### PR TITLE
feat(nexior): add Wan video generation service

### DIFF
--- a/change/feat-wan-video.json
+++ b/change/feat-wan-video.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(nexior): add Wan video generation service",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/wan/ConfigPanel.vue
+++ b/src/components/wan/ConfigPanel.vue
@@ -1,0 +1,73 @@
+<template>
+  <div class="flex flex-col h-full">
+    <div class="flex-1 overflow-y-auto p-5">
+      <prompt-input class="mb-4" />
+      <model-selector class="mb-4" />
+      <resolution-selector v-if="supportsResolution" class="mb-4" />
+      <duration-selector v-if="supportsDuration" class="mb-4" />
+      <image-url-input v-if="supportsImageUrl" class="mb-2" />
+    </div>
+    <div class="flex flex-col items-center justify-center px-5 pb-5">
+      <consumption :value="consumption" :service="service" />
+      <el-button type="primary" class="btn w-full" round @click="onGenerate">
+        <font-awesome-icon icon="fa-solid fa-magic" class="mr-2" />
+        {{ $t('wan.button.generate') }}
+      </el-button>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElButton } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import ModelSelector from './config/ModelSelector.vue';
+import ResolutionSelector from './config/ResolutionSelector.vue';
+import DurationSelector from './config/DurationSelector.vue';
+import ImageUrlInput from './config/ImageUrlInput.vue';
+import PromptInput from './config/PromptInput.vue';
+import Consumption from '../common/Consumption.vue';
+import { getConsumption } from '@/utils';
+
+export default defineComponent({
+  name: 'PresetPanel',
+  components: {
+    ElButton,
+    FontAwesomeIcon,
+    PromptInput,
+    ImageUrlInput,
+    ModelSelector,
+    ResolutionSelector,
+    DurationSelector,
+    Consumption
+  },
+  emits: ['generate'],
+  computed: {
+    config() {
+      return this.$store.state.wan?.config;
+    },
+    consumption() {
+      return getConsumption(this.config, this.service?.cost);
+    },
+    service() {
+      return this.$store.state.wan?.service;
+    },
+    supportsResolution() {
+      const model = this.config?.model;
+      return model === 'wan2.6-t2v' || model === 'wan2.6-i2v' || model === 'wan2.6-i2v-flash';
+    },
+    supportsDuration() {
+      return this.config?.model === 'wan2.6-t2v';
+    },
+    supportsImageUrl() {
+      const model = this.config?.model;
+      return model === 'wan2.6-i2v' || model === 'wan2.6-i2v-flash';
+    }
+  },
+  methods: {
+    onGenerate() {
+      this.$emit('generate');
+    }
+  }
+});
+</script>

--- a/src/components/wan/RecentPanel.vue
+++ b/src/components/wan/RecentPanel.vue
@@ -1,0 +1,61 @@
+<template>
+  <div v-if="tasks?.items === undefined">
+    <bot-placeholder />
+  </div>
+  <scroll-list
+    v-else-if="tasks?.items?.length && tasks?.items?.length > 0"
+    ref="scrollList"
+    class="tasks w-full h-full overflow-y-auto"
+    :loading="loading"
+    @reach-top="$emit('reach-top')"
+  >
+    <task-preview v-for="task in tasks?.items" :key="task.id" :model-value="task" />
+  </scroll-list>
+  <div v-if="tasks?.items?.length === 0" class="w-full h-full flex items-center justify-center">
+    <no-tasks />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import TaskPreview from './task/Preview.vue';
+import BotPlaceholder from '@/components/common/BotPlaceholder.vue';
+import NoTasks from '@/components/common/NoTasks.vue';
+import ScrollList from '@/components/common/ScrollList.vue';
+
+export default defineComponent({
+  name: 'RecentPanel',
+  components: {
+    TaskPreview,
+    BotPlaceholder,
+    NoTasks,
+    ScrollList
+  },
+  props: {
+    loading: {
+      type: Boolean,
+      default: false
+    }
+  },
+  emits: ['reach-top'],
+  data() {
+    return {
+      job: 0
+    };
+  },
+  computed: {
+    tasks() {
+      return {
+        ...this.$store.state.wan?.tasks,
+        items: this.$store.state.wan?.tasks?.items?.slice()
+      };
+    }
+  },
+  methods: {
+    getScrollElement(): HTMLElement | undefined {
+      const list = this.$refs.scrollList as any;
+      return list?.getScrollElement?.();
+    }
+  }
+});
+</script>

--- a/src/components/wan/config/DurationSelector.vue
+++ b/src/components/wan/config/DurationSelector.vue
@@ -1,0 +1,76 @@
+<template>
+  <div class="field">
+    <h2 class="title font-bold">{{ $t('wan.name.duration') }}</h2>
+    <el-select v-model="value" class="value" :placeholder="$t('wan.placeholder.select')" clearable>
+      <el-option v-for="item in options" :key="item.value" :label="item.label" :value="item.value">
+        <span class="float-left">{{ item.label }}</span>
+      </el-option>
+    </el-select>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElSelect, ElOption } from 'element-plus';
+
+const DEFAULT_DURATION = 5;
+
+export default defineComponent({
+  name: 'DurationSelector',
+  components: {
+    ElSelect,
+    ElOption
+  },
+  computed: {
+    options() {
+      return [
+        {
+          value: 5,
+          label: this.$t('wan.name.duration5s')
+        },
+        {
+          value: 10,
+          label: this.$t('wan.name.duration10s')
+        },
+        {
+          value: 15,
+          label: this.$t('wan.name.duration15s')
+        }
+      ];
+    },
+    value: {
+      get() {
+        return this.$store.state.wan?.config?.duration;
+      },
+      set(val: number) {
+        this.$store.commit('wan/setConfig', {
+          ...this.$store.state.wan?.config,
+          duration: val
+        });
+      }
+    }
+  },
+  mounted() {
+    if (!this.value) {
+      this.value = DEFAULT_DURATION;
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.field {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  .title {
+    font-size: 14px;
+    margin: 0;
+    width: 30%;
+  }
+  .value {
+    flex: 1;
+  }
+}
+</style>

--- a/src/components/wan/config/ImageUrlInput.vue
+++ b/src/components/wan/config/ImageUrlInput.vue
@@ -1,0 +1,131 @@
+<template>
+  <div class="relative">
+    <div class="flex justify-between">
+      <div class="flex justify-start items-center">
+        <span class="text-sm font-bold">{{ $t('wan.name.imageUrl') }}</span>
+        <info-icon :content="$t('wan.description.imageUrl')" class="info" />
+      </div>
+    </div>
+    <el-upload
+      v-model:file-list="fileList"
+      accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
+      name="file"
+      :show-file-list="true"
+      :limit="1"
+      :multiple="false"
+      list-type="picture"
+      :action="uploadUrl"
+      :on-exceed="onExceed"
+      :on-error="onError"
+      :on-remove="onRemove"
+      :on-success="onSuccess"
+      :headers="headers"
+    >
+      <template #file="{ file }">
+        <image-preview
+          v-if="file.url && file.percentage !== undefined"
+          :url="file.url"
+          :name="file.name"
+          :percentage="file.percentage"
+          @remove="fileList.splice(fileList.indexOf(file), 1)"
+        />
+      </template>
+      <el-button size="small" type="primary" class="btn btn-upload" round>
+        {{ $t('wan.button.uploadImageUrl') }}
+      </el-button>
+    </el-upload>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElButton, ElUpload, ElMessage, UploadFiles, UploadFile } from 'element-plus';
+import { getBaseUrlPlatform } from '@/utils';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+import ImagePreview from '@/components/common/ImagePreview.vue';
+
+export const DEFAULT_CONTENT = '';
+
+interface IData {
+  fileList: UploadFiles;
+  uploadUrl: string;
+}
+
+export default defineComponent({
+  name: 'ImageUrlInput',
+  components: {
+    ElUpload,
+    ElButton,
+    InfoIcon,
+    ImagePreview
+  },
+  data(): IData {
+    return {
+      fileList: [],
+      uploadUrl: getBaseUrlPlatform() + '/api/v1/files/'
+    };
+  },
+  computed: {
+    headers() {
+      return {
+        Authorization: `Bearer ${this.$store.state.token.access}`
+      };
+    },
+    urls(): string[] {
+      return this.fileList.map((file: UploadFile) => file.url).filter((url: string | undefined) => url !== undefined);
+    },
+    value: {
+      get() {
+        return this.$store.state.wan?.config?.image_url;
+      },
+      set() {
+        const url = this.urls?.[0];
+        this.$store.commit('wan/setConfig', {
+          ...this.$store.state.wan?.config,
+          image_url: url
+        });
+      }
+    }
+  },
+  mounted() {
+    if (!this.value) {
+      this.value = undefined;
+    }
+    this.onSetImageUrl();
+  },
+  methods: {
+    onExceed() {
+      ElMessage.warning(this.$t('wan.message.uploadImageExceed'));
+    },
+    onError() {
+      ElMessage.error(this.$t('wan.message.uploadImageError'));
+    },
+    async onRemove() {
+      ElMessage.error(this.$t('wan.message.uploadImageError'));
+    },
+    onSetImageUrl() {
+      const url = this.urls?.[0];
+      this.$store.commit('wan/setConfig', {
+        ...this.$store.state.wan?.config,
+        image_url: url
+      });
+    },
+    async onSuccess() {
+      this.onSetImageUrl();
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.title {
+  font-size: 14px;
+  margin-bottom: 0;
+  width: 30%;
+}
+.btn.btn-upload {
+  position: absolute;
+  top: 5px;
+  right: 0;
+}
+</style>

--- a/src/components/wan/config/ModelSelector.vue
+++ b/src/components/wan/config/ModelSelector.vue
@@ -1,0 +1,82 @@
+<template>
+  <div class="field">
+    <h2 class="title font-bold">{{ $t('wan.name.model') }}</h2>
+    <el-select v-model="value" class="value" :placeholder="$t('wan.placeholder.select')" clearable>
+      <el-option v-for="item in options" :key="item.value" :label="item.label" :value="item.value">
+        <span class="float-left">{{ item.label }}</span>
+      </el-option>
+    </el-select>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElSelect, ElOption } from 'element-plus';
+import { WAN_DEFAULT_MODEL } from '@/constants';
+
+export default defineComponent({
+  name: 'ModelSelector',
+  components: {
+    ElSelect,
+    ElOption
+  },
+  data() {
+    return {};
+  },
+  computed: {
+    options() {
+      return [
+        {
+          value: 'wan2.6-t2v',
+          label: this.$t('wan.button.modelT2v')
+        },
+        {
+          value: 'wan2.6-i2v',
+          label: this.$t('wan.button.modelI2v')
+        },
+        {
+          value: 'wan2.6-i2v-flash',
+          label: this.$t('wan.button.modelI2vFlash')
+        },
+        {
+          value: 'wan2.6-r2v',
+          label: this.$t('wan.button.modelR2v')
+        }
+      ];
+    },
+    value: {
+      get() {
+        return this.$store.state.wan?.config?.model;
+      },
+      set(val: string) {
+        this.$store.commit('wan/setConfig', {
+          ...this.$store.state.wan?.config,
+          model: val
+        });
+      }
+    }
+  },
+  mounted() {
+    if (!this.value) {
+      this.value = WAN_DEFAULT_MODEL;
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.field {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  .title {
+    font-size: 14px;
+    margin: 0;
+    width: 30%;
+  }
+  .value {
+    flex: 1;
+  }
+}
+</style>

--- a/src/components/wan/config/PromptInput.vue
+++ b/src/components/wan/config/PromptInput.vue
@@ -1,0 +1,63 @@
+<template>
+  <div class="field">
+    <div class="box">
+      <h2 class="title font-bold">{{ $t('wan.name.prompt') }}</h2>
+      <info-icon :content="$t('wan.description.prompt')" class="info" />
+    </div>
+    <el-input v-model="prompt" :rows="3" type="textarea" class="prompt" :placeholder="$t('wan.placeholder.prompt')" />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElInput } from 'element-plus';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+
+export const DEFAULT_PROMPT = '';
+
+export default defineComponent({
+  name: 'PromptInput',
+  components: {
+    ElInput,
+    InfoIcon
+  },
+  computed: {
+    prompt: {
+      get() {
+        return this.$store.state.wan?.config?.prompt;
+      },
+      set(val: string) {
+        console.debug('set prompt', val);
+        this.$store.commit('wan/setConfig', {
+          ...this.$store.state.wan?.config,
+          prompt: val
+        });
+      }
+    }
+  },
+  mounted() {
+    if (!this.prompt) {
+      this.prompt = DEFAULT_PROMPT;
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.field {
+  .box {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    position: relative;
+    .title {
+      font-size: 14px;
+      margin-bottom: 10px;
+    }
+  }
+  .info {
+    margin-left: auto;
+  }
+}
+</style>

--- a/src/components/wan/config/ResolutionSelector.vue
+++ b/src/components/wan/config/ResolutionSelector.vue
@@ -1,0 +1,76 @@
+<template>
+  <div class="field">
+    <h2 class="title font-bold">{{ $t('wan.name.resolution') }}</h2>
+    <el-select v-model="value" class="value" :placeholder="$t('wan.placeholder.select')" clearable>
+      <el-option v-for="item in options" :key="item.value" :label="item.label" :value="item.value">
+        <span class="float-left">{{ item.label }}</span>
+      </el-option>
+    </el-select>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElSelect, ElOption } from 'element-plus';
+
+const DEFAULT_RESOLUTION = '720P';
+
+export default defineComponent({
+  name: 'ResolutionSelector',
+  components: {
+    ElSelect,
+    ElOption
+  },
+  computed: {
+    options() {
+      return [
+        {
+          value: '480P',
+          label: this.$t('wan.name.resolution480p')
+        },
+        {
+          value: '720P',
+          label: this.$t('wan.name.resolution720p')
+        },
+        {
+          value: '1080P',
+          label: this.$t('wan.name.resolution1080p')
+        }
+      ];
+    },
+    value: {
+      get() {
+        return this.$store.state.wan?.config?.resolution;
+      },
+      set(val: string) {
+        this.$store.commit('wan/setConfig', {
+          ...this.$store.state.wan?.config,
+          resolution: val
+        });
+      }
+    }
+  },
+  mounted() {
+    if (!this.value) {
+      this.value = DEFAULT_RESOLUTION;
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.field {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  .title {
+    font-size: 14px;
+    margin: 0;
+    width: 30%;
+  }
+  .value {
+    flex: 1;
+  }
+}
+</style>

--- a/src/components/wan/task/Preview.vue
+++ b/src/components/wan/task/Preview.vue
@@ -1,0 +1,218 @@
+<template>
+  <div class="preview">
+    <div class="left">
+      <el-image src="https://cdn.acedata.cloud/wan.png" class="avatar" />
+    </div>
+    <div class="main">
+      <div class="bot">
+        {{ $t('wan.name.wanBot') }}
+        <span class="datetime">
+          {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
+        </span>
+      </div>
+      <div class="info">
+        <p v-if="modelValue?.request?.prompt" class="prompt mt-2">
+          {{ modelValue?.request?.prompt }}
+          <span v-if="!modelValue?.response"> - ({{ $t('wan.status.pending') }}) </span>
+          <span
+            v-if="
+              modelValue?.response?.state === 'processing' ||
+              modelValue?.response?.state === 'pending' ||
+              modelValue?.response?.state === 'running'
+            "
+          >
+            - ({{ $t('wan.status.processing') }})
+          </span>
+        </p>
+      </div>
+      <!-- Display success message -->
+      <div v-if="modelValue?.response?.success === true" :class="{ content: true, failed: true }">
+        <div v-if="modelValue?.response?.video_url" class="mb-4">
+          <video-player :src="modelValue?.response?.video_url" />
+        </div>
+        <div v-if="modelValue?.response?.video_url" :class="{ operations: true, 'mt-2': true }">
+          <el-tooltip class="box-item" effect="dark" :content="$t('wan.message.downloadVideo')" placement="top-start">
+            <el-button type="info" size="small" class="mb-2" @click.stop="onDownload(modelValue?.response?.video_url)">
+              {{ $t('wan.button.download') }}
+            </el-button>
+          </el-tooltip>
+        </div>
+        <el-alert :closable="false" class="mt-2 success">
+          <p v-if="modelValue?.request?.model" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />
+            {{ $t('wan.name.model') }}:
+            {{ modelValue?.request?.model }}
+            <copy-to-clipboard :content="modelValue?.id!" />
+          </p>
+          <p class="text-[var(--el-text-color-regular)] text-xs mb-0">
+            <font-awesome-icon icon="fa-solid fa-magic" class="mr-1" />
+            {{ $t('wan.name.taskId') }}:
+            {{ modelValue?.id }}
+            <copy-to-clipboard :content="modelValue?.id!" />
+          </p>
+        </el-alert>
+      </div>
+      <!-- Display error message -->
+      <div v-if="modelValue?.response?.success === false" :class="{ content: true }">
+        <el-alert :closable="false" class="failure">
+          <template #template>
+            <font-awesome-icon icon="fa-solid fa-exclamation-triangle" class="mr-1" />
+            {{ $t('wan.name.failure') }}
+          </template>
+          <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-magic" class="mr-1" />
+            {{ $t('wan.name.taskId') }}:
+            {{ modelValue?.id }}
+            <copy-to-clipboard :content="modelValue?.id!" />
+          </p>
+          <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-circle-info" class="mr-1" />
+            {{ $t('wan.name.failureReason') }}:
+            {{ modelValue?.response?.error?.message }}
+            <copy-to-clipboard :content="modelValue?.response?.error?.message!" />
+          </p>
+          <p class="text-[var(--el-text-color-regular)] text-xs mb-0">
+            <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />
+            {{ $t('wan.name.traceId') }}:
+            {{ modelValue?.response?.trace_id }}
+            <copy-to-clipboard :content="modelValue?.response?.trace_id" />
+          </p>
+        </el-alert>
+      </div>
+      <!-- Display error message -->
+      <div v-if="modelValue?.response?.success === undefined" :class="{ content: true }">
+        <el-alert :closable="false" class="info">
+          <template #template>
+            <font-awesome-icon icon="fa-solid fa-exclamation-triangle" class="mr-1" />
+            {{ $t('wan.name.failure') }}
+          </template>
+          <p class="text-[var(--el-text-color-regular)] text-xs mb-0">
+            <font-awesome-icon icon="fa-solid fa-magic" class="mr-1" />
+            {{ $t('wan.name.taskId') }}:
+            {{ modelValue?.id }}
+            <copy-to-clipboard :content="modelValue?.id!" />
+          </p>
+        </el-alert>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElImage, ElAlert, ElButton, ElTooltip } from 'element-plus';
+import { IWanTask } from '@/models';
+import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import VideoPlayer from '@/components/common/VideoPlayer.vue';
+
+export default defineComponent({
+  name: 'TaskPreview',
+  components: {
+    ElImage,
+    CopyToClipboard,
+    FontAwesomeIcon,
+    ElAlert,
+    VideoPlayer,
+    ElTooltip,
+    ElButton
+  },
+  props: {
+    modelValue: {
+      type: Object as () => IWanTask | undefined,
+      required: true
+    }
+  },
+  computed: {
+    application() {
+      return this.$store.state.wan?.application;
+    },
+    config() {
+      return this.$store.state.wan?.config;
+    }
+  },
+  methods: {
+    onDownload(videoUrl: string) {
+      console.debug('on download wan video', videoUrl);
+      window.open(videoUrl, '_blank');
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+$left-width: 70px;
+.preview {
+  width: 100%;
+  height: fit-content;
+  text-align: left;
+  display: flex;
+  flex-direction: row;
+  margin-bottom: 15px;
+  .left {
+    width: $left-width;
+    .avatar {
+      width: 50px;
+      height: 50px;
+      margin: 10px;
+      border-radius: 50%;
+      box-shadow: var(--app-shadow-xs);
+    }
+  }
+
+  .main {
+    flex: 1;
+    width: calc(100% - $left-width);
+    min-width: 0;
+    padding: 10px 10px 0 10px;
+
+    .bot {
+      font-size: 16px;
+      font-weight: bold;
+      color: var(--el-color-primary);
+      margin-bottom: 0;
+      margin-top: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      .datetime {
+        font-size: 12px;
+        font-weight: normal;
+        color: var(--el-text-color-secondary);
+        margin-left: 10px;
+      }
+    }
+
+    .info {
+      overflow: hidden;
+      .prompt {
+        font-size: 16px;
+        font-weight: bold;
+        color: var(--el-text-color-regular);
+        margin-bottom: 10px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+    }
+
+    .content {
+      word-break: break-word;
+      overflow-wrap: anywhere;
+      .el-alert {
+        border-left-width: 2px;
+        border-left-style: solid;
+        &.failure {
+          border-color: var(--el-color-danger);
+        }
+        &.success {
+          border-color: var(--el-color-success);
+        }
+        &.info {
+          border-color: var(--el-color-info);
+        }
+      }
+    }
+  }
+}
+</style>

--- a/src/constants/i18n.ts
+++ b/src/constants/i18n.ts
@@ -37,6 +37,7 @@ export const I18N_SCOPES = [
   'seedream',
   'seedance',
   'hailuo',
+  'wan',
   'headshots',
   'suno',
   'producer',

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -20,6 +20,7 @@ export * from './nanobanana';
 export * from './seedream';
 export * from './seedance';
 export * from './serp';
+export * from './wan';
 export * from './mapping';
 export * from './surface';
 export * from './mobile';

--- a/src/constants/wan.ts
+++ b/src/constants/wan.ts
@@ -1,0 +1,5 @@
+export const WAN_SERVICE_ID = 'f35a16da-726b-425f-96ba-bec7436cfc23';
+
+export const WAN_LOGO = 'https://cdn.acedata.cloud/wan.png';
+
+export const WAN_DEFAULT_MODEL = 'wan2.6-t2v';

--- a/src/i18n/en/wan.json
+++ b/src/i18n/en/wan.json
@@ -1,0 +1,162 @@
+{
+  "name.taskId": {
+    "message": "Task ID",
+    "description": "The ID of the task"
+  },
+  "name.type": {
+    "message": "Type",
+    "description": "The video type"
+  },
+  "name.failure": {
+    "message": "Failed",
+    "description": "The failure status of the task"
+  },
+  "name.failureReason": {
+    "message": "Failure Reason",
+    "description": "The reason for the task failure"
+  },
+  "name.status": {
+    "message": "Status",
+    "description": "The status of the task"
+  },
+  "name.traceId": {
+    "message": "Trace ID",
+    "description": "The trace ID of the task"
+  },
+  "name.createdAt": {
+    "message": "Created At",
+    "description": "The date and time the Wan video was created"
+  },
+  "name.prompt": {
+    "message": "Video Prompt",
+    "description": "The prompt for content input"
+  },
+  "name.model": {
+    "message": "Model",
+    "description": "The video generation model"
+  },
+  "name.resolution": {
+    "message": "Resolution",
+    "description": "The video resolution"
+  },
+  "name.duration": {
+    "message": "Duration",
+    "description": "The video duration"
+  },
+  "name.imageUrl": {
+    "message": "Reference Image",
+    "description": "The reference image for video generation"
+  },
+  "name.wanBot": {
+    "message": "Wan Bot",
+    "description": "The Wan video generator"
+  },
+  "description.prompt": {
+    "message": "The prompt for generating Wan videos",
+    "description": "Description for the prompt parameter"
+  },
+  "description.imageUrl": {
+    "message": "The first frame image, which will be the first frame of the generated video.",
+    "description": "Description for the imageUrl parameter"
+  },
+  "status.pending": {
+    "message": "Pending",
+    "description": "The pending status of the task"
+  },
+  "status.processing": {
+    "message": "Processing",
+    "description": "The processing status of the task"
+  },
+  "placeholder.prompt": {
+    "message": "Enter a prompt for the video content to generate",
+    "description": "Placeholder text for the prompt input"
+  },
+  "placeholder.select": {
+    "message": "Select",
+    "description": "Placeholder text for select fields"
+  },
+  "button.modelT2v": {
+    "message": "Text to Video",
+    "description": "Text to video generation"
+  },
+  "button.modelI2v": {
+    "message": "Image to Video",
+    "description": "Image to video generation"
+  },
+  "button.modelI2vFlash": {
+    "message": "Image to Video (Flash)",
+    "description": "Flash image to video generation"
+  },
+  "button.modelR2v": {
+    "message": "Reference Video",
+    "description": "Reference video generation"
+  },
+  "button.generate": {
+    "message": "Generate",
+    "description": "Generate video button"
+  },
+  "button.download": {
+    "message": "Download Video",
+    "description": "Download video button"
+  },
+  "button.uploadImageUrl": {
+    "message": "Upload",
+    "description": "Upload image button"
+  },
+  "message.startingTask": {
+    "message": "Starting task...",
+    "description": "Task is starting"
+  },
+  "message.startTaskSuccess": {
+    "message": "Task initiated successfully",
+    "description": "Task started successfully"
+  },
+  "message.startTaskFailed": {
+    "message": "Failed to initiate task, please contact the administrator",
+    "description": "Task failed to start"
+  },
+  "message.usedUp": {
+    "message": "Your credits are exhausted, please purchase more credits to continue",
+    "description": "Credits exhausted"
+  },
+  "message.downloadVideo": {
+    "message": "Download this video",
+    "description": "Download video tooltip"
+  },
+  "message.noTasks": {
+    "message": "No historical tasks, please click on the left to generate a video",
+    "description": "No tasks message"
+  },
+  "message.uploadImageExceed": {
+    "message": "Exceeded the limit for the number of images uploaded",
+    "description": "Image upload limit exceeded"
+  },
+  "message.uploadImageError": {
+    "message": "Failed to upload image",
+    "description": "Image upload failed"
+  },
+  "name.resolution480p": {
+    "message": "480P",
+    "description": "480P resolution"
+  },
+  "name.resolution720p": {
+    "message": "720P",
+    "description": "720P resolution"
+  },
+  "name.resolution1080p": {
+    "message": "1080P",
+    "description": "1080P resolution"
+  },
+  "name.duration5s": {
+    "message": "5 Seconds",
+    "description": "5 seconds duration"
+  },
+  "name.duration10s": {
+    "message": "10 Seconds",
+    "description": "10 seconds duration"
+  },
+  "name.duration15s": {
+    "message": "15 Seconds",
+    "description": "15 seconds duration"
+  }
+}

--- a/src/i18n/zh-CN/wan.json
+++ b/src/i18n/zh-CN/wan.json
@@ -1,0 +1,162 @@
+{
+  "name.taskId": {
+    "message": "任务 ID",
+    "description": "任务的 ID"
+  },
+  "name.type": {
+    "message": "类型",
+    "description": "视频类型"
+  },
+  "name.failure": {
+    "message": "失败",
+    "description": "任务的失败状态"
+  },
+  "name.failureReason": {
+    "message": "失败原因",
+    "description": "任务失败的原因"
+  },
+  "name.status": {
+    "message": "状态",
+    "description": "任务的状态"
+  },
+  "name.traceId": {
+    "message": "追踪 ID",
+    "description": "任务的追踪 ID"
+  },
+  "name.createdAt": {
+    "message": "创建时间",
+    "description": "通义万象视频创建时间"
+  },
+  "name.prompt": {
+    "message": "视频提示",
+    "description": "内容输入的提示"
+  },
+  "name.model": {
+    "message": "模型",
+    "description": "视频生成模型"
+  },
+  "name.resolution": {
+    "message": "分辨率",
+    "description": "视频分辨率"
+  },
+  "name.duration": {
+    "message": "时长",
+    "description": "视频时长"
+  },
+  "name.imageUrl": {
+    "message": "参考图片",
+    "description": "生成视频的参考图片"
+  },
+  "name.wanBot": {
+    "message": "Wan Bot",
+    "description": "通义万象视频生成器"
+  },
+  "description.prompt": {
+    "message": "生成通义万象视频的提示词",
+    "description": "参数prompt的描述"
+  },
+  "description.imageUrl": {
+    "message": "首帧图像，将作为生成视频的第一帧。",
+    "description": "参数imageUrl的描述"
+  },
+  "status.pending": {
+    "message": "等待中",
+    "description": "任务等待状态"
+  },
+  "status.processing": {
+    "message": "处理中",
+    "description": "任务处理状态"
+  },
+  "placeholder.prompt": {
+    "message": "输入要生成的视频内容提示词",
+    "description": "提示词输入占位文本"
+  },
+  "placeholder.select": {
+    "message": "选择",
+    "description": "选择字段占位文本"
+  },
+  "button.modelT2v": {
+    "message": "文生视频",
+    "description": "文本生成视频"
+  },
+  "button.modelI2v": {
+    "message": "图生视频",
+    "description": "图片生成视频"
+  },
+  "button.modelI2vFlash": {
+    "message": "图生视频(极速)",
+    "description": "极速图片生成视频"
+  },
+  "button.modelR2v": {
+    "message": "参考视频生成",
+    "description": "参考视频生成"
+  },
+  "button.generate": {
+    "message": "生成",
+    "description": "生成视频按钮"
+  },
+  "button.download": {
+    "message": "下载视频",
+    "description": "下载视频按钮"
+  },
+  "button.uploadImageUrl": {
+    "message": "上传图片",
+    "description": "上传图片按钮"
+  },
+  "message.startingTask": {
+    "message": "正在启动任务...",
+    "description": "任务启动中"
+  },
+  "message.startTaskSuccess": {
+    "message": "成功发起生成任务",
+    "description": "任务启动成功"
+  },
+  "message.startTaskFailed": {
+    "message": "发起任务失败，请联系管理员",
+    "description": "任务启动失败"
+  },
+  "message.usedUp": {
+    "message": "您的积分已用完，请购买更多积分后继续使用",
+    "description": "积分用完"
+  },
+  "message.downloadVideo": {
+    "message": "下载此视频",
+    "description": "下载视频提示"
+  },
+  "message.noTasks": {
+    "message": "没有历史任务，请点击左方生成视频",
+    "description": "无任务提示"
+  },
+  "message.uploadImageExceed": {
+    "message": "上传图片数量超过限制",
+    "description": "图片上传超限"
+  },
+  "message.uploadImageError": {
+    "message": "上传图片失败",
+    "description": "图片上传失败"
+  },
+  "name.resolution480p": {
+    "message": "480P",
+    "description": "480P分辨率"
+  },
+  "name.resolution720p": {
+    "message": "720P",
+    "description": "720P分辨率"
+  },
+  "name.resolution1080p": {
+    "message": "1080P",
+    "description": "1080P分辨率"
+  },
+  "name.duration5s": {
+    "message": "5 秒",
+    "description": "5秒时长"
+  },
+  "name.duration10s": {
+    "message": "10 秒",
+    "description": "10秒时长"
+  },
+  "name.duration15s": {
+    "message": "15 秒",
+    "description": "15秒时长"
+  }
+}

--- a/src/layouts/Wan.vue
+++ b/src/layouts/Wan.vue
@@ -1,0 +1,60 @@
+<template>
+  <div class="main flex flex-row flex-1">
+    <div
+      class="config w-[320px] flex-none h-full overflow-y-auto bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+    >
+      <slot name="config" />
+    </div>
+    <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
+      <slot name="result" />
+    </div>
+    <el-button circle class="menu" @click="drawer = true">
+      <font-awesome-icon icon="fa-solid fa-magic" />
+    </el-button>
+    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px">
+      <slot name="config" />
+    </el-drawer>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElDrawer, ElButton } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+
+export default defineComponent({
+  name: 'LayoutWan',
+  components: {
+    ElDrawer,
+    ElButton,
+    FontAwesomeIcon
+  },
+  data() {
+    return {
+      drawer: false
+    };
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.menu {
+  display: none;
+}
+
+@media (max-width: 767px) {
+  .config {
+    display: none;
+  }
+  .result {
+    width: 100%;
+  }
+  .menu {
+    display: block;
+    position: absolute;
+    right: 8px;
+    top: 45px;
+    z-index: 1000;
+  }
+}
+</style>

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -26,6 +26,7 @@ export * from './nanobanana';
 export * from './seedream';
 export * from './seedance';
 export * from './serp';
+export * from './wan';
 export * from './site';
 export * from './exchange';
 export * from './error';

--- a/src/models/wan.ts
+++ b/src/models/wan.ts
@@ -1,0 +1,62 @@
+export interface IWanConfig {
+  action?: string;
+  prompt?: string;
+  model?: string;
+  resolution?: string;
+  duration?: number;
+  image_url?: string;
+  audio?: boolean;
+  prompt_extend?: boolean;
+  callback_url?: string;
+}
+
+export interface IWanGenerateRequest {
+  action?: string;
+  prompt?: string;
+  model?: string;
+  resolution?: string;
+  duration?: number;
+  image_url?: string;
+  audio?: boolean;
+  prompt_extend?: boolean;
+  negative_prompt?: string;
+  callback_url?: string;
+}
+
+export interface IWanVideo {
+  id?: string;
+  video_url?: string;
+  model?: string;
+  prompt?: string;
+  state?: string;
+  action?: string;
+}
+
+export interface IWanGenerateResponse {
+  success: boolean;
+  task_id: string;
+  trace_id: string;
+  video_id?: string;
+  video_url?: string;
+  thumbnail_url?: string;
+  state?: string;
+  prompt?: string;
+  error?: {
+    code?: string;
+    message?: string;
+  };
+}
+
+export interface IWanTask {
+  id: string;
+  created_at?: number;
+  request?: IWanGenerateRequest;
+  response?: IWanGenerateResponse;
+}
+
+export type IWanTaskResponse = IWanTask;
+
+export interface IWanTasksResponse {
+  count: number;
+  items: IWanTask[];
+}

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -28,4 +28,5 @@ export * from './nanobanana';
 export * from './seedream';
 export * from './seedance';
 export * from './serp';
+export * from './wan';
 export * from './config';

--- a/src/operators/wan.ts
+++ b/src/operators/wan.ts
@@ -1,0 +1,112 @@
+import axios, { AxiosResponse } from 'axios';
+import { IWanGenerateRequest, IWanGenerateResponse, IWanTaskResponse, IWanTasksResponse } from '@/models';
+import { BASE_URL_API } from '@/constants';
+
+class WanOperator {
+  async task(id: string, options: { token: string }): Promise<AxiosResponse<IWanTaskResponse>> {
+    return await axios.post(
+      `/wan/tasks`,
+      {
+        action: 'retrieve',
+        id: id
+      },
+      {
+        headers: {
+          accept: 'application/json',
+          'content-type': 'application/json',
+          authorization: `Bearer ${options.token}`,
+          'x-record-exempt': 'true'
+        },
+        baseURL: BASE_URL_API
+      }
+    );
+  }
+
+  async tasks(
+    filter: {
+      ids?: string[];
+      applicationId?: string;
+      userId?: string;
+      type?: string;
+      limit?: number;
+      offset?: number;
+      createdAtMax?: number;
+      createdAtMin?: number;
+    },
+    options: { token: string }
+  ): Promise<AxiosResponse<IWanTasksResponse>> {
+    return await axios.post(
+      `/wan/tasks`,
+      {
+        action: 'retrieve_batch',
+        ...(filter.ids
+          ? {
+              ids: filter.ids
+            }
+          : {}),
+        ...(filter.applicationId
+          ? {
+              application_id: filter.applicationId
+            }
+          : {}),
+        ...(filter.userId
+          ? {
+              user_id: filter.userId
+            }
+          : {}),
+        ...(filter.type
+          ? {
+              type: filter.type
+            }
+          : {}),
+        ...(filter.limit !== undefined
+          ? {
+              limit: filter.limit
+            }
+          : {}),
+        ...(filter.offset !== undefined
+          ? {
+              offset: filter.offset
+            }
+          : {}),
+        ...(filter.createdAtMax !== undefined
+          ? {
+              created_at_max: filter.createdAtMax
+            }
+          : {}),
+        ...(filter.createdAtMin !== undefined
+          ? {
+              created_at_min: filter.createdAtMin
+            }
+          : {})
+      },
+      {
+        headers: {
+          accept: 'application/json',
+          'content-type': 'application/json',
+          authorization: `Bearer ${options.token}`,
+          'x-record-exempt': 'true'
+        },
+        baseURL: BASE_URL_API
+      }
+    );
+  }
+
+  async generate(
+    data: IWanGenerateRequest,
+    options: {
+      token: string;
+    }
+  ): Promise<AxiosResponse<IWanGenerateResponse>> {
+    return await axios.post('/wan/videos', data, {
+      headers: {
+        authorization: `Bearer ${options.token}`,
+        'content-type': 'application/json',
+        accept: 'application/x-ndjson'
+      },
+      baseURL: BASE_URL_API
+    });
+  }
+}
+
+export const wanOperator = new WanOperator();

--- a/src/pages/wan/Index.vue
+++ b/src/pages/wan/Index.vue
@@ -1,0 +1,192 @@
+<template>
+  <layout>
+    <template #config>
+      <config-panel @generate="onGenerate" />
+    </template>
+    <template #result>
+      <recent-panel ref="recentPanel" :loading="loadingMore" @reach-top="onReachTop" />
+    </template>
+  </layout>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import Layout from '@/layouts/Wan.vue';
+import ConfigPanel from '@/components/wan/ConfigPanel.vue';
+import { wanOperator } from '@/operators';
+import { IWanGenerateRequest, Status } from '@/models';
+import { ElMessage } from 'element-plus';
+import { ERROR_CODE_USED_UP } from '@/constants';
+import RecentPanel from '@/components/wan/RecentPanel.vue';
+import { IWanTask } from '@/models';
+import { loadPreviousPage } from '@/utils/pagination';
+
+const CALLBACK_URL = 'https://webhook.acedata.cloud/wan';
+
+interface IData {
+  task: IWanTask | undefined;
+  job: number;
+  loadingMore: boolean;
+  fetchingTasks: boolean;
+}
+
+export default defineComponent({
+  name: 'WanIndex',
+  components: {
+    ConfigPanel,
+    Layout,
+    RecentPanel
+  },
+  inject: ['initialized'],
+  data(): IData {
+    return {
+      task: undefined,
+      job: 0,
+      // @ts-ignore
+      timer: undefined,
+      loadingMore: false,
+      fetchingTasks: false
+    };
+  },
+  computed: {
+    applicationsLoading() {
+      return this.$store.state.wan?.status?.getApplications === Status.Request;
+    },
+    tasksLoading() {
+      return this.$store.state.wan?.status?.getTasks === Status.Request || this.fetchingTasks;
+    },
+    credential() {
+      return this.$store.state.wan.credential;
+    },
+    config() {
+      return this.$store.state.wan.config;
+    },
+    application() {
+      return this.$store.state.wan.application;
+    },
+    tasks() {
+      return this.$store.state.wan.tasks;
+    }
+  },
+  watch: {
+    tasks: {
+      handler(value, oldValue) {
+        // scroll down if new tasks are added
+        if (value?.items?.length > oldValue?.items?.length) {
+          console.debug('new tasks detected');
+        }
+      },
+      deep: true
+    },
+    initialized: {
+      async handler(newValue) {
+        if (newValue) {
+          console.debug('layout initialized');
+          await this.onGetTasks();
+          await this.onScrollDown();
+          this.job = window.setInterval(() => {
+            this.onGetTasks();
+          }, 5000);
+        }
+      },
+      immediate: true
+    }
+  },
+  async mounted() {
+    await this.onGetService();
+  },
+  async unmounted() {
+    window.clearInterval(this.job);
+  },
+  methods: {
+    async onReachTop() {
+      await loadPreviousPage({
+        tasks: this.tasks,
+        getTasks: () => this.tasks,
+        loading: this.loadingMore,
+        setLoading: (v) => (this.loadingMore = v),
+        isBlocked: () => this.tasksLoading || this.applicationsLoading,
+        fetch: (createdAtMax) =>
+          this.onGetTasks({
+            createdAtMax
+          }),
+        getScrollElement: () => this.getTasksScrollElement()
+      });
+    },
+    async onGetService() {
+      console.debug('start onGetService');
+      await this.$store.dispatch('wan/getService');
+      console.debug('end onGetService');
+    },
+    async onGetApplication() {
+      console.debug('start onGetApplication');
+      await this.$store.dispatch('wan/getApplications');
+      console.debug('end onGetApplication');
+      await this.onGetTasks();
+    },
+    async onScrollDown() {
+      await this.$nextTick();
+      const el = this.getTasksScrollElement();
+      if (el) {
+        el.scrollTop = el.scrollHeight;
+      }
+    },
+    async onGetTasks(payload?: { limit?: number; createdAtMin?: number; createdAtMax?: number }) {
+      if (this.applicationsLoading || this.fetchingTasks) {
+        console.debug('loading');
+        return;
+      }
+      console.debug('start onGetTasks', payload);
+      const { limit = 5, createdAtMin, createdAtMax } = payload || {};
+      console.debug('limit', limit, 'createdAtMin', createdAtMin, 'createdAtMax', createdAtMax);
+      this.fetchingTasks = true;
+      try {
+        await this.$store.dispatch('wan/getTasks', {
+          limit,
+          createdAtMin,
+          createdAtMax
+        });
+      } finally {
+        this.fetchingTasks = false;
+      }
+    },
+    async onGenerate() {
+      const request = {
+        ...this.config,
+        callback_url: CALLBACK_URL
+      } as IWanGenerateRequest;
+      const token = this.credential?.token;
+      if (!token) {
+        console.error('no token specified');
+        return;
+      }
+      ElMessage.info(this.$t('wan.message.startingTask'));
+      wanOperator
+        .generate(request, {
+          token
+        })
+        .then(() => {
+          ElMessage.success(this.$t('wan.message.startTaskSuccess'));
+        })
+        .catch((error) => {
+          const response = error?.response?.data;
+          if (response?.error?.code === ERROR_CODE_USED_UP) {
+            ElMessage.error(this.$t('wan.message.usedUp'));
+          } else {
+            ElMessage.error(this.$t('wan.message.startTaskFailed'));
+          }
+        })
+        .finally(async () => {
+          setTimeout(async () => {
+            await this.onGetTasks();
+            await this.onScrollDown();
+          }, 1000);
+        });
+    },
+    getTasksScrollElement(): HTMLElement | undefined {
+      const panel = this.$refs.recentPanel as any;
+      return panel?.getScrollElement?.();
+    }
+  }
+});
+</script>

--- a/src/router/constants.ts
+++ b/src/router/constants.ts
@@ -66,6 +66,8 @@ export const ROUTE_SEEDANCE_INDEX = 'seedance-index';
 
 export const ROUTE_SERP_INDEX = 'serp-index';
 
+export const ROUTE_WAN_INDEX = 'wan-index';
+
 export const ROUTE_PROFILE_INDEX = 'profile-index';
 
 export const ROUTE_CONSOLE_ROOT = 'console-root';

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -26,6 +26,7 @@ import nanobanana from './nanobanana';
 import seedream from './seedream';
 import seedance from './seedance';
 import serp from './serp';
+import wan from './wan';
 import site from './site';
 import profile from './profile';
 
@@ -158,6 +159,12 @@ const ROUTE_SEO: Record<string, { title: string; description: string; keywords: 
     keywords: ['Seedance', 'AI Video', 'Dance Video', 'ByteDance'],
     category: 'AI Video Generation'
   },
+  wan: {
+    title: 'Wan',
+    description: 'Generate AI videos with Wan — high-quality video generation by Tongyi Wanxiang.',
+    keywords: ['Wan', 'Tongyi', 'AI Video', 'Video Generation'],
+    category: 'AI Video Generation'
+  },
   suno: {
     title: 'Suno',
     description: 'Create AI music with Suno — generate songs, lyrics, and music from text descriptions.',
@@ -214,6 +221,7 @@ const routes = [
   seedream,
   seedance,
   serp,
+  wan,
   midjourney,
   distribution,
   download,

--- a/src/router/wan.ts
+++ b/src/router/wan.ts
@@ -1,0 +1,17 @@
+import { ROUTE_WAN_INDEX } from './constants';
+
+export default {
+  path: '/wan',
+  meta: {
+    auth: true,
+    appName: 'wan'
+  },
+  component: () => import('@/layouts/Main.vue'),
+  children: [
+    {
+      path: '',
+      name: ROUTE_WAN_INDEX,
+      component: () => import('@/pages/wan/Index.vue')
+    }
+  ]
+};

--- a/src/store/common/models.ts
+++ b/src/store/common/models.ts
@@ -17,6 +17,7 @@ import { INanobananaState } from '../nanobanana/models';
 import { ISeedreamState } from '../seedream/models';
 import { ISeedanceState } from '../seedance/models';
 import { ISerpState } from '../serp/models';
+import { IWanState } from '../wan/models';
 
 export interface ISetting {}
 
@@ -64,6 +65,7 @@ export interface IAppState {
   seedream: ISeedreamState;
   seedance: ISeedanceState;
   serp: ISerpState;
+  wan: IWanState;
 }
 
 export interface IRootState extends ICommonState, IAppState {}

--- a/src/store/common/state.ts
+++ b/src/store/common/state.ts
@@ -17,6 +17,7 @@ import nanobananaState from '../nanobanana/state';
 import seedreamState from '../seedream/state';
 import seedanceState from '../seedance/state';
 import serpState from '../serp/state';
+import wanState from '../wan/state';
 
 export default (): IRootState => {
   return {
@@ -59,6 +60,7 @@ export default (): IRootState => {
     nanobanana: nanobananaState(),
     seedream: seedreamState(),
     seedance: seedanceState(),
-    serp: serpState()
+    serp: serpState(),
+    wan: wanState()
   };
 };

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -18,6 +18,7 @@ import nanobanana from './nanobanana';
 import seedream from './seedream';
 import seedance from './seedance';
 import serp from './serp';
+import wan from './wan';
 import root from './common';
 import persistChat from './chat/persist';
 import persistMidjourney from './midjourney/persist';
@@ -37,6 +38,7 @@ import persistNanobanana from './nanobanana/persist';
 import persistSeedream from './seedream/persist';
 import persistSeedance from './seedance/persist';
 import persistSerp from './serp/persist';
+import persistWan from './wan/persist';
 import persistRoot from './common/persist';
 
 const store = createStore({
@@ -59,7 +61,8 @@ const store = createStore({
     nanobanana: nanobanana,
     seedream: seedream,
     seedance: seedance,
-    serp: serp
+    serp: serp,
+    wan: wan
   },
   plugins: [
     createPersistedState({
@@ -82,7 +85,8 @@ const store = createStore({
         ...persistNanobanana,
         ...persistSeedream,
         ...persistSeedance,
-        ...persistSerp
+        ...persistSerp,
+        ...persistWan
       ]
     })
   ]

--- a/src/store/wan/actions.ts
+++ b/src/store/wan/actions.ts
@@ -1,0 +1,188 @@
+import { applicationOperator, credentialOperator, wanOperator, serviceOperator } from '@/operators';
+import { IWanState } from './models';
+import { ActionContext } from 'vuex';
+import { IRootState } from '../common/models';
+import { IApplication, ICredential, IWanConfig, IWanTask, IService } from '@/models';
+import { Status } from '@/models/common';
+import { WAN_SERVICE_ID } from '@/constants';
+import { mergeAndSortLists } from '@/utils/merge';
+
+export const resetAll = ({ commit }: ActionContext<IWanState, IRootState>): void => {
+  commit('resetAll');
+};
+
+export const setApplication = async ({ commit, dispatch }: any, payload: IApplication): Promise<void> => {
+  console.debug('set application', payload);
+  commit('setApplication', payload);
+  if (!payload) {
+    console.debug('application is null, return');
+    return;
+  }
+  const credential = payload?.credentials?.find((credential) => credential?.host === window.location.origin);
+  if (credential) {
+    console.debug('credential exists, set credential', credential);
+    commit('setCredential', credential);
+  } else {
+    console.debug('credential not exists, start to create credential for application', payload);
+    await dispatch('createCredential');
+  }
+};
+
+export const setApplications = async ({ commit }: any, payload: IApplication[]): Promise<void> => {
+  console.debug('set applications', payload);
+  commit('setApplications', payload);
+};
+
+export const setService = async ({ commit }: any, payload: IService): Promise<void> => {
+  console.debug('set service', payload);
+  commit('setService', payload);
+};
+
+export const setCredential = async ({ commit }: any, payload: ICredential): Promise<void> => {
+  console.debug('set credential', payload);
+  commit('setCredential', payload);
+};
+
+export const createCredential = async ({ commit, state }: any): Promise<ICredential | undefined> => {
+  const application = state.application;
+  console.debug('prepare to create credential for application', application);
+  if (!application) {
+    console.error('Application not found');
+    return undefined;
+  }
+  console.debug('creating create credential for application', application);
+  const { data: credential } = await credentialOperator.create({
+    application_id: application?.id,
+    host: window.location.origin
+  });
+  console.debug('created credential success', credential);
+  commit('setCredential', credential);
+  console.debug('end createCredential');
+  return credential;
+};
+
+export const getService = async ({
+  commit,
+  state
+}: ActionContext<IWanState, IRootState>): Promise<IService | undefined> => {
+  state.status.getService = Status.Request;
+  try {
+    const { data: service } = await serviceOperator.get(WAN_SERVICE_ID);
+    state.status.getService = Status.Success;
+    commit('setService', service);
+    return service;
+  } catch (error) {
+    state.status.getService = Status.Error;
+    commit('setService', undefined);
+  }
+};
+
+export const getApplications = async ({
+  commit,
+  state,
+  rootState
+}: ActionContext<IWanState, IRootState>): Promise<IApplication[] | undefined> => {
+  console.debug('start to get applications for chat');
+  state.status.getApplications = Status.Request;
+  const currentApplication = state.application;
+  console.debug('current application', currentApplication);
+  try {
+    const { data: applications } = await applicationOperator.getAll({
+      user_id: rootState?.user?.id,
+      service_id: WAN_SERVICE_ID
+    });
+    state.status.getApplications = Status.Success;
+    commit('setApplications', applications.items);
+    return applications.items;
+  } catch (error) {
+    console.error('get applications failed', error);
+    state.status.getApplications = Status.Error;
+    commit('setApplications', undefined);
+    commit('setApplication', undefined);
+  }
+};
+
+export const setConfig = ({ commit }: any, payload: IWanConfig) => {
+  commit('setConfig', payload);
+};
+
+export const setTasks = ({ commit }: any, payload: any) => {
+  commit('setTasks', payload);
+};
+
+export const setTasksItems = ({ commit }: any, payload: IWanTask[]) => {
+  commit('setTasksItems', payload);
+};
+
+export const setTasksTotal = ({ commit }: any, payload: number) => {
+  commit('setTasksTotal', payload);
+};
+
+export const setTasksActive = ({ commit }: any, payload: IWanTask) => {
+  commit('setTasksActive', payload);
+};
+
+export const getTasks = async (
+  { commit, state, rootState }: ActionContext<IWanState, IRootState>,
+  {
+    offset,
+    limit,
+    createdAtMin,
+    createdAtMax
+  }: { offset?: number; limit?: number; createdAtMin?: number; createdAtMax?: number }
+): Promise<IWanTask[]> => {
+  return new Promise((resolve, reject) => {
+    console.debug('start to get tasks', offset, limit);
+    const credential = state.credential;
+    console.debug('current credential', credential);
+    const token = credential?.token;
+    if (!token) {
+      return reject('no token');
+    }
+    wanOperator
+      .tasks(
+        {
+          userId: rootState?.user?.id,
+          createdAtMin,
+          createdAtMax,
+          type: 'videos'
+        },
+        {
+          token
+        }
+      )
+      .then((response) => {
+        console.debug('get videos tasks success', response.data.items);
+        // merge with existing tasks
+        const existingItems = state?.tasks?.items || [];
+        console.debug('existing items', existingItems);
+        const newItems = response.data.items || [];
+        console.debug('new items', newItems);
+        // sort and de-duplicate using created_at
+        const mergedItems = mergeAndSortLists(existingItems, newItems);
+        commit('setTasksItems', mergedItems);
+        commit('setTasksTotal', response.data.count);
+        resolve(response.data.items);
+      })
+      .catch((error) => {
+        return reject(error);
+      });
+  });
+};
+
+export default {
+  setService,
+  getService,
+  resetAll,
+  setCredential,
+  setConfig,
+  setApplication,
+  setApplications,
+  getApplications,
+  setTasks,
+  setTasksItems,
+  setTasksTotal,
+  setTasksActive,
+  getTasks,
+  createCredential
+};

--- a/src/store/wan/index.ts
+++ b/src/store/wan/index.ts
@@ -1,0 +1,14 @@
+import { Module } from 'vuex';
+import { IWanState } from './models';
+import actions from './actions';
+import mutations from './mutations';
+import state from './state';
+
+export const wan: Module<IWanState, any> = {
+  namespaced: true,
+  state,
+  mutations,
+  actions
+};
+
+export default wan;

--- a/src/store/wan/models.ts
+++ b/src/store/wan/models.ts
@@ -1,0 +1,22 @@
+import { IApplication, ICredential, IService, Status } from '@/models';
+import { IWanConfig, IWanTask } from '@/models';
+
+export interface IWanState {
+  application: IApplication | undefined;
+  applications: IApplication[] | undefined;
+  service: IService | undefined;
+  credential: ICredential | undefined;
+  config: IWanConfig | undefined;
+  tasks:
+    | {
+        items: IWanTask[] | undefined;
+        total: number | undefined;
+        active: IWanTask | undefined;
+      }
+    | undefined;
+  status: {
+    getService: Status;
+    getApplications: Status;
+    getTasks: Status;
+  };
+}

--- a/src/store/wan/mutations.ts
+++ b/src/store/wan/mutations.ts
@@ -1,0 +1,68 @@
+import { IApplication, ICredential, IWanConfig, IWanTask, IService } from '@/models';
+import initialState from './state';
+import { IWanState } from './models';
+
+export const resetAll = (state: IWanState): void => {
+  Object.assign(state, initialState());
+};
+
+export const setService = (state: IWanState, payload: IService): void => {
+  state.service = payload;
+};
+
+export const setCredential = (state: IWanState, payload: ICredential): void => {
+  state.credential = payload;
+};
+
+export const setApplication = (state: IWanState, payload: IApplication): void => {
+  state.application = payload;
+};
+
+export const setApplications = (state: IWanState, payload: IApplication[]): void => {
+  state.applications = payload;
+};
+
+export const setConfig = (state: IWanState, payload: IWanConfig): void => {
+  state.config = payload;
+};
+
+export const setTasksItems = (state: IWanState, payload: IWanTask[]): void => {
+  const newPayload = {
+    ...state.tasks,
+    items: payload
+  } as typeof state.tasks;
+  state.tasks = newPayload;
+};
+
+export const setTasksTotal = (state: IWanState, payload: number): void => {
+  const newPayload = {
+    ...state.tasks,
+    total: payload
+  } as typeof state.tasks;
+  state.tasks = newPayload;
+};
+
+export const setTasksActive = (state: IWanState, payload: IWanTask): void => {
+  const newPayload = {
+    ...state.tasks,
+    active: payload
+  } as typeof state.tasks;
+  state.tasks = newPayload;
+};
+
+export const setTasks = (state: IWanState, payload: any): void => {
+  state.tasks = payload;
+};
+
+export default {
+  setTasks,
+  setApplication,
+  setApplications,
+  setConfig,
+  setCredential,
+  setService,
+  setTasksActive,
+  setTasksItems,
+  setTasksTotal,
+  resetAll
+};

--- a/src/store/wan/persist.ts
+++ b/src/store/wan/persist.ts
@@ -1,0 +1,1 @@
+export default ['wan.credential', 'wan.application', 'wan.applications', 'wan.tasks'];

--- a/src/store/wan/state.ts
+++ b/src/store/wan/state.ts
@@ -1,0 +1,18 @@
+import { IWanState } from './models';
+import { Status } from '@/models';
+
+export default (): IWanState => {
+  return {
+    service: undefined,
+    application: undefined,
+    applications: undefined,
+    tasks: undefined,
+    credential: undefined,
+    config: undefined,
+    status: {
+      getService: Status.None,
+      getApplications: Status.None,
+      getTasks: Status.None
+    }
+  };
+};


### PR DESCRIPTION
## Summary
- Add Wan (Tongyi Wanxiang) as a new AI video generation service following the existing hailuo pattern
- Support 4 models: wan2.6-t2v (text-to-video), wan2.6-i2v (image-to-video), wan2.6-i2v-flash (fast image-to-video), wan2.6-r2v (reference video)
- Include model-aware config panel with resolution selector (480P/720P/1080P), duration selector (5/10/15s), and image upload for i2v models

## Changes
- New files: constants, models, operator, store (6 files), router, layout, page, 7 components, i18n (zh-CN + en)
- Modified: constants/index, models/index, operators/index, router/constants, router/index, store/index, constants/i18n (registered wan scope)

## Test plan
- [ ] Verify `/wan` route loads the Wan video generation page
- [ ] Verify model selector shows all 4 models with correct labels
- [ ] Verify resolution/duration/image-url fields show/hide based on selected model
- [ ] Verify video generation request sends correct payload to `/wan/videos`
- [ ] Verify task polling and video preview display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)