### PR TITLE
fix: resolve aichat2 UI bugs (dialog leaks, z-index, error handling)

### DIFF
--- a/src/components/chat/ConnectorManager.vue
+++ b/src/components/chat/ConnectorManager.vue
@@ -8,8 +8,11 @@
   >
     <div v-loading="loading" class="connector-manager">
       <!-- Provider List -->
-      <div v-if="providers.length === 0 && !loading" class="empty">
+      <div v-if="providers.length === 0 && !loading && !loadError" class="empty">
         {{ $t('chat.connector.noProviders') }}
+      </div>
+      <div v-if="loadError && !loading" class="empty">
+        {{ $t('chat.connector.loadErrorHint') }}
       </div>
       <div v-for="provider in providers" :key="provider.id" class="provider-item">
         <div class="provider-icon">
@@ -83,6 +86,7 @@ export default defineComponent({
       providers: [] as IConnectorProvider[],
       connectors: [] as IConnector[],
       loading: false,
+      loadError: false,
       connecting: '' as string
     };
   },
@@ -116,6 +120,7 @@ export default defineComponent({
     async loadData() {
       if (!this.token) return;
       this.loading = true;
+      this.loadError = false;
       try {
         const [providersRes, connectorsRes] = await Promise.all([
           connectorOperator.listProviders(this.token),
@@ -124,7 +129,7 @@ export default defineComponent({
         this.providers = providersRes.data.providers || [];
         this.connectors = connectorsRes.data.items || [];
       } catch {
-        ElMessage.error(this.$t('chat.connector.loadError'));
+        this.loadError = true;
       } finally {
         this.loading = false;
       }

--- a/src/components/chat/McpManager.vue
+++ b/src/components/chat/McpManager.vue
@@ -71,8 +71,11 @@
 
       <!-- Server List -->
       <div v-loading="loading" class="server-list">
-        <div v-if="servers.length === 0 && !loading" class="empty">
+        <div v-if="servers.length === 0 && !loading && !loadError" class="empty">
           {{ $t('chat.mcp.empty') }}
+        </div>
+        <div v-if="loadError && !loading" class="empty">
+          {{ $t('chat.mcp.loadErrorHint') }}
         </div>
         <div v-for="server in servers" :key="server.id" class="server-item">
           <div class="server-info">
@@ -154,6 +157,7 @@ export default defineComponent({
     return {
       servers: [] as IMcpServer[],
       loading: false,
+      loadError: false,
       submitting: false,
       testing: false,
       showAddForm: false,
@@ -191,11 +195,12 @@ export default defineComponent({
   methods: {
     async onLoad() {
       this.loading = true;
+      this.loadError = false;
       try {
         const { data } = await mcpServerOperator.list(this.token);
         this.servers = data.items || [];
       } catch {
-        ElMessage.error('Failed to load MCP servers');
+        this.loadError = true;
       } finally {
         this.loading = false;
       }

--- a/src/components/nanobanana/task/Preview.vue
+++ b/src/components/nanobanana/task/Preview.vue
@@ -271,9 +271,9 @@ $left-width: 70px;
         font-weight: bold;
         color: var(--el-text-color-regular);
         margin-bottom: 15px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+        white-space: normal;
+        word-break: break-word;
+        overflow-wrap: anywhere;
       }
     }
 

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -567,6 +567,10 @@
     "message": "No MCP servers yet. Add one to extend AI capabilities.",
     "description": "MCP server list empty"
   },
+  "mcp.loadErrorHint": {
+    "message": "Unable to load MCP servers. This feature may not be available yet.",
+    "description": "Hint when MCP servers fail to load due to network/CORS errors"
+  },
   "mcp.nameUrlRequired": {
     "message": "Name and URL are required",
     "description": "Name and URL required validation"
@@ -634,6 +638,10 @@
   "connector.loadError": {
     "message": "Failed to load connectors",
     "description": "Load error message"
+  },
+  "connector.loadErrorHint": {
+    "message": "Unable to load connectors. This feature may not be available yet.",
+    "description": "Hint when connectors fail to load due to network/CORS errors"
   },
   "connector.disconnectError": {
     "message": "Failed to disconnect connector",

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -567,6 +567,10 @@
     "message": "暂无 MCP 服务器，添加一个以扩展 AI 的能力",
     "description": "MCP 服务器列表为空"
   },
+  "mcp.loadErrorHint": {
+    "message": "无法加载 MCP 服务器，该功能可能暂未开放。",
+    "description": "MCP 服务器因网络/CORS错误加载失败时的提示"
+  },
   "mcp.nameUrlRequired": {
     "message": "请填写名称和 URL",
     "description": "名称和 URL 必填"
@@ -634,6 +638,10 @@
   "connector.loadError": {
     "message": "加载连接器失败",
     "description": "加载错误消息"
+  },
+  "connector.loadErrorHint": {
+    "message": "无法加载连接器，该功能可能暂未开放。",
+    "description": "连接器因网络/CORS错误加载失败时的提示"
   },
   "connector.disconnectError": {
     "message": "断开连接器失败",

--- a/src/layouts/Main.vue
+++ b/src/layouts/Main.vue
@@ -4,7 +4,7 @@
     <navigator class="navigator" :direction="mobile ? 'row' : 'column'" />
     <application-status
       v-if="application"
-      class="fixed right-2 top-2"
+      class="fixed right-2 top-2 z-[200]"
       :application="application"
       :applications="applications"
       :show-price="false"

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -35,15 +35,17 @@
           </el-tooltip>
         </div>
       </div>
-      <mcp-manager v-model="mcpManagerVisible" @change="onMcpChange" />
-      <connector-manager v-model="connectorManagerVisible" @change="onConnectorChange" />
+      <mcp-manager v-if="mcpManagerVisible" v-model="mcpManagerVisible" @change="onMcpChange" />
+      <connector-manager v-if="connectorManagerVisible" v-model="connectorManagerVisible" @change="onConnectorChange" />
       <skill-manager
+        v-if="skillManagerVisible"
         v-model="skillManagerVisible"
         :active-skills="activeSkills"
         :token="credential?.token"
         @change="onSkillChange"
       />
       <desktop-agent-manager
+        v-if="agentManagerVisible"
         v-model="agentManagerVisible"
         :connected="agentConnected"
         :agent-name="agentName"


### PR DESCRIPTION
## Summary
- Add `v-if` guards to all dialog components (McpManager, ConnectorManager, SkillManager, DesktopAgentManager) to prevent Element Plus `el-dialog` from rendering content in DOM when closed — this caused "No connectors available" message to appear inline between toolbar and messages
- Add `z-[200]` to ApplicationStatus wallet button in Main.vue to fix it being covered by toolbar z-index
- Add silent error handling with `loadError` state in McpManager and ConnectorManager to avoid error popups on CORS-blocked `/aichat2/` requests
- Add `loadErrorHint` i18n keys for graceful error display

## Test plan
- [x] Local dev server testing — verified "No connectors available" message no longer appears inline
- [x] Verified wallet button is clickable
- [x] Verified MCP/connector dialogs open cleanly without error popups
- [x] TypeScript check (`npx vue-tsc --noEmit`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)