### PR TITLE
fix(user-center): remove Connections entry from user menu

### DIFF
--- a/src/components/user/Center.vue
+++ b/src/components/user/Center.vue
@@ -20,10 +20,6 @@
             <font-awesome-icon icon="fa-solid fa-coins" class="mr-2" />
             {{ $t('common.nav.distribution') }}
           </el-dropdown-item>
-          <el-dropdown-item class="py-2" @click="onConnectors">
-            <font-awesome-icon icon="fa-solid fa-plug" class="mr-2" />
-            {{ $t('common.nav.connections') }}
-          </el-dropdown-item>
           <el-dropdown-item v-if="showSubsite" class="py-2" @click="onSubsite">
             <font-awesome-icon icon="fa-solid fa-sitemap" class="mr-2" />
             {{ $t('common.nav.subsite') }}
@@ -49,7 +45,6 @@ import UserAvatar from '@/components/user/Avatar.vue';
 import UserSetting from '@/components/user/Setting.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { ROUTE_CONSOLE_ROOT, ROUTE_DISTRIBUTION_INDEX, ROUTE_DOWNLOAD, ROUTE_SUBSITE_INDEX } from '@/router';
-import { withCurrentUserId } from '@/utils';
 import { ElDivider } from 'element-plus';
 import { ElDropdownMenu, ElDropdownItem, ElDropdown } from 'element-plus';
 
@@ -118,12 +113,6 @@ export default defineComponent({
     },
     onConsole() {
       this.$router.push({ name: ROUTE_CONSOLE_ROOT });
-    },
-    onConnectors() {
-      // Connections are managed exclusively at auth.acedata.cloud.
-      // Append `?user_id=` so a cross-site identity mismatch is detected
-      // and the user is bounced through SSO if needed.
-      window.open(withCurrentUserId('https://auth.acedata.cloud/user/connections'), '_blank', 'noopener');
     },
     onDistribution() {
       this.$router.push({


### PR DESCRIPTION
Drops the **Connections / 连接** entry from the user-avatar dropdown in `UserCenter`.

Connections (MCP + OAuth connectors) live exclusively at `auth.acedata.cloud/user/connections` now, and the in-chat `Composer.vue` already exposes the same external link from its "+" menu, so the user-center duplicate is redundant — and surfacing it next to first-class app navigation (Settings / Distribution / Console / Sub-site) made the menu noisier than it needed to be.

### Changes

- Remove the `<el-dropdown-item @click="onConnectors">` entry and its `fa-plug` icon
- Remove the now-unused `onConnectors()` handler
- Remove the now-unused `withCurrentUserId` import

`Composer.vue`'s "+" menu still has its own "Connections" shortcut for users who want to manage MCP servers / OAuth connectors during a chat — that path is untouched. Only the avatar-dropdown duplicate is gone.
