### PR TITLE
fix: resolve publish version conflict with npm registry

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
 

--- a/change/@acedatacloud-nexior-36907f5f-a5f6-46ce-938b-a6a2f18e84f6.json
+++ b/change/@acedatacloud-nexior-36907f5f-a5f6-46ce-938b-a6a2f18e84f6.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "fix: replace broken CDN logos for Wan, Kimi, and SERP services",
-  "packageName": "@acedatacloud/nexior",
-  "email": "cqc@cuiqingcai.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@acedatacloud-nexior-44dd8597-2abe-4e92-8ae3-1d19636b1df8.json
+++ b/change/@acedatacloud-nexior-44dd8597-2abe-4e92-8ae3-1d19636b1df8.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "fix: make sidebar permanently narrow and remove expand/collapse toggle",
-  "packageName": "@acedatacloud/nexior",
-  "email": "dev@acedata.cloud",
-  "dependentChangeType": "patch"
-}

--- a/change/@acedatacloud-nexior-5c1a6fc6-5d08-4c78-9f36-b9c644ce6774.json
+++ b/change/@acedatacloud-nexior-5c1a6fc6-5d08-4c78-9f36-b9c644ce6774.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Restore brand logo in sidebar navigator",
-  "packageName": "@acedatacloud/nexior",
-  "email": "cqc@cuiqingcai.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@acedatacloud-nexior-841e3adc-0ae1-426d-8620-50448cc1098f.json
+++ b/change/@acedatacloud-nexior-841e3adc-0ae1-426d-8620-50448cc1098f.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "feat: beautify SERP page UI with improved visual hierarchy",
-  "packageName": "@acedatacloud/nexior",
-  "email": "cqc@cuiqingcai.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@acedatacloud-nexior-855a8b78-249e-4539-8d7b-a523b7750f3d.json
+++ b/change/@acedatacloud-nexior-855a8b78-249e-4539-8d7b-a523b7750f3d.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Add feature setting toggles for Wan, Producer, Kimi, and SERP services",
-  "packageName": "@acedatacloud/nexior",
-  "email": "cqc@cuiqingcai.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@acedatacloud-nexior-8fbbe054-4cc0-4172-bcf5-9a6348fc6540.json
+++ b/change/@acedatacloud-nexior-8fbbe054-4cc0-4172-bcf5-9a6348fc6540.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "fix: add Suno v5.5 model to selector dropdown",
-  "packageName": "@acedatacloud/nexior",
-  "email": "cqc@cuiqingcai.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@acedatacloud-nexior-add-producer-service.json
+++ b/change/@acedatacloud-nexior-add-producer-service.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "feat: add Producer music generation service with FUZZ models",
-  "packageName": "@acedatacloud/nexior",
-  "email": "dev@acedata.cloud",
-  "dependentChangeType": "patch"
-}

--- a/change/@acedatacloud-nexior-fix-serp-image-search.json
+++ b/change/@acedatacloud-nexior-fix-serp-image-search.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "fix: serp image search shows no results due to missing images check in noResults",
-  "packageName": "@acedatacloud/nexior",
-  "email": "dev@acedata.cloud",
-  "dependentChangeType": "patch"
-}

--- a/change/@acedatacloud-nexior-fix-small-inputs.json
+++ b/change/@acedatacloud-nexior-fix-small-inputs.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "fix: remove size=\"small\" from form input elements for better UX",
-  "packageName": "@acedatacloud/nexior",
-  "email": "dev@acedata.cloud",
-  "dependentChangeType": "patch"
-}

--- a/change/@acedatacloud-nexior-midjourney-default-v7.json
+++ b/change/@acedatacloud-nexior-midjourney-default-v7.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "fix: change Midjourney default version from 6.1 to 7",
-  "packageName": "@acedatacloud/nexior",
-  "email": "dev@acedata.cloud",
-  "dependentChangeType": "patch"
-}

--- a/change/@acedatacloud-nexior-serp-search.json
+++ b/change/@acedatacloud-nexior-serp-search.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "feat: add SERP Google search service with instant results display",
-  "packageName": "@acedatacloud/nexior",
-  "email": "dev@acedata.cloud",
-  "dependentChangeType": "patch"
-}

--- a/change/@acedatacloud-nexior-serp-video-news.json
+++ b/change/@acedatacloud-nexior-serp-video-news.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "fix: add video and news result rendering to SERP search page",
-  "packageName": "@acedatacloud/nexior",
-  "email": "dev@acedata.cloud",
-  "dependentChangeType": "patch"
-}

--- a/change/@acedatacloud-nexior-suno-missing-features.json
+++ b/change/@acedatacloud-nexior-suno-missing-features.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "feat: add missing Suno API features (upload_cover, overpainting, underpainting, samples, artist_consistency, vox, timing, persona, voices, mashup-lyrics)",
-  "packageName": "@acedatacloud/nexior",
-  "email": "dev@acedata.cloud",
-  "dependentChangeType": "patch"
-}

--- a/change/add-kimi-chat-service.json
+++ b/change/add-kimi-chat-service.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "feat: add Kimi chat service with K2.5 and K2 Thinking models",
-  "packageName": "@acedatacloud/nexior",
-  "email": "dev@acedata.cloud",
-  "dependentChangeType": "patch"
-}

--- a/change/feat-wan-video.json
+++ b/change/feat-wan-video.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "feat(nexior): add Wan video generation service",
-  "packageName": "@acedatacloud/nexior",
-  "email": "dev@acedata.cloud",
-  "dependentChangeType": "patch"
-}

--- a/change/fix-publish-version-conflict.json
+++ b/change/fix-publish-version-conflict.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix: resolve publish version conflict with npm registry",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "none"
+}

--- a/change/fix-wan-bot-avatar.json
+++ b/change/fix-wan-bot-avatar.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "fix: use WAN_LOGO constant for broken wan bot avatar",
-  "packageName": "@acedatacloud/nexior",
-  "email": "dev@acedata.cloud",
-  "dependentChangeType": "patch"
-}

--- a/change/fix-wan-resolution-case.json
+++ b/change/fix-wan-resolution-case.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "fix: use lowercase resolution values in Wan config for cost matching",
-  "packageName": "@acedatacloud/nexior",
-  "email": "dev@acedata.cloud",
-  "dependentChangeType": "patch"
-}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acedatacloud/nexior",
-  "version": "3.32.9",
+  "version": "3.33.0",
   "author": "Ace Data Cloud <office@acedata.cloud>",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The `publish` workflow has been failing since Run #642 (18+ consecutive failures).

**Root cause:** `@acedatacloud/nexior@3.33.0` was published to npm by a partially successful run, but the version bump commit never made it back to `main`. This left `package.json` at `3.32.9` while npm already had `3.33.0`, causing beachball to repeatedly fail with:

```
ERROR: Attempting to publish package versions that already exist in the registry:
- @acedatacloud/nexior@3.33.0
```

**Fix:**
- Bump `package.json` version from `3.32.9` → `3.33.0` to match npm
- Remove 17 stale change files that were causing the version conflict
- Update `actions/checkout@v3` → `v4`, `actions/setup-node@v2` → `v4` (Node.js 20 deprecation warning)