### PR TITLE
feat(chat): add tool-calling event support for aichat2

### DIFF
--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -136,12 +136,24 @@ export interface IChatConversationRequest {
   messages?: IChatMessage[];
   action?: IChatConversationAction;
   model: IChatModelName;
+  tools_enabled?: boolean;
+  tools_filter?: string[];
 }
 
 export interface IChatConversationResponse {
   answer: string;
   delta_answer: string;
   id?: string;
+  // aichat2 tool-calling event fields
+  type?: string;
+  tool_id?: string;
+  tool_name?: string;
+  tool_display_name?: string;
+  input?: Record<string, unknown>;
+  output?: string;
+  is_error?: boolean;
+  duration_ms?: number;
+  content?: string;
 }
 
 export interface IChatConversationsResponse {

--- a/src/operators/chat.ts
+++ b/src/operators/chat.ts
@@ -79,7 +79,17 @@ class ChatOperator {
                   options.stream({
                     answer: finalAnswer,
                     delta_answer: json.delta_answer || '',
-                    id
+                    id,
+                    // Forward aichat2 event types for tool-calling UI
+                    type: json.type,
+                    tool_id: json.tool_id,
+                    tool_name: json.tool_name,
+                    tool_display_name: json.tool_display_name,
+                    input: json.input,
+                    output: json.output,
+                    is_error: json.is_error,
+                    duration_ms: json.duration_ms,
+                    content: json.content
                   });
                 }
               } catch (err) {


### PR DESCRIPTION
## Summary

Update chat models and operator to support aichat2's tool-calling SSE events. This prepares the data layer for the tool-calling UI components (ToolCallBlock, ArtifactBlock, ThinkingBlock) added in PR #427.

## Changes

- `src/models/chat.ts`:
  - `IChatConversationResponse`: Added `type`, `tool_id`, `tool_name`, `tool_display_name`, `input`, `output`, `is_error`, `duration_ms`, `content` fields
  - `IChatConversationRequest`: Added `tools_enabled` and `tools_filter` fields
- `src/operators/chat.ts`: Stream callback now forwards all tool-calling event fields from aichat2 SSE events

## Context

aichat2 emits SSE events with types like `tool_start`, `tool_result`, `text_delta`, etc. The existing Nexior stream parser only reads `delta_answer` and `id`. This PR extends the response model and stream callback to pass through all event fields, enabling the tool-calling UI components to render tool invocations in real-time.