### PR TITLE
ci: use custom Anthropic base URL for Claude action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -28,3 +28,5 @@ jobs:
           github_token: ${{ secrets.BOT_GITHUB_TOKEN }}
           model: "claude-sonnet-4-20250514"
           timeout_minutes: 30
+        env:
+          ANTHROPIC_BASE_URL: https://api.acedata.cloud


### PR DESCRIPTION
Use api.acedata.cloud as Anthropic API proxy for Claude Code Action.