### PR TITLE
feat(chat): BYOK settings page + active-key badge (PR 3/3)

### DIFF
--- a/src/components/chat/BYOKBadge.vue
+++ b/src/components/chat/BYOKBadge.vue
@@ -1,0 +1,131 @@
+<template>
+  <el-tooltip
+    v-if="show && providerLabel"
+    :content="$t('byok.badge.tooltip', { provider: providerLabel })"
+    placement="bottom"
+  >
+    <span class="byok-badge">
+      <font-awesome-icon icon="fa-solid fa-key" class="badge-icon" />
+      <span class="badge-text">{{ $t('byok.badge.active', { provider: providerLabel }) }}</span>
+    </span>
+  </el-tooltip>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElTooltip } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { byokCredentialOperator } from '@/operators';
+import type { IBYOKCredential, IBYOKProvider, ICredential } from '@/models';
+
+/**
+ * In-chat badge that lights up when the user has an active BYOK row
+ * matching the currently-selected model's provider. The badge's
+ * presence tells the user "this conversation is going to your own
+ * upstream account, not the platform's pool" so they're not confused
+ * about who's getting billed.
+ */
+
+const PROVIDER_FOR_GROUP: Record<string, IBYOKProvider> = {
+  chatgpt: 'openai',
+  claude: 'anthropic',
+  gemini: 'google',
+  grok: 'xai',
+  deepseek: 'deepseek',
+  kimi: 'moonshot',
+  glm: 'zhipu'
+};
+
+export default defineComponent({
+  name: 'BYOKBadge',
+  components: {
+    ElTooltip,
+    FontAwesomeIcon
+  },
+  data() {
+    return {
+      credentials: [] as IBYOKCredential[],
+      loaded: false
+    };
+  },
+  computed: {
+    token(): string | undefined {
+      const credential = this.$store?.state?.chat?.credential as ICredential | undefined;
+      return credential?.token;
+    },
+    modelGroup(): string | undefined {
+      return this.$store?.state?.chat?.modelGroup?.name;
+    },
+    expectedProvider(): IBYOKProvider | undefined {
+      const group = this.modelGroup;
+      if (!group) return undefined;
+      return PROVIDER_FOR_GROUP[group];
+    },
+    activeCredential(): IBYOKCredential | undefined {
+      const provider = this.expectedProvider;
+      if (!provider) return undefined;
+      return this.credentials.find((c) => c.provider === provider && c.is_active);
+    },
+    providerLabel(): string | undefined {
+      return this.activeCredential?.provider_label;
+    },
+    show(): boolean {
+      return !!this.activeCredential;
+    }
+  },
+  watch: {
+    token: {
+      immediate: true,
+      handler(value?: string) {
+        if (value && !this.loaded) {
+          this.fetch();
+        }
+      }
+    }
+  },
+  methods: {
+    async fetch() {
+      if (!this.token) return;
+      try {
+        const { data } = await byokCredentialOperator.list({ token: this.token });
+        this.credentials = data?.items ?? [];
+        this.loaded = true;
+      } catch (err) {
+        // BYOK feature off / endpoint unreachable — silently no badge.
+        console.debug('BYOK badge fetch skipped', err);
+        this.credentials = [];
+      }
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.byok-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background-color: var(--el-color-primary-light-9, rgba(64, 158, 255, 0.12));
+  color: var(--el-color-primary, #409eff);
+  font-size: 12px;
+  line-height: 1;
+  white-space: nowrap;
+  cursor: default;
+  user-select: none;
+
+  .badge-icon {
+    font-size: 10px;
+  }
+}
+
+@media (max-width: 640px) {
+  .byok-badge .badge-text {
+    display: none;
+  }
+  .byok-badge {
+    padding: 4px 6px;
+  }
+}
+</style>

--- a/src/components/console/SidePanel.vue
+++ b/src/components/console/SidePanel.vue
@@ -28,6 +28,7 @@
 import { defineComponent } from 'vue';
 import {
   ROUTE_CONSOLE_APPLICATION_LIST,
+  ROUTE_CONSOLE_BYOK_LIST,
   ROUTE_CONSOLE_ORDER_LIST,
   ROUTE_CONSOLE_USAGE_LIST,
   ROUTE_INDEX
@@ -78,6 +79,12 @@ export default defineComponent({
           text: this.$t('console.menu.usageList'),
           name: ROUTE_CONSOLE_USAGE_LIST,
           icon: 'fa-solid fa-rotate-left'
+        },
+        {
+          key: 'byok-list',
+          text: this.$t('console.menu.byokList'),
+          name: ROUTE_CONSOLE_BYOK_LIST,
+          icon: 'fa-solid fa-key'
         }
       ];
 

--- a/src/components/console/byok/Dialog.vue
+++ b/src/components/console/byok/Dialog.vue
@@ -1,0 +1,247 @@
+<template>
+  <el-dialog
+    :model-value="visible"
+    :title="credential ? $t('byok.title.editCredential') : $t('byok.title.addCredential')"
+    width="560px"
+    :close-on-click-modal="false"
+    @update:model-value="onClose"
+  >
+    <el-form ref="formRef" :model="form" :rules="rules" label-position="top">
+      <el-form-item :label="$t('byok.field.provider')" prop="provider">
+        <el-select
+          v-model="form.provider"
+          :placeholder="$t('byok.field.provider')"
+          :disabled="!!credential"
+          class="w-full"
+        >
+          <el-option v-for="opt in providers" :key="opt.id" :label="opt.label" :value="opt.id" />
+        </el-select>
+      </el-form-item>
+
+      <el-form-item :label="$t('byok.field.label')">
+        <el-input
+          v-model="form.label"
+          :placeholder="$t('byok.field.labelPlaceholder')"
+          maxlength="64"
+          show-word-limit
+        />
+      </el-form-item>
+
+      <el-form-item :label="$t('byok.field.apiKey')" prop="api_key">
+        <el-input
+          v-model="form.api_key"
+          type="password"
+          autocomplete="new-password"
+          show-password
+          :placeholder="credential ? $t('byok.field.apiKeyEditPlaceholder') : $t('byok.field.apiKeyPlaceholder')"
+        />
+      </el-form-item>
+
+      <div class="advanced-toggle" @click="advancedOpen = !advancedOpen">
+        <font-awesome-icon
+          :icon="advancedOpen ? 'fa-solid fa-chevron-down' : 'fa-solid fa-chevron-right'"
+          class="text-[10px]"
+        />
+        <span>{{ $t('byok.message.advancedToggle') }}</span>
+      </div>
+      <div v-if="advancedOpen" class="advanced-section">
+        <el-form-item :label="$t('byok.field.baseUrl')" prop="base_url">
+          <el-input v-model="form.base_url" :placeholder="placeholderBaseUrl" />
+          <p class="hint">{{ $t('byok.message.baseUrlHelp') }}</p>
+        </el-form-item>
+      </div>
+    </el-form>
+    <template #footer>
+      <el-button @click="onClose(false)">{{ $t('byok.button.cancel') }}</el-button>
+      <el-button type="primary" :loading="saving" @click="onSubmit">
+        {{ $t('byok.button.save') }}
+      </el-button>
+    </template>
+  </el-dialog>
+</template>
+
+<script lang="ts">
+import { defineComponent, type PropType } from 'vue';
+import {
+  ElButton,
+  ElDialog,
+  ElForm,
+  ElFormItem,
+  ElInput,
+  ElMessage,
+  ElOption,
+  ElSelect,
+  type FormInstance,
+  type FormRules
+} from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { byokCredentialOperator } from '@/operators';
+import type { IBYOKCredential, IBYOKCredentialCreatePayload, IBYOKProvider, IBYOKProviderInfo } from '@/models';
+
+export default defineComponent({
+  name: 'BYOKDialog',
+  components: {
+    ElButton,
+    ElDialog,
+    ElForm,
+    ElFormItem,
+    ElInput,
+    ElOption,
+    ElSelect,
+    FontAwesomeIcon
+  },
+  props: {
+    visible: { type: Boolean, default: false },
+    credential: { type: Object as PropType<IBYOKCredential | null>, default: null },
+    providers: { type: Array as PropType<IBYOKProviderInfo[]>, default: () => [] },
+    token: { type: String, default: '' }
+  },
+  emits: ['update:visible', 'saved'],
+  data() {
+    const form: { provider: IBYOKProvider | ''; api_key: string; base_url: string; label: string } = {
+      provider: '',
+      api_key: '',
+      base_url: '',
+      label: ''
+    };
+    return {
+      form,
+      advancedOpen: false,
+      saving: false
+    };
+  },
+  computed: {
+    rules(): FormRules {
+      return {
+        provider: [{ required: true, message: this.$t('byok.field.provider'), trigger: 'change' }],
+        api_key: [
+          {
+            // On edit, empty api_key means "keep current" — only enforce on create.
+            required: !this.credential,
+            message: this.$t('byok.field.apiKeyPlaceholder'),
+            trigger: 'blur'
+          }
+        ]
+      };
+    },
+    placeholderBaseUrl(): string {
+      const provider = this.form.provider;
+      const info = this.providers.find((p) => p.id === provider);
+      return info?.default_base_url ?? this.$t('byok.field.baseUrlPlaceholder');
+    }
+  },
+  watch: {
+    credential: {
+      immediate: true,
+      handler(row: IBYOKCredential | null) {
+        if (row) {
+          this.form = {
+            provider: row.provider,
+            api_key: '',
+            base_url: row.base_url ?? '',
+            label: row.label ?? ''
+          };
+          this.advancedOpen = !!row.base_url;
+        } else {
+          this.form = {
+            provider: this.providers?.[0]?.id ?? '',
+            api_key: '',
+            base_url: '',
+            label: ''
+          };
+          this.advancedOpen = false;
+        }
+      }
+    }
+  },
+  methods: {
+    onClose(value?: boolean) {
+      // ElDialog passes a boolean, ElButton passes a click event — only
+      // respect explicit `false` (close).
+      if (value === false || value === undefined) {
+        this.$emit('update:visible', false);
+      }
+    },
+    async onSubmit() {
+      const formRef = this.$refs.formRef as FormInstance | undefined;
+      if (formRef) {
+        try {
+          await formRef.validate();
+        } catch {
+          return;
+        }
+      }
+      if (!this.token) return;
+      this.saving = true;
+      try {
+        const baseUrl = this.form.base_url.trim();
+        const label = this.form.label.trim();
+        const apiKey = this.form.api_key.trim();
+        if (this.credential) {
+          // Edit — only send fields that changed (api_key omitted when blank).
+          const patch: Record<string, unknown> = {};
+          if (apiKey) patch.api_key = apiKey;
+          if (baseUrl !== (this.credential.base_url ?? '')) patch.base_url = baseUrl;
+          if (label !== (this.credential.label ?? '')) patch.label = label;
+          if (Object.keys(patch).length === 0) {
+            this.$emit('saved');
+            return;
+          }
+          await byokCredentialOperator.update(this.credential.id, patch, { token: this.token });
+        } else {
+          if (!this.form.provider) return;
+          const payload: IBYOKCredentialCreatePayload = {
+            provider: this.form.provider,
+            api_key: apiKey,
+            ...(baseUrl ? { base_url: baseUrl } : {}),
+            ...(label ? { label } : {})
+          };
+          await byokCredentialOperator.create(payload, { token: this.token });
+        }
+        ElMessage.success(this.$t('byok.message.saveSuccess'));
+        this.$emit('saved');
+      } catch (err) {
+        const message =
+          (err as { response?: { data?: { message?: string } } })?.response?.data?.message ||
+          (err instanceof Error ? err.message : 'unknown error');
+        console.error('Failed to save BYOK credential', err);
+        ElMessage.error(this.$t('byok.message.saveFailed') + ': ' + message);
+      } finally {
+        this.saving = false;
+      }
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.advanced-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--el-text-color-regular);
+  cursor: pointer;
+  user-select: none;
+  margin: -6px 0 8px;
+  &:hover {
+    color: var(--el-color-primary);
+  }
+}
+
+.advanced-section {
+  border-left: 2px solid var(--el-border-color-lighter);
+  padding-left: 12px;
+}
+
+.hint {
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+  line-height: 1.5;
+  margin: 4px 0 0;
+}
+
+.w-full {
+  width: 100%;
+}
+</style>

--- a/src/constants/i18n.ts
+++ b/src/constants/i18n.ts
@@ -56,5 +56,6 @@ export const I18N_SCOPES = [
   'chat',
   'midjourney',
   'serp',
-  'connector'
+  'connector',
+  'byok'
 ];

--- a/src/i18n/en/byok.json
+++ b/src/i18n/en/byok.json
@@ -1,0 +1,54 @@
+{
+  "title": {
+    "list": "Custom API Keys",
+    "addCredential": "Add API Key",
+    "editCredential": "Edit API Key",
+    "deleteCredential": "Delete API Key"
+  },
+  "description": {
+    "list": "Use your own provider API keys (OpenAI, Anthropic, Google, xAI, DeepSeek, Moonshot, Zhipu) instead of the platform's pooled accounts. When configured, chat traffic for the matching model goes directly from this app to the provider with your key — no platform credit is consumed. Tools, references, artifacts, cloud history and other features keep working unchanged."
+  },
+  "field": {
+    "provider": "Provider",
+    "label": "Label",
+    "labelPlaceholder": "e.g. \"My work account\" (optional)",
+    "apiKey": "API Key",
+    "apiKeyPlaceholder": "sk-...",
+    "apiKeyEditPlaceholder": "Leave empty to keep the current key",
+    "baseUrl": "Custom Base URL",
+    "baseUrlPlaceholder": "Leave empty for the provider's default",
+    "isActive": "Active",
+    "lastUsedAt": "Last used",
+    "createdAt": "Created"
+  },
+  "value": {
+    "active": "Active",
+    "inactive": "Inactive",
+    "never": "Never",
+    "default": "Default"
+  },
+  "button": {
+    "add": "Add API Key",
+    "edit": "Edit",
+    "test": "Test",
+    "delete": "Delete",
+    "save": "Save",
+    "cancel": "Cancel"
+  },
+  "message": {
+    "deleteConfirm": "Delete this API key? Future chat requests for {provider} models will fall back to the platform's default upstream.",
+    "deleteSuccess": "API key deleted.",
+    "saveSuccess": "API key saved.",
+    "testSuccess": "Connection successful.",
+    "testFailed": "Test failed: {message}",
+    "loadFailed": "Failed to load credentials.",
+    "saveFailed": "Failed to save credential.",
+    "empty": "No custom API keys configured. Click \"Add API Key\" to use your own provider account for chat.",
+    "advancedToggle": "Show advanced options",
+    "baseUrlHelp": "Optional. Override the default endpoint to route through OpenRouter, a self-hosted proxy, or your own gateway. Must be HTTPS and not point at any private/loopback address."
+  },
+  "badge": {
+    "active": "Using your {provider} key",
+    "tooltip": "This conversation uses your own {provider} API key. Cost is billed to your {provider} account, not your platform balance."
+  }
+}

--- a/src/i18n/en/console.json
+++ b/src/i18n/en/console.json
@@ -35,6 +35,10 @@
     "message": "Usage History",
     "description": "Text in the website menu referring to the history of API service usage by the user"
   },
+  "menu.byokList": {
+    "message": "Custom API Keys",
+    "description": "Text in the website menu referring to the list of user-supplied upstream provider API keys (BYOK)"
+  },
   "menu.credentialIndex": {
     "message": "Credentials",
     "description": "Text in the website menu referring to the credentials for accessing the API"

--- a/src/i18n/zh-CN/byok.json
+++ b/src/i18n/zh-CN/byok.json
@@ -1,0 +1,54 @@
+{
+  "title": {
+    "list": "自定义 API Key",
+    "addCredential": "添加 API Key",
+    "editCredential": "编辑 API Key",
+    "deleteCredential": "删除 API Key"
+  },
+  "description": {
+    "list": "使用你自己的服务商 API Key（OpenAI、Anthropic、Google、xAI、DeepSeek、Moonshot、智谱）代替平台账户池。配置后，对应模型的对话请求会直接以你的 Key 调用上游服务商，不消耗平台 Credit；工具调用、引用、工件、云端历史等其他功能照常工作。"
+  },
+  "field": {
+    "provider": "服务商",
+    "label": "备注",
+    "labelPlaceholder": "如 \"我的工作号\"（可选）",
+    "apiKey": "API Key",
+    "apiKeyPlaceholder": "sk-...",
+    "apiKeyEditPlaceholder": "留空表示保持当前 Key 不变",
+    "baseUrl": "自定义 Base URL",
+    "baseUrlPlaceholder": "留空使用服务商默认地址",
+    "isActive": "启用",
+    "lastUsedAt": "上次使用",
+    "createdAt": "添加时间"
+  },
+  "value": {
+    "active": "启用中",
+    "inactive": "未启用",
+    "never": "从未使用",
+    "default": "默认"
+  },
+  "button": {
+    "add": "添加 API Key",
+    "edit": "编辑",
+    "test": "测试",
+    "delete": "删除",
+    "save": "保存",
+    "cancel": "取消"
+  },
+  "message": {
+    "deleteConfirm": "确认删除这个 API Key？后续 {provider} 模型的对话将回落到平台默认上游。",
+    "deleteSuccess": "API Key 已删除。",
+    "saveSuccess": "API Key 已保存。",
+    "testSuccess": "连接正常。",
+    "testFailed": "测试失败：{message}",
+    "loadFailed": "凭据加载失败。",
+    "saveFailed": "保存凭据失败。",
+    "empty": "尚未配置自定义 API Key。点击\"添加 API Key\"以使用你自己的服务商账户。",
+    "advancedToggle": "显示高级选项",
+    "baseUrlHelp": "可选。自定义上游地址（用于 OpenRouter、自建反代、企业网关等）。仅允许 HTTPS，不能指向内网/回环地址。"
+  },
+  "badge": {
+    "active": "使用你的 {provider} Key",
+    "tooltip": "本次对话使用你自己的 {provider} API Key，费用由 {provider} 账户结算，不扣减平台余额。"
+  }
+}

--- a/src/i18n/zh-CN/console.json
+++ b/src/i18n/zh-CN/console.json
@@ -31,6 +31,10 @@
     "message": "开发者平台",
     "description": "网站菜单中的文本，开发者平台表示开发者的平台"
   },
+  "menu.byokList": {
+    "message": "自定义 API Key",
+    "description": "侧栏菜单项：用户自带的上游服务商 API Key（BYOK）列表"
+  },
   "menu.usageList": {
     "message": "使用历史",
     "description": "网站菜单中的文本，使用历史指的是用户对API服务的使用历史"

--- a/src/models/byok.ts
+++ b/src/models/byok.ts
@@ -1,0 +1,60 @@
+/**
+ * BYOK ("Bring Your Own Key") — types for user-supplied upstream API
+ * credentials. Mirrors the public schema of `POST /aichat2/credentials`
+ * served by PlatformService/aichat2 (see PR
+ * https://github.com/AceDataCloud/PlatformService/pull/817).
+ */
+
+export type IBYOKProvider = 'openai' | 'anthropic' | 'google' | 'xai' | 'deepseek' | 'moonshot' | 'zhipu';
+
+export interface IBYOKProviderInfo {
+  id: IBYOKProvider;
+  label: string;
+  default_base_url: string;
+  groups: ReadonlyArray<string>;
+}
+
+export interface IBYOKCredential {
+  id: string;
+  provider: IBYOKProvider;
+  provider_label: string;
+  /** Empty string → row uses the provider default base URL. */
+  base_url: string;
+  /** "sk-...XXXX" — never the plaintext key. */
+  api_key_masked: string;
+  label: string;
+  is_active: boolean;
+  /** Unix seconds. */
+  created_at: number;
+  updated_at: number;
+  last_used_at: number | null;
+}
+
+export interface IBYOKCredentialCreatePayload {
+  provider: IBYOKProvider;
+  api_key: string;
+  base_url?: string;
+  label?: string;
+  is_active?: boolean;
+}
+
+export interface IBYOKCredentialUpdatePayload {
+  api_key?: string;
+  base_url?: string;
+  label?: string;
+  is_active?: boolean;
+}
+
+export interface IBYOKListResponse {
+  items: IBYOKCredential[];
+}
+
+export interface IBYOKProvidersResponse {
+  providers: IBYOKProviderInfo[];
+}
+
+export interface IBYOKTestResponse {
+  ok: boolean;
+  status?: number;
+  message?: string;
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -32,3 +32,4 @@ export * from './site';
 export * from './exchange';
 export * from './error';
 export * from './config';
+export * from './byok';

--- a/src/operators/byokCredential.ts
+++ b/src/operators/byokCredential.ts
@@ -1,0 +1,112 @@
+/**
+ * BYOK credential operator.
+ *
+ * Calls the action-dispatch endpoint `POST /aichat2/credentials` exposed
+ * by PlatformService/aichat2. Mirrors the shape and auth model of
+ * `chatOperator.getConversation` etc.: raw axios against
+ * `${BASE_URL_API}` with an explicit `Authorization: Bearer <token>`,
+ * where the token is the user's chat-Application credential token (from
+ * the `chat` Vuex module).
+ *
+ * Why the chat credential? `/aichat2/credentials` lives behind the same
+ * Kong route (`/aichat2/*`) as `/aichat2/conversations`, so it
+ * authenticates with the same credential. The aichat2 worker only ever
+ * reads `ctx.userId` from Kong's injected query string — every chat
+ * credential the user owns resolves to the same `user_id`, so one
+ * credential is enough.
+ */
+import axios, { AxiosResponse } from 'axios';
+import {
+  IBYOKCredential,
+  IBYOKCredentialCreatePayload,
+  IBYOKCredentialUpdatePayload,
+  IBYOKListResponse,
+  IBYOKProvidersResponse,
+  IBYOKTestResponse
+} from '@/models';
+import { BASE_URL_API } from '@/constants';
+
+interface AuthOptions {
+  /** Chat-Application credential token. */
+  token: string;
+}
+
+const ENDPOINT = '/aichat2/credentials';
+
+function authHeaders(token: string) {
+  return {
+    'content-type': 'application/json',
+    authorization: `Bearer ${token}`,
+    // BYOK CRUD is metadata, not chat — skip the platform's billing
+    // pre-check the same way `/aichat2/conversations` retrieve / update /
+    // delete actions do.
+    'x-record-exempt': 'true'
+  };
+}
+
+class BYOKCredentialOperator {
+  /**
+   * List supported providers + their default base URLs. The UI uses this
+   * to populate the "add credential" dialog so the registry stays
+   * server-driven (a new provider on the worker side appears here on
+   * the next page load).
+   */
+  async providers(options: AuthOptions): Promise<AxiosResponse<IBYOKProvidersResponse>> {
+    return await axios.post(
+      ENDPOINT,
+      { action: 'providers' },
+      { headers: authHeaders(options.token), baseURL: BASE_URL_API }
+    );
+  }
+
+  async list(options: AuthOptions): Promise<AxiosResponse<IBYOKListResponse>> {
+    return await axios.post(
+      ENDPOINT,
+      { action: 'list' },
+      { headers: authHeaders(options.token), baseURL: BASE_URL_API }
+    );
+  }
+
+  async create(payload: IBYOKCredentialCreatePayload, options: AuthOptions): Promise<AxiosResponse<IBYOKCredential>> {
+    return await axios.post(
+      ENDPOINT,
+      { action: 'create', ...payload },
+      { headers: authHeaders(options.token), baseURL: BASE_URL_API }
+    );
+  }
+
+  async update(
+    id: string,
+    payload: IBYOKCredentialUpdatePayload,
+    options: AuthOptions
+  ): Promise<AxiosResponse<IBYOKCredential>> {
+    return await axios.post(
+      ENDPOINT,
+      { action: 'update', id, ...payload },
+      { headers: authHeaders(options.token), baseURL: BASE_URL_API }
+    );
+  }
+
+  async delete(id: string, options: AuthOptions): Promise<AxiosResponse<{ id: string; success: boolean }>> {
+    return await axios.post(
+      ENDPOINT,
+      { action: 'delete', id },
+      { headers: authHeaders(options.token), baseURL: BASE_URL_API }
+    );
+  }
+
+  /**
+   * Smoke-test the credential against the real upstream's `/models`
+   * endpoint. Returns `{ok: false, message}` on failure rather than
+   * throwing — the UI wants to show "401 unauthorized" inline.
+   */
+  async test(id: string, options: AuthOptions): Promise<AxiosResponse<IBYOKTestResponse>> {
+    return await axios.post(
+      ENDPOINT,
+      { action: 'test', id },
+      { headers: authHeaders(options.token), baseURL: BASE_URL_API }
+    );
+  }
+}
+
+export const byokCredentialOperator = new BYOKCredentialOperator();

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -32,3 +32,4 @@ export * from './serp';
 export * from './wan';
 export * from './config';
 export * from './agent';
+export * from './byokCredential';

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -2,7 +2,10 @@
   <layout @change-conversation="onChangeConversation($event)">
     <template #chat>
       <div class="toolbar">
-        <model-selector class="selector" @model-group-changed="onChangeConversation(undefined)" />
+        <div class="toolbar-left">
+          <model-selector class="selector" @model-group-changed="onChangeConversation(undefined)" />
+          <byok-badge class="byok-badge" />
+        </div>
         <div class="toolbar-actions">
           <el-tooltip v-if="false" :content="$t('chat.agent.tooltip')" placement="bottom">
             <el-button class="toolbar-btn" text @click="agentManagerVisible = true">
@@ -61,6 +64,7 @@ import { IChatMessageState, IChatConversationResponse, IChatConversation, IChatM
 import Composer from '@/components/chat/Composer.vue';
 import ModelSelector from '@/components/chat/ModelSelector.vue';
 import DesktopAgentManager from '@/components/chat/DesktopAgentManager.vue';
+import BYOKBadge from '@/components/chat/BYOKBadge.vue';
 import { ERROR_CODE_CANCELED, ERROR_CODE_NOT_APPLIED, ERROR_CODE_UNKNOWN } from '@/constants/errorCode';
 import { Status } from '@/models';
 import Disclaimer from '@/components/chat/Disclaimer.vue';
@@ -99,6 +103,7 @@ export default defineComponent({
     Disclaimer,
     ModelSelector,
     DesktopAgentManager,
+    'byok-badge': BYOKBadge,
     Message,
     Layout,
     ElTooltip,
@@ -705,6 +710,17 @@ export default defineComponent({
 
 .selector {
   width: max-content;
+}
+
+.toolbar-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.byok-badge {
+  flex-shrink: 0;
 }
 
 .toolbar-actions {

--- a/src/pages/console/byok/List.vue
+++ b/src/pages/console/byok/List.vue
@@ -1,0 +1,305 @@
+<template>
+  <el-row class="panel p-[30px]">
+    <el-col :span="24">
+      <el-row>
+        <el-col :span="24">
+          <h2 class="title">{{ $t('byok.title.list') }}</h2>
+          <p class="text-sm text-[var(--el-text-color-regular)] mt-2 mb-4 max-w-[760px] leading-relaxed">
+            {{ $t('byok.description.list') }}
+          </p>
+        </el-col>
+      </el-row>
+      <el-row>
+        <el-col :span="24" class="flex justify-end mb-3">
+          <el-button type="primary" round size="default" :disabled="!token" @click="onAdd">
+            <font-awesome-icon icon="fa-solid fa-plus" class="mr-1 text-[12px]" />
+            {{ $t('byok.button.add') }}
+          </el-button>
+        </el-col>
+      </el-row>
+      <el-row>
+        <el-col :span="24">
+          <el-card shadow="hover">
+            <el-table
+              v-loading="loading"
+              :data="credentials"
+              stripe
+              class="!min-h-[calc(100vh-420px)]"
+              table-layout="fixed"
+              :empty-text="$t('byok.message.empty')"
+            >
+              <el-table-column :label="$t('byok.field.provider')" width="160px">
+                <template #default="scope">
+                  <el-tag :type="scope.row.is_active ? 'success' : 'info'" effect="dark" round>
+                    {{ scope.row.provider_label }}
+                  </el-tag>
+                </template>
+              </el-table-column>
+              <el-table-column :label="$t('byok.field.label')" min-width="160px">
+                <template #default="scope">
+                  <span v-if="scope.row.label" class="break-all">{{ scope.row.label }}</span>
+                  <span v-else class="text-[var(--el-text-color-placeholder)]">—</span>
+                </template>
+              </el-table-column>
+              <el-table-column :label="$t('byok.field.apiKey')" width="180px">
+                <template #default="scope">
+                  <code class="text-xs text-[var(--el-text-color-regular)]">{{ scope.row.api_key_masked }}</code>
+                </template>
+              </el-table-column>
+              <el-table-column :label="$t('byok.field.baseUrl')" min-width="200px">
+                <template #default="scope">
+                  <span v-if="scope.row.base_url" class="break-all text-xs">{{ scope.row.base_url }}</span>
+                  <span v-else class="text-[var(--el-text-color-placeholder)]">{{ $t('byok.value.default') }}</span>
+                </template>
+              </el-table-column>
+              <el-table-column :label="$t('byok.field.isActive')" width="100px" class-name="text-center">
+                <template #default="scope">
+                  <el-switch
+                    :model-value="scope.row.is_active"
+                    :loading="togglingId === scope.row.id"
+                    @change="(val: string | number | boolean) => onToggleActive(scope.row, !!val)"
+                  />
+                </template>
+              </el-table-column>
+              <el-table-column :label="$t('byok.field.lastUsedAt')" width="170px">
+                <template #default="scope">
+                  <span v-if="scope.row.last_used_at" class="text-xs">
+                    {{ formatTime(scope.row.last_used_at) }}
+                  </span>
+                  <span v-else class="text-[var(--el-text-color-placeholder)]">
+                    {{ $t('byok.value.never') }}
+                  </span>
+                </template>
+              </el-table-column>
+              <el-table-column :label="$t('common.field.operations')" width="220px" fixed="right">
+                <template #default="scope">
+                  <el-button size="small" :loading="testingId === scope.row.id" @click="onTest(scope.row)">
+                    <font-awesome-icon icon="fa-solid fa-plug" class="mr-1 text-[10px]" />
+                    {{ $t('byok.button.test') }}
+                  </el-button>
+                  <el-button size="small" @click="onEdit(scope.row)">
+                    <font-awesome-icon icon="fa-solid fa-pen" class="mr-1 text-[10px]" />
+                    {{ $t('byok.button.edit') }}
+                  </el-button>
+                  <el-button size="small" type="danger" plain @click="onDelete(scope.row)">
+                    <font-awesome-icon icon="fa-solid fa-trash" class="mr-1 text-[10px]" />
+                    {{ $t('byok.button.delete') }}
+                  </el-button>
+                </template>
+              </el-table-column>
+            </el-table>
+          </el-card>
+        </el-col>
+      </el-row>
+    </el-col>
+
+    <byok-dialog
+      v-if="dialog.visible"
+      v-model:visible="dialog.visible"
+      :credential="dialog.credential"
+      :providers="providers"
+      :token="token"
+      @saved="onSaved"
+    />
+  </el-row>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import {
+  ElButton,
+  ElCard,
+  ElCol,
+  ElMessage,
+  ElMessageBox,
+  ElRow,
+  ElSwitch,
+  ElTable,
+  ElTableColumn,
+  ElTag,
+  vLoading
+} from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import dayjs from 'dayjs';
+import { byokCredentialOperator } from '@/operators';
+import type { IBYOKCredential, IBYOKProviderInfo, ICredential } from '@/models';
+import BYOKDialog from '@/components/console/byok/Dialog.vue';
+
+export default defineComponent({
+  name: 'BYOKList',
+  components: {
+    ElButton,
+    ElCard,
+    ElCol,
+    ElRow,
+    ElSwitch,
+    ElTable,
+    ElTableColumn,
+    ElTag,
+    FontAwesomeIcon,
+    'byok-dialog': BYOKDialog
+  },
+  directives: {
+    loading: vLoading
+  },
+  data() {
+    return {
+      loading: false,
+      credentials: [] as IBYOKCredential[],
+      providers: [] as IBYOKProviderInfo[],
+      togglingId: null as string | null,
+      testingId: null as string | null,
+      dialog: {
+        visible: false,
+        credential: null as IBYOKCredential | null
+      }
+    };
+  },
+  computed: {
+    /**
+     * Chat-Application credential token. The chat module is lazy-loaded
+     * because this route declares `meta.appName: 'chat'`; until the
+     * module finishes registering or the user's chat application
+     * resolves, the token can be undefined and we keep the table empty.
+     */
+    token(): string | undefined {
+      const credential = this.$store?.state?.chat?.credential as ICredential | undefined;
+      return credential?.token;
+    }
+  },
+  watch: {
+    token: {
+      immediate: true,
+      handler(value?: string) {
+        if (value) {
+          this.bootstrap();
+        }
+      }
+    }
+  },
+  async mounted() {
+    // Lazy-loaded chat module needs an Application + credential before
+    // we can authenticate. Mirror what the chat page does on entry.
+    if (!this.token) {
+      try {
+        await this.$store.dispatch('chat/getApplications');
+        const apps = this.$store?.state?.chat?.applications;
+        if (Array.isArray(apps) && apps.length > 0) {
+          await this.$store.dispatch('chat/setApplication', apps[0]);
+        }
+      } catch (err) {
+        console.error('Failed to bootstrap chat application for BYOK', err);
+      }
+    }
+  },
+  methods: {
+    formatTime(unixSeconds: number): string {
+      return dayjs.unix(unixSeconds).format('YYYY-MM-DD HH:mm');
+    },
+    async bootstrap() {
+      await Promise.all([this.loadProviders(), this.loadCredentials()]);
+    },
+    async loadProviders() {
+      if (!this.token) return;
+      try {
+        const { data } = await byokCredentialOperator.providers({ token: this.token });
+        this.providers = data?.providers ?? [];
+      } catch (err) {
+        console.error('Failed to load BYOK providers', err);
+      }
+    },
+    async loadCredentials() {
+      if (!this.token) return;
+      this.loading = true;
+      try {
+        const { data } = await byokCredentialOperator.list({ token: this.token });
+        this.credentials = data?.items ?? [];
+      } catch (err) {
+        console.error('Failed to load BYOK credentials', err);
+        ElMessage.error(this.$t('byok.message.loadFailed'));
+      } finally {
+        this.loading = false;
+      }
+    },
+    onAdd() {
+      this.dialog.credential = null;
+      this.dialog.visible = true;
+    },
+    onEdit(row: IBYOKCredential) {
+      this.dialog.credential = row;
+      this.dialog.visible = true;
+    },
+    async onSaved() {
+      this.dialog.visible = false;
+      this.dialog.credential = null;
+      await this.loadCredentials();
+    },
+    async onToggleActive(row: IBYOKCredential, value: boolean) {
+      if (!this.token) return;
+      this.togglingId = row.id;
+      try {
+        await byokCredentialOperator.update(row.id, { is_active: value }, { token: this.token });
+        await this.loadCredentials();
+      } catch (err) {
+        console.error('Failed to toggle BYOK credential', err);
+        ElMessage.error(this.$t('byok.message.saveFailed'));
+      } finally {
+        this.togglingId = null;
+      }
+    },
+    async onTest(row: IBYOKCredential) {
+      if (!this.token) return;
+      this.testingId = row.id;
+      try {
+        const { data } = await byokCredentialOperator.test(row.id, { token: this.token });
+        if (data?.ok) {
+          ElMessage.success(this.$t('byok.message.testSuccess'));
+        } else {
+          ElMessage.error(this.$t('byok.message.testFailed', { message: data?.message ?? 'unknown error' }));
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'unknown error';
+        ElMessage.error(this.$t('byok.message.testFailed', { message }));
+      } finally {
+        this.testingId = null;
+      }
+    },
+    async onDelete(row: IBYOKCredential) {
+      if (!this.token) return;
+      try {
+        await ElMessageBox.confirm(
+          this.$t('byok.message.deleteConfirm', { provider: row.provider_label }),
+          this.$t('byok.title.deleteCredential'),
+          { type: 'warning' }
+        );
+      } catch {
+        return;
+      }
+      try {
+        await byokCredentialOperator.delete(row.id, { token: this.token });
+        ElMessage.success(this.$t('byok.message.deleteSuccess'));
+        await this.loadCredentials();
+      } catch (err) {
+        console.error('Failed to delete BYOK credential', err);
+        ElMessage.error(this.$t('byok.message.saveFailed'));
+      }
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.title {
+  font-size: 20px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.panel {
+  width: 100%;
+}
+
+:deep(code) {
+  font-family: var(--el-font-family-mono, ui-monospace, monospace);
+}
+</style>

--- a/src/pages/profile/Index.vue
+++ b/src/pages/profile/Index.vue
@@ -33,6 +33,7 @@ import { defineComponent } from 'vue';
 import { ElImage } from 'element-plus';
 import {
   ROUTE_CONSOLE_APPLICATION_LIST,
+  ROUTE_CONSOLE_BYOK_LIST,
   ROUTE_CONSOLE_ORDER_LIST,
   ROUTE_CONSOLE_USAGE_LIST,
   ROUTE_DISTRIBUTION_INDEX,
@@ -115,6 +116,12 @@ export default defineComponent({
           text: this.$t('console.menu.usageList'),
           name: ROUTE_CONSOLE_USAGE_LIST,
           icon: 'fa-solid fa-rotate-left'
+        },
+        {
+          key: 'byok-list',
+          text: this.$t('console.menu.byokList'),
+          name: ROUTE_CONSOLE_BYOK_LIST,
+          icon: 'fa-solid fa-key'
         },
         {
           key: 'distribution-index',

--- a/src/plugins/font-awesome.ts
+++ b/src/plugins/font-awesome.ts
@@ -122,7 +122,8 @@ import {
   faBroom as faSolidBroom,
   faStar as faSolidStar,
   faHouse as faSolidHouse,
-  faBrain as faSolidBrain
+  faBrain as faSolidBrain,
+  faKey as faSolidKey
 } from '@fortawesome/free-solid-svg-icons';
 // add icons
 library.add(faSolidEllipsis);
@@ -244,3 +245,4 @@ library.add(faSolidExpand);
 library.add(faSolidCompress);
 library.add(faSolidBroom);
 library.add(faSolidHouse);
+library.add(faSolidKey);

--- a/src/router/console.ts
+++ b/src/router/console.ts
@@ -2,6 +2,7 @@ import {
   ROUTE_CONSOLE_APPLICATION_EXTRA,
   ROUTE_CONSOLE_APPLICATION_LIST,
   ROUTE_CONSOLE_APPLICATION_SUBSCRIBE,
+  ROUTE_CONSOLE_BYOK_LIST,
   ROUTE_CONSOLE_ORDER_DETAIL,
   ROUTE_CONSOLE_ORDER_LIST,
   ROUTE_CONSOLE_ROOT,
@@ -51,6 +52,15 @@ export default {
       path: 'usages',
       name: ROUTE_CONSOLE_USAGE_LIST,
       component: () => import('@/pages/console/usage/List.vue')
+    },
+    {
+      path: 'byok',
+      name: ROUTE_CONSOLE_BYOK_LIST,
+      // Lazy-load the chat module on entry so the BYOK page can use
+      // the existing chat-Application credential token to authenticate
+      // against `/aichat2/credentials`.
+      meta: { appName: 'chat' },
+      component: () => import('@/pages/console/byok/List.vue')
     }
   ]
 };

--- a/src/router/constants.ts
+++ b/src/router/constants.ts
@@ -86,4 +86,12 @@ export const ROUTE_DISTRIBUTION_INVITEES = 'distribution-invitees';
 
 export const ROUTE_CONSOLE_USAGE_LIST = 'console-usage-list';
 
+/**
+ * BYOK ("bring your own key") settings — manage user-supplied upstream
+ * API credentials for AI chat models. See
+ * `src/pages/console/byok/List.vue` and the matching aichat2 endpoint
+ * `POST /aichat2/credentials`.
+ */
+export const ROUTE_CONSOLE_BYOK_LIST = 'console-byok-list';
+
 export const ROUTE_NOT_FOUND = 'not-found';


### PR DESCRIPTION
**Closes the BYOK series.** [#817](https://github.com/AceDataCloud/PlatformService/pull/817) shipped storage + CRUD on the worker; [#818](https://github.com/AceDataCloud/PlatformService/pull/818) wired the chat path to use a user's upstream when registered. This PR lets users actually register / edit / test / delete those credentials, and surfaces a 🔑 badge in the chat header when their key is in use.

## What lands

### Settings page — `/console/byok`

Lives alongside **Applications / Orders / Usage** in the existing console layout. Sidebar entry added in both `Console/SidePanel.vue` and `profile/Index.vue` (mobile profile menu).

Table per credential:

- Masked api_key (`sk-…XXXX` only — plaintext never round-trips)
- Provider label as a coloured tag (active = green, inactive = grey)
- User-supplied label, custom base_url (or "Default")
- **Active toggle** — flip without re-opening the dialog
- Last-used time
- **Test** — smoke-tests the key against the real upstream's `/models` endpoint; shows the upstream's error verbatim on failure
- Edit / Delete

Add / Edit dialog has a password-typed API-key input (with show/hide), an "advanced" disclosure that reveals custom `base_url` (validated server-side by PR 1's SSRF guard), and per-provider help text. Editing leaves the key field blank → keeps the existing key.

### 🔑 badge — `src/components/chat/BYOKBadge.vue`

Mounts inside the existing toolbar next to `ModelSelector`. Visible only when the currently-selected model's provider has an active BYOK row. Tooltip:

> This conversation uses your own {provider} API key. Cost is billed to your {provider} account, not your platform balance.

Provider classification mirrors the worker (`deriveModelGroup` → provider): chatgpt → openai, claude → anthropic, gemini → google, grok → xai, deepseek / kimi / glm → deepseek / moonshot / zhipu.

### Operator + types

`src/operators/byokCredential.ts` and `src/models/byok.ts`:

- Mirrors the chat operator's pattern: raw axios against `${BASE_URL_API}` with explicit `Authorization: Bearer <chat credential token>`. The chat module's `state.credential.token` authenticates against Kong's custom-auth, which resolves to the same `user_id` the worker reads from `ctx.userId` — so any of the user's chat credentials authenticate the BYOK CRUD calls. No new credential service needed.
- The `/console/byok` route declares `meta.appName: 'chat'` so the Vuex chat module is lazy-registered on entry. Users don't have to visit `/chat` first.

### i18n

zh-CN + en only (per `AGENTS.md` guidance — auto-translation runs separately for the other 16 locales). New `byok.json` scope plus `console.menu.byokList` in both locales' `console.json`.

## Verification

- `npm run lint` clean
- `npm run build` clean
- `vue-tsc -b` no errors
- Manual smoke test against `/aichat2/credentials` endpoint (live aichat2 once PR 1 + PR 2 deploy + the ops step below)

Pre-existing prettier nits in `Composer.vue` / `NotFound.vue` (introduced by the npm migration #549) are explicitly **not** included — they belong in a separate cleanup PR. CI's `npm run lint` runs with `--fix` so it auto-handles them.

## Operations prerequisite (NOT in this PR)

`/aichat2/credentials` is a new path under the existing `/aichat2/*` Kong route, but the gateway's `get_api_by_path()` only resolves paths that have an `Api` row in PlatformBackend. Without registration, every CRUD call will get a 404 from the gateway. Same one-shot operation as the existing `/aichat2/skills` / `/aichat2/connectors` registrations:

1. Run `python manage.py shell` on a `platform-backend` pod and create an `Api` row with `path='/aichat2/credentials'` (any service id; the worker only reads `ctx.userId`).
2. Take the returned UUID, open a one-line PR against [`PlatformGateway/app/utils/can_skip_check.py`](https://github.com/AceDataCloud/PlatformGateway) adding it to the BYOK skip-check block (so credential CRUD doesn't try to deduct credits).
3. Roll out PlatformGateway.

After that, this PR's CRUD UI becomes functional. The 🔑 badge stays inert (silent `console.debug` fallback) until then — no broken UI for users who haven't configured BYOK.

## Series wrap-up

| PR | Repo | What |
|---|---|---|
| [#817](https://github.com/AceDataCloud/PlatformService/pull/817) | PlatformService | BYOK CRUD + storage + AES-256-GCM encryption + SSRF guard (32 new tests) |
| [#818](https://github.com/AceDataCloud/PlatformService/pull/818) | PlatformService | Chat-path routing — `LLMClient` honours user override (5 new tests) |
| **This PR** | Nexior | Settings page + 🔑 badge |

