### PR TITLE
feat: add Midjourney V8 Alpha support with HD toggle and billing fields

### DIFF
--- a/src/components/midjourney/ConfigPanel.vue
+++ b/src/components/midjourney/ConfigPanel.vue
@@ -10,13 +10,14 @@
             <ratio-selector class="mb-4" />
             <quality-selector class="mb-4" />
             <version-selector class="mb-4" />
+            <hd-selector v-if="isV8" class="mb-4" />
             <elements-selector class="mb-2" />
             <advanced-selector class="mb-2" />
             <div v-show="config?.advanced">
               <stylize-selector class="mb-2" />
               <weird-selector class="mb-2" />
               <chaos-selector class="mb-2" />
-              <image-weight-selector class="mb-2" />
+              <image-weight-selector v-if="!isV8" class="mb-2" />
               <style-selector class="mb-2" />
             </div>
           </div>
@@ -59,6 +60,7 @@ import RatioSelector from './config/RatioSelector.vue';
 import AdvancedSelector from './config/AdvancedSelector.vue';
 import LoopSelector from './config/LoopSelector.vue';
 import VersionSelector from './config/VersionSelector.vue';
+import HdSelector from './config/HdSelector.vue';
 import ImageUrlInput from './config/ImageUrlInput.vue';
 import EndImageUrlInput from './config/EndImageUrlInput.vue';
 import ImageUrlInput2 from './config/ImageUrlInput2.vue';
@@ -92,6 +94,7 @@ export default defineComponent({
     QualitySelector,
     RatioSelector,
     VersionSelector,
+    HdSelector,
     StylizeSelector,
     AdvancedSelector,
     ChaosSelector,
@@ -112,6 +115,9 @@ export default defineComponent({
   computed: {
     config() {
       return this.$store.state.midjourney.config;
+    },
+    isV8(): boolean {
+      return this.config?.version === '8';
     },
     type: {
       get() {

--- a/src/components/midjourney/config/HdSelector.vue
+++ b/src/components/midjourney/config/HdSelector.vue
@@ -1,0 +1,55 @@
+<template>
+  <div class="field">
+    <span class="text-sm font-bold">
+      {{ $t('midjourney.name.hd') }}
+      <el-tooltip :content="$t('midjourney.description.hd')" placement="top">
+        <font-awesome-icon icon="fa-solid fa-circle-info" class="info-icon" />
+      </el-tooltip>
+    </span>
+    <el-switch v-model="value" />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElSwitch, ElTooltip } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+
+export default defineComponent({
+  name: 'HdSelector',
+  components: {
+    ElSwitch,
+    ElTooltip,
+    FontAwesomeIcon
+  },
+  computed: {
+    value: {
+      get() {
+        return this.$store.state.midjourney.config.hd || false;
+      },
+      set(val: boolean) {
+        this.$store.commit('midjourney/setConfig', {
+          ...this.$store.state.midjourney.config,
+          hd: val
+        });
+      }
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.field {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+
+  .info-icon {
+    margin-left: 4px;
+    font-size: 12px;
+    color: var(--el-text-color-secondary);
+    cursor: pointer;
+  }
+}
+</style>

--- a/src/components/midjourney/config/QualitySelector.vue
+++ b/src/components/midjourney/config/QualitySelector.vue
@@ -20,25 +20,26 @@ export default defineComponent({
     ElRadioButton,
     ElRadioGroup
   },
-  data() {
-    return {
-      options: [
-        {
-          label: this.$t('midjourney.button.low'),
-          value: '.25'
-        },
-        {
-          label: this.$t('midjourney.button.medium'),
-          value: '.5'
-        },
-        {
-          label: this.$t('midjourney.button.high'),
-          value: '1'
-        }
-      ]
-    };
-  },
   computed: {
+    version(): string {
+      return this.$store.state.midjourney.config.version || '';
+    },
+    isV8(): boolean {
+      return this.version === '8';
+    },
+    options() {
+      if (this.isV8) {
+        return [
+          { label: this.$t('midjourney.button.standard'), value: '1' },
+          { label: this.$t('midjourney.button.ultra'), value: '4' }
+        ];
+      }
+      return [
+        { label: this.$t('midjourney.button.low'), value: '.25' },
+        { label: this.$t('midjourney.button.medium'), value: '.5' },
+        { label: this.$t('midjourney.button.high'), value: '1' }
+      ];
+    },
     value: {
       get() {
         return this.$store.state.midjourney.config.quality;
@@ -48,6 +49,15 @@ export default defineComponent({
           ...this.$store.state.midjourney.config,
           quality: val
         });
+      }
+    }
+  },
+  watch: {
+    isV8(newVal) {
+      if (newVal && this.value !== '1' && this.value !== '4') {
+        this.value = MIDJOURNEY_DEFAULT_QUALITY;
+      } else if (!newVal && this.value === '4') {
+        this.value = MIDJOURNEY_DEFAULT_QUALITY;
       }
     }
   },

--- a/src/components/midjourney/config/VersionSelector.vue
+++ b/src/components/midjourney/config/VersionSelector.vue
@@ -30,6 +30,10 @@ export default defineComponent({
     return {
       options: [
         {
+          value: '8',
+          label: '8 (Alpha)'
+        },
+        {
           value: '7',
           label: '7'
         },

--- a/src/i18n/en/midjourney.json
+++ b/src/i18n/en/midjourney.json
@@ -2046,5 +2046,21 @@
   "status.describeComplete": {
     "message": "Image description complete",
     "description": "A status of the task - not yet started"
+  },
+  "name.hd": {
+    "message": "HD",
+    "description": "HD image parameter name, V8 supports 2K resolution image generation"
+  },
+  "description.hd": {
+    "message": "Enable HD mode for 2K resolution images (V8 only). Costs 4x credits.",
+    "description": "HD parameter description"
+  },
+  "button.standard": {
+    "message": "Standard",
+    "description": "Standard quality button label"
+  },
+  "button.ultra": {
+    "message": "Ultra",
+    "description": "Ultra quality button label (V8 --q 4), costs 4x credits"
   }
 }

--- a/src/i18n/zh-CN/midjourney.json
+++ b/src/i18n/zh-CN/midjourney.json
@@ -2046,5 +2046,21 @@
   "status.describeComplete": {
     "message": "获取该图片描述完成",
     "description": "任务的某种状态 - 尚未开始"
+  },
+  "name.hd": {
+    "message": "HD 高清",
+    "description": "HD高清图像参数的名称，V8版本支持生成2K分辨率图像"
+  },
+  "description.hd": {
+    "message": "启用 HD 高清模式，生成 2K 分辨率图像（仅 V8），消耗 4 倍积分",
+    "description": "HD高清参数的描述信息"
+  },
+  "button.standard": {
+    "message": "标准",
+    "description": "标准画质按钮标签"
+  },
+  "button.ultra": {
+    "message": "超高",
+    "description": "超高画质按钮标签（V8版本 --q 4），消耗4倍积分"
   }
 }

--- a/src/models/midjourney.ts
+++ b/src/models/midjourney.ts
@@ -24,6 +24,9 @@ export interface IMidjourneyConfig {
   translation?: boolean;
   elements?: any[];
   type?: 'imagine' | 'videos' | 'describe';
+  hd?: boolean;
+  style_reference?: boolean;
+  moodboard?: boolean;
 }
 
 export enum MidjourneyImagineAction {
@@ -75,6 +78,11 @@ export interface IMidjourneyImagineRequest {
   translation?: boolean;
   callback_url?: string;
   application_id?: string;
+  version?: string;
+  hd?: boolean;
+  quality?: string;
+  style_reference?: boolean;
+  moodboard?: boolean;
 }
 
 export interface IMidjourneyVideosRequest {

--- a/src/pages/midjourney/Index.vue
+++ b/src/pages/midjourney/Index.vue
@@ -146,6 +146,10 @@ export default defineComponent({
       if (this.config?.style && this.config?.advanced && !content.includes(`--style`)) {
         content += ` --style ${this.config?.style}`;
       }
+      // V8 --hd parameter
+      if (this.config?.hd && !content.includes(`--hd`)) {
+        content += ` --hd`;
+      }
       // remove `--fast`, `--relax`, `--turbo`
       content = content.replace(/--(fast|relax|turbo) /g, '');
       return this.config.prompt || (this.config.references && this.config.references?.length > 0) ? content : '';
@@ -310,7 +314,10 @@ export default defineComponent({
         image_id: payload.image_id,
         action: payload.action,
         mode: this.config?.mode || MIDJOURNEY_DEFAULT_MODE,
-        callback_url: CALLBACK_URL
+        callback_url: CALLBACK_URL,
+        version: this.config?.version,
+        hd: this.config?.hd || false,
+        quality: this.config?.quality || MIDJOURNEY_DEFAULT_QUALITY
       };
       this.onStartImagineTask(request);
     },
@@ -330,12 +337,20 @@ export default defineComponent({
         };
         await this.onStartVideosTask(request);
       } else if (this.config?.type === 'imagine') {
+        const isV8 = this.config?.version === '8';
+        const hasSref = !!(this.finalPrompt && this.finalPrompt.includes('--sref'));
+        const hasMoodboard = !!(isV8 && this.config?.references && this.config.references.length > 0);
         const request = {
           mode: this.config?.mode || MIDJOURNEY_DEFAULT_MODE,
           prompt: this.finalPrompt,
           action: MidjourneyImagineAction.GENERATE,
           translation: this.config?.translation,
-          callback_url: CALLBACK_URL
+          callback_url: CALLBACK_URL,
+          version: this.config?.version,
+          hd: this.config?.hd || false,
+          quality: this.config?.quality || MIDJOURNEY_DEFAULT_QUALITY,
+          style_reference: hasSref,
+          moodboard: hasMoodboard
         };
         await this.onStartImagineTask(request);
       } else if (this.config?.type === 'describe') {


### PR DESCRIPTION
Add Midjourney V8 Alpha support to Nexior frontend. Includes V8 in version selector, HD toggle, Ultra quality option (--q 4), and sends billing metadata fields (version, hd, quality, style_reference, moodboard) in API requests. Auto-detects --sref in prompt and moodboard from image references. Requires AceDataCloud/PlatformBackend#203 for backend billing rules. Run yarn translate after merge to sync i18n to all 17 locales.