### PR TITLE
fix: logo collapsed state and dark-mode borders

### DIFF
--- a/change/logo-dark-borders.json
+++ b/change/logo-dark-borders.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: show correct logo on collapsed/expanded sidebar and add dark-mode borders",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/assets/scss/_common.scss
+++ b/src/assets/scss/_common.scss
@@ -354,3 +354,66 @@ h1, h2, h3, h4, h5, h6 {
   letter-spacing: -0.02em;
   font-weight: 700;
 }
+
+/* Dark mode: subtle borders for form elements & cards */
+html.dark {
+  .el-input .el-input__wrapper {
+    border: 1px solid var(--app-glass-border);
+    &.is-focus {
+      border-color: var(--el-color-primary);
+    }
+  }
+
+  .el-select .el-select__wrapper {
+    border: 1px solid var(--app-glass-border);
+    &.is-focused {
+      border-color: var(--el-color-primary);
+    }
+  }
+
+  .el-textarea .el-textarea__inner {
+    border: 1px solid var(--app-glass-border);
+    &:focus {
+      border-color: var(--el-color-primary);
+    }
+  }
+
+  .el-input-number {
+    .el-input__wrapper {
+      border: 1px solid var(--app-glass-border);
+    }
+  }
+
+  .el-radio-button__inner,
+  .el-checkbox-button__inner {
+    border-color: var(--app-glass-border);
+  }
+
+  .el-switch {
+    border: 1px solid var(--app-glass-border);
+  }
+
+  .el-date-editor {
+    border: 1px solid var(--app-glass-border);
+  }
+
+  .el-tabs--border-card {
+    border-color: var(--app-glass-border);
+  }
+
+  .el-table {
+    --el-table-border-color: var(--app-glass-border);
+  }
+
+  .el-dropdown-menu {
+    border: 1px solid var(--app-glass-border);
+  }
+
+  .el-popover.el-popper {
+    border: 1px solid var(--app-glass-border);
+  }
+
+  .el-message-box {
+    border: 1px solid var(--app-glass-border);
+  }
+}

--- a/src/components/common/Logo.vue
+++ b/src/components/common/Logo.vue
@@ -9,14 +9,21 @@ import { defineComponent } from 'vue';
 
 export default defineComponent({
   emits: ['click'],
+  props: {
+    collapsed: {
+      type: Boolean,
+      default: false
+    }
+  },
   computed: {
     siteTitle() {
       return this.$store.state.site?.title || 'AceData';
     },
     url() {
-      return (
-        this.$store.state.site?.logo || this.$store.state.site?.favicon || 'https://cdn.acedata.cloud/8c6ed0e068.png'
-      );
+      if (this.collapsed) {
+        return this.$store.state.site?.favicon || 'https://cdn.acedata.cloud/8c6ed0e068.png';
+      }
+      return this.$store.state.site?.logo || this.$store.state.site?.favicon || 'https://cdn.acedata.cloud/8c6ed0e068.png';
     }
   }
 });

--- a/src/components/common/Navigator.vue
+++ b/src/components/common/Navigator.vue
@@ -2,7 +2,7 @@
   <div :direction="direction" :class="['navigator', { collapsed: isCollapsed && direction === 'column' }]">
     <div class="top">
       <div class="w-full flex items-center brand">
-        <logo v-if="direction === 'column'" @click.stop="onHome" />
+        <logo v-if="direction === 'column'" :collapsed="isCollapsed" @click.stop="onHome" />
         <button
           v-if="direction === 'column'"
           class="collapse-btn"


### PR DESCRIPTION
## Summary
- **Logo fix**: Shows favicon/CDN icon (`8c6ed0e068.png`) when sidebar is collapsed, and the full site logo when expanded. Added `collapsed` prop to `Logo.vue` and passed `isCollapsed` from `Navigator.vue`.
- **Dark-mode borders**: Added subtle `rgba(255,255,255,0.06)` borders to form elements (`.el-input`, `.el-select`, `.el-textarea`, `.el-date-editor`, `.el-switch`, `.el-tabs`, `.el-table`, `.el-dropdown-menu`, `.el-popover`, `.el-message-box`) in dark mode for a more refined, polished look.

## Test plan
- [ ] Verify logo shows square icon when sidebar is collapsed
- [ ] Verify logo shows full horizontal logo when sidebar is expanded
- [ ] Toggle dark mode and verify inputs, selects, textareas have visible subtle borders
- [ ] Verify focus states still show purple border highlight
- [ ] Test on mobile (row-direction navigator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)