### PR TITLE
fix: replace broken DeepSeek avatar icon

### DIFF
--- a/change/fix-deepseek-avatar-icon.json
+++ b/change/fix-deepseek-avatar-icon.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: replace broken DeepSeek avatar icon with original clean logo",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -33,7 +33,7 @@ export const CHAT_MODEL_NAME_CLAUDE_3_7_SONNET = 'claude-3-7-sonnet';
 
 export const CHAT_MODEL_ICON_CHATGPT = 'https://cdn.acedata.cloud/7dljuv.png';
 export const CHAT_MODEL_ICON_GROK = 'https://cdn.acedata.cloud/p1ge98.png';
-export const CHAT_MODEL_ICON_DEEPSEEK = 'https://cdn.acedata.cloud/4rb23t.jpg';
+export const CHAT_MODEL_ICON_DEEPSEEK = 'https://cdn.acedata.cloud/bc71ae.png';
 export const CHAT_MODEL_ICON_GEMINI = 'https://cdn.acedata.cloud/psfx0g.jpg';
 export const CHAT_MODEL_ICON_CLAUDE = 'https://cdn.acedata.cloud/8fnw4v.jpg';
 


### PR DESCRIPTION
## Summary
- Replaced the DeepSeek icon URL from `4rb23t.jpg` (an extremely dark image where the whale logo is invisible) to `bc71ae.png` (the original clean blue logo on white background)
- This fixes the broken/missing avatar display in the model selector dropdown and chat messages on the DeepSeek page

## Test plan
- [ ] Visit `/deepseek/conversations` and verify the DeepSeek logo displays correctly in the model selector dropdown
- [ ] Send a message and verify the assistant avatar shows the proper DeepSeek logo
- [ ] Verify other model pages (ChatGPT, Claude, Gemini, Grok) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)