### PR TITLE
fix: use lowercase resolution in Wan config for cost display

### DIFF
--- a/change/fix-wan-resolution-case.json
+++ b/change/fix-wan-resolution-case.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: use lowercase resolution values in Wan config for cost matching",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/wan/config/ResolutionSelector.vue
+++ b/src/components/wan/config/ResolutionSelector.vue
@@ -13,7 +13,7 @@
 import { defineComponent } from 'vue';
 import { ElSelect, ElOption } from 'element-plus';
 
-const DEFAULT_RESOLUTION = '720P';
+const DEFAULT_RESOLUTION = '720p';
 
 export default defineComponent({
   name: 'ResolutionSelector',
@@ -25,15 +25,15 @@ export default defineComponent({
     options() {
       return [
         {
-          value: '480P',
+          value: '480p',
           label: this.$t('wan.name.resolution480p')
         },
         {
-          value: '720P',
+          value: '720p',
           label: this.$t('wan.name.resolution720p')
         },
         {
-          value: '1080P',
+          value: '1080p',
           label: this.$t('wan.name.resolution1080p')
         }
       ];

--- a/src/components/wan/task/Preview.vue
+++ b/src/components/wan/task/Preview.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="preview">
     <div class="left">
-      <el-image src="https://cdn.acedata.cloud/wan.png" class="avatar" />
+      <el-image :src="WAN_LOGO" class="avatar" />
     </div>
     <div class="main">
       <div class="bot">
@@ -105,6 +105,7 @@ import { IWanTask } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import VideoPlayer from '@/components/common/VideoPlayer.vue';
+import { WAN_LOGO } from '@/constants/wan';
 
 export default defineComponent({
   name: 'TaskPreview',
@@ -122,6 +123,9 @@ export default defineComponent({
       type: Object as () => IWanTask | undefined,
       required: true
     }
+  },
+  setup() {
+    return { WAN_LOGO };
   },
   computed: {
     application() {


### PR DESCRIPTION
## Summary
- Fix resolution option values from uppercase (`720P`, `1080P`, `480P`) to lowercase (`720p`, `1080p`, `480p`) in the Wan resolution selector
- This is needed for the consumption/credits preview to correctly match service cost rules (which use lowercase)
- Companion PR: https://github.com/AceDataCloud/PlatformBackend/pull/282 (adds the missing service cost file)

## Test plan
- [ ] Verify the consumption/credits preview appears on hub.acedata.cloud/wan after both PRs are deployed
- [ ] Verify consumption value changes dynamically when switching model/resolution/duration
- [ ] Verify the API call still works correctly with lowercase resolution values

🤖 Generated with [Claude Code](https://claude.com/claude-code)