### PR TITLE
fix(chat): ignore Enter while IME is composing in composer/edit textarea

### DIFF
--- a/src/components/chat/Composer.vue
+++ b/src/components/chat/Composer.vue
@@ -46,7 +46,7 @@
       class="input"
       :placeholder="$t('chat.message.newMessagePlaceholder')"
       :style="{ height: inputHeight }"
-      @keydown.enter.exact.prevent="onSubmit"
+      @keydown.enter.exact="onEnterKey"
       @input="adjustTextareaHeight"
     ></textarea>
     <div class="tools">
@@ -261,6 +261,17 @@ export default defineComponent({
         return;
       }
       this.$emit('submit');
+    },
+    onEnterKey(e: KeyboardEvent) {
+      // Avoid submitting while an IME (e.g. Chinese/Japanese/Korean) is
+      // composing — pressing Enter to confirm the IME candidate must NOT
+      // send the message. `isComposing` is true during composition; some
+      // browsers also report keyCode 229 for the same state.
+      if (e.isComposing || e.keyCode === 229) {
+        return;
+      }
+      e.preventDefault();
+      this.onSubmit();
     },
     onStop() {
       this.$emit('stop');

--- a/src/components/chat/Message.vue
+++ b/src/components/chat/Message.vue
@@ -259,9 +259,11 @@ export default defineComponent({
       this.isEditing = false;
       this.onSubmit();
     },
-    onEditEnterKey(e: KeyboardEvent) {
+    onEditEnterKey(evt: Event) {
       // Skip IME composition: pressing Enter to commit a Chinese/Japanese/Korean
       // candidate must NOT submit the edit. See Composer.vue for full rationale.
+      // ElInput types this event as `Event | KeyboardEvent`, hence the cast.
+      const e = evt as KeyboardEvent;
       if (e.isComposing || e.keyCode === 229) {
         return;
       }

--- a/src/components/chat/Message.vue
+++ b/src/components/chat/Message.vue
@@ -62,7 +62,7 @@
             v-model="questionValue"
             type="textarea"
             class="mb-2"
-            @keydown.enter.exact.prevent="onEdit"
+            @keydown.enter.exact="onEditEnterKey"
           ></el-input>
           <div class="flex justify-end">
             <el-button round @click="cancelEdit">{{ $t('common.button.cancel') }}</el-button>
@@ -258,6 +258,15 @@ export default defineComponent({
     onEdit() {
       this.isEditing = false;
       this.onSubmit();
+    },
+    onEditEnterKey(e: KeyboardEvent) {
+      // Skip IME composition: pressing Enter to commit a Chinese/Japanese/Korean
+      // candidate must NOT submit the edit. See Composer.vue for full rationale.
+      if (e.isComposing || e.keyCode === 229) {
+        return;
+      }
+      e.preventDefault();
+      this.onEdit();
     },
     onSubmit() {
       this.$emit('edit', this.message, this.questionValue);


### PR DESCRIPTION
## Problem

User report on `https://hub.acedata.cloud/chatgpt/conversations`:

> 输入法一旦输入点了回车，就会发出去？比如我中文输入法要打英文 ACE，我就会回车一下。但是一下子回车，就发出去了。

When the user is typing with a CJK IME (e.g. 中文输入法 typing English `ACE`), pressing **Enter** to commit / cancel the IME candidate also fires the chat composer's `submit` handler, so the message is sent before the user is done typing.

## Root cause

Both the main composer textarea and the in-place edit textarea use:

```html
@keydown.enter.exact.prevent="onSubmit"
```

Vue's `.enter` modifier (and the underlying `keydown` event) fires regardless of IME composition state, so the Enter that should only confirm the IME candidate also triggers send.

## Fix

Replace the inline submit binding with a small handler that bails out when the IME is composing:

```ts
onEnterKey(e: KeyboardEvent) {
  if (e.isComposing || e.keyCode === 229) return;
  e.preventDefault();
  this.onSubmit();
}
```

Same treatment for the message edit textarea (`Message.vue`).

## Files

- `src/components/chat/Composer.vue` — main chat input
- `src/components/chat/Message.vue` — in-place edit textarea

## Manual verification

- ABC keyboard: Enter still sends the message (no Shift) and Shift+Enter still inserts a newline.
- 中文输入法 (Pinyin / 注音 / 五笔): typing `ACE` and pressing Enter to confirm the candidate now stays in the textarea instead of sending.
- Same for editing an existing message.
