### PR TITLE
feat(chat): use external-link icon for skills/connections toolbar buttons

### DIFF
--- a/change/@acedatacloud-nexior-a1a446ac-ad75-42f0-9260-6cc6b35940dc.json
+++ b/change/@acedatacloud-nexior-a1a446ac-ad75-42f0-9260-6cc6b35940dc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(chat): use external-link icon for skills/connections toolbar buttons",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -416,7 +416,7 @@
     "description": "Hint for closing window after OAuth callback"
   },
   "connections.tooltip": {
-    "message": "Manage connections (auth.acedata.cloud)",
+    "message": "Manage connections",
     "description": "Tooltip for the toolbar button that opens the auth.acedata.cloud connections page"
   },
   "agent.title": {
@@ -464,7 +464,7 @@
     "description": "Run instructions label"
   },
   "skill.tooltip": {
-    "message": "Manage skills (auth.acedata.cloud)",
+    "message": "Manage skills",
     "description": "Tooltip for the toolbar button that opens the auth.acedata.cloud skills page"
   },
   "composer.addFiles": {

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -416,11 +416,11 @@
     "description": "OAuth 回调关闭提示"
   },
   "connections.tooltip": {
-    "message": "连接管理（auth.acedata.cloud）",
+    "message": "连接管理",
     "description": "跳转到 auth.acedata.cloud 连接管理页的按钮提示"
   },
   "skill.tooltip": {
-    "message": "技能管理（auth.acedata.cloud）",
+    "message": "技能管理",
     "description": "跳转到 auth.acedata.cloud 技能管理页的按钮提示"
   },
   "composer.addFiles": {

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -13,11 +13,13 @@
           <el-tooltip :content="$t('chat.skill.tooltip')" placement="bottom">
             <el-button class="toolbar-btn" text @click="onOpenSkills">
               <font-awesome-icon icon="fa-solid fa-wand-magic-sparkles" />
+              <font-awesome-icon icon="fa-solid fa-up-right-from-square" class="external-icon" />
             </el-button>
           </el-tooltip>
           <el-tooltip :content="$t('chat.connections.tooltip')" placement="bottom">
             <el-button class="toolbar-btn" text @click="onOpenConnections">
               <font-awesome-icon icon="fa-solid fa-plug" />
+              <font-awesome-icon icon="fa-solid fa-up-right-from-square" class="external-icon" />
             </el-button>
           </el-tooltip>
         </div>
@@ -682,6 +684,12 @@ export default defineComponent({
     height: 8px;
     border-radius: 50%;
     background: var(--el-color-success);
+  }
+
+  .external-icon {
+    font-size: 9px;
+    opacity: 0.55;
+    margin-left: -2px;
   }
 }
 @media (max-width: 767px) {


### PR DESCRIPTION
## Summary

The **Skills** and **Connections** toolbar buttons in the chat composer open auth.acedata.cloud in a new tab. Previously the tooltip embedded the URL in parentheses ("Manage connections (auth.acedata.cloud)"), which was noisy and inconsistent with how AuthFrontend's sidebar indicates external links.

## Changes

- **Tooltip text**: simplified to "Manage connections" / "Manage skills" (en + zh-CN).
- **Button visual**: added a small `fa-up-right-from-square` icon next to the main icon on each button — same affordance AuthFrontend uses for *Developer Platform* / *UX Platform* in its sidebar nav.

## Files

- `src/i18n/en/chat.json` — strip `(auth.acedata.cloud)` from `connections.tooltip` + `skill.tooltip`
- `src/i18n/zh-CN/chat.json` — strip `（auth.acedata.cloud）` from same keys
- `src/pages/chat/Conversation.vue` — render external-link icon on both buttons; add minimal `.external-icon` SCSS rule (small, dimmed)

## Notes

- Other locales already have URL-free `skill.tooltip` translations and don't yet ship `connections.tooltip` — the translation cron will fill those in.
- Icon `fa-up-right-from-square` is already registered in `src/plugins/font-awesome.ts`, no plugin changes needed.