### PR TITLE
fix(connectors): polish round 2 — BUILT-IN badge, icons, wider cards

### DIFF
--- a/change/@acedatacloud-nexior-7a58f414-5be2-4428-98c7-216da7df2653.json
+++ b/change/@acedatacloud-nexior-7a58f414-5be2-4428-98c7-216da7df2653.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Connectors polish: BUILT-IN badge, icons, GitLab brand, wider cards",
+  "packageName": "@acedatacloud/nexior",
+  "email": "cqc@cuiqingcai.com",
+  "dependentChangeType": "patch"
+}

--- a/src/components/connectors/ConnectorDetail.vue
+++ b/src/components/connectors/ConnectorDetail.vue
@@ -8,7 +8,10 @@
         <div class="info">
           <div class="title-row">
             <span class="title">{{ item.name }}</span>
-            <el-tag v-if="item.isCustom" type="info" effect="plain" round>
+            <el-tag v-if="item.isBuiltin" type="success" effect="plain" round>
+              {{ $t('connector.badge.builtin') }}
+            </el-tag>
+            <el-tag v-else-if="item.isCustom" type="info" effect="plain" round>
               {{ $t('connector.badge.custom') }}
             </el-tag>
           </div>

--- a/src/components/connectors/ConnectorListItem.vue
+++ b/src/components/connectors/ConnectorListItem.vue
@@ -6,7 +6,10 @@
     <div class="meta">
       <div class="name-row">
         <span class="name">{{ item.name }}</span>
-        <el-tag v-if="item.isCustom" size="small" type="info" effect="plain" round class="custom-tag">
+        <el-tag v-if="item.isBuiltin" size="small" type="success" effect="plain" round class="custom-tag">
+          {{ $t('connector.badge.builtin') }}
+        </el-tag>
+        <el-tag v-else-if="item.isCustom" size="small" type="info" effect="plain" round class="custom-tag">
           {{ $t('connector.badge.custom') }}
         </el-tag>
       </div>

--- a/src/components/connectors/types.ts
+++ b/src/components/connectors/types.ts
@@ -12,6 +12,8 @@ export interface IConnectorItem {
   description?: string;
   icon?: string;
   isCustom: boolean;
+  /** True for built-in MCP servers installed from the catalog. */
+  isBuiltin: boolean;
   connected: boolean;
   provider?: IConnectorProvider;
   connector?: IConnector;
@@ -21,10 +23,27 @@ export interface IConnectorItem {
 export const PROVIDER_ICONS: Record<string, string> = {
   google: 'fa-brands fa-google',
   github: 'fa-brands fa-github',
+  gitlab: 'fa-brands fa-gitlab',
   slack: 'fa-brands fa-slack',
   vercel: 'fa-brands fa-v',
-  figma: 'fa-brands fa-figma'
+  figma: 'fa-brands fa-figma',
+  notion: 'fa-solid fa-cube',
+  linear: 'fa-solid fa-cube'
 };
+
+/** Shared icon mapping for built-in MCP catalog entries. */
+export const BUILTIN_ICON_MAP: Record<string, string> = {
+  search: 'fa-solid fa-magnifying-glass',
+  link: 'fa-solid fa-link',
+  music: 'fa-solid fa-music',
+  image: 'fa-solid fa-image',
+  video: 'fa-solid fa-video'
+};
+
+export function resolveBuiltinIcon(key?: string): string {
+  if (!key) return 'fa-solid fa-cube';
+  return BUILTIN_ICON_MAP[key] || 'fa-solid fa-cube';
+}
 
 export type ToolPermission = 'always' | 'ask' | 'never';
 

--- a/src/i18n/en/connector.json
+++ b/src/i18n/en/connector.json
@@ -15,6 +15,10 @@
     "message": "Web",
     "description": "Web connectors group title"
   },
+  "group.builtin": {
+    "message": "Built-in",
+    "description": "Built-in MCP servers group title"
+  },
   "group.custom": {
     "message": "Custom",
     "description": "Custom MCP servers group title"

--- a/src/i18n/zh-CN/connector.json
+++ b/src/i18n/zh-CN/connector.json
@@ -15,6 +15,10 @@
     "message": "网页",
     "description": "已连接的网页类连接器分组标题"
   },
+  "group.builtin": {
+    "message": "内置",
+    "description": "内置 MCP 服务器分组标题"
+  },
   "group.custom": {
     "message": "自定义",
     "description": "自定义 MCP 服务器分组标题"

--- a/src/models/mcp.ts
+++ b/src/models/mcp.ts
@@ -12,6 +12,12 @@ export interface IMcpServer {
   created_at?: string;
   /** OAuth status: 'authorized' if tokens exist, undefined otherwise */
   oauth_status?: 'authorized' | 'pending';
+  /** Optional metadata; for built-in installs holds builtin_id, icon, tags. */
+  metadata?: {
+    builtin_id?: string;
+    icon?: string;
+    tags?: string[];
+  } & Record<string, unknown>;
 }
 
 export interface IMcpTool {

--- a/src/pages/connectors/Browse.vue
+++ b/src/pages/connectors/Browse.vue
@@ -122,16 +122,8 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { connectorOperator, mcpServerOperator } from '@/operators';
 import { IConnectorProvider, IBuiltinMcpServer } from '@/models';
 import { ROUTE_CONNECTORS_INDEX } from '@/router/constants';
-import { PROVIDER_ICONS } from '@/components/connectors/types';
+import { PROVIDER_ICONS, resolveBuiltinIcon } from '@/components/connectors/types';
 import McpManager from '@/components/chat/McpManager.vue';
-
-const BUILTIN_ICON_MAP: Record<string, string> = {
-  search: 'fa-solid fa-magnifying-glass',
-  link: 'fa-solid fa-link',
-  music: 'fa-solid fa-music',
-  image: 'fa-solid fa-image',
-  video: 'fa-solid fa-video'
-};
 
 export default defineComponent({
   name: 'ConnectorsBrowse',
@@ -179,7 +171,7 @@ export default defineComponent({
       return PROVIDER_ICONS[id] || 'fa-solid fa-plug';
     },
     getBuiltinIcon(key: string): string {
-      return BUILTIN_ICON_MAP[key] || 'fa-solid fa-cube';
+      return resolveBuiltinIcon(key);
     },
     async loadAll() {
       if (!this.token) return;
@@ -320,22 +312,25 @@ export default defineComponent({
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
   gap: 12px;
 }
 
 .card {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 14px;
   padding: 16px;
   border: 1px solid var(--el-border-color-lighter);
   border-radius: 10px;
   background: var(--el-bg-color);
-  transition: border-color 0.15s;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
 
   &:hover {
     border-color: var(--el-border-color);
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.04);
   }
 
   &.disabled {
@@ -371,9 +366,9 @@ export default defineComponent({
     .card-desc {
       margin-top: 4px;
       font-size: 12px;
+      line-height: 1.45;
       color: var(--el-text-color-secondary);
       overflow: hidden;
-      text-overflow: ellipsis;
       display: -webkit-box;
       -webkit-line-clamp: 2;
       line-clamp: 2;
@@ -383,6 +378,7 @@ export default defineComponent({
 
   .card-action {
     flex-shrink: 0;
+    margin-top: 4px;
   }
 }
 

--- a/src/pages/connectors/Index.vue
+++ b/src/pages/connectors/Index.vue
@@ -33,11 +33,33 @@
       <div v-loading="loading" class="rail-body">
         <div v-if="loadError" class="empty-hint">{{ $t('connector.common.loadError') }}</div>
 
-        <!-- Connected: built-in providers + custom MCP -->
+        <!-- Connected: OAuth providers + built-in MCPs + custom MCPs -->
+        <div v-if="builtinGroupItems.length" class="group">
+          <div class="group-title">{{ $t('connector.group.builtin') }}</div>
+          <connector-list-item
+            v-for="item in builtinGroupItems"
+            :key="item.id"
+            :item="item"
+            :selected="selectedId === item.id"
+            @click="selectedId = item.id"
+          />
+        </div>
+
         <div v-if="webGroupItems.length" class="group">
           <div class="group-title">{{ $t('connector.group.web') }}</div>
           <connector-list-item
             v-for="item in webGroupItems"
+            :key="item.id"
+            :item="item"
+            :selected="selectedId === item.id"
+            @click="selectedId = item.id"
+          />
+        </div>
+
+        <div v-if="customGroupItems.length" class="group">
+          <div class="group-title">{{ $t('connector.group.custom') }}</div>
+          <connector-list-item
+            v-for="item in customGroupItems"
             :key="item.id"
             :item="item"
             :selected="selectedId === item.id"
@@ -105,7 +127,7 @@ import { ROUTE_CONNECTORS_BROWSE } from '@/router/constants';
 import ConnectorListItem from '@/components/connectors/ConnectorListItem.vue';
 import ConnectorDetail from '@/components/connectors/ConnectorDetail.vue';
 import McpManager from '@/components/chat/McpManager.vue';
-import { IConnectorItem, PROVIDER_ICONS } from '@/components/connectors/types';
+import { IConnectorItem, PROVIDER_ICONS, resolveBuiltinIcon } from '@/components/connectors/types';
 
 export default defineComponent({
   name: 'ConnectorsIndex',
@@ -150,20 +172,25 @@ export default defineComponent({
           description: provider.description,
           icon: PROVIDER_ICONS[provider.id] || 'fa-solid fa-plug',
           isCustom: false,
+          isBuiltin: false,
           connected: !!connector || provider.connected,
           provider,
           connector
         });
       }
-      // User's MCP servers (custom + installed builtins)
+      // User's MCP servers (custom + installed builtins). Built-ins carry
+      // metadata.builtin_id and metadata.icon (set by the backend on install).
       for (const mcp of this.mcpServers) {
+        const builtinId = mcp.metadata?.builtin_id;
+        const isBuiltin = !!builtinId;
         result.push({
           id: `mcp:${mcp.id}`,
           kind: 'custom',
           name: mcp.name,
           description: mcp.description,
-          icon: 'fa-solid fa-cube',
-          isCustom: true,
+          icon: isBuiltin ? resolveBuiltinIcon(mcp.metadata?.icon) : 'fa-solid fa-cube',
+          isCustom: !isBuiltin,
+          isBuiltin,
           connected: true,
           mcp
         });
@@ -175,7 +202,14 @@ export default defineComponent({
       );
     },
     webGroupItems(): IConnectorItem[] {
-      return this.items.filter((it) => it.connected);
+      // OAuth providers that are already connected.
+      return this.items.filter((it) => it.connected && it.kind === 'provider');
+    },
+    builtinGroupItems(): IConnectorItem[] {
+      return this.items.filter((it) => it.connected && it.isBuiltin);
+    },
+    customGroupItems(): IConnectorItem[] {
+      return this.items.filter((it) => it.connected && it.isCustom);
     },
     notConnectedItems(): IConnectorItem[] {
       return this.items.filter((it) => !it.connected);

--- a/src/plugins/font-awesome.ts
+++ b/src/plugins/font-awesome.ts
@@ -16,6 +16,7 @@ import {
   faWeixin as faBrandsWeixin,
   faGoogle as faBrandsGoogle,
   faGithub as faBrandsGithub,
+  faGitlab as faBrandsGitlab,
   faSlack as faBrandsSlack
 } from '@fortawesome/free-brands-svg-icons';
 import {
@@ -25,6 +26,7 @@ import {
   faPlayCircle as faSolidPlayCircle,
   faDownload as faSolidDownload,
   faFilm as faSolidFilm,
+  faVideo as faSolidVideo,
   faMusic as faSolidMusic,
   faLanguage as faSolidLanguage,
   faUser as faSolidUser,
@@ -111,6 +113,7 @@ library.add(faSolidPlayCircle);
 library.add(faSolidArrowUp);
 library.add(faRegularFileAlt);
 library.add(faSolidFilm);
+library.add(faSolidVideo);
 library.add(faSolidMusic);
 library.add(faRegularCopy);
 library.add(faRegularMessage);
@@ -195,4 +198,5 @@ library.add(faSolidCheckCircle);
 library.add(faSolidCircleExclamation);
 library.add(faBrandsGoogle);
 library.add(faBrandsGithub);
+library.add(faBrandsGitlab);
 library.add(faBrandsSlack);


### PR DESCRIPTION
Polish round after live-testing the deployed /connectors page on hub.acedata.cloud.

### Issues found during smoke test
1. Installing a built-in MCP (e.g. Google Search) showed a **CUSTOM** badge in the rail and detail pane — wrong identity.
2. Three built-in directory cards (Luma Video, Google Veo, OpenAI Sora) rendered with **no icon** — the Font Awesome `fa-video` glyph was never registered in the icon library plugin.
3. OAuth provider cards (Notion / Linear / GitLab) showed a generic plug icon and their descriptions were truncated to 'Access pages, databases, and...' because the grid was too tight.

### Changes

- **`models/mcp.ts`** — `IMcpServer.metadata` now typed (`builtin_id`, `icon`, `tags`) so the front-end can read what the backend stores on install.
- **`components/connectors/types.ts`** —
  - `IConnectorItem.isBuiltin` flag added.
  - `PROVIDER_ICONS` extended with `gitlab`, `notion`, `linear`.
  - Shared `BUILTIN_ICON_MAP` + `resolveBuiltinIcon()` helper.
- **`pages/connectors/Index.vue`** — derives `isBuiltin` from `metadata.builtin_id`, picks the proper FA icon from `metadata.icon`, and now splits the rail into three groups: **Web** (OAuth) / **Built-in** (MCP) / **Custom** (MCP).
- **`components/connectors/ConnectorListItem.vue`** + **`ConnectorDetail.vue`** — show green **BUILT-IN** tag for built-ins; **CUSTOM** tag only for true custom MCPs.
- **`pages/connectors/Browse.vue`** — uses the shared icon helper; cards now `min-width: 360px` (was 320px) so descriptions like Notion's no longer ellipsize, plus a subtle hover shadow.
- **`plugins/font-awesome.ts`** — register `faVideo` (solid) and `faGitlab` (brands).
- **i18n** — add `group.builtin` for both `zh-CN` and `en`.

### Manual test
- Login → /connectors empty state with CTA ✓
- Browse: 9 built-in cards now render full set of icons including Luma / Veo / Sora ✓
- Install Google Search → rail shows BUILT-IN badge with magnifier icon ✓
- '+ Add custom connector' opens MCP manager dialog ✓

Cosmetic only; no API or behavioural changes.