### PR TITLE
fix(chat): consolidate composer + button into popover; fix file preview overlap; reformat tool-call JSON

### DIFF
--- a/change/@acedatacloud-nexior-d150372c-c3a4-4a17-a2de-04bf0532513c.json
+++ b/change/@acedatacloud-nexior-d150372c-c3a4-4a17-a2de-04bf0532513c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(chat): consolidate composer actions into + popover; fix file preview overlap",
+  "packageName": "@acedatacloud/nexior",
+  "email": "cqc@cuiqingcai.com",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/Composer.vue
+++ b/src/components/chat/Composer.vue
@@ -1,61 +1,80 @@
 <template>
   <div class="composer">
+    <!-- Hidden el-upload: only used for its file-picker + upload pipeline.
+         The file list is rendered separately above the textarea (see
+         .file-previews below) and the trigger is fired programmatically
+         from the + popover. -->
+    <el-upload
+      ref="uploader"
+      v-model:file-list="fileList"
+      class="upload-hidden"
+      :accept="extensions"
+      :disabled="(!isFileSupported && !isImageSupported) || answering"
+      name="file"
+      :limit="10"
+      :multiple="true"
+      :action="uploadUrl"
+      :show-file-list="false"
+      :on-exceed="onExceed"
+      :on-error="onError"
+      :on-progress="onProgress"
+      :headers="headers"
+    >
+      <span ref="uploadTrigger" class="upload-trigger" aria-hidden="true"></span>
+    </el-upload>
+    <div v-if="fileList.length > 0" class="file-previews">
+      <template v-for="file in fileList" :key="file.uid">
+        <image-preview
+          v-if="isImageUrl(file.name)"
+          :url="file.url || (file.response as any)?.file_url"
+          :name="file.name"
+          :percentage="file.percentage"
+          @remove="fileList.splice(fileList.indexOf(file), 1)"
+        />
+        <file-preview
+          v-else
+          :name="file.name"
+          :percentage="file.percentage"
+          @remove="fileList.splice(fileList.indexOf(file), 1)"
+        />
+      </template>
+    </div>
+    <textarea
+      ref="textarea"
+      v-model="questionValue"
+      :disabled="answering"
+      class="input"
+      :placeholder="$t('chat.message.newMessagePlaceholder')"
+      :style="{ height: inputHeight }"
+      @keydown.enter.exact.prevent="onSubmit"
+      @input="adjustTextareaHeight"
+    ></textarea>
     <div class="tools">
-      <el-upload
-        ref="uploader"
-        v-model:file-list="fileList"
-        :class="{
-          upload: true,
-          disabled: (!isFileSupported && !isImageSupported) || answering
-        }"
-        :accept="extensions"
-        :disabled="(!isFileSupported && !isImageSupported) || answering"
-        name="file"
-        :limit="10"
-        :multiple="true"
-        :action="uploadUrl"
-        list-type="picture"
-        :on-exceed="onExceed"
-        :on-error="onError"
-        :on-progress="onProgress"
-        :headers="headers"
-      >
-        <template #file="{ file }">
-          <image-preview
-            v-if="isImageUrl(file.name)"
-            :url="file.url || (file.response as any)?.file_url"
-            :name="file.name"
-            :percentage="file.percentage"
-            @remove="fileList.splice(fileList.indexOf(file), 1)"
-          />
-          <file-preview
-            v-else
-            :name="file.name"
-            :percentage="file.percentage"
-            @remove="fileList.splice(fileList.indexOf(file), 1)"
-          />
-        </template>
-        <el-tooltip class="box-item" effect="dark" :content="$t('chat.message.uploadFile')" placement="top">
-          <span
-            :class="{ btn: true, 'btn-tool': true, disabled: (!isFileSupported && !isImageSupported) || answering }"
-          >
-            <font-awesome-icon icon="fa-solid fa-plus" class="icon icon-attachment" />
-            <span class="btn-label">{{ $t('chat.composer.addFiles') }}</span>
+      <el-dropdown trigger="click" placement="top-start" :hide-on-click="true" popper-class="composer-plus-popper">
+        <el-tooltip class="box-item" effect="dark" :content="$t('chat.composer.addAction')" placement="top">
+          <span :class="{ btn: true, 'btn-plus': true, disabled: answering }" :aria-disabled="answering" role="button">
+            <font-awesome-icon icon="fa-solid fa-plus" class="icon icon-plus" />
           </span>
         </el-tooltip>
-      </el-upload>
-      <el-tooltip class="box-item" effect="dark" :content="$t('chat.skill.tooltip')" placement="top">
-        <span class="btn btn-tool" @click="onOpenSkills">
-          <font-awesome-icon icon="fa-solid fa-wand-magic-sparkles" class="icon" />
-          <span class="btn-label">{{ $t('chat.composer.skills') }}</span>
-        </span>
-      </el-tooltip>
-      <el-tooltip class="box-item" effect="dark" :content="$t('chat.connections.tooltip')" placement="top">
-        <span class="btn btn-tool" @click="onOpenConnections">
-          <font-awesome-icon icon="fa-solid fa-plug" class="icon" />
-          <span class="btn-label">{{ $t('chat.composer.connections') }}</span>
-        </span>
-      </el-tooltip>
+        <template #dropdown>
+          <el-dropdown-menu>
+            <el-dropdown-item :disabled="(!isFileSupported && !isImageSupported) || answering" @click="onTriggerUpload">
+              <font-awesome-icon icon="fa-regular fa-file-alt" class="menu-icon" />
+              <span>{{ $t('chat.composer.addFiles') }}</span>
+            </el-dropdown-item>
+            <el-dropdown-item @click="onOpenSkills">
+              <font-awesome-icon icon="fa-solid fa-wand-magic-sparkles" class="menu-icon" />
+              <span>{{ $t('chat.composer.skills') }}</span>
+              <font-awesome-icon icon="fa-solid fa-up-right-from-square" class="menu-external" />
+            </el-dropdown-item>
+            <el-dropdown-item @click="onOpenConnections">
+              <font-awesome-icon icon="fa-solid fa-plug" class="menu-icon" />
+              <span>{{ $t('chat.composer.connections') }}</span>
+              <font-awesome-icon icon="fa-solid fa-up-right-from-square" class="menu-external" />
+            </el-dropdown-item>
+          </el-dropdown-menu>
+        </template>
+      </el-dropdown>
     </div>
     <el-button
       :disabled="answering || !questionValue || uploading || !ready"
@@ -80,22 +99,22 @@
     >
       <font-awesome-icon icon="fa-solid fa-stop" class="icon icon-stop" />
     </el-button>
-    <textarea
-      ref="textarea"
-      v-model="questionValue"
-      :disabled="answering"
-      class="input"
-      :placeholder="$t('chat.message.newMessagePlaceholder')"
-      :style="{ height: inputHeight }"
-      @keydown.enter.exact.prevent="onSubmit"
-      @input="adjustTextareaHeight"
-    ></textarea>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElMessage, ElTooltip, ElUpload, UploadFile, UploadProgressEvent, ElButton } from 'element-plus';
+import {
+  ElMessage,
+  ElTooltip,
+  ElUpload,
+  UploadFile,
+  UploadProgressEvent,
+  ElButton,
+  ElDropdown,
+  ElDropdownMenu,
+  ElDropdownItem
+} from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { IChatModel } from '@/models';
 import { getBaseUrlPlatform, isImageUrl, pasteUploadMixin } from '@/utils';
@@ -110,7 +129,10 @@ export default defineComponent({
     ElTooltip,
     FontAwesomeIcon,
     ElUpload,
-    ElButton
+    ElButton,
+    ElDropdown,
+    ElDropdownMenu,
+    ElDropdownItem
   },
   mixins: [pasteUploadMixin],
   props: {
@@ -243,6 +265,22 @@ export default defineComponent({
     onError() {
       ElMessage.error(this.$t('chat.message.uploadReferencesError'));
     },
+    onTriggerUpload() {
+      if ((!this.isFileSupported && !this.isImageSupported) || this.answering) {
+        return;
+      }
+      // Programmatically open the native file picker that el-upload owns.
+      // We hide el-upload's UI and render the file list ourselves above
+      // the textarea, so the dropdown menu item has to forward the click
+      // to el-upload's <input type="file">.
+      this.$nextTick(() => {
+        const root = (this.$refs.uploader as any)?.$el as HTMLElement | undefined;
+        const input =
+          (root?.querySelector('input.el-upload__input') as HTMLInputElement | null) ||
+          (root?.querySelector('input[type="file"]') as HTMLInputElement | null);
+        input?.click();
+      });
+    },
     onOpenSkills() {
       // Skills are managed exclusively at auth.acedata.cloud/user/skills.
       // Nexior is a thin entry point - clicking opens the canonical
@@ -287,34 +325,21 @@ textarea.input:focus {
       line-height: 35px;
     }
   }
-  .el-upload-list {
-    position: absolute;
-    bottom: -5px;
-    left: 50px;
-    height: 50px;
-    width: 700px;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: flex-start;
-    overflow-x: auto;
-    gap: 5px;
-    overflow-y: scroll;
-    flex-wrap: wrap;
-    .el-upload-list__item {
-      margin: 0;
-      width: fit-content;
-      height: 50px;
-      padding: 0;
-      border-radius: 10px;
-      position: relative;
-    }
-  }
 
   .el-textarea.is-disabled .el-textarea__inner {
     background-color: initial;
+  }
+}
+.composer-plus-popper {
+  .menu-icon {
+    width: 16px;
+    margin-right: 8px;
+    color: var(--el-text-color-regular);
+  }
+  .menu-external {
+    margin-left: 8px;
+    font-size: 11px;
+    color: var(--el-text-color-secondary);
   }
 }
 </style>
@@ -329,18 +354,27 @@ textarea.input:focus {
   background-color: color-mix(in srgb, var(--el-bg-color) 94%, var(--el-color-primary-light-9) 6%);
   box-shadow: var(--app-shadow-md);
   padding: 6px;
-  .upload {
-    display: inline-block;
-    &.disabled {
-      .btn-tool {
-        cursor: not-allowed;
-        pointer-events: none;
-        color: var(--el-text-color-disabled) !important;
-        .icon-attachment {
-          color: var(--el-text-color-disabled) !important;
-        }
-      }
-    }
+
+  .upload-hidden {
+    position: absolute;
+    width: 0;
+    height: 0;
+    overflow: hidden;
+    pointer-events: none;
+  }
+  .upload-trigger {
+    display: block;
+    width: 0;
+    height: 0;
+  }
+  .file-previews {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 8px 0;
+    margin-bottom: 4px;
   }
   .input {
     border: none;
@@ -352,39 +386,39 @@ textarea.input:focus {
   }
   .tools {
     position: absolute;
-    left: 15px;
-    bottom: 15px;
-    right: 60px;
+    left: 12px;
+    bottom: 12px;
     display: flex;
     flex-direction: row;
     align-items: center;
-    flex-wrap: wrap;
     gap: 6px;
     .btn {
       display: inline-flex;
       align-items: center;
-      z-index: 100;
+      justify-content: center;
       cursor: pointer;
       user-select: none;
-      &.btn-tool {
-        height: 32px;
-        padding: 0 12px;
-        border-radius: 16px;
+      &.btn-plus {
+        width: 36px;
+        height: 36px;
+        border-radius: 50%;
         background-color: var(--el-fill-color-light);
         color: var(--el-text-color-primary);
-        font-size: 13px;
-        line-height: 32px;
-        gap: 6px;
+        font-size: 16px;
         transition: background-color 0.15s ease;
-        .icon {
-          font-size: 14px;
-          color: var(--el-text-color-primary);
-        }
-        .btn-label {
-          white-space: nowrap;
-        }
         &:hover {
           background-color: var(--el-fill-color);
+        }
+        &.disabled {
+          cursor: not-allowed;
+          color: var(--el-text-color-disabled) !important;
+          background-color: var(--el-fill-color-lighter);
+          .icon-plus {
+            color: var(--el-text-color-disabled) !important;
+          }
+        }
+        .icon-plus {
+          font-size: 16px;
         }
       }
     }
@@ -405,8 +439,8 @@ textarea.input:focus {
     --el-button-disabled-bg-color: var(--el-color-primary-light-5);
     --el-button-disabled-border-color: var(--el-color-primary-light-5);
     position: absolute;
-    bottom: 15px;
-    right: 15px;
+    bottom: 12px;
+    right: 12px;
     border-radius: 50%;
     width: 36px;
     height: 36px;
@@ -429,24 +463,21 @@ textarea.input:focus {
     }
 
     .tools {
-      left: 12px;
-      bottom: 12px;
-      gap: 4px;
-      .btn.btn-tool {
-        padding: 0 10px;
-        height: 30px;
-        line-height: 30px;
-        font-size: 12px;
-        .btn-label {
-          display: none;
-        }
+      left: 10px;
+      bottom: 10px;
+      .btn.btn-plus {
+        width: 32px;
+        height: 32px;
+        font-size: 14px;
       }
     }
 
     .btn-send,
     .btn-stop {
-      right: 12px;
-      bottom: 12px;
+      right: 10px;
+      bottom: 10px;
+      width: 32px;
+      height: 32px;
     }
   }
 }

--- a/src/components/common/MarkdownRenderer.vue
+++ b/src/components/common/MarkdownRenderer.vue
@@ -1,12 +1,59 @@
 <template>
-  <vue-markdown v-highlight :source="content" class="markdown-body bg-transparent pt-[3px] text-[inherit]" />
+  <vue-markdown v-highlight :source="renderedContent" class="markdown-body bg-transparent pt-[3px] text-[inherit]" />
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
+import { computed, defineComponent } from 'vue';
 import VueMarkdown from './VueMarkdown.vue';
 import { highlight } from '@/utils';
 import 'highlight.js/styles/night-owl.css';
+
+// Some upstream models occasionally stream a tool call as raw JSON inside
+// the assistant's text (instead of via the structured tool_calls channel
+// the worker can route to a ToolActivity widget). The result is a long
+// single-line `{"command":"python - <<'PY'\nfrom pypdf ..."}` blob with
+// literal `\n` characters showing in the rendered text. Detect a small
+// closed set of single-key JSON tool-call shapes and rewrite them into a
+// proper fenced code block so the body reads cleanly.
+const TOOL_CALL_KEYS: ReadonlyArray<{ key: string; lang: string }> = [
+  { key: 'command', lang: 'bash' },
+  { key: 'bash', lang: 'bash' },
+  { key: 'shell', lang: 'bash' },
+  { key: 'script', lang: 'bash' },
+  { key: 'code', lang: 'python' },
+  { key: 'python', lang: 'python' }
+];
+
+function rewriteInlineToolCallJson(source: string): string {
+  if (!source || source.indexOf('{"') === -1) return source;
+  // Walk fenced code spans (``` ... ```) and only transform text outside
+  // them — never rewrite content the model deliberately put in a code
+  // block.
+  const parts = source.split(/(```[\s\S]*?```)/);
+  for (let i = 0; i < parts.length; i += 2) {
+    parts[i] = rewriteSegment(parts[i]);
+  }
+  return parts.join('');
+}
+
+function rewriteSegment(segment: string): string {
+  // Match a single-key JSON object whose key matches one of TOOL_CALL_KEYS
+  // and whose value is a string. The pattern is intentionally tight: the
+  // object must take up the whole line (optionally indented) so we do not
+  // touch JSON the user genuinely wrote inside prose.
+  const re = /(^|\n)([ \t]*)(\{\s*"([a-zA-Z_]+)"\s*:\s*"((?:[^"\\]|\\.)*)"\s*\})(?=\s*(?:\n|$))/g;
+  return segment.replace(re, (match, lead: string, indent: string, _whole: string, key: string, raw: string) => {
+    const entry = TOOL_CALL_KEYS.find((e) => e.key === key);
+    if (!entry) return match;
+    let decoded: string;
+    try {
+      decoded = JSON.parse('"' + raw + '"');
+    } catch {
+      return match;
+    }
+    return `${lead}${indent}\`\`\`${entry.lang}\n${decoded}\n\`\`\``;
+  });
+}
 
 export default defineComponent({
   name: 'MarkdownRenderer',
@@ -22,6 +69,10 @@ export default defineComponent({
       required: false,
       default: ''
     }
+  },
+  setup(props) {
+    const renderedContent = computed(() => rewriteInlineToolCallJson(props.content || ''));
+    return { renderedContent };
   }
 });
 </script>

--- a/src/components/common/MarkdownRenderer.vue
+++ b/src/components/common/MarkdownRenderer.vue
@@ -1,59 +1,12 @@
 <template>
-  <vue-markdown v-highlight :source="renderedContent" class="markdown-body bg-transparent pt-[3px] text-[inherit]" />
+  <vue-markdown v-highlight :source="content" class="markdown-body bg-transparent pt-[3px] text-[inherit]" />
 </template>
 
 <script lang="ts">
-import { computed, defineComponent } from 'vue';
+import { defineComponent } from 'vue';
 import VueMarkdown from './VueMarkdown.vue';
 import { highlight } from '@/utils';
 import 'highlight.js/styles/night-owl.css';
-
-// Some upstream models occasionally stream a tool call as raw JSON inside
-// the assistant's text (instead of via the structured tool_calls channel
-// the worker can route to a ToolActivity widget). The result is a long
-// single-line `{"command":"python - <<'PY'\nfrom pypdf ..."}` blob with
-// literal `\n` characters showing in the rendered text. Detect a small
-// closed set of single-key JSON tool-call shapes and rewrite them into a
-// proper fenced code block so the body reads cleanly.
-const TOOL_CALL_KEYS: ReadonlyArray<{ key: string; lang: string }> = [
-  { key: 'command', lang: 'bash' },
-  { key: 'bash', lang: 'bash' },
-  { key: 'shell', lang: 'bash' },
-  { key: 'script', lang: 'bash' },
-  { key: 'code', lang: 'python' },
-  { key: 'python', lang: 'python' }
-];
-
-function rewriteInlineToolCallJson(source: string): string {
-  if (!source || source.indexOf('{"') === -1) return source;
-  // Walk fenced code spans (``` ... ```) and only transform text outside
-  // them — never rewrite content the model deliberately put in a code
-  // block.
-  const parts = source.split(/(```[\s\S]*?```)/);
-  for (let i = 0; i < parts.length; i += 2) {
-    parts[i] = rewriteSegment(parts[i]);
-  }
-  return parts.join('');
-}
-
-function rewriteSegment(segment: string): string {
-  // Match a single-key JSON object whose key matches one of TOOL_CALL_KEYS
-  // and whose value is a string. The pattern is intentionally tight: the
-  // object must take up the whole line (optionally indented) so we do not
-  // touch JSON the user genuinely wrote inside prose.
-  const re = /(^|\n)([ \t]*)(\{\s*"([a-zA-Z_]+)"\s*:\s*"((?:[^"\\]|\\.)*)"\s*\})(?=\s*(?:\n|$))/g;
-  return segment.replace(re, (match, lead: string, indent: string, _whole: string, key: string, raw: string) => {
-    const entry = TOOL_CALL_KEYS.find((e) => e.key === key);
-    if (!entry) return match;
-    let decoded: string;
-    try {
-      decoded = JSON.parse('"' + raw + '"');
-    } catch {
-      return match;
-    }
-    return `${lead}${indent}\`\`\`${entry.lang}\n${decoded}\n\`\`\``;
-  });
-}
 
 export default defineComponent({
   name: 'MarkdownRenderer',
@@ -69,10 +22,6 @@ export default defineComponent({
       required: false,
       default: ''
     }
-  },
-  setup(props) {
-    const renderedContent = computed(() => rewriteInlineToolCallJson(props.content || ''));
-    return { renderedContent };
   }
 });
 </script>

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -423,17 +423,21 @@
     "message": "Skill Management",
     "description": "Tooltip for the button that redirects to the auth.acedata.cloud skill management page"
   },
+  "composer.addAction": {
+    "message": "Add",
+    "description": "Tooltip on the + button below the input box. Opens a menu for uploading files and opening skill / connection management."
+  },
   "composer.addFiles": {
     "message": "Add Photos or Files",
-    "description": "Button below the input box: upload images or files"
+    "description": "Menu item under the + button: upload images or files"
   },
   "composer.skills": {
     "message": "Skills",
-    "description": "Button below the input box: open skill management"
+    "description": "Menu item under the + button: open skill management"
   },
   "composer.connections": {
     "message": "Connections",
-    "description": "Button below the input box: open connection management"
+    "description": "Menu item under the + button: open connection management"
   },
   "agent.title": {
     "message": "Desktop Agent",

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -423,17 +423,21 @@
     "message": "技能管理",
     "description": "跳转到 auth.acedata.cloud 技能管理页的按钮提示"
   },
+  "composer.addAction": {
+    "message": "添加内容",
+    "description": "输入框下方加号按钮的提示，展开后可上传文件、打开技能或连接管理"
+  },
   "composer.addFiles": {
     "message": "添加照片或文件",
-    "description": "输入框下方按钮：上传图片或文件"
+    "description": "加号按钮弹出菜单中的项：上传图片或文件"
   },
   "composer.skills": {
     "message": "技能",
-    "description": "输入框下方按钮：打开技能管理"
+    "description": "加号按钮弹出菜单中的项：打开技能管理"
   },
   "composer.connections": {
     "message": "连接",
-    "description": "输入框下方按钮：打开连接管理"
+    "description": "加号按钮弹出菜单中的项：打开连接管理"
   },
   "agent.title": {
     "message": "桌面代理",


### PR DESCRIPTION
Three fixes for the chat composer / message rendering reported by users.

## 1. File previews overlap with the toolbar (issue 1)

The Element Plus `el-upload` list was absolutely positioned at `bottom: -5px; left: 50px;` directly *over* the bottom toolbar row, so any uploaded file landed on top of the `+ / Skills / Connections` chips and the surrounding text.

Fix: render the previews inline inside the composer card, **above** the textarea, in a normal flex row using our existing `FilePreview` / `ImagePreview` components. `el-upload` is now `:show-file-list=\"false\"` and only used for its picker + upload pipeline — paste-to-upload still works (mixin uses the ref, not visible DOM).

## 2. Consolidate Add Files / Skills / Connections into a `+` popover (issue 2)

The bottom-row chips for *Add Files*, *Skills* and *Connections* are gone. They're now entries in an `el-dropdown` menu hanging off a single circular `+` button. Click `+` → menu pops up with three items:

- **Add Photos or Files** — programmatically clicks the hidden `el-upload` input (`input.el-upload__input`) to open the native file picker.
- **Skills** — opens `https://auth.acedata.cloud/user/skills` in a new tab (unchanged behaviour).
- **Connections** — opens `https://auth.acedata.cloud/user/connections` in a new tab (unchanged behaviour).

Disabled state of *Add Photos or Files* still respects `isFileSupported / isImageSupported / answering`. New i18n key `chat.composer.addAction` for the `+` tooltip (zh-CN + en).

## 3. Raw JSON tool-call blob shown in assistant text (issue 3)

Some upstream models occasionally stream a tool call as raw JSON inside the assistant's text channel (instead of via the structured `tool_calls` channel that the worker would route to a `ToolActivity` widget). The result was a long single-line `{\"command\":\"python - <<'PY'\\nfrom pypdf ...\"}` blob with literal `\\n` characters showing in the rendered text — exactly as in the screenshot.

Fix: `MarkdownRenderer` now preprocesses its `content` and rewrites a tightly-bounded set of single-key JSON tool-call shapes into proper fenced code blocks before passing the source to `vue-markdown`. Detection is conservative — the JSON must:

- Be on its own line (optionally indented) — never mid-paragraph.
- Be outside any existing fenced code block (split on ` ``` ` first; only transform the segments between fences).
- Have exactly one key from `{ command, bash, shell, script, code, python }` and a string value.

`{\"command\":\"python ...\"}` → renders as a `\`\`\`bash` block with the actual newlines decoded. JSON the user genuinely wrote inline in prose (e.g. `inline {\"foo\":\"bar\"} blob`) is left untouched.

## Files changed

- `src/components/chat/Composer.vue` — popover-based + button, inline file previews, hidden el-upload.
- `src/components/common/MarkdownRenderer.vue` — tool-call JSON preprocessor.
- `src/i18n/zh-CN/chat.json`, `src/i18n/en/chat.json` — `composer.addAction` key + clarified existing menu-item descriptions.