### PR TITLE
fix(android): prevent login from opening Chrome and redirecting to localhost

### DIFF
--- a/change/@acedatacloud-nexior-fix-android-login-redirect.json
+++ b/change/@acedatacloud-nexior-fix-android-login-redirect.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(android): prevent login from opening Chrome and redirecting to localhost",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -69,8 +69,16 @@ export default defineComponent({
     const authenticated = !!this.$store.state.token.access && !!this.$store.state.user?.id;
     console.debug('App mounted, authenticated:', authenticated);
     if (!authenticated) {
-      this.$store.dispatch('logout');
-      this.$store.dispatch('login');
+      if (import.meta.env.VITE_SURFACE === 'android' || import.meta.env.VITE_SURFACE === 'ios') {
+        // On native platforms, just reset state and show login popup.
+        // Don't dispatch 'logout' which would navigate the WebView to an
+        // external auth URL, opening Chrome and landing on localhost.
+        this.$store.dispatch('resetAll');
+        this.$store.dispatch('login');
+      } else {
+        this.$store.dispatch('logout');
+        this.$store.dispatch('login');
+      }
     }
   },
   methods: {

--- a/src/store/common/actions.ts
+++ b/src/store/common/actions.ts
@@ -226,7 +226,7 @@ export const login = async ({ state, commit }: ActionContext<IRootState, IRootSt
   }
 };
 
-export const logout = async ({ dispatch }: ActionContext<IRootState, IRootState>) => {
+export const logout = async ({ dispatch, commit }: ActionContext<IRootState, IRootState>) => {
   await dispatch('resetAll');
   await dispatch('chat/resetAll');
   await dispatch('midjourney/resetAll');
@@ -244,11 +244,20 @@ export const logout = async ({ dispatch }: ActionContext<IRootState, IRootState>
   await dispatch('seedream/resetAll');
   await dispatch('seedance/resetAll');
   await dispatch('veo/resetAll');
-  const currentUrl = window.location.href;
-  const baseUrlAuth = getBaseUrlAuth();
-  const loginUrl = `${baseUrlAuth}/auth/login?redirect=${currentUrl}`;
-  const redirectUrl = `${baseUrlAuth}/auth/logout?redirect=${loginUrl}`;
-  window.location.href = redirectUrl;
+  if (import.meta.env.VITE_SURFACE === SURFACE_IOS || import.meta.env.VITE_SURFACE === SURFACE_ANDROID) {
+    // On native platforms, show in-app login popup instead of navigating to
+    // external auth URL (which would open Chrome and redirect to localhost)
+    commit('setAuth', {
+      flow: 'popup',
+      visible: true
+    });
+  } else {
+    const currentUrl = window.location.href;
+    const baseUrlAuth = getBaseUrlAuth();
+    const loginUrl = `${baseUrlAuth}/auth/login?redirect=${currentUrl}`;
+    const redirectUrl = `${baseUrlAuth}/auth/logout?redirect=${loginUrl}`;
+    window.location.href = redirectUrl;
+  }
 };
 
 export default {

--- a/src/utils/baseUrl.ts
+++ b/src/utils/baseUrl.ts
@@ -19,6 +19,11 @@ export const getBaseUrlHub = () => {
   if (import.meta.env.VITE_BASE_URL_HUB) {
     return import.meta.env.VITE_BASE_URL_HUB;
   }
+  // On native platforms (Capacitor), window.location.origin is http://localhost
+  // which is not the real hub URL — use the hardcoded constant instead
+  if (import.meta.env.VITE_SURFACE === 'android' || import.meta.env.VITE_SURFACE === 'ios') {
+    return BASE_URL_HUB;
+  }
   return window.location.origin || BASE_URL_HUB;
 };
 


### PR DESCRIPTION
## Problem

On Android (Capacitor), the login flow was completely broken:

1. **App opens Chrome for login**: When the app detected an unauthenticated user, it dispatched both `logout` and `login`. The `logout` action set `window.location.href` to an external `auth.acedata.cloud` URL, which Capacitor opened in Chrome (external browser) instead of handling in-app.

2. **Redirects to localhost**: After completing authentication in Chrome, the redirect chain contained `http://localhost` — Capacitor's internal WebView origin — which is meaningless in Chrome. The user saw a dead localhost page.

3. **Can't return to app**: With no deep link configured and the auth completing in an external browser, there was no way back to the app.

## Root Cause

The `logout` action unconditionally navigated the browser to `auth.acedata.cloud/auth/logout?redirect=...`, embedding `window.location.href` (which is `http://localhost` on Capacitor) in the redirect chain. On web this works fine since the browser handles the full redirect loop. On Android, Capacitor opens external URLs in Chrome, breaking the flow.

## Fix

Three targeted changes:

1. **`logout` action** (`src/store/common/actions.ts`): On native platforms (`VITE_SURFACE === 'android' | 'ios'`), show the in-app login popup instead of navigating to an external auth URL.

2. **`App.vue` mounted hook**: On native platforms, when user is not authenticated, only dispatch `login` (which shows the iframe popup). Skip `logout` (which would navigate away) since there's no server-side session to clear on first boot.

3. **`getBaseUrlHub`** (`src/utils/baseUrl.ts`): On native platforms, return the hardcoded `BASE_URL_HUB` constant (`https://hub.acedata.cloud`) instead of `window.location.origin` (`http://localhost`), preventing any other code path from generating broken localhost URLs.

## Testing

- [x] TypeScript type check passes (`vue-tsc --noEmit`)
- [x] ESLint passes (`npm run lint`)
- [x] Android build succeeds (`VITE_SURFACE=android vite build`)
