### PR TITLE
Fix navigator More button popover and task preview text overflow

### DIFF
--- a/change/@acedatacloud-nexior-fix-navigator-overflow.json
+++ b/change/@acedatacloud-nexior-fix-navigator-overflow.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix navigator More button popover and task preview text overflow",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/Navigator.vue
+++ b/src/components/common/Navigator.vue
@@ -24,24 +24,17 @@
             popper-class="navigator-overflow-popover"
           >
             <template #reference>
-              <el-tooltip
-                effect="dark"
-                :content="$t('common.nav.more')"
-                :placement="direction === 'row' ? 'top' : 'right'"
-                :disabled="showOverflow"
-              >
-                <div class="more-button" :class="{ active: isOverflowActive }">
-                  <div class="folder-preview">
-                    <el-image
-                      v-for="(link, i) in overflowPreviewLinks"
-                      :key="i"
-                      :src="link.logo"
-                      class="folder-icon"
-                      fit="cover"
-                    />
-                  </div>
+              <div class="more-button" :class="{ active: isOverflowActive }" :title="$t('common.nav.more')">
+                <div class="folder-preview">
+                  <el-image
+                    v-for="(link, i) in overflowPreviewLinks"
+                    :key="i"
+                    :src="link.logo"
+                    class="folder-icon"
+                    fit="cover"
+                  />
                 </div>
-              </el-tooltip>
+              </div>
             </template>
             <div class="overflow-menu">
               <div

--- a/src/components/flux/task/Preview.vue
+++ b/src/components/flux/task/Preview.vue
@@ -198,6 +198,8 @@ $left-width: 70px;
     }
 
     .content {
+      word-break: break-word;
+      overflow-wrap: anywhere;
       .el-alert {
         border-left-width: 2px;
         border-left-style: solid;

--- a/src/components/hailuo/task/Preview.vue
+++ b/src/components/hailuo/task/Preview.vue
@@ -197,6 +197,8 @@ $left-width: 70px;
     }
 
     .content {
+      word-break: break-word;
+      overflow-wrap: anywhere;
       .el-alert {
         border-left-width: 2px;
         border-left-style: solid;

--- a/src/components/headshots/task/Preview.vue
+++ b/src/components/headshots/task/Preview.vue
@@ -207,6 +207,8 @@ $left-width: 70px;
     }
 
     .content {
+      word-break: break-word;
+      overflow-wrap: anywhere;
       .el-alert {
         border-left-width: 2px;
         border-left-style: solid;

--- a/src/components/kling/task/Preview.vue
+++ b/src/components/kling/task/Preview.vue
@@ -208,6 +208,8 @@ $left-width: 70px;
     }
 
     .content {
+      word-break: break-word;
+      overflow-wrap: anywhere;
       .el-alert {
         border-left-width: 2px;
         border-left-style: solid;

--- a/src/components/luma/task/Preview.vue
+++ b/src/components/luma/task/Preview.vue
@@ -215,6 +215,8 @@ $left-width: 70px;
     }
 
     .content {
+      word-break: break-word;
+      overflow-wrap: anywhere;
       .el-alert {
         border-left-width: 2px;
         border-left-style: solid;

--- a/src/components/nanobanana/task/Preview.vue
+++ b/src/components/nanobanana/task/Preview.vue
@@ -270,6 +270,8 @@ $left-width: 70px;
     }
 
     .content {
+      word-break: break-word;
+      overflow-wrap: anywhere;
       .el-alert {
         border-left-width: 2px;
         border-left-style: solid;

--- a/src/components/pika/task/Preview.vue
+++ b/src/components/pika/task/Preview.vue
@@ -246,6 +246,8 @@ $left-width: 70px;
     }
 
     .content {
+      word-break: break-word;
+      overflow-wrap: anywhere;
       .el-alert {
         border-left-width: 2px;
         border-left-style: solid;

--- a/src/components/pixverse/task/Preview.vue
+++ b/src/components/pixverse/task/Preview.vue
@@ -194,6 +194,8 @@ $left-width: 70px;
     }
 
     .content {
+      word-break: break-word;
+      overflow-wrap: anywhere;
       .el-alert {
         border-left-width: 2px;
         border-left-style: solid;

--- a/src/components/qrart/task/Preview.vue
+++ b/src/components/qrart/task/Preview.vue
@@ -229,6 +229,8 @@ $left-width: 70px;
     }
 
     .content {
+      word-break: break-word;
+      overflow-wrap: anywhere;
       .el-alert {
         border-left-width: 2px;
         border-left-style: solid;

--- a/src/components/seedance/task/Preview.vue
+++ b/src/components/seedance/task/Preview.vue
@@ -233,6 +233,8 @@ $left-width: 70px;
     }
 
     .content {
+      word-break: break-word;
+      overflow-wrap: anywhere;
       .el-alert {
         border-left-width: 2px;
         border-left-style: solid;

--- a/src/components/seedream/task/Preview.vue
+++ b/src/components/seedream/task/Preview.vue
@@ -259,6 +259,8 @@ $left-width: 70px;
     }
 
     .content {
+      word-break: break-word;
+      overflow-wrap: anywhere;
       .el-alert {
         border-left-width: 2px;
         border-left-style: solid;

--- a/src/components/sora/task/Preview.vue
+++ b/src/components/sora/task/Preview.vue
@@ -204,6 +204,9 @@ $left-width: 70px;
     }
 
     .content {
+      word-break: break-word;
+      overflow-wrap: anywhere;
+
       .el-alert {
         border-left-width: 2px;
         border-left-style: solid;

--- a/src/components/veo/task/Preview.vue
+++ b/src/components/veo/task/Preview.vue
@@ -228,6 +228,8 @@ $left-width: 70px;
     }
 
     .content {
+      word-break: break-word;
+      overflow-wrap: anywhere;
       .el-alert {
         border-left-width: 2px;
         border-left-style: solid;


### PR DESCRIPTION
## Changes

### Navigator More Button Fix
- Removed `el-tooltip` nesting inside `el-popover`'s `#reference` slot which was intercepting click events and preventing the overflow popover from opening
- Replaced with native `title` attribute for the More button tooltip

### Task Preview Text Overflow Fix
- Added `word-break: break-word` and `overflow-wrap: anywhere` to `.content` blocks in all task Preview components (sora, luma, hailuo, kling, veo, pixverse, flux, nanobanana, seedream, seedance, headshots, pika, qrart)
- Prevents long error messages (JSON errors, trace IDs, Chinese text) from overflowing horizontally