### PR TITLE
fix(site): resolve Site row by bare host so studio.acedata.cloud works

### DIFF
--- a/src/utils/site.ts
+++ b/src/utils/site.ts
@@ -1,27 +1,59 @@
 import { ISite } from '@/models';
 import { v4 as uuid } from 'uuid';
-import { isOfficial } from './is';
-import { BASE_URL_HUB } from '@/constants';
+import { BASE_HOST_HUB } from '@/constants';
+
+/**
+ * Resolve the origin we send to PlatformBackend's
+ * `/api/v1/sites/?origin=...` so we look up the correct Site row.
+ *
+ * Two rules to keep straight:
+ *
+ *  1. **Always return a bare hostname** (no scheme, no port).
+ *     PlatformBackend stores `Site.origin` as the bare host
+ *     (`studio.acedata.cloud`, not `https://studio.acedata.cloud`).
+ *     The historical "official" branch returned `BASE_URL_HUB`
+ *     (https://hub.acedata.cloud) which only matched because hub's
+ *     Site row happened to have been bootstrapped under that exact
+ *     URL form. New origins (e.g. studio) never got that special row,
+ *     so the lookup returned 0 items and the bundle silently dropped
+ *     all features.* — including the subsite gate.
+ *
+ *  2. **hub.acedata.cloud now 301-redirects to studio.acedata.cloud**
+ *     in production, so the user-visible host on first-party traffic
+ *     is studio. We still treat hub's host as the canonical "user
+ *     hub" identifier when the bundle runs natively (Capacitor) —
+ *     where `window.location.host` is `localhost` — by falling back
+ *     to studio's bare host instead.
+ */
+const STUDIO_HOST = 'studio.acedata.cloud';
 
 export const getSiteOrigin = (site?: ISite) => {
+  // If we already have a Site row, trust its stored origin.
   if (site?.origin) {
-    return site?.origin;
+    return site.origin;
   }
-  // On native platforms (Capacitor), window.location.host is "localhost"
-  // which is not the real origin — use the official hub URL
+  // On native shells (Capacitor on Android / iOS) window.location.host
+  // is "localhost" and useless; fall back to studio's bare host so the
+  // app boots against the canonical first-party Site row.
   if (import.meta.env.VITE_SURFACE === 'android' || import.meta.env.VITE_SURFACE === 'ios') {
-    return BASE_URL_HUB;
+    return STUDIO_HOST;
   }
-  if (isOfficial()) {
-    return BASE_URL_HUB;
+  if (typeof window === 'undefined' || !window.location?.host) {
+    return STUDIO_HOST;
   }
   const host = window.location.host;
-  // if localhost, try to generate uuid
+  // Local dev: synthesize a unique fake host so we don't collide with
+  // any real Site row.
   if (host.includes('localhost')) {
-    // generate uuid
-    const randomId = uuid();
-    return `http://localhost-${randomId}`;
-  } else {
-    return window.location.origin;
+    return `localhost-${uuid()}`;
   }
+  // hub.acedata.cloud now permanently redirects to studio. If for any
+  // reason the bundle is rendering on hub (cached HTML, dev override,
+  // etc.) treat it as studio so we still resolve the real Site row.
+  if (host === BASE_HOST_HUB) {
+    return STUDIO_HOST;
+  }
+  // Strip an accidental ":port" if the visitor is on a non-standard
+  // port; PlatformBackend never stores ports either.
+  return host.split(':')[0];
 };


### PR DESCRIPTION
## TL;DR — 这才是真正让 studio 上 "我的分站" 入口隐形的 bug

后端 [`Site`](https://github.com/AceDataCloud/PlatformBackend/blob/main/app/models/site.py) 表里 `studio.acedata.cloud` 的行已经有 `features.subsite.enabled=true`，但前端 `getSiteOrigin()` 拿不到这一行——因为它发的 origin 参数和后端存储格式不匹配。

## 病灶链

后端 DB:

```
hub Site row:    origin = "https://hub.acedata.cloud"   (历史上带 scheme)
studio Site row: origin = "studio.acedata.cloud"        (PR #382 之后建的，bare host)
```

前端 `src/utils/site.ts` `getSiteOrigin()`:

```ts
if (isOfficial()) {
  return BASE_URL_HUB;   // ← studio 也被当 official → 返回 https://hub.acedata.cloud
}
return window.location.origin;  // ← fallback 返回 https://studio.acedata.cloud (带 scheme)
```

两条路都走不通：

| 实际发出的 origin | 后端匹配行数 | 命运 |
|---|---|---|
| `https://hub.acedata.cloud` | 1 (hub 行) | 拿到 hub 配置，**没有 subsite features** |
| `https://studio.acedata.cloud` | **0** (因为 studio 行是 bare) | 拿空 → store 里 features 完全 undefined |

任意一种结局都让 `Center.vue` 的 `showSubsite` computed 看到 falsy → 头像下拉里**没**入口；`/subsite` 路由的 mounted 守卫看到 falsy → **瞬间 `$router.replace('/')` 跳走**。

PR #560 加 navbar 入口、PR #565 改 nginx no-cache、PR #568 移除 site 持久化 —— 都是真 bug，但**这个 PR 才是真正解锁 studio 上 subsite 功能的那个**。

## 修复

`getSiteOrigin()` 重写两条规则：

1. **永远返回 bare hostname**（不带 scheme、不带 port）。匹配 PlatformBackend 后续创建 Site 行的存储约定。
2. **hub.acedata.cloud 现在 301 永久重定向到 studio.acedata.cloud**，所以前端任何地方走到 hub fallback（旧 bundle / Capacitor 原生 / 强制 BASE_URL_HUB）一律改返 studio 的 bare host。

后端 curl 验证：

```bash
$ curl -s 'https://platform.acedata.cloud/api/v1/sites/?origin=studio.acedata.cloud'   | jq '.count'
1                                                              # ✅ 命中 studio 行

$ curl -s 'https://platform.acedata.cloud/api/v1/sites/?origin=https://studio.acedata.cloud' | jq '.count'
0                                                              # ❌ 旧前端发的，0 命中
```

## 其它影响

- `isOfficial` / `isSubOfficial` / `SidePanel.vue` / `initializer.ts` 不动 —— 它们用的是 `window.location.host`，不经过 `getSiteOrigin`。
- 旧的 hub Site row（`https://hub.acedata.cloud`）继续躺在 DB 里没事，但永远不会再被前端查询（hub host 已被 301 替换 + Capacitor fallback 也改成 studio）。

## 一起合并的 PR

- #565 (nginx no-cache)：仍然有用，防止 stale `index.html` 引用 404 chunk
- #568 (drop persisted site)：仍然有用，防御性，避免 features flag 翻转后老用户被锁
- **本 PR**：真正修复 studio 端 site lookup 失败的根因

合并 + 部署后建议大家硬刷一次浏览器（或者跑这一行 console 清缓存）：

```js
const v=JSON.parse(localStorage.getItem('vuex')||'{}'); delete v.site; localStorage.setItem('vuex', JSON.stringify(v)); location.reload();
```

PR #568 合并后，连这一步都不需要了。
