### PR TITLE
feat(kling): Inspiration & Presets drawer for prompt building (mirror kling.ai)

### DIFF
--- a/src/components/kling/ConfigPanel.vue
+++ b/src/components/kling/ConfigPanel.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex flex-col h-full">
     <div class="flex-1 overflow-y-auto p-5">
-      <prompt-input class="mb-4" />
+      <prompt-input class="mb-4" @open-inspiration="inspirationOpen = true" />
       <model-selector class="mb-4" />
       <ratio-selector class="mb-4" />
       <start-image class="mb-2" />
@@ -30,6 +30,7 @@
         {{ $t('kling.button.generate') }}
       </el-button>
     </div>
+    <inspiration-drawer v-model="inspirationOpen" />
   </div>
 </template>
 
@@ -49,6 +50,7 @@ import GenerateAudioSelector from './config/GenerateAudioSelector.vue';
 import CameraControlSelector from './config/CameraControlSelector.vue';
 import PromptInput from './config/PromptInput.vue';
 import NegativePromptInput from './config/NegativePromptInput.vue';
+import InspirationDrawer from './inspiration/InspirationDrawer.vue';
 import { getConsumption } from '@/utils';
 
 export default defineComponent({
@@ -67,9 +69,15 @@ export default defineComponent({
     CfgScaleSelector,
     GenerateAudioSelector,
     CameraControlSelector,
+    InspirationDrawer,
     EndImage
   },
   emits: ['generate'],
+  data() {
+    return {
+      inspirationOpen: false
+    };
+  },
   computed: {
     config() {
       return this.$store.state.kling?.config;

--- a/src/components/kling/config/PromptInput.vue
+++ b/src/components/kling/config/PromptInput.vue
@@ -2,7 +2,13 @@
   <div class="field">
     <div class="box">
       <h2 class="title font-bold">{{ $t('kling.name.prompt') }}</h2>
-      <info-icon :content="$t('kling.description.prompt')" class="info" />
+      <div class="actions">
+        <el-button text size="small" class="inspiration-btn" @click="$emit('open-inspiration')">
+          <font-awesome-icon icon="fa-regular fa-lightbulb" class="mr-1" />
+          {{ $t('kling.inspiration.openButton') }}
+        </el-button>
+        <info-icon :content="$t('kling.description.prompt')" class="info" />
+      </div>
     </div>
     <el-input v-model="prompt" :rows="3" type="textarea" class="prompt" :placeholder="$t('kling.placeholder.prompt')" />
   </div>
@@ -10,7 +16,8 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElInput } from 'element-plus';
+import { ElInput, ElButton } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 
 export const DEFAULT_PROMPT = '';
@@ -19,8 +26,11 @@ export default defineComponent({
   name: 'PromptInput',
   components: {
     ElInput,
+    ElButton,
+    FontAwesomeIcon,
     InfoIcon
   },
+  emits: ['open-inspiration'],
   computed: {
     prompt: {
       get() {
@@ -49,15 +59,28 @@ export default defineComponent({
     display: flex;
     flex-direction: row;
     align-items: center;
-    justify-content: space-between; // Add this line to move the icon to the right
+    justify-content: space-between;
     position: relative;
+    margin-bottom: 6px;
+
     .title {
       font-size: 14px;
-      margin-bottom: 10px;
+      margin: 0;
+    }
+    .actions {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+    }
+    .inspiration-btn {
+      font-size: 12px;
+      color: var(--el-color-primary);
+      padding: 0 6px;
+      height: 24px;
     }
   }
   .info {
-    margin-left: auto; // Ensure the icon stays on the right
+    margin-left: 4px;
   }
 }
 </style>

--- a/src/components/kling/inspiration/InspirationDrawer.vue
+++ b/src/components/kling/inspiration/InspirationDrawer.vue
@@ -1,0 +1,257 @@
+<template>
+  <el-drawer
+    v-model="visible"
+    direction="rtl"
+    :with-header="false"
+    :size="drawerSize"
+    custom-class="kling-inspiration-drawer"
+    :destroy-on-close="false"
+  >
+    <div class="drawer-content">
+      <div class="drawer-header">
+        <div class="title-row">
+          <font-awesome-icon icon="fa-regular fa-lightbulb" class="mr-2" />
+          <span class="title">{{ $t('kling.inspiration.title') }}</span>
+        </div>
+        <el-button text :icon="Close" class="close-btn" @click="visible = false" />
+      </div>
+
+      <div class="hint">{{ $t('kling.inspiration.hint') }}</div>
+
+      <div v-if="selectedCount > 0" class="selected-bar">
+        <span class="selected-text">{{ $t('kling.inspiration.selectedSummary', { count: selectedCount }) }}</span>
+        <el-button text size="small" class="clear-btn" @click="onClearSelected">
+          {{ $t('kling.inspiration.clearSelected') }}
+        </el-button>
+      </div>
+
+      <div class="groups">
+        <div v-for="group in groups" :key="group.groupKey" class="group">
+          <div class="group-title">{{ $t(`kling.inspiration.group.${group.groupKey}`) }}</div>
+          <div class="chip-grid">
+            <button
+              v-for="chipKey in group.chipKeys"
+              :key="chipKey"
+              type="button"
+              :class="{ chip: true, active: isSelected(chipText(chipKey)) }"
+              @click="onToggle(chipText(chipKey))"
+            >
+              {{ chipText(chipKey) }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </el-drawer>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElDrawer, ElButton } from 'element-plus';
+import { Close } from '@element-plus/icons-vue';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { KLING_PRESET_GROUPS } from './presets';
+
+const SEPARATOR = ', ';
+
+export default defineComponent({
+  name: 'InspirationDrawer',
+  components: {
+    ElDrawer,
+    ElButton,
+    FontAwesomeIcon
+  },
+  props: {
+    modelValue: {
+      type: Boolean,
+      default: false
+    }
+  },
+  emits: ['update:modelValue'],
+  data() {
+    return {
+      groups: KLING_PRESET_GROUPS,
+      Close
+    };
+  },
+  computed: {
+    visible: {
+      get(): boolean {
+        return this.modelValue;
+      },
+      set(val: boolean) {
+        this.$emit('update:modelValue', val);
+      }
+    },
+    drawerSize(): string {
+      // Mobile gets full width; desktop a fixed-width side panel.
+      return window.innerWidth < 768 ? '100%' : '380px';
+    },
+    prompt(): string {
+      return this.$store.state.kling?.config?.prompt || '';
+    },
+    allChipTexts(): string[] {
+      return this.groups.flatMap((g) => g.chipKeys.map((k) => this.$t(`kling.inspiration.chip.${k}`) as string));
+    },
+    selectedCount(): number {
+      return this.allChipTexts.filter((t) => this.isSelected(t)).length;
+    }
+  },
+  methods: {
+    chipText(chipKey: string): string {
+      return this.$t(`kling.inspiration.chip.${chipKey}`) as string;
+    },
+    isSelected(text: string): boolean {
+      if (!text) return false;
+      // Use word-boundary-ish substring match. Chip text is unique enough that
+      // a literal includes() works reliably across en + zh.
+      return this.prompt.includes(text);
+    },
+    setPrompt(val: string) {
+      this.$store.commit('kling/setConfig', {
+        ...this.$store.state.kling?.config,
+        prompt: val
+      });
+    },
+    onToggle(text: string) {
+      if (!text) return;
+      if (this.isSelected(text)) {
+        this.setPrompt(this.removeChunk(this.prompt, text));
+      } else {
+        this.setPrompt(this.appendChunk(this.prompt, text));
+      }
+    },
+    onClearSelected() {
+      let next = this.prompt;
+      for (const t of this.allChipTexts) {
+        while (next.includes(t)) {
+          next = this.removeChunk(next, t);
+        }
+      }
+      this.setPrompt(next);
+    },
+    appendChunk(current: string, chunk: string): string {
+      const trimmed = current.trim();
+      if (!trimmed) return chunk;
+      // Avoid duplicating an already-present chunk.
+      if (trimmed.includes(chunk)) return trimmed;
+      return `${trimmed}${SEPARATOR}${chunk}`;
+    },
+    removeChunk(current: string, chunk: string): string {
+      // Remove the chunk plus any adjacent separator/space, preserving the rest.
+      const variants = [`${chunk}${SEPARATOR}`, `${SEPARATOR}${chunk}`, chunk];
+      let next = current;
+      for (const v of variants) {
+        if (next.includes(v)) {
+          next = next.replace(v, '');
+          break;
+        }
+      }
+      // Tidy trailing separators.
+      return next.replace(/(?:,\s*)+$/, '').replace(/^(?:,\s*)+/, '');
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.drawer-content {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 16px 18px 24px;
+  overflow-y: auto;
+}
+.drawer-header {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+
+  .title-row {
+    display: inline-flex;
+    align-items: center;
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--el-text-color-primary);
+  }
+  .close-btn {
+    padding: 6px;
+    height: 32px;
+    width: 32px;
+  }
+}
+.hint {
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+  margin-bottom: 12px;
+  line-height: 1.5;
+}
+.selected-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  margin-bottom: 12px;
+  background-color: var(--el-color-primary-light-9);
+  border-radius: 8px;
+  font-size: 12px;
+
+  .selected-text {
+    color: var(--el-color-primary);
+    font-weight: 500;
+  }
+}
+.groups {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+.group {
+  .group-title {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--el-text-color-regular);
+    margin-bottom: 8px;
+  }
+  .chip-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+}
+.chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--el-border-color);
+  background-color: var(--el-fill-color-lighter);
+  color: var(--el-text-color-regular);
+  font-size: 13px;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease;
+
+  &:hover {
+    border-color: var(--el-color-primary-light-5);
+    background-color: var(--el-color-primary-light-9);
+  }
+
+  &.active {
+    border-color: var(--el-color-primary);
+    background-color: var(--el-color-primary-light-9);
+    color: var(--el-color-primary);
+    font-weight: 500;
+  }
+}
+</style>
+
+<style lang="scss">
+.kling-inspiration-drawer .el-drawer__body {
+  padding: 0;
+}
+</style>

--- a/src/components/kling/inspiration/presets.ts
+++ b/src/components/kling/inspiration/presets.ts
@@ -1,0 +1,69 @@
+/**
+ * Kling Inspiration & Presets data — mirrors the official kling.ai prompt
+ * dictionary. Each chip's display text and the text appended to the prompt
+ * both come from i18n, so Chinese users get Chinese chips that prepend
+ * Chinese descriptors (matching how kling.ai itself behaves per locale).
+ *
+ * Group structure: { groupKey, chipKeys[] }
+ * - groupKey resolves to `kling.inspiration.group.<groupKey>`
+ * - chipKey  resolves to `kling.inspiration.chip.<chipKey>`
+ */
+export interface IKlingPresetGroup {
+  groupKey: string;
+  chipKeys: string[];
+}
+
+export const KLING_PRESET_GROUPS: IKlingPresetGroup[] = [
+  {
+    groupKey: 'cameraMovements',
+    chipKeys: [
+      'rotateAround',
+      'stationary',
+      'handheld',
+      'zoomOut',
+      'zoomIn',
+      'follow',
+      'panRight',
+      'tiltUp',
+      'tiltDown',
+      'orbit'
+    ]
+  },
+  {
+    groupKey: 'cameraSpeed',
+    chipKeys: ['speedSlow', 'speedMedium', 'speedFast']
+  },
+  {
+    groupKey: 'shotType',
+    chipKeys: [
+      'shotClose',
+      'shotMedium',
+      'shotLong',
+      'shotLowAngle',
+      'shotHighAngle',
+      'shotShallowDof',
+      'shotFront',
+      'shotProfile',
+      'shotCloseUp',
+      'shotDrone'
+    ]
+  },
+  {
+    groupKey: 'light',
+    chipKeys: ['lightSunlight', 'lightSoft', 'lightNeon', 'lightWarm', 'lightNature', 'lightCandle', 'lightCityNight']
+  },
+  {
+    groupKey: 'frame',
+    chipKeys: ['frameRichDetails', 'frameSimpleBg']
+  },
+  {
+    groupKey: 'atmosphere',
+    chipKeys: [
+      'atmosphereMysterious',
+      'atmospherePeaceful',
+      'atmosphereHeartwarming',
+      'atmosphereVivid',
+      'atmosphereColorful'
+    ]
+  }
+];

--- a/src/i18n/en/kling.json
+++ b/src/i18n/en/kling.json
@@ -83,6 +83,202 @@
     "message": "Please upload both a character image and a motion reference video.",
     "description": "Motion Control missing inputs warning"
   },
+  "inspiration.title": {
+    "message": "Inspiration & Presets",
+    "description": "Inspiration drawer title"
+  },
+  "inspiration.openButton": {
+    "message": "Inspiration",
+    "description": "Button to open the Inspiration drawer"
+  },
+  "inspiration.hint": {
+    "message": "Click a chip to append it to your prompt; click again to remove it.",
+    "description": "Hint shown at top of the Inspiration drawer"
+  },
+  "inspiration.empty": {
+    "message": "No presets available",
+    "description": "Inspiration drawer empty state"
+  },
+  "inspiration.selectedSummary": {
+    "message": "{count} selected",
+    "description": "Number of selected chips"
+  },
+  "inspiration.clearSelected": {
+    "message": "Clear all",
+    "description": "Button to clear all selected chips"
+  },
+  "inspiration.group.cameraMovements": {
+    "message": "Camera Movements",
+    "description": "Inspiration group"
+  },
+  "inspiration.group.cameraSpeed": {
+    "message": "Camera Speed",
+    "description": "Inspiration group"
+  },
+  "inspiration.group.shotType": {
+    "message": "Shot Type",
+    "description": "Inspiration group"
+  },
+  "inspiration.group.light": {
+    "message": "Light & Shadow",
+    "description": "Inspiration group"
+  },
+  "inspiration.group.frame": {
+    "message": "Frame",
+    "description": "Inspiration group"
+  },
+  "inspiration.group.atmosphere": {
+    "message": "Atmosphere",
+    "description": "Inspiration group"
+  },
+  "inspiration.chip.rotateAround": {
+    "message": "the camera rotates around the subject",
+    "description": ""
+  },
+  "inspiration.chip.stationary": {
+    "message": "the camera is stationary",
+    "description": ""
+  },
+  "inspiration.chip.handheld": {
+    "message": "handheld device filming",
+    "description": ""
+  },
+  "inspiration.chip.zoomOut": {
+    "message": "the camera zooms out",
+    "description": ""
+  },
+  "inspiration.chip.zoomIn": {
+    "message": "the camera zooms in",
+    "description": ""
+  },
+  "inspiration.chip.follow": {
+    "message": "the camera follows the subject moving",
+    "description": ""
+  },
+  "inspiration.chip.panRight": {
+    "message": "camera pans right",
+    "description": ""
+  },
+  "inspiration.chip.tiltUp": {
+    "message": "camera tilts up",
+    "description": ""
+  },
+  "inspiration.chip.tiltDown": {
+    "message": "camera tilts down",
+    "description": ""
+  },
+  "inspiration.chip.orbit": {
+    "message": "camera orbits around and pushes in",
+    "description": ""
+  },
+  "inspiration.chip.speedSlow": {
+    "message": "the speed of the camera motion is slow",
+    "description": ""
+  },
+  "inspiration.chip.speedMedium": {
+    "message": "the speed of the camera motion is medium",
+    "description": ""
+  },
+  "inspiration.chip.speedFast": {
+    "message": "the speed of the camera motion is fast",
+    "description": ""
+  },
+  "inspiration.chip.shotClose": {
+    "message": "maintaining a close shot",
+    "description": ""
+  },
+  "inspiration.chip.shotMedium": {
+    "message": "medium shot",
+    "description": ""
+  },
+  "inspiration.chip.shotLong": {
+    "message": "positioned at a long shot",
+    "description": ""
+  },
+  "inspiration.chip.shotLowAngle": {
+    "message": "positioned at a low angle",
+    "description": ""
+  },
+  "inspiration.chip.shotHighAngle": {
+    "message": "positioned at a higher angle",
+    "description": ""
+  },
+  "inspiration.chip.shotShallowDof": {
+    "message": "shallow depth of field",
+    "description": ""
+  },
+  "inspiration.chip.shotFront": {
+    "message": "capture the subject's front view",
+    "description": ""
+  },
+  "inspiration.chip.shotProfile": {
+    "message": "profile shot",
+    "description": ""
+  },
+  "inspiration.chip.shotCloseUp": {
+    "message": "close-up",
+    "description": ""
+  },
+  "inspiration.chip.shotDrone": {
+    "message": "from a drone's perspective",
+    "description": ""
+  },
+  "inspiration.chip.lightSunlight": {
+    "message": "sunlight",
+    "description": ""
+  },
+  "inspiration.chip.lightSoft": {
+    "message": "soft light",
+    "description": ""
+  },
+  "inspiration.chip.lightNeon": {
+    "message": "neon light",
+    "description": ""
+  },
+  "inspiration.chip.lightWarm": {
+    "message": "warm light",
+    "description": ""
+  },
+  "inspiration.chip.lightNature": {
+    "message": "nature light",
+    "description": ""
+  },
+  "inspiration.chip.lightCandle": {
+    "message": "candlelight",
+    "description": ""
+  },
+  "inspiration.chip.lightCityNight": {
+    "message": "city night lights",
+    "description": ""
+  },
+  "inspiration.chip.frameRichDetails": {
+    "message": "rich details",
+    "description": ""
+  },
+  "inspiration.chip.frameSimpleBg": {
+    "message": "simple background",
+    "description": ""
+  },
+  "inspiration.chip.atmosphereMysterious": {
+    "message": "mysterious",
+    "description": ""
+  },
+  "inspiration.chip.atmospherePeaceful": {
+    "message": "peaceful",
+    "description": ""
+  },
+  "inspiration.chip.atmosphereHeartwarming": {
+    "message": "heartwarming",
+    "description": ""
+  },
+  "inspiration.chip.atmosphereVivid": {
+    "message": "vivid",
+    "description": ""
+  },
+  "inspiration.chip.atmosphereColorful": {
+    "message": "colorful",
+    "description": ""
+  },
   "name.taskId": {
     "message": "Task ID",
     "description": "The ID of the task"

--- a/src/i18n/zh-CN/kling.json
+++ b/src/i18n/zh-CN/kling.json
@@ -83,6 +83,202 @@
     "message": "请同时上传人物图与动作参考视频",
     "description": "Motion Control 缺少输入时的提示"
   },
+  "inspiration.title": {
+    "message": "灵感与预设",
+    "description": "Inspiration 抽屉的标题"
+  },
+  "inspiration.openButton": {
+    "message": "灵感",
+    "description": "打开 Inspiration 抽屉的按钮"
+  },
+  "inspiration.hint": {
+    "message": "点击短语自动追加到提示词；再次点击可移除。",
+    "description": "Inspiration 抽屉顶部的使用说明"
+  },
+  "inspiration.empty": {
+    "message": "暂无可用预设",
+    "description": "Inspiration 抽屉空状态"
+  },
+  "inspiration.selectedSummary": {
+    "message": "已选 {count} 项",
+    "description": "已选择的预设数量"
+  },
+  "inspiration.clearSelected": {
+    "message": "全部清除",
+    "description": "清除所有已选预设的按钮"
+  },
+  "inspiration.group.cameraMovements": {
+    "message": "镜头运动",
+    "description": "Inspiration 分组：镜头运动"
+  },
+  "inspiration.group.cameraSpeed": {
+    "message": "运动速度",
+    "description": "Inspiration 分组：运动速度"
+  },
+  "inspiration.group.shotType": {
+    "message": "镜头景别",
+    "description": "Inspiration 分组：景别 / 视角"
+  },
+  "inspiration.group.light": {
+    "message": "光影",
+    "description": "Inspiration 分组：光影"
+  },
+  "inspiration.group.frame": {
+    "message": "画面",
+    "description": "Inspiration 分组：画面 / 构图"
+  },
+  "inspiration.group.atmosphere": {
+    "message": "氛围",
+    "description": "Inspiration 分组：氛围 / 风格"
+  },
+  "inspiration.chip.rotateAround": {
+    "message": "镜头围绕主体旋转",
+    "description": ""
+  },
+  "inspiration.chip.stationary": {
+    "message": "镜头静止",
+    "description": ""
+  },
+  "inspiration.chip.handheld": {
+    "message": "手持拍摄",
+    "description": ""
+  },
+  "inspiration.chip.zoomOut": {
+    "message": "镜头拉远",
+    "description": ""
+  },
+  "inspiration.chip.zoomIn": {
+    "message": "镜头推近",
+    "description": ""
+  },
+  "inspiration.chip.follow": {
+    "message": "镜头跟随主体移动",
+    "description": ""
+  },
+  "inspiration.chip.panRight": {
+    "message": "镜头向右平移",
+    "description": ""
+  },
+  "inspiration.chip.tiltUp": {
+    "message": "镜头向上倾斜",
+    "description": ""
+  },
+  "inspiration.chip.tiltDown": {
+    "message": "镜头向下倾斜",
+    "description": ""
+  },
+  "inspiration.chip.orbit": {
+    "message": "镜头环绕推进",
+    "description": ""
+  },
+  "inspiration.chip.speedSlow": {
+    "message": "镜头运动缓慢",
+    "description": ""
+  },
+  "inspiration.chip.speedMedium": {
+    "message": "镜头运动中速",
+    "description": ""
+  },
+  "inspiration.chip.speedFast": {
+    "message": "镜头运动快速",
+    "description": ""
+  },
+  "inspiration.chip.shotClose": {
+    "message": "近景特写",
+    "description": ""
+  },
+  "inspiration.chip.shotMedium": {
+    "message": "中景",
+    "description": ""
+  },
+  "inspiration.chip.shotLong": {
+    "message": "远景",
+    "description": ""
+  },
+  "inspiration.chip.shotLowAngle": {
+    "message": "低角度仰拍",
+    "description": ""
+  },
+  "inspiration.chip.shotHighAngle": {
+    "message": "高角度俯拍",
+    "description": ""
+  },
+  "inspiration.chip.shotShallowDof": {
+    "message": "浅景深",
+    "description": ""
+  },
+  "inspiration.chip.shotFront": {
+    "message": "正面视角",
+    "description": ""
+  },
+  "inspiration.chip.shotProfile": {
+    "message": "侧面视角",
+    "description": ""
+  },
+  "inspiration.chip.shotCloseUp": {
+    "message": "面部特写",
+    "description": ""
+  },
+  "inspiration.chip.shotDrone": {
+    "message": "无人机视角",
+    "description": ""
+  },
+  "inspiration.chip.lightSunlight": {
+    "message": "阳光",
+    "description": ""
+  },
+  "inspiration.chip.lightSoft": {
+    "message": "柔光",
+    "description": ""
+  },
+  "inspiration.chip.lightNeon": {
+    "message": "霓虹光",
+    "description": ""
+  },
+  "inspiration.chip.lightWarm": {
+    "message": "暖光",
+    "description": ""
+  },
+  "inspiration.chip.lightNature": {
+    "message": "自然光",
+    "description": ""
+  },
+  "inspiration.chip.lightCandle": {
+    "message": "烛光",
+    "description": ""
+  },
+  "inspiration.chip.lightCityNight": {
+    "message": "城市夜景灯光",
+    "description": ""
+  },
+  "inspiration.chip.frameRichDetails": {
+    "message": "细节丰富",
+    "description": ""
+  },
+  "inspiration.chip.frameSimpleBg": {
+    "message": "简洁背景",
+    "description": ""
+  },
+  "inspiration.chip.atmosphereMysterious": {
+    "message": "神秘氛围",
+    "description": ""
+  },
+  "inspiration.chip.atmospherePeaceful": {
+    "message": "宁静氛围",
+    "description": ""
+  },
+  "inspiration.chip.atmosphereHeartwarming": {
+    "message": "温暖治愈",
+    "description": ""
+  },
+  "inspiration.chip.atmosphereVivid": {
+    "message": "鲜活生动",
+    "description": ""
+  },
+  "inspiration.chip.atmosphereColorful": {
+    "message": "色彩丰富",
+    "description": ""
+  },
   "name.taskId": {
     "message": "任务 ID",
     "description": "任务的 ID"


### PR DESCRIPTION
## Why

Most users don't know the exact English wording that yields consistent camera-motion or shot-composition results. The official kling.ai site exposes a right-side **Inspiration & Presets** dictionary with grouped tag chips that get appended to the prompt. This PR brings that pattern to Nexior's `/kling` video tab, completing the parity work started in #562 (4K + camera control + disable-not-hide UX) and #566 (Motion Control tab + Avatar coming-soon).

## What's in the drawer

6 groups, 38 chips total (curated from kling.ai's own dictionary):

| Group | Chips |
|---|---|
| Camera Movements | rotate around, stationary, handheld, zoom out, zoom in, follow, pan right, tilt up, tilt down, orbit |
| Camera Speed | slow, medium, fast |
| Shot Type | close, medium, long, low angle, high angle, shallow DoF, front view, profile, close-up, drone perspective |
| Light & Shadow | sunlight, soft, neon, warm, nature, candlelight, city night |
| Frame | rich details, simple background |
| Atmosphere | mysterious, peaceful, heartwarming, vivid, colorful |

## How it works

- A small **Inspiration** text button next to the prompt-input label opens the drawer (right-side, 380px desktop / full-width mobile).
- Click a chip → appended to the prompt with `, ` separator (deduped).
- Click an already-selected chip → removed from the prompt along with its adjacent separator.
- **Selection state is derived from the prompt text itself** (`prompt.includes(chipText)`), so the chips stay in sync even if the user hand-edits the textarea or clears it manually. No extra store slot to maintain.
- A summary bar shows `N selected` + a **Clear all** shortcut that wipes only the preset chunks, never the user's free-text prompt.
- Trailing/leading commas auto-tidied.

## Code structure

```
src/components/kling/inspiration/
├── InspirationDrawer.vue      # the drawer + chip grid
└── presets.ts                 # KLING_PRESET_GROUPS data table
```

Every chip's display text **and** the text appended to the prompt come from i18n. So:

- **English UI** → English chip → appends English descriptor (drives the model in English, which matches how Kling docs are written).
- **Chinese UI** → Chinese chip → appends Chinese descriptor (matches how kling.ai's own zh site behaves).

This is intentional: localizing the drawer also localizes prompt construction.

## Surface

- Wired into `ConfigPanel.vue` (videos tab only). Motion Control tab is intentionally untouched — its prompt is supplemental and the API is driven by the reference video, so chips would mostly produce noise there.
- `PromptInput.vue` emits `open-inspiration`; ConfigPanel toggles the drawer via local data (no router/store coupling).

## Verification

- `npx vue-tsc --noEmit` — clean.
- `npm run lint` — clean.
- `npx vite build` — built successfully.

## Out of scope (next PRs)

- **Duration slider + Mode label refinement (`std → 720p`, `pro → 1080p`, `4k → 4K`) + bottom Summary chip** — minor polish, planned next.
- **Avatar tab activation** — needs upstream `kling-avatar` worker + `/kling/avatar` API (separate epic).
- **My Presets** (kling.ai also has a "My Presets" tab) — would need new server-side storage; deferred.
