### PR TITLE
feat(kling): add kling-v3, v3-omni, v2-6 model support

### DIFF
--- a/change/@acedatacloud-nexior-c23e09b0-33b6-4fcb-9f10-515dcbaec22b.json
+++ b/change/@acedatacloud-nexior-c23e09b0-33b6-4fcb-9f10-515dcbaec22b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(kling): add kling-v3, v3-omni, v2-6 model support",
+  "packageName": "@acedatacloud/nexior",
+  "email": "cqc@cuiqingcai.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@acedatacloud-nexior-db8ef0db-de4b-4451-88e4-5c0c43bf3b29.json
+++ b/change/@acedatacloud-nexior-db8ef0db-de4b-4451-88e4-5c0c43bf3b29.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(kling): add kling-v3, v3-omni, v2-6 model support with generate audio toggle",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/kling/ConfigPanel.vue
+++ b/src/components/kling/ConfigPanel.vue
@@ -8,6 +8,7 @@
       <end-image class="mb-2" />
       <duration-selector class="mb-4" />
       <mode-selector class="mb-4" />
+      <generate-audio-selector class="mb-4" />
       <cfg-scale-selector class="mb-4" />
       <negative-prompt-input class="mb-4" />
     </div>
@@ -43,6 +44,7 @@ import StartImage from './config/StartImage.vue';
 import EndImage from './config/EndImage.vue';
 import Consumption from '../common/Consumption.vue';
 import CfgScaleSelector from './config/CfgScaleSelector.vue';
+import GenerateAudioSelector from './config/GenerateAudioSelector.vue';
 import PromptInput from './config/PromptInput.vue';
 import NegativePromptInput from './config/NegativePromptInput.vue';
 import { getConsumption } from '@/utils';
@@ -61,6 +63,7 @@ export default defineComponent({
     RatioSelector,
     StartImage,
     CfgScaleSelector,
+    GenerateAudioSelector,
     EndImage
   },
   emits: ['generate'],

--- a/src/components/kling/config/DurationSelector.vue
+++ b/src/components/kling/config/DurationSelector.vue
@@ -65,7 +65,7 @@ export default defineComponent({
     isV3Model(newVal: boolean) {
       const current = this.value;
       const validValues = (newVal ? V3_OPTIONS : STANDARD_OPTIONS).map((o) => o.value);
-      if (!validValues.includes(current)) {
+      if (current !== undefined && !validValues.includes(current)) {
         this.value = KLING_DEFAULT_DURATION;
       }
     }

--- a/src/components/kling/config/DurationSelector.vue
+++ b/src/components/kling/config/DurationSelector.vue
@@ -10,7 +10,21 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import { ElSelect, ElOption } from 'element-plus';
-import { KLING_DEFAULT_DURATION } from '@/constants';
+import { KLING_DEFAULT_DURATION, KLING_V3_MODELS } from '@/constants';
+
+const STANDARD_OPTIONS = [
+  { value: 5, label: '5秒' },
+  { value: 10, label: '10秒' }
+];
+
+const V3_OPTIONS = [
+  { value: 3, label: '3秒' },
+  { value: 5, label: '5秒' },
+  { value: 8, label: '8秒' },
+  { value: 10, label: '10秒' },
+  { value: 12, label: '12秒' },
+  { value: 15, label: '15秒' }
+];
 
 export default defineComponent({
   name: 'DurationSelector',
@@ -25,21 +39,16 @@ export default defineComponent({
     }
   },
   emits: ['update:modelValue'],
-  data() {
-    return {
-      options: [
-        {
-          value: 5,
-          label: '5秒'
-        },
-        {
-          value: 10,
-          label: '10秒'
-        }
-      ]
-    };
-  },
   computed: {
+    selectedModel() {
+      return this.$store.state.kling?.config?.model || '';
+    },
+    isV3Model() {
+      return KLING_V3_MODELS.includes(this.selectedModel);
+    },
+    options() {
+      return this.isV3Model ? V3_OPTIONS : STANDARD_OPTIONS;
+    },
     value: {
       get() {
         return this.$store.state.kling?.config?.duration;
@@ -49,6 +58,15 @@ export default defineComponent({
           ...this.$store.state.kling.config,
           duration: val
         });
+      }
+    }
+  },
+  watch: {
+    isV3Model(newVal: boolean) {
+      const current = this.value;
+      const validValues = (newVal ? V3_OPTIONS : STANDARD_OPTIONS).map((o) => o.value);
+      if (!validValues.includes(current)) {
+        this.value = KLING_DEFAULT_DURATION;
       }
     }
   },

--- a/src/components/kling/config/GenerateAudioSelector.vue
+++ b/src/components/kling/config/GenerateAudioSelector.vue
@@ -12,8 +12,6 @@ import { defineComponent } from 'vue';
 import { ElSwitch } from 'element-plus';
 import { KLING_DEFAULT_GENERATE_AUDIO, KLING_V3_MODELS } from '@/constants';
 
-const AUDIO_SUPPORTED_MODELS = [...KLING_V3_MODELS, 'kling-v2-6'];
-
 export default defineComponent({
   name: 'GenerateAudioSelector',
   components: {

--- a/src/components/kling/config/GenerateAudioSelector.vue
+++ b/src/components/kling/config/GenerateAudioSelector.vue
@@ -1,0 +1,58 @@
+<template>
+  <div v-if="visible" class="relative">
+    <div class="flex justify-between items-center">
+      <span class="text-sm font-bold">{{ $t('kling.name.generateAudio') }}</span>
+      <el-switch v-model="value" class="value" />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElSwitch } from 'element-plus';
+import { KLING_DEFAULT_GENERATE_AUDIO, KLING_V3_MODELS } from '@/constants';
+
+const AUDIO_SUPPORTED_MODELS = [...KLING_V3_MODELS, 'kling-v2-6'];
+
+export default defineComponent({
+  name: 'GenerateAudioSelector',
+  components: {
+    ElSwitch
+  },
+  computed: {
+    selectedModel() {
+      return this.$store.state.kling?.config?.model || '';
+    },
+    selectedMode() {
+      return this.$store.state.kling?.config?.mode || '';
+    },
+    visible() {
+      if (KLING_V3_MODELS.includes(this.selectedModel)) {
+        return true;
+      }
+      if (this.selectedModel === 'kling-v2-6' && this.selectedMode === 'pro') {
+        return true;
+      }
+      return false;
+    },
+    value: {
+      get() {
+        return this.$store.state.kling?.config?.generate_audio ?? KLING_DEFAULT_GENERATE_AUDIO;
+      },
+      set(val: boolean) {
+        this.$store.commit('kling/setConfig', {
+          ...this.$store.state.kling?.config,
+          generate_audio: val
+        });
+      }
+    }
+  },
+  watch: {
+    visible(newVal: boolean) {
+      if (!newVal && this.value) {
+        this.value = false;
+      }
+    }
+  }
+});
+</script>

--- a/src/components/kling/config/ModelSelector.vue
+++ b/src/components/kling/config/ModelSelector.vue
@@ -29,24 +29,36 @@ export default defineComponent({
     return {
       options: [
         {
-          value: 'kling-v1',
-          label: 'v1'
+          value: 'kling-v3',
+          label: 'v3'
         },
         {
-          value: 'kling-v1-6',
-          label: 'v1.6'
+          value: 'kling-v3-omni',
+          label: 'v3-Omni'
         },
         {
-          value: 'kling-v2-master',
-          label: 'v2-Master'
+          value: 'kling-v2-6',
+          label: 'v2.6'
+        },
+        {
+          value: 'kling-v2-5-turbo',
+          label: 'v2.5-Turbo'
         },
         {
           value: 'kling-v2-1-master',
           label: 'v2.1-Master'
         },
         {
-          value: 'kling-v2-5-turbo',
-          label: 'v2.5-Turbo'
+          value: 'kling-v2-master',
+          label: 'v2-Master'
+        },
+        {
+          value: 'kling-v1-6',
+          label: 'v1.6'
+        },
+        {
+          value: 'kling-v1',
+          label: 'v1'
         },
         {
           value: 'kling-video-o1',

--- a/src/components/nanobanana/task/Preview.vue
+++ b/src/components/nanobanana/task/Preview.vue
@@ -271,9 +271,9 @@ $left-width: 70px;
         font-weight: bold;
         color: var(--el-text-color-regular);
         margin-bottom: 15px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+        white-space: normal;
+        word-break: break-word;
+        overflow-wrap: anywhere;
       }
     }
 

--- a/src/constants/kling.ts
+++ b/src/constants/kling.ts
@@ -2,9 +2,12 @@ export const KLING_SERVICE_ID = '3369e077-2500-4263-86c7-cae0f0e7e843';
 
 export const KLING_LOGO = 'https://cdn.acedata.cloud/qpbbbb.jpg';
 
-export const KLING_DEFAULT_MODEL = 'kling-v1';
+export const KLING_DEFAULT_MODEL = 'kling-v2-5-turbo';
 export const KLING_DEFAULT_DURATION = 5;
 export const KLING_DEFAULT_MODE = 'std';
 export const KLING_DEFAULT_ASPECT_RATIO = '1:1';
 export const KLING_DEFAULT_INGREDIENTS = false;
 export const KLING_DEFAULT_CFG_SCALE = 0;
+export const KLING_DEFAULT_GENERATE_AUDIO = false;
+
+export const KLING_V3_MODELS = ['kling-v3', 'kling-v3-omni'];

--- a/src/i18n/en/kling.json
+++ b/src/i18n/en/kling.json
@@ -39,6 +39,10 @@
     "message": "Freedom Level",
     "description": "The freedom parameter for generating the video (0-1), larger values are closer to the reference"
   },
+  "name.generateAudio": {
+    "message": "Generate Audio",
+    "description": "Whether to generate audio synchronously, supported by kling-v3, kling-v3-omni, and kling-v2-6 (pro mode)"
+  },
   "name.startImage": {
     "message": "First Frame",
     "description": "Form field label: first frame reference image"

--- a/src/i18n/zh-CN/kling.json
+++ b/src/i18n/zh-CN/kling.json
@@ -39,6 +39,10 @@
     "message": "自由度",
     "description": "生成视频的自由度参数（0-1），值越大越贴近参考（英文建议：Freedom Level）"
   },
+  "name.generateAudio": {
+    "message": "同步生成音效",
+    "description": "是否同步生成音效，支持 kling-v3、kling-v3-omni 和 kling-v2-6（pro 模式）"
+  },
   "name.startImage": {
     "message": "首帧参考图片",
     "description": "表单字段标签：首帧参考图（英文建议翻译为“First Frame”，保持简短避免遮挡按钮）"

--- a/src/models/kling.ts
+++ b/src/models/kling.ts
@@ -14,6 +14,7 @@ export interface IKlingConfig {
   camera_control?: string;
   cfg_scale?: number;
   callback_url?: string;
+  generate_audio?: boolean;
 }
 
 export interface IKlingGenerateRequest {
@@ -31,6 +32,7 @@ export interface IKlingGenerateRequest {
   cfg_scale?: number;
   callback_url?: string;
   mirror?: boolean;
+  generate_audio?: boolean;
 }
 export interface IKlingVideo {
   id?: string;


### PR DESCRIPTION
## Summary
- Add kling-v3, kling-v3-omni, kling-v2-6 models to ModelSelector (ordered newest first)
- Add GenerateAudioSelector toggle (visible for v3/v3-omni always, v2-6 pro mode only)
- Make DurationSelector reactive: v3 models support 3-15s range, others keep 5/10s
- Update default model from kling-v1 to kling-v2-5-turbo
- Add generate_audio field to IKlingConfig and IKlingGenerateRequest interfaces
- Add zh-CN and en i18n entries for generateAudio

## Test plan
- [ ] Select kling-v3 model → verify duration options show 3/5/8/10/12/15s
- [ ] Select kling-v1 model → verify duration options show only 5/10s
- [ ] Select kling-v3 → verify Generate Audio toggle is visible
- [ ] Select kling-v2-6 + pro mode → verify Generate Audio toggle appears
- [ ] Select kling-v2-6 + std mode → verify Generate Audio toggle is hidden
- [ ] Enable Generate Audio, switch to non-audio model → verify toggle auto-resets to off
- [ ] Generate a video with kling-v3 + audio enabled → verify request includes generate_audio: true

🤖 Generated with [Claude Code](https://claude.ai/claude-code)