### PR TITLE
feat(chat): add skills system UI (Phase 5)

### DIFF
--- a/src/components/chat/SkillManager.vue
+++ b/src/components/chat/SkillManager.vue
@@ -11,7 +11,7 @@
             </el-tag>
             <el-tag v-for="tag in skill.tags.slice(0, 2)" :key="tag" size="small" class="skill-tag">{{ tag }}</el-tag>
           </div>
-          <el-switch :model-value="isActive(skill.id)" @change="(val: boolean) => onToggle(skill.id, val)" />
+          <el-switch :model-value="isActive(skill.id)" @change="(val: string | number | boolean) => onToggle(skill.id, !!val)" />
         </div>
         <p class="skill-description">{{ skill.description }}</p>
       </div>

--- a/src/components/chat/SkillManager.vue
+++ b/src/components/chat/SkillManager.vue
@@ -1,0 +1,145 @@
+<template>
+  <el-dialog v-model="visible" :title="$t('chat.skill.title')" width="560px" :close-on-click-modal="false">
+    <div v-loading="loading" class="skill-manager">
+      <div v-for="skill in skills" :key="skill.id" class="skill-item">
+        <div class="skill-header">
+          <span class="skill-icon">{{ skill.icon }}</span>
+          <div class="skill-info">
+            <span class="skill-name">{{ skill.display_name }}</span>
+            <el-tag v-if="skill.is_builtin" size="small" type="info" class="skill-tag">
+              {{ $t('chat.skill.builtin') }}
+            </el-tag>
+            <el-tag v-for="tag in skill.tags.slice(0, 2)" :key="tag" size="small" class="skill-tag">{{ tag }}</el-tag>
+          </div>
+          <el-switch :model-value="isActive(skill.id)" @change="(val: boolean) => onToggle(skill.id, val)" />
+        </div>
+        <p class="skill-description">{{ skill.description }}</p>
+      </div>
+      <div v-if="!loading && skills.length === 0" class="empty-state">
+        <p>{{ $t('chat.skill.empty') }}</p>
+      </div>
+    </div>
+  </el-dialog>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElDialog, ElSwitch, ElTag, ElMessage } from 'element-plus';
+import { skillOperator } from '@/operators';
+import { ISkill } from '@/models';
+
+export default defineComponent({
+  name: 'SkillManager',
+  components: { ElDialog, ElSwitch, ElTag },
+  props: {
+    modelValue: { type: Boolean, default: false },
+    activeSkills: { type: Array as () => string[], default: () => [] },
+    token: { type: String, default: undefined }
+  },
+  emits: ['update:modelValue', 'change'],
+  data() {
+    return {
+      loading: false,
+      skills: [] as ISkill[]
+    };
+  },
+  computed: {
+    visible: {
+      get() {
+        return this.modelValue;
+      },
+      set(val: boolean) {
+        this.$emit('update:modelValue', val);
+      }
+    }
+  },
+  watch: {
+    modelValue(val: boolean) {
+      if (val) {
+        this.loadData();
+      }
+    }
+  },
+  methods: {
+    isActive(skillId: string): boolean {
+      return this.activeSkills.includes(skillId);
+    },
+    async loadData() {
+      const token = this.token;
+      if (!token) return;
+      this.loading = true;
+      try {
+        const { data } = await skillOperator.list(token);
+        this.skills = data.items || [];
+      } catch {
+        ElMessage.error(this.$t('chat.skill.loadError'));
+      } finally {
+        this.loading = false;
+      }
+    },
+    onToggle(skillId: string, active: boolean) {
+      const updated = active ? [...this.activeSkills, skillId] : this.activeSkills.filter((id) => id !== skillId);
+      this.$emit('change', updated);
+    }
+  }
+});
+</script>
+
+<style scoped lang="scss">
+.skill-manager {
+  min-height: 120px;
+}
+
+.skill-item {
+  padding: 12px;
+  border-radius: 8px;
+  border: 1px solid var(--el-border-color-lighter);
+  margin-bottom: 10px;
+  transition: border-color 0.2s;
+
+  &:hover {
+    border-color: var(--el-color-primary-light-5);
+  }
+}
+
+.skill-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.skill-icon {
+  font-size: 24px;
+  flex-shrink: 0;
+}
+
+.skill-info {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.skill-name {
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.skill-tag {
+  font-size: 11px;
+}
+
+.skill-description {
+  margin: 8px 0 0;
+  font-size: 13px;
+  color: var(--el-text-color-secondary);
+  line-height: 1.5;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 40px 0;
+  color: var(--el-text-color-secondary);
+}
+</style>

--- a/src/components/nanobanana/task/Preview.vue
+++ b/src/components/nanobanana/task/Preview.vue
@@ -271,9 +271,9 @@ $left-width: 70px;
         font-weight: bold;
         color: var(--el-text-color-regular);
         margin-bottom: 15px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+        white-space: normal;
+        word-break: break-word;
+        overflow-wrap: anywhere;
       }
     }
 

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -606,5 +606,25 @@
   "connector.closeWindow": {
     "message": "This window will close automatically.",
     "description": "OAuth callback close hint"
+  },
+  "skill.title": {
+    "message": "Skills",
+    "description": "Skill manager dialog title"
+  },
+  "skill.tooltip": {
+    "message": "AI Skills",
+    "description": "Skill button tooltip"
+  },
+  "skill.builtin": {
+    "message": "Built-in",
+    "description": "Built-in skill tag"
+  },
+  "skill.empty": {
+    "message": "No skills available.",
+    "description": "Empty skill list message"
+  },
+  "skill.loadError": {
+    "message": "Failed to load skills",
+    "description": "Skill load error message"
   }
 }

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -606,5 +606,25 @@
   "connector.closeWindow": {
     "message": "此窗口将自动关闭。",
     "description": "OAuth 回调关闭提示"
+  },
+  "skill.title": {
+    "message": "技能",
+    "description": "技能管理对话框标题"
+  },
+  "skill.tooltip": {
+    "message": "AI 技能",
+    "description": "技能按钮提示"
+  },
+  "skill.builtin": {
+    "message": "内置",
+    "description": "内置技能标签"
+  },
+  "skill.empty": {
+    "message": "暂无可用技能。",
+    "description": "技能列表为空提示"
+  },
+  "skill.loadError": {
+    "message": "加载技能失败",
+    "description": "技能加载失败提示"
   }
 }

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -149,6 +149,7 @@ export interface IChatConversationRequest {
   tools_filter?: string[];
   mcp_servers?: string[];
   connectors?: string[];
+  skills?: string[];
 }
 
 export interface IChatConversationResponse {

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -30,6 +30,7 @@ export * from './wan';
 export * from './site';
 export * from './mcp';
 export * from './connector';
+export * from './skill';
 export * from './exchange';
 export * from './error';
 export * from './config';

--- a/src/models/skill.ts
+++ b/src/models/skill.ts
@@ -1,0 +1,31 @@
+export type ISkillType = 'prompt' | 'workflow' | 'code';
+
+export interface ISkill {
+  id: string;
+  name: string;
+  display_name: string;
+  description: string;
+  icon: string;
+  type: ISkillType;
+  instructions?: string;
+  steps?: IWorkflowStep[];
+  code?: string;
+  required_tools?: string[];
+  tags: string[];
+  is_builtin: boolean;
+  is_public: boolean;
+  user_id?: string;
+  created_at: number;
+  updated_at: number;
+}
+
+export interface IWorkflowStep {
+  tool: string;
+  args: Record<string, unknown>;
+  output?: string;
+  condition?: string;
+}
+
+export interface ISkillListResponse {
+  items: ISkill[];
+}

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -30,5 +30,6 @@ export * from './seedance';
 export * from './serp';
 export * from './mcp';
 export * from './connector';
+export * from './skill';
 export * from './wan';
 export * from './config';

--- a/src/operators/skill.ts
+++ b/src/operators/skill.ts
@@ -1,0 +1,54 @@
+import axios, { AxiosResponse } from 'axios';
+import { ISkillListResponse, ISkill } from '@/models';
+import { BASE_URL_API } from '@/constants';
+
+class SkillOperator {
+  private getHeaders(token: string) {
+    return {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`
+    };
+  }
+
+  async list(token: string): Promise<AxiosResponse<ISkillListResponse>> {
+    return await axios.post(
+      '/aichat2/skills',
+      { action: 'list' },
+      { headers: this.getHeaders(token), baseURL: BASE_URL_API }
+    );
+  }
+
+  async get(id: string, token: string): Promise<AxiosResponse<ISkill>> {
+    return await axios.post(
+      '/aichat2/skills',
+      { action: 'get', id },
+      { headers: this.getHeaders(token), baseURL: BASE_URL_API }
+    );
+  }
+
+  async create(skill: Partial<ISkill>, token: string): Promise<AxiosResponse<ISkill>> {
+    return await axios.post(
+      '/aichat2/skills',
+      { action: 'create', ...skill },
+      { headers: this.getHeaders(token), baseURL: BASE_URL_API }
+    );
+  }
+
+  async update(id: string, updates: Partial<ISkill>, token: string): Promise<AxiosResponse<ISkill>> {
+    return await axios.post(
+      '/aichat2/skills',
+      { action: 'update', id, ...updates },
+      { headers: this.getHeaders(token), baseURL: BASE_URL_API }
+    );
+  }
+
+  async remove(id: string, token: string): Promise<AxiosResponse<{ success: boolean }>> {
+    return await axios.post(
+      '/aichat2/skills',
+      { action: 'delete', id },
+      { headers: this.getHeaders(token), baseURL: BASE_URL_API }
+    );
+  }
+}
+
+export const skillOperator = new SkillOperator();

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -14,8 +14,20 @@
           <el-badge v-if="enabledConnectorCount > 0" :value="enabledConnectorCount" :max="9" class="connector-badge" />
         </el-button>
       </el-tooltip>
+      <el-tooltip :content="$t('chat.skill.tooltip')" placement="bottom">
+        <el-button class="btn-skill" text @click="skillManagerVisible = true">
+          <font-awesome-icon icon="fa-solid fa-wand-magic-sparkles" />
+          <el-badge v-if="activeSkillCount > 0" :value="activeSkillCount" :max="9" class="skill-badge" />
+        </el-button>
+      </el-tooltip>
       <mcp-manager v-model="mcpManagerVisible" @change="onMcpChange" />
       <connector-manager v-model="connectorManagerVisible" @change="onConnectorChange" />
+      <skill-manager
+        v-model="skillManagerVisible"
+        :active-skills="activeSkills"
+        :token="credential?.token"
+        @change="onSkillChange"
+      />
       <div :class="{ dialogue: true, empty: messages.length === 0 }">
         <div v-if="messages.length > 0" class="messages">
           <message
@@ -57,6 +69,7 @@ import Composer from '@/components/chat/Composer.vue';
 import ModelSelector from '@/components/chat/ModelSelector.vue';
 import McpManager from '@/components/chat/McpManager.vue';
 import ConnectorManager from '@/components/chat/ConnectorManager.vue';
+import SkillManager from '@/components/chat/SkillManager.vue';
 import { ERROR_CODE_CANCELED, ERROR_CODE_NOT_APPLIED, ERROR_CODE_UNKNOWN } from '@/constants/errorCode';
 import { Status } from '@/models';
 import Disclaimer from '@/components/chat/Disclaimer.vue';
@@ -79,6 +92,8 @@ export interface IData {
   mcpServers: IMcpServer[];
   connectorManagerVisible: boolean;
   connectors: IConnector[];
+  skillManagerVisible: boolean;
+  activeSkills: string[];
 }
 
 export default defineComponent({
@@ -89,6 +104,7 @@ export default defineComponent({
     ModelSelector,
     McpManager,
     ConnectorManager,
+    SkillManager,
     Message,
     Layout,
     ElTooltip,
@@ -108,6 +124,8 @@ export default defineComponent({
       mcpServers: [] as IMcpServer[],
       connectorManagerVisible: false,
       connectors: [] as IConnector[],
+      skillManagerVisible: false,
+      activeSkills: [] as string[],
       messages:
         this.$store.state.chat.conversations?.find(
           (conversation: IChatConversation) => conversation.id === this.$route.params.id?.toString()
@@ -161,6 +179,9 @@ export default defineComponent({
     },
     enabledConnectorProviders(): string[] {
       return this.connectors.filter((c: IConnector) => c.is_enabled).map((c: IConnector) => c.provider);
+    },
+    activeSkillCount(): number {
+      return this.activeSkills.length;
     }
   },
   watch: {
@@ -180,6 +201,7 @@ export default defineComponent({
     await this.onGetConversations();
     await this.onLoadMcpServers();
     await this.onLoadConnectors();
+    this.onLoadPersistedSkills();
   },
   methods: {
     async onLoadMcpServers() {
@@ -207,6 +229,20 @@ export default defineComponent({
     },
     async onConnectorChange() {
       await this.onLoadConnectors();
+    },
+    onLoadPersistedSkills() {
+      try {
+        const stored = localStorage.getItem('chat_active_skills');
+        if (stored) {
+          this.activeSkills = JSON.parse(stored);
+        }
+      } catch {
+        // ignore
+      }
+    },
+    onSkillChange(skills: string[]) {
+      this.activeSkills = skills;
+      localStorage.setItem('chat_active_skills', JSON.stringify(skills));
     },
     async onGetService() {
       console.debug('start onGetService');
@@ -485,7 +521,8 @@ export default defineComponent({
             stateful: true,
             tools_enabled: true,
             mcp_servers: this.enabledMcpIds.length > 0 ? this.enabledMcpIds : undefined,
-            connectors: this.enabledConnectorProviders.length > 0 ? this.enabledConnectorProviders : undefined
+            connectors: this.enabledConnectorProviders.length > 0 ? this.enabledConnectorProviders : undefined,
+            skills: this.activeSkills.length > 0 ? this.activeSkills : undefined
           },
           {
             token,
@@ -666,6 +703,31 @@ export default defineComponent({
   }
 
   .connector-badge {
+    position: absolute;
+    top: -4px;
+    right: -8px;
+
+    :deep(.el-badge__content) {
+      font-size: 10px;
+      height: 16px;
+      line-height: 16px;
+      padding: 0 4px;
+    }
+  }
+}
+.btn-skill {
+  position: absolute;
+  top: 10px;
+  right: 90px;
+  z-index: 100;
+  font-size: 16px;
+  color: var(--el-text-color-secondary);
+
+  &:hover {
+    color: var(--el-color-primary);
+  }
+
+  .skill-badge {
     position: absolute;
     top: -4px;
     right: -8px;


### PR DESCRIPTION
## Phase 5: Skills System - Frontend

### Changes
- **SkillManager.vue**: Dialog component listing all available skills with toggle switches, built-in tags, icons, and descriptions
- **models/skill.ts**: ISkill, IWorkflowStep, ISkillListResponse TypeScript interfaces
- **operators/skill.ts**: SkillOperator class with CRUD methods (list, get, create, update, remove) calling `/aichat2/skills`
- **Conversation.vue**: Added skill button (wand icon) with badge counter, skill state management with localStorage persistence, sends active skill IDs in chat requests
- **chat.ts**: Added `skills?: string[]` field to IChatConversationRequest
- **i18n**: Added skill-related keys for en and zh-CN locales

### UI
- Skill button with ✨ wand icon positioned in the top-right header area alongside MCP and connector buttons
- Badge counter shows number of active skills
- SkillManager dialog shows all available skills. Each skill displays: icon, name, built-in tag, description, and toggle switch
- Active skill selections persist in localStorage across sessions

### Testing
- TypeScript: `npx vue-tsc --noEmit` — zero errors
- Lint: `npm run lint` — clean

### Related
- PlatformService PR: https://github.com/AceDataCloud/PlatformService/pull/691
- Gateway PR: https://github.com/AceDataCloud/PlatformGateway/pull/104
- Kong route: needs manual creation via TSE console (`/aichat2/skills` → `platform-service-aichat2:3000`)