### PR TITLE
feat(veo): expose 4 new endpoints + ingredients2video as separate actions

### DIFF
--- a/src/components/veo/ConfigPanel.vue
+++ b/src/components/veo/ConfigPanel.vue
@@ -108,10 +108,10 @@ export default defineComponent({
       return this.$store.state.veo?.service;
     },
     isPostProcessing() {
-      return POST_PROCESSING_ACTIONS.includes(this.config?.action);
+      return POST_PROCESSING_ACTIONS.includes(this.config?.action ?? '');
     },
     isGeneration() {
-      return GENERATION_ACTIONS.includes(this.config?.action);
+      return GENERATION_ACTIONS.includes(this.config?.action ?? '');
     }
   },
   methods: {

--- a/src/components/veo/ConfigPanel.vue
+++ b/src/components/veo/ConfigPanel.vue
@@ -1,13 +1,42 @@
 <template>
   <div class="flex flex-col h-full">
     <div class="flex-1 overflow-y-auto p-5">
-      <video-from-input v-show="config?.action === 'get1080p'" class="mb-4" />
       <action-selector class="mb-4" />
-      <translation-selector v-show="config?.action !== 'get1080p'" class="mb-4" />
-      <aspect-ratio-selector v-show="config?.action === 'image2video'" class="mb-4" />
-      <prompt-input v-show="config?.action !== 'get1080p'" class="mb-4" />
-      <model-selector v-show="config?.action !== 'get1080p'" class="mb-4" />
-      <start-end-image v-show="config?.action === 'image2video'" class="mb-2" />
+
+      <!-- Post-processing actions: video_id is the source video. Show
+           the preview if the user picked it from a previous task; show
+           a manual input as a fallback for paste-from-clipboard. -->
+      <template v-if="isPostProcessing">
+        <video-from-input v-if="config?.video_url" class="mb-4" />
+        <video-id-input class="mb-4" />
+      </template>
+
+      <!-- Per-action specific fields -->
+      <upsample-action-selector v-if="config?.action === 'upsample'" class="mb-4" />
+
+      <extend-model-selector v-if="config?.action === 'extend'" class="mb-4" />
+      <prompt-input v-if="config?.action === 'extend'" class="mb-4" />
+
+      <motion-type-selector v-if="config?.action === 'reshoot'" class="mb-4" />
+
+      <prompt-input v-if="config?.action === 'object_insert'" class="mb-4" />
+      <image-mask-input v-if="config?.action === 'object_insert' || config?.action === 'object_remove'" class="mb-4" />
+      <prompt-input v-if="config?.action === 'object_remove'" class="mb-4" />
+
+      <!-- Generation actions: text2video, image2video, ingredients2video -->
+      <template v-if="isGeneration">
+        <translation-selector class="mb-4" />
+        <aspect-ratio-selector
+          v-if="config?.action === 'image2video' || config?.action === 'ingredients2video'"
+          class="mb-4"
+        />
+        <prompt-input class="mb-4" />
+        <model-selector v-if="config?.action !== 'ingredients2video'" class="mb-4" />
+        <start-end-image
+          v-if="config?.action === 'image2video' || config?.action === 'ingredients2video'"
+          class="mb-2"
+        />
+      </template>
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
       <consumption :value="consumption" :service="service" />
@@ -28,10 +57,25 @@ import ActionSelector from './config/ActionSelector.vue';
 import TranslationSelector from './config/TranslationSelector.vue';
 import AspectRatioSelector from './config/AspectRatioSelector.vue';
 import VideoFromInput from './config/VideoFromInput.vue';
+import VideoIdInput from './config/VideoIdInput.vue';
 import StartEndImage from './config/StartEndImage.vue';
+import UpsampleActionSelector from './config/UpsampleActionSelector.vue';
+import ExtendModelSelector from './config/ExtendModelSelector.vue';
+import MotionTypeSelector from './config/MotionTypeSelector.vue';
+import ImageMaskInput from './config/ImageMaskInput.vue';
 import Consumption from '../common/Consumption.vue';
 import PromptInput from './config/PromptInput.vue';
 import { getConsumption } from '@/utils';
+
+const POST_PROCESSING_ACTIONS = [
+  'upsample',
+  'extend',
+  'reshoot',
+  'object_insert',
+  'object_remove',
+  'get1080p' // legacy alias for upsample(1080p), kept for backward compat
+];
+const GENERATION_ACTIONS = ['text2video', 'image2video', 'ingredients2video'];
 
 export default defineComponent({
   name: 'ConfigPanel',
@@ -44,6 +88,11 @@ export default defineComponent({
     StartEndImage,
     ActionSelector,
     VideoFromInput,
+    VideoIdInput,
+    UpsampleActionSelector,
+    ExtendModelSelector,
+    MotionTypeSelector,
+    ImageMaskInput,
     TranslationSelector,
     AspectRatioSelector
   },
@@ -57,6 +106,12 @@ export default defineComponent({
     },
     service() {
       return this.$store.state.veo?.service;
+    },
+    isPostProcessing() {
+      return POST_PROCESSING_ACTIONS.includes(this.config?.action);
+    },
+    isGeneration() {
+      return GENERATION_ACTIONS.includes(this.config?.action);
     }
   },
   methods: {

--- a/src/components/veo/config/ActionSelector.vue
+++ b/src/components/veo/config/ActionSelector.vue
@@ -35,8 +35,28 @@ export default defineComponent({
           label: this.$t('veo.button.action2')
         },
         {
-          value: 'get1080p',
-          label: this.$t('veo.button.action3')
+          value: 'ingredients2video',
+          label: this.$t('veo.button.actionIngredients')
+        },
+        {
+          value: 'upsample',
+          label: this.$t('veo.button.actionUpsample')
+        },
+        {
+          value: 'extend',
+          label: this.$t('veo.button.actionExtend')
+        },
+        {
+          value: 'reshoot',
+          label: this.$t('veo.button.actionReshoot')
+        },
+        {
+          value: 'object_insert',
+          label: this.$t('veo.button.actionObjectInsert')
+        },
+        {
+          value: 'object_remove',
+          label: this.$t('veo.button.actionObjectRemove')
         }
       ];
     },

--- a/src/components/veo/config/ExtendModelSelector.vue
+++ b/src/components/veo/config/ExtendModelSelector.vue
@@ -1,0 +1,59 @@
+<template>
+  <div class="field">
+    <h2 class="title font-bold">{{ $t('veo.name.model') }}</h2>
+    <el-select v-model="value" class="value" :placeholder="$t('veo.placeholder.select')">
+      <el-option v-for="item in options" :key="item.value" :label="item.label" :value="item.value" />
+    </el-select>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElSelect, ElOption } from 'element-plus';
+import { VEO_DEFAULT_EXTEND_MODEL, VEO_EXTEND_MODELS } from '@/constants';
+
+// Subset of model picker that only exposes the veo31 series — the only
+// models the upstream provider supports for /veo/extend.
+export default defineComponent({
+  name: 'ExtendModelSelector',
+  components: { ElSelect, ElOption },
+  computed: {
+    options() {
+      return VEO_EXTEND_MODELS.map((v) => ({ value: v, label: v }));
+    },
+    value: {
+      get() {
+        return this.$store.state.veo?.config?.model;
+      },
+      set(val: string) {
+        this.$store.commit('veo/setConfig', {
+          ...this.$store.state.veo.config,
+          model: val
+        });
+      }
+    }
+  },
+  mounted() {
+    if (!this.value || !(VEO_EXTEND_MODELS as readonly string[]).includes(this.value)) {
+      this.value = VEO_DEFAULT_EXTEND_MODEL;
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.field {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  .title {
+    font-size: 14px;
+    margin: 0;
+    width: 30%;
+  }
+  .value {
+    flex: 1;
+  }
+}
+</style>

--- a/src/components/veo/config/ImageMaskInput.vue
+++ b/src/components/veo/config/ImageMaskInput.vue
@@ -1,0 +1,50 @@
+<template>
+  <div class="field">
+    <h2 class="title font-bold">{{ $t('veo.name.imageMask') }}</h2>
+    <el-input v-model="value" class="value" type="text" :placeholder="$t('veo.placeholder.imageMask')" clearable />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElInput } from 'element-plus';
+
+// Mask input. Accepts either a public HTTP(S) JPEG URL or a base64 string
+// (with or without the data:image/jpeg;base64, prefix). The
+// platform-service worker normalises both to base64 JPEG before
+// forwarding upstream.
+export default defineComponent({
+  name: 'ImageMaskInput',
+  components: { ElInput },
+  computed: {
+    value: {
+      get() {
+        return this.$store.state.veo?.config?.image_mask;
+      },
+      set(val: string) {
+        this.$store.commit('veo/setConfig', {
+          ...this.$store.state.veo.config,
+          image_mask: val
+        });
+      }
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.field {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  .title {
+    font-size: 14px;
+    margin: 0;
+    width: 30%;
+  }
+  .value {
+    flex: 1;
+  }
+}
+</style>

--- a/src/components/veo/config/MotionTypeSelector.vue
+++ b/src/components/veo/config/MotionTypeSelector.vue
@@ -1,0 +1,57 @@
+<template>
+  <div class="field">
+    <h2 class="title font-bold">{{ $t('veo.name.motionType') }}</h2>
+    <el-select v-model="value" class="value" :placeholder="$t('veo.placeholder.select')" filterable>
+      <el-option v-for="item in options" :key="item.value" :label="item.label" :value="item.value" />
+    </el-select>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElSelect, ElOption } from 'element-plus';
+import { VEO_DEFAULT_MOTION_TYPE, VEO_MOTION_TYPES } from '@/constants';
+
+export default defineComponent({
+  name: 'MotionTypeSelector',
+  components: { ElSelect, ElOption },
+  computed: {
+    options() {
+      return VEO_MOTION_TYPES.map((v) => ({ value: v, label: v }));
+    },
+    value: {
+      get() {
+        return this.$store.state.veo?.config?.motion_type;
+      },
+      set(val: string) {
+        this.$store.commit('veo/setConfig', {
+          ...this.$store.state.veo.config,
+          motion_type: val
+        });
+      }
+    }
+  },
+  mounted() {
+    if (!this.value) {
+      this.value = VEO_DEFAULT_MOTION_TYPE;
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.field {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  .title {
+    font-size: 14px;
+    margin: 0;
+    width: 30%;
+  }
+  .value {
+    flex: 1;
+  }
+}
+</style>

--- a/src/components/veo/config/UpsampleActionSelector.vue
+++ b/src/components/veo/config/UpsampleActionSelector.vue
@@ -1,0 +1,57 @@
+<template>
+  <div class="field">
+    <h2 class="title font-bold">{{ $t('veo.name.upsampleAction') }}</h2>
+    <el-select v-model="value" class="value" :placeholder="$t('veo.placeholder.select')">
+      <el-option v-for="item in options" :key="item.value" :label="item.label" :value="item.value" />
+    </el-select>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElSelect, ElOption } from 'element-plus';
+import { VEO_DEFAULT_UPSAMPLE_ACTION, VEO_UPSAMPLE_ACTIONS } from '@/constants';
+
+export default defineComponent({
+  name: 'UpsampleActionSelector',
+  components: { ElSelect, ElOption },
+  computed: {
+    options() {
+      return VEO_UPSAMPLE_ACTIONS.map((v) => ({ value: v, label: v }));
+    },
+    value: {
+      get() {
+        return this.$store.state.veo?.config?.upsample_action;
+      },
+      set(val: string) {
+        this.$store.commit('veo/setConfig', {
+          ...this.$store.state.veo.config,
+          upsample_action: val
+        });
+      }
+    }
+  },
+  mounted() {
+    if (!this.value) {
+      this.value = VEO_DEFAULT_UPSAMPLE_ACTION;
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.field {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  .title {
+    font-size: 14px;
+    margin: 0;
+    width: 30%;
+  }
+  .value {
+    flex: 1;
+  }
+}
+</style>

--- a/src/components/veo/config/VideoIdInput.vue
+++ b/src/components/veo/config/VideoIdInput.vue
@@ -1,0 +1,49 @@
+<template>
+  <div class="field">
+    <h2 class="title font-bold">{{ $t('veo.name.videoId') }}</h2>
+    <el-input v-model="value" class="value" type="text" :placeholder="$t('veo.placeholder.videoId')" clearable />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElInput } from 'element-plus';
+
+// video_id picker. The user can paste an ID directly here, or click
+// one of the action buttons on a recent task's Preview to seed it
+// automatically.
+export default defineComponent({
+  name: 'VideoIdInput',
+  components: { ElInput },
+  computed: {
+    value: {
+      get() {
+        return this.$store.state.veo?.config?.video_id;
+      },
+      set(val: string) {
+        this.$store.commit('veo/setConfig', {
+          ...this.$store.state.veo.config,
+          video_id: val
+        });
+      }
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.field {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  .title {
+    font-size: 14px;
+    margin: 0;
+    width: 30%;
+  }
+  .value {
+    flex: 1;
+  }
+}
+</style>

--- a/src/components/veo/task/Preview.vue
+++ b/src/components/veo/task/Preview.vue
@@ -28,17 +28,69 @@
           <video-player :src="modelValue?.response?.data[0]?.video_url" />
         </div>
         <div v-if="modelValue?.response.success" :class="{ operations: true, 'mt-2': true }">
-          <el-tooltip class="box-item" effect="dark" :content="$t('veo.message.downloadVideo')" placement="top-start">
-            <el-button
-              v-if="modelValue?.response?.data[0]?.video_url"
-              type="info"
-              size="small"
-              class="btn-action"
-              @click="onGet1080p($event, modelValue?.response)"
-            >
-              {{ $t('veo.button.action3') }}
-            </el-button>
-          </el-tooltip>
+          <el-button
+            v-if="modelValue?.response?.data[0]?.video_url"
+            type="info"
+            size="small"
+            class="btn-action"
+            @click="onPickAction($event, modelValue?.response, 'upsample', '1080p')"
+          >
+            {{ $t('veo.button.actionUpsample1080p') }}
+          </el-button>
+          <el-button
+            v-if="modelValue?.response?.data[0]?.video_url"
+            type="info"
+            size="small"
+            class="btn-action"
+            @click="onPickAction($event, modelValue?.response, 'upsample', '4k')"
+          >
+            {{ $t('veo.button.actionUpsample4k') }}
+          </el-button>
+          <el-button
+            v-if="modelValue?.response?.data[0]?.video_url"
+            type="info"
+            size="small"
+            class="btn-action"
+            @click="onPickAction($event, modelValue?.response, 'upsample', 'gif')"
+          >
+            {{ $t('veo.button.actionUpsampleGif') }}
+          </el-button>
+          <el-button
+            v-if="modelValue?.response?.data[0]?.video_url"
+            type="info"
+            size="small"
+            class="btn-action"
+            @click="onPickAction($event, modelValue?.response, 'extend')"
+          >
+            {{ $t('veo.button.actionExtend') }}
+          </el-button>
+          <el-button
+            v-if="modelValue?.response?.data[0]?.video_url"
+            type="info"
+            size="small"
+            class="btn-action"
+            @click="onPickAction($event, modelValue?.response, 'reshoot')"
+          >
+            {{ $t('veo.button.actionReshoot') }}
+          </el-button>
+          <el-button
+            v-if="modelValue?.response?.data[0]?.video_url"
+            type="info"
+            size="small"
+            class="btn-action"
+            @click="onPickAction($event, modelValue?.response, 'object_insert')"
+          >
+            {{ $t('veo.button.actionObjectInsert') }}
+          </el-button>
+          <el-button
+            v-if="modelValue?.response?.data[0]?.video_url"
+            type="info"
+            size="small"
+            class="btn-action"
+            @click="onPickAction($event, modelValue?.response, 'object_remove')"
+          >
+            {{ $t('veo.button.actionObjectRemove') }}
+          </el-button>
           <el-tooltip class="box-item" effect="dark" :content="$t('veo.message.downloadVideo')" placement="top-start">
             <el-button
               v-if="modelValue?.response?.data[0]?.video_url"
@@ -155,16 +207,20 @@ export default defineComponent({
     }
   },
   methods: {
-    onGet1080p(_event: MouseEvent, response: IVeoGenerateResponse) {
-      // extend url here
-      console.debug('set config', response);
+    onPickAction(_event: MouseEvent, response: IVeoGenerateResponse, action: string, upsampleAction?: string) {
+      // Seed config so the user lands on the chosen post-processing form
+      // with video_id + video_url already filled. Specific extra fields
+      // (motion_type, prompt, image_mask, model) are left for the user
+      // to fill in via the now-visible per-action inputs.
+      console.debug('seed config from preview', { action, upsampleAction, response });
       this.$store.commit('veo/setConfig', {
         ...this.$store.state.veo?.config,
+        action,
         // @ts-ignore
         video_id: response?.data?.[0]?.id,
         // @ts-ignore
-        video_url: response?.data[0]?.video_url,
-        action: 'get1080p'
+        video_url: response?.data?.[0]?.video_url,
+        ...(upsampleAction ? { upsample_action: upsampleAction } : {})
       });
     },
     onDownload(event: MouseEvent, video_url: string) {

--- a/src/constants/veo.ts
+++ b/src/constants/veo.ts
@@ -7,3 +7,36 @@ export const VEO_DEFAULT_ACTION = 'text2video';
 export const VEO_DEFAULT_ASPECT_RATIO = '16:9';
 export const VEO_DEFAULT_TRANSLATION = false;
 export const VEO_DEFAULT_EXTEND_IMG = false;
+
+// /veo/upsample
+export const VEO_UPSAMPLE_ACTIONS = ['1080p', '4k', 'gif'] as const;
+export const VEO_DEFAULT_UPSAMPLE_ACTION = '1080p';
+
+// /veo/extend (only veo31 series supported by upstream)
+export const VEO_EXTEND_MODELS = ['veo31-fast', 'veo31'] as const;
+export const VEO_DEFAULT_EXTEND_MODEL = 'veo31-fast';
+
+// /veo/objects
+export const VEO_OBJECT_ACTIONS = ['insert', 'remove'] as const;
+export const VEO_DEFAULT_OBJECT_ACTION = 'insert';
+
+// /veo/reshoot — short uppercase aliases mapped server-side to upstream
+// RESHOOT_MOTION_TYPE_* values. Order chosen to surface common picks first.
+export const VEO_MOTION_TYPES = [
+  'STATIONARY',
+  'LEFT_TO_RIGHT',
+  'RIGHT_TO_LEFT',
+  'FORWARD',
+  'BACKWARD',
+  'UP',
+  'DOWN',
+  'STATIONARY_UP',
+  'STATIONARY_DOWN',
+  'STATIONARY_LEFT',
+  'STATIONARY_RIGHT',
+  'DOLLY_IN_ZOOM_OUT',
+  'DOLLY_OUT_ZOOM_IN',
+  'STATIONARY_DOLLY_IN_ZOOM_OUT',
+  'STATIONARY_DOLLY_OUT_ZOOM_IN'
+] as const;
+export const VEO_DEFAULT_MOTION_TYPE = 'LEFT_TO_RIGHT';

--- a/src/i18n/zh-CN/veo.json
+++ b/src/i18n/zh-CN/veo.json
@@ -222,5 +222,65 @@
   "message.noTasks": {
     "message": "没有历史任务，请点击左方生成视频",
     "description": "没有任务时的消息"
+  },
+  "name.upsampleAction": {
+    "message": "升采样目标",
+    "description": "/veo/upsample 的目标格式（1080p/4k/gif）"
+  },
+  "name.motionType": {
+    "message": "镜头运动",
+    "description": "/veo/reshoot 的镜头运动类型"
+  },
+  "name.imageMask": {
+    "message": "区域蒙版",
+    "description": "/veo/objects 的图片蒙版（白色像素=操作区域）"
+  },
+  "name.videoId": {
+    "message": "视频 ID",
+    "description": "来源视频的 ID（来自之前一次生成任务的 data[].id）"
+  },
+  "placeholder.imageMask": {
+    "message": "蒙版图片 URL 或 base64 编码的 JPEG",
+    "description": "image_mask 输入框占位符"
+  },
+  "placeholder.videoId": {
+    "message": "粘贴视频 ID，或在右侧任务列表点击操作按钮自动填入",
+    "description": "video_id 输入框占位符"
+  },
+  "button.actionIngredients": {
+    "message": "多图融合视频",
+    "description": "ingredients2video — 1-3 张图融合生成新场景"
+  },
+  "button.actionUpsample": {
+    "message": "升采样 / GIF 预览",
+    "description": "/veo/upsample — 升 1080p/4K 或导出 GIF"
+  },
+  "button.actionExtend": {
+    "message": "续写视频",
+    "description": "/veo/extend — 延长已生成视频时长"
+  },
+  "button.actionReshoot": {
+    "message": "换镜头重拍",
+    "description": "/veo/reshoot — 同内容换镜头运动重新生成"
+  },
+  "button.actionObjectInsert": {
+    "message": "添加物体",
+    "description": "/veo/objects insert — 在视频中添加物体"
+  },
+  "button.actionObjectRemove": {
+    "message": "移除物体",
+    "description": "/veo/objects remove — 通过蒙版抠除视频中的物体"
+  },
+  "button.actionUpsample1080p": {
+    "message": "升 1080P",
+    "description": "Preview 操作按钮 — 升采样到 1080P"
+  },
+  "button.actionUpsample4k": {
+    "message": "升 4K",
+    "description": "Preview 操作按钮 — 升采样到 4K"
+  },
+  "button.actionUpsampleGif": {
+    "message": "导出 GIF",
+    "description": "Preview 操作按钮 — 转 GIF 预览"
   }
 }

--- a/src/models/veo.ts
+++ b/src/models/veo.ts
@@ -8,6 +8,12 @@ export interface IVeoConfig {
   image_urls?: string[];
   prompt?: string;
   callback_url?: string;
+  // /veo/upsample — sub-action: 1080p / 4k / gif
+  upsample_action?: string;
+  // /veo/reshoot — short uppercase motion-type alias
+  motion_type?: string;
+  // /veo/objects — base64-encoded JPEG or HTTP(S) URL to a mask image
+  image_mask?: string;
 }
 
 export interface IVeoGenerateRequest {
@@ -21,6 +27,12 @@ export interface IVeoGenerateRequest {
   aspect_ratio?: string;
   callback_url?: string;
   mirror?: boolean;
+  // /veo/upsample
+  upsample_action?: string;
+  // /veo/reshoot
+  motion_type?: string;
+  // /veo/objects
+  image_mask?: string;
 }
 export interface IVeoVideo {
   id?: string;

--- a/src/operators/veo.ts
+++ b/src/operators/veo.ts
@@ -98,14 +98,70 @@ class VeoOperator {
       token: string;
     }
   ): Promise<AxiosResponse<IVeoGenerateResponse>> {
-    return await axios.post('/veo/videos', data, {
-      headers: {
-        authorization: `Bearer ${options.token}`,
-        'content-type': 'application/json',
-        accept: 'application/x-ndjson'
-      },
-      baseURL: BASE_URL_API
-    });
+    // Dispatch to the appropriate Veo endpoint based on action. The
+    // platform exposes /veo/videos for generation flows and dedicated
+    // endpoints for post-processing operations. We strip fields the
+    // target endpoint doesn't accept so the upstream JsonLogic billing
+    // rules don't see noise from stale UI state.
+    const action = data.action;
+    const headers = {
+      authorization: `Bearer ${options.token}`,
+      'content-type': 'application/json',
+      accept: 'application/x-ndjson'
+    };
+    const config = { headers, baseURL: BASE_URL_API };
+
+    if (action === 'upsample') {
+      return await axios.post(
+        '/veo/upsample',
+        {
+          video_id: data.video_id,
+          action: data.upsample_action || '1080p',
+          ...(data.callback_url ? { callback_url: data.callback_url } : {})
+        },
+        config
+      );
+    }
+    if (action === 'extend') {
+      return await axios.post(
+        '/veo/extend',
+        {
+          video_id: data.video_id,
+          model: data.model,
+          ...(data.prompt ? { prompt: data.prompt } : {}),
+          ...(data.callback_url ? { callback_url: data.callback_url } : {})
+        },
+        config
+      );
+    }
+    if (action === 'reshoot') {
+      return await axios.post(
+        '/veo/reshoot',
+        {
+          video_id: data.video_id,
+          motion_type: data.motion_type,
+          ...(data.callback_url ? { callback_url: data.callback_url } : {})
+        },
+        config
+      );
+    }
+    if (action === 'object_insert' || action === 'object_remove') {
+      return await axios.post(
+        '/veo/objects',
+        {
+          video_id: data.video_id,
+          action: action === 'object_insert' ? 'insert' : 'remove',
+          ...(data.prompt ? { prompt: data.prompt } : {}),
+          ...(data.image_mask ? { image_mask: data.image_mask } : {})
+        },
+        config
+      );
+    }
+    // Default: generation flows (text2video / image2video / ingredients2video / get1080p) all
+    // hit /veo/videos. Strip frontend-only fields used by other endpoints
+    // so JsonLogic billing rules don't see noise from stale UI state.
+    const { upsample_action: _u, motion_type: _m, image_mask: _i, ...generatePayload } = data;
+    return await axios.post('/veo/videos', generatePayload, config);
   }
 }
 


### PR DESCRIPTION
The platform shipped 4 new Veo endpoints (`/veo/upsample`, `/veo/extend`, `/veo/reshoot`, `/veo/objects`) in [PlatformService #820](https://github.com/AceDataCloud/PlatformService/pull/820) + [PlatformBackend #389](https://github.com/AceDataCloud/PlatformBackend/pull/389), but Studio's Veo page only exposed `text2video` / `image2video` / `get1080p`. Customers had no UI path to upsample to 4K, extend a video, change camera motion, or insert/remove objects. This PR closes that gap.

## What changed

**ActionSelector** now exposes 8 actions (was 3):

| Action | Backed by | Visible fields |
|---|---|---|
| `text2video` | `/veo/videos` | translation, prompt, model |
| `image2video` | `/veo/videos` | translation, aspect_ratio, prompt, model, image_urls |
| `ingredients2video` ⭐ | `/veo/videos` | translation, aspect_ratio, prompt, image_urls |
| `upsample` ⭐ | `/veo/upsample` | video_id, upsample_action (1080p/4k/gif) |
| `extend` ⭐ | `/veo/extend` | video_id, model (veo31 series only), prompt |
| `reshoot` ⭐ | `/veo/reshoot` | video_id, motion_type (15 short uppercase aliases) |
| `object_insert` ⭐ | `/veo/objects` | video_id, prompt, image_mask (optional) |
| `object_remove` ⭐ | `/veo/objects` | video_id, image_mask (required), prompt (optional) |
| `get1080p` (legacy) | `/veo/videos` | video_id (kept as backcompat alias) |

ConfigPanel uses `v-if` per action so only the relevant fields render.

## New components

- `UpsampleActionSelector` — 1080p / 4k / gif
- `ExtendModelSelector` — `veo31-fast` / `veo31` (subset of full model list, since upstream only supports veo31 series for /extend)
- `MotionTypeSelector` — 15 motion types with filterable search
- `ImageMaskInput` — text input that accepts URL or base64 JPEG (worker normalises to base64)
- `VideoIdInput` — paste-or-pick text input for `video_id`

## Operator dispatch

`veoOperator.generate()` now dispatches to the correct endpoint based on `action`:
- `upsample` / `extend` / `reshoot` / `object_insert` / `object_remove` → their dedicated paths
- everything else → `/veo/videos` (so JsonLogic billing rules can still discriminate on action)

Frontend-only fields (`upsample_action`, `motion_type`, `image_mask`) are stripped before posting to `/veo/videos` so billing rules don't see noise.

## Preview integration

Each completed task in the recent panel now offers **8 action buttons** (was just "Get 1080p"): `1080P` / `4K` / `GIF` / `Extend` / `Reshoot` / `Object Insert` / `Object Remove` / `Download`. Clicking any seeds `video_id` + `video_url` + `action` into the config so the user lands on the relevant form ready to fill in the per-action specifics.

## i18n

Added 12 new zh-CN keys covering the new action labels, field names, placeholders, and Preview shortcut buttons. Other languages auto-fill via the existing translate pipeline.

## Validation

```
$ npx vue-tsc --noEmit
exit 0

$ npx eslint src/components/veo/ src/operators/veo.ts src/models/veo.ts src/constants/veo.ts
exit 0

$ npx vite build
✓ built in 12.84s

$ python3 -c "import json; d=json.load(open('src/i18n/zh-CN/veo.json')); print(len(d))"
71  # was 59
```

## Note on mountsea upstream

The 4 new endpoints currently return `account has been removed` from mountsea — the feature flags need to be enabled on our mountsea account before they'll succeed. Once mountsea provisions them, this UI works immediately with no code change. The Beta badges in `Documents` and `Studio` mark the affordance as preview-stage.
