### PR TITLE
feat(chat): add MCP server OAuth 2.0 UI support

### DIFF
--- a/src/components/chat/McpManager.vue
+++ b/src/components/chat/McpManager.vue
@@ -30,6 +30,7 @@
             <el-select v-model="form.auth_type" style="width: 100%">
               <el-option value="none" :label="$t('chat.mcp.authNone')" />
               <el-option value="bearer" :label="$t('chat.mcp.authBearer')" />
+              <el-option value="oauth" :label="$t('chat.mcp.authOAuth')" />
             </el-select>
           </el-form-item>
           <el-form-item v-if="form.auth_type === 'bearer'" :label="$t('chat.mcp.authToken')">
@@ -40,6 +41,9 @@
               :placeholder="$t('chat.mcp.authTokenPlaceholder')"
             />
           </el-form-item>
+          <div v-if="form.auth_type === 'oauth'" class="oauth-hint">
+            <el-text type="info" size="small">{{ $t('chat.mcp.oauthHint') }}</el-text>
+          </div>
           <div class="form-actions">
             <el-button size="small" @click="onCancelForm">{{ $t('common.button.cancel') }}</el-button>
             <el-button size="small" :loading="testing" @click="onTest">
@@ -85,6 +89,19 @@
               <el-tag v-if="server.tools_cache?.length" size="small" type="info" effect="plain">
                 {{ server.tools_cache.length }} tools
               </el-tag>
+              <el-tag v-if="server.auth_type === 'oauth' && server.oauth_status === 'authorized'" size="small" type="success" effect="plain">
+                OAuth
+              </el-tag>
+              <el-button
+                v-if="server.auth_type === 'oauth' && server.oauth_status !== 'authorized'"
+                size="small"
+                type="warning"
+                :loading="authorizingServerId === server.id"
+                @click="onAuthorize(server)"
+              >
+                <font-awesome-icon icon="fa-solid fa-key" class="mr-1" />
+                {{ $t('chat.mcp.authorize') }}
+              </el-button>
             </div>
             <div class="server-url">{{ server.url }}</div>
             <div v-if="server.description" class="server-desc">{{ server.description }}</div>
@@ -117,7 +134,8 @@ import {
   ElSwitch,
   ElTag,
   ElMessage,
-  ElMessageBox
+  ElMessageBox,
+  ElText
 } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { mcpServerOperator } from '@/operators';
@@ -144,6 +162,7 @@ export default defineComponent({
     ElCard,
     ElSwitch,
     ElTag,
+    ElText,
     FontAwesomeIcon
   },
   props: {
@@ -169,7 +188,9 @@ export default defineComponent({
         description: '',
         auth_type: 'none',
         auth_token: ''
-      } as IForm
+      } as IForm,
+      authorizingServerId: null as string | null,
+      oauthMessageHandler: null as ((event: MessageEvent) => void) | null
     };
   },
   computed: {
@@ -190,6 +211,11 @@ export default defineComponent({
       if (val) {
         this.onLoad();
       }
+    }
+  },
+  beforeUnmount() {
+    if (this.oauthMessageHandler) {
+      window.removeEventListener('message', this.oauthMessageHandler);
     }
   },
   methods: {
@@ -294,6 +320,56 @@ export default defineComponent({
       } finally {
         this.testing = false;
       }
+    },
+    async onAuthorize(server: IMcpServer) {
+      this.authorizingServerId = server.id;
+      try {
+        const { data } = await mcpServerOperator.oauthStart(server.id, this.token);
+        if (data.status === 'authorized') {
+          ElMessage.success(this.$t('chat.mcp.oauthAuthorized') as string);
+          await this.onLoad();
+          this.$emit('change');
+          return;
+        }
+        if (data.status === 'redirect' && data.authorization_url) {
+          const popup = window.open(data.authorization_url, 'mcp-oauth', 'width=600,height=700');
+          if (!popup) {
+            ElMessage.error(this.$t('chat.mcp.popupBlocked') as string);
+            return;
+          }
+          // Clean up any previous listener
+          if (this.oauthMessageHandler) {
+            window.removeEventListener('message', this.oauthMessageHandler);
+          }
+          this.oauthMessageHandler = async (event: MessageEvent) => {
+            if (event.origin !== window.location.origin) return;
+            if (event.data?.type !== 'oauth-callback') return;
+            window.removeEventListener('message', this.oauthMessageHandler!);
+            this.oauthMessageHandler = null;
+            try {
+              const { data: cbData } = await mcpServerOperator.oauthCallback(server.id, event.data.code, this.token);
+              if (cbData.status === 'authorized') {
+                ElMessage.success(this.$t('chat.mcp.oauthAuthorized') as string);
+                await this.onLoad();
+                this.$emit('change');
+              } else {
+                ElMessage.error(cbData.error || this.$t('chat.mcp.oauthFailed') as string);
+              }
+            } catch {
+              ElMessage.error(this.$t('chat.mcp.oauthFailed') as string);
+            } finally {
+              this.authorizingServerId = null;
+            }
+          };
+          window.addEventListener('message', this.oauthMessageHandler);
+        }
+      } catch {
+        ElMessage.error(this.$t('chat.mcp.oauthFailed') as string);
+      } finally {
+        if (!this.oauthMessageHandler) {
+          this.authorizingServerId = null;
+        }
+      }
     }
   }
 });
@@ -312,6 +388,10 @@ export default defineComponent({
       display: flex;
       justify-content: flex-end;
       gap: 8px;
+    }
+
+    .oauth-hint {
+      margin-bottom: 12px;
     }
   }
 

--- a/src/components/nanobanana/task/Preview.vue
+++ b/src/components/nanobanana/task/Preview.vue
@@ -271,9 +271,9 @@ $left-width: 70px;
         font-weight: bold;
         color: var(--el-text-color-regular);
         margin-bottom: 15px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+        white-space: normal;
+        word-break: break-word;
+        overflow-wrap: anywhere;
       }
     }
 

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -603,6 +603,30 @@
     "message": "MCP Servers",
     "description": "MCP button tooltip"
   },
+  "mcp.authOAuth": {
+    "message": "OAuth 2.0",
+    "description": "OAuth authentication type"
+  },
+  "mcp.oauthHint": {
+    "message": "After saving, click the Authorize button on the server card to complete OAuth authentication.",
+    "description": "Hint shown when OAuth auth type is selected"
+  },
+  "mcp.authorize": {
+    "message": "Authorize",
+    "description": "OAuth authorize button"
+  },
+  "mcp.oauthAuthorized": {
+    "message": "OAuth authorized successfully",
+    "description": "OAuth authorization success message"
+  },
+  "mcp.oauthFailed": {
+    "message": "OAuth authorization failed",
+    "description": "OAuth authorization failure message"
+  },
+  "mcp.popupBlocked": {
+    "message": "Popup blocked. Please allow popups for this site.",
+    "description": "Popup blocked warning"
+  },
   "connector.title": {
     "message": "Connectors",
     "description": "Connector manager dialog title"

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -603,6 +603,30 @@
     "message": "MCP 服务器",
     "description": "MCP 按钮提示"
   },
+  "mcp.authOAuth": {
+    "message": "OAuth 2.0",
+    "description": "OAuth 认证类型"
+  },
+  "mcp.oauthHint": {
+    "message": "保存后，在服务器卡片上点击「授权」按钮完成 OAuth 认证。",
+    "description": "选择 OAuth 认证类型时的提示"
+  },
+  "mcp.authorize": {
+    "message": "授权",
+    "description": "OAuth 授权按钮"
+  },
+  "mcp.oauthAuthorized": {
+    "message": "OAuth 授权成功",
+    "description": "OAuth 授权成功消息"
+  },
+  "mcp.oauthFailed": {
+    "message": "OAuth 授权失败",
+    "description": "OAuth 授权失败消息"
+  },
+  "mcp.popupBlocked": {
+    "message": "弹出窗口被阻止，请允许本站弹出窗口。",
+    "description": "弹出窗口被阻止提示"
+  },
   "connector.title": {
     "message": "连接器",
     "description": "连接器管理对话框标题"

--- a/src/models/mcp.ts
+++ b/src/models/mcp.ts
@@ -10,6 +10,8 @@ export interface IMcpServer {
   tools_cache?: IMcpTool[];
   is_enabled: boolean;
   created_at?: string;
+  /** OAuth status: 'authorized' if tokens exist, undefined otherwise */
+  oauth_status?: 'authorized' | 'pending';
 }
 
 export interface IMcpTool {
@@ -25,5 +27,15 @@ export interface IMcpServerTestResponse {
   success: boolean;
   tools_count?: number;
   tools?: IMcpTool[];
+  error?: string;
+}
+
+export interface IMcpOAuthStartResponse {
+  status: 'redirect' | 'authorized';
+  authorization_url?: string;
+}
+
+export interface IMcpOAuthCallbackResponse {
+  status: 'authorized' | 'error';
   error?: string;
 }

--- a/src/operators/mcp.ts
+++ b/src/operators/mcp.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosResponse } from 'axios';
-import { IMcpServer, IMcpServerListResponse, IMcpServerTestResponse } from '@/models';
+import { IMcpServer, IMcpServerListResponse, IMcpServerTestResponse, IMcpOAuthStartResponse, IMcpOAuthCallbackResponse } from '@/models';
 import { BASE_URL_API } from '@/constants';
 
 class McpServerOperator {
@@ -63,6 +63,22 @@ class McpServerOperator {
     return await axios.post(
       '/aichat2/mcp-servers',
       { action: 'test', ...data },
+      { headers: this.getHeaders(token), baseURL: BASE_URL_API }
+    );
+  }
+
+  async oauthStart(id: string, token: string): Promise<AxiosResponse<IMcpOAuthStartResponse>> {
+    return await axios.post(
+      '/aichat2/mcp-servers',
+      { action: 'oauth_start', id },
+      { headers: this.getHeaders(token), baseURL: BASE_URL_API }
+    );
+  }
+
+  async oauthCallback(id: string, code: string, token: string): Promise<AxiosResponse<IMcpOAuthCallbackResponse>> {
+    return await axios.post(
+      '/aichat2/mcp-servers',
+      { action: 'oauth_callback', id, code },
       { headers: this.getHeaders(token), baseURL: BASE_URL_API }
     );
   }


### PR DESCRIPTION
## Summary
- Add OAuth 2.0 as a third auth type option for MCP servers (alongside None and Bearer)
- Add "Authorize" button on OAuth server cards that opens a popup for the OAuth flow
- Show green "OAuth" badge on successfully authorized servers
- Add `oauthStart()` / `oauthCallback()` API methods and `IMcpOAuthStartResponse` / `IMcpOAuthCallbackResponse` types
- Reuses existing `/chat/oauth/callback` page via `postMessage` pattern

Depends on: https://github.com/AceDataCloud/PlatformService/pull/718

## Test plan
- [ ] Select OAuth 2.0 auth type → verify hint text appears, token field hidden
- [ ] Save OAuth server → verify Authorize button shows on server card
- [ ] Click Authorize → verify popup opens with authorization URL
- [ ] Complete OAuth in popup → verify success message and OAuth badge appears
- [ ] Verify popup-blocked error shown when browser blocks the window

🤖 Generated with [Claude Code](https://claude.com/claude-code)