### PR TITLE
feat: add desktop agent connection manager UI (Phase 6)

### DIFF
--- a/src/components/chat/DesktopAgentManager.vue
+++ b/src/components/chat/DesktopAgentManager.vue
@@ -1,0 +1,149 @@
+<template>
+  <el-dialog
+    :model-value="modelValue"
+    :title="$t('chat.agent.title')"
+    width="480px"
+    @update:model-value="$emit('update:modelValue', $event)"
+  >
+    <div class="agent-manager">
+      <p class="description">{{ $t('chat.agent.description') }}</p>
+
+      <div v-if="connected" class="status-card connected">
+        <div class="status-header">
+          <span class="pulse-dot"></span>
+          <span class="status-text">{{ $t('chat.agent.connected') }}</span>
+        </div>
+        <div class="info-row">
+          <span class="label">{{ $t('chat.agent.name') }}:</span>
+          <span class="value">{{ agentName }}</span>
+        </div>
+        <div class="info-row">
+          <span class="label">{{ $t('chat.agent.tools') }}:</span>
+          <span class="value">{{ toolCount }}</span>
+        </div>
+        <div class="info-row">
+          <span class="label">{{ $t('chat.agent.connectedSince') }}:</span>
+          <span class="value">{{ connectedAt }}</span>
+        </div>
+        <p class="hint">{{ $t('chat.agent.connectedHint') }}</p>
+      </div>
+
+      <div v-else class="status-card disconnected">
+        <div class="status-header">
+          <span class="status-text">{{ $t('chat.agent.notConnected') }}</span>
+        </div>
+        <div class="install-guide">
+          <p class="step-label">{{ $t('chat.agent.installLabel') }}</p>
+          <code class="command">npm install -g @acedatacloud/desktop-agent</code>
+          <p class="step-label">{{ $t('chat.agent.runLabel') }}</p>
+          <code class="command">adc-agent --token YOUR_API_TOKEN</code>
+        </div>
+      </div>
+    </div>
+  </el-dialog>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElDialog } from 'element-plus';
+
+export default defineComponent({
+  name: 'DesktopAgentManager',
+  components: { ElDialog },
+  props: {
+    modelValue: { type: Boolean, default: false },
+    connected: { type: Boolean, default: false },
+    agentName: { type: String, default: '' },
+    toolCount: { type: Number, default: 0 },
+    connectedAt: { type: String, default: '' }
+  },
+  emits: ['update:modelValue']
+});
+</script>
+
+<style lang="scss" scoped>
+.agent-manager {
+  .description {
+    color: var(--el-text-color-secondary);
+    margin-bottom: 16px;
+    font-size: 14px;
+  }
+
+  .status-card {
+    border: 1px solid var(--el-border-color-light);
+    border-radius: 8px;
+    padding: 16px;
+
+    &.connected {
+      border-color: var(--el-color-success-light-5);
+      background: var(--el-color-success-light-9);
+    }
+
+    &.disconnected {
+      border-color: var(--el-border-color-light);
+      background: var(--el-fill-color-light);
+    }
+  }
+
+  .status-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 12px;
+    font-weight: 600;
+  }
+
+  .pulse-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--el-color-success);
+    animation: pulse 2s infinite;
+  }
+
+  @keyframes pulse {
+    0% { opacity: 1; }
+    50% { opacity: 0.4; }
+    100% { opacity: 1; }
+  }
+
+  .info-row {
+    display: flex;
+    justify-content: space-between;
+    padding: 4px 0;
+    font-size: 13px;
+
+    .label {
+      color: var(--el-text-color-secondary);
+    }
+    .value {
+      font-weight: 500;
+    }
+  }
+
+  .hint {
+    margin-top: 12px;
+    font-size: 12px;
+    color: var(--el-text-color-secondary);
+  }
+
+  .install-guide {
+    .step-label {
+      font-size: 13px;
+      margin: 8px 0 4px;
+      color: var(--el-text-color-regular);
+    }
+
+    .command {
+      display: block;
+      background: var(--el-fill-color-darker);
+      color: var(--el-color-success);
+      padding: 8px 12px;
+      border-radius: 4px;
+      font-size: 13px;
+      font-family: 'SF Mono', Monaco, 'Courier New', monospace;
+      user-select: all;
+    }
+  }
+}
+</style>

--- a/src/components/nanobanana/task/Preview.vue
+++ b/src/components/nanobanana/task/Preview.vue
@@ -271,9 +271,9 @@ $left-width: 70px;
         font-weight: bold;
         color: var(--el-text-color-regular);
         margin-bottom: 15px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+        white-space: normal;
+        word-break: break-word;
+        overflow-wrap: anywhere;
       }
     }
 

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -626,5 +626,49 @@
   "skill.loadError": {
     "message": "Failed to load skills",
     "description": "Skill load error message"
+  },
+  "agent.title": {
+    "message": "Desktop Agent",
+    "description": "Agent manager dialog title"
+  },
+  "agent.tooltip": {
+    "message": "Desktop Agent",
+    "description": "Agent button tooltip"
+  },
+  "agent.connected": {
+    "message": "Connected",
+    "description": "Agent connected status"
+  },
+  "agent.notConnected": {
+    "message": "Not Connected",
+    "description": "Agent not connected status"
+  },
+  "agent.description": {
+    "message": "Connect a desktop agent to access local files, run commands, and use local MCP servers from AI chat.",
+    "description": "Agent description"
+  },
+  "agent.name": {
+    "message": "Agent Name",
+    "description": "Agent name label"
+  },
+  "agent.tools": {
+    "message": "Available Tools",
+    "description": "Agent tool count label"
+  },
+  "agent.connectedSince": {
+    "message": "Connected Since",
+    "description": "Agent connection time label"
+  },
+  "agent.connectedHint": {
+    "message": "Your desktop agent is connected and ready to use.",
+    "description": "Agent connected hint"
+  },
+  "agent.installLabel": {
+    "message": "Install the desktop agent:",
+    "description": "Install instruction label"
+  },
+  "agent.runLabel": {
+    "message": "Run the agent:",
+    "description": "Run instruction label"
   }
 }

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -626,5 +626,49 @@
   "skill.loadError": {
     "message": "加载技能失败",
     "description": "技能加载失败提示"
+  },
+  "agent.title": {
+    "message": "桌面代理",
+    "description": "代理管理对话框标题"
+  },
+  "agent.tooltip": {
+    "message": "桌面代理",
+    "description": "代理按钮提示"
+  },
+  "agent.connected": {
+    "message": "已连接",
+    "description": "代理已连接状态"
+  },
+  "agent.notConnected": {
+    "message": "未连接",
+    "description": "代理未连接状态"
+  },
+  "agent.description": {
+    "message": "连接桌面代理以在 AI 对话中访问本地文件、运行命令和使用本地 MCP 服务器。",
+    "description": "代理描述"
+  },
+  "agent.name": {
+    "message": "代理名称",
+    "description": "代理名称标签"
+  },
+  "agent.tools": {
+    "message": "可用工具",
+    "description": "代理工具数量标签"
+  },
+  "agent.connectedSince": {
+    "message": "连接时间",
+    "description": "代理连接时间标签"
+  },
+  "agent.connectedHint": {
+    "message": "您的桌面代理已连接，可以使用。",
+    "description": "代理已连接提示"
+  },
+  "agent.installLabel": {
+    "message": "安装桌面代理：",
+    "description": "安装说明标签"
+  },
+  "agent.runLabel": {
+    "message": "运行代理：",
+    "description": "运行说明标签"
   }
 }

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -20,6 +20,12 @@
           <el-badge v-if="activeSkillCount > 0" :value="activeSkillCount" :max="9" class="skill-badge" />
         </el-button>
       </el-tooltip>
+      <el-tooltip :content="$t('chat.agent.tooltip')" placement="bottom">
+        <el-button class="btn-agent" text @click="agentManagerVisible = true">
+          <font-awesome-icon icon="fa-solid fa-desktop" />
+          <span v-if="agentConnected" class="agent-dot"></span>
+        </el-button>
+      </el-tooltip>
       <mcp-manager v-model="mcpManagerVisible" @change="onMcpChange" />
       <connector-manager v-model="connectorManagerVisible" @change="onConnectorChange" />
       <skill-manager
@@ -27,6 +33,13 @@
         :active-skills="activeSkills"
         :token="credential?.token"
         @change="onSkillChange"
+      />
+      <desktop-agent-manager
+        v-model="agentManagerVisible"
+        :connected="agentConnected"
+        :agent-name="agentName"
+        :tool-count="agentToolCount"
+        :connected-at="agentConnectedAt"
       />
       <div :class="{ dialogue: true, empty: messages.length === 0 }">
         <div v-if="messages.length > 0" class="messages">
@@ -70,6 +83,7 @@ import ModelSelector from '@/components/chat/ModelSelector.vue';
 import McpManager from '@/components/chat/McpManager.vue';
 import ConnectorManager from '@/components/chat/ConnectorManager.vue';
 import SkillManager from '@/components/chat/SkillManager.vue';
+import DesktopAgentManager from '@/components/chat/DesktopAgentManager.vue';
 import { ERROR_CODE_CANCELED, ERROR_CODE_NOT_APPLIED, ERROR_CODE_UNKNOWN } from '@/constants/errorCode';
 import { Status } from '@/models';
 import Disclaimer from '@/components/chat/Disclaimer.vue';
@@ -94,6 +108,11 @@ export interface IData {
   connectors: IConnector[];
   skillManagerVisible: boolean;
   activeSkills: string[];
+  agentManagerVisible: boolean;
+  agentConnected: boolean;
+  agentName: string;
+  agentToolCount: number;
+  agentConnectedAt: string;
 }
 
 export default defineComponent({
@@ -105,6 +124,7 @@ export default defineComponent({
     McpManager,
     ConnectorManager,
     SkillManager,
+    DesktopAgentManager,
     Message,
     Layout,
     ElTooltip,
@@ -126,6 +146,11 @@ export default defineComponent({
       connectors: [] as IConnector[],
       skillManagerVisible: false,
       activeSkills: [] as string[],
+      agentManagerVisible: false,
+      agentConnected: false,
+      agentName: '',
+      agentToolCount: 0,
+      agentConnectedAt: '',
       messages:
         this.$store.state.chat.conversations?.find(
           (conversation: IChatConversation) => conversation.id === this.$route.params.id?.toString()
@@ -202,6 +227,7 @@ export default defineComponent({
     await this.onLoadMcpServers();
     await this.onLoadConnectors();
     this.onLoadPersistedSkills();
+    this.onCheckAgentStatus();
   },
   methods: {
     async onLoadMcpServers() {
@@ -243,6 +269,23 @@ export default defineComponent({
     onSkillChange(skills: string[]) {
       this.activeSkills = skills;
       localStorage.setItem('chat_active_skills', JSON.stringify(skills));
+    },
+    async onCheckAgentStatus() {
+      const token = this.credential?.token;
+      if (!token) return;
+      try {
+        const { data } = await axios.post(
+          '/aichat2/agent',
+          { action: 'status' },
+          { headers: { Authorization: `Bearer ${token}` } }
+        );
+        this.agentConnected = data?.connected === true;
+        this.agentName = data?.name || '';
+        this.agentToolCount = data?.tool_count || 0;
+        this.agentConnectedAt = data?.connected_at || '';
+      } catch {
+        this.agentConnected = false;
+      }
     },
     async onGetService() {
       console.debug('start onGetService');
@@ -738,6 +781,29 @@ export default defineComponent({
       line-height: 16px;
       padding: 0 4px;
     }
+  }
+}
+
+.btn-agent {
+  position: absolute;
+  top: 10px;
+  right: 120px;
+  z-index: 100;
+  font-size: 16px;
+  color: var(--el-text-color-secondary);
+
+  &:hover {
+    color: var(--el-color-primary);
+  }
+
+  .agent-dot {
+    position: absolute;
+    top: 2px;
+    right: -2px;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--el-color-success);
   }
 }
 @media (max-width: 767px) {

--- a/src/plugins/font-awesome.ts
+++ b/src/plugins/font-awesome.ts
@@ -55,6 +55,7 @@ import {
   faGlobe as faSolidGlobe,
   faStop as faSolidStop,
   faWandMagicSparkles as faSolidWandMagicSparkles,
+  faDesktop as faSolidDesktop,
   faPalette as faSolidPalette,
   faBars as faSolidBars,
   faGear as faSolidGear,
@@ -164,6 +165,7 @@ library.add(faSolidTrash);
 library.add(faSolidChevronDown);
 library.add(faSolidPalette);
 library.add(faSolidWandMagicSparkles);
+library.add(faSolidDesktop);
 library.add(faSolidMugSaucer);
 library.add(faSolidInfo);
 library.add(faSolidMagic);


### PR DESCRIPTION
## Phase 6 — Desktop Agent Frontend

- `DesktopAgentManager.vue` — shows agent connection status and install instructions
- Agent button in chat Conversation toolbar with green dot indicator when connected
- Calls `POST /aichat2/agent` to check desktop agent connectivity
- i18n keys for en and zh-CN