### PR TITLE
feat: add SKALE Base network option in X402 payment

### DIFF
--- a/src/components/order/X402Pay.vue
+++ b/src/components/order/X402Pay.vue
@@ -331,7 +331,8 @@ export default defineComponent({
         arbitrum: '0xA4B1',
         optimism: '0xA',
         bsc: '0x38',
-        avalanche: '0xA86A'
+        avalanche: '0xA86A',
+        skale: '0x46CEA59D'
       };
       const key = (this.expectedNetwork || '').toLowerCase();
       return mapping[key];
@@ -506,6 +507,7 @@ export default defineComponent({
       if (lower === 'base') return 'Base';
       if (lower === 'solana') return 'Solana';
       if (lower === 'solana-devnet') return 'Solana Devnet';
+      if (lower === 'skale') return 'SKALE';
       if (lower === 'ethereum') return 'Ethereum';
       if (lower === 'sepolia') return 'Sepolia';
       if (lower === 'polygon') return 'Polygon';
@@ -747,6 +749,13 @@ export default defineComponent({
           nativeCurrency: { name: 'ETH', symbol: 'ETH', decimals: 18 },
           rpcUrls: ['https://sepolia.base.org'],
           blockExplorerUrls: ['https://sepolia.basescan.org']
+        },
+        skale: {
+          chainId: '0x46CEA59D',
+          chainName: 'SKALE Base',
+          nativeCurrency: { name: 'CREDIT', symbol: 'CREDIT', decimals: 18 },
+          rpcUrls: ['https://skale-base.skalenodes.com/v1/base'],
+          blockExplorerUrls: ['https://skale-base-explorer.skalenodes.com']
         }
       };
       const key = (this.expectedNetwork || '').toLowerCase();


### PR DESCRIPTION
Add SKALE Base (zero gas fees) as a payment network option in the X402Pay component.

## Changes in `src/components/order/X402Pay.vue`
- Add SKALE chain ID hex mapping (`0x46CEA59D` = Chain ID 1187947933)
- Add 'SKALE' label in `formatNetworkLabel()`
- Add SKALE chain params for `wallet_addEthereumChain` in `getExpectedChainParams()`

Mirrors PlatformFrontend#72. Requires: AceDataCloud/PlatformBackend#196, AceDataCloud/FacilitatorX402#17