### PR TITLE
fix: remove radial gradient background in dark mode chat page

### DIFF
--- a/change/@acedatacloud-nexior-482e8160-8d06-48b0-9ab0-164cbf67983e.json
+++ b/change/@acedatacloud-nexior-482e8160-8d06-48b0-9ab0-164cbf67983e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove radial gradient background from chat dialogue in dark mode",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -531,6 +531,10 @@ export default defineComponent({
       color-mix(in srgb, var(--el-color-primary-light-9) 65%, transparent) 0%,
       transparent 24%
     );
+
+  html.dark & {
+    background: none;
+  }
   .disclaimer {
     width: 100%;
     text-align: center;


### PR DESCRIPTION
The previous fix (#338) only removed the `linear-gradient` from `Chat.vue` (layout). The actual visible gradient comes from `radial-gradient` in `Conversation.vue`'s `.dialogue` class. This adds `html.dark & { background: none; }` to disable it in dark mode.