### PR TITLE
perf(load): drop vendor-web3 from initial preload (-650 KB gzipped)

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,14 +63,40 @@
     <!-- Inter font -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
-    <script>
+    <!--
+      Load Inter without blocking first paint: request via `media="print"` so
+      the browser does not block render on the stylesheet, then swap to `all`
+      once it loads. Falls back to a synchronous `<link>` for clients without JS.
+    -->
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
+      media="print"
+      onload="this.media='all'"
+    />
+    <noscript>
+      <link
+        rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
+      />
+    </noscript>    <script>
       var _hmt = _hmt || [];
+      // Defer Baidu analytics so it never blocks initial paint or competes for
+      // bandwidth with the application bundle. `requestIdleCallback` lets the
+      // browser pick an idle moment; `setTimeout` is a fallback for Safari.
       (function () {
-        var hm = document.createElement('script');
-        hm.src = 'https://hm.baidu.com/hm.js?6216b5ba30d8e35b2319b4c0331cbf21';
-        var s = document.getElementsByTagName('script')[0];
-        s.parentNode.insertBefore(hm, s);
+        var inject = function () {
+          var hm = document.createElement('script');
+          hm.async = true;
+          hm.src = 'https://hm.baidu.com/hm.js?6216b5ba30d8e35b2319b4c0331cbf21';
+          var s = document.getElementsByTagName('script')[0];
+          s.parentNode.insertBefore(hm, s);
+        };
+        if ('requestIdleCallback' in window) {
+          requestIdleCallback(inject, { timeout: 4000 });
+        } else {
+          setTimeout(inject, 2000);
+        }
       })();
     </script>
     <style>

--- a/src/utils/x402/solana.ts
+++ b/src/utils/x402/solana.ts
@@ -12,15 +12,35 @@
  * 4. Confirm transaction after sending
  */
 
-import { Connection, PublicKey, Transaction, TransactionInstruction, ComputeBudgetProgram } from '@solana/web3.js';
+// `@solana/web3.js` is heavy (~2 MB / 650 KB gzipped). Keep types only at the top
+// level so the runtime module is loaded lazily inside the exported helpers and
+// never enters the application's static import graph (vendor-web3 chunk stays
+// dynamic-only and is no longer preloaded on initial page load).
+import type {
+  Connection as ConnectionType,
+  PublicKey as PublicKeyType,
+  Transaction as TransactionType,
+  TransactionInstruction as TransactionInstructionType
+} from '@solana/web3.js';
+
+type SolanaWeb3 = typeof import('@solana/web3.js');
+
+let solanaWeb3Promise: Promise<SolanaWeb3> | null = null;
+const loadSolanaWeb3 = (): Promise<SolanaWeb3> => {
+  if (!solanaWeb3Promise) {
+    solanaWeb3Promise = import('@solana/web3.js');
+  }
+  return solanaWeb3Promise;
+};
 
 // RPC endpoints
 const SOLANA_MAINNET_RPC = 'https://api.mainnet-beta.solana.com';
 const SOLANA_DEVNET_RPC = 'https://api.devnet.solana.com';
 
-// Solana program IDs
-const TOKEN_PROGRAM_ID = new PublicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA');
-const ASSOCIATED_TOKEN_PROGRAM_ID = new PublicKey('ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL');
+// Solana program IDs (raw strings; `PublicKey` instances are constructed lazily
+// after the module is loaded).
+const TOKEN_PROGRAM_ID_STR = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA';
+const ASSOCIATED_TOKEN_PROGRAM_ID_STR = 'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL';
 
 /**
  * Convert Uint8Array to base64 string (browser-compatible, no Node.js Buffer)
@@ -45,10 +65,12 @@ function resolveRpcUrl(network: string, customRpcUrl?: string): string {
 /**
  * Find Associated Token Account address
  */
-function findAta(owner: PublicKey, mint: PublicKey): PublicKey {
-  const [ata] = PublicKey.findProgramAddressSync(
-    [owner.toBuffer(), TOKEN_PROGRAM_ID.toBuffer(), mint.toBuffer()],
-    ASSOCIATED_TOKEN_PROGRAM_ID
+function findAta(web3: SolanaWeb3, owner: PublicKeyType, mint: PublicKeyType): PublicKeyType {
+  const tokenProgramId = new web3.PublicKey(TOKEN_PROGRAM_ID_STR);
+  const associatedTokenProgramId = new web3.PublicKey(ASSOCIATED_TOKEN_PROGRAM_ID_STR);
+  const [ata] = web3.PublicKey.findProgramAddressSync(
+    [owner.toBuffer(), tokenProgramId.toBuffer(), mint.toBuffer()],
+    associatedTokenProgramId
   );
   return ata;
 }
@@ -68,16 +90,18 @@ function createTransferCheckedData(amount: bigint, decimals: number): Uint8Array
  * Build SPL Token TransferChecked instruction
  */
 function buildTransferCheckedInstruction(
-  source: PublicKey,
-  mint: PublicKey,
-  destination: PublicKey,
-  authority: PublicKey,
+  web3: SolanaWeb3,
+  source: PublicKeyType,
+  mint: PublicKeyType,
+  destination: PublicKeyType,
+  authority: PublicKeyType,
   amount: bigint,
   decimals: number
-): TransactionInstruction {
+): TransactionInstructionType {
   const instructionData = createTransferCheckedData(amount, decimals);
-  return new TransactionInstruction({
-    programId: TOKEN_PROGRAM_ID,
+  const tokenProgramId = new web3.PublicKey(TOKEN_PROGRAM_ID_STR);
+  return new web3.TransactionInstruction({
+    programId: tokenProgramId,
     keys: [
       { pubkey: source, isSigner: false, isWritable: true },
       { pubkey: mint, isSigner: false, isWritable: false },
@@ -122,7 +146,7 @@ export interface SolanaPaymentResult {
 export async function executeSolanaPayment(args: {
   requirements: SolanaPaymentRequirements;
   payerAddress: string;
-  signAndSendTransaction: (tx: Transaction) => Promise<string | { signature: string }>;
+  signAndSendTransaction: (tx: TransactionType) => Promise<string | { signature: string }>;
   fetchBlockhash?: (network: string) => Promise<string>;
 }): Promise<SolanaPaymentResult> {
   const { requirements, payerAddress, signAndSendTransaction, fetchBlockhash } = args;
@@ -148,25 +172,26 @@ export async function executeSolanaPayment(args: {
   const network = String(requirements.network || 'solana').toLowerCase();
   const rpcUrl = resolveRpcUrl(network, extra.rpcUrl || extra.rpc_url);
 
-  const connection = new Connection(rpcUrl, 'confirmed');
+  const web3 = await loadSolanaWeb3();
+  const connection = new web3.Connection(rpcUrl, 'confirmed');
 
-  const payerPubkey = new PublicKey(payerAddress);
-  const payToPubkey = new PublicKey(payTo);
-  const mint = new PublicKey(requirements.asset);
+  const payerPubkey = new web3.PublicKey(payerAddress);
+  const payToPubkey = new web3.PublicKey(payTo);
+  const mint = new web3.PublicKey(requirements.asset);
 
-  const sourceAta = findAta(payerPubkey, mint);
-  const destAta = findAta(payToPubkey, mint);
+  const sourceAta = findAta(web3, payerPubkey, mint);
+  const destAta = findAta(web3, payToPubkey, mint);
 
-  const tx = new Transaction();
+  const tx = new web3.Transaction();
 
   if (computeUnitLimit > 0) {
-    tx.add(ComputeBudgetProgram.setComputeUnitLimit({ units: computeUnitLimit }));
+    tx.add(web3.ComputeBudgetProgram.setComputeUnitLimit({ units: computeUnitLimit }));
   }
   if (computeUnitPriceMicroLamports > 0) {
-    tx.add(ComputeBudgetProgram.setComputeUnitPrice({ microLamports: computeUnitPriceMicroLamports }));
+    tx.add(web3.ComputeBudgetProgram.setComputeUnitPrice({ microLamports: computeUnitPriceMicroLamports }));
   }
 
-  tx.add(buildTransferCheckedInstruction(sourceAta, mint, destAta, payerPubkey, amount, decimals));
+  tx.add(buildTransferCheckedInstruction(web3, sourceAta, mint, destAta, payerPubkey, amount, decimals));
 
   // CRITICAL: User wallet is the fee payer
   tx.feePayer = payerPubkey;
@@ -250,11 +275,12 @@ export async function buildSolanaX402Header(args: {
   const network = String(requirements.network || 'solana').toLowerCase();
   const rpcUrl = resolveRpcUrl(network, extra.rpcUrl || extra.rpc_url);
 
-  const connection = args.connection || new Connection(rpcUrl, 'confirmed');
+  const web3 = await loadSolanaWeb3();
+  const connection: ConnectionType = args.connection || new web3.Connection(rpcUrl, 'confirmed');
 
-  const payerPubkey = new PublicKey(payerAddress);
-  const payTo = new PublicKey(String(requirements.payTo || requirements.pay_to));
-  const mint = new PublicKey(String(requirements.asset));
+  const payerPubkey = new web3.PublicKey(payerAddress);
+  const payTo = new web3.PublicKey(String(requirements.payTo || requirements.pay_to));
+  const mint = new web3.PublicKey(String(requirements.asset));
 
   const localDecimals = Number(extra.decimals ?? 6);
   const localComputeUnitLimit = Number(extra.computeUnitLimit ?? extra.compute_unit_limit ?? 200_000);
@@ -265,19 +291,19 @@ export async function buildSolanaX402Header(args: {
   const amount = BigInt(String(requirements.maxAmountRequired || requirements.max_amount_required || '0'));
   if (amount <= 0n) throw new Error('Invalid amount');
 
-  const sourceAta = findAta(payerPubkey, mint);
-  const destAta = findAta(payTo, mint);
+  const sourceAta = findAta(web3, payerPubkey, mint);
+  const destAta = findAta(web3, payTo, mint);
 
-  const tx = new Transaction();
+  const tx = new web3.Transaction();
   tx.feePayer = payerPubkey;
 
   if (localComputeUnitLimit > 0) {
-    tx.add(ComputeBudgetProgram.setComputeUnitLimit({ units: localComputeUnitLimit }));
+    tx.add(web3.ComputeBudgetProgram.setComputeUnitLimit({ units: localComputeUnitLimit }));
   }
   if (localComputeUnitPriceMicroLamports > 0) {
-    tx.add(ComputeBudgetProgram.setComputeUnitPrice({ microLamports: localComputeUnitPriceMicroLamports }));
+    tx.add(web3.ComputeBudgetProgram.setComputeUnitPrice({ microLamports: localComputeUnitPriceMicroLamports }));
   }
-  tx.add(buildTransferCheckedInstruction(sourceAta, mint, destAta, payerPubkey, amount, localDecimals));
+  tx.add(buildTransferCheckedInstruction(web3, sourceAta, mint, destAta, payerPubkey, amount, localDecimals));
 
   if (args.fetchLatestBlockhash) {
     tx.recentBlockhash = await args.fetchLatestBlockhash(network);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,30 +6,14 @@ import * as path from 'path';
 const normalizeModuleId = (id: string) => id.replace(/\\/g, '/');
 
 const vendorChunkRules: Array<[chunkName: string, matches: (normalizedId: string) => boolean]> = [
-  [
-    'vendor-web3',
-    (id) =>
-      id.includes('/@solana/') ||
-      id.includes('/solana-wallets-vue/') ||
-      id.includes('/ethers/') ||
-      id.includes('/@noble/') ||
-      id.includes('/@scure/') ||
-      id.includes('/@stablelib/') ||
-      id.includes('/bn.js/') ||
-      id.includes('/borsh/') ||
-      id.includes('/bs58/') ||
-      id.includes('/tweetnacl/') ||
-      id.includes('/superstruct/') ||
-      id.includes('/jayson/') ||
-      id.includes('/rpc-websockets/') ||
-      id.includes('/secp256k1/') ||
-      id.includes('/uint8arrays/') ||
-      id.includes('/multiformats/') ||
-      id.includes('/@lit/') ||
-      id.includes('/lit-html/') ||
-      id.includes('/@w3m/') ||
-      id.includes('/@reown/')
-  ],
+  // NOTE: We deliberately do NOT define a `vendor-web3` chunk here. Forcing
+  // every Web3 dependency into one giant chunk causes Rollup to hoist shared
+  // helpers (notably Vite's auto-generated `__vitePreload`) into that chunk,
+  // which makes the entry statically depend on it. The browser then preloads
+  // ~2 MB / 650 KB-gz of Solana code on first paint even for users who never
+  // visit a payment page. Letting Rollup pick natural chunk boundaries keeps
+  // Web3 code split across small chunks that are only fetched lazily by
+  // `utils/x402/solana.ts` and `plugins/solana-wallets.ts`.
   ['vendor-element-plus', (id) => id.includes('/element-plus/')],
   ['vendor-vue-router', (id) => id.includes('/vue-router/')],
   ['vendor-vue', (id) => id.includes('/node_modules/vue/') || id.includes('/node_modules/@vue/')],


### PR DESCRIPTION
## Why is the page slow to load?

The previous Vite `manualChunks` rule swept every Web3-related package into a single `vendor-web3` chunk:

- `@solana/*`, `solana-wallets-vue`, `ethers`, `@reown/*`, `@w3m/*`, plus a long list of crypto/encoding libs (`@noble`, `@scure`, `bs58`, `tweetnacl`, `multiformats`, `borsh`, `superstruct`, `jayson`, `rpc-websockets`, …).

That made `vendor-web3` the largest shared sink in the build (2.1 MB / ~635 KB-gz). Rollup then hoisted Vite's auto-generated `__vitePreload` helper into that chunk, which made the **entry chunk statically depend on it**. The browser ended up preloading the entire Web3 bundle on first paint — even for visitors who never open a crypto payment page.

Decoded entry imports before this PR:

```js
import { _ as l, r as dh, a as mh } from "./vendor-web3-…js"; // <- 2.1 MB / 635 KB-gz
```

`_` was `__vitePreload` and the others were CommonJS-module helpers that got stuck in the same chunk.

## What this PR changes

1. **`src/utils/x402/solana.ts`** — the only file that statically imported `@solana/web3.js`. Top-level imports are now `import type` only; the runtime module is loaded once via `import('@solana/web3.js')` cached behind a promise and resolved inside the two exported async helpers (`executeSolanaPayment`, `buildSolanaX402Header`). Constructor calls go through the resolved namespace (`web3.PublicKey`, `web3.Transaction`, `web3.ComputeBudgetProgram`, …).

2. **`vite.config.ts`** — drop the `vendor-web3` manualChunks rule entirely. With no static import path remaining, Rollup splits Web3 code naturally into smaller chunks reachable only from:
   - the dynamic `import('@solana/web3.js')` inside `utils/x402/solana.ts` (X402 pay flow)
   - the post-mount lazy `installSolanaWallets` plugin in `main.ts`

3. **`index.html`** — two render-blocking 3rd-party requests on the critical path are made non-blocking:
   - **Baidu `hm.js`** is now injected via `requestIdleCallback` (`setTimeout` fallback) so it never competes with the application bundle.
   - **Google Fonts (Inter)** stylesheet now uses the `media="print" onload` swap pattern with a `<noscript>` fallback, so it no longer blocks first paint.

## Result

| | before | after | change |
|---|---:|---:|---:|
| `vendor-web3` in entry preload | yes | **no** | — |
| Eager JS + entry CSS (raw) | ~3.9 MB | **~1.8 MB** | **-2.1 MB** |
| Eager JS + entry CSS (gzip) | ~1.15 MB | **~503 KB** | **-650 KB** |
| First-paint blocking 3rd-party requests | 2 | 0 | -2 |

Web3 code (`@solana/web3.js` + Phantom/Solflare/Nightly/WalletConnect adapters + Reown) is now loaded **only** when the user actually opens an X402 payment dialog or the post-mount Solana wallet plugin runs.

## Verification

- `npx vue-tsc -b` ✅ clean
- `eslint src` ✅ clean
- `npm run build` ✅ — `dist/index.html` no longer lists `vendor-web3-*.js` in `<link rel=modulepreload>`. The new dynamic-only `index-*.js` chunk that contains the wallet adapters (~1.26 MB raw / ~387 KB-gz) is fetched lazily on demand.
- No public-API changes; X402 Solana payment, both `signAndSendTransaction` and the legacy `signTransaction` fallback, go through the same code paths.