### PR TITLE
feat(kling): inline pills for selected inspiration chips above prompt textarea

### DIFF
--- a/src/components/kling/config/PromptInput.vue
+++ b/src/components/kling/config/PromptInput.vue
@@ -10,6 +10,7 @@
         <info-icon :content="$t('kling.description.prompt')" class="info" />
       </div>
     </div>
+    <inspiration-pills />
     <el-input v-model="prompt" :rows="3" type="textarea" class="prompt" :placeholder="$t('kling.placeholder.prompt')" />
   </div>
 </template>
@@ -19,6 +20,7 @@ import { defineComponent } from 'vue';
 import { ElInput, ElButton } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import InfoIcon from '@/components/common/InfoIcon.vue';
+import InspirationPills from '../inspiration/InspirationPills.vue';
 
 export const DEFAULT_PROMPT = '';
 
@@ -28,7 +30,8 @@ export default defineComponent({
     ElInput,
     ElButton,
     FontAwesomeIcon,
-    InfoIcon
+    InfoIcon,
+    InspirationPills
   },
   emits: ['open-inspiration'],
   computed: {

--- a/src/components/kling/inspiration/InspirationDrawer.vue
+++ b/src/components/kling/inspiration/InspirationDrawer.vue
@@ -51,8 +51,7 @@ import { ElDrawer, ElButton } from 'element-plus';
 import { Close } from '@element-plus/icons-vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { KLING_PRESET_GROUPS } from './presets';
-
-const SEPARATOR = ', ';
+import { appendChunk, removeChunk } from './promptChunks';
 
 export default defineComponent({
   name: 'InspirationDrawer',
@@ -116,39 +115,19 @@ export default defineComponent({
     onToggle(text: string) {
       if (!text) return;
       if (this.isSelected(text)) {
-        this.setPrompt(this.removeChunk(this.prompt, text));
+        this.setPrompt(removeChunk(this.prompt, text));
       } else {
-        this.setPrompt(this.appendChunk(this.prompt, text));
+        this.setPrompt(appendChunk(this.prompt, text));
       }
     },
     onClearSelected() {
       let next = this.prompt;
       for (const t of this.allChipTexts) {
         while (next.includes(t)) {
-          next = this.removeChunk(next, t);
+          next = removeChunk(next, t);
         }
       }
       this.setPrompt(next);
-    },
-    appendChunk(current: string, chunk: string): string {
-      const trimmed = current.trim();
-      if (!trimmed) return chunk;
-      // Avoid duplicating an already-present chunk.
-      if (trimmed.includes(chunk)) return trimmed;
-      return `${trimmed}${SEPARATOR}${chunk}`;
-    },
-    removeChunk(current: string, chunk: string): string {
-      // Remove the chunk plus any adjacent separator/space, preserving the rest.
-      const variants = [`${chunk}${SEPARATOR}`, `${SEPARATOR}${chunk}`, chunk];
-      let next = current;
-      for (const v of variants) {
-        if (next.includes(v)) {
-          next = next.replace(v, '');
-          break;
-        }
-      }
-      // Tidy trailing separators.
-      return next.replace(/(?:,\s*)+$/, '').replace(/^(?:,\s*)+/, '');
     }
   }
 });

--- a/src/components/kling/inspiration/InspirationPills.vue
+++ b/src/components/kling/inspiration/InspirationPills.vue
@@ -1,0 +1,114 @@
+<template>
+  <div v-if="selected.length > 0" class="pills" role="list">
+    <div v-for="text in selected" :key="text" class="pill" role="listitem">
+      <span class="pill-text">{{ text }}</span>
+      <button
+        type="button"
+        class="pill-remove"
+        :aria-label="$t('kling.inspiration.removeChip')"
+        @click.stop="onRemove(text)"
+      >
+        <font-awesome-icon icon="fa-solid fa-xmark" />
+      </button>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { KLING_PRESET_GROUPS } from './presets';
+import { removeChunk } from './promptChunks';
+
+export default defineComponent({
+  name: 'InspirationPills',
+  components: {
+    FontAwesomeIcon
+  },
+  computed: {
+    prompt(): string {
+      return this.$store.state.kling?.config?.prompt || '';
+    },
+    /**
+     * Localized text for every preset chip, used to detect which ones the
+     * user has currently selected. We match against the raw prompt text
+     * because that is also the source of truth used by the drawer.
+     */
+    allChipTexts(): string[] {
+      return KLING_PRESET_GROUPS.flatMap((g) =>
+        g.chipKeys.map((k) => this.$t(`kling.inspiration.chip.${k}`) as string)
+      );
+    },
+    selected(): string[] {
+      const text = this.prompt;
+      if (!text) return [];
+      // Preserve the order in which chips appear inside the prompt so the
+      // pills visually match the content as the user reads it.
+      const found: { text: string; idx: number }[] = [];
+      for (const t of this.allChipTexts) {
+        const idx = text.indexOf(t);
+        if (idx !== -1) {
+          found.push({ text: t, idx });
+        }
+      }
+      return found.sort((a, b) => a.idx - b.idx).map((f) => f.text);
+    }
+  },
+  methods: {
+    onRemove(text: string) {
+      const next = removeChunk(this.prompt, text);
+      this.$store.commit('kling/setConfig', {
+        ...this.$store.state.kling?.config,
+        prompt: next
+      });
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+.pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 4px 3px 10px;
+  border-radius: 999px;
+  background-color: var(--el-color-primary-light-9);
+  border: 1px solid var(--el-color-primary-light-7);
+  color: var(--el-color-primary);
+  font-size: 12px;
+  line-height: 1;
+  max-width: 100%;
+
+  .pill-text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 220px;
+  }
+  .pill-remove {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    margin-left: 4px;
+    padding: 0;
+    border: none;
+    background: transparent;
+    border-radius: 50%;
+    color: var(--el-color-primary);
+    cursor: pointer;
+    font-size: 10px;
+
+    &:hover {
+      background-color: var(--el-color-primary-light-7);
+    }
+  }
+}
+</style>

--- a/src/components/kling/inspiration/promptChunks.ts
+++ b/src/components/kling/inspiration/promptChunks.ts
@@ -1,0 +1,29 @@
+/**
+ * Append/remove helpers for joining preset chips with the user's free-text
+ * prompt. Used by both InspirationDrawer (multi-toggle) and InspirationPills
+ * (per-chip remove). Keeping the logic here avoids drift between the two.
+ */
+const SEPARATOR = ', ';
+
+export function appendChunk(current: string, chunk: string): string {
+  const trimmed = (current || '').trim();
+  if (!trimmed) return chunk;
+  // Avoid duplicating an already-present chunk.
+  if (trimmed.includes(chunk)) return trimmed;
+  return `${trimmed}${SEPARATOR}${chunk}`;
+}
+
+export function removeChunk(current: string, chunk: string): string {
+  if (!current || !chunk) return current || '';
+  // Remove the chunk plus any adjacent separator/space, preserving the rest.
+  const variants = [`${chunk}${SEPARATOR}`, `${SEPARATOR}${chunk}`, chunk];
+  let next = current;
+  for (const v of variants) {
+    if (next.includes(v)) {
+      next = next.replace(v, '');
+      break;
+    }
+  }
+  // Tidy trailing/leading separators.
+  return next.replace(/(?:,\s*)+$/, '').replace(/^(?:,\s*)+/, '');
+}

--- a/src/i18n/en/kling.json
+++ b/src/i18n/en/kling.json
@@ -91,6 +91,10 @@
     "message": "Inspiration",
     "description": "Button to open the Inspiration drawer"
   },
+  "inspiration.removeChip": {
+    "message": "Remove this preset",
+    "description": "aria-label for the remove button on a selected-preset pill"
+  },
   "inspiration.hint": {
     "message": "Click a chip to append it to your prompt; click again to remove it.",
     "description": "Hint shown at top of the Inspiration drawer"

--- a/src/i18n/zh-CN/kling.json
+++ b/src/i18n/zh-CN/kling.json
@@ -91,6 +91,10 @@
     "message": "灵感",
     "description": "打开 Inspiration 抽屉的按钮"
   },
+  "inspiration.removeChip": {
+    "message": "移除此预设",
+    "description": "移除提示词区中已选预设的按钮 aria-label"
+  },
   "inspiration.hint": {
     "message": "点击短语自动追加到提示词；再次点击可移除。",
     "description": "Inspiration 抽屉顶部的使用说明"


### PR DESCRIPTION
## Why

After picking presets in the Inspiration drawer (#570), users could only see what they had selected by reading the comma-separated text inside the prompt textarea. The official kling.ai UX, in contrast, renders each selected preset as a removable pill directly above the textarea (see screenshot 1 in the design discussion: `capture the subject's front view ✕`, `the speed of the camera motion is slow ✕`, `camera orbits around and pushes in ✕`). This PR closes that visual gap.

## What changes

### Inline removable pills

[InspirationPills.vue](Nexior/src/components/kling/inspiration/InspirationPills.vue) renders one pill per selected preset, sitting between the prompt title row and the `el-input` textarea. Each pill has its own `×` button — one click removes that single preset. No need to reopen the drawer.

Pills are ordered by where each phrase appears in the prompt, so the visible list matches reading order.

### Single source of truth (no new state)

The component computes selected presets by scanning the current prompt text for any phrase from `KLING_PRESET_GROUPS` — the same heuristic the drawer already uses. So:

- No store changes, no schema migration.
- Drawer and pills can never drift apart — they're both views over the same `config.prompt` string.
- Existing users who have already inlined chips into their prompt will see them as pills on first load, immediately and automatically.

### Shared util

`appendChunk` / `removeChunk` are extracted into [promptChunks.ts](Nexior/src/components/kling/inspiration/promptChunks.ts). Both `InspirationDrawer` (multi-toggle in the drawer) and `InspirationPills` (per-chip remove on the pill) import from there, so the comma-handling and tidying logic lives in one place.

### i18n

Added `kling.inspiration.removeChip` (zh-CN + en) for the per-pill remove button's aria-label. Other 16 locales auto-translate via the CronJob.

## Side effects

None. Pills only render when at least one preset is selected. Users who haven't picked any chips see no change.

## Verification

- `npx vue-tsc --noEmit` — clean.
- `npm run lint` — clean.
- `npx vite build` — built.

## What's left for the kling page

| Item | Status |
|---|---|
| 4K mode + camera control + disable-not-hide | ✅ #562 |
| Top 3-tab + Motion Control + Avatar coming-soon | ✅ #566 |
| Inspiration & Presets drawer | ✅ #570 |
| Duration slider + Mode resolution suffix + Summary chip | ✅ #571 |
| **Inline pills for selected presets** | ✅ this PR |
| Avatar tab activation | ⏳ cross-repo epic — needs PlatformService `kling-avatar` worker + new `/kling/avatar` API in PlatformBackend + cost rule + Kong route. Owns separate planning. |
| `Number of Outputs (1–4)` | ❌ infra-blocked: API only emits one video per call |
| `Custom Multi-Shot` | ❌ infra-blocked: API has no native multi-shot field |
