### PR TITLE
chore(router): default fallback origin to studio.acedata.cloud

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -366,8 +366,8 @@ router.afterEach((to) => {
       keywords: seoData.keywords
     });
     // Use the current origin so the WebApplication schema URL reflects the
-    // hostname the visitor is actually on (hub.acedata.cloud, studio.acedata.cloud, etc.).
-    const origin = (typeof window !== 'undefined' && window.location?.origin) || 'https://hub.acedata.cloud';
+    // hostname the visitor is actually on (studio.acedata.cloud, hub.acedata.cloud, etc.).
+    const origin = (typeof window !== 'undefined' && window.location?.origin) || 'https://studio.acedata.cloud';
     setWebApplicationSchema({
       name: seoData.title,
       description: seoData.description,


### PR DESCRIPTION
## Summary

Updates the SSR/initial-paint fallback `origin` in the router's `WebApplication` JSON-LD schema from `https://hub.acedata.cloud` to `https://studio.acedata.cloud`. The fallback only kicks in when `window.location.origin` is unavailable (e.g. during static prerender or non-browser execution); on real visits the actual hostname is used as before.

## Change

- `src/router/index.ts` — single line: fallback origin `'https://hub.acedata.cloud'` → `'https://studio.acedata.cloud'` (also reorders the comment example to put `studio` first).

## Notes

- Both hostnames continue to serve the same Nexior bundle, so this only affects the WebApplication schema URL when the browser-origin lookup is unavailable.
- Part of a coordinated cross-repo rename — see corresponding PRs in AuthFrontend, PlatformFrontend, Roadmap, PlatformBackend.
