### PR TITLE
fix: serp image search shows no results

### DIFF
--- a/change/@acedatacloud-nexior-fix-serp-image-search.json
+++ b/change/@acedatacloud-nexior-fix-serp-image-search.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: serp image search shows no results due to missing images check in noResults",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/serp/ResultPanel.vue
+++ b/src/components/serp/ResultPanel.vue
@@ -1,16 +1,27 @@
 <template>
   <div class="h-full overflow-y-auto p-6">
-    <div v-if="searching" class="flex flex-col items-center justify-center py-20">
-      <el-skeleton :rows="8" animated />
+    <div v-if="searching" class="max-w-3xl mx-auto py-8">
+      <div v-for="i in 4" :key="i" class="mb-6 animate-pulse">
+        <div class="flex items-center gap-2 mb-2">
+          <div class="w-4 h-4 rounded-sm bg-[var(--el-fill-color-darker)]" />
+          <div class="h-3 w-32 rounded bg-[var(--el-fill-color-darker)]" />
+        </div>
+        <div class="h-4 w-3/4 rounded bg-[var(--el-fill-color-dark)] mb-2" />
+        <div class="h-3 w-full rounded bg-[var(--el-fill-color)] mb-1" />
+        <div class="h-3 w-5/6 rounded bg-[var(--el-fill-color)]" />
+      </div>
     </div>
-    <div v-else-if="noResults" class="flex flex-col items-center justify-center py-20 text-gray-400">
-      <font-awesome-icon icon="fa-solid fa-search" class="text-4xl mb-4" />
-      <p>{{ $t('serp.message.noResults') }}</p>
+    <div
+      v-else-if="noResults"
+      class="flex flex-col items-center justify-center py-24 text-[var(--el-text-color-disabled)]"
+    >
+      <font-awesome-icon icon="fa-solid fa-face-meh" class="text-5xl mb-4 opacity-40" />
+      <p class="text-base">{{ $t('serp.message.noResults') }}</p>
     </div>
     <div v-else-if="results" class="max-w-3xl mx-auto">
       <knowledge-graph v-if="results.knowledge_graph?.title" :data="results.knowledge_graph" class="mb-6" />
       <div v-if="results.organic?.length" class="mb-6">
-        <organic-result v-for="(item, index) in results.organic" :key="index" :data="item" class="mb-5" />
+        <organic-result v-for="(item, index) in results.organic" :key="index" :data="item" class="mb-1" />
       </div>
       <image-results v-if="results.images?.length" :data="results.images" class="mb-6" />
       <people-also-ask v-if="results.people_also_ask?.length" :data="results.people_also_ask" class="mb-6" />
@@ -21,16 +32,15 @@
         @search="onRelatedSearch"
       />
     </div>
-    <div v-else class="flex flex-col items-center justify-center py-20 text-gray-400">
-      <font-awesome-icon icon="fa-solid fa-search" class="text-4xl mb-4" />
-      <p>{{ $t('serp.description.query') }}</p>
+    <div v-else class="flex flex-col items-center justify-center py-24 text-[var(--el-text-color-disabled)]">
+      <font-awesome-icon icon="fa-solid fa-globe" class="text-5xl mb-4 opacity-30" />
+      <p class="text-base">{{ $t('serp.description.query') }}</p>
     </div>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElSkeleton } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { Status } from '@/models';
 import KnowledgeGraph from './result/KnowledgeGraph.vue';
@@ -42,7 +52,6 @@ import RelatedSearches from './result/RelatedSearches.vue';
 export default defineComponent({
   name: 'ResultPanel',
   components: {
-    ElSkeleton,
     FontAwesomeIcon,
     KnowledgeGraph,
     OrganicResult,
@@ -63,6 +72,7 @@ export default defineComponent({
         this.$store.state.serp?.status?.search === Status.Success &&
         this.results &&
         !this.results.organic?.length &&
+        !this.results.images?.length &&
         !this.results.knowledge_graph?.title
       );
     }


### PR DESCRIPTION
## Summary
- Fixed image search on SERP page showing "no results found" even when the API returns image results successfully
- Root cause: `noResults` computed property in `ResultPanel.vue` only checked `organic` and `knowledge_graph` fields, ignoring `images` — so image-type searches were always treated as empty
- Added `!this.results.images?.length` check to `noResults`
- Also includes pre-existing skeleton/styling refinements (ElSkeleton → custom pulse animation)

## Test plan
- [ ] Search with type "图片搜索" (images) on hub.acedata.cloud/serp — verify image results display
- [ ] Search with type "网页搜索" (search) — verify web results still work correctly
- [ ] Verify "no results" message still shows when search genuinely returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)