### PR TITLE
fix(nexior): wire openaiimage feature toggle, settings entry & default route

### DIFF
--- a/src/components/common/Navigator.vue
+++ b/src/components/common/Navigator.vue
@@ -248,10 +248,7 @@ export default defineComponent({
           category: 'image'
         });
       }
-      if (
-        this.$store?.state?.site?.features?.openaiimage?.enabled ||
-        this.$store?.state?.site?.features?.chatgpt?.enabled
-      ) {
+      if (this.$store?.state?.site?.features?.openaiimage?.enabled) {
         result.push({
           route: { name: ROUTE_OPENAIIMAGE_INDEX },
           displayName: this.$t('common.nav.openaiimage'),

--- a/src/components/setting/Function.vue
+++ b/src/components/setting/Function.vue
@@ -104,6 +104,7 @@ const FEATURE_KEYS = [
   'hailuo',
   'headshots',
   'nanobanana',
+  'openaiimage',
   'seedream',
   'seedance',
   'wan',

--- a/src/i18n/ar/site.json
+++ b/src/i18n/ar/site.json
@@ -1,1110 +1,450 @@
 {
-  "field.title": [
-    [
-      "message",
-      "عنوان الموقع"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "field.origin": [
-    [
-      "message",
-      "اسم نطاق الموقع"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "field.description": [
-    [
-      "message",
-      "وصف الموقع"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "field.keywords": [
-    [
-      "message",
-      "كلمات مفتاحية للموقع"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "field.logo": [
-    [
-      "message",
-      "شعار الموقع"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "field.favicon": [
-    [
-      "message",
-      "فافيكون الموقع"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "field.qr": [
-    [
-      "message",
-      "رمز الاستجابة السريعة"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "field.url": [
-    [
-      "message",
-      "رابط"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "field.admins": [
-    [
-      "message",
-      "معرفات مديري الموقع"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "field.distributionDefaultInviterId": [
-    [
-      "message",
-      "معرف المدعو الافتراضي"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "field.distributionForceInviterId": [
-    [
-      "message",
-      "معرف المدعو الإجباري"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "field.featuresChat": [
-    [
-      "message",
-      "دردشة"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "field.featuresVeo": [
-    [
-      "message",
-      "فيو"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "field.featuresSora": [
-    [
-      "message",
-      "سورا"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "field.featuresGrok": [
-    [
-      "message",
-      "غروك"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "field.featuresDeepseek": [
-    [
-      "message",
-      "ديب سيك"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "field.featuresChatgpt": [
-    [
-      "message",
-      "تشات جي بي تي"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "field.featuresMidjourney": [
-    [
-      "message",
-      "ميدجورني"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "field.featuresChatdoc": [
-    [
-      "message",
-      "تشات دوك"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "field.featuresQrart": [
-    [
-      "message",
-      "كيو آر آرت"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "field.featuresLuma": [
-    [
-      "message",
-      "لما"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "field.featuresPixverse": [
-    [
-      "message",
-      "بيكسفيرس"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "field.featuresPika": [
-    [
-      "message",
-      "بيكا"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "field.featuresKling": [
-    [
-      "message",
-      "كلينغ"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "field.featuresHailuo": [
-    [
-      "message",
-      "هاي لو"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "field.featuresHeadshots": [
-    [
-      "message",
-      "صور هوية بالذكاء الاصطناعي"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "field.featuresSuno": [
-    [
-      "message",
-      "سونو"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "field.featuresFlux": [
-    [
-      "message",
-      "فلوكس"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "field.featuresNanobanana": [
-    [
-      "message",
-      "موز نانو"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
+  "field.title": {
+    "message": "عنوان الموقع",
+    "description": "عرض في مربع التحرير"
+  },
+  "field.origin": {
+    "message": "اسم نطاق الموقع",
+    "description": "عرض في مربع التحرير"
+  },
+  "field.description": {
+    "message": "وصف الموقع",
+    "description": "عرض في مربع التحرير"
+  },
+  "field.keywords": {
+    "message": "كلمات مفتاحية للموقع",
+    "description": "عرض في مربع التحرير"
+  },
+  "field.logo": {
+    "message": "شعار الموقع",
+    "description": "عرض في مربع التحرير"
+  },
+  "field.favicon": {
+    "message": "فافيكون الموقع",
+    "description": "عرض في مربع التحرير"
+  },
+  "field.qr": {
+    "message": "رمز الاستجابة السريعة",
+    "description": "عرض في مربع التحرير"
+  },
+  "field.url": {
+    "message": "رابط",
+    "description": "عرض في مربع التحرير"
+  },
+  "field.admins": {
+    "message": "معرفات مديري الموقع",
+    "description": "عرض في مربع التحرير"
+  },
+  "field.distributionDefaultInviterId": {
+    "message": "معرف المدعو الافتراضي",
+    "description": "عرض في مربع التحرير"
+  },
+  "field.distributionForceInviterId": {
+    "message": "معرف المدعو الإجباري",
+    "description": "عرض في مربع التحرير"
+  },
+  "field.featuresChat": {
+    "message": "دردشة",
+    "description": "عرض في مربع التحرير"
+  },
+  "field.featuresVeo": {
+    "message": "فيو",
+    "description": "عرض في مربع التحرير"
+  },
+  "field.featuresSora": {
+    "message": "سورا",
+    "description": "عرض في مربع التحرير"
+  },
+  "field.featuresGrok": {
+    "message": "غروك",
+    "description": "عرض في مربع التحرير"
+  },
+  "field.featuresDeepseek": {
+    "message": "ديب سيك",
+    "description": "عرض في مربع التحرير"
+  },
+  "field.featuresChatgpt": {
+    "message": "تشات جي بي تي",
+    "description": "عرض في مربع التحرير"
+  },
+  "field.featuresMidjourney": {
+    "message": "ميدجورني",
+    "description": "عرض في مربع التحرير"
+  },
+  "field.featuresChatdoc": {
+    "message": "تشات دوك",
+    "description": "عرض في مربع التحرير"
+  },
+  "field.featuresQrart": {
+    "message": "كيو آر آرت",
+    "description": "عرض في مربع التحرير"
+  },
+  "field.featuresLuma": {
+    "message": "لما",
+    "description": "عرض في مربع التحرير"
+  },
+  "field.featuresPixverse": {
+    "message": "بيكسفيرس",
+    "description": "عرض في مربع التحرير"
+  },
+  "field.featuresPika": {
+    "message": "بيكا",
+    "description": "عرض في مربع التحرير"
+  },
+  "field.featuresKling": {
+    "message": "كلينغ",
+    "description": "عرض في مربع التحرير"
+  },
+  "field.featuresHailuo": {
+    "message": "هاي لو",
+    "description": "عرض في مربع التحرير"
+  },
+  "field.featuresHeadshots": {
+    "message": "صور هوية بالذكاء الاصطناعي",
+    "description": "عرض في مربع التحرير"
+  },
+  "field.featuresSuno": {
+    "message": "سونو",
+    "description": "عرض في مربع التحرير"
+  },
+  "field.featuresFlux": {
+    "message": "فلوكس",
+    "description": "عرض في مربع التحرير"
+  },
+  "field.featuresNanobanana": {
+    "message": "موز نانو",
+    "description": "عرض في مربع التحرير"
+  },
   "field.featuresOpenaiimage": {
     "message": "OpenAI Image",
     "description": "Displayed as the title in the editing box"
   },
-  "field.featuresSeedream": [
-    [
-      "message",
-      "سي دريم"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "field.featuresSeedance": [
-    [
-      "message",
-      "سي دانس"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "field.featuresWan": [
-    [
-      "message",
-      "وان"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "field.featuresProducer": [
-    [
-      "message",
-      "منتج"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "field.featuresKimi": [
-    [
-      "message",
-      "كي مي"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "field.featuresSerp": [
-    [
-      "message",
-      "سيرب"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "field.featuresSupport": [
-    [
-      "message",
-      "دعم العملاء"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "field.featuresI18n": [
-    [
-      "message",
-      "دعم متعدد اللغات"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "title.basicConfig": [
-    [
-      "message",
-      "الإعدادات الأساسية"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "title.seoConfig": [
-    [
-      "message",
-      "إعدادات تحسين محركات البحث"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "title.editAdmins": [
-    [
-      "message",
-      "تحرير المدراء"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "title.featuresConfig": [
-    [
-      "message",
-      "إعدادات الميزات"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "title.editTitle": [
-    [
-      "message",
-      "تحرير العنوان"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "title.editOrigin": [
-    [
-      "message",
-      "تحرير اسم النطاق"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "title.editKeywords": [
-    [
-      "message",
-      "تحرير الكلمات المفتاحية"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "title.editLogo": [
-    [
-      "message",
-      "تحرير الشعار"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "title.editFavicon": [
-    [
-      "message",
-      "تحرير الفافيكون"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "title.editDescription": [
-    [
-      "message",
-      "تحرير الوصف"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "title.distributionConfig": [
-    [
-      "message",
-      "إعدادات التوزيع"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "title.editDistributionDefaultInviterId": [
-    [
-      "message",
-      "تحرير المدعو الافتراضي"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "title.editDistributionForceInviterId": [
-    [
-      "message",
-      "تحرير المدعو الإجباري"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "title.editQR": [
-    [
-      "message",
-      "تعديل رمز الاستجابة السريعة"
-    ],
-    [
-      "description",
-      "عرض في عنوان مربع التحرير"
-    ]
-  ],
-  "title.editUrl": [
-    [
-      "message",
-      "تعديل الرابط"
-    ],
-    [
-      "description",
-      "عرض في عنوان مربع التحرير"
-    ]
-  ],
-  "placeholder.title": [
-    [
-      "message",
-      "أدخل عنوان الموقع"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "placeholder.origin": [
-    [
-      "message",
-      "أدخل اسم نطاق الموقع"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "placeholder.editUrl": [
-    [
-      "message",
-      "أدخل الرابط"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "placeholder.description": [
-    [
-      "message",
-      "أدخل وصف الموقع"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "placeholder.keywords": [
-    [
-      "message",
-      "أدخل كلمات مفتاحية للموقع"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "placeholder.editDistributionDefaultInviterId": [
-    [
-      "message",
-      "أدخل معرف المدعو الافتراضي"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "placeholder.editDistributionForceInviterId": [
-    [
-      "message",
-      "أدخل معرف المدعو الإجباري"
-    ],
-    [
-      "description",
-      "عرض في مربع التحرير"
-    ]
-  ],
-  "message.uploadImageExceed": [
-    [
-      "message",
-      "تجاوز حد رفع الصورة"
-    ],
-    [
-      "description",
-      "تنبيه عند تجاوز حد رفع الصورة"
-    ]
-  ],
-  "message.uploadImageError": [
-    [
-      "message",
-      "خطأ في رفع الصورة"
-    ],
-    [
-      "description",
-      "تنبيه عند حدوث خطأ في رفع الصورة"
-    ]
-  ],
-  "message.editLogoTip": [
-    [
-      "message",
-      "الأبعاد الموصى بها: 200*60 بكسل"
-    ],
-    [
-      "description",
-      "لغة تنبيه رفع الصورة"
-    ]
-  ],
-  "message.editQRTip": [
-    [
-      "message",
-      "الأبعاد الموصى بها: 200*200 بكسل"
-    ],
-    [
-      "description",
-      "لغة تنبيه رفع الصورة"
-    ]
-  ],
-  "message.editFaviconTip": [
-    [
-      "message",
-      "الأبعاد الموصى بها: 32*32 بكسل"
-    ],
-    [
-      "description",
-      "لغة تنبيه رفع الصورة"
-    ]
-  ],
-  "message.editUrl": [
-    [
-      "message",
-      "أدخل الرابط"
-    ],
-    [
-      "description",
-      "تنبيه لإدخال الرابط"
-    ]
-  ],
-  "message.atLeastOneAdmin": [
-    [
-      "message",
-      "يجب الاحتفاظ بمدير واحد على الأقل"
-    ],
-    [
-      "description",
-      "تنبيه للاحتفاظ بمدير واحد على الأقل"
-    ]
-  ],
-  "message.distributionDefaultInviterIdTip": [
-    [
-      "message",
-      "معرف المستخدم للمدعو الافتراضي، إذا لم يحمل رابط التوزيع معلمة inviter_id، سيتم استخدام هذا المعرف كمدعو افتراضي."
-    ],
-    [
-      "description",
-      "تنبيه معرف المدعو الافتراضي"
-    ]
-  ],
-  "message.distributionForceInviterIdTip": [
-    [
-      "message",
-      "معرف المستخدم للمدعو الإجباري، إذا تم تعيين هذا المعرف، سيتم استخدامه كمدعو بغض النظر عما إذا كان رابط التوزيع يحمل معلمة inviter_id."
-    ],
-    [
-      "description",
-      "تنبيه معرف المدعو الإجباري"
-    ]
-  ],
-  "message.originTip": [
-    [
-      "message",
-      "اسم نطاق الموقع، يتم ربط إعدادات الموقع بالنطاق، ولا يمكن تغيير اسم نطاق الموقع."
-    ],
-    [
-      "description",
-      "تنبيه اسم نطاق الموقع"
-    ]
-  ],
-  "message.titleTip": [
-    [
-      "message",
-      "عنوان الموقع، يظهر في علامة تبويب المتصفح."
-    ],
-    [
-      "description",
-      "تنبيه عنوان الموقع"
-    ]
-  ],
-  "message.descriptionTip": [
-    [
-      "message",
-      "وصف الموقع، موجود في معلومات الموقع الوصفية، يستخدم لتحسين SEO للموقع."
-    ],
-    [
-      "description",
-      "تنبيه وصف الموقع"
-    ]
-  ],
-  "message.logoTip": [
-    [
-      "message",
-      "شعار الموقع، يظهر في أعلى قائمة الموقع عند فتح القائمة."
-    ],
-    [
-      "description",
-      "تنبيه شعار الموقع"
-    ]
-  ],
-  "message.faviconTip": [
-    [
-      "message",
-      "فافيكون الموقع، يظهر في علامة تبويب المتصفح."
-    ],
-    [
-      "description",
-      "تنبيه فافيكون الموقع"
-    ]
-  ],
-  "message.adminsTip": [
-    [
-      "message",
-      "معرفات مديري الموقع، المستخدم الذي ينشئ الموقع لأول مرة يصبح مديرًا بشكل افتراضي، فقط مديري الموقع يمكنهم إدارة الموقع."
-    ],
-    [
-      "description",
-      "تنبيه مديري الموقع"
-    ]
-  ],
-  "message.adminsTip2": [
-    [
-      "message",
-      "يمكنك إضافة أو حذف معرفات المديرين هنا، يمكنك زيارة https://auth.acedata.cloud لرؤية معرفات المستخدمين"
-    ],
-    [
-      "description",
-      "تنبيه مديري الموقع"
-    ]
-  ],
-  "message.keywordsTip": [
-    [
-      "message",
-      "كلمات مفتاحية للموقع، موجودة في المعلومات الوصفية للموقع، تستخدم لتحسين SEO للموقع."
-    ],
-    [
-      "description",
-      "تنبيه كلمات مفتاحية للموقع"
-    ]
-  ],
-  "message.keywordsTip2": [
-    [
-      "message",
-      "يمكنك إضافة أو حذف كلمات مفتاحية للموقع هنا، كلما كانت الكلمات أكثر دقة، كانت أفضل لتحسين SEO."
-    ],
-    [
-      "description",
-      "تنبيه كلمات مفتاحية للموقع"
-    ]
-  ],
-  "message.featuresChat": [
-    [
-      "message",
-      "تفعيل أو تعطيل وحدة وظيفة الدردشة."
-    ],
-    [
-      "description",
-      "وصف وظيفة الدردشة"
-    ]
-  ],
-  "message.featuresGrok": [
-    [
-      "message",
-      "تفعيل أو تعطيل وحدة وظيفة Grok."
-    ],
-    [
-      "description",
-      "وصف وظيفة Grok"
-    ]
-  ],
-  "message.featuresDeepseek": [
-    [
-      "message",
-      "تفعيل أو تعطيل وحدة وظيفة Deepseek."
-    ],
-    [
-      "description",
-      "وصف وظيفة Deepseek"
-    ]
-  ],
-  "message.featuresChatgpt": [
-    [
-      "message",
-      "تفعيل أو تعطيل وحدة وظيفة ChatGPT."
-    ],
-    [
-      "description",
-      "وصف وظيفة ChatGPT"
-    ]
-  ],
-  "message.featuresMidjourney": [
-    [
-      "message",
-      "تفعيل أو تعطيل وحدة وظيفة Midjourney."
-    ],
-    [
-      "description",
-      "وصف وظيفة Midjourney"
-    ]
-  ],
-  "message.featuresChatdoc": [
-    [
-      "message",
-      "تفعيل أو تعطيل وحدة وظيفة Chatdoc."
-    ],
-    [
-      "description",
-      "وصف وظيفة Chatdoc"
-    ]
-  ],
-  "message.featuresQrart": [
-    [
-      "message",
-      "تفعيل أو تعطيل وحدة وظيفة Qrart."
-    ],
-    [
-      "description",
-      "وصف وظيفة Qrart"
-    ]
-  ],
-  "message.featuresVeo": [
-    [
-      "message",
-      "تفعيل أو تعطيل وحدة وظيفة Veo."
-    ],
-    [
-      "description",
-      "وصف وظيفة Veo"
-    ]
-  ],
-  "message.featuresSora": [
-    [
-      "message",
-      "تفعيل أو تعطيل وحدة وظيفة Sora."
-    ],
-    [
-      "description",
-      "وصف وظيفة Sora"
-    ]
-  ],
-  "message.featuresSuno": [
-    [
-      "message",
-      "تفعيل أو تعطيل وحدة وظيفة Suno."
-    ],
-    [
-      "description",
-      "وصف وظيفة Suno"
-    ]
-  ],
-  "message.featuresPixverse": [
-    [
-      "message",
-      "قم بتشغيل أو إيقاف تشغيل وحدة ميزات Pixverse."
-    ],
-    [
-      "description",
-      "وصف ميزات Pixverse"
-    ]
-  ],
-  "message.featuresFlux": [
-    [
-      "message",
-      "قم بتشغيل أو إيقاف تشغيل وحدة ميزات FLux."
-    ],
-    [
-      "description",
-      "وصف ميزات FLux"
-    ]
-  ],
-  "message.featuresNanobanana": [
-    [
-      "message",
-      "قم بتشغيل أو إيقاف تشغيل وحدة ميزات Nano Banana."
-    ],
-    [
-      "description",
-      "وصف ميزات Nano Banana"
-    ]
-  ],
+  "field.featuresSeedream": {
+    "message": "سي دريم",
+    "description": "عرض في مربع التحرير"
+  },
+  "field.featuresSeedance": {
+    "message": "سي دانس",
+    "description": "عرض في مربع التحرير"
+  },
+  "field.featuresWan": {
+    "message": "وان",
+    "description": "عرض في مربع التحرير"
+  },
+  "field.featuresProducer": {
+    "message": "منتج",
+    "description": "عرض في مربع التحرير"
+  },
+  "field.featuresKimi": {
+    "message": "كي مي",
+    "description": "عرض في مربع التحرير"
+  },
+  "field.featuresSerp": {
+    "message": "سيرب",
+    "description": "عرض في مربع التحرير"
+  },
+  "field.featuresSupport": {
+    "message": "دعم العملاء",
+    "description": "عرض في مربع التحرير"
+  },
+  "field.featuresI18n": {
+    "message": "دعم متعدد اللغات",
+    "description": "عرض في مربع التحرير"
+  },
+  "title.basicConfig": {
+    "message": "الإعدادات الأساسية",
+    "description": "عرض في مربع التحرير"
+  },
+  "title.seoConfig": {
+    "message": "إعدادات تحسين محركات البحث",
+    "description": "عرض في مربع التحرير"
+  },
+  "title.editAdmins": {
+    "message": "تحرير المدراء",
+    "description": "عرض في مربع التحرير"
+  },
+  "title.featuresConfig": {
+    "message": "إعدادات الميزات",
+    "description": "عرض في مربع التحرير"
+  },
+  "title.editTitle": {
+    "message": "تحرير العنوان",
+    "description": "عرض في مربع التحرير"
+  },
+  "title.editOrigin": {
+    "message": "تحرير اسم النطاق",
+    "description": "عرض في مربع التحرير"
+  },
+  "title.editKeywords": {
+    "message": "تحرير الكلمات المفتاحية",
+    "description": "عرض في مربع التحرير"
+  },
+  "title.editLogo": {
+    "message": "تحرير الشعار",
+    "description": "عرض في مربع التحرير"
+  },
+  "title.editFavicon": {
+    "message": "تحرير الفافيكون",
+    "description": "عرض في مربع التحرير"
+  },
+  "title.editDescription": {
+    "message": "تحرير الوصف",
+    "description": "عرض في مربع التحرير"
+  },
+  "title.distributionConfig": {
+    "message": "إعدادات التوزيع",
+    "description": "عرض في مربع التحرير"
+  },
+  "title.editDistributionDefaultInviterId": {
+    "message": "تحرير المدعو الافتراضي",
+    "description": "عرض في مربع التحرير"
+  },
+  "title.editDistributionForceInviterId": {
+    "message": "تحرير المدعو الإجباري",
+    "description": "عرض في مربع التحرير"
+  },
+  "title.editQR": {
+    "message": "تعديل رمز الاستجابة السريعة",
+    "description": "عرض في عنوان مربع التحرير"
+  },
+  "title.editUrl": {
+    "message": "تعديل الرابط",
+    "description": "عرض في عنوان مربع التحرير"
+  },
+  "placeholder.title": {
+    "message": "أدخل عنوان الموقع",
+    "description": "عرض في مربع التحرير"
+  },
+  "placeholder.origin": {
+    "message": "أدخل اسم نطاق الموقع",
+    "description": "عرض في مربع التحرير"
+  },
+  "placeholder.editUrl": {
+    "message": "أدخل الرابط",
+    "description": "عرض في مربع التحرير"
+  },
+  "placeholder.description": {
+    "message": "أدخل وصف الموقع",
+    "description": "عرض في مربع التحرير"
+  },
+  "placeholder.keywords": {
+    "message": "أدخل كلمات مفتاحية للموقع",
+    "description": "عرض في مربع التحرير"
+  },
+  "placeholder.editDistributionDefaultInviterId": {
+    "message": "أدخل معرف المدعو الافتراضي",
+    "description": "عرض في مربع التحرير"
+  },
+  "placeholder.editDistributionForceInviterId": {
+    "message": "أدخل معرف المدعو الإجباري",
+    "description": "عرض في مربع التحرير"
+  },
+  "message.uploadImageExceed": {
+    "message": "تجاوز حد رفع الصورة",
+    "description": "تنبيه عند تجاوز حد رفع الصورة"
+  },
+  "message.uploadImageError": {
+    "message": "خطأ في رفع الصورة",
+    "description": "تنبيه عند حدوث خطأ في رفع الصورة"
+  },
+  "message.editLogoTip": {
+    "message": "الأبعاد الموصى بها: 200*60 بكسل",
+    "description": "لغة تنبيه رفع الصورة"
+  },
+  "message.editQRTip": {
+    "message": "الأبعاد الموصى بها: 200*200 بكسل",
+    "description": "لغة تنبيه رفع الصورة"
+  },
+  "message.editFaviconTip": {
+    "message": "الأبعاد الموصى بها: 32*32 بكسل",
+    "description": "لغة تنبيه رفع الصورة"
+  },
+  "message.editUrl": {
+    "message": "أدخل الرابط",
+    "description": "تنبيه لإدخال الرابط"
+  },
+  "message.atLeastOneAdmin": {
+    "message": "يجب الاحتفاظ بمدير واحد على الأقل",
+    "description": "تنبيه للاحتفاظ بمدير واحد على الأقل"
+  },
+  "message.distributionDefaultInviterIdTip": {
+    "message": "معرف المستخدم للمدعو الافتراضي، إذا لم يحمل رابط التوزيع معلمة inviter_id، سيتم استخدام هذا المعرف كمدعو افتراضي.",
+    "description": "تنبيه معرف المدعو الافتراضي"
+  },
+  "message.distributionForceInviterIdTip": {
+    "message": "معرف المستخدم للمدعو الإجباري، إذا تم تعيين هذا المعرف، سيتم استخدامه كمدعو بغض النظر عما إذا كان رابط التوزيع يحمل معلمة inviter_id.",
+    "description": "تنبيه معرف المدعو الإجباري"
+  },
+  "message.originTip": {
+    "message": "اسم نطاق الموقع، يتم ربط إعدادات الموقع بالنطاق، ولا يمكن تغيير اسم نطاق الموقع.",
+    "description": "تنبيه اسم نطاق الموقع"
+  },
+  "message.titleTip": {
+    "message": "عنوان الموقع، يظهر في علامة تبويب المتصفح.",
+    "description": "تنبيه عنوان الموقع"
+  },
+  "message.descriptionTip": {
+    "message": "وصف الموقع، موجود في معلومات الموقع الوصفية، يستخدم لتحسين SEO للموقع.",
+    "description": "تنبيه وصف الموقع"
+  },
+  "message.logoTip": {
+    "message": "شعار الموقع، يظهر في أعلى قائمة الموقع عند فتح القائمة.",
+    "description": "تنبيه شعار الموقع"
+  },
+  "message.faviconTip": {
+    "message": "فافيكون الموقع، يظهر في علامة تبويب المتصفح.",
+    "description": "تنبيه فافيكون الموقع"
+  },
+  "message.adminsTip": {
+    "message": "معرفات مديري الموقع، المستخدم الذي ينشئ الموقع لأول مرة يصبح مديرًا بشكل افتراضي، فقط مديري الموقع يمكنهم إدارة الموقع.",
+    "description": "تنبيه مديري الموقع"
+  },
+  "message.adminsTip2": {
+    "message": "يمكنك إضافة أو حذف معرفات المديرين هنا، يمكنك زيارة https://auth.acedata.cloud لرؤية معرفات المستخدمين",
+    "description": "تنبيه مديري الموقع"
+  },
+  "message.keywordsTip": {
+    "message": "كلمات مفتاحية للموقع، موجودة في المعلومات الوصفية للموقع، تستخدم لتحسين SEO للموقع.",
+    "description": "تنبيه كلمات مفتاحية للموقع"
+  },
+  "message.keywordsTip2": {
+    "message": "يمكنك إضافة أو حذف كلمات مفتاحية للموقع هنا، كلما كانت الكلمات أكثر دقة، كانت أفضل لتحسين SEO.",
+    "description": "تنبيه كلمات مفتاحية للموقع"
+  },
+  "message.featuresChat": {
+    "message": "تفعيل أو تعطيل وحدة وظيفة الدردشة.",
+    "description": "وصف وظيفة الدردشة"
+  },
+  "message.featuresGrok": {
+    "message": "تفعيل أو تعطيل وحدة وظيفة Grok.",
+    "description": "وصف وظيفة Grok"
+  },
+  "message.featuresDeepseek": {
+    "message": "تفعيل أو تعطيل وحدة وظيفة Deepseek.",
+    "description": "وصف وظيفة Deepseek"
+  },
+  "message.featuresChatgpt": {
+    "message": "تفعيل أو تعطيل وحدة وظيفة ChatGPT.",
+    "description": "وصف وظيفة ChatGPT"
+  },
+  "message.featuresMidjourney": {
+    "message": "تفعيل أو تعطيل وحدة وظيفة Midjourney.",
+    "description": "وصف وظيفة Midjourney"
+  },
+  "message.featuresChatdoc": {
+    "message": "تفعيل أو تعطيل وحدة وظيفة Chatdoc.",
+    "description": "وصف وظيفة Chatdoc"
+  },
+  "message.featuresQrart": {
+    "message": "تفعيل أو تعطيل وحدة وظيفة Qrart.",
+    "description": "وصف وظيفة Qrart"
+  },
+  "message.featuresVeo": {
+    "message": "تفعيل أو تعطيل وحدة وظيفة Veo.",
+    "description": "وصف وظيفة Veo"
+  },
+  "message.featuresSora": {
+    "message": "تفعيل أو تعطيل وحدة وظيفة Sora.",
+    "description": "وصف وظيفة Sora"
+  },
+  "message.featuresSuno": {
+    "message": "تفعيل أو تعطيل وحدة وظيفة Suno.",
+    "description": "وصف وظيفة Suno"
+  },
+  "message.featuresPixverse": {
+    "message": "قم بتشغيل أو إيقاف تشغيل وحدة ميزات Pixverse.",
+    "description": "وصف ميزات Pixverse"
+  },
+  "message.featuresFlux": {
+    "message": "قم بتشغيل أو إيقاف تشغيل وحدة ميزات FLux.",
+    "description": "وصف ميزات FLux"
+  },
+  "message.featuresNanobanana": {
+    "message": "قم بتشغيل أو إيقاف تشغيل وحدة ميزات Nano Banana.",
+    "description": "وصف ميزات Nano Banana"
+  },
   "message.featuresOpenaiimage": {
     "message": "Toggle OpenAI Image feature module.",
     "description": "Description of the OpenAI Image feature"
   },
-  "message.featuresSeedream": [
-    [
-      "message",
-      "قم بتشغيل أو إيقاف تشغيل وحدة ميزات SeeDream."
-    ],
-    [
-      "description",
-      "وصف ميزات SeeDream"
-    ]
-  ],
-  "message.featuresSeedance": [
-    [
-      "message",
-      "قم بتمكين أو تعطيل وحدة ميزات SeeDance."
-    ],
-    [
-      "description",
-      "وصف ميزات SeeDance"
-    ]
-  ],
-  "message.featuresWan": [
-    [
-      "message",
-      "قم بتشغيل أو إيقاف تشغيل وحدة ميزات Wan."
-    ],
-    [
-      "description",
-      "وصف ميزات Wan"
-    ]
-  ],
-  "message.featuresProducer": [
-    [
-      "message",
-      "قم بتشغيل أو إيقاف تشغيل وحدة ميزات Producer."
-    ],
-    [
-      "description",
-      "وصف ميزات Producer"
-    ]
-  ],
-  "message.featuresKimi": [
-    [
-      "message",
-      "قم بتشغيل أو إيقاف تشغيل وحدة ميزات Kimi."
-    ],
-    [
-      "description",
-      "وصف ميزات Kimi"
-    ]
-  ],
-  "message.featuresSerp": [
-    [
-      "message",
-      "قم بتشغيل أو إيقاف تشغيل وحدة ميزات SERP."
-    ],
-    [
-      "description",
-      "وصف ميزات SERP"
-    ]
-  ],
-  "message.featuresLuma": [
-    [
-      "message",
-      "قم بتشغيل أو إيقاف تشغيل وحدة ميزات Luma."
-    ],
-    [
-      "description",
-      "وصف ميزات Luma"
-    ]
-  ],
-  "message.featuresPika": [
-    [
-      "message",
-      "قم بتشغيل أو إيقاف تشغيل وحدة ميزات Pika."
-    ],
-    [
-      "description",
-      "وصف ميزات Pika"
-    ]
-  ],
-  "message.featuresKling": [
-    [
-      "message",
-      "قم بتشغيل أو إيقاف تشغيل وحدة ميزات Kling."
-    ],
-    [
-      "description",
-      "وصف ميزات Kling"
-    ]
-  ],
-  "message.featuresHailuo": [
-    [
-      "message",
-      "قم بتشغيل أو إيقاف تشغيل وحدة ميزات Hailuo."
-    ],
-    [
-      "description",
-      "وصف ميزات Hailuo"
-    ]
-  ],
-  "message.featuresHeadshots": [
-    [
-      "message",
-      "قم بتشغيل أو إيقاف تشغيل وحدة ميزات صور الهوية AI."
-    ],
-    [
-      "description",
-      "وصف ميزات صور الهوية AI"
-    ]
-  ],
-  "message.featuresSupport": [
-    [
-      "message",
-      "قم بتشغيل أو إيقاف تشغيل دعم العملاء"
-    ],
-    [
-      "description",
-      "وصف ميزات الدعم"
-    ]
-  ],
-  "message.featuresI18n": [
-    [
-      "message",
-      "قم بتشغيل أو إيقاف تشغيل الدعم متعدد اللغات، بعد الإيقاف، يمكن للمستخدمين استخدام اللغة الافتراضية فقط."
-    ],
-    [
-      "description",
-      "وصف الدعم متعدد اللغات"
-    ]
-  ],
-  "button.upload": [
-    [
-      "message",
-      "رفع"
-    ],
-    [
-      "description",
-      "رفع"
-    ]
-  ],
-  "button.enabled": [
-    [
-      "message",
-      "مفعل"
-    ],
-    [
-      "description",
-      "نص التبديل، يشير إلى أنه تم تفعيله"
-    ]
-  ],
-  "button.disabled": [
-    [
-      "message",
-      "معطل"
-    ],
-    [
-      "description",
-      "نص التبديل، يشير إلى أنه تم تعطيله"
-    ]
-  ],
-  "field.featuresGemini": [
-    [
-      "message",
-      "جمني"
-    ],
-    [
-      "description",
-      "يظهر كعنوان في صندوق التحرير"
-    ]
-  ],
-  "message.featuresGemini": [
-    [
-      "message",
-      "قم بتمكين أو تعطيل وحدة ميزات Gemini."
-    ],
-    [
-      "description",
-      "وصف ميزات Gemini"
-    ]
-  ],
-  "field.featuresClaude": [
-    [
-      "message",
-      "كلود"
-    ],
-    [
-      "description",
-      "يظهر كعنوان في صندوق التحرير"
-    ]
-  ],
-  "message.featuresClaude": [
-    [
-      "message",
-      "قم بتمكين أو تعطيل وحدة ميزات Claude."
-    ],
-    [
-      "description",
-      "وصف ميزات Claude"
-    ]
-  ]
+  "message.featuresSeedream": {
+    "message": "قم بتشغيل أو إيقاف تشغيل وحدة ميزات SeeDream.",
+    "description": "وصف ميزات SeeDream"
+  },
+  "message.featuresSeedance": {
+    "message": "قم بتمكين أو تعطيل وحدة ميزات SeeDance.",
+    "description": "وصف ميزات SeeDance"
+  },
+  "message.featuresWan": {
+    "message": "قم بتشغيل أو إيقاف تشغيل وحدة ميزات Wan.",
+    "description": "وصف ميزات Wan"
+  },
+  "message.featuresProducer": {
+    "message": "قم بتشغيل أو إيقاف تشغيل وحدة ميزات Producer.",
+    "description": "وصف ميزات Producer"
+  },
+  "message.featuresKimi": {
+    "message": "قم بتشغيل أو إيقاف تشغيل وحدة ميزات Kimi.",
+    "description": "وصف ميزات Kimi"
+  },
+  "message.featuresSerp": {
+    "message": "قم بتشغيل أو إيقاف تشغيل وحدة ميزات SERP.",
+    "description": "وصف ميزات SERP"
+  },
+  "message.featuresLuma": {
+    "message": "قم بتشغيل أو إيقاف تشغيل وحدة ميزات Luma.",
+    "description": "وصف ميزات Luma"
+  },
+  "message.featuresPika": {
+    "message": "قم بتشغيل أو إيقاف تشغيل وحدة ميزات Pika.",
+    "description": "وصف ميزات Pika"
+  },
+  "message.featuresKling": {
+    "message": "قم بتشغيل أو إيقاف تشغيل وحدة ميزات Kling.",
+    "description": "وصف ميزات Kling"
+  },
+  "message.featuresHailuo": {
+    "message": "قم بتشغيل أو إيقاف تشغيل وحدة ميزات Hailuo.",
+    "description": "وصف ميزات Hailuo"
+  },
+  "message.featuresHeadshots": {
+    "message": "قم بتشغيل أو إيقاف تشغيل وحدة ميزات صور الهوية AI.",
+    "description": "وصف ميزات صور الهوية AI"
+  },
+  "message.featuresSupport": {
+    "message": "قم بتشغيل أو إيقاف تشغيل دعم العملاء",
+    "description": "وصف ميزات الدعم"
+  },
+  "message.featuresI18n": {
+    "message": "قم بتشغيل أو إيقاف تشغيل الدعم متعدد اللغات، بعد الإيقاف، يمكن للمستخدمين استخدام اللغة الافتراضية فقط.",
+    "description": "وصف الدعم متعدد اللغات"
+  },
+  "button.upload": {
+    "message": "رفع",
+    "description": "رفع"
+  },
+  "button.enabled": {
+    "message": "مفعل",
+    "description": "نص التبديل، يشير إلى أنه تم تفعيله"
+  },
+  "button.disabled": {
+    "message": "معطل",
+    "description": "نص التبديل، يشير إلى أنه تم تعطيله"
+  },
+  "field.featuresGemini": {
+    "message": "جمني",
+    "description": "يظهر كعنوان في صندوق التحرير"
+  },
+  "message.featuresGemini": {
+    "message": "قم بتمكين أو تعطيل وحدة ميزات Gemini.",
+    "description": "وصف ميزات Gemini"
+  },
+  "field.featuresClaude": {
+    "message": "كلود",
+    "description": "يظهر كعنوان في صندوق التحرير"
+  },
+  "message.featuresClaude": {
+    "message": "قم بتمكين أو تعطيل وحدة ميزات Claude.",
+    "description": "وصف ميزات Claude"
+  }
 }

--- a/src/i18n/ar/site.json
+++ b/src/i18n/ar/site.json
@@ -1,442 +1,1110 @@
 {
-  "field.title": {
-    "message": "عنوان الموقع",
-    "description": "عرض في مربع التحرير"
-  },
-  "field.origin": {
-    "message": "اسم نطاق الموقع",
-    "description": "عرض في مربع التحرير"
-  },
-  "field.description": {
-    "message": "وصف الموقع",
-    "description": "عرض في مربع التحرير"
-  },
-  "field.keywords": {
-    "message": "كلمات مفتاحية للموقع",
-    "description": "عرض في مربع التحرير"
-  },
-  "field.logo": {
-    "message": "شعار الموقع",
-    "description": "عرض في مربع التحرير"
-  },
-  "field.favicon": {
-    "message": "فافيكون الموقع",
-    "description": "عرض في مربع التحرير"
-  },
-  "field.qr": {
-    "message": "رمز الاستجابة السريعة",
-    "description": "عرض في مربع التحرير"
-  },
-  "field.url": {
-    "message": "رابط",
-    "description": "عرض في مربع التحرير"
-  },
-  "field.admins": {
-    "message": "معرفات مديري الموقع",
-    "description": "عرض في مربع التحرير"
-  },
-  "field.distributionDefaultInviterId": {
-    "message": "معرف المدعو الافتراضي",
-    "description": "عرض في مربع التحرير"
-  },
-  "field.distributionForceInviterId": {
-    "message": "معرف المدعو الإجباري",
-    "description": "عرض في مربع التحرير"
-  },
-  "field.featuresChat": {
-    "message": "دردشة",
-    "description": "عرض في مربع التحرير"
-  },
-  "field.featuresVeo": {
-    "message": "فيو",
-    "description": "عرض في مربع التحرير"
-  },
-  "field.featuresSora": {
-    "message": "سورا",
-    "description": "عرض في مربع التحرير"
-  },
-  "field.featuresGrok": {
-    "message": "غروك",
-    "description": "عرض في مربع التحرير"
-  },
-  "field.featuresDeepseek": {
-    "message": "ديب سيك",
-    "description": "عرض في مربع التحرير"
-  },
-  "field.featuresChatgpt": {
-    "message": "تشات جي بي تي",
-    "description": "عرض في مربع التحرير"
-  },
-  "field.featuresMidjourney": {
-    "message": "ميدجورني",
-    "description": "عرض في مربع التحرير"
-  },
-  "field.featuresChatdoc": {
-    "message": "تشات دوك",
-    "description": "عرض في مربع التحرير"
-  },
-  "field.featuresQrart": {
-    "message": "كيو آر آرت",
-    "description": "عرض في مربع التحرير"
-  },
-  "field.featuresLuma": {
-    "message": "لما",
-    "description": "عرض في مربع التحرير"
-  },
-  "field.featuresPixverse": {
-    "message": "بيكسفيرس",
-    "description": "عرض في مربع التحرير"
-  },
-  "field.featuresPika": {
-    "message": "بيكا",
-    "description": "عرض في مربع التحرير"
-  },
-  "field.featuresKling": {
-    "message": "كلينغ",
-    "description": "عرض في مربع التحرير"
-  },
-  "field.featuresHailuo": {
-    "message": "هاي لو",
-    "description": "عرض في مربع التحرير"
-  },
-  "field.featuresHeadshots": {
-    "message": "صور هوية بالذكاء الاصطناعي",
-    "description": "عرض في مربع التحرير"
-  },
-  "field.featuresSuno": {
-    "message": "سونو",
-    "description": "عرض في مربع التحرير"
-  },
-  "field.featuresFlux": {
-    "message": "فلوكس",
-    "description": "عرض في مربع التحرير"
-  },
-  "field.featuresNanobanana": {
-    "message": "موز نانو",
-    "description": "عرض في مربع التحرير"
-  },
-  "field.featuresSeedream": {
-    "message": "سي دريم",
-    "description": "عرض في مربع التحرير"
-  },
-  "field.featuresSeedance": {
-    "message": "سي دانس",
-    "description": "عرض في مربع التحرير"
-  },
-  "field.featuresWan": {
-    "message": "وان",
-    "description": "عرض في مربع التحرير"
-  },
-  "field.featuresProducer": {
-    "message": "منتج",
-    "description": "عرض في مربع التحرير"
-  },
-  "field.featuresKimi": {
-    "message": "كي مي",
-    "description": "عرض في مربع التحرير"
-  },
-  "field.featuresSerp": {
-    "message": "سيرب",
-    "description": "عرض في مربع التحرير"
-  },
-  "field.featuresSupport": {
-    "message": "دعم العملاء",
-    "description": "عرض في مربع التحرير"
-  },
-  "field.featuresI18n": {
-    "message": "دعم متعدد اللغات",
-    "description": "عرض في مربع التحرير"
-  },
-  "title.basicConfig": {
-    "message": "الإعدادات الأساسية",
-    "description": "عرض في مربع التحرير"
-  },
-  "title.seoConfig": {
-    "message": "إعدادات تحسين محركات البحث",
-    "description": "عرض في مربع التحرير"
-  },
-  "title.editAdmins": {
-    "message": "تحرير المدراء",
-    "description": "عرض في مربع التحرير"
-  },
-  "title.featuresConfig": {
-    "message": "إعدادات الميزات",
-    "description": "عرض في مربع التحرير"
-  },
-  "title.editTitle": {
-    "message": "تحرير العنوان",
-    "description": "عرض في مربع التحرير"
-  },
-  "title.editOrigin": {
-    "message": "تحرير اسم النطاق",
-    "description": "عرض في مربع التحرير"
-  },
-  "title.editKeywords": {
-    "message": "تحرير الكلمات المفتاحية",
-    "description": "عرض في مربع التحرير"
-  },
-  "title.editLogo": {
-    "message": "تحرير الشعار",
-    "description": "عرض في مربع التحرير"
-  },
-  "title.editFavicon": {
-    "message": "تحرير الفافيكون",
-    "description": "عرض في مربع التحرير"
-  },
-  "title.editDescription": {
-    "message": "تحرير الوصف",
-    "description": "عرض في مربع التحرير"
-  },
-  "title.distributionConfig": {
-    "message": "إعدادات التوزيع",
-    "description": "عرض في مربع التحرير"
-  },
-  "title.editDistributionDefaultInviterId": {
-    "message": "تحرير المدعو الافتراضي",
-    "description": "عرض في مربع التحرير"
-  },
-  "title.editDistributionForceInviterId": {
-    "message": "تحرير المدعو الإجباري",
-    "description": "عرض في مربع التحرير"
-  },
-  "title.editQR": {
-    "message": "تعديل رمز الاستجابة السريعة",
-    "description": "عرض في عنوان مربع التحرير"
-  },
-  "title.editUrl": {
-    "message": "تعديل الرابط",
-    "description": "عرض في عنوان مربع التحرير"
-  },
-  "placeholder.title": {
-    "message": "أدخل عنوان الموقع",
-    "description": "عرض في مربع التحرير"
-  },
-  "placeholder.origin": {
-    "message": "أدخل اسم نطاق الموقع",
-    "description": "عرض في مربع التحرير"
-  },
-  "placeholder.editUrl": {
-    "message": "أدخل الرابط",
-    "description": "عرض في مربع التحرير"
-  },
-  "placeholder.description": {
-    "message": "أدخل وصف الموقع",
-    "description": "عرض في مربع التحرير"
-  },
-  "placeholder.keywords": {
-    "message": "أدخل كلمات مفتاحية للموقع",
-    "description": "عرض في مربع التحرير"
-  },
-  "placeholder.editDistributionDefaultInviterId": {
-    "message": "أدخل معرف المدعو الافتراضي",
-    "description": "عرض في مربع التحرير"
-  },
-  "placeholder.editDistributionForceInviterId": {
-    "message": "أدخل معرف المدعو الإجباري",
-    "description": "عرض في مربع التحرير"
-  },
-  "message.uploadImageExceed": {
-    "message": "تجاوز حد رفع الصورة",
-    "description": "تنبيه عند تجاوز حد رفع الصورة"
-  },
-  "message.uploadImageError": {
-    "message": "خطأ في رفع الصورة",
-    "description": "تنبيه عند حدوث خطأ في رفع الصورة"
-  },
-  "message.editLogoTip": {
-    "message": "الأبعاد الموصى بها: 200*60 بكسل",
-    "description": "لغة تنبيه رفع الصورة"
-  },
-  "message.editQRTip": {
-    "message": "الأبعاد الموصى بها: 200*200 بكسل",
-    "description": "لغة تنبيه رفع الصورة"
-  },
-  "message.editFaviconTip": {
-    "message": "الأبعاد الموصى بها: 32*32 بكسل",
-    "description": "لغة تنبيه رفع الصورة"
-  },
-  "message.editUrl": {
-    "message": "أدخل الرابط",
-    "description": "تنبيه لإدخال الرابط"
-  },
-  "message.atLeastOneAdmin": {
-    "message": "يجب الاحتفاظ بمدير واحد على الأقل",
-    "description": "تنبيه للاحتفاظ بمدير واحد على الأقل"
-  },
-  "message.distributionDefaultInviterIdTip": {
-    "message": "معرف المستخدم للمدعو الافتراضي، إذا لم يحمل رابط التوزيع معلمة inviter_id، سيتم استخدام هذا المعرف كمدعو افتراضي.",
-    "description": "تنبيه معرف المدعو الافتراضي"
-  },
-  "message.distributionForceInviterIdTip": {
-    "message": "معرف المستخدم للمدعو الإجباري، إذا تم تعيين هذا المعرف، سيتم استخدامه كمدعو بغض النظر عما إذا كان رابط التوزيع يحمل معلمة inviter_id.",
-    "description": "تنبيه معرف المدعو الإجباري"
-  },
-  "message.originTip": {
-    "message": "اسم نطاق الموقع، يتم ربط إعدادات الموقع بالنطاق، ولا يمكن تغيير اسم نطاق الموقع.",
-    "description": "تنبيه اسم نطاق الموقع"
-  },
-  "message.titleTip": {
-    "message": "عنوان الموقع، يظهر في علامة تبويب المتصفح.",
-    "description": "تنبيه عنوان الموقع"
-  },
-  "message.descriptionTip": {
-    "message": "وصف الموقع، موجود في معلومات الموقع الوصفية، يستخدم لتحسين SEO للموقع.",
-    "description": "تنبيه وصف الموقع"
-  },
-  "message.logoTip": {
-    "message": "شعار الموقع، يظهر في أعلى قائمة الموقع عند فتح القائمة.",
-    "description": "تنبيه شعار الموقع"
-  },
-  "message.faviconTip": {
-    "message": "فافيكون الموقع، يظهر في علامة تبويب المتصفح.",
-    "description": "تنبيه فافيكون الموقع"
-  },
-  "message.adminsTip": {
-    "message": "معرفات مديري الموقع، المستخدم الذي ينشئ الموقع لأول مرة يصبح مديرًا بشكل افتراضي، فقط مديري الموقع يمكنهم إدارة الموقع.",
-    "description": "تنبيه مديري الموقع"
-  },
-  "message.adminsTip2": {
-    "message": "يمكنك إضافة أو حذف معرفات المديرين هنا، يمكنك زيارة https://auth.acedata.cloud لرؤية معرفات المستخدمين",
-    "description": "تنبيه مديري الموقع"
-  },
-  "message.keywordsTip": {
-    "message": "كلمات مفتاحية للموقع، موجودة في المعلومات الوصفية للموقع، تستخدم لتحسين SEO للموقع.",
-    "description": "تنبيه كلمات مفتاحية للموقع"
-  },
-  "message.keywordsTip2": {
-    "message": "يمكنك إضافة أو حذف كلمات مفتاحية للموقع هنا، كلما كانت الكلمات أكثر دقة، كانت أفضل لتحسين SEO.",
-    "description": "تنبيه كلمات مفتاحية للموقع"
-  },
-  "message.featuresChat": {
-    "message": "تفعيل أو تعطيل وحدة وظيفة الدردشة.",
-    "description": "وصف وظيفة الدردشة"
-  },
-  "message.featuresGrok": {
-    "message": "تفعيل أو تعطيل وحدة وظيفة Grok.",
-    "description": "وصف وظيفة Grok"
-  },
-  "message.featuresDeepseek": {
-    "message": "تفعيل أو تعطيل وحدة وظيفة Deepseek.",
-    "description": "وصف وظيفة Deepseek"
-  },
-  "message.featuresChatgpt": {
-    "message": "تفعيل أو تعطيل وحدة وظيفة ChatGPT.",
-    "description": "وصف وظيفة ChatGPT"
-  },
-  "message.featuresMidjourney": {
-    "message": "تفعيل أو تعطيل وحدة وظيفة Midjourney.",
-    "description": "وصف وظيفة Midjourney"
-  },
-  "message.featuresChatdoc": {
-    "message": "تفعيل أو تعطيل وحدة وظيفة Chatdoc.",
-    "description": "وصف وظيفة Chatdoc"
-  },
-  "message.featuresQrart": {
-    "message": "تفعيل أو تعطيل وحدة وظيفة Qrart.",
-    "description": "وصف وظيفة Qrart"
-  },
-  "message.featuresVeo": {
-    "message": "تفعيل أو تعطيل وحدة وظيفة Veo.",
-    "description": "وصف وظيفة Veo"
-  },
-  "message.featuresSora": {
-    "message": "تفعيل أو تعطيل وحدة وظيفة Sora.",
-    "description": "وصف وظيفة Sora"
-  },
-  "message.featuresSuno": {
-    "message": "تفعيل أو تعطيل وحدة وظيفة Suno.",
-    "description": "وصف وظيفة Suno"
-  },
-  "message.featuresPixverse": {
-    "message": "قم بتشغيل أو إيقاف تشغيل وحدة ميزات Pixverse.",
-    "description": "وصف ميزات Pixverse"
-  },
-  "message.featuresFlux": {
-    "message": "قم بتشغيل أو إيقاف تشغيل وحدة ميزات FLux.",
-    "description": "وصف ميزات FLux"
-  },
-  "message.featuresNanobanana": {
-    "message": "قم بتشغيل أو إيقاف تشغيل وحدة ميزات Nano Banana.",
-    "description": "وصف ميزات Nano Banana"
-  },
-  "message.featuresSeedream": {
-    "message": "قم بتشغيل أو إيقاف تشغيل وحدة ميزات SeeDream.",
-    "description": "وصف ميزات SeeDream"
-  },
-  "message.featuresSeedance": {
-    "message": "قم بتمكين أو تعطيل وحدة ميزات SeeDance.",
-    "description": "وصف ميزات SeeDance"
-  },
-  "message.featuresWan": {
-    "message": "قم بتشغيل أو إيقاف تشغيل وحدة ميزات Wan.",
-    "description": "وصف ميزات Wan"
-  },
-  "message.featuresProducer": {
-    "message": "قم بتشغيل أو إيقاف تشغيل وحدة ميزات Producer.",
-    "description": "وصف ميزات Producer"
-  },
-  "message.featuresKimi": {
-    "message": "قم بتشغيل أو إيقاف تشغيل وحدة ميزات Kimi.",
-    "description": "وصف ميزات Kimi"
-  },
-  "message.featuresSerp": {
-    "message": "قم بتشغيل أو إيقاف تشغيل وحدة ميزات SERP.",
-    "description": "وصف ميزات SERP"
-  },
-  "message.featuresLuma": {
-    "message": "قم بتشغيل أو إيقاف تشغيل وحدة ميزات Luma.",
-    "description": "وصف ميزات Luma"
-  },
-  "message.featuresPika": {
-    "message": "قم بتشغيل أو إيقاف تشغيل وحدة ميزات Pika.",
-    "description": "وصف ميزات Pika"
-  },
-  "message.featuresKling": {
-    "message": "قم بتشغيل أو إيقاف تشغيل وحدة ميزات Kling.",
-    "description": "وصف ميزات Kling"
-  },
-  "message.featuresHailuo": {
-    "message": "قم بتشغيل أو إيقاف تشغيل وحدة ميزات Hailuo.",
-    "description": "وصف ميزات Hailuo"
-  },
-  "message.featuresHeadshots": {
-    "message": "قم بتشغيل أو إيقاف تشغيل وحدة ميزات صور الهوية AI.",
-    "description": "وصف ميزات صور الهوية AI"
-  },
-  "message.featuresSupport": {
-    "message": "قم بتشغيل أو إيقاف تشغيل دعم العملاء",
-    "description": "وصف ميزات الدعم"
-  },
-  "message.featuresI18n": {
-    "message": "قم بتشغيل أو إيقاف تشغيل الدعم متعدد اللغات، بعد الإيقاف، يمكن للمستخدمين استخدام اللغة الافتراضية فقط.",
-    "description": "وصف الدعم متعدد اللغات"
-  },
-  "button.upload": {
-    "message": "رفع",
-    "description": "رفع"
-  },
-  "button.enabled": {
-    "message": "مفعل",
-    "description": "نص التبديل، يشير إلى أنه تم تفعيله"
-  },
-  "button.disabled": {
-    "message": "معطل",
-    "description": "نص التبديل، يشير إلى أنه تم تعطيله"
-  },
-  "field.featuresGemini": {
-    "message": "جمني",
-    "description": "يظهر كعنوان في صندوق التحرير"
-  },
-  "message.featuresGemini": {
-    "message": "قم بتمكين أو تعطيل وحدة ميزات Gemini.",
-    "description": "وصف ميزات Gemini"
-  },
-  "field.featuresClaude": {
-    "message": "كلود",
-    "description": "يظهر كعنوان في صندوق التحرير"
-  },
-  "message.featuresClaude": {
-    "message": "قم بتمكين أو تعطيل وحدة ميزات Claude.",
-    "description": "وصف ميزات Claude"
-  }
+  "field.title": [
+    [
+      "message",
+      "عنوان الموقع"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "field.origin": [
+    [
+      "message",
+      "اسم نطاق الموقع"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "field.description": [
+    [
+      "message",
+      "وصف الموقع"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "field.keywords": [
+    [
+      "message",
+      "كلمات مفتاحية للموقع"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "field.logo": [
+    [
+      "message",
+      "شعار الموقع"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "field.favicon": [
+    [
+      "message",
+      "فافيكون الموقع"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "field.qr": [
+    [
+      "message",
+      "رمز الاستجابة السريعة"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "field.url": [
+    [
+      "message",
+      "رابط"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "field.admins": [
+    [
+      "message",
+      "معرفات مديري الموقع"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "field.distributionDefaultInviterId": [
+    [
+      "message",
+      "معرف المدعو الافتراضي"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "field.distributionForceInviterId": [
+    [
+      "message",
+      "معرف المدعو الإجباري"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "field.featuresChat": [
+    [
+      "message",
+      "دردشة"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "field.featuresVeo": [
+    [
+      "message",
+      "فيو"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "field.featuresSora": [
+    [
+      "message",
+      "سورا"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "field.featuresGrok": [
+    [
+      "message",
+      "غروك"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "field.featuresDeepseek": [
+    [
+      "message",
+      "ديب سيك"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "field.featuresChatgpt": [
+    [
+      "message",
+      "تشات جي بي تي"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "field.featuresMidjourney": [
+    [
+      "message",
+      "ميدجورني"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "field.featuresChatdoc": [
+    [
+      "message",
+      "تشات دوك"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "field.featuresQrart": [
+    [
+      "message",
+      "كيو آر آرت"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "field.featuresLuma": [
+    [
+      "message",
+      "لما"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "field.featuresPixverse": [
+    [
+      "message",
+      "بيكسفيرس"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "field.featuresPika": [
+    [
+      "message",
+      "بيكا"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "field.featuresKling": [
+    [
+      "message",
+      "كلينغ"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "field.featuresHailuo": [
+    [
+      "message",
+      "هاي لو"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "field.featuresHeadshots": [
+    [
+      "message",
+      "صور هوية بالذكاء الاصطناعي"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "field.featuresSuno": [
+    [
+      "message",
+      "سونو"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "field.featuresFlux": [
+    [
+      "message",
+      "فلوكس"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "field.featuresNanobanana": [
+    [
+      "message",
+      "موز نانو"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "field.featuresOpenaiimage": {
+    "message": "OpenAI Image",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresSeedream": [
+    [
+      "message",
+      "سي دريم"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "field.featuresSeedance": [
+    [
+      "message",
+      "سي دانس"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "field.featuresWan": [
+    [
+      "message",
+      "وان"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "field.featuresProducer": [
+    [
+      "message",
+      "منتج"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "field.featuresKimi": [
+    [
+      "message",
+      "كي مي"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "field.featuresSerp": [
+    [
+      "message",
+      "سيرب"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "field.featuresSupport": [
+    [
+      "message",
+      "دعم العملاء"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "field.featuresI18n": [
+    [
+      "message",
+      "دعم متعدد اللغات"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "title.basicConfig": [
+    [
+      "message",
+      "الإعدادات الأساسية"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "title.seoConfig": [
+    [
+      "message",
+      "إعدادات تحسين محركات البحث"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "title.editAdmins": [
+    [
+      "message",
+      "تحرير المدراء"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "title.featuresConfig": [
+    [
+      "message",
+      "إعدادات الميزات"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "title.editTitle": [
+    [
+      "message",
+      "تحرير العنوان"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "title.editOrigin": [
+    [
+      "message",
+      "تحرير اسم النطاق"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "title.editKeywords": [
+    [
+      "message",
+      "تحرير الكلمات المفتاحية"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "title.editLogo": [
+    [
+      "message",
+      "تحرير الشعار"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "title.editFavicon": [
+    [
+      "message",
+      "تحرير الفافيكون"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "title.editDescription": [
+    [
+      "message",
+      "تحرير الوصف"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "title.distributionConfig": [
+    [
+      "message",
+      "إعدادات التوزيع"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "title.editDistributionDefaultInviterId": [
+    [
+      "message",
+      "تحرير المدعو الافتراضي"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "title.editDistributionForceInviterId": [
+    [
+      "message",
+      "تحرير المدعو الإجباري"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "title.editQR": [
+    [
+      "message",
+      "تعديل رمز الاستجابة السريعة"
+    ],
+    [
+      "description",
+      "عرض في عنوان مربع التحرير"
+    ]
+  ],
+  "title.editUrl": [
+    [
+      "message",
+      "تعديل الرابط"
+    ],
+    [
+      "description",
+      "عرض في عنوان مربع التحرير"
+    ]
+  ],
+  "placeholder.title": [
+    [
+      "message",
+      "أدخل عنوان الموقع"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "placeholder.origin": [
+    [
+      "message",
+      "أدخل اسم نطاق الموقع"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "placeholder.editUrl": [
+    [
+      "message",
+      "أدخل الرابط"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "placeholder.description": [
+    [
+      "message",
+      "أدخل وصف الموقع"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "placeholder.keywords": [
+    [
+      "message",
+      "أدخل كلمات مفتاحية للموقع"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "placeholder.editDistributionDefaultInviterId": [
+    [
+      "message",
+      "أدخل معرف المدعو الافتراضي"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "placeholder.editDistributionForceInviterId": [
+    [
+      "message",
+      "أدخل معرف المدعو الإجباري"
+    ],
+    [
+      "description",
+      "عرض في مربع التحرير"
+    ]
+  ],
+  "message.uploadImageExceed": [
+    [
+      "message",
+      "تجاوز حد رفع الصورة"
+    ],
+    [
+      "description",
+      "تنبيه عند تجاوز حد رفع الصورة"
+    ]
+  ],
+  "message.uploadImageError": [
+    [
+      "message",
+      "خطأ في رفع الصورة"
+    ],
+    [
+      "description",
+      "تنبيه عند حدوث خطأ في رفع الصورة"
+    ]
+  ],
+  "message.editLogoTip": [
+    [
+      "message",
+      "الأبعاد الموصى بها: 200*60 بكسل"
+    ],
+    [
+      "description",
+      "لغة تنبيه رفع الصورة"
+    ]
+  ],
+  "message.editQRTip": [
+    [
+      "message",
+      "الأبعاد الموصى بها: 200*200 بكسل"
+    ],
+    [
+      "description",
+      "لغة تنبيه رفع الصورة"
+    ]
+  ],
+  "message.editFaviconTip": [
+    [
+      "message",
+      "الأبعاد الموصى بها: 32*32 بكسل"
+    ],
+    [
+      "description",
+      "لغة تنبيه رفع الصورة"
+    ]
+  ],
+  "message.editUrl": [
+    [
+      "message",
+      "أدخل الرابط"
+    ],
+    [
+      "description",
+      "تنبيه لإدخال الرابط"
+    ]
+  ],
+  "message.atLeastOneAdmin": [
+    [
+      "message",
+      "يجب الاحتفاظ بمدير واحد على الأقل"
+    ],
+    [
+      "description",
+      "تنبيه للاحتفاظ بمدير واحد على الأقل"
+    ]
+  ],
+  "message.distributionDefaultInviterIdTip": [
+    [
+      "message",
+      "معرف المستخدم للمدعو الافتراضي، إذا لم يحمل رابط التوزيع معلمة inviter_id، سيتم استخدام هذا المعرف كمدعو افتراضي."
+    ],
+    [
+      "description",
+      "تنبيه معرف المدعو الافتراضي"
+    ]
+  ],
+  "message.distributionForceInviterIdTip": [
+    [
+      "message",
+      "معرف المستخدم للمدعو الإجباري، إذا تم تعيين هذا المعرف، سيتم استخدامه كمدعو بغض النظر عما إذا كان رابط التوزيع يحمل معلمة inviter_id."
+    ],
+    [
+      "description",
+      "تنبيه معرف المدعو الإجباري"
+    ]
+  ],
+  "message.originTip": [
+    [
+      "message",
+      "اسم نطاق الموقع، يتم ربط إعدادات الموقع بالنطاق، ولا يمكن تغيير اسم نطاق الموقع."
+    ],
+    [
+      "description",
+      "تنبيه اسم نطاق الموقع"
+    ]
+  ],
+  "message.titleTip": [
+    [
+      "message",
+      "عنوان الموقع، يظهر في علامة تبويب المتصفح."
+    ],
+    [
+      "description",
+      "تنبيه عنوان الموقع"
+    ]
+  ],
+  "message.descriptionTip": [
+    [
+      "message",
+      "وصف الموقع، موجود في معلومات الموقع الوصفية، يستخدم لتحسين SEO للموقع."
+    ],
+    [
+      "description",
+      "تنبيه وصف الموقع"
+    ]
+  ],
+  "message.logoTip": [
+    [
+      "message",
+      "شعار الموقع، يظهر في أعلى قائمة الموقع عند فتح القائمة."
+    ],
+    [
+      "description",
+      "تنبيه شعار الموقع"
+    ]
+  ],
+  "message.faviconTip": [
+    [
+      "message",
+      "فافيكون الموقع، يظهر في علامة تبويب المتصفح."
+    ],
+    [
+      "description",
+      "تنبيه فافيكون الموقع"
+    ]
+  ],
+  "message.adminsTip": [
+    [
+      "message",
+      "معرفات مديري الموقع، المستخدم الذي ينشئ الموقع لأول مرة يصبح مديرًا بشكل افتراضي، فقط مديري الموقع يمكنهم إدارة الموقع."
+    ],
+    [
+      "description",
+      "تنبيه مديري الموقع"
+    ]
+  ],
+  "message.adminsTip2": [
+    [
+      "message",
+      "يمكنك إضافة أو حذف معرفات المديرين هنا، يمكنك زيارة https://auth.acedata.cloud لرؤية معرفات المستخدمين"
+    ],
+    [
+      "description",
+      "تنبيه مديري الموقع"
+    ]
+  ],
+  "message.keywordsTip": [
+    [
+      "message",
+      "كلمات مفتاحية للموقع، موجودة في المعلومات الوصفية للموقع، تستخدم لتحسين SEO للموقع."
+    ],
+    [
+      "description",
+      "تنبيه كلمات مفتاحية للموقع"
+    ]
+  ],
+  "message.keywordsTip2": [
+    [
+      "message",
+      "يمكنك إضافة أو حذف كلمات مفتاحية للموقع هنا، كلما كانت الكلمات أكثر دقة، كانت أفضل لتحسين SEO."
+    ],
+    [
+      "description",
+      "تنبيه كلمات مفتاحية للموقع"
+    ]
+  ],
+  "message.featuresChat": [
+    [
+      "message",
+      "تفعيل أو تعطيل وحدة وظيفة الدردشة."
+    ],
+    [
+      "description",
+      "وصف وظيفة الدردشة"
+    ]
+  ],
+  "message.featuresGrok": [
+    [
+      "message",
+      "تفعيل أو تعطيل وحدة وظيفة Grok."
+    ],
+    [
+      "description",
+      "وصف وظيفة Grok"
+    ]
+  ],
+  "message.featuresDeepseek": [
+    [
+      "message",
+      "تفعيل أو تعطيل وحدة وظيفة Deepseek."
+    ],
+    [
+      "description",
+      "وصف وظيفة Deepseek"
+    ]
+  ],
+  "message.featuresChatgpt": [
+    [
+      "message",
+      "تفعيل أو تعطيل وحدة وظيفة ChatGPT."
+    ],
+    [
+      "description",
+      "وصف وظيفة ChatGPT"
+    ]
+  ],
+  "message.featuresMidjourney": [
+    [
+      "message",
+      "تفعيل أو تعطيل وحدة وظيفة Midjourney."
+    ],
+    [
+      "description",
+      "وصف وظيفة Midjourney"
+    ]
+  ],
+  "message.featuresChatdoc": [
+    [
+      "message",
+      "تفعيل أو تعطيل وحدة وظيفة Chatdoc."
+    ],
+    [
+      "description",
+      "وصف وظيفة Chatdoc"
+    ]
+  ],
+  "message.featuresQrart": [
+    [
+      "message",
+      "تفعيل أو تعطيل وحدة وظيفة Qrart."
+    ],
+    [
+      "description",
+      "وصف وظيفة Qrart"
+    ]
+  ],
+  "message.featuresVeo": [
+    [
+      "message",
+      "تفعيل أو تعطيل وحدة وظيفة Veo."
+    ],
+    [
+      "description",
+      "وصف وظيفة Veo"
+    ]
+  ],
+  "message.featuresSora": [
+    [
+      "message",
+      "تفعيل أو تعطيل وحدة وظيفة Sora."
+    ],
+    [
+      "description",
+      "وصف وظيفة Sora"
+    ]
+  ],
+  "message.featuresSuno": [
+    [
+      "message",
+      "تفعيل أو تعطيل وحدة وظيفة Suno."
+    ],
+    [
+      "description",
+      "وصف وظيفة Suno"
+    ]
+  ],
+  "message.featuresPixverse": [
+    [
+      "message",
+      "قم بتشغيل أو إيقاف تشغيل وحدة ميزات Pixverse."
+    ],
+    [
+      "description",
+      "وصف ميزات Pixverse"
+    ]
+  ],
+  "message.featuresFlux": [
+    [
+      "message",
+      "قم بتشغيل أو إيقاف تشغيل وحدة ميزات FLux."
+    ],
+    [
+      "description",
+      "وصف ميزات FLux"
+    ]
+  ],
+  "message.featuresNanobanana": [
+    [
+      "message",
+      "قم بتشغيل أو إيقاف تشغيل وحدة ميزات Nano Banana."
+    ],
+    [
+      "description",
+      "وصف ميزات Nano Banana"
+    ]
+  ],
+  "message.featuresOpenaiimage": {
+    "message": "Toggle OpenAI Image feature module.",
+    "description": "Description of the OpenAI Image feature"
+  },
+  "message.featuresSeedream": [
+    [
+      "message",
+      "قم بتشغيل أو إيقاف تشغيل وحدة ميزات SeeDream."
+    ],
+    [
+      "description",
+      "وصف ميزات SeeDream"
+    ]
+  ],
+  "message.featuresSeedance": [
+    [
+      "message",
+      "قم بتمكين أو تعطيل وحدة ميزات SeeDance."
+    ],
+    [
+      "description",
+      "وصف ميزات SeeDance"
+    ]
+  ],
+  "message.featuresWan": [
+    [
+      "message",
+      "قم بتشغيل أو إيقاف تشغيل وحدة ميزات Wan."
+    ],
+    [
+      "description",
+      "وصف ميزات Wan"
+    ]
+  ],
+  "message.featuresProducer": [
+    [
+      "message",
+      "قم بتشغيل أو إيقاف تشغيل وحدة ميزات Producer."
+    ],
+    [
+      "description",
+      "وصف ميزات Producer"
+    ]
+  ],
+  "message.featuresKimi": [
+    [
+      "message",
+      "قم بتشغيل أو إيقاف تشغيل وحدة ميزات Kimi."
+    ],
+    [
+      "description",
+      "وصف ميزات Kimi"
+    ]
+  ],
+  "message.featuresSerp": [
+    [
+      "message",
+      "قم بتشغيل أو إيقاف تشغيل وحدة ميزات SERP."
+    ],
+    [
+      "description",
+      "وصف ميزات SERP"
+    ]
+  ],
+  "message.featuresLuma": [
+    [
+      "message",
+      "قم بتشغيل أو إيقاف تشغيل وحدة ميزات Luma."
+    ],
+    [
+      "description",
+      "وصف ميزات Luma"
+    ]
+  ],
+  "message.featuresPika": [
+    [
+      "message",
+      "قم بتشغيل أو إيقاف تشغيل وحدة ميزات Pika."
+    ],
+    [
+      "description",
+      "وصف ميزات Pika"
+    ]
+  ],
+  "message.featuresKling": [
+    [
+      "message",
+      "قم بتشغيل أو إيقاف تشغيل وحدة ميزات Kling."
+    ],
+    [
+      "description",
+      "وصف ميزات Kling"
+    ]
+  ],
+  "message.featuresHailuo": [
+    [
+      "message",
+      "قم بتشغيل أو إيقاف تشغيل وحدة ميزات Hailuo."
+    ],
+    [
+      "description",
+      "وصف ميزات Hailuo"
+    ]
+  ],
+  "message.featuresHeadshots": [
+    [
+      "message",
+      "قم بتشغيل أو إيقاف تشغيل وحدة ميزات صور الهوية AI."
+    ],
+    [
+      "description",
+      "وصف ميزات صور الهوية AI"
+    ]
+  ],
+  "message.featuresSupport": [
+    [
+      "message",
+      "قم بتشغيل أو إيقاف تشغيل دعم العملاء"
+    ],
+    [
+      "description",
+      "وصف ميزات الدعم"
+    ]
+  ],
+  "message.featuresI18n": [
+    [
+      "message",
+      "قم بتشغيل أو إيقاف تشغيل الدعم متعدد اللغات، بعد الإيقاف، يمكن للمستخدمين استخدام اللغة الافتراضية فقط."
+    ],
+    [
+      "description",
+      "وصف الدعم متعدد اللغات"
+    ]
+  ],
+  "button.upload": [
+    [
+      "message",
+      "رفع"
+    ],
+    [
+      "description",
+      "رفع"
+    ]
+  ],
+  "button.enabled": [
+    [
+      "message",
+      "مفعل"
+    ],
+    [
+      "description",
+      "نص التبديل، يشير إلى أنه تم تفعيله"
+    ]
+  ],
+  "button.disabled": [
+    [
+      "message",
+      "معطل"
+    ],
+    [
+      "description",
+      "نص التبديل، يشير إلى أنه تم تعطيله"
+    ]
+  ],
+  "field.featuresGemini": [
+    [
+      "message",
+      "جمني"
+    ],
+    [
+      "description",
+      "يظهر كعنوان في صندوق التحرير"
+    ]
+  ],
+  "message.featuresGemini": [
+    [
+      "message",
+      "قم بتمكين أو تعطيل وحدة ميزات Gemini."
+    ],
+    [
+      "description",
+      "وصف ميزات Gemini"
+    ]
+  ],
+  "field.featuresClaude": [
+    [
+      "message",
+      "كلود"
+    ],
+    [
+      "description",
+      "يظهر كعنوان في صندوق التحرير"
+    ]
+  ],
+  "message.featuresClaude": [
+    [
+      "message",
+      "قم بتمكين أو تعطيل وحدة ميزات Claude."
+    ],
+    [
+      "description",
+      "وصف ميزات Claude"
+    ]
+  ]
 }

--- a/src/i18n/de/site.json
+++ b/src/i18n/de/site.json
@@ -1,442 +1,1110 @@
 {
-  "field.title": {
-    "message": "Seitenüberschrift",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "field.origin": {
-    "message": "Seiten-Domain",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "field.description": {
-    "message": "Seitenbeschreibung",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "field.keywords": {
-    "message": "Seitenkeywords",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "field.logo": {
-    "message": "Seitenlogo",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "field.favicon": {
-    "message": "Seiten-Favicon",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "field.qr": {
-    "message": "QR-Code",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "field.url": {
-    "message": "Link",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "field.admins": {
-    "message": "Seiten-Admin-ID",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "field.distributionDefaultInviterId": {
-    "message": "Standard-Einladungs-ID",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "field.distributionForceInviterId": {
-    "message": "Zwangseinladungs-ID",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "field.featuresChat": {
-    "message": "Chat",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "field.featuresVeo": {
-    "message": "Veo",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "field.featuresSora": {
-    "message": "Sora",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "field.featuresGrok": {
-    "message": "Grok",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "field.featuresDeepseek": {
-    "message": "Deepseek",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "field.featuresChatgpt": {
-    "message": "ChatGPT",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "field.featuresMidjourney": {
-    "message": "Midjourney",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "field.featuresChatdoc": {
-    "message": "Chatdoc",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "field.featuresQrart": {
-    "message": "Qrart",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "field.featuresLuma": {
-    "message": "Luma",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "field.featuresPixverse": {
-    "message": "Pixverse",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "field.featuresPika": {
-    "message": "Pika",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "field.featuresKling": {
-    "message": "Kling",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "field.featuresHailuo": {
-    "message": "Hailuo",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "field.featuresHeadshots": {
-    "message": "AI-Porträt",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "field.featuresSuno": {
-    "message": "Suno",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "field.featuresFlux": {
-    "message": "Flux",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "field.featuresNanobanana": {
-    "message": "Nano-Banane",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "field.featuresSeedream": {
-    "message": "SeeDream",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "field.featuresSeedance": {
-    "message": "SeeDance",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "field.featuresWan": {
-    "message": "Wan",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "field.featuresProducer": {
-    "message": "Produzent",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "field.featuresKimi": {
-    "message": "Kimi",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "field.featuresSerp": {
-    "message": "SERP",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "field.featuresSupport": {
-    "message": "Kundensupport",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "field.featuresI18n": {
-    "message": "Mehrsprachige Unterstützung",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "title.basicConfig": {
-    "message": "Basis-Konfiguration",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "title.seoConfig": {
-    "message": "SEO-Konfiguration",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "title.editAdmins": {
-    "message": "Admins bearbeiten",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "title.featuresConfig": {
-    "message": "Funktionskonfiguration",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "title.editTitle": {
-    "message": "Titel bearbeiten",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "title.editOrigin": {
-    "message": "Domain bearbeiten",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "title.editKeywords": {
-    "message": "Keywords bearbeiten",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "title.editLogo": {
-    "message": "Logo bearbeiten",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "title.editFavicon": {
-    "message": "Favicon bearbeiten",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "title.editDescription": {
-    "message": "Beschreibung bearbeiten",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "title.distributionConfig": {
-    "message": "Vertriebskonfiguration",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "title.editDistributionDefaultInviterId": {
-    "message": "Standard-Einladungs-ID bearbeiten",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "title.editDistributionForceInviterId": {
-    "message": "Zwangseinladungs-ID bearbeiten",
-    "description": "Anzeige im Bearbeitungsfeld"
-  },
-  "title.editQR": {
-    "message": "QR-Code bearbeiten",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editUrl": {
-    "message": "Link bearbeiten",
-    "description": "展示在编辑框的标题"
-  },
-  "placeholder.title": {
-    "message": "Bitte Titel der Seite eingeben",
-    "description": "展示在编辑框的标题"
-  },
-  "placeholder.origin": {
-    "message": "Bitte Domain der Seite eingeben",
-    "description": "展示在编辑框的标题"
-  },
-  "placeholder.editUrl": {
-    "message": "Bitte Link eingeben",
-    "description": "展示在编辑框的标题"
-  },
-  "placeholder.description": {
-    "message": "Bitte Beschreibung der Seite eingeben",
-    "description": "展示在编辑框的标题"
-  },
-  "placeholder.keywords": {
-    "message": "Bitte Schlüsselwörter der Seite eingeben",
-    "description": "展示在编辑框的标题"
-  },
-  "placeholder.editDistributionDefaultInviterId": {
-    "message": "Bitte Standard-Einladenden-ID eingeben",
-    "description": "展示在编辑框的标题"
-  },
-  "placeholder.editDistributionForceInviterId": {
-    "message": "Bitte zwingende Einladenden-ID eingeben",
-    "description": "展示在编辑框的标题"
-  },
-  "message.uploadImageExceed": {
-    "message": "Bildüberschreitung des Upload-Limits",
-    "description": "上传图片超过限制的提示"
-  },
-  "message.uploadImageError": {
-    "message": "Fehler beim Hochladen des Bildes",
-    "description": "上传图片错误的提示"
-  },
-  "message.editLogoTip": {
-    "message": "Empfohlene Größe: 200*60px",
-    "description": "上传图片的提示语言"
-  },
-  "message.editQRTip": {
-    "message": "Empfohlene Größe: 200*200px",
-    "description": "上传图片的提示语言"
-  },
-  "message.editFaviconTip": {
-    "message": "Empfohlene Größe: 32*32px",
-    "description": "上传图片的提示语言"
-  },
-  "message.editUrl": {
-    "message": "Bitte Link eingeben",
-    "description": "请输入链接的提示"
-  },
-  "message.atLeastOneAdmin": {
-    "message": "Mindestens einen Administrator behalten",
-    "description": "至少保留一个管理员的提示"
-  },
-  "message.distributionDefaultInviterIdTip": {
-    "message": "Benutzer-ID des Standard-Einladenden. Wenn der Verlinkungsparameter inviter_id nicht vorhanden ist, wird diese Benutzer-ID als Einladender verwendet.",
-    "description": "默认邀请人ID的提示"
-  },
-  "message.distributionForceInviterIdTip": {
-    "message": "Benutzer-ID des zwingenden Einladenden. Wenn diese ID gesetzt ist, wird unabhängig davon, ob der Verlinkungsparameter inviter_id vorhanden ist, diese Benutzer-ID als Einladender verwendet.",
-    "description": "强制邀请人ID的提示"
-  },
-  "message.originTip": {
-    "message": "Domain der Seite, die Konfiguration der Seite ist an die Domain gebunden und kann nicht geändert werden.",
-    "description": "站点域名的提示"
-  },
-  "message.titleTip": {
-    "message": "Titel der Seite, angezeigt im Browser-Tab.",
-    "description": "站点标题的提示"
-  },
-  "message.descriptionTip": {
-    "message": "Beschreibung der Seite, im Metainformationen der Seite, für SEO-Optimierung.",
-    "description": "站点描述的提示"
-  },
-  "message.logoTip": {
-    "message": "Logo der Seite, angezeigt oben im Menü, wenn das Menü ausgeklappt ist.",
-    "description": "站点 Logo 的提示"
-  },
-  "message.faviconTip": {
-    "message": "Favicon der Seite, angezeigt im Browser-Tab.",
-    "description": "站点 Favicon 的提示"
-  },
-  "message.adminsTip": {
-    "message": "Administrator-ID der Seite. Standardmäßig wird der Benutzer, der die Seite zuerst erstellt, Administrator. Nur Administratoren können die Seite verwalten.",
-    "description": "站点管理员的提示"
-  },
-  "message.adminsTip2": {
-    "message": "Hier können Administrator-IDs hinzugefügt oder entfernt werden. Benutzer-IDs können unter https://auth.acedata.cloud eingesehen werden.",
-    "description": "站点管理员的提示"
-  },
-  "message.keywordsTip": {
-    "message": "Schlüsselwörter der Seite, im Metainformationen der Seite, für SEO-Optimierung.",
-    "description": "站点关键词的提示"
-  },
-  "message.keywordsTip2": {
-    "message": "Hier können Schlüsselwörter der Website hinzugefügt oder entfernt werden. Je präziser die Schlüsselwörter, desto besser für die SEO-Optimierung.",
-    "description": "站点关键词的提示"
-  },
-  "message.featuresChat": {
-    "message": "Chat-Funktion aktivieren oder deaktivieren.",
-    "description": "Chat 功能的描述"
-  },
-  "message.featuresGrok": {
-    "message": "Grok-Funktion aktivieren oder deaktivieren.",
-    "description": "Grok 功能的描述"
-  },
-  "message.featuresDeepseek": {
-    "message": "Deepseek-Funktion aktivieren oder deaktivieren.",
-    "description": "Deepseek 功能的描述"
-  },
-  "message.featuresChatgpt": {
-    "message": "ChatGPT-Funktion aktivieren oder deaktivieren.",
-    "description": "ChatGPT 功能的描述"
-  },
-  "message.featuresMidjourney": {
-    "message": "Midjourney-Funktion aktivieren oder deaktivieren.",
-    "description": "Midjourney 功能的描述"
-  },
-  "message.featuresChatdoc": {
-    "message": "Chatdoc-Funktion aktivieren oder deaktivieren.",
-    "description": "Chatdoc 功能的描述"
-  },
-  "message.featuresQrart": {
-    "message": "Qrart-Funktion aktivieren oder deaktivieren.",
-    "description": "Qrart 功能的描述"
-  },
-  "message.featuresVeo": {
-    "message": "Veo-Funktion aktivieren oder deaktivieren.",
-    "description": "Veo 功能的描述"
-  },
-  "message.featuresSora": {
-    "message": "Sora-Funktion aktivieren oder deaktivieren.",
-    "description": "Sora 功能的描述"
-  },
-  "message.featuresSuno": {
-    "message": "Suno-Funktion aktivieren oder deaktivieren.",
-    "description": "Suno 功能的描述"
-  },
-  "message.featuresPixverse": {
-    "message": "Pixverse-Funktion aktivieren oder deaktivieren.",
-    "description": "Pixverse Funktion der Beschreibung"
-  },
-  "message.featuresFlux": {
-    "message": "FLux-Funktion aktivieren oder deaktivieren.",
-    "description": "FLux Funktion der Beschreibung"
-  },
-  "message.featuresNanobanana": {
-    "message": "Nano Banana-Funktion aktivieren oder deaktivieren.",
-    "description": "Nano Banana Funktion der Beschreibung"
-  },
-  "message.featuresSeedream": {
-    "message": "SeeDream-Funktion aktivieren oder deaktivieren.",
-    "description": "SeeDream Funktion der Beschreibung"
-  },
-  "message.featuresSeedance": {
-    "message": "SeeDance-Funktion aktivieren oder deaktivieren.",
-    "description": "SeeDance Funktion der Beschreibung"
-  },
-  "message.featuresWan": {
-    "message": "Wan-Funktion aktivieren oder deaktivieren.",
-    "description": "Wan Funktion der Beschreibung"
-  },
-  "message.featuresProducer": {
-    "message": "Producer-Funktion aktivieren oder deaktivieren.",
-    "description": "Producer Funktion der Beschreibung"
-  },
-  "message.featuresKimi": {
-    "message": "Kimi-Funktion aktivieren oder deaktivieren.",
-    "description": "Kimi Funktion der Beschreibung"
-  },
-  "message.featuresSerp": {
-    "message": "SERP-Funktion aktivieren oder deaktivieren.",
-    "description": "SERP Funktion der Beschreibung"
-  },
-  "message.featuresLuma": {
-    "message": "Luma-Funktion aktivieren oder deaktivieren.",
-    "description": "Luma Funktion der Beschreibung"
-  },
-  "message.featuresPika": {
-    "message": "Pika-Funktion aktivieren oder deaktivieren.",
-    "description": "Pika Funktion der Beschreibung"
-  },
-  "message.featuresKling": {
-    "message": "Kling-Funktion aktivieren oder deaktivieren.",
-    "description": "Kling Funktion der Beschreibung"
-  },
-  "message.featuresHailuo": {
-    "message": "Hailuo-Funktion aktivieren oder deaktivieren.",
-    "description": "Hailuo Funktion der Beschreibung"
-  },
-  "message.featuresHeadshots": {
-    "message": "AI-Passfoto-Funktion aktivieren oder deaktivieren.",
-    "description": "AI-Passfoto Funktion der Beschreibung"
-  },
-  "message.featuresSupport": {
-    "message": "Kundensupport aktivieren oder deaktivieren.",
-    "description": "Support Funktion der Beschreibung"
-  },
-  "message.featuresI18n": {
-    "message": "Mehrsprachige Unterstützung aktivieren oder deaktivieren. Bei Deaktivierung kann der Benutzer nur die Standardsprache verwenden.",
-    "description": "Mehrsprachige Unterstützung der Beschreibung"
-  },
-  "button.upload": {
-    "message": "Hochladen",
-    "description": "Hochladen"
-  },
-  "button.enabled": {
-    "message": "Aktiviert",
-    "description": "Schaltertext, der anzeigt, dass es aktiviert ist"
-  },
-  "button.disabled": {
-    "message": "Deaktiviert",
-    "description": "Schaltertext, der anzeigt, dass es deaktiviert ist"
-  },
-  "field.featuresGemini": {
-    "message": "Gemini",
-    "description": "Als Titel im Bearbeitungsfeld angezeigt"
-  },
-  "message.featuresGemini": {
-    "message": "Gemini-Funktion aktivieren oder deaktivieren.",
-    "description": "Beschreibung der Gemini Funktion"
-  },
-  "field.featuresClaude": {
-    "message": "Claude",
-    "description": "Als Titel im Bearbeitungsfeld angezeigt"
-  },
-  "message.featuresClaude": {
-    "message": "Claude-Funktion aktivieren oder deaktivieren.",
-    "description": "Beschreibung der Claude Funktion"
-  }
+  "field.title": [
+    [
+      "message",
+      "Seitenüberschrift"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "field.origin": [
+    [
+      "message",
+      "Seiten-Domain"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "field.description": [
+    [
+      "message",
+      "Seitenbeschreibung"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "field.keywords": [
+    [
+      "message",
+      "Seitenkeywords"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "field.logo": [
+    [
+      "message",
+      "Seitenlogo"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "field.favicon": [
+    [
+      "message",
+      "Seiten-Favicon"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "field.qr": [
+    [
+      "message",
+      "QR-Code"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "field.url": [
+    [
+      "message",
+      "Link"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "field.admins": [
+    [
+      "message",
+      "Seiten-Admin-ID"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "field.distributionDefaultInviterId": [
+    [
+      "message",
+      "Standard-Einladungs-ID"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "field.distributionForceInviterId": [
+    [
+      "message",
+      "Zwangseinladungs-ID"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "field.featuresChat": [
+    [
+      "message",
+      "Chat"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "field.featuresVeo": [
+    [
+      "message",
+      "Veo"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "field.featuresSora": [
+    [
+      "message",
+      "Sora"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "field.featuresGrok": [
+    [
+      "message",
+      "Grok"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "field.featuresDeepseek": [
+    [
+      "message",
+      "Deepseek"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "field.featuresChatgpt": [
+    [
+      "message",
+      "ChatGPT"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "field.featuresMidjourney": [
+    [
+      "message",
+      "Midjourney"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "field.featuresChatdoc": [
+    [
+      "message",
+      "Chatdoc"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "field.featuresQrart": [
+    [
+      "message",
+      "Qrart"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "field.featuresLuma": [
+    [
+      "message",
+      "Luma"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "field.featuresPixverse": [
+    [
+      "message",
+      "Pixverse"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "field.featuresPika": [
+    [
+      "message",
+      "Pika"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "field.featuresKling": [
+    [
+      "message",
+      "Kling"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "field.featuresHailuo": [
+    [
+      "message",
+      "Hailuo"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "field.featuresHeadshots": [
+    [
+      "message",
+      "AI-Porträt"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "field.featuresSuno": [
+    [
+      "message",
+      "Suno"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "field.featuresFlux": [
+    [
+      "message",
+      "Flux"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "field.featuresNanobanana": [
+    [
+      "message",
+      "Nano-Banane"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "field.featuresOpenaiimage": {
+    "message": "OpenAI Image",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresSeedream": [
+    [
+      "message",
+      "SeeDream"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "field.featuresSeedance": [
+    [
+      "message",
+      "SeeDance"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "field.featuresWan": [
+    [
+      "message",
+      "Wan"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "field.featuresProducer": [
+    [
+      "message",
+      "Produzent"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "field.featuresKimi": [
+    [
+      "message",
+      "Kimi"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "field.featuresSerp": [
+    [
+      "message",
+      "SERP"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "field.featuresSupport": [
+    [
+      "message",
+      "Kundensupport"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "field.featuresI18n": [
+    [
+      "message",
+      "Mehrsprachige Unterstützung"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "title.basicConfig": [
+    [
+      "message",
+      "Basis-Konfiguration"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "title.seoConfig": [
+    [
+      "message",
+      "SEO-Konfiguration"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "title.editAdmins": [
+    [
+      "message",
+      "Admins bearbeiten"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "title.featuresConfig": [
+    [
+      "message",
+      "Funktionskonfiguration"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "title.editTitle": [
+    [
+      "message",
+      "Titel bearbeiten"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "title.editOrigin": [
+    [
+      "message",
+      "Domain bearbeiten"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "title.editKeywords": [
+    [
+      "message",
+      "Keywords bearbeiten"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "title.editLogo": [
+    [
+      "message",
+      "Logo bearbeiten"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "title.editFavicon": [
+    [
+      "message",
+      "Favicon bearbeiten"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "title.editDescription": [
+    [
+      "message",
+      "Beschreibung bearbeiten"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "title.distributionConfig": [
+    [
+      "message",
+      "Vertriebskonfiguration"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "title.editDistributionDefaultInviterId": [
+    [
+      "message",
+      "Standard-Einladungs-ID bearbeiten"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "title.editDistributionForceInviterId": [
+    [
+      "message",
+      "Zwangseinladungs-ID bearbeiten"
+    ],
+    [
+      "description",
+      "Anzeige im Bearbeitungsfeld"
+    ]
+  ],
+  "title.editQR": [
+    [
+      "message",
+      "QR-Code bearbeiten"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editUrl": [
+    [
+      "message",
+      "Link bearbeiten"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "placeholder.title": [
+    [
+      "message",
+      "Bitte Titel der Seite eingeben"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "placeholder.origin": [
+    [
+      "message",
+      "Bitte Domain der Seite eingeben"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "placeholder.editUrl": [
+    [
+      "message",
+      "Bitte Link eingeben"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "placeholder.description": [
+    [
+      "message",
+      "Bitte Beschreibung der Seite eingeben"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "placeholder.keywords": [
+    [
+      "message",
+      "Bitte Schlüsselwörter der Seite eingeben"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "placeholder.editDistributionDefaultInviterId": [
+    [
+      "message",
+      "Bitte Standard-Einladenden-ID eingeben"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "placeholder.editDistributionForceInviterId": [
+    [
+      "message",
+      "Bitte zwingende Einladenden-ID eingeben"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "message.uploadImageExceed": [
+    [
+      "message",
+      "Bildüberschreitung des Upload-Limits"
+    ],
+    [
+      "description",
+      "上传图片超过限制的提示"
+    ]
+  ],
+  "message.uploadImageError": [
+    [
+      "message",
+      "Fehler beim Hochladen des Bildes"
+    ],
+    [
+      "description",
+      "上传图片错误的提示"
+    ]
+  ],
+  "message.editLogoTip": [
+    [
+      "message",
+      "Empfohlene Größe: 200*60px"
+    ],
+    [
+      "description",
+      "上传图片的提示语言"
+    ]
+  ],
+  "message.editQRTip": [
+    [
+      "message",
+      "Empfohlene Größe: 200*200px"
+    ],
+    [
+      "description",
+      "上传图片的提示语言"
+    ]
+  ],
+  "message.editFaviconTip": [
+    [
+      "message",
+      "Empfohlene Größe: 32*32px"
+    ],
+    [
+      "description",
+      "上传图片的提示语言"
+    ]
+  ],
+  "message.editUrl": [
+    [
+      "message",
+      "Bitte Link eingeben"
+    ],
+    [
+      "description",
+      "请输入链接的提示"
+    ]
+  ],
+  "message.atLeastOneAdmin": [
+    [
+      "message",
+      "Mindestens einen Administrator behalten"
+    ],
+    [
+      "description",
+      "至少保留一个管理员的提示"
+    ]
+  ],
+  "message.distributionDefaultInviterIdTip": [
+    [
+      "message",
+      "Benutzer-ID des Standard-Einladenden. Wenn der Verlinkungsparameter inviter_id nicht vorhanden ist, wird diese Benutzer-ID als Einladender verwendet."
+    ],
+    [
+      "description",
+      "默认邀请人ID的提示"
+    ]
+  ],
+  "message.distributionForceInviterIdTip": [
+    [
+      "message",
+      "Benutzer-ID des zwingenden Einladenden. Wenn diese ID gesetzt ist, wird unabhängig davon, ob der Verlinkungsparameter inviter_id vorhanden ist, diese Benutzer-ID als Einladender verwendet."
+    ],
+    [
+      "description",
+      "强制邀请人ID的提示"
+    ]
+  ],
+  "message.originTip": [
+    [
+      "message",
+      "Domain der Seite, die Konfiguration der Seite ist an die Domain gebunden und kann nicht geändert werden."
+    ],
+    [
+      "description",
+      "站点域名的提示"
+    ]
+  ],
+  "message.titleTip": [
+    [
+      "message",
+      "Titel der Seite, angezeigt im Browser-Tab."
+    ],
+    [
+      "description",
+      "站点标题的提示"
+    ]
+  ],
+  "message.descriptionTip": [
+    [
+      "message",
+      "Beschreibung der Seite, im Metainformationen der Seite, für SEO-Optimierung."
+    ],
+    [
+      "description",
+      "站点描述的提示"
+    ]
+  ],
+  "message.logoTip": [
+    [
+      "message",
+      "Logo der Seite, angezeigt oben im Menü, wenn das Menü ausgeklappt ist."
+    ],
+    [
+      "description",
+      "站点 Logo 的提示"
+    ]
+  ],
+  "message.faviconTip": [
+    [
+      "message",
+      "Favicon der Seite, angezeigt im Browser-Tab."
+    ],
+    [
+      "description",
+      "站点 Favicon 的提示"
+    ]
+  ],
+  "message.adminsTip": [
+    [
+      "message",
+      "Administrator-ID der Seite. Standardmäßig wird der Benutzer, der die Seite zuerst erstellt, Administrator. Nur Administratoren können die Seite verwalten."
+    ],
+    [
+      "description",
+      "站点管理员的提示"
+    ]
+  ],
+  "message.adminsTip2": [
+    [
+      "message",
+      "Hier können Administrator-IDs hinzugefügt oder entfernt werden. Benutzer-IDs können unter https://auth.acedata.cloud eingesehen werden."
+    ],
+    [
+      "description",
+      "站点管理员的提示"
+    ]
+  ],
+  "message.keywordsTip": [
+    [
+      "message",
+      "Schlüsselwörter der Seite, im Metainformationen der Seite, für SEO-Optimierung."
+    ],
+    [
+      "description",
+      "站点关键词的提示"
+    ]
+  ],
+  "message.keywordsTip2": [
+    [
+      "message",
+      "Hier können Schlüsselwörter der Website hinzugefügt oder entfernt werden. Je präziser die Schlüsselwörter, desto besser für die SEO-Optimierung."
+    ],
+    [
+      "description",
+      "站点关键词的提示"
+    ]
+  ],
+  "message.featuresChat": [
+    [
+      "message",
+      "Chat-Funktion aktivieren oder deaktivieren."
+    ],
+    [
+      "description",
+      "Chat 功能的描述"
+    ]
+  ],
+  "message.featuresGrok": [
+    [
+      "message",
+      "Grok-Funktion aktivieren oder deaktivieren."
+    ],
+    [
+      "description",
+      "Grok 功能的描述"
+    ]
+  ],
+  "message.featuresDeepseek": [
+    [
+      "message",
+      "Deepseek-Funktion aktivieren oder deaktivieren."
+    ],
+    [
+      "description",
+      "Deepseek 功能的描述"
+    ]
+  ],
+  "message.featuresChatgpt": [
+    [
+      "message",
+      "ChatGPT-Funktion aktivieren oder deaktivieren."
+    ],
+    [
+      "description",
+      "ChatGPT 功能的描述"
+    ]
+  ],
+  "message.featuresMidjourney": [
+    [
+      "message",
+      "Midjourney-Funktion aktivieren oder deaktivieren."
+    ],
+    [
+      "description",
+      "Midjourney 功能的描述"
+    ]
+  ],
+  "message.featuresChatdoc": [
+    [
+      "message",
+      "Chatdoc-Funktion aktivieren oder deaktivieren."
+    ],
+    [
+      "description",
+      "Chatdoc 功能的描述"
+    ]
+  ],
+  "message.featuresQrart": [
+    [
+      "message",
+      "Qrart-Funktion aktivieren oder deaktivieren."
+    ],
+    [
+      "description",
+      "Qrart 功能的描述"
+    ]
+  ],
+  "message.featuresVeo": [
+    [
+      "message",
+      "Veo-Funktion aktivieren oder deaktivieren."
+    ],
+    [
+      "description",
+      "Veo 功能的描述"
+    ]
+  ],
+  "message.featuresSora": [
+    [
+      "message",
+      "Sora-Funktion aktivieren oder deaktivieren."
+    ],
+    [
+      "description",
+      "Sora 功能的描述"
+    ]
+  ],
+  "message.featuresSuno": [
+    [
+      "message",
+      "Suno-Funktion aktivieren oder deaktivieren."
+    ],
+    [
+      "description",
+      "Suno 功能的描述"
+    ]
+  ],
+  "message.featuresPixverse": [
+    [
+      "message",
+      "Pixverse-Funktion aktivieren oder deaktivieren."
+    ],
+    [
+      "description",
+      "Pixverse Funktion der Beschreibung"
+    ]
+  ],
+  "message.featuresFlux": [
+    [
+      "message",
+      "FLux-Funktion aktivieren oder deaktivieren."
+    ],
+    [
+      "description",
+      "FLux Funktion der Beschreibung"
+    ]
+  ],
+  "message.featuresNanobanana": [
+    [
+      "message",
+      "Nano Banana-Funktion aktivieren oder deaktivieren."
+    ],
+    [
+      "description",
+      "Nano Banana Funktion der Beschreibung"
+    ]
+  ],
+  "message.featuresOpenaiimage": {
+    "message": "Toggle OpenAI Image feature module.",
+    "description": "Description of the OpenAI Image feature"
+  },
+  "message.featuresSeedream": [
+    [
+      "message",
+      "SeeDream-Funktion aktivieren oder deaktivieren."
+    ],
+    [
+      "description",
+      "SeeDream Funktion der Beschreibung"
+    ]
+  ],
+  "message.featuresSeedance": [
+    [
+      "message",
+      "SeeDance-Funktion aktivieren oder deaktivieren."
+    ],
+    [
+      "description",
+      "SeeDance Funktion der Beschreibung"
+    ]
+  ],
+  "message.featuresWan": [
+    [
+      "message",
+      "Wan-Funktion aktivieren oder deaktivieren."
+    ],
+    [
+      "description",
+      "Wan Funktion der Beschreibung"
+    ]
+  ],
+  "message.featuresProducer": [
+    [
+      "message",
+      "Producer-Funktion aktivieren oder deaktivieren."
+    ],
+    [
+      "description",
+      "Producer Funktion der Beschreibung"
+    ]
+  ],
+  "message.featuresKimi": [
+    [
+      "message",
+      "Kimi-Funktion aktivieren oder deaktivieren."
+    ],
+    [
+      "description",
+      "Kimi Funktion der Beschreibung"
+    ]
+  ],
+  "message.featuresSerp": [
+    [
+      "message",
+      "SERP-Funktion aktivieren oder deaktivieren."
+    ],
+    [
+      "description",
+      "SERP Funktion der Beschreibung"
+    ]
+  ],
+  "message.featuresLuma": [
+    [
+      "message",
+      "Luma-Funktion aktivieren oder deaktivieren."
+    ],
+    [
+      "description",
+      "Luma Funktion der Beschreibung"
+    ]
+  ],
+  "message.featuresPika": [
+    [
+      "message",
+      "Pika-Funktion aktivieren oder deaktivieren."
+    ],
+    [
+      "description",
+      "Pika Funktion der Beschreibung"
+    ]
+  ],
+  "message.featuresKling": [
+    [
+      "message",
+      "Kling-Funktion aktivieren oder deaktivieren."
+    ],
+    [
+      "description",
+      "Kling Funktion der Beschreibung"
+    ]
+  ],
+  "message.featuresHailuo": [
+    [
+      "message",
+      "Hailuo-Funktion aktivieren oder deaktivieren."
+    ],
+    [
+      "description",
+      "Hailuo Funktion der Beschreibung"
+    ]
+  ],
+  "message.featuresHeadshots": [
+    [
+      "message",
+      "AI-Passfoto-Funktion aktivieren oder deaktivieren."
+    ],
+    [
+      "description",
+      "AI-Passfoto Funktion der Beschreibung"
+    ]
+  ],
+  "message.featuresSupport": [
+    [
+      "message",
+      "Kundensupport aktivieren oder deaktivieren."
+    ],
+    [
+      "description",
+      "Support Funktion der Beschreibung"
+    ]
+  ],
+  "message.featuresI18n": [
+    [
+      "message",
+      "Mehrsprachige Unterstützung aktivieren oder deaktivieren. Bei Deaktivierung kann der Benutzer nur die Standardsprache verwenden."
+    ],
+    [
+      "description",
+      "Mehrsprachige Unterstützung der Beschreibung"
+    ]
+  ],
+  "button.upload": [
+    [
+      "message",
+      "Hochladen"
+    ],
+    [
+      "description",
+      "Hochladen"
+    ]
+  ],
+  "button.enabled": [
+    [
+      "message",
+      "Aktiviert"
+    ],
+    [
+      "description",
+      "Schaltertext, der anzeigt, dass es aktiviert ist"
+    ]
+  ],
+  "button.disabled": [
+    [
+      "message",
+      "Deaktiviert"
+    ],
+    [
+      "description",
+      "Schaltertext, der anzeigt, dass es deaktiviert ist"
+    ]
+  ],
+  "field.featuresGemini": [
+    [
+      "message",
+      "Gemini"
+    ],
+    [
+      "description",
+      "Als Titel im Bearbeitungsfeld angezeigt"
+    ]
+  ],
+  "message.featuresGemini": [
+    [
+      "message",
+      "Gemini-Funktion aktivieren oder deaktivieren."
+    ],
+    [
+      "description",
+      "Beschreibung der Gemini Funktion"
+    ]
+  ],
+  "field.featuresClaude": [
+    [
+      "message",
+      "Claude"
+    ],
+    [
+      "description",
+      "Als Titel im Bearbeitungsfeld angezeigt"
+    ]
+  ],
+  "message.featuresClaude": [
+    [
+      "message",
+      "Claude-Funktion aktivieren oder deaktivieren."
+    ],
+    [
+      "description",
+      "Beschreibung der Claude Funktion"
+    ]
+  ]
 }

--- a/src/i18n/de/site.json
+++ b/src/i18n/de/site.json
@@ -1,1110 +1,450 @@
 {
-  "field.title": [
-    [
-      "message",
-      "Seitenüberschrift"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "field.origin": [
-    [
-      "message",
-      "Seiten-Domain"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "field.description": [
-    [
-      "message",
-      "Seitenbeschreibung"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "field.keywords": [
-    [
-      "message",
-      "Seitenkeywords"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "field.logo": [
-    [
-      "message",
-      "Seitenlogo"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "field.favicon": [
-    [
-      "message",
-      "Seiten-Favicon"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "field.qr": [
-    [
-      "message",
-      "QR-Code"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "field.url": [
-    [
-      "message",
-      "Link"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "field.admins": [
-    [
-      "message",
-      "Seiten-Admin-ID"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "field.distributionDefaultInviterId": [
-    [
-      "message",
-      "Standard-Einladungs-ID"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "field.distributionForceInviterId": [
-    [
-      "message",
-      "Zwangseinladungs-ID"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "field.featuresChat": [
-    [
-      "message",
-      "Chat"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "field.featuresVeo": [
-    [
-      "message",
-      "Veo"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "field.featuresSora": [
-    [
-      "message",
-      "Sora"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "field.featuresGrok": [
-    [
-      "message",
-      "Grok"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "field.featuresDeepseek": [
-    [
-      "message",
-      "Deepseek"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "field.featuresChatgpt": [
-    [
-      "message",
-      "ChatGPT"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "field.featuresMidjourney": [
-    [
-      "message",
-      "Midjourney"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "field.featuresChatdoc": [
-    [
-      "message",
-      "Chatdoc"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "field.featuresQrart": [
-    [
-      "message",
-      "Qrart"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "field.featuresLuma": [
-    [
-      "message",
-      "Luma"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "field.featuresPixverse": [
-    [
-      "message",
-      "Pixverse"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "field.featuresPika": [
-    [
-      "message",
-      "Pika"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "field.featuresKling": [
-    [
-      "message",
-      "Kling"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "field.featuresHailuo": [
-    [
-      "message",
-      "Hailuo"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "field.featuresHeadshots": [
-    [
-      "message",
-      "AI-Porträt"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "field.featuresSuno": [
-    [
-      "message",
-      "Suno"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "field.featuresFlux": [
-    [
-      "message",
-      "Flux"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "field.featuresNanobanana": [
-    [
-      "message",
-      "Nano-Banane"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
+  "field.title": {
+    "message": "Seitenüberschrift",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "field.origin": {
+    "message": "Seiten-Domain",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "field.description": {
+    "message": "Seitenbeschreibung",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "field.keywords": {
+    "message": "Seitenkeywords",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "field.logo": {
+    "message": "Seitenlogo",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "field.favicon": {
+    "message": "Seiten-Favicon",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "field.qr": {
+    "message": "QR-Code",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "field.url": {
+    "message": "Link",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "field.admins": {
+    "message": "Seiten-Admin-ID",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "field.distributionDefaultInviterId": {
+    "message": "Standard-Einladungs-ID",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "field.distributionForceInviterId": {
+    "message": "Zwangseinladungs-ID",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "field.featuresChat": {
+    "message": "Chat",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "field.featuresVeo": {
+    "message": "Veo",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "field.featuresSora": {
+    "message": "Sora",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "field.featuresGrok": {
+    "message": "Grok",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "field.featuresDeepseek": {
+    "message": "Deepseek",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "field.featuresChatgpt": {
+    "message": "ChatGPT",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "field.featuresMidjourney": {
+    "message": "Midjourney",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "field.featuresChatdoc": {
+    "message": "Chatdoc",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "field.featuresQrart": {
+    "message": "Qrart",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "field.featuresLuma": {
+    "message": "Luma",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "field.featuresPixverse": {
+    "message": "Pixverse",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "field.featuresPika": {
+    "message": "Pika",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "field.featuresKling": {
+    "message": "Kling",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "field.featuresHailuo": {
+    "message": "Hailuo",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "field.featuresHeadshots": {
+    "message": "AI-Porträt",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "field.featuresSuno": {
+    "message": "Suno",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "field.featuresFlux": {
+    "message": "Flux",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "field.featuresNanobanana": {
+    "message": "Nano-Banane",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
   "field.featuresOpenaiimage": {
     "message": "OpenAI Image",
     "description": "Displayed as the title in the editing box"
   },
-  "field.featuresSeedream": [
-    [
-      "message",
-      "SeeDream"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "field.featuresSeedance": [
-    [
-      "message",
-      "SeeDance"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "field.featuresWan": [
-    [
-      "message",
-      "Wan"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "field.featuresProducer": [
-    [
-      "message",
-      "Produzent"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "field.featuresKimi": [
-    [
-      "message",
-      "Kimi"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "field.featuresSerp": [
-    [
-      "message",
-      "SERP"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "field.featuresSupport": [
-    [
-      "message",
-      "Kundensupport"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "field.featuresI18n": [
-    [
-      "message",
-      "Mehrsprachige Unterstützung"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "title.basicConfig": [
-    [
-      "message",
-      "Basis-Konfiguration"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "title.seoConfig": [
-    [
-      "message",
-      "SEO-Konfiguration"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "title.editAdmins": [
-    [
-      "message",
-      "Admins bearbeiten"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "title.featuresConfig": [
-    [
-      "message",
-      "Funktionskonfiguration"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "title.editTitle": [
-    [
-      "message",
-      "Titel bearbeiten"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "title.editOrigin": [
-    [
-      "message",
-      "Domain bearbeiten"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "title.editKeywords": [
-    [
-      "message",
-      "Keywords bearbeiten"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "title.editLogo": [
-    [
-      "message",
-      "Logo bearbeiten"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "title.editFavicon": [
-    [
-      "message",
-      "Favicon bearbeiten"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "title.editDescription": [
-    [
-      "message",
-      "Beschreibung bearbeiten"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "title.distributionConfig": [
-    [
-      "message",
-      "Vertriebskonfiguration"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "title.editDistributionDefaultInviterId": [
-    [
-      "message",
-      "Standard-Einladungs-ID bearbeiten"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "title.editDistributionForceInviterId": [
-    [
-      "message",
-      "Zwangseinladungs-ID bearbeiten"
-    ],
-    [
-      "description",
-      "Anzeige im Bearbeitungsfeld"
-    ]
-  ],
-  "title.editQR": [
-    [
-      "message",
-      "QR-Code bearbeiten"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editUrl": [
-    [
-      "message",
-      "Link bearbeiten"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "placeholder.title": [
-    [
-      "message",
-      "Bitte Titel der Seite eingeben"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "placeholder.origin": [
-    [
-      "message",
-      "Bitte Domain der Seite eingeben"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "placeholder.editUrl": [
-    [
-      "message",
-      "Bitte Link eingeben"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "placeholder.description": [
-    [
-      "message",
-      "Bitte Beschreibung der Seite eingeben"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "placeholder.keywords": [
-    [
-      "message",
-      "Bitte Schlüsselwörter der Seite eingeben"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "placeholder.editDistributionDefaultInviterId": [
-    [
-      "message",
-      "Bitte Standard-Einladenden-ID eingeben"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "placeholder.editDistributionForceInviterId": [
-    [
-      "message",
-      "Bitte zwingende Einladenden-ID eingeben"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "message.uploadImageExceed": [
-    [
-      "message",
-      "Bildüberschreitung des Upload-Limits"
-    ],
-    [
-      "description",
-      "上传图片超过限制的提示"
-    ]
-  ],
-  "message.uploadImageError": [
-    [
-      "message",
-      "Fehler beim Hochladen des Bildes"
-    ],
-    [
-      "description",
-      "上传图片错误的提示"
-    ]
-  ],
-  "message.editLogoTip": [
-    [
-      "message",
-      "Empfohlene Größe: 200*60px"
-    ],
-    [
-      "description",
-      "上传图片的提示语言"
-    ]
-  ],
-  "message.editQRTip": [
-    [
-      "message",
-      "Empfohlene Größe: 200*200px"
-    ],
-    [
-      "description",
-      "上传图片的提示语言"
-    ]
-  ],
-  "message.editFaviconTip": [
-    [
-      "message",
-      "Empfohlene Größe: 32*32px"
-    ],
-    [
-      "description",
-      "上传图片的提示语言"
-    ]
-  ],
-  "message.editUrl": [
-    [
-      "message",
-      "Bitte Link eingeben"
-    ],
-    [
-      "description",
-      "请输入链接的提示"
-    ]
-  ],
-  "message.atLeastOneAdmin": [
-    [
-      "message",
-      "Mindestens einen Administrator behalten"
-    ],
-    [
-      "description",
-      "至少保留一个管理员的提示"
-    ]
-  ],
-  "message.distributionDefaultInviterIdTip": [
-    [
-      "message",
-      "Benutzer-ID des Standard-Einladenden. Wenn der Verlinkungsparameter inviter_id nicht vorhanden ist, wird diese Benutzer-ID als Einladender verwendet."
-    ],
-    [
-      "description",
-      "默认邀请人ID的提示"
-    ]
-  ],
-  "message.distributionForceInviterIdTip": [
-    [
-      "message",
-      "Benutzer-ID des zwingenden Einladenden. Wenn diese ID gesetzt ist, wird unabhängig davon, ob der Verlinkungsparameter inviter_id vorhanden ist, diese Benutzer-ID als Einladender verwendet."
-    ],
-    [
-      "description",
-      "强制邀请人ID的提示"
-    ]
-  ],
-  "message.originTip": [
-    [
-      "message",
-      "Domain der Seite, die Konfiguration der Seite ist an die Domain gebunden und kann nicht geändert werden."
-    ],
-    [
-      "description",
-      "站点域名的提示"
-    ]
-  ],
-  "message.titleTip": [
-    [
-      "message",
-      "Titel der Seite, angezeigt im Browser-Tab."
-    ],
-    [
-      "description",
-      "站点标题的提示"
-    ]
-  ],
-  "message.descriptionTip": [
-    [
-      "message",
-      "Beschreibung der Seite, im Metainformationen der Seite, für SEO-Optimierung."
-    ],
-    [
-      "description",
-      "站点描述的提示"
-    ]
-  ],
-  "message.logoTip": [
-    [
-      "message",
-      "Logo der Seite, angezeigt oben im Menü, wenn das Menü ausgeklappt ist."
-    ],
-    [
-      "description",
-      "站点 Logo 的提示"
-    ]
-  ],
-  "message.faviconTip": [
-    [
-      "message",
-      "Favicon der Seite, angezeigt im Browser-Tab."
-    ],
-    [
-      "description",
-      "站点 Favicon 的提示"
-    ]
-  ],
-  "message.adminsTip": [
-    [
-      "message",
-      "Administrator-ID der Seite. Standardmäßig wird der Benutzer, der die Seite zuerst erstellt, Administrator. Nur Administratoren können die Seite verwalten."
-    ],
-    [
-      "description",
-      "站点管理员的提示"
-    ]
-  ],
-  "message.adminsTip2": [
-    [
-      "message",
-      "Hier können Administrator-IDs hinzugefügt oder entfernt werden. Benutzer-IDs können unter https://auth.acedata.cloud eingesehen werden."
-    ],
-    [
-      "description",
-      "站点管理员的提示"
-    ]
-  ],
-  "message.keywordsTip": [
-    [
-      "message",
-      "Schlüsselwörter der Seite, im Metainformationen der Seite, für SEO-Optimierung."
-    ],
-    [
-      "description",
-      "站点关键词的提示"
-    ]
-  ],
-  "message.keywordsTip2": [
-    [
-      "message",
-      "Hier können Schlüsselwörter der Website hinzugefügt oder entfernt werden. Je präziser die Schlüsselwörter, desto besser für die SEO-Optimierung."
-    ],
-    [
-      "description",
-      "站点关键词的提示"
-    ]
-  ],
-  "message.featuresChat": [
-    [
-      "message",
-      "Chat-Funktion aktivieren oder deaktivieren."
-    ],
-    [
-      "description",
-      "Chat 功能的描述"
-    ]
-  ],
-  "message.featuresGrok": [
-    [
-      "message",
-      "Grok-Funktion aktivieren oder deaktivieren."
-    ],
-    [
-      "description",
-      "Grok 功能的描述"
-    ]
-  ],
-  "message.featuresDeepseek": [
-    [
-      "message",
-      "Deepseek-Funktion aktivieren oder deaktivieren."
-    ],
-    [
-      "description",
-      "Deepseek 功能的描述"
-    ]
-  ],
-  "message.featuresChatgpt": [
-    [
-      "message",
-      "ChatGPT-Funktion aktivieren oder deaktivieren."
-    ],
-    [
-      "description",
-      "ChatGPT 功能的描述"
-    ]
-  ],
-  "message.featuresMidjourney": [
-    [
-      "message",
-      "Midjourney-Funktion aktivieren oder deaktivieren."
-    ],
-    [
-      "description",
-      "Midjourney 功能的描述"
-    ]
-  ],
-  "message.featuresChatdoc": [
-    [
-      "message",
-      "Chatdoc-Funktion aktivieren oder deaktivieren."
-    ],
-    [
-      "description",
-      "Chatdoc 功能的描述"
-    ]
-  ],
-  "message.featuresQrart": [
-    [
-      "message",
-      "Qrart-Funktion aktivieren oder deaktivieren."
-    ],
-    [
-      "description",
-      "Qrart 功能的描述"
-    ]
-  ],
-  "message.featuresVeo": [
-    [
-      "message",
-      "Veo-Funktion aktivieren oder deaktivieren."
-    ],
-    [
-      "description",
-      "Veo 功能的描述"
-    ]
-  ],
-  "message.featuresSora": [
-    [
-      "message",
-      "Sora-Funktion aktivieren oder deaktivieren."
-    ],
-    [
-      "description",
-      "Sora 功能的描述"
-    ]
-  ],
-  "message.featuresSuno": [
-    [
-      "message",
-      "Suno-Funktion aktivieren oder deaktivieren."
-    ],
-    [
-      "description",
-      "Suno 功能的描述"
-    ]
-  ],
-  "message.featuresPixverse": [
-    [
-      "message",
-      "Pixverse-Funktion aktivieren oder deaktivieren."
-    ],
-    [
-      "description",
-      "Pixverse Funktion der Beschreibung"
-    ]
-  ],
-  "message.featuresFlux": [
-    [
-      "message",
-      "FLux-Funktion aktivieren oder deaktivieren."
-    ],
-    [
-      "description",
-      "FLux Funktion der Beschreibung"
-    ]
-  ],
-  "message.featuresNanobanana": [
-    [
-      "message",
-      "Nano Banana-Funktion aktivieren oder deaktivieren."
-    ],
-    [
-      "description",
-      "Nano Banana Funktion der Beschreibung"
-    ]
-  ],
+  "field.featuresSeedream": {
+    "message": "SeeDream",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "field.featuresSeedance": {
+    "message": "SeeDance",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "field.featuresWan": {
+    "message": "Wan",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "field.featuresProducer": {
+    "message": "Produzent",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "field.featuresKimi": {
+    "message": "Kimi",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "field.featuresSerp": {
+    "message": "SERP",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "field.featuresSupport": {
+    "message": "Kundensupport",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "field.featuresI18n": {
+    "message": "Mehrsprachige Unterstützung",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "title.basicConfig": {
+    "message": "Basis-Konfiguration",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "title.seoConfig": {
+    "message": "SEO-Konfiguration",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "title.editAdmins": {
+    "message": "Admins bearbeiten",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "title.featuresConfig": {
+    "message": "Funktionskonfiguration",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "title.editTitle": {
+    "message": "Titel bearbeiten",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "title.editOrigin": {
+    "message": "Domain bearbeiten",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "title.editKeywords": {
+    "message": "Keywords bearbeiten",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "title.editLogo": {
+    "message": "Logo bearbeiten",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "title.editFavicon": {
+    "message": "Favicon bearbeiten",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "title.editDescription": {
+    "message": "Beschreibung bearbeiten",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "title.distributionConfig": {
+    "message": "Vertriebskonfiguration",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "title.editDistributionDefaultInviterId": {
+    "message": "Standard-Einladungs-ID bearbeiten",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "title.editDistributionForceInviterId": {
+    "message": "Zwangseinladungs-ID bearbeiten",
+    "description": "Anzeige im Bearbeitungsfeld"
+  },
+  "title.editQR": {
+    "message": "QR-Code bearbeiten",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editUrl": {
+    "message": "Link bearbeiten",
+    "description": "展示在编辑框的标题"
+  },
+  "placeholder.title": {
+    "message": "Bitte Titel der Seite eingeben",
+    "description": "展示在编辑框的标题"
+  },
+  "placeholder.origin": {
+    "message": "Bitte Domain der Seite eingeben",
+    "description": "展示在编辑框的标题"
+  },
+  "placeholder.editUrl": {
+    "message": "Bitte Link eingeben",
+    "description": "展示在编辑框的标题"
+  },
+  "placeholder.description": {
+    "message": "Bitte Beschreibung der Seite eingeben",
+    "description": "展示在编辑框的标题"
+  },
+  "placeholder.keywords": {
+    "message": "Bitte Schlüsselwörter der Seite eingeben",
+    "description": "展示在编辑框的标题"
+  },
+  "placeholder.editDistributionDefaultInviterId": {
+    "message": "Bitte Standard-Einladenden-ID eingeben",
+    "description": "展示在编辑框的标题"
+  },
+  "placeholder.editDistributionForceInviterId": {
+    "message": "Bitte zwingende Einladenden-ID eingeben",
+    "description": "展示在编辑框的标题"
+  },
+  "message.uploadImageExceed": {
+    "message": "Bildüberschreitung des Upload-Limits",
+    "description": "上传图片超过限制的提示"
+  },
+  "message.uploadImageError": {
+    "message": "Fehler beim Hochladen des Bildes",
+    "description": "上传图片错误的提示"
+  },
+  "message.editLogoTip": {
+    "message": "Empfohlene Größe: 200*60px",
+    "description": "上传图片的提示语言"
+  },
+  "message.editQRTip": {
+    "message": "Empfohlene Größe: 200*200px",
+    "description": "上传图片的提示语言"
+  },
+  "message.editFaviconTip": {
+    "message": "Empfohlene Größe: 32*32px",
+    "description": "上传图片的提示语言"
+  },
+  "message.editUrl": {
+    "message": "Bitte Link eingeben",
+    "description": "请输入链接的提示"
+  },
+  "message.atLeastOneAdmin": {
+    "message": "Mindestens einen Administrator behalten",
+    "description": "至少保留一个管理员的提示"
+  },
+  "message.distributionDefaultInviterIdTip": {
+    "message": "Benutzer-ID des Standard-Einladenden. Wenn der Verlinkungsparameter inviter_id nicht vorhanden ist, wird diese Benutzer-ID als Einladender verwendet.",
+    "description": "默认邀请人ID的提示"
+  },
+  "message.distributionForceInviterIdTip": {
+    "message": "Benutzer-ID des zwingenden Einladenden. Wenn diese ID gesetzt ist, wird unabhängig davon, ob der Verlinkungsparameter inviter_id vorhanden ist, diese Benutzer-ID als Einladender verwendet.",
+    "description": "强制邀请人ID的提示"
+  },
+  "message.originTip": {
+    "message": "Domain der Seite, die Konfiguration der Seite ist an die Domain gebunden und kann nicht geändert werden.",
+    "description": "站点域名的提示"
+  },
+  "message.titleTip": {
+    "message": "Titel der Seite, angezeigt im Browser-Tab.",
+    "description": "站点标题的提示"
+  },
+  "message.descriptionTip": {
+    "message": "Beschreibung der Seite, im Metainformationen der Seite, für SEO-Optimierung.",
+    "description": "站点描述的提示"
+  },
+  "message.logoTip": {
+    "message": "Logo der Seite, angezeigt oben im Menü, wenn das Menü ausgeklappt ist.",
+    "description": "站点 Logo 的提示"
+  },
+  "message.faviconTip": {
+    "message": "Favicon der Seite, angezeigt im Browser-Tab.",
+    "description": "站点 Favicon 的提示"
+  },
+  "message.adminsTip": {
+    "message": "Administrator-ID der Seite. Standardmäßig wird der Benutzer, der die Seite zuerst erstellt, Administrator. Nur Administratoren können die Seite verwalten.",
+    "description": "站点管理员的提示"
+  },
+  "message.adminsTip2": {
+    "message": "Hier können Administrator-IDs hinzugefügt oder entfernt werden. Benutzer-IDs können unter https://auth.acedata.cloud eingesehen werden.",
+    "description": "站点管理员的提示"
+  },
+  "message.keywordsTip": {
+    "message": "Schlüsselwörter der Seite, im Metainformationen der Seite, für SEO-Optimierung.",
+    "description": "站点关键词的提示"
+  },
+  "message.keywordsTip2": {
+    "message": "Hier können Schlüsselwörter der Website hinzugefügt oder entfernt werden. Je präziser die Schlüsselwörter, desto besser für die SEO-Optimierung.",
+    "description": "站点关键词的提示"
+  },
+  "message.featuresChat": {
+    "message": "Chat-Funktion aktivieren oder deaktivieren.",
+    "description": "Chat 功能的描述"
+  },
+  "message.featuresGrok": {
+    "message": "Grok-Funktion aktivieren oder deaktivieren.",
+    "description": "Grok 功能的描述"
+  },
+  "message.featuresDeepseek": {
+    "message": "Deepseek-Funktion aktivieren oder deaktivieren.",
+    "description": "Deepseek 功能的描述"
+  },
+  "message.featuresChatgpt": {
+    "message": "ChatGPT-Funktion aktivieren oder deaktivieren.",
+    "description": "ChatGPT 功能的描述"
+  },
+  "message.featuresMidjourney": {
+    "message": "Midjourney-Funktion aktivieren oder deaktivieren.",
+    "description": "Midjourney 功能的描述"
+  },
+  "message.featuresChatdoc": {
+    "message": "Chatdoc-Funktion aktivieren oder deaktivieren.",
+    "description": "Chatdoc 功能的描述"
+  },
+  "message.featuresQrart": {
+    "message": "Qrart-Funktion aktivieren oder deaktivieren.",
+    "description": "Qrart 功能的描述"
+  },
+  "message.featuresVeo": {
+    "message": "Veo-Funktion aktivieren oder deaktivieren.",
+    "description": "Veo 功能的描述"
+  },
+  "message.featuresSora": {
+    "message": "Sora-Funktion aktivieren oder deaktivieren.",
+    "description": "Sora 功能的描述"
+  },
+  "message.featuresSuno": {
+    "message": "Suno-Funktion aktivieren oder deaktivieren.",
+    "description": "Suno 功能的描述"
+  },
+  "message.featuresPixverse": {
+    "message": "Pixverse-Funktion aktivieren oder deaktivieren.",
+    "description": "Pixverse Funktion der Beschreibung"
+  },
+  "message.featuresFlux": {
+    "message": "FLux-Funktion aktivieren oder deaktivieren.",
+    "description": "FLux Funktion der Beschreibung"
+  },
+  "message.featuresNanobanana": {
+    "message": "Nano Banana-Funktion aktivieren oder deaktivieren.",
+    "description": "Nano Banana Funktion der Beschreibung"
+  },
   "message.featuresOpenaiimage": {
     "message": "Toggle OpenAI Image feature module.",
     "description": "Description of the OpenAI Image feature"
   },
-  "message.featuresSeedream": [
-    [
-      "message",
-      "SeeDream-Funktion aktivieren oder deaktivieren."
-    ],
-    [
-      "description",
-      "SeeDream Funktion der Beschreibung"
-    ]
-  ],
-  "message.featuresSeedance": [
-    [
-      "message",
-      "SeeDance-Funktion aktivieren oder deaktivieren."
-    ],
-    [
-      "description",
-      "SeeDance Funktion der Beschreibung"
-    ]
-  ],
-  "message.featuresWan": [
-    [
-      "message",
-      "Wan-Funktion aktivieren oder deaktivieren."
-    ],
-    [
-      "description",
-      "Wan Funktion der Beschreibung"
-    ]
-  ],
-  "message.featuresProducer": [
-    [
-      "message",
-      "Producer-Funktion aktivieren oder deaktivieren."
-    ],
-    [
-      "description",
-      "Producer Funktion der Beschreibung"
-    ]
-  ],
-  "message.featuresKimi": [
-    [
-      "message",
-      "Kimi-Funktion aktivieren oder deaktivieren."
-    ],
-    [
-      "description",
-      "Kimi Funktion der Beschreibung"
-    ]
-  ],
-  "message.featuresSerp": [
-    [
-      "message",
-      "SERP-Funktion aktivieren oder deaktivieren."
-    ],
-    [
-      "description",
-      "SERP Funktion der Beschreibung"
-    ]
-  ],
-  "message.featuresLuma": [
-    [
-      "message",
-      "Luma-Funktion aktivieren oder deaktivieren."
-    ],
-    [
-      "description",
-      "Luma Funktion der Beschreibung"
-    ]
-  ],
-  "message.featuresPika": [
-    [
-      "message",
-      "Pika-Funktion aktivieren oder deaktivieren."
-    ],
-    [
-      "description",
-      "Pika Funktion der Beschreibung"
-    ]
-  ],
-  "message.featuresKling": [
-    [
-      "message",
-      "Kling-Funktion aktivieren oder deaktivieren."
-    ],
-    [
-      "description",
-      "Kling Funktion der Beschreibung"
-    ]
-  ],
-  "message.featuresHailuo": [
-    [
-      "message",
-      "Hailuo-Funktion aktivieren oder deaktivieren."
-    ],
-    [
-      "description",
-      "Hailuo Funktion der Beschreibung"
-    ]
-  ],
-  "message.featuresHeadshots": [
-    [
-      "message",
-      "AI-Passfoto-Funktion aktivieren oder deaktivieren."
-    ],
-    [
-      "description",
-      "AI-Passfoto Funktion der Beschreibung"
-    ]
-  ],
-  "message.featuresSupport": [
-    [
-      "message",
-      "Kundensupport aktivieren oder deaktivieren."
-    ],
-    [
-      "description",
-      "Support Funktion der Beschreibung"
-    ]
-  ],
-  "message.featuresI18n": [
-    [
-      "message",
-      "Mehrsprachige Unterstützung aktivieren oder deaktivieren. Bei Deaktivierung kann der Benutzer nur die Standardsprache verwenden."
-    ],
-    [
-      "description",
-      "Mehrsprachige Unterstützung der Beschreibung"
-    ]
-  ],
-  "button.upload": [
-    [
-      "message",
-      "Hochladen"
-    ],
-    [
-      "description",
-      "Hochladen"
-    ]
-  ],
-  "button.enabled": [
-    [
-      "message",
-      "Aktiviert"
-    ],
-    [
-      "description",
-      "Schaltertext, der anzeigt, dass es aktiviert ist"
-    ]
-  ],
-  "button.disabled": [
-    [
-      "message",
-      "Deaktiviert"
-    ],
-    [
-      "description",
-      "Schaltertext, der anzeigt, dass es deaktiviert ist"
-    ]
-  ],
-  "field.featuresGemini": [
-    [
-      "message",
-      "Gemini"
-    ],
-    [
-      "description",
-      "Als Titel im Bearbeitungsfeld angezeigt"
-    ]
-  ],
-  "message.featuresGemini": [
-    [
-      "message",
-      "Gemini-Funktion aktivieren oder deaktivieren."
-    ],
-    [
-      "description",
-      "Beschreibung der Gemini Funktion"
-    ]
-  ],
-  "field.featuresClaude": [
-    [
-      "message",
-      "Claude"
-    ],
-    [
-      "description",
-      "Als Titel im Bearbeitungsfeld angezeigt"
-    ]
-  ],
-  "message.featuresClaude": [
-    [
-      "message",
-      "Claude-Funktion aktivieren oder deaktivieren."
-    ],
-    [
-      "description",
-      "Beschreibung der Claude Funktion"
-    ]
-  ]
+  "message.featuresSeedream": {
+    "message": "SeeDream-Funktion aktivieren oder deaktivieren.",
+    "description": "SeeDream Funktion der Beschreibung"
+  },
+  "message.featuresSeedance": {
+    "message": "SeeDance-Funktion aktivieren oder deaktivieren.",
+    "description": "SeeDance Funktion der Beschreibung"
+  },
+  "message.featuresWan": {
+    "message": "Wan-Funktion aktivieren oder deaktivieren.",
+    "description": "Wan Funktion der Beschreibung"
+  },
+  "message.featuresProducer": {
+    "message": "Producer-Funktion aktivieren oder deaktivieren.",
+    "description": "Producer Funktion der Beschreibung"
+  },
+  "message.featuresKimi": {
+    "message": "Kimi-Funktion aktivieren oder deaktivieren.",
+    "description": "Kimi Funktion der Beschreibung"
+  },
+  "message.featuresSerp": {
+    "message": "SERP-Funktion aktivieren oder deaktivieren.",
+    "description": "SERP Funktion der Beschreibung"
+  },
+  "message.featuresLuma": {
+    "message": "Luma-Funktion aktivieren oder deaktivieren.",
+    "description": "Luma Funktion der Beschreibung"
+  },
+  "message.featuresPika": {
+    "message": "Pika-Funktion aktivieren oder deaktivieren.",
+    "description": "Pika Funktion der Beschreibung"
+  },
+  "message.featuresKling": {
+    "message": "Kling-Funktion aktivieren oder deaktivieren.",
+    "description": "Kling Funktion der Beschreibung"
+  },
+  "message.featuresHailuo": {
+    "message": "Hailuo-Funktion aktivieren oder deaktivieren.",
+    "description": "Hailuo Funktion der Beschreibung"
+  },
+  "message.featuresHeadshots": {
+    "message": "AI-Passfoto-Funktion aktivieren oder deaktivieren.",
+    "description": "AI-Passfoto Funktion der Beschreibung"
+  },
+  "message.featuresSupport": {
+    "message": "Kundensupport aktivieren oder deaktivieren.",
+    "description": "Support Funktion der Beschreibung"
+  },
+  "message.featuresI18n": {
+    "message": "Mehrsprachige Unterstützung aktivieren oder deaktivieren. Bei Deaktivierung kann der Benutzer nur die Standardsprache verwenden.",
+    "description": "Mehrsprachige Unterstützung der Beschreibung"
+  },
+  "button.upload": {
+    "message": "Hochladen",
+    "description": "Hochladen"
+  },
+  "button.enabled": {
+    "message": "Aktiviert",
+    "description": "Schaltertext, der anzeigt, dass es aktiviert ist"
+  },
+  "button.disabled": {
+    "message": "Deaktiviert",
+    "description": "Schaltertext, der anzeigt, dass es deaktiviert ist"
+  },
+  "field.featuresGemini": {
+    "message": "Gemini",
+    "description": "Als Titel im Bearbeitungsfeld angezeigt"
+  },
+  "message.featuresGemini": {
+    "message": "Gemini-Funktion aktivieren oder deaktivieren.",
+    "description": "Beschreibung der Gemini Funktion"
+  },
+  "field.featuresClaude": {
+    "message": "Claude",
+    "description": "Als Titel im Bearbeitungsfeld angezeigt"
+  },
+  "message.featuresClaude": {
+    "message": "Claude-Funktion aktivieren oder deaktivieren.",
+    "description": "Beschreibung der Claude Funktion"
+  }
 }

--- a/src/i18n/el/site.json
+++ b/src/i18n/el/site.json
@@ -1,1110 +1,450 @@
 {
-  "field.title": [
-    [
-      "message",
-      "Τίτλος Ιστοσελίδας"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.origin": [
-    [
-      "message",
-      "Διεύθυνση Ιστοσελίδας"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.description": [
-    [
-      "message",
-      "Περιγραφή Ιστοσελίδας"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.keywords": [
-    [
-      "message",
-      "Λέξεις-κλειδιά Ιστοσελίδας"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.logo": [
-    [
-      "message",
-      "Λογότυπο Ιστοσελίδας"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.favicon": [
-    [
-      "message",
-      "Favicon Ιστοσελίδας"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.qr": [
-    [
-      "message",
-      "QR Κωδικός"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.url": [
-    [
-      "message",
-      "Σύνδεσμος"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.admins": [
-    [
-      "message",
-      "ID Διαχειριστών Ιστοσελίδας"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.distributionDefaultInviterId": [
-    [
-      "message",
-      "ID Προεπιλεγμένου Προσκαλέσματος"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.distributionForceInviterId": [
-    [
-      "message",
-      "ID Υποχρεωτικού Προσκαλέσματος"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresChat": [
-    [
-      "message",
-      "Chat"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresVeo": [
-    [
-      "message",
-      "Veo"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresSora": [
-    [
-      "message",
-      "Sora"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresGrok": [
-    [
-      "message",
-      "Grok"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresDeepseek": [
-    [
-      "message",
-      "Deepseek"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresChatgpt": [
-    [
-      "message",
-      "ChatGPT"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresMidjourney": [
-    [
-      "message",
-      "Midjourney"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresChatdoc": [
-    [
-      "message",
-      "Chatdoc"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresQrart": [
-    [
-      "message",
-      "Qrart"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresLuma": [
-    [
-      "message",
-      "Luma"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresPixverse": [
-    [
-      "message",
-      "Pixverse"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresPika": [
-    [
-      "message",
-      "Pika"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresKling": [
-    [
-      "message",
-      "Kling"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresHailuo": [
-    [
-      "message",
-      "Hailuo"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresHeadshots": [
-    [
-      "message",
-      "AI Φωτογραφίες Ταυτότητας"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresSuno": [
-    [
-      "message",
-      "Suno"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresFlux": [
-    [
-      "message",
-      "Flux"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresNanobanana": [
-    [
-      "message",
-      "Nano Banana"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
+  "field.title": {
+    "message": "Τίτλος Ιστοσελίδας",
+    "description": "展示在编辑框的标题"
+  },
+  "field.origin": {
+    "message": "Διεύθυνση Ιστοσελίδας",
+    "description": "展示在编辑框的标题"
+  },
+  "field.description": {
+    "message": "Περιγραφή Ιστοσελίδας",
+    "description": "展示在编辑框的标题"
+  },
+  "field.keywords": {
+    "message": "Λέξεις-κλειδιά Ιστοσελίδας",
+    "description": "展示在编辑框的标题"
+  },
+  "field.logo": {
+    "message": "Λογότυπο Ιστοσελίδας",
+    "description": "展示在编辑框的标题"
+  },
+  "field.favicon": {
+    "message": "Favicon Ιστοσελίδας",
+    "description": "展示在编辑框的标题"
+  },
+  "field.qr": {
+    "message": "QR Κωδικός",
+    "description": "展示在编辑框的标题"
+  },
+  "field.url": {
+    "message": "Σύνδεσμος",
+    "description": "展示在编辑框的标题"
+  },
+  "field.admins": {
+    "message": "ID Διαχειριστών Ιστοσελίδας",
+    "description": "展示在编辑框的标题"
+  },
+  "field.distributionDefaultInviterId": {
+    "message": "ID Προεπιλεγμένου Προσκαλέσματος",
+    "description": "展示在编辑框的标题"
+  },
+  "field.distributionForceInviterId": {
+    "message": "ID Υποχρεωτικού Προσκαλέσματος",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresChat": {
+    "message": "Chat",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresVeo": {
+    "message": "Veo",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresSora": {
+    "message": "Sora",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresGrok": {
+    "message": "Grok",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresDeepseek": {
+    "message": "Deepseek",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresChatgpt": {
+    "message": "ChatGPT",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresMidjourney": {
+    "message": "Midjourney",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresChatdoc": {
+    "message": "Chatdoc",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresQrart": {
+    "message": "Qrart",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresLuma": {
+    "message": "Luma",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresPixverse": {
+    "message": "Pixverse",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresPika": {
+    "message": "Pika",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresKling": {
+    "message": "Kling",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresHailuo": {
+    "message": "Hailuo",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresHeadshots": {
+    "message": "AI Φωτογραφίες Ταυτότητας",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresSuno": {
+    "message": "Suno",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresFlux": {
+    "message": "Flux",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresNanobanana": {
+    "message": "Nano Banana",
+    "description": "展示在编辑框的标题"
+  },
   "field.featuresOpenaiimage": {
     "message": "OpenAI Image",
     "description": "Displayed as the title in the editing box"
   },
-  "field.featuresSeedream": [
-    [
-      "message",
-      "SeeDream"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresSeedance": [
-    [
-      "message",
-      "SeeDance"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "field.featuresWan": [
-    [
-      "message",
-      "Wan"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresProducer": [
-    [
-      "message",
-      "Παραγωγός"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresKimi": [
-    [
-      "message",
-      "Kimi"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresSerp": [
-    [
-      "message",
-      "SERP"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresSupport": [
-    [
-      "message",
-      "Υποστήριξη Πελατών"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresI18n": [
-    [
-      "message",
-      "Πολυγλωσσική Υποστήριξη"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.basicConfig": [
-    [
-      "message",
-      "Βασική Ρύθμιση"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.seoConfig": [
-    [
-      "message",
-      "Ρύθμιση SEO"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editAdmins": [
-    [
-      "message",
-      "Επεξεργασία Διαχειριστών"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.featuresConfig": [
-    [
-      "message",
-      "Ρύθμιση Λειτουργιών"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editTitle": [
-    [
-      "message",
-      "Επεξεργασία Τίτλου"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editOrigin": [
-    [
-      "message",
-      "Επεξεργασία Διεύθυνσης"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editKeywords": [
-    [
-      "message",
-      "Επεξεργασία Λέξεων-κλειδιών"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editLogo": [
-    [
-      "message",
-      "Επεξεργασία Λογότυπου"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editFavicon": [
-    [
-      "message",
-      "Επεξεργασία Favicon"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editDescription": [
-    [
-      "message",
-      "Επεξεργασία Περιγραφής"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.distributionConfig": [
-    [
-      "message",
-      "Ρύθμιση Διανομής"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editDistributionDefaultInviterId": [
-    [
-      "message",
-      "Επεξεργασία Προεπιλεγμένου Προσκαλέσματος"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editDistributionForceInviterId": [
-    [
-      "message",
-      "Επεξεργασία Υποχρεωτικού Προσκαλέσματος"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editQR": [
-    [
-      "message",
-      "Επεξεργασία QR Code"
-    ],
-    [
-      "description",
-      "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
-    ]
-  ],
-  "title.editUrl": [
-    [
-      "message",
-      "Επεξεργασία Συνδέσμου"
-    ],
-    [
-      "description",
-      "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
-    ]
-  ],
-  "placeholder.title": [
-    [
-      "message",
-      "Εισάγετε τον τίτλο της ιστοσελίδας"
-    ],
-    [
-      "description",
-      "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
-    ]
-  ],
-  "placeholder.origin": [
-    [
-      "message",
-      "Εισάγετε το domain της ιστοσελίδας"
-    ],
-    [
-      "description",
-      "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
-    ]
-  ],
-  "placeholder.editUrl": [
-    [
-      "message",
-      "Εισάγετε τον σύνδεσμο"
-    ],
-    [
-      "description",
-      "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
-    ]
-  ],
-  "placeholder.description": [
-    [
-      "message",
-      "Εισάγετε την περιγραφή της ιστοσελίδας"
-    ],
-    [
-      "description",
-      "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
-    ]
-  ],
-  "placeholder.keywords": [
-    [
-      "message",
-      "Εισάγετε τις λέξεις-κλειδιά της ιστοσελίδας"
-    ],
-    [
-      "description",
-      "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
-    ]
-  ],
-  "placeholder.editDistributionDefaultInviterId": [
-    [
-      "message",
-      "Εισάγετε το ID του προεπιλεγμένου προσκαλούντα"
-    ],
-    [
-      "description",
-      "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
-    ]
-  ],
-  "placeholder.editDistributionForceInviterId": [
-    [
-      "message",
-      "Εισάγετε το ID του υποχρεωτικού προσκαλούντα"
-    ],
-    [
-      "description",
-      "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
-    ]
-  ],
-  "message.uploadImageExceed": [
-    [
-      "message",
-      "Η εικόνα που ανεβάσατε ξεπερνά το όριο"
-    ],
-    [
-      "description",
-      "Μήνυμα προειδοποίησης για την υπέρβαση του ορίου κατά την ανάρτηση εικόνας"
-    ]
-  ],
-  "message.uploadImageError": [
-    [
-      "message",
-      "Σφάλμα κατά την ανάρτηση εικόνας"
-    ],
-    [
-      "description",
-      "Μήνυμα σφάλματος κατά την ανάρτηση εικόνας"
-    ]
-  ],
-  "message.editLogoTip": [
-    [
-      "message",
-      "Συνιστώμενες διαστάσεις: 200*60px"
-    ],
-    [
-      "description",
-      "Γλώσσα προτροπής για την ανάρτηση εικόνας"
-    ]
-  ],
-  "message.editQRTip": [
-    [
-      "message",
-      "Συνιστώμενες διαστάσεις: 200*200px"
-    ],
-    [
-      "description",
-      "Γλώσσα προτροπής για την ανάρτηση εικόνας"
-    ]
-  ],
-  "message.editFaviconTip": [
-    [
-      "message",
-      "Συνιστώμενες διαστάσεις: 32*32px"
-    ],
-    [
-      "description",
-      "Γλώσσα προτροπής για την ανάρτηση εικόνας"
-    ]
-  ],
-  "message.editUrl": [
-    [
-      "message",
-      "Εισάγετε τον σύνδεσμο"
-    ],
-    [
-      "description",
-      "Προτροπή για την εισαγωγή συνδέσμου"
-    ]
-  ],
-  "message.atLeastOneAdmin": [
-    [
-      "message",
-      "Πρέπει να διατηρηθεί τουλάχιστον ένας διαχειριστής"
-    ],
-    [
-      "description",
-      "Προτροπή για τη διατήρηση τουλάχιστον ενός διαχειριστή"
-    ]
-  ],
-  "message.distributionDefaultInviterIdTip": [
-    [
-      "message",
-      "Το ID του προεπιλεγμένου προσκαλούντα. Αν ο σύνδεσμος διανομής δεν περιέχει την παράμετρο inviter_id, θα χρησιμοποιηθεί αυτό το ID ως προσκαλών."
-    ],
-    [
-      "description",
-      "Προτροπή για το ID του προεπιλεγμένου προσκαλούντα"
-    ]
-  ],
-  "message.distributionForceInviterIdTip": [
-    [
-      "message",
-      "Το ID του υποχρεωτικού προσκαλούντα. Αν οριστεί αυτό το ID, θα χρησιμοποιηθεί υποχρεωτικά ανεξαρτήτως αν ο σύνδεσμος διανομής περιέχει την παράμετρο inviter_id."
-    ],
-    [
-      "description",
-      "Προτροπή για το ID του υποχρεωτικού προσκαλούντα"
-    ]
-  ],
-  "message.originTip": [
-    [
-      "message",
-      "Το domain της ιστοσελίδας, η ρύθμιση της ιστοσελίδας είναι δεσμευμένη με το domain και δεν μπορεί να αλλάξει."
-    ],
-    [
-      "description",
-      "Προτροπή για το domain της ιστοσελίδας"
-    ]
-  ],
-  "message.titleTip": [
-    [
-      "message",
-      "Ο τίτλος της ιστοσελίδας, εμφανίζεται στην καρτέλα του προγράμματος περιήγησης."
-    ],
-    [
-      "description",
-      "Προτροπή για τον τίτλο της ιστοσελίδας"
-    ]
-  ],
-  "message.descriptionTip": [
-    [
-      "message",
-      "Η περιγραφή της ιστοσελίδας, βρίσκεται στα μεταδεδομένα της ιστοσελίδας και χρησιμοποιείται για SEO."
-    ],
-    [
-      "description",
-      "Προτροπή για την περιγραφή της ιστοσελίδας"
-    ]
-  ],
-  "message.logoTip": [
-    [
-      "message",
-      "Το λογότυπο της ιστοσελίδας, εμφανίζεται στην κορυφή του μενού όταν το μενού είναι ανοιχτό."
-    ],
-    [
-      "description",
-      "Προτροπή για το λογότυπο της ιστοσελίδας"
-    ]
-  ],
-  "message.faviconTip": [
-    [
-      "message",
-      "Το favicon της ιστοσελίδας, εμφανίζεται στην καρτέλα του προγράμματος περιήγησης."
-    ],
-    [
-      "description",
-      "Προτροπή για το favicon της ιστοσελίδας"
-    ]
-  ],
-  "message.adminsTip": [
-    [
-      "message",
-      "ID διαχειριστών της ιστοσελίδας. Ο πρώτος χρήστης που δημιουργεί την ιστοσελίδα γίνεται διαχειριστής. Μόνο οι διαχειριστές μπορούν να διαχειρίζονται την ιστοσελίδα."
-    ],
-    [
-      "description",
-      "Προτροπή για τους διαχειριστές της ιστοσελίδας"
-    ]
-  ],
-  "message.adminsTip2": [
-    [
-      "message",
-      "Μπορείτε να προσθέσετε ή να αφαιρέσετε ID διαχειριστών εδώ. Μπορείτε να δείτε τα ID χρηστών στο https://auth.acedata.cloud"
-    ],
-    [
-      "description",
-      "Προτροπή για τους διαχειριστές της ιστοσελίδας"
-    ]
-  ],
-  "message.keywordsTip": [
-    [
-      "message",
-      "Λέξεις-κλειδιά της ιστοσελίδας, βρίσκονται στα μεταδεδομένα της ιστοσελίδας και χρησιμοποιούνται για SEO."
-    ],
-    [
-      "description",
-      "Προτροπή για τις λέξεις-κλειδιά της ιστοσελίδας"
-    ]
-  ],
-  "message.keywordsTip2": [
-    [
-      "message",
-      "Μπορείτε να προσθέσετε ή να αφαιρέσετε λέξεις-κλειδιά εδώ. Όσο πιο ακριβείς είναι οι λέξεις-κλειδιά, τόσο καλύτερα για το SEO."
-    ],
-    [
-      "description",
-      "Προτροπή για τις λέξεις-κλειδιά της ιστοσελίδας"
-    ]
-  ],
-  "message.featuresChat": [
-    [
-      "message",
-      "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Chat."
-    ],
-    [
-      "description",
-      "Περιγραφή της λειτουργίας Chat"
-    ]
-  ],
-  "message.featuresGrok": [
-    [
-      "message",
-      "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Grok."
-    ],
-    [
-      "description",
-      "Περιγραφή της λειτουργίας Grok"
-    ]
-  ],
-  "message.featuresDeepseek": [
-    [
-      "message",
-      "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Deepseek."
-    ],
-    [
-      "description",
-      "Περιγραφή της λειτουργίας Deepseek"
-    ]
-  ],
-  "message.featuresChatgpt": [
-    [
-      "message",
-      "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία ChatGPT."
-    ],
-    [
-      "description",
-      "Περιγραφή της λειτουργίας ChatGPT"
-    ]
-  ],
-  "message.featuresMidjourney": [
-    [
-      "message",
-      "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Midjourney."
-    ],
-    [
-      "description",
-      "Περιγραφή της λειτουργίας Midjourney"
-    ]
-  ],
-  "message.featuresChatdoc": [
-    [
-      "message",
-      "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Chatdoc."
-    ],
-    [
-      "description",
-      "Περιγραφή της λειτουργίας Chatdoc"
-    ]
-  ],
-  "message.featuresQrart": [
-    [
-      "message",
-      "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Qrart."
-    ],
-    [
-      "description",
-      "Περιγραφή της λειτουργίας Qrart"
-    ]
-  ],
-  "message.featuresVeo": [
-    [
-      "message",
-      "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Veo."
-    ],
-    [
-      "description",
-      "Περιγραφή της λειτουργίας Veo"
-    ]
-  ],
-  "message.featuresSora": [
-    [
-      "message",
-      "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Sora."
-    ],
-    [
-      "description",
-      "Περιγραφή της λειτουργίας Sora"
-    ]
-  ],
-  "message.featuresSuno": [
-    [
-      "message",
-      "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Suno."
-    ],
-    [
-      "description",
-      "Περιγραφή της λειτουργίας Suno"
-    ]
-  ],
-  "message.featuresPixverse": [
-    [
-      "message",
-      "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Pixverse."
-    ],
-    [
-      "description",
-      "Περιγραφή της λειτουργίας Pixverse"
-    ]
-  ],
-  "message.featuresFlux": [
-    [
-      "message",
-      "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου FLux."
-    ],
-    [
-      "description",
-      "Περιγραφή της λειτουργίας FLux"
-    ]
-  ],
-  "message.featuresNanobanana": [
-    [
-      "message",
-      "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Nano Banana."
-    ],
-    [
-      "description",
-      "Περιγραφή της λειτουργίας Nano Banana"
-    ]
-  ],
+  "field.featuresSeedream": {
+    "message": "SeeDream",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresSeedance": {
+    "message": "SeeDance",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresWan": {
+    "message": "Wan",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresProducer": {
+    "message": "Παραγωγός",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresKimi": {
+    "message": "Kimi",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresSerp": {
+    "message": "SERP",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresSupport": {
+    "message": "Υποστήριξη Πελατών",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresI18n": {
+    "message": "Πολυγλωσσική Υποστήριξη",
+    "description": "展示在编辑框的标题"
+  },
+  "title.basicConfig": {
+    "message": "Βασική Ρύθμιση",
+    "description": "展示在编辑框的标题"
+  },
+  "title.seoConfig": {
+    "message": "Ρύθμιση SEO",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editAdmins": {
+    "message": "Επεξεργασία Διαχειριστών",
+    "description": "展示在编辑框的标题"
+  },
+  "title.featuresConfig": {
+    "message": "Ρύθμιση Λειτουργιών",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editTitle": {
+    "message": "Επεξεργασία Τίτλου",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editOrigin": {
+    "message": "Επεξεργασία Διεύθυνσης",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editKeywords": {
+    "message": "Επεξεργασία Λέξεων-κλειδιών",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editLogo": {
+    "message": "Επεξεργασία Λογότυπου",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editFavicon": {
+    "message": "Επεξεργασία Favicon",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editDescription": {
+    "message": "Επεξεργασία Περιγραφής",
+    "description": "展示在编辑框的标题"
+  },
+  "title.distributionConfig": {
+    "message": "Ρύθμιση Διανομής",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editDistributionDefaultInviterId": {
+    "message": "Επεξεργασία Προεπιλεγμένου Προσκαλέσματος",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editDistributionForceInviterId": {
+    "message": "Επεξεργασία Υποχρεωτικού Προσκαλέσματος",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editQR": {
+    "message": "Επεξεργασία QR Code",
+    "description": "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
+  },
+  "title.editUrl": {
+    "message": "Επεξεργασία Συνδέσμου",
+    "description": "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
+  },
+  "placeholder.title": {
+    "message": "Εισάγετε τον τίτλο της ιστοσελίδας",
+    "description": "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
+  },
+  "placeholder.origin": {
+    "message": "Εισάγετε το domain της ιστοσελίδας",
+    "description": "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
+  },
+  "placeholder.editUrl": {
+    "message": "Εισάγετε τον σύνδεσμο",
+    "description": "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
+  },
+  "placeholder.description": {
+    "message": "Εισάγετε την περιγραφή της ιστοσελίδας",
+    "description": "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
+  },
+  "placeholder.keywords": {
+    "message": "Εισάγετε τις λέξεις-κλειδιά της ιστοσελίδας",
+    "description": "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
+  },
+  "placeholder.editDistributionDefaultInviterId": {
+    "message": "Εισάγετε το ID του προεπιλεγμένου προσκαλούντα",
+    "description": "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
+  },
+  "placeholder.editDistributionForceInviterId": {
+    "message": "Εισάγετε το ID του υποχρεωτικού προσκαλούντα",
+    "description": "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
+  },
+  "message.uploadImageExceed": {
+    "message": "Η εικόνα που ανεβάσατε ξεπερνά το όριο",
+    "description": "Μήνυμα προειδοποίησης για την υπέρβαση του ορίου κατά την ανάρτηση εικόνας"
+  },
+  "message.uploadImageError": {
+    "message": "Σφάλμα κατά την ανάρτηση εικόνας",
+    "description": "Μήνυμα σφάλματος κατά την ανάρτηση εικόνας"
+  },
+  "message.editLogoTip": {
+    "message": "Συνιστώμενες διαστάσεις: 200*60px",
+    "description": "Γλώσσα προτροπής για την ανάρτηση εικόνας"
+  },
+  "message.editQRTip": {
+    "message": "Συνιστώμενες διαστάσεις: 200*200px",
+    "description": "Γλώσσα προτροπής για την ανάρτηση εικόνας"
+  },
+  "message.editFaviconTip": {
+    "message": "Συνιστώμενες διαστάσεις: 32*32px",
+    "description": "Γλώσσα προτροπής για την ανάρτηση εικόνας"
+  },
+  "message.editUrl": {
+    "message": "Εισάγετε τον σύνδεσμο",
+    "description": "Προτροπή για την εισαγωγή συνδέσμου"
+  },
+  "message.atLeastOneAdmin": {
+    "message": "Πρέπει να διατηρηθεί τουλάχιστον ένας διαχειριστής",
+    "description": "Προτροπή για τη διατήρηση τουλάχιστον ενός διαχειριστή"
+  },
+  "message.distributionDefaultInviterIdTip": {
+    "message": "Το ID του προεπιλεγμένου προσκαλούντα. Αν ο σύνδεσμος διανομής δεν περιέχει την παράμετρο inviter_id, θα χρησιμοποιηθεί αυτό το ID ως προσκαλών.",
+    "description": "Προτροπή για το ID του προεπιλεγμένου προσκαλούντα"
+  },
+  "message.distributionForceInviterIdTip": {
+    "message": "Το ID του υποχρεωτικού προσκαλούντα. Αν οριστεί αυτό το ID, θα χρησιμοποιηθεί υποχρεωτικά ανεξαρτήτως αν ο σύνδεσμος διανομής περιέχει την παράμετρο inviter_id.",
+    "description": "Προτροπή για το ID του υποχρεωτικού προσκαλούντα"
+  },
+  "message.originTip": {
+    "message": "Το domain της ιστοσελίδας, η ρύθμιση της ιστοσελίδας είναι δεσμευμένη με το domain και δεν μπορεί να αλλάξει.",
+    "description": "Προτροπή για το domain της ιστοσελίδας"
+  },
+  "message.titleTip": {
+    "message": "Ο τίτλος της ιστοσελίδας, εμφανίζεται στην καρτέλα του προγράμματος περιήγησης.",
+    "description": "Προτροπή για τον τίτλο της ιστοσελίδας"
+  },
+  "message.descriptionTip": {
+    "message": "Η περιγραφή της ιστοσελίδας, βρίσκεται στα μεταδεδομένα της ιστοσελίδας και χρησιμοποιείται για SEO.",
+    "description": "Προτροπή για την περιγραφή της ιστοσελίδας"
+  },
+  "message.logoTip": {
+    "message": "Το λογότυπο της ιστοσελίδας, εμφανίζεται στην κορυφή του μενού όταν το μενού είναι ανοιχτό.",
+    "description": "Προτροπή για το λογότυπο της ιστοσελίδας"
+  },
+  "message.faviconTip": {
+    "message": "Το favicon της ιστοσελίδας, εμφανίζεται στην καρτέλα του προγράμματος περιήγησης.",
+    "description": "Προτροπή για το favicon της ιστοσελίδας"
+  },
+  "message.adminsTip": {
+    "message": "ID διαχειριστών της ιστοσελίδας. Ο πρώτος χρήστης που δημιουργεί την ιστοσελίδα γίνεται διαχειριστής. Μόνο οι διαχειριστές μπορούν να διαχειρίζονται την ιστοσελίδα.",
+    "description": "Προτροπή για τους διαχειριστές της ιστοσελίδας"
+  },
+  "message.adminsTip2": {
+    "message": "Μπορείτε να προσθέσετε ή να αφαιρέσετε ID διαχειριστών εδώ. Μπορείτε να δείτε τα ID χρηστών στο https://auth.acedata.cloud",
+    "description": "Προτροπή για τους διαχειριστές της ιστοσελίδας"
+  },
+  "message.keywordsTip": {
+    "message": "Λέξεις-κλειδιά της ιστοσελίδας, βρίσκονται στα μεταδεδομένα της ιστοσελίδας και χρησιμοποιούνται για SEO.",
+    "description": "Προτροπή για τις λέξεις-κλειδιά της ιστοσελίδας"
+  },
+  "message.keywordsTip2": {
+    "message": "Μπορείτε να προσθέσετε ή να αφαιρέσετε λέξεις-κλειδιά εδώ. Όσο πιο ακριβείς είναι οι λέξεις-κλειδιά, τόσο καλύτερα για το SEO.",
+    "description": "Προτροπή για τις λέξεις-κλειδιά της ιστοσελίδας"
+  },
+  "message.featuresChat": {
+    "message": "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Chat.",
+    "description": "Περιγραφή της λειτουργίας Chat"
+  },
+  "message.featuresGrok": {
+    "message": "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Grok.",
+    "description": "Περιγραφή της λειτουργίας Grok"
+  },
+  "message.featuresDeepseek": {
+    "message": "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Deepseek.",
+    "description": "Περιγραφή της λειτουργίας Deepseek"
+  },
+  "message.featuresChatgpt": {
+    "message": "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία ChatGPT.",
+    "description": "Περιγραφή της λειτουργίας ChatGPT"
+  },
+  "message.featuresMidjourney": {
+    "message": "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Midjourney.",
+    "description": "Περιγραφή της λειτουργίας Midjourney"
+  },
+  "message.featuresChatdoc": {
+    "message": "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Chatdoc.",
+    "description": "Περιγραφή της λειτουργίας Chatdoc"
+  },
+  "message.featuresQrart": {
+    "message": "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Qrart.",
+    "description": "Περιγραφή της λειτουργίας Qrart"
+  },
+  "message.featuresVeo": {
+    "message": "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Veo.",
+    "description": "Περιγραφή της λειτουργίας Veo"
+  },
+  "message.featuresSora": {
+    "message": "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Sora.",
+    "description": "Περιγραφή της λειτουργίας Sora"
+  },
+  "message.featuresSuno": {
+    "message": "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Suno.",
+    "description": "Περιγραφή της λειτουργίας Suno"
+  },
+  "message.featuresPixverse": {
+    "message": "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Pixverse.",
+    "description": "Περιγραφή της λειτουργίας Pixverse"
+  },
+  "message.featuresFlux": {
+    "message": "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου FLux.",
+    "description": "Περιγραφή της λειτουργίας FLux"
+  },
+  "message.featuresNanobanana": {
+    "message": "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Nano Banana.",
+    "description": "Περιγραφή της λειτουργίας Nano Banana"
+  },
   "message.featuresOpenaiimage": {
     "message": "Toggle OpenAI Image feature module.",
     "description": "Description of the OpenAI Image feature"
   },
-  "message.featuresSeedream": [
-    [
-      "message",
-      "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου SeeDream."
-    ],
-    [
-      "description",
-      "Περιγραφή της λειτουργίας SeeDream"
-    ]
-  ],
-  "message.featuresSeedance": [
-    [
-      "message",
-      "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου SeeDance."
-    ],
-    [
-      "description",
-      "Περιγραφή της λειτουργίας SeeDance"
-    ]
-  ],
-  "message.featuresWan": [
-    [
-      "message",
-      "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Wan."
-    ],
-    [
-      "description",
-      "Περιγραφή της λειτουργίας Wan"
-    ]
-  ],
-  "message.featuresProducer": [
-    [
-      "message",
-      "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Producer."
-    ],
-    [
-      "description",
-      "Περιγραφή της λειτουργίας Producer"
-    ]
-  ],
-  "message.featuresKimi": [
-    [
-      "message",
-      "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Kimi."
-    ],
-    [
-      "description",
-      "Περιγραφή της λειτουργίας Kimi"
-    ]
-  ],
-  "message.featuresSerp": [
-    [
-      "message",
-      "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου SERP."
-    ],
-    [
-      "description",
-      "Περιγραφή της λειτουργίας SERP"
-    ]
-  ],
-  "message.featuresLuma": [
-    [
-      "message",
-      "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Luma."
-    ],
-    [
-      "description",
-      "Περιγραφή της λειτουργίας Luma"
-    ]
-  ],
-  "message.featuresPika": [
-    [
-      "message",
-      "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Pika."
-    ],
-    [
-      "description",
-      "Περιγραφή της λειτουργίας Pika"
-    ]
-  ],
-  "message.featuresKling": [
-    [
-      "message",
-      "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Kling."
-    ],
-    [
-      "description",
-      "Περιγραφή της λειτουργίας Kling"
-    ]
-  ],
-  "message.featuresHailuo": [
-    [
-      "message",
-      "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Hailuo."
-    ],
-    [
-      "description",
-      "Περιγραφή της λειτουργίας Hailuo"
-    ]
-  ],
-  "message.featuresHeadshots": [
-    [
-      "message",
-      "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου AI ταυτότητας."
-    ],
-    [
-      "description",
-      "Περιγραφή της λειτουργίας AI ταυτότητας"
-    ]
-  ],
-  "message.featuresSupport": [
-    [
-      "message",
-      "Ενεργοποίηση ή απενεργοποίηση υποστήριξης πελατών"
-    ],
-    [
-      "description",
-      "Περιγραφή της λειτουργίας υποστήριξης"
-    ]
-  ],
-  "message.featuresI18n": [
-    [
-      "message",
-      "Ενεργοποίηση ή απενεργοποίηση υποστήριξης πολλών γλωσσών. Με την απενεργοποίηση, οι χρήστες θα μπορούν να χρησιμοποιούν μόνο τη προεπιλεγμένη γλώσσα."
-    ],
-    [
-      "description",
-      "Περιγραφή της υποστήριξης πολλών γλωσσών"
-    ]
-  ],
-  "button.upload": [
-    [
-      "message",
-      "Ανέβασμα"
-    ],
-    [
-      "description",
-      "Ανέβασμα"
-    ]
-  ],
-  "button.enabled": [
-    [
-      "message",
-      "Ενεργοποιημένο"
-    ],
-    [
-      "description",
-      "Κείμενο διακόπτη που δηλώνει ότι είναι ενεργοποιημένο"
-    ]
-  ],
-  "button.disabled": [
-    [
-      "message",
-      "Απενεργοποιημένο"
-    ],
-    [
-      "description",
-      "Κείμενο διακόπτη που δηλώνει ότι είναι απενεργοποιημένο"
-    ]
-  ],
-  "field.featuresGemini": [
-    [
-      "message",
-      "Gemini"
-    ],
-    [
-      "description",
-      "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
-    ]
-  ],
-  "message.featuresGemini": [
-    [
-      "message",
-      "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Gemini."
-    ],
-    [
-      "description",
-      "Περιγραφή της λειτουργίας Gemini"
-    ]
-  ],
-  "field.featuresClaude": [
-    [
-      "message",
-      "Claude"
-    ],
-    [
-      "description",
-      "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
-    ]
-  ],
-  "message.featuresClaude": [
-    [
-      "message",
-      "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Claude."
-    ],
-    [
-      "description",
-      "Περιγραφή της λειτουργίας Claude"
-    ]
-  ]
+  "message.featuresSeedream": {
+    "message": "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου SeeDream.",
+    "description": "Περιγραφή της λειτουργίας SeeDream"
+  },
+  "message.featuresSeedance": {
+    "message": "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου SeeDance.",
+    "description": "Περιγραφή της λειτουργίας SeeDance"
+  },
+  "message.featuresWan": {
+    "message": "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Wan.",
+    "description": "Περιγραφή της λειτουργίας Wan"
+  },
+  "message.featuresProducer": {
+    "message": "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Producer.",
+    "description": "Περιγραφή της λειτουργίας Producer"
+  },
+  "message.featuresKimi": {
+    "message": "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Kimi.",
+    "description": "Περιγραφή της λειτουργίας Kimi"
+  },
+  "message.featuresSerp": {
+    "message": "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου SERP.",
+    "description": "Περιγραφή της λειτουργίας SERP"
+  },
+  "message.featuresLuma": {
+    "message": "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Luma.",
+    "description": "Περιγραφή της λειτουργίας Luma"
+  },
+  "message.featuresPika": {
+    "message": "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Pika.",
+    "description": "Περιγραφή της λειτουργίας Pika"
+  },
+  "message.featuresKling": {
+    "message": "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Kling.",
+    "description": "Περιγραφή της λειτουργίας Kling"
+  },
+  "message.featuresHailuo": {
+    "message": "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Hailuo.",
+    "description": "Περιγραφή της λειτουργίας Hailuo"
+  },
+  "message.featuresHeadshots": {
+    "message": "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου AI ταυτότητας.",
+    "description": "Περιγραφή της λειτουργίας AI ταυτότητας"
+  },
+  "message.featuresSupport": {
+    "message": "Ενεργοποίηση ή απενεργοποίηση υποστήριξης πελατών",
+    "description": "Περιγραφή της λειτουργίας υποστήριξης"
+  },
+  "message.featuresI18n": {
+    "message": "Ενεργοποίηση ή απενεργοποίηση υποστήριξης πολλών γλωσσών. Με την απενεργοποίηση, οι χρήστες θα μπορούν να χρησιμοποιούν μόνο τη προεπιλεγμένη γλώσσα.",
+    "description": "Περιγραφή της υποστήριξης πολλών γλωσσών"
+  },
+  "button.upload": {
+    "message": "Ανέβασμα",
+    "description": "Ανέβασμα"
+  },
+  "button.enabled": {
+    "message": "Ενεργοποιημένο",
+    "description": "Κείμενο διακόπτη που δηλώνει ότι είναι ενεργοποιημένο"
+  },
+  "button.disabled": {
+    "message": "Απενεργοποιημένο",
+    "description": "Κείμενο διακόπτη που δηλώνει ότι είναι απενεργοποιημένο"
+  },
+  "field.featuresGemini": {
+    "message": "Gemini",
+    "description": "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
+  },
+  "message.featuresGemini": {
+    "message": "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Gemini.",
+    "description": "Περιγραφή της λειτουργίας Gemini"
+  },
+  "field.featuresClaude": {
+    "message": "Claude",
+    "description": "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
+  },
+  "message.featuresClaude": {
+    "message": "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Claude.",
+    "description": "Περιγραφή της λειτουργίας Claude"
+  }
 }

--- a/src/i18n/el/site.json
+++ b/src/i18n/el/site.json
@@ -1,442 +1,1110 @@
 {
-  "field.title": {
-    "message": "Τίτλος Ιστοσελίδας",
-    "description": "展示在编辑框的标题"
-  },
-  "field.origin": {
-    "message": "Διεύθυνση Ιστοσελίδας",
-    "description": "展示在编辑框的标题"
-  },
-  "field.description": {
-    "message": "Περιγραφή Ιστοσελίδας",
-    "description": "展示在编辑框的标题"
-  },
-  "field.keywords": {
-    "message": "Λέξεις-κλειδιά Ιστοσελίδας",
-    "description": "展示在编辑框的标题"
-  },
-  "field.logo": {
-    "message": "Λογότυπο Ιστοσελίδας",
-    "description": "展示在编辑框的标题"
-  },
-  "field.favicon": {
-    "message": "Favicon Ιστοσελίδας",
-    "description": "展示在编辑框的标题"
-  },
-  "field.qr": {
-    "message": "QR Κωδικός",
-    "description": "展示在编辑框的标题"
-  },
-  "field.url": {
-    "message": "Σύνδεσμος",
-    "description": "展示在编辑框的标题"
-  },
-  "field.admins": {
-    "message": "ID Διαχειριστών Ιστοσελίδας",
-    "description": "展示在编辑框的标题"
-  },
-  "field.distributionDefaultInviterId": {
-    "message": "ID Προεπιλεγμένου Προσκαλέσματος",
-    "description": "展示在编辑框的标题"
-  },
-  "field.distributionForceInviterId": {
-    "message": "ID Υποχρεωτικού Προσκαλέσματος",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresChat": {
-    "message": "Chat",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresVeo": {
-    "message": "Veo",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresSora": {
-    "message": "Sora",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresGrok": {
-    "message": "Grok",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresDeepseek": {
-    "message": "Deepseek",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresChatgpt": {
-    "message": "ChatGPT",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresMidjourney": {
-    "message": "Midjourney",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresChatdoc": {
-    "message": "Chatdoc",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresQrart": {
-    "message": "Qrart",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresLuma": {
-    "message": "Luma",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresPixverse": {
-    "message": "Pixverse",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresPika": {
-    "message": "Pika",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresKling": {
-    "message": "Kling",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresHailuo": {
-    "message": "Hailuo",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresHeadshots": {
-    "message": "AI Φωτογραφίες Ταυτότητας",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresSuno": {
-    "message": "Suno",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresFlux": {
-    "message": "Flux",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresNanobanana": {
-    "message": "Nano Banana",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresSeedream": {
-    "message": "SeeDream",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresSeedance": {
-    "message": "SeeDance",
+  "field.title": [
+    [
+      "message",
+      "Τίτλος Ιστοσελίδας"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.origin": [
+    [
+      "message",
+      "Διεύθυνση Ιστοσελίδας"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.description": [
+    [
+      "message",
+      "Περιγραφή Ιστοσελίδας"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.keywords": [
+    [
+      "message",
+      "Λέξεις-κλειδιά Ιστοσελίδας"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.logo": [
+    [
+      "message",
+      "Λογότυπο Ιστοσελίδας"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.favicon": [
+    [
+      "message",
+      "Favicon Ιστοσελίδας"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.qr": [
+    [
+      "message",
+      "QR Κωδικός"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.url": [
+    [
+      "message",
+      "Σύνδεσμος"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.admins": [
+    [
+      "message",
+      "ID Διαχειριστών Ιστοσελίδας"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.distributionDefaultInviterId": [
+    [
+      "message",
+      "ID Προεπιλεγμένου Προσκαλέσματος"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.distributionForceInviterId": [
+    [
+      "message",
+      "ID Υποχρεωτικού Προσκαλέσματος"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresChat": [
+    [
+      "message",
+      "Chat"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresVeo": [
+    [
+      "message",
+      "Veo"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresSora": [
+    [
+      "message",
+      "Sora"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresGrok": [
+    [
+      "message",
+      "Grok"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresDeepseek": [
+    [
+      "message",
+      "Deepseek"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresChatgpt": [
+    [
+      "message",
+      "ChatGPT"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresMidjourney": [
+    [
+      "message",
+      "Midjourney"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresChatdoc": [
+    [
+      "message",
+      "Chatdoc"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresQrart": [
+    [
+      "message",
+      "Qrart"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresLuma": [
+    [
+      "message",
+      "Luma"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresPixverse": [
+    [
+      "message",
+      "Pixverse"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresPika": [
+    [
+      "message",
+      "Pika"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresKling": [
+    [
+      "message",
+      "Kling"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresHailuo": [
+    [
+      "message",
+      "Hailuo"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresHeadshots": [
+    [
+      "message",
+      "AI Φωτογραφίες Ταυτότητας"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresSuno": [
+    [
+      "message",
+      "Suno"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresFlux": [
+    [
+      "message",
+      "Flux"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresNanobanana": [
+    [
+      "message",
+      "Nano Banana"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresOpenaiimage": {
+    "message": "OpenAI Image",
     "description": "Displayed as the title in the editing box"
   },
-  "field.featuresWan": {
-    "message": "Wan",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresProducer": {
-    "message": "Παραγωγός",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresKimi": {
-    "message": "Kimi",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresSerp": {
-    "message": "SERP",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresSupport": {
-    "message": "Υποστήριξη Πελατών",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresI18n": {
-    "message": "Πολυγλωσσική Υποστήριξη",
-    "description": "展示在编辑框的标题"
-  },
-  "title.basicConfig": {
-    "message": "Βασική Ρύθμιση",
-    "description": "展示在编辑框的标题"
-  },
-  "title.seoConfig": {
-    "message": "Ρύθμιση SEO",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editAdmins": {
-    "message": "Επεξεργασία Διαχειριστών",
-    "description": "展示在编辑框的标题"
-  },
-  "title.featuresConfig": {
-    "message": "Ρύθμιση Λειτουργιών",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editTitle": {
-    "message": "Επεξεργασία Τίτλου",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editOrigin": {
-    "message": "Επεξεργασία Διεύθυνσης",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editKeywords": {
-    "message": "Επεξεργασία Λέξεων-κλειδιών",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editLogo": {
-    "message": "Επεξεργασία Λογότυπου",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editFavicon": {
-    "message": "Επεξεργασία Favicon",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editDescription": {
-    "message": "Επεξεργασία Περιγραφής",
-    "description": "展示在编辑框的标题"
-  },
-  "title.distributionConfig": {
-    "message": "Ρύθμιση Διανομής",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editDistributionDefaultInviterId": {
-    "message": "Επεξεργασία Προεπιλεγμένου Προσκαλέσματος",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editDistributionForceInviterId": {
-    "message": "Επεξεργασία Υποχρεωτικού Προσκαλέσματος",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editQR": {
-    "message": "Επεξεργασία QR Code",
-    "description": "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
-  },
-  "title.editUrl": {
-    "message": "Επεξεργασία Συνδέσμου",
-    "description": "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
-  },
-  "placeholder.title": {
-    "message": "Εισάγετε τον τίτλο της ιστοσελίδας",
-    "description": "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
-  },
-  "placeholder.origin": {
-    "message": "Εισάγετε το domain της ιστοσελίδας",
-    "description": "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
-  },
-  "placeholder.editUrl": {
-    "message": "Εισάγετε τον σύνδεσμο",
-    "description": "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
-  },
-  "placeholder.description": {
-    "message": "Εισάγετε την περιγραφή της ιστοσελίδας",
-    "description": "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
-  },
-  "placeholder.keywords": {
-    "message": "Εισάγετε τις λέξεις-κλειδιά της ιστοσελίδας",
-    "description": "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
-  },
-  "placeholder.editDistributionDefaultInviterId": {
-    "message": "Εισάγετε το ID του προεπιλεγμένου προσκαλούντα",
-    "description": "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
-  },
-  "placeholder.editDistributionForceInviterId": {
-    "message": "Εισάγετε το ID του υποχρεωτικού προσκαλούντα",
-    "description": "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
-  },
-  "message.uploadImageExceed": {
-    "message": "Η εικόνα που ανεβάσατε ξεπερνά το όριο",
-    "description": "Μήνυμα προειδοποίησης για την υπέρβαση του ορίου κατά την ανάρτηση εικόνας"
-  },
-  "message.uploadImageError": {
-    "message": "Σφάλμα κατά την ανάρτηση εικόνας",
-    "description": "Μήνυμα σφάλματος κατά την ανάρτηση εικόνας"
-  },
-  "message.editLogoTip": {
-    "message": "Συνιστώμενες διαστάσεις: 200*60px",
-    "description": "Γλώσσα προτροπής για την ανάρτηση εικόνας"
-  },
-  "message.editQRTip": {
-    "message": "Συνιστώμενες διαστάσεις: 200*200px",
-    "description": "Γλώσσα προτροπής για την ανάρτηση εικόνας"
-  },
-  "message.editFaviconTip": {
-    "message": "Συνιστώμενες διαστάσεις: 32*32px",
-    "description": "Γλώσσα προτροπής για την ανάρτηση εικόνας"
-  },
-  "message.editUrl": {
-    "message": "Εισάγετε τον σύνδεσμο",
-    "description": "Προτροπή για την εισαγωγή συνδέσμου"
-  },
-  "message.atLeastOneAdmin": {
-    "message": "Πρέπει να διατηρηθεί τουλάχιστον ένας διαχειριστής",
-    "description": "Προτροπή για τη διατήρηση τουλάχιστον ενός διαχειριστή"
-  },
-  "message.distributionDefaultInviterIdTip": {
-    "message": "Το ID του προεπιλεγμένου προσκαλούντα. Αν ο σύνδεσμος διανομής δεν περιέχει την παράμετρο inviter_id, θα χρησιμοποιηθεί αυτό το ID ως προσκαλών.",
-    "description": "Προτροπή για το ID του προεπιλεγμένου προσκαλούντα"
-  },
-  "message.distributionForceInviterIdTip": {
-    "message": "Το ID του υποχρεωτικού προσκαλούντα. Αν οριστεί αυτό το ID, θα χρησιμοποιηθεί υποχρεωτικά ανεξαρτήτως αν ο σύνδεσμος διανομής περιέχει την παράμετρο inviter_id.",
-    "description": "Προτροπή για το ID του υποχρεωτικού προσκαλούντα"
-  },
-  "message.originTip": {
-    "message": "Το domain της ιστοσελίδας, η ρύθμιση της ιστοσελίδας είναι δεσμευμένη με το domain και δεν μπορεί να αλλάξει.",
-    "description": "Προτροπή για το domain της ιστοσελίδας"
-  },
-  "message.titleTip": {
-    "message": "Ο τίτλος της ιστοσελίδας, εμφανίζεται στην καρτέλα του προγράμματος περιήγησης.",
-    "description": "Προτροπή για τον τίτλο της ιστοσελίδας"
-  },
-  "message.descriptionTip": {
-    "message": "Η περιγραφή της ιστοσελίδας, βρίσκεται στα μεταδεδομένα της ιστοσελίδας και χρησιμοποιείται για SEO.",
-    "description": "Προτροπή για την περιγραφή της ιστοσελίδας"
-  },
-  "message.logoTip": {
-    "message": "Το λογότυπο της ιστοσελίδας, εμφανίζεται στην κορυφή του μενού όταν το μενού είναι ανοιχτό.",
-    "description": "Προτροπή για το λογότυπο της ιστοσελίδας"
-  },
-  "message.faviconTip": {
-    "message": "Το favicon της ιστοσελίδας, εμφανίζεται στην καρτέλα του προγράμματος περιήγησης.",
-    "description": "Προτροπή για το favicon της ιστοσελίδας"
-  },
-  "message.adminsTip": {
-    "message": "ID διαχειριστών της ιστοσελίδας. Ο πρώτος χρήστης που δημιουργεί την ιστοσελίδα γίνεται διαχειριστής. Μόνο οι διαχειριστές μπορούν να διαχειρίζονται την ιστοσελίδα.",
-    "description": "Προτροπή για τους διαχειριστές της ιστοσελίδας"
-  },
-  "message.adminsTip2": {
-    "message": "Μπορείτε να προσθέσετε ή να αφαιρέσετε ID διαχειριστών εδώ. Μπορείτε να δείτε τα ID χρηστών στο https://auth.acedata.cloud",
-    "description": "Προτροπή για τους διαχειριστές της ιστοσελίδας"
-  },
-  "message.keywordsTip": {
-    "message": "Λέξεις-κλειδιά της ιστοσελίδας, βρίσκονται στα μεταδεδομένα της ιστοσελίδας και χρησιμοποιούνται για SEO.",
-    "description": "Προτροπή για τις λέξεις-κλειδιά της ιστοσελίδας"
-  },
-  "message.keywordsTip2": {
-    "message": "Μπορείτε να προσθέσετε ή να αφαιρέσετε λέξεις-κλειδιά εδώ. Όσο πιο ακριβείς είναι οι λέξεις-κλειδιά, τόσο καλύτερα για το SEO.",
-    "description": "Προτροπή για τις λέξεις-κλειδιά της ιστοσελίδας"
-  },
-  "message.featuresChat": {
-    "message": "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Chat.",
-    "description": "Περιγραφή της λειτουργίας Chat"
-  },
-  "message.featuresGrok": {
-    "message": "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Grok.",
-    "description": "Περιγραφή της λειτουργίας Grok"
-  },
-  "message.featuresDeepseek": {
-    "message": "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Deepseek.",
-    "description": "Περιγραφή της λειτουργίας Deepseek"
-  },
-  "message.featuresChatgpt": {
-    "message": "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία ChatGPT.",
-    "description": "Περιγραφή της λειτουργίας ChatGPT"
-  },
-  "message.featuresMidjourney": {
-    "message": "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Midjourney.",
-    "description": "Περιγραφή της λειτουργίας Midjourney"
-  },
-  "message.featuresChatdoc": {
-    "message": "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Chatdoc.",
-    "description": "Περιγραφή της λειτουργίας Chatdoc"
-  },
-  "message.featuresQrart": {
-    "message": "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Qrart.",
-    "description": "Περιγραφή της λειτουργίας Qrart"
-  },
-  "message.featuresVeo": {
-    "message": "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Veo.",
-    "description": "Περιγραφή της λειτουργίας Veo"
-  },
-  "message.featuresSora": {
-    "message": "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Sora.",
-    "description": "Περιγραφή της λειτουργίας Sora"
-  },
-  "message.featuresSuno": {
-    "message": "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Suno.",
-    "description": "Περιγραφή της λειτουργίας Suno"
-  },
-  "message.featuresPixverse": {
-    "message": "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Pixverse.",
-    "description": "Περιγραφή της λειτουργίας Pixverse"
-  },
-  "message.featuresFlux": {
-    "message": "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου FLux.",
-    "description": "Περιγραφή της λειτουργίας FLux"
-  },
-  "message.featuresNanobanana": {
-    "message": "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Nano Banana.",
-    "description": "Περιγραφή της λειτουργίας Nano Banana"
-  },
-  "message.featuresSeedream": {
-    "message": "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου SeeDream.",
-    "description": "Περιγραφή της λειτουργίας SeeDream"
-  },
-  "message.featuresSeedance": {
-    "message": "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου SeeDance.",
-    "description": "Περιγραφή της λειτουργίας SeeDance"
-  },
-  "message.featuresWan": {
-    "message": "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Wan.",
-    "description": "Περιγραφή της λειτουργίας Wan"
-  },
-  "message.featuresProducer": {
-    "message": "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Producer.",
-    "description": "Περιγραφή της λειτουργίας Producer"
-  },
-  "message.featuresKimi": {
-    "message": "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Kimi.",
-    "description": "Περιγραφή της λειτουργίας Kimi"
-  },
-  "message.featuresSerp": {
-    "message": "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου SERP.",
-    "description": "Περιγραφή της λειτουργίας SERP"
-  },
-  "message.featuresLuma": {
-    "message": "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Luma.",
-    "description": "Περιγραφή της λειτουργίας Luma"
-  },
-  "message.featuresPika": {
-    "message": "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Pika.",
-    "description": "Περιγραφή της λειτουργίας Pika"
-  },
-  "message.featuresKling": {
-    "message": "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Kling.",
-    "description": "Περιγραφή της λειτουργίας Kling"
-  },
-  "message.featuresHailuo": {
-    "message": "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Hailuo.",
-    "description": "Περιγραφή της λειτουργίας Hailuo"
-  },
-  "message.featuresHeadshots": {
-    "message": "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου AI ταυτότητας.",
-    "description": "Περιγραφή της λειτουργίας AI ταυτότητας"
-  },
-  "message.featuresSupport": {
-    "message": "Ενεργοποίηση ή απενεργοποίηση υποστήριξης πελατών",
-    "description": "Περιγραφή της λειτουργίας υποστήριξης"
-  },
-  "message.featuresI18n": {
-    "message": "Ενεργοποίηση ή απενεργοποίηση υποστήριξης πολλών γλωσσών. Με την απενεργοποίηση, οι χρήστες θα μπορούν να χρησιμοποιούν μόνο τη προεπιλεγμένη γλώσσα.",
-    "description": "Περιγραφή της υποστήριξης πολλών γλωσσών"
-  },
-  "button.upload": {
-    "message": "Ανέβασμα",
-    "description": "Ανέβασμα"
-  },
-  "button.enabled": {
-    "message": "Ενεργοποιημένο",
-    "description": "Κείμενο διακόπτη που δηλώνει ότι είναι ενεργοποιημένο"
-  },
-  "button.disabled": {
-    "message": "Απενεργοποιημένο",
-    "description": "Κείμενο διακόπτη που δηλώνει ότι είναι απενεργοποιημένο"
-  },
-  "field.featuresGemini": {
-    "message": "Gemini",
-    "description": "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
-  },
-  "message.featuresGemini": {
-    "message": "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Gemini.",
-    "description": "Περιγραφή της λειτουργίας Gemini"
-  },
-  "field.featuresClaude": {
-    "message": "Claude",
-    "description": "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
-  },
-  "message.featuresClaude": {
-    "message": "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Claude.",
-    "description": "Περιγραφή της λειτουργίας Claude"
-  }
+  "field.featuresSeedream": [
+    [
+      "message",
+      "SeeDream"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresSeedance": [
+    [
+      "message",
+      "SeeDance"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "field.featuresWan": [
+    [
+      "message",
+      "Wan"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresProducer": [
+    [
+      "message",
+      "Παραγωγός"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresKimi": [
+    [
+      "message",
+      "Kimi"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresSerp": [
+    [
+      "message",
+      "SERP"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresSupport": [
+    [
+      "message",
+      "Υποστήριξη Πελατών"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresI18n": [
+    [
+      "message",
+      "Πολυγλωσσική Υποστήριξη"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.basicConfig": [
+    [
+      "message",
+      "Βασική Ρύθμιση"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.seoConfig": [
+    [
+      "message",
+      "Ρύθμιση SEO"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editAdmins": [
+    [
+      "message",
+      "Επεξεργασία Διαχειριστών"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.featuresConfig": [
+    [
+      "message",
+      "Ρύθμιση Λειτουργιών"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editTitle": [
+    [
+      "message",
+      "Επεξεργασία Τίτλου"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editOrigin": [
+    [
+      "message",
+      "Επεξεργασία Διεύθυνσης"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editKeywords": [
+    [
+      "message",
+      "Επεξεργασία Λέξεων-κλειδιών"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editLogo": [
+    [
+      "message",
+      "Επεξεργασία Λογότυπου"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editFavicon": [
+    [
+      "message",
+      "Επεξεργασία Favicon"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editDescription": [
+    [
+      "message",
+      "Επεξεργασία Περιγραφής"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.distributionConfig": [
+    [
+      "message",
+      "Ρύθμιση Διανομής"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editDistributionDefaultInviterId": [
+    [
+      "message",
+      "Επεξεργασία Προεπιλεγμένου Προσκαλέσματος"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editDistributionForceInviterId": [
+    [
+      "message",
+      "Επεξεργασία Υποχρεωτικού Προσκαλέσματος"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editQR": [
+    [
+      "message",
+      "Επεξεργασία QR Code"
+    ],
+    [
+      "description",
+      "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
+    ]
+  ],
+  "title.editUrl": [
+    [
+      "message",
+      "Επεξεργασία Συνδέσμου"
+    ],
+    [
+      "description",
+      "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
+    ]
+  ],
+  "placeholder.title": [
+    [
+      "message",
+      "Εισάγετε τον τίτλο της ιστοσελίδας"
+    ],
+    [
+      "description",
+      "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
+    ]
+  ],
+  "placeholder.origin": [
+    [
+      "message",
+      "Εισάγετε το domain της ιστοσελίδας"
+    ],
+    [
+      "description",
+      "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
+    ]
+  ],
+  "placeholder.editUrl": [
+    [
+      "message",
+      "Εισάγετε τον σύνδεσμο"
+    ],
+    [
+      "description",
+      "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
+    ]
+  ],
+  "placeholder.description": [
+    [
+      "message",
+      "Εισάγετε την περιγραφή της ιστοσελίδας"
+    ],
+    [
+      "description",
+      "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
+    ]
+  ],
+  "placeholder.keywords": [
+    [
+      "message",
+      "Εισάγετε τις λέξεις-κλειδιά της ιστοσελίδας"
+    ],
+    [
+      "description",
+      "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
+    ]
+  ],
+  "placeholder.editDistributionDefaultInviterId": [
+    [
+      "message",
+      "Εισάγετε το ID του προεπιλεγμένου προσκαλούντα"
+    ],
+    [
+      "description",
+      "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
+    ]
+  ],
+  "placeholder.editDistributionForceInviterId": [
+    [
+      "message",
+      "Εισάγετε το ID του υποχρεωτικού προσκαλούντα"
+    ],
+    [
+      "description",
+      "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
+    ]
+  ],
+  "message.uploadImageExceed": [
+    [
+      "message",
+      "Η εικόνα που ανεβάσατε ξεπερνά το όριο"
+    ],
+    [
+      "description",
+      "Μήνυμα προειδοποίησης για την υπέρβαση του ορίου κατά την ανάρτηση εικόνας"
+    ]
+  ],
+  "message.uploadImageError": [
+    [
+      "message",
+      "Σφάλμα κατά την ανάρτηση εικόνας"
+    ],
+    [
+      "description",
+      "Μήνυμα σφάλματος κατά την ανάρτηση εικόνας"
+    ]
+  ],
+  "message.editLogoTip": [
+    [
+      "message",
+      "Συνιστώμενες διαστάσεις: 200*60px"
+    ],
+    [
+      "description",
+      "Γλώσσα προτροπής για την ανάρτηση εικόνας"
+    ]
+  ],
+  "message.editQRTip": [
+    [
+      "message",
+      "Συνιστώμενες διαστάσεις: 200*200px"
+    ],
+    [
+      "description",
+      "Γλώσσα προτροπής για την ανάρτηση εικόνας"
+    ]
+  ],
+  "message.editFaviconTip": [
+    [
+      "message",
+      "Συνιστώμενες διαστάσεις: 32*32px"
+    ],
+    [
+      "description",
+      "Γλώσσα προτροπής για την ανάρτηση εικόνας"
+    ]
+  ],
+  "message.editUrl": [
+    [
+      "message",
+      "Εισάγετε τον σύνδεσμο"
+    ],
+    [
+      "description",
+      "Προτροπή για την εισαγωγή συνδέσμου"
+    ]
+  ],
+  "message.atLeastOneAdmin": [
+    [
+      "message",
+      "Πρέπει να διατηρηθεί τουλάχιστον ένας διαχειριστής"
+    ],
+    [
+      "description",
+      "Προτροπή για τη διατήρηση τουλάχιστον ενός διαχειριστή"
+    ]
+  ],
+  "message.distributionDefaultInviterIdTip": [
+    [
+      "message",
+      "Το ID του προεπιλεγμένου προσκαλούντα. Αν ο σύνδεσμος διανομής δεν περιέχει την παράμετρο inviter_id, θα χρησιμοποιηθεί αυτό το ID ως προσκαλών."
+    ],
+    [
+      "description",
+      "Προτροπή για το ID του προεπιλεγμένου προσκαλούντα"
+    ]
+  ],
+  "message.distributionForceInviterIdTip": [
+    [
+      "message",
+      "Το ID του υποχρεωτικού προσκαλούντα. Αν οριστεί αυτό το ID, θα χρησιμοποιηθεί υποχρεωτικά ανεξαρτήτως αν ο σύνδεσμος διανομής περιέχει την παράμετρο inviter_id."
+    ],
+    [
+      "description",
+      "Προτροπή για το ID του υποχρεωτικού προσκαλούντα"
+    ]
+  ],
+  "message.originTip": [
+    [
+      "message",
+      "Το domain της ιστοσελίδας, η ρύθμιση της ιστοσελίδας είναι δεσμευμένη με το domain και δεν μπορεί να αλλάξει."
+    ],
+    [
+      "description",
+      "Προτροπή για το domain της ιστοσελίδας"
+    ]
+  ],
+  "message.titleTip": [
+    [
+      "message",
+      "Ο τίτλος της ιστοσελίδας, εμφανίζεται στην καρτέλα του προγράμματος περιήγησης."
+    ],
+    [
+      "description",
+      "Προτροπή για τον τίτλο της ιστοσελίδας"
+    ]
+  ],
+  "message.descriptionTip": [
+    [
+      "message",
+      "Η περιγραφή της ιστοσελίδας, βρίσκεται στα μεταδεδομένα της ιστοσελίδας και χρησιμοποιείται για SEO."
+    ],
+    [
+      "description",
+      "Προτροπή για την περιγραφή της ιστοσελίδας"
+    ]
+  ],
+  "message.logoTip": [
+    [
+      "message",
+      "Το λογότυπο της ιστοσελίδας, εμφανίζεται στην κορυφή του μενού όταν το μενού είναι ανοιχτό."
+    ],
+    [
+      "description",
+      "Προτροπή για το λογότυπο της ιστοσελίδας"
+    ]
+  ],
+  "message.faviconTip": [
+    [
+      "message",
+      "Το favicon της ιστοσελίδας, εμφανίζεται στην καρτέλα του προγράμματος περιήγησης."
+    ],
+    [
+      "description",
+      "Προτροπή για το favicon της ιστοσελίδας"
+    ]
+  ],
+  "message.adminsTip": [
+    [
+      "message",
+      "ID διαχειριστών της ιστοσελίδας. Ο πρώτος χρήστης που δημιουργεί την ιστοσελίδα γίνεται διαχειριστής. Μόνο οι διαχειριστές μπορούν να διαχειρίζονται την ιστοσελίδα."
+    ],
+    [
+      "description",
+      "Προτροπή για τους διαχειριστές της ιστοσελίδας"
+    ]
+  ],
+  "message.adminsTip2": [
+    [
+      "message",
+      "Μπορείτε να προσθέσετε ή να αφαιρέσετε ID διαχειριστών εδώ. Μπορείτε να δείτε τα ID χρηστών στο https://auth.acedata.cloud"
+    ],
+    [
+      "description",
+      "Προτροπή για τους διαχειριστές της ιστοσελίδας"
+    ]
+  ],
+  "message.keywordsTip": [
+    [
+      "message",
+      "Λέξεις-κλειδιά της ιστοσελίδας, βρίσκονται στα μεταδεδομένα της ιστοσελίδας και χρησιμοποιούνται για SEO."
+    ],
+    [
+      "description",
+      "Προτροπή για τις λέξεις-κλειδιά της ιστοσελίδας"
+    ]
+  ],
+  "message.keywordsTip2": [
+    [
+      "message",
+      "Μπορείτε να προσθέσετε ή να αφαιρέσετε λέξεις-κλειδιά εδώ. Όσο πιο ακριβείς είναι οι λέξεις-κλειδιά, τόσο καλύτερα για το SEO."
+    ],
+    [
+      "description",
+      "Προτροπή για τις λέξεις-κλειδιά της ιστοσελίδας"
+    ]
+  ],
+  "message.featuresChat": [
+    [
+      "message",
+      "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Chat."
+    ],
+    [
+      "description",
+      "Περιγραφή της λειτουργίας Chat"
+    ]
+  ],
+  "message.featuresGrok": [
+    [
+      "message",
+      "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Grok."
+    ],
+    [
+      "description",
+      "Περιγραφή της λειτουργίας Grok"
+    ]
+  ],
+  "message.featuresDeepseek": [
+    [
+      "message",
+      "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Deepseek."
+    ],
+    [
+      "description",
+      "Περιγραφή της λειτουργίας Deepseek"
+    ]
+  ],
+  "message.featuresChatgpt": [
+    [
+      "message",
+      "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία ChatGPT."
+    ],
+    [
+      "description",
+      "Περιγραφή της λειτουργίας ChatGPT"
+    ]
+  ],
+  "message.featuresMidjourney": [
+    [
+      "message",
+      "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Midjourney."
+    ],
+    [
+      "description",
+      "Περιγραφή της λειτουργίας Midjourney"
+    ]
+  ],
+  "message.featuresChatdoc": [
+    [
+      "message",
+      "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Chatdoc."
+    ],
+    [
+      "description",
+      "Περιγραφή της λειτουργίας Chatdoc"
+    ]
+  ],
+  "message.featuresQrart": [
+    [
+      "message",
+      "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Qrart."
+    ],
+    [
+      "description",
+      "Περιγραφή της λειτουργίας Qrart"
+    ]
+  ],
+  "message.featuresVeo": [
+    [
+      "message",
+      "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Veo."
+    ],
+    [
+      "description",
+      "Περιγραφή της λειτουργίας Veo"
+    ]
+  ],
+  "message.featuresSora": [
+    [
+      "message",
+      "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Sora."
+    ],
+    [
+      "description",
+      "Περιγραφή της λειτουργίας Sora"
+    ]
+  ],
+  "message.featuresSuno": [
+    [
+      "message",
+      "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Suno."
+    ],
+    [
+      "description",
+      "Περιγραφή της λειτουργίας Suno"
+    ]
+  ],
+  "message.featuresPixverse": [
+    [
+      "message",
+      "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Pixverse."
+    ],
+    [
+      "description",
+      "Περιγραφή της λειτουργίας Pixverse"
+    ]
+  ],
+  "message.featuresFlux": [
+    [
+      "message",
+      "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου FLux."
+    ],
+    [
+      "description",
+      "Περιγραφή της λειτουργίας FLux"
+    ]
+  ],
+  "message.featuresNanobanana": [
+    [
+      "message",
+      "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Nano Banana."
+    ],
+    [
+      "description",
+      "Περιγραφή της λειτουργίας Nano Banana"
+    ]
+  ],
+  "message.featuresOpenaiimage": {
+    "message": "Toggle OpenAI Image feature module.",
+    "description": "Description of the OpenAI Image feature"
+  },
+  "message.featuresSeedream": [
+    [
+      "message",
+      "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου SeeDream."
+    ],
+    [
+      "description",
+      "Περιγραφή της λειτουργίας SeeDream"
+    ]
+  ],
+  "message.featuresSeedance": [
+    [
+      "message",
+      "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου SeeDance."
+    ],
+    [
+      "description",
+      "Περιγραφή της λειτουργίας SeeDance"
+    ]
+  ],
+  "message.featuresWan": [
+    [
+      "message",
+      "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Wan."
+    ],
+    [
+      "description",
+      "Περιγραφή της λειτουργίας Wan"
+    ]
+  ],
+  "message.featuresProducer": [
+    [
+      "message",
+      "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Producer."
+    ],
+    [
+      "description",
+      "Περιγραφή της λειτουργίας Producer"
+    ]
+  ],
+  "message.featuresKimi": [
+    [
+      "message",
+      "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Kimi."
+    ],
+    [
+      "description",
+      "Περιγραφή της λειτουργίας Kimi"
+    ]
+  ],
+  "message.featuresSerp": [
+    [
+      "message",
+      "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου SERP."
+    ],
+    [
+      "description",
+      "Περιγραφή της λειτουργίας SERP"
+    ]
+  ],
+  "message.featuresLuma": [
+    [
+      "message",
+      "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Luma."
+    ],
+    [
+      "description",
+      "Περιγραφή της λειτουργίας Luma"
+    ]
+  ],
+  "message.featuresPika": [
+    [
+      "message",
+      "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Pika."
+    ],
+    [
+      "description",
+      "Περιγραφή της λειτουργίας Pika"
+    ]
+  ],
+  "message.featuresKling": [
+    [
+      "message",
+      "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Kling."
+    ],
+    [
+      "description",
+      "Περιγραφή της λειτουργίας Kling"
+    ]
+  ],
+  "message.featuresHailuo": [
+    [
+      "message",
+      "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Hailuo."
+    ],
+    [
+      "description",
+      "Περιγραφή της λειτουργίας Hailuo"
+    ]
+  ],
+  "message.featuresHeadshots": [
+    [
+      "message",
+      "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου AI ταυτότητας."
+    ],
+    [
+      "description",
+      "Περιγραφή της λειτουργίας AI ταυτότητας"
+    ]
+  ],
+  "message.featuresSupport": [
+    [
+      "message",
+      "Ενεργοποίηση ή απενεργοποίηση υποστήριξης πελατών"
+    ],
+    [
+      "description",
+      "Περιγραφή της λειτουργίας υποστήριξης"
+    ]
+  ],
+  "message.featuresI18n": [
+    [
+      "message",
+      "Ενεργοποίηση ή απενεργοποίηση υποστήριξης πολλών γλωσσών. Με την απενεργοποίηση, οι χρήστες θα μπορούν να χρησιμοποιούν μόνο τη προεπιλεγμένη γλώσσα."
+    ],
+    [
+      "description",
+      "Περιγραφή της υποστήριξης πολλών γλωσσών"
+    ]
+  ],
+  "button.upload": [
+    [
+      "message",
+      "Ανέβασμα"
+    ],
+    [
+      "description",
+      "Ανέβασμα"
+    ]
+  ],
+  "button.enabled": [
+    [
+      "message",
+      "Ενεργοποιημένο"
+    ],
+    [
+      "description",
+      "Κείμενο διακόπτη που δηλώνει ότι είναι ενεργοποιημένο"
+    ]
+  ],
+  "button.disabled": [
+    [
+      "message",
+      "Απενεργοποιημένο"
+    ],
+    [
+      "description",
+      "Κείμενο διακόπτη που δηλώνει ότι είναι απενεργοποιημένο"
+    ]
+  ],
+  "field.featuresGemini": [
+    [
+      "message",
+      "Gemini"
+    ],
+    [
+      "description",
+      "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
+    ]
+  ],
+  "message.featuresGemini": [
+    [
+      "message",
+      "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Gemini."
+    ],
+    [
+      "description",
+      "Περιγραφή της λειτουργίας Gemini"
+    ]
+  ],
+  "field.featuresClaude": [
+    [
+      "message",
+      "Claude"
+    ],
+    [
+      "description",
+      "Εμφανίζεται ως τίτλος στο πλαίσιο επεξεργασίας"
+    ]
+  ],
+  "message.featuresClaude": [
+    [
+      "message",
+      "Ενεργοποίηση ή απενεργοποίηση του λειτουργικού μοντέλου Claude."
+    ],
+    [
+      "description",
+      "Περιγραφή της λειτουργίας Claude"
+    ]
+  ]
 }

--- a/src/i18n/en/site.json
+++ b/src/i18n/en/site.json
@@ -1,1110 +1,450 @@
 {
-  "field.title": [
-    [
-      "message",
-      "Site Title"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "field.origin": [
-    [
-      "message",
-      "Site Domain"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "field.description": [
-    [
-      "message",
-      "Site Description"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "field.keywords": [
-    [
-      "message",
-      "Site Keywords"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "field.logo": [
-    [
-      "message",
-      "Site Logo"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "field.favicon": [
-    [
-      "message",
-      "Site Favicon"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "field.qr": [
-    [
-      "message",
-      "QR Code"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "field.url": [
-    [
-      "message",
-      "Link"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "field.admins": [
-    [
-      "message",
-      "Site Admin IDs"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "field.distributionDefaultInviterId": [
-    [
-      "message",
-      "Default Inviter ID"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "field.distributionForceInviterId": [
-    [
-      "message",
-      "Forced Inviter ID"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "field.featuresChat": [
-    [
-      "message",
-      "Chat"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "field.featuresVeo": [
-    [
-      "message",
-      "Veo"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "field.featuresSora": [
-    [
-      "message",
-      "Sora"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "field.featuresGrok": [
-    [
-      "message",
-      "Grok"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "field.featuresDeepseek": [
-    [
-      "message",
-      "Deepseek"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "field.featuresChatgpt": [
-    [
-      "message",
-      "ChatGPT"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "field.featuresMidjourney": [
-    [
-      "message",
-      "Midjourney"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "field.featuresChatdoc": [
-    [
-      "message",
-      "Chatdoc"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "field.featuresQrart": [
-    [
-      "message",
-      "Qrart"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "field.featuresLuma": [
-    [
-      "message",
-      "Luma"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "field.featuresPixverse": [
-    [
-      "message",
-      "Pixverse"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "field.featuresPika": [
-    [
-      "message",
-      "Pika"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "field.featuresKling": [
-    [
-      "message",
-      "Kling"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "field.featuresHailuo": [
-    [
-      "message",
-      "Hailuo"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "field.featuresHeadshots": [
-    [
-      "message",
-      "AI ID Photo"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "field.featuresSuno": [
-    [
-      "message",
-      "Suno"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "field.featuresFlux": [
-    [
-      "message",
-      "Flux"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "field.featuresNanobanana": [
-    [
-      "message",
-      "Nano Banana"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
+  "field.title": {
+    "message": "Site Title",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.origin": {
+    "message": "Site Domain",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.description": {
+    "message": "Site Description",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.keywords": {
+    "message": "Site Keywords",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.logo": {
+    "message": "Site Logo",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.favicon": {
+    "message": "Site Favicon",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.qr": {
+    "message": "QR Code",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.url": {
+    "message": "Link",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.admins": {
+    "message": "Site Admin IDs",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.distributionDefaultInviterId": {
+    "message": "Default Inviter ID",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.distributionForceInviterId": {
+    "message": "Forced Inviter ID",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresChat": {
+    "message": "Chat",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresVeo": {
+    "message": "Veo",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresSora": {
+    "message": "Sora",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresGrok": {
+    "message": "Grok",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresDeepseek": {
+    "message": "Deepseek",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresChatgpt": {
+    "message": "ChatGPT",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresMidjourney": {
+    "message": "Midjourney",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresChatdoc": {
+    "message": "Chatdoc",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresQrart": {
+    "message": "Qrart",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresLuma": {
+    "message": "Luma",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresPixverse": {
+    "message": "Pixverse",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresPika": {
+    "message": "Pika",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresKling": {
+    "message": "Kling",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresHailuo": {
+    "message": "Hailuo",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresHeadshots": {
+    "message": "AI ID Photo",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresSuno": {
+    "message": "Suno",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresFlux": {
+    "message": "Flux",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresNanobanana": {
+    "message": "Nano Banana",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresOpenaiimage": {
     "message": "OpenAI Image",
     "description": "Displayed as the title in the editing box"
   },
-  "field.featuresSeedream": [
-    [
-      "message",
-      "SeeDream"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "field.featuresSeedance": [
-    [
-      "message",
-      "SeeDance"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "field.featuresWan": [
-    [
-      "message",
-      "Wan"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "field.featuresProducer": [
-    [
-      "message",
-      "Producer"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "field.featuresKimi": [
-    [
-      "message",
-      "Kimi"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "field.featuresSerp": [
-    [
-      "message",
-      "SERP"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "field.featuresSupport": [
-    [
-      "message",
-      "Customer Support"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "field.featuresI18n": [
-    [
-      "message",
-      "Multilingual Support"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "title.basicConfig": [
-    [
-      "message",
-      "Basic Configuration"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "title.seoConfig": [
-    [
-      "message",
-      "SEO Configuration"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "title.editAdmins": [
-    [
-      "message",
-      "Edit Admins"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "title.featuresConfig": [
-    [
-      "message",
-      "Features Configuration"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "title.editTitle": [
-    [
-      "message",
-      "Edit Title"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "title.editOrigin": [
-    [
-      "message",
-      "Edit Domain"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "title.editKeywords": [
-    [
-      "message",
-      "Edit Keywords"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "title.editLogo": [
-    [
-      "message",
-      "Edit Logo"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "title.editFavicon": [
-    [
-      "message",
-      "Edit Favicon"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "title.editDescription": [
-    [
-      "message",
-      "Edit Description"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "title.distributionConfig": [
-    [
-      "message",
-      "Distribution Configuration"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "title.editDistributionDefaultInviterId": [
-    [
-      "message",
-      "Edit Default Inviter"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "title.editDistributionForceInviterId": [
-    [
-      "message",
-      "Edit Forced Inviter"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "title.editQR": [
-    [
-      "message",
-      "Edit QR Code"
-    ],
-    [
-      "description",
-      "Title displayed in the editing box"
-    ]
-  ],
-  "title.editUrl": [
-    [
-      "message",
-      "Edit Link"
-    ],
-    [
-      "description",
-      "Title displayed in the editing box"
-    ]
-  ],
-  "placeholder.title": [
-    [
-      "message",
-      "Enter Site Title"
-    ],
-    [
-      "description",
-      "Placeholder text in the editing box"
-    ]
-  ],
-  "placeholder.origin": [
-    [
-      "message",
-      "Enter Site Domain"
-    ],
-    [
-      "description",
-      "Placeholder text in the editing box"
-    ]
-  ],
-  "placeholder.editUrl": [
-    [
-      "message",
-      "Enter Link"
-    ],
-    [
-      "description",
-      "Placeholder text in the editing box"
-    ]
-  ],
-  "placeholder.description": [
-    [
-      "message",
-      "Enter Site Description"
-    ],
-    [
-      "description",
-      "Placeholder text in the editing box"
-    ]
-  ],
-  "placeholder.keywords": [
-    [
-      "message",
-      "Enter Site Keywords"
-    ],
-    [
-      "description",
-      "Placeholder text in the editing box"
-    ]
-  ],
-  "placeholder.editDistributionDefaultInviterId": [
-    [
-      "message",
-      "Enter Default Inviter ID"
-    ],
-    [
-      "description",
-      "Placeholder text in the editing box"
-    ]
-  ],
-  "placeholder.editDistributionForceInviterId": [
-    [
-      "message",
-      "Enter Forced Inviter ID"
-    ],
-    [
-      "description",
-      "Placeholder text in the editing box"
-    ]
-  ],
-  "message.uploadImageExceed": [
-    [
-      "message",
-      "Image Upload Exceeds Limit"
-    ],
-    [
-      "description",
-      "Notification for exceeding image upload limit"
-    ]
-  ],
-  "message.uploadImageError": [
-    [
-      "message",
-      "Image Upload Error"
-    ],
-    [
-      "description",
-      "Notification for image upload error"
-    ]
-  ],
-  "message.editLogoTip": [
-    [
-      "message",
-      "Recommended Size: 200*60px"
-    ],
-    [
-      "description",
-      "Tip for uploading images"
-    ]
-  ],
-  "message.editQRTip": [
-    [
-      "message",
-      "Recommended Size: 200*200px"
-    ],
-    [
-      "description",
-      "Tip for uploading images"
-    ]
-  ],
-  "message.editFaviconTip": [
-    [
-      "message",
-      "Recommended Size: 32*32px"
-    ],
-    [
-      "description",
-      "Tip for uploading images"
-    ]
-  ],
-  "message.editUrl": [
-    [
-      "message",
-      "Enter Link"
-    ],
-    [
-      "description",
-      "Prompt to enter a link"
-    ]
-  ],
-  "message.atLeastOneAdmin": [
-    [
-      "message",
-      "At Least One Admin Must Remain"
-    ],
-    [
-      "description",
-      "Notification to keep at least one admin"
-    ]
-  ],
-  "message.distributionDefaultInviterIdTip": [
-    [
-      "message",
-      "User ID of the default inviter. If the distribution link does not carry the inviter_id parameter, this user ID will be used as the inviter by default."
-    ],
-    [
-      "description",
-      "Tip for default inviter ID"
-    ]
-  ],
-  "message.distributionForceInviterIdTip": [
-    [
-      "message",
-      "User ID of the forced inviter. If this ID is set, it will be used as the inviter regardless of whether the distribution link carries the inviter_id parameter."
-    ],
-    [
-      "description",
-      "Tip for forced inviter ID"
-    ]
-  ],
-  "message.originTip": [
-    [
-      "message",
-      "Site domain, site configuration is bound to the domain, and the site domain cannot be changed."
-    ],
-    [
-      "description",
-      "Tip for site domain"
-    ]
-  ],
-  "message.titleTip": [
-    [
-      "message",
-      "Site title, displayed in the browser tab."
-    ],
-    [
-      "description",
-      "Tip for site title"
-    ]
-  ],
-  "message.descriptionTip": [
-    [
-      "message",
-      "Site description, located in the site metadata, used for site SEO optimization."
-    ],
-    [
-      "description",
-      "Tip for site description"
-    ]
-  ],
-  "message.logoTip": [
-    [
-      "message",
-      "Site Logo, displayed at the top of the site menu when the menu bar is expanded."
-    ],
-    [
-      "description",
-      "Tip for site logo"
-    ]
-  ],
-  "message.faviconTip": [
-    [
-      "message",
-      "Site Favicon, displayed in the browser tab."
-    ],
-    [
-      "description",
-      "Tip for site favicon"
-    ]
-  ],
-  "message.adminsTip": [
-    [
-      "message",
-      "Site admin IDs. By default, the user who first creates the site will become an admin. Only site admins can manage the site."
-    ],
-    [
-      "description",
-      "Tip for site admins"
-    ]
-  ],
-  "message.adminsTip2": [
-    [
-      "message",
-      "You can add or remove admin IDs here. You can view user IDs at https://auth.acedata.cloud"
-    ],
-    [
-      "description",
-      "Tip for site admins"
-    ]
-  ],
-  "message.keywordsTip": [
-    [
-      "message",
-      "Site keywords, located in the site metadata, used for site SEO optimization."
-    ],
-    [
-      "description",
-      "Tip for site keywords"
-    ]
-  ],
-  "message.keywordsTip2": [
-    [
-      "message",
-      "You can add or remove site keywords here. The more precise the keywords, the more beneficial for SEO optimization."
-    ],
-    [
-      "description",
-      "Tip for site keywords"
-    ]
-  ],
-  "message.featuresChat": [
-    [
-      "message",
-      "Enable or Disable Chat Feature Module."
-    ],
-    [
-      "description",
-      "Description of the Chat feature"
-    ]
-  ],
-  "message.featuresGrok": [
-    [
-      "message",
-      "Enable or Disable Grok Feature Module."
-    ],
-    [
-      "description",
-      "Description of the Grok feature"
-    ]
-  ],
-  "message.featuresDeepseek": [
-    [
-      "message",
-      "Enable or Disable Deepseek Feature Module."
-    ],
-    [
-      "description",
-      "Description of the Deepseek feature"
-    ]
-  ],
-  "message.featuresChatgpt": [
-    [
-      "message",
-      "Enable or Disable ChatGPT Feature Module."
-    ],
-    [
-      "description",
-      "Description of the ChatGPT feature"
-    ]
-  ],
-  "message.featuresMidjourney": [
-    [
-      "message",
-      "Enable or Disable Midjourney Feature Module."
-    ],
-    [
-      "description",
-      "Description of the Midjourney feature"
-    ]
-  ],
-  "message.featuresChatdoc": [
-    [
-      "message",
-      "Enable or Disable Chatdoc Feature Module."
-    ],
-    [
-      "description",
-      "Description of the Chatdoc feature"
-    ]
-  ],
-  "message.featuresQrart": [
-    [
-      "message",
-      "Enable or Disable Qrart Feature Module."
-    ],
-    [
-      "description",
-      "Description of the Qrart feature"
-    ]
-  ],
-  "message.featuresVeo": [
-    [
-      "message",
-      "Enable or Disable Veo Feature Module."
-    ],
-    [
-      "description",
-      "Description of the Veo feature"
-    ]
-  ],
-  "message.featuresSora": [
-    [
-      "message",
-      "Enable or Disable Sora Feature Module."
-    ],
-    [
-      "description",
-      "Description of the Sora feature"
-    ]
-  ],
-  "message.featuresSuno": [
-    [
-      "message",
-      "Enable or Disable Suno Feature Module."
-    ],
-    [
-      "description",
-      "Description of the Suno feature"
-    ]
-  ],
-  "message.featuresPixverse": [
-    [
-      "message",
-      "Toggle Pixverse feature module."
-    ],
-    [
-      "description",
-      "Description of the Pixverse feature"
-    ]
-  ],
-  "message.featuresFlux": [
-    [
-      "message",
-      "Toggle FLux feature module."
-    ],
-    [
-      "description",
-      "Description of the FLux feature"
-    ]
-  ],
-  "message.featuresNanobanana": [
-    [
-      "message",
-      "Toggle Nano Banana feature module."
-    ],
-    [
-      "description",
-      "Description of the Nano Banana feature"
-    ]
-  ],
+  "field.featuresSeedream": {
+    "message": "SeeDream",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresSeedance": {
+    "message": "SeeDance",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresWan": {
+    "message": "Wan",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresProducer": {
+    "message": "Producer",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresKimi": {
+    "message": "Kimi",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresSerp": {
+    "message": "SERP",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresSupport": {
+    "message": "Customer Support",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresI18n": {
+    "message": "Multilingual Support",
+    "description": "Displayed as the title in the editing box"
+  },
+  "title.basicConfig": {
+    "message": "Basic Configuration",
+    "description": "Displayed as the title in the editing box"
+  },
+  "title.seoConfig": {
+    "message": "SEO Configuration",
+    "description": "Displayed as the title in the editing box"
+  },
+  "title.editAdmins": {
+    "message": "Edit Admins",
+    "description": "Displayed as the title in the editing box"
+  },
+  "title.featuresConfig": {
+    "message": "Features Configuration",
+    "description": "Displayed as the title in the editing box"
+  },
+  "title.editTitle": {
+    "message": "Edit Title",
+    "description": "Displayed as the title in the editing box"
+  },
+  "title.editOrigin": {
+    "message": "Edit Domain",
+    "description": "Displayed as the title in the editing box"
+  },
+  "title.editKeywords": {
+    "message": "Edit Keywords",
+    "description": "Displayed as the title in the editing box"
+  },
+  "title.editLogo": {
+    "message": "Edit Logo",
+    "description": "Displayed as the title in the editing box"
+  },
+  "title.editFavicon": {
+    "message": "Edit Favicon",
+    "description": "Displayed as the title in the editing box"
+  },
+  "title.editDescription": {
+    "message": "Edit Description",
+    "description": "Displayed as the title in the editing box"
+  },
+  "title.distributionConfig": {
+    "message": "Distribution Configuration",
+    "description": "Displayed as the title in the editing box"
+  },
+  "title.editDistributionDefaultInviterId": {
+    "message": "Edit Default Inviter",
+    "description": "Displayed as the title in the editing box"
+  },
+  "title.editDistributionForceInviterId": {
+    "message": "Edit Forced Inviter",
+    "description": "Displayed as the title in the editing box"
+  },
+  "title.editQR": {
+    "message": "Edit QR Code",
+    "description": "Title displayed in the editing box"
+  },
+  "title.editUrl": {
+    "message": "Edit Link",
+    "description": "Title displayed in the editing box"
+  },
+  "placeholder.title": {
+    "message": "Enter Site Title",
+    "description": "Placeholder text in the editing box"
+  },
+  "placeholder.origin": {
+    "message": "Enter Site Domain",
+    "description": "Placeholder text in the editing box"
+  },
+  "placeholder.editUrl": {
+    "message": "Enter Link",
+    "description": "Placeholder text in the editing box"
+  },
+  "placeholder.description": {
+    "message": "Enter Site Description",
+    "description": "Placeholder text in the editing box"
+  },
+  "placeholder.keywords": {
+    "message": "Enter Site Keywords",
+    "description": "Placeholder text in the editing box"
+  },
+  "placeholder.editDistributionDefaultInviterId": {
+    "message": "Enter Default Inviter ID",
+    "description": "Placeholder text in the editing box"
+  },
+  "placeholder.editDistributionForceInviterId": {
+    "message": "Enter Forced Inviter ID",
+    "description": "Placeholder text in the editing box"
+  },
+  "message.uploadImageExceed": {
+    "message": "Image Upload Exceeds Limit",
+    "description": "Notification for exceeding image upload limit"
+  },
+  "message.uploadImageError": {
+    "message": "Image Upload Error",
+    "description": "Notification for image upload error"
+  },
+  "message.editLogoTip": {
+    "message": "Recommended Size: 200*60px",
+    "description": "Tip for uploading images"
+  },
+  "message.editQRTip": {
+    "message": "Recommended Size: 200*200px",
+    "description": "Tip for uploading images"
+  },
+  "message.editFaviconTip": {
+    "message": "Recommended Size: 32*32px",
+    "description": "Tip for uploading images"
+  },
+  "message.editUrl": {
+    "message": "Enter Link",
+    "description": "Prompt to enter a link"
+  },
+  "message.atLeastOneAdmin": {
+    "message": "At Least One Admin Must Remain",
+    "description": "Notification to keep at least one admin"
+  },
+  "message.distributionDefaultInviterIdTip": {
+    "message": "User ID of the default inviter. If the distribution link does not carry the inviter_id parameter, this user ID will be used as the inviter by default.",
+    "description": "Tip for default inviter ID"
+  },
+  "message.distributionForceInviterIdTip": {
+    "message": "User ID of the forced inviter. If this ID is set, it will be used as the inviter regardless of whether the distribution link carries the inviter_id parameter.",
+    "description": "Tip for forced inviter ID"
+  },
+  "message.originTip": {
+    "message": "Site domain, site configuration is bound to the domain, and the site domain cannot be changed.",
+    "description": "Tip for site domain"
+  },
+  "message.titleTip": {
+    "message": "Site title, displayed in the browser tab.",
+    "description": "Tip for site title"
+  },
+  "message.descriptionTip": {
+    "message": "Site description, located in the site metadata, used for site SEO optimization.",
+    "description": "Tip for site description"
+  },
+  "message.logoTip": {
+    "message": "Site Logo, displayed at the top of the site menu when the menu bar is expanded.",
+    "description": "Tip for site logo"
+  },
+  "message.faviconTip": {
+    "message": "Site Favicon, displayed in the browser tab.",
+    "description": "Tip for site favicon"
+  },
+  "message.adminsTip": {
+    "message": "Site admin IDs. By default, the user who first creates the site will become an admin. Only site admins can manage the site.",
+    "description": "Tip for site admins"
+  },
+  "message.adminsTip2": {
+    "message": "You can add or remove admin IDs here. You can view user IDs at https://auth.acedata.cloud",
+    "description": "Tip for site admins"
+  },
+  "message.keywordsTip": {
+    "message": "Site keywords, located in the site metadata, used for site SEO optimization.",
+    "description": "Tip for site keywords"
+  },
+  "message.keywordsTip2": {
+    "message": "You can add or remove site keywords here. The more precise the keywords, the more beneficial for SEO optimization.",
+    "description": "Tip for site keywords"
+  },
+  "message.featuresChat": {
+    "message": "Enable or Disable Chat Feature Module.",
+    "description": "Description of the Chat feature"
+  },
+  "message.featuresGrok": {
+    "message": "Enable or Disable Grok Feature Module.",
+    "description": "Description of the Grok feature"
+  },
+  "message.featuresDeepseek": {
+    "message": "Enable or Disable Deepseek Feature Module.",
+    "description": "Description of the Deepseek feature"
+  },
+  "message.featuresChatgpt": {
+    "message": "Enable or Disable ChatGPT Feature Module.",
+    "description": "Description of the ChatGPT feature"
+  },
+  "message.featuresMidjourney": {
+    "message": "Enable or Disable Midjourney Feature Module.",
+    "description": "Description of the Midjourney feature"
+  },
+  "message.featuresChatdoc": {
+    "message": "Enable or Disable Chatdoc Feature Module.",
+    "description": "Description of the Chatdoc feature"
+  },
+  "message.featuresQrart": {
+    "message": "Enable or Disable Qrart Feature Module.",
+    "description": "Description of the Qrart feature"
+  },
+  "message.featuresVeo": {
+    "message": "Enable or Disable Veo Feature Module.",
+    "description": "Description of the Veo feature"
+  },
+  "message.featuresSora": {
+    "message": "Enable or Disable Sora Feature Module.",
+    "description": "Description of the Sora feature"
+  },
+  "message.featuresSuno": {
+    "message": "Enable or Disable Suno Feature Module.",
+    "description": "Description of the Suno feature"
+  },
+  "message.featuresPixverse": {
+    "message": "Toggle Pixverse feature module.",
+    "description": "Description of the Pixverse feature"
+  },
+  "message.featuresFlux": {
+    "message": "Toggle FLux feature module.",
+    "description": "Description of the FLux feature"
+  },
+  "message.featuresNanobanana": {
+    "message": "Toggle Nano Banana feature module.",
+    "description": "Description of the Nano Banana feature"
+  },
   "message.featuresOpenaiimage": {
     "message": "Toggle OpenAI Image feature module.",
     "description": "Description of the OpenAI Image feature"
   },
-  "message.featuresSeedream": [
-    [
-      "message",
-      "Toggle SeeDream feature module."
-    ],
-    [
-      "description",
-      "Description of the SeeDream feature"
-    ]
-  ],
-  "message.featuresSeedance": [
-    [
-      "message",
-      "Enable or disable SeeDance feature module."
-    ],
-    [
-      "description",
-      "Description of the SeeDance feature"
-    ]
-  ],
-  "message.featuresWan": [
-    [
-      "message",
-      "Toggle Wan feature module."
-    ],
-    [
-      "description",
-      "Description of the Wan feature"
-    ]
-  ],
-  "message.featuresProducer": [
-    [
-      "message",
-      "Toggle Producer feature module."
-    ],
-    [
-      "description",
-      "Description of the Producer feature"
-    ]
-  ],
-  "message.featuresKimi": [
-    [
-      "message",
-      "Toggle Kimi feature module."
-    ],
-    [
-      "description",
-      "Description of the Kimi feature"
-    ]
-  ],
-  "message.featuresSerp": [
-    [
-      "message",
-      "Toggle SERP feature module."
-    ],
-    [
-      "description",
-      "Description of the SERP feature"
-    ]
-  ],
-  "message.featuresLuma": [
-    [
-      "message",
-      "Toggle Luma feature module."
-    ],
-    [
-      "description",
-      "Description of the Luma feature"
-    ]
-  ],
-  "message.featuresPika": [
-    [
-      "message",
-      "Toggle Pika feature module."
-    ],
-    [
-      "description",
-      "Description of the Pika feature"
-    ]
-  ],
-  "message.featuresKling": [
-    [
-      "message",
-      "Toggle Kling feature module."
-    ],
-    [
-      "description",
-      "Description of the Kling feature"
-    ]
-  ],
-  "message.featuresHailuo": [
-    [
-      "message",
-      "Toggle Hailuo feature module."
-    ],
-    [
-      "description",
-      "Description of the Hailuo feature"
-    ]
-  ],
-  "message.featuresHeadshots": [
-    [
-      "message",
-      "Toggle AI ID Photo feature module."
-    ],
-    [
-      "description",
-      "Description of the AI ID Photo feature"
-    ]
-  ],
-  "message.featuresSupport": [
-    [
-      "message",
-      "Toggle customer support"
-    ],
-    [
-      "description",
-      "Description of the Support feature"
-    ]
-  ],
-  "message.featuresI18n": [
-    [
-      "message",
-      "Toggle multilingual support; when disabled, users can only use the default language."
-    ],
-    [
-      "description",
-      "Description of multilingual support"
-    ]
-  ],
-  "button.upload": [
-    [
-      "message",
-      "Upload"
-    ],
-    [
-      "description",
-      "Upload"
-    ]
-  ],
-  "button.enabled": [
-    [
-      "message",
-      "Enabled"
-    ],
-    [
-      "description",
-      "Toggle text indicating it is enabled"
-    ]
-  ],
-  "button.disabled": [
-    [
-      "message",
-      "Disabled"
-    ],
-    [
-      "description",
-      "Toggle text indicating it is disabled"
-    ]
-  ],
-  "field.featuresGemini": [
-    [
-      "message",
-      "Gemini"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "message.featuresGemini": [
-    [
-      "message",
-      "Enable or disable the Gemini feature module."
-    ],
-    [
-      "description",
-      "Description of the Gemini feature"
-    ]
-  ],
-  "field.featuresClaude": [
-    [
-      "message",
-      "Claude"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "message.featuresClaude": [
-    [
-      "message",
-      "Enable or disable the Claude feature module."
-    ],
-    [
-      "description",
-      "Description of the Claude feature"
-    ]
-  ]
+  "message.featuresSeedream": {
+    "message": "Toggle SeeDream feature module.",
+    "description": "Description of the SeeDream feature"
+  },
+  "message.featuresSeedance": {
+    "message": "Enable or disable SeeDance feature module.",
+    "description": "Description of the SeeDance feature"
+  },
+  "message.featuresWan": {
+    "message": "Toggle Wan feature module.",
+    "description": "Description of the Wan feature"
+  },
+  "message.featuresProducer": {
+    "message": "Toggle Producer feature module.",
+    "description": "Description of the Producer feature"
+  },
+  "message.featuresKimi": {
+    "message": "Toggle Kimi feature module.",
+    "description": "Description of the Kimi feature"
+  },
+  "message.featuresSerp": {
+    "message": "Toggle SERP feature module.",
+    "description": "Description of the SERP feature"
+  },
+  "message.featuresLuma": {
+    "message": "Toggle Luma feature module.",
+    "description": "Description of the Luma feature"
+  },
+  "message.featuresPika": {
+    "message": "Toggle Pika feature module.",
+    "description": "Description of the Pika feature"
+  },
+  "message.featuresKling": {
+    "message": "Toggle Kling feature module.",
+    "description": "Description of the Kling feature"
+  },
+  "message.featuresHailuo": {
+    "message": "Toggle Hailuo feature module.",
+    "description": "Description of the Hailuo feature"
+  },
+  "message.featuresHeadshots": {
+    "message": "Toggle AI ID Photo feature module.",
+    "description": "Description of the AI ID Photo feature"
+  },
+  "message.featuresSupport": {
+    "message": "Toggle customer support",
+    "description": "Description of the Support feature"
+  },
+  "message.featuresI18n": {
+    "message": "Toggle multilingual support; when disabled, users can only use the default language.",
+    "description": "Description of multilingual support"
+  },
+  "button.upload": {
+    "message": "Upload",
+    "description": "Upload"
+  },
+  "button.enabled": {
+    "message": "Enabled",
+    "description": "Toggle text indicating it is enabled"
+  },
+  "button.disabled": {
+    "message": "Disabled",
+    "description": "Toggle text indicating it is disabled"
+  },
+  "field.featuresGemini": {
+    "message": "Gemini",
+    "description": "Displayed as the title in the editing box"
+  },
+  "message.featuresGemini": {
+    "message": "Enable or disable the Gemini feature module.",
+    "description": "Description of the Gemini feature"
+  },
+  "field.featuresClaude": {
+    "message": "Claude",
+    "description": "Displayed as the title in the editing box"
+  },
+  "message.featuresClaude": {
+    "message": "Enable or disable the Claude feature module.",
+    "description": "Description of the Claude feature"
+  }
 }

--- a/src/i18n/en/site.json
+++ b/src/i18n/en/site.json
@@ -1,442 +1,1110 @@
 {
-  "field.title": {
-    "message": "Site Title",
+  "field.title": [
+    [
+      "message",
+      "Site Title"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "field.origin": [
+    [
+      "message",
+      "Site Domain"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "field.description": [
+    [
+      "message",
+      "Site Description"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "field.keywords": [
+    [
+      "message",
+      "Site Keywords"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "field.logo": [
+    [
+      "message",
+      "Site Logo"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "field.favicon": [
+    [
+      "message",
+      "Site Favicon"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "field.qr": [
+    [
+      "message",
+      "QR Code"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "field.url": [
+    [
+      "message",
+      "Link"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "field.admins": [
+    [
+      "message",
+      "Site Admin IDs"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "field.distributionDefaultInviterId": [
+    [
+      "message",
+      "Default Inviter ID"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "field.distributionForceInviterId": [
+    [
+      "message",
+      "Forced Inviter ID"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "field.featuresChat": [
+    [
+      "message",
+      "Chat"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "field.featuresVeo": [
+    [
+      "message",
+      "Veo"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "field.featuresSora": [
+    [
+      "message",
+      "Sora"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "field.featuresGrok": [
+    [
+      "message",
+      "Grok"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "field.featuresDeepseek": [
+    [
+      "message",
+      "Deepseek"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "field.featuresChatgpt": [
+    [
+      "message",
+      "ChatGPT"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "field.featuresMidjourney": [
+    [
+      "message",
+      "Midjourney"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "field.featuresChatdoc": [
+    [
+      "message",
+      "Chatdoc"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "field.featuresQrart": [
+    [
+      "message",
+      "Qrart"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "field.featuresLuma": [
+    [
+      "message",
+      "Luma"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "field.featuresPixverse": [
+    [
+      "message",
+      "Pixverse"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "field.featuresPika": [
+    [
+      "message",
+      "Pika"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "field.featuresKling": [
+    [
+      "message",
+      "Kling"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "field.featuresHailuo": [
+    [
+      "message",
+      "Hailuo"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "field.featuresHeadshots": [
+    [
+      "message",
+      "AI ID Photo"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "field.featuresSuno": [
+    [
+      "message",
+      "Suno"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "field.featuresFlux": [
+    [
+      "message",
+      "Flux"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "field.featuresNanobanana": [
+    [
+      "message",
+      "Nano Banana"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "field.featuresOpenaiimage": {
+    "message": "OpenAI Image",
     "description": "Displayed as the title in the editing box"
   },
-  "field.origin": {
-    "message": "Site Domain",
-    "description": "Displayed as the title in the editing box"
-  },
-  "field.description": {
-    "message": "Site Description",
-    "description": "Displayed as the title in the editing box"
-  },
-  "field.keywords": {
-    "message": "Site Keywords",
-    "description": "Displayed as the title in the editing box"
-  },
-  "field.logo": {
-    "message": "Site Logo",
-    "description": "Displayed as the title in the editing box"
-  },
-  "field.favicon": {
-    "message": "Site Favicon",
-    "description": "Displayed as the title in the editing box"
-  },
-  "field.qr": {
-    "message": "QR Code",
-    "description": "Displayed as the title in the editing box"
-  },
-  "field.url": {
-    "message": "Link",
-    "description": "Displayed as the title in the editing box"
-  },
-  "field.admins": {
-    "message": "Site Admin IDs",
-    "description": "Displayed as the title in the editing box"
-  },
-  "field.distributionDefaultInviterId": {
-    "message": "Default Inviter ID",
-    "description": "Displayed as the title in the editing box"
-  },
-  "field.distributionForceInviterId": {
-    "message": "Forced Inviter ID",
-    "description": "Displayed as the title in the editing box"
-  },
-  "field.featuresChat": {
-    "message": "Chat",
-    "description": "Displayed as the title in the editing box"
-  },
-  "field.featuresVeo": {
-    "message": "Veo",
-    "description": "Displayed as the title in the editing box"
-  },
-  "field.featuresSora": {
-    "message": "Sora",
-    "description": "Displayed as the title in the editing box"
-  },
-  "field.featuresGrok": {
-    "message": "Grok",
-    "description": "Displayed as the title in the editing box"
-  },
-  "field.featuresDeepseek": {
-    "message": "Deepseek",
-    "description": "Displayed as the title in the editing box"
-  },
-  "field.featuresChatgpt": {
-    "message": "ChatGPT",
-    "description": "Displayed as the title in the editing box"
-  },
-  "field.featuresMidjourney": {
-    "message": "Midjourney",
-    "description": "Displayed as the title in the editing box"
-  },
-  "field.featuresChatdoc": {
-    "message": "Chatdoc",
-    "description": "Displayed as the title in the editing box"
-  },
-  "field.featuresQrart": {
-    "message": "Qrart",
-    "description": "Displayed as the title in the editing box"
-  },
-  "field.featuresLuma": {
-    "message": "Luma",
-    "description": "Displayed as the title in the editing box"
-  },
-  "field.featuresPixverse": {
-    "message": "Pixverse",
-    "description": "Displayed as the title in the editing box"
-  },
-  "field.featuresPika": {
-    "message": "Pika",
-    "description": "Displayed as the title in the editing box"
-  },
-  "field.featuresKling": {
-    "message": "Kling",
-    "description": "Displayed as the title in the editing box"
-  },
-  "field.featuresHailuo": {
-    "message": "Hailuo",
-    "description": "Displayed as the title in the editing box"
-  },
-  "field.featuresHeadshots": {
-    "message": "AI ID Photo",
-    "description": "Displayed as the title in the editing box"
-  },
-  "field.featuresSuno": {
-    "message": "Suno",
-    "description": "Displayed as the title in the editing box"
-  },
-  "field.featuresFlux": {
-    "message": "Flux",
-    "description": "Displayed as the title in the editing box"
-  },
-  "field.featuresNanobanana": {
-    "message": "Nano Banana",
-    "description": "Displayed as the title in the editing box"
-  },
-  "field.featuresSeedream": {
-    "message": "SeeDream",
-    "description": "Displayed as the title in the editing box"
-  },
-  "field.featuresSeedance": {
-    "message": "SeeDance",
-    "description": "Displayed as the title in the editing box"
-  },
-  "field.featuresWan": {
-    "message": "Wan",
-    "description": "Displayed as the title in the editing box"
-  },
-  "field.featuresProducer": {
-    "message": "Producer",
-    "description": "Displayed as the title in the editing box"
-  },
-  "field.featuresKimi": {
-    "message": "Kimi",
-    "description": "Displayed as the title in the editing box"
-  },
-  "field.featuresSerp": {
-    "message": "SERP",
-    "description": "Displayed as the title in the editing box"
-  },
-  "field.featuresSupport": {
-    "message": "Customer Support",
-    "description": "Displayed as the title in the editing box"
-  },
-  "field.featuresI18n": {
-    "message": "Multilingual Support",
-    "description": "Displayed as the title in the editing box"
-  },
-  "title.basicConfig": {
-    "message": "Basic Configuration",
-    "description": "Displayed as the title in the editing box"
-  },
-  "title.seoConfig": {
-    "message": "SEO Configuration",
-    "description": "Displayed as the title in the editing box"
-  },
-  "title.editAdmins": {
-    "message": "Edit Admins",
-    "description": "Displayed as the title in the editing box"
-  },
-  "title.featuresConfig": {
-    "message": "Features Configuration",
-    "description": "Displayed as the title in the editing box"
-  },
-  "title.editTitle": {
-    "message": "Edit Title",
-    "description": "Displayed as the title in the editing box"
-  },
-  "title.editOrigin": {
-    "message": "Edit Domain",
-    "description": "Displayed as the title in the editing box"
-  },
-  "title.editKeywords": {
-    "message": "Edit Keywords",
-    "description": "Displayed as the title in the editing box"
-  },
-  "title.editLogo": {
-    "message": "Edit Logo",
-    "description": "Displayed as the title in the editing box"
-  },
-  "title.editFavicon": {
-    "message": "Edit Favicon",
-    "description": "Displayed as the title in the editing box"
-  },
-  "title.editDescription": {
-    "message": "Edit Description",
-    "description": "Displayed as the title in the editing box"
-  },
-  "title.distributionConfig": {
-    "message": "Distribution Configuration",
-    "description": "Displayed as the title in the editing box"
-  },
-  "title.editDistributionDefaultInviterId": {
-    "message": "Edit Default Inviter",
-    "description": "Displayed as the title in the editing box"
-  },
-  "title.editDistributionForceInviterId": {
-    "message": "Edit Forced Inviter",
-    "description": "Displayed as the title in the editing box"
-  },
-  "title.editQR": {
-    "message": "Edit QR Code",
-    "description": "Title displayed in the editing box"
-  },
-  "title.editUrl": {
-    "message": "Edit Link",
-    "description": "Title displayed in the editing box"
-  },
-  "placeholder.title": {
-    "message": "Enter Site Title",
-    "description": "Placeholder text in the editing box"
-  },
-  "placeholder.origin": {
-    "message": "Enter Site Domain",
-    "description": "Placeholder text in the editing box"
-  },
-  "placeholder.editUrl": {
-    "message": "Enter Link",
-    "description": "Placeholder text in the editing box"
-  },
-  "placeholder.description": {
-    "message": "Enter Site Description",
-    "description": "Placeholder text in the editing box"
-  },
-  "placeholder.keywords": {
-    "message": "Enter Site Keywords",
-    "description": "Placeholder text in the editing box"
-  },
-  "placeholder.editDistributionDefaultInviterId": {
-    "message": "Enter Default Inviter ID",
-    "description": "Placeholder text in the editing box"
-  },
-  "placeholder.editDistributionForceInviterId": {
-    "message": "Enter Forced Inviter ID",
-    "description": "Placeholder text in the editing box"
-  },
-  "message.uploadImageExceed": {
-    "message": "Image Upload Exceeds Limit",
-    "description": "Notification for exceeding image upload limit"
-  },
-  "message.uploadImageError": {
-    "message": "Image Upload Error",
-    "description": "Notification for image upload error"
-  },
-  "message.editLogoTip": {
-    "message": "Recommended Size: 200*60px",
-    "description": "Tip for uploading images"
-  },
-  "message.editQRTip": {
-    "message": "Recommended Size: 200*200px",
-    "description": "Tip for uploading images"
-  },
-  "message.editFaviconTip": {
-    "message": "Recommended Size: 32*32px",
-    "description": "Tip for uploading images"
-  },
-  "message.editUrl": {
-    "message": "Enter Link",
-    "description": "Prompt to enter a link"
-  },
-  "message.atLeastOneAdmin": {
-    "message": "At Least One Admin Must Remain",
-    "description": "Notification to keep at least one admin"
-  },
-  "message.distributionDefaultInviterIdTip": {
-    "message": "User ID of the default inviter. If the distribution link does not carry the inviter_id parameter, this user ID will be used as the inviter by default.",
-    "description": "Tip for default inviter ID"
-  },
-  "message.distributionForceInviterIdTip": {
-    "message": "User ID of the forced inviter. If this ID is set, it will be used as the inviter regardless of whether the distribution link carries the inviter_id parameter.",
-    "description": "Tip for forced inviter ID"
-  },
-  "message.originTip": {
-    "message": "Site domain, site configuration is bound to the domain, and the site domain cannot be changed.",
-    "description": "Tip for site domain"
-  },
-  "message.titleTip": {
-    "message": "Site title, displayed in the browser tab.",
-    "description": "Tip for site title"
-  },
-  "message.descriptionTip": {
-    "message": "Site description, located in the site metadata, used for site SEO optimization.",
-    "description": "Tip for site description"
-  },
-  "message.logoTip": {
-    "message": "Site Logo, displayed at the top of the site menu when the menu bar is expanded.",
-    "description": "Tip for site logo"
-  },
-  "message.faviconTip": {
-    "message": "Site Favicon, displayed in the browser tab.",
-    "description": "Tip for site favicon"
-  },
-  "message.adminsTip": {
-    "message": "Site admin IDs. By default, the user who first creates the site will become an admin. Only site admins can manage the site.",
-    "description": "Tip for site admins"
-  },
-  "message.adminsTip2": {
-    "message": "You can add or remove admin IDs here. You can view user IDs at https://auth.acedata.cloud",
-    "description": "Tip for site admins"
-  },
-  "message.keywordsTip": {
-    "message": "Site keywords, located in the site metadata, used for site SEO optimization.",
-    "description": "Tip for site keywords"
-  },
-  "message.keywordsTip2": {
-    "message": "You can add or remove site keywords here. The more precise the keywords, the more beneficial for SEO optimization.",
-    "description": "Tip for site keywords"
-  },
-  "message.featuresChat": {
-    "message": "Enable or Disable Chat Feature Module.",
-    "description": "Description of the Chat feature"
-  },
-  "message.featuresGrok": {
-    "message": "Enable or Disable Grok Feature Module.",
-    "description": "Description of the Grok feature"
-  },
-  "message.featuresDeepseek": {
-    "message": "Enable or Disable Deepseek Feature Module.",
-    "description": "Description of the Deepseek feature"
-  },
-  "message.featuresChatgpt": {
-    "message": "Enable or Disable ChatGPT Feature Module.",
-    "description": "Description of the ChatGPT feature"
-  },
-  "message.featuresMidjourney": {
-    "message": "Enable or Disable Midjourney Feature Module.",
-    "description": "Description of the Midjourney feature"
-  },
-  "message.featuresChatdoc": {
-    "message": "Enable or Disable Chatdoc Feature Module.",
-    "description": "Description of the Chatdoc feature"
-  },
-  "message.featuresQrart": {
-    "message": "Enable or Disable Qrart Feature Module.",
-    "description": "Description of the Qrart feature"
-  },
-  "message.featuresVeo": {
-    "message": "Enable or Disable Veo Feature Module.",
-    "description": "Description of the Veo feature"
-  },
-  "message.featuresSora": {
-    "message": "Enable or Disable Sora Feature Module.",
-    "description": "Description of the Sora feature"
-  },
-  "message.featuresSuno": {
-    "message": "Enable or Disable Suno Feature Module.",
-    "description": "Description of the Suno feature"
-  },
-  "message.featuresPixverse": {
-    "message": "Toggle Pixverse feature module.",
-    "description": "Description of the Pixverse feature"
-  },
-  "message.featuresFlux": {
-    "message": "Toggle FLux feature module.",
-    "description": "Description of the FLux feature"
-  },
-  "message.featuresNanobanana": {
-    "message": "Toggle Nano Banana feature module.",
-    "description": "Description of the Nano Banana feature"
-  },
-  "message.featuresSeedream": {
-    "message": "Toggle SeeDream feature module.",
-    "description": "Description of the SeeDream feature"
-  },
-  "message.featuresSeedance": {
-    "message": "Enable or disable SeeDance feature module.",
-    "description": "Description of the SeeDance feature"
-  },
-  "message.featuresWan": {
-    "message": "Toggle Wan feature module.",
-    "description": "Description of the Wan feature"
-  },
-  "message.featuresProducer": {
-    "message": "Toggle Producer feature module.",
-    "description": "Description of the Producer feature"
-  },
-  "message.featuresKimi": {
-    "message": "Toggle Kimi feature module.",
-    "description": "Description of the Kimi feature"
-  },
-  "message.featuresSerp": {
-    "message": "Toggle SERP feature module.",
-    "description": "Description of the SERP feature"
-  },
-  "message.featuresLuma": {
-    "message": "Toggle Luma feature module.",
-    "description": "Description of the Luma feature"
-  },
-  "message.featuresPika": {
-    "message": "Toggle Pika feature module.",
-    "description": "Description of the Pika feature"
-  },
-  "message.featuresKling": {
-    "message": "Toggle Kling feature module.",
-    "description": "Description of the Kling feature"
-  },
-  "message.featuresHailuo": {
-    "message": "Toggle Hailuo feature module.",
-    "description": "Description of the Hailuo feature"
-  },
-  "message.featuresHeadshots": {
-    "message": "Toggle AI ID Photo feature module.",
-    "description": "Description of the AI ID Photo feature"
-  },
-  "message.featuresSupport": {
-    "message": "Toggle customer support",
-    "description": "Description of the Support feature"
-  },
-  "message.featuresI18n": {
-    "message": "Toggle multilingual support; when disabled, users can only use the default language.",
-    "description": "Description of multilingual support"
-  },
-  "button.upload": {
-    "message": "Upload",
-    "description": "Upload"
-  },
-  "button.enabled": {
-    "message": "Enabled",
-    "description": "Toggle text indicating it is enabled"
-  },
-  "button.disabled": {
-    "message": "Disabled",
-    "description": "Toggle text indicating it is disabled"
-  },
-  "field.featuresGemini": {
-    "message": "Gemini",
-    "description": "Displayed as the title in the editing box"
-  },
-  "message.featuresGemini": {
-    "message": "Enable or disable the Gemini feature module.",
-    "description": "Description of the Gemini feature"
-  },
-  "field.featuresClaude": {
-    "message": "Claude",
-    "description": "Displayed as the title in the editing box"
-  },
-  "message.featuresClaude": {
-    "message": "Enable or disable the Claude feature module.",
-    "description": "Description of the Claude feature"
-  }
+  "field.featuresSeedream": [
+    [
+      "message",
+      "SeeDream"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "field.featuresSeedance": [
+    [
+      "message",
+      "SeeDance"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "field.featuresWan": [
+    [
+      "message",
+      "Wan"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "field.featuresProducer": [
+    [
+      "message",
+      "Producer"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "field.featuresKimi": [
+    [
+      "message",
+      "Kimi"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "field.featuresSerp": [
+    [
+      "message",
+      "SERP"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "field.featuresSupport": [
+    [
+      "message",
+      "Customer Support"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "field.featuresI18n": [
+    [
+      "message",
+      "Multilingual Support"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "title.basicConfig": [
+    [
+      "message",
+      "Basic Configuration"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "title.seoConfig": [
+    [
+      "message",
+      "SEO Configuration"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "title.editAdmins": [
+    [
+      "message",
+      "Edit Admins"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "title.featuresConfig": [
+    [
+      "message",
+      "Features Configuration"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "title.editTitle": [
+    [
+      "message",
+      "Edit Title"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "title.editOrigin": [
+    [
+      "message",
+      "Edit Domain"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "title.editKeywords": [
+    [
+      "message",
+      "Edit Keywords"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "title.editLogo": [
+    [
+      "message",
+      "Edit Logo"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "title.editFavicon": [
+    [
+      "message",
+      "Edit Favicon"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "title.editDescription": [
+    [
+      "message",
+      "Edit Description"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "title.distributionConfig": [
+    [
+      "message",
+      "Distribution Configuration"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "title.editDistributionDefaultInviterId": [
+    [
+      "message",
+      "Edit Default Inviter"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "title.editDistributionForceInviterId": [
+    [
+      "message",
+      "Edit Forced Inviter"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "title.editQR": [
+    [
+      "message",
+      "Edit QR Code"
+    ],
+    [
+      "description",
+      "Title displayed in the editing box"
+    ]
+  ],
+  "title.editUrl": [
+    [
+      "message",
+      "Edit Link"
+    ],
+    [
+      "description",
+      "Title displayed in the editing box"
+    ]
+  ],
+  "placeholder.title": [
+    [
+      "message",
+      "Enter Site Title"
+    ],
+    [
+      "description",
+      "Placeholder text in the editing box"
+    ]
+  ],
+  "placeholder.origin": [
+    [
+      "message",
+      "Enter Site Domain"
+    ],
+    [
+      "description",
+      "Placeholder text in the editing box"
+    ]
+  ],
+  "placeholder.editUrl": [
+    [
+      "message",
+      "Enter Link"
+    ],
+    [
+      "description",
+      "Placeholder text in the editing box"
+    ]
+  ],
+  "placeholder.description": [
+    [
+      "message",
+      "Enter Site Description"
+    ],
+    [
+      "description",
+      "Placeholder text in the editing box"
+    ]
+  ],
+  "placeholder.keywords": [
+    [
+      "message",
+      "Enter Site Keywords"
+    ],
+    [
+      "description",
+      "Placeholder text in the editing box"
+    ]
+  ],
+  "placeholder.editDistributionDefaultInviterId": [
+    [
+      "message",
+      "Enter Default Inviter ID"
+    ],
+    [
+      "description",
+      "Placeholder text in the editing box"
+    ]
+  ],
+  "placeholder.editDistributionForceInviterId": [
+    [
+      "message",
+      "Enter Forced Inviter ID"
+    ],
+    [
+      "description",
+      "Placeholder text in the editing box"
+    ]
+  ],
+  "message.uploadImageExceed": [
+    [
+      "message",
+      "Image Upload Exceeds Limit"
+    ],
+    [
+      "description",
+      "Notification for exceeding image upload limit"
+    ]
+  ],
+  "message.uploadImageError": [
+    [
+      "message",
+      "Image Upload Error"
+    ],
+    [
+      "description",
+      "Notification for image upload error"
+    ]
+  ],
+  "message.editLogoTip": [
+    [
+      "message",
+      "Recommended Size: 200*60px"
+    ],
+    [
+      "description",
+      "Tip for uploading images"
+    ]
+  ],
+  "message.editQRTip": [
+    [
+      "message",
+      "Recommended Size: 200*200px"
+    ],
+    [
+      "description",
+      "Tip for uploading images"
+    ]
+  ],
+  "message.editFaviconTip": [
+    [
+      "message",
+      "Recommended Size: 32*32px"
+    ],
+    [
+      "description",
+      "Tip for uploading images"
+    ]
+  ],
+  "message.editUrl": [
+    [
+      "message",
+      "Enter Link"
+    ],
+    [
+      "description",
+      "Prompt to enter a link"
+    ]
+  ],
+  "message.atLeastOneAdmin": [
+    [
+      "message",
+      "At Least One Admin Must Remain"
+    ],
+    [
+      "description",
+      "Notification to keep at least one admin"
+    ]
+  ],
+  "message.distributionDefaultInviterIdTip": [
+    [
+      "message",
+      "User ID of the default inviter. If the distribution link does not carry the inviter_id parameter, this user ID will be used as the inviter by default."
+    ],
+    [
+      "description",
+      "Tip for default inviter ID"
+    ]
+  ],
+  "message.distributionForceInviterIdTip": [
+    [
+      "message",
+      "User ID of the forced inviter. If this ID is set, it will be used as the inviter regardless of whether the distribution link carries the inviter_id parameter."
+    ],
+    [
+      "description",
+      "Tip for forced inviter ID"
+    ]
+  ],
+  "message.originTip": [
+    [
+      "message",
+      "Site domain, site configuration is bound to the domain, and the site domain cannot be changed."
+    ],
+    [
+      "description",
+      "Tip for site domain"
+    ]
+  ],
+  "message.titleTip": [
+    [
+      "message",
+      "Site title, displayed in the browser tab."
+    ],
+    [
+      "description",
+      "Tip for site title"
+    ]
+  ],
+  "message.descriptionTip": [
+    [
+      "message",
+      "Site description, located in the site metadata, used for site SEO optimization."
+    ],
+    [
+      "description",
+      "Tip for site description"
+    ]
+  ],
+  "message.logoTip": [
+    [
+      "message",
+      "Site Logo, displayed at the top of the site menu when the menu bar is expanded."
+    ],
+    [
+      "description",
+      "Tip for site logo"
+    ]
+  ],
+  "message.faviconTip": [
+    [
+      "message",
+      "Site Favicon, displayed in the browser tab."
+    ],
+    [
+      "description",
+      "Tip for site favicon"
+    ]
+  ],
+  "message.adminsTip": [
+    [
+      "message",
+      "Site admin IDs. By default, the user who first creates the site will become an admin. Only site admins can manage the site."
+    ],
+    [
+      "description",
+      "Tip for site admins"
+    ]
+  ],
+  "message.adminsTip2": [
+    [
+      "message",
+      "You can add or remove admin IDs here. You can view user IDs at https://auth.acedata.cloud"
+    ],
+    [
+      "description",
+      "Tip for site admins"
+    ]
+  ],
+  "message.keywordsTip": [
+    [
+      "message",
+      "Site keywords, located in the site metadata, used for site SEO optimization."
+    ],
+    [
+      "description",
+      "Tip for site keywords"
+    ]
+  ],
+  "message.keywordsTip2": [
+    [
+      "message",
+      "You can add or remove site keywords here. The more precise the keywords, the more beneficial for SEO optimization."
+    ],
+    [
+      "description",
+      "Tip for site keywords"
+    ]
+  ],
+  "message.featuresChat": [
+    [
+      "message",
+      "Enable or Disable Chat Feature Module."
+    ],
+    [
+      "description",
+      "Description of the Chat feature"
+    ]
+  ],
+  "message.featuresGrok": [
+    [
+      "message",
+      "Enable or Disable Grok Feature Module."
+    ],
+    [
+      "description",
+      "Description of the Grok feature"
+    ]
+  ],
+  "message.featuresDeepseek": [
+    [
+      "message",
+      "Enable or Disable Deepseek Feature Module."
+    ],
+    [
+      "description",
+      "Description of the Deepseek feature"
+    ]
+  ],
+  "message.featuresChatgpt": [
+    [
+      "message",
+      "Enable or Disable ChatGPT Feature Module."
+    ],
+    [
+      "description",
+      "Description of the ChatGPT feature"
+    ]
+  ],
+  "message.featuresMidjourney": [
+    [
+      "message",
+      "Enable or Disable Midjourney Feature Module."
+    ],
+    [
+      "description",
+      "Description of the Midjourney feature"
+    ]
+  ],
+  "message.featuresChatdoc": [
+    [
+      "message",
+      "Enable or Disable Chatdoc Feature Module."
+    ],
+    [
+      "description",
+      "Description of the Chatdoc feature"
+    ]
+  ],
+  "message.featuresQrart": [
+    [
+      "message",
+      "Enable or Disable Qrart Feature Module."
+    ],
+    [
+      "description",
+      "Description of the Qrart feature"
+    ]
+  ],
+  "message.featuresVeo": [
+    [
+      "message",
+      "Enable or Disable Veo Feature Module."
+    ],
+    [
+      "description",
+      "Description of the Veo feature"
+    ]
+  ],
+  "message.featuresSora": [
+    [
+      "message",
+      "Enable or Disable Sora Feature Module."
+    ],
+    [
+      "description",
+      "Description of the Sora feature"
+    ]
+  ],
+  "message.featuresSuno": [
+    [
+      "message",
+      "Enable or Disable Suno Feature Module."
+    ],
+    [
+      "description",
+      "Description of the Suno feature"
+    ]
+  ],
+  "message.featuresPixverse": [
+    [
+      "message",
+      "Toggle Pixverse feature module."
+    ],
+    [
+      "description",
+      "Description of the Pixverse feature"
+    ]
+  ],
+  "message.featuresFlux": [
+    [
+      "message",
+      "Toggle FLux feature module."
+    ],
+    [
+      "description",
+      "Description of the FLux feature"
+    ]
+  ],
+  "message.featuresNanobanana": [
+    [
+      "message",
+      "Toggle Nano Banana feature module."
+    ],
+    [
+      "description",
+      "Description of the Nano Banana feature"
+    ]
+  ],
+  "message.featuresOpenaiimage": {
+    "message": "Toggle OpenAI Image feature module.",
+    "description": "Description of the OpenAI Image feature"
+  },
+  "message.featuresSeedream": [
+    [
+      "message",
+      "Toggle SeeDream feature module."
+    ],
+    [
+      "description",
+      "Description of the SeeDream feature"
+    ]
+  ],
+  "message.featuresSeedance": [
+    [
+      "message",
+      "Enable or disable SeeDance feature module."
+    ],
+    [
+      "description",
+      "Description of the SeeDance feature"
+    ]
+  ],
+  "message.featuresWan": [
+    [
+      "message",
+      "Toggle Wan feature module."
+    ],
+    [
+      "description",
+      "Description of the Wan feature"
+    ]
+  ],
+  "message.featuresProducer": [
+    [
+      "message",
+      "Toggle Producer feature module."
+    ],
+    [
+      "description",
+      "Description of the Producer feature"
+    ]
+  ],
+  "message.featuresKimi": [
+    [
+      "message",
+      "Toggle Kimi feature module."
+    ],
+    [
+      "description",
+      "Description of the Kimi feature"
+    ]
+  ],
+  "message.featuresSerp": [
+    [
+      "message",
+      "Toggle SERP feature module."
+    ],
+    [
+      "description",
+      "Description of the SERP feature"
+    ]
+  ],
+  "message.featuresLuma": [
+    [
+      "message",
+      "Toggle Luma feature module."
+    ],
+    [
+      "description",
+      "Description of the Luma feature"
+    ]
+  ],
+  "message.featuresPika": [
+    [
+      "message",
+      "Toggle Pika feature module."
+    ],
+    [
+      "description",
+      "Description of the Pika feature"
+    ]
+  ],
+  "message.featuresKling": [
+    [
+      "message",
+      "Toggle Kling feature module."
+    ],
+    [
+      "description",
+      "Description of the Kling feature"
+    ]
+  ],
+  "message.featuresHailuo": [
+    [
+      "message",
+      "Toggle Hailuo feature module."
+    ],
+    [
+      "description",
+      "Description of the Hailuo feature"
+    ]
+  ],
+  "message.featuresHeadshots": [
+    [
+      "message",
+      "Toggle AI ID Photo feature module."
+    ],
+    [
+      "description",
+      "Description of the AI ID Photo feature"
+    ]
+  ],
+  "message.featuresSupport": [
+    [
+      "message",
+      "Toggle customer support"
+    ],
+    [
+      "description",
+      "Description of the Support feature"
+    ]
+  ],
+  "message.featuresI18n": [
+    [
+      "message",
+      "Toggle multilingual support; when disabled, users can only use the default language."
+    ],
+    [
+      "description",
+      "Description of multilingual support"
+    ]
+  ],
+  "button.upload": [
+    [
+      "message",
+      "Upload"
+    ],
+    [
+      "description",
+      "Upload"
+    ]
+  ],
+  "button.enabled": [
+    [
+      "message",
+      "Enabled"
+    ],
+    [
+      "description",
+      "Toggle text indicating it is enabled"
+    ]
+  ],
+  "button.disabled": [
+    [
+      "message",
+      "Disabled"
+    ],
+    [
+      "description",
+      "Toggle text indicating it is disabled"
+    ]
+  ],
+  "field.featuresGemini": [
+    [
+      "message",
+      "Gemini"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "message.featuresGemini": [
+    [
+      "message",
+      "Enable or disable the Gemini feature module."
+    ],
+    [
+      "description",
+      "Description of the Gemini feature"
+    ]
+  ],
+  "field.featuresClaude": [
+    [
+      "message",
+      "Claude"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "message.featuresClaude": [
+    [
+      "message",
+      "Enable or disable the Claude feature module."
+    ],
+    [
+      "description",
+      "Description of the Claude feature"
+    ]
+  ]
 }

--- a/src/i18n/es/site.json
+++ b/src/i18n/es/site.json
@@ -1,1110 +1,450 @@
 {
-  "field.title": [
-    [
-      "message",
-      "Título del sitio"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "field.origin": [
-    [
-      "message",
-      "Dominio del sitio"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "field.description": [
-    [
-      "message",
-      "Descripción del sitio"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "field.keywords": [
-    [
-      "message",
-      "Palabras clave del sitio"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "field.logo": [
-    [
-      "message",
-      "Logo del sitio"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "field.favicon": [
-    [
-      "message",
-      "Favicon del sitio"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "field.qr": [
-    [
-      "message",
-      "Código QR"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "field.url": [
-    [
-      "message",
-      "Enlace"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "field.admins": [
-    [
-      "message",
-      "ID de administradores del sitio"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "field.distributionDefaultInviterId": [
-    [
-      "message",
-      "ID del invitador por defecto"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "field.distributionForceInviterId": [
-    [
-      "message",
-      "ID del invitador forzado"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "field.featuresChat": [
-    [
-      "message",
-      "Chat"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "field.featuresVeo": [
-    [
-      "message",
-      "Veo"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "field.featuresSora": [
-    [
-      "message",
-      "Sora"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "field.featuresGrok": [
-    [
-      "message",
-      "Grok"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "field.featuresDeepseek": [
-    [
-      "message",
-      "Deepseek"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "field.featuresChatgpt": [
-    [
-      "message",
-      "ChatGPT"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "field.featuresMidjourney": [
-    [
-      "message",
-      "Midjourney"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "field.featuresChatdoc": [
-    [
-      "message",
-      "Chatdoc"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "field.featuresQrart": [
-    [
-      "message",
-      "Qrart"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "field.featuresLuma": [
-    [
-      "message",
-      "Luma"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "field.featuresPixverse": [
-    [
-      "message",
-      "Pixverse"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "field.featuresPika": [
-    [
-      "message",
-      "Pika"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "field.featuresKling": [
-    [
-      "message",
-      "Kling"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "field.featuresHailuo": [
-    [
-      "message",
-      "Hailuo"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "field.featuresHeadshots": [
-    [
-      "message",
-      "Foto de identificación AI"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "field.featuresSuno": [
-    [
-      "message",
-      "Suno"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "field.featuresFlux": [
-    [
-      "message",
-      "Flux"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "field.featuresNanobanana": [
-    [
-      "message",
-      "Nano Banana"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
+  "field.title": {
+    "message": "Título del sitio",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "field.origin": {
+    "message": "Dominio del sitio",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "field.description": {
+    "message": "Descripción del sitio",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "field.keywords": {
+    "message": "Palabras clave del sitio",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "field.logo": {
+    "message": "Logo del sitio",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "field.favicon": {
+    "message": "Favicon del sitio",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "field.qr": {
+    "message": "Código QR",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "field.url": {
+    "message": "Enlace",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "field.admins": {
+    "message": "ID de administradores del sitio",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "field.distributionDefaultInviterId": {
+    "message": "ID del invitador por defecto",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "field.distributionForceInviterId": {
+    "message": "ID del invitador forzado",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "field.featuresChat": {
+    "message": "Chat",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "field.featuresVeo": {
+    "message": "Veo",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "field.featuresSora": {
+    "message": "Sora",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "field.featuresGrok": {
+    "message": "Grok",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "field.featuresDeepseek": {
+    "message": "Deepseek",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "field.featuresChatgpt": {
+    "message": "ChatGPT",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "field.featuresMidjourney": {
+    "message": "Midjourney",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "field.featuresChatdoc": {
+    "message": "Chatdoc",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "field.featuresQrart": {
+    "message": "Qrart",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "field.featuresLuma": {
+    "message": "Luma",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "field.featuresPixverse": {
+    "message": "Pixverse",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "field.featuresPika": {
+    "message": "Pika",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "field.featuresKling": {
+    "message": "Kling",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "field.featuresHailuo": {
+    "message": "Hailuo",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "field.featuresHeadshots": {
+    "message": "Foto de identificación AI",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "field.featuresSuno": {
+    "message": "Suno",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "field.featuresFlux": {
+    "message": "Flux",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "field.featuresNanobanana": {
+    "message": "Nano Banana",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
   "field.featuresOpenaiimage": {
     "message": "OpenAI Image",
     "description": "Displayed as the title in the editing box"
   },
-  "field.featuresSeedream": [
-    [
-      "message",
-      "SeeDream"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "field.featuresSeedance": [
-    [
-      "message",
-      "SeeDance"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "field.featuresWan": [
-    [
-      "message",
-      "Wan"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "field.featuresProducer": [
-    [
-      "message",
-      "Productor"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "field.featuresKimi": [
-    [
-      "message",
-      "Kimi"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "field.featuresSerp": [
-    [
-      "message",
-      "SERP"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "field.featuresSupport": [
-    [
-      "message",
-      "Soporte al cliente"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "field.featuresI18n": [
-    [
-      "message",
-      "Soporte multilingüe"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "title.basicConfig": [
-    [
-      "message",
-      "Configuración básica"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "title.seoConfig": [
-    [
-      "message",
-      "Configuración SEO"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "title.editAdmins": [
-    [
-      "message",
-      "Editar administradores"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "title.featuresConfig": [
-    [
-      "message",
-      "Configuración de funciones"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "title.editTitle": [
-    [
-      "message",
-      "Editar título"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "title.editOrigin": [
-    [
-      "message",
-      "Editar dominio"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "title.editKeywords": [
-    [
-      "message",
-      "Editar palabras clave"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "title.editLogo": [
-    [
-      "message",
-      "Editar logo"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "title.editFavicon": [
-    [
-      "message",
-      "Editar favicon"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "title.editDescription": [
-    [
-      "message",
-      "Editar descripción"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "title.distributionConfig": [
-    [
-      "message",
-      "Configuración de distribución"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "title.editDistributionDefaultInviterId": [
-    [
-      "message",
-      "Editar invitador por defecto"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "title.editDistributionForceInviterId": [
-    [
-      "message",
-      "Editar invitador forzado"
-    ],
-    [
-      "description",
-      "Texto que se muestra en el cuadro de edición"
-    ]
-  ],
-  "title.editQR": [
-    [
-      "message",
-      "Editar QR"
-    ],
-    [
-      "description",
-      "Título mostrado en el cuadro de edición"
-    ]
-  ],
-  "title.editUrl": [
-    [
-      "message",
-      "Editar enlace"
-    ],
-    [
-      "description",
-      "Título mostrado en el cuadro de edición"
-    ]
-  ],
-  "placeholder.title": [
-    [
-      "message",
-      "Ingrese el título del sitio"
-    ],
-    [
-      "description",
-      "Texto mostrado en el cuadro de edición"
-    ]
-  ],
-  "placeholder.origin": [
-    [
-      "message",
-      "Ingrese el dominio del sitio"
-    ],
-    [
-      "description",
-      "Texto mostrado en el cuadro de edición"
-    ]
-  ],
-  "placeholder.editUrl": [
-    [
-      "message",
-      "Ingrese el enlace"
-    ],
-    [
-      "description",
-      "Texto mostrado en el cuadro de edición"
-    ]
-  ],
-  "placeholder.description": [
-    [
-      "message",
-      "Ingrese la descripción del sitio"
-    ],
-    [
-      "description",
-      "Texto mostrado en el cuadro de edición"
-    ]
-  ],
-  "placeholder.keywords": [
-    [
-      "message",
-      "Ingrese las palabras clave del sitio"
-    ],
-    [
-      "description",
-      "Texto mostrado en el cuadro de edición"
-    ]
-  ],
-  "placeholder.editDistributionDefaultInviterId": [
-    [
-      "message",
-      "Ingrese el ID del invitador predeterminado"
-    ],
-    [
-      "description",
-      "Texto mostrado en el cuadro de edición"
-    ]
-  ],
-  "placeholder.editDistributionForceInviterId": [
-    [
-      "message",
-      "Ingrese el ID del invitador forzado"
-    ],
-    [
-      "description",
-      "Texto mostrado en el cuadro de edición"
-    ]
-  ],
-  "message.uploadImageExceed": [
-    [
-      "message",
-      "La imagen subida excede el límite"
-    ],
-    [
-      "description",
-      "Mensaje de advertencia cuando la imagen subida excede el límite"
-    ]
-  ],
-  "message.uploadImageError": [
-    [
-      "message",
-      "Error al subir la imagen"
-    ],
-    [
-      "description",
-      "Mensaje de error al subir la imagen"
-    ]
-  ],
-  "message.editLogoTip": [
-    [
-      "message",
-      "Tamaño recomendado: 200*60px"
-    ],
-    [
-      "description",
-      "Texto de sugerencia para la imagen subida"
-    ]
-  ],
-  "message.editQRTip": [
-    [
-      "message",
-      "Tamaño recomendado: 200*200px"
-    ],
-    [
-      "description",
-      "Texto de sugerencia para la imagen subida"
-    ]
-  ],
-  "message.editFaviconTip": [
-    [
-      "message",
-      "Tamaño recomendado: 32*32px"
-    ],
-    [
-      "description",
-      "Texto de sugerencia para la imagen subida"
-    ]
-  ],
-  "message.editUrl": [
-    [
-      "message",
-      "Ingrese el enlace"
-    ],
-    [
-      "description",
-      "Sugerencia para ingresar el enlace"
-    ]
-  ],
-  "message.atLeastOneAdmin": [
-    [
-      "message",
-      "Mantenga al menos un administrador"
-    ],
-    [
-      "description",
-      "Mensaje de advertencia para mantener al menos un administrador"
-    ]
-  ],
-  "message.distributionDefaultInviterIdTip": [
-    [
-      "message",
-      "ID de usuario del invitador predeterminado. Si el enlace de distribución no incluye el parámetro inviter_id, se usará este ID como invitador por defecto."
-    ],
-    [
-      "description",
-      "Sugerencia para el ID del invitador predeterminado"
-    ]
-  ],
-  "message.distributionForceInviterIdTip": [
-    [
-      "message",
-      "ID de usuario del invitador forzado. Si se establece este ID, se usará forzosamente como invitador, independientemente de si el enlace de distribución incluye el parámetro inviter_id."
-    ],
-    [
-      "description",
-      "Sugerencia para el ID del invitador forzado"
-    ]
-  ],
-  "message.originTip": [
-    [
-      "message",
-      "Dominio del sitio. La configuración del sitio está vinculada al dominio y no se puede cambiar."
-    ],
-    [
-      "description",
-      "Sugerencia para el dominio del sitio"
-    ]
-  ],
-  "message.titleTip": [
-    [
-      "message",
-      "Título del sitio, mostrado en la pestaña del navegador."
-    ],
-    [
-      "description",
-      "Sugerencia para el título del sitio"
-    ]
-  ],
-  "message.descriptionTip": [
-    [
-      "message",
-      "Descripción del sitio, ubicada en la metainformación del sitio, utilizada para la optimización SEO."
-    ],
-    [
-      "description",
-      "Sugerencia para la descripción del sitio"
-    ]
-  ],
-  "message.logoTip": [
-    [
-      "message",
-      "Logo del sitio, mostrado en la parte superior del menú del sitio cuando se expande."
-    ],
-    [
-      "description",
-      "Sugerencia para el logo del sitio"
-    ]
-  ],
-  "message.faviconTip": [
-    [
-      "message",
-      "Favicon del sitio, mostrado en la pestaña del navegador."
-    ],
-    [
-      "description",
-      "Sugerencia para el favicon del sitio"
-    ]
-  ],
-  "message.adminsTip": [
-    [
-      "message",
-      "ID de administrador del sitio. Por defecto, el primer usuario que crea el sitio será el administrador. Solo los administradores del sitio pueden gestionarlo."
-    ],
-    [
-      "description",
-      "Sugerencia para los administradores del sitio"
-    ]
-  ],
-  "message.adminsTip2": [
-    [
-      "message",
-      "Puede agregar o eliminar ID de administradores aquí. Puede ver los ID de usuario en https://auth.acedata.cloud"
-    ],
-    [
-      "description",
-      "Sugerencia para los administradores del sitio"
-    ]
-  ],
-  "message.keywordsTip": [
-    [
-      "message",
-      "Palabras clave del sitio, ubicadas en la metainformación del sitio, utilizadas para la optimización SEO."
-    ],
-    [
-      "description",
-      "Sugerencia para las palabras clave del sitio"
-    ]
-  ],
-  "message.keywordsTip2": [
-    [
-      "message",
-      "Puede agregar o eliminar palabras clave del sitio aquí. Cuanto más precisas sean las palabras clave, mejor será para la optimización SEO."
-    ],
-    [
-      "description",
-      "Sugerencia para las palabras clave del sitio"
-    ]
-  ],
-  "message.featuresChat": [
-    [
-      "message",
-      "Activar o desactivar el módulo de función de Chat."
-    ],
-    [
-      "description",
-      "Descripción de la función de Chat"
-    ]
-  ],
-  "message.featuresGrok": [
-    [
-      "message",
-      "Activar o desactivar el módulo de función de Grok."
-    ],
-    [
-      "description",
-      "Descripción de la función de Grok"
-    ]
-  ],
-  "message.featuresDeepseek": [
-    [
-      "message",
-      "Activar o desactivar el módulo de función de Deepseek."
-    ],
-    [
-      "description",
-      "Descripción de la función de Deepseek"
-    ]
-  ],
-  "message.featuresChatgpt": [
-    [
-      "message",
-      "Activar o desactivar el módulo de función de ChatGPT."
-    ],
-    [
-      "description",
-      "Descripción de la función de ChatGPT"
-    ]
-  ],
-  "message.featuresMidjourney": [
-    [
-      "message",
-      "Activar o desactivar el módulo de función de Midjourney."
-    ],
-    [
-      "description",
-      "Descripción de la función de Midjourney"
-    ]
-  ],
-  "message.featuresChatdoc": [
-    [
-      "message",
-      "Activar o desactivar el módulo de función de Chatdoc."
-    ],
-    [
-      "description",
-      "Descripción de la función de Chatdoc"
-    ]
-  ],
-  "message.featuresQrart": [
-    [
-      "message",
-      "Activar o desactivar el módulo de función de Qrart."
-    ],
-    [
-      "description",
-      "Descripción de la función de Qrart"
-    ]
-  ],
-  "message.featuresVeo": [
-    [
-      "message",
-      "Activar o desactivar el módulo de función de Veo."
-    ],
-    [
-      "description",
-      "Descripción de la función de Veo"
-    ]
-  ],
-  "message.featuresSora": [
-    [
-      "message",
-      "Activar o desactivar el módulo de función de Sora."
-    ],
-    [
-      "description",
-      "Descripción de la función de Sora"
-    ]
-  ],
-  "message.featuresSuno": [
-    [
-      "message",
-      "Activar o desactivar el módulo de función de Suno."
-    ],
-    [
-      "description",
-      "Descripción de la función de Suno"
-    ]
-  ],
-  "message.featuresPixverse": [
-    [
-      "message",
-      "Activar o desactivar el módulo de funciones de Pixverse."
-    ],
-    [
-      "description",
-      "Descripción de la función de Pixverse"
-    ]
-  ],
-  "message.featuresFlux": [
-    [
-      "message",
-      "Activar o desactivar el módulo de funciones de FLux."
-    ],
-    [
-      "description",
-      "Descripción de la función de FLux"
-    ]
-  ],
-  "message.featuresNanobanana": [
-    [
-      "message",
-      "Activar o desactivar el módulo de funciones de Nano Banana."
-    ],
-    [
-      "description",
-      "Descripción de la función de Nano Banana"
-    ]
-  ],
+  "field.featuresSeedream": {
+    "message": "SeeDream",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "field.featuresSeedance": {
+    "message": "SeeDance",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "field.featuresWan": {
+    "message": "Wan",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "field.featuresProducer": {
+    "message": "Productor",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "field.featuresKimi": {
+    "message": "Kimi",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "field.featuresSerp": {
+    "message": "SERP",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "field.featuresSupport": {
+    "message": "Soporte al cliente",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "field.featuresI18n": {
+    "message": "Soporte multilingüe",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "title.basicConfig": {
+    "message": "Configuración básica",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "title.seoConfig": {
+    "message": "Configuración SEO",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "title.editAdmins": {
+    "message": "Editar administradores",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "title.featuresConfig": {
+    "message": "Configuración de funciones",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "title.editTitle": {
+    "message": "Editar título",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "title.editOrigin": {
+    "message": "Editar dominio",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "title.editKeywords": {
+    "message": "Editar palabras clave",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "title.editLogo": {
+    "message": "Editar logo",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "title.editFavicon": {
+    "message": "Editar favicon",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "title.editDescription": {
+    "message": "Editar descripción",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "title.distributionConfig": {
+    "message": "Configuración de distribución",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "title.editDistributionDefaultInviterId": {
+    "message": "Editar invitador por defecto",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "title.editDistributionForceInviterId": {
+    "message": "Editar invitador forzado",
+    "description": "Texto que se muestra en el cuadro de edición"
+  },
+  "title.editQR": {
+    "message": "Editar QR",
+    "description": "Título mostrado en el cuadro de edición"
+  },
+  "title.editUrl": {
+    "message": "Editar enlace",
+    "description": "Título mostrado en el cuadro de edición"
+  },
+  "placeholder.title": {
+    "message": "Ingrese el título del sitio",
+    "description": "Texto mostrado en el cuadro de edición"
+  },
+  "placeholder.origin": {
+    "message": "Ingrese el dominio del sitio",
+    "description": "Texto mostrado en el cuadro de edición"
+  },
+  "placeholder.editUrl": {
+    "message": "Ingrese el enlace",
+    "description": "Texto mostrado en el cuadro de edición"
+  },
+  "placeholder.description": {
+    "message": "Ingrese la descripción del sitio",
+    "description": "Texto mostrado en el cuadro de edición"
+  },
+  "placeholder.keywords": {
+    "message": "Ingrese las palabras clave del sitio",
+    "description": "Texto mostrado en el cuadro de edición"
+  },
+  "placeholder.editDistributionDefaultInviterId": {
+    "message": "Ingrese el ID del invitador predeterminado",
+    "description": "Texto mostrado en el cuadro de edición"
+  },
+  "placeholder.editDistributionForceInviterId": {
+    "message": "Ingrese el ID del invitador forzado",
+    "description": "Texto mostrado en el cuadro de edición"
+  },
+  "message.uploadImageExceed": {
+    "message": "La imagen subida excede el límite",
+    "description": "Mensaje de advertencia cuando la imagen subida excede el límite"
+  },
+  "message.uploadImageError": {
+    "message": "Error al subir la imagen",
+    "description": "Mensaje de error al subir la imagen"
+  },
+  "message.editLogoTip": {
+    "message": "Tamaño recomendado: 200*60px",
+    "description": "Texto de sugerencia para la imagen subida"
+  },
+  "message.editQRTip": {
+    "message": "Tamaño recomendado: 200*200px",
+    "description": "Texto de sugerencia para la imagen subida"
+  },
+  "message.editFaviconTip": {
+    "message": "Tamaño recomendado: 32*32px",
+    "description": "Texto de sugerencia para la imagen subida"
+  },
+  "message.editUrl": {
+    "message": "Ingrese el enlace",
+    "description": "Sugerencia para ingresar el enlace"
+  },
+  "message.atLeastOneAdmin": {
+    "message": "Mantenga al menos un administrador",
+    "description": "Mensaje de advertencia para mantener al menos un administrador"
+  },
+  "message.distributionDefaultInviterIdTip": {
+    "message": "ID de usuario del invitador predeterminado. Si el enlace de distribución no incluye el parámetro inviter_id, se usará este ID como invitador por defecto.",
+    "description": "Sugerencia para el ID del invitador predeterminado"
+  },
+  "message.distributionForceInviterIdTip": {
+    "message": "ID de usuario del invitador forzado. Si se establece este ID, se usará forzosamente como invitador, independientemente de si el enlace de distribución incluye el parámetro inviter_id.",
+    "description": "Sugerencia para el ID del invitador forzado"
+  },
+  "message.originTip": {
+    "message": "Dominio del sitio. La configuración del sitio está vinculada al dominio y no se puede cambiar.",
+    "description": "Sugerencia para el dominio del sitio"
+  },
+  "message.titleTip": {
+    "message": "Título del sitio, mostrado en la pestaña del navegador.",
+    "description": "Sugerencia para el título del sitio"
+  },
+  "message.descriptionTip": {
+    "message": "Descripción del sitio, ubicada en la metainformación del sitio, utilizada para la optimización SEO.",
+    "description": "Sugerencia para la descripción del sitio"
+  },
+  "message.logoTip": {
+    "message": "Logo del sitio, mostrado en la parte superior del menú del sitio cuando se expande.",
+    "description": "Sugerencia para el logo del sitio"
+  },
+  "message.faviconTip": {
+    "message": "Favicon del sitio, mostrado en la pestaña del navegador.",
+    "description": "Sugerencia para el favicon del sitio"
+  },
+  "message.adminsTip": {
+    "message": "ID de administrador del sitio. Por defecto, el primer usuario que crea el sitio será el administrador. Solo los administradores del sitio pueden gestionarlo.",
+    "description": "Sugerencia para los administradores del sitio"
+  },
+  "message.adminsTip2": {
+    "message": "Puede agregar o eliminar ID de administradores aquí. Puede ver los ID de usuario en https://auth.acedata.cloud",
+    "description": "Sugerencia para los administradores del sitio"
+  },
+  "message.keywordsTip": {
+    "message": "Palabras clave del sitio, ubicadas en la metainformación del sitio, utilizadas para la optimización SEO.",
+    "description": "Sugerencia para las palabras clave del sitio"
+  },
+  "message.keywordsTip2": {
+    "message": "Puede agregar o eliminar palabras clave del sitio aquí. Cuanto más precisas sean las palabras clave, mejor será para la optimización SEO.",
+    "description": "Sugerencia para las palabras clave del sitio"
+  },
+  "message.featuresChat": {
+    "message": "Activar o desactivar el módulo de función de Chat.",
+    "description": "Descripción de la función de Chat"
+  },
+  "message.featuresGrok": {
+    "message": "Activar o desactivar el módulo de función de Grok.",
+    "description": "Descripción de la función de Grok"
+  },
+  "message.featuresDeepseek": {
+    "message": "Activar o desactivar el módulo de función de Deepseek.",
+    "description": "Descripción de la función de Deepseek"
+  },
+  "message.featuresChatgpt": {
+    "message": "Activar o desactivar el módulo de función de ChatGPT.",
+    "description": "Descripción de la función de ChatGPT"
+  },
+  "message.featuresMidjourney": {
+    "message": "Activar o desactivar el módulo de función de Midjourney.",
+    "description": "Descripción de la función de Midjourney"
+  },
+  "message.featuresChatdoc": {
+    "message": "Activar o desactivar el módulo de función de Chatdoc.",
+    "description": "Descripción de la función de Chatdoc"
+  },
+  "message.featuresQrart": {
+    "message": "Activar o desactivar el módulo de función de Qrart.",
+    "description": "Descripción de la función de Qrart"
+  },
+  "message.featuresVeo": {
+    "message": "Activar o desactivar el módulo de función de Veo.",
+    "description": "Descripción de la función de Veo"
+  },
+  "message.featuresSora": {
+    "message": "Activar o desactivar el módulo de función de Sora.",
+    "description": "Descripción de la función de Sora"
+  },
+  "message.featuresSuno": {
+    "message": "Activar o desactivar el módulo de función de Suno.",
+    "description": "Descripción de la función de Suno"
+  },
+  "message.featuresPixverse": {
+    "message": "Activar o desactivar el módulo de funciones de Pixverse.",
+    "description": "Descripción de la función de Pixverse"
+  },
+  "message.featuresFlux": {
+    "message": "Activar o desactivar el módulo de funciones de FLux.",
+    "description": "Descripción de la función de FLux"
+  },
+  "message.featuresNanobanana": {
+    "message": "Activar o desactivar el módulo de funciones de Nano Banana.",
+    "description": "Descripción de la función de Nano Banana"
+  },
   "message.featuresOpenaiimage": {
     "message": "Toggle OpenAI Image feature module.",
     "description": "Description of the OpenAI Image feature"
   },
-  "message.featuresSeedream": [
-    [
-      "message",
-      "Activar o desactivar el módulo de funciones de SeeDream."
-    ],
-    [
-      "description",
-      "Descripción de la función de SeeDream"
-    ]
-  ],
-  "message.featuresSeedance": [
-    [
-      "message",
-      "Activar o desactivar el módulo de funciones de SeeDance."
-    ],
-    [
-      "description",
-      "Descripción de la función de SeeDance"
-    ]
-  ],
-  "message.featuresWan": [
-    [
-      "message",
-      "Activar o desactivar el módulo de funciones de Wan."
-    ],
-    [
-      "description",
-      "Descripción de la función de Wan"
-    ]
-  ],
-  "message.featuresProducer": [
-    [
-      "message",
-      "Activar o desactivar el módulo de funciones de Producer."
-    ],
-    [
-      "description",
-      "Descripción de la función de Producer"
-    ]
-  ],
-  "message.featuresKimi": [
-    [
-      "message",
-      "Activar o desactivar el módulo de funciones de Kimi."
-    ],
-    [
-      "description",
-      "Descripción de la función de Kimi"
-    ]
-  ],
-  "message.featuresSerp": [
-    [
-      "message",
-      "Activar o desactivar el módulo de funciones de SERP."
-    ],
-    [
-      "description",
-      "Descripción de la función de SERP"
-    ]
-  ],
-  "message.featuresLuma": [
-    [
-      "message",
-      "Activar o desactivar el módulo de funciones de Luma."
-    ],
-    [
-      "description",
-      "Descripción de la función de Luma"
-    ]
-  ],
-  "message.featuresPika": [
-    [
-      "message",
-      "Activar o desactivar el módulo de funciones de Pika."
-    ],
-    [
-      "description",
-      "Descripción de la función de Pika"
-    ]
-  ],
-  "message.featuresKling": [
-    [
-      "message",
-      "Activar o desactivar el módulo de funciones de Kling."
-    ],
-    [
-      "description",
-      "Descripción de la función de Kling"
-    ]
-  ],
-  "message.featuresHailuo": [
-    [
-      "message",
-      "Activar o desactivar el módulo de funciones de Hailuo."
-    ],
-    [
-      "description",
-      "Descripción de la función de Hailuo"
-    ]
-  ],
-  "message.featuresHeadshots": [
-    [
-      "message",
-      "Activar o desactivar el módulo de funciones de fotos de identificación AI."
-    ],
-    [
-      "description",
-      "Descripción de la función de fotos de identificación AI"
-    ]
-  ],
-  "message.featuresSupport": [
-    [
-      "message",
-      "Activar o desactivar el soporte al cliente"
-    ],
-    [
-      "description",
-      "Descripción de la función de soporte"
-    ]
-  ],
-  "message.featuresI18n": [
-    [
-      "message",
-      "Activar o desactivar el soporte multilingüe. Al desactivarlo, los usuarios solo podrán usar el idioma predeterminado."
-    ],
-    [
-      "description",
-      "Descripción del soporte multilingüe"
-    ]
-  ],
-  "button.upload": [
-    [
-      "message",
-      "Subir"
-    ],
-    [
-      "description",
-      "Subir"
-    ]
-  ],
-  "button.enabled": [
-    [
-      "message",
-      "Habilitado"
-    ],
-    [
-      "description",
-      "Texto del interruptor que indica que está habilitado"
-    ]
-  ],
-  "button.disabled": [
-    [
-      "message",
-      "Deshabilitado"
-    ],
-    [
-      "description",
-      "Texto del interruptor que indica que está deshabilitado"
-    ]
-  ],
-  "field.featuresGemini": [
-    [
-      "message",
-      "Gemini"
-    ],
-    [
-      "description",
-      "Mostrado como el título en el cuadro de edición"
-    ]
-  ],
-  "message.featuresGemini": [
-    [
-      "message",
-      "Activar o desactivar el módulo de funciones de Gemini."
-    ],
-    [
-      "description",
-      "Descripción de la función de Gemini"
-    ]
-  ],
-  "field.featuresClaude": [
-    [
-      "message",
-      "Claude"
-    ],
-    [
-      "description",
-      "Mostrado como el título en el cuadro de edición"
-    ]
-  ],
-  "message.featuresClaude": [
-    [
-      "message",
-      "Activar o desactivar el módulo de funciones de Claude."
-    ],
-    [
-      "description",
-      "Descripción de la función de Claude"
-    ]
-  ]
+  "message.featuresSeedream": {
+    "message": "Activar o desactivar el módulo de funciones de SeeDream.",
+    "description": "Descripción de la función de SeeDream"
+  },
+  "message.featuresSeedance": {
+    "message": "Activar o desactivar el módulo de funciones de SeeDance.",
+    "description": "Descripción de la función de SeeDance"
+  },
+  "message.featuresWan": {
+    "message": "Activar o desactivar el módulo de funciones de Wan.",
+    "description": "Descripción de la función de Wan"
+  },
+  "message.featuresProducer": {
+    "message": "Activar o desactivar el módulo de funciones de Producer.",
+    "description": "Descripción de la función de Producer"
+  },
+  "message.featuresKimi": {
+    "message": "Activar o desactivar el módulo de funciones de Kimi.",
+    "description": "Descripción de la función de Kimi"
+  },
+  "message.featuresSerp": {
+    "message": "Activar o desactivar el módulo de funciones de SERP.",
+    "description": "Descripción de la función de SERP"
+  },
+  "message.featuresLuma": {
+    "message": "Activar o desactivar el módulo de funciones de Luma.",
+    "description": "Descripción de la función de Luma"
+  },
+  "message.featuresPika": {
+    "message": "Activar o desactivar el módulo de funciones de Pika.",
+    "description": "Descripción de la función de Pika"
+  },
+  "message.featuresKling": {
+    "message": "Activar o desactivar el módulo de funciones de Kling.",
+    "description": "Descripción de la función de Kling"
+  },
+  "message.featuresHailuo": {
+    "message": "Activar o desactivar el módulo de funciones de Hailuo.",
+    "description": "Descripción de la función de Hailuo"
+  },
+  "message.featuresHeadshots": {
+    "message": "Activar o desactivar el módulo de funciones de fotos de identificación AI.",
+    "description": "Descripción de la función de fotos de identificación AI"
+  },
+  "message.featuresSupport": {
+    "message": "Activar o desactivar el soporte al cliente",
+    "description": "Descripción de la función de soporte"
+  },
+  "message.featuresI18n": {
+    "message": "Activar o desactivar el soporte multilingüe. Al desactivarlo, los usuarios solo podrán usar el idioma predeterminado.",
+    "description": "Descripción del soporte multilingüe"
+  },
+  "button.upload": {
+    "message": "Subir",
+    "description": "Subir"
+  },
+  "button.enabled": {
+    "message": "Habilitado",
+    "description": "Texto del interruptor que indica que está habilitado"
+  },
+  "button.disabled": {
+    "message": "Deshabilitado",
+    "description": "Texto del interruptor que indica que está deshabilitado"
+  },
+  "field.featuresGemini": {
+    "message": "Gemini",
+    "description": "Mostrado como el título en el cuadro de edición"
+  },
+  "message.featuresGemini": {
+    "message": "Activar o desactivar el módulo de funciones de Gemini.",
+    "description": "Descripción de la función de Gemini"
+  },
+  "field.featuresClaude": {
+    "message": "Claude",
+    "description": "Mostrado como el título en el cuadro de edición"
+  },
+  "message.featuresClaude": {
+    "message": "Activar o desactivar el módulo de funciones de Claude.",
+    "description": "Descripción de la función de Claude"
+  }
 }

--- a/src/i18n/es/site.json
+++ b/src/i18n/es/site.json
@@ -1,442 +1,1110 @@
 {
-  "field.title": {
-    "message": "Título del sitio",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "field.origin": {
-    "message": "Dominio del sitio",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "field.description": {
-    "message": "Descripción del sitio",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "field.keywords": {
-    "message": "Palabras clave del sitio",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "field.logo": {
-    "message": "Logo del sitio",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "field.favicon": {
-    "message": "Favicon del sitio",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "field.qr": {
-    "message": "Código QR",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "field.url": {
-    "message": "Enlace",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "field.admins": {
-    "message": "ID de administradores del sitio",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "field.distributionDefaultInviterId": {
-    "message": "ID del invitador por defecto",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "field.distributionForceInviterId": {
-    "message": "ID del invitador forzado",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "field.featuresChat": {
-    "message": "Chat",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "field.featuresVeo": {
-    "message": "Veo",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "field.featuresSora": {
-    "message": "Sora",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "field.featuresGrok": {
-    "message": "Grok",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "field.featuresDeepseek": {
-    "message": "Deepseek",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "field.featuresChatgpt": {
-    "message": "ChatGPT",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "field.featuresMidjourney": {
-    "message": "Midjourney",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "field.featuresChatdoc": {
-    "message": "Chatdoc",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "field.featuresQrart": {
-    "message": "Qrart",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "field.featuresLuma": {
-    "message": "Luma",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "field.featuresPixverse": {
-    "message": "Pixverse",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "field.featuresPika": {
-    "message": "Pika",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "field.featuresKling": {
-    "message": "Kling",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "field.featuresHailuo": {
-    "message": "Hailuo",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "field.featuresHeadshots": {
-    "message": "Foto de identificación AI",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "field.featuresSuno": {
-    "message": "Suno",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "field.featuresFlux": {
-    "message": "Flux",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "field.featuresNanobanana": {
-    "message": "Nano Banana",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "field.featuresSeedream": {
-    "message": "SeeDream",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "field.featuresSeedance": {
-    "message": "SeeDance",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "field.featuresWan": {
-    "message": "Wan",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "field.featuresProducer": {
-    "message": "Productor",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "field.featuresKimi": {
-    "message": "Kimi",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "field.featuresSerp": {
-    "message": "SERP",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "field.featuresSupport": {
-    "message": "Soporte al cliente",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "field.featuresI18n": {
-    "message": "Soporte multilingüe",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "title.basicConfig": {
-    "message": "Configuración básica",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "title.seoConfig": {
-    "message": "Configuración SEO",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "title.editAdmins": {
-    "message": "Editar administradores",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "title.featuresConfig": {
-    "message": "Configuración de funciones",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "title.editTitle": {
-    "message": "Editar título",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "title.editOrigin": {
-    "message": "Editar dominio",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "title.editKeywords": {
-    "message": "Editar palabras clave",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "title.editLogo": {
-    "message": "Editar logo",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "title.editFavicon": {
-    "message": "Editar favicon",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "title.editDescription": {
-    "message": "Editar descripción",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "title.distributionConfig": {
-    "message": "Configuración de distribución",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "title.editDistributionDefaultInviterId": {
-    "message": "Editar invitador por defecto",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "title.editDistributionForceInviterId": {
-    "message": "Editar invitador forzado",
-    "description": "Texto que se muestra en el cuadro de edición"
-  },
-  "title.editQR": {
-    "message": "Editar QR",
-    "description": "Título mostrado en el cuadro de edición"
-  },
-  "title.editUrl": {
-    "message": "Editar enlace",
-    "description": "Título mostrado en el cuadro de edición"
-  },
-  "placeholder.title": {
-    "message": "Ingrese el título del sitio",
-    "description": "Texto mostrado en el cuadro de edición"
-  },
-  "placeholder.origin": {
-    "message": "Ingrese el dominio del sitio",
-    "description": "Texto mostrado en el cuadro de edición"
-  },
-  "placeholder.editUrl": {
-    "message": "Ingrese el enlace",
-    "description": "Texto mostrado en el cuadro de edición"
-  },
-  "placeholder.description": {
-    "message": "Ingrese la descripción del sitio",
-    "description": "Texto mostrado en el cuadro de edición"
-  },
-  "placeholder.keywords": {
-    "message": "Ingrese las palabras clave del sitio",
-    "description": "Texto mostrado en el cuadro de edición"
-  },
-  "placeholder.editDistributionDefaultInviterId": {
-    "message": "Ingrese el ID del invitador predeterminado",
-    "description": "Texto mostrado en el cuadro de edición"
-  },
-  "placeholder.editDistributionForceInviterId": {
-    "message": "Ingrese el ID del invitador forzado",
-    "description": "Texto mostrado en el cuadro de edición"
-  },
-  "message.uploadImageExceed": {
-    "message": "La imagen subida excede el límite",
-    "description": "Mensaje de advertencia cuando la imagen subida excede el límite"
-  },
-  "message.uploadImageError": {
-    "message": "Error al subir la imagen",
-    "description": "Mensaje de error al subir la imagen"
-  },
-  "message.editLogoTip": {
-    "message": "Tamaño recomendado: 200*60px",
-    "description": "Texto de sugerencia para la imagen subida"
-  },
-  "message.editQRTip": {
-    "message": "Tamaño recomendado: 200*200px",
-    "description": "Texto de sugerencia para la imagen subida"
-  },
-  "message.editFaviconTip": {
-    "message": "Tamaño recomendado: 32*32px",
-    "description": "Texto de sugerencia para la imagen subida"
-  },
-  "message.editUrl": {
-    "message": "Ingrese el enlace",
-    "description": "Sugerencia para ingresar el enlace"
-  },
-  "message.atLeastOneAdmin": {
-    "message": "Mantenga al menos un administrador",
-    "description": "Mensaje de advertencia para mantener al menos un administrador"
-  },
-  "message.distributionDefaultInviterIdTip": {
-    "message": "ID de usuario del invitador predeterminado. Si el enlace de distribución no incluye el parámetro inviter_id, se usará este ID como invitador por defecto.",
-    "description": "Sugerencia para el ID del invitador predeterminado"
-  },
-  "message.distributionForceInviterIdTip": {
-    "message": "ID de usuario del invitador forzado. Si se establece este ID, se usará forzosamente como invitador, independientemente de si el enlace de distribución incluye el parámetro inviter_id.",
-    "description": "Sugerencia para el ID del invitador forzado"
-  },
-  "message.originTip": {
-    "message": "Dominio del sitio. La configuración del sitio está vinculada al dominio y no se puede cambiar.",
-    "description": "Sugerencia para el dominio del sitio"
-  },
-  "message.titleTip": {
-    "message": "Título del sitio, mostrado en la pestaña del navegador.",
-    "description": "Sugerencia para el título del sitio"
-  },
-  "message.descriptionTip": {
-    "message": "Descripción del sitio, ubicada en la metainformación del sitio, utilizada para la optimización SEO.",
-    "description": "Sugerencia para la descripción del sitio"
-  },
-  "message.logoTip": {
-    "message": "Logo del sitio, mostrado en la parte superior del menú del sitio cuando se expande.",
-    "description": "Sugerencia para el logo del sitio"
-  },
-  "message.faviconTip": {
-    "message": "Favicon del sitio, mostrado en la pestaña del navegador.",
-    "description": "Sugerencia para el favicon del sitio"
-  },
-  "message.adminsTip": {
-    "message": "ID de administrador del sitio. Por defecto, el primer usuario que crea el sitio será el administrador. Solo los administradores del sitio pueden gestionarlo.",
-    "description": "Sugerencia para los administradores del sitio"
-  },
-  "message.adminsTip2": {
-    "message": "Puede agregar o eliminar ID de administradores aquí. Puede ver los ID de usuario en https://auth.acedata.cloud",
-    "description": "Sugerencia para los administradores del sitio"
-  },
-  "message.keywordsTip": {
-    "message": "Palabras clave del sitio, ubicadas en la metainformación del sitio, utilizadas para la optimización SEO.",
-    "description": "Sugerencia para las palabras clave del sitio"
-  },
-  "message.keywordsTip2": {
-    "message": "Puede agregar o eliminar palabras clave del sitio aquí. Cuanto más precisas sean las palabras clave, mejor será para la optimización SEO.",
-    "description": "Sugerencia para las palabras clave del sitio"
-  },
-  "message.featuresChat": {
-    "message": "Activar o desactivar el módulo de función de Chat.",
-    "description": "Descripción de la función de Chat"
-  },
-  "message.featuresGrok": {
-    "message": "Activar o desactivar el módulo de función de Grok.",
-    "description": "Descripción de la función de Grok"
-  },
-  "message.featuresDeepseek": {
-    "message": "Activar o desactivar el módulo de función de Deepseek.",
-    "description": "Descripción de la función de Deepseek"
-  },
-  "message.featuresChatgpt": {
-    "message": "Activar o desactivar el módulo de función de ChatGPT.",
-    "description": "Descripción de la función de ChatGPT"
-  },
-  "message.featuresMidjourney": {
-    "message": "Activar o desactivar el módulo de función de Midjourney.",
-    "description": "Descripción de la función de Midjourney"
-  },
-  "message.featuresChatdoc": {
-    "message": "Activar o desactivar el módulo de función de Chatdoc.",
-    "description": "Descripción de la función de Chatdoc"
-  },
-  "message.featuresQrart": {
-    "message": "Activar o desactivar el módulo de función de Qrart.",
-    "description": "Descripción de la función de Qrart"
-  },
-  "message.featuresVeo": {
-    "message": "Activar o desactivar el módulo de función de Veo.",
-    "description": "Descripción de la función de Veo"
-  },
-  "message.featuresSora": {
-    "message": "Activar o desactivar el módulo de función de Sora.",
-    "description": "Descripción de la función de Sora"
-  },
-  "message.featuresSuno": {
-    "message": "Activar o desactivar el módulo de función de Suno.",
-    "description": "Descripción de la función de Suno"
-  },
-  "message.featuresPixverse": {
-    "message": "Activar o desactivar el módulo de funciones de Pixverse.",
-    "description": "Descripción de la función de Pixverse"
-  },
-  "message.featuresFlux": {
-    "message": "Activar o desactivar el módulo de funciones de FLux.",
-    "description": "Descripción de la función de FLux"
-  },
-  "message.featuresNanobanana": {
-    "message": "Activar o desactivar el módulo de funciones de Nano Banana.",
-    "description": "Descripción de la función de Nano Banana"
-  },
-  "message.featuresSeedream": {
-    "message": "Activar o desactivar el módulo de funciones de SeeDream.",
-    "description": "Descripción de la función de SeeDream"
-  },
-  "message.featuresSeedance": {
-    "message": "Activar o desactivar el módulo de funciones de SeeDance.",
-    "description": "Descripción de la función de SeeDance"
-  },
-  "message.featuresWan": {
-    "message": "Activar o desactivar el módulo de funciones de Wan.",
-    "description": "Descripción de la función de Wan"
-  },
-  "message.featuresProducer": {
-    "message": "Activar o desactivar el módulo de funciones de Producer.",
-    "description": "Descripción de la función de Producer"
-  },
-  "message.featuresKimi": {
-    "message": "Activar o desactivar el módulo de funciones de Kimi.",
-    "description": "Descripción de la función de Kimi"
-  },
-  "message.featuresSerp": {
-    "message": "Activar o desactivar el módulo de funciones de SERP.",
-    "description": "Descripción de la función de SERP"
-  },
-  "message.featuresLuma": {
-    "message": "Activar o desactivar el módulo de funciones de Luma.",
-    "description": "Descripción de la función de Luma"
-  },
-  "message.featuresPika": {
-    "message": "Activar o desactivar el módulo de funciones de Pika.",
-    "description": "Descripción de la función de Pika"
-  },
-  "message.featuresKling": {
-    "message": "Activar o desactivar el módulo de funciones de Kling.",
-    "description": "Descripción de la función de Kling"
-  },
-  "message.featuresHailuo": {
-    "message": "Activar o desactivar el módulo de funciones de Hailuo.",
-    "description": "Descripción de la función de Hailuo"
-  },
-  "message.featuresHeadshots": {
-    "message": "Activar o desactivar el módulo de funciones de fotos de identificación AI.",
-    "description": "Descripción de la función de fotos de identificación AI"
-  },
-  "message.featuresSupport": {
-    "message": "Activar o desactivar el soporte al cliente",
-    "description": "Descripción de la función de soporte"
-  },
-  "message.featuresI18n": {
-    "message": "Activar o desactivar el soporte multilingüe. Al desactivarlo, los usuarios solo podrán usar el idioma predeterminado.",
-    "description": "Descripción del soporte multilingüe"
-  },
-  "button.upload": {
-    "message": "Subir",
-    "description": "Subir"
-  },
-  "button.enabled": {
-    "message": "Habilitado",
-    "description": "Texto del interruptor que indica que está habilitado"
-  },
-  "button.disabled": {
-    "message": "Deshabilitado",
-    "description": "Texto del interruptor que indica que está deshabilitado"
-  },
-  "field.featuresGemini": {
-    "message": "Gemini",
-    "description": "Mostrado como el título en el cuadro de edición"
-  },
-  "message.featuresGemini": {
-    "message": "Activar o desactivar el módulo de funciones de Gemini.",
-    "description": "Descripción de la función de Gemini"
-  },
-  "field.featuresClaude": {
-    "message": "Claude",
-    "description": "Mostrado como el título en el cuadro de edición"
-  },
-  "message.featuresClaude": {
-    "message": "Activar o desactivar el módulo de funciones de Claude.",
-    "description": "Descripción de la función de Claude"
-  }
+  "field.title": [
+    [
+      "message",
+      "Título del sitio"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "field.origin": [
+    [
+      "message",
+      "Dominio del sitio"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "field.description": [
+    [
+      "message",
+      "Descripción del sitio"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "field.keywords": [
+    [
+      "message",
+      "Palabras clave del sitio"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "field.logo": [
+    [
+      "message",
+      "Logo del sitio"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "field.favicon": [
+    [
+      "message",
+      "Favicon del sitio"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "field.qr": [
+    [
+      "message",
+      "Código QR"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "field.url": [
+    [
+      "message",
+      "Enlace"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "field.admins": [
+    [
+      "message",
+      "ID de administradores del sitio"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "field.distributionDefaultInviterId": [
+    [
+      "message",
+      "ID del invitador por defecto"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "field.distributionForceInviterId": [
+    [
+      "message",
+      "ID del invitador forzado"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "field.featuresChat": [
+    [
+      "message",
+      "Chat"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "field.featuresVeo": [
+    [
+      "message",
+      "Veo"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "field.featuresSora": [
+    [
+      "message",
+      "Sora"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "field.featuresGrok": [
+    [
+      "message",
+      "Grok"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "field.featuresDeepseek": [
+    [
+      "message",
+      "Deepseek"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "field.featuresChatgpt": [
+    [
+      "message",
+      "ChatGPT"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "field.featuresMidjourney": [
+    [
+      "message",
+      "Midjourney"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "field.featuresChatdoc": [
+    [
+      "message",
+      "Chatdoc"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "field.featuresQrart": [
+    [
+      "message",
+      "Qrart"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "field.featuresLuma": [
+    [
+      "message",
+      "Luma"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "field.featuresPixverse": [
+    [
+      "message",
+      "Pixverse"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "field.featuresPika": [
+    [
+      "message",
+      "Pika"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "field.featuresKling": [
+    [
+      "message",
+      "Kling"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "field.featuresHailuo": [
+    [
+      "message",
+      "Hailuo"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "field.featuresHeadshots": [
+    [
+      "message",
+      "Foto de identificación AI"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "field.featuresSuno": [
+    [
+      "message",
+      "Suno"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "field.featuresFlux": [
+    [
+      "message",
+      "Flux"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "field.featuresNanobanana": [
+    [
+      "message",
+      "Nano Banana"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "field.featuresOpenaiimage": {
+    "message": "OpenAI Image",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresSeedream": [
+    [
+      "message",
+      "SeeDream"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "field.featuresSeedance": [
+    [
+      "message",
+      "SeeDance"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "field.featuresWan": [
+    [
+      "message",
+      "Wan"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "field.featuresProducer": [
+    [
+      "message",
+      "Productor"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "field.featuresKimi": [
+    [
+      "message",
+      "Kimi"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "field.featuresSerp": [
+    [
+      "message",
+      "SERP"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "field.featuresSupport": [
+    [
+      "message",
+      "Soporte al cliente"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "field.featuresI18n": [
+    [
+      "message",
+      "Soporte multilingüe"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "title.basicConfig": [
+    [
+      "message",
+      "Configuración básica"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "title.seoConfig": [
+    [
+      "message",
+      "Configuración SEO"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "title.editAdmins": [
+    [
+      "message",
+      "Editar administradores"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "title.featuresConfig": [
+    [
+      "message",
+      "Configuración de funciones"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "title.editTitle": [
+    [
+      "message",
+      "Editar título"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "title.editOrigin": [
+    [
+      "message",
+      "Editar dominio"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "title.editKeywords": [
+    [
+      "message",
+      "Editar palabras clave"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "title.editLogo": [
+    [
+      "message",
+      "Editar logo"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "title.editFavicon": [
+    [
+      "message",
+      "Editar favicon"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "title.editDescription": [
+    [
+      "message",
+      "Editar descripción"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "title.distributionConfig": [
+    [
+      "message",
+      "Configuración de distribución"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "title.editDistributionDefaultInviterId": [
+    [
+      "message",
+      "Editar invitador por defecto"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "title.editDistributionForceInviterId": [
+    [
+      "message",
+      "Editar invitador forzado"
+    ],
+    [
+      "description",
+      "Texto que se muestra en el cuadro de edición"
+    ]
+  ],
+  "title.editQR": [
+    [
+      "message",
+      "Editar QR"
+    ],
+    [
+      "description",
+      "Título mostrado en el cuadro de edición"
+    ]
+  ],
+  "title.editUrl": [
+    [
+      "message",
+      "Editar enlace"
+    ],
+    [
+      "description",
+      "Título mostrado en el cuadro de edición"
+    ]
+  ],
+  "placeholder.title": [
+    [
+      "message",
+      "Ingrese el título del sitio"
+    ],
+    [
+      "description",
+      "Texto mostrado en el cuadro de edición"
+    ]
+  ],
+  "placeholder.origin": [
+    [
+      "message",
+      "Ingrese el dominio del sitio"
+    ],
+    [
+      "description",
+      "Texto mostrado en el cuadro de edición"
+    ]
+  ],
+  "placeholder.editUrl": [
+    [
+      "message",
+      "Ingrese el enlace"
+    ],
+    [
+      "description",
+      "Texto mostrado en el cuadro de edición"
+    ]
+  ],
+  "placeholder.description": [
+    [
+      "message",
+      "Ingrese la descripción del sitio"
+    ],
+    [
+      "description",
+      "Texto mostrado en el cuadro de edición"
+    ]
+  ],
+  "placeholder.keywords": [
+    [
+      "message",
+      "Ingrese las palabras clave del sitio"
+    ],
+    [
+      "description",
+      "Texto mostrado en el cuadro de edición"
+    ]
+  ],
+  "placeholder.editDistributionDefaultInviterId": [
+    [
+      "message",
+      "Ingrese el ID del invitador predeterminado"
+    ],
+    [
+      "description",
+      "Texto mostrado en el cuadro de edición"
+    ]
+  ],
+  "placeholder.editDistributionForceInviterId": [
+    [
+      "message",
+      "Ingrese el ID del invitador forzado"
+    ],
+    [
+      "description",
+      "Texto mostrado en el cuadro de edición"
+    ]
+  ],
+  "message.uploadImageExceed": [
+    [
+      "message",
+      "La imagen subida excede el límite"
+    ],
+    [
+      "description",
+      "Mensaje de advertencia cuando la imagen subida excede el límite"
+    ]
+  ],
+  "message.uploadImageError": [
+    [
+      "message",
+      "Error al subir la imagen"
+    ],
+    [
+      "description",
+      "Mensaje de error al subir la imagen"
+    ]
+  ],
+  "message.editLogoTip": [
+    [
+      "message",
+      "Tamaño recomendado: 200*60px"
+    ],
+    [
+      "description",
+      "Texto de sugerencia para la imagen subida"
+    ]
+  ],
+  "message.editQRTip": [
+    [
+      "message",
+      "Tamaño recomendado: 200*200px"
+    ],
+    [
+      "description",
+      "Texto de sugerencia para la imagen subida"
+    ]
+  ],
+  "message.editFaviconTip": [
+    [
+      "message",
+      "Tamaño recomendado: 32*32px"
+    ],
+    [
+      "description",
+      "Texto de sugerencia para la imagen subida"
+    ]
+  ],
+  "message.editUrl": [
+    [
+      "message",
+      "Ingrese el enlace"
+    ],
+    [
+      "description",
+      "Sugerencia para ingresar el enlace"
+    ]
+  ],
+  "message.atLeastOneAdmin": [
+    [
+      "message",
+      "Mantenga al menos un administrador"
+    ],
+    [
+      "description",
+      "Mensaje de advertencia para mantener al menos un administrador"
+    ]
+  ],
+  "message.distributionDefaultInviterIdTip": [
+    [
+      "message",
+      "ID de usuario del invitador predeterminado. Si el enlace de distribución no incluye el parámetro inviter_id, se usará este ID como invitador por defecto."
+    ],
+    [
+      "description",
+      "Sugerencia para el ID del invitador predeterminado"
+    ]
+  ],
+  "message.distributionForceInviterIdTip": [
+    [
+      "message",
+      "ID de usuario del invitador forzado. Si se establece este ID, se usará forzosamente como invitador, independientemente de si el enlace de distribución incluye el parámetro inviter_id."
+    ],
+    [
+      "description",
+      "Sugerencia para el ID del invitador forzado"
+    ]
+  ],
+  "message.originTip": [
+    [
+      "message",
+      "Dominio del sitio. La configuración del sitio está vinculada al dominio y no se puede cambiar."
+    ],
+    [
+      "description",
+      "Sugerencia para el dominio del sitio"
+    ]
+  ],
+  "message.titleTip": [
+    [
+      "message",
+      "Título del sitio, mostrado en la pestaña del navegador."
+    ],
+    [
+      "description",
+      "Sugerencia para el título del sitio"
+    ]
+  ],
+  "message.descriptionTip": [
+    [
+      "message",
+      "Descripción del sitio, ubicada en la metainformación del sitio, utilizada para la optimización SEO."
+    ],
+    [
+      "description",
+      "Sugerencia para la descripción del sitio"
+    ]
+  ],
+  "message.logoTip": [
+    [
+      "message",
+      "Logo del sitio, mostrado en la parte superior del menú del sitio cuando se expande."
+    ],
+    [
+      "description",
+      "Sugerencia para el logo del sitio"
+    ]
+  ],
+  "message.faviconTip": [
+    [
+      "message",
+      "Favicon del sitio, mostrado en la pestaña del navegador."
+    ],
+    [
+      "description",
+      "Sugerencia para el favicon del sitio"
+    ]
+  ],
+  "message.adminsTip": [
+    [
+      "message",
+      "ID de administrador del sitio. Por defecto, el primer usuario que crea el sitio será el administrador. Solo los administradores del sitio pueden gestionarlo."
+    ],
+    [
+      "description",
+      "Sugerencia para los administradores del sitio"
+    ]
+  ],
+  "message.adminsTip2": [
+    [
+      "message",
+      "Puede agregar o eliminar ID de administradores aquí. Puede ver los ID de usuario en https://auth.acedata.cloud"
+    ],
+    [
+      "description",
+      "Sugerencia para los administradores del sitio"
+    ]
+  ],
+  "message.keywordsTip": [
+    [
+      "message",
+      "Palabras clave del sitio, ubicadas en la metainformación del sitio, utilizadas para la optimización SEO."
+    ],
+    [
+      "description",
+      "Sugerencia para las palabras clave del sitio"
+    ]
+  ],
+  "message.keywordsTip2": [
+    [
+      "message",
+      "Puede agregar o eliminar palabras clave del sitio aquí. Cuanto más precisas sean las palabras clave, mejor será para la optimización SEO."
+    ],
+    [
+      "description",
+      "Sugerencia para las palabras clave del sitio"
+    ]
+  ],
+  "message.featuresChat": [
+    [
+      "message",
+      "Activar o desactivar el módulo de función de Chat."
+    ],
+    [
+      "description",
+      "Descripción de la función de Chat"
+    ]
+  ],
+  "message.featuresGrok": [
+    [
+      "message",
+      "Activar o desactivar el módulo de función de Grok."
+    ],
+    [
+      "description",
+      "Descripción de la función de Grok"
+    ]
+  ],
+  "message.featuresDeepseek": [
+    [
+      "message",
+      "Activar o desactivar el módulo de función de Deepseek."
+    ],
+    [
+      "description",
+      "Descripción de la función de Deepseek"
+    ]
+  ],
+  "message.featuresChatgpt": [
+    [
+      "message",
+      "Activar o desactivar el módulo de función de ChatGPT."
+    ],
+    [
+      "description",
+      "Descripción de la función de ChatGPT"
+    ]
+  ],
+  "message.featuresMidjourney": [
+    [
+      "message",
+      "Activar o desactivar el módulo de función de Midjourney."
+    ],
+    [
+      "description",
+      "Descripción de la función de Midjourney"
+    ]
+  ],
+  "message.featuresChatdoc": [
+    [
+      "message",
+      "Activar o desactivar el módulo de función de Chatdoc."
+    ],
+    [
+      "description",
+      "Descripción de la función de Chatdoc"
+    ]
+  ],
+  "message.featuresQrart": [
+    [
+      "message",
+      "Activar o desactivar el módulo de función de Qrart."
+    ],
+    [
+      "description",
+      "Descripción de la función de Qrart"
+    ]
+  ],
+  "message.featuresVeo": [
+    [
+      "message",
+      "Activar o desactivar el módulo de función de Veo."
+    ],
+    [
+      "description",
+      "Descripción de la función de Veo"
+    ]
+  ],
+  "message.featuresSora": [
+    [
+      "message",
+      "Activar o desactivar el módulo de función de Sora."
+    ],
+    [
+      "description",
+      "Descripción de la función de Sora"
+    ]
+  ],
+  "message.featuresSuno": [
+    [
+      "message",
+      "Activar o desactivar el módulo de función de Suno."
+    ],
+    [
+      "description",
+      "Descripción de la función de Suno"
+    ]
+  ],
+  "message.featuresPixverse": [
+    [
+      "message",
+      "Activar o desactivar el módulo de funciones de Pixverse."
+    ],
+    [
+      "description",
+      "Descripción de la función de Pixverse"
+    ]
+  ],
+  "message.featuresFlux": [
+    [
+      "message",
+      "Activar o desactivar el módulo de funciones de FLux."
+    ],
+    [
+      "description",
+      "Descripción de la función de FLux"
+    ]
+  ],
+  "message.featuresNanobanana": [
+    [
+      "message",
+      "Activar o desactivar el módulo de funciones de Nano Banana."
+    ],
+    [
+      "description",
+      "Descripción de la función de Nano Banana"
+    ]
+  ],
+  "message.featuresOpenaiimage": {
+    "message": "Toggle OpenAI Image feature module.",
+    "description": "Description of the OpenAI Image feature"
+  },
+  "message.featuresSeedream": [
+    [
+      "message",
+      "Activar o desactivar el módulo de funciones de SeeDream."
+    ],
+    [
+      "description",
+      "Descripción de la función de SeeDream"
+    ]
+  ],
+  "message.featuresSeedance": [
+    [
+      "message",
+      "Activar o desactivar el módulo de funciones de SeeDance."
+    ],
+    [
+      "description",
+      "Descripción de la función de SeeDance"
+    ]
+  ],
+  "message.featuresWan": [
+    [
+      "message",
+      "Activar o desactivar el módulo de funciones de Wan."
+    ],
+    [
+      "description",
+      "Descripción de la función de Wan"
+    ]
+  ],
+  "message.featuresProducer": [
+    [
+      "message",
+      "Activar o desactivar el módulo de funciones de Producer."
+    ],
+    [
+      "description",
+      "Descripción de la función de Producer"
+    ]
+  ],
+  "message.featuresKimi": [
+    [
+      "message",
+      "Activar o desactivar el módulo de funciones de Kimi."
+    ],
+    [
+      "description",
+      "Descripción de la función de Kimi"
+    ]
+  ],
+  "message.featuresSerp": [
+    [
+      "message",
+      "Activar o desactivar el módulo de funciones de SERP."
+    ],
+    [
+      "description",
+      "Descripción de la función de SERP"
+    ]
+  ],
+  "message.featuresLuma": [
+    [
+      "message",
+      "Activar o desactivar el módulo de funciones de Luma."
+    ],
+    [
+      "description",
+      "Descripción de la función de Luma"
+    ]
+  ],
+  "message.featuresPika": [
+    [
+      "message",
+      "Activar o desactivar el módulo de funciones de Pika."
+    ],
+    [
+      "description",
+      "Descripción de la función de Pika"
+    ]
+  ],
+  "message.featuresKling": [
+    [
+      "message",
+      "Activar o desactivar el módulo de funciones de Kling."
+    ],
+    [
+      "description",
+      "Descripción de la función de Kling"
+    ]
+  ],
+  "message.featuresHailuo": [
+    [
+      "message",
+      "Activar o desactivar el módulo de funciones de Hailuo."
+    ],
+    [
+      "description",
+      "Descripción de la función de Hailuo"
+    ]
+  ],
+  "message.featuresHeadshots": [
+    [
+      "message",
+      "Activar o desactivar el módulo de funciones de fotos de identificación AI."
+    ],
+    [
+      "description",
+      "Descripción de la función de fotos de identificación AI"
+    ]
+  ],
+  "message.featuresSupport": [
+    [
+      "message",
+      "Activar o desactivar el soporte al cliente"
+    ],
+    [
+      "description",
+      "Descripción de la función de soporte"
+    ]
+  ],
+  "message.featuresI18n": [
+    [
+      "message",
+      "Activar o desactivar el soporte multilingüe. Al desactivarlo, los usuarios solo podrán usar el idioma predeterminado."
+    ],
+    [
+      "description",
+      "Descripción del soporte multilingüe"
+    ]
+  ],
+  "button.upload": [
+    [
+      "message",
+      "Subir"
+    ],
+    [
+      "description",
+      "Subir"
+    ]
+  ],
+  "button.enabled": [
+    [
+      "message",
+      "Habilitado"
+    ],
+    [
+      "description",
+      "Texto del interruptor que indica que está habilitado"
+    ]
+  ],
+  "button.disabled": [
+    [
+      "message",
+      "Deshabilitado"
+    ],
+    [
+      "description",
+      "Texto del interruptor que indica que está deshabilitado"
+    ]
+  ],
+  "field.featuresGemini": [
+    [
+      "message",
+      "Gemini"
+    ],
+    [
+      "description",
+      "Mostrado como el título en el cuadro de edición"
+    ]
+  ],
+  "message.featuresGemini": [
+    [
+      "message",
+      "Activar o desactivar el módulo de funciones de Gemini."
+    ],
+    [
+      "description",
+      "Descripción de la función de Gemini"
+    ]
+  ],
+  "field.featuresClaude": [
+    [
+      "message",
+      "Claude"
+    ],
+    [
+      "description",
+      "Mostrado como el título en el cuadro de edición"
+    ]
+  ],
+  "message.featuresClaude": [
+    [
+      "message",
+      "Activar o desactivar el módulo de funciones de Claude."
+    ],
+    [
+      "description",
+      "Descripción de la función de Claude"
+    ]
+  ]
 }

--- a/src/i18n/fi/site.json
+++ b/src/i18n/fi/site.json
@@ -1,442 +1,1110 @@
 {
-  "field.title": {
-    "message": "Sivuston otsikko",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "field.origin": {
-    "message": "Sivuston verkkotunnus",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "field.description": {
-    "message": "Sivuston kuvaus",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "field.keywords": {
-    "message": "Sivuston avainsanat",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "field.logo": {
-    "message": "Sivuston logo",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "field.favicon": {
-    "message": "Sivuston favicon",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "field.qr": {
-    "message": "QR-koodi",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "field.url": {
-    "message": "Linkki",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "field.admins": {
-    "message": "Sivuston ylläpitäjätunnus",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "field.distributionDefaultInviterId": {
-    "message": "Oletus kutsujan tunnus",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "field.distributionForceInviterId": {
-    "message": "Pakotettu kutsujan tunnus",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "field.featuresChat": {
-    "message": "Chat",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "field.featuresVeo": {
-    "message": "Veo",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "field.featuresSora": {
-    "message": "Sora",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "field.featuresGrok": {
-    "message": "Grok",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "field.featuresDeepseek": {
-    "message": "Deepseek",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "field.featuresChatgpt": {
-    "message": "ChatGPT",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "field.featuresMidjourney": {
-    "message": "Midjourney",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "field.featuresChatdoc": {
-    "message": "Chatdoc",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "field.featuresQrart": {
-    "message": "Qrart",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "field.featuresLuma": {
-    "message": "Luma",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "field.featuresPixverse": {
-    "message": "Pixverse",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "field.featuresPika": {
-    "message": "Pika",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "field.featuresKling": {
-    "message": "Kling",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "field.featuresHailuo": {
-    "message": "Hailuo",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "field.featuresHeadshots": {
-    "message": "AI-profiilikuva",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "field.featuresSuno": {
-    "message": "Suno",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "field.featuresFlux": {
-    "message": "Flux",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "field.featuresNanobanana": {
-    "message": "Nano Banaani",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "field.featuresSeedream": {
-    "message": "SeeDream",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "field.featuresSeedance": {
-    "message": "SeeDance",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "field.featuresWan": {
-    "message": "Wan",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "field.featuresProducer": {
-    "message": "Tuottaja",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "field.featuresKimi": {
-    "message": "Kimi",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "field.featuresSerp": {
-    "message": "SERP",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "field.featuresSupport": {
-    "message": "Asiakastuki",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "field.featuresI18n": {
-    "message": "Monikielinen tuki",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "title.basicConfig": {
-    "message": "Perusasetukset",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "title.seoConfig": {
-    "message": "SEO-asetukset",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "title.editAdmins": {
-    "message": "Muokkaa ylläpitäjiä",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "title.featuresConfig": {
-    "message": "Ominaisuuksien asetukset",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "title.editTitle": {
-    "message": "Muokkaa otsikkoa",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "title.editOrigin": {
-    "message": "Muokkaa verkkotunnusta",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "title.editKeywords": {
-    "message": "Muokkaa avainsanoja",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "title.editLogo": {
-    "message": "Muokkaa logoa",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "title.editFavicon": {
-    "message": "Muokkaa faviconia",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "title.editDescription": {
-    "message": "Muokkaa kuvausta",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "title.distributionConfig": {
-    "message": "Jakeluasetukset",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "title.editDistributionDefaultInviterId": {
-    "message": "Muokkaa oletuskutsujaa",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "title.editDistributionForceInviterId": {
-    "message": "Muokkaa pakotettua kutsujaa",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "title.editQR": {
-    "message": "Muokkaa QR-koodia",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "title.editUrl": {
-    "message": "Muokkaa linkkiä",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "placeholder.title": {
-    "message": "Syötä sivuston otsikko",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "placeholder.origin": {
-    "message": "Syötä sivuston verkkotunnus",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "placeholder.editUrl": {
-    "message": "Syötä linkki",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "placeholder.description": {
-    "message": "Syötä sivuston kuvaus",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "placeholder.keywords": {
-    "message": "Syötä sivuston avainsanat",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "placeholder.editDistributionDefaultInviterId": {
-    "message": "Syötä oletus kutsujan ID",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "placeholder.editDistributionForceInviterId": {
-    "message": "Syötä pakotettu kutsujan ID",
-    "description": "Näytetään muokkausruudun otsikkona"
-  },
-  "message.uploadImageExceed": {
-    "message": "Kuvan lataus ylittää rajan",
-    "description": "Vihje kuvan lataamisen ylittämisestä"
-  },
-  "message.uploadImageError": {
-    "message": "Kuvan latausvirhe",
-    "description": "Vihje kuvan latausvirheestä"
-  },
-  "message.editLogoTip": {
-    "message": "Suositeltu koko: 200*60px",
-    "description": "Vihje kuvan lataamisesta"
-  },
-  "message.editQRTip": {
-    "message": "Suositeltu koko: 200*200px",
-    "description": "Vihje kuvan lataamisesta"
-  },
-  "message.editFaviconTip": {
-    "message": "Suositeltu koko: 32*32px",
-    "description": "Vihje kuvan lataamisesta"
-  },
-  "message.editUrl": {
-    "message": "Syötä linkki",
-    "description": "Vihje linkin syöttämisestä"
-  },
-  "message.atLeastOneAdmin": {
-    "message": "Vähintään yksi ylläpitäjä on säilytettävä",
-    "description": "Vihje vähintään yhdestä ylläpitäjästä"
-  },
-  "message.distributionDefaultInviterIdTip": {
-    "message": "Oletuskutsujan käyttäjän ID, jos jakolinkki ei sisällä inviter_id-parametria, käytetään oletuksena tätä käyttäjän ID:tä kutsujana.",
-    "description": "Oletuskutsujan ID:n vihje"
-  },
-  "message.distributionForceInviterIdTip": {
-    "message": "Pakotetun kutsujan käyttäjän ID, jos tämä ID on asetettu, käytetään pakotetusti tätä käyttäjän ID:tä kutsujana riippumatta siitä, sisältääkö jakolinkki inviter_id-parametrin.",
-    "description": "Pakotetun kutsujan ID:n vihje"
-  },
-  "message.originTip": {
-    "message": "Sivuston verkkotunnus, sivuston asetukset on sidottu verkkotunnukseen, verkkotunnusta ei voi muuttaa.",
-    "description": "Sivuston verkkotunnuksen vihje"
-  },
-  "message.titleTip": {
-    "message": "Sivuston otsikko, näytetään selaimen välilehdessä.",
-    "description": "Sivuston otsikon vihje"
-  },
-  "message.descriptionTip": {
-    "message": "Sivuston kuvaus, sijaitsee sivuston metatiedoissa, käytetään sivuston SEO-optimointiin.",
-    "description": "Sivuston kuvauksen vihje"
-  },
-  "message.logoTip": {
-    "message": "Sivuston logo, näytetään sivuston valikon yläosassa, kun valikko on avattu.",
-    "description": "Sivuston logon vihje"
-  },
-  "message.faviconTip": {
-    "message": "Sivuston favicon, näytetään selaimen välilehdessä.",
-    "description": "Sivuston faviconin vihje"
-  },
-  "message.adminsTip": {
-    "message": "Sivuston ylläpitäjän ID, oletuksena ensimmäinen sivuston luonut käyttäjä on ylläpitäjä, vain sivuston ylläpitäjät voivat hallita sivustoa.",
-    "description": "Sivuston ylläpitäjien vihje"
-  },
-  "message.adminsTip2": {
-    "message": "Voit lisätä tai poistaa ylläpitäjän ID:tä täältä, voit tarkistaa käyttäjän ID:n osoitteesta https://auth.acedata.cloud",
-    "description": "Sivuston ylläpitäjien vihje"
-  },
-  "message.keywordsTip": {
-    "message": "Sivuston avainsanat, sijaitsee sivuston metatiedoissa, käytetään sivuston SEO-optimointiin.",
-    "description": "Sivuston avainsanojen vihje"
-  },
-  "message.keywordsTip2": {
-    "message": "Voit lisätä tai poistaa sivuston avainsanoja täältä, mitä tarkempia avainsanoja käytetään, sitä parempi SEO-optimointi.",
-    "description": "Sivuston avainsanojen vihje"
-  },
-  "message.featuresChat": {
-    "message": "Avaa tai sulje Chat-toimintomoduuli.",
-    "description": "Chat-toiminnon kuvaus"
-  },
-  "message.featuresGrok": {
-    "message": "Avaa tai sulje Grok-toimintomoduuli.",
-    "description": "Grok-toiminnon kuvaus"
-  },
-  "message.featuresDeepseek": {
-    "message": "Avaa tai sulje Deepseek-toimintomoduuli.",
-    "description": "Deepseek-toiminnon kuvaus"
-  },
-  "message.featuresChatgpt": {
-    "message": "Avaa tai sulje ChatGPT-toimintomoduuli.",
-    "description": "ChatGPT-toiminnon kuvaus"
-  },
-  "message.featuresMidjourney": {
-    "message": "Avaa tai sulje Midjourney-toimintomoduuli.",
-    "description": "Midjourney-toiminnon kuvaus"
-  },
-  "message.featuresChatdoc": {
-    "message": "Avaa tai sulje Chatdoc-toimintomoduuli.",
-    "description": "Chatdoc-toiminnon kuvaus"
-  },
-  "message.featuresQrart": {
-    "message": "Avaa tai sulje Qrart-toimintomoduuli.",
-    "description": "Qrart-toiminnon kuvaus"
-  },
-  "message.featuresVeo": {
-    "message": "Avaa tai sulje Veo-toimintomoduuli.",
-    "description": "Veo-toiminnon kuvaus"
-  },
-  "message.featuresSora": {
-    "message": "Avaa tai sulje Sora-toimintomoduuli.",
-    "description": "Sora-toiminnon kuvaus"
-  },
-  "message.featuresSuno": {
-    "message": "Avaa tai sulje Suno-toimintomoduuli.",
-    "description": "Suno-toiminnon kuvaus"
-  },
-  "message.featuresPixverse": {
-    "message": "Ota käyttöön tai poista käytöstä Pixverse-ominaisuusmoduuli.",
-    "description": "Pixverse-ominaisuuden kuvaus"
-  },
-  "message.featuresFlux": {
-    "message": "Ota käyttöön tai poista käytöstä FLux-ominaisuusmoduuli.",
-    "description": "FLux-ominaisuuden kuvaus"
-  },
-  "message.featuresNanobanana": {
-    "message": "Ota käyttöön tai poista käytöstä Nano Banana -ominaisuusmoduuli.",
-    "description": "Nano Banana -ominaisuuden kuvaus"
-  },
-  "message.featuresSeedream": {
-    "message": "Ota käyttöön tai poista käytöstä SeeDream-ominaisuusmoduuli.",
-    "description": "SeeDream-ominaisuuden kuvaus"
-  },
-  "message.featuresSeedance": {
-    "message": "Ota käyttöön tai poista käytöstä SeeDance-ominaisuusmoduuli.",
-    "description": "SeeDance-ominaisuuden kuvaus"
-  },
-  "message.featuresWan": {
-    "message": "Ota käyttöön tai poista käytöstä Wan-ominaisuusmoduuli.",
-    "description": "Wan-ominaisuuden kuvaus"
-  },
-  "message.featuresProducer": {
-    "message": "Ota käyttöön tai poista käytöstä Producer-ominaisuusmoduuli.",
-    "description": "Producer-ominaisuuden kuvaus"
-  },
-  "message.featuresKimi": {
-    "message": "Ota käyttöön tai poista käytöstä Kimi-ominaisuusmoduuli.",
-    "description": "Kimi-ominaisuuden kuvaus"
-  },
-  "message.featuresSerp": {
-    "message": "Ota käyttöön tai poista käytöstä SERP-ominaisuusmoduuli.",
-    "description": "SERP-ominaisuuden kuvaus"
-  },
-  "message.featuresLuma": {
-    "message": "Ota käyttöön tai poista käytöstä Luma-ominaisuusmoduuli.",
-    "description": "Luma-ominaisuuden kuvaus"
-  },
-  "message.featuresPika": {
-    "message": "Ota käyttöön tai poista käytöstä Pika-ominaisuusmoduuli.",
-    "description": "Pika-ominaisuuden kuvaus"
-  },
-  "message.featuresKling": {
-    "message": "Ota käyttöön tai poista käytöstä Kling-ominaisuusmoduuli.",
-    "description": "Kling-ominaisuuden kuvaus"
-  },
-  "message.featuresHailuo": {
-    "message": "Ota käyttöön tai poista käytöstä Hailuo-ominaisuusmoduuli.",
-    "description": "Hailuo-ominaisuuden kuvaus"
-  },
-  "message.featuresHeadshots": {
-    "message": "Ota käyttöön tai poista käytöstä AI-asiakirjakuvamoduuli.",
-    "description": "AI-asiakirjakuvan kuvaus"
-  },
-  "message.featuresSupport": {
-    "message": "Ota käyttöön tai poista käytöstä asiakastuki",
-    "description": "Tuen kuvaus"
-  },
-  "message.featuresI18n": {
-    "message": "Ota käyttöön tai poista käytöstä monikielinen tuki, sulkemisen jälkeen käyttäjä voi käyttää vain oletuskieltä.",
-    "description": "Monikielisen tuen kuvaus"
-  },
-  "button.upload": {
-    "message": "Lataa",
-    "description": "Lataa"
-  },
-  "button.enabled": {
-    "message": "Otetaan käyttöön",
-    "description": "Kytkin teksti, joka osoittaa, että se on otettu käyttöön"
-  },
-  "button.disabled": {
-    "message": "Poistettu käytöstä",
-    "description": "Kytkin teksti, joka osoittaa, että se on poistettu käytöstä"
-  },
-  "field.featuresGemini": {
-    "message": "Gemini",
-    "description": "Näytetään otsikkona muokkausruudussa"
-  },
-  "message.featuresGemini": {
-    "message": "Ota käyttöön tai poista käytöstä Gemini-ominaisuusmoduuli.",
-    "description": "Gemini-ominaisuuden kuvaus"
-  },
-  "field.featuresClaude": {
-    "message": "Claude",
-    "description": "Näytetään otsikkona muokkausruudussa"
-  },
-  "message.featuresClaude": {
-    "message": "Ota käyttöön tai poista käytöstä Claude-ominaisuusmoduuli.",
-    "description": "Claude-ominaisuuden kuvaus"
-  }
+  "field.title": [
+    [
+      "message",
+      "Sivuston otsikko"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "field.origin": [
+    [
+      "message",
+      "Sivuston verkkotunnus"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "field.description": [
+    [
+      "message",
+      "Sivuston kuvaus"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "field.keywords": [
+    [
+      "message",
+      "Sivuston avainsanat"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "field.logo": [
+    [
+      "message",
+      "Sivuston logo"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "field.favicon": [
+    [
+      "message",
+      "Sivuston favicon"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "field.qr": [
+    [
+      "message",
+      "QR-koodi"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "field.url": [
+    [
+      "message",
+      "Linkki"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "field.admins": [
+    [
+      "message",
+      "Sivuston ylläpitäjätunnus"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "field.distributionDefaultInviterId": [
+    [
+      "message",
+      "Oletus kutsujan tunnus"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "field.distributionForceInviterId": [
+    [
+      "message",
+      "Pakotettu kutsujan tunnus"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "field.featuresChat": [
+    [
+      "message",
+      "Chat"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "field.featuresVeo": [
+    [
+      "message",
+      "Veo"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "field.featuresSora": [
+    [
+      "message",
+      "Sora"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "field.featuresGrok": [
+    [
+      "message",
+      "Grok"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "field.featuresDeepseek": [
+    [
+      "message",
+      "Deepseek"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "field.featuresChatgpt": [
+    [
+      "message",
+      "ChatGPT"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "field.featuresMidjourney": [
+    [
+      "message",
+      "Midjourney"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "field.featuresChatdoc": [
+    [
+      "message",
+      "Chatdoc"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "field.featuresQrart": [
+    [
+      "message",
+      "Qrart"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "field.featuresLuma": [
+    [
+      "message",
+      "Luma"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "field.featuresPixverse": [
+    [
+      "message",
+      "Pixverse"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "field.featuresPika": [
+    [
+      "message",
+      "Pika"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "field.featuresKling": [
+    [
+      "message",
+      "Kling"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "field.featuresHailuo": [
+    [
+      "message",
+      "Hailuo"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "field.featuresHeadshots": [
+    [
+      "message",
+      "AI-profiilikuva"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "field.featuresSuno": [
+    [
+      "message",
+      "Suno"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "field.featuresFlux": [
+    [
+      "message",
+      "Flux"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "field.featuresNanobanana": [
+    [
+      "message",
+      "Nano Banaani"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "field.featuresOpenaiimage": {
+    "message": "OpenAI Image",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresSeedream": [
+    [
+      "message",
+      "SeeDream"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "field.featuresSeedance": [
+    [
+      "message",
+      "SeeDance"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "field.featuresWan": [
+    [
+      "message",
+      "Wan"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "field.featuresProducer": [
+    [
+      "message",
+      "Tuottaja"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "field.featuresKimi": [
+    [
+      "message",
+      "Kimi"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "field.featuresSerp": [
+    [
+      "message",
+      "SERP"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "field.featuresSupport": [
+    [
+      "message",
+      "Asiakastuki"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "field.featuresI18n": [
+    [
+      "message",
+      "Monikielinen tuki"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "title.basicConfig": [
+    [
+      "message",
+      "Perusasetukset"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "title.seoConfig": [
+    [
+      "message",
+      "SEO-asetukset"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "title.editAdmins": [
+    [
+      "message",
+      "Muokkaa ylläpitäjiä"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "title.featuresConfig": [
+    [
+      "message",
+      "Ominaisuuksien asetukset"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "title.editTitle": [
+    [
+      "message",
+      "Muokkaa otsikkoa"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "title.editOrigin": [
+    [
+      "message",
+      "Muokkaa verkkotunnusta"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "title.editKeywords": [
+    [
+      "message",
+      "Muokkaa avainsanoja"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "title.editLogo": [
+    [
+      "message",
+      "Muokkaa logoa"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "title.editFavicon": [
+    [
+      "message",
+      "Muokkaa faviconia"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "title.editDescription": [
+    [
+      "message",
+      "Muokkaa kuvausta"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "title.distributionConfig": [
+    [
+      "message",
+      "Jakeluasetukset"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "title.editDistributionDefaultInviterId": [
+    [
+      "message",
+      "Muokkaa oletuskutsujaa"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "title.editDistributionForceInviterId": [
+    [
+      "message",
+      "Muokkaa pakotettua kutsujaa"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "title.editQR": [
+    [
+      "message",
+      "Muokkaa QR-koodia"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "title.editUrl": [
+    [
+      "message",
+      "Muokkaa linkkiä"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "placeholder.title": [
+    [
+      "message",
+      "Syötä sivuston otsikko"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "placeholder.origin": [
+    [
+      "message",
+      "Syötä sivuston verkkotunnus"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "placeholder.editUrl": [
+    [
+      "message",
+      "Syötä linkki"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "placeholder.description": [
+    [
+      "message",
+      "Syötä sivuston kuvaus"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "placeholder.keywords": [
+    [
+      "message",
+      "Syötä sivuston avainsanat"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "placeholder.editDistributionDefaultInviterId": [
+    [
+      "message",
+      "Syötä oletus kutsujan ID"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "placeholder.editDistributionForceInviterId": [
+    [
+      "message",
+      "Syötä pakotettu kutsujan ID"
+    ],
+    [
+      "description",
+      "Näytetään muokkausruudun otsikkona"
+    ]
+  ],
+  "message.uploadImageExceed": [
+    [
+      "message",
+      "Kuvan lataus ylittää rajan"
+    ],
+    [
+      "description",
+      "Vihje kuvan lataamisen ylittämisestä"
+    ]
+  ],
+  "message.uploadImageError": [
+    [
+      "message",
+      "Kuvan latausvirhe"
+    ],
+    [
+      "description",
+      "Vihje kuvan latausvirheestä"
+    ]
+  ],
+  "message.editLogoTip": [
+    [
+      "message",
+      "Suositeltu koko: 200*60px"
+    ],
+    [
+      "description",
+      "Vihje kuvan lataamisesta"
+    ]
+  ],
+  "message.editQRTip": [
+    [
+      "message",
+      "Suositeltu koko: 200*200px"
+    ],
+    [
+      "description",
+      "Vihje kuvan lataamisesta"
+    ]
+  ],
+  "message.editFaviconTip": [
+    [
+      "message",
+      "Suositeltu koko: 32*32px"
+    ],
+    [
+      "description",
+      "Vihje kuvan lataamisesta"
+    ]
+  ],
+  "message.editUrl": [
+    [
+      "message",
+      "Syötä linkki"
+    ],
+    [
+      "description",
+      "Vihje linkin syöttämisestä"
+    ]
+  ],
+  "message.atLeastOneAdmin": [
+    [
+      "message",
+      "Vähintään yksi ylläpitäjä on säilytettävä"
+    ],
+    [
+      "description",
+      "Vihje vähintään yhdestä ylläpitäjästä"
+    ]
+  ],
+  "message.distributionDefaultInviterIdTip": [
+    [
+      "message",
+      "Oletuskutsujan käyttäjän ID, jos jakolinkki ei sisällä inviter_id-parametria, käytetään oletuksena tätä käyttäjän ID:tä kutsujana."
+    ],
+    [
+      "description",
+      "Oletuskutsujan ID:n vihje"
+    ]
+  ],
+  "message.distributionForceInviterIdTip": [
+    [
+      "message",
+      "Pakotetun kutsujan käyttäjän ID, jos tämä ID on asetettu, käytetään pakotetusti tätä käyttäjän ID:tä kutsujana riippumatta siitä, sisältääkö jakolinkki inviter_id-parametrin."
+    ],
+    [
+      "description",
+      "Pakotetun kutsujan ID:n vihje"
+    ]
+  ],
+  "message.originTip": [
+    [
+      "message",
+      "Sivuston verkkotunnus, sivuston asetukset on sidottu verkkotunnukseen, verkkotunnusta ei voi muuttaa."
+    ],
+    [
+      "description",
+      "Sivuston verkkotunnuksen vihje"
+    ]
+  ],
+  "message.titleTip": [
+    [
+      "message",
+      "Sivuston otsikko, näytetään selaimen välilehdessä."
+    ],
+    [
+      "description",
+      "Sivuston otsikon vihje"
+    ]
+  ],
+  "message.descriptionTip": [
+    [
+      "message",
+      "Sivuston kuvaus, sijaitsee sivuston metatiedoissa, käytetään sivuston SEO-optimointiin."
+    ],
+    [
+      "description",
+      "Sivuston kuvauksen vihje"
+    ]
+  ],
+  "message.logoTip": [
+    [
+      "message",
+      "Sivuston logo, näytetään sivuston valikon yläosassa, kun valikko on avattu."
+    ],
+    [
+      "description",
+      "Sivuston logon vihje"
+    ]
+  ],
+  "message.faviconTip": [
+    [
+      "message",
+      "Sivuston favicon, näytetään selaimen välilehdessä."
+    ],
+    [
+      "description",
+      "Sivuston faviconin vihje"
+    ]
+  ],
+  "message.adminsTip": [
+    [
+      "message",
+      "Sivuston ylläpitäjän ID, oletuksena ensimmäinen sivuston luonut käyttäjä on ylläpitäjä, vain sivuston ylläpitäjät voivat hallita sivustoa."
+    ],
+    [
+      "description",
+      "Sivuston ylläpitäjien vihje"
+    ]
+  ],
+  "message.adminsTip2": [
+    [
+      "message",
+      "Voit lisätä tai poistaa ylläpitäjän ID:tä täältä, voit tarkistaa käyttäjän ID:n osoitteesta https://auth.acedata.cloud"
+    ],
+    [
+      "description",
+      "Sivuston ylläpitäjien vihje"
+    ]
+  ],
+  "message.keywordsTip": [
+    [
+      "message",
+      "Sivuston avainsanat, sijaitsee sivuston metatiedoissa, käytetään sivuston SEO-optimointiin."
+    ],
+    [
+      "description",
+      "Sivuston avainsanojen vihje"
+    ]
+  ],
+  "message.keywordsTip2": [
+    [
+      "message",
+      "Voit lisätä tai poistaa sivuston avainsanoja täältä, mitä tarkempia avainsanoja käytetään, sitä parempi SEO-optimointi."
+    ],
+    [
+      "description",
+      "Sivuston avainsanojen vihje"
+    ]
+  ],
+  "message.featuresChat": [
+    [
+      "message",
+      "Avaa tai sulje Chat-toimintomoduuli."
+    ],
+    [
+      "description",
+      "Chat-toiminnon kuvaus"
+    ]
+  ],
+  "message.featuresGrok": [
+    [
+      "message",
+      "Avaa tai sulje Grok-toimintomoduuli."
+    ],
+    [
+      "description",
+      "Grok-toiminnon kuvaus"
+    ]
+  ],
+  "message.featuresDeepseek": [
+    [
+      "message",
+      "Avaa tai sulje Deepseek-toimintomoduuli."
+    ],
+    [
+      "description",
+      "Deepseek-toiminnon kuvaus"
+    ]
+  ],
+  "message.featuresChatgpt": [
+    [
+      "message",
+      "Avaa tai sulje ChatGPT-toimintomoduuli."
+    ],
+    [
+      "description",
+      "ChatGPT-toiminnon kuvaus"
+    ]
+  ],
+  "message.featuresMidjourney": [
+    [
+      "message",
+      "Avaa tai sulje Midjourney-toimintomoduuli."
+    ],
+    [
+      "description",
+      "Midjourney-toiminnon kuvaus"
+    ]
+  ],
+  "message.featuresChatdoc": [
+    [
+      "message",
+      "Avaa tai sulje Chatdoc-toimintomoduuli."
+    ],
+    [
+      "description",
+      "Chatdoc-toiminnon kuvaus"
+    ]
+  ],
+  "message.featuresQrart": [
+    [
+      "message",
+      "Avaa tai sulje Qrart-toimintomoduuli."
+    ],
+    [
+      "description",
+      "Qrart-toiminnon kuvaus"
+    ]
+  ],
+  "message.featuresVeo": [
+    [
+      "message",
+      "Avaa tai sulje Veo-toimintomoduuli."
+    ],
+    [
+      "description",
+      "Veo-toiminnon kuvaus"
+    ]
+  ],
+  "message.featuresSora": [
+    [
+      "message",
+      "Avaa tai sulje Sora-toimintomoduuli."
+    ],
+    [
+      "description",
+      "Sora-toiminnon kuvaus"
+    ]
+  ],
+  "message.featuresSuno": [
+    [
+      "message",
+      "Avaa tai sulje Suno-toimintomoduuli."
+    ],
+    [
+      "description",
+      "Suno-toiminnon kuvaus"
+    ]
+  ],
+  "message.featuresPixverse": [
+    [
+      "message",
+      "Ota käyttöön tai poista käytöstä Pixverse-ominaisuusmoduuli."
+    ],
+    [
+      "description",
+      "Pixverse-ominaisuuden kuvaus"
+    ]
+  ],
+  "message.featuresFlux": [
+    [
+      "message",
+      "Ota käyttöön tai poista käytöstä FLux-ominaisuusmoduuli."
+    ],
+    [
+      "description",
+      "FLux-ominaisuuden kuvaus"
+    ]
+  ],
+  "message.featuresNanobanana": [
+    [
+      "message",
+      "Ota käyttöön tai poista käytöstä Nano Banana -ominaisuusmoduuli."
+    ],
+    [
+      "description",
+      "Nano Banana -ominaisuuden kuvaus"
+    ]
+  ],
+  "message.featuresOpenaiimage": {
+    "message": "Toggle OpenAI Image feature module.",
+    "description": "Description of the OpenAI Image feature"
+  },
+  "message.featuresSeedream": [
+    [
+      "message",
+      "Ota käyttöön tai poista käytöstä SeeDream-ominaisuusmoduuli."
+    ],
+    [
+      "description",
+      "SeeDream-ominaisuuden kuvaus"
+    ]
+  ],
+  "message.featuresSeedance": [
+    [
+      "message",
+      "Ota käyttöön tai poista käytöstä SeeDance-ominaisuusmoduuli."
+    ],
+    [
+      "description",
+      "SeeDance-ominaisuuden kuvaus"
+    ]
+  ],
+  "message.featuresWan": [
+    [
+      "message",
+      "Ota käyttöön tai poista käytöstä Wan-ominaisuusmoduuli."
+    ],
+    [
+      "description",
+      "Wan-ominaisuuden kuvaus"
+    ]
+  ],
+  "message.featuresProducer": [
+    [
+      "message",
+      "Ota käyttöön tai poista käytöstä Producer-ominaisuusmoduuli."
+    ],
+    [
+      "description",
+      "Producer-ominaisuuden kuvaus"
+    ]
+  ],
+  "message.featuresKimi": [
+    [
+      "message",
+      "Ota käyttöön tai poista käytöstä Kimi-ominaisuusmoduuli."
+    ],
+    [
+      "description",
+      "Kimi-ominaisuuden kuvaus"
+    ]
+  ],
+  "message.featuresSerp": [
+    [
+      "message",
+      "Ota käyttöön tai poista käytöstä SERP-ominaisuusmoduuli."
+    ],
+    [
+      "description",
+      "SERP-ominaisuuden kuvaus"
+    ]
+  ],
+  "message.featuresLuma": [
+    [
+      "message",
+      "Ota käyttöön tai poista käytöstä Luma-ominaisuusmoduuli."
+    ],
+    [
+      "description",
+      "Luma-ominaisuuden kuvaus"
+    ]
+  ],
+  "message.featuresPika": [
+    [
+      "message",
+      "Ota käyttöön tai poista käytöstä Pika-ominaisuusmoduuli."
+    ],
+    [
+      "description",
+      "Pika-ominaisuuden kuvaus"
+    ]
+  ],
+  "message.featuresKling": [
+    [
+      "message",
+      "Ota käyttöön tai poista käytöstä Kling-ominaisuusmoduuli."
+    ],
+    [
+      "description",
+      "Kling-ominaisuuden kuvaus"
+    ]
+  ],
+  "message.featuresHailuo": [
+    [
+      "message",
+      "Ota käyttöön tai poista käytöstä Hailuo-ominaisuusmoduuli."
+    ],
+    [
+      "description",
+      "Hailuo-ominaisuuden kuvaus"
+    ]
+  ],
+  "message.featuresHeadshots": [
+    [
+      "message",
+      "Ota käyttöön tai poista käytöstä AI-asiakirjakuvamoduuli."
+    ],
+    [
+      "description",
+      "AI-asiakirjakuvan kuvaus"
+    ]
+  ],
+  "message.featuresSupport": [
+    [
+      "message",
+      "Ota käyttöön tai poista käytöstä asiakastuki"
+    ],
+    [
+      "description",
+      "Tuen kuvaus"
+    ]
+  ],
+  "message.featuresI18n": [
+    [
+      "message",
+      "Ota käyttöön tai poista käytöstä monikielinen tuki, sulkemisen jälkeen käyttäjä voi käyttää vain oletuskieltä."
+    ],
+    [
+      "description",
+      "Monikielisen tuen kuvaus"
+    ]
+  ],
+  "button.upload": [
+    [
+      "message",
+      "Lataa"
+    ],
+    [
+      "description",
+      "Lataa"
+    ]
+  ],
+  "button.enabled": [
+    [
+      "message",
+      "Otetaan käyttöön"
+    ],
+    [
+      "description",
+      "Kytkin teksti, joka osoittaa, että se on otettu käyttöön"
+    ]
+  ],
+  "button.disabled": [
+    [
+      "message",
+      "Poistettu käytöstä"
+    ],
+    [
+      "description",
+      "Kytkin teksti, joka osoittaa, että se on poistettu käytöstä"
+    ]
+  ],
+  "field.featuresGemini": [
+    [
+      "message",
+      "Gemini"
+    ],
+    [
+      "description",
+      "Näytetään otsikkona muokkausruudussa"
+    ]
+  ],
+  "message.featuresGemini": [
+    [
+      "message",
+      "Ota käyttöön tai poista käytöstä Gemini-ominaisuusmoduuli."
+    ],
+    [
+      "description",
+      "Gemini-ominaisuuden kuvaus"
+    ]
+  ],
+  "field.featuresClaude": [
+    [
+      "message",
+      "Claude"
+    ],
+    [
+      "description",
+      "Näytetään otsikkona muokkausruudussa"
+    ]
+  ],
+  "message.featuresClaude": [
+    [
+      "message",
+      "Ota käyttöön tai poista käytöstä Claude-ominaisuusmoduuli."
+    ],
+    [
+      "description",
+      "Claude-ominaisuuden kuvaus"
+    ]
+  ]
 }

--- a/src/i18n/fi/site.json
+++ b/src/i18n/fi/site.json
@@ -1,1110 +1,450 @@
 {
-  "field.title": [
-    [
-      "message",
-      "Sivuston otsikko"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "field.origin": [
-    [
-      "message",
-      "Sivuston verkkotunnus"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "field.description": [
-    [
-      "message",
-      "Sivuston kuvaus"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "field.keywords": [
-    [
-      "message",
-      "Sivuston avainsanat"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "field.logo": [
-    [
-      "message",
-      "Sivuston logo"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "field.favicon": [
-    [
-      "message",
-      "Sivuston favicon"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "field.qr": [
-    [
-      "message",
-      "QR-koodi"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "field.url": [
-    [
-      "message",
-      "Linkki"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "field.admins": [
-    [
-      "message",
-      "Sivuston ylläpitäjätunnus"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "field.distributionDefaultInviterId": [
-    [
-      "message",
-      "Oletus kutsujan tunnus"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "field.distributionForceInviterId": [
-    [
-      "message",
-      "Pakotettu kutsujan tunnus"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "field.featuresChat": [
-    [
-      "message",
-      "Chat"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "field.featuresVeo": [
-    [
-      "message",
-      "Veo"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "field.featuresSora": [
-    [
-      "message",
-      "Sora"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "field.featuresGrok": [
-    [
-      "message",
-      "Grok"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "field.featuresDeepseek": [
-    [
-      "message",
-      "Deepseek"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "field.featuresChatgpt": [
-    [
-      "message",
-      "ChatGPT"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "field.featuresMidjourney": [
-    [
-      "message",
-      "Midjourney"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "field.featuresChatdoc": [
-    [
-      "message",
-      "Chatdoc"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "field.featuresQrart": [
-    [
-      "message",
-      "Qrart"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "field.featuresLuma": [
-    [
-      "message",
-      "Luma"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "field.featuresPixverse": [
-    [
-      "message",
-      "Pixverse"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "field.featuresPika": [
-    [
-      "message",
-      "Pika"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "field.featuresKling": [
-    [
-      "message",
-      "Kling"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "field.featuresHailuo": [
-    [
-      "message",
-      "Hailuo"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "field.featuresHeadshots": [
-    [
-      "message",
-      "AI-profiilikuva"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "field.featuresSuno": [
-    [
-      "message",
-      "Suno"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "field.featuresFlux": [
-    [
-      "message",
-      "Flux"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "field.featuresNanobanana": [
-    [
-      "message",
-      "Nano Banaani"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
+  "field.title": {
+    "message": "Sivuston otsikko",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "field.origin": {
+    "message": "Sivuston verkkotunnus",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "field.description": {
+    "message": "Sivuston kuvaus",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "field.keywords": {
+    "message": "Sivuston avainsanat",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "field.logo": {
+    "message": "Sivuston logo",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "field.favicon": {
+    "message": "Sivuston favicon",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "field.qr": {
+    "message": "QR-koodi",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "field.url": {
+    "message": "Linkki",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "field.admins": {
+    "message": "Sivuston ylläpitäjätunnus",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "field.distributionDefaultInviterId": {
+    "message": "Oletus kutsujan tunnus",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "field.distributionForceInviterId": {
+    "message": "Pakotettu kutsujan tunnus",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "field.featuresChat": {
+    "message": "Chat",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "field.featuresVeo": {
+    "message": "Veo",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "field.featuresSora": {
+    "message": "Sora",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "field.featuresGrok": {
+    "message": "Grok",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "field.featuresDeepseek": {
+    "message": "Deepseek",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "field.featuresChatgpt": {
+    "message": "ChatGPT",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "field.featuresMidjourney": {
+    "message": "Midjourney",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "field.featuresChatdoc": {
+    "message": "Chatdoc",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "field.featuresQrart": {
+    "message": "Qrart",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "field.featuresLuma": {
+    "message": "Luma",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "field.featuresPixverse": {
+    "message": "Pixverse",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "field.featuresPika": {
+    "message": "Pika",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "field.featuresKling": {
+    "message": "Kling",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "field.featuresHailuo": {
+    "message": "Hailuo",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "field.featuresHeadshots": {
+    "message": "AI-profiilikuva",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "field.featuresSuno": {
+    "message": "Suno",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "field.featuresFlux": {
+    "message": "Flux",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "field.featuresNanobanana": {
+    "message": "Nano Banaani",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
   "field.featuresOpenaiimage": {
     "message": "OpenAI Image",
     "description": "Displayed as the title in the editing box"
   },
-  "field.featuresSeedream": [
-    [
-      "message",
-      "SeeDream"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "field.featuresSeedance": [
-    [
-      "message",
-      "SeeDance"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "field.featuresWan": [
-    [
-      "message",
-      "Wan"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "field.featuresProducer": [
-    [
-      "message",
-      "Tuottaja"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "field.featuresKimi": [
-    [
-      "message",
-      "Kimi"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "field.featuresSerp": [
-    [
-      "message",
-      "SERP"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "field.featuresSupport": [
-    [
-      "message",
-      "Asiakastuki"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "field.featuresI18n": [
-    [
-      "message",
-      "Monikielinen tuki"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "title.basicConfig": [
-    [
-      "message",
-      "Perusasetukset"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "title.seoConfig": [
-    [
-      "message",
-      "SEO-asetukset"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "title.editAdmins": [
-    [
-      "message",
-      "Muokkaa ylläpitäjiä"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "title.featuresConfig": [
-    [
-      "message",
-      "Ominaisuuksien asetukset"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "title.editTitle": [
-    [
-      "message",
-      "Muokkaa otsikkoa"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "title.editOrigin": [
-    [
-      "message",
-      "Muokkaa verkkotunnusta"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "title.editKeywords": [
-    [
-      "message",
-      "Muokkaa avainsanoja"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "title.editLogo": [
-    [
-      "message",
-      "Muokkaa logoa"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "title.editFavicon": [
-    [
-      "message",
-      "Muokkaa faviconia"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "title.editDescription": [
-    [
-      "message",
-      "Muokkaa kuvausta"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "title.distributionConfig": [
-    [
-      "message",
-      "Jakeluasetukset"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "title.editDistributionDefaultInviterId": [
-    [
-      "message",
-      "Muokkaa oletuskutsujaa"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "title.editDistributionForceInviterId": [
-    [
-      "message",
-      "Muokkaa pakotettua kutsujaa"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "title.editQR": [
-    [
-      "message",
-      "Muokkaa QR-koodia"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "title.editUrl": [
-    [
-      "message",
-      "Muokkaa linkkiä"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "placeholder.title": [
-    [
-      "message",
-      "Syötä sivuston otsikko"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "placeholder.origin": [
-    [
-      "message",
-      "Syötä sivuston verkkotunnus"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "placeholder.editUrl": [
-    [
-      "message",
-      "Syötä linkki"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "placeholder.description": [
-    [
-      "message",
-      "Syötä sivuston kuvaus"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "placeholder.keywords": [
-    [
-      "message",
-      "Syötä sivuston avainsanat"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "placeholder.editDistributionDefaultInviterId": [
-    [
-      "message",
-      "Syötä oletus kutsujan ID"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "placeholder.editDistributionForceInviterId": [
-    [
-      "message",
-      "Syötä pakotettu kutsujan ID"
-    ],
-    [
-      "description",
-      "Näytetään muokkausruudun otsikkona"
-    ]
-  ],
-  "message.uploadImageExceed": [
-    [
-      "message",
-      "Kuvan lataus ylittää rajan"
-    ],
-    [
-      "description",
-      "Vihje kuvan lataamisen ylittämisestä"
-    ]
-  ],
-  "message.uploadImageError": [
-    [
-      "message",
-      "Kuvan latausvirhe"
-    ],
-    [
-      "description",
-      "Vihje kuvan latausvirheestä"
-    ]
-  ],
-  "message.editLogoTip": [
-    [
-      "message",
-      "Suositeltu koko: 200*60px"
-    ],
-    [
-      "description",
-      "Vihje kuvan lataamisesta"
-    ]
-  ],
-  "message.editQRTip": [
-    [
-      "message",
-      "Suositeltu koko: 200*200px"
-    ],
-    [
-      "description",
-      "Vihje kuvan lataamisesta"
-    ]
-  ],
-  "message.editFaviconTip": [
-    [
-      "message",
-      "Suositeltu koko: 32*32px"
-    ],
-    [
-      "description",
-      "Vihje kuvan lataamisesta"
-    ]
-  ],
-  "message.editUrl": [
-    [
-      "message",
-      "Syötä linkki"
-    ],
-    [
-      "description",
-      "Vihje linkin syöttämisestä"
-    ]
-  ],
-  "message.atLeastOneAdmin": [
-    [
-      "message",
-      "Vähintään yksi ylläpitäjä on säilytettävä"
-    ],
-    [
-      "description",
-      "Vihje vähintään yhdestä ylläpitäjästä"
-    ]
-  ],
-  "message.distributionDefaultInviterIdTip": [
-    [
-      "message",
-      "Oletuskutsujan käyttäjän ID, jos jakolinkki ei sisällä inviter_id-parametria, käytetään oletuksena tätä käyttäjän ID:tä kutsujana."
-    ],
-    [
-      "description",
-      "Oletuskutsujan ID:n vihje"
-    ]
-  ],
-  "message.distributionForceInviterIdTip": [
-    [
-      "message",
-      "Pakotetun kutsujan käyttäjän ID, jos tämä ID on asetettu, käytetään pakotetusti tätä käyttäjän ID:tä kutsujana riippumatta siitä, sisältääkö jakolinkki inviter_id-parametrin."
-    ],
-    [
-      "description",
-      "Pakotetun kutsujan ID:n vihje"
-    ]
-  ],
-  "message.originTip": [
-    [
-      "message",
-      "Sivuston verkkotunnus, sivuston asetukset on sidottu verkkotunnukseen, verkkotunnusta ei voi muuttaa."
-    ],
-    [
-      "description",
-      "Sivuston verkkotunnuksen vihje"
-    ]
-  ],
-  "message.titleTip": [
-    [
-      "message",
-      "Sivuston otsikko, näytetään selaimen välilehdessä."
-    ],
-    [
-      "description",
-      "Sivuston otsikon vihje"
-    ]
-  ],
-  "message.descriptionTip": [
-    [
-      "message",
-      "Sivuston kuvaus, sijaitsee sivuston metatiedoissa, käytetään sivuston SEO-optimointiin."
-    ],
-    [
-      "description",
-      "Sivuston kuvauksen vihje"
-    ]
-  ],
-  "message.logoTip": [
-    [
-      "message",
-      "Sivuston logo, näytetään sivuston valikon yläosassa, kun valikko on avattu."
-    ],
-    [
-      "description",
-      "Sivuston logon vihje"
-    ]
-  ],
-  "message.faviconTip": [
-    [
-      "message",
-      "Sivuston favicon, näytetään selaimen välilehdessä."
-    ],
-    [
-      "description",
-      "Sivuston faviconin vihje"
-    ]
-  ],
-  "message.adminsTip": [
-    [
-      "message",
-      "Sivuston ylläpitäjän ID, oletuksena ensimmäinen sivuston luonut käyttäjä on ylläpitäjä, vain sivuston ylläpitäjät voivat hallita sivustoa."
-    ],
-    [
-      "description",
-      "Sivuston ylläpitäjien vihje"
-    ]
-  ],
-  "message.adminsTip2": [
-    [
-      "message",
-      "Voit lisätä tai poistaa ylläpitäjän ID:tä täältä, voit tarkistaa käyttäjän ID:n osoitteesta https://auth.acedata.cloud"
-    ],
-    [
-      "description",
-      "Sivuston ylläpitäjien vihje"
-    ]
-  ],
-  "message.keywordsTip": [
-    [
-      "message",
-      "Sivuston avainsanat, sijaitsee sivuston metatiedoissa, käytetään sivuston SEO-optimointiin."
-    ],
-    [
-      "description",
-      "Sivuston avainsanojen vihje"
-    ]
-  ],
-  "message.keywordsTip2": [
-    [
-      "message",
-      "Voit lisätä tai poistaa sivuston avainsanoja täältä, mitä tarkempia avainsanoja käytetään, sitä parempi SEO-optimointi."
-    ],
-    [
-      "description",
-      "Sivuston avainsanojen vihje"
-    ]
-  ],
-  "message.featuresChat": [
-    [
-      "message",
-      "Avaa tai sulje Chat-toimintomoduuli."
-    ],
-    [
-      "description",
-      "Chat-toiminnon kuvaus"
-    ]
-  ],
-  "message.featuresGrok": [
-    [
-      "message",
-      "Avaa tai sulje Grok-toimintomoduuli."
-    ],
-    [
-      "description",
-      "Grok-toiminnon kuvaus"
-    ]
-  ],
-  "message.featuresDeepseek": [
-    [
-      "message",
-      "Avaa tai sulje Deepseek-toimintomoduuli."
-    ],
-    [
-      "description",
-      "Deepseek-toiminnon kuvaus"
-    ]
-  ],
-  "message.featuresChatgpt": [
-    [
-      "message",
-      "Avaa tai sulje ChatGPT-toimintomoduuli."
-    ],
-    [
-      "description",
-      "ChatGPT-toiminnon kuvaus"
-    ]
-  ],
-  "message.featuresMidjourney": [
-    [
-      "message",
-      "Avaa tai sulje Midjourney-toimintomoduuli."
-    ],
-    [
-      "description",
-      "Midjourney-toiminnon kuvaus"
-    ]
-  ],
-  "message.featuresChatdoc": [
-    [
-      "message",
-      "Avaa tai sulje Chatdoc-toimintomoduuli."
-    ],
-    [
-      "description",
-      "Chatdoc-toiminnon kuvaus"
-    ]
-  ],
-  "message.featuresQrart": [
-    [
-      "message",
-      "Avaa tai sulje Qrart-toimintomoduuli."
-    ],
-    [
-      "description",
-      "Qrart-toiminnon kuvaus"
-    ]
-  ],
-  "message.featuresVeo": [
-    [
-      "message",
-      "Avaa tai sulje Veo-toimintomoduuli."
-    ],
-    [
-      "description",
-      "Veo-toiminnon kuvaus"
-    ]
-  ],
-  "message.featuresSora": [
-    [
-      "message",
-      "Avaa tai sulje Sora-toimintomoduuli."
-    ],
-    [
-      "description",
-      "Sora-toiminnon kuvaus"
-    ]
-  ],
-  "message.featuresSuno": [
-    [
-      "message",
-      "Avaa tai sulje Suno-toimintomoduuli."
-    ],
-    [
-      "description",
-      "Suno-toiminnon kuvaus"
-    ]
-  ],
-  "message.featuresPixverse": [
-    [
-      "message",
-      "Ota käyttöön tai poista käytöstä Pixverse-ominaisuusmoduuli."
-    ],
-    [
-      "description",
-      "Pixverse-ominaisuuden kuvaus"
-    ]
-  ],
-  "message.featuresFlux": [
-    [
-      "message",
-      "Ota käyttöön tai poista käytöstä FLux-ominaisuusmoduuli."
-    ],
-    [
-      "description",
-      "FLux-ominaisuuden kuvaus"
-    ]
-  ],
-  "message.featuresNanobanana": [
-    [
-      "message",
-      "Ota käyttöön tai poista käytöstä Nano Banana -ominaisuusmoduuli."
-    ],
-    [
-      "description",
-      "Nano Banana -ominaisuuden kuvaus"
-    ]
-  ],
+  "field.featuresSeedream": {
+    "message": "SeeDream",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "field.featuresSeedance": {
+    "message": "SeeDance",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "field.featuresWan": {
+    "message": "Wan",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "field.featuresProducer": {
+    "message": "Tuottaja",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "field.featuresKimi": {
+    "message": "Kimi",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "field.featuresSerp": {
+    "message": "SERP",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "field.featuresSupport": {
+    "message": "Asiakastuki",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "field.featuresI18n": {
+    "message": "Monikielinen tuki",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "title.basicConfig": {
+    "message": "Perusasetukset",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "title.seoConfig": {
+    "message": "SEO-asetukset",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "title.editAdmins": {
+    "message": "Muokkaa ylläpitäjiä",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "title.featuresConfig": {
+    "message": "Ominaisuuksien asetukset",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "title.editTitle": {
+    "message": "Muokkaa otsikkoa",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "title.editOrigin": {
+    "message": "Muokkaa verkkotunnusta",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "title.editKeywords": {
+    "message": "Muokkaa avainsanoja",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "title.editLogo": {
+    "message": "Muokkaa logoa",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "title.editFavicon": {
+    "message": "Muokkaa faviconia",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "title.editDescription": {
+    "message": "Muokkaa kuvausta",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "title.distributionConfig": {
+    "message": "Jakeluasetukset",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "title.editDistributionDefaultInviterId": {
+    "message": "Muokkaa oletuskutsujaa",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "title.editDistributionForceInviterId": {
+    "message": "Muokkaa pakotettua kutsujaa",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "title.editQR": {
+    "message": "Muokkaa QR-koodia",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "title.editUrl": {
+    "message": "Muokkaa linkkiä",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "placeholder.title": {
+    "message": "Syötä sivuston otsikko",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "placeholder.origin": {
+    "message": "Syötä sivuston verkkotunnus",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "placeholder.editUrl": {
+    "message": "Syötä linkki",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "placeholder.description": {
+    "message": "Syötä sivuston kuvaus",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "placeholder.keywords": {
+    "message": "Syötä sivuston avainsanat",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "placeholder.editDistributionDefaultInviterId": {
+    "message": "Syötä oletus kutsujan ID",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "placeholder.editDistributionForceInviterId": {
+    "message": "Syötä pakotettu kutsujan ID",
+    "description": "Näytetään muokkausruudun otsikkona"
+  },
+  "message.uploadImageExceed": {
+    "message": "Kuvan lataus ylittää rajan",
+    "description": "Vihje kuvan lataamisen ylittämisestä"
+  },
+  "message.uploadImageError": {
+    "message": "Kuvan latausvirhe",
+    "description": "Vihje kuvan latausvirheestä"
+  },
+  "message.editLogoTip": {
+    "message": "Suositeltu koko: 200*60px",
+    "description": "Vihje kuvan lataamisesta"
+  },
+  "message.editQRTip": {
+    "message": "Suositeltu koko: 200*200px",
+    "description": "Vihje kuvan lataamisesta"
+  },
+  "message.editFaviconTip": {
+    "message": "Suositeltu koko: 32*32px",
+    "description": "Vihje kuvan lataamisesta"
+  },
+  "message.editUrl": {
+    "message": "Syötä linkki",
+    "description": "Vihje linkin syöttämisestä"
+  },
+  "message.atLeastOneAdmin": {
+    "message": "Vähintään yksi ylläpitäjä on säilytettävä",
+    "description": "Vihje vähintään yhdestä ylläpitäjästä"
+  },
+  "message.distributionDefaultInviterIdTip": {
+    "message": "Oletuskutsujan käyttäjän ID, jos jakolinkki ei sisällä inviter_id-parametria, käytetään oletuksena tätä käyttäjän ID:tä kutsujana.",
+    "description": "Oletuskutsujan ID:n vihje"
+  },
+  "message.distributionForceInviterIdTip": {
+    "message": "Pakotetun kutsujan käyttäjän ID, jos tämä ID on asetettu, käytetään pakotetusti tätä käyttäjän ID:tä kutsujana riippumatta siitä, sisältääkö jakolinkki inviter_id-parametrin.",
+    "description": "Pakotetun kutsujan ID:n vihje"
+  },
+  "message.originTip": {
+    "message": "Sivuston verkkotunnus, sivuston asetukset on sidottu verkkotunnukseen, verkkotunnusta ei voi muuttaa.",
+    "description": "Sivuston verkkotunnuksen vihje"
+  },
+  "message.titleTip": {
+    "message": "Sivuston otsikko, näytetään selaimen välilehdessä.",
+    "description": "Sivuston otsikon vihje"
+  },
+  "message.descriptionTip": {
+    "message": "Sivuston kuvaus, sijaitsee sivuston metatiedoissa, käytetään sivuston SEO-optimointiin.",
+    "description": "Sivuston kuvauksen vihje"
+  },
+  "message.logoTip": {
+    "message": "Sivuston logo, näytetään sivuston valikon yläosassa, kun valikko on avattu.",
+    "description": "Sivuston logon vihje"
+  },
+  "message.faviconTip": {
+    "message": "Sivuston favicon, näytetään selaimen välilehdessä.",
+    "description": "Sivuston faviconin vihje"
+  },
+  "message.adminsTip": {
+    "message": "Sivuston ylläpitäjän ID, oletuksena ensimmäinen sivuston luonut käyttäjä on ylläpitäjä, vain sivuston ylläpitäjät voivat hallita sivustoa.",
+    "description": "Sivuston ylläpitäjien vihje"
+  },
+  "message.adminsTip2": {
+    "message": "Voit lisätä tai poistaa ylläpitäjän ID:tä täältä, voit tarkistaa käyttäjän ID:n osoitteesta https://auth.acedata.cloud",
+    "description": "Sivuston ylläpitäjien vihje"
+  },
+  "message.keywordsTip": {
+    "message": "Sivuston avainsanat, sijaitsee sivuston metatiedoissa, käytetään sivuston SEO-optimointiin.",
+    "description": "Sivuston avainsanojen vihje"
+  },
+  "message.keywordsTip2": {
+    "message": "Voit lisätä tai poistaa sivuston avainsanoja täältä, mitä tarkempia avainsanoja käytetään, sitä parempi SEO-optimointi.",
+    "description": "Sivuston avainsanojen vihje"
+  },
+  "message.featuresChat": {
+    "message": "Avaa tai sulje Chat-toimintomoduuli.",
+    "description": "Chat-toiminnon kuvaus"
+  },
+  "message.featuresGrok": {
+    "message": "Avaa tai sulje Grok-toimintomoduuli.",
+    "description": "Grok-toiminnon kuvaus"
+  },
+  "message.featuresDeepseek": {
+    "message": "Avaa tai sulje Deepseek-toimintomoduuli.",
+    "description": "Deepseek-toiminnon kuvaus"
+  },
+  "message.featuresChatgpt": {
+    "message": "Avaa tai sulje ChatGPT-toimintomoduuli.",
+    "description": "ChatGPT-toiminnon kuvaus"
+  },
+  "message.featuresMidjourney": {
+    "message": "Avaa tai sulje Midjourney-toimintomoduuli.",
+    "description": "Midjourney-toiminnon kuvaus"
+  },
+  "message.featuresChatdoc": {
+    "message": "Avaa tai sulje Chatdoc-toimintomoduuli.",
+    "description": "Chatdoc-toiminnon kuvaus"
+  },
+  "message.featuresQrart": {
+    "message": "Avaa tai sulje Qrart-toimintomoduuli.",
+    "description": "Qrart-toiminnon kuvaus"
+  },
+  "message.featuresVeo": {
+    "message": "Avaa tai sulje Veo-toimintomoduuli.",
+    "description": "Veo-toiminnon kuvaus"
+  },
+  "message.featuresSora": {
+    "message": "Avaa tai sulje Sora-toimintomoduuli.",
+    "description": "Sora-toiminnon kuvaus"
+  },
+  "message.featuresSuno": {
+    "message": "Avaa tai sulje Suno-toimintomoduuli.",
+    "description": "Suno-toiminnon kuvaus"
+  },
+  "message.featuresPixverse": {
+    "message": "Ota käyttöön tai poista käytöstä Pixverse-ominaisuusmoduuli.",
+    "description": "Pixverse-ominaisuuden kuvaus"
+  },
+  "message.featuresFlux": {
+    "message": "Ota käyttöön tai poista käytöstä FLux-ominaisuusmoduuli.",
+    "description": "FLux-ominaisuuden kuvaus"
+  },
+  "message.featuresNanobanana": {
+    "message": "Ota käyttöön tai poista käytöstä Nano Banana -ominaisuusmoduuli.",
+    "description": "Nano Banana -ominaisuuden kuvaus"
+  },
   "message.featuresOpenaiimage": {
     "message": "Toggle OpenAI Image feature module.",
     "description": "Description of the OpenAI Image feature"
   },
-  "message.featuresSeedream": [
-    [
-      "message",
-      "Ota käyttöön tai poista käytöstä SeeDream-ominaisuusmoduuli."
-    ],
-    [
-      "description",
-      "SeeDream-ominaisuuden kuvaus"
-    ]
-  ],
-  "message.featuresSeedance": [
-    [
-      "message",
-      "Ota käyttöön tai poista käytöstä SeeDance-ominaisuusmoduuli."
-    ],
-    [
-      "description",
-      "SeeDance-ominaisuuden kuvaus"
-    ]
-  ],
-  "message.featuresWan": [
-    [
-      "message",
-      "Ota käyttöön tai poista käytöstä Wan-ominaisuusmoduuli."
-    ],
-    [
-      "description",
-      "Wan-ominaisuuden kuvaus"
-    ]
-  ],
-  "message.featuresProducer": [
-    [
-      "message",
-      "Ota käyttöön tai poista käytöstä Producer-ominaisuusmoduuli."
-    ],
-    [
-      "description",
-      "Producer-ominaisuuden kuvaus"
-    ]
-  ],
-  "message.featuresKimi": [
-    [
-      "message",
-      "Ota käyttöön tai poista käytöstä Kimi-ominaisuusmoduuli."
-    ],
-    [
-      "description",
-      "Kimi-ominaisuuden kuvaus"
-    ]
-  ],
-  "message.featuresSerp": [
-    [
-      "message",
-      "Ota käyttöön tai poista käytöstä SERP-ominaisuusmoduuli."
-    ],
-    [
-      "description",
-      "SERP-ominaisuuden kuvaus"
-    ]
-  ],
-  "message.featuresLuma": [
-    [
-      "message",
-      "Ota käyttöön tai poista käytöstä Luma-ominaisuusmoduuli."
-    ],
-    [
-      "description",
-      "Luma-ominaisuuden kuvaus"
-    ]
-  ],
-  "message.featuresPika": [
-    [
-      "message",
-      "Ota käyttöön tai poista käytöstä Pika-ominaisuusmoduuli."
-    ],
-    [
-      "description",
-      "Pika-ominaisuuden kuvaus"
-    ]
-  ],
-  "message.featuresKling": [
-    [
-      "message",
-      "Ota käyttöön tai poista käytöstä Kling-ominaisuusmoduuli."
-    ],
-    [
-      "description",
-      "Kling-ominaisuuden kuvaus"
-    ]
-  ],
-  "message.featuresHailuo": [
-    [
-      "message",
-      "Ota käyttöön tai poista käytöstä Hailuo-ominaisuusmoduuli."
-    ],
-    [
-      "description",
-      "Hailuo-ominaisuuden kuvaus"
-    ]
-  ],
-  "message.featuresHeadshots": [
-    [
-      "message",
-      "Ota käyttöön tai poista käytöstä AI-asiakirjakuvamoduuli."
-    ],
-    [
-      "description",
-      "AI-asiakirjakuvan kuvaus"
-    ]
-  ],
-  "message.featuresSupport": [
-    [
-      "message",
-      "Ota käyttöön tai poista käytöstä asiakastuki"
-    ],
-    [
-      "description",
-      "Tuen kuvaus"
-    ]
-  ],
-  "message.featuresI18n": [
-    [
-      "message",
-      "Ota käyttöön tai poista käytöstä monikielinen tuki, sulkemisen jälkeen käyttäjä voi käyttää vain oletuskieltä."
-    ],
-    [
-      "description",
-      "Monikielisen tuen kuvaus"
-    ]
-  ],
-  "button.upload": [
-    [
-      "message",
-      "Lataa"
-    ],
-    [
-      "description",
-      "Lataa"
-    ]
-  ],
-  "button.enabled": [
-    [
-      "message",
-      "Otetaan käyttöön"
-    ],
-    [
-      "description",
-      "Kytkin teksti, joka osoittaa, että se on otettu käyttöön"
-    ]
-  ],
-  "button.disabled": [
-    [
-      "message",
-      "Poistettu käytöstä"
-    ],
-    [
-      "description",
-      "Kytkin teksti, joka osoittaa, että se on poistettu käytöstä"
-    ]
-  ],
-  "field.featuresGemini": [
-    [
-      "message",
-      "Gemini"
-    ],
-    [
-      "description",
-      "Näytetään otsikkona muokkausruudussa"
-    ]
-  ],
-  "message.featuresGemini": [
-    [
-      "message",
-      "Ota käyttöön tai poista käytöstä Gemini-ominaisuusmoduuli."
-    ],
-    [
-      "description",
-      "Gemini-ominaisuuden kuvaus"
-    ]
-  ],
-  "field.featuresClaude": [
-    [
-      "message",
-      "Claude"
-    ],
-    [
-      "description",
-      "Näytetään otsikkona muokkausruudussa"
-    ]
-  ],
-  "message.featuresClaude": [
-    [
-      "message",
-      "Ota käyttöön tai poista käytöstä Claude-ominaisuusmoduuli."
-    ],
-    [
-      "description",
-      "Claude-ominaisuuden kuvaus"
-    ]
-  ]
+  "message.featuresSeedream": {
+    "message": "Ota käyttöön tai poista käytöstä SeeDream-ominaisuusmoduuli.",
+    "description": "SeeDream-ominaisuuden kuvaus"
+  },
+  "message.featuresSeedance": {
+    "message": "Ota käyttöön tai poista käytöstä SeeDance-ominaisuusmoduuli.",
+    "description": "SeeDance-ominaisuuden kuvaus"
+  },
+  "message.featuresWan": {
+    "message": "Ota käyttöön tai poista käytöstä Wan-ominaisuusmoduuli.",
+    "description": "Wan-ominaisuuden kuvaus"
+  },
+  "message.featuresProducer": {
+    "message": "Ota käyttöön tai poista käytöstä Producer-ominaisuusmoduuli.",
+    "description": "Producer-ominaisuuden kuvaus"
+  },
+  "message.featuresKimi": {
+    "message": "Ota käyttöön tai poista käytöstä Kimi-ominaisuusmoduuli.",
+    "description": "Kimi-ominaisuuden kuvaus"
+  },
+  "message.featuresSerp": {
+    "message": "Ota käyttöön tai poista käytöstä SERP-ominaisuusmoduuli.",
+    "description": "SERP-ominaisuuden kuvaus"
+  },
+  "message.featuresLuma": {
+    "message": "Ota käyttöön tai poista käytöstä Luma-ominaisuusmoduuli.",
+    "description": "Luma-ominaisuuden kuvaus"
+  },
+  "message.featuresPika": {
+    "message": "Ota käyttöön tai poista käytöstä Pika-ominaisuusmoduuli.",
+    "description": "Pika-ominaisuuden kuvaus"
+  },
+  "message.featuresKling": {
+    "message": "Ota käyttöön tai poista käytöstä Kling-ominaisuusmoduuli.",
+    "description": "Kling-ominaisuuden kuvaus"
+  },
+  "message.featuresHailuo": {
+    "message": "Ota käyttöön tai poista käytöstä Hailuo-ominaisuusmoduuli.",
+    "description": "Hailuo-ominaisuuden kuvaus"
+  },
+  "message.featuresHeadshots": {
+    "message": "Ota käyttöön tai poista käytöstä AI-asiakirjakuvamoduuli.",
+    "description": "AI-asiakirjakuvan kuvaus"
+  },
+  "message.featuresSupport": {
+    "message": "Ota käyttöön tai poista käytöstä asiakastuki",
+    "description": "Tuen kuvaus"
+  },
+  "message.featuresI18n": {
+    "message": "Ota käyttöön tai poista käytöstä monikielinen tuki, sulkemisen jälkeen käyttäjä voi käyttää vain oletuskieltä.",
+    "description": "Monikielisen tuen kuvaus"
+  },
+  "button.upload": {
+    "message": "Lataa",
+    "description": "Lataa"
+  },
+  "button.enabled": {
+    "message": "Otetaan käyttöön",
+    "description": "Kytkin teksti, joka osoittaa, että se on otettu käyttöön"
+  },
+  "button.disabled": {
+    "message": "Poistettu käytöstä",
+    "description": "Kytkin teksti, joka osoittaa, että se on poistettu käytöstä"
+  },
+  "field.featuresGemini": {
+    "message": "Gemini",
+    "description": "Näytetään otsikkona muokkausruudussa"
+  },
+  "message.featuresGemini": {
+    "message": "Ota käyttöön tai poista käytöstä Gemini-ominaisuusmoduuli.",
+    "description": "Gemini-ominaisuuden kuvaus"
+  },
+  "field.featuresClaude": {
+    "message": "Claude",
+    "description": "Näytetään otsikkona muokkausruudussa"
+  },
+  "message.featuresClaude": {
+    "message": "Ota käyttöön tai poista käytöstä Claude-ominaisuusmoduuli.",
+    "description": "Claude-ominaisuuden kuvaus"
+  }
 }

--- a/src/i18n/fr/site.json
+++ b/src/i18n/fr/site.json
@@ -1,1110 +1,450 @@
 {
-  "field.title": [
-    [
-      "message",
-      "Titre du site"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "field.origin": [
-    [
-      "message",
-      "Nom de domaine du site"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "field.description": [
-    [
-      "message",
-      "Description du site"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "field.keywords": [
-    [
-      "message",
-      "Mots-clés du site"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "field.logo": [
-    [
-      "message",
-      "Logo du site"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "field.favicon": [
-    [
-      "message",
-      "Favicon du site"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "field.qr": [
-    [
-      "message",
-      "Code QR"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "field.url": [
-    [
-      "message",
-      "Lien"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "field.admins": [
-    [
-      "message",
-      "ID des administrateurs du site"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "field.distributionDefaultInviterId": [
-    [
-      "message",
-      "ID de l'inviteur par défaut"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "field.distributionForceInviterId": [
-    [
-      "message",
-      "ID de l'inviteur obligatoire"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "field.featuresChat": [
-    [
-      "message",
-      "Chat"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "field.featuresVeo": [
-    [
-      "message",
-      "Veo"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "field.featuresSora": [
-    [
-      "message",
-      "Sora"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "field.featuresGrok": [
-    [
-      "message",
-      "Grok"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "field.featuresDeepseek": [
-    [
-      "message",
-      "Deepseek"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "field.featuresChatgpt": [
-    [
-      "message",
-      "ChatGPT"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "field.featuresMidjourney": [
-    [
-      "message",
-      "Midjourney"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "field.featuresChatdoc": [
-    [
-      "message",
-      "Chatdoc"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "field.featuresQrart": [
-    [
-      "message",
-      "Qrart"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "field.featuresLuma": [
-    [
-      "message",
-      "Luma"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "field.featuresPixverse": [
-    [
-      "message",
-      "Pixverse"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "field.featuresPika": [
-    [
-      "message",
-      "Pika"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "field.featuresKling": [
-    [
-      "message",
-      "Kling"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "field.featuresHailuo": [
-    [
-      "message",
-      "Hailuo"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "field.featuresHeadshots": [
-    [
-      "message",
-      "Photo d'identité AI"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "field.featuresSuno": [
-    [
-      "message",
-      "Suno"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "field.featuresFlux": [
-    [
-      "message",
-      "Flux"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "field.featuresNanobanana": [
-    [
-      "message",
-      "Banane Nano"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
+  "field.title": {
+    "message": "Titre du site",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "field.origin": {
+    "message": "Nom de domaine du site",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "field.description": {
+    "message": "Description du site",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "field.keywords": {
+    "message": "Mots-clés du site",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "field.logo": {
+    "message": "Logo du site",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "field.favicon": {
+    "message": "Favicon du site",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "field.qr": {
+    "message": "Code QR",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "field.url": {
+    "message": "Lien",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "field.admins": {
+    "message": "ID des administrateurs du site",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "field.distributionDefaultInviterId": {
+    "message": "ID de l'inviteur par défaut",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "field.distributionForceInviterId": {
+    "message": "ID de l'inviteur obligatoire",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "field.featuresChat": {
+    "message": "Chat",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "field.featuresVeo": {
+    "message": "Veo",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "field.featuresSora": {
+    "message": "Sora",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "field.featuresGrok": {
+    "message": "Grok",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "field.featuresDeepseek": {
+    "message": "Deepseek",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "field.featuresChatgpt": {
+    "message": "ChatGPT",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "field.featuresMidjourney": {
+    "message": "Midjourney",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "field.featuresChatdoc": {
+    "message": "Chatdoc",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "field.featuresQrart": {
+    "message": "Qrart",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "field.featuresLuma": {
+    "message": "Luma",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "field.featuresPixverse": {
+    "message": "Pixverse",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "field.featuresPika": {
+    "message": "Pika",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "field.featuresKling": {
+    "message": "Kling",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "field.featuresHailuo": {
+    "message": "Hailuo",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "field.featuresHeadshots": {
+    "message": "Photo d'identité AI",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "field.featuresSuno": {
+    "message": "Suno",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "field.featuresFlux": {
+    "message": "Flux",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "field.featuresNanobanana": {
+    "message": "Banane Nano",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
   "field.featuresOpenaiimage": {
     "message": "OpenAI Image",
     "description": "Displayed as the title in the editing box"
   },
-  "field.featuresSeedream": [
-    [
-      "message",
-      "SeeDream"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "field.featuresSeedance": [
-    [
-      "message",
-      "SeeDance"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "field.featuresWan": [
-    [
-      "message",
-      "Wan"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "field.featuresProducer": [
-    [
-      "message",
-      "Producteur"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "field.featuresKimi": [
-    [
-      "message",
-      "Kimi"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "field.featuresSerp": [
-    [
-      "message",
-      "SERP"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "field.featuresSupport": [
-    [
-      "message",
-      "Support client"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "field.featuresI18n": [
-    [
-      "message",
-      "Support multilingue"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "title.basicConfig": [
-    [
-      "message",
-      "Configuration de base"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "title.seoConfig": [
-    [
-      "message",
-      "Configuration SEO"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "title.editAdmins": [
-    [
-      "message",
-      "Modifier les administrateurs"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "title.featuresConfig": [
-    [
-      "message",
-      "Configuration des fonctionnalités"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "title.editTitle": [
-    [
-      "message",
-      "Modifier le titre"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "title.editOrigin": [
-    [
-      "message",
-      "Modifier le nom de domaine"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "title.editKeywords": [
-    [
-      "message",
-      "Modifier les mots-clés"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "title.editLogo": [
-    [
-      "message",
-      "Modifier le logo"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "title.editFavicon": [
-    [
-      "message",
-      "Modifier le favicon"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "title.editDescription": [
-    [
-      "message",
-      "Modifier la description"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "title.distributionConfig": [
-    [
-      "message",
-      "Configuration de distribution"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "title.editDistributionDefaultInviterId": [
-    [
-      "message",
-      "Modifier l'inviteur par défaut"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "title.editDistributionForceInviterId": [
-    [
-      "message",
-      "Modifier l'inviteur obligatoire"
-    ],
-    [
-      "description",
-      "Affiché comme titre dans la zone d'édition"
-    ]
-  ],
-  "title.editQR": [
-    [
-      "message",
-      "Modifier le QR code"
-    ],
-    [
-      "description",
-      "Titre affiché dans la zone d'édition"
-    ]
-  ],
-  "title.editUrl": [
-    [
-      "message",
-      "Modifier le lien"
-    ],
-    [
-      "description",
-      "Titre affiché dans la zone d'édition"
-    ]
-  ],
-  "placeholder.title": [
-    [
-      "message",
-      "Veuillez entrer le titre du site"
-    ],
-    [
-      "description",
-      "Titre affiché dans la zone d'édition"
-    ]
-  ],
-  "placeholder.origin": [
-    [
-      "message",
-      "Veuillez entrer le domaine du site"
-    ],
-    [
-      "description",
-      "Titre affiché dans la zone d'édition"
-    ]
-  ],
-  "placeholder.editUrl": [
-    [
-      "message",
-      "Veuillez entrer le lien"
-    ],
-    [
-      "description",
-      "Titre affiché dans la zone d'édition"
-    ]
-  ],
-  "placeholder.description": [
-    [
-      "message",
-      "Veuillez entrer la description du site"
-    ],
-    [
-      "description",
-      "Titre affiché dans la zone d'édition"
-    ]
-  ],
-  "placeholder.keywords": [
-    [
-      "message",
-      "Veuillez entrer les mots-clés du site"
-    ],
-    [
-      "description",
-      "Titre affiché dans la zone d'édition"
-    ]
-  ],
-  "placeholder.editDistributionDefaultInviterId": [
-    [
-      "message",
-      "Veuillez entrer l'ID de l'inviteur par défaut"
-    ],
-    [
-      "description",
-      "Titre affiché dans la zone d'édition"
-    ]
-  ],
-  "placeholder.editDistributionForceInviterId": [
-    [
-      "message",
-      "Veuillez entrer l'ID de l'inviteur forcé"
-    ],
-    [
-      "description",
-      "Titre affiché dans la zone d'édition"
-    ]
-  ],
-  "message.uploadImageExceed": [
-    [
-      "message",
-      "Image téléchargée dépassant la limite"
-    ],
-    [
-      "description",
-      "Alerte lorsque l'image téléchargée dépasse la limite"
-    ]
-  ],
-  "message.uploadImageError": [
-    [
-      "message",
-      "Erreur de téléchargement de l'image"
-    ],
-    [
-      "description",
-      "Alerte en cas d'erreur de téléchargement de l'image"
-    ]
-  ],
-  "message.editLogoTip": [
-    [
-      "message",
-      "Taille recommandée : 200*60px"
-    ],
-    [
-      "description",
-      "Langage d'alerte pour le téléchargement d'image"
-    ]
-  ],
-  "message.editQRTip": [
-    [
-      "message",
-      "Taille recommandée : 200*200px"
-    ],
-    [
-      "description",
-      "Langage d'alerte pour le téléchargement d'image"
-    ]
-  ],
-  "message.editFaviconTip": [
-    [
-      "message",
-      "Taille recommandée : 32*32px"
-    ],
-    [
-      "description",
-      "Langage d'alerte pour le téléchargement d'image"
-    ]
-  ],
-  "message.editUrl": [
-    [
-      "message",
-      "Veuillez entrer le lien"
-    ],
-    [
-      "description",
-      "Alerte pour entrer le lien"
-    ]
-  ],
-  "message.atLeastOneAdmin": [
-    [
-      "message",
-      "Au moins un administrateur doit être conservé"
-    ],
-    [
-      "description",
-      "Alerte pour conserver au moins un administrateur"
-    ]
-  ],
-  "message.distributionDefaultInviterIdTip": [
-    [
-      "message",
-      "ID utilisateur de l'inviteur par défaut. Si le lien de distribution ne contient pas le paramètre inviter_id, cet ID utilisateur sera utilisé par défaut comme invitateur."
-    ],
-    [
-      "description",
-      "Alerte pour l'ID de l'inviteur par défaut"
-    ]
-  ],
-  "message.distributionForceInviterIdTip": [
-    [
-      "message",
-      "ID utilisateur de l'inviteur forcé. Si cet ID est défini, il sera utilisé comme invitateur, que le lien de distribution contienne ou non le paramètre inviter_id."
-    ],
-    [
-      "description",
-      "Alerte pour l'ID de l'inviteur forcé"
-    ]
-  ],
-  "message.originTip": [
-    [
-      "message",
-      "Domaine du site, la configuration du site est liée au domaine et ne peut pas être modifiée."
-    ],
-    [
-      "description",
-      "Alerte pour le domaine du site"
-    ]
-  ],
-  "message.titleTip": [
-    [
-      "message",
-      "Titre du site, affiché dans l'onglet du navigateur."
-    ],
-    [
-      "description",
-      "Alerte pour le titre du site"
-    ]
-  ],
-  "message.descriptionTip": [
-    [
-      "message",
-      "Description du site, située dans les métadonnées du site, utilisée pour l'optimisation SEO."
-    ],
-    [
-      "description",
-      "Alerte pour la description du site"
-    ]
-  ],
-  "message.logoTip": [
-    [
-      "message",
-      "Logo du site, affiché en haut du menu du site lorsque le menu est développé."
-    ],
-    [
-      "description",
-      "Alerte pour le logo du site"
-    ]
-  ],
-  "message.faviconTip": [
-    [
-      "message",
-      "Favicon du site, affiché dans l'onglet du navigateur."
-    ],
-    [
-      "description",
-      "Alerte pour le favicon du site"
-    ]
-  ],
-  "message.adminsTip": [
-    [
-      "message",
-      "ID des administrateurs du site. Par défaut, l'utilisateur qui crée le site pour la première fois devient administrateur. Seuls les administrateurs du site peuvent gérer le site."
-    ],
-    [
-      "description",
-      "Alerte pour les administrateurs du site"
-    ]
-  ],
-  "message.adminsTip2": [
-    [
-      "message",
-      "Vous pouvez ajouter ou supprimer des ID d'administrateurs ici. Vous pouvez consulter les ID d'utilisateur sur https://auth.acedata.cloud"
-    ],
-    [
-      "description",
-      "Alerte pour les administrateurs du site"
-    ]
-  ],
-  "message.keywordsTip": [
-    [
-      "message",
-      "Mots-clés du site, situés dans les métadonnées du site, utilisés pour l'optimisation SEO."
-    ],
-    [
-      "description",
-      "Alerte pour les mots-clés du site"
-    ]
-  ],
-  "message.keywordsTip2": [
-    [
-      "message",
-      "Vous pouvez ajouter ou supprimer des mots-clés du site ici. Plus les mots-clés sont précis, mieux c'est pour l'optimisation SEO."
-    ],
-    [
-      "description",
-      "Alerte pour les mots-clés du site"
-    ]
-  ],
-  "message.featuresChat": [
-    [
-      "message",
-      "Activer ou désactiver le module de fonction Chat."
-    ],
-    [
-      "description",
-      "Description de la fonction Chat"
-    ]
-  ],
-  "message.featuresGrok": [
-    [
-      "message",
-      "Activer ou désactiver le module de fonction Grok."
-    ],
-    [
-      "description",
-      "Description de la fonction Grok"
-    ]
-  ],
-  "message.featuresDeepseek": [
-    [
-      "message",
-      "Activer ou désactiver le module de fonction Deepseek."
-    ],
-    [
-      "description",
-      "Description de la fonction Deepseek"
-    ]
-  ],
-  "message.featuresChatgpt": [
-    [
-      "message",
-      "Activer ou désactiver le module de fonction ChatGPT."
-    ],
-    [
-      "description",
-      "Description de la fonction ChatGPT"
-    ]
-  ],
-  "message.featuresMidjourney": [
-    [
-      "message",
-      "Activer ou désactiver le module de fonction Midjourney."
-    ],
-    [
-      "description",
-      "Description de la fonction Midjourney"
-    ]
-  ],
-  "message.featuresChatdoc": [
-    [
-      "message",
-      "Activer ou désactiver le module de fonction Chatdoc."
-    ],
-    [
-      "description",
-      "Description de la fonction Chatdoc"
-    ]
-  ],
-  "message.featuresQrart": [
-    [
-      "message",
-      "Activer ou désactiver le module de fonction Qrart."
-    ],
-    [
-      "description",
-      "Description de la fonction Qrart"
-    ]
-  ],
-  "message.featuresVeo": [
-    [
-      "message",
-      "Activer ou désactiver le module de fonction Veo."
-    ],
-    [
-      "description",
-      "Description de la fonction Veo"
-    ]
-  ],
-  "message.featuresSora": [
-    [
-      "message",
-      "Activer ou désactiver le module de fonction Sora."
-    ],
-    [
-      "description",
-      "Description de la fonction Sora"
-    ]
-  ],
-  "message.featuresSuno": [
-    [
-      "message",
-      "Activer ou désactiver le module de fonction Suno."
-    ],
-    [
-      "description",
-      "Description de la fonction Suno"
-    ]
-  ],
-  "message.featuresPixverse": [
-    [
-      "message",
-      "Activer ou désactiver le module de fonctionnalités Pixverse."
-    ],
-    [
-      "description",
-      "Description de la fonctionnalité Pixverse"
-    ]
-  ],
-  "message.featuresFlux": [
-    [
-      "message",
-      "Activer ou désactiver le module de fonctionnalités FLux."
-    ],
-    [
-      "description",
-      "Description de la fonctionnalité FLux"
-    ]
-  ],
-  "message.featuresNanobanana": [
-    [
-      "message",
-      "Activer ou désactiver le module de fonctionnalités Nano Banana."
-    ],
-    [
-      "description",
-      "Description de la fonctionnalité Nano Banana"
-    ]
-  ],
+  "field.featuresSeedream": {
+    "message": "SeeDream",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "field.featuresSeedance": {
+    "message": "SeeDance",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "field.featuresWan": {
+    "message": "Wan",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "field.featuresProducer": {
+    "message": "Producteur",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "field.featuresKimi": {
+    "message": "Kimi",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "field.featuresSerp": {
+    "message": "SERP",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "field.featuresSupport": {
+    "message": "Support client",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "field.featuresI18n": {
+    "message": "Support multilingue",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "title.basicConfig": {
+    "message": "Configuration de base",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "title.seoConfig": {
+    "message": "Configuration SEO",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "title.editAdmins": {
+    "message": "Modifier les administrateurs",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "title.featuresConfig": {
+    "message": "Configuration des fonctionnalités",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "title.editTitle": {
+    "message": "Modifier le titre",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "title.editOrigin": {
+    "message": "Modifier le nom de domaine",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "title.editKeywords": {
+    "message": "Modifier les mots-clés",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "title.editLogo": {
+    "message": "Modifier le logo",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "title.editFavicon": {
+    "message": "Modifier le favicon",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "title.editDescription": {
+    "message": "Modifier la description",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "title.distributionConfig": {
+    "message": "Configuration de distribution",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "title.editDistributionDefaultInviterId": {
+    "message": "Modifier l'inviteur par défaut",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "title.editDistributionForceInviterId": {
+    "message": "Modifier l'inviteur obligatoire",
+    "description": "Affiché comme titre dans la zone d'édition"
+  },
+  "title.editQR": {
+    "message": "Modifier le QR code",
+    "description": "Titre affiché dans la zone d'édition"
+  },
+  "title.editUrl": {
+    "message": "Modifier le lien",
+    "description": "Titre affiché dans la zone d'édition"
+  },
+  "placeholder.title": {
+    "message": "Veuillez entrer le titre du site",
+    "description": "Titre affiché dans la zone d'édition"
+  },
+  "placeholder.origin": {
+    "message": "Veuillez entrer le domaine du site",
+    "description": "Titre affiché dans la zone d'édition"
+  },
+  "placeholder.editUrl": {
+    "message": "Veuillez entrer le lien",
+    "description": "Titre affiché dans la zone d'édition"
+  },
+  "placeholder.description": {
+    "message": "Veuillez entrer la description du site",
+    "description": "Titre affiché dans la zone d'édition"
+  },
+  "placeholder.keywords": {
+    "message": "Veuillez entrer les mots-clés du site",
+    "description": "Titre affiché dans la zone d'édition"
+  },
+  "placeholder.editDistributionDefaultInviterId": {
+    "message": "Veuillez entrer l'ID de l'inviteur par défaut",
+    "description": "Titre affiché dans la zone d'édition"
+  },
+  "placeholder.editDistributionForceInviterId": {
+    "message": "Veuillez entrer l'ID de l'inviteur forcé",
+    "description": "Titre affiché dans la zone d'édition"
+  },
+  "message.uploadImageExceed": {
+    "message": "Image téléchargée dépassant la limite",
+    "description": "Alerte lorsque l'image téléchargée dépasse la limite"
+  },
+  "message.uploadImageError": {
+    "message": "Erreur de téléchargement de l'image",
+    "description": "Alerte en cas d'erreur de téléchargement de l'image"
+  },
+  "message.editLogoTip": {
+    "message": "Taille recommandée : 200*60px",
+    "description": "Langage d'alerte pour le téléchargement d'image"
+  },
+  "message.editQRTip": {
+    "message": "Taille recommandée : 200*200px",
+    "description": "Langage d'alerte pour le téléchargement d'image"
+  },
+  "message.editFaviconTip": {
+    "message": "Taille recommandée : 32*32px",
+    "description": "Langage d'alerte pour le téléchargement d'image"
+  },
+  "message.editUrl": {
+    "message": "Veuillez entrer le lien",
+    "description": "Alerte pour entrer le lien"
+  },
+  "message.atLeastOneAdmin": {
+    "message": "Au moins un administrateur doit être conservé",
+    "description": "Alerte pour conserver au moins un administrateur"
+  },
+  "message.distributionDefaultInviterIdTip": {
+    "message": "ID utilisateur de l'inviteur par défaut. Si le lien de distribution ne contient pas le paramètre inviter_id, cet ID utilisateur sera utilisé par défaut comme invitateur.",
+    "description": "Alerte pour l'ID de l'inviteur par défaut"
+  },
+  "message.distributionForceInviterIdTip": {
+    "message": "ID utilisateur de l'inviteur forcé. Si cet ID est défini, il sera utilisé comme invitateur, que le lien de distribution contienne ou non le paramètre inviter_id.",
+    "description": "Alerte pour l'ID de l'inviteur forcé"
+  },
+  "message.originTip": {
+    "message": "Domaine du site, la configuration du site est liée au domaine et ne peut pas être modifiée.",
+    "description": "Alerte pour le domaine du site"
+  },
+  "message.titleTip": {
+    "message": "Titre du site, affiché dans l'onglet du navigateur.",
+    "description": "Alerte pour le titre du site"
+  },
+  "message.descriptionTip": {
+    "message": "Description du site, située dans les métadonnées du site, utilisée pour l'optimisation SEO.",
+    "description": "Alerte pour la description du site"
+  },
+  "message.logoTip": {
+    "message": "Logo du site, affiché en haut du menu du site lorsque le menu est développé.",
+    "description": "Alerte pour le logo du site"
+  },
+  "message.faviconTip": {
+    "message": "Favicon du site, affiché dans l'onglet du navigateur.",
+    "description": "Alerte pour le favicon du site"
+  },
+  "message.adminsTip": {
+    "message": "ID des administrateurs du site. Par défaut, l'utilisateur qui crée le site pour la première fois devient administrateur. Seuls les administrateurs du site peuvent gérer le site.",
+    "description": "Alerte pour les administrateurs du site"
+  },
+  "message.adminsTip2": {
+    "message": "Vous pouvez ajouter ou supprimer des ID d'administrateurs ici. Vous pouvez consulter les ID d'utilisateur sur https://auth.acedata.cloud",
+    "description": "Alerte pour les administrateurs du site"
+  },
+  "message.keywordsTip": {
+    "message": "Mots-clés du site, situés dans les métadonnées du site, utilisés pour l'optimisation SEO.",
+    "description": "Alerte pour les mots-clés du site"
+  },
+  "message.keywordsTip2": {
+    "message": "Vous pouvez ajouter ou supprimer des mots-clés du site ici. Plus les mots-clés sont précis, mieux c'est pour l'optimisation SEO.",
+    "description": "Alerte pour les mots-clés du site"
+  },
+  "message.featuresChat": {
+    "message": "Activer ou désactiver le module de fonction Chat.",
+    "description": "Description de la fonction Chat"
+  },
+  "message.featuresGrok": {
+    "message": "Activer ou désactiver le module de fonction Grok.",
+    "description": "Description de la fonction Grok"
+  },
+  "message.featuresDeepseek": {
+    "message": "Activer ou désactiver le module de fonction Deepseek.",
+    "description": "Description de la fonction Deepseek"
+  },
+  "message.featuresChatgpt": {
+    "message": "Activer ou désactiver le module de fonction ChatGPT.",
+    "description": "Description de la fonction ChatGPT"
+  },
+  "message.featuresMidjourney": {
+    "message": "Activer ou désactiver le module de fonction Midjourney.",
+    "description": "Description de la fonction Midjourney"
+  },
+  "message.featuresChatdoc": {
+    "message": "Activer ou désactiver le module de fonction Chatdoc.",
+    "description": "Description de la fonction Chatdoc"
+  },
+  "message.featuresQrart": {
+    "message": "Activer ou désactiver le module de fonction Qrart.",
+    "description": "Description de la fonction Qrart"
+  },
+  "message.featuresVeo": {
+    "message": "Activer ou désactiver le module de fonction Veo.",
+    "description": "Description de la fonction Veo"
+  },
+  "message.featuresSora": {
+    "message": "Activer ou désactiver le module de fonction Sora.",
+    "description": "Description de la fonction Sora"
+  },
+  "message.featuresSuno": {
+    "message": "Activer ou désactiver le module de fonction Suno.",
+    "description": "Description de la fonction Suno"
+  },
+  "message.featuresPixverse": {
+    "message": "Activer ou désactiver le module de fonctionnalités Pixverse.",
+    "description": "Description de la fonctionnalité Pixverse"
+  },
+  "message.featuresFlux": {
+    "message": "Activer ou désactiver le module de fonctionnalités FLux.",
+    "description": "Description de la fonctionnalité FLux"
+  },
+  "message.featuresNanobanana": {
+    "message": "Activer ou désactiver le module de fonctionnalités Nano Banana.",
+    "description": "Description de la fonctionnalité Nano Banana"
+  },
   "message.featuresOpenaiimage": {
     "message": "Toggle OpenAI Image feature module.",
     "description": "Description of the OpenAI Image feature"
   },
-  "message.featuresSeedream": [
-    [
-      "message",
-      "Activer ou désactiver le module de fonctionnalités SeeDream."
-    ],
-    [
-      "description",
-      "Description de la fonctionnalité SeeDream"
-    ]
-  ],
-  "message.featuresSeedance": [
-    [
-      "message",
-      "Activer ou désactiver le module de fonctionnalités SeeDance."
-    ],
-    [
-      "description",
-      "Description de la fonctionnalité SeeDance"
-    ]
-  ],
-  "message.featuresWan": [
-    [
-      "message",
-      "Activer ou désactiver le module de fonctionnalités Wan."
-    ],
-    [
-      "description",
-      "Description de la fonctionnalité Wan"
-    ]
-  ],
-  "message.featuresProducer": [
-    [
-      "message",
-      "Activer ou désactiver le module de fonctionnalités Producer."
-    ],
-    [
-      "description",
-      "Description de la fonctionnalité Producer"
-    ]
-  ],
-  "message.featuresKimi": [
-    [
-      "message",
-      "Activer ou désactiver le module de fonctionnalités Kimi."
-    ],
-    [
-      "description",
-      "Description de la fonctionnalité Kimi"
-    ]
-  ],
-  "message.featuresSerp": [
-    [
-      "message",
-      "Activer ou désactiver le module de fonctionnalités SERP."
-    ],
-    [
-      "description",
-      "Description de la fonctionnalité SERP"
-    ]
-  ],
-  "message.featuresLuma": [
-    [
-      "message",
-      "Activer ou désactiver le module de fonctionnalités Luma."
-    ],
-    [
-      "description",
-      "Description de la fonctionnalité Luma"
-    ]
-  ],
-  "message.featuresPika": [
-    [
-      "message",
-      "Activer ou désactiver le module de fonctionnalités Pika."
-    ],
-    [
-      "description",
-      "Description de la fonctionnalité Pika"
-    ]
-  ],
-  "message.featuresKling": [
-    [
-      "message",
-      "Activer ou désactiver le module de fonctionnalités Kling."
-    ],
-    [
-      "description",
-      "Description de la fonctionnalité Kling"
-    ]
-  ],
-  "message.featuresHailuo": [
-    [
-      "message",
-      "Activer ou désactiver le module de fonctionnalités Hailuo."
-    ],
-    [
-      "description",
-      "Description de la fonctionnalité Hailuo"
-    ]
-  ],
-  "message.featuresHeadshots": [
-    [
-      "message",
-      "Activer ou désactiver le module de fonctionnalités AI Photo d'identité."
-    ],
-    [
-      "description",
-      "Description de la fonctionnalité AI Photo d'identité"
-    ]
-  ],
-  "message.featuresSupport": [
-    [
-      "message",
-      "Activer ou désactiver le support client"
-    ],
-    [
-      "description",
-      "Description de la fonctionnalité Support"
-    ]
-  ],
-  "message.featuresI18n": [
-    [
-      "message",
-      "Activer ou désactiver le support multilingue. Une fois désactivé, l'utilisateur ne peut utiliser que la langue par défaut."
-    ],
-    [
-      "description",
-      "Description du support multilingue"
-    ]
-  ],
-  "button.upload": [
-    [
-      "message",
-      "Télécharger"
-    ],
-    [
-      "description",
-      "Télécharger"
-    ]
-  ],
-  "button.enabled": [
-    [
-      "message",
-      "Activé"
-    ],
-    [
-      "description",
-      "Texte du commutateur, indiquant qu'il est activé"
-    ]
-  ],
-  "button.disabled": [
-    [
-      "message",
-      "Désactivé"
-    ],
-    [
-      "description",
-      "Texte du commutateur, indiquant qu'il est désactivé"
-    ]
-  ],
-  "field.featuresGemini": [
-    [
-      "message",
-      "Gemini"
-    ],
-    [
-      "description",
-      "Affiché comme le titre dans la boîte d'édition"
-    ]
-  ],
-  "message.featuresGemini": [
-    [
-      "message",
-      "Activer ou désactiver le module de fonctionnalités Gemini."
-    ],
-    [
-      "description",
-      "Description de la fonctionnalité Gemini"
-    ]
-  ],
-  "field.featuresClaude": [
-    [
-      "message",
-      "Claude"
-    ],
-    [
-      "description",
-      "Affiché comme le titre dans la boîte d'édition"
-    ]
-  ],
-  "message.featuresClaude": [
-    [
-      "message",
-      "Activer ou désactiver le module de fonctionnalités Claude."
-    ],
-    [
-      "description",
-      "Description de la fonctionnalité Claude"
-    ]
-  ]
+  "message.featuresSeedream": {
+    "message": "Activer ou désactiver le module de fonctionnalités SeeDream.",
+    "description": "Description de la fonctionnalité SeeDream"
+  },
+  "message.featuresSeedance": {
+    "message": "Activer ou désactiver le module de fonctionnalités SeeDance.",
+    "description": "Description de la fonctionnalité SeeDance"
+  },
+  "message.featuresWan": {
+    "message": "Activer ou désactiver le module de fonctionnalités Wan.",
+    "description": "Description de la fonctionnalité Wan"
+  },
+  "message.featuresProducer": {
+    "message": "Activer ou désactiver le module de fonctionnalités Producer.",
+    "description": "Description de la fonctionnalité Producer"
+  },
+  "message.featuresKimi": {
+    "message": "Activer ou désactiver le module de fonctionnalités Kimi.",
+    "description": "Description de la fonctionnalité Kimi"
+  },
+  "message.featuresSerp": {
+    "message": "Activer ou désactiver le module de fonctionnalités SERP.",
+    "description": "Description de la fonctionnalité SERP"
+  },
+  "message.featuresLuma": {
+    "message": "Activer ou désactiver le module de fonctionnalités Luma.",
+    "description": "Description de la fonctionnalité Luma"
+  },
+  "message.featuresPika": {
+    "message": "Activer ou désactiver le module de fonctionnalités Pika.",
+    "description": "Description de la fonctionnalité Pika"
+  },
+  "message.featuresKling": {
+    "message": "Activer ou désactiver le module de fonctionnalités Kling.",
+    "description": "Description de la fonctionnalité Kling"
+  },
+  "message.featuresHailuo": {
+    "message": "Activer ou désactiver le module de fonctionnalités Hailuo.",
+    "description": "Description de la fonctionnalité Hailuo"
+  },
+  "message.featuresHeadshots": {
+    "message": "Activer ou désactiver le module de fonctionnalités AI Photo d'identité.",
+    "description": "Description de la fonctionnalité AI Photo d'identité"
+  },
+  "message.featuresSupport": {
+    "message": "Activer ou désactiver le support client",
+    "description": "Description de la fonctionnalité Support"
+  },
+  "message.featuresI18n": {
+    "message": "Activer ou désactiver le support multilingue. Une fois désactivé, l'utilisateur ne peut utiliser que la langue par défaut.",
+    "description": "Description du support multilingue"
+  },
+  "button.upload": {
+    "message": "Télécharger",
+    "description": "Télécharger"
+  },
+  "button.enabled": {
+    "message": "Activé",
+    "description": "Texte du commutateur, indiquant qu'il est activé"
+  },
+  "button.disabled": {
+    "message": "Désactivé",
+    "description": "Texte du commutateur, indiquant qu'il est désactivé"
+  },
+  "field.featuresGemini": {
+    "message": "Gemini",
+    "description": "Affiché comme le titre dans la boîte d'édition"
+  },
+  "message.featuresGemini": {
+    "message": "Activer ou désactiver le module de fonctionnalités Gemini.",
+    "description": "Description de la fonctionnalité Gemini"
+  },
+  "field.featuresClaude": {
+    "message": "Claude",
+    "description": "Affiché comme le titre dans la boîte d'édition"
+  },
+  "message.featuresClaude": {
+    "message": "Activer ou désactiver le module de fonctionnalités Claude.",
+    "description": "Description de la fonctionnalité Claude"
+  }
 }

--- a/src/i18n/fr/site.json
+++ b/src/i18n/fr/site.json
@@ -1,442 +1,1110 @@
 {
-  "field.title": {
-    "message": "Titre du site",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "field.origin": {
-    "message": "Nom de domaine du site",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "field.description": {
-    "message": "Description du site",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "field.keywords": {
-    "message": "Mots-clés du site",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "field.logo": {
-    "message": "Logo du site",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "field.favicon": {
-    "message": "Favicon du site",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "field.qr": {
-    "message": "Code QR",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "field.url": {
-    "message": "Lien",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "field.admins": {
-    "message": "ID des administrateurs du site",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "field.distributionDefaultInviterId": {
-    "message": "ID de l'inviteur par défaut",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "field.distributionForceInviterId": {
-    "message": "ID de l'inviteur obligatoire",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "field.featuresChat": {
-    "message": "Chat",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "field.featuresVeo": {
-    "message": "Veo",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "field.featuresSora": {
-    "message": "Sora",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "field.featuresGrok": {
-    "message": "Grok",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "field.featuresDeepseek": {
-    "message": "Deepseek",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "field.featuresChatgpt": {
-    "message": "ChatGPT",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "field.featuresMidjourney": {
-    "message": "Midjourney",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "field.featuresChatdoc": {
-    "message": "Chatdoc",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "field.featuresQrart": {
-    "message": "Qrart",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "field.featuresLuma": {
-    "message": "Luma",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "field.featuresPixverse": {
-    "message": "Pixverse",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "field.featuresPika": {
-    "message": "Pika",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "field.featuresKling": {
-    "message": "Kling",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "field.featuresHailuo": {
-    "message": "Hailuo",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "field.featuresHeadshots": {
-    "message": "Photo d'identité AI",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "field.featuresSuno": {
-    "message": "Suno",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "field.featuresFlux": {
-    "message": "Flux",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "field.featuresNanobanana": {
-    "message": "Banane Nano",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "field.featuresSeedream": {
-    "message": "SeeDream",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "field.featuresSeedance": {
-    "message": "SeeDance",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "field.featuresWan": {
-    "message": "Wan",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "field.featuresProducer": {
-    "message": "Producteur",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "field.featuresKimi": {
-    "message": "Kimi",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "field.featuresSerp": {
-    "message": "SERP",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "field.featuresSupport": {
-    "message": "Support client",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "field.featuresI18n": {
-    "message": "Support multilingue",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "title.basicConfig": {
-    "message": "Configuration de base",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "title.seoConfig": {
-    "message": "Configuration SEO",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "title.editAdmins": {
-    "message": "Modifier les administrateurs",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "title.featuresConfig": {
-    "message": "Configuration des fonctionnalités",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "title.editTitle": {
-    "message": "Modifier le titre",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "title.editOrigin": {
-    "message": "Modifier le nom de domaine",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "title.editKeywords": {
-    "message": "Modifier les mots-clés",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "title.editLogo": {
-    "message": "Modifier le logo",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "title.editFavicon": {
-    "message": "Modifier le favicon",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "title.editDescription": {
-    "message": "Modifier la description",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "title.distributionConfig": {
-    "message": "Configuration de distribution",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "title.editDistributionDefaultInviterId": {
-    "message": "Modifier l'inviteur par défaut",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "title.editDistributionForceInviterId": {
-    "message": "Modifier l'inviteur obligatoire",
-    "description": "Affiché comme titre dans la zone d'édition"
-  },
-  "title.editQR": {
-    "message": "Modifier le QR code",
-    "description": "Titre affiché dans la zone d'édition"
-  },
-  "title.editUrl": {
-    "message": "Modifier le lien",
-    "description": "Titre affiché dans la zone d'édition"
-  },
-  "placeholder.title": {
-    "message": "Veuillez entrer le titre du site",
-    "description": "Titre affiché dans la zone d'édition"
-  },
-  "placeholder.origin": {
-    "message": "Veuillez entrer le domaine du site",
-    "description": "Titre affiché dans la zone d'édition"
-  },
-  "placeholder.editUrl": {
-    "message": "Veuillez entrer le lien",
-    "description": "Titre affiché dans la zone d'édition"
-  },
-  "placeholder.description": {
-    "message": "Veuillez entrer la description du site",
-    "description": "Titre affiché dans la zone d'édition"
-  },
-  "placeholder.keywords": {
-    "message": "Veuillez entrer les mots-clés du site",
-    "description": "Titre affiché dans la zone d'édition"
-  },
-  "placeholder.editDistributionDefaultInviterId": {
-    "message": "Veuillez entrer l'ID de l'inviteur par défaut",
-    "description": "Titre affiché dans la zone d'édition"
-  },
-  "placeholder.editDistributionForceInviterId": {
-    "message": "Veuillez entrer l'ID de l'inviteur forcé",
-    "description": "Titre affiché dans la zone d'édition"
-  },
-  "message.uploadImageExceed": {
-    "message": "Image téléchargée dépassant la limite",
-    "description": "Alerte lorsque l'image téléchargée dépasse la limite"
-  },
-  "message.uploadImageError": {
-    "message": "Erreur de téléchargement de l'image",
-    "description": "Alerte en cas d'erreur de téléchargement de l'image"
-  },
-  "message.editLogoTip": {
-    "message": "Taille recommandée : 200*60px",
-    "description": "Langage d'alerte pour le téléchargement d'image"
-  },
-  "message.editQRTip": {
-    "message": "Taille recommandée : 200*200px",
-    "description": "Langage d'alerte pour le téléchargement d'image"
-  },
-  "message.editFaviconTip": {
-    "message": "Taille recommandée : 32*32px",
-    "description": "Langage d'alerte pour le téléchargement d'image"
-  },
-  "message.editUrl": {
-    "message": "Veuillez entrer le lien",
-    "description": "Alerte pour entrer le lien"
-  },
-  "message.atLeastOneAdmin": {
-    "message": "Au moins un administrateur doit être conservé",
-    "description": "Alerte pour conserver au moins un administrateur"
-  },
-  "message.distributionDefaultInviterIdTip": {
-    "message": "ID utilisateur de l'inviteur par défaut. Si le lien de distribution ne contient pas le paramètre inviter_id, cet ID utilisateur sera utilisé par défaut comme invitateur.",
-    "description": "Alerte pour l'ID de l'inviteur par défaut"
-  },
-  "message.distributionForceInviterIdTip": {
-    "message": "ID utilisateur de l'inviteur forcé. Si cet ID est défini, il sera utilisé comme invitateur, que le lien de distribution contienne ou non le paramètre inviter_id.",
-    "description": "Alerte pour l'ID de l'inviteur forcé"
-  },
-  "message.originTip": {
-    "message": "Domaine du site, la configuration du site est liée au domaine et ne peut pas être modifiée.",
-    "description": "Alerte pour le domaine du site"
-  },
-  "message.titleTip": {
-    "message": "Titre du site, affiché dans l'onglet du navigateur.",
-    "description": "Alerte pour le titre du site"
-  },
-  "message.descriptionTip": {
-    "message": "Description du site, située dans les métadonnées du site, utilisée pour l'optimisation SEO.",
-    "description": "Alerte pour la description du site"
-  },
-  "message.logoTip": {
-    "message": "Logo du site, affiché en haut du menu du site lorsque le menu est développé.",
-    "description": "Alerte pour le logo du site"
-  },
-  "message.faviconTip": {
-    "message": "Favicon du site, affiché dans l'onglet du navigateur.",
-    "description": "Alerte pour le favicon du site"
-  },
-  "message.adminsTip": {
-    "message": "ID des administrateurs du site. Par défaut, l'utilisateur qui crée le site pour la première fois devient administrateur. Seuls les administrateurs du site peuvent gérer le site.",
-    "description": "Alerte pour les administrateurs du site"
-  },
-  "message.adminsTip2": {
-    "message": "Vous pouvez ajouter ou supprimer des ID d'administrateurs ici. Vous pouvez consulter les ID d'utilisateur sur https://auth.acedata.cloud",
-    "description": "Alerte pour les administrateurs du site"
-  },
-  "message.keywordsTip": {
-    "message": "Mots-clés du site, situés dans les métadonnées du site, utilisés pour l'optimisation SEO.",
-    "description": "Alerte pour les mots-clés du site"
-  },
-  "message.keywordsTip2": {
-    "message": "Vous pouvez ajouter ou supprimer des mots-clés du site ici. Plus les mots-clés sont précis, mieux c'est pour l'optimisation SEO.",
-    "description": "Alerte pour les mots-clés du site"
-  },
-  "message.featuresChat": {
-    "message": "Activer ou désactiver le module de fonction Chat.",
-    "description": "Description de la fonction Chat"
-  },
-  "message.featuresGrok": {
-    "message": "Activer ou désactiver le module de fonction Grok.",
-    "description": "Description de la fonction Grok"
-  },
-  "message.featuresDeepseek": {
-    "message": "Activer ou désactiver le module de fonction Deepseek.",
-    "description": "Description de la fonction Deepseek"
-  },
-  "message.featuresChatgpt": {
-    "message": "Activer ou désactiver le module de fonction ChatGPT.",
-    "description": "Description de la fonction ChatGPT"
-  },
-  "message.featuresMidjourney": {
-    "message": "Activer ou désactiver le module de fonction Midjourney.",
-    "description": "Description de la fonction Midjourney"
-  },
-  "message.featuresChatdoc": {
-    "message": "Activer ou désactiver le module de fonction Chatdoc.",
-    "description": "Description de la fonction Chatdoc"
-  },
-  "message.featuresQrart": {
-    "message": "Activer ou désactiver le module de fonction Qrart.",
-    "description": "Description de la fonction Qrart"
-  },
-  "message.featuresVeo": {
-    "message": "Activer ou désactiver le module de fonction Veo.",
-    "description": "Description de la fonction Veo"
-  },
-  "message.featuresSora": {
-    "message": "Activer ou désactiver le module de fonction Sora.",
-    "description": "Description de la fonction Sora"
-  },
-  "message.featuresSuno": {
-    "message": "Activer ou désactiver le module de fonction Suno.",
-    "description": "Description de la fonction Suno"
-  },
-  "message.featuresPixverse": {
-    "message": "Activer ou désactiver le module de fonctionnalités Pixverse.",
-    "description": "Description de la fonctionnalité Pixverse"
-  },
-  "message.featuresFlux": {
-    "message": "Activer ou désactiver le module de fonctionnalités FLux.",
-    "description": "Description de la fonctionnalité FLux"
-  },
-  "message.featuresNanobanana": {
-    "message": "Activer ou désactiver le module de fonctionnalités Nano Banana.",
-    "description": "Description de la fonctionnalité Nano Banana"
-  },
-  "message.featuresSeedream": {
-    "message": "Activer ou désactiver le module de fonctionnalités SeeDream.",
-    "description": "Description de la fonctionnalité SeeDream"
-  },
-  "message.featuresSeedance": {
-    "message": "Activer ou désactiver le module de fonctionnalités SeeDance.",
-    "description": "Description de la fonctionnalité SeeDance"
-  },
-  "message.featuresWan": {
-    "message": "Activer ou désactiver le module de fonctionnalités Wan.",
-    "description": "Description de la fonctionnalité Wan"
-  },
-  "message.featuresProducer": {
-    "message": "Activer ou désactiver le module de fonctionnalités Producer.",
-    "description": "Description de la fonctionnalité Producer"
-  },
-  "message.featuresKimi": {
-    "message": "Activer ou désactiver le module de fonctionnalités Kimi.",
-    "description": "Description de la fonctionnalité Kimi"
-  },
-  "message.featuresSerp": {
-    "message": "Activer ou désactiver le module de fonctionnalités SERP.",
-    "description": "Description de la fonctionnalité SERP"
-  },
-  "message.featuresLuma": {
-    "message": "Activer ou désactiver le module de fonctionnalités Luma.",
-    "description": "Description de la fonctionnalité Luma"
-  },
-  "message.featuresPika": {
-    "message": "Activer ou désactiver le module de fonctionnalités Pika.",
-    "description": "Description de la fonctionnalité Pika"
-  },
-  "message.featuresKling": {
-    "message": "Activer ou désactiver le module de fonctionnalités Kling.",
-    "description": "Description de la fonctionnalité Kling"
-  },
-  "message.featuresHailuo": {
-    "message": "Activer ou désactiver le module de fonctionnalités Hailuo.",
-    "description": "Description de la fonctionnalité Hailuo"
-  },
-  "message.featuresHeadshots": {
-    "message": "Activer ou désactiver le module de fonctionnalités AI Photo d'identité.",
-    "description": "Description de la fonctionnalité AI Photo d'identité"
-  },
-  "message.featuresSupport": {
-    "message": "Activer ou désactiver le support client",
-    "description": "Description de la fonctionnalité Support"
-  },
-  "message.featuresI18n": {
-    "message": "Activer ou désactiver le support multilingue. Une fois désactivé, l'utilisateur ne peut utiliser que la langue par défaut.",
-    "description": "Description du support multilingue"
-  },
-  "button.upload": {
-    "message": "Télécharger",
-    "description": "Télécharger"
-  },
-  "button.enabled": {
-    "message": "Activé",
-    "description": "Texte du commutateur, indiquant qu'il est activé"
-  },
-  "button.disabled": {
-    "message": "Désactivé",
-    "description": "Texte du commutateur, indiquant qu'il est désactivé"
-  },
-  "field.featuresGemini": {
-    "message": "Gemini",
-    "description": "Affiché comme le titre dans la boîte d'édition"
-  },
-  "message.featuresGemini": {
-    "message": "Activer ou désactiver le module de fonctionnalités Gemini.",
-    "description": "Description de la fonctionnalité Gemini"
-  },
-  "field.featuresClaude": {
-    "message": "Claude",
-    "description": "Affiché comme le titre dans la boîte d'édition"
-  },
-  "message.featuresClaude": {
-    "message": "Activer ou désactiver le module de fonctionnalités Claude.",
-    "description": "Description de la fonctionnalité Claude"
-  }
+  "field.title": [
+    [
+      "message",
+      "Titre du site"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "field.origin": [
+    [
+      "message",
+      "Nom de domaine du site"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "field.description": [
+    [
+      "message",
+      "Description du site"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "field.keywords": [
+    [
+      "message",
+      "Mots-clés du site"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "field.logo": [
+    [
+      "message",
+      "Logo du site"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "field.favicon": [
+    [
+      "message",
+      "Favicon du site"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "field.qr": [
+    [
+      "message",
+      "Code QR"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "field.url": [
+    [
+      "message",
+      "Lien"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "field.admins": [
+    [
+      "message",
+      "ID des administrateurs du site"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "field.distributionDefaultInviterId": [
+    [
+      "message",
+      "ID de l'inviteur par défaut"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "field.distributionForceInviterId": [
+    [
+      "message",
+      "ID de l'inviteur obligatoire"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "field.featuresChat": [
+    [
+      "message",
+      "Chat"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "field.featuresVeo": [
+    [
+      "message",
+      "Veo"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "field.featuresSora": [
+    [
+      "message",
+      "Sora"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "field.featuresGrok": [
+    [
+      "message",
+      "Grok"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "field.featuresDeepseek": [
+    [
+      "message",
+      "Deepseek"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "field.featuresChatgpt": [
+    [
+      "message",
+      "ChatGPT"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "field.featuresMidjourney": [
+    [
+      "message",
+      "Midjourney"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "field.featuresChatdoc": [
+    [
+      "message",
+      "Chatdoc"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "field.featuresQrart": [
+    [
+      "message",
+      "Qrart"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "field.featuresLuma": [
+    [
+      "message",
+      "Luma"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "field.featuresPixverse": [
+    [
+      "message",
+      "Pixverse"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "field.featuresPika": [
+    [
+      "message",
+      "Pika"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "field.featuresKling": [
+    [
+      "message",
+      "Kling"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "field.featuresHailuo": [
+    [
+      "message",
+      "Hailuo"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "field.featuresHeadshots": [
+    [
+      "message",
+      "Photo d'identité AI"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "field.featuresSuno": [
+    [
+      "message",
+      "Suno"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "field.featuresFlux": [
+    [
+      "message",
+      "Flux"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "field.featuresNanobanana": [
+    [
+      "message",
+      "Banane Nano"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "field.featuresOpenaiimage": {
+    "message": "OpenAI Image",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresSeedream": [
+    [
+      "message",
+      "SeeDream"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "field.featuresSeedance": [
+    [
+      "message",
+      "SeeDance"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "field.featuresWan": [
+    [
+      "message",
+      "Wan"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "field.featuresProducer": [
+    [
+      "message",
+      "Producteur"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "field.featuresKimi": [
+    [
+      "message",
+      "Kimi"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "field.featuresSerp": [
+    [
+      "message",
+      "SERP"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "field.featuresSupport": [
+    [
+      "message",
+      "Support client"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "field.featuresI18n": [
+    [
+      "message",
+      "Support multilingue"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "title.basicConfig": [
+    [
+      "message",
+      "Configuration de base"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "title.seoConfig": [
+    [
+      "message",
+      "Configuration SEO"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "title.editAdmins": [
+    [
+      "message",
+      "Modifier les administrateurs"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "title.featuresConfig": [
+    [
+      "message",
+      "Configuration des fonctionnalités"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "title.editTitle": [
+    [
+      "message",
+      "Modifier le titre"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "title.editOrigin": [
+    [
+      "message",
+      "Modifier le nom de domaine"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "title.editKeywords": [
+    [
+      "message",
+      "Modifier les mots-clés"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "title.editLogo": [
+    [
+      "message",
+      "Modifier le logo"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "title.editFavicon": [
+    [
+      "message",
+      "Modifier le favicon"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "title.editDescription": [
+    [
+      "message",
+      "Modifier la description"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "title.distributionConfig": [
+    [
+      "message",
+      "Configuration de distribution"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "title.editDistributionDefaultInviterId": [
+    [
+      "message",
+      "Modifier l'inviteur par défaut"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "title.editDistributionForceInviterId": [
+    [
+      "message",
+      "Modifier l'inviteur obligatoire"
+    ],
+    [
+      "description",
+      "Affiché comme titre dans la zone d'édition"
+    ]
+  ],
+  "title.editQR": [
+    [
+      "message",
+      "Modifier le QR code"
+    ],
+    [
+      "description",
+      "Titre affiché dans la zone d'édition"
+    ]
+  ],
+  "title.editUrl": [
+    [
+      "message",
+      "Modifier le lien"
+    ],
+    [
+      "description",
+      "Titre affiché dans la zone d'édition"
+    ]
+  ],
+  "placeholder.title": [
+    [
+      "message",
+      "Veuillez entrer le titre du site"
+    ],
+    [
+      "description",
+      "Titre affiché dans la zone d'édition"
+    ]
+  ],
+  "placeholder.origin": [
+    [
+      "message",
+      "Veuillez entrer le domaine du site"
+    ],
+    [
+      "description",
+      "Titre affiché dans la zone d'édition"
+    ]
+  ],
+  "placeholder.editUrl": [
+    [
+      "message",
+      "Veuillez entrer le lien"
+    ],
+    [
+      "description",
+      "Titre affiché dans la zone d'édition"
+    ]
+  ],
+  "placeholder.description": [
+    [
+      "message",
+      "Veuillez entrer la description du site"
+    ],
+    [
+      "description",
+      "Titre affiché dans la zone d'édition"
+    ]
+  ],
+  "placeholder.keywords": [
+    [
+      "message",
+      "Veuillez entrer les mots-clés du site"
+    ],
+    [
+      "description",
+      "Titre affiché dans la zone d'édition"
+    ]
+  ],
+  "placeholder.editDistributionDefaultInviterId": [
+    [
+      "message",
+      "Veuillez entrer l'ID de l'inviteur par défaut"
+    ],
+    [
+      "description",
+      "Titre affiché dans la zone d'édition"
+    ]
+  ],
+  "placeholder.editDistributionForceInviterId": [
+    [
+      "message",
+      "Veuillez entrer l'ID de l'inviteur forcé"
+    ],
+    [
+      "description",
+      "Titre affiché dans la zone d'édition"
+    ]
+  ],
+  "message.uploadImageExceed": [
+    [
+      "message",
+      "Image téléchargée dépassant la limite"
+    ],
+    [
+      "description",
+      "Alerte lorsque l'image téléchargée dépasse la limite"
+    ]
+  ],
+  "message.uploadImageError": [
+    [
+      "message",
+      "Erreur de téléchargement de l'image"
+    ],
+    [
+      "description",
+      "Alerte en cas d'erreur de téléchargement de l'image"
+    ]
+  ],
+  "message.editLogoTip": [
+    [
+      "message",
+      "Taille recommandée : 200*60px"
+    ],
+    [
+      "description",
+      "Langage d'alerte pour le téléchargement d'image"
+    ]
+  ],
+  "message.editQRTip": [
+    [
+      "message",
+      "Taille recommandée : 200*200px"
+    ],
+    [
+      "description",
+      "Langage d'alerte pour le téléchargement d'image"
+    ]
+  ],
+  "message.editFaviconTip": [
+    [
+      "message",
+      "Taille recommandée : 32*32px"
+    ],
+    [
+      "description",
+      "Langage d'alerte pour le téléchargement d'image"
+    ]
+  ],
+  "message.editUrl": [
+    [
+      "message",
+      "Veuillez entrer le lien"
+    ],
+    [
+      "description",
+      "Alerte pour entrer le lien"
+    ]
+  ],
+  "message.atLeastOneAdmin": [
+    [
+      "message",
+      "Au moins un administrateur doit être conservé"
+    ],
+    [
+      "description",
+      "Alerte pour conserver au moins un administrateur"
+    ]
+  ],
+  "message.distributionDefaultInviterIdTip": [
+    [
+      "message",
+      "ID utilisateur de l'inviteur par défaut. Si le lien de distribution ne contient pas le paramètre inviter_id, cet ID utilisateur sera utilisé par défaut comme invitateur."
+    ],
+    [
+      "description",
+      "Alerte pour l'ID de l'inviteur par défaut"
+    ]
+  ],
+  "message.distributionForceInviterIdTip": [
+    [
+      "message",
+      "ID utilisateur de l'inviteur forcé. Si cet ID est défini, il sera utilisé comme invitateur, que le lien de distribution contienne ou non le paramètre inviter_id."
+    ],
+    [
+      "description",
+      "Alerte pour l'ID de l'inviteur forcé"
+    ]
+  ],
+  "message.originTip": [
+    [
+      "message",
+      "Domaine du site, la configuration du site est liée au domaine et ne peut pas être modifiée."
+    ],
+    [
+      "description",
+      "Alerte pour le domaine du site"
+    ]
+  ],
+  "message.titleTip": [
+    [
+      "message",
+      "Titre du site, affiché dans l'onglet du navigateur."
+    ],
+    [
+      "description",
+      "Alerte pour le titre du site"
+    ]
+  ],
+  "message.descriptionTip": [
+    [
+      "message",
+      "Description du site, située dans les métadonnées du site, utilisée pour l'optimisation SEO."
+    ],
+    [
+      "description",
+      "Alerte pour la description du site"
+    ]
+  ],
+  "message.logoTip": [
+    [
+      "message",
+      "Logo du site, affiché en haut du menu du site lorsque le menu est développé."
+    ],
+    [
+      "description",
+      "Alerte pour le logo du site"
+    ]
+  ],
+  "message.faviconTip": [
+    [
+      "message",
+      "Favicon du site, affiché dans l'onglet du navigateur."
+    ],
+    [
+      "description",
+      "Alerte pour le favicon du site"
+    ]
+  ],
+  "message.adminsTip": [
+    [
+      "message",
+      "ID des administrateurs du site. Par défaut, l'utilisateur qui crée le site pour la première fois devient administrateur. Seuls les administrateurs du site peuvent gérer le site."
+    ],
+    [
+      "description",
+      "Alerte pour les administrateurs du site"
+    ]
+  ],
+  "message.adminsTip2": [
+    [
+      "message",
+      "Vous pouvez ajouter ou supprimer des ID d'administrateurs ici. Vous pouvez consulter les ID d'utilisateur sur https://auth.acedata.cloud"
+    ],
+    [
+      "description",
+      "Alerte pour les administrateurs du site"
+    ]
+  ],
+  "message.keywordsTip": [
+    [
+      "message",
+      "Mots-clés du site, situés dans les métadonnées du site, utilisés pour l'optimisation SEO."
+    ],
+    [
+      "description",
+      "Alerte pour les mots-clés du site"
+    ]
+  ],
+  "message.keywordsTip2": [
+    [
+      "message",
+      "Vous pouvez ajouter ou supprimer des mots-clés du site ici. Plus les mots-clés sont précis, mieux c'est pour l'optimisation SEO."
+    ],
+    [
+      "description",
+      "Alerte pour les mots-clés du site"
+    ]
+  ],
+  "message.featuresChat": [
+    [
+      "message",
+      "Activer ou désactiver le module de fonction Chat."
+    ],
+    [
+      "description",
+      "Description de la fonction Chat"
+    ]
+  ],
+  "message.featuresGrok": [
+    [
+      "message",
+      "Activer ou désactiver le module de fonction Grok."
+    ],
+    [
+      "description",
+      "Description de la fonction Grok"
+    ]
+  ],
+  "message.featuresDeepseek": [
+    [
+      "message",
+      "Activer ou désactiver le module de fonction Deepseek."
+    ],
+    [
+      "description",
+      "Description de la fonction Deepseek"
+    ]
+  ],
+  "message.featuresChatgpt": [
+    [
+      "message",
+      "Activer ou désactiver le module de fonction ChatGPT."
+    ],
+    [
+      "description",
+      "Description de la fonction ChatGPT"
+    ]
+  ],
+  "message.featuresMidjourney": [
+    [
+      "message",
+      "Activer ou désactiver le module de fonction Midjourney."
+    ],
+    [
+      "description",
+      "Description de la fonction Midjourney"
+    ]
+  ],
+  "message.featuresChatdoc": [
+    [
+      "message",
+      "Activer ou désactiver le module de fonction Chatdoc."
+    ],
+    [
+      "description",
+      "Description de la fonction Chatdoc"
+    ]
+  ],
+  "message.featuresQrart": [
+    [
+      "message",
+      "Activer ou désactiver le module de fonction Qrart."
+    ],
+    [
+      "description",
+      "Description de la fonction Qrart"
+    ]
+  ],
+  "message.featuresVeo": [
+    [
+      "message",
+      "Activer ou désactiver le module de fonction Veo."
+    ],
+    [
+      "description",
+      "Description de la fonction Veo"
+    ]
+  ],
+  "message.featuresSora": [
+    [
+      "message",
+      "Activer ou désactiver le module de fonction Sora."
+    ],
+    [
+      "description",
+      "Description de la fonction Sora"
+    ]
+  ],
+  "message.featuresSuno": [
+    [
+      "message",
+      "Activer ou désactiver le module de fonction Suno."
+    ],
+    [
+      "description",
+      "Description de la fonction Suno"
+    ]
+  ],
+  "message.featuresPixverse": [
+    [
+      "message",
+      "Activer ou désactiver le module de fonctionnalités Pixverse."
+    ],
+    [
+      "description",
+      "Description de la fonctionnalité Pixverse"
+    ]
+  ],
+  "message.featuresFlux": [
+    [
+      "message",
+      "Activer ou désactiver le module de fonctionnalités FLux."
+    ],
+    [
+      "description",
+      "Description de la fonctionnalité FLux"
+    ]
+  ],
+  "message.featuresNanobanana": [
+    [
+      "message",
+      "Activer ou désactiver le module de fonctionnalités Nano Banana."
+    ],
+    [
+      "description",
+      "Description de la fonctionnalité Nano Banana"
+    ]
+  ],
+  "message.featuresOpenaiimage": {
+    "message": "Toggle OpenAI Image feature module.",
+    "description": "Description of the OpenAI Image feature"
+  },
+  "message.featuresSeedream": [
+    [
+      "message",
+      "Activer ou désactiver le module de fonctionnalités SeeDream."
+    ],
+    [
+      "description",
+      "Description de la fonctionnalité SeeDream"
+    ]
+  ],
+  "message.featuresSeedance": [
+    [
+      "message",
+      "Activer ou désactiver le module de fonctionnalités SeeDance."
+    ],
+    [
+      "description",
+      "Description de la fonctionnalité SeeDance"
+    ]
+  ],
+  "message.featuresWan": [
+    [
+      "message",
+      "Activer ou désactiver le module de fonctionnalités Wan."
+    ],
+    [
+      "description",
+      "Description de la fonctionnalité Wan"
+    ]
+  ],
+  "message.featuresProducer": [
+    [
+      "message",
+      "Activer ou désactiver le module de fonctionnalités Producer."
+    ],
+    [
+      "description",
+      "Description de la fonctionnalité Producer"
+    ]
+  ],
+  "message.featuresKimi": [
+    [
+      "message",
+      "Activer ou désactiver le module de fonctionnalités Kimi."
+    ],
+    [
+      "description",
+      "Description de la fonctionnalité Kimi"
+    ]
+  ],
+  "message.featuresSerp": [
+    [
+      "message",
+      "Activer ou désactiver le module de fonctionnalités SERP."
+    ],
+    [
+      "description",
+      "Description de la fonctionnalité SERP"
+    ]
+  ],
+  "message.featuresLuma": [
+    [
+      "message",
+      "Activer ou désactiver le module de fonctionnalités Luma."
+    ],
+    [
+      "description",
+      "Description de la fonctionnalité Luma"
+    ]
+  ],
+  "message.featuresPika": [
+    [
+      "message",
+      "Activer ou désactiver le module de fonctionnalités Pika."
+    ],
+    [
+      "description",
+      "Description de la fonctionnalité Pika"
+    ]
+  ],
+  "message.featuresKling": [
+    [
+      "message",
+      "Activer ou désactiver le module de fonctionnalités Kling."
+    ],
+    [
+      "description",
+      "Description de la fonctionnalité Kling"
+    ]
+  ],
+  "message.featuresHailuo": [
+    [
+      "message",
+      "Activer ou désactiver le module de fonctionnalités Hailuo."
+    ],
+    [
+      "description",
+      "Description de la fonctionnalité Hailuo"
+    ]
+  ],
+  "message.featuresHeadshots": [
+    [
+      "message",
+      "Activer ou désactiver le module de fonctionnalités AI Photo d'identité."
+    ],
+    [
+      "description",
+      "Description de la fonctionnalité AI Photo d'identité"
+    ]
+  ],
+  "message.featuresSupport": [
+    [
+      "message",
+      "Activer ou désactiver le support client"
+    ],
+    [
+      "description",
+      "Description de la fonctionnalité Support"
+    ]
+  ],
+  "message.featuresI18n": [
+    [
+      "message",
+      "Activer ou désactiver le support multilingue. Une fois désactivé, l'utilisateur ne peut utiliser que la langue par défaut."
+    ],
+    [
+      "description",
+      "Description du support multilingue"
+    ]
+  ],
+  "button.upload": [
+    [
+      "message",
+      "Télécharger"
+    ],
+    [
+      "description",
+      "Télécharger"
+    ]
+  ],
+  "button.enabled": [
+    [
+      "message",
+      "Activé"
+    ],
+    [
+      "description",
+      "Texte du commutateur, indiquant qu'il est activé"
+    ]
+  ],
+  "button.disabled": [
+    [
+      "message",
+      "Désactivé"
+    ],
+    [
+      "description",
+      "Texte du commutateur, indiquant qu'il est désactivé"
+    ]
+  ],
+  "field.featuresGemini": [
+    [
+      "message",
+      "Gemini"
+    ],
+    [
+      "description",
+      "Affiché comme le titre dans la boîte d'édition"
+    ]
+  ],
+  "message.featuresGemini": [
+    [
+      "message",
+      "Activer ou désactiver le module de fonctionnalités Gemini."
+    ],
+    [
+      "description",
+      "Description de la fonctionnalité Gemini"
+    ]
+  ],
+  "field.featuresClaude": [
+    [
+      "message",
+      "Claude"
+    ],
+    [
+      "description",
+      "Affiché comme le titre dans la boîte d'édition"
+    ]
+  ],
+  "message.featuresClaude": [
+    [
+      "message",
+      "Activer ou désactiver le module de fonctionnalités Claude."
+    ],
+    [
+      "description",
+      "Description de la fonctionnalité Claude"
+    ]
+  ]
 }

--- a/src/i18n/it/site.json
+++ b/src/i18n/it/site.json
@@ -1,1110 +1,450 @@
 {
-  "field.title": [
-    [
-      "message",
-      "Titolo del sito"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "field.origin": [
-    [
-      "message",
-      "Dominio del sito"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "field.description": [
-    [
-      "message",
-      "Descrizione del sito"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "field.keywords": [
-    [
-      "message",
-      "Parole chiave del sito"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "field.logo": [
-    [
-      "message",
-      "Logo del sito"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "field.favicon": [
-    [
-      "message",
-      "Favicon del sito"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "field.qr": [
-    [
-      "message",
-      "Codice QR"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "field.url": [
-    [
-      "message",
-      "Link"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "field.admins": [
-    [
-      "message",
-      "ID amministratori del sito"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "field.distributionDefaultInviterId": [
-    [
-      "message",
-      "ID invitante predefinito"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "field.distributionForceInviterId": [
-    [
-      "message",
-      "ID invitante obbligatorio"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "field.featuresChat": [
-    [
-      "message",
-      "Chat"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "field.featuresVeo": [
-    [
-      "message",
-      "Veo"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "field.featuresSora": [
-    [
-      "message",
-      "Sora"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "field.featuresGrok": [
-    [
-      "message",
-      "Grok"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "field.featuresDeepseek": [
-    [
-      "message",
-      "Deepseek"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "field.featuresChatgpt": [
-    [
-      "message",
-      "ChatGPT"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "field.featuresMidjourney": [
-    [
-      "message",
-      "Midjourney"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "field.featuresChatdoc": [
-    [
-      "message",
-      "Chatdoc"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "field.featuresQrart": [
-    [
-      "message",
-      "Qrart"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "field.featuresLuma": [
-    [
-      "message",
-      "Luma"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "field.featuresPixverse": [
-    [
-      "message",
-      "Pixverse"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "field.featuresPika": [
-    [
-      "message",
-      "Pika"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "field.featuresKling": [
-    [
-      "message",
-      "Kling"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "field.featuresHailuo": [
-    [
-      "message",
-      "Hailuo"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "field.featuresHeadshots": [
-    [
-      "message",
-      "Foto identificativa AI"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "field.featuresSuno": [
-    [
-      "message",
-      "Suno"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "field.featuresFlux": [
-    [
-      "message",
-      "Flux"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "field.featuresNanobanana": [
-    [
-      "message",
-      "Nano Banana"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
+  "field.title": {
+    "message": "Titolo del sito",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "field.origin": {
+    "message": "Dominio del sito",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "field.description": {
+    "message": "Descrizione del sito",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "field.keywords": {
+    "message": "Parole chiave del sito",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "field.logo": {
+    "message": "Logo del sito",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "field.favicon": {
+    "message": "Favicon del sito",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "field.qr": {
+    "message": "Codice QR",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "field.url": {
+    "message": "Link",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "field.admins": {
+    "message": "ID amministratori del sito",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "field.distributionDefaultInviterId": {
+    "message": "ID invitante predefinito",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "field.distributionForceInviterId": {
+    "message": "ID invitante obbligatorio",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "field.featuresChat": {
+    "message": "Chat",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "field.featuresVeo": {
+    "message": "Veo",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "field.featuresSora": {
+    "message": "Sora",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "field.featuresGrok": {
+    "message": "Grok",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "field.featuresDeepseek": {
+    "message": "Deepseek",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "field.featuresChatgpt": {
+    "message": "ChatGPT",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "field.featuresMidjourney": {
+    "message": "Midjourney",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "field.featuresChatdoc": {
+    "message": "Chatdoc",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "field.featuresQrart": {
+    "message": "Qrart",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "field.featuresLuma": {
+    "message": "Luma",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "field.featuresPixverse": {
+    "message": "Pixverse",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "field.featuresPika": {
+    "message": "Pika",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "field.featuresKling": {
+    "message": "Kling",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "field.featuresHailuo": {
+    "message": "Hailuo",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "field.featuresHeadshots": {
+    "message": "Foto identificativa AI",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "field.featuresSuno": {
+    "message": "Suno",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "field.featuresFlux": {
+    "message": "Flux",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "field.featuresNanobanana": {
+    "message": "Nano Banana",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
   "field.featuresOpenaiimage": {
     "message": "OpenAI Image",
     "description": "Displayed as the title in the editing box"
   },
-  "field.featuresSeedream": [
-    [
-      "message",
-      "SeeDream"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "field.featuresSeedance": [
-    [
-      "message",
-      "SeeDance"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "field.featuresWan": [
-    [
-      "message",
-      "Wan"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "field.featuresProducer": [
-    [
-      "message",
-      "Produttore"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "field.featuresKimi": [
-    [
-      "message",
-      "Kimi"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "field.featuresSerp": [
-    [
-      "message",
-      "SERP"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "field.featuresSupport": [
-    [
-      "message",
-      "Supporto clienti"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "field.featuresI18n": [
-    [
-      "message",
-      "Supporto multilingue"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "title.basicConfig": [
-    [
-      "message",
-      "Configurazione di base"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "title.seoConfig": [
-    [
-      "message",
-      "Configurazione SEO"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "title.editAdmins": [
-    [
-      "message",
-      "Modifica amministratori"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "title.featuresConfig": [
-    [
-      "message",
-      "Configurazione funzionalità"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "title.editTitle": [
-    [
-      "message",
-      "Modifica titolo"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "title.editOrigin": [
-    [
-      "message",
-      "Modifica dominio"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "title.editKeywords": [
-    [
-      "message",
-      "Modifica parole chiave"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "title.editLogo": [
-    [
-      "message",
-      "Modifica logo"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "title.editFavicon": [
-    [
-      "message",
-      "Modifica favicon"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "title.editDescription": [
-    [
-      "message",
-      "Modifica descrizione"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "title.distributionConfig": [
-    [
-      "message",
-      "Configurazione distribuzione"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "title.editDistributionDefaultInviterId": [
-    [
-      "message",
-      "Modifica invitante predefinito"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "title.editDistributionForceInviterId": [
-    [
-      "message",
-      "Modifica invitante obbligatorio"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "title.editQR": [
-    [
-      "message",
-      "Modifica QR Code"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "title.editUrl": [
-    [
-      "message",
-      "Modifica Link"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "placeholder.title": [
-    [
-      "message",
-      "Inserisci il titolo del sito"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "placeholder.origin": [
-    [
-      "message",
-      "Inserisci il dominio del sito"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "placeholder.editUrl": [
-    [
-      "message",
-      "Inserisci il link"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "placeholder.description": [
-    [
-      "message",
-      "Inserisci la descrizione del sito"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "placeholder.keywords": [
-    [
-      "message",
-      "Inserisci le parole chiave del sito"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "placeholder.editDistributionDefaultInviterId": [
-    [
-      "message",
-      "Inserisci l'ID dell'invitante predefinito"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "placeholder.editDistributionForceInviterId": [
-    [
-      "message",
-      "Inserisci l'ID dell'invitante forzato"
-    ],
-    [
-      "description",
-      "Mostrato come titolo nella casella di modifica"
-    ]
-  ],
-  "message.uploadImageExceed": [
-    [
-      "message",
-      "Immagine caricata oltre il limite"
-    ],
-    [
-      "description",
-      "Messaggio di avviso per superamento limite di caricamento"
-    ]
-  ],
-  "message.uploadImageError": [
-    [
-      "message",
-      "Errore nel caricamento dell'immagine"
-    ],
-    [
-      "description",
-      "Messaggio di avviso per errore di caricamento"
-    ]
-  ],
-  "message.editLogoTip": [
-    [
-      "message",
-      "Dimensione consigliata: 200*60px"
-    ],
-    [
-      "description",
-      "Lingua di avviso per il caricamento dell'immagine"
-    ]
-  ],
-  "message.editQRTip": [
-    [
-      "message",
-      "Dimensione consigliata: 200*200px"
-    ],
-    [
-      "description",
-      "Lingua di avviso per il caricamento dell'immagine"
-    ]
-  ],
-  "message.editFaviconTip": [
-    [
-      "message",
-      "Dimensione consigliata: 32*32px"
-    ],
-    [
-      "description",
-      "Lingua di avviso per il caricamento dell'immagine"
-    ]
-  ],
-  "message.editUrl": [
-    [
-      "message",
-      "Inserisci il link"
-    ],
-    [
-      "description",
-      "Messaggio di avviso per inserire il link"
-    ]
-  ],
-  "message.atLeastOneAdmin": [
-    [
-      "message",
-      "Devi mantenere almeno un amministratore"
-    ],
-    [
-      "description",
-      "Messaggio di avviso per la presenza di un amministratore"
-    ]
-  ],
-  "message.distributionDefaultInviterIdTip": [
-    [
-      "message",
-      "ID utente dell'invitante predefinito. Se il link di distribuzione non include il parametro inviter_id, verrà utilizzato questo ID come invitante."
-    ],
-    [
-      "description",
-      "Messaggio di avviso per l'ID dell'invitante predefinito"
-    ]
-  ],
-  "message.distributionForceInviterIdTip": [
-    [
-      "message",
-      "ID utente dell'invitante forzato. Se impostato, questo ID sarà utilizzato come invitante indipendentemente dalla presenza del parametro inviter_id nel link di distribuzione."
-    ],
-    [
-      "description",
-      "Messaggio di avviso per l'ID dell'invitante forzato"
-    ]
-  ],
-  "message.originTip": [
-    [
-      "message",
-      "Dominio del sito. La configurazione del sito è legata al dominio e non può essere modificata."
-    ],
-    [
-      "description",
-      "Messaggio di avviso per il dominio del sito"
-    ]
-  ],
-  "message.titleTip": [
-    [
-      "message",
-      "Titolo del sito, mostrato nella scheda del browser."
-    ],
-    [
-      "description",
-      "Messaggio di avviso per il titolo del sito"
-    ]
-  ],
-  "message.descriptionTip": [
-    [
-      "message",
-      "Descrizione del sito, presente nei metadati del sito, utile per l'ottimizzazione SEO."
-    ],
-    [
-      "description",
-      "Messaggio di avviso per la descrizione del sito"
-    ]
-  ],
-  "message.logoTip": [
-    [
-      "message",
-      "Logo del sito, mostrato in cima al menu del sito quando il menu è espanso."
-    ],
-    [
-      "description",
-      "Messaggio di avviso per il logo del sito"
-    ]
-  ],
-  "message.faviconTip": [
-    [
-      "message",
-      "Favicon del sito, mostrato nella scheda del browser."
-    ],
-    [
-      "description",
-      "Messaggio di avviso per il favicon del sito"
-    ]
-  ],
-  "message.adminsTip": [
-    [
-      "message",
-      "ID degli amministratori del sito. L'utente che crea il sito diventa automaticamente amministratore. Solo gli amministratori possono gestire il sito."
-    ],
-    [
-      "description",
-      "Messaggio di avviso per gli amministratori del sito"
-    ]
-  ],
-  "message.adminsTip2": [
-    [
-      "message",
-      "Puoi aggiungere o rimuovere ID amministratori qui. Puoi visualizzare gli ID utente su https://auth.acedata.cloud"
-    ],
-    [
-      "description",
-      "Messaggio di avviso per gli amministratori del sito"
-    ]
-  ],
-  "message.keywordsTip": [
-    [
-      "message",
-      "Parole chiave del sito, presenti nei metadati del sito, utili per l'ottimizzazione SEO."
-    ],
-    [
-      "description",
-      "Messaggio di avviso per le parole chiave del sito"
-    ]
-  ],
-  "message.keywordsTip2": [
-    [
-      "message",
-      "Puoi aggiungere o rimuovere parole chiave qui. Parole chiave più precise sono più vantaggiose per l'ottimizzazione SEO."
-    ],
-    [
-      "description",
-      "Messaggio di avviso per le parole chiave del sito"
-    ]
-  ],
-  "message.featuresChat": [
-    [
-      "message",
-      "Attiva o disattiva il modulo Chat."
-    ],
-    [
-      "description",
-      "Descrizione della funzionalità Chat"
-    ]
-  ],
-  "message.featuresGrok": [
-    [
-      "message",
-      "Attiva o disattiva il modulo Grok."
-    ],
-    [
-      "description",
-      "Descrizione della funzionalità Grok"
-    ]
-  ],
-  "message.featuresDeepseek": [
-    [
-      "message",
-      "Attiva o disattiva il modulo Deepseek."
-    ],
-    [
-      "description",
-      "Descrizione della funzionalità Deepseek"
-    ]
-  ],
-  "message.featuresChatgpt": [
-    [
-      "message",
-      "Attiva o disattiva il modulo ChatGPT."
-    ],
-    [
-      "description",
-      "Descrizione della funzionalità ChatGPT"
-    ]
-  ],
-  "message.featuresMidjourney": [
-    [
-      "message",
-      "Attiva o disattiva il modulo Midjourney."
-    ],
-    [
-      "description",
-      "Descrizione della funzionalità Midjourney"
-    ]
-  ],
-  "message.featuresChatdoc": [
-    [
-      "message",
-      "Attiva o disattiva il modulo Chatdoc."
-    ],
-    [
-      "description",
-      "Descrizione della funzionalità Chatdoc"
-    ]
-  ],
-  "message.featuresQrart": [
-    [
-      "message",
-      "Attiva o disattiva il modulo Qrart."
-    ],
-    [
-      "description",
-      "Descrizione della funzionalità Qrart"
-    ]
-  ],
-  "message.featuresVeo": [
-    [
-      "message",
-      "Attiva o disattiva il modulo Veo."
-    ],
-    [
-      "description",
-      "Descrizione della funzionalità Veo"
-    ]
-  ],
-  "message.featuresSora": [
-    [
-      "message",
-      "Attiva o disattiva il modulo Sora."
-    ],
-    [
-      "description",
-      "Descrizione della funzionalità Sora"
-    ]
-  ],
-  "message.featuresSuno": [
-    [
-      "message",
-      "Attiva o disattiva il modulo Suno."
-    ],
-    [
-      "description",
-      "Descrizione della funzionalità Suno"
-    ]
-  ],
-  "message.featuresPixverse": [
-    [
-      "message",
-      "Attiva o disattiva il modulo funzionale di Pixverse."
-    ],
-    [
-      "description",
-      "Descrizione della funzionalità di Pixverse"
-    ]
-  ],
-  "message.featuresFlux": [
-    [
-      "message",
-      "Attiva o disattiva il modulo funzionale di FLux."
-    ],
-    [
-      "description",
-      "Descrizione della funzionalità di FLux"
-    ]
-  ],
-  "message.featuresNanobanana": [
-    [
-      "message",
-      "Attiva o disattiva il modulo funzionale di Nano Banana."
-    ],
-    [
-      "description",
-      "Descrizione della funzionalità di Nano Banana"
-    ]
-  ],
+  "field.featuresSeedream": {
+    "message": "SeeDream",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "field.featuresSeedance": {
+    "message": "SeeDance",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "field.featuresWan": {
+    "message": "Wan",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "field.featuresProducer": {
+    "message": "Produttore",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "field.featuresKimi": {
+    "message": "Kimi",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "field.featuresSerp": {
+    "message": "SERP",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "field.featuresSupport": {
+    "message": "Supporto clienti",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "field.featuresI18n": {
+    "message": "Supporto multilingue",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "title.basicConfig": {
+    "message": "Configurazione di base",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "title.seoConfig": {
+    "message": "Configurazione SEO",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "title.editAdmins": {
+    "message": "Modifica amministratori",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "title.featuresConfig": {
+    "message": "Configurazione funzionalità",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "title.editTitle": {
+    "message": "Modifica titolo",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "title.editOrigin": {
+    "message": "Modifica dominio",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "title.editKeywords": {
+    "message": "Modifica parole chiave",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "title.editLogo": {
+    "message": "Modifica logo",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "title.editFavicon": {
+    "message": "Modifica favicon",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "title.editDescription": {
+    "message": "Modifica descrizione",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "title.distributionConfig": {
+    "message": "Configurazione distribuzione",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "title.editDistributionDefaultInviterId": {
+    "message": "Modifica invitante predefinito",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "title.editDistributionForceInviterId": {
+    "message": "Modifica invitante obbligatorio",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "title.editQR": {
+    "message": "Modifica QR Code",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "title.editUrl": {
+    "message": "Modifica Link",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "placeholder.title": {
+    "message": "Inserisci il titolo del sito",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "placeholder.origin": {
+    "message": "Inserisci il dominio del sito",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "placeholder.editUrl": {
+    "message": "Inserisci il link",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "placeholder.description": {
+    "message": "Inserisci la descrizione del sito",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "placeholder.keywords": {
+    "message": "Inserisci le parole chiave del sito",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "placeholder.editDistributionDefaultInviterId": {
+    "message": "Inserisci l'ID dell'invitante predefinito",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "placeholder.editDistributionForceInviterId": {
+    "message": "Inserisci l'ID dell'invitante forzato",
+    "description": "Mostrato come titolo nella casella di modifica"
+  },
+  "message.uploadImageExceed": {
+    "message": "Immagine caricata oltre il limite",
+    "description": "Messaggio di avviso per superamento limite di caricamento"
+  },
+  "message.uploadImageError": {
+    "message": "Errore nel caricamento dell'immagine",
+    "description": "Messaggio di avviso per errore di caricamento"
+  },
+  "message.editLogoTip": {
+    "message": "Dimensione consigliata: 200*60px",
+    "description": "Lingua di avviso per il caricamento dell'immagine"
+  },
+  "message.editQRTip": {
+    "message": "Dimensione consigliata: 200*200px",
+    "description": "Lingua di avviso per il caricamento dell'immagine"
+  },
+  "message.editFaviconTip": {
+    "message": "Dimensione consigliata: 32*32px",
+    "description": "Lingua di avviso per il caricamento dell'immagine"
+  },
+  "message.editUrl": {
+    "message": "Inserisci il link",
+    "description": "Messaggio di avviso per inserire il link"
+  },
+  "message.atLeastOneAdmin": {
+    "message": "Devi mantenere almeno un amministratore",
+    "description": "Messaggio di avviso per la presenza di un amministratore"
+  },
+  "message.distributionDefaultInviterIdTip": {
+    "message": "ID utente dell'invitante predefinito. Se il link di distribuzione non include il parametro inviter_id, verrà utilizzato questo ID come invitante.",
+    "description": "Messaggio di avviso per l'ID dell'invitante predefinito"
+  },
+  "message.distributionForceInviterIdTip": {
+    "message": "ID utente dell'invitante forzato. Se impostato, questo ID sarà utilizzato come invitante indipendentemente dalla presenza del parametro inviter_id nel link di distribuzione.",
+    "description": "Messaggio di avviso per l'ID dell'invitante forzato"
+  },
+  "message.originTip": {
+    "message": "Dominio del sito. La configurazione del sito è legata al dominio e non può essere modificata.",
+    "description": "Messaggio di avviso per il dominio del sito"
+  },
+  "message.titleTip": {
+    "message": "Titolo del sito, mostrato nella scheda del browser.",
+    "description": "Messaggio di avviso per il titolo del sito"
+  },
+  "message.descriptionTip": {
+    "message": "Descrizione del sito, presente nei metadati del sito, utile per l'ottimizzazione SEO.",
+    "description": "Messaggio di avviso per la descrizione del sito"
+  },
+  "message.logoTip": {
+    "message": "Logo del sito, mostrato in cima al menu del sito quando il menu è espanso.",
+    "description": "Messaggio di avviso per il logo del sito"
+  },
+  "message.faviconTip": {
+    "message": "Favicon del sito, mostrato nella scheda del browser.",
+    "description": "Messaggio di avviso per il favicon del sito"
+  },
+  "message.adminsTip": {
+    "message": "ID degli amministratori del sito. L'utente che crea il sito diventa automaticamente amministratore. Solo gli amministratori possono gestire il sito.",
+    "description": "Messaggio di avviso per gli amministratori del sito"
+  },
+  "message.adminsTip2": {
+    "message": "Puoi aggiungere o rimuovere ID amministratori qui. Puoi visualizzare gli ID utente su https://auth.acedata.cloud",
+    "description": "Messaggio di avviso per gli amministratori del sito"
+  },
+  "message.keywordsTip": {
+    "message": "Parole chiave del sito, presenti nei metadati del sito, utili per l'ottimizzazione SEO.",
+    "description": "Messaggio di avviso per le parole chiave del sito"
+  },
+  "message.keywordsTip2": {
+    "message": "Puoi aggiungere o rimuovere parole chiave qui. Parole chiave più precise sono più vantaggiose per l'ottimizzazione SEO.",
+    "description": "Messaggio di avviso per le parole chiave del sito"
+  },
+  "message.featuresChat": {
+    "message": "Attiva o disattiva il modulo Chat.",
+    "description": "Descrizione della funzionalità Chat"
+  },
+  "message.featuresGrok": {
+    "message": "Attiva o disattiva il modulo Grok.",
+    "description": "Descrizione della funzionalità Grok"
+  },
+  "message.featuresDeepseek": {
+    "message": "Attiva o disattiva il modulo Deepseek.",
+    "description": "Descrizione della funzionalità Deepseek"
+  },
+  "message.featuresChatgpt": {
+    "message": "Attiva o disattiva il modulo ChatGPT.",
+    "description": "Descrizione della funzionalità ChatGPT"
+  },
+  "message.featuresMidjourney": {
+    "message": "Attiva o disattiva il modulo Midjourney.",
+    "description": "Descrizione della funzionalità Midjourney"
+  },
+  "message.featuresChatdoc": {
+    "message": "Attiva o disattiva il modulo Chatdoc.",
+    "description": "Descrizione della funzionalità Chatdoc"
+  },
+  "message.featuresQrart": {
+    "message": "Attiva o disattiva il modulo Qrart.",
+    "description": "Descrizione della funzionalità Qrart"
+  },
+  "message.featuresVeo": {
+    "message": "Attiva o disattiva il modulo Veo.",
+    "description": "Descrizione della funzionalità Veo"
+  },
+  "message.featuresSora": {
+    "message": "Attiva o disattiva il modulo Sora.",
+    "description": "Descrizione della funzionalità Sora"
+  },
+  "message.featuresSuno": {
+    "message": "Attiva o disattiva il modulo Suno.",
+    "description": "Descrizione della funzionalità Suno"
+  },
+  "message.featuresPixverse": {
+    "message": "Attiva o disattiva il modulo funzionale di Pixverse.",
+    "description": "Descrizione della funzionalità di Pixverse"
+  },
+  "message.featuresFlux": {
+    "message": "Attiva o disattiva il modulo funzionale di FLux.",
+    "description": "Descrizione della funzionalità di FLux"
+  },
+  "message.featuresNanobanana": {
+    "message": "Attiva o disattiva il modulo funzionale di Nano Banana.",
+    "description": "Descrizione della funzionalità di Nano Banana"
+  },
   "message.featuresOpenaiimage": {
     "message": "Toggle OpenAI Image feature module.",
     "description": "Description of the OpenAI Image feature"
   },
-  "message.featuresSeedream": [
-    [
-      "message",
-      "Attiva o disattiva il modulo funzionale di SeeDream."
-    ],
-    [
-      "description",
-      "Descrizione della funzionalità di SeeDream"
-    ]
-  ],
-  "message.featuresSeedance": [
-    [
-      "message",
-      "Attiva o disattiva il modulo funzionale di SeeDance."
-    ],
-    [
-      "description",
-      "Descrizione della funzionalità di SeeDance"
-    ]
-  ],
-  "message.featuresWan": [
-    [
-      "message",
-      "Attiva o disattiva il modulo funzionale di Wan."
-    ],
-    [
-      "description",
-      "Descrizione della funzionalità di Wan"
-    ]
-  ],
-  "message.featuresProducer": [
-    [
-      "message",
-      "Attiva o disattiva il modulo funzionale di Producer."
-    ],
-    [
-      "description",
-      "Descrizione della funzionalità di Producer"
-    ]
-  ],
-  "message.featuresKimi": [
-    [
-      "message",
-      "Attiva o disattiva il modulo funzionale di Kimi."
-    ],
-    [
-      "description",
-      "Descrizione della funzionalità di Kimi"
-    ]
-  ],
-  "message.featuresSerp": [
-    [
-      "message",
-      "Attiva o disattiva il modulo funzionale di SERP."
-    ],
-    [
-      "description",
-      "Descrizione della funzionalità di SERP"
-    ]
-  ],
-  "message.featuresLuma": [
-    [
-      "message",
-      "Attiva o disattiva il modulo funzionale di Luma."
-    ],
-    [
-      "description",
-      "Descrizione della funzionalità di Luma"
-    ]
-  ],
-  "message.featuresPika": [
-    [
-      "message",
-      "Attiva o disattiva il modulo funzionale di Pika."
-    ],
-    [
-      "description",
-      "Descrizione della funzionalità di Pika"
-    ]
-  ],
-  "message.featuresKling": [
-    [
-      "message",
-      "Attiva o disattiva il modulo funzionale di Kling."
-    ],
-    [
-      "description",
-      "Descrizione della funzionalità di Kling"
-    ]
-  ],
-  "message.featuresHailuo": [
-    [
-      "message",
-      "Attiva o disattiva il modulo funzionale di Hailuo."
-    ],
-    [
-      "description",
-      "Descrizione della funzionalità di Hailuo"
-    ]
-  ],
-  "message.featuresHeadshots": [
-    [
-      "message",
-      "Attiva o disattiva il modulo funzionale di foto identificative AI."
-    ],
-    [
-      "description",
-      "Descrizione della funzionalità di foto identificative AI"
-    ]
-  ],
-  "message.featuresSupport": [
-    [
-      "message",
-      "Attiva o disattiva il supporto clienti"
-    ],
-    [
-      "description",
-      "Descrizione della funzionalità di supporto"
-    ]
-  ],
-  "message.featuresI18n": [
-    [
-      "message",
-      "Attiva o disattiva il supporto multilingue; se disattivato, gli utenti possono utilizzare solo la lingua predefinita."
-    ],
-    [
-      "description",
-      "Descrizione del supporto multilingue"
-    ]
-  ],
-  "button.upload": [
-    [
-      "message",
-      "Carica"
-    ],
-    [
-      "description",
-      "Carica"
-    ]
-  ],
-  "button.enabled": [
-    [
-      "message",
-      "Attivato"
-    ],
-    [
-      "description",
-      "Testo dell'interruttore che indica che è stato attivato"
-    ]
-  ],
-  "button.disabled": [
-    [
-      "message",
-      "Disattivato"
-    ],
-    [
-      "description",
-      "Testo dell'interruttore che indica che è stato disattivato"
-    ]
-  ],
-  "field.featuresGemini": [
-    [
-      "message",
-      "Gemini"
-    ],
-    [
-      "description",
-      "Visualizzato come titolo nella casella di modifica"
-    ]
-  ],
-  "message.featuresGemini": [
-    [
-      "message",
-      "Attiva o disattiva il modulo funzionale di Gemini."
-    ],
-    [
-      "description",
-      "Descrizione della funzionalità di Gemini"
-    ]
-  ],
-  "field.featuresClaude": [
-    [
-      "message",
-      "Claude"
-    ],
-    [
-      "description",
-      "Visualizzato come titolo nella casella di modifica"
-    ]
-  ],
-  "message.featuresClaude": [
-    [
-      "message",
-      "Attiva o disattiva il modulo funzionale di Claude."
-    ],
-    [
-      "description",
-      "Descrizione della funzionalità di Claude"
-    ]
-  ]
+  "message.featuresSeedream": {
+    "message": "Attiva o disattiva il modulo funzionale di SeeDream.",
+    "description": "Descrizione della funzionalità di SeeDream"
+  },
+  "message.featuresSeedance": {
+    "message": "Attiva o disattiva il modulo funzionale di SeeDance.",
+    "description": "Descrizione della funzionalità di SeeDance"
+  },
+  "message.featuresWan": {
+    "message": "Attiva o disattiva il modulo funzionale di Wan.",
+    "description": "Descrizione della funzionalità di Wan"
+  },
+  "message.featuresProducer": {
+    "message": "Attiva o disattiva il modulo funzionale di Producer.",
+    "description": "Descrizione della funzionalità di Producer"
+  },
+  "message.featuresKimi": {
+    "message": "Attiva o disattiva il modulo funzionale di Kimi.",
+    "description": "Descrizione della funzionalità di Kimi"
+  },
+  "message.featuresSerp": {
+    "message": "Attiva o disattiva il modulo funzionale di SERP.",
+    "description": "Descrizione della funzionalità di SERP"
+  },
+  "message.featuresLuma": {
+    "message": "Attiva o disattiva il modulo funzionale di Luma.",
+    "description": "Descrizione della funzionalità di Luma"
+  },
+  "message.featuresPika": {
+    "message": "Attiva o disattiva il modulo funzionale di Pika.",
+    "description": "Descrizione della funzionalità di Pika"
+  },
+  "message.featuresKling": {
+    "message": "Attiva o disattiva il modulo funzionale di Kling.",
+    "description": "Descrizione della funzionalità di Kling"
+  },
+  "message.featuresHailuo": {
+    "message": "Attiva o disattiva il modulo funzionale di Hailuo.",
+    "description": "Descrizione della funzionalità di Hailuo"
+  },
+  "message.featuresHeadshots": {
+    "message": "Attiva o disattiva il modulo funzionale di foto identificative AI.",
+    "description": "Descrizione della funzionalità di foto identificative AI"
+  },
+  "message.featuresSupport": {
+    "message": "Attiva o disattiva il supporto clienti",
+    "description": "Descrizione della funzionalità di supporto"
+  },
+  "message.featuresI18n": {
+    "message": "Attiva o disattiva il supporto multilingue; se disattivato, gli utenti possono utilizzare solo la lingua predefinita.",
+    "description": "Descrizione del supporto multilingue"
+  },
+  "button.upload": {
+    "message": "Carica",
+    "description": "Carica"
+  },
+  "button.enabled": {
+    "message": "Attivato",
+    "description": "Testo dell'interruttore che indica che è stato attivato"
+  },
+  "button.disabled": {
+    "message": "Disattivato",
+    "description": "Testo dell'interruttore che indica che è stato disattivato"
+  },
+  "field.featuresGemini": {
+    "message": "Gemini",
+    "description": "Visualizzato come titolo nella casella di modifica"
+  },
+  "message.featuresGemini": {
+    "message": "Attiva o disattiva il modulo funzionale di Gemini.",
+    "description": "Descrizione della funzionalità di Gemini"
+  },
+  "field.featuresClaude": {
+    "message": "Claude",
+    "description": "Visualizzato come titolo nella casella di modifica"
+  },
+  "message.featuresClaude": {
+    "message": "Attiva o disattiva il modulo funzionale di Claude.",
+    "description": "Descrizione della funzionalità di Claude"
+  }
 }

--- a/src/i18n/it/site.json
+++ b/src/i18n/it/site.json
@@ -1,442 +1,1110 @@
 {
-  "field.title": {
-    "message": "Titolo del sito",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "field.origin": {
-    "message": "Dominio del sito",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "field.description": {
-    "message": "Descrizione del sito",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "field.keywords": {
-    "message": "Parole chiave del sito",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "field.logo": {
-    "message": "Logo del sito",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "field.favicon": {
-    "message": "Favicon del sito",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "field.qr": {
-    "message": "Codice QR",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "field.url": {
-    "message": "Link",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "field.admins": {
-    "message": "ID amministratori del sito",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "field.distributionDefaultInviterId": {
-    "message": "ID invitante predefinito",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "field.distributionForceInviterId": {
-    "message": "ID invitante obbligatorio",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "field.featuresChat": {
-    "message": "Chat",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "field.featuresVeo": {
-    "message": "Veo",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "field.featuresSora": {
-    "message": "Sora",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "field.featuresGrok": {
-    "message": "Grok",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "field.featuresDeepseek": {
-    "message": "Deepseek",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "field.featuresChatgpt": {
-    "message": "ChatGPT",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "field.featuresMidjourney": {
-    "message": "Midjourney",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "field.featuresChatdoc": {
-    "message": "Chatdoc",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "field.featuresQrart": {
-    "message": "Qrart",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "field.featuresLuma": {
-    "message": "Luma",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "field.featuresPixverse": {
-    "message": "Pixverse",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "field.featuresPika": {
-    "message": "Pika",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "field.featuresKling": {
-    "message": "Kling",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "field.featuresHailuo": {
-    "message": "Hailuo",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "field.featuresHeadshots": {
-    "message": "Foto identificativa AI",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "field.featuresSuno": {
-    "message": "Suno",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "field.featuresFlux": {
-    "message": "Flux",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "field.featuresNanobanana": {
-    "message": "Nano Banana",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "field.featuresSeedream": {
-    "message": "SeeDream",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "field.featuresSeedance": {
-    "message": "SeeDance",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "field.featuresWan": {
-    "message": "Wan",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "field.featuresProducer": {
-    "message": "Produttore",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "field.featuresKimi": {
-    "message": "Kimi",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "field.featuresSerp": {
-    "message": "SERP",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "field.featuresSupport": {
-    "message": "Supporto clienti",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "field.featuresI18n": {
-    "message": "Supporto multilingue",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "title.basicConfig": {
-    "message": "Configurazione di base",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "title.seoConfig": {
-    "message": "Configurazione SEO",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "title.editAdmins": {
-    "message": "Modifica amministratori",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "title.featuresConfig": {
-    "message": "Configurazione funzionalità",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "title.editTitle": {
-    "message": "Modifica titolo",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "title.editOrigin": {
-    "message": "Modifica dominio",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "title.editKeywords": {
-    "message": "Modifica parole chiave",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "title.editLogo": {
-    "message": "Modifica logo",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "title.editFavicon": {
-    "message": "Modifica favicon",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "title.editDescription": {
-    "message": "Modifica descrizione",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "title.distributionConfig": {
-    "message": "Configurazione distribuzione",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "title.editDistributionDefaultInviterId": {
-    "message": "Modifica invitante predefinito",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "title.editDistributionForceInviterId": {
-    "message": "Modifica invitante obbligatorio",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "title.editQR": {
-    "message": "Modifica QR Code",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "title.editUrl": {
-    "message": "Modifica Link",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "placeholder.title": {
-    "message": "Inserisci il titolo del sito",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "placeholder.origin": {
-    "message": "Inserisci il dominio del sito",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "placeholder.editUrl": {
-    "message": "Inserisci il link",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "placeholder.description": {
-    "message": "Inserisci la descrizione del sito",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "placeholder.keywords": {
-    "message": "Inserisci le parole chiave del sito",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "placeholder.editDistributionDefaultInviterId": {
-    "message": "Inserisci l'ID dell'invitante predefinito",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "placeholder.editDistributionForceInviterId": {
-    "message": "Inserisci l'ID dell'invitante forzato",
-    "description": "Mostrato come titolo nella casella di modifica"
-  },
-  "message.uploadImageExceed": {
-    "message": "Immagine caricata oltre il limite",
-    "description": "Messaggio di avviso per superamento limite di caricamento"
-  },
-  "message.uploadImageError": {
-    "message": "Errore nel caricamento dell'immagine",
-    "description": "Messaggio di avviso per errore di caricamento"
-  },
-  "message.editLogoTip": {
-    "message": "Dimensione consigliata: 200*60px",
-    "description": "Lingua di avviso per il caricamento dell'immagine"
-  },
-  "message.editQRTip": {
-    "message": "Dimensione consigliata: 200*200px",
-    "description": "Lingua di avviso per il caricamento dell'immagine"
-  },
-  "message.editFaviconTip": {
-    "message": "Dimensione consigliata: 32*32px",
-    "description": "Lingua di avviso per il caricamento dell'immagine"
-  },
-  "message.editUrl": {
-    "message": "Inserisci il link",
-    "description": "Messaggio di avviso per inserire il link"
-  },
-  "message.atLeastOneAdmin": {
-    "message": "Devi mantenere almeno un amministratore",
-    "description": "Messaggio di avviso per la presenza di un amministratore"
-  },
-  "message.distributionDefaultInviterIdTip": {
-    "message": "ID utente dell'invitante predefinito. Se il link di distribuzione non include il parametro inviter_id, verrà utilizzato questo ID come invitante.",
-    "description": "Messaggio di avviso per l'ID dell'invitante predefinito"
-  },
-  "message.distributionForceInviterIdTip": {
-    "message": "ID utente dell'invitante forzato. Se impostato, questo ID sarà utilizzato come invitante indipendentemente dalla presenza del parametro inviter_id nel link di distribuzione.",
-    "description": "Messaggio di avviso per l'ID dell'invitante forzato"
-  },
-  "message.originTip": {
-    "message": "Dominio del sito. La configurazione del sito è legata al dominio e non può essere modificata.",
-    "description": "Messaggio di avviso per il dominio del sito"
-  },
-  "message.titleTip": {
-    "message": "Titolo del sito, mostrato nella scheda del browser.",
-    "description": "Messaggio di avviso per il titolo del sito"
-  },
-  "message.descriptionTip": {
-    "message": "Descrizione del sito, presente nei metadati del sito, utile per l'ottimizzazione SEO.",
-    "description": "Messaggio di avviso per la descrizione del sito"
-  },
-  "message.logoTip": {
-    "message": "Logo del sito, mostrato in cima al menu del sito quando il menu è espanso.",
-    "description": "Messaggio di avviso per il logo del sito"
-  },
-  "message.faviconTip": {
-    "message": "Favicon del sito, mostrato nella scheda del browser.",
-    "description": "Messaggio di avviso per il favicon del sito"
-  },
-  "message.adminsTip": {
-    "message": "ID degli amministratori del sito. L'utente che crea il sito diventa automaticamente amministratore. Solo gli amministratori possono gestire il sito.",
-    "description": "Messaggio di avviso per gli amministratori del sito"
-  },
-  "message.adminsTip2": {
-    "message": "Puoi aggiungere o rimuovere ID amministratori qui. Puoi visualizzare gli ID utente su https://auth.acedata.cloud",
-    "description": "Messaggio di avviso per gli amministratori del sito"
-  },
-  "message.keywordsTip": {
-    "message": "Parole chiave del sito, presenti nei metadati del sito, utili per l'ottimizzazione SEO.",
-    "description": "Messaggio di avviso per le parole chiave del sito"
-  },
-  "message.keywordsTip2": {
-    "message": "Puoi aggiungere o rimuovere parole chiave qui. Parole chiave più precise sono più vantaggiose per l'ottimizzazione SEO.",
-    "description": "Messaggio di avviso per le parole chiave del sito"
-  },
-  "message.featuresChat": {
-    "message": "Attiva o disattiva il modulo Chat.",
-    "description": "Descrizione della funzionalità Chat"
-  },
-  "message.featuresGrok": {
-    "message": "Attiva o disattiva il modulo Grok.",
-    "description": "Descrizione della funzionalità Grok"
-  },
-  "message.featuresDeepseek": {
-    "message": "Attiva o disattiva il modulo Deepseek.",
-    "description": "Descrizione della funzionalità Deepseek"
-  },
-  "message.featuresChatgpt": {
-    "message": "Attiva o disattiva il modulo ChatGPT.",
-    "description": "Descrizione della funzionalità ChatGPT"
-  },
-  "message.featuresMidjourney": {
-    "message": "Attiva o disattiva il modulo Midjourney.",
-    "description": "Descrizione della funzionalità Midjourney"
-  },
-  "message.featuresChatdoc": {
-    "message": "Attiva o disattiva il modulo Chatdoc.",
-    "description": "Descrizione della funzionalità Chatdoc"
-  },
-  "message.featuresQrart": {
-    "message": "Attiva o disattiva il modulo Qrart.",
-    "description": "Descrizione della funzionalità Qrart"
-  },
-  "message.featuresVeo": {
-    "message": "Attiva o disattiva il modulo Veo.",
-    "description": "Descrizione della funzionalità Veo"
-  },
-  "message.featuresSora": {
-    "message": "Attiva o disattiva il modulo Sora.",
-    "description": "Descrizione della funzionalità Sora"
-  },
-  "message.featuresSuno": {
-    "message": "Attiva o disattiva il modulo Suno.",
-    "description": "Descrizione della funzionalità Suno"
-  },
-  "message.featuresPixverse": {
-    "message": "Attiva o disattiva il modulo funzionale di Pixverse.",
-    "description": "Descrizione della funzionalità di Pixverse"
-  },
-  "message.featuresFlux": {
-    "message": "Attiva o disattiva il modulo funzionale di FLux.",
-    "description": "Descrizione della funzionalità di FLux"
-  },
-  "message.featuresNanobanana": {
-    "message": "Attiva o disattiva il modulo funzionale di Nano Banana.",
-    "description": "Descrizione della funzionalità di Nano Banana"
-  },
-  "message.featuresSeedream": {
-    "message": "Attiva o disattiva il modulo funzionale di SeeDream.",
-    "description": "Descrizione della funzionalità di SeeDream"
-  },
-  "message.featuresSeedance": {
-    "message": "Attiva o disattiva il modulo funzionale di SeeDance.",
-    "description": "Descrizione della funzionalità di SeeDance"
-  },
-  "message.featuresWan": {
-    "message": "Attiva o disattiva il modulo funzionale di Wan.",
-    "description": "Descrizione della funzionalità di Wan"
-  },
-  "message.featuresProducer": {
-    "message": "Attiva o disattiva il modulo funzionale di Producer.",
-    "description": "Descrizione della funzionalità di Producer"
-  },
-  "message.featuresKimi": {
-    "message": "Attiva o disattiva il modulo funzionale di Kimi.",
-    "description": "Descrizione della funzionalità di Kimi"
-  },
-  "message.featuresSerp": {
-    "message": "Attiva o disattiva il modulo funzionale di SERP.",
-    "description": "Descrizione della funzionalità di SERP"
-  },
-  "message.featuresLuma": {
-    "message": "Attiva o disattiva il modulo funzionale di Luma.",
-    "description": "Descrizione della funzionalità di Luma"
-  },
-  "message.featuresPika": {
-    "message": "Attiva o disattiva il modulo funzionale di Pika.",
-    "description": "Descrizione della funzionalità di Pika"
-  },
-  "message.featuresKling": {
-    "message": "Attiva o disattiva il modulo funzionale di Kling.",
-    "description": "Descrizione della funzionalità di Kling"
-  },
-  "message.featuresHailuo": {
-    "message": "Attiva o disattiva il modulo funzionale di Hailuo.",
-    "description": "Descrizione della funzionalità di Hailuo"
-  },
-  "message.featuresHeadshots": {
-    "message": "Attiva o disattiva il modulo funzionale di foto identificative AI.",
-    "description": "Descrizione della funzionalità di foto identificative AI"
-  },
-  "message.featuresSupport": {
-    "message": "Attiva o disattiva il supporto clienti",
-    "description": "Descrizione della funzionalità di supporto"
-  },
-  "message.featuresI18n": {
-    "message": "Attiva o disattiva il supporto multilingue; se disattivato, gli utenti possono utilizzare solo la lingua predefinita.",
-    "description": "Descrizione del supporto multilingue"
-  },
-  "button.upload": {
-    "message": "Carica",
-    "description": "Carica"
-  },
-  "button.enabled": {
-    "message": "Attivato",
-    "description": "Testo dell'interruttore che indica che è stato attivato"
-  },
-  "button.disabled": {
-    "message": "Disattivato",
-    "description": "Testo dell'interruttore che indica che è stato disattivato"
-  },
-  "field.featuresGemini": {
-    "message": "Gemini",
-    "description": "Visualizzato come titolo nella casella di modifica"
-  },
-  "message.featuresGemini": {
-    "message": "Attiva o disattiva il modulo funzionale di Gemini.",
-    "description": "Descrizione della funzionalità di Gemini"
-  },
-  "field.featuresClaude": {
-    "message": "Claude",
-    "description": "Visualizzato come titolo nella casella di modifica"
-  },
-  "message.featuresClaude": {
-    "message": "Attiva o disattiva il modulo funzionale di Claude.",
-    "description": "Descrizione della funzionalità di Claude"
-  }
+  "field.title": [
+    [
+      "message",
+      "Titolo del sito"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "field.origin": [
+    [
+      "message",
+      "Dominio del sito"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "field.description": [
+    [
+      "message",
+      "Descrizione del sito"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "field.keywords": [
+    [
+      "message",
+      "Parole chiave del sito"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "field.logo": [
+    [
+      "message",
+      "Logo del sito"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "field.favicon": [
+    [
+      "message",
+      "Favicon del sito"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "field.qr": [
+    [
+      "message",
+      "Codice QR"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "field.url": [
+    [
+      "message",
+      "Link"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "field.admins": [
+    [
+      "message",
+      "ID amministratori del sito"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "field.distributionDefaultInviterId": [
+    [
+      "message",
+      "ID invitante predefinito"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "field.distributionForceInviterId": [
+    [
+      "message",
+      "ID invitante obbligatorio"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "field.featuresChat": [
+    [
+      "message",
+      "Chat"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "field.featuresVeo": [
+    [
+      "message",
+      "Veo"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "field.featuresSora": [
+    [
+      "message",
+      "Sora"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "field.featuresGrok": [
+    [
+      "message",
+      "Grok"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "field.featuresDeepseek": [
+    [
+      "message",
+      "Deepseek"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "field.featuresChatgpt": [
+    [
+      "message",
+      "ChatGPT"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "field.featuresMidjourney": [
+    [
+      "message",
+      "Midjourney"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "field.featuresChatdoc": [
+    [
+      "message",
+      "Chatdoc"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "field.featuresQrart": [
+    [
+      "message",
+      "Qrart"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "field.featuresLuma": [
+    [
+      "message",
+      "Luma"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "field.featuresPixverse": [
+    [
+      "message",
+      "Pixverse"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "field.featuresPika": [
+    [
+      "message",
+      "Pika"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "field.featuresKling": [
+    [
+      "message",
+      "Kling"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "field.featuresHailuo": [
+    [
+      "message",
+      "Hailuo"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "field.featuresHeadshots": [
+    [
+      "message",
+      "Foto identificativa AI"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "field.featuresSuno": [
+    [
+      "message",
+      "Suno"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "field.featuresFlux": [
+    [
+      "message",
+      "Flux"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "field.featuresNanobanana": [
+    [
+      "message",
+      "Nano Banana"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "field.featuresOpenaiimage": {
+    "message": "OpenAI Image",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresSeedream": [
+    [
+      "message",
+      "SeeDream"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "field.featuresSeedance": [
+    [
+      "message",
+      "SeeDance"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "field.featuresWan": [
+    [
+      "message",
+      "Wan"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "field.featuresProducer": [
+    [
+      "message",
+      "Produttore"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "field.featuresKimi": [
+    [
+      "message",
+      "Kimi"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "field.featuresSerp": [
+    [
+      "message",
+      "SERP"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "field.featuresSupport": [
+    [
+      "message",
+      "Supporto clienti"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "field.featuresI18n": [
+    [
+      "message",
+      "Supporto multilingue"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "title.basicConfig": [
+    [
+      "message",
+      "Configurazione di base"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "title.seoConfig": [
+    [
+      "message",
+      "Configurazione SEO"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "title.editAdmins": [
+    [
+      "message",
+      "Modifica amministratori"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "title.featuresConfig": [
+    [
+      "message",
+      "Configurazione funzionalità"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "title.editTitle": [
+    [
+      "message",
+      "Modifica titolo"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "title.editOrigin": [
+    [
+      "message",
+      "Modifica dominio"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "title.editKeywords": [
+    [
+      "message",
+      "Modifica parole chiave"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "title.editLogo": [
+    [
+      "message",
+      "Modifica logo"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "title.editFavicon": [
+    [
+      "message",
+      "Modifica favicon"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "title.editDescription": [
+    [
+      "message",
+      "Modifica descrizione"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "title.distributionConfig": [
+    [
+      "message",
+      "Configurazione distribuzione"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "title.editDistributionDefaultInviterId": [
+    [
+      "message",
+      "Modifica invitante predefinito"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "title.editDistributionForceInviterId": [
+    [
+      "message",
+      "Modifica invitante obbligatorio"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "title.editQR": [
+    [
+      "message",
+      "Modifica QR Code"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "title.editUrl": [
+    [
+      "message",
+      "Modifica Link"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "placeholder.title": [
+    [
+      "message",
+      "Inserisci il titolo del sito"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "placeholder.origin": [
+    [
+      "message",
+      "Inserisci il dominio del sito"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "placeholder.editUrl": [
+    [
+      "message",
+      "Inserisci il link"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "placeholder.description": [
+    [
+      "message",
+      "Inserisci la descrizione del sito"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "placeholder.keywords": [
+    [
+      "message",
+      "Inserisci le parole chiave del sito"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "placeholder.editDistributionDefaultInviterId": [
+    [
+      "message",
+      "Inserisci l'ID dell'invitante predefinito"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "placeholder.editDistributionForceInviterId": [
+    [
+      "message",
+      "Inserisci l'ID dell'invitante forzato"
+    ],
+    [
+      "description",
+      "Mostrato come titolo nella casella di modifica"
+    ]
+  ],
+  "message.uploadImageExceed": [
+    [
+      "message",
+      "Immagine caricata oltre il limite"
+    ],
+    [
+      "description",
+      "Messaggio di avviso per superamento limite di caricamento"
+    ]
+  ],
+  "message.uploadImageError": [
+    [
+      "message",
+      "Errore nel caricamento dell'immagine"
+    ],
+    [
+      "description",
+      "Messaggio di avviso per errore di caricamento"
+    ]
+  ],
+  "message.editLogoTip": [
+    [
+      "message",
+      "Dimensione consigliata: 200*60px"
+    ],
+    [
+      "description",
+      "Lingua di avviso per il caricamento dell'immagine"
+    ]
+  ],
+  "message.editQRTip": [
+    [
+      "message",
+      "Dimensione consigliata: 200*200px"
+    ],
+    [
+      "description",
+      "Lingua di avviso per il caricamento dell'immagine"
+    ]
+  ],
+  "message.editFaviconTip": [
+    [
+      "message",
+      "Dimensione consigliata: 32*32px"
+    ],
+    [
+      "description",
+      "Lingua di avviso per il caricamento dell'immagine"
+    ]
+  ],
+  "message.editUrl": [
+    [
+      "message",
+      "Inserisci il link"
+    ],
+    [
+      "description",
+      "Messaggio di avviso per inserire il link"
+    ]
+  ],
+  "message.atLeastOneAdmin": [
+    [
+      "message",
+      "Devi mantenere almeno un amministratore"
+    ],
+    [
+      "description",
+      "Messaggio di avviso per la presenza di un amministratore"
+    ]
+  ],
+  "message.distributionDefaultInviterIdTip": [
+    [
+      "message",
+      "ID utente dell'invitante predefinito. Se il link di distribuzione non include il parametro inviter_id, verrà utilizzato questo ID come invitante."
+    ],
+    [
+      "description",
+      "Messaggio di avviso per l'ID dell'invitante predefinito"
+    ]
+  ],
+  "message.distributionForceInviterIdTip": [
+    [
+      "message",
+      "ID utente dell'invitante forzato. Se impostato, questo ID sarà utilizzato come invitante indipendentemente dalla presenza del parametro inviter_id nel link di distribuzione."
+    ],
+    [
+      "description",
+      "Messaggio di avviso per l'ID dell'invitante forzato"
+    ]
+  ],
+  "message.originTip": [
+    [
+      "message",
+      "Dominio del sito. La configurazione del sito è legata al dominio e non può essere modificata."
+    ],
+    [
+      "description",
+      "Messaggio di avviso per il dominio del sito"
+    ]
+  ],
+  "message.titleTip": [
+    [
+      "message",
+      "Titolo del sito, mostrato nella scheda del browser."
+    ],
+    [
+      "description",
+      "Messaggio di avviso per il titolo del sito"
+    ]
+  ],
+  "message.descriptionTip": [
+    [
+      "message",
+      "Descrizione del sito, presente nei metadati del sito, utile per l'ottimizzazione SEO."
+    ],
+    [
+      "description",
+      "Messaggio di avviso per la descrizione del sito"
+    ]
+  ],
+  "message.logoTip": [
+    [
+      "message",
+      "Logo del sito, mostrato in cima al menu del sito quando il menu è espanso."
+    ],
+    [
+      "description",
+      "Messaggio di avviso per il logo del sito"
+    ]
+  ],
+  "message.faviconTip": [
+    [
+      "message",
+      "Favicon del sito, mostrato nella scheda del browser."
+    ],
+    [
+      "description",
+      "Messaggio di avviso per il favicon del sito"
+    ]
+  ],
+  "message.adminsTip": [
+    [
+      "message",
+      "ID degli amministratori del sito. L'utente che crea il sito diventa automaticamente amministratore. Solo gli amministratori possono gestire il sito."
+    ],
+    [
+      "description",
+      "Messaggio di avviso per gli amministratori del sito"
+    ]
+  ],
+  "message.adminsTip2": [
+    [
+      "message",
+      "Puoi aggiungere o rimuovere ID amministratori qui. Puoi visualizzare gli ID utente su https://auth.acedata.cloud"
+    ],
+    [
+      "description",
+      "Messaggio di avviso per gli amministratori del sito"
+    ]
+  ],
+  "message.keywordsTip": [
+    [
+      "message",
+      "Parole chiave del sito, presenti nei metadati del sito, utili per l'ottimizzazione SEO."
+    ],
+    [
+      "description",
+      "Messaggio di avviso per le parole chiave del sito"
+    ]
+  ],
+  "message.keywordsTip2": [
+    [
+      "message",
+      "Puoi aggiungere o rimuovere parole chiave qui. Parole chiave più precise sono più vantaggiose per l'ottimizzazione SEO."
+    ],
+    [
+      "description",
+      "Messaggio di avviso per le parole chiave del sito"
+    ]
+  ],
+  "message.featuresChat": [
+    [
+      "message",
+      "Attiva o disattiva il modulo Chat."
+    ],
+    [
+      "description",
+      "Descrizione della funzionalità Chat"
+    ]
+  ],
+  "message.featuresGrok": [
+    [
+      "message",
+      "Attiva o disattiva il modulo Grok."
+    ],
+    [
+      "description",
+      "Descrizione della funzionalità Grok"
+    ]
+  ],
+  "message.featuresDeepseek": [
+    [
+      "message",
+      "Attiva o disattiva il modulo Deepseek."
+    ],
+    [
+      "description",
+      "Descrizione della funzionalità Deepseek"
+    ]
+  ],
+  "message.featuresChatgpt": [
+    [
+      "message",
+      "Attiva o disattiva il modulo ChatGPT."
+    ],
+    [
+      "description",
+      "Descrizione della funzionalità ChatGPT"
+    ]
+  ],
+  "message.featuresMidjourney": [
+    [
+      "message",
+      "Attiva o disattiva il modulo Midjourney."
+    ],
+    [
+      "description",
+      "Descrizione della funzionalità Midjourney"
+    ]
+  ],
+  "message.featuresChatdoc": [
+    [
+      "message",
+      "Attiva o disattiva il modulo Chatdoc."
+    ],
+    [
+      "description",
+      "Descrizione della funzionalità Chatdoc"
+    ]
+  ],
+  "message.featuresQrart": [
+    [
+      "message",
+      "Attiva o disattiva il modulo Qrart."
+    ],
+    [
+      "description",
+      "Descrizione della funzionalità Qrart"
+    ]
+  ],
+  "message.featuresVeo": [
+    [
+      "message",
+      "Attiva o disattiva il modulo Veo."
+    ],
+    [
+      "description",
+      "Descrizione della funzionalità Veo"
+    ]
+  ],
+  "message.featuresSora": [
+    [
+      "message",
+      "Attiva o disattiva il modulo Sora."
+    ],
+    [
+      "description",
+      "Descrizione della funzionalità Sora"
+    ]
+  ],
+  "message.featuresSuno": [
+    [
+      "message",
+      "Attiva o disattiva il modulo Suno."
+    ],
+    [
+      "description",
+      "Descrizione della funzionalità Suno"
+    ]
+  ],
+  "message.featuresPixverse": [
+    [
+      "message",
+      "Attiva o disattiva il modulo funzionale di Pixverse."
+    ],
+    [
+      "description",
+      "Descrizione della funzionalità di Pixverse"
+    ]
+  ],
+  "message.featuresFlux": [
+    [
+      "message",
+      "Attiva o disattiva il modulo funzionale di FLux."
+    ],
+    [
+      "description",
+      "Descrizione della funzionalità di FLux"
+    ]
+  ],
+  "message.featuresNanobanana": [
+    [
+      "message",
+      "Attiva o disattiva il modulo funzionale di Nano Banana."
+    ],
+    [
+      "description",
+      "Descrizione della funzionalità di Nano Banana"
+    ]
+  ],
+  "message.featuresOpenaiimage": {
+    "message": "Toggle OpenAI Image feature module.",
+    "description": "Description of the OpenAI Image feature"
+  },
+  "message.featuresSeedream": [
+    [
+      "message",
+      "Attiva o disattiva il modulo funzionale di SeeDream."
+    ],
+    [
+      "description",
+      "Descrizione della funzionalità di SeeDream"
+    ]
+  ],
+  "message.featuresSeedance": [
+    [
+      "message",
+      "Attiva o disattiva il modulo funzionale di SeeDance."
+    ],
+    [
+      "description",
+      "Descrizione della funzionalità di SeeDance"
+    ]
+  ],
+  "message.featuresWan": [
+    [
+      "message",
+      "Attiva o disattiva il modulo funzionale di Wan."
+    ],
+    [
+      "description",
+      "Descrizione della funzionalità di Wan"
+    ]
+  ],
+  "message.featuresProducer": [
+    [
+      "message",
+      "Attiva o disattiva il modulo funzionale di Producer."
+    ],
+    [
+      "description",
+      "Descrizione della funzionalità di Producer"
+    ]
+  ],
+  "message.featuresKimi": [
+    [
+      "message",
+      "Attiva o disattiva il modulo funzionale di Kimi."
+    ],
+    [
+      "description",
+      "Descrizione della funzionalità di Kimi"
+    ]
+  ],
+  "message.featuresSerp": [
+    [
+      "message",
+      "Attiva o disattiva il modulo funzionale di SERP."
+    ],
+    [
+      "description",
+      "Descrizione della funzionalità di SERP"
+    ]
+  ],
+  "message.featuresLuma": [
+    [
+      "message",
+      "Attiva o disattiva il modulo funzionale di Luma."
+    ],
+    [
+      "description",
+      "Descrizione della funzionalità di Luma"
+    ]
+  ],
+  "message.featuresPika": [
+    [
+      "message",
+      "Attiva o disattiva il modulo funzionale di Pika."
+    ],
+    [
+      "description",
+      "Descrizione della funzionalità di Pika"
+    ]
+  ],
+  "message.featuresKling": [
+    [
+      "message",
+      "Attiva o disattiva il modulo funzionale di Kling."
+    ],
+    [
+      "description",
+      "Descrizione della funzionalità di Kling"
+    ]
+  ],
+  "message.featuresHailuo": [
+    [
+      "message",
+      "Attiva o disattiva il modulo funzionale di Hailuo."
+    ],
+    [
+      "description",
+      "Descrizione della funzionalità di Hailuo"
+    ]
+  ],
+  "message.featuresHeadshots": [
+    [
+      "message",
+      "Attiva o disattiva il modulo funzionale di foto identificative AI."
+    ],
+    [
+      "description",
+      "Descrizione della funzionalità di foto identificative AI"
+    ]
+  ],
+  "message.featuresSupport": [
+    [
+      "message",
+      "Attiva o disattiva il supporto clienti"
+    ],
+    [
+      "description",
+      "Descrizione della funzionalità di supporto"
+    ]
+  ],
+  "message.featuresI18n": [
+    [
+      "message",
+      "Attiva o disattiva il supporto multilingue; se disattivato, gli utenti possono utilizzare solo la lingua predefinita."
+    ],
+    [
+      "description",
+      "Descrizione del supporto multilingue"
+    ]
+  ],
+  "button.upload": [
+    [
+      "message",
+      "Carica"
+    ],
+    [
+      "description",
+      "Carica"
+    ]
+  ],
+  "button.enabled": [
+    [
+      "message",
+      "Attivato"
+    ],
+    [
+      "description",
+      "Testo dell'interruttore che indica che è stato attivato"
+    ]
+  ],
+  "button.disabled": [
+    [
+      "message",
+      "Disattivato"
+    ],
+    [
+      "description",
+      "Testo dell'interruttore che indica che è stato disattivato"
+    ]
+  ],
+  "field.featuresGemini": [
+    [
+      "message",
+      "Gemini"
+    ],
+    [
+      "description",
+      "Visualizzato come titolo nella casella di modifica"
+    ]
+  ],
+  "message.featuresGemini": [
+    [
+      "message",
+      "Attiva o disattiva il modulo funzionale di Gemini."
+    ],
+    [
+      "description",
+      "Descrizione della funzionalità di Gemini"
+    ]
+  ],
+  "field.featuresClaude": [
+    [
+      "message",
+      "Claude"
+    ],
+    [
+      "description",
+      "Visualizzato come titolo nella casella di modifica"
+    ]
+  ],
+  "message.featuresClaude": [
+    [
+      "message",
+      "Attiva o disattiva il modulo funzionale di Claude."
+    ],
+    [
+      "description",
+      "Descrizione della funzionalità di Claude"
+    ]
+  ]
 }

--- a/src/i18n/ja/site.json
+++ b/src/i18n/ja/site.json
@@ -1,1110 +1,450 @@
 {
-  "field.title": [
-    [
-      "message",
-      "サイトタイトル"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "field.origin": [
-    [
-      "message",
-      "サイトドメイン"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "field.description": [
-    [
-      "message",
-      "サイト説明"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "field.keywords": [
-    [
-      "message",
-      "サイトキーワード"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "field.logo": [
-    [
-      "message",
-      "サイトロゴ"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "field.favicon": [
-    [
-      "message",
-      "サイトファビコン"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "field.qr": [
-    [
-      "message",
-      "QRコード"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "field.url": [
-    [
-      "message",
-      "リンク"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "field.admins": [
-    [
-      "message",
-      "サイト管理者ID"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "field.distributionDefaultInviterId": [
-    [
-      "message",
-      "デフォルト招待者ID"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "field.distributionForceInviterId": [
-    [
-      "message",
-      "強制招待者ID"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "field.featuresChat": [
-    [
-      "message",
-      "チャット"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "field.featuresVeo": [
-    [
-      "message",
-      "Veo"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "field.featuresSora": [
-    [
-      "message",
-      "Sora"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "field.featuresGrok": [
-    [
-      "message",
-      "Grok"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "field.featuresDeepseek": [
-    [
-      "message",
-      "Deepseek"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "field.featuresChatgpt": [
-    [
-      "message",
-      "ChatGPT"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "field.featuresMidjourney": [
-    [
-      "message",
-      "Midjourney"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "field.featuresChatdoc": [
-    [
-      "message",
-      "Chatdoc"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "field.featuresQrart": [
-    [
-      "message",
-      "Qrart"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "field.featuresLuma": [
-    [
-      "message",
-      "Luma"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "field.featuresPixverse": [
-    [
-      "message",
-      "Pixverse"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "field.featuresPika": [
-    [
-      "message",
-      "Pika"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "field.featuresKling": [
-    [
-      "message",
-      "Kling"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "field.featuresHailuo": [
-    [
-      "message",
-      "Hailuo"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "field.featuresHeadshots": [
-    [
-      "message",
-      "AI証明写真"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "field.featuresSuno": [
-    [
-      "message",
-      "Suno"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "field.featuresFlux": [
-    [
-      "message",
-      "Flux"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "field.featuresNanobanana": [
-    [
-      "message",
-      "ナノバナナ"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
+  "field.title": {
+    "message": "サイトタイトル",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "field.origin": {
+    "message": "サイトドメイン",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "field.description": {
+    "message": "サイト説明",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "field.keywords": {
+    "message": "サイトキーワード",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "field.logo": {
+    "message": "サイトロゴ",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "field.favicon": {
+    "message": "サイトファビコン",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "field.qr": {
+    "message": "QRコード",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "field.url": {
+    "message": "リンク",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "field.admins": {
+    "message": "サイト管理者ID",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "field.distributionDefaultInviterId": {
+    "message": "デフォルト招待者ID",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "field.distributionForceInviterId": {
+    "message": "強制招待者ID",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "field.featuresChat": {
+    "message": "チャット",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "field.featuresVeo": {
+    "message": "Veo",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "field.featuresSora": {
+    "message": "Sora",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "field.featuresGrok": {
+    "message": "Grok",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "field.featuresDeepseek": {
+    "message": "Deepseek",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "field.featuresChatgpt": {
+    "message": "ChatGPT",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "field.featuresMidjourney": {
+    "message": "Midjourney",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "field.featuresChatdoc": {
+    "message": "Chatdoc",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "field.featuresQrart": {
+    "message": "Qrart",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "field.featuresLuma": {
+    "message": "Luma",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "field.featuresPixverse": {
+    "message": "Pixverse",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "field.featuresPika": {
+    "message": "Pika",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "field.featuresKling": {
+    "message": "Kling",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "field.featuresHailuo": {
+    "message": "Hailuo",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "field.featuresHeadshots": {
+    "message": "AI証明写真",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "field.featuresSuno": {
+    "message": "Suno",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "field.featuresFlux": {
+    "message": "Flux",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "field.featuresNanobanana": {
+    "message": "ナノバナナ",
+    "description": "編集ボックスに表示されるタイトル"
+  },
   "field.featuresOpenaiimage": {
     "message": "OpenAI Image",
     "description": "Displayed as the title in the editing box"
   },
-  "field.featuresSeedream": [
-    [
-      "message",
-      "SeeDream"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "field.featuresSeedance": [
-    [
-      "message",
-      "SeeDance"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "field.featuresWan": [
-    [
-      "message",
-      "Wan"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "field.featuresProducer": [
-    [
-      "message",
-      "プロデューサー"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "field.featuresKimi": [
-    [
-      "message",
-      "Kimi"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "field.featuresSerp": [
-    [
-      "message",
-      "SERP"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "field.featuresSupport": [
-    [
-      "message",
-      "カスタマーサポート"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "field.featuresI18n": [
-    [
-      "message",
-      "多言語サポート"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "title.basicConfig": [
-    [
-      "message",
-      "基本設定"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "title.seoConfig": [
-    [
-      "message",
-      "SEO設定"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "title.editAdmins": [
-    [
-      "message",
-      "管理者を編集"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "title.featuresConfig": [
-    [
-      "message",
-      "機能設定"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "title.editTitle": [
-    [
-      "message",
-      "タイトルを編集"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "title.editOrigin": [
-    [
-      "message",
-      "ドメインを編集"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "title.editKeywords": [
-    [
-      "message",
-      "キーワードを編集"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "title.editLogo": [
-    [
-      "message",
-      "ロゴを編集"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "title.editFavicon": [
-    [
-      "message",
-      "ファビコンを編集"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "title.editDescription": [
-    [
-      "message",
-      "説明を編集"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "title.distributionConfig": [
-    [
-      "message",
-      "流通設定"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "title.editDistributionDefaultInviterId": [
-    [
-      "message",
-      "デフォルト招待者を編集"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "title.editDistributionForceInviterId": [
-    [
-      "message",
-      "強制招待者を編集"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "title.editQR": [
-    [
-      "message",
-      "QRコードを編集"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "title.editUrl": [
-    [
-      "message",
-      "リンクを編集"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "placeholder.title": [
-    [
-      "message",
-      "サイトのタイトルを入力"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "placeholder.origin": [
-    [
-      "message",
-      "サイトのドメインを入力"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "placeholder.editUrl": [
-    [
-      "message",
-      "リンクを入力"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "placeholder.description": [
-    [
-      "message",
-      "サイトの説明を入力"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "placeholder.keywords": [
-    [
-      "message",
-      "サイトのキーワードを入力"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "placeholder.editDistributionDefaultInviterId": [
-    [
-      "message",
-      "デフォルトの招待者IDを入力"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "placeholder.editDistributionForceInviterId": [
-    [
-      "message",
-      "強制招待者IDを入力"
-    ],
-    [
-      "description",
-      "編集ボックスに表示されるタイトル"
-    ]
-  ],
-  "message.uploadImageExceed": [
-    [
-      "message",
-      "画像のアップロードが制限を超えました"
-    ],
-    [
-      "description",
-      "画像のアップロードが制限を超えた場合のメッセージ"
-    ]
-  ],
-  "message.uploadImageError": [
-    [
-      "message",
-      "画像のアップロードエラー"
-    ],
-    [
-      "description",
-      "画像のアップロードにエラーが発生した場合のメッセージ"
-    ]
-  ],
-  "message.editLogoTip": [
-    [
-      "message",
-      "推奨サイズ：200*60px"
-    ],
-    [
-      "description",
-      "画像をアップロードする際のヒント"
-    ]
-  ],
-  "message.editQRTip": [
-    [
-      "message",
-      "推奨サイズ：200*200px"
-    ],
-    [
-      "description",
-      "画像をアップロードする際のヒント"
-    ]
-  ],
-  "message.editFaviconTip": [
-    [
-      "message",
-      "推奨サイズ：32*32px"
-    ],
-    [
-      "description",
-      "画像をアップロードする際のヒント"
-    ]
-  ],
-  "message.editUrl": [
-    [
-      "message",
-      "リンクを入力"
-    ],
-    [
-      "description",
-      "リンクを入力する際のヒント"
-    ]
-  ],
-  "message.atLeastOneAdmin": [
-    [
-      "message",
-      "少なくとも1人の管理者を保持"
-    ],
-    [
-      "description",
-      "少なくとも1人の管理者を保持する必要がある場合のメッセージ"
-    ]
-  ],
-  "message.distributionDefaultInviterIdTip": [
-    [
-      "message",
-      "デフォルトの招待者のユーザーID。分配リンクがinviter_idパラメータを持たない場合、このユーザーIDが招待者として使用されます。"
-    ],
-    [
-      "description",
-      "デフォルトの招待者IDに関するヒント"
-    ]
-  ],
-  "message.distributionForceInviterIdTip": [
-    [
-      "message",
-      "強制招待者のユーザーID。このIDが設定されている場合、分配リンクがinviter_idパラメータを持っていても、このユーザーIDが招待者として強制的に使用されます。"
-    ],
-    [
-      "description",
-      "強制招待者IDに関するヒント"
-    ]
-  ],
-  "message.originTip": [
-    [
-      "message",
-      "サイトのドメイン。サイトの設定はドメインにバインドされ、変更できません。"
-    ],
-    [
-      "description",
-      "サイトのドメインに関するヒント"
-    ]
-  ],
-  "message.titleTip": [
-    [
-      "message",
-      "サイトのタイトル。ブラウザのタブに表示されます。"
-    ],
-    [
-      "description",
-      "サイトのタイトルに関するヒント"
-    ]
-  ],
-  "message.descriptionTip": [
-    [
-      "message",
-      "サイトの説明。サイトのメタ情報にあり、SEO最適化に使用されます。"
-    ],
-    [
-      "description",
-      "サイトの説明に関するヒント"
-    ]
-  ],
-  "message.logoTip": [
-    [
-      "message",
-      "サイトのロゴ。メニューが展開されたとき、サイトメニューの上部に表示されます。"
-    ],
-    [
-      "description",
-      "サイトのロゴに関するヒント"
-    ]
-  ],
-  "message.faviconTip": [
-    [
-      "message",
-      "サイトのファビコン。ブラウザのタブに表示されます。"
-    ],
-    [
-      "description",
-      "サイトのファビコンに関するヒント"
-    ]
-  ],
-  "message.adminsTip": [
-    [
-      "message",
-      "サイトの管理者ID。最初にこのサイトを作成したユーザーがデフォルトで管理者になります。サイトの管理者のみがサイトを管理できます。"
-    ],
-    [
-      "description",
-      "サイトの管理者に関するヒント"
-    ]
-  ],
-  "message.adminsTip2": [
-    [
-      "message",
-      "ここで管理者IDを追加または削除できます。ユーザーIDは https://auth.acedata.cloud で確認できます。"
-    ],
-    [
-      "description",
-      "サイトの管理者に関するヒント"
-    ]
-  ],
-  "message.keywordsTip": [
-    [
-      "message",
-      "サイトのキーワード。サイトのメタ情報にあり、SEO最適化に使用されます。"
-    ],
-    [
-      "description",
-      "サイトのキーワードに関するヒント"
-    ]
-  ],
-  "message.keywordsTip2": [
-    [
-      "message",
-      "ここでサイトのキーワードを追加または削除できます。キーワードが正確であるほど、SEO最適化に有利です。"
-    ],
-    [
-      "description",
-      "サイトのキーワードに関するヒント"
-    ]
-  ],
-  "message.featuresChat": [
-    [
-      "message",
-      "チャット機能モジュールをオンまたはオフにします。"
-    ],
-    [
-      "description",
-      "チャット機能の説明"
-    ]
-  ],
-  "message.featuresGrok": [
-    [
-      "message",
-      "Grok機能モジュールをオンまたはオフにします。"
-    ],
-    [
-      "description",
-      "Grok機能の説明"
-    ]
-  ],
-  "message.featuresDeepseek": [
-    [
-      "message",
-      "Deepseek機能モジュールをオンまたはオフにします。"
-    ],
-    [
-      "description",
-      "Deepseek機能の説明"
-    ]
-  ],
-  "message.featuresChatgpt": [
-    [
-      "message",
-      "ChatGPT機能モジュールをオンまたはオフにします。"
-    ],
-    [
-      "description",
-      "ChatGPT機能の説明"
-    ]
-  ],
-  "message.featuresMidjourney": [
-    [
-      "message",
-      "Midjourney機能モジュールをオンまたはオフにします。"
-    ],
-    [
-      "description",
-      "Midjourney機能の説明"
-    ]
-  ],
-  "message.featuresChatdoc": [
-    [
-      "message",
-      "Chatdoc機能モジュールをオンまたはオフにします。"
-    ],
-    [
-      "description",
-      "Chatdoc機能の説明"
-    ]
-  ],
-  "message.featuresQrart": [
-    [
-      "message",
-      "Qrart機能モジュールをオンまたはオフにします。"
-    ],
-    [
-      "description",
-      "Qrart機能の説明"
-    ]
-  ],
-  "message.featuresVeo": [
-    [
-      "message",
-      "Veo機能モジュールをオンまたはオフにします。"
-    ],
-    [
-      "description",
-      "Veo機能の説明"
-    ]
-  ],
-  "message.featuresSora": [
-    [
-      "message",
-      "Sora機能モジュールをオンまたはオフにします。"
-    ],
-    [
-      "description",
-      "Sora機能の説明"
-    ]
-  ],
-  "message.featuresSuno": [
-    [
-      "message",
-      "Suno機能モジュールをオンまたはオフにします。"
-    ],
-    [
-      "description",
-      "Suno機能の説明"
-    ]
-  ],
-  "message.featuresPixverse": [
-    [
-      "message",
-      "Pixverse 機能モジュールを有効または無効にします。"
-    ],
-    [
-      "description",
-      "Pixverse 機能の説明"
-    ]
-  ],
-  "message.featuresFlux": [
-    [
-      "message",
-      "FLux 機能モジュールを有効または無効にします。"
-    ],
-    [
-      "description",
-      "FLux 機能の説明"
-    ]
-  ],
-  "message.featuresNanobanana": [
-    [
-      "message",
-      "Nano Banana 機能モジュールを有効または無効にします。"
-    ],
-    [
-      "description",
-      "Nano Banana 機能の説明"
-    ]
-  ],
+  "field.featuresSeedream": {
+    "message": "SeeDream",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "field.featuresSeedance": {
+    "message": "SeeDance",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "field.featuresWan": {
+    "message": "Wan",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "field.featuresProducer": {
+    "message": "プロデューサー",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "field.featuresKimi": {
+    "message": "Kimi",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "field.featuresSerp": {
+    "message": "SERP",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "field.featuresSupport": {
+    "message": "カスタマーサポート",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "field.featuresI18n": {
+    "message": "多言語サポート",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "title.basicConfig": {
+    "message": "基本設定",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "title.seoConfig": {
+    "message": "SEO設定",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "title.editAdmins": {
+    "message": "管理者を編集",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "title.featuresConfig": {
+    "message": "機能設定",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "title.editTitle": {
+    "message": "タイトルを編集",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "title.editOrigin": {
+    "message": "ドメインを編集",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "title.editKeywords": {
+    "message": "キーワードを編集",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "title.editLogo": {
+    "message": "ロゴを編集",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "title.editFavicon": {
+    "message": "ファビコンを編集",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "title.editDescription": {
+    "message": "説明を編集",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "title.distributionConfig": {
+    "message": "流通設定",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "title.editDistributionDefaultInviterId": {
+    "message": "デフォルト招待者を編集",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "title.editDistributionForceInviterId": {
+    "message": "強制招待者を編集",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "title.editQR": {
+    "message": "QRコードを編集",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "title.editUrl": {
+    "message": "リンクを編集",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "placeholder.title": {
+    "message": "サイトのタイトルを入力",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "placeholder.origin": {
+    "message": "サイトのドメインを入力",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "placeholder.editUrl": {
+    "message": "リンクを入力",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "placeholder.description": {
+    "message": "サイトの説明を入力",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "placeholder.keywords": {
+    "message": "サイトのキーワードを入力",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "placeholder.editDistributionDefaultInviterId": {
+    "message": "デフォルトの招待者IDを入力",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "placeholder.editDistributionForceInviterId": {
+    "message": "強制招待者IDを入力",
+    "description": "編集ボックスに表示されるタイトル"
+  },
+  "message.uploadImageExceed": {
+    "message": "画像のアップロードが制限を超えました",
+    "description": "画像のアップロードが制限を超えた場合のメッセージ"
+  },
+  "message.uploadImageError": {
+    "message": "画像のアップロードエラー",
+    "description": "画像のアップロードにエラーが発生した場合のメッセージ"
+  },
+  "message.editLogoTip": {
+    "message": "推奨サイズ：200*60px",
+    "description": "画像をアップロードする際のヒント"
+  },
+  "message.editQRTip": {
+    "message": "推奨サイズ：200*200px",
+    "description": "画像をアップロードする際のヒント"
+  },
+  "message.editFaviconTip": {
+    "message": "推奨サイズ：32*32px",
+    "description": "画像をアップロードする際のヒント"
+  },
+  "message.editUrl": {
+    "message": "リンクを入力",
+    "description": "リンクを入力する際のヒント"
+  },
+  "message.atLeastOneAdmin": {
+    "message": "少なくとも1人の管理者を保持",
+    "description": "少なくとも1人の管理者を保持する必要がある場合のメッセージ"
+  },
+  "message.distributionDefaultInviterIdTip": {
+    "message": "デフォルトの招待者のユーザーID。分配リンクがinviter_idパラメータを持たない場合、このユーザーIDが招待者として使用されます。",
+    "description": "デフォルトの招待者IDに関するヒント"
+  },
+  "message.distributionForceInviterIdTip": {
+    "message": "強制招待者のユーザーID。このIDが設定されている場合、分配リンクがinviter_idパラメータを持っていても、このユーザーIDが招待者として強制的に使用されます。",
+    "description": "強制招待者IDに関するヒント"
+  },
+  "message.originTip": {
+    "message": "サイトのドメイン。サイトの設定はドメインにバインドされ、変更できません。",
+    "description": "サイトのドメインに関するヒント"
+  },
+  "message.titleTip": {
+    "message": "サイトのタイトル。ブラウザのタブに表示されます。",
+    "description": "サイトのタイトルに関するヒント"
+  },
+  "message.descriptionTip": {
+    "message": "サイトの説明。サイトのメタ情報にあり、SEO最適化に使用されます。",
+    "description": "サイトの説明に関するヒント"
+  },
+  "message.logoTip": {
+    "message": "サイトのロゴ。メニューが展開されたとき、サイトメニューの上部に表示されます。",
+    "description": "サイトのロゴに関するヒント"
+  },
+  "message.faviconTip": {
+    "message": "サイトのファビコン。ブラウザのタブに表示されます。",
+    "description": "サイトのファビコンに関するヒント"
+  },
+  "message.adminsTip": {
+    "message": "サイトの管理者ID。最初にこのサイトを作成したユーザーがデフォルトで管理者になります。サイトの管理者のみがサイトを管理できます。",
+    "description": "サイトの管理者に関するヒント"
+  },
+  "message.adminsTip2": {
+    "message": "ここで管理者IDを追加または削除できます。ユーザーIDは https://auth.acedata.cloud で確認できます。",
+    "description": "サイトの管理者に関するヒント"
+  },
+  "message.keywordsTip": {
+    "message": "サイトのキーワード。サイトのメタ情報にあり、SEO最適化に使用されます。",
+    "description": "サイトのキーワードに関するヒント"
+  },
+  "message.keywordsTip2": {
+    "message": "ここでサイトのキーワードを追加または削除できます。キーワードが正確であるほど、SEO最適化に有利です。",
+    "description": "サイトのキーワードに関するヒント"
+  },
+  "message.featuresChat": {
+    "message": "チャット機能モジュールをオンまたはオフにします。",
+    "description": "チャット機能の説明"
+  },
+  "message.featuresGrok": {
+    "message": "Grok機能モジュールをオンまたはオフにします。",
+    "description": "Grok機能の説明"
+  },
+  "message.featuresDeepseek": {
+    "message": "Deepseek機能モジュールをオンまたはオフにします。",
+    "description": "Deepseek機能の説明"
+  },
+  "message.featuresChatgpt": {
+    "message": "ChatGPT機能モジュールをオンまたはオフにします。",
+    "description": "ChatGPT機能の説明"
+  },
+  "message.featuresMidjourney": {
+    "message": "Midjourney機能モジュールをオンまたはオフにします。",
+    "description": "Midjourney機能の説明"
+  },
+  "message.featuresChatdoc": {
+    "message": "Chatdoc機能モジュールをオンまたはオフにします。",
+    "description": "Chatdoc機能の説明"
+  },
+  "message.featuresQrart": {
+    "message": "Qrart機能モジュールをオンまたはオフにします。",
+    "description": "Qrart機能の説明"
+  },
+  "message.featuresVeo": {
+    "message": "Veo機能モジュールをオンまたはオフにします。",
+    "description": "Veo機能の説明"
+  },
+  "message.featuresSora": {
+    "message": "Sora機能モジュールをオンまたはオフにします。",
+    "description": "Sora機能の説明"
+  },
+  "message.featuresSuno": {
+    "message": "Suno機能モジュールをオンまたはオフにします。",
+    "description": "Suno機能の説明"
+  },
+  "message.featuresPixverse": {
+    "message": "Pixverse 機能モジュールを有効または無効にします。",
+    "description": "Pixverse 機能の説明"
+  },
+  "message.featuresFlux": {
+    "message": "FLux 機能モジュールを有効または無効にします。",
+    "description": "FLux 機能の説明"
+  },
+  "message.featuresNanobanana": {
+    "message": "Nano Banana 機能モジュールを有効または無効にします。",
+    "description": "Nano Banana 機能の説明"
+  },
   "message.featuresOpenaiimage": {
     "message": "Toggle OpenAI Image feature module.",
     "description": "Description of the OpenAI Image feature"
   },
-  "message.featuresSeedream": [
-    [
-      "message",
-      "SeeDream 機能モジュールを有効または無効にします。"
-    ],
-    [
-      "description",
-      "SeeDream 機能の説明"
-    ]
-  ],
-  "message.featuresSeedance": [
-    [
-      "message",
-      "SeeDance 機能モジュールを有効または無効にします。"
-    ],
-    [
-      "description",
-      "SeeDance 機能の説明"
-    ]
-  ],
-  "message.featuresWan": [
-    [
-      "message",
-      "Wan 機能モジュールを有効または無効にします。"
-    ],
-    [
-      "description",
-      "Wan 機能の説明"
-    ]
-  ],
-  "message.featuresProducer": [
-    [
-      "message",
-      "Producer 機能モジュールを有効または無効にします。"
-    ],
-    [
-      "description",
-      "Producer 機能の説明"
-    ]
-  ],
-  "message.featuresKimi": [
-    [
-      "message",
-      "Kimi 機能モジュールを有効または無効にします。"
-    ],
-    [
-      "description",
-      "Kimi 機能の説明"
-    ]
-  ],
-  "message.featuresSerp": [
-    [
-      "message",
-      "SERP 機能モジュールを有効または無効にします。"
-    ],
-    [
-      "description",
-      "SERP 機能の説明"
-    ]
-  ],
-  "message.featuresLuma": [
-    [
-      "message",
-      "Luma 機能モジュールを有効または無効にします。"
-    ],
-    [
-      "description",
-      "Luma 機能の説明"
-    ]
-  ],
-  "message.featuresPika": [
-    [
-      "message",
-      "Pika 機能モジュールを有効または無効にします。"
-    ],
-    [
-      "description",
-      "Pika 機能の説明"
-    ]
-  ],
-  "message.featuresKling": [
-    [
-      "message",
-      "Kling 機能モジュールを有効または無効にします。"
-    ],
-    [
-      "description",
-      "Kling 機能の説明"
-    ]
-  ],
-  "message.featuresHailuo": [
-    [
-      "message",
-      "Hailuo 機能モジュールを有効または無効にします。"
-    ],
-    [
-      "description",
-      "Hailuo 機能の説明"
-    ]
-  ],
-  "message.featuresHeadshots": [
-    [
-      "message",
-      "AI 証明写真機能モジュールを有効または無効にします。"
-    ],
-    [
-      "description",
-      "AI 証明写真機能の説明"
-    ]
-  ],
-  "message.featuresSupport": [
-    [
-      "message",
-      "カスタマーサポートを有効または無効にします。"
-    ],
-    [
-      "description",
-      "Support 機能の説明"
-    ]
-  ],
-  "message.featuresI18n": [
-    [
-      "message",
-      "多言語サポートを有効または無効にします。無効にすると、ユーザーはデフォルト言語のみ使用できます。"
-    ],
-    [
-      "description",
-      "多言語サポートの説明"
-    ]
-  ],
-  "button.upload": [
-    [
-      "message",
-      "アップロード"
-    ],
-    [
-      "description",
-      "アップロード"
-    ]
-  ],
-  "button.enabled": [
-    [
-      "message",
-      "有効"
-    ],
-    [
-      "description",
-      "スイッチのテキスト、すでに有効であることを示します"
-    ]
-  ],
-  "button.disabled": [
-    [
-      "message",
-      "無効"
-    ],
-    [
-      "description",
-      "スイッチのテキスト、すでに無効であることを示します"
-    ]
-  ],
-  "field.featuresGemini": [
-    [
-      "message",
-      "Gemini"
-    ],
-    [
-      "description",
-      "編集ボックスのタイトルとして表示されます"
-    ]
-  ],
-  "message.featuresGemini": [
-    [
-      "message",
-      "Gemini 機能モジュールを有効または無効にします。"
-    ],
-    [
-      "description",
-      "Gemini 機能の説明"
-    ]
-  ],
-  "field.featuresClaude": [
-    [
-      "message",
-      "Claude"
-    ],
-    [
-      "description",
-      "編集ボックスのタイトルとして表示されます"
-    ]
-  ],
-  "message.featuresClaude": [
-    [
-      "message",
-      "Claude 機能モジュールを有効または無効にします。"
-    ],
-    [
-      "description",
-      "Claude 機能の説明"
-    ]
-  ]
+  "message.featuresSeedream": {
+    "message": "SeeDream 機能モジュールを有効または無効にします。",
+    "description": "SeeDream 機能の説明"
+  },
+  "message.featuresSeedance": {
+    "message": "SeeDance 機能モジュールを有効または無効にします。",
+    "description": "SeeDance 機能の説明"
+  },
+  "message.featuresWan": {
+    "message": "Wan 機能モジュールを有効または無効にします。",
+    "description": "Wan 機能の説明"
+  },
+  "message.featuresProducer": {
+    "message": "Producer 機能モジュールを有効または無効にします。",
+    "description": "Producer 機能の説明"
+  },
+  "message.featuresKimi": {
+    "message": "Kimi 機能モジュールを有効または無効にします。",
+    "description": "Kimi 機能の説明"
+  },
+  "message.featuresSerp": {
+    "message": "SERP 機能モジュールを有効または無効にします。",
+    "description": "SERP 機能の説明"
+  },
+  "message.featuresLuma": {
+    "message": "Luma 機能モジュールを有効または無効にします。",
+    "description": "Luma 機能の説明"
+  },
+  "message.featuresPika": {
+    "message": "Pika 機能モジュールを有効または無効にします。",
+    "description": "Pika 機能の説明"
+  },
+  "message.featuresKling": {
+    "message": "Kling 機能モジュールを有効または無効にします。",
+    "description": "Kling 機能の説明"
+  },
+  "message.featuresHailuo": {
+    "message": "Hailuo 機能モジュールを有効または無効にします。",
+    "description": "Hailuo 機能の説明"
+  },
+  "message.featuresHeadshots": {
+    "message": "AI 証明写真機能モジュールを有効または無効にします。",
+    "description": "AI 証明写真機能の説明"
+  },
+  "message.featuresSupport": {
+    "message": "カスタマーサポートを有効または無効にします。",
+    "description": "Support 機能の説明"
+  },
+  "message.featuresI18n": {
+    "message": "多言語サポートを有効または無効にします。無効にすると、ユーザーはデフォルト言語のみ使用できます。",
+    "description": "多言語サポートの説明"
+  },
+  "button.upload": {
+    "message": "アップロード",
+    "description": "アップロード"
+  },
+  "button.enabled": {
+    "message": "有効",
+    "description": "スイッチのテキスト、すでに有効であることを示します"
+  },
+  "button.disabled": {
+    "message": "無効",
+    "description": "スイッチのテキスト、すでに無効であることを示します"
+  },
+  "field.featuresGemini": {
+    "message": "Gemini",
+    "description": "編集ボックスのタイトルとして表示されます"
+  },
+  "message.featuresGemini": {
+    "message": "Gemini 機能モジュールを有効または無効にします。",
+    "description": "Gemini 機能の説明"
+  },
+  "field.featuresClaude": {
+    "message": "Claude",
+    "description": "編集ボックスのタイトルとして表示されます"
+  },
+  "message.featuresClaude": {
+    "message": "Claude 機能モジュールを有効または無効にします。",
+    "description": "Claude 機能の説明"
+  }
 }

--- a/src/i18n/ja/site.json
+++ b/src/i18n/ja/site.json
@@ -1,442 +1,1110 @@
 {
-  "field.title": {
-    "message": "サイトタイトル",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "field.origin": {
-    "message": "サイトドメイン",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "field.description": {
-    "message": "サイト説明",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "field.keywords": {
-    "message": "サイトキーワード",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "field.logo": {
-    "message": "サイトロゴ",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "field.favicon": {
-    "message": "サイトファビコン",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "field.qr": {
-    "message": "QRコード",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "field.url": {
-    "message": "リンク",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "field.admins": {
-    "message": "サイト管理者ID",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "field.distributionDefaultInviterId": {
-    "message": "デフォルト招待者ID",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "field.distributionForceInviterId": {
-    "message": "強制招待者ID",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "field.featuresChat": {
-    "message": "チャット",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "field.featuresVeo": {
-    "message": "Veo",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "field.featuresSora": {
-    "message": "Sora",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "field.featuresGrok": {
-    "message": "Grok",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "field.featuresDeepseek": {
-    "message": "Deepseek",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "field.featuresChatgpt": {
-    "message": "ChatGPT",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "field.featuresMidjourney": {
-    "message": "Midjourney",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "field.featuresChatdoc": {
-    "message": "Chatdoc",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "field.featuresQrart": {
-    "message": "Qrart",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "field.featuresLuma": {
-    "message": "Luma",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "field.featuresPixverse": {
-    "message": "Pixverse",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "field.featuresPika": {
-    "message": "Pika",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "field.featuresKling": {
-    "message": "Kling",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "field.featuresHailuo": {
-    "message": "Hailuo",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "field.featuresHeadshots": {
-    "message": "AI証明写真",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "field.featuresSuno": {
-    "message": "Suno",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "field.featuresFlux": {
-    "message": "Flux",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "field.featuresNanobanana": {
-    "message": "ナノバナナ",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "field.featuresSeedream": {
-    "message": "SeeDream",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "field.featuresSeedance": {
-    "message": "SeeDance",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "field.featuresWan": {
-    "message": "Wan",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "field.featuresProducer": {
-    "message": "プロデューサー",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "field.featuresKimi": {
-    "message": "Kimi",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "field.featuresSerp": {
-    "message": "SERP",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "field.featuresSupport": {
-    "message": "カスタマーサポート",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "field.featuresI18n": {
-    "message": "多言語サポート",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "title.basicConfig": {
-    "message": "基本設定",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "title.seoConfig": {
-    "message": "SEO設定",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "title.editAdmins": {
-    "message": "管理者を編集",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "title.featuresConfig": {
-    "message": "機能設定",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "title.editTitle": {
-    "message": "タイトルを編集",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "title.editOrigin": {
-    "message": "ドメインを編集",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "title.editKeywords": {
-    "message": "キーワードを編集",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "title.editLogo": {
-    "message": "ロゴを編集",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "title.editFavicon": {
-    "message": "ファビコンを編集",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "title.editDescription": {
-    "message": "説明を編集",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "title.distributionConfig": {
-    "message": "流通設定",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "title.editDistributionDefaultInviterId": {
-    "message": "デフォルト招待者を編集",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "title.editDistributionForceInviterId": {
-    "message": "強制招待者を編集",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "title.editQR": {
-    "message": "QRコードを編集",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "title.editUrl": {
-    "message": "リンクを編集",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "placeholder.title": {
-    "message": "サイトのタイトルを入力",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "placeholder.origin": {
-    "message": "サイトのドメインを入力",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "placeholder.editUrl": {
-    "message": "リンクを入力",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "placeholder.description": {
-    "message": "サイトの説明を入力",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "placeholder.keywords": {
-    "message": "サイトのキーワードを入力",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "placeholder.editDistributionDefaultInviterId": {
-    "message": "デフォルトの招待者IDを入力",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "placeholder.editDistributionForceInviterId": {
-    "message": "強制招待者IDを入力",
-    "description": "編集ボックスに表示されるタイトル"
-  },
-  "message.uploadImageExceed": {
-    "message": "画像のアップロードが制限を超えました",
-    "description": "画像のアップロードが制限を超えた場合のメッセージ"
-  },
-  "message.uploadImageError": {
-    "message": "画像のアップロードエラー",
-    "description": "画像のアップロードにエラーが発生した場合のメッセージ"
-  },
-  "message.editLogoTip": {
-    "message": "推奨サイズ：200*60px",
-    "description": "画像をアップロードする際のヒント"
-  },
-  "message.editQRTip": {
-    "message": "推奨サイズ：200*200px",
-    "description": "画像をアップロードする際のヒント"
-  },
-  "message.editFaviconTip": {
-    "message": "推奨サイズ：32*32px",
-    "description": "画像をアップロードする際のヒント"
-  },
-  "message.editUrl": {
-    "message": "リンクを入力",
-    "description": "リンクを入力する際のヒント"
-  },
-  "message.atLeastOneAdmin": {
-    "message": "少なくとも1人の管理者を保持",
-    "description": "少なくとも1人の管理者を保持する必要がある場合のメッセージ"
-  },
-  "message.distributionDefaultInviterIdTip": {
-    "message": "デフォルトの招待者のユーザーID。分配リンクがinviter_idパラメータを持たない場合、このユーザーIDが招待者として使用されます。",
-    "description": "デフォルトの招待者IDに関するヒント"
-  },
-  "message.distributionForceInviterIdTip": {
-    "message": "強制招待者のユーザーID。このIDが設定されている場合、分配リンクがinviter_idパラメータを持っていても、このユーザーIDが招待者として強制的に使用されます。",
-    "description": "強制招待者IDに関するヒント"
-  },
-  "message.originTip": {
-    "message": "サイトのドメイン。サイトの設定はドメインにバインドされ、変更できません。",
-    "description": "サイトのドメインに関するヒント"
-  },
-  "message.titleTip": {
-    "message": "サイトのタイトル。ブラウザのタブに表示されます。",
-    "description": "サイトのタイトルに関するヒント"
-  },
-  "message.descriptionTip": {
-    "message": "サイトの説明。サイトのメタ情報にあり、SEO最適化に使用されます。",
-    "description": "サイトの説明に関するヒント"
-  },
-  "message.logoTip": {
-    "message": "サイトのロゴ。メニューが展開されたとき、サイトメニューの上部に表示されます。",
-    "description": "サイトのロゴに関するヒント"
-  },
-  "message.faviconTip": {
-    "message": "サイトのファビコン。ブラウザのタブに表示されます。",
-    "description": "サイトのファビコンに関するヒント"
-  },
-  "message.adminsTip": {
-    "message": "サイトの管理者ID。最初にこのサイトを作成したユーザーがデフォルトで管理者になります。サイトの管理者のみがサイトを管理できます。",
-    "description": "サイトの管理者に関するヒント"
-  },
-  "message.adminsTip2": {
-    "message": "ここで管理者IDを追加または削除できます。ユーザーIDは https://auth.acedata.cloud で確認できます。",
-    "description": "サイトの管理者に関するヒント"
-  },
-  "message.keywordsTip": {
-    "message": "サイトのキーワード。サイトのメタ情報にあり、SEO最適化に使用されます。",
-    "description": "サイトのキーワードに関するヒント"
-  },
-  "message.keywordsTip2": {
-    "message": "ここでサイトのキーワードを追加または削除できます。キーワードが正確であるほど、SEO最適化に有利です。",
-    "description": "サイトのキーワードに関するヒント"
-  },
-  "message.featuresChat": {
-    "message": "チャット機能モジュールをオンまたはオフにします。",
-    "description": "チャット機能の説明"
-  },
-  "message.featuresGrok": {
-    "message": "Grok機能モジュールをオンまたはオフにします。",
-    "description": "Grok機能の説明"
-  },
-  "message.featuresDeepseek": {
-    "message": "Deepseek機能モジュールをオンまたはオフにします。",
-    "description": "Deepseek機能の説明"
-  },
-  "message.featuresChatgpt": {
-    "message": "ChatGPT機能モジュールをオンまたはオフにします。",
-    "description": "ChatGPT機能の説明"
-  },
-  "message.featuresMidjourney": {
-    "message": "Midjourney機能モジュールをオンまたはオフにします。",
-    "description": "Midjourney機能の説明"
-  },
-  "message.featuresChatdoc": {
-    "message": "Chatdoc機能モジュールをオンまたはオフにします。",
-    "description": "Chatdoc機能の説明"
-  },
-  "message.featuresQrart": {
-    "message": "Qrart機能モジュールをオンまたはオフにします。",
-    "description": "Qrart機能の説明"
-  },
-  "message.featuresVeo": {
-    "message": "Veo機能モジュールをオンまたはオフにします。",
-    "description": "Veo機能の説明"
-  },
-  "message.featuresSora": {
-    "message": "Sora機能モジュールをオンまたはオフにします。",
-    "description": "Sora機能の説明"
-  },
-  "message.featuresSuno": {
-    "message": "Suno機能モジュールをオンまたはオフにします。",
-    "description": "Suno機能の説明"
-  },
-  "message.featuresPixverse": {
-    "message": "Pixverse 機能モジュールを有効または無効にします。",
-    "description": "Pixverse 機能の説明"
-  },
-  "message.featuresFlux": {
-    "message": "FLux 機能モジュールを有効または無効にします。",
-    "description": "FLux 機能の説明"
-  },
-  "message.featuresNanobanana": {
-    "message": "Nano Banana 機能モジュールを有効または無効にします。",
-    "description": "Nano Banana 機能の説明"
-  },
-  "message.featuresSeedream": {
-    "message": "SeeDream 機能モジュールを有効または無効にします。",
-    "description": "SeeDream 機能の説明"
-  },
-  "message.featuresSeedance": {
-    "message": "SeeDance 機能モジュールを有効または無効にします。",
-    "description": "SeeDance 機能の説明"
-  },
-  "message.featuresWan": {
-    "message": "Wan 機能モジュールを有効または無効にします。",
-    "description": "Wan 機能の説明"
-  },
-  "message.featuresProducer": {
-    "message": "Producer 機能モジュールを有効または無効にします。",
-    "description": "Producer 機能の説明"
-  },
-  "message.featuresKimi": {
-    "message": "Kimi 機能モジュールを有効または無効にします。",
-    "description": "Kimi 機能の説明"
-  },
-  "message.featuresSerp": {
-    "message": "SERP 機能モジュールを有効または無効にします。",
-    "description": "SERP 機能の説明"
-  },
-  "message.featuresLuma": {
-    "message": "Luma 機能モジュールを有効または無効にします。",
-    "description": "Luma 機能の説明"
-  },
-  "message.featuresPika": {
-    "message": "Pika 機能モジュールを有効または無効にします。",
-    "description": "Pika 機能の説明"
-  },
-  "message.featuresKling": {
-    "message": "Kling 機能モジュールを有効または無効にします。",
-    "description": "Kling 機能の説明"
-  },
-  "message.featuresHailuo": {
-    "message": "Hailuo 機能モジュールを有効または無効にします。",
-    "description": "Hailuo 機能の説明"
-  },
-  "message.featuresHeadshots": {
-    "message": "AI 証明写真機能モジュールを有効または無効にします。",
-    "description": "AI 証明写真機能の説明"
-  },
-  "message.featuresSupport": {
-    "message": "カスタマーサポートを有効または無効にします。",
-    "description": "Support 機能の説明"
-  },
-  "message.featuresI18n": {
-    "message": "多言語サポートを有効または無効にします。無効にすると、ユーザーはデフォルト言語のみ使用できます。",
-    "description": "多言語サポートの説明"
-  },
-  "button.upload": {
-    "message": "アップロード",
-    "description": "アップロード"
-  },
-  "button.enabled": {
-    "message": "有効",
-    "description": "スイッチのテキスト、すでに有効であることを示します"
-  },
-  "button.disabled": {
-    "message": "無効",
-    "description": "スイッチのテキスト、すでに無効であることを示します"
-  },
-  "field.featuresGemini": {
-    "message": "Gemini",
-    "description": "編集ボックスのタイトルとして表示されます"
-  },
-  "message.featuresGemini": {
-    "message": "Gemini 機能モジュールを有効または無効にします。",
-    "description": "Gemini 機能の説明"
-  },
-  "field.featuresClaude": {
-    "message": "Claude",
-    "description": "編集ボックスのタイトルとして表示されます"
-  },
-  "message.featuresClaude": {
-    "message": "Claude 機能モジュールを有効または無効にします。",
-    "description": "Claude 機能の説明"
-  }
+  "field.title": [
+    [
+      "message",
+      "サイトタイトル"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "field.origin": [
+    [
+      "message",
+      "サイトドメイン"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "field.description": [
+    [
+      "message",
+      "サイト説明"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "field.keywords": [
+    [
+      "message",
+      "サイトキーワード"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "field.logo": [
+    [
+      "message",
+      "サイトロゴ"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "field.favicon": [
+    [
+      "message",
+      "サイトファビコン"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "field.qr": [
+    [
+      "message",
+      "QRコード"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "field.url": [
+    [
+      "message",
+      "リンク"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "field.admins": [
+    [
+      "message",
+      "サイト管理者ID"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "field.distributionDefaultInviterId": [
+    [
+      "message",
+      "デフォルト招待者ID"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "field.distributionForceInviterId": [
+    [
+      "message",
+      "強制招待者ID"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "field.featuresChat": [
+    [
+      "message",
+      "チャット"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "field.featuresVeo": [
+    [
+      "message",
+      "Veo"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "field.featuresSora": [
+    [
+      "message",
+      "Sora"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "field.featuresGrok": [
+    [
+      "message",
+      "Grok"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "field.featuresDeepseek": [
+    [
+      "message",
+      "Deepseek"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "field.featuresChatgpt": [
+    [
+      "message",
+      "ChatGPT"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "field.featuresMidjourney": [
+    [
+      "message",
+      "Midjourney"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "field.featuresChatdoc": [
+    [
+      "message",
+      "Chatdoc"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "field.featuresQrart": [
+    [
+      "message",
+      "Qrart"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "field.featuresLuma": [
+    [
+      "message",
+      "Luma"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "field.featuresPixverse": [
+    [
+      "message",
+      "Pixverse"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "field.featuresPika": [
+    [
+      "message",
+      "Pika"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "field.featuresKling": [
+    [
+      "message",
+      "Kling"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "field.featuresHailuo": [
+    [
+      "message",
+      "Hailuo"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "field.featuresHeadshots": [
+    [
+      "message",
+      "AI証明写真"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "field.featuresSuno": [
+    [
+      "message",
+      "Suno"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "field.featuresFlux": [
+    [
+      "message",
+      "Flux"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "field.featuresNanobanana": [
+    [
+      "message",
+      "ナノバナナ"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "field.featuresOpenaiimage": {
+    "message": "OpenAI Image",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresSeedream": [
+    [
+      "message",
+      "SeeDream"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "field.featuresSeedance": [
+    [
+      "message",
+      "SeeDance"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "field.featuresWan": [
+    [
+      "message",
+      "Wan"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "field.featuresProducer": [
+    [
+      "message",
+      "プロデューサー"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "field.featuresKimi": [
+    [
+      "message",
+      "Kimi"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "field.featuresSerp": [
+    [
+      "message",
+      "SERP"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "field.featuresSupport": [
+    [
+      "message",
+      "カスタマーサポート"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "field.featuresI18n": [
+    [
+      "message",
+      "多言語サポート"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "title.basicConfig": [
+    [
+      "message",
+      "基本設定"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "title.seoConfig": [
+    [
+      "message",
+      "SEO設定"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "title.editAdmins": [
+    [
+      "message",
+      "管理者を編集"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "title.featuresConfig": [
+    [
+      "message",
+      "機能設定"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "title.editTitle": [
+    [
+      "message",
+      "タイトルを編集"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "title.editOrigin": [
+    [
+      "message",
+      "ドメインを編集"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "title.editKeywords": [
+    [
+      "message",
+      "キーワードを編集"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "title.editLogo": [
+    [
+      "message",
+      "ロゴを編集"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "title.editFavicon": [
+    [
+      "message",
+      "ファビコンを編集"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "title.editDescription": [
+    [
+      "message",
+      "説明を編集"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "title.distributionConfig": [
+    [
+      "message",
+      "流通設定"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "title.editDistributionDefaultInviterId": [
+    [
+      "message",
+      "デフォルト招待者を編集"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "title.editDistributionForceInviterId": [
+    [
+      "message",
+      "強制招待者を編集"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "title.editQR": [
+    [
+      "message",
+      "QRコードを編集"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "title.editUrl": [
+    [
+      "message",
+      "リンクを編集"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "placeholder.title": [
+    [
+      "message",
+      "サイトのタイトルを入力"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "placeholder.origin": [
+    [
+      "message",
+      "サイトのドメインを入力"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "placeholder.editUrl": [
+    [
+      "message",
+      "リンクを入力"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "placeholder.description": [
+    [
+      "message",
+      "サイトの説明を入力"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "placeholder.keywords": [
+    [
+      "message",
+      "サイトのキーワードを入力"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "placeholder.editDistributionDefaultInviterId": [
+    [
+      "message",
+      "デフォルトの招待者IDを入力"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "placeholder.editDistributionForceInviterId": [
+    [
+      "message",
+      "強制招待者IDを入力"
+    ],
+    [
+      "description",
+      "編集ボックスに表示されるタイトル"
+    ]
+  ],
+  "message.uploadImageExceed": [
+    [
+      "message",
+      "画像のアップロードが制限を超えました"
+    ],
+    [
+      "description",
+      "画像のアップロードが制限を超えた場合のメッセージ"
+    ]
+  ],
+  "message.uploadImageError": [
+    [
+      "message",
+      "画像のアップロードエラー"
+    ],
+    [
+      "description",
+      "画像のアップロードにエラーが発生した場合のメッセージ"
+    ]
+  ],
+  "message.editLogoTip": [
+    [
+      "message",
+      "推奨サイズ：200*60px"
+    ],
+    [
+      "description",
+      "画像をアップロードする際のヒント"
+    ]
+  ],
+  "message.editQRTip": [
+    [
+      "message",
+      "推奨サイズ：200*200px"
+    ],
+    [
+      "description",
+      "画像をアップロードする際のヒント"
+    ]
+  ],
+  "message.editFaviconTip": [
+    [
+      "message",
+      "推奨サイズ：32*32px"
+    ],
+    [
+      "description",
+      "画像をアップロードする際のヒント"
+    ]
+  ],
+  "message.editUrl": [
+    [
+      "message",
+      "リンクを入力"
+    ],
+    [
+      "description",
+      "リンクを入力する際のヒント"
+    ]
+  ],
+  "message.atLeastOneAdmin": [
+    [
+      "message",
+      "少なくとも1人の管理者を保持"
+    ],
+    [
+      "description",
+      "少なくとも1人の管理者を保持する必要がある場合のメッセージ"
+    ]
+  ],
+  "message.distributionDefaultInviterIdTip": [
+    [
+      "message",
+      "デフォルトの招待者のユーザーID。分配リンクがinviter_idパラメータを持たない場合、このユーザーIDが招待者として使用されます。"
+    ],
+    [
+      "description",
+      "デフォルトの招待者IDに関するヒント"
+    ]
+  ],
+  "message.distributionForceInviterIdTip": [
+    [
+      "message",
+      "強制招待者のユーザーID。このIDが設定されている場合、分配リンクがinviter_idパラメータを持っていても、このユーザーIDが招待者として強制的に使用されます。"
+    ],
+    [
+      "description",
+      "強制招待者IDに関するヒント"
+    ]
+  ],
+  "message.originTip": [
+    [
+      "message",
+      "サイトのドメイン。サイトの設定はドメインにバインドされ、変更できません。"
+    ],
+    [
+      "description",
+      "サイトのドメインに関するヒント"
+    ]
+  ],
+  "message.titleTip": [
+    [
+      "message",
+      "サイトのタイトル。ブラウザのタブに表示されます。"
+    ],
+    [
+      "description",
+      "サイトのタイトルに関するヒント"
+    ]
+  ],
+  "message.descriptionTip": [
+    [
+      "message",
+      "サイトの説明。サイトのメタ情報にあり、SEO最適化に使用されます。"
+    ],
+    [
+      "description",
+      "サイトの説明に関するヒント"
+    ]
+  ],
+  "message.logoTip": [
+    [
+      "message",
+      "サイトのロゴ。メニューが展開されたとき、サイトメニューの上部に表示されます。"
+    ],
+    [
+      "description",
+      "サイトのロゴに関するヒント"
+    ]
+  ],
+  "message.faviconTip": [
+    [
+      "message",
+      "サイトのファビコン。ブラウザのタブに表示されます。"
+    ],
+    [
+      "description",
+      "サイトのファビコンに関するヒント"
+    ]
+  ],
+  "message.adminsTip": [
+    [
+      "message",
+      "サイトの管理者ID。最初にこのサイトを作成したユーザーがデフォルトで管理者になります。サイトの管理者のみがサイトを管理できます。"
+    ],
+    [
+      "description",
+      "サイトの管理者に関するヒント"
+    ]
+  ],
+  "message.adminsTip2": [
+    [
+      "message",
+      "ここで管理者IDを追加または削除できます。ユーザーIDは https://auth.acedata.cloud で確認できます。"
+    ],
+    [
+      "description",
+      "サイトの管理者に関するヒント"
+    ]
+  ],
+  "message.keywordsTip": [
+    [
+      "message",
+      "サイトのキーワード。サイトのメタ情報にあり、SEO最適化に使用されます。"
+    ],
+    [
+      "description",
+      "サイトのキーワードに関するヒント"
+    ]
+  ],
+  "message.keywordsTip2": [
+    [
+      "message",
+      "ここでサイトのキーワードを追加または削除できます。キーワードが正確であるほど、SEO最適化に有利です。"
+    ],
+    [
+      "description",
+      "サイトのキーワードに関するヒント"
+    ]
+  ],
+  "message.featuresChat": [
+    [
+      "message",
+      "チャット機能モジュールをオンまたはオフにします。"
+    ],
+    [
+      "description",
+      "チャット機能の説明"
+    ]
+  ],
+  "message.featuresGrok": [
+    [
+      "message",
+      "Grok機能モジュールをオンまたはオフにします。"
+    ],
+    [
+      "description",
+      "Grok機能の説明"
+    ]
+  ],
+  "message.featuresDeepseek": [
+    [
+      "message",
+      "Deepseek機能モジュールをオンまたはオフにします。"
+    ],
+    [
+      "description",
+      "Deepseek機能の説明"
+    ]
+  ],
+  "message.featuresChatgpt": [
+    [
+      "message",
+      "ChatGPT機能モジュールをオンまたはオフにします。"
+    ],
+    [
+      "description",
+      "ChatGPT機能の説明"
+    ]
+  ],
+  "message.featuresMidjourney": [
+    [
+      "message",
+      "Midjourney機能モジュールをオンまたはオフにします。"
+    ],
+    [
+      "description",
+      "Midjourney機能の説明"
+    ]
+  ],
+  "message.featuresChatdoc": [
+    [
+      "message",
+      "Chatdoc機能モジュールをオンまたはオフにします。"
+    ],
+    [
+      "description",
+      "Chatdoc機能の説明"
+    ]
+  ],
+  "message.featuresQrart": [
+    [
+      "message",
+      "Qrart機能モジュールをオンまたはオフにします。"
+    ],
+    [
+      "description",
+      "Qrart機能の説明"
+    ]
+  ],
+  "message.featuresVeo": [
+    [
+      "message",
+      "Veo機能モジュールをオンまたはオフにします。"
+    ],
+    [
+      "description",
+      "Veo機能の説明"
+    ]
+  ],
+  "message.featuresSora": [
+    [
+      "message",
+      "Sora機能モジュールをオンまたはオフにします。"
+    ],
+    [
+      "description",
+      "Sora機能の説明"
+    ]
+  ],
+  "message.featuresSuno": [
+    [
+      "message",
+      "Suno機能モジュールをオンまたはオフにします。"
+    ],
+    [
+      "description",
+      "Suno機能の説明"
+    ]
+  ],
+  "message.featuresPixverse": [
+    [
+      "message",
+      "Pixverse 機能モジュールを有効または無効にします。"
+    ],
+    [
+      "description",
+      "Pixverse 機能の説明"
+    ]
+  ],
+  "message.featuresFlux": [
+    [
+      "message",
+      "FLux 機能モジュールを有効または無効にします。"
+    ],
+    [
+      "description",
+      "FLux 機能の説明"
+    ]
+  ],
+  "message.featuresNanobanana": [
+    [
+      "message",
+      "Nano Banana 機能モジュールを有効または無効にします。"
+    ],
+    [
+      "description",
+      "Nano Banana 機能の説明"
+    ]
+  ],
+  "message.featuresOpenaiimage": {
+    "message": "Toggle OpenAI Image feature module.",
+    "description": "Description of the OpenAI Image feature"
+  },
+  "message.featuresSeedream": [
+    [
+      "message",
+      "SeeDream 機能モジュールを有効または無効にします。"
+    ],
+    [
+      "description",
+      "SeeDream 機能の説明"
+    ]
+  ],
+  "message.featuresSeedance": [
+    [
+      "message",
+      "SeeDance 機能モジュールを有効または無効にします。"
+    ],
+    [
+      "description",
+      "SeeDance 機能の説明"
+    ]
+  ],
+  "message.featuresWan": [
+    [
+      "message",
+      "Wan 機能モジュールを有効または無効にします。"
+    ],
+    [
+      "description",
+      "Wan 機能の説明"
+    ]
+  ],
+  "message.featuresProducer": [
+    [
+      "message",
+      "Producer 機能モジュールを有効または無効にします。"
+    ],
+    [
+      "description",
+      "Producer 機能の説明"
+    ]
+  ],
+  "message.featuresKimi": [
+    [
+      "message",
+      "Kimi 機能モジュールを有効または無効にします。"
+    ],
+    [
+      "description",
+      "Kimi 機能の説明"
+    ]
+  ],
+  "message.featuresSerp": [
+    [
+      "message",
+      "SERP 機能モジュールを有効または無効にします。"
+    ],
+    [
+      "description",
+      "SERP 機能の説明"
+    ]
+  ],
+  "message.featuresLuma": [
+    [
+      "message",
+      "Luma 機能モジュールを有効または無効にします。"
+    ],
+    [
+      "description",
+      "Luma 機能の説明"
+    ]
+  ],
+  "message.featuresPika": [
+    [
+      "message",
+      "Pika 機能モジュールを有効または無効にします。"
+    ],
+    [
+      "description",
+      "Pika 機能の説明"
+    ]
+  ],
+  "message.featuresKling": [
+    [
+      "message",
+      "Kling 機能モジュールを有効または無効にします。"
+    ],
+    [
+      "description",
+      "Kling 機能の説明"
+    ]
+  ],
+  "message.featuresHailuo": [
+    [
+      "message",
+      "Hailuo 機能モジュールを有効または無効にします。"
+    ],
+    [
+      "description",
+      "Hailuo 機能の説明"
+    ]
+  ],
+  "message.featuresHeadshots": [
+    [
+      "message",
+      "AI 証明写真機能モジュールを有効または無効にします。"
+    ],
+    [
+      "description",
+      "AI 証明写真機能の説明"
+    ]
+  ],
+  "message.featuresSupport": [
+    [
+      "message",
+      "カスタマーサポートを有効または無効にします。"
+    ],
+    [
+      "description",
+      "Support 機能の説明"
+    ]
+  ],
+  "message.featuresI18n": [
+    [
+      "message",
+      "多言語サポートを有効または無効にします。無効にすると、ユーザーはデフォルト言語のみ使用できます。"
+    ],
+    [
+      "description",
+      "多言語サポートの説明"
+    ]
+  ],
+  "button.upload": [
+    [
+      "message",
+      "アップロード"
+    ],
+    [
+      "description",
+      "アップロード"
+    ]
+  ],
+  "button.enabled": [
+    [
+      "message",
+      "有効"
+    ],
+    [
+      "description",
+      "スイッチのテキスト、すでに有効であることを示します"
+    ]
+  ],
+  "button.disabled": [
+    [
+      "message",
+      "無効"
+    ],
+    [
+      "description",
+      "スイッチのテキスト、すでに無効であることを示します"
+    ]
+  ],
+  "field.featuresGemini": [
+    [
+      "message",
+      "Gemini"
+    ],
+    [
+      "description",
+      "編集ボックスのタイトルとして表示されます"
+    ]
+  ],
+  "message.featuresGemini": [
+    [
+      "message",
+      "Gemini 機能モジュールを有効または無効にします。"
+    ],
+    [
+      "description",
+      "Gemini 機能の説明"
+    ]
+  ],
+  "field.featuresClaude": [
+    [
+      "message",
+      "Claude"
+    ],
+    [
+      "description",
+      "編集ボックスのタイトルとして表示されます"
+    ]
+  ],
+  "message.featuresClaude": [
+    [
+      "message",
+      "Claude 機能モジュールを有効または無効にします。"
+    ],
+    [
+      "description",
+      "Claude 機能の説明"
+    ]
+  ]
 }

--- a/src/i18n/ko/site.json
+++ b/src/i18n/ko/site.json
@@ -1,442 +1,1110 @@
 {
-  "field.title": {
-    "message": "사이트 제목",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "field.origin": {
-    "message": "사이트 도메인",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "field.description": {
-    "message": "사이트 설명",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "field.keywords": {
-    "message": "사이트 키워드",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "field.logo": {
-    "message": "사이트 로고",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "field.favicon": {
-    "message": "사이트 파비콘",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "field.qr": {
-    "message": "QR 코드",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "field.url": {
-    "message": "링크",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "field.admins": {
-    "message": "사이트 관리자 ID",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "field.distributionDefaultInviterId": {
-    "message": "기본 초대자 ID",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "field.distributionForceInviterId": {
-    "message": "강제 초대자 ID",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "field.featuresChat": {
-    "message": "채팅",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "field.featuresVeo": {
-    "message": "Veo",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "field.featuresSora": {
-    "message": "Sora",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "field.featuresGrok": {
-    "message": "Grok",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "field.featuresDeepseek": {
-    "message": "Deepseek",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "field.featuresChatgpt": {
-    "message": "ChatGPT",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "field.featuresMidjourney": {
-    "message": "Midjourney",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "field.featuresChatdoc": {
-    "message": "Chatdoc",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "field.featuresQrart": {
-    "message": "Qrart",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "field.featuresLuma": {
-    "message": "Luma",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "field.featuresPixverse": {
-    "message": "Pixverse",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "field.featuresPika": {
-    "message": "Pika",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "field.featuresKling": {
-    "message": "Kling",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "field.featuresHailuo": {
-    "message": "Hailuo",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "field.featuresHeadshots": {
-    "message": "AI 증명사진",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "field.featuresSuno": {
-    "message": "Suno",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "field.featuresFlux": {
-    "message": "Flux",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "field.featuresNanobanana": {
-    "message": "Nano Banana",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "field.featuresSeedream": {
-    "message": "SeeDream",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "field.featuresSeedance": {
-    "message": "SeeDance",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "field.featuresWan": {
-    "message": "Wan",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "field.featuresProducer": {
-    "message": "Producer",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "field.featuresKimi": {
-    "message": "Kimi",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "field.featuresSerp": {
-    "message": "SERP",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "field.featuresSupport": {
-    "message": "고객 지원",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "field.featuresI18n": {
-    "message": "다국어 지원",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "title.basicConfig": {
-    "message": "기본 설정",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "title.seoConfig": {
-    "message": "SEO 설정",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "title.editAdmins": {
-    "message": "관리자 편집",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "title.featuresConfig": {
-    "message": "기능 설정",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "title.editTitle": {
-    "message": "제목 편집",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "title.editOrigin": {
-    "message": "도메인 편집",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "title.editKeywords": {
-    "message": "키워드 편집",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "title.editLogo": {
-    "message": "로고 편집",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "title.editFavicon": {
-    "message": "파비콘 편집",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "title.editDescription": {
-    "message": "설명 편집",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "title.distributionConfig": {
-    "message": "배포 설정",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "title.editDistributionDefaultInviterId": {
-    "message": "기본 초대자 편집",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "title.editDistributionForceInviterId": {
-    "message": "강제 초대자 편집",
-    "description": "편집 상자에 표시되는 제목"
-  },
-  "title.editQR": {
-    "message": "QR 코드 편집",
-    "description": "편집 창에 표시되는 제목"
-  },
-  "title.editUrl": {
-    "message": "링크 편집",
-    "description": "편집 창에 표시되는 제목"
-  },
-  "placeholder.title": {
-    "message": "사이트 제목을 입력하세요",
-    "description": "편집 창에 표시되는 제목"
-  },
-  "placeholder.origin": {
-    "message": "사이트 도메인을 입력하세요",
-    "description": "편집 창에 표시되는 제목"
-  },
-  "placeholder.editUrl": {
-    "message": "링크를 입력하세요",
-    "description": "편집 창에 표시되는 제목"
-  },
-  "placeholder.description": {
-    "message": "사이트 설명을 입력하세요",
-    "description": "편집 창에 표시되는 제목"
-  },
-  "placeholder.keywords": {
-    "message": "사이트 키워드를 입력하세요",
-    "description": "편집 창에 표시되는 제목"
-  },
-  "placeholder.editDistributionDefaultInviterId": {
-    "message": "기본 초대자 ID를 입력하세요",
-    "description": "편집 창에 표시되는 제목"
-  },
-  "placeholder.editDistributionForceInviterId": {
-    "message": "강제 초대자 ID를 입력하세요",
-    "description": "편집 창에 표시되는 제목"
-  },
-  "message.uploadImageExceed": {
-    "message": "업로드 이미지가 제한을 초과했습니다",
-    "description": "업로드 이미지가 제한을 초과했을 때의 알림"
-  },
-  "message.uploadImageError": {
-    "message": "업로드 이미지 오류",
-    "description": "업로드 이미지 오류에 대한 알림"
-  },
-  "message.editLogoTip": {
-    "message": "권장 크기: 200*60px",
-    "description": "이미지 업로드에 대한 안내"
-  },
-  "message.editQRTip": {
-    "message": "권장 크기: 200*200px",
-    "description": "이미지 업로드에 대한 안내"
-  },
-  "message.editFaviconTip": {
-    "message": "권장 크기: 32*32px",
-    "description": "이미지 업로드에 대한 안내"
-  },
-  "message.editUrl": {
-    "message": "링크를 입력하세요",
-    "description": "링크 입력에 대한 안내"
-  },
-  "message.atLeastOneAdmin": {
-    "message": "최소한 한 명의 관리자를 유지해야 합니다",
-    "description": "최소한 한 명의 관리자를 유지해야 한다는 알림"
-  },
-  "message.distributionDefaultInviterIdTip": {
-    "message": "기본 초대자의 사용자 ID, 분배 링크에 inviter_id 매개변수가 없으면 이 사용자 ID가 초대자로 사용됩니다.",
-    "description": "기본 초대자 ID에 대한 안내"
-  },
-  "message.distributionForceInviterIdTip": {
-    "message": "강제 초대자의 사용자 ID, 이 ID가 설정되면 분배 링크에 inviter_id 매개변수가 있든 없든 이 사용자 ID가 초대자로 사용됩니다.",
-    "description": "강제 초대자 ID에 대한 안내"
-  },
-  "message.originTip": {
-    "message": "사이트 도메인, 사이트 구성은 도메인에 바인딩되며, 사이트 도메인은 변경할 수 없습니다.",
-    "description": "사이트 도메인에 대한 안내"
-  },
-  "message.titleTip": {
-    "message": "사이트 제목, 브라우저 탭에 표시됩니다.",
-    "description": "사이트 제목에 대한 안내"
-  },
-  "message.descriptionTip": {
-    "message": "사이트 설명, 사이트 메타 정보에 위치하며, 사이트 SEO 최적화에 사용됩니다.",
-    "description": "사이트 설명에 대한 안내"
-  },
-  "message.logoTip": {
-    "message": "사이트 로고, 메뉴 바가 펼쳐질 때 사이트 메뉴 상단에 표시됩니다.",
-    "description": "사이트 로고에 대한 안내"
-  },
-  "message.faviconTip": {
-    "message": "사이트 파비콘, 브라우저 탭에 표시됩니다.",
-    "description": "사이트 파비콘에 대한 안내"
-  },
-  "message.adminsTip": {
-    "message": "사이트 관리자 ID, 기본적으로 사이트를 처음 생성한 사용자가 관리자가 되며, 사이트 관리자만 사이트를 관리할 수 있습니다.",
-    "description": "사이트 관리자에 대한 안내"
-  },
-  "message.adminsTip2": {
-    "message": "여기에서 관리자 ID를 추가하거나 삭제할 수 있으며, https://auth.acedata.cloud에서 사용자 ID를 확인할 수 있습니다.",
-    "description": "사이트 관리자에 대한 안내"
-  },
-  "message.keywordsTip": {
-    "message": "사이트 키워드, 사이트 메타 정보에 위치하며, 사이트 SEO 최적화에 사용됩니다.",
-    "description": "사이트 키워드에 대한 안내"
-  },
-  "message.keywordsTip2": {
-    "message": "여기에서 사이트 키워드를 추가하거나 삭제할 수 있으며, 키워드가 정확할수록 SEO 최적화에 유리합니다.",
-    "description": "사이트 키워드에 대한 안내"
-  },
-  "message.featuresChat": {
-    "message": "Chat 기능 모듈을 켜거나 끕니다.",
-    "description": "Chat 기능에 대한 설명"
-  },
-  "message.featuresGrok": {
-    "message": "Grok 기능 모듈을 켜거나 끕니다.",
-    "description": "Grok 기능에 대한 설명"
-  },
-  "message.featuresDeepseek": {
-    "message": "Deepseek 기능 모듈을 켜거나 끕니다.",
-    "description": "Deepseek 기능에 대한 설명"
-  },
-  "message.featuresChatgpt": {
-    "message": "ChatGPT 기능 모듈을 켜거나 끕니다.",
-    "description": "ChatGPT 기능에 대한 설명"
-  },
-  "message.featuresMidjourney": {
-    "message": "Midjourney 기능 모듈을 켜거나 끕니다.",
-    "description": "Midjourney 기능에 대한 설명"
-  },
-  "message.featuresChatdoc": {
-    "message": "Chatdoc 기능 모듈을 켜거나 끕니다.",
-    "description": "Chatdoc 기능에 대한 설명"
-  },
-  "message.featuresQrart": {
-    "message": "Qrart 기능 모듈을 켜거나 끕니다.",
-    "description": "Qrart 기능에 대한 설명"
-  },
-  "message.featuresVeo": {
-    "message": "Veo 기능 모듈을 켜거나 끕니다.",
-    "description": "Veo 기능에 대한 설명"
-  },
-  "message.featuresSora": {
-    "message": "Sora 기능 모듈을 켜거나 끕니다.",
-    "description": "Sora 기능에 대한 설명"
-  },
-  "message.featuresSuno": {
-    "message": "Suno 기능 모듈을 켜거나 끕니다.",
-    "description": "Suno 기능에 대한 설명"
-  },
-  "message.featuresPixverse": {
-    "message": "Pixverse 기능 모듈을 켜거나 끕니다.",
-    "description": "Pixverse 기능의 설명"
-  },
-  "message.featuresFlux": {
-    "message": "FLux 기능 모듈을 켜거나 끕니다.",
-    "description": "FLux 기능의 설명"
-  },
-  "message.featuresNanobanana": {
-    "message": "Nano Banana 기능 모듈을 켜거나 끕니다.",
-    "description": "Nano Banana 기능의 설명"
-  },
-  "message.featuresSeedream": {
-    "message": "SeeDream 기능 모듈을 켜거나 끕니다.",
-    "description": "SeeDream 기능의 설명"
-  },
-  "message.featuresSeedance": {
-    "message": "SeeDance 기능 모듈을 활성화하거나 비활성화합니다.",
-    "description": "SeeDance 기능의 설명"
-  },
-  "message.featuresWan": {
-    "message": "Wan 기능 모듈을 켜거나 끕니다.",
-    "description": "Wan 기능의 설명"
-  },
-  "message.featuresProducer": {
-    "message": "Producer 기능 모듈을 켜거나 끕니다.",
-    "description": "Producer 기능의 설명"
-  },
-  "message.featuresKimi": {
-    "message": "Kimi 기능 모듈을 켜거나 끕니다.",
-    "description": "Kimi 기능의 설명"
-  },
-  "message.featuresSerp": {
-    "message": "SERP 기능 모듈을 켜거나 끕니다.",
-    "description": "SERP 기능의 설명"
-  },
-  "message.featuresLuma": {
-    "message": "Luma 기능 모듈을 켜거나 끕니다.",
-    "description": "Luma 기능의 설명"
-  },
-  "message.featuresPika": {
-    "message": "Pika 기능 모듈을 켜거나 끕니다.",
-    "description": "Pika 기능의 설명"
-  },
-  "message.featuresKling": {
-    "message": "Kling 기능 모듈을 켜거나 끕니다.",
-    "description": "Kling 기능의 설명"
-  },
-  "message.featuresHailuo": {
-    "message": "Hailuo 기능 모듈을 켜거나 끕니다.",
-    "description": "Hailuo 기능의 설명"
-  },
-  "message.featuresHeadshots": {
-    "message": "AI 증명사진 기능 모듈을 켜거나 끕니다.",
-    "description": "AI 증명사진 기능의 설명"
-  },
-  "message.featuresSupport": {
-    "message": "고객 지원을 켜거나 끕니다.",
-    "description": "Support 기능의 설명"
-  },
-  "message.featuresI18n": {
-    "message": "다국어 지원을 켜거나 끕니다. 끄면 사용자는 기본 언어만 사용할 수 있습니다.",
-    "description": "다국어 지원의 설명"
-  },
-  "button.upload": {
-    "message": "업로드",
-    "description": "업로드"
-  },
-  "button.enabled": {
-    "message": "활성화됨",
-    "description": "스위치 텍스트, 활성화된 상태를 나타냄"
-  },
-  "button.disabled": {
-    "message": "비활성화됨",
-    "description": "스위치 텍스트, 비활성화된 상태를 나타냄"
-  },
-  "field.featuresGemini": {
-    "message": "Gemini",
-    "description": "편집 상자에 제목으로 표시됨"
-  },
-  "message.featuresGemini": {
-    "message": "Gemini 기능 모듈을 활성화하거나 비활성화합니다.",
-    "description": "Gemini 기능의 설명"
-  },
-  "field.featuresClaude": {
-    "message": "Claude",
-    "description": "편집 상자에 제목으로 표시됨"
-  },
-  "message.featuresClaude": {
-    "message": "Claude 기능 모듈을 활성화하거나 비활성화합니다.",
-    "description": "Claude 기능의 설명"
-  }
+  "field.title": [
+    [
+      "message",
+      "사이트 제목"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "field.origin": [
+    [
+      "message",
+      "사이트 도메인"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "field.description": [
+    [
+      "message",
+      "사이트 설명"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "field.keywords": [
+    [
+      "message",
+      "사이트 키워드"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "field.logo": [
+    [
+      "message",
+      "사이트 로고"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "field.favicon": [
+    [
+      "message",
+      "사이트 파비콘"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "field.qr": [
+    [
+      "message",
+      "QR 코드"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "field.url": [
+    [
+      "message",
+      "링크"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "field.admins": [
+    [
+      "message",
+      "사이트 관리자 ID"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "field.distributionDefaultInviterId": [
+    [
+      "message",
+      "기본 초대자 ID"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "field.distributionForceInviterId": [
+    [
+      "message",
+      "강제 초대자 ID"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "field.featuresChat": [
+    [
+      "message",
+      "채팅"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "field.featuresVeo": [
+    [
+      "message",
+      "Veo"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "field.featuresSora": [
+    [
+      "message",
+      "Sora"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "field.featuresGrok": [
+    [
+      "message",
+      "Grok"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "field.featuresDeepseek": [
+    [
+      "message",
+      "Deepseek"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "field.featuresChatgpt": [
+    [
+      "message",
+      "ChatGPT"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "field.featuresMidjourney": [
+    [
+      "message",
+      "Midjourney"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "field.featuresChatdoc": [
+    [
+      "message",
+      "Chatdoc"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "field.featuresQrart": [
+    [
+      "message",
+      "Qrart"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "field.featuresLuma": [
+    [
+      "message",
+      "Luma"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "field.featuresPixverse": [
+    [
+      "message",
+      "Pixverse"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "field.featuresPika": [
+    [
+      "message",
+      "Pika"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "field.featuresKling": [
+    [
+      "message",
+      "Kling"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "field.featuresHailuo": [
+    [
+      "message",
+      "Hailuo"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "field.featuresHeadshots": [
+    [
+      "message",
+      "AI 증명사진"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "field.featuresSuno": [
+    [
+      "message",
+      "Suno"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "field.featuresFlux": [
+    [
+      "message",
+      "Flux"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "field.featuresNanobanana": [
+    [
+      "message",
+      "Nano Banana"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "field.featuresOpenaiimage": {
+    "message": "OpenAI Image",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresSeedream": [
+    [
+      "message",
+      "SeeDream"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "field.featuresSeedance": [
+    [
+      "message",
+      "SeeDance"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "field.featuresWan": [
+    [
+      "message",
+      "Wan"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "field.featuresProducer": [
+    [
+      "message",
+      "Producer"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "field.featuresKimi": [
+    [
+      "message",
+      "Kimi"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "field.featuresSerp": [
+    [
+      "message",
+      "SERP"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "field.featuresSupport": [
+    [
+      "message",
+      "고객 지원"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "field.featuresI18n": [
+    [
+      "message",
+      "다국어 지원"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "title.basicConfig": [
+    [
+      "message",
+      "기본 설정"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "title.seoConfig": [
+    [
+      "message",
+      "SEO 설정"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "title.editAdmins": [
+    [
+      "message",
+      "관리자 편집"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "title.featuresConfig": [
+    [
+      "message",
+      "기능 설정"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "title.editTitle": [
+    [
+      "message",
+      "제목 편집"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "title.editOrigin": [
+    [
+      "message",
+      "도메인 편집"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "title.editKeywords": [
+    [
+      "message",
+      "키워드 편집"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "title.editLogo": [
+    [
+      "message",
+      "로고 편집"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "title.editFavicon": [
+    [
+      "message",
+      "파비콘 편집"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "title.editDescription": [
+    [
+      "message",
+      "설명 편집"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "title.distributionConfig": [
+    [
+      "message",
+      "배포 설정"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "title.editDistributionDefaultInviterId": [
+    [
+      "message",
+      "기본 초대자 편집"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "title.editDistributionForceInviterId": [
+    [
+      "message",
+      "강제 초대자 편집"
+    ],
+    [
+      "description",
+      "편집 상자에 표시되는 제목"
+    ]
+  ],
+  "title.editQR": [
+    [
+      "message",
+      "QR 코드 편집"
+    ],
+    [
+      "description",
+      "편집 창에 표시되는 제목"
+    ]
+  ],
+  "title.editUrl": [
+    [
+      "message",
+      "링크 편집"
+    ],
+    [
+      "description",
+      "편집 창에 표시되는 제목"
+    ]
+  ],
+  "placeholder.title": [
+    [
+      "message",
+      "사이트 제목을 입력하세요"
+    ],
+    [
+      "description",
+      "편집 창에 표시되는 제목"
+    ]
+  ],
+  "placeholder.origin": [
+    [
+      "message",
+      "사이트 도메인을 입력하세요"
+    ],
+    [
+      "description",
+      "편집 창에 표시되는 제목"
+    ]
+  ],
+  "placeholder.editUrl": [
+    [
+      "message",
+      "링크를 입력하세요"
+    ],
+    [
+      "description",
+      "편집 창에 표시되는 제목"
+    ]
+  ],
+  "placeholder.description": [
+    [
+      "message",
+      "사이트 설명을 입력하세요"
+    ],
+    [
+      "description",
+      "편집 창에 표시되는 제목"
+    ]
+  ],
+  "placeholder.keywords": [
+    [
+      "message",
+      "사이트 키워드를 입력하세요"
+    ],
+    [
+      "description",
+      "편집 창에 표시되는 제목"
+    ]
+  ],
+  "placeholder.editDistributionDefaultInviterId": [
+    [
+      "message",
+      "기본 초대자 ID를 입력하세요"
+    ],
+    [
+      "description",
+      "편집 창에 표시되는 제목"
+    ]
+  ],
+  "placeholder.editDistributionForceInviterId": [
+    [
+      "message",
+      "강제 초대자 ID를 입력하세요"
+    ],
+    [
+      "description",
+      "편집 창에 표시되는 제목"
+    ]
+  ],
+  "message.uploadImageExceed": [
+    [
+      "message",
+      "업로드 이미지가 제한을 초과했습니다"
+    ],
+    [
+      "description",
+      "업로드 이미지가 제한을 초과했을 때의 알림"
+    ]
+  ],
+  "message.uploadImageError": [
+    [
+      "message",
+      "업로드 이미지 오류"
+    ],
+    [
+      "description",
+      "업로드 이미지 오류에 대한 알림"
+    ]
+  ],
+  "message.editLogoTip": [
+    [
+      "message",
+      "권장 크기: 200*60px"
+    ],
+    [
+      "description",
+      "이미지 업로드에 대한 안내"
+    ]
+  ],
+  "message.editQRTip": [
+    [
+      "message",
+      "권장 크기: 200*200px"
+    ],
+    [
+      "description",
+      "이미지 업로드에 대한 안내"
+    ]
+  ],
+  "message.editFaviconTip": [
+    [
+      "message",
+      "권장 크기: 32*32px"
+    ],
+    [
+      "description",
+      "이미지 업로드에 대한 안내"
+    ]
+  ],
+  "message.editUrl": [
+    [
+      "message",
+      "링크를 입력하세요"
+    ],
+    [
+      "description",
+      "링크 입력에 대한 안내"
+    ]
+  ],
+  "message.atLeastOneAdmin": [
+    [
+      "message",
+      "최소한 한 명의 관리자를 유지해야 합니다"
+    ],
+    [
+      "description",
+      "최소한 한 명의 관리자를 유지해야 한다는 알림"
+    ]
+  ],
+  "message.distributionDefaultInviterIdTip": [
+    [
+      "message",
+      "기본 초대자의 사용자 ID, 분배 링크에 inviter_id 매개변수가 없으면 이 사용자 ID가 초대자로 사용됩니다."
+    ],
+    [
+      "description",
+      "기본 초대자 ID에 대한 안내"
+    ]
+  ],
+  "message.distributionForceInviterIdTip": [
+    [
+      "message",
+      "강제 초대자의 사용자 ID, 이 ID가 설정되면 분배 링크에 inviter_id 매개변수가 있든 없든 이 사용자 ID가 초대자로 사용됩니다."
+    ],
+    [
+      "description",
+      "강제 초대자 ID에 대한 안내"
+    ]
+  ],
+  "message.originTip": [
+    [
+      "message",
+      "사이트 도메인, 사이트 구성은 도메인에 바인딩되며, 사이트 도메인은 변경할 수 없습니다."
+    ],
+    [
+      "description",
+      "사이트 도메인에 대한 안내"
+    ]
+  ],
+  "message.titleTip": [
+    [
+      "message",
+      "사이트 제목, 브라우저 탭에 표시됩니다."
+    ],
+    [
+      "description",
+      "사이트 제목에 대한 안내"
+    ]
+  ],
+  "message.descriptionTip": [
+    [
+      "message",
+      "사이트 설명, 사이트 메타 정보에 위치하며, 사이트 SEO 최적화에 사용됩니다."
+    ],
+    [
+      "description",
+      "사이트 설명에 대한 안내"
+    ]
+  ],
+  "message.logoTip": [
+    [
+      "message",
+      "사이트 로고, 메뉴 바가 펼쳐질 때 사이트 메뉴 상단에 표시됩니다."
+    ],
+    [
+      "description",
+      "사이트 로고에 대한 안내"
+    ]
+  ],
+  "message.faviconTip": [
+    [
+      "message",
+      "사이트 파비콘, 브라우저 탭에 표시됩니다."
+    ],
+    [
+      "description",
+      "사이트 파비콘에 대한 안내"
+    ]
+  ],
+  "message.adminsTip": [
+    [
+      "message",
+      "사이트 관리자 ID, 기본적으로 사이트를 처음 생성한 사용자가 관리자가 되며, 사이트 관리자만 사이트를 관리할 수 있습니다."
+    ],
+    [
+      "description",
+      "사이트 관리자에 대한 안내"
+    ]
+  ],
+  "message.adminsTip2": [
+    [
+      "message",
+      "여기에서 관리자 ID를 추가하거나 삭제할 수 있으며, https://auth.acedata.cloud에서 사용자 ID를 확인할 수 있습니다."
+    ],
+    [
+      "description",
+      "사이트 관리자에 대한 안내"
+    ]
+  ],
+  "message.keywordsTip": [
+    [
+      "message",
+      "사이트 키워드, 사이트 메타 정보에 위치하며, 사이트 SEO 최적화에 사용됩니다."
+    ],
+    [
+      "description",
+      "사이트 키워드에 대한 안내"
+    ]
+  ],
+  "message.keywordsTip2": [
+    [
+      "message",
+      "여기에서 사이트 키워드를 추가하거나 삭제할 수 있으며, 키워드가 정확할수록 SEO 최적화에 유리합니다."
+    ],
+    [
+      "description",
+      "사이트 키워드에 대한 안내"
+    ]
+  ],
+  "message.featuresChat": [
+    [
+      "message",
+      "Chat 기능 모듈을 켜거나 끕니다."
+    ],
+    [
+      "description",
+      "Chat 기능에 대한 설명"
+    ]
+  ],
+  "message.featuresGrok": [
+    [
+      "message",
+      "Grok 기능 모듈을 켜거나 끕니다."
+    ],
+    [
+      "description",
+      "Grok 기능에 대한 설명"
+    ]
+  ],
+  "message.featuresDeepseek": [
+    [
+      "message",
+      "Deepseek 기능 모듈을 켜거나 끕니다."
+    ],
+    [
+      "description",
+      "Deepseek 기능에 대한 설명"
+    ]
+  ],
+  "message.featuresChatgpt": [
+    [
+      "message",
+      "ChatGPT 기능 모듈을 켜거나 끕니다."
+    ],
+    [
+      "description",
+      "ChatGPT 기능에 대한 설명"
+    ]
+  ],
+  "message.featuresMidjourney": [
+    [
+      "message",
+      "Midjourney 기능 모듈을 켜거나 끕니다."
+    ],
+    [
+      "description",
+      "Midjourney 기능에 대한 설명"
+    ]
+  ],
+  "message.featuresChatdoc": [
+    [
+      "message",
+      "Chatdoc 기능 모듈을 켜거나 끕니다."
+    ],
+    [
+      "description",
+      "Chatdoc 기능에 대한 설명"
+    ]
+  ],
+  "message.featuresQrart": [
+    [
+      "message",
+      "Qrart 기능 모듈을 켜거나 끕니다."
+    ],
+    [
+      "description",
+      "Qrart 기능에 대한 설명"
+    ]
+  ],
+  "message.featuresVeo": [
+    [
+      "message",
+      "Veo 기능 모듈을 켜거나 끕니다."
+    ],
+    [
+      "description",
+      "Veo 기능에 대한 설명"
+    ]
+  ],
+  "message.featuresSora": [
+    [
+      "message",
+      "Sora 기능 모듈을 켜거나 끕니다."
+    ],
+    [
+      "description",
+      "Sora 기능에 대한 설명"
+    ]
+  ],
+  "message.featuresSuno": [
+    [
+      "message",
+      "Suno 기능 모듈을 켜거나 끕니다."
+    ],
+    [
+      "description",
+      "Suno 기능에 대한 설명"
+    ]
+  ],
+  "message.featuresPixverse": [
+    [
+      "message",
+      "Pixverse 기능 모듈을 켜거나 끕니다."
+    ],
+    [
+      "description",
+      "Pixverse 기능의 설명"
+    ]
+  ],
+  "message.featuresFlux": [
+    [
+      "message",
+      "FLux 기능 모듈을 켜거나 끕니다."
+    ],
+    [
+      "description",
+      "FLux 기능의 설명"
+    ]
+  ],
+  "message.featuresNanobanana": [
+    [
+      "message",
+      "Nano Banana 기능 모듈을 켜거나 끕니다."
+    ],
+    [
+      "description",
+      "Nano Banana 기능의 설명"
+    ]
+  ],
+  "message.featuresOpenaiimage": {
+    "message": "Toggle OpenAI Image feature module.",
+    "description": "Description of the OpenAI Image feature"
+  },
+  "message.featuresSeedream": [
+    [
+      "message",
+      "SeeDream 기능 모듈을 켜거나 끕니다."
+    ],
+    [
+      "description",
+      "SeeDream 기능의 설명"
+    ]
+  ],
+  "message.featuresSeedance": [
+    [
+      "message",
+      "SeeDance 기능 모듈을 활성화하거나 비활성화합니다."
+    ],
+    [
+      "description",
+      "SeeDance 기능의 설명"
+    ]
+  ],
+  "message.featuresWan": [
+    [
+      "message",
+      "Wan 기능 모듈을 켜거나 끕니다."
+    ],
+    [
+      "description",
+      "Wan 기능의 설명"
+    ]
+  ],
+  "message.featuresProducer": [
+    [
+      "message",
+      "Producer 기능 모듈을 켜거나 끕니다."
+    ],
+    [
+      "description",
+      "Producer 기능의 설명"
+    ]
+  ],
+  "message.featuresKimi": [
+    [
+      "message",
+      "Kimi 기능 모듈을 켜거나 끕니다."
+    ],
+    [
+      "description",
+      "Kimi 기능의 설명"
+    ]
+  ],
+  "message.featuresSerp": [
+    [
+      "message",
+      "SERP 기능 모듈을 켜거나 끕니다."
+    ],
+    [
+      "description",
+      "SERP 기능의 설명"
+    ]
+  ],
+  "message.featuresLuma": [
+    [
+      "message",
+      "Luma 기능 모듈을 켜거나 끕니다."
+    ],
+    [
+      "description",
+      "Luma 기능의 설명"
+    ]
+  ],
+  "message.featuresPika": [
+    [
+      "message",
+      "Pika 기능 모듈을 켜거나 끕니다."
+    ],
+    [
+      "description",
+      "Pika 기능의 설명"
+    ]
+  ],
+  "message.featuresKling": [
+    [
+      "message",
+      "Kling 기능 모듈을 켜거나 끕니다."
+    ],
+    [
+      "description",
+      "Kling 기능의 설명"
+    ]
+  ],
+  "message.featuresHailuo": [
+    [
+      "message",
+      "Hailuo 기능 모듈을 켜거나 끕니다."
+    ],
+    [
+      "description",
+      "Hailuo 기능의 설명"
+    ]
+  ],
+  "message.featuresHeadshots": [
+    [
+      "message",
+      "AI 증명사진 기능 모듈을 켜거나 끕니다."
+    ],
+    [
+      "description",
+      "AI 증명사진 기능의 설명"
+    ]
+  ],
+  "message.featuresSupport": [
+    [
+      "message",
+      "고객 지원을 켜거나 끕니다."
+    ],
+    [
+      "description",
+      "Support 기능의 설명"
+    ]
+  ],
+  "message.featuresI18n": [
+    [
+      "message",
+      "다국어 지원을 켜거나 끕니다. 끄면 사용자는 기본 언어만 사용할 수 있습니다."
+    ],
+    [
+      "description",
+      "다국어 지원의 설명"
+    ]
+  ],
+  "button.upload": [
+    [
+      "message",
+      "업로드"
+    ],
+    [
+      "description",
+      "업로드"
+    ]
+  ],
+  "button.enabled": [
+    [
+      "message",
+      "활성화됨"
+    ],
+    [
+      "description",
+      "스위치 텍스트, 활성화된 상태를 나타냄"
+    ]
+  ],
+  "button.disabled": [
+    [
+      "message",
+      "비활성화됨"
+    ],
+    [
+      "description",
+      "스위치 텍스트, 비활성화된 상태를 나타냄"
+    ]
+  ],
+  "field.featuresGemini": [
+    [
+      "message",
+      "Gemini"
+    ],
+    [
+      "description",
+      "편집 상자에 제목으로 표시됨"
+    ]
+  ],
+  "message.featuresGemini": [
+    [
+      "message",
+      "Gemini 기능 모듈을 활성화하거나 비활성화합니다."
+    ],
+    [
+      "description",
+      "Gemini 기능의 설명"
+    ]
+  ],
+  "field.featuresClaude": [
+    [
+      "message",
+      "Claude"
+    ],
+    [
+      "description",
+      "편집 상자에 제목으로 표시됨"
+    ]
+  ],
+  "message.featuresClaude": [
+    [
+      "message",
+      "Claude 기능 모듈을 활성화하거나 비활성화합니다."
+    ],
+    [
+      "description",
+      "Claude 기능의 설명"
+    ]
+  ]
 }

--- a/src/i18n/ko/site.json
+++ b/src/i18n/ko/site.json
@@ -1,1110 +1,450 @@
 {
-  "field.title": [
-    [
-      "message",
-      "사이트 제목"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "field.origin": [
-    [
-      "message",
-      "사이트 도메인"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "field.description": [
-    [
-      "message",
-      "사이트 설명"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "field.keywords": [
-    [
-      "message",
-      "사이트 키워드"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "field.logo": [
-    [
-      "message",
-      "사이트 로고"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "field.favicon": [
-    [
-      "message",
-      "사이트 파비콘"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "field.qr": [
-    [
-      "message",
-      "QR 코드"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "field.url": [
-    [
-      "message",
-      "링크"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "field.admins": [
-    [
-      "message",
-      "사이트 관리자 ID"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "field.distributionDefaultInviterId": [
-    [
-      "message",
-      "기본 초대자 ID"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "field.distributionForceInviterId": [
-    [
-      "message",
-      "강제 초대자 ID"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "field.featuresChat": [
-    [
-      "message",
-      "채팅"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "field.featuresVeo": [
-    [
-      "message",
-      "Veo"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "field.featuresSora": [
-    [
-      "message",
-      "Sora"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "field.featuresGrok": [
-    [
-      "message",
-      "Grok"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "field.featuresDeepseek": [
-    [
-      "message",
-      "Deepseek"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "field.featuresChatgpt": [
-    [
-      "message",
-      "ChatGPT"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "field.featuresMidjourney": [
-    [
-      "message",
-      "Midjourney"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "field.featuresChatdoc": [
-    [
-      "message",
-      "Chatdoc"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "field.featuresQrart": [
-    [
-      "message",
-      "Qrart"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "field.featuresLuma": [
-    [
-      "message",
-      "Luma"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "field.featuresPixverse": [
-    [
-      "message",
-      "Pixverse"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "field.featuresPika": [
-    [
-      "message",
-      "Pika"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "field.featuresKling": [
-    [
-      "message",
-      "Kling"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "field.featuresHailuo": [
-    [
-      "message",
-      "Hailuo"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "field.featuresHeadshots": [
-    [
-      "message",
-      "AI 증명사진"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "field.featuresSuno": [
-    [
-      "message",
-      "Suno"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "field.featuresFlux": [
-    [
-      "message",
-      "Flux"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "field.featuresNanobanana": [
-    [
-      "message",
-      "Nano Banana"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
+  "field.title": {
+    "message": "사이트 제목",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "field.origin": {
+    "message": "사이트 도메인",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "field.description": {
+    "message": "사이트 설명",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "field.keywords": {
+    "message": "사이트 키워드",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "field.logo": {
+    "message": "사이트 로고",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "field.favicon": {
+    "message": "사이트 파비콘",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "field.qr": {
+    "message": "QR 코드",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "field.url": {
+    "message": "링크",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "field.admins": {
+    "message": "사이트 관리자 ID",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "field.distributionDefaultInviterId": {
+    "message": "기본 초대자 ID",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "field.distributionForceInviterId": {
+    "message": "강제 초대자 ID",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "field.featuresChat": {
+    "message": "채팅",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "field.featuresVeo": {
+    "message": "Veo",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "field.featuresSora": {
+    "message": "Sora",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "field.featuresGrok": {
+    "message": "Grok",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "field.featuresDeepseek": {
+    "message": "Deepseek",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "field.featuresChatgpt": {
+    "message": "ChatGPT",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "field.featuresMidjourney": {
+    "message": "Midjourney",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "field.featuresChatdoc": {
+    "message": "Chatdoc",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "field.featuresQrart": {
+    "message": "Qrart",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "field.featuresLuma": {
+    "message": "Luma",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "field.featuresPixverse": {
+    "message": "Pixverse",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "field.featuresPika": {
+    "message": "Pika",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "field.featuresKling": {
+    "message": "Kling",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "field.featuresHailuo": {
+    "message": "Hailuo",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "field.featuresHeadshots": {
+    "message": "AI 증명사진",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "field.featuresSuno": {
+    "message": "Suno",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "field.featuresFlux": {
+    "message": "Flux",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "field.featuresNanobanana": {
+    "message": "Nano Banana",
+    "description": "편집 상자에 표시되는 제목"
+  },
   "field.featuresOpenaiimage": {
     "message": "OpenAI Image",
     "description": "Displayed as the title in the editing box"
   },
-  "field.featuresSeedream": [
-    [
-      "message",
-      "SeeDream"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "field.featuresSeedance": [
-    [
-      "message",
-      "SeeDance"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "field.featuresWan": [
-    [
-      "message",
-      "Wan"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "field.featuresProducer": [
-    [
-      "message",
-      "Producer"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "field.featuresKimi": [
-    [
-      "message",
-      "Kimi"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "field.featuresSerp": [
-    [
-      "message",
-      "SERP"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "field.featuresSupport": [
-    [
-      "message",
-      "고객 지원"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "field.featuresI18n": [
-    [
-      "message",
-      "다국어 지원"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "title.basicConfig": [
-    [
-      "message",
-      "기본 설정"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "title.seoConfig": [
-    [
-      "message",
-      "SEO 설정"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "title.editAdmins": [
-    [
-      "message",
-      "관리자 편집"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "title.featuresConfig": [
-    [
-      "message",
-      "기능 설정"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "title.editTitle": [
-    [
-      "message",
-      "제목 편집"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "title.editOrigin": [
-    [
-      "message",
-      "도메인 편집"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "title.editKeywords": [
-    [
-      "message",
-      "키워드 편집"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "title.editLogo": [
-    [
-      "message",
-      "로고 편집"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "title.editFavicon": [
-    [
-      "message",
-      "파비콘 편집"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "title.editDescription": [
-    [
-      "message",
-      "설명 편집"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "title.distributionConfig": [
-    [
-      "message",
-      "배포 설정"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "title.editDistributionDefaultInviterId": [
-    [
-      "message",
-      "기본 초대자 편집"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "title.editDistributionForceInviterId": [
-    [
-      "message",
-      "강제 초대자 편집"
-    ],
-    [
-      "description",
-      "편집 상자에 표시되는 제목"
-    ]
-  ],
-  "title.editQR": [
-    [
-      "message",
-      "QR 코드 편집"
-    ],
-    [
-      "description",
-      "편집 창에 표시되는 제목"
-    ]
-  ],
-  "title.editUrl": [
-    [
-      "message",
-      "링크 편집"
-    ],
-    [
-      "description",
-      "편집 창에 표시되는 제목"
-    ]
-  ],
-  "placeholder.title": [
-    [
-      "message",
-      "사이트 제목을 입력하세요"
-    ],
-    [
-      "description",
-      "편집 창에 표시되는 제목"
-    ]
-  ],
-  "placeholder.origin": [
-    [
-      "message",
-      "사이트 도메인을 입력하세요"
-    ],
-    [
-      "description",
-      "편집 창에 표시되는 제목"
-    ]
-  ],
-  "placeholder.editUrl": [
-    [
-      "message",
-      "링크를 입력하세요"
-    ],
-    [
-      "description",
-      "편집 창에 표시되는 제목"
-    ]
-  ],
-  "placeholder.description": [
-    [
-      "message",
-      "사이트 설명을 입력하세요"
-    ],
-    [
-      "description",
-      "편집 창에 표시되는 제목"
-    ]
-  ],
-  "placeholder.keywords": [
-    [
-      "message",
-      "사이트 키워드를 입력하세요"
-    ],
-    [
-      "description",
-      "편집 창에 표시되는 제목"
-    ]
-  ],
-  "placeholder.editDistributionDefaultInviterId": [
-    [
-      "message",
-      "기본 초대자 ID를 입력하세요"
-    ],
-    [
-      "description",
-      "편집 창에 표시되는 제목"
-    ]
-  ],
-  "placeholder.editDistributionForceInviterId": [
-    [
-      "message",
-      "강제 초대자 ID를 입력하세요"
-    ],
-    [
-      "description",
-      "편집 창에 표시되는 제목"
-    ]
-  ],
-  "message.uploadImageExceed": [
-    [
-      "message",
-      "업로드 이미지가 제한을 초과했습니다"
-    ],
-    [
-      "description",
-      "업로드 이미지가 제한을 초과했을 때의 알림"
-    ]
-  ],
-  "message.uploadImageError": [
-    [
-      "message",
-      "업로드 이미지 오류"
-    ],
-    [
-      "description",
-      "업로드 이미지 오류에 대한 알림"
-    ]
-  ],
-  "message.editLogoTip": [
-    [
-      "message",
-      "권장 크기: 200*60px"
-    ],
-    [
-      "description",
-      "이미지 업로드에 대한 안내"
-    ]
-  ],
-  "message.editQRTip": [
-    [
-      "message",
-      "권장 크기: 200*200px"
-    ],
-    [
-      "description",
-      "이미지 업로드에 대한 안내"
-    ]
-  ],
-  "message.editFaviconTip": [
-    [
-      "message",
-      "권장 크기: 32*32px"
-    ],
-    [
-      "description",
-      "이미지 업로드에 대한 안내"
-    ]
-  ],
-  "message.editUrl": [
-    [
-      "message",
-      "링크를 입력하세요"
-    ],
-    [
-      "description",
-      "링크 입력에 대한 안내"
-    ]
-  ],
-  "message.atLeastOneAdmin": [
-    [
-      "message",
-      "최소한 한 명의 관리자를 유지해야 합니다"
-    ],
-    [
-      "description",
-      "최소한 한 명의 관리자를 유지해야 한다는 알림"
-    ]
-  ],
-  "message.distributionDefaultInviterIdTip": [
-    [
-      "message",
-      "기본 초대자의 사용자 ID, 분배 링크에 inviter_id 매개변수가 없으면 이 사용자 ID가 초대자로 사용됩니다."
-    ],
-    [
-      "description",
-      "기본 초대자 ID에 대한 안내"
-    ]
-  ],
-  "message.distributionForceInviterIdTip": [
-    [
-      "message",
-      "강제 초대자의 사용자 ID, 이 ID가 설정되면 분배 링크에 inviter_id 매개변수가 있든 없든 이 사용자 ID가 초대자로 사용됩니다."
-    ],
-    [
-      "description",
-      "강제 초대자 ID에 대한 안내"
-    ]
-  ],
-  "message.originTip": [
-    [
-      "message",
-      "사이트 도메인, 사이트 구성은 도메인에 바인딩되며, 사이트 도메인은 변경할 수 없습니다."
-    ],
-    [
-      "description",
-      "사이트 도메인에 대한 안내"
-    ]
-  ],
-  "message.titleTip": [
-    [
-      "message",
-      "사이트 제목, 브라우저 탭에 표시됩니다."
-    ],
-    [
-      "description",
-      "사이트 제목에 대한 안내"
-    ]
-  ],
-  "message.descriptionTip": [
-    [
-      "message",
-      "사이트 설명, 사이트 메타 정보에 위치하며, 사이트 SEO 최적화에 사용됩니다."
-    ],
-    [
-      "description",
-      "사이트 설명에 대한 안내"
-    ]
-  ],
-  "message.logoTip": [
-    [
-      "message",
-      "사이트 로고, 메뉴 바가 펼쳐질 때 사이트 메뉴 상단에 표시됩니다."
-    ],
-    [
-      "description",
-      "사이트 로고에 대한 안내"
-    ]
-  ],
-  "message.faviconTip": [
-    [
-      "message",
-      "사이트 파비콘, 브라우저 탭에 표시됩니다."
-    ],
-    [
-      "description",
-      "사이트 파비콘에 대한 안내"
-    ]
-  ],
-  "message.adminsTip": [
-    [
-      "message",
-      "사이트 관리자 ID, 기본적으로 사이트를 처음 생성한 사용자가 관리자가 되며, 사이트 관리자만 사이트를 관리할 수 있습니다."
-    ],
-    [
-      "description",
-      "사이트 관리자에 대한 안내"
-    ]
-  ],
-  "message.adminsTip2": [
-    [
-      "message",
-      "여기에서 관리자 ID를 추가하거나 삭제할 수 있으며, https://auth.acedata.cloud에서 사용자 ID를 확인할 수 있습니다."
-    ],
-    [
-      "description",
-      "사이트 관리자에 대한 안내"
-    ]
-  ],
-  "message.keywordsTip": [
-    [
-      "message",
-      "사이트 키워드, 사이트 메타 정보에 위치하며, 사이트 SEO 최적화에 사용됩니다."
-    ],
-    [
-      "description",
-      "사이트 키워드에 대한 안내"
-    ]
-  ],
-  "message.keywordsTip2": [
-    [
-      "message",
-      "여기에서 사이트 키워드를 추가하거나 삭제할 수 있으며, 키워드가 정확할수록 SEO 최적화에 유리합니다."
-    ],
-    [
-      "description",
-      "사이트 키워드에 대한 안내"
-    ]
-  ],
-  "message.featuresChat": [
-    [
-      "message",
-      "Chat 기능 모듈을 켜거나 끕니다."
-    ],
-    [
-      "description",
-      "Chat 기능에 대한 설명"
-    ]
-  ],
-  "message.featuresGrok": [
-    [
-      "message",
-      "Grok 기능 모듈을 켜거나 끕니다."
-    ],
-    [
-      "description",
-      "Grok 기능에 대한 설명"
-    ]
-  ],
-  "message.featuresDeepseek": [
-    [
-      "message",
-      "Deepseek 기능 모듈을 켜거나 끕니다."
-    ],
-    [
-      "description",
-      "Deepseek 기능에 대한 설명"
-    ]
-  ],
-  "message.featuresChatgpt": [
-    [
-      "message",
-      "ChatGPT 기능 모듈을 켜거나 끕니다."
-    ],
-    [
-      "description",
-      "ChatGPT 기능에 대한 설명"
-    ]
-  ],
-  "message.featuresMidjourney": [
-    [
-      "message",
-      "Midjourney 기능 모듈을 켜거나 끕니다."
-    ],
-    [
-      "description",
-      "Midjourney 기능에 대한 설명"
-    ]
-  ],
-  "message.featuresChatdoc": [
-    [
-      "message",
-      "Chatdoc 기능 모듈을 켜거나 끕니다."
-    ],
-    [
-      "description",
-      "Chatdoc 기능에 대한 설명"
-    ]
-  ],
-  "message.featuresQrart": [
-    [
-      "message",
-      "Qrart 기능 모듈을 켜거나 끕니다."
-    ],
-    [
-      "description",
-      "Qrart 기능에 대한 설명"
-    ]
-  ],
-  "message.featuresVeo": [
-    [
-      "message",
-      "Veo 기능 모듈을 켜거나 끕니다."
-    ],
-    [
-      "description",
-      "Veo 기능에 대한 설명"
-    ]
-  ],
-  "message.featuresSora": [
-    [
-      "message",
-      "Sora 기능 모듈을 켜거나 끕니다."
-    ],
-    [
-      "description",
-      "Sora 기능에 대한 설명"
-    ]
-  ],
-  "message.featuresSuno": [
-    [
-      "message",
-      "Suno 기능 모듈을 켜거나 끕니다."
-    ],
-    [
-      "description",
-      "Suno 기능에 대한 설명"
-    ]
-  ],
-  "message.featuresPixverse": [
-    [
-      "message",
-      "Pixverse 기능 모듈을 켜거나 끕니다."
-    ],
-    [
-      "description",
-      "Pixverse 기능의 설명"
-    ]
-  ],
-  "message.featuresFlux": [
-    [
-      "message",
-      "FLux 기능 모듈을 켜거나 끕니다."
-    ],
-    [
-      "description",
-      "FLux 기능의 설명"
-    ]
-  ],
-  "message.featuresNanobanana": [
-    [
-      "message",
-      "Nano Banana 기능 모듈을 켜거나 끕니다."
-    ],
-    [
-      "description",
-      "Nano Banana 기능의 설명"
-    ]
-  ],
+  "field.featuresSeedream": {
+    "message": "SeeDream",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "field.featuresSeedance": {
+    "message": "SeeDance",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "field.featuresWan": {
+    "message": "Wan",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "field.featuresProducer": {
+    "message": "Producer",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "field.featuresKimi": {
+    "message": "Kimi",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "field.featuresSerp": {
+    "message": "SERP",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "field.featuresSupport": {
+    "message": "고객 지원",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "field.featuresI18n": {
+    "message": "다국어 지원",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "title.basicConfig": {
+    "message": "기본 설정",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "title.seoConfig": {
+    "message": "SEO 설정",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "title.editAdmins": {
+    "message": "관리자 편집",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "title.featuresConfig": {
+    "message": "기능 설정",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "title.editTitle": {
+    "message": "제목 편집",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "title.editOrigin": {
+    "message": "도메인 편집",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "title.editKeywords": {
+    "message": "키워드 편집",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "title.editLogo": {
+    "message": "로고 편집",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "title.editFavicon": {
+    "message": "파비콘 편집",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "title.editDescription": {
+    "message": "설명 편집",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "title.distributionConfig": {
+    "message": "배포 설정",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "title.editDistributionDefaultInviterId": {
+    "message": "기본 초대자 편집",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "title.editDistributionForceInviterId": {
+    "message": "강제 초대자 편집",
+    "description": "편집 상자에 표시되는 제목"
+  },
+  "title.editQR": {
+    "message": "QR 코드 편집",
+    "description": "편집 창에 표시되는 제목"
+  },
+  "title.editUrl": {
+    "message": "링크 편집",
+    "description": "편집 창에 표시되는 제목"
+  },
+  "placeholder.title": {
+    "message": "사이트 제목을 입력하세요",
+    "description": "편집 창에 표시되는 제목"
+  },
+  "placeholder.origin": {
+    "message": "사이트 도메인을 입력하세요",
+    "description": "편집 창에 표시되는 제목"
+  },
+  "placeholder.editUrl": {
+    "message": "링크를 입력하세요",
+    "description": "편집 창에 표시되는 제목"
+  },
+  "placeholder.description": {
+    "message": "사이트 설명을 입력하세요",
+    "description": "편집 창에 표시되는 제목"
+  },
+  "placeholder.keywords": {
+    "message": "사이트 키워드를 입력하세요",
+    "description": "편집 창에 표시되는 제목"
+  },
+  "placeholder.editDistributionDefaultInviterId": {
+    "message": "기본 초대자 ID를 입력하세요",
+    "description": "편집 창에 표시되는 제목"
+  },
+  "placeholder.editDistributionForceInviterId": {
+    "message": "강제 초대자 ID를 입력하세요",
+    "description": "편집 창에 표시되는 제목"
+  },
+  "message.uploadImageExceed": {
+    "message": "업로드 이미지가 제한을 초과했습니다",
+    "description": "업로드 이미지가 제한을 초과했을 때의 알림"
+  },
+  "message.uploadImageError": {
+    "message": "업로드 이미지 오류",
+    "description": "업로드 이미지 오류에 대한 알림"
+  },
+  "message.editLogoTip": {
+    "message": "권장 크기: 200*60px",
+    "description": "이미지 업로드에 대한 안내"
+  },
+  "message.editQRTip": {
+    "message": "권장 크기: 200*200px",
+    "description": "이미지 업로드에 대한 안내"
+  },
+  "message.editFaviconTip": {
+    "message": "권장 크기: 32*32px",
+    "description": "이미지 업로드에 대한 안내"
+  },
+  "message.editUrl": {
+    "message": "링크를 입력하세요",
+    "description": "링크 입력에 대한 안내"
+  },
+  "message.atLeastOneAdmin": {
+    "message": "최소한 한 명의 관리자를 유지해야 합니다",
+    "description": "최소한 한 명의 관리자를 유지해야 한다는 알림"
+  },
+  "message.distributionDefaultInviterIdTip": {
+    "message": "기본 초대자의 사용자 ID, 분배 링크에 inviter_id 매개변수가 없으면 이 사용자 ID가 초대자로 사용됩니다.",
+    "description": "기본 초대자 ID에 대한 안내"
+  },
+  "message.distributionForceInviterIdTip": {
+    "message": "강제 초대자의 사용자 ID, 이 ID가 설정되면 분배 링크에 inviter_id 매개변수가 있든 없든 이 사용자 ID가 초대자로 사용됩니다.",
+    "description": "강제 초대자 ID에 대한 안내"
+  },
+  "message.originTip": {
+    "message": "사이트 도메인, 사이트 구성은 도메인에 바인딩되며, 사이트 도메인은 변경할 수 없습니다.",
+    "description": "사이트 도메인에 대한 안내"
+  },
+  "message.titleTip": {
+    "message": "사이트 제목, 브라우저 탭에 표시됩니다.",
+    "description": "사이트 제목에 대한 안내"
+  },
+  "message.descriptionTip": {
+    "message": "사이트 설명, 사이트 메타 정보에 위치하며, 사이트 SEO 최적화에 사용됩니다.",
+    "description": "사이트 설명에 대한 안내"
+  },
+  "message.logoTip": {
+    "message": "사이트 로고, 메뉴 바가 펼쳐질 때 사이트 메뉴 상단에 표시됩니다.",
+    "description": "사이트 로고에 대한 안내"
+  },
+  "message.faviconTip": {
+    "message": "사이트 파비콘, 브라우저 탭에 표시됩니다.",
+    "description": "사이트 파비콘에 대한 안내"
+  },
+  "message.adminsTip": {
+    "message": "사이트 관리자 ID, 기본적으로 사이트를 처음 생성한 사용자가 관리자가 되며, 사이트 관리자만 사이트를 관리할 수 있습니다.",
+    "description": "사이트 관리자에 대한 안내"
+  },
+  "message.adminsTip2": {
+    "message": "여기에서 관리자 ID를 추가하거나 삭제할 수 있으며, https://auth.acedata.cloud에서 사용자 ID를 확인할 수 있습니다.",
+    "description": "사이트 관리자에 대한 안내"
+  },
+  "message.keywordsTip": {
+    "message": "사이트 키워드, 사이트 메타 정보에 위치하며, 사이트 SEO 최적화에 사용됩니다.",
+    "description": "사이트 키워드에 대한 안내"
+  },
+  "message.keywordsTip2": {
+    "message": "여기에서 사이트 키워드를 추가하거나 삭제할 수 있으며, 키워드가 정확할수록 SEO 최적화에 유리합니다.",
+    "description": "사이트 키워드에 대한 안내"
+  },
+  "message.featuresChat": {
+    "message": "Chat 기능 모듈을 켜거나 끕니다.",
+    "description": "Chat 기능에 대한 설명"
+  },
+  "message.featuresGrok": {
+    "message": "Grok 기능 모듈을 켜거나 끕니다.",
+    "description": "Grok 기능에 대한 설명"
+  },
+  "message.featuresDeepseek": {
+    "message": "Deepseek 기능 모듈을 켜거나 끕니다.",
+    "description": "Deepseek 기능에 대한 설명"
+  },
+  "message.featuresChatgpt": {
+    "message": "ChatGPT 기능 모듈을 켜거나 끕니다.",
+    "description": "ChatGPT 기능에 대한 설명"
+  },
+  "message.featuresMidjourney": {
+    "message": "Midjourney 기능 모듈을 켜거나 끕니다.",
+    "description": "Midjourney 기능에 대한 설명"
+  },
+  "message.featuresChatdoc": {
+    "message": "Chatdoc 기능 모듈을 켜거나 끕니다.",
+    "description": "Chatdoc 기능에 대한 설명"
+  },
+  "message.featuresQrart": {
+    "message": "Qrart 기능 모듈을 켜거나 끕니다.",
+    "description": "Qrart 기능에 대한 설명"
+  },
+  "message.featuresVeo": {
+    "message": "Veo 기능 모듈을 켜거나 끕니다.",
+    "description": "Veo 기능에 대한 설명"
+  },
+  "message.featuresSora": {
+    "message": "Sora 기능 모듈을 켜거나 끕니다.",
+    "description": "Sora 기능에 대한 설명"
+  },
+  "message.featuresSuno": {
+    "message": "Suno 기능 모듈을 켜거나 끕니다.",
+    "description": "Suno 기능에 대한 설명"
+  },
+  "message.featuresPixverse": {
+    "message": "Pixverse 기능 모듈을 켜거나 끕니다.",
+    "description": "Pixverse 기능의 설명"
+  },
+  "message.featuresFlux": {
+    "message": "FLux 기능 모듈을 켜거나 끕니다.",
+    "description": "FLux 기능의 설명"
+  },
+  "message.featuresNanobanana": {
+    "message": "Nano Banana 기능 모듈을 켜거나 끕니다.",
+    "description": "Nano Banana 기능의 설명"
+  },
   "message.featuresOpenaiimage": {
     "message": "Toggle OpenAI Image feature module.",
     "description": "Description of the OpenAI Image feature"
   },
-  "message.featuresSeedream": [
-    [
-      "message",
-      "SeeDream 기능 모듈을 켜거나 끕니다."
-    ],
-    [
-      "description",
-      "SeeDream 기능의 설명"
-    ]
-  ],
-  "message.featuresSeedance": [
-    [
-      "message",
-      "SeeDance 기능 모듈을 활성화하거나 비활성화합니다."
-    ],
-    [
-      "description",
-      "SeeDance 기능의 설명"
-    ]
-  ],
-  "message.featuresWan": [
-    [
-      "message",
-      "Wan 기능 모듈을 켜거나 끕니다."
-    ],
-    [
-      "description",
-      "Wan 기능의 설명"
-    ]
-  ],
-  "message.featuresProducer": [
-    [
-      "message",
-      "Producer 기능 모듈을 켜거나 끕니다."
-    ],
-    [
-      "description",
-      "Producer 기능의 설명"
-    ]
-  ],
-  "message.featuresKimi": [
-    [
-      "message",
-      "Kimi 기능 모듈을 켜거나 끕니다."
-    ],
-    [
-      "description",
-      "Kimi 기능의 설명"
-    ]
-  ],
-  "message.featuresSerp": [
-    [
-      "message",
-      "SERP 기능 모듈을 켜거나 끕니다."
-    ],
-    [
-      "description",
-      "SERP 기능의 설명"
-    ]
-  ],
-  "message.featuresLuma": [
-    [
-      "message",
-      "Luma 기능 모듈을 켜거나 끕니다."
-    ],
-    [
-      "description",
-      "Luma 기능의 설명"
-    ]
-  ],
-  "message.featuresPika": [
-    [
-      "message",
-      "Pika 기능 모듈을 켜거나 끕니다."
-    ],
-    [
-      "description",
-      "Pika 기능의 설명"
-    ]
-  ],
-  "message.featuresKling": [
-    [
-      "message",
-      "Kling 기능 모듈을 켜거나 끕니다."
-    ],
-    [
-      "description",
-      "Kling 기능의 설명"
-    ]
-  ],
-  "message.featuresHailuo": [
-    [
-      "message",
-      "Hailuo 기능 모듈을 켜거나 끕니다."
-    ],
-    [
-      "description",
-      "Hailuo 기능의 설명"
-    ]
-  ],
-  "message.featuresHeadshots": [
-    [
-      "message",
-      "AI 증명사진 기능 모듈을 켜거나 끕니다."
-    ],
-    [
-      "description",
-      "AI 증명사진 기능의 설명"
-    ]
-  ],
-  "message.featuresSupport": [
-    [
-      "message",
-      "고객 지원을 켜거나 끕니다."
-    ],
-    [
-      "description",
-      "Support 기능의 설명"
-    ]
-  ],
-  "message.featuresI18n": [
-    [
-      "message",
-      "다국어 지원을 켜거나 끕니다. 끄면 사용자는 기본 언어만 사용할 수 있습니다."
-    ],
-    [
-      "description",
-      "다국어 지원의 설명"
-    ]
-  ],
-  "button.upload": [
-    [
-      "message",
-      "업로드"
-    ],
-    [
-      "description",
-      "업로드"
-    ]
-  ],
-  "button.enabled": [
-    [
-      "message",
-      "활성화됨"
-    ],
-    [
-      "description",
-      "스위치 텍스트, 활성화된 상태를 나타냄"
-    ]
-  ],
-  "button.disabled": [
-    [
-      "message",
-      "비활성화됨"
-    ],
-    [
-      "description",
-      "스위치 텍스트, 비활성화된 상태를 나타냄"
-    ]
-  ],
-  "field.featuresGemini": [
-    [
-      "message",
-      "Gemini"
-    ],
-    [
-      "description",
-      "편집 상자에 제목으로 표시됨"
-    ]
-  ],
-  "message.featuresGemini": [
-    [
-      "message",
-      "Gemini 기능 모듈을 활성화하거나 비활성화합니다."
-    ],
-    [
-      "description",
-      "Gemini 기능의 설명"
-    ]
-  ],
-  "field.featuresClaude": [
-    [
-      "message",
-      "Claude"
-    ],
-    [
-      "description",
-      "편집 상자에 제목으로 표시됨"
-    ]
-  ],
-  "message.featuresClaude": [
-    [
-      "message",
-      "Claude 기능 모듈을 활성화하거나 비활성화합니다."
-    ],
-    [
-      "description",
-      "Claude 기능의 설명"
-    ]
-  ]
+  "message.featuresSeedream": {
+    "message": "SeeDream 기능 모듈을 켜거나 끕니다.",
+    "description": "SeeDream 기능의 설명"
+  },
+  "message.featuresSeedance": {
+    "message": "SeeDance 기능 모듈을 활성화하거나 비활성화합니다.",
+    "description": "SeeDance 기능의 설명"
+  },
+  "message.featuresWan": {
+    "message": "Wan 기능 모듈을 켜거나 끕니다.",
+    "description": "Wan 기능의 설명"
+  },
+  "message.featuresProducer": {
+    "message": "Producer 기능 모듈을 켜거나 끕니다.",
+    "description": "Producer 기능의 설명"
+  },
+  "message.featuresKimi": {
+    "message": "Kimi 기능 모듈을 켜거나 끕니다.",
+    "description": "Kimi 기능의 설명"
+  },
+  "message.featuresSerp": {
+    "message": "SERP 기능 모듈을 켜거나 끕니다.",
+    "description": "SERP 기능의 설명"
+  },
+  "message.featuresLuma": {
+    "message": "Luma 기능 모듈을 켜거나 끕니다.",
+    "description": "Luma 기능의 설명"
+  },
+  "message.featuresPika": {
+    "message": "Pika 기능 모듈을 켜거나 끕니다.",
+    "description": "Pika 기능의 설명"
+  },
+  "message.featuresKling": {
+    "message": "Kling 기능 모듈을 켜거나 끕니다.",
+    "description": "Kling 기능의 설명"
+  },
+  "message.featuresHailuo": {
+    "message": "Hailuo 기능 모듈을 켜거나 끕니다.",
+    "description": "Hailuo 기능의 설명"
+  },
+  "message.featuresHeadshots": {
+    "message": "AI 증명사진 기능 모듈을 켜거나 끕니다.",
+    "description": "AI 증명사진 기능의 설명"
+  },
+  "message.featuresSupport": {
+    "message": "고객 지원을 켜거나 끕니다.",
+    "description": "Support 기능의 설명"
+  },
+  "message.featuresI18n": {
+    "message": "다국어 지원을 켜거나 끕니다. 끄면 사용자는 기본 언어만 사용할 수 있습니다.",
+    "description": "다국어 지원의 설명"
+  },
+  "button.upload": {
+    "message": "업로드",
+    "description": "업로드"
+  },
+  "button.enabled": {
+    "message": "활성화됨",
+    "description": "스위치 텍스트, 활성화된 상태를 나타냄"
+  },
+  "button.disabled": {
+    "message": "비활성화됨",
+    "description": "스위치 텍스트, 비활성화된 상태를 나타냄"
+  },
+  "field.featuresGemini": {
+    "message": "Gemini",
+    "description": "편집 상자에 제목으로 표시됨"
+  },
+  "message.featuresGemini": {
+    "message": "Gemini 기능 모듈을 활성화하거나 비활성화합니다.",
+    "description": "Gemini 기능의 설명"
+  },
+  "field.featuresClaude": {
+    "message": "Claude",
+    "description": "편집 상자에 제목으로 표시됨"
+  },
+  "message.featuresClaude": {
+    "message": "Claude 기능 모듈을 활성화하거나 비활성화합니다.",
+    "description": "Claude 기능의 설명"
+  }
 }

--- a/src/i18n/pl/site.json
+++ b/src/i18n/pl/site.json
@@ -1,442 +1,1110 @@
 {
-  "field.title": {
-    "message": "Tytuł witryny",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "field.origin": {
-    "message": "Domena witryny",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "field.description": {
-    "message": "Opis witryny",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "field.keywords": {
-    "message": "Słowa kluczowe witryny",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "field.logo": {
-    "message": "Logo witryny",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "field.favicon": {
-    "message": "Favicon witryny",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "field.qr": {
-    "message": "Kod QR",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "field.url": {
-    "message": "Link",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "field.admins": {
-    "message": "ID administratorów witryny",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "field.distributionDefaultInviterId": {
-    "message": "ID domyślnego zapraszającego",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "field.distributionForceInviterId": {
-    "message": "ID wymuszonego zapraszającego",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "field.featuresChat": {
-    "message": "Czat",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "field.featuresVeo": {
-    "message": "Veo",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "field.featuresSora": {
-    "message": "Sora",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "field.featuresGrok": {
-    "message": "Grok",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "field.featuresDeepseek": {
-    "message": "Deepseek",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "field.featuresChatgpt": {
-    "message": "ChatGPT",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "field.featuresMidjourney": {
-    "message": "Midjourney",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "field.featuresChatdoc": {
-    "message": "Chatdoc",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "field.featuresQrart": {
-    "message": "Qrart",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "field.featuresLuma": {
-    "message": "Luma",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "field.featuresPixverse": {
-    "message": "Pixverse",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "field.featuresPika": {
-    "message": "Pika",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "field.featuresKling": {
-    "message": "Kling",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "field.featuresHailuo": {
-    "message": "Hailuo",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "field.featuresHeadshots": {
-    "message": "Zdjęcia AI",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "field.featuresSuno": {
-    "message": "Suno",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "field.featuresFlux": {
-    "message": "Flux",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "field.featuresNanobanana": {
-    "message": "Nano Banana",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "field.featuresSeedream": {
-    "message": "SeeDream",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "field.featuresSeedance": {
-    "message": "SeeDance",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "field.featuresWan": {
-    "message": "Wan",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "field.featuresProducer": {
-    "message": "Producent",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "field.featuresKimi": {
-    "message": "Kimi",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "field.featuresSerp": {
-    "message": "SERP",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "field.featuresSupport": {
-    "message": "Wsparcie klienta",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "field.featuresI18n": {
-    "message": "Wsparcie wielojęzyczne",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "title.basicConfig": {
-    "message": "Podstawowa konfiguracja",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "title.seoConfig": {
-    "message": "Konfiguracja SEO",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "title.editAdmins": {
-    "message": "Edytuj administratorów",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "title.featuresConfig": {
-    "message": "Konfiguracja funkcji",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "title.editTitle": {
-    "message": "Edytuj tytuł",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "title.editOrigin": {
-    "message": "Edytuj domenę",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "title.editKeywords": {
-    "message": "Edytuj słowa kluczowe",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "title.editLogo": {
-    "message": "Edytuj logo",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "title.editFavicon": {
-    "message": "Edytuj favicon",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "title.editDescription": {
-    "message": "Edytuj opis",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "title.distributionConfig": {
-    "message": "Konfiguracja dystrybucji",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "title.editDistributionDefaultInviterId": {
-    "message": "Edytuj domyślnego zapraszającego",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "title.editDistributionForceInviterId": {
-    "message": "Edytuj wymuszonego zapraszającego",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "title.editQR": {
-    "message": "Edytuj QR kod",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "title.editUrl": {
-    "message": "Edytuj link",
-    "description": "Wyświetlane w tytule edytora"
-  },
-  "placeholder.title": {
-    "message": "Wprowadź tytuł strony",
-    "description": "Wyświetlane w edytorze"
-  },
-  "placeholder.origin": {
-    "message": "Wprowadź domenę strony",
-    "description": "Wyświetlane w edytorze"
-  },
-  "placeholder.editUrl": {
-    "message": "Wprowadź link",
-    "description": "Wyświetlane w edytorze"
-  },
-  "placeholder.description": {
-    "message": "Wprowadź opis strony",
-    "description": "Wyświetlane w edytorze"
-  },
-  "placeholder.keywords": {
-    "message": "Wprowadź słowa kluczowe",
-    "description": "Wyświetlane w edytorze"
-  },
-  "placeholder.editDistributionDefaultInviterId": {
-    "message": "Wprowadź domyślne ID zapraszającego",
-    "description": "Wyświetlane w edytorze"
-  },
-  "placeholder.editDistributionForceInviterId": {
-    "message": "Wprowadź wymuszone ID zapraszającego",
-    "description": "Wyświetlane w edytorze"
-  },
-  "message.uploadImageExceed": {
-    "message": "Przekroczono limit rozmiaru obrazu",
-    "description": "Komunikat o przekroczeniu limitu rozmiaru obrazu"
-  },
-  "message.uploadImageError": {
-    "message": "Błąd przesyłania obrazu",
-    "description": "Komunikat o błędzie przesyłania obrazu"
-  },
-  "message.editLogoTip": {
-    "message": "Zalecany rozmiar: 200*60px",
-    "description": "Wskazówki dotyczące przesyłania obrazu"
-  },
-  "message.editQRTip": {
-    "message": "Zalecany rozmiar: 200*200px",
-    "description": "Wskazówki dotyczące przesyłania obrazu"
-  },
-  "message.editFaviconTip": {
-    "message": "Zalecany rozmiar: 32*32px",
-    "description": "Wskazówki dotyczące przesyłania obrazu"
-  },
-  "message.editUrl": {
-    "message": "Wprowadź link",
-    "description": "Wskazówki dotyczące wprowadzania linku"
-  },
-  "message.atLeastOneAdmin": {
-    "message": "Zachowaj przynajmniej jednego administratora",
-    "description": "Komunikat o konieczności posiadania przynajmniej jednego administratora"
-  },
-  "message.distributionDefaultInviterIdTip": {
-    "message": "ID użytkownika domyślnego zapraszającego. Jeśli link dystrybucji nie zawiera parametru inviter_id, użyje tego ID jako zapraszającego.",
-    "description": "Wskazówki dotyczące domyślnego ID zapraszającego"
-  },
-  "message.distributionForceInviterIdTip": {
-    "message": "ID użytkownika wymuszonego zapraszającego. Jeśli to ID jest ustawione, niezależnie od tego, czy link dystrybucji zawiera parametr inviter_id, użyje tego ID jako zapraszającego.",
-    "description": "Wskazówki dotyczące wymuszonego ID zapraszającego"
-  },
-  "message.originTip": {
-    "message": "Domena strony, konfiguracja strony jest powiązana z domeną, nie można jej zmienić.",
-    "description": "Wskazówki dotyczące domeny strony"
-  },
-  "message.titleTip": {
-    "message": "Tytuł strony, wyświetlany na karcie przeglądarki.",
-    "description": "Wskazówki dotyczące tytułu strony"
-  },
-  "message.descriptionTip": {
-    "message": "Opis strony, znajduje się w metadanych strony, używany do optymalizacji SEO.",
-    "description": "Wskazówki dotyczące opisu strony"
-  },
-  "message.logoTip": {
-    "message": "Logo strony, wyświetlane na górze menu, gdy menu jest rozwinięte.",
-    "description": "Wskazówki dotyczące logo strony"
-  },
-  "message.faviconTip": {
-    "message": "Favicon strony, wyświetlany na karcie przeglądarki.",
-    "description": "Wskazówki dotyczące faviconu strony"
-  },
-  "message.adminsTip": {
-    "message": "ID administratorów strony, domyślnie pierwszy użytkownik tworzący stronę staje się administratorem, tylko administratorzy mogą zarządzać stroną.",
-    "description": "Wskazówki dotyczące administratorów strony"
-  },
-  "message.adminsTip2": {
-    "message": "Możesz dodać lub usunąć ID administratorów, ID użytkowników można znaleźć na https://auth.acedata.cloud",
-    "description": "Wskazówki dotyczące administratorów strony"
-  },
-  "message.keywordsTip": {
-    "message": "Słowa kluczowe strony, znajdują się w metadanych strony, używane do optymalizacji SEO.",
-    "description": "Wskazówki dotyczące słów kluczowych strony"
-  },
-  "message.keywordsTip2": {
-    "message": "Możesz dodać lub usunąć słowa kluczowe, im bardziej precyzyjne słowa kluczowe, tym lepsza optymalizacja SEO.",
-    "description": "Wskazówki dotyczące słów kluczowych strony"
-  },
-  "message.featuresChat": {
-    "message": "Włącz lub wyłącz moduł funkcji czatu.",
-    "description": "Opis funkcji czatu"
-  },
-  "message.featuresGrok": {
-    "message": "Włącz lub wyłącz moduł funkcji Grok.",
-    "description": "Opis funkcji Grok"
-  },
-  "message.featuresDeepseek": {
-    "message": "Włącz lub wyłącz moduł funkcji Deepseek.",
-    "description": "Opis funkcji Deepseek"
-  },
-  "message.featuresChatgpt": {
-    "message": "Włącz lub wyłącz moduł funkcji ChatGPT.",
-    "description": "Opis funkcji ChatGPT"
-  },
-  "message.featuresMidjourney": {
-    "message": "Włącz lub wyłącz moduł funkcji Midjourney.",
-    "description": "Opis funkcji Midjourney"
-  },
-  "message.featuresChatdoc": {
-    "message": "Włącz lub wyłącz moduł funkcji Chatdoc.",
-    "description": "Opis funkcji Chatdoc"
-  },
-  "message.featuresQrart": {
-    "message": "Włącz lub wyłącz moduł funkcji Qrart.",
-    "description": "Opis funkcji Qrart"
-  },
-  "message.featuresVeo": {
-    "message": "Włącz lub wyłącz moduł funkcji Veo.",
-    "description": "Opis funkcji Veo"
-  },
-  "message.featuresSora": {
-    "message": "Włącz lub wyłącz moduł funkcji Sora.",
-    "description": "Opis funkcji Sora"
-  },
-  "message.featuresSuno": {
-    "message": "Włącz lub wyłącz moduł funkcji Suno.",
-    "description": "Opis funkcji Suno"
-  },
-  "message.featuresPixverse": {
-    "message": "Włącz lub wyłącz moduł funkcji Pixverse.",
-    "description": "Opis funkcji Pixverse"
-  },
-  "message.featuresFlux": {
-    "message": "Włącz lub wyłącz moduł funkcji FLux.",
-    "description": "Opis funkcji FLux"
-  },
-  "message.featuresNanobanana": {
-    "message": "Włącz lub wyłącz moduł funkcji Nano Banana.",
-    "description": "Opis funkcji Nano Banana"
-  },
-  "message.featuresSeedream": {
-    "message": "Włącz lub wyłącz moduł funkcji SeeDream.",
-    "description": "Opis funkcji SeeDream"
-  },
-  "message.featuresSeedance": {
-    "message": "Włącz lub wyłącz moduł funkcji SeeDance.",
-    "description": "Opis funkcji SeeDance"
-  },
-  "message.featuresWan": {
-    "message": "Włącz lub wyłącz moduł funkcji Wan.",
-    "description": "Opis funkcji Wan"
-  },
-  "message.featuresProducer": {
-    "message": "Włącz lub wyłącz moduł funkcji Producer.",
-    "description": "Opis funkcji Producer"
-  },
-  "message.featuresKimi": {
-    "message": "Włącz lub wyłącz moduł funkcji Kimi.",
-    "description": "Opis funkcji Kimi"
-  },
-  "message.featuresSerp": {
-    "message": "Włącz lub wyłącz moduł funkcji SERP.",
-    "description": "Opis funkcji SERP"
-  },
-  "message.featuresLuma": {
-    "message": "Włącz lub wyłącz moduł funkcji Luma.",
-    "description": "Opis funkcji Luma"
-  },
-  "message.featuresPika": {
-    "message": "Włącz lub wyłącz moduł funkcji Pika.",
-    "description": "Opis funkcji Pika"
-  },
-  "message.featuresKling": {
-    "message": "Włącz lub wyłącz moduł funkcji Kling.",
-    "description": "Opis funkcji Kling"
-  },
-  "message.featuresHailuo": {
-    "message": "Włącz lub wyłącz moduł funkcji Hailuo.",
-    "description": "Opis funkcji Hailuo"
-  },
-  "message.featuresHeadshots": {
-    "message": "Włącz lub wyłącz moduł funkcji AI zdjęcia identyfikacyjne.",
-    "description": "Opis funkcji AI zdjęcia identyfikacyjne"
-  },
-  "message.featuresSupport": {
-    "message": "Włącz lub wyłącz wsparcie klienta",
-    "description": "Opis funkcji wsparcia"
-  },
-  "message.featuresI18n": {
-    "message": "Włącz lub wyłącz wsparcie wielojęzyczne, po wyłączeniu użytkownik może korzystać tylko z domyślnego języka.",
-    "description": "Opis wsparcia wielojęzycznego"
-  },
-  "button.upload": {
-    "message": "Prześlij",
-    "description": "Prześlij"
-  },
-  "button.enabled": {
-    "message": "Włączone",
-    "description": "Tekst przełącznika, oznaczający, że jest włączone"
-  },
-  "button.disabled": {
-    "message": "Wyłączone",
-    "description": "Tekst przełącznika, oznaczający, że jest wyłączone"
-  },
-  "field.featuresGemini": {
-    "message": "Gemini",
-    "description": "Wyświetlane jako tytuł w polu edycji"
-  },
-  "message.featuresGemini": {
-    "message": "Włącz lub wyłącz moduł funkcji Gemini.",
-    "description": "Opis funkcji Gemini"
-  },
-  "field.featuresClaude": {
-    "message": "Claude",
-    "description": "Wyświetlane jako tytuł w polu edycji"
-  },
-  "message.featuresClaude": {
-    "message": "Włącz lub wyłącz moduł funkcji Claude.",
-    "description": "Opis funkcji Claude"
-  }
+  "field.title": [
+    [
+      "message",
+      "Tytuł witryny"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "field.origin": [
+    [
+      "message",
+      "Domena witryny"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "field.description": [
+    [
+      "message",
+      "Opis witryny"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "field.keywords": [
+    [
+      "message",
+      "Słowa kluczowe witryny"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "field.logo": [
+    [
+      "message",
+      "Logo witryny"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "field.favicon": [
+    [
+      "message",
+      "Favicon witryny"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "field.qr": [
+    [
+      "message",
+      "Kod QR"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "field.url": [
+    [
+      "message",
+      "Link"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "field.admins": [
+    [
+      "message",
+      "ID administratorów witryny"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "field.distributionDefaultInviterId": [
+    [
+      "message",
+      "ID domyślnego zapraszającego"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "field.distributionForceInviterId": [
+    [
+      "message",
+      "ID wymuszonego zapraszającego"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "field.featuresChat": [
+    [
+      "message",
+      "Czat"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "field.featuresVeo": [
+    [
+      "message",
+      "Veo"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "field.featuresSora": [
+    [
+      "message",
+      "Sora"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "field.featuresGrok": [
+    [
+      "message",
+      "Grok"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "field.featuresDeepseek": [
+    [
+      "message",
+      "Deepseek"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "field.featuresChatgpt": [
+    [
+      "message",
+      "ChatGPT"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "field.featuresMidjourney": [
+    [
+      "message",
+      "Midjourney"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "field.featuresChatdoc": [
+    [
+      "message",
+      "Chatdoc"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "field.featuresQrart": [
+    [
+      "message",
+      "Qrart"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "field.featuresLuma": [
+    [
+      "message",
+      "Luma"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "field.featuresPixverse": [
+    [
+      "message",
+      "Pixverse"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "field.featuresPika": [
+    [
+      "message",
+      "Pika"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "field.featuresKling": [
+    [
+      "message",
+      "Kling"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "field.featuresHailuo": [
+    [
+      "message",
+      "Hailuo"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "field.featuresHeadshots": [
+    [
+      "message",
+      "Zdjęcia AI"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "field.featuresSuno": [
+    [
+      "message",
+      "Suno"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "field.featuresFlux": [
+    [
+      "message",
+      "Flux"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "field.featuresNanobanana": [
+    [
+      "message",
+      "Nano Banana"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "field.featuresOpenaiimage": {
+    "message": "OpenAI Image",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresSeedream": [
+    [
+      "message",
+      "SeeDream"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "field.featuresSeedance": [
+    [
+      "message",
+      "SeeDance"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "field.featuresWan": [
+    [
+      "message",
+      "Wan"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "field.featuresProducer": [
+    [
+      "message",
+      "Producent"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "field.featuresKimi": [
+    [
+      "message",
+      "Kimi"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "field.featuresSerp": [
+    [
+      "message",
+      "SERP"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "field.featuresSupport": [
+    [
+      "message",
+      "Wsparcie klienta"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "field.featuresI18n": [
+    [
+      "message",
+      "Wsparcie wielojęzyczne"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "title.basicConfig": [
+    [
+      "message",
+      "Podstawowa konfiguracja"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "title.seoConfig": [
+    [
+      "message",
+      "Konfiguracja SEO"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "title.editAdmins": [
+    [
+      "message",
+      "Edytuj administratorów"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "title.featuresConfig": [
+    [
+      "message",
+      "Konfiguracja funkcji"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "title.editTitle": [
+    [
+      "message",
+      "Edytuj tytuł"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "title.editOrigin": [
+    [
+      "message",
+      "Edytuj domenę"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "title.editKeywords": [
+    [
+      "message",
+      "Edytuj słowa kluczowe"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "title.editLogo": [
+    [
+      "message",
+      "Edytuj logo"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "title.editFavicon": [
+    [
+      "message",
+      "Edytuj favicon"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "title.editDescription": [
+    [
+      "message",
+      "Edytuj opis"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "title.distributionConfig": [
+    [
+      "message",
+      "Konfiguracja dystrybucji"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "title.editDistributionDefaultInviterId": [
+    [
+      "message",
+      "Edytuj domyślnego zapraszającego"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "title.editDistributionForceInviterId": [
+    [
+      "message",
+      "Edytuj wymuszonego zapraszającego"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "title.editQR": [
+    [
+      "message",
+      "Edytuj QR kod"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "title.editUrl": [
+    [
+      "message",
+      "Edytuj link"
+    ],
+    [
+      "description",
+      "Wyświetlane w tytule edytora"
+    ]
+  ],
+  "placeholder.title": [
+    [
+      "message",
+      "Wprowadź tytuł strony"
+    ],
+    [
+      "description",
+      "Wyświetlane w edytorze"
+    ]
+  ],
+  "placeholder.origin": [
+    [
+      "message",
+      "Wprowadź domenę strony"
+    ],
+    [
+      "description",
+      "Wyświetlane w edytorze"
+    ]
+  ],
+  "placeholder.editUrl": [
+    [
+      "message",
+      "Wprowadź link"
+    ],
+    [
+      "description",
+      "Wyświetlane w edytorze"
+    ]
+  ],
+  "placeholder.description": [
+    [
+      "message",
+      "Wprowadź opis strony"
+    ],
+    [
+      "description",
+      "Wyświetlane w edytorze"
+    ]
+  ],
+  "placeholder.keywords": [
+    [
+      "message",
+      "Wprowadź słowa kluczowe"
+    ],
+    [
+      "description",
+      "Wyświetlane w edytorze"
+    ]
+  ],
+  "placeholder.editDistributionDefaultInviterId": [
+    [
+      "message",
+      "Wprowadź domyślne ID zapraszającego"
+    ],
+    [
+      "description",
+      "Wyświetlane w edytorze"
+    ]
+  ],
+  "placeholder.editDistributionForceInviterId": [
+    [
+      "message",
+      "Wprowadź wymuszone ID zapraszającego"
+    ],
+    [
+      "description",
+      "Wyświetlane w edytorze"
+    ]
+  ],
+  "message.uploadImageExceed": [
+    [
+      "message",
+      "Przekroczono limit rozmiaru obrazu"
+    ],
+    [
+      "description",
+      "Komunikat o przekroczeniu limitu rozmiaru obrazu"
+    ]
+  ],
+  "message.uploadImageError": [
+    [
+      "message",
+      "Błąd przesyłania obrazu"
+    ],
+    [
+      "description",
+      "Komunikat o błędzie przesyłania obrazu"
+    ]
+  ],
+  "message.editLogoTip": [
+    [
+      "message",
+      "Zalecany rozmiar: 200*60px"
+    ],
+    [
+      "description",
+      "Wskazówki dotyczące przesyłania obrazu"
+    ]
+  ],
+  "message.editQRTip": [
+    [
+      "message",
+      "Zalecany rozmiar: 200*200px"
+    ],
+    [
+      "description",
+      "Wskazówki dotyczące przesyłania obrazu"
+    ]
+  ],
+  "message.editFaviconTip": [
+    [
+      "message",
+      "Zalecany rozmiar: 32*32px"
+    ],
+    [
+      "description",
+      "Wskazówki dotyczące przesyłania obrazu"
+    ]
+  ],
+  "message.editUrl": [
+    [
+      "message",
+      "Wprowadź link"
+    ],
+    [
+      "description",
+      "Wskazówki dotyczące wprowadzania linku"
+    ]
+  ],
+  "message.atLeastOneAdmin": [
+    [
+      "message",
+      "Zachowaj przynajmniej jednego administratora"
+    ],
+    [
+      "description",
+      "Komunikat o konieczności posiadania przynajmniej jednego administratora"
+    ]
+  ],
+  "message.distributionDefaultInviterIdTip": [
+    [
+      "message",
+      "ID użytkownika domyślnego zapraszającego. Jeśli link dystrybucji nie zawiera parametru inviter_id, użyje tego ID jako zapraszającego."
+    ],
+    [
+      "description",
+      "Wskazówki dotyczące domyślnego ID zapraszającego"
+    ]
+  ],
+  "message.distributionForceInviterIdTip": [
+    [
+      "message",
+      "ID użytkownika wymuszonego zapraszającego. Jeśli to ID jest ustawione, niezależnie od tego, czy link dystrybucji zawiera parametr inviter_id, użyje tego ID jako zapraszającego."
+    ],
+    [
+      "description",
+      "Wskazówki dotyczące wymuszonego ID zapraszającego"
+    ]
+  ],
+  "message.originTip": [
+    [
+      "message",
+      "Domena strony, konfiguracja strony jest powiązana z domeną, nie można jej zmienić."
+    ],
+    [
+      "description",
+      "Wskazówki dotyczące domeny strony"
+    ]
+  ],
+  "message.titleTip": [
+    [
+      "message",
+      "Tytuł strony, wyświetlany na karcie przeglądarki."
+    ],
+    [
+      "description",
+      "Wskazówki dotyczące tytułu strony"
+    ]
+  ],
+  "message.descriptionTip": [
+    [
+      "message",
+      "Opis strony, znajduje się w metadanych strony, używany do optymalizacji SEO."
+    ],
+    [
+      "description",
+      "Wskazówki dotyczące opisu strony"
+    ]
+  ],
+  "message.logoTip": [
+    [
+      "message",
+      "Logo strony, wyświetlane na górze menu, gdy menu jest rozwinięte."
+    ],
+    [
+      "description",
+      "Wskazówki dotyczące logo strony"
+    ]
+  ],
+  "message.faviconTip": [
+    [
+      "message",
+      "Favicon strony, wyświetlany na karcie przeglądarki."
+    ],
+    [
+      "description",
+      "Wskazówki dotyczące faviconu strony"
+    ]
+  ],
+  "message.adminsTip": [
+    [
+      "message",
+      "ID administratorów strony, domyślnie pierwszy użytkownik tworzący stronę staje się administratorem, tylko administratorzy mogą zarządzać stroną."
+    ],
+    [
+      "description",
+      "Wskazówki dotyczące administratorów strony"
+    ]
+  ],
+  "message.adminsTip2": [
+    [
+      "message",
+      "Możesz dodać lub usunąć ID administratorów, ID użytkowników można znaleźć na https://auth.acedata.cloud"
+    ],
+    [
+      "description",
+      "Wskazówki dotyczące administratorów strony"
+    ]
+  ],
+  "message.keywordsTip": [
+    [
+      "message",
+      "Słowa kluczowe strony, znajdują się w metadanych strony, używane do optymalizacji SEO."
+    ],
+    [
+      "description",
+      "Wskazówki dotyczące słów kluczowych strony"
+    ]
+  ],
+  "message.keywordsTip2": [
+    [
+      "message",
+      "Możesz dodać lub usunąć słowa kluczowe, im bardziej precyzyjne słowa kluczowe, tym lepsza optymalizacja SEO."
+    ],
+    [
+      "description",
+      "Wskazówki dotyczące słów kluczowych strony"
+    ]
+  ],
+  "message.featuresChat": [
+    [
+      "message",
+      "Włącz lub wyłącz moduł funkcji czatu."
+    ],
+    [
+      "description",
+      "Opis funkcji czatu"
+    ]
+  ],
+  "message.featuresGrok": [
+    [
+      "message",
+      "Włącz lub wyłącz moduł funkcji Grok."
+    ],
+    [
+      "description",
+      "Opis funkcji Grok"
+    ]
+  ],
+  "message.featuresDeepseek": [
+    [
+      "message",
+      "Włącz lub wyłącz moduł funkcji Deepseek."
+    ],
+    [
+      "description",
+      "Opis funkcji Deepseek"
+    ]
+  ],
+  "message.featuresChatgpt": [
+    [
+      "message",
+      "Włącz lub wyłącz moduł funkcji ChatGPT."
+    ],
+    [
+      "description",
+      "Opis funkcji ChatGPT"
+    ]
+  ],
+  "message.featuresMidjourney": [
+    [
+      "message",
+      "Włącz lub wyłącz moduł funkcji Midjourney."
+    ],
+    [
+      "description",
+      "Opis funkcji Midjourney"
+    ]
+  ],
+  "message.featuresChatdoc": [
+    [
+      "message",
+      "Włącz lub wyłącz moduł funkcji Chatdoc."
+    ],
+    [
+      "description",
+      "Opis funkcji Chatdoc"
+    ]
+  ],
+  "message.featuresQrart": [
+    [
+      "message",
+      "Włącz lub wyłącz moduł funkcji Qrart."
+    ],
+    [
+      "description",
+      "Opis funkcji Qrart"
+    ]
+  ],
+  "message.featuresVeo": [
+    [
+      "message",
+      "Włącz lub wyłącz moduł funkcji Veo."
+    ],
+    [
+      "description",
+      "Opis funkcji Veo"
+    ]
+  ],
+  "message.featuresSora": [
+    [
+      "message",
+      "Włącz lub wyłącz moduł funkcji Sora."
+    ],
+    [
+      "description",
+      "Opis funkcji Sora"
+    ]
+  ],
+  "message.featuresSuno": [
+    [
+      "message",
+      "Włącz lub wyłącz moduł funkcji Suno."
+    ],
+    [
+      "description",
+      "Opis funkcji Suno"
+    ]
+  ],
+  "message.featuresPixverse": [
+    [
+      "message",
+      "Włącz lub wyłącz moduł funkcji Pixverse."
+    ],
+    [
+      "description",
+      "Opis funkcji Pixverse"
+    ]
+  ],
+  "message.featuresFlux": [
+    [
+      "message",
+      "Włącz lub wyłącz moduł funkcji FLux."
+    ],
+    [
+      "description",
+      "Opis funkcji FLux"
+    ]
+  ],
+  "message.featuresNanobanana": [
+    [
+      "message",
+      "Włącz lub wyłącz moduł funkcji Nano Banana."
+    ],
+    [
+      "description",
+      "Opis funkcji Nano Banana"
+    ]
+  ],
+  "message.featuresOpenaiimage": {
+    "message": "Toggle OpenAI Image feature module.",
+    "description": "Description of the OpenAI Image feature"
+  },
+  "message.featuresSeedream": [
+    [
+      "message",
+      "Włącz lub wyłącz moduł funkcji SeeDream."
+    ],
+    [
+      "description",
+      "Opis funkcji SeeDream"
+    ]
+  ],
+  "message.featuresSeedance": [
+    [
+      "message",
+      "Włącz lub wyłącz moduł funkcji SeeDance."
+    ],
+    [
+      "description",
+      "Opis funkcji SeeDance"
+    ]
+  ],
+  "message.featuresWan": [
+    [
+      "message",
+      "Włącz lub wyłącz moduł funkcji Wan."
+    ],
+    [
+      "description",
+      "Opis funkcji Wan"
+    ]
+  ],
+  "message.featuresProducer": [
+    [
+      "message",
+      "Włącz lub wyłącz moduł funkcji Producer."
+    ],
+    [
+      "description",
+      "Opis funkcji Producer"
+    ]
+  ],
+  "message.featuresKimi": [
+    [
+      "message",
+      "Włącz lub wyłącz moduł funkcji Kimi."
+    ],
+    [
+      "description",
+      "Opis funkcji Kimi"
+    ]
+  ],
+  "message.featuresSerp": [
+    [
+      "message",
+      "Włącz lub wyłącz moduł funkcji SERP."
+    ],
+    [
+      "description",
+      "Opis funkcji SERP"
+    ]
+  ],
+  "message.featuresLuma": [
+    [
+      "message",
+      "Włącz lub wyłącz moduł funkcji Luma."
+    ],
+    [
+      "description",
+      "Opis funkcji Luma"
+    ]
+  ],
+  "message.featuresPika": [
+    [
+      "message",
+      "Włącz lub wyłącz moduł funkcji Pika."
+    ],
+    [
+      "description",
+      "Opis funkcji Pika"
+    ]
+  ],
+  "message.featuresKling": [
+    [
+      "message",
+      "Włącz lub wyłącz moduł funkcji Kling."
+    ],
+    [
+      "description",
+      "Opis funkcji Kling"
+    ]
+  ],
+  "message.featuresHailuo": [
+    [
+      "message",
+      "Włącz lub wyłącz moduł funkcji Hailuo."
+    ],
+    [
+      "description",
+      "Opis funkcji Hailuo"
+    ]
+  ],
+  "message.featuresHeadshots": [
+    [
+      "message",
+      "Włącz lub wyłącz moduł funkcji AI zdjęcia identyfikacyjne."
+    ],
+    [
+      "description",
+      "Opis funkcji AI zdjęcia identyfikacyjne"
+    ]
+  ],
+  "message.featuresSupport": [
+    [
+      "message",
+      "Włącz lub wyłącz wsparcie klienta"
+    ],
+    [
+      "description",
+      "Opis funkcji wsparcia"
+    ]
+  ],
+  "message.featuresI18n": [
+    [
+      "message",
+      "Włącz lub wyłącz wsparcie wielojęzyczne, po wyłączeniu użytkownik może korzystać tylko z domyślnego języka."
+    ],
+    [
+      "description",
+      "Opis wsparcia wielojęzycznego"
+    ]
+  ],
+  "button.upload": [
+    [
+      "message",
+      "Prześlij"
+    ],
+    [
+      "description",
+      "Prześlij"
+    ]
+  ],
+  "button.enabled": [
+    [
+      "message",
+      "Włączone"
+    ],
+    [
+      "description",
+      "Tekst przełącznika, oznaczający, że jest włączone"
+    ]
+  ],
+  "button.disabled": [
+    [
+      "message",
+      "Wyłączone"
+    ],
+    [
+      "description",
+      "Tekst przełącznika, oznaczający, że jest wyłączone"
+    ]
+  ],
+  "field.featuresGemini": [
+    [
+      "message",
+      "Gemini"
+    ],
+    [
+      "description",
+      "Wyświetlane jako tytuł w polu edycji"
+    ]
+  ],
+  "message.featuresGemini": [
+    [
+      "message",
+      "Włącz lub wyłącz moduł funkcji Gemini."
+    ],
+    [
+      "description",
+      "Opis funkcji Gemini"
+    ]
+  ],
+  "field.featuresClaude": [
+    [
+      "message",
+      "Claude"
+    ],
+    [
+      "description",
+      "Wyświetlane jako tytuł w polu edycji"
+    ]
+  ],
+  "message.featuresClaude": [
+    [
+      "message",
+      "Włącz lub wyłącz moduł funkcji Claude."
+    ],
+    [
+      "description",
+      "Opis funkcji Claude"
+    ]
+  ]
 }

--- a/src/i18n/pl/site.json
+++ b/src/i18n/pl/site.json
@@ -1,1110 +1,450 @@
 {
-  "field.title": [
-    [
-      "message",
-      "Tytuł witryny"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "field.origin": [
-    [
-      "message",
-      "Domena witryny"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "field.description": [
-    [
-      "message",
-      "Opis witryny"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "field.keywords": [
-    [
-      "message",
-      "Słowa kluczowe witryny"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "field.logo": [
-    [
-      "message",
-      "Logo witryny"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "field.favicon": [
-    [
-      "message",
-      "Favicon witryny"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "field.qr": [
-    [
-      "message",
-      "Kod QR"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "field.url": [
-    [
-      "message",
-      "Link"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "field.admins": [
-    [
-      "message",
-      "ID administratorów witryny"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "field.distributionDefaultInviterId": [
-    [
-      "message",
-      "ID domyślnego zapraszającego"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "field.distributionForceInviterId": [
-    [
-      "message",
-      "ID wymuszonego zapraszającego"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "field.featuresChat": [
-    [
-      "message",
-      "Czat"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "field.featuresVeo": [
-    [
-      "message",
-      "Veo"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "field.featuresSora": [
-    [
-      "message",
-      "Sora"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "field.featuresGrok": [
-    [
-      "message",
-      "Grok"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "field.featuresDeepseek": [
-    [
-      "message",
-      "Deepseek"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "field.featuresChatgpt": [
-    [
-      "message",
-      "ChatGPT"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "field.featuresMidjourney": [
-    [
-      "message",
-      "Midjourney"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "field.featuresChatdoc": [
-    [
-      "message",
-      "Chatdoc"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "field.featuresQrart": [
-    [
-      "message",
-      "Qrart"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "field.featuresLuma": [
-    [
-      "message",
-      "Luma"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "field.featuresPixverse": [
-    [
-      "message",
-      "Pixverse"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "field.featuresPika": [
-    [
-      "message",
-      "Pika"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "field.featuresKling": [
-    [
-      "message",
-      "Kling"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "field.featuresHailuo": [
-    [
-      "message",
-      "Hailuo"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "field.featuresHeadshots": [
-    [
-      "message",
-      "Zdjęcia AI"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "field.featuresSuno": [
-    [
-      "message",
-      "Suno"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "field.featuresFlux": [
-    [
-      "message",
-      "Flux"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "field.featuresNanobanana": [
-    [
-      "message",
-      "Nano Banana"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
+  "field.title": {
+    "message": "Tytuł witryny",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "field.origin": {
+    "message": "Domena witryny",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "field.description": {
+    "message": "Opis witryny",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "field.keywords": {
+    "message": "Słowa kluczowe witryny",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "field.logo": {
+    "message": "Logo witryny",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "field.favicon": {
+    "message": "Favicon witryny",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "field.qr": {
+    "message": "Kod QR",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "field.url": {
+    "message": "Link",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "field.admins": {
+    "message": "ID administratorów witryny",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "field.distributionDefaultInviterId": {
+    "message": "ID domyślnego zapraszającego",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "field.distributionForceInviterId": {
+    "message": "ID wymuszonego zapraszającego",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "field.featuresChat": {
+    "message": "Czat",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "field.featuresVeo": {
+    "message": "Veo",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "field.featuresSora": {
+    "message": "Sora",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "field.featuresGrok": {
+    "message": "Grok",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "field.featuresDeepseek": {
+    "message": "Deepseek",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "field.featuresChatgpt": {
+    "message": "ChatGPT",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "field.featuresMidjourney": {
+    "message": "Midjourney",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "field.featuresChatdoc": {
+    "message": "Chatdoc",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "field.featuresQrart": {
+    "message": "Qrart",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "field.featuresLuma": {
+    "message": "Luma",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "field.featuresPixverse": {
+    "message": "Pixverse",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "field.featuresPika": {
+    "message": "Pika",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "field.featuresKling": {
+    "message": "Kling",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "field.featuresHailuo": {
+    "message": "Hailuo",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "field.featuresHeadshots": {
+    "message": "Zdjęcia AI",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "field.featuresSuno": {
+    "message": "Suno",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "field.featuresFlux": {
+    "message": "Flux",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "field.featuresNanobanana": {
+    "message": "Nano Banana",
+    "description": "Wyświetlane w tytule edytora"
+  },
   "field.featuresOpenaiimage": {
     "message": "OpenAI Image",
     "description": "Displayed as the title in the editing box"
   },
-  "field.featuresSeedream": [
-    [
-      "message",
-      "SeeDream"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "field.featuresSeedance": [
-    [
-      "message",
-      "SeeDance"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "field.featuresWan": [
-    [
-      "message",
-      "Wan"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "field.featuresProducer": [
-    [
-      "message",
-      "Producent"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "field.featuresKimi": [
-    [
-      "message",
-      "Kimi"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "field.featuresSerp": [
-    [
-      "message",
-      "SERP"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "field.featuresSupport": [
-    [
-      "message",
-      "Wsparcie klienta"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "field.featuresI18n": [
-    [
-      "message",
-      "Wsparcie wielojęzyczne"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "title.basicConfig": [
-    [
-      "message",
-      "Podstawowa konfiguracja"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "title.seoConfig": [
-    [
-      "message",
-      "Konfiguracja SEO"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "title.editAdmins": [
-    [
-      "message",
-      "Edytuj administratorów"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "title.featuresConfig": [
-    [
-      "message",
-      "Konfiguracja funkcji"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "title.editTitle": [
-    [
-      "message",
-      "Edytuj tytuł"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "title.editOrigin": [
-    [
-      "message",
-      "Edytuj domenę"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "title.editKeywords": [
-    [
-      "message",
-      "Edytuj słowa kluczowe"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "title.editLogo": [
-    [
-      "message",
-      "Edytuj logo"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "title.editFavicon": [
-    [
-      "message",
-      "Edytuj favicon"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "title.editDescription": [
-    [
-      "message",
-      "Edytuj opis"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "title.distributionConfig": [
-    [
-      "message",
-      "Konfiguracja dystrybucji"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "title.editDistributionDefaultInviterId": [
-    [
-      "message",
-      "Edytuj domyślnego zapraszającego"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "title.editDistributionForceInviterId": [
-    [
-      "message",
-      "Edytuj wymuszonego zapraszającego"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "title.editQR": [
-    [
-      "message",
-      "Edytuj QR kod"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "title.editUrl": [
-    [
-      "message",
-      "Edytuj link"
-    ],
-    [
-      "description",
-      "Wyświetlane w tytule edytora"
-    ]
-  ],
-  "placeholder.title": [
-    [
-      "message",
-      "Wprowadź tytuł strony"
-    ],
-    [
-      "description",
-      "Wyświetlane w edytorze"
-    ]
-  ],
-  "placeholder.origin": [
-    [
-      "message",
-      "Wprowadź domenę strony"
-    ],
-    [
-      "description",
-      "Wyświetlane w edytorze"
-    ]
-  ],
-  "placeholder.editUrl": [
-    [
-      "message",
-      "Wprowadź link"
-    ],
-    [
-      "description",
-      "Wyświetlane w edytorze"
-    ]
-  ],
-  "placeholder.description": [
-    [
-      "message",
-      "Wprowadź opis strony"
-    ],
-    [
-      "description",
-      "Wyświetlane w edytorze"
-    ]
-  ],
-  "placeholder.keywords": [
-    [
-      "message",
-      "Wprowadź słowa kluczowe"
-    ],
-    [
-      "description",
-      "Wyświetlane w edytorze"
-    ]
-  ],
-  "placeholder.editDistributionDefaultInviterId": [
-    [
-      "message",
-      "Wprowadź domyślne ID zapraszającego"
-    ],
-    [
-      "description",
-      "Wyświetlane w edytorze"
-    ]
-  ],
-  "placeholder.editDistributionForceInviterId": [
-    [
-      "message",
-      "Wprowadź wymuszone ID zapraszającego"
-    ],
-    [
-      "description",
-      "Wyświetlane w edytorze"
-    ]
-  ],
-  "message.uploadImageExceed": [
-    [
-      "message",
-      "Przekroczono limit rozmiaru obrazu"
-    ],
-    [
-      "description",
-      "Komunikat o przekroczeniu limitu rozmiaru obrazu"
-    ]
-  ],
-  "message.uploadImageError": [
-    [
-      "message",
-      "Błąd przesyłania obrazu"
-    ],
-    [
-      "description",
-      "Komunikat o błędzie przesyłania obrazu"
-    ]
-  ],
-  "message.editLogoTip": [
-    [
-      "message",
-      "Zalecany rozmiar: 200*60px"
-    ],
-    [
-      "description",
-      "Wskazówki dotyczące przesyłania obrazu"
-    ]
-  ],
-  "message.editQRTip": [
-    [
-      "message",
-      "Zalecany rozmiar: 200*200px"
-    ],
-    [
-      "description",
-      "Wskazówki dotyczące przesyłania obrazu"
-    ]
-  ],
-  "message.editFaviconTip": [
-    [
-      "message",
-      "Zalecany rozmiar: 32*32px"
-    ],
-    [
-      "description",
-      "Wskazówki dotyczące przesyłania obrazu"
-    ]
-  ],
-  "message.editUrl": [
-    [
-      "message",
-      "Wprowadź link"
-    ],
-    [
-      "description",
-      "Wskazówki dotyczące wprowadzania linku"
-    ]
-  ],
-  "message.atLeastOneAdmin": [
-    [
-      "message",
-      "Zachowaj przynajmniej jednego administratora"
-    ],
-    [
-      "description",
-      "Komunikat o konieczności posiadania przynajmniej jednego administratora"
-    ]
-  ],
-  "message.distributionDefaultInviterIdTip": [
-    [
-      "message",
-      "ID użytkownika domyślnego zapraszającego. Jeśli link dystrybucji nie zawiera parametru inviter_id, użyje tego ID jako zapraszającego."
-    ],
-    [
-      "description",
-      "Wskazówki dotyczące domyślnego ID zapraszającego"
-    ]
-  ],
-  "message.distributionForceInviterIdTip": [
-    [
-      "message",
-      "ID użytkownika wymuszonego zapraszającego. Jeśli to ID jest ustawione, niezależnie od tego, czy link dystrybucji zawiera parametr inviter_id, użyje tego ID jako zapraszającego."
-    ],
-    [
-      "description",
-      "Wskazówki dotyczące wymuszonego ID zapraszającego"
-    ]
-  ],
-  "message.originTip": [
-    [
-      "message",
-      "Domena strony, konfiguracja strony jest powiązana z domeną, nie można jej zmienić."
-    ],
-    [
-      "description",
-      "Wskazówki dotyczące domeny strony"
-    ]
-  ],
-  "message.titleTip": [
-    [
-      "message",
-      "Tytuł strony, wyświetlany na karcie przeglądarki."
-    ],
-    [
-      "description",
-      "Wskazówki dotyczące tytułu strony"
-    ]
-  ],
-  "message.descriptionTip": [
-    [
-      "message",
-      "Opis strony, znajduje się w metadanych strony, używany do optymalizacji SEO."
-    ],
-    [
-      "description",
-      "Wskazówki dotyczące opisu strony"
-    ]
-  ],
-  "message.logoTip": [
-    [
-      "message",
-      "Logo strony, wyświetlane na górze menu, gdy menu jest rozwinięte."
-    ],
-    [
-      "description",
-      "Wskazówki dotyczące logo strony"
-    ]
-  ],
-  "message.faviconTip": [
-    [
-      "message",
-      "Favicon strony, wyświetlany na karcie przeglądarki."
-    ],
-    [
-      "description",
-      "Wskazówki dotyczące faviconu strony"
-    ]
-  ],
-  "message.adminsTip": [
-    [
-      "message",
-      "ID administratorów strony, domyślnie pierwszy użytkownik tworzący stronę staje się administratorem, tylko administratorzy mogą zarządzać stroną."
-    ],
-    [
-      "description",
-      "Wskazówki dotyczące administratorów strony"
-    ]
-  ],
-  "message.adminsTip2": [
-    [
-      "message",
-      "Możesz dodać lub usunąć ID administratorów, ID użytkowników można znaleźć na https://auth.acedata.cloud"
-    ],
-    [
-      "description",
-      "Wskazówki dotyczące administratorów strony"
-    ]
-  ],
-  "message.keywordsTip": [
-    [
-      "message",
-      "Słowa kluczowe strony, znajdują się w metadanych strony, używane do optymalizacji SEO."
-    ],
-    [
-      "description",
-      "Wskazówki dotyczące słów kluczowych strony"
-    ]
-  ],
-  "message.keywordsTip2": [
-    [
-      "message",
-      "Możesz dodać lub usunąć słowa kluczowe, im bardziej precyzyjne słowa kluczowe, tym lepsza optymalizacja SEO."
-    ],
-    [
-      "description",
-      "Wskazówki dotyczące słów kluczowych strony"
-    ]
-  ],
-  "message.featuresChat": [
-    [
-      "message",
-      "Włącz lub wyłącz moduł funkcji czatu."
-    ],
-    [
-      "description",
-      "Opis funkcji czatu"
-    ]
-  ],
-  "message.featuresGrok": [
-    [
-      "message",
-      "Włącz lub wyłącz moduł funkcji Grok."
-    ],
-    [
-      "description",
-      "Opis funkcji Grok"
-    ]
-  ],
-  "message.featuresDeepseek": [
-    [
-      "message",
-      "Włącz lub wyłącz moduł funkcji Deepseek."
-    ],
-    [
-      "description",
-      "Opis funkcji Deepseek"
-    ]
-  ],
-  "message.featuresChatgpt": [
-    [
-      "message",
-      "Włącz lub wyłącz moduł funkcji ChatGPT."
-    ],
-    [
-      "description",
-      "Opis funkcji ChatGPT"
-    ]
-  ],
-  "message.featuresMidjourney": [
-    [
-      "message",
-      "Włącz lub wyłącz moduł funkcji Midjourney."
-    ],
-    [
-      "description",
-      "Opis funkcji Midjourney"
-    ]
-  ],
-  "message.featuresChatdoc": [
-    [
-      "message",
-      "Włącz lub wyłącz moduł funkcji Chatdoc."
-    ],
-    [
-      "description",
-      "Opis funkcji Chatdoc"
-    ]
-  ],
-  "message.featuresQrart": [
-    [
-      "message",
-      "Włącz lub wyłącz moduł funkcji Qrart."
-    ],
-    [
-      "description",
-      "Opis funkcji Qrart"
-    ]
-  ],
-  "message.featuresVeo": [
-    [
-      "message",
-      "Włącz lub wyłącz moduł funkcji Veo."
-    ],
-    [
-      "description",
-      "Opis funkcji Veo"
-    ]
-  ],
-  "message.featuresSora": [
-    [
-      "message",
-      "Włącz lub wyłącz moduł funkcji Sora."
-    ],
-    [
-      "description",
-      "Opis funkcji Sora"
-    ]
-  ],
-  "message.featuresSuno": [
-    [
-      "message",
-      "Włącz lub wyłącz moduł funkcji Suno."
-    ],
-    [
-      "description",
-      "Opis funkcji Suno"
-    ]
-  ],
-  "message.featuresPixverse": [
-    [
-      "message",
-      "Włącz lub wyłącz moduł funkcji Pixverse."
-    ],
-    [
-      "description",
-      "Opis funkcji Pixverse"
-    ]
-  ],
-  "message.featuresFlux": [
-    [
-      "message",
-      "Włącz lub wyłącz moduł funkcji FLux."
-    ],
-    [
-      "description",
-      "Opis funkcji FLux"
-    ]
-  ],
-  "message.featuresNanobanana": [
-    [
-      "message",
-      "Włącz lub wyłącz moduł funkcji Nano Banana."
-    ],
-    [
-      "description",
-      "Opis funkcji Nano Banana"
-    ]
-  ],
+  "field.featuresSeedream": {
+    "message": "SeeDream",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "field.featuresSeedance": {
+    "message": "SeeDance",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "field.featuresWan": {
+    "message": "Wan",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "field.featuresProducer": {
+    "message": "Producent",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "field.featuresKimi": {
+    "message": "Kimi",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "field.featuresSerp": {
+    "message": "SERP",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "field.featuresSupport": {
+    "message": "Wsparcie klienta",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "field.featuresI18n": {
+    "message": "Wsparcie wielojęzyczne",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "title.basicConfig": {
+    "message": "Podstawowa konfiguracja",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "title.seoConfig": {
+    "message": "Konfiguracja SEO",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "title.editAdmins": {
+    "message": "Edytuj administratorów",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "title.featuresConfig": {
+    "message": "Konfiguracja funkcji",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "title.editTitle": {
+    "message": "Edytuj tytuł",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "title.editOrigin": {
+    "message": "Edytuj domenę",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "title.editKeywords": {
+    "message": "Edytuj słowa kluczowe",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "title.editLogo": {
+    "message": "Edytuj logo",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "title.editFavicon": {
+    "message": "Edytuj favicon",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "title.editDescription": {
+    "message": "Edytuj opis",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "title.distributionConfig": {
+    "message": "Konfiguracja dystrybucji",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "title.editDistributionDefaultInviterId": {
+    "message": "Edytuj domyślnego zapraszającego",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "title.editDistributionForceInviterId": {
+    "message": "Edytuj wymuszonego zapraszającego",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "title.editQR": {
+    "message": "Edytuj QR kod",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "title.editUrl": {
+    "message": "Edytuj link",
+    "description": "Wyświetlane w tytule edytora"
+  },
+  "placeholder.title": {
+    "message": "Wprowadź tytuł strony",
+    "description": "Wyświetlane w edytorze"
+  },
+  "placeholder.origin": {
+    "message": "Wprowadź domenę strony",
+    "description": "Wyświetlane w edytorze"
+  },
+  "placeholder.editUrl": {
+    "message": "Wprowadź link",
+    "description": "Wyświetlane w edytorze"
+  },
+  "placeholder.description": {
+    "message": "Wprowadź opis strony",
+    "description": "Wyświetlane w edytorze"
+  },
+  "placeholder.keywords": {
+    "message": "Wprowadź słowa kluczowe",
+    "description": "Wyświetlane w edytorze"
+  },
+  "placeholder.editDistributionDefaultInviterId": {
+    "message": "Wprowadź domyślne ID zapraszającego",
+    "description": "Wyświetlane w edytorze"
+  },
+  "placeholder.editDistributionForceInviterId": {
+    "message": "Wprowadź wymuszone ID zapraszającego",
+    "description": "Wyświetlane w edytorze"
+  },
+  "message.uploadImageExceed": {
+    "message": "Przekroczono limit rozmiaru obrazu",
+    "description": "Komunikat o przekroczeniu limitu rozmiaru obrazu"
+  },
+  "message.uploadImageError": {
+    "message": "Błąd przesyłania obrazu",
+    "description": "Komunikat o błędzie przesyłania obrazu"
+  },
+  "message.editLogoTip": {
+    "message": "Zalecany rozmiar: 200*60px",
+    "description": "Wskazówki dotyczące przesyłania obrazu"
+  },
+  "message.editQRTip": {
+    "message": "Zalecany rozmiar: 200*200px",
+    "description": "Wskazówki dotyczące przesyłania obrazu"
+  },
+  "message.editFaviconTip": {
+    "message": "Zalecany rozmiar: 32*32px",
+    "description": "Wskazówki dotyczące przesyłania obrazu"
+  },
+  "message.editUrl": {
+    "message": "Wprowadź link",
+    "description": "Wskazówki dotyczące wprowadzania linku"
+  },
+  "message.atLeastOneAdmin": {
+    "message": "Zachowaj przynajmniej jednego administratora",
+    "description": "Komunikat o konieczności posiadania przynajmniej jednego administratora"
+  },
+  "message.distributionDefaultInviterIdTip": {
+    "message": "ID użytkownika domyślnego zapraszającego. Jeśli link dystrybucji nie zawiera parametru inviter_id, użyje tego ID jako zapraszającego.",
+    "description": "Wskazówki dotyczące domyślnego ID zapraszającego"
+  },
+  "message.distributionForceInviterIdTip": {
+    "message": "ID użytkownika wymuszonego zapraszającego. Jeśli to ID jest ustawione, niezależnie od tego, czy link dystrybucji zawiera parametr inviter_id, użyje tego ID jako zapraszającego.",
+    "description": "Wskazówki dotyczące wymuszonego ID zapraszającego"
+  },
+  "message.originTip": {
+    "message": "Domena strony, konfiguracja strony jest powiązana z domeną, nie można jej zmienić.",
+    "description": "Wskazówki dotyczące domeny strony"
+  },
+  "message.titleTip": {
+    "message": "Tytuł strony, wyświetlany na karcie przeglądarki.",
+    "description": "Wskazówki dotyczące tytułu strony"
+  },
+  "message.descriptionTip": {
+    "message": "Opis strony, znajduje się w metadanych strony, używany do optymalizacji SEO.",
+    "description": "Wskazówki dotyczące opisu strony"
+  },
+  "message.logoTip": {
+    "message": "Logo strony, wyświetlane na górze menu, gdy menu jest rozwinięte.",
+    "description": "Wskazówki dotyczące logo strony"
+  },
+  "message.faviconTip": {
+    "message": "Favicon strony, wyświetlany na karcie przeglądarki.",
+    "description": "Wskazówki dotyczące faviconu strony"
+  },
+  "message.adminsTip": {
+    "message": "ID administratorów strony, domyślnie pierwszy użytkownik tworzący stronę staje się administratorem, tylko administratorzy mogą zarządzać stroną.",
+    "description": "Wskazówki dotyczące administratorów strony"
+  },
+  "message.adminsTip2": {
+    "message": "Możesz dodać lub usunąć ID administratorów, ID użytkowników można znaleźć na https://auth.acedata.cloud",
+    "description": "Wskazówki dotyczące administratorów strony"
+  },
+  "message.keywordsTip": {
+    "message": "Słowa kluczowe strony, znajdują się w metadanych strony, używane do optymalizacji SEO.",
+    "description": "Wskazówki dotyczące słów kluczowych strony"
+  },
+  "message.keywordsTip2": {
+    "message": "Możesz dodać lub usunąć słowa kluczowe, im bardziej precyzyjne słowa kluczowe, tym lepsza optymalizacja SEO.",
+    "description": "Wskazówki dotyczące słów kluczowych strony"
+  },
+  "message.featuresChat": {
+    "message": "Włącz lub wyłącz moduł funkcji czatu.",
+    "description": "Opis funkcji czatu"
+  },
+  "message.featuresGrok": {
+    "message": "Włącz lub wyłącz moduł funkcji Grok.",
+    "description": "Opis funkcji Grok"
+  },
+  "message.featuresDeepseek": {
+    "message": "Włącz lub wyłącz moduł funkcji Deepseek.",
+    "description": "Opis funkcji Deepseek"
+  },
+  "message.featuresChatgpt": {
+    "message": "Włącz lub wyłącz moduł funkcji ChatGPT.",
+    "description": "Opis funkcji ChatGPT"
+  },
+  "message.featuresMidjourney": {
+    "message": "Włącz lub wyłącz moduł funkcji Midjourney.",
+    "description": "Opis funkcji Midjourney"
+  },
+  "message.featuresChatdoc": {
+    "message": "Włącz lub wyłącz moduł funkcji Chatdoc.",
+    "description": "Opis funkcji Chatdoc"
+  },
+  "message.featuresQrart": {
+    "message": "Włącz lub wyłącz moduł funkcji Qrart.",
+    "description": "Opis funkcji Qrart"
+  },
+  "message.featuresVeo": {
+    "message": "Włącz lub wyłącz moduł funkcji Veo.",
+    "description": "Opis funkcji Veo"
+  },
+  "message.featuresSora": {
+    "message": "Włącz lub wyłącz moduł funkcji Sora.",
+    "description": "Opis funkcji Sora"
+  },
+  "message.featuresSuno": {
+    "message": "Włącz lub wyłącz moduł funkcji Suno.",
+    "description": "Opis funkcji Suno"
+  },
+  "message.featuresPixverse": {
+    "message": "Włącz lub wyłącz moduł funkcji Pixverse.",
+    "description": "Opis funkcji Pixverse"
+  },
+  "message.featuresFlux": {
+    "message": "Włącz lub wyłącz moduł funkcji FLux.",
+    "description": "Opis funkcji FLux"
+  },
+  "message.featuresNanobanana": {
+    "message": "Włącz lub wyłącz moduł funkcji Nano Banana.",
+    "description": "Opis funkcji Nano Banana"
+  },
   "message.featuresOpenaiimage": {
     "message": "Toggle OpenAI Image feature module.",
     "description": "Description of the OpenAI Image feature"
   },
-  "message.featuresSeedream": [
-    [
-      "message",
-      "Włącz lub wyłącz moduł funkcji SeeDream."
-    ],
-    [
-      "description",
-      "Opis funkcji SeeDream"
-    ]
-  ],
-  "message.featuresSeedance": [
-    [
-      "message",
-      "Włącz lub wyłącz moduł funkcji SeeDance."
-    ],
-    [
-      "description",
-      "Opis funkcji SeeDance"
-    ]
-  ],
-  "message.featuresWan": [
-    [
-      "message",
-      "Włącz lub wyłącz moduł funkcji Wan."
-    ],
-    [
-      "description",
-      "Opis funkcji Wan"
-    ]
-  ],
-  "message.featuresProducer": [
-    [
-      "message",
-      "Włącz lub wyłącz moduł funkcji Producer."
-    ],
-    [
-      "description",
-      "Opis funkcji Producer"
-    ]
-  ],
-  "message.featuresKimi": [
-    [
-      "message",
-      "Włącz lub wyłącz moduł funkcji Kimi."
-    ],
-    [
-      "description",
-      "Opis funkcji Kimi"
-    ]
-  ],
-  "message.featuresSerp": [
-    [
-      "message",
-      "Włącz lub wyłącz moduł funkcji SERP."
-    ],
-    [
-      "description",
-      "Opis funkcji SERP"
-    ]
-  ],
-  "message.featuresLuma": [
-    [
-      "message",
-      "Włącz lub wyłącz moduł funkcji Luma."
-    ],
-    [
-      "description",
-      "Opis funkcji Luma"
-    ]
-  ],
-  "message.featuresPika": [
-    [
-      "message",
-      "Włącz lub wyłącz moduł funkcji Pika."
-    ],
-    [
-      "description",
-      "Opis funkcji Pika"
-    ]
-  ],
-  "message.featuresKling": [
-    [
-      "message",
-      "Włącz lub wyłącz moduł funkcji Kling."
-    ],
-    [
-      "description",
-      "Opis funkcji Kling"
-    ]
-  ],
-  "message.featuresHailuo": [
-    [
-      "message",
-      "Włącz lub wyłącz moduł funkcji Hailuo."
-    ],
-    [
-      "description",
-      "Opis funkcji Hailuo"
-    ]
-  ],
-  "message.featuresHeadshots": [
-    [
-      "message",
-      "Włącz lub wyłącz moduł funkcji AI zdjęcia identyfikacyjne."
-    ],
-    [
-      "description",
-      "Opis funkcji AI zdjęcia identyfikacyjne"
-    ]
-  ],
-  "message.featuresSupport": [
-    [
-      "message",
-      "Włącz lub wyłącz wsparcie klienta"
-    ],
-    [
-      "description",
-      "Opis funkcji wsparcia"
-    ]
-  ],
-  "message.featuresI18n": [
-    [
-      "message",
-      "Włącz lub wyłącz wsparcie wielojęzyczne, po wyłączeniu użytkownik może korzystać tylko z domyślnego języka."
-    ],
-    [
-      "description",
-      "Opis wsparcia wielojęzycznego"
-    ]
-  ],
-  "button.upload": [
-    [
-      "message",
-      "Prześlij"
-    ],
-    [
-      "description",
-      "Prześlij"
-    ]
-  ],
-  "button.enabled": [
-    [
-      "message",
-      "Włączone"
-    ],
-    [
-      "description",
-      "Tekst przełącznika, oznaczający, że jest włączone"
-    ]
-  ],
-  "button.disabled": [
-    [
-      "message",
-      "Wyłączone"
-    ],
-    [
-      "description",
-      "Tekst przełącznika, oznaczający, że jest wyłączone"
-    ]
-  ],
-  "field.featuresGemini": [
-    [
-      "message",
-      "Gemini"
-    ],
-    [
-      "description",
-      "Wyświetlane jako tytuł w polu edycji"
-    ]
-  ],
-  "message.featuresGemini": [
-    [
-      "message",
-      "Włącz lub wyłącz moduł funkcji Gemini."
-    ],
-    [
-      "description",
-      "Opis funkcji Gemini"
-    ]
-  ],
-  "field.featuresClaude": [
-    [
-      "message",
-      "Claude"
-    ],
-    [
-      "description",
-      "Wyświetlane jako tytuł w polu edycji"
-    ]
-  ],
-  "message.featuresClaude": [
-    [
-      "message",
-      "Włącz lub wyłącz moduł funkcji Claude."
-    ],
-    [
-      "description",
-      "Opis funkcji Claude"
-    ]
-  ]
+  "message.featuresSeedream": {
+    "message": "Włącz lub wyłącz moduł funkcji SeeDream.",
+    "description": "Opis funkcji SeeDream"
+  },
+  "message.featuresSeedance": {
+    "message": "Włącz lub wyłącz moduł funkcji SeeDance.",
+    "description": "Opis funkcji SeeDance"
+  },
+  "message.featuresWan": {
+    "message": "Włącz lub wyłącz moduł funkcji Wan.",
+    "description": "Opis funkcji Wan"
+  },
+  "message.featuresProducer": {
+    "message": "Włącz lub wyłącz moduł funkcji Producer.",
+    "description": "Opis funkcji Producer"
+  },
+  "message.featuresKimi": {
+    "message": "Włącz lub wyłącz moduł funkcji Kimi.",
+    "description": "Opis funkcji Kimi"
+  },
+  "message.featuresSerp": {
+    "message": "Włącz lub wyłącz moduł funkcji SERP.",
+    "description": "Opis funkcji SERP"
+  },
+  "message.featuresLuma": {
+    "message": "Włącz lub wyłącz moduł funkcji Luma.",
+    "description": "Opis funkcji Luma"
+  },
+  "message.featuresPika": {
+    "message": "Włącz lub wyłącz moduł funkcji Pika.",
+    "description": "Opis funkcji Pika"
+  },
+  "message.featuresKling": {
+    "message": "Włącz lub wyłącz moduł funkcji Kling.",
+    "description": "Opis funkcji Kling"
+  },
+  "message.featuresHailuo": {
+    "message": "Włącz lub wyłącz moduł funkcji Hailuo.",
+    "description": "Opis funkcji Hailuo"
+  },
+  "message.featuresHeadshots": {
+    "message": "Włącz lub wyłącz moduł funkcji AI zdjęcia identyfikacyjne.",
+    "description": "Opis funkcji AI zdjęcia identyfikacyjne"
+  },
+  "message.featuresSupport": {
+    "message": "Włącz lub wyłącz wsparcie klienta",
+    "description": "Opis funkcji wsparcia"
+  },
+  "message.featuresI18n": {
+    "message": "Włącz lub wyłącz wsparcie wielojęzyczne, po wyłączeniu użytkownik może korzystać tylko z domyślnego języka.",
+    "description": "Opis wsparcia wielojęzycznego"
+  },
+  "button.upload": {
+    "message": "Prześlij",
+    "description": "Prześlij"
+  },
+  "button.enabled": {
+    "message": "Włączone",
+    "description": "Tekst przełącznika, oznaczający, że jest włączone"
+  },
+  "button.disabled": {
+    "message": "Wyłączone",
+    "description": "Tekst przełącznika, oznaczający, że jest wyłączone"
+  },
+  "field.featuresGemini": {
+    "message": "Gemini",
+    "description": "Wyświetlane jako tytuł w polu edycji"
+  },
+  "message.featuresGemini": {
+    "message": "Włącz lub wyłącz moduł funkcji Gemini.",
+    "description": "Opis funkcji Gemini"
+  },
+  "field.featuresClaude": {
+    "message": "Claude",
+    "description": "Wyświetlane jako tytuł w polu edycji"
+  },
+  "message.featuresClaude": {
+    "message": "Włącz lub wyłącz moduł funkcji Claude.",
+    "description": "Opis funkcji Claude"
+  }
 }

--- a/src/i18n/pt/site.json
+++ b/src/i18n/pt/site.json
@@ -1,442 +1,1110 @@
 {
-  "field.title": {
-    "message": "Título do site",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "field.origin": {
-    "message": "Domínio do site",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "field.description": {
-    "message": "Descrição do site",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "field.keywords": {
-    "message": "Palavras-chave do site",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "field.logo": {
-    "message": "Logo do site",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "field.favicon": {
-    "message": "Favicon do site",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "field.qr": {
-    "message": "Código QR",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "field.url": {
-    "message": "Link",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "field.admins": {
-    "message": "ID dos administradores do site",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "field.distributionDefaultInviterId": {
-    "message": "ID do convidador padrão",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "field.distributionForceInviterId": {
-    "message": "ID do convidador forçado",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "field.featuresChat": {
-    "message": "Chat",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "field.featuresVeo": {
-    "message": "Veo",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "field.featuresSora": {
-    "message": "Sora",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "field.featuresGrok": {
-    "message": "Grok",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "field.featuresDeepseek": {
-    "message": "Deepseek",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "field.featuresChatgpt": {
-    "message": "ChatGPT",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "field.featuresMidjourney": {
-    "message": "Midjourney",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "field.featuresChatdoc": {
-    "message": "Chatdoc",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "field.featuresQrart": {
-    "message": "Qrart",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "field.featuresLuma": {
-    "message": "Luma",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "field.featuresPixverse": {
-    "message": "Pixverse",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "field.featuresPika": {
-    "message": "Pika",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "field.featuresKling": {
-    "message": "Kling",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "field.featuresHailuo": {
-    "message": "Hailuo",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "field.featuresHeadshots": {
-    "message": "Foto de identificação AI",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "field.featuresSuno": {
-    "message": "Suno",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "field.featuresFlux": {
-    "message": "Flux",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "field.featuresNanobanana": {
-    "message": "Nano Banana",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "field.featuresSeedream": {
-    "message": "SeeDream",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "field.featuresSeedance": {
-    "message": "SeeDance",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "field.featuresWan": {
-    "message": "Wan",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "field.featuresProducer": {
-    "message": "Produtor",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "field.featuresKimi": {
-    "message": "Kimi",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "field.featuresSerp": {
-    "message": "SERP",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "field.featuresSupport": {
-    "message": "Suporte ao cliente",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "field.featuresI18n": {
-    "message": "Suporte multilíngue",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "title.basicConfig": {
-    "message": "Configuração básica",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "title.seoConfig": {
-    "message": "Configuração de SEO",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "title.editAdmins": {
-    "message": "Editar administradores",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "title.featuresConfig": {
-    "message": "Configuração de funcionalidades",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "title.editTitle": {
-    "message": "Editar título",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "title.editOrigin": {
-    "message": "Editar domínio",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "title.editKeywords": {
-    "message": "Editar palavras-chave",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "title.editLogo": {
-    "message": "Editar logo",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "title.editFavicon": {
-    "message": "Editar favicon",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "title.editDescription": {
-    "message": "Editar descrição",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "title.distributionConfig": {
-    "message": "Configuração de distribuição",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "title.editDistributionDefaultInviterId": {
-    "message": "Editar convidador padrão",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "title.editDistributionForceInviterId": {
-    "message": "Editar convidador forçado",
-    "description": "Exibido como o título na caixa de edição"
-  },
-  "title.editQR": {
-    "message": "Editar QR Code",
-    "description": "Título exibido na caixa de edição"
-  },
-  "title.editUrl": {
-    "message": "Editar Link",
-    "description": "Título exibido na caixa de edição"
-  },
-  "placeholder.title": {
-    "message": "Digite o título do site",
-    "description": "Exibido na caixa de edição"
-  },
-  "placeholder.origin": {
-    "message": "Digite o domínio do site",
-    "description": "Exibido na caixa de edição"
-  },
-  "placeholder.editUrl": {
-    "message": "Digite o link",
-    "description": "Exibido na caixa de edição"
-  },
-  "placeholder.description": {
-    "message": "Digite a descrição do site",
-    "description": "Exibido na caixa de edição"
-  },
-  "placeholder.keywords": {
-    "message": "Digite as palavras-chave do site",
-    "description": "Exibido na caixa de edição"
-  },
-  "placeholder.editDistributionDefaultInviterId": {
-    "message": "Digite o ID do convidador padrão",
-    "description": "Exibido na caixa de edição"
-  },
-  "placeholder.editDistributionForceInviterId": {
-    "message": "Digite o ID do convidador forçado",
-    "description": "Exibido na caixa de edição"
-  },
-  "message.uploadImageExceed": {
-    "message": "Imagem enviada excede o limite",
-    "description": "Mensagem de aviso quando a imagem enviada excede o limite"
-  },
-  "message.uploadImageError": {
-    "message": "Erro ao enviar imagem",
-    "description": "Mensagem de erro ao enviar imagem"
-  },
-  "message.editLogoTip": {
-    "message": "Tamanho recomendado: 200*60px",
-    "description": "Mensagem de dica para o upload da imagem"
-  },
-  "message.editQRTip": {
-    "message": "Tamanho recomendado: 200*200px",
-    "description": "Mensagem de dica para o upload da imagem"
-  },
-  "message.editFaviconTip": {
-    "message": "Tamanho recomendado: 32*32px",
-    "description": "Mensagem de dica para o upload da imagem"
-  },
-  "message.editUrl": {
-    "message": "Digite o link",
-    "description": "Mensagem de dica para inserir o link"
-  },
-  "message.atLeastOneAdmin": {
-    "message": "Mantenha pelo menos um administrador",
-    "description": "Mensagem de aviso para manter pelo menos um administrador"
-  },
-  "message.distributionDefaultInviterIdTip": {
-    "message": "ID do usuário do convidador padrão. Se o link de distribuição não incluir o parâmetro inviter_id, este ID será usado como convidador.",
-    "description": "Mensagem de dica para o ID do convidador padrão"
-  },
-  "message.distributionForceInviterIdTip": {
-    "message": "ID do usuário do convidador forçado. Se este ID for definido, será usado como convidador, independentemente de o link de distribuição incluir o parâmetro inviter_id.",
-    "description": "Mensagem de dica para o ID do convidador forçado"
-  },
-  "message.originTip": {
-    "message": "Domínio do site. A configuração do site está vinculada ao domínio e não pode ser alterada.",
-    "description": "Mensagem de dica para o domínio do site"
-  },
-  "message.titleTip": {
-    "message": "Título do site, exibido na aba do navegador.",
-    "description": "Mensagem de dica para o título do site"
-  },
-  "message.descriptionTip": {
-    "message": "Descrição do site, localizada nas metainformações do site, usada para otimização de SEO.",
-    "description": "Mensagem de dica para a descrição do site"
-  },
-  "message.logoTip": {
-    "message": "Logo do site, exibido no topo do menu do site quando o menu é expandido.",
-    "description": "Mensagem de dica para o logo do site"
-  },
-  "message.faviconTip": {
-    "message": "Favicon do site, exibido na aba do navegador.",
-    "description": "Mensagem de dica para o favicon do site"
-  },
-  "message.adminsTip": {
-    "message": "IDs dos administradores do site. O usuário que cria o site pela primeira vez se torna o administrador. Apenas administradores podem gerenciar o site.",
-    "description": "Mensagem de dica para os administradores do site"
-  },
-  "message.adminsTip2": {
-    "message": "Você pode adicionar ou remover IDs de administradores aqui. Veja os IDs de usuários em https://auth.acedata.cloud",
-    "description": "Mensagem de dica para os administradores do site"
-  },
-  "message.keywordsTip": {
-    "message": "Palavras-chave do site, localizadas nas metainformações do site, usadas para otimização de SEO.",
-    "description": "Mensagem de dica para as palavras-chave do site"
-  },
-  "message.keywordsTip2": {
-    "message": "Você pode adicionar ou remover palavras-chave do site aqui. Quanto mais precisas forem as palavras-chave, melhor para a otimização de SEO.",
-    "description": "Mensagem de dica para as palavras-chave do site"
-  },
-  "message.featuresChat": {
-    "message": "Ativar ou desativar o módulo de Chat.",
-    "description": "Descrição da funcionalidade de Chat"
-  },
-  "message.featuresGrok": {
-    "message": "Ativar ou desativar o módulo de Grok.",
-    "description": "Descrição da funcionalidade de Grok"
-  },
-  "message.featuresDeepseek": {
-    "message": "Ativar ou desativar o módulo de Deepseek.",
-    "description": "Descrição da funcionalidade de Deepseek"
-  },
-  "message.featuresChatgpt": {
-    "message": "Ativar ou desativar o módulo de ChatGPT.",
-    "description": "Descrição da funcionalidade de ChatGPT"
-  },
-  "message.featuresMidjourney": {
-    "message": "Ativar ou desativar o módulo de Midjourney.",
-    "description": "Descrição da funcionalidade de Midjourney"
-  },
-  "message.featuresChatdoc": {
-    "message": "Ativar ou desativar o módulo de Chatdoc.",
-    "description": "Descrição da funcionalidade de Chatdoc"
-  },
-  "message.featuresQrart": {
-    "message": "Ativar ou desativar o módulo de Qrart.",
-    "description": "Descrição da funcionalidade de Qrart"
-  },
-  "message.featuresVeo": {
-    "message": "Ativar ou desativar o módulo de Veo.",
-    "description": "Descrição da funcionalidade de Veo"
-  },
-  "message.featuresSora": {
-    "message": "Ativar ou desativar o módulo de Sora.",
-    "description": "Descrição da funcionalidade de Sora"
-  },
-  "message.featuresSuno": {
-    "message": "Ativar ou desativar o módulo de Suno.",
-    "description": "Descrição da funcionalidade de Suno"
-  },
-  "message.featuresPixverse": {
-    "message": "Ativar ou desativar o módulo de recursos do Pixverse.",
-    "description": "Descrição da funcionalidade do Pixverse"
-  },
-  "message.featuresFlux": {
-    "message": "Ativar ou desativar o módulo de recursos do FLux.",
-    "description": "Descrição da funcionalidade do FLux"
-  },
-  "message.featuresNanobanana": {
-    "message": "Ativar ou desativar o módulo de recursos do Nano Banana.",
-    "description": "Descrição da funcionalidade do Nano Banana"
-  },
-  "message.featuresSeedream": {
-    "message": "Ativar ou desativar o módulo de recursos do SeeDream.",
-    "description": "Descrição da funcionalidade do SeeDream"
-  },
-  "message.featuresSeedance": {
-    "message": "Ativar ou desativar o módulo de recursos do SeeDance.",
-    "description": "Descrição da funcionalidade do SeeDance"
-  },
-  "message.featuresWan": {
-    "message": "Ativar ou desativar o módulo de recursos do Wan.",
-    "description": "Descrição da funcionalidade do Wan"
-  },
-  "message.featuresProducer": {
-    "message": "Ativar ou desativar o módulo de recursos do Producer.",
-    "description": "Descrição da funcionalidade do Producer"
-  },
-  "message.featuresKimi": {
-    "message": "Ativar ou desativar o módulo de recursos do Kimi.",
-    "description": "Descrição da funcionalidade do Kimi"
-  },
-  "message.featuresSerp": {
-    "message": "Ativar ou desativar o módulo de recursos do SERP.",
-    "description": "Descrição da funcionalidade do SERP"
-  },
-  "message.featuresLuma": {
-    "message": "Ativar ou desativar o módulo de recursos do Luma.",
-    "description": "Descrição da funcionalidade do Luma"
-  },
-  "message.featuresPika": {
-    "message": "Ativar ou desativar o módulo de recursos do Pika.",
-    "description": "Descrição da funcionalidade do Pika"
-  },
-  "message.featuresKling": {
-    "message": "Ativar ou desativar o módulo de recursos do Kling.",
-    "description": "Descrição da funcionalidade do Kling"
-  },
-  "message.featuresHailuo": {
-    "message": "Ativar ou desativar o módulo de recursos do Hailuo.",
-    "description": "Descrição da funcionalidade do Hailuo"
-  },
-  "message.featuresHeadshots": {
-    "message": "Ativar ou desativar o módulo de recursos de fotos de identificação AI.",
-    "description": "Descrição da funcionalidade de fotos de identificação AI"
-  },
-  "message.featuresSupport": {
-    "message": "Ativar ou desativar o suporte ao cliente",
-    "description": "Descrição da funcionalidade de suporte"
-  },
-  "message.featuresI18n": {
-    "message": "Ativar ou desativar o suporte a múltiplos idiomas. Se desativado, o usuário só poderá usar o idioma padrão.",
-    "description": "Descrição do suporte a múltiplos idiomas"
-  },
-  "button.upload": {
-    "message": "Enviar",
-    "description": "Enviar"
-  },
-  "button.enabled": {
-    "message": "Ativado",
-    "description": "Texto do botão que indica que está ativado"
-  },
-  "button.disabled": {
-    "message": "Desativado",
-    "description": "Texto do botão que indica que está desativado"
-  },
-  "field.featuresGemini": {
-    "message": "Gemini",
-    "description": "Exibido como título na caixa de edição"
-  },
-  "message.featuresGemini": {
-    "message": "Ativar ou desativar o módulo de recursos do Gemini.",
-    "description": "Descrição da funcionalidade do Gemini"
-  },
-  "field.featuresClaude": {
-    "message": "Claude",
-    "description": "Exibido como título na caixa de edição"
-  },
-  "message.featuresClaude": {
-    "message": "Ativar ou desativar o módulo de recursos do Claude.",
-    "description": "Descrição da funcionalidade do Claude"
-  }
+  "field.title": [
+    [
+      "message",
+      "Título do site"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "field.origin": [
+    [
+      "message",
+      "Domínio do site"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "field.description": [
+    [
+      "message",
+      "Descrição do site"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "field.keywords": [
+    [
+      "message",
+      "Palavras-chave do site"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "field.logo": [
+    [
+      "message",
+      "Logo do site"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "field.favicon": [
+    [
+      "message",
+      "Favicon do site"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "field.qr": [
+    [
+      "message",
+      "Código QR"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "field.url": [
+    [
+      "message",
+      "Link"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "field.admins": [
+    [
+      "message",
+      "ID dos administradores do site"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "field.distributionDefaultInviterId": [
+    [
+      "message",
+      "ID do convidador padrão"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "field.distributionForceInviterId": [
+    [
+      "message",
+      "ID do convidador forçado"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "field.featuresChat": [
+    [
+      "message",
+      "Chat"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "field.featuresVeo": [
+    [
+      "message",
+      "Veo"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "field.featuresSora": [
+    [
+      "message",
+      "Sora"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "field.featuresGrok": [
+    [
+      "message",
+      "Grok"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "field.featuresDeepseek": [
+    [
+      "message",
+      "Deepseek"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "field.featuresChatgpt": [
+    [
+      "message",
+      "ChatGPT"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "field.featuresMidjourney": [
+    [
+      "message",
+      "Midjourney"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "field.featuresChatdoc": [
+    [
+      "message",
+      "Chatdoc"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "field.featuresQrart": [
+    [
+      "message",
+      "Qrart"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "field.featuresLuma": [
+    [
+      "message",
+      "Luma"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "field.featuresPixverse": [
+    [
+      "message",
+      "Pixverse"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "field.featuresPika": [
+    [
+      "message",
+      "Pika"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "field.featuresKling": [
+    [
+      "message",
+      "Kling"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "field.featuresHailuo": [
+    [
+      "message",
+      "Hailuo"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "field.featuresHeadshots": [
+    [
+      "message",
+      "Foto de identificação AI"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "field.featuresSuno": [
+    [
+      "message",
+      "Suno"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "field.featuresFlux": [
+    [
+      "message",
+      "Flux"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "field.featuresNanobanana": [
+    [
+      "message",
+      "Nano Banana"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "field.featuresOpenaiimage": {
+    "message": "OpenAI Image",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresSeedream": [
+    [
+      "message",
+      "SeeDream"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "field.featuresSeedance": [
+    [
+      "message",
+      "SeeDance"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "field.featuresWan": [
+    [
+      "message",
+      "Wan"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "field.featuresProducer": [
+    [
+      "message",
+      "Produtor"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "field.featuresKimi": [
+    [
+      "message",
+      "Kimi"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "field.featuresSerp": [
+    [
+      "message",
+      "SERP"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "field.featuresSupport": [
+    [
+      "message",
+      "Suporte ao cliente"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "field.featuresI18n": [
+    [
+      "message",
+      "Suporte multilíngue"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "title.basicConfig": [
+    [
+      "message",
+      "Configuração básica"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "title.seoConfig": [
+    [
+      "message",
+      "Configuração de SEO"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "title.editAdmins": [
+    [
+      "message",
+      "Editar administradores"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "title.featuresConfig": [
+    [
+      "message",
+      "Configuração de funcionalidades"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "title.editTitle": [
+    [
+      "message",
+      "Editar título"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "title.editOrigin": [
+    [
+      "message",
+      "Editar domínio"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "title.editKeywords": [
+    [
+      "message",
+      "Editar palavras-chave"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "title.editLogo": [
+    [
+      "message",
+      "Editar logo"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "title.editFavicon": [
+    [
+      "message",
+      "Editar favicon"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "title.editDescription": [
+    [
+      "message",
+      "Editar descrição"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "title.distributionConfig": [
+    [
+      "message",
+      "Configuração de distribuição"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "title.editDistributionDefaultInviterId": [
+    [
+      "message",
+      "Editar convidador padrão"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "title.editDistributionForceInviterId": [
+    [
+      "message",
+      "Editar convidador forçado"
+    ],
+    [
+      "description",
+      "Exibido como o título na caixa de edição"
+    ]
+  ],
+  "title.editQR": [
+    [
+      "message",
+      "Editar QR Code"
+    ],
+    [
+      "description",
+      "Título exibido na caixa de edição"
+    ]
+  ],
+  "title.editUrl": [
+    [
+      "message",
+      "Editar Link"
+    ],
+    [
+      "description",
+      "Título exibido na caixa de edição"
+    ]
+  ],
+  "placeholder.title": [
+    [
+      "message",
+      "Digite o título do site"
+    ],
+    [
+      "description",
+      "Exibido na caixa de edição"
+    ]
+  ],
+  "placeholder.origin": [
+    [
+      "message",
+      "Digite o domínio do site"
+    ],
+    [
+      "description",
+      "Exibido na caixa de edição"
+    ]
+  ],
+  "placeholder.editUrl": [
+    [
+      "message",
+      "Digite o link"
+    ],
+    [
+      "description",
+      "Exibido na caixa de edição"
+    ]
+  ],
+  "placeholder.description": [
+    [
+      "message",
+      "Digite a descrição do site"
+    ],
+    [
+      "description",
+      "Exibido na caixa de edição"
+    ]
+  ],
+  "placeholder.keywords": [
+    [
+      "message",
+      "Digite as palavras-chave do site"
+    ],
+    [
+      "description",
+      "Exibido na caixa de edição"
+    ]
+  ],
+  "placeholder.editDistributionDefaultInviterId": [
+    [
+      "message",
+      "Digite o ID do convidador padrão"
+    ],
+    [
+      "description",
+      "Exibido na caixa de edição"
+    ]
+  ],
+  "placeholder.editDistributionForceInviterId": [
+    [
+      "message",
+      "Digite o ID do convidador forçado"
+    ],
+    [
+      "description",
+      "Exibido na caixa de edição"
+    ]
+  ],
+  "message.uploadImageExceed": [
+    [
+      "message",
+      "Imagem enviada excede o limite"
+    ],
+    [
+      "description",
+      "Mensagem de aviso quando a imagem enviada excede o limite"
+    ]
+  ],
+  "message.uploadImageError": [
+    [
+      "message",
+      "Erro ao enviar imagem"
+    ],
+    [
+      "description",
+      "Mensagem de erro ao enviar imagem"
+    ]
+  ],
+  "message.editLogoTip": [
+    [
+      "message",
+      "Tamanho recomendado: 200*60px"
+    ],
+    [
+      "description",
+      "Mensagem de dica para o upload da imagem"
+    ]
+  ],
+  "message.editQRTip": [
+    [
+      "message",
+      "Tamanho recomendado: 200*200px"
+    ],
+    [
+      "description",
+      "Mensagem de dica para o upload da imagem"
+    ]
+  ],
+  "message.editFaviconTip": [
+    [
+      "message",
+      "Tamanho recomendado: 32*32px"
+    ],
+    [
+      "description",
+      "Mensagem de dica para o upload da imagem"
+    ]
+  ],
+  "message.editUrl": [
+    [
+      "message",
+      "Digite o link"
+    ],
+    [
+      "description",
+      "Mensagem de dica para inserir o link"
+    ]
+  ],
+  "message.atLeastOneAdmin": [
+    [
+      "message",
+      "Mantenha pelo menos um administrador"
+    ],
+    [
+      "description",
+      "Mensagem de aviso para manter pelo menos um administrador"
+    ]
+  ],
+  "message.distributionDefaultInviterIdTip": [
+    [
+      "message",
+      "ID do usuário do convidador padrão. Se o link de distribuição não incluir o parâmetro inviter_id, este ID será usado como convidador."
+    ],
+    [
+      "description",
+      "Mensagem de dica para o ID do convidador padrão"
+    ]
+  ],
+  "message.distributionForceInviterIdTip": [
+    [
+      "message",
+      "ID do usuário do convidador forçado. Se este ID for definido, será usado como convidador, independentemente de o link de distribuição incluir o parâmetro inviter_id."
+    ],
+    [
+      "description",
+      "Mensagem de dica para o ID do convidador forçado"
+    ]
+  ],
+  "message.originTip": [
+    [
+      "message",
+      "Domínio do site. A configuração do site está vinculada ao domínio e não pode ser alterada."
+    ],
+    [
+      "description",
+      "Mensagem de dica para o domínio do site"
+    ]
+  ],
+  "message.titleTip": [
+    [
+      "message",
+      "Título do site, exibido na aba do navegador."
+    ],
+    [
+      "description",
+      "Mensagem de dica para o título do site"
+    ]
+  ],
+  "message.descriptionTip": [
+    [
+      "message",
+      "Descrição do site, localizada nas metainformações do site, usada para otimização de SEO."
+    ],
+    [
+      "description",
+      "Mensagem de dica para a descrição do site"
+    ]
+  ],
+  "message.logoTip": [
+    [
+      "message",
+      "Logo do site, exibido no topo do menu do site quando o menu é expandido."
+    ],
+    [
+      "description",
+      "Mensagem de dica para o logo do site"
+    ]
+  ],
+  "message.faviconTip": [
+    [
+      "message",
+      "Favicon do site, exibido na aba do navegador."
+    ],
+    [
+      "description",
+      "Mensagem de dica para o favicon do site"
+    ]
+  ],
+  "message.adminsTip": [
+    [
+      "message",
+      "IDs dos administradores do site. O usuário que cria o site pela primeira vez se torna o administrador. Apenas administradores podem gerenciar o site."
+    ],
+    [
+      "description",
+      "Mensagem de dica para os administradores do site"
+    ]
+  ],
+  "message.adminsTip2": [
+    [
+      "message",
+      "Você pode adicionar ou remover IDs de administradores aqui. Veja os IDs de usuários em https://auth.acedata.cloud"
+    ],
+    [
+      "description",
+      "Mensagem de dica para os administradores do site"
+    ]
+  ],
+  "message.keywordsTip": [
+    [
+      "message",
+      "Palavras-chave do site, localizadas nas metainformações do site, usadas para otimização de SEO."
+    ],
+    [
+      "description",
+      "Mensagem de dica para as palavras-chave do site"
+    ]
+  ],
+  "message.keywordsTip2": [
+    [
+      "message",
+      "Você pode adicionar ou remover palavras-chave do site aqui. Quanto mais precisas forem as palavras-chave, melhor para a otimização de SEO."
+    ],
+    [
+      "description",
+      "Mensagem de dica para as palavras-chave do site"
+    ]
+  ],
+  "message.featuresChat": [
+    [
+      "message",
+      "Ativar ou desativar o módulo de Chat."
+    ],
+    [
+      "description",
+      "Descrição da funcionalidade de Chat"
+    ]
+  ],
+  "message.featuresGrok": [
+    [
+      "message",
+      "Ativar ou desativar o módulo de Grok."
+    ],
+    [
+      "description",
+      "Descrição da funcionalidade de Grok"
+    ]
+  ],
+  "message.featuresDeepseek": [
+    [
+      "message",
+      "Ativar ou desativar o módulo de Deepseek."
+    ],
+    [
+      "description",
+      "Descrição da funcionalidade de Deepseek"
+    ]
+  ],
+  "message.featuresChatgpt": [
+    [
+      "message",
+      "Ativar ou desativar o módulo de ChatGPT."
+    ],
+    [
+      "description",
+      "Descrição da funcionalidade de ChatGPT"
+    ]
+  ],
+  "message.featuresMidjourney": [
+    [
+      "message",
+      "Ativar ou desativar o módulo de Midjourney."
+    ],
+    [
+      "description",
+      "Descrição da funcionalidade de Midjourney"
+    ]
+  ],
+  "message.featuresChatdoc": [
+    [
+      "message",
+      "Ativar ou desativar o módulo de Chatdoc."
+    ],
+    [
+      "description",
+      "Descrição da funcionalidade de Chatdoc"
+    ]
+  ],
+  "message.featuresQrart": [
+    [
+      "message",
+      "Ativar ou desativar o módulo de Qrart."
+    ],
+    [
+      "description",
+      "Descrição da funcionalidade de Qrart"
+    ]
+  ],
+  "message.featuresVeo": [
+    [
+      "message",
+      "Ativar ou desativar o módulo de Veo."
+    ],
+    [
+      "description",
+      "Descrição da funcionalidade de Veo"
+    ]
+  ],
+  "message.featuresSora": [
+    [
+      "message",
+      "Ativar ou desativar o módulo de Sora."
+    ],
+    [
+      "description",
+      "Descrição da funcionalidade de Sora"
+    ]
+  ],
+  "message.featuresSuno": [
+    [
+      "message",
+      "Ativar ou desativar o módulo de Suno."
+    ],
+    [
+      "description",
+      "Descrição da funcionalidade de Suno"
+    ]
+  ],
+  "message.featuresPixverse": [
+    [
+      "message",
+      "Ativar ou desativar o módulo de recursos do Pixverse."
+    ],
+    [
+      "description",
+      "Descrição da funcionalidade do Pixverse"
+    ]
+  ],
+  "message.featuresFlux": [
+    [
+      "message",
+      "Ativar ou desativar o módulo de recursos do FLux."
+    ],
+    [
+      "description",
+      "Descrição da funcionalidade do FLux"
+    ]
+  ],
+  "message.featuresNanobanana": [
+    [
+      "message",
+      "Ativar ou desativar o módulo de recursos do Nano Banana."
+    ],
+    [
+      "description",
+      "Descrição da funcionalidade do Nano Banana"
+    ]
+  ],
+  "message.featuresOpenaiimage": {
+    "message": "Toggle OpenAI Image feature module.",
+    "description": "Description of the OpenAI Image feature"
+  },
+  "message.featuresSeedream": [
+    [
+      "message",
+      "Ativar ou desativar o módulo de recursos do SeeDream."
+    ],
+    [
+      "description",
+      "Descrição da funcionalidade do SeeDream"
+    ]
+  ],
+  "message.featuresSeedance": [
+    [
+      "message",
+      "Ativar ou desativar o módulo de recursos do SeeDance."
+    ],
+    [
+      "description",
+      "Descrição da funcionalidade do SeeDance"
+    ]
+  ],
+  "message.featuresWan": [
+    [
+      "message",
+      "Ativar ou desativar o módulo de recursos do Wan."
+    ],
+    [
+      "description",
+      "Descrição da funcionalidade do Wan"
+    ]
+  ],
+  "message.featuresProducer": [
+    [
+      "message",
+      "Ativar ou desativar o módulo de recursos do Producer."
+    ],
+    [
+      "description",
+      "Descrição da funcionalidade do Producer"
+    ]
+  ],
+  "message.featuresKimi": [
+    [
+      "message",
+      "Ativar ou desativar o módulo de recursos do Kimi."
+    ],
+    [
+      "description",
+      "Descrição da funcionalidade do Kimi"
+    ]
+  ],
+  "message.featuresSerp": [
+    [
+      "message",
+      "Ativar ou desativar o módulo de recursos do SERP."
+    ],
+    [
+      "description",
+      "Descrição da funcionalidade do SERP"
+    ]
+  ],
+  "message.featuresLuma": [
+    [
+      "message",
+      "Ativar ou desativar o módulo de recursos do Luma."
+    ],
+    [
+      "description",
+      "Descrição da funcionalidade do Luma"
+    ]
+  ],
+  "message.featuresPika": [
+    [
+      "message",
+      "Ativar ou desativar o módulo de recursos do Pika."
+    ],
+    [
+      "description",
+      "Descrição da funcionalidade do Pika"
+    ]
+  ],
+  "message.featuresKling": [
+    [
+      "message",
+      "Ativar ou desativar o módulo de recursos do Kling."
+    ],
+    [
+      "description",
+      "Descrição da funcionalidade do Kling"
+    ]
+  ],
+  "message.featuresHailuo": [
+    [
+      "message",
+      "Ativar ou desativar o módulo de recursos do Hailuo."
+    ],
+    [
+      "description",
+      "Descrição da funcionalidade do Hailuo"
+    ]
+  ],
+  "message.featuresHeadshots": [
+    [
+      "message",
+      "Ativar ou desativar o módulo de recursos de fotos de identificação AI."
+    ],
+    [
+      "description",
+      "Descrição da funcionalidade de fotos de identificação AI"
+    ]
+  ],
+  "message.featuresSupport": [
+    [
+      "message",
+      "Ativar ou desativar o suporte ao cliente"
+    ],
+    [
+      "description",
+      "Descrição da funcionalidade de suporte"
+    ]
+  ],
+  "message.featuresI18n": [
+    [
+      "message",
+      "Ativar ou desativar o suporte a múltiplos idiomas. Se desativado, o usuário só poderá usar o idioma padrão."
+    ],
+    [
+      "description",
+      "Descrição do suporte a múltiplos idiomas"
+    ]
+  ],
+  "button.upload": [
+    [
+      "message",
+      "Enviar"
+    ],
+    [
+      "description",
+      "Enviar"
+    ]
+  ],
+  "button.enabled": [
+    [
+      "message",
+      "Ativado"
+    ],
+    [
+      "description",
+      "Texto do botão que indica que está ativado"
+    ]
+  ],
+  "button.disabled": [
+    [
+      "message",
+      "Desativado"
+    ],
+    [
+      "description",
+      "Texto do botão que indica que está desativado"
+    ]
+  ],
+  "field.featuresGemini": [
+    [
+      "message",
+      "Gemini"
+    ],
+    [
+      "description",
+      "Exibido como título na caixa de edição"
+    ]
+  ],
+  "message.featuresGemini": [
+    [
+      "message",
+      "Ativar ou desativar o módulo de recursos do Gemini."
+    ],
+    [
+      "description",
+      "Descrição da funcionalidade do Gemini"
+    ]
+  ],
+  "field.featuresClaude": [
+    [
+      "message",
+      "Claude"
+    ],
+    [
+      "description",
+      "Exibido como título na caixa de edição"
+    ]
+  ],
+  "message.featuresClaude": [
+    [
+      "message",
+      "Ativar ou desativar o módulo de recursos do Claude."
+    ],
+    [
+      "description",
+      "Descrição da funcionalidade do Claude"
+    ]
+  ]
 }

--- a/src/i18n/pt/site.json
+++ b/src/i18n/pt/site.json
@@ -1,1110 +1,450 @@
 {
-  "field.title": [
-    [
-      "message",
-      "Título do site"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "field.origin": [
-    [
-      "message",
-      "Domínio do site"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "field.description": [
-    [
-      "message",
-      "Descrição do site"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "field.keywords": [
-    [
-      "message",
-      "Palavras-chave do site"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "field.logo": [
-    [
-      "message",
-      "Logo do site"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "field.favicon": [
-    [
-      "message",
-      "Favicon do site"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "field.qr": [
-    [
-      "message",
-      "Código QR"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "field.url": [
-    [
-      "message",
-      "Link"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "field.admins": [
-    [
-      "message",
-      "ID dos administradores do site"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "field.distributionDefaultInviterId": [
-    [
-      "message",
-      "ID do convidador padrão"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "field.distributionForceInviterId": [
-    [
-      "message",
-      "ID do convidador forçado"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "field.featuresChat": [
-    [
-      "message",
-      "Chat"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "field.featuresVeo": [
-    [
-      "message",
-      "Veo"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "field.featuresSora": [
-    [
-      "message",
-      "Sora"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "field.featuresGrok": [
-    [
-      "message",
-      "Grok"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "field.featuresDeepseek": [
-    [
-      "message",
-      "Deepseek"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "field.featuresChatgpt": [
-    [
-      "message",
-      "ChatGPT"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "field.featuresMidjourney": [
-    [
-      "message",
-      "Midjourney"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "field.featuresChatdoc": [
-    [
-      "message",
-      "Chatdoc"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "field.featuresQrart": [
-    [
-      "message",
-      "Qrart"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "field.featuresLuma": [
-    [
-      "message",
-      "Luma"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "field.featuresPixverse": [
-    [
-      "message",
-      "Pixverse"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "field.featuresPika": [
-    [
-      "message",
-      "Pika"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "field.featuresKling": [
-    [
-      "message",
-      "Kling"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "field.featuresHailuo": [
-    [
-      "message",
-      "Hailuo"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "field.featuresHeadshots": [
-    [
-      "message",
-      "Foto de identificação AI"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "field.featuresSuno": [
-    [
-      "message",
-      "Suno"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "field.featuresFlux": [
-    [
-      "message",
-      "Flux"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "field.featuresNanobanana": [
-    [
-      "message",
-      "Nano Banana"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
+  "field.title": {
+    "message": "Título do site",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "field.origin": {
+    "message": "Domínio do site",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "field.description": {
+    "message": "Descrição do site",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "field.keywords": {
+    "message": "Palavras-chave do site",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "field.logo": {
+    "message": "Logo do site",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "field.favicon": {
+    "message": "Favicon do site",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "field.qr": {
+    "message": "Código QR",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "field.url": {
+    "message": "Link",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "field.admins": {
+    "message": "ID dos administradores do site",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "field.distributionDefaultInviterId": {
+    "message": "ID do convidador padrão",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "field.distributionForceInviterId": {
+    "message": "ID do convidador forçado",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "field.featuresChat": {
+    "message": "Chat",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "field.featuresVeo": {
+    "message": "Veo",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "field.featuresSora": {
+    "message": "Sora",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "field.featuresGrok": {
+    "message": "Grok",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "field.featuresDeepseek": {
+    "message": "Deepseek",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "field.featuresChatgpt": {
+    "message": "ChatGPT",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "field.featuresMidjourney": {
+    "message": "Midjourney",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "field.featuresChatdoc": {
+    "message": "Chatdoc",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "field.featuresQrart": {
+    "message": "Qrart",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "field.featuresLuma": {
+    "message": "Luma",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "field.featuresPixverse": {
+    "message": "Pixverse",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "field.featuresPika": {
+    "message": "Pika",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "field.featuresKling": {
+    "message": "Kling",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "field.featuresHailuo": {
+    "message": "Hailuo",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "field.featuresHeadshots": {
+    "message": "Foto de identificação AI",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "field.featuresSuno": {
+    "message": "Suno",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "field.featuresFlux": {
+    "message": "Flux",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "field.featuresNanobanana": {
+    "message": "Nano Banana",
+    "description": "Exibido como o título na caixa de edição"
+  },
   "field.featuresOpenaiimage": {
     "message": "OpenAI Image",
     "description": "Displayed as the title in the editing box"
   },
-  "field.featuresSeedream": [
-    [
-      "message",
-      "SeeDream"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "field.featuresSeedance": [
-    [
-      "message",
-      "SeeDance"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "field.featuresWan": [
-    [
-      "message",
-      "Wan"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "field.featuresProducer": [
-    [
-      "message",
-      "Produtor"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "field.featuresKimi": [
-    [
-      "message",
-      "Kimi"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "field.featuresSerp": [
-    [
-      "message",
-      "SERP"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "field.featuresSupport": [
-    [
-      "message",
-      "Suporte ao cliente"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "field.featuresI18n": [
-    [
-      "message",
-      "Suporte multilíngue"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "title.basicConfig": [
-    [
-      "message",
-      "Configuração básica"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "title.seoConfig": [
-    [
-      "message",
-      "Configuração de SEO"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "title.editAdmins": [
-    [
-      "message",
-      "Editar administradores"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "title.featuresConfig": [
-    [
-      "message",
-      "Configuração de funcionalidades"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "title.editTitle": [
-    [
-      "message",
-      "Editar título"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "title.editOrigin": [
-    [
-      "message",
-      "Editar domínio"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "title.editKeywords": [
-    [
-      "message",
-      "Editar palavras-chave"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "title.editLogo": [
-    [
-      "message",
-      "Editar logo"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "title.editFavicon": [
-    [
-      "message",
-      "Editar favicon"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "title.editDescription": [
-    [
-      "message",
-      "Editar descrição"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "title.distributionConfig": [
-    [
-      "message",
-      "Configuração de distribuição"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "title.editDistributionDefaultInviterId": [
-    [
-      "message",
-      "Editar convidador padrão"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "title.editDistributionForceInviterId": [
-    [
-      "message",
-      "Editar convidador forçado"
-    ],
-    [
-      "description",
-      "Exibido como o título na caixa de edição"
-    ]
-  ],
-  "title.editQR": [
-    [
-      "message",
-      "Editar QR Code"
-    ],
-    [
-      "description",
-      "Título exibido na caixa de edição"
-    ]
-  ],
-  "title.editUrl": [
-    [
-      "message",
-      "Editar Link"
-    ],
-    [
-      "description",
-      "Título exibido na caixa de edição"
-    ]
-  ],
-  "placeholder.title": [
-    [
-      "message",
-      "Digite o título do site"
-    ],
-    [
-      "description",
-      "Exibido na caixa de edição"
-    ]
-  ],
-  "placeholder.origin": [
-    [
-      "message",
-      "Digite o domínio do site"
-    ],
-    [
-      "description",
-      "Exibido na caixa de edição"
-    ]
-  ],
-  "placeholder.editUrl": [
-    [
-      "message",
-      "Digite o link"
-    ],
-    [
-      "description",
-      "Exibido na caixa de edição"
-    ]
-  ],
-  "placeholder.description": [
-    [
-      "message",
-      "Digite a descrição do site"
-    ],
-    [
-      "description",
-      "Exibido na caixa de edição"
-    ]
-  ],
-  "placeholder.keywords": [
-    [
-      "message",
-      "Digite as palavras-chave do site"
-    ],
-    [
-      "description",
-      "Exibido na caixa de edição"
-    ]
-  ],
-  "placeholder.editDistributionDefaultInviterId": [
-    [
-      "message",
-      "Digite o ID do convidador padrão"
-    ],
-    [
-      "description",
-      "Exibido na caixa de edição"
-    ]
-  ],
-  "placeholder.editDistributionForceInviterId": [
-    [
-      "message",
-      "Digite o ID do convidador forçado"
-    ],
-    [
-      "description",
-      "Exibido na caixa de edição"
-    ]
-  ],
-  "message.uploadImageExceed": [
-    [
-      "message",
-      "Imagem enviada excede o limite"
-    ],
-    [
-      "description",
-      "Mensagem de aviso quando a imagem enviada excede o limite"
-    ]
-  ],
-  "message.uploadImageError": [
-    [
-      "message",
-      "Erro ao enviar imagem"
-    ],
-    [
-      "description",
-      "Mensagem de erro ao enviar imagem"
-    ]
-  ],
-  "message.editLogoTip": [
-    [
-      "message",
-      "Tamanho recomendado: 200*60px"
-    ],
-    [
-      "description",
-      "Mensagem de dica para o upload da imagem"
-    ]
-  ],
-  "message.editQRTip": [
-    [
-      "message",
-      "Tamanho recomendado: 200*200px"
-    ],
-    [
-      "description",
-      "Mensagem de dica para o upload da imagem"
-    ]
-  ],
-  "message.editFaviconTip": [
-    [
-      "message",
-      "Tamanho recomendado: 32*32px"
-    ],
-    [
-      "description",
-      "Mensagem de dica para o upload da imagem"
-    ]
-  ],
-  "message.editUrl": [
-    [
-      "message",
-      "Digite o link"
-    ],
-    [
-      "description",
-      "Mensagem de dica para inserir o link"
-    ]
-  ],
-  "message.atLeastOneAdmin": [
-    [
-      "message",
-      "Mantenha pelo menos um administrador"
-    ],
-    [
-      "description",
-      "Mensagem de aviso para manter pelo menos um administrador"
-    ]
-  ],
-  "message.distributionDefaultInviterIdTip": [
-    [
-      "message",
-      "ID do usuário do convidador padrão. Se o link de distribuição não incluir o parâmetro inviter_id, este ID será usado como convidador."
-    ],
-    [
-      "description",
-      "Mensagem de dica para o ID do convidador padrão"
-    ]
-  ],
-  "message.distributionForceInviterIdTip": [
-    [
-      "message",
-      "ID do usuário do convidador forçado. Se este ID for definido, será usado como convidador, independentemente de o link de distribuição incluir o parâmetro inviter_id."
-    ],
-    [
-      "description",
-      "Mensagem de dica para o ID do convidador forçado"
-    ]
-  ],
-  "message.originTip": [
-    [
-      "message",
-      "Domínio do site. A configuração do site está vinculada ao domínio e não pode ser alterada."
-    ],
-    [
-      "description",
-      "Mensagem de dica para o domínio do site"
-    ]
-  ],
-  "message.titleTip": [
-    [
-      "message",
-      "Título do site, exibido na aba do navegador."
-    ],
-    [
-      "description",
-      "Mensagem de dica para o título do site"
-    ]
-  ],
-  "message.descriptionTip": [
-    [
-      "message",
-      "Descrição do site, localizada nas metainformações do site, usada para otimização de SEO."
-    ],
-    [
-      "description",
-      "Mensagem de dica para a descrição do site"
-    ]
-  ],
-  "message.logoTip": [
-    [
-      "message",
-      "Logo do site, exibido no topo do menu do site quando o menu é expandido."
-    ],
-    [
-      "description",
-      "Mensagem de dica para o logo do site"
-    ]
-  ],
-  "message.faviconTip": [
-    [
-      "message",
-      "Favicon do site, exibido na aba do navegador."
-    ],
-    [
-      "description",
-      "Mensagem de dica para o favicon do site"
-    ]
-  ],
-  "message.adminsTip": [
-    [
-      "message",
-      "IDs dos administradores do site. O usuário que cria o site pela primeira vez se torna o administrador. Apenas administradores podem gerenciar o site."
-    ],
-    [
-      "description",
-      "Mensagem de dica para os administradores do site"
-    ]
-  ],
-  "message.adminsTip2": [
-    [
-      "message",
-      "Você pode adicionar ou remover IDs de administradores aqui. Veja os IDs de usuários em https://auth.acedata.cloud"
-    ],
-    [
-      "description",
-      "Mensagem de dica para os administradores do site"
-    ]
-  ],
-  "message.keywordsTip": [
-    [
-      "message",
-      "Palavras-chave do site, localizadas nas metainformações do site, usadas para otimização de SEO."
-    ],
-    [
-      "description",
-      "Mensagem de dica para as palavras-chave do site"
-    ]
-  ],
-  "message.keywordsTip2": [
-    [
-      "message",
-      "Você pode adicionar ou remover palavras-chave do site aqui. Quanto mais precisas forem as palavras-chave, melhor para a otimização de SEO."
-    ],
-    [
-      "description",
-      "Mensagem de dica para as palavras-chave do site"
-    ]
-  ],
-  "message.featuresChat": [
-    [
-      "message",
-      "Ativar ou desativar o módulo de Chat."
-    ],
-    [
-      "description",
-      "Descrição da funcionalidade de Chat"
-    ]
-  ],
-  "message.featuresGrok": [
-    [
-      "message",
-      "Ativar ou desativar o módulo de Grok."
-    ],
-    [
-      "description",
-      "Descrição da funcionalidade de Grok"
-    ]
-  ],
-  "message.featuresDeepseek": [
-    [
-      "message",
-      "Ativar ou desativar o módulo de Deepseek."
-    ],
-    [
-      "description",
-      "Descrição da funcionalidade de Deepseek"
-    ]
-  ],
-  "message.featuresChatgpt": [
-    [
-      "message",
-      "Ativar ou desativar o módulo de ChatGPT."
-    ],
-    [
-      "description",
-      "Descrição da funcionalidade de ChatGPT"
-    ]
-  ],
-  "message.featuresMidjourney": [
-    [
-      "message",
-      "Ativar ou desativar o módulo de Midjourney."
-    ],
-    [
-      "description",
-      "Descrição da funcionalidade de Midjourney"
-    ]
-  ],
-  "message.featuresChatdoc": [
-    [
-      "message",
-      "Ativar ou desativar o módulo de Chatdoc."
-    ],
-    [
-      "description",
-      "Descrição da funcionalidade de Chatdoc"
-    ]
-  ],
-  "message.featuresQrart": [
-    [
-      "message",
-      "Ativar ou desativar o módulo de Qrart."
-    ],
-    [
-      "description",
-      "Descrição da funcionalidade de Qrart"
-    ]
-  ],
-  "message.featuresVeo": [
-    [
-      "message",
-      "Ativar ou desativar o módulo de Veo."
-    ],
-    [
-      "description",
-      "Descrição da funcionalidade de Veo"
-    ]
-  ],
-  "message.featuresSora": [
-    [
-      "message",
-      "Ativar ou desativar o módulo de Sora."
-    ],
-    [
-      "description",
-      "Descrição da funcionalidade de Sora"
-    ]
-  ],
-  "message.featuresSuno": [
-    [
-      "message",
-      "Ativar ou desativar o módulo de Suno."
-    ],
-    [
-      "description",
-      "Descrição da funcionalidade de Suno"
-    ]
-  ],
-  "message.featuresPixverse": [
-    [
-      "message",
-      "Ativar ou desativar o módulo de recursos do Pixverse."
-    ],
-    [
-      "description",
-      "Descrição da funcionalidade do Pixverse"
-    ]
-  ],
-  "message.featuresFlux": [
-    [
-      "message",
-      "Ativar ou desativar o módulo de recursos do FLux."
-    ],
-    [
-      "description",
-      "Descrição da funcionalidade do FLux"
-    ]
-  ],
-  "message.featuresNanobanana": [
-    [
-      "message",
-      "Ativar ou desativar o módulo de recursos do Nano Banana."
-    ],
-    [
-      "description",
-      "Descrição da funcionalidade do Nano Banana"
-    ]
-  ],
+  "field.featuresSeedream": {
+    "message": "SeeDream",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "field.featuresSeedance": {
+    "message": "SeeDance",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "field.featuresWan": {
+    "message": "Wan",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "field.featuresProducer": {
+    "message": "Produtor",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "field.featuresKimi": {
+    "message": "Kimi",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "field.featuresSerp": {
+    "message": "SERP",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "field.featuresSupport": {
+    "message": "Suporte ao cliente",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "field.featuresI18n": {
+    "message": "Suporte multilíngue",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "title.basicConfig": {
+    "message": "Configuração básica",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "title.seoConfig": {
+    "message": "Configuração de SEO",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "title.editAdmins": {
+    "message": "Editar administradores",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "title.featuresConfig": {
+    "message": "Configuração de funcionalidades",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "title.editTitle": {
+    "message": "Editar título",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "title.editOrigin": {
+    "message": "Editar domínio",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "title.editKeywords": {
+    "message": "Editar palavras-chave",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "title.editLogo": {
+    "message": "Editar logo",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "title.editFavicon": {
+    "message": "Editar favicon",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "title.editDescription": {
+    "message": "Editar descrição",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "title.distributionConfig": {
+    "message": "Configuração de distribuição",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "title.editDistributionDefaultInviterId": {
+    "message": "Editar convidador padrão",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "title.editDistributionForceInviterId": {
+    "message": "Editar convidador forçado",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "title.editQR": {
+    "message": "Editar QR Code",
+    "description": "Título exibido na caixa de edição"
+  },
+  "title.editUrl": {
+    "message": "Editar Link",
+    "description": "Título exibido na caixa de edição"
+  },
+  "placeholder.title": {
+    "message": "Digite o título do site",
+    "description": "Exibido na caixa de edição"
+  },
+  "placeholder.origin": {
+    "message": "Digite o domínio do site",
+    "description": "Exibido na caixa de edição"
+  },
+  "placeholder.editUrl": {
+    "message": "Digite o link",
+    "description": "Exibido na caixa de edição"
+  },
+  "placeholder.description": {
+    "message": "Digite a descrição do site",
+    "description": "Exibido na caixa de edição"
+  },
+  "placeholder.keywords": {
+    "message": "Digite as palavras-chave do site",
+    "description": "Exibido na caixa de edição"
+  },
+  "placeholder.editDistributionDefaultInviterId": {
+    "message": "Digite o ID do convidador padrão",
+    "description": "Exibido na caixa de edição"
+  },
+  "placeholder.editDistributionForceInviterId": {
+    "message": "Digite o ID do convidador forçado",
+    "description": "Exibido na caixa de edição"
+  },
+  "message.uploadImageExceed": {
+    "message": "Imagem enviada excede o limite",
+    "description": "Mensagem de aviso quando a imagem enviada excede o limite"
+  },
+  "message.uploadImageError": {
+    "message": "Erro ao enviar imagem",
+    "description": "Mensagem de erro ao enviar imagem"
+  },
+  "message.editLogoTip": {
+    "message": "Tamanho recomendado: 200*60px",
+    "description": "Mensagem de dica para o upload da imagem"
+  },
+  "message.editQRTip": {
+    "message": "Tamanho recomendado: 200*200px",
+    "description": "Mensagem de dica para o upload da imagem"
+  },
+  "message.editFaviconTip": {
+    "message": "Tamanho recomendado: 32*32px",
+    "description": "Mensagem de dica para o upload da imagem"
+  },
+  "message.editUrl": {
+    "message": "Digite o link",
+    "description": "Mensagem de dica para inserir o link"
+  },
+  "message.atLeastOneAdmin": {
+    "message": "Mantenha pelo menos um administrador",
+    "description": "Mensagem de aviso para manter pelo menos um administrador"
+  },
+  "message.distributionDefaultInviterIdTip": {
+    "message": "ID do usuário do convidador padrão. Se o link de distribuição não incluir o parâmetro inviter_id, este ID será usado como convidador.",
+    "description": "Mensagem de dica para o ID do convidador padrão"
+  },
+  "message.distributionForceInviterIdTip": {
+    "message": "ID do usuário do convidador forçado. Se este ID for definido, será usado como convidador, independentemente de o link de distribuição incluir o parâmetro inviter_id.",
+    "description": "Mensagem de dica para o ID do convidador forçado"
+  },
+  "message.originTip": {
+    "message": "Domínio do site. A configuração do site está vinculada ao domínio e não pode ser alterada.",
+    "description": "Mensagem de dica para o domínio do site"
+  },
+  "message.titleTip": {
+    "message": "Título do site, exibido na aba do navegador.",
+    "description": "Mensagem de dica para o título do site"
+  },
+  "message.descriptionTip": {
+    "message": "Descrição do site, localizada nas metainformações do site, usada para otimização de SEO.",
+    "description": "Mensagem de dica para a descrição do site"
+  },
+  "message.logoTip": {
+    "message": "Logo do site, exibido no topo do menu do site quando o menu é expandido.",
+    "description": "Mensagem de dica para o logo do site"
+  },
+  "message.faviconTip": {
+    "message": "Favicon do site, exibido na aba do navegador.",
+    "description": "Mensagem de dica para o favicon do site"
+  },
+  "message.adminsTip": {
+    "message": "IDs dos administradores do site. O usuário que cria o site pela primeira vez se torna o administrador. Apenas administradores podem gerenciar o site.",
+    "description": "Mensagem de dica para os administradores do site"
+  },
+  "message.adminsTip2": {
+    "message": "Você pode adicionar ou remover IDs de administradores aqui. Veja os IDs de usuários em https://auth.acedata.cloud",
+    "description": "Mensagem de dica para os administradores do site"
+  },
+  "message.keywordsTip": {
+    "message": "Palavras-chave do site, localizadas nas metainformações do site, usadas para otimização de SEO.",
+    "description": "Mensagem de dica para as palavras-chave do site"
+  },
+  "message.keywordsTip2": {
+    "message": "Você pode adicionar ou remover palavras-chave do site aqui. Quanto mais precisas forem as palavras-chave, melhor para a otimização de SEO.",
+    "description": "Mensagem de dica para as palavras-chave do site"
+  },
+  "message.featuresChat": {
+    "message": "Ativar ou desativar o módulo de Chat.",
+    "description": "Descrição da funcionalidade de Chat"
+  },
+  "message.featuresGrok": {
+    "message": "Ativar ou desativar o módulo de Grok.",
+    "description": "Descrição da funcionalidade de Grok"
+  },
+  "message.featuresDeepseek": {
+    "message": "Ativar ou desativar o módulo de Deepseek.",
+    "description": "Descrição da funcionalidade de Deepseek"
+  },
+  "message.featuresChatgpt": {
+    "message": "Ativar ou desativar o módulo de ChatGPT.",
+    "description": "Descrição da funcionalidade de ChatGPT"
+  },
+  "message.featuresMidjourney": {
+    "message": "Ativar ou desativar o módulo de Midjourney.",
+    "description": "Descrição da funcionalidade de Midjourney"
+  },
+  "message.featuresChatdoc": {
+    "message": "Ativar ou desativar o módulo de Chatdoc.",
+    "description": "Descrição da funcionalidade de Chatdoc"
+  },
+  "message.featuresQrart": {
+    "message": "Ativar ou desativar o módulo de Qrart.",
+    "description": "Descrição da funcionalidade de Qrart"
+  },
+  "message.featuresVeo": {
+    "message": "Ativar ou desativar o módulo de Veo.",
+    "description": "Descrição da funcionalidade de Veo"
+  },
+  "message.featuresSora": {
+    "message": "Ativar ou desativar o módulo de Sora.",
+    "description": "Descrição da funcionalidade de Sora"
+  },
+  "message.featuresSuno": {
+    "message": "Ativar ou desativar o módulo de Suno.",
+    "description": "Descrição da funcionalidade de Suno"
+  },
+  "message.featuresPixverse": {
+    "message": "Ativar ou desativar o módulo de recursos do Pixverse.",
+    "description": "Descrição da funcionalidade do Pixverse"
+  },
+  "message.featuresFlux": {
+    "message": "Ativar ou desativar o módulo de recursos do FLux.",
+    "description": "Descrição da funcionalidade do FLux"
+  },
+  "message.featuresNanobanana": {
+    "message": "Ativar ou desativar o módulo de recursos do Nano Banana.",
+    "description": "Descrição da funcionalidade do Nano Banana"
+  },
   "message.featuresOpenaiimage": {
     "message": "Toggle OpenAI Image feature module.",
     "description": "Description of the OpenAI Image feature"
   },
-  "message.featuresSeedream": [
-    [
-      "message",
-      "Ativar ou desativar o módulo de recursos do SeeDream."
-    ],
-    [
-      "description",
-      "Descrição da funcionalidade do SeeDream"
-    ]
-  ],
-  "message.featuresSeedance": [
-    [
-      "message",
-      "Ativar ou desativar o módulo de recursos do SeeDance."
-    ],
-    [
-      "description",
-      "Descrição da funcionalidade do SeeDance"
-    ]
-  ],
-  "message.featuresWan": [
-    [
-      "message",
-      "Ativar ou desativar o módulo de recursos do Wan."
-    ],
-    [
-      "description",
-      "Descrição da funcionalidade do Wan"
-    ]
-  ],
-  "message.featuresProducer": [
-    [
-      "message",
-      "Ativar ou desativar o módulo de recursos do Producer."
-    ],
-    [
-      "description",
-      "Descrição da funcionalidade do Producer"
-    ]
-  ],
-  "message.featuresKimi": [
-    [
-      "message",
-      "Ativar ou desativar o módulo de recursos do Kimi."
-    ],
-    [
-      "description",
-      "Descrição da funcionalidade do Kimi"
-    ]
-  ],
-  "message.featuresSerp": [
-    [
-      "message",
-      "Ativar ou desativar o módulo de recursos do SERP."
-    ],
-    [
-      "description",
-      "Descrição da funcionalidade do SERP"
-    ]
-  ],
-  "message.featuresLuma": [
-    [
-      "message",
-      "Ativar ou desativar o módulo de recursos do Luma."
-    ],
-    [
-      "description",
-      "Descrição da funcionalidade do Luma"
-    ]
-  ],
-  "message.featuresPika": [
-    [
-      "message",
-      "Ativar ou desativar o módulo de recursos do Pika."
-    ],
-    [
-      "description",
-      "Descrição da funcionalidade do Pika"
-    ]
-  ],
-  "message.featuresKling": [
-    [
-      "message",
-      "Ativar ou desativar o módulo de recursos do Kling."
-    ],
-    [
-      "description",
-      "Descrição da funcionalidade do Kling"
-    ]
-  ],
-  "message.featuresHailuo": [
-    [
-      "message",
-      "Ativar ou desativar o módulo de recursos do Hailuo."
-    ],
-    [
-      "description",
-      "Descrição da funcionalidade do Hailuo"
-    ]
-  ],
-  "message.featuresHeadshots": [
-    [
-      "message",
-      "Ativar ou desativar o módulo de recursos de fotos de identificação AI."
-    ],
-    [
-      "description",
-      "Descrição da funcionalidade de fotos de identificação AI"
-    ]
-  ],
-  "message.featuresSupport": [
-    [
-      "message",
-      "Ativar ou desativar o suporte ao cliente"
-    ],
-    [
-      "description",
-      "Descrição da funcionalidade de suporte"
-    ]
-  ],
-  "message.featuresI18n": [
-    [
-      "message",
-      "Ativar ou desativar o suporte a múltiplos idiomas. Se desativado, o usuário só poderá usar o idioma padrão."
-    ],
-    [
-      "description",
-      "Descrição do suporte a múltiplos idiomas"
-    ]
-  ],
-  "button.upload": [
-    [
-      "message",
-      "Enviar"
-    ],
-    [
-      "description",
-      "Enviar"
-    ]
-  ],
-  "button.enabled": [
-    [
-      "message",
-      "Ativado"
-    ],
-    [
-      "description",
-      "Texto do botão que indica que está ativado"
-    ]
-  ],
-  "button.disabled": [
-    [
-      "message",
-      "Desativado"
-    ],
-    [
-      "description",
-      "Texto do botão que indica que está desativado"
-    ]
-  ],
-  "field.featuresGemini": [
-    [
-      "message",
-      "Gemini"
-    ],
-    [
-      "description",
-      "Exibido como título na caixa de edição"
-    ]
-  ],
-  "message.featuresGemini": [
-    [
-      "message",
-      "Ativar ou desativar o módulo de recursos do Gemini."
-    ],
-    [
-      "description",
-      "Descrição da funcionalidade do Gemini"
-    ]
-  ],
-  "field.featuresClaude": [
-    [
-      "message",
-      "Claude"
-    ],
-    [
-      "description",
-      "Exibido como título na caixa de edição"
-    ]
-  ],
-  "message.featuresClaude": [
-    [
-      "message",
-      "Ativar ou desativar o módulo de recursos do Claude."
-    ],
-    [
-      "description",
-      "Descrição da funcionalidade do Claude"
-    ]
-  ]
+  "message.featuresSeedream": {
+    "message": "Ativar ou desativar o módulo de recursos do SeeDream.",
+    "description": "Descrição da funcionalidade do SeeDream"
+  },
+  "message.featuresSeedance": {
+    "message": "Ativar ou desativar o módulo de recursos do SeeDance.",
+    "description": "Descrição da funcionalidade do SeeDance"
+  },
+  "message.featuresWan": {
+    "message": "Ativar ou desativar o módulo de recursos do Wan.",
+    "description": "Descrição da funcionalidade do Wan"
+  },
+  "message.featuresProducer": {
+    "message": "Ativar ou desativar o módulo de recursos do Producer.",
+    "description": "Descrição da funcionalidade do Producer"
+  },
+  "message.featuresKimi": {
+    "message": "Ativar ou desativar o módulo de recursos do Kimi.",
+    "description": "Descrição da funcionalidade do Kimi"
+  },
+  "message.featuresSerp": {
+    "message": "Ativar ou desativar o módulo de recursos do SERP.",
+    "description": "Descrição da funcionalidade do SERP"
+  },
+  "message.featuresLuma": {
+    "message": "Ativar ou desativar o módulo de recursos do Luma.",
+    "description": "Descrição da funcionalidade do Luma"
+  },
+  "message.featuresPika": {
+    "message": "Ativar ou desativar o módulo de recursos do Pika.",
+    "description": "Descrição da funcionalidade do Pika"
+  },
+  "message.featuresKling": {
+    "message": "Ativar ou desativar o módulo de recursos do Kling.",
+    "description": "Descrição da funcionalidade do Kling"
+  },
+  "message.featuresHailuo": {
+    "message": "Ativar ou desativar o módulo de recursos do Hailuo.",
+    "description": "Descrição da funcionalidade do Hailuo"
+  },
+  "message.featuresHeadshots": {
+    "message": "Ativar ou desativar o módulo de recursos de fotos de identificação AI.",
+    "description": "Descrição da funcionalidade de fotos de identificação AI"
+  },
+  "message.featuresSupport": {
+    "message": "Ativar ou desativar o suporte ao cliente",
+    "description": "Descrição da funcionalidade de suporte"
+  },
+  "message.featuresI18n": {
+    "message": "Ativar ou desativar o suporte a múltiplos idiomas. Se desativado, o usuário só poderá usar o idioma padrão.",
+    "description": "Descrição do suporte a múltiplos idiomas"
+  },
+  "button.upload": {
+    "message": "Enviar",
+    "description": "Enviar"
+  },
+  "button.enabled": {
+    "message": "Ativado",
+    "description": "Texto do botão que indica que está ativado"
+  },
+  "button.disabled": {
+    "message": "Desativado",
+    "description": "Texto do botão que indica que está desativado"
+  },
+  "field.featuresGemini": {
+    "message": "Gemini",
+    "description": "Exibido como título na caixa de edição"
+  },
+  "message.featuresGemini": {
+    "message": "Ativar ou desativar o módulo de recursos do Gemini.",
+    "description": "Descrição da funcionalidade do Gemini"
+  },
+  "field.featuresClaude": {
+    "message": "Claude",
+    "description": "Exibido como título na caixa de edição"
+  },
+  "message.featuresClaude": {
+    "message": "Ativar ou desativar o módulo de recursos do Claude.",
+    "description": "Descrição da funcionalidade do Claude"
+  }
 }

--- a/src/i18n/ru/site.json
+++ b/src/i18n/ru/site.json
@@ -1,442 +1,1110 @@
 {
-  "field.title": {
-    "message": "Заголовок сайта",
-    "description": "展示在编辑框的标题"
-  },
-  "field.origin": {
-    "message": "Домен сайта",
-    "description": "展示在编辑框的标题"
-  },
-  "field.description": {
-    "message": "Описание сайта",
-    "description": "展示在编辑框的标题"
-  },
-  "field.keywords": {
-    "message": "Ключевые слова сайта",
-    "description": "展示在编辑框的标题"
-  },
-  "field.logo": {
-    "message": "Логотип сайта",
-    "description": "展示在编辑框的标题"
-  },
-  "field.favicon": {
-    "message": "Favicon сайта",
-    "description": "展示在编辑框的标题"
-  },
-  "field.qr": {
-    "message": "QR-код",
-    "description": "展示在编辑框的标题"
-  },
-  "field.url": {
-    "message": "Ссылка",
-    "description": "展示在编辑框的标题"
-  },
-  "field.admins": {
-    "message": "ID администраторов сайта",
-    "description": "展示在编辑框的标题"
-  },
-  "field.distributionDefaultInviterId": {
-    "message": "ID приглашенного по умолчанию",
-    "description": "展示在编辑框的标题"
-  },
-  "field.distributionForceInviterId": {
-    "message": "ID обязательного приглашенного",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresChat": {
-    "message": "Чат",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresVeo": {
-    "message": "Veo",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresSora": {
-    "message": "Sora",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresGrok": {
-    "message": "Grok",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresDeepseek": {
-    "message": "Deepseek",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresChatgpt": {
-    "message": "ChatGPT",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresMidjourney": {
-    "message": "Midjourney",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresChatdoc": {
-    "message": "Chatdoc",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresQrart": {
-    "message": "Qrart",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresLuma": {
-    "message": "Luma",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresPixverse": {
-    "message": "Pixverse",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresPika": {
-    "message": "Pika",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresKling": {
-    "message": "Kling",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresHailuo": {
-    "message": "Hailuo",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresHeadshots": {
-    "message": "AI Фотография",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresSuno": {
-    "message": "Suno",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresFlux": {
-    "message": "Flux",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresNanobanana": {
-    "message": "Нано Банан",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresSeedream": {
-    "message": "SeeDream",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresSeedance": {
-    "message": "SeeDance",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresWan": {
-    "message": "Wan",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresProducer": {
-    "message": "Продюсер",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresKimi": {
-    "message": "Kimi",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresSerp": {
-    "message": "SERP",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresSupport": {
-    "message": "Поддержка клиентов",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresI18n": {
-    "message": "Многоязычная поддержка",
-    "description": "展示在编辑框的标题"
-  },
-  "title.basicConfig": {
-    "message": "Основные настройки",
-    "description": "展示在编辑框的标题"
-  },
-  "title.seoConfig": {
-    "message": "Настройки SEO",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editAdmins": {
-    "message": "Редактировать администраторов",
-    "description": "展示在编辑框的标题"
-  },
-  "title.featuresConfig": {
-    "message": "Настройки функций",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editTitle": {
-    "message": "Редактировать заголовок",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editOrigin": {
-    "message": "Редактировать домен",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editKeywords": {
-    "message": "Редактировать ключевые слова",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editLogo": {
-    "message": "Редактировать логотип",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editFavicon": {
-    "message": "Редактировать Favicon",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editDescription": {
-    "message": "Редактировать описание",
-    "description": "展示在编辑框的标题"
-  },
-  "title.distributionConfig": {
-    "message": "Настройки дистрибуции",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editDistributionDefaultInviterId": {
-    "message": "Редактировать приглашенного по умолчанию",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editDistributionForceInviterId": {
-    "message": "Редактировать обязательного приглашенного",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editQR": {
-    "message": "Редактировать QR-код",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editUrl": {
-    "message": "Редактировать ссылку",
-    "description": "展示在编辑框的标题"
-  },
-  "placeholder.title": {
-    "message": "Введите заголовок сайта",
-    "description": "展示在编辑框的标题"
-  },
-  "placeholder.origin": {
-    "message": "Введите домен сайта",
-    "description": "展示在编辑框的标题"
-  },
-  "placeholder.editUrl": {
-    "message": "Введите ссылку",
-    "description": "展示在编辑框的标题"
-  },
-  "placeholder.description": {
-    "message": "Введите описание сайта",
-    "description": "展示在编辑框的标题"
-  },
-  "placeholder.keywords": {
-    "message": "Введите ключевые слова сайта",
-    "description": "展示在编辑框的标题"
-  },
-  "placeholder.editDistributionDefaultInviterId": {
-    "message": "Введите ID приглашенного по умолчанию",
-    "description": "展示在编辑框的标题"
-  },
-  "placeholder.editDistributionForceInviterId": {
-    "message": "Введите ID обязательного приглашенного",
-    "description": "展示在编辑框的标题"
-  },
-  "message.uploadImageExceed": {
-    "message": "Превышен лимит загрузки изображения",
-    "description": "上传图片超过限制的提示"
-  },
-  "message.uploadImageError": {
-    "message": "Ошибка загрузки изображения",
-    "description": "上传图片错误的提示"
-  },
-  "message.editLogoTip": {
-    "message": "Рекомендуемый размер: 200*60px",
-    "description": "上传图片的提示语言"
-  },
-  "message.editQRTip": {
-    "message": "Рекомендуемый размер: 200*200px",
-    "description": "上传图片的提示语言"
-  },
-  "message.editFaviconTip": {
-    "message": "Рекомендуемый размер: 32*32px",
-    "description": "上传图片的提示语言"
-  },
-  "message.editUrl": {
-    "message": "Введите ссылку",
-    "description": "请输入链接的提示"
-  },
-  "message.atLeastOneAdmin": {
-    "message": "Должен быть хотя бы один администратор",
-    "description": "至少保留一个管理员的提示"
-  },
-  "message.distributionDefaultInviterIdTip": {
-    "message": "ID пользователя приглашенного по умолчанию. Если ссылка на распределение не содержит параметра inviter_id, будет использоваться этот ID.",
-    "description": "默认邀请人ID的提示"
-  },
-  "message.distributionForceInviterIdTip": {
-    "message": "ID обязательного приглашенного. Если установлен этот ID, будет использоваться он, независимо от наличия параметра inviter_id в ссылке.",
-    "description": "强制邀请人ID的提示"
-  },
-  "message.originTip": {
-    "message": "Домен сайта, конфигурация сайта связана с доменом, домен сайта нельзя изменить.",
-    "description": "站点域名的提示"
-  },
-  "message.titleTip": {
-    "message": "Заголовок сайта, отображается на вкладке браузера.",
-    "description": "站点标题的提示"
-  },
-  "message.descriptionTip": {
-    "message": "Описание сайта, находится в метаданных сайта, используется для SEO-оптимизации.",
-    "description": "站点描述的提示"
-  },
-  "message.logoTip": {
-    "message": "Логотип сайта, отображается в верхней части меню сайта, когда меню развернуто.",
-    "description": "站点 Logo 的提示"
-  },
-  "message.faviconTip": {
-    "message": "Favicon сайта, отображается на вкладке браузера.",
-    "description": "站点 Favicon 的提示"
-  },
-  "message.adminsTip": {
-    "message": "ID администраторов сайта. По умолчанию первый созданный пользователь становится администратором, только администраторы могут управлять сайтом.",
-    "description": "站点管理员的提示"
-  },
-  "message.adminsTip2": {
-    "message": "Здесь можно добавлять или удалять ID администраторов. Вы можете посмотреть ID пользователей на https://auth.acedata.cloud",
-    "description": "站点管理员的提示"
-  },
-  "message.keywordsTip": {
-    "message": "Ключевые слова сайта, находятся в метаданных сайта, используются для SEO-оптимизации.",
-    "description": "站点关键词的提示"
-  },
-  "message.keywordsTip2": {
-    "message": "Здесь можно добавлять или удалять ключевые слова сайта. Чем точнее ключевые слова, тем лучше для SEO-оптимизации.",
-    "description": "站点关键词的提示"
-  },
-  "message.featuresChat": {
-    "message": "Включить или отключить модуль функции Chat.",
-    "description": "Chat 功能的描述"
-  },
-  "message.featuresGrok": {
-    "message": "Включить или отключить модуль функции Grok.",
-    "description": "Grok 功能的描述"
-  },
-  "message.featuresDeepseek": {
-    "message": "Включить или отключить модуль функции Deepseek.",
-    "description": "Deepseek 功能的描述"
-  },
-  "message.featuresChatgpt": {
-    "message": "Включить или отключить модуль функции ChatGPT.",
-    "description": "ChatGPT 功能的描述"
-  },
-  "message.featuresMidjourney": {
-    "message": "Включить или отключить модуль функции Midjourney.",
-    "description": "Midjourney 功能的描述"
-  },
-  "message.featuresChatdoc": {
-    "message": "Включить или отключить модуль функции Chatdoc.",
-    "description": "Chatdoc 功能的描述"
-  },
-  "message.featuresQrart": {
-    "message": "Включить или отключить модуль функции Qrart.",
-    "description": "Qrart 功能的描述"
-  },
-  "message.featuresVeo": {
-    "message": "Включить или отключить модуль функции Veo.",
-    "description": "Veo 功能的描述"
-  },
-  "message.featuresSora": {
-    "message": "Включить или отключить модуль функции Sora.",
-    "description": "Sora 功能的描述"
-  },
-  "message.featuresSuno": {
-    "message": "Включить или отключить модуль функции Suno.",
-    "description": "Suno 功能的描述"
-  },
-  "message.featuresPixverse": {
-    "message": "Включить или отключить модуль функций Pixverse.",
-    "description": "Описание функции Pixverse"
-  },
-  "message.featuresFlux": {
-    "message": "Включить или отключить модуль функций FLux.",
-    "description": "Описание функции FLux"
-  },
-  "message.featuresNanobanana": {
-    "message": "Включить или отключить модуль функций Nano Banana.",
-    "description": "Описание функции Nano Banana"
-  },
-  "message.featuresSeedream": {
-    "message": "Включить или отключить модуль функций SeeDream.",
-    "description": "Описание функции SeeDream"
-  },
-  "message.featuresSeedance": {
-    "message": "Включить или отключить модуль функций SeeDance.",
-    "description": "Описание функции SeeDance"
-  },
-  "message.featuresWan": {
-    "message": "Включить или отключить модуль функций Wan.",
-    "description": "Описание функции Wan"
-  },
-  "message.featuresProducer": {
-    "message": "Включить или отключить модуль функций Producer.",
-    "description": "Описание функции Producer"
-  },
-  "message.featuresKimi": {
-    "message": "Включить или отключить модуль функций Kimi.",
-    "description": "Описание функции Kimi"
-  },
-  "message.featuresSerp": {
-    "message": "Включить или отключить модуль функций SERP.",
-    "description": "Описание функции SERP"
-  },
-  "message.featuresLuma": {
-    "message": "Включить или отключить модуль функций Luma.",
-    "description": "Описание функции Luma"
-  },
-  "message.featuresPika": {
-    "message": "Включить или отключить модуль функций Pika.",
-    "description": "Описание функции Pika"
-  },
-  "message.featuresKling": {
-    "message": "Включить или отключить модуль функций Kling.",
-    "description": "Описание функции Kling"
-  },
-  "message.featuresHailuo": {
-    "message": "Включить или отключить модуль функций Hailuo.",
-    "description": "Описание функции Hailuo"
-  },
-  "message.featuresHeadshots": {
-    "message": "Включить или отключить модуль функций AI удостоверения личности.",
-    "description": "Описание функции AI удостоверения личности"
-  },
-  "message.featuresSupport": {
-    "message": "Включить или отключить поддержку клиентов",
-    "description": "Описание функции поддержки"
-  },
-  "message.featuresI18n": {
-    "message": "Включить или отключить поддержку нескольких языков. При отключении пользователи смогут использовать только язык по умолчанию.",
-    "description": "Описание поддержки нескольких языков"
-  },
-  "button.upload": {
-    "message": "Загрузить",
-    "description": "Загрузить"
-  },
-  "button.enabled": {
-    "message": "Включено",
-    "description": "Текст переключателя, указывающий, что функция включена"
-  },
-  "button.disabled": {
-    "message": "Отключено",
-    "description": "Текст переключателя, указывающий, что функция отключена"
-  },
-  "field.featuresGemini": {
-    "message": "Gemini",
-    "description": "Отображается как заголовок в редакторе"
-  },
-  "message.featuresGemini": {
-    "message": "Включить или отключить модуль функций Gemini.",
-    "description": "Описание функции Gemini"
-  },
-  "field.featuresClaude": {
-    "message": "Claude",
-    "description": "Отображается как заголовок в редакторе"
-  },
-  "message.featuresClaude": {
-    "message": "Включить или отключить модуль функций Claude.",
-    "description": "Описание функции Claude"
-  }
+  "field.title": [
+    [
+      "message",
+      "Заголовок сайта"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.origin": [
+    [
+      "message",
+      "Домен сайта"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.description": [
+    [
+      "message",
+      "Описание сайта"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.keywords": [
+    [
+      "message",
+      "Ключевые слова сайта"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.logo": [
+    [
+      "message",
+      "Логотип сайта"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.favicon": [
+    [
+      "message",
+      "Favicon сайта"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.qr": [
+    [
+      "message",
+      "QR-код"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.url": [
+    [
+      "message",
+      "Ссылка"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.admins": [
+    [
+      "message",
+      "ID администраторов сайта"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.distributionDefaultInviterId": [
+    [
+      "message",
+      "ID приглашенного по умолчанию"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.distributionForceInviterId": [
+    [
+      "message",
+      "ID обязательного приглашенного"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresChat": [
+    [
+      "message",
+      "Чат"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresVeo": [
+    [
+      "message",
+      "Veo"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresSora": [
+    [
+      "message",
+      "Sora"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresGrok": [
+    [
+      "message",
+      "Grok"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresDeepseek": [
+    [
+      "message",
+      "Deepseek"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresChatgpt": [
+    [
+      "message",
+      "ChatGPT"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresMidjourney": [
+    [
+      "message",
+      "Midjourney"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresChatdoc": [
+    [
+      "message",
+      "Chatdoc"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresQrart": [
+    [
+      "message",
+      "Qrart"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresLuma": [
+    [
+      "message",
+      "Luma"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresPixverse": [
+    [
+      "message",
+      "Pixverse"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresPika": [
+    [
+      "message",
+      "Pika"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresKling": [
+    [
+      "message",
+      "Kling"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresHailuo": [
+    [
+      "message",
+      "Hailuo"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresHeadshots": [
+    [
+      "message",
+      "AI Фотография"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresSuno": [
+    [
+      "message",
+      "Suno"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresFlux": [
+    [
+      "message",
+      "Flux"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresNanobanana": [
+    [
+      "message",
+      "Нано Банан"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresOpenaiimage": {
+    "message": "OpenAI Image",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresSeedream": [
+    [
+      "message",
+      "SeeDream"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresSeedance": [
+    [
+      "message",
+      "SeeDance"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresWan": [
+    [
+      "message",
+      "Wan"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresProducer": [
+    [
+      "message",
+      "Продюсер"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresKimi": [
+    [
+      "message",
+      "Kimi"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresSerp": [
+    [
+      "message",
+      "SERP"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresSupport": [
+    [
+      "message",
+      "Поддержка клиентов"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresI18n": [
+    [
+      "message",
+      "Многоязычная поддержка"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.basicConfig": [
+    [
+      "message",
+      "Основные настройки"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.seoConfig": [
+    [
+      "message",
+      "Настройки SEO"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editAdmins": [
+    [
+      "message",
+      "Редактировать администраторов"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.featuresConfig": [
+    [
+      "message",
+      "Настройки функций"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editTitle": [
+    [
+      "message",
+      "Редактировать заголовок"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editOrigin": [
+    [
+      "message",
+      "Редактировать домен"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editKeywords": [
+    [
+      "message",
+      "Редактировать ключевые слова"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editLogo": [
+    [
+      "message",
+      "Редактировать логотип"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editFavicon": [
+    [
+      "message",
+      "Редактировать Favicon"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editDescription": [
+    [
+      "message",
+      "Редактировать описание"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.distributionConfig": [
+    [
+      "message",
+      "Настройки дистрибуции"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editDistributionDefaultInviterId": [
+    [
+      "message",
+      "Редактировать приглашенного по умолчанию"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editDistributionForceInviterId": [
+    [
+      "message",
+      "Редактировать обязательного приглашенного"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editQR": [
+    [
+      "message",
+      "Редактировать QR-код"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editUrl": [
+    [
+      "message",
+      "Редактировать ссылку"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "placeholder.title": [
+    [
+      "message",
+      "Введите заголовок сайта"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "placeholder.origin": [
+    [
+      "message",
+      "Введите домен сайта"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "placeholder.editUrl": [
+    [
+      "message",
+      "Введите ссылку"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "placeholder.description": [
+    [
+      "message",
+      "Введите описание сайта"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "placeholder.keywords": [
+    [
+      "message",
+      "Введите ключевые слова сайта"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "placeholder.editDistributionDefaultInviterId": [
+    [
+      "message",
+      "Введите ID приглашенного по умолчанию"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "placeholder.editDistributionForceInviterId": [
+    [
+      "message",
+      "Введите ID обязательного приглашенного"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "message.uploadImageExceed": [
+    [
+      "message",
+      "Превышен лимит загрузки изображения"
+    ],
+    [
+      "description",
+      "上传图片超过限制的提示"
+    ]
+  ],
+  "message.uploadImageError": [
+    [
+      "message",
+      "Ошибка загрузки изображения"
+    ],
+    [
+      "description",
+      "上传图片错误的提示"
+    ]
+  ],
+  "message.editLogoTip": [
+    [
+      "message",
+      "Рекомендуемый размер: 200*60px"
+    ],
+    [
+      "description",
+      "上传图片的提示语言"
+    ]
+  ],
+  "message.editQRTip": [
+    [
+      "message",
+      "Рекомендуемый размер: 200*200px"
+    ],
+    [
+      "description",
+      "上传图片的提示语言"
+    ]
+  ],
+  "message.editFaviconTip": [
+    [
+      "message",
+      "Рекомендуемый размер: 32*32px"
+    ],
+    [
+      "description",
+      "上传图片的提示语言"
+    ]
+  ],
+  "message.editUrl": [
+    [
+      "message",
+      "Введите ссылку"
+    ],
+    [
+      "description",
+      "请输入链接的提示"
+    ]
+  ],
+  "message.atLeastOneAdmin": [
+    [
+      "message",
+      "Должен быть хотя бы один администратор"
+    ],
+    [
+      "description",
+      "至少保留一个管理员的提示"
+    ]
+  ],
+  "message.distributionDefaultInviterIdTip": [
+    [
+      "message",
+      "ID пользователя приглашенного по умолчанию. Если ссылка на распределение не содержит параметра inviter_id, будет использоваться этот ID."
+    ],
+    [
+      "description",
+      "默认邀请人ID的提示"
+    ]
+  ],
+  "message.distributionForceInviterIdTip": [
+    [
+      "message",
+      "ID обязательного приглашенного. Если установлен этот ID, будет использоваться он, независимо от наличия параметра inviter_id в ссылке."
+    ],
+    [
+      "description",
+      "强制邀请人ID的提示"
+    ]
+  ],
+  "message.originTip": [
+    [
+      "message",
+      "Домен сайта, конфигурация сайта связана с доменом, домен сайта нельзя изменить."
+    ],
+    [
+      "description",
+      "站点域名的提示"
+    ]
+  ],
+  "message.titleTip": [
+    [
+      "message",
+      "Заголовок сайта, отображается на вкладке браузера."
+    ],
+    [
+      "description",
+      "站点标题的提示"
+    ]
+  ],
+  "message.descriptionTip": [
+    [
+      "message",
+      "Описание сайта, находится в метаданных сайта, используется для SEO-оптимизации."
+    ],
+    [
+      "description",
+      "站点描述的提示"
+    ]
+  ],
+  "message.logoTip": [
+    [
+      "message",
+      "Логотип сайта, отображается в верхней части меню сайта, когда меню развернуто."
+    ],
+    [
+      "description",
+      "站点 Logo 的提示"
+    ]
+  ],
+  "message.faviconTip": [
+    [
+      "message",
+      "Favicon сайта, отображается на вкладке браузера."
+    ],
+    [
+      "description",
+      "站点 Favicon 的提示"
+    ]
+  ],
+  "message.adminsTip": [
+    [
+      "message",
+      "ID администраторов сайта. По умолчанию первый созданный пользователь становится администратором, только администраторы могут управлять сайтом."
+    ],
+    [
+      "description",
+      "站点管理员的提示"
+    ]
+  ],
+  "message.adminsTip2": [
+    [
+      "message",
+      "Здесь можно добавлять или удалять ID администраторов. Вы можете посмотреть ID пользователей на https://auth.acedata.cloud"
+    ],
+    [
+      "description",
+      "站点管理员的提示"
+    ]
+  ],
+  "message.keywordsTip": [
+    [
+      "message",
+      "Ключевые слова сайта, находятся в метаданных сайта, используются для SEO-оптимизации."
+    ],
+    [
+      "description",
+      "站点关键词的提示"
+    ]
+  ],
+  "message.keywordsTip2": [
+    [
+      "message",
+      "Здесь можно добавлять или удалять ключевые слова сайта. Чем точнее ключевые слова, тем лучше для SEO-оптимизации."
+    ],
+    [
+      "description",
+      "站点关键词的提示"
+    ]
+  ],
+  "message.featuresChat": [
+    [
+      "message",
+      "Включить или отключить модуль функции Chat."
+    ],
+    [
+      "description",
+      "Chat 功能的描述"
+    ]
+  ],
+  "message.featuresGrok": [
+    [
+      "message",
+      "Включить или отключить модуль функции Grok."
+    ],
+    [
+      "description",
+      "Grok 功能的描述"
+    ]
+  ],
+  "message.featuresDeepseek": [
+    [
+      "message",
+      "Включить или отключить модуль функции Deepseek."
+    ],
+    [
+      "description",
+      "Deepseek 功能的描述"
+    ]
+  ],
+  "message.featuresChatgpt": [
+    [
+      "message",
+      "Включить или отключить модуль функции ChatGPT."
+    ],
+    [
+      "description",
+      "ChatGPT 功能的描述"
+    ]
+  ],
+  "message.featuresMidjourney": [
+    [
+      "message",
+      "Включить или отключить модуль функции Midjourney."
+    ],
+    [
+      "description",
+      "Midjourney 功能的描述"
+    ]
+  ],
+  "message.featuresChatdoc": [
+    [
+      "message",
+      "Включить или отключить модуль функции Chatdoc."
+    ],
+    [
+      "description",
+      "Chatdoc 功能的描述"
+    ]
+  ],
+  "message.featuresQrart": [
+    [
+      "message",
+      "Включить или отключить модуль функции Qrart."
+    ],
+    [
+      "description",
+      "Qrart 功能的描述"
+    ]
+  ],
+  "message.featuresVeo": [
+    [
+      "message",
+      "Включить или отключить модуль функции Veo."
+    ],
+    [
+      "description",
+      "Veo 功能的描述"
+    ]
+  ],
+  "message.featuresSora": [
+    [
+      "message",
+      "Включить или отключить модуль функции Sora."
+    ],
+    [
+      "description",
+      "Sora 功能的描述"
+    ]
+  ],
+  "message.featuresSuno": [
+    [
+      "message",
+      "Включить или отключить модуль функции Suno."
+    ],
+    [
+      "description",
+      "Suno 功能的描述"
+    ]
+  ],
+  "message.featuresPixverse": [
+    [
+      "message",
+      "Включить или отключить модуль функций Pixverse."
+    ],
+    [
+      "description",
+      "Описание функции Pixverse"
+    ]
+  ],
+  "message.featuresFlux": [
+    [
+      "message",
+      "Включить или отключить модуль функций FLux."
+    ],
+    [
+      "description",
+      "Описание функции FLux"
+    ]
+  ],
+  "message.featuresNanobanana": [
+    [
+      "message",
+      "Включить или отключить модуль функций Nano Banana."
+    ],
+    [
+      "description",
+      "Описание функции Nano Banana"
+    ]
+  ],
+  "message.featuresOpenaiimage": {
+    "message": "Toggle OpenAI Image feature module.",
+    "description": "Description of the OpenAI Image feature"
+  },
+  "message.featuresSeedream": [
+    [
+      "message",
+      "Включить или отключить модуль функций SeeDream."
+    ],
+    [
+      "description",
+      "Описание функции SeeDream"
+    ]
+  ],
+  "message.featuresSeedance": [
+    [
+      "message",
+      "Включить или отключить модуль функций SeeDance."
+    ],
+    [
+      "description",
+      "Описание функции SeeDance"
+    ]
+  ],
+  "message.featuresWan": [
+    [
+      "message",
+      "Включить или отключить модуль функций Wan."
+    ],
+    [
+      "description",
+      "Описание функции Wan"
+    ]
+  ],
+  "message.featuresProducer": [
+    [
+      "message",
+      "Включить или отключить модуль функций Producer."
+    ],
+    [
+      "description",
+      "Описание функции Producer"
+    ]
+  ],
+  "message.featuresKimi": [
+    [
+      "message",
+      "Включить или отключить модуль функций Kimi."
+    ],
+    [
+      "description",
+      "Описание функции Kimi"
+    ]
+  ],
+  "message.featuresSerp": [
+    [
+      "message",
+      "Включить или отключить модуль функций SERP."
+    ],
+    [
+      "description",
+      "Описание функции SERP"
+    ]
+  ],
+  "message.featuresLuma": [
+    [
+      "message",
+      "Включить или отключить модуль функций Luma."
+    ],
+    [
+      "description",
+      "Описание функции Luma"
+    ]
+  ],
+  "message.featuresPika": [
+    [
+      "message",
+      "Включить или отключить модуль функций Pika."
+    ],
+    [
+      "description",
+      "Описание функции Pika"
+    ]
+  ],
+  "message.featuresKling": [
+    [
+      "message",
+      "Включить или отключить модуль функций Kling."
+    ],
+    [
+      "description",
+      "Описание функции Kling"
+    ]
+  ],
+  "message.featuresHailuo": [
+    [
+      "message",
+      "Включить или отключить модуль функций Hailuo."
+    ],
+    [
+      "description",
+      "Описание функции Hailuo"
+    ]
+  ],
+  "message.featuresHeadshots": [
+    [
+      "message",
+      "Включить или отключить модуль функций AI удостоверения личности."
+    ],
+    [
+      "description",
+      "Описание функции AI удостоверения личности"
+    ]
+  ],
+  "message.featuresSupport": [
+    [
+      "message",
+      "Включить или отключить поддержку клиентов"
+    ],
+    [
+      "description",
+      "Описание функции поддержки"
+    ]
+  ],
+  "message.featuresI18n": [
+    [
+      "message",
+      "Включить или отключить поддержку нескольких языков. При отключении пользователи смогут использовать только язык по умолчанию."
+    ],
+    [
+      "description",
+      "Описание поддержки нескольких языков"
+    ]
+  ],
+  "button.upload": [
+    [
+      "message",
+      "Загрузить"
+    ],
+    [
+      "description",
+      "Загрузить"
+    ]
+  ],
+  "button.enabled": [
+    [
+      "message",
+      "Включено"
+    ],
+    [
+      "description",
+      "Текст переключателя, указывающий, что функция включена"
+    ]
+  ],
+  "button.disabled": [
+    [
+      "message",
+      "Отключено"
+    ],
+    [
+      "description",
+      "Текст переключателя, указывающий, что функция отключена"
+    ]
+  ],
+  "field.featuresGemini": [
+    [
+      "message",
+      "Gemini"
+    ],
+    [
+      "description",
+      "Отображается как заголовок в редакторе"
+    ]
+  ],
+  "message.featuresGemini": [
+    [
+      "message",
+      "Включить или отключить модуль функций Gemini."
+    ],
+    [
+      "description",
+      "Описание функции Gemini"
+    ]
+  ],
+  "field.featuresClaude": [
+    [
+      "message",
+      "Claude"
+    ],
+    [
+      "description",
+      "Отображается как заголовок в редакторе"
+    ]
+  ],
+  "message.featuresClaude": [
+    [
+      "message",
+      "Включить или отключить модуль функций Claude."
+    ],
+    [
+      "description",
+      "Описание функции Claude"
+    ]
+  ]
 }

--- a/src/i18n/ru/site.json
+++ b/src/i18n/ru/site.json
@@ -1,1110 +1,450 @@
 {
-  "field.title": [
-    [
-      "message",
-      "Заголовок сайта"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.origin": [
-    [
-      "message",
-      "Домен сайта"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.description": [
-    [
-      "message",
-      "Описание сайта"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.keywords": [
-    [
-      "message",
-      "Ключевые слова сайта"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.logo": [
-    [
-      "message",
-      "Логотип сайта"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.favicon": [
-    [
-      "message",
-      "Favicon сайта"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.qr": [
-    [
-      "message",
-      "QR-код"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.url": [
-    [
-      "message",
-      "Ссылка"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.admins": [
-    [
-      "message",
-      "ID администраторов сайта"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.distributionDefaultInviterId": [
-    [
-      "message",
-      "ID приглашенного по умолчанию"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.distributionForceInviterId": [
-    [
-      "message",
-      "ID обязательного приглашенного"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresChat": [
-    [
-      "message",
-      "Чат"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresVeo": [
-    [
-      "message",
-      "Veo"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresSora": [
-    [
-      "message",
-      "Sora"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresGrok": [
-    [
-      "message",
-      "Grok"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresDeepseek": [
-    [
-      "message",
-      "Deepseek"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresChatgpt": [
-    [
-      "message",
-      "ChatGPT"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresMidjourney": [
-    [
-      "message",
-      "Midjourney"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresChatdoc": [
-    [
-      "message",
-      "Chatdoc"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresQrart": [
-    [
-      "message",
-      "Qrart"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresLuma": [
-    [
-      "message",
-      "Luma"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresPixverse": [
-    [
-      "message",
-      "Pixverse"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresPika": [
-    [
-      "message",
-      "Pika"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresKling": [
-    [
-      "message",
-      "Kling"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresHailuo": [
-    [
-      "message",
-      "Hailuo"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresHeadshots": [
-    [
-      "message",
-      "AI Фотография"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresSuno": [
-    [
-      "message",
-      "Suno"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresFlux": [
-    [
-      "message",
-      "Flux"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresNanobanana": [
-    [
-      "message",
-      "Нано Банан"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
+  "field.title": {
+    "message": "Заголовок сайта",
+    "description": "展示在编辑框的标题"
+  },
+  "field.origin": {
+    "message": "Домен сайта",
+    "description": "展示在编辑框的标题"
+  },
+  "field.description": {
+    "message": "Описание сайта",
+    "description": "展示在编辑框的标题"
+  },
+  "field.keywords": {
+    "message": "Ключевые слова сайта",
+    "description": "展示在编辑框的标题"
+  },
+  "field.logo": {
+    "message": "Логотип сайта",
+    "description": "展示在编辑框的标题"
+  },
+  "field.favicon": {
+    "message": "Favicon сайта",
+    "description": "展示在编辑框的标题"
+  },
+  "field.qr": {
+    "message": "QR-код",
+    "description": "展示在编辑框的标题"
+  },
+  "field.url": {
+    "message": "Ссылка",
+    "description": "展示在编辑框的标题"
+  },
+  "field.admins": {
+    "message": "ID администраторов сайта",
+    "description": "展示在编辑框的标题"
+  },
+  "field.distributionDefaultInviterId": {
+    "message": "ID приглашенного по умолчанию",
+    "description": "展示在编辑框的标题"
+  },
+  "field.distributionForceInviterId": {
+    "message": "ID обязательного приглашенного",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresChat": {
+    "message": "Чат",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresVeo": {
+    "message": "Veo",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresSora": {
+    "message": "Sora",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresGrok": {
+    "message": "Grok",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresDeepseek": {
+    "message": "Deepseek",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresChatgpt": {
+    "message": "ChatGPT",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresMidjourney": {
+    "message": "Midjourney",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresChatdoc": {
+    "message": "Chatdoc",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresQrart": {
+    "message": "Qrart",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresLuma": {
+    "message": "Luma",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresPixverse": {
+    "message": "Pixverse",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresPika": {
+    "message": "Pika",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresKling": {
+    "message": "Kling",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresHailuo": {
+    "message": "Hailuo",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresHeadshots": {
+    "message": "AI Фотография",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresSuno": {
+    "message": "Suno",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresFlux": {
+    "message": "Flux",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresNanobanana": {
+    "message": "Нано Банан",
+    "description": "展示在编辑框的标题"
+  },
   "field.featuresOpenaiimage": {
     "message": "OpenAI Image",
     "description": "Displayed as the title in the editing box"
   },
-  "field.featuresSeedream": [
-    [
-      "message",
-      "SeeDream"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresSeedance": [
-    [
-      "message",
-      "SeeDance"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresWan": [
-    [
-      "message",
-      "Wan"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresProducer": [
-    [
-      "message",
-      "Продюсер"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresKimi": [
-    [
-      "message",
-      "Kimi"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresSerp": [
-    [
-      "message",
-      "SERP"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresSupport": [
-    [
-      "message",
-      "Поддержка клиентов"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresI18n": [
-    [
-      "message",
-      "Многоязычная поддержка"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.basicConfig": [
-    [
-      "message",
-      "Основные настройки"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.seoConfig": [
-    [
-      "message",
-      "Настройки SEO"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editAdmins": [
-    [
-      "message",
-      "Редактировать администраторов"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.featuresConfig": [
-    [
-      "message",
-      "Настройки функций"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editTitle": [
-    [
-      "message",
-      "Редактировать заголовок"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editOrigin": [
-    [
-      "message",
-      "Редактировать домен"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editKeywords": [
-    [
-      "message",
-      "Редактировать ключевые слова"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editLogo": [
-    [
-      "message",
-      "Редактировать логотип"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editFavicon": [
-    [
-      "message",
-      "Редактировать Favicon"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editDescription": [
-    [
-      "message",
-      "Редактировать описание"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.distributionConfig": [
-    [
-      "message",
-      "Настройки дистрибуции"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editDistributionDefaultInviterId": [
-    [
-      "message",
-      "Редактировать приглашенного по умолчанию"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editDistributionForceInviterId": [
-    [
-      "message",
-      "Редактировать обязательного приглашенного"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editQR": [
-    [
-      "message",
-      "Редактировать QR-код"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editUrl": [
-    [
-      "message",
-      "Редактировать ссылку"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "placeholder.title": [
-    [
-      "message",
-      "Введите заголовок сайта"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "placeholder.origin": [
-    [
-      "message",
-      "Введите домен сайта"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "placeholder.editUrl": [
-    [
-      "message",
-      "Введите ссылку"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "placeholder.description": [
-    [
-      "message",
-      "Введите описание сайта"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "placeholder.keywords": [
-    [
-      "message",
-      "Введите ключевые слова сайта"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "placeholder.editDistributionDefaultInviterId": [
-    [
-      "message",
-      "Введите ID приглашенного по умолчанию"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "placeholder.editDistributionForceInviterId": [
-    [
-      "message",
-      "Введите ID обязательного приглашенного"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "message.uploadImageExceed": [
-    [
-      "message",
-      "Превышен лимит загрузки изображения"
-    ],
-    [
-      "description",
-      "上传图片超过限制的提示"
-    ]
-  ],
-  "message.uploadImageError": [
-    [
-      "message",
-      "Ошибка загрузки изображения"
-    ],
-    [
-      "description",
-      "上传图片错误的提示"
-    ]
-  ],
-  "message.editLogoTip": [
-    [
-      "message",
-      "Рекомендуемый размер: 200*60px"
-    ],
-    [
-      "description",
-      "上传图片的提示语言"
-    ]
-  ],
-  "message.editQRTip": [
-    [
-      "message",
-      "Рекомендуемый размер: 200*200px"
-    ],
-    [
-      "description",
-      "上传图片的提示语言"
-    ]
-  ],
-  "message.editFaviconTip": [
-    [
-      "message",
-      "Рекомендуемый размер: 32*32px"
-    ],
-    [
-      "description",
-      "上传图片的提示语言"
-    ]
-  ],
-  "message.editUrl": [
-    [
-      "message",
-      "Введите ссылку"
-    ],
-    [
-      "description",
-      "请输入链接的提示"
-    ]
-  ],
-  "message.atLeastOneAdmin": [
-    [
-      "message",
-      "Должен быть хотя бы один администратор"
-    ],
-    [
-      "description",
-      "至少保留一个管理员的提示"
-    ]
-  ],
-  "message.distributionDefaultInviterIdTip": [
-    [
-      "message",
-      "ID пользователя приглашенного по умолчанию. Если ссылка на распределение не содержит параметра inviter_id, будет использоваться этот ID."
-    ],
-    [
-      "description",
-      "默认邀请人ID的提示"
-    ]
-  ],
-  "message.distributionForceInviterIdTip": [
-    [
-      "message",
-      "ID обязательного приглашенного. Если установлен этот ID, будет использоваться он, независимо от наличия параметра inviter_id в ссылке."
-    ],
-    [
-      "description",
-      "强制邀请人ID的提示"
-    ]
-  ],
-  "message.originTip": [
-    [
-      "message",
-      "Домен сайта, конфигурация сайта связана с доменом, домен сайта нельзя изменить."
-    ],
-    [
-      "description",
-      "站点域名的提示"
-    ]
-  ],
-  "message.titleTip": [
-    [
-      "message",
-      "Заголовок сайта, отображается на вкладке браузера."
-    ],
-    [
-      "description",
-      "站点标题的提示"
-    ]
-  ],
-  "message.descriptionTip": [
-    [
-      "message",
-      "Описание сайта, находится в метаданных сайта, используется для SEO-оптимизации."
-    ],
-    [
-      "description",
-      "站点描述的提示"
-    ]
-  ],
-  "message.logoTip": [
-    [
-      "message",
-      "Логотип сайта, отображается в верхней части меню сайта, когда меню развернуто."
-    ],
-    [
-      "description",
-      "站点 Logo 的提示"
-    ]
-  ],
-  "message.faviconTip": [
-    [
-      "message",
-      "Favicon сайта, отображается на вкладке браузера."
-    ],
-    [
-      "description",
-      "站点 Favicon 的提示"
-    ]
-  ],
-  "message.adminsTip": [
-    [
-      "message",
-      "ID администраторов сайта. По умолчанию первый созданный пользователь становится администратором, только администраторы могут управлять сайтом."
-    ],
-    [
-      "description",
-      "站点管理员的提示"
-    ]
-  ],
-  "message.adminsTip2": [
-    [
-      "message",
-      "Здесь можно добавлять или удалять ID администраторов. Вы можете посмотреть ID пользователей на https://auth.acedata.cloud"
-    ],
-    [
-      "description",
-      "站点管理员的提示"
-    ]
-  ],
-  "message.keywordsTip": [
-    [
-      "message",
-      "Ключевые слова сайта, находятся в метаданных сайта, используются для SEO-оптимизации."
-    ],
-    [
-      "description",
-      "站点关键词的提示"
-    ]
-  ],
-  "message.keywordsTip2": [
-    [
-      "message",
-      "Здесь можно добавлять или удалять ключевые слова сайта. Чем точнее ключевые слова, тем лучше для SEO-оптимизации."
-    ],
-    [
-      "description",
-      "站点关键词的提示"
-    ]
-  ],
-  "message.featuresChat": [
-    [
-      "message",
-      "Включить или отключить модуль функции Chat."
-    ],
-    [
-      "description",
-      "Chat 功能的描述"
-    ]
-  ],
-  "message.featuresGrok": [
-    [
-      "message",
-      "Включить или отключить модуль функции Grok."
-    ],
-    [
-      "description",
-      "Grok 功能的描述"
-    ]
-  ],
-  "message.featuresDeepseek": [
-    [
-      "message",
-      "Включить или отключить модуль функции Deepseek."
-    ],
-    [
-      "description",
-      "Deepseek 功能的描述"
-    ]
-  ],
-  "message.featuresChatgpt": [
-    [
-      "message",
-      "Включить или отключить модуль функции ChatGPT."
-    ],
-    [
-      "description",
-      "ChatGPT 功能的描述"
-    ]
-  ],
-  "message.featuresMidjourney": [
-    [
-      "message",
-      "Включить или отключить модуль функции Midjourney."
-    ],
-    [
-      "description",
-      "Midjourney 功能的描述"
-    ]
-  ],
-  "message.featuresChatdoc": [
-    [
-      "message",
-      "Включить или отключить модуль функции Chatdoc."
-    ],
-    [
-      "description",
-      "Chatdoc 功能的描述"
-    ]
-  ],
-  "message.featuresQrart": [
-    [
-      "message",
-      "Включить или отключить модуль функции Qrart."
-    ],
-    [
-      "description",
-      "Qrart 功能的描述"
-    ]
-  ],
-  "message.featuresVeo": [
-    [
-      "message",
-      "Включить или отключить модуль функции Veo."
-    ],
-    [
-      "description",
-      "Veo 功能的描述"
-    ]
-  ],
-  "message.featuresSora": [
-    [
-      "message",
-      "Включить или отключить модуль функции Sora."
-    ],
-    [
-      "description",
-      "Sora 功能的描述"
-    ]
-  ],
-  "message.featuresSuno": [
-    [
-      "message",
-      "Включить или отключить модуль функции Suno."
-    ],
-    [
-      "description",
-      "Suno 功能的描述"
-    ]
-  ],
-  "message.featuresPixverse": [
-    [
-      "message",
-      "Включить или отключить модуль функций Pixverse."
-    ],
-    [
-      "description",
-      "Описание функции Pixverse"
-    ]
-  ],
-  "message.featuresFlux": [
-    [
-      "message",
-      "Включить или отключить модуль функций FLux."
-    ],
-    [
-      "description",
-      "Описание функции FLux"
-    ]
-  ],
-  "message.featuresNanobanana": [
-    [
-      "message",
-      "Включить или отключить модуль функций Nano Banana."
-    ],
-    [
-      "description",
-      "Описание функции Nano Banana"
-    ]
-  ],
+  "field.featuresSeedream": {
+    "message": "SeeDream",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresSeedance": {
+    "message": "SeeDance",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresWan": {
+    "message": "Wan",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresProducer": {
+    "message": "Продюсер",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresKimi": {
+    "message": "Kimi",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresSerp": {
+    "message": "SERP",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresSupport": {
+    "message": "Поддержка клиентов",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresI18n": {
+    "message": "Многоязычная поддержка",
+    "description": "展示在编辑框的标题"
+  },
+  "title.basicConfig": {
+    "message": "Основные настройки",
+    "description": "展示在编辑框的标题"
+  },
+  "title.seoConfig": {
+    "message": "Настройки SEO",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editAdmins": {
+    "message": "Редактировать администраторов",
+    "description": "展示在编辑框的标题"
+  },
+  "title.featuresConfig": {
+    "message": "Настройки функций",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editTitle": {
+    "message": "Редактировать заголовок",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editOrigin": {
+    "message": "Редактировать домен",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editKeywords": {
+    "message": "Редактировать ключевые слова",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editLogo": {
+    "message": "Редактировать логотип",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editFavicon": {
+    "message": "Редактировать Favicon",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editDescription": {
+    "message": "Редактировать описание",
+    "description": "展示在编辑框的标题"
+  },
+  "title.distributionConfig": {
+    "message": "Настройки дистрибуции",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editDistributionDefaultInviterId": {
+    "message": "Редактировать приглашенного по умолчанию",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editDistributionForceInviterId": {
+    "message": "Редактировать обязательного приглашенного",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editQR": {
+    "message": "Редактировать QR-код",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editUrl": {
+    "message": "Редактировать ссылку",
+    "description": "展示在编辑框的标题"
+  },
+  "placeholder.title": {
+    "message": "Введите заголовок сайта",
+    "description": "展示在编辑框的标题"
+  },
+  "placeholder.origin": {
+    "message": "Введите домен сайта",
+    "description": "展示在编辑框的标题"
+  },
+  "placeholder.editUrl": {
+    "message": "Введите ссылку",
+    "description": "展示在编辑框的标题"
+  },
+  "placeholder.description": {
+    "message": "Введите описание сайта",
+    "description": "展示在编辑框的标题"
+  },
+  "placeholder.keywords": {
+    "message": "Введите ключевые слова сайта",
+    "description": "展示在编辑框的标题"
+  },
+  "placeholder.editDistributionDefaultInviterId": {
+    "message": "Введите ID приглашенного по умолчанию",
+    "description": "展示在编辑框的标题"
+  },
+  "placeholder.editDistributionForceInviterId": {
+    "message": "Введите ID обязательного приглашенного",
+    "description": "展示在编辑框的标题"
+  },
+  "message.uploadImageExceed": {
+    "message": "Превышен лимит загрузки изображения",
+    "description": "上传图片超过限制的提示"
+  },
+  "message.uploadImageError": {
+    "message": "Ошибка загрузки изображения",
+    "description": "上传图片错误的提示"
+  },
+  "message.editLogoTip": {
+    "message": "Рекомендуемый размер: 200*60px",
+    "description": "上传图片的提示语言"
+  },
+  "message.editQRTip": {
+    "message": "Рекомендуемый размер: 200*200px",
+    "description": "上传图片的提示语言"
+  },
+  "message.editFaviconTip": {
+    "message": "Рекомендуемый размер: 32*32px",
+    "description": "上传图片的提示语言"
+  },
+  "message.editUrl": {
+    "message": "Введите ссылку",
+    "description": "请输入链接的提示"
+  },
+  "message.atLeastOneAdmin": {
+    "message": "Должен быть хотя бы один администратор",
+    "description": "至少保留一个管理员的提示"
+  },
+  "message.distributionDefaultInviterIdTip": {
+    "message": "ID пользователя приглашенного по умолчанию. Если ссылка на распределение не содержит параметра inviter_id, будет использоваться этот ID.",
+    "description": "默认邀请人ID的提示"
+  },
+  "message.distributionForceInviterIdTip": {
+    "message": "ID обязательного приглашенного. Если установлен этот ID, будет использоваться он, независимо от наличия параметра inviter_id в ссылке.",
+    "description": "强制邀请人ID的提示"
+  },
+  "message.originTip": {
+    "message": "Домен сайта, конфигурация сайта связана с доменом, домен сайта нельзя изменить.",
+    "description": "站点域名的提示"
+  },
+  "message.titleTip": {
+    "message": "Заголовок сайта, отображается на вкладке браузера.",
+    "description": "站点标题的提示"
+  },
+  "message.descriptionTip": {
+    "message": "Описание сайта, находится в метаданных сайта, используется для SEO-оптимизации.",
+    "description": "站点描述的提示"
+  },
+  "message.logoTip": {
+    "message": "Логотип сайта, отображается в верхней части меню сайта, когда меню развернуто.",
+    "description": "站点 Logo 的提示"
+  },
+  "message.faviconTip": {
+    "message": "Favicon сайта, отображается на вкладке браузера.",
+    "description": "站点 Favicon 的提示"
+  },
+  "message.adminsTip": {
+    "message": "ID администраторов сайта. По умолчанию первый созданный пользователь становится администратором, только администраторы могут управлять сайтом.",
+    "description": "站点管理员的提示"
+  },
+  "message.adminsTip2": {
+    "message": "Здесь можно добавлять или удалять ID администраторов. Вы можете посмотреть ID пользователей на https://auth.acedata.cloud",
+    "description": "站点管理员的提示"
+  },
+  "message.keywordsTip": {
+    "message": "Ключевые слова сайта, находятся в метаданных сайта, используются для SEO-оптимизации.",
+    "description": "站点关键词的提示"
+  },
+  "message.keywordsTip2": {
+    "message": "Здесь можно добавлять или удалять ключевые слова сайта. Чем точнее ключевые слова, тем лучше для SEO-оптимизации.",
+    "description": "站点关键词的提示"
+  },
+  "message.featuresChat": {
+    "message": "Включить или отключить модуль функции Chat.",
+    "description": "Chat 功能的描述"
+  },
+  "message.featuresGrok": {
+    "message": "Включить или отключить модуль функции Grok.",
+    "description": "Grok 功能的描述"
+  },
+  "message.featuresDeepseek": {
+    "message": "Включить или отключить модуль функции Deepseek.",
+    "description": "Deepseek 功能的描述"
+  },
+  "message.featuresChatgpt": {
+    "message": "Включить или отключить модуль функции ChatGPT.",
+    "description": "ChatGPT 功能的描述"
+  },
+  "message.featuresMidjourney": {
+    "message": "Включить или отключить модуль функции Midjourney.",
+    "description": "Midjourney 功能的描述"
+  },
+  "message.featuresChatdoc": {
+    "message": "Включить или отключить модуль функции Chatdoc.",
+    "description": "Chatdoc 功能的描述"
+  },
+  "message.featuresQrart": {
+    "message": "Включить или отключить модуль функции Qrart.",
+    "description": "Qrart 功能的描述"
+  },
+  "message.featuresVeo": {
+    "message": "Включить или отключить модуль функции Veo.",
+    "description": "Veo 功能的描述"
+  },
+  "message.featuresSora": {
+    "message": "Включить или отключить модуль функции Sora.",
+    "description": "Sora 功能的描述"
+  },
+  "message.featuresSuno": {
+    "message": "Включить или отключить модуль функции Suno.",
+    "description": "Suno 功能的描述"
+  },
+  "message.featuresPixverse": {
+    "message": "Включить или отключить модуль функций Pixverse.",
+    "description": "Описание функции Pixverse"
+  },
+  "message.featuresFlux": {
+    "message": "Включить или отключить модуль функций FLux.",
+    "description": "Описание функции FLux"
+  },
+  "message.featuresNanobanana": {
+    "message": "Включить или отключить модуль функций Nano Banana.",
+    "description": "Описание функции Nano Banana"
+  },
   "message.featuresOpenaiimage": {
     "message": "Toggle OpenAI Image feature module.",
     "description": "Description of the OpenAI Image feature"
   },
-  "message.featuresSeedream": [
-    [
-      "message",
-      "Включить или отключить модуль функций SeeDream."
-    ],
-    [
-      "description",
-      "Описание функции SeeDream"
-    ]
-  ],
-  "message.featuresSeedance": [
-    [
-      "message",
-      "Включить или отключить модуль функций SeeDance."
-    ],
-    [
-      "description",
-      "Описание функции SeeDance"
-    ]
-  ],
-  "message.featuresWan": [
-    [
-      "message",
-      "Включить или отключить модуль функций Wan."
-    ],
-    [
-      "description",
-      "Описание функции Wan"
-    ]
-  ],
-  "message.featuresProducer": [
-    [
-      "message",
-      "Включить или отключить модуль функций Producer."
-    ],
-    [
-      "description",
-      "Описание функции Producer"
-    ]
-  ],
-  "message.featuresKimi": [
-    [
-      "message",
-      "Включить или отключить модуль функций Kimi."
-    ],
-    [
-      "description",
-      "Описание функции Kimi"
-    ]
-  ],
-  "message.featuresSerp": [
-    [
-      "message",
-      "Включить или отключить модуль функций SERP."
-    ],
-    [
-      "description",
-      "Описание функции SERP"
-    ]
-  ],
-  "message.featuresLuma": [
-    [
-      "message",
-      "Включить или отключить модуль функций Luma."
-    ],
-    [
-      "description",
-      "Описание функции Luma"
-    ]
-  ],
-  "message.featuresPika": [
-    [
-      "message",
-      "Включить или отключить модуль функций Pika."
-    ],
-    [
-      "description",
-      "Описание функции Pika"
-    ]
-  ],
-  "message.featuresKling": [
-    [
-      "message",
-      "Включить или отключить модуль функций Kling."
-    ],
-    [
-      "description",
-      "Описание функции Kling"
-    ]
-  ],
-  "message.featuresHailuo": [
-    [
-      "message",
-      "Включить или отключить модуль функций Hailuo."
-    ],
-    [
-      "description",
-      "Описание функции Hailuo"
-    ]
-  ],
-  "message.featuresHeadshots": [
-    [
-      "message",
-      "Включить или отключить модуль функций AI удостоверения личности."
-    ],
-    [
-      "description",
-      "Описание функции AI удостоверения личности"
-    ]
-  ],
-  "message.featuresSupport": [
-    [
-      "message",
-      "Включить или отключить поддержку клиентов"
-    ],
-    [
-      "description",
-      "Описание функции поддержки"
-    ]
-  ],
-  "message.featuresI18n": [
-    [
-      "message",
-      "Включить или отключить поддержку нескольких языков. При отключении пользователи смогут использовать только язык по умолчанию."
-    ],
-    [
-      "description",
-      "Описание поддержки нескольких языков"
-    ]
-  ],
-  "button.upload": [
-    [
-      "message",
-      "Загрузить"
-    ],
-    [
-      "description",
-      "Загрузить"
-    ]
-  ],
-  "button.enabled": [
-    [
-      "message",
-      "Включено"
-    ],
-    [
-      "description",
-      "Текст переключателя, указывающий, что функция включена"
-    ]
-  ],
-  "button.disabled": [
-    [
-      "message",
-      "Отключено"
-    ],
-    [
-      "description",
-      "Текст переключателя, указывающий, что функция отключена"
-    ]
-  ],
-  "field.featuresGemini": [
-    [
-      "message",
-      "Gemini"
-    ],
-    [
-      "description",
-      "Отображается как заголовок в редакторе"
-    ]
-  ],
-  "message.featuresGemini": [
-    [
-      "message",
-      "Включить или отключить модуль функций Gemini."
-    ],
-    [
-      "description",
-      "Описание функции Gemini"
-    ]
-  ],
-  "field.featuresClaude": [
-    [
-      "message",
-      "Claude"
-    ],
-    [
-      "description",
-      "Отображается как заголовок в редакторе"
-    ]
-  ],
-  "message.featuresClaude": [
-    [
-      "message",
-      "Включить или отключить модуль функций Claude."
-    ],
-    [
-      "description",
-      "Описание функции Claude"
-    ]
-  ]
+  "message.featuresSeedream": {
+    "message": "Включить или отключить модуль функций SeeDream.",
+    "description": "Описание функции SeeDream"
+  },
+  "message.featuresSeedance": {
+    "message": "Включить или отключить модуль функций SeeDance.",
+    "description": "Описание функции SeeDance"
+  },
+  "message.featuresWan": {
+    "message": "Включить или отключить модуль функций Wan.",
+    "description": "Описание функции Wan"
+  },
+  "message.featuresProducer": {
+    "message": "Включить или отключить модуль функций Producer.",
+    "description": "Описание функции Producer"
+  },
+  "message.featuresKimi": {
+    "message": "Включить или отключить модуль функций Kimi.",
+    "description": "Описание функции Kimi"
+  },
+  "message.featuresSerp": {
+    "message": "Включить или отключить модуль функций SERP.",
+    "description": "Описание функции SERP"
+  },
+  "message.featuresLuma": {
+    "message": "Включить или отключить модуль функций Luma.",
+    "description": "Описание функции Luma"
+  },
+  "message.featuresPika": {
+    "message": "Включить или отключить модуль функций Pika.",
+    "description": "Описание функции Pika"
+  },
+  "message.featuresKling": {
+    "message": "Включить или отключить модуль функций Kling.",
+    "description": "Описание функции Kling"
+  },
+  "message.featuresHailuo": {
+    "message": "Включить или отключить модуль функций Hailuo.",
+    "description": "Описание функции Hailuo"
+  },
+  "message.featuresHeadshots": {
+    "message": "Включить или отключить модуль функций AI удостоверения личности.",
+    "description": "Описание функции AI удостоверения личности"
+  },
+  "message.featuresSupport": {
+    "message": "Включить или отключить поддержку клиентов",
+    "description": "Описание функции поддержки"
+  },
+  "message.featuresI18n": {
+    "message": "Включить или отключить поддержку нескольких языков. При отключении пользователи смогут использовать только язык по умолчанию.",
+    "description": "Описание поддержки нескольких языков"
+  },
+  "button.upload": {
+    "message": "Загрузить",
+    "description": "Загрузить"
+  },
+  "button.enabled": {
+    "message": "Включено",
+    "description": "Текст переключателя, указывающий, что функция включена"
+  },
+  "button.disabled": {
+    "message": "Отключено",
+    "description": "Текст переключателя, указывающий, что функция отключена"
+  },
+  "field.featuresGemini": {
+    "message": "Gemini",
+    "description": "Отображается как заголовок в редакторе"
+  },
+  "message.featuresGemini": {
+    "message": "Включить или отключить модуль функций Gemini.",
+    "description": "Описание функции Gemini"
+  },
+  "field.featuresClaude": {
+    "message": "Claude",
+    "description": "Отображается как заголовок в редакторе"
+  },
+  "message.featuresClaude": {
+    "message": "Включить или отключить модуль функций Claude.",
+    "description": "Описание функции Claude"
+  }
 }

--- a/src/i18n/sr/site.json
+++ b/src/i18n/sr/site.json
@@ -1,442 +1,1110 @@
 {
-  "field.title": {
-    "message": "Naslov sajta",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "field.origin": {
-    "message": "Domen sajta",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "field.description": {
-    "message": "Opis sajta",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "field.keywords": {
-    "message": "Ključne reči sajta",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "field.logo": {
-    "message": "Logo sajta",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "field.favicon": {
-    "message": "Favicon sajta",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "field.qr": {
-    "message": "QR kod",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "field.url": {
-    "message": "Link",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "field.admins": {
-    "message": "ID administratora sajta",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "field.distributionDefaultInviterId": {
-    "message": "ID podrazumevanog pozivaoca",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "field.distributionForceInviterId": {
-    "message": "ID obaveznog pozivaoca",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "field.featuresChat": {
-    "message": "Chat",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "field.featuresVeo": {
-    "message": "Veo",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "field.featuresSora": {
-    "message": "Sora",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "field.featuresGrok": {
-    "message": "Grok",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "field.featuresDeepseek": {
-    "message": "Deepseek",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "field.featuresChatgpt": {
-    "message": "ChatGPT",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "field.featuresMidjourney": {
-    "message": "Midjourney",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "field.featuresChatdoc": {
-    "message": "Chatdoc",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "field.featuresQrart": {
-    "message": "Qrart",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "field.featuresLuma": {
-    "message": "Luma",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "field.featuresPixverse": {
-    "message": "Pixverse",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "field.featuresPika": {
-    "message": "Pika",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "field.featuresKling": {
-    "message": "Kling",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "field.featuresHailuo": {
-    "message": "Hailuo",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "field.featuresHeadshots": {
-    "message": "AI fotografije",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "field.featuresSuno": {
-    "message": "Suno",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "field.featuresFlux": {
-    "message": "Flux",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "field.featuresNanobanana": {
-    "message": "Nano Banana",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "field.featuresSeedream": {
-    "message": "SeeDream",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "field.featuresSeedance": {
-    "message": "SeeDance",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "field.featuresWan": {
-    "message": "Wan",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "field.featuresProducer": {
-    "message": "Producent",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "field.featuresKimi": {
-    "message": "Kimi",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "field.featuresSerp": {
-    "message": "SERP",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "field.featuresSupport": {
-    "message": "Korisnička podrška",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "field.featuresI18n": {
-    "message": "Podrška za više jezika",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "title.basicConfig": {
-    "message": "Osnovna podešavanja",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "title.seoConfig": {
-    "message": "SEO podešavanja",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "title.editAdmins": {
-    "message": "Uredi administratore",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "title.featuresConfig": {
-    "message": "Podešavanje funkcija",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "title.editTitle": {
-    "message": "Uredi naslov",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "title.editOrigin": {
-    "message": "Uredi domen",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "title.editKeywords": {
-    "message": "Uredi ključne reči",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "title.editLogo": {
-    "message": "Uredi logo",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "title.editFavicon": {
-    "message": "Uredi favicon",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "title.editDescription": {
-    "message": "Uredi opis",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "title.distributionConfig": {
-    "message": "Podešavanje distribucije",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "title.editDistributionDefaultInviterId": {
-    "message": "Uredi podrazumevanog pozivaoca",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "title.editDistributionForceInviterId": {
-    "message": "Uredi obaveznog pozivaoca",
-    "description": "Prikazuje se kao naslov u okviru za uređivanje"
-  },
-  "title.editQR": {
-    "message": "Уреди QR код",
-    "description": "Приказује се у заглављу уређивања"
-  },
-  "title.editUrl": {
-    "message": "Уреди линк",
-    "description": "Приказује се у заглављу уређивања"
-  },
-  "placeholder.title": {
-    "message": "Унесите наслов сајта",
-    "description": "Приказује се у уређивању"
-  },
-  "placeholder.origin": {
-    "message": "Унесите домен сајта",
-    "description": "Приказује се у уређивању"
-  },
-  "placeholder.editUrl": {
-    "message": "Унесите линк",
-    "description": "Приказује се у уређивању"
-  },
-  "placeholder.description": {
-    "message": "Унесите опис сајта",
-    "description": "Приказује се у уређивању"
-  },
-  "placeholder.keywords": {
-    "message": "Унесите кључне речи сајта",
-    "description": "Приказује се у уређивању"
-  },
-  "placeholder.editDistributionDefaultInviterId": {
-    "message": "Унесите ID подразумеваног позиватеља",
-    "description": "Приказује се у уређивању"
-  },
-  "placeholder.editDistributionForceInviterId": {
-    "message": "Унесите ID обавезног позиватеља",
-    "description": "Приказује се у уређивању"
-  },
-  "message.uploadImageExceed": {
-    "message": "Превише слике за учитавање",
-    "description": "Порука о превеликој слици за учитавање"
-  },
-  "message.uploadImageError": {
-    "message": "Грешка при учитавању слике",
-    "description": "Порука о грешци при учитавању слике"
-  },
-  "message.editLogoTip": {
-    "message": "Препоручена величина: 200*60px",
-    "description": "Језик упутства за учитавање слике"
-  },
-  "message.editQRTip": {
-    "message": "Препоручена величина: 200*200px",
-    "description": "Језик упутства за учитавање слике"
-  },
-  "message.editFaviconTip": {
-    "message": "Препоручена величина: 32*32px",
-    "description": "Језик упутства за учитавање слике"
-  },
-  "message.editUrl": {
-    "message": "Унесите линк",
-    "description": "Упутство за унос линка"
-  },
-  "message.atLeastOneAdmin": {
-    "message": "Мора остати бар један администратор",
-    "description": "Упозорење о потреби за бар једним администратором"
-  },
-  "message.distributionDefaultInviterIdTip": {
-    "message": "ID корисника подразумеваног позиватеља. Ако дистрибутивна веза не садржи параметар inviter_id, користиће се овај ID као позиватељ.",
-    "description": "Упутство о ID подразумеваног позиватеља"
-  },
-  "message.distributionForceInviterIdTip": {
-    "message": "ID корисника обавезног позиватеља. Ако је овај ID постављен, без обзира на то да ли дистрибутивна веза садржи параметар inviter_id, користиће се овај ID као позиватељ.",
-    "description": "Упутство о ID обавезног позиватеља"
-  },
-  "message.originTip": {
-    "message": "Домен сајта, конфигурација сајта је повезана са доменом и не може се променити.",
-    "description": "Упутство о домену сајта"
-  },
-  "message.titleTip": {
-    "message": "Наслов сајта, приказује се на картици прегледача.",
-    "description": "Упутство о наслову сајта"
-  },
-  "message.descriptionTip": {
-    "message": "Опис сајта, налази се у мета информацијама сајта, користи се за SEO оптимизацију.",
-    "description": "Упутство о опису сајта"
-  },
-  "message.logoTip": {
-    "message": "Лого сајта, приказује се на врху менија када се мени прошири.",
-    "description": "Упутство о логу сајта"
-  },
-  "message.faviconTip": {
-    "message": "Favicon сајта, приказује се на картици прегледача.",
-    "description": "Упутство о favicon-у сајта"
-  },
-  "message.adminsTip": {
-    "message": "ID администраторови сајта, подразумевано, први корисник који креира сајт постаје администратор, само администратори могу управљати сајтом.",
-    "description": "Упутство о администраторима сајта"
-  },
-  "message.adminsTip2": {
-    "message": "Можете додавати или уклањати ID администраторови овде, можете посетити https://auth.acedata.cloud за преглед ID корисника",
-    "description": "Упутство о администраторима сајта"
-  },
-  "message.keywordsTip": {
-    "message": "Кључне речи сајта, налазе се у мета информацијама сајта, користе се за SEO оптимизацију.",
-    "description": "Упутство о кључним речима сајта"
-  },
-  "message.keywordsTip2": {
-    "message": "Можете додавати или уклањати кључне речи сајта овде, што прецизније кључне речи, то боље за SEO оптимизацију.",
-    "description": "Упутство о кључним речима сајта"
-  },
-  "message.featuresChat": {
-    "message": "Укључи или искључи Chat модул.",
-    "description": "Опис Chat функције"
-  },
-  "message.featuresGrok": {
-    "message": "Укључи или искључи Grok модул.",
-    "description": "Опис Grok функције"
-  },
-  "message.featuresDeepseek": {
-    "message": "Укључи или искључи Deepseek модул.",
-    "description": "Опис Deepseek функције"
-  },
-  "message.featuresChatgpt": {
-    "message": "Укључи или искључи ChatGPT модул.",
-    "description": "Опис ChatGPT функције"
-  },
-  "message.featuresMidjourney": {
-    "message": "Укључи или искључи Midjourney модул.",
-    "description": "Опис Midjourney функције"
-  },
-  "message.featuresChatdoc": {
-    "message": "Укључи или искључи Chatdoc модул.",
-    "description": "Опис Chatdoc функције"
-  },
-  "message.featuresQrart": {
-    "message": "Укључи или искључи Qrart модул.",
-    "description": "Опис Qrart функције"
-  },
-  "message.featuresVeo": {
-    "message": "Укључи или искључи Veo модул.",
-    "description": "Опис Veo функције"
-  },
-  "message.featuresSora": {
-    "message": "Укључи или искључи Sora модул.",
-    "description": "Опис Sora функције"
-  },
-  "message.featuresSuno": {
-    "message": "Укључи или искључи Suno модул.",
-    "description": "Опис Suno функције"
-  },
-  "message.featuresPixverse": {
-    "message": "Uključite ili isključite Pixverse funkcionalni modul.",
-    "description": "Opis Pixverse funkcionalnosti"
-  },
-  "message.featuresFlux": {
-    "message": "Uključite ili isključite FLux funkcionalni modul.",
-    "description": "Opis FLux funkcionalnosti"
-  },
-  "message.featuresNanobanana": {
-    "message": "Uključite ili isključite Nano Banana funkcionalni modul.",
-    "description": "Opis Nano Banana funkcionalnosti"
-  },
-  "message.featuresSeedream": {
-    "message": "Uključite ili isključite SeeDream funkcionalni modul.",
-    "description": "Opis SeeDream funkcionalnosti"
-  },
-  "message.featuresSeedance": {
-    "message": "Omogućite ili onemogućite SeeDance funkcionalni modul.",
-    "description": "Opis SeeDance funkcionalnosti"
-  },
-  "message.featuresWan": {
-    "message": "Uključite ili isključite Wan funkcionalni modul.",
-    "description": "Opis Wan funkcionalnosti"
-  },
-  "message.featuresProducer": {
-    "message": "Uključite ili isključite Producer funkcionalni modul.",
-    "description": "Opis Producer funkcionalnosti"
-  },
-  "message.featuresKimi": {
-    "message": "Uključite ili isključite Kimi funkcionalni modul.",
-    "description": "Opis Kimi funkcionalnosti"
-  },
-  "message.featuresSerp": {
-    "message": "Uključite ili isključite SERP funkcionalni modul.",
-    "description": "Opis SERP funkcionalnosti"
-  },
-  "message.featuresLuma": {
-    "message": "Uključite ili isključite Luma funkcionalni modul.",
-    "description": "Opis Luma funkcionalnosti"
-  },
-  "message.featuresPika": {
-    "message": "Uključite ili isključite Pika funkcionalni modul.",
-    "description": "Opis Pika funkcionalnosti"
-  },
-  "message.featuresKling": {
-    "message": "Uključite ili isključite Kling funkcionalni modul.",
-    "description": "Opis Kling funkcionalnosti"
-  },
-  "message.featuresHailuo": {
-    "message": "Uključite ili isključite Hailuo funkcionalni modul.",
-    "description": "Opis Hailuo funkcionalnosti"
-  },
-  "message.featuresHeadshots": {
-    "message": "Uključite ili isključite AI pasoške fotografije funkcionalni modul.",
-    "description": "Opis AI pasoških fotografija funkcionalnosti"
-  },
-  "message.featuresSupport": {
-    "message": "Uključite ili isključite korisničku podršku",
-    "description": "Opis funkcionalnosti podrške"
-  },
-  "message.featuresI18n": {
-    "message": "Uključite ili isključite podršku za više jezika, kada je isključeno, korisnici mogu koristiti samo podrazumevani jezik.",
-    "description": "Opis funkcionalnosti podrške za više jezika"
-  },
-  "button.upload": {
-    "message": "Otpremi",
-    "description": "Otpremi"
-  },
-  "button.enabled": {
-    "message": "Omogućeno",
-    "description": "Tekst na prekidaču koji označava da je omogućeno"
-  },
-  "button.disabled": {
-    "message": "Onemogućeno",
-    "description": "Tekst na prekidaču koji označava da je onemogućeno"
-  },
-  "field.featuresGemini": {
-    "message": "Gemini",
-    "description": "Prikazano kao naslov u kutiji za uređivanje"
-  },
-  "message.featuresGemini": {
-    "message": "Omogućite ili onemogućite Gemini funkcionalni modul.",
-    "description": "Opis Gemini funkcionalnosti"
-  },
-  "field.featuresClaude": {
-    "message": "Claude",
-    "description": "Prikazano kao naslov u kutiji za uređivanje"
-  },
-  "message.featuresClaude": {
-    "message": "Omogućite ili onemogućite Claude funkcionalni modul.",
-    "description": "Opis Claude funkcionalnosti"
-  }
+  "field.title": [
+    [
+      "message",
+      "Naslov sajta"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "field.origin": [
+    [
+      "message",
+      "Domen sajta"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "field.description": [
+    [
+      "message",
+      "Opis sajta"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "field.keywords": [
+    [
+      "message",
+      "Ključne reči sajta"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "field.logo": [
+    [
+      "message",
+      "Logo sajta"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "field.favicon": [
+    [
+      "message",
+      "Favicon sajta"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "field.qr": [
+    [
+      "message",
+      "QR kod"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "field.url": [
+    [
+      "message",
+      "Link"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "field.admins": [
+    [
+      "message",
+      "ID administratora sajta"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "field.distributionDefaultInviterId": [
+    [
+      "message",
+      "ID podrazumevanog pozivaoca"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "field.distributionForceInviterId": [
+    [
+      "message",
+      "ID obaveznog pozivaoca"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "field.featuresChat": [
+    [
+      "message",
+      "Chat"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "field.featuresVeo": [
+    [
+      "message",
+      "Veo"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "field.featuresSora": [
+    [
+      "message",
+      "Sora"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "field.featuresGrok": [
+    [
+      "message",
+      "Grok"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "field.featuresDeepseek": [
+    [
+      "message",
+      "Deepseek"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "field.featuresChatgpt": [
+    [
+      "message",
+      "ChatGPT"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "field.featuresMidjourney": [
+    [
+      "message",
+      "Midjourney"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "field.featuresChatdoc": [
+    [
+      "message",
+      "Chatdoc"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "field.featuresQrart": [
+    [
+      "message",
+      "Qrart"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "field.featuresLuma": [
+    [
+      "message",
+      "Luma"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "field.featuresPixverse": [
+    [
+      "message",
+      "Pixverse"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "field.featuresPika": [
+    [
+      "message",
+      "Pika"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "field.featuresKling": [
+    [
+      "message",
+      "Kling"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "field.featuresHailuo": [
+    [
+      "message",
+      "Hailuo"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "field.featuresHeadshots": [
+    [
+      "message",
+      "AI fotografije"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "field.featuresSuno": [
+    [
+      "message",
+      "Suno"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "field.featuresFlux": [
+    [
+      "message",
+      "Flux"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "field.featuresNanobanana": [
+    [
+      "message",
+      "Nano Banana"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "field.featuresOpenaiimage": {
+    "message": "OpenAI Image",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresSeedream": [
+    [
+      "message",
+      "SeeDream"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "field.featuresSeedance": [
+    [
+      "message",
+      "SeeDance"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "field.featuresWan": [
+    [
+      "message",
+      "Wan"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "field.featuresProducer": [
+    [
+      "message",
+      "Producent"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "field.featuresKimi": [
+    [
+      "message",
+      "Kimi"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "field.featuresSerp": [
+    [
+      "message",
+      "SERP"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "field.featuresSupport": [
+    [
+      "message",
+      "Korisnička podrška"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "field.featuresI18n": [
+    [
+      "message",
+      "Podrška za više jezika"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "title.basicConfig": [
+    [
+      "message",
+      "Osnovna podešavanja"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "title.seoConfig": [
+    [
+      "message",
+      "SEO podešavanja"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "title.editAdmins": [
+    [
+      "message",
+      "Uredi administratore"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "title.featuresConfig": [
+    [
+      "message",
+      "Podešavanje funkcija"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "title.editTitle": [
+    [
+      "message",
+      "Uredi naslov"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "title.editOrigin": [
+    [
+      "message",
+      "Uredi domen"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "title.editKeywords": [
+    [
+      "message",
+      "Uredi ključne reči"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "title.editLogo": [
+    [
+      "message",
+      "Uredi logo"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "title.editFavicon": [
+    [
+      "message",
+      "Uredi favicon"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "title.editDescription": [
+    [
+      "message",
+      "Uredi opis"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "title.distributionConfig": [
+    [
+      "message",
+      "Podešavanje distribucije"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "title.editDistributionDefaultInviterId": [
+    [
+      "message",
+      "Uredi podrazumevanog pozivaoca"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "title.editDistributionForceInviterId": [
+    [
+      "message",
+      "Uredi obaveznog pozivaoca"
+    ],
+    [
+      "description",
+      "Prikazuje se kao naslov u okviru za uređivanje"
+    ]
+  ],
+  "title.editQR": [
+    [
+      "message",
+      "Уреди QR код"
+    ],
+    [
+      "description",
+      "Приказује се у заглављу уређивања"
+    ]
+  ],
+  "title.editUrl": [
+    [
+      "message",
+      "Уреди линк"
+    ],
+    [
+      "description",
+      "Приказује се у заглављу уређивања"
+    ]
+  ],
+  "placeholder.title": [
+    [
+      "message",
+      "Унесите наслов сајта"
+    ],
+    [
+      "description",
+      "Приказује се у уређивању"
+    ]
+  ],
+  "placeholder.origin": [
+    [
+      "message",
+      "Унесите домен сајта"
+    ],
+    [
+      "description",
+      "Приказује се у уређивању"
+    ]
+  ],
+  "placeholder.editUrl": [
+    [
+      "message",
+      "Унесите линк"
+    ],
+    [
+      "description",
+      "Приказује се у уређивању"
+    ]
+  ],
+  "placeholder.description": [
+    [
+      "message",
+      "Унесите опис сајта"
+    ],
+    [
+      "description",
+      "Приказује се у уређивању"
+    ]
+  ],
+  "placeholder.keywords": [
+    [
+      "message",
+      "Унесите кључне речи сајта"
+    ],
+    [
+      "description",
+      "Приказује се у уређивању"
+    ]
+  ],
+  "placeholder.editDistributionDefaultInviterId": [
+    [
+      "message",
+      "Унесите ID подразумеваног позиватеља"
+    ],
+    [
+      "description",
+      "Приказује се у уређивању"
+    ]
+  ],
+  "placeholder.editDistributionForceInviterId": [
+    [
+      "message",
+      "Унесите ID обавезног позиватеља"
+    ],
+    [
+      "description",
+      "Приказује се у уређивању"
+    ]
+  ],
+  "message.uploadImageExceed": [
+    [
+      "message",
+      "Превише слике за учитавање"
+    ],
+    [
+      "description",
+      "Порука о превеликој слици за учитавање"
+    ]
+  ],
+  "message.uploadImageError": [
+    [
+      "message",
+      "Грешка при учитавању слике"
+    ],
+    [
+      "description",
+      "Порука о грешци при учитавању слике"
+    ]
+  ],
+  "message.editLogoTip": [
+    [
+      "message",
+      "Препоручена величина: 200*60px"
+    ],
+    [
+      "description",
+      "Језик упутства за учитавање слике"
+    ]
+  ],
+  "message.editQRTip": [
+    [
+      "message",
+      "Препоручена величина: 200*200px"
+    ],
+    [
+      "description",
+      "Језик упутства за учитавање слике"
+    ]
+  ],
+  "message.editFaviconTip": [
+    [
+      "message",
+      "Препоручена величина: 32*32px"
+    ],
+    [
+      "description",
+      "Језик упутства за учитавање слике"
+    ]
+  ],
+  "message.editUrl": [
+    [
+      "message",
+      "Унесите линк"
+    ],
+    [
+      "description",
+      "Упутство за унос линка"
+    ]
+  ],
+  "message.atLeastOneAdmin": [
+    [
+      "message",
+      "Мора остати бар један администратор"
+    ],
+    [
+      "description",
+      "Упозорење о потреби за бар једним администратором"
+    ]
+  ],
+  "message.distributionDefaultInviterIdTip": [
+    [
+      "message",
+      "ID корисника подразумеваног позиватеља. Ако дистрибутивна веза не садржи параметар inviter_id, користиће се овај ID као позиватељ."
+    ],
+    [
+      "description",
+      "Упутство о ID подразумеваног позиватеља"
+    ]
+  ],
+  "message.distributionForceInviterIdTip": [
+    [
+      "message",
+      "ID корисника обавезног позиватеља. Ако је овај ID постављен, без обзира на то да ли дистрибутивна веза садржи параметар inviter_id, користиће се овај ID као позиватељ."
+    ],
+    [
+      "description",
+      "Упутство о ID обавезног позиватеља"
+    ]
+  ],
+  "message.originTip": [
+    [
+      "message",
+      "Домен сајта, конфигурација сајта је повезана са доменом и не може се променити."
+    ],
+    [
+      "description",
+      "Упутство о домену сајта"
+    ]
+  ],
+  "message.titleTip": [
+    [
+      "message",
+      "Наслов сајта, приказује се на картици прегледача."
+    ],
+    [
+      "description",
+      "Упутство о наслову сајта"
+    ]
+  ],
+  "message.descriptionTip": [
+    [
+      "message",
+      "Опис сајта, налази се у мета информацијама сајта, користи се за SEO оптимизацију."
+    ],
+    [
+      "description",
+      "Упутство о опису сајта"
+    ]
+  ],
+  "message.logoTip": [
+    [
+      "message",
+      "Лого сајта, приказује се на врху менија када се мени прошири."
+    ],
+    [
+      "description",
+      "Упутство о логу сајта"
+    ]
+  ],
+  "message.faviconTip": [
+    [
+      "message",
+      "Favicon сајта, приказује се на картици прегледача."
+    ],
+    [
+      "description",
+      "Упутство о favicon-у сајта"
+    ]
+  ],
+  "message.adminsTip": [
+    [
+      "message",
+      "ID администраторови сајта, подразумевано, први корисник који креира сајт постаје администратор, само администратори могу управљати сајтом."
+    ],
+    [
+      "description",
+      "Упутство о администраторима сајта"
+    ]
+  ],
+  "message.adminsTip2": [
+    [
+      "message",
+      "Можете додавати или уклањати ID администраторови овде, можете посетити https://auth.acedata.cloud за преглед ID корисника"
+    ],
+    [
+      "description",
+      "Упутство о администраторима сајта"
+    ]
+  ],
+  "message.keywordsTip": [
+    [
+      "message",
+      "Кључне речи сајта, налазе се у мета информацијама сајта, користе се за SEO оптимизацију."
+    ],
+    [
+      "description",
+      "Упутство о кључним речима сајта"
+    ]
+  ],
+  "message.keywordsTip2": [
+    [
+      "message",
+      "Можете додавати или уклањати кључне речи сајта овде, што прецизније кључне речи, то боље за SEO оптимизацију."
+    ],
+    [
+      "description",
+      "Упутство о кључним речима сајта"
+    ]
+  ],
+  "message.featuresChat": [
+    [
+      "message",
+      "Укључи или искључи Chat модул."
+    ],
+    [
+      "description",
+      "Опис Chat функције"
+    ]
+  ],
+  "message.featuresGrok": [
+    [
+      "message",
+      "Укључи или искључи Grok модул."
+    ],
+    [
+      "description",
+      "Опис Grok функције"
+    ]
+  ],
+  "message.featuresDeepseek": [
+    [
+      "message",
+      "Укључи или искључи Deepseek модул."
+    ],
+    [
+      "description",
+      "Опис Deepseek функције"
+    ]
+  ],
+  "message.featuresChatgpt": [
+    [
+      "message",
+      "Укључи или искључи ChatGPT модул."
+    ],
+    [
+      "description",
+      "Опис ChatGPT функције"
+    ]
+  ],
+  "message.featuresMidjourney": [
+    [
+      "message",
+      "Укључи или искључи Midjourney модул."
+    ],
+    [
+      "description",
+      "Опис Midjourney функције"
+    ]
+  ],
+  "message.featuresChatdoc": [
+    [
+      "message",
+      "Укључи или искључи Chatdoc модул."
+    ],
+    [
+      "description",
+      "Опис Chatdoc функције"
+    ]
+  ],
+  "message.featuresQrart": [
+    [
+      "message",
+      "Укључи или искључи Qrart модул."
+    ],
+    [
+      "description",
+      "Опис Qrart функције"
+    ]
+  ],
+  "message.featuresVeo": [
+    [
+      "message",
+      "Укључи или искључи Veo модул."
+    ],
+    [
+      "description",
+      "Опис Veo функције"
+    ]
+  ],
+  "message.featuresSora": [
+    [
+      "message",
+      "Укључи или искључи Sora модул."
+    ],
+    [
+      "description",
+      "Опис Sora функције"
+    ]
+  ],
+  "message.featuresSuno": [
+    [
+      "message",
+      "Укључи или искључи Suno модул."
+    ],
+    [
+      "description",
+      "Опис Suno функције"
+    ]
+  ],
+  "message.featuresPixverse": [
+    [
+      "message",
+      "Uključite ili isključite Pixverse funkcionalni modul."
+    ],
+    [
+      "description",
+      "Opis Pixverse funkcionalnosti"
+    ]
+  ],
+  "message.featuresFlux": [
+    [
+      "message",
+      "Uključite ili isključite FLux funkcionalni modul."
+    ],
+    [
+      "description",
+      "Opis FLux funkcionalnosti"
+    ]
+  ],
+  "message.featuresNanobanana": [
+    [
+      "message",
+      "Uključite ili isključite Nano Banana funkcionalni modul."
+    ],
+    [
+      "description",
+      "Opis Nano Banana funkcionalnosti"
+    ]
+  ],
+  "message.featuresOpenaiimage": {
+    "message": "Toggle OpenAI Image feature module.",
+    "description": "Description of the OpenAI Image feature"
+  },
+  "message.featuresSeedream": [
+    [
+      "message",
+      "Uključite ili isključite SeeDream funkcionalni modul."
+    ],
+    [
+      "description",
+      "Opis SeeDream funkcionalnosti"
+    ]
+  ],
+  "message.featuresSeedance": [
+    [
+      "message",
+      "Omogućite ili onemogućite SeeDance funkcionalni modul."
+    ],
+    [
+      "description",
+      "Opis SeeDance funkcionalnosti"
+    ]
+  ],
+  "message.featuresWan": [
+    [
+      "message",
+      "Uključite ili isključite Wan funkcionalni modul."
+    ],
+    [
+      "description",
+      "Opis Wan funkcionalnosti"
+    ]
+  ],
+  "message.featuresProducer": [
+    [
+      "message",
+      "Uključite ili isključite Producer funkcionalni modul."
+    ],
+    [
+      "description",
+      "Opis Producer funkcionalnosti"
+    ]
+  ],
+  "message.featuresKimi": [
+    [
+      "message",
+      "Uključite ili isključite Kimi funkcionalni modul."
+    ],
+    [
+      "description",
+      "Opis Kimi funkcionalnosti"
+    ]
+  ],
+  "message.featuresSerp": [
+    [
+      "message",
+      "Uključite ili isključite SERP funkcionalni modul."
+    ],
+    [
+      "description",
+      "Opis SERP funkcionalnosti"
+    ]
+  ],
+  "message.featuresLuma": [
+    [
+      "message",
+      "Uključite ili isključite Luma funkcionalni modul."
+    ],
+    [
+      "description",
+      "Opis Luma funkcionalnosti"
+    ]
+  ],
+  "message.featuresPika": [
+    [
+      "message",
+      "Uključite ili isključite Pika funkcionalni modul."
+    ],
+    [
+      "description",
+      "Opis Pika funkcionalnosti"
+    ]
+  ],
+  "message.featuresKling": [
+    [
+      "message",
+      "Uključite ili isključite Kling funkcionalni modul."
+    ],
+    [
+      "description",
+      "Opis Kling funkcionalnosti"
+    ]
+  ],
+  "message.featuresHailuo": [
+    [
+      "message",
+      "Uključite ili isključite Hailuo funkcionalni modul."
+    ],
+    [
+      "description",
+      "Opis Hailuo funkcionalnosti"
+    ]
+  ],
+  "message.featuresHeadshots": [
+    [
+      "message",
+      "Uključite ili isključite AI pasoške fotografije funkcionalni modul."
+    ],
+    [
+      "description",
+      "Opis AI pasoških fotografija funkcionalnosti"
+    ]
+  ],
+  "message.featuresSupport": [
+    [
+      "message",
+      "Uključite ili isključite korisničku podršku"
+    ],
+    [
+      "description",
+      "Opis funkcionalnosti podrške"
+    ]
+  ],
+  "message.featuresI18n": [
+    [
+      "message",
+      "Uključite ili isključite podršku za više jezika, kada je isključeno, korisnici mogu koristiti samo podrazumevani jezik."
+    ],
+    [
+      "description",
+      "Opis funkcionalnosti podrške za više jezika"
+    ]
+  ],
+  "button.upload": [
+    [
+      "message",
+      "Otpremi"
+    ],
+    [
+      "description",
+      "Otpremi"
+    ]
+  ],
+  "button.enabled": [
+    [
+      "message",
+      "Omogućeno"
+    ],
+    [
+      "description",
+      "Tekst na prekidaču koji označava da je omogućeno"
+    ]
+  ],
+  "button.disabled": [
+    [
+      "message",
+      "Onemogućeno"
+    ],
+    [
+      "description",
+      "Tekst na prekidaču koji označava da je onemogućeno"
+    ]
+  ],
+  "field.featuresGemini": [
+    [
+      "message",
+      "Gemini"
+    ],
+    [
+      "description",
+      "Prikazano kao naslov u kutiji za uređivanje"
+    ]
+  ],
+  "message.featuresGemini": [
+    [
+      "message",
+      "Omogućite ili onemogućite Gemini funkcionalni modul."
+    ],
+    [
+      "description",
+      "Opis Gemini funkcionalnosti"
+    ]
+  ],
+  "field.featuresClaude": [
+    [
+      "message",
+      "Claude"
+    ],
+    [
+      "description",
+      "Prikazano kao naslov u kutiji za uređivanje"
+    ]
+  ],
+  "message.featuresClaude": [
+    [
+      "message",
+      "Omogućite ili onemogućite Claude funkcionalni modul."
+    ],
+    [
+      "description",
+      "Opis Claude funkcionalnosti"
+    ]
+  ]
 }

--- a/src/i18n/sr/site.json
+++ b/src/i18n/sr/site.json
@@ -1,1110 +1,450 @@
 {
-  "field.title": [
-    [
-      "message",
-      "Naslov sajta"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "field.origin": [
-    [
-      "message",
-      "Domen sajta"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "field.description": [
-    [
-      "message",
-      "Opis sajta"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "field.keywords": [
-    [
-      "message",
-      "Ključne reči sajta"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "field.logo": [
-    [
-      "message",
-      "Logo sajta"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "field.favicon": [
-    [
-      "message",
-      "Favicon sajta"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "field.qr": [
-    [
-      "message",
-      "QR kod"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "field.url": [
-    [
-      "message",
-      "Link"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "field.admins": [
-    [
-      "message",
-      "ID administratora sajta"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "field.distributionDefaultInviterId": [
-    [
-      "message",
-      "ID podrazumevanog pozivaoca"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "field.distributionForceInviterId": [
-    [
-      "message",
-      "ID obaveznog pozivaoca"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "field.featuresChat": [
-    [
-      "message",
-      "Chat"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "field.featuresVeo": [
-    [
-      "message",
-      "Veo"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "field.featuresSora": [
-    [
-      "message",
-      "Sora"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "field.featuresGrok": [
-    [
-      "message",
-      "Grok"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "field.featuresDeepseek": [
-    [
-      "message",
-      "Deepseek"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "field.featuresChatgpt": [
-    [
-      "message",
-      "ChatGPT"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "field.featuresMidjourney": [
-    [
-      "message",
-      "Midjourney"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "field.featuresChatdoc": [
-    [
-      "message",
-      "Chatdoc"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "field.featuresQrart": [
-    [
-      "message",
-      "Qrart"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "field.featuresLuma": [
-    [
-      "message",
-      "Luma"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "field.featuresPixverse": [
-    [
-      "message",
-      "Pixverse"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "field.featuresPika": [
-    [
-      "message",
-      "Pika"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "field.featuresKling": [
-    [
-      "message",
-      "Kling"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "field.featuresHailuo": [
-    [
-      "message",
-      "Hailuo"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "field.featuresHeadshots": [
-    [
-      "message",
-      "AI fotografije"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "field.featuresSuno": [
-    [
-      "message",
-      "Suno"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "field.featuresFlux": [
-    [
-      "message",
-      "Flux"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "field.featuresNanobanana": [
-    [
-      "message",
-      "Nano Banana"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
+  "field.title": {
+    "message": "Naslov sajta",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "field.origin": {
+    "message": "Domen sajta",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "field.description": {
+    "message": "Opis sajta",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "field.keywords": {
+    "message": "Ključne reči sajta",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "field.logo": {
+    "message": "Logo sajta",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "field.favicon": {
+    "message": "Favicon sajta",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "field.qr": {
+    "message": "QR kod",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "field.url": {
+    "message": "Link",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "field.admins": {
+    "message": "ID administratora sajta",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "field.distributionDefaultInviterId": {
+    "message": "ID podrazumevanog pozivaoca",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "field.distributionForceInviterId": {
+    "message": "ID obaveznog pozivaoca",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "field.featuresChat": {
+    "message": "Chat",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "field.featuresVeo": {
+    "message": "Veo",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "field.featuresSora": {
+    "message": "Sora",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "field.featuresGrok": {
+    "message": "Grok",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "field.featuresDeepseek": {
+    "message": "Deepseek",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "field.featuresChatgpt": {
+    "message": "ChatGPT",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "field.featuresMidjourney": {
+    "message": "Midjourney",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "field.featuresChatdoc": {
+    "message": "Chatdoc",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "field.featuresQrart": {
+    "message": "Qrart",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "field.featuresLuma": {
+    "message": "Luma",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "field.featuresPixverse": {
+    "message": "Pixverse",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "field.featuresPika": {
+    "message": "Pika",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "field.featuresKling": {
+    "message": "Kling",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "field.featuresHailuo": {
+    "message": "Hailuo",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "field.featuresHeadshots": {
+    "message": "AI fotografije",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "field.featuresSuno": {
+    "message": "Suno",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "field.featuresFlux": {
+    "message": "Flux",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "field.featuresNanobanana": {
+    "message": "Nano Banana",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
   "field.featuresOpenaiimage": {
     "message": "OpenAI Image",
     "description": "Displayed as the title in the editing box"
   },
-  "field.featuresSeedream": [
-    [
-      "message",
-      "SeeDream"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "field.featuresSeedance": [
-    [
-      "message",
-      "SeeDance"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "field.featuresWan": [
-    [
-      "message",
-      "Wan"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "field.featuresProducer": [
-    [
-      "message",
-      "Producent"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "field.featuresKimi": [
-    [
-      "message",
-      "Kimi"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "field.featuresSerp": [
-    [
-      "message",
-      "SERP"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "field.featuresSupport": [
-    [
-      "message",
-      "Korisnička podrška"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "field.featuresI18n": [
-    [
-      "message",
-      "Podrška za više jezika"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "title.basicConfig": [
-    [
-      "message",
-      "Osnovna podešavanja"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "title.seoConfig": [
-    [
-      "message",
-      "SEO podešavanja"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "title.editAdmins": [
-    [
-      "message",
-      "Uredi administratore"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "title.featuresConfig": [
-    [
-      "message",
-      "Podešavanje funkcija"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "title.editTitle": [
-    [
-      "message",
-      "Uredi naslov"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "title.editOrigin": [
-    [
-      "message",
-      "Uredi domen"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "title.editKeywords": [
-    [
-      "message",
-      "Uredi ključne reči"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "title.editLogo": [
-    [
-      "message",
-      "Uredi logo"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "title.editFavicon": [
-    [
-      "message",
-      "Uredi favicon"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "title.editDescription": [
-    [
-      "message",
-      "Uredi opis"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "title.distributionConfig": [
-    [
-      "message",
-      "Podešavanje distribucije"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "title.editDistributionDefaultInviterId": [
-    [
-      "message",
-      "Uredi podrazumevanog pozivaoca"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "title.editDistributionForceInviterId": [
-    [
-      "message",
-      "Uredi obaveznog pozivaoca"
-    ],
-    [
-      "description",
-      "Prikazuje se kao naslov u okviru za uređivanje"
-    ]
-  ],
-  "title.editQR": [
-    [
-      "message",
-      "Уреди QR код"
-    ],
-    [
-      "description",
-      "Приказује се у заглављу уређивања"
-    ]
-  ],
-  "title.editUrl": [
-    [
-      "message",
-      "Уреди линк"
-    ],
-    [
-      "description",
-      "Приказује се у заглављу уређивања"
-    ]
-  ],
-  "placeholder.title": [
-    [
-      "message",
-      "Унесите наслов сајта"
-    ],
-    [
-      "description",
-      "Приказује се у уређивању"
-    ]
-  ],
-  "placeholder.origin": [
-    [
-      "message",
-      "Унесите домен сајта"
-    ],
-    [
-      "description",
-      "Приказује се у уређивању"
-    ]
-  ],
-  "placeholder.editUrl": [
-    [
-      "message",
-      "Унесите линк"
-    ],
-    [
-      "description",
-      "Приказује се у уређивању"
-    ]
-  ],
-  "placeholder.description": [
-    [
-      "message",
-      "Унесите опис сајта"
-    ],
-    [
-      "description",
-      "Приказује се у уређивању"
-    ]
-  ],
-  "placeholder.keywords": [
-    [
-      "message",
-      "Унесите кључне речи сајта"
-    ],
-    [
-      "description",
-      "Приказује се у уређивању"
-    ]
-  ],
-  "placeholder.editDistributionDefaultInviterId": [
-    [
-      "message",
-      "Унесите ID подразумеваног позиватеља"
-    ],
-    [
-      "description",
-      "Приказује се у уређивању"
-    ]
-  ],
-  "placeholder.editDistributionForceInviterId": [
-    [
-      "message",
-      "Унесите ID обавезног позиватеља"
-    ],
-    [
-      "description",
-      "Приказује се у уређивању"
-    ]
-  ],
-  "message.uploadImageExceed": [
-    [
-      "message",
-      "Превише слике за учитавање"
-    ],
-    [
-      "description",
-      "Порука о превеликој слици за учитавање"
-    ]
-  ],
-  "message.uploadImageError": [
-    [
-      "message",
-      "Грешка при учитавању слике"
-    ],
-    [
-      "description",
-      "Порука о грешци при учитавању слике"
-    ]
-  ],
-  "message.editLogoTip": [
-    [
-      "message",
-      "Препоручена величина: 200*60px"
-    ],
-    [
-      "description",
-      "Језик упутства за учитавање слике"
-    ]
-  ],
-  "message.editQRTip": [
-    [
-      "message",
-      "Препоручена величина: 200*200px"
-    ],
-    [
-      "description",
-      "Језик упутства за учитавање слике"
-    ]
-  ],
-  "message.editFaviconTip": [
-    [
-      "message",
-      "Препоручена величина: 32*32px"
-    ],
-    [
-      "description",
-      "Језик упутства за учитавање слике"
-    ]
-  ],
-  "message.editUrl": [
-    [
-      "message",
-      "Унесите линк"
-    ],
-    [
-      "description",
-      "Упутство за унос линка"
-    ]
-  ],
-  "message.atLeastOneAdmin": [
-    [
-      "message",
-      "Мора остати бар један администратор"
-    ],
-    [
-      "description",
-      "Упозорење о потреби за бар једним администратором"
-    ]
-  ],
-  "message.distributionDefaultInviterIdTip": [
-    [
-      "message",
-      "ID корисника подразумеваног позиватеља. Ако дистрибутивна веза не садржи параметар inviter_id, користиће се овај ID као позиватељ."
-    ],
-    [
-      "description",
-      "Упутство о ID подразумеваног позиватеља"
-    ]
-  ],
-  "message.distributionForceInviterIdTip": [
-    [
-      "message",
-      "ID корисника обавезног позиватеља. Ако је овај ID постављен, без обзира на то да ли дистрибутивна веза садржи параметар inviter_id, користиће се овај ID као позиватељ."
-    ],
-    [
-      "description",
-      "Упутство о ID обавезног позиватеља"
-    ]
-  ],
-  "message.originTip": [
-    [
-      "message",
-      "Домен сајта, конфигурација сајта је повезана са доменом и не може се променити."
-    ],
-    [
-      "description",
-      "Упутство о домену сајта"
-    ]
-  ],
-  "message.titleTip": [
-    [
-      "message",
-      "Наслов сајта, приказује се на картици прегледача."
-    ],
-    [
-      "description",
-      "Упутство о наслову сајта"
-    ]
-  ],
-  "message.descriptionTip": [
-    [
-      "message",
-      "Опис сајта, налази се у мета информацијама сајта, користи се за SEO оптимизацију."
-    ],
-    [
-      "description",
-      "Упутство о опису сајта"
-    ]
-  ],
-  "message.logoTip": [
-    [
-      "message",
-      "Лого сајта, приказује се на врху менија када се мени прошири."
-    ],
-    [
-      "description",
-      "Упутство о логу сајта"
-    ]
-  ],
-  "message.faviconTip": [
-    [
-      "message",
-      "Favicon сајта, приказује се на картици прегледача."
-    ],
-    [
-      "description",
-      "Упутство о favicon-у сајта"
-    ]
-  ],
-  "message.adminsTip": [
-    [
-      "message",
-      "ID администраторови сајта, подразумевано, први корисник који креира сајт постаје администратор, само администратори могу управљати сајтом."
-    ],
-    [
-      "description",
-      "Упутство о администраторима сајта"
-    ]
-  ],
-  "message.adminsTip2": [
-    [
-      "message",
-      "Можете додавати или уклањати ID администраторови овде, можете посетити https://auth.acedata.cloud за преглед ID корисника"
-    ],
-    [
-      "description",
-      "Упутство о администраторима сајта"
-    ]
-  ],
-  "message.keywordsTip": [
-    [
-      "message",
-      "Кључне речи сајта, налазе се у мета информацијама сајта, користе се за SEO оптимизацију."
-    ],
-    [
-      "description",
-      "Упутство о кључним речима сајта"
-    ]
-  ],
-  "message.keywordsTip2": [
-    [
-      "message",
-      "Можете додавати или уклањати кључне речи сајта овде, што прецизније кључне речи, то боље за SEO оптимизацију."
-    ],
-    [
-      "description",
-      "Упутство о кључним речима сајта"
-    ]
-  ],
-  "message.featuresChat": [
-    [
-      "message",
-      "Укључи или искључи Chat модул."
-    ],
-    [
-      "description",
-      "Опис Chat функције"
-    ]
-  ],
-  "message.featuresGrok": [
-    [
-      "message",
-      "Укључи или искључи Grok модул."
-    ],
-    [
-      "description",
-      "Опис Grok функције"
-    ]
-  ],
-  "message.featuresDeepseek": [
-    [
-      "message",
-      "Укључи или искључи Deepseek модул."
-    ],
-    [
-      "description",
-      "Опис Deepseek функције"
-    ]
-  ],
-  "message.featuresChatgpt": [
-    [
-      "message",
-      "Укључи или искључи ChatGPT модул."
-    ],
-    [
-      "description",
-      "Опис ChatGPT функције"
-    ]
-  ],
-  "message.featuresMidjourney": [
-    [
-      "message",
-      "Укључи или искључи Midjourney модул."
-    ],
-    [
-      "description",
-      "Опис Midjourney функције"
-    ]
-  ],
-  "message.featuresChatdoc": [
-    [
-      "message",
-      "Укључи или искључи Chatdoc модул."
-    ],
-    [
-      "description",
-      "Опис Chatdoc функције"
-    ]
-  ],
-  "message.featuresQrart": [
-    [
-      "message",
-      "Укључи или искључи Qrart модул."
-    ],
-    [
-      "description",
-      "Опис Qrart функције"
-    ]
-  ],
-  "message.featuresVeo": [
-    [
-      "message",
-      "Укључи или искључи Veo модул."
-    ],
-    [
-      "description",
-      "Опис Veo функције"
-    ]
-  ],
-  "message.featuresSora": [
-    [
-      "message",
-      "Укључи или искључи Sora модул."
-    ],
-    [
-      "description",
-      "Опис Sora функције"
-    ]
-  ],
-  "message.featuresSuno": [
-    [
-      "message",
-      "Укључи или искључи Suno модул."
-    ],
-    [
-      "description",
-      "Опис Suno функције"
-    ]
-  ],
-  "message.featuresPixverse": [
-    [
-      "message",
-      "Uključite ili isključite Pixverse funkcionalni modul."
-    ],
-    [
-      "description",
-      "Opis Pixverse funkcionalnosti"
-    ]
-  ],
-  "message.featuresFlux": [
-    [
-      "message",
-      "Uključite ili isključite FLux funkcionalni modul."
-    ],
-    [
-      "description",
-      "Opis FLux funkcionalnosti"
-    ]
-  ],
-  "message.featuresNanobanana": [
-    [
-      "message",
-      "Uključite ili isključite Nano Banana funkcionalni modul."
-    ],
-    [
-      "description",
-      "Opis Nano Banana funkcionalnosti"
-    ]
-  ],
+  "field.featuresSeedream": {
+    "message": "SeeDream",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "field.featuresSeedance": {
+    "message": "SeeDance",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "field.featuresWan": {
+    "message": "Wan",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "field.featuresProducer": {
+    "message": "Producent",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "field.featuresKimi": {
+    "message": "Kimi",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "field.featuresSerp": {
+    "message": "SERP",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "field.featuresSupport": {
+    "message": "Korisnička podrška",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "field.featuresI18n": {
+    "message": "Podrška za više jezika",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "title.basicConfig": {
+    "message": "Osnovna podešavanja",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "title.seoConfig": {
+    "message": "SEO podešavanja",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "title.editAdmins": {
+    "message": "Uredi administratore",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "title.featuresConfig": {
+    "message": "Podešavanje funkcija",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "title.editTitle": {
+    "message": "Uredi naslov",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "title.editOrigin": {
+    "message": "Uredi domen",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "title.editKeywords": {
+    "message": "Uredi ključne reči",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "title.editLogo": {
+    "message": "Uredi logo",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "title.editFavicon": {
+    "message": "Uredi favicon",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "title.editDescription": {
+    "message": "Uredi opis",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "title.distributionConfig": {
+    "message": "Podešavanje distribucije",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "title.editDistributionDefaultInviterId": {
+    "message": "Uredi podrazumevanog pozivaoca",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "title.editDistributionForceInviterId": {
+    "message": "Uredi obaveznog pozivaoca",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "title.editQR": {
+    "message": "Уреди QR код",
+    "description": "Приказује се у заглављу уређивања"
+  },
+  "title.editUrl": {
+    "message": "Уреди линк",
+    "description": "Приказује се у заглављу уређивања"
+  },
+  "placeholder.title": {
+    "message": "Унесите наслов сајта",
+    "description": "Приказује се у уређивању"
+  },
+  "placeholder.origin": {
+    "message": "Унесите домен сајта",
+    "description": "Приказује се у уређивању"
+  },
+  "placeholder.editUrl": {
+    "message": "Унесите линк",
+    "description": "Приказује се у уређивању"
+  },
+  "placeholder.description": {
+    "message": "Унесите опис сајта",
+    "description": "Приказује се у уређивању"
+  },
+  "placeholder.keywords": {
+    "message": "Унесите кључне речи сајта",
+    "description": "Приказује се у уређивању"
+  },
+  "placeholder.editDistributionDefaultInviterId": {
+    "message": "Унесите ID подразумеваног позиватеља",
+    "description": "Приказује се у уређивању"
+  },
+  "placeholder.editDistributionForceInviterId": {
+    "message": "Унесите ID обавезног позиватеља",
+    "description": "Приказује се у уређивању"
+  },
+  "message.uploadImageExceed": {
+    "message": "Превише слике за учитавање",
+    "description": "Порука о превеликој слици за учитавање"
+  },
+  "message.uploadImageError": {
+    "message": "Грешка при учитавању слике",
+    "description": "Порука о грешци при учитавању слике"
+  },
+  "message.editLogoTip": {
+    "message": "Препоручена величина: 200*60px",
+    "description": "Језик упутства за учитавање слике"
+  },
+  "message.editQRTip": {
+    "message": "Препоручена величина: 200*200px",
+    "description": "Језик упутства за учитавање слике"
+  },
+  "message.editFaviconTip": {
+    "message": "Препоручена величина: 32*32px",
+    "description": "Језик упутства за учитавање слике"
+  },
+  "message.editUrl": {
+    "message": "Унесите линк",
+    "description": "Упутство за унос линка"
+  },
+  "message.atLeastOneAdmin": {
+    "message": "Мора остати бар један администратор",
+    "description": "Упозорење о потреби за бар једним администратором"
+  },
+  "message.distributionDefaultInviterIdTip": {
+    "message": "ID корисника подразумеваног позиватеља. Ако дистрибутивна веза не садржи параметар inviter_id, користиће се овај ID као позиватељ.",
+    "description": "Упутство о ID подразумеваног позиватеља"
+  },
+  "message.distributionForceInviterIdTip": {
+    "message": "ID корисника обавезног позиватеља. Ако је овај ID постављен, без обзира на то да ли дистрибутивна веза садржи параметар inviter_id, користиће се овај ID као позиватељ.",
+    "description": "Упутство о ID обавезног позиватеља"
+  },
+  "message.originTip": {
+    "message": "Домен сајта, конфигурација сајта је повезана са доменом и не може се променити.",
+    "description": "Упутство о домену сајта"
+  },
+  "message.titleTip": {
+    "message": "Наслов сајта, приказује се на картици прегледача.",
+    "description": "Упутство о наслову сајта"
+  },
+  "message.descriptionTip": {
+    "message": "Опис сајта, налази се у мета информацијама сајта, користи се за SEO оптимизацију.",
+    "description": "Упутство о опису сајта"
+  },
+  "message.logoTip": {
+    "message": "Лого сајта, приказује се на врху менија када се мени прошири.",
+    "description": "Упутство о логу сајта"
+  },
+  "message.faviconTip": {
+    "message": "Favicon сајта, приказује се на картици прегледача.",
+    "description": "Упутство о favicon-у сајта"
+  },
+  "message.adminsTip": {
+    "message": "ID администраторови сајта, подразумевано, први корисник који креира сајт постаје администратор, само администратори могу управљати сајтом.",
+    "description": "Упутство о администраторима сајта"
+  },
+  "message.adminsTip2": {
+    "message": "Можете додавати или уклањати ID администраторови овде, можете посетити https://auth.acedata.cloud за преглед ID корисника",
+    "description": "Упутство о администраторима сајта"
+  },
+  "message.keywordsTip": {
+    "message": "Кључне речи сајта, налазе се у мета информацијама сајта, користе се за SEO оптимизацију.",
+    "description": "Упутство о кључним речима сајта"
+  },
+  "message.keywordsTip2": {
+    "message": "Можете додавати или уклањати кључне речи сајта овде, што прецизније кључне речи, то боље за SEO оптимизацију.",
+    "description": "Упутство о кључним речима сајта"
+  },
+  "message.featuresChat": {
+    "message": "Укључи или искључи Chat модул.",
+    "description": "Опис Chat функције"
+  },
+  "message.featuresGrok": {
+    "message": "Укључи или искључи Grok модул.",
+    "description": "Опис Grok функције"
+  },
+  "message.featuresDeepseek": {
+    "message": "Укључи или искључи Deepseek модул.",
+    "description": "Опис Deepseek функције"
+  },
+  "message.featuresChatgpt": {
+    "message": "Укључи или искључи ChatGPT модул.",
+    "description": "Опис ChatGPT функције"
+  },
+  "message.featuresMidjourney": {
+    "message": "Укључи или искључи Midjourney модул.",
+    "description": "Опис Midjourney функције"
+  },
+  "message.featuresChatdoc": {
+    "message": "Укључи или искључи Chatdoc модул.",
+    "description": "Опис Chatdoc функције"
+  },
+  "message.featuresQrart": {
+    "message": "Укључи или искључи Qrart модул.",
+    "description": "Опис Qrart функције"
+  },
+  "message.featuresVeo": {
+    "message": "Укључи или искључи Veo модул.",
+    "description": "Опис Veo функције"
+  },
+  "message.featuresSora": {
+    "message": "Укључи или искључи Sora модул.",
+    "description": "Опис Sora функције"
+  },
+  "message.featuresSuno": {
+    "message": "Укључи или искључи Suno модул.",
+    "description": "Опис Suno функције"
+  },
+  "message.featuresPixverse": {
+    "message": "Uključite ili isključite Pixverse funkcionalni modul.",
+    "description": "Opis Pixverse funkcionalnosti"
+  },
+  "message.featuresFlux": {
+    "message": "Uključite ili isključite FLux funkcionalni modul.",
+    "description": "Opis FLux funkcionalnosti"
+  },
+  "message.featuresNanobanana": {
+    "message": "Uključite ili isključite Nano Banana funkcionalni modul.",
+    "description": "Opis Nano Banana funkcionalnosti"
+  },
   "message.featuresOpenaiimage": {
     "message": "Toggle OpenAI Image feature module.",
     "description": "Description of the OpenAI Image feature"
   },
-  "message.featuresSeedream": [
-    [
-      "message",
-      "Uključite ili isključite SeeDream funkcionalni modul."
-    ],
-    [
-      "description",
-      "Opis SeeDream funkcionalnosti"
-    ]
-  ],
-  "message.featuresSeedance": [
-    [
-      "message",
-      "Omogućite ili onemogućite SeeDance funkcionalni modul."
-    ],
-    [
-      "description",
-      "Opis SeeDance funkcionalnosti"
-    ]
-  ],
-  "message.featuresWan": [
-    [
-      "message",
-      "Uključite ili isključite Wan funkcionalni modul."
-    ],
-    [
-      "description",
-      "Opis Wan funkcionalnosti"
-    ]
-  ],
-  "message.featuresProducer": [
-    [
-      "message",
-      "Uključite ili isključite Producer funkcionalni modul."
-    ],
-    [
-      "description",
-      "Opis Producer funkcionalnosti"
-    ]
-  ],
-  "message.featuresKimi": [
-    [
-      "message",
-      "Uključite ili isključite Kimi funkcionalni modul."
-    ],
-    [
-      "description",
-      "Opis Kimi funkcionalnosti"
-    ]
-  ],
-  "message.featuresSerp": [
-    [
-      "message",
-      "Uključite ili isključite SERP funkcionalni modul."
-    ],
-    [
-      "description",
-      "Opis SERP funkcionalnosti"
-    ]
-  ],
-  "message.featuresLuma": [
-    [
-      "message",
-      "Uključite ili isključite Luma funkcionalni modul."
-    ],
-    [
-      "description",
-      "Opis Luma funkcionalnosti"
-    ]
-  ],
-  "message.featuresPika": [
-    [
-      "message",
-      "Uključite ili isključite Pika funkcionalni modul."
-    ],
-    [
-      "description",
-      "Opis Pika funkcionalnosti"
-    ]
-  ],
-  "message.featuresKling": [
-    [
-      "message",
-      "Uključite ili isključite Kling funkcionalni modul."
-    ],
-    [
-      "description",
-      "Opis Kling funkcionalnosti"
-    ]
-  ],
-  "message.featuresHailuo": [
-    [
-      "message",
-      "Uključite ili isključite Hailuo funkcionalni modul."
-    ],
-    [
-      "description",
-      "Opis Hailuo funkcionalnosti"
-    ]
-  ],
-  "message.featuresHeadshots": [
-    [
-      "message",
-      "Uključite ili isključite AI pasoške fotografije funkcionalni modul."
-    ],
-    [
-      "description",
-      "Opis AI pasoških fotografija funkcionalnosti"
-    ]
-  ],
-  "message.featuresSupport": [
-    [
-      "message",
-      "Uključite ili isključite korisničku podršku"
-    ],
-    [
-      "description",
-      "Opis funkcionalnosti podrške"
-    ]
-  ],
-  "message.featuresI18n": [
-    [
-      "message",
-      "Uključite ili isključite podršku za više jezika, kada je isključeno, korisnici mogu koristiti samo podrazumevani jezik."
-    ],
-    [
-      "description",
-      "Opis funkcionalnosti podrške za više jezika"
-    ]
-  ],
-  "button.upload": [
-    [
-      "message",
-      "Otpremi"
-    ],
-    [
-      "description",
-      "Otpremi"
-    ]
-  ],
-  "button.enabled": [
-    [
-      "message",
-      "Omogućeno"
-    ],
-    [
-      "description",
-      "Tekst na prekidaču koji označava da je omogućeno"
-    ]
-  ],
-  "button.disabled": [
-    [
-      "message",
-      "Onemogućeno"
-    ],
-    [
-      "description",
-      "Tekst na prekidaču koji označava da je onemogućeno"
-    ]
-  ],
-  "field.featuresGemini": [
-    [
-      "message",
-      "Gemini"
-    ],
-    [
-      "description",
-      "Prikazano kao naslov u kutiji za uređivanje"
-    ]
-  ],
-  "message.featuresGemini": [
-    [
-      "message",
-      "Omogućite ili onemogućite Gemini funkcionalni modul."
-    ],
-    [
-      "description",
-      "Opis Gemini funkcionalnosti"
-    ]
-  ],
-  "field.featuresClaude": [
-    [
-      "message",
-      "Claude"
-    ],
-    [
-      "description",
-      "Prikazano kao naslov u kutiji za uređivanje"
-    ]
-  ],
-  "message.featuresClaude": [
-    [
-      "message",
-      "Omogućite ili onemogućite Claude funkcionalni modul."
-    ],
-    [
-      "description",
-      "Opis Claude funkcionalnosti"
-    ]
-  ]
+  "message.featuresSeedream": {
+    "message": "Uključite ili isključite SeeDream funkcionalni modul.",
+    "description": "Opis SeeDream funkcionalnosti"
+  },
+  "message.featuresSeedance": {
+    "message": "Omogućite ili onemogućite SeeDance funkcionalni modul.",
+    "description": "Opis SeeDance funkcionalnosti"
+  },
+  "message.featuresWan": {
+    "message": "Uključite ili isključite Wan funkcionalni modul.",
+    "description": "Opis Wan funkcionalnosti"
+  },
+  "message.featuresProducer": {
+    "message": "Uključite ili isključite Producer funkcionalni modul.",
+    "description": "Opis Producer funkcionalnosti"
+  },
+  "message.featuresKimi": {
+    "message": "Uključite ili isključite Kimi funkcionalni modul.",
+    "description": "Opis Kimi funkcionalnosti"
+  },
+  "message.featuresSerp": {
+    "message": "Uključite ili isključite SERP funkcionalni modul.",
+    "description": "Opis SERP funkcionalnosti"
+  },
+  "message.featuresLuma": {
+    "message": "Uključite ili isključite Luma funkcionalni modul.",
+    "description": "Opis Luma funkcionalnosti"
+  },
+  "message.featuresPika": {
+    "message": "Uključite ili isključite Pika funkcionalni modul.",
+    "description": "Opis Pika funkcionalnosti"
+  },
+  "message.featuresKling": {
+    "message": "Uključite ili isključite Kling funkcionalni modul.",
+    "description": "Opis Kling funkcionalnosti"
+  },
+  "message.featuresHailuo": {
+    "message": "Uključite ili isključite Hailuo funkcionalni modul.",
+    "description": "Opis Hailuo funkcionalnosti"
+  },
+  "message.featuresHeadshots": {
+    "message": "Uključite ili isključite AI pasoške fotografije funkcionalni modul.",
+    "description": "Opis AI pasoških fotografija funkcionalnosti"
+  },
+  "message.featuresSupport": {
+    "message": "Uključite ili isključite korisničku podršku",
+    "description": "Opis funkcionalnosti podrške"
+  },
+  "message.featuresI18n": {
+    "message": "Uključite ili isključite podršku za više jezika, kada je isključeno, korisnici mogu koristiti samo podrazumevani jezik.",
+    "description": "Opis funkcionalnosti podrške za više jezika"
+  },
+  "button.upload": {
+    "message": "Otpremi",
+    "description": "Otpremi"
+  },
+  "button.enabled": {
+    "message": "Omogućeno",
+    "description": "Tekst na prekidaču koji označava da je omogućeno"
+  },
+  "button.disabled": {
+    "message": "Onemogućeno",
+    "description": "Tekst na prekidaču koji označava da je onemogućeno"
+  },
+  "field.featuresGemini": {
+    "message": "Gemini",
+    "description": "Prikazano kao naslov u kutiji za uređivanje"
+  },
+  "message.featuresGemini": {
+    "message": "Omogućite ili onemogućite Gemini funkcionalni modul.",
+    "description": "Opis Gemini funkcionalnosti"
+  },
+  "field.featuresClaude": {
+    "message": "Claude",
+    "description": "Prikazano kao naslov u kutiji za uređivanje"
+  },
+  "message.featuresClaude": {
+    "message": "Omogućite ili onemogućite Claude funkcionalni modul.",
+    "description": "Opis Claude funkcionalnosti"
+  }
 }

--- a/src/i18n/sv/site.json
+++ b/src/i18n/sv/site.json
@@ -1,1110 +1,450 @@
 {
-  "field.title": [
-    [
-      "message",
-      "Webbplatsens titel"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "field.origin": [
-    [
-      "message",
-      "Webbplatsens domän"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "field.description": [
-    [
-      "message",
-      "Webbplatsens beskrivning"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "field.keywords": [
-    [
-      "message",
-      "Webbplatsens nyckelord"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "field.logo": [
-    [
-      "message",
-      "Webbplatsens logotyp"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "field.favicon": [
-    [
-      "message",
-      "Webbplatsens favicon"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "field.qr": [
-    [
-      "message",
-      "QR-kod"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "field.url": [
-    [
-      "message",
-      "Länk"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "field.admins": [
-    [
-      "message",
-      "Webbplatsens administratörs-ID"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "field.distributionDefaultInviterId": [
-    [
-      "message",
-      "Standardinbjudar-ID"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "field.distributionForceInviterId": [
-    [
-      "message",
-      "Tvingad inbjudar-ID"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "field.featuresChat": [
-    [
-      "message",
-      "Chat"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "field.featuresVeo": [
-    [
-      "message",
-      "Veo"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "field.featuresSora": [
-    [
-      "message",
-      "Sora"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "field.featuresGrok": [
-    [
-      "message",
-      "Grok"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "field.featuresDeepseek": [
-    [
-      "message",
-      "Deepseek"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "field.featuresChatgpt": [
-    [
-      "message",
-      "ChatGPT"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "field.featuresMidjourney": [
-    [
-      "message",
-      "Midjourney"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "field.featuresChatdoc": [
-    [
-      "message",
-      "Chatdoc"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "field.featuresQrart": [
-    [
-      "message",
-      "Qrart"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "field.featuresLuma": [
-    [
-      "message",
-      "Luma"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "field.featuresPixverse": [
-    [
-      "message",
-      "Pixverse"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "field.featuresPika": [
-    [
-      "message",
-      "Pika"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "field.featuresKling": [
-    [
-      "message",
-      "Kling"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "field.featuresHailuo": [
-    [
-      "message",
-      "Hailuo"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "field.featuresHeadshots": [
-    [
-      "message",
-      "AI ID-foto"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "field.featuresSuno": [
-    [
-      "message",
-      "Suno"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "field.featuresFlux": [
-    [
-      "message",
-      "Flux"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "field.featuresNanobanana": [
-    [
-      "message",
-      "Nano Banana"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
+  "field.title": {
+    "message": "Webbplatsens titel",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "field.origin": {
+    "message": "Webbplatsens domän",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "field.description": {
+    "message": "Webbplatsens beskrivning",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "field.keywords": {
+    "message": "Webbplatsens nyckelord",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "field.logo": {
+    "message": "Webbplatsens logotyp",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "field.favicon": {
+    "message": "Webbplatsens favicon",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "field.qr": {
+    "message": "QR-kod",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "field.url": {
+    "message": "Länk",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "field.admins": {
+    "message": "Webbplatsens administratörs-ID",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "field.distributionDefaultInviterId": {
+    "message": "Standardinbjudar-ID",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "field.distributionForceInviterId": {
+    "message": "Tvingad inbjudar-ID",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "field.featuresChat": {
+    "message": "Chat",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "field.featuresVeo": {
+    "message": "Veo",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "field.featuresSora": {
+    "message": "Sora",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "field.featuresGrok": {
+    "message": "Grok",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "field.featuresDeepseek": {
+    "message": "Deepseek",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "field.featuresChatgpt": {
+    "message": "ChatGPT",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "field.featuresMidjourney": {
+    "message": "Midjourney",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "field.featuresChatdoc": {
+    "message": "Chatdoc",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "field.featuresQrart": {
+    "message": "Qrart",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "field.featuresLuma": {
+    "message": "Luma",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "field.featuresPixverse": {
+    "message": "Pixverse",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "field.featuresPika": {
+    "message": "Pika",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "field.featuresKling": {
+    "message": "Kling",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "field.featuresHailuo": {
+    "message": "Hailuo",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "field.featuresHeadshots": {
+    "message": "AI ID-foto",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "field.featuresSuno": {
+    "message": "Suno",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "field.featuresFlux": {
+    "message": "Flux",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "field.featuresNanobanana": {
+    "message": "Nano Banana",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
   "field.featuresOpenaiimage": {
     "message": "OpenAI Image",
     "description": "Displayed as the title in the editing box"
   },
-  "field.featuresSeedream": [
-    [
-      "message",
-      "SeeDream"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "field.featuresSeedance": [
-    [
-      "message",
-      "SeeDance"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "field.featuresWan": [
-    [
-      "message",
-      "Wan"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "field.featuresProducer": [
-    [
-      "message",
-      "Producent"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "field.featuresKimi": [
-    [
-      "message",
-      "Kimi"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "field.featuresSerp": [
-    [
-      "message",
-      "SERP"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "field.featuresSupport": [
-    [
-      "message",
-      "Kundsupport"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "field.featuresI18n": [
-    [
-      "message",
-      "Flerspråkigt stöd"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "title.basicConfig": [
-    [
-      "message",
-      "Grundkonfiguration"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "title.seoConfig": [
-    [
-      "message",
-      "SEO-konfiguration"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "title.editAdmins": [
-    [
-      "message",
-      "Redigera administratörer"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "title.featuresConfig": [
-    [
-      "message",
-      "Funktioner konfiguration"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "title.editTitle": [
-    [
-      "message",
-      "Redigera titel"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "title.editOrigin": [
-    [
-      "message",
-      "Redigera domän"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "title.editKeywords": [
-    [
-      "message",
-      "Redigera nyckelord"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "title.editLogo": [
-    [
-      "message",
-      "Redigera logotyp"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "title.editFavicon": [
-    [
-      "message",
-      "Redigera favicon"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "title.editDescription": [
-    [
-      "message",
-      "Redigera beskrivning"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "title.distributionConfig": [
-    [
-      "message",
-      "Distributionskonfiguration"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "title.editDistributionDefaultInviterId": [
-    [
-      "message",
-      "Redigera standardinbjudare"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "title.editDistributionForceInviterId": [
-    [
-      "message",
-      "Redigera tvingad inbjudare"
-    ],
-    [
-      "description",
-      "Visas som titeln i redigeringsrutan"
-    ]
-  ],
-  "title.editQR": [
-    [
-      "message",
-      "Redigera QR-kod"
-    ],
-    [
-      "description",
-      "Visas som titel i redigeringsrutan"
-    ]
-  ],
-  "title.editUrl": [
-    [
-      "message",
-      "Redigera länk"
-    ],
-    [
-      "description",
-      "Visas som titel i redigeringsrutan"
-    ]
-  ],
-  "placeholder.title": [
-    [
-      "message",
-      "Ange webbplatsens titel"
-    ],
-    [
-      "description",
-      "Visas som titel i redigeringsrutan"
-    ]
-  ],
-  "placeholder.origin": [
-    [
-      "message",
-      "Ange webbplatsens domän"
-    ],
-    [
-      "description",
-      "Visas som titel i redigeringsrutan"
-    ]
-  ],
-  "placeholder.editUrl": [
-    [
-      "message",
-      "Ange länk"
-    ],
-    [
-      "description",
-      "Visas som titel i redigeringsrutan"
-    ]
-  ],
-  "placeholder.description": [
-    [
-      "message",
-      "Ange webbplatsens beskrivning"
-    ],
-    [
-      "description",
-      "Visas som titel i redigeringsrutan"
-    ]
-  ],
-  "placeholder.keywords": [
-    [
-      "message",
-      "Ange webbplatsens nyckelord"
-    ],
-    [
-      "description",
-      "Visas som titel i redigeringsrutan"
-    ]
-  ],
-  "placeholder.editDistributionDefaultInviterId": [
-    [
-      "message",
-      "Ange standardinbjudarens ID"
-    ],
-    [
-      "description",
-      "Visas som titel i redigeringsrutan"
-    ]
-  ],
-  "placeholder.editDistributionForceInviterId": [
-    [
-      "message",
-      "Ange tvingad inbjudarens ID"
-    ],
-    [
-      "description",
-      "Visas som titel i redigeringsrutan"
-    ]
-  ],
-  "message.uploadImageExceed": [
-    [
-      "message",
-      "Uppladdad bild överskrider gränsen"
-    ],
-    [
-      "description",
-      "Meddelande om att uppladdad bild överskrider gränsen"
-    ]
-  ],
-  "message.uploadImageError": [
-    [
-      "message",
-      "Fel vid bilduppladdning"
-    ],
-    [
-      "description",
-      "Meddelande om fel vid bilduppladdning"
-    ]
-  ],
-  "message.editLogoTip": [
-    [
-      "message",
-      "Rekommenderad storlek: 200*60px"
-    ],
-    [
-      "description",
-      "Tips för bilduppladdning"
-    ]
-  ],
-  "message.editQRTip": [
-    [
-      "message",
-      "Rekommenderad storlek: 200*200px"
-    ],
-    [
-      "description",
-      "Tips för bilduppladdning"
-    ]
-  ],
-  "message.editFaviconTip": [
-    [
-      "message",
-      "Rekommenderad storlek: 32*32px"
-    ],
-    [
-      "description",
-      "Tips för bilduppladdning"
-    ]
-  ],
-  "message.editUrl": [
-    [
-      "message",
-      "Ange länk"
-    ],
-    [
-      "description",
-      "Tips för att ange länk"
-    ]
-  ],
-  "message.atLeastOneAdmin": [
-    [
-      "message",
-      "Behåll minst en administratör"
-    ],
-    [
-      "description",
-      "Meddelande om att behålla minst en administratör"
-    ]
-  ],
-  "message.distributionDefaultInviterIdTip": [
-    [
-      "message",
-      "Standardinbjudarens användar-ID. Om distributionslänken inte innehåller inviter_id-parametern används detta användar-ID som inbjudare."
-    ],
-    [
-      "description",
-      "Tips om standardinbjudarens ID"
-    ]
-  ],
-  "message.distributionForceInviterIdTip": [
-    [
-      "message",
-      "Tvingad inbjudarens användar-ID. Om detta ID är inställt används det alltid som inbjudare oavsett om distributionslänken innehåller inviter_id-parametern."
-    ],
-    [
-      "description",
-      "Tips om tvingad inbjudarens ID"
-    ]
-  ],
-  "message.originTip": [
-    [
-      "message",
-      "Webbplatsens domän, webbplatskonfigurationen är kopplad till domänen och kan inte ändras."
-    ],
-    [
-      "description",
-      "Tips om webbplatsens domän"
-    ]
-  ],
-  "message.titleTip": [
-    [
-      "message",
-      "Webbplatsens titel, visas i webbläsarens flik."
-    ],
-    [
-      "description",
-      "Tips om webbplatsens titel"
-    ]
-  ],
-  "message.descriptionTip": [
-    [
-      "message",
-      "Webbplatsens beskrivning, finns i webbplatsens metadata och används för SEO-optimering."
-    ],
-    [
-      "description",
-      "Tips om webbplatsens beskrivning"
-    ]
-  ],
-  "message.logoTip": [
-    [
-      "message",
-      "Webbplatsens logotyp, visas högst upp i webbplatsens meny när menyn är öppen."
-    ],
-    [
-      "description",
-      "Tips om webbplatsens logotyp"
-    ]
-  ],
-  "message.faviconTip": [
-    [
-      "message",
-      "Webbplatsens favicon, visas i webbläsarens flik."
-    ],
-    [
-      "description",
-      "Tips om webbplatsens favicon"
-    ]
-  ],
-  "message.adminsTip": [
-    [
-      "message",
-      "Webbplatsens administratörs-ID. Som standard blir den första användaren som skapar webbplatsen administratör. Endast webbplatsadministratörer kan hantera webbplatsen."
-    ],
-    [
-      "description",
-      "Tips om webbplatsens administratörer"
-    ]
-  ],
-  "message.adminsTip2": [
-    [
-      "message",
-      "Kan lägga till eller ta bort administratörs-ID här. Du kan se användar-ID på https://auth.acedata.cloud"
-    ],
-    [
-      "description",
-      "Tips om webbplatsens administratörer"
-    ]
-  ],
-  "message.keywordsTip": [
-    [
-      "message",
-      "Webbplatsens nyckelord, finns i webbplatsens metadata och används för SEO-optimering."
-    ],
-    [
-      "description",
-      "Tips om webbplatsens nyckelord"
-    ]
-  ],
-  "message.keywordsTip2": [
-    [
-      "message",
-      "Kan lägga till eller ta bort webbplatsnyckelord här. Ju mer precisa nyckelord, desto bättre för SEO-optimering."
-    ],
-    [
-      "description",
-      "Tips om webbplatsens nyckelord"
-    ]
-  ],
-  "message.featuresChat": [
-    [
-      "message",
-      "Aktivera eller inaktivera Chat-funktion."
-    ],
-    [
-      "description",
-      "Beskrivning av Chat-funktionen"
-    ]
-  ],
-  "message.featuresGrok": [
-    [
-      "message",
-      "Aktivera eller inaktivera Grok-funktion."
-    ],
-    [
-      "description",
-      "Beskrivning av Grok-funktionen"
-    ]
-  ],
-  "message.featuresDeepseek": [
-    [
-      "message",
-      "Aktivera eller inaktivera Deepseek-funktion."
-    ],
-    [
-      "description",
-      "Beskrivning av Deepseek-funktionen"
-    ]
-  ],
-  "message.featuresChatgpt": [
-    [
-      "message",
-      "Aktivera eller inaktivera ChatGPT-funktion."
-    ],
-    [
-      "description",
-      "Beskrivning av ChatGPT-funktionen"
-    ]
-  ],
-  "message.featuresMidjourney": [
-    [
-      "message",
-      "Aktivera eller inaktivera Midjourney-funktion."
-    ],
-    [
-      "description",
-      "Beskrivning av Midjourney-funktionen"
-    ]
-  ],
-  "message.featuresChatdoc": [
-    [
-      "message",
-      "Aktivera eller inaktivera Chatdoc-funktion."
-    ],
-    [
-      "description",
-      "Beskrivning av Chatdoc-funktionen"
-    ]
-  ],
-  "message.featuresQrart": [
-    [
-      "message",
-      "Aktivera eller inaktivera Qrart-funktion."
-    ],
-    [
-      "description",
-      "Beskrivning av Qrart-funktionen"
-    ]
-  ],
-  "message.featuresVeo": [
-    [
-      "message",
-      "Aktivera eller inaktivera Veo-funktion."
-    ],
-    [
-      "description",
-      "Beskrivning av Veo-funktionen"
-    ]
-  ],
-  "message.featuresSora": [
-    [
-      "message",
-      "Aktivera eller inaktivera Sora-funktion."
-    ],
-    [
-      "description",
-      "Beskrivning av Sora-funktionen"
-    ]
-  ],
-  "message.featuresSuno": [
-    [
-      "message",
-      "Aktivera eller inaktivera Suno-funktion."
-    ],
-    [
-      "description",
-      "Beskrivning av Suno-funktionen"
-    ]
-  ],
-  "message.featuresPixverse": [
-    [
-      "message",
-      "Aktivera eller inaktivera Pixverse-funktioner."
-    ],
-    [
-      "description",
-      "Pixverse-funktionens beskrivning"
-    ]
-  ],
-  "message.featuresFlux": [
-    [
-      "message",
-      "Aktivera eller inaktivera FLux-funktioner."
-    ],
-    [
-      "description",
-      "FLux-funktionens beskrivning"
-    ]
-  ],
-  "message.featuresNanobanana": [
-    [
-      "message",
-      "Aktivera eller inaktivera Nano Banana-funktioner."
-    ],
-    [
-      "description",
-      "Nano Banana-funktionens beskrivning"
-    ]
-  ],
+  "field.featuresSeedream": {
+    "message": "SeeDream",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "field.featuresSeedance": {
+    "message": "SeeDance",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "field.featuresWan": {
+    "message": "Wan",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "field.featuresProducer": {
+    "message": "Producent",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "field.featuresKimi": {
+    "message": "Kimi",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "field.featuresSerp": {
+    "message": "SERP",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "field.featuresSupport": {
+    "message": "Kundsupport",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "field.featuresI18n": {
+    "message": "Flerspråkigt stöd",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "title.basicConfig": {
+    "message": "Grundkonfiguration",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "title.seoConfig": {
+    "message": "SEO-konfiguration",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "title.editAdmins": {
+    "message": "Redigera administratörer",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "title.featuresConfig": {
+    "message": "Funktioner konfiguration",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "title.editTitle": {
+    "message": "Redigera titel",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "title.editOrigin": {
+    "message": "Redigera domän",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "title.editKeywords": {
+    "message": "Redigera nyckelord",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "title.editLogo": {
+    "message": "Redigera logotyp",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "title.editFavicon": {
+    "message": "Redigera favicon",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "title.editDescription": {
+    "message": "Redigera beskrivning",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "title.distributionConfig": {
+    "message": "Distributionskonfiguration",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "title.editDistributionDefaultInviterId": {
+    "message": "Redigera standardinbjudare",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "title.editDistributionForceInviterId": {
+    "message": "Redigera tvingad inbjudare",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "title.editQR": {
+    "message": "Redigera QR-kod",
+    "description": "Visas som titel i redigeringsrutan"
+  },
+  "title.editUrl": {
+    "message": "Redigera länk",
+    "description": "Visas som titel i redigeringsrutan"
+  },
+  "placeholder.title": {
+    "message": "Ange webbplatsens titel",
+    "description": "Visas som titel i redigeringsrutan"
+  },
+  "placeholder.origin": {
+    "message": "Ange webbplatsens domän",
+    "description": "Visas som titel i redigeringsrutan"
+  },
+  "placeholder.editUrl": {
+    "message": "Ange länk",
+    "description": "Visas som titel i redigeringsrutan"
+  },
+  "placeholder.description": {
+    "message": "Ange webbplatsens beskrivning",
+    "description": "Visas som titel i redigeringsrutan"
+  },
+  "placeholder.keywords": {
+    "message": "Ange webbplatsens nyckelord",
+    "description": "Visas som titel i redigeringsrutan"
+  },
+  "placeholder.editDistributionDefaultInviterId": {
+    "message": "Ange standardinbjudarens ID",
+    "description": "Visas som titel i redigeringsrutan"
+  },
+  "placeholder.editDistributionForceInviterId": {
+    "message": "Ange tvingad inbjudarens ID",
+    "description": "Visas som titel i redigeringsrutan"
+  },
+  "message.uploadImageExceed": {
+    "message": "Uppladdad bild överskrider gränsen",
+    "description": "Meddelande om att uppladdad bild överskrider gränsen"
+  },
+  "message.uploadImageError": {
+    "message": "Fel vid bilduppladdning",
+    "description": "Meddelande om fel vid bilduppladdning"
+  },
+  "message.editLogoTip": {
+    "message": "Rekommenderad storlek: 200*60px",
+    "description": "Tips för bilduppladdning"
+  },
+  "message.editQRTip": {
+    "message": "Rekommenderad storlek: 200*200px",
+    "description": "Tips för bilduppladdning"
+  },
+  "message.editFaviconTip": {
+    "message": "Rekommenderad storlek: 32*32px",
+    "description": "Tips för bilduppladdning"
+  },
+  "message.editUrl": {
+    "message": "Ange länk",
+    "description": "Tips för att ange länk"
+  },
+  "message.atLeastOneAdmin": {
+    "message": "Behåll minst en administratör",
+    "description": "Meddelande om att behålla minst en administratör"
+  },
+  "message.distributionDefaultInviterIdTip": {
+    "message": "Standardinbjudarens användar-ID. Om distributionslänken inte innehåller inviter_id-parametern används detta användar-ID som inbjudare.",
+    "description": "Tips om standardinbjudarens ID"
+  },
+  "message.distributionForceInviterIdTip": {
+    "message": "Tvingad inbjudarens användar-ID. Om detta ID är inställt används det alltid som inbjudare oavsett om distributionslänken innehåller inviter_id-parametern.",
+    "description": "Tips om tvingad inbjudarens ID"
+  },
+  "message.originTip": {
+    "message": "Webbplatsens domän, webbplatskonfigurationen är kopplad till domänen och kan inte ändras.",
+    "description": "Tips om webbplatsens domän"
+  },
+  "message.titleTip": {
+    "message": "Webbplatsens titel, visas i webbläsarens flik.",
+    "description": "Tips om webbplatsens titel"
+  },
+  "message.descriptionTip": {
+    "message": "Webbplatsens beskrivning, finns i webbplatsens metadata och används för SEO-optimering.",
+    "description": "Tips om webbplatsens beskrivning"
+  },
+  "message.logoTip": {
+    "message": "Webbplatsens logotyp, visas högst upp i webbplatsens meny när menyn är öppen.",
+    "description": "Tips om webbplatsens logotyp"
+  },
+  "message.faviconTip": {
+    "message": "Webbplatsens favicon, visas i webbläsarens flik.",
+    "description": "Tips om webbplatsens favicon"
+  },
+  "message.adminsTip": {
+    "message": "Webbplatsens administratörs-ID. Som standard blir den första användaren som skapar webbplatsen administratör. Endast webbplatsadministratörer kan hantera webbplatsen.",
+    "description": "Tips om webbplatsens administratörer"
+  },
+  "message.adminsTip2": {
+    "message": "Kan lägga till eller ta bort administratörs-ID här. Du kan se användar-ID på https://auth.acedata.cloud",
+    "description": "Tips om webbplatsens administratörer"
+  },
+  "message.keywordsTip": {
+    "message": "Webbplatsens nyckelord, finns i webbplatsens metadata och används för SEO-optimering.",
+    "description": "Tips om webbplatsens nyckelord"
+  },
+  "message.keywordsTip2": {
+    "message": "Kan lägga till eller ta bort webbplatsnyckelord här. Ju mer precisa nyckelord, desto bättre för SEO-optimering.",
+    "description": "Tips om webbplatsens nyckelord"
+  },
+  "message.featuresChat": {
+    "message": "Aktivera eller inaktivera Chat-funktion.",
+    "description": "Beskrivning av Chat-funktionen"
+  },
+  "message.featuresGrok": {
+    "message": "Aktivera eller inaktivera Grok-funktion.",
+    "description": "Beskrivning av Grok-funktionen"
+  },
+  "message.featuresDeepseek": {
+    "message": "Aktivera eller inaktivera Deepseek-funktion.",
+    "description": "Beskrivning av Deepseek-funktionen"
+  },
+  "message.featuresChatgpt": {
+    "message": "Aktivera eller inaktivera ChatGPT-funktion.",
+    "description": "Beskrivning av ChatGPT-funktionen"
+  },
+  "message.featuresMidjourney": {
+    "message": "Aktivera eller inaktivera Midjourney-funktion.",
+    "description": "Beskrivning av Midjourney-funktionen"
+  },
+  "message.featuresChatdoc": {
+    "message": "Aktivera eller inaktivera Chatdoc-funktion.",
+    "description": "Beskrivning av Chatdoc-funktionen"
+  },
+  "message.featuresQrart": {
+    "message": "Aktivera eller inaktivera Qrart-funktion.",
+    "description": "Beskrivning av Qrart-funktionen"
+  },
+  "message.featuresVeo": {
+    "message": "Aktivera eller inaktivera Veo-funktion.",
+    "description": "Beskrivning av Veo-funktionen"
+  },
+  "message.featuresSora": {
+    "message": "Aktivera eller inaktivera Sora-funktion.",
+    "description": "Beskrivning av Sora-funktionen"
+  },
+  "message.featuresSuno": {
+    "message": "Aktivera eller inaktivera Suno-funktion.",
+    "description": "Beskrivning av Suno-funktionen"
+  },
+  "message.featuresPixverse": {
+    "message": "Aktivera eller inaktivera Pixverse-funktioner.",
+    "description": "Pixverse-funktionens beskrivning"
+  },
+  "message.featuresFlux": {
+    "message": "Aktivera eller inaktivera FLux-funktioner.",
+    "description": "FLux-funktionens beskrivning"
+  },
+  "message.featuresNanobanana": {
+    "message": "Aktivera eller inaktivera Nano Banana-funktioner.",
+    "description": "Nano Banana-funktionens beskrivning"
+  },
   "message.featuresOpenaiimage": {
     "message": "Toggle OpenAI Image feature module.",
     "description": "Description of the OpenAI Image feature"
   },
-  "message.featuresSeedream": [
-    [
-      "message",
-      "Aktivera eller inaktivera SeeDream-funktioner."
-    ],
-    [
-      "description",
-      "SeeDream-funktionens beskrivning"
-    ]
-  ],
-  "message.featuresSeedance": [
-    [
-      "message",
-      "Aktivera eller inaktivera SeeDance-funktioner."
-    ],
-    [
-      "description",
-      "SeeDance-funktionens beskrivning"
-    ]
-  ],
-  "message.featuresWan": [
-    [
-      "message",
-      "Aktivera eller inaktivera Wan-funktioner."
-    ],
-    [
-      "description",
-      "Wan-funktionens beskrivning"
-    ]
-  ],
-  "message.featuresProducer": [
-    [
-      "message",
-      "Aktivera eller inaktivera Producer-funktioner."
-    ],
-    [
-      "description",
-      "Producer-funktionens beskrivning"
-    ]
-  ],
-  "message.featuresKimi": [
-    [
-      "message",
-      "Aktivera eller inaktivera Kimi-funktioner."
-    ],
-    [
-      "description",
-      "Kimi-funktionens beskrivning"
-    ]
-  ],
-  "message.featuresSerp": [
-    [
-      "message",
-      "Aktivera eller inaktivera SERP-funktioner."
-    ],
-    [
-      "description",
-      "SERP-funktionens beskrivning"
-    ]
-  ],
-  "message.featuresLuma": [
-    [
-      "message",
-      "Aktivera eller inaktivera Luma-funktioner."
-    ],
-    [
-      "description",
-      "Luma-funktionens beskrivning"
-    ]
-  ],
-  "message.featuresPika": [
-    [
-      "message",
-      "Aktivera eller inaktivera Pika-funktioner."
-    ],
-    [
-      "description",
-      "Pika-funktionens beskrivning"
-    ]
-  ],
-  "message.featuresKling": [
-    [
-      "message",
-      "Aktivera eller inaktivera Kling-funktioner."
-    ],
-    [
-      "description",
-      "Kling-funktionens beskrivning"
-    ]
-  ],
-  "message.featuresHailuo": [
-    [
-      "message",
-      "Aktivera eller inaktivera Hailuo-funktioner."
-    ],
-    [
-      "description",
-      "Hailuo-funktionens beskrivning"
-    ]
-  ],
-  "message.featuresHeadshots": [
-    [
-      "message",
-      "Aktivera eller inaktivera AI ID-foto-funktioner."
-    ],
-    [
-      "description",
-      "AI ID-foto-funktionens beskrivning"
-    ]
-  ],
-  "message.featuresSupport": [
-    [
-      "message",
-      "Aktivera eller inaktivera kundsupport"
-    ],
-    [
-      "description",
-      "Supportfunktionens beskrivning"
-    ]
-  ],
-  "message.featuresI18n": [
-    [
-      "message",
-      "Aktivera eller inaktivera flerspråkigt stöd. När det är inaktiverat kan användare endast använda standardspråket."
-    ],
-    [
-      "description",
-      "Beskrivning av flerspråkigt stöd"
-    ]
-  ],
-  "button.upload": [
-    [
-      "message",
-      "Ladda upp"
-    ],
-    [
-      "description",
-      "Ladda upp"
-    ]
-  ],
-  "button.enabled": [
-    [
-      "message",
-      "Aktiverad"
-    ],
-    [
-      "description",
-      "Knappt text som indikerar att det är aktiverat"
-    ]
-  ],
-  "button.disabled": [
-    [
-      "message",
-      "Inaktiverad"
-    ],
-    [
-      "description",
-      "Knappt text som indikerar att det är inaktiverat"
-    ]
-  ],
-  "field.featuresGemini": [
-    [
-      "message",
-      "Gemini"
-    ],
-    [
-      "description",
-      "Visas som titel i redigeringsrutan"
-    ]
-  ],
-  "message.featuresGemini": [
-    [
-      "message",
-      "Aktivera eller inaktivera Gemini-funktioner."
-    ],
-    [
-      "description",
-      "Beskrivning av Gemini-funktionen"
-    ]
-  ],
-  "field.featuresClaude": [
-    [
-      "message",
-      "Claude"
-    ],
-    [
-      "description",
-      "Visas som titel i redigeringsrutan"
-    ]
-  ],
-  "message.featuresClaude": [
-    [
-      "message",
-      "Aktivera eller inaktivera Claude-funktioner."
-    ],
-    [
-      "description",
-      "Beskrivning av Claude-funktionen"
-    ]
-  ]
+  "message.featuresSeedream": {
+    "message": "Aktivera eller inaktivera SeeDream-funktioner.",
+    "description": "SeeDream-funktionens beskrivning"
+  },
+  "message.featuresSeedance": {
+    "message": "Aktivera eller inaktivera SeeDance-funktioner.",
+    "description": "SeeDance-funktionens beskrivning"
+  },
+  "message.featuresWan": {
+    "message": "Aktivera eller inaktivera Wan-funktioner.",
+    "description": "Wan-funktionens beskrivning"
+  },
+  "message.featuresProducer": {
+    "message": "Aktivera eller inaktivera Producer-funktioner.",
+    "description": "Producer-funktionens beskrivning"
+  },
+  "message.featuresKimi": {
+    "message": "Aktivera eller inaktivera Kimi-funktioner.",
+    "description": "Kimi-funktionens beskrivning"
+  },
+  "message.featuresSerp": {
+    "message": "Aktivera eller inaktivera SERP-funktioner.",
+    "description": "SERP-funktionens beskrivning"
+  },
+  "message.featuresLuma": {
+    "message": "Aktivera eller inaktivera Luma-funktioner.",
+    "description": "Luma-funktionens beskrivning"
+  },
+  "message.featuresPika": {
+    "message": "Aktivera eller inaktivera Pika-funktioner.",
+    "description": "Pika-funktionens beskrivning"
+  },
+  "message.featuresKling": {
+    "message": "Aktivera eller inaktivera Kling-funktioner.",
+    "description": "Kling-funktionens beskrivning"
+  },
+  "message.featuresHailuo": {
+    "message": "Aktivera eller inaktivera Hailuo-funktioner.",
+    "description": "Hailuo-funktionens beskrivning"
+  },
+  "message.featuresHeadshots": {
+    "message": "Aktivera eller inaktivera AI ID-foto-funktioner.",
+    "description": "AI ID-foto-funktionens beskrivning"
+  },
+  "message.featuresSupport": {
+    "message": "Aktivera eller inaktivera kundsupport",
+    "description": "Supportfunktionens beskrivning"
+  },
+  "message.featuresI18n": {
+    "message": "Aktivera eller inaktivera flerspråkigt stöd. När det är inaktiverat kan användare endast använda standardspråket.",
+    "description": "Beskrivning av flerspråkigt stöd"
+  },
+  "button.upload": {
+    "message": "Ladda upp",
+    "description": "Ladda upp"
+  },
+  "button.enabled": {
+    "message": "Aktiverad",
+    "description": "Knappt text som indikerar att det är aktiverat"
+  },
+  "button.disabled": {
+    "message": "Inaktiverad",
+    "description": "Knappt text som indikerar att det är inaktiverat"
+  },
+  "field.featuresGemini": {
+    "message": "Gemini",
+    "description": "Visas som titel i redigeringsrutan"
+  },
+  "message.featuresGemini": {
+    "message": "Aktivera eller inaktivera Gemini-funktioner.",
+    "description": "Beskrivning av Gemini-funktionen"
+  },
+  "field.featuresClaude": {
+    "message": "Claude",
+    "description": "Visas som titel i redigeringsrutan"
+  },
+  "message.featuresClaude": {
+    "message": "Aktivera eller inaktivera Claude-funktioner.",
+    "description": "Beskrivning av Claude-funktionen"
+  }
 }

--- a/src/i18n/sv/site.json
+++ b/src/i18n/sv/site.json
@@ -1,442 +1,1110 @@
 {
-  "field.title": {
-    "message": "Webbplatsens titel",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "field.origin": {
-    "message": "Webbplatsens domän",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "field.description": {
-    "message": "Webbplatsens beskrivning",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "field.keywords": {
-    "message": "Webbplatsens nyckelord",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "field.logo": {
-    "message": "Webbplatsens logotyp",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "field.favicon": {
-    "message": "Webbplatsens favicon",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "field.qr": {
-    "message": "QR-kod",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "field.url": {
-    "message": "Länk",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "field.admins": {
-    "message": "Webbplatsens administratörs-ID",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "field.distributionDefaultInviterId": {
-    "message": "Standardinbjudar-ID",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "field.distributionForceInviterId": {
-    "message": "Tvingad inbjudar-ID",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "field.featuresChat": {
-    "message": "Chat",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "field.featuresVeo": {
-    "message": "Veo",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "field.featuresSora": {
-    "message": "Sora",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "field.featuresGrok": {
-    "message": "Grok",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "field.featuresDeepseek": {
-    "message": "Deepseek",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "field.featuresChatgpt": {
-    "message": "ChatGPT",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "field.featuresMidjourney": {
-    "message": "Midjourney",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "field.featuresChatdoc": {
-    "message": "Chatdoc",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "field.featuresQrart": {
-    "message": "Qrart",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "field.featuresLuma": {
-    "message": "Luma",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "field.featuresPixverse": {
-    "message": "Pixverse",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "field.featuresPika": {
-    "message": "Pika",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "field.featuresKling": {
-    "message": "Kling",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "field.featuresHailuo": {
-    "message": "Hailuo",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "field.featuresHeadshots": {
-    "message": "AI ID-foto",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "field.featuresSuno": {
-    "message": "Suno",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "field.featuresFlux": {
-    "message": "Flux",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "field.featuresNanobanana": {
-    "message": "Nano Banana",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "field.featuresSeedream": {
-    "message": "SeeDream",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "field.featuresSeedance": {
-    "message": "SeeDance",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "field.featuresWan": {
-    "message": "Wan",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "field.featuresProducer": {
-    "message": "Producent",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "field.featuresKimi": {
-    "message": "Kimi",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "field.featuresSerp": {
-    "message": "SERP",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "field.featuresSupport": {
-    "message": "Kundsupport",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "field.featuresI18n": {
-    "message": "Flerspråkigt stöd",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "title.basicConfig": {
-    "message": "Grundkonfiguration",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "title.seoConfig": {
-    "message": "SEO-konfiguration",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "title.editAdmins": {
-    "message": "Redigera administratörer",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "title.featuresConfig": {
-    "message": "Funktioner konfiguration",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "title.editTitle": {
-    "message": "Redigera titel",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "title.editOrigin": {
-    "message": "Redigera domän",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "title.editKeywords": {
-    "message": "Redigera nyckelord",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "title.editLogo": {
-    "message": "Redigera logotyp",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "title.editFavicon": {
-    "message": "Redigera favicon",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "title.editDescription": {
-    "message": "Redigera beskrivning",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "title.distributionConfig": {
-    "message": "Distributionskonfiguration",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "title.editDistributionDefaultInviterId": {
-    "message": "Redigera standardinbjudare",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "title.editDistributionForceInviterId": {
-    "message": "Redigera tvingad inbjudare",
-    "description": "Visas som titeln i redigeringsrutan"
-  },
-  "title.editQR": {
-    "message": "Redigera QR-kod",
-    "description": "Visas som titel i redigeringsrutan"
-  },
-  "title.editUrl": {
-    "message": "Redigera länk",
-    "description": "Visas som titel i redigeringsrutan"
-  },
-  "placeholder.title": {
-    "message": "Ange webbplatsens titel",
-    "description": "Visas som titel i redigeringsrutan"
-  },
-  "placeholder.origin": {
-    "message": "Ange webbplatsens domän",
-    "description": "Visas som titel i redigeringsrutan"
-  },
-  "placeholder.editUrl": {
-    "message": "Ange länk",
-    "description": "Visas som titel i redigeringsrutan"
-  },
-  "placeholder.description": {
-    "message": "Ange webbplatsens beskrivning",
-    "description": "Visas som titel i redigeringsrutan"
-  },
-  "placeholder.keywords": {
-    "message": "Ange webbplatsens nyckelord",
-    "description": "Visas som titel i redigeringsrutan"
-  },
-  "placeholder.editDistributionDefaultInviterId": {
-    "message": "Ange standardinbjudarens ID",
-    "description": "Visas som titel i redigeringsrutan"
-  },
-  "placeholder.editDistributionForceInviterId": {
-    "message": "Ange tvingad inbjudarens ID",
-    "description": "Visas som titel i redigeringsrutan"
-  },
-  "message.uploadImageExceed": {
-    "message": "Uppladdad bild överskrider gränsen",
-    "description": "Meddelande om att uppladdad bild överskrider gränsen"
-  },
-  "message.uploadImageError": {
-    "message": "Fel vid bilduppladdning",
-    "description": "Meddelande om fel vid bilduppladdning"
-  },
-  "message.editLogoTip": {
-    "message": "Rekommenderad storlek: 200*60px",
-    "description": "Tips för bilduppladdning"
-  },
-  "message.editQRTip": {
-    "message": "Rekommenderad storlek: 200*200px",
-    "description": "Tips för bilduppladdning"
-  },
-  "message.editFaviconTip": {
-    "message": "Rekommenderad storlek: 32*32px",
-    "description": "Tips för bilduppladdning"
-  },
-  "message.editUrl": {
-    "message": "Ange länk",
-    "description": "Tips för att ange länk"
-  },
-  "message.atLeastOneAdmin": {
-    "message": "Behåll minst en administratör",
-    "description": "Meddelande om att behålla minst en administratör"
-  },
-  "message.distributionDefaultInviterIdTip": {
-    "message": "Standardinbjudarens användar-ID. Om distributionslänken inte innehåller inviter_id-parametern används detta användar-ID som inbjudare.",
-    "description": "Tips om standardinbjudarens ID"
-  },
-  "message.distributionForceInviterIdTip": {
-    "message": "Tvingad inbjudarens användar-ID. Om detta ID är inställt används det alltid som inbjudare oavsett om distributionslänken innehåller inviter_id-parametern.",
-    "description": "Tips om tvingad inbjudarens ID"
-  },
-  "message.originTip": {
-    "message": "Webbplatsens domän, webbplatskonfigurationen är kopplad till domänen och kan inte ändras.",
-    "description": "Tips om webbplatsens domän"
-  },
-  "message.titleTip": {
-    "message": "Webbplatsens titel, visas i webbläsarens flik.",
-    "description": "Tips om webbplatsens titel"
-  },
-  "message.descriptionTip": {
-    "message": "Webbplatsens beskrivning, finns i webbplatsens metadata och används för SEO-optimering.",
-    "description": "Tips om webbplatsens beskrivning"
-  },
-  "message.logoTip": {
-    "message": "Webbplatsens logotyp, visas högst upp i webbplatsens meny när menyn är öppen.",
-    "description": "Tips om webbplatsens logotyp"
-  },
-  "message.faviconTip": {
-    "message": "Webbplatsens favicon, visas i webbläsarens flik.",
-    "description": "Tips om webbplatsens favicon"
-  },
-  "message.adminsTip": {
-    "message": "Webbplatsens administratörs-ID. Som standard blir den första användaren som skapar webbplatsen administratör. Endast webbplatsadministratörer kan hantera webbplatsen.",
-    "description": "Tips om webbplatsens administratörer"
-  },
-  "message.adminsTip2": {
-    "message": "Kan lägga till eller ta bort administratörs-ID här. Du kan se användar-ID på https://auth.acedata.cloud",
-    "description": "Tips om webbplatsens administratörer"
-  },
-  "message.keywordsTip": {
-    "message": "Webbplatsens nyckelord, finns i webbplatsens metadata och används för SEO-optimering.",
-    "description": "Tips om webbplatsens nyckelord"
-  },
-  "message.keywordsTip2": {
-    "message": "Kan lägga till eller ta bort webbplatsnyckelord här. Ju mer precisa nyckelord, desto bättre för SEO-optimering.",
-    "description": "Tips om webbplatsens nyckelord"
-  },
-  "message.featuresChat": {
-    "message": "Aktivera eller inaktivera Chat-funktion.",
-    "description": "Beskrivning av Chat-funktionen"
-  },
-  "message.featuresGrok": {
-    "message": "Aktivera eller inaktivera Grok-funktion.",
-    "description": "Beskrivning av Grok-funktionen"
-  },
-  "message.featuresDeepseek": {
-    "message": "Aktivera eller inaktivera Deepseek-funktion.",
-    "description": "Beskrivning av Deepseek-funktionen"
-  },
-  "message.featuresChatgpt": {
-    "message": "Aktivera eller inaktivera ChatGPT-funktion.",
-    "description": "Beskrivning av ChatGPT-funktionen"
-  },
-  "message.featuresMidjourney": {
-    "message": "Aktivera eller inaktivera Midjourney-funktion.",
-    "description": "Beskrivning av Midjourney-funktionen"
-  },
-  "message.featuresChatdoc": {
-    "message": "Aktivera eller inaktivera Chatdoc-funktion.",
-    "description": "Beskrivning av Chatdoc-funktionen"
-  },
-  "message.featuresQrart": {
-    "message": "Aktivera eller inaktivera Qrart-funktion.",
-    "description": "Beskrivning av Qrart-funktionen"
-  },
-  "message.featuresVeo": {
-    "message": "Aktivera eller inaktivera Veo-funktion.",
-    "description": "Beskrivning av Veo-funktionen"
-  },
-  "message.featuresSora": {
-    "message": "Aktivera eller inaktivera Sora-funktion.",
-    "description": "Beskrivning av Sora-funktionen"
-  },
-  "message.featuresSuno": {
-    "message": "Aktivera eller inaktivera Suno-funktion.",
-    "description": "Beskrivning av Suno-funktionen"
-  },
-  "message.featuresPixverse": {
-    "message": "Aktivera eller inaktivera Pixverse-funktioner.",
-    "description": "Pixverse-funktionens beskrivning"
-  },
-  "message.featuresFlux": {
-    "message": "Aktivera eller inaktivera FLux-funktioner.",
-    "description": "FLux-funktionens beskrivning"
-  },
-  "message.featuresNanobanana": {
-    "message": "Aktivera eller inaktivera Nano Banana-funktioner.",
-    "description": "Nano Banana-funktionens beskrivning"
-  },
-  "message.featuresSeedream": {
-    "message": "Aktivera eller inaktivera SeeDream-funktioner.",
-    "description": "SeeDream-funktionens beskrivning"
-  },
-  "message.featuresSeedance": {
-    "message": "Aktivera eller inaktivera SeeDance-funktioner.",
-    "description": "SeeDance-funktionens beskrivning"
-  },
-  "message.featuresWan": {
-    "message": "Aktivera eller inaktivera Wan-funktioner.",
-    "description": "Wan-funktionens beskrivning"
-  },
-  "message.featuresProducer": {
-    "message": "Aktivera eller inaktivera Producer-funktioner.",
-    "description": "Producer-funktionens beskrivning"
-  },
-  "message.featuresKimi": {
-    "message": "Aktivera eller inaktivera Kimi-funktioner.",
-    "description": "Kimi-funktionens beskrivning"
-  },
-  "message.featuresSerp": {
-    "message": "Aktivera eller inaktivera SERP-funktioner.",
-    "description": "SERP-funktionens beskrivning"
-  },
-  "message.featuresLuma": {
-    "message": "Aktivera eller inaktivera Luma-funktioner.",
-    "description": "Luma-funktionens beskrivning"
-  },
-  "message.featuresPika": {
-    "message": "Aktivera eller inaktivera Pika-funktioner.",
-    "description": "Pika-funktionens beskrivning"
-  },
-  "message.featuresKling": {
-    "message": "Aktivera eller inaktivera Kling-funktioner.",
-    "description": "Kling-funktionens beskrivning"
-  },
-  "message.featuresHailuo": {
-    "message": "Aktivera eller inaktivera Hailuo-funktioner.",
-    "description": "Hailuo-funktionens beskrivning"
-  },
-  "message.featuresHeadshots": {
-    "message": "Aktivera eller inaktivera AI ID-foto-funktioner.",
-    "description": "AI ID-foto-funktionens beskrivning"
-  },
-  "message.featuresSupport": {
-    "message": "Aktivera eller inaktivera kundsupport",
-    "description": "Supportfunktionens beskrivning"
-  },
-  "message.featuresI18n": {
-    "message": "Aktivera eller inaktivera flerspråkigt stöd. När det är inaktiverat kan användare endast använda standardspråket.",
-    "description": "Beskrivning av flerspråkigt stöd"
-  },
-  "button.upload": {
-    "message": "Ladda upp",
-    "description": "Ladda upp"
-  },
-  "button.enabled": {
-    "message": "Aktiverad",
-    "description": "Knappt text som indikerar att det är aktiverat"
-  },
-  "button.disabled": {
-    "message": "Inaktiverad",
-    "description": "Knappt text som indikerar att det är inaktiverat"
-  },
-  "field.featuresGemini": {
-    "message": "Gemini",
-    "description": "Visas som titel i redigeringsrutan"
-  },
-  "message.featuresGemini": {
-    "message": "Aktivera eller inaktivera Gemini-funktioner.",
-    "description": "Beskrivning av Gemini-funktionen"
-  },
-  "field.featuresClaude": {
-    "message": "Claude",
-    "description": "Visas som titel i redigeringsrutan"
-  },
-  "message.featuresClaude": {
-    "message": "Aktivera eller inaktivera Claude-funktioner.",
-    "description": "Beskrivning av Claude-funktionen"
-  }
+  "field.title": [
+    [
+      "message",
+      "Webbplatsens titel"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "field.origin": [
+    [
+      "message",
+      "Webbplatsens domän"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "field.description": [
+    [
+      "message",
+      "Webbplatsens beskrivning"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "field.keywords": [
+    [
+      "message",
+      "Webbplatsens nyckelord"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "field.logo": [
+    [
+      "message",
+      "Webbplatsens logotyp"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "field.favicon": [
+    [
+      "message",
+      "Webbplatsens favicon"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "field.qr": [
+    [
+      "message",
+      "QR-kod"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "field.url": [
+    [
+      "message",
+      "Länk"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "field.admins": [
+    [
+      "message",
+      "Webbplatsens administratörs-ID"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "field.distributionDefaultInviterId": [
+    [
+      "message",
+      "Standardinbjudar-ID"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "field.distributionForceInviterId": [
+    [
+      "message",
+      "Tvingad inbjudar-ID"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "field.featuresChat": [
+    [
+      "message",
+      "Chat"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "field.featuresVeo": [
+    [
+      "message",
+      "Veo"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "field.featuresSora": [
+    [
+      "message",
+      "Sora"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "field.featuresGrok": [
+    [
+      "message",
+      "Grok"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "field.featuresDeepseek": [
+    [
+      "message",
+      "Deepseek"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "field.featuresChatgpt": [
+    [
+      "message",
+      "ChatGPT"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "field.featuresMidjourney": [
+    [
+      "message",
+      "Midjourney"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "field.featuresChatdoc": [
+    [
+      "message",
+      "Chatdoc"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "field.featuresQrart": [
+    [
+      "message",
+      "Qrart"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "field.featuresLuma": [
+    [
+      "message",
+      "Luma"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "field.featuresPixverse": [
+    [
+      "message",
+      "Pixverse"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "field.featuresPika": [
+    [
+      "message",
+      "Pika"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "field.featuresKling": [
+    [
+      "message",
+      "Kling"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "field.featuresHailuo": [
+    [
+      "message",
+      "Hailuo"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "field.featuresHeadshots": [
+    [
+      "message",
+      "AI ID-foto"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "field.featuresSuno": [
+    [
+      "message",
+      "Suno"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "field.featuresFlux": [
+    [
+      "message",
+      "Flux"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "field.featuresNanobanana": [
+    [
+      "message",
+      "Nano Banana"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "field.featuresOpenaiimage": {
+    "message": "OpenAI Image",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresSeedream": [
+    [
+      "message",
+      "SeeDream"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "field.featuresSeedance": [
+    [
+      "message",
+      "SeeDance"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "field.featuresWan": [
+    [
+      "message",
+      "Wan"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "field.featuresProducer": [
+    [
+      "message",
+      "Producent"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "field.featuresKimi": [
+    [
+      "message",
+      "Kimi"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "field.featuresSerp": [
+    [
+      "message",
+      "SERP"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "field.featuresSupport": [
+    [
+      "message",
+      "Kundsupport"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "field.featuresI18n": [
+    [
+      "message",
+      "Flerspråkigt stöd"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "title.basicConfig": [
+    [
+      "message",
+      "Grundkonfiguration"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "title.seoConfig": [
+    [
+      "message",
+      "SEO-konfiguration"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "title.editAdmins": [
+    [
+      "message",
+      "Redigera administratörer"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "title.featuresConfig": [
+    [
+      "message",
+      "Funktioner konfiguration"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "title.editTitle": [
+    [
+      "message",
+      "Redigera titel"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "title.editOrigin": [
+    [
+      "message",
+      "Redigera domän"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "title.editKeywords": [
+    [
+      "message",
+      "Redigera nyckelord"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "title.editLogo": [
+    [
+      "message",
+      "Redigera logotyp"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "title.editFavicon": [
+    [
+      "message",
+      "Redigera favicon"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "title.editDescription": [
+    [
+      "message",
+      "Redigera beskrivning"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "title.distributionConfig": [
+    [
+      "message",
+      "Distributionskonfiguration"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "title.editDistributionDefaultInviterId": [
+    [
+      "message",
+      "Redigera standardinbjudare"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "title.editDistributionForceInviterId": [
+    [
+      "message",
+      "Redigera tvingad inbjudare"
+    ],
+    [
+      "description",
+      "Visas som titeln i redigeringsrutan"
+    ]
+  ],
+  "title.editQR": [
+    [
+      "message",
+      "Redigera QR-kod"
+    ],
+    [
+      "description",
+      "Visas som titel i redigeringsrutan"
+    ]
+  ],
+  "title.editUrl": [
+    [
+      "message",
+      "Redigera länk"
+    ],
+    [
+      "description",
+      "Visas som titel i redigeringsrutan"
+    ]
+  ],
+  "placeholder.title": [
+    [
+      "message",
+      "Ange webbplatsens titel"
+    ],
+    [
+      "description",
+      "Visas som titel i redigeringsrutan"
+    ]
+  ],
+  "placeholder.origin": [
+    [
+      "message",
+      "Ange webbplatsens domän"
+    ],
+    [
+      "description",
+      "Visas som titel i redigeringsrutan"
+    ]
+  ],
+  "placeholder.editUrl": [
+    [
+      "message",
+      "Ange länk"
+    ],
+    [
+      "description",
+      "Visas som titel i redigeringsrutan"
+    ]
+  ],
+  "placeholder.description": [
+    [
+      "message",
+      "Ange webbplatsens beskrivning"
+    ],
+    [
+      "description",
+      "Visas som titel i redigeringsrutan"
+    ]
+  ],
+  "placeholder.keywords": [
+    [
+      "message",
+      "Ange webbplatsens nyckelord"
+    ],
+    [
+      "description",
+      "Visas som titel i redigeringsrutan"
+    ]
+  ],
+  "placeholder.editDistributionDefaultInviterId": [
+    [
+      "message",
+      "Ange standardinbjudarens ID"
+    ],
+    [
+      "description",
+      "Visas som titel i redigeringsrutan"
+    ]
+  ],
+  "placeholder.editDistributionForceInviterId": [
+    [
+      "message",
+      "Ange tvingad inbjudarens ID"
+    ],
+    [
+      "description",
+      "Visas som titel i redigeringsrutan"
+    ]
+  ],
+  "message.uploadImageExceed": [
+    [
+      "message",
+      "Uppladdad bild överskrider gränsen"
+    ],
+    [
+      "description",
+      "Meddelande om att uppladdad bild överskrider gränsen"
+    ]
+  ],
+  "message.uploadImageError": [
+    [
+      "message",
+      "Fel vid bilduppladdning"
+    ],
+    [
+      "description",
+      "Meddelande om fel vid bilduppladdning"
+    ]
+  ],
+  "message.editLogoTip": [
+    [
+      "message",
+      "Rekommenderad storlek: 200*60px"
+    ],
+    [
+      "description",
+      "Tips för bilduppladdning"
+    ]
+  ],
+  "message.editQRTip": [
+    [
+      "message",
+      "Rekommenderad storlek: 200*200px"
+    ],
+    [
+      "description",
+      "Tips för bilduppladdning"
+    ]
+  ],
+  "message.editFaviconTip": [
+    [
+      "message",
+      "Rekommenderad storlek: 32*32px"
+    ],
+    [
+      "description",
+      "Tips för bilduppladdning"
+    ]
+  ],
+  "message.editUrl": [
+    [
+      "message",
+      "Ange länk"
+    ],
+    [
+      "description",
+      "Tips för att ange länk"
+    ]
+  ],
+  "message.atLeastOneAdmin": [
+    [
+      "message",
+      "Behåll minst en administratör"
+    ],
+    [
+      "description",
+      "Meddelande om att behålla minst en administratör"
+    ]
+  ],
+  "message.distributionDefaultInviterIdTip": [
+    [
+      "message",
+      "Standardinbjudarens användar-ID. Om distributionslänken inte innehåller inviter_id-parametern används detta användar-ID som inbjudare."
+    ],
+    [
+      "description",
+      "Tips om standardinbjudarens ID"
+    ]
+  ],
+  "message.distributionForceInviterIdTip": [
+    [
+      "message",
+      "Tvingad inbjudarens användar-ID. Om detta ID är inställt används det alltid som inbjudare oavsett om distributionslänken innehåller inviter_id-parametern."
+    ],
+    [
+      "description",
+      "Tips om tvingad inbjudarens ID"
+    ]
+  ],
+  "message.originTip": [
+    [
+      "message",
+      "Webbplatsens domän, webbplatskonfigurationen är kopplad till domänen och kan inte ändras."
+    ],
+    [
+      "description",
+      "Tips om webbplatsens domän"
+    ]
+  ],
+  "message.titleTip": [
+    [
+      "message",
+      "Webbplatsens titel, visas i webbläsarens flik."
+    ],
+    [
+      "description",
+      "Tips om webbplatsens titel"
+    ]
+  ],
+  "message.descriptionTip": [
+    [
+      "message",
+      "Webbplatsens beskrivning, finns i webbplatsens metadata och används för SEO-optimering."
+    ],
+    [
+      "description",
+      "Tips om webbplatsens beskrivning"
+    ]
+  ],
+  "message.logoTip": [
+    [
+      "message",
+      "Webbplatsens logotyp, visas högst upp i webbplatsens meny när menyn är öppen."
+    ],
+    [
+      "description",
+      "Tips om webbplatsens logotyp"
+    ]
+  ],
+  "message.faviconTip": [
+    [
+      "message",
+      "Webbplatsens favicon, visas i webbläsarens flik."
+    ],
+    [
+      "description",
+      "Tips om webbplatsens favicon"
+    ]
+  ],
+  "message.adminsTip": [
+    [
+      "message",
+      "Webbplatsens administratörs-ID. Som standard blir den första användaren som skapar webbplatsen administratör. Endast webbplatsadministratörer kan hantera webbplatsen."
+    ],
+    [
+      "description",
+      "Tips om webbplatsens administratörer"
+    ]
+  ],
+  "message.adminsTip2": [
+    [
+      "message",
+      "Kan lägga till eller ta bort administratörs-ID här. Du kan se användar-ID på https://auth.acedata.cloud"
+    ],
+    [
+      "description",
+      "Tips om webbplatsens administratörer"
+    ]
+  ],
+  "message.keywordsTip": [
+    [
+      "message",
+      "Webbplatsens nyckelord, finns i webbplatsens metadata och används för SEO-optimering."
+    ],
+    [
+      "description",
+      "Tips om webbplatsens nyckelord"
+    ]
+  ],
+  "message.keywordsTip2": [
+    [
+      "message",
+      "Kan lägga till eller ta bort webbplatsnyckelord här. Ju mer precisa nyckelord, desto bättre för SEO-optimering."
+    ],
+    [
+      "description",
+      "Tips om webbplatsens nyckelord"
+    ]
+  ],
+  "message.featuresChat": [
+    [
+      "message",
+      "Aktivera eller inaktivera Chat-funktion."
+    ],
+    [
+      "description",
+      "Beskrivning av Chat-funktionen"
+    ]
+  ],
+  "message.featuresGrok": [
+    [
+      "message",
+      "Aktivera eller inaktivera Grok-funktion."
+    ],
+    [
+      "description",
+      "Beskrivning av Grok-funktionen"
+    ]
+  ],
+  "message.featuresDeepseek": [
+    [
+      "message",
+      "Aktivera eller inaktivera Deepseek-funktion."
+    ],
+    [
+      "description",
+      "Beskrivning av Deepseek-funktionen"
+    ]
+  ],
+  "message.featuresChatgpt": [
+    [
+      "message",
+      "Aktivera eller inaktivera ChatGPT-funktion."
+    ],
+    [
+      "description",
+      "Beskrivning av ChatGPT-funktionen"
+    ]
+  ],
+  "message.featuresMidjourney": [
+    [
+      "message",
+      "Aktivera eller inaktivera Midjourney-funktion."
+    ],
+    [
+      "description",
+      "Beskrivning av Midjourney-funktionen"
+    ]
+  ],
+  "message.featuresChatdoc": [
+    [
+      "message",
+      "Aktivera eller inaktivera Chatdoc-funktion."
+    ],
+    [
+      "description",
+      "Beskrivning av Chatdoc-funktionen"
+    ]
+  ],
+  "message.featuresQrart": [
+    [
+      "message",
+      "Aktivera eller inaktivera Qrart-funktion."
+    ],
+    [
+      "description",
+      "Beskrivning av Qrart-funktionen"
+    ]
+  ],
+  "message.featuresVeo": [
+    [
+      "message",
+      "Aktivera eller inaktivera Veo-funktion."
+    ],
+    [
+      "description",
+      "Beskrivning av Veo-funktionen"
+    ]
+  ],
+  "message.featuresSora": [
+    [
+      "message",
+      "Aktivera eller inaktivera Sora-funktion."
+    ],
+    [
+      "description",
+      "Beskrivning av Sora-funktionen"
+    ]
+  ],
+  "message.featuresSuno": [
+    [
+      "message",
+      "Aktivera eller inaktivera Suno-funktion."
+    ],
+    [
+      "description",
+      "Beskrivning av Suno-funktionen"
+    ]
+  ],
+  "message.featuresPixverse": [
+    [
+      "message",
+      "Aktivera eller inaktivera Pixverse-funktioner."
+    ],
+    [
+      "description",
+      "Pixverse-funktionens beskrivning"
+    ]
+  ],
+  "message.featuresFlux": [
+    [
+      "message",
+      "Aktivera eller inaktivera FLux-funktioner."
+    ],
+    [
+      "description",
+      "FLux-funktionens beskrivning"
+    ]
+  ],
+  "message.featuresNanobanana": [
+    [
+      "message",
+      "Aktivera eller inaktivera Nano Banana-funktioner."
+    ],
+    [
+      "description",
+      "Nano Banana-funktionens beskrivning"
+    ]
+  ],
+  "message.featuresOpenaiimage": {
+    "message": "Toggle OpenAI Image feature module.",
+    "description": "Description of the OpenAI Image feature"
+  },
+  "message.featuresSeedream": [
+    [
+      "message",
+      "Aktivera eller inaktivera SeeDream-funktioner."
+    ],
+    [
+      "description",
+      "SeeDream-funktionens beskrivning"
+    ]
+  ],
+  "message.featuresSeedance": [
+    [
+      "message",
+      "Aktivera eller inaktivera SeeDance-funktioner."
+    ],
+    [
+      "description",
+      "SeeDance-funktionens beskrivning"
+    ]
+  ],
+  "message.featuresWan": [
+    [
+      "message",
+      "Aktivera eller inaktivera Wan-funktioner."
+    ],
+    [
+      "description",
+      "Wan-funktionens beskrivning"
+    ]
+  ],
+  "message.featuresProducer": [
+    [
+      "message",
+      "Aktivera eller inaktivera Producer-funktioner."
+    ],
+    [
+      "description",
+      "Producer-funktionens beskrivning"
+    ]
+  ],
+  "message.featuresKimi": [
+    [
+      "message",
+      "Aktivera eller inaktivera Kimi-funktioner."
+    ],
+    [
+      "description",
+      "Kimi-funktionens beskrivning"
+    ]
+  ],
+  "message.featuresSerp": [
+    [
+      "message",
+      "Aktivera eller inaktivera SERP-funktioner."
+    ],
+    [
+      "description",
+      "SERP-funktionens beskrivning"
+    ]
+  ],
+  "message.featuresLuma": [
+    [
+      "message",
+      "Aktivera eller inaktivera Luma-funktioner."
+    ],
+    [
+      "description",
+      "Luma-funktionens beskrivning"
+    ]
+  ],
+  "message.featuresPika": [
+    [
+      "message",
+      "Aktivera eller inaktivera Pika-funktioner."
+    ],
+    [
+      "description",
+      "Pika-funktionens beskrivning"
+    ]
+  ],
+  "message.featuresKling": [
+    [
+      "message",
+      "Aktivera eller inaktivera Kling-funktioner."
+    ],
+    [
+      "description",
+      "Kling-funktionens beskrivning"
+    ]
+  ],
+  "message.featuresHailuo": [
+    [
+      "message",
+      "Aktivera eller inaktivera Hailuo-funktioner."
+    ],
+    [
+      "description",
+      "Hailuo-funktionens beskrivning"
+    ]
+  ],
+  "message.featuresHeadshots": [
+    [
+      "message",
+      "Aktivera eller inaktivera AI ID-foto-funktioner."
+    ],
+    [
+      "description",
+      "AI ID-foto-funktionens beskrivning"
+    ]
+  ],
+  "message.featuresSupport": [
+    [
+      "message",
+      "Aktivera eller inaktivera kundsupport"
+    ],
+    [
+      "description",
+      "Supportfunktionens beskrivning"
+    ]
+  ],
+  "message.featuresI18n": [
+    [
+      "message",
+      "Aktivera eller inaktivera flerspråkigt stöd. När det är inaktiverat kan användare endast använda standardspråket."
+    ],
+    [
+      "description",
+      "Beskrivning av flerspråkigt stöd"
+    ]
+  ],
+  "button.upload": [
+    [
+      "message",
+      "Ladda upp"
+    ],
+    [
+      "description",
+      "Ladda upp"
+    ]
+  ],
+  "button.enabled": [
+    [
+      "message",
+      "Aktiverad"
+    ],
+    [
+      "description",
+      "Knappt text som indikerar att det är aktiverat"
+    ]
+  ],
+  "button.disabled": [
+    [
+      "message",
+      "Inaktiverad"
+    ],
+    [
+      "description",
+      "Knappt text som indikerar att det är inaktiverat"
+    ]
+  ],
+  "field.featuresGemini": [
+    [
+      "message",
+      "Gemini"
+    ],
+    [
+      "description",
+      "Visas som titel i redigeringsrutan"
+    ]
+  ],
+  "message.featuresGemini": [
+    [
+      "message",
+      "Aktivera eller inaktivera Gemini-funktioner."
+    ],
+    [
+      "description",
+      "Beskrivning av Gemini-funktionen"
+    ]
+  ],
+  "field.featuresClaude": [
+    [
+      "message",
+      "Claude"
+    ],
+    [
+      "description",
+      "Visas som titel i redigeringsrutan"
+    ]
+  ],
+  "message.featuresClaude": [
+    [
+      "message",
+      "Aktivera eller inaktivera Claude-funktioner."
+    ],
+    [
+      "description",
+      "Beskrivning av Claude-funktionen"
+    ]
+  ]
 }

--- a/src/i18n/uk/site.json
+++ b/src/i18n/uk/site.json
@@ -1,442 +1,1110 @@
 {
-  "field.title": {
-    "message": "Назва сайту",
-    "description": "展示在编辑框的标题"
-  },
-  "field.origin": {
-    "message": "Домен сайту",
-    "description": "展示在编辑框的标题"
-  },
-  "field.description": {
-    "message": "Опис сайту",
-    "description": "展示在编辑框的标题"
-  },
-  "field.keywords": {
-    "message": "Ключові слова сайту",
-    "description": "展示在编辑框的标题"
-  },
-  "field.logo": {
-    "message": "Логотип сайту",
-    "description": "展示在编辑框的标题"
-  },
-  "field.favicon": {
-    "message": "Favicon сайту",
-    "description": "展示在编辑框的标题"
-  },
-  "field.qr": {
-    "message": "QR-код",
-    "description": "展示在编辑框的标题"
-  },
-  "field.url": {
-    "message": "Посилання",
-    "description": "展示在编辑框的标题"
-  },
-  "field.admins": {
-    "message": "ID адміністраторів сайту",
-    "description": "展示在编辑框的标题"
-  },
-  "field.distributionDefaultInviterId": {
-    "message": "ID запрошувача за замовчуванням",
-    "description": "展示在编辑框的标题"
-  },
-  "field.distributionForceInviterId": {
-    "message": "ID обов'язкового запрошувача",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresChat": {
-    "message": "Чат",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresVeo": {
-    "message": "Veo",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresSora": {
-    "message": "Sora",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresGrok": {
-    "message": "Grok",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresDeepseek": {
-    "message": "Deepseek",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresChatgpt": {
-    "message": "ChatGPT",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresMidjourney": {
-    "message": "Midjourney",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresChatdoc": {
-    "message": "Chatdoc",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresQrart": {
-    "message": "Qrart",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresLuma": {
-    "message": "Luma",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresPixverse": {
-    "message": "Pixverse",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresPika": {
-    "message": "Pika",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresKling": {
-    "message": "Kling",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresHailuo": {
-    "message": "Hailuo",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresHeadshots": {
-    "message": "AI фото",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresSuno": {
-    "message": "Suno",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresFlux": {
-    "message": "Flux",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresNanobanana": {
-    "message": "Нано Банан",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresSeedream": {
-    "message": "SeeDream",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresSeedance": {
-    "message": "SeeDance",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresWan": {
-    "message": "Wan",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresProducer": {
-    "message": "Продюсер",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresKimi": {
-    "message": "Kimi",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresSerp": {
-    "message": "SERP",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresSupport": {
-    "message": "Підтримка клієнтів",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresI18n": {
-    "message": "Підтримка багатомовності",
-    "description": "展示在编辑框的标题"
-  },
-  "title.basicConfig": {
-    "message": "Основні налаштування",
-    "description": "展示在编辑框的标题"
-  },
-  "title.seoConfig": {
-    "message": "Налаштування SEO",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editAdmins": {
-    "message": "Редагувати адміністраторів",
-    "description": "展示在编辑框的标题"
-  },
-  "title.featuresConfig": {
-    "message": "Налаштування функцій",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editTitle": {
-    "message": "Редагувати назву",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editOrigin": {
-    "message": "Редагувати домен",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editKeywords": {
-    "message": "Редагувати ключові слова",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editLogo": {
-    "message": "Редагувати логотип",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editFavicon": {
-    "message": "Редагувати Favicon",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editDescription": {
-    "message": "Редагувати опис",
-    "description": "展示在编辑框的标题"
-  },
-  "title.distributionConfig": {
-    "message": "Налаштування дистрибуції",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editDistributionDefaultInviterId": {
-    "message": "Редагувати запрошувача за замовчуванням",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editDistributionForceInviterId": {
-    "message": "Редагувати обов'язкового запрошувача",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editQR": {
-    "message": "Редагувати QR-код",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editUrl": {
-    "message": "Редагувати посилання",
-    "description": "展示在编辑框的标题"
-  },
-  "placeholder.title": {
-    "message": "Введіть заголовок сайту",
-    "description": "展示在编辑框的标题"
-  },
-  "placeholder.origin": {
-    "message": "Введіть домен сайту",
-    "description": "展示在编辑框的标题"
-  },
-  "placeholder.editUrl": {
-    "message": "Введіть посилання",
-    "description": "展示在编辑框的标题"
-  },
-  "placeholder.description": {
-    "message": "Введіть опис сайту",
-    "description": "展示在编辑框的标题"
-  },
-  "placeholder.keywords": {
-    "message": "Введіть ключові слова сайту",
-    "description": "展示在编辑框的标题"
-  },
-  "placeholder.editDistributionDefaultInviterId": {
-    "message": "Введіть ID запрошувача за замовчуванням",
-    "description": "展示在编辑框的标题"
-  },
-  "placeholder.editDistributionForceInviterId": {
-    "message": "Введіть ID обов'язкового запрошувача",
-    "description": "展示在编辑框的标题"
-  },
-  "message.uploadImageExceed": {
-    "message": "Перевищено ліміт на завантаження зображення",
-    "description": "上传图片超过限制的提示"
-  },
-  "message.uploadImageError": {
-    "message": "Помилка завантаження зображення",
-    "description": "上传图片错误的提示"
-  },
-  "message.editLogoTip": {
-    "message": "Рекомендований розмір: 200*60px",
-    "description": "上传图片的提示语言"
-  },
-  "message.editQRTip": {
-    "message": "Рекомендований розмір: 200*200px",
-    "description": "上传图片的提示语言"
-  },
-  "message.editFaviconTip": {
-    "message": "Рекомендований розмір: 32*32px",
-    "description": "上传图片的提示语言"
-  },
-  "message.editUrl": {
-    "message": "Введіть посилання",
-    "description": "请输入链接的提示"
-  },
-  "message.atLeastOneAdmin": {
-    "message": "Принаймні один адміністратор має залишитися",
-    "description": "至少保留一个管理员的提示"
-  },
-  "message.distributionDefaultInviterIdTip": {
-    "message": "ID користувача запрошувача за замовчуванням. Якщо посилання на розподіл не містить параметра inviter_id, за замовчуванням використовується цей ID як запрошувач.",
-    "description": "默认邀请人ID的提示"
-  },
-  "message.distributionForceInviterIdTip": {
-    "message": "ID обов'язкового запрошувача. Якщо цей ID встановлено, незалежно від того, чи містить посилання на розподіл параметр inviter_id, цей ID буде використовуватися як запрошувач.",
-    "description": "强制邀请人ID的提示"
-  },
-  "message.originTip": {
-    "message": "Домен сайту, конфігурація сайту прив'язана до домену, домен сайту не можна змінити.",
-    "description": "站点域名的提示"
-  },
-  "message.titleTip": {
-    "message": "Заголовок сайту, відображається на вкладці браузера.",
-    "description": "站点标题的提示"
-  },
-  "message.descriptionTip": {
-    "message": "Опис сайту, розташований у метаданих сайту, використовується для SEO оптимізації сайту.",
-    "description": "站点描述的提示"
-  },
-  "message.logoTip": {
-    "message": "Логотип сайту, відображається у верхній частині меню сайту, коли меню розгорнуте.",
-    "description": "站点 Logo 的提示"
-  },
-  "message.faviconTip": {
-    "message": "Favicon сайту, відображається на вкладці браузера.",
-    "description": "站点 Favicon 的提示"
-  },
-  "message.adminsTip": {
-    "message": "ID адміністраторів сайту. За замовчуванням перший користувач, який створює сайт, стає адміністратором. Тільки адміністратори сайту можуть керувати сайтом.",
-    "description": "站点管理员的提示"
-  },
-  "message.adminsTip2": {
-    "message": "Тут можна додавати або видаляти ID адміністраторів. Ви можете переглянути ID користувачів на https://auth.acedata.cloud",
-    "description": "站点管理员的提示"
-  },
-  "message.keywordsTip": {
-    "message": "Ключові слова сайту, розташовані у метаданих сайту, використовуються для SEO оптимізації сайту.",
-    "description": "站点关键词的提示"
-  },
-  "message.keywordsTip2": {
-    "message": "Тут можна додавати або видаляти ключові слова сайту. Чим точніші ключові слова, тим краще для SEO оптимізації.",
-    "description": "站点关键词的提示"
-  },
-  "message.featuresChat": {
-    "message": "Увімкнути або вимкнути модуль функції Chat.",
-    "description": "Chat 功能的描述"
-  },
-  "message.featuresGrok": {
-    "message": "Увімкнути або вимкнути модуль функції Grok.",
-    "description": "Grok 功能的描述"
-  },
-  "message.featuresDeepseek": {
-    "message": "Увімкнути або вимкнути модуль функції Deepseek.",
-    "description": "Deepseek 功能的描述"
-  },
-  "message.featuresChatgpt": {
-    "message": "Увімкнути або вимкнути модуль функції ChatGPT.",
-    "description": "ChatGPT 功能的描述"
-  },
-  "message.featuresMidjourney": {
-    "message": "Увімкнути або вимкнути модуль функції Midjourney.",
-    "description": "Midjourney 功能的描述"
-  },
-  "message.featuresChatdoc": {
-    "message": "Увімкнути або вимкнути модуль функції Chatdoc.",
-    "description": "Chatdoc 功能的描述"
-  },
-  "message.featuresQrart": {
-    "message": "Увімкнути або вимкнути модуль функції Qrart.",
-    "description": "Qrart 功能的描述"
-  },
-  "message.featuresVeo": {
-    "message": "Увімкнути або вимкнути модуль функції Veo.",
-    "description": "Veo 功能的描述"
-  },
-  "message.featuresSora": {
-    "message": "Увімкнути або вимкнути модуль функції Sora.",
-    "description": "Sora 功能的描述"
-  },
-  "message.featuresSuno": {
-    "message": "Увімкнути або вимкнути модуль функції Suno.",
-    "description": "Suno 功能的描述"
-  },
-  "message.featuresPixverse": {
-    "message": "Увімкнути або вимкнути модуль функцій Pixverse.",
-    "description": "Опис функцій Pixverse"
-  },
-  "message.featuresFlux": {
-    "message": "Увімкнути або вимкнути модуль функцій FLux.",
-    "description": "Опис функцій FLux"
-  },
-  "message.featuresNanobanana": {
-    "message": "Увімкнути або вимкнути модуль функцій Nano Banana.",
-    "description": "Опис функцій Nano Banana"
-  },
-  "message.featuresSeedream": {
-    "message": "Увімкнути або вимкнути модуль функцій SeeDream.",
-    "description": "Опис функцій SeeDream"
-  },
-  "message.featuresSeedance": {
-    "message": "Увімкнути або вимкнути модуль функцій SeeDance.",
-    "description": "Опис функцій SeeDance"
-  },
-  "message.featuresWan": {
-    "message": "Увімкнути або вимкнути модуль функцій Wan.",
-    "description": "Опис функцій Wan"
-  },
-  "message.featuresProducer": {
-    "message": "Увімкнути або вимкнути модуль функцій Producer.",
-    "description": "Опис функцій Producer"
-  },
-  "message.featuresKimi": {
-    "message": "Увімкнути або вимкнути модуль функцій Kimi.",
-    "description": "Опис функцій Kimi"
-  },
-  "message.featuresSerp": {
-    "message": "Увімкнути або вимкнути модуль функцій SERP.",
-    "description": "Опис функцій SERP"
-  },
-  "message.featuresLuma": {
-    "message": "Увімкнути або вимкнути модуль функцій Luma.",
-    "description": "Опис функцій Luma"
-  },
-  "message.featuresPika": {
-    "message": "Увімкнути або вимкнути модуль функцій Pika.",
-    "description": "Опис функцій Pika"
-  },
-  "message.featuresKling": {
-    "message": "Увімкнути або вимкнути модуль функцій Kling.",
-    "description": "Опис функцій Kling"
-  },
-  "message.featuresHailuo": {
-    "message": "Увімкнути або вимкнути модуль функцій Hailuo.",
-    "description": "Опис функцій Hailuo"
-  },
-  "message.featuresHeadshots": {
-    "message": "Увімкнути або вимкнути модуль функцій AI фото.",
-    "description": "Опис функцій AI фото"
-  },
-  "message.featuresSupport": {
-    "message": "Увімкнути або вимкнути підтримку клієнтів",
-    "description": "Опис функцій підтримки"
-  },
-  "message.featuresI18n": {
-    "message": "Увімкнути або вимкнути багатомовну підтримку, після вимкнення користувач зможе використовувати лише мову за замовчуванням.",
-    "description": "Опис багатомовної підтримки"
-  },
-  "button.upload": {
-    "message": "Завантажити",
-    "description": "Завантажити"
-  },
-  "button.enabled": {
-    "message": "Увімкнено",
-    "description": "Текст перемикача, що вказує на те, що функція увімкнена"
-  },
-  "button.disabled": {
-    "message": "Вимкнено",
-    "description": "Текст перемикача, що вказує на те, що функція вимкнена"
-  },
-  "field.featuresGemini": {
-    "message": "Gemini",
-    "description": "Відображається як заголовок у редакторі"
-  },
-  "message.featuresGemini": {
-    "message": "Увімкнути або вимкнути модуль функцій Gemini.",
-    "description": "Опис функцій Gemini"
-  },
-  "field.featuresClaude": {
-    "message": "Claude",
-    "description": "Відображається як заголовок у редакторі"
-  },
-  "message.featuresClaude": {
-    "message": "Увімкнути або вимкнути модуль функцій Claude.",
-    "description": "Опис функцій Claude"
-  }
+  "field.title": [
+    [
+      "message",
+      "Назва сайту"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.origin": [
+    [
+      "message",
+      "Домен сайту"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.description": [
+    [
+      "message",
+      "Опис сайту"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.keywords": [
+    [
+      "message",
+      "Ключові слова сайту"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.logo": [
+    [
+      "message",
+      "Логотип сайту"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.favicon": [
+    [
+      "message",
+      "Favicon сайту"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.qr": [
+    [
+      "message",
+      "QR-код"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.url": [
+    [
+      "message",
+      "Посилання"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.admins": [
+    [
+      "message",
+      "ID адміністраторів сайту"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.distributionDefaultInviterId": [
+    [
+      "message",
+      "ID запрошувача за замовчуванням"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.distributionForceInviterId": [
+    [
+      "message",
+      "ID обов'язкового запрошувача"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresChat": [
+    [
+      "message",
+      "Чат"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresVeo": [
+    [
+      "message",
+      "Veo"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresSora": [
+    [
+      "message",
+      "Sora"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresGrok": [
+    [
+      "message",
+      "Grok"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresDeepseek": [
+    [
+      "message",
+      "Deepseek"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresChatgpt": [
+    [
+      "message",
+      "ChatGPT"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresMidjourney": [
+    [
+      "message",
+      "Midjourney"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresChatdoc": [
+    [
+      "message",
+      "Chatdoc"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresQrart": [
+    [
+      "message",
+      "Qrart"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresLuma": [
+    [
+      "message",
+      "Luma"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresPixverse": [
+    [
+      "message",
+      "Pixverse"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresPika": [
+    [
+      "message",
+      "Pika"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresKling": [
+    [
+      "message",
+      "Kling"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresHailuo": [
+    [
+      "message",
+      "Hailuo"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresHeadshots": [
+    [
+      "message",
+      "AI фото"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresSuno": [
+    [
+      "message",
+      "Suno"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresFlux": [
+    [
+      "message",
+      "Flux"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresNanobanana": [
+    [
+      "message",
+      "Нано Банан"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresOpenaiimage": {
+    "message": "OpenAI Image",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresSeedream": [
+    [
+      "message",
+      "SeeDream"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresSeedance": [
+    [
+      "message",
+      "SeeDance"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresWan": [
+    [
+      "message",
+      "Wan"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresProducer": [
+    [
+      "message",
+      "Продюсер"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresKimi": [
+    [
+      "message",
+      "Kimi"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresSerp": [
+    [
+      "message",
+      "SERP"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresSupport": [
+    [
+      "message",
+      "Підтримка клієнтів"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresI18n": [
+    [
+      "message",
+      "Підтримка багатомовності"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.basicConfig": [
+    [
+      "message",
+      "Основні налаштування"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.seoConfig": [
+    [
+      "message",
+      "Налаштування SEO"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editAdmins": [
+    [
+      "message",
+      "Редагувати адміністраторів"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.featuresConfig": [
+    [
+      "message",
+      "Налаштування функцій"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editTitle": [
+    [
+      "message",
+      "Редагувати назву"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editOrigin": [
+    [
+      "message",
+      "Редагувати домен"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editKeywords": [
+    [
+      "message",
+      "Редагувати ключові слова"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editLogo": [
+    [
+      "message",
+      "Редагувати логотип"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editFavicon": [
+    [
+      "message",
+      "Редагувати Favicon"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editDescription": [
+    [
+      "message",
+      "Редагувати опис"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.distributionConfig": [
+    [
+      "message",
+      "Налаштування дистрибуції"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editDistributionDefaultInviterId": [
+    [
+      "message",
+      "Редагувати запрошувача за замовчуванням"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editDistributionForceInviterId": [
+    [
+      "message",
+      "Редагувати обов'язкового запрошувача"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editQR": [
+    [
+      "message",
+      "Редагувати QR-код"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editUrl": [
+    [
+      "message",
+      "Редагувати посилання"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "placeholder.title": [
+    [
+      "message",
+      "Введіть заголовок сайту"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "placeholder.origin": [
+    [
+      "message",
+      "Введіть домен сайту"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "placeholder.editUrl": [
+    [
+      "message",
+      "Введіть посилання"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "placeholder.description": [
+    [
+      "message",
+      "Введіть опис сайту"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "placeholder.keywords": [
+    [
+      "message",
+      "Введіть ключові слова сайту"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "placeholder.editDistributionDefaultInviterId": [
+    [
+      "message",
+      "Введіть ID запрошувача за замовчуванням"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "placeholder.editDistributionForceInviterId": [
+    [
+      "message",
+      "Введіть ID обов'язкового запрошувача"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "message.uploadImageExceed": [
+    [
+      "message",
+      "Перевищено ліміт на завантаження зображення"
+    ],
+    [
+      "description",
+      "上传图片超过限制的提示"
+    ]
+  ],
+  "message.uploadImageError": [
+    [
+      "message",
+      "Помилка завантаження зображення"
+    ],
+    [
+      "description",
+      "上传图片错误的提示"
+    ]
+  ],
+  "message.editLogoTip": [
+    [
+      "message",
+      "Рекомендований розмір: 200*60px"
+    ],
+    [
+      "description",
+      "上传图片的提示语言"
+    ]
+  ],
+  "message.editQRTip": [
+    [
+      "message",
+      "Рекомендований розмір: 200*200px"
+    ],
+    [
+      "description",
+      "上传图片的提示语言"
+    ]
+  ],
+  "message.editFaviconTip": [
+    [
+      "message",
+      "Рекомендований розмір: 32*32px"
+    ],
+    [
+      "description",
+      "上传图片的提示语言"
+    ]
+  ],
+  "message.editUrl": [
+    [
+      "message",
+      "Введіть посилання"
+    ],
+    [
+      "description",
+      "请输入链接的提示"
+    ]
+  ],
+  "message.atLeastOneAdmin": [
+    [
+      "message",
+      "Принаймні один адміністратор має залишитися"
+    ],
+    [
+      "description",
+      "至少保留一个管理员的提示"
+    ]
+  ],
+  "message.distributionDefaultInviterIdTip": [
+    [
+      "message",
+      "ID користувача запрошувача за замовчуванням. Якщо посилання на розподіл не містить параметра inviter_id, за замовчуванням використовується цей ID як запрошувач."
+    ],
+    [
+      "description",
+      "默认邀请人ID的提示"
+    ]
+  ],
+  "message.distributionForceInviterIdTip": [
+    [
+      "message",
+      "ID обов'язкового запрошувача. Якщо цей ID встановлено, незалежно від того, чи містить посилання на розподіл параметр inviter_id, цей ID буде використовуватися як запрошувач."
+    ],
+    [
+      "description",
+      "强制邀请人ID的提示"
+    ]
+  ],
+  "message.originTip": [
+    [
+      "message",
+      "Домен сайту, конфігурація сайту прив'язана до домену, домен сайту не можна змінити."
+    ],
+    [
+      "description",
+      "站点域名的提示"
+    ]
+  ],
+  "message.titleTip": [
+    [
+      "message",
+      "Заголовок сайту, відображається на вкладці браузера."
+    ],
+    [
+      "description",
+      "站点标题的提示"
+    ]
+  ],
+  "message.descriptionTip": [
+    [
+      "message",
+      "Опис сайту, розташований у метаданих сайту, використовується для SEO оптимізації сайту."
+    ],
+    [
+      "description",
+      "站点描述的提示"
+    ]
+  ],
+  "message.logoTip": [
+    [
+      "message",
+      "Логотип сайту, відображається у верхній частині меню сайту, коли меню розгорнуте."
+    ],
+    [
+      "description",
+      "站点 Logo 的提示"
+    ]
+  ],
+  "message.faviconTip": [
+    [
+      "message",
+      "Favicon сайту, відображається на вкладці браузера."
+    ],
+    [
+      "description",
+      "站点 Favicon 的提示"
+    ]
+  ],
+  "message.adminsTip": [
+    [
+      "message",
+      "ID адміністраторів сайту. За замовчуванням перший користувач, який створює сайт, стає адміністратором. Тільки адміністратори сайту можуть керувати сайтом."
+    ],
+    [
+      "description",
+      "站点管理员的提示"
+    ]
+  ],
+  "message.adminsTip2": [
+    [
+      "message",
+      "Тут можна додавати або видаляти ID адміністраторів. Ви можете переглянути ID користувачів на https://auth.acedata.cloud"
+    ],
+    [
+      "description",
+      "站点管理员的提示"
+    ]
+  ],
+  "message.keywordsTip": [
+    [
+      "message",
+      "Ключові слова сайту, розташовані у метаданих сайту, використовуються для SEO оптимізації сайту."
+    ],
+    [
+      "description",
+      "站点关键词的提示"
+    ]
+  ],
+  "message.keywordsTip2": [
+    [
+      "message",
+      "Тут можна додавати або видаляти ключові слова сайту. Чим точніші ключові слова, тим краще для SEO оптимізації."
+    ],
+    [
+      "description",
+      "站点关键词的提示"
+    ]
+  ],
+  "message.featuresChat": [
+    [
+      "message",
+      "Увімкнути або вимкнути модуль функції Chat."
+    ],
+    [
+      "description",
+      "Chat 功能的描述"
+    ]
+  ],
+  "message.featuresGrok": [
+    [
+      "message",
+      "Увімкнути або вимкнути модуль функції Grok."
+    ],
+    [
+      "description",
+      "Grok 功能的描述"
+    ]
+  ],
+  "message.featuresDeepseek": [
+    [
+      "message",
+      "Увімкнути або вимкнути модуль функції Deepseek."
+    ],
+    [
+      "description",
+      "Deepseek 功能的描述"
+    ]
+  ],
+  "message.featuresChatgpt": [
+    [
+      "message",
+      "Увімкнути або вимкнути модуль функції ChatGPT."
+    ],
+    [
+      "description",
+      "ChatGPT 功能的描述"
+    ]
+  ],
+  "message.featuresMidjourney": [
+    [
+      "message",
+      "Увімкнути або вимкнути модуль функції Midjourney."
+    ],
+    [
+      "description",
+      "Midjourney 功能的描述"
+    ]
+  ],
+  "message.featuresChatdoc": [
+    [
+      "message",
+      "Увімкнути або вимкнути модуль функції Chatdoc."
+    ],
+    [
+      "description",
+      "Chatdoc 功能的描述"
+    ]
+  ],
+  "message.featuresQrart": [
+    [
+      "message",
+      "Увімкнути або вимкнути модуль функції Qrart."
+    ],
+    [
+      "description",
+      "Qrart 功能的描述"
+    ]
+  ],
+  "message.featuresVeo": [
+    [
+      "message",
+      "Увімкнути або вимкнути модуль функції Veo."
+    ],
+    [
+      "description",
+      "Veo 功能的描述"
+    ]
+  ],
+  "message.featuresSora": [
+    [
+      "message",
+      "Увімкнути або вимкнути модуль функції Sora."
+    ],
+    [
+      "description",
+      "Sora 功能的描述"
+    ]
+  ],
+  "message.featuresSuno": [
+    [
+      "message",
+      "Увімкнути або вимкнути модуль функції Suno."
+    ],
+    [
+      "description",
+      "Suno 功能的描述"
+    ]
+  ],
+  "message.featuresPixverse": [
+    [
+      "message",
+      "Увімкнути або вимкнути модуль функцій Pixverse."
+    ],
+    [
+      "description",
+      "Опис функцій Pixverse"
+    ]
+  ],
+  "message.featuresFlux": [
+    [
+      "message",
+      "Увімкнути або вимкнути модуль функцій FLux."
+    ],
+    [
+      "description",
+      "Опис функцій FLux"
+    ]
+  ],
+  "message.featuresNanobanana": [
+    [
+      "message",
+      "Увімкнути або вимкнути модуль функцій Nano Banana."
+    ],
+    [
+      "description",
+      "Опис функцій Nano Banana"
+    ]
+  ],
+  "message.featuresOpenaiimage": {
+    "message": "Toggle OpenAI Image feature module.",
+    "description": "Description of the OpenAI Image feature"
+  },
+  "message.featuresSeedream": [
+    [
+      "message",
+      "Увімкнути або вимкнути модуль функцій SeeDream."
+    ],
+    [
+      "description",
+      "Опис функцій SeeDream"
+    ]
+  ],
+  "message.featuresSeedance": [
+    [
+      "message",
+      "Увімкнути або вимкнути модуль функцій SeeDance."
+    ],
+    [
+      "description",
+      "Опис функцій SeeDance"
+    ]
+  ],
+  "message.featuresWan": [
+    [
+      "message",
+      "Увімкнути або вимкнути модуль функцій Wan."
+    ],
+    [
+      "description",
+      "Опис функцій Wan"
+    ]
+  ],
+  "message.featuresProducer": [
+    [
+      "message",
+      "Увімкнути або вимкнути модуль функцій Producer."
+    ],
+    [
+      "description",
+      "Опис функцій Producer"
+    ]
+  ],
+  "message.featuresKimi": [
+    [
+      "message",
+      "Увімкнути або вимкнути модуль функцій Kimi."
+    ],
+    [
+      "description",
+      "Опис функцій Kimi"
+    ]
+  ],
+  "message.featuresSerp": [
+    [
+      "message",
+      "Увімкнути або вимкнути модуль функцій SERP."
+    ],
+    [
+      "description",
+      "Опис функцій SERP"
+    ]
+  ],
+  "message.featuresLuma": [
+    [
+      "message",
+      "Увімкнути або вимкнути модуль функцій Luma."
+    ],
+    [
+      "description",
+      "Опис функцій Luma"
+    ]
+  ],
+  "message.featuresPika": [
+    [
+      "message",
+      "Увімкнути або вимкнути модуль функцій Pika."
+    ],
+    [
+      "description",
+      "Опис функцій Pika"
+    ]
+  ],
+  "message.featuresKling": [
+    [
+      "message",
+      "Увімкнути або вимкнути модуль функцій Kling."
+    ],
+    [
+      "description",
+      "Опис функцій Kling"
+    ]
+  ],
+  "message.featuresHailuo": [
+    [
+      "message",
+      "Увімкнути або вимкнути модуль функцій Hailuo."
+    ],
+    [
+      "description",
+      "Опис функцій Hailuo"
+    ]
+  ],
+  "message.featuresHeadshots": [
+    [
+      "message",
+      "Увімкнути або вимкнути модуль функцій AI фото."
+    ],
+    [
+      "description",
+      "Опис функцій AI фото"
+    ]
+  ],
+  "message.featuresSupport": [
+    [
+      "message",
+      "Увімкнути або вимкнути підтримку клієнтів"
+    ],
+    [
+      "description",
+      "Опис функцій підтримки"
+    ]
+  ],
+  "message.featuresI18n": [
+    [
+      "message",
+      "Увімкнути або вимкнути багатомовну підтримку, після вимкнення користувач зможе використовувати лише мову за замовчуванням."
+    ],
+    [
+      "description",
+      "Опис багатомовної підтримки"
+    ]
+  ],
+  "button.upload": [
+    [
+      "message",
+      "Завантажити"
+    ],
+    [
+      "description",
+      "Завантажити"
+    ]
+  ],
+  "button.enabled": [
+    [
+      "message",
+      "Увімкнено"
+    ],
+    [
+      "description",
+      "Текст перемикача, що вказує на те, що функція увімкнена"
+    ]
+  ],
+  "button.disabled": [
+    [
+      "message",
+      "Вимкнено"
+    ],
+    [
+      "description",
+      "Текст перемикача, що вказує на те, що функція вимкнена"
+    ]
+  ],
+  "field.featuresGemini": [
+    [
+      "message",
+      "Gemini"
+    ],
+    [
+      "description",
+      "Відображається як заголовок у редакторі"
+    ]
+  ],
+  "message.featuresGemini": [
+    [
+      "message",
+      "Увімкнути або вимкнути модуль функцій Gemini."
+    ],
+    [
+      "description",
+      "Опис функцій Gemini"
+    ]
+  ],
+  "field.featuresClaude": [
+    [
+      "message",
+      "Claude"
+    ],
+    [
+      "description",
+      "Відображається як заголовок у редакторі"
+    ]
+  ],
+  "message.featuresClaude": [
+    [
+      "message",
+      "Увімкнути або вимкнути модуль функцій Claude."
+    ],
+    [
+      "description",
+      "Опис функцій Claude"
+    ]
+  ]
 }

--- a/src/i18n/uk/site.json
+++ b/src/i18n/uk/site.json
@@ -1,1110 +1,450 @@
 {
-  "field.title": [
-    [
-      "message",
-      "Назва сайту"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.origin": [
-    [
-      "message",
-      "Домен сайту"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.description": [
-    [
-      "message",
-      "Опис сайту"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.keywords": [
-    [
-      "message",
-      "Ключові слова сайту"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.logo": [
-    [
-      "message",
-      "Логотип сайту"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.favicon": [
-    [
-      "message",
-      "Favicon сайту"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.qr": [
-    [
-      "message",
-      "QR-код"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.url": [
-    [
-      "message",
-      "Посилання"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.admins": [
-    [
-      "message",
-      "ID адміністраторів сайту"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.distributionDefaultInviterId": [
-    [
-      "message",
-      "ID запрошувача за замовчуванням"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.distributionForceInviterId": [
-    [
-      "message",
-      "ID обов'язкового запрошувача"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresChat": [
-    [
-      "message",
-      "Чат"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresVeo": [
-    [
-      "message",
-      "Veo"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresSora": [
-    [
-      "message",
-      "Sora"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresGrok": [
-    [
-      "message",
-      "Grok"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresDeepseek": [
-    [
-      "message",
-      "Deepseek"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresChatgpt": [
-    [
-      "message",
-      "ChatGPT"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresMidjourney": [
-    [
-      "message",
-      "Midjourney"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresChatdoc": [
-    [
-      "message",
-      "Chatdoc"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresQrart": [
-    [
-      "message",
-      "Qrart"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresLuma": [
-    [
-      "message",
-      "Luma"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresPixverse": [
-    [
-      "message",
-      "Pixverse"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresPika": [
-    [
-      "message",
-      "Pika"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresKling": [
-    [
-      "message",
-      "Kling"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresHailuo": [
-    [
-      "message",
-      "Hailuo"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresHeadshots": [
-    [
-      "message",
-      "AI фото"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresSuno": [
-    [
-      "message",
-      "Suno"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresFlux": [
-    [
-      "message",
-      "Flux"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresNanobanana": [
-    [
-      "message",
-      "Нано Банан"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
+  "field.title": {
+    "message": "Назва сайту",
+    "description": "展示在编辑框的标题"
+  },
+  "field.origin": {
+    "message": "Домен сайту",
+    "description": "展示在编辑框的标题"
+  },
+  "field.description": {
+    "message": "Опис сайту",
+    "description": "展示在编辑框的标题"
+  },
+  "field.keywords": {
+    "message": "Ключові слова сайту",
+    "description": "展示在编辑框的标题"
+  },
+  "field.logo": {
+    "message": "Логотип сайту",
+    "description": "展示在编辑框的标题"
+  },
+  "field.favicon": {
+    "message": "Favicon сайту",
+    "description": "展示在编辑框的标题"
+  },
+  "field.qr": {
+    "message": "QR-код",
+    "description": "展示在编辑框的标题"
+  },
+  "field.url": {
+    "message": "Посилання",
+    "description": "展示在编辑框的标题"
+  },
+  "field.admins": {
+    "message": "ID адміністраторів сайту",
+    "description": "展示在编辑框的标题"
+  },
+  "field.distributionDefaultInviterId": {
+    "message": "ID запрошувача за замовчуванням",
+    "description": "展示在编辑框的标题"
+  },
+  "field.distributionForceInviterId": {
+    "message": "ID обов'язкового запрошувача",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresChat": {
+    "message": "Чат",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresVeo": {
+    "message": "Veo",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresSora": {
+    "message": "Sora",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresGrok": {
+    "message": "Grok",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresDeepseek": {
+    "message": "Deepseek",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresChatgpt": {
+    "message": "ChatGPT",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresMidjourney": {
+    "message": "Midjourney",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresChatdoc": {
+    "message": "Chatdoc",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresQrart": {
+    "message": "Qrart",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresLuma": {
+    "message": "Luma",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresPixverse": {
+    "message": "Pixverse",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresPika": {
+    "message": "Pika",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresKling": {
+    "message": "Kling",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresHailuo": {
+    "message": "Hailuo",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresHeadshots": {
+    "message": "AI фото",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresSuno": {
+    "message": "Suno",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresFlux": {
+    "message": "Flux",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresNanobanana": {
+    "message": "Нано Банан",
+    "description": "展示在编辑框的标题"
+  },
   "field.featuresOpenaiimage": {
     "message": "OpenAI Image",
     "description": "Displayed as the title in the editing box"
   },
-  "field.featuresSeedream": [
-    [
-      "message",
-      "SeeDream"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresSeedance": [
-    [
-      "message",
-      "SeeDance"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresWan": [
-    [
-      "message",
-      "Wan"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresProducer": [
-    [
-      "message",
-      "Продюсер"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresKimi": [
-    [
-      "message",
-      "Kimi"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresSerp": [
-    [
-      "message",
-      "SERP"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresSupport": [
-    [
-      "message",
-      "Підтримка клієнтів"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresI18n": [
-    [
-      "message",
-      "Підтримка багатомовності"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.basicConfig": [
-    [
-      "message",
-      "Основні налаштування"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.seoConfig": [
-    [
-      "message",
-      "Налаштування SEO"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editAdmins": [
-    [
-      "message",
-      "Редагувати адміністраторів"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.featuresConfig": [
-    [
-      "message",
-      "Налаштування функцій"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editTitle": [
-    [
-      "message",
-      "Редагувати назву"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editOrigin": [
-    [
-      "message",
-      "Редагувати домен"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editKeywords": [
-    [
-      "message",
-      "Редагувати ключові слова"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editLogo": [
-    [
-      "message",
-      "Редагувати логотип"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editFavicon": [
-    [
-      "message",
-      "Редагувати Favicon"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editDescription": [
-    [
-      "message",
-      "Редагувати опис"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.distributionConfig": [
-    [
-      "message",
-      "Налаштування дистрибуції"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editDistributionDefaultInviterId": [
-    [
-      "message",
-      "Редагувати запрошувача за замовчуванням"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editDistributionForceInviterId": [
-    [
-      "message",
-      "Редагувати обов'язкового запрошувача"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editQR": [
-    [
-      "message",
-      "Редагувати QR-код"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editUrl": [
-    [
-      "message",
-      "Редагувати посилання"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "placeholder.title": [
-    [
-      "message",
-      "Введіть заголовок сайту"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "placeholder.origin": [
-    [
-      "message",
-      "Введіть домен сайту"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "placeholder.editUrl": [
-    [
-      "message",
-      "Введіть посилання"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "placeholder.description": [
-    [
-      "message",
-      "Введіть опис сайту"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "placeholder.keywords": [
-    [
-      "message",
-      "Введіть ключові слова сайту"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "placeholder.editDistributionDefaultInviterId": [
-    [
-      "message",
-      "Введіть ID запрошувача за замовчуванням"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "placeholder.editDistributionForceInviterId": [
-    [
-      "message",
-      "Введіть ID обов'язкового запрошувача"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "message.uploadImageExceed": [
-    [
-      "message",
-      "Перевищено ліміт на завантаження зображення"
-    ],
-    [
-      "description",
-      "上传图片超过限制的提示"
-    ]
-  ],
-  "message.uploadImageError": [
-    [
-      "message",
-      "Помилка завантаження зображення"
-    ],
-    [
-      "description",
-      "上传图片错误的提示"
-    ]
-  ],
-  "message.editLogoTip": [
-    [
-      "message",
-      "Рекомендований розмір: 200*60px"
-    ],
-    [
-      "description",
-      "上传图片的提示语言"
-    ]
-  ],
-  "message.editQRTip": [
-    [
-      "message",
-      "Рекомендований розмір: 200*200px"
-    ],
-    [
-      "description",
-      "上传图片的提示语言"
-    ]
-  ],
-  "message.editFaviconTip": [
-    [
-      "message",
-      "Рекомендований розмір: 32*32px"
-    ],
-    [
-      "description",
-      "上传图片的提示语言"
-    ]
-  ],
-  "message.editUrl": [
-    [
-      "message",
-      "Введіть посилання"
-    ],
-    [
-      "description",
-      "请输入链接的提示"
-    ]
-  ],
-  "message.atLeastOneAdmin": [
-    [
-      "message",
-      "Принаймні один адміністратор має залишитися"
-    ],
-    [
-      "description",
-      "至少保留一个管理员的提示"
-    ]
-  ],
-  "message.distributionDefaultInviterIdTip": [
-    [
-      "message",
-      "ID користувача запрошувача за замовчуванням. Якщо посилання на розподіл не містить параметра inviter_id, за замовчуванням використовується цей ID як запрошувач."
-    ],
-    [
-      "description",
-      "默认邀请人ID的提示"
-    ]
-  ],
-  "message.distributionForceInviterIdTip": [
-    [
-      "message",
-      "ID обов'язкового запрошувача. Якщо цей ID встановлено, незалежно від того, чи містить посилання на розподіл параметр inviter_id, цей ID буде використовуватися як запрошувач."
-    ],
-    [
-      "description",
-      "强制邀请人ID的提示"
-    ]
-  ],
-  "message.originTip": [
-    [
-      "message",
-      "Домен сайту, конфігурація сайту прив'язана до домену, домен сайту не можна змінити."
-    ],
-    [
-      "description",
-      "站点域名的提示"
-    ]
-  ],
-  "message.titleTip": [
-    [
-      "message",
-      "Заголовок сайту, відображається на вкладці браузера."
-    ],
-    [
-      "description",
-      "站点标题的提示"
-    ]
-  ],
-  "message.descriptionTip": [
-    [
-      "message",
-      "Опис сайту, розташований у метаданих сайту, використовується для SEO оптимізації сайту."
-    ],
-    [
-      "description",
-      "站点描述的提示"
-    ]
-  ],
-  "message.logoTip": [
-    [
-      "message",
-      "Логотип сайту, відображається у верхній частині меню сайту, коли меню розгорнуте."
-    ],
-    [
-      "description",
-      "站点 Logo 的提示"
-    ]
-  ],
-  "message.faviconTip": [
-    [
-      "message",
-      "Favicon сайту, відображається на вкладці браузера."
-    ],
-    [
-      "description",
-      "站点 Favicon 的提示"
-    ]
-  ],
-  "message.adminsTip": [
-    [
-      "message",
-      "ID адміністраторів сайту. За замовчуванням перший користувач, який створює сайт, стає адміністратором. Тільки адміністратори сайту можуть керувати сайтом."
-    ],
-    [
-      "description",
-      "站点管理员的提示"
-    ]
-  ],
-  "message.adminsTip2": [
-    [
-      "message",
-      "Тут можна додавати або видаляти ID адміністраторів. Ви можете переглянути ID користувачів на https://auth.acedata.cloud"
-    ],
-    [
-      "description",
-      "站点管理员的提示"
-    ]
-  ],
-  "message.keywordsTip": [
-    [
-      "message",
-      "Ключові слова сайту, розташовані у метаданих сайту, використовуються для SEO оптимізації сайту."
-    ],
-    [
-      "description",
-      "站点关键词的提示"
-    ]
-  ],
-  "message.keywordsTip2": [
-    [
-      "message",
-      "Тут можна додавати або видаляти ключові слова сайту. Чим точніші ключові слова, тим краще для SEO оптимізації."
-    ],
-    [
-      "description",
-      "站点关键词的提示"
-    ]
-  ],
-  "message.featuresChat": [
-    [
-      "message",
-      "Увімкнути або вимкнути модуль функції Chat."
-    ],
-    [
-      "description",
-      "Chat 功能的描述"
-    ]
-  ],
-  "message.featuresGrok": [
-    [
-      "message",
-      "Увімкнути або вимкнути модуль функції Grok."
-    ],
-    [
-      "description",
-      "Grok 功能的描述"
-    ]
-  ],
-  "message.featuresDeepseek": [
-    [
-      "message",
-      "Увімкнути або вимкнути модуль функції Deepseek."
-    ],
-    [
-      "description",
-      "Deepseek 功能的描述"
-    ]
-  ],
-  "message.featuresChatgpt": [
-    [
-      "message",
-      "Увімкнути або вимкнути модуль функції ChatGPT."
-    ],
-    [
-      "description",
-      "ChatGPT 功能的描述"
-    ]
-  ],
-  "message.featuresMidjourney": [
-    [
-      "message",
-      "Увімкнути або вимкнути модуль функції Midjourney."
-    ],
-    [
-      "description",
-      "Midjourney 功能的描述"
-    ]
-  ],
-  "message.featuresChatdoc": [
-    [
-      "message",
-      "Увімкнути або вимкнути модуль функції Chatdoc."
-    ],
-    [
-      "description",
-      "Chatdoc 功能的描述"
-    ]
-  ],
-  "message.featuresQrart": [
-    [
-      "message",
-      "Увімкнути або вимкнути модуль функції Qrart."
-    ],
-    [
-      "description",
-      "Qrart 功能的描述"
-    ]
-  ],
-  "message.featuresVeo": [
-    [
-      "message",
-      "Увімкнути або вимкнути модуль функції Veo."
-    ],
-    [
-      "description",
-      "Veo 功能的描述"
-    ]
-  ],
-  "message.featuresSora": [
-    [
-      "message",
-      "Увімкнути або вимкнути модуль функції Sora."
-    ],
-    [
-      "description",
-      "Sora 功能的描述"
-    ]
-  ],
-  "message.featuresSuno": [
-    [
-      "message",
-      "Увімкнути або вимкнути модуль функції Suno."
-    ],
-    [
-      "description",
-      "Suno 功能的描述"
-    ]
-  ],
-  "message.featuresPixverse": [
-    [
-      "message",
-      "Увімкнути або вимкнути модуль функцій Pixverse."
-    ],
-    [
-      "description",
-      "Опис функцій Pixverse"
-    ]
-  ],
-  "message.featuresFlux": [
-    [
-      "message",
-      "Увімкнути або вимкнути модуль функцій FLux."
-    ],
-    [
-      "description",
-      "Опис функцій FLux"
-    ]
-  ],
-  "message.featuresNanobanana": [
-    [
-      "message",
-      "Увімкнути або вимкнути модуль функцій Nano Banana."
-    ],
-    [
-      "description",
-      "Опис функцій Nano Banana"
-    ]
-  ],
+  "field.featuresSeedream": {
+    "message": "SeeDream",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresSeedance": {
+    "message": "SeeDance",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresWan": {
+    "message": "Wan",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresProducer": {
+    "message": "Продюсер",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresKimi": {
+    "message": "Kimi",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresSerp": {
+    "message": "SERP",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresSupport": {
+    "message": "Підтримка клієнтів",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresI18n": {
+    "message": "Підтримка багатомовності",
+    "description": "展示在编辑框的标题"
+  },
+  "title.basicConfig": {
+    "message": "Основні налаштування",
+    "description": "展示在编辑框的标题"
+  },
+  "title.seoConfig": {
+    "message": "Налаштування SEO",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editAdmins": {
+    "message": "Редагувати адміністраторів",
+    "description": "展示在编辑框的标题"
+  },
+  "title.featuresConfig": {
+    "message": "Налаштування функцій",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editTitle": {
+    "message": "Редагувати назву",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editOrigin": {
+    "message": "Редагувати домен",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editKeywords": {
+    "message": "Редагувати ключові слова",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editLogo": {
+    "message": "Редагувати логотип",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editFavicon": {
+    "message": "Редагувати Favicon",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editDescription": {
+    "message": "Редагувати опис",
+    "description": "展示在编辑框的标题"
+  },
+  "title.distributionConfig": {
+    "message": "Налаштування дистрибуції",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editDistributionDefaultInviterId": {
+    "message": "Редагувати запрошувача за замовчуванням",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editDistributionForceInviterId": {
+    "message": "Редагувати обов'язкового запрошувача",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editQR": {
+    "message": "Редагувати QR-код",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editUrl": {
+    "message": "Редагувати посилання",
+    "description": "展示在编辑框的标题"
+  },
+  "placeholder.title": {
+    "message": "Введіть заголовок сайту",
+    "description": "展示在编辑框的标题"
+  },
+  "placeholder.origin": {
+    "message": "Введіть домен сайту",
+    "description": "展示在编辑框的标题"
+  },
+  "placeholder.editUrl": {
+    "message": "Введіть посилання",
+    "description": "展示在编辑框的标题"
+  },
+  "placeholder.description": {
+    "message": "Введіть опис сайту",
+    "description": "展示在编辑框的标题"
+  },
+  "placeholder.keywords": {
+    "message": "Введіть ключові слова сайту",
+    "description": "展示在编辑框的标题"
+  },
+  "placeholder.editDistributionDefaultInviterId": {
+    "message": "Введіть ID запрошувача за замовчуванням",
+    "description": "展示在编辑框的标题"
+  },
+  "placeholder.editDistributionForceInviterId": {
+    "message": "Введіть ID обов'язкового запрошувача",
+    "description": "展示在编辑框的标题"
+  },
+  "message.uploadImageExceed": {
+    "message": "Перевищено ліміт на завантаження зображення",
+    "description": "上传图片超过限制的提示"
+  },
+  "message.uploadImageError": {
+    "message": "Помилка завантаження зображення",
+    "description": "上传图片错误的提示"
+  },
+  "message.editLogoTip": {
+    "message": "Рекомендований розмір: 200*60px",
+    "description": "上传图片的提示语言"
+  },
+  "message.editQRTip": {
+    "message": "Рекомендований розмір: 200*200px",
+    "description": "上传图片的提示语言"
+  },
+  "message.editFaviconTip": {
+    "message": "Рекомендований розмір: 32*32px",
+    "description": "上传图片的提示语言"
+  },
+  "message.editUrl": {
+    "message": "Введіть посилання",
+    "description": "请输入链接的提示"
+  },
+  "message.atLeastOneAdmin": {
+    "message": "Принаймні один адміністратор має залишитися",
+    "description": "至少保留一个管理员的提示"
+  },
+  "message.distributionDefaultInviterIdTip": {
+    "message": "ID користувача запрошувача за замовчуванням. Якщо посилання на розподіл не містить параметра inviter_id, за замовчуванням використовується цей ID як запрошувач.",
+    "description": "默认邀请人ID的提示"
+  },
+  "message.distributionForceInviterIdTip": {
+    "message": "ID обов'язкового запрошувача. Якщо цей ID встановлено, незалежно від того, чи містить посилання на розподіл параметр inviter_id, цей ID буде використовуватися як запрошувач.",
+    "description": "强制邀请人ID的提示"
+  },
+  "message.originTip": {
+    "message": "Домен сайту, конфігурація сайту прив'язана до домену, домен сайту не можна змінити.",
+    "description": "站点域名的提示"
+  },
+  "message.titleTip": {
+    "message": "Заголовок сайту, відображається на вкладці браузера.",
+    "description": "站点标题的提示"
+  },
+  "message.descriptionTip": {
+    "message": "Опис сайту, розташований у метаданих сайту, використовується для SEO оптимізації сайту.",
+    "description": "站点描述的提示"
+  },
+  "message.logoTip": {
+    "message": "Логотип сайту, відображається у верхній частині меню сайту, коли меню розгорнуте.",
+    "description": "站点 Logo 的提示"
+  },
+  "message.faviconTip": {
+    "message": "Favicon сайту, відображається на вкладці браузера.",
+    "description": "站点 Favicon 的提示"
+  },
+  "message.adminsTip": {
+    "message": "ID адміністраторів сайту. За замовчуванням перший користувач, який створює сайт, стає адміністратором. Тільки адміністратори сайту можуть керувати сайтом.",
+    "description": "站点管理员的提示"
+  },
+  "message.adminsTip2": {
+    "message": "Тут можна додавати або видаляти ID адміністраторів. Ви можете переглянути ID користувачів на https://auth.acedata.cloud",
+    "description": "站点管理员的提示"
+  },
+  "message.keywordsTip": {
+    "message": "Ключові слова сайту, розташовані у метаданих сайту, використовуються для SEO оптимізації сайту.",
+    "description": "站点关键词的提示"
+  },
+  "message.keywordsTip2": {
+    "message": "Тут можна додавати або видаляти ключові слова сайту. Чим точніші ключові слова, тим краще для SEO оптимізації.",
+    "description": "站点关键词的提示"
+  },
+  "message.featuresChat": {
+    "message": "Увімкнути або вимкнути модуль функції Chat.",
+    "description": "Chat 功能的描述"
+  },
+  "message.featuresGrok": {
+    "message": "Увімкнути або вимкнути модуль функції Grok.",
+    "description": "Grok 功能的描述"
+  },
+  "message.featuresDeepseek": {
+    "message": "Увімкнути або вимкнути модуль функції Deepseek.",
+    "description": "Deepseek 功能的描述"
+  },
+  "message.featuresChatgpt": {
+    "message": "Увімкнути або вимкнути модуль функції ChatGPT.",
+    "description": "ChatGPT 功能的描述"
+  },
+  "message.featuresMidjourney": {
+    "message": "Увімкнути або вимкнути модуль функції Midjourney.",
+    "description": "Midjourney 功能的描述"
+  },
+  "message.featuresChatdoc": {
+    "message": "Увімкнути або вимкнути модуль функції Chatdoc.",
+    "description": "Chatdoc 功能的描述"
+  },
+  "message.featuresQrart": {
+    "message": "Увімкнути або вимкнути модуль функції Qrart.",
+    "description": "Qrart 功能的描述"
+  },
+  "message.featuresVeo": {
+    "message": "Увімкнути або вимкнути модуль функції Veo.",
+    "description": "Veo 功能的描述"
+  },
+  "message.featuresSora": {
+    "message": "Увімкнути або вимкнути модуль функції Sora.",
+    "description": "Sora 功能的描述"
+  },
+  "message.featuresSuno": {
+    "message": "Увімкнути або вимкнути модуль функції Suno.",
+    "description": "Suno 功能的描述"
+  },
+  "message.featuresPixverse": {
+    "message": "Увімкнути або вимкнути модуль функцій Pixverse.",
+    "description": "Опис функцій Pixverse"
+  },
+  "message.featuresFlux": {
+    "message": "Увімкнути або вимкнути модуль функцій FLux.",
+    "description": "Опис функцій FLux"
+  },
+  "message.featuresNanobanana": {
+    "message": "Увімкнути або вимкнути модуль функцій Nano Banana.",
+    "description": "Опис функцій Nano Banana"
+  },
   "message.featuresOpenaiimage": {
     "message": "Toggle OpenAI Image feature module.",
     "description": "Description of the OpenAI Image feature"
   },
-  "message.featuresSeedream": [
-    [
-      "message",
-      "Увімкнути або вимкнути модуль функцій SeeDream."
-    ],
-    [
-      "description",
-      "Опис функцій SeeDream"
-    ]
-  ],
-  "message.featuresSeedance": [
-    [
-      "message",
-      "Увімкнути або вимкнути модуль функцій SeeDance."
-    ],
-    [
-      "description",
-      "Опис функцій SeeDance"
-    ]
-  ],
-  "message.featuresWan": [
-    [
-      "message",
-      "Увімкнути або вимкнути модуль функцій Wan."
-    ],
-    [
-      "description",
-      "Опис функцій Wan"
-    ]
-  ],
-  "message.featuresProducer": [
-    [
-      "message",
-      "Увімкнути або вимкнути модуль функцій Producer."
-    ],
-    [
-      "description",
-      "Опис функцій Producer"
-    ]
-  ],
-  "message.featuresKimi": [
-    [
-      "message",
-      "Увімкнути або вимкнути модуль функцій Kimi."
-    ],
-    [
-      "description",
-      "Опис функцій Kimi"
-    ]
-  ],
-  "message.featuresSerp": [
-    [
-      "message",
-      "Увімкнути або вимкнути модуль функцій SERP."
-    ],
-    [
-      "description",
-      "Опис функцій SERP"
-    ]
-  ],
-  "message.featuresLuma": [
-    [
-      "message",
-      "Увімкнути або вимкнути модуль функцій Luma."
-    ],
-    [
-      "description",
-      "Опис функцій Luma"
-    ]
-  ],
-  "message.featuresPika": [
-    [
-      "message",
-      "Увімкнути або вимкнути модуль функцій Pika."
-    ],
-    [
-      "description",
-      "Опис функцій Pika"
-    ]
-  ],
-  "message.featuresKling": [
-    [
-      "message",
-      "Увімкнути або вимкнути модуль функцій Kling."
-    ],
-    [
-      "description",
-      "Опис функцій Kling"
-    ]
-  ],
-  "message.featuresHailuo": [
-    [
-      "message",
-      "Увімкнути або вимкнути модуль функцій Hailuo."
-    ],
-    [
-      "description",
-      "Опис функцій Hailuo"
-    ]
-  ],
-  "message.featuresHeadshots": [
-    [
-      "message",
-      "Увімкнути або вимкнути модуль функцій AI фото."
-    ],
-    [
-      "description",
-      "Опис функцій AI фото"
-    ]
-  ],
-  "message.featuresSupport": [
-    [
-      "message",
-      "Увімкнути або вимкнути підтримку клієнтів"
-    ],
-    [
-      "description",
-      "Опис функцій підтримки"
-    ]
-  ],
-  "message.featuresI18n": [
-    [
-      "message",
-      "Увімкнути або вимкнути багатомовну підтримку, після вимкнення користувач зможе використовувати лише мову за замовчуванням."
-    ],
-    [
-      "description",
-      "Опис багатомовної підтримки"
-    ]
-  ],
-  "button.upload": [
-    [
-      "message",
-      "Завантажити"
-    ],
-    [
-      "description",
-      "Завантажити"
-    ]
-  ],
-  "button.enabled": [
-    [
-      "message",
-      "Увімкнено"
-    ],
-    [
-      "description",
-      "Текст перемикача, що вказує на те, що функція увімкнена"
-    ]
-  ],
-  "button.disabled": [
-    [
-      "message",
-      "Вимкнено"
-    ],
-    [
-      "description",
-      "Текст перемикача, що вказує на те, що функція вимкнена"
-    ]
-  ],
-  "field.featuresGemini": [
-    [
-      "message",
-      "Gemini"
-    ],
-    [
-      "description",
-      "Відображається як заголовок у редакторі"
-    ]
-  ],
-  "message.featuresGemini": [
-    [
-      "message",
-      "Увімкнути або вимкнути модуль функцій Gemini."
-    ],
-    [
-      "description",
-      "Опис функцій Gemini"
-    ]
-  ],
-  "field.featuresClaude": [
-    [
-      "message",
-      "Claude"
-    ],
-    [
-      "description",
-      "Відображається як заголовок у редакторі"
-    ]
-  ],
-  "message.featuresClaude": [
-    [
-      "message",
-      "Увімкнути або вимкнути модуль функцій Claude."
-    ],
-    [
-      "description",
-      "Опис функцій Claude"
-    ]
-  ]
+  "message.featuresSeedream": {
+    "message": "Увімкнути або вимкнути модуль функцій SeeDream.",
+    "description": "Опис функцій SeeDream"
+  },
+  "message.featuresSeedance": {
+    "message": "Увімкнути або вимкнути модуль функцій SeeDance.",
+    "description": "Опис функцій SeeDance"
+  },
+  "message.featuresWan": {
+    "message": "Увімкнути або вимкнути модуль функцій Wan.",
+    "description": "Опис функцій Wan"
+  },
+  "message.featuresProducer": {
+    "message": "Увімкнути або вимкнути модуль функцій Producer.",
+    "description": "Опис функцій Producer"
+  },
+  "message.featuresKimi": {
+    "message": "Увімкнути або вимкнути модуль функцій Kimi.",
+    "description": "Опис функцій Kimi"
+  },
+  "message.featuresSerp": {
+    "message": "Увімкнути або вимкнути модуль функцій SERP.",
+    "description": "Опис функцій SERP"
+  },
+  "message.featuresLuma": {
+    "message": "Увімкнути або вимкнути модуль функцій Luma.",
+    "description": "Опис функцій Luma"
+  },
+  "message.featuresPika": {
+    "message": "Увімкнути або вимкнути модуль функцій Pika.",
+    "description": "Опис функцій Pika"
+  },
+  "message.featuresKling": {
+    "message": "Увімкнути або вимкнути модуль функцій Kling.",
+    "description": "Опис функцій Kling"
+  },
+  "message.featuresHailuo": {
+    "message": "Увімкнути або вимкнути модуль функцій Hailuo.",
+    "description": "Опис функцій Hailuo"
+  },
+  "message.featuresHeadshots": {
+    "message": "Увімкнути або вимкнути модуль функцій AI фото.",
+    "description": "Опис функцій AI фото"
+  },
+  "message.featuresSupport": {
+    "message": "Увімкнути або вимкнути підтримку клієнтів",
+    "description": "Опис функцій підтримки"
+  },
+  "message.featuresI18n": {
+    "message": "Увімкнути або вимкнути багатомовну підтримку, після вимкнення користувач зможе використовувати лише мову за замовчуванням.",
+    "description": "Опис багатомовної підтримки"
+  },
+  "button.upload": {
+    "message": "Завантажити",
+    "description": "Завантажити"
+  },
+  "button.enabled": {
+    "message": "Увімкнено",
+    "description": "Текст перемикача, що вказує на те, що функція увімкнена"
+  },
+  "button.disabled": {
+    "message": "Вимкнено",
+    "description": "Текст перемикача, що вказує на те, що функція вимкнена"
+  },
+  "field.featuresGemini": {
+    "message": "Gemini",
+    "description": "Відображається як заголовок у редакторі"
+  },
+  "message.featuresGemini": {
+    "message": "Увімкнути або вимкнути модуль функцій Gemini.",
+    "description": "Опис функцій Gemini"
+  },
+  "field.featuresClaude": {
+    "message": "Claude",
+    "description": "Відображається як заголовок у редакторі"
+  },
+  "message.featuresClaude": {
+    "message": "Увімкнути або вимкнути модуль функцій Claude.",
+    "description": "Опис функцій Claude"
+  }
 }

--- a/src/i18n/zh-CN/site.json
+++ b/src/i18n/zh-CN/site.json
@@ -1,1110 +1,450 @@
 {
-  "field.title": [
-    [
-      "message",
-      "站点标题"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.origin": [
-    [
-      "message",
-      "站点域名"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.description": [
-    [
-      "message",
-      "站点描述"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.keywords": [
-    [
-      "message",
-      "站点关键词"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.logo": [
-    [
-      "message",
-      "站点 Logo"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.favicon": [
-    [
-      "message",
-      "站点 Favicon"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.qr": [
-    [
-      "message",
-      "二维码"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.url": [
-    [
-      "message",
-      "链接"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.admins": [
-    [
-      "message",
-      "站点管理员 ID"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.distributionDefaultInviterId": [
-    [
-      "message",
-      "默认邀请人 ID"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.distributionForceInviterId": [
-    [
-      "message",
-      "强制邀请人 ID"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresChat": [
-    [
-      "message",
-      "Chat"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresVeo": [
-    [
-      "message",
-      "Veo"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresSora": [
-    [
-      "message",
-      "Sora"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresGrok": [
-    [
-      "message",
-      "Grok"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresDeepseek": [
-    [
-      "message",
-      "Deepseek"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresChatgpt": [
-    [
-      "message",
-      "ChatGPT"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresMidjourney": [
-    [
-      "message",
-      "Midjourney"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresChatdoc": [
-    [
-      "message",
-      "Chatdoc"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresQrart": [
-    [
-      "message",
-      "Qrart"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresLuma": [
-    [
-      "message",
-      "Luma"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresPixverse": [
-    [
-      "message",
-      "Pixverse"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresPika": [
-    [
-      "message",
-      "Pika"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresKling": [
-    [
-      "message",
-      "Kling"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresHailuo": [
-    [
-      "message",
-      "Hailuo"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresHeadshots": [
-    [
-      "message",
-      "AI证件照"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresSuno": [
-    [
-      "message",
-      "Suno"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresFlux": [
-    [
-      "message",
-      "Flux"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresNanobanana": [
-    [
-      "message",
-      "Nano Banana"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
+  "field.title": {
+    "message": "站点标题",
+    "description": "展示在编辑框的标题"
+  },
+  "field.origin": {
+    "message": "站点域名",
+    "description": "展示在编辑框的标题"
+  },
+  "field.description": {
+    "message": "站点描述",
+    "description": "展示在编辑框的标题"
+  },
+  "field.keywords": {
+    "message": "站点关键词",
+    "description": "展示在编辑框的标题"
+  },
+  "field.logo": {
+    "message": "站点 Logo",
+    "description": "展示在编辑框的标题"
+  },
+  "field.favicon": {
+    "message": "站点 Favicon",
+    "description": "展示在编辑框的标题"
+  },
+  "field.qr": {
+    "message": "二维码",
+    "description": "展示在编辑框的标题"
+  },
+  "field.url": {
+    "message": "链接",
+    "description": "展示在编辑框的标题"
+  },
+  "field.admins": {
+    "message": "站点管理员 ID",
+    "description": "展示在编辑框的标题"
+  },
+  "field.distributionDefaultInviterId": {
+    "message": "默认邀请人 ID",
+    "description": "展示在编辑框的标题"
+  },
+  "field.distributionForceInviterId": {
+    "message": "强制邀请人 ID",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresChat": {
+    "message": "Chat",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresVeo": {
+    "message": "Veo",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresSora": {
+    "message": "Sora",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresGrok": {
+    "message": "Grok",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresDeepseek": {
+    "message": "Deepseek",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresChatgpt": {
+    "message": "ChatGPT",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresMidjourney": {
+    "message": "Midjourney",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresChatdoc": {
+    "message": "Chatdoc",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresQrart": {
+    "message": "Qrart",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresLuma": {
+    "message": "Luma",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresPixverse": {
+    "message": "Pixverse",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresPika": {
+    "message": "Pika",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresKling": {
+    "message": "Kling",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresHailuo": {
+    "message": "Hailuo",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresHeadshots": {
+    "message": "AI证件照",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresSuno": {
+    "message": "Suno",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresFlux": {
+    "message": "Flux",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresNanobanana": {
+    "message": "Nano Banana",
+    "description": "展示在编辑框的标题"
+  },
   "field.featuresOpenaiimage": {
     "message": "OpenAI 图像",
     "description": "展示在编辑框的标题"
   },
-  "field.featuresSeedream": [
-    [
-      "message",
-      "SeeDream"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresSeedance": [
-    [
-      "message",
-      "SeeDance"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "field.featuresWan": [
-    [
-      "message",
-      "Wan"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresProducer": [
-    [
-      "message",
-      "Producer"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresKimi": [
-    [
-      "message",
-      "Kimi"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresSerp": [
-    [
-      "message",
-      "SERP"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresSupport": [
-    [
-      "message",
-      "客服支持"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "field.featuresI18n": [
-    [
-      "message",
-      "多语言支持"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.basicConfig": [
-    [
-      "message",
-      "基本配置"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.seoConfig": [
-    [
-      "message",
-      "SEO 配置"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editAdmins": [
-    [
-      "message",
-      "编辑管理员"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.featuresConfig": [
-    [
-      "message",
-      "功能配置"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editTitle": [
-    [
-      "message",
-      "编辑标题"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editOrigin": [
-    [
-      "message",
-      "编辑域名"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editKeywords": [
-    [
-      "message",
-      "编辑关键词"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editLogo": [
-    [
-      "message",
-      "编辑 Logo"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editFavicon": [
-    [
-      "message",
-      "编辑 Favicon"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editDescription": [
-    [
-      "message",
-      "编辑描述"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.distributionConfig": [
-    [
-      "message",
-      "分销配置"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editDistributionDefaultInviterId": [
-    [
-      "message",
-      "编辑默认邀请人"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editDistributionForceInviterId": [
-    [
-      "message",
-      "编辑强制邀请人"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editQR": [
-    [
-      "message",
-      "编辑二维码"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "title.editUrl": [
-    [
-      "message",
-      "编辑链接"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "placeholder.title": [
-    [
-      "message",
-      "请输入站点标题"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "placeholder.origin": [
-    [
-      "message",
-      "请输入站点域名"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "placeholder.editUrl": [
-    [
-      "message",
-      "请输入链接"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "placeholder.description": [
-    [
-      "message",
-      "请输入站点描述"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "placeholder.keywords": [
-    [
-      "message",
-      "请输入站点关键词"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "placeholder.editDistributionDefaultInviterId": [
-    [
-      "message",
-      "请输入默认邀请人 ID"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "placeholder.editDistributionForceInviterId": [
-    [
-      "message",
-      "请输入强制邀请人 ID"
-    ],
-    [
-      "description",
-      "展示在编辑框的标题"
-    ]
-  ],
-  "message.uploadImageExceed": [
-    [
-      "message",
-      "上传图片超过限制"
-    ],
-    [
-      "description",
-      "上传图片超过限制的提示"
-    ]
-  ],
-  "message.uploadImageError": [
-    [
-      "message",
-      "上传图片错误"
-    ],
-    [
-      "description",
-      "上传图片错误的提示"
-    ]
-  ],
-  "message.editLogoTip": [
-    [
-      "message",
-      "建议尺寸：200*60px"
-    ],
-    [
-      "description",
-      "上传图片的提示语言"
-    ]
-  ],
-  "message.editQRTip": [
-    [
-      "message",
-      "建议尺寸：200*200px"
-    ],
-    [
-      "description",
-      "上传图片的提示语言"
-    ]
-  ],
-  "message.editFaviconTip": [
-    [
-      "message",
-      "建议尺寸：32*32px"
-    ],
-    [
-      "description",
-      "上传图片的提示语言"
-    ]
-  ],
-  "message.editUrl": [
-    [
-      "message",
-      "请输入链接"
-    ],
-    [
-      "description",
-      "请输入链接的提示"
-    ]
-  ],
-  "message.atLeastOneAdmin": [
-    [
-      "message",
-      "至少保留一个管理员"
-    ],
-    [
-      "description",
-      "至少保留一个管理员的提示"
-    ]
-  ],
-  "message.distributionDefaultInviterIdTip": [
-    [
-      "message",
-      "默认邀请人的用户 ID，分销链接如果不携带 inviter_id 参数，则默认使用该用户 ID 作为邀请人。"
-    ],
-    [
-      "description",
-      "默认邀请人ID的提示"
-    ]
-  ],
-  "message.distributionForceInviterIdTip": [
-    [
-      "message",
-      "强制邀请人的用户 ID，如果设置了此 ID，无论分销链接是否携带 inviter_id 参数，则强制使用该用户 ID 作为邀请人。"
-    ],
-    [
-      "description",
-      "强制邀请人ID的提示"
-    ]
-  ],
-  "message.originTip": [
-    [
-      "message",
-      "站点域名，站点配置与域名绑定，站点域名不可更改。"
-    ],
-    [
-      "description",
-      "站点域名的提示"
-    ]
-  ],
-  "message.titleTip": [
-    [
-      "message",
-      "站点标题，展示在浏览器标签页。"
-    ],
-    [
-      "description",
-      "站点标题的提示"
-    ]
-  ],
-  "message.descriptionTip": [
-    [
-      "message",
-      "站点描述，位于站点元信息中，用于站点 SEO 优化。"
-    ],
-    [
-      "description",
-      "站点描述的提示"
-    ]
-  ],
-  "message.logoTip": [
-    [
-      "message",
-      "站点 Logo，当菜单栏展开时，展示在站点菜单顶部。"
-    ],
-    [
-      "description",
-      "站点 Logo 的提示"
-    ]
-  ],
-  "message.faviconTip": [
-    [
-      "message",
-      "站点 Favicon，展示在浏览器标签页。"
-    ],
-    [
-      "description",
-      "站点 Favicon 的提示"
-    ]
-  ],
-  "message.adminsTip": [
-    [
-      "message",
-      "站点管理员 ID，默认首次创建该站点的用户会成为管理员，只有站点管理员可以管理站点。"
-    ],
-    [
-      "description",
-      "站点管理员的提示"
-    ]
-  ],
-  "message.adminsTip2": [
-    [
-      "message",
-      "可在此处增删管理员 ID，可到 https://auth.acedata.cloud 查看用户 ID"
-    ],
-    [
-      "description",
-      "站点管理员的提示"
-    ]
-  ],
-  "message.keywordsTip": [
-    [
-      "message",
-      "站点关键词，位于站点元信息中，用于站点 SEO 优化。"
-    ],
-    [
-      "description",
-      "站点关键词的提示"
-    ]
-  ],
-  "message.keywordsTip2": [
-    [
-      "message",
-      "可在此处增删网站关键词，关键词越精准，越有利于 SEO 优化。"
-    ],
-    [
-      "description",
-      "站点关键词的提示"
-    ]
-  ],
-  "message.featuresChat": [
-    [
-      "message",
-      "打开或关闭 Chat 功能模块。"
-    ],
-    [
-      "description",
-      "Chat 功能的描述"
-    ]
-  ],
-  "message.featuresGrok": [
-    [
-      "message",
-      "打开或关闭 Grok 功能模块。"
-    ],
-    [
-      "description",
-      "Grok 功能的描述"
-    ]
-  ],
-  "message.featuresDeepseek": [
-    [
-      "message",
-      "打开或关闭 Deepseek 功能模块。"
-    ],
-    [
-      "description",
-      "Deepseek 功能的描述"
-    ]
-  ],
-  "message.featuresChatgpt": [
-    [
-      "message",
-      "打开或关闭 ChatGPT 功能模块。"
-    ],
-    [
-      "description",
-      "ChatGPT 功能的描述"
-    ]
-  ],
-  "message.featuresMidjourney": [
-    [
-      "message",
-      "打开或关闭 Midjourney 功能模块。"
-    ],
-    [
-      "description",
-      "Midjourney 功能的描述"
-    ]
-  ],
-  "message.featuresChatdoc": [
-    [
-      "message",
-      "打开或关闭 Chatdoc 功能模块。"
-    ],
-    [
-      "description",
-      "Chatdoc 功能的描述"
-    ]
-  ],
-  "message.featuresQrart": [
-    [
-      "message",
-      "打开或关闭 Qrart 功能模块。"
-    ],
-    [
-      "description",
-      "Qrart 功能的描述"
-    ]
-  ],
-  "message.featuresVeo": [
-    [
-      "message",
-      "打开或关闭 Veo 功能模块。"
-    ],
-    [
-      "description",
-      "Veo 功能的描述"
-    ]
-  ],
-  "message.featuresSora": [
-    [
-      "message",
-      "打开或关闭 Sora 功能模块。"
-    ],
-    [
-      "description",
-      "Sora 功能的描述"
-    ]
-  ],
-  "message.featuresSuno": [
-    [
-      "message",
-      "打开或关闭 Suno 功能模块。"
-    ],
-    [
-      "description",
-      "Suno 功能的描述"
-    ]
-  ],
-  "message.featuresPixverse": [
-    [
-      "message",
-      "打开或关闭 Pixverse 功能模块。"
-    ],
-    [
-      "description",
-      "Pixverse 功能的描述"
-    ]
-  ],
-  "message.featuresFlux": [
-    [
-      "message",
-      "打开或关闭 FLux 功能模块。"
-    ],
-    [
-      "description",
-      "FLux 功能的描述"
-    ]
-  ],
-  "message.featuresNanobanana": [
-    [
-      "message",
-      "打开或关闭 Nano Banana 功能模块。"
-    ],
-    [
-      "description",
-      "Nano Banana 功能的描述"
-    ]
-  ],
+  "field.featuresSeedream": {
+    "message": "SeeDream",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresSeedance": {
+    "message": "SeeDance",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresWan": {
+    "message": "Wan",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresProducer": {
+    "message": "Producer",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresKimi": {
+    "message": "Kimi",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresSerp": {
+    "message": "SERP",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresSupport": {
+    "message": "客服支持",
+    "description": "展示在编辑框的标题"
+  },
+  "field.featuresI18n": {
+    "message": "多语言支持",
+    "description": "展示在编辑框的标题"
+  },
+  "title.basicConfig": {
+    "message": "基本配置",
+    "description": "展示在编辑框的标题"
+  },
+  "title.seoConfig": {
+    "message": "SEO 配置",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editAdmins": {
+    "message": "编辑管理员",
+    "description": "展示在编辑框的标题"
+  },
+  "title.featuresConfig": {
+    "message": "功能配置",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editTitle": {
+    "message": "编辑标题",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editOrigin": {
+    "message": "编辑域名",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editKeywords": {
+    "message": "编辑关键词",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editLogo": {
+    "message": "编辑 Logo",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editFavicon": {
+    "message": "编辑 Favicon",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editDescription": {
+    "message": "编辑描述",
+    "description": "展示在编辑框的标题"
+  },
+  "title.distributionConfig": {
+    "message": "分销配置",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editDistributionDefaultInviterId": {
+    "message": "编辑默认邀请人",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editDistributionForceInviterId": {
+    "message": "编辑强制邀请人",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editQR": {
+    "message": "编辑二维码",
+    "description": "展示在编辑框的标题"
+  },
+  "title.editUrl": {
+    "message": "编辑链接",
+    "description": "展示在编辑框的标题"
+  },
+  "placeholder.title": {
+    "message": "请输入站点标题",
+    "description": "展示在编辑框的标题"
+  },
+  "placeholder.origin": {
+    "message": "请输入站点域名",
+    "description": "展示在编辑框的标题"
+  },
+  "placeholder.editUrl": {
+    "message": "请输入链接",
+    "description": "展示在编辑框的标题"
+  },
+  "placeholder.description": {
+    "message": "请输入站点描述",
+    "description": "展示在编辑框的标题"
+  },
+  "placeholder.keywords": {
+    "message": "请输入站点关键词",
+    "description": "展示在编辑框的标题"
+  },
+  "placeholder.editDistributionDefaultInviterId": {
+    "message": "请输入默认邀请人 ID",
+    "description": "展示在编辑框的标题"
+  },
+  "placeholder.editDistributionForceInviterId": {
+    "message": "请输入强制邀请人 ID",
+    "description": "展示在编辑框的标题"
+  },
+  "message.uploadImageExceed": {
+    "message": "上传图片超过限制",
+    "description": "上传图片超过限制的提示"
+  },
+  "message.uploadImageError": {
+    "message": "上传图片错误",
+    "description": "上传图片错误的提示"
+  },
+  "message.editLogoTip": {
+    "message": "建议尺寸：200*60px",
+    "description": "上传图片的提示语言"
+  },
+  "message.editQRTip": {
+    "message": "建议尺寸：200*200px",
+    "description": "上传图片的提示语言"
+  },
+  "message.editFaviconTip": {
+    "message": "建议尺寸：32*32px",
+    "description": "上传图片的提示语言"
+  },
+  "message.editUrl": {
+    "message": "请输入链接",
+    "description": "请输入链接的提示"
+  },
+  "message.atLeastOneAdmin": {
+    "message": "至少保留一个管理员",
+    "description": "至少保留一个管理员的提示"
+  },
+  "message.distributionDefaultInviterIdTip": {
+    "message": "默认邀请人的用户 ID，分销链接如果不携带 inviter_id 参数，则默认使用该用户 ID 作为邀请人。",
+    "description": "默认邀请人ID的提示"
+  },
+  "message.distributionForceInviterIdTip": {
+    "message": "强制邀请人的用户 ID，如果设置了此 ID，无论分销链接是否携带 inviter_id 参数，则强制使用该用户 ID 作为邀请人。",
+    "description": "强制邀请人ID的提示"
+  },
+  "message.originTip": {
+    "message": "站点域名，站点配置与域名绑定，站点域名不可更改。",
+    "description": "站点域名的提示"
+  },
+  "message.titleTip": {
+    "message": "站点标题，展示在浏览器标签页。",
+    "description": "站点标题的提示"
+  },
+  "message.descriptionTip": {
+    "message": "站点描述，位于站点元信息中，用于站点 SEO 优化。",
+    "description": "站点描述的提示"
+  },
+  "message.logoTip": {
+    "message": "站点 Logo，当菜单栏展开时，展示在站点菜单顶部。",
+    "description": "站点 Logo 的提示"
+  },
+  "message.faviconTip": {
+    "message": "站点 Favicon，展示在浏览器标签页。",
+    "description": "站点 Favicon 的提示"
+  },
+  "message.adminsTip": {
+    "message": "站点管理员 ID，默认首次创建该站点的用户会成为管理员，只有站点管理员可以管理站点。",
+    "description": "站点管理员的提示"
+  },
+  "message.adminsTip2": {
+    "message": "可在此处增删管理员 ID，可到 https://auth.acedata.cloud 查看用户 ID",
+    "description": "站点管理员的提示"
+  },
+  "message.keywordsTip": {
+    "message": "站点关键词，位于站点元信息中，用于站点 SEO 优化。",
+    "description": "站点关键词的提示"
+  },
+  "message.keywordsTip2": {
+    "message": "可在此处增删网站关键词，关键词越精准，越有利于 SEO 优化。",
+    "description": "站点关键词的提示"
+  },
+  "message.featuresChat": {
+    "message": "打开或关闭 Chat 功能模块。",
+    "description": "Chat 功能的描述"
+  },
+  "message.featuresGrok": {
+    "message": "打开或关闭 Grok 功能模块。",
+    "description": "Grok 功能的描述"
+  },
+  "message.featuresDeepseek": {
+    "message": "打开或关闭 Deepseek 功能模块。",
+    "description": "Deepseek 功能的描述"
+  },
+  "message.featuresChatgpt": {
+    "message": "打开或关闭 ChatGPT 功能模块。",
+    "description": "ChatGPT 功能的描述"
+  },
+  "message.featuresMidjourney": {
+    "message": "打开或关闭 Midjourney 功能模块。",
+    "description": "Midjourney 功能的描述"
+  },
+  "message.featuresChatdoc": {
+    "message": "打开或关闭 Chatdoc 功能模块。",
+    "description": "Chatdoc 功能的描述"
+  },
+  "message.featuresQrart": {
+    "message": "打开或关闭 Qrart 功能模块。",
+    "description": "Qrart 功能的描述"
+  },
+  "message.featuresVeo": {
+    "message": "打开或关闭 Veo 功能模块。",
+    "description": "Veo 功能的描述"
+  },
+  "message.featuresSora": {
+    "message": "打开或关闭 Sora 功能模块。",
+    "description": "Sora 功能的描述"
+  },
+  "message.featuresSuno": {
+    "message": "打开或关闭 Suno 功能模块。",
+    "description": "Suno 功能的描述"
+  },
+  "message.featuresPixverse": {
+    "message": "打开或关闭 Pixverse 功能模块。",
+    "description": "Pixverse 功能的描述"
+  },
+  "message.featuresFlux": {
+    "message": "打开或关闭 FLux 功能模块。",
+    "description": "FLux 功能的描述"
+  },
+  "message.featuresNanobanana": {
+    "message": "打开或关闭 Nano Banana 功能模块。",
+    "description": "Nano Banana 功能的描述"
+  },
   "message.featuresOpenaiimage": {
     "message": "打开或关闭 OpenAI 图像功能模块。",
     "description": "OpenAI 图像功能的描述"
   },
-  "message.featuresSeedream": [
-    [
-      "message",
-      "打开或关闭 SeeDream 功能模块。"
-    ],
-    [
-      "description",
-      "SeeDream 功能的描述"
-    ]
-  ],
-  "message.featuresSeedance": [
-    [
-      "message",
-      "启用或禁用SeeDance功能模块。"
-    ],
-    [
-      "description",
-      "SeeDance功能的描述"
-    ]
-  ],
-  "message.featuresWan": [
-    [
-      "message",
-      "打开或关闭 Wan 功能模块。"
-    ],
-    [
-      "description",
-      "Wan 功能的描述"
-    ]
-  ],
-  "message.featuresProducer": [
-    [
-      "message",
-      "打开或关闭 Producer 功能模块。"
-    ],
-    [
-      "description",
-      "Producer 功能的描述"
-    ]
-  ],
-  "message.featuresKimi": [
-    [
-      "message",
-      "打开或关闭 Kimi 功能模块。"
-    ],
-    [
-      "description",
-      "Kimi 功能的描述"
-    ]
-  ],
-  "message.featuresSerp": [
-    [
-      "message",
-      "打开或关闭 SERP 功能模块。"
-    ],
-    [
-      "description",
-      "SERP 功能的描述"
-    ]
-  ],
-  "message.featuresLuma": [
-    [
-      "message",
-      "打开或关闭 Luma 功能模块。"
-    ],
-    [
-      "description",
-      "Luma 功能的描述"
-    ]
-  ],
-  "message.featuresPika": [
-    [
-      "message",
-      "打开或关闭 Pika 功能模块。"
-    ],
-    [
-      "description",
-      "Pika 功能的描述"
-    ]
-  ],
-  "message.featuresKling": [
-    [
-      "message",
-      "打开或关闭 Kling 功能模块。"
-    ],
-    [
-      "description",
-      "Kling 功能的描述"
-    ]
-  ],
-  "message.featuresHailuo": [
-    [
-      "message",
-      "打开或关闭 Hailuo 功能模块。"
-    ],
-    [
-      "description",
-      "Hailuo 功能的描述"
-    ]
-  ],
-  "message.featuresHeadshots": [
-    [
-      "message",
-      "打开或关闭 AI证件照 功能模块。"
-    ],
-    [
-      "description",
-      "AI证件照 功能的描述"
-    ]
-  ],
-  "message.featuresSupport": [
-    [
-      "message",
-      "打开或关闭客服支持"
-    ],
-    [
-      "description",
-      "Support 功能的描述"
-    ]
-  ],
-  "message.featuresI18n": [
-    [
-      "message",
-      "打开或关闭多语言支持，关闭后，用户只能使用默认语言。"
-    ],
-    [
-      "description",
-      "多语言支持的描述"
-    ]
-  ],
-  "button.upload": [
-    [
-      "message",
-      "上传"
-    ],
-    [
-      "description",
-      "上传"
-    ]
-  ],
-  "button.enabled": [
-    [
-      "message",
-      "已启用"
-    ],
-    [
-      "description",
-      "开关文字，表示已经启用"
-    ]
-  ],
-  "button.disabled": [
-    [
-      "message",
-      "已禁用"
-    ],
-    [
-      "description",
-      "开关文字，表示已经禁用"
-    ]
-  ],
-  "field.featuresGemini": [
-    [
-      "message",
-      "Gemini"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "message.featuresGemini": [
-    [
-      "message",
-      "Enable or disable the Gemini feature module."
-    ],
-    [
-      "description",
-      "Description of the Gemini feature"
-    ]
-  ],
-  "field.featuresClaude": [
-    [
-      "message",
-      "Claude"
-    ],
-    [
-      "description",
-      "Displayed as the title in the editing box"
-    ]
-  ],
-  "message.featuresClaude": [
-    [
-      "message",
-      "Enable or disable the Claude feature module."
-    ],
-    [
-      "description",
-      "Description of the Claude feature"
-    ]
-  ]
+  "message.featuresSeedream": {
+    "message": "打开或关闭 SeeDream 功能模块。",
+    "description": "SeeDream 功能的描述"
+  },
+  "message.featuresSeedance": {
+    "message": "启用或禁用SeeDance功能模块。",
+    "description": "SeeDance功能的描述"
+  },
+  "message.featuresWan": {
+    "message": "打开或关闭 Wan 功能模块。",
+    "description": "Wan 功能的描述"
+  },
+  "message.featuresProducer": {
+    "message": "打开或关闭 Producer 功能模块。",
+    "description": "Producer 功能的描述"
+  },
+  "message.featuresKimi": {
+    "message": "打开或关闭 Kimi 功能模块。",
+    "description": "Kimi 功能的描述"
+  },
+  "message.featuresSerp": {
+    "message": "打开或关闭 SERP 功能模块。",
+    "description": "SERP 功能的描述"
+  },
+  "message.featuresLuma": {
+    "message": "打开或关闭 Luma 功能模块。",
+    "description": "Luma 功能的描述"
+  },
+  "message.featuresPika": {
+    "message": "打开或关闭 Pika 功能模块。",
+    "description": "Pika 功能的描述"
+  },
+  "message.featuresKling": {
+    "message": "打开或关闭 Kling 功能模块。",
+    "description": "Kling 功能的描述"
+  },
+  "message.featuresHailuo": {
+    "message": "打开或关闭 Hailuo 功能模块。",
+    "description": "Hailuo 功能的描述"
+  },
+  "message.featuresHeadshots": {
+    "message": "打开或关闭 AI证件照 功能模块。",
+    "description": "AI证件照 功能的描述"
+  },
+  "message.featuresSupport": {
+    "message": "打开或关闭客服支持",
+    "description": "Support 功能的描述"
+  },
+  "message.featuresI18n": {
+    "message": "打开或关闭多语言支持，关闭后，用户只能使用默认语言。",
+    "description": "多语言支持的描述"
+  },
+  "button.upload": {
+    "message": "上传",
+    "description": "上传"
+  },
+  "button.enabled": {
+    "message": "已启用",
+    "description": "开关文字，表示已经启用"
+  },
+  "button.disabled": {
+    "message": "已禁用",
+    "description": "开关文字，表示已经禁用"
+  },
+  "field.featuresGemini": {
+    "message": "Gemini",
+    "description": "Displayed as the title in the editing box"
+  },
+  "message.featuresGemini": {
+    "message": "Enable or disable the Gemini feature module.",
+    "description": "Description of the Gemini feature"
+  },
+  "field.featuresClaude": {
+    "message": "Claude",
+    "description": "Displayed as the title in the editing box"
+  },
+  "message.featuresClaude": {
+    "message": "Enable or disable the Claude feature module.",
+    "description": "Description of the Claude feature"
+  }
 }

--- a/src/i18n/zh-CN/site.json
+++ b/src/i18n/zh-CN/site.json
@@ -1,442 +1,1110 @@
 {
-  "field.title": {
-    "message": "站点标题",
+  "field.title": [
+    [
+      "message",
+      "站点标题"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.origin": [
+    [
+      "message",
+      "站点域名"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.description": [
+    [
+      "message",
+      "站点描述"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.keywords": [
+    [
+      "message",
+      "站点关键词"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.logo": [
+    [
+      "message",
+      "站点 Logo"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.favicon": [
+    [
+      "message",
+      "站点 Favicon"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.qr": [
+    [
+      "message",
+      "二维码"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.url": [
+    [
+      "message",
+      "链接"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.admins": [
+    [
+      "message",
+      "站点管理员 ID"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.distributionDefaultInviterId": [
+    [
+      "message",
+      "默认邀请人 ID"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.distributionForceInviterId": [
+    [
+      "message",
+      "强制邀请人 ID"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresChat": [
+    [
+      "message",
+      "Chat"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresVeo": [
+    [
+      "message",
+      "Veo"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresSora": [
+    [
+      "message",
+      "Sora"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresGrok": [
+    [
+      "message",
+      "Grok"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresDeepseek": [
+    [
+      "message",
+      "Deepseek"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresChatgpt": [
+    [
+      "message",
+      "ChatGPT"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresMidjourney": [
+    [
+      "message",
+      "Midjourney"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresChatdoc": [
+    [
+      "message",
+      "Chatdoc"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresQrart": [
+    [
+      "message",
+      "Qrart"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresLuma": [
+    [
+      "message",
+      "Luma"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresPixverse": [
+    [
+      "message",
+      "Pixverse"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresPika": [
+    [
+      "message",
+      "Pika"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresKling": [
+    [
+      "message",
+      "Kling"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresHailuo": [
+    [
+      "message",
+      "Hailuo"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresHeadshots": [
+    [
+      "message",
+      "AI证件照"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresSuno": [
+    [
+      "message",
+      "Suno"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresFlux": [
+    [
+      "message",
+      "Flux"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresNanobanana": [
+    [
+      "message",
+      "Nano Banana"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresOpenaiimage": {
+    "message": "OpenAI 图像",
     "description": "展示在编辑框的标题"
   },
-  "field.origin": {
-    "message": "站点域名",
-    "description": "展示在编辑框的标题"
-  },
-  "field.description": {
-    "message": "站点描述",
-    "description": "展示在编辑框的标题"
-  },
-  "field.keywords": {
-    "message": "站点关键词",
-    "description": "展示在编辑框的标题"
-  },
-  "field.logo": {
-    "message": "站点 Logo",
-    "description": "展示在编辑框的标题"
-  },
-  "field.favicon": {
-    "message": "站点 Favicon",
-    "description": "展示在编辑框的标题"
-  },
-  "field.qr": {
-    "message": "二维码",
-    "description": "展示在编辑框的标题"
-  },
-  "field.url": {
-    "message": "链接",
-    "description": "展示在编辑框的标题"
-  },
-  "field.admins": {
-    "message": "站点管理员 ID",
-    "description": "展示在编辑框的标题"
-  },
-  "field.distributionDefaultInviterId": {
-    "message": "默认邀请人 ID",
-    "description": "展示在编辑框的标题"
-  },
-  "field.distributionForceInviterId": {
-    "message": "强制邀请人 ID",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresChat": {
-    "message": "Chat",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresVeo": {
-    "message": "Veo",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresSora": {
-    "message": "Sora",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresGrok": {
-    "message": "Grok",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresDeepseek": {
-    "message": "Deepseek",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresChatgpt": {
-    "message": "ChatGPT",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresMidjourney": {
-    "message": "Midjourney",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresChatdoc": {
-    "message": "Chatdoc",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresQrart": {
-    "message": "Qrart",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresLuma": {
-    "message": "Luma",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresPixverse": {
-    "message": "Pixverse",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresPika": {
-    "message": "Pika",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresKling": {
-    "message": "Kling",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresHailuo": {
-    "message": "Hailuo",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresHeadshots": {
-    "message": "AI证件照",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresSuno": {
-    "message": "Suno",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresFlux": {
-    "message": "Flux",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresNanobanana": {
-    "message": "Nano Banana",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresSeedream": {
-    "message": "SeeDream",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresSeedance": {
-    "message": "SeeDance",
-    "description": "Displayed as the title in the editing box"
-  },
-  "field.featuresWan": {
-    "message": "Wan",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresProducer": {
-    "message": "Producer",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresKimi": {
-    "message": "Kimi",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresSerp": {
-    "message": "SERP",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresSupport": {
-    "message": "客服支持",
-    "description": "展示在编辑框的标题"
-  },
-  "field.featuresI18n": {
-    "message": "多语言支持",
-    "description": "展示在编辑框的标题"
-  },
-  "title.basicConfig": {
-    "message": "基本配置",
-    "description": "展示在编辑框的标题"
-  },
-  "title.seoConfig": {
-    "message": "SEO 配置",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editAdmins": {
-    "message": "编辑管理员",
-    "description": "展示在编辑框的标题"
-  },
-  "title.featuresConfig": {
-    "message": "功能配置",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editTitle": {
-    "message": "编辑标题",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editOrigin": {
-    "message": "编辑域名",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editKeywords": {
-    "message": "编辑关键词",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editLogo": {
-    "message": "编辑 Logo",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editFavicon": {
-    "message": "编辑 Favicon",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editDescription": {
-    "message": "编辑描述",
-    "description": "展示在编辑框的标题"
-  },
-  "title.distributionConfig": {
-    "message": "分销配置",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editDistributionDefaultInviterId": {
-    "message": "编辑默认邀请人",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editDistributionForceInviterId": {
-    "message": "编辑强制邀请人",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editQR": {
-    "message": "编辑二维码",
-    "description": "展示在编辑框的标题"
-  },
-  "title.editUrl": {
-    "message": "编辑链接",
-    "description": "展示在编辑框的标题"
-  },
-  "placeholder.title": {
-    "message": "请输入站点标题",
-    "description": "展示在编辑框的标题"
-  },
-  "placeholder.origin": {
-    "message": "请输入站点域名",
-    "description": "展示在编辑框的标题"
-  },
-  "placeholder.editUrl": {
-    "message": "请输入链接",
-    "description": "展示在编辑框的标题"
-  },
-  "placeholder.description": {
-    "message": "请输入站点描述",
-    "description": "展示在编辑框的标题"
-  },
-  "placeholder.keywords": {
-    "message": "请输入站点关键词",
-    "description": "展示在编辑框的标题"
-  },
-  "placeholder.editDistributionDefaultInviterId": {
-    "message": "请输入默认邀请人 ID",
-    "description": "展示在编辑框的标题"
-  },
-  "placeholder.editDistributionForceInviterId": {
-    "message": "请输入强制邀请人 ID",
-    "description": "展示在编辑框的标题"
-  },
-  "message.uploadImageExceed": {
-    "message": "上传图片超过限制",
-    "description": "上传图片超过限制的提示"
-  },
-  "message.uploadImageError": {
-    "message": "上传图片错误",
-    "description": "上传图片错误的提示"
-  },
-  "message.editLogoTip": {
-    "message": "建议尺寸：200*60px",
-    "description": "上传图片的提示语言"
-  },
-  "message.editQRTip": {
-    "message": "建议尺寸：200*200px",
-    "description": "上传图片的提示语言"
-  },
-  "message.editFaviconTip": {
-    "message": "建议尺寸：32*32px",
-    "description": "上传图片的提示语言"
-  },
-  "message.editUrl": {
-    "message": "请输入链接",
-    "description": "请输入链接的提示"
-  },
-  "message.atLeastOneAdmin": {
-    "message": "至少保留一个管理员",
-    "description": "至少保留一个管理员的提示"
-  },
-  "message.distributionDefaultInviterIdTip": {
-    "message": "默认邀请人的用户 ID，分销链接如果不携带 inviter_id 参数，则默认使用该用户 ID 作为邀请人。",
-    "description": "默认邀请人ID的提示"
-  },
-  "message.distributionForceInviterIdTip": {
-    "message": "强制邀请人的用户 ID，如果设置了此 ID，无论分销链接是否携带 inviter_id 参数，则强制使用该用户 ID 作为邀请人。",
-    "description": "强制邀请人ID的提示"
-  },
-  "message.originTip": {
-    "message": "站点域名，站点配置与域名绑定，站点域名不可更改。",
-    "description": "站点域名的提示"
-  },
-  "message.titleTip": {
-    "message": "站点标题，展示在浏览器标签页。",
-    "description": "站点标题的提示"
-  },
-  "message.descriptionTip": {
-    "message": "站点描述，位于站点元信息中，用于站点 SEO 优化。",
-    "description": "站点描述的提示"
-  },
-  "message.logoTip": {
-    "message": "站点 Logo，当菜单栏展开时，展示在站点菜单顶部。",
-    "description": "站点 Logo 的提示"
-  },
-  "message.faviconTip": {
-    "message": "站点 Favicon，展示在浏览器标签页。",
-    "description": "站点 Favicon 的提示"
-  },
-  "message.adminsTip": {
-    "message": "站点管理员 ID，默认首次创建该站点的用户会成为管理员，只有站点管理员可以管理站点。",
-    "description": "站点管理员的提示"
-  },
-  "message.adminsTip2": {
-    "message": "可在此处增删管理员 ID，可到 https://auth.acedata.cloud 查看用户 ID",
-    "description": "站点管理员的提示"
-  },
-  "message.keywordsTip": {
-    "message": "站点关键词，位于站点元信息中，用于站点 SEO 优化。",
-    "description": "站点关键词的提示"
-  },
-  "message.keywordsTip2": {
-    "message": "可在此处增删网站关键词，关键词越精准，越有利于 SEO 优化。",
-    "description": "站点关键词的提示"
-  },
-  "message.featuresChat": {
-    "message": "打开或关闭 Chat 功能模块。",
-    "description": "Chat 功能的描述"
-  },
-  "message.featuresGrok": {
-    "message": "打开或关闭 Grok 功能模块。",
-    "description": "Grok 功能的描述"
-  },
-  "message.featuresDeepseek": {
-    "message": "打开或关闭 Deepseek 功能模块。",
-    "description": "Deepseek 功能的描述"
-  },
-  "message.featuresChatgpt": {
-    "message": "打开或关闭 ChatGPT 功能模块。",
-    "description": "ChatGPT 功能的描述"
-  },
-  "message.featuresMidjourney": {
-    "message": "打开或关闭 Midjourney 功能模块。",
-    "description": "Midjourney 功能的描述"
-  },
-  "message.featuresChatdoc": {
-    "message": "打开或关闭 Chatdoc 功能模块。",
-    "description": "Chatdoc 功能的描述"
-  },
-  "message.featuresQrart": {
-    "message": "打开或关闭 Qrart 功能模块。",
-    "description": "Qrart 功能的描述"
-  },
-  "message.featuresVeo": {
-    "message": "打开或关闭 Veo 功能模块。",
-    "description": "Veo 功能的描述"
-  },
-  "message.featuresSora": {
-    "message": "打开或关闭 Sora 功能模块。",
-    "description": "Sora 功能的描述"
-  },
-  "message.featuresSuno": {
-    "message": "打开或关闭 Suno 功能模块。",
-    "description": "Suno 功能的描述"
-  },
-  "message.featuresPixverse": {
-    "message": "打开或关闭 Pixverse 功能模块。",
-    "description": "Pixverse 功能的描述"
-  },
-  "message.featuresFlux": {
-    "message": "打开或关闭 FLux 功能模块。",
-    "description": "FLux 功能的描述"
-  },
-  "message.featuresNanobanana": {
-    "message": "打开或关闭 Nano Banana 功能模块。",
-    "description": "Nano Banana 功能的描述"
-  },
-  "message.featuresSeedream": {
-    "message": "打开或关闭 SeeDream 功能模块。",
-    "description": "SeeDream 功能的描述"
-  },
-  "message.featuresSeedance": {
-    "message": "启用或禁用SeeDance功能模块。",
-    "description": "SeeDance功能的描述"
-  },
-  "message.featuresWan": {
-    "message": "打开或关闭 Wan 功能模块。",
-    "description": "Wan 功能的描述"
-  },
-  "message.featuresProducer": {
-    "message": "打开或关闭 Producer 功能模块。",
-    "description": "Producer 功能的描述"
-  },
-  "message.featuresKimi": {
-    "message": "打开或关闭 Kimi 功能模块。",
-    "description": "Kimi 功能的描述"
-  },
-  "message.featuresSerp": {
-    "message": "打开或关闭 SERP 功能模块。",
-    "description": "SERP 功能的描述"
-  },
-  "message.featuresLuma": {
-    "message": "打开或关闭 Luma 功能模块。",
-    "description": "Luma 功能的描述"
-  },
-  "message.featuresPika": {
-    "message": "打开或关闭 Pika 功能模块。",
-    "description": "Pika 功能的描述"
-  },
-  "message.featuresKling": {
-    "message": "打开或关闭 Kling 功能模块。",
-    "description": "Kling 功能的描述"
-  },
-  "message.featuresHailuo": {
-    "message": "打开或关闭 Hailuo 功能模块。",
-    "description": "Hailuo 功能的描述"
-  },
-  "message.featuresHeadshots": {
-    "message": "打开或关闭 AI证件照 功能模块。",
-    "description": "AI证件照 功能的描述"
-  },
-  "message.featuresSupport": {
-    "message": "打开或关闭客服支持",
-    "description": "Support 功能的描述"
-  },
-  "message.featuresI18n": {
-    "message": "打开或关闭多语言支持，关闭后，用户只能使用默认语言。",
-    "description": "多语言支持的描述"
-  },
-  "button.upload": {
-    "message": "上传",
-    "description": "上传"
-  },
-  "button.enabled": {
-    "message": "已启用",
-    "description": "开关文字，表示已经启用"
-  },
-  "button.disabled": {
-    "message": "已禁用",
-    "description": "开关文字，表示已经禁用"
-  },
-  "field.featuresGemini": {
-    "message": "Gemini",
-    "description": "Displayed as the title in the editing box"
-  },
-  "message.featuresGemini": {
-    "message": "Enable or disable the Gemini feature module.",
-    "description": "Description of the Gemini feature"
-  },
-  "field.featuresClaude": {
-    "message": "Claude",
-    "description": "Displayed as the title in the editing box"
-  },
-  "message.featuresClaude": {
-    "message": "Enable or disable the Claude feature module.",
-    "description": "Description of the Claude feature"
-  }
+  "field.featuresSeedream": [
+    [
+      "message",
+      "SeeDream"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresSeedance": [
+    [
+      "message",
+      "SeeDance"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "field.featuresWan": [
+    [
+      "message",
+      "Wan"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresProducer": [
+    [
+      "message",
+      "Producer"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresKimi": [
+    [
+      "message",
+      "Kimi"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresSerp": [
+    [
+      "message",
+      "SERP"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresSupport": [
+    [
+      "message",
+      "客服支持"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "field.featuresI18n": [
+    [
+      "message",
+      "多语言支持"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.basicConfig": [
+    [
+      "message",
+      "基本配置"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.seoConfig": [
+    [
+      "message",
+      "SEO 配置"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editAdmins": [
+    [
+      "message",
+      "编辑管理员"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.featuresConfig": [
+    [
+      "message",
+      "功能配置"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editTitle": [
+    [
+      "message",
+      "编辑标题"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editOrigin": [
+    [
+      "message",
+      "编辑域名"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editKeywords": [
+    [
+      "message",
+      "编辑关键词"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editLogo": [
+    [
+      "message",
+      "编辑 Logo"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editFavicon": [
+    [
+      "message",
+      "编辑 Favicon"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editDescription": [
+    [
+      "message",
+      "编辑描述"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.distributionConfig": [
+    [
+      "message",
+      "分销配置"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editDistributionDefaultInviterId": [
+    [
+      "message",
+      "编辑默认邀请人"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editDistributionForceInviterId": [
+    [
+      "message",
+      "编辑强制邀请人"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editQR": [
+    [
+      "message",
+      "编辑二维码"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "title.editUrl": [
+    [
+      "message",
+      "编辑链接"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "placeholder.title": [
+    [
+      "message",
+      "请输入站点标题"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "placeholder.origin": [
+    [
+      "message",
+      "请输入站点域名"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "placeholder.editUrl": [
+    [
+      "message",
+      "请输入链接"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "placeholder.description": [
+    [
+      "message",
+      "请输入站点描述"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "placeholder.keywords": [
+    [
+      "message",
+      "请输入站点关键词"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "placeholder.editDistributionDefaultInviterId": [
+    [
+      "message",
+      "请输入默认邀请人 ID"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "placeholder.editDistributionForceInviterId": [
+    [
+      "message",
+      "请输入强制邀请人 ID"
+    ],
+    [
+      "description",
+      "展示在编辑框的标题"
+    ]
+  ],
+  "message.uploadImageExceed": [
+    [
+      "message",
+      "上传图片超过限制"
+    ],
+    [
+      "description",
+      "上传图片超过限制的提示"
+    ]
+  ],
+  "message.uploadImageError": [
+    [
+      "message",
+      "上传图片错误"
+    ],
+    [
+      "description",
+      "上传图片错误的提示"
+    ]
+  ],
+  "message.editLogoTip": [
+    [
+      "message",
+      "建议尺寸：200*60px"
+    ],
+    [
+      "description",
+      "上传图片的提示语言"
+    ]
+  ],
+  "message.editQRTip": [
+    [
+      "message",
+      "建议尺寸：200*200px"
+    ],
+    [
+      "description",
+      "上传图片的提示语言"
+    ]
+  ],
+  "message.editFaviconTip": [
+    [
+      "message",
+      "建议尺寸：32*32px"
+    ],
+    [
+      "description",
+      "上传图片的提示语言"
+    ]
+  ],
+  "message.editUrl": [
+    [
+      "message",
+      "请输入链接"
+    ],
+    [
+      "description",
+      "请输入链接的提示"
+    ]
+  ],
+  "message.atLeastOneAdmin": [
+    [
+      "message",
+      "至少保留一个管理员"
+    ],
+    [
+      "description",
+      "至少保留一个管理员的提示"
+    ]
+  ],
+  "message.distributionDefaultInviterIdTip": [
+    [
+      "message",
+      "默认邀请人的用户 ID，分销链接如果不携带 inviter_id 参数，则默认使用该用户 ID 作为邀请人。"
+    ],
+    [
+      "description",
+      "默认邀请人ID的提示"
+    ]
+  ],
+  "message.distributionForceInviterIdTip": [
+    [
+      "message",
+      "强制邀请人的用户 ID，如果设置了此 ID，无论分销链接是否携带 inviter_id 参数，则强制使用该用户 ID 作为邀请人。"
+    ],
+    [
+      "description",
+      "强制邀请人ID的提示"
+    ]
+  ],
+  "message.originTip": [
+    [
+      "message",
+      "站点域名，站点配置与域名绑定，站点域名不可更改。"
+    ],
+    [
+      "description",
+      "站点域名的提示"
+    ]
+  ],
+  "message.titleTip": [
+    [
+      "message",
+      "站点标题，展示在浏览器标签页。"
+    ],
+    [
+      "description",
+      "站点标题的提示"
+    ]
+  ],
+  "message.descriptionTip": [
+    [
+      "message",
+      "站点描述，位于站点元信息中，用于站点 SEO 优化。"
+    ],
+    [
+      "description",
+      "站点描述的提示"
+    ]
+  ],
+  "message.logoTip": [
+    [
+      "message",
+      "站点 Logo，当菜单栏展开时，展示在站点菜单顶部。"
+    ],
+    [
+      "description",
+      "站点 Logo 的提示"
+    ]
+  ],
+  "message.faviconTip": [
+    [
+      "message",
+      "站点 Favicon，展示在浏览器标签页。"
+    ],
+    [
+      "description",
+      "站点 Favicon 的提示"
+    ]
+  ],
+  "message.adminsTip": [
+    [
+      "message",
+      "站点管理员 ID，默认首次创建该站点的用户会成为管理员，只有站点管理员可以管理站点。"
+    ],
+    [
+      "description",
+      "站点管理员的提示"
+    ]
+  ],
+  "message.adminsTip2": [
+    [
+      "message",
+      "可在此处增删管理员 ID，可到 https://auth.acedata.cloud 查看用户 ID"
+    ],
+    [
+      "description",
+      "站点管理员的提示"
+    ]
+  ],
+  "message.keywordsTip": [
+    [
+      "message",
+      "站点关键词，位于站点元信息中，用于站点 SEO 优化。"
+    ],
+    [
+      "description",
+      "站点关键词的提示"
+    ]
+  ],
+  "message.keywordsTip2": [
+    [
+      "message",
+      "可在此处增删网站关键词，关键词越精准，越有利于 SEO 优化。"
+    ],
+    [
+      "description",
+      "站点关键词的提示"
+    ]
+  ],
+  "message.featuresChat": [
+    [
+      "message",
+      "打开或关闭 Chat 功能模块。"
+    ],
+    [
+      "description",
+      "Chat 功能的描述"
+    ]
+  ],
+  "message.featuresGrok": [
+    [
+      "message",
+      "打开或关闭 Grok 功能模块。"
+    ],
+    [
+      "description",
+      "Grok 功能的描述"
+    ]
+  ],
+  "message.featuresDeepseek": [
+    [
+      "message",
+      "打开或关闭 Deepseek 功能模块。"
+    ],
+    [
+      "description",
+      "Deepseek 功能的描述"
+    ]
+  ],
+  "message.featuresChatgpt": [
+    [
+      "message",
+      "打开或关闭 ChatGPT 功能模块。"
+    ],
+    [
+      "description",
+      "ChatGPT 功能的描述"
+    ]
+  ],
+  "message.featuresMidjourney": [
+    [
+      "message",
+      "打开或关闭 Midjourney 功能模块。"
+    ],
+    [
+      "description",
+      "Midjourney 功能的描述"
+    ]
+  ],
+  "message.featuresChatdoc": [
+    [
+      "message",
+      "打开或关闭 Chatdoc 功能模块。"
+    ],
+    [
+      "description",
+      "Chatdoc 功能的描述"
+    ]
+  ],
+  "message.featuresQrart": [
+    [
+      "message",
+      "打开或关闭 Qrart 功能模块。"
+    ],
+    [
+      "description",
+      "Qrart 功能的描述"
+    ]
+  ],
+  "message.featuresVeo": [
+    [
+      "message",
+      "打开或关闭 Veo 功能模块。"
+    ],
+    [
+      "description",
+      "Veo 功能的描述"
+    ]
+  ],
+  "message.featuresSora": [
+    [
+      "message",
+      "打开或关闭 Sora 功能模块。"
+    ],
+    [
+      "description",
+      "Sora 功能的描述"
+    ]
+  ],
+  "message.featuresSuno": [
+    [
+      "message",
+      "打开或关闭 Suno 功能模块。"
+    ],
+    [
+      "description",
+      "Suno 功能的描述"
+    ]
+  ],
+  "message.featuresPixverse": [
+    [
+      "message",
+      "打开或关闭 Pixverse 功能模块。"
+    ],
+    [
+      "description",
+      "Pixverse 功能的描述"
+    ]
+  ],
+  "message.featuresFlux": [
+    [
+      "message",
+      "打开或关闭 FLux 功能模块。"
+    ],
+    [
+      "description",
+      "FLux 功能的描述"
+    ]
+  ],
+  "message.featuresNanobanana": [
+    [
+      "message",
+      "打开或关闭 Nano Banana 功能模块。"
+    ],
+    [
+      "description",
+      "Nano Banana 功能的描述"
+    ]
+  ],
+  "message.featuresOpenaiimage": {
+    "message": "打开或关闭 OpenAI 图像功能模块。",
+    "description": "OpenAI 图像功能的描述"
+  },
+  "message.featuresSeedream": [
+    [
+      "message",
+      "打开或关闭 SeeDream 功能模块。"
+    ],
+    [
+      "description",
+      "SeeDream 功能的描述"
+    ]
+  ],
+  "message.featuresSeedance": [
+    [
+      "message",
+      "启用或禁用SeeDance功能模块。"
+    ],
+    [
+      "description",
+      "SeeDance功能的描述"
+    ]
+  ],
+  "message.featuresWan": [
+    [
+      "message",
+      "打开或关闭 Wan 功能模块。"
+    ],
+    [
+      "description",
+      "Wan 功能的描述"
+    ]
+  ],
+  "message.featuresProducer": [
+    [
+      "message",
+      "打开或关闭 Producer 功能模块。"
+    ],
+    [
+      "description",
+      "Producer 功能的描述"
+    ]
+  ],
+  "message.featuresKimi": [
+    [
+      "message",
+      "打开或关闭 Kimi 功能模块。"
+    ],
+    [
+      "description",
+      "Kimi 功能的描述"
+    ]
+  ],
+  "message.featuresSerp": [
+    [
+      "message",
+      "打开或关闭 SERP 功能模块。"
+    ],
+    [
+      "description",
+      "SERP 功能的描述"
+    ]
+  ],
+  "message.featuresLuma": [
+    [
+      "message",
+      "打开或关闭 Luma 功能模块。"
+    ],
+    [
+      "description",
+      "Luma 功能的描述"
+    ]
+  ],
+  "message.featuresPika": [
+    [
+      "message",
+      "打开或关闭 Pika 功能模块。"
+    ],
+    [
+      "description",
+      "Pika 功能的描述"
+    ]
+  ],
+  "message.featuresKling": [
+    [
+      "message",
+      "打开或关闭 Kling 功能模块。"
+    ],
+    [
+      "description",
+      "Kling 功能的描述"
+    ]
+  ],
+  "message.featuresHailuo": [
+    [
+      "message",
+      "打开或关闭 Hailuo 功能模块。"
+    ],
+    [
+      "description",
+      "Hailuo 功能的描述"
+    ]
+  ],
+  "message.featuresHeadshots": [
+    [
+      "message",
+      "打开或关闭 AI证件照 功能模块。"
+    ],
+    [
+      "description",
+      "AI证件照 功能的描述"
+    ]
+  ],
+  "message.featuresSupport": [
+    [
+      "message",
+      "打开或关闭客服支持"
+    ],
+    [
+      "description",
+      "Support 功能的描述"
+    ]
+  ],
+  "message.featuresI18n": [
+    [
+      "message",
+      "打开或关闭多语言支持，关闭后，用户只能使用默认语言。"
+    ],
+    [
+      "description",
+      "多语言支持的描述"
+    ]
+  ],
+  "button.upload": [
+    [
+      "message",
+      "上传"
+    ],
+    [
+      "description",
+      "上传"
+    ]
+  ],
+  "button.enabled": [
+    [
+      "message",
+      "已启用"
+    ],
+    [
+      "description",
+      "开关文字，表示已经启用"
+    ]
+  ],
+  "button.disabled": [
+    [
+      "message",
+      "已禁用"
+    ],
+    [
+      "description",
+      "开关文字，表示已经禁用"
+    ]
+  ],
+  "field.featuresGemini": [
+    [
+      "message",
+      "Gemini"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "message.featuresGemini": [
+    [
+      "message",
+      "Enable or disable the Gemini feature module."
+    ],
+    [
+      "description",
+      "Description of the Gemini feature"
+    ]
+  ],
+  "field.featuresClaude": [
+    [
+      "message",
+      "Claude"
+    ],
+    [
+      "description",
+      "Displayed as the title in the editing box"
+    ]
+  ],
+  "message.featuresClaude": [
+    [
+      "message",
+      "Enable or disable the Claude feature module."
+    ],
+    [
+      "description",
+      "Description of the Claude feature"
+    ]
+  ]
 }

--- a/src/i18n/zh-TW/site.json
+++ b/src/i18n/zh-TW/site.json
@@ -1,1110 +1,450 @@
 {
-  "field.title": [
-    [
-      "message",
-      "站點標題"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "field.origin": [
-    [
-      "message",
-      "站點域名"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "field.description": [
-    [
-      "message",
-      "站點描述"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "field.keywords": [
-    [
-      "message",
-      "站點關鍵詞"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "field.logo": [
-    [
-      "message",
-      "站點 Logo"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "field.favicon": [
-    [
-      "message",
-      "站點 Favicon"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "field.qr": [
-    [
-      "message",
-      "二維碼"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "field.url": [
-    [
-      "message",
-      "連結"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "field.admins": [
-    [
-      "message",
-      "站點管理員 ID"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "field.distributionDefaultInviterId": [
-    [
-      "message",
-      "默認邀請人 ID"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "field.distributionForceInviterId": [
-    [
-      "message",
-      "強制邀請人 ID"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "field.featuresChat": [
-    [
-      "message",
-      "聊天"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "field.featuresVeo": [
-    [
-      "message",
-      "Veo"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "field.featuresSora": [
-    [
-      "message",
-      "Sora"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "field.featuresGrok": [
-    [
-      "message",
-      "Grok"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "field.featuresDeepseek": [
-    [
-      "message",
-      "Deepseek"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "field.featuresChatgpt": [
-    [
-      "message",
-      "ChatGPT"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "field.featuresMidjourney": [
-    [
-      "message",
-      "Midjourney"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "field.featuresChatdoc": [
-    [
-      "message",
-      "Chatdoc"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "field.featuresQrart": [
-    [
-      "message",
-      "Qrart"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "field.featuresLuma": [
-    [
-      "message",
-      "Luma"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "field.featuresPixverse": [
-    [
-      "message",
-      "Pixverse"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "field.featuresPika": [
-    [
-      "message",
-      "Pika"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "field.featuresKling": [
-    [
-      "message",
-      "Kling"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "field.featuresHailuo": [
-    [
-      "message",
-      "Hailuo"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "field.featuresHeadshots": [
-    [
-      "message",
-      "AI 證件照"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "field.featuresSuno": [
-    [
-      "message",
-      "Suno"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "field.featuresFlux": [
-    [
-      "message",
-      "Flux"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "field.featuresNanobanana": [
-    [
-      "message",
-      "Nano Banana"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
+  "field.title": {
+    "message": "站點標題",
+    "description": "展示在編輯框的標題"
+  },
+  "field.origin": {
+    "message": "站點域名",
+    "description": "展示在編輯框的標題"
+  },
+  "field.description": {
+    "message": "站點描述",
+    "description": "展示在編輯框的標題"
+  },
+  "field.keywords": {
+    "message": "站點關鍵詞",
+    "description": "展示在編輯框的標題"
+  },
+  "field.logo": {
+    "message": "站點 Logo",
+    "description": "展示在編輯框的標題"
+  },
+  "field.favicon": {
+    "message": "站點 Favicon",
+    "description": "展示在編輯框的標題"
+  },
+  "field.qr": {
+    "message": "二維碼",
+    "description": "展示在編輯框的標題"
+  },
+  "field.url": {
+    "message": "連結",
+    "description": "展示在編輯框的標題"
+  },
+  "field.admins": {
+    "message": "站點管理員 ID",
+    "description": "展示在編輯框的標題"
+  },
+  "field.distributionDefaultInviterId": {
+    "message": "默認邀請人 ID",
+    "description": "展示在編輯框的標題"
+  },
+  "field.distributionForceInviterId": {
+    "message": "強制邀請人 ID",
+    "description": "展示在編輯框的標題"
+  },
+  "field.featuresChat": {
+    "message": "聊天",
+    "description": "展示在編輯框的標題"
+  },
+  "field.featuresVeo": {
+    "message": "Veo",
+    "description": "展示在編輯框的標題"
+  },
+  "field.featuresSora": {
+    "message": "Sora",
+    "description": "展示在編輯框的標題"
+  },
+  "field.featuresGrok": {
+    "message": "Grok",
+    "description": "展示在編輯框的標題"
+  },
+  "field.featuresDeepseek": {
+    "message": "Deepseek",
+    "description": "展示在編輯框的標題"
+  },
+  "field.featuresChatgpt": {
+    "message": "ChatGPT",
+    "description": "展示在編輯框的標題"
+  },
+  "field.featuresMidjourney": {
+    "message": "Midjourney",
+    "description": "展示在編輯框的標題"
+  },
+  "field.featuresChatdoc": {
+    "message": "Chatdoc",
+    "description": "展示在編輯框的標題"
+  },
+  "field.featuresQrart": {
+    "message": "Qrart",
+    "description": "展示在編輯框的標題"
+  },
+  "field.featuresLuma": {
+    "message": "Luma",
+    "description": "展示在編輯框的標題"
+  },
+  "field.featuresPixverse": {
+    "message": "Pixverse",
+    "description": "展示在編輯框的標題"
+  },
+  "field.featuresPika": {
+    "message": "Pika",
+    "description": "展示在編輯框的標題"
+  },
+  "field.featuresKling": {
+    "message": "Kling",
+    "description": "展示在編輯框的標題"
+  },
+  "field.featuresHailuo": {
+    "message": "Hailuo",
+    "description": "展示在編輯框的標題"
+  },
+  "field.featuresHeadshots": {
+    "message": "AI 證件照",
+    "description": "展示在編輯框的標題"
+  },
+  "field.featuresSuno": {
+    "message": "Suno",
+    "description": "展示在編輯框的標題"
+  },
+  "field.featuresFlux": {
+    "message": "Flux",
+    "description": "展示在編輯框的標題"
+  },
+  "field.featuresNanobanana": {
+    "message": "Nano Banana",
+    "description": "展示在編輯框的標題"
+  },
   "field.featuresOpenaiimage": {
     "message": "OpenAI 圖像",
     "description": "展示在編輯框的標題"
   },
-  "field.featuresSeedream": [
-    [
-      "message",
-      "SeeDream"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "field.featuresSeedance": [
-    [
-      "message",
-      "SeeDance"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "field.featuresWan": [
-    [
-      "message",
-      "Wan"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "field.featuresProducer": [
-    [
-      "message",
-      "製作人"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "field.featuresKimi": [
-    [
-      "message",
-      "Kimi"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "field.featuresSerp": [
-    [
-      "message",
-      "SERP"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "field.featuresSupport": [
-    [
-      "message",
-      "客服支持"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "field.featuresI18n": [
-    [
-      "message",
-      "多語言支持"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "title.basicConfig": [
-    [
-      "message",
-      "基本配置"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "title.seoConfig": [
-    [
-      "message",
-      "SEO 配置"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "title.editAdmins": [
-    [
-      "message",
-      "編輯管理員"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "title.featuresConfig": [
-    [
-      "message",
-      "功能配置"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "title.editTitle": [
-    [
-      "message",
-      "編輯標題"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "title.editOrigin": [
-    [
-      "message",
-      "編輯域名"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "title.editKeywords": [
-    [
-      "message",
-      "編輯關鍵詞"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "title.editLogo": [
-    [
-      "message",
-      "編輯 Logo"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "title.editFavicon": [
-    [
-      "message",
-      "編輯 Favicon"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "title.editDescription": [
-    [
-      "message",
-      "編輯描述"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "title.distributionConfig": [
-    [
-      "message",
-      "分銷配置"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "title.editDistributionDefaultInviterId": [
-    [
-      "message",
-      "編輯默認邀請人"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "title.editDistributionForceInviterId": [
-    [
-      "message",
-      "編輯強制邀請人"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "title.editQR": [
-    [
-      "message",
-      "編輯二維碼"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "title.editUrl": [
-    [
-      "message",
-      "編輯連結"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "placeholder.title": [
-    [
-      "message",
-      "請輸入站點標題"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "placeholder.origin": [
-    [
-      "message",
-      "請輸入站點域名"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "placeholder.editUrl": [
-    [
-      "message",
-      "請輸入連結"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "placeholder.description": [
-    [
-      "message",
-      "請輸入站點描述"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "placeholder.keywords": [
-    [
-      "message",
-      "請輸入站點關鍵詞"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "placeholder.editDistributionDefaultInviterId": [
-    [
-      "message",
-      "請輸入默認邀請人 ID"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "placeholder.editDistributionForceInviterId": [
-    [
-      "message",
-      "請輸入強制邀請人 ID"
-    ],
-    [
-      "description",
-      "展示在編輯框的標題"
-    ]
-  ],
-  "message.uploadImageExceed": [
-    [
-      "message",
-      "上傳圖片超過限制"
-    ],
-    [
-      "description",
-      "上傳圖片超過限制的提示"
-    ]
-  ],
-  "message.uploadImageError": [
-    [
-      "message",
-      "上傳圖片錯誤"
-    ],
-    [
-      "description",
-      "上傳圖片錯誤的提示"
-    ]
-  ],
-  "message.editLogoTip": [
-    [
-      "message",
-      "建議尺寸：200*60px"
-    ],
-    [
-      "description",
-      "上傳圖片的提示語言"
-    ]
-  ],
-  "message.editQRTip": [
-    [
-      "message",
-      "建議尺寸：200*200px"
-    ],
-    [
-      "description",
-      "上傳圖片的提示語言"
-    ]
-  ],
-  "message.editFaviconTip": [
-    [
-      "message",
-      "建議尺寸：32*32px"
-    ],
-    [
-      "description",
-      "上傳圖片的提示語言"
-    ]
-  ],
-  "message.editUrl": [
-    [
-      "message",
-      "請輸入連結"
-    ],
-    [
-      "description",
-      "請輸入連結的提示"
-    ]
-  ],
-  "message.atLeastOneAdmin": [
-    [
-      "message",
-      "至少保留一位管理員"
-    ],
-    [
-      "description",
-      "至少保留一位管理員的提示"
-    ]
-  ],
-  "message.distributionDefaultInviterIdTip": [
-    [
-      "message",
-      "默認邀請人的用戶 ID，分銷連結如果不攜帶 inviter_id 參數，則默認使用該用戶 ID 作為邀請人。"
-    ],
-    [
-      "description",
-      "默認邀請人ID的提示"
-    ]
-  ],
-  "message.distributionForceInviterIdTip": [
-    [
-      "message",
-      "強制邀請人的用戶 ID，如果設置了此 ID，無論分銷連結是否攜帶 inviter_id 參數，則強制使用該用戶 ID 作為邀請人。"
-    ],
-    [
-      "description",
-      "強制邀請人ID的提示"
-    ]
-  ],
-  "message.originTip": [
-    [
-      "message",
-      "站點域名，站點配置與域名綁定，站點域名不可更改。"
-    ],
-    [
-      "description",
-      "站點域名的提示"
-    ]
-  ],
-  "message.titleTip": [
-    [
-      "message",
-      "站點標題，展示在瀏覽器標籤頁。"
-    ],
-    [
-      "description",
-      "站點標題的提示"
-    ]
-  ],
-  "message.descriptionTip": [
-    [
-      "message",
-      "站點描述，位於站點元信息中，用於站點 SEO 優化。"
-    ],
-    [
-      "description",
-      "站點描述的提示"
-    ]
-  ],
-  "message.logoTip": [
-    [
-      "message",
-      "站點 Logo，當菜單欄展開時，展示在站點菜單頂部。"
-    ],
-    [
-      "description",
-      "站點 Logo 的提示"
-    ]
-  ],
-  "message.faviconTip": [
-    [
-      "message",
-      "站點 Favicon，展示在瀏覽器標籤頁。"
-    ],
-    [
-      "description",
-      "站點 Favicon 的提示"
-    ]
-  ],
-  "message.adminsTip": [
-    [
-      "message",
-      "站點管理員 ID，默認首次創建該站點的用戶會成為管理員，只有站點管理員可以管理站點。"
-    ],
-    [
-      "description",
-      "站點管理員的提示"
-    ]
-  ],
-  "message.adminsTip2": [
-    [
-      "message",
-      "可在此處增刪管理員 ID，可到 https://auth.acedata.cloud 查看用戶 ID"
-    ],
-    [
-      "description",
-      "站點管理員的提示"
-    ]
-  ],
-  "message.keywordsTip": [
-    [
-      "message",
-      "站點關鍵詞，位於站點元信息中，用於站點 SEO 優化。"
-    ],
-    [
-      "description",
-      "站點關鍵詞的提示"
-    ]
-  ],
-  "message.keywordsTip2": [
-    [
-      "message",
-      "可在此處增刪網站關鍵詞，關鍵詞越精準，越有利於 SEO 優化。"
-    ],
-    [
-      "description",
-      "站點關鍵詞的提示"
-    ]
-  ],
-  "message.featuresChat": [
-    [
-      "message",
-      "開啟或關閉 Chat 功能模塊。"
-    ],
-    [
-      "description",
-      "Chat 功能的描述"
-    ]
-  ],
-  "message.featuresGrok": [
-    [
-      "message",
-      "開啟或關閉 Grok 功能模塊。"
-    ],
-    [
-      "description",
-      "Grok 功能的描述"
-    ]
-  ],
-  "message.featuresDeepseek": [
-    [
-      "message",
-      "開啟或關閉 Deepseek 功能模塊。"
-    ],
-    [
-      "description",
-      "Deepseek 功能的描述"
-    ]
-  ],
-  "message.featuresChatgpt": [
-    [
-      "message",
-      "開啟或關閉 ChatGPT 功能模塊。"
-    ],
-    [
-      "description",
-      "ChatGPT 功能的描述"
-    ]
-  ],
-  "message.featuresMidjourney": [
-    [
-      "message",
-      "開啟或關閉 Midjourney 功能模塊。"
-    ],
-    [
-      "description",
-      "Midjourney 功能的描述"
-    ]
-  ],
-  "message.featuresChatdoc": [
-    [
-      "message",
-      "開啟或關閉 Chatdoc 功能模塊。"
-    ],
-    [
-      "description",
-      "Chatdoc 功能的描述"
-    ]
-  ],
-  "message.featuresQrart": [
-    [
-      "message",
-      "開啟或關閉 Qrart 功能模塊。"
-    ],
-    [
-      "description",
-      "Qrart 功能的描述"
-    ]
-  ],
-  "message.featuresVeo": [
-    [
-      "message",
-      "開啟或關閉 Veo 功能模塊。"
-    ],
-    [
-      "description",
-      "Veo 功能的描述"
-    ]
-  ],
-  "message.featuresSora": [
-    [
-      "message",
-      "開啟或關閉 Sora 功能模塊。"
-    ],
-    [
-      "description",
-      "Sora 功能的描述"
-    ]
-  ],
-  "message.featuresSuno": [
-    [
-      "message",
-      "開啟或關閉 Suno 功能模塊。"
-    ],
-    [
-      "description",
-      "Suno 功能的描述"
-    ]
-  ],
-  "message.featuresPixverse": [
-    [
-      "message",
-      "開啟或關閉 Pixverse 功能模組。"
-    ],
-    [
-      "description",
-      "Pixverse 功能的描述"
-    ]
-  ],
-  "message.featuresFlux": [
-    [
-      "message",
-      "開啟或關閉 FLux 功能模組。"
-    ],
-    [
-      "description",
-      "FLux 功能的描述"
-    ]
-  ],
-  "message.featuresNanobanana": [
-    [
-      "message",
-      "開啟或關閉 Nano Banana 功能模組。"
-    ],
-    [
-      "description",
-      "Nano Banana 功能的描述"
-    ]
-  ],
+  "field.featuresSeedream": {
+    "message": "SeeDream",
+    "description": "展示在編輯框的標題"
+  },
+  "field.featuresSeedance": {
+    "message": "SeeDance",
+    "description": "展示在編輯框的標題"
+  },
+  "field.featuresWan": {
+    "message": "Wan",
+    "description": "展示在編輯框的標題"
+  },
+  "field.featuresProducer": {
+    "message": "製作人",
+    "description": "展示在編輯框的標題"
+  },
+  "field.featuresKimi": {
+    "message": "Kimi",
+    "description": "展示在編輯框的標題"
+  },
+  "field.featuresSerp": {
+    "message": "SERP",
+    "description": "展示在編輯框的標題"
+  },
+  "field.featuresSupport": {
+    "message": "客服支持",
+    "description": "展示在編輯框的標題"
+  },
+  "field.featuresI18n": {
+    "message": "多語言支持",
+    "description": "展示在編輯框的標題"
+  },
+  "title.basicConfig": {
+    "message": "基本配置",
+    "description": "展示在編輯框的標題"
+  },
+  "title.seoConfig": {
+    "message": "SEO 配置",
+    "description": "展示在編輯框的標題"
+  },
+  "title.editAdmins": {
+    "message": "編輯管理員",
+    "description": "展示在編輯框的標題"
+  },
+  "title.featuresConfig": {
+    "message": "功能配置",
+    "description": "展示在編輯框的標題"
+  },
+  "title.editTitle": {
+    "message": "編輯標題",
+    "description": "展示在編輯框的標題"
+  },
+  "title.editOrigin": {
+    "message": "編輯域名",
+    "description": "展示在編輯框的標題"
+  },
+  "title.editKeywords": {
+    "message": "編輯關鍵詞",
+    "description": "展示在編輯框的標題"
+  },
+  "title.editLogo": {
+    "message": "編輯 Logo",
+    "description": "展示在編輯框的標題"
+  },
+  "title.editFavicon": {
+    "message": "編輯 Favicon",
+    "description": "展示在編輯框的標題"
+  },
+  "title.editDescription": {
+    "message": "編輯描述",
+    "description": "展示在編輯框的標題"
+  },
+  "title.distributionConfig": {
+    "message": "分銷配置",
+    "description": "展示在編輯框的標題"
+  },
+  "title.editDistributionDefaultInviterId": {
+    "message": "編輯默認邀請人",
+    "description": "展示在編輯框的標題"
+  },
+  "title.editDistributionForceInviterId": {
+    "message": "編輯強制邀請人",
+    "description": "展示在編輯框的標題"
+  },
+  "title.editQR": {
+    "message": "編輯二維碼",
+    "description": "展示在編輯框的標題"
+  },
+  "title.editUrl": {
+    "message": "編輯連結",
+    "description": "展示在編輯框的標題"
+  },
+  "placeholder.title": {
+    "message": "請輸入站點標題",
+    "description": "展示在編輯框的標題"
+  },
+  "placeholder.origin": {
+    "message": "請輸入站點域名",
+    "description": "展示在編輯框的標題"
+  },
+  "placeholder.editUrl": {
+    "message": "請輸入連結",
+    "description": "展示在編輯框的標題"
+  },
+  "placeholder.description": {
+    "message": "請輸入站點描述",
+    "description": "展示在編輯框的標題"
+  },
+  "placeholder.keywords": {
+    "message": "請輸入站點關鍵詞",
+    "description": "展示在編輯框的標題"
+  },
+  "placeholder.editDistributionDefaultInviterId": {
+    "message": "請輸入默認邀請人 ID",
+    "description": "展示在編輯框的標題"
+  },
+  "placeholder.editDistributionForceInviterId": {
+    "message": "請輸入強制邀請人 ID",
+    "description": "展示在編輯框的標題"
+  },
+  "message.uploadImageExceed": {
+    "message": "上傳圖片超過限制",
+    "description": "上傳圖片超過限制的提示"
+  },
+  "message.uploadImageError": {
+    "message": "上傳圖片錯誤",
+    "description": "上傳圖片錯誤的提示"
+  },
+  "message.editLogoTip": {
+    "message": "建議尺寸：200*60px",
+    "description": "上傳圖片的提示語言"
+  },
+  "message.editQRTip": {
+    "message": "建議尺寸：200*200px",
+    "description": "上傳圖片的提示語言"
+  },
+  "message.editFaviconTip": {
+    "message": "建議尺寸：32*32px",
+    "description": "上傳圖片的提示語言"
+  },
+  "message.editUrl": {
+    "message": "請輸入連結",
+    "description": "請輸入連結的提示"
+  },
+  "message.atLeastOneAdmin": {
+    "message": "至少保留一位管理員",
+    "description": "至少保留一位管理員的提示"
+  },
+  "message.distributionDefaultInviterIdTip": {
+    "message": "默認邀請人的用戶 ID，分銷連結如果不攜帶 inviter_id 參數，則默認使用該用戶 ID 作為邀請人。",
+    "description": "默認邀請人ID的提示"
+  },
+  "message.distributionForceInviterIdTip": {
+    "message": "強制邀請人的用戶 ID，如果設置了此 ID，無論分銷連結是否攜帶 inviter_id 參數，則強制使用該用戶 ID 作為邀請人。",
+    "description": "強制邀請人ID的提示"
+  },
+  "message.originTip": {
+    "message": "站點域名，站點配置與域名綁定，站點域名不可更改。",
+    "description": "站點域名的提示"
+  },
+  "message.titleTip": {
+    "message": "站點標題，展示在瀏覽器標籤頁。",
+    "description": "站點標題的提示"
+  },
+  "message.descriptionTip": {
+    "message": "站點描述，位於站點元信息中，用於站點 SEO 優化。",
+    "description": "站點描述的提示"
+  },
+  "message.logoTip": {
+    "message": "站點 Logo，當菜單欄展開時，展示在站點菜單頂部。",
+    "description": "站點 Logo 的提示"
+  },
+  "message.faviconTip": {
+    "message": "站點 Favicon，展示在瀏覽器標籤頁。",
+    "description": "站點 Favicon 的提示"
+  },
+  "message.adminsTip": {
+    "message": "站點管理員 ID，默認首次創建該站點的用戶會成為管理員，只有站點管理員可以管理站點。",
+    "description": "站點管理員的提示"
+  },
+  "message.adminsTip2": {
+    "message": "可在此處增刪管理員 ID，可到 https://auth.acedata.cloud 查看用戶 ID",
+    "description": "站點管理員的提示"
+  },
+  "message.keywordsTip": {
+    "message": "站點關鍵詞，位於站點元信息中，用於站點 SEO 優化。",
+    "description": "站點關鍵詞的提示"
+  },
+  "message.keywordsTip2": {
+    "message": "可在此處增刪網站關鍵詞，關鍵詞越精準，越有利於 SEO 優化。",
+    "description": "站點關鍵詞的提示"
+  },
+  "message.featuresChat": {
+    "message": "開啟或關閉 Chat 功能模塊。",
+    "description": "Chat 功能的描述"
+  },
+  "message.featuresGrok": {
+    "message": "開啟或關閉 Grok 功能模塊。",
+    "description": "Grok 功能的描述"
+  },
+  "message.featuresDeepseek": {
+    "message": "開啟或關閉 Deepseek 功能模塊。",
+    "description": "Deepseek 功能的描述"
+  },
+  "message.featuresChatgpt": {
+    "message": "開啟或關閉 ChatGPT 功能模塊。",
+    "description": "ChatGPT 功能的描述"
+  },
+  "message.featuresMidjourney": {
+    "message": "開啟或關閉 Midjourney 功能模塊。",
+    "description": "Midjourney 功能的描述"
+  },
+  "message.featuresChatdoc": {
+    "message": "開啟或關閉 Chatdoc 功能模塊。",
+    "description": "Chatdoc 功能的描述"
+  },
+  "message.featuresQrart": {
+    "message": "開啟或關閉 Qrart 功能模塊。",
+    "description": "Qrart 功能的描述"
+  },
+  "message.featuresVeo": {
+    "message": "開啟或關閉 Veo 功能模塊。",
+    "description": "Veo 功能的描述"
+  },
+  "message.featuresSora": {
+    "message": "開啟或關閉 Sora 功能模塊。",
+    "description": "Sora 功能的描述"
+  },
+  "message.featuresSuno": {
+    "message": "開啟或關閉 Suno 功能模塊。",
+    "description": "Suno 功能的描述"
+  },
+  "message.featuresPixverse": {
+    "message": "開啟或關閉 Pixverse 功能模組。",
+    "description": "Pixverse 功能的描述"
+  },
+  "message.featuresFlux": {
+    "message": "開啟或關閉 FLux 功能模組。",
+    "description": "FLux 功能的描述"
+  },
+  "message.featuresNanobanana": {
+    "message": "開啟或關閉 Nano Banana 功能模組。",
+    "description": "Nano Banana 功能的描述"
+  },
   "message.featuresOpenaiimage": {
     "message": "開啟或關閉 OpenAI 圖像功能模組。",
     "description": "OpenAI 圖像功能的描述"
   },
-  "message.featuresSeedream": [
-    [
-      "message",
-      "開啟或關閉 SeeDream 功能模組。"
-    ],
-    [
-      "description",
-      "SeeDream 功能的描述"
-    ]
-  ],
-  "message.featuresSeedance": [
-    [
-      "message",
-      "啟用或禁用 SeeDance 功能模組。"
-    ],
-    [
-      "description",
-      "SeeDance 功能的描述"
-    ]
-  ],
-  "message.featuresWan": [
-    [
-      "message",
-      "開啟或關閉 Wan 功能模組。"
-    ],
-    [
-      "description",
-      "Wan 功能的描述"
-    ]
-  ],
-  "message.featuresProducer": [
-    [
-      "message",
-      "開啟或關閉 Producer 功能模組。"
-    ],
-    [
-      "description",
-      "Producer 功能的描述"
-    ]
-  ],
-  "message.featuresKimi": [
-    [
-      "message",
-      "開啟或關閉 Kimi 功能模組。"
-    ],
-    [
-      "description",
-      "Kimi 功能的描述"
-    ]
-  ],
-  "message.featuresSerp": [
-    [
-      "message",
-      "開啟或關閉 SERP 功能模組。"
-    ],
-    [
-      "description",
-      "SERP 功能的描述"
-    ]
-  ],
-  "message.featuresLuma": [
-    [
-      "message",
-      "開啟或關閉 Luma 功能模組。"
-    ],
-    [
-      "description",
-      "Luma 功能的描述"
-    ]
-  ],
-  "message.featuresPika": [
-    [
-      "message",
-      "開啟或關閉 Pika 功能模組。"
-    ],
-    [
-      "description",
-      "Pika 功能的描述"
-    ]
-  ],
-  "message.featuresKling": [
-    [
-      "message",
-      "開啟或關閉 Kling 功能模組。"
-    ],
-    [
-      "description",
-      "Kling 功能的描述"
-    ]
-  ],
-  "message.featuresHailuo": [
-    [
-      "message",
-      "開啟或關閉 Hailuo 功能模組。"
-    ],
-    [
-      "description",
-      "Hailuo 功能的描述"
-    ]
-  ],
-  "message.featuresHeadshots": [
-    [
-      "message",
-      "開啟或關閉 AI 證件照 功能模組。"
-    ],
-    [
-      "description",
-      "AI 證件照 功能的描述"
-    ]
-  ],
-  "message.featuresSupport": [
-    [
-      "message",
-      "開啟或關閉客服支持"
-    ],
-    [
-      "description",
-      "Support 功能的描述"
-    ]
-  ],
-  "message.featuresI18n": [
-    [
-      "message",
-      "開啟或關閉多語言支持，關閉後，使用者只能使用預設語言。"
-    ],
-    [
-      "description",
-      "多語言支持的描述"
-    ]
-  ],
-  "button.upload": [
-    [
-      "message",
-      "上傳"
-    ],
-    [
-      "description",
-      "上傳"
-    ]
-  ],
-  "button.enabled": [
-    [
-      "message",
-      "已啟用"
-    ],
-    [
-      "description",
-      "開關文字，表示已經啟用"
-    ]
-  ],
-  "button.disabled": [
-    [
-      "message",
-      "已禁用"
-    ],
-    [
-      "description",
-      "開關文字，表示已經禁用"
-    ]
-  ],
-  "field.featuresGemini": [
-    [
-      "message",
-      "Gemini"
-    ],
-    [
-      "description",
-      "在編輯框中顯示為標題"
-    ]
-  ],
-  "message.featuresGemini": [
-    [
-      "message",
-      "啟用或禁用 Gemini 功能模組。"
-    ],
-    [
-      "description",
-      "Gemini 功能的描述"
-    ]
-  ],
-  "field.featuresClaude": [
-    [
-      "message",
-      "Claude"
-    ],
-    [
-      "description",
-      "在編輯框中顯示為標題"
-    ]
-  ],
-  "message.featuresClaude": [
-    [
-      "message",
-      "啟用或禁用 Claude 功能模組。"
-    ],
-    [
-      "description",
-      "Claude 功能的描述"
-    ]
-  ]
+  "message.featuresSeedream": {
+    "message": "開啟或關閉 SeeDream 功能模組。",
+    "description": "SeeDream 功能的描述"
+  },
+  "message.featuresSeedance": {
+    "message": "啟用或禁用 SeeDance 功能模組。",
+    "description": "SeeDance 功能的描述"
+  },
+  "message.featuresWan": {
+    "message": "開啟或關閉 Wan 功能模組。",
+    "description": "Wan 功能的描述"
+  },
+  "message.featuresProducer": {
+    "message": "開啟或關閉 Producer 功能模組。",
+    "description": "Producer 功能的描述"
+  },
+  "message.featuresKimi": {
+    "message": "開啟或關閉 Kimi 功能模組。",
+    "description": "Kimi 功能的描述"
+  },
+  "message.featuresSerp": {
+    "message": "開啟或關閉 SERP 功能模組。",
+    "description": "SERP 功能的描述"
+  },
+  "message.featuresLuma": {
+    "message": "開啟或關閉 Luma 功能模組。",
+    "description": "Luma 功能的描述"
+  },
+  "message.featuresPika": {
+    "message": "開啟或關閉 Pika 功能模組。",
+    "description": "Pika 功能的描述"
+  },
+  "message.featuresKling": {
+    "message": "開啟或關閉 Kling 功能模組。",
+    "description": "Kling 功能的描述"
+  },
+  "message.featuresHailuo": {
+    "message": "開啟或關閉 Hailuo 功能模組。",
+    "description": "Hailuo 功能的描述"
+  },
+  "message.featuresHeadshots": {
+    "message": "開啟或關閉 AI 證件照 功能模組。",
+    "description": "AI 證件照 功能的描述"
+  },
+  "message.featuresSupport": {
+    "message": "開啟或關閉客服支持",
+    "description": "Support 功能的描述"
+  },
+  "message.featuresI18n": {
+    "message": "開啟或關閉多語言支持，關閉後，使用者只能使用預設語言。",
+    "description": "多語言支持的描述"
+  },
+  "button.upload": {
+    "message": "上傳",
+    "description": "上傳"
+  },
+  "button.enabled": {
+    "message": "已啟用",
+    "description": "開關文字，表示已經啟用"
+  },
+  "button.disabled": {
+    "message": "已禁用",
+    "description": "開關文字，表示已經禁用"
+  },
+  "field.featuresGemini": {
+    "message": "Gemini",
+    "description": "在編輯框中顯示為標題"
+  },
+  "message.featuresGemini": {
+    "message": "啟用或禁用 Gemini 功能模組。",
+    "description": "Gemini 功能的描述"
+  },
+  "field.featuresClaude": {
+    "message": "Claude",
+    "description": "在編輯框中顯示為標題"
+  },
+  "message.featuresClaude": {
+    "message": "啟用或禁用 Claude 功能模組。",
+    "description": "Claude 功能的描述"
+  }
 }

--- a/src/i18n/zh-TW/site.json
+++ b/src/i18n/zh-TW/site.json
@@ -1,442 +1,1110 @@
 {
-  "field.title": {
-    "message": "站點標題",
+  "field.title": [
+    [
+      "message",
+      "站點標題"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "field.origin": [
+    [
+      "message",
+      "站點域名"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "field.description": [
+    [
+      "message",
+      "站點描述"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "field.keywords": [
+    [
+      "message",
+      "站點關鍵詞"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "field.logo": [
+    [
+      "message",
+      "站點 Logo"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "field.favicon": [
+    [
+      "message",
+      "站點 Favicon"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "field.qr": [
+    [
+      "message",
+      "二維碼"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "field.url": [
+    [
+      "message",
+      "連結"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "field.admins": [
+    [
+      "message",
+      "站點管理員 ID"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "field.distributionDefaultInviterId": [
+    [
+      "message",
+      "默認邀請人 ID"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "field.distributionForceInviterId": [
+    [
+      "message",
+      "強制邀請人 ID"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "field.featuresChat": [
+    [
+      "message",
+      "聊天"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "field.featuresVeo": [
+    [
+      "message",
+      "Veo"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "field.featuresSora": [
+    [
+      "message",
+      "Sora"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "field.featuresGrok": [
+    [
+      "message",
+      "Grok"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "field.featuresDeepseek": [
+    [
+      "message",
+      "Deepseek"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "field.featuresChatgpt": [
+    [
+      "message",
+      "ChatGPT"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "field.featuresMidjourney": [
+    [
+      "message",
+      "Midjourney"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "field.featuresChatdoc": [
+    [
+      "message",
+      "Chatdoc"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "field.featuresQrart": [
+    [
+      "message",
+      "Qrart"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "field.featuresLuma": [
+    [
+      "message",
+      "Luma"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "field.featuresPixverse": [
+    [
+      "message",
+      "Pixverse"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "field.featuresPika": [
+    [
+      "message",
+      "Pika"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "field.featuresKling": [
+    [
+      "message",
+      "Kling"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "field.featuresHailuo": [
+    [
+      "message",
+      "Hailuo"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "field.featuresHeadshots": [
+    [
+      "message",
+      "AI 證件照"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "field.featuresSuno": [
+    [
+      "message",
+      "Suno"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "field.featuresFlux": [
+    [
+      "message",
+      "Flux"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "field.featuresNanobanana": [
+    [
+      "message",
+      "Nano Banana"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "field.featuresOpenaiimage": {
+    "message": "OpenAI 圖像",
     "description": "展示在編輯框的標題"
   },
-  "field.origin": {
-    "message": "站點域名",
-    "description": "展示在編輯框的標題"
-  },
-  "field.description": {
-    "message": "站點描述",
-    "description": "展示在編輯框的標題"
-  },
-  "field.keywords": {
-    "message": "站點關鍵詞",
-    "description": "展示在編輯框的標題"
-  },
-  "field.logo": {
-    "message": "站點 Logo",
-    "description": "展示在編輯框的標題"
-  },
-  "field.favicon": {
-    "message": "站點 Favicon",
-    "description": "展示在編輯框的標題"
-  },
-  "field.qr": {
-    "message": "二維碼",
-    "description": "展示在編輯框的標題"
-  },
-  "field.url": {
-    "message": "連結",
-    "description": "展示在編輯框的標題"
-  },
-  "field.admins": {
-    "message": "站點管理員 ID",
-    "description": "展示在編輯框的標題"
-  },
-  "field.distributionDefaultInviterId": {
-    "message": "默認邀請人 ID",
-    "description": "展示在編輯框的標題"
-  },
-  "field.distributionForceInviterId": {
-    "message": "強制邀請人 ID",
-    "description": "展示在編輯框的標題"
-  },
-  "field.featuresChat": {
-    "message": "聊天",
-    "description": "展示在編輯框的標題"
-  },
-  "field.featuresVeo": {
-    "message": "Veo",
-    "description": "展示在編輯框的標題"
-  },
-  "field.featuresSora": {
-    "message": "Sora",
-    "description": "展示在編輯框的標題"
-  },
-  "field.featuresGrok": {
-    "message": "Grok",
-    "description": "展示在編輯框的標題"
-  },
-  "field.featuresDeepseek": {
-    "message": "Deepseek",
-    "description": "展示在編輯框的標題"
-  },
-  "field.featuresChatgpt": {
-    "message": "ChatGPT",
-    "description": "展示在編輯框的標題"
-  },
-  "field.featuresMidjourney": {
-    "message": "Midjourney",
-    "description": "展示在編輯框的標題"
-  },
-  "field.featuresChatdoc": {
-    "message": "Chatdoc",
-    "description": "展示在編輯框的標題"
-  },
-  "field.featuresQrart": {
-    "message": "Qrart",
-    "description": "展示在編輯框的標題"
-  },
-  "field.featuresLuma": {
-    "message": "Luma",
-    "description": "展示在編輯框的標題"
-  },
-  "field.featuresPixverse": {
-    "message": "Pixverse",
-    "description": "展示在編輯框的標題"
-  },
-  "field.featuresPika": {
-    "message": "Pika",
-    "description": "展示在編輯框的標題"
-  },
-  "field.featuresKling": {
-    "message": "Kling",
-    "description": "展示在編輯框的標題"
-  },
-  "field.featuresHailuo": {
-    "message": "Hailuo",
-    "description": "展示在編輯框的標題"
-  },
-  "field.featuresHeadshots": {
-    "message": "AI 證件照",
-    "description": "展示在編輯框的標題"
-  },
-  "field.featuresSuno": {
-    "message": "Suno",
-    "description": "展示在編輯框的標題"
-  },
-  "field.featuresFlux": {
-    "message": "Flux",
-    "description": "展示在編輯框的標題"
-  },
-  "field.featuresNanobanana": {
-    "message": "Nano Banana",
-    "description": "展示在編輯框的標題"
-  },
-  "field.featuresSeedream": {
-    "message": "SeeDream",
-    "description": "展示在編輯框的標題"
-  },
-  "field.featuresSeedance": {
-    "message": "SeeDance",
-    "description": "展示在編輯框的標題"
-  },
-  "field.featuresWan": {
-    "message": "Wan",
-    "description": "展示在編輯框的標題"
-  },
-  "field.featuresProducer": {
-    "message": "製作人",
-    "description": "展示在編輯框的標題"
-  },
-  "field.featuresKimi": {
-    "message": "Kimi",
-    "description": "展示在編輯框的標題"
-  },
-  "field.featuresSerp": {
-    "message": "SERP",
-    "description": "展示在編輯框的標題"
-  },
-  "field.featuresSupport": {
-    "message": "客服支持",
-    "description": "展示在編輯框的標題"
-  },
-  "field.featuresI18n": {
-    "message": "多語言支持",
-    "description": "展示在編輯框的標題"
-  },
-  "title.basicConfig": {
-    "message": "基本配置",
-    "description": "展示在編輯框的標題"
-  },
-  "title.seoConfig": {
-    "message": "SEO 配置",
-    "description": "展示在編輯框的標題"
-  },
-  "title.editAdmins": {
-    "message": "編輯管理員",
-    "description": "展示在編輯框的標題"
-  },
-  "title.featuresConfig": {
-    "message": "功能配置",
-    "description": "展示在編輯框的標題"
-  },
-  "title.editTitle": {
-    "message": "編輯標題",
-    "description": "展示在編輯框的標題"
-  },
-  "title.editOrigin": {
-    "message": "編輯域名",
-    "description": "展示在編輯框的標題"
-  },
-  "title.editKeywords": {
-    "message": "編輯關鍵詞",
-    "description": "展示在編輯框的標題"
-  },
-  "title.editLogo": {
-    "message": "編輯 Logo",
-    "description": "展示在編輯框的標題"
-  },
-  "title.editFavicon": {
-    "message": "編輯 Favicon",
-    "description": "展示在編輯框的標題"
-  },
-  "title.editDescription": {
-    "message": "編輯描述",
-    "description": "展示在編輯框的標題"
-  },
-  "title.distributionConfig": {
-    "message": "分銷配置",
-    "description": "展示在編輯框的標題"
-  },
-  "title.editDistributionDefaultInviterId": {
-    "message": "編輯默認邀請人",
-    "description": "展示在編輯框的標題"
-  },
-  "title.editDistributionForceInviterId": {
-    "message": "編輯強制邀請人",
-    "description": "展示在編輯框的標題"
-  },
-  "title.editQR": {
-    "message": "編輯二維碼",
-    "description": "展示在編輯框的標題"
-  },
-  "title.editUrl": {
-    "message": "編輯連結",
-    "description": "展示在編輯框的標題"
-  },
-  "placeholder.title": {
-    "message": "請輸入站點標題",
-    "description": "展示在編輯框的標題"
-  },
-  "placeholder.origin": {
-    "message": "請輸入站點域名",
-    "description": "展示在編輯框的標題"
-  },
-  "placeholder.editUrl": {
-    "message": "請輸入連結",
-    "description": "展示在編輯框的標題"
-  },
-  "placeholder.description": {
-    "message": "請輸入站點描述",
-    "description": "展示在編輯框的標題"
-  },
-  "placeholder.keywords": {
-    "message": "請輸入站點關鍵詞",
-    "description": "展示在編輯框的標題"
-  },
-  "placeholder.editDistributionDefaultInviterId": {
-    "message": "請輸入默認邀請人 ID",
-    "description": "展示在編輯框的標題"
-  },
-  "placeholder.editDistributionForceInviterId": {
-    "message": "請輸入強制邀請人 ID",
-    "description": "展示在編輯框的標題"
-  },
-  "message.uploadImageExceed": {
-    "message": "上傳圖片超過限制",
-    "description": "上傳圖片超過限制的提示"
-  },
-  "message.uploadImageError": {
-    "message": "上傳圖片錯誤",
-    "description": "上傳圖片錯誤的提示"
-  },
-  "message.editLogoTip": {
-    "message": "建議尺寸：200*60px",
-    "description": "上傳圖片的提示語言"
-  },
-  "message.editQRTip": {
-    "message": "建議尺寸：200*200px",
-    "description": "上傳圖片的提示語言"
-  },
-  "message.editFaviconTip": {
-    "message": "建議尺寸：32*32px",
-    "description": "上傳圖片的提示語言"
-  },
-  "message.editUrl": {
-    "message": "請輸入連結",
-    "description": "請輸入連結的提示"
-  },
-  "message.atLeastOneAdmin": {
-    "message": "至少保留一位管理員",
-    "description": "至少保留一位管理員的提示"
-  },
-  "message.distributionDefaultInviterIdTip": {
-    "message": "默認邀請人的用戶 ID，分銷連結如果不攜帶 inviter_id 參數，則默認使用該用戶 ID 作為邀請人。",
-    "description": "默認邀請人ID的提示"
-  },
-  "message.distributionForceInviterIdTip": {
-    "message": "強制邀請人的用戶 ID，如果設置了此 ID，無論分銷連結是否攜帶 inviter_id 參數，則強制使用該用戶 ID 作為邀請人。",
-    "description": "強制邀請人ID的提示"
-  },
-  "message.originTip": {
-    "message": "站點域名，站點配置與域名綁定，站點域名不可更改。",
-    "description": "站點域名的提示"
-  },
-  "message.titleTip": {
-    "message": "站點標題，展示在瀏覽器標籤頁。",
-    "description": "站點標題的提示"
-  },
-  "message.descriptionTip": {
-    "message": "站點描述，位於站點元信息中，用於站點 SEO 優化。",
-    "description": "站點描述的提示"
-  },
-  "message.logoTip": {
-    "message": "站點 Logo，當菜單欄展開時，展示在站點菜單頂部。",
-    "description": "站點 Logo 的提示"
-  },
-  "message.faviconTip": {
-    "message": "站點 Favicon，展示在瀏覽器標籤頁。",
-    "description": "站點 Favicon 的提示"
-  },
-  "message.adminsTip": {
-    "message": "站點管理員 ID，默認首次創建該站點的用戶會成為管理員，只有站點管理員可以管理站點。",
-    "description": "站點管理員的提示"
-  },
-  "message.adminsTip2": {
-    "message": "可在此處增刪管理員 ID，可到 https://auth.acedata.cloud 查看用戶 ID",
-    "description": "站點管理員的提示"
-  },
-  "message.keywordsTip": {
-    "message": "站點關鍵詞，位於站點元信息中，用於站點 SEO 優化。",
-    "description": "站點關鍵詞的提示"
-  },
-  "message.keywordsTip2": {
-    "message": "可在此處增刪網站關鍵詞，關鍵詞越精準，越有利於 SEO 優化。",
-    "description": "站點關鍵詞的提示"
-  },
-  "message.featuresChat": {
-    "message": "開啟或關閉 Chat 功能模塊。",
-    "description": "Chat 功能的描述"
-  },
-  "message.featuresGrok": {
-    "message": "開啟或關閉 Grok 功能模塊。",
-    "description": "Grok 功能的描述"
-  },
-  "message.featuresDeepseek": {
-    "message": "開啟或關閉 Deepseek 功能模塊。",
-    "description": "Deepseek 功能的描述"
-  },
-  "message.featuresChatgpt": {
-    "message": "開啟或關閉 ChatGPT 功能模塊。",
-    "description": "ChatGPT 功能的描述"
-  },
-  "message.featuresMidjourney": {
-    "message": "開啟或關閉 Midjourney 功能模塊。",
-    "description": "Midjourney 功能的描述"
-  },
-  "message.featuresChatdoc": {
-    "message": "開啟或關閉 Chatdoc 功能模塊。",
-    "description": "Chatdoc 功能的描述"
-  },
-  "message.featuresQrart": {
-    "message": "開啟或關閉 Qrart 功能模塊。",
-    "description": "Qrart 功能的描述"
-  },
-  "message.featuresVeo": {
-    "message": "開啟或關閉 Veo 功能模塊。",
-    "description": "Veo 功能的描述"
-  },
-  "message.featuresSora": {
-    "message": "開啟或關閉 Sora 功能模塊。",
-    "description": "Sora 功能的描述"
-  },
-  "message.featuresSuno": {
-    "message": "開啟或關閉 Suno 功能模塊。",
-    "description": "Suno 功能的描述"
-  },
-  "message.featuresPixverse": {
-    "message": "開啟或關閉 Pixverse 功能模組。",
-    "description": "Pixverse 功能的描述"
-  },
-  "message.featuresFlux": {
-    "message": "開啟或關閉 FLux 功能模組。",
-    "description": "FLux 功能的描述"
-  },
-  "message.featuresNanobanana": {
-    "message": "開啟或關閉 Nano Banana 功能模組。",
-    "description": "Nano Banana 功能的描述"
-  },
-  "message.featuresSeedream": {
-    "message": "開啟或關閉 SeeDream 功能模組。",
-    "description": "SeeDream 功能的描述"
-  },
-  "message.featuresSeedance": {
-    "message": "啟用或禁用 SeeDance 功能模組。",
-    "description": "SeeDance 功能的描述"
-  },
-  "message.featuresWan": {
-    "message": "開啟或關閉 Wan 功能模組。",
-    "description": "Wan 功能的描述"
-  },
-  "message.featuresProducer": {
-    "message": "開啟或關閉 Producer 功能模組。",
-    "description": "Producer 功能的描述"
-  },
-  "message.featuresKimi": {
-    "message": "開啟或關閉 Kimi 功能模組。",
-    "description": "Kimi 功能的描述"
-  },
-  "message.featuresSerp": {
-    "message": "開啟或關閉 SERP 功能模組。",
-    "description": "SERP 功能的描述"
-  },
-  "message.featuresLuma": {
-    "message": "開啟或關閉 Luma 功能模組。",
-    "description": "Luma 功能的描述"
-  },
-  "message.featuresPika": {
-    "message": "開啟或關閉 Pika 功能模組。",
-    "description": "Pika 功能的描述"
-  },
-  "message.featuresKling": {
-    "message": "開啟或關閉 Kling 功能模組。",
-    "description": "Kling 功能的描述"
-  },
-  "message.featuresHailuo": {
-    "message": "開啟或關閉 Hailuo 功能模組。",
-    "description": "Hailuo 功能的描述"
-  },
-  "message.featuresHeadshots": {
-    "message": "開啟或關閉 AI 證件照 功能模組。",
-    "description": "AI 證件照 功能的描述"
-  },
-  "message.featuresSupport": {
-    "message": "開啟或關閉客服支持",
-    "description": "Support 功能的描述"
-  },
-  "message.featuresI18n": {
-    "message": "開啟或關閉多語言支持，關閉後，使用者只能使用預設語言。",
-    "description": "多語言支持的描述"
-  },
-  "button.upload": {
-    "message": "上傳",
-    "description": "上傳"
-  },
-  "button.enabled": {
-    "message": "已啟用",
-    "description": "開關文字，表示已經啟用"
-  },
-  "button.disabled": {
-    "message": "已禁用",
-    "description": "開關文字，表示已經禁用"
-  },
-  "field.featuresGemini": {
-    "message": "Gemini",
-    "description": "在編輯框中顯示為標題"
-  },
-  "message.featuresGemini": {
-    "message": "啟用或禁用 Gemini 功能模組。",
-    "description": "Gemini 功能的描述"
-  },
-  "field.featuresClaude": {
-    "message": "Claude",
-    "description": "在編輯框中顯示為標題"
-  },
-  "message.featuresClaude": {
-    "message": "啟用或禁用 Claude 功能模組。",
-    "description": "Claude 功能的描述"
-  }
+  "field.featuresSeedream": [
+    [
+      "message",
+      "SeeDream"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "field.featuresSeedance": [
+    [
+      "message",
+      "SeeDance"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "field.featuresWan": [
+    [
+      "message",
+      "Wan"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "field.featuresProducer": [
+    [
+      "message",
+      "製作人"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "field.featuresKimi": [
+    [
+      "message",
+      "Kimi"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "field.featuresSerp": [
+    [
+      "message",
+      "SERP"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "field.featuresSupport": [
+    [
+      "message",
+      "客服支持"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "field.featuresI18n": [
+    [
+      "message",
+      "多語言支持"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "title.basicConfig": [
+    [
+      "message",
+      "基本配置"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "title.seoConfig": [
+    [
+      "message",
+      "SEO 配置"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "title.editAdmins": [
+    [
+      "message",
+      "編輯管理員"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "title.featuresConfig": [
+    [
+      "message",
+      "功能配置"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "title.editTitle": [
+    [
+      "message",
+      "編輯標題"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "title.editOrigin": [
+    [
+      "message",
+      "編輯域名"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "title.editKeywords": [
+    [
+      "message",
+      "編輯關鍵詞"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "title.editLogo": [
+    [
+      "message",
+      "編輯 Logo"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "title.editFavicon": [
+    [
+      "message",
+      "編輯 Favicon"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "title.editDescription": [
+    [
+      "message",
+      "編輯描述"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "title.distributionConfig": [
+    [
+      "message",
+      "分銷配置"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "title.editDistributionDefaultInviterId": [
+    [
+      "message",
+      "編輯默認邀請人"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "title.editDistributionForceInviterId": [
+    [
+      "message",
+      "編輯強制邀請人"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "title.editQR": [
+    [
+      "message",
+      "編輯二維碼"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "title.editUrl": [
+    [
+      "message",
+      "編輯連結"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "placeholder.title": [
+    [
+      "message",
+      "請輸入站點標題"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "placeholder.origin": [
+    [
+      "message",
+      "請輸入站點域名"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "placeholder.editUrl": [
+    [
+      "message",
+      "請輸入連結"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "placeholder.description": [
+    [
+      "message",
+      "請輸入站點描述"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "placeholder.keywords": [
+    [
+      "message",
+      "請輸入站點關鍵詞"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "placeholder.editDistributionDefaultInviterId": [
+    [
+      "message",
+      "請輸入默認邀請人 ID"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "placeholder.editDistributionForceInviterId": [
+    [
+      "message",
+      "請輸入強制邀請人 ID"
+    ],
+    [
+      "description",
+      "展示在編輯框的標題"
+    ]
+  ],
+  "message.uploadImageExceed": [
+    [
+      "message",
+      "上傳圖片超過限制"
+    ],
+    [
+      "description",
+      "上傳圖片超過限制的提示"
+    ]
+  ],
+  "message.uploadImageError": [
+    [
+      "message",
+      "上傳圖片錯誤"
+    ],
+    [
+      "description",
+      "上傳圖片錯誤的提示"
+    ]
+  ],
+  "message.editLogoTip": [
+    [
+      "message",
+      "建議尺寸：200*60px"
+    ],
+    [
+      "description",
+      "上傳圖片的提示語言"
+    ]
+  ],
+  "message.editQRTip": [
+    [
+      "message",
+      "建議尺寸：200*200px"
+    ],
+    [
+      "description",
+      "上傳圖片的提示語言"
+    ]
+  ],
+  "message.editFaviconTip": [
+    [
+      "message",
+      "建議尺寸：32*32px"
+    ],
+    [
+      "description",
+      "上傳圖片的提示語言"
+    ]
+  ],
+  "message.editUrl": [
+    [
+      "message",
+      "請輸入連結"
+    ],
+    [
+      "description",
+      "請輸入連結的提示"
+    ]
+  ],
+  "message.atLeastOneAdmin": [
+    [
+      "message",
+      "至少保留一位管理員"
+    ],
+    [
+      "description",
+      "至少保留一位管理員的提示"
+    ]
+  ],
+  "message.distributionDefaultInviterIdTip": [
+    [
+      "message",
+      "默認邀請人的用戶 ID，分銷連結如果不攜帶 inviter_id 參數，則默認使用該用戶 ID 作為邀請人。"
+    ],
+    [
+      "description",
+      "默認邀請人ID的提示"
+    ]
+  ],
+  "message.distributionForceInviterIdTip": [
+    [
+      "message",
+      "強制邀請人的用戶 ID，如果設置了此 ID，無論分銷連結是否攜帶 inviter_id 參數，則強制使用該用戶 ID 作為邀請人。"
+    ],
+    [
+      "description",
+      "強制邀請人ID的提示"
+    ]
+  ],
+  "message.originTip": [
+    [
+      "message",
+      "站點域名，站點配置與域名綁定，站點域名不可更改。"
+    ],
+    [
+      "description",
+      "站點域名的提示"
+    ]
+  ],
+  "message.titleTip": [
+    [
+      "message",
+      "站點標題，展示在瀏覽器標籤頁。"
+    ],
+    [
+      "description",
+      "站點標題的提示"
+    ]
+  ],
+  "message.descriptionTip": [
+    [
+      "message",
+      "站點描述，位於站點元信息中，用於站點 SEO 優化。"
+    ],
+    [
+      "description",
+      "站點描述的提示"
+    ]
+  ],
+  "message.logoTip": [
+    [
+      "message",
+      "站點 Logo，當菜單欄展開時，展示在站點菜單頂部。"
+    ],
+    [
+      "description",
+      "站點 Logo 的提示"
+    ]
+  ],
+  "message.faviconTip": [
+    [
+      "message",
+      "站點 Favicon，展示在瀏覽器標籤頁。"
+    ],
+    [
+      "description",
+      "站點 Favicon 的提示"
+    ]
+  ],
+  "message.adminsTip": [
+    [
+      "message",
+      "站點管理員 ID，默認首次創建該站點的用戶會成為管理員，只有站點管理員可以管理站點。"
+    ],
+    [
+      "description",
+      "站點管理員的提示"
+    ]
+  ],
+  "message.adminsTip2": [
+    [
+      "message",
+      "可在此處增刪管理員 ID，可到 https://auth.acedata.cloud 查看用戶 ID"
+    ],
+    [
+      "description",
+      "站點管理員的提示"
+    ]
+  ],
+  "message.keywordsTip": [
+    [
+      "message",
+      "站點關鍵詞，位於站點元信息中，用於站點 SEO 優化。"
+    ],
+    [
+      "description",
+      "站點關鍵詞的提示"
+    ]
+  ],
+  "message.keywordsTip2": [
+    [
+      "message",
+      "可在此處增刪網站關鍵詞，關鍵詞越精準，越有利於 SEO 優化。"
+    ],
+    [
+      "description",
+      "站點關鍵詞的提示"
+    ]
+  ],
+  "message.featuresChat": [
+    [
+      "message",
+      "開啟或關閉 Chat 功能模塊。"
+    ],
+    [
+      "description",
+      "Chat 功能的描述"
+    ]
+  ],
+  "message.featuresGrok": [
+    [
+      "message",
+      "開啟或關閉 Grok 功能模塊。"
+    ],
+    [
+      "description",
+      "Grok 功能的描述"
+    ]
+  ],
+  "message.featuresDeepseek": [
+    [
+      "message",
+      "開啟或關閉 Deepseek 功能模塊。"
+    ],
+    [
+      "description",
+      "Deepseek 功能的描述"
+    ]
+  ],
+  "message.featuresChatgpt": [
+    [
+      "message",
+      "開啟或關閉 ChatGPT 功能模塊。"
+    ],
+    [
+      "description",
+      "ChatGPT 功能的描述"
+    ]
+  ],
+  "message.featuresMidjourney": [
+    [
+      "message",
+      "開啟或關閉 Midjourney 功能模塊。"
+    ],
+    [
+      "description",
+      "Midjourney 功能的描述"
+    ]
+  ],
+  "message.featuresChatdoc": [
+    [
+      "message",
+      "開啟或關閉 Chatdoc 功能模塊。"
+    ],
+    [
+      "description",
+      "Chatdoc 功能的描述"
+    ]
+  ],
+  "message.featuresQrart": [
+    [
+      "message",
+      "開啟或關閉 Qrart 功能模塊。"
+    ],
+    [
+      "description",
+      "Qrart 功能的描述"
+    ]
+  ],
+  "message.featuresVeo": [
+    [
+      "message",
+      "開啟或關閉 Veo 功能模塊。"
+    ],
+    [
+      "description",
+      "Veo 功能的描述"
+    ]
+  ],
+  "message.featuresSora": [
+    [
+      "message",
+      "開啟或關閉 Sora 功能模塊。"
+    ],
+    [
+      "description",
+      "Sora 功能的描述"
+    ]
+  ],
+  "message.featuresSuno": [
+    [
+      "message",
+      "開啟或關閉 Suno 功能模塊。"
+    ],
+    [
+      "description",
+      "Suno 功能的描述"
+    ]
+  ],
+  "message.featuresPixverse": [
+    [
+      "message",
+      "開啟或關閉 Pixverse 功能模組。"
+    ],
+    [
+      "description",
+      "Pixverse 功能的描述"
+    ]
+  ],
+  "message.featuresFlux": [
+    [
+      "message",
+      "開啟或關閉 FLux 功能模組。"
+    ],
+    [
+      "description",
+      "FLux 功能的描述"
+    ]
+  ],
+  "message.featuresNanobanana": [
+    [
+      "message",
+      "開啟或關閉 Nano Banana 功能模組。"
+    ],
+    [
+      "description",
+      "Nano Banana 功能的描述"
+    ]
+  ],
+  "message.featuresOpenaiimage": {
+    "message": "開啟或關閉 OpenAI 圖像功能模組。",
+    "description": "OpenAI 圖像功能的描述"
+  },
+  "message.featuresSeedream": [
+    [
+      "message",
+      "開啟或關閉 SeeDream 功能模組。"
+    ],
+    [
+      "description",
+      "SeeDream 功能的描述"
+    ]
+  ],
+  "message.featuresSeedance": [
+    [
+      "message",
+      "啟用或禁用 SeeDance 功能模組。"
+    ],
+    [
+      "description",
+      "SeeDance 功能的描述"
+    ]
+  ],
+  "message.featuresWan": [
+    [
+      "message",
+      "開啟或關閉 Wan 功能模組。"
+    ],
+    [
+      "description",
+      "Wan 功能的描述"
+    ]
+  ],
+  "message.featuresProducer": [
+    [
+      "message",
+      "開啟或關閉 Producer 功能模組。"
+    ],
+    [
+      "description",
+      "Producer 功能的描述"
+    ]
+  ],
+  "message.featuresKimi": [
+    [
+      "message",
+      "開啟或關閉 Kimi 功能模組。"
+    ],
+    [
+      "description",
+      "Kimi 功能的描述"
+    ]
+  ],
+  "message.featuresSerp": [
+    [
+      "message",
+      "開啟或關閉 SERP 功能模組。"
+    ],
+    [
+      "description",
+      "SERP 功能的描述"
+    ]
+  ],
+  "message.featuresLuma": [
+    [
+      "message",
+      "開啟或關閉 Luma 功能模組。"
+    ],
+    [
+      "description",
+      "Luma 功能的描述"
+    ]
+  ],
+  "message.featuresPika": [
+    [
+      "message",
+      "開啟或關閉 Pika 功能模組。"
+    ],
+    [
+      "description",
+      "Pika 功能的描述"
+    ]
+  ],
+  "message.featuresKling": [
+    [
+      "message",
+      "開啟或關閉 Kling 功能模組。"
+    ],
+    [
+      "description",
+      "Kling 功能的描述"
+    ]
+  ],
+  "message.featuresHailuo": [
+    [
+      "message",
+      "開啟或關閉 Hailuo 功能模組。"
+    ],
+    [
+      "description",
+      "Hailuo 功能的描述"
+    ]
+  ],
+  "message.featuresHeadshots": [
+    [
+      "message",
+      "開啟或關閉 AI 證件照 功能模組。"
+    ],
+    [
+      "description",
+      "AI 證件照 功能的描述"
+    ]
+  ],
+  "message.featuresSupport": [
+    [
+      "message",
+      "開啟或關閉客服支持"
+    ],
+    [
+      "description",
+      "Support 功能的描述"
+    ]
+  ],
+  "message.featuresI18n": [
+    [
+      "message",
+      "開啟或關閉多語言支持，關閉後，使用者只能使用預設語言。"
+    ],
+    [
+      "description",
+      "多語言支持的描述"
+    ]
+  ],
+  "button.upload": [
+    [
+      "message",
+      "上傳"
+    ],
+    [
+      "description",
+      "上傳"
+    ]
+  ],
+  "button.enabled": [
+    [
+      "message",
+      "已啟用"
+    ],
+    [
+      "description",
+      "開關文字，表示已經啟用"
+    ]
+  ],
+  "button.disabled": [
+    [
+      "message",
+      "已禁用"
+    ],
+    [
+      "description",
+      "開關文字，表示已經禁用"
+    ]
+  ],
+  "field.featuresGemini": [
+    [
+      "message",
+      "Gemini"
+    ],
+    [
+      "description",
+      "在編輯框中顯示為標題"
+    ]
+  ],
+  "message.featuresGemini": [
+    [
+      "message",
+      "啟用或禁用 Gemini 功能模組。"
+    ],
+    [
+      "description",
+      "Gemini 功能的描述"
+    ]
+  ],
+  "field.featuresClaude": [
+    [
+      "message",
+      "Claude"
+    ],
+    [
+      "description",
+      "在編輯框中顯示為標題"
+    ]
+  ],
+  "message.featuresClaude": [
+    [
+      "message",
+      "啟用或禁用 Claude 功能模組。"
+    ],
+    [
+      "description",
+      "Claude 功能的描述"
+    ]
+  ]
 }

--- a/src/pages/site/Index.vue
+++ b/src/pages/site/Index.vue
@@ -179,6 +179,7 @@
                   'midjourney',
                   'qrart',
                   'nanobanana',
+                  'openaiimage',
                   'seedream',
                   'seedance',
                   'suno',

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,6 +1,5 @@
 import { createRouter, createWebHistory } from 'vue-router';
 import store from '@/store';
-import type { ISiteFeatures } from '@/models/site';
 import auth from './auth';
 import console from './console';
 import grok from './grok';
@@ -43,6 +42,7 @@ import {
   ROUTE_MIDJOURNEY_INDEX,
   ROUTE_FLUX_INDEX,
   ROUTE_NANOBANANA_INDEX,
+  ROUTE_OPENAIIMAGE_INDEX,
   ROUTE_SEEDREAM_INDEX,
   ROUTE_SUNO_INDEX,
   ROUTE_PRODUCER_INDEX,
@@ -54,7 +54,7 @@ import {
   ROUTE_SORA_INDEX,
   ROUTE_PIXVERSE_INDEX,
   ROUTE_WAN_INDEX,
-  ROUTE_SERP_INDEX,
+  ROUTE_SERP_INDEX
 } from './constants';
 import { getCookie } from 'typescript-cookie';
 import { I18N_DEFAULT_LOCALE } from '@/constants/i18n';
@@ -223,69 +223,57 @@ const ROUTE_SEO: Record<string, { title: string; description: string; keywords: 
   }
 };
 
-const FEATURE_ROUTE_ORDER: Array<keyof ISiteFeatures> = [
-  'chatgpt',
-  'deepseek',
-  'grok',
-  'gemini',
-  'claude',
-  'kimi',
-  'midjourney',
-  'flux',
-  'nanobanana',
-  'seedream',
-  'suno',
-  'producer',
-  'seedance',
-  'luma',
-  'hailuo',
-  'kling',
-  'veo',
-  'sora',
-  'pixverse',
-  'wan',
-  'serp',
-];
+// Map every routeable feature key to the route name it should land on.
+// Note: this map only declares "this feature has a landing page". The order
+// of the user's default route is taken from the site's `features` config
+// (insertion order returned by the API), NOT from this map — so operators
+// can control which feature greets new visitors by ordering site.features.
+const FEATURE_ROUTE_NAME: Record<string, string> = {
+  chatgpt: ROUTE_CHATGPT_CONVERSATION_NEW,
+  deepseek: ROUTE_DEEPSEEK_CONVERSATION_NEW,
+  grok: ROUTE_GROK_CONVERSATION_NEW,
+  gemini: ROUTE_GEMINI_CONVERSATION_NEW,
+  claude: ROUTE_CLAUDE_CONVERSATION_NEW,
+  kimi: ROUTE_KIMI_CONVERSATION_NEW,
+  midjourney: ROUTE_MIDJOURNEY_INDEX,
+  flux: ROUTE_FLUX_INDEX,
+  nanobanana: ROUTE_NANOBANANA_INDEX,
+  openaiimage: ROUTE_OPENAIIMAGE_INDEX,
+  seedream: ROUTE_SEEDREAM_INDEX,
+  suno: ROUTE_SUNO_INDEX,
+  producer: ROUTE_PRODUCER_INDEX,
+  seedance: ROUTE_SEEDANCE_INDEX,
+  luma: ROUTE_LUMA_INDEX,
+  hailuo: ROUTE_HAILUO_INDEX,
+  kling: ROUTE_KLING_INDEX,
+  veo: ROUTE_VEO_INDEX,
+  sora: ROUTE_SORA_INDEX,
+  pixverse: ROUTE_PIXVERSE_INDEX,
+  wan: ROUTE_WAN_INDEX,
+  serp: ROUTE_SERP_INDEX
+};
 
-const getDefaultRoute = (): string => {
-  const features = store.state.site?.features ?? {};
-  for (const key of FEATURE_ROUTE_ORDER) {
-    if ((features as ISiteFeatures)[key as keyof ISiteFeatures]?.enabled) {
-      const routeNameMap: Record<string, string> = {
-        chatgpt: ROUTE_CHATGPT_CONVERSATION_NEW,
-        deepseek: ROUTE_DEEPSEEK_CONVERSATION_NEW,
-        grok: ROUTE_GROK_CONVERSATION_NEW,
-        gemini: ROUTE_GEMINI_CONVERSATION_NEW,
-        claude: ROUTE_CLAUDE_CONVERSATION_NEW,
-        kimi: ROUTE_KIMI_CONVERSATION_NEW,
-        midjourney: ROUTE_MIDJOURNEY_INDEX,
-        flux: ROUTE_FLUX_INDEX,
-        nanobanana: ROUTE_NANOBANANA_INDEX,
-        seedream: ROUTE_SEEDREAM_INDEX,
-        suno: ROUTE_SUNO_INDEX,
-        producer: ROUTE_PRODUCER_INDEX,
-        seedance: ROUTE_SEEDANCE_INDEX,
-        luma: ROUTE_LUMA_INDEX,
-        hailuo: ROUTE_HAILUO_INDEX,
-        kling: ROUTE_KLING_INDEX,
-        veo: ROUTE_VEO_INDEX,
-        sora: ROUTE_SORA_INDEX,
-        pixverse: ROUTE_PIXVERSE_INDEX,
-        wan: ROUTE_WAN_INDEX,
-        serp: ROUTE_SERP_INDEX,
-      };
-      const name = routeNameMap[key];
-      if (name) return name;
-    }
+const getDefaultRoute = (): { name: string } => {
+  const features = (store.state.site?.features ?? {}) as Record<string, { enabled?: boolean } | undefined>;
+  // Walk site.features in the order the API returned them and pick the
+  // first enabled feature that maps to a known landing route.
+  for (const key of Object.keys(features)) {
+    if (!features[key]?.enabled) continue;
+    const name = FEATURE_ROUTE_NAME[key];
+    // IMPORTANT: must return { name } — returning a bare string makes
+    // vue-router treat it as a *path*, which would navigate to e.g.
+    // /chatgpt-conversation-new (the route name) instead of the actual
+    // path /chatgpt/conversations.
+    if (name) return { name };
   }
-  // Fallback to chatgpt
-  return ROUTE_CHATGPT_CONVERSATION_NEW;
+  // Fallback: if no enabled feature has a landing route, use chatgpt.
+  return { name: ROUTE_CHATGPT_CONVERSATION_NEW };
 };
 
 const routes = [
   {
     path: '/',
-    redirect: () => getDefaultRoute(),
+    redirect: () => getDefaultRoute()
   },
   {
     path: '/chat/oauth/callback',


### PR DESCRIPTION
## Problem

The OpenAI Image module shipped in #460 was missing from three places, so end-users could not enable or reach it:

1. **No toggle in Site Settings** — `pages/site/Index.vue` and `components/setting/Function.vue` did not list `openaiimage` in their feature arrays, so the on/off switch never appeared.
2. **Dynamic default route ignored it** — `FEATURE_ROUTE_NAME` in `src/router/index.ts` had no `openaiimage` entry, so even when the feature was enabled the home redirect could never land on `/openai-image`.
3. **Navigator only showed it if ChatGPT was on** — the gating used `openaiimage?.enabled || chatgpt?.enabled` as a placeholder. With no real toggle anywhere, sites without ChatGPT never saw the entry.

## Fix

- Add `openaiimage` to `FEATURE_ROUTE_NAME` so the dynamic default route picks it up.
- Add `openaiimage` to the features grid in `pages/site/Index.vue` (admin site config UI).
- Add `openaiimage` to `FEATURE_KEYS` in `components/setting/Function.vue` (per-user function settings).
- Drop the ChatGPT fallback in Navigator — visibility now matches the new toggle, mirroring the nanobanana pattern.
- Add `field.featuresOpenaiimage` + `message.featuresOpenaiimage` to all 18 locale `site.json` files. zh-CN / zh-TW localized; other 16 locales seeded with English (consistent with prior practice for new toggles).

## Verification

- `npx vue-tsc -b` passes.
- All 18 `site.json` files re-parse as valid JSON.
