### PR TITLE
feat(suno): add Favorites tab to voice manager

### DIFF
--- a/src/components/suno/voice/VoiceManager.vue
+++ b/src/components/suno/voice/VoiceManager.vue
@@ -7,15 +7,19 @@
         {{ $t('suno.voice.create') }}
       </el-button>
     </div>
+    <el-tabs v-model="activeTab" class="voice-tabs" size="small">
+      <el-tab-pane name="all" :label="$t('suno.voice.tabAll') + ' (' + (personas?.length || 0) + ')'" />
+      <el-tab-pane name="favorites" :label="$t('suno.voice.tabFavorites') + ' (' + favoritePersonas.length + ')'" />
+    </el-tabs>
     <div v-if="loading" class="text-center py-6">
       <el-icon class="is-loading"><loading /></el-icon>
     </div>
-    <div v-else-if="!personas || personas.length === 0" class="text-center py-6 text-gray-400 text-sm">
-      {{ $t('suno.voice.empty') }}
+    <div v-else-if="visiblePersonas.length === 0" class="text-center py-6 text-gray-400 text-sm">
+      {{ activeTab === 'favorites' ? $t('suno.voice.emptyFavorites') : $t('suno.voice.empty') }}
     </div>
     <div v-else class="voice-list">
       <div
-        v-for="persona in personas"
+        v-for="persona in visiblePersonas"
         :key="persona.persona_id"
         class="voice-item"
         :class="{ active: selectedPersonaId === persona.persona_id }"
@@ -32,6 +36,19 @@
           <div v-if="persona.description" class="voice-desc">{{ persona.description }}</div>
         </div>
         <div class="voice-actions" @click.stop>
+          <el-tooltip
+            :content="isFavorite(persona.persona_id) ? $t('suno.voice.unfavorite') : $t('suno.voice.favorite')"
+            placement="top"
+          >
+            <el-button
+              size="small"
+              text
+              :class="{ 'voice-fav-active': isFavorite(persona.persona_id) }"
+              @click="onToggleFavorite(persona)"
+            >
+              <font-awesome-icon :icon="isFavorite(persona.persona_id) ? 'fa-solid fa-star' : 'fa-regular fa-star'" />
+            </el-button>
+          </el-tooltip>
           <el-button
             type="danger"
             size="small"
@@ -50,7 +67,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElButton, ElIcon, ElMessage, ElMessageBox } from 'element-plus';
+import { ElButton, ElIcon, ElMessage, ElMessageBox, ElTabs, ElTabPane, ElTooltip } from 'element-plus';
 import { Loading } from '@element-plus/icons-vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import VoiceCreateDialog from './VoiceCreateDialog.vue';
@@ -61,6 +78,9 @@ export default defineComponent({
   components: {
     ElButton,
     ElIcon,
+    ElTabs,
+    ElTabPane,
+    ElTooltip,
     Loading,
     FontAwesomeIcon,
     VoiceCreateDialog
@@ -69,12 +89,22 @@ export default defineComponent({
     return {
       showCreateDialog: false,
       loading: false,
-      deletingId: null as string | null
+      deletingId: null as string | null,
+      activeTab: 'all' as 'all' | 'favorites'
     };
   },
   computed: {
     personas(): ISunoPersona[] {
       return this.$store.state.suno?.personas || [];
+    },
+    favoriteIds(): string[] {
+      return this.$store.state.suno?.favoritePersonaIds || [];
+    },
+    favoritePersonas(): ISunoPersona[] {
+      return this.personas.filter((p) => p.persona_id && this.favoriteIds.includes(p.persona_id));
+    },
+    visiblePersonas(): ISunoPersona[] {
+      return this.activeTab === 'favorites' ? this.favoritePersonas : this.personas;
     },
     selectedPersonaId(): string | undefined {
       return this.$store.state.suno?.config?.persona_id;
@@ -89,6 +119,13 @@ export default defineComponent({
     }
   },
   methods: {
+    isFavorite(personaId?: string): boolean {
+      return !!personaId && this.favoriteIds.includes(personaId);
+    },
+    onToggleFavorite(persona: ISunoPersona) {
+      if (!persona.persona_id) return;
+      this.$store.commit('suno/togglePersonaFavorite', persona.persona_id);
+    },
     async loadPersonas() {
       if (!this.$store.state.suno?.credential?.token) return;
       this.loading = true;
@@ -128,6 +165,10 @@ export default defineComponent({
           const config = { ...this.$store.state.suno?.config, persona_id: undefined };
           this.$store.dispatch('suno/setConfig', config);
         }
+        // Also drop from favorites if present
+        if (this.favoriteIds.includes(persona.persona_id)) {
+          this.$store.commit('suno/togglePersonaFavorite', persona.persona_id);
+        }
       } else {
         ElMessage.error(this.$t('suno.voice.deleteFailed'));
       }
@@ -140,6 +181,15 @@ export default defineComponent({
 </script>
 
 <style scoped>
+.voice-tabs {
+  margin-bottom: 8px;
+}
+.voice-tabs :deep(.el-tabs__header) {
+  margin: 0 0 8px 0;
+}
+.voice-tabs :deep(.el-tabs__nav-wrap::after) {
+  height: 1px;
+}
 .voice-list {
   display: flex;
   flex-direction: column;
@@ -188,5 +238,13 @@ export default defineComponent({
 .voice-actions {
   flex-shrink: 0;
   margin-left: 8px;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.voice-fav-active :deep(svg),
+.voice-fav-active {
+  color: #f5a623;
 }
 </style>

--- a/src/i18n/en/suno.json
+++ b/src/i18n/en/suno.json
@@ -71,6 +71,26 @@
     "message": "No voices available, click the button above to create",
     "description": "Prompt when the voice list is empty"
   },
+  "voice.emptyFavorites": {
+    "message": "No favorite voices yet. Tap the star icon to add one.",
+    "description": "Prompt when the favorites tab is empty"
+  },
+  "voice.tabAll": {
+    "message": "All",
+    "description": "Tab label showing all voices"
+  },
+  "voice.tabFavorites": {
+    "message": "Favorites",
+    "description": "Tab label showing favorite voices"
+  },
+  "voice.favorite": {
+    "message": "Add to favorites",
+    "description": "Tooltip for the star button when not yet favorited"
+  },
+  "voice.unfavorite": {
+    "message": "Remove from favorites",
+    "description": "Tooltip for the star button when favorited"
+  },
   "voice.delete": {
     "message": "Delete Voice",
     "description": "Title for the delete voice confirmation"

--- a/src/i18n/zh-CN/suno.json
+++ b/src/i18n/zh-CN/suno.json
@@ -71,6 +71,26 @@
     "message": "暂无声音，点击上方按钮创建",
     "description": "声音列表为空时的提示"
   },
+  "voice.emptyFavorites": {
+    "message": "还没收藏任何声音，点击星标添加",
+    "description": "收藏标签为空时的提示"
+  },
+  "voice.tabAll": {
+    "message": "全部",
+    "description": "展示所有声音的标签"
+  },
+  "voice.tabFavorites": {
+    "message": "收藏",
+    "description": "展示收藏声音的标签"
+  },
+  "voice.favorite": {
+    "message": "添加到收藏",
+    "description": "未收藏时的星标提示"
+  },
+  "voice.unfavorite": {
+    "message": "从收藏中移除",
+    "description": "已收藏时的星标提示"
+  },
   "voice.delete": {
     "message": "删除声音",
     "description": "删除声音确认标题"

--- a/src/plugins/font-awesome.ts
+++ b/src/plugins/font-awesome.ts
@@ -9,7 +9,8 @@ import {
   faMessage as faRegularMessage,
   faFileAlt as faRegularFileAlt,
   faClock as faRegularClock,
-  faFile as faRegularFile
+  faFile as faRegularFile,
+  faStar as faRegularStar
 } from '@fortawesome/free-regular-svg-icons';
 import {
   faDiscord as faBrandsDiscord,
@@ -115,7 +116,8 @@ import {
   faPen as faSolidPen,
   faExpand as faSolidExpand,
   faCompress as faSolidCompress,
-  faBroom as faSolidBroom
+  faBroom as faSolidBroom,
+  faStar as faSolidStar
 } from '@fortawesome/free-solid-svg-icons';
 // add icons
 library.add(faSolidEllipsis);
@@ -128,6 +130,8 @@ library.add(faSolidPlayCircle);
 library.add(faSolidArrowUp);
 library.add(faRegularFileAlt);
 library.add(faSolidFilm);
+library.add(faSolidStar);
+library.add(faRegularStar);
 library.add(faSolidVideo);
 library.add(faSolidMusic);
 library.add(faRegularCopy);

--- a/src/store/suno/models.ts
+++ b/src/store/suno/models.ts
@@ -16,6 +16,7 @@ export interface ISunoState {
     | undefined;
   audio: ISunoAudio | undefined;
   personas: ISunoPersona[] | undefined;
+  favoritePersonaIds: string[];
   status: {
     getService: Status;
     getApplications: Status;

--- a/src/store/suno/mutations.ts
+++ b/src/store/suno/mutations.ts
@@ -67,6 +67,19 @@ export const setPersonas = (state: ISunoState, payload: ISunoPersona[]): void =>
   state.personas = payload;
 };
 
+export const togglePersonaFavorite = (state: ISunoState, personaId: string): void => {
+  if (!personaId) return;
+  if (!Array.isArray(state.favoritePersonaIds)) {
+    state.favoritePersonaIds = [];
+  }
+  const idx = state.favoritePersonaIds.indexOf(personaId);
+  if (idx >= 0) {
+    state.favoritePersonaIds.splice(idx, 1);
+  } else {
+    state.favoritePersonaIds.push(personaId);
+  }
+};
+
 export default {
   setTasks,
   setApplication,
@@ -79,5 +92,6 @@ export default {
   setTasksTotal,
   setAudio,
   setPersonas,
+  togglePersonaFavorite,
   resetAll
 };

--- a/src/store/suno/persist.ts
+++ b/src/store/suno/persist.ts
@@ -1,1 +1,1 @@
-export default ['suno.credential', 'suno.application', 'suno.applications', 'suno.tasks'];
+export default ['suno.credential', 'suno.application', 'suno.applications', 'suno.tasks', 'suno.favoritePersonaIds'];

--- a/src/store/suno/state.ts
+++ b/src/store/suno/state.ts
@@ -13,6 +13,7 @@ export default (): ISunoState => {
     credential: undefined,
     config: undefined,
     personas: undefined,
+    favoritePersonaIds: [],
     status: {
       getService: Status.None,
       getApplications: Status.None,


### PR DESCRIPTION
## P1-2 — Voice Favorites tab

Adds a **Favorites** tab next to **All** in the voice manager so users can curate frequently-used voices.

### Changes
- `store/suno/models.ts` + `state.ts`: new `favoritePersonaIds: string[]` field
- `store/suno/persist.ts`: persist `suno.favoritePersonaIds` (so favorites survive reloads)
- `store/suno/mutations.ts`: new `togglePersonaFavorite` mutation
- `VoiceManager.vue`: 
  - Two `el-tabs` panes — All (count) / Favorites (count)
  - Star toggle button on each row (solid star = favorited)
  - Empty-state copy specific to favorites tab
  - Auto-removes from favorites when a persona is deleted
- `font-awesome.ts`: register `fa-solid fa-star` + `fa-regular fa-star`
- i18n: `voice.tabAll`, `voice.tabFavorites`, `voice.favorite`, `voice.unfavorite`, `voice.emptyFavorites` (en + zh-CN)

### Validation
- ✅ `npx vue-tsc -b` (strict)
- ✅ `npx eslint`

### Notes
- Favorites are stored client-side (localStorage via vuex-persistedstate) — no backend changes
- A future PR can sync favorites to the server if needed