### PR TITLE
fix(kling): show start/end reference images in task preview

### DIFF
--- a/src/components/kling/task/Preview.vue
+++ b/src/components/kling/task/Preview.vue
@@ -11,6 +11,18 @@
         </span>
       </div>
       <div class="info">
+        <div
+          v-if="referenceImages.length > 0"
+          class="flex justify-start items-center gap-2 mt-2 w-full overflow-x-auto"
+        >
+          <image-preview
+            v-for="(image, idx) in referenceImages"
+            :key="idx"
+            :url="image.url"
+            :name="image.name"
+            :closable="false"
+          />
+        </div>
         <p v-if="modelValue?.request?.prompt" class="prompt mt-2">
           {{ modelValue?.request?.prompt }}
           <span v-if="!modelValue?.response"> - ({{ $t('kling.status.pending') }}) </span>
@@ -117,6 +129,7 @@ import { IKlingTask } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import VideoPlayer from '@/components/common/VideoPlayer.vue';
+import ImagePreview from '@/components/common/ImagePreview.vue';
 
 export default defineComponent({
   name: 'TaskPreview',
@@ -127,7 +140,8 @@ export default defineComponent({
     ElAlert,
     VideoPlayer,
     ElTooltip,
-    ElButton
+    ElButton,
+    ImagePreview
   },
   props: {
     modelValue: {
@@ -144,6 +158,18 @@ export default defineComponent({
     },
     config() {
       return this.$store.state.kling?.config;
+    },
+    referenceImages(): { url: string; name: string }[] {
+      const images: { url: string; name: string }[] = [];
+      const startImageUrl = this.modelValue?.request?.start_image_url;
+      const endImageUrl = this.modelValue?.request?.end_image_url;
+      if (startImageUrl) {
+        images.push({ url: startImageUrl, name: 'start-image' });
+      }
+      if (endImageUrl) {
+        images.push({ url: endImageUrl, name: 'end-image' });
+      }
+      return images;
     }
   },
   methods: {


### PR DESCRIPTION
## Problem

In `studio.acedata.cloud/kling`, when a user uploads a 首帧参考图 (`start_image_url`) and/or 尾帧参考图 (`end_image_url`) for video generation, the task list preview did not display those reference images. Other services like NanoBanana already render thumbnails of the input reference images in their task preview.

## Fix

Mirror the NanoBanana pattern in `src/components/kling/task/Preview.vue`:

- Import `ImagePreview` (the same component used by NanoBanana / others).
- Add a `referenceImages` computed property that builds a list from `modelValue.request.start_image_url` and `modelValue.request.end_image_url` (named `start-image` / `end-image`).
- Render the thumbnails above the prompt in a horizontally-scrollable flex row, matching the existing NanoBanana layout.

No backend / model changes — `IKlingGenerateRequest` already exposes both fields.

## Test

- Vue/TS lint clean (`get_errors` shows no errors on the modified file).
- Visual: a Kling task with one or both reference images now shows the thumbnails next to the prompt, consistent with NanoBanana.