### PR TITLE
feat(suno): add expand fullscreen lyrics editor

### DIFF
--- a/src/components/suno/config/LyricInput.vue
+++ b/src/components/suno/config/LyricInput.vue
@@ -16,6 +16,11 @@
             <font-awesome-icon icon="fa-solid fa-eraser" />
           </el-button>
         </el-tooltip>
+        <el-tooltip :content="$t('suno.button.expand_lyrics')" placement="top">
+          <el-button size="small" circle @click="expanded = true">
+            <font-awesome-icon icon="fa-solid fa-expand" />
+          </el-button>
+        </el-tooltip>
         <el-button
           v-if="config?.action !== 'extend'"
           size="small"
@@ -61,12 +66,72 @@
         </template>
       </el-input>
     </div>
+    <!-- Fullscreen lyrics editor -->
+    <el-dialog
+      v-model="expanded"
+      :title="$t('suno.name.lyrics')"
+      width="720px"
+      top="5vh"
+      :close-on-click-modal="false"
+      class="lyrics-expand-dialog"
+    >
+      <el-input
+        v-model="lyric"
+        type="textarea"
+        :rows="20"
+        class="lyrics-expanded"
+        :placeholder="$t('suno.placeholder.lyrics')"
+        autofocus
+      />
+      <div v-if="config?.action !== 'extend'" class="enhance-bar mt-3">
+        <el-input
+          v-model="enhancePrompt"
+          size="small"
+          :placeholder="$t('suno.placeholder.enhanceLyrics')"
+          class="enhance-input"
+          @keyup.enter="onEnhanceLyrics"
+        >
+          <template #append>
+            <el-button :loading="enhancingLyrics" @click="onEnhanceLyrics">
+              <font-awesome-icon v-if="!enhancingLyrics" icon="fa-solid fa-wand-magic-sparkles" class="mr-1" />
+              {{ $t('suno.button.enhance_lyrics') }}
+            </el-button>
+          </template>
+        </el-input>
+      </div>
+      <template #footer>
+        <div class="flex items-center justify-between">
+          <div class="flex items-center gap-1">
+            <el-button v-if="lyricHistory.length > 0" size="small" @click="onUndo">
+              <font-awesome-icon icon="fa-solid fa-rotate-left" class="mr-1" />
+              {{ $t('suno.button.undo') }}
+            </el-button>
+            <el-button v-if="lyric" size="small" @click="onClear">
+              <font-awesome-icon icon="fa-solid fa-eraser" class="mr-1" />
+              {{ $t('suno.button.clear_lyrics') }}
+            </el-button>
+            <el-button
+              v-if="config?.action !== 'extend'"
+              size="small"
+              :loading="generatingLyrics"
+              @click="onGenerateLyrics"
+            >
+              <font-awesome-icon v-if="!generatingLyrics" icon="fa-solid fa-wand-magic-sparkles" class="mr-1" />
+              {{ $t('suno.button.generate_lyrics') }}
+            </el-button>
+          </div>
+          <el-button type="primary" @click="expanded = false">
+            {{ $t('common.button.confirm') }}
+          </el-button>
+        </div>
+      </template>
+    </el-dialog>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElInput, ElButton, ElMessage, ElTooltip } from 'element-plus';
+import { ElInput, ElButton, ElMessage, ElTooltip, ElDialog } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import { sunoOperator } from '@/operators';
@@ -79,6 +144,7 @@ export default defineComponent({
     ElInput,
     ElButton,
     ElTooltip,
+    ElDialog,
     FontAwesomeIcon,
     InfoIcon
   },
@@ -87,7 +153,8 @@ export default defineComponent({
       generatingLyrics: false,
       enhancingLyrics: false,
       enhancePrompt: '',
-      lyricHistory: [] as string[]
+      lyricHistory: [] as string[],
+      expanded: false
     };
   },
   computed: {
@@ -201,6 +268,14 @@ export default defineComponent({
     :deep(.el-input-group__append) {
       padding: 0 12px;
     }
+  }
+}
+
+.lyrics-expanded {
+  :deep(.el-textarea__inner) {
+    font-family: monospace;
+    line-height: 1.8;
+    font-size: 14px;
   }
 }
 </style>

--- a/src/i18n/en/suno.json
+++ b/src/i18n/en/suno.json
@@ -671,6 +671,10 @@
     "message": "Clear lyrics",
     "description": "Clear lyrics button tooltip"
   },
+  "button.expand_lyrics": {
+    "message": "Expand editor",
+    "description": "Expand lyrics fullscreen editor button tooltip"
+  },
   "button.enhance_lyrics": {
     "message": "Enhance",
     "description": "Enhance lyrics button"

--- a/src/i18n/zh-CN/suno.json
+++ b/src/i18n/zh-CN/suno.json
@@ -671,6 +671,10 @@
     "message": "清空歌词",
     "description": "清空歌词按钮提示"
   },
+  "button.expand_lyrics": {
+    "message": "展开编辑",
+    "description": "展开歌词全屏编辑按钮提示"
+  },
   "button.enhance_lyrics": {
     "message": "增强",
     "description": "增强歌词按钮"

--- a/src/plugins/font-awesome.ts
+++ b/src/plugins/font-awesome.ts
@@ -112,7 +112,9 @@ import {
   faClock as faSolidClock,
   faEraser as faSolidEraser,
   faArrowDownWideShort as faSolidArrowDownWideShort,
-  faPen as faSolidPen
+  faPen as faSolidPen,
+  faExpand as faSolidExpand,
+  faCompress as faSolidCompress
 } from '@fortawesome/free-solid-svg-icons';
 // add icons
 library.add(faSolidEllipsis);
@@ -224,3 +226,5 @@ library.add(faSolidClock);
 library.add(faSolidEraser);
 library.add(faSolidArrowDownWideShort);
 library.add(faSolidPen);
+library.add(faSolidExpand);
+library.add(faSolidCompress);


### PR DESCRIPTION
## Summary

Add an expand button to the lyrics toolbar that opens a fullscreen dialog for comfortable lyrics editing.

## Changes

- **LyricInput.vue**: Add expand icon button to toolbar → opens `el-dialog` with 20-row textarea
- **LyricInput.vue**: Dialog footer includes all toolbar actions (Undo/Clear/Generate Lyrics) + Enhance bar
- **font-awesome.ts**: Register `faExpand` and `faCompress` icons
- **i18n**: Add `button.expand_lyrics` key for zh-CN and en

## Why

The current lyrics textarea is only 5 rows — too small for editing long, multi-verse lyrics. Suno.com offers a full-height editor. This dialog provides a spacious editing experience while keeping all existing toolbar features accessible.

## Testing

- `vue-tsc -b` ✅
- `eslint` ✅