### PR TITLE
fix(chat): load skills on first open and allow creating/deleting custom skills

### DIFF
--- a/src/components/chat/SkillManager.vue
+++ b/src/components/chat/SkillManager.vue
@@ -1,6 +1,13 @@
 <template>
-  <el-dialog v-model="visible" :title="$t('chat.skill.title')" width="560px" :close-on-click-modal="false">
-    <div v-loading="loading" class="skill-manager">
+  <el-dialog v-model="visible" :title="$t('chat.skill.title')" width="620px" :close-on-click-modal="false">
+    <!-- List view -->
+    <div v-if="mode === 'list'" v-loading="loading" class="skill-manager">
+      <div class="toolbar-row">
+        <el-button type="primary" size="small" @click="openCreate">
+          <font-awesome-icon icon="fa-solid fa-plus" class="btn-icon" />
+          {{ $t('chat.skill.add') }}
+        </el-button>
+      </div>
       <div v-for="skill in skills" :key="skill.id" class="skill-item">
         <div class="skill-header">
           <span class="skill-icon">{{ skill.icon }}</span>
@@ -11,7 +18,20 @@
             </el-tag>
             <el-tag v-for="tag in skill.tags.slice(0, 2)" :key="tag" size="small" class="skill-tag">{{ tag }}</el-tag>
           </div>
-          <el-switch :model-value="isActive(skill.id)" @change="(val: string | number | boolean) => onToggle(skill.id, !!val)" />
+          <el-switch
+            :model-value="isActive(skill.id)"
+            @change="(val: string | number | boolean) => onToggle(skill.id, !!val)"
+          />
+          <el-button
+            v-if="!skill.is_builtin"
+            text
+            size="small"
+            class="skill-delete"
+            :title="$t('chat.skill.delete')"
+            @click="onDelete(skill)"
+          >
+            <font-awesome-icon icon="fa-solid fa-trash" />
+          </el-button>
         </div>
         <p class="skill-description">{{ skill.description }}</p>
       </div>
@@ -19,18 +39,128 @@
         <p>{{ $t('chat.skill.empty') }}</p>
       </div>
     </div>
+
+    <!-- Create view -->
+    <div v-else class="skill-form">
+      <el-form label-position="top" :model="form" @submit.prevent>
+        <el-form-item :label="$t('chat.skill.form.name')" required>
+          <el-input v-model="form.name" :placeholder="$t('chat.skill.form.namePlaceholder')" />
+        </el-form-item>
+        <el-form-item :label="$t('chat.skill.form.displayName')">
+          <el-input v-model="form.display_name" :placeholder="$t('chat.skill.form.displayNamePlaceholder')" />
+        </el-form-item>
+        <el-form-item :label="$t('chat.skill.form.icon')">
+          <el-input v-model="form.icon" maxlength="4" style="width: 120px" />
+        </el-form-item>
+        <el-form-item :label="$t('chat.skill.form.description')">
+          <el-input v-model="form.description" type="textarea" :rows="2" />
+        </el-form-item>
+        <el-form-item :label="$t('chat.skill.form.type')">
+          <el-radio-group v-model="form.type">
+            <el-radio value="prompt">{{ $t('chat.skill.form.typePrompt') }}</el-radio>
+            <el-radio value="code">{{ $t('chat.skill.form.typeCode') }}</el-radio>
+          </el-radio-group>
+        </el-form-item>
+        <el-form-item v-if="form.type === 'prompt'" :label="$t('chat.skill.form.instructions')" required>
+          <el-input
+            v-model="form.instructions"
+            type="textarea"
+            :rows="6"
+            :placeholder="$t('chat.skill.form.instructionsPlaceholder')"
+          />
+          <div class="upload-hint">
+            <el-button size="small" @click="onPickFile">
+              <font-awesome-icon icon="fa-solid fa-upload" class="btn-icon" />
+              {{ $t('chat.skill.form.uploadText') }}
+            </el-button>
+            <input ref="fileInput" type="file" accept=".txt,.md,.prompt" style="display: none" @change="onFilePicked" />
+          </div>
+        </el-form-item>
+        <el-form-item v-else :label="$t('chat.skill.form.code')" required>
+          <el-input
+            v-model="form.code"
+            type="textarea"
+            :rows="8"
+            :placeholder="$t('chat.skill.form.codePlaceholder')"
+          />
+          <div class="upload-hint">
+            <el-button size="small" @click="onPickFile">
+              <font-awesome-icon icon="fa-solid fa-upload" class="btn-icon" />
+              {{ $t('chat.skill.form.uploadCode') }}
+            </el-button>
+            <input ref="fileInput" type="file" accept=".js,.ts,.py,.txt" style="display: none" @change="onFilePicked" />
+          </div>
+        </el-form-item>
+        <el-form-item :label="$t('chat.skill.form.tags')">
+          <el-input v-model="form.tagsText" :placeholder="$t('chat.skill.form.tagsPlaceholder')" />
+        </el-form-item>
+      </el-form>
+    </div>
+
+    <template v-if="mode === 'create'" #footer>
+      <el-button @click="mode = 'list'">{{ $t('common.button.cancel') }}</el-button>
+      <el-button type="primary" :loading="saving" @click="onSave">
+        {{ $t('common.button.create') }}
+      </el-button>
+    </template>
   </el-dialog>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElDialog, ElSwitch, ElTag, ElMessage } from 'element-plus';
+import {
+  ElDialog,
+  ElSwitch,
+  ElTag,
+  ElButton,
+  ElMessage,
+  ElMessageBox,
+  ElForm,
+  ElFormItem,
+  ElInput,
+  ElRadioGroup,
+  ElRadio
+} from 'element-plus';
 import { skillOperator } from '@/operators';
-import { ISkill } from '@/models';
+import { ISkill, ISkillType } from '@/models';
+
+interface CreateForm {
+  name: string;
+  display_name: string;
+  icon: string;
+  description: string;
+  type: ISkillType;
+  instructions: string;
+  code: string;
+  tagsText: string;
+}
+
+function emptyForm(): CreateForm {
+  return {
+    name: '',
+    display_name: '',
+    icon: '⚡',
+    description: '',
+    type: 'prompt',
+    instructions: '',
+    code: '',
+    tagsText: ''
+  };
+}
 
 export default defineComponent({
   name: 'SkillManager',
-  components: { ElDialog, ElSwitch, ElTag },
+  components: {
+    ElDialog,
+    ElSwitch,
+    ElTag,
+    ElButton,
+    ElForm,
+    ElFormItem,
+    ElInput,
+    ElRadioGroup,
+    ElRadio
+  },
   props: {
     modelValue: { type: Boolean, default: false },
     activeSkills: { type: Array as () => string[], default: () => [] },
@@ -40,7 +170,10 @@ export default defineComponent({
   data() {
     return {
       loading: false,
-      skills: [] as ISkill[]
+      saving: false,
+      skills: [] as ISkill[],
+      mode: 'list' as 'list' | 'create',
+      form: emptyForm()
     };
   },
   computed: {
@@ -54,10 +187,19 @@ export default defineComponent({
     }
   },
   watch: {
-    modelValue(val: boolean) {
-      if (val) {
-        this.loadData();
+    modelValue: {
+      immediate: true,
+      handler(val: boolean) {
+        if (val) {
+          this.mode = 'list';
+          this.loadData();
+        }
       }
+    }
+  },
+  mounted() {
+    if (this.modelValue) {
+      this.loadData();
     }
   },
   methods: {
@@ -80,6 +222,102 @@ export default defineComponent({
     onToggle(skillId: string, active: boolean) {
       const updated = active ? [...this.activeSkills, skillId] : this.activeSkills.filter((id) => id !== skillId);
       this.$emit('change', updated);
+    },
+    openCreate() {
+      this.form = emptyForm();
+      this.mode = 'create';
+    },
+    onPickFile() {
+      const el = this.$refs.fileInput as HTMLInputElement | undefined;
+      el?.click();
+    },
+    onFilePicked(ev: Event) {
+      const input = ev.target as HTMLInputElement;
+      const file = input.files?.[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = () => {
+        const text = String(reader.result ?? '');
+        if (this.form.type === 'prompt') {
+          this.form.instructions = text;
+        } else {
+          this.form.code = text;
+        }
+        if (!this.form.name) {
+          this.form.name = file.name.replace(/\.[^.]+$/, '');
+        }
+      };
+      reader.readAsText(file);
+      input.value = '';
+    },
+    async onSave() {
+      const token = this.token;
+      if (!token) return;
+      const f = this.form;
+      if (!f.name.trim()) {
+        ElMessage.warning(this.$t('chat.skill.form.nameRequired'));
+        return;
+      }
+      if (f.type === 'prompt' && !f.instructions.trim()) {
+        ElMessage.warning(this.$t('chat.skill.form.instructionsRequired'));
+        return;
+      }
+      if (f.type === 'code' && !f.code.trim()) {
+        ElMessage.warning(this.$t('chat.skill.form.codeRequired'));
+        return;
+      }
+      const tags = f.tagsText
+        .split(',')
+        .map((t) => t.trim())
+        .filter(Boolean);
+      const payload: Partial<ISkill> = {
+        name: f.name.trim(),
+        display_name: f.display_name.trim() || f.name.trim(),
+        description: f.description.trim(),
+        icon: f.icon.trim() || '⚡',
+        type: f.type,
+        tags
+      };
+      if (f.type === 'prompt') payload.instructions = f.instructions;
+      else payload.code = f.code;
+
+      this.saving = true;
+      try {
+        await skillOperator.create(payload, token);
+        ElMessage.success(this.$t('chat.skill.createSuccess'));
+        this.mode = 'list';
+        await this.loadData();
+      } catch {
+        ElMessage.error(this.$t('chat.skill.createError'));
+      } finally {
+        this.saving = false;
+      }
+    },
+    async onDelete(skill: ISkill) {
+      const token = this.token;
+      if (!token) return;
+      try {
+        await ElMessageBox.confirm(
+          this.$t('chat.skill.deleteConfirm', { name: skill.display_name }) as string,
+          this.$t('chat.skill.delete') as string,
+          { type: 'warning' }
+        );
+      } catch {
+        return;
+      }
+      try {
+        await skillOperator.remove(skill.id, token);
+        ElMessage.success(this.$t('chat.skill.deleteSuccess'));
+        if (this.activeSkills.includes(skill.id)) {
+          this.$emit(
+            'change',
+            this.activeSkills.filter((id) => id !== skill.id)
+          );
+        }
+        await this.loadData();
+      } catch {
+        ElMessage.error(this.$t('chat.skill.deleteError'));
+      }
     }
   }
 });
@@ -88,6 +326,16 @@ export default defineComponent({
 <style scoped lang="scss">
 .skill-manager {
   min-height: 120px;
+}
+
+.toolbar-row {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 12px;
+}
+
+.btn-icon {
+  margin-right: 4px;
 }
 
 .skill-item {
@@ -130,6 +378,10 @@ export default defineComponent({
   font-size: 11px;
 }
 
+.skill-delete {
+  color: var(--el-color-danger);
+}
+
 .skill-description {
   margin: 8px 0 0;
   font-size: 13px;
@@ -141,5 +393,11 @@ export default defineComponent({
   text-align: center;
   padding: 40px 0;
   color: var(--el-text-color-secondary);
+}
+
+.skill-form {
+  .upload-hint {
+    margin-top: 6px;
+  }
 }
 </style>

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -95,6 +95,30 @@
     "message": "Faster and lighter GPT 5 model",
     "description": "Description of the GPT 5 Mini model"
   },
+  "model.54": {
+    "message": "gpt-5.4",
+    "description": "Name of the service model, i.e., GPT 5.4"
+  },
+  "model.54Description": {
+    "message": "Latest flagship GPT 5.4 model",
+    "description": "Description of the GPT 5.4 model"
+  },
+  "model.54Mini": {
+    "message": "gpt-5.4-mini",
+    "description": "Name of the service model, i.e., GPT 5.4 Mini"
+  },
+  "model.54MiniDescription": {
+    "message": "Faster and lighter GPT 5.4 model",
+    "description": "Description of the GPT 5.4 Mini model"
+  },
+  "model.54Nano": {
+    "message": "gpt-5.4-nano",
+    "description": "Name of the service model, i.e., GPT 5.4 Nano"
+  },
+  "model.54NanoDescription": {
+    "message": "Smallest and fastest GPT 5.4 model",
+    "description": "Description of the GPT 5.4 Nano model"
+  },
   "model.4O": {
     "message": "gpt-4o",
     "description": "Name of the service model, i.e., GPT 4.0 Vision"
@@ -682,6 +706,114 @@
   "skill.loadError": {
     "message": "Failed to load skills",
     "description": "Skill load error message"
+  },
+  "skill.add": {
+    "message": "Add Skill",
+    "description": "Add skill button label"
+  },
+  "skill.delete": {
+    "message": "Delete",
+    "description": "Delete skill button label"
+  },
+  "skill.deleteConfirm": {
+    "message": "Delete skill \"{name}\"? This cannot be undone.",
+    "description": "Confirm message before deleting a skill"
+  },
+  "skill.deleteSuccess": {
+    "message": "Skill deleted",
+    "description": "Delete skill success message"
+  },
+  "skill.deleteError": {
+    "message": "Failed to delete skill",
+    "description": "Delete skill error message"
+  },
+  "skill.createSuccess": {
+    "message": "Skill created",
+    "description": "Create skill success message"
+  },
+  "skill.createError": {
+    "message": "Failed to create skill",
+    "description": "Create skill error message"
+  },
+  "skill.form.name": {
+    "message": "Name",
+    "description": "Skill form name label"
+  },
+  "skill.form.namePlaceholder": {
+    "message": "e.g. summarizer",
+    "description": "Skill form name placeholder"
+  },
+  "skill.form.nameRequired": {
+    "message": "Name is required",
+    "description": "Skill form name required message"
+  },
+  "skill.form.displayName": {
+    "message": "Display name",
+    "description": "Skill form display name label"
+  },
+  "skill.form.displayNamePlaceholder": {
+    "message": "Shown in the skill list",
+    "description": "Skill form display name placeholder"
+  },
+  "skill.form.icon": {
+    "message": "Icon (emoji)",
+    "description": "Skill form icon label"
+  },
+  "skill.form.description": {
+    "message": "Description",
+    "description": "Skill form description label"
+  },
+  "skill.form.type": {
+    "message": "Type",
+    "description": "Skill form type label"
+  },
+  "skill.form.typePrompt": {
+    "message": "Prompt",
+    "description": "Prompt type label"
+  },
+  "skill.form.typeCode": {
+    "message": "Code",
+    "description": "Code type label"
+  },
+  "skill.form.instructions": {
+    "message": "Instructions",
+    "description": "Prompt instructions label"
+  },
+  "skill.form.instructionsPlaceholder": {
+    "message": "Paste or write the prompt/instructions for this skill...",
+    "description": "Prompt instructions placeholder"
+  },
+  "skill.form.instructionsRequired": {
+    "message": "Instructions are required for prompt skills",
+    "description": "Prompt instructions required message"
+  },
+  "skill.form.code": {
+    "message": "Code",
+    "description": "Code skill label"
+  },
+  "skill.form.codePlaceholder": {
+    "message": "Paste the code for this skill...",
+    "description": "Code skill placeholder"
+  },
+  "skill.form.codeRequired": {
+    "message": "Code is required for code skills",
+    "description": "Code skill required message"
+  },
+  "skill.form.tags": {
+    "message": "Tags",
+    "description": "Skill form tags label"
+  },
+  "skill.form.tagsPlaceholder": {
+    "message": "Comma-separated, e.g. writing, coding",
+    "description": "Skill form tags placeholder"
+  },
+  "skill.form.uploadText": {
+    "message": "Upload .txt / .md",
+    "description": "Upload prompt file button"
+  },
+  "skill.form.uploadCode": {
+    "message": "Upload file",
+    "description": "Upload code file button"
   },
   "agent.title": {
     "message": "Desktop Agent",

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -95,6 +95,30 @@
     "message": "更快更轻量的 GPT 5 模型",
     "description": "GPT 5 Mini 模型的描述"
   },
+  "model.54": {
+    "message": "gpt-5.4",
+    "description": "服务的模型名称，即 GPT 5.4"
+  },
+  "model.54Description": {
+    "message": "最新一代旗舰 GPT 5.4 模型",
+    "description": "GPT 5.4 模型的描述"
+  },
+  "model.54Mini": {
+    "message": "gpt-5.4-mini",
+    "description": "服务的模型名称，即 GPT 5.4 Mini"
+  },
+  "model.54MiniDescription": {
+    "message": "更快更轻量的 GPT 5.4 模型",
+    "description": "GPT 5.4 Mini 模型的描述"
+  },
+  "model.54Nano": {
+    "message": "gpt-5.4-nano",
+    "description": "服务的模型名称，即 GPT 5.4 Nano"
+  },
+  "model.54NanoDescription": {
+    "message": "最小、最快的 GPT 5.4 模型",
+    "description": "GPT 5.4 Nano 模型的描述"
+  },
   "model.4O": {
     "message": "gpt-4o",
     "description": "服务的模型名称，即 GPT 4.0 视觉"
@@ -682,6 +706,114 @@
   "skill.loadError": {
     "message": "加载技能失败",
     "description": "技能加载失败提示"
+  },
+  "skill.add": {
+    "message": "添加技能",
+    "description": "Add skill button label"
+  },
+  "skill.delete": {
+    "message": "删除",
+    "description": "Delete skill button label"
+  },
+  "skill.deleteConfirm": {
+    "message": "确认删除技能「{name}」？此操作无法撤销。",
+    "description": "Confirm message before deleting a skill"
+  },
+  "skill.deleteSuccess": {
+    "message": "已删除",
+    "description": "Delete skill success message"
+  },
+  "skill.deleteError": {
+    "message": "删除失败",
+    "description": "Delete skill error message"
+  },
+  "skill.createSuccess": {
+    "message": "技能已创建",
+    "description": "Create skill success message"
+  },
+  "skill.createError": {
+    "message": "创建技能失败",
+    "description": "Create skill error message"
+  },
+  "skill.form.name": {
+    "message": "名称",
+    "description": "Skill form name label"
+  },
+  "skill.form.namePlaceholder": {
+    "message": "例如 summarizer",
+    "description": "Skill form name placeholder"
+  },
+  "skill.form.nameRequired": {
+    "message": "请填写名称",
+    "description": "Skill form name required message"
+  },
+  "skill.form.displayName": {
+    "message": "显示名称",
+    "description": "Skill form display name label"
+  },
+  "skill.form.displayNamePlaceholder": {
+    "message": "在技能列表中展示的名称",
+    "description": "Skill form display name placeholder"
+  },
+  "skill.form.icon": {
+    "message": "图标（emoji）",
+    "description": "Skill form icon label"
+  },
+  "skill.form.description": {
+    "message": "描述",
+    "description": "Skill form description label"
+  },
+  "skill.form.type": {
+    "message": "类型",
+    "description": "Skill form type label"
+  },
+  "skill.form.typePrompt": {
+    "message": "提示词",
+    "description": "Prompt type label"
+  },
+  "skill.form.typeCode": {
+    "message": "代码",
+    "description": "Code type label"
+  },
+  "skill.form.instructions": {
+    "message": "提示词内容",
+    "description": "Prompt instructions label"
+  },
+  "skill.form.instructionsPlaceholder": {
+    "message": "粘贴或编写该技能对应的提示词 / 指令...",
+    "description": "Prompt instructions placeholder"
+  },
+  "skill.form.instructionsRequired": {
+    "message": "提示词类型必须填写提示词内容",
+    "description": "Prompt instructions required message"
+  },
+  "skill.form.code": {
+    "message": "代码",
+    "description": "Code skill label"
+  },
+  "skill.form.codePlaceholder": {
+    "message": "粘贴该技能对应的代码...",
+    "description": "Code skill placeholder"
+  },
+  "skill.form.codeRequired": {
+    "message": "代码类型必须填写代码",
+    "description": "Code skill required message"
+  },
+  "skill.form.tags": {
+    "message": "标签",
+    "description": "Skill form tags label"
+  },
+  "skill.form.tagsPlaceholder": {
+    "message": "用逗号分隔，如：写作, 编程",
+    "description": "Skill form tags placeholder"
+  },
+  "skill.form.uploadText": {
+    "message": "上传 .txt / .md 文件",
+    "description": "Upload prompt file button"
+  },
+  "skill.form.uploadCode": {
+    "message": "上传代码文件",
+    "description": "Upload code file button"
   },
   "agent.title": {
     "message": "桌面代理",


### PR DESCRIPTION
## Problem

In Nexior the **AI Skills** dialog has two issues:

1. **Skills don't show up on first open.** The `SkillManager` dialog is mounted via `v-if="skillManagerVisible"`, so the component is created with `modelValue=true`. The `watch: { modelValue }` watcher never fires for the initial value, so `loadData()` was never called — users saw an empty list even when they had custom skills.
2. **No way to add/upload a skill.** The dialog was read-only (list + toggle). The backend (`PlatformService/aichat2` `/skills`) already supports `create` / `update` / `delete`, but there was no UI for it.

## Fix

- Switch the watcher to `immediate: true` and add a `mounted()` fallback so the skill list loads on first open.
- Add an **Add Skill** button that switches the dialog into a create form.
  - Supports `prompt` and `code` skill types (workflow still available via API).
  - Fields: name, display name, icon (emoji), description, type, instructions / code, tags.
  - Optional **Upload file** button reads `.txt` / `.md` / `.js` / `.ts` / `.py` into the instructions / code textarea.
- Add **Delete** action on each user-owned skill (built-ins are not deletable), with a confirmation dialog. When deleting an active skill, also remove it from `activeSkills`.
- Added English and zh-CN i18n strings (only these two languages, per project policy).

## Testing

- `npx vue-tsc --noEmit` — clean.
- `npx eslint src/components/chat/SkillManager.vue` — clean.