### PR TITLE
fix: add feature setting toggles for new services

### DIFF
--- a/change/@acedatacloud-nexior-855a8b78-249e-4539-8d7b-a523b7750f3d.json
+++ b/change/@acedatacloud-nexior-855a8b78-249e-4539-8d7b-a523b7750f3d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add feature setting toggles for Wan, Producer, Kimi, and SERP services",
+  "packageName": "@acedatacloud/nexior",
+  "email": "cqc@cuiqingcai.com",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/Navigator.vue
+++ b/src/components/common/Navigator.vue
@@ -87,7 +87,12 @@ import {
   ROUTE_SORA_HISTORY,
   ROUTE_NANOBANANA_INDEX,
   ROUTE_SEEDREAM_INDEX,
-  ROUTE_SEEDANCE_INDEX
+  ROUTE_SEEDANCE_INDEX,
+  ROUTE_WAN_INDEX,
+  ROUTE_PRODUCER_INDEX,
+  ROUTE_KIMI_CONVERSATION,
+  ROUTE_KIMI_CONVERSATION_NEW,
+  ROUTE_SERP_INDEX
 } from '@/router/constants';
 import {
   CHAT_MODEL_ICON_CHATGPT,
@@ -106,7 +111,10 @@ import {
   KLING_LOGO,
   VEO_LOGO,
   SORA_LOGO,
-  PIXVERSE_LOGO
+  PIXVERSE_LOGO,
+  WAN_LOGO,
+  PRODUCER_LOGO,
+  CHAT_MODEL_ICON_KIMI
 } from '@/constants';
 import UserCenter from '@/components/user/Center.vue';
 
@@ -194,6 +202,15 @@ export default defineComponent({
           category: 'chat'
         });
       }
+      if (this.$store?.state?.site?.features?.kimi?.enabled) {
+        result.push({
+          route: { name: ROUTE_KIMI_CONVERSATION_NEW },
+          displayName: this.$t('common.nav.kimi'),
+          logo: CHAT_MODEL_ICON_KIMI,
+          routes: [ROUTE_KIMI_CONVERSATION, ROUTE_KIMI_CONVERSATION_NEW],
+          category: 'chat'
+        });
+      }
       // Image category
       if (this.$store?.state?.site?.features?.midjourney?.enabled) {
         result.push({
@@ -238,6 +255,15 @@ export default defineComponent({
           displayName: this.$t('common.nav.suno'),
           logo: SUNO_LOGO,
           routes: [ROUTE_SUNO_INDEX, ROUTE_SUNO_HISTORY],
+          category: 'music'
+        });
+      }
+      if (this.$store?.state?.site?.features?.producer?.enabled) {
+        result.push({
+          route: { name: ROUTE_PRODUCER_INDEX },
+          displayName: this.$t('common.nav.producer'),
+          logo: PRODUCER_LOGO,
+          routes: [ROUTE_PRODUCER_INDEX],
           category: 'music'
         });
       }
@@ -303,6 +329,25 @@ export default defineComponent({
           logo: PIXVERSE_LOGO,
           routes: [ROUTE_PIXVERSE_INDEX, ROUTE_PIXVERSE_HISTORY],
           category: 'video'
+        });
+      }
+      if (this.$store?.state?.site?.features?.wan?.enabled) {
+        result.push({
+          route: { name: ROUTE_WAN_INDEX },
+          displayName: this.$t('common.nav.wan'),
+          logo: WAN_LOGO,
+          routes: [ROUTE_WAN_INDEX],
+          category: 'video'
+        });
+      }
+      // Search category
+      if (this.$store?.state?.site?.features?.serp?.enabled) {
+        result.push({
+          route: { name: ROUTE_SERP_INDEX },
+          displayName: this.$t('common.nav.serp'),
+          icon: 'fa-solid fa-magnifying-glass',
+          routes: [ROUTE_SERP_INDEX],
+          category: 'search'
         });
       }
       if (this.direction === 'row') {

--- a/src/components/setting/Function.vue
+++ b/src/components/setting/Function.vue
@@ -105,7 +105,11 @@ const FEATURE_KEYS = [
   'headshots',
   'nanobanana',
   'seedream',
-  'seedance'
+  'seedance',
+  'wan',
+  'producer',
+  'kimi',
+  'serp'
 ];
 
 export default defineComponent({

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -475,6 +475,22 @@
     "message": "Hailuo",
     "description": "Text in the website navigation bar to display the Hailuo page, must remain as 'Hailuo'"
   },
+  "nav.wan": {
+    "message": "Wan",
+    "description": "Text in the website navigation bar to display the Wan page, must remain as 'Wan'"
+  },
+  "nav.producer": {
+    "message": "Producer",
+    "description": "Text in the website navigation bar to display the Producer page, must remain as 'Producer'"
+  },
+  "nav.kimi": {
+    "message": "Kimi",
+    "description": "Text in the website navigation bar to display the Kimi page, must remain as 'Kimi'"
+  },
+  "nav.serp": {
+    "message": "SERP",
+    "description": "Text in the website navigation bar to display the SERP page, must remain as 'SERP'"
+  },
   "nav.image": {
     "message": "Image",
     "description": "Text in the website navigation bar to display the image page"

--- a/src/i18n/en/site.json
+++ b/src/i18n/en/site.json
@@ -123,6 +123,22 @@
     "message": "SeeDance",
     "description": "Displayed as the title in the editing box"
   },
+  "field.featuresWan": {
+    "message": "Wan",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresProducer": {
+    "message": "Producer",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresKimi": {
+    "message": "Kimi",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresSerp": {
+    "message": "SERP",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresSupport": {
     "message": "Customer Support",
     "description": "Displayed as the title in the editing box"
@@ -350,6 +366,22 @@
   "message.featuresSeedance": {
     "message": "Enable or disable the SeeDance feature module.",
     "description": "Description of the SeeDance feature"
+  },
+  "message.featuresWan": {
+    "message": "Enable or disable the Wan feature module.",
+    "description": "Description of the Wan feature"
+  },
+  "message.featuresProducer": {
+    "message": "Enable or disable the Producer feature module.",
+    "description": "Description of the Producer feature"
+  },
+  "message.featuresKimi": {
+    "message": "Enable or disable the Kimi feature module.",
+    "description": "Description of the Kimi feature"
+  },
+  "message.featuresSerp": {
+    "message": "Enable or disable the SERP feature module.",
+    "description": "Description of the SERP feature"
   },
   "message.featuresLuma": {
     "message": "Enable or disable the Luma feature module.",

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -475,6 +475,22 @@
     "message": "Hailuo",
     "description": "网站导航栏中的文本，用于显示Hailuo页面，请不要翻译此字段，必须保持为'Hailuo'"
   },
+  "nav.wan": {
+    "message": "Wan",
+    "description": "网站导航栏中的文本，用于显示Wan页面，请不要翻译此字段，必须保持为'Wan'"
+  },
+  "nav.producer": {
+    "message": "Producer",
+    "description": "网站导航栏中的文本，用于显示Producer页面，请不要翻译此字段，必须保持为'Producer'"
+  },
+  "nav.kimi": {
+    "message": "Kimi",
+    "description": "网站导航栏中的文本，用于显示Kimi页面，请不要翻译此字段，必须保持为'Kimi'"
+  },
+  "nav.serp": {
+    "message": "SERP",
+    "description": "网站导航栏中的文本，用于显示SERP页面，请不要翻译此字段，必须保持为'SERP'"
+  },
   "nav.image": {
     "message": "图片",
     "description": "网站导航栏中的文本，用于显示图片页面"

--- a/src/i18n/zh-CN/site.json
+++ b/src/i18n/zh-CN/site.json
@@ -123,6 +123,22 @@
     "message": "SeeDance",
     "description": "Displayed as the title in the editing box"
   },
+  "field.featuresWan": {
+    "message": "Wan",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresProducer": {
+    "message": "Producer",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresKimi": {
+    "message": "Kimi",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresSerp": {
+    "message": "SERP",
+    "description": "展示在编辑框的标题"
+  },
   "field.featuresSupport": {
     "message": "客服支持",
     "description": "展示在编辑框的标题"
@@ -350,6 +366,22 @@
   "message.featuresSeedance": {
     "message": "启用或禁用SeeDance功能模块。",
     "description": "SeeDance功能的描述"
+  },
+  "message.featuresWan": {
+    "message": "打开或关闭 Wan 功能模块。",
+    "description": "Wan 功能的描述"
+  },
+  "message.featuresProducer": {
+    "message": "打开或关闭 Producer 功能模块。",
+    "description": "Producer 功能的描述"
+  },
+  "message.featuresKimi": {
+    "message": "打开或关闭 Kimi 功能模块。",
+    "description": "Kimi 功能的描述"
+  },
+  "message.featuresSerp": {
+    "message": "打开或关闭 SERP 功能模块。",
+    "description": "SERP 功能的描述"
   },
   "message.featuresLuma": {
     "message": "打开或关闭 Luma 功能模块。",

--- a/src/models/site.ts
+++ b/src/models/site.ts
@@ -19,6 +19,10 @@ export interface ISiteFeatures {
   nanobanana?: any;
   seedream?: any;
   seedance?: any;
+  wan?: any;
+  producer?: any;
+  kimi?: any;
+  serp?: any;
   support?: any;
 }
 

--- a/src/pages/site/Index.vue
+++ b/src/pages/site/Index.vue
@@ -188,6 +188,9 @@
                   'flux',
                   'hailuo',
                   'headshots',
+                  'wan',
+                  'producer',
+                  'serp',
                   'support'
                 ]"
                 :key="featureIndex"


### PR DESCRIPTION
## Summary
- Add Wan, Producer, Kimi, and SERP to the feature settings toggle list (`Function.vue`)
- Add navigation sidebar entries for all 4 new services (`Navigator.vue`)
- Add feature toggles in site admin page (`site/Index.vue`) for Wan, Producer, SERP
- Add i18n labels (en + zh-CN) for feature settings and navigation

## Test plan
- [ ] Verify Wan, Producer, Kimi, SERP appear in 功能设置 (Feature Settings) dialog
- [ ] Verify toggling each service on/off works correctly
- [ ] Verify navigation sidebar shows new services when enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)