### PR TITLE
feat: add Producer music generation service

### DIFF
--- a/change/@acedatacloud-nexior-add-producer-service.json
+++ b/change/@acedatacloud-nexior-add-producer-service.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add Producer music generation service with FUZZ models",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/producer/ConfigPanel.vue
+++ b/src/components/producer/ConfigPanel.vue
@@ -1,0 +1,115 @@
+<template>
+  <div class="flex flex-col h-full">
+    <div class="flex-1 overflow-y-auto p-5">
+      <type-selector class="mb-4" />
+      <upload-audio class="mb-4" />
+      <prompt-input v-if="!config?.custom" class="mb-4" />
+      <lyric-input v-if="config?.custom && !config.instrumental" class="mb-4" />
+      <style-input v-if="config?.custom" class="mb-4" />
+      <title-input v-if="config?.custom" class="mb-4" />
+      <vocal-gender-selector v-if="config?.custom && !config.instrumental" class="mb-4" />
+      <extend-from-input v-if="config?.action === 'extend'" class="mb-4" />
+      <cover-from-input v-if="config?.action === 'cover'" class="mb-4" />
+      <replace-section-input v-if="config?.action === 'replace_section'" class="mb-4" />
+      <advanced-params class="mb-4" />
+    </div>
+    <div class="flex flex-col items-center justify-center px-5 pb-5">
+      <consumption :value="consumption" :service="service" />
+      <el-button type="primary" class="btn w-full" round @click="onGenerate">
+        <font-awesome-icon icon="fa-solid fa-magic" class="mr-2" />
+        {{ generateButtonText }}
+      </el-button>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElButton } from 'element-plus';
+import TypeSelector from './config/TypeSelector.vue';
+import UploadAudio from './config/UploadAudio.vue';
+import PromptInput from './config/PromptInput.vue';
+import LyricInput from './config/LyricInput.vue';
+import StyleInput from './config/StyleInput.vue';
+import TitleInput from './config/TitleInput.vue';
+import ExtendFromInput from './config/ExtendFromInput.vue';
+import CoverFromInput from './config/CoverFromInput.vue';
+import VocalGenderSelector from './config/VocalGenderSelector.vue';
+import AdvancedParams from './config/AdvancedParams.vue';
+import ReplaceSectionInput from './config/ReplaceSectionInput.vue';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import Consumption from '../common/Consumption.vue';
+import { getConsumption } from '@/utils';
+
+export default defineComponent({
+  name: 'PresetPanel',
+  components: {
+    TypeSelector,
+    PromptInput,
+    LyricInput,
+    StyleInput,
+    TitleInput,
+    ExtendFromInput,
+    CoverFromInput,
+    UploadAudio,
+    VocalGenderSelector,
+    AdvancedParams,
+    ReplaceSectionInput,
+    FontAwesomeIcon,
+    ElButton,
+    Consumption
+  },
+  emits: ['generate'],
+  computed: {
+    config() {
+      return this.$store.state.producer?.config;
+    },
+    consumption() {
+      return getConsumption(this.config, this.service?.cost);
+    },
+    service() {
+      return this.$store.state.producer?.service;
+    },
+    generateButtonText() {
+      const action = this.config?.action;
+      if (action === 'extend') return this.$t('producer.button.extend');
+      if (action === 'cover') return this.$t('producer.button.cover_music');
+      if (action === 'variation') return this.$t('producer.button.variation');
+      if (action === 'replace_section') return this.$t('producer.button.replace_section');
+      if (action === 'stems') return this.$t('producer.button.get_stems');
+      if (action === 'swap_vocals') return this.$t('producer.button.swap_vocals');
+      if (action === 'swap_instrumentals') return this.$t('producer.button.swap_instrumentals');
+      return this.$t('producer.button.generate');
+    }
+  },
+  methods: {
+    onGenerate() {
+      this.$emit('generate');
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.panel {
+  height: 100%;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  .config {
+    width: 100%;
+    height: calc(100% - 50px);
+    flex: 1;
+    position: relative;
+  }
+  .actions {
+    height: 50px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    .btn {
+      width: 100%;
+    }
+  }
+}
+</style>

--- a/src/components/producer/PreviewPanel.vue
+++ b/src/components/producer/PreviewPanel.vue
@@ -1,0 +1,51 @@
+<template>
+  <div v-if="audio?.object" class="size-full overflow-hidden">
+    <div class="relative h-[300px]">
+      <el-image :src="audio.image_url" fit="cover" class="size-full">
+        <template #error>
+          <div class="flex items-center justify-center size-full bg-[var(--el-bg-color)]">
+            <el-icon class="text-3xl"><icon-picture /></el-icon>
+          </div>
+        </template>
+      </el-image>
+      <h2
+        class="absolute bottom-0 left-0 right-0 m-0 p-4 text-white z-10 bg-gradient-to-t from-black/70 to-transparent"
+      >
+        {{ audio?.title }}
+      </h2>
+    </div>
+    <div class="p-4">
+      <div class="flex items-center font-bold mb-2">
+        <el-avatar :size="30" :src="audio?.image_url" class="mr-2"></el-avatar>
+        <span>{{ audio?.title }}</span>
+      </div>
+      <p class="text-[var(--el-text-color-regular)] mb-2">{{ audio?.style }}</p>
+      <p class="text-xs text-[var(--el-text-color-regular)]">{{ $dayjs.format(audio?.created_at) }}</p>
+      <div class="mt-4 text-sm leading-[25px] whitespace-pre-wrap">
+        <p>{{ audio?.lyric }}</p>
+      </div>
+    </div>
+  </div>
+  <div v-else class="w-full h-full"></div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElImage, ElAvatar, ElIcon } from 'element-plus';
+import { Picture as IconPicture } from '@element-plus/icons-vue';
+
+export default defineComponent({
+  name: 'TaskPreview',
+  components: {
+    IconPicture,
+    ElImage,
+    ElAvatar,
+    ElIcon
+  },
+  computed: {
+    audio() {
+      return this.$store.state.producer?.audio;
+    }
+  }
+});
+</script>

--- a/src/components/producer/RecentPanel.vue
+++ b/src/components/producer/RecentPanel.vue
@@ -1,0 +1,83 @@
+<template>
+  <div v-if="tasks?.items === undefined" class="tasks">
+    <div v-for="_ in 3" :key="_" class="flex">
+      <div class="left w-[70px] p-[10px] flex items-center">
+        <el-skeleton animated>
+          <template #template>
+            <el-skeleton-item variant="image" class="avatar w-[50px] h-[50px]" />
+          </template>
+        </el-skeleton>
+      </div>
+      <div class="main w-[calc(100%-70px)] flex-1 p-[10px]">
+        <el-skeleton animated>
+          <template #template>
+            <el-skeleton-item variant="p" class="w-[200px] h-[15px] mb-[5px] mt-[10px]" />
+            <el-skeleton-item variant="text" />
+          </template>
+        </el-skeleton>
+      </div>
+    </div>
+  </div>
+  <scroll-list
+    v-else-if="tasks?.items?.length && tasks?.items?.length > 0"
+    ref="scrollList"
+    class="flex-1 w-full overflow-y-auto tasks p-2"
+    :loading="loading"
+    @reach-top="$emit('reach-top')"
+  >
+    <task-preview v-for="(task, taskId) in tasks?.items" :key="taskId" :model-value="task" class="preview" />
+  </scroll-list>
+  <div v-if="tasks?.items?.length === 0" class="w-full flex-1 flex items-center justify-center">
+    <no-tasks />
+  </div>
+  <div v-show="!!$store?.state?.producer?.audio?.object" class="h-20">
+    <player />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import TaskPreview from './task/Preview.vue';
+import Player from '@/components/producer/player/Player.vue';
+import NoTasks from '@/components/common/NoTasks.vue';
+import { ElSkeleton, ElSkeletonItem } from 'element-plus';
+import ScrollList from '@/components/common/ScrollList.vue';
+
+export default defineComponent({
+  name: 'RecentPanel',
+  components: {
+    ElSkeletonItem,
+    ElSkeleton,
+    TaskPreview,
+    Player,
+    NoTasks,
+    ScrollList
+  },
+  props: {
+    loading: {
+      type: Boolean,
+      default: false
+    }
+  },
+  emits: ['reach-top'],
+  data() {
+    return {
+      job: 0
+    };
+  },
+  computed: {
+    tasks() {
+      return {
+        ...this.$store.state.producer?.tasks,
+        items: this.$store.state.producer?.tasks?.items?.slice()
+      };
+    }
+  },
+  methods: {
+    getScrollElement(): HTMLElement | undefined {
+      const list = this.$refs.scrollList as any;
+      return list?.getScrollElement?.();
+    }
+  }
+});
+</script>

--- a/src/components/producer/config/AdvancedParams.vue
+++ b/src/components/producer/config/AdvancedParams.vue
@@ -1,0 +1,176 @@
+<template>
+  <el-collapse v-model="activeNames" class="advanced-collapse">
+    <el-collapse-item :title="$t('producer.name.advancedParams')" name="advanced">
+      <!-- Style Negative -->
+      <div v-if="config?.custom" class="mb-3">
+        <div class="flex items-center mb-1">
+          <span class="text-xs font-bold">{{ $t('producer.name.styleNegative') }}</span>
+        </div>
+        <el-input v-model="styleNegative" size="small" :placeholder="$t('producer.placeholder.styleNegative')" />
+      </div>
+
+      <!-- Lyric Prompt (auto-generate lyrics) -->
+      <div v-if="config?.custom && !config?.instrumental" class="mb-3">
+        <div class="flex items-center mb-1">
+          <span class="text-xs font-bold">{{ $t('producer.name.lyricPrompt') }}</span>
+        </div>
+        <el-input v-model="lyricPrompt" size="small" :placeholder="$t('producer.placeholder.lyricPrompt')" />
+      </div>
+
+      <!-- Weirdness -->
+      <div v-if="config?.custom" class="mb-3">
+        <div class="flex items-center justify-between mb-1">
+          <span class="text-xs font-bold">{{ $t('producer.name.weirdness') }}</span>
+          <span class="text-xs text-[var(--el-text-color-secondary)]">{{ weirdness ?? 0 }}</span>
+        </div>
+        <el-slider v-model="weirdness" :min="0" :max="100" :step="1" size="small" />
+      </div>
+
+      <!-- Sound Strength -->
+      <div v-if="config?.custom" class="mb-3">
+        <div class="flex items-center justify-between mb-1">
+          <span class="text-xs font-bold">{{ $t('producer.name.soundStrength') }}</span>
+          <span class="text-xs text-[var(--el-text-color-secondary)]">{{ soundStrength ?? 50 }}</span>
+        </div>
+        <el-slider v-model="soundStrength" :min="0" :max="100" :step="1" size="small" />
+      </div>
+
+      <!-- Lyrics Strength -->
+      <div v-if="config?.custom && !config?.instrumental" class="mb-3">
+        <div class="flex items-center justify-between mb-1">
+          <span class="text-xs font-bold">{{ $t('producer.name.lyricsStrength') }}</span>
+          <span class="text-xs text-[var(--el-text-color-secondary)]">{{ lyricsStrength ?? 50 }}</span>
+        </div>
+        <el-slider v-model="lyricsStrength" :min="0" :max="100" :step="1" size="small" />
+      </div>
+
+      <!-- Seed -->
+      <div v-if="config?.custom" class="mb-3">
+        <div class="flex items-center mb-1">
+          <span class="text-xs font-bold">{{ $t('producer.name.seed') }}</span>
+        </div>
+        <el-input-number
+          v-model="seed"
+          size="small"
+          :min="0"
+          :controls="false"
+          :placeholder="$t('producer.placeholder.seed')"
+          class="w-full"
+        />
+      </div>
+    </el-collapse-item>
+  </el-collapse>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElCollapse, ElCollapseItem, ElInput, ElSlider, ElInputNumber } from 'element-plus';
+
+export default defineComponent({
+  name: 'AdvancedParams',
+  components: {
+    ElCollapse,
+    ElCollapseItem,
+    ElInput,
+    ElSlider,
+    ElInputNumber
+  },
+  data() {
+    return {
+      activeNames: [] as string[]
+    };
+  },
+  computed: {
+    config() {
+      return this.$store.state.producer?.config;
+    },
+    styleNegative: {
+      get() {
+        return this.$store.state.producer?.config?.style_negative || '';
+      },
+      set(val: string) {
+        this.$store.commit('producer/setConfig', {
+          ...this.$store.state.producer?.config,
+          style_negative: val || undefined
+        });
+      }
+    },
+    lyricPrompt: {
+      get() {
+        return this.$store.state.producer?.config?.lyric_prompt || '';
+      },
+      set(val: string) {
+        this.$store.commit('producer/setConfig', {
+          ...this.$store.state.producer?.config,
+          lyric_prompt: val || undefined
+        });
+      }
+    },
+    weirdness: {
+      get() {
+        return this.$store.state.producer?.config?.weirdness ?? 0;
+      },
+      set(val: number) {
+        this.$store.commit('producer/setConfig', {
+          ...this.$store.state.producer?.config,
+          weirdness: val || undefined
+        });
+      }
+    },
+    soundStrength: {
+      get() {
+        return this.$store.state.producer?.config?.sound_strength ?? 50;
+      },
+      set(val: number) {
+        this.$store.commit('producer/setConfig', {
+          ...this.$store.state.producer?.config,
+          sound_strength: val
+        });
+      }
+    },
+    lyricsStrength: {
+      get() {
+        return this.$store.state.producer?.config?.lyrics_strength ?? 50;
+      },
+      set(val: number) {
+        this.$store.commit('producer/setConfig', {
+          ...this.$store.state.producer?.config,
+          lyrics_strength: val
+        });
+      }
+    },
+    seed: {
+      get() {
+        return this.$store.state.producer?.config?.seed;
+      },
+      set(val: number | undefined) {
+        this.$store.commit('producer/setConfig', {
+          ...this.$store.state.producer?.config,
+          seed: val
+        });
+      }
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.advanced-collapse {
+  border: none;
+  :deep(.el-collapse-item__header) {
+    font-size: 14px;
+    font-weight: bold;
+    background: transparent;
+    border: none;
+    height: 32px;
+    line-height: 32px;
+  }
+  :deep(.el-collapse-item__wrap) {
+    background: transparent;
+    border: none;
+  }
+  :deep(.el-collapse-item__content) {
+    padding-bottom: 0;
+  }
+}
+</style>

--- a/src/components/producer/config/CoverFromInput.vue
+++ b/src/components/producer/config/CoverFromInput.vue
@@ -1,0 +1,146 @@
+<template>
+  <div class="field">
+    <div class="box">
+      <h2 class="title font-bold">{{ $t('producer.name.cover') }}</h2>
+    </div>
+    <div class="task">
+      <div v-if="audio" class="audio" @click="onClick(audio)">
+        <div v-loading="!audio?.audio_url" class="left">
+          <el-image :src="audio?.image_url" class="cover" fit="cover" />
+          <div
+            v-if="
+              audio?.audio_url &&
+              $store.state?.producer?.audio?.id === audio.id &&
+              $store.state?.producer?.audio?.state === 'playing'
+            "
+            class="overlay"
+            @click="onPause(audio)"
+          >
+            <el-icon><video-pause /></el-icon>
+          </div>
+          <div
+            v-if="
+              audio?.audio_url &&
+              ($store.state?.producer?.audio?.id !== audio.id ||
+                ($store.state?.producer?.audio?.id === audio.id && $store.state?.producer?.audio?.state === 'paused'))
+            "
+            class="overlay"
+            @click="onPlay(audio)"
+          >
+            <el-icon><video-play /></el-icon>
+          </div>
+          <div v-if="audio?.duration" class="duration">
+            {{ useFormatDuring(audio?.duration) }}
+          </div>
+        </div>
+        <div class="info">
+          <h2 class="title">{{ audio?.title }}</h2>
+          <p class="style">{{ audio?.style }}</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { useFormatDuring } from '@/utils/number';
+import { IProducerAudio } from '@/models';
+import { ElImage, ElIcon } from 'element-plus';
+import { VideoPlay, VideoPause } from '@element-plus/icons-vue';
+
+export default defineComponent({
+  name: 'CoverFromInput',
+  components: {
+    ElImage,
+    ElIcon,
+    VideoPlay,
+    VideoPause
+  },
+  data() {
+    return {};
+  },
+  computed: {
+    // @ts-ignore
+    audio() {
+      // @ts-ignore
+      return this.$store.state.producer?.config?.audio;
+    },
+    value: {
+      get() {
+        return this.$store.state.producer?.config?.continue_at;
+      },
+      set(val: string) {
+        console.debug('set continue_at', val);
+        this.$store.commit('producer/setConfig', {
+          ...this.$store.state.producer?.config,
+          continue_at: val ? parseInt(val) : undefined
+        });
+      }
+    }
+  },
+  mounted() {
+    if (!this.value) {
+      this.value = undefined;
+    }
+  },
+  methods: {
+    handleChange(val: number) {
+      if (val < 0) {
+        this.value = 0;
+        // @ts-ignore
+      } else if (val > this.audio?.duration) {
+        this.value = this.audio?.duration;
+      } else {
+        this.value = val;
+      }
+    },
+    useFormatDuring,
+    onPlay(audio: IProducerAudio) {
+      this.$store.dispatch('producer/setAudio', {
+        ...this.$store.state.producer.audio,
+        ...audio,
+        state: 'playing'
+      });
+      console.log('on play');
+    },
+    onPause(audio: IProducerAudio) {
+      this.$store.dispatch('producer/setAudio', {
+        ...this.$store.state.producer.audio,
+        ...audio,
+        state: 'paused'
+      });
+      console.log('on pause');
+    },
+    onClick(audio: IProducerAudio) {
+      if (this.$store.state?.producer?.audio?.id !== audio.id) {
+        this.onPlay({
+          ...audio,
+          progress: 0
+        });
+      }
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.field {
+  .box {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    position: relative;
+    margin-bottom: 10px;
+    .title {
+      font-size: 14px;
+      margin-bottom: 10px;
+    }
+    .input-wrapper {
+      width: 150px;
+      margin-left: 30px;
+    }
+  }
+}
+</style>

--- a/src/components/producer/config/ExtendFromInput.vue
+++ b/src/components/producer/config/ExtendFromInput.vue
@@ -1,0 +1,162 @@
+<template>
+  <div class="field">
+    <div class="box">
+      <h2 class="title font-bold">{{ $t('producer.name.extend') }}</h2>
+      <div class="input-wrapper">
+        <el-input-number
+          v-model="value"
+          class="value"
+          :min="0"
+          :max="audio?.duration"
+          :controls="false"
+          :placeholder="$t('producer.placeholder.extend.continue_at')"
+          @change="handleChange"
+        />
+      </div>
+    </div>
+    <div class="task">
+      <div v-if="audio" class="audio" @click="onClick(audio)">
+        <div v-loading="!audio?.audio_url" class="left">
+          <el-image :src="audio?.image_url" class="cover" fit="cover" />
+          <div
+            v-if="
+              audio?.audio_url &&
+              $store.state?.producer?.audio?.id === audio.id &&
+              $store.state?.producer?.audio?.state === 'playing'
+            "
+            class="overlay"
+            @click="onPause(audio)"
+          >
+            <el-icon><video-pause /></el-icon>
+          </div>
+          <div
+            v-if="
+              audio?.audio_url &&
+              ($store.state?.producer?.audio?.id !== audio.id ||
+                ($store.state?.producer?.audio?.id === audio.id && $store.state?.producer?.audio?.state === 'paused'))
+            "
+            class="overlay"
+            @click="onPlay(audio)"
+          >
+            <el-icon><video-play /></el-icon>
+          </div>
+          <div v-if="audio?.duration" class="duration">
+            {{ useFormatDuring(audio?.duration) }}
+          </div>
+        </div>
+        <div class="info">
+          <h2 class="title">{{ audio?.title }}</h2>
+          <p class="style">{{ audio?.style }}</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { useFormatDuring } from '@/utils/number';
+import { IProducerAudio } from '@/models';
+import { ElImage, ElIcon, ElInputNumber } from 'element-plus';
+import { VideoPlay, VideoPause } from '@element-plus/icons-vue';
+
+export default defineComponent({
+  name: 'ExtendFromInput',
+  components: {
+    ElImage,
+    ElIcon,
+    ElInputNumber,
+    VideoPlay,
+    VideoPause
+  },
+  data() {
+    return {};
+  },
+  computed: {
+    // @ts-ignore
+    audio() {
+      // @ts-ignore
+      return this.$store.state.producer?.config?.audio;
+    },
+    value: {
+      get() {
+        return this.$store.state.producer?.config?.continue_at;
+      },
+      set(val: string) {
+        console.debug('set continue_at', val);
+        this.$store.commit('producer/setConfig', {
+          ...this.$store.state.producer?.config,
+          continue_at: val ? parseInt(val) : undefined
+        });
+      }
+    }
+  },
+  mounted() {
+    if (!this.value) {
+      this.value = undefined;
+    }
+  },
+  methods: {
+    handleChange(val: number | undefined) {
+      if (val === undefined) {
+        this.value = undefined;
+        return;
+      }
+      if (val < 0) {
+        this.value = 0;
+        // @ts-ignore
+      } else if (val > this.audio?.duration) {
+        this.value = this.audio?.duration;
+      } else {
+        this.value = val;
+      }
+    },
+    useFormatDuring,
+    onPlay(audio: IProducerAudio) {
+      this.$store.dispatch('producer/setAudio', {
+        ...this.$store.state.producer.audio,
+        ...audio,
+        state: 'playing'
+      });
+      console.log('on play');
+    },
+    onPause(audio: IProducerAudio) {
+      this.$store.dispatch('producer/setAudio', {
+        ...this.$store.state.producer.audio,
+        ...audio,
+        state: 'paused'
+      });
+      console.log('on pause');
+    },
+    onClick(audio: IProducerAudio) {
+      if (this.$store.state?.producer?.audio?.id !== audio.id) {
+        this.onPlay({
+          ...audio,
+          progress: 0
+        });
+      }
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.field {
+  .box {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    position: relative;
+    margin-bottom: 10px;
+    .title {
+      font-size: 14px;
+      margin-bottom: 10px;
+    }
+    .input-wrapper {
+      width: 150px;
+      margin-left: 30px;
+    }
+  }
+}
+</style>

--- a/src/components/producer/config/LyricInput.vue
+++ b/src/components/producer/config/LyricInput.vue
@@ -1,0 +1,124 @@
+<template>
+  <div class="field">
+    <div class="flex items-center justify-between mb-1">
+      <div class="flex items-center">
+        <span class="text-sm font-bold">{{ $t('producer.name.lyrics') }}</span>
+        <info-icon :content="$t('producer.description.lyrics')" />
+      </div>
+      <el-button
+        v-if="config?.action !== 'extend'"
+        size="small"
+        :loading="generatingLyrics"
+        round
+        @click="onGenerateLyrics"
+      >
+        <font-awesome-icon v-if="!generatingLyrics" icon="fa-solid fa-wand-magic-sparkles" class="mr-1" />
+        {{ $t('producer.button.generate_lyrics') }}
+      </el-button>
+    </div>
+    <el-input
+      v-if="config?.action !== 'extend'"
+      v-model="lyric"
+      :rows="5"
+      type="textarea"
+      class="lyrics"
+      :placeholder="$t('producer.placeholder.lyrics')"
+    />
+    <el-input
+      v-else
+      v-model="lyric"
+      :rows="5"
+      type="textarea"
+      class="lyrics"
+      :placeholder="$t('producer.placeholder.extend.lyrics')"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElInput, ElButton, ElMessage } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+import { producerOperator } from '@/operators';
+
+export const DEFAULT_LYRIC = '';
+
+export default defineComponent({
+  name: 'LyricInput',
+  components: {
+    ElInput,
+    ElButton,
+    FontAwesomeIcon,
+    InfoIcon
+  },
+  data() {
+    return {
+      generatingLyrics: false
+    };
+  },
+  computed: {
+    lyric: {
+      get() {
+        return this.$store.state.producer?.config?.lyric;
+      },
+      set(val: string) {
+        this.$store.commit('producer/setConfig', {
+          ...this.$store.state.producer?.config,
+          lyric: val
+        });
+      }
+    },
+    config() {
+      return this.$store.state.producer?.config;
+    },
+    credential() {
+      return this.$store.state.producer?.credential;
+    }
+  },
+  mounted() {
+    if (!this.lyric) {
+      this.lyric = DEFAULT_LYRIC;
+    }
+  },
+  methods: {
+    async onGenerateLyrics() {
+      const token = this.credential?.token;
+      if (!token) return;
+
+      const prompt = this.config?.style || this.config?.title || 'a beautiful song';
+      this.generatingLyrics = true;
+      ElMessage.info(this.$t('producer.message.generatingLyrics'));
+
+      try {
+        const response = await producerOperator.lyric({ prompt }, { token });
+        const data = response.data?.data;
+        if (data?.text) {
+          this.lyric = data.text;
+          if (data?.title && !this.config?.title) {
+            this.$store.commit('producer/setConfig', {
+              ...this.$store.state.producer?.config,
+              lyric: data.text,
+              title: data.title
+            });
+          }
+          ElMessage.success(this.$t('producer.message.generateLyricsSuccess'));
+        }
+      } catch {
+        ElMessage.error(this.$t('producer.message.generateLyricsFailed'));
+      } finally {
+        this.generatingLyrics = false;
+      }
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.field {
+  :deep(.el-textarea__inner) {
+    font-family: monospace;
+    line-height: 1.6;
+  }
+}
+</style>

--- a/src/components/producer/config/PromptInput.vue
+++ b/src/components/producer/config/PromptInput.vue
@@ -1,0 +1,43 @@
+<template>
+  <div class="field">
+    <div class="flex items-center mb-1">
+      <span class="text-sm font-bold">{{ $t('producer.name.songDescription') }}</span>
+      <info-icon :content="$t('producer.description.prompt')" />
+    </div>
+    <el-input v-model="prompt" :rows="4" type="textarea" :placeholder="$t('producer.placeholder.prompt')" />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElInput } from 'element-plus';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+
+export const DEFAULT_PROMPT = '';
+
+export default defineComponent({
+  name: 'PromptInput',
+  components: {
+    ElInput,
+    InfoIcon
+  },
+  computed: {
+    prompt: {
+      get() {
+        return this.$store.state.producer?.config?.prompt;
+      },
+      set(val: string) {
+        this.$store.commit('producer/setConfig', {
+          ...this.$store.state.producer?.config,
+          prompt: val
+        });
+      }
+    }
+  },
+  mounted() {
+    if (!this.prompt) {
+      this.prompt = DEFAULT_PROMPT;
+    }
+  }
+});
+</script>

--- a/src/components/producer/config/ReplaceSectionInput.vue
+++ b/src/components/producer/config/ReplaceSectionInput.vue
@@ -1,0 +1,91 @@
+<template>
+  <div class="field">
+    <div class="flex items-center mb-2">
+      <h2 class="text-sm font-bold m-0">{{ $t('producer.name.replaceSection') }}</h2>
+      <info-icon :content="$t('producer.description.replaceSection')" />
+    </div>
+    <div v-if="audio" class="task mb-2">
+      <div class="audio flex items-center" @click="onClick(audio)">
+        <div v-loading="!audio?.audio_url" class="left relative w-[50px] h-[50px] mr-3 flex-shrink-0">
+          <el-image :src="audio?.image_url" class="w-full h-full rounded" fit="cover" />
+        </div>
+        <div class="info flex-1 min-w-0">
+          <h2 class="text-sm font-bold m-0 truncate">{{ audio?.title }}</h2>
+          <p class="text-xs text-[var(--el-text-color-secondary)] m-0 truncate">{{ audio?.style }}</p>
+        </div>
+      </div>
+    </div>
+    <div class="flex gap-2">
+      <el-input-number
+        v-model="replaceSectionStart"
+        class="flex-1"
+        size="small"
+        :min="0"
+        :max="audio?.duration"
+        :controls="false"
+        :placeholder="$t('producer.placeholder.replaceSectionStart')"
+      />
+      <el-input-number
+        v-model="replaceSectionEnd"
+        class="flex-1"
+        size="small"
+        :min="replaceSectionStart || 0"
+        :max="audio?.duration"
+        :controls="false"
+        :placeholder="$t('producer.placeholder.replaceSectionEnd')"
+      />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElInputNumber, ElImage } from 'element-plus';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+import { IProducerAudio } from '@/models';
+
+export default defineComponent({
+  name: 'ReplaceSectionInput',
+  components: {
+    ElInputNumber,
+    ElImage,
+    InfoIcon
+  },
+  computed: {
+    audio(): IProducerAudio | undefined {
+      return this.$store.state.producer?.config?.audio;
+    },
+    replaceSectionStart: {
+      get() {
+        return this.$store.state.producer?.config?.replace_section_start;
+      },
+      set(val: number | undefined) {
+        this.$store.commit('producer/setConfig', {
+          ...this.$store.state.producer?.config,
+          replace_section_start: val
+        });
+      }
+    },
+    replaceSectionEnd: {
+      get() {
+        return this.$store.state.producer?.config?.replace_section_end;
+      },
+      set(val: number | undefined) {
+        this.$store.commit('producer/setConfig', {
+          ...this.$store.state.producer?.config,
+          replace_section_end: val
+        });
+      }
+    }
+  },
+  methods: {
+    onClick(audio: IProducerAudio) {
+      this.$store.dispatch('producer/setAudio', {
+        ...this.$store.state.producer.audio,
+        ...audio,
+        state: 'playing'
+      });
+    }
+  }
+});
+</script>

--- a/src/components/producer/config/StyleInput.vue
+++ b/src/components/producer/config/StyleInput.vue
@@ -1,0 +1,38 @@
+<template>
+  <div class="field">
+    <div class="flex items-center justify-between mb-1">
+      <div class="flex items-center">
+        <span class="text-sm font-bold">{{ $t('producer.name.style') }}</span>
+        <info-icon :content="$t('producer.description.style')" />
+      </div>
+    </div>
+    <el-input v-model="style" :rows="2" type="textarea" :placeholder="$t('producer.placeholder.style')" />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElInput } from 'element-plus';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+
+export default defineComponent({
+  name: 'StyleInput',
+  components: {
+    ElInput,
+    InfoIcon
+  },
+  computed: {
+    style: {
+      get() {
+        return this.$store.state.producer?.config?.style;
+      },
+      set(val: string) {
+        this.$store.commit('producer/setConfig', {
+          ...this.$store.state.producer?.config,
+          style: val
+        });
+      }
+    }
+  }
+});
+</script>

--- a/src/components/producer/config/TitleInput.vue
+++ b/src/components/producer/config/TitleInput.vue
@@ -1,0 +1,36 @@
+<template>
+  <div class="field">
+    <div class="flex items-center mb-1">
+      <span class="text-sm font-bold">{{ $t('producer.name.title') }}</span>
+      <info-icon :content="$t('producer.description.title')" />
+    </div>
+    <el-input v-model="title" :placeholder="$t('producer.placeholder.title')" />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElInput } from 'element-plus';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+
+export default defineComponent({
+  name: 'TitleInput',
+  components: {
+    ElInput,
+    InfoIcon
+  },
+  computed: {
+    title: {
+      get() {
+        return this.$store.state.producer?.config?.title;
+      },
+      set(val: string) {
+        this.$store.commit('producer/setConfig', {
+          ...this.$store.state.producer?.config,
+          title: val
+        });
+      }
+    }
+  }
+});
+</script>

--- a/src/components/producer/config/TypeSelector.vue
+++ b/src/components/producer/config/TypeSelector.vue
@@ -1,0 +1,131 @@
+<template>
+  <div>
+    <!-- Custom Mode Toggle -->
+    <div class="flex items-center justify-between mb-3">
+      <span class="text-sm font-bold">{{ $t('producer.name.type') }}</span>
+      <el-switch v-model="custom" size="small" />
+    </div>
+
+    <!-- Model Selection -->
+    <div class="mb-3">
+      <div class="flex items-center mb-1">
+        <span class="text-sm font-bold">{{ $t('producer.name.model') }}</span>
+      </div>
+      <el-select v-model="model" class="w-full" size="default" :placeholder="$t('producer.placeholder.select')">
+        <el-option v-for="item in options" :key="item.value" :label="item.label" :value="item.value">
+          <div class="flex items-center justify-between w-full">
+            <span>{{ item.label }}</span>
+            <span class="text-xs text-[var(--el-text-color-placeholder)]">{{ item.info }}</span>
+          </div>
+        </el-option>
+      </el-select>
+    </div>
+
+    <!-- Song Description / Instrumental Toggle -->
+    <div v-if="custom" class="flex items-center justify-between mb-3">
+      <span class="text-sm font-bold">{{ $t('producer.name.instrumental') }}</span>
+      <el-switch v-model="instrumental" size="small" />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElSelect, ElOption, ElSwitch } from 'element-plus';
+import { PRODUCER_DEFAULT_MODEL } from '@/constants';
+
+export default defineComponent({
+  name: 'TypeSelector',
+  components: {
+    ElSelect,
+    ElOption,
+    ElSwitch
+  },
+  data() {
+    return {
+      options: [
+        {
+          label: 'FUZZ-2.0 Pro',
+          value: 'FUZZ-2.0 Pro',
+          info: '8 min'
+        },
+        {
+          label: 'FUZZ-2.0',
+          value: 'FUZZ-2.0',
+          info: '8 min'
+        },
+        {
+          label: 'FUZZ-2.0 Raw',
+          value: 'FUZZ-2.0 Raw',
+          info: '8 min'
+        },
+        {
+          label: 'FUZZ-1.1 Pro',
+          value: 'FUZZ-1.1 Pro',
+          info: '4 min'
+        },
+        {
+          label: 'FUZZ-1.0 Pro',
+          value: 'FUZZ-1.0 Pro',
+          info: '4 min'
+        },
+        {
+          label: 'FUZZ-1.1',
+          value: 'FUZZ-1.1',
+          info: '4 min'
+        },
+        {
+          label: 'FUZZ-1.0',
+          value: 'FUZZ-1.0',
+          info: '2 min'
+        },
+        {
+          label: 'FUZZ-0.8',
+          value: 'FUZZ-0.8',
+          info: '2 min'
+        }
+      ]
+    };
+  },
+  computed: {
+    custom: {
+      get() {
+        return this.$store.state.producer?.config?.custom || false;
+      },
+      set(val: boolean) {
+        this.$store.commit('producer/setConfig', {
+          ...this.$store.state.producer?.config,
+          custom: val
+        });
+      }
+    },
+    instrumental: {
+      get() {
+        return this.$store.state.producer?.config?.instrumental || false;
+      },
+      set(val: boolean) {
+        this.$store.commit('producer/setConfig', {
+          ...this.$store.state.producer?.config,
+          instrumental: val
+        });
+      }
+    },
+    model: {
+      get() {
+        return this.$store.state.producer?.config?.model;
+      },
+      set(val: string) {
+        this.$store.commit('producer/setConfig', {
+          ...this.$store.state.producer?.config,
+          model: val
+        });
+      }
+    }
+  },
+  mounted() {
+    if (!this.model) {
+      this.model = PRODUCER_DEFAULT_MODEL;
+    }
+  }
+});
+</script>

--- a/src/components/producer/config/UploadAudio.vue
+++ b/src/components/producer/config/UploadAudio.vue
@@ -1,0 +1,162 @@
+<template>
+  <div class="relative">
+    <div class="flex justify-between">
+      <div class="flex justify-start items-center">
+        <span class="text-sm font-bold">{{ $t('producer.name.referenceAudios') }}</span>
+        <info-icon :content="$t('producer.description.uploadAudios')" />
+      </div>
+    </div>
+    <el-upload
+      v-model:file-list="fileList"
+      name="file"
+      :limit="1"
+      class="upload-wrapper"
+      :action="uploadUrl"
+      accept=".mp3"
+      :show-file-list="true"
+      :on-exceed="onExceed"
+      :on-error="onError"
+      :on-success="onSuccess"
+      :headers="headers"
+    >
+      <el-button round type="primary" size="small" class="btn btn-upload">
+        <font-awesome-icon icon="fa-solid fa-upload" class="icon mr-1" />
+        {{ $t('producer.button.uploadAudios') }}
+      </el-button>
+    </el-upload>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElUpload, ElButton, UploadFiles, UploadFile, ElMessage } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { getBaseUrlPlatform } from '@/utils';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+import { IProducerUploadRequest } from '@/models';
+import { producerOperator } from '@/operators';
+interface IData {
+  fileList: UploadFiles;
+  uploadUrl: string;
+}
+
+export default defineComponent({
+  name: 'UploadAudio',
+  components: {
+    ElUpload,
+    ElButton,
+    InfoIcon,
+    FontAwesomeIcon
+  },
+  emits: ['change'],
+  data(): IData {
+    return {
+      fileList: [],
+      uploadUrl: getBaseUrlPlatform() + '/api/v1/files/'
+    };
+  },
+  computed: {
+    headers() {
+      return {
+        Authorization: `Bearer ${this.$store.state.token.access}`
+      };
+    },
+    credential() {
+      return this.$store.state.producer.credential;
+    },
+    config() {
+      return this.$store.state.producer.config;
+    },
+    urls() {
+      // @ts-ignore
+      return this.fileList.map((file: UploadFile) => file?.response?.file_url);
+    },
+    value: {
+      get() {
+        return this.$store.state.producer?.config?.audio_id;
+      },
+      set() {}
+    }
+  },
+  watch: {
+    urls: {
+      handler(val) {
+        this.$emit('change', val);
+      }
+    }
+  },
+  mounted() {
+    if (!this.value) {
+      this.value = undefined;
+    }
+    this.onSetAudio();
+  },
+  methods: {
+    onExceed() {
+      ElMessage.warning(this.$t('producer.message.uploadReferencesExceed'));
+    },
+    onError() {
+      ElMessage.error(this.$t('producer.message.uploadReferencesError'));
+    },
+    async onSuccess() {
+      const url = this.urls?.[0];
+      await this.onGenerateAudioId(url);
+    },
+    async onGenerateAudioId(audio_url: string) {
+      const request = {
+        audio_url
+      } as IProducerUploadRequest;
+      const token = this.credential?.token;
+      if (!token) {
+        console.error('no token specified');
+        return;
+      }
+      ElMessage.info(this.$t('producer.message.startingUploadAudio'));
+      producerOperator
+        .upload(request, {
+          token
+        })
+        .then((response) => {
+          console.debug('get upload music success', response.data);
+          const audio_id = response.data?.data.audio_id;
+          this.$store.commit('producer/setConfig', {
+            ...this.$store.state.producer?.config,
+            audio_id: audio_id,
+            action: 'upload_extend'
+          });
+          ElMessage.success(this.$t('producer.message.startUploadAudioSuccess'));
+        })
+        .catch((error) => {
+          ElMessage.error(error?.response?.data?.error?.message || this.$t('producer.message.startUploadAudioFailed'));
+        });
+    },
+    onSetAudio() {
+      // placeholder for future logic
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.title {
+  font-size: 14px;
+  margin-bottom: 0;
+  width: 30%;
+}
+.btn.btn-upload {
+  position: absolute;
+  top: 5px;
+  right: 0;
+}
+</style>
+
+<style lang="scss">
+.upload-wrapper {
+  height: auto;
+  display: flex;
+  .el-upload-list {
+    margin: 0;
+    width: 100%;
+  }
+}
+</style>

--- a/src/components/producer/config/VocalGenderSelector.vue
+++ b/src/components/producer/config/VocalGenderSelector.vue
@@ -1,0 +1,41 @@
+<template>
+  <div class="mb-2">
+    <div class="flex items-center mb-1">
+      <span class="text-sm font-bold">{{ $t('producer.name.vocalGender') }}</span>
+      <info-icon :content="$t('producer.description.vocalGender')" />
+    </div>
+    <el-radio-group v-model="vocalGender" size="small">
+      <el-radio-button value="">{{ $t('producer.gender.auto') }}</el-radio-button>
+      <el-radio-button value="f">{{ $t('producer.gender.female') }}</el-radio-button>
+      <el-radio-button value="m">{{ $t('producer.gender.male') }}</el-radio-button>
+    </el-radio-group>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElRadioGroup, ElRadioButton } from 'element-plus';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+
+export default defineComponent({
+  name: 'VocalGenderSelector',
+  components: {
+    ElRadioGroup,
+    ElRadioButton,
+    InfoIcon
+  },
+  computed: {
+    vocalGender: {
+      get() {
+        return this.$store.state.producer?.config?.vocal_gender || '';
+      },
+      set(val: string) {
+        this.$store.commit('producer/setConfig', {
+          ...this.$store.state.producer?.config,
+          vocal_gender: val || undefined
+        });
+      }
+    }
+  }
+});
+</script>

--- a/src/components/producer/player/Player.vue
+++ b/src/components/producer/player/Player.vue
@@ -1,0 +1,23 @@
+<template>
+  <div class="flex flex-col items-stretch h-20">
+    <player-slider />
+    <div class="flex grow px-5 items-center">
+      <div class="flex-1">
+        <player-song />
+      </div>
+      <div class="flex-1">
+        <player-controller />
+      </div>
+      <div class="flex-1">
+        <player-action />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import PlayerSlider from './PlayerSlider.vue';
+import PlayerSong from './PlayerSong.vue';
+import PlayerAction from './PlayerAction.vue';
+import PlayerController from './PlayerController.vue';
+</script>

--- a/src/components/producer/player/PlayerAction.vue
+++ b/src/components/producer/player/PlayerAction.vue
@@ -1,0 +1,31 @@
+<template>
+  <div class="flex justify-end items-center gap-x-2.5">
+    <span class="text-xs"> {{ useFormatDuring(progress) }} / {{ useFormatDuring(duration) }} </span>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useFormatDuring } from '@/utils/number';
+import { computed } from 'vue';
+import { useStore } from 'vuex';
+
+const store = useStore();
+
+const progress = computed({
+  get: () => store.state.producer?.audio?.progress,
+  set: (value) =>
+    store.commit('producer/setAudio', {
+      ...store.state.producer.audio,
+      progress: value
+    })
+});
+
+const duration = computed({
+  get: () => store.state.producer?.audio?.duration,
+  set: (value) =>
+    store.commit('producer/setAudio', {
+      ...store.state.producer.audio,
+      duration: value
+    })
+});
+</script>

--- a/src/components/producer/player/PlayerController.vue
+++ b/src/components/producer/player/PlayerController.vue
@@ -1,0 +1,34 @@
+<template>
+  <div class="flex items-center justify-center gap-x-3">
+    <icon-park
+      :icon="audio?.state === 'playing' ? PauseOne : Play"
+      size="45"
+      theme="filled"
+      class="text-[var(--el-color-primary)] cursor-pointer"
+      @click="togglePlay"
+    />
+    <el-popover placement="top" width="50px" trigger="click">
+      <template #reference>
+        <icon-park :icon="VolumeSmall" size="20" :stroke-width="2" class="cursor-pointer" />
+      </template>
+      <player-volume-slider />
+    </el-popover>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { Play, PauseOne, VolumeSmall } from '@icon-park/vue-next';
+import IconPark from '@/components/common/IconPark.vue';
+import PlayerVolumeSlider from './PlayerVolumeSlider.vue';
+import { ElPopover } from 'element-plus';
+import { computed } from 'vue';
+import { useStore } from 'vuex';
+
+const store = useStore();
+const togglePlay = () =>
+  store.dispatch('producer/setAudio', {
+    ...store.state.producer.audio,
+    state: store.state.producer.audio.state === 'playing' ? 'paused' : 'playing'
+  });
+const audio = computed(() => store.state.producer.audio);
+</script>

--- a/src/components/producer/player/PlayerSlider.vue
+++ b/src/components/producer/player/PlayerSlider.vue
@@ -1,0 +1,74 @@
+<template>
+  <div class="player-slider">
+    <el-slider
+      v-model="progress"
+      :show-tooltip="false"
+      :min="0"
+      :max="duration"
+      @change="onSliderChange"
+      @input="onSliderInput"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ElSlider } from 'element-plus';
+import { computed } from 'vue';
+import { useStore } from 'vuex';
+
+const store = useStore();
+
+const progress = computed({
+  get: () => store.state.producer?.audio?.progress,
+  set: (value) =>
+    store.commit('producer/setAudio', {
+      ...store.state.producer.audio,
+      progress: value
+    })
+});
+
+const duration = computed({
+  get: () => store.state.producer?.audio?.duration,
+  set: (value) => store.commit('producer/setAudio', { ...store.state.producer.audio, duration: value })
+});
+
+const onSliderInput = () => {};
+const onSliderChange = (val: any) =>
+  store.dispatch('producer/setAudio', {
+    ...store.state.producer.audio,
+    progress: val
+  });
+</script>
+
+<style lang="scss">
+.player-slider {
+  .el-slider {
+    height: 10px;
+
+    .el-slider__runway,
+    .el-slider__bar {
+      height: 2px;
+      border-radius: 0;
+    }
+
+    .el-slider__runway {
+    }
+
+    .el-slider__button-wrapper {
+      width: 10px;
+      height: 10px;
+      top: -10.5px;
+    }
+
+    &:hover {
+      .el-slider__button-wrapper {
+      }
+    }
+
+    .el-slider__button {
+      width: 8px;
+      height: 8px;
+    }
+  }
+}
+</style>

--- a/src/components/producer/player/PlayerSong.vue
+++ b/src/components/producer/player/PlayerSong.vue
@@ -1,0 +1,83 @@
+<template>
+  <div class="flex player-song">
+    <img alt="" class="w-11 h-11 rounded" :src="audio?.image_url || OpticalDisk" />
+    <div class="ml-2 text-xs flex flex-col justify-between">
+      <div class="w-52 2xl:w-96 cursor-pointer truncate">
+        <div class="flex">
+          <span>{{ audio?.title || 'Music' }}</span>
+          <span class="ml-2 text-dc">- {{ audio?.style || `SmallRuralDog` }}</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import OpticalDisk from '@/assets/images/disk.png';
+import { computed, watch } from 'vue';
+import { useStore } from 'vuex';
+
+const store = useStore();
+const audio = computed({
+  get: () => store.state.producer.audio,
+  set: (value) => store.commit('producer/setAudio', value)
+});
+
+// watch audio change and play
+watch(audio, (value, oldValue) => {
+  // url changed
+  if (value?.audio_url !== oldValue?.audio_url) {
+    console.log('audio changed', value);
+    if (value.object) {
+      console.log('111', value.object);
+      // delete old object
+      value.object.pause();
+      delete value.object;
+    }
+    const object = new Audio(value.audio_url);
+    if (value.state === 'playing') {
+      object.play();
+    } else {
+      object.pause();
+    }
+
+    // listen to the time change of audio
+    object.addEventListener('loadedmetadata', () => {
+      object.currentTime = 0;
+      object.addEventListener('timeupdate', () => {
+        store.commit('producer/setAudio', {
+          ...store.state.producer.audio,
+          progress: object.currentTime
+        });
+      });
+    });
+
+    store.commit('producer/setAudio', {
+      ...store.state.producer.audio,
+      object: object
+    });
+  } else if (value?.progress !== oldValue?.progress && Math.abs(value.progress - value.object.currentTime) > 2) {
+    console.log('progress changed', value.progress);
+    const audio = store.state.producer.audio;
+    if (audio.object) {
+      audio.object.currentTime = audio.progress;
+    }
+  } else if (value?.state !== oldValue?.state) {
+    console.log('state changed', value.state);
+    if (value.object) {
+      if (value.state === 'playing') {
+        value.object.play();
+      } else {
+        value.object.pause();
+      }
+    }
+  }
+
+  if (value?.volume !== oldValue?.volume) {
+    console.log('volume changed', value.volume);
+    if (value.object) {
+      value.object.volume = value.volume / 100;
+    }
+  }
+});
+</script>

--- a/src/components/producer/player/PlayerVolumeSlider.vue
+++ b/src/components/producer/player/PlayerVolumeSlider.vue
@@ -1,0 +1,40 @@
+<template>
+  <div class="player-volume flex flex-col items-center pt-2">
+    <el-slider
+      v-model="volume"
+      vertical
+      height="100px"
+      :show-tooltip="false"
+      :max="100"
+      :min="0"
+      size="small"
+      :disabled="muted"
+      @input="setVolume"
+    />
+    <div class="text-sm mt-3">{{ volume }}</div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ElSlider } from 'element-plus';
+import { computed } from 'vue';
+import { useStore } from 'vuex';
+const store = useStore();
+
+const volume = computed({
+  get: () => store.state.producer.audio?.volume,
+  set: (value) => store.commit('producer/setAudio', { ...store.state.producer.audio, volume: value })
+});
+
+const muted = computed({
+  get: () => store.state.producer.audio?.muted,
+  set: (value) => store.commit('producer/setAudio', { ...store.state.producer.audio, muted: value })
+});
+
+const setVolume = (value: any) => store.dispatch('producer/setVolume', value);
+</script>
+<style lang="scss">
+.el-popover.el-popper {
+  min-width: auto;
+}
+</style>

--- a/src/components/producer/task/Preview.vue
+++ b/src/components/producer/task/Preview.vue
@@ -1,0 +1,508 @@
+<template>
+  <div class="task">
+    <div v-for="audio in audios" :key="audio.id" class="audio" @click.stop="onClick(audio)">
+      <div v-loading="!audio?.audio_url" class="left">
+        <el-image :src="audio?.image_url" class="cover" fit="cover" lazy />
+        <div
+          v-if="
+            audio?.audio_url &&
+            $store.state?.producer?.audio?.id === audio.id &&
+            $store.state?.producer?.audio?.state === 'playing'
+          "
+          class="overlay"
+          @click.stop="onPause(audio)"
+        >
+          <el-icon><video-pause /></el-icon>
+        </div>
+        <div
+          v-if="
+            audio?.audio_url &&
+            ($store.state?.producer?.audio?.id !== audio.id ||
+              ($store.state?.producer?.audio?.id === audio.id && $store.state?.producer?.audio?.state === 'paused'))
+          "
+          class="overlay"
+          @click.stop="onPlay(audio)"
+        >
+          <el-icon><video-play /></el-icon>
+        </div>
+        <div v-if="audio?.duration" class="duration">
+          {{ useFormatDuring(audio?.duration) }}
+        </div>
+      </div>
+      <div class="info">
+        <h2 class="title">{{ audio?.title }}</h2>
+        <p class="style">{{ audio?.style }}</p>
+      </div>
+      <div class="right">
+        <el-dropdown>
+          <span class="el-dropdown-link">
+            <el-tooltip effect="dark" :content="$t('producer.button.download')" placement="top">
+              <font-awesome-icon
+                v-if="audio?.audio_url || audio?.video_url"
+                icon="fa-solid fa-download"
+                class="icon icon-download"
+              />
+            </el-tooltip>
+          </span>
+          <template #dropdown>
+            <el-dropdown-menu>
+              <el-dropdown-item :disabled="isFetchingVideoUrl" @click="handleVideoDownload(audio)">
+                <div class="flex items-center min-w-[120px]">
+                  <el-icon v-if="isFetchingVideoUrl" class="is-loading mr-2">
+                    <Loading />
+                  </el-icon>
+                  <span>{{ $t('producer.button.download_video') }}</span>
+                </div>
+              </el-dropdown-item>
+              <el-dropdown-item v-if="audio?.audio_url" @click.stop="onDownload($event, audio?.audio_url)">
+                {{ $t('producer.button.download_audio') }}
+              </el-dropdown-item>
+              <el-dropdown-item :disabled="isFetchingWav" @click="handleWavDownload(audio)">
+                <div class="flex items-center min-w-[120px]">
+                  <el-icon v-if="isFetchingWav" class="is-loading mr-2">
+                    <Loading />
+                  </el-icon>
+                  <span>{{ $t('producer.button.download_wav') }}</span>
+                </div>
+              </el-dropdown-item>
+            </el-dropdown-menu>
+          </template>
+        </el-dropdown>
+        <el-dropdown>
+          <span class="el-dropdown-link">
+            <el-tooltip effect="dark" :content="$t('producer.button.more')" placement="top">
+              <font-awesome-icon
+                v-if="audio?.audio_url || audio?.video_url"
+                icon="fa-solid fa-ellipsis"
+                class="icon icon-ellipsis"
+              />
+            </el-tooltip>
+          </span>
+          <template #dropdown>
+            <el-dropdown-menu>
+              <el-dropdown-item v-if="audio?.audio_url" @click.stop="onExtend($event, audio)">
+                {{ $t('producer.button.extend') }}
+              </el-dropdown-item>
+              <el-dropdown-item v-if="audio.id" @click.stop="onGetStems(audio.id)">
+                {{ $t('producer.button.get_stems') }}
+              </el-dropdown-item>
+              <el-dropdown-item v-if="audio.id" @click.stop="onGetAllStems(audio.id)">
+                {{ $t('producer.button.all_stems') }}
+              </el-dropdown-item>
+              <el-dropdown-item @click.stop="onCover(audio)">
+                {{ $t('producer.button.cover_music') }}
+              </el-dropdown-item>
+              <el-dropdown-item v-if="audio?.id" @click.stop="onVariation(audio)">
+                {{ $t('producer.button.variation') }}
+              </el-dropdown-item>
+              <el-dropdown-item v-if="audio?.id" @click.stop="onSwapVocals(audio.id)">
+                {{ $t('producer.button.swap_vocals') }}
+              </el-dropdown-item>
+              <el-dropdown-item v-if="audio?.id" @click.stop="onSwapInstrumentals(audio.id)">
+                {{ $t('producer.button.swap_instrumentals') }}
+              </el-dropdown-item>
+              <el-dropdown-item v-if="audio?.id" @click.stop="onReplaceSection(audio)">
+                {{ $t('producer.button.replace_section') }}
+              </el-dropdown-item>
+            </el-dropdown-menu>
+          </template>
+        </el-dropdown>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { useFormatDuring } from '@/utils/number';
+import { IProducerAudio, IProducerTask } from '@/models';
+import { ElImage, ElIcon, ElTooltip, ElDropdown, ElDropdownMenu, ElDropdownItem, ElMessage } from 'element-plus';
+import { Loading } from '@element-plus/icons-vue';
+import { VideoPlay, VideoPause } from '@element-plus/icons-vue';
+import { IProducerVideoRequest, IProducerAudioRequest, Status } from '@/models';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { saveAs } from 'file-saver';
+import { producerOperator } from '@/operators';
+
+const CALLBACK_URL = 'https://webhook.acedata.cloud/producer';
+
+export default defineComponent({
+  name: 'TaskPreview',
+  components: {
+    ElImage,
+    ElIcon,
+    ElTooltip,
+    FontAwesomeIcon,
+    VideoPlay,
+    VideoPause,
+    ElDropdown,
+    ElDropdownMenu,
+    ElDropdownItem,
+    Loading
+  },
+  props: {
+    modelValue: {
+      type: Object as () => IProducerTask,
+      required: true
+    }
+  },
+  data() {
+    return {
+      isFetchingVideoUrl: false,
+      isFetchingWav: false
+    };
+  },
+  computed: {
+    loading() {
+      return this.$store.state.producer?.status?.getApplications === Status.Request;
+    },
+    credential() {
+      return this.$store.state.producer.credential;
+    },
+    config() {
+      return this.$store.state.producer.config;
+    },
+    task() {
+      return this.$store.state.producer?.tasks;
+    },
+    audios(): IProducerAudio[] {
+      const data = (this.modelValue?.response?.data ?? []) as IProducerAudio[];
+      // @ts-ignore
+      const action = this.modelValue?.request?.action as IProducerAudio['action'] | undefined;
+      return action ? data.map((a) => ({ ...a, action })) : data;
+    },
+    application() {
+      return this.$store.state.producer?.application;
+    },
+    active() {
+      return this.$store.state.producer?.tasks?.active;
+    }
+  },
+  methods: {
+    useFormatDuring,
+    onPlay(audio: IProducerAudio) {
+      this.$store.dispatch('producer/setAudio', {
+        ...this.$store.state.producer.audio,
+        ...audio,
+        state: 'playing'
+      });
+      console.log('on play');
+    },
+    onPause(audio: IProducerAudio) {
+      this.$store.dispatch('producer/setAudio', {
+        ...this.$store.state.producer.audio,
+        ...audio,
+        state: 'paused'
+      });
+      console.log('on pause');
+    },
+    onClick(audio: IProducerAudio) {
+      if (this.$store.state?.producer?.audio?.id !== audio.id) {
+        this.onPlay({
+          ...audio,
+          progress: 0
+        });
+      }
+    },
+    onExtend(event: MouseEvent, audio: IProducerAudio) {
+      event.stopPropagation();
+      console.debug('set config', audio);
+      this.$store.commit('producer/setConfig', {
+        ...this.$store.state.producer?.config,
+        model: audio.model,
+        custom: true,
+        instrumental: false,
+        style: audio.style,
+        action: 'extend',
+        audio: audio,
+        audio_id: audio.id,
+        continue_at: audio.duration
+      });
+    },
+    onDownload(event: MouseEvent | null, audioUrl: string) {
+      if (event) {
+        event.stopPropagation();
+      }
+      const parsedUrl = new URL(audioUrl);
+      const pathname = parsedUrl.pathname;
+      const filename = pathname.substring(pathname.lastIndexOf('/') + 1);
+      fetch(audioUrl)
+        .then((response) => response.blob())
+        .then((blob) => {
+          saveAs(blob, filename);
+        });
+    },
+    async handleVideoDownload(audio: IProducerAudio) {
+      if (audio.video_url) {
+        this.onDownload(null, audio.video_url);
+        return;
+      }
+      if (this.isFetchingVideoUrl) {
+        return;
+      }
+      try {
+        this.isFetchingVideoUrl = true;
+        // @ts-ignore
+        const videoUrl = await this.fetchVideoUrlFromApi(audio?.id);
+        console.log(`get videoUrl: ${videoUrl}`);
+        audio.video_url = videoUrl;
+        this.onDownload(null, videoUrl);
+      } catch (error) {
+        console.error('get videoUrl failed:', error);
+        ElMessage.error(this.$t('producer.message.getVideoUrlFailed'));
+      } finally {
+        this.isFetchingVideoUrl = false;
+      }
+    },
+    async fetchVideoUrlFromApi(audioId: string): Promise<string> {
+      return new Promise((resolve, reject) => {
+        const request = {
+          audio_id: audioId
+        } as IProducerVideoRequest;
+        const token = this.credential?.token;
+        if (!token) {
+          console.error('no token specified');
+          reject(new Error('No token specified'));
+          return;
+        }
+        producerOperator
+          .video(request, { token })
+          .then((response) => {
+            const videoUrl = response.data?.data?.video_url;
+            if (videoUrl) {
+              resolve(videoUrl);
+            } else {
+              reject(new Error('Video URL not found in response'));
+            }
+          })
+          .catch((error) => {
+            reject(error);
+          });
+      });
+    },
+    onPreview(event: MouseEvent, videoUrl: string) {
+      event.stopPropagation();
+      window.open(videoUrl, '_blank');
+    },
+    async onGetStems(audioId: string) {
+      await this.onGenerateAudioUrl('stems', audioId);
+    },
+    onCover(audio: IProducerAudio) {
+      this.$store.commit('producer/setConfig', {
+        ...this.$store.state.producer?.config,
+        model: audio.model,
+        custom: true,
+        instrumental: false,
+        style: audio.style,
+        action: 'cover',
+        audio: audio,
+        audio_id: audio.id
+      });
+    },
+    onVariation(audio: IProducerAudio) {
+      this.$store.commit('producer/setConfig', {
+        ...this.$store.state.producer?.config,
+        model: audio.model,
+        custom: true,
+        style: audio.style,
+        action: 'variation',
+        audio: audio,
+        audio_id: audio.id
+      });
+    },
+    async onSwapVocals(audioId: string) {
+      await this.onGenerateAudioUrl('swap_vocals', audioId);
+    },
+    async onSwapInstrumentals(audioId: string) {
+      await this.onGenerateAudioUrl('swap_instrumentals', audioId);
+    },
+    async onGetAllStems(audioId: string) {
+      await this.onGenerateAudioUrl('all_stems', audioId);
+    },
+    onReplaceSection(audio: IProducerAudio) {
+      this.$store.commit('producer/setConfig', {
+        ...this.$store.state.producer?.config,
+        model: audio.model,
+        custom: true,
+        instrumental: false,
+        style: audio.style,
+        action: 'replace_section',
+        audio: audio,
+        audio_id: audio.id,
+        replace_section_start: 0,
+        replace_section_end: Math.min(30, audio.duration || 30)
+      });
+    },
+    async handleWavDownload(audio: IProducerAudio) {
+      if (!audio?.id || this.isFetchingWav) return;
+      const token = this.credential?.token;
+      if (!token) return;
+      try {
+        this.isFetchingWav = true;
+        ElMessage.info(this.$t('producer.message.fetchingWav'));
+        const response = await producerOperator.wav({ audio_id: audio.id }, { token });
+        const wavUrl = response.data?.data?.audio_url;
+        if (wavUrl) {
+          this.onDownload(null, wavUrl);
+        } else {
+          ElMessage.error(this.$t('producer.message.fetchWavFailed'));
+        }
+      } catch {
+        ElMessage.error(this.$t('producer.message.fetchWavFailed'));
+      } finally {
+        this.isFetchingWav = false;
+      }
+    },
+    async onGenerateAudioUrl(action: string, audioId: string) {
+      const request = {
+        action,
+        audio_id: audioId,
+        callback_url: CALLBACK_URL
+      } as IProducerAudioRequest;
+      const token = this.credential?.token;
+      if (!token) {
+        console.error('no token specified');
+        return;
+      }
+      ElMessage.info(this.$t('producer.message.startingTask'));
+      producerOperator
+        .audio(request, {
+          token
+        })
+        .then(() => {
+          ElMessage.success(this.$t('producer.message.startTaskSuccess'));
+        })
+        .catch((error) => {
+          ElMessage.error(error?.response?.data?.error?.message || this.$t('producer.message.startTaskFailed'));
+        })
+        .finally(async () => {
+          await this.onGetTasks();
+          await this.onScrollDown();
+        });
+    },
+    async onScrollDown() {
+      setTimeout(() => {
+        const el = document.querySelector('.tasks');
+        if (el) {
+          el.scrollTop = el.scrollHeight;
+        }
+      }, 1000);
+    },
+    async onGetTasks() {
+      if (this.loading) {
+        console.debug('loading');
+        return;
+      }
+      await this.$store.dispatch('producer/getTasks', {
+        limit: 30,
+        offset: 0
+      });
+    }
+  }
+});
+</script>
+
+<style lang="scss">
+.task {
+  display: flex;
+  flex-direction: column;
+  cursor: pointer;
+  .audio {
+    display: flex;
+    margin-bottom: 10px;
+    border-radius: 10px;
+
+    &:hover {
+      background-color: var(--el-bg-color-page);
+    }
+
+    .left {
+      position: relative;
+      width: 60px;
+      height: 60px;
+      margin-right: 16px;
+      flex-shrink: 0;
+
+      &:hover .overlay {
+        display: block;
+      }
+
+      .cover {
+        width: 100%;
+        height: 100%;
+        border-radius: 4px;
+      }
+
+      .duration {
+        position: absolute;
+        right: 0px;
+        bottom: 0px;
+        background-color: rgba(0, 0, 0, 0.7);
+        padding: 2px 4px;
+        color: white;
+        border-radius: 2px;
+        font-size: 10px;
+      }
+
+      .overlay {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background-color: rgba(0, 0, 0, 0.5);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        display: none;
+        transition: opacity 0.3s;
+        border-radius: 4px;
+        text-align: center;
+        line-height: 70px;
+        cursor: pointer;
+        .el-icon {
+          font-size: 20px;
+          color: white;
+        }
+      }
+    }
+    .info {
+      flex: 1;
+      min-width: 0;
+      overflow: hidden;
+      .title {
+        font-size: 14px;
+        font-weight: bold;
+        margin-top: 5px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .style {
+        font-size: 12px;
+        margin-bottom: 0;
+        color: var(--el-text-color-secondary);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+    }
+    .right {
+      width: 120px;
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      padding-right: 1px;
+      .icon {
+        display: block;
+        z-index: 100;
+        cursor: pointer;
+        margin-right: 15px;
+      }
+      .el-button {
+        margin-right: 15px;
+      }
+    }
+  }
+}
+</style>

--- a/src/constants/i18n.ts
+++ b/src/constants/i18n.ts
@@ -39,6 +39,7 @@ export const I18N_SCOPES = [
   'hailuo',
   'headshots',
   'suno',
+  'producer',
   'coin',
   'common',
   'console',

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -15,6 +15,7 @@ export * from './flux';
 export * from './hailuo';
 export * from './headshots';
 export * from './suno';
+export * from './producer';
 export * from './nanobanana';
 export * from './seedream';
 export * from './seedance';

--- a/src/constants/producer.ts
+++ b/src/constants/producer.ts
@@ -1,0 +1,5 @@
+export const PRODUCER_SERVICE_ID = '864a7efd-c7a3-4ad8-b372-ba8d64cdeda8';
+
+export const PRODUCER_LOGO = 'https://cdn.acedata.cloud/l3ffw7.jpg';
+
+export const PRODUCER_DEFAULT_MODEL = 'FUZZ-2.0 Pro';

--- a/src/i18n/en/producer.json
+++ b/src/i18n/en/producer.json
@@ -1,0 +1,394 @@
+{
+  "button.extend": {
+    "message": "Continue Generating",
+    "description": "Text for the continue generating button"
+  },
+  "button.download": {
+    "message": "Download",
+    "description": "Text for the download button"
+  },
+  "button.more": {
+    "message": "More Actions",
+    "description": "Text for the more actions button"
+  },
+  "button.uploadAudios": {
+    "message": "Upload",
+    "description": "Text for the button that allows users to upload references"
+  },
+  "button.video": {
+    "message": "Video",
+    "description": "Text for the video button"
+  },
+  "button.download_video": {
+    "message": "Download Video",
+    "description": "Text for the download video button"
+  },
+  "button.download_wav": {
+    "message": "Download Lossless WAV",
+    "description": "Text for the download WAV lossless format button"
+  },
+  "button.get_stems": {
+    "message": "Get Stems",
+    "description": "Text for the get stems button"
+  },
+  "button.cover_music": {
+    "message": "Cover",
+    "description": "Text for the cover button"
+  },
+  "button.download_audio": {
+    "message": "Download Music",
+    "description": "Text for the download music button"
+  },
+  "button.replace_section": {
+    "message": "Replace Section",
+    "description": "Text for the button to replace a section in the song"
+  },
+  "button.generate_lyrics": {
+    "message": "AI Generate Lyrics",
+    "description": "Text for the button to automatically generate lyrics using AI"
+  },
+  "button.all_stems": {
+    "message": "All Stems",
+    "description": "Text for the button to separate all tracks"
+  },
+  "button.variation": {
+    "message": "Variation",
+    "description": "Text for the variation button"
+  },
+  "button.swap_vocals": {
+    "message": "Swap Vocals",
+    "description": "Text for the swap vocals button"
+  },
+  "button.swap_instrumentals": {
+    "message": "Swap Instrumentals",
+    "description": "Text for the swap instrumentals button"
+  },
+  "model.fuzz20pro": {
+    "message": "FUZZ-2.0 Pro",
+    "description": "Model used for music generation"
+  },
+  "model.fuzz20": {
+    "message": "FUZZ-2.0",
+    "description": "Model used for music generation"
+  },
+  "model.fuzz20raw": {
+    "message": "FUZZ-2.0 Raw",
+    "description": "Model used for music generation"
+  },
+  "model.fuzz11pro": {
+    "message": "FUZZ-1.1 Pro",
+    "description": "Model used for music generation"
+  },
+  "model.fuzz10pro": {
+    "message": "FUZZ-1.0 Pro",
+    "description": "Model used for music generation"
+  },
+  "model.fuzz10": {
+    "message": "FUZZ-1.0",
+    "description": "Model used for music generation"
+  },
+  "model.fuzz11": {
+    "message": "FUZZ-1.1",
+    "description": "Model used for music generation"
+  },
+  "model.fuzz08": {
+    "message": "FUZZ-0.8",
+    "description": "Model used for music generation"
+  },
+  "name.instrumental": {
+    "message": "Instrumental",
+    "description": "Generate instrumental music without vocals"
+  },
+  "name.referenceAudios": {
+    "message": "Reference Music",
+    "description": "Name for reference music"
+  },
+  "name.taskId": {
+    "message": "Task ID",
+    "description": "ID of the task"
+  },
+  "name.type": {
+    "message": "Custom Mode",
+    "description": "Name for the custom mode"
+  },
+  "name.prompt": {
+    "message": "Song Description",
+    "description": "Prompt for content input"
+  },
+  "name.extend": {
+    "message": "Extend Song From",
+    "description": "Prompt for content input"
+  },
+  "name.cover": {
+    "message": "Cover Song From",
+    "description": "Prompt for content input"
+  },
+  "name.lyrics": {
+    "message": "Lyrics",
+    "description": "Prompt for lyrics content input"
+  },
+  "name.style": {
+    "message": "Style",
+    "description": "Prompt for song style content input"
+  },
+  "name.styleNegative": {
+    "message": "Exclude Style",
+    "description": "Description of styles to exclude"
+  },
+  "name.title": {
+    "message": "Title",
+    "description": "Prompt for song title content input"
+  },
+  "name.vocalGender": {
+    "message": "Vocal Gender",
+    "description": "Select vocal gender"
+  },
+  "name.advancedParams": {
+    "message": "Advanced Parameters",
+    "description": "Settings for advanced parameters"
+  },
+  "name.weirdness": {
+    "message": "Creativity Level",
+    "description": "Control the level of creativity in generated music"
+  },
+  "name.soundStrength": {
+    "message": "Sound Strength",
+    "description": "Control the intensity of the generated sound"
+  },
+  "name.lyricsStrength": {
+    "message": "Lyrics Strength",
+    "description": "Control the influence of lyrics on the generated result"
+  },
+  "name.seed": {
+    "message": "Seed",
+    "description": "Random seed for reproducible generation"
+  },
+  "name.lyricPrompt": {
+    "message": "Lyric Prompt",
+    "description": "Prompt for automatically generating lyrics"
+  },
+  "name.failureReason": {
+    "message": "Failure Reason",
+    "description": "Reason for task failure"
+  },
+  "name.status": {
+    "message": "Status",
+    "description": "Status of the task"
+  },
+  "name.traceId": {
+    "message": "Trace ID",
+    "description": "Trace ID of the task"
+  },
+  "name.producerBot": {
+    "message": "Producer Bot",
+    "description": "Name of the Producer generator"
+  },
+  "name.replaceSection": {
+    "message": "Replace Section",
+    "description": "Replace a section in the song"
+  },
+  "name.model": {
+    "message": "Model",
+    "description": "Select model version"
+  },
+  "name.songDescription": {
+    "message": "Song Description",
+    "description": "Mode for song description"
+  },
+  "description.prompt": {
+    "message": "Describe the music style and theme you want",
+    "description": "Description for the 'prompt' parameter"
+  },
+  "description.lyrics": {
+    "message": "Enter custom lyrics, supporting paragraph markers like [Verse], [Chorus], [Bridge], etc.",
+    "description": "Description for the 'lyrics' parameter"
+  },
+  "description.style": {
+    "message": "Describe music styles, such as acoustic pop, jazz, electronic",
+    "description": "Description for the 'style' parameter"
+  },
+  "description.styleNegative": {
+    "message": "Describe unwanted styles, such as heavy metal, screaming",
+    "description": "Description for the exclusion style parameter"
+  },
+  "description.title": {
+    "message": "Song Title",
+    "description": "Description for the 'title' parameter"
+  },
+  "description.uploadAudios": {
+    "message": "Upload music as a reference for generation. The upload process may take some time, and generation will occur based on the uploaded music once successful.",
+    "description": "Description for the upload reference parameter"
+  },
+  "description.vocalGender": {
+    "message": "Select the gender of the generated vocals",
+    "description": "Description for the vocal gender selector"
+  },
+  "description.weirdness": {
+    "message": "Higher values result in more creative and experimental music (0-100)",
+    "description": "Description for the creativity parameter"
+  },
+  "description.soundStrength": {
+    "message": "Control the intensity of the generated sound (0-100)",
+    "description": "Description for the sound strength parameter"
+  },
+  "description.lyricsStrength": {
+    "message": "Control the influence of lyrics on the generated result (0-100)",
+    "description": "Description for the lyrics strength parameter"
+  },
+  "description.seed": {
+    "message": "Enter a seed value for reproducible results, leave empty for random",
+    "description": "Description for the seed parameter"
+  },
+  "description.lyricPrompt": {
+    "message": "Enter a lyric description, and the AI will automatically generate lyrics",
+    "description": "Description for the lyric prompt"
+  },
+  "description.replaceSection": {
+    "message": "Replace content in the specified time section of the song",
+    "description": "Description for the replace section feature"
+  },
+  "status.pending": {
+    "message": "Pending",
+    "description": "Waiting status of the task"
+  },
+  "placeholder.prompt": {
+    "message": "Describe the music you want, e.g., a warm folk song about autumn nostalgia...",
+    "description": "Placeholder for song description input"
+  },
+  "placeholder.lyrics": {
+    "message": "[Verse]\nIn this quiet night\nStars twinkle in the sky\n\n[Chorus]\nLet's sing together\nUntil dawn...",
+    "description": "Placeholder for lyrics input"
+  },
+  "placeholder.extend.lyrics": {
+    "message": "Enter the lyrics to be extended...",
+    "description": "Placeholder for extended lyrics input"
+  },
+  "placeholder.extend.continue_at": {
+    "message": "Start extending from which second...",
+    "description": "Placeholder for the start time of extension"
+  },
+  "placeholder.style": {
+    "message": "For example: acoustic pop, jazz, R&B, electronic...",
+    "description": "Placeholder for style input"
+  },
+  "placeholder.styleNegative": {
+    "message": "For example: heavy metal, screaming...",
+    "description": "Placeholder for excluded style input"
+  },
+  "placeholder.title": {
+    "message": "Enter the song name...",
+    "description": "Placeholder for title input"
+  },
+  "placeholder.select": {
+    "message": "Please select a model...",
+    "description": "Placeholder for model selection"
+  },
+  "placeholder.position": {
+    "message": "Please select...",
+    "description": "Placeholder for position input"
+  },
+  "placeholder.lyricPrompt": {
+    "message": "Describe the theme of the lyrics, and the AI will generate automatically...",
+    "description": "Placeholder for lyric prompt input"
+  },
+  "placeholder.replaceSectionStart": {
+    "message": "Start time (seconds)",
+    "description": "Placeholder for the start time of the replace section"
+  },
+  "placeholder.replaceSectionEnd": {
+    "message": "End time (seconds)",
+    "description": "Placeholder for the end time of the replace section"
+  },
+  "placeholder.seed": {
+    "message": "Enter seed value (optional)...",
+    "description": "Placeholder for seed input"
+  },
+  "button.generate": {
+    "message": "Generate",
+    "description": "Text for the generate button"
+  },
+  "gender.male": {
+    "message": "Male Voice",
+    "description": "Option for male vocals"
+  },
+  "gender.female": {
+    "message": "Female Voice",
+    "description": "Option for female vocals"
+  },
+  "gender.auto": {
+    "message": "Automatic",
+    "description": "Automatically select vocal gender"
+  },
+  "message.startingTask": {
+    "message": "Starting task...",
+    "description": "Message when starting the music generation task"
+  },
+  "message.startingUploadAudio": {
+    "message": "Uploading custom music...",
+    "description": "Message when starting the music upload"
+  },
+  "message.uploadReferencesExceed": {
+    "message": "Uploaded music exceeds the maximum number",
+    "description": "Error message when uploaded music exceeds the maximum number"
+  },
+  "message.uploadReferencesError": {
+    "message": "Failed to upload music",
+    "description": "Error message when music upload fails"
+  },
+  "message.startTaskSuccess": {
+    "message": "Successfully started the music generation task",
+    "description": "Success message when the music generation task starts successfully"
+  },
+  "message.startUploadAudioSuccess": {
+    "message": "Successfully uploaded custom music",
+    "description": "Success message when custom music is uploaded successfully"
+  },
+  "message.startUploadAudioFailed": {
+    "message": "Failed to upload custom music",
+    "description": "Error message when starting the music generation task fails"
+  },
+  "message.startTaskFailed": {
+    "message": "Failed to start the music generation task",
+    "description": "Error message when starting the music generation task fails"
+  },
+  "message.getVideoUrlFailed": {
+    "message": "Failed to get music video, please try again later",
+    "description": "Error message when getting video fails"
+  },
+  "message.generatingLyrics": {
+    "message": "Generating lyrics...",
+    "description": "Message when generating lyrics"
+  },
+  "message.generateLyricsSuccess": {
+    "message": "Lyrics generated successfully",
+    "description": "Message when lyrics are generated successfully"
+  },
+  "message.generateLyricsFailed": {
+    "message": "Lyrics generation failed",
+    "description": "Message when lyrics generation fails"
+  },
+  "message.fetchingWav": {
+    "message": "Fetching WAV file...",
+    "description": "Message while fetching WAV file"
+  },
+  "message.fetchWavFailed": {
+    "message": "Failed to fetch WAV file",
+    "description": "Message when fetching WAV file fails"
+  },
+  "message.generating": {
+    "message": "Generating...",
+    "description": "Message while music is being generated"
+  },
+  "message.generateFailed": {
+    "message": "Music generation failed",
+    "description": "Message when music generation fails"
+  },
+  "message.noOperations": {
+    "message": "No available operations",
+    "description": "Message when there are no available operations"
+  },
+  "message.noTasks": {
+    "message": "No history tasks, please generate music in the left configuration panel",
+    "description": "Message when there are no tasks"
+  }
+}

--- a/src/i18n/zh-CN/producer.json
+++ b/src/i18n/zh-CN/producer.json
@@ -1,0 +1,394 @@
+{
+  "button.extend": {
+    "message": "继续生成",
+    "description": "继续生成按钮文本"
+  },
+  "button.download": {
+    "message": "下载",
+    "description": "下载按钮文本"
+  },
+  "button.more": {
+    "message": "更多操作",
+    "description": "更多操作按钮文本"
+  },
+  "button.uploadAudios": {
+    "message": "上传",
+    "description": "按钮文本，允许用户上传参考"
+  },
+  "button.video": {
+    "message": "视频",
+    "description": "视频按钮文本"
+  },
+  "button.download_video": {
+    "message": "下载视频",
+    "description": "下载视频按钮文本"
+  },
+  "button.download_wav": {
+    "message": "下载 WAV 无损",
+    "description": "下载WAV无损格式按钮文本"
+  },
+  "button.get_stems": {
+    "message": "声曲分离",
+    "description": "声曲分离按钮文本"
+  },
+  "button.cover_music": {
+    "message": "翻唱",
+    "description": "翻唱按钮文本"
+  },
+  "button.download_audio": {
+    "message": "下载音乐",
+    "description": "下载音乐按钮文本"
+  },
+  "button.replace_section": {
+    "message": "替换片段",
+    "description": "替换歌曲中的某个片段按钮文本"
+  },
+  "button.generate_lyrics": {
+    "message": "AI 生成歌词",
+    "description": "使用AI自动生成歌词按钮文本"
+  },
+  "button.all_stems": {
+    "message": "全部分离",
+    "description": "分离所有音轨按钮文本"
+  },
+  "button.variation": {
+    "message": "变体",
+    "description": "变体按钮文本"
+  },
+  "button.swap_vocals": {
+    "message": "人声替换",
+    "description": "人声替换按钮文本"
+  },
+  "button.swap_instrumentals": {
+    "message": "伴奏替换",
+    "description": "伴奏替换按钮文本"
+  },
+  "model.fuzz20pro": {
+    "message": "FUZZ-2.0 Pro",
+    "description": "用于生成音乐的模型"
+  },
+  "model.fuzz20": {
+    "message": "FUZZ-2.0",
+    "description": "用于生成音乐的模型"
+  },
+  "model.fuzz20raw": {
+    "message": "FUZZ-2.0 Raw",
+    "description": "用于生成音乐的模型"
+  },
+  "model.fuzz11pro": {
+    "message": "FUZZ-1.1 Pro",
+    "description": "用于生成音乐的模型"
+  },
+  "model.fuzz10pro": {
+    "message": "FUZZ-1.0 Pro",
+    "description": "用于生成音乐的模型"
+  },
+  "model.fuzz10": {
+    "message": "FUZZ-1.0",
+    "description": "用于生成音乐的模型"
+  },
+  "model.fuzz11": {
+    "message": "FUZZ-1.1",
+    "description": "用于生成音乐的模型"
+  },
+  "model.fuzz08": {
+    "message": "FUZZ-0.8",
+    "description": "用于生成音乐的模型"
+  },
+  "name.instrumental": {
+    "message": "纯音乐",
+    "description": "生成纯音乐无人声"
+  },
+  "name.referenceAudios": {
+    "message": "参考音乐",
+    "description": "参考音乐的名称"
+  },
+  "name.taskId": {
+    "message": "任务 ID",
+    "description": "任务的 ID"
+  },
+  "name.type": {
+    "message": "定制模式",
+    "description": "定制模式的名称"
+  },
+  "name.prompt": {
+    "message": "歌曲描述",
+    "description": "内容输入的提示"
+  },
+  "name.extend": {
+    "message": "扩展歌曲来自",
+    "description": "内容输入的提示"
+  },
+  "name.cover": {
+    "message": "翻唱歌曲来自",
+    "description": "内容输入的提示"
+  },
+  "name.lyrics": {
+    "message": "歌词",
+    "description": "歌词内容输入的提示"
+  },
+  "name.style": {
+    "message": "风格",
+    "description": "歌曲风格内容输入的提示"
+  },
+  "name.styleNegative": {
+    "message": "排除风格",
+    "description": "不想要的风格描述"
+  },
+  "name.title": {
+    "message": "标题",
+    "description": "歌曲标题内容输入的提示"
+  },
+  "name.vocalGender": {
+    "message": "人声性别",
+    "description": "选择人声性别"
+  },
+  "name.advancedParams": {
+    "message": "高级参数",
+    "description": "高级参数设置"
+  },
+  "name.weirdness": {
+    "message": "创意度",
+    "description": "控制生成音乐的创意程度"
+  },
+  "name.soundStrength": {
+    "message": "声音强度",
+    "description": "控制生成声音的强度"
+  },
+  "name.lyricsStrength": {
+    "message": "歌词强度",
+    "description": "控制歌词对生成结果的影响程度"
+  },
+  "name.seed": {
+    "message": "种子",
+    "description": "用于可重复生成的随机种子"
+  },
+  "name.lyricPrompt": {
+    "message": "歌词提示",
+    "description": "用于自动生成歌词的提示"
+  },
+  "name.failureReason": {
+    "message": "失败原因",
+    "description": "任务失败的原因"
+  },
+  "name.status": {
+    "message": "状态",
+    "description": "任务的状态"
+  },
+  "name.traceId": {
+    "message": "追踪 ID",
+    "description": "任务的追踪 ID"
+  },
+  "name.producerBot": {
+    "message": "Producer Bot",
+    "description": "Producer生成器的名称"
+  },
+  "name.replaceSection": {
+    "message": "替换片段",
+    "description": "替换歌曲中的某个片段"
+  },
+  "name.model": {
+    "message": "模型",
+    "description": "选择模型版本"
+  },
+  "name.songDescription": {
+    "message": "歌曲描述",
+    "description": "歌曲描述模式"
+  },
+  "description.prompt": {
+    "message": "描述你想要的音乐风格和主题",
+    "description": "参数'prompt'的描述"
+  },
+  "description.lyrics": {
+    "message": "输入自定义歌词，支持 [Verse]、[Chorus]、[Bridge] 等段落标记",
+    "description": "参数'lyrics'的描述"
+  },
+  "description.style": {
+    "message": "描述音乐风格，如 acoustic pop、jazz、electronic",
+    "description": "参数'style'的描述"
+  },
+  "description.styleNegative": {
+    "message": "描述不想要的风格，例如 heavy metal、screaming",
+    "description": "排除风格参数的描述"
+  },
+  "description.title": {
+    "message": "歌曲标题",
+    "description": "参数'title'的描述"
+  },
+  "description.uploadAudios": {
+    "message": "上传音乐作为生成的参考，上传的过程需要等待一会，生成成功后便可根据上传的音乐进行生成",
+    "description": "上传参考参数的描述"
+  },
+  "description.vocalGender": {
+    "message": "选择生成人声的性别",
+    "description": "人声性别选择器的描述"
+  },
+  "description.weirdness": {
+    "message": "值越高生成的音乐越有创意和实验性 (0-100)",
+    "description": "创意度参数的描述"
+  },
+  "description.soundStrength": {
+    "message": "控制生成声音的强度 (0-100)",
+    "description": "声音强度参数的描述"
+  },
+  "description.lyricsStrength": {
+    "message": "控制歌词对生成结果的影响程度 (0-100)",
+    "description": "歌词强度参数的描述"
+  },
+  "description.seed": {
+    "message": "输入种子值以获得可重复的结果，留空为随机",
+    "description": "种子参数的描述"
+  },
+  "description.lyricPrompt": {
+    "message": "输入歌词描述，AI 将自动生成歌词",
+    "description": "歌词提示描述"
+  },
+  "description.replaceSection": {
+    "message": "替换歌曲中指定时间段的内容",
+    "description": "替换片段功能的描述"
+  },
+  "status.pending": {
+    "message": "等待中",
+    "description": "任务的等待状态"
+  },
+  "placeholder.prompt": {
+    "message": "描述你想要的音乐，例如：一首温暖的民谣，关于秋天的思念...",
+    "description": "歌曲描述输入的占位符"
+  },
+  "placeholder.lyrics": {
+    "message": "[Verse]\n在这个寂静的夜里\n星星在天空闪烁\n\n[Chorus]\n让我们一起唱歌\n直到天亮...",
+    "description": "歌词输入的占位符"
+  },
+  "placeholder.extend.lyrics": {
+    "message": "请输入需要扩展的歌词...",
+    "description": "扩展歌词输入的占位符"
+  },
+  "placeholder.extend.continue_at": {
+    "message": "从第几秒开始扩展...",
+    "description": "扩展起始时间的占位符"
+  },
+  "placeholder.style": {
+    "message": "例如：acoustic pop, jazz, R&B, electronic...",
+    "description": "风格输入的占位符"
+  },
+  "placeholder.styleNegative": {
+    "message": "例如：heavy metal, screaming...",
+    "description": "排除风格输入的占位符"
+  },
+  "placeholder.title": {
+    "message": "输入歌曲名称...",
+    "description": "标题输入的占位符"
+  },
+  "placeholder.select": {
+    "message": "请选择模型...",
+    "description": "模型选择的占位符"
+  },
+  "placeholder.position": {
+    "message": "请选择...",
+    "description": "位置输入的占位符"
+  },
+  "placeholder.lyricPrompt": {
+    "message": "描述歌词主题，AI 将自动生成...",
+    "description": "歌词提示输入的占位符"
+  },
+  "placeholder.replaceSectionStart": {
+    "message": "开始时间 (秒)",
+    "description": "替换片段开始时间的占位符"
+  },
+  "placeholder.replaceSectionEnd": {
+    "message": "结束时间 (秒)",
+    "description": "替换片段结束时间的占位符"
+  },
+  "placeholder.seed": {
+    "message": "输入种子值（可选）...",
+    "description": "种子输入的占位符"
+  },
+  "button.generate": {
+    "message": "生成",
+    "description": "生成按钮文本"
+  },
+  "gender.male": {
+    "message": "男声",
+    "description": "男性人声选项"
+  },
+  "gender.female": {
+    "message": "女声",
+    "description": "女性人声选项"
+  },
+  "gender.auto": {
+    "message": "自动",
+    "description": "自动选择人声性别"
+  },
+  "message.startingTask": {
+    "message": "正在启动任务...",
+    "description": "音乐生成任务开始时的消息"
+  },
+  "message.startingUploadAudio": {
+    "message": "正在上传自定义音乐...",
+    "description": "音乐生成任务开始时的消息"
+  },
+  "message.uploadReferencesExceed": {
+    "message": "上传的音乐超过了最大数量",
+    "description": "上传的音乐超过了最大数量时的错误消息"
+  },
+  "message.uploadReferencesError": {
+    "message": "上传音乐失败",
+    "description": "上传音乐失败时的错误消息"
+  },
+  "message.startTaskSuccess": {
+    "message": "成功启动音乐生成任务",
+    "description": "成功启动音乐生成任务时的成功消息"
+  },
+  "message.startUploadAudioSuccess": {
+    "message": "成功上传自定义音乐",
+    "description": "成功启动音乐生成任务时的成功消息"
+  },
+  "message.startUploadAudioFailed": {
+    "message": "上传自定义音乐失败",
+    "description": "启动音乐生成任务失败时的错误消息"
+  },
+  "message.startTaskFailed": {
+    "message": "启动音乐生成任务失败",
+    "description": "启动音乐生成任务失败时的错误消息"
+  },
+  "message.getVideoUrlFailed": {
+    "message": "获取音乐视频失败，请稍后重试",
+    "description": "获取视频失败时的错误消息"
+  },
+  "message.generatingLyrics": {
+    "message": "正在生成歌词...",
+    "description": "生成歌词时的消息"
+  },
+  "message.generateLyricsSuccess": {
+    "message": "歌词生成成功",
+    "description": "歌词生成成功时的消息"
+  },
+  "message.generateLyricsFailed": {
+    "message": "歌词生成失败",
+    "description": "歌词生成失败时的消息"
+  },
+  "message.fetchingWav": {
+    "message": "正在获取 WAV 文件...",
+    "description": "获取WAV文件时的消息"
+  },
+  "message.fetchWavFailed": {
+    "message": "获取 WAV 文件失败",
+    "description": "获取WAV文件失败时的消息"
+  },
+  "message.generating": {
+    "message": "生成中...",
+    "description": "音乐正在生成时的消息"
+  },
+  "message.generateFailed": {
+    "message": "生成音乐失败",
+    "description": "音乐生成失败时的消息"
+  },
+  "message.noOperations": {
+    "message": "没有可用操作",
+    "description": "没有可用操作时的消息"
+  },
+  "message.noTasks": {
+    "message": "没有历史任务，请在左侧配置栏生成音乐",
+    "description": "没有任务时的消息"
+  }
+}

--- a/src/layouts/Producer.vue
+++ b/src/layouts/Producer.vue
@@ -1,0 +1,70 @@
+<template>
+  <div class="main flex flex-row flex-1">
+    <div
+      class="config w-[320px] flex-none h-full overflow-y-auto bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+    >
+      <slot name="config" />
+    </div>
+    <div class="result h-full flex flex-col flex-1 min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
+      <slot name="result" />
+    </div>
+    <div class="preview h-full w-[300px] flex flex-col">
+      <slot name="preview" />
+    </div>
+    <el-button circle class="menu" @click="drawer = true">
+      <font-awesome-icon icon="fa-solid fa-magic" />
+    </el-button>
+    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px" class="drawer">
+      <slot name="config" />
+    </el-drawer>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElDrawer, ElButton } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+
+export default defineComponent({
+  name: 'LayoutProducer',
+  components: {
+    ElDrawer,
+    ElButton,
+    FontAwesomeIcon
+  },
+  data() {
+    return {
+      drawer: false,
+      preview: false
+    };
+  },
+  computed: {}
+});
+</script>
+
+<style lang="scss" scoped>
+.menu {
+  display: none;
+}
+
+@media (max-width: 767px) {
+  .main {
+    .config {
+      display: none;
+    }
+    .result {
+      width: 100%;
+    }
+    .preview {
+      display: none;
+    }
+    .menu {
+      display: block;
+      position: absolute;
+      right: 8px;
+      top: 45px;
+      z-index: 1000;
+    }
+  }
+}
+</style>

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -21,6 +21,7 @@ export * from './flux';
 export * from './hailuo';
 export * from './headshots';
 export * from './suno';
+export * from './producer';
 export * from './nanobanana';
 export * from './seedream';
 export * from './seedance';

--- a/src/models/producer.ts
+++ b/src/models/producer.ts
@@ -1,0 +1,128 @@
+export interface IProducerConfig {
+  prompt?: string;
+  model?: string;
+  lyric?: string;
+  custom?: boolean;
+  instrumental?: boolean;
+  title?: string;
+  style?: string;
+  action?: string;
+  audio?: IProducerAudio | undefined;
+  audio_id?: string;
+  continue_at: number;
+  sound_strength?: number;
+  lyrics_strength?: number;
+  weirdness?: number;
+  seed?: number;
+  vocal_gender?: string;
+  replace_section_start?: number;
+  replace_section_end?: number;
+  style_negative?: string;
+  lyric_prompt?: string;
+}
+
+export interface IProducerAudioRequest {
+  action?: string;
+  prompt?: string;
+  model?: string;
+  lyric?: string;
+  custom?: boolean;
+  title?: string;
+  style?: string;
+  audio_id?: string;
+  continue_at?: number;
+  sound_strength?: number;
+  lyrics_strength?: number;
+  weirdness?: number;
+  seed?: number;
+  callback_url?: string;
+  instrumental?: boolean;
+  vocal_gender?: string;
+  replace_section_start?: number;
+  replace_section_end?: number;
+  style_negative?: string;
+  lyric_prompt?: string;
+}
+
+export interface IProducerVideoRequest {
+  audio_id?: string;
+}
+
+export interface IProducerLyricRequest {
+  prompt?: string;
+}
+
+export interface IProducerUploadRequest {
+  audio_url?: string;
+}
+
+export interface IProducerAudio {
+  id?: string;
+  action?: string;
+  lyric?: string;
+  volume?: number;
+  progress?: number;
+  model?: string;
+  style?: string;
+  title?: string;
+  prompt?: string;
+  audio_url?: string;
+  video_url?: string;
+  image_url?: string;
+  created_at?: string;
+  duration?: number;
+  state?: 'playing' | 'paused';
+  object?: any;
+}
+
+export interface IProducerAudioLyric {
+  text?: string;
+  title?: string;
+}
+
+export interface IProducerUploadAudio {
+  audio_id?: string;
+}
+
+export interface IProducerVideo {
+  video_url?: string;
+}
+
+export interface IProducerAudioResponse {
+  success?: boolean;
+  task_id: string;
+  data: IProducerAudio[];
+}
+
+export interface IProducerLyricResponse {
+  success?: boolean;
+  task_id: string;
+  data: IProducerAudioLyric;
+}
+
+export interface IProducerUploadResponse {
+  success?: boolean;
+  task_id: string;
+  data: IProducerUploadAudio;
+}
+
+export interface IProducerVideoResponse {
+  success?: boolean;
+  task_id: string;
+  data: IProducerVideo;
+}
+
+export interface IProducerTask {
+  map(arg0: (song: any) => any): any;
+  id: string;
+  created_at?: number;
+  request?: IProducerAudioRequest | IProducerLyricRequest;
+  response?: IProducerAudioResponse | IProducerLyricResponse;
+}
+
+export type IProducerTaskResponse = IProducerTask;
+
+export interface IProducerTasksResponse {
+  count: number;
+  items: IProducerTask[];
+}

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -22,6 +22,7 @@ export * from './hailuo';
 export * from './headshots';
 export * from './site';
 export * from './suno';
+export * from './producer';
 export * from './exchange';
 export * from './nanobanana';
 export * from './seedream';

--- a/src/operators/producer.ts
+++ b/src/operators/producer.ts
@@ -1,0 +1,182 @@
+import axios, { AxiosResponse } from 'axios';
+import {
+  IProducerAudioRequest,
+  IProducerAudioResponse,
+  IProducerLyricRequest,
+  IProducerLyricResponse,
+  IProducerTaskResponse,
+  IProducerTasksResponse,
+  IProducerUploadResponse,
+  IProducerUploadRequest,
+  IProducerVideoRequest,
+  IProducerVideoResponse
+} from '@/models';
+import { BASE_URL_API } from '@/constants';
+
+class ProducerOperator {
+  async task(id: string, options: { token: string }): Promise<AxiosResponse<IProducerTaskResponse>> {
+    return await axios.post(
+      `/producer/tasks`,
+      {
+        action: 'retrieve',
+        id: id
+      },
+      {
+        headers: {
+          accept: 'application/json',
+          'content-type': 'application/json',
+          authorization: `Bearer ${options.token}`,
+          'x-record-exempt': 'true'
+        },
+        baseURL: BASE_URL_API
+      }
+    );
+  }
+
+  async tasks(
+    filter: {
+      ids?: string[];
+      applicationId?: string;
+      userId?: string;
+      type?: string;
+      limit?: number;
+      offset?: number;
+      createdAtMax?: number;
+      createdAtMin?: number;
+    },
+    options: { token: string }
+  ): Promise<AxiosResponse<IProducerTasksResponse>> {
+    return await axios.post(
+      `/producer/tasks`,
+      {
+        action: 'retrieve_batch',
+        ...(filter.ids
+          ? {
+              ids: filter.ids
+            }
+          : {}),
+        ...(filter.userId
+          ? {
+              user_id: filter.userId
+            }
+          : {}),
+        ...(filter.type
+          ? {
+              type: filter.type
+            }
+          : {}),
+        ...(filter.applicationId
+          ? {
+              application_id: filter.applicationId
+            }
+          : {}),
+        ...(filter.limit !== undefined
+          ? {
+              limit: filter.limit
+            }
+          : {}),
+        ...(filter.offset !== undefined
+          ? {
+              offset: filter.offset
+            }
+          : {}),
+        ...(filter.createdAtMax !== undefined
+          ? {
+              created_at_max: filter.createdAtMax
+            }
+          : {}),
+        ...(filter.createdAtMin !== undefined
+          ? {
+              created_at_min: filter.createdAtMin
+            }
+          : {})
+      },
+      {
+        headers: {
+          accept: 'application/json',
+          'content-type': 'application/json',
+          authorization: `Bearer ${options.token}`,
+          'x-record-exempt': 'true'
+        },
+        baseURL: BASE_URL_API
+      }
+    );
+  }
+
+  async audio(
+    data: IProducerAudioRequest,
+    options: {
+      token: string;
+    }
+  ): Promise<AxiosResponse<IProducerAudioResponse>> {
+    return await axios.post('/producer/audios', data, {
+      headers: {
+        authorization: `Bearer ${options.token}`,
+        'content-type': 'application/json'
+      },
+      baseURL: BASE_URL_API
+    });
+  }
+
+  async lyric(
+    data: IProducerLyricRequest,
+    options: {
+      token: string;
+    }
+  ): Promise<AxiosResponse<IProducerLyricResponse>> {
+    return await axios.post('/producer/lyrics', data, {
+      headers: {
+        authorization: `Bearer ${options.token}`,
+        'content-type': 'application/json'
+      },
+      baseURL: BASE_URL_API
+    });
+  }
+
+  async upload(
+    data: IProducerUploadRequest,
+    options: {
+      token: string;
+    }
+  ): Promise<AxiosResponse<IProducerUploadResponse>> {
+    return await axios.post('/producer/upload', data, {
+      headers: {
+        authorization: `Bearer ${options.token}`,
+        'content-type': 'application/json'
+      },
+      baseURL: BASE_URL_API
+    });
+  }
+
+  async video(
+    data: IProducerVideoRequest,
+    options: {
+      token: string;
+    }
+  ): Promise<AxiosResponse<IProducerVideoResponse>> {
+    return await axios.post('/producer/videos', data, {
+      headers: {
+        authorization: `Bearer ${options.token}`,
+        'content-type': 'application/json'
+      },
+      baseURL: BASE_URL_API
+    });
+  }
+
+  async wav(
+    data: { audio_id: string },
+    options: {
+      token: string;
+    }
+  ): Promise<AxiosResponse<{ data: { audio_url: string } }>> {
+    return await axios.post('/producer/wav', data, {
+      headers: {
+        authorization: `Bearer ${options.token}`,
+        'content-type': 'application/json'
+      },
+      baseURL: BASE_URL_API
+    });
+  }
+}
+
+export const producerOperator = new ProducerOperator();

--- a/src/pages/producer/Index.vue
+++ b/src/pages/producer/Index.vue
@@ -1,0 +1,241 @@
+<template>
+  <layout>
+    <template #config>
+      <config-panel @generate="onGenerateAudio" />
+    </template>
+    <template #result>
+      <recent-panel ref="recentPanel" class="panel recent" :loading="loadingMore" @reach-top="onReachTop" />
+    </template>
+    <template #preview>
+      <preview-panel />
+    </template>
+  </layout>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import Layout from '@/layouts/Producer.vue';
+import { applicationOperator, producerOperator } from '@/operators';
+import { IApplicationDetailResponse, IProducerAudioRequest, Status } from '@/models';
+import { ElMessage } from 'element-plus';
+import { IProducerTask } from '@/models';
+import { ERROR_CODE_DUPLICATION } from '@/constants';
+import ConfigPanel from '@/components/producer/ConfigPanel.vue';
+import RecentPanel from '@/components/producer/RecentPanel.vue';
+import PreviewPanel from '@/components/producer/PreviewPanel.vue';
+import { loadPreviousPage } from '@/utils/pagination';
+
+const CALLBACK_URL = 'https://webhook.acedata.cloud/producer';
+
+interface IData {
+  task: IProducerTask | undefined;
+  job: number;
+  loadingMore: boolean;
+  fetchingTasks: boolean;
+}
+
+export default defineComponent({
+  name: 'ProducerIndex',
+  components: {
+    Layout,
+    ConfigPanel,
+    RecentPanel,
+    PreviewPanel
+  },
+  inject: ['initialized'],
+  data(): IData {
+    return {
+      task: undefined,
+      job: 0,
+      loadingMore: false,
+      fetchingTasks: false
+    };
+  },
+  computed: {
+    applicationsLoading() {
+      return this.$store.state.producer?.status?.getApplications === Status.Request;
+    },
+    tasksLoading() {
+      return this.$store.state.producer?.status?.getTasks === Status.Request || this.fetchingTasks;
+    },
+    service() {
+      return this.$store.state.producer.service;
+    },
+    credential() {
+      return this.$store.state.producer.credential;
+    },
+    config() {
+      return this.$store.state.producer.config;
+    },
+    initializing() {
+      return this.$store.state.producer.status.getApplications === Status.Request;
+    },
+    needApply() {
+      return this.$store.state.producer.status.getApplications === Status.Success && !this.application;
+    },
+    application() {
+      return this.$store.state.producer.application;
+    },
+    tasks() {
+      return this.$store.state.producer.tasks;
+    },
+    applications() {
+      return this.$store.state.producer.applications;
+    }
+  },
+  watch: {
+    tasks: {
+      handler(value, oldValue) {
+        if (value?.items?.length > oldValue?.items?.length) {
+          console.debug('new tasks detected');
+        }
+      },
+      deep: true
+    },
+    initialized: {
+      async handler(newValue) {
+        if (newValue) {
+          console.debug('layout initialized');
+          await this.onGetTasks();
+          await this.onScrollDown();
+          this.job = window.setInterval(() => {
+            this.onGetTasks();
+          }, 5000);
+        }
+      },
+      immediate: true
+    }
+  },
+  async mounted() {
+    await this.onGetService();
+  },
+  async unmounted() {
+    window.clearInterval(this.job);
+  },
+  methods: {
+    async onReachTop() {
+      await loadPreviousPage({
+        tasks: this.tasks,
+        getTasks: () => this.tasks,
+        loading: this.loadingMore,
+        setLoading: (v) => (this.loadingMore = v),
+        isBlocked: () => this.tasksLoading || this.applicationsLoading,
+        fetch: (createdAtMax) =>
+          this.onGetTasks({
+            createdAtMax
+          }),
+        getScrollElement: () => this.getTasksScrollElement()
+      });
+    },
+    async onGetService() {
+      console.debug('start onGetService');
+      await this.$store.dispatch('producer/getService');
+      console.debug('end onGetService');
+    },
+    async onGetApplication() {
+      console.debug('start onGetApplications');
+      await this.$store.dispatch('producer/getApplications');
+      console.debug('end onGetApplications');
+      await this.onGetTasks();
+    },
+    onApply() {
+      applicationOperator
+        .create({
+          // @ts-ignore
+          application: this.application
+        })
+        .then(({ data: data }: { data: IApplicationDetailResponse }) => {
+          this.application = data;
+          ElMessage.success(this.$t('application.message.applySuccessfully'));
+        })
+        .catch((error) => {
+          if (error?.response?.data?.code === ERROR_CODE_DUPLICATION) {
+            ElMessage.error(this.$t('application.message.alreadyApplied'));
+          }
+        });
+    },
+    async onScrollDown() {
+      await this.$nextTick();
+      const el = this.getTasksScrollElement();
+      if (el) {
+        el.scrollTop = el.scrollHeight;
+      }
+    },
+    async onGetTasks(payload?: { limit?: number; createdAtMin?: number; createdAtMax?: number }) {
+      if (this.applicationsLoading || this.fetchingTasks) {
+        console.debug('loading');
+        return;
+      }
+      console.debug('start onGetTasks', payload);
+      const { limit = 5, createdAtMin, createdAtMax } = payload || {};
+      console.debug('limit', limit, 'createdAtMin', createdAtMin, 'createdAtMax', createdAtMax);
+      this.fetchingTasks = true;
+      try {
+        await this.$store.dispatch('producer/getTasks', {
+          limit,
+          createdAtMin,
+          createdAtMax
+        });
+      } finally {
+        this.fetchingTasks = false;
+      }
+    },
+    async onGenerateAudio() {
+      const request = {
+        ...this.config,
+        callback_url: CALLBACK_URL
+      } as IProducerAudioRequest;
+      const token = this.credential?.token;
+      if (!token) {
+        console.error('no token specified');
+        return;
+      }
+      ElMessage.info(this.$t('producer.message.startingTask'));
+      producerOperator
+        .audio(request, {
+          token
+        })
+        .then(() => {
+          ElMessage.success(this.$t('producer.message.startTaskSuccess'));
+        })
+        .catch((error) => {
+          ElMessage.error(error?.response?.data?.error?.message || this.$t('producer.message.startTaskFailed'));
+        })
+        .finally(async () => {
+          setTimeout(async () => {
+            await this.onGetTasks();
+            await this.onScrollDown();
+          }, 1000);
+        });
+    },
+    getTasksScrollElement(): HTMLElement | undefined {
+      const panel = this.$refs.recentPanel as any;
+      return panel?.getScrollElement?.();
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.status {
+  margin-bottom: 10px;
+}
+
+.panel {
+  &.detail {
+    width: 100%;
+    flex: 1;
+    overflow-y: scroll;
+  }
+  &.recent {
+    height: 100%;
+    width: 100%;
+    margin-bottom: 10px;
+    position: relative;
+    justify-content: initial;
+  }
+  &.operation {
+    position: relative;
+  }
+}
+</style>

--- a/src/router/constants.ts
+++ b/src/router/constants.ts
@@ -54,6 +54,8 @@ export const ROUTE_HEADSHOTS_HISTORY = 'headshots-history';
 export const ROUTE_SUNO_INDEX = 'suno-index';
 export const ROUTE_SUNO_HISTORY = 'suno-history';
 
+export const ROUTE_PRODUCER_INDEX = 'producer-index';
+
 export const ROUTE_NANOBANANA_INDEX = 'nanobanana-index';
 
 export const ROUTE_SEEDREAM_INDEX = 'seedream-index';

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -20,6 +20,7 @@ import flux from './flux';
 import hailuo from './hailuo';
 import headshots from './headshots';
 import suno from './suno';
+import producer from './producer';
 import nanobanana from './nanobanana';
 import seedream from './seedream';
 import seedance from './seedance';
@@ -155,6 +156,12 @@ const ROUTE_SEO: Record<string, { title: string; description: string; keywords: 
     keywords: ['Suno', 'AI Music', 'Music Generation', 'AI Song', 'Text to Music'],
     category: 'AI Music Generation'
   },
+  producer: {
+    title: 'Producer',
+    description: 'Create AI music with Producer — generate songs, lyrics, and music with FUZZ models.',
+    keywords: ['Producer', 'AI Music', 'Music Generation', 'FUZZ', 'AI Song'],
+    category: 'AI Music Generation'
+  },
   distribution: {
     title: 'Affiliate',
     description: 'Join the Ace Data Cloud affiliate program — earn commissions by referring AI services.',
@@ -186,6 +193,7 @@ const routes = [
   hailuo,
   headshots,
   suno,
+  producer,
   nanobanana,
   seedream,
   seedance,

--- a/src/router/producer.ts
+++ b/src/router/producer.ts
@@ -1,0 +1,17 @@
+import { ROUTE_PRODUCER_INDEX } from './constants';
+
+export default {
+  path: '/producer',
+  meta: {
+    auth: true,
+    appName: 'producer'
+  },
+  component: () => import('@/layouts/Main.vue'),
+  children: [
+    {
+      path: '',
+      name: ROUTE_PRODUCER_INDEX,
+      component: () => import('@/pages/producer/Index.vue')
+    }
+  ]
+};

--- a/src/store/common/models.ts
+++ b/src/store/common/models.ts
@@ -12,6 +12,7 @@ import { IFluxState } from '../flux/models';
 import { IHailuoState } from '../hailuo/models';
 import { IHeadshotsState } from '../headshots/models';
 import { ISunoState } from '../suno/models';
+import { IProducerState } from '../producer/models';
 import { INanobananaState } from '../nanobanana/models';
 import { ISeedreamState } from '../seedream/models';
 import { ISeedanceState } from '../seedance/models';
@@ -57,6 +58,7 @@ export interface IAppState {
   hailuo: IHailuoState;
   headshots: IHeadshotsState;
   suno: ISunoState;
+  producer: IProducerState;
   nanobanana: INanobananaState;
   seedream: ISeedreamState;
   seedance: ISeedanceState;

--- a/src/store/common/state.ts
+++ b/src/store/common/state.ts
@@ -11,6 +11,7 @@ import pixverseState from '../pixverse/state';
 import fluxState from '../flux/state';
 import hailuoState from '../hailuo/state';
 import sunoState from '../suno/state';
+import producerState from '../producer/state';
 import headshotsState from '../headshots/state';
 import nanobananaState from '../nanobanana/state';
 import seedreamState from '../seedream/state';
@@ -52,6 +53,7 @@ export default (): IRootState => {
     flux: fluxState(),
     hailuo: hailuoState(),
     suno: sunoState(),
+    producer: producerState(),
     headshots: headshotsState(),
     nanobanana: nanobananaState(),
     seedream: seedreamState(),

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -13,6 +13,7 @@ import flux from './flux';
 import hailuo from './hailuo';
 import headshots from './headshots';
 import suno from './suno';
+import producer from './producer';
 import nanobanana from './nanobanana';
 import seedream from './seedream';
 import seedance from './seedance';
@@ -30,6 +31,7 @@ import persistFlux from './flux/persist';
 import persistHailuo from './hailuo/persist';
 import persistHeadshots from './headshots/persist';
 import persistSuno from './suno/persist';
+import persistProducer from './producer/persist';
 import persistNanobanana from './nanobanana/persist';
 import persistSeedream from './seedream/persist';
 import persistSeedance from './seedance/persist';
@@ -51,6 +53,7 @@ const store = createStore({
     hailuo: hailuo,
     headshots: headshots,
     suno: suno,
+    producer: producer,
     nanobanana: nanobanana,
     seedream: seedream,
     seedance: seedance
@@ -72,6 +75,7 @@ const store = createStore({
         ...persistHailuo,
         ...persistHeadshots,
         ...persistSuno,
+        ...persistProducer,
         ...persistNanobanana,
         ...persistSeedream,
         ...persistSeedance

--- a/src/store/producer/actions.ts
+++ b/src/store/producer/actions.ts
@@ -1,0 +1,192 @@
+import { applicationOperator, producerOperator, serviceOperator, credentialOperator } from '@/operators';
+import { IProducerState } from './models';
+import { ActionContext } from 'vuex';
+import { IRootState } from '../common/models';
+import { IApplication, ICredential, IProducerConfig, IProducerTask, IService } from '@/models';
+import { Status } from '@/models/common';
+import { PRODUCER_SERVICE_ID } from '@/constants';
+import { mergeAndSortLists } from '@/utils/merge';
+
+export const resetAll = ({ commit }: ActionContext<IProducerState, IRootState>): void => {
+  commit('resetAll');
+};
+
+export const setApplication = async ({ commit, dispatch }: any, payload: IApplication): Promise<void> => {
+  console.debug('set application', payload);
+  commit('setApplication', payload);
+  if (!payload) {
+    console.debug('application is null, return');
+    return;
+  }
+  const credential = payload?.credentials?.find((credential) => credential?.host === window.location.origin);
+  if (credential) {
+    console.debug('credential exists, set credential', credential);
+    commit('setCredential', credential);
+  } else {
+    console.debug('credential not exists, start to create credential for application', payload);
+    await dispatch('createCredential');
+  }
+};
+
+export const setApplications = async ({ commit }: any, payload: IApplication[]): Promise<void> => {
+  console.debug('set applications', payload);
+  commit('setApplications', payload);
+};
+
+export const setService = async ({ commit }: any, payload: IService): Promise<void> => {
+  console.debug('set service', payload);
+  commit('setService', payload);
+};
+
+export const setCredential = async ({ commit }: any, payload: ICredential): Promise<void> => {
+  console.debug('set credential', payload);
+  commit('setCredential', payload);
+};
+
+export const createCredential = async ({ commit, state }: any): Promise<ICredential | undefined> => {
+  const application = state.application;
+  console.debug('prepare to create credential for application', application);
+  if (!application) {
+    console.error('Application not found');
+    return undefined;
+  }
+  console.debug('creating create credential for application', application);
+  const { data: credential } = await credentialOperator.create({
+    application_id: application?.id,
+    host: window.location.origin
+  });
+  console.debug('created credential success', credential);
+  commit('setCredential', credential);
+  console.debug('end createCredential');
+  return credential;
+};
+
+export const getService = async ({
+  commit,
+  state
+}: ActionContext<IProducerState, IRootState>): Promise<IService | undefined> => {
+  state.status.getService = Status.Request;
+  try {
+    const { data: service } = await serviceOperator.get(PRODUCER_SERVICE_ID);
+    state.status.getService = Status.Success;
+    commit('setService', service);
+    return service;
+  } catch (error) {
+    state.status.getService = Status.Error;
+    commit('setService', undefined);
+  }
+};
+
+export const getApplications = async ({
+  commit,
+  state,
+  rootState
+}: ActionContext<IProducerState, IRootState>): Promise<IApplication[] | undefined> => {
+  console.debug('start to get applications for producer');
+  state.status.getApplications = Status.Request;
+  const currentApplication = state.application;
+  console.debug('current application', currentApplication);
+  try {
+    const { data: applications } = await applicationOperator.getAll({
+      user_id: rootState?.user?.id,
+      service_id: PRODUCER_SERVICE_ID
+    });
+    state.status.getApplications = Status.Success;
+    commit('setApplications', applications.items);
+    return applications.items;
+  } catch (error) {
+    console.error('get applications failed', error);
+    state.status.getApplications = Status.Error;
+    commit('setApplications', undefined);
+    commit('setApplication', undefined);
+  }
+};
+
+export const setConfig = ({ commit }: any, payload: IProducerConfig) => {
+  commit('setConfig', payload);
+};
+
+export const setTasks = ({ commit }: any, payload: any) => {
+  commit('setTasks', payload);
+};
+
+export const setTasksItems = ({ commit }: any, payload: IProducerTask[]) => {
+  commit('setTasksItems', payload);
+};
+
+export const setTasksTotal = ({ commit }: any, payload: number) => {
+  commit('setTasksTotal', payload);
+};
+
+export const setTasksActive = ({ commit }: any, payload: IProducerTask) => {
+  commit('setTasksActive', payload);
+};
+
+export const setAudio = ({ commit }: any, payload: any) => {
+  commit('setAudio', payload);
+};
+
+export const getTasks = async (
+  { commit, state, rootState }: ActionContext<IProducerState, IRootState>,
+  {
+    offset,
+    limit,
+    createdAtMin,
+    createdAtMax
+  }: { offset?: number; limit?: number; createdAtMin?: number; createdAtMax?: number }
+): Promise<IProducerTask[]> => {
+  return new Promise((resolve, reject) => {
+    console.debug('start to get tasks', offset, limit, createdAtMax, createdAtMin);
+    const credential = state.credential;
+    const token = credential?.token;
+    if (!token) {
+      return reject('no token');
+    }
+    producerOperator
+      .tasks(
+        {
+          userId: rootState?.user?.id,
+          createdAtMin,
+          createdAtMax,
+          type: 'audios'
+        },
+        {
+          token
+        }
+      )
+      .then((response) => {
+        console.debug('get producer tasks success', response.data.items);
+        // merge with existing tasks
+        const existingItems = state?.tasks?.items || [];
+        console.debug('existing items', existingItems);
+        const newItems = response.data.items || [];
+        console.debug('new items', newItems);
+        // sort and de-duplicate using created_at
+        const mergedItems = mergeAndSortLists(existingItems, newItems);
+        commit('setTasksItems', mergedItems);
+        commit('setTasksTotal', response.data.count);
+        resolve(response.data.items);
+      })
+      .catch((error) => {
+        return reject(error);
+      });
+  });
+};
+
+export default {
+  setService,
+  getService,
+  resetAll,
+  setCredential,
+  setConfig,
+  setApplication,
+  setApplications,
+  getApplications,
+  setTasks,
+  setTasksItems,
+  setTasksTotal,
+  setTasksActive,
+  getTasks,
+  setAudio,
+  createCredential
+};

--- a/src/store/producer/index.ts
+++ b/src/store/producer/index.ts
@@ -1,0 +1,14 @@
+import { Module } from 'vuex';
+import { IProducerState } from './models';
+import actions from './actions';
+import mutations from './mutations';
+import state from './state';
+
+export const producer: Module<IProducerState, any> = {
+  namespaced: true,
+  state,
+  mutations,
+  actions
+};
+
+export default producer;

--- a/src/store/producer/models.ts
+++ b/src/store/producer/models.ts
@@ -1,0 +1,23 @@
+import { IApplication, ICredential, IService, IProducerAudio, Status } from '@/models';
+import { IProducerConfig, IProducerTask } from '@/models';
+
+export interface IProducerState {
+  application: IApplication | undefined;
+  applications: IApplication[] | undefined;
+  service: IService | undefined;
+  credential: ICredential | undefined;
+  config: IProducerConfig | undefined;
+  tasks:
+    | {
+        items: IProducerTask[] | undefined;
+        total: number | undefined;
+        active: IProducerTask | undefined;
+      }
+    | undefined;
+  audio: IProducerAudio | undefined;
+  status: {
+    getService: Status;
+    getApplications: Status;
+    getTasks: Status;
+  };
+}

--- a/src/store/producer/mutations.ts
+++ b/src/store/producer/mutations.ts
@@ -1,0 +1,77 @@
+import { IApplication, ICredential, IProducerConfig, IProducerTask, IService } from '@/models';
+import { IProducerState } from './models';
+
+export const resetAll = (state: IProducerState): void => {
+  state.service = undefined;
+  state.application = undefined;
+  state.applications = undefined;
+  state.config = undefined;
+  state.credential = undefined;
+  state.tasks = undefined;
+};
+
+export const setApplications = (state: IProducerState, payload: IApplication[]): void => {
+  state.applications = payload;
+};
+
+export const setService = (state: IProducerState, payload: IService): void => {
+  state.service = payload;
+};
+
+export const setCredential = (state: IProducerState, payload: ICredential): void => {
+  state.credential = payload;
+};
+
+export const setApplication = (state: IProducerState, payload: IApplication): void => {
+  state.application = payload;
+};
+
+export const setConfig = (state: IProducerState, payload: IProducerConfig): void => {
+  state.config = payload;
+};
+
+export const setTasksItems = (state: IProducerState, payload: IProducerTask[]): void => {
+  const newPayload = {
+    ...state.tasks,
+    items: payload
+  } as typeof state.tasks;
+  state.tasks = newPayload;
+};
+
+export const setTasksTotal = (state: IProducerState, payload: number): void => {
+  const newPayload = {
+    ...state.tasks,
+    total: payload
+  } as typeof state.tasks;
+  state.tasks = newPayload;
+};
+
+export const setTasksActive = (state: IProducerState, payload: IProducerTask): void => {
+  const newPayload = {
+    ...state.tasks,
+    active: payload
+  } as typeof state.tasks;
+  state.tasks = newPayload;
+};
+
+export const setAudio = (state: IProducerState, payload: any): void => {
+  state.audio = payload;
+};
+
+export const setTasks = (state: IProducerState, payload: any): void => {
+  state.tasks = payload;
+};
+
+export default {
+  setTasks,
+  setApplication,
+  setApplications,
+  setConfig,
+  setCredential,
+  setService,
+  setTasksActive,
+  setTasksItems,
+  setTasksTotal,
+  setAudio,
+  resetAll
+};

--- a/src/store/producer/persist.ts
+++ b/src/store/producer/persist.ts
@@ -1,0 +1,1 @@
+export default ['producer.credential', 'producer.application', 'producer.applications', 'producer.tasks'];

--- a/src/store/producer/state.ts
+++ b/src/store/producer/state.ts
@@ -1,0 +1,21 @@
+import { IProducerState } from './models';
+import { Status } from '@/models';
+
+export default (): IProducerState => {
+  return {
+    service: undefined,
+    application: undefined,
+    applications: undefined,
+    tasks: undefined,
+    audio: {
+      volume: 100
+    },
+    credential: undefined,
+    config: undefined,
+    status: {
+      getService: Status.None,
+      getApplications: Status.None,
+      getTasks: Status.None
+    }
+  };
+};


### PR DESCRIPTION
## Summary

Add complete Producer AI music generation service to Nexior, following the exact same architecture as the existing Suno service with Producer-specific adaptations.

### Key differences from Suno
- **Models**: FUZZ model family (2.0 Pro, 2.0, 2.0 Raw, 1.1 Pro, 1.0 Pro, 1.0, 1.1, 0.8) instead of Suno v2-v5.5
- **Actions**: variation, swap_vocals, swap_instrumentals (no mashup, concat, remaster)
- **Advanced params**: sound_strength, lyrics_strength, seed (no style_influence, variation_category, audio_weight)
- **No MIDI** download option, **no style optimization** endpoint
- **Video endpoint**: `/producer/videos` instead of `/suno/mp4`
- **Webhook**: `https://webhook.acedata.cloud/producer`
- **Service ID**: `864a7efd-c7a3-4ad8-b372-ba8d64cdeda8`

### Files added (35 new files)
- `src/constants/producer.ts` — Constants (service ID, logo, default model)
- `src/models/producer.ts` — TypeScript interfaces
- `src/operators/producer.ts` — API operator (singleton)
- `src/store/producer/` — Vuex namespaced module (6 files)
- `src/router/producer.ts` — Route configuration
- `src/layouts/Producer.vue` — Three-column layout
- `src/pages/producer/Index.vue` — Main page with task polling
- `src/components/producer/ConfigPanel.vue` — Config panel
- `src/components/producer/config/` — 10 config sub-components
- `src/components/producer/RecentPanel.vue` — Task list panel
- `src/components/producer/PreviewPanel.vue` — Audio preview panel
- `src/components/producer/task/Preview.vue` — Task card with actions
- `src/components/producer/player/` — 6 audio player components
- `src/i18n/en/producer.json` — English translations
- `src/i18n/zh-CN/producer.json` — Chinese translations

### Integration files modified (7)
- `src/constants/index.ts` — Export producer constants
- `src/models/index.ts` — Export producer models
- `src/operators/index.ts` — Export producer operator
- `src/store/index.ts` — Register producer Vuex module + persist
- `src/router/index.ts` — Register producer route + SEO metadata
- `src/router/constants.ts` — Add ROUTE_PRODUCER_INDEX constant
- `src/constants/i18n.ts` — Add 'producer' to I18N_SCOPES

## Test plan
- [ ] Verify TypeScript compilation passes
- [ ] Verify ESLint passes
- [ ] Navigate to /producer route and verify three-column layout renders
- [ ] Test music generation with FUZZ-2.0 Pro model
- [ ] Test all config sub-components (lyrics, style, title, model selector, advanced params)
- [ ] Test extend, cover, upload, replace section, vocal gender, variation actions
- [ ] Test audio player (play/pause, progress slider, volume control)
- [ ] Test task list polling and preview panel
- [ ] Test download options (video, audio, WAV -- no MIDI)
- [ ] Verify i18n translations load for both en and zh-CN