### PR TITLE
feat(chat): graceful fallback for broken markdown images

### DIFF
--- a/src/components/common/MarkdownRenderer.vue
+++ b/src/components/common/MarkdownRenderer.vue
@@ -8,6 +8,33 @@ import VueMarkdown from './VueMarkdown.vue';
 import { highlight } from '@/utils';
 import 'highlight.js/styles/night-owl.css';
 
+// Install a single global capture-phase listener once. `error` events on <img>
+// don't bubble, so we use the capture phase to catch them. Markdown-rendered
+// images carry the `md-image` class — when one fails, mark its wrapper with
+// `md-image-error` so the styled fallback shows instead of the broken icon.
+const INSTALL_FLAG = '__nexiorMdImgErrorInstalled';
+type FlaggedWindow = Window & { [INSTALL_FLAG]?: boolean };
+
+const installImageErrorHandler = () => {
+  if (typeof window === 'undefined') return;
+  const w = window as FlaggedWindow;
+  if (w[INSTALL_FLAG]) return;
+  w[INSTALL_FLAG] = true;
+  window.addEventListener(
+    'error',
+    (event) => {
+      const target = event.target as HTMLElement | null;
+      if (!target || target.tagName !== 'IMG') return;
+      if (!target.classList.contains('md-image')) return;
+      const wrap = target.closest('.md-image-wrap');
+      wrap?.classList.add('md-image-error');
+    },
+    true
+  );
+};
+
+installImageErrorHandler();
+
 export default defineComponent({
   name: 'MarkdownRenderer',
   directives: {
@@ -28,6 +55,106 @@ export default defineComponent({
 
 <style lang="scss">
 @import 'github-markdown-css/github-markdown.css';
+
+// Graceful broken-image fallback for markdown-rendered <img> tags.
+// The default user-agent broken-image icon (small icon + alt text) looks bad,
+// especially in chat. Wrap each markdown image in `.md-image-wrap`; on `error`
+// (caught via the capture-phase listener installed above), the wrapper gets
+// `md-image-error`, which hides the <img> and reveals a styled fallback card.
+.markdown-body .md-image-wrap {
+  position: relative;
+  display: inline-block;
+  max-width: 100%;
+  vertical-align: middle;
+
+  > .md-image {
+    max-width: 100%;
+    height: auto;
+    border-radius: 8px;
+  }
+
+  > .md-image-fallback {
+    display: none;
+  }
+
+  &.md-image-error {
+    > .md-image {
+      display: none;
+    }
+
+    > .md-image-fallback {
+      display: inline-flex;
+      align-items: center;
+      gap: 12px;
+      padding: 14px 18px;
+      max-width: 100%;
+      min-width: min(280px, 100%);
+      border-radius: 12px;
+      border: 1px dashed rgba(148, 163, 184, 0.55);
+      background:
+        linear-gradient(135deg, rgba(248, 250, 252, 0.95) 0%, rgba(241, 245, 249, 0.95) 100%),
+        radial-gradient(circle at 100% 0%, rgba(196, 181, 253, 0.18) 0%, transparent 60%);
+      color: #475569;
+      font-size: 13px;
+      line-height: 1.45;
+      box-shadow: 0 1px 0 rgba(148, 163, 184, 0.08);
+
+      .md-image-icon {
+        flex-shrink: 0;
+        width: 28px;
+        height: 28px;
+        color: #94a3b8;
+      }
+
+      .md-image-fallback-text {
+        display: inline-flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+        max-width: min(360px, 70vw);
+      }
+
+      .md-image-fallback-title {
+        font-weight: 600;
+        color: #334155;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .md-image-fallback-meta {
+        font-family: 'SF Mono', 'Menlo', 'Consolas', monospace;
+        font-size: 12px;
+        color: #94a3b8;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+    }
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .markdown-body .md-image-wrap.md-image-error > .md-image-fallback {
+    background:
+      linear-gradient(135deg, rgba(30, 41, 59, 0.85) 0%, rgba(15, 23, 42, 0.85) 100%),
+      radial-gradient(circle at 100% 0%, rgba(196, 181, 253, 0.18) 0%, transparent 60%);
+    border-color: rgba(148, 163, 184, 0.3);
+    color: #cbd5e1;
+
+    .md-image-icon {
+      color: #64748b;
+    }
+
+    .md-image-fallback-title {
+      color: #e2e8f0;
+    }
+
+    .md-image-fallback-meta {
+      color: #64748b;
+    }
+  }
+}
 </style>
 
 <style lang="scss" scoped>

--- a/src/components/common/VueMarkdown.vue
+++ b/src/components/common/VueMarkdown.vue
@@ -5,6 +5,29 @@ import MarkdownIt, { Options as MarkdownItOptions } from 'markdown-it';
 import 'katex/dist/katex.min.css';
 import { katex } from '@mdit/plugin-katex';
 
+const truncate = (s: string, max = 60) => (s.length > max ? `${s.slice(0, max - 1)}…` : s);
+
+const deriveFilename = (src: string): string => {
+  if (!src) return '';
+  try {
+    const url = new URL(src, typeof window !== 'undefined' ? window.location.origin : 'http://localhost');
+    const pathname = url.pathname.replace(/\/+$/, '');
+    const last = pathname.split('/').filter(Boolean).pop();
+    return last || url.host || src;
+  } catch {
+    const cleaned = src.split('?')[0].split('#')[0];
+    return cleaned.split('/').filter(Boolean).pop() || src;
+  }
+};
+
+const FALLBACK_ICON_SVG = `
+<svg class="md-image-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+  <rect x="3" y="3" width="18" height="18" rx="3" ry="3"></rect>
+  <circle cx="8.5" cy="8.5" r="1.5"></circle>
+  <path d="m21 16-4.5-4.5L11 17l-3-3L3 19"></path>
+  <line x1="3.5" y1="3.5" x2="20.5" y2="20.5" stroke-dasharray="2 3"></line>
+</svg>`.trim();
+
 export default defineComponent({
   name: 'VueMarkdown',
   props: {
@@ -25,6 +48,63 @@ export default defineComponent({
       errorColor: '#cc0000',
       mathFence: true
     });
+
+    // Override the default image renderer to:
+    //  - add `loading="lazy"` and `decoding="async"` for better perf,
+    //  - tag the <img> with `md-image` so we can attach error handling globally,
+    //  - wrap it in a `.md-image-wrap` span that contains a graceful fallback
+    //    (icon + alt text + filename) shown when the image fails to load.
+    md.renderer.rules.image = (tokens, idx, options, env, self) => {
+      const token = tokens[idx];
+
+      // Resolve alt from inline children (markdown-it stores alt as children tokens).
+      const altText = token.children?.length
+        ? md.renderer.renderInlineAsText(token.children, options, env)
+        : token.content || '';
+
+      const altIdx = token.attrIndex('alt');
+      if (altIdx < 0) {
+        token.attrPush(['alt', altText]);
+      } else {
+        token.attrs![altIdx][1] = altText;
+      }
+
+      if (token.attrIndex('loading') < 0) token.attrPush(['loading', 'lazy']);
+      if (token.attrIndex('decoding') < 0) token.attrPush(['decoding', 'async']);
+
+      const classIdx = token.attrIndex('class');
+      const existingClass = classIdx >= 0 ? token.attrs![classIdx][1] : '';
+      const nextClass = `md-image${existingClass ? ` ${existingClass}` : ''}`;
+      if (classIdx >= 0) {
+        token.attrs![classIdx][1] = nextClass;
+      } else {
+        token.attrPush(['class', nextClass]);
+      }
+
+      const srcIdx = token.attrIndex('src');
+      const src = srcIdx >= 0 ? token.attrs![srcIdx][1] : '';
+
+      const imgHtml = self.renderToken(tokens, idx, options);
+      const filename = truncate(deriveFilename(src) || src, 60);
+      const titleText = altText.trim() || 'Image unavailable';
+
+      return (
+        '<span class="md-image-wrap">' +
+        imgHtml +
+        '<span class="md-image-fallback" role="img" aria-label="' +
+        md.utils.escapeHtml(`Failed to load image: ${titleText}`) +
+        '">' +
+        FALLBACK_ICON_SVG +
+        '<span class="md-image-fallback-text">' +
+        '<span class="md-image-fallback-title">' +
+        md.utils.escapeHtml(titleText) +
+        '</span>' +
+        (filename ? '<span class="md-image-fallback-meta">' + md.utils.escapeHtml(filename) + '</span>' : '') +
+        '</span>' +
+        '</span>' +
+        '</span>'
+      );
+    };
 
     const content = computed(() => {
       const src = props.source;


### PR DESCRIPTION
## Why

In chat, images posted in markdown — e.g. Nano Banana Bot's `![image-...](url)` output — fell back to the browser's default broken-image icon when the URL failed to load (CDN expired, network blocked, etc.). The result is a tiny placeholder with the alt text awkwardly squeezed beside it, which looks unpolished.

## What

Replaces the user-agent broken-image rendering with a designed card-style fallback for **all** markdown-rendered images.

### Before
A 16×16 broken-image icon + tiny alt text on a single line.

### After
A rounded dashed-border card with:
- a soft illustration icon (mountain/picture SVG) on the left
- the alt text as a bold title
- the truncated filename in a monospace meta line beneath it

## How

- **`src/components/common/VueMarkdown.vue`** — overrides markdown-it's `image` renderer to:
  - tag the `<img>` with class `md-image`
  - set `loading="lazy"` + `decoding="async"` for free perf wins
  - wrap the `<img>` in `<span class="md-image-wrap">` followed by an inline `<span class="md-image-fallback">` containing the SVG icon + alt + filename
  - alt text + filename are properly escaped via `md.utils.escapeHtml`

- **`src/components/common/MarkdownRenderer.vue`** — installs a single global capture-phase `error` listener (image error events don't bubble, so capture is required). When a `.md-image` errors, the listener adds `md-image-error` to its `.md-image-wrap` parent. CSS hides the broken `<img>` and reveals the fallback. Includes a `prefers-color-scheme: dark` polish.

## Scope

- Affects every `<markdown-renderer>` usage (chat assistant messages and any other markdown content). Plain `<img>` tags rendered directly in Vue templates (e.g. user-uploaded `image_url` items in `Message.vue`) are out of scope here.
- No new dependencies.
- Lint + type-check clean.

## How to verify

In a chat transcript, send/receive an assistant message that includes a markdown image with an unreachable URL, e.g.:

```
![image-broken-test](https://example.invalid/missing.png)
```

The card-style fallback should render in place of the default broken-image icon.
