### PR TITLE
feat(chat): enable image/file upload entry for Claude, Gemini, Grok-4

### DIFF
--- a/change/@acedatacloud-nexior-34464010-da51-4a53-a6e9-c0f1cad9c483.json
+++ b/change/@acedatacloud-nexior-34464010-da51-4a53-a6e9-c0f1cad9c483.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(chat): enable image/file upload entry for Claude, Gemini, Grok-4",
+  "packageName": "@acedatacloud/nexior",
+  "email": "cqc@cuiqingcai.com",
+  "dependentChangeType": "patch"
+}

--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -104,6 +104,7 @@ export const CHAT_MODEL_GROK_4: IChatModel = {
   name: CHAT_MODEL_NAME_GROK_4,
   icon: CHAT_MODEL_ICON_GROK,
   modelGroup: 'grok',
+  isImageSupported: true,
   getDisplayName: () => i18n.global.t('chat.model.grok4'),
   getDescription: () => i18n.global.t('chat.model.grok4Description')
 };
@@ -140,6 +141,8 @@ export const CHAT_MODEL_GEMINI_3_0_PRO: IChatModel = {
   name: CHAT_MODEL_NAME_GEMINI_3_0_PRO,
   icon: CHAT_MODEL_ICON_GEMINI,
   modelGroup: 'gemini',
+  isImageSupported: true,
+  isFileSupported: true,
   getDisplayName: () => i18n.global.t('chat.model.gemini30Pro'),
   getDescription: () => i18n.global.t('chat.model.gemini30ProDescription')
 };
@@ -149,6 +152,8 @@ export const CHAT_MODEL_GEMINI_2_5_PRO: IChatModel = {
   name: CHAT_MODEL_NAME_GEMINI_2_5_PRO,
   icon: CHAT_MODEL_ICON_GEMINI,
   modelGroup: 'gemini',
+  isImageSupported: true,
+  isFileSupported: true,
   getDisplayName: () => i18n.global.t('chat.model.gemini25Pro'),
   getDescription: () => i18n.global.t('chat.model.gemini25ProDescription')
 };
@@ -158,6 +163,8 @@ export const CHAT_MODEL_GEMINI_2_5_FLASH: IChatModel = {
   name: CHAT_MODEL_NAME_GEMINI_2_5_FLASH,
   icon: CHAT_MODEL_ICON_GEMINI,
   modelGroup: 'gemini',
+  isImageSupported: true,
+  isFileSupported: true,
   getDisplayName: () => i18n.global.t('chat.model.gemini25Flash'),
   getDescription: () => i18n.global.t('chat.model.gemini25FlashDescription')
 };
@@ -167,6 +174,8 @@ export const CHAT_MODEL_CLAUDE_OPUS_4: IChatModel = {
   name: CHAT_MODEL_NAME_CLAUDE_OPUS_4,
   icon: CHAT_MODEL_ICON_CLAUDE,
   modelGroup: 'claude',
+  isImageSupported: true,
+  isFileSupported: true,
   getDisplayName: () => i18n.global.t('chat.model.claudeOpus4'),
   getDescription: () => i18n.global.t('chat.model.claudeOpus4Description')
 };
@@ -176,6 +185,8 @@ export const CHAT_MODEL_CLAUDE_SONNET_4: IChatModel = {
   name: CHAT_MODEL_NAME_CLAUDE_SONNET_4,
   icon: CHAT_MODEL_ICON_CLAUDE,
   modelGroup: 'claude',
+  isImageSupported: true,
+  isFileSupported: true,
   getDisplayName: () => i18n.global.t('chat.model.claudeSonnet4'),
   getDescription: () => i18n.global.t('chat.model.claudeSonnet4Description')
 };
@@ -185,6 +196,8 @@ export const CHAT_MODEL_CLAUDE_3_7_SONNET: IChatModel = {
   name: CHAT_MODEL_NAME_CLAUDE_3_7_SONNET,
   icon: CHAT_MODEL_ICON_CLAUDE,
   modelGroup: 'claude',
+  isImageSupported: true,
+  isFileSupported: true,
   getDisplayName: () => i18n.global.t('chat.model.claude37Sonnet'),
   getDescription: () => i18n.global.t('chat.model.claude37SonnetDescription')
 };


### PR DESCRIPTION
## Summary

The chat **Composer** already has an `Add files` entry, but it is gated on per-model `isImageSupported` / `isFileSupported` flags in `src/constants/chat.ts`. Until now only the GPT-5.4 family had those flags set, so the upload button was greyed out for **every other model** — even though Claude, Gemini, and Grok-4 all natively support vision (and Claude/Gemini natively support PDF).

This PR fixes the omission by setting the right capability flags on the models that actually support multimodal input.

## What this enables

| Model | `isImageSupported` | `isFileSupported` |
|---|:---:|:---:|
| `claude-opus-4` / `claude-sonnet-4` / `claude-3-7-sonnet` | ✅ | ✅ |
| `gemini-3.0-pro` / `gemini-2.5-pro` / `gemini-2.5-flash` | ✅ | ✅ |
| `grok-4` | ✅ | — |

DeepSeek, Grok-3 family, Kimi K2 Thinking, and GLM models remain text-only — their upload entry stays disabled, which matches their actual upstream capabilities.

## Why no backend change is needed

[`PlatformService/aichat2/worker/src/handlers/conversations.ts`](https://github.com/AceDataCloud/PlatformService/blob/main/aichat2/worker/src/handlers/conversations.ts) already serializes the `references` array into the OpenAI-compatible multimodal format:

```ts
for (const ref of body.references) {
  if (isImageUrl(ref)) {
    parts.push({ type: 'image_url', image_url: { url: ref } });
  } else {
    parts.push({ type: 'file_url', file_url: { url: ref } });
  }
}
```

So once the front-end stops gating the upload button, images flow through to upstream providers untouched — preserving spatial layout, color, OCR, and every other visual detail that would be lost if we routed images through a text-extraction tool.

## Test plan

- `npx vue-tsc --noEmit` ✅
- `npm run lint` ✅
- Manual: select Claude / Gemini / Grok-4, confirm the `+ Add files` button is now enabled and a paste/drop of an image attaches it.

## Out of scope (follow-ups)

- Vision-as-tool fallback for text-only models (DeepSeek / Grok-3 / GLM) — would require a new `vision.describe` skill.
- Moving capability discovery to the backend (e.g. capabilities field in `cost/api/_chat_models.json`) so we don't have to maintain the flags in the front-end at all.