### PR TITLE
fix(chat): hide empty user bubbles from Anthropic tool_result blocks

### DIFF
--- a/src/components/chat/Message.vue
+++ b/src/components/chat/Message.vue
@@ -1,5 +1,6 @@
 <template>
   <div
+    v-if="!isToolResultOnly"
     :class="{
       message: true,
       [message.role as string]: true
@@ -195,6 +196,16 @@ export default defineComponent({
   computed: {
     modelGroup() {
       return this.$store.state.chat.modelGroup;
+    },
+    isToolResultOnly(): boolean {
+      // Anthropic API stores tool_result blocks under role:'user'. These are
+      // protocol-level messages (not real user input) and must not render as
+      // user bubbles — otherwise we get empty gray bubbles in the chat.
+      const content = this.message.content;
+      if (this.message.role !== 'user' || !Array.isArray(content) || content.length === 0) {
+        return false;
+      }
+      return content.every((item: any) => item && item.type === 'tool_result');
     },
     errorText() {
       console.debug('error', this.message.error);

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -488,6 +488,9 @@ export default defineComponent({
       this.$store.dispatch('chat/setModel', targetModel);
       console.debug('conversation', conversation);
       console.debug('conversation messages', this.messages);
+      // conversation.messages is already in UI-shape — the aichat2 backend
+      // folds Anthropic tool_use/tool_result pairs into enriched tool_use
+      // blocks before serving them.
       this.messages = conversation?.messages || [];
       this.onScrollDown();
     },


### PR DESCRIPTION
## Problem

aichat2 stores conversations in **Anthropic Messages format**, where `tool_result` blocks live under `role: 'user'`. When restoring a conversation from history, those messages would render as **empty gray bubbles** in the chat (see screenshot in the linked thread) because there is no real user-visible text in their content.

## Fix

[AceDataCloud/PlatformService#766](https://github.com/AceDataCloud/PlatformService/pull/766) is the proper fix — the aichat2 worker now folds `tool_result` blocks back into the matching assistant `tool_use` block at the read API boundary, so clients receive a clean, model-agnostic, UI-friendly shape (`tool_id` / `tool_name` / `input` / `output` / `is_error` / `status`) regardless of which model produced the conversation.

This Nexior PR is a **small defensive companion**:

- `Message.vue` — adds a `v-if="!isToolResultOnly"` guard so any user message whose content is non-empty and consists *entirely* of `tool_result` blocks is hidden. Protects against legacy data already cached in `vuex-persistedstate` (so users don't have to clear their browser to recover from the bug).
- `Conversation.vue` — adds a comment in `onRestoreConversation` clarifying that `conversation.messages` arrives already in UI-shape from the backend.

No changes to live SSE rendering or the chat actions; the live tool-call path was already correct via `ToolActivity.vue`.
