### PR TITLE
feat(suno): add audio Browse/Record dialog for reference audio

### DIFF
--- a/src/components/suno/config/UploadAudio.vue
+++ b/src/components/suno/config/UploadAudio.vue
@@ -1,49 +1,135 @@
 <template>
   <div class="relative">
-    <div class="flex justify-between">
+    <div class="flex justify-between items-center mb-2">
       <div class="flex justify-start items-center">
         <span class="text-sm font-bold">{{ $t('suno.name.referenceAudios') }}</span>
         <info-icon :content="$t('suno.description.uploadAudios')" />
       </div>
-    </div>
-    <el-upload
-      v-model:file-list="fileList"
-      name="file"
-      :limit="1"
-      class="upload-wrapper"
-      :action="uploadUrl"
-      accept=".mp3"
-      :show-file-list="true"
-      :on-exceed="onExceed"
-      :on-error="onError"
-      :on-success="onSuccess"
-      :headers="headers"
-    >
-      <el-button round type="primary" size="small" class="btn btn-upload">
-        <font-awesome-icon icon="fa-solid fa-upload" class="icon mr-1" />
-        {{ $t('suno.button.uploadAudios') }}
+      <el-button round type="primary" size="small" @click="dialogVisible = true">
+        <font-awesome-icon icon="fa-solid fa-plus" class="icon mr-1" />
+        {{ $t('suno.button.addAudio') }}
       </el-button>
-    </el-upload>
+    </div>
+    <div v-if="audioPreviewUrl" class="mb-2">
+      <audio :src="audioPreviewUrl" controls class="w-full" />
+    </div>
     <div v-if="hasUploadedAudio" class="mt-2">
       <el-radio-group v-model="uploadAction" size="small">
         <el-radio-button value="upload_extend">{{ $t('suno.button.extend') }}</el-radio-button>
         <el-radio-button value="upload_cover">{{ $t('suno.button.upload_cover') }}</el-radio-button>
       </el-radio-group>
     </div>
+
+    <el-dialog
+      v-model="dialogVisible"
+      :title="$t('suno.name.addAudio')"
+      width="520px"
+      :close-on-click-modal="false"
+      append-to-body
+    >
+      <el-tabs v-model="activeTab" class="add-audio-tabs">
+        <el-tab-pane name="browse" :label="$t('suno.tab.browse')">
+          <div class="py-4">
+            <el-upload
+              v-model:file-list="fileList"
+              name="file"
+              :limit="1"
+              class="upload-wrapper"
+              :action="uploadUrl"
+              accept=".mp3,.wav,.m4a,audio/*"
+              :show-file-list="true"
+              :on-exceed="onExceed"
+              :on-error="onError"
+              :on-success="onBrowseSuccess"
+              :headers="headers"
+              drag
+            >
+              <div class="text-center py-6">
+                <font-awesome-icon icon="fa-solid fa-upload" class="text-4xl text-gray-400 mb-3" />
+                <div class="text-sm">{{ $t('suno.description.dropAudioHere') }}</div>
+                <div class="text-xs text-gray-400 mt-1">{{ $t('suno.description.audioFormats') }}</div>
+              </div>
+            </el-upload>
+          </div>
+        </el-tab-pane>
+        <el-tab-pane name="record" :label="$t('suno.tab.record')">
+          <div class="py-4 text-center">
+            <div class="recorder-display mb-4">
+              <div v-if="recording" class="text-red-500 flex items-center justify-center gap-2">
+                <span class="recording-dot" />
+                <span class="text-2xl font-mono">{{ formattedTime }}</span>
+              </div>
+              <div v-else-if="recordedBlob" class="text-green-600">
+                <font-awesome-icon icon="fa-solid fa-check-circle" class="text-2xl mr-2" />
+                <span>{{ $t('suno.message.recordingReady') }} ({{ formattedTime }})</span>
+              </div>
+              <div v-else class="text-gray-400 text-2xl font-mono">00:00</div>
+            </div>
+            <div v-if="recordedAudioUrl && !recording" class="mb-4">
+              <audio :src="recordedAudioUrl" controls class="w-full" />
+            </div>
+            <div class="flex justify-center gap-3">
+              <el-button v-if="!recording && !recordedBlob" type="primary" round @click="startRecording">
+                <font-awesome-icon icon="fa-solid fa-microphone" class="mr-1" />
+                {{ $t('suno.button.startRecord') }}
+              </el-button>
+              <el-button v-if="recording" type="danger" round @click="stopRecording">
+                <font-awesome-icon icon="fa-solid fa-stop" class="mr-1" />
+                {{ $t('suno.button.stopRecord') }}
+              </el-button>
+              <template v-if="recordedBlob && !recording">
+                <el-button round @click="resetRecording">
+                  <font-awesome-icon icon="fa-solid fa-rotate-left" class="mr-1" />
+                  {{ $t('suno.button.reRecord') }}
+                </el-button>
+                <el-button type="primary" round :loading="uploadingRecord" @click="uploadRecording">
+                  <font-awesome-icon icon="fa-solid fa-upload" class="mr-1" />
+                  {{ $t('suno.button.useRecording') }}
+                </el-button>
+              </template>
+            </div>
+          </div>
+        </el-tab-pane>
+      </el-tabs>
+    </el-dialog>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElUpload, ElButton, UploadFiles, UploadFile, ElMessage, ElRadioGroup, ElRadioButton } from 'element-plus';
+import {
+  ElUpload,
+  ElButton,
+  ElDialog,
+  ElTabs,
+  ElTabPane,
+  UploadFiles,
+  UploadFile,
+  ElMessage,
+  ElRadioGroup,
+  ElRadioButton
+} from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { getBaseUrlPlatform } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import { ISunoUploadRequest } from '@/models';
 import { sunoOperator } from '@/operators';
+
 interface IData {
   fileList: UploadFiles;
   uploadUrl: string;
+  dialogVisible: boolean;
+  activeTab: 'browse' | 'record';
+  recording: boolean;
+  recordedBlob: Blob | null;
+  recordedAudioUrl: string | null;
+  audioPreviewUrl: string | null;
+  recordTimer: number | null;
+  recordSeconds: number;
+  mediaRecorder: MediaRecorder | null;
+  mediaStream: MediaStream | null;
+  recordedChunks: Blob[];
+  uploadingRecord: boolean;
 }
 
 export default defineComponent({
@@ -51,6 +137,9 @@ export default defineComponent({
   components: {
     ElUpload,
     ElButton,
+    ElDialog,
+    ElTabs,
+    ElTabPane,
     InfoIcon,
     FontAwesomeIcon,
     ElRadioGroup,
@@ -60,7 +149,19 @@ export default defineComponent({
   data(): IData {
     return {
       fileList: [],
-      uploadUrl: getBaseUrlPlatform() + '/api/v1/files/'
+      uploadUrl: getBaseUrlPlatform() + '/api/v1/files/',
+      dialogVisible: false,
+      activeTab: 'browse',
+      recording: false,
+      recordedBlob: null,
+      recordedAudioUrl: null,
+      audioPreviewUrl: null,
+      recordTimer: null,
+      recordSeconds: 0,
+      mediaRecorder: null,
+      mediaStream: null,
+      recordedChunks: [],
+      uploadingRecord: false
     };
   },
   computed: {
@@ -99,6 +200,13 @@ export default defineComponent({
           action: val
         });
       }
+    },
+    formattedTime(): string {
+      const m = Math.floor(this.recordSeconds / 60)
+        .toString()
+        .padStart(2, '0');
+      const s = (this.recordSeconds % 60).toString().padStart(2, '0');
+      return `${m}:${s}`;
     }
   },
   watch: {
@@ -108,11 +216,8 @@ export default defineComponent({
       }
     }
   },
-  mounted() {
-    if (!this.value) {
-      this.value = undefined;
-    }
-    this.onSetAudio();
+  beforeUnmount() {
+    this.cleanupRecording();
   },
   methods: {
     onExceed() {
@@ -121,9 +226,13 @@ export default defineComponent({
     onError() {
       ElMessage.error(this.$t('suno.message.uploadReferencesError'));
     },
-    async onSuccess() {
+    async onBrowseSuccess() {
       const url = this.urls?.[0];
-      await this.onGenerateAudioId(url);
+      if (url) {
+        this.audioPreviewUrl = url;
+        await this.onGenerateAudioId(url);
+        this.dialogVisible = false;
+      }
     },
     async onGenerateAudioId(audio_url: string) {
       const request = {
@@ -135,30 +244,118 @@ export default defineComponent({
         return;
       }
       ElMessage.info(this.$t('suno.message.startingUploadAudio'));
-      sunoOperator
-        .upload(request, {
-          token
-        })
-        .then((response) => {
-          console.debug('get upload music success', response.data);
-          const audio_id = response.data?.data.audio_id;
-          this.$store.commit('suno/setConfig', {
-            ...this.$store.state.suno?.config,
-            audio_id: audio_id,
-            action: 'upload_extend'
-          });
-          ElMessage.success(this.$t('suno.message.startUploadAudioSuccess'));
-        })
-        .catch((error) => {
-          ElMessage.error(error?.response?.data?.error?.message || this.$t('suno.message.startUploadAudioFailed'));
+      try {
+        const response = await sunoOperator.upload(request, { token });
+        console.debug('get upload music success', response.data);
+        const audio_id = response.data?.data.audio_id;
+        this.$store.commit('suno/setConfig', {
+          ...this.$store.state.suno?.config,
+          audio_id: audio_id,
+          action: 'upload_extend'
         });
+        ElMessage.success(this.$t('suno.message.startUploadAudioSuccess'));
+      } catch (error: any) {
+        ElMessage.error(error?.response?.data?.error?.message || this.$t('suno.message.startUploadAudioFailed'));
+      }
     },
-    onSetAudio() {
-      // const url = this.urls?.[0];
-      // this.$store.commit('suno/setConfig', {
-      //   ...this.$store.state.suno?.config,
-      //   audio_id: url
-      // });
+    async startRecording() {
+      if (!navigator.mediaDevices?.getUserMedia || typeof MediaRecorder === 'undefined') {
+        ElMessage.error(this.$t('suno.message.recordingUnsupported'));
+        return;
+      }
+      try {
+        this.mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        this.recordedChunks = [];
+        this.mediaRecorder = new MediaRecorder(this.mediaStream);
+        this.mediaRecorder.ondataavailable = (e: BlobEvent) => {
+          if (e.data && e.data.size > 0) {
+            this.recordedChunks.push(e.data);
+          }
+        };
+        this.mediaRecorder.onstop = () => {
+          const blob = new Blob(this.recordedChunks, { type: 'audio/webm' });
+          this.recordedBlob = blob;
+          if (this.recordedAudioUrl) URL.revokeObjectURL(this.recordedAudioUrl);
+          this.recordedAudioUrl = URL.createObjectURL(blob);
+          this.releaseStream();
+        };
+        this.mediaRecorder.start();
+        this.recording = true;
+        this.recordSeconds = 0;
+        this.recordTimer = window.setInterval(() => {
+          this.recordSeconds += 1;
+          if (this.recordSeconds >= 600) {
+            this.stopRecording();
+          }
+        }, 1000);
+      } catch (err: any) {
+        console.error('record error', err);
+        ElMessage.error(this.$t('suno.message.recordingPermissionDenied'));
+      }
+    },
+    stopRecording() {
+      if (this.recordTimer) {
+        window.clearInterval(this.recordTimer);
+        this.recordTimer = null;
+      }
+      if (this.mediaRecorder && this.mediaRecorder.state !== 'inactive') {
+        this.mediaRecorder.stop();
+      }
+      this.recording = false;
+    },
+    resetRecording() {
+      if (this.recordedAudioUrl) {
+        URL.revokeObjectURL(this.recordedAudioUrl);
+      }
+      this.recordedBlob = null;
+      this.recordedAudioUrl = null;
+      this.recordSeconds = 0;
+    },
+    async uploadRecording() {
+      if (!this.recordedBlob) return;
+      this.uploadingRecord = true;
+      try {
+        const formData = new FormData();
+        const filename = `recording-${Date.now()}.webm`;
+        formData.append('file', this.recordedBlob, filename);
+        const resp = await fetch(this.uploadUrl, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${this.$store.state.token.access}`
+          },
+          body: formData
+        });
+        if (!resp.ok) throw new Error(`upload failed: ${resp.status}`);
+        const data = await resp.json();
+        const url = data?.file_url || data?.data?.file_url;
+        if (!url) throw new Error('no file_url in response');
+        this.audioPreviewUrl = url;
+        await this.onGenerateAudioId(url);
+        this.dialogVisible = false;
+        this.resetRecording();
+      } catch (error: any) {
+        console.error(error);
+        ElMessage.error(error?.message || this.$t('suno.message.uploadReferencesError'));
+      } finally {
+        this.uploadingRecord = false;
+      }
+    },
+    releaseStream() {
+      if (this.mediaStream) {
+        this.mediaStream.getTracks().forEach((t) => t.stop());
+        this.mediaStream = null;
+      }
+    },
+    cleanupRecording() {
+      if (this.recordTimer) {
+        window.clearInterval(this.recordTimer);
+        this.recordTimer = null;
+      }
+      this.releaseStream();
+      if (this.recordedAudioUrl) {
+        URL.revokeObjectURL(this.recordedAudioUrl);
+        this.recordedAudioUrl = null;
+      }
     }
   }
 });
@@ -170,20 +367,47 @@ export default defineComponent({
   margin-bottom: 0;
   width: 30%;
 }
-.btn.btn-upload {
-  position: absolute;
-  top: 5px;
-  right: 0;
+.recorder-display {
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.recording-dot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #f56c6c;
+  animation: pulse 1s infinite;
+}
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.3;
+  }
 }
 </style>
 
 <style lang="scss">
 .upload-wrapper {
-  height: auto;
-  display: flex;
+  width: 100%;
+  .el-upload {
+    width: 100%;
+  }
+  .el-upload-dragger {
+    width: 100%;
+    padding: 12px;
+  }
   .el-upload-list {
     margin: 0;
     width: 100%;
   }
+}
+.add-audio-tabs .el-tabs__nav-wrap::after {
+  height: 1px;
 }
 </style>

--- a/src/i18n/en/suno.json
+++ b/src/i18n/en/suno.json
@@ -103,6 +103,58 @@
     "message": "Upload",
     "description": "Text for the button that allows users to upload references"
   },
+  "button.addAudio": {
+    "message": "+ Audio",
+    "description": "Button to open the add-audio dialog (browse or record)"
+  },
+  "button.startRecord": {
+    "message": "Start Recording",
+    "description": "Button to begin microphone recording"
+  },
+  "button.stopRecord": {
+    "message": "Stop",
+    "description": "Button to stop microphone recording"
+  },
+  "button.reRecord": {
+    "message": "Re-record",
+    "description": "Button to discard the current recording and record again"
+  },
+  "button.useRecording": {
+    "message": "Use Recording",
+    "description": "Button to upload the recorded audio as reference"
+  },
+  "name.addAudio": {
+    "message": "Add Audio",
+    "description": "Title of the add-audio dialog"
+  },
+  "tab.browse": {
+    "message": "Browse",
+    "description": "Tab label for browsing local audio files"
+  },
+  "tab.record": {
+    "message": "Record",
+    "description": "Tab label for recording microphone audio"
+  },
+  "description.dropAudioHere": {
+    "message": "Drop audio file here, or click to upload",
+    "description": "Hint inside the audio drop zone"
+  },
+  "description.audioFormats": {
+    "message": "Supported: MP3, WAV, M4A",
+    "description": "Supported audio formats hint"
+  },
+  "message.recordingReady": {
+    "message": "Recording ready",
+    "description": "Shown after recording is complete"
+  },
+  "message.recordingUnsupported": {
+    "message": "Audio recording is not supported in this browser",
+    "description": "Browser does not support MediaRecorder"
+  },
+  "message.recordingPermissionDenied": {
+    "message": "Microphone permission denied or unavailable",
+    "description": "User denied microphone permission"
+  },
   "button.video": {
     "message": "Video",
     "description": "Text for the video button"

--- a/src/i18n/zh-CN/suno.json
+++ b/src/i18n/zh-CN/suno.json
@@ -103,6 +103,58 @@
     "message": "上传",
     "description": "按钮文本，允许用户上传参考"
   },
+  "button.addAudio": {
+    "message": "+ 音频",
+    "description": "打开添加音频对话框的按钮（浏览或录制）"
+  },
+  "button.startRecord": {
+    "message": "开始录制",
+    "description": "开始麦克风录音按钮"
+  },
+  "button.stopRecord": {
+    "message": "停止",
+    "description": "停止麦克风录音按钮"
+  },
+  "button.reRecord": {
+    "message": "重新录制",
+    "description": "丢弃当前录音并重新录制"
+  },
+  "button.useRecording": {
+    "message": "使用此录音",
+    "description": "将录制的音频作为参考上传"
+  },
+  "name.addAudio": {
+    "message": "添加音频",
+    "description": "添加音频对话框的标题"
+  },
+  "tab.browse": {
+    "message": "浏览",
+    "description": "浏览本地音频文件的标签"
+  },
+  "tab.record": {
+    "message": "录制",
+    "description": "录制麦克风音频的标签"
+  },
+  "description.dropAudioHere": {
+    "message": "拖拽音频到此处，或点击上传",
+    "description": "音频拖拽区域的提示文字"
+  },
+  "description.audioFormats": {
+    "message": "支持格式：MP3、WAV、M4A",
+    "description": "支持的音频格式提示"
+  },
+  "message.recordingReady": {
+    "message": "录音已就绪",
+    "description": "录音完成后显示"
+  },
+  "message.recordingUnsupported": {
+    "message": "当前浏览器不支持音频录制",
+    "description": "浏览器不支持 MediaRecorder"
+  },
+  "message.recordingPermissionDenied": {
+    "message": "麦克风权限被拒绝或不可用",
+    "description": "用户拒绝麦克风权限"
+  },
   "button.video": {
     "message": "视频",
     "description": "视频按钮文本"


### PR DESCRIPTION
## P1 — + Audio Browse / Record dialog

Matches Suno UX: a single **+ Audio** entry that opens a dialog with two tabs.

### Changes
- `UploadAudio.vue`: replace inline upload with tabbed dialog
  - **Browse** tab: drag-and-drop or click to upload (mp3/wav/m4a)
  - **Record** tab: in-browser mic recording via `MediaRecorder` with timer, preview, re-record, upload
- Reuses existing `/api/v1/files/` + `sunoOperator.upload()` flow — no backend changes needed
- Permission denial / unsupported browser handled with user-facing messages
- Cleans up media stream + object URLs on unmount / re-record

### i18n
- New keys (en + zh-CN only, per repo policy):
  - `button.addAudio`, `button.startRecord`, `button.stopRecord`, `button.reRecord`, `button.useRecording`
  - `name.addAudio`, `tab.browse`, `tab.record`
  - `description.dropAudioHere`, `description.audioFormats`
  - `message.recordingReady`, `message.recordingUnsupported`, `message.recordingPermissionDenied`

### Validation
- ✅ `npx vue-tsc -b` (strict)
- ✅ `npx eslint`

### Notes
- Recording max length capped at 10 minutes
- Output mime: `audio/webm` (Chromium / Firefox supported); upload endpoint stores as-is