### PR TITLE
docs(readme): add OpenAI Image to AI Image service list

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 <h1 align="center">Nexior</h1>
 
-Deploy your own AI System in minutes, including applications such as AI Chat (ChatGPT, DeepSeek, Grok, Gemini, Claude), AI Image (Midjourney, Flux, QRArt, Headshots, NanoBanana, Seedream), AI Music (Suno), AI Video (Luma, Pika, Hailuo, Sora, Veo, Pixverse, Kling, Seedance), etc. No development experience required, no need to purchase AI accounts, no need to worry about API support, and no need to configure payment systems. Zero startup costs, zero risk, earn revenue through AI.
+Deploy your own AI System in minutes, including applications such as AI Chat (ChatGPT, DeepSeek, Grok, Gemini, Claude), AI Image (Midjourney, Flux, QRArt, Headshots, NanoBanana, OpenAI Image, Seedream), AI Music (Suno), AI Video (Luma, Pika, Hailuo, Sora, Veo, Pixverse, Kling, Seedance), etc. No development experience required, no need to purchase AI accounts, no need to worry about API support, and no need to configure payment systems. Zero startup costs, zero risk, earn revenue through AI.
 
-一键部署属于你的 AI 应用，包括 AI 聊天 (ChatGPT, DeepSeek, Grok, Gemini, Claude), AI 图片 (Midjourney, Flux, QRArt, Headshots, NanoBanana, Seedream), AI 音乐 (Suno), AI 视频 (Luma, Pika, Hailuo, Sora, Veo, Pixverse, Kling, Seedance) 等，无需任何开发经验、无需采购 AI 账号、无需关心 API 支持、无需配置支付系统。零启动成本，零风险通过 AI 赚取收益。
+一键部署属于你的 AI 应用，包括 AI 聊天 (ChatGPT, DeepSeek, Grok, Gemini, Claude), AI 图片 (Midjourney, Flux, QRArt, Headshots, NanoBanana, OpenAI Image, Seedream), AI 音乐 (Suno), AI 视频 (Luma, Pika, Hailuo, Sora, Veo, Pixverse, Kling, Seedance) 等，无需任何开发经验、无需采购 AI 账号、无需关心 API 支持、无需配置支付系统。零启动成本，零风险通过 AI 赚取收益。
 
 ---
 
@@ -18,7 +18,7 @@ One click to deploy to Vercel：
 
 ## Features
 
-- An integrated system offering all-in-one services including AI Chat (ChatGPT, DeepSeek, Grok, Gemini, Claude), AI Image (Midjourney, Flux, QRArt, Headshots, NanoBanana, Seedream), AI Music (Suno), AI Video (Luma, Pika, Hailuo, Sora, Veo, Pixverse, Kling, Seedance), etc.
+- An integrated system offering all-in-one services including AI Chat (ChatGPT, DeepSeek, Grok, Gemini, Claude), AI Image (Midjourney, Flux, QRArt, Headshots, NanoBanana, OpenAI Image, Seedream), AI Music (Suno), AI Video (Luma, Pika, Hailuo, Sora, Veo, Pixverse, Kling, Seedance), etc.
 - No need to set up API service by yourself, ready to use out of the box.
 - Supports all capabilities with free trials.
 - Out-of-the-box support for payment and referral systems, enabling profit generation without any additional configuration.
@@ -28,13 +28,13 @@ One click to deploy to Vercel：
 **Supported Apps**
 
 - AI Chat: ChatGPT, DeepSeek, Grok, Gemini, Claude
-- AI Image: Midjourney, Flux, QRArt, Headshots, NanoBanana, Seedream
+- AI Image: Midjourney, Flux, QRArt, Headshots, NanoBanana, OpenAI Image, Seedream
 - AI Music: Suno
 - AI Video: Luma, Pika, Hailuo, Sora, Veo, Pixverse, Kling, Seedance
 
 ---
 
-- 集成 AI 聊天 (ChatGPT, DeepSeek, Grok, Gemini, Claude), AI 图片 (Midjourney, Flux, QRArt, Headshots, NanoBanana, Seedream), AI 音乐 (Suno), AI 视频 (Luma, Pika, Hailuo, Sora, Veo, Pixverse, Kling, Seedance) 的系统。
+- 集成 AI 聊天 (ChatGPT, DeepSeek, Grok, Gemini, Claude), AI 图片 (Midjourney, Flux, QRArt, Headshots, NanoBanana, OpenAI Image, Seedream), AI 音乐 (Suno), AI 视频 (Luma, Pika, Hailuo, Sora, Veo, Pixverse, Kling, Seedance) 的系统。
 - 无需自行搭建 API 服务，开箱即用。
 - 支持所有功能免费注册体验。
 - 开箱支持支付和分销系统，无需任何额外配置即可赚取收益。
@@ -44,7 +44,7 @@ One click to deploy to Vercel：
 **支持的应用**
 
 - AI 聊天：ChatGPT、DeepSeek、Grok、Gemini、Claude
-- AI 图片：Midjourney、Flux、QRArt、Headshots、NanoBanana、Seedream
+- AI 图片：Midjourney、Flux、QRArt、Headshots、NanoBanana、OpenAI Image、Seedream
 - AI 音乐：Suno
 - AI 视频：Luma、Pika、Hailuo、Sora、Veo、Pixverse、Kling、Seedance
 


### PR DESCRIPTION
## What
Adds OpenAI Image to the AI Image service list in README.md (EN + zh-CN sections), so the README matches the integration that just landed in PR #460.

## Why
The new `/openai-image` page is fully wired (router, store, i18n, navigator, layout, etc.) but the README service enumeration was the only documentation surface still missing it.
