### PR TITLE
feat: Discord-style sidebar overflow with folder preview popover

### DIFF
--- a/change/@acedatacloud-nexior-discord-sidebar-overflow.json
+++ b/change/@acedatacloud-nexior-discord-sidebar-overflow.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: Discord-style sidebar overflow with folder preview popover",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/assets/scss/_common.scss
+++ b/src/assets/scss/_common.scss
@@ -43,6 +43,11 @@ html.dark,
   --app-border-subtle: #ddd;
   --app-badge-bg: #ffe8d5;
   --app-badge-border: #ff7200;
+
+  /* Discord-style surface levels (no borders, background separation) */
+  --app-nav-bg: #f0f2f5;
+  --app-sidebar-bg: #f5f7fa;
+  --app-content-bg: #ffffff;
 }
 
 html.dark {
@@ -52,6 +57,11 @@ html.dark {
   --app-border-subtle: #3a3a3a;
   --app-badge-bg: #3d2a1a;
   --app-badge-border: #ff7200;
+
+  /* Discord-style surface levels */
+  --app-nav-bg: #111214;
+  --app-sidebar-bg: #18191c;
+  --app-content-bg: #1e1f22;
 }
 
 w3m-modal {

--- a/src/components/common/Navigator.vue
+++ b/src/components/common/Navigator.vue
@@ -4,15 +4,57 @@
       <div class="w-full flex justify-center brand">
         <logo v-if="direction === 'column'" @click.stop="onHome" />
       </div>
-      <div class="links">
+      <div ref="linksContainer" class="links">
         <div
-          v-for="(link, linkIndex) in links"
+          v-for="(link, linkIndex) in visibleLinks"
           :key="linkIndex"
           :class="{ link: true, active: link.routes.includes($route.name as string) }"
         >
           <el-tooltip effect="dark" :content="link.displayName" :placement="direction === 'row' ? 'top' : 'right'">
             <el-image v-if="link.logo" :src="link.logo" class="avatar" @click="$router.push(link.route)" />
           </el-tooltip>
+        </div>
+        <div v-if="overflowLinks.length > 0" :class="{ link: true, active: isOverflowActive }">
+          <el-popover
+            v-model:visible="showOverflow"
+            :placement="direction === 'row' ? 'top' : 'right-start'"
+            :width="180"
+            trigger="click"
+            :show-arrow="false"
+            popper-class="navigator-overflow-popover"
+          >
+            <template #reference>
+              <el-tooltip
+                effect="dark"
+                :content="$t('common.nav.more')"
+                :placement="direction === 'row' ? 'top' : 'right'"
+                :disabled="showOverflow"
+              >
+                <div class="more-button" :class="{ active: isOverflowActive }">
+                  <div class="folder-preview">
+                    <el-image
+                      v-for="(link, i) in overflowPreviewLinks"
+                      :key="i"
+                      :src="link.logo"
+                      class="folder-icon"
+                      fit="cover"
+                    />
+                  </div>
+                </div>
+              </el-tooltip>
+            </template>
+            <div class="overflow-menu">
+              <div
+                v-for="(link, linkIndex) in overflowLinks"
+                :key="linkIndex"
+                :class="{ 'overflow-item': true, active: link.routes.includes($route.name as string) }"
+                @click="onOverflowItemClick(link)"
+              >
+                <el-image v-if="link.logo" :src="link.logo" class="overflow-avatar" fit="cover" />
+                <span class="overflow-name">{{ link.displayName }}</span>
+              </div>
+            </div>
+          </el-popover>
         </div>
       </div>
     </div>
@@ -24,7 +66,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElTooltip, ElImage } from 'element-plus';
+import { ElTooltip, ElImage, ElPopover } from 'element-plus';
 import {
   ROUTE_PROFILE_INDEX,
   ROUTE_INDEX,
@@ -84,6 +126,7 @@ export default defineComponent({
   name: 'Navigator',
   components: {
     ElImage,
+    ElPopover,
     Logo,
     ElTooltip,
     UserCenter
@@ -100,7 +143,10 @@ export default defineComponent({
         dark: false,
         locale: false
       },
-      activeIndex: this.$route.name as string
+      activeIndex: this.$route.name as string,
+      containerHeight: 0,
+      showOverflow: false,
+      resizeObserver: null as ResizeObserver | null
     };
   },
   computed: {
@@ -339,6 +385,50 @@ export default defineComponent({
     },
     authenticated() {
       return !!this.$store.state.token.access;
+    },
+    maxVisibleItems(): number {
+      if (this.direction === 'row') return this.links.length;
+      const itemHeight = 50; // 35px avatar + 15px gap
+      const maxItems = Math.floor((this.containerHeight + 15) / itemHeight);
+      return Math.max(maxItems, 3);
+    },
+    visibleLinks() {
+      if (this.links.length <= this.maxVisibleItems) return this.links;
+      return this.links.slice(0, this.maxVisibleItems - 1);
+    },
+    overflowLinks() {
+      if (this.links.length <= this.maxVisibleItems) return [];
+      return this.links.slice(this.maxVisibleItems - 1);
+    },
+    overflowPreviewLinks() {
+      return this.overflowLinks.slice(0, 4);
+    },
+    isOverflowActive(): boolean {
+      const routeName = this.$route.name as string;
+      return this.overflowLinks.some((link: { routes: string[] }) => link.routes.includes(routeName));
+    }
+  },
+  watch: {
+    $route() {
+      this.showOverflow = false;
+    }
+  },
+  mounted() {
+    if (this.$refs.linksContainer) {
+      const el = this.$refs.linksContainer as HTMLElement;
+      this.containerHeight = el.clientHeight;
+      this.resizeObserver = new ResizeObserver((entries) => {
+        for (const entry of entries) {
+          this.containerHeight = entry.contentRect.height;
+        }
+      });
+      this.resizeObserver.observe(el);
+    }
+  },
+  beforeUnmount() {
+    if (this.resizeObserver) {
+      this.resizeObserver.disconnect();
+      this.resizeObserver = null;
     }
   },
   methods: {
@@ -346,6 +436,10 @@ export default defineComponent({
       this.$router.push({
         name: ROUTE_INDEX
       });
+    },
+    onOverflowItemClick(link: { route: { name: string } }) {
+      this.showOverflow = false;
+      this.$router.push(link.route);
     }
   }
 });
@@ -356,7 +450,7 @@ export default defineComponent({
   display: flex;
   align-items: center;
   position: relative;
-  background-color: var(--el-bg-color);
+  background-color: var(--app-nav-bg);
 
   .top {
     .avatar {
@@ -366,13 +460,11 @@ export default defineComponent({
       height: 35px;
       border-radius: 50%;
       cursor: pointer;
-      border: 1px solid var(--el-border-color-lighter);
     }
   }
 
   &[direction='row'] {
     flex-direction: row;
-    border-top: 1px solid var(--el-border-color);
     overflow-x: scroll;
     .brand {
       display: none;
@@ -428,8 +520,7 @@ export default defineComponent({
         display: flex;
         flex-direction: column;
         gap: 15px;
-        overflow-y: auto;
-        overflow-x: hidden;
+        overflow: hidden;
         padding-bottom: 10px;
       }
       .logo {
@@ -439,6 +530,45 @@ export default defineComponent({
       }
       .link {
         width: 100%;
+      }
+      .more-button {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 35px;
+        height: 35px;
+        border-radius: 50%;
+        background: var(--el-fill-color-light);
+        cursor: pointer;
+        margin: auto;
+        border: 1px solid var(--el-border-color-lighter);
+        transition:
+          border-radius 0.2s,
+          background-color 0.2s;
+
+        &:hover {
+          border-radius: 35%;
+          background: var(--el-fill-color);
+        }
+
+        &.active {
+          border: 2px solid var(--el-color-primary);
+        }
+
+        .folder-preview {
+          display: grid;
+          grid-template-columns: 1fr 1fr;
+          grid-template-rows: 1fr 1fr;
+          gap: 1px;
+          width: 22px;
+          height: 22px;
+
+          .folder-icon {
+            width: 10px;
+            height: 10px;
+            border-radius: 50%;
+          }
+        }
       }
     }
 
@@ -450,6 +580,51 @@ export default defineComponent({
       justify-content: flex-end;
       align-items: center;
       padding-bottom: 10px;
+    }
+  }
+}
+</style>
+
+<style lang="scss">
+.navigator-overflow-popover {
+  padding: 6px !important;
+  border-radius: 8px !important;
+
+  .overflow-menu {
+    max-height: 400px;
+    overflow-y: auto;
+
+    .overflow-item {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 7px 8px;
+      border-radius: 6px;
+      cursor: pointer;
+      transition: background-color 0.15s;
+
+      &:hover {
+        background: var(--el-fill-color-light);
+      }
+
+      &.active {
+        background: var(--el-fill-color);
+      }
+
+      .overflow-avatar {
+        width: 28px;
+        height: 28px;
+        border-radius: 50%;
+        flex-shrink: 0;
+      }
+
+      .overflow-name {
+        font-size: 13px;
+        color: var(--el-text-color-primary);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
     }
   }
 }

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -419,6 +419,10 @@
     "message": "AI证件照",
     "description": "网站导航栏中的文本，用于显示站点配置页面"
   },
+  "nav.more": {
+    "message": "更多",
+    "description": "网站导航栏中的文本，用于展开更多服务"
+  },
   "nav.locale": {
     "message": "语言设置",
     "description": "网站导航栏中的文本，用于更改语言"

--- a/src/layouts/Chat.vue
+++ b/src/layouts/Chat.vue
@@ -58,8 +58,7 @@ export default defineComponent({
   height: 100%;
   overflow-y: auto;
   flex-shrink: 0;
-  border-right: 1px solid var(--el-border-color-lighter);
-  background-color: color-mix(in srgb, var(--el-bg-color) 92%, var(--el-color-primary-light-9) 8%);
+  background-color: var(--app-sidebar-bg);
 }
 
 .chat {

--- a/src/layouts/Console.vue
+++ b/src/layouts/Console.vue
@@ -43,7 +43,6 @@ export default defineComponent({
     .navigator {
       height: 100%;
       width: 60px;
-      border-right: 1px solid var(--el-border-color);
     }
 
     .main {
@@ -56,6 +55,7 @@ export default defineComponent({
       .side {
         width: 200px;
         height: 100%;
+        background-color: var(--app-sidebar-bg);
       }
       .panel {
         width: calc(100% - 200px);

--- a/src/layouts/Flux.vue
+++ b/src/layouts/Flux.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="main flex flex-row flex-1">
-    <div class="config w-[300px] flex-none h-full overflow-y-auto border-r border-[var(--el-border-color)]">
+    <div class="config w-[300px] flex-none h-full overflow-y-auto bg-[var(--app-sidebar-bg)]">
       <slot name="config" />
     </div>
     <div class="result h-full p-[15px] flex-1 flex flex-col min-w-0 overflow-x-hidden">

--- a/src/layouts/Hailuo.vue
+++ b/src/layouts/Hailuo.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="main flex flex-row flex-1">
-    <div class="config w-[300px] h-full overflow-y-scroll border-r border-[var(--el-border-color)]">
+    <div class="config w-[300px] h-full overflow-y-scroll bg-[var(--app-sidebar-bg)]">
       <slot name="config" />
     </div>
     <div class="result h-full p-[15px] flex-1 flex flex-col">

--- a/src/layouts/Headshots.vue
+++ b/src/layouts/Headshots.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="main flex flex-row flex-1">
-    <div class="config w-[300px] h-full overflow-y-scroll border-r border-[var(--el-border-color)]">
+    <div class="config w-[300px] h-full overflow-y-scroll bg-[var(--app-sidebar-bg)]">
       <slot name="config" />
     </div>
     <div class="result h-full p-[15px] flex-1 flex flex-col">

--- a/src/layouts/Kling.vue
+++ b/src/layouts/Kling.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="main flex flex-row flex-1">
-    <div class="config w-[300px] h-full overflow-y-scroll border-r border-[var(--el-border-color)]">
+    <div class="config w-[300px] h-full overflow-y-scroll bg-[var(--app-sidebar-bg)]">
       <slot name="config" />
     </div>
     <div class="result h-full p-[15px] flex-1 flex flex-col">

--- a/src/layouts/Luma.vue
+++ b/src/layouts/Luma.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="main flex flex-row flex-1">
-    <div class="config w-[300px] h-full overflow-y-scroll border-r border-[var(--el-border-color)]">
+    <div class="config w-[300px] h-full overflow-y-scroll bg-[var(--app-sidebar-bg)]">
       <slot name="config" />
     </div>
     <div class="result h-full p-[15px] flex-1 flex flex-col">

--- a/src/layouts/Main.vue
+++ b/src/layouts/Main.vue
@@ -144,13 +144,13 @@ export default defineComponent({
   .navigator {
     height: 100%;
     width: 60px;
-    border-right: 1px solid var(--el-border-color);
   }
 
   .main {
     height: 100%;
     width: calc(100% - 60px);
     flex: 1;
+    background-color: var(--app-content-bg);
   }
 }
 

--- a/src/layouts/Midjourney.vue
+++ b/src/layouts/Midjourney.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="main flex-1 h-full flex flex-row">
-    <div class="config w-[300px] h-full flex flex-col border-r border-[var(--el-border-color)]">
+    <div class="config w-[300px] h-full flex flex-col bg-[var(--app-sidebar-bg)]">
       <slot name="config" />
     </div>
     <div class="results flex-1 h-full flex flex-col">

--- a/src/layouts/Nanobanana.vue
+++ b/src/layouts/Nanobanana.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="main flex flex-row flex-1">
-    <div class="config w-[300px] h-full overflow-y-scroll border-r border-[var(--el-border-color)]">
+    <div class="config w-[300px] h-full overflow-y-scroll bg-[var(--app-sidebar-bg)]">
       <slot name="config" />
     </div>
     <div class="result h-full p-[15px] flex-1 flex flex-col">

--- a/src/layouts/Pika.vue
+++ b/src/layouts/Pika.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="main flex flex-row flex-1">
-    <div class="config w-[300px] h-full overflow-y-scroll border-r border-[var(--el-border-color)]">
+    <div class="config w-[300px] h-full overflow-y-scroll bg-[var(--app-sidebar-bg)]">
       <slot name="config" />
     </div>
     <div class="result h-full p-[15px] flex-1 flex flex-col">

--- a/src/layouts/Pixverse.vue
+++ b/src/layouts/Pixverse.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="main flex flex-row flex-1">
-    <div class="config w-[300px] h-full overflow-y-scroll border-r border-[var(--el-border-color)]">
+    <div class="config w-[300px] h-full overflow-y-scroll bg-[var(--app-sidebar-bg)]">
       <slot name="config" />
     </div>
     <div class="result h-full p-[15px] flex-1 flex flex-col">

--- a/src/layouts/Qrart.vue
+++ b/src/layouts/Qrart.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="main flex flex-row flex-1">
-    <div class="config w-[300px] h-full overflow-y-scroll border-r border-[var(--el-border-color)]">
+    <div class="config w-[300px] h-full overflow-y-scroll bg-[var(--app-sidebar-bg)]">
       <slot name="config" />
     </div>
     <div class="result h-full p-[15px] flex-1 flex flex-col">

--- a/src/layouts/Seedance.vue
+++ b/src/layouts/Seedance.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="main flex flex-row flex-1">
-    <div class="config w-[300px] h-full overflow-y-scroll border-r border-[var(--el-border-color)]">
+    <div class="config w-[300px] h-full overflow-y-scroll bg-[var(--app-sidebar-bg)]">
       <slot name="config" />
     </div>
     <div class="result h-full p-[15px] flex-1 flex flex-col">

--- a/src/layouts/Seedream.vue
+++ b/src/layouts/Seedream.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="main flex flex-row flex-1">
-    <div class="config w-[300px] h-full overflow-y-scroll border-r border-[var(--el-border-color)]">
+    <div class="config w-[300px] h-full overflow-y-scroll bg-[var(--app-sidebar-bg)]">
       <slot name="config" />
     </div>
     <div class="result h-full p-[15px] flex-1 flex flex-col">

--- a/src/layouts/Sora.vue
+++ b/src/layouts/Sora.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="main flex flex-row flex-1">
-    <div class="config w-[300px] h-full overflow-y-scroll border-r border-[var(--el-border-color)]">
+    <div class="config w-[300px] h-full overflow-y-scroll bg-[var(--app-sidebar-bg)]">
       <slot name="config" />
     </div>
     <div class="result h-full p-[15px] flex-1 flex flex-col">

--- a/src/layouts/Suno.vue
+++ b/src/layouts/Suno.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="main flex flex-row flex-1">
-    <div class="config w-[300px] h-full overflow-y-scroll border-r border-[var(--el-border-color)]">
+    <div class="config w-[300px] h-full overflow-y-scroll bg-[var(--app-sidebar-bg)]">
       <slot name="config" />
     </div>
-    <div class="result h-full flex flex-col flex-1 border-r border-[var(--el-border-color)]">
+    <div class="result h-full flex flex-col flex-1">
       <slot name="result" />
     </div>
     <div class="preview h-full w-[300px] flex flex-col">

--- a/src/layouts/Veo.vue
+++ b/src/layouts/Veo.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="main flex flex-row flex-1">
-    <div class="config w-[300px] h-full overflow-y-scroll border-r border-[var(--el-border-color)]">
+    <div class="config w-[300px] h-full overflow-y-scroll bg-[var(--app-sidebar-bg)]">
       <slot name="config" />
     </div>
     <div class="result h-full p-[15px] flex-1 flex flex-col">


### PR DESCRIPTION
When the sidebar has more service icons than can vertically fit, excess items are collapsed into a Discord-style folder button with a 2x2 mini-grid preview. Clicking opens a popover menu listing all overflow services.

Changes:
- Navigator.vue: ResizeObserver-based overflow calculation, folder preview button, el-popover menu
- common.json: Added nav.more i18n key

Behavior: visible icons + folder button with popover (replaces scroll). Folder button highlights when overflow item is active. Auto-closes on navigation. Mobile row mode unchanged.
