### PR TITLE
fix(ui): swap purple theme for PlatformFrontend teal, polish logo & chat toolbar

### DIFF
--- a/src/assets/css/loading.css
+++ b/src/assets/css/loading.css
@@ -18,7 +18,7 @@
   width: 13.33333px;
   height: 13.33333px;
   border-radius: 50%;
-  background-color: #7c3aed;
+  background-color: #277186;
   animation-timing-function: cubic-bezier(0, 1, 1, 0);
 }
 .loading div:nth-child(1) {

--- a/src/assets/scss/_common.scss
+++ b/src/assets/scss/_common.scss
@@ -26,13 +26,13 @@ html.dark body {
 html,
 html.dark,
 :root {
-  --el-color-primary: #7c3aed;
-  --el-color-primary-light-3: #a78bfa;
-  --el-color-primary-light-5: #c4b5fd;
-  --el-color-primary-light-7: #ddd6fe;
-  --el-color-primary-light-8: #ede9fe;
-  --el-color-primary-light-9: #f5f3ff;
-  --el-color-primary-dark-2: #6d28d9;
+  --el-color-primary: #277186;
+  --el-color-primary-light-3: #689caa;
+  --el-color-primary-light-5: #93b8c3;
+  --el-color-primary-light-7: #bed4db;
+  --el-color-primary-light-8: #d4e3e7;
+  --el-color-primary-light-9: #e9f1f3;
+  --el-color-primary-dark-2: #1f5a6b;
   --el-border-radius-base: 12px;
   --el-border-radius-small: 8px;
   --el-border-radius-round: 9999px;
@@ -45,8 +45,8 @@ html.dark,
   --app-bg-surface: #ffffff;
   --app-bg-section: #f8fafc;
   --app-border-subtle: #e2e8f0;
-  --app-badge-bg: #ede9fe;
-  --app-badge-border: #7c3aed;
+  --app-badge-bg: #d4e3e7;
+  --app-badge-border: #277186;
 
   /* Elevation / shadow system */
   --app-shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.04);
@@ -60,11 +60,11 @@ html.dark,
   --app-content-bg: #ffffff;
 
   /* Gradients */
-  --app-gradient-brand: linear-gradient(135deg, #7c3aed 0%, #6366f1 50%, #818cf8 100%);
-  --app-gradient-brand-hover: linear-gradient(135deg, #6d28d9 0%, #4f46e5 50%, #6366f1 100%);
-  --app-gradient-hero: linear-gradient(135deg, #0b0d17 0%, #1a103a 50%, #0b0d17 100%);
-  --app-gradient-card: linear-gradient(135deg, rgba(124, 58, 237, 0.04), rgba(99, 102, 241, 0.02));
-  --app-gradient-subtle: linear-gradient(180deg, rgba(124, 58, 237, 0.03) 0%, transparent 100%);
+  --app-gradient-brand: linear-gradient(135deg, #277186 0%, #1f5a6b 50%, #689caa 100%);
+  --app-gradient-brand-hover: linear-gradient(135deg, #1f5a6b 0%, #15485a 50%, #1f5a6b 100%);
+  --app-gradient-hero: linear-gradient(135deg, #0b0f17 0%, #0e2a33 50%, #0b0f17 100%);
+  --app-gradient-card: linear-gradient(135deg, rgba(39, 113, 134, 0.04), rgba(31, 90, 107, 0.02));
+  --app-gradient-subtle: linear-gradient(180deg, rgba(39, 113, 134, 0.03) 0%, transparent 100%);
 
   /* Glass effect */
   --app-glass-bg: rgba(255, 255, 255, 0.7);
@@ -72,20 +72,20 @@ html.dark,
   --app-glass-blur: 12px;
 
   /* Glow */
-  --app-glow-primary: 0 0 20px rgba(124, 58, 237, 0.15);
-  --app-glow-primary-lg: 0 0 40px rgba(124, 58, 237, 0.25);
+  --app-glow-primary: 0 0 20px rgba(39, 113, 134, 0.15);
+  --app-glow-primary-lg: 0 0 40px rgba(39, 113, 134, 0.25);
 }
 
 html.dark {
   --el-color-primary-light-9: #1e1635;
   --el-bg-color: #0f1117;
-  --el-bg-color-page: #0b0d17;
+  --el-bg-color-page: #0b0f17;
   --el-card-bg-color: rgba(26, 29, 46, 0.8);
   --app-bg-surface: #111427;
   --app-bg-section: #0f1117;
   --app-border-subtle: rgba(255, 255, 255, 0.06);
-  --app-badge-bg: rgba(124, 58, 237, 0.15);
-  --app-badge-border: #7c3aed;
+  --app-badge-bg: rgba(39, 113, 134, 0.15);
+  --app-badge-border: #277186;
 
   /* Elevation / shadow system (dark) */
   --app-shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.25);
@@ -99,16 +99,16 @@ html.dark {
   --app-content-bg: #111427;
 
   /* Gradients (dark) */
-  --app-gradient-card: linear-gradient(135deg, rgba(124, 58, 237, 0.06), rgba(99, 102, 241, 0.03));
-  --app-gradient-subtle: linear-gradient(180deg, rgba(124, 58, 237, 0.05) 0%, transparent 100%);
+  --app-gradient-card: linear-gradient(135deg, rgba(39, 113, 134, 0.06), rgba(31, 90, 107, 0.03));
+  --app-gradient-subtle: linear-gradient(180deg, rgba(39, 113, 134, 0.05) 0%, transparent 100%);
 
   /* Glass effect (dark) */
   --app-glass-bg: rgba(17, 20, 39, 0.7);
   --app-glass-border: rgba(255, 255, 255, 0.06);
 
   /* Glow (dark - slightly stronger for visibility) */
-  --app-glow-primary: 0 0 20px rgba(124, 58, 237, 0.2);
-  --app-glow-primary-lg: 0 0 40px rgba(124, 58, 237, 0.3);
+  --app-glow-primary: 0 0 20px rgba(39, 113, 134, 0.2);
+  --app-glow-primary-lg: 0 0 40px rgba(39, 113, 134, 0.3);
 }
 
 w3m-modal {

--- a/src/assets/scss/_element.scss
+++ b/src/assets/scss/_element.scss
@@ -1,7 +1,7 @@
 @forward 'element-plus/theme-chalk/src/common/var.scss' with (
   $colors: (
     'primary': (
-      'base': #7c3aed
+      'base': #277186
     ),
     'danger': (
       'base': #ef4444

--- a/src/components/chat/Composer.vue
+++ b/src/components/chat/Composer.vue
@@ -382,7 +382,7 @@ textarea.input:focus {
     font-size: 16px;
     transition: box-shadow 0.2s ease;
     &:hover:not(:disabled) {
-      box-shadow: 0 0 16px rgba(124, 58, 237, 0.3);
+      box-shadow: 0 0 16px rgba(39, 113, 134, 0.3);
     }
   }
 }

--- a/src/components/common/BottomFooter.vue
+++ b/src/components/common/BottomFooter.vue
@@ -76,7 +76,7 @@ export default defineComponent({
     transition: color 0.2s;
 
     &:hover {
-      color: #c4b5fd;
+      color: #93b8c3;
     }
   }
 
@@ -87,7 +87,7 @@ export default defineComponent({
     transition: color 0.2s;
 
     &:hover {
-      color: #c4b5fd;
+      color: #93b8c3;
     }
   }
 }

--- a/src/components/common/Logo.vue
+++ b/src/components/common/Logo.vue
@@ -39,8 +39,8 @@ export default defineComponent({
   &__image {
     display: block;
     width: auto;
-    max-width: 52px;
-    height: 52px;
+    max-width: 44px;
+    height: 44px;
     object-fit: contain;
     object-position: center;
     transition: height 0.2s ease;
@@ -48,8 +48,8 @@ export default defineComponent({
 
   .collapsed & {
     &__image {
-      height: 32px;
-      max-width: 32px;
+      height: 28px;
+      max-width: 28px;
     }
   }
 }

--- a/src/components/common/Navigator.vue
+++ b/src/components/common/Navigator.vue
@@ -96,7 +96,7 @@ import {
   ROUTE_WAN_INDEX,
   ROUTE_PRODUCER_INDEX,
   ROUTE_KIMI_CONVERSATION,
-  ROUTE_KIMI_CONVERSATION_NEW,
+  ROUTE_KIMI_CONVERSATION_NEW
 } from '@/router/constants';
 import { SERP_LOGO } from '@/constants';
 import { ROUTE_SERP_INDEX } from '@/constants/serp';
@@ -511,7 +511,7 @@ export default defineComponent({
       display: flex;
       justify-content: center;
       align-items: center;
-      padding: 6px 0 4px;
+      padding: 10px 0 6px;
       width: 100%;
     }
 

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -11,26 +11,31 @@
             </el-button>
           </el-tooltip>
           <el-tooltip :content="$t('chat.skill.tooltip')" placement="bottom">
-            <el-button class="toolbar-btn" text @click="skillManagerVisible = true">
+            <el-button
+              :class="['toolbar-btn', { active: activeSkillCount > 0 }]"
+              text
+              @click="skillManagerVisible = true"
+            >
               <font-awesome-icon icon="fa-solid fa-wand-magic-sparkles" />
-              <el-badge v-if="activeSkillCount > 0" :value="activeSkillCount" :max="9" class="toolbar-badge" />
+              <span v-if="activeSkillCount > 0" class="toolbar-count">{{ Math.min(activeSkillCount, 9) }}</span>
             </el-button>
           </el-tooltip>
           <el-tooltip :content="$t('chat.mcp.tooltip')" placement="bottom">
-            <el-button class="toolbar-btn" text @click="mcpManagerVisible = true">
+            <el-button :class="['toolbar-btn', { active: enabledMcpCount > 0 }]" text @click="mcpManagerVisible = true">
               <font-awesome-icon icon="fa-solid fa-cubes-stacked" />
-              <el-badge v-if="enabledMcpCount > 0" :value="enabledMcpCount" :max="9" class="toolbar-badge" />
+              <span v-if="enabledMcpCount > 0" class="toolbar-count">{{ Math.min(enabledMcpCount, 9) }}</span>
             </el-button>
           </el-tooltip>
           <el-tooltip v-if="hasConnectorProviders" :content="$t('chat.connector.tooltip')" placement="bottom">
-            <el-button class="toolbar-btn" text @click="connectorManagerVisible = true">
+            <el-button
+              :class="['toolbar-btn', { active: enabledConnectorCount > 0 }]"
+              text
+              @click="connectorManagerVisible = true"
+            >
               <font-awesome-icon icon="fa-solid fa-plug" />
-              <el-badge
-                v-if="enabledConnectorCount > 0"
-                :value="enabledConnectorCount"
-                :max="9"
-                class="toolbar-badge"
-              />
+              <span v-if="enabledConnectorCount > 0" class="toolbar-count">{{
+                Math.min(enabledConnectorCount, 9)
+              }}</span>
             </el-button>
           </el-tooltip>
         </div>
@@ -103,7 +108,7 @@ import Layout from '@/layouts/Chat.vue';
 import { isImageUrl } from '@/utils/is';
 import { IChatMessageContentItem, IMcpServer, IConnector } from '@/models';
 import { chatOperator, mcpServerOperator, connectorOperator, agentOperator } from '@/operators';
-import { ElTooltip, ElButton, ElBadge } from 'element-plus';
+import { ElTooltip, ElButton } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 
 export interface IData {
@@ -142,7 +147,6 @@ export default defineComponent({
     Layout,
     ElTooltip,
     ElButton,
-    ElBadge,
     FontAwesomeIcon
   },
   data(): IData {
@@ -738,7 +742,7 @@ export default defineComponent({
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0 12px;
+  padding: 0 16px;
   z-index: 100;
 }
 
@@ -749,30 +753,42 @@ export default defineComponent({
 .toolbar-actions {
   display: flex;
   align-items: center;
-  gap: 4px;
-  margin-right: 40px;
+  gap: 2px;
 }
 
 .toolbar-btn {
   position: relative;
-  font-size: 16px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 15px;
   color: var(--el-text-color-secondary);
+  padding: 6px 10px;
+  height: 32px;
+  line-height: 1;
 
   &:hover {
     color: var(--el-color-primary);
   }
 
-  .toolbar-badge {
-    position: absolute;
-    top: -4px;
-    right: -8px;
+  &.active {
+    color: var(--el-color-primary);
+    background-color: var(--el-color-primary-light-9);
+  }
 
-    :deep(.el-badge__content) {
-      font-size: 10px;
-      height: 16px;
-      line-height: 16px;
-      padding: 0 4px;
-    }
+  .toolbar-count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 16px;
+    height: 16px;
+    padding: 0 5px;
+    font-size: 11px;
+    font-weight: 600;
+    line-height: 1;
+    color: #fff;
+    background-color: var(--el-color-primary);
+    border-radius: 9999px;
   }
 
   .agent-dot {

--- a/src/pages/download/Index.vue
+++ b/src/pages/download/Index.vue
@@ -190,7 +190,7 @@ export default defineComponent({
   position: relative;
   overflow: hidden;
   min-height: calc(100vh - 140px);
-  background: linear-gradient(180deg, #f5f3ff 0%, #ede9fe 48%, #f8f7ff 100%);
+  background: linear-gradient(180deg, #e9f1f3 0%, #d4e3e7 48%, #f1f7f8 100%);
 }
 
 .ambient {
@@ -213,7 +213,7 @@ export default defineComponent({
     right: -80px;
     width: 260px;
     height: 260px;
-    background: rgba(99, 102, 241, 0.15);
+    background: rgba(31, 90, 107, 0.15);
   }
 }
 
@@ -302,9 +302,9 @@ export default defineComponent({
 }
 
 .secondary-action {
-  border-color: rgba(124, 58, 237, 0.18);
+  border-color: rgba(39, 113, 134, 0.18);
   background: rgba(255, 255, 255, 0.72);
-  color: #1a103a;
+  color: #0e2a33;
 }
 
 .metrics {
@@ -360,7 +360,7 @@ export default defineComponent({
   }
 
   &--android::before {
-    background: linear-gradient(145deg, rgba(124, 58, 237, 0.12), transparent 42%);
+    background: linear-gradient(145deg, rgba(39, 113, 134, 0.12), transparent 42%);
   }
 
   &--ios::before {
@@ -407,8 +407,8 @@ export default defineComponent({
 }
 
 .platform-badge {
-  background: rgba(124, 58, 237, 0.12);
-  color: #7c3aed;
+  background: rgba(39, 113, 134, 0.12);
+  color: #277186;
 }
 
 .platform-badge--ios {
@@ -523,7 +523,7 @@ export default defineComponent({
     font-size: 12px;
     font-weight: 700;
     letter-spacing: 0.12em;
-    color: #7c3aed;
+    color: #277186;
   }
 
   h3 {

--- a/src/pages/index/Index.vue
+++ b/src/pages/index/Index.vue
@@ -481,7 +481,7 @@ export default defineComponent({
     content: '';
     position: absolute;
     inset: 0;
-    background-image: radial-gradient(rgba(124, 58, 237, 0.15) 1px, transparent 1px);
+    background-image: radial-gradient(rgba(39, 113, 134, 0.15) 1px, transparent 1px);
     background-size: 32px 32px;
     opacity: 0.5;
     pointer-events: none;
@@ -503,7 +503,7 @@ export default defineComponent({
         text-align: left;
         letter-spacing: -0.03em;
         color: #ffffff;
-        background: linear-gradient(135deg, #ffffff 0%, #c4b5fd 50%, #a78bfa 100%);
+        background: linear-gradient(135deg, #ffffff 0%, #93b8c3 50%, #689caa 100%);
         -webkit-background-clip: text;
         -webkit-text-fill-color: transparent;
         background-clip: text;
@@ -531,7 +531,7 @@ export default defineComponent({
 
           &:hover {
             transform: translateY(-2px);
-            box-shadow: 0 0 50px rgba(124, 58, 237, 0.4);
+            box-shadow: 0 0 50px rgba(39, 113, 134, 0.4);
           }
         }
       }

--- a/src/pages/profile/Index.vue
+++ b/src/pages/profile/Index.vue
@@ -223,7 +223,7 @@ export default defineComponent({
     width: 56px;
     height: 56px;
     border-radius: 50%;
-    box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.3);
+    box-shadow: 0 0 0 3px rgba(39, 113, 134, 0.3);
   }
   h2 {
     font-size: 18px;


### PR DESCRIPTION
## Why

Several UI papercuts on `hub.acedata.cloud` (Kimi conversations and other chat pages):

1. **Top-left logo** felt cramped — the 52px logo image only had ~4px breathing room inside the 60px column nav, and the brand wrapper had asymmetric `padding: 6px 0 4px`.
2. **Top-right "red 4"** — the active-skill / MCP / connector counts were rendered with the default Element Plus `<el-badge>` (danger red). It looked like a notification badge, not a count of enabled tools, and the small floating number visually clashed with everything.
3. **Whole-app purple theme** (`#7c3aed` / `#6d28d9` / indigos) was off-brand vs. PlatformFrontend, which uses the teal `#277186` family. The user explicitly wants Nexior aligned with the platform primary.
4. **Toolbar alignment** — `.toolbar-actions` had a leftover `margin-right: 40px` (nothing on the right needs clearing anymore), and toolbar padding was `0 12px` while the rest of the chat content uses a wider gutter, so the action icons were visually misaligned.

## What changed

**Theme color (purple → platform teal)** — replaces the entire violet/indigo palette with the PlatformFrontend teal palette in:

- `src/assets/scss/_common.scss` — `--el-color-primary` and the light-3/5/7/8/9 + dark-2 ramp, badge bg/border, brand gradient, glow shadows, hero/card/subtle gradients (light + dark).
- `src/assets/scss/_element.scss` — Element Plus SCSS `primary.base`.
- `src/assets/css/loading.css` — loading dots.
- `src/components/chat/Composer.vue`, `src/components/common/BottomFooter.vue`, `src/pages/index/Index.vue`, `src/pages/download/Index.vue`, `src/pages/profile/Index.vue` — inline hex/rgba purples.

| old (purple) | new (teal, mirrors PlatformFrontend) |
|---|---|
| `#7c3aed` | `#277186` |
| `#6d28d9` | `#1f5a6b` |
| `#a78bfa` | `#689caa` |
| `#c4b5fd` | `#93b8c3` |
| `#ddd6fe` | `#bed4db` |
| `#ede9fe` | `#d4e3e7` |
| `#f5f3ff` | `#e9f1f3` |
| `#6366f1` / `#4f46e5` / `#818cf8` (gradient indigos) | `#1f5a6b` / `#15485a` / `#689caa` |
| `rgba(124, 58, 237, …)` | `rgba(39, 113, 134, …)` |

**Logo crowding** (`src/components/common/Logo.vue`)

- `max-width: 52px; height: 52px` → `44px / 44px`.
- `collapsed` variant: `32px` → `28px`.

**Brand padding** (`src/components/common/Navigator.vue`)

- Column-mode `.brand` padding: `6px 0 4px` → `10px 0 6px` for symmetric vertical breathing room above the icon rail.

**Chat toolbar** (`src/pages/chat/Conversation.vue`)

- Replaced the three `<el-badge>` (default red) instances on the skills / MCP / connector buttons with an inline `.toolbar-count` pill that uses `--el-color-primary`.
- Buttons get an `.active` class (with subtle `--el-color-primary-light-9` background) when the count is > 0, so the affordance reads as "this tool is on" instead of "you have 4 unread notifications".
- Dropped `.toolbar-actions { margin-right: 40px }` (no longer needed) and bumped `.toolbar { padding: 0 16px }` so icons sit at the same gutter as chat content.
- Removed the now-unused `ElBadge` import.

## Verify

- `npx eslint <changed files>` → clean (one ignore-pattern warning on `.scss` only).
- `npx vue-tsc --noEmit` → clean.
- Visually: top-right of chat now shows a teal pill instead of red number; logo no longer touches the nav edges; the toolbar icons align with the chat gutter.

Closes the items from the design review of `https://hub.acedata.cloud/kimi/conversations`.