### PR TITLE
feat: simplify chat model list and remove unused model groups

### DIFF
--- a/change/@acedatacloud-nexior-simplify-chat-models.json
+++ b/change/@acedatacloud-nexior-simplify-chat-models.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: simplify chat model list and remove unused model groups",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -5,8 +5,8 @@ export const ROLE_SYSTEM = 'system';
 export const ROLE_ASSISTANT = 'assistant';
 export const ROLE_USER = 'user';
 
-export const CHAT_MODEL_NAME_GPT_5_ALL = 'gpt-5-all';
 export const CHAT_MODEL_NAME_GPT_5 = 'gpt-5';
+export const CHAT_MODEL_NAME_GPT_5_ALL = 'gpt-5-all';
 export const CHAT_MODEL_NAME_GPT_5_MINI = 'gpt-5-mini';
 export const CHAT_MODEL_NAME_GPT_4O_ALL = 'gpt-4o-all';
 export const CHAT_MODEL_NAME_GPT_4_ALL = 'gpt-4-all';
@@ -18,29 +18,18 @@ export const CHAT_MODEL_NAME_O1_MINI = 'o1-mini';
 export const CHAT_MODEL_NAME_O3 = 'o3';
 export const CHAT_MODEL_NAME_O4_MINI = 'o4-mini';
 export const CHAT_MODEL_NAME_DEEPSEEK_CHAT = 'deepseek-v3';
-export const CHAT_MODEL_NAME_DEEPSEEK32_CHAT = 'deepseek-v3.2-exp';
 export const CHAT_MODEL_NAME_DEEPSEEK_REASONER = 'deepseek-r1';
-export const CHAT_MODEL_NAME_GROK_4 = 'grok-4';
 export const CHAT_MODEL_NAME_GROK_3 = 'grok-3';
 export const CHAT_MODEL_NAME_GROK_3_REASONER = 'grok-3-reasoning';
 export const CHAT_MODEL_NAME_GROK_3_DEEPSEARCH = 'grok-3-deepsearch';
-export const CHAT_MODEL_NAME_GEMINI_3_0_PRO = 'gemini-3.0-pro';
-export const CHAT_MODEL_NAME_GEMINI_2_5_PRO = 'gemini-2.5-pro';
-export const CHAT_MODEL_NAME_GEMINI_2_5_FLASH = 'gemini-2.5-flash';
-export const CHAT_MODEL_NAME_CLAUDE_OPUS_4 = 'claude-opus-4';
-export const CHAT_MODEL_NAME_CLAUDE_SONNET_4 = 'claude-sonnet-4';
-export const CHAT_MODEL_NAME_CLAUDE_3_7_SONNET = 'claude-3-7-sonnet';
 
 export const CHAT_MODEL_ICON_CHATGPT = 'https://cdn.acedata.cloud/7dljuv.png';
 export const CHAT_MODEL_ICON_GROK = 'https://cdn.acedata.cloud/p1ge98.png';
 export const CHAT_MODEL_ICON_DEEPSEEK = 'https://cdn.acedata.cloud/4rb23t.jpg';
-export const CHAT_MODEL_ICON_GEMINI = 'https://cdn.acedata.cloud/psfx0g.jpg';
-export const CHAT_MODEL_ICON_CLAUDE = 'https://cdn.acedata.cloud/8fnw4v.jpg';
 
 export const CHAT_SERVICE_ID = 'b1fbcc32-e218-4253-9dc3-4fe600a1bfb9';
 
 export const CHAT_MODEL_GPT_5_ALL: IChatModel = {
-  enabled: true,
   name: CHAT_MODEL_NAME_GPT_5_ALL,
   icon: CHAT_MODEL_ICON_CHATGPT,
   modelGroup: 'chatgpt',
@@ -51,11 +40,10 @@ export const CHAT_MODEL_GPT_5_ALL: IChatModel = {
 };
 
 export const CHAT_MODEL_GPT_5: IChatModel = {
-  enabled: false,
   name: CHAT_MODEL_NAME_GPT_5,
   icon: CHAT_MODEL_ICON_CHATGPT,
   modelGroup: 'chatgpt',
-  isFileSupported: false,
+  isFileSupported: true,
   isImageSupported: true,
   getDisplayName: () => i18n.global.t('chat.model.5'),
   getDescription: () => i18n.global.t('chat.model.5Description')
@@ -72,7 +60,6 @@ export const CHAT_MODEL_GPT_5_MINI: IChatModel = {
 };
 
 export const CHAT_MODEL_GPT_4O_ALL: IChatModel = {
-  enabled: true,
   name: CHAT_MODEL_NAME_GPT_4O_ALL,
   icon: CHAT_MODEL_ICON_CHATGPT,
   modelGroup: 'chatgpt',
@@ -163,7 +150,6 @@ export const CHAT_MODEL_O4_MINI: IChatModel = {
 };
 
 export const CHAT_MODEL_DEEPSEEK_CHAT: IChatModel = {
-  enabled: true,
   name: CHAT_MODEL_NAME_DEEPSEEK_CHAT,
   icon: CHAT_MODEL_ICON_DEEPSEEK,
   modelGroup: 'deepseek',
@@ -171,17 +157,7 @@ export const CHAT_MODEL_DEEPSEEK_CHAT: IChatModel = {
   getDescription: () => i18n.global.t('chat.model.deepseekChatDescription')
 };
 
-export const CHAT_MODEL_DEEPSEEK_CHAT32: IChatModel = {
-  enabled: true,
-  name: CHAT_MODEL_NAME_DEEPSEEK32_CHAT,
-  icon: CHAT_MODEL_ICON_DEEPSEEK,
-  modelGroup: 'deepseek',
-  getDisplayName: () => i18n.global.t('chat.model.deepseekChat32'),
-  getDescription: () => i18n.global.t('chat.model.deepseekChat32Description')
-};
-
 export const CHAT_MODEL_DEEPSEEK_REASONER: IChatModel = {
-  enabled: true,
   name: CHAT_MODEL_NAME_DEEPSEEK_REASONER,
   icon: CHAT_MODEL_ICON_DEEPSEEK,
   modelGroup: 'deepseek',
@@ -189,17 +165,7 @@ export const CHAT_MODEL_DEEPSEEK_REASONER: IChatModel = {
   getDescription: () => i18n.global.t('chat.model.deepseekReasonerDescription')
 };
 
-export const CHAT_MODEL_GROK_4: IChatModel = {
-  enabled: true,
-  name: CHAT_MODEL_NAME_GROK_4,
-  icon: CHAT_MODEL_ICON_GROK,
-  modelGroup: 'grok',
-  getDisplayName: () => i18n.global.t('chat.model.grok4'),
-  getDescription: () => i18n.global.t('chat.model.grok4Description')
-};
-
 export const CHAT_MODEL_GROK_3: IChatModel = {
-  enabled: true,
   name: CHAT_MODEL_NAME_GROK_3,
   icon: CHAT_MODEL_ICON_GROK,
   modelGroup: 'grok',
@@ -208,7 +174,6 @@ export const CHAT_MODEL_GROK_3: IChatModel = {
 };
 
 export const CHAT_MODEL_GROK_3_REASONER: IChatModel = {
-  enabled: true,
   name: CHAT_MODEL_NAME_GROK_3_REASONER,
   icon: CHAT_MODEL_ICON_GROK,
   modelGroup: 'grok',
@@ -217,66 +182,11 @@ export const CHAT_MODEL_GROK_3_REASONER: IChatModel = {
 };
 
 export const CHAT_MODEL_GROK_3_DEEPSEARCH: IChatModel = {
-  enabled: true,
   name: CHAT_MODEL_NAME_GROK_3_DEEPSEARCH,
   icon: CHAT_MODEL_ICON_GROK,
   modelGroup: 'grok',
   getDisplayName: () => i18n.global.t('chat.model.grok3Deepsearch'),
   getDescription: () => i18n.global.t('chat.model.grok3DeepsearchDescription')
-};
-
-export const CHAT_MODEL_GEMINI_3_0_PRO: IChatModel = {
-  enabled: true,
-  name: CHAT_MODEL_NAME_GEMINI_3_0_PRO,
-  icon: CHAT_MODEL_ICON_GEMINI,
-  modelGroup: 'gemini',
-  getDisplayName: () => i18n.global.t('chat.model.gemini30Pro'),
-  getDescription: () => i18n.global.t('chat.model.gemini30ProDescription')
-};
-
-export const CHAT_MODEL_GEMINI_2_5_PRO: IChatModel = {
-  enabled: true,
-  name: CHAT_MODEL_NAME_GEMINI_2_5_PRO,
-  icon: CHAT_MODEL_ICON_GEMINI,
-  modelGroup: 'gemini',
-  getDisplayName: () => i18n.global.t('chat.model.gemini25Pro'),
-  getDescription: () => i18n.global.t('chat.model.gemini25ProDescription')
-};
-
-export const CHAT_MODEL_GEMINI_2_5_FLASH: IChatModel = {
-  enabled: true,
-  name: CHAT_MODEL_NAME_GEMINI_2_5_FLASH,
-  icon: CHAT_MODEL_ICON_GEMINI,
-  modelGroup: 'gemini',
-  getDisplayName: () => i18n.global.t('chat.model.gemini25Flash'),
-  getDescription: () => i18n.global.t('chat.model.gemini25FlashDescription')
-};
-
-export const CHAT_MODEL_CLAUDE_OPUS_4: IChatModel = {
-  enabled: true,
-  name: CHAT_MODEL_NAME_CLAUDE_OPUS_4,
-  icon: CHAT_MODEL_ICON_CLAUDE,
-  modelGroup: 'claude',
-  getDisplayName: () => i18n.global.t('chat.model.claudeOpus4'),
-  getDescription: () => i18n.global.t('chat.model.claudeOpus4Description')
-};
-
-export const CHAT_MODEL_CLAUDE_SONNET_4: IChatModel = {
-  enabled: true,
-  name: CHAT_MODEL_NAME_CLAUDE_SONNET_4,
-  icon: CHAT_MODEL_ICON_CLAUDE,
-  modelGroup: 'claude',
-  getDisplayName: () => i18n.global.t('chat.model.claudeSonnet4'),
-  getDescription: () => i18n.global.t('chat.model.claudeSonnet4Description')
-};
-
-export const CHAT_MODEL_CLAUDE_3_7_SONNET: IChatModel = {
-  enabled: true,
-  name: CHAT_MODEL_NAME_CLAUDE_3_7_SONNET,
-  icon: CHAT_MODEL_ICON_CLAUDE,
-  modelGroup: 'claude',
-  getDisplayName: () => i18n.global.t('chat.model.claude37Sonnet'),
-  getDescription: () => i18n.global.t('chat.model.claude37SonnetDescription')
 };
 
 export const CHAT_MODEL_GROUP_CHATGPT: IChatModelGroup = {
@@ -286,16 +196,13 @@ export const CHAT_MODEL_GROUP_CHATGPT: IChatModelGroup = {
   getDescription: () => i18n.global.t('chat.modelGroup.chatgptDescription'),
   models: [
     CHAT_MODEL_GPT_5_ALL,
-    CHAT_MODEL_GPT_5,
-    CHAT_MODEL_GPT_5_MINI,
-    CHAT_MODEL_GPT_4O,
-    CHAT_MODEL_GPT_4O_MINI,
+    // CHAT_MODEL_GPT_5,
+    // CHAT_MODEL_GPT_5_MINI,
+    // CHAT_MODEL_GPT_4O,
     CHAT_MODEL_GPT_4O_ALL,
-    CHAT_MODEL_GPT_4_ALL,
-    CHAT_MODEL_GPT_4O_IMAGE,
+    // CHAT_MODEL_GPT_4O_IMAGE,
     CHAT_MODEL_O3,
-    CHAT_MODEL_O4_MINI,
-    CHAT_MODEL_O1_MINI
+    CHAT_MODEL_O4_MINI
   ]
 };
 
@@ -304,7 +211,7 @@ export const CHAT_MODEL_GROUP_DEEPSEEK: IChatModelGroup = {
   name: 'deepseek',
   getDisplayName: () => i18n.global.t('chat.modelGroup.deepseek'),
   getDescription: () => i18n.global.t('chat.modelGroup.deepseekDescription'),
-  models: [CHAT_MODEL_DEEPSEEK_CHAT, CHAT_MODEL_DEEPSEEK_CHAT32, CHAT_MODEL_DEEPSEEK_REASONER]
+  models: [CHAT_MODEL_DEEPSEEK_CHAT, CHAT_MODEL_DEEPSEEK_REASONER]
 };
 
 export const CHAT_MODEL_GROUP_GROK: IChatModelGroup = {
@@ -312,54 +219,27 @@ export const CHAT_MODEL_GROUP_GROK: IChatModelGroup = {
   name: 'grok',
   getDisplayName: () => i18n.global.t('chat.modelGroup.grok'),
   getDescription: () => i18n.global.t('chat.modelGroup.grokDescription'),
-  models: [CHAT_MODEL_GROK_4, CHAT_MODEL_GROK_3, CHAT_MODEL_GROK_3_REASONER, CHAT_MODEL_GROK_3_DEEPSEARCH]
-};
-
-export const CHAT_MODEL_GROUP_GEMINI: IChatModelGroup = {
-  icon: CHAT_MODEL_ICON_GEMINI,
-  name: 'gemini',
-  getDisplayName: () => i18n.global.t('chat.modelGroup.gemini'),
-  getDescription: () => i18n.global.t('chat.modelGroup.geminiDescription'),
-  models: [CHAT_MODEL_GEMINI_3_0_PRO, CHAT_MODEL_GEMINI_2_5_PRO, CHAT_MODEL_GEMINI_2_5_FLASH]
-};
-
-export const CHAT_MODEL_GROUP_CLAUDE: IChatModelGroup = {
-  icon: CHAT_MODEL_ICON_CLAUDE,
-  name: 'claude',
-  getDisplayName: () => i18n.global.t('chat.modelGroup.claude'),
-  getDescription: () => i18n.global.t('chat.modelGroup.claudeDescription'),
-  models: [CHAT_MODEL_CLAUDE_OPUS_4, CHAT_MODEL_CLAUDE_SONNET_4, CHAT_MODEL_CLAUDE_3_7_SONNET]
+  models: [CHAT_MODEL_GROK_3, CHAT_MODEL_GROK_3_REASONER, CHAT_MODEL_GROK_3_DEEPSEARCH]
 };
 
 export const CHAT_MODELS: IChatModel[] = [
-  CHAT_MODEL_GPT_5_ALL,
   CHAT_MODEL_GPT_5,
   CHAT_MODEL_GPT_5_MINI,
   CHAT_MODEL_GPT_4O,
   CHAT_MODEL_GPT_4O_ALL,
   CHAT_MODEL_GPT_4_ALL,
-  CHAT_MODEL_GPT_4O_MINI,
   CHAT_MODEL_GPT_4O_IMAGE,
   CHAT_MODEL_O3,
   CHAT_MODEL_O4_MINI,
   CHAT_MODEL_DEEPSEEK_CHAT,
   CHAT_MODEL_DEEPSEEK_REASONER,
-  CHAT_MODEL_GROK_4,
   CHAT_MODEL_GROK_3,
   CHAT_MODEL_GROK_3_REASONER,
-  CHAT_MODEL_GROK_3_DEEPSEARCH,
-  CHAT_MODEL_GEMINI_3_0_PRO,
-  CHAT_MODEL_GEMINI_2_5_PRO,
-  CHAT_MODEL_GEMINI_2_5_FLASH,
-  CHAT_MODEL_CLAUDE_OPUS_4,
-  CHAT_MODEL_CLAUDE_SONNET_4,
-  CHAT_MODEL_CLAUDE_3_7_SONNET
+  CHAT_MODEL_GROK_3_DEEPSEARCH
 ];
 
 export const CHAT_MODEL_GROUPS: IChatModelGroup[] = [
   CHAT_MODEL_GROUP_CHATGPT,
   CHAT_MODEL_GROUP_DEEPSEEK,
-  CHAT_MODEL_GROUP_GROK,
-  CHAT_MODEL_GROUP_GEMINI,
-  CHAT_MODEL_GROUP_CLAUDE
+  CHAT_MODEL_GROUP_GROK
 ];

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -11,7 +11,6 @@ import {
   CHAT_MODEL_NAME_GPT_4O_IMAGE,
   CHAT_MODEL_NAME_GPT_4O_MINI,
   CHAT_MODEL_NAME_DEEPSEEK_CHAT,
-  CHAT_MODEL_NAME_DEEPSEEK32_CHAT,
   CHAT_MODEL_NAME_DEEPSEEK_REASONER,
   CHAT_MODEL_NAME_GROK_3,
   CHAT_MODEL_NAME_GROK_3_REASONER,
@@ -19,14 +18,7 @@ import {
   CHAT_MODEL_NAME_GPT_5,
   CHAT_MODEL_NAME_GPT_5_MINI,
   CHAT_MODEL_NAME_GPT_5_ALL,
-  CHAT_MODEL_NAME_GPT_4O_ALL,
-  CHAT_MODEL_NAME_GROK_4,
-  CHAT_MODEL_NAME_GEMINI_2_5_FLASH,
-  CHAT_MODEL_NAME_GEMINI_2_5_PRO,
-  CHAT_MODEL_NAME_GEMINI_3_0_PRO,
-  CHAT_MODEL_NAME_CLAUDE_OPUS_4,
-  CHAT_MODEL_NAME_CLAUDE_SONNET_4,
-  CHAT_MODEL_NAME_CLAUDE_3_7_SONNET
+  CHAT_MODEL_NAME_GPT_4O_ALL
 } from '@/constants';
 
 export type IChatModelName =
@@ -38,9 +30,7 @@ export type IChatModelName =
   | typeof CHAT_MODEL_NAME_GPT_4O
   | typeof CHAT_MODEL_NAME_GPT_4O_MINI
   | typeof CHAT_MODEL_NAME_DEEPSEEK_CHAT
-  | typeof CHAT_MODEL_NAME_DEEPSEEK32_CHAT
   | typeof CHAT_MODEL_NAME_DEEPSEEK_REASONER
-  | typeof CHAT_MODEL_NAME_GROK_4
   | typeof CHAT_MODEL_NAME_GROK_3
   | typeof CHAT_MODEL_NAME_GROK_3_REASONER
   | typeof CHAT_MODEL_NAME_GROK_3_DEEPSEARCH
@@ -49,19 +39,12 @@ export type IChatModelName =
   | typeof CHAT_MODEL_NAME_O3
   | typeof CHAT_MODEL_NAME_O4_MINI
   | typeof CHAT_MODEL_NAME_GPT_4O_IMAGE
-  | typeof CHAT_MODEL_NAME_O3
-  | typeof CHAT_MODEL_NAME_GEMINI_3_0_PRO
-  | typeof CHAT_MODEL_NAME_GEMINI_2_5_PRO
-  | typeof CHAT_MODEL_NAME_GEMINI_2_5_FLASH
-  | typeof CHAT_MODEL_NAME_CLAUDE_OPUS_4
-  | typeof CHAT_MODEL_NAME_CLAUDE_SONNET_4
-  | typeof CHAT_MODEL_NAME_CLAUDE_3_7_SONNET;
+  | typeof CHAT_MODEL_NAME_O3;
 
 export interface IChatModel {
-  enabled?: boolean;
   name: IChatModelName;
   icon: string;
-  modelGroup?: 'chatgpt' | 'deepseek' | 'grok' | 'gemini' | 'claude';
+  modelGroup?: 'chatgpt' | 'deepseek' | 'grok';
   getDisplayName: () => string;
   getDescription: () => string;
   isSearchSupported?: boolean;
@@ -72,7 +55,7 @@ export interface IChatModel {
 }
 
 export interface IChatModelGroup {
-  name: 'chatgpt' | 'deepseek' | 'grok' | 'gemini' | 'claude';
+  name: 'chatgpt' | 'deepseek' | 'grok';
   icon: string;
   getDisplayName: () => string;
   getDescription: () => string;

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -531,6 +531,10 @@ export default defineComponent({
       color-mix(in srgb, var(--el-color-primary-light-9) 65%, transparent) 0%,
       transparent 24%
     );
+
+html.dark & {
+    background: none;
+  }
   .disclaimer {
     width: 100%;
     text-align: center;


### PR DESCRIPTION
- Remove Gemini and Claude model groups from chat UI
- Remove deepseek-v3.2-exp and grok-4 models
- Remove enabled field from IChatModel interface
- Simplify ChatGPT group to show fewer model variants
- Clean up model type definitions