### PR TITLE
fix(i18n): add common.button.download for chat entity card

### DIFF
--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -103,6 +103,10 @@
     "message": "Start for Free",
     "description": "Text in button for allowing users to start for free"
   },
+  "button.download": {
+    "message": "Download",
+    "description": "Text in button for downloading a file (e.g. audio, video, image)"
+  },
   "button.downloadAndroid": {
     "message": "Download Android",
     "description": "Text in button for downloading the Android installer"

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -103,6 +103,10 @@
     "message": "免费开始",
     "description": "按钮中的文本，用于让用户免费开始"
   },
+  "button.download": {
+    "message": "下载",
+    "description": "按钮中的文本，用于下载文件（如音频、视频、图片）"
+  },
   "button.downloadAndroid": {
     "message": "下载 Android",
     "description": "按钮中的文本，用于下载 Android 安装包"


### PR DESCRIPTION
## Problem

On https://hub.acedata.cloud/chatgpt/conversations, audio cards (and the entity-card download link in general) render the raw i18n key `common.button.download` instead of a translated label.

Reported via screenshot showing a Suno-generated audio card whose download link reads `common.button.download` instead of "Download" / "下载".

## Root cause

[src/components/chat/EntityCard.vue](https://github.com/AceDataCloud/Nexior/blob/main/src/components/chat/EntityCard.vue#L15) uses `$t('common.button.download')`, but the key was never defined in `src/i18n/{en,zh-CN}/common.json`. Only `button.downloadAndroid` and `button.downloadIos` existed.

When a key is missing, `vue-i18n` falls back to printing the key string verbatim, which is what we see in the UI.

## Fix

Add a plain `button.download` entry to `src/i18n/en/common.json` and `src/i18n/zh-CN/common.json`:

- en: "Download"
- zh-CN: "下载"

Per project policy, only `en` and `zh-CN` locales are updated manually here. Other languages will be picked up by the translation CronJob on the next pass.

## Verification

- `python3 -c "import json; [json.load(open(f)) for f in ['src/i18n/en/common.json','src/i18n/zh-CN/common.json']]"` → JSON OK.
- After deploy, the audio/video/file card "Download" link on `/chatgpt/conversations` will render the localized string instead of the raw key.
