### PR TITLE
fix(chat): update URL :id segment when switching conversations

### DIFF
--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -380,12 +380,23 @@ export default defineComponent({
           this.handleRequestError(error);
         });
     },
+    // Build a `/<prefix>/conversations[/<id>]` path from the matched
+    // parent route (e.g. `/chatgpt`, `/grok`). We can't use
+    // `router.push({ params: { id } })` here because Vue Router 4 keeps
+    // the *current* route name on a params-only push — and the new-chat
+    // route's path template has no `:id` slot, so the URL silently
+    // doesn't change when navigating from /chatgpt/conversations to
+    // /chatgpt/conversations/<id> (and vice versa).
+    conversationsPath(id?: string): string {
+      const prefix = this.$route.matched[0]?.path ?? '';
+      return id ? `${prefix}/conversations/${id}` : `${prefix}/conversations`;
+    },
     async onNewConversation() {
-      // Single-source-of-truth: drive everything off the URL. Calling
-      // router.push with an empty :id removes the path segment. The
+      // Single-source-of-truth: drive everything off the URL. Pushing
+      // the bare `/conversations` path drops the `:id` segment. The
       // `conversationId` watcher then resets messages/question/refs.
       if (this.conversationId) {
-        await this.$router.push({ params: { id: '' } });
+        await this.$router.push(this.conversationsPath());
       } else {
         // Already on /chatgpt/conversations — no route change to trigger
         // the watcher, so reset locally.
@@ -428,7 +439,7 @@ export default defineComponent({
         if (!target) await this.onNewConversation();
         return;
       }
-      await this.$router.push({ params: { id: target } });
+      await this.$router.push(this.conversationsPath(target));
     },
     async onSubmit() {
       if (this.references.length > 0) {
@@ -627,11 +638,7 @@ export default defineComponent({
           this.answering = false;
           if (conversationId) {
             this.skipNextRestoreId = conversationId;
-            await this.$router.push({
-              params: {
-                id: conversationId
-              }
-            });
+            await this.$router.push(this.conversationsPath(conversationId));
           }
           this.onScrollDown();
           await this.$store.dispatch('chat/getConversations');


### PR DESCRIPTION
## Bug

Clicking a conversation in the chat side panel loads the messages but **leaves the address bar at `/<model>/conversations`** — the `:id` segment is never appended. This breaks page refresh, copy/share links, and browser back/forward navigation.

Reproduce on production (`hub.acedata.cloud/chatgpt/conversations`):
1. Open ChatGPT (or any chat model) — you land on `/chatgpt/conversations` (the "new chat" route).
2. Click any conversation in the left side panel.
3. Messages load, but the URL stays at `/chatgpt/conversations` instead of `/chatgpt/conversations/<uuid>`.
4. Hit refresh → conversation is gone.

## Root cause

PR #517 introduced URL-driven conversation routing using:

```ts
await this.$router.push({ params: { id: target } });
```

In Vue Router 4, a params-only `router.push` keeps the **current** matched route name and merges the params into that route's path template. When the active route is the `conversations` variant (route name `<model>-conversation-new`, no `:id` in the path template), the `id` param has no slot to go into and is silently dropped. Result: navigation fires (the `conversationId` watcher runs, content loads), but the visible URL doesn't change.

It only ever surfaces on the **first** click out of the new-chat state — once you're on `/<model>/conversations/<id>`, the route already has a `:id` slot and subsequent clicks update fine. That's exactly the symptom users are reporting and what the screenshot shows.

The same bug exists in two other call sites that the same PR introduced or didn't touch:
- `onNewConversation` — going from `:id` → no-id (params-only push, same Vue Router quirk in reverse)
- post-stream promotion (line 630) — when the first reply on a fresh chat returns an id, push to `/<model>/conversations/<id>`. From the new-chat URL, this also silently no-ops, so a brand-new conversation never gets its shareable URL.

## Fix

Replace all three `router.push({ params: { id } })` sites with a path-based push derived from the matched parent route:

```ts
conversationsPath(id?: string): string {
  const prefix = this.$route.matched[0]?.path ?? ''; // '/chatgpt', '/grok', ...
  return id ? `${prefix}/conversations/${id}` : `${prefix}/conversations`;
}
```

Stays model-agnostic across `/chatgpt`, `/grok`, `/gemini`, `/claude`, `/deepseek`, `/kimi` without hardcoding any route names.

## Files

- `src/pages/chat/Conversation.vue` — add `conversationsPath()` helper, swap three `router.push` call sites.

## Risk

Single-file, behavior-only fix in the chat router glue. No model/store/operator changes. Confined to the three navigation paths covered above.
