### PR TITLE
chore: standardize GitHub token secret names

### DIFF
--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         env:
-          GITHUB_TOKEN: ${{ secrets.REPO_PAT || github.token }}
+          GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN || github.token }}
         with:
           tag_name: ${{ steps.meta.outputs.tag }}
           name: v${{ steps.meta.outputs.version }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -37,7 +37,7 @@ jobs:
         run: |
           git config --global user.name 'GitHub Actions'
           git config --global user.email 'actions@github.com'
-          git remote set-url origin "https://${{ secrets.REPO_PAT }}@github.com/AceDataCloud/Nexior"
+          git remote set-url origin "https://${{ secrets.BOT_GITHUB_TOKEN }}@github.com/AceDataCloud/Nexior"
 
       - name: Publish
         run: yarn release

--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Auto-approve translation PR
         if: ${{ steps.cpr.outputs.pull-request-number }}
         env:
-          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
         run: |
           gh pr review ${{ steps.cpr.outputs.pull-request-number }} --approve --repo ${{ github.repository }}
 


### PR DESCRIPTION
Standardize GitHub token secret names. Replace legacy `secrets.BOT_TOKEN` and `secrets.REPO_PAT` with `secrets.BOT_GITHUB_TOKEN`.