### PR TITLE
chore(chat): simplify DeepSeek model display names (4.0 / 3.2 / 3.0 / R1)

### DIFF
--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -104,7 +104,7 @@
     "description": "Description of the GPT 5.4 Mini model"
   },
   "model.deepseekChat": {
-    "message": "3.0 Standard",
+    "message": "3.0",
     "description": "Model name of the service, i.e., DeepSeek Chat"
   },
   "model.deepseekChatDescription": {
@@ -112,7 +112,7 @@
     "description": "Description of the DeepSeek Chat model"
   },
   "model.deepseekReasoner": {
-    "message": "R1 Reasoner",
+    "message": "R1",
     "description": "Model name of the service, i.e., DeepSeek Reasoner"
   },
   "model.deepseekReasonerDescription": {
@@ -120,7 +120,7 @@
     "description": "Description of the DeepSeek Reasoner model"
   },
   "model.deepseekChat32": {
-    "message": "V3.2 Experimental",
+    "message": "3.2",
     "description": "Model name of the service, i.e., DeepSeek V3.2 Exp"
   },
   "model.deepseekChat32Description": {
@@ -128,7 +128,7 @@
     "description": "Description of the DeepSeek V3.2 experimental model"
   },
   "model.deepseekV4Flash": {
-    "message": "V4 Flash",
+    "message": "4.0",
     "description": "Model name of the service, i.e., DeepSeek V4 Flash"
   },
   "model.deepseekV4FlashDescription": {

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -104,7 +104,7 @@
     "description": "GPT 5.4 Mini 模型的描述"
   },
   "model.deepseekChat": {
-    "message": "3.0 标准",
+    "message": "3.0",
     "description": "服务的模型名称，即 DeepSeek 聊天"
   },
   "model.deepseekChatDescription": {
@@ -112,7 +112,7 @@
     "description": "DeepSeek 聊天模型的描述"
   },
   "model.deepseekReasoner": {
-    "message": "R1 推理",
+    "message": "R1",
     "description": "服务的模型名称，即 DeepSeek 推理"
   },
   "model.deepseekReasonerDescription": {
@@ -120,7 +120,7 @@
     "description": "DeepSeek 推理模型的描述"
   },
   "model.deepseekChat32": {
-    "message": "V3.2 实验版",
+    "message": "3.2",
     "description": "服务的模型名称，即 DeepSeek V3.2 Exp"
   },
   "model.deepseekChat32Description": {
@@ -128,7 +128,7 @@
     "description": "DeepSeek V3.2 实验模型的描述"
   },
   "model.deepseekV4Flash": {
-    "message": "V4 Flash",
+    "message": "4.0",
     "description": "服务的模型名称，即 DeepSeek V4 Flash"
   },
   "model.deepseekV4FlashDescription": {


### PR DESCRIPTION
## Summary

Simplifies DeepSeek model display names in the chat model picker (`hub.acedata.cloud/deepseek/conversations`). The current labels mix styles (`V4 Flash`, `V3.2 Experimental`, `3.0 Standard`, `R1 Reasoner`) which looks inconsistent. Per request, switch to a uniform short form:

| Internal `name` (unchanged) | Old display | New display |
| --- | --- | --- |
| `deepseek-v4-flash` | V4 Flash / V4 Flash | **4.0** |
| `deepseek-v3.2-exp` | V3.2 Experimental / V3.2 实验版 | **3.2** |
| `deepseek-v3` | 3.0 Standard / 3.0 标准 | **3.0** |
| `deepseek-r1` | R1 Reasoner / R1 推理 | **R1** |

Only `i18n/zh-CN/chat.json` and `i18n/en/chat.json` are modified (project rule: do not auto-translate other locales). Descriptions and the underlying model `name` values are unchanged, so billing/API routing is unaffected.

## Test plan

- JSON parse OK for both edited files.
- No code logic changed — only the rendered label inside the model dropdown.
