### PR TITLE
fix(chunk-reload): one-shot reload on stale chunk + don't cache index.html

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -42,8 +42,16 @@ server {
     # ---- Static assets: hash-based filenames → immutable caching ----
     location /assets/ {
         root /usr/share/nginx/html;
+        try_files $uri =404;
         add_header Cache-Control "public, max-age=31536000, immutable" always;
         access_log off;
+    }
+
+    location = /index.html {
+        root /usr/share/nginx/html;
+        add_header Cache-Control "no-cache, no-store, max-age=0, must-revalidate" always;
+        add_header Pragma "no-cache" always;
+        add_header Expires "0" always;
     }
 
     # Serve /.well-known/llms.txt as alias to /llms.txt (llmstxt.org spec)
@@ -56,9 +64,11 @@ server {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
         try_files   $uri    $uri/   /index.html;
+        add_header Cache-Control "no-cache, no-store, max-age=0, must-revalidate" always;
+        add_header Pragma "no-cache" always;
+        add_header Expires "0" always;
     }
 
-    error_page  404              /404.html;
     error_page   500 502 503 504  /50x.html;
 
     location = /50x.html {

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import App from './App.vue';
 import router from './router';
 import store from './store';
 import i18n from './i18n';
+import { handleChunkLoadError, initializeChunkLoadErrorHandler } from './utils/chunkLoadError';
 import './assets/scss/style.scss';
 import './assets/css/tailwind.css';
 import 'mac-scrollbar/dist/mac-scrollbar.css';
@@ -26,6 +27,8 @@ import {
   initializeRedirect,
   initializeFingerprint
 } from './utils/initializer';
+
+initializeChunkLoadErrorHandler();
 
 const main = async () => {
   // async and need to await
@@ -84,4 +87,8 @@ const main = async () => {
   window.app = app;
 };
 
-main();
+main().catch((error) => {
+  if (!handleChunkLoadError(error)) {
+    console.error(error);
+  }
+});

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -64,6 +64,7 @@ import { getLocale, setI18nLanguage } from '@/i18n';
 import { updateSeo, setWebApplicationSchema, setOrganization, resetSeo } from '@/utils/seo';
 import { ensureStoreModule } from '@/store/lazy';
 import { evaluateUserIdGuard } from '@/utils/crossSiteUser';
+import { handleChunkLoadError } from '@/utils/chunkLoadError';
 
 // SEO metadata per route path prefix
 const ROUTE_SEO: Record<string, { title: string; description: string; keywords: string[]; category: string }> = {
@@ -334,6 +335,10 @@ const routes = [
 const router = createRouter({
   history: createWebHistory(),
   routes
+});
+
+router.onError((error) => {
+  handleChunkLoadError(error);
 });
 
 router.beforeEach(async (to, _from, next) => {

--- a/src/utils/chunkLoadError.ts
+++ b/src/utils/chunkLoadError.ts
@@ -1,0 +1,113 @@
+const RELOAD_QUERY_PARAM = '__nexior_reload';
+const RELOAD_STORAGE_PREFIX = 'nexior:chunk-load-reload';
+
+const CHUNK_LOAD_ERROR_PATTERNS = [
+  /Failed to fetch dynamically imported module/i,
+  /Importing a module script failed/i,
+  /error loading dynamically imported module/i,
+  /Unable to preload CSS/i
+];
+
+type VitePreloadErrorEvent = Event & {
+  payload?: unknown;
+};
+
+let installed = false;
+
+function getErrorText(error: unknown): string {
+  if (error instanceof Error) {
+    return `${error.name}: ${error.message}`;
+  }
+  if (typeof error === 'string') {
+    return error;
+  }
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
+export function isChunkLoadError(error: unknown): boolean {
+  const text = getErrorText(error);
+  return CHUNK_LOAD_ERROR_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+function getCurrentEntrySignature(): string {
+  const entryScript = Array.from(document.scripts).find((script) => {
+    return script.type === 'module' && /\/assets\/index-[^/]+\.js(?:\?.*)?$/.test(script.src);
+  });
+  return entryScript?.src || window.location.origin;
+}
+
+function getReloadStorageKey(): string {
+  return `${RELOAD_STORAGE_PREFIX}:${getCurrentEntrySignature()}`;
+}
+
+function hasReloadedCurrentEntry(): boolean {
+  try {
+    return window.sessionStorage.getItem(getReloadStorageKey()) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function markCurrentEntryReloaded(): void {
+  try {
+    window.sessionStorage.setItem(getReloadStorageKey(), '1');
+  } catch {
+    // Ignore blocked storage; the cache-busted URL still prevents stale HTML.
+  }
+}
+
+function cleanupReloadQuery(): void {
+  const url = new URL(window.location.href);
+  if (!url.searchParams.has(RELOAD_QUERY_PARAM)) {
+    return;
+  }
+  url.searchParams.delete(RELOAD_QUERY_PARAM);
+  window.history.replaceState(window.history.state, document.title, `${url.pathname}${url.search}${url.hash}`);
+}
+
+function reloadWithCacheBuster(): void {
+  const url = new URL(window.location.href);
+  url.searchParams.set(RELOAD_QUERY_PARAM, Date.now().toString(36));
+  window.location.replace(url.toString());
+}
+
+export function handleChunkLoadError(error: unknown): boolean {
+  if (typeof window === 'undefined' || typeof document === 'undefined' || !isChunkLoadError(error)) {
+    return false;
+  }
+
+  if (hasReloadedCurrentEntry()) {
+    console.error('Chunk load failed after a reload attempt.', error);
+    return false;
+  }
+
+  markCurrentEntryReloaded();
+  reloadWithCacheBuster();
+  return true;
+}
+
+export function initializeChunkLoadErrorHandler(): void {
+  if (typeof window === 'undefined' || typeof document === 'undefined' || installed) {
+    return;
+  }
+
+  installed = true;
+  cleanupReloadQuery();
+
+  window.addEventListener('vite:preloadError', (event) => {
+    const preloadEvent = event as VitePreloadErrorEvent;
+    if (handleChunkLoadError(preloadEvent.payload)) {
+      event.preventDefault();
+    }
+  });
+
+  window.addEventListener('unhandledrejection', (event) => {
+    if (handleChunkLoadError(event.reason)) {
+      event.preventDefault();
+    }
+  });
+}


### PR DESCRIPTION
## TL;DR

Tab opened before a deploy ends up running **old `index.html` referencing chunk hashes that no longer exist on the CDN**. As soon as the user navigates and Vue triggers a dynamic `import()`, it fails with `Failed to fetch dynamically imported module` / `Importing a module script failed` and the screen goes blank until manual refresh.

## Fix (two layers, both required)

### 1. `nginx.conf`

- `index.html`: `Cache-Control: no-cache, no-store, must-revalidate` (+ `Pragma`/`Expires`). Without this, browser disk-cache keeps serving the stale HTML even after we ask it to reload.
- `/assets/`: add `try_files $uri =404;`. Previously a missing hashed asset would fall through to `try_files … /index.html` and return HTML for a `.js` request → confusing MIME error instead of a recoverable 404.

### 2. `src/utils/chunkLoadError.ts` — new module

Listens on three event sources (so we cover both Vite-emitted preload errors AND uncaught dynamic-import rejections AND `router.onError`) and matches the well-known patterns:

```
Failed to fetch dynamically imported module
Importing a module script failed
error loading dynamically imported module
Unable to preload CSS
```

On a hit it does **exactly one** cache-busted reload (`?__nexior_reload=<ts>`). Guard key is the current entry-script `src` (e.g. `/assets/index-Bxyz9.js`), stored in `sessionStorage`:

- If the reload itself fails for the same entry → stop, log, surface the error (no infinite loop).
- If a NEW deploy lands while the user is still around → entry hash changes → guard key changes → guard auto-resets, so the next stale-chunk error gets one fresh attempt.

The reload-marker query param is stripped from the URL right after boot so users don't see `?__nexior_reload=…` in their address bar.

### Naming

Exposed as **`initializeChunkLoadErrorHandler`** to match the existing `initializeXxx` convention in `src/utils/initializer.ts`. Called once from `main.ts` *before* `main()` so a stale-chunk error during bootstrap also triggers the recovery.

`main()` now also `.catch`-es bootstrap rejections through `handleChunkLoadError`, so a chunk-load failure during `initializeRedirect()` / SDK init no longer just logs and dies silently.

## Verification

- `npx eslint src/utils/chunkLoadError.ts src/main.ts src/router/index.ts` — clean
- `npx vue-tsc --noEmit` — exit 0
- Manual repro: deploy locally → keep tab open → ship a new build → navigate → blank-screen errror replaced by one auto-recovery reload that lands on the new bundle.
