### PR TITLE
[codex] Sync published Nexior version to 3.34.0

### DIFF
--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -2,6 +2,43 @@
   "name": "@acedatacloud/nexior",
   "entries": [
     {
+      "date": "Sun, 19 Apr 2026 03:30:51 GMT",
+      "version": "3.34.0",
+      "tag": "@acedatacloud/nexior_v3.34.0",
+      "comments": {
+        "none": [
+          {
+            "author": "dev@acedata.cloud",
+            "package": "@acedatacloud/nexior",
+            "commit": "19ef4aeeb5c2fe4d34758982279fabd6ce8d89ab",
+            "comment": "fix: resolve publish version conflict with npm registry"
+          }
+        ],
+        "minor": [
+          {
+            "author": "cqc@cuiqingcai.com",
+            "package": "@acedatacloud/nexior",
+            "commit": "71654c1546c4b3dfca2264c415209ea780e70dd5",
+            "comment": "feat(kling): add kling-v3, v3-omni, v2-6 model support"
+          },
+          {
+            "author": "dev@acedata.cloud",
+            "package": "@acedatacloud/nexior",
+            "commit": "71654c1546c4b3dfca2264c415209ea780e70dd5",
+            "comment": "feat(kling): add kling-v3, v3-omni, v2-6 model support with generate audio toggle"
+          }
+        ],
+        "patch": [
+          {
+            "author": "dev@acedata.cloud",
+            "package": "@acedatacloud/nexior",
+            "commit": "7479b6a0ae9cc472316fb8b90c599b9f34bc6c66",
+            "comment": "fix: remove 3 broken GLM models from frontend"
+          }
+        ]
+      }
+    },
+    {
       "date": "Sun, 05 Apr 2026 13:15:16 GMT",
       "version": "3.32.9",
       "tag": "@acedatacloud/nexior_v3.32.9",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,21 @@
 # Change Log - @acedatacloud/nexior
 
-<!-- This log was last generated on Sun, 05 Apr 2026 13:15:16 GMT and should not be manually modified. -->
+<!-- This log was last generated on Sun, 19 Apr 2026 03:30:51 GMT and should not be manually modified. -->
 
 <!-- Start content -->
+
+## 3.34.0
+
+Sun, 19 Apr 2026 03:30:51 GMT
+
+### Minor changes
+
+- feat(kling): add kling-v3, v3-omni, v2-6 model support (cqc@cuiqingcai.com)
+- feat(kling): add kling-v3, v3-omni, v2-6 model support with generate audio toggle (dev@acedata.cloud)
+
+### Patches
+
+- fix: remove 3 broken GLM models from frontend (dev@acedata.cloud)
 
 ## 3.32.9
 

--- a/change/@acedatacloud-nexior-c23e09b0-33b6-4fcb-9f10-515dcbaec22b.json
+++ b/change/@acedatacloud-nexior-c23e09b0-33b6-4fcb-9f10-515dcbaec22b.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "feat(kling): add kling-v3, v3-omni, v2-6 model support",
-  "packageName": "@acedatacloud/nexior",
-  "email": "cqc@cuiqingcai.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@acedatacloud-nexior-db8ef0db-de4b-4451-88e4-5c0c43bf3b29.json
+++ b/change/@acedatacloud-nexior-db8ef0db-de4b-4451-88e4-5c0c43bf3b29.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "feat(kling): add kling-v3, v3-omni, v2-6 model support with generate audio toggle",
-  "packageName": "@acedatacloud/nexior",
-  "email": "dev@acedata.cloud",
-  "dependentChangeType": "patch"
-}

--- a/change/fix-disable-broken-glm-models.json
+++ b/change/fix-disable-broken-glm-models.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "fix: remove 3 broken GLM models from frontend",
-  "packageName": "@acedatacloud/nexior",
-  "email": "dev@acedata.cloud",
-  "dependentChangeType": "patch"
-}

--- a/change/fix-publish-version-conflict.json
+++ b/change/fix-publish-version-conflict.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "fix: resolve publish version conflict with npm registry",
-  "packageName": "@acedatacloud/nexior",
-  "email": "dev@acedata.cloud",
-  "dependentChangeType": "none"
-}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acedatacloud/nexior",
-  "version": "3.33.0",
+  "version": "3.34.0",
   "author": "Ace Data Cloud <office@acedata.cloud>",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- sync the repo release state to the already-published `@acedatacloud/nexior@3.34.0`
- remove the consumed change files and record the 3.34.0 changelog entry
- unblock the `publish` workflow on `main`, which was repeatedly trying to republish an existing version

## Validation
- `cd Nexior && npx vue-tsc -b`
- `cd Nexior && npm run build:web`
- `cd Nexior && yarn --ignore-engines verify`
