### PR TITLE
fix(openai-image): show reference images for legacy edit task snapshots

### DIFF
--- a/src/components/openaiimage/task/Preview.vue
+++ b/src/components/openaiimage/task/Preview.vue
@@ -12,11 +12,11 @@
       </div>
       <div class="info">
         <div
-          v-if="modelValue?.request?.image_urls && modelValue?.request?.image_urls.length > 0"
+          v-if="referenceImages.length > 0"
           class="flex justify-start items-center gap-2 mt-2 w-full overflow-x-auto"
         >
           <image-preview
-            v-for="(url, idx) in modelValue?.request?.image_urls"
+            v-for="(url, idx) in referenceImages"
             :key="idx"
             :url="url"
             :name="`image-${idx + 1}`"
@@ -215,6 +215,23 @@ export default defineComponent({
         });
       }
       return result;
+    },
+    // Reference images for an edit task. Reads two field shapes:
+    //   - `request.image_urls`: string[] — written by the worker after PR
+    //     PlatformService#821 (new tasks).
+    //   - `request.image`: string | string[] — legacy snapshot shape used by
+    //     the worker before #821, which mirrored the multipart `image` form
+    //     field 1:1 (singular for one ref, array for multiple). This branch
+    //     keeps history rendering correct for tasks already in MongoDB.
+    referenceImages(): string[] {
+      const req: any = this.modelValue?.request;
+      if (!req) return [];
+      const fromUrls = Array.isArray(req.image_urls) ? (req.image_urls as string[]) : [];
+      if (fromUrls.length > 0) return fromUrls.filter((u) => typeof u === 'string' && u.length > 0);
+      const raw = req.image;
+      if (Array.isArray(raw)) return raw.filter((u: unknown): u is string => typeof u === 'string' && u.length > 0);
+      if (typeof raw === 'string' && raw.length > 0) return [raw];
+      return [];
     }
   },
   methods: {


### PR DESCRIPTION
配套 [AceDataCloud/PlatformService#821](https://github.com/AceDataCloud/PlatformService/pull/821) ——前者修了 worker 的快照丢字段，但生产 MongoDB 里**历史 task 不会回填**，必须前端兼容老 schema 才能立刻让用户看到参考图。

## 现象

`https://studio.acedata.cloud/openai-image` 的聊天历史里，gpt-image-2 的编辑任务始终不显示参考图缩略图，但 `/tasks` API 实际返回了图：

```json
{
  "id": "bb3bd1eb-...",
  "type": "images",
  "request": {
    "model": "gpt-image-2",
    "prompt": "把这个发票背后的背景改成户外",
    "callback_url": "https://webhook.acedata.cloud/openaiimage",
    "image": "https://cdn.acedata.cloud/9717767e83.jpg"   // ← 单图
  }
}
```

或多图：

```json
"image": ["https://cdn.acedata.cloud/9717767e83.jpg", "https://cdn.acedata.cloud/bcf3dc1a85.jpg"]
```

## 根因

`Preview.vue` 只读 `request.image_urls`：

```vue
<div v-if="modelValue?.request?.image_urls && modelValue?.request?.image_urls.length > 0">
  <image-preview v-for="(url, idx) in modelValue?.request?.image_urls" .../>
</div>
```

但生产历史数据用的字段是 `request.image`（单图是 string，多图是 string[]——直接 1:1 镜像了 multipart `image` 表单字段）。所以 `image_urls` 永远 undefined，DOM 永远不渲染。

## 修复

加一个归一化 computed，**优先**新字段、**回退**老字段：

```ts
referenceImages(): string[] {
  const req: any = this.modelValue?.request;
  if (!req) return [];
  const fromUrls = Array.isArray(req.image_urls) ? (req.image_urls as string[]) : [];
  if (fromUrls.length > 0) return fromUrls.filter((u) => typeof u === 'string' && u.length > 0);
  const raw = req.image;
  if (Array.isArray(raw)) return raw.filter((u: unknown): u is string => typeof u === 'string' && u.length > 0);
  if (typeof raw === 'string' && raw.length > 0) return [raw];
  return [];
}
```

模板从 `modelValue?.request?.image_urls` 改为 `referenceImages`。

## 兼容性

- **新任务**（worker PR #821 部署后写）：`request.image_urls = [...]` → 走第一分支，行为一致
- **老任务**（已经在 MongoDB 里的）：`request.image = "..."` 或 `[...]` → 走 fallback，**立刻补上缩略图**
- 没有任何字段 → 返回 `[]`，原本就不显示，无回归

## 验证

```
npx eslint src/components/openaiimage/task/Preview.vue          # clean
npx vue-tsc --noEmit                                            # clean
```
