### PR TITLE
fix(auth): recover from native OAuth loading dead-end

### DIFF
--- a/change/@acedatacloud-nexior-a1a9acdd-f443-4095-86a1-45f73def81bb.json
+++ b/change/@acedatacloud-nexior-a1a9acdd-f443-4095-86a1-45f73def81bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(auth): recover from native OAuth loading dead-end",
+  "packageName": "@acedatacloud/nexior",
+  "email": "cqc@cuiqingcai.com",
+  "dependentChangeType": "patch"
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -96,6 +96,8 @@ export default defineComponent({
               await this.$router.push('/');
             } catch (e) {
               console.error('token exchange failed after deep link', e);
+              this.$store.commit('setAuth', { visible: false });
+              await this.$store.dispatch('login');
             }
           }
         }

--- a/src/components/common/AuthPanel.vue
+++ b/src/components/common/AuthPanel.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="isNative" class="auth-native">
     <div v-if="useBrowser" class="auth-native__loading">
-      <p>{{ $t('common.message.loading') }}</p>
+      <p>{{ $t('common.status.loading') }}</p>
     </div>
     <iframe v-else class="auth-native__iframe" :src="iframeUrl" frameborder="0" />
   </div>
@@ -79,6 +79,13 @@ export default defineComponent({
     }
   },
   mounted() {
+    if (this.isNative) {
+      // If user closes the in-app browser manually, fall back to iframe login UI.
+      Browser.addListener('browserFinished', () => {
+        console.debug('browser closed by user');
+        this.useBrowser = false;
+      });
+    }
     // On native platforms, keep the iframe for regular login (email/password).
     // When the user clicks Google/GitHub, the iframe (AuthFrontend) sends a
     // postMessage asking us to open the OAuth flow in the in-app browser.


### PR DESCRIPTION
## Summary
- fix native loading text key from `common.message.loading` to `common.status.loading`
- when deep-link token exchange fails, close auth panel and re-trigger login flow instead of getting stuck
- when user manually closes in-app browser, fall back to iframe login UI

## Why
After OAuth returns to app, failures in code exchange could leave users on a permanent loading screen.

## Testing
- `npx vue-tsc --noEmit`