### PR TITLE
chore(deploy): redirect hub.acedata.cloud → studio.acedata.cloud

### DIFF
--- a/deploy/production/ingress.yaml
+++ b/deploy/production/ingress.yaml
@@ -1,0 +1,43 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: hub-frontend
+  namespace: acedatacloud
+  annotations:
+    kubernetes.io/ingress.class: nginx-router
+    kubernetes.io/ingress.rule-mix: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    # Force redirect every request (path + query preserved) to studio.acedata.cloud.
+    # `return 301` runs before the upstream is hit, so the dummy backend below is
+    # never reached — it only exists to satisfy the Ingress schema.
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      return 301 https://studio.acedata.cloud$request_uri;
+spec:
+  tls:
+    - hosts:
+        - hub.acedata.cloud
+      secretName: tls-wildcard-acedata-cloud
+    - hosts:
+        - "*.hub.acedata.cloud"
+      secretName: tls-wildcard-hub-acedata-cloud
+  rules:
+    - host: hub.acedata.cloud
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: hub-frontend
+                port:
+                  number: 8083
+    - host: "*.hub.acedata.cloud"
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: hub-frontend
+                port:
+                  number: 8083


### PR DESCRIPTION
## Summary

Adds a redirect-only Ingress (`deploy/production/ingress.yaml`) that catches every request to `hub.acedata.cloud` (and `*.hub.acedata.cloud`) and returns **HTTP 301 → `https://studio.acedata.cloud$request_uri`** so the full path and query string are preserved.

## Why

`studio.acedata.cloud` is the canonical Nexior host. `hub.acedata.cloud` should now be a permanent redirect so users, search engines and old bookmarks all consolidate onto Studio.

## How

`nginx.ingress.kubernetes.io/configuration-snippet` injects:

```nginx
return 301 https://studio.acedata.cloud$request_uri;
```

This runs inside the location block before the upstream is reached, so the dummy `hub-frontend` backend reference is never hit — it only exists to satisfy the Ingress schema. The `configuration-snippet` annotation is already in use elsewhere in the cluster (`wisdom-novnc`), so the controller (Tencent TKE `nginx-router`) is known to allow it.

## Verification (already applied to prod)

```
$ curl -sI https://hub.acedata.cloud/
HTTP/2 301
location: https://studio.acedata.cloud/

$ curl -sI 'https://hub.acedata.cloud/chatgpt/conversations?lang=en'
HTTP/2 301
location: https://studio.acedata.cloud/chatgpt/conversations?lang=en
```

Both root and deep links with query strings redirect correctly.

## Notes / follow-ups

- The legacy `hub-frontend` Deployment + Service are intentionally **not** deleted in this PR. They are still referenced by the dummy backend block above and can be cleaned up in a follow-up once we confirm no traffic relies on them.
- EdgeOne sits in front of this Ingress for `hub.acedata.cloud`. 301 responses are not cached by default, but if any HTML page was previously cached by EO, an EO cache purge for `hub.acedata.cloud/*` may be useful as an extra step.