### PR TITLE
fix(theme): neutralize dark mode palette (drop deep navy cast)

### DIFF
--- a/src/assets/scss/_common.scss
+++ b/src/assets/scss/_common.scss
@@ -77,12 +77,19 @@ html.dark,
 }
 
 html.dark {
-  --el-color-primary-light-9: #1e1635;
-  --el-bg-color: #0f1117;
-  --el-bg-color-page: #0b0f17;
-  --el-card-bg-color: rgba(26, 29, 46, 0.8);
-  --app-bg-surface: #111427;
-  --app-bg-section: #0f1117;
+  // Neutral, GitHub-style dark palette. Previously the dark surfaces were
+  // strongly blue/purple-tinted (e.g. #111427 = rgb(17,20,39), where blue is
+  // ~20 points higher than red), which gave the whole app a "deep navy" cast.
+  // The brand colour is teal (#277186), so a slight cool undertone is fine,
+  // but we now use balanced cool-grays close to GitHub's dark canvas tokens
+  // (#0d1117 / #161b22) and keep the teal only as accent (`primary-light-9`,
+  // hero gradient, glows).
+  --el-color-primary-light-9: #0e2a33; // dark teal for code-block bg etc.
+  --el-bg-color: #0d1117;
+  --el-bg-color-page: #08090c;
+  --el-card-bg-color: #161b22;
+  --app-bg-surface: #161b22;
+  --app-bg-section: #0d1117;
   --app-border-subtle: rgba(255, 255, 255, 0.06);
   --app-badge-bg: rgba(39, 113, 134, 0.15);
   --app-badge-border: #277186;
@@ -94,16 +101,16 @@ html.dark {
   --app-shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.45), 0 4px 12px rgba(0, 0, 0, 0.3);
 
   /* Surface levels (dark) */
-  --app-nav-bg: #080a12;
-  --app-sidebar-bg: #0d0f1a;
-  --app-content-bg: #111427;
+  --app-nav-bg: #08090c;
+  --app-sidebar-bg: #0d1117;
+  --app-content-bg: #0d1117;
 
   /* Gradients (dark) */
   --app-gradient-card: linear-gradient(135deg, rgba(39, 113, 134, 0.06), rgba(31, 90, 107, 0.03));
   --app-gradient-subtle: linear-gradient(180deg, rgba(39, 113, 134, 0.05) 0%, transparent 100%);
 
-  /* Glass effect (dark) */
-  --app-glass-bg: rgba(17, 20, 39, 0.7);
+  /* Glass effect (dark) — matches surface, no blue-purple cast */
+  --app-glass-bg: rgba(22, 27, 34, 0.75);
   --app-glass-border: rgba(255, 255, 255, 0.06);
 
   /* Glow (dark - slightly stronger for visibility) */


### PR DESCRIPTION
## 问题
夜间模式整个站点（聊天页 https://studio.acedata.cloud/deepseek/conversations/... 、Console 卡片、Sidebar 等）有强烈的 **"深海军蓝/紫" 色调**，看起来不像现代深色主题，而像偏紫的低饱和蓝。

## 根因
`html.dark` 块里几个关键 surface 变量的蓝通道远高于红/绿，等于在每个表面上叠了一层蓝色滤镜：

| 变量 | 旧值 | RGB | 蓝-红差 |
|---|---|---|---|
| `--el-card-bg-color` | `rgba(26, 29, 46, 0.8)` | (26,29,**46**) | +20 |
| `--app-bg-surface` | `#111427` | (17,20,**39**) | +22 |
| `--app-content-bg` | `#111427` | (17,20,**39**) | +22 |
| `--app-glass-bg` | `rgba(17, 20, 39, 0.7)` | (17,20,**39**) | +22 |
| `--app-sidebar-bg` | `#0d0f1a` | (13,15,**26**) | +13 |
| `--el-color-primary-light-9` | `#1e1635` | (30,22,**53**) | 紫色 |

`--app-content-bg` 是聊天主区域 (Chat / Flux / Luma / Wan / ... 所有 layouts) 的背景。`--app-glass-bg` 是 `html.dark .el-card` 真正使用的卡片背景。所以这两个值决定了"夜间模式整体观感"。

## 改动
品牌色是 teal `#277186`，深色模式可以保留**轻微**冷调，但不能让蓝色这么压人。改成 GitHub-风格 (`#0d1117` / `#161b22`) 的中性冷灰，并把 `primary-light-9` 从紫色改成深 teal（与品牌一致）。

```diff
- --el-color-primary-light-9: #1e1635;     /* 紫 */
+ --el-color-primary-light-9: #0e2a33;     /* 深 teal */

- --el-bg-color: #0f1117;
+ --el-bg-color: #0d1117;
- --el-bg-color-page: #0b0f17;
+ --el-bg-color-page: #08090c;
- --el-card-bg-color: rgba(26, 29, 46, 0.8);
+ --el-card-bg-color: #161b22;
- --app-bg-surface: #111427;
+ --app-bg-surface: #161b22;
- --app-bg-section: #0f1117;
+ --app-bg-section: #0d1117;
- --app-nav-bg: #080a12;
+ --app-nav-bg: #08090c;
- --app-sidebar-bg: #0d0f1a;
+ --app-sidebar-bg: #0d1117;
- --app-content-bg: #111427;
+ --app-content-bg: #0d1117;
- --app-glass-bg: rgba(17, 20, 39, 0.7);
+ --app-glass-bg: rgba(22, 27, 34, 0.75);
```

层级（深→浅）：`--app-nav-bg` (#08090c) ≤ `page/sidebar/content` (#0d1117) ≤ `surface/card/glass` (#161b22 / rgba(22,27,34,.75))，跟 GitHub 的 canvas / canvas-overlay 思路一致。

只动 `html.dark`，**浅色模式完全不受影响**。

## 影响范围
- 聊天主区域（`Chat.vue`、`Flux/Luma/Wan/Pixverse/Qrart/Nanobanana/Seedance` 等所有 layouts，都消费 `--app-content-bg`）：从深海军变成中性深灰。
- 所有 `el-card`（夜间走 `--app-glass-bg` 玻璃效果）：变中性深灰玻璃，不再发紫蓝。
- Sidebar / Navigator / Console 表面：同样去蓝化。
- Markdown 代码块（`--el-color-primary-light-9`）：从偏紫变深 teal，跟品牌一致。
- Brand 色 `#277186` 自身、glow、按钮渐变都不变。

## 验证
- `vite build` ✅ 通过
- 直接 grep 编译后 css 确认：`--app-glass-bg: rgba(22, 27, 34, .75)`、`--app-content-bg: #0d1117`、`--el-color-primary-light-9: #0e2a33` 全部就位。
