### PR TITLE
fix(chat): remove radial-gradient background from conversation dialogue

### DIFF
--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -798,21 +798,6 @@ export default defineComponent({
   height: 100%;
   overflow-y: auto;
   position: relative;
-  background:
-    radial-gradient(
-      circle at 88% 8%,
-      color-mix(in srgb, var(--el-color-primary-light-9) 75%, transparent) 0%,
-      transparent 28%
-    ),
-    radial-gradient(
-      circle at 8% 94%,
-      color-mix(in srgb, var(--el-color-primary-light-9) 65%, transparent) 0%,
-      transparent 24%
-    );
-
-  html.dark & {
-    background: none;
-  }
   .disclaimer {
     width: 100%;
     text-align: center;


### PR DESCRIPTION
Removes the two `radial-gradient` halos (top-right + bottom-left primary-tinted) from the chat conversation dialogue background. The user requested a plain background with no gradient.

Affects [src/pages/chat/Conversation.vue](src/pages/chat/Conversation.vue) — `.dialogue` selector. Dark mode override is also removed since it's no longer needed.