### PR TITLE
style: apply prettier formatting to Vue components

### DIFF
--- a/change/@acedatacloud-nexior-prettier-formatting.json
+++ b/change/@acedatacloud-nexior-prettier-formatting.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "style: apply prettier formatting to Vue components",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/SuggestionItem.vue
+++ b/src/components/chat/SuggestionItem.vue
@@ -54,7 +54,9 @@ export default defineComponent({
   border-radius: 20px;
   margin-bottom: 15px;
   cursor: pointer;
-  transition: box-shadow 0.2s ease, background-color 0.2s ease;
+  transition:
+    box-shadow 0.2s ease,
+    background-color 0.2s ease;
   &:hover {
     background-color: var(--el-bg-color-page);
     box-shadow: var(--app-shadow-md);

--- a/src/components/kling/config/RatioSelector.vue
+++ b/src/components/kling/config/RatioSelector.vue
@@ -96,7 +96,9 @@ export default defineComponent({
     align-items: center;
     cursor: pointer;
     border-radius: 10px;
-    transition: background-color 0.2s ease, border-color 0.2s ease;
+    transition:
+      background-color 0.2s ease,
+      border-color 0.2s ease;
 
     .preview {
       margin-top: 8px;

--- a/src/components/midjourney/config/RatioSelector.vue
+++ b/src/components/midjourney/config/RatioSelector.vue
@@ -107,7 +107,9 @@ export default defineComponent({
     align-items: center;
     cursor: pointer;
     border-radius: var(--el-border-radius-base);
-    transition: background-color 0.2s ease, border-color 0.2s ease;
+    transition:
+      background-color 0.2s ease,
+      border-color 0.2s ease;
 
     .preview {
       margin-top: 5px;

--- a/src/components/pixverse/config/RatioSelector.vue
+++ b/src/components/pixverse/config/RatioSelector.vue
@@ -107,7 +107,9 @@ export default defineComponent({
     align-items: center;
     cursor: pointer;
     border-radius: var(--el-border-radius-base);
-    transition: background-color 0.2s ease, border-color 0.2s ease;
+    transition:
+      background-color 0.2s ease,
+      border-color 0.2s ease;
 
     .preview {
       margin-top: 5px;

--- a/src/components/sora/config/OrientationSelector.vue
+++ b/src/components/sora/config/OrientationSelector.vue
@@ -91,7 +91,9 @@ export default defineComponent({
     align-items: center;
     cursor: pointer;
     border-radius: var(--el-border-radius-base);
-    transition: background-color 0.2s ease, border-color 0.2s ease;
+    transition:
+      background-color 0.2s ease,
+      border-color 0.2s ease;
 
     .preview {
       margin-top: 5px;

--- a/src/components/suno/config/AdvancedParams.vue
+++ b/src/components/suno/config/AdvancedParams.vue
@@ -6,11 +6,7 @@
         <div class="flex items-center mb-1">
           <span class="text-xs font-bold">{{ $t('suno.name.styleNegative') }}</span>
         </div>
-        <el-input
-          v-model="styleNegative"
-          size="small"
-          :placeholder="$t('suno.placeholder.styleNegative')"
-        />
+        <el-input v-model="styleNegative" size="small" :placeholder="$t('suno.placeholder.styleNegative')" />
       </div>
 
       <!-- Lyric Prompt (auto-generate lyrics) -->
@@ -18,11 +14,7 @@
         <div class="flex items-center mb-1">
           <span class="text-xs font-bold">{{ $t('suno.name.lyricPrompt') }}</span>
         </div>
-        <el-input
-          v-model="lyricPrompt"
-          size="small"
-          :placeholder="$t('suno.placeholder.lyricPrompt')"
-        />
+        <el-input v-model="lyricPrompt" size="small" :placeholder="$t('suno.placeholder.lyricPrompt')" />
       </div>
 
       <!-- Weirdness -->

--- a/src/components/veo/config/AspectRatioSelector.vue
+++ b/src/components/veo/config/AspectRatioSelector.vue
@@ -107,7 +107,9 @@ export default defineComponent({
     align-items: center;
     cursor: pointer;
     border-radius: var(--el-border-radius-base);
-    transition: background-color 0.2s ease, border-color 0.2s ease;
+    transition:
+      background-color 0.2s ease,
+      border-color 0.2s ease;
 
     .preview {
       margin-top: 5px;


### PR DESCRIPTION
Apply Prettier formatting fixes to 7 Vue components:

- CSS `transition` multi-value properties formatted to multi-line (6 files)
- `el-input` template attributes collapsed to single line (AdvancedParams.vue)

No functional changes.