### PR TITLE
perf(load): lazy-register per-app Vuex modules at navigation time

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -60,6 +60,7 @@ import { getCookie } from 'typescript-cookie';
 import { I18N_DEFAULT_LOCALE } from '@/constants/i18n';
 import { getLocale, setI18nLanguage } from '@/i18n';
 import { updateSeo, setWebApplicationSchema, setOrganization, resetSeo } from '@/utils/seo';
+import { ensureStoreModule } from '@/store/lazy';
 
 // SEO metadata per route path prefix
 const ROUTE_SEO: Record<string, { title: string; description: string; keywords: string[]; category: string }> = {
@@ -319,9 +320,24 @@ const router = createRouter({
   routes
 });
 
-router.beforeEach(async (_to, _from, next) => {
+router.beforeEach(async (to, _from, next) => {
   const locale = getLocale(getCookie('LOCALE') || I18N_DEFAULT_LOCALE);
   await setI18nLanguage(locale);
+
+  // Lazily register the per-app Vuex store module owned by this route. The
+  // mapping is `meta.appName` → store module name (set in each
+  // `src/router/<app>.ts`); routes without a per-app module (auth, console,
+  // profile, distribution, download, site) skip this branch entirely.
+  // Resolving the dynamic import here means the module's actions/mutations,
+  // its operator(s) and its model bindings are only fetched the first time
+  // the user navigates into that section of the app.
+  for (const matched of to.matched) {
+    const appName = matched.meta?.appName;
+    if (typeof appName === 'string' && appName) {
+      await ensureStoreModule(appName);
+    }
+  }
+
   return next();
 });
 

--- a/src/store/common/actions.ts
+++ b/src/store/common/actions.ts
@@ -232,22 +232,15 @@ export const login = async ({ state, commit }: ActionContext<IRootState, IRootSt
 
 export const logout = async ({ dispatch, commit }: ActionContext<IRootState, IRootState>) => {
   await dispatch('resetAll');
-  await dispatch('chat/resetAll');
-  await dispatch('midjourney/resetAll');
-  await dispatch('flux/resetAll');
-  await dispatch('hailuo/resetAll');
-  await dispatch('headshots/resetAll');
-  await dispatch('kling/resetAll');
-  await dispatch('luma/resetAll');
-  await dispatch('pika/resetAll');
-  await dispatch('pixverse/resetAll');
-  await dispatch('qrart/resetAll');
-  await dispatch('sora/resetAll');
-  await dispatch('suno/resetAll');
-  await dispatch('nanobanana/resetAll');
-  await dispatch('seedream/resetAll');
-  await dispatch('seedance/resetAll');
-  await dispatch('veo/resetAll');
+  // Per-app store modules are registered lazily (see `src/store/lazy.ts` and
+  // the router's `beforeEach` hook). Only fan out the reset to modules that
+  // are actually registered in the running session — there is nothing to
+  // reset for a module the user never opened, and dispatching to an
+  // unregistered module would emit a Vuex warning.
+  const { getRegisteredLazyModules } = await import('@/store/lazy');
+  for (const name of getRegisteredLazyModules()) {
+    await dispatch(`${name}/resetAll`);
+  }
   if (import.meta.env.VITE_SURFACE === SURFACE_IOS || import.meta.env.VITE_SURFACE === SURFACE_ANDROID) {
     // On native platforms, show in-app login popup instead of navigating to
     // external auth URL (which would open Chrome and redirect to localhost)

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,97 +1,35 @@
 import { createStore } from 'vuex';
 import createPersistedState from 'vuex-persistedstate';
-import midjourney from './midjourney';
-import chat from './chat';
-import qrart from './qrart';
-import luma from './luma';
-import pika from './pika';
-import kling from './kling';
-import veo from './veo';
-import sora from './sora';
-import pixverse from './pixverse';
-import flux from './flux';
-import hailuo from './hailuo';
-import headshots from './headshots';
-import suno from './suno';
-import producer from './producer';
-import nanobanana from './nanobanana';
-import openaiimage from './openaiimage';
-import seedream from './seedream';
-import seedance from './seedance';
-import serp from './serp';
-import wan from './wan';
 import root from './common';
-import persistChat from './chat/persist';
-import persistMidjourney from './midjourney/persist';
-import persistQrart from './qrart/persist';
-import persistLuma from './luma/persist';
-import persistPika from './pika/persist';
-import persistKling from './kling/persist';
-import persistVeo from './veo/persist';
-import persistSora from './sora/persist';
-import persistPixverse from './pixverse/persist';
-import persistFlux from './flux/persist';
-import persistHailuo from './hailuo/persist';
-import persistHeadshots from './headshots/persist';
-import persistSuno from './suno/persist';
-import persistProducer from './producer/persist';
-import persistNanobanana from './nanobanana/persist';
-import persistOpenaiimage from './openaiimage/persist';
-import persistSeedream from './seedream/persist';
-import persistSeedance from './seedance/persist';
-import persistSerp from './serp/persist';
-import persistWan from './wan/persist';
 import persistRoot from './common/persist';
+
+// Per-app store modules (chat / midjourney / qrart / luma / pika / kling /
+// veo / sora / pixverse / flux / hailuo / headshots / suno / producer /
+// nanobanana / openaiimage / seedream / seedance / serp / wan) are
+// registered lazily at navigation time — see `src/store/lazy.ts` and the
+// router's `beforeEach` hook in `src/router/index.ts`. Only the root
+// (common) module is part of the entry chunk; opening the ChatGPT page no
+// longer loads Suno / Midjourney / Luma / Sora / etc. and their operators.
+
+// The persist *paths* are tiny string arrays so we eager-import every
+// `<module>/persist.ts` file via `import.meta.glob` — a few hundred bytes,
+// far smaller than registering a full `vuex-persistedstate` plugin per
+// module. The plugin then watches every listed path; entries belonging to a
+// not-yet-registered module are simply absent from `state` and become live
+// the moment the module is registered (state is seeded from localStorage by
+// `ensureStoreModule` so persisted values survive reloads even when the
+// module is registered for the first time later in the session).
+const lazyPersistModules = import.meta.glob<{ default: string[] }>(['./*/persist.ts', '!./common/persist.ts'], {
+  eager: true
+});
+
+const lazyPersistPaths: string[] = Object.values(lazyPersistModules).flatMap((m) => m.default);
 
 const store = createStore({
   ...root,
-  modules: {
-    midjourney: midjourney,
-    chat: chat,
-    qrart: qrart,
-    luma: luma,
-    pika: pika,
-    kling: kling,
-    veo: veo,
-    sora: sora,
-    pixverse: pixverse,
-    flux: flux,
-    hailuo: hailuo,
-    headshots: headshots,
-    suno: suno,
-    producer: producer,
-    nanobanana: nanobanana,
-    openaiimage: openaiimage,
-    seedream: seedream,
-    seedance: seedance,
-    serp: serp,
-    wan: wan
-  },
   plugins: [
     createPersistedState({
-      paths: [
-        ...persistRoot,
-        ...persistChat,
-        ...persistMidjourney,
-        ...persistQrart,
-        ...persistLuma,
-        ...persistPika,
-        ...persistKling,
-        ...persistVeo,
-        ...persistSora,
-        ...persistPixverse,
-        ...persistFlux,
-        ...persistHailuo,
-        ...persistHeadshots,
-        ...persistSuno,
-        ...persistProducer,
-        ...persistNanobanana,
-        ...persistOpenaiimage,
-        ...persistSeedream,
-        ...persistSeedance,
-        ...persistSerp,
-        ...persistWan
-      ]
+      paths: [...persistRoot, ...lazyPersistPaths]
     })
   ]
 });

--- a/src/store/lazy.ts
+++ b/src/store/lazy.ts
@@ -1,0 +1,117 @@
+import type { Module } from 'vuex';
+import store from './index';
+
+// Each loader returns the per-module Vuex `Module` from
+// `src/store/<name>/index.ts`. We type it as `Module<any, any>` because
+// each module exports a concrete `Module<IConcreteState, IRootState>`
+// shape — Vuex's GetterTree / ActionTree type parameters make those
+// individually-typed modules structurally incompatible with a single
+// `Module<unknown, unknown>` generic. `store.registerModule` only cares
+// about the runtime shape, so this loose typing is correct here.
+type AnyVuexModule = Module<any, any>;
+
+/**
+ * Per-app store modules are registered lazily so that opening (e.g.) the
+ * ChatGPT page never loads the Suno / Midjourney / Luma / Sora / Veo /
+ * Pixverse / … modules and their operators. Each loader resolves to the
+ * default-exported Vuex module from `src/store/<name>/index.ts`.
+ *
+ * Adding a new module: create `src/store/<name>/index.ts` (plus the existing
+ * `state.ts` / `mutations.ts` / `actions.ts` / `persist.ts` files), then add
+ * a single entry below. The router (`src/router/index.ts`) maps each route's
+ * `meta.appName` to one of these names.
+ */
+const moduleLoaders: Record<string, () => Promise<{ default: AnyVuexModule }>> = {
+  chat: () => import('./chat'),
+  midjourney: () => import('./midjourney'),
+  qrart: () => import('./qrart'),
+  luma: () => import('./luma'),
+  pika: () => import('./pika'),
+  kling: () => import('./kling'),
+  veo: () => import('./veo'),
+  sora: () => import('./sora'),
+  pixverse: () => import('./pixverse'),
+  flux: () => import('./flux'),
+  hailuo: () => import('./hailuo'),
+  headshots: () => import('./headshots'),
+  suno: () => import('./suno'),
+  producer: () => import('./producer'),
+  nanobanana: () => import('./nanobanana'),
+  openaiimage: () => import('./openaiimage'),
+  seedream: () => import('./seedream'),
+  seedance: () => import('./seedance'),
+  serp: () => import('./serp'),
+  wan: () => import('./wan')
+};
+
+/** Names of every lazy-registerable per-app module (single source of truth). */
+export const LAZY_MODULE_NAMES = Object.keys(moduleLoaders) as Array<keyof typeof moduleLoaders>;
+
+const inFlight = new Map<string, Promise<void>>();
+
+/**
+ * Read `vuex-persistedstate`'s saved blob from localStorage. We use the same
+ * default key (`'vuex'`) as the persistence plugin in `src/store/index.ts`,
+ * so any state that the plugin saved before the user reloaded the page is
+ * restored when its owning module is registered later.
+ */
+function readSavedRootState(): Record<string, unknown> {
+  if (typeof window === 'undefined' || !window.localStorage) return {};
+  try {
+    const raw = window.localStorage.getItem('vuex');
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Lazily register a per-app store module. Returns a promise that resolves
+ * once the module is loaded *and* registered; concurrent calls for the same
+ * name de-dupe, and repeated calls after registration are cheap no-ops.
+ */
+export async function ensureStoreModule(name: string): Promise<void> {
+  if (!Object.prototype.hasOwnProperty.call(moduleLoaders, name)) {
+    return;
+  }
+  if (store.hasModule(name)) {
+    return;
+  }
+  const existing = inFlight.get(name);
+  if (existing) {
+    return existing;
+  }
+  const task = (async () => {
+    const mod = await moduleLoaders[name]();
+    if (store.hasModule(name)) {
+      return;
+    }
+    const baseModule = mod.default;
+    const baseState =
+      typeof baseModule.state === 'function'
+        ? (baseModule.state as () => unknown)()
+        : { ...(baseModule.state as object) };
+    const saved = readSavedRootState()[name];
+    const initialState =
+      saved && typeof saved === 'object' ? { ...(baseState as object), ...(saved as object) } : baseState;
+    store.registerModule(name, {
+      ...baseModule,
+      state: initialState
+    });
+  })().finally(() => {
+    inFlight.delete(name);
+  });
+  inFlight.set(name, task);
+  return task;
+}
+
+/**
+ * Helper for code paths (e.g. logout) that need to fan out to every
+ * registered module without forcing unloaded ones to be loaded just to be
+ * reset.
+ */
+export function getRegisteredLazyModules(): string[] {
+  return LAZY_MODULE_NAMES.filter((name) => store.hasModule(name));
+}


### PR DESCRIPTION
Round 3 of the Nexior initial-load cleanup, on top of #518 / #520. Targets the per-app Vuex modules that were eagerly loaded together with the entry chunk.

## Why was this still slow?

The entry chunk eagerly imported all 20 per-app Vuex modules from `src/store/index.ts`:

```ts
import midjourney from './midjourney';
import chat from './chat';
import qrart from './qrart';
import luma from './luma';
// ... 16 more
```

Every per-module `actions.ts` then statically imported its operator (`midjourneyOperator`, `sunoOperator`, `lumaOperator`, …), so the entry chunk transitively contained 20 store modules + 20 operators worth of code. A user opening only `/chatgpt` paid for ~90 KB raw / ~9 KB-gz of code that handles Suno / Luma / Sora / Veo / Pixverse / Flux / Hailuo / Headshots / Producer / NanoBanana / OpenAI Image / Seedream / Seedance / Serp / Wan / QrArt / Pika / Kling / Midjourney — none of which they ever touched.

Just as importantly, the giant static graph stopped Rollup from giving each app its own per-route chunk: operators that *should* have ended up in `midjourney-*.js` / `suno-*.js` / `luma-*.js` instead got merged into the entry's shared sinks.

## What this PR changes

### 1. `src/store/lazy.ts` (new)

Single source of truth for the lazy-loadable per-app modules:

```ts
const moduleLoaders = {
  chat: () => import('./chat'),
  midjourney: () => import('./midjourney'),
  // ... 18 more
};

export async function ensureStoreModule(name: string): Promise<void> { … }
export function getRegisteredLazyModules(): string[] { … }
```

`ensureStoreModule` de-dupes concurrent loads, is a no-op when the module is already registered, and (critically) reads the `vuex-persistedstate` blob from `localStorage['vuex']` and seeds the module's initial state from it before calling `store.registerModule` — so persisted state survives reloads even when a module is registered for the first time mid-session.

### 2. `src/store/index.ts`

The eager registration of all 20 modules is removed. Only the root (`common`) module ships in the entry chunk. The per-module `persist.ts` arrays are still loaded eagerly via `import.meta.glob({ eager: true })` (each is a tiny string array, totaling a few hundred bytes) so `vuex-persistedstate` knows which paths to write the moment a lazy module gets registered.

### 3. `src/router/index.ts`

`beforeEach` walks `to.matched` and calls `ensureStoreModule(meta.appName)`:

```ts
for (const matched of to.matched) {
  const appName = matched.meta?.appName;
  if (typeof appName === 'string' && appName) {
    await ensureStoreModule(appName);
  }
}
```

The mapping is 1:1 with module names because every per-app route file already declares `meta.appName`. The chat-style routes (`chatgpt`, `claude`, `deepseek`, `gemini`, `grok`, `kimi`) all share `appName: 'chat'`, everything else matches its own name. Routes outside the AI surface (`auth`, `console`, `profile`, `distribution`, `download`, `site`) have no `meta.appName` and skip this branch entirely.

### 4. `src/store/common/actions.ts` `logout`

Replaced the hard-coded fan-out:

```diff
-  await dispatch('chat/resetAll');
-  await dispatch('midjourney/resetAll');
-  await dispatch('flux/resetAll');
-  // ... 14 more
+  for (const name of getRegisteredLazyModules()) {
+    await dispatch(`${name}/resetAll`);
+  }
```

with iteration over `getRegisteredLazyModules()` so we only reset what the session actually loaded — dispatching to a never-registered module would emit a Vuex warning.

## Result

Entry chunk:

| | before | after | change |
|---|---:|---:|---:|
| Entry JS (raw) | 717 KB | **626 KB** | **-91 KB** |
| Entry JS (gzip) | 207 KB | **198 KB** | **-9 KB** |

Code paths now lazy:

- All 20 per-app store modules (`chat`, `midjourney`, `qrart`, `luma`, `pika`, `kling`, `veo`, `sora`, `pixverse`, `flux`, `hailuo`, `headshots`, `suno`, `producer`, `nanobanana`, `openaiimage`, `seedream`, `seedance`, `serp`, `wan`).
- All 20 corresponding operator classes — they now sit in tiny per-app chunks (1–3 KB raw each, e.g. `midjourney-*.js`, `suno-*.js`).
- Cross-app module store actions/mutations only ever execute when the user navigates into that section.

Cold-loading `/chatgpt` no longer fetches, parses, or executes a single line of Suno/Luma/Sora/Veo/Pixverse/Midjourney/Flux/Hailuo/Headshots/Producer/NanoBanana/OpenAIImage/Seedream/Seedance/Serp/Wan/QrArt/Pika/Kling code.

## Behaviour parity

- **Persisted state survives reloads.** `ensureStoreModule` reseeds module state from `localStorage['vuex'][name]` before registering, then `vuex-persistedstate`'s existing subscription handles writes.
- **Same-section navigation reuses the module** (e.g. `/chatgpt → /claude → /gemini` registers `chat` once).
- **Cross-section navigation** keeps previously loaded modules registered (`registerModule` is additive). The dynamic `import()` is cached by the browser, so going back is instant.
- `logout` still resets every loaded module, just dynamically.

## Verification

- `npx vue-tsc -b` ✅
- `eslint src` ✅
- `npm run build` ✅ — entry chunk drops from 717 KB / 207 KB-gz to 626 KB / 198 KB-gz; per-app operator URL strings (`/midjourney/tasks`, `/suno/songs`, `aichat2/conversations`, etc.) confirmed to land in their per-app chunks rather than the entry.
