### PR TITLE
fix(ui): sidebar logo respects site.logo / site.favicon again

### DIFF
--- a/change/@acedatacloud-nexior-f61933ab-921e-41f1-8599-bc61a6083250.json
+++ b/change/@acedatacloud-nexior-f61933ab-921e-41f1-8599-bc61a6083250.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(ui): sidebar logo respects site.logo / site.favicon again",
+  "packageName": "@acedatacloud/nexior",
+  "email": "cqc@cuiqingcai.com",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/Logo.vue
+++ b/src/components/common/Logo.vue
@@ -20,7 +20,12 @@ export default defineComponent({
       return this.$store.state.site?.title || 'AceData';
     },
     url() {
-      return 'https://platform.acedata.cloud/favicon.ico';
+      const site = this.$store.state.site;
+      const fallback = 'https://platform.acedata.cloud/favicon.ico';
+      if (this.collapsed) {
+        return site?.favicon || site?.logo || fallback;
+      }
+      return site?.logo || site?.favicon || fallback;
     }
   }
 });


### PR DESCRIPTION
## Problem

The sidebar (top-left) brand logo no longer reflects the per-site customization configured in **Settings → Site → Logo / Favicon** (`site.logo` / `site.favicon`). Every site now shows the AceData platform favicon, regardless of what the site admin uploaded.

## Cause

[#432](https://github.com/AceDataCloud/Nexior/pull/432) (`fix: always use platform favicon as sidebar logo`) replaced the dynamic store-driven URL with a hardcoded `https://platform.acedata.cloud/favicon.ico` in [src/components/common/Logo.vue](src/components/common/Logo.vue):

```ts
url() {
  return 'https://platform.acedata.cloud/favicon.ico';   // <- breaks white-label
}
```

This silently broke white-label / multi-tenant deployments that rely on `site.logo` and `site.favicon` from the Site config.

## Fix

Restore the original store-driven logic, with the platform favicon kept only as a final fallback (e.g. before the Site config has loaded), in [src/components/common/Logo.vue](src/components/common/Logo.vue#L21-L28):

- **Expanded sidebar** → prefer `site.logo`, fall back to `site.favicon`, then platform favicon
- **Collapsed sidebar** → prefer `site.favicon` (square form factor), fall back to `site.logo`, then platform favicon

## Test

- Default `platform.acedata.cloud` site (no custom logo): unchanged — still shows platform favicon via fallback.
- Custom site with `site.logo` / `site.favicon` set in Settings → Site: now shows the configured image again, both expanded and collapsed.
