### PR TITLE
fix(veo): block image2video submit when no reference image is uploaded

### DIFF
--- a/src/i18n/en/veo.json
+++ b/src/i18n/en/veo.json
@@ -159,6 +159,10 @@
     "message": "Failed to initiate task, please contact the administrator",
     "description": "Error message when starting the drawing task fails"
   },
+  "message.imageRequired": {
+    "message": "Please upload at least one reference image before starting an image-to-video task",
+    "description": "Shown when image2video is selected but no image was uploaded"
+  },
   "message.usedUp": {
     "message": "Your credits are exhausted, please purchase more to continue",
     "description": "Message when credits are used up"

--- a/src/i18n/zh-CN/veo.json
+++ b/src/i18n/zh-CN/veo.json
@@ -159,6 +159,10 @@
     "message": "发起任务失败，请联系管理员",
     "description": "启动绘图任务失败时的错误消息"
   },
+  "message.imageRequired": {
+    "message": "请先上传至少一张参考图片，再发起图生视频任务",
+    "description": "image2video 模式下未上传图片时的提示"
+  },
   "message.usedUp": {
     "message": "您的积分已用完，请购买更多积分后继续使用",
     "description": "已用完时的消息"

--- a/src/pages/veo/Index.vue
+++ b/src/pages/veo/Index.vue
@@ -156,6 +156,17 @@ export default defineComponent({
         console.error('no token specified');
         return;
       }
+      // image2video requires at least one image; otherwise the upstream rejects with
+      // "image_urls is invalid when generate videos". Validate client-side so the user
+      // gets an actionable message instead of the generic failure toast.
+      if (request.action === 'image2video' && !(request.image_urls && request.image_urls.length > 0)) {
+        ElMessage.warning(this.$t('veo.message.imageRequired'));
+        return;
+      }
+      // Only send image_urls when it actually has values; the worker rejects empty arrays.
+      if (!request.image_urls || request.image_urls.length === 0) {
+        delete request.image_urls;
+      }
       ElMessage.info(this.$t('veo.message.startingTask'));
       veoOperator
         .generate(request, {


### PR DESCRIPTION
## Summary

Live trace [`d0018392-f8a9-4587-9f3d-608044a6da62`](https://platform.acedata.cloud) showed Nexior calling `POST /veo/videos` with:

```json
{ "action": "image2video", "image_urls": [], "model": "veo3-fast", ... }
```

The upstream worker rightly rejects this with `400 image_urls is invalid when generate videos`, and the user only saw the generic `message.startTaskFailed` toast ("\u53d1\u8d77\u4efb\u52a1\u5931\u8d25\uff0c\u8bf7\u8054\u7cfb\u7ba1\u7406\u5458"). The screenshot from the user matches: `image2video` was selected but no image was uploaded.

## Fix

In [`src/pages/veo/Index.vue`](src/pages/veo/Index.vue) `onGenerate()`:

1. **Validate before submit** \u2014 if `action === 'image2video'` and `image_urls` is empty/missing, show a clear `veo.message.imageRequired` warning and abort, instead of letting the request go upstream.
2. **Strip empty `image_urls`** \u2014 if the array is empty (e.g. user cleared uploads after switching action), drop the field from the payload entirely so a future `text2video` request can\u2019t accidentally include `image_urls: []`.

## i18n

Added `veo.message.imageRequired` to `zh-CN` and `en` only, per repo policy (other locales auto-translate via translate.py CronJob).