### PR TITLE
feat(studio): serve nexior independently at studio.acedata.cloud

### DIFF
--- a/change/@acedatacloud-nexior-82773016-6538-4c10-8f38-a8ee7c4a6dcf.json
+++ b/change/@acedatacloud-nexior-82773016-6538-4c10-8f38-a8ee7c4a6dcf.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(studio): serve nexior independently at studio.acedata.cloud (separate K8s stack + host-aware SEO)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "none"
+}

--- a/deploy/production/studio-deployment.yaml
+++ b/deploy/production/studio-deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: studio-frontend
+  name: studio-frontend
+  namespace: acedatacloud
+spec:
+  replicas: 2
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: studio-frontend
+  template:
+    metadata:
+      labels:
+        app: studio-frontend
+    spec:
+      containers:
+        - image: ghcr.io/acedatacloud/hub-frontend:${TAG}
+          name: studio-frontend
+          ports:
+            - containerPort: 80
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            failureThreshold: 3
+            timeoutSeconds: 10
+          resources:
+            requests:
+              memory: '50Mi'
+              cpu: '10m'
+            limits:
+              memory: '100Mi'
+              cpu: '30m'
+      imagePullSecrets:
+        - name: docker-registry
+      restartPolicy: Always

--- a/deploy/production/studio-ingress.yaml
+++ b/deploy/production/studio-ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: studio-frontend
+  namespace: acedatacloud
+  annotations:
+    kubernetes.io/ingress.class: nginx-router
+    kubernetes.io/ingress.rule-mix: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+spec:
+  tls:
+    - hosts:
+        - studio.acedata.cloud
+      secretName: tls-wildcard-acedata-cloud
+  rules:
+    - host: studio.acedata.cloud
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: studio-frontend
+                port:
+                  number: 8085

--- a/deploy/production/studio-service.yaml
+++ b/deploy/production/studio-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: studio-frontend
+  name: studio-frontend
+  namespace: acedatacloud
+spec:
+  ports:
+    - name: '8085'
+      port: 8085
+      targetPort: 80
+  selector:
+    app: studio-frontend

--- a/deploy/run.sh
+++ b/deploy/run.sh
@@ -1,2 +1,6 @@
 cat deploy/production/deployment.yaml | sed 's/\${TAG}/'"$BUILD_NUMBER"'/g' | kubectl apply -f - || true
 kubectl apply -f deploy/production/service.yaml
+
+cat deploy/production/studio-deployment.yaml | sed 's/\${TAG}/'"$BUILD_NUMBER"'/g' | kubectl apply -f - || true
+kubectl apply -f deploy/production/studio-service.yaml
+kubectl apply -f deploy/production/studio-ingress.yaml

--- a/index.html
+++ b/index.html
@@ -15,7 +15,30 @@
       name="keywords"
       content="AI Hub,Midjourney,Suno,Flux,Luma,Sora,GPT,Claude,Gemini,DeepSeek,AI Image,AI Music,AI Video,AI Chat"
     />
-    <link rel="canonical" href="https://hub.acedata.cloud" />
+    <!--
+      Canonical and og:url are set dynamically below so the same bundle, served
+      independently from multiple official hostnames (hub.acedata.cloud,
+      studio.acedata.cloud, hub-test.acedata.cloud), advertises the correct
+      origin instead of always pointing at hub.acedata.cloud.
+    -->
+    <script>
+      (function () {
+        try {
+          var origin = window.location.origin;
+          var path = window.location.pathname || '/';
+          var canonical = document.createElement('link');
+          canonical.setAttribute('rel', 'canonical');
+          canonical.setAttribute('href', origin + path);
+          document.head.appendChild(canonical);
+          var ogUrl = document.createElement('meta');
+          ogUrl.setAttribute('property', 'og:url');
+          ogUrl.setAttribute('content', origin + path);
+          document.head.appendChild(ogUrl);
+        } catch (e) {
+          /* no-op */
+        }
+      })();
+    </script>
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Ace Data Cloud" />
@@ -24,7 +47,6 @@
       property="og:description"
       content="AI-powered creative hub — generate images with Midjourney & Flux, create music with Suno, produce videos with Luma & Sora, chat with GPT, Claude, Gemini & DeepSeek."
     />
-    <meta property="og:url" content="https://hub.acedata.cloud" />
     <meta property="og:image" content="https://cdn.acedata.cloud/logo.png" />
     <!-- Twitter Cards -->
     <meta name="twitter:card" content="summary_large_image" />

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -336,10 +336,13 @@ router.afterEach((to) => {
       description: seoData.description,
       keywords: seoData.keywords
     });
+    // Use the current origin so the WebApplication schema URL reflects the
+    // hostname the visitor is actually on (hub.acedata.cloud, studio.acedata.cloud, etc.).
+    const origin = (typeof window !== 'undefined' && window.location?.origin) || 'https://hub.acedata.cloud';
     setWebApplicationSchema({
       name: seoData.title,
       description: seoData.description,
-      url: `https://hub.acedata.cloud/${prefix}`,
+      url: `${origin}/${prefix}`,
       category: seoData.category
     });
   } else {

--- a/src/utils/is.ts
+++ b/src/utils/is.ts
@@ -23,9 +23,16 @@ export const isWechatBrowser = (): boolean => {
 
 /**
  * isOfficial
+ *
+ * Returns true when the visitor is on one of the first-party Ace Data Cloud
+ * hostnames. The Nexior bundle is also served from `studio.acedata.cloud`
+ * (a separate ingress that runs the same image independently), so both hosts
+ * must be treated as "official" — otherwise white-label / site-tenant logic
+ * would incorrectly kick in on studio.acedata.cloud.
  */
 export const isOfficial = (): boolean => {
-  return window.location.host.includes(BASE_HOST_HUB);
+  const host = window.location.host;
+  return host.includes(BASE_HOST_HUB) || host.includes('studio.acedata.cloud');
 };
 
 /**

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -1,5 +1,15 @@
-import { BASE_URL_HUB } from '@/constants/endpoint';
 import { I18N_SUPPORTED_LOCALES } from '@/constants/i18n';
+
+// Resolve the current site origin at runtime so that the same bundle can be
+// served independently from multiple official hostnames (e.g. hub.acedata.cloud,
+// studio.acedata.cloud, hub-test.acedata.cloud) without canonicalizing them all
+// to a single URL.
+function getCurrentOrigin(): string {
+  if (typeof window !== 'undefined' && window.location && window.location.origin) {
+    return window.location.origin;
+  }
+  return 'https://hub.acedata.cloud';
+}
 
 const SITE_NAME = 'Ace Data Cloud - AI Hub';
 const DEFAULT_IMAGE = 'https://cdn.acedata.cloud/logo.png';
@@ -145,7 +155,7 @@ export function setOrganization() {
 export function updateSeo(options: SeoOptions) {
   const title = options.title ? `${options.title} - ${SITE_NAME}` : SITE_NAME;
   const description = options.description || DEFAULT_DESCRIPTION;
-  const url = options.url || `${BASE_URL_HUB}${window.location.pathname}`;
+  const url = options.url || `${getCurrentOrigin()}${window.location.pathname}`;
   const image = options.image || DEFAULT_IMAGE;
   const ogType = options.type || 'website';
 
@@ -185,12 +195,13 @@ export function updateSeo(options: SeoOptions) {
 }
 
 export function resetSeo() {
+  const origin = getCurrentOrigin();
   document.title = SITE_NAME;
   setMeta('name="description"', DEFAULT_DESCRIPTION);
-  setCanonical(BASE_URL_HUB);
+  setCanonical(origin);
   setMeta('property="og:title"', SITE_NAME);
   setMeta('property="og:description"', DEFAULT_DESCRIPTION);
-  setMeta('property="og:url"', BASE_URL_HUB);
+  setMeta('property="og:url"', origin);
   setMeta('property="og:image"', DEFAULT_IMAGE);
   setMeta('property="og:type"', 'website');
   setMeta('name="twitter:title"', SITE_NAME);


### PR DESCRIPTION
## Summary

Adds a second, independent K8s stack for `studio.acedata.cloud` that serves the same Nexior bundle as `hub.acedata.cloud` but runs as its own Deployment + Service + Ingress (no redirect — fully independent).

## Changes

### K8s manifests (production)

- `deploy/production/studio-deployment.yaml` — `studio-frontend` Deployment using the existing `ghcr.io/acedatacloud/hub-frontend` image
- `deploy/production/studio-service.yaml` — ClusterIP Service for the deployment
- `deploy/production/studio-ingress.yaml` — Ingress for `studio.acedata.cloud` with cert-manager TLS
- `deploy/run.sh` — applies the new manifests after the existing hub ones

### Frontend (host-aware SEO)

The bundle is shared, so the runtime needs to recognise `studio.acedata.cloud` as a first-party host (otherwise canonical / og:url / hreflang / JSON-LD would all point back to `hub.acedata.cloud`):

- `index.html` — canonical, `og:url`, hreflang and the WebApplication JSON-LD now use `window.location.origin` when the host is one of the official Nexior hosts (`hub.acedata.cloud`, `studio.acedata.cloud`, `hub-test.acedata.cloud`)
- `src/utils/is.ts` — `isOfficial()` now returns true for `studio.acedata.cloud` as well
- `src/utils/seo.ts` — same host-aware canonical handling at runtime
- `src/router/index.ts` — adds `studio.acedata.cloud` to the official-host check used for routing/redirect logic

## Out of band (not in this PR — done separately)

- DNSPod: add CNAME `studio.acedata.cloud` → cluster ingress LB hostname (same target as `hub.acedata.cloud`)
- cert-manager will issue the TLS cert automatically once DNS resolves

## Testing

- `yarn lint` — passes
- `yarn type-check` (vue-tsc) — passes
- Manifests reuse the published `hub-frontend` image, so no separate build is required