### PR TITLE
feat: add SEO meta tags to Nexior

### DIFF
--- a/change/@acedatacloud-nexior-seo-basics.json
+++ b/change/@acedatacloud-nexior-seo-basics.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: add SEO meta tags - description, OG tags, Twitter Cards, canonical URL",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/index.html
+++ b/index.html
@@ -6,7 +6,34 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, max-age=0, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
-    <title>AceData</title>
+    <title>Ace Data Cloud - AI Hub</title>
+    <meta
+      name="description"
+      content="AI-powered creative hub — generate images with Midjourney & Flux, create music with Suno, produce videos with Luma & Sora, chat with GPT, Claude, Gemini & DeepSeek."
+    />
+    <meta
+      name="keywords"
+      content="AI Hub,Midjourney,Suno,Flux,Luma,Sora,GPT,Claude,Gemini,DeepSeek,AI Image,AI Music,AI Video,AI Chat"
+    />
+    <link rel="canonical" href="https://hub.acedata.cloud" />
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Ace Data Cloud" />
+    <meta property="og:title" content="Ace Data Cloud - AI Hub" />
+    <meta
+      property="og:description"
+      content="AI-powered creative hub — generate images with Midjourney & Flux, create music with Suno, produce videos with Luma & Sora, chat with GPT, Claude, Gemini & DeepSeek."
+    />
+    <meta property="og:url" content="https://hub.acedata.cloud" />
+    <meta property="og:image" content="https://cdn.acedata.cloud/logo.png" />
+    <!-- Twitter Cards -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Ace Data Cloud - AI Hub" />
+    <meta
+      name="twitter:description"
+      content="AI-powered creative hub — generate images with Midjourney & Flux, create music with Suno, produce videos with Luma & Sora, chat with GPT, Claude, Gemini & DeepSeek."
+    />
+    <meta name="twitter:image" content="https://cdn.acedata.cloud/logo.png" />
     <link rel="icon" href="/src/images/favicon.ico" />
     <script>
       var _hmt = _hmt || [];


### PR DESCRIPTION
Add SEO meta tags to Nexior (hub.acedata.cloud).

**Changes to `index.html`:**
- Title: "AceData" → "Ace Data Cloud - AI Hub"
- Meta description covering all AI services
- Keywords targeting key products
- Canonical URL: https://hub.acedata.cloud
- Open Graph tags (type, site_name, title, description, url, image)
- Twitter Cards (summary_large_image)

**Impact:** hub.acedata.cloud will now show proper previews when shared on social media, and search engines can index it with relevant descriptions.
