### PR TITLE
fix: add text overflow ellipsis to suno song list

### DIFF
--- a/change/@acedatacloud-nexior-suno-overflow.json
+++ b/change/@acedatacloud-nexior-suno-overflow.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: add text overflow ellipsis to suno song title and style",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/suno/task/Preview.vue
+++ b/src/components/suno/task/Preview.vue
@@ -512,15 +512,23 @@ export default defineComponent({
     }
     .info {
       flex: 1;
+      min-width: 0;
+      overflow: hidden;
       .title {
         font-size: 14px;
         font-weight: bold;
         margin-top: 5px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
       .style {
         font-size: 12px;
         margin-bottom: 0;
         color: var(--el-text-color-secondary);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
     }
     .right {


### PR DESCRIPTION
## Summary
- Add `text-overflow: ellipsis` with `overflow: hidden` and `white-space: nowrap` to `.title` and `.style` in the Suno task preview component
- Add `min-width: 0` and `overflow: hidden` on `.info` container so flex children can properly truncate
- Fixes long song titles/descriptions overflowing horizontally and breaking the layout

## Test plan
- [ ] Open hub.acedata.cloud/suno
- [ ] Generate or view a song with a very long title/style text
- [ ] Verify text truncates with ellipsis instead of overflowing

🤖 Generated with [Claude Code](https://claude.com/claude-code)