### PR TITLE
fix(nginx): never cache index.html (fixes stale-bundle 404 after deploys)

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -52,10 +52,30 @@ server {
         try_files /llms.txt =404;
     }
 
+    # ---- HTML / SPA shell: NEVER cache ----
+    # index.html (and any *.html) hardcodes the hashed asset filenames of
+    # the current build (e.g. <script src="/assets/index-Be3-2h2U.js">).
+    # If a CDN edge keeps an old index.html after a deploy, browsers
+    # receive the old hashes and 404 on the new chunks — exactly the
+    # outage we hit on studio.acedata.cloud (#560 deploy).
+    # Hashed assets in /assets/ are content-addressed, so they stay
+    # `immutable` forever; only the HTML shell needs no-store.
+    location ~* \.html$ {
+        root /usr/share/nginx/html;
+        add_header Cache-Control "no-store, must-revalidate" always;
+        add_header Pragma "no-cache" always;
+        expires 0;
+    }
+
     location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
         try_files   $uri    $uri/   /index.html;
+        # Same no-cache policy when the SPA fallback serves /index.html
+        # for a deep link (e.g. /veo, /chatgpt).
+        add_header Cache-Control "no-store, must-revalidate" always;
+        add_header Pragma "no-cache" always;
+        expires 0;
     }
 
     error_page  404              /404.html;


### PR DESCRIPTION
## 这是 #560 那次诡异 bug 的真凶

PR #560 上线后，studio.acedata.cloud 上 navbar 头像下拉**还是看不到 "My Subsites"**。我反复 deploy、purge、看 bundle 都正常，但用户那边死活不行。最后挖到底——

**问题:** 浏览器拿到的 `index.html` 引用的是**旧** main bundle (`index-BYsLWQ2Z.js`)，那个旧 bundle 引用 `Navigator-BFDWCxP1.js` —— 这个 chunk 在新 build 里已经被覆盖成 `Navigator-D867UM8Z.js`，404。结果新菜单代码根本没加载。

**根因:** [`nginx.conf`](https://github.com/AceDataCloud/Nexior/blob/main/nginx.conf) 对 `index.html` 没设任何 `Cache-Control`，EdgeOne CDN 默认会缓存它。每次部署都会留一段时间窗口，期间 edge 服 stale `index.html` → 浏览器按旧 hash 加载 chunk → 拿到 404。

我们一直在手动 `python3 .claude/scripts/edgeone.py purge ...` 修这个，但显然不可持续。

## 修复

`nginx.conf` 给 `*.html` 和 SPA fallback 路径加：

```nginx
add_header Cache-Control "no-store, must-revalidate" always;
add_header Pragma "no-cache" always;
expires 0;
```

这是 hash-named-assets SPA 的标准 pattern：
- `index.html` 是唯一 pin 当前 build hash 的文件，必须永远从源拉。
- `/assets/*`（hash 文件名）保持 `Cache-Control: public, max-age=31536000, immutable` **不变** —— 它们文件名每 build 都变，永远能安全长期缓存。

## 影响

- ✅ 修好后再也不用 deploy 完手动 purge EO
- ✅ Hashed asset 缓存策略不变（继续吃 CDN benefit）
- ✅ 用户体验：HTML 多走一次源（~10–30ms）但 chunk 永不再 404
- ❌ 不变更任何业务逻辑或 API 行为

## 验证

- `git diff` +20 行，对 `/assets/` 块零改动
- 语法和文件里其他 location 块的 `add_header` + `expires` 模式一致
- 真正的验证会在合并 + 部署后由下次 deploy 自然完成 —— 第一次请求就会拿到 fresh `index.html`，不再需要任何手动 purge
