### PR TITLE
fix(ci): use BOT_GITHUB_TOKEN in translate workflow so generated PRs trigger checks

### DIFF
--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -24,7 +24,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use the bot PAT so that the commit pushed by create-pull-request below
+          # is authored by the bot user. This is required for the resulting PR to
+          # trigger downstream workflows (pull_request events created with the
+          # default GITHUB_TOKEN are intentionally suppressed by GitHub).
+          token: ${{ secrets.BOT_GITHUB_TOKEN }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -44,7 +48,9 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # MUST be a PAT (not GITHUB_TOKEN), otherwise the resulting PR will not
+          # trigger any workflows (including ci.yaml's pull_request job).
+          token: ${{ secrets.BOT_GITHUB_TOKEN }}
           commit-message: 'ci: auto-translate i18n from zh-CN'
           title: 'ci: auto-translate i18n from zh-CN'
           body: |
@@ -67,6 +73,6 @@ jobs:
       - name: Enable auto-merge for translation PR
         if: ${{ steps.cpr.outputs.pull-request-number }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
         run: |
           gh pr merge ${{ steps.cpr.outputs.pull-request-number }} --auto --squash --repo ${{ github.repository }}

--- a/change/@acedatacloud-nexior-65b16313-8756-4eec-8e1e-123c991a5db0.json
+++ b/change/@acedatacloud-nexior-65b16313-8756-4eec-8e1e-123c991a5db0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "ci: use BOT_GITHUB_TOKEN in translate workflow so generated PRs trigger checks",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "none"
+}


### PR DESCRIPTION
## Why

PR #483 (and any other auto-translate PR) shows zero CI checks (`statusCheckRollup: []`) and stays "BEHIND" forever. Root cause: `peter-evans/create-pull-request` was authenticated with the default `GITHUB_TOKEN`. Per [GitHub docs](https://docs.github.com/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow), pushes / PRs made with `GITHUB_TOKEN` intentionally **do not** trigger downstream workflows, so `ci.yaml`'s `pull_request` job never runs.

## What

Switch the three token references in `translate.yaml` from `GITHUB_TOKEN` to the existing `BOT_GITHUB_TOKEN` PAT (same secret already used by `publish.yaml` and `github-release.yaml`):

1. `actions/checkout` token — so the working tree's pushed commit is bot-authored.
2. `peter-evans/create-pull-request` token — so the resulting PR triggers `pull_request` workflows.
3. `gh pr merge --auto` token — so auto-merge has the necessary perms.

The auto-approve step already used the bot token, so it is unchanged.

## Effect

Future translation PRs will run the `check` job (lint + build) and can actually auto-merge once green. The currently-stuck #483 will be unblocked separately by close+reopen via the bot PAT.
