### PR TITLE
fix: remove arm64 platform from Docker Hub workflow

### DIFF
--- a/.github/workflows/publish-dockerhub.yaml
+++ b/.github/workflows/publish-dockerhub.yaml
@@ -40,4 +40,3 @@ jobs:
           tags: |
             acedatacloud/nexior:${{ steps.version.outputs.version }}
             acedatacloud/nexior:latest
-          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Fix Docker Hub publish workflow failure ([run](https://github.com/AceDataCloud/Nexior/actions/runs/24203848097/job/70654321157)).

**Root cause:** The `linux/arm64` build runs under QEMU emulation on GitHub Actions, which causes `yarn install` network timeouts (`ESOCKETTIMEDOUT` downloading npm packages).

**Fix:** Remove `platforms: linux/amd64,linux/arm64` — defaults to host platform (`linux/amd64`). Since the image only serves static files via nginx, amd64-only is sufficient for production.