### PR TITLE
fix: add text overflow handling to all task preview cards

### DIFF
--- a/change/fix-task-preview-text-overflow.json
+++ b/change/fix-task-preview-text-overflow.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: add text overflow handling to all task preview cards",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/flux/task/Preview.vue
+++ b/src/components/flux/task/Preview.vue
@@ -172,6 +172,7 @@ $left-width: 70px;
   .main {
     flex: 1;
     width: calc(100% - $left-width);
+    min-width: 0;
     padding: 10px 10px 0 10px;
 
     .bot {
@@ -180,6 +181,9 @@ $left-width: 70px;
       color: var(--el-color-primary);
       margin-bottom: 0;
       margin-top: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
       .datetime {
         font-size: 12px;
         font-weight: normal;
@@ -189,11 +193,15 @@ $left-width: 70px;
     }
 
     .info {
+      overflow: hidden;
       .prompt {
         font-size: 16px;
         font-weight: bold;
         color: var(--el-text-color-regular);
         margin-bottom: 15px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
     }
 

--- a/src/components/hailuo/task/Preview.vue
+++ b/src/components/hailuo/task/Preview.vue
@@ -171,6 +171,7 @@ $left-width: 70px;
   .main {
     flex: 1;
     width: calc(100% - $left-width);
+    min-width: 0;
     padding: 10px 10px 0 10px;
 
     .bot {
@@ -179,6 +180,9 @@ $left-width: 70px;
       color: var(--el-color-primary);
       margin-bottom: 0;
       margin-top: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
       .datetime {
         font-size: 12px;
         font-weight: normal;
@@ -188,11 +192,15 @@ $left-width: 70px;
     }
 
     .info {
+      overflow: hidden;
       .prompt {
         font-size: 16px;
         font-weight: bold;
         color: var(--el-text-color-regular);
         margin-bottom: 10px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
     }
 

--- a/src/components/headshots/task/Preview.vue
+++ b/src/components/headshots/task/Preview.vue
@@ -181,6 +181,7 @@ $left-width: 70px;
   .main {
     flex: 1;
     width: calc(100% - $left-width);
+    min-width: 0;
     padding: 10px 10px 0 10px;
 
     .bot {
@@ -189,6 +190,9 @@ $left-width: 70px;
       color: var(--el-color-primary);
       margin-bottom: 0;
       margin-top: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
       .datetime {
         font-size: 12px;
         font-weight: normal;
@@ -198,11 +202,15 @@ $left-width: 70px;
     }
 
     .info {
+      overflow: hidden;
       .prompt {
         font-size: 14px;
         font-weight: bold;
         color: var(--el-text-color-regular);
         margin-bottom: 10px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
     }
 

--- a/src/components/kling/task/Preview.vue
+++ b/src/components/kling/task/Preview.vue
@@ -182,6 +182,7 @@ $left-width: 70px;
   .main {
     flex: 1;
     width: calc(100% - $left-width);
+    min-width: 0;
     padding: 10px 10px 0 10px;
 
     .bot {
@@ -190,6 +191,9 @@ $left-width: 70px;
       color: var(--el-color-primary);
       margin-bottom: 0;
       margin-top: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
       .datetime {
         font-size: 12px;
         font-weight: normal;
@@ -199,11 +203,15 @@ $left-width: 70px;
     }
 
     .info {
+      overflow: hidden;
       .prompt {
         font-size: 16px;
         font-weight: bold;
         color: var(--el-text-color-regular);
         margin-bottom: 10px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
     }
 

--- a/src/components/luma/task/Preview.vue
+++ b/src/components/luma/task/Preview.vue
@@ -189,6 +189,7 @@ $left-width: 70px;
   .main {
     flex: 1;
     width: calc(100% - $left-width);
+    min-width: 0;
     padding: 10px 10px 0 10px;
 
     .bot {
@@ -197,6 +198,9 @@ $left-width: 70px;
       color: var(--el-color-primary);
       margin-bottom: 0;
       margin-top: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
       .datetime {
         font-size: 12px;
         font-weight: normal;
@@ -206,11 +210,15 @@ $left-width: 70px;
     }
 
     .info {
+      overflow: hidden;
       .prompt {
         font-size: 14px;
         font-weight: bold;
         color: var(--el-text-color-regular);
         margin-bottom: 10px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
     }
 

--- a/src/components/midjourney/tasks/TaskItem.vue
+++ b/src/components/midjourney/tasks/TaskItem.vue
@@ -484,6 +484,7 @@ $left-width: 70px;
   .preview {
     flex: 1;
     width: calc(100% - $left-width);
+    min-width: 0;
     padding: 10px 10px 0 10px;
     display: flex;
     flex-direction: column;
@@ -494,6 +495,9 @@ $left-width: 70px;
       color: var(--el-color-primary);
       margin-bottom: 10px;
       margin-top: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
       .datetime {
         font-size: 12px;
         font-weight: normal;
@@ -513,12 +517,16 @@ $left-width: 70px;
       display: flex;
       flex-direction: row;
       width: 100%;
+      overflow: hidden;
 
       .prompt {
         font-size: 14px;
         font-weight: bold;
         color: var(--el-text-color-regular);
         margin-bottom: 10px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
 
       .mode {

--- a/src/components/nanobanana/task/Preview.vue
+++ b/src/components/nanobanana/task/Preview.vue
@@ -244,6 +244,7 @@ $left-width: 70px;
   .main {
     flex: 1;
     width: calc(100% - $left-width);
+    min-width: 0;
     padding: 10px 10px 0 10px;
 
     .bot {
@@ -252,6 +253,9 @@ $left-width: 70px;
       color: var(--el-color-primary);
       margin-bottom: 0;
       margin-top: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
       .datetime {
         font-size: 12px;
         font-weight: normal;
@@ -261,11 +265,15 @@ $left-width: 70px;
     }
 
     .info {
+      overflow: hidden;
       .prompt {
         font-size: 16px;
         font-weight: bold;
         color: var(--el-text-color-regular);
         margin-bottom: 15px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
     }
 

--- a/src/components/pika/task/Preview.vue
+++ b/src/components/pika/task/Preview.vue
@@ -220,6 +220,7 @@ $left-width: 70px;
   .main {
     flex: 1;
     width: calc(100% - $left-width);
+    min-width: 0;
     padding: 10px 10px 0 10px;
 
     .bot {
@@ -228,6 +229,9 @@ $left-width: 70px;
       color: var(--el-color-primary);
       margin-bottom: 0;
       margin-top: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
       .datetime {
         font-size: 12px;
         font-weight: normal;
@@ -237,11 +241,15 @@ $left-width: 70px;
     }
 
     .info {
+      overflow: hidden;
       .prompt {
         font-size: 14px;
         font-weight: bold;
         color: var(--el-text-color-regular);
         margin-bottom: 10px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
     }
 

--- a/src/components/pixverse/task/Preview.vue
+++ b/src/components/pixverse/task/Preview.vue
@@ -168,6 +168,7 @@ $left-width: 70px;
   .main {
     flex: 1;
     width: calc(100% - $left-width);
+    min-width: 0;
     padding: 10px 10px 0 10px;
 
     .bot {
@@ -176,6 +177,9 @@ $left-width: 70px;
       color: var(--el-color-primary);
       margin-bottom: 0;
       margin-top: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
       .datetime {
         font-size: 12px;
         font-weight: normal;
@@ -185,11 +189,15 @@ $left-width: 70px;
     }
 
     .info {
+      overflow: hidden;
       .prompt {
         font-size: 16px;
         font-weight: bold;
         color: var(--el-text-color-regular);
         margin-bottom: 10px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
     }
 

--- a/src/components/qrart/task/Preview.vue
+++ b/src/components/qrart/task/Preview.vue
@@ -6,8 +6,8 @@
         class="avatar bg-[var(--el-bg-color)] p-[2px] w-[50px] h-[50px] m-[10px] rounded-full"
       />
     </div>
-    <div class="main flex-1 w-[calc(100%-70px)] pt-[10px] pr-[10px] pb-0 pl-[10px]">
-      <div class="bot text-[16px] font-bold text-[var(--el-color-primary)]">
+    <div class="main flex-1 w-[calc(100%-70px)] min-w-0 pt-[10px] pr-[10px] pb-0 pl-[10px]">
+      <div class="bot text-[16px] font-bold text-[var(--el-color-primary)] overflow-hidden text-ellipsis whitespace-nowrap">
         {{ $t('qrart.name.qrartBot') }}
         <span class="datetime text-[12px] font-normal text-[var(--el-text-color-secondary)] ml-[10px]">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
@@ -16,7 +16,7 @@
       <div class="info">
         <p
           v-if="modelValue?.request?.prompt"
-          class="prompt mt-2 text-[14px] font-bold text-[var(--el-text-color-regular)] mb-[10px]"
+          class="prompt mt-2 text-[14px] font-bold text-[var(--el-text-color-regular)] mb-[10px] overflow-hidden text-ellipsis whitespace-nowrap"
         >
           {{ modelValue?.request?.prompt }}
           <span v-if="!modelValue?.response"> - ({{ $t('qrart.status.pending') }}) </span>
@@ -203,6 +203,7 @@ $left-width: 70px;
   .main {
     flex: 1;
     width: calc(100% - $left-width);
+    min-width: 0;
     padding: 10px 10px 0 10px;
 
     .bot {
@@ -211,6 +212,9 @@ $left-width: 70px;
       color: rgb(46, 204, 113);
       margin-bottom: 0;
       margin-top: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
       .datetime {
         font-size: 12px;
         font-weight: normal;
@@ -220,11 +224,15 @@ $left-width: 70px;
     }
 
     .info {
+      overflow: hidden;
       .prompt {
         font-size: 14px;
         font-weight: bold;
         color: var(--el-text-color-regular);
         margin-bottom: 10px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
     }
 

--- a/src/components/seedance/task/Preview.vue
+++ b/src/components/seedance/task/Preview.vue
@@ -207,6 +207,7 @@ $left-width: 70px;
   .main {
     flex: 1;
     width: calc(100% - $left-width);
+    min-width: 0;
     padding: 10px 10px 0 10px;
 
     .bot {
@@ -215,6 +216,9 @@ $left-width: 70px;
       color: var(--el-color-primary);
       margin-bottom: 0;
       margin-top: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
       .datetime {
         font-size: 12px;
         font-weight: normal;
@@ -224,11 +228,15 @@ $left-width: 70px;
     }
 
     .info {
+      overflow: hidden;
       .prompt {
         font-size: 14px;
         font-weight: bold;
         color: var(--el-text-color-regular);
         margin-bottom: 10px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
     }
 

--- a/src/components/seedream/task/Preview.vue
+++ b/src/components/seedream/task/Preview.vue
@@ -233,6 +233,7 @@ $left-width: 70px;
   .main {
     flex: 1;
     width: calc(100% - $left-width);
+    min-width: 0;
     padding: 10px 10px 0 10px;
 
     .bot {
@@ -241,6 +242,9 @@ $left-width: 70px;
       color: var(--el-color-primary);
       margin-bottom: 0;
       margin-top: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
       .datetime {
         font-size: 12px;
         font-weight: normal;
@@ -250,11 +254,15 @@ $left-width: 70px;
     }
 
     .info {
+      overflow: hidden;
       .prompt {
         font-size: 16px;
         font-weight: bold;
         color: var(--el-text-color-regular);
         margin-bottom: 15px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
     }
 

--- a/src/components/sora/task/Preview.vue
+++ b/src/components/sora/task/Preview.vue
@@ -178,6 +178,7 @@ $left-width: 70px;
   .main {
     flex: 1;
     width: calc(100% - $left-width);
+    min-width: 0;
     padding: 10px 10px 0 10px;
 
     .bot {
@@ -186,6 +187,9 @@ $left-width: 70px;
       color: var(--el-color-primary);
       margin-bottom: 0;
       margin-top: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
       .datetime {
         font-size: 12px;
         font-weight: normal;
@@ -195,11 +199,15 @@ $left-width: 70px;
     }
 
     .info {
+      overflow: hidden;
       .prompt {
         font-size: 16px;
         font-weight: bold;
         color: var(--el-text-color-regular);
         margin-bottom: 10px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
     }
 

--- a/src/components/veo/task/Preview.vue
+++ b/src/components/veo/task/Preview.vue
@@ -202,6 +202,7 @@ $left-width: 70px;
   .main {
     flex: 1;
     width: calc(100% - $left-width);
+    min-width: 0;
     padding: 10px 10px 0 10px;
 
     .bot {
@@ -210,6 +211,9 @@ $left-width: 70px;
       color: var(--el-color-primary);
       margin-bottom: 0;
       margin-top: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
       .datetime {
         font-size: 12px;
         font-weight: normal;
@@ -219,11 +223,15 @@ $left-width: 70px;
     }
 
     .info {
+      overflow: hidden;
       .prompt {
         font-size: 16px;
         font-weight: bold;
         color: var(--el-text-color-regular);
         margin-bottom: 10px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
     }
 


### PR DESCRIPTION
## Summary
- Add `overflow: hidden`, `text-overflow: ellipsis`, `white-space: nowrap` to `.prompt` and `.bot` elements across all 14 task Preview components
- Add `min-width: 0` on `.main` flex children to enable proper text truncation in flex layouts
- Add `overflow: hidden` on `.info` containers to constrain child overflow
- Fix qrart's inline Tailwind classes with matching overflow utilities

**Affected components:** sora, luma, flux, kling, pixverse, veo, hailuo, headshots, pika, qrart, nanobanana, seedream, seedance, midjourney

## Test plan
- [ ] Verify task cards with long prompts show ellipsis instead of overflowing
- [ ] Verify bot name + datetime row truncates properly in narrow panels
- [ ] Check all 14 AI service pages for consistent text truncation behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)