### PR TITLE
feat(infra): add *.studio.acedata.cloud wildcard to studio ingress

### DIFF
--- a/deploy/production/studio-ingress.yaml
+++ b/deploy/production/studio-ingress.yaml
@@ -11,9 +11,20 @@ spec:
   tls:
     - hosts:
         - studio.acedata.cloud
+        - "*.studio.acedata.cloud"
       secretName: tls-wildcard-acedata-cloud
   rules:
     - host: studio.acedata.cloud
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: studio-frontend
+                port:
+                  number: 8085
+    - host: "*.studio.acedata.cloud"
       http:
         paths:
           - path: /


### PR DESCRIPTION
PR 2 of the **subsite (self-service white-label)** track. Routes any `<slug>.studio.acedata.cloud` host to the existing `studio-frontend` Service so that, once the per-origin Site config exists in PlatformBackend, the Nexior bundle renders the right brand.

Companion to PlatformBackend#382 (the backend gate is dormant and harmless without this PR; this PR is also dormant on its own — it just adds a route that no DB row currently matches).

## Diff

`deploy/production/studio-ingress.yaml`:

- Add `"*.studio.acedata.cloud"` to `spec.tls[0].hosts`
- Add a second `spec.rules[]` entry for `host: "*.studio.acedata.cloud"` pointing at the same `studio-frontend:8085` backend (the same trick `hub-frontend` ingress already uses for `*.hub.acedata.cloud`).

## Other infra pieces (not in this PR — already done)

- **DNS:** `*.studio` CNAME → `3poemroa3wpe.studio.acedata.cloud.eo.dnse1.com.` — added in DNSPod, propagated.
- **EdgeOne:** `*.studio.acedata.cloud` acceleration domain — created (zone `zone-35dwtsoy41g2`), currently `process` (DNS verification finishing).

## Pre-merge gate — TLS cert reissue

The TLS secret `tls-wildcard-acedata-cloud` is the same shared cert AutoCert renews for everything under `acedata.cloud`. Today its SAN list is:

```
*.acedata.cloud, *.app.acedata.cloud, *.cdn.acedata.cloud, *.hub.acedata.cloud,
*.mcp.acedata.cloud, *.platform.acedata.cloud, acedata.cloud
```

`*.acedata.cloud` is **single-label only** — it does NOT cover `foo.studio.acedata.cloud` (two labels). [AutoCert#8](https://github.com/AceDataCloud/AutoCert/pull/8) already added `*.studio.acedata.cloud` to the AutoCert profile and is **merged**, but the cert hasn't been re-issued yet.

**Before merging this PR**, manually trigger the AutoCert renew workflow:

```
gh workflow run renew.yaml --repo AceDataCloud/AutoCert
```

Verify after it finishes:

```
echo Q | openssl s_client -connect studio.acedata.cloud:443 \
  -servername studio.acedata.cloud 2>/dev/null \
  | openssl x509 -noout -ext subjectAltName \
  | grep -o '\*\.studio\.acedata\.cloud'
```

If the grep returns a hit, this PR is safe to merge.

## End-to-end verification post-deploy

```
curl -sIk https://nonexistent-test.studio.acedata.cloud/ | head -1
```

Should return `HTTP/2 200` (the same Nexior bundle as `studio.acedata.cloud`). The page itself will boot but won't have a registered Site yet, so PlatformBackend's `siteOperator.initialize` will create a default-feature row on first hit — exactly the behavior we want for subsites once PlatformBackend#382 lands and `features.subsite.enabled = true` is set on the parent `studio.acedata.cloud` Site.

## Roadmap

- [x] AutoCert#8 — add `*.studio.acedata.cloud` SAN
- [x] PlatformBackend#382 — backend subsite gating
- [x] **This PR — K8s wildcard host rule**
- [ ] Trigger AutoCert renew workflow
- [ ] PATCH `studio.acedata.cloud` Site `features.subsite.enabled = true` + set `subdomain_zone`
- [ ] Nexior PR — subsite management UI
- [ ] Nexior PR — per-origin branding consistency pass
