### PR TITLE
fix: restore brand logo in sidebar navigator

### DIFF
--- a/change/@acedatacloud-nexior-5c1a6fc6-5d08-4c78-9f36-b9c644ce6774.json
+++ b/change/@acedatacloud-nexior-5c1a6fc6-5d08-4c78-9f36-b9c644ce6774.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Restore brand logo in sidebar navigator",
+  "packageName": "@acedatacloud/nexior",
+  "email": "cqc@cuiqingcai.com",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/Navigator.vue
+++ b/src/components/common/Navigator.vue
@@ -1,5 +1,8 @@
 <template>
   <div :direction="direction" :class="['navigator', { collapsed: direction === 'column' }]">
+    <div v-if="direction === 'column'" class="brand">
+      <logo @click.stop="onHome" />
+    </div>
     <div class="top">
       <div ref="linksContainer" class="links">
         <div
@@ -58,6 +61,7 @@
 import { defineComponent } from 'vue';
 import { ElTooltip, ElImage, ElPopover } from 'element-plus';
 import {
+  ROUTE_INDEX,
   ROUTE_PROFILE_INDEX,
   ROUTE_MIDJOURNEY_INDEX,
   ROUTE_LUMA_INDEX,
@@ -117,6 +121,7 @@ import {
   CHAT_MODEL_ICON_KIMI,
   SERP_LOGO
 } from '@/constants';
+import Logo from './Logo.vue';
 import UserCenter from '@/components/user/Center.vue';
 
 interface NavLink {
@@ -133,6 +138,7 @@ export default defineComponent({
   components: {
     ElImage,
     ElPopover,
+    Logo,
     ElTooltip,
     UserCenter
   },
@@ -411,6 +417,9 @@ export default defineComponent({
     }
   },
   methods: {
+    onHome() {
+      this.$router.push({ name: ROUTE_INDEX });
+    },
     onOverflowItemClick(link: { route: { name: string } }) {
       this.showOverflow = false;
       this.$router.push(link.route);
@@ -487,11 +496,19 @@ export default defineComponent({
     flex-direction: column;
     width: 60px;
 
+    .brand {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      padding: 12px 0 6px;
+      width: 100%;
+    }
+
     .top {
       flex: 1;
       display: flex;
       flex-direction: column;
-      padding-top: 10px;
+      padding-top: 0;
       width: 100%;
       min-height: 0;
       overflow: hidden;


### PR DESCRIPTION
## Summary
- The Logo component was accidentally removed from `Navigator.vue` in #409 (commit 5fa0c0ef) when the sidebar collapse/expand feature was removed
- This restores the brand logo at the top of the desktop sidebar, clickable to navigate home
- Only shows in column (desktop) direction, not in the mobile row layout

## Test plan
- [ ] Verify the brand logo appears at the top of the left sidebar on desktop
- [ ] Click the logo and confirm it navigates to the home/index page
- [ ] Verify the logo does not appear in the mobile bottom navigation bar
- [ ] Verify sidebar service icons still display and work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)