### PR TITLE
fix(kling): derive action from inputs so end_image_url isn't rejected as text2video

### DIFF
--- a/src/components/kling/config/EndImage.vue
+++ b/src/components/kling/config/EndImage.vue
@@ -12,6 +12,7 @@
       name="file"
       accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
       :limit="1"
+      :disabled="reachedLimit"
       class="upload-wrapper"
       :multiple="false"
       :action="uploadUrl"
@@ -30,17 +31,21 @@
           @remove="fileList.splice(fileList.indexOf(file), 1)"
         />
       </template>
-      <el-button round type="primary" size="small" class="btn btn-upload">
-        <font-awesome-icon icon="fa-solid fa-upload" class="icon mr-1" />
-        {{ $t('kling.button.uploadReferences') }}
-      </el-button>
+      <el-tooltip :content="$t('kling.message.uploadReferencesExceed')" :disabled="!reachedLimit" placement="top">
+        <span>
+          <el-button round type="primary" size="small" class="btn btn-upload" :disabled="reachedLimit">
+            <font-awesome-icon icon="fa-solid fa-upload" class="icon mr-1" />
+            {{ $t('kling.button.uploadReferences') }}
+          </el-button>
+        </span>
+      </el-tooltip>
     </el-upload>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElUpload, ElButton, UploadFiles, UploadFile, ElMessage } from 'element-plus';
+import { ElUpload, ElButton, ElTooltip, UploadFiles, UploadFile, ElMessage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
@@ -56,6 +61,7 @@ export default defineComponent({
   components: {
     ElUpload,
     ElButton,
+    ElTooltip,
     ImagePreview,
     InfoIcon,
     FontAwesomeIcon
@@ -76,6 +82,9 @@ export default defineComponent({
     urls() {
       // @ts-ignore
       return this.fileList.map((file: UploadFile) => file?.response?.file_url);
+    },
+    reachedLimit(): boolean {
+      return (this.fileList?.length || 0) >= 1;
     },
     value: {
       get() {

--- a/src/components/kling/config/EndImage.vue
+++ b/src/components/kling/config/EndImage.vue
@@ -11,7 +11,7 @@
       v-model:file-list="fileList"
       name="file"
       accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
-      :limit="5"
+      :limit="1"
       class="upload-wrapper"
       :multiple="false"
       :action="uploadUrl"
@@ -79,12 +79,12 @@ export default defineComponent({
     },
     value: {
       get() {
-        return this.$store.state?.kling?.config?.start_image_url;
+        return this.$store.state?.kling?.config?.end_image_url;
       },
       set() {
         // this.$store.commit('kling/setConfig', {
         //   ...this.$store.state?.kling?.config,
-        //   start_image_url: val
+        //   end_image_url: val
         // });
       }
     }

--- a/src/components/kling/config/StartImage.vue
+++ b/src/components/kling/config/StartImage.vue
@@ -12,6 +12,7 @@
       name="file"
       accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
       :limit="1"
+      :disabled="reachedLimit"
       class="upload-wrapper"
       :multiple="false"
       :action="uploadUrl"
@@ -30,17 +31,21 @@
           @remove="fileList.splice(fileList.indexOf(file), 1)"
         />
       </template>
-      <el-button round type="primary" size="small" class="btn btn-upload">
-        <font-awesome-icon icon="fa-solid fa-upload" class="icon mr-1" />
-        {{ $t('kling.button.uploadReferences') }}
-      </el-button>
+      <el-tooltip :content="$t('kling.message.uploadReferencesExceed')" :disabled="!reachedLimit" placement="top">
+        <span>
+          <el-button round type="primary" size="small" class="btn btn-upload" :disabled="reachedLimit">
+            <font-awesome-icon icon="fa-solid fa-upload" class="icon mr-1" />
+            {{ $t('kling.button.uploadReferences') }}
+          </el-button>
+        </span>
+      </el-tooltip>
     </el-upload>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElUpload, ElButton, UploadFiles, UploadFile, ElMessage } from 'element-plus';
+import { ElUpload, ElButton, ElTooltip, UploadFiles, UploadFile, ElMessage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
@@ -56,6 +61,7 @@ export default defineComponent({
   components: {
     ElUpload,
     ElButton,
+    ElTooltip,
     InfoIcon,
     FontAwesomeIcon,
     ImagePreview
@@ -77,6 +83,9 @@ export default defineComponent({
     urls() {
       // @ts-ignore
       return this.fileList.map((file: UploadFile) => file?.response?.file_url);
+    },
+    reachedLimit(): boolean {
+      return (this.fileList?.length || 0) >= 1;
     },
     value: {
       get() {

--- a/src/components/kling/config/StartImage.vue
+++ b/src/components/kling/config/StartImage.vue
@@ -11,7 +11,7 @@
       v-model:file-list="fileList"
       name="file"
       accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
-      :limit="5"
+      :limit="1"
       class="upload-wrapper"
       :multiple="false"
       :action="uploadUrl"

--- a/src/i18n/en/kling.json
+++ b/src/i18n/en/kling.json
@@ -595,6 +595,10 @@
     "message": "Image upload failed, please try again later",
     "description": "Error message when image upload fails"
   },
+  "message.endImageRequiresStart": {
+    "message": "Please upload a start frame before adding an end frame",
+    "description": "Shown when the user uploads only an end frame without a start frame"
+  },
   "message.startingTask": {
     "message": "Starting task...",
     "description": "Message when the drawing task starts"

--- a/src/i18n/zh-CN/kling.json
+++ b/src/i18n/zh-CN/kling.json
@@ -595,6 +595,10 @@
     "message": "上传图片失败，请稍后重试",
     "description": "图片上传失败时的错误消息"
   },
+  "message.endImageRequiresStart": {
+    "message": "使用尾帧参考图前，请先上传首帧参考图",
+    "description": "用户只上传了尾帧没有首帧时的错误提示"
+  },
   "message.startingTask": {
     "message": "正在启动任务...",
     "description": "绘图任务开始时的消息"

--- a/src/pages/kling/Index.vue
+++ b/src/pages/kling/Index.vue
@@ -167,6 +167,22 @@ export default defineComponent({
         ...rest,
         callback_url: CALLBACK_URL
       } as IKlingGenerateRequest;
+      // Derive `action` from inputs if the user did not set one explicitly.
+      // Upstream Kling worker requires `action` and defaults to `text2video`,
+      // which rejects `start_image_url`/`end_image_url` (#bug: image refs ignored).
+      if (!request.action) {
+        if (request.video_id || (rest as any).video_url) {
+          request.action = 'extend';
+        } else if (request.start_image_url) {
+          request.action = 'image2video';
+        } else {
+          request.action = 'text2video';
+        }
+      }
+      // text2video does not accept end_image_url; strip it to avoid a 400.
+      if (request.action === 'text2video' && request.end_image_url) {
+        delete request.end_image_url;
+      }
       // Only include camera_control when a type is set; clean empty config blocks.
       if (camera_control?.type) {
         request.camera_control = {

--- a/src/pages/kling/Index.vue
+++ b/src/pages/kling/Index.vue
@@ -167,6 +167,12 @@ export default defineComponent({
         ...rest,
         callback_url: CALLBACK_URL
       } as IKlingGenerateRequest;
+      // Reject "only end frame, no start frame" — Kling can't anchor an
+      // end-frame without a starting reference.
+      if (!request.video_id && !(rest as any).video_url && !request.start_image_url && request.end_image_url) {
+        ElMessage.warning(this.$t('kling.message.endImageRequiresStart'));
+        return;
+      }
       // Derive `action` from inputs if the user did not set one explicitly.
       // Upstream Kling worker requires `action` and defaults to `text2video`,
       // which rejects `start_image_url`/`end_image_url` (#bug: image refs ignored).


### PR DESCRIPTION
## TL;DR

报错 `end_image_url is not supported for text2video`（trace `d1ef685d-6a6b-4e29-8d03-e2d4d3c3d0b3`）的根因：**Nexior 在 `/kling/videos` 请求里从来没设过 `action`**。

上游 Kling worker（`PlatformService/ephone/worker/src/handlers/kling/videos.ts`）的逻辑是：

```ts
const action = this.request.body.action || ACTION_GENERATE1;  // = 'text2video'
...
if (action === 'text2video' && this.request.body.end_image_url) {
  throw new BadRequestError('end_image_url is not supported for text2video.');
}
```

所以即使前端同时传了 `start_image_url` + `end_image_url`，上游仍然按 text2video 走，然后看到 end_image_url 就报错。截图里"首帧+尾帧 都上传了"的场景必中。

## 改动

### 1. `pages/kling/Index.vue` — `onGenerate()` 自动推导 `action`

```
video_id / video_url -> 'extend'
start_image_url      -> 'image2video'
其他                  -> 'text2video'
```

并且作为额外保险：当推导出 `text2video` 时主动 `delete request.end_image_url`，避免上游 400。

### 2. `StartImage.vue` / `EndImage.vue` — `:limit="5"` → `:limit="1"`

顺手回答用户第二个问题"上传图片有限制吗，是不是最多一张"：**设计上就是一张**。

- 实际只读 `urls?.[0]`，第二张往后是被静默丢弃的
- i18n 文案 `message.uploadReferencesExceed` 已经写的是"最多可上传 1 张图片" / "You can upload a maximum of 1 image"
- 但模板里 `:limit="5"` 跟文案、跟实际行为都对不上，UX 误导

改成 `:limit="1"` 让三者一致：超过 1 张直接弹 exceed 警告，不会让用户以为多张参考全都生效了。

### 3. `EndImage.vue` — 修 `value` getter 的 typo

`get()` 写的是 `start_image_url`，复制 StartImage.vue 时漏改。setter 是空的，目前没造成 bug，但顺手改对。

## 验证

- `npx vue-tsc --noEmit` ✅
- `npx eslint src/pages/kling/Index.vue src/components/kling/config/StartImage.vue src/components/kling/config/EndImage.vue` ✅

## 影响面

只动 Kling 视频生成 tab。Motion control / 数字人不走 `/kling/videos`，不受影响。其它 provider（Luma / Veo 等）有同样的"`:limit="5"` 但只读 [0]"模式但不在本 PR 范围内。
