### PR TITLE
chore(chat): remove skill and connector entry buttons from top-right toolbar

### DIFF
--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -10,18 +10,6 @@
               <span v-if="agentConnected" class="agent-dot"></span>
             </el-button>
           </el-tooltip>
-          <el-tooltip :content="$t('chat.skill.tooltip')" placement="bottom">
-            <el-button class="toolbar-btn" text @click="onOpenSkills">
-              <font-awesome-icon icon="fa-solid fa-wand-magic-sparkles" />
-              <font-awesome-icon icon="fa-solid fa-up-right-from-square" class="external-icon" />
-            </el-button>
-          </el-tooltip>
-          <el-tooltip :content="$t('chat.connections.tooltip')" placement="bottom">
-            <el-button class="toolbar-btn" text @click="onOpenConnections">
-              <font-awesome-icon icon="fa-solid fa-plug" />
-              <font-awesome-icon icon="fa-solid fa-up-right-from-square" class="external-icon" />
-            </el-button>
-          </el-tooltip>
         </div>
       </div>
       <desktop-agent-manager
@@ -221,22 +209,6 @@ export default defineComponent({
     this.onCheckAgentStatus();
   },
   methods: {
-    onOpenConnections() {
-      // Connections (MCP + OAuth connectors) are managed exclusively at
-      // auth.acedata.cloud. Nexior is a thin entry point - clicking opens
-      // the canonical management page in a new tab. aichat2 reads the
-      // user's active connections from auth.acedata.cloud at request time.
-      window.open('https://auth.acedata.cloud/user/connections', '_blank', 'noopener');
-    },
-    onOpenSkills() {
-      // Same model as connections: skills are managed exclusively at
-      // auth.acedata.cloud/user/skills. The aichat2 worker pulls the
-      // user's active skills (uploads + globals + bundled built-ins +
-      // virtual MCP-prompt skills) on every request and exposes them
-      // to the model via the <skills> system-prompt block, so there is
-      // nothing to toggle in-app.
-      window.open('https://auth.acedata.cloud/user/skills', '_blank', 'noopener');
-    },
     async onCheckAgentStatus() {
       const token = this.credential?.token;
       if (!token) return;


### PR DESCRIPTION
## Summary

Remove the **skill** (wand icon) and **connector** (plug icon) entry buttons from the chat conversation page's top-right toolbar.

These were thin links that opened `auth.acedata.cloud/user/skills` and `auth.acedata.cloud/user/connections` in a new tab. Per request, the entries are no longer surfaced from Nexior's chat header.

## Changes

- `src/pages/chat/Conversation.vue`
  - Drop the two `<el-tooltip>` + `<el-button>` blocks for `onOpenSkills` and `onOpenConnections`.
  - Drop the now-unused `onOpenSkills` and `onOpenConnections` methods.

The hidden agent button (already gated by `v-if="false"`) is left untouched, so the toolbar continues to render the model selector and the (still-hidden) agent slot.

## Notes

- Composer "+" menu's `Skills` / `Connectors` entries (in `src/components/chat/Composer.vue`) and the user-center dropdown's `Connectors` entry (in `src/components/user/Center.vue`) are **not** modified — the request was specifically about the top-right toolbar entry points.
- No translations / icon registrations need to be removed; `chat.skill.tooltip` and `chat.connections.tooltip` remain referenced by other surfaces.
