### PR TITLE
style(chat): give user message bubble more breathing room

### DIFF
--- a/src/components/chat/Message.vue
+++ b/src/components/chat/Message.vue
@@ -421,8 +421,8 @@ export default defineComponent({
     }
   }
   .content {
-    border-radius: 16px;
-    padding: 10px 16px;
+    border-radius: 18px;
+    padding: 10px 20px;
     width: 100%;
     max-width: 800px;
     margin-bottom: 4px;


### PR DESCRIPTION
截图反馈：用户消息气泡的左右 padding 太挤，文字（尤其是中文标点）几乎贴在气泡边缘。

## 改动
`src/components/chat/Message.vue` 中 `.message .content`：
- `padding`: `10px 16px` → `10px 20px`（左右 +4px，更有呼吸感）
- `border-radius`: `16px` → `18px`（与略宽的 padding 协调）

## 影响
- 仅影响用户消息气泡（`.message.assistant .content` 已显式覆盖 `padding: 0`，AI 回复仍贴左、不缩进）。
- 编辑模式下的 `.edits` 自带 `padding: 0`，不受影响。
- 移动端断点未单独覆盖 padding，自动跟随。

## 验证
- 桌面 / 移动 端用户气泡左右间距更舒服，气泡仍保持 `width: fit-content; max-width: 85% / 90%`。
