### PR TITLE
fix(nexior): use favicon for collapsed sidebar logo

### DIFF
--- a/src/components/common/Navigator.vue
+++ b/src/components/common/Navigator.vue
@@ -1,7 +1,7 @@
 <template>
   <div :direction="direction" :class="['navigator', { collapsed: direction === 'column' }]">
     <div v-if="direction === 'column'" class="brand">
-      <logo @click.stop="onHome" />
+      <logo collapsed @click.stop="onHome" />
     </div>
     <div class="top">
       <div ref="linksContainer" class="links">


### PR DESCRIPTION
## Problem

The narrow 60px-wide vertical navigator (`Navigator.vue` with `direction='column'`) was rendering the full `site.logo` (horizontal wordmark) instead of `site.favicon` — squashing a wide brand mark into a tiny square slot, which looked terrible.

## Root cause

`Logo.vue` exposes a `collapsed` prop that switches the source from `site.logo` → `site.favicon`. `Navigator.vue` did not pass it, so collapsed mode kept loading the wordmark.

## Fix

Pass `collapsed` to `<logo>` when the navigator is in column (collapsed) mode. `TopHeader.vue` (full-width header) is unchanged — it should still use the wordmark.