### PR TITLE
fix(release): auto-sync package.json baseline to npm latest before publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -39,6 +39,31 @@ jobs:
           git config --global user.email 'actions@github.com'
           git remote set-url origin "https://${{ secrets.BOT_GITHUB_TOKEN }}@github.com/AceDataCloud/Nexior"
 
+      # Auto-recover from "version already exists" errors caused by partial
+      # publishes (npm push succeeded, git push failed). If the local
+      # package.json baseline is behind the npm registry's latest version,
+      # bump the baseline so beachball computes a fresh next version instead
+      # of trying to re-publish an already-taken one.
+      - name: Sync package.json baseline to npm latest
+        run: |
+          set -e
+          PKG=$(node -p "require('./package.json').name")
+          LOCAL=$(node -p "require('./package.json').version")
+          NPM_LATEST=$(npm view "$PKG" version 2>/dev/null || true)
+          if [ -z "$NPM_LATEST" ]; then
+            echo "Could not fetch npm latest for $PKG; skipping baseline sync."
+            exit 0
+          fi
+          HIGHER=$(node -e "const s=require('semver'); console.log(s.gt(process.argv[1], process.argv[2]) ? '1' : '0')" "$NPM_LATEST" "$LOCAL")
+          if [ "$HIGHER" = "1" ]; then
+            echo "::warning::Local package.json version ($LOCAL) is behind npm registry ($NPM_LATEST). Syncing baseline so beachball can publish."
+            sed -i.bak -E "s/(\"version\": \")[^\"]+(\")/\\1${NPM_LATEST}\\2/" package.json
+            rm -f package.json.bak
+            echo "package.json baseline now at $NPM_LATEST"
+          else
+            echo "Local version ($LOCAL) >= npm registry ($NPM_LATEST). No sync needed."
+          fi
+
       - name: Publish
         run: yarn release
         env:

--- a/change/@acedatacloud-nexior-fix-publish-autosync.json
+++ b/change/@acedatacloud-nexior-fix-publish-autosync.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "ci(release): auto-sync package.json baseline to npm latest before publish",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "none"
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acedatacloud/nexior",
-  "version": "3.34.0",
+  "version": "3.35.0",
   "author": "Ace Data Cloud <office@acedata.cloud>",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Why

The publish workflow has been failing on **every** push to `main` since 2026-04-05 (~4 weeks). 11 `change/` files have piled up un-consumed, including `feat(studio)`, `feat(connectors)`, the Claude model lineup update, etc.

Latest run ([25265156110](https://github.com/AceDataCloud/Nexior/actions/runs/25265156110)) error:
```
ERROR: Attempting to publish package versions that already exist in the registry:
- @acedatacloud/nexior@3.35.0
```

## Root cause

The local `package.json` baseline drifted behind the npm registry:

| Source | Version |
|---|---|
| `package.json` (main HEAD) | **3.34.0** |
| npm registry latest | **3.35.0** (3.34.1 also taken) |
| Last git tag | `@acedatacloud/nexior_v3.32.9` |

beachball computes the next version from the **local** baseline, so any patch change tried `3.34.1` (taken) and any minor change tried `3.35.0` (taken) — abort, change files left behind, no publish.

The drift was caused by partial publishes (npm push succeeded, git push failed) and then prior manual sync PRs (#425, #451) only catching up partway.

## Fix

1. **Bump `package.json` to 3.35.0** to clear the immediate jam. Next bump from the pending change files will land on `3.35.1` / `3.36.0` (both fresh).
2. **New auto-recover step in `publish.yaml`**: before invoking beachball, query `npm view <pkg> version` and rewrite `package.json`'s `version` field if local is behind. This makes future drift self-healing — no more manual sync PRs needed.

```yaml
- name: Sync package.json baseline to npm latest
  run: |
    PKG=$(node -p "require('./package.json').name")
    LOCAL=$(node -p "require('./package.json').version")
    NPM_LATEST=$(npm view "$PKG" version 2>/dev/null || true)
    HIGHER=$(node -e "const s=require('semver'); console.log(s.gt(process.argv[1], process.argv[2]) ? '1' : '0')" "$NPM_LATEST" "$LOCAL")
    if [ "$HIGHER" = "1" ]; then
      sed -i.bak -E "s/(\"version\": \")[^\"]+(\")/\\1${NPM_LATEST}\\2/" package.json
      ...
    fi
```

## Verification

After this PR merges, the publish workflow should:
1. Detect baseline 3.35.0 == npm latest 3.35.0 (no sync needed).
2. beachball bumps to **3.36.0** (minor — driven by `feat(studio)` etc.) and consumes all 12 change files in one go.

Going forward, even if a partial publish happens again, the next push to main will auto-correct the baseline.