### PR TITLE
feat(chat): render aichat2 entity cards (audio/video/image/file) inline

### DIFF
--- a/change/@acedatacloud-nexior-472964a8-2897-40ae-a906-60bfc4573b83.json
+++ b/change/@acedatacloud-nexior-472964a8-2897-40ae-a906-60bfc4573b83.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(chat): render aichat2 entity cards (audio/video/image/file) inline",
+  "packageName": "@acedatacloud/nexior",
+  "email": "cqc@cuiqingcai.com",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/EntityCard.vue
+++ b/src/components/chat/EntityCard.vue
@@ -1,0 +1,249 @@
+<template>
+  <div class="entity-card" :class="`entity-card--${cardType}`">
+    <!-- Audio -->
+    <div v-if="cardType === 'audio'" class="audio-card">
+      <div v-if="card.thumbnail" class="thumb">
+        <img :src="card.thumbnail" :alt="card.title || ''" />
+      </div>
+      <div class="meta">
+        <div v-if="card.title" class="title" :title="card.title">{{ card.title }}</div>
+        <div v-if="card.duration" class="sub">{{ formattedDuration }}</div>
+        <audio class="player" controls preload="metadata" :src="card.url" />
+        <div class="actions">
+          <a class="download" :href="card.url" target="_blank" rel="noopener noreferrer">
+            <font-awesome-icon icon="fa-solid fa-arrow-down" />
+            {{ $t('common.button.download') }}
+          </a>
+        </div>
+      </div>
+    </div>
+
+    <!-- Video -->
+    <div v-else-if="cardType === 'video'" class="video-card">
+      <video class="player" controls preload="metadata" :src="card.url" :poster="card.thumbnail || undefined" />
+      <div v-if="card.title || card.duration" class="meta">
+        <span v-if="card.title" class="title" :title="card.title">{{ card.title }}</span>
+        <span v-if="card.duration" class="sub">{{ formattedDuration }}</span>
+      </div>
+    </div>
+
+    <!-- Image -->
+    <div v-else-if="cardType === 'image'" class="image-card">
+      <el-image
+        :src="card.url"
+        :alt="card.alt || card.title || ''"
+        fit="contain"
+        class="image"
+        :preview-src-list="[card.url]"
+        :initial-index="0"
+        :hide-on-click-modal="true"
+      />
+      <div v-if="card.title" class="title" :title="card.title">{{ card.title }}</div>
+    </div>
+
+    <!-- File / fallback -->
+    <a
+      v-else
+      class="file-card"
+      :href="card.url"
+      target="_blank"
+      rel="noopener noreferrer"
+      :title="card.title || card.url"
+    >
+      <font-awesome-icon class="icon" :icon="fileIcon" />
+      <div class="info">
+        <div class="title">{{ card.title || cleanFileName }}</div>
+        <div class="sub">{{ card.mimeType || hostname }}</div>
+      </div>
+      <font-awesome-icon class="open" icon="fa-solid fa-arrow-up-right-from-square" />
+    </a>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, type PropType } from 'vue';
+import { ElImage } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import type { IChatCard } from '@/models';
+
+export default defineComponent({
+  name: 'EntityCard',
+  components: { ElImage, FontAwesomeIcon },
+  props: {
+    card: {
+      type: Object as PropType<IChatCard>,
+      required: true
+    }
+  },
+  computed: {
+    /** Normalize the card type into one of the four primary renderers. */
+    cardType(): 'audio' | 'video' | 'image' | 'file' {
+      const t = (this.card.type || '').toLowerCase();
+      if (t === 'audio' || t === 'video' || t === 'image') return t;
+      if (this.card.mimeType?.startsWith('audio/')) return 'audio';
+      if (this.card.mimeType?.startsWith('video/')) return 'video';
+      if (this.card.mimeType?.startsWith('image/')) return 'image';
+      return 'file';
+    },
+    formattedDuration(): string {
+      const total = this.card.duration ?? 0;
+      if (!Number.isFinite(total) || total <= 0) return '';
+      const mm = Math.floor(total / 60);
+      const ss = Math.floor(total % 60)
+        .toString()
+        .padStart(2, '0');
+      return `${mm}:${ss}`;
+    },
+    cleanFileName(): string {
+      try {
+        const u = new URL(this.card.url);
+        const segs = u.pathname.split('/').filter(Boolean);
+        return decodeURIComponent(segs[segs.length - 1] || u.hostname);
+      } catch {
+        return this.card.url;
+      }
+    },
+    hostname(): string {
+      try {
+        return new URL(this.card.url).hostname;
+      } catch {
+        return '';
+      }
+    },
+    fileIcon(): string {
+      const mime = (this.card.mimeType || '').toLowerCase();
+      if (mime.includes('pdf')) return 'fa-solid fa-file-pdf';
+      if (mime.includes('word') || mime.includes('msword')) return 'fa-solid fa-file-word';
+      if (mime.includes('sheet') || mime.includes('excel') || mime.includes('csv')) return 'fa-solid fa-file-excel';
+      if (mime.includes('zip') || mime.includes('compressed')) return 'fa-solid fa-file-zipper';
+      if (mime.startsWith('text/')) return 'fa-solid fa-file-lines';
+      return 'fa-solid fa-file';
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.entity-card {
+  margin: 8px 0;
+  max-width: 480px;
+
+  .title {
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .sub {
+    font-size: 12px;
+    color: var(--el-text-color-secondary);
+  }
+}
+
+.audio-card {
+  display: flex;
+  gap: 12px;
+  padding: 12px;
+  border: 1px solid var(--el-border-color-light);
+  border-radius: 12px;
+  background: var(--el-fill-color-light);
+
+  .thumb img {
+    width: 56px;
+    height: 56px;
+    border-radius: 8px;
+    object-fit: cover;
+    display: block;
+  }
+  .meta {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .player {
+    width: 100%;
+    height: 36px;
+    margin-top: 4px;
+  }
+  .actions {
+    display: flex;
+    gap: 8px;
+    font-size: 12px;
+    margin-top: 2px;
+  }
+  .download {
+    color: var(--el-color-primary);
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+  }
+  .download:hover {
+    text-decoration: underline;
+  }
+}
+
+.video-card {
+  border: 1px solid var(--el-border-color-light);
+  border-radius: 12px;
+  overflow: hidden;
+  background: #000;
+
+  .player {
+    width: 100%;
+    max-height: 360px;
+    display: block;
+    background: #000;
+  }
+  .meta {
+    padding: 8px 12px;
+    background: var(--el-fill-color-light);
+    color: var(--el-text-color-primary);
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 8px;
+  }
+}
+
+.image-card {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+
+  .image {
+    max-width: 100%;
+    max-height: 400px;
+    border-radius: 8px;
+  }
+}
+
+.file-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--el-border-color-light);
+  border-radius: 10px;
+  background: var(--el-fill-color-light);
+  text-decoration: none;
+  color: inherit;
+
+  .icon {
+    font-size: 24px;
+    color: var(--el-color-primary);
+  }
+  .info {
+    flex: 1;
+    min-width: 0;
+  }
+  .open {
+    color: var(--el-text-color-secondary);
+  }
+}
+.file-card:hover {
+  background: var(--el-fill-color);
+}
+</style>

--- a/src/components/chat/Message.vue
+++ b/src/components/chat/Message.vue
@@ -48,6 +48,7 @@
                 <pre v-else class="whitespace-pre-wrap break-words w-fit max-w-full py-1">{{ item.text?.trim() }}</pre>
               </div>
               <tool-activity v-if="item.type === 'tool_use'" :item="item" />
+              <entity-card v-if="item.type === 'card' && item.card" :card="item.card" />
             </div>
           </div>
         </div>
@@ -131,6 +132,7 @@ import RestartToGenerate from './RestartToGenerate.vue';
 import EditMessage from './EditMessage.vue';
 import FilePreview from '@/components/common/FilePreview.vue';
 import ToolActivity from './ToolActivity.vue';
+import EntityCard from './EntityCard.vue';
 import {
   ERROR_CODE_API_ERROR,
   ERROR_CODE_BAD_REQUEST,
@@ -163,6 +165,7 @@ export default defineComponent({
     MarkdownRenderer,
     FilePreview,
     ToolActivity,
+    EntityCard,
     ElButton,
     ElImage,
     ElInput,

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -98,6 +98,12 @@ export interface IChatMessageContentItem {
   is_error?: boolean;
   duration_ms?: number;
   status?: 'running' | 'done';
+  // Rich-output entity card (type='card') — payload mirrors the
+  // worker's `CardData` SSE event. `type` inside `card` is open-ended:
+  // 'audio' | 'video' | 'image' | 'file' today, with room for future
+  // entity types (e.g. 'task', 'location', 'code-canvas') that the
+  // EntityCard component can dispatch on without changing this shape.
+  card?: IChatCard;
 }
 
 export interface IChatMessage {
@@ -162,6 +168,8 @@ export interface IChatConversationResponse {
     mimeType: string;
     size?: number;
   };
+  // Rich-output entity card (`type === 'card'`). See `IChatCard` below.
+  card?: IChatCard;
 }
 
 export interface IChatConversationsResponse {
@@ -186,6 +194,26 @@ export interface IChatArtifact {
   url: string;
   name: string;
   mimeType: string;
+}
+
+/**
+ * Rich-output entity card emitted by aichat2 whenever the assistant
+ * surfaces a media artifact (audio / video / image / file). The
+ * worker streams `card` SSE events while parsing `<acard>` tags out of
+ * the LLM text deltas, and persists the same payload as a
+ * `{ type: 'card', card: IChatCard }` content block on the assistant
+ * message. `type` is intentionally open-ended so future entity types
+ * (e.g. 'task', 'location', 'code-canvas') only need a renderer on the
+ * frontend — protocol shape stays the same.
+ */
+export interface IChatCard {
+  type: string;
+  url: string;
+  title?: string;
+  thumbnail?: string;
+  duration?: number;
+  mimeType?: string;
+  alt?: string;
 }
 
 export interface IChatToolCall {

--- a/src/operators/chat.ts
+++ b/src/operators/chat.ts
@@ -101,7 +101,8 @@ class ChatOperator {
                     is_error: json.is_error,
                     duration_ms: json.duration_ms,
                     content: json.content,
-                    artifact: json.artifact
+                    artifact: json.artifact,
+                    card: json.card
                   });
                 }
               } catch (err) {

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -485,6 +485,14 @@ export default defineComponent({
       const contentParts: IChatMessageContentItem[] = [];
       const toolMap = new Map<string, IChatMessageContentItem>();
       let currentText = '';
+      // The aichat2 operator emits `response.answer` as the full
+      // accumulated text since the start of the turn. Whenever we flush
+      // currentText as its own content block (because a tool_use or a
+      // card arrives mid-stream and has to land between text segments),
+      // bump this offset so the next text_delta only contains the
+      // *remaining* text instead of duplicating everything we already
+      // pushed.
+      let answerOffset = 0;
 
       chatOperator
         .chatConversation(
@@ -507,6 +515,7 @@ export default defineComponent({
                 if (currentText) {
                   contentParts.push({ type: 'text', text: currentText });
                   currentText = '';
+                  answerOffset = response.answer?.length ?? 0;
                 }
                 const toolItem: IChatMessageContentItem = {
                   type: 'tool_use',
@@ -542,8 +551,20 @@ export default defineComponent({
                     mimeType: response.artifact.mimeType
                   });
                 }
+              } else if (response.type === 'card' && response.card) {
+                // Rich-output entity card from the worker's <acard> stream
+                // parser. Flush any text we'd accumulated up to this
+                // point as its own block first so the card lands at the
+                // right position in the message; this mirrors how
+                // tool_use blocks bracket the text stream.
+                if (currentText) {
+                  contentParts.push({ type: 'text', text: currentText });
+                  currentText = '';
+                  answerOffset = response.answer?.length ?? 0;
+                }
+                contentParts.push({ type: 'card', card: response.card });
               } else if (response.delta_answer) {
-                currentText = response.answer;
+                currentText = (response.answer || '').slice(answerOffset);
               }
 
               // Build display content: parts + trailing text


### PR DESCRIPTION
Renders the rich-output entity cards introduced in [PlatformService #809](https://github.com/AceDataCloud/PlatformService/pull/809) inline inside chat messages, replacing the flat URL-only behaviour for media artifacts produced by aichat2 (Suno songs, Luma videos, generated images, downloadable files, …).

## What lands in the UI

When the worker emits a \`card\` SSE event (parsed from the assistant's \`<acard>\` tags) or persists a \`{ type: 'card', card }\` content block on a message, the new \`EntityCard\` component dispatches on \`card.type\` and renders:

| type | render |
|---|---|
| \`audio\` | inline \`<audio controls>\` player + thumbnail + title + duration + download link |
| \`video\` | inline \`<video controls>\` with poster (thumbnail) and optional title/duration |
| \`image\` | preview-friendly \`el-image\` (zoomable on click) |
| \`file\` | file-card affordance with mime-aware icon + hostname |

\`card.type\` is open-ended, so future entity types (\`task\`, \`location\`, \`code-canvas\`) only need a renderer here — protocol shape stays the same.

## Wiring

- **\`models/chat.ts\`** — add \`IChatCard\`, extend \`IChatMessageContentItem\` with the optional \`card\` payload, extend \`IChatConversationResponse\` so the SSE event field flows through.
- **\`operators/chat.ts\`** — forward \`json.card\` on the streaming callback.
- **\`pages/chat/Conversation.vue\`** — handle \`response.type === 'card'\` by flushing the in-flight text segment as its own block, pushing a \`{ type: 'card', card }\` block, and continuing. Tracks an \`answerOffset\` cursor so subsequent text deltas only contribute the *remaining* prose instead of re-pushing already-flushed text. Same treatment is applied to the existing \`tool_use_start\` branch so cards and tools share the same flush model.
- **\`components/chat/Message.vue\`** — render each card item via the new \`EntityCard\` component when iterating \`message.content\` blocks.

## Backwards compat

- Old \`image_url\` / \`file_url\` / \`tool_use\` rendering paths are untouched.
- If the worker emits no \`card\` events (older deployments), the UI behaves exactly as before.
- If an assistant message persists with a \`card\` block, reload re-renders the player identically — no extra parsing on the client.

## Verification

- \`vue-tsc -b && vite build\` clean.
- \`eslint src/components/chat/EntityCard.vue src/components/chat/Message.vue src/pages/chat/Conversation.vue src/operators/chat.ts src/models/chat.ts\` clean.

## Follow-up

Depends on [PlatformService #809](https://github.com/AceDataCloud/PlatformService/pull/809). Until that lands, this PR is silently a no-op — the worker simply won't emit \`card\` events.