### PR TITLE
feat(suno): add voice management UI with persona selector

### DIFF
--- a/src/components/suno/config/PersonaInput.vue
+++ b/src/components/suno/config/PersonaInput.vue
@@ -1,27 +1,68 @@
 <template>
   <div class="field">
-    <div class="flex items-center mb-2">
-      <h2 class="text-sm font-bold m-0">{{ $t('suno.name.persona') }}</h2>
-      <info-icon :content="$t('suno.description.persona')" />
+    <div class="flex items-center justify-between mb-2">
+      <div class="flex items-center">
+        <h2 class="text-sm font-bold m-0">{{ $t('suno.name.persona') }}</h2>
+        <info-icon :content="$t('suno.description.persona')" />
+      </div>
+      <el-button type="primary" size="small" text @click="showManager = true">
+        <font-awesome-icon icon="fa-solid fa-microphone" class="mr-1" />
+        {{ $t('suno.voice.manage') }}
+      </el-button>
     </div>
-    <el-input v-model="personaId" size="small" :placeholder="$t('suno.placeholder.personaId')" />
+    <el-select
+      v-model="personaId"
+      size="small"
+      :placeholder="$t('suno.placeholder.personaId')"
+      clearable
+      filterable
+      class="w-full"
+    >
+      <el-option
+        v-for="persona in personas"
+        :key="persona.persona_id || ''"
+        :value="persona.persona_id || ''"
+        :label="persona.name || persona.persona_id || ''"
+      >
+        <div class="flex items-center justify-between w-full">
+          <span>{{ persona.name || persona.persona_id }}</span>
+          <span v-if="persona.source_type" class="text-xs text-gray-400 ml-2">{{ persona.source_type }}</span>
+        </div>
+      </el-option>
+    </el-select>
+    <el-drawer v-model="showManager" :title="$t('suno.voice.title')" size="380px" direction="rtl">
+      <voice-manager />
+    </el-drawer>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElInput } from 'element-plus';
+import { ElSelect, ElOption, ElButton, ElDrawer } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import InfoIcon from '@/components/common/InfoIcon.vue';
+import VoiceManager from '@/components/suno/voice/VoiceManager.vue';
+import { ISunoPersona } from '@/models';
 
 export default defineComponent({
   name: 'PersonaInput',
   components: {
-    ElInput,
-    InfoIcon
+    ElSelect,
+    ElOption,
+    ElButton,
+    ElDrawer,
+    FontAwesomeIcon,
+    InfoIcon,
+    VoiceManager
+  },
+  data() {
+    return {
+      showManager: false
+    };
   },
   computed: {
     personaId: {
-      get() {
+      get(): string {
         return this.$store.state.suno?.config?.persona_id || '';
       },
       set(val: string) {
@@ -30,6 +71,9 @@ export default defineComponent({
           persona_id: val || undefined
         });
       }
+    },
+    personas(): ISunoPersona[] {
+      return this.$store.state.suno?.personas || [];
     }
   }
 });

--- a/src/components/suno/voice/VoiceCreateDialog.vue
+++ b/src/components/suno/voice/VoiceCreateDialog.vue
@@ -1,0 +1,141 @@
+<template>
+  <el-dialog
+    v-model="visible"
+    :title="$t('suno.voice.createTitle')"
+    width="480px"
+    :close-on-click-modal="false"
+    @close="onClose"
+  >
+    <el-form label-position="top" class="voice-create-form">
+      <el-form-item :label="$t('suno.voice.name')">
+        <el-input v-model="form.name" :placeholder="$t('suno.voice.namePlaceholder')" maxlength="50" />
+      </el-form-item>
+      <el-form-item :label="$t('suno.voice.description')">
+        <el-input
+          v-model="form.description"
+          type="textarea"
+          :rows="2"
+          :placeholder="$t('suno.voice.descriptionPlaceholder')"
+          maxlength="200"
+        />
+      </el-form-item>
+      <el-form-item :label="$t('suno.voice.sourceType')">
+        <el-radio-group v-model="sourceType" class="w-full">
+          <el-radio value="song">{{ $t('suno.voice.fromSong') }}</el-radio>
+          <el-radio value="upload">{{ $t('suno.voice.fromUpload') }}</el-radio>
+        </el-radio-group>
+      </el-form-item>
+      <el-form-item v-if="sourceType === 'song'" :label="$t('suno.voice.audioId')">
+        <el-input v-model="form.audio_id" :placeholder="$t('suno.voice.audioIdPlaceholder')" />
+      </el-form-item>
+      <el-form-item v-if="sourceType === 'upload'" :label="$t('suno.voice.audioUrl')">
+        <el-input v-model="form.audio_url" :placeholder="$t('suno.voice.audioUrlPlaceholder')" />
+      </el-form-item>
+    </el-form>
+    <template #footer>
+      <el-button @click="onClose">{{ $t('common.button.cancel') }}</el-button>
+      <el-button type="primary" :loading="loading" :disabled="!canSubmit" @click="onSubmit">
+        {{ $t('suno.voice.create') }}
+      </el-button>
+    </template>
+  </el-dialog>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElDialog, ElForm, ElFormItem, ElInput, ElButton, ElRadioGroup, ElRadio, ElMessage } from 'element-plus';
+import { sunoOperator } from '@/operators';
+
+export default defineComponent({
+  name: 'VoiceCreateDialog',
+  components: {
+    ElDialog,
+    ElForm,
+    ElFormItem,
+    ElInput,
+    ElButton,
+    ElRadioGroup,
+    ElRadio
+  },
+  props: {
+    modelValue: {
+      type: Boolean,
+      default: false
+    }
+  },
+  emits: ['update:modelValue', 'created'],
+  data() {
+    return {
+      sourceType: 'song' as 'song' | 'upload',
+      form: {
+        name: '',
+        description: '',
+        audio_id: '',
+        audio_url: ''
+      },
+      loading: false
+    };
+  },
+  computed: {
+    visible: {
+      get(): boolean {
+        return this.modelValue;
+      },
+      set(val: boolean) {
+        this.$emit('update:modelValue', val);
+      }
+    },
+    token(): string | undefined {
+      return this.$store.state.suno?.credential?.token;
+    },
+    canSubmit(): boolean {
+      if (!this.form.name) return false;
+      if (this.sourceType === 'song' && !this.form.audio_id) return false;
+      if (this.sourceType === 'upload' && !this.form.audio_url) return false;
+      return true;
+    }
+  },
+  methods: {
+    onClose() {
+      this.visible = false;
+      this.resetForm();
+    },
+    resetForm() {
+      this.form = { name: '', description: '', audio_id: '', audio_url: '' };
+      this.sourceType = 'song';
+    },
+    async onSubmit() {
+      if (!this.token) return;
+      this.loading = true;
+      try {
+        if (this.sourceType === 'song') {
+          await sunoOperator.persona(
+            {
+              audio_id: this.form.audio_id,
+              name: this.form.name,
+              description: this.form.description
+            },
+            { token: this.token }
+          );
+        } else {
+          await sunoOperator.voices(
+            {
+              audio_url: this.form.audio_url,
+              name: this.form.name,
+              description: this.form.description
+            },
+            { token: this.token }
+          );
+        }
+        ElMessage.success(this.$t('suno.voice.createSuccess'));
+        this.$emit('created');
+        this.onClose();
+      } catch {
+        ElMessage.error(this.$t('suno.voice.createFailed'));
+      } finally {
+        this.loading = false;
+      }
+    }
+  }
+});
+</script>

--- a/src/components/suno/voice/VoiceManager.vue
+++ b/src/components/suno/voice/VoiceManager.vue
@@ -1,0 +1,192 @@
+<template>
+  <div class="voice-manager">
+    <div class="flex items-center justify-between mb-3">
+      <span class="text-sm font-medium">{{ $t('suno.voice.title') }}</span>
+      <el-button type="primary" size="small" @click="showCreateDialog = true">
+        <font-awesome-icon icon="fa-solid fa-plus" class="mr-1" />
+        {{ $t('suno.voice.create') }}
+      </el-button>
+    </div>
+    <div v-if="loading" class="text-center py-6">
+      <el-icon class="is-loading"><loading /></el-icon>
+    </div>
+    <div v-else-if="!personas || personas.length === 0" class="text-center py-6 text-gray-400 text-sm">
+      {{ $t('suno.voice.empty') }}
+    </div>
+    <div v-else class="voice-list">
+      <div
+        v-for="persona in personas"
+        :key="persona.persona_id"
+        class="voice-item"
+        :class="{ active: selectedPersonaId === persona.persona_id }"
+        @click="selectPersona(persona)"
+      >
+        <div class="flex-1 min-w-0">
+          <div class="voice-name">
+            <font-awesome-icon
+              :icon="persona.source_type === 'voice' ? 'fa-solid fa-microphone' : 'fa-solid fa-music'"
+              class="mr-1.5 text-xs opacity-60"
+            />
+            {{ persona.name || persona.persona_id }}
+          </div>
+          <div v-if="persona.description" class="voice-desc">{{ persona.description }}</div>
+        </div>
+        <div class="voice-actions" @click.stop>
+          <el-button
+            type="danger"
+            size="small"
+            text
+            :loading="deletingId === persona.persona_id"
+            @click="onDelete(persona)"
+          >
+            <font-awesome-icon icon="fa-solid fa-trash" />
+          </el-button>
+        </div>
+      </div>
+    </div>
+    <voice-create-dialog v-model="showCreateDialog" @created="onCreated" />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElButton, ElIcon, ElMessage, ElMessageBox } from 'element-plus';
+import { Loading } from '@element-plus/icons-vue';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import VoiceCreateDialog from './VoiceCreateDialog.vue';
+import { ISunoPersona } from '@/models';
+
+export default defineComponent({
+  name: 'VoiceManager',
+  components: {
+    ElButton,
+    ElIcon,
+    Loading,
+    FontAwesomeIcon,
+    VoiceCreateDialog
+  },
+  data() {
+    return {
+      showCreateDialog: false,
+      loading: false,
+      deletingId: null as string | null
+    };
+  },
+  computed: {
+    personas(): ISunoPersona[] {
+      return this.$store.state.suno?.personas || [];
+    },
+    selectedPersonaId(): string | undefined {
+      return this.$store.state.suno?.config?.persona_id;
+    }
+  },
+  watch: {
+    '$store.state.suno.credential': {
+      handler() {
+        this.loadPersonas();
+      },
+      immediate: true
+    }
+  },
+  methods: {
+    async loadPersonas() {
+      if (!this.$store.state.suno?.credential?.token) return;
+      this.loading = true;
+      try {
+        await this.$store.dispatch('suno/getPersonas');
+      } finally {
+        this.loading = false;
+      }
+    },
+    selectPersona(persona: ISunoPersona) {
+      const config = { ...this.$store.state.suno?.config };
+      if (config.persona_id === persona.persona_id) {
+        config.persona_id = undefined;
+      } else {
+        config.persona_id = persona.persona_id;
+      }
+      this.$store.dispatch('suno/setConfig', config);
+    },
+    async onDelete(persona: ISunoPersona) {
+      try {
+        await ElMessageBox.confirm(this.$t('suno.voice.confirmDelete'), this.$t('suno.voice.delete'), {
+          type: 'warning',
+          confirmButtonText: this.$t('common.button.confirm'),
+          cancelButtonText: this.$t('common.button.cancel')
+        });
+      } catch {
+        return;
+      }
+      if (!persona.persona_id) return;
+      this.deletingId = persona.persona_id;
+      const success = await this.$store.dispatch('suno/deletePersona', persona.persona_id);
+      this.deletingId = null;
+      if (success) {
+        ElMessage.success(this.$t('suno.voice.deleteSuccess'));
+        // Clear selection if deleted persona was selected
+        if (this.selectedPersonaId === persona.persona_id) {
+          const config = { ...this.$store.state.suno?.config, persona_id: undefined };
+          this.$store.dispatch('suno/setConfig', config);
+        }
+      } else {
+        ElMessage.error(this.$t('suno.voice.deleteFailed'));
+      }
+    },
+    async onCreated() {
+      await this.loadPersonas();
+    }
+  }
+});
+</script>
+
+<style scoped>
+.voice-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.voice-item {
+  display: flex;
+  align-items: center;
+  padding: 8px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  border: 1px solid var(--el-border-color-lighter);
+  transition: all 0.2s;
+}
+
+.voice-item:hover {
+  border-color: var(--el-color-primary-light-5);
+  background: var(--el-fill-color-light);
+}
+
+.voice-item.active {
+  border-color: var(--el-color-primary);
+  background: var(--el-color-primary-light-9);
+}
+
+.voice-name {
+  font-size: 13px;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.voice-desc {
+  font-size: 11px;
+  color: var(--el-text-color-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin-top: 2px;
+}
+
+.voice-actions {
+  flex-shrink: 0;
+  margin-left: 8px;
+}
+</style>

--- a/src/i18n/en/suno.json
+++ b/src/i18n/en/suno.json
@@ -1,4 +1,92 @@
 {
+  "voice.title": {
+    "message": "Voice Management",
+    "description": "Voice management panel title"
+  },
+  "voice.manage": {
+    "message": "Manage Voices",
+    "description": "Manage voices button text"
+  },
+  "voice.create": {
+    "message": "Create Voice",
+    "description": "Create voice button text"
+  },
+  "voice.createTitle": {
+    "message": "Create New Voice",
+    "description": "Create voice dialog title"
+  },
+  "voice.name": {
+    "message": "Name",
+    "description": "Voice name label"
+  },
+  "voice.namePlaceholder": {
+    "message": "Give your voice a name...",
+    "description": "Voice name input placeholder"
+  },
+  "voice.description": {
+    "message": "Description",
+    "description": "Voice description label"
+  },
+  "voice.descriptionPlaceholder": {
+    "message": "Describe the characteristics of this voice...",
+    "description": "Voice description input placeholder"
+  },
+  "voice.sourceType": {
+    "message": "Source Type",
+    "description": "Voice source type label"
+  },
+  "voice.fromSong": {
+    "message": "From Song",
+    "description": "Create voice from existing song option"
+  },
+  "voice.fromUpload": {
+    "message": "Upload Audio Clone",
+    "description": "Upload audio file to clone voice option"
+  },
+  "voice.audioId": {
+    "message": "Song ID",
+    "description": "Song ID label"
+  },
+  "voice.audioIdPlaceholder": {
+    "message": "Enter song ID...",
+    "description": "Song ID input placeholder"
+  },
+  "voice.audioUrl": {
+    "message": "Audio URL",
+    "description": "Audio URL label"
+  },
+  "voice.audioUrlPlaceholder": {
+    "message": "Enter audio file URL...",
+    "description": "Audio URL input placeholder"
+  },
+  "voice.createSuccess": {
+    "message": "Voice created successfully, please check the list later",
+    "description": "Voice creation success message"
+  },
+  "voice.createFailed": {
+    "message": "Failed to create voice",
+    "description": "Voice creation failed message"
+  },
+  "voice.empty": {
+    "message": "No voices yet, click the button above to create one",
+    "description": "Hint when voice list is empty"
+  },
+  "voice.delete": {
+    "message": "Delete Voice",
+    "description": "Delete voice confirmation title"
+  },
+  "voice.confirmDelete": {
+    "message": "Are you sure you want to delete this voice? This action cannot be undone.",
+    "description": "Delete voice confirmation message"
+  },
+  "voice.deleteSuccess": {
+    "message": "Voice deleted",
+    "description": "Voice deletion success message"
+  },
+  "voice.deleteFailed": {
+    "message": "Failed to delete voice",
+    "description": "Voice deletion failed message"
+  },
   "button.extend": {
     "message": "Continue Generating",
     "description": "Text for the continue generating button"

--- a/src/i18n/zh-CN/suno.json
+++ b/src/i18n/zh-CN/suno.json
@@ -1,4 +1,92 @@
 {
+  "voice.title": {
+    "message": "声音管理",
+    "description": "声音管理面板标题"
+  },
+  "voice.manage": {
+    "message": "管理声音",
+    "description": "管理声音按钮文本"
+  },
+  "voice.create": {
+    "message": "创建声音",
+    "description": "创建声音按钮文本"
+  },
+  "voice.createTitle": {
+    "message": "创建新声音",
+    "description": "创建声音对话框标题"
+  },
+  "voice.name": {
+    "message": "名称",
+    "description": "声音名称标签"
+  },
+  "voice.namePlaceholder": {
+    "message": "为声音取个名称...",
+    "description": "声音名称输入占位符"
+  },
+  "voice.description": {
+    "message": "描述",
+    "description": "声音描述标签"
+  },
+  "voice.descriptionPlaceholder": {
+    "message": "描述这个声音的特点...",
+    "description": "声音描述输入占位符"
+  },
+  "voice.sourceType": {
+    "message": "来源类型",
+    "description": "声音来源类型标签"
+  },
+  "voice.fromSong": {
+    "message": "从歌曲创建",
+    "description": "从已有歌曲创建声音选项"
+  },
+  "voice.fromUpload": {
+    "message": "上传音频克隆",
+    "description": "上传音频文件克隆声音选项"
+  },
+  "voice.audioId": {
+    "message": "歌曲 ID",
+    "description": "歌曲 ID 标签"
+  },
+  "voice.audioIdPlaceholder": {
+    "message": "输入歌曲 ID...",
+    "description": "歌曲 ID 输入占位符"
+  },
+  "voice.audioUrl": {
+    "message": "音频 URL",
+    "description": "音频 URL 标签"
+  },
+  "voice.audioUrlPlaceholder": {
+    "message": "输入音频文件 URL...",
+    "description": "音频 URL 输入占位符"
+  },
+  "voice.createSuccess": {
+    "message": "声音创建成功，请稍后在列表中查看",
+    "description": "声音创建成功消息"
+  },
+  "voice.createFailed": {
+    "message": "声音创建失败",
+    "description": "声音创建失败消息"
+  },
+  "voice.empty": {
+    "message": "暂无声音，点击上方按钮创建",
+    "description": "声音列表为空时的提示"
+  },
+  "voice.delete": {
+    "message": "删除声音",
+    "description": "删除声音确认标题"
+  },
+  "voice.confirmDelete": {
+    "message": "确定要删除这个声音吗？此操作不可撤销。",
+    "description": "删除声音确认消息"
+  },
+  "voice.deleteSuccess": {
+    "message": "声音已删除",
+    "description": "声音删除成功消息"
+  },
+  "voice.deleteFailed": {
+    "message": "删除声音失败",
+    "description": "声音删除失败消息"
+  },
   "button.extend": {
     "message": "继续生成",
     "description": "继续生成按钮文本"

--- a/src/models/suno.ts
+++ b/src/models/suno.ts
@@ -171,14 +171,26 @@ export interface ISunoPersonaRequest {
 
 export interface ISunoPersona {
   id?: string;
+  persona_id?: string;
   name?: string;
   description?: string;
+  source_type?: 'persona' | 'voice';
+  source_audio_id?: string;
+  source_audio_url?: string;
+  user_id?: string;
+  task_id?: string;
+  created_at?: number;
 }
 
 export interface ISunoPersonaResponse {
   success?: boolean;
   task_id: string;
   data: ISunoPersona;
+}
+
+export interface ISunoPersonasListResponse {
+  items: ISunoPersona[];
+  count: number;
 }
 
 export interface ISunoVoxRequest {

--- a/src/operators/suno.ts
+++ b/src/operators/suno.ts
@@ -21,7 +21,8 @@ import {
   ISunoVoicesRequest,
   ISunoVoicesResponse,
   ISunoMashupLyricsRequest,
-  ISunoMashupLyricsResponse
+  ISunoMashupLyricsResponse,
+  ISunoPersonasListResponse
 } from '@/models';
 import { BASE_URL_API } from '@/constants';
 
@@ -303,6 +304,50 @@ class SunoOperator {
       },
       baseURL: BASE_URL_API
     });
+  }
+
+  // suno/personas - list user personas
+  async personasList(
+    data: { user_id: string; limit?: number; offset?: number },
+    options: { token: string }
+  ): Promise<AxiosResponse<ISunoPersonasListResponse>> {
+    return await axios.post(
+      '/suno/personas',
+      {
+        action: 'list',
+        ...data
+      },
+      {
+        headers: {
+          authorization: `Bearer ${options.token}`,
+          'content-type': 'application/json',
+          'x-record-exempt': 'true'
+        },
+        baseURL: BASE_URL_API
+      }
+    );
+  }
+
+  // suno/personas - delete a persona
+  async personasDelete(
+    data: { persona_id: string; user_id?: string },
+    options: { token: string }
+  ): Promise<AxiosResponse<{ success: boolean }>> {
+    return await axios.post(
+      '/suno/personas',
+      {
+        action: 'delete',
+        ...data
+      },
+      {
+        headers: {
+          authorization: `Bearer ${options.token}`,
+          'content-type': 'application/json',
+          'x-record-exempt': 'true'
+        },
+        baseURL: BASE_URL_API
+      }
+    );
   }
 }
 

--- a/src/operators/suno.ts
+++ b/src/operators/suno.ts
@@ -306,48 +306,34 @@ class SunoOperator {
     });
   }
 
-  // suno/personas - list user personas
+  // GET /suno/persona - list user personas
   async personasList(
     data: { user_id: string; limit?: number; offset?: number },
     options: { token: string }
   ): Promise<AxiosResponse<ISunoPersonasListResponse>> {
-    return await axios.post(
-      '/suno/personas',
-      {
-        action: 'list',
-        ...data
+    return await axios.get('/suno/persona', {
+      params: data,
+      headers: {
+        authorization: `Bearer ${options.token}`,
+        'x-record-exempt': 'true'
       },
-      {
-        headers: {
-          authorization: `Bearer ${options.token}`,
-          'content-type': 'application/json',
-          'x-record-exempt': 'true'
-        },
-        baseURL: BASE_URL_API
-      }
-    );
+      baseURL: BASE_URL_API
+    });
   }
 
-  // suno/personas - delete a persona
+  // DELETE /suno/persona - delete a persona
   async personasDelete(
     data: { persona_id: string; user_id?: string },
     options: { token: string }
   ): Promise<AxiosResponse<{ success: boolean }>> {
-    return await axios.post(
-      '/suno/personas',
-      {
-        action: 'delete',
-        ...data
+    return await axios.delete('/suno/persona', {
+      params: data,
+      headers: {
+        authorization: `Bearer ${options.token}`,
+        'x-record-exempt': 'true'
       },
-      {
-        headers: {
-          authorization: `Bearer ${options.token}`,
-          'content-type': 'application/json',
-          'x-record-exempt': 'true'
-        },
-        baseURL: BASE_URL_API
-      }
-    );
+      baseURL: BASE_URL_API
+    });
   }
 }
 

--- a/src/store/suno/actions.ts
+++ b/src/store/suno/actions.ts
@@ -2,7 +2,7 @@ import { applicationOperator, sunoOperator, serviceOperator, credentialOperator 
 import { ISunoState } from './models';
 import { ActionContext } from 'vuex';
 import { IRootState } from '../common/models';
-import { IApplication, ICredential, ISunoConfig, ISunoTask, IService } from '@/models';
+import { IApplication, ICredential, ISunoConfig, ISunoPersona, ISunoTask, IService } from '@/models';
 import { Status } from '@/models/common';
 import { SUNO_SERVICE_ID } from '@/constants';
 import { mergeAndSortLists } from '@/utils/merge';
@@ -173,6 +173,49 @@ export const getTasks = async (
   });
 };
 
+export const getPersonas = async ({
+  commit,
+  state,
+  rootState
+}: ActionContext<ISunoState, IRootState>): Promise<ISunoPersona[]> => {
+  const credential = state.credential;
+  const token = credential?.token;
+  if (!token) {
+    return [];
+  }
+  const userId = rootState?.user?.id;
+  if (!userId) {
+    return [];
+  }
+  try {
+    const { data } = await sunoOperator.personasList({ user_id: userId }, { token });
+    commit('setPersonas', data.items || []);
+    return data.items || [];
+  } catch (error) {
+    console.error('get personas failed', error);
+    return [];
+  }
+};
+
+export const deletePersona = async (
+  { state, dispatch, rootState }: ActionContext<ISunoState, IRootState>,
+  personaId: string
+): Promise<boolean> => {
+  const credential = state.credential;
+  const token = credential?.token;
+  if (!token) {
+    return false;
+  }
+  try {
+    await sunoOperator.personasDelete({ persona_id: personaId, user_id: rootState?.user?.id }, { token });
+    await dispatch('getPersonas');
+    return true;
+  } catch (error) {
+    console.error('delete persona failed', error);
+    return false;
+  }
+};
+
 export default {
   setService,
   getService,
@@ -188,5 +231,7 @@ export default {
   setTasksActive,
   getTasks,
   setAudio,
+  getPersonas,
+  deletePersona,
   createCredential
 };

--- a/src/store/suno/models.ts
+++ b/src/store/suno/models.ts
@@ -1,4 +1,4 @@
-import { IApplication, ICredential, IService, ISunoAudio, Status } from '@/models';
+import { IApplication, ICredential, IService, ISunoAudio, ISunoPersona, Status } from '@/models';
 import { ISunoConfig, ISunoTask } from '@/models';
 
 export interface ISunoState {
@@ -15,6 +15,7 @@ export interface ISunoState {
       }
     | undefined;
   audio: ISunoAudio | undefined;
+  personas: ISunoPersona[] | undefined;
   status: {
     getService: Status;
     getApplications: Status;

--- a/src/store/suno/mutations.ts
+++ b/src/store/suno/mutations.ts
@@ -1,4 +1,4 @@
-import { IApplication, ICredential, ISunoConfig, ISunoTask, IService } from '@/models';
+import { IApplication, ICredential, ISunoConfig, ISunoPersona, ISunoTask, IService } from '@/models';
 import { ISunoState } from './models';
 
 export const resetAll = (state: ISunoState): void => {
@@ -8,6 +8,7 @@ export const resetAll = (state: ISunoState): void => {
   state.config = undefined;
   state.credential = undefined;
   state.tasks = undefined;
+  state.personas = undefined;
 };
 
 export const setApplications = (state: ISunoState, payload: IApplication[]): void => {
@@ -62,6 +63,10 @@ export const setTasks = (state: ISunoState, payload: any): void => {
   state.tasks = payload;
 };
 
+export const setPersonas = (state: ISunoState, payload: ISunoPersona[]): void => {
+  state.personas = payload;
+};
+
 export default {
   setTasks,
   setApplication,
@@ -73,5 +78,6 @@ export default {
   setTasksItems,
   setTasksTotal,
   setAudio,
+  setPersonas,
   resetAll
 };

--- a/src/store/suno/state.ts
+++ b/src/store/suno/state.ts
@@ -12,6 +12,7 @@ export default (): ISunoState => {
     },
     credential: undefined,
     config: undefined,
+    personas: undefined,
     status: {
       getService: Status.None,
       getApplications: Status.None,


### PR DESCRIPTION
## Summary

Add voice management UI for Suno, allowing users to create, list, select, and delete voice personas directly from the Nexior frontend.

## Changes

### PersonaInput Redesign
- Replaced raw text input with a searchable dropdown selector populated from user's saved personas
- Added "Manage Voices" button that opens a side drawer

### VoiceManager Panel (New)
- Lists all user's saved voice personas with name, description, and source type
- Click to select/deselect a persona for generation
- Delete button with confirmation dialog
- Loading state and empty state

### VoiceCreateDialog (New)
- Create voice from existing song (persona API) or upload audio URL (voice clone API)
- Name and description fields
- Radio toggle between "From Song" and "Upload Audio Clone" modes

### Store & Operator
- Added `personas` to Vuex state/mutations/actions
- Added `personasList()` and `personasDelete()` operator methods for `/suno/personas` endpoint
- Extended `ISunoPersona` model with full MongoDB document shape

### i18n
- Added zh-CN and en locale keys for all voice management strings

## Depends On
- https://github.com/AceDataCloud/PlatformService/pull/768 (merged - backend persona storage)