### PR TITLE
fix: add subtle border to cards in dark mode for visibility

### DIFF
--- a/change/@acedatacloud-nexior-281fd0ef-59dc-493b-936c-98b9ccc5fdb8.json
+++ b/change/@acedatacloud-nexior-281fd0ef-59dc-493b-936c-98b9ccc5fdb8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: add subtle border to cards in dark mode for visibility",
+  "packageName": "@acedatacloud/nexior",
+  "email": "cqc@cuiqingcai.com",
+  "dependentChangeType": "patch"
+}

--- a/src/assets/scss/_common.scss
+++ b/src/assets/scss/_common.scss
@@ -168,6 +168,10 @@ w3m-modal {
   --el-card-padding: 10px;
 }
 
+html.dark .el-card {
+  border: 1px solid var(--app-border-subtle);
+}
+
 .el-breadcrumb__inner a,
 .el-breadcrumb__inner.is-link {
   color: var(--el-text-color-regular);


### PR DESCRIPTION
In dark mode, `el-card` had `border: none` globally while the page background (`--el-bg-color-page`) and card background (`--el-bg-color`) were nearly identical colors (~`#0a0a0a` vs `#141414`). This made cards invisible on pages like /distribution.

**Fix:** Add a subtle `1px solid var(--app-border-subtle)` border to `.el-card` in dark mode only, using the existing `--app-border-subtle: #3a3a3a` design token.