### PR TITLE
fix(auth): generate request ids with uuid

### DIFF
--- a/src/operators/common.ts
+++ b/src/operators/common.ts
@@ -3,6 +3,7 @@ import { getBaseUrlPlatform } from '@/utils';
 import axios, { AxiosInstance } from 'axios';
 import qs from 'qs';
 import { getCookie } from 'typescript-cookie';
+import { v4 as uuidv4 } from 'uuid';
 
 const httpClient: AxiosInstance = axios.create({
   baseURL: `${getBaseUrlPlatform()}/api/v1`,
@@ -22,7 +23,7 @@ httpClient.interceptors.request.use((config) => {
   const locale = getCookie('LOCALE');
   console.debug('userId', userId);
   console.debug('fingerprint', fingerprint);
-  config.headers['x-request-id'] = crypto.randomUUID();
+  config.headers['x-request-id'] = uuidv4();
   if (accessToken) {
     config.headers['Authorization'] = `Bearer ${accessToken}`;
   }


### PR DESCRIPTION
## Problem

Some WebView environments, including WeChat WebView, lack `crypto.randomUUID`. The shared axios request interceptor can throw before API requests are sent.

## Fix

Switched `x-request-id` generation from `crypto.randomUUID()` to the existing `uuid` package.

## Validation

- `npx eslint src/operators/common.ts`
- `npm run build:web` currently reaches an unrelated existing TypeScript error in `src/components/chat/ConnectorManager.vue`: `TS2554: Expected 1 arguments, but got 2.`