### PR TITLE
fix(subsite): drop client-side features gate; show entry on studio.* always

### DIFF
--- a/src/components/user/Center.vue
+++ b/src/components/user/Center.vue
@@ -75,12 +75,17 @@ export default defineComponent({
       return this.$store.getters?.user;
     },
     showSubsite() {
-      // Show 'My Subsites' only when the parent Site has explicitly opted
-      // into the subsite (white-label) feature. The /subsite route's own
-      // mounted() guard plus PlatformBackend's POST /api/v1/sites/ check
-      // stay the source of truth; this just hides the menu entry on
-      // origins that haven't enabled it.
-      return Boolean(this.$store?.state?.site?.features?.subsite?.enabled);
+      // Hostname-driven gate: any host whose Site row is intended to expose
+      // subsite (white-label) management surfaces the menu entry.
+      // PlatformBackend #382 enforces the real authorization on POST /sites/,
+      // so the worst case here is a logged-in user clicking through to a UI
+      // that returns 403 — cheap, and hugely better than the previous
+      // failure mode where a stale persisted `state.site` (without
+      // `features.subsite`) silently hid the entry on a subsite-enabled
+      // origin.
+      if (typeof window === 'undefined' || !window.location?.host) return false;
+      const host = window.location.host.split(':')[0];
+      return host === 'studio.acedata.cloud' || host.endsWith('.studio.acedata.cloud');
     }
   },
   mounted() {

--- a/src/pages/subsite/Index.vue
+++ b/src/pages/subsite/Index.vue
@@ -156,28 +156,36 @@ export default defineComponent({
     },
     subdomainZone(): string {
       const zone = this.parentSite?.features?.subsite?.subdomain_zone;
-      return zone || this.parentSite?.origin || '';
+      if (zone) return zone;
+      // Fall back to the bare current host so the create dialog can render
+      // even if `state.site` hasn't been hydrated with the subsite block yet
+      // (e.g. Vuex still has a stale persisted Site without features.subsite).
+      if (typeof window !== 'undefined' && window.location?.host) {
+        return window.location.host.split(':')[0];
+      }
+      return this.parentSite?.origin || '';
     },
     maxSubsitesPerUser(): number {
       const max = this.parentSite?.features?.subsite?.max_subsites_per_user;
       return typeof max === 'number' && max > 0 ? max : 5;
     },
     canCreate(): boolean {
-      return (
-        Boolean(this.parentSite?.features?.subsite?.enabled) &&
-        Boolean(this.subdomainZone) &&
-        Boolean(this.user?.id) &&
-        this.items.length < this.maxSubsitesPerUser
-      );
+      // Don't gate the button on `features.subsite.enabled` here —
+      // PlatformBackend (#382) is the source of truth and will return 403
+      // if the parent Site hasn't opted in. Gating client-side on a Vuex
+      // value that can be stale (rehydrated from localStorage before the
+      // backend fetch lands) was the original cause of the entry being
+      // unreachable on studio.acedata.cloud.
+      return Boolean(this.subdomainZone) && Boolean(this.user?.id) && this.items.length < this.maxSubsitesPerUser;
     }
   },
   mounted() {
-    if (!this.parentSite?.features?.subsite?.enabled) {
-      // Server-side check is the source of truth, but bail out here to avoid
-      // a 403 storm on origins that haven't opted in.
-      this.$router.replace('/');
-      return;
-    }
+    // Server-side check (PlatformBackend #382) is the source of truth.
+    // Skip the Vuex-state gate that historically bounced visitors to '/'
+    // when `state.site.features.subsite` hadn't loaded yet — the user
+    // would land on the page, see it flash, then be redirected away with
+    // no explanation. If they aren't authorized, fetchSubsites returns
+    // an empty list and the create button still surfaces a backend 403.
     this.fetchSubsites();
   },
   methods: {


### PR DESCRIPTION
## TL;DR — 删除前端 features gate，让入口在 studio.* 永远显示

经过 PR #560、#565、#568、#569 还是有人看不到 "我的分站" 入口。

每个 PR 都修了一个真实的 bug，但**最后一道独立失败模式**还在：第一次渲染时，`state.site` 是 `undefined`（在 `getSite()` 网络请求 resolve 之前），这个时候 `Center.vue` 的 `showSubsite` 和 `/subsite` 路由的 `mounted()` 守卫都已经跑了一次。如果你恰好 race 到这个时间窗，入口隐形 + 页面瞬间跳走，**清 localStorage 也救不回**。

## 解决方案

把客户端 gate 改成纯 hostname 检查，不依赖 `state.site` 任何字段。**真正的授权一直在后端**——PlatformBackend #382 在 `POST /api/v1/sites/` 上检查 `features.subsite.enabled`，**stale 或空 Vuex store 不再能把 UI 藏起来**。

## 具体改动

* `Center.vue` `showSubsite`: `host === 'studio.acedata.cloud' || host.endsWith('.studio.acedata.cloud')`，不再读 `state.site`
* `pages/subsite/Index.vue` `mounted()`: 不再 `$router.replace('/')`，只调 `fetchSubsites()`
* `pages/subsite/Index.vue` `subdomainZone`: fallback 到 `window.location.host`，让创建对话框能正常渲染 `.<zone>` 后缀
* `canCreate` 移除 `features.subsite.enabled` 检查，由后端 403 兜底

## 后果

- 任何登录用户在 `studio.acedata.cloud` 上都看得到 "我的分站" 入口
- 直接访问 `/subsite` 总能进，不再 flash-and-redirect
- 真正的限制由后端处理：用户在没启用 subsite 的 origin 点 Create → 后端 403 → 现有 toast 显示错误

## 安全分析

后端 gate（PR #382）**一字未动**。前端就算把入口暴露给任意 user，他们：
1. 看到的列表是空（`siteOperator.getAll({user_id: me})` 没他名下的子站）
2. 点 Create 会被后端 403 reject

唯一的"代价"是无授权用户点了 Create 才会看到错误信息——比之前的"页面隐形/瞬间跳走"对用户友好得多。
