### PR TITLE
fix(cf-workers): drop public/_redirects (handled by wrangler SPA fallback)

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,5 +1,0 @@
-# Cloudflare Pages SPA history-mode fallback.
-# Vue Router uses createWebHistory(), so deep links like /chat/<id> must be
-# rewritten to /index.html (status 200) on the edge — otherwise refreshing
-# any non-root route on a *.pages.dev preview returns 404.
-/*    /index.html   200

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,3 +1,8 @@
+// Cloudflare Workers config for Nexior.
+// Deploys the Vite SPA build (`dist/`) as a static-assets-only Worker.
+// SPA fallback routes unknown paths to `index.html` so client-side
+// Vue Router routes resolve correctly instead of returning 404.
+// Docs: https://developers.cloudflare.com/workers/static-assets/
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "nexior",


### PR DESCRIPTION
Cloudflare Workers Builds was failing with:

```
Invalid _redirects configuration:
Line 5: Infinite loop detected in this rule. This would cause a redirect to strip `.html` or `/index` and end up triggering this rule again. [code: 10021]
```

The offending rule was `/*    /index.html   200`.

This file was originally added for Cloudflare **Pages**, but the current deployment target is Cloudflare **Workers** (per `wrangler.jsonc`). On Workers, the `_redirects` validator rejects this rule as an infinite loop because Workers auto-strips `.html`/`/index` paths and would re-match the wildcard.

SPA fallback is already declared at the Worker level via `assets.not_found_handling: "single-page-application"`, so `public/_redirects` is now both redundant and breaking. Removing it.

Also includes a small header comment on `wrangler.jsonc` explaining what the file does.