### PR TITLE
feat(chat): add MCP server management UI

### DIFF
--- a/src/components/chat/McpManager.vue
+++ b/src/components/chat/McpManager.vue
@@ -1,0 +1,423 @@
+<template>
+  <el-dialog
+    v-model="visible"
+    :title="$t('chat.mcp.title')"
+    width="600px"
+    :close-on-click-modal="false"
+    @close="$emit('update:modelValue', false)"
+  >
+    <div class="mcp-manager">
+      <div class="header">
+        <el-button type="primary" size="small" @click="showAddForm = true">
+          <font-awesome-icon icon="fa-solid fa-plus" class="mr-1" />
+          {{ $t('chat.mcp.addServer') }}
+        </el-button>
+      </div>
+
+      <!-- Add/Edit Form -->
+      <el-card v-if="showAddForm || editingServer" shadow="never" class="form-card">
+        <el-form :model="form" label-position="top" size="default">
+          <el-form-item :label="$t('chat.mcp.name')" required>
+            <el-input v-model="form.name" :placeholder="$t('chat.mcp.namePlaceholder')" />
+          </el-form-item>
+          <el-form-item :label="$t('chat.mcp.url')" required>
+            <el-input v-model="form.url" :placeholder="$t('chat.mcp.urlPlaceholder')" />
+          </el-form-item>
+          <el-form-item :label="$t('chat.mcp.description')">
+            <el-input v-model="form.description" :placeholder="$t('chat.mcp.descriptionPlaceholder')" />
+          </el-form-item>
+          <el-form-item :label="$t('chat.mcp.authType')">
+            <el-select v-model="form.auth_type" style="width: 100%">
+              <el-option value="none" :label="$t('chat.mcp.authNone')" />
+              <el-option value="bearer" :label="$t('chat.mcp.authBearer')" />
+            </el-select>
+          </el-form-item>
+          <el-form-item v-if="form.auth_type === 'bearer'" :label="$t('chat.mcp.authToken')">
+            <el-input
+              v-model="form.auth_token"
+              type="password"
+              show-password
+              :placeholder="$t('chat.mcp.authTokenPlaceholder')"
+            />
+          </el-form-item>
+          <div class="form-actions">
+            <el-button size="small" @click="onCancelForm">{{ $t('common.button.cancel') }}</el-button>
+            <el-button size="small" :loading="testing" @click="onTest">
+              <font-awesome-icon icon="fa-solid fa-link" class="mr-1" />
+              {{ $t('chat.mcp.test') }}
+            </el-button>
+            <el-button type="primary" size="small" :loading="submitting" @click="onSave">
+              {{ editingServer ? $t('common.button.save') : $t('chat.mcp.addServer') }}
+            </el-button>
+          </div>
+        </el-form>
+        <!-- Test Results -->
+        <div v-if="testResult" class="test-result">
+          <el-tag :type="testResult.success ? 'success' : 'danger'" size="small" effect="dark">
+            {{ testResult.success ? $t('chat.mcp.testSuccess') : $t('chat.mcp.testFailed') }}
+          </el-tag>
+          <span v-if="testResult.success" class="test-info">
+            {{ $t('chat.mcp.toolsFound', { count: testResult.tools_count }) }}
+          </span>
+          <span v-else class="test-error">{{ testResult.error }}</span>
+          <div v-if="testResult.tools?.length" class="test-tools">
+            <div v-for="tool in testResult.tools" :key="tool.name" class="test-tool">
+              <span class="tool-name">{{ tool.name }}</span>
+              <span v-if="tool.description" class="tool-desc">{{ tool.description }}</span>
+            </div>
+          </div>
+        </div>
+      </el-card>
+
+      <!-- Server List -->
+      <div v-loading="loading" class="server-list">
+        <div v-if="servers.length === 0 && !loading" class="empty">
+          {{ $t('chat.mcp.empty') }}
+        </div>
+        <div v-for="server in servers" :key="server.id" class="server-item">
+          <div class="server-info">
+            <div class="server-header">
+              <el-switch :model-value="server.is_enabled" size="small" @change="onToggle(server, $event as boolean)" />
+              <span class="server-name">{{ server.name }}</span>
+              <el-tag v-if="server.tools_cache?.length" size="small" type="info" effect="plain">
+                {{ server.tools_cache.length }} tools
+              </el-tag>
+            </div>
+            <div class="server-url">{{ server.url }}</div>
+            <div v-if="server.description" class="server-desc">{{ server.description }}</div>
+          </div>
+          <div class="server-actions">
+            <el-button text size="small" @click="onEdit(server)">
+              <font-awesome-icon icon="fa-solid fa-pen-to-square" />
+            </el-button>
+            <el-button text size="small" type="danger" @click="onDelete(server)">
+              <font-awesome-icon icon="fa-solid fa-trash" />
+            </el-button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </el-dialog>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import {
+  ElDialog,
+  ElButton,
+  ElForm,
+  ElFormItem,
+  ElInput,
+  ElSelect,
+  ElOption,
+  ElCard,
+  ElSwitch,
+  ElTag,
+  ElMessage,
+  ElMessageBox
+} from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { mcpServerOperator } from '@/operators';
+import { IMcpServer, IMcpServerTestResponse } from '@/models';
+
+interface IForm {
+  name: string;
+  url: string;
+  description: string;
+  auth_type: string;
+  auth_token: string;
+}
+
+export default defineComponent({
+  name: 'McpManager',
+  components: {
+    ElDialog,
+    ElButton,
+    ElForm,
+    ElFormItem,
+    ElInput,
+    ElSelect,
+    ElOption,
+    ElCard,
+    ElSwitch,
+    ElTag,
+    FontAwesomeIcon
+  },
+  props: {
+    modelValue: {
+      type: Boolean,
+      default: false
+    }
+  },
+  emits: ['update:modelValue', 'change'],
+  data() {
+    return {
+      servers: [] as IMcpServer[],
+      loading: false,
+      submitting: false,
+      testing: false,
+      showAddForm: false,
+      editingServer: null as IMcpServer | null,
+      testResult: null as IMcpServerTestResponse | null,
+      form: {
+        name: '',
+        url: '',
+        description: '',
+        auth_type: 'none',
+        auth_token: ''
+      } as IForm
+    };
+  },
+  computed: {
+    visible: {
+      get(): boolean {
+        return this.modelValue;
+      },
+      set(val: boolean) {
+        this.$emit('update:modelValue', val);
+      }
+    },
+    token(): string {
+      return this.$store.state.chat?.credential?.token || '';
+    }
+  },
+  watch: {
+    modelValue(val) {
+      if (val) {
+        this.onLoad();
+      }
+    }
+  },
+  methods: {
+    async onLoad() {
+      this.loading = true;
+      try {
+        const { data } = await mcpServerOperator.list(this.token);
+        this.servers = data.items || [];
+      } catch {
+        ElMessage.error('Failed to load MCP servers');
+      } finally {
+        this.loading = false;
+      }
+    },
+    resetForm() {
+      this.form = { name: '', url: '', description: '', auth_type: 'none', auth_token: '' };
+      this.testResult = null;
+      this.showAddForm = false;
+      this.editingServer = null;
+    },
+    onCancelForm() {
+      this.resetForm();
+    },
+    onEdit(server: IMcpServer) {
+      this.editingServer = server;
+      this.showAddForm = false;
+      this.testResult = null;
+      this.form = {
+        name: server.name,
+        url: server.url,
+        description: server.description || '',
+        auth_type: server.auth_type || 'none',
+        auth_token: server.auth_token || ''
+      };
+    },
+    async onSave() {
+      if (!this.form.name || !this.form.url) {
+        ElMessage.warning(this.$t('chat.mcp.nameUrlRequired') as string);
+        return;
+      }
+      this.submitting = true;
+      try {
+        if (this.editingServer) {
+          await mcpServerOperator.update({ id: this.editingServer.id, ...this.form }, this.token);
+          ElMessage.success(this.$t('chat.mcp.updated') as string);
+        } else {
+          await mcpServerOperator.create(this.form, this.token);
+          ElMessage.success(this.$t('chat.mcp.created') as string);
+        }
+        this.resetForm();
+        await this.onLoad();
+        this.$emit('change');
+      } catch {
+        ElMessage.error(this.$t('chat.mcp.saveFailed') as string);
+      } finally {
+        this.submitting = false;
+      }
+    },
+    async onDelete(server: IMcpServer) {
+      try {
+        await ElMessageBox.confirm(
+          this.$t('chat.mcp.deleteConfirm', { name: server.name }) as string,
+          this.$t('common.button.delete') as string,
+          { type: 'warning', confirmButtonClass: 'el-button--danger' }
+        );
+        await mcpServerOperator.delete(server.id, this.token);
+        ElMessage.success(this.$t('chat.mcp.deleted') as string);
+        await this.onLoad();
+        this.$emit('change');
+      } catch {
+        // cancelled
+      }
+    },
+    async onToggle(server: IMcpServer, enabled: boolean) {
+      try {
+        await mcpServerOperator.update({ id: server.id, is_enabled: enabled }, this.token);
+        server.is_enabled = enabled;
+        this.$emit('change');
+      } catch {
+        ElMessage.error('Failed to update server');
+      }
+    },
+    async onTest() {
+      if (!this.form.url) {
+        ElMessage.warning(this.$t('chat.mcp.urlRequired') as string);
+        return;
+      }
+      this.testing = true;
+      this.testResult = null;
+      try {
+        const { data } = await mcpServerOperator.test(
+          { url: this.form.url, auth_type: this.form.auth_type, auth_token: this.form.auth_token },
+          this.token
+        );
+        this.testResult = data;
+      } catch (err: any) {
+        this.testResult = {
+          success: false,
+          error: err?.response?.data?.error || 'Connection failed'
+        };
+      } finally {
+        this.testing = false;
+      }
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.mcp-manager {
+  .header {
+    margin-bottom: 12px;
+  }
+
+  .form-card {
+    margin-bottom: 16px;
+
+    .form-actions {
+      display: flex;
+      justify-content: flex-end;
+      gap: 8px;
+    }
+  }
+
+  .test-result {
+    margin-top: 12px;
+    padding: 8px 12px;
+    background: var(--el-fill-color-light);
+    border-radius: 6px;
+    font-size: 13px;
+
+    .test-info {
+      margin-left: 8px;
+      color: var(--el-text-color-secondary);
+    }
+
+    .test-error {
+      margin-left: 8px;
+      color: var(--el-color-danger);
+    }
+
+    .test-tools {
+      margin-top: 8px;
+
+      .test-tool {
+        padding: 4px 0;
+        display: flex;
+        gap: 8px;
+        align-items: baseline;
+
+        .tool-name {
+          font-family: monospace;
+          font-weight: 500;
+          color: var(--el-text-color-primary);
+        }
+
+        .tool-desc {
+          font-size: 12px;
+          color: var(--el-text-color-secondary);
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+      }
+    }
+  }
+
+  .server-list {
+    min-height: 60px;
+
+    .empty {
+      text-align: center;
+      color: var(--el-text-color-secondary);
+      padding: 20px 0;
+      font-size: 14px;
+    }
+  }
+
+  .server-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px;
+    border: 1px solid var(--el-border-color-lighter);
+    border-radius: 8px;
+    margin-bottom: 8px;
+
+    &:hover {
+      border-color: var(--el-border-color);
+    }
+
+    .server-info {
+      flex: 1;
+      min-width: 0;
+
+      .server-header {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-bottom: 4px;
+
+        .server-name {
+          font-weight: 500;
+          font-size: 14px;
+        }
+      }
+
+      .server-url {
+        font-size: 12px;
+        color: var(--el-text-color-secondary);
+        font-family: monospace;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .server-desc {
+        font-size: 12px;
+        color: var(--el-text-color-secondary);
+        margin-top: 2px;
+      }
+    }
+
+    .server-actions {
+      display: flex;
+      gap: 2px;
+      flex-shrink: 0;
+    }
+  }
+}
+
+.mr-1 {
+  margin-right: 4px;
+}
+</style>

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -446,5 +446,109 @@
   "group.earlier": {
     "message": "Earlier",
     "description": "Group name on the webpage, i.e., Earlier"
+  },
+  "mcp.title": {
+    "message": "MCP Servers",
+    "description": "MCP server management dialog title"
+  },
+  "mcp.addServer": {
+    "message": "Add Server",
+    "description": "Add MCP server button"
+  },
+  "mcp.name": {
+    "message": "Name",
+    "description": "MCP server name"
+  },
+  "mcp.namePlaceholder": {
+    "message": "Name your server",
+    "description": "MCP server name placeholder"
+  },
+  "mcp.url": {
+    "message": "URL",
+    "description": "MCP server URL"
+  },
+  "mcp.urlPlaceholder": {
+    "message": "https://example.com/mcp",
+    "description": "MCP server URL placeholder"
+  },
+  "mcp.description": {
+    "message": "Description",
+    "description": "MCP server description"
+  },
+  "mcp.descriptionPlaceholder": {
+    "message": "Describe what this server does",
+    "description": "MCP server description placeholder"
+  },
+  "mcp.authType": {
+    "message": "Authentication",
+    "description": "MCP server authentication type"
+  },
+  "mcp.authNone": {
+    "message": "None",
+    "description": "No authentication"
+  },
+  "mcp.authBearer": {
+    "message": "Bearer Token",
+    "description": "Bearer Token authentication"
+  },
+  "mcp.authToken": {
+    "message": "Token",
+    "description": "Authentication token"
+  },
+  "mcp.authTokenPlaceholder": {
+    "message": "Enter authentication token",
+    "description": "Authentication token placeholder"
+  },
+  "mcp.test": {
+    "message": "Test Connection",
+    "description": "Test MCP server connection"
+  },
+  "mcp.testSuccess": {
+    "message": "Connected",
+    "description": "Connection test succeeded"
+  },
+  "mcp.testFailed": {
+    "message": "Failed",
+    "description": "Connection test failed"
+  },
+  "mcp.toolsFound": {
+    "message": "{count} tool(s) found",
+    "description": "Number of tools found"
+  },
+  "mcp.empty": {
+    "message": "No MCP servers yet. Add one to extend AI capabilities.",
+    "description": "MCP server list empty"
+  },
+  "mcp.nameUrlRequired": {
+    "message": "Name and URL are required",
+    "description": "Name and URL required validation"
+  },
+  "mcp.urlRequired": {
+    "message": "URL is required",
+    "description": "URL required validation"
+  },
+  "mcp.created": {
+    "message": "Server added",
+    "description": "MCP server created"
+  },
+  "mcp.updated": {
+    "message": "Server updated",
+    "description": "MCP server updated"
+  },
+  "mcp.deleted": {
+    "message": "Server deleted",
+    "description": "MCP server deleted"
+  },
+  "mcp.saveFailed": {
+    "message": "Failed to save",
+    "description": "MCP server save failed"
+  },
+  "mcp.deleteConfirm": {
+    "message": "Delete server \"{name}\"?",
+    "description": "Delete confirmation"
+  },
+  "mcp.tooltip": {
+    "message": "MCP Servers",
+    "description": "MCP button tooltip"
   }
 }

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -446,5 +446,109 @@
   "group.earlier": {
     "message": "更早",
     "description": "网页中的分组名称，即 更早"
+  },
+  "mcp.title": {
+    "message": "MCP 服务器",
+    "description": "MCP 服务器管理对话框标题"
+  },
+  "mcp.addServer": {
+    "message": "添加服务器",
+    "description": "添加 MCP 服务器按钮"
+  },
+  "mcp.name": {
+    "message": "名称",
+    "description": "MCP 服务器名称"
+  },
+  "mcp.namePlaceholder": {
+    "message": "为服务器命名",
+    "description": "MCP 服务器名称占位符"
+  },
+  "mcp.url": {
+    "message": "URL",
+    "description": "MCP 服务器 URL"
+  },
+  "mcp.urlPlaceholder": {
+    "message": "https://example.com/mcp",
+    "description": "MCP 服务器 URL 占位符"
+  },
+  "mcp.description": {
+    "message": "描述",
+    "description": "MCP 服务器描述"
+  },
+  "mcp.descriptionPlaceholder": {
+    "message": "描述此服务器的用途",
+    "description": "MCP 服务器描述占位符"
+  },
+  "mcp.authType": {
+    "message": "认证方式",
+    "description": "MCP 服务器认证方式"
+  },
+  "mcp.authNone": {
+    "message": "无",
+    "description": "无认证"
+  },
+  "mcp.authBearer": {
+    "message": "Bearer Token",
+    "description": "Bearer Token 认证"
+  },
+  "mcp.authToken": {
+    "message": "Token",
+    "description": "认证 Token"
+  },
+  "mcp.authTokenPlaceholder": {
+    "message": "输入认证 Token",
+    "description": "认证 Token 占位符"
+  },
+  "mcp.test": {
+    "message": "测试连接",
+    "description": "测试 MCP 服务器连接"
+  },
+  "mcp.testSuccess": {
+    "message": "连接成功",
+    "description": "连接测试成功"
+  },
+  "mcp.testFailed": {
+    "message": "连接失败",
+    "description": "连接测试失败"
+  },
+  "mcp.toolsFound": {
+    "message": "发现 {count} 个工具",
+    "description": "发现的工具数量"
+  },
+  "mcp.empty": {
+    "message": "暂无 MCP 服务器，添加一个以扩展 AI 的能力",
+    "description": "MCP 服务器列表为空"
+  },
+  "mcp.nameUrlRequired": {
+    "message": "请填写名称和 URL",
+    "description": "名称和 URL 必填"
+  },
+  "mcp.urlRequired": {
+    "message": "请填写 URL",
+    "description": "URL 必填"
+  },
+  "mcp.created": {
+    "message": "添加成功",
+    "description": "MCP 服务器添加成功"
+  },
+  "mcp.updated": {
+    "message": "更新成功",
+    "description": "MCP 服务器更新成功"
+  },
+  "mcp.deleted": {
+    "message": "删除成功",
+    "description": "MCP 服务器删除成功"
+  },
+  "mcp.saveFailed": {
+    "message": "保存失败",
+    "description": "MCP 服务器保存失败"
+  },
+  "mcp.deleteConfirm": {
+    "message": "确认删除服务器 \"{name}\"？",
+    "description": "删除确认"
+  },
+  "mcp.tooltip": {
+    "message": "MCP 服务器",
+    "description": "MCP 按钮提示"
   }
 }

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -147,6 +147,7 @@ export interface IChatConversationRequest {
   model: IChatModelName;
   tools_enabled?: boolean;
   tools_filter?: string[];
+  mcp_servers?: string[];
 }
 
 export interface IChatConversationResponse {

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -28,6 +28,7 @@ export * from './seedance';
 export * from './serp';
 export * from './wan';
 export * from './site';
+export * from './mcp';
 export * from './exchange';
 export * from './error';
 export * from './config';

--- a/src/models/mcp.ts
+++ b/src/models/mcp.ts
@@ -1,0 +1,29 @@
+export interface IMcpServer {
+  id: string;
+  user_id?: string;
+  name: string;
+  description?: string;
+  transport?: string;
+  url: string;
+  auth_type?: string;
+  auth_token?: string;
+  tools_cache?: IMcpTool[];
+  is_enabled: boolean;
+  created_at?: string;
+}
+
+export interface IMcpTool {
+  name: string;
+  description?: string;
+}
+
+export interface IMcpServerListResponse {
+  items: IMcpServer[];
+}
+
+export interface IMcpServerTestResponse {
+  success: boolean;
+  tools_count?: number;
+  tools?: IMcpTool[];
+  error?: string;
+}

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -28,5 +28,6 @@ export * from './nanobanana';
 export * from './seedream';
 export * from './seedance';
 export * from './serp';
+export * from './mcp';
 export * from './wan';
 export * from './config';

--- a/src/operators/mcp.ts
+++ b/src/operators/mcp.ts
@@ -1,0 +1,71 @@
+import axios, { AxiosResponse } from 'axios';
+import { IMcpServer, IMcpServerListResponse, IMcpServerTestResponse } from '@/models';
+import { BASE_URL_API } from '@/constants';
+
+class McpServerOperator {
+  private getHeaders(token: string) {
+    return {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`
+    };
+  }
+
+  async list(token: string): Promise<AxiosResponse<IMcpServerListResponse>> {
+    return await axios.post(
+      '/aichat2/mcp-servers',
+      { action: 'list' },
+      { headers: this.getHeaders(token), baseURL: BASE_URL_API }
+    );
+  }
+
+  async create(
+    data: { name: string; url: string; description?: string; auth_type?: string; auth_token?: string },
+    token: string
+  ): Promise<AxiosResponse<IMcpServer>> {
+    return await axios.post(
+      '/aichat2/mcp-servers',
+      { action: 'create', ...data },
+      { headers: this.getHeaders(token), baseURL: BASE_URL_API }
+    );
+  }
+
+  async update(
+    data: {
+      id: string;
+      name?: string;
+      url?: string;
+      description?: string;
+      auth_type?: string;
+      auth_token?: string;
+      is_enabled?: boolean;
+    },
+    token: string
+  ): Promise<AxiosResponse<{ id: string; success: boolean }>> {
+    return await axios.post(
+      '/aichat2/mcp-servers',
+      { action: 'update', ...data },
+      { headers: this.getHeaders(token), baseURL: BASE_URL_API }
+    );
+  }
+
+  async delete(id: string, token: string): Promise<AxiosResponse<{ id: string; success: boolean }>> {
+    return await axios.post(
+      '/aichat2/mcp-servers',
+      { action: 'delete', id },
+      { headers: this.getHeaders(token), baseURL: BASE_URL_API }
+    );
+  }
+
+  async test(
+    data: { url: string; auth_type?: string; auth_token?: string },
+    token: string
+  ): Promise<AxiosResponse<IMcpServerTestResponse>> {
+    return await axios.post(
+      '/aichat2/mcp-servers',
+      { action: 'test', ...data },
+      { headers: this.getHeaders(token), baseURL: BASE_URL_API }
+    );
+  }
+}
+
+export const mcpServerOperator = new McpServerOperator();

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -2,6 +2,13 @@
   <layout @change-conversation="onChangeConversation($event)">
     <template #chat>
       <model-selector class="selector" @model-group-changed="onChangeConversation(undefined)" />
+      <el-tooltip :content="$t('chat.mcp.tooltip')" placement="bottom">
+        <el-button class="btn-mcp" text @click="mcpManagerVisible = true">
+          <font-awesome-icon icon="fa-solid fa-cubes-stacked" />
+          <el-badge v-if="enabledMcpCount > 0" :value="enabledMcpCount" :max="9" class="mcp-badge" />
+        </el-button>
+      </el-tooltip>
+      <mcp-manager v-model="mcpManagerVisible" @change="onMcpChange" />
       <div :class="{ dialogue: true, empty: messages.length === 0 }">
         <div v-if="messages.length > 0" class="messages">
           <message
@@ -41,13 +48,16 @@ import { CHAT_MODEL_GROUPS, CHAT_MODELS, ROLE_ASSISTANT, ROLE_USER } from '@/con
 import { IChatMessageState, IChatConversationResponse, IChatConversation, IChatMessage, BaseError } from '@/models';
 import Composer from '@/components/chat/Composer.vue';
 import ModelSelector from '@/components/chat/ModelSelector.vue';
+import McpManager from '@/components/chat/McpManager.vue';
 import { ERROR_CODE_CANCELED, ERROR_CODE_NOT_APPLIED, ERROR_CODE_UNKNOWN } from '@/constants/errorCode';
 import { Status } from '@/models';
 import Disclaimer from '@/components/chat/Disclaimer.vue';
 import Layout from '@/layouts/Chat.vue';
 import { isImageUrl } from '@/utils/is';
-import { IChatMessageContentItem } from '@/models';
-import { chatOperator } from '@/operators';
+import { IChatMessageContentItem, IMcpServer } from '@/models';
+import { chatOperator, mcpServerOperator } from '@/operators';
+import { ElTooltip, ElButton, ElBadge } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 
 export interface IData {
   drawer: boolean;
@@ -57,6 +67,8 @@ export interface IData {
   answering: boolean;
   messages: IChatMessage[];
   canceler: AbortController | undefined;
+  mcpManagerVisible: boolean;
+  mcpServers: IMcpServer[];
 }
 
 export default defineComponent({
@@ -65,8 +77,13 @@ export default defineComponent({
     Composer,
     Disclaimer,
     ModelSelector,
+    McpManager,
     Message,
-    Layout
+    Layout,
+    ElTooltip,
+    ElButton,
+    ElBadge,
+    FontAwesomeIcon
   },
   data(): IData {
     return {
@@ -76,6 +93,8 @@ export default defineComponent({
       upload: false,
       answering: false,
       canceler: undefined,
+      mcpManagerVisible: false,
+      mcpServers: [] as IMcpServer[],
       messages:
         this.$store.state.chat.conversations?.find(
           (conversation: IChatConversation) => conversation.id === this.$route.params.id?.toString()
@@ -117,6 +136,12 @@ export default defineComponent({
     },
     initializing() {
       return this.$store.state.chat.status.getApplications === Status.Request;
+    },
+    enabledMcpCount(): number {
+      return this.mcpServers.filter((s: IMcpServer) => s.is_enabled).length;
+    },
+    enabledMcpIds(): string[] {
+      return this.mcpServers.filter((s: IMcpServer) => s.is_enabled).map((s: IMcpServer) => s.id);
     }
   },
   watch: {
@@ -134,8 +159,22 @@ export default defineComponent({
     await this.onGetService();
     await this.onGetApplication();
     await this.onGetConversations();
+    await this.onLoadMcpServers();
   },
   methods: {
+    async onLoadMcpServers() {
+      const token = this.credential?.token;
+      if (!token) return;
+      try {
+        const { data } = await mcpServerOperator.list(token);
+        this.mcpServers = data.items || [];
+      } catch {
+        // silently fail - MCP is optional
+      }
+    },
+    async onMcpChange() {
+      await this.onLoadMcpServers();
+    },
     async onGetService() {
       console.debug('start onGetService');
       await this.$store.dispatch('chat/getService');
@@ -411,7 +450,8 @@ export default defineComponent({
             references,
             id: this.conversationId,
             stateful: true,
-            tools_enabled: true
+            tools_enabled: true,
+            mcp_servers: this.enabledMcpIds.length > 0 ? this.enabledMcpIds : undefined
           },
           {
             token,
@@ -553,6 +593,31 @@ export default defineComponent({
   top: 10px;
   right: 10px;
   margin-bottom: 10px;
+}
+.btn-mcp {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 100;
+  font-size: 16px;
+  color: var(--el-text-color-secondary);
+
+  &:hover {
+    color: var(--el-color-primary);
+  }
+
+  .mcp-badge {
+    position: absolute;
+    top: -4px;
+    right: -8px;
+
+    :deep(.el-badge__content) {
+      font-size: 10px;
+      height: 16px;
+      line-height: 16px;
+      padding: 0 4px;
+    }
+  }
 }
 @media (max-width: 767px) {
   .setting {


### PR DESCRIPTION
Add MCP (Model Context Protocol) server management to the chat interface.

**New files:**
- `src/models/mcp.ts` — IMcpServer, IMcpTool, IMcpServerTestResponse interfaces
- `src/operators/mcp.ts` — McpServerOperator (CRUD + test via `/aichat2/mcp-servers`)
- `src/components/chat/McpManager.vue` — Dialog for managing MCP servers

**Changes:**
- Chat header: MCP button with badge showing enabled server count
- Chat request: passes `mcp_servers` (enabled server IDs) to aichat2
- `IChatConversationRequest`: added `mcp_servers?: string[]`
- i18n: added MCP keys for zh-CN and en

**UX:**
- Click the cube-stacked icon in the chat header to open MCP Manager
- Add/edit/delete/test remote MCP servers
- Toggle servers on/off — enabled servers auto-inject tools into chat
- Test shows tool count and descriptions

Phase 3 of AI Orchestrator (MCP Connectors).