### PR TITLE
refactor: replace borders with shadow system for premium UI feel

### DIFF
--- a/change/@acedatacloud-nexior-b8dba5aa-9b06-4638-998b-723d5129e767.json
+++ b/change/@acedatacloud-nexior-b8dba5aa-9b06-4638-998b-723d5129e767.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: redesign model selector and add missing i18n translations",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/assets/scss/_common.scss
+++ b/src/assets/scss/_common.scss
@@ -44,9 +44,15 @@ html.dark,
   --app-badge-bg: #ffe8d5;
   --app-badge-border: #ff7200;
 
-  /* Discord-style surface levels (no borders, background separation) */
-  --app-nav-bg: #f0f2f5;
-  --app-sidebar-bg: #f5f7fa;
+  /* Elevation / shadow system */
+  --app-shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.04);
+  --app-shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.06), 0 1px 2px rgba(0, 0, 0, 0.04);
+  --app-shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08), 0 2px 4px rgba(0, 0, 0, 0.04);
+  --app-shadow-lg: 0 12px 32px rgba(0, 0, 0, 0.1), 0 4px 12px rgba(0, 0, 0, 0.06);
+
+  /* Surface levels (wider contrast for depth) */
+  --app-nav-bg: #eaecf0;
+  --app-sidebar-bg: #f2f4f7;
   --app-content-bg: #ffffff;
 }
 
@@ -60,9 +66,15 @@ html.dark {
   --app-badge-bg: #3d2a1a;
   --app-badge-border: #ff7200;
 
-  /* Discord-style surface levels */
-  --app-nav-bg: #111214;
-  --app-sidebar-bg: #18191c;
+  /* Elevation / shadow system (dark) */
+  --app-shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.2);
+  --app-shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.3), 0 1px 2px rgba(0, 0, 0, 0.2);
+  --app-shadow-md: 0 4px 12px rgba(0, 0, 0, 0.3), 0 2px 4px rgba(0, 0, 0, 0.2);
+  --app-shadow-lg: 0 12px 32px rgba(0, 0, 0, 0.4), 0 4px 12px rgba(0, 0, 0, 0.25);
+
+  /* Surface levels (dark) */
+  --app-nav-bg: #0e0f11;
+  --app-sidebar-bg: #17181b;
   --app-content-bg: #1e1f22;
 }
 
@@ -167,7 +179,9 @@ w3m-modal {
   word-wrap: break-word;
   border-radius: 1rem;
   border: none;
-  --el-card-padding: 10px;
+  --el-card-padding: 16px;
+  box-shadow: var(--app-shadow-sm);
+  transition: box-shadow 0.2s ease;
 }
 
 .el-breadcrumb__inner a,
@@ -202,7 +216,7 @@ w3m-modal {
     border-radius: var(--el-border-radius-base);
     width: 100%;
     &.is-focus {
-      box-shadow: 0 0 0 1px var(--el-input-border-color, var(--el-border-color)) inset;
+      box-shadow: 0 0 0 1px var(--el-color-primary) inset, 0 0 0 3px var(--el-color-primary-light-8);
     }
     textarea:focus,
     input:focus {

--- a/src/components/application/Info.vue
+++ b/src/components/application/Info.vue
@@ -89,7 +89,7 @@ export default defineComponent({
   width: 100%;
   background-color: var(--el-bg-color);
   border-radius: 15px;
-  border: 1px solid var(--el-border-color-lighter);
+  box-shadow: var(--app-shadow-sm);
   display: flex;
   gap: 16px;
   justify-content: space-between;

--- a/src/components/chat/SuggestionItem.vue
+++ b/src/components/chat/SuggestionItem.vue
@@ -47,14 +47,17 @@ export default defineComponent({
 .item {
   // height: 80px;
   font-size: 14px;
-  background-color: var(--el-color-color);
+  background-color: var(--el-bg-color);
   color: var(--el-text-color-primary);
-  border: 1px solid var(--el-border-color-lighter);
-  padding: 10px 20px;
+  box-shadow: var(--app-shadow-sm);
+  padding: 12px 20px;
   border-radius: 20px;
   margin-bottom: 15px;
+  cursor: pointer;
+  transition: box-shadow 0.2s ease, background-color 0.2s ease;
   &:hover {
     background-color: var(--el-bg-color-page);
+    box-shadow: var(--app-shadow-md);
   }
   .icon {
     font-size: 14px;

--- a/src/components/common/Navigator.vue
+++ b/src/components/common/Navigator.vue
@@ -541,18 +541,20 @@ export default defineComponent({
         background: var(--el-fill-color-light);
         cursor: pointer;
         margin: auto;
-        border: 1px solid var(--el-border-color-lighter);
+        box-shadow: var(--app-shadow-xs);
         transition:
           border-radius 0.2s,
-          background-color 0.2s;
+          background-color 0.2s,
+          box-shadow 0.2s;
 
         &:hover {
           border-radius: 35%;
           background: var(--el-fill-color);
+          box-shadow: var(--app-shadow-sm);
         }
 
         &.active {
-          border: 2px solid var(--el-color-primary);
+          box-shadow: 0 0 0 2px var(--el-color-primary);
         }
 
         .folder-preview {

--- a/src/layouts/Chat.vue
+++ b/src/layouts/Chat.vue
@@ -91,8 +91,7 @@ export default defineComponent({
     left: 12px;
     top: 48px;
     z-index: 2000;
-    border: 1px solid var(--el-border-color-lighter);
-    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.12);
+    box-shadow: var(--app-shadow-md);
   }
 }
 </style>


### PR DESCRIPTION
Replace thin 1px borders with a proper shadow elevation system for more depth and polish.

**Global Design System (_common.scss):**
- 4-level shadow tokens (--app-shadow-xs/sm/md/lg) with light + dark variants
- Widened surface level contrast for nav/sidebar/content backgrounds
- Card padding 10px → 16px with shadow elevation and hover transition
- Input focus ring: primary color + outer glow

**Components:**
- Navigator.vue: border → shadow on more-button; active ring replaces border
- SuggestionItem.vue: border → shadow card with hover depth; fixed broken bg var
- application/Info.vue: border → shadow
- Chat.vue: mobile menu button border → shadow
