### PR TITLE
perf(load): drop vendor-element-plus chunk rule, route-split components (-156 KB gz)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,16 @@ const vendorChunkRules: Array<[chunkName: string, matches: (normalizedId: string
   // visit a payment page. Letting Rollup pick natural chunk boundaries keeps
   // Web3 code split across small chunks that are only fetched lazily by
   // `utils/x402/solana.ts` and `plugins/solana-wallets.ts`.
-  ['vendor-element-plus', (id) => id.includes('/element-plus/')],
+  //
+  // Same rationale applies to `element-plus`: although every consumer in `src`
+  // uses selective `import { ElButton } from 'element-plus'` (so tree-shaking
+  // is already at work), forcing all retained components into a single shared
+  // chunk lumps ~115 component subtrees (570 KB / 180 KB-gz) onto the entry's
+  // static graph, because dozens of routes statically import from it. Letting
+  // Rollup do the splitting naturally keeps each component family in a small
+  // chunk co-located with its consumer route. The eager critical path then
+  // only carries the few components that App.vue / Layouts / `vLoading`
+  // actually need (ElConfigProvider, ElTag, ElIcon, ElDialog/Overlay/…).
   ['vendor-vue-router', (id) => id.includes('/vue-router/')],
   ['vendor-vue', (id) => id.includes('/node_modules/vue/') || id.includes('/node_modules/@vue/')],
   ['vendor-codemirror', (id) => id.includes('/codemirror/') || id.includes('/@codemirror/')],


### PR DESCRIPTION
Round 3 of the Nexior initial-load cleanup, on top of #518 (merged). Independent of #520 (still open).

## Why selective imports weren't enough

Every consumer in `src` already uses selective imports — e.g. `import { ElButton } from 'element-plus'` — so tree-shaking is already at work. The retained set is **55 user-imported components** + **~60 internal subtrees** that tree-shaking *cannot* drop (`ElPopperContent`, `ElDialogContent`, `ElCollection`, `ElDropdownCollection`, `ElPaginationPager`, …): 115 components total.

The pre-existing manualChunks rule

```ts
['vendor-element-plus', (id) => id.includes('/element-plus/')]
```

bundled all 115 of them into a single shared 570 KB / **~180 KB-gz** chunk. And because dozens of routes statically import from `element-plus`, Rollup placed that chunk in the **entry's static graph**, which made the browser `<link rel=modulepreload>` it on first paint — even though most of it is only used by lazy routes.

> Selective imports = **tree-shaking** ≠ **lazy loading**. Tree-shaking decides *what* ends up in the bundle. Manual chunking decides *which* bundle. Forcing them all into one shared bundle defeats route-level lazy loading.

## What this PR does

Drops the `vendor-element-plus` rule from `vite.config.ts` and lets Rollup do natural splitting. Each `element-plus` component family ends up in a small chunk co-located with its consumer route. The eager critical path only carries what App.vue / Layouts / `vLoading` actually need:

| component | source |
|---|---|
| `ElConfigProvider`, `ElTag` | `App.vue` |
| `ElIcon` | used across eager paths |
| `ElDialog`, `ElDialogContent`, `ElFocusTrap`, `ElOverlay` | transitively from an eager `ElDialog` consumer |
| `ElLoading`, `ElLoadingChild` | `vLoading` directive in `main.ts` |

That's **9 components** in the entry chunk vs the previous 115. The other ~100 component chunks (DatePicker, Pagination, Menu, Tabs, Cascader, ColorPicker, Tree, Transfer, Upload, Form, Steps, Table, Image, Carousel, Slider, …) are now fetched lazily by the routes that use them.

## Result

Critical-path JS+CSS preloaded by the entry HTML (gzipped), measured against `main` post-#518:

| | before (`main`) | after (this PR) |
|---|---:|---:|
| Entry JS chunk | 206 KB | 231 KB *(+25 from 9 EP components)* |
| `vendor-element-plus` (preloaded) | **180 KB** | **— gone —** |
| Other vendor chunks + entry CSS | ~117 KB | ~116 KB |
| **Total** | **~503 KB** | **~347 KB** |

Net **~156 KB-gz removed** from initial download.

Stacks cleanly with #520 (psl + lazy fingerprintjs). Combined with #518 + #520, the cumulative reduction vs. `main` before #518 is **~870 KB-gz**.

## Verification

- `npx vue-tsc -b` ✅
- `eslint src` ✅
- `npm run build` ✅ — `vendor-element-plus-*.js` no longer appears in `dist/index.html` modulepreload list. Lazy routes that use heavier EP components (DatePicker, Pagination, Tabs, …) get their own per-route chunks containing just the EP code they need.