### PR TITLE
feat: beautify SERP page UI

### DIFF
--- a/change/@acedatacloud-nexior-841e3adc-0ae1-426d-8620-50448cc1098f.json
+++ b/change/@acedatacloud-nexior-841e3adc-0ae1-426d-8620-50448cc1098f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: beautify SERP page UI with improved visual hierarchy",
+  "packageName": "@acedatacloud/nexior",
+  "email": "cqc@cuiqingcai.com",
+  "dependentChangeType": "patch"
+}

--- a/src/components/serp/ResultPanel.vue
+++ b/src/components/serp/ResultPanel.vue
@@ -1,16 +1,27 @@
 <template>
   <div class="h-full overflow-y-auto p-6">
-    <div v-if="searching" class="flex flex-col items-center justify-center py-20">
-      <el-skeleton :rows="8" animated />
+    <div v-if="searching" class="max-w-3xl mx-auto py-8">
+      <div v-for="i in 4" :key="i" class="mb-6 animate-pulse">
+        <div class="flex items-center gap-2 mb-2">
+          <div class="w-4 h-4 rounded-sm bg-[var(--el-fill-color-darker)]" />
+          <div class="h-3 w-32 rounded bg-[var(--el-fill-color-darker)]" />
+        </div>
+        <div class="h-4 w-3/4 rounded bg-[var(--el-fill-color-dark)] mb-2" />
+        <div class="h-3 w-full rounded bg-[var(--el-fill-color)] mb-1" />
+        <div class="h-3 w-5/6 rounded bg-[var(--el-fill-color)]" />
+      </div>
     </div>
-    <div v-else-if="noResults" class="flex flex-col items-center justify-center py-20 text-gray-400">
-      <font-awesome-icon icon="fa-solid fa-search" class="text-4xl mb-4" />
-      <p>{{ $t('serp.message.noResults') }}</p>
+    <div
+      v-else-if="noResults"
+      class="flex flex-col items-center justify-center py-24 text-[var(--el-text-color-disabled)]"
+    >
+      <font-awesome-icon icon="fa-solid fa-face-meh" class="text-5xl mb-4 opacity-40" />
+      <p class="text-base">{{ $t('serp.message.noResults') }}</p>
     </div>
     <div v-else-if="results" class="max-w-3xl mx-auto">
       <knowledge-graph v-if="results.knowledge_graph?.title" :data="results.knowledge_graph" class="mb-6" />
       <div v-if="results.organic?.length" class="mb-6">
-        <organic-result v-for="(item, index) in results.organic" :key="index" :data="item" class="mb-5" />
+        <organic-result v-for="(item, index) in results.organic" :key="index" :data="item" class="mb-1" />
       </div>
       <image-results v-if="results.images?.length" :data="results.images" class="mb-6" />
       <people-also-ask v-if="results.people_also_ask?.length" :data="results.people_also_ask" class="mb-6" />
@@ -21,16 +32,15 @@
         @search="onRelatedSearch"
       />
     </div>
-    <div v-else class="flex flex-col items-center justify-center py-20 text-gray-400">
-      <font-awesome-icon icon="fa-solid fa-search" class="text-4xl mb-4" />
-      <p>{{ $t('serp.description.query') }}</p>
+    <div v-else class="flex flex-col items-center justify-center py-24 text-[var(--el-text-color-disabled)]">
+      <font-awesome-icon icon="fa-solid fa-globe" class="text-5xl mb-4 opacity-30" />
+      <p class="text-base">{{ $t('serp.description.query') }}</p>
     </div>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElSkeleton } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { Status } from '@/models';
 import KnowledgeGraph from './result/KnowledgeGraph.vue';
@@ -42,7 +52,6 @@ import RelatedSearches from './result/RelatedSearches.vue';
 export default defineComponent({
   name: 'ResultPanel',
   components: {
-    ElSkeleton,
     FontAwesomeIcon,
     KnowledgeGraph,
     OrganicResult,
@@ -63,6 +72,7 @@ export default defineComponent({
         this.$store.state.serp?.status?.search === Status.Success &&
         this.results &&
         !this.results.organic?.length &&
+        !this.results.images?.length &&
         !this.results.knowledge_graph?.title
       );
     }

--- a/src/components/serp/result/ImageResults.vue
+++ b/src/components/serp/result/ImageResults.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="rounded-xl border border-[var(--el-border-color-lighter)] p-5 bg-[var(--el-fill-color-blank)]">
     <h3 class="text-base font-bold mb-3">{{ $t('serp.name.imageResults') }}</h3>
     <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
       <a
@@ -8,17 +8,17 @@
         :href="item.link"
         target="_blank"
         rel="noopener noreferrer"
-        class="group relative rounded overflow-hidden bg-gray-100 dark:bg-gray-800 aspect-square"
+        class="group relative rounded-lg overflow-hidden bg-[var(--el-fill-color-light)] aspect-square"
       >
         <img
           v-if="item.image_url"
           :src="item.image_url"
           :alt="item.title"
-          class="w-full h-full object-cover"
+          class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
           loading="lazy"
         />
         <div
-          class="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/60 to-transparent p-2 opacity-0 group-hover:opacity-100 transition-opacity"
+          class="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 to-transparent p-2.5 opacity-0 group-hover:opacity-100 transition-opacity duration-200"
         >
           <span class="text-xs text-white line-clamp-2">{{ item.title }}</span>
         </div>

--- a/src/components/serp/result/KnowledgeGraph.vue
+++ b/src/components/serp/result/KnowledgeGraph.vue
@@ -1,48 +1,48 @@
 <template>
-  <el-card class="knowledge-graph" shadow="hover">
+  <div
+    class="knowledge-graph rounded-xl border border-[var(--el-border-color-lighter)] p-5 bg-[var(--el-fill-color-blank)]"
+  >
     <div class="flex flex-row gap-4">
       <img
         v-if="data.image_url"
         :src="data.image_url"
         :alt="data.title"
-        class="w-24 h-24 rounded object-cover flex-none"
+        class="w-28 h-28 rounded-lg object-cover flex-none shadow-sm"
       />
       <div class="flex-1 min-w-0">
-        <div v-if="data.type" class="text-xs text-gray-400 mb-1">{{ data.type }}</div>
-        <h3 class="text-lg font-bold mb-1">{{ data.title }}</h3>
-        <p v-if="data.description" class="text-sm text-gray-600 dark:text-gray-300 mb-2">
+        <div v-if="data.type" class="text-xs text-[var(--el-text-color-disabled)] mb-1 uppercase tracking-wide">
+          {{ data.type }}
+        </div>
+        <h3 class="text-xl font-bold mb-1.5">{{ data.title }}</h3>
+        <p v-if="data.description" class="text-sm text-[var(--el-text-color-regular)] mb-3 leading-relaxed">
           {{ data.description }}
           <a
             v-if="data.description_link"
             :href="data.description_link"
             target="_blank"
             rel="noopener noreferrer"
-            class="text-blue-500 hover:underline ml-1"
+            class="text-[var(--el-color-primary)] hover:underline ml-1"
           >
             {{ data.description_source || 'Source' }}
           </a>
         </p>
         <div v-if="data.attributes && Object.keys(data.attributes).length" class="text-sm">
-          <div v-for="(value, key) in data.attributes" :key="key" class="flex gap-2 mb-1">
-            <span class="text-gray-400 flex-none">{{ key }}:</span>
-            <span>{{ value }}</span>
+          <div v-for="(value, key) in data.attributes" :key="key" class="flex gap-2 mb-1 py-0.5">
+            <span class="text-[var(--el-text-color-disabled)] flex-none font-medium">{{ key }}:</span>
+            <span class="text-[var(--el-text-color-regular)]">{{ value }}</span>
           </div>
         </div>
       </div>
     </div>
-  </el-card>
+  </div>
 </template>
 
 <script lang="ts">
 import { defineComponent, PropType } from 'vue';
-import { ElCard } from 'element-plus';
 import { ISerpKnowledgeGraph } from '@/models';
 
 export default defineComponent({
   name: 'KnowledgeGraph',
-  components: {
-    ElCard
-  },
   props: {
     data: {
       type: Object as PropType<ISerpKnowledgeGraph>,

--- a/src/components/serp/result/OrganicResult.vue
+++ b/src/components/serp/result/OrganicResult.vue
@@ -1,28 +1,36 @@
 <template>
-  <div class="organic-result">
-    <div v-if="displayUrl" class="text-sm text-green-600 dark:text-green-400 truncate mb-0.5">
-      {{ displayUrl }}
+  <div class="organic-result rounded-lg p-4 transition-all duration-200 hover:bg-[var(--el-fill-color-lighter)]">
+    <div v-if="displayUrl" class="flex items-center gap-2 mb-1.5">
+      <img
+        :src="faviconUrl"
+        :alt="hostname"
+        class="w-4 h-4 rounded-sm flex-none"
+        loading="lazy"
+        @error="onFaviconError"
+      />
+      <span class="text-xs text-[var(--el-text-color-secondary)] truncate">{{ hostname }}</span>
+      <span class="text-xs text-[var(--el-text-color-disabled)]">{{ pathname }}</span>
     </div>
     <a
       :href="data.link"
       target="_blank"
       rel="noopener noreferrer"
-      class="title text-lg text-blue-600 hover:underline font-medium"
+      class="text-base font-semibold text-[var(--el-color-primary)] hover:underline leading-snug block"
     >
       {{ data.title }}
     </a>
-    <div v-if="data.date" class="text-xs text-gray-400 mt-0.5">{{ data.date }}</div>
-    <p v-if="data.snippet" class="text-sm text-gray-600 dark:text-gray-300 mt-1 leading-relaxed">
+    <div v-if="data.date" class="text-xs text-[var(--el-text-color-disabled)] mt-1">{{ data.date }}</div>
+    <p v-if="data.snippet" class="text-sm text-[var(--el-text-color-regular)] mt-1.5 leading-relaxed line-clamp-3">
       {{ data.snippet }}
     </p>
-    <div v-if="data.sitelinks?.length" class="mt-2 flex flex-wrap gap-2">
+    <div v-if="data.sitelinks?.length" class="mt-3 flex flex-wrap gap-x-4 gap-y-1">
       <a
         v-for="(sitelink, index) in data.sitelinks"
         :key="index"
         :href="sitelink.link"
         target="_blank"
         rel="noopener noreferrer"
-        class="text-xs text-blue-500 hover:underline"
+        class="text-xs text-[var(--el-color-primary-light-3)] hover:text-[var(--el-color-primary)] hover:underline transition-colors"
       >
         {{ sitelink.title }}
       </a>
@@ -42,15 +50,41 @@ export default defineComponent({
       required: true
     }
   },
+  data() {
+    return {
+      faviconFailed: false
+    };
+  },
   computed: {
-    displayUrl(): string {
+    hostname(): string {
       if (!this.data.link) return '';
       try {
-        const url = new URL(this.data.link);
-        return url.hostname + url.pathname;
+        return new URL(this.data.link).hostname;
       } catch {
-        return this.data.link;
+        return '';
       }
+    },
+    pathname(): string {
+      if (!this.data.link) return '';
+      try {
+        const path = new URL(this.data.link).pathname;
+        return path === '/' ? '' : path;
+      } catch {
+        return '';
+      }
+    },
+    displayUrl(): string {
+      return this.hostname;
+    },
+    faviconUrl(): string {
+      if (this.faviconFailed || !this.hostname) return '';
+      return `https://www.google.com/s2/favicons?domain=${this.hostname}&sz=32`;
+    }
+  },
+  methods: {
+    onFaviconError(e: Event) {
+      this.faviconFailed = true;
+      (e.target as HTMLImageElement).style.display = 'none';
     }
   }
 });

--- a/src/components/serp/result/PeopleAlsoAsk.vue
+++ b/src/components/serp/result/PeopleAlsoAsk.vue
@@ -1,15 +1,17 @@
 <template>
-  <div>
+  <div class="rounded-xl border border-[var(--el-border-color-lighter)] p-5 bg-[var(--el-fill-color-blank)]">
     <h3 class="text-base font-bold mb-3">{{ $t('serp.name.peopleAlsoAsk') }}</h3>
     <el-collapse>
       <el-collapse-item v-for="(item, index) in data" :key="index" :title="item.question || item.title || ''">
-        <p v-if="item.snippet" class="text-sm text-gray-600 dark:text-gray-300 mb-2">{{ item.snippet }}</p>
+        <p v-if="item.snippet" class="text-sm text-[var(--el-text-color-regular)] mb-2 leading-relaxed">
+          {{ item.snippet }}
+        </p>
         <a
           v-if="item.link"
           :href="item.link"
           target="_blank"
           rel="noopener noreferrer"
-          class="text-xs text-blue-500 hover:underline"
+          class="text-xs text-[var(--el-color-primary)] hover:underline"
         >
           {{ item.title || item.link }}
         </a>

--- a/src/components/serp/result/RelatedSearches.vue
+++ b/src/components/serp/result/RelatedSearches.vue
@@ -1,30 +1,29 @@
 <template>
-  <div>
+  <div class="rounded-xl border border-[var(--el-border-color-lighter)] p-5 bg-[var(--el-fill-color-blank)]">
     <h3 class="text-base font-bold mb-3">{{ $t('serp.name.relatedSearches') }}</h3>
     <div class="flex flex-wrap gap-2">
-      <el-tag
+      <button
         v-for="(item, index) in data"
         :key="index"
-        class="cursor-pointer"
-        effect="plain"
-        round
+        class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm bg-[var(--el-fill-color-light)] text-[var(--el-text-color-regular)] hover:bg-[var(--el-color-primary-light-9)] hover:text-[var(--el-color-primary)] transition-colors cursor-pointer border-none"
         @click="onSearch(item.query)"
       >
+        <font-awesome-icon icon="fa-solid fa-magnifying-glass" class="text-xs opacity-50" />
         {{ item.query }}
-      </el-tag>
+      </button>
     </div>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent, PropType } from 'vue';
-import { ElTag } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { ISerpRelatedSearch } from '@/models';
 
 export default defineComponent({
   name: 'RelatedSearches',
   components: {
-    ElTag
+    FontAwesomeIcon
   },
   props: {
     data: {

--- a/src/plugins/font-awesome.ts
+++ b/src/plugins/font-awesome.ts
@@ -86,7 +86,9 @@ import {
   faAnglesRight as faSolidAnglesRight,
   faCubesStacked as faSolidCubesStacked,
   faChartLine as faSolidChartLine,
-  faMobileScreenButton as faSolidMobileScreenButton
+  faMobileScreenButton as faSolidMobileScreenButton,
+  faMagnifyingGlass as faSolidMagnifyingGlass,
+  faFaceMeh as faSolidFaceMeh
 } from '@fortawesome/free-solid-svg-icons';
 // add icons
 library.add(faSolidEllipsis);
@@ -175,3 +177,5 @@ library.add(faSolidMobileScreenButton);
 library.add(faBrandsDiscord);
 library.add(faSolidAnglesLeft);
 library.add(faSolidAnglesRight);
+library.add(faSolidMagnifyingGlass);
+library.add(faSolidFaceMeh);


### PR DESCRIPTION
## Summary
- **Organic results**: Added favicons via Google Favicon API, improved URL display (hostname + pathname separated), hover highlight effect, theme-aware CSS variables instead of hardcoded colors
- **Knowledge Graph / Images / People Also Ask**: Wrapped in consistent rounded bordered card containers with proper padding and spacing  
- **Related Searches**: Replaced plain `el-tag` with custom pill buttons featuring search icons and hover color transitions
- **Result Panel**: Custom skeleton loading animation (mimics search result cards), improved empty states with globe/face-meh icons
- **Font Awesome**: Registered `faMagnifyingGlass` and `faFaceMeh` icons

## Test plan
- [ ] Visit hub.acedata.cloud/serp and perform a search query
- [ ] Verify organic results show favicons, proper hover effects, and theme-consistent colors
- [ ] Verify Knowledge Graph, Image Results, People Also Ask, and Related Searches render in card containers
- [ ] Check loading skeleton animation appears during search
- [ ] Test in both dark and light themes
- [ ] Test responsive layout on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)