### PR TITLE
feat: add .well-known/llms.txt alias and fix robots.txt llms.txt reference

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -46,6 +46,12 @@ server {
         access_log off;
     }
 
+    # Serve /.well-known/llms.txt as alias to /llms.txt (llmstxt.org spec)
+    location = /.well-known/llms.txt {
+        root /usr/share/nginx/html;
+        try_files /llms.txt =404;
+    }
+
     location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -40,7 +40,4 @@ Disallow: /deepseek/conversations/
 Disallow: /assets/
 
 Sitemap: https://hub.acedata.cloud/sitemap.xml
-
-# LLMs.txt for AI search engines
-# See https://llmstxt.org/
-# https://hub.acedata.cloud/llms.txt
+Sitemap: https://hub.acedata.cloud/llms.txt


### PR DESCRIPTION
## Summary

Add `/.well-known/llms.txt` alias and fix `robots.txt` llms.txt reference to be machine-readable.

## Changes

1. **`nginx.conf`**: Add `location = /.well-known/llms.txt` that serves the same static `llms.txt` file from `public/`. The [llmstxt.org](https://llmstxt.org/) spec recommends serving at both `/llms.txt` and `/.well-known/llms.txt`.

2. **`public/robots.txt`**: Change the llms.txt reference from a comment to a proper `Sitemap:` directive for machine-readability.

### Before (robots.txt)
```
Sitemap: https://hub.acedata.cloud/sitemap.xml

# LLMs.txt for AI search engines
# See https://llmstxt.org/
# https://hub.acedata.cloud/llms.txt
```

### After (robots.txt)
```
Sitemap: https://hub.acedata.cloud/sitemap.xml
Sitemap: https://hub.acedata.cloud/llms.txt
```

## Related

- PlatformBackend: AceDataCloud/PlatformBackend#251
- PlatformFrontend: AceDataCloud/PlatformFrontend#150
