### PR TITLE
feat(kling): align ConfigPanel UI with /kling/videos API (4K mode + camera control + disable-not-hide UX)

### DIFF
--- a/src/components/kling/ConfigPanel.vue
+++ b/src/components/kling/ConfigPanel.vue
@@ -9,6 +9,7 @@
       <duration-selector class="mb-4" />
       <mode-selector class="mb-4" />
       <generate-audio-selector class="mb-4" />
+      <camera-control-selector class="mb-4" />
       <cfg-scale-selector class="mb-4" />
       <negative-prompt-input class="mb-4" />
     </div>
@@ -45,6 +46,7 @@ import EndImage from './config/EndImage.vue';
 import Consumption from '../common/Consumption.vue';
 import CfgScaleSelector from './config/CfgScaleSelector.vue';
 import GenerateAudioSelector from './config/GenerateAudioSelector.vue';
+import CameraControlSelector from './config/CameraControlSelector.vue';
 import PromptInput from './config/PromptInput.vue';
 import NegativePromptInput from './config/NegativePromptInput.vue';
 import { getConsumption } from '@/utils';
@@ -64,6 +66,7 @@ export default defineComponent({
     StartImage,
     CfgScaleSelector,
     GenerateAudioSelector,
+    CameraControlSelector,
     EndImage
   },
   emits: ['generate'],

--- a/src/components/kling/config/CameraControlSelector.vue
+++ b/src/components/kling/config/CameraControlSelector.vue
@@ -1,0 +1,206 @@
+<template>
+  <div class="field">
+    <div class="header">
+      <span class="text-sm font-bold">{{ $t('kling.name.cameraControl') }}</span>
+      <info-icon :content="tooltipContent" />
+    </div>
+    <el-select
+      v-model="selectedTypeRaw"
+      class="value"
+      :placeholder="$t('kling.placeholder.cameraType')"
+      :clearable="true"
+      :disabled="disabled"
+    >
+      <el-option v-for="item in typeOptions" :key="item.value" :label="item.label" :value="item.value" />
+    </el-select>
+    <div v-if="selectedType === 'simple' && !disabled" class="config-grid">
+      <div v-for="key in configKeys" :key="key" class="cfg-row">
+        <div class="cfg-row-head">
+          <span class="cfg-name">{{ $t(`kling.name.cc_${key}`) }}</span>
+          <el-input-number
+            v-model="configValues[key]"
+            :min="-1"
+            :max="1"
+            :step="0.1"
+            :precision="1"
+            controls-position="right"
+            size="small"
+            class="cfg-num"
+            @change="onNumberChange(key, $event)"
+          />
+        </div>
+        <el-slider
+          :model-value="configValues[key] ?? 0"
+          :min="-1"
+          :max="1"
+          :step="0.1"
+          @input="onSliderChange(key, $event as number)"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElSelect, ElOption, ElSlider, ElInputNumber } from 'element-plus';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+import { IKlingCameraType, IKlingCameraControlConfig } from '@/models';
+
+const CONFIG_KEYS: (keyof IKlingCameraControlConfig)[] = ['horizontal', 'vertical', 'pan', 'tilt', 'roll', 'zoom'];
+
+interface IData {
+  configKeys: (keyof IKlingCameraControlConfig)[];
+}
+
+export default defineComponent({
+  name: 'CameraControlSelector',
+  components: {
+    ElSelect,
+    ElOption,
+    ElSlider,
+    ElInputNumber,
+    InfoIcon
+  },
+  data(): IData {
+    return {
+      configKeys: CONFIG_KEYS
+    };
+  },
+  computed: {
+    typeOptions() {
+      return [
+        { value: '', label: this.$t('kling.name.cameraTypeNone') },
+        { value: 'simple', label: this.$t('kling.name.cameraTypeSimple') },
+        { value: 'down_back', label: this.$t('kling.name.cameraTypeDownBack') },
+        { value: 'forward_up', label: this.$t('kling.name.cameraTypeForwardUp') },
+        { value: 'left_turn_forward', label: this.$t('kling.name.cameraTypeLeftTurnForward') },
+        { value: 'right_turn_forward', label: this.$t('kling.name.cameraTypeRightTurnForward') }
+      ];
+    },
+    selectedMode(): string {
+      return this.$store.state.kling?.config?.mode || '';
+    },
+    disabled(): boolean {
+      // 4k mode is incompatible with motion / camera control per API spec.
+      return this.selectedMode === '4k';
+    },
+    tooltipContent(): string {
+      if (this.disabled) {
+        return this.$t('kling.description.cameraControlDisabled4k');
+      }
+      return this.$t('kling.description.cameraControl');
+    },
+    selectedType(): IKlingCameraType | undefined {
+      return this.$store.state.kling?.config?.camera_control?.type;
+    },
+    selectedTypeRaw: {
+      get(): string {
+        return this.selectedType ?? '';
+      },
+      set(val: string) {
+        const cfg = this.$store.state.kling?.config || {};
+        if (!val) {
+          // Clear camera_control entirely
+          const next = { ...cfg };
+          delete next.camera_control;
+          this.$store.commit('kling/setConfig', next);
+          return;
+        }
+        const typed = val as IKlingCameraType;
+        this.$store.commit('kling/setConfig', {
+          ...cfg,
+          camera_control: {
+            type: typed,
+            // Only 'simple' carries a config block; presets ignore numeric values.
+            config: typed === 'simple' ? cfg.camera_control?.config || {} : undefined
+          }
+        });
+      }
+    },
+    configValues(): IKlingCameraControlConfig {
+      return this.$store.state.kling?.config?.camera_control?.config || {};
+    }
+  },
+  watch: {
+    disabled(now: boolean) {
+      // Auto-clear camera_control when 4k mode is selected so the request stays valid.
+      if (now && this.selectedType !== undefined) {
+        this.selectedTypeRaw = '';
+      }
+    }
+  },
+  methods: {
+    writeConfig(key: keyof IKlingCameraControlConfig, val: number | undefined) {
+      const cfg = this.$store.state.kling?.config || {};
+      const cc = cfg.camera_control || { type: 'simple' };
+      const nextConfig: IKlingCameraControlConfig = { ...(cc.config || {}) };
+      if (val === undefined || val === null) {
+        delete nextConfig[key];
+      } else {
+        nextConfig[key] = val;
+      }
+      this.$store.commit('kling/setConfig', {
+        ...cfg,
+        camera_control: {
+          ...cc,
+          type: 'simple',
+          config: nextConfig
+        }
+      });
+    },
+    onSliderChange(key: keyof IKlingCameraControlConfig, val: number) {
+      this.writeConfig(key, val);
+    },
+    onNumberChange(key: keyof IKlingCameraControlConfig, val: number | undefined) {
+      this.writeConfig(key, val);
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  .header {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+  .value {
+    width: 100%;
+  }
+}
+.config-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px;
+  border-radius: 8px;
+  background-color: var(--el-fill-color-lighter);
+
+  .cfg-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+
+    .cfg-row-head {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      justify-content: space-between;
+
+      .cfg-name {
+        font-size: 12px;
+        color: var(--el-text-color-regular);
+      }
+      .cfg-num {
+        width: 100px;
+      }
+    }
+  }
+}
+</style>

--- a/src/components/kling/config/DurationSelector.vue
+++ b/src/components/kling/config/DurationSelector.vue
@@ -1,8 +1,22 @@
 <template>
   <div class="field">
-    <h2 class="title font-bold">{{ $t('kling.name.duration') }}</h2>
+    <div class="header">
+      <h2 class="title font-bold">{{ $t('kling.name.duration') }}</h2>
+      <info-icon :content="$t('kling.description.duration')" class="info-icon" />
+    </div>
     <el-select v-model="value" class="value" :placeholder="$t('kling.placeholder.select')">
-      <el-option v-for="item in options" :key="item.value" :label="item.label" :value="item.value" />
+      <el-option
+        v-for="item in options"
+        :key="item.value"
+        :label="item.label"
+        :value="item.value"
+        :disabled="item.disabled"
+      >
+        <span :class="{ 'opt-disabled': item.disabled }">{{ item.label }}</span>
+        <span v-if="item.disabled" class="opt-tip">
+          {{ $t('kling.description.durationV3Only') }}
+        </span>
+      </el-option>
     </el-select>
   </div>
 </template>
@@ -10,27 +24,24 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import { ElSelect, ElOption } from 'element-plus';
+import InfoIcon from '@/components/common/InfoIcon.vue';
 import { KLING_DEFAULT_DURATION, KLING_V3_MODELS } from '@/constants';
 
-const STANDARD_OPTIONS = [
-  { value: 5, label: '5秒' },
-  { value: 10, label: '10秒' }
-];
-
-const V3_OPTIONS = [
-  { value: 3, label: '3秒' },
-  { value: 5, label: '5秒' },
-  { value: 8, label: '8秒' },
-  { value: 10, label: '10秒' },
-  { value: 12, label: '12秒' },
-  { value: 15, label: '15秒' }
+const ALL_DURATIONS: { value: number; label: string; v3Only: boolean }[] = [
+  { value: 3, label: '3s', v3Only: true },
+  { value: 5, label: '5s', v3Only: false },
+  { value: 8, label: '8s', v3Only: true },
+  { value: 10, label: '10s', v3Only: false },
+  { value: 12, label: '12s', v3Only: true },
+  { value: 15, label: '15s', v3Only: true }
 ];
 
 export default defineComponent({
   name: 'DurationSelector',
   components: {
     ElSelect,
-    ElOption
+    ElOption,
+    InfoIcon
   },
   props: {
     modelValue: {
@@ -40,20 +51,23 @@ export default defineComponent({
   },
   emits: ['update:modelValue'],
   computed: {
-    selectedModel() {
+    selectedModel(): string {
       return this.$store.state.kling?.config?.model || '';
     },
-    isV3Model() {
+    isV3Model(): boolean {
       return KLING_V3_MODELS.includes(this.selectedModel);
     },
     options() {
-      return this.isV3Model ? V3_OPTIONS : STANDARD_OPTIONS;
+      return ALL_DURATIONS.map((d) => ({
+        ...d,
+        disabled: d.v3Only && !this.isV3Model
+      }));
     },
     value: {
-      get() {
+      get(): number | undefined {
         return this.$store.state.kling?.config?.duration;
       },
-      set(val: string) {
+      set(val: number) {
         this.$store.commit('kling/setConfig', {
           ...this.$store.state.kling.config,
           duration: val
@@ -62,10 +76,11 @@ export default defineComponent({
     }
   },
   watch: {
-    isV3Model(newVal: boolean) {
+    isV3Model(_: boolean) {
+      // Auto-correct if the currently selected duration becomes disabled.
       const current = this.value;
-      const validValues = (newVal ? V3_OPTIONS : STANDARD_OPTIONS).map((o) => o.value);
-      if (current !== undefined && !validValues.includes(current)) {
+      const enabled = this.options.filter((o) => !o.disabled).map((o) => o.value);
+      if (current !== undefined && !enabled.includes(current)) {
         this.value = KLING_DEFAULT_DURATION;
       }
     }
@@ -85,13 +100,27 @@ export default defineComponent({
   align-items: center;
   justify-content: space-between;
 
-  .title {
-    font-size: 14px;
-    margin: 0;
-    width: 30%;
+  .header {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    width: 50%;
+
+    .title {
+      font-size: 14px;
+      margin: 0;
+    }
   }
   .value {
-    width: 80px;
+    width: 120px;
   }
+}
+.opt-disabled {
+  color: var(--el-text-color-disabled);
+}
+.opt-tip {
+  margin-left: 8px;
+  font-size: 11px;
+  color: var(--el-text-color-placeholder);
 }
 </style>

--- a/src/components/kling/config/GenerateAudioSelector.vue
+++ b/src/components/kling/config/GenerateAudioSelector.vue
@@ -1,8 +1,11 @@
 <template>
-  <div v-if="visible" class="relative">
+  <div class="relative">
     <div class="flex justify-between items-center">
-      <span class="text-sm font-bold">{{ $t('kling.name.generateAudio') }}</span>
-      <el-switch v-model="value" class="value" />
+      <div class="flex justify-start items-center">
+        <span class="text-sm font-bold">{{ $t('kling.name.generateAudio') }}</span>
+        <info-icon :content="tooltipContent" />
+      </div>
+      <el-switch v-model="value" class="value" :disabled="!supported" />
     </div>
   </div>
 </template>
@@ -10,21 +13,23 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import { ElSwitch } from 'element-plus';
+import InfoIcon from '@/components/common/InfoIcon.vue';
 import { KLING_DEFAULT_GENERATE_AUDIO, KLING_V3_MODELS } from '@/constants';
 
 export default defineComponent({
   name: 'GenerateAudioSelector',
   components: {
-    ElSwitch
+    ElSwitch,
+    InfoIcon
   },
   computed: {
-    selectedModel() {
+    selectedModel(): string {
       return this.$store.state.kling?.config?.model || '';
     },
-    selectedMode() {
+    selectedMode(): string {
       return this.$store.state.kling?.config?.mode || '';
     },
-    visible() {
+    supported(): boolean {
       if (KLING_V3_MODELS.includes(this.selectedModel)) {
         return true;
       }
@@ -33,8 +38,14 @@ export default defineComponent({
       }
       return false;
     },
+    tooltipContent(): string {
+      return this.supported
+        ? this.$t('kling.description.generateAudio')
+        : this.$t('kling.description.generateAudioUnsupported');
+    },
     value: {
-      get() {
+      get(): boolean {
+        if (!this.supported) return false;
         return this.$store.state.kling?.config?.generate_audio ?? KLING_DEFAULT_GENERATE_AUDIO;
       },
       set(val: boolean) {
@@ -46,9 +57,13 @@ export default defineComponent({
     }
   },
   watch: {
-    visible(newVal: boolean) {
-      if (!newVal && this.value) {
-        this.value = false;
+    supported(newVal: boolean) {
+      // When option becomes unsupported, clear the persisted value so the request payload stays clean.
+      if (!newVal && this.$store.state.kling?.config?.generate_audio) {
+        this.$store.commit('kling/setConfig', {
+          ...this.$store.state.kling?.config,
+          generate_audio: false
+        });
       }
     }
   }

--- a/src/components/kling/config/ModeSelector.vue
+++ b/src/components/kling/config/ModeSelector.vue
@@ -1,8 +1,22 @@
 <template>
   <div class="field">
-    <h2 class="title font-bold">{{ $t('kling.name.mode') }}</h2>
+    <div class="header">
+      <h2 class="title font-bold">{{ $t('kling.name.mode') }}</h2>
+      <info-icon :content="$t('kling.description.mode')" class="info-icon" />
+    </div>
     <el-select v-model="value" class="value" :placeholder="$t('kling.placeholder.select')" :clearable="true">
-      <el-option v-for="item in options" :key="item.value" :label="item.label" :value="item.value" />
+      <el-option
+        v-for="item in options"
+        :key="item.value"
+        :label="item.label"
+        :value="item.value"
+        :disabled="item.disabled"
+      >
+        <span :class="{ 'opt-disabled': item.disabled }">{{ item.label }}</span>
+        <span v-if="item.disabled && item.disabledReason" class="opt-tip">
+          {{ item.disabledReason }}
+        </span>
+      </el-option>
     </el-select>
   </div>
 </template>
@@ -10,13 +24,15 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import { ElSelect, ElOption } from 'element-plus';
-import { KLING_DEFAULT_MODE } from '@/constants';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+import { KLING_DEFAULT_MODE, KLING_V3_MODELS } from '@/constants';
 
 export default defineComponent({
   name: 'ModeSelector',
   components: {
     ElSelect,
-    ElOption
+    ElOption,
+    InfoIcon
   },
   props: {
     modelValue: {
@@ -25,23 +41,37 @@ export default defineComponent({
     }
   },
   emits: ['update:modelValue'],
-  data() {
-    return {
-      options: [
-        {
-          value: 'std',
-          label: this.$t('kling.name.modeStd')
-        },
-        {
-          value: 'pro',
-          label: this.$t('kling.name.modePro')
-        }
-      ]
-    };
-  },
   computed: {
+    selectedModel(): string {
+      return this.$store.state.kling?.config?.model || '';
+    },
+    cameraControlSet(): boolean {
+      const cc = this.$store.state.kling?.config?.camera_control;
+      return Boolean(cc?.type);
+    },
+    fourKReason(): string {
+      if (!KLING_V3_MODELS.includes(this.selectedModel)) {
+        return this.$t('kling.description.mode4kRequiresV3');
+      }
+      if (this.cameraControlSet) {
+        return this.$t('kling.description.mode4kIncompatibleCamera');
+      }
+      return '';
+    },
+    options() {
+      return [
+        { value: 'std', label: this.$t('kling.name.modeStd'), disabled: false, disabledReason: '' },
+        { value: 'pro', label: this.$t('kling.name.modePro'), disabled: false, disabledReason: '' },
+        {
+          value: '4k',
+          label: this.$t('kling.name.mode4k'),
+          disabled: Boolean(this.fourKReason),
+          disabledReason: this.fourKReason
+        }
+      ];
+    },
     value: {
-      get() {
+      get(): string | undefined {
         return this.$store.state.kling?.config?.mode;
       },
       set(val: string) {
@@ -49,6 +79,14 @@ export default defineComponent({
           ...this.$store.state.kling.config,
           mode: val
         });
+      }
+    }
+  },
+  watch: {
+    fourKReason(reason: string) {
+      // If 4k becomes invalid (e.g. user switched model away from v3), revert to default.
+      if (reason && this.value === '4k') {
+        this.value = KLING_DEFAULT_MODE;
       }
     }
   },
@@ -67,13 +105,27 @@ export default defineComponent({
   align-items: center;
   justify-content: space-between;
 
-  .title {
-    font-size: 14px;
-    margin: 0;
-    width: 30%;
+  .header {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    width: 50%;
+
+    .title {
+      font-size: 14px;
+      margin: 0;
+    }
   }
   .value {
-    width: 80px;
+    width: 120px;
   }
+}
+.opt-disabled {
+  color: var(--el-text-color-disabled);
+}
+.opt-tip {
+  margin-left: 8px;
+  font-size: 11px;
+  color: var(--el-text-color-placeholder);
 }
 </style>

--- a/src/i18n/en/kling.json
+++ b/src/i18n/en/kling.json
@@ -15,6 +15,62 @@
     "message": "High Quality",
     "description": "The high-quality mode of the Kling video"
   },
+  "name.mode4k": {
+    "message": "Native 4K",
+    "description": "Native 4K mode (only kling-v3 / kling-v3-omni)"
+  },
+  "name.cameraControl": {
+    "message": "Camera Control",
+    "description": "Camera control type and parameters"
+  },
+  "name.cameraTypeNone": {
+    "message": "Off",
+    "description": "No camera control"
+  },
+  "name.cameraTypeSimple": {
+    "message": "Custom (6 axes)",
+    "description": "Use custom 6-axis simple control"
+  },
+  "name.cameraTypeDownBack": {
+    "message": "Down + Back",
+    "description": "Preset move: down then back"
+  },
+  "name.cameraTypeForwardUp": {
+    "message": "Forward + Up",
+    "description": "Preset move: forward then up"
+  },
+  "name.cameraTypeLeftTurnForward": {
+    "message": "Left Turn + Forward",
+    "description": "Preset move: turn left and move forward"
+  },
+  "name.cameraTypeRightTurnForward": {
+    "message": "Right Turn + Forward",
+    "description": "Preset move: turn right and move forward"
+  },
+  "name.cc_horizontal": {
+    "message": "Horizontal",
+    "description": "camera_control.config.horizontal"
+  },
+  "name.cc_vertical": {
+    "message": "Vertical",
+    "description": "camera_control.config.vertical"
+  },
+  "name.cc_pan": {
+    "message": "Pan",
+    "description": "camera_control.config.pan"
+  },
+  "name.cc_tilt": {
+    "message": "Tilt",
+    "description": "camera_control.config.tilt"
+  },
+  "name.cc_roll": {
+    "message": "Roll",
+    "description": "camera_control.config.roll"
+  },
+  "name.cc_zoom": {
+    "message": "Zoom",
+    "description": "camera_control.config.zoom"
+  },
   "name.failure": {
     "message": "Failure",
     "description": "The failure status of the task"
@@ -123,6 +179,42 @@
     "message": "The freedom level for generating the video, optional [0,1]. Larger values indicate stronger relevance.",
     "description": "Description for the upload reference parameter"
   },
+  "description.mode": {
+    "message": "std is faster, pro has higher quality; 4K is only supported by v3 / v3-Omni and is not compatible with camera control.",
+    "description": "Mode field overall description"
+  },
+  "description.mode4kRequiresV3": {
+    "message": "Only kling-v3 / kling-v3-omni",
+    "description": "Reason 4k is disabled (model mismatch)"
+  },
+  "description.mode4kIncompatibleCamera": {
+    "message": "Camera control is enabled (incompatible)",
+    "description": "Reason 4k is disabled (camera control set)"
+  },
+  "description.duration": {
+    "message": "Standard models support only 5 / 10 seconds; v3 / v3-Omni support 3 / 5 / 8 / 10 / 12 / 15 seconds.",
+    "description": "Duration field overall description"
+  },
+  "description.durationV3Only": {
+    "message": "v3 / v3-Omni only",
+    "description": "Reason a duration option is disabled"
+  },
+  "description.generateAudio": {
+    "message": "Generate audio together with the video. Only kling-v3 / kling-v3-omni / kling-v2-6 (pro mode) support this.",
+    "description": "Audio toggle description (supported)"
+  },
+  "description.generateAudioUnsupported": {
+    "message": "The current model does not support synchronized audio. Switch to kling-v3 / kling-v3-omni or kling-v2-6 (pro mode) to enable.",
+    "description": "Audio toggle description (disabled)"
+  },
+  "description.cameraControl": {
+    "message": "Drive the camera direction. Choose 'Custom' to fine-tune 6 axes; each accepts values in [-1, 1].",
+    "description": "Camera control description"
+  },
+  "description.cameraControlDisabled4k": {
+    "message": "Camera control is unavailable in 4K mode. Switch to std / pro to enable.",
+    "description": "Reason camera control is disabled"
+  },
   "status.pending": {
     "message": "Pending",
     "description": "The pending status of the task"
@@ -158,6 +250,10 @@
   "placeholder.aspectRatio": {
     "message": "Please select...",
     "description": "Placeholder for aspect ratio input"
+  },
+  "placeholder.cameraType": {
+    "message": "Off",
+    "description": "Placeholder for camera control type"
   },
   "placeholder.preset": {
     "message": "Please select...",

--- a/src/i18n/zh-CN/kling.json
+++ b/src/i18n/zh-CN/kling.json
@@ -15,6 +15,62 @@
     "message": "高品质",
     "description": "Kling视频的高品质模式"
   },
+  "name.mode4k": {
+    "message": "原生 4K",
+    "description": "Kling 4K 模式（仅 v3 / v3-Omni 支持）"
+  },
+  "name.cameraControl": {
+    "message": "运镜控制",
+    "description": "相机控制类型与参数"
+  },
+  "name.cameraTypeNone": {
+    "message": "不使用",
+    "description": "不使用运镜控制"
+  },
+  "name.cameraTypeSimple": {
+    "message": "自定义（6 维度）",
+    "description": "使用自定义六维度参数"
+  },
+  "name.cameraTypeDownBack": {
+    "message": "下移并后退",
+    "description": "预设运镜：下移并后退"
+  },
+  "name.cameraTypeForwardUp": {
+    "message": "向前并上移",
+    "description": "预设运镜：向前并上移"
+  },
+  "name.cameraTypeLeftTurnForward": {
+    "message": "左转并前进",
+    "description": "预设运镜：左转并前进"
+  },
+  "name.cameraTypeRightTurnForward": {
+    "message": "右转并前进",
+    "description": "预设运镜：右转并前进"
+  },
+  "name.cc_horizontal": {
+    "message": "水平移动",
+    "description": "camera_control.config.horizontal"
+  },
+  "name.cc_vertical": {
+    "message": "垂直移动",
+    "description": "camera_control.config.vertical"
+  },
+  "name.cc_pan": {
+    "message": "水平摇镜（pan）",
+    "description": "camera_control.config.pan"
+  },
+  "name.cc_tilt": {
+    "message": "垂直摇镜（tilt）",
+    "description": "camera_control.config.tilt"
+  },
+  "name.cc_roll": {
+    "message": "翻滚（roll）",
+    "description": "camera_control.config.roll"
+  },
+  "name.cc_zoom": {
+    "message": "推拉变焦（zoom）",
+    "description": "camera_control.config.zoom"
+  },
   "name.failure": {
     "message": "失败",
     "description": "任务的失败状态"
@@ -123,6 +179,42 @@
     "message": "生成视频的自由度，可选[0,1]。值越大，相关性越强，",
     "description": "上传参考参数的描述"
   },
+  "description.mode": {
+    "message": "std 性能更高，pro 画质更好；4K 仅 v3 / v3-Omni 支持，且不可与运镜控制同时使用",
+    "description": "模式字段的整体说明"
+  },
+  "description.mode4kRequiresV3": {
+    "message": "仅 kling-v3 / kling-v3-omni 支持",
+    "description": "4k 选项被禁用的原因（模型不匹配）"
+  },
+  "description.mode4kIncompatibleCamera": {
+    "message": "已开启运镜控制，不可与 4K 同时使用",
+    "description": "4k 选项被禁用的原因（已设置运镜）"
+  },
+  "description.duration": {
+    "message": "普通模型仅支持 5/10 秒；v3 / v3-Omni 支持 3/5/8/10/12/15 秒",
+    "description": "时长字段的整体说明"
+  },
+  "description.durationV3Only": {
+    "message": "仅 v3 / v3-Omni 支持",
+    "description": "时长选项禁用原因"
+  },
+  "description.generateAudio": {
+    "message": "在生成视频的同时合成音效。仅 kling-v3 / kling-v3-omni / kling-v2-6（pro 模式）支持",
+    "description": "音效开关说明（已支持）"
+  },
+  "description.generateAudioUnsupported": {
+    "message": "当前模型不支持同步音效，仅 kling-v3 / kling-v3-omni / kling-v2-6（pro 模式）可用",
+    "description": "音效开关说明（已禁用）"
+  },
+  "description.cameraControl": {
+    "message": "控制相机的运动方向。选择「自定义」可在 6 个维度上微调，每项取值 [-1, 1]",
+    "description": "运镜控制说明"
+  },
+  "description.cameraControlDisabled4k": {
+    "message": "已选择 4K 模式，运镜控制不可用，请切换到 std / pro 后再启用",
+    "description": "运镜控制被禁用原因"
+  },
   "status.pending": {
     "message": "等待中",
     "description": "任务的等待状态"
@@ -158,6 +250,10 @@
   "placeholder.aspectRatio": {
     "message": "请选择...",
     "description": "宽高比输入的占位符"
+  },
+  "placeholder.cameraType": {
+    "message": "不使用",
+    "description": "运镜类型选择占位符"
   },
   "placeholder.preset": {
     "message": "请选择...",

--- a/src/models/kling.ts
+++ b/src/models/kling.ts
@@ -1,3 +1,29 @@
+export type IKlingCameraType = 'simple' | 'down_back' | 'forward_up' | 'left_turn_forward' | 'right_turn_forward';
+
+export interface IKlingCameraControlConfig {
+  horizontal?: number;
+  vertical?: number;
+  pan?: number;
+  tilt?: number;
+  roll?: number;
+  zoom?: number;
+}
+
+export interface IKlingCameraControl {
+  type?: IKlingCameraType;
+  config?: IKlingCameraControlConfig;
+}
+
+export interface IKlingReferenceVideo {
+  video_url?: string;
+  refer_type?: 'feature' | 'base';
+  keep_original_sound?: 'yes' | 'no';
+}
+
+export interface IKlingElementRef {
+  element_id?: string;
+}
+
 export interface IKlingConfig {
   action?: string;
   mode?: string;
@@ -11,10 +37,12 @@ export interface IKlingConfig {
   negative_prompt?: string;
   aspect_ratio?: string;
   duration?: number;
-  camera_control?: string;
+  camera_control?: IKlingCameraControl;
   cfg_scale?: number;
   callback_url?: string;
   generate_audio?: boolean;
+  element_list?: IKlingElementRef[];
+  video_list?: IKlingReferenceVideo[];
 }
 
 export interface IKlingGenerateRequest {
@@ -28,11 +56,12 @@ export interface IKlingGenerateRequest {
   negative_prompt?: string;
   aspect_ratio?: string;
   duration?: number;
-  camera_control?: string;
+  camera_control?: IKlingCameraControl;
   cfg_scale?: number;
   callback_url?: string;
-  mirror?: boolean;
   generate_audio?: boolean;
+  element_list?: IKlingElementRef[];
+  video_list?: IKlingReferenceVideo[];
 }
 export interface IKlingVideo {
   id?: string;

--- a/src/pages/kling/Index.vue
+++ b/src/pages/kling/Index.vue
@@ -146,10 +146,24 @@ export default defineComponent({
       }
     },
     async onGenerate() {
+      const { camera_control, ...rest } = this.config || {};
       const request = {
-        ...this.config,
+        ...rest,
         callback_url: CALLBACK_URL
       } as IKlingGenerateRequest;
+      // Only include camera_control when a type is set; clean empty config blocks.
+      if (camera_control?.type) {
+        request.camera_control = {
+          type: camera_control.type,
+          ...(camera_control.type === 'simple' && camera_control.config
+            ? {
+                config: Object.fromEntries(
+                  Object.entries(camera_control.config).filter(([, v]) => v !== undefined && v !== null)
+                )
+              }
+            : {})
+        };
+      }
       const token = this.credential?.token;
       if (!token) {
         console.error('no token specified');


### PR DESCRIPTION
## Why

The current Kling page in `studio.acedata.cloud/kling` is missing several `/kling/videos` parameters and hides options that should still be visible (so users can see *what's not available and why*). Recent failures from the live UI:

- `mode \"4k\" is only supported by kling-v3 and kling-v1-video-01` — UI never offered \`4k\`, but a stale persisted config / direct API call exposed it.
- Camera control (Kling's marquee feature) had a stale \`camera_control: string\` in TypeScript and **no UI at all**.
- Audio toggle previously *vanished* on unsupported models; users couldn't tell whether the feature existed.

## What changed

### Added (visible in UI now)

| Field | UI |
|---|---|
| \`mode = \"4k\"\` | New option in ModeSelector. Disabled (greyed) with InfoIcon when model is not v3/v3-omni or when camera control is set. Auto-reverts to std on invalid combinations. |
| \`camera_control\` | New \`CameraControlSelector.vue\`. Type select: Off / Custom (6 axes) / Down+Back / Forward+Up / Left+Forward / Right+Forward. When **Custom** is chosen, 6 sliders + numeric inputs appear for \`horizontal / vertical / pan / tilt / roll / zoom\` in [-1, 1]. The whole section is disabled with an InfoIcon when 4K mode is selected (per API spec they're mutually exclusive). |
| Forward-compat types | \`IKlingReferenceVideo\`, \`IKlingElementRef\` added to models so future UIs for \`video_list\` / \`element_list\` can wire in without another type migration. |

### Behavior changes (disable, not hide)

| Component | Before | After |
|---|---|---|
| GenerateAudioSelector | \`v-if=\"visible\"\` removed the toggle on unsupported models. | Always visible. Switch is **disabled** with InfoIcon explaining \"only kling-v3 / v3-omni / v2-6 (pro) support synchronized audio\". |
| DurationSelector | Swapped option list (5/10 ↔ 3/5/8/10/12/15) when model changed. | Always shows all 6 options. \`3/8/12/15\` are **disabled** with \"v3 / v3-Omni only\" hint when model isn't v3. |
| ModeSelector | Only \`std\` / \`pro\`. | All three. \`4k\` is disabled with reason text inline + InfoIcon on the field. |

### Removed

- \`mirror?: boolean\` from \`IKlingGenerateRequest\` — not in the OpenAPI spec, dead code.

### Payload

\`Index.vue#onGenerate\` now sanitizes \`camera_control\` before sending: drop the entire object if no type set, drop the \`config\` block for non-\`simple\` presets, drop empty keys inside \`config\`.

### i18n

Added zh-CN + en strings for the new field names, disable reasons, and InfoIcon tooltips. Other 16 locales will be auto-translated by the \`translate.py\` CronJob (no manual translation per CLAUDE.md).

## Verification

- \`vue-tsc --noEmit\`: clean for kling files.
- \`npm run lint\`: clean.
- \`npx vite build\`: ✓ built. (Pre-existing \`src/utils/domain.test.ts\` errors on main are not introduced by this PR.)

## Out of scope (separate follow-ups)

- \`element_list\` (Kling subject library): UI deferred — needs an upstream subject browser; just typing element_id strings without lookup is poor UX.
- \`video_list\` (reference video upload): UI deferred. Both fields are typed and round-trip-safe so a future PR can add the editor without further model changes.
- The motion API (\`/kling/motion\`) returning \`model is invalid, it can only be kling-v1...\` for non-v1 models is a separate UI guard in the motion entry path, not in \`/kling/videos\`.