### PR TITLE
feat: add Android/iOS CI/CD pipelines for Play Store and App Store

### DIFF
--- a/.github/workflows/build-android.yaml
+++ b/.github/workflows/build-android.yaml
@@ -1,0 +1,127 @@
+name: Build Android
+
+on:
+  push:
+    tags:
+      - 'android-v*'
+  workflow_dispatch:
+    inputs:
+      track:
+        description: 'Play Store track (internal / alpha / beta / production)'
+        required: true
+        default: 'internal'
+        type: choice
+        options:
+          - internal
+          - alpha
+          - beta
+          - production
+
+permissions:
+  contents: read
+
+env:
+  NODE_VERSION: '20'
+  JAVA_VERSION: '17'
+
+jobs:
+  build:
+    name: Build & Upload to Play Store
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: yarn
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+          cache: gradle
+
+      - name: Install Node dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build web assets (Android surface)
+        run: yarn build:android
+
+      - name: Copy web assets to Android project
+        run: npx cap copy android
+
+      - name: Decode keystore
+        run: |
+          echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > android/app/release.keystore
+        shell: bash
+
+      - name: Determine version
+        id: version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          # versionCode: major*10000 + minor*100 + patch
+          IFS='.' read -r major minor patch <<< "$VERSION"
+          CODE=$((major * 10000 + minor * 100 + patch))
+          echo "name=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "code=$CODE" >> "$GITHUB_OUTPUT"
+          echo "Version: $VERSION  Code: $CODE"
+
+      - name: Set version in build.gradle
+        run: |
+          sed -i "s/versionCode [0-9]*/versionCode ${{ steps.version.outputs.code }}/" android/app/build.gradle
+          sed -i "s/versionName \"[^\"]*\"/versionName \"${{ steps.version.outputs.name }}\"/" android/app/build.gradle
+        shell: bash
+
+      - name: Build release AAB
+        working-directory: android
+        run: |
+          chmod +x gradlew
+          ./gradlew bundleRelease \
+            -PRELEASE_STORE_FILE=release.keystore \
+            -PRELEASE_STORE_PASSWORD='${{ secrets.ANDROID_KEYSTORE_PASSWORD }}' \
+            -PRELEASE_KEY_ALIAS='${{ secrets.ANDROID_KEY_ALIAS }}' \
+            -PRELEASE_KEY_PASSWORD='${{ secrets.ANDROID_KEY_PASSWORD }}'
+
+      - name: Build release APK (for GitHub artifacts)
+        working-directory: android
+        run: |
+          ./gradlew assembleRelease \
+            -PRELEASE_STORE_FILE=release.keystore \
+            -PRELEASE_STORE_PASSWORD='${{ secrets.ANDROID_KEYSTORE_PASSWORD }}' \
+            -PRELEASE_KEY_ALIAS='${{ secrets.ANDROID_KEY_ALIAS }}' \
+            -PRELEASE_KEY_PASSWORD='${{ secrets.ANDROID_KEY_PASSWORD }}'
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: nexior-${{ steps.version.outputs.name }}.apk
+          path: android/app/build/outputs/apk/release/app-release.apk
+
+      - name: Upload AAB artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: nexior-${{ steps.version.outputs.name }}.aab
+          path: android/app/build/outputs/bundle/release/app-release.aab
+
+      - name: Determine Play Store track
+        id: track
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "track=${{ inputs.track }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "track=internal" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload to Play Store
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: com.acedatacloud.nexior
+          releaseFiles: android/app/build/outputs/bundle/release/app-release.aab
+          track: ${{ steps.track.outputs.track }}
+          status: completed

--- a/.github/workflows/build-ios.yaml
+++ b/.github/workflows/build-ios.yaml
@@ -1,0 +1,165 @@
+name: Build iOS
+
+on:
+  push:
+    tags:
+      - 'ios-v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  NODE_VERSION: '20'
+
+jobs:
+  build:
+    name: Build & Upload to TestFlight
+    runs-on: macos-15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: yarn
+
+      - name: Install Node dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build web assets (iOS surface)
+        run: yarn build:ios
+
+      - name: Copy web assets to iOS project
+        run: npx cap copy ios
+
+      - name: Install CocoaPods
+        working-directory: ios/App
+        run: pod install
+
+      - name: Determine version
+        id: version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          IFS='.' read -r major minor patch <<< "$VERSION"
+          CODE=$((major * 10000 + minor * 100 + patch))
+          echo "name=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "code=$CODE" >> "$GITHUB_OUTPUT"
+          echo "Version: $VERSION  Code: $CODE"
+
+      - name: Set version in Xcode project
+        run: |
+          cd ios/App
+          agvtool new-marketing-version "${{ steps.version.outputs.name }}"
+          agvtool new-version -all "${{ steps.version.outputs.code }}"
+
+      - name: Install Apple certificate and provisioning profile
+        env:
+          P12_BASE64: ${{ secrets.IOS_P12_BASE64 }}
+          P12_PASSWORD: ${{ secrets.IOS_P12_PASSWORD }}
+          PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_PROVISIONING_PROFILE_BASE64 }}
+          KEYCHAIN_PASSWORD: ${{ github.run_id }}
+        run: |
+          # Create variables
+          CERTIFICATE_PATH=$RUNNER_TEMP/certificate.p12
+          PP_PATH=$RUNNER_TEMP/build_pp.mobileprovision
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+
+          # Decode files
+          echo "$P12_BASE64" | base64 --decode > "$CERTIFICATE_PATH"
+          echo "$PROVISIONING_PROFILE_BASE64" | base64 --decode > "$PP_PATH"
+
+          # Create temporary keychain
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Import certificate
+          security import "$CERTIFICATE_PATH" -P "$P12_PASSWORD" -A -t cert -f pkcs12 \
+            -k "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" \
+            "$KEYCHAIN_PATH"
+          security list-keychain -d user -s "$KEYCHAIN_PATH"
+
+          # Install provisioning profile
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          cp "$PP_PATH" ~/Library/MobileDevice/Provisioning\ Profiles/
+
+      - name: Build archive
+        working-directory: ios/App
+        run: |
+          xcodebuild -workspace App.xcworkspace \
+            -scheme App \
+            -sdk iphoneos \
+            -configuration Release \
+            -archivePath $RUNNER_TEMP/App.xcarchive \
+            archive \
+            CODE_SIGN_STYLE=Manual \
+            PROVISIONING_PROFILE_SPECIFIER="${{ secrets.IOS_PROVISIONING_PROFILE_NAME }}" \
+            CODE_SIGN_IDENTITY="Apple Distribution" \
+            DEVELOPMENT_TEAM="${{ secrets.IOS_TEAM_ID }}"
+
+      - name: Create ExportOptions.plist
+        run: |
+          cat > $RUNNER_TEMP/ExportOptions.plist <<EOF
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+              <key>method</key>
+              <string>app-store-connect</string>
+              <key>teamID</key>
+              <string>${{ secrets.IOS_TEAM_ID }}</string>
+              <key>signingStyle</key>
+              <string>manual</string>
+              <key>provisioningProfiles</key>
+              <dict>
+                  <key>com.acedatacloud.nexior</key>
+                  <string>${{ secrets.IOS_PROVISIONING_PROFILE_NAME }}</string>
+              </dict>
+              <key>uploadBitcode</key>
+              <false/>
+              <key>uploadSymbols</key>
+              <true/>
+          </dict>
+          </plist>
+          EOF
+
+      - name: Export IPA
+        run: |
+          xcodebuild -exportArchive \
+            -archivePath $RUNNER_TEMP/App.xcarchive \
+            -exportOptionsPlist $RUNNER_TEMP/ExportOptions.plist \
+            -exportPath $RUNNER_TEMP/export
+
+      - name: Upload IPA artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: nexior-${{ steps.version.outputs.name }}.ipa
+          path: ${{ runner.temp }}/export/*.ipa
+
+      - name: Upload to TestFlight
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_KEY_BASE64 }}
+        run: |
+          # Decode API key
+          mkdir -p ~/private_keys
+          echo "$APP_STORE_CONNECT_API_KEY_BASE64" | base64 --decode \
+            > ~/private_keys/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8
+
+          # Upload via xcrun
+          xcrun altool --upload-app \
+            --type ios \
+            --file "$(find $RUNNER_TEMP/export -name '*.ipa')" \
+            --apiKey "$APP_STORE_CONNECT_API_KEY_ID" \
+            --apiIssuer "$APP_STORE_CONNECT_API_ISSUER_ID"
+
+      - name: Clean up keychain
+        if: always()
+        run: |
+          security delete-keychain $RUNNER_TEMP/app-signing.keychain-db 2>/dev/null || true

--- a/android/.gitignore
+++ b/android/.gitignore
@@ -53,9 +53,8 @@ captures/
 .idea/navEditor.xml
 
 # Keystore files
-# Uncomment the following lines if you do not want to check your keystore files in.
-#*.jks
-#*.keystore
+*.jks
+*.keystore
 
 # External native build folder generated in Android Studio 2.2 and later
 .externalNativeBuild

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -28,8 +28,9 @@ android {
     }
     buildTypes {
         release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            minifyEnabled true
+            shrinkResources true
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             if (project.hasProperty('RELEASE_STORE_FILE')) {
                 signingConfig signingConfigs.release
             }

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -5,17 +5,15 @@
 # For more details, see
 #   http://developer.android.com/guide/developing/tools/proguard.html
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+# Keep Capacitor classes
+-keep class com.getcapacitor.** { *; }
+-dontwarn com.getcapacitor.**
 
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+# Keep WebView JavaScript interface
+-keepclassmembers class * {
+    @android.webkit.JavascriptInterface <methods>;
+}
 
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
+# Keep AndroidX
+-keep class androidx.** { *; }
+-dontwarn androidx.**

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -42,6 +42,9 @@
     </application>
 
     <!-- Permissions -->
-
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29" />
 </manifest>

--- a/change/@acedatacloud-nexior-mobile-cicd.json
+++ b/change/@acedatacloud-nexior-mobile-cicd.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add Android/iOS CI/CD pipelines for Play Store & App Store",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/docs/MOBILE_RELEASE.md
+++ b/docs/MOBILE_RELEASE.md
@@ -1,0 +1,208 @@
+# Nexior Mobile Release Guide
+
+Android (Google Play Store) 和 iOS (App Store) 的 CI/CD 构建与发布指南。
+
+## 架构概览
+
+```
+package.json (版本源)
+    ↓  npm run sync-version
+android/app/build.gradle  +  ios/App/App.xcodeproj/project.pbxproj
+    ↓  git tag android-v* / ios-v*
+GitHub Actions
+    ↓
+Google Play Store (AAB)  /  TestFlight (IPA)
+```
+
+- **Android workflow**: `.github/workflows/build-android.yaml`
+- **iOS workflow**: `.github/workflows/build-ios.yaml`
+- **版本同步脚本**: `scripts/sync-native-version.js`
+
+---
+
+## 一、Google Play Store（Android）
+
+### 1. 创建开发者账号
+
+- 前往 https://play.google.com/console 注册（一次性 $25）
+- 创建 App：包名 `com.acedatacloud.nexior`，名称 `AceData`
+
+### 2. 生成签名 Keystore
+
+```bash
+keytool -genkeypair -v -storetype PKCS12 \
+  -keystore nexior-release.keystore \
+  -alias nexior \
+  -keyalg RSA -keysize 2048 -validity 10000 \
+  -dname "CN=Ace Data Cloud, O=Ace Data Cloud, L=Beijing, C=CN"
+```
+
+> **⚠️ 这个 keystore 文件和密码必须永久保存。丢失后无法再更新此 App。**
+
+### 3. Base64 编码 Keystore
+
+```bash
+base64 -i nexior-release.keystore | tr -d '\n' > nexior-release.keystore.b64
+```
+
+### 4. 创建 Google Play 服务账号（CI 上传用）
+
+1. Google Play Console → **Settings** → **API access** → **Create new service account**
+2. 跳转到 Google Cloud Console，创建 Service Account，下载 JSON key 文件
+3. 回到 Play Console，给该 service account 分配 **Release manager** 权限
+
+### 5. 设置 GitHub Secrets
+
+前往 https://github.com/AceDataCloud/Nexior/settings/secrets/actions 添加：
+
+| Secret | 值 |
+|---|---|
+| `ANDROID_KEYSTORE_BASE64` | `nexior-release.keystore.b64` 文件的全部内容 |
+| `ANDROID_KEYSTORE_PASSWORD` | keytool 生成时设置的密码 |
+| `ANDROID_KEY_ALIAS` | `nexior` |
+| `ANDROID_KEY_PASSWORD` | 与 keystore 密码相同（或单独设置） |
+| `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` | 服务账号 JSON 文件的全部内容（不是 base64） |
+
+### 6. 首次手动上传
+
+Google Play 要求第一个 AAB 必须在 Console 手动上传，之后 CI 才可自动推送。
+
+```bash
+# 本地构建
+npm run pack:android
+
+# 在 Android Studio 中用 keystore 签名打包 release AAB
+# 或命令行：
+cd android && chmod +x gradlew && ./gradlew bundleRelease \
+  -PRELEASE_STORE_FILE=/path/to/nexior-release.keystore \
+  -PRELEASE_STORE_PASSWORD=your_password \
+  -PRELEASE_KEY_ALIAS=nexior \
+  -PRELEASE_KEY_PASSWORD=your_password
+```
+
+产出文件在 `android/app/build/outputs/bundle/release/app-release.aab`，上传到 Play Console → **Internal testing**。
+
+### 7. 触发 CI 构建
+
+```bash
+# 方式 1：打 tag 自动触发（默认推到 internal track）
+git tag android-v3.29.5 && git push origin android-v3.29.5
+
+# 方式 2：GitHub Actions 页面 → Build Android → Run workflow → 选择 track
+#   internal  → 内部测试
+#   alpha     → 封闭测试
+#   beta      → 公开测试
+#   production → 正式发布
+```
+
+---
+
+## 二、App Store（iOS）
+
+### 1. Apple Developer Program
+
+- 前往 https://developer.apple.com/programs/ 加入（$99/年）
+- 注册后记录 **Team ID**（10 位字母数字）
+
+### 2. 创建 App ID + Provisioning Profile
+
+1. Apple Developer → **Certificates, Identifiers & Profiles**
+2. **Identifiers** → 新建 App ID，Bundle ID = `com.acedatacloud.nexior`
+3. **Certificates** → 创建 **Apple Distribution** 证书，下载 `.cer` 并双击安装到 Keychain
+4. **Profiles** → 新建 **App Store Connect** Distribution Profile，选择上面的证书和 App ID
+
+### 3. 导出 P12
+
+1. 打开 Mac **Keychain Access**
+2. 找到刚安装的 Apple Distribution 证书
+3. 右键 → **Export** → 保存为 `.p12`（设置导出密码）
+4. Base64 编码：
+
+```bash
+base64 -i Certificates.p12 | tr -d '\n' > cert.b64
+```
+
+### 4. Base64 编码 Provisioning Profile
+
+```bash
+base64 -i AceData_AppStore.mobileprovision | tr -d '\n' > profile.b64
+```
+
+### 5. 创建 App Store Connect API Key
+
+1. 前往 https://appstoreconnect.apple.com → **Users and Access** → **Integrations** → **App Store Connect API**
+2. 点 **Generate API Key**，Role 选 **App Manager**
+3. 下载 `.p8` 文件，记录 **Key ID** 和 **Issuer ID**
+4. Base64 编码：
+
+```bash
+base64 -i AuthKey_XXXXXXXXXX.p8 | tr -d '\n' > key.b64
+```
+
+### 6. 设置 GitHub Secrets
+
+| Secret | 值 |
+|---|---|
+| `IOS_P12_BASE64` | P12 证书的 base64 内容 |
+| `IOS_P12_PASSWORD` | 导出 P12 时设置的密码 |
+| `IOS_PROVISIONING_PROFILE_BASE64` | Provisioning Profile 的 base64 内容 |
+| `IOS_PROVISIONING_PROFILE_NAME` | Profile 名称（Apple Developer 页面上显示的） |
+| `IOS_TEAM_ID` | Apple Developer Team ID |
+| `APP_STORE_CONNECT_KEY_ID` | API Key ID |
+| `APP_STORE_CONNECT_ISSUER_ID` | Issuer ID |
+| `APP_STORE_CONNECT_KEY_BASE64` | `.p8` 文件的 base64 内容 |
+
+### 7. 在 App Store Connect 创建 App
+
+- https://appstoreconnect.apple.com → **My Apps** → **+** → Bundle ID 选 `com.acedatacloud.nexior`
+
+### 8. 触发 CI 构建
+
+```bash
+# 方式 1：打 tag 自动触发
+git tag ios-v3.29.5 && git push origin ios-v3.29.5
+
+# 方式 2：GitHub Actions 页面 → Build iOS → Run workflow
+```
+
+构建完成后 IPA 自动上传到 TestFlight，审核通过后可发布到 App Store。
+
+---
+
+## 三、日常发版流程
+
+```bash
+# 1. 更新 package.json 版本号（通过 beachball 或手动修改）
+
+# 2. 同步版本到 Android + iOS native 项目
+npm run sync-version
+
+# 3. 提交版本变更
+git add -A && git commit -m "chore: bump version to x.y.z"
+
+# 4. 打 tag 触发 CI
+git tag android-vX.Y.Z && git tag ios-vX.Y.Z
+git push origin android-vX.Y.Z ios-vX.Y.Z
+```
+
+Android 可通过 GitHub Actions 手动选择 track 逐步放量：`internal → alpha → beta → production`。
+
+---
+
+## 四、GitHub Secrets 清单
+
+| Secret | 用途 | 平台 |
+|---|---|---|
+| `ANDROID_KEYSTORE_BASE64` | 签名密钥库 | Android |
+| `ANDROID_KEYSTORE_PASSWORD` | 密钥库密码 | Android |
+| `ANDROID_KEY_ALIAS` | 密钥别名 | Android |
+| `ANDROID_KEY_PASSWORD` | 密钥密码 | Android |
+| `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` | Play Store 上传凭证 | Android |
+| `IOS_P12_BASE64` | 签名证书 | iOS |
+| `IOS_P12_PASSWORD` | 证书密码 | iOS |
+| `IOS_PROVISIONING_PROFILE_BASE64` | 描述文件 | iOS |
+| `IOS_PROVISIONING_PROFILE_NAME` | 描述文件名称 | iOS |
+| `IOS_TEAM_ID` | 开发者团队 ID | iOS |
+| `APP_STORE_CONNECT_KEY_ID` | API Key ID | iOS |
+| `APP_STORE_CONNECT_ISSUER_ID` | Issuer ID | iOS |
+| `APP_STORE_CONNECT_KEY_BASE64` | API Key 文件 | iOS |

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -348,11 +348,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 32905;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 3.29.5;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.acedatacloud.nexior;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -368,11 +368,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 32905;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 3.29.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.acedatacloud.nexior;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build:ios": "cross-env VITE_SURFACE=ios vite build",
     "pack:android": "npm run build:android && npx cap copy android",
     "pack:ios": "npm run build:ios && npx cap copy ios",
+    "sync-version": "node scripts/sync-native-version.js",
     "preview": "vite preview",
     "translate": "transmart",
     "lint": "eslint src --fix",

--- a/scripts/sync-native-version.js
+++ b/scripts/sync-native-version.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+/**
+ * Sync version from package.json → Android build.gradle + iOS project.
+ *
+ * Usage:  node scripts/sync-native-version.js
+ *
+ * Version code formula: major*10000 + minor*100 + patch
+ * e.g. 3.29.5 → 32905
+ */
+
+const fs = require('fs')
+const path = require('path')
+
+const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'))
+const version = pkg.version
+const [major, minor, patch] = version.split('.').map(Number)
+const code = major * 10000 + minor * 100 + patch
+
+console.log(`Syncing version: ${version} (code: ${code})`)
+
+// --- Android ---
+const gradlePath = path.join(__dirname, '..', 'android', 'app', 'build.gradle')
+let gradle = fs.readFileSync(gradlePath, 'utf8')
+gradle = gradle.replace(/versionCode \d+/, `versionCode ${code}`)
+gradle = gradle.replace(/versionName "[^"]*"/, `versionName "${version}"`)
+fs.writeFileSync(gradlePath, gradle)
+console.log(`  ✓ android/app/build.gradle → ${version} (${code})`)
+
+// --- iOS (update via sed-like replacement in project.pbxproj) ---
+const pbxPath = path.join(__dirname, '..', 'ios', 'App', 'App.xcodeproj', 'project.pbxproj')
+if (fs.existsSync(pbxPath)) {
+  let pbx = fs.readFileSync(pbxPath, 'utf8')
+  pbx = pbx.replace(/MARKETING_VERSION = [^;]+;/g, `MARKETING_VERSION = ${version};`)
+  pbx = pbx.replace(/CURRENT_PROJECT_VERSION = [^;]+;/g, `CURRENT_PROJECT_VERSION = ${code};`)
+  fs.writeFileSync(pbxPath, pbx)
+  console.log(`  ✓ ios project.pbxproj → ${version} (${code})`)
+}
+
+console.log('Done.')


### PR DESCRIPTION
## Changes

- **Android workflow** (`build-android.yaml`): Builds AAB + APK, uploads to Google Play Store via service account
  - Triggered by `android-v*` tags or manual dispatch (choose track: internal/alpha/beta/production)
  - Auto-syncs version from package.json
  - Signing via base64-encoded keystore in secrets

- **iOS workflow** (`build-ios.yaml`): Builds IPA, uploads to TestFlight
  - Triggered by `ios-v*` tags or manual dispatch
  - Uses manual code signing with P12 + provisioning profile
  - Uploads via App Store Connect API key

- **Android permissions**: Added `READ_MEDIA_IMAGES`, `READ_MEDIA_VIDEO`, `READ_EXTERNAL_STORAGE` (<=32), `WRITE_EXTERNAL_STORAGE` (<=29)
- **ProGuard**: Enabled minification + shrinkResources for release builds, added Capacitor-specific keep rules
- **Version sync**: `scripts/sync-native-version.js` syncs package.json version to Android build.gradle + iOS project.pbxproj
- **Security**: Uncommented keystore gitignore entries
- **iOS version**: Synced to 3.29.5 (32905)
