### PR TITLE
fix(theme): use clean white background for el-card in light mode

### DIFF
--- a/src/assets/scss/_common.scss
+++ b/src/assets/scss/_common.scss
@@ -236,7 +236,11 @@ w3m-modal {
   --el-card-padding: 20px;
   box-shadow: var(--app-shadow-sm);
   transition: box-shadow 0.25s ease, transform 0.25s ease;
-  background: var(--app-gradient-card);
+  // Use the standard Element Plus card background (white in light mode) so
+  // console panels (Applications / Orders / Top Up) read as clean white
+  // surfaces instead of being tinted by the brand gradient. The dark-mode
+  // override below restores the glass effect.
+  background: var(--el-card-bg-color);
   &:hover {
     box-shadow: var(--app-shadow-md);
   }


### PR DESCRIPTION
## 问题
`studio.acedata.cloud` 控制台页面（Applications / Orders / Top Up 等）所有 `el-card` 看起来都是脏脏、暗暗的灰青色，而不是干净的白色卡片。和 `platform.acedata.cloud` 的同类页面对比明显发暗。

## 根因
`src/assets/scss/_common.scss` 里全局给 `.el-card` 设了：

```scss
background: var(--app-gradient-card);
// 浅色模式：linear-gradient(135deg, rgba(39, 113, 134, 0.04), rgba(31, 90, 107, 0.02))
```

这个品牌色（`#277186` 青色）渐变铺在每张卡片上，于是浅色模式的卡片永远带一层青灰色调，叠加到 Element Plus 默认的页面灰底（`--el-bg-color-page: #f2f3f5`）上时，整个面板的对比就被拉平、整体观感发暗。

## 修复
浅色模式的卡片改回 Element Plus 默认的 `var(--el-card-bg-color)`（=`#ffffff` 干净白）。深色模式保留原本的 `html.dark .el-card` 玻璃效果（`var(--app-glass-bg)` + blur），不动。

```diff
-  background: var(--app-gradient-card);
+  background: var(--el-card-bg-color);
```

## 影响范围
- 影响所有 `el-card`（Console、Order、Application、Subscribe、Extra、其他用到 `el-card` 的组件）。
- 浅色模式：卡片变成干净白，与 PlatformFrontend 一致。
- 深色模式：行为不变（`html.dark .el-card` 在 64 行下面继续覆盖）。
- `--app-gradient-card` 变量仍保留在 `:root` / `html.dark` 里，便于以后想做渐变背景时复用。

## 验证
- `npx vite build` 通过。
- `npx vue-tsc --noEmit` 通过。
