### PR TITLE
fix(android): use official hub origin on native, skip site config page after login

### DIFF
--- a/change/@acedatacloud-nexior-fix-android-site-origin.json
+++ b/change/@acedatacloud-nexior-fix-android-site-origin.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(android): use official hub origin on native, skip site config page after login",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/AuthPanel.vue
+++ b/src/components/common/AuthPanel.vue
@@ -80,10 +80,14 @@ export default defineComponent({
         // if the site is not initialized, initialize it
         if (!this.$store.state.site?.origin) {
           await this.$store.dispatch('initializeSite');
-          // after initialization, navigate to the site config page
-          await this.$router.push({
-            name: ROUTE_SITE_INDEX
-          });
+          // navigate to site config page for white-label site owners,
+          // but skip on native platforms (Android/iOS) where users are
+          // always on the official site
+          if (import.meta.env.VITE_SURFACE !== 'android' && import.meta.env.VITE_SURFACE !== 'ios') {
+            await this.$router.push({
+              name: ROUTE_SITE_INDEX
+            });
+          }
         }
         window.location.reload();
       }

--- a/src/utils/site.ts
+++ b/src/utils/site.ts
@@ -7,6 +7,11 @@ export const getSiteOrigin = (site?: ISite) => {
   if (site?.origin) {
     return site?.origin;
   }
+  // On native platforms (Capacitor), window.location.host is "localhost"
+  // which is not the real origin — use the official hub URL
+  if (import.meta.env.VITE_SURFACE === 'android' || import.meta.env.VITE_SURFACE === 'ios') {
+    return BASE_URL_HUB;
+  }
   if (isOfficial()) {
     return BASE_URL_HUB;
   }


### PR DESCRIPTION
## Problem

After fixing the Android login flow (PR #326), users logging in on Android were redirected to a **site configuration page** (`/site`) instead of the home page.

## Root Cause

Two issues with Capacitor's `http://localhost` origin:

1. **`getSiteOrigin()`** (`src/utils/site.ts`) — detected `localhost` in the host and generated a random UUID origin (`http://localhost-{uuid}`). This caused the backend to create a brand new Site config (treating the user as a white-label site owner).

2. **`AuthPanel.vue`** — after login, checked if `site.origin` was set. Since it was a freshly created site with no configuration, it navigated to the site settings page (`ROUTE_SITE_INDEX`).

## Fix

- **`site.ts`**: On native platforms (`VITE_SURFACE === 'android' | 'ios'`), return `BASE_URL_HUB` (`https://hub.acedata.cloud`) directly, so the app uses the official site config instead of creating a new one.
- **`AuthPanel.vue`**: On native platforms, skip the site config page redirect after login — native users are always on the official site and don't need site configuration.
