### PR TITLE
fix: add video and news result rendering to SERP search page

### DIFF
--- a/change/@acedatacloud-nexior-serp-video-news.json
+++ b/change/@acedatacloud-nexior-serp-video-news.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: add video and news result rendering to SERP search page",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/serp/ResultPanel.vue
+++ b/src/components/serp/ResultPanel.vue
@@ -24,6 +24,8 @@
         <organic-result v-for="(item, index) in results.organic" :key="index" :data="item" class="mb-1" />
       </div>
       <image-results v-if="results.images?.length" :data="results.images" class="mb-6" />
+      <video-results v-if="results.videos?.length" :data="results.videos" class="mb-6" />
+      <news-results v-if="results.news?.length" :data="results.news" class="mb-6" />
       <people-also-ask v-if="results.people_also_ask?.length" :data="results.people_also_ask" class="mb-6" />
       <related-searches
         v-if="results.related_searches?.length"
@@ -46,6 +48,8 @@ import { Status } from '@/models';
 import KnowledgeGraph from './result/KnowledgeGraph.vue';
 import OrganicResult from './result/OrganicResult.vue';
 import ImageResults from './result/ImageResults.vue';
+import VideoResults from './result/VideoResults.vue';
+import NewsResults from './result/NewsResults.vue';
 import PeopleAlsoAsk from './result/PeopleAlsoAsk.vue';
 import RelatedSearches from './result/RelatedSearches.vue';
 
@@ -56,6 +60,8 @@ export default defineComponent({
     KnowledgeGraph,
     OrganicResult,
     ImageResults,
+    VideoResults,
+    NewsResults,
     PeopleAlsoAsk,
     RelatedSearches
   },
@@ -73,6 +79,8 @@ export default defineComponent({
         this.results &&
         !this.results.organic?.length &&
         !this.results.images?.length &&
+        !this.results.videos?.length &&
+        !this.results.news?.length &&
         !this.results.knowledge_graph?.title
       );
     }

--- a/src/components/serp/result/NewsResults.vue
+++ b/src/components/serp/result/NewsResults.vue
@@ -1,0 +1,47 @@
+<template>
+  <div>
+    <h3 class="text-base font-bold mb-3">{{ $t('serp.name.newsResults') }}</h3>
+    <div class="space-y-4">
+      <a
+        v-for="(item, index) in data"
+        :key="index"
+        :href="item.link"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="flex gap-4 group"
+      >
+        <div class="flex-1 min-w-0">
+          <div class="text-blue-600 group-hover:underline font-medium line-clamp-2">{{ item.title }}</div>
+          <div class="text-xs text-gray-400 mt-1">
+            <span v-if="item.source">{{ item.source }}</span>
+            <span v-if="item.date"> &middot; {{ item.date }}</span>
+          </div>
+          <p v-if="item.snippet" class="text-sm text-gray-600 dark:text-gray-300 mt-1 line-clamp-2">
+            {{ item.snippet }}
+          </p>
+        </div>
+        <div
+          v-if="item.image_url"
+          class="flex-shrink-0 w-24 h-24 rounded overflow-hidden bg-gray-100 dark:bg-gray-800"
+        >
+          <img :src="item.image_url" :alt="item.title" class="w-full h-full object-cover" loading="lazy" />
+        </div>
+      </a>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, PropType } from 'vue';
+import { ISerpNewsResult } from '@/models';
+
+export default defineComponent({
+  name: 'NewsResults',
+  props: {
+    data: {
+      type: Array as PropType<ISerpNewsResult[]>,
+      required: true
+    }
+  }
+});
+</script>

--- a/src/components/serp/result/VideoResults.vue
+++ b/src/components/serp/result/VideoResults.vue
@@ -1,0 +1,54 @@
+<template>
+  <div>
+    <h3 class="text-base font-bold mb-3">{{ $t('serp.name.videoResults') }}</h3>
+    <div class="space-y-4">
+      <a
+        v-for="(item, index) in data"
+        :key="index"
+        :href="item.link"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="flex gap-4 group"
+      >
+        <div class="relative flex-shrink-0 w-40 h-24 rounded overflow-hidden bg-gray-100 dark:bg-gray-800">
+          <img
+            v-if="item.image_url"
+            :src="item.image_url"
+            :alt="item.title"
+            class="w-full h-full object-cover"
+            loading="lazy"
+          />
+          <div v-if="item.duration" class="absolute bottom-1 right-1 bg-black/80 text-white text-xs px-1 rounded">
+            {{ item.duration }}
+          </div>
+        </div>
+        <div class="flex-1 min-w-0">
+          <div class="text-blue-600 group-hover:underline font-medium line-clamp-2">{{ item.title }}</div>
+          <div class="text-xs text-gray-400 mt-1">
+            <span v-if="item.source">{{ item.source }}</span>
+            <span v-if="item.channel"> &middot; {{ item.channel }}</span>
+            <span v-if="item.date"> &middot; {{ item.date }}</span>
+          </div>
+          <p v-if="item.snippet" class="text-sm text-gray-600 dark:text-gray-300 mt-1 line-clamp-2">
+            {{ item.snippet }}
+          </p>
+        </div>
+      </a>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, PropType } from 'vue';
+import { ISerpVideoResult } from '@/models';
+
+export default defineComponent({
+  name: 'VideoResults',
+  props: {
+    data: {
+      type: Array as PropType<ISerpVideoResult[]>,
+      required: true
+    }
+  }
+});
+</script>

--- a/src/i18n/en/serp.json
+++ b/src/i18n/en/serp.json
@@ -27,6 +27,14 @@
     "message": "Image Results",
     "description": "Title for the image results area"
   },
+  "name.videoResults": {
+    "message": "Video Results",
+    "description": "Title for the video results area"
+  },
+  "name.newsResults": {
+    "message": "News Results",
+    "description": "Title for the news results area"
+  },
   "name.peopleAlsoAsk": {
     "message": "People Also Ask",
     "description": "Title for the people also ask area"

--- a/src/i18n/zh-CN/serp.json
+++ b/src/i18n/zh-CN/serp.json
@@ -27,6 +27,14 @@
     "message": "图片结果",
     "description": "图片结果区域标题"
   },
+  "name.videoResults": {
+    "message": "视频结果",
+    "description": "视频结果区域标题"
+  },
+  "name.newsResults": {
+    "message": "新闻结果",
+    "description": "新闻结果区域标题"
+  },
   "name.peopleAlsoAsk": {
     "message": "大家也在问",
     "description": "大家也在问区域标题"

--- a/src/models/serp.ts
+++ b/src/models/serp.ts
@@ -61,9 +61,33 @@ export interface ISerpRelatedSearch {
   query?: string;
 }
 
+export interface ISerpVideoResult {
+  title?: string;
+  link?: string;
+  snippet?: string;
+  image_url?: string;
+  video_url?: string;
+  duration?: string;
+  source?: string;
+  channel?: string;
+  date?: string;
+  position?: number;
+}
+
+export interface ISerpNewsResult {
+  title?: string;
+  link?: string;
+  snippet?: string;
+  date?: string;
+  source?: string;
+  image_url?: string;
+}
+
 export interface ISerpSearchResponse {
   organic?: ISerpOrganicResult[];
   images?: ISerpImageResult[];
+  videos?: ISerpVideoResult[];
+  news?: ISerpNewsResult[];
   knowledge_graph?: ISerpKnowledgeGraph;
   people_also_ask?: ISerpPeopleAlsoAsk[];
   related_searches?: ISerpRelatedSearch[];


### PR DESCRIPTION
## Summary
- Video Search and News Search on the SERP page showed "No search results found" despite the API returning valid data
- Root cause: `ResultPanel.vue` only checked `organic` and `knowledge_graph` fields — the `videos` and `news` response fields were not modeled, not rendered, and not included in the empty-check
- Added `ISerpVideoResult` / `ISerpNewsResult` types, `VideoResults.vue` / `NewsResults.vue` components, and fixed the `noResults` computed property

## Test plan
- [ ] Go to hub.acedata.cloud/serp, select "Video Search", search "boy" → verify video results render with thumbnails, duration, source
- [ ] Select "News Search", search "boy" → verify news results render with title, source, date, thumbnail
- [ ] Verify "Web Search" and "Image Search" still work correctly
- [ ] Verify "no results" message still appears for genuinely empty searches

🤖 Generated with [Claude Code](https://claude.com/claude-code)