### PR TITLE
fix: remove small-sized form inputs across all pages

### DIFF
--- a/change/@acedatacloud-nexior-fix-small-inputs.json
+++ b/change/@acedatacloud-nexior-fix-small-inputs.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove size=\"small\" from form input elements for better UX",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/flux/config/QualitySelector.vue
+++ b/src/components/flux/config/QualitySelector.vue
@@ -6,7 +6,7 @@
         <info-icon :content="$t('flux.description.quality')" />
       </div>
       <div class="flex justify-end items-center">
-        <el-input-number v-model="value" size="small" controls-position="right" />
+        <el-input-number v-model="value" controls-position="right" />
       </div>
     </div>
     <div class="w-full">

--- a/src/components/headshots/config/ModeSelector.vue
+++ b/src/components/headshots/config/ModeSelector.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="field">
     <h2 class="title font-bold">{{ $t('headshots.name.mode') }}</h2>
-    <el-radio-group v-model="value" size="small" class="mode">
+    <el-radio-group v-model="value" class="mode">
       <el-radio-button v-for="item in options" :key="item.value" :label="item.value">
         {{ item.label }}
       </el-radio-button>
@@ -76,7 +76,7 @@ export default defineComponent({
 
 <style lang="scss">
 .mode {
-  .el-radio-button--small .el-radio-button__inner {
+  .el-radio-button .el-radio-button__inner {
     padding: 8px 11px;
   }
 }

--- a/src/components/midjourney/config/ImageWeightSelector.vue
+++ b/src/components/midjourney/config/ImageWeightSelector.vue
@@ -6,7 +6,7 @@
         <info-icon :content="$t('midjourney.description.imageWeight')" />
       </div>
       <div class="flex justify-end items-center">
-        <el-input-number v-model="value" size="small" controls-position="right" />
+        <el-input-number v-model="value" controls-position="right" />
       </div>
     </div>
     <div class="w-full px-2">

--- a/src/components/midjourney/config/ModeSelector.vue
+++ b/src/components/midjourney/config/ModeSelector.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="field">
     <h2 class="title">{{ $t('midjourney.name.mode') }}</h2>
-    <el-radio-group v-model="value" size="small" class="mode">
+    <el-radio-group v-model="value" class="mode">
       <el-radio-button v-for="item in options" :key="item.value" :label="item.value">
         {{ item.label }}
       </el-radio-button>
@@ -79,7 +79,7 @@ export default defineComponent({
 
 <style lang="scss">
 .mode {
-  .el-radio-button--small .el-radio-button__inner {
+  .el-radio-button .el-radio-button__inner {
     padding: 8px 11px;
   }
 }

--- a/src/components/midjourney/config/QualitySelector.vue
+++ b/src/components/midjourney/config/QualitySelector.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="field">
     <span class="text-sm font-bold">{{ $t('midjourney.name.quality') }}</span>
-    <el-radio-group v-model="value" size="small" class="quality">
+    <el-radio-group v-model="value" class="quality">
       <el-radio-button v-for="item in options" :key="item.value" :label="item.value">
         {{ item.label }}
       </el-radio-button>
@@ -89,7 +89,7 @@ export default defineComponent({
 
 <style lang="scss">
 .quality {
-  .el-radio-button--small .el-radio-button__inner {
+  .el-radio-button .el-radio-button__inner {
     padding: 8px 11px;
   }
 }

--- a/src/components/order/X402Pay.vue
+++ b/src/components/order/X402Pay.vue
@@ -9,7 +9,7 @@
         <div class="x402-wallet-head">
           <div class="x402-network">
             <span class="x402-network-label">{{ $t('order.message.x402IntegrationNetworkLabel') }}</span>
-            <el-radio-group v-model="selectedNetwork" size="small" class="x402-network-group">
+            <el-radio-group v-model="selectedNetwork" class="x402-network-group">
               <el-radio-button v-for="option in networkOptions" :key="option.network" :label="option.network">
                 {{ option.label }}
               </el-radio-button>
@@ -840,10 +840,7 @@ export default defineComponent({
 
         if (phantomProvider?.isPhantom && typeof phantomProvider?.signAndSendTransaction === 'function') {
           signAndSendFn = phantomProvider.signAndSendTransaction.bind(phantomProvider);
-        } else if (
-          solflareProvider?.isSolflare &&
-          typeof solflareProvider?.signAndSendTransaction === 'function'
-        ) {
+        } else if (solflareProvider?.isSolflare && typeof solflareProvider?.signAndSendTransaction === 'function') {
           signAndSendFn = solflareProvider.signAndSendTransaction.bind(solflareProvider);
         } else if (
           typeof window !== 'undefined' &&

--- a/src/components/pika/config/IngredientsModelSelector.vue
+++ b/src/components/pika/config/IngredientsModelSelector.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="field">
     <h2 class="title font-bold">{{ $t('pika.name.ingredientsModel') }}</h2>
-    <el-radio-group v-model="value" size="small" class="quality">
+    <el-radio-group v-model="value" class="quality">
       <el-radio-button v-for="item in options" :key="item.value" :label="item.value">
         {{ item.label }}
       </el-radio-button>
@@ -75,7 +75,7 @@ export default defineComponent({
 
 <style lang="scss">
 .quality {
-  .el-radio-button--small .el-radio-button__inner {
+  .el-radio-button .el-radio-button__inner {
     padding: 8px 11px;
   }
 }

--- a/src/components/producer/config/AdvancedParams.vue
+++ b/src/components/producer/config/AdvancedParams.vue
@@ -6,7 +6,7 @@
         <div class="flex items-center mb-1">
           <span class="text-xs font-bold">{{ $t('producer.name.styleNegative') }}</span>
         </div>
-        <el-input v-model="styleNegative" size="small" :placeholder="$t('producer.placeholder.styleNegative')" />
+        <el-input v-model="styleNegative" :placeholder="$t('producer.placeholder.styleNegative')" />
       </div>
 
       <!-- Lyric Prompt (auto-generate lyrics) -->
@@ -14,7 +14,7 @@
         <div class="flex items-center mb-1">
           <span class="text-xs font-bold">{{ $t('producer.name.lyricPrompt') }}</span>
         </div>
-        <el-input v-model="lyricPrompt" size="small" :placeholder="$t('producer.placeholder.lyricPrompt')" />
+        <el-input v-model="lyricPrompt" :placeholder="$t('producer.placeholder.lyricPrompt')" />
       </div>
 
       <!-- Weirdness -->
@@ -23,7 +23,7 @@
           <span class="text-xs font-bold">{{ $t('producer.name.weirdness') }}</span>
           <span class="text-xs text-[var(--el-text-color-secondary)]">{{ weirdness ?? 0 }}</span>
         </div>
-        <el-slider v-model="weirdness" :min="0" :max="100" :step="1" size="small" />
+        <el-slider v-model="weirdness" :min="0" :max="100" :step="1" />
       </div>
 
       <!-- Sound Strength -->
@@ -32,7 +32,7 @@
           <span class="text-xs font-bold">{{ $t('producer.name.soundStrength') }}</span>
           <span class="text-xs text-[var(--el-text-color-secondary)]">{{ soundStrength ?? 50 }}</span>
         </div>
-        <el-slider v-model="soundStrength" :min="0" :max="100" :step="1" size="small" />
+        <el-slider v-model="soundStrength" :min="0" :max="100" :step="1" />
       </div>
 
       <!-- Lyrics Strength -->
@@ -41,7 +41,7 @@
           <span class="text-xs font-bold">{{ $t('producer.name.lyricsStrength') }}</span>
           <span class="text-xs text-[var(--el-text-color-secondary)]">{{ lyricsStrength ?? 50 }}</span>
         </div>
-        <el-slider v-model="lyricsStrength" :min="0" :max="100" :step="1" size="small" />
+        <el-slider v-model="lyricsStrength" :min="0" :max="100" :step="1" />
       </div>
 
       <!-- Seed -->
@@ -51,7 +51,6 @@
         </div>
         <el-input-number
           v-model="seed"
-          size="small"
           :min="0"
           :controls="false"
           :placeholder="$t('producer.placeholder.seed')"

--- a/src/components/producer/config/ReplaceSectionInput.vue
+++ b/src/components/producer/config/ReplaceSectionInput.vue
@@ -19,7 +19,6 @@
       <el-input-number
         v-model="replaceSectionStart"
         class="flex-1"
-        size="small"
         :min="0"
         :max="audio?.duration"
         :controls="false"
@@ -28,7 +27,6 @@
       <el-input-number
         v-model="replaceSectionEnd"
         class="flex-1"
-        size="small"
         :min="replaceSectionStart || 0"
         :max="audio?.duration"
         :controls="false"

--- a/src/components/producer/config/TypeSelector.vue
+++ b/src/components/producer/config/TypeSelector.vue
@@ -3,7 +3,7 @@
     <!-- Custom Mode Toggle -->
     <div class="flex items-center justify-between mb-3">
       <span class="text-sm font-bold">{{ $t('producer.name.type') }}</span>
-      <el-switch v-model="custom" size="small" />
+      <el-switch v-model="custom" />
     </div>
 
     <!-- Model Selection -->
@@ -24,7 +24,7 @@
     <!-- Song Description / Instrumental Toggle -->
     <div v-if="custom" class="flex items-center justify-between mb-3">
       <span class="text-sm font-bold">{{ $t('producer.name.instrumental') }}</span>
-      <el-switch v-model="instrumental" size="small" />
+      <el-switch v-model="instrumental" />
     </div>
   </div>
 </template>

--- a/src/components/producer/config/VocalGenderSelector.vue
+++ b/src/components/producer/config/VocalGenderSelector.vue
@@ -4,7 +4,7 @@
       <span class="text-sm font-bold">{{ $t('producer.name.vocalGender') }}</span>
       <info-icon :content="$t('producer.description.vocalGender')" />
     </div>
-    <el-radio-group v-model="vocalGender" size="small">
+    <el-radio-group v-model="vocalGender">
       <el-radio-button value="">{{ $t('producer.gender.auto') }}</el-radio-button>
       <el-radio-button value="f">{{ $t('producer.gender.female') }}</el-radio-button>
       <el-radio-button value="m">{{ $t('producer.gender.male') }}</el-radio-button>

--- a/src/components/site/EditArray.vue
+++ b/src/components/site/EditArray.vue
@@ -19,7 +19,6 @@
         ref="input"
         v-model="inputValue"
         class="block"
-        size="small"
         @keyup.enter="onInputConfirm"
         @blur="onInputConfirm"
       />

--- a/src/components/suno/config/AdvancedParams.vue
+++ b/src/components/suno/config/AdvancedParams.vue
@@ -6,7 +6,7 @@
         <div class="flex items-center mb-1">
           <span class="text-xs font-bold">{{ $t('suno.name.styleNegative') }}</span>
         </div>
-        <el-input v-model="styleNegative" size="small" :placeholder="$t('suno.placeholder.styleNegative')" />
+        <el-input v-model="styleNegative" :placeholder="$t('suno.placeholder.styleNegative')" />
       </div>
 
       <!-- Lyric Prompt (auto-generate lyrics) -->
@@ -14,7 +14,7 @@
         <div class="flex items-center mb-1">
           <span class="text-xs font-bold">{{ $t('suno.name.lyricPrompt') }}</span>
         </div>
-        <el-input v-model="lyricPrompt" size="small" :placeholder="$t('suno.placeholder.lyricPrompt')" />
+        <el-input v-model="lyricPrompt" :placeholder="$t('suno.placeholder.lyricPrompt')" />
       </div>
 
       <!-- Weirdness -->
@@ -23,7 +23,7 @@
           <span class="text-xs font-bold">{{ $t('suno.name.weirdness') }}</span>
           <span class="text-xs text-[var(--el-text-color-secondary)]">{{ weirdness ?? 0 }}</span>
         </div>
-        <el-slider v-model="weirdness" :min="0" :max="100" :step="1" size="small" />
+        <el-slider v-model="weirdness" :min="0" :max="100" :step="1" />
       </div>
 
       <!-- Style Influence -->
@@ -32,7 +32,7 @@
           <span class="text-xs font-bold">{{ $t('suno.name.styleInfluence') }}</span>
           <span class="text-xs text-[var(--el-text-color-secondary)]">{{ styleInfluence ?? 50 }}</span>
         </div>
-        <el-slider v-model="styleInfluence" :min="0" :max="100" :step="1" size="small" />
+        <el-slider v-model="styleInfluence" :min="0" :max="100" :step="1" />
       </div>
 
       <!-- Variation Category (v5+ only) -->
@@ -40,7 +40,7 @@
         <div class="flex items-center mb-1">
           <span class="text-xs font-bold">{{ $t('suno.name.variationCategory') }}</span>
         </div>
-        <el-radio-group v-model="variationCategory" size="small">
+        <el-radio-group v-model="variationCategory">
           <el-radio-button value="">{{ $t('suno.gender.auto') }}</el-radio-button>
           <el-radio-button value="high">{{ $t('suno.variation.high') }}</el-radio-button>
           <el-radio-button value="low">{{ $t('suno.variation.low') }}</el-radio-button>
@@ -53,7 +53,7 @@
           <span class="text-xs font-bold">{{ $t('suno.name.audioWeight') }}</span>
           <span class="text-xs text-[var(--el-text-color-secondary)]">{{ audioWeight ?? 50 }}</span>
         </div>
-        <el-slider v-model="audioWeight" :min="0" :max="100" :step="1" size="small" />
+        <el-slider v-model="audioWeight" :min="0" :max="100" :step="1" />
       </div>
     </el-collapse-item>
   </el-collapse>

--- a/src/components/suno/config/ReplaceSectionInput.vue
+++ b/src/components/suno/config/ReplaceSectionInput.vue
@@ -19,7 +19,6 @@
       <el-input-number
         v-model="replaceSectionStart"
         class="flex-1"
-        size="small"
         :min="0"
         :max="audio?.duration"
         :controls="false"
@@ -28,7 +27,6 @@
       <el-input-number
         v-model="replaceSectionEnd"
         class="flex-1"
-        size="small"
         :min="replaceSectionStart || 0"
         :max="audio?.duration"
         :controls="false"

--- a/src/components/suno/config/TypeSelector.vue
+++ b/src/components/suno/config/TypeSelector.vue
@@ -3,7 +3,7 @@
     <!-- Custom Mode Toggle -->
     <div class="flex items-center justify-between mb-3">
       <span class="text-sm font-bold">{{ $t('suno.name.type') }}</span>
-      <el-switch v-model="custom" size="small" />
+      <el-switch v-model="custom" />
     </div>
 
     <!-- Model Selection -->
@@ -24,7 +24,7 @@
     <!-- Song Description / Instrumental Toggle -->
     <div v-if="custom" class="flex items-center justify-between mb-3">
       <span class="text-sm font-bold">{{ $t('suno.name.instrumental') }}</span>
-      <el-switch v-model="instrumental" size="small" />
+      <el-switch v-model="instrumental" />
     </div>
   </div>
 </template>

--- a/src/components/suno/config/VocalGenderSelector.vue
+++ b/src/components/suno/config/VocalGenderSelector.vue
@@ -4,7 +4,7 @@
       <span class="text-sm font-bold">{{ $t('suno.name.vocalGender') }}</span>
       <info-icon :content="$t('suno.description.vocalGender')" />
     </div>
-    <el-radio-group v-model="vocalGender" size="small">
+    <el-radio-group v-model="vocalGender">
       <el-radio-button value="">{{ $t('suno.gender.auto') }}</el-radio-button>
       <el-radio-button value="f">{{ $t('suno.gender.female') }}</el-radio-button>
       <el-radio-button value="m">{{ $t('suno.gender.male') }}</el-radio-button>


### PR DESCRIPTION
## Summary
- Remove `size="small"` from `el-input`, `el-input-number`, `el-slider`, `el-radio-group`, and `el-switch` components across 16 files
- These made form controls (text inputs, number inputs, sliders, radio buttons, switches) look too tiny and ugly
- Buttons and tags retain `size="small"` as intended — only form elements are affected
- Updated CSS selectors that referenced `.el-radio-button--small` to `.el-radio-button`

## Affected pages
- Producer (Suno-based music generation)
- Suno (music generation)
- Midjourney (image generation)
- Flux (image generation)
- Pika (video generation)
- Headshots
- X402 payment dialog
- Site admin (EditArray)

## Test plan
- [ ] Verify Producer page inputs (exclude style, lyrics prompt, seed, sliders) display at default size
- [ ] Verify Suno page inputs display at default size
- [ ] Verify Midjourney mode/quality radio buttons display at default size
- [ ] Verify Flux quality input-number displays at default size
- [ ] Verify switches (custom mode, instrumental) display at default size
- [ ] Verify buttons throughout the app still display at small size (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)