### PR TITLE
fix: change default Veo model to veo31-fast

### DIFF
--- a/change/fix-veo-default-model.json
+++ b/change/fix-veo-default-model.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: change default Veo model from veo2-fast to veo31-fast",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/constants/veo.ts
+++ b/src/constants/veo.ts
@@ -2,7 +2,7 @@ export const VEO_SERVICE_ID = '73cd74ba-a1bd-4a12-8df6-11d64c38df14';
 
 export const VEO_LOGO = 'https://cdn.acedata.cloud/8nxyy9.jpg';
 
-export const VEO_DEFAULT_MODEL = 'veo2-fast';
+export const VEO_DEFAULT_MODEL = 'veo31-fast';
 export const VEO_DEFAULT_ACTION = 'text2video';
 export const VEO_DEFAULT_ASPECT_RATIO = '16:9';
 export const VEO_DEFAULT_TRANSLATION = false;


### PR DESCRIPTION
## Summary
- Change default Veo model from `veo2-fast` to `veo31-fast` in Nexior

## Test plan
- [ ] Verify hub.acedata.cloud/veo loads with veo31-fast selected by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)