### PR TITLE
fix: add missing i18n keys for download page buttons

### DIFF
--- a/change/@acedatacloud-nexior-c0543c01-d743-4d56-9d8c-9d112da298e2.json
+++ b/change/@acedatacloud-nexior-c0543c01-d743-4d56-9d8c-9d112da298e2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: add missing English i18n keys for download page buttons",
+  "packageName": "@acedatacloud/nexior",
+  "email": "cqc@cuiqingcai.com",
+  "dependentChangeType": "patch"
+}

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -103,6 +103,18 @@
     "message": "Start for Free",
     "description": "Text in button for allowing users to start for free"
   },
+  "button.downloadAndroid": {
+    "message": "Download Android",
+    "description": "Text in button for downloading the Android APK"
+  },
+  "button.downloadIos": {
+    "message": "Download iOS",
+    "description": "Text in button for downloading the iOS package file"
+  },
+  "button.installIos": {
+    "message": "Install iOS",
+    "description": "Text in button for installing the iOS app"
+  },
   "button.apply": {
     "message": "Apply",
     "description": "Text in button for allowing users to apply for API services"

--- a/src/pages/download/Index.vue
+++ b/src/pages/download/Index.vue
@@ -157,11 +157,6 @@ export default defineComponent({
     ElButton,
     QrCode
   },
-  methods: {
-    openSupport() {
-      window.open('https://platform.acedata.cloud/support', '_blank');
-    }
-  },
   computed: {
     version() {
       return MOBILE_APP_VERSION;
@@ -180,6 +175,11 @@ export default defineComponent({
     },
     hasIosDownload() {
       return !!MOBILE_IOS_DOWNLOAD_URL && !!MOBILE_IOS_FALLBACK_URL;
+    }
+  },
+  methods: {
+    openSupport() {
+      window.open('https://platform.acedata.cloud/support', '_blank');
     }
   }
 });
@@ -236,7 +236,12 @@ export default defineComponent({
 .hero-copy {
   padding: 48px;
   border-radius: 36px;
-  background: linear-gradient(135deg, rgba(7, 17, 31, 0.98) 0%, rgba(12, 39, 67, 0.96) 56%, rgba(16, 92, 153, 0.92) 100%);
+  background: linear-gradient(
+    135deg,
+    rgba(7, 17, 31, 0.98) 0%,
+    rgba(12, 39, 67, 0.96) 56%,
+    rgba(16, 92, 153, 0.92) 100%
+  );
   color: #f8fbff;
   box-shadow: 0 30px 80px rgba(7, 23, 43, 0.24);
 


### PR DESCRIPTION
## Problem

The mobile download page (`/download`) displays raw i18n key names instead of translated text:
- `common.button.downloadAndroid`
- `common.button.downloadIos`

## Root Cause

The English locale file (`src/i18n/en/common.json`) was missing three button translation keys that existed in `zh-CN`:
- `button.downloadAndroid`
- `button.downloadIos`
- `button.installIos`

Since `en` is the fallback locale, missing keys there cause raw key names to display for all languages.

## Fix

Added the three missing keys to `src/i18n/en/common.json` with appropriate English translations:
- **Download Android** – for the Android APK download button
- **Download iOS** – for the iOS package download button
- **Install iOS** – for the iOS install button