### PR TITLE
fix(byok): pure Test button — no longer silently saves draft credentials

### DIFF
--- a/src/components/setting/byok/Dialog.vue
+++ b/src/components/setting/byok/Dialog.vue
@@ -29,8 +29,12 @@
           type="password"
           autocomplete="new-password"
           show-password
-          :placeholder="credential ? $t('byok.field.apiKeyEditPlaceholder') : $t('byok.field.apiKeyPlaceholder')"
+          :placeholder="apiKeyPlaceholder"
         />
+        <p v-if="credential?.api_key_masked" class="current-key">
+          <code>{{ credential.api_key_masked }}</code>
+          <span>{{ $t('byok.field.apiKeyEditPlaceholder') }}</span>
+        </p>
       </el-form-item>
 
       <el-form-item :label="$t('byok.field.baseUrl')" prop="base_url">
@@ -73,8 +77,8 @@
 
     <template #footer>
       <el-button @click="onClose(false)">{{ $t('byok.button.cancel') }}</el-button>
-      <el-button :loading="testing" :disabled="saving || !canTest" @click="onSaveAndTest">
-        {{ $t('byok.button.testConnection') }}
+      <el-button :loading="testing" :disabled="saving || !canTest" @click="onTest">
+        {{ $t('byok.button.test') }}
       </el-button>
       <el-button type="primary" :loading="saving" @click="onSubmit">
         {{ $t('byok.button.save') }}
@@ -98,7 +102,13 @@ import {
   type FormRules
 } from 'element-plus';
 import { byokCredentialOperator } from '@/operators';
-import type { IBYOKCredential, IBYOKCredentialCreatePayload, IBYOKProvider, IBYOKProviderInfo } from '@/models';
+import type {
+  IBYOKCredential,
+  IBYOKCredentialCreatePayload,
+  IBYOKCredentialTestPayload,
+  IBYOKProvider,
+  IBYOKProviderInfo
+} from '@/models';
 
 interface ITestResult {
   ok: boolean;
@@ -160,12 +170,18 @@ export default defineComponent({
       const info = this.providers.find((p) => p.id === provider);
       return info?.default_base_url ?? this.$t('byok.field.baseUrlPlaceholder');
     },
+    apiKeyPlaceholder(): string {
+      if (!this.credential) return this.$t('byok.field.apiKeyPlaceholder');
+      if (this.credential.api_key_masked) {
+        return `${this.credential.api_key_masked} · ${this.$t('byok.field.apiKeyEditPlaceholder')}`;
+      }
+      return this.$t('byok.field.apiKeyEditPlaceholder');
+    },
     /**
      * On edit, the row already has an api_key on the server, so the
      * test button can run even when the api_key field is left blank
-     * (= "keep existing"). On create, we need a non-empty api_key
-     * because the row doesn't exist yet and the test button needs to
-     * save it first.
+     * (= "keep existing"). On create, the draft test payload needs a
+     * non-empty api_key because no saved row exists yet.
      */
     canTest(): boolean {
       if (!this.token) return false;
@@ -213,8 +229,7 @@ export default defineComponent({
     },
     /**
      * Persist the row (create or update). Returns the row's id on
-     * success so the caller can chain `test`. Returns null on
-     * validation / network failure (caller surfaces the error toast).
+     * success. Returns null on validation / network failure.
      */
     async persist(options: { silent?: boolean } = {}): Promise<string | null> {
       const formRef = this.$refs.formRef as FormInstance | undefined;
@@ -267,29 +282,45 @@ export default defineComponent({
       const id = await this.persist();
       if (id) this.$emit('saved');
     },
-    async onSaveAndTest() {
-      this.testResult = null;
-      // Save first so the test runs against exactly the config the
-      // user entered (api_key + base_url + provider) and reuses the
-      // existing `POST /aichat2/credentials {action: 'test'}` endpoint
-      // — there's no anonymous dry-run endpoint server-side.
-      const id = await this.persist({ silent: true });
-      if (!id) return;
+    async buildTestPayload(): Promise<IBYOKCredentialTestPayload | null> {
+      const formRef = this.$refs.formRef as FormInstance | undefined;
+      if (formRef) {
+        try {
+          await formRef.validate();
+        } catch {
+          return null;
+        }
+      }
+      const provider = this.form.provider;
+      if (!this.token || !provider) return null;
+      const apiKey = this.form.api_key.trim();
+      if (!this.credential && !apiKey) return null;
+      return {
+        ...(this.credential ? { id: this.credential.id } : {}),
+        provider,
+        ...(apiKey ? { api_key: apiKey } : {}),
+        base_url: this.form.base_url.trim()
+      };
+    },
+    resolveTestEndpoint(): string {
       const provider = this.providers.find((p) => p.id === this.form.provider);
       const baseUrl = (this.form.base_url || provider?.default_base_url || '').replace(/\/+$/, '');
-      const endpoint = `${baseUrl}/models`;
+      return `${baseUrl}/models`;
+    },
+    async onTest() {
+      this.testResult = null;
+      const payload = await this.buildTestPayload();
+      if (!payload) return;
+      const endpoint = this.resolveTestEndpoint();
       this.testing = true;
       try {
-        const { data } = await byokCredentialOperator.test(id, { token: this.token });
+        const { data } = await byokCredentialOperator.test(payload, { token: this.token });
         this.testResult = {
           ok: !!data?.ok,
-          endpoint,
+          endpoint: data?.endpoint || endpoint,
           status: data?.status,
           message: data?.message
         };
-        // The list view re-pulls credentials via the parent `saved`
-        // emit — `last_used_at` updates after a successful test.
-        this.$emit('saved');
       } catch (err) {
         const status = (err as { response?: { status?: number } })?.response?.status;
         const message =
@@ -315,6 +346,20 @@ export default defineComponent({
   color: var(--el-text-color-secondary);
   line-height: 1.5;
   margin: 4px 0 0;
+}
+
+.current-key {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin: 6px 0 0;
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+
+  code {
+    color: var(--el-text-color-primary);
+  }
 }
 
 .w-full {

--- a/src/i18n/en/byok.json
+++ b/src/i18n/en/byok.json
@@ -144,20 +144,20 @@
     "description": ""
   },
   "badge.active": {
-    "message": "Using your {provider} Key",
+    "message": "Using custom {provider} API Key",
     "description": ""
   },
   "badge.tooltip": {
-    "message": "This dialogue uses your own {provider} API Key, costs will be settled by your {provider} account, and will not deduct from platform balance.",
+    "message": "This conversation is using your {provider} API Key. Costs are settled by your {provider} account and do not deduct platform balance.",
     "description": ""
   },
   "badge.manage": {
-    "message": "Click to manage your custom API Key",
+    "message": "Click to open API Key settings",
     "description": "Prompt after clicking the BYOK badge on the chat page: Click to open the API Key tab in the settings dialog."
   },
   "button.testConnection": {
-    "message": "Save and Test Connection",
-    "description": "Button in the add/edit dialog - first save the credentials, then call upstream /models to verify connectivity."
+    "message": "Test",
+    "description": "Button in the add/edit dialog - only tests the current form configuration without saving credentials."
   },
   "test.success": {
     "message": "Connectivity Test Successful",

--- a/src/i18n/zh-CN/byok.json
+++ b/src/i18n/zh-CN/byok.json
@@ -144,19 +144,19 @@
     "description": ""
   },
   "badge.active": {
-    "message": "使用你的 {provider} Key",
+    "message": "正在使用自定义 {provider} API Key",
     "description": ""
   },
   "badge.tooltip": {
-    "message": "本次对话使用你自己的 {provider} API Key，费用由 {provider} 账户结算，不扣减平台余额。",
+    "message": "当前对话正在使用你的 {provider} API Key，费用由 {provider} 账户结算，不扣减平台余额。",
     "description": ""  },
   "badge.manage": {
-    "message": "点击管理你的自定义 API Key",
+    "message": "点击可打开 API Key 设置",
     "description": "聊天页面 BYOK 徽章点击后的提示：点击打开设置对话框的 API Key 选项卡。"
   },
   "button.testConnection": {
-    "message": "保存并测试连通",
-    "description": "新增/编辑对话框中的按钮——先保存凭据，再调用上游 /models 验证连通性。"
+    "message": "测试",
+    "description": "新增/编辑对话框中的按钮——只测试当前表单配置，不保存凭据。"
   },
   "test.success": {
     "message": "连通性测试成功",

--- a/src/models/byok.ts
+++ b/src/models/byok.ts
@@ -45,6 +45,13 @@ export interface IBYOKCredentialUpdatePayload {
   is_active?: boolean;
 }
 
+export interface IBYOKCredentialTestPayload {
+  id?: string;
+  provider?: IBYOKProvider;
+  api_key?: string;
+  base_url?: string;
+}
+
 export interface IBYOKListResponse {
   items: IBYOKCredential[];
 }
@@ -55,6 +62,7 @@ export interface IBYOKProvidersResponse {
 
 export interface IBYOKTestResponse {
   ok: boolean;
+  endpoint?: string;
   status?: number;
   message?: string;
 }

--- a/src/operators/byokCredential.ts
+++ b/src/operators/byokCredential.ts
@@ -19,6 +19,7 @@ import axios, { AxiosResponse } from 'axios';
 import {
   IBYOKCredential,
   IBYOKCredentialCreatePayload,
+  IBYOKCredentialTestPayload,
   IBYOKCredentialUpdatePayload,
   IBYOKListResponse,
   IBYOKProvidersResponse,
@@ -100,10 +101,10 @@ class BYOKCredentialOperator {
    * endpoint. Returns `{ok: false, message}` on failure rather than
    * throwing — the UI wants to show "401 unauthorized" inline.
    */
-  async test(id: string, options: AuthOptions): Promise<AxiosResponse<IBYOKTestResponse>> {
+  async test(payload: IBYOKCredentialTestPayload, options: AuthOptions): Promise<AxiosResponse<IBYOKTestResponse>> {
     return await axios.post(
       ENDPOINT,
-      { action: 'test', id },
+      { action: 'test', ...payload },
       { headers: authHeaders(options.token), baseURL: BASE_URL_API }
     );
   }


### PR DESCRIPTION
## TL;DR

Replace the "Save and Test Connection" button in the BYOK credential dialog with a **pure "Test" button** that no longer persists the form before testing. Also surface the masked api-key on edit so users can see which key they're about to overwrite.

## Why

Old flow: clicking the test button silently called `persist()` first, then ran `POST /aichat2/credentials {action: 'test', id}` (server re-reads `api_key`/`base_url` from the saved row). Two failure modes:

1. **Editing**: hitting Test would overwrite the saved row with the in-progress draft *even if the test failed*. Users expect Save to require an explicit click.
2. **Creating**: hitting Test would create a half-baked row before the user finished tweaking, polluting the credentials list.

## Change

| Layer | Before | After |
|---|---|---|
| Operator signature | `test(id: string, options)` | `test(payload: IBYOKCredentialTestPayload, options)` |
| Request body | `{action: 'test', id}` | `{action: 'test', id?, provider, api_key?, base_url}` |
| Dialog button | "Save and Test Connection" → calls `persist()` then `test(id)` | "Test" → validates form, builds draft payload, calls `test(payload)` directly |
| Result UI | shows endpoint guessed from form `base_url` | shows server-echoed `endpoint` if present, else falls back |
| Edit dialog | – | masked existing key shown inline under the input (`api_key_masked`) |

`IBYOKTestResponse` gains optional `endpoint` so the server can tell us exactly which URL it hit (helpful when the server normalizes the user's `base_url`, e.g. trailing-slash, `/v1` suffix).

Backend already accepts the new payload shape — this PR only catches the frontend up to the new contract.

## i18n

Light polish on `en`/`zh-CN` `badge.active` / `badge.tooltip` / `badge.manage` / `button.testConnection` strings. Other 16 locales follow via the auto-translate CronJob — not touched here per the workspace convention (only `zh-CN` and `en` are maintained manually).

## Verification

- `npx eslint src/components/setting/byok/Dialog.vue src/models/byok.ts src/operators/byokCredential.ts` — clean
- `npx vue-tsc --noEmit` — exit 0
- Manual: edit existing credential → hit Test with bad key → verify saved row UNCHANGED; hit Save → row updates.
- Manual: create new credential → hit Test → verify NO new row appears in the list; hit Save → row created.
