### PR TITLE
fix(chat): swap DeepSeek logo to new clean asset

### DIFF
--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -30,7 +30,7 @@ export const CHAT_MODEL_NAME_GLM_4_7 = 'glm-4.7';
 
 export const CHAT_MODEL_ICON_CHATGPT = 'https://cdn.acedata.cloud/7dljuv.png';
 export const CHAT_MODEL_ICON_GROK = 'https://cdn.acedata.cloud/p1ge98.png';
-export const CHAT_MODEL_ICON_DEEPSEEK = 'https://cdn.acedata.cloud/bc71ae.png';
+export const CHAT_MODEL_ICON_DEEPSEEK = 'https://cdn.acedata.cloud/zv0360.jpg';
 export const CHAT_MODEL_ICON_GEMINI = 'https://cdn.acedata.cloud/psfx0g.jpg';
 export const CHAT_MODEL_ICON_CLAUDE = 'https://cdn.acedata.cloud/8fnw4v.jpg';
 export const CHAT_MODEL_ICON_KIMI = 'https://cdn.acedata.cloud/57ebgy.png';


### PR DESCRIPTION
将 DeepSeek 在 Nexior 中使用的 Logo 资源切换为更干净的新图：
`https://cdn.acedata.cloud/bc71ae.png` → `https://cdn.acedata.cloud/zv0360.jpg`

## 改动
- `src/constants/chat.ts`：更新 `CHAT_MODEL_ICON_DEEPSEEK` 常量

## 影响范围（无需逐处替换，DeepSeek logo 只此一处定义）
- `src/constants/chat.ts` 中所有 DeepSeek 模型条目（Standard 3.0 / R1 Reasoner / V3.2 Exp / 等）的 `icon`
- `src/components/common/Navigator.vue` 中导航栏的 DeepSeek 入口图标

## 验证
- `git grep "CHAT_MODEL_ICON_DEEPSEEK\|bc71ae"` 显示常量被 6 处引用，原 URL 已无残留。
