### PR TITLE
[codex] Gate chat submit on init-ready state

### DIFF
--- a/src/components/chat/Composer.vue
+++ b/src/components/chat/Composer.vue
@@ -44,7 +44,7 @@
       </el-upload>
     </div>
     <el-button
-      :disabled="answering || !questionValue || uploading"
+      :disabled="answering || !questionValue || uploading || !ready"
       type="primary"
       :class="{
         btn: true,
@@ -103,6 +103,11 @@ export default defineComponent({
       type: Boolean,
       required: false,
       default: false
+    },
+    ready: {
+      type: Boolean,
+      required: false,
+      default: true
     },
     references: {
       type: Array,
@@ -200,7 +205,7 @@ export default defineComponent({
       });
     },
     onSubmit() {
-      if (!this.question || this.uploading) {
+      if (!this.question || this.uploading || !this.ready) {
         return;
       }
       this.$emit('submit');

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -71,6 +71,7 @@
           <composer
             v-model:question="question"
             :answering="answering"
+            :ready="ready"
             :references="references"
             @update:references="references = $event"
             @submit="onSubmit"
@@ -205,6 +206,11 @@ export default defineComponent({
     },
     initializing() {
       return this.$store.state.chat.status.getApplications === Status.Request;
+    },
+    ready(): boolean {
+      // Disable sending until token/application/credential are all initialized,
+      // otherwise the first submit races init and hits `You have not applied for this service...`.
+      return !this.initializing && !!this.credential?.token && !!this.application;
     },
     enabledMcpCount(): number {
       return this.mcpServers.filter((s: IMcpServer) => s.is_enabled).length;


### PR DESCRIPTION
## Problem

During live E2E testing on https://hub.acedata.cloud, submitting a message immediately after the chat page loads occasionally produced `You have not applied for this service...`. The send button was clickable before the application/credential bootstrap finished, racing the first submit against store initialization.

## Fix

- Add a `ready` prop to `Composer` that disables the submit button and the `onSubmit` method when the parent is not yet ready.
- In `Conversation.vue`, compute `ready` as `!initializing && !!credential?.token && !!application` and pass it through.

## Verification

```
npx vue-tsc -b
```

passes.

Resumes the live E2E remediation from the aichat2 redesign (see earlier PRs #450, #451, #452).
