### PR TITLE
fix: nanobanana prompt full display

### DIFF
--- a/src/components/nanobanana/task/Preview.vue
+++ b/src/components/nanobanana/task/Preview.vue
@@ -271,9 +271,9 @@ $left-width: 70px;
         font-weight: bold;
         color: var(--el-text-color-regular);
         margin-bottom: 15px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+        white-space: normal;
+        word-break: break-word;
+        overflow-wrap: anywhere;
       }
     }
 


### PR DESCRIPTION
## Summary\n- remove prompt single-line ellipsis in nanobanana task preview\n- allow prompt text to wrap and display fully\n\n## Testing\n- verified no Vue file errors via editor diagnostics\n