### PR TITLE
feat(subsite): add 'My Subsites' management UI

### DIFF
--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -527,6 +527,10 @@
     "message": "Site Configuration",
     "description": "Text in the website navigation bar to display the site configuration page"
   },
+  "nav.subsite": {
+    "message": "My Subsites",
+    "description": "Sidebar entry for the subsites manager, only shown when features.subsite is enabled on the parent site"
+  },
   "nav.setting": {
     "message": "Settings",
     "description": "Text in the website navigation bar to display the settings page"

--- a/src/i18n/en/subsite.json
+++ b/src/i18n/en/subsite.json
@@ -1,0 +1,90 @@
+{
+  "title.index": {
+    "message": "My Subsites",
+    "description": "Subsite list page title"
+  },
+  "title.create": {
+    "message": "Create a subsite",
+    "description": "Create-subsite dialog title"
+  },
+  "title.openNow": {
+    "message": "Open the new subsite",
+    "description": "After-create confirm dialog title"
+  },
+  "field.slug": {
+    "message": "Subdomain prefix",
+    "description": "slug input label"
+  },
+  "field.origin": {
+    "message": "Subsite hostname",
+    "description": "List column for the full origin"
+  },
+  "field.title": {
+    "message": "Title",
+    "description": "Subsite title column / field"
+  },
+  "field.createdAt": {
+    "message": "Created at",
+    "description": "List column for created_at"
+  },
+  "field.actions": {
+    "message": "Actions",
+    "description": "List actions column"
+  },
+  "placeholder.slug": {
+    "message": "e.g. my-brand",
+    "description": "slug input placeholder"
+  },
+  "placeholder.title": {
+    "message": "Shown in the browser tab and the subsite header",
+    "description": "title input placeholder"
+  },
+  "button.create": {
+    "message": "Create subsite",
+    "description": "Create button"
+  },
+  "button.open": {
+    "message": "Open",
+    "description": "Open subsite button"
+  },
+  "button.manage": {
+    "message": "Manage",
+    "description": "Enter subsite settings button"
+  },
+  "message.indexTip": {
+    "message": "Spin up a branded subsite under this parent — each one has its own logo, title, and feature set, no source-level deploy required.",
+    "description": "Index page subtitle"
+  },
+  "message.empty": {
+    "message": "You haven't created any subsites yet. Click \"Create subsite\" to get started.",
+    "description": "Empty list hint"
+  },
+  "message.slugTip": {
+    "message": "3-32 lowercase letters, digits, or hyphens; no leading/trailing hyphen, no consecutive hyphens.",
+    "description": "Slug field tip"
+  },
+  "message.slugInvalid": {
+    "message": "Subdomain prefix is not valid. Check the rules and try again.",
+    "description": "Client-side slug check failed"
+  },
+  "message.zoneMissing": {
+    "message": "This parent site has no subdomain zone configured. Contact the site administrator.",
+    "description": "subdomain_zone missing"
+  },
+  "message.created": {
+    "message": "Subsite created!",
+    "description": "Create success"
+  },
+  "message.createFailed": {
+    "message": "Failed to create subsite. Please try again.",
+    "description": "Create failed"
+  },
+  "message.loadFailed": {
+    "message": "Failed to load subsites.",
+    "description": "List load failed"
+  },
+  "message.openNowConfirm": {
+    "message": "Subsite {origin} has been created. Open it now to continue configuring?",
+    "description": "Confirm dialog after create"
+  }
+}

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -527,6 +527,10 @@
     "message": "站点配置",
     "description": "网站导航栏中的文本，用于显示站点配置页面"
   },
+  "nav.subsite": {
+    "message": "我的分站",
+    "description": "侧边栏“我的分站”入口，仅在站点开启 features.subsite 时显示"
+  },
   "nav.setting": {
     "message": "设置",
     "description": "网站导航栏中的文本，用于显示设置页面"

--- a/src/i18n/zh-CN/subsite.json
+++ b/src/i18n/zh-CN/subsite.json
@@ -1,0 +1,90 @@
+{
+  "title.index": {
+    "message": "我的分站",
+    "description": "分站管理首页大标题"
+  },
+  "title.create": {
+    "message": "创建分站",
+    "description": "新建分站对话框标题"
+  },
+  "title.openNow": {
+    "message": "立即访问分站",
+    "description": "新建成功后询问是否立即跳转的对话框标题"
+  },
+  "field.slug": {
+    "message": "子域名前缀",
+    "description": "分站 slug 输入框标题"
+  },
+  "field.origin": {
+    "message": "分站域名",
+    "description": "分站列表的域名列"
+  },
+  "field.title": {
+    "message": "分站标题",
+    "description": "分站标题字段"
+  },
+  "field.createdAt": {
+    "message": "创建时间",
+    "description": "分站创建时间列"
+  },
+  "field.actions": {
+    "message": "操作",
+    "description": "分站列表操作列"
+  },
+  "placeholder.slug": {
+    "message": "例如 my-brand",
+    "description": "slug 输入框占位符"
+  },
+  "placeholder.title": {
+    "message": "用于显示在分站浏览器标签和站点头部",
+    "description": "标题输入框占位符"
+  },
+  "button.create": {
+    "message": "创建分站",
+    "description": "创建分站按钮"
+  },
+  "button.open": {
+    "message": "打开",
+    "description": "打开分站按钮"
+  },
+  "button.manage": {
+    "message": "管理",
+    "description": "进入分站设置按钮"
+  },
+  "message.indexTip": {
+    "message": "在主站之下创建独立品牌的分站，每个分站可以拥有自己的 Logo、标题和功能集，不需要单独搭建源代码。",
+    "description": "分站管理首页说明文字"
+  },
+  "message.empty": {
+    "message": "你还没有创建任何分站。点击右上角“创建分站”开始。",
+    "description": "空列表提示"
+  },
+  "message.slugTip": {
+    "message": "3-32 位小写字母、数字或短横线；不能以短横线开头或结尾，也不能包含连续短横线。",
+    "description": "slug 字段说明"
+  },
+  "message.slugInvalid": {
+    "message": "子域名前缀格式不正确，请检查规则后重试。",
+    "description": "slug 校验失败"
+  },
+  "message.zoneMissing": {
+    "message": "当前主站未配置分站域名区，请联系站点管理员。",
+    "description": "subdomain_zone 缺失"
+  },
+  "message.created": {
+    "message": "分站创建成功！",
+    "description": "创建成功"
+  },
+  "message.createFailed": {
+    "message": "创建分站失败，请稍后重试。",
+    "description": "创建失败"
+  },
+  "message.loadFailed": {
+    "message": "加载分站列表失败。",
+    "description": "拉列表失败"
+  },
+  "message.openNowConfirm": {
+    "message": "分站 {origin} 已创建。是否现在打开它继续配置？",
+    "description": "创建后是否立即打开"
+  }
+}

--- a/src/models/site.ts
+++ b/src/models/site.ts
@@ -25,6 +25,13 @@ export interface ISiteFeatures {
   kimi?: any;
   serp?: any;
   support?: any;
+  subsite?: ISiteSubsiteFeature;
+}
+
+export interface ISiteSubsiteFeature {
+  enabled?: boolean;
+  max_subsites_per_user?: number;
+  subdomain_zone?: string;
 }
 
 export interface ISiteDistribution {

--- a/src/operators/site.ts
+++ b/src/operators/site.ts
@@ -4,6 +4,7 @@ import { ISite, ISiteDetailResponse, ISiteListResponse } from '@/models';
 
 export interface ISiteQuery {
   origin?: string;
+  user_id?: string;
   offset?: number;
   limit?: number;
 }

--- a/src/pages/profile/Index.vue
+++ b/src/pages/profile/Index.vue
@@ -37,7 +37,8 @@ import {
   ROUTE_CONSOLE_USAGE_LIST,
   ROUTE_DISTRIBUTION_INDEX,
   ROUTE_INDEX,
-  ROUTE_SITE_INDEX
+  ROUTE_SITE_INDEX,
+  ROUTE_SUBSITE_INDEX
 } from '@/router';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { getBaseUrlAuth, getBaseUrlPlatform, withCurrentUserId } from '@/utils';
@@ -82,6 +83,13 @@ export default defineComponent({
     showSite() {
       return this.$store?.state?.site?.admins?.includes(this.$store.getters.user?.id);
     },
+    showSubsite() {
+      // Show the "my subsites" entry only when the current parent site has
+      // explicitly opted into the subsite (white-label) feature. This is
+      // gated server-side too — the menu link just hides UI noise on sites
+      // that haven't enabled it.
+      return Boolean(this.$store?.state?.site?.features?.subsite?.enabled);
+    },
     links(): ILink[] {
       let links: ILink[] = [
         {
@@ -121,6 +129,16 @@ export default defineComponent({
                 text: this.$t('common.nav.site'),
                 name: ROUTE_SITE_INDEX,
                 icon: 'fa-solid fa-gear'
+              }
+            ]
+          : []),
+        ...(this.showSubsite
+          ? [
+              {
+                key: 'subsite-index',
+                text: this.$t('common.nav.subsite'),
+                name: ROUTE_SUBSITE_INDEX,
+                icon: 'fa-solid fa-sitemap'
               }
             ]
           : []),

--- a/src/pages/subsite/Index.vue
+++ b/src/pages/subsite/Index.vue
@@ -1,0 +1,324 @@
+<template>
+  <el-row class="panel">
+    <el-col :span="24">
+      <el-row class="header" justify="space-between" align="middle">
+        <el-col :md="16" :xs="24">
+          <h2 class="title">{{ $t('subsite.title.index') }}</h2>
+          <p class="tip">{{ $t('subsite.message.indexTip') }}</p>
+        </el-col>
+        <el-col :md="8" :xs="24" class="header-actions">
+          <el-button type="primary" round :icon="Plus" :disabled="!canCreate" @click="onOpenCreate">
+            {{ $t('subsite.button.create') }}
+          </el-button>
+        </el-col>
+      </el-row>
+
+      <el-card v-loading="loading" shadow="hover" class="list-card">
+        <el-empty v-if="!loading && items.length === 0" :description="$t('subsite.message.empty')" />
+        <el-table v-else :data="items" stripe>
+          <el-table-column :label="$t('subsite.field.origin')" prop="origin">
+            <template #default="{ row }">
+              <a :href="rowUrl(row)" target="_blank" rel="noopener" class="origin-link">
+                {{ row.origin }}
+              </a>
+            </template>
+          </el-table-column>
+          <el-table-column :label="$t('subsite.field.title')" prop="title">
+            <template #default="{ row }">
+              <span>{{ row.title || '-' }}</span>
+            </template>
+          </el-table-column>
+          <el-table-column :label="$t('subsite.field.createdAt')" prop="created_at" width="180">
+            <template #default="{ row }">
+              <span>{{ formatDate(row.created_at) }}</span>
+            </template>
+          </el-table-column>
+          <el-table-column :label="$t('subsite.field.actions')" width="160" fixed="right">
+            <template #default="{ row }">
+              <el-button size="small" link type="primary" @click="onOpenSite(row)">
+                {{ $t('subsite.button.open') }}
+              </el-button>
+              <el-button size="small" link type="primary" @click="onManageSite(row)">
+                {{ $t('subsite.button.manage') }}
+              </el-button>
+            </template>
+          </el-table-column>
+        </el-table>
+      </el-card>
+    </el-col>
+
+    <el-dialog v-model="creating.visible" :title="$t('subsite.title.create')" width="480px" class="create-dialog">
+      <el-form :model="creating.form" label-width="auto" class="form" @submit.prevent>
+        <el-form-item :label="$t('subsite.field.slug')" required>
+          <el-input
+            v-model="creating.form.slug"
+            :placeholder="$t('subsite.placeholder.slug')"
+            maxlength="32"
+            show-word-limit
+            autofocus
+          >
+            <template #append>.{{ subdomainZone }}</template>
+          </el-input>
+          <span class="tip">{{ $t('subsite.message.slugTip') }}</span>
+        </el-form-item>
+        <el-form-item :label="$t('subsite.field.title')">
+          <el-input v-model="creating.form.title" :placeholder="$t('subsite.placeholder.title')" maxlength="80" />
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <span>
+          <el-button round @click="onCancelCreate">{{ $t('common.button.cancel') }}</el-button>
+          <el-button
+            round
+            type="primary"
+            :loading="creating.submitting"
+            :disabled="!creating.form.slug.trim()"
+            @click="onSubmitCreate"
+          >
+            {{ $t('common.button.confirm') }}
+          </el-button>
+        </span>
+      </template>
+    </el-dialog>
+  </el-row>
+</template>
+
+<script lang="ts">
+import { defineComponent, markRaw } from 'vue';
+import {
+  ElRow,
+  ElCol,
+  ElCard,
+  ElButton,
+  ElTable,
+  ElTableColumn,
+  ElEmpty,
+  ElDialog,
+  ElForm,
+  ElFormItem,
+  ElInput,
+  ElMessage,
+  ElMessageBox
+} from 'element-plus';
+import { Plus } from '@element-plus/icons-vue';
+import { siteOperator } from '@/operators';
+import type { ISite } from '@/models';
+
+const SLUG_RE = /^(?!.*--)[a-z0-9][a-z0-9-]{1,30}[a-z0-9]$/;
+
+export default defineComponent({
+  name: 'SubsiteIndex',
+  components: {
+    ElRow,
+    ElCol,
+    ElCard,
+    ElButton,
+    ElTable,
+    ElTableColumn,
+    ElEmpty,
+    ElDialog,
+    ElForm,
+    ElFormItem,
+    ElInput
+  },
+  data() {
+    return {
+      Plus: markRaw(Plus),
+      loading: false,
+      items: [] as ISite[],
+      creating: {
+        visible: false,
+        submitting: false,
+        form: {
+          slug: '',
+          title: ''
+        }
+      }
+    };
+  },
+  computed: {
+    parentSite(): ISite | undefined {
+      return this.$store.state.site;
+    },
+    user() {
+      return this.$store.getters.user;
+    },
+    subdomainZone(): string {
+      const zone = this.parentSite?.features?.subsite?.subdomain_zone;
+      return zone || this.parentSite?.origin || '';
+    },
+    maxSubsitesPerUser(): number {
+      const max = this.parentSite?.features?.subsite?.max_subsites_per_user;
+      return typeof max === 'number' && max > 0 ? max : 5;
+    },
+    canCreate(): boolean {
+      return (
+        Boolean(this.parentSite?.features?.subsite?.enabled) &&
+        Boolean(this.subdomainZone) &&
+        Boolean(this.user?.id) &&
+        this.items.length < this.maxSubsitesPerUser
+      );
+    }
+  },
+  mounted() {
+    if (!this.parentSite?.features?.subsite?.enabled) {
+      // Server-side check is the source of truth, but bail out here to avoid
+      // a 403 storm on origins that haven't opted in.
+      this.$router.replace('/');
+      return;
+    }
+    this.fetchSubsites();
+  },
+  methods: {
+    async fetchSubsites() {
+      const userId = this.user?.id;
+      if (!userId) {
+        this.items = [];
+        return;
+      }
+      this.loading = true;
+      try {
+        const { data } = await siteOperator.getAll({ user_id: userId });
+        const all = (data?.items || []) as ISite[];
+        const parentId = this.parentSite?.id;
+        // Backend filters by user_id; we further restrict to children of the
+        // current parent so a single user creating subsites under multiple
+        // parent sites still sees the right subset on each.
+        this.items = all.filter((s) => {
+          if (s.id === parentId) return false;
+          const meta = (s.metadata || {}) as Record<string, unknown>;
+          if (parentId && meta.parent_site_id) return meta.parent_site_id === parentId;
+          // Fallback for older subsites without parent_site_id metadata: match
+          // by suffix under the configured subdomain zone.
+          return Boolean(s.origin && this.subdomainZone && s.origin.endsWith(`.${this.subdomainZone}`));
+        });
+      } catch (e) {
+        console.error('failed to load subsites', e);
+        ElMessage.error(this.$t('subsite.message.loadFailed'));
+      } finally {
+        this.loading = false;
+      }
+    },
+    onOpenCreate() {
+      this.creating.form.slug = '';
+      this.creating.form.title = '';
+      this.creating.visible = true;
+    },
+    onCancelCreate() {
+      this.creating.visible = false;
+    },
+    async onSubmitCreate() {
+      const slug = this.creating.form.slug.trim().toLowerCase();
+      if (!SLUG_RE.test(slug)) {
+        ElMessage.warning(this.$t('subsite.message.slugInvalid'));
+        return;
+      }
+      if (!this.subdomainZone) {
+        ElMessage.error(this.$t('subsite.message.zoneMissing'));
+        return;
+      }
+      const origin = `${slug}.${this.subdomainZone}`;
+      this.creating.submitting = true;
+      try {
+        const { data } = await siteOperator.create({
+          origin,
+          title: this.creating.form.title.trim() || undefined
+        });
+        ElMessage.success(this.$t('subsite.message.created'));
+        this.creating.visible = false;
+        this.items = [data, ...this.items];
+        // Offer to jump straight to the new subsite so the user can finish
+        // branding and feature toggles there.
+        ElMessageBox.confirm(
+          this.$t('subsite.message.openNowConfirm', { origin }) as string,
+          this.$t('subsite.title.openNow') as string,
+          {
+            confirmButtonText: this.$t('subsite.button.open') as string,
+            cancelButtonText: this.$t('common.button.cancel') as string,
+            type: 'success'
+          }
+        )
+          .then(() => window.open(`https://${origin}/`, '_blank', 'noopener'))
+          .catch(() => {
+            /* user dismissed */
+          });
+      } catch (e: any) {
+        const detail = e?.response?.data?.origin || e?.response?.data?.detail || e?.message;
+        ElMessage.error(typeof detail === 'string' ? detail : this.$t('subsite.message.createFailed'));
+      } finally {
+        this.creating.submitting = false;
+      }
+    },
+    onOpenSite(row: ISite) {
+      if (!row.origin) return;
+      window.open(`https://${row.origin}/`, '_blank', 'noopener');
+    },
+    onManageSite(row: ISite) {
+      if (!row.origin) return;
+      // Each subsite is the source of truth for its own settings; deep-link to
+      // /site on the subsite itself instead of trying to manage cross-origin.
+      window.open(`https://${row.origin}/site`, '_blank', 'noopener');
+    },
+    rowUrl(row: ISite) {
+      return row.origin ? `https://${row.origin}/` : '#';
+    },
+    formatDate(value?: string) {
+      if (!value) return '-';
+      try {
+        return new Date(value).toLocaleString();
+      } catch {
+        return value;
+      }
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.panel {
+  padding: 30px;
+  background-color: var(--el-bg-color-page);
+  overflow-y: auto;
+
+  h2.title {
+    font-size: 26px;
+    font-weight: bold;
+    margin-bottom: 6px;
+    color: var(--el-text-color-primary);
+  }
+
+  .tip {
+    color: var(--el-text-color-secondary);
+    font-size: 13px;
+    margin: 0 0 16px 0;
+  }
+
+  .header-actions {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    margin-bottom: 16px;
+  }
+
+  .list-card {
+    margin-top: 12px;
+  }
+
+  .origin-link {
+    color: var(--el-color-primary);
+    text-decoration: none;
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  .form {
+    .tip {
+      display: block;
+      color: var(--el-text-color-secondary);
+      font-size: 12px;
+      margin-top: 4px;
+    }
+  }
+}
+</style>

--- a/src/plugins/font-awesome.ts
+++ b/src/plugins/font-awesome.ts
@@ -62,6 +62,7 @@ import {
   faPalette as faSolidPalette,
   faBars as faSolidBars,
   faGear as faSolidGear,
+  faSitemap as faSolidSitemap,
   faMugSaucer as faSolidMugSaucer,
   faRotateRight as faSolidRotateRight,
   faCheck as faSolidCheck,
@@ -172,6 +173,7 @@ library.add(faSolidMoon);
 library.add(faSolidBolt);
 library.add(faSolidBook);
 library.add(faSolidGear);
+library.add(faSolidSitemap);
 library.add(faSolidMicrophone);
 library.add(faSolidBars);
 library.add(faSolidPlus);

--- a/src/router/constants.ts
+++ b/src/router/constants.ts
@@ -5,6 +5,7 @@ export const ROUTE_AUTH_LOGIN = 'auth-login';
 export const ROUTE_AUTH_CALLBACK = 'auth-callback';
 
 export const ROUTE_SITE_INDEX = 'site-index';
+export const ROUTE_SUBSITE_INDEX = 'subsite-index';
 
 export const ROUTE_CHATGPT_CONVERSATION = 'chatgpt-conversation';
 export const ROUTE_CHATGPT_CONVERSATION_NEW = 'chatgpt-conversation-new';

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -30,6 +30,7 @@ import seedance from './seedance';
 import serp from './serp';
 import wan from './wan';
 import site from './site';
+import subsite from './subsite';
 import profile from './profile';
 
 import {
@@ -314,6 +315,7 @@ const routes = [
   distribution,
   download,
   site,
+  subsite,
   profile,
   {
     path: '/:pathMatch(.*)*',

--- a/src/router/subsite.ts
+++ b/src/router/subsite.ts
@@ -1,0 +1,13 @@
+import { ROUTE_SUBSITE_INDEX } from './constants';
+
+export default {
+  path: '/subsite',
+  component: () => import('@/layouts/Main.vue'),
+  children: [
+    {
+      path: '',
+      name: ROUTE_SUBSITE_INDEX,
+      component: () => import('@/pages/subsite/Index.vue')
+    }
+  ]
+};


### PR DESCRIPTION
PR 3 of the **subsite (self-service white-label)** track. Consumer of [PlatformBackend#382](https://github.com/AceDataCloud/PlatformBackend/pull/382) (already merged) and [Nexior#550](https://github.com/AceDataCloud/Nexior/pull/550) (already merged + deployed).

## What this adds

A new sidebar entry **"My Subsites"** on the profile menu — gated entirely on the current parent Site's `features.subsite.enabled` flag, so it stays invisible on origins that haven't opted in.

When clicked, it opens `/subsite` which:

1. Lists the current user's subsites (calls `GET /api/v1/sites/?user_id=<me>`, then locally filters to children of the current parent via `metadata.parent_site_id`).
2. Provides a **Create subsite** dialog: slug + optional title.
3. On submit, calls `POST /api/v1/sites/` with `{ origin: "<slug>.<subdomain_zone>", title }`; the backend enforces ownership, slug rules, and the per-user quota.
4. Offers to jump straight to the brand-new subsite so the user can finish branding/feature toggles there (each subsite is the source of truth for its own settings — same `Site.vue` UI, just under a different origin).

## Files

| File | Change |
|---|---|
| `src/pages/subsite/Index.vue` | New page (table + create dialog) |
| `src/router/subsite.ts` + `router/constants.ts` + `router/index.ts` | Register `/subsite` route under `Main.vue` layout |
| `src/pages/profile/Index.vue` | Add `showSubsite` computed + menu entry |
| `src/models/site.ts` | Add `ISiteSubsiteFeature` to `ISiteFeatures.subsite` |
| `src/operators/site.ts` | `ISiteQuery.user_id?: string` (used by the list call) |
| `src/plugins/font-awesome.ts` | Register `faSitemap` (menu icon) |
| `src/i18n/{zh-CN,en}/subsite.json` | New namespace |
| `src/i18n/{zh-CN,en}/common.json` | `common.nav.subsite` |

Per AGENTS.md, locales are zh-CN and en only — no `yarn translate`.

## Client-side slug check

The dialog runs the same regex the backend enforces (`/^(?!.*--)[a-z0-9][a-z0-9-]{1,30}[a-z0-9]$/`) so users see invalid slugs immediately instead of waiting for a 400. The backend's reserved-slug list is still the source of truth — when it rejects `support`/`admin`/etc. the page surfaces the server message verbatim in the toast.

## Activation

This UI is dormant on every origin until an admin sets `features.subsite.enabled=true` and `features.subsite.subdomain_zone="studio.acedata.cloud"` on the parent Site (already done for `studio.acedata.cloud`).

## Verification

- `yarn lint` clean (the only warnings are pre-existing in `Composer.vue` / `NotFound.vue`, untouched by this PR)
- `yarn build` passes (vue-tsc + vite, ~14s)
- Manually walked the click path against the live backend with the studio.acedata.cloud Site having `features.subsite.enabled=true`:
  - Empty list renders correctly
  - Slug client-side validation rejects `ab`, `Foo--bar`, `-leading`, etc.
  - 201 path creates a subsite + offers "Open now"
  - Reserved slug 400 surfaces the backend's `origin: "slug 'support' is reserved"` message in the toast

## Roadmap

- [x] AutoCert#8 — `*.studio.acedata.cloud` SAN
- [x] PlatformBackend#382 — backend subsite gating
- [x] Nexior#550 — wildcard ingress
- [x] AutoCert renew + Site `features.subsite.enabled=true` on `studio.acedata.cloud`
- [x] **This PR — subsite management UI**
- [ ] Nexior PR — per-origin branding consistency pass (default logo / title from `Site.title` / `Site.logo` everywhere — currently a few spots still hardcode `'Ace Data Cloud'`)
- [ ] PlatformBackend PR — subsite distribution / commission flow (so subsite owners earn from API usage on their subsite)
- [ ] PlatformBackend PR — Phase 2 custom-domain (`mybrand.com`) automation against EO `CreateAccelerationDomain`
- [ ] Nexior PR — custom-domain UI
