### PR TITLE
feat(subsite): Phase 2 - custom-domain UI (binding wizard + status panel)

### DIFF
--- a/src/i18n/en/subsite.json
+++ b/src/i18n/en/subsite.json
@@ -86,5 +86,125 @@
   "message.openNowConfirm": {
     "message": "Subsite {origin} has been created. Would you like to open it now to continue configuration?",
     "description": "Asks if the user wants to open immediately after creation"
+  },
+  "title.domains": {
+    "message": "Custom domains for {origin}",
+    "description": "Domain manager dialog title"
+  },
+  "title.bindDomain": {
+    "message": "Bind a new domain",
+    "description": "Bind form heading"
+  },
+  "button.domains": {
+    "message": "Domains",
+    "description": "Open the per-subsite domain manager dialog"
+  },
+  "button.bindDomain": {
+    "message": "Bind domain",
+    "description": "Submit the bind form"
+  },
+  "button.verify": {
+    "message": "Verify",
+    "description": "Check the TXT challenge and advance state"
+  },
+  "button.checkProgress": {
+    "message": "Check progress",
+    "description": "Re-sync state from EdgeOne"
+  },
+  "button.refresh": {
+    "message": "Refresh",
+    "description": "Reload row state"
+  },
+  "field.hostname": {
+    "message": "Your hostname",
+    "description": "hostname input label"
+  },
+  "field.recordType": {
+    "message": "Record type",
+    "description": "DNS record type column"
+  },
+  "field.recordName": {
+    "message": "Record name",
+    "description": "DNS record name column"
+  },
+  "field.recordValue": {
+    "message": "Record value",
+    "description": "DNS record value column"
+  },
+  "placeholder.hostname": {
+    "message": "e.g. studio.mybrand.com",
+    "description": "hostname input placeholder"
+  },
+  "message.domainsIntro": {
+    "message": "Bind a hostname you own to this subsite. You'll need to control its DNS. Once verified, EdgeOne automatically issues a free HTTPS certificate and starts serving traffic.",
+    "description": "Top-of-dialog explainer"
+  },
+  "message.domainsEmpty": {
+    "message": "No custom domains bound yet. Fill in the hostname below and click Bind to start.",
+    "description": "Empty list hint"
+  },
+  "message.hostnameTip": {
+    "message": "Must be a public DNS-resolvable hostname under a domain you control. acedata.cloud / surl.id subdomains are not allowed.",
+    "description": "hostname input tip"
+  },
+  "message.hostnameInvalid": {
+    "message": "Invalid hostname. Must be a public domain (no IPs, no scheme).",
+    "description": "Client-side validation failure"
+  },
+  "message.domainCreated": {
+    "message": "Domain submitted. Add the DNS record below to verify ownership.",
+    "description": "POST /site-domains/ success"
+  },
+  "message.domainCreateFailed": {
+    "message": "Failed to create the domain. Please try again.",
+    "description": "Create failure fallback"
+  },
+  "message.domainsLoadFailed": {
+    "message": "Failed to load domain list.",
+    "description": "List load failed"
+  },
+  "message.domainProgressed": {
+    "message": "Verification advanced - hold tight while we finish provisioning.",
+    "description": "State machine progressed"
+  },
+  "message.domainActive": {
+    "message": "Domain is live! Your subsite is now reachable over your custom HTTPS hostname.",
+    "description": "Reached Active"
+  },
+  "message.domainFailed": {
+    "message": "Domain verification or provisioning failed.",
+    "description": "Failed fallback message"
+  },
+  "message.domainVerifyFailed": {
+    "message": "Verification failed. Check that the DNS record has propagated.",
+    "description": "verify endpoint 4xx"
+  },
+  "message.domainDeleteConfirm": {
+    "message": "Unbind {hostname}? After unbinding, users will no longer reach your subsite at this hostname.",
+    "description": "Delete confirm dialog"
+  },
+  "message.domainDeleteFailed": {
+    "message": "Failed to unbind the domain.",
+    "description": "DELETE endpoint failure"
+  },
+  "status.pendingDnsVerification": {
+    "message": "Awaiting DNS",
+    "description": "PendingDnsVerification tag"
+  },
+  "status.provisioningEo": {
+    "message": "Provisioning edge",
+    "description": "ProvisioningEo tag"
+  },
+  "status.provisioningCert": {
+    "message": "Issuing cert",
+    "description": "ProvisioningCert tag"
+  },
+  "status.active": {
+    "message": "Active",
+    "description": "Active tag"
+  },
+  "status.failed": {
+    "message": "Failed",
+    "description": "Failed tag"
   }
 }

--- a/src/i18n/zh-CN/subsite.json
+++ b/src/i18n/zh-CN/subsite.json
@@ -86,5 +86,125 @@
   "message.openNowConfirm": {
     "message": "分站 {origin} 已创建。是否现在打开它继续配置？",
     "description": "创建后是否立即打开"
+  },
+  "title.domains": {
+    "message": "{origin} 的自定义域名",
+    "description": "自定义域名对话框标题"
+  },
+  "title.bindDomain": {
+    "message": "绑定新域名",
+    "description": "绑定表单标题"
+  },
+  "button.domains": {
+    "message": "域名",
+    "description": "打开域名管理对话框的按钮"
+  },
+  "button.bindDomain": {
+    "message": "绑定域名",
+    "description": "提交绑定新域名"
+  },
+  "button.verify": {
+    "message": "验证",
+    "description": "检查 TXT 验证记录是否到位"
+  },
+  "button.checkProgress": {
+    "message": "检查进度",
+    "description": "从 EdgeOne 同步最新状态"
+  },
+  "button.refresh": {
+    "message": "刷新",
+    "description": "重新拉取该域名的状态"
+  },
+  "field.hostname": {
+    "message": "你的域名",
+    "description": "输入你拥有的域名或子域名"
+  },
+  "field.recordType": {
+    "message": "记录类型",
+    "description": "DNS 记录类型列"
+  },
+  "field.recordName": {
+    "message": "记录名称",
+    "description": "DNS 记录名称列"
+  },
+  "field.recordValue": {
+    "message": "记录值",
+    "description": "DNS 记录值列"
+  },
+  "placeholder.hostname": {
+    "message": "例如 studio.mybrand.com",
+    "description": "hostname 输入框占位符"
+  },
+  "message.domainsIntro": {
+    "message": "将你拥有的域名绑定到该分站。你需要能修改该域名的 DNS。验证通过后我们会自动为你申请免费 HTTPS 证书并在 EdgeOne 上部署。",
+    "description": "对话框顶部说明"
+  },
+  "message.domainsEmpty": {
+    "message": "暂未绑定任何自定义域名。在下方表单中填写完整域名并点击“绑定”即可开始。",
+    "description": "空列表提示"
+  },
+  "message.hostnameTip": {
+    "message": "需是你能控制 DNS 的公网域名。不允许 acedata.cloud / surl.id 的任何子域名。",
+    "description": "hostname 输入提示"
+  },
+  "message.hostnameInvalid": {
+    "message": "域名格式不正确。必须是公网可解析的域名，不允许 IP 地址。",
+    "description": "hostname 本地校验失败"
+  },
+  "message.domainCreated": {
+    "message": "域名已提交，请按提示添加 DNS 记录。",
+    "description": "POST /site-domains/ 成功"
+  },
+  "message.domainCreateFailed": {
+    "message": "创建域名失败，请稍后重试。",
+    "description": "创建失败兑底"
+  },
+  "message.domainsLoadFailed": {
+    "message": "加载域名列表失败。",
+    "description": "拉域名列表失败"
+  },
+  "message.domainProgressed": {
+    "message": "验证进入下一阶段，请耐心等待。",
+    "description": "状态机推进"
+  },
+  "message.domainActive": {
+    "message": "域名已上线！现在可以通过你的自定义 HTTPS 地址访问分站。",
+    "description": "进入 Active 状态"
+  },
+  "message.domainFailed": {
+    "message": "域名验证或上线失败。",
+    "description": "Failed 状态兑底文案"
+  },
+  "message.domainVerifyFailed": {
+    "message": "验证失败，请检查 DNS 记录是否已生效。",
+    "description": "verify 接口 4xx"
+  },
+  "message.domainDeleteConfirm": {
+    "message": "确定要解绑 {hostname} 吗？解绑后用户将无法从该域名访问你的分站。",
+    "description": "删除确认"
+  },
+  "message.domainDeleteFailed": {
+    "message": "删除域名失败。",
+    "description": "DELETE 接口 5xx"
+  },
+  "status.pendingDnsVerification": {
+    "message": "待验证 DNS",
+    "description": "PendingDnsVerification 状态标签"
+  },
+  "status.provisioningEo": {
+    "message": "接入边缘中",
+    "description": "ProvisioningEo 状态标签"
+  },
+  "status.provisioningCert": {
+    "message": "申请证书中",
+    "description": "ProvisioningCert 状态标签"
+  },
+  "status.active": {
+    "message": "已上线",
+    "description": "Active 状态标签"
+  },
+  "status.failed": {
+    "message": "失败",
+    "description": "Failed 状态标签"
   }
 }

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -29,6 +29,7 @@ export * from './seedance';
 export * from './serp';
 export * from './wan';
 export * from './site';
+export * from './site_domain';
 export * from './exchange';
 export * from './error';
 export * from './config';

--- a/src/models/site_domain.ts
+++ b/src/models/site_domain.ts
@@ -1,0 +1,55 @@
+/**
+ * Custom (BYO) domain model — mirrors PlatformBackend's SiteDomain row.
+ *
+ * Each ISiteDomain represents one tenant-owned hostname (e.g.
+ * "studio.mybrand.com") that has been bound to a parent ISite. Phase 1
+ * uses subdomains under <subdomain_zone>; Phase 2 (this model) lets the
+ * tenant CNAME their own apex/sub from a registrar they control.
+ *
+ * The `status` field walks a small DAG; see `SiteDomainStatus` below.
+ * `dns_instructions` is a UI-friendly hint the backend appends to the
+ * GET / verify response so the page doesn't have to re-derive the TXT
+ * or CNAME copy itself.
+ */
+
+export enum SiteDomainStatus {
+  PendingDnsVerification = 'PendingDnsVerification',
+  ProvisioningEo = 'ProvisioningEo',
+  ProvisioningCert = 'ProvisioningCert',
+  Active = 'Active',
+  Failed = 'Failed'
+}
+
+export interface ISiteDomainDnsInstructions {
+  step: 'txt' | 'cname';
+  record_name: string;
+  record_type: 'TXT' | 'CNAME';
+  record_value: string;
+  instructions: string;
+}
+
+export interface ISiteDomain {
+  id?: string;
+  site?: string;
+  hostname?: string;
+  status?: SiteDomainStatus;
+  status_reason?: string | null;
+  verification_token?: string;
+  eo_zone_id?: string | null;
+  eo_cname?: string | null;
+  user_id?: string | null;
+  created_at?: string;
+  updated_at?: string;
+  last_synced_at?: string | null;
+  tags?: string[];
+  metadata?: Record<string, unknown> | null;
+  // Server-appended hint, only present on detail / verify responses.
+  dns_instructions?: ISiteDomainDnsInstructions | null;
+}
+
+export interface ISiteDomainListResponse {
+  count: number;
+  items: ISiteDomain[];
+}
+
+export type ISiteDomainDetailResponse = ISiteDomain;

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -21,6 +21,7 @@ export * from './flux';
 export * from './hailuo';
 export * from './headshots';
 export * from './site';
+export * from './site_domain';
 export * from './suno';
 export * from './producer';
 export * from './exchange';

--- a/src/operators/site_domain.ts
+++ b/src/operators/site_domain.ts
@@ -1,0 +1,40 @@
+import { AxiosResponse } from 'axios';
+import { httpClient } from './common';
+import { ISiteDomain, ISiteDomainDetailResponse, ISiteDomainListResponse } from '@/models';
+
+export interface ISiteDomainQuery {
+  site?: string;
+  status?: string;
+  hostname?: string;
+  user_id?: string;
+  offset?: number;
+  limit?: number;
+}
+
+class SiteDomainService {
+  key = 'site-domains';
+
+  async getAll(query: ISiteDomainQuery = {}): Promise<AxiosResponse<ISiteDomainListResponse>> {
+    return await httpClient.get(`/${this.key}/`, { params: query });
+  }
+
+  async get(id: string): Promise<AxiosResponse<ISiteDomainDetailResponse>> {
+    return await httpClient.get(`/${this.key}/${id}`);
+  }
+
+  async create(data: { site: string; hostname: string }): Promise<AxiosResponse<ISiteDomainDetailResponse>> {
+    return await httpClient.post(`/${this.key}/`, data);
+  }
+
+  async verify(id: string): Promise<AxiosResponse<ISiteDomainDetailResponse>> {
+    return await httpClient.post(`/${this.key}/${id}/verify/`);
+  }
+
+  async delete(id: string): Promise<AxiosResponse<void>> {
+    return await httpClient.delete(`/${this.key}/${id}`);
+  }
+}
+
+export const siteDomainOperator = new SiteDomainService();
+
+export type { ISiteDomain };

--- a/src/pages/subsite/DomainsDialog.vue
+++ b/src/pages/subsite/DomainsDialog.vue
@@ -1,0 +1,397 @@
+<template>
+  <el-dialog
+    :model-value="modelValue"
+    :title="$t('subsite.title.domains', { origin: site?.origin || '' })"
+    width="640px"
+    class="domains-dialog"
+    @update:model-value="$emit('update:modelValue', $event)"
+  >
+    <div v-loading="loading" class="domains-body">
+      <p class="tip">{{ $t('subsite.message.domainsIntro') }}</p>
+
+      <el-empty v-if="!loading && domains.length === 0" :description="$t('subsite.message.domainsEmpty')" />
+
+      <div v-for="d in domains" :key="d.id" class="domain-row">
+        <div class="domain-row-head">
+          <strong class="hostname">{{ d.hostname }}</strong>
+          <el-tag :type="statusTagType(d.status)" size="small" class="status-tag">
+            {{ statusLabel(d.status) }}
+          </el-tag>
+          <span class="row-actions">
+            <el-button
+              v-if="canVerify(d)"
+              size="small"
+              type="primary"
+              :loading="busyId === d.id"
+              link
+              @click="onVerify(d)"
+            >
+              {{ verifyButtonLabel(d.status) }}
+            </el-button>
+            <el-button v-if="d.status !== 'Active'" size="small" link :loading="busyId === d.id" @click="onRefresh(d)">
+              {{ $t('subsite.button.refresh') }}
+            </el-button>
+            <el-button size="small" link type="danger" :loading="busyId === d.id" @click="onDelete(d)">
+              {{ $t('common.button.delete') }}
+            </el-button>
+          </span>
+        </div>
+        <div v-if="d.status_reason" class="status-reason error">{{ d.status_reason }}</div>
+        <div v-if="d.dns_instructions" class="dns-instructions">
+          <p class="instructions">{{ d.dns_instructions.instructions }}</p>
+          <table class="dns-record">
+            <tr>
+              <th>{{ $t('subsite.field.recordType') }}</th>
+              <td>
+                <code>{{ d.dns_instructions.record_type }}</code>
+              </td>
+            </tr>
+            <tr>
+              <th>{{ $t('subsite.field.recordName') }}</th>
+              <td>
+                <code>{{ d.dns_instructions.record_name }}</code>
+              </td>
+            </tr>
+            <tr>
+              <th>{{ $t('subsite.field.recordValue') }}</th>
+              <td>
+                <code class="break">{{ d.dns_instructions.record_value }}</code>
+              </td>
+            </tr>
+          </table>
+        </div>
+      </div>
+
+      <el-divider />
+
+      <h4 class="bind-title">{{ $t('subsite.title.bindDomain') }}</h4>
+      <el-form :model="bind" label-width="auto" class="form" @submit.prevent>
+        <el-form-item :label="$t('subsite.field.hostname')" required>
+          <el-input
+            v-model="bind.hostname"
+            :placeholder="$t('subsite.placeholder.hostname')"
+            maxlength="253"
+            autofocus
+          />
+          <span class="tip">{{ $t('subsite.message.hostnameTip') }}</span>
+        </el-form-item>
+      </el-form>
+    </div>
+
+    <template #footer>
+      <span>
+        <el-button round @click="$emit('update:modelValue', false)">{{ $t('common.button.close') }}</el-button>
+        <el-button round type="primary" :loading="binding" :disabled="!bind.hostname.trim()" @click="onBind">
+          {{ $t('subsite.button.bindDomain') }}
+        </el-button>
+      </span>
+    </template>
+  </el-dialog>
+</template>
+
+<script lang="ts">
+import { defineComponent, type PropType } from 'vue';
+import {
+  ElDialog,
+  ElButton,
+  ElEmpty,
+  ElForm,
+  ElFormItem,
+  ElInput,
+  ElTag,
+  ElDivider,
+  ElMessage,
+  ElMessageBox
+} from 'element-plus';
+import { siteDomainOperator } from '@/operators';
+import type { ISite, ISiteDomain } from '@/models';
+
+// Mirror of the backend hostname validator. Keep in sync with
+// PlatformBackend's app/utils/custom_domain.py validate_custom_domain.
+const HOSTNAME_LABEL_RE = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/;
+const RESERVED_SUFFIXES = ['acedata.cloud', 'surl.id', 'localhost'];
+
+function clientValidateHostname(raw: string): { ok: true; value: string } | { ok: false; reason: string } {
+  let s = (raw || '').trim().toLowerCase();
+  if (!s) return { ok: false, reason: 'empty' };
+  // Strip scheme + path + port for friendlier UX (the user may paste a URL).
+  if (s.includes('://')) {
+    try {
+      const url = new URL(s);
+      s = url.hostname || '';
+    } catch {
+      return { ok: false, reason: 'invalid_url' };
+    }
+  }
+  s = s.replace(/\/.*$/, '').split(':')[0];
+  if (!s) return { ok: false, reason: 'empty' };
+  if (!s.includes('.')) return { ok: false, reason: 'no_dot' };
+  for (const suffix of RESERVED_SUFFIXES) {
+    if (s === suffix || s.endsWith('.' + suffix)) {
+      return { ok: false, reason: 'reserved' };
+    }
+  }
+  const labels = s.split('.');
+  if (labels.length < 2) return { ok: false, reason: 'too_few_labels' };
+  for (const label of labels) {
+    if (!label || !HOSTNAME_LABEL_RE.test(label)) {
+      return { ok: false, reason: 'bad_label' };
+    }
+  }
+  return { ok: true, value: s };
+}
+
+export default defineComponent({
+  name: 'DomainsDialog',
+  components: {
+    ElDialog,
+    ElButton,
+    ElEmpty,
+    ElForm,
+    ElFormItem,
+    ElInput,
+    ElTag,
+    ElDivider
+  },
+  props: {
+    modelValue: {
+      type: Boolean,
+      required: true
+    },
+    site: {
+      type: Object as PropType<ISite | null>,
+      default: null
+    }
+  },
+  emits: ['update:modelValue'],
+  data() {
+    return {
+      loading: false,
+      domains: [] as ISiteDomain[],
+      bind: { hostname: '' },
+      binding: false,
+      busyId: null as string | null
+    };
+  },
+  watch: {
+    modelValue(open: boolean) {
+      if (open && this.site?.id) {
+        this.fetchDomains();
+      } else if (!open) {
+        this.domains = [];
+        this.bind.hostname = '';
+        this.busyId = null;
+      }
+    }
+  },
+  methods: {
+    async fetchDomains() {
+      if (!this.site?.id) return;
+      this.loading = true;
+      try {
+        const { data } = await siteDomainOperator.getAll({ site: this.site.id });
+        this.domains = (data?.items || []) as ISiteDomain[];
+      } catch (e) {
+        console.error('failed to load domains', e);
+        ElMessage.error(this.$t('subsite.message.domainsLoadFailed'));
+      } finally {
+        this.loading = false;
+      }
+    },
+    async onBind() {
+      if (!this.site?.id) return;
+      const check = clientValidateHostname(this.bind.hostname);
+      if (!check.ok) {
+        ElMessage.warning(this.$t('subsite.message.hostnameInvalid'));
+        return;
+      }
+      this.binding = true;
+      try {
+        const { data } = await siteDomainOperator.create({
+          site: this.site.id,
+          hostname: check.value
+        });
+        ElMessage.success(this.$t('subsite.message.domainCreated'));
+        this.domains = [data, ...this.domains];
+        this.bind.hostname = '';
+      } catch (e: any) {
+        const detail =
+          e?.response?.data?.hostname || e?.response?.data?.detail || e?.response?.data?.site || e?.message;
+        ElMessage.error(typeof detail === 'string' ? detail : this.$t('subsite.message.domainCreateFailed'));
+      } finally {
+        this.binding = false;
+      }
+    },
+    async onVerify(d: ISiteDomain) {
+      if (!d.id) return;
+      this.busyId = d.id;
+      try {
+        const { data } = await siteDomainOperator.verify(d.id);
+        this.replaceRow(data);
+        if (data.status === 'Active') {
+          ElMessage.success(this.$t('subsite.message.domainActive'));
+        } else if (data.status === 'Failed') {
+          ElMessage.error(data.status_reason || this.$t('subsite.message.domainFailed'));
+        } else {
+          ElMessage.info(this.$t('subsite.message.domainProgressed'));
+        }
+      } catch (e: any) {
+        const detail =
+          e?.response?.data?.verification || e?.response?.data?.edgeone || e?.response?.data?.detail || e?.message;
+        ElMessage.error(typeof detail === 'string' ? detail : this.$t('subsite.message.domainVerifyFailed'));
+      } finally {
+        this.busyId = null;
+      }
+    },
+    async onRefresh(d: ISiteDomain) {
+      if (!d.id) return;
+      this.busyId = d.id;
+      try {
+        const { data } = await siteDomainOperator.get(d.id);
+        this.replaceRow(data);
+      } catch (e) {
+        console.error('refresh failed', e);
+      } finally {
+        this.busyId = null;
+      }
+    },
+    async onDelete(d: ISiteDomain) {
+      if (!d.id || !d.hostname) return;
+      try {
+        await ElMessageBox.confirm(
+          this.$t('subsite.message.domainDeleteConfirm', { hostname: d.hostname }) as string,
+          this.$t('common.button.delete') as string,
+          {
+            type: 'warning',
+            confirmButtonText: this.$t('common.button.delete') as string,
+            cancelButtonText: this.$t('common.button.cancel') as string
+          }
+        );
+      } catch {
+        return;
+      }
+      this.busyId = d.id;
+      try {
+        await siteDomainOperator.delete(d.id);
+        this.domains = this.domains.filter((x) => x.id !== d.id);
+      } catch (e: any) {
+        const detail = e?.response?.data?.detail || e?.message;
+        ElMessage.error(typeof detail === 'string' ? detail : this.$t('subsite.message.domainDeleteFailed'));
+      } finally {
+        this.busyId = null;
+      }
+    },
+    replaceRow(updated: ISiteDomain) {
+      const idx = this.domains.findIndex((x) => x.id === updated.id);
+      if (idx >= 0) this.domains.splice(idx, 1, updated);
+      else this.domains = [updated, ...this.domains];
+    },
+    canVerify(d: ISiteDomain): boolean {
+      return d.status === 'PendingDnsVerification' || d.status === 'ProvisioningEo' || d.status === 'ProvisioningCert';
+    },
+    verifyButtonLabel(status?: string): string {
+      if (status === 'PendingDnsVerification') return this.$t('subsite.button.verify') as string;
+      return this.$t('subsite.button.checkProgress') as string;
+    },
+    statusLabel(status?: string): string {
+      if (!status) return '-';
+      const key = `subsite.status.${status.charAt(0).toLowerCase() + status.slice(1)}`;
+      return this.$t(key) as string;
+    },
+    statusTagType(status?: string): 'success' | 'warning' | 'info' | 'danger' {
+      if (status === 'Active') return 'success';
+      if (status === 'Failed') return 'danger';
+      if (status === 'PendingDnsVerification') return 'info';
+      return 'warning';
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.domains-dialog {
+  .tip {
+    color: var(--el-text-color-secondary);
+    font-size: 13px;
+    margin: 0 0 16px 0;
+  }
+  .domain-row {
+    border: 1px solid var(--el-border-color-lighter);
+    border-radius: 6px;
+    padding: 12px 14px;
+    margin-bottom: 12px;
+    .domain-row-head {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+      .hostname {
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        flex: 1 1 auto;
+        word-break: break-all;
+      }
+      .status-tag {
+        flex: 0 0 auto;
+      }
+      .row-actions {
+        margin-left: auto;
+        display: flex;
+        gap: 4px;
+      }
+    }
+    .status-reason {
+      margin-top: 8px;
+      font-size: 12px;
+      color: var(--el-color-danger);
+      &.error {
+        color: var(--el-color-danger);
+      }
+    }
+    .dns-instructions {
+      margin-top: 12px;
+      .instructions {
+        margin: 0 0 8px 0;
+        color: var(--el-text-color-regular);
+        font-size: 13px;
+      }
+      .dns-record {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 12px;
+        th {
+          text-align: left;
+          width: 110px;
+          color: var(--el-text-color-secondary);
+          font-weight: normal;
+          padding: 4px 8px 4px 0;
+          vertical-align: top;
+        }
+        td {
+          padding: 4px 0;
+          code {
+            background: var(--el-fill-color-lighter);
+            padding: 2px 6px;
+            border-radius: 4px;
+            font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+            font-size: 12px;
+          }
+          code.break {
+            word-break: break-all;
+          }
+        }
+      }
+    }
+  }
+  .bind-title {
+    font-size: 14px;
+    margin: 0 0 12px 0;
+    color: var(--el-text-color-primary);
+  }
+  .form .tip {
+    display: block;
+    margin-top: 4px;
+    font-size: 12px;
+    color: var(--el-text-color-secondary);
+  }
+}
+</style>

--- a/src/pages/subsite/Index.vue
+++ b/src/pages/subsite/Index.vue
@@ -33,13 +33,16 @@
               <span>{{ formatDate(row.created_at) }}</span>
             </template>
           </el-table-column>
-          <el-table-column :label="$t('subsite.field.actions')" width="160" fixed="right">
+          <el-table-column :label="$t('subsite.field.actions')" width="260" fixed="right">
             <template #default="{ row }">
               <el-button size="small" link type="primary" @click="onOpenSite(row)">
                 {{ $t('subsite.button.open') }}
               </el-button>
               <el-button size="small" link type="primary" @click="onManageSite(row)">
                 {{ $t('subsite.button.manage') }}
+              </el-button>
+              <el-button size="small" link type="primary" @click="onOpenDomains(row)">
+                {{ $t('subsite.button.domains') }}
               </el-button>
             </template>
           </el-table-column>
@@ -80,6 +83,8 @@
         </span>
       </template>
     </el-dialog>
+
+    <domains-dialog v-model="domainsDialog.visible" :site="domainsDialog.site" />
   </el-row>
 </template>
 
@@ -103,6 +108,7 @@ import {
 import { Plus } from '@element-plus/icons-vue';
 import { siteOperator } from '@/operators';
 import type { ISite } from '@/models';
+import DomainsDialog from './DomainsDialog.vue';
 
 const SLUG_RE = /^(?!.*--)[a-z0-9][a-z0-9-]{1,30}[a-z0-9]$/;
 
@@ -119,7 +125,8 @@ export default defineComponent({
     ElDialog,
     ElForm,
     ElFormItem,
-    ElInput
+    ElInput,
+    DomainsDialog
   },
   data() {
     return {
@@ -133,6 +140,10 @@ export default defineComponent({
           slug: '',
           title: ''
         }
+      },
+      domainsDialog: {
+        visible: false,
+        site: null as ISite | null
       }
     };
   },
@@ -258,6 +269,10 @@ export default defineComponent({
       // Each subsite is the source of truth for its own settings; deep-link to
       // /site on the subsite itself instead of trying to manage cross-origin.
       window.open(`https://${row.origin}/site`, '_blank', 'noopener');
+    },
+    onOpenDomains(row: ISite) {
+      this.domainsDialog.site = row;
+      this.domainsDialog.visible = true;
     },
     rowUrl(row: ISite) {
       return row.origin ? `https://${row.origin}/` : '#';


### PR DESCRIPTION
PR 7 of the subsite (self-service white-label) track. Closes the loop with [PlatformBackend #384](https://github.com/AceDataCloud/PlatformBackend/pull/384).

After this PR a subsite owner can bind their own hostname (e.g. `studio.mybrand.com`) entirely from the browser:

1. Go to **My Subsites**, click **Domains** on the row.
2. Type the hostname into the bind form.
3. Backend returns the TXT verification instructions; the dialog renders them as a copy-friendly mini-table.
4. Add the TXT at the registrar, click **Verify**.
5. Status walks `Awaiting DNS` → `Provisioning edge` → `Issuing cert` → `Active`. The dialog re-syncs from EdgeOne every time you click **Refresh** or **Verify**.

No PlatformBackend or DevOps involvement after the user clicks **Bind**.

## What's in the PR

| File | Purpose |
|------|---------|
| `src/models/site_domain.ts` | Typed `ISiteDomain` + `SiteDomainStatus` enum + `ISiteDomainDnsInstructions` |
| `src/operators/site_domain.ts` | `siteDomainOperator` — wraps `/api/v1/site-domains/` (`getAll` / `get` / `create` / `verify` / `delete`) |
| `src/pages/subsite/DomainsDialog.vue` | The actual binding wizard + per-row status / verify / refresh / delete |
| `src/pages/subsite/Index.vue` | Third row action — **Domains** button — plus the dialog mount |
| `src/i18n/{zh-CN,en}/subsite.json` | New strings: `title.domains`, status tag labels, DNS-instruction copy, all error messages |
| `src/{models,operators}/index.ts` | Re-export the new files |

Per AGENTS.md, locales are zh-CN and en only — no `npm run translate`.

## Client-side hostname validation

The dialog mirrors the backend's `validate_custom_domain` regex + reserved-suffix list (`acedata.cloud`, `surl.id`, `localhost`) so users see invalid input instantly instead of waiting for a 400. The backend remains the source of truth — when it rejects (e.g. quota exhausted, hostname already bound), the page surfaces the server's error fields (`hostname` / `detail` / `site` / `verification` / `edgeone`) verbatim in the toast.

## State machine display

The dialog's status tag maps the backend's `SiteDomainStatus` directly:

| Status | Tag color | Visible buttons |
|--------|-----------|-----------------|
| `PendingDnsVerification` | info | **Verify**, Refresh, Delete |
| `ProvisioningEo` | warning | **Check progress**, Refresh, Delete |
| `ProvisioningCert` | warning | **Check progress**, Refresh, Delete |
| `Active` | success | Delete only |
| `Failed` | danger | Delete only (`status_reason` shown inline) |

When the backend returns `dns_instructions`, the dialog renders it as a 3-row table (Type / Name / Value) with monospace cells so users can copy directly into their registrar. Same panel for the TXT challenge as for the CNAME step.

## Verification

- `npm run lint` clean (only the pre-existing `Composer.vue` / `NotFound.vue` lint debt remains, untouched here).
- `npm run build` passes (~14s).
- Manually walked the flow against the live backend with PR #384 deployed:
  - Bind a hostname → 201, dialog shows TXT instructions.
  - Verify before publishing TXT → 400 surfacing backend message in toast.
  - After publishing TXT → 200, status flips to `ProvisioningEo`, EO CNAME shown.
  - Click Refresh after EO comes online → status flips to `ProvisioningCert`, then `Active` once the cert deploys.
  - Delete row → confirm dialog → 204, row disappears.

## Roadmap

- [x] Backend gating (PlatformBackend #382)
- [x] K8s wildcard ingress (Nexior #550)
- [x] Subsite UI (Nexior #551)
- [x] Per-origin branding (Nexior #552)
- [x] Distribution attribution fix (PlatformBackend #383)
- [x] Custom-domain backend + EO automation (PlatformBackend #384)
- [x] **This PR — custom-domain UI**
- [ ] Background poller (optional follow-up — replace lazy sync with a 60s job)
- [ ] Per-site domain quota enforcement (before opening to all tenants)
