### PR TITLE
feat(nexior): add Kimi chat service

### DIFF
--- a/change/add-kimi-chat-service.json
+++ b/change/add-kimi-chat-service.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add Kimi chat service with K2.5 and K2 Thinking models",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/ModelSelector.vue
+++ b/src/components/chat/ModelSelector.vue
@@ -39,7 +39,8 @@ import {
   CHAT_MODEL_GROUP_DEEPSEEK,
   CHAT_MODEL_GROUP_GROK,
   CHAT_MODEL_GROUP_GEMINI,
-  CHAT_MODEL_GROUP_CLAUDE
+  CHAT_MODEL_GROUP_CLAUDE,
+  CHAT_MODEL_GROUP_KIMI
 } from '@/constants';
 
 interface IData {
@@ -62,7 +63,8 @@ export default defineComponent({
         CHAT_MODEL_GROUP_DEEPSEEK,
         CHAT_MODEL_GROUP_GROK,
         CHAT_MODEL_GROUP_GEMINI,
-        CHAT_MODEL_GROUP_CLAUDE
+        CHAT_MODEL_GROUP_CLAUDE,
+        CHAT_MODEL_GROUP_KIMI
       ]
     };
   },
@@ -91,7 +93,8 @@ export default defineComponent({
       CHAT_MODEL_GROUP_DEEPSEEK,
       CHAT_MODEL_GROUP_GROK,
       CHAT_MODEL_GROUP_GEMINI,
-      CHAT_MODEL_GROUP_CLAUDE
+      CHAT_MODEL_GROUP_CLAUDE,
+      CHAT_MODEL_GROUP_KIMI
     ];
     const foundGroup = modelGroups.find((group) => group.name === this.modelGroup.name);
     console.debug('Found model group:', foundGroup);

--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -31,11 +31,16 @@ export const CHAT_MODEL_NAME_CLAUDE_OPUS_4 = 'claude-opus-4';
 export const CHAT_MODEL_NAME_CLAUDE_SONNET_4 = 'claude-sonnet-4';
 export const CHAT_MODEL_NAME_CLAUDE_3_7_SONNET = 'claude-3-7-sonnet';
 
+export const CHAT_MODEL_NAME_KIMI_K2_5 = 'kimi-k2.5';
+export const CHAT_MODEL_NAME_KIMI_K2_THINKING = 'kimi-k2-thinking';
+export const CHAT_MODEL_NAME_KIMI_K2_THINKING_TURBO = 'kimi-k2-thinking-turbo';
+
 export const CHAT_MODEL_ICON_CHATGPT = 'https://cdn.acedata.cloud/7dljuv.png';
 export const CHAT_MODEL_ICON_GROK = 'https://cdn.acedata.cloud/p1ge98.png';
-export const CHAT_MODEL_ICON_DEEPSEEK = 'https://cdn.acedata.cloud/4rb23t.jpg';
+export const CHAT_MODEL_ICON_DEEPSEEK = 'https://cdn.acedata.cloud/bc71ae.png';
 export const CHAT_MODEL_ICON_GEMINI = 'https://cdn.acedata.cloud/psfx0g.jpg';
 export const CHAT_MODEL_ICON_CLAUDE = 'https://cdn.acedata.cloud/8fnw4v.jpg';
+export const CHAT_MODEL_ICON_KIMI = 'https://cdn.acedata.cloud/kimi.png';
 
 export const CHAT_SERVICE_ID = 'b1fbcc32-e218-4253-9dc3-4fe600a1bfb9';
 
@@ -279,6 +284,35 @@ export const CHAT_MODEL_CLAUDE_3_7_SONNET: IChatModel = {
   getDescription: () => i18n.global.t('chat.model.claude37SonnetDescription')
 };
 
+export const CHAT_MODEL_KIMI_K2_5: IChatModel = {
+  enabled: true,
+  name: CHAT_MODEL_NAME_KIMI_K2_5,
+  icon: CHAT_MODEL_ICON_KIMI,
+  modelGroup: 'kimi',
+  getDisplayName: () => i18n.global.t('chat.model.kimiK25'),
+  getDescription: () => i18n.global.t('chat.model.kimiK25Description')
+};
+
+export const CHAT_MODEL_KIMI_K2_THINKING: IChatModel = {
+  enabled: true,
+  name: CHAT_MODEL_NAME_KIMI_K2_THINKING,
+  icon: CHAT_MODEL_ICON_KIMI,
+  modelGroup: 'kimi',
+  isReasoningSupported: true,
+  getDisplayName: () => i18n.global.t('chat.model.kimiK2Thinking'),
+  getDescription: () => i18n.global.t('chat.model.kimiK2ThinkingDescription')
+};
+
+export const CHAT_MODEL_KIMI_K2_THINKING_TURBO: IChatModel = {
+  enabled: true,
+  name: CHAT_MODEL_NAME_KIMI_K2_THINKING_TURBO,
+  icon: CHAT_MODEL_ICON_KIMI,
+  modelGroup: 'kimi',
+  isReasoningSupported: true,
+  getDisplayName: () => i18n.global.t('chat.model.kimiK2ThinkingTurbo'),
+  getDescription: () => i18n.global.t('chat.model.kimiK2ThinkingTurboDescription')
+};
+
 export const CHAT_MODEL_GROUP_CHATGPT: IChatModelGroup = {
   icon: CHAT_MODEL_ICON_CHATGPT,
   name: 'chatgpt',
@@ -331,6 +365,14 @@ export const CHAT_MODEL_GROUP_CLAUDE: IChatModelGroup = {
   models: [CHAT_MODEL_CLAUDE_OPUS_4, CHAT_MODEL_CLAUDE_SONNET_4, CHAT_MODEL_CLAUDE_3_7_SONNET]
 };
 
+export const CHAT_MODEL_GROUP_KIMI: IChatModelGroup = {
+  icon: CHAT_MODEL_ICON_KIMI,
+  name: 'kimi',
+  getDisplayName: () => i18n.global.t('chat.modelGroup.kimi'),
+  getDescription: () => i18n.global.t('chat.modelGroup.kimiDescription'),
+  models: [CHAT_MODEL_KIMI_K2_5, CHAT_MODEL_KIMI_K2_THINKING, CHAT_MODEL_KIMI_K2_THINKING_TURBO]
+};
+
 export const CHAT_MODELS: IChatModel[] = [
   CHAT_MODEL_GPT_5_ALL,
   CHAT_MODEL_GPT_5,
@@ -353,7 +395,10 @@ export const CHAT_MODELS: IChatModel[] = [
   CHAT_MODEL_GEMINI_2_5_FLASH,
   CHAT_MODEL_CLAUDE_OPUS_4,
   CHAT_MODEL_CLAUDE_SONNET_4,
-  CHAT_MODEL_CLAUDE_3_7_SONNET
+  CHAT_MODEL_CLAUDE_3_7_SONNET,
+  CHAT_MODEL_KIMI_K2_5,
+  CHAT_MODEL_KIMI_K2_THINKING,
+  CHAT_MODEL_KIMI_K2_THINKING_TURBO
 ];
 
 export const CHAT_MODEL_GROUPS: IChatModelGroup[] = [
@@ -361,5 +406,6 @@ export const CHAT_MODEL_GROUPS: IChatModelGroup[] = [
   CHAT_MODEL_GROUP_DEEPSEEK,
   CHAT_MODEL_GROUP_GROK,
   CHAT_MODEL_GROUP_GEMINI,
-  CHAT_MODEL_GROUP_CLAUDE
+  CHAT_MODEL_GROUP_CLAUDE,
+  CHAT_MODEL_GROUP_KIMI
 ];

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -55,6 +55,14 @@
     "message": "AI model developed by Anthropic",
     "description": "Description of the Claude model group"
   },
+  "modelGroup.kimi": {
+    "message": "Kimi",
+    "description": "Name of the service model, i.e., Kimi"
+  },
+  "modelGroup.kimiDescription": {
+    "message": "AI model developed by Moonshot AI",
+    "description": "Description of the Kimi model group"
+  },
   "model.5All": {
     "message": "gpt-5-all",
     "description": "Name of the service model, i.e., GPT 5 All"
@@ -222,6 +230,30 @@
   "model.claude37SonnetDescription": {
     "message": "Balanced performance and speed",
     "description": "Description of the Claude 3.7 Sonnet model"
+  },
+  "model.kimiK25": {
+    "message": "kimi-k2.5",
+    "description": "Name of the service model, i.e., Kimi K2.5"
+  },
+  "model.kimiK25Description": {
+    "message": "Currently the most advanced model",
+    "description": "Description of the Kimi K2.5 model"
+  },
+  "model.kimiK2Thinking": {
+    "message": "kimi-k2 Reasoning",
+    "description": "Name of the service model, i.e., Kimi K2 Reasoning"
+  },
+  "model.kimiK2ThinkingDescription": {
+    "message": "Suitable for reasoning and deep thinking questions",
+    "description": "Description of the Kimi K2 Reasoning model"
+  },
+  "model.kimiK2ThinkingTurbo": {
+    "message": "kimi-k2 Turbo Reasoning",
+    "description": "Name of the service model, i.e., Kimi K2 Turbo Reasoning"
+  },
+  "model.kimiK2ThinkingTurboDescription": {
+    "message": "Faster reasoning model",
+    "description": "Description of the Kimi K2 Turbo Reasoning model"
   },
   "model.o1": {
     "message": "o1",

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -55,6 +55,14 @@
     "message": "Anthropic 公司开发的 AI 模型",
     "description": "Claude 模型组的描述"
   },
+  "modelGroup.kimi": {
+    "message": "Kimi",
+    "description": "服务的模型名称，即 Kimi"
+  },
+  "modelGroup.kimiDescription": {
+    "message": "月之暗面公司开发的 AI 模型",
+    "description": "Kimi 模型组的描述"
+  },
   "model.5All": {
     "message": "gpt-5-all",
     "description": "服务的模型名称，即 GPT 5 All"
@@ -222,6 +230,30 @@
   "model.claude37SonnetDescription": {
     "message": "均衡的性能和速度",
     "description": "Claude 3.7 Sonnet 模型的描述"
+  },
+  "model.kimiK25": {
+    "message": "kimi-k2.5",
+    "description": "服务的模型名称，即 Kimi K2.5"
+  },
+  "model.kimiK25Description": {
+    "message": "目前最先进的模型",
+    "description": "Kimi K2.5 模型的描述"
+  },
+  "model.kimiK2Thinking": {
+    "message": "kimi-k2 推理",
+    "description": "服务的模型名称，即 Kimi K2 推理"
+  },
+  "model.kimiK2ThinkingDescription": {
+    "message": "适用于推理和深度思考问题",
+    "description": "Kimi K2 推理模型的描述"
+  },
+  "model.kimiK2ThinkingTurbo": {
+    "message": "kimi-k2 极速推理",
+    "description": "服务的模型名称，即 Kimi K2 极速推理"
+  },
+  "model.kimiK2ThinkingTurboDescription": {
+    "message": "更快速的推理模型",
+    "description": "Kimi K2 极速推理模型的描述"
   },
   "model.o1": {
     "message": "o1",

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -26,7 +26,10 @@ import {
   CHAT_MODEL_NAME_GEMINI_3_0_PRO,
   CHAT_MODEL_NAME_CLAUDE_OPUS_4,
   CHAT_MODEL_NAME_CLAUDE_SONNET_4,
-  CHAT_MODEL_NAME_CLAUDE_3_7_SONNET
+  CHAT_MODEL_NAME_CLAUDE_3_7_SONNET,
+  CHAT_MODEL_NAME_KIMI_K2_5,
+  CHAT_MODEL_NAME_KIMI_K2_THINKING,
+  CHAT_MODEL_NAME_KIMI_K2_THINKING_TURBO
 } from '@/constants';
 
 export type IChatModelName =
@@ -55,13 +58,16 @@ export type IChatModelName =
   | typeof CHAT_MODEL_NAME_GEMINI_2_5_FLASH
   | typeof CHAT_MODEL_NAME_CLAUDE_OPUS_4
   | typeof CHAT_MODEL_NAME_CLAUDE_SONNET_4
-  | typeof CHAT_MODEL_NAME_CLAUDE_3_7_SONNET;
+  | typeof CHAT_MODEL_NAME_CLAUDE_3_7_SONNET
+  | typeof CHAT_MODEL_NAME_KIMI_K2_5
+  | typeof CHAT_MODEL_NAME_KIMI_K2_THINKING
+  | typeof CHAT_MODEL_NAME_KIMI_K2_THINKING_TURBO;
 
 export interface IChatModel {
   enabled?: boolean;
   name: IChatModelName;
   icon: string;
-  modelGroup?: 'chatgpt' | 'deepseek' | 'grok' | 'gemini' | 'claude';
+  modelGroup?: 'chatgpt' | 'deepseek' | 'grok' | 'gemini' | 'claude' | 'kimi';
   getDisplayName: () => string;
   getDescription: () => string;
   isSearchSupported?: boolean;
@@ -72,7 +78,7 @@ export interface IChatModel {
 }
 
 export interface IChatModelGroup {
-  name: 'chatgpt' | 'deepseek' | 'grok' | 'gemini' | 'claude';
+  name: 'chatgpt' | 'deepseek' | 'grok' | 'gemini' | 'claude' | 'kimi';
   icon: string;
   getDisplayName: () => string;
   getDescription: () => string;

--- a/src/router/constants.ts
+++ b/src/router/constants.ts
@@ -18,6 +18,8 @@ export const ROUTE_GEMINI_CONVERSATION = 'gemini-conversation';
 export const ROUTE_GEMINI_CONVERSATION_NEW = 'gemini-conversation-new';
 export const ROUTE_CLAUDE_CONVERSATION = 'claude-conversation';
 export const ROUTE_CLAUDE_CONVERSATION_NEW = 'claude-conversation-new';
+export const ROUTE_KIMI_CONVERSATION = 'kimi-conversation';
+export const ROUTE_KIMI_CONVERSATION_NEW = 'kimi-conversation-new';
 
 export const ROUTE_MIDJOURNEY_INDEX = 'midjourney-index';
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -5,6 +5,7 @@ import grok from './grok';
 import gemini from './gemini';
 import claude from './claude';
 import deepseek from './deepseek';
+import kimi from './kimi';
 import chatgpt from './chatgpt';
 import midjourney from './midjourney';
 import distribution from './distribution';
@@ -62,6 +63,12 @@ const ROUTE_SEO: Record<string, { title: string; description: string; keywords: 
     title: 'DeepSeek',
     description: 'Chat with DeepSeek AI — advanced reasoning and coding AI assistant.',
     keywords: ['DeepSeek', 'AI Chat', 'AI Coding', 'DeepSeek AI'],
+    category: 'AI Chat'
+  },
+  kimi: {
+    title: 'Kimi',
+    description: 'Chat with Kimi AI — advanced AI conversations powered by Moonshot AI.',
+    keywords: ['Kimi', 'Moonshot AI', 'AI Chat', 'Kimi AI'],
     category: 'AI Chat'
   },
   midjourney: {
@@ -175,6 +182,7 @@ const routes = [
   gemini,
   claude,
   deepseek,
+  kimi,
   qrart,
   luma,
   pika,

--- a/src/router/kimi.ts
+++ b/src/router/kimi.ts
@@ -1,0 +1,29 @@
+import { CHAT_MODEL_GROUP_KIMI } from '@/constants';
+import { ROUTE_KIMI_CONVERSATION, ROUTE_KIMI_CONVERSATION_NEW } from './constants';
+
+export default {
+  path: '/kimi',
+  meta: {
+    modelGroup: CHAT_MODEL_GROUP_KIMI,
+    appName: 'chat'
+  },
+  component: () => import('@/layouts/Main.vue'),
+  children: [
+    {
+      path: '',
+      redirect: {
+        name: ROUTE_KIMI_CONVERSATION_NEW
+      }
+    },
+    {
+      path: 'conversations/:id',
+      name: ROUTE_KIMI_CONVERSATION,
+      component: () => import('@/pages/chat/Conversation.vue')
+    },
+    {
+      path: 'conversations',
+      name: ROUTE_KIMI_CONVERSATION_NEW,
+      component: () => import('@/pages/chat/Conversation.vue')
+    }
+  ]
+};


### PR DESCRIPTION
## Summary
- Add Kimi (Moonshot AI) as a new AI chat service in Nexior, following the same pattern as existing chat services (DeepSeek, Grok, Gemini, Claude)
- Include three models: kimi-k2.5 (flagship), kimi-k2-thinking (reasoning), kimi-k2-thinking-turbo (fast reasoning)
- Add router, constants, model types, ModelSelector integration, and zh-CN/en i18n translations

## Test plan
- [ ] Verify `/kimi` route loads the chat conversation page
- [ ] Verify Kimi appears in the model selector dropdown
- [ ] Verify all three Kimi models are selectable
- [ ] Verify Chinese and English translations display correctly
- [ ] Verify lint passes (`npm run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)