### PR TITLE
fix: show full prompt/title text across all task previews

### DIFF
--- a/src/components/flux/task/Preview.vue
+++ b/src/components/flux/task/Preview.vue
@@ -199,9 +199,9 @@ $left-width: 70px;
         font-weight: bold;
         color: var(--el-text-color-regular);
         margin-bottom: 15px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+        white-space: normal;
+        word-break: break-word;
+        overflow-wrap: anywhere;
       }
     }
 

--- a/src/components/hailuo/task/Preview.vue
+++ b/src/components/hailuo/task/Preview.vue
@@ -198,9 +198,9 @@ $left-width: 70px;
         font-weight: bold;
         color: var(--el-text-color-regular);
         margin-bottom: 10px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+        white-space: normal;
+        word-break: break-word;
+        overflow-wrap: anywhere;
       }
     }
 

--- a/src/components/headshots/task/Preview.vue
+++ b/src/components/headshots/task/Preview.vue
@@ -208,9 +208,9 @@ $left-width: 70px;
         font-weight: bold;
         color: var(--el-text-color-regular);
         margin-bottom: 10px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+        white-space: normal;
+        word-break: break-word;
+        overflow-wrap: anywhere;
       }
     }
 

--- a/src/components/kling/task/Preview.vue
+++ b/src/components/kling/task/Preview.vue
@@ -209,9 +209,9 @@ $left-width: 70px;
         font-weight: bold;
         color: var(--el-text-color-regular);
         margin-bottom: 10px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+        white-space: normal;
+        word-break: break-word;
+        overflow-wrap: anywhere;
       }
     }
 

--- a/src/components/luma/task/Preview.vue
+++ b/src/components/luma/task/Preview.vue
@@ -216,9 +216,9 @@ $left-width: 70px;
         font-weight: bold;
         color: var(--el-text-color-regular);
         margin-bottom: 10px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+        white-space: normal;
+        word-break: break-word;
+        overflow-wrap: anywhere;
       }
     }
 

--- a/src/components/nanobanana/task/Preview.vue
+++ b/src/components/nanobanana/task/Preview.vue
@@ -271,9 +271,9 @@ $left-width: 70px;
         font-weight: bold;
         color: var(--el-text-color-regular);
         margin-bottom: 15px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+        white-space: normal;
+        word-break: break-word;
+        overflow-wrap: anywhere;
       }
     }
 

--- a/src/components/pika/task/Preview.vue
+++ b/src/components/pika/task/Preview.vue
@@ -247,9 +247,9 @@ $left-width: 70px;
         font-weight: bold;
         color: var(--el-text-color-regular);
         margin-bottom: 10px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+        white-space: normal;
+        word-break: break-word;
+        overflow-wrap: anywhere;
       }
     }
 

--- a/src/components/pixverse/task/Preview.vue
+++ b/src/components/pixverse/task/Preview.vue
@@ -195,9 +195,9 @@ $left-width: 70px;
         font-weight: bold;
         color: var(--el-text-color-regular);
         margin-bottom: 10px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+        white-space: normal;
+        word-break: break-word;
+        overflow-wrap: anywhere;
       }
     }
 

--- a/src/components/producer/task/Preview.vue
+++ b/src/components/producer/task/Preview.vue
@@ -474,17 +474,17 @@ export default defineComponent({
         font-size: 14px;
         font-weight: bold;
         margin-top: 5px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+        white-space: normal;
+        word-break: break-word;
+        overflow-wrap: anywhere;
       }
       .style {
         font-size: 12px;
         margin-bottom: 0;
         color: var(--el-text-color-secondary);
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+        white-space: normal;
+        word-break: break-word;
+        overflow-wrap: anywhere;
       }
     }
     .right {

--- a/src/components/qrart/task/Preview.vue
+++ b/src/components/qrart/task/Preview.vue
@@ -7,7 +7,9 @@
       />
     </div>
     <div class="main flex-1 w-[calc(100%-70px)] min-w-0 pt-[10px] pr-[10px] pb-0 pl-[10px]">
-      <div class="bot text-[16px] font-bold text-[var(--el-color-primary)] overflow-hidden text-ellipsis whitespace-nowrap">
+      <div
+        class="bot text-[16px] font-bold text-[var(--el-color-primary)] overflow-hidden text-ellipsis whitespace-nowrap"
+      >
         {{ $t('qrart.name.qrartBot') }}
         <span class="datetime text-[12px] font-normal text-[var(--el-text-color-secondary)] ml-[10px]">
           {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
@@ -230,9 +232,9 @@ $left-width: 70px;
         font-weight: bold;
         color: var(--el-text-color-regular);
         margin-bottom: 10px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+        white-space: normal;
+        word-break: break-word;
+        overflow-wrap: anywhere;
       }
     }
 

--- a/src/components/seedance/task/Preview.vue
+++ b/src/components/seedance/task/Preview.vue
@@ -234,9 +234,9 @@ $left-width: 70px;
         font-weight: bold;
         color: var(--el-text-color-regular);
         margin-bottom: 10px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+        white-space: normal;
+        word-break: break-word;
+        overflow-wrap: anywhere;
       }
     }
 

--- a/src/components/seedream/task/Preview.vue
+++ b/src/components/seedream/task/Preview.vue
@@ -260,9 +260,9 @@ $left-width: 70px;
         font-weight: bold;
         color: var(--el-text-color-regular);
         margin-bottom: 15px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+        white-space: normal;
+        word-break: break-word;
+        overflow-wrap: anywhere;
       }
     }
 

--- a/src/components/sora/task/Preview.vue
+++ b/src/components/sora/task/Preview.vue
@@ -205,9 +205,9 @@ $left-width: 70px;
         font-weight: bold;
         color: var(--el-text-color-regular);
         margin-bottom: 10px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+        white-space: normal;
+        word-break: break-word;
+        overflow-wrap: anywhere;
       }
     }
 

--- a/src/components/suno/task/Preview.vue
+++ b/src/components/suno/task/Preview.vue
@@ -617,17 +617,17 @@ export default defineComponent({
         font-size: 14px;
         font-weight: bold;
         margin-top: 5px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+        white-space: normal;
+        word-break: break-word;
+        overflow-wrap: anywhere;
       }
       .style {
         font-size: 12px;
         margin-bottom: 0;
         color: var(--el-text-color-secondary);
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+        white-space: normal;
+        word-break: break-word;
+        overflow-wrap: anywhere;
       }
     }
     .right {

--- a/src/components/veo/task/Preview.vue
+++ b/src/components/veo/task/Preview.vue
@@ -229,9 +229,9 @@ $left-width: 70px;
         font-weight: bold;
         color: var(--el-text-color-regular);
         margin-bottom: 10px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+        white-space: normal;
+        word-break: break-word;
+        overflow-wrap: anywhere;
       }
     }
 

--- a/src/components/wan/task/Preview.vue
+++ b/src/components/wan/task/Preview.vue
@@ -194,9 +194,9 @@ $left-width: 70px;
         font-weight: bold;
         color: var(--el-text-color-regular);
         margin-bottom: 10px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+        white-space: normal;
+        word-break: break-word;
+        overflow-wrap: anywhere;
       }
     }
 


### PR DESCRIPTION
## Summary

Remove single-line ellipsis truncation from prompt/title display across all 15 AI service task preview components.

## Affected Components
- flux, hailuo, headshots, kling, luma, pika, pixverse, qrart, seedance, seedream, sora, veo, wan: `.prompt` CSS block
- suno, producer: `.title` + `.style` CSS blocks

## Change
Replace `overflow: hidden; text-overflow: ellipsis; white-space: nowrap` with `white-space: normal; word-break: break-word; overflow-wrap: anywhere` to allow full text wrapping.