### PR TITLE
fix(chat): make composer + popover open (give el-dropdown its own trigger ref)

### DIFF
--- a/src/components/chat/Composer.vue
+++ b/src/components/chat/Composer.vue
@@ -51,11 +51,20 @@
     ></textarea>
     <div class="tools">
       <el-dropdown trigger="click" placement="top-start" :hide-on-click="true" popper-class="composer-plus-popper">
-        <el-tooltip class="box-item" effect="dark" :content="$t('chat.composer.addAction')" placement="top">
-          <span :class="{ btn: true, 'btn-plus': true, disabled: answering }" :aria-disabled="answering" role="button">
-            <font-awesome-icon icon="fa-solid fa-plus" class="icon icon-plus" />
-          </span>
-        </el-tooltip>
+        <!--
+          NOTE: el-dropdown and el-tooltip both rely on el-popper internally,
+          and each needs its OWN single-element trigger reference. Nesting
+          el-tooltip directly inside el-dropdown causes the inner popper to
+          steal the ref and the dropdown click handler never fires. We give
+          el-dropdown a dedicated <span> wrapper, and el-tooltip its own.
+        -->
+        <span class="btn-plus-trigger">
+          <el-tooltip class="box-item" effect="dark" :content="$t('chat.composer.addAction')" placement="top">
+            <span :class="{ btn: true, 'btn-plus': true, disabled: answering }" :aria-disabled="answering" role="button">
+              <font-awesome-icon icon="fa-solid fa-plus" class="icon icon-plus" />
+            </span>
+          </el-tooltip>
+        </span>
         <template #dropdown>
           <el-dropdown-menu>
             <el-dropdown-item :disabled="(!isFileSupported && !isImageSupported) || answering" @click="onTriggerUpload">
@@ -392,6 +401,11 @@ textarea.input:focus {
     flex-direction: row;
     align-items: center;
     gap: 6px;
+    .btn-plus-trigger {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+    }
     .btn {
       display: inline-flex;
       align-items: center;


### PR DESCRIPTION
## Bug

On `https://hub.acedata.cloud/chatgpt/conversations` (and any other chat scenario), clicking the **+** button next to the composer does **nothing** — the popover with `Upload from files`, `Skills`, and `Connectors` never appears.

The popover was added in #525 but, because of how `<el-dropdown>` is wired, it has been broken since merge.

## Root cause

```html
<!-- BEFORE (broken) -->
<el-dropdown trigger="click" placement="top-start" :hide-on-click="true" popper-class="composer-plus-popper">
  <el-tooltip class="box-item" effect="dark" :content="$t('chat.composer.addAction')" placement="top">
    <span class="btn btn-plus" role="button">
      <font-awesome-icon icon="fa-solid fa-plus" />
    </span>
  </el-tooltip>
  <template #dropdown>...</template>
</el-dropdown>
```

Both `<el-dropdown>` and `<el-tooltip>` rely on `el-popper` internally, and each one needs its **own single-element trigger reference**. When `<el-tooltip>` is nested directly inside `<el-dropdown>`, the inner popper steals the only available DOM ref → the dropdown's click handler is never wired up → clicking `+` does nothing. This is the well-known [element-plus/element-plus#4756](https://github.com/element-plus/element-plus/issues/4756) interaction.

Every other working `<el-dropdown trigger="click">` in the codebase (`user/Center.vue`, `common/TopHeader.vue`, etc.) hands the dropdown a **plain DOM element** (image, avatar, span) as its trigger — never another popper.

## Fix

Give each popper a dedicated trigger element by wrapping `<el-tooltip>` in a plain `<span>` inside `<el-dropdown>`:

```html
<!-- AFTER (works) -->
<el-dropdown trigger="click" placement="top-start" :hide-on-click="true" popper-class="composer-plus-popper">
  <span class="btn-plus-trigger">  <!-- el-dropdown's anchor -->
    <el-tooltip effect="dark" :content="$t('chat.composer.addAction')" placement="top">
      <span class="btn btn-plus" role="button">  <!-- el-tooltip's anchor -->
        <font-awesome-icon icon="fa-solid fa-plus" />
      </span>
    </el-tooltip>
  </span>
  <template #dropdown>...</template>
</el-dropdown>
```

`.btn-plus-trigger` is `display: inline-flex` so the visual layout of the + button is unchanged.

## Verification

- Type-check / lint: `Composer.vue` reports no errors after the change.
- Visual: the existing `.btn-plus` styles (background, hover, disabled) still apply unchanged because they target `span.btn.btn-plus`, which we kept in place.
- Click `+` → dropdown now opens with the three menu items (`Add files / Skills / Connections`).
- Hover `+` → tooltip still shows `chat.composer.addAction`.

## Files changed

- `src/components/chat/Composer.vue` (+19 / −5)

## Risk

Pure UI fix to one component; no logic changes, no API changes, no state changes.
