### PR TITLE
fix: use WAN_LOGO constant for broken wan bot avatar

### DIFF
--- a/change/fix-wan-bot-avatar.json
+++ b/change/fix-wan-bot-avatar.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: use WAN_LOGO constant for broken wan bot avatar",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/wan/task/Preview.vue
+++ b/src/components/wan/task/Preview.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="preview">
     <div class="left">
-      <el-image src="https://cdn.acedata.cloud/wan.png" class="avatar" />
+      <el-image :src="WAN_LOGO" class="avatar" />
     </div>
     <div class="main">
       <div class="bot">
@@ -105,6 +105,7 @@ import { IWanTask } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import VideoPlayer from '@/components/common/VideoPlayer.vue';
+import { WAN_LOGO } from '@/constants/wan';
 
 export default defineComponent({
   name: 'TaskPreview',
@@ -122,6 +123,9 @@ export default defineComponent({
       type: Object as () => IWanTask | undefined,
       required: true
     }
+  },
+  setup() {
+    return { WAN_LOGO };
   },
   computed: {
     application() {


### PR DESCRIPTION
## Summary
- The Wan bot avatar in the chat preview was hardcoded to `cdn.acedata.cloud/wan.png` which returns 404, causing "加载失败" (loading failed)
- Replaced with the `WAN_LOGO` constant (`cdn.acedata.cloud/a033884259.png`) already used in the sidebar navigator
- Checked all other scenario avatars (Midjourney, Suno, Flux, Luma, Sora, etc.) — they all return 200, only Wan was broken

## Test plan
- [ ] Open hub.acedata.cloud, navigate to Wan bot chat
- [ ] Verify the bot avatar loads correctly in the chat preview
- [ ] Verify the sidebar Wan icon still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)