### PR TITLE
fix(chat): align message icons + restore copy/regenerate under array-content answers

### DIFF
--- a/src/components/chat/Message.vue
+++ b/src/components/chat/Message.vue
@@ -92,16 +92,12 @@
           @click="startEditing"
         />
         <copy-to-clipboard
-          v-if="
-            !Array.isArray(message.content) &&
-            (message.state === messageState.FINISHED || message.state === messageState.FAILED)
-          "
-          :content="message.content!"
+          v-if="copyableText && (message.state === messageState.FINISHED || message.state === messageState.FAILED)"
+          :content="copyableText"
           class="btn-copy"
         />
         <restart-to-generate
           v-if="
-            !Array.isArray(message.content) &&
             (message.state === messageState.FINISHED || message.state === messageState.FAILED) &&
             message.role === 'assistant' &&
             message === messages[messages.length - 1]
@@ -205,6 +201,23 @@ export default defineComponent({
   computed: {
     modelGroup() {
       return this.$store.state.chat.modelGroup;
+    },
+    // Plain-text view of `message.content` for the copy button. Assistant
+    // messages are now stored as IChatMessageContentItem[] (text + tool_use
+    // + card + artifact parts) even for plain prose answers, so we collect
+    // the text fragments here so copy still works.
+    copyableText(): string {
+      const c = this.message.content;
+      if (!c) return '';
+      if (typeof c === 'string') return c;
+      if (Array.isArray(c)) {
+        return c
+          .filter((item) => item && item.type === 'text' && typeof item.text === 'string')
+          .map((item) => item.text as string)
+          .join('\n\n')
+          .trim();
+      }
+      return '';
     },
     errorText() {
       console.debug('error', this.message.error);
@@ -368,6 +381,12 @@ export default defineComponent({
     align-items: start;
     .content {
       color: var(--el-text-color-primary);
+      // Avatar (32px) sits flush at the top of the row; drop the bubble
+      // padding/border-radius for assistant turns so the first text line
+      // top-aligns with the avatar instead of being pushed ~10px down.
+      padding: 0;
+      border-radius: 0;
+      background-color: transparent;
     }
   }
   &.user {
@@ -430,18 +449,23 @@ export default defineComponent({
 
   .operations {
     display: flex;
+    align-items: center;
     gap: 8px;
     margin-left: 4px;
     margin-top: 2px;
     color: var(--el-text-color-placeholder);
+    // Keep all action icons at the same size so they vertically align.
+    font-size: 12px;
     .btn-edit {
       visibility: hidden;
     }
-    .btn-restart {
-      font-size: 12px;
-    }
-    .btn-copy {
-      font-size: 12px;
+    // CopyToClipboard / RestartToGenerate ship with their own
+    // `margin-left: 5px`; null it out so the parent `gap` is the single
+    // source of truth for spacing and the icons line up cleanly.
+    :deep(.icon-copy),
+    :deep(.icon-check),
+    :deep(.icon-sync) {
+      margin-left: 0;
     }
   }
 


### PR DESCRIPTION
## Summary

Three small UI regressions in the chat message row that together made the answer area look "unprofessional":

1. **Edit / copy icons in the user bubble were misaligned and different sizes.**
   The flex container `.operations` had no `align-items`, and `.btn-copy` / `.btn-restart` were pinned to `font-size: 12px` while `.btn-edit` inherited the parent (~14px). Two icons of two different sizes laid out without center-alignment looked off-grid.

2. **Assistant avatar and answer text were not vertically aligned.**
   `.content` kept its `10px 16px` bubble padding even on assistant turns, so the first line of markdown started ~10px below the 32px avatar's top edge.

3. **No copy / regenerate buttons under any answer.**
   The streaming pipeline in `Conversation.vue` now stores `message.content` as `IChatMessageContentItem[]` (text + tool_use + card + artifact parts) for **any** non-empty response — even plain prose. The buttons in `Message.vue` were gated by `!Array.isArray(message.content)`, so they were always hidden, and `<copy-to-clipboard>`'s `:content` only accepts `string | number` so we can't just pass the array.

## Fix

`Message.vue` only.

- Add `align-items: center` and `font-size: 12px` to `.operations`; zero out the in-component `margin-left: 5px` on `.icon-copy` / `.icon-check` / `.icon-sync` via `:deep()` so the parent `gap: 8px` is the single source of truth for icon spacing.
- For `&.assistant` drop `.content`'s padding / border-radius / background so the first line of markdown top-aligns with the avatar (the avatar itself already sits with `padding: 4px 8px 4px 0`).
- Add a `copyableText` computed that joins `text` parts out of an `IChatMessageContentItem[]` (or returns the string form). Use it for `copy-to-clipboard`, drop the array guard from `restart-to-generate`. `edit-message` keeps its array guard — we only allow editing plain-string user turns.

## Verification

- `npx vue-tsc --noEmit` → clean
- `npx eslint src/components/chat/Message.vue` → clean
- Visual: avatar/text top-align cleanly, edit + copy icons sit on the same baseline at the same size, copy + regenerate icons appear under finished assistant answers (including answers with tool_use / card / artifact parts).

## Reproduction (before this PR)

Ask any model a plain text question (e.g. `9.8 和 9.11 哪个更大?`) and observe:
- The pencil + copy icons above the user bubble look subtly out of line.
- The ChatGPT-style avatar is offset above the first line of the answer.
- The answer has no copy / regenerate icons below it (regression introduced when the streaming pipeline switched to `IChatMessageContentItem[]`).
