### PR TITLE
feat(nexior): cross-site user_id guard + outbound link annotation

### DIFF
--- a/src/components/chat/Composer.vue
+++ b/src/components/chat/Composer.vue
@@ -126,7 +126,7 @@ import {
 } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { IChatModel } from '@/models';
-import { getBaseUrlPlatform, isImageUrl, pasteUploadMixin } from '@/utils';
+import { getBaseUrlPlatform, isImageUrl, pasteUploadMixin, withCurrentUserId } from '@/utils';
 import FilePreview from '@/components/common/FilePreview.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 
@@ -305,12 +305,12 @@ export default defineComponent({
       // Skills are managed exclusively at auth.acedata.cloud/user/skills.
       // Nexior is a thin entry point - clicking opens the canonical
       // management page in a new tab.
-      window.open('https://auth.acedata.cloud/user/skills', '_blank', 'noopener');
+      window.open(withCurrentUserId('https://auth.acedata.cloud/user/skills'), '_blank', 'noopener');
     },
     onOpenConnections() {
       // Connections (MCP + OAuth connectors) are managed exclusively at
       // auth.acedata.cloud/user/connections.
-      window.open('https://auth.acedata.cloud/user/connections', '_blank', 'noopener');
+      window.open(withCurrentUserId('https://auth.acedata.cloud/user/connections'), '_blank', 'noopener');
     }
   }
 });

--- a/src/components/common/TopHeader.vue
+++ b/src/components/common/TopHeader.vue
@@ -69,7 +69,7 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import defaultAvatar from '@/assets/images/avatar.png';
-import { getBaseUrlAuth } from '@/utils';
+import { getBaseUrlAuth, withCurrentUserId } from '@/utils';
 import { ROUTE_AUTH_LOGIN, ROUTE_CONSOLE_ROOT, ROUTE_DOWNLOAD, ROUTE_INDEX } from '@/router';
 import { ElCol, ElRow, ElDropdown, ElMenu, ElSubMenu, ElMenuItem, ElDropdownItem, ElButton } from 'element-plus';
 import Logo from './Logo.vue';
@@ -136,11 +136,11 @@ export default defineComponent({
     },
     onProfile() {
       const baseUrlAuth = getBaseUrlAuth();
-      window.open(`${baseUrlAuth}/user/profile`, '_blank');
+      window.open(withCurrentUserId(`${baseUrlAuth}/user/profile`), '_blank');
     },
     onVerify() {
       const baseUrlAuth = getBaseUrlAuth();
-      window.open(`${baseUrlAuth}/user/verify`, '_blank');
+      window.open(withCurrentUserId(`${baseUrlAuth}/user/verify`), '_blank');
     },
     onConsole() {
       this.$router.push({

--- a/src/components/user/Center.vue
+++ b/src/components/user/Center.vue
@@ -45,6 +45,7 @@ import UserAvatar from '@/components/user/Avatar.vue';
 import UserSetting from '@/components/user/Setting.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { ROUTE_CONSOLE_ROOT, ROUTE_DISTRIBUTION_INDEX, ROUTE_DOWNLOAD } from '@/router';
+import { withCurrentUserId } from '@/utils';
 import { ElDivider } from 'element-plus';
 import { ElDropdownMenu, ElDropdownItem, ElDropdown } from 'element-plus';
 
@@ -97,7 +98,9 @@ export default defineComponent({
     },
     onConnectors() {
       // Connections are managed exclusively at auth.acedata.cloud.
-      window.open('https://auth.acedata.cloud/user/connections', '_blank', 'noopener');
+      // Append `?user_id=` so a cross-site identity mismatch is detected
+      // and the user is bounced through SSO if needed.
+      window.open(withCurrentUserId('https://auth.acedata.cloud/user/connections'), '_blank', 'noopener');
     },
     onDistribution() {
       this.$router.push({

--- a/src/pages/profile/Index.vue
+++ b/src/pages/profile/Index.vue
@@ -40,7 +40,7 @@ import {
   ROUTE_SITE_INDEX
 } from '@/router';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlAuth, getBaseUrlPlatform } from '@/utils';
+import { getBaseUrlAuth, getBaseUrlPlatform, withCurrentUserId } from '@/utils';
 import HelpDialog from '@/components/common/HelpDialog.vue';
 
 interface ILink {
@@ -183,7 +183,9 @@ export default defineComponent({
           name: link.name
         });
       } else if (link.href) {
-        window.open(link.href, '_blank');
+        // Append `?user_id=<currentUserId>` so the destination site can
+        // detect a cross-site identity mismatch and re-auth.
+        window.open(withCurrentUserId(link.href), '_blank');
       } else if (link.callback) {
         link.callback();
       }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -62,6 +62,7 @@ import { I18N_DEFAULT_LOCALE } from '@/constants/i18n';
 import { getLocale, setI18nLanguage } from '@/i18n';
 import { updateSeo, setWebApplicationSchema, setOrganization, resetSeo } from '@/utils/seo';
 import { ensureStoreModule } from '@/store/lazy';
+import { evaluateUserIdGuard } from '@/utils/crossSiteUser';
 
 // SEO metadata per route path prefix
 const ROUTE_SEO: Record<string, { title: string; description: string; keywords: string[]; category: string }> = {
@@ -336,6 +337,18 @@ const router = createRouter({
 router.beforeEach(async (to, _from, next) => {
   const locale = getLocale(getCookie('LOCALE') || I18N_DEFAULT_LOCALE);
   await setI18nLanguage(locale);
+
+  // Cross-site identity guard: handle `?user_id=<id>` query param attached by
+  // outbound links from sibling sub-sites (auth / platform). See
+  // `src/utils/crossSiteUser.ts` for the full contract.
+  const decision = evaluateUserIdGuard(to);
+  if (decision.kind === 'strip') {
+    return next(decision.redirect);
+  }
+  if (decision.kind === 'mismatch') {
+    // Helper has already triggered a full-page SSO redirect; abort.
+    return next(false);
+  }
 
   // Lazily register the per-app Vuex store module owned by this route. The
   // mapping is `meta.appName` → store module name (set in each

--- a/src/utils/connections.ts
+++ b/src/utils/connections.ts
@@ -6,6 +6,8 @@
  * via the `return_url` query parameter.
  */
 
+import { withCurrentUserId } from './crossSiteUser';
+
 const CONNECTIONS_MANAGER_URL = 'https://auth.acedata.cloud/user/connections';
 
 /**
@@ -14,6 +16,9 @@ const CONNECTIONS_MANAGER_URL = 'https://auth.acedata.cloud/user/connections';
  *
  * Use a new tab (vs same-tab navigation) so the user does not lose
  * their current Nexior context (chat draft, scroll position, etc.).
+ *
+ * Also annotates the URL with `?user_id=<currentUserId>` so AuthFrontend
+ * can detect a cross-site identity mismatch and re-auth.
  */
 export function openConnectionsManager(provider?: string): void {
   const returnUrl = window.location.href;
@@ -22,5 +27,5 @@ export function openConnectionsManager(provider?: string): void {
   if (provider) {
     url.searchParams.set('provider', provider);
   }
-  window.open(url.toString(), '_blank', 'noopener,noreferrer');
+  window.open(withCurrentUserId(url.toString()), '_blank', 'noopener,noreferrer');
 }

--- a/src/utils/crossSiteUser.ts
+++ b/src/utils/crossSiteUser.ts
@@ -1,0 +1,108 @@
+import store from '@/store';
+import { RouteLocationNormalized, RouteLocationRaw } from 'vue-router';
+import { loginRedirect } from './login';
+
+/**
+ * Cross-site user-identity guard.
+ *
+ * Each AceDataCloud sub-site (auth.acedata.cloud, platform.acedata.cloud,
+ * hub.acedata.cloud) keeps its own independent session in vuex-persistedstate /
+ * localStorage — they don't share state. So it's possible for the user to be
+ * logged in as user A on one site and user B (or nobody) on another.
+ *
+ * To avoid the confusion, every outbound cross-site link should append the
+ * source site's currently-logged-in user id as `?user_id=<id>`. The destination
+ * site checks that param in a router guard:
+ *
+ *   - no `user_id` in URL                       → do nothing
+ *   - logged in & matches user_id               → strip the param, continue
+ *   - logged in but different OR not logged in  → clear local session and
+ *     redirect through the normal SSO login flow so the user re-authenticates
+ *     with the correct account
+ *
+ * The redirect URL passed to login always has `user_id` removed to avoid an
+ * infinite loop on the next round-trip.
+ */
+export const USER_ID_QUERY_PARAM = 'user_id';
+
+/**
+ * Append `?user_id=<currentUserId>` to a URL when there is a logged-in user.
+ *
+ * @param url Absolute URL to decorate.
+ * @returns The URL, possibly with `user_id` added to its query string. If
+ *   no user is logged in, the URL is returned unchanged.
+ */
+export const withCurrentUserId = (url: string): string => {
+  const userId = store.getters?.user?.id;
+  if (!userId) return url;
+  try {
+    const u = new URL(url);
+    if (!u.searchParams.has(USER_ID_QUERY_PARAM)) {
+      u.searchParams.set(USER_ID_QUERY_PARAM, String(userId));
+    }
+    return u.toString();
+  } catch {
+    // Not a parseable absolute URL — fall back to manual concat.
+    const sep = url.includes('?') ? '&' : '?';
+    return `${url}${sep}${USER_ID_QUERY_PARAM}=${encodeURIComponent(String(userId))}`;
+  }
+};
+
+/** Build a path+query string for `to`, omitting `user_id`. */
+const buildRedirectWithoutUserId = (to: RouteLocationNormalized): string => {
+  const params = new URLSearchParams();
+  for (const [k, v] of Object.entries(to.query)) {
+    if (k === USER_ID_QUERY_PARAM) continue;
+    if (v == null) continue;
+    if (Array.isArray(v)) {
+      v.forEach((entry) => entry != null && params.append(k, String(entry)));
+    } else {
+      params.set(k, String(v));
+    }
+  }
+  const search = params.toString();
+  return to.path + (search ? `?${search}` : '');
+};
+
+/**
+ * Process `?user_id=<id>` on the incoming route and decide what to do.
+ *
+ * Side effects:
+ *   - On a "mismatch" decision, clears local user/token state and triggers
+ *     `window.location.href = <auth.acedata.cloud SSO login>` via
+ *     `loginRedirect`. The current navigation should be aborted by the caller
+ *     (`next(false)`).
+ *
+ * Returns:
+ *   - `passthrough` — caller should `next()`.
+ *   - `strip(redirect)` — caller should `next(redirect)` to remove the
+ *     `user_id` query param from the URL bar.
+ *   - `mismatch` — caller should `next(false)` because the helper has
+ *     initiated a full-page SSO redirect.
+ */
+export type UserIdGuardDecision =
+  | { kind: 'passthrough' }
+  | { kind: 'strip'; redirect: RouteLocationRaw }
+  | { kind: 'mismatch' };
+
+export const evaluateUserIdGuard = (to: RouteLocationNormalized): UserIdGuardDecision => {
+  const expectedRaw = to.query[USER_ID_QUERY_PARAM];
+  const expected = Array.isArray(expectedRaw) ? expectedRaw[0] : expectedRaw;
+  if (!expected) return { kind: 'passthrough' };
+
+  const currentId = store.getters?.user?.id;
+  if (currentId && String(currentId) === String(expected)) {
+    const { [USER_ID_QUERY_PARAM]: _omit, ...rest } = to.query;
+    return {
+      kind: 'strip',
+      redirect: { path: to.path, query: rest, replace: true } as RouteLocationRaw
+    };
+  }
+
+  // Mismatch (or not logged in). Clear local session so the next render does
+  // not flash the wrong identity, then bounce through the normal SSO flow.
+  store.dispatch('resetToken');
+  store.dispatch('resetUser');
+  loginRedirect({ redirect: buildRedirectWithoutUserId(to) });
+  return { kind: 'mismatch' };
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './baseUrl';
+export * from './crossSiteUser';
 export * from './mode';
 export * from './domain';
 export * from './initializer';


### PR DESCRIPTION
## Problem

Each AceDataCloud sub-site (`auth.acedata.cloud`, `platform.acedata.cloud`, `hub.acedata.cloud`) keeps its own independent vuex-persistedstate session in `localStorage` — they don't share state. So a user can be logged in as user A on hub and user B on auth at the same time. When they click an external link from hub to auth (e.g. composer "Skills" / "Connections", profile menu, top header), they may silently land on the *wrong* account's page on auth, which is extremely confusing.

Concrete user-reported scenario: logged in as A on `hub.acedata.cloud`, click Composer → Skills → arrive on `auth.acedata.cloud/user/skills` logged in as B. Skills shown belong to B, not A.

## Solution

Pass `?user_id=<currentUserId>` on every cross-site outbound link. The destination site's router guard checks the param:

| Case | Action |
|---|---|
| no `user_id` in URL | passthrough |
| logged in & matches | strip the param, continue |
| not logged in **or** mismatch | dispatch `resetToken` + `resetUser` to clear local session, then `loginRedirect({ redirect: <original-without-uid> })` to bounce through SSO |

The `redirect` URL passed to login always has `user_id` removed, so we can't infinite-loop.

## What this PR adds (Nexior half)

- `src/utils/crossSiteUser.ts` — central helper:
  - `withCurrentUserId(url)` decorates an outbound URL.
  - `evaluateUserIdGuard(to)` is the inbound decision function used by the router guard. Returns `passthrough` / `strip` / `mismatch`. On `mismatch` the helper performs the `loginRedirect` itself (full-page nav), so the router caller just needs to `next(false)` to abort the in-flight transition.
- `src/router/index.ts` — wires the guard into the existing `beforeEach` (runs after the i18n hook, before lazy store-module loading).
- Outbound link callsites updated to use `withCurrentUserId(...)`:
  - `src/components/common/TopHeader.vue` — `onProfile` / `onVerify`
  - `src/components/user/Center.vue` — `onConnectors`
  - `src/components/chat/Composer.vue` — `onOpenSkills` / `onOpenConnections`
  - `src/pages/profile/Index.vue` — `onNavigate(link.href)` covers the profile entry
  - `src/utils/connections.ts` — `openConnectionsManager` helper

## Companion PRs

- AuthFrontend: https://github.com/AceDataCloud/AuthFrontend/pull/71
- PlatformFrontend: https://github.com/AceDataCloud/PlatformFrontend/pull/255

Each PR is independently safe to merge — sites that don't yet emit `user_id` simply don't trigger the guard, and sites that don't yet honor `user_id` ignore an unknown query param.

## Risks

Low. The guard is a no-op when `user_id` is absent, and our existing outbound URLs don't yet contain it (this PR adds that). So merging this alone has zero behavioral impact on production traffic until the AuthFrontend PR is also deployed (which is when other sites start emitting the param onto auth-bound URLs).

Native (Capacitor iOS/Android) flows are unaffected: `loginRedirect` already handles `native_redirect` upstream in the SSO chain.
