### PR TITLE
fix: standardize selector borders and default to dark theme

### DIFF
--- a/change/fix-border-and-dark-default.json
+++ b/change/fix-border-and-dark-default.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: standardize selector borders and default to dark theme",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/ModelSelector.vue
+++ b/src/components/chat/ModelSelector.vue
@@ -142,6 +142,7 @@ export default defineComponent({
   width: 20px;
   height: 20px;
   border-radius: 50%;
+  border: 1px solid var(--el-border-color);
   object-fit: cover;
   flex-shrink: 0;
 }
@@ -171,6 +172,7 @@ export default defineComponent({
   width: 24px;
   height: 24px;
   border-radius: 50%;
+  border: 1px solid var(--el-border-color);
   object-fit: cover;
   flex-shrink: 0;
 }

--- a/src/components/kling/config/RatioSelector.vue
+++ b/src/components/kling/config/RatioSelector.vue
@@ -89,7 +89,7 @@ export default defineComponent({
   .item {
     width: 48px;
     height: 70px;
-    border: 1px solid transparent;
+    border: 1px solid var(--el-border-color);
     background-color: var(--el-fill-color-lighter);
     display: flex;
     flex-direction: column;

--- a/src/components/midjourney/config/ElementsSelector.vue
+++ b/src/components/midjourney/config/ElementsSelector.vue
@@ -2157,7 +2157,7 @@ export default defineComponent({
     position: relative;
     width: $width;
     height: $height;
-    border: 1px solid transparent;
+    border: 1px solid var(--el-border-color);
     background-color: var(--el-fill-color-lighter);
     border-radius: 10px;
     overflow: hidden;

--- a/src/components/midjourney/config/ModelSelector.vue
+++ b/src/components/midjourney/config/ModelSelector.vue
@@ -85,7 +85,7 @@ export default defineComponent({
   .item {
     width: 130px;
     height: 60px;
-    border: 1px solid transparent;
+    border: 1px solid var(--el-border-color);
     background-color: var(--el-fill-color-lighter);
     display: flex;
     flex-direction: column;

--- a/src/components/midjourney/config/RatioSelector.vue
+++ b/src/components/midjourney/config/RatioSelector.vue
@@ -100,7 +100,7 @@ export default defineComponent({
   .item {
     width: 48px;
     height: 65px;
-    border: 1px solid transparent;
+    border: 1px solid var(--el-border-color);
     background-color: var(--el-fill-color-lighter);
     display: flex;
     flex-direction: column;

--- a/src/components/pixverse/config/RatioSelector.vue
+++ b/src/components/pixverse/config/RatioSelector.vue
@@ -100,7 +100,7 @@ export default defineComponent({
   .item {
     width: 48px;
     height: 65px;
-    border: 1px solid transparent;
+    border: 1px solid var(--el-border-color);
     background-color: var(--el-fill-color-lighter);
     display: flex;
     flex-direction: column;

--- a/src/components/sora/config/OrientationSelector.vue
+++ b/src/components/sora/config/OrientationSelector.vue
@@ -84,7 +84,7 @@ export default defineComponent({
   .item {
     width: 48px;
     height: 65px;
-    border: 1px solid transparent;
+    border: 1px solid var(--el-border-color);
     background-color: var(--el-fill-color-lighter);
     display: flex;
     flex-direction: column;

--- a/src/components/veo/config/AspectRatioSelector.vue
+++ b/src/components/veo/config/AspectRatioSelector.vue
@@ -100,7 +100,7 @@ export default defineComponent({
   .item {
     width: 48px;
     height: 65px;
-    border: 1px solid transparent;
+    border: 1px solid var(--el-border-color);
     background-color: var(--el-fill-color-lighter);
     display: flex;
     flex-direction: column;

--- a/src/utils/initializer.ts
+++ b/src/utils/initializer.ts
@@ -52,9 +52,8 @@ export const initializeCookies = async () => {
       domain: getDomain()
     });
   } else if (!getCookie('THEME')) {
-    const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    console.debug('set THEME to cookies', isDark ? 'dark' : 'light');
-    setCookie('THEME', isDark ? 'dark' : 'light', {
+    console.debug('set THEME to cookies', 'dark');
+    setCookie('THEME', 'dark', {
       path: '/',
       domain: getDomain()
     });


### PR DESCRIPTION
## Summary
- Standardize all custom selector component borders from `transparent` to `var(--el-border-color)` for visible borders in both light and dark mode (Midjourney, Kling, Pixverse, Veo, Sora ratio selectors; Midjourney model/elements selectors)
- Add `border: 1px solid var(--el-border-color)` to chat model avatar icons (`.trigger-icon` and `.item-icon`) for better visibility (e.g. Gemini)
- Default new users to dark mode instead of following system preference when no THEME cookie exists

## Test plan
- [ ] Verify selector borders are visible in dark mode across Midjourney, Flux, Kling, Pixverse, Veo, Sora, QR Art pages
- [ ] Verify chat model avatars (Gemini, etc.) have visible borders
- [ ] Verify new users (no THEME cookie) get dark mode by default
- [ ] Verify existing users' theme preference is not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)