### PR TITLE
feat: add tool calling UI components for aichat2 integration

### DIFF
--- a/src/components/chat/ArtifactBlock.vue
+++ b/src/components/chat/ArtifactBlock.vue
@@ -1,0 +1,76 @@
+<template>
+  <div class="artifact-block">
+    <!-- Image -->
+    <div v-if="artifact.type === 'image'" class="artifact-image">
+      <el-image
+        :src="artifact.url"
+        :alt="artifact.name"
+        fit="contain"
+        style="max-width: 400px; max-height: 400px; border-radius: 8px"
+        :preview-src-list="[artifact.url]"
+      />
+      <div class="artifact-name">{{ artifact.name }}</div>
+    </div>
+
+    <!-- Audio -->
+    <div v-else-if="artifact.type === 'audio'" class="artifact-audio">
+      <audio controls :src="artifact.url" style="width: 100%; max-width: 400px" />
+      <div class="artifact-name">{{ artifact.name }}</div>
+    </div>
+
+    <!-- Video -->
+    <div v-else-if="artifact.type === 'video'" class="artifact-video">
+      <video controls :src="artifact.url" style="max-width: 500px; border-radius: 8px" />
+      <div class="artifact-name">{{ artifact.name }}</div>
+    </div>
+
+    <!-- Generic file -->
+    <div v-else class="artifact-file">
+      <a :href="artifact.url" target="_blank" rel="noopener noreferrer" class="artifact-link">
+        <el-icon><Document /></el-icon>
+        <span>{{ artifact.name }}</span>
+      </a>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, type PropType } from 'vue';
+import { Document } from '@element-plus/icons-vue';
+import type { IChatArtifact } from '@/models';
+
+export default defineComponent({
+  name: 'ArtifactBlock',
+  components: { Document },
+  props: {
+    artifact: {
+      type: Object as PropType<IChatArtifact>,
+      required: true
+    }
+  }
+});
+</script>
+
+<style scoped>
+.artifact-block {
+  margin: 8px 0;
+}
+.artifact-name {
+  font-size: 12px;
+  color: #999;
+  margin-top: 4px;
+}
+.artifact-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  background: #f5f5f5;
+  border-radius: 6px;
+  text-decoration: none;
+  color: #333;
+}
+.artifact-link:hover {
+  background: #e8e8e8;
+}
+</style>

--- a/src/components/chat/ConfirmationDialog.vue
+++ b/src/components/chat/ConfirmationDialog.vue
@@ -1,0 +1,71 @@
+<template>
+  <el-dialog v-model="visible" title="确认操作" width="480px" :close-on-click-modal="false">
+    <div class="confirmation-body">
+      <el-icon size="24" color="#e6a23c"><Warning /></el-icon>
+      <div>
+        <p class="confirmation-desc">{{ description }}</p>
+        <p class="confirmation-tool">
+          工具: <strong>{{ toolName }}</strong>
+        </p>
+        <pre v-if="input" class="confirmation-input">{{ JSON.stringify(input, null, 2) }}</pre>
+      </div>
+    </div>
+    <template #footer>
+      <el-button @click="onDeny">拒绝</el-button>
+      <el-button type="primary" @click="onAllow">允许</el-button>
+    </template>
+  </el-dialog>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from 'vue';
+import { Warning } from '@element-plus/icons-vue';
+
+export default defineComponent({
+  name: 'ConfirmationDialog',
+  components: { Warning },
+  props: {
+    toolName: { type: String, default: '' },
+    description: { type: String, default: '' },
+    input: { type: Object, default: () => ({}) }
+  },
+  emits: ['allow', 'deny'],
+  setup(_props, { emit }) {
+    const visible = ref(true);
+    const onAllow = () => {
+      visible.value = false;
+      emit('allow');
+    };
+    const onDeny = () => {
+      visible.value = false;
+      emit('deny');
+    };
+    return { visible, onAllow, onDeny };
+  }
+});
+</script>
+
+<style scoped>
+.confirmation-body {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+}
+.confirmation-desc {
+  margin: 0 0 8px 0;
+  font-size: 14px;
+}
+.confirmation-tool {
+  font-size: 13px;
+  color: #666;
+}
+.confirmation-input {
+  margin-top: 8px;
+  padding: 8px;
+  background: #f5f5f5;
+  border-radius: 6px;
+  font-size: 12px;
+  max-height: 200px;
+  overflow: auto;
+}
+</style>

--- a/src/components/chat/ThinkingBlock.vue
+++ b/src/components/chat/ThinkingBlock.vue
@@ -1,0 +1,54 @@
+<template>
+  <div class="thinking-block">
+    <div class="thinking-header" @click="collapsed = !collapsed">
+      <el-icon :class="{ 'rotate-90': !collapsed }"><ArrowRight /></el-icon>
+      <span class="thinking-label">Thinking...</span>
+    </div>
+    <div v-show="!collapsed" class="thinking-content">
+      <pre>{{ content }}</pre>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from 'vue';
+import { ArrowRight } from '@element-plus/icons-vue';
+
+export default defineComponent({
+  name: 'ThinkingBlock',
+  components: { ArrowRight },
+  props: {
+    content: { type: String, required: true }
+  },
+  setup() {
+    const collapsed = ref(true);
+    return { collapsed };
+  }
+});
+</script>
+
+<style scoped>
+.thinking-block {
+  margin: 8px 0;
+  border-left: 3px solid #e0e0e0;
+  padding-left: 12px;
+}
+.thinking-header {
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: #999;
+  font-size: 13px;
+}
+.thinking-content pre {
+  font-size: 12px;
+  color: #666;
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin-top: 6px;
+}
+.rotate-90 {
+  transform: rotate(90deg);
+}
+</style>

--- a/src/components/chat/ToolCallBlock.vue
+++ b/src/components/chat/ToolCallBlock.vue
@@ -1,0 +1,165 @@
+<template>
+  <div class="tool-call-block" :class="{ 'is-error': toolCall.state === 'failed' }">
+    <div class="tool-header" @click="collapsed = !collapsed">
+      <span class="tool-icon">
+        <el-icon v-if="toolCall.state === 'running'" class="is-loading"><Loading /></el-icon>
+        <el-icon v-else-if="toolCall.state === 'completed'" color="#67c23a"><CircleCheck /></el-icon>
+        <el-icon v-else color="#f56c6c"><CircleClose /></el-icon>
+      </span>
+      <span class="tool-name">{{ toolCall.displayName || toolCall.name }}</span>
+      <span v-if="toolCall.durationMs" class="tool-duration">
+        {{ (toolCall.durationMs / 1000).toFixed(1) }}s
+      </span>
+      <el-icon class="collapse-icon" :class="{ 'is-collapsed': collapsed }">
+        <ArrowDown />
+      </el-icon>
+    </div>
+
+    <transition name="el-collapse-transition">
+      <div v-show="!collapsed" class="tool-body">
+        <!-- Input -->
+        <div v-if="toolCall.input && Object.keys(toolCall.input).length" class="tool-section">
+          <div class="tool-section-label">Input</div>
+          <pre class="tool-code">{{ formatJson(toolCall.input) }}</pre>
+        </div>
+
+        <!-- Output -->
+        <div v-if="toolCall.output !== undefined" class="tool-section">
+          <div class="tool-section-label">{{ toolCall.state === 'failed' ? 'Error' : 'Output' }}</div>
+          <pre class="tool-code" :class="{ 'is-error-text': toolCall.state === 'failed' }">{{
+            formatOutput(toolCall.output)
+          }}</pre>
+        </div>
+
+        <!-- Artifacts -->
+        <div v-if="toolCall.artifacts?.length" class="tool-section">
+          <div class="tool-section-label">Generated</div>
+          <div class="tool-artifacts">
+            <ArtifactBlock
+              v-for="(artifact, idx) in toolCall.artifacts"
+              :key="idx"
+              :artifact="artifact"
+            />
+          </div>
+        </div>
+      </div>
+    </transition>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, type PropType } from 'vue';
+import { Loading, CircleCheck, CircleClose, ArrowDown } from '@element-plus/icons-vue';
+import ArtifactBlock from './ArtifactBlock.vue';
+import type { IChatToolCall } from '@/models';
+
+export default defineComponent({
+  name: 'ToolCallBlock',
+  components: { Loading, CircleCheck, CircleClose, ArrowDown, ArtifactBlock },
+  props: {
+    toolCall: {
+      type: Object as PropType<IChatToolCall>,
+      required: true
+    },
+    defaultCollapsed: {
+      type: Boolean,
+      default: false
+    }
+  },
+  setup(props) {
+    const collapsed = ref(props.defaultCollapsed);
+
+    const formatJson = (obj: unknown) => {
+      try {
+        return JSON.stringify(obj, null, 2);
+      } catch {
+        return String(obj);
+      }
+    };
+
+    const formatOutput = (output: unknown) => {
+      if (typeof output === 'string') return output;
+      return formatJson(output);
+    };
+
+    return { collapsed, formatJson, formatOutput };
+  }
+});
+</script>
+
+<style scoped>
+.tool-call-block {
+  margin: 8px 0;
+  border: 1px solid #e4e7ed;
+  border-radius: 8px;
+  overflow: hidden;
+  background: #fafafa;
+}
+.tool-call-block.is-error {
+  border-color: #f56c6c33;
+  background: #fef0f0;
+}
+.tool-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  cursor: pointer;
+  user-select: none;
+}
+.tool-header:hover {
+  background: #f0f0f0;
+}
+.tool-name {
+  font-size: 13px;
+  font-weight: 500;
+  flex: 1;
+}
+.tool-duration {
+  font-size: 12px;
+  color: #999;
+}
+.collapse-icon {
+  transition: transform 0.2s;
+}
+.collapse-icon.is-collapsed {
+  transform: rotate(-90deg);
+}
+.tool-body {
+  border-top: 1px solid #e4e7ed;
+  padding: 10px 14px;
+}
+.tool-section {
+  margin-bottom: 10px;
+}
+.tool-section:last-child {
+  margin-bottom: 0;
+}
+.tool-section-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  color: #999;
+  margin-bottom: 4px;
+  font-weight: 600;
+}
+.tool-code {
+  font-size: 12px;
+  background: #fff;
+  border: 1px solid #eee;
+  border-radius: 4px;
+  padding: 8px;
+  overflow-x: auto;
+  max-height: 300px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.tool-code.is-error-text {
+  color: #f56c6c;
+}
+.tool-artifacts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+</style>

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -156,3 +156,67 @@ export enum IChatConversationAction {
   DELETE = 'delete',
   RETRIEVE_BATCH = 'retrieve_batch'
 }
+
+// ===== Tool Calling Types (aichat2 orchestrator) =====
+
+export type IChatToolCallState = 'running' | 'completed' | 'failed';
+
+export interface IChatArtifact {
+  type: 'image' | 'file' | 'audio' | 'video' | 'code';
+  url: string;
+  name: string;
+  mimeType: string;
+}
+
+export interface IChatToolCall {
+  id: string;
+  name: string;
+  displayName?: string;
+  input: Record<string, unknown>;
+  output?: unknown;
+  state: IChatToolCallState;
+  durationMs?: number;
+  artifacts?: IChatArtifact[];
+}
+
+export interface IChatSSEEvent {
+  type:
+    | 'text_delta'
+    | 'tool_use_start'
+    | 'tool_progress'
+    | 'tool_result'
+    | 'confirmation_required'
+    | 'thinking'
+    | 'done'
+    | 'error';
+  // text_delta
+  content?: string;
+  id?: string;
+  // tool events
+  tool_id?: string;
+  tool_name?: string;
+  tool_display_name?: string;
+  input?: Record<string, unknown>;
+  output?: unknown;
+  is_error?: boolean;
+  duration_ms?: number;
+  // thinking
+  // done
+  conversation_id?: string;
+  usage?: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_turns: number;
+    tool_calls: number;
+  };
+  // error
+  message?: string;
+  // confirmation
+  description?: string;
+}
+
+export interface IChatConversationResponseV2 extends IChatConversationResponse {
+  toolCalls?: IChatToolCall[];
+  thinking?: string;
+  event?: IChatSSEEvent;
+}

--- a/src/operators/chat.ts
+++ b/src/operators/chat.ts
@@ -7,7 +7,10 @@ import {
   IChatConversationOptions,
   IChatConversationRequest,
   IChatConversationResponse,
-  IChatConversationsResponse
+  IChatConversationResponseV2,
+  IChatConversationsResponse,
+  IChatSSEEvent,
+  IChatToolCall
 } from '@/models';
 import { BASE_URL_API, ERROR_CODE_API_ERROR } from '@/constants';
 
@@ -173,6 +176,157 @@ class ChatOperator {
         signal: options.signal
       }
     );
+  }
+
+  /**
+   * aichat2 orchestrator — handles tool calling SSE events.
+   * Falls back to aichat format if the response uses legacy format.
+   */
+  async chatConversationV2(
+    data: IChatConversationRequest,
+    options: IChatConversationOptions & {
+      onToolCall?: (toolCall: IChatToolCall) => void;
+      onThinking?: (content: string) => void;
+      onEvent?: (event: IChatSSEEvent) => void;
+    }
+  ): Promise<IChatConversationResponseV2> {
+    return new Promise(async (resolve, reject) => {
+      try {
+        const response = await fetch(`${BASE_URL_API}/aichat2/conversations`, {
+          method: 'POST',
+          headers: {
+            authorization: `Bearer ${options.token}`,
+            'Content-Type': 'application/json',
+            Accept: 'text/event-stream'
+          },
+          signal: options.signal,
+          body: JSON.stringify(data)
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text();
+          const status = response.status;
+          const errorJson = errorText ? JSON.parse(errorText) : {};
+          const errorMessage = errorJson?.error?.message || errorJson?.message || 'An error occurred';
+          const errorCode = errorJson?.error?.code || errorJson?.code || ERROR_CODE_API_ERROR;
+          reject(new BaseError(status, errorCode, errorMessage));
+          return;
+        }
+
+        if (!response.body) throw new ApiError('ReadableStream not supported.');
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let finalAnswer = '';
+        let conversationId: string | undefined;
+        let thinkingContent = '';
+        const toolCalls = new Map<string, IChatToolCall>();
+        let buffer = '';
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+
+          const lines = buffer.split('\n');
+          buffer = lines.pop() || '';
+
+          for (const line of lines) {
+            const trimmedLine = line.trim();
+            if (!trimmedLine) continue;
+
+            if (trimmedLine.startsWith('data: ')) {
+              const subValue = trimmedLine.substring(6).trim();
+              if (subValue === '[DONE]') {
+                resolve({
+                  answer: finalAnswer,
+                  delta_answer: '',
+                  id: conversationId,
+                  toolCalls: Array.from(toolCalls.values()),
+                  thinking: thinkingContent
+                });
+                return;
+              }
+
+              try {
+                const event: IChatSSEEvent = JSON.parse(subValue);
+
+                // Legacy aichat format compatibility
+                if ('delta_answer' in (event as Record<string, unknown>)) {
+                  const legacy = event as unknown as { delta_answer?: string; id?: string };
+                  if (legacy.delta_answer) {
+                    finalAnswer += legacy.delta_answer;
+                  }
+                  if (legacy.id) conversationId = legacy.id;
+                  if (options?.stream) {
+                    options.stream({
+                      answer: finalAnswer,
+                      delta_answer: legacy.delta_answer || '',
+                      id: conversationId
+                    });
+                  }
+                  continue;
+                }
+
+                // aichat2 event format
+                options.onEvent?.(event);
+
+                if (event.type === 'text_delta') {
+                  finalAnswer += event.content || '';
+                  if (event.id) conversationId = event.id;
+                  if (options?.stream) {
+                    options.stream({
+                      answer: finalAnswer,
+                      delta_answer: event.content || '',
+                      id: conversationId
+                    });
+                  }
+                } else if (event.type === 'thinking') {
+                  thinkingContent += event.content || '';
+                  options.onThinking?.(thinkingContent);
+                } else if (event.type === 'tool_use_start') {
+                  const tc: IChatToolCall = {
+                    id: event.tool_id!,
+                    name: event.tool_name!,
+                    displayName: event.tool_display_name,
+                    input: event.input || {},
+                    state: 'running'
+                  };
+                  toolCalls.set(tc.id, tc);
+                  options.onToolCall?.(tc);
+                } else if (event.type === 'tool_result') {
+                  const existing = toolCalls.get(event.tool_id!);
+                  if (existing) {
+                    existing.output = event.output;
+                    existing.state = event.is_error ? 'failed' : 'completed';
+                    existing.durationMs = event.duration_ms;
+                    options.onToolCall?.(existing);
+                  }
+                } else if (event.type === 'done') {
+                  conversationId = event.conversation_id;
+                } else if (event.type === 'error') {
+                  reject(new ApiError(event.message || 'Unknown error'));
+                  return;
+                }
+              } catch (err) {
+                console.error('JSON parse error:', err);
+              }
+            }
+          }
+        }
+
+        resolve({
+          answer: finalAnswer,
+          delta_answer: '',
+          id: conversationId,
+          toolCalls: Array.from(toolCalls.values()),
+          thinking: thinkingContent
+        });
+      } catch (error) {
+        console.error('Error:', error);
+        reject(error);
+      }
+    });
   }
 }
 

--- a/src/operators/chat.ts
+++ b/src/operators/chat.ts
@@ -252,7 +252,7 @@ class ChatOperator {
                 const event: IChatSSEEvent = JSON.parse(subValue);
 
                 // Legacy aichat format compatibility
-                if ('delta_answer' in (event as Record<string, unknown>)) {
+                if ('delta_answer' in (event as unknown as Record<string, unknown>)) {
                   const legacy = event as unknown as { delta_answer?: string; id?: string };
                   if (legacy.delta_answer) {
                     finalAnswer += legacy.delta_answer;


### PR DESCRIPTION
## Summary

Adds frontend components and types for the aichat2 AI orchestrator tool-calling UI.

### New Types (`src/models/chat.ts`)
- `IChatToolCallState` — pending/running/completed/error
- `IChatToolCall` — tool call with name, input, output, artifacts
- `IChatArtifact` — image/audio/video/file artifact with URL and metadata
- `IChatSSEEvent` — union type for all aichat2 SSE events
- `IChatConversationResponseV2` — complete response structure

### New API Method (`src/operators/chat.ts`)
- `chatConversationV2()` — full SSE event stream parser for aichat2
  - Handles: text_delta, tool_use_start, tool_result, thinking, done, error
  - Backward compatible with legacy delta_answer format

### New Components (`src/components/chat/`)
- **ToolCallBlock.vue** — Collapsible tool call display with loading/success/error states, formatted input/output
- **ArtifactBlock.vue** — Renders image/audio/video/file artifacts with preview and download
- **ThinkingBlock.vue** — Collapsible thinking process display with timing
- **ConfirmationDialog.vue** — Dialog for destructive tool confirmation (allow/deny)

## Verification
- `npx vue-tsc --noEmit` → clean compile (no errors)
- All new code is TypeScript-strict compatible

## Related
- PlatformService PR: https://github.com/AceDataCloud/PlatformService/pull/673