### PR TITLE
fix: replace broken CDN logos for Wan, Kimi, and SERP

### DIFF
--- a/change/@acedatacloud-nexior-36907f5f-a5f6-46ce-938b-a6a2f18e84f6.json
+++ b/change/@acedatacloud-nexior-36907f5f-a5f6-46ce-938b-a6a2f18e84f6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: replace broken CDN logos for Wan, Kimi, and SERP services",
+  "packageName": "@acedatacloud/nexior",
+  "email": "cqc@cuiqingcai.com",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/Navigator.vue
+++ b/src/components/common/Navigator.vue
@@ -114,7 +114,8 @@ import {
   PIXVERSE_LOGO,
   WAN_LOGO,
   PRODUCER_LOGO,
-  CHAT_MODEL_ICON_KIMI
+  CHAT_MODEL_ICON_KIMI,
+  SERP_LOGO
 } from '@/constants';
 import UserCenter from '@/components/user/Center.vue';
 
@@ -345,7 +346,7 @@ export default defineComponent({
         result.push({
           route: { name: ROUTE_SERP_INDEX },
           displayName: this.$t('common.nav.serp'),
-          icon: 'fa-solid fa-magnifying-glass',
+          logo: SERP_LOGO,
           routes: [ROUTE_SERP_INDEX],
           category: 'search'
         });

--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -40,7 +40,7 @@ export const CHAT_MODEL_ICON_GROK = 'https://cdn.acedata.cloud/p1ge98.png';
 export const CHAT_MODEL_ICON_DEEPSEEK = 'https://cdn.acedata.cloud/bc71ae.png';
 export const CHAT_MODEL_ICON_GEMINI = 'https://cdn.acedata.cloud/psfx0g.jpg';
 export const CHAT_MODEL_ICON_CLAUDE = 'https://cdn.acedata.cloud/8fnw4v.jpg';
-export const CHAT_MODEL_ICON_KIMI = 'https://cdn.acedata.cloud/kimi.png';
+export const CHAT_MODEL_ICON_KIMI = 'https://cdn.acedata.cloud/e7861e4761.png';
 
 export const CHAT_SERVICE_ID = 'b1fbcc32-e218-4253-9dc3-4fe600a1bfb9';
 

--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -40,7 +40,7 @@ export const CHAT_MODEL_ICON_GROK = 'https://cdn.acedata.cloud/p1ge98.png';
 export const CHAT_MODEL_ICON_DEEPSEEK = 'https://cdn.acedata.cloud/bc71ae.png';
 export const CHAT_MODEL_ICON_GEMINI = 'https://cdn.acedata.cloud/psfx0g.jpg';
 export const CHAT_MODEL_ICON_CLAUDE = 'https://cdn.acedata.cloud/8fnw4v.jpg';
-export const CHAT_MODEL_ICON_KIMI = 'https://cdn.acedata.cloud/e7861e4761.png';
+export const CHAT_MODEL_ICON_KIMI = 'https://cdn.acedata.cloud/57ebgy.png';
 
 export const CHAT_SERVICE_ID = 'b1fbcc32-e218-4253-9dc3-4fe600a1bfb9';
 

--- a/src/constants/producer.ts
+++ b/src/constants/producer.ts
@@ -1,5 +1,5 @@
 export const PRODUCER_SERVICE_ID = '864a7efd-c7a3-4ad8-b372-ba8d64cdeda8';
 
-export const PRODUCER_LOGO = 'https://cdn.acedata.cloud/l3ffw7.jpg';
+export const PRODUCER_LOGO = 'https://cdn.acedata.cloud/id0mz5.jpg';
 
 export const PRODUCER_DEFAULT_MODEL = 'FUZZ-2.0 Pro';

--- a/src/constants/serp.ts
+++ b/src/constants/serp.ts
@@ -1,1 +1,3 @@
 export const SERP_SERVICE_ID = 'a9af5926-e8d8-4c5e-bdef-bbebf19cdbc3';
+
+export const SERP_LOGO = 'https://cdn.acedata.cloud/27e11e555d.png';

--- a/src/constants/wan.ts
+++ b/src/constants/wan.ts
@@ -1,5 +1,5 @@
 export const WAN_SERVICE_ID = 'f35a16da-726b-425f-96ba-bec7436cfc23';
 
-export const WAN_LOGO = 'https://cdn.acedata.cloud/wan.png';
+export const WAN_LOGO = 'https://cdn.acedata.cloud/a033884259.png';
 
 export const WAN_DEFAULT_MODEL = 'wan2.6-t2v';


### PR DESCRIPTION
## Summary
- Replace broken Wan logo CDN URL with working GitHub org avatar image
- Replace broken Kimi chat model icon CDN URL with working app icon image
- Add `SERP_LOGO` constant with uploaded MCP icon to CDN
- Update Navigator.vue to use `SERP_LOGO` image instead of Font Awesome icon for SERP nav entry

## Test plan
- [ ] Verify Wan logo renders correctly in the sidebar navigation
- [ ] Verify Kimi icon renders correctly in the chat model selector
- [ ] Verify SERP logo renders correctly in the sidebar navigation
- [ ] Confirm all three CDN URLs return HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)