### PR TITLE
Fix: remove gradient background from chat layout in dark mode

### DIFF
--- a/change/@acedatacloud-nexior-remove-chat-gradient.json
+++ b/change/@acedatacloud-nexior-remove-chat-gradient.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove gradient background from chat layout in dark mode",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/layouts/Chat.vue
+++ b/src/layouts/Chat.vue
@@ -51,7 +51,6 @@ export default defineComponent({
   display: flex;
   flex: 1;
   height: 100%;
-  background: linear-gradient(180deg, var(--el-fill-color-lighter) 0%, transparent 18%);
 }
 
 .side {


### PR DESCRIPTION
The `linear-gradient` on `.main` in `Chat.vue` (added in #334) causes a visible gradient effect in dark mode. This removes it to restore the plain background.