### PR TITLE
fix(chat): enlarge message action icons (copy/restart/edit) to 14px

### DIFF
--- a/src/components/chat/Message.vue
+++ b/src/components/chat/Message.vue
@@ -450,12 +450,12 @@ export default defineComponent({
   .operations {
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: 10px;
     margin-left: 4px;
-    margin-top: 2px;
+    margin-top: 4px;
     color: var(--el-text-color-placeholder);
     // Keep all action icons at the same size so they vertically align.
-    font-size: 12px;
+    font-size: 14px;
     .btn-edit {
       visibility: hidden;
     }


### PR DESCRIPTION
消息下方的复制 / 重新生成 / 编辑图标在 12px 时偏小、点起来容易戳不准。这里轻微放大到 14px，并把 `.operations` 容器的 `gap` 从 8px → 10px、`margin-top` 从 2px → 4px，让三个图标多一点呼吸感、和气泡之间也不那么贴。

## 改动

`src/components/chat/Message.vue`：

- `.operations`
  - `font-size: 12px` → `14px`（图标 / tooltip 触发区一起变大）
  - `gap: 8px` → `10px`
  - `margin-top: 2px` → `4px`

## 影响

- 仅影响聊天消息气泡下方的操作行（Copy / Restart / Edit），不影响其它地方使用的 `CopyToClipboard`（那些组件没在 `.operations` 容器内，font-size 不会被覆盖）。
- 桌面 / 移动端均生效。
