### PR TITLE
chore: update Gradle 8.13, CocoaPods 1.16.2 and Capacitor 7.5.0 lockfile

### DIFF
--- a/android/app/src/main/java/com/acedatacloud/nexior/MainActivity.java
+++ b/android/app/src/main/java/com/acedatacloud/nexior/MainActivity.java
@@ -2,4 +2,8 @@ package com.acedatacloud.nexior;
 
 import com.getcapacitor.BridgeActivity;
 
+/**
+ * MainActivity is the main entry point for the Nexior Android application.
+ * It extends BridgeActivity to provide Capacitor functionality.
+ */
 public class MainActivity extends BridgeActivity {}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.7.3'
+        classpath 'com.android.tools.build:gradle:8.13.2'
         classpath 'com.google.gms:google-services:4.4.0'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/ios/App/Podfile.lock
+++ b/ios/App/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - Capacitor (6.1.1):
+  - Capacitor (7.5.0):
     - CapacitorCordova
-  - CapacitorCordova (6.1.1)
+  - CapacitorCordova (7.5.0)
 
 DEPENDENCIES:
   - "Capacitor (from `../../node_modules/@capacitor/ios`)"
@@ -14,9 +14,9 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/@capacitor/ios"
 
 SPEC CHECKSUMS:
-  Capacitor: 8941aba4364ba9d1b22188569001f2ce45cc2b00
-  CapacitorCordova: 8f2cc8d8d3619c566e9418fe8772064a94266106
+  Capacitor: 0a78ec6b54580fa055c11744a4e83cd7942d98ca
+  CapacitorCordova: ae35646a9b46cfd00d637f195509c86594026aad
 
-PODFILE CHECKSUM: 8ab55909c5de2b217f9841e5e5b329f5ec901553
+PODFILE CHECKSUM: 84ee8333eaf3c4f44013bcb5a170b64f5f06576b
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2


### PR DESCRIPTION
Update native platform dependencies from local build:

- Android Gradle Plugin: 8.7.3 → 8.13.2
- Gradle wrapper: 8.11.1 → 8.13
- Capacitor iOS pod: 6.1.1 → 7.5.0
- CocoaPods: 1.15.2 → 1.16.2
- Add Javadoc comment to MainActivity