### PR TITLE
fix: add Suno v5.5 model to selector dropdown

### DIFF
--- a/change/@acedatacloud-nexior-8fbbe054-4cc0-4172-bcf5-9a6348fc6540.json
+++ b/change/@acedatacloud-nexior-8fbbe054-4cc0-4172-bcf5-9a6348fc6540.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: add Suno v5.5 model to selector dropdown",
+  "packageName": "@acedatacloud/nexior",
+  "email": "cqc@cuiqingcai.com",
+  "dependentChangeType": "patch"
+}

--- a/src/components/suno/ConfigPanel.vue
+++ b/src/components/suno/ConfigPanel.vue
@@ -72,7 +72,7 @@ export default defineComponent({
     },
     supportsVocalGender() {
       const model = this.config?.model || '';
-      return ['chirp-v4-5-plus', 'chirp-v5'].includes(model);
+      return ['chirp-v4-5-plus', 'chirp-v5', 'chirp-v5-5'].includes(model);
     },
     generateButtonText() {
       const action = this.config?.action;

--- a/src/components/suno/config/AdvancedParams.vue
+++ b/src/components/suno/config/AdvancedParams.vue
@@ -84,7 +84,7 @@ export default defineComponent({
     },
     isV5OrAbove() {
       const model = this.config?.model || '';
-      return model === 'chirp-v5';
+      return ['chirp-v5', 'chirp-v5-5'].includes(model);
     },
     styleNegative: {
       get() {

--- a/src/components/suno/config/TypeSelector.vue
+++ b/src/components/suno/config/TypeSelector.vue
@@ -45,6 +45,11 @@ export default defineComponent({
     return {
       options: [
         {
+          label: 'Suno v5.5',
+          value: 'chirp-v5-5',
+          info: '8 min'
+        },
+        {
           label: 'Suno v5',
           value: 'chirp-v5',
           info: '8 min'


### PR DESCRIPTION
## Summary
- Add missing `chirp-v5-5` (Suno v5.5) option to the model selector dropdown in `TypeSelector.vue`
- The default model was `chirp-v5-5` but it wasn't in the options list, causing the input box to display the raw value instead of a human-readable label
- Also include `chirp-v5-5` in v5+ feature checks (`isV5OrAbove`, `supportsVocalGender`)

## Test plan
- [ ] Open hub.acedata.cloud/suno and verify the model selector input box shows "Suno v5.5" instead of "chirp-v5-5"
- [ ] Verify dropdown options list includes "Suno v5.5" at the top
- [ ] Verify advanced params (variation category) appear when v5.5 is selected
- [ ] Verify vocal gender selector appears when v5.5 is selected in custom mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)