### PR TITLE
feat(chat): URL-driven conversation routing + lazy history + scenario-scoped list

### DIFF
--- a/change/@acedatacloud-nexior-0c3cc439-c15f-4a8a-97d4-134c0e995cd8.json
+++ b/change/@acedatacloud-nexior-0c3cc439-c15f-4a8a-97d4-134c0e995cd8.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Conversation list now scoped per scenario; URL reflects active conversation; lazy-load message history",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/SidePanel.vue
+++ b/src/components/chat/SidePanel.vue
@@ -130,17 +130,10 @@ export default defineComponent({
       return this.$route.params?.id?.toString();
     },
     conversations() {
-      let conversations = this.$store.state.chat.conversations;
-      console.debug('conversations', conversations);
-      console.debug('modelGroup', this.modelGroup);
-      // filter by model group
-      conversations = conversations?.filter(
-        (conversation: IChatConversation) =>
-          conversation?.model &&
-          this.modelGroup?.models?.map((item) => item.name as string)?.includes(conversation?.model)
-      );
-      console.debug('filtered conversations', conversations);
-      return conversations;
+      // Server already filters by `model_group` (chat store action passes
+      // `state.modelGroup.name`), so the panel just renders whatever the
+      // store currently holds. No client-side filter needed.
+      return this.$store.state.chat.conversations;
     },
     conversationGroups() {
       // split our 4 groups according to the `updated_at` field, to 'today', 'yesterday', 'this week', 'earlier'.
@@ -210,12 +203,11 @@ export default defineComponent({
       this.$emit('change-conversation', id);
     },
     getConversationTitle(conversation: IChatConversation) {
-      return (
-        conversation?.title ||
-        conversation?.messages?.[conversation?.messages.length - 1]?.content ||
-        conversation?.messages?.[0]?.content ||
-        ''
-      );
+      // Backend writes `title` on every save (buildConversationTitle in
+      // aichat2). For really old rows that never got a title we fall back
+      // to the server-supplied `last_message_preview`. Don't try to dig
+      // into `messages` here — list responses no longer carry it.
+      return conversation?.title || conversation?.last_message_preview || '';
     },
     onConversationCommand(command: ConversationCommand, conversation: IChatConversation) {
       if (command === 'rename') {

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -110,7 +110,21 @@ export interface IChatMessage {
 export interface IChatConversation {
   id?: string;
   model?: string;
+  /**
+   * Provider bucket the conversation belongs to (chatgpt | claude | gemini |
+   * grok | kimi | glm | deepseek | other). Filled by aichat2 from the model
+   * name; relied on by the side-panel to know which scenario page should
+   * own each row without having to look up the model registry.
+   */
+  model_group?: string;
   messages?: IChatMessage[];
+  /**
+   * Short text preview of the last user/assistant turn, returned by
+   * `retrieve_batch` so the side panel can show context without loading
+   * the entire `messages` array. Absent on full `retrieve` responses
+   * (which carry `messages` instead).
+   */
+  last_message_preview?: string;
   title?: string;
   deleting?: boolean;
   editing?: boolean;

--- a/src/operators/chat.ts
+++ b/src/operators/chat.ts
@@ -123,6 +123,17 @@ class ChatOperator {
       ids?: string[];
       applicationId?: string;
       userId?: string;
+      /**
+       * Provider bucket to scope the side-panel list (`chatgpt`, `claude`,
+       * `gemini`, `grok`, `kimi`, `glm`, `deepseek`). Strongly recommended
+       * — without it the worker returns every conversation across every
+       * scenario, which can be hundreds of rows.
+       */
+      modelGroup?: string;
+      /** Filter by exact model name (rarely needed; modelGroup is usually enough). */
+      model?: string;
+      offset?: number;
+      limit?: number;
     },
     options: IChatConversationOptions
   ): Promise<AxiosResponse<IChatConversationsResponse>> {
@@ -130,21 +141,36 @@ class ChatOperator {
       `/aichat2/conversations`,
       {
         action: IChatConversationAction.RETRIEVE_BATCH,
-        ...(filter.ids
-          ? {
-              ids: filter.ids
-            }
-          : {}),
-        ...(filter.applicationId
-          ? {
-              application_id: filter.applicationId
-            }
-          : {}),
-        ...(filter.userId
-          ? {
-              user_id: filter.userId
-            }
-          : {})
+        ...(filter.ids ? { ids: filter.ids } : {}),
+        ...(filter.applicationId ? { application_id: filter.applicationId } : {}),
+        ...(filter.userId ? { user_id: filter.userId } : {}),
+        ...(filter.modelGroup ? { model_group: filter.modelGroup } : {}),
+        ...(filter.model ? { model: filter.model } : {}),
+        ...(filter.offset !== undefined ? { offset: filter.offset } : {}),
+        ...(filter.limit !== undefined ? { limit: filter.limit } : {})
+      },
+      {
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${options.token}`,
+          'x-record-exempt': 'true'
+        },
+        baseURL: BASE_URL_API
+      }
+    );
+  }
+
+  /**
+   * Lazy-load full message history for a single conversation.
+   * Side panel deliberately fetches summaries only (no `messages`); call
+   * this when the user clicks a row to actually open it.
+   */
+  async getConversation(id: string, options: IChatConversationOptions): Promise<AxiosResponse<IChatConversation>> {
+    return await axios.post(
+      `/aichat2/conversations`,
+      {
+        action: IChatConversationAction.RETRIEVE,
+        id
       },
       {
         headers: {

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -96,6 +96,12 @@ export interface IData {
   agentName: string;
   agentToolCount: number;
   agentConnectedAt: string;
+  /**
+   * Set right before pushing the URL for a freshly-completed chat so the
+   * `conversationId` watcher can recognise the change as “already loaded
+   * locally” and skip the otherwise-redundant `retrieve` call.
+   */
+  skipNextRestoreId: string | undefined;
 }
 
 export default defineComponent({
@@ -124,10 +130,8 @@ export default defineComponent({
       agentName: '',
       agentToolCount: 0,
       agentConnectedAt: '',
-      messages:
-        this.$store.state.chat.conversations?.find(
-          (conversation: IChatConversation) => conversation.id === this.$route.params.id?.toString()
-        )?.messages || []
+      skipNextRestoreId: undefined,
+      messages: []
     };
   },
   computed: {
@@ -178,15 +182,42 @@ export default defineComponent({
     },
     async modelGroup(val) {
       console.debug('modelGroup changed', val);
+      // Side-panel list is server-filtered by model_group, so any change
+      // here forces a refresh. Reset local store first so the panel does
+      // not flash the previous group's rows during the round-trip.
+      this.$store.commit('chat/setConversations', []);
+      await this.$store.dispatch('chat/getConversations');
     },
-    async conversationId(val) {
+    async conversationId(val: string | undefined) {
       console.debug('conversationId changed', val);
+      // URL is the source of truth: load (or reset) the conversation
+      // here. UI components dispatch onChangeConversation -> router.push
+      // -> this watcher fires.
+      if (!val) {
+        this.messages = [];
+        this.question = '';
+        this.references = [];
+        return;
+      }
+      // Just-completed chat already populated `this.messages` locally;
+      // skip the round-trip (the router push only changed the URL).
+      if (this.skipNextRestoreId && val === this.skipNextRestoreId) {
+        this.skipNextRestoreId = undefined;
+        return;
+      }
+      await this.onRestoreConversation(val);
     }
   },
   async mounted() {
     await this.onGetService();
     await this.onGetApplication();
     await this.onGetConversations();
+    // If the URL already carries a :id (deep-link / refresh), restore it
+    // now that store/credential are warm. The conversationId watcher
+    // doesn't fire `immediate` (we'd race the data() init with no token).
+    if (this.conversationId) {
+      await this.onRestoreConversation(this.conversationId);
+    }
     this.onCheckAgentStatus();
   },
   methods: {
@@ -378,29 +409,35 @@ export default defineComponent({
         });
     },
     async onNewConversation() {
-      this.$router.push({
-        params: {
-          id: ''
-        }
-      });
-      this.messages = [];
-      this.question = '';
-      this.references = [];
+      // Single-source-of-truth: drive everything off the URL. Calling
+      // router.push with an empty :id removes the path segment. The
+      // `conversationId` watcher then resets messages/question/refs.
+      if (this.conversationId) {
+        await this.$router.push({ params: { id: '' } });
+      } else {
+        // Already on /chatgpt/conversations — no route change to trigger
+        // the watcher, so reset locally.
+        this.messages = [];
+        this.question = '';
+        this.references = [];
+      }
     },
     async onRestoreConversation(id: string) {
       console.debug('onRestoreConversation id', id);
-      const conversation = this.conversations?.find((conversation: IChatConversation) => conversation.id === id);
-      // change the model and model group
+      // 1. Pull from store cache, or lazy-fetch full history from aichat2.
+      //    Side-panel summaries do NOT include `messages`, so we always
+      //    need a `retrieve` call the first time a conversation is opened.
+      let conversation: IChatConversation | undefined = this.conversations?.find((c: IChatConversation) => c.id === id);
+      if (!conversation || !conversation.messages) {
+        const fetched = await this.$store.dispatch('chat/getConversation', id);
+        if (fetched) conversation = fetched;
+      }
+      // 2. Switch model + model group to whatever this conversation used.
       const model = conversation?.model;
-      console.debug('conversation model', model);
       const targetModel = CHAT_MODELS.find((m) => m.name === model);
-      console.debug('target model', targetModel);
       const targetModelGroup = CHAT_MODEL_GROUPS.find((g) => g.name === targetModel?.modelGroup);
-      console.debug('target model group', targetModelGroup);
-      this.$store.dispatch('chat/setModelGroup', targetModelGroup);
-      this.$store.dispatch('chat/setModel', targetModel);
-      console.debug('conversation', conversation);
-      console.debug('conversation messages', this.messages);
+      if (targetModelGroup) this.$store.dispatch('chat/setModelGroup', targetModelGroup);
+      if (targetModel) this.$store.dispatch('chat/setModel', targetModel);
       this.messages = conversation?.messages || [];
       this.onScrollDown();
     },
@@ -408,12 +445,18 @@ export default defineComponent({
       console.log('onChangeConversation in conversation', id);
       // stop the current request
       await this.onStop();
-      // if id is undefined, create a new conversation
-      if (!id) {
-        this.onNewConversation();
-      } else {
-        this.onRestoreConversation(id);
+      // Drive everything off the URL — router push triggers the
+      // conversationId watcher which then loads/resets state. This makes
+      // back/forward, refresh, and shareable URLs all behave correctly.
+      const target = id || '';
+      if (target === (this.conversationId || '')) {
+        // Same id (or both empty): nothing for the router to do, fall
+        // through to the explicit handlers so e.g. clicking "new" while
+        // already on a new chat still resets state.
+        if (!target) await this.onNewConversation();
+        return;
       }
+      await this.$router.push({ params: { id: target } });
     },
     async onSubmit() {
       if (this.references.length > 0) {
@@ -582,6 +625,7 @@ export default defineComponent({
           });
           this.answering = false;
           if (conversationId) {
+            this.skipNextRestoreId = conversationId;
             await this.$router.push({
               params: {
                 id: conversationId

--- a/src/store/chat/actions.ts
+++ b/src/store/chat/actions.ts
@@ -134,28 +134,64 @@ export const getConversations = async ({
 }: ActionContext<IChatState, IRootState>): Promise<IChatConversation[]> => {
   state.status.getConversations = Status.Request;
   const credential = state.credential;
-  console.debug('credential', credential);
   const token = credential?.token;
-  if (!token) {
+  const modelGroup = state.modelGroup?.name;
+  // Without a token we can't authenticate; without a modelGroup we'd pull
+  // every scenario at once (chatgpt + claude + kimi + …) which can be
+  // hundreds of rows. Bail in both cases — the page reactively refetches
+  // once the modelGroup is selected.
+  if (!token || !modelGroup) {
     state.status.getConversations = Status.Error;
+    commit('setConversations', []);
     return [];
   }
   try {
     const { data } = await chatOperator.getConversations(
       {
-        userId: rootState.user?.id
+        userId: rootState.user?.id,
+        modelGroup
       },
       {
         token
       }
     );
-    console.debug('get conversations success', data?.items?.length);
+    console.debug('get conversations success', data?.items?.length, 'group=', modelGroup);
+    state.status.getConversations = Status.Success;
     commit('setConversations', data.items);
     return data.items;
   } catch (error) {
     state.status.getConversations = Status.Error;
     commit('setConversations', []);
     return [];
+  }
+};
+
+/**
+ * Lazy-load full message history for a single conversation. Used when the
+ * user clicks a row in the side panel — the panel itself only ever holds
+ * summaries (no `messages` array). Result is also merged back into
+ * `state.conversations` so subsequent reads are instant.
+ */
+export const getConversation = async (
+  { commit, state }: ActionContext<IChatState, IRootState>,
+  id: string
+): Promise<IChatConversation | undefined> => {
+  const token = state.credential?.token;
+  if (!token || !id) return undefined;
+  try {
+    const { data } = await chatOperator.getConversation(id, { token });
+    const list = state.conversations || [];
+    const idx = list.findIndex((c) => c.id === id);
+    const merged = idx > -1 ? { ...list[idx], ...data } : data;
+    if (idx > -1) {
+      const next = [...list];
+      next[idx] = merged;
+      commit('setConversations', next);
+    }
+    return merged;
+  } catch (error) {
+    console.error('getConversation failed', id, error);
+    return undefined;
   }
 };
 
@@ -172,5 +208,6 @@ export default {
   getApplications,
   setConversation,
   setConversations,
-  getConversations
+  getConversations,
+  getConversation
 };


### PR DESCRIPTION
## Summary

Fixes the side-panel URL bug and rewires `/chatgpt/conversations` (and Claude / Kimi / Grok / Gemini / DeepSeek peers) to scope by scenario and lazy-load history.

### Bug fix — URL doesn't change on click
`onChangeConversation` used to just mutate `messages` in place. Now every conversation switch goes through `router.push({ params: { id } })`, and a watcher on `$route.params.id` performs the load. Outcome:
- Clicking a side-panel row updates the URL to `/chatgpt/conversations/<uuid>`.
- Browser back/forward and refresh restore the right conversation.
- Deep-linking now works.

### List/history split
- `chatOperator.getConversations()` now sends `model_group` + `model` + `offset/limit` (defaults: current `state.modelGroup.name`).
- New `chatOperator.getConversation(id)` for the on-click "load full history" path. Result is merged into `state.conversations` so subsequent re-opens are instant.
- `getConversations` action bails when no `modelGroup` is selected — avoids fetching all scenarios.
- `setConversations` is reset on `modelGroup` change so the panel doesn't flash the previous group.

### SidePanel cleanup
- Removed the client-side `modelGroup.models.includes(conversation.model)` filter — the server now filters by `model_group`.
- `getConversationTitle` falls back to `last_message_preview` (server-supplied) instead of digging into `messages`, which list responses no longer carry.

### Companion PR (must merge first)
- PlatformService: https://github.com/AceDataCloud/PlatformService/pull/808

### Files changed
- `src/models/chat.ts` — add `model_group`, `last_message_preview` to `IChatConversation`
- `src/operators/chat.ts` — split `getConversations` (with filters) + new `getConversation(id)`
- `src/store/chat/actions.ts` — modelGroup-scoped fetch + new `getConversation` action
- `src/pages/chat/Conversation.vue` — URL-driven conversation switching, lazy history load, modelGroup-watcher refetch
- `src/components/chat/SidePanel.vue` — drop client filter, use server preview for title fallback

### Test
```bash
npx vue-tsc --noEmit   # clean
npm run lint           # clean
npm run build          # clean
```
