### PR TITLE
fix(subsite): expose 'My Subsites' from the navbar avatar dropdown

### DIFF
--- a/src/components/user/Center.vue
+++ b/src/components/user/Center.vue
@@ -24,6 +24,10 @@
             <font-awesome-icon icon="fa-solid fa-plug" class="mr-2" />
             {{ $t('common.nav.connections') }}
           </el-dropdown-item>
+          <el-dropdown-item v-if="showSubsite" class="py-2" @click="onSubsite">
+            <font-awesome-icon icon="fa-solid fa-sitemap" class="mr-2" />
+            {{ $t('common.nav.subsite') }}
+          </el-dropdown-item>
           <el-dropdown-item class="py-2" @click="onConsole">
             <font-awesome-icon icon="fa-solid fa-compass" class="mr-2" />
             {{ $t('common.nav.console') }}
@@ -44,7 +48,7 @@ import { defineComponent } from 'vue';
 import UserAvatar from '@/components/user/Avatar.vue';
 import UserSetting from '@/components/user/Setting.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { ROUTE_CONSOLE_ROOT, ROUTE_DISTRIBUTION_INDEX, ROUTE_DOWNLOAD } from '@/router';
+import { ROUTE_CONSOLE_ROOT, ROUTE_DISTRIBUTION_INDEX, ROUTE_DOWNLOAD, ROUTE_SUBSITE_INDEX } from '@/router';
 import { withCurrentUserId } from '@/utils';
 import { ElDivider } from 'element-plus';
 import { ElDropdownMenu, ElDropdownItem, ElDropdown } from 'element-plus';
@@ -69,6 +73,14 @@ export default defineComponent({
   computed: {
     user() {
       return this.$store.getters?.user;
+    },
+    showSubsite() {
+      // Show 'My Subsites' only when the parent Site has explicitly opted
+      // into the subsite (white-label) feature. The /subsite route's own
+      // mounted() guard plus PlatformBackend's POST /api/v1/sites/ check
+      // stay the source of truth; this just hides the menu entry on
+      // origins that haven't enabled it.
+      return Boolean(this.$store?.state?.site?.features?.subsite?.enabled);
     }
   },
   mounted() {
@@ -105,6 +117,11 @@ export default defineComponent({
     onDistribution() {
       this.$router.push({
         name: ROUTE_DISTRIBUTION_INDEX
+      });
+    },
+    onSubsite() {
+      this.$router.push({
+        name: ROUTE_SUBSITE_INDEX
       });
     },
     onSettings() {


### PR DESCRIPTION
小修，但这个修不上线整个分站功能在生产其实是隐藏的 — 我刚才在 studio.acedata.cloud 上找入口才发现的。

## 背景

PR #551 把 "My Subsites" 加到了 [`pages/profile/Index.vue`](https://github.com/AceDataCloud/Nexior/blob/main/src/pages/profile/Index.vue) 的菜单里 — 但那只是 **`/profile` 路由的侧栏**，不是用户日常点开的 **navbar 头像下拉**（`components/user/Center.vue`）。所以即使在 `features.subsite.enabled=true` 的 origin（`studio.acedata.cloud`）上，从首页/聊天页根本找不到入口。

## 改动

`components/user/Center.vue` 的下拉菜单加一个 "My Subsites" 项：

- 跳 `ROUTE_SUBSITE_INDEX`（PR #551 已经注册）
- 用 `faSitemap` 图标（PR #551 已注册到 font-awesome library）
- `showSubsite` computed 复用 `pages/profile/Index.vue` 同款 gate：`store.state.site.features.subsite.enabled`

`/subsite` 路由的 `mounted()` 守卫 + PlatformBackend #382 的 `POST /api/v1/sites/` 网关仍然是真正的访问控制 — 这个 PR 只是让入口在 subsite-enabled origin 上**实际可见**。

## 验证

- `npm run lint` 干净
- `npm run build` 通过（~12s，vue-tsc + vite）
- studio.acedata.cloud（已开启 subsite）的头像下拉里现在能看到 "我的分站" / "My Subsites"
- 其它 origin 的下拉菜单完全不变（gate 关闭时 `<el-dropdown-item v-if="showSubsite">` 不渲染）
