### PR TITLE
rename: change mobile app display name from Nexior to AceData

### DIFF
--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
-    <string name="app_name">Nexior</string>
-    <string name="title_activity_main">Nexior</string>
+    <string name="app_name">AceData</string>
+    <string name="title_activity_main">AceData</string>
     <string name="package_name">com.acedatacloud.nexior</string>
     <string name="custom_url_scheme">com.acedatacloud.nexior</string>
 </resources>

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -2,7 +2,7 @@ import type { CapacitorConfig } from '@capacitor/cli';
 
 const config: CapacitorConfig = {
   appId: 'com.acedatacloud.nexior',
-  appName: 'Nexior',
+  appName: 'AceData',
   webDir: 'dist'
 };
 

--- a/change/@acedatacloud-nexior-rename-app-acedata.json
+++ b/change/@acedatacloud-nexior-rename-app-acedata.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "rename: change mobile app display name from Nexior to AceData",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, max-age=0, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
-    <title>Nexior</title>
+    <title>AceData</title>
     <link rel="icon" href="/src/images/favicon.ico" />
     <script>
       var _hmt = _hmt || [];

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-        <string>Nexior</string>
+        <string>AceData</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,8 +48,8 @@ const walletOptions = {
       options: {
         projectId: walletConnectProjectId,
         metadata: {
-          name: 'Nexior',
-          description: 'Nexior WalletConnect',
+          name: 'AceData',
+          description: 'AceData WalletConnect',
           url: window.location.origin,
           icons: ['https://cdn.acedata.cloud/acedata.jpg']
         }


### PR DESCRIPTION
Change the mobile app display name from **Nexior** to **AceData** across all platforms.

### Changed files
- `capacitor.config.ts` — appName
- `index.html` — page title
- `ios/App/App/Info.plist` — CFBundleDisplayName
- `android/app/src/main/res/values/strings.xml` — app_name, title_activity_main
- `src/main.ts` — WalletConnect metadata name