### PR TITLE
feat(chat): integrate aichat2 endpoint with tool-calling UI

### DIFF
--- a/src/components/chat/Message.vue
+++ b/src/components/chat/Message.vue
@@ -47,6 +47,7 @@
                 <markdown-renderer v-if="message.role === 'assistant'" :content="item.text" />
                 <pre v-else class="whitespace-pre-wrap break-words w-fit max-w-full py-1">{{ item.text?.trim() }}</pre>
               </div>
+              <tool-activity v-if="item.type === 'tool_use'" :item="item" />
             </div>
           </div>
         </div>
@@ -129,6 +130,7 @@ import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import RestartToGenerate from './RestartToGenerate.vue';
 import EditMessage from './EditMessage.vue';
 import FilePreview from '@/components/common/FilePreview.vue';
+import ToolActivity from './ToolActivity.vue';
 import {
   ERROR_CODE_API_ERROR,
   ERROR_CODE_BAD_REQUEST,
@@ -160,6 +162,7 @@ export default defineComponent({
     AnsweringMark,
     MarkdownRenderer,
     FilePreview,
+    ToolActivity,
     ElButton,
     ElImage,
     ElInput,

--- a/src/components/chat/ToolActivity.vue
+++ b/src/components/chat/ToolActivity.vue
@@ -1,0 +1,160 @@
+<template>
+  <div :class="['tool-activity', { 'is-error': item.is_error, 'is-running': item.status === 'running' }]">
+    <div class="tool-header" @click="expanded = !expanded">
+      <span class="tool-icon">
+        <el-icon v-if="item.status === 'running'" class="is-loading"><Loading /></el-icon>
+        <el-icon v-else-if="item.is_error" color="var(--el-color-danger)"><CircleCloseFilled /></el-icon>
+        <el-icon v-else color="var(--el-color-success)"><CircleCheckFilled /></el-icon>
+      </span>
+      <span class="tool-name">{{ displayName }}</span>
+      <span v-if="item.duration_ms" class="tool-duration">{{ item.duration_ms }}ms</span>
+      <el-icon class="tool-expand" :class="{ rotated: expanded }"><ArrowRight /></el-icon>
+    </div>
+    <div v-if="expanded" class="tool-body">
+      <div v-if="inputText" class="tool-section">
+        <div class="tool-section-label">Input</div>
+        <pre class="tool-code">{{ inputText }}</pre>
+      </div>
+      <div v-if="item.output" class="tool-section">
+        <div class="tool-section-label">Output</div>
+        <pre class="tool-code">{{ item.output }}</pre>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, PropType } from 'vue';
+import { IChatMessageContentItem } from '@/models';
+import { Loading, CircleCheckFilled, CircleCloseFilled, ArrowRight } from '@element-plus/icons-vue';
+
+const TOOL_LABELS: Record<string, string> = {
+  code_execute: 'Running code',
+  web_search: 'Searching the web',
+  image_generate: 'Generating image',
+  video_generate: 'Generating video',
+  music_generate: 'Generating music'
+};
+
+export default defineComponent({
+  name: 'ToolActivity',
+  components: { Loading, CircleCheckFilled, CircleCloseFilled, ArrowRight },
+  props: {
+    item: {
+      type: Object as PropType<IChatMessageContentItem>,
+      required: true
+    }
+  },
+  data() {
+    return {
+      expanded: false
+    };
+  },
+  computed: {
+    displayName(): string {
+      if (this.item.tool_display_name) return this.item.tool_display_name;
+      const name = this.item.tool_name || '';
+      return TOOL_LABELS[name] || name.replace(/_/g, ' ');
+    },
+    inputText(): string {
+      if (!this.item.input) return '';
+      if (this.item.tool_name === 'code_execute') {
+        return (this.item.input.code as string) || '';
+      }
+      if (this.item.tool_name === 'web_search') {
+        return (this.item.input.query as string) || '';
+      }
+      return JSON.stringify(this.item.input, null, 2);
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.tool-activity {
+  margin: 8px 0;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 8px;
+  overflow: hidden;
+  font-size: 13px;
+
+  &.is-error {
+    border-color: var(--el-color-danger-light-5);
+  }
+
+  &.is-running {
+    border-color: var(--el-color-primary-light-5);
+  }
+}
+
+.tool-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  cursor: pointer;
+  user-select: none;
+  background: var(--el-fill-color-light);
+
+  &:hover {
+    background: var(--el-fill-color);
+  }
+}
+
+.tool-icon {
+  display: flex;
+  align-items: center;
+  font-size: 14px;
+}
+
+.tool-name {
+  flex: 1;
+  font-weight: 500;
+  color: var(--el-text-color-primary);
+}
+
+.tool-duration {
+  color: var(--el-text-color-secondary);
+  font-size: 12px;
+}
+
+.tool-expand {
+  transition: transform 0.2s;
+  color: var(--el-text-color-secondary);
+
+  &.rotated {
+    transform: rotate(90deg);
+  }
+}
+
+.tool-body {
+  padding: 0 12px 8px;
+}
+
+.tool-section {
+  margin-top: 6px;
+}
+
+.tool-section-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: var(--el-text-color-secondary);
+  margin-bottom: 4px;
+}
+
+.tool-code {
+  background: var(--el-fill-color-darker);
+  border-radius: 4px;
+  padding: 8px 10px;
+  font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
+  margin: 0;
+  max-height: 300px;
+  overflow-y: auto;
+}
+</style>

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -102,6 +102,15 @@ export interface IChatMessageContentItem {
   text?: string;
   image_url?: { url: string } | string;
   file_url?: { url: string } | string;
+  // Tool-calling fields (type='tool_use')
+  tool_id?: string;
+  tool_name?: string;
+  tool_display_name?: string;
+  input?: Record<string, unknown>;
+  output?: string;
+  is_error?: boolean;
+  duration_ms?: number;
+  status?: 'running' | 'done';
 }
 
 export interface IChatMessage {

--- a/src/operators/chat.ts
+++ b/src/operators/chat.ts
@@ -18,7 +18,7 @@ class ChatOperator {
   ): Promise<IChatConversationResponse> {
     return new Promise(async (resolve, reject) => {
       try {
-        const response = await fetch(`${BASE_URL_API}/aichat/conversations`, {
+        const response = await fetch(`${BASE_URL_API}/aichat2/conversations`, {
           method: 'POST',
           headers: {
             authorization: `Bearer ${options.token}`,
@@ -115,7 +115,7 @@ class ChatOperator {
     options: IChatConversationOptions
   ): Promise<AxiosResponse<IChatConversationsResponse>> {
     return await axios.post(
-      `/aichat/conversations`,
+      `/aichat2/conversations`,
       {
         action: IChatConversationAction.RETRIEVE_BATCH,
         ...(filter.ids
@@ -147,7 +147,7 @@ class ChatOperator {
 
   async deleteConversation(id: string, options: IChatConversationOptions): Promise<AxiosResponse<IChatConversation>> {
     return await axios.post(
-      `/aichat/conversations`,
+      `/aichat2/conversations`,
       {
         action: IChatConversationAction.DELETE,
         id: id
@@ -168,7 +168,7 @@ class ChatOperator {
     options: IChatConversationOptions
   ): Promise<AxiosResponse<IChatConversation>> {
     return await axios.post(
-      `/aichat/conversations`,
+      `/aichat2/conversations`,
       {
         action: IChatConversationAction.UPDATE,
         ...payload

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -46,6 +46,7 @@ import { Status } from '@/models';
 import Disclaimer from '@/components/chat/Disclaimer.vue';
 import Layout from '@/layouts/Chat.vue';
 import { isImageUrl } from '@/utils/is';
+import { IChatMessageContentItem } from '@/models';
 import { chatOperator } from '@/operators';
 
 export interface IData {
@@ -397,6 +398,11 @@ export default defineComponent({
       // request server to get answer
       this.answering = true;
       this.canceler = new AbortController();
+      // Track content parts for tool-calling interleaving
+      const contentParts: IChatMessageContentItem[] = [];
+      const toolMap = new Map<string, IChatMessageContentItem>();
+      let currentText = '';
+
       chatOperator
         .chatConversation(
           {
@@ -404,19 +410,65 @@ export default defineComponent({
             model: this.model.name,
             references,
             id: this.conversationId,
-            stateful: true
+            stateful: true,
+            tools_enabled: true
           },
           {
             token,
             stream: (response: IChatConversationResponse) => {
               console.debug('stream response', response);
               const lastMessage = this.messages[this.messages.length - 1];
-              this.messages[this.messages.length - 1] = {
-                role: ROLE_ASSISTANT,
-                content: response.answer,
-                state:
-                  lastMessage?.state !== IChatMessageState.FINISHED ? IChatMessageState.ANSWERING : lastMessage?.state
-              };
+
+              // Handle tool-calling events
+              if (response.type === 'tool_use_start' && response.tool_id) {
+                // Flush any accumulated text before tool
+                if (currentText) {
+                  contentParts.push({ type: 'text', text: currentText });
+                  currentText = '';
+                }
+                const toolItem: IChatMessageContentItem = {
+                  type: 'tool_use',
+                  tool_id: response.tool_id,
+                  tool_name: response.tool_name,
+                  tool_display_name: response.tool_display_name,
+                  input: response.input,
+                  status: 'running'
+                };
+                contentParts.push(toolItem);
+                toolMap.set(response.tool_id, toolItem);
+              } else if (response.type === 'tool_result' && response.tool_id) {
+                const toolItem = toolMap.get(response.tool_id);
+                if (toolItem) {
+                  toolItem.output = response.output;
+                  toolItem.is_error = response.is_error;
+                  toolItem.duration_ms = response.duration_ms;
+                  toolItem.status = 'done';
+                }
+              } else if (response.delta_answer) {
+                currentText = response.answer;
+              }
+
+              // Build display content: parts + trailing text
+              const displayParts: IChatMessageContentItem[] = [...contentParts];
+              if (currentText) {
+                displayParts.push({ type: 'text', text: currentText });
+              }
+
+              if (displayParts.length > 0 && displayParts.some((p) => p.type === 'tool_use')) {
+                this.messages[this.messages.length - 1] = {
+                  role: ROLE_ASSISTANT,
+                  content: displayParts,
+                  state:
+                    lastMessage?.state !== IChatMessageState.FINISHED ? IChatMessageState.ANSWERING : lastMessage?.state
+                };
+              } else {
+                this.messages[this.messages.length - 1] = {
+                  role: ROLE_ASSISTANT,
+                  content: response.answer,
+                  state:
+                    lastMessage?.state !== IChatMessageState.FINISHED ? IChatMessageState.ANSWERING : lastMessage?.state
+                };
+              }
               conversationId = response?.id;
             },
             signal: this.canceler.signal


### PR DESCRIPTION
## Changes

### Endpoint Migration
Switch all chat API calls from `/aichat/conversations` to `/aichat2/conversations` (the new AI orchestrator with tool-calling support).

### Tool-Calling UI
- **ToolActivity.vue**: New component showing tool calls inline with collapsible input/output. Shows loading spinner while running, success/error icons when done, and duration.
- **Stream handler**: Builds structured content array interleaving text blocks with tool activity blocks during streaming.
- **Message.vue**: Renders `tool_use` content items using ToolActivity component.

### Model Updates
- `IChatConversationRequest`: `tools_enabled: true` sent by default
- `IChatMessageContentItem`: Extended with tool-calling fields (tool_id, tool_name, input, output, status)

### Supported Tools
| Tool | Display |
|------|---------|
| code_execute | Running code (with code preview) |
| web_search | Searching the web (with query preview) |
| image_generate | Generating image |
| video_generate | Generating video |
| music_generate | Generating music |

### Screenshot
Tool activity appears inline between text blocks with expand/collapse for details.