### PR TITLE
feat(kling): add Motion Control tab + Avatar coming-soon (mirror kling.ai 3-tab UX)

### DIFF
--- a/src/components/kling/MotionPanel.vue
+++ b/src/components/kling/MotionPanel.vue
@@ -1,0 +1,69 @@
+<template>
+  <div class="flex flex-col h-full">
+    <div class="flex-1 overflow-y-auto p-5">
+      <motion-image class="mb-3" />
+      <motion-video class="mb-3" />
+      <motion-prompt-input class="mb-4" />
+      <character-orientation-selector class="mb-4" />
+      <motion-mode-selector class="mb-4" />
+      <keep-original-sound-selector class="mb-4" />
+    </div>
+    <div class="flex flex-col items-center justify-center px-5 pb-5">
+      <consumption :value="consumption" :service="service" />
+      <el-button type="primary" class="btn w-full" round :disabled="!canGenerate" @click="onGenerate">
+        <font-awesome-icon icon="fa-solid fa-magic" class="mr-2" />
+        {{ $t('kling.button.generateMotion') }}
+      </el-button>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElButton } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import Consumption from '../common/Consumption.vue';
+import MotionImage from './motion/MotionImage.vue';
+import MotionVideo from './motion/MotionVideo.vue';
+import MotionPromptInput from './motion/MotionPromptInput.vue';
+import CharacterOrientationSelector from './motion/CharacterOrientationSelector.vue';
+import MotionModeSelector from './motion/MotionModeSelector.vue';
+import KeepOriginalSoundSelector from './motion/KeepOriginalSoundSelector.vue';
+import { getConsumption } from '@/utils';
+
+export default defineComponent({
+  name: 'MotionPanel',
+  components: {
+    ElButton,
+    FontAwesomeIcon,
+    Consumption,
+    MotionImage,
+    MotionVideo,
+    MotionPromptInput,
+    CharacterOrientationSelector,
+    MotionModeSelector,
+    KeepOriginalSoundSelector
+  },
+  emits: ['generate'],
+  computed: {
+    motionConfig() {
+      return this.$store.state.kling?.motionConfig;
+    },
+    consumption() {
+      return getConsumption(this.motionConfig, this.service?.cost);
+    },
+    service() {
+      return this.$store.state.kling?.service;
+    },
+    canGenerate(): boolean {
+      const cfg = this.motionConfig;
+      return Boolean(cfg?.image_url && cfg?.video_url);
+    }
+  },
+  methods: {
+    onGenerate() {
+      this.$emit('generate');
+    }
+  }
+});
+</script>

--- a/src/components/kling/TabSwitcher.vue
+++ b/src/components/kling/TabSwitcher.vue
@@ -1,0 +1,152 @@
+<template>
+  <div class="kling-tabs">
+    <div
+      v-for="tab in tabs"
+      :key="tab.value"
+      :class="{ tab: true, active: tab.value === modelValue, disabled: tab.disabled }"
+      @click="onSelect(tab)"
+    >
+      <font-awesome-icon v-if="tab.icon" :icon="tab.icon" class="mr-2" />
+      <span>{{ tab.label }}</span>
+      <el-tooltip v-if="tab.disabled && tab.disabledReason" effect="dark" :content="tab.disabledReason" placement="top">
+        <font-awesome-icon icon="fa-solid fa-info" class="info ml-2" />
+      </el-tooltip>
+      <el-tag v-if="tab.badge" size="small" type="warning" class="ml-2 badge">{{ tab.badge }}</el-tag>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, PropType } from 'vue';
+import { ElTooltip, ElTag } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { IKlingTaskType } from '@/models';
+
+interface ITab {
+  value: IKlingTaskType | 'avatar';
+  label: string;
+  icon?: string;
+  disabled?: boolean;
+  disabledReason?: string;
+  badge?: string;
+}
+
+export default defineComponent({
+  name: 'KlingTabSwitcher',
+  components: {
+    ElTooltip,
+    ElTag,
+    FontAwesomeIcon
+  },
+  props: {
+    modelValue: {
+      type: String as PropType<IKlingTaskType>,
+      default: 'videos'
+    }
+  },
+  emits: ['update:modelValue'],
+  computed: {
+    tabs(): ITab[] {
+      return [
+        {
+          value: 'videos',
+          label: this.$t('kling.tab.videoGeneration'),
+          icon: 'fa-solid fa-film'
+        },
+        {
+          value: 'motion',
+          label: this.$t('kling.tab.motionControl'),
+          icon: 'fa-solid fa-person-running'
+        },
+        {
+          value: 'avatar',
+          label: this.$t('kling.tab.avatar'),
+          icon: 'fa-solid fa-user-tie',
+          disabled: true,
+          disabledReason: this.$t('kling.tab.avatarComingSoon'),
+          badge: this.$t('kling.tab.comingSoon')
+        }
+      ];
+    }
+  },
+  methods: {
+    onSelect(tab: ITab) {
+      if (tab.disabled) return;
+      if (tab.value === 'avatar') return;
+      this.$emit('update:modelValue', tab.value);
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.kling-tabs {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--app-border-subtle);
+  background-color: var(--app-content-bg);
+  overflow-x: auto;
+
+  .tab {
+    display: inline-flex;
+    align-items: center;
+    padding: 6px 14px;
+    border-radius: 999px;
+    font-size: 14px;
+    color: var(--el-text-color-regular);
+    cursor: pointer;
+    user-select: none;
+    white-space: nowrap;
+    transition:
+      background-color 0.15s ease,
+      color 0.15s ease,
+      box-shadow 0.15s ease;
+
+    &:hover:not(.disabled):not(.active) {
+      background-color: var(--el-fill-color);
+    }
+
+    &.active {
+      background-color: var(--el-color-primary);
+      color: #fff;
+      box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+    }
+
+    &.disabled {
+      color: var(--el-text-color-disabled);
+      cursor: not-allowed;
+    }
+
+    .info {
+      font-size: 11px;
+      width: 14px;
+      height: 14px;
+      border: 2px solid currentColor;
+      border-radius: 50%;
+      padding: 2px;
+      transform: scale(0.8);
+      opacity: 0.7;
+    }
+
+    .badge {
+      font-size: 10px;
+      height: 18px;
+      line-height: 16px;
+    }
+  }
+}
+
+@media (max-width: 767px) {
+  .kling-tabs {
+    padding: 8px 12px;
+    gap: 4px;
+    .tab {
+      padding: 4px 10px;
+      font-size: 12px;
+    }
+  }
+}
+</style>

--- a/src/components/kling/motion/CharacterOrientationSelector.vue
+++ b/src/components/kling/motion/CharacterOrientationSelector.vue
@@ -1,0 +1,61 @@
+<template>
+  <div class="field">
+    <div class="header">
+      <span class="text-sm font-bold">{{ $t('kling.name.characterOrientation') }}</span>
+      <info-icon :content="$t('kling.description.characterOrientation')" />
+    </div>
+    <el-radio-group v-model="value" size="small" class="value">
+      <el-radio-button label="image">{{ $t('kling.name.orientationImage') }}</el-radio-button>
+      <el-radio-button label="video">{{ $t('kling.name.orientationVideo') }}</el-radio-button>
+    </el-radio-group>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElRadioGroup, ElRadioButton } from 'element-plus';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+
+const DEFAULT: 'image' | 'video' = 'video';
+
+export default defineComponent({
+  name: 'CharacterOrientationSelector',
+  components: {
+    ElRadioGroup,
+    ElRadioButton,
+    InfoIcon
+  },
+  computed: {
+    value: {
+      get(): 'image' | 'video' {
+        return this.$store.state.kling?.motionConfig?.character_orientation || DEFAULT;
+      },
+      set(val: 'image' | 'video') {
+        this.$store.commit('kling/setMotionConfig', {
+          ...this.$store.state.kling?.motionConfig,
+          character_orientation: val
+        });
+      }
+    }
+  },
+  mounted() {
+    if (!this.$store.state.kling?.motionConfig?.character_orientation) {
+      this.value = DEFAULT;
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+
+  .header {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+}
+</style>

--- a/src/components/kling/motion/KeepOriginalSoundSelector.vue
+++ b/src/components/kling/motion/KeepOriginalSoundSelector.vue
@@ -1,0 +1,39 @@
+<template>
+  <div class="relative">
+    <div class="flex justify-between items-center">
+      <div class="flex justify-start items-center">
+        <span class="text-sm font-bold">{{ $t('kling.name.keepOriginalSound') }}</span>
+        <info-icon :content="$t('kling.description.keepOriginalSound')" />
+      </div>
+      <el-switch v-model="value" />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElSwitch } from 'element-plus';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+
+export default defineComponent({
+  name: 'KeepOriginalSoundSelector',
+  components: {
+    ElSwitch,
+    InfoIcon
+  },
+  computed: {
+    value: {
+      get(): boolean {
+        // Default `yes` per API spec.
+        return (this.$store.state.kling?.motionConfig?.keep_original_sound ?? 'yes') === 'yes';
+      },
+      set(val: boolean) {
+        this.$store.commit('kling/setMotionConfig', {
+          ...this.$store.state.kling?.motionConfig,
+          keep_original_sound: val ? 'yes' : 'no'
+        });
+      }
+    }
+  }
+});
+</script>

--- a/src/components/kling/motion/MotionImage.vue
+++ b/src/components/kling/motion/MotionImage.vue
@@ -1,0 +1,129 @@
+<template>
+  <div class="relative">
+    <div class="flex justify-between">
+      <div class="flex justify-start items-center">
+        <span class="text-sm font-bold">{{ $t('kling.name.motionImage') }}</span>
+        <info-icon :content="$t('kling.description.motionImage')" />
+      </div>
+    </div>
+    <el-upload
+      ref="uploader"
+      v-model:file-list="fileList"
+      name="file"
+      accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
+      :limit="1"
+      class="upload-wrapper"
+      :multiple="false"
+      :action="uploadUrl"
+      list-type="picture"
+      :on-exceed="onExceed"
+      :on-error="onError"
+      :on-success="onSuccess"
+      :headers="headers"
+    >
+      <template #file="{ file }">
+        <image-preview
+          v-if="file.url && file.percentage !== undefined"
+          :url="file.url"
+          :name="file.name"
+          :percentage="file.percentage"
+          @remove="onRemove(file)"
+        />
+      </template>
+      <el-button round type="primary" size="small" class="btn btn-upload">
+        <font-awesome-icon icon="fa-solid fa-upload" class="icon mr-1" />
+        {{ $t('kling.button.uploadReferences') }}
+      </el-button>
+    </el-upload>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElUpload, ElButton, UploadFiles, UploadFile, ElMessage } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+import ImagePreview from '@/components/common/ImagePreview.vue';
+
+interface IData {
+  fileList: UploadFiles;
+  uploadUrl: string;
+}
+
+export default defineComponent({
+  name: 'MotionImage',
+  components: {
+    ElUpload,
+    ElButton,
+    InfoIcon,
+    FontAwesomeIcon,
+    ImagePreview
+  },
+  mixins: [pasteUploadMixin],
+  data(): IData {
+    return {
+      fileList: [],
+      uploadUrl: getBaseUrlPlatform() + '/api/v1/files/'
+    };
+  },
+  computed: {
+    headers() {
+      return {
+        Authorization: `Bearer ${this.$store.state.token.access}`
+      };
+    },
+    urls() {
+      // @ts-ignore
+      return this.fileList.map((file: UploadFile) => file?.response?.file_url);
+    }
+  },
+  mounted() {
+    this.onSetImageUrl();
+  },
+  methods: {
+    onExceed() {
+      ElMessage.warning(this.$t('kling.message.uploadReferencesExceed'));
+    },
+    onError() {
+      ElMessage.error(this.$t('kling.message.uploadReferencesError'));
+    },
+    onRemove(file: UploadFile) {
+      this.fileList.splice(this.fileList.indexOf(file), 1);
+      this.$store.commit('kling/setMotionConfig', {
+        ...this.$store.state.kling?.motionConfig,
+        image_url: undefined
+      });
+    },
+    onSetImageUrl() {
+      const url = this.urls?.[0];
+      this.$store.commit('kling/setMotionConfig', {
+        ...this.$store.state.kling?.motionConfig,
+        image_url: url
+      });
+    },
+    async onSuccess() {
+      this.onSetImageUrl();
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.btn.btn-upload {
+  position: absolute;
+  top: 5px;
+  right: 0;
+}
+</style>
+
+<style lang="scss">
+.upload-wrapper {
+  height: auto;
+  display: flex;
+  .el-upload-list {
+    margin: 0;
+    width: 100%;
+  }
+}
+</style>

--- a/src/components/kling/motion/MotionModeSelector.vue
+++ b/src/components/kling/motion/MotionModeSelector.vue
@@ -1,0 +1,76 @@
+<template>
+  <div class="field">
+    <div class="header">
+      <h2 class="title font-bold">{{ $t('kling.name.mode') }}</h2>
+      <info-icon :content="$t('kling.description.motionMode')" />
+    </div>
+    <el-select v-model="value" class="value" :placeholder="$t('kling.placeholder.select')">
+      <el-option v-for="item in options" :key="item.value" :label="item.label" :value="item.value" />
+    </el-select>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElSelect, ElOption } from 'element-plus';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+
+const DEFAULT: 'std' | 'pro' = 'std';
+
+export default defineComponent({
+  name: 'MotionModeSelector',
+  components: {
+    ElSelect,
+    ElOption,
+    InfoIcon
+  },
+  computed: {
+    options() {
+      return [
+        { value: 'std', label: this.$t('kling.name.modeStd') },
+        { value: 'pro', label: this.$t('kling.name.modePro') }
+      ];
+    },
+    value: {
+      get(): 'std' | 'pro' {
+        return this.$store.state.kling?.motionConfig?.mode || DEFAULT;
+      },
+      set(val: 'std' | 'pro') {
+        this.$store.commit('kling/setMotionConfig', {
+          ...this.$store.state.kling?.motionConfig,
+          mode: val
+        });
+      }
+    }
+  },
+  mounted() {
+    if (!this.$store.state.kling?.motionConfig?.mode) {
+      this.value = DEFAULT;
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.field {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+
+  .header {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    width: 50%;
+
+    .title {
+      font-size: 14px;
+      margin: 0;
+    }
+  }
+  .value {
+    width: 120px;
+  }
+}
+</style>

--- a/src/components/kling/motion/MotionPromptInput.vue
+++ b/src/components/kling/motion/MotionPromptInput.vue
@@ -1,0 +1,60 @@
+<template>
+  <div class="field">
+    <div class="box">
+      <h2 class="title font-bold">{{ $t('kling.name.motionPrompt') }}</h2>
+      <info-icon :content="$t('kling.description.motionPrompt')" class="info" />
+    </div>
+    <el-input
+      v-model="prompt"
+      :rows="3"
+      type="textarea"
+      class="prompt"
+      :placeholder="$t('kling.placeholder.motionPrompt')"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElInput } from 'element-plus';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+
+export default defineComponent({
+  name: 'MotionPromptInput',
+  components: {
+    ElInput,
+    InfoIcon
+  },
+  computed: {
+    prompt: {
+      get(): string {
+        return this.$store.state.kling?.motionConfig?.prompt || '';
+      },
+      set(val: string) {
+        this.$store.commit('kling/setMotionConfig', {
+          ...this.$store.state.kling?.motionConfig,
+          prompt: val
+        });
+      }
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.field {
+  .box {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    position: relative;
+    .title {
+      font-size: 14px;
+      margin-bottom: 10px;
+    }
+  }
+  .info {
+    margin-left: auto;
+  }
+}
+</style>

--- a/src/components/kling/motion/MotionVideo.vue
+++ b/src/components/kling/motion/MotionVideo.vue
@@ -1,0 +1,130 @@
+<template>
+  <div class="relative">
+    <div class="flex justify-between">
+      <div class="flex justify-start items-center">
+        <span class="text-sm font-bold">{{ $t('kling.name.motionVideo') }}</span>
+        <info-icon :content="$t('kling.description.motionVideo')" />
+      </div>
+    </div>
+    <el-upload
+      v-model:file-list="fileList"
+      accept=".mp4,.mov"
+      name="file"
+      class="value"
+      :show-file-list="true"
+      :limit="1"
+      :multiple="false"
+      :action="uploadUrl"
+      :before-upload="beforeUpload"
+      :on-exceed="onExceed"
+      :on-error="onError"
+      :on-success="onSuccess"
+      :headers="headers"
+    >
+      <template #file="{ file }">
+        <file-preview
+          v-if="file.percentage !== undefined"
+          :url="file.url || (file.response as any)?.file_url"
+          :name="file.name"
+          :percentage="file.percentage"
+          @remove="onRemove(file)"
+        />
+      </template>
+      <el-button round type="primary" size="small" class="btn btn-upload">
+        <font-awesome-icon icon="fa-solid fa-upload" class="icon mr-1" />
+        {{ $t('kling.button.uploadVideoUrl') }}
+      </el-button>
+    </el-upload>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElButton, ElUpload, ElMessage, UploadFiles, UploadFile } from 'element-plus';
+import { getBaseUrlPlatform } from '@/utils';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+import FilePreview from '@/components/common/FilePreview.vue';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+
+interface IData {
+  fileList: UploadFiles;
+  uploadUrl: string;
+}
+
+export default defineComponent({
+  name: 'MotionVideo',
+  components: {
+    ElUpload,
+    ElButton,
+    InfoIcon,
+    FilePreview,
+    FontAwesomeIcon
+  },
+  data(): IData {
+    return {
+      fileList: [],
+      uploadUrl: getBaseUrlPlatform() + '/api/v1/files/'
+    };
+  },
+  computed: {
+    headers() {
+      return {
+        Authorization: `Bearer ${this.$store.state.token.access}`
+      };
+    },
+    urls(): string[] {
+      // @ts-ignore
+      return this.fileList.map((file: UploadFile) => file?.response?.file_url);
+    }
+  },
+  mounted() {
+    this.onSetVideoUrl();
+  },
+  methods: {
+    onExceed() {
+      ElMessage.warning(this.$t('kling.message.uploadVideoExceed'));
+    },
+    onError() {
+      ElMessage.error(this.$t('kling.message.uploadVideoError'));
+    },
+    onRemove(file: UploadFile) {
+      this.fileList.splice(this.fileList.indexOf(file), 1);
+      this.$store.commit('kling/setMotionConfig', {
+        ...this.$store.state.kling?.motionConfig,
+        video_url: undefined
+      });
+    },
+    beforeUpload(file: File) {
+      const isMP4orMOV = file.type === 'video/mp4' || file.type === 'video/quicktime';
+      const isLt100M = file.size / 1024 / 1024 < 100;
+      if (!isMP4orMOV) {
+        ElMessage.error(this.$t('kling.message.uploadVideoTypeFailed'));
+        return false;
+      }
+      if (!isLt100M) {
+        ElMessage.error(this.$t('kling.message.uploadVideoSizeExceed'));
+        return false;
+      }
+      return true;
+    },
+    onSetVideoUrl() {
+      const url = this.urls?.[0];
+      this.$store.commit('kling/setMotionConfig', {
+        ...this.$store.state.kling?.motionConfig,
+        video_url: url
+      });
+    },
+    async onSuccess() {
+      this.onSetVideoUrl();
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.btn.btn-upload {
+  position: absolute;
+  top: 5px;
+  right: 0;
+}
+</style>

--- a/src/i18n/en/kling.json
+++ b/src/i18n/en/kling.json
@@ -1,4 +1,88 @@
 {
+  "tab.videoGeneration": {
+    "message": "Video Generation",
+    "description": "Tab label"
+  },
+  "tab.motionControl": {
+    "message": "Motion Control",
+    "description": "Tab label"
+  },
+  "tab.avatar": {
+    "message": "Avatar",
+    "description": "Tab label: AI-Human / digital avatar"
+  },
+  "tab.comingSoon": {
+    "message": "Coming soon",
+    "description": "Coming-soon badge text"
+  },
+  "tab.avatarComingSoon": {
+    "message": "Avatar (face image + speech to talking-head video) is coming soon. Stay tuned.",
+    "description": "Tooltip explaining why Avatar tab is disabled"
+  },
+  "name.motionImage": {
+    "message": "Character image",
+    "description": "Motion Control character/scene reference image"
+  },
+  "name.motionVideo": {
+    "message": "Motion reference video",
+    "description": "Motion Control reference motion video"
+  },
+  "name.motionPrompt": {
+    "message": "Additional prompt (optional)",
+    "description": "Motion Control supplemental prompt"
+  },
+  "name.characterOrientation": {
+    "message": "Character orientation",
+    "description": "character_orientation field"
+  },
+  "name.orientationImage": {
+    "message": "Match image",
+    "description": "character_orientation = image"
+  },
+  "name.orientationVideo": {
+    "message": "Match video",
+    "description": "character_orientation = video"
+  },
+  "name.keepOriginalSound": {
+    "message": "Keep original sound",
+    "description": "keep_original_sound switch"
+  },
+  "description.motionImage": {
+    "message": "Upload the character reference image. The characters, backgrounds and other elements in the generated video will be based on this image.",
+    "description": "motion image_url description"
+  },
+  "description.motionVideo": {
+    "message": "Upload a motion reference video. Character movements in the generated video will follow this video (MP4 / MOV, ≤1 minute, ≤1 GB).",
+    "description": "motion video_url description"
+  },
+  "description.motionPrompt": {
+    "message": "Optional. May contain both positive and negative descriptions to refine the result.",
+    "description": "motion prompt description"
+  },
+  "description.characterOrientation": {
+    "message": "Choose 'Match video' for complex motions; choose 'Match image' to keep the character orientation aligned with the image and improve camera-movement fidelity.",
+    "description": "character_orientation description"
+  },
+  "description.motionMode": {
+    "message": "std prioritizes speed; pro prioritizes quality.",
+    "description": "motion mode description"
+  },
+  "description.keepOriginalSound": {
+    "message": "When ON, retain the original audio from the reference video. When OFF, the output will not contain the original audio.",
+    "description": "keep_original_sound description"
+  },
+  "placeholder.motionPrompt": {
+    "message": "e.g. A person dancing. Optional.",
+    "description": "motion prompt placeholder"
+  },
+  "button.generateMotion": {
+    "message": "Generate motion video",
+    "description": "Motion Control generate button"
+  },
+  "message.motionMissingInputs": {
+    "message": "Please upload both a character image and a motion reference video.",
+    "description": "Motion Control missing inputs warning"
+  },
   "name.taskId": {
     "message": "Task ID",
     "description": "The ID of the task"

--- a/src/i18n/zh-CN/kling.json
+++ b/src/i18n/zh-CN/kling.json
@@ -1,4 +1,88 @@
 {
+  "tab.videoGeneration": {
+    "message": "视频生成",
+    "description": "Tab 标签：Video Generation"
+  },
+  "tab.motionControl": {
+    "message": "动作控制",
+    "description": "Tab 标签：Motion Control"
+  },
+  "tab.avatar": {
+    "message": "数字人",
+    "description": "Tab 标签：Avatar / AI-Human"
+  },
+  "tab.comingSoon": {
+    "message": "即将上线",
+    "description": "即将上线的起骨标签"
+  },
+  "tab.avatarComingSoon": {
+    "message": "数字人（股脸 + 语音合成说话视频）即将上线，敬请期待",
+    "description": "Avatar Tab 被禁用的 Tooltip 说明"
+  },
+  "name.motionImage": {
+    "message": "人物参考图片",
+    "description": "Motion Control 中的人物图输入"
+  },
+  "name.motionVideo": {
+    "message": "动作参考视频",
+    "description": "Motion Control 中的参考视频输入"
+  },
+  "name.motionPrompt": {
+    "message": "补充提示词（可选）",
+    "description": "Motion Control 中的补充提示词"
+  },
+  "name.characterOrientation": {
+    "message": "人物朝向",
+    "description": "人物朝向字段"
+  },
+  "name.orientationImage": {
+    "message": "跟随图片",
+    "description": "人物朝向选项：跟随图片"
+  },
+  "name.orientationVideo": {
+    "message": "跟随视频",
+    "description": "人物朝向选项：跟随视频"
+  },
+  "name.keepOriginalSound": {
+    "message": "保留原始音频",
+    "description": "keep_original_sound 开关"
+  },
+  "description.motionImage": {
+    "message": "上传人物参考图，生成视频中的人物、背景等元素均以此为参照",
+    "description": "motion image_url 说明"
+  },
+  "description.motionVideo": {
+    "message": "上传动作参考视频，生成视频中的人物动作与该视频一致（MP4 / MOV，≤1 分钟，≤1 GB）",
+    "description": "motion video_url 说明"
+  },
+  "description.motionPrompt": {
+    "message": "可选。可以包含正向描述与负向描述，辅助生成效果",
+    "description": "motion prompt 说明"
+  },
+  "description.characterOrientation": {
+    "message": "选「跟随视频」时，复杂动作表现更好；选「跟随图片」时，人物朝向与参考图一致，镜头运动表现更好",
+    "description": "character_orientation 说明"
+  },
+  "description.motionMode": {
+    "message": "std 性能优先，pro 画质优先",
+    "description": "motion mode 说明"
+  },
+  "description.keepOriginalSound": {
+    "message": "开启后保留参考视频的原声；关闭后输出视频不包含原始音频",
+    "description": "keep_original_sound 说明"
+  },
+  "placeholder.motionPrompt": {
+    "message": "例如：一个人在跳舅。可选。",
+    "description": "motion prompt 占位符"
+  },
+  "button.generateMotion": {
+    "message": "生成动作控制视频",
+    "description": "Motion Control 生成按钮"
+  },
+  "message.motionMissingInputs": {
+    "message": "请同时上传人物图与动作参考视频",
+    "description": "Motion Control 缺少输入时的提示"
+  },
   "name.taskId": {
     "message": "任务 ID",
     "description": "任务的 ID"

--- a/src/layouts/Kling.vue
+++ b/src/layouts/Kling.vue
@@ -1,19 +1,22 @@
 <template>
-  <div class="main flex flex-row flex-1">
-    <div
-      class="config w-[320px] flex-none h-full overflow-y-auto bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
-    >
-      <slot name="config" />
+  <div class="kling-layout flex flex-col flex-1 min-h-0">
+    <slot v-if="$slots.tabs" name="tabs" />
+    <div class="main flex flex-row flex-1 min-h-0">
+      <div
+        class="config w-[320px] flex-none h-full overflow-y-auto bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+      >
+        <slot name="config" />
+      </div>
+      <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
+        <slot name="result" />
+      </div>
+      <el-button circle class="menu" @click="drawer = true">
+        <font-awesome-icon icon="fa-solid fa-magic" />
+      </el-button>
+      <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="350px">
+        <slot name="config" />
+      </el-drawer>
     </div>
-    <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
-      <slot name="result" />
-    </div>
-    <el-button circle class="menu" @click="drawer = true">
-      <font-awesome-icon icon="fa-solid fa-magic" />
-    </el-button>
-    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="350px">
-      <slot name="config" />
-    </el-drawer>
   </div>
 </template>
 

--- a/src/models/kling.ts
+++ b/src/models/kling.ts
@@ -24,6 +24,28 @@ export interface IKlingElementRef {
   element_id?: string;
 }
 
+export type IKlingTaskType = 'videos' | 'motion';
+
+export interface IKlingMotionConfig {
+  prompt?: string;
+  image_url?: string;
+  video_url?: string;
+  character_orientation?: 'image' | 'video';
+  mode?: 'std' | 'pro';
+  keep_original_sound?: 'yes' | 'no';
+  callback_url?: string;
+}
+
+export interface IKlingMotionRequest {
+  prompt?: string;
+  image_url?: string;
+  video_url?: string;
+  character_orientation?: 'image' | 'video';
+  mode?: 'std' | 'pro';
+  keep_original_sound?: 'yes' | 'no';
+  callback_url?: string;
+}
+
 export interface IKlingConfig {
   action?: string;
   mode?: string;
@@ -89,7 +111,8 @@ export interface IKlingGenerateResponse {
 export interface IKlingTask {
   id: string;
   created_at?: number;
-  request?: IKlingGenerateRequest;
+  type?: IKlingTaskType;
+  request?: IKlingGenerateRequest & IKlingMotionRequest;
   response?: IKlingGenerateResponse;
 }
 

--- a/src/operators/kling.ts
+++ b/src/operators/kling.ts
@@ -1,5 +1,11 @@
 import axios, { AxiosResponse } from 'axios';
-import { IKlingGenerateRequest, IKlingGenerateResponse, IKlingTaskResponse, IKlingTasksResponse } from '@/models';
+import {
+  IKlingGenerateRequest,
+  IKlingGenerateResponse,
+  IKlingMotionRequest,
+  IKlingTaskResponse,
+  IKlingTasksResponse
+} from '@/models';
 import { BASE_URL_API } from '@/constants';
 
 class KlingOperator {
@@ -99,6 +105,22 @@ class KlingOperator {
     }
   ): Promise<AxiosResponse<IKlingGenerateResponse>> {
     return await axios.post('/kling/videos', data, {
+      headers: {
+        authorization: `Bearer ${options.token}`,
+        'content-type': 'application/json',
+        accept: 'application/x-ndjson'
+      },
+      baseURL: BASE_URL_API
+    });
+  }
+
+  async motion(
+    data: IKlingMotionRequest,
+    options: {
+      token: string;
+    }
+  ): Promise<AxiosResponse<IKlingGenerateResponse>> {
+    return await axios.post('/kling/motion', data, {
       headers: {
         authorization: `Bearer ${options.token}`,
         'content-type': 'application/json',

--- a/src/pages/kling/Index.vue
+++ b/src/pages/kling/Index.vue
@@ -1,7 +1,11 @@
 <template>
   <layout>
+    <template #tabs>
+      <tab-switcher :model-value="taskType" @update:model-value="onTabChange" />
+    </template>
     <template #config>
-      <config-panel @generate="onGenerate" />
+      <config-panel v-if="taskType === 'videos'" @generate="onGenerate" />
+      <motion-panel v-else-if="taskType === 'motion'" @generate="onGenerateMotion" />
     </template>
     <template #result>
       <recent-panel ref="recentPanel" :loading="loadingMore" @reach-top="onReachTop" />
@@ -13,8 +17,10 @@
 import { defineComponent } from 'vue';
 import Layout from '@/layouts/Kling.vue';
 import ConfigPanel from '@/components/kling/ConfigPanel.vue';
+import MotionPanel from '@/components/kling/MotionPanel.vue';
+import TabSwitcher from '@/components/kling/TabSwitcher.vue';
 import { klingOperator } from '@/operators';
-import { IKlingGenerateRequest, Status } from '@/models';
+import { IKlingGenerateRequest, IKlingMotionRequest, IKlingTaskType, Status } from '@/models';
 import { ElMessage } from 'element-plus';
 import { ERROR_CODE_USED_UP } from '@/constants';
 import RecentPanel from '@/components/kling/RecentPanel.vue';
@@ -34,6 +40,8 @@ export default defineComponent({
   name: 'KlingIndex',
   components: {
     ConfigPanel,
+    MotionPanel,
+    TabSwitcher,
     Layout,
     RecentPanel
   },
@@ -58,6 +66,12 @@ export default defineComponent({
     },
     config() {
       return this.$store.state.kling.config;
+    },
+    motionConfig() {
+      return this.$store.state.kling.motionConfig;
+    },
+    taskType(): IKlingTaskType {
+      return this.$store.state.kling.taskType || 'videos';
     },
     tasks() {
       return this.$store.state.kling.tasks;
@@ -195,6 +209,54 @@ export default defineComponent({
     getTasksScrollElement(): HTMLElement | undefined {
       const panel = this.$refs.recentPanel as any;
       return panel?.getScrollElement?.();
+    },
+    async onTabChange(value: IKlingTaskType) {
+      if (value === this.taskType) return;
+      await this.$store.dispatch('kling/setTaskType', value);
+      // taskType change clears tasks; re-fetch.
+      await this.onGetTasks();
+      await this.onScrollDown();
+    },
+    async onGenerateMotion() {
+      const cfg = this.motionConfig || {};
+      if (!cfg.image_url || !cfg.video_url) {
+        ElMessage.warning(this.$t('kling.message.motionMissingInputs'));
+        return;
+      }
+      const request: IKlingMotionRequest = {
+        image_url: cfg.image_url,
+        video_url: cfg.video_url,
+        character_orientation: cfg.character_orientation || 'video',
+        mode: cfg.mode || 'std',
+        keep_original_sound: cfg.keep_original_sound ?? 'yes',
+        ...(cfg.prompt ? { prompt: cfg.prompt } : {}),
+        callback_url: CALLBACK_URL
+      };
+      const token = this.credential?.token;
+      if (!token) {
+        console.error('no token specified');
+        return;
+      }
+      ElMessage.info(this.$t('kling.message.startingTask'));
+      klingOperator
+        .motion(request, { token })
+        .then(() => {
+          ElMessage.success(this.$t('kling.message.startTaskSuccess'));
+        })
+        .catch((error) => {
+          const response = error?.response?.data;
+          if (response?.error?.code === ERROR_CODE_USED_UP) {
+            ElMessage.error(this.$t('kling.message.usedUp'));
+          } else {
+            ElMessage.error(this.$t('kling.message.startTaskFailed'));
+          }
+        })
+        .finally(async () => {
+          setTimeout(async () => {
+            await this.onGetTasks();
+            await this.onScrollDown();
+          }, 1000);
+        });
     }
   }
 });

--- a/src/plugins/font-awesome.ts
+++ b/src/plugins/font-awesome.ts
@@ -123,7 +123,9 @@ import {
   faStar as faSolidStar,
   faHouse as faSolidHouse,
   faBrain as faSolidBrain,
-  faKey as faSolidKey
+  faKey as faSolidKey,
+  faPersonRunning as faSolidPersonRunning,
+  faUserTie as faSolidUserTie
 } from '@fortawesome/free-solid-svg-icons';
 // add icons
 library.add(faSolidEllipsis);
@@ -246,3 +248,5 @@ library.add(faSolidCompress);
 library.add(faSolidBroom);
 library.add(faSolidHouse);
 library.add(faSolidKey);
+library.add(faSolidPersonRunning);
+library.add(faSolidUserTie);

--- a/src/store/kling/actions.ts
+++ b/src/store/kling/actions.ts
@@ -2,7 +2,15 @@ import { applicationOperator, credentialOperator, klingOperator, serviceOperator
 import { IKlingState } from './models';
 import { ActionContext } from 'vuex';
 import { IRootState } from '../common/models';
-import { IApplication, ICredential, IKlingConfig, IKlingTask, IService } from '@/models';
+import {
+  IApplication,
+  ICredential,
+  IKlingConfig,
+  IKlingMotionConfig,
+  IKlingTask,
+  IKlingTaskType,
+  IService
+} from '@/models';
 import { Status } from '@/models/common';
 import { KLING_SERVICE_ID } from '@/constants';
 import { mergeAndSortLists } from '@/utils/merge';
@@ -106,6 +114,14 @@ export const setConfig = ({ commit }: any, payload: IKlingConfig) => {
   commit('setConfig', payload);
 };
 
+export const setMotionConfig = ({ commit }: any, payload: IKlingMotionConfig) => {
+  commit('setMotionConfig', payload);
+};
+
+export const setTaskType = ({ commit }: any, payload: IKlingTaskType) => {
+  commit('setTaskType', payload);
+};
+
 export const setTasks = ({ commit }: any, payload: any) => {
   commit('setTasks', payload);
 };
@@ -145,14 +161,14 @@ export const getTasks = async (
           userId: rootState?.user?.id,
           createdAtMin,
           createdAtMax,
-          type: 'videos'
+          type: state.taskType
         },
         {
           token
         }
       )
       .then((response) => {
-        console.debug('get videos tasks success', response.data.items);
+        console.debug('get kling tasks success', response.data.items);
         // merge with existing tasks
         const existingItems = state?.tasks?.items || [];
         console.debug('existing items', existingItems);
@@ -176,6 +192,8 @@ export default {
   resetAll,
   setCredential,
   setConfig,
+  setMotionConfig,
+  setTaskType,
   setApplication,
   setApplications,
   getApplications,

--- a/src/store/kling/models.ts
+++ b/src/store/kling/models.ts
@@ -1,5 +1,5 @@
 import { IApplication, ICredential, IService, Status } from '@/models';
-import { IKlingConfig, IKlingTask } from '@/models';
+import { IKlingConfig, IKlingMotionConfig, IKlingTask, IKlingTaskType } from '@/models';
 
 export interface IKlingState {
   application: IApplication | undefined;
@@ -7,6 +7,8 @@ export interface IKlingState {
   service: IService | undefined;
   credential: ICredential | undefined;
   config: IKlingConfig | undefined;
+  motionConfig: IKlingMotionConfig | undefined;
+  taskType: IKlingTaskType;
   tasks:
     | {
         items: IKlingTask[] | undefined;

--- a/src/store/kling/mutations.ts
+++ b/src/store/kling/mutations.ts
@@ -1,4 +1,12 @@
-import { IApplication, ICredential, IKlingConfig, IKlingTask, IService } from '@/models';
+import {
+  IApplication,
+  ICredential,
+  IKlingConfig,
+  IKlingMotionConfig,
+  IKlingTask,
+  IKlingTaskType,
+  IService
+} from '@/models';
 import initialState from './state';
 import { IKlingState } from './models';
 
@@ -24,6 +32,16 @@ export const setApplications = (state: IKlingState, payload: IApplication[]): vo
 
 export const setConfig = (state: IKlingState, payload: IKlingConfig): void => {
   state.config = payload;
+};
+
+export const setMotionConfig = (state: IKlingState, payload: IKlingMotionConfig): void => {
+  state.motionConfig = payload;
+};
+
+export const setTaskType = (state: IKlingState, payload: IKlingTaskType): void => {
+  state.taskType = payload;
+  // Switching tabs invalidates the task list cache so the next fetch fully reloads.
+  state.tasks = undefined;
 };
 
 export const setTasksItems = (state: IKlingState, payload: IKlingTask[]): void => {
@@ -59,6 +77,8 @@ export default {
   setApplication,
   setApplications,
   setConfig,
+  setMotionConfig,
+  setTaskType,
   setCredential,
   setService,
   setTasksActive,

--- a/src/store/kling/persist.ts
+++ b/src/store/kling/persist.ts
@@ -1,1 +1,1 @@
-export default ['kling.credential', 'kling.application', 'kling.applications', 'kling.tasks'];
+export default ['kling.credential', 'kling.application', 'kling.applications', 'kling.tasks', 'kling.taskType'];

--- a/src/store/kling/state.ts
+++ b/src/store/kling/state.ts
@@ -9,6 +9,8 @@ export default (): IKlingState => {
     tasks: undefined,
     credential: undefined,
     config: undefined,
+    motionConfig: undefined,
+    taskType: 'videos',
     status: {
       getService: Status.None,
       getApplications: Status.None,


### PR DESCRIPTION
## Why

`/kling` (studio.acedata.cloud/kling) only had one screen — Video Generation. Meanwhile, the Kling official site exposes three top-level tabs: **Video Generation / Motion Control / Avatar**. We've already had `POST /kling/motion` in production for a long time, but no UI surfaces it — users had no way to use it without crafting raw API calls.

This PR mirrors the official 3-tab layout so:

1. Motion Control finally has a panel that drives our existing API.
2. Avatar (AI-Human) is reserved as a disabled tab with an InfoIcon explaining "coming soon" — discoverable, not hidden — pending the upstream worker and a new `/kling/avatar` API.

## What changed

### New UI

- **TabSwitcher.vue** — pill-style segmented switcher above the config/result row. Active tab is highlighted; the Avatar tab is greyed with a tooltip ("Avatar — face image + speech to talking-head video — coming soon. Stay tuned.") and a small "Coming soon" badge. Clicking the Avatar tab is a no-op.
- **MotionPanel.vue** + 6 children under [src/components/kling/motion/](Nexior/src/components/kling/motion/):
  - `MotionImage` — single-image uploader (image_url)
  - `MotionVideo` — MP4/MOV uploader, ≤100MB (video_url)
  - `MotionPromptInput` — optional textarea (prompt)
  - `CharacterOrientationSelector` — radio: `Match image | Match video`, with InfoIcon paraphrasing the official guidance
  - `MotionModeSelector` — std/pro select with InfoIcon
  - `KeepOriginalSoundSelector` — switch with InfoIcon
- Generate button is disabled until both image_url + video_url exist, and shows a clear `kling.message.motionMissingInputs` warning if the user clicks anyway. Mode defaults to `std`, character_orientation defaults to `video`, keep_original_sound defaults to `yes` (mirrors the API spec).

### Layout

- [Kling.vue](Nexior/src/layouts/Kling.vue) gets a new `tabs` slot above the existing `config / result` row. Backward compatible: when no slot is supplied, the layout is unchanged. Mobile (<768px) drawer behavior preserved.

### Models / store / operator

- New types: `IKlingTaskType` (`'videos' | 'motion'`), `IKlingMotionConfig`, `IKlingMotionRequest`. `IKlingTask.request` is now a union covering both videos and motion fields.
- Store: `motionConfig` + `taskType` added to state; `setMotionConfig` / `setTaskType` mutations + actions. `getTasks` now passes `state.taskType` to the operator (was hardcoded `'videos'`). Switching tabs invalidates the task list cache so the next fetch fully reloads instead of mixing types. `taskType` is persisted to localStorage so the previously-selected tab is restored on page revisit.
- New `klingOperator.motion()` posting to `/kling/motion` with the same auth + accept headers as `generate()`.

### Page wiring

- [Index.vue](Nexior/src/pages/kling/Index.vue) routes generate calls by tab: `onGenerate` for videos, `onGenerateMotion` for motion. The motion payload is built explicitly (drops empty optional prompt; defaults are filled in) instead of the spread-everything pattern, since the motion API has different required fields than videos.

### i18n

- zh-CN + en strings added for: 3 tab labels + Avatar coming-soon tooltip, all 6 motion field names + descriptions, motion prompt placeholder, generate button, missing-inputs warning. Other 16 locales auto-translate via the `translate.py` CronJob.

### Misc

- font-awesome plugin: register `faPersonRunning` (motion tab icon) and `faUserTie` (avatar tab icon).

## Verification

- `npx vue-tsc --noEmit` — clean.
- `npm run lint` — clean.
- `npx vite build` — built (504 kB main chunk, no new warnings).

## Out of scope (next PRs)

- **Avatar tab activation** — needs a `kling-avatar` worker in PlatformService and a new `/kling/avatar` API in PlatformBackend (separate epic).
- **Inspiration & Presets drawer** (camera movements / shot type / light / atmosphere quick-add chips) — high UX value, pure-frontend; planned as a follow-up PR.
- **Duration slider + Mode label refinement + Summary chip** — minor polish, planned as another follow-up PR.
- **`element_list` / `video_list`** — typed in models since the previous PR; UI deferred.
