### PR TITLE
feat: add Docker Hub publish workflow

### DIFF
--- a/.github/workflows/publish-dockerhub.yaml
+++ b/.github/workflows/publish-dockerhub.yaml
@@ -1,0 +1,43 @@
+name: Publish to Docker Hub
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - .gitignore
+      - README.md
+      - CHANGELOG.md
+      - CHANGELOG.json
+      - '.github/ISSUE_TEMPLATE/**'
+  workflow_dispatch:
+
+jobs:
+  publish-dockerhub:
+    name: Publish to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Generate version tag
+        id: version
+        run: |
+          echo "version=$(date +'%Y.%-m.%-d')-$(echo ${GITHUB_SHA} | cut -c1-7)" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            acedatacloud/nexior:${{ steps.version.outputs.version }}
+            acedatacloud/nexior:latest
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Add workflow to publish `acedatacloud/nexior` Docker image to Docker Hub on push to main.

- Image: `acedatacloud/nexior`
- Tags: `latest` + date-based version with commit SHA (e.g. `2026.4.10-abc1234`)
- Multi-platform: `linux/amd64`, `linux/arm64`
- Uses org secrets `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`
- Triggered on push to main or manual workflow dispatch