### PR TITLE
feat: add missing Suno API features

### DIFF
--- a/change/@acedatacloud-nexior-suno-missing-features.json
+++ b/change/@acedatacloud-nexior-suno-missing-features.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add missing Suno API features (upload_cover, overpainting, underpainting, samples, artist_consistency, vox, timing, persona, voices, mashup-lyrics)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/suno/ConfigPanel.vue
+++ b/src/components/suno/ConfigPanel.vue
@@ -8,9 +8,13 @@
       <style-input v-if="config?.custom" class="mb-4" />
       <title-input v-if="config?.custom" class="mb-4" />
       <vocal-gender-selector v-if="config?.custom && !config.instrumental && supportsVocalGender" class="mb-4" />
+      <persona-input v-if="config?.custom && supportsPersona" class="mb-4" />
       <extend-from-input v-if="config?.action === 'extend'" class="mb-4" />
       <cover-from-input v-if="config?.action === 'cover'" class="mb-4" />
       <replace-section-input v-if="config?.action === 'replace_section'" class="mb-4" />
+      <overpainting-input v-if="config?.action === 'overpainting'" class="mb-4" />
+      <underpainting-input v-if="config?.action === 'underpainting'" class="mb-4" />
+      <samples-input v-if="config?.action === 'samples'" class="mb-4" />
       <advanced-params class="mb-4" />
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
@@ -37,6 +41,10 @@ import CoverFromInput from './config/CoverFromInput.vue';
 import VocalGenderSelector from './config/VocalGenderSelector.vue';
 import AdvancedParams from './config/AdvancedParams.vue';
 import ReplaceSectionInput from './config/ReplaceSectionInput.vue';
+import OverpaintingInput from './config/OverpaintingInput.vue';
+import UnderpaintingInput from './config/UnderpaintingInput.vue';
+import SamplesInput from './config/SamplesInput.vue';
+import PersonaInput from './config/PersonaInput.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import Consumption from '../common/Consumption.vue';
 import { getConsumption } from '@/utils';
@@ -55,6 +63,10 @@ export default defineComponent({
     VocalGenderSelector,
     AdvancedParams,
     ReplaceSectionInput,
+    OverpaintingInput,
+    UnderpaintingInput,
+    SamplesInput,
+    PersonaInput,
     FontAwesomeIcon,
     ElButton,
     Consumption
@@ -74,6 +86,10 @@ export default defineComponent({
       const model = this.config?.model || '';
       return ['chirp-v4-5-plus', 'chirp-v5', 'chirp-v5-5'].includes(model);
     },
+    supportsPersona() {
+      const action = this.config?.action;
+      return !action || action === 'generate' || action === 'artist_consistency' || action === 'artist_consistency_vox';
+    },
     generateButtonText() {
       const action = this.config?.action;
       if (action === 'extend') return this.$t('suno.button.extend');
@@ -83,6 +99,12 @@ export default defineComponent({
       if (action === 'mashup') return this.$t('suno.button.mashup');
       if (action === 'stems') return this.$t('suno.button.get_stems');
       if (action === 'concat') return this.$t('suno.button.concat_music');
+      if (action === 'upload_cover') return this.$t('suno.button.upload_cover');
+      if (action === 'artist_consistency') return this.$t('suno.button.artist_consistency');
+      if (action === 'artist_consistency_vox') return this.$t('suno.button.artist_consistency_vox');
+      if (action === 'overpainting') return this.$t('suno.button.overpainting');
+      if (action === 'underpainting') return this.$t('suno.button.underpainting');
+      if (action === 'samples') return this.$t('suno.button.samples');
       return this.$t('suno.button.generate');
     }
   },

--- a/src/components/suno/config/OverpaintingInput.vue
+++ b/src/components/suno/config/OverpaintingInput.vue
@@ -1,0 +1,91 @@
+<template>
+  <div class="field">
+    <div class="flex items-center mb-2">
+      <h2 class="text-sm font-bold m-0">{{ $t('suno.name.overpaintingRange') }}</h2>
+      <info-icon :content="$t('suno.description.overpainting')" />
+    </div>
+    <div v-if="audio" class="task mb-2">
+      <div class="audio flex items-center" @click="onClick(audio)">
+        <div v-loading="!audio?.audio_url" class="left relative w-[50px] h-[50px] mr-3 flex-shrink-0">
+          <el-image :src="audio?.image_url" class="w-full h-full rounded" fit="cover" />
+        </div>
+        <div class="info flex-1 min-w-0">
+          <h2 class="text-sm font-bold m-0 truncate">{{ audio?.title }}</h2>
+          <p class="text-xs text-[var(--el-text-color-secondary)] m-0 truncate">{{ audio?.style }}</p>
+        </div>
+      </div>
+    </div>
+    <div class="flex gap-2">
+      <el-input-number
+        v-model="overpaintingStart"
+        class="flex-1"
+        size="small"
+        :min="0"
+        :max="audio?.duration"
+        :controls="false"
+        :placeholder="$t('suno.placeholder.overpaintingStart')"
+      />
+      <el-input-number
+        v-model="overpaintingEnd"
+        class="flex-1"
+        size="small"
+        :min="overpaintingStart || 0"
+        :max="audio?.duration"
+        :controls="false"
+        :placeholder="$t('suno.placeholder.overpaintingEnd')"
+      />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElInputNumber, ElImage } from 'element-plus';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+import { ISunoAudio } from '@/models';
+
+export default defineComponent({
+  name: 'OverpaintingInput',
+  components: {
+    ElInputNumber,
+    ElImage,
+    InfoIcon
+  },
+  computed: {
+    audio(): ISunoAudio | undefined {
+      return this.$store.state.suno?.config?.audio;
+    },
+    overpaintingStart: {
+      get() {
+        return this.$store.state.suno?.config?.overpainting_start;
+      },
+      set(val: number | undefined) {
+        this.$store.commit('suno/setConfig', {
+          ...this.$store.state.suno?.config,
+          overpainting_start: val
+        });
+      }
+    },
+    overpaintingEnd: {
+      get() {
+        return this.$store.state.suno?.config?.overpainting_end;
+      },
+      set(val: number | undefined) {
+        this.$store.commit('suno/setConfig', {
+          ...this.$store.state.suno?.config,
+          overpainting_end: val
+        });
+      }
+    }
+  },
+  methods: {
+    onClick(audio: ISunoAudio) {
+      this.$store.dispatch('suno/setAudio', {
+        ...this.$store.state.suno.audio,
+        ...audio,
+        state: 'playing'
+      });
+    }
+  }
+});
+</script>

--- a/src/components/suno/config/PersonaInput.vue
+++ b/src/components/suno/config/PersonaInput.vue
@@ -1,0 +1,36 @@
+<template>
+  <div class="field">
+    <div class="flex items-center mb-2">
+      <h2 class="text-sm font-bold m-0">{{ $t('suno.name.persona') }}</h2>
+      <info-icon :content="$t('suno.description.persona')" />
+    </div>
+    <el-input v-model="personaId" size="small" :placeholder="$t('suno.placeholder.personaId')" />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElInput } from 'element-plus';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+
+export default defineComponent({
+  name: 'PersonaInput',
+  components: {
+    ElInput,
+    InfoIcon
+  },
+  computed: {
+    personaId: {
+      get() {
+        return this.$store.state.suno?.config?.persona_id || '';
+      },
+      set(val: string) {
+        this.$store.commit('suno/setConfig', {
+          ...this.$store.state.suno?.config,
+          persona_id: val || undefined
+        });
+      }
+    }
+  }
+});
+</script>

--- a/src/components/suno/config/SamplesInput.vue
+++ b/src/components/suno/config/SamplesInput.vue
@@ -1,0 +1,91 @@
+<template>
+  <div class="field">
+    <div class="flex items-center mb-2">
+      <h2 class="text-sm font-bold m-0">{{ $t('suno.name.samplesRange') }}</h2>
+      <info-icon :content="$t('suno.description.samples')" />
+    </div>
+    <div v-if="audio" class="task mb-2">
+      <div class="audio flex items-center" @click="onClick(audio)">
+        <div v-loading="!audio?.audio_url" class="left relative w-[50px] h-[50px] mr-3 flex-shrink-0">
+          <el-image :src="audio?.image_url" class="w-full h-full rounded" fit="cover" />
+        </div>
+        <div class="info flex-1 min-w-0">
+          <h2 class="text-sm font-bold m-0 truncate">{{ audio?.title }}</h2>
+          <p class="text-xs text-[var(--el-text-color-secondary)] m-0 truncate">{{ audio?.style }}</p>
+        </div>
+      </div>
+    </div>
+    <div class="flex gap-2">
+      <el-input-number
+        v-model="samplesStart"
+        class="flex-1"
+        size="small"
+        :min="0"
+        :max="audio?.duration"
+        :controls="false"
+        :placeholder="$t('suno.placeholder.samplesStart')"
+      />
+      <el-input-number
+        v-model="samplesEnd"
+        class="flex-1"
+        size="small"
+        :min="samplesStart || 0"
+        :max="audio?.duration"
+        :controls="false"
+        :placeholder="$t('suno.placeholder.samplesEnd')"
+      />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElInputNumber, ElImage } from 'element-plus';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+import { ISunoAudio } from '@/models';
+
+export default defineComponent({
+  name: 'SamplesInput',
+  components: {
+    ElInputNumber,
+    ElImage,
+    InfoIcon
+  },
+  computed: {
+    audio(): ISunoAudio | undefined {
+      return this.$store.state.suno?.config?.audio;
+    },
+    samplesStart: {
+      get() {
+        return this.$store.state.suno?.config?.samples_start;
+      },
+      set(val: number | undefined) {
+        this.$store.commit('suno/setConfig', {
+          ...this.$store.state.suno?.config,
+          samples_start: val
+        });
+      }
+    },
+    samplesEnd: {
+      get() {
+        return this.$store.state.suno?.config?.samples_end;
+      },
+      set(val: number | undefined) {
+        this.$store.commit('suno/setConfig', {
+          ...this.$store.state.suno?.config,
+          samples_end: val
+        });
+      }
+    }
+  },
+  methods: {
+    onClick(audio: ISunoAudio) {
+      this.$store.dispatch('suno/setAudio', {
+        ...this.$store.state.suno.audio,
+        ...audio,
+        state: 'playing'
+      });
+    }
+  }
+});
+</script>

--- a/src/components/suno/config/UnderpaintingInput.vue
+++ b/src/components/suno/config/UnderpaintingInput.vue
@@ -1,0 +1,91 @@
+<template>
+  <div class="field">
+    <div class="flex items-center mb-2">
+      <h2 class="text-sm font-bold m-0">{{ $t('suno.name.underpaintingRange') }}</h2>
+      <info-icon :content="$t('suno.description.underpainting')" />
+    </div>
+    <div v-if="audio" class="task mb-2">
+      <div class="audio flex items-center" @click="onClick(audio)">
+        <div v-loading="!audio?.audio_url" class="left relative w-[50px] h-[50px] mr-3 flex-shrink-0">
+          <el-image :src="audio?.image_url" class="w-full h-full rounded" fit="cover" />
+        </div>
+        <div class="info flex-1 min-w-0">
+          <h2 class="text-sm font-bold m-0 truncate">{{ audio?.title }}</h2>
+          <p class="text-xs text-[var(--el-text-color-secondary)] m-0 truncate">{{ audio?.style }}</p>
+        </div>
+      </div>
+    </div>
+    <div class="flex gap-2">
+      <el-input-number
+        v-model="underpaintingStart"
+        class="flex-1"
+        size="small"
+        :min="0"
+        :max="audio?.duration"
+        :controls="false"
+        :placeholder="$t('suno.placeholder.underpaintingStart')"
+      />
+      <el-input-number
+        v-model="underpaintingEnd"
+        class="flex-1"
+        size="small"
+        :min="underpaintingStart || 0"
+        :max="audio?.duration"
+        :controls="false"
+        :placeholder="$t('suno.placeholder.underpaintingEnd')"
+      />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElInputNumber, ElImage } from 'element-plus';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+import { ISunoAudio } from '@/models';
+
+export default defineComponent({
+  name: 'UnderpaintingInput',
+  components: {
+    ElInputNumber,
+    ElImage,
+    InfoIcon
+  },
+  computed: {
+    audio(): ISunoAudio | undefined {
+      return this.$store.state.suno?.config?.audio;
+    },
+    underpaintingStart: {
+      get() {
+        return this.$store.state.suno?.config?.underpainting_start;
+      },
+      set(val: number | undefined) {
+        this.$store.commit('suno/setConfig', {
+          ...this.$store.state.suno?.config,
+          underpainting_start: val
+        });
+      }
+    },
+    underpaintingEnd: {
+      get() {
+        return this.$store.state.suno?.config?.underpainting_end;
+      },
+      set(val: number | undefined) {
+        this.$store.commit('suno/setConfig', {
+          ...this.$store.state.suno?.config,
+          underpainting_end: val
+        });
+      }
+    }
+  },
+  methods: {
+    onClick(audio: ISunoAudio) {
+      this.$store.dispatch('suno/setAudio', {
+        ...this.$store.state.suno.audio,
+        ...audio,
+        state: 'playing'
+      });
+    }
+  }
+});
+</script>

--- a/src/components/suno/config/UploadAudio.vue
+++ b/src/components/suno/config/UploadAudio.vue
@@ -24,12 +24,18 @@
         {{ $t('suno.button.uploadAudios') }}
       </el-button>
     </el-upload>
+    <div v-if="hasUploadedAudio" class="mt-2">
+      <el-radio-group v-model="uploadAction" size="small">
+        <el-radio-button value="upload_extend">{{ $t('suno.button.extend') }}</el-radio-button>
+        <el-radio-button value="upload_cover">{{ $t('suno.button.upload_cover') }}</el-radio-button>
+      </el-radio-group>
+    </div>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElUpload, ElButton, UploadFiles, UploadFile, ElMessage } from 'element-plus';
+import { ElUpload, ElButton, UploadFiles, UploadFile, ElMessage, ElRadioGroup, ElRadioButton } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { getBaseUrlPlatform } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
@@ -46,7 +52,9 @@ export default defineComponent({
     ElUpload,
     ElButton,
     InfoIcon,
-    FontAwesomeIcon
+    FontAwesomeIcon,
+    ElRadioGroup,
+    ElRadioButton
   },
   emits: ['change'],
   data(): IData {
@@ -76,6 +84,21 @@ export default defineComponent({
         return this.$store.state.suno?.config?.audio_id;
       },
       set() {}
+    },
+    hasUploadedAudio() {
+      const action = this.$store.state.suno?.config?.action;
+      return action === 'upload_extend' || action === 'upload_cover';
+    },
+    uploadAction: {
+      get() {
+        return this.$store.state.suno?.config?.action || 'upload_extend';
+      },
+      set(val: string) {
+        this.$store.commit('suno/setConfig', {
+          ...this.$store.state.suno?.config,
+          action: val
+        });
+      }
     }
   },
   watch: {

--- a/src/components/suno/task/Preview.vue
+++ b/src/components/suno/task/Preview.vue
@@ -115,6 +115,24 @@
               <el-dropdown-item v-if="audio?.id && audio?.action === 'extend'" @click.stop="onConcatMusic(audio?.id)">
                 {{ $t('suno.button.concat_music') }}
               </el-dropdown-item>
+              <el-dropdown-item v-if="audio?.id" @click.stop="onOverpainting(audio)">
+                {{ $t('suno.button.overpainting') }}
+              </el-dropdown-item>
+              <el-dropdown-item v-if="audio?.id" @click.stop="onUnderpainting(audio)">
+                {{ $t('suno.button.underpainting') }}
+              </el-dropdown-item>
+              <el-dropdown-item v-if="audio?.id" @click.stop="onSamples(audio)">
+                {{ $t('suno.button.samples') }}
+              </el-dropdown-item>
+              <el-dropdown-item v-if="audio?.id" @click.stop="onArtistConsistency(audio)">
+                {{ $t('suno.button.artist_consistency') }}
+              </el-dropdown-item>
+              <el-dropdown-item v-if="audio?.id" @click.stop="onExtractVocals(audio.id)">
+                {{ $t('suno.button.extract_vocals') }}
+              </el-dropdown-item>
+              <el-dropdown-item v-if="audio?.id" @click.stop="onGetTiming(audio.id)">
+                {{ $t('suno.button.get_timing') }}
+              </el-dropdown-item>
             </el-dropdown-menu>
           </template>
         </el-dropdown>
@@ -356,6 +374,87 @@ export default defineComponent({
         audio_id: audio.id,
         mashup_audio_ids: [audio.id]
       });
+    },
+    onOverpainting(audio: ISunoAudio) {
+      this.$store.commit('suno/setConfig', {
+        ...this.$store.state.suno?.config,
+        model: audio.model,
+        custom: true,
+        style: audio.style,
+        action: 'overpainting',
+        audio: audio,
+        audio_id: audio.id,
+        overpainting_start: 0,
+        overpainting_end: Math.min(30, audio.duration || 30)
+      });
+    },
+    onUnderpainting(audio: ISunoAudio) {
+      this.$store.commit('suno/setConfig', {
+        ...this.$store.state.suno?.config,
+        model: audio.model,
+        custom: true,
+        style: audio.style,
+        action: 'underpainting',
+        audio: audio,
+        audio_id: audio.id,
+        underpainting_start: 0,
+        underpainting_end: Math.min(30, audio.duration || 30)
+      });
+    },
+    onSamples(audio: ISunoAudio) {
+      this.$store.commit('suno/setConfig', {
+        ...this.$store.state.suno?.config,
+        model: audio.model,
+        custom: true,
+        style: audio.style,
+        action: 'samples',
+        audio: audio,
+        audio_id: audio.id,
+        samples_start: 0,
+        samples_end: Math.min(30, audio.duration || 30)
+      });
+    },
+    onArtistConsistency(audio: ISunoAudio) {
+      this.$store.commit('suno/setConfig', {
+        ...this.$store.state.suno?.config,
+        model: audio.model,
+        custom: true,
+        style: audio.style,
+        action: 'artist_consistency',
+        audio: audio,
+        audio_id: audio.id
+      });
+    },
+    async onExtractVocals(audioId: string) {
+      const token = this.credential?.token;
+      if (!token) return;
+      ElMessage.info(this.$t('suno.message.extractingVocals'));
+      sunoOperator
+        .vox({ audio_id: audioId, callback_url: CALLBACK_URL }, { token })
+        .then(() => {
+          ElMessage.success(this.$t('suno.message.extractVocalsSuccess'));
+        })
+        .catch((error) => {
+          ElMessage.error(error?.response?.data?.error?.message || this.$t('suno.message.extractVocalsFailed'));
+        })
+        .finally(async () => {
+          await this.onGetTasks();
+          await this.onScrollDown();
+        });
+    },
+    async onGetTiming(audioId: string) {
+      const token = this.credential?.token;
+      if (!token) return;
+      ElMessage.info(this.$t('suno.message.fetchingTiming'));
+      sunoOperator
+        .timing({ audio_id: audioId }, { token })
+        .then((response) => {
+          ElMessage.success(this.$t('suno.message.fetchTimingSuccess'));
+          console.debug('timing data', response.data);
+        })
+        .catch((error) => {
+          ElMessage.error(error?.response?.data?.error?.message || this.$t('suno.message.fetchTimingFailed'));
+        });
     },
     async handleWavDownload(audio: ISunoAudio) {
       if (!audio?.id || this.isFetchingWav) return;

--- a/src/i18n/en/suno.json
+++ b/src/i18n/en/suno.json
@@ -414,5 +414,129 @@
   "message.noTasks": {
     "message": "No history tasks, please generate music in the left configuration panel",
     "description": "Message when there are no tasks"
+  },
+  "button.upload_cover": {
+    "message": "Upload & Cover",
+    "description": "Text for upload audio then cover button"
+  },
+  "button.artist_consistency": {
+    "message": "Artist Consistency",
+    "description": "Text for artist style consistency generation button"
+  },
+  "button.artist_consistency_vox": {
+    "message": "Vocal Consistency",
+    "description": "Text for artist vocal style consistency generation button"
+  },
+  "button.underpainting": {
+    "message": "Add Accompaniment",
+    "description": "Text for adding accompaniment to uploaded song button"
+  },
+  "button.overpainting": {
+    "message": "Add Vocals",
+    "description": "Text for adding vocals to uploaded song button"
+  },
+  "button.samples": {
+    "message": "Add Samples",
+    "description": "Text for adding samples to uploaded song button"
+  },
+  "button.extract_vocals": {
+    "message": "Extract Vocals",
+    "description": "Text for extracting vocals from song button"
+  },
+  "button.get_timing": {
+    "message": "Get Timing",
+    "description": "Text for getting song timing data button"
+  },
+  "button.create_persona": {
+    "message": "Create Persona",
+    "description": "Text for creating singer persona button"
+  },
+  "button.mashup_lyrics": {
+    "message": "Mashup Lyrics",
+    "description": "Text for mashing up two lyrics button"
+  },
+  "name.persona": {
+    "message": "Singer Persona",
+    "description": "Singer persona selection"
+  },
+  "name.overpaintingRange": {
+    "message": "Vocal Range",
+    "description": "Time range for adding vocals"
+  },
+  "name.underpaintingRange": {
+    "message": "Accompaniment Range",
+    "description": "Time range for adding accompaniment"
+  },
+  "name.samplesRange": {
+    "message": "Samples Range",
+    "description": "Time range for adding samples"
+  },
+  "placeholder.overpaintingStart": {
+    "message": "Start time (seconds)",
+    "description": "Placeholder for vocal start time"
+  },
+  "placeholder.overpaintingEnd": {
+    "message": "End time (seconds)",
+    "description": "Placeholder for vocal end time"
+  },
+  "placeholder.underpaintingStart": {
+    "message": "Start time (seconds)",
+    "description": "Placeholder for accompaniment start time"
+  },
+  "placeholder.underpaintingEnd": {
+    "message": "End time (seconds)",
+    "description": "Placeholder for accompaniment end time"
+  },
+  "placeholder.samplesStart": {
+    "message": "Start time (seconds)",
+    "description": "Placeholder for samples start time"
+  },
+  "placeholder.samplesEnd": {
+    "message": "End time (seconds)",
+    "description": "Placeholder for samples end time"
+  },
+  "placeholder.personaId": {
+    "message": "Enter singer persona ID...",
+    "description": "Placeholder for singer persona ID input"
+  },
+  "description.persona": {
+    "message": "Use a created singer persona to generate songs with consistent style",
+    "description": "Description of the singer persona feature"
+  },
+  "description.overpainting": {
+    "message": "Add vocals to uploaded music in the specified time range",
+    "description": "Description of the add vocals feature"
+  },
+  "description.underpainting": {
+    "message": "Add accompaniment to uploaded music in the specified time range",
+    "description": "Description of the add accompaniment feature"
+  },
+  "description.samples": {
+    "message": "Add samples to uploaded music in the specified time range",
+    "description": "Description of the add samples feature"
+  },
+  "message.fetchingTiming": {
+    "message": "Fetching timing data...",
+    "description": "Message while fetching timing data"
+  },
+  "message.fetchTimingFailed": {
+    "message": "Failed to fetch timing data",
+    "description": "Message when fetching timing data fails"
+  },
+  "message.fetchTimingSuccess": {
+    "message": "Timing data fetched successfully",
+    "description": "Message when timing data is fetched successfully"
+  },
+  "message.extractingVocals": {
+    "message": "Extracting vocals...",
+    "description": "Message while extracting vocals"
+  },
+  "message.extractVocalsFailed": {
+    "message": "Failed to extract vocals",
+    "description": "Message when extracting vocals fails"
+  },
+  "message.extractVocalsSuccess": {
+    "message": "Vocals extracted successfully",
+    "description": "Message when vocals are extracted successfully"
   }
 }

--- a/src/i18n/zh-CN/suno.json
+++ b/src/i18n/zh-CN/suno.json
@@ -414,5 +414,129 @@
   "message.noTasks": {
     "message": "没有历史任务，请在左侧配置栏生成音乐",
     "description": "没有任务时的消息"
+  },
+  "button.upload_cover": {
+    "message": "上传翻唱",
+    "description": "上传音频后翻唱按钮文本"
+  },
+  "button.artist_consistency": {
+    "message": "风格一致性",
+    "description": "基于歌手风格生成按钮文本"
+  },
+  "button.artist_consistency_vox": {
+    "message": "人声风格一致性",
+    "description": "基于歌手人声风格生成按钮文本"
+  },
+  "button.underpainting": {
+    "message": "添加伴奏",
+    "description": "为上传的歌曲添加伴奏按钮文本"
+  },
+  "button.overpainting": {
+    "message": "添加人声",
+    "description": "为上传的歌曲添加人声按钮文本"
+  },
+  "button.samples": {
+    "message": "添加采样",
+    "description": "为上传的歌曲添加采样按钮文本"
+  },
+  "button.extract_vocals": {
+    "message": "提取人声",
+    "description": "从歌曲中提取人声按钮文本"
+  },
+  "button.get_timing": {
+    "message": "获取节拍",
+    "description": "获取歌曲节拍数据按钮文本"
+  },
+  "button.create_persona": {
+    "message": "创建歌手风格",
+    "description": "创建歌手风格按钮文本"
+  },
+  "button.mashup_lyrics": {
+    "message": "混搭歌词",
+    "description": "混搭两段歌词按钮文本"
+  },
+  "name.persona": {
+    "message": "歌手风格",
+    "description": "歌手风格选择"
+  },
+  "name.overpaintingRange": {
+    "message": "人声范围",
+    "description": "添加人声的时间范围"
+  },
+  "name.underpaintingRange": {
+    "message": "伴奏范围",
+    "description": "添加伴奏的时间范围"
+  },
+  "name.samplesRange": {
+    "message": "采样范围",
+    "description": "添加采样的时间范围"
+  },
+  "placeholder.overpaintingStart": {
+    "message": "开始时间 (秒)",
+    "description": "人声开始时间的占位符"
+  },
+  "placeholder.overpaintingEnd": {
+    "message": "结束时间 (秒)",
+    "description": "人声结束时间的占位符"
+  },
+  "placeholder.underpaintingStart": {
+    "message": "开始时间 (秒)",
+    "description": "伴奏开始时间的占位符"
+  },
+  "placeholder.underpaintingEnd": {
+    "message": "结束时间 (秒)",
+    "description": "伴奏结束时间的占位符"
+  },
+  "placeholder.samplesStart": {
+    "message": "开始时间 (秒)",
+    "description": "采样开始时间的占位符"
+  },
+  "placeholder.samplesEnd": {
+    "message": "结束时间 (秒)",
+    "description": "采样结束时间的占位符"
+  },
+  "placeholder.personaId": {
+    "message": "输入歌手风格 ID...",
+    "description": "歌手风格 ID 输入的占位符"
+  },
+  "description.persona": {
+    "message": "使用已创建的歌手风格来生成一致风格的歌曲",
+    "description": "歌手风格功能的描述"
+  },
+  "description.overpainting": {
+    "message": "在指定时间范围内为上传的音乐添加人声",
+    "description": "添加人声功能的描述"
+  },
+  "description.underpainting": {
+    "message": "在指定时间范围内为上传的音乐添加伴奏",
+    "description": "添加伴奏功能的描述"
+  },
+  "description.samples": {
+    "message": "在指定时间范围内为上传的音乐添加采样",
+    "description": "添加采样功能的描述"
+  },
+  "message.fetchingTiming": {
+    "message": "正在获取节拍数据...",
+    "description": "获取节拍数据时的消息"
+  },
+  "message.fetchTimingFailed": {
+    "message": "获取节拍数据失败",
+    "description": "获取节拍数据失败时的消息"
+  },
+  "message.fetchTimingSuccess": {
+    "message": "节拍数据获取成功",
+    "description": "获取节拍数据成功时的消息"
+  },
+  "message.extractingVocals": {
+    "message": "正在提取人声...",
+    "description": "提取人声时的消息"
+  },
+  "message.extractVocalsFailed": {
+    "message": "提取人声失败",
+    "description": "提取人声失败时的消息"
+  },
+  "message.extractVocalsSuccess": {
+    "message": "人声提取成功",
+    "description": "提取人声成功时的消息"
   }
 }

--- a/src/models/suno.ts
+++ b/src/models/suno.ts
@@ -160,6 +160,73 @@ export interface ISunoStyleResponse {
   text?: string;
 }
 
+export interface ISunoPersonaRequest {
+  audio_id: string;
+  name: string;
+  vox_audio_id?: string;
+  vocal_start?: number;
+  vocal_end?: number;
+  description?: string;
+}
+
+export interface ISunoPersona {
+  id?: string;
+  name?: string;
+  description?: string;
+}
+
+export interface ISunoPersonaResponse {
+  success?: boolean;
+  task_id: string;
+  data: ISunoPersona;
+}
+
+export interface ISunoVoxRequest {
+  audio_id: string;
+  vocal_start?: number;
+  vocal_end?: number;
+  callback_url?: string;
+}
+
+export interface ISunoVoxResponse {
+  success?: boolean;
+  task_id: string;
+  data: { audio_url?: string };
+}
+
+export interface ISunoTimingRequest {
+  audio_id: string;
+}
+
+export interface ISunoTimingResponse {
+  success?: boolean;
+  task_id: string;
+  data: any;
+}
+
+export interface ISunoVoicesRequest {
+  audio_url: string;
+  name?: string;
+  description?: string;
+}
+
+export interface ISunoVoicesResponse {
+  success?: boolean;
+  task_id: string;
+  data: any;
+}
+
+export interface ISunoMashupLyricsRequest {
+  lyrics_a: string;
+  lyrics_b: string;
+}
+
+export interface ISunoMashupLyricsResponse {
+  success?: boolean;
+  task_id: string;
+  data: { text?: string };
+}
+
 export interface ISunoUploadAudio {
   audio_id?: string;
 }

--- a/src/operators/suno.ts
+++ b/src/operators/suno.ts
@@ -11,7 +11,17 @@ import {
   ISunoMp4Request,
   ISunoMp4Response,
   ISunoStyleRequest,
-  ISunoStyleResponse
+  ISunoStyleResponse,
+  ISunoPersonaRequest,
+  ISunoPersonaResponse,
+  ISunoVoxRequest,
+  ISunoVoxResponse,
+  ISunoTimingRequest,
+  ISunoTimingResponse,
+  ISunoVoicesRequest,
+  ISunoVoicesResponse,
+  ISunoMashupLyricsRequest,
+  ISunoMashupLyricsResponse
 } from '@/models';
 import { BASE_URL_API } from '@/constants';
 
@@ -207,6 +217,86 @@ class SunoOperator {
     }
   ): Promise<AxiosResponse<{ data: { midi_url: string } }>> {
     return await axios.post('/suno/midi', data, {
+      headers: {
+        authorization: `Bearer ${options.token}`,
+        'content-type': 'application/json'
+      },
+      baseURL: BASE_URL_API
+    });
+  }
+
+  // suno/persona - create vocal persona
+  async persona(
+    data: ISunoPersonaRequest,
+    options: {
+      token: string;
+    }
+  ): Promise<AxiosResponse<ISunoPersonaResponse>> {
+    return await axios.post('/suno/persona', data, {
+      headers: {
+        authorization: `Bearer ${options.token}`,
+        'content-type': 'application/json'
+      },
+      baseURL: BASE_URL_API
+    });
+  }
+
+  // suno/vox - extract vocals
+  async vox(
+    data: ISunoVoxRequest,
+    options: {
+      token: string;
+    }
+  ): Promise<AxiosResponse<ISunoVoxResponse>> {
+    return await axios.post('/suno/vox', data, {
+      headers: {
+        authorization: `Bearer ${options.token}`,
+        'content-type': 'application/json'
+      },
+      baseURL: BASE_URL_API
+    });
+  }
+
+  // suno/timing - get timing data
+  async timing(
+    data: ISunoTimingRequest,
+    options: {
+      token: string;
+    }
+  ): Promise<AxiosResponse<ISunoTimingResponse>> {
+    return await axios.post('/suno/timing', data, {
+      headers: {
+        authorization: `Bearer ${options.token}`,
+        'content-type': 'application/json'
+      },
+      baseURL: BASE_URL_API
+    });
+  }
+
+  // suno/voices - create custom voice
+  async voices(
+    data: ISunoVoicesRequest,
+    options: {
+      token: string;
+    }
+  ): Promise<AxiosResponse<ISunoVoicesResponse>> {
+    return await axios.post('/suno/voices', data, {
+      headers: {
+        authorization: `Bearer ${options.token}`,
+        'content-type': 'application/json'
+      },
+      baseURL: BASE_URL_API
+    });
+  }
+
+  // suno/mashup-lyrics - generate mashup lyrics
+  async mashupLyrics(
+    data: ISunoMashupLyricsRequest,
+    options: {
+      token: string;
+    }
+  ): Promise<AxiosResponse<ISunoMashupLyricsResponse>> {
+    return await axios.post('/suno/mashup-lyrics', data, {
       headers: {
         authorization: `Bearer ${options.token}`,
         'content-type': 'application/json'


### PR DESCRIPTION
## Summary
- Add support for 5 missing Suno audios actions: `upload_cover`, `artist_consistency`, `artist_consistency_vox`, `overpainting`, `underpainting`, `samples`
- Add 5 missing API endpoint operators: `/suno/persona`, `/suno/vox`, `/suno/timing`, `/suno/voices`, `/suno/mashup-lyrics`
- New config UI components: OverpaintingInput, UnderpaintingInput, SamplesInput, PersonaInput
- Upload component now supports toggling between `upload_extend` and `upload_cover`
- Song dropdown menu expanded with: extract vocals, get timing, overpainting, underpainting, samples, artist consistency
- Full i18n support (zh-CN + en) for all new features

## Test plan
- [ ] Verify new dropdown menu items appear on generated songs
- [ ] Test overpainting/underpainting/samples actions set correct config and time ranges
- [ ] Test upload audio toggle between extend and cover modes
- [ ] Test persona input appears in custom mode
- [ ] Verify type check and lint pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)