### PR TITLE
[codex] fix empty site admin initialization

### DIFF
--- a/change/@acedatacloud-nexior-5bea47f2-962a-47e5-9df0-9e70d147d4c1.json
+++ b/change/@acedatacloud-nexior-5bea47f2-962a-47e5-9df0-9e70d147d4c1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Claim existing empty-admin sites during authenticated initialization.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "cqc@cuiqingcai.com",
+  "dependentChangeType": "patch"
+}

--- a/src/utils/initializer.ts
+++ b/src/utils/initializer.ts
@@ -133,7 +133,9 @@ export const initializeSite = async () => {
   const site = store.state.site;
   console.debug('site', site);
   // if site is not set, try to initialize site
-  if (!site?.origin) {
+  const shouldClaimEmptyAdminSite =
+    !!store.state.token?.access && site?.origin && (!site.admins || site.admins.length === 0);
+  if (!site?.origin || shouldClaimEmptyAdminSite) {
     await store.dispatch('initializeSite');
   }
 };


### PR DESCRIPTION
## Summary

Ensures Nexior repairs existing Site records that were created with an empty `admins` list once an authenticated user loads the site.

## Root cause

Nexior only called `/sites/initialize/` when `GET /sites` found no site at all. If a bad `Site` row already existed with `admins` missing or empty, the app kept that row in store and never triggered the backend initialization path that can assign the first authenticated user as admin.

## Changes

- During site initialization, call `initializeSite` when the user is authenticated and the loaded site has no admins.
- Add a patch Beachball change file for release tracking.

## Validation

- `npx eslint src/utils/initializer.ts`
- `npx vue-tsc --noEmit`
- `npm run verify`