### PR TITLE
feat(suno): add advanced filters to recent songs panel

### DIFF
--- a/src/components/suno/RecentPanel.vue
+++ b/src/components/suno/RecentPanel.vue
@@ -48,6 +48,54 @@
           </el-dropdown-menu>
         </template>
       </el-dropdown>
+      <el-popover trigger="click" placement="bottom-end" :width="260">
+        <template #reference>
+          <el-button size="small" class="filter-btn" :class="{ 'has-active-filter': activeFilterCount > 0 }">
+            <font-awesome-icon icon="fa-solid fa-filter" class="mr-1" />
+            {{ $t('suno.filter.title') }}
+            <span v-if="activeFilterCount > 0" class="filter-badge">{{ activeFilterCount }}</span>
+          </el-button>
+        </template>
+        <div class="filter-popover">
+          <div class="filter-row">
+            <div class="filter-label">{{ $t('suno.filter.type') }}</div>
+            <el-radio-group v-model="filterType" size="small">
+              <el-radio-button value="all">{{ $t('suno.filter.typeAll') }}</el-radio-button>
+              <el-radio-button value="vocal">{{ $t('suno.filter.typeVocal') }}</el-radio-button>
+              <el-radio-button value="instrumental">{{ $t('suno.filter.typeInstrumental') }}</el-radio-button>
+            </el-radio-group>
+          </div>
+          <div class="filter-row">
+            <div class="filter-label">{{ $t('suno.filter.duration') }}</div>
+            <el-radio-group v-model="filterDuration" size="small">
+              <el-radio-button value="all">{{ $t('suno.filter.durationAll') }}</el-radio-button>
+              <el-radio-button value="short">{{ $t('suno.filter.durationShort') }}</el-radio-button>
+              <el-radio-button value="medium">{{ $t('suno.filter.durationMedium') }}</el-radio-button>
+              <el-radio-button value="long">{{ $t('suno.filter.durationLong') }}</el-radio-button>
+            </el-radio-group>
+          </div>
+          <div class="filter-row">
+            <div class="filter-label">{{ $t('suno.filter.video') }}</div>
+            <el-radio-group v-model="filterVideo" size="small">
+              <el-radio-button value="all">{{ $t('suno.filter.videoAll') }}</el-radio-button>
+              <el-radio-button value="with">{{ $t('suno.filter.videoWith') }}</el-radio-button>
+              <el-radio-button value="without">{{ $t('suno.filter.videoWithout') }}</el-radio-button>
+            </el-radio-group>
+          </div>
+          <div v-if="availableModels.length > 0" class="filter-row">
+            <div class="filter-label">{{ $t('suno.filter.model') }}</div>
+            <el-select v-model="filterModel" size="small" :placeholder="$t('suno.filter.modelAll')" clearable>
+              <el-option :label="$t('suno.filter.modelAll')" value="all" />
+              <el-option v-for="m in availableModels" :key="m" :label="m" :value="m" />
+            </el-select>
+          </div>
+          <div class="filter-actions">
+            <el-button size="small" text @click="onResetFilters">
+              {{ $t('suno.filter.reset') }}
+            </el-button>
+          </div>
+        </div>
+      </el-popover>
     </div>
     <scroll-list
       v-if="filteredTasks?.length > 0"
@@ -60,6 +108,13 @@
     </scroll-list>
     <div v-else-if="searchQuery && tasks?.items?.length > 0" class="w-full flex-1 flex items-center justify-center">
       <p class="text-sm text-gray-400">{{ $t('suno.message.noSearchResults') }}</p>
+    </div>
+    <div
+      v-else-if="activeFilterCount > 0 && tasks?.items?.length > 0"
+      class="w-full flex-1 flex flex-col items-center justify-center gap-2"
+    >
+      <p class="text-sm text-gray-400">{{ $t('suno.message.noFilterResults') }}</p>
+      <el-button size="small" text @click="onResetFilters">{{ $t('suno.filter.reset') }}</el-button>
     </div>
     <div v-else-if="tasks?.items?.length === 0" class="w-full flex-1 flex items-center justify-center">
       <no-tasks />
@@ -82,7 +137,12 @@ import {
   ElButton,
   ElDropdown,
   ElDropdownMenu,
-  ElDropdownItem
+  ElDropdownItem,
+  ElPopover,
+  ElRadioGroup,
+  ElRadioButton,
+  ElSelect,
+  ElOption
 } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import ScrollList from '@/components/common/ScrollList.vue';
@@ -98,6 +158,11 @@ export default defineComponent({
     ElDropdown,
     ElDropdownMenu,
     ElDropdownItem,
+    ElPopover,
+    ElRadioGroup,
+    ElRadioButton,
+    ElSelect,
+    ElOption,
     FontAwesomeIcon,
     TaskPreview,
     Player,
@@ -115,7 +180,11 @@ export default defineComponent({
     return {
       job: 0,
       searchQuery: '',
-      sortBy: 'newest' as 'newest' | 'oldest'
+      sortBy: 'newest' as 'newest' | 'oldest',
+      filterType: 'all' as 'all' | 'vocal' | 'instrumental',
+      filterDuration: 'all' as 'all' | 'short' | 'medium' | 'long',
+      filterVideo: 'all' as 'all' | 'with' | 'without',
+      filterModel: 'all' as string
     };
   },
   computed: {
@@ -129,6 +198,25 @@ export default defineComponent({
       return this.sortBy === 'newest'
         ? (this.$t('suno.sort.newest') as string)
         : (this.$t('suno.sort.oldest') as string);
+    },
+    activeFilterCount(): number {
+      let count = 0;
+      if (this.filterType !== 'all') count++;
+      if (this.filterDuration !== 'all') count++;
+      if (this.filterVideo !== 'all') count++;
+      if (this.filterModel && this.filterModel !== 'all') count++;
+      return count;
+    },
+    availableModels(): string[] {
+      const items = (this.tasks?.items || []) as ISunoTask[];
+      const set = new Set<string>();
+      for (const t of items) {
+        const audios = (t?.response?.data ?? []) as ISunoAudio[];
+        for (const a of audios) {
+          if (a.model) set.add(a.model);
+        }
+      }
+      return Array.from(set).sort();
     },
     filteredTasks(): ISunoTask[] {
       let items = this.tasks?.items || [];
@@ -145,6 +233,37 @@ export default defineComponent({
           );
         });
       }
+      // Advanced filters: keep tasks where at least one audio matches all active filters
+      if (this.activeFilterCount > 0) {
+        items = items.filter((task: ISunoTask) => {
+          const req: any = task?.request ?? {};
+          const audios = (task?.response?.data ?? []) as ISunoAudio[];
+          // Type filter (uses request.instrumental)
+          if (this.filterType === 'vocal' && req.instrumental === true) return false;
+          if (this.filterType === 'instrumental' && req.instrumental !== true) return false;
+          // Audio-level filters: at least one audio must match
+          if (
+            this.filterDuration !== 'all' ||
+            this.filterVideo !== 'all' ||
+            (this.filterModel && this.filterModel !== 'all')
+          ) {
+            return audios.some((a) => {
+              if (this.filterDuration === 'short' && !(typeof a.duration === 'number' && a.duration < 60)) return false;
+              if (
+                this.filterDuration === 'medium' &&
+                !(typeof a.duration === 'number' && a.duration >= 60 && a.duration <= 180)
+              )
+                return false;
+              if (this.filterDuration === 'long' && !(typeof a.duration === 'number' && a.duration > 180)) return false;
+              if (this.filterVideo === 'with' && !a.video_url) return false;
+              if (this.filterVideo === 'without' && a.video_url) return false;
+              if (this.filterModel && this.filterModel !== 'all' && a.model !== this.filterModel) return false;
+              return true;
+            });
+          }
+          return true;
+        });
+      }
       // Sort
       if (this.sortBy === 'oldest') {
         items = [...items].reverse();
@@ -155,6 +274,12 @@ export default defineComponent({
   methods: {
     onSortChange(command: 'newest' | 'oldest') {
       this.sortBy = command;
+    },
+    onResetFilters() {
+      this.filterType = 'all';
+      this.filterDuration = 'all';
+      this.filterVideo = 'all';
+      this.filterModel = 'all';
     },
     getScrollElement(): HTMLElement | undefined {
       const list = this.$refs.scrollList as any;
@@ -180,6 +305,57 @@ export default defineComponent({
   .sort-btn {
     flex-shrink: 0;
     white-space: nowrap;
+  }
+
+  .filter-btn {
+    flex-shrink: 0;
+    white-space: nowrap;
+    position: relative;
+
+    &.has-active-filter {
+      color: var(--el-color-primary);
+      border-color: var(--el-color-primary-light-5);
+    }
+
+    .filter-badge {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 16px;
+      height: 16px;
+      padding: 0 4px;
+      margin-left: 4px;
+      border-radius: 8px;
+      background: var(--el-color-primary);
+      color: #fff;
+      font-size: 10px;
+      line-height: 1;
+    }
+  }
+}
+
+.filter-popover {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+
+  .filter-row {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .filter-label {
+    font-size: 12px;
+    color: var(--el-text-color-secondary);
+  }
+
+  .filter-actions {
+    display: flex;
+    justify-content: flex-end;
+    border-top: 1px solid var(--el-border-color-lighter);
+    padding-top: 8px;
+    margin-top: 4px;
   }
 }
 </style>

--- a/src/i18n/en/suno.json
+++ b/src/i18n/en/suno.json
@@ -791,6 +791,74 @@
     "message": "Oldest",
     "description": "Sort by oldest"
   },
+  "filter.title": {
+    "message": "Filter",
+    "description": "Filter button label"
+  },
+  "filter.type": {
+    "message": "Type",
+    "description": "Filter section: vocal vs instrumental"
+  },
+  "filter.typeAll": {
+    "message": "All",
+    "description": "Filter type: any"
+  },
+  "filter.typeVocal": {
+    "message": "Vocal",
+    "description": "Filter type: with vocals"
+  },
+  "filter.typeInstrumental": {
+    "message": "Instrumental",
+    "description": "Filter type: instrumental only"
+  },
+  "filter.duration": {
+    "message": "Duration",
+    "description": "Filter section: song duration"
+  },
+  "filter.durationAll": {
+    "message": "All",
+    "description": "Filter duration: any length"
+  },
+  "filter.durationShort": {
+    "message": "< 1 min",
+    "description": "Filter duration: shorter than 1 minute"
+  },
+  "filter.durationMedium": {
+    "message": "1-3 min",
+    "description": "Filter duration: 1 to 3 minutes"
+  },
+  "filter.durationLong": {
+    "message": "> 3 min",
+    "description": "Filter duration: longer than 3 minutes"
+  },
+  "filter.video": {
+    "message": "Video",
+    "description": "Filter section: has video"
+  },
+  "filter.videoAll": {
+    "message": "All",
+    "description": "Filter video: any"
+  },
+  "filter.videoWith": {
+    "message": "With Video",
+    "description": "Filter video: only songs with video"
+  },
+  "filter.videoWithout": {
+    "message": "Audio Only",
+    "description": "Filter video: only songs without video"
+  },
+  "filter.model": {
+    "message": "Model",
+    "description": "Filter section: AI model"
+  },
+  "filter.modelAll": {
+    "message": "All Models",
+    "description": "Filter model: any"
+  },
+  "filter.reset": {
+    "message": "Reset",
+    "description": "Reset all filters"
+  },
   "button.delete": {
     "message": "Delete",
     "description": "Text for the delete song button"
@@ -802,6 +870,10 @@
   "message.noSearchResults": {
     "message": "No songs found",
     "description": "Message when no search results are found"
+  },
+  "message.noFilterResults": {
+    "message": "No songs match the selected filters",
+    "description": "Message when no songs match the active filters"
   },
   "message.confirmDelete": {
     "message": "Are you sure you want to delete this song? This action cannot be undone.",

--- a/src/i18n/zh-CN/suno.json
+++ b/src/i18n/zh-CN/suno.json
@@ -791,6 +791,74 @@
     "message": "最旧",
     "description": "按最旧排序"
   },
+  "filter.title": {
+    "message": "筛选",
+    "description": "筛选按钮"
+  },
+  "filter.type": {
+    "message": "类型",
+    "description": "筛选分区：人声/纯音乐"
+  },
+  "filter.typeAll": {
+    "message": "全部",
+    "description": "类型：全部"
+  },
+  "filter.typeVocal": {
+    "message": "人声",
+    "description": "类型：含人声"
+  },
+  "filter.typeInstrumental": {
+    "message": "纯音乐",
+    "description": "类型：纯音乐"
+  },
+  "filter.duration": {
+    "message": "时长",
+    "description": "筛选分区：歌曲时长"
+  },
+  "filter.durationAll": {
+    "message": "全部",
+    "description": "时长：不限"
+  },
+  "filter.durationShort": {
+    "message": "< 1 分钟",
+    "description": "时长：小于 1 分钟"
+  },
+  "filter.durationMedium": {
+    "message": "1-3 分钟",
+    "description": "时长：1 到 3 分钟"
+  },
+  "filter.durationLong": {
+    "message": "> 3 分钟",
+    "description": "时长：大于 3 分钟"
+  },
+  "filter.video": {
+    "message": "视频",
+    "description": "筛选分区：是否含视频"
+  },
+  "filter.videoAll": {
+    "message": "全部",
+    "description": "视频：不限"
+  },
+  "filter.videoWith": {
+    "message": "含视频",
+    "description": "视频：仅含视频"
+  },
+  "filter.videoWithout": {
+    "message": "仅音频",
+    "description": "视频：仅音频"
+  },
+  "filter.model": {
+    "message": "模型",
+    "description": "筛选分区：AI 模型"
+  },
+  "filter.modelAll": {
+    "message": "全部模型",
+    "description": "模型：不限"
+  },
+  "filter.reset": {
+    "message": "重置",
+    "description": "重置所有筛选"
+  },
   "button.delete": {
     "message": "删除",
     "description": "删除歌曲的按钮文本"
@@ -802,6 +870,10 @@
   "message.noSearchResults": {
     "message": "未找到歌曲",
     "description": "搜索无结果时的消息"
+  },
+  "message.noFilterResults": {
+    "message": "没有符合筛选条件的歌曲",
+    "description": "筛选无结果时的消息"
   },
   "message.confirmDelete": {
     "message": "确定要删除这首歌吗？此操作不可撤销。",

--- a/src/plugins/font-awesome.ts
+++ b/src/plugins/font-awesome.ts
@@ -113,6 +113,7 @@ import {
   faClock as faSolidClock,
   faEraser as faSolidEraser,
   faArrowDownWideShort as faSolidArrowDownWideShort,
+  faFilter as faSolidFilter,
   faPen as faSolidPen,
   faExpand as faSolidExpand,
   faCompress as faSolidCompress,
@@ -230,6 +231,7 @@ library.add(faSolidHeadphones);
 library.add(faSolidClock);
 library.add(faSolidEraser);
 library.add(faSolidArrowDownWideShort);
+library.add(faSolidFilter);
 library.add(faSolidPen);
 library.add(faSolidExpand);
 library.add(faSolidCompress);


### PR DESCRIPTION
## P1-3 — Advanced filters

Adds a **Filter** popover next to Search/Sort in the Suno *Recent* panel so users can narrow the song list without scrolling.

### Filters
- **Type**: All / Vocal / Instrumental — driven by `request.instrumental`
- **Duration**: All / `< 1 min` / `1–3 min` / `> 3 min` — derived from `audio.duration`
- **Video**: All / With Video / Audio Only — based on `audio.video_url`
- **Model**: dynamic dropdown listing every model present in the current tasks

A task matches if **any** of its audios satisfies all active filters; the type filter applies at the request level.

### UX
- Active filter count rendered as a small badge on the button
- Filter button highlights when at least one filter is active
- Dedicated empty state with a Reset shortcut when filters yield zero results
- Reset button clears all filters at once

### Tech
- Filters live in component state only (no store changes)
- Registers `fa-solid fa-filter` icon centrally in `src/plugins/font-awesome.ts`
- en + zh-CN i18n keys; other locales auto-handled by translate workflow

### Validation
- ✅ `npx vue-tsc -b` (strict)
- ✅ `npx eslint`