### PR TITLE
feat(nexior): paste images directly into upload fields

### DIFF
--- a/src/components/chat/Composer.vue
+++ b/src/components/chat/Composer.vue
@@ -2,6 +2,7 @@
   <div class="composer">
     <div class="tools">
       <el-upload
+        ref="uploader"
         v-model:file-list="fileList"
         :class="{
           upload: true,
@@ -84,7 +85,7 @@ import { defineComponent } from 'vue';
 import { ElMessage, ElTooltip, ElUpload, UploadFile, UploadProgressEvent, ElButton } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { IChatModel } from '@/models';
-import { getBaseUrlPlatform, isImageUrl } from '@/utils';
+import { getBaseUrlPlatform, isImageUrl, pasteUploadMixin } from '@/utils';
 import FilePreview from '@/components/common/FilePreview.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 
@@ -98,6 +99,7 @@ export default defineComponent({
     ElUpload,
     ElButton
   },
+  mixins: [pasteUploadMixin],
   props: {
     answering: {
       type: Boolean,
@@ -161,6 +163,12 @@ export default defineComponent({
         return '.png,.jpg,.jpeg,.gif,.bmp,.webp,.svg,.tiff,.ico,.heic';
       }
       return undefined;
+    },
+    pasteAccept(): string {
+      // Restrict clipboard paste to images (still useful even when other file
+      // types are supported). The upload control itself will continue to
+      // accept anything via the file picker.
+      return '.png,.jpg,.jpeg,.gif,.bmp,.webp,.svg,.tiff,.ico,.heic,image/*';
     }
   },
   watch: {

--- a/src/components/flux/config/ImageUrlInput.vue
+++ b/src/components/flux/config/ImageUrlInput.vue
@@ -7,6 +7,7 @@
       </div>
     </div>
     <el-upload
+      ref="uploader"
       v-model:file-list="fileList"
       name="file"
       :limit="5"
@@ -39,7 +40,7 @@
 import { defineComponent } from 'vue';
 import { ElUpload, ElButton, UploadFiles, UploadFile, ElMessage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 
@@ -57,6 +58,7 @@ export default defineComponent({
     FontAwesomeIcon,
     ImagePreview
   },
+  mixins: [pasteUploadMixin],
   emits: ['change'],
   data(): IData {
     return {

--- a/src/components/hailuo/config/StartImageUrlInput.vue
+++ b/src/components/hailuo/config/StartImageUrlInput.vue
@@ -7,6 +7,7 @@
       </div>
     </div>
     <el-upload
+      ref="uploader"
       v-model:file-list="fileList"
       accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
       name="file"
@@ -40,7 +41,7 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import { ElButton, ElUpload, ElMessage, UploadFiles, UploadFile } from 'element-plus';
-import { getBaseUrlPlatform } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 
@@ -59,6 +60,7 @@ export default defineComponent({
     InfoIcon,
     ImagePreview
   },
+  mixins: [pasteUploadMixin],
   data(): IData {
     return {
       fileList: [],

--- a/src/components/headshots/config/ImageUrlsInput.vue
+++ b/src/components/headshots/config/ImageUrlsInput.vue
@@ -3,6 +3,7 @@
     <h2 class="title font-bold">{{ $t('headshots.name.endImageUrls') }}</h2>
     <div class="upload-wrapper">
       <el-upload
+        ref="uploader"
         v-model:file-list="fileList"
         accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
         name="file"
@@ -38,7 +39,7 @@
 import { defineComponent } from 'vue';
 import { ElButton, ElUpload, ElMessage, UploadFiles } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 export const DEFAULT_CONTENT = '';
@@ -57,6 +58,7 @@ export default defineComponent({
     ImagePreview,
     FontAwesomeIcon
   },
+  mixins: [pasteUploadMixin],
   data(): IData {
     return {
       fileList: [],

--- a/src/components/kling/config/EndImage.vue
+++ b/src/components/kling/config/EndImage.vue
@@ -7,6 +7,7 @@
       </div>
     </div>
     <el-upload
+      ref="uploader"
       v-model:file-list="fileList"
       name="file"
       accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
@@ -41,7 +42,7 @@
 import { defineComponent } from 'vue';
 import { ElUpload, ElButton, UploadFiles, UploadFile, ElMessage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 
@@ -59,6 +60,7 @@ export default defineComponent({
     InfoIcon,
     FontAwesomeIcon
   },
+  mixins: [pasteUploadMixin],
   data(): IData {
     return {
       fileList: [],

--- a/src/components/kling/config/StartImage.vue
+++ b/src/components/kling/config/StartImage.vue
@@ -7,6 +7,7 @@
       </div>
     </div>
     <el-upload
+      ref="uploader"
       v-model:file-list="fileList"
       name="file"
       accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
@@ -41,7 +42,7 @@
 import { defineComponent } from 'vue';
 import { ElUpload, ElButton, UploadFiles, UploadFile, ElMessage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 
@@ -59,6 +60,7 @@ export default defineComponent({
     FontAwesomeIcon,
     ImagePreview
   },
+  mixins: [pasteUploadMixin],
   emits: ['change'],
   data(): IData {
     return {

--- a/src/components/luma/config/EndImageInput.vue
+++ b/src/components/luma/config/EndImageInput.vue
@@ -7,6 +7,7 @@
       </div>
     </div>
     <el-upload
+      ref="uploader"
       v-model:file-list="fileList"
       name="file"
       accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
@@ -41,7 +42,7 @@
 import { defineComponent } from 'vue';
 import { ElUpload, ElButton, UploadFiles, UploadFile, ElMessage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 
@@ -59,6 +60,7 @@ export default defineComponent({
     InfoIcon,
     FontAwesomeIcon
   },
+  mixins: [pasteUploadMixin],
   data(): IData {
     return {
       fileList: [],

--- a/src/components/luma/config/StartImageInput.vue
+++ b/src/components/luma/config/StartImageInput.vue
@@ -7,6 +7,7 @@
       </div>
     </div>
     <el-upload
+      ref="uploader"
       v-model:file-list="fileList"
       name="file"
       accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
@@ -41,7 +42,7 @@
 import { defineComponent } from 'vue';
 import { ElUpload, ElButton, UploadFiles, UploadFile, ElMessage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 
@@ -59,6 +60,7 @@ export default defineComponent({
     InfoIcon,
     FontAwesomeIcon
   },
+  mixins: [pasteUploadMixin],
   data(): IData {
     return {
       fileList: [],

--- a/src/components/midjourney/config/EndImageUrlInput.vue
+++ b/src/components/midjourney/config/EndImageUrlInput.vue
@@ -7,6 +7,7 @@
       </div>
     </div>
     <el-upload
+      ref="uploader"
       v-model:file-list="fileList"
       name="file"
       :limit="5"
@@ -39,7 +40,7 @@
 import { defineComponent } from 'vue';
 import { ElUpload, ElButton, UploadFiles, UploadFile, ElMessage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 
@@ -57,6 +58,7 @@ export default defineComponent({
     FontAwesomeIcon,
     ImagePreview
   },
+  mixins: [pasteUploadMixin],
   emits: ['change'],
   data(): IData {
     return {

--- a/src/components/midjourney/config/ImageUrlInput.vue
+++ b/src/components/midjourney/config/ImageUrlInput.vue
@@ -7,6 +7,7 @@
       </div>
     </div>
     <el-upload
+      ref="uploader"
       v-model:file-list="fileList"
       name="file"
       :limit="5"
@@ -39,7 +40,7 @@
 import { defineComponent } from 'vue';
 import { ElUpload, ElButton, UploadFiles, UploadFile, ElMessage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 
@@ -57,6 +58,7 @@ export default defineComponent({
     FontAwesomeIcon,
     ImagePreview
   },
+  mixins: [pasteUploadMixin],
   emits: ['change'],
   data(): IData {
     return {

--- a/src/components/midjourney/config/ImageUrlInput2.vue
+++ b/src/components/midjourney/config/ImageUrlInput2.vue
@@ -7,6 +7,7 @@
       </div>
     </div>
     <el-upload
+      ref="uploader"
       v-model:file-list="fileList"
       name="file"
       :limit="5"
@@ -39,7 +40,7 @@
 import { defineComponent } from 'vue';
 import { ElUpload, ElButton, UploadFiles, UploadFile, ElMessage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 
@@ -57,6 +58,7 @@ export default defineComponent({
     FontAwesomeIcon,
     ImagePreview
   },
+  mixins: [pasteUploadMixin],
   emits: ['change'],
   data(): IData {
     return {

--- a/src/components/midjourney/config/ReferenceImage.vue
+++ b/src/components/midjourney/config/ReferenceImage.vue
@@ -7,6 +7,7 @@
       </div>
     </div>
     <el-upload
+      ref="uploader"
       v-model:file-list="fileList"
       name="file"
       :limit="5"
@@ -39,7 +40,7 @@
 import { defineComponent } from 'vue';
 import { ElUpload, ElButton, UploadFiles, UploadFile, ElMessage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 
@@ -57,6 +58,7 @@ export default defineComponent({
     FontAwesomeIcon,
     ImagePreview
   },
+  mixins: [pasteUploadMixin],
   emits: ['change'],
   data(): IData {
     return {

--- a/src/components/nanobanana/config/ImageUrlsInput.vue
+++ b/src/components/nanobanana/config/ImageUrlsInput.vue
@@ -4,6 +4,7 @@
     <div class="upload-wrapper flex flex-col items-start gap-[8px]">
       <div class="controls flex items-center">
         <el-upload
+          ref="uploader"
           v-model:file-list="fileList"
           accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
           name="file"
@@ -47,6 +48,7 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { getBaseUrlPlatform } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
+import { pasteUploadMixin } from '@/utils';
 
 interface IData {
   fileList: UploadFiles;
@@ -63,6 +65,7 @@ export default defineComponent({
     ImagePreview,
     FontAwesomeIcon
   },
+  mixins: [pasteUploadMixin],
   data(): IData {
     return {
       fileList: [],

--- a/src/components/pika/config/ImageUrlInput.vue
+++ b/src/components/pika/config/ImageUrlInput.vue
@@ -3,6 +3,7 @@
     <h2 class="title font-bold">{{ $t('pika.name.imageUrl') }}</h2>
     <div class="upload-wrapper">
       <el-upload
+        ref="uploader"
         v-model:file-list="fileList"
         accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
         name="file"
@@ -39,7 +40,7 @@
 import { defineComponent } from 'vue';
 import { ElButton, ElUpload, ElMessage, UploadFiles } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 export const DEFAULT_CONTENT = '';
@@ -58,6 +59,7 @@ export default defineComponent({
     ImagePreview,
     FontAwesomeIcon
   },
+  mixins: [pasteUploadMixin],
   data(): IData {
     return {
       fileList: [],

--- a/src/components/pixverse/config/StartImage.vue
+++ b/src/components/pixverse/config/StartImage.vue
@@ -7,6 +7,7 @@
       </div>
     </div>
     <el-upload
+      ref="uploader"
       v-model:file-list="fileList"
       name="file"
       accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
@@ -41,7 +42,7 @@
 import { defineComponent } from 'vue';
 import { ElUpload, ElButton, UploadFiles, UploadFile, ElMessage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 
@@ -59,6 +60,7 @@ export default defineComponent({
     FontAwesomeIcon,
     ImagePreview
   },
+  mixins: [pasteUploadMixin],
   emits: ['change'],
   data(): IData {
     return {

--- a/src/components/qrart/config/ContentInput.vue
+++ b/src/components/qrart/config/ContentInput.vue
@@ -17,6 +17,7 @@
     />
     <el-upload
       v-if="inputWay == 'upload'"
+      ref="uploader"
       v-model:file-list="fileList"
       accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
       name="file"
@@ -54,7 +55,7 @@ import { defineComponent } from 'vue';
 import { ElInput, ElRadioGroup, ElRadioButton, ElButton, ElUpload, ElMessage, UploadFiles } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import ImagePreview from '@/components/common/ImagePreview.vue';
-import { getBaseUrlPlatform } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
 
 export const DEFAULT_CONTENT = '';
 
@@ -75,6 +76,7 @@ export default defineComponent({
     ImagePreview,
     FontAwesomeIcon
   },
+  mixins: [pasteUploadMixin],
   data(): IData {
     return {
       inputWay: 'input',

--- a/src/components/seedance/config/FirstFrameImage.vue
+++ b/src/components/seedance/config/FirstFrameImage.vue
@@ -7,6 +7,7 @@
       </div>
     </div>
     <el-upload
+      ref="uploader"
       v-model:file-list="fileList"
       name="file"
       accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
@@ -42,7 +43,7 @@
 import { defineComponent } from 'vue';
 import { ElUpload, ElButton, UploadFiles, UploadFile, ElMessage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 import { ISeedanceImageInput } from '@/models';
@@ -61,6 +62,7 @@ export default defineComponent({
     FontAwesomeIcon,
     ImagePreview
   },
+  mixins: [pasteUploadMixin],
   data(): IData {
     return {
       fileList: [],

--- a/src/components/seedance/config/LastFrameImage.vue
+++ b/src/components/seedance/config/LastFrameImage.vue
@@ -7,6 +7,7 @@
       </div>
     </div>
     <el-upload
+      ref="uploader"
       v-model:file-list="fileList"
       name="file"
       accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
@@ -42,7 +43,7 @@
 import { defineComponent } from 'vue';
 import { ElUpload, ElButton, UploadFiles, UploadFile, ElMessage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 import { ISeedanceImageInput } from '@/models';
@@ -61,6 +62,7 @@ export default defineComponent({
     InfoIcon,
     FontAwesomeIcon
   },
+  mixins: [pasteUploadMixin],
   data(): IData {
     return {
       fileList: [],

--- a/src/components/seedream/config/ImageInput.vue
+++ b/src/components/seedream/config/ImageInput.vue
@@ -8,6 +8,7 @@
     </div>
     <div class="value">
       <el-upload
+        ref="uploader"
         v-model:file-list="fileList"
         accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
         name="file"
@@ -45,7 +46,7 @@
 import { defineComponent } from 'vue';
 import { ElButton, ElUpload, ElMessage, UploadFiles, UploadFile } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 
@@ -64,6 +65,7 @@ export default defineComponent({
     ImagePreview,
     FontAwesomeIcon
   },
+  mixins: [pasteUploadMixin],
   data(): IData {
     return {
       fileList: [],

--- a/src/components/sora/config/StartEndImage.vue
+++ b/src/components/sora/config/StartEndImage.vue
@@ -7,6 +7,7 @@
       </div>
     </div>
     <el-upload
+      ref="uploader"
       v-model:file-list="fileList"
       name="file"
       accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
@@ -41,7 +42,7 @@
 import { defineComponent } from 'vue';
 import { ElUpload, ElButton, UploadFiles, UploadFile, ElMessage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 
@@ -59,6 +60,7 @@ export default defineComponent({
     FontAwesomeIcon,
     ImagePreview
   },
+  mixins: [pasteUploadMixin],
   emits: ['change'],
   data(): IData {
     return {

--- a/src/components/veo/config/StartEndImage.vue
+++ b/src/components/veo/config/StartEndImage.vue
@@ -7,6 +7,7 @@
       </div>
     </div>
     <el-upload
+      ref="uploader"
       v-model:file-list="fileList"
       name="file"
       accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
@@ -41,7 +42,7 @@
 import { defineComponent } from 'vue';
 import { ElUpload, ElButton, UploadFiles, UploadFile, ElMessage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 
@@ -59,6 +60,7 @@ export default defineComponent({
     FontAwesomeIcon,
     ImagePreview
   },
+  mixins: [pasteUploadMixin],
   emits: ['change'],
   data(): IData {
     return {

--- a/src/components/wan/config/ImageUrlInput.vue
+++ b/src/components/wan/config/ImageUrlInput.vue
@@ -40,7 +40,7 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import { ElButton, ElUpload, ElMessage, UploadFiles, UploadFile } from 'element-plus';
-import { getBaseUrlPlatform } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 
@@ -59,6 +59,7 @@ export default defineComponent({
     InfoIcon,
     ImagePreview
   },
+  mixins: [pasteUploadMixin],
   data(): IData {
     return {
       fileList: [],

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -9,3 +9,5 @@ export * from './site';
 export * from './price';
 export * from './application';
 export * from './theme';
+export * from './pasteUpload';
+export * from './pasteUploadMixin';

--- a/src/utils/pasteUpload.ts
+++ b/src/utils/pasteUpload.ts
@@ -1,0 +1,154 @@
+/**
+ * Global paste-to-upload helper.
+ *
+ * Each `<el-upload>` component that wants to support pasting an image from the
+ * clipboard registers itself via `registerPasteUploadTarget`. A single
+ * document-level `paste` listener then routes pasted images/files to the
+ * "active" target, where active is determined by:
+ *   1. The target the user most recently hovered/focused, or
+ *   2. The most recently registered target, if no hover info is available.
+ *
+ * Targets are responsible for accepting a `File` and pushing it into their own
+ * upload queue (typically via the `el-upload` instance's `handleStart` API).
+ */
+
+import { ElMessage } from 'element-plus';
+
+export interface IPasteUploadTarget {
+  /** Stable id used for dedup / targeting. */
+  id: symbol;
+  /** Accept hint such as `.png,.jpg,.jpeg,.gif,.bmp,.webp` (optional). */
+  accept?: string;
+  /** Called with the raw `File` extracted from the clipboard. */
+  handleFile: (file: File) => void;
+  /** DOM element used to detect hover for target selection. */
+  el?: HTMLElement | null;
+}
+
+const targets: IPasteUploadTarget[] = [];
+let hoveredTargetId: symbol | null = null;
+let listenerInstalled = false;
+
+const matchesAccept = (file: File, accept?: string): boolean => {
+  if (!accept) return true;
+  const rules = accept
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+  if (!rules.length) return true;
+  const name = file.name.toLowerCase();
+  const type = (file.type || '').toLowerCase();
+  return rules.some((rule) => {
+    if (rule.startsWith('.')) {
+      return name.endsWith(rule);
+    }
+    if (rule.endsWith('/*')) {
+      return type.startsWith(rule.slice(0, -1));
+    }
+    return type === rule;
+  });
+};
+
+const pickTarget = (): IPasteUploadTarget | null => {
+  if (!targets.length) return null;
+  if (hoveredTargetId) {
+    const t = targets.find((x) => x.id === hoveredTargetId);
+    if (t) return t;
+  }
+  // Fallback: most recently registered, still mounted.
+  return targets[targets.length - 1];
+};
+
+const onDocumentPaste = (event: ClipboardEvent) => {
+  if (!targets.length) return;
+
+  // Don't hijack paste while user is typing in a text field.
+  const active = document.activeElement as HTMLElement | null;
+  if (active) {
+    const tag = active.tagName;
+    const isEditable = active.isContentEditable;
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || isEditable) {
+      // Only proceed if the clipboard actually contains a file (image), not
+      // just text — text paste into inputs should behave normally.
+      const items = event.clipboardData?.items;
+      const hasFile = items ? Array.from(items).some((i) => i.kind === 'file') : false;
+      if (!hasFile) return;
+    }
+  }
+
+  const items = event.clipboardData?.items;
+  if (!items || items.length === 0) return;
+
+  const files: File[] = [];
+  for (let i = 0; i < items.length; i += 1) {
+    const item = items[i];
+    if (item.kind === 'file') {
+      const f = item.getAsFile();
+      if (f) files.push(f);
+    }
+  }
+  if (!files.length) return;
+
+  const target = pickTarget();
+  if (!target) return;
+
+  const accepted = files.filter((f) => matchesAccept(f, target.accept));
+  if (!accepted.length) return;
+
+  event.preventDefault();
+  accepted.forEach((file) => {
+    // Clipboard images are usually named `image.png` with the same name for
+    // every paste, which trips Element Plus dedup logic. Give each one a
+    // unique suffix while preserving the extension.
+    let named: File = file;
+    try {
+      const dot = file.name.lastIndexOf('.');
+      const base = dot > 0 ? file.name.slice(0, dot) : file.name || 'pasted';
+      const ext = dot > 0 ? file.name.slice(dot) : '';
+      const stamp = Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+      named = new File([file], `${base}-${stamp}${ext || '.png'}`, {
+        type: file.type || 'image/png',
+        lastModified: Date.now()
+      });
+    } catch (_e) {
+      // Some older browsers don't allow constructing File; fall back to raw.
+      named = file;
+    }
+    target.handleFile(named);
+  });
+};
+
+const ensureListener = () => {
+  if (listenerInstalled) return;
+  if (typeof document === 'undefined') return;
+  document.addEventListener('paste', onDocumentPaste, true);
+  listenerInstalled = true;
+};
+
+export const registerPasteUploadTarget = (target: IPasteUploadTarget): (() => void) => {
+  ensureListener();
+  targets.push(target);
+
+  const onEnter = () => {
+    hoveredTargetId = target.id;
+  };
+  if (target.el) {
+    target.el.addEventListener('mouseenter', onEnter);
+    target.el.addEventListener('focusin', onEnter);
+  }
+
+  return () => {
+    const idx = targets.findIndex((t) => t.id === target.id);
+    if (idx >= 0) targets.splice(idx, 1);
+    if (hoveredTargetId === target.id) hoveredTargetId = null;
+    if (target.el) {
+      target.el.removeEventListener('mouseenter', onEnter);
+      target.el.removeEventListener('focusin', onEnter);
+    }
+  };
+};
+
+/** Reusable `ElMessage`-based notification when a paste was accepted. */
+export const notifyPasteAccepted = (label?: string) => {
+  ElMessage.success(label || 'Pasted image uploaded');
+};

--- a/src/utils/pasteUploadMixin.ts
+++ b/src/utils/pasteUploadMixin.ts
@@ -1,0 +1,64 @@
+/**
+ * Mixin for `<el-upload>`-based components that adds clipboard paste support.
+ *
+ * Usage:
+ *   1. Add `ref="uploader"` to the `<el-upload>` element.
+ *   2. Add `mixins: [pasteUploadMixin]` to the component options.
+ *   3. (Optional) override `pasteAccept` to match the upload's `accept`.
+ *
+ * The mixin will register itself with the global paste router on mount and
+ * forward any pasted image to `uploader.handleStart(file)`.
+ */
+
+import type { ComponentPublicInstance } from 'vue';
+import { registerPasteUploadTarget } from '@/utils/pasteUpload';
+
+interface IPasteMixinThis extends ComponentPublicInstance {
+  pasteAccept?: string;
+  $refs: { uploader?: any } & ComponentPublicInstance['$refs'];
+  __pasteUploadCleanup?: () => void;
+}
+
+export const pasteUploadMixin = {
+  computed: {
+    pasteAccept(): string {
+      return '.png,.jpg,.jpeg,.gif,.bmp,.webp';
+    }
+  },
+  mounted(this: IPasteMixinThis) {
+    const id = Symbol('paste-upload-target');
+    const el = (this.$el instanceof HTMLElement ? this.$el : null) as HTMLElement | null;
+    this.__pasteUploadCleanup = registerPasteUploadTarget({
+      id,
+      accept: this.pasteAccept,
+      el,
+      handleFile: (file: File) => {
+        const uploader: any = this.$refs?.uploader;
+        if (!uploader) return;
+        // ElUpload exposes handleStart since 2.x. Fall back to .submit/.upload
+        // if the version differs.
+        if (typeof uploader.handleStart === 'function') {
+          uploader.handleStart(file);
+          if (typeof uploader.submit === 'function') {
+            // Some configurations (auto-upload=false) need an explicit submit.
+            try {
+              uploader.submit();
+            } catch (_e) {
+              /* ignore */
+            }
+          }
+        } else if (typeof uploader.handleAdd === 'function') {
+          uploader.handleAdd(file);
+        }
+      }
+    });
+  },
+  beforeUnmount(this: IPasteMixinThis) {
+    if (this.__pasteUploadCleanup) {
+      this.__pasteUploadCleanup();
+      this.__pasteUploadCleanup = undefined;
+    }
+  }
+};
+
+export default pasteUploadMixin;


### PR DESCRIPTION
## What

Adds clipboard paste-to-upload across every image upload control in Nexior. Users can now press `Ctrl+V` / `Cmd+V` (or right-click → paste) on any service page and the pasted image is uploaded directly — no need to save the screenshot to disk first.

## Why

Customer feedback: pasting a screenshot/image from the clipboard is a much faster workflow than "save → click upload → pick file", especially for reference-image-heavy services like nano-banana, Midjourney references, and Seedream.

## How

- New utility `src/utils/pasteUpload.ts` installs a single document-level `paste` listener and routes pasted files to the upload component the user most recently hovered/focused. Honors each target's `accept` rules and renames pasted files so Element Plus's dedup logic doesn't drop repeated "image.png" pastes.
- New mixin `src/utils/pasteUploadMixin.ts` is a drop-in for any `<el-upload>` component: add `ref="uploader"` to the upload element, add `mixins: [pasteUploadMixin]`, done. The mixin forwards pasted files via `el-upload.handleStart()` so they go through the normal upload pipeline (progress + on-success + store sync, all unchanged).
- Wired into 21 image upload components across nano-banana, Midjourney (image / image2 / end / reference), Flux, Seedream, Seedance (first/last frame), Sora, Veo, Kling (start/end), Luma (start/end), Hailuo, Wan, Pika, Pixverse, qrart, Headshots, plus the chat Composer.

## Behavior

- Paste is only hijacked when the clipboard contains a `kind: 'file'` item, so typing + plain-text paste in textareas still works normally.
- When multiple upload slots are visible (e.g. Seedance first-frame + last-frame), the most recently hovered one receives the paste; before any hover, the most recently registered slot receives it.
- Audio / video upload components are intentionally excluded.

## Test plan

- `vue-tsc --noEmit`: clean
- `npm run lint`: clean
- Manual: paste a screenshot on nano-banana / Midjourney reference / chat Composer and confirm it uploads + previews + drives the request payload.