### PR TITLE
feat(kling): duration slider + mode resolution suffix + summary chip (UX polish)

### DIFF
--- a/src/components/kling/ConfigPanel.vue
+++ b/src/components/kling/ConfigPanel.vue
@@ -14,6 +14,7 @@
       <negative-prompt-input class="mb-4" />
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
+      <summary-chip />
       <consumption :value="consumption" :service="service" />
       <el-button
         v-if="config?.video_url !== undefined || config?.custom"
@@ -51,6 +52,7 @@ import CameraControlSelector from './config/CameraControlSelector.vue';
 import PromptInput from './config/PromptInput.vue';
 import NegativePromptInput from './config/NegativePromptInput.vue';
 import InspirationDrawer from './inspiration/InspirationDrawer.vue';
+import SummaryChip from './SummaryChip.vue';
 import { getConsumption } from '@/utils';
 
 export default defineComponent({
@@ -70,6 +72,7 @@ export default defineComponent({
     GenerateAudioSelector,
     CameraControlSelector,
     InspirationDrawer,
+    SummaryChip,
     EndImage
   },
   emits: ['generate'],

--- a/src/components/kling/SummaryChip.vue
+++ b/src/components/kling/SummaryChip.vue
@@ -1,0 +1,94 @@
+<template>
+  <div class="summary-chip">
+    <span class="part" :title="$t('kling.name.model')">{{ modelLabel }}</span>
+    <span class="dot">·</span>
+    <span class="part" :title="$t('kling.name.duration')">{{ durationLabel }}</span>
+    <span class="dot">·</span>
+    <span class="part" :title="$t('kling.name.ratio')">{{ aspectRatio || '16:9' }}</span>
+    <span class="dot">·</span>
+    <span class="part" :title="$t('kling.name.mode')">{{ modeLabel }}</span>
+    <span v-if="generateAudio" class="audio" :title="$t('kling.name.generateAudio')">
+      <font-awesome-icon icon="fa-solid fa-headphones" />
+    </span>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+
+const MODEL_LABELS: Record<string, string> = {
+  'kling-v3': 'v3',
+  'kling-v3-omni': 'v3-Omni',
+  'kling-v2-6': 'v2.6',
+  'kling-v2-5-turbo': 'v2.5-Turbo',
+  'kling-v2-1-master': 'v2.1-Master',
+  'kling-v2-master': 'v2-Master',
+  'kling-v1-6': 'v1.6',
+  'kling-v1': 'v1',
+  'kling-video-o1': 'Video-o1'
+};
+
+const MODE_RESOLUTION: Record<string, string> = {
+  std: '720p',
+  pro: '1080p',
+  '4k': '4K'
+};
+
+export default defineComponent({
+  name: 'SummaryChip',
+  components: {
+    FontAwesomeIcon
+  },
+  computed: {
+    config() {
+      return this.$store.state.kling?.config || {};
+    },
+    modelLabel(): string {
+      const id = this.config?.model || 'kling-v2-5-turbo';
+      return MODEL_LABELS[id] || id;
+    },
+    durationLabel(): string {
+      const d = this.config?.duration ?? 5;
+      return `${d}s`;
+    },
+    aspectRatio(): string {
+      return this.config?.aspect_ratio || '';
+    },
+    modeLabel(): string {
+      const m = this.config?.mode || 'std';
+      return MODE_RESOLUTION[m] || m;
+    },
+    generateAudio(): boolean {
+      return Boolean(this.config?.generate_audio);
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.summary-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  margin-bottom: 10px;
+  border-radius: 999px;
+  background-color: var(--el-fill-color-light);
+  color: var(--el-text-color-regular);
+  font-size: 12px;
+  user-select: none;
+
+  .part {
+    white-space: nowrap;
+  }
+  .dot {
+    color: var(--el-text-color-disabled);
+  }
+  .audio {
+    margin-left: 4px;
+    color: var(--el-color-primary);
+    font-size: 11px;
+  }
+}
+</style>

--- a/src/components/kling/config/DurationSelector.vue
+++ b/src/components/kling/config/DurationSelector.vue
@@ -2,50 +2,39 @@
   <div class="field">
     <div class="header">
       <h2 class="title font-bold">{{ $t('kling.name.duration') }}</h2>
-      <info-icon :content="$t('kling.description.duration')" class="info-icon" />
+      <info-icon :content="$t('kling.description.duration')" class="info-icon ml-1" />
+      <span class="value-display">{{ value }}s</span>
     </div>
-    <el-select v-model="value" class="value" :placeholder="$t('kling.placeholder.select')">
-      <el-option
-        v-for="item in options"
-        :key="item.value"
-        :label="item.label"
-        :value="item.value"
-        :disabled="item.disabled"
-      >
-        <span :class="{ 'opt-disabled': item.disabled }">{{ item.label }}</span>
-        <span v-if="item.disabled" class="opt-tip">
-          {{ $t('kling.description.durationV3Only') }}
-        </span>
-      </el-option>
-    </el-select>
+    <el-slider
+      v-model="sliderValue"
+      class="slider"
+      :min="sliderMin"
+      :max="sliderMax"
+      :step="sliderStep"
+      :marks="marks"
+      :show-tooltip="false"
+    />
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElSelect, ElOption } from 'element-plus';
+import { ElSlider } from 'element-plus';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import { KLING_DEFAULT_DURATION, KLING_V3_MODELS } from '@/constants';
 
-const ALL_DURATIONS: { value: number; label: string; v3Only: boolean }[] = [
-  { value: 3, label: '3s', v3Only: true },
-  { value: 5, label: '5s', v3Only: false },
-  { value: 8, label: '8s', v3Only: true },
-  { value: 10, label: '10s', v3Only: false },
-  { value: 12, label: '12s', v3Only: true },
-  { value: 15, label: '15s', v3Only: true }
-];
+const V3_VALUES = [3, 5, 8, 10, 12, 15];
+const STANDARD_VALUES = [5, 10];
 
 export default defineComponent({
   name: 'DurationSelector',
   components: {
-    ElSelect,
-    ElOption,
+    ElSlider,
     InfoIcon
   },
   props: {
     modelValue: {
-      type: String,
+      type: Number,
       default: undefined
     }
   },
@@ -57,15 +46,33 @@ export default defineComponent({
     isV3Model(): boolean {
       return KLING_V3_MODELS.includes(this.selectedModel);
     },
-    options() {
-      return ALL_DURATIONS.map((d) => ({
-        ...d,
-        disabled: d.v3Only && !this.isV3Model
-      }));
+    sliderMin(): number {
+      return this.isV3Model ? 3 : 5;
     },
-    value: {
-      get(): number | undefined {
-        return this.$store.state.kling?.config?.duration;
+    sliderMax(): number {
+      return this.isV3Model ? 15 : 10;
+    },
+    sliderStep(): number {
+      // Non-v3 only allows 5 and 10, so step over the range jumps directly between them.
+      return this.isV3Model ? 1 : 5;
+    },
+    marks() {
+      const values = this.isV3Model ? V3_VALUES : STANDARD_VALUES;
+      const m: Record<number, string> = {};
+      for (const v of values) m[v] = `${v}s`;
+      return m;
+    },
+    value(): number {
+      return this.$store.state.kling?.config?.duration ?? KLING_DEFAULT_DURATION;
+    },
+    sliderValue: {
+      get(): number {
+        // Clamp the persisted value into the slider's current valid range so the
+        // thumb is always visible when switching models.
+        const v = this.value;
+        if (v < this.sliderMin) return this.sliderMin;
+        if (v > this.sliderMax) return this.sliderMax;
+        return v;
       },
       set(val: number) {
         this.$store.commit('kling/setConfig', {
@@ -77,17 +84,16 @@ export default defineComponent({
   },
   watch: {
     isV3Model(_: boolean) {
-      // Auto-correct if the currently selected duration becomes disabled.
-      const current = this.value;
-      const enabled = this.options.filter((o) => !o.disabled).map((o) => o.value);
-      if (current !== undefined && !enabled.includes(current)) {
-        this.value = KLING_DEFAULT_DURATION;
+      // Auto-correct when the persisted duration falls outside the new range.
+      const valid = this.isV3Model ? V3_VALUES : STANDARD_VALUES;
+      if (!valid.includes(this.value)) {
+        this.sliderValue = KLING_DEFAULT_DURATION;
       }
     }
   },
   mounted() {
-    if (!this.value) {
-      this.value = KLING_DEFAULT_DURATION;
+    if (!this.$store.state.kling?.config?.duration) {
+      this.sliderValue = KLING_DEFAULT_DURATION;
     }
   }
 });
@@ -96,31 +102,28 @@ export default defineComponent({
 <style lang="scss" scoped>
 .field {
   display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: space-between;
+  flex-direction: column;
 
   .header {
     display: flex;
     flex-direction: row;
     align-items: center;
-    width: 50%;
 
     .title {
       font-size: 14px;
       margin: 0;
     }
+    .value-display {
+      margin-left: auto;
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--el-color-primary);
+      min-width: 40px;
+      text-align: right;
+    }
   }
-  .value {
-    width: 120px;
+  .slider {
+    margin: 4px 8px 18px;
   }
-}
-.opt-disabled {
-  color: var(--el-text-color-disabled);
-}
-.opt-tip {
-  margin-left: 8px;
-  font-size: 11px;
-  color: var(--el-text-color-placeholder);
 }
 </style>

--- a/src/i18n/en/kling.json
+++ b/src/i18n/en/kling.json
@@ -288,12 +288,12 @@
     "description": "The content type of the Kling video to be generated, such as 'link', 'text', etc."
   },
   "name.modeStd": {
-    "message": "Standard",
-    "description": "The standard mode of the Kling video"
+    "message": "Standard (720p)",
+    "description": "Kling video standard mode (720p output)"
   },
   "name.modePro": {
-    "message": "High Quality",
-    "description": "The high-quality mode of the Kling video"
+    "message": "High Quality (1080p)",
+    "description": "Kling video high quality mode (1080p output)"
   },
   "name.mode4k": {
     "message": "Native 4K",

--- a/src/i18n/zh-CN/kling.json
+++ b/src/i18n/zh-CN/kling.json
@@ -288,12 +288,12 @@
     "description": "要生成的 Kling视频的内容类型，如'链接'、'文本'等"
   },
   "name.modeStd": {
-    "message": "标准",
-    "description": "Kling视频的标准模式"
+    "message": "标准 (720p)",
+    "description": "Kling视频的标准模式（输出 720p）"
   },
   "name.modePro": {
-    "message": "高品质",
-    "description": "Kling视频的高品质模式"
+    "message": "高品质 (1080p)",
+    "description": "Kling视频的高品质模式（输出 1080p）"
   },
   "name.mode4k": {
     "message": "原生 4K",


### PR DESCRIPTION
## Why

Three small UX polish wins to close the gap with kling.ai's at-a-glance feel — completing the polish series after #562 (4K + camera control), #566 (Motion Control tab + Avatar coming-soon), and #570 (Inspiration drawer).

## What changed

### 1. Duration: dropdown → slider

[DurationSelector.vue](Nexior/src/components/kling/config/DurationSelector.vue) now mirrors kling.ai's Length slider:

| Model | Range | Step | Marks |
|---|---|---|---|
| `kling-v3` / `kling-v3-omni` | 3 – 15s | 1s | 3 / 5 / 8 / 10 / 12 / 15 |
| Other models | 5 – 10s | 5s (snaps directly between 5 and 10) | 5 / 10 |

Why step=5 for non-v3: the API only accepts `5` or `10` for those models, so a step-5 slider with `min=5/max=10` makes the thumb physically unable to pick an invalid value. Cleaner than greyed-out dropdown items because the constraint is *visible*. The persisted value is clamped into the slider's current range when switching models, so the thumb is always visible.

The current value is rendered to the right of the title in primary colour, e.g. `5s`, so the user doesn't have to read the slider tooltip.

### 2. ModeSelector labels gain resolution suffixes

| Mode | Before | After |
|---|---|---|
| `std` | Standard / 标准 | **Standard (720p) / 标准 (720p)** |
| `pro` | High Quality / 高品质 | **High Quality (1080p) / 高品质 (1080p)** |
| `4k` | Native 4K / 原生 4K | (unchanged) |

Addresses recurring confusion about what *std / pro* actually means in terms of output quality. zh-CN + en updated; other 16 locales auto-translate via the CronJob.

### 3. New SummaryChip just above the Generate button

[SummaryChip.vue](Nexior/src/components/kling/SummaryChip.vue) displays the current generation parameters in compressed form:

```
v2.5-Turbo · 5s · 16:9 · 720p   🎧
```

The headphones icon only appears when `generate_audio = true`. Gives a one-glance confirmation of what's about to be billed without having to scroll the config column. Mirrors the `720p · 5s · 16:9 · 1` chip on kling.ai's own page.

## Verification

- `npx vue-tsc --noEmit` — clean.
- `npm run lint` — clean.
- `npx vite build` — built successfully.

## Out of scope (next PRs)

- **Avatar tab activation** — needs upstream `kling-avatar` worker + new `/kling/avatar` API (separate epic).
- **My Presets** in the Inspiration drawer — needs server-side storage; deferred.
