### PR TITLE
fix(store): drop site from vuex-persistedstate to fix flag-flip outage

### DIFF
--- a/src/store/common/persist.ts
+++ b/src/store/common/persist.ts
@@ -1,1 +1,10 @@
-export default ['user', 'token', 'setting', 'locale', 'dark', 'site', 'config', 'currency', 'exchange', 'fingerprint'];
+// Vuex root keys to persist into localStorage via vuex-persistedstate.
+//
+// `site` is intentionally NOT persisted: the value is fetched fresh on
+// every page load by `initializeSite` -> `getSite`, and persisting it
+// causes a real outage when admins flip a feature flag (e.g.
+// `features.subsite.enabled`) — every previously-logged-in user will
+// rehydrate the OLD site object from localStorage on next visit and
+// the new flag never reaches the UI until they manually clear storage.
+// Site rows are tiny (<5 KB), so refetching on every load is cheap.
+export default ['user', 'token', 'setting', 'locale', 'dark', 'config', 'currency', 'exchange', 'fingerprint'];


### PR DESCRIPTION
## TL;DR

`store.state.site` 被 `vuex-persistedstate` 持久化到 localStorage。每次刷页面，旧 site 对象在 `initializeSite -> getSite` 之前**先**从 localStorage rehydrate 进 store，造成首屏渲染读到的是**旧** features 字段。

只要后台改过 site features（例如刚刚把 `studio.acedata.cloud` 的 `features.subsite.enabled` 从 false 翻到 true），所有**已登录过**的用户都被锁死在旧值里——直到他们手动清 localStorage。

## 实际症状（在 production 上重现）

- 后端 `GET /api/v1/sites/?origin=studio.acedata.cloud` ✅ 返回 `subsite.enabled=true`
- 浏览器 DevTools → `JSON.parse(localStorage.getItem('vuex')).site.features.subsite` → 老对象，**没有 `subsite` 字段**
- `components/user/Center.vue` 的 `showSubsite` computed 读 `state.site.features.subsite.enabled` → false → 头像下拉里**没有 "我的分站"**
- 路由 `/subsite` 的 mounted 守卫读同款 → 进页面瞬间 `$router.replace('/')` 跳走
- **唯一解锁方式：** `localStorage.removeItem('vuex'); location.reload()`

## 修复

`src/store/common/persist.ts` 把 `'site'` 从持久化白名单移除。

## 为什么安全

1. `site` 在每次应用启动时由 [`initializer.ts`](https://github.com/AceDataCloud/Nexior/blob/main/src/utils/initializer.ts) 的 `initializeSite -> getSite` 主动拉取——dispatch 已经存在，不需要新增任何代码。
2. Site 对象很小（< 5 KB），多一次 API 调用代价可忽略。
3. 其它 reader（`Center.vue`、`Navigator.vue`、`HelpDialog.vue`、`initializer.ts` 自己 …）都通过 `store.state.site?.*`，得到 fresh 值后才被组件 mount/render 读到，没有任何顺序 race。
4. 其余持久化字段（`user / token / setting / locale / dark / config / currency / exchange / fingerprint`）都是 user-specific 或几乎不变的，**保持持久化不变**。

## 部署后的迁移

无需用户操作。新代码会忽略 localStorage 里 `vuex.site` 字段（若存在），首次启动直接用 API 拿来的 fresh value 覆盖。

但**已经被这个 bug 锁住的用户**，部署生效之前可以用 console 一行解锁：

```js
const v=JSON.parse(localStorage.getItem('vuex')||'{}'); delete v.site; localStorage.setItem('vuex', JSON.stringify(v)); location.reload();
```

## 相关 PR / 上下文

- #560 加了 navbar dropdown 的 "我的分站" 入口（前一个 dropdown PR）
- #565 让 nginx 不缓存 `index.html`（修复另一个 stale-bundle 的 footgun）
- 这个 PR 修复**同等严重的 client-side 状态 footgun**：CDN/HTML 修了之后，client localStorage 还会再咬一口
