### PR TITLE
fix(subsite): register 'subsite' in I18N_SCOPES so /subsite shows real strings

### DIFF
--- a/src/constants/i18n.ts
+++ b/src/constants/i18n.ts
@@ -57,5 +57,6 @@ export const I18N_SCOPES = [
   'midjourney',
   'serp',
   'connector',
-  'byok'
+  'byok',
+  'subsite'
 ];


### PR DESCRIPTION
## Bug

studio.acedata.cloud/subsite renders raw translation keys instead of real strings:

- 标题显示 `subsite.title.index`
- 副标题显示 `subsite.message.indexTip`
- 按钮显示 `subsite.button.create`
- 空状态显示 `subsite.message.empty`

## Root cause

`src/i18n/<locale>/subsite.json` 文件全 18 种语言都齐了，但 `src/i18n/index.ts` 的 loader 只遍历 `I18N_SCOPES`：

```ts
const promises = I18N_SCOPES.map((name) => loadLocaleResource(name, locale));
```

而 `I18N_SCOPES` 里漏了 `'subsite'`（之前 `byok` 也是漏过然后补上的，同一个坑）。所以 `subsite.*` 这一组 key 永远不会被注册到 vue-i18n，回退渲染原始 key。

## Fix

`src/constants/i18n.ts` 列表里追加 `'subsite'`。一行（带逗号两行 diff）。

```diff
-  'byok'
+  'byok',
+  'subsite'
```

## Verification

- `npx eslint src/constants/i18n.ts` ✅
- `npx vue-tsc --noEmit` ✅
- locale files 已确认存在且包含截图里出现的全部 4 个 key（zh-CN + en 都已检查）

部署后刷新 `/subsite` 即可看到中文/英文的真实文案。