### PR TITLE
fix: preserve inviter_id through auth redirect on custom-domain sites

### DIFF
--- a/change/@acedatacloud-nexior-c05d067a-dbb2-4192-98de-2d00f5e6bbeb.json
+++ b/change/@acedatacloud-nexior-c05d067a-dbb2-4192-98de-2d00f5e6bbeb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix inviter_id binding through auth redirect on custom-domain (white-label) sites",
+  "packageName": "@acedatacloud/nexior",
+  "email": "cqc@cuiqingcai.com",
+  "dependentChangeType": "patch"
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -114,7 +114,15 @@ export default defineComponent({
         this.$store.dispatch('resetAll');
         this.$store.dispatch('login');
       } else {
-        this.$store.dispatch('logout');
+        // Don't dispatch 'logout' here — there's nothing to log out from when
+        // the user isn't authenticated, and 'logout' races with 'login' for
+        // window.location.href. Because 'logout' has many awaits, it would win
+        // the race and overwrite 'login's properly-encoded URL with a raw
+        // string-concatenated one, causing inviter_id to end up nested inside
+        // the redirect= value where AuthFrontend can't find it. This silently
+        // breaks the referral binding for users who arrive via share links on
+        // custom-domain (white-label) deployments.
+        this.$store.dispatch('resetAll');
         this.$store.dispatch('login');
       }
     }

--- a/src/store/common/actions.ts
+++ b/src/store/common/actions.ts
@@ -11,7 +11,7 @@ import {
 } from '@/operators';
 import { IApplication, IApplicationScope, IApplicationType, ICredential, IToken, IUser, Status } from '@/models';
 import { getSiteOrigin } from '@/utils/site';
-import { getBaseUrlAuth, loginRedirect } from '@/utils';
+import { getBaseUrlAuth, getBaseUrlHub, getInviterId, loginRedirect } from '@/utils';
 import { SURFACE_ANDROID, SURFACE_IOS } from '@/constants';
 import FingerprintJS from '@fingerprintjs/fingerprintjs';
 
@@ -222,7 +222,11 @@ export const login = async ({ state, commit }: ActionContext<IRootState, IRootSt
       flow: 'redirect'
     });
     console.debug('login redirect');
-    loginRedirect({ redirect: window.location.pathname, site });
+    // Preserve the original query string (e.g. ?inviter_id, ?utm_source) so
+    // it survives the auth round-trip and is still present when the user
+    // lands back on Nexior. inviter_id is also forwarded as a top-level
+    // query param by loginRedirect itself.
+    loginRedirect({ redirect: window.location.pathname + window.location.search, site });
   }
 };
 
@@ -252,10 +256,27 @@ export const logout = async ({ dispatch, commit }: ActionContext<IRootState, IRo
       visible: true
     });
   } else {
-    const currentUrl = window.location.href;
+    // Build the post-logout login URL via URLSearchParams so the inviter_id
+    // (and any other query params on the current page) survive as top-level
+    // query keys after AuthFrontend parses the URL — otherwise they end up
+    // nested inside the `redirect` value (because raw `?redirect=${url}`
+    // concatenation does no encoding) and AuthFrontend's
+    // `URLSearchParams.get('inviter_id')` returns null, breaking referral
+    // binding for OAuth signups (especially WeChat) on custom-domain sites.
     const baseUrlAuth = getBaseUrlAuth();
-    const loginUrl = `${baseUrlAuth}/auth/login?redirect=${currentUrl}`;
-    const redirectUrl = `${baseUrlAuth}/auth/logout?redirect=${loginUrl}`;
+    const baseUrlHub = getBaseUrlHub();
+    const site = window.location.origin;
+    const inviterId = getInviterId();
+    const callbackUrl = `${baseUrlHub}/auth/callback?${new URLSearchParams({
+      redirect: window.location.pathname + window.location.search
+    }).toString()}`;
+    const loginQuery: Record<string, string> = {
+      site,
+      ...(inviterId ? { inviter_id: inviterId } : {}),
+      redirect: callbackUrl
+    };
+    const loginUrl = `${baseUrlAuth}/auth/login?${new URLSearchParams(loginQuery).toString()}`;
+    const redirectUrl = `${baseUrlAuth}/auth/logout?${new URLSearchParams({ redirect: loginUrl }).toString()}`;
     window.location.href = redirectUrl;
   }
 };


### PR DESCRIPTION
## Summary

On white-label / self-hosted Nexior deployments (e.g. `www.15light.com`), referral binding silently broke for users who arrived via share links and signed up with an OAuth provider (especially WeChat). The new user's `inviter_id` ended up `NULL`.

## Root cause

The `INVITER_ID` cookie is scoped to the custom domain (e.g. `.15light.com`) and is **not** visible to `auth.acedata.cloud` (different eTLD+1), so the only way to carry the inviter across the auth round-trip is via the URL. Two bugs prevented that:

### 1. Race in `App.vue` between `logout` and `login`

```js
this.$store.dispatch('logout');
this.$store.dispatch('login');
```

Both fire and forget. `login` synchronously sets `window.location.href` to a properly URL-encoded URL where `inviter_id` is a top-level query key. `logout` has ~17 `await`s on `resetAll` actions, then **also** sets `window.location.href` — and because it runs last in the same task, it overwrites `login`'s URL. `logout` always wins the race.

There's nothing to log out of when the user isn't authenticated, so this PR replaces it with `resetAll`.

### 2. `logout` action used raw template-literal concatenation

```js
const loginUrl = `${baseUrlAuth}/auth/login?redirect=${currentUrl}`;
const redirectUrl = `${baseUrlAuth}/auth/logout?redirect=${loginUrl}`;
```

When `currentUrl = 'https://www.15light.com/?inviter_id=abc'`, the resulting URL has `?` characters nested unencoded inside the `redirect` value. AuthFrontend's `URLSearchParams.get('inviter_id')` returns `null`, so it doesn't write the `.acedata.cloud` `INVITER_ID` cookie, and the OAuth callbacks (`Wechat.vue`, `Google.vue`) read `undefined` from `getCookie('INVITER_ID')` and post `inviter_id: undefined` to AuthBackend → user created with `inviter_id=NULL`.

This PR rebuilds both URLs via `URLSearchParams` and explicitly forwards `inviter_id` as a top-level query key (reusing `getInviterId()` so cookie + site-default fallbacks apply).

## Also (defensive)

Include `window.location.search` in the post-login redirect path so `utm_*`, `inviter_id`, etc. survive the round-trip and are still on the URL when the user lands back on Nexior.

## Affects

- All custom-domain (white-label) Nexior deployments
- All OAuth providers (WeChat / Google / GitHub) — most user-visible on WeChat because that's the dominant flow

## Companion PR

AuthFrontend gets a defensive fallback that recovers `inviter_id` from a malformed `redirect=` value, so any legacy clients still in the wild (mobile WebViews with cached JS, etc.) also bind correctly.

## Test plan

1. Open `https://<custom-domain>/?inviter_id=<known-id>` in an incognito browser.
2. DevTools → Network: first navigation to `auth.acedata.cloud/auth/login` should have `?site=...&inviter_id=<known-id>&redirect=...`.
3. DevTools → Application → Cookies → `.acedata.cloud`: `INVITER_ID=<known-id>` is set.
4. Complete WeChat OAuth → AuthBackend creates the new user with `inviter_id=<known-id>`.
5. Repeat in WeChat in-app browser.
