### PR TITLE
feat: add OAuth Connector management UI (Phase 4)

### DIFF
--- a/src/components/chat/ConnectorManager.vue
+++ b/src/components/chat/ConnectorManager.vue
@@ -95,7 +95,7 @@ export default defineComponent({
         this.$emit('update:modelValue', val);
       }
     },
-    token(): string {
+    token(): string | undefined {
       return this.$store.state.token?.access;
     }
   },

--- a/src/components/chat/ConnectorManager.vue
+++ b/src/components/chat/ConnectorManager.vue
@@ -1,0 +1,279 @@
+<template>
+  <el-dialog
+    v-model="visible"
+    :title="$t('chat.connector.title')"
+    width="560px"
+    :close-on-click-modal="false"
+    @close="$emit('update:modelValue', false)"
+  >
+    <div v-loading="loading" class="connector-manager">
+      <!-- Provider List -->
+      <div v-if="providers.length === 0 && !loading" class="empty">
+        {{ $t('chat.connector.noProviders') }}
+      </div>
+      <div v-for="provider in providers" :key="provider.id" class="provider-item">
+        <div class="provider-icon">
+          <font-awesome-icon :icon="getProviderIcon(provider.id)" class="icon" />
+        </div>
+        <div class="provider-info">
+          <div class="provider-name">{{ provider.name }}</div>
+          <div class="provider-desc">{{ provider.description }}</div>
+          <div v-if="getConnector(provider.id)" class="provider-profile">
+            <img
+              v-if="getConnector(provider.id)?.profile?.avatar"
+              :src="getConnector(provider.id)?.profile?.avatar"
+              class="avatar"
+            />
+            <span class="profile-name">{{ getConnector(provider.id)?.profile?.name }}</span>
+            <span v-if="getConnector(provider.id)?.profile?.email" class="profile-email">
+              ({{ getConnector(provider.id)?.profile?.email }})
+            </span>
+          </div>
+        </div>
+        <div class="provider-actions">
+          <template v-if="provider.connected">
+            <el-switch
+              :model-value="getConnector(provider.id)?.is_enabled"
+              size="small"
+              @change="onToggle(provider.id, $event as boolean)"
+            />
+            <el-button size="small" type="danger" text @click="onDisconnect(provider.id)">
+              {{ $t('chat.connector.disconnect') }}
+            </el-button>
+          </template>
+          <el-button
+            v-else
+            size="small"
+            type="primary"
+            :loading="connecting === provider.id"
+            @click="onConnect(provider.id)"
+          >
+            <font-awesome-icon icon="fa-solid fa-plug" class="mr-1" />
+            {{ $t('chat.connector.connect') }}
+          </el-button>
+        </div>
+      </div>
+    </div>
+  </el-dialog>
+</template>
+
+<script lang="ts">
+import { defineComponent, PropType } from 'vue';
+import { ElMessage } from 'element-plus';
+import { connectorOperator } from '@/operators';
+import { IConnectorProvider, IConnector } from '@/models';
+
+const PROVIDER_ICONS: Record<string, string> = {
+  google: 'fa-brands fa-google',
+  github: 'fa-brands fa-github',
+  slack: 'fa-brands fa-slack'
+};
+
+export default defineComponent({
+  name: 'ConnectorManager',
+  props: {
+    modelValue: {
+      type: Boolean as PropType<boolean>,
+      default: false
+    }
+  },
+  emits: ['update:modelValue', 'change'],
+  data() {
+    return {
+      providers: [] as IConnectorProvider[],
+      connectors: [] as IConnector[],
+      loading: false,
+      connecting: '' as string
+    };
+  },
+  computed: {
+    visible: {
+      get() {
+        return this.modelValue;
+      },
+      set(val: boolean) {
+        this.$emit('update:modelValue', val);
+      }
+    },
+    token(): string {
+      return this.$store.state.token?.access;
+    }
+  },
+  watch: {
+    modelValue(val: boolean) {
+      if (val) {
+        this.loadData();
+      }
+    }
+  },
+  methods: {
+    getProviderIcon(id: string): string {
+      return PROVIDER_ICONS[id] || 'fa-solid fa-plug';
+    },
+    getConnector(providerId: string): IConnector | undefined {
+      return this.connectors.find((c) => c.provider === providerId);
+    },
+    async loadData() {
+      if (!this.token) return;
+      this.loading = true;
+      try {
+        const [providersRes, connectorsRes] = await Promise.all([
+          connectorOperator.listProviders(this.token),
+          connectorOperator.list(this.token)
+        ]);
+        this.providers = providersRes.data.providers || [];
+        this.connectors = connectorsRes.data.items || [];
+      } catch {
+        ElMessage.error(this.$t('chat.connector.loadError'));
+      } finally {
+        this.loading = false;
+      }
+    },
+    async onConnect(providerId: string) {
+      if (!this.token) return;
+      this.connecting = providerId;
+      try {
+        const { data } = await connectorOperator.authorize(providerId, this.token);
+        // Open OAuth popup
+        const popup = window.open(data.authorization_url, 'oauth-popup', 'width=600,height=700,scrollbars=yes');
+        // Listen for callback message from popup
+        const handler = async (event: MessageEvent) => {
+          if (event.data?.type !== 'oauth-callback') return;
+          window.removeEventListener('message', handler);
+          const { code, state } = event.data;
+          if (!code || !state) {
+            ElMessage.error(this.$t('chat.connector.authFailed'));
+            return;
+          }
+          try {
+            await connectorOperator.exchange(code, state, this.token);
+            ElMessage.success(this.$t('chat.connector.connected'));
+            await this.loadData();
+            this.$emit('change');
+          } catch {
+            ElMessage.error(this.$t('chat.connector.authFailed'));
+          }
+        };
+        window.addEventListener('message', handler);
+        // Also poll for popup close
+        const pollTimer = setInterval(() => {
+          if (popup?.closed) {
+            clearInterval(pollTimer);
+            this.connecting = '';
+          }
+        }, 500);
+      } catch {
+        ElMessage.error(this.$t('chat.connector.authFailed'));
+      } finally {
+        this.connecting = '';
+      }
+    },
+    async onDisconnect(providerId: string) {
+      if (!this.token) return;
+      try {
+        await connectorOperator.disconnect(providerId, this.token);
+        ElMessage.success(this.$t('chat.connector.disconnected'));
+        await this.loadData();
+        this.$emit('change');
+      } catch {
+        ElMessage.error(this.$t('chat.connector.disconnectError'));
+      }
+    },
+    async onToggle(providerId: string, enabled: boolean) {
+      if (!this.token) return;
+      try {
+        await connectorOperator.toggle(providerId, enabled, this.token);
+        const connector = this.getConnector(providerId);
+        if (connector) connector.is_enabled = enabled;
+        this.$emit('change');
+      } catch {
+        ElMessage.error(this.$t('chat.connector.toggleError'));
+      }
+    }
+  }
+});
+</script>
+
+<style scoped lang="scss">
+.connector-manager {
+  min-height: 120px;
+}
+
+.empty {
+  text-align: center;
+  color: var(--el-text-color-secondary);
+  padding: 40px 0;
+}
+
+.provider-item {
+  display: flex;
+  align-items: center;
+  padding: 16px;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 8px;
+  margin-bottom: 12px;
+  gap: 14px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.provider-icon {
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  background: var(--el-fill-color);
+  flex-shrink: 0;
+
+  .icon {
+    font-size: 20px;
+    color: var(--el-text-color-primary);
+  }
+}
+
+.provider-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.provider-name {
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.provider-desc {
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+  margin-top: 2px;
+}
+
+.provider-profile {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 6px;
+  font-size: 12px;
+  color: var(--el-text-color-regular);
+
+  .avatar {
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+  }
+
+  .profile-email {
+    color: var(--el-text-color-secondary);
+  }
+}
+
+.provider-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+</style>

--- a/src/components/chat/ConnectorManager.vue
+++ b/src/components/chat/ConnectorManager.vue
@@ -130,10 +130,11 @@ export default defineComponent({
       }
     },
     async onConnect(providerId: string) {
-      if (!this.token) return;
+      const token = this.token;
+      if (!token) return;
       this.connecting = providerId;
       try {
-        const { data } = await connectorOperator.authorize(providerId, this.token);
+        const { data } = await connectorOperator.authorize(providerId, token);
         // Open OAuth popup
         const popup = window.open(data.authorization_url, 'oauth-popup', 'width=600,height=700,scrollbars=yes');
         // Listen for callback message from popup
@@ -146,7 +147,7 @@ export default defineComponent({
             return;
           }
           try {
-            await connectorOperator.exchange(code, state, this.token);
+            await connectorOperator.exchange(code, state, token);
             ElMessage.success(this.$t('chat.connector.connected'));
             await this.loadData();
             this.$emit('change');

--- a/src/components/nanobanana/task/Preview.vue
+++ b/src/components/nanobanana/task/Preview.vue
@@ -271,9 +271,9 @@ $left-width: 70px;
         font-weight: bold;
         color: var(--el-text-color-regular);
         margin-bottom: 15px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+        white-space: normal;
+        word-break: break-word;
+        overflow-wrap: anywhere;
       }
     }
 

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -550,5 +550,61 @@
   "mcp.tooltip": {
     "message": "MCP Servers",
     "description": "MCP button tooltip"
+  },
+  "connector.title": {
+    "message": "Connectors",
+    "description": "Connector manager dialog title"
+  },
+  "connector.tooltip": {
+    "message": "OAuth Connectors",
+    "description": "Connector button tooltip"
+  },
+  "connector.noProviders": {
+    "message": "No connectors available. Configure OAuth providers on the server.",
+    "description": "No providers configured message"
+  },
+  "connector.connect": {
+    "message": "Connect",
+    "description": "Connect button label"
+  },
+  "connector.disconnect": {
+    "message": "Disconnect",
+    "description": "Disconnect button label"
+  },
+  "connector.connected": {
+    "message": "Connector connected successfully",
+    "description": "Success message after connecting"
+  },
+  "connector.disconnected": {
+    "message": "Connector disconnected",
+    "description": "Success message after disconnecting"
+  },
+  "connector.authFailed": {
+    "message": "Authorization failed. Please try again.",
+    "description": "Auth failure message"
+  },
+  "connector.loadError": {
+    "message": "Failed to load connectors",
+    "description": "Load error message"
+  },
+  "connector.disconnectError": {
+    "message": "Failed to disconnect connector",
+    "description": "Disconnect error message"
+  },
+  "connector.toggleError": {
+    "message": "Failed to update connector",
+    "description": "Toggle error message"
+  },
+  "connector.processing": {
+    "message": "Processing authorization...",
+    "description": "OAuth callback processing message"
+  },
+  "connector.authSuccess": {
+    "message": "Authorization successful!",
+    "description": "OAuth callback success message"
+  },
+  "connector.closeWindow": {
+    "message": "This window will close automatically.",
+    "description": "OAuth callback close hint"
   }
 }

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -550,5 +550,61 @@
   "mcp.tooltip": {
     "message": "MCP 服务器",
     "description": "MCP 按钮提示"
+  },
+  "connector.title": {
+    "message": "连接器",
+    "description": "连接器管理对话框标题"
+  },
+  "connector.tooltip": {
+    "message": "OAuth 连接器",
+    "description": "连接器按钮提示"
+  },
+  "connector.noProviders": {
+    "message": "暂无可用连接器，请在服务端配置 OAuth 提供商。",
+    "description": "无提供商消息"
+  },
+  "connector.connect": {
+    "message": "连接",
+    "description": "连接按钮"
+  },
+  "connector.disconnect": {
+    "message": "断开",
+    "description": "断开按钮"
+  },
+  "connector.connected": {
+    "message": "连接器连接成功",
+    "description": "连接成功消息"
+  },
+  "connector.disconnected": {
+    "message": "连接器已断开",
+    "description": "断开成功消息"
+  },
+  "connector.authFailed": {
+    "message": "授权失败，请重试。",
+    "description": "授权失败消息"
+  },
+  "connector.loadError": {
+    "message": "加载连接器失败",
+    "description": "加载错误消息"
+  },
+  "connector.disconnectError": {
+    "message": "断开连接器失败",
+    "description": "断开错误消息"
+  },
+  "connector.toggleError": {
+    "message": "更新连接器失败",
+    "description": "切换错误消息"
+  },
+  "connector.processing": {
+    "message": "正在处理授权...",
+    "description": "OAuth 回调处理消息"
+  },
+  "connector.authSuccess": {
+    "message": "授权成功！",
+    "description": "OAuth 回调成功消息"
+  },
+  "connector.closeWindow": {
+    "message": "此窗口将自动关闭。",
+    "description": "OAuth 回调关闭提示"
   }
 }

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -148,6 +148,7 @@ export interface IChatConversationRequest {
   tools_enabled?: boolean;
   tools_filter?: string[];
   mcp_servers?: string[];
+  connectors?: string[];
 }
 
 export interface IChatConversationResponse {

--- a/src/models/connector.ts
+++ b/src/models/connector.ts
@@ -1,0 +1,46 @@
+export interface IConnectorProvider {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  scopes: string[];
+  connected: boolean;
+}
+
+export interface IConnector {
+  id: string;
+  provider: string;
+  profile: {
+    name: string;
+    email: string;
+    avatar?: string;
+  };
+  scopes: string[];
+  is_enabled: boolean;
+  expires_at: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface IConnectorProvidersResponse {
+  providers: IConnectorProvider[];
+}
+
+export interface IConnectorListResponse {
+  items: IConnector[];
+}
+
+export interface IConnectorAuthorizeResponse {
+  authorization_url: string;
+  provider: string;
+}
+
+export interface IConnectorExchangeResponse {
+  success: boolean;
+  provider: string;
+  profile: {
+    name: string;
+    email: string;
+    avatar?: string;
+  };
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -29,6 +29,7 @@ export * from './serp';
 export * from './wan';
 export * from './site';
 export * from './mcp';
+export * from './connector';
 export * from './exchange';
 export * from './error';
 export * from './config';

--- a/src/operators/connector.ts
+++ b/src/operators/connector.ts
@@ -1,0 +1,67 @@
+import axios, { AxiosResponse } from 'axios';
+import {
+  IConnectorProvidersResponse,
+  IConnectorListResponse,
+  IConnectorAuthorizeResponse,
+  IConnectorExchangeResponse
+} from '@/models';
+import { BASE_URL_API } from '@/constants';
+
+class ConnectorOperator {
+  private getHeaders(token: string) {
+    return {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`
+    };
+  }
+
+  async listProviders(token: string): Promise<AxiosResponse<IConnectorProvidersResponse>> {
+    return await axios.post(
+      '/aichat2/connectors',
+      { action: 'list_providers' },
+      { headers: this.getHeaders(token), baseURL: BASE_URL_API }
+    );
+  }
+
+  async list(token: string): Promise<AxiosResponse<IConnectorListResponse>> {
+    return await axios.post(
+      '/aichat2/connectors',
+      { action: 'list' },
+      { headers: this.getHeaders(token), baseURL: BASE_URL_API }
+    );
+  }
+
+  async authorize(provider: string, token: string): Promise<AxiosResponse<IConnectorAuthorizeResponse>> {
+    return await axios.post(
+      '/aichat2/connectors',
+      { action: 'authorize', provider },
+      { headers: this.getHeaders(token), baseURL: BASE_URL_API }
+    );
+  }
+
+  async exchange(code: string, state: string, token: string): Promise<AxiosResponse<IConnectorExchangeResponse>> {
+    return await axios.post(
+      '/aichat2/connectors',
+      { action: 'exchange', code, state },
+      { headers: this.getHeaders(token), baseURL: BASE_URL_API }
+    );
+  }
+
+  async disconnect(provider: string, token: string): Promise<AxiosResponse<{ success: boolean }>> {
+    return await axios.post(
+      '/aichat2/connectors',
+      { action: 'disconnect', provider },
+      { headers: this.getHeaders(token), baseURL: BASE_URL_API }
+    );
+  }
+
+  async toggle(provider: string, isEnabled: boolean, token: string): Promise<AxiosResponse<{ success: boolean }>> {
+    return await axios.post(
+      '/aichat2/connectors',
+      { action: 'toggle', provider, is_enabled: isEnabled },
+      { headers: this.getHeaders(token), baseURL: BASE_URL_API }
+    );
+  }
+}
+
+export const connectorOperator = new ConnectorOperator();

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -29,5 +29,6 @@ export * from './seedream';
 export * from './seedance';
 export * from './serp';
 export * from './mcp';
+export * from './connector';
 export * from './wan';
 export * from './config';

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -8,7 +8,14 @@
           <el-badge v-if="enabledMcpCount > 0" :value="enabledMcpCount" :max="9" class="mcp-badge" />
         </el-button>
       </el-tooltip>
+      <el-tooltip :content="$t('chat.connector.tooltip')" placement="bottom">
+        <el-button class="btn-connector" text @click="connectorManagerVisible = true">
+          <font-awesome-icon icon="fa-solid fa-plug" />
+          <el-badge v-if="enabledConnectorCount > 0" :value="enabledConnectorCount" :max="9" class="connector-badge" />
+        </el-button>
+      </el-tooltip>
       <mcp-manager v-model="mcpManagerVisible" @change="onMcpChange" />
+      <connector-manager v-model="connectorManagerVisible" @change="onConnectorChange" />
       <div :class="{ dialogue: true, empty: messages.length === 0 }">
         <div v-if="messages.length > 0" class="messages">
           <message
@@ -49,13 +56,14 @@ import { IChatMessageState, IChatConversationResponse, IChatConversation, IChatM
 import Composer from '@/components/chat/Composer.vue';
 import ModelSelector from '@/components/chat/ModelSelector.vue';
 import McpManager from '@/components/chat/McpManager.vue';
+import ConnectorManager from '@/components/chat/ConnectorManager.vue';
 import { ERROR_CODE_CANCELED, ERROR_CODE_NOT_APPLIED, ERROR_CODE_UNKNOWN } from '@/constants/errorCode';
 import { Status } from '@/models';
 import Disclaimer from '@/components/chat/Disclaimer.vue';
 import Layout from '@/layouts/Chat.vue';
 import { isImageUrl } from '@/utils/is';
-import { IChatMessageContentItem, IMcpServer } from '@/models';
-import { chatOperator, mcpServerOperator } from '@/operators';
+import { IChatMessageContentItem, IMcpServer, IConnector } from '@/models';
+import { chatOperator, mcpServerOperator, connectorOperator } from '@/operators';
 import { ElTooltip, ElButton, ElBadge } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 
@@ -69,6 +77,8 @@ export interface IData {
   canceler: AbortController | undefined;
   mcpManagerVisible: boolean;
   mcpServers: IMcpServer[];
+  connectorManagerVisible: boolean;
+  connectors: IConnector[];
 }
 
 export default defineComponent({
@@ -78,6 +88,7 @@ export default defineComponent({
     Disclaimer,
     ModelSelector,
     McpManager,
+    ConnectorManager,
     Message,
     Layout,
     ElTooltip,
@@ -95,6 +106,8 @@ export default defineComponent({
       canceler: undefined,
       mcpManagerVisible: false,
       mcpServers: [] as IMcpServer[],
+      connectorManagerVisible: false,
+      connectors: [] as IConnector[],
       messages:
         this.$store.state.chat.conversations?.find(
           (conversation: IChatConversation) => conversation.id === this.$route.params.id?.toString()
@@ -142,6 +155,12 @@ export default defineComponent({
     },
     enabledMcpIds(): string[] {
       return this.mcpServers.filter((s: IMcpServer) => s.is_enabled).map((s: IMcpServer) => s.id);
+    },
+    enabledConnectorCount(): number {
+      return this.connectors.filter((c: IConnector) => c.is_enabled).length;
+    },
+    enabledConnectorProviders(): string[] {
+      return this.connectors.filter((c: IConnector) => c.is_enabled).map((c: IConnector) => c.provider);
     }
   },
   watch: {
@@ -160,6 +179,7 @@ export default defineComponent({
     await this.onGetApplication();
     await this.onGetConversations();
     await this.onLoadMcpServers();
+    await this.onLoadConnectors();
   },
   methods: {
     async onLoadMcpServers() {
@@ -174,6 +194,19 @@ export default defineComponent({
     },
     async onMcpChange() {
       await this.onLoadMcpServers();
+    },
+    async onLoadConnectors() {
+      const token = this.credential?.token;
+      if (!token) return;
+      try {
+        const { data } = await connectorOperator.list(token);
+        this.connectors = data.items || [];
+      } catch {
+        // silently fail - connectors are optional
+      }
+    },
+    async onConnectorChange() {
+      await this.onLoadConnectors();
     },
     async onGetService() {
       console.debug('start onGetService');
@@ -451,7 +484,8 @@ export default defineComponent({
             id: this.conversationId,
             stateful: true,
             tools_enabled: true,
-            mcp_servers: this.enabledMcpIds.length > 0 ? this.enabledMcpIds : undefined
+            mcp_servers: this.enabledMcpIds.length > 0 ? this.enabledMcpIds : undefined,
+            connectors: this.enabledConnectorProviders.length > 0 ? this.enabledConnectorProviders : undefined
           },
           {
             token,
@@ -597,7 +631,7 @@ export default defineComponent({
 .btn-mcp {
   position: absolute;
   top: 10px;
-  right: 10px;
+  right: 50px;
   z-index: 100;
   font-size: 16px;
   color: var(--el-text-color-secondary);
@@ -607,6 +641,31 @@ export default defineComponent({
   }
 
   .mcp-badge {
+    position: absolute;
+    top: -4px;
+    right: -8px;
+
+    :deep(.el-badge__content) {
+      font-size: 10px;
+      height: 16px;
+      line-height: 16px;
+      padding: 0 4px;
+    }
+  }
+}
+.btn-connector {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 100;
+  font-size: 16px;
+  color: var(--el-text-color-secondary);
+
+  &:hover {
+    color: var(--el-color-primary);
+  }
+
+  .connector-badge {
     position: absolute;
     top: -4px;
     right: -8px;

--- a/src/pages/chat/OAuthCallback.vue
+++ b/src/pages/chat/OAuthCallback.vue
@@ -1,0 +1,106 @@
+<template>
+  <div class="oauth-callback">
+    <div v-if="status === 'processing'" class="status">
+      <el-icon class="is-loading" :size="32"><loading /></el-icon>
+      <p>{{ $t('chat.connector.processing') }}</p>
+    </div>
+    <div v-else-if="status === 'success'" class="status success">
+      <font-awesome-icon icon="fa-solid fa-check-circle" class="icon" />
+      <p>{{ $t('chat.connector.authSuccess') }}</p>
+      <p class="hint">{{ $t('chat.connector.closeWindow') }}</p>
+    </div>
+    <div v-else class="status error">
+      <font-awesome-icon icon="fa-solid fa-circle-exclamation" class="icon" />
+      <p>{{ errorMessage || $t('chat.connector.authFailed') }}</p>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { Loading } from '@element-plus/icons-vue';
+
+export default defineComponent({
+  name: 'OAuthCallback',
+  components: { Loading },
+  data() {
+    return {
+      status: 'processing' as 'processing' | 'success' | 'error',
+      errorMessage: ''
+    };
+  },
+  mounted() {
+    this.handleCallback();
+  },
+  methods: {
+    handleCallback() {
+      const params = new URLSearchParams(window.location.search);
+      const code = params.get('code');
+      const state = params.get('state');
+      const error = params.get('error');
+
+      if (error) {
+        this.status = 'error';
+        this.errorMessage = params.get('error_description') || error;
+        return;
+      }
+
+      if (!code || !state) {
+        this.status = 'error';
+        this.errorMessage = 'Missing authorization code or state';
+        return;
+      }
+
+      // Send code and state to the parent window (ConnectorManager)
+      if (window.opener) {
+        window.opener.postMessage({ type: 'oauth-callback', code, state }, window.location.origin);
+        this.status = 'success';
+        // Auto-close after 2 seconds
+        setTimeout(() => window.close(), 2000);
+      } else {
+        this.status = 'error';
+        this.errorMessage = 'No parent window found. Please try again.';
+      }
+    }
+  }
+});
+</script>
+
+<style scoped lang="scss">
+.oauth-callback {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  background: var(--el-bg-color);
+}
+
+.status {
+  text-align: center;
+  padding: 40px;
+
+  p {
+    margin-top: 16px;
+    font-size: 16px;
+    color: var(--el-text-color-primary);
+  }
+
+  .hint {
+    font-size: 13px;
+    color: var(--el-text-color-secondary);
+    margin-top: 8px;
+  }
+
+  .icon {
+    font-size: 48px;
+  }
+
+  &.success .icon {
+    color: var(--el-color-success);
+  }
+
+  &.error .icon {
+    color: var(--el-color-danger);
+  }
+}
+</style>

--- a/src/plugins/font-awesome.ts
+++ b/src/plugins/font-awesome.ts
@@ -11,7 +11,13 @@ import {
   faClock as faRegularClock,
   faFile as faRegularFile
 } from '@fortawesome/free-regular-svg-icons';
-import { faDiscord as faBrandsDiscord, faWeixin as faBrandsWeixin } from '@fortawesome/free-brands-svg-icons';
+import {
+  faDiscord as faBrandsDiscord,
+  faWeixin as faBrandsWeixin,
+  faGoogle as faBrandsGoogle,
+  faGithub as faBrandsGithub,
+  faSlack as faBrandsSlack
+} from '@fortawesome/free-brands-svg-icons';
 import {
   faEllipsis as faSolidEllipsis,
   faIdCard as faSolidIdCard,
@@ -88,7 +94,10 @@ import {
   faChartLine as faSolidChartLine,
   faMobileScreenButton as faSolidMobileScreenButton,
   faMagnifyingGlass as faSolidMagnifyingGlass,
-  faFaceMeh as faSolidFaceMeh
+  faFaceMeh as faSolidFaceMeh,
+  faPlug as faSolidPlug,
+  faCheckCircle as faSolidCheckCircle,
+  faCircleExclamation as faSolidCircleExclamation
 } from '@fortawesome/free-solid-svg-icons';
 // add icons
 library.add(faSolidEllipsis);
@@ -179,3 +188,9 @@ library.add(faSolidAnglesLeft);
 library.add(faSolidAnglesRight);
 library.add(faSolidMagnifyingGlass);
 library.add(faSolidFaceMeh);
+library.add(faSolidPlug);
+library.add(faSolidCheckCircle);
+library.add(faSolidCircleExclamation);
+library.add(faBrandsGoogle);
+library.add(faBrandsGithub);
+library.add(faBrandsSlack);

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -197,6 +197,12 @@ const routes = [
     path: '/',
     redirect: { name: ROUTE_CHATGPT_CONVERSATION_NEW }
   },
+  {
+    path: '/chat/oauth/callback',
+    name: 'oauth-callback',
+    component: () => import('@/pages/chat/OAuthCallback.vue'),
+    meta: { auth: false }
+  },
   console,
   auth,
   chatgpt,


### PR DESCRIPTION
## Summary
Phase 4 frontend: OAuth Connector management UI for the AI chat.

### New components
| File | Purpose |
|------|---------|
| `ConnectorManager.vue` | Dialog for connecting/disconnecting OAuth providers |
| `OAuthCallback.vue` | Popup callback page that captures OAuth code |
| `connector.ts` (model) | TypeScript interfaces |
| `connector.ts` (operator) | API calls to `/aichat2/connectors` |

### Changes to existing files
- **`Conversation.vue`** — Added connector button (plug icon) with badge, loads connectors on mount, sends `connectors` array with chat requests
- **`chat.ts` model** — Added `connectors?: string[]` to request interface
- **`font-awesome.ts`** — Registered plug + Google/GitHub/Slack brand icons
- **`router/index.ts`** — Added `/chat/oauth/callback` route
- **i18n** — Added `connector.*` keys for en + zh-CN

### OAuth popup flow
1. User clicks 'Connect' on a provider (Google/GitHub/Slack)
2. Frontend gets OAuth URL from aichat2 backend
3. Popup window opens to provider's consent page
4. After authorization, provider redirects to `/chat/oauth/callback`
5. Callback page sends code+state to parent window via `postMessage`
6. Parent exchanges code for tokens via aichat2 backend
7. Provider shows as connected with profile info

### Screenshot
Connector manager dialog shows available providers with Connect/Disconnect buttons, profile info for connected accounts, and enable/disable toggles.