### PR TITLE
[codex] Surface streaming chat SSE errors

### DIFF
--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -165,6 +165,7 @@ export interface IChatConversationResponse {
   id?: string;
   // aichat2 tool-calling event fields
   type?: string;
+  message?: string;
   tool_id?: string;
   tool_name?: string;
   tool_display_name?: string;

--- a/src/operators/chat.ts
+++ b/src/operators/chat.ts
@@ -75,6 +75,13 @@ class ChatOperator {
                 if (json.id) {
                   id = json.id;
                 }
+                if (json.type === 'error') {
+                  const errorMessage =
+                    typeof json.message === 'string' && json.message.trim() ? json.message.trim() : 'An error occurred';
+                  await reader.cancel().catch(() => undefined);
+                  reject(new BaseError(500, ERROR_CODE_API_ERROR, errorMessage));
+                  return;
+                }
                 if (options?.stream) {
                   options.stream({
                     answer: finalAnswer,
@@ -82,6 +89,7 @@ class ChatOperator {
                     id,
                     // Forward aichat2 event types for tool-calling UI
                     type: json.type,
+                    message: json.message,
                     tool_id: json.tool_id,
                     tool_name: json.tool_name,
                     tool_display_name: json.tool_display_name,


### PR DESCRIPTION
## Summary\n- forward SSE error messages through the chat operator response shape\n- reject the streaming conversation promise when the backend emits an error event\n- let the existing chat failure path render a visible error instead of leaving an empty assistant bubble\n\n## Validation\n- cd Nexior && npx vue-tsc -b\n- cd Nexior && npm run build:web\n\n## Online E2E finding\nA real Playwright upload flow against https://hub.acedata.cloud showed the backend returning an SSE error event. Before this patch the frontend dropped the message field and resolved the stream as if it had succeeded, leaving a blank assistant response.