### PR TITLE
[codex] Add aichat2 artifact message rendering

### DIFF
--- a/src/components/chat/Message.vue
+++ b/src/components/chat/Message.vue
@@ -38,7 +38,7 @@
               />
               <file-preview
                 v-if="item.file_url"
-                :name="typeof item?.file_url === 'string' ? item.file_url : item.file_url?.url"
+                :name="item.name || (typeof item?.file_url === 'string' ? item.file_url : item.file_url?.url)"
                 :percentage="0"
                 :closable="false"
                 class="mt-2"

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -106,6 +106,8 @@ export interface IChatMessageContentItem {
   text?: string;
   image_url?: { url: string } | string;
   file_url?: { url: string } | string;
+  name?: string;
+  mimeType?: string;
   // Tool-calling fields (type='tool_use')
   tool_id?: string;
   tool_name?: string;
@@ -144,6 +146,7 @@ export interface IChatConversationOptions {
 export interface IChatConversationRequest {
   id?: string;
   question?: string;
+  message?: string | IChatMessageContentItem[];
   references?: string[];
   stateful?: boolean;
   messages?: IChatMessage[];
@@ -170,6 +173,13 @@ export interface IChatConversationResponse {
   is_error?: boolean;
   duration_ms?: number;
   content?: string;
+  artifact?: {
+    type: string;
+    url: string;
+    name: string;
+    mimeType: string;
+    size?: number;
+  };
 }
 
 export interface IChatConversationsResponse {

--- a/src/operators/chat.ts
+++ b/src/operators/chat.ts
@@ -89,7 +89,8 @@ class ChatOperator {
                     output: json.output,
                     is_error: json.is_error,
                     duration_ms: json.duration_ms,
-                    content: json.content
+                    content: json.content,
+                    artifact: json.artifact
                   });
                 }
               } catch (err) {

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -611,6 +611,22 @@ export default defineComponent({
                   toolItem.duration_ms = response.duration_ms;
                   toolItem.status = 'done';
                 }
+              } else if (response.type === 'artifact' && response.artifact) {
+                if (response.artifact.type === 'image' || response.artifact.mimeType?.startsWith('image/')) {
+                  contentParts.push({
+                    type: 'image_url',
+                    image_url: response.artifact.url,
+                    name: response.artifact.name,
+                    mimeType: response.artifact.mimeType
+                  });
+                } else {
+                  contentParts.push({
+                    type: 'file_url',
+                    file_url: response.artifact.url,
+                    name: response.artifact.name,
+                    mimeType: response.artifact.mimeType
+                  });
+                }
               } else if (response.delta_answer) {
                 currentText = response.answer;
               }
@@ -621,7 +637,7 @@ export default defineComponent({
                 displayParts.push({ type: 'text', text: currentText });
               }
 
-              if (displayParts.length > 0 && displayParts.some((p) => p.type === 'tool_use')) {
+              if (displayParts.length > 0) {
                 this.messages[this.messages.length - 1] = {
                   role: ROLE_ASSISTANT,
                   content: displayParts,


### PR DESCRIPTION
## Summary
- extend chat content typing to carry artifact metadata and direct structured `message` payloads
- forward `artifact` SSE events through the chat operator and render them in the conversation stream as image/file blocks
- show file artifact names in the message preview UI instead of falling back to the raw URL

## Validation
- `cd Nexior && npx vue-tsc -b`
