### PR TITLE
feat(suno): UX overhaul — model dropdown, style tags, menu groups, lyrics toolbar

### DIFF
--- a/src/components/suno/config/LyricInput.vue
+++ b/src/components/suno/config/LyricInput.vue
@@ -5,16 +5,28 @@
         <span class="text-sm font-bold">{{ $t('suno.name.lyrics') }}</span>
         <info-icon :content="$t('suno.description.lyrics')" />
       </div>
-      <el-button
-        v-if="config?.action !== 'extend'"
-        size="small"
-        :loading="generatingLyrics"
-        round
-        @click="onGenerateLyrics"
-      >
-        <font-awesome-icon v-if="!generatingLyrics" icon="fa-solid fa-wand-magic-sparkles" class="mr-1" />
-        {{ $t('suno.button.generate_lyrics') }}
-      </el-button>
+      <div class="flex items-center gap-1">
+        <el-tooltip v-if="lyricHistory.length > 0" :content="$t('suno.button.undo')" placement="top">
+          <el-button size="small" circle @click="onUndo">
+            <font-awesome-icon icon="fa-solid fa-rotate-left" />
+          </el-button>
+        </el-tooltip>
+        <el-tooltip v-if="lyric" :content="$t('suno.button.clear_lyrics')" placement="top">
+          <el-button size="small" circle @click="onClear">
+            <font-awesome-icon icon="fa-solid fa-eraser" />
+          </el-button>
+        </el-tooltip>
+        <el-button
+          v-if="config?.action !== 'extend'"
+          size="small"
+          :loading="generatingLyrics"
+          round
+          @click="onGenerateLyrics"
+        >
+          <font-awesome-icon v-if="!generatingLyrics" icon="fa-solid fa-wand-magic-sparkles" class="mr-1" />
+          {{ $t('suno.button.generate_lyrics') }}
+        </el-button>
+      </div>
     </div>
     <el-input
       v-if="config?.action !== 'extend'"
@@ -32,12 +44,29 @@
       class="lyrics"
       :placeholder="$t('suno.placeholder.extend.lyrics')"
     />
+    <!-- Enhance lyrics -->
+    <div v-if="lyric && config?.action !== 'extend'" class="enhance-bar">
+      <el-input
+        v-model="enhancePrompt"
+        size="small"
+        :placeholder="$t('suno.placeholder.enhanceLyrics')"
+        class="enhance-input"
+        @keyup.enter="onEnhanceLyrics"
+      >
+        <template #append>
+          <el-button :loading="enhancingLyrics" @click="onEnhanceLyrics">
+            <font-awesome-icon v-if="!enhancingLyrics" icon="fa-solid fa-wand-magic-sparkles" class="mr-1" />
+            {{ $t('suno.button.enhance_lyrics') }}
+          </el-button>
+        </template>
+      </el-input>
+    </div>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElInput, ElButton, ElMessage } from 'element-plus';
+import { ElInput, ElButton, ElMessage, ElTooltip } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import { sunoOperator } from '@/operators';
@@ -49,12 +78,16 @@ export default defineComponent({
   components: {
     ElInput,
     ElButton,
+    ElTooltip,
     FontAwesomeIcon,
     InfoIcon
   },
   data() {
     return {
-      generatingLyrics: false
+      generatingLyrics: false,
+      enhancingLyrics: false,
+      enhancePrompt: '',
+      lyricHistory: [] as string[]
     };
   },
   computed: {
@@ -82,10 +115,49 @@ export default defineComponent({
     }
   },
   methods: {
+    pushHistory() {
+      if (this.lyric) {
+        this.lyricHistory.push(this.lyric);
+        if (this.lyricHistory.length > 20) this.lyricHistory.shift();
+      }
+    },
+    onUndo() {
+      const prev = this.lyricHistory.pop();
+      if (prev !== undefined) {
+        this.lyric = prev;
+      }
+    },
+    onClear() {
+      this.pushHistory();
+      this.lyric = '';
+    },
+    async onEnhanceLyrics() {
+      const token = this.credential?.token;
+      if (!token || !this.lyric || !this.enhancePrompt) return;
+
+      this.pushHistory();
+      this.enhancingLyrics = true;
+      ElMessage.info(this.$t('suno.message.enhancingLyrics'));
+      try {
+        const prompt = `${this.enhancePrompt}\n\nOriginal lyrics:\n${this.lyric}`;
+        const response = await sunoOperator.lyric({ prompt }, { token });
+        const data = response.data?.data;
+        if (data?.text) {
+          this.lyric = data.text;
+          this.enhancePrompt = '';
+          ElMessage.success(this.$t('suno.message.enhanceLyricsSuccess'));
+        }
+      } catch {
+        ElMessage.error(this.$t('suno.message.enhanceLyricsFailed'));
+      } finally {
+        this.enhancingLyrics = false;
+      }
+    },
     async onGenerateLyrics() {
       const token = this.credential?.token;
       if (!token) return;
 
+      this.pushHistory();
       const prompt = this.config?.style || this.config?.title || 'a beautiful song';
       this.generatingLyrics = true;
       ElMessage.info(this.$t('suno.message.generatingLyrics'));
@@ -119,6 +191,16 @@ export default defineComponent({
   :deep(.el-textarea__inner) {
     font-family: monospace;
     line-height: 1.6;
+  }
+}
+
+.enhance-bar {
+  margin-top: 6px;
+
+  .enhance-input {
+    :deep(.el-input-group__append) {
+      padding: 0 12px;
+    }
   }
 }
 </style>

--- a/src/components/suno/config/StyleInput.vue
+++ b/src/components/suno/config/StyleInput.vue
@@ -11,6 +11,15 @@
       </el-button>
     </div>
     <el-input v-model="style" :rows="2" type="textarea" :placeholder="$t('suno.placeholder.style')" />
+    <!-- Style Tag Cloud -->
+    <div class="style-tags">
+      <button v-for="tag in visibleTags" :key="tag" class="style-tag" @click="onTagClick(tag)">
+        {{ tag }}
+      </button>
+      <button class="style-tag style-tag-refresh" @click="onRefreshTags">
+        <font-awesome-icon icon="fa-solid fa-arrows-rotate" />
+      </button>
+    </div>
   </div>
 </template>
 
@@ -20,6 +29,70 @@ import { ElInput, ElButton, ElMessage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import { sunoOperator } from '@/operators';
+
+const ALL_STYLE_TAGS = [
+  'Pop',
+  'Rock',
+  'Jazz',
+  'R&B',
+  'Hip Hop',
+  'Lo-fi',
+  'Electronic',
+  'Classical',
+  'Country',
+  'Blues',
+  'Folk',
+  'Reggae',
+  'Metal',
+  'Punk',
+  'Soul',
+  'Funk',
+  'Ambient',
+  'Indie',
+  'Latin',
+  'Acoustic',
+  'Dance',
+  'Disco',
+  'Gospel',
+  'K-Pop',
+  'J-Pop',
+  'C-Pop',
+  'Bossa Nova',
+  'Trap',
+  'Drill',
+  'House',
+  'Techno',
+  'Dubstep',
+  'Synthwave',
+  'Chill',
+  'Dreamy',
+  'Upbeat',
+  'Melancholic',
+  'Romantic',
+  'Epic',
+  'Cinematic',
+  'Orchestral',
+  'Piano',
+  'Guitar',
+  'Saxophone',
+  'Violin',
+  'Tribal',
+  'World Music',
+  'Afrobeat',
+  'Ska',
+  'Grunge'
+];
+
+const TAGS_PER_PAGE = 12;
+
+function shuffleArray<T>(arr: T[]): T[] {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
 
 export default defineComponent({
   name: 'StyleInput',
@@ -31,7 +104,8 @@ export default defineComponent({
   },
   data() {
     return {
-      optimizing: false
+      optimizing: false,
+      shuffledTags: shuffleArray(ALL_STYLE_TAGS)
     };
   },
   computed: {
@@ -48,9 +122,20 @@ export default defineComponent({
     },
     credential() {
       return this.$store.state.suno?.credential;
+    },
+    visibleTags(): string[] {
+      return this.shuffledTags.slice(0, TAGS_PER_PAGE);
     }
   },
   methods: {
+    onTagClick(tag: string) {
+      const current = this.style || '';
+      if (current.toLowerCase().includes(tag.toLowerCase())) return;
+      this.style = current ? `${current}, ${tag}` : tag;
+    },
+    onRefreshTags() {
+      this.shuffledTags = shuffleArray(ALL_STYLE_TAGS);
+    },
     async onOptimizeStyle() {
       const token = this.credential?.token;
       if (!token || !this.style) return;
@@ -73,3 +158,41 @@ export default defineComponent({
   }
 });
 </script>
+
+<style lang="scss" scoped>
+.style-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.style-tag {
+  padding: 3px 10px;
+  border: 1px solid var(--el-border-color);
+  border-radius: 14px;
+  background: var(--el-bg-color);
+  color: var(--el-text-color-regular);
+  font-size: 12px;
+  cursor: pointer;
+  transition: all 0.2s;
+  white-space: nowrap;
+
+  &:hover {
+    border-color: var(--el-color-primary);
+    color: var(--el-color-primary);
+    background: var(--el-color-primary-light-9);
+  }
+}
+
+.style-tag-refresh {
+  border-style: dashed;
+  color: var(--el-text-color-placeholder);
+  padding: 3px 8px;
+
+  &:hover {
+    border-color: var(--el-color-primary);
+    color: var(--el-color-primary);
+  }
+}
+</style>

--- a/src/components/suno/config/TypeSelector.vue
+++ b/src/components/suno/config/TypeSelector.vue
@@ -1,9 +1,13 @@
 <template>
   <div>
-    <!-- Custom Mode Toggle -->
-    <div class="flex items-center justify-between mb-3">
-      <span class="text-sm font-bold">{{ $t('suno.name.type') }}</span>
-      <el-switch v-model="custom" />
+    <!-- Creation Mode Tabs -->
+    <div class="mode-tabs mb-3">
+      <button class="mode-tab" :class="{ active: !custom }" @click="custom = false">
+        {{ $t('suno.mode.simple') }}
+      </button>
+      <button class="mode-tab" :class="{ active: custom }" @click="custom = true">
+        {{ $t('suno.mode.custom') }}
+      </button>
     </div>
 
     <!-- Model Selection -->
@@ -11,17 +15,31 @@
       <div class="flex items-center mb-1">
         <span class="text-sm font-bold">{{ $t('suno.name.model') }}</span>
       </div>
-      <el-select v-model="model" class="w-full" size="default" :placeholder="$t('suno.placeholder.select')">
-        <el-option v-for="item in options" :key="item.value" :label="item.label" :value="item.value">
-          <div class="flex items-center justify-between w-full">
-            <span>{{ item.label }}</span>
-            <span class="text-xs text-[var(--el-text-color-placeholder)]">{{ item.info }}</span>
+      <el-select
+        v-model="model"
+        class="w-full model-select"
+        size="default"
+        :placeholder="$t('suno.placeholder.select')"
+      >
+        <el-option
+          v-for="item in options"
+          :key="item.value"
+          :label="item.label"
+          :value="item.value"
+          :class="{ 'model-option-divider': item.dividerAfter }"
+        >
+          <div class="model-option">
+            <div class="model-option-left">
+              <span class="model-option-name">{{ item.label }}</span>
+              <el-tag v-if="item.pro" size="small" type="warning" effect="plain" class="model-option-pro">Pro</el-tag>
+            </div>
+            <span class="model-option-desc">{{ item.desc }}</span>
           </div>
         </el-option>
       </el-select>
     </div>
 
-    <!-- Song Description / Instrumental Toggle -->
+    <!-- Instrumental Toggle (custom mode only) -->
     <div v-if="custom" class="flex items-center justify-between mb-3">
       <span class="text-sm font-bold">{{ $t('suno.name.instrumental') }}</span>
       <el-switch v-model="instrumental" />
@@ -31,55 +49,69 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElSelect, ElOption, ElSwitch } from 'element-plus';
+import { ElSelect, ElOption, ElSwitch, ElTag } from 'element-plus';
 import { SUNO_DEFAULT_MODEL } from '@/constants';
+
+interface ModelOption {
+  label: string;
+  value: string;
+  desc: string;
+  pro?: boolean;
+  dividerAfter?: boolean;
+}
 
 export default defineComponent({
   name: 'TypeSelector',
   components: {
     ElSelect,
     ElOption,
-    ElSwitch
+    ElSwitch,
+    ElTag
   },
   data() {
     return {
       options: [
         {
-          label: 'Suno v5.5',
+          label: 'v5.5',
           value: 'chirp-v5-5',
-          info: '8 min'
+          desc: this.$t('suno.model.v55desc'),
+          pro: true
         },
         {
-          label: 'Suno v5',
+          label: 'v5',
           value: 'chirp-v5',
-          info: '8 min'
+          desc: this.$t('suno.model.v5desc'),
+          pro: true
         },
         {
-          label: 'Suno v4.5+',
+          label: 'v4.5+',
           value: 'chirp-v4-5-plus',
-          info: '8 min'
+          desc: this.$t('suno.model.v45plusdesc'),
+          pro: true
         },
         {
-          label: 'Suno v4.5',
+          label: 'v4.5',
           value: 'chirp-v4-5',
-          info: '4 min'
+          desc: this.$t('suno.model.v45desc'),
+          pro: true,
+          dividerAfter: true
         },
         {
-          label: 'Suno v4',
+          label: 'v4',
           value: 'chirp-v4',
-          info: '2.5 min'
+          desc: this.$t('suno.model.v4desc')
         },
         {
-          label: 'Suno v3.5',
+          label: 'v3.5',
           value: 'chirp-v3-5',
-          info: '2 min'
+          desc: this.$t('suno.model.v35desc')
         },
         {
-          label: 'Suno v3',
+          label: 'v3',
           value: 'chirp-v3-0',
-          info: '2 min'
+          desc: this.$t('suno.model.v3desc')
         }
-      ]
+      ] as ModelOption[]
     };
   },
   computed: {
@@ -124,3 +156,75 @@ export default defineComponent({
   }
 });
 </script>
+
+<style lang="scss" scoped>
+.mode-tabs {
+  display: flex;
+  gap: 4px;
+  background: var(--el-fill-color-light);
+  border-radius: 8px;
+  padding: 3px;
+}
+
+.mode-tab {
+  flex: 1;
+  padding: 6px 12px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--el-text-color-secondary);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+
+  &.active {
+    background: var(--el-bg-color);
+    color: var(--el-text-color-primary);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  }
+
+  &:hover:not(.active) {
+    color: var(--el-text-color-primary);
+  }
+}
+
+.model-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 2px 0;
+}
+
+.model-option-left {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.model-option-name {
+  font-weight: 500;
+}
+
+.model-option-pro {
+  font-size: 10px !important;
+  padding: 0 4px !important;
+  height: 18px !important;
+  line-height: 16px !important;
+  border-radius: 4px !important;
+}
+
+.model-option-desc {
+  font-size: 12px;
+  color: var(--el-text-color-placeholder);
+  margin-left: 8px;
+  white-space: nowrap;
+}
+
+:deep(.model-option-divider) {
+  border-bottom: 1px solid var(--el-border-color-lighter);
+  margin-bottom: 4px;
+  padding-bottom: 4px;
+}
+</style>

--- a/src/components/suno/task/Preview.vue
+++ b/src/components/suno/task/Preview.vue
@@ -90,47 +90,71 @@
             </el-tooltip>
           </span>
           <template #dropdown>
-            <el-dropdown-menu>
+            <el-dropdown-menu class="suno-action-menu">
+              <!-- Creation group -->
               <el-dropdown-item v-if="audio?.audio_url" @click.stop="onExtend($event, audio)">
+                <font-awesome-icon icon="fa-solid fa-forward" class="menu-icon" />
                 {{ $t('suno.button.extend') }}
               </el-dropdown-item>
-              <el-dropdown-item v-if="audio.id" @click.stop="onGetStems(audio.id)">
-                {{ $t('suno.button.get_stems') }}
-              </el-dropdown-item>
-              <el-dropdown-item v-if="audio.id" @click.stop="onGetAllStems(audio.id)">
-                {{ $t('suno.button.all_stems') }}
-              </el-dropdown-item>
               <el-dropdown-item @click.stop="onCover(audio)">
+                <font-awesome-icon icon="fa-solid fa-music" class="menu-icon" />
                 {{ $t('suno.button.cover_music') }}
               </el-dropdown-item>
-              <el-dropdown-item v-if="audio?.id" @click.stop="onRemaster(audio.id)">
-                {{ $t('suno.button.remaster') }}
-              </el-dropdown-item>
-              <el-dropdown-item v-if="audio?.id" @click.stop="onReplaceSection(audio)">
-                {{ $t('suno.button.replace_section') }}
-              </el-dropdown-item>
               <el-dropdown-item v-if="audio?.id" @click.stop="onMashup(audio)">
+                <font-awesome-icon icon="fa-solid fa-shuffle" class="menu-icon" />
                 {{ $t('suno.button.mashup') }}
               </el-dropdown-item>
               <el-dropdown-item v-if="audio?.id && audio?.action === 'extend'" @click.stop="onConcatMusic(audio?.id)">
+                <font-awesome-icon icon="fa-solid fa-link" class="menu-icon" />
                 {{ $t('suno.button.concat_music') }}
               </el-dropdown-item>
+
+              <!-- Editing group -->
+              <div class="menu-divider" />
+              <el-dropdown-item v-if="audio?.id" @click.stop="onReplaceSection(audio)">
+                <font-awesome-icon icon="fa-solid fa-scissors" class="menu-icon" />
+                {{ $t('suno.button.replace_section') }}
+              </el-dropdown-item>
               <el-dropdown-item v-if="audio?.id" @click.stop="onOverpainting(audio)">
+                <font-awesome-icon icon="fa-solid fa-microphone" class="menu-icon" />
                 {{ $t('suno.button.overpainting') }}
               </el-dropdown-item>
               <el-dropdown-item v-if="audio?.id" @click.stop="onUnderpainting(audio)">
+                <font-awesome-icon icon="fa-solid fa-guitar" class="menu-icon" />
                 {{ $t('suno.button.underpainting') }}
               </el-dropdown-item>
               <el-dropdown-item v-if="audio?.id" @click.stop="onSamples(audio)">
+                <font-awesome-icon icon="fa-solid fa-drum" class="menu-icon" />
                 {{ $t('suno.button.samples') }}
               </el-dropdown-item>
-              <el-dropdown-item v-if="audio?.id" @click.stop="onArtistConsistency(audio)">
-                {{ $t('suno.button.artist_consistency') }}
+
+              <!-- Processing group -->
+              <div class="menu-divider" />
+              <el-dropdown-item v-if="audio.id" @click.stop="onGetStems(audio.id)">
+                <font-awesome-icon icon="fa-solid fa-layer-group" class="menu-icon" />
+                {{ $t('suno.button.get_stems') }}
+              </el-dropdown-item>
+              <el-dropdown-item v-if="audio.id" @click.stop="onGetAllStems(audio.id)">
+                <font-awesome-icon icon="fa-solid fa-bars-staggered" class="menu-icon" />
+                {{ $t('suno.button.all_stems') }}
+              </el-dropdown-item>
+              <el-dropdown-item v-if="audio?.id" @click.stop="onRemaster(audio.id)">
+                <font-awesome-icon icon="fa-solid fa-wand-magic-sparkles" class="menu-icon" />
+                {{ $t('suno.button.remaster') }}
               </el-dropdown-item>
               <el-dropdown-item v-if="audio?.id" @click.stop="onExtractVocals(audio.id)">
+                <font-awesome-icon icon="fa-solid fa-headphones" class="menu-icon" />
                 {{ $t('suno.button.extract_vocals') }}
               </el-dropdown-item>
+              <el-dropdown-item v-if="audio?.id" @click.stop="onArtistConsistency(audio)">
+                <font-awesome-icon icon="fa-solid fa-palette" class="menu-icon" />
+                {{ $t('suno.button.artist_consistency') }}
+              </el-dropdown-item>
+
+              <!-- Utility group -->
+              <div class="menu-divider" />
               <el-dropdown-item v-if="audio?.id" @click.stop="onGetTiming(audio.id)">
+                <font-awesome-icon icon="fa-solid fa-clock" class="menu-icon" />
                 {{ $t('suno.button.get_timing') }}
               </el-dropdown-item>
             </el-dropdown-menu>
@@ -646,6 +670,20 @@ export default defineComponent({
         margin-right: 15px; /* Add margin to the right of the button */
       }
     }
+  }
+}
+
+.suno-action-menu {
+  .menu-icon {
+    width: 14px;
+    margin-right: 8px;
+    color: var(--el-text-color-secondary);
+  }
+
+  .menu-divider {
+    height: 1px;
+    background: var(--el-border-color-lighter);
+    margin: 4px 12px;
   }
 }
 </style>

--- a/src/i18n/en/suno.json
+++ b/src/i18n/en/suno.json
@@ -538,5 +538,69 @@
   "message.extractVocalsSuccess": {
     "message": "Vocals extracted successfully",
     "description": "Message when vocals are successfully extracted"
+  },
+  "mode.simple": {
+    "message": "Simple",
+    "description": "Simple creation mode tab label"
+  },
+  "mode.custom": {
+    "message": "Custom",
+    "description": "Custom creation mode tab label"
+  },
+  "model.v55desc": {
+    "message": "Voices & Custom Models",
+    "description": "v5.5 model description"
+  },
+  "model.v5desc": {
+    "message": "Authentic vocals, high quality",
+    "description": "v5 model description"
+  },
+  "model.v45plusdesc": {
+    "message": "Advanced creation",
+    "description": "v4.5+ model description"
+  },
+  "model.v45desc": {
+    "message": "Intelligent prompts",
+    "description": "v4.5 model description"
+  },
+  "model.v4desc": {
+    "message": "Improved sound quality",
+    "description": "v4 model description"
+  },
+  "model.v35desc": {
+    "message": "Basic song structure",
+    "description": "v3.5 model description"
+  },
+  "model.v3desc": {
+    "message": "Classic",
+    "description": "v3 model description"
+  },
+  "button.undo": {
+    "message": "Undo",
+    "description": "Undo button tooltip"
+  },
+  "button.clear_lyrics": {
+    "message": "Clear lyrics",
+    "description": "Clear lyrics button tooltip"
+  },
+  "button.enhance_lyrics": {
+    "message": "Enhance",
+    "description": "Enhance lyrics button"
+  },
+  "placeholder.enhanceLyrics": {
+    "message": "Enter instructions, e.g., make it more upbeat...",
+    "description": "Placeholder for lyrics enhance input"
+  },
+  "message.enhancingLyrics": {
+    "message": "Enhancing lyrics...",
+    "description": "Message while enhancing lyrics"
+  },
+  "message.enhanceLyricsSuccess": {
+    "message": "Lyrics enhanced successfully",
+    "description": "Message when lyrics enhancement is successful"
+  },
+  "message.enhanceLyricsFailed": {
+    "message": "Lyrics enhancement failed",
+    "description": "Message when lyrics enhancement fails"
   }
 }

--- a/src/i18n/zh-CN/suno.json
+++ b/src/i18n/zh-CN/suno.json
@@ -538,5 +538,69 @@
   "message.extractVocalsSuccess": {
     "message": "人声提取成功",
     "description": "提取人声成功时的消息"
+  },
+  "mode.simple": {
+    "message": "简单",
+    "description": "简单创作模式标签"
+  },
+  "mode.custom": {
+    "message": "定制",
+    "description": "定制创作模式标签"
+  },
+  "model.v55desc": {
+    "message": "声音人设 · 自定义模型",
+    "description": "v5.5 模型描述"
+  },
+  "model.v5desc": {
+    "message": "真实人声 · 高品质音频",
+    "description": "v5 模型描述"
+  },
+  "model.v45plusdesc": {
+    "message": "高级创作方法",
+    "description": "v4.5+ 模型描述"
+  },
+  "model.v45desc": {
+    "message": "智能提示词",
+    "description": "v4.5 模型描述"
+  },
+  "model.v4desc": {
+    "message": "改进音质",
+    "description": "v4 模型描述"
+  },
+  "model.v35desc": {
+    "message": "基础歌曲结构",
+    "description": "v3.5 模型描述"
+  },
+  "model.v3desc": {
+    "message": "经典",
+    "description": "v3 模型描述"
+  },
+  "button.undo": {
+    "message": "撤销",
+    "description": "撤销按钮提示"
+  },
+  "button.clear_lyrics": {
+    "message": "清空歌词",
+    "description": "清空歌词按钮提示"
+  },
+  "button.enhance_lyrics": {
+    "message": "增强",
+    "description": "增强歌词按钮"
+  },
+  "placeholder.enhanceLyrics": {
+    "message": "输入修改指令，例如：让歌词更欢快...",
+    "description": "歌词增强输入占位符"
+  },
+  "message.enhancingLyrics": {
+    "message": "正在增强歌词...",
+    "description": "增强歌词时的消息"
+  },
+  "message.enhanceLyricsSuccess": {
+    "message": "歌词增强成功",
+    "description": "增强歌词成功时的消息"
+  },
+  "message.enhanceLyricsFailed": {
+    "message": "歌词增强失败",
+    "description": "增强歌词失败时的消息"
   }
 }

--- a/src/plugins/font-awesome.ts
+++ b/src/plugins/font-awesome.ts
@@ -98,7 +98,17 @@ import {
   faFaceMeh as faSolidFaceMeh,
   faPlug as faSolidPlug,
   faCheckCircle as faSolidCheckCircle,
-  faCircleExclamation as faSolidCircleExclamation
+  faCircleExclamation as faSolidCircleExclamation,
+  faForward as faSolidForward,
+  faShuffle as faSolidShuffle,
+  faScissors as faSolidScissors,
+  faGuitar as faSolidGuitar,
+  faDrum as faSolidDrum,
+  faLayerGroup as faSolidLayerGroup,
+  faBarsStaggered as faSolidBarsStaggered,
+  faHeadphones as faSolidHeadphones,
+  faClock as faSolidClock,
+  faEraser as faSolidEraser
 } from '@fortawesome/free-solid-svg-icons';
 // add icons
 library.add(faSolidEllipsis);
@@ -196,3 +206,13 @@ library.add(faSolidCircleExclamation);
 library.add(faBrandsGoogle);
 library.add(faBrandsGithub);
 library.add(faBrandsSlack);
+library.add(faSolidForward);
+library.add(faSolidShuffle);
+library.add(faSolidScissors);
+library.add(faSolidGuitar);
+library.add(faSolidDrum);
+library.add(faSolidLayerGroup);
+library.add(faSolidBarsStaggered);
+library.add(faSolidHeadphones);
+library.add(faSolidClock);
+library.add(faSolidEraser);


### PR DESCRIPTION
## Summary

Based on comprehensive Suno.com vs Nexior comparison research, this PR implements the P0 UX improvements for the Suno music creation page.

### Changes

**1. Model Dropdown Redesign** (`TypeSelector.vue`)
- Grouped model list with Pro badges and descriptions (e.g. "Voices & Custom Models", "Authentic vocals")
- Visual divider separating Pro and free models
- Matches Suno.com's model selector UX

**2. Simple/Custom Tab Switcher** (`TypeSelector.vue`)
- Replaced bare toggle switch with styled pill tab buttons
- `[Simple] [Custom]` tabs — clearer mental model for users

**3. Style Tag Cloud** (`StyleInput.vue`)
- 50 genre/style tags displayed as clickable chips (12 visible at a time)
- Shuffle/refresh button for discovering new styles
- Click to append tag to style input
- Addresses: "new users don't know what to write" problem

**4. Song Action Menu Grouping** (`task/Preview.vue`)
- Organized flat 14-item dropdown into 4 logical groups with dividers:
  - **Creation** — Extend, Cover, Mashup, Concat
  - **Editing** — Replace Section, Add Vocals/Accompaniment/Samples
  - **Processing** — Stems, Remaster, Extract Vocals, Style Consistency
  - **Utility** — Get Timing
- Added Font Awesome icons to every menu item

**5. Lyrics Toolbar Enhancement** (`LyricInput.vue`)
- Added Undo button (with 20-level history stack)
- Added Clear button with one click
- Added "Enhance lyrics" input bar — type instructions like "make it more upbeat" to refine AI-generated lyrics

**6. i18n** (`suno.json`)
- 14 new keys added to both `zh-CN` and `en` locales
- Model descriptions, mode labels, toolbar labels, enhance messages

**7. Font Awesome Icons** (`font-awesome.ts`)
- Registered 10 new icons: forward, shuffle, scissors, guitar, drum, layer-group, bars-staggered, headphones, clock, eraser
