### PR TITLE
feat(kling): capability matrix — confirm before dropping unsupported settings

### DIFF
--- a/src/components/kling/config/DurationSelector.vue
+++ b/src/components/kling/config/DurationSelector.vue
@@ -6,22 +6,25 @@
       <span class="value-display">{{ value }}s</span>
     </div>
     <el-slider
-      v-model="sliderValue"
+      :key="revertKey"
+      :model-value="sliderValue"
       class="slider"
       :min="sliderMin"
       :max="sliderMax"
       :step="sliderStep"
       :marks="marks"
       :show-tooltip="false"
+      @change="onChange"
     />
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElSlider } from 'element-plus';
+import { ElSlider, ElMessage, ElMessageBox } from 'element-plus';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import { KLING_DEFAULT_DURATION, KLING_V3_MODELS } from '@/constants';
+import { findKlingConflicts, clearKlingConflicts } from '@/utils/kling/capabilities';
 
 const V3_VALUES = [3, 5, 8, 10, 12, 15];
 const STANDARD_VALUES = [5, 10];
@@ -39,6 +42,11 @@ export default defineComponent({
     }
   },
   emits: ['update:modelValue'],
+  data() {
+    return {
+      revertKey: 0
+    };
+  },
   computed: {
     selectedModel(): string {
       return this.$store.state.kling?.config?.model || '';
@@ -53,7 +61,6 @@ export default defineComponent({
       return this.isV3Model ? 15 : 10;
     },
     sliderStep(): number {
-      // Non-v3 only allows 5 and 10, so step over the range jumps directly between them.
       return this.isV3Model ? 1 : 5;
     },
     marks() {
@@ -65,35 +72,58 @@ export default defineComponent({
     value(): number {
       return this.$store.state.kling?.config?.duration ?? KLING_DEFAULT_DURATION;
     },
-    sliderValue: {
-      get(): number {
-        // Clamp the persisted value into the slider's current valid range so the
-        // thumb is always visible when switching models.
-        const v = this.value;
-        if (v < this.sliderMin) return this.sliderMin;
-        if (v > this.sliderMax) return this.sliderMax;
-        return v;
-      },
-      set(val: number) {
-        this.$store.commit('kling/setConfig', {
-          ...this.$store.state.kling.config,
-          duration: val
-        });
-      }
+    sliderValue(): number {
+      const v = this.value;
+      if (v < this.sliderMin) return this.sliderMin;
+      if (v > this.sliderMax) return this.sliderMax;
+      return v;
     }
   },
   watch: {
     isV3Model(_: boolean) {
-      // Auto-correct when the persisted duration falls outside the new range.
       const valid = this.isV3Model ? V3_VALUES : STANDARD_VALUES;
       if (!valid.includes(this.value)) {
-        this.sliderValue = KLING_DEFAULT_DURATION;
+        this.applyDuration(KLING_DEFAULT_DURATION);
       }
     }
   },
   mounted() {
     if (!this.$store.state.kling?.config?.duration) {
-      this.sliderValue = KLING_DEFAULT_DURATION;
+      this.applyDuration(KLING_DEFAULT_DURATION);
+    }
+  },
+  methods: {
+    async onChange(val: number) {
+      const config = this.$store.state.kling?.config || {};
+      const conflicts = findKlingConflicts(config, { duration: val });
+      if (conflicts.length === 0) {
+        this.applyDuration(val);
+        return;
+      }
+      const fields = conflicts.map((c) => this.$t(c.i18nLabel)).join('、');
+      try {
+        await ElMessageBox.confirm(
+          this.$t('kling.message.featureNotSupportedBody', { fields }),
+          this.$t('kling.message.featureNotSupportedTitle'),
+          {
+            confirmButtonText: this.$t('kling.button.confirmContinue'),
+            cancelButtonText: this.$t('kling.button.cancelSwitch'),
+            type: 'warning'
+          }
+        );
+        const cleared = clearKlingConflicts({ ...config, duration: val }, conflicts);
+        this.$store.commit('kling/setConfig', cleared);
+        ElMessage.success(this.$t('kling.message.featureRemovedNotice', { fields }));
+      } catch {
+        // User cancelled — repaint slider with the previous value.
+        this.revertKey += 1;
+      }
+    },
+    applyDuration(val: number) {
+      this.$store.commit('kling/setConfig', {
+        ...this.$store.state.kling.config,
+        duration: val
+      });
     }
   }
 });

--- a/src/components/kling/config/DurationSelector.vue
+++ b/src/components/kling/config/DurationSelector.vue
@@ -93,7 +93,9 @@ export default defineComponent({
     }
   },
   methods: {
-    async onChange(val: number) {
+    async onChange(raw: number | number[]) {
+      // ElSlider supports range mode (number[]); we only use single mode.
+      const val = Array.isArray(raw) ? raw[0] : raw;
       const config = this.$store.state.kling?.config || {};
       const conflicts = findKlingConflicts(config, { duration: val });
       if (conflicts.length === 0) {

--- a/src/components/kling/config/EndImage.vue
+++ b/src/components/kling/config/EndImage.vue
@@ -12,11 +12,12 @@
       name="file"
       accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
       :limit="1"
-      :disabled="reachedLimit"
+      :disabled="uploadDisabled"
       class="upload-wrapper"
       :multiple="false"
       :action="uploadUrl"
       list-type="picture"
+      :before-upload="onBeforeUpload"
       :on-exceed="onExceed"
       :on-error="onError"
       :on-success="onSuccess"
@@ -31,9 +32,9 @@
           @remove="fileList.splice(fileList.indexOf(file), 1)"
         />
       </template>
-      <el-tooltip :content="$t('kling.message.uploadReferencesExceed')" :disabled="!reachedLimit" placement="top">
+      <el-tooltip :content="uploadTooltip" :disabled="!uploadDisabled" placement="top">
         <span>
-          <el-button round type="primary" size="small" class="btn btn-upload" :disabled="reachedLimit">
+          <el-button round type="primary" size="small" class="btn btn-upload" :disabled="uploadDisabled">
             <font-awesome-icon icon="fa-solid fa-upload" class="icon mr-1" />
             {{ $t('kling.button.uploadReferences') }}
           </el-button>
@@ -48,6 +49,7 @@ import { defineComponent } from 'vue';
 import { ElUpload, ElButton, ElTooltip, UploadFiles, UploadFile, ElMessage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
+import { getKlingCapabilities } from '@/utils/kling/capabilities';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 
@@ -86,15 +88,39 @@ export default defineComponent({
     reachedLimit(): boolean {
       return (this.fileList?.length || 0) >= 1;
     },
+    klingConfig(): Record<string, any> {
+      return this.$store.state?.kling?.config || {};
+    },
+    endImageSupported(): boolean {
+      return getKlingCapabilities(this.klingConfig.model, this.klingConfig.mode, this.klingConfig.duration).endImage;
+    },
+    uploadDisabled(): boolean {
+      return this.reachedLimit || !this.endImageSupported;
+    },
+    uploadTooltip(): string {
+      if (!this.endImageSupported) return this.$t('kling.message.endImageNotSupported');
+      if (this.reachedLimit) return this.$t('kling.message.uploadReferencesExceed');
+      return '';
+    },
+    storeValue(): string | undefined {
+      return this.klingConfig.end_image_url;
+    },
     value: {
-      get() {
-        return this.$store.state?.kling?.config?.end_image_url;
+      get(): string | undefined {
+        return this.storeValue;
       },
       set() {
-        // this.$store.commit('kling/setConfig', {
-        //   ...this.$store.state?.kling?.config,
-        //   end_image_url: val
-        // });
+        // Mutation flows through onSetEndImageUrl/store only.
+      }
+    }
+  },
+  watch: {
+    storeValue(val: string | undefined) {
+      // When the store clears the value (e.g. user confirmed dropping it after
+      // switching to an incompatible model), drop the local thumbnail too so
+      // the UI stays in sync.
+      if (!val && this.fileList.length > 0) {
+        this.fileList = [];
       }
     }
   },
@@ -105,6 +131,13 @@ export default defineComponent({
     this.onSetEndImageUrl();
   },
   methods: {
+    onBeforeUpload(): boolean {
+      if (!this.endImageSupported) {
+        ElMessage.warning(this.$t('kling.message.endImageNotSupported'));
+        return false;
+      }
+      return true;
+    },
     onExceed() {
       ElMessage.warning(this.$t('kling.message.uploadReferencesExceed'));
     },

--- a/src/components/kling/config/ModeSelector.vue
+++ b/src/components/kling/config/ModeSelector.vue
@@ -4,7 +4,14 @@
       <h2 class="title font-bold">{{ $t('kling.name.mode') }}</h2>
       <info-icon :content="$t('kling.description.mode')" class="info-icon" />
     </div>
-    <el-select v-model="value" class="value" :placeholder="$t('kling.placeholder.select')" :clearable="true">
+    <el-select
+      :key="revertKey"
+      :model-value="value"
+      class="value"
+      :placeholder="$t('kling.placeholder.select')"
+      :clearable="true"
+      @change="onChange"
+    >
       <el-option
         v-for="item in options"
         :key="item.value"
@@ -23,9 +30,10 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElSelect, ElOption } from 'element-plus';
+import { ElSelect, ElOption, ElMessage, ElMessageBox } from 'element-plus';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import { KLING_DEFAULT_MODE, KLING_V3_MODELS } from '@/constants';
+import { findKlingConflicts, clearKlingConflicts } from '@/utils/kling/capabilities';
 
 export default defineComponent({
   name: 'ModeSelector',
@@ -41,6 +49,11 @@ export default defineComponent({
     }
   },
   emits: ['update:modelValue'],
+  data() {
+    return {
+      revertKey: 0
+    };
+  },
   computed: {
     selectedModel(): string {
       return this.$store.state.kling?.config?.model || '';
@@ -70,29 +83,54 @@ export default defineComponent({
         }
       ];
     },
-    value: {
-      get(): string | undefined {
-        return this.$store.state.kling?.config?.mode;
-      },
-      set(val: string) {
-        this.$store.commit('kling/setConfig', {
-          ...this.$store.state.kling.config,
-          mode: val
-        });
-      }
+    value(): string | undefined {
+      return this.$store.state.kling?.config?.mode;
     }
   },
   watch: {
     fourKReason(reason: string) {
       // If 4k becomes invalid (e.g. user switched model away from v3), revert to default.
       if (reason && this.value === '4k') {
-        this.value = KLING_DEFAULT_MODE;
+        this.applyMode(KLING_DEFAULT_MODE);
       }
     }
   },
   mounted() {
     if (!this.value) {
-      this.value = KLING_DEFAULT_MODE;
+      this.applyMode(KLING_DEFAULT_MODE);
+    }
+  },
+  methods: {
+    async onChange(val: string) {
+      const config = this.$store.state.kling?.config || {};
+      const conflicts = findKlingConflicts(config, { mode: val });
+      if (conflicts.length === 0) {
+        this.applyMode(val);
+        return;
+      }
+      const fields = conflicts.map((c) => this.$t(c.i18nLabel)).join('、');
+      try {
+        await ElMessageBox.confirm(
+          this.$t('kling.message.featureNotSupportedBody', { fields }),
+          this.$t('kling.message.featureNotSupportedTitle'),
+          {
+            confirmButtonText: this.$t('kling.button.confirmContinue'),
+            cancelButtonText: this.$t('kling.button.cancelSwitch'),
+            type: 'warning'
+          }
+        );
+        const cleared = clearKlingConflicts({ ...config, mode: val }, conflicts);
+        this.$store.commit('kling/setConfig', cleared);
+        ElMessage.success(this.$t('kling.message.featureRemovedNotice', { fields }));
+      } catch {
+        this.revertKey += 1;
+      }
+    },
+    applyMode(val: string) {
+      this.$store.commit('kling/setConfig', {
+        ...this.$store.state.kling.config,
+        mode: val
+      });
     }
   }
 });

--- a/src/components/kling/config/ModelSelector.vue
+++ b/src/components/kling/config/ModelSelector.vue
@@ -1,7 +1,13 @@
 <template>
   <div class="field">
     <h2 class="title font-bold">{{ $t('pika.name.model') }}</h2>
-    <el-select v-model="value" class="value" :placeholder="$t('pika.placeholder.select')">
+    <el-select
+      :key="revertKey"
+      :model-value="value"
+      class="value"
+      :placeholder="$t('pika.placeholder.select')"
+      @change="onChange"
+    >
       <el-option v-for="item in options" :key="item.value" :label="item.label" :value="item.value" />
     </el-select>
   </div>
@@ -9,8 +15,9 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElSelect, ElOption } from 'element-plus';
+import { ElSelect, ElOption, ElMessage, ElMessageBox } from 'element-plus';
 import { KLING_DEFAULT_MODEL } from '@/constants';
+import { findKlingConflicts, clearKlingConflicts } from '@/utils/kling/capabilities';
 
 export default defineComponent({
   name: 'ModelSelector',
@@ -27,6 +34,9 @@ export default defineComponent({
   emits: ['update:modelValue'],
   data() {
     return {
+      // Bumped to force el-select to re-render and revert its internal display
+      // when the user cancels a model switch.
+      revertKey: 0,
       options: [
         {
           value: 'kling-v3',
@@ -68,21 +78,47 @@ export default defineComponent({
     };
   },
   computed: {
-    value: {
-      get() {
-        return this.$store.state.kling?.config?.model;
-      },
-      set(val: string) {
-        this.$store.commit('kling/setConfig', {
-          ...this.$store.state.kling.config,
-          model: val
-        });
-      }
+    value(): string | undefined {
+      return this.$store.state.kling?.config?.model;
     }
   },
   mounted() {
     if (!this.value) {
-      this.value = KLING_DEFAULT_MODEL;
+      this.applyModel(KLING_DEFAULT_MODEL);
+    }
+  },
+  methods: {
+    async onChange(val: string) {
+      const config = this.$store.state.kling?.config || {};
+      const conflicts = findKlingConflicts(config, { model: val });
+      if (conflicts.length === 0) {
+        this.applyModel(val);
+        return;
+      }
+      const fields = conflicts.map((c) => this.$t(c.i18nLabel)).join('、');
+      try {
+        await ElMessageBox.confirm(
+          this.$t('kling.message.featureNotSupportedBody', { fields }),
+          this.$t('kling.message.featureNotSupportedTitle'),
+          {
+            confirmButtonText: this.$t('kling.button.confirmContinue'),
+            cancelButtonText: this.$t('kling.button.cancelSwitch'),
+            type: 'warning'
+          }
+        );
+        const cleared = clearKlingConflicts({ ...config, model: val }, conflicts);
+        this.$store.commit('kling/setConfig', cleared);
+        ElMessage.success(this.$t('kling.message.featureRemovedNotice', { fields }));
+      } catch {
+        // User cancelled — force el-select to repaint with the current store value.
+        this.revertKey += 1;
+      }
+    },
+    applyModel(val: string) {
+      this.$store.commit('kling/setConfig', {
+        ...this.$store.state.kling.config,
+        model: val
+      });
     }
   }
 });

--- a/src/i18n/en/kling.json
+++ b/src/i18n/en/kling.json
@@ -603,6 +603,30 @@
     "message": "Please upload the first frame reference image before using the end frame reference image",
     "description": "Error message when the user has only uploaded the end frame without the first frame"
   },
+  "message.endImageNotSupported": {
+    "message": "The current model/mode/duration does not support an end-frame reference image. Adjust the configuration first (typically: mode pro, duration 5s).",
+    "description": "Shown when uploading an end frame to a model that does not support it"
+  },
+  "message.featureNotSupportedTitle": {
+    "message": "Confirm change",
+    "description": "Title of the confirm dialog when switching parameters drops existing settings"
+  },
+  "message.featureNotSupportedBody": {
+    "message": "The new selection does not support the following enabled settings: {fields}. Continuing will clear them.",
+    "description": "Body of the confirm dialog; {fields} is replaced with a comma-separated list of field names"
+  },
+  "message.featureRemovedNotice": {
+    "message": "Cleared unsupported settings: {fields}",
+    "description": "Toast shown after the user confirms the switch"
+  },
+  "button.confirmContinue": {
+    "message": "Continue",
+    "description": "Primary button on the feature-removal confirm dialog"
+  },
+  "button.cancelSwitch": {
+    "message": "Cancel",
+    "description": "Cancel button on the feature-removal confirm dialog"
+  },
   "message.startingTask": {
     "message": "Starting task...",
     "description": "Message when the drawing task begins"

--- a/src/i18n/zh-CN/kling.json
+++ b/src/i18n/zh-CN/kling.json
@@ -603,6 +603,30 @@
     "message": "使用尾帧参考图前，请先上传首帧参考图",
     "description": "用户只上传了尾帧没有首帧时的错误提示"
   },
+  "message.endImageNotSupported": {
+    "message": "尾帧参考图不被当前模型/模式/时长支持，请先调整配置（常见要求：模式 pro、时长 5s）。",
+    "description": "上传尾帧时当前模型不支持的提示"
+  },
+  "message.featureNotSupportedTitle": {
+    "message": "需要确认",
+    "description": "切换参数时会丢失现有设置的确认弹窗标题"
+  },
+  "message.featureNotSupportedBody": {
+    "message": "当前选择不支持以下已启用的设置：{fields}。继续将清理这些设置。",
+    "description": "切换 model/mode/duration 后会丢失募集设置的提示文案，{fields} 会被占位符替换为实际字段名"
+  },
+  "message.featureRemovedNotice": {
+    "message": "已清理不支持的设置：{fields}",
+    "description": "用户确认切换后的 toast 提醒"
+  },
+  "button.confirmContinue": {
+    "message": "继续切换",
+    "description": "feature 丢失确认弹窗的主按钮"
+  },
+  "button.cancelSwitch": {
+    "message": "取消",
+    "description": "feature 丢失确认弹窗的取消按钮"
+  },
   "message.startingTask": {
     "message": "正在启动任务...",
     "description": "绘图任务开始时的消息"

--- a/src/utils/kling/capabilities.ts
+++ b/src/utils/kling/capabilities.ts
@@ -1,0 +1,159 @@
+// Capability matrix for Kling video models.
+//
+// Single source of truth derived from the official Kling docs:
+// https://app.klingai.com/global/dev/document-api/apiReference/model/videoModels
+//
+// Used by the Kling config UI to:
+//   - decide which features are valid for the current (model, mode, duration)
+//   - prompt the user before silently dropping config that is no longer supported
+
+export interface IKlingCapability {
+  /** Model accepts the request at all (effectively always true here). */
+  text2video: boolean;
+  image2video: boolean;
+  /** start_image_url + end_image_url combo (image_tail). */
+  endImage: boolean;
+  /** generate_audio (background sound, not voice/lip-sync). */
+  audio: boolean;
+  /** camera_control / motion control. */
+  motionControl: boolean;
+}
+
+const FALLBACK: IKlingCapability = {
+  text2video: true,
+  image2video: true,
+  endImage: false,
+  audio: false,
+  motionControl: false
+};
+
+/**
+ * Return the support matrix for a given (model, mode, duration) combo.
+ *
+ * Mode and duration may be undefined; we default mode to "std" and duration to 5
+ * to mirror the upstream worker's defaulting behaviour.
+ */
+export function getKlingCapabilities(model?: string, mode?: string, duration?: number): IKlingCapability {
+  const m = mode || 'std';
+  const d = duration ?? 5;
+  switch (model) {
+    // Legacy v1: only 5s combos support start/end-frame and motion brush.
+    case 'kling-v1':
+      return {
+        text2video: true,
+        image2video: true,
+        endImage: d === 5,
+        audio: false,
+        motionControl: d === 5
+      };
+    // v1.6 / v2.5-Turbo / v2.6 / v2.1: end-frame is pro-only.
+    case 'kling-v1-6':
+    case 'kling-v2-5-turbo':
+      return {
+        text2video: true,
+        image2video: true,
+        endImage: m === 'pro',
+        audio: false,
+        motionControl: false
+      };
+    case 'kling-v2-6':
+      return {
+        text2video: true,
+        image2video: true,
+        endImage: m === 'pro',
+        audio: m === 'pro',
+        motionControl: false
+      };
+    // v2-Master / v2.1-Master: single-mode, no end-frame in matrix.
+    case 'kling-v2-master':
+    case 'kling-v2-1-master':
+      return {
+        text2video: true,
+        image2video: true,
+        endImage: false,
+        audio: false,
+        motionControl: false
+      };
+    // v3 family: end-frame in every mode; motion control on v3 std/pro only.
+    case 'kling-v3':
+      return {
+        text2video: true,
+        image2video: true,
+        endImage: true,
+        audio: true,
+        motionControl: m !== '4k'
+      };
+    case 'kling-v3-omni':
+      return {
+        text2video: true,
+        image2video: true,
+        endImage: true,
+        audio: true,
+        motionControl: false
+      };
+    case 'kling-video-o1':
+      return {
+        text2video: true,
+        image2video: true,
+        endImage: true,
+        audio: false,
+        motionControl: false
+      };
+    default:
+      return FALLBACK;
+  }
+}
+
+export interface IKlingConflict {
+  /** Field name in the config object. */
+  field: 'end_image_url' | 'generate_audio' | 'camera_control';
+  /** i18n key for the user-facing label of the field. */
+  i18nLabel: string;
+}
+
+/**
+ * Compute which currently-set config fields will be unsupported under the
+ * proposed (model, mode, duration) combo.
+ */
+export function findKlingConflicts(
+  config: Record<string, any> | undefined,
+  next: { model?: string; mode?: string; duration?: number }
+): IKlingConflict[] {
+  if (!config) return [];
+  const model = next.model ?? config.model;
+  const mode = next.mode ?? config.mode;
+  const duration = next.duration ?? config.duration;
+  if (!model) return [];
+
+  const caps = getKlingCapabilities(model, mode, duration);
+  const conflicts: IKlingConflict[] = [];
+
+  if (config.end_image_url && !caps.endImage) {
+    conflicts.push({ field: 'end_image_url', i18nLabel: 'kling.name.endImage' });
+  }
+  if (config.generate_audio && !caps.audio) {
+    conflicts.push({ field: 'generate_audio', i18nLabel: 'kling.name.generateAudio' });
+  }
+  if (config.camera_control?.type && !caps.motionControl) {
+    conflicts.push({ field: 'camera_control', i18nLabel: 'kling.name.cameraControl' });
+  }
+
+  return conflicts;
+}
+
+/**
+ * Apply the conflict resolutions to a config object. Returns a new config with
+ * the offending fields cleared.
+ */
+export function clearKlingConflicts(
+  config: Record<string, any>,
+  conflicts: IKlingConflict[]
+): Record<string, any> {
+  const next = { ...config };
+  for (const c of conflicts) {
+    if (c.field === 'end_image_url') next.end_image_url = undefined;
+    if (c.field === 'generate_audio') next.generate_audio = false;
+    if (c.field === 'camera_control') next.camera_control = undefined;
+  }
+  return next;
+}


### PR DESCRIPTION
继续 #578 的修复——上一个 PR 解决了"text2video 不接受 image_tail"的具体报错；这个 PR 把整个 Kling **能力矩阵** 落到前端，避免一切类似的 silent footgun（截图里那一串 `model/mode/duration(kling-v2-5-turbo/std/10) is not supported with image_tail`、`Image tail is not supported by the current model`、`only image_tail` 全都属于这一类）。

来源：[Kling 官方 video models 文档](https://app.klingai.com/global/dev/document-api/apiReference/model/videoModels)。

## 矩阵（mirrors Kling docs）

| Model | end_image | audio | motion |
|---|---|---|---|
| `kling-v1` | duration=5 only | ❌ | duration=5 only |
| `kling-v1-6` | pro only | ❌ | ❌ |
| `kling-v2-5-turbo` | pro only | ❌ | ❌ |
| `kling-v2-6` | pro only | pro only | ❌ |
| `kling-v2-master` / `kling-v2-1-master` | ❌ | ❌ | ❌ |
| `kling-v3` | ✅ all modes | ✅ | std/pro only (4k ❌) |
| `kling-v3-omni` | ✅ all modes | ✅ | ❌ |
| `kling-video-o1` | ✅ | ❌ | ❌ |

## 改动

### 新增 `src/utils/kling/capabilities.ts`
- `getKlingCapabilities(model, mode, duration) → { endImage, audio, motionControl, ... }`
- `findKlingConflicts(config, next)` — 给定一个准备应用的 partial 变更，返回会被破坏的字段
- `clearKlingConflicts(config, conflicts)` — 返回清理后的新 config

### 三个 Selector 改成 confirm-then-clear
ModelSelector / ModeSelector / DurationSelector：
- 不再 `v-model` 直接写 store；改成 `:model-value="value"` + `@change="onChange"`
- `onChange` 先 `findKlingConflicts`：
  - 无冲突 → 直接应用
  - 有冲突 → `ElMessageBox.confirm`，告诉用户"以下设置不支持：尾帧参考图、声音…，是否继续？"
    - 确认 → 应用新值 + 清空冲突字段 + `ElMessage.success` 告知清理结果
    - 取消 → 通过 `:key="revertKey"` 强制 el-select / el-slider 重渲染回旧值（解决 element-plus 内部 display state 不会自动回滚的问题）

### EndImage 上传守卫
- `uploadDisabled = reachedLimit || !endImageSupported`
- tooltip 文案根据原因变化：「尾帧不被当前模型/模式/时长支持」 vs 「最多 1 张」
- `:before-upload` 双保险拦截
- 新加 watcher：`config.end_image_url` 被外部清空（confirm 流走完）→ 自动清掉本地 fileList，缩略图同步消失

### i18n（zh-CN + en）
新增 6 个 key：`endImageNotSupported`、`featureNotSupportedTitle`/`Body`、`featureRemovedNotice`、`confirmContinue`、`cancelSwitch`

## 验证
- `npx vue-tsc --noEmit` ✅
- `npx eslint src/utils/kling/capabilities.ts src/components/kling/config/{Model,Mode,Duration}Selector.vue src/components/kling/config/EndImage.vue` ✅

## 后续
PlatformBackend 的 Kling OpenAPI spec 还应当用同一份矩阵补一段 description（"The end_image_url field requires …"），单独 PR 处理，避免本 PR 跨仓变更过多。
