### PR TITLE
fix: change Midjourney default version to V7

### DIFF
--- a/change/@acedatacloud-nexior-midjourney-default-v7.json
+++ b/change/@acedatacloud-nexior-midjourney-default-v7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: change Midjourney default version from 6.1 to 7",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/midjourney/config/VersionSelector.vue
+++ b/src/components/midjourney/config/VersionSelector.vue
@@ -11,7 +11,7 @@
 import { defineComponent } from 'vue';
 import { ElSelect, ElOption } from 'element-plus';
 
-const DEFAULT_VERSION = '6.1';
+const DEFAULT_VERSION = '7';
 
 export default defineComponent({
   name: 'VersionSelector',


### PR DESCRIPTION
## Summary
- Change Midjourney default version from 6.1 to 7 in VersionSelector component

## Test plan
- [ ] Open hub.acedata.cloud/midjourney, verify Version dropdown defaults to "7"

🤖 Generated with [Claude Code](https://claude.com/claude-code)