### PR TITLE
feat(tasks): show elapsed time on task preview cards across scenarios

### DIFF
--- a/src/components/flux/task/Preview.vue
+++ b/src/components/flux/task/Preview.vue
@@ -33,11 +33,15 @@
             {{ $t('flux.name.model') }}:
             {{ modelValue?.request?.model }}
           </p>
-          <p class="text-[var(--el-text-color-regular)] text-xs mb-0">
+          <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
             <font-awesome-icon icon="fa-solid fa-magic" class="mr-1" />
             {{ $t('flux.name.taskId') }}:
             {{ modelValue?.id }}
             <copy-to-clipboard :content="modelValue?.id!" class="btn-copy inline-block" />
+          </p>
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-0">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('flux.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
           </p>
         </el-alert>
       </div>
@@ -59,6 +63,10 @@
             {{ $t('flux.name.failureReason') }}:
             {{ modelValue?.response?.error?.message }}
             <copy-to-clipboard :content="modelValue?.response?.error?.message!" class="btn-copy" />
+          </p>
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('flux.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
           </p>
           <p class="text-[var(--el-text-color-regular)] text-xs mb-0">
             <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />

--- a/src/components/hailuo/task/Preview.vue
+++ b/src/components/hailuo/task/Preview.vue
@@ -49,11 +49,15 @@
             {{ modelValue?.request?.model }}
             <copy-to-clipboard :content="modelValue?.id!" />
           </p>
-          <p class="text-[var(--el-text-color-regular)] text-xs mb-0">
+          <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
             <font-awesome-icon icon="fa-solid fa-magic" class="mr-1" />
             {{ $t('hailuo.name.taskId') }}:
             {{ modelValue?.id }}
             <copy-to-clipboard :content="modelValue?.id!" />
+          </p>
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-0">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('hailuo.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
           </p>
         </el-alert>
       </div>
@@ -75,6 +79,10 @@
             {{ $t('hailuo.name.failureReason') }}:
             {{ modelValue?.response?.error?.message }}
             <copy-to-clipboard :content="modelValue?.response?.error?.message!" />
+          </p>
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('hailuo.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
           </p>
           <p class="text-[var(--el-text-color-regular)] text-xs mb-0">
             <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />

--- a/src/components/headshots/task/Preview.vue
+++ b/src/components/headshots/task/Preview.vue
@@ -29,6 +29,10 @@
             {{ modelValue?.id }}
             <copy-to-clipboard :content="modelValue?.id!" class="btn-copy" />
           </p>
+          <p v-if="modelValue?.elapsed" class="description">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('headshots.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
+          </p>
         </el-alert>
       </div>
       <!-- Display error message -->
@@ -49,6 +53,10 @@
             {{ $t('headshots.name.failureReason') }}:
             {{ modelValue?.response?.error?.message }}
             <copy-to-clipboard :content="modelValue?.response?.error?.message!" class="btn-copy" />
+          </p>
+          <p v-if="modelValue?.elapsed" class="description">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('headshots.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
           </p>
           <p class="description">
             <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />

--- a/src/components/kling/task/Preview.vue
+++ b/src/components/kling/task/Preview.vue
@@ -62,11 +62,15 @@
             {{ $t('kling.name.model') }}:
             {{ modelValue?.request?.model }}
           </p>
-          <p class="text-[var(--el-text-color-regular)] text-xs mb-0">
+          <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
             <font-awesome-icon icon="fa-solid fa-magic" class="mr-1" />
             {{ $t('kling.name.taskId') }}:
             {{ modelValue?.id }}
             <copy-to-clipboard :content="modelValue?.id!" />
+          </p>
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-0">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('kling.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
           </p>
         </el-alert>
       </div>
@@ -88,6 +92,10 @@
             {{ $t('kling.name.failureReason') }}:
             {{ modelValue?.response?.error?.message }}
             <copy-to-clipboard :content="modelValue?.response?.error?.message!" />
+          </p>
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('kling.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
           </p>
           <p v-if="modelValue?.response?.trace_id" class="text-[var(--el-text-color-regular)] text-xs mb-0">
             <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />

--- a/src/components/luma/task/Preview.vue
+++ b/src/components/luma/task/Preview.vue
@@ -42,11 +42,15 @@
           </el-tooltip>
         </div>
         <el-alert :closable="false" class="mt-2 success">
-          <p class="text-[var(--el-text-color-regular)] text-xs mb-0">
+          <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
             <font-awesome-icon icon="fa-solid fa-magic" class="mr-1" />
             {{ $t('luma.name.taskId') }}:
             {{ modelValue?.id }}
             <copy-to-clipboard :content="modelValue?.id!" />
+          </p>
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-0">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('luma.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
           </p>
         </el-alert>
       </div>
@@ -71,6 +75,10 @@
             {{ $t('luma.name.failureReason') }}:
             {{ modelValue?.response?.error?.message }}
             <copy-to-clipboard :content="modelValue?.response?.error?.message!" />
+          </p>
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('luma.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
           </p>
           <p class="text-[var(--el-text-color-regular)] text-xs mb-0">
             <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />

--- a/src/components/nanobanana/task/Preview.vue
+++ b/src/components/nanobanana/task/Preview.vue
@@ -73,6 +73,10 @@
             {{ modelValue?.id }}
             <copy-to-clipboard :content="modelValue?.id!" class="btn-copy inline-block" />
           </p>
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('nanobanana.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
+          </p>
           <p v-if="modelValue?.response?.trace_id" class="text-[var(--el-text-color-regular)] text-xs mb-0">
             <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />
             {{ $t('nanobanana.name.traceId') }}:
@@ -120,6 +124,10 @@
             {{ $t('nanobanana.name.failureReason') }}:
             {{ modelValue?.response?.error?.message }}
             <copy-to-clipboard :content="modelValue?.response?.error?.message!" class="btn-copy" />
+          </p>
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('nanobanana.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
           </p>
           <p v-if="modelValue?.response?.trace_id" class="text-[var(--el-text-color-regular)] text-xs mb-0">
             <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />

--- a/src/components/openaiimage/task/Preview.vue
+++ b/src/components/openaiimage/task/Preview.vue
@@ -75,6 +75,10 @@
             {{ modelValue?.id }}
             <copy-to-clipboard :content="modelValue?.id!" class="btn-copy inline-block" />
           </p>
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('openaiimage.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
+          </p>
           <p v-if="modelValue?.response?.trace_id" class="text-[var(--el-text-color-regular)] text-xs mb-0">
             <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />
             {{ $t('openaiimage.name.traceId') }}:
@@ -119,6 +123,10 @@
             {{ $t('openaiimage.name.failureReason') }}:
             {{ modelValue?.response?.error?.message }}
             <copy-to-clipboard :content="modelValue?.response?.error?.message!" class="btn-copy" />
+          </p>
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('openaiimage.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
           </p>
           <p v-if="modelValue?.response?.trace_id" class="text-[var(--el-text-color-regular)] text-xs mb-0">
             <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />

--- a/src/components/pika/task/Preview.vue
+++ b/src/components/pika/task/Preview.vue
@@ -49,6 +49,10 @@
             {{ modelValue?.id }}
             <copy-to-clipboard :content="modelValue?.id!" class="btn-copy" />
           </p>
+          <p v-if="modelValue?.elapsed" class="description">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('pika.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
+          </p>
         </el-alert>
       </div>
       <!-- Display error message -->
@@ -69,6 +73,10 @@
             {{ $t('pika.name.failureReason') }}:
             {{ modelValue?.response?.error?.message }}
             <copy-to-clipboard :content="modelValue?.response?.error?.message!" class="btn-copy" />
+          </p>
+          <p v-if="modelValue?.elapsed" class="description">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('pika.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
           </p>
           <p class="description">
             <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />

--- a/src/components/pixverse/task/Preview.vue
+++ b/src/components/pixverse/task/Preview.vue
@@ -57,11 +57,15 @@
             {{ $t('pixverse.name.model') }}:
             {{ modelValue?.request?.model }}
           </p>
-          <p class="text-[var(--el-text-color-regular)] text-xs mb-0">
+          <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
             <font-awesome-icon icon="fa-solid fa-magic" class="mr-1" />
             {{ $t('pixverse.name.taskId') }}:
             {{ modelValue?.id }}
             <copy-to-clipboard :content="modelValue?.id!" />
+          </p>
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-0">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('pixverse.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
           </p>
         </el-alert>
       </div>
@@ -83,6 +87,10 @@
             {{ $t('pixverse.name.taskId') }}:
             {{ modelValue?.id }}
             <copy-to-clipboard :content="modelValue?.id!" />
+          </p>
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('pixverse.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
           </p>
           <p v-if="modelValue?.response?.trace_id" class="text-[var(--el-text-color-regular)] text-xs mb-0">
             <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />

--- a/src/components/qrart/task/Preview.vue
+++ b/src/components/qrart/task/Preview.vue
@@ -67,6 +67,10 @@
               class="btn-copy"
             />
           </p>
+          <p v-if="modelValue?.elapsed" class="description">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('qrart.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
+          </p>
         </el-alert>
       </div>
       <div v-if="modelValue?.response?.success === false" :class="{ content: true }">
@@ -86,6 +90,10 @@
             {{ $t('qrart.name.failureReason') }}:
             {{ modelValue?.response?.error?.message }}
             <copy-to-clipboard :content="modelValue?.response?.error?.message!" class="btn-copy" />
+          </p>
+          <p v-if="modelValue?.elapsed" class="description">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('qrart.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
           </p>
           <p class="description">
             <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />

--- a/src/components/seedance/task/Preview.vue
+++ b/src/components/seedance/task/Preview.vue
@@ -80,6 +80,10 @@
             {{ modelValue?.id }}
             <copy-to-clipboard :content="modelValue?.id!" class="btn-copy inline-block" />
           </p>
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('seedance.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
+          </p>
           <p v-if="modelValue?.response?.trace_id" class="text-[var(--el-text-color-regular)] text-xs mb-0">
             <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />
             {{ $t('seedance.name.traceId') }}:
@@ -105,6 +109,10 @@
             {{ $t('seedance.name.failureReason') }}:
             {{ modelValue?.response?.error?.message }}
             <copy-to-clipboard :content="modelValue?.response?.error?.message!" class="btn-copy inline-block" />
+          </p>
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('seedance.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
           </p>
           <p v-if="modelValue?.response?.trace_id" class="text-[var(--el-text-color-regular)] text-xs mb-0">
             <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />

--- a/src/components/seedream/task/Preview.vue
+++ b/src/components/seedream/task/Preview.vue
@@ -80,6 +80,10 @@
             {{ modelValue?.id }}
             <copy-to-clipboard :content="modelValue?.id!" class="btn-copy inline-block" />
           </p>
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('seedream.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
+          </p>
           <p v-if="modelValue?.response?.trace_id" class="text-[var(--el-text-color-regular)] text-xs mb-0">
             <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />
             {{ $t('seedream.name.traceId') }}:
@@ -120,6 +124,10 @@
             {{ $t('seedream.name.failureReason') }}:
             {{ modelValue?.response?.error?.message }}
             <copy-to-clipboard :content="modelValue?.response?.error?.message!" class="btn-copy" />
+          </p>
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('seedream.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
           </p>
           <p v-if="modelValue?.response?.trace_id" class="text-[var(--el-text-color-regular)] text-xs mb-0">
             <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />

--- a/src/components/sora/task/Preview.vue
+++ b/src/components/sora/task/Preview.vue
@@ -46,11 +46,15 @@
             {{ $t('sora.name.model') }}:
             {{ modelValue?.request?.model }}
           </p>
-          <p class="text-[var(--el-text-color-regular)] text-xs mb-0">
+          <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
             <font-awesome-icon icon="fa-solid fa-magic" class="mr-1" />
             {{ $t('sora.name.taskId') }}:
             {{ modelValue?.id }}
             <copy-to-clipboard :content="modelValue?.id!" />
+          </p>
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-0">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('sora.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
           </p>
         </el-alert>
       </div>
@@ -72,6 +76,10 @@
             {{ $t('sora.name.failureReason') }}:
             {{ modelValue?.response?.error?.message }}
             <copy-to-clipboard :content="modelValue?.response?.error?.message!" />
+          </p>
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('sora.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
           </p>
           <p v-if="modelValue?.response?.trace_id" class="text-[var(--el-text-color-regular)] text-xs mb-0">
             <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />

--- a/src/components/veo/task/Preview.vue
+++ b/src/components/veo/task/Preview.vue
@@ -109,11 +109,15 @@
             {{ $t('veo.name.model') }}:
             {{ modelValue?.request?.model }}
           </p>
-          <p class="text-[var(--el-text-color-regular)] text-xs mb-0">
+          <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
             <font-awesome-icon icon="fa-solid fa-magic" class="mr-1" />
             {{ $t('veo.name.taskId') }}:
             {{ modelValue?.id }}
             <copy-to-clipboard :content="modelValue?.id!" />
+          </p>
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-0">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('veo.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
           </p>
         </el-alert>
       </div>
@@ -135,6 +139,10 @@
             {{ $t('veo.name.failureReason') }}:
             {{ modelValue?.response?.error?.message }}
             <copy-to-clipboard :content="modelValue?.response?.error?.message!" />
+          </p>
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('veo.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
           </p>
           <p v-if="modelValue?.response?.trace_id" class="text-[var(--el-text-color-regular)] text-xs mb-0">
             <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />

--- a/src/components/wan/task/Preview.vue
+++ b/src/components/wan/task/Preview.vue
@@ -44,11 +44,15 @@
             {{ modelValue?.request?.model }}
             <copy-to-clipboard :content="modelValue?.id!" />
           </p>
-          <p class="text-[var(--el-text-color-regular)] text-xs mb-0">
+          <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
             <font-awesome-icon icon="fa-solid fa-magic" class="mr-1" />
             {{ $t('wan.name.taskId') }}:
             {{ modelValue?.id }}
             <copy-to-clipboard :content="modelValue?.id!" />
+          </p>
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-0">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('wan.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
           </p>
         </el-alert>
       </div>
@@ -70,6 +74,10 @@
             {{ $t('wan.name.failureReason') }}:
             {{ modelValue?.response?.error?.message }}
             <copy-to-clipboard :content="modelValue?.response?.error?.message!" />
+          </p>
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('wan.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
           </p>
           <p class="text-[var(--el-text-color-regular)] text-xs mb-0">
             <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />

--- a/src/i18n/en/flux.json
+++ b/src/i18n/en/flux.json
@@ -39,6 +39,10 @@
     "message": "Trace ID",
     "description": "The trace ID of the task"
   },
+  "name.elapsed": {
+    "message": "Elapsed",
+    "description": "Elapsed time of the task in seconds"
+  },
   "name.createdAt": {
     "message": "Created At",
     "description": "The date and time the Flux image was generated"

--- a/src/i18n/en/hailuo.json
+++ b/src/i18n/en/hailuo.json
@@ -23,6 +23,10 @@
     "message": "Trace ID",
     "description": "The trace ID of the task"
   },
+  "name.elapsed": {
+    "message": "Elapsed",
+    "description": "Elapsed time of the task in seconds"
+  },
   "name.createdAt": {
     "message": "Created At",
     "description": "The date and time the Hailuo video was generated"

--- a/src/i18n/en/headshots.json
+++ b/src/i18n/en/headshots.json
@@ -27,6 +27,10 @@
     "message": "Trace ID",
     "description": "The trace ID of the task"
   },
+  "name.elapsed": {
+    "message": "Elapsed",
+    "description": "Elapsed time of the task in seconds"
+  },
   "name.size": {
     "message": "Size",
     "description": "The size of the QR code to be generated"

--- a/src/i18n/en/kling.json
+++ b/src/i18n/en/kling.json
@@ -371,6 +371,10 @@
     "message": "Trace ID",
     "description": "The trace ID of the task"
   },
+  "name.elapsed": {
+    "message": "Elapsed",
+    "description": "Elapsed time of the task in seconds"
+  },
   "name.createdAt": {
     "message": "Created At",
     "description": "The date and time the Kling video was generated"

--- a/src/i18n/en/luma.json
+++ b/src/i18n/en/luma.json
@@ -23,6 +23,10 @@
     "message": "Trace ID",
     "description": "The trace ID of the task"
   },
+  "name.elapsed": {
+    "message": "Elapsed",
+    "description": "Elapsed time of the task in seconds"
+  },
   "name.size": {
     "message": "Size",
     "description": "The size of the QR code to be generated"

--- a/src/i18n/en/nanobanana.json
+++ b/src/i18n/en/nanobanana.json
@@ -35,6 +35,10 @@
     "message": "Trace ID",
     "description": "Trace ID"
   },
+  "name.elapsed": {
+    "message": "Elapsed",
+    "description": "Elapsed time of the task in seconds"
+  },
   "name.prompt": {
     "message": "Image Prompt",
     "description": "Prompt for generating/editing"

--- a/src/i18n/en/openaiimage.json
+++ b/src/i18n/en/openaiimage.json
@@ -35,6 +35,10 @@
     "message": "Trace ID",
     "description": "Trace ID"
   },
+  "name.elapsed": {
+    "message": "Elapsed",
+    "description": "Elapsed time of the task in seconds"
+  },
   "name.prompt": {
     "message": "Image Prompt",
     "description": "Prompt for generating/editing"

--- a/src/i18n/en/pika.json
+++ b/src/i18n/en/pika.json
@@ -75,6 +75,10 @@
     "message": "Trace ID",
     "description": "Trace ID of the task"
   },
+  "name.elapsed": {
+    "message": "Elapsed",
+    "description": "Elapsed time of the task in seconds"
+  },
   "name.createdAt": {
     "message": "Created At",
     "description": "Date and time when the Pika video was generated"

--- a/src/i18n/en/pixverse.json
+++ b/src/i18n/en/pixverse.json
@@ -23,6 +23,10 @@
     "message": "Trace ID",
     "description": "The trace ID of the task"
   },
+  "name.elapsed": {
+    "message": "Elapsed",
+    "description": "Elapsed time of the task in seconds"
+  },
   "name.createdAt": {
     "message": "Created At",
     "description": "The date and time the Pixverse video was generated"

--- a/src/i18n/en/qrart.json
+++ b/src/i18n/en/qrart.json
@@ -23,6 +23,10 @@
     "message": "Trace ID",
     "description": "The trace ID of the task"
   },
+  "name.elapsed": {
+    "message": "Elapsed",
+    "description": "Elapsed time of the task in seconds"
+  },
   "name.size": {
     "message": "Size",
     "description": "The size of the QR code to be generated"

--- a/src/i18n/en/seedance.json
+++ b/src/i18n/en/seedance.json
@@ -171,6 +171,10 @@
     "message": "Trace ID",
     "description": "Label for trace ID"
   },
+  "name.elapsed": {
+    "message": "Elapsed",
+    "description": "Label for elapsed time in seconds"
+  },
   "name.failure": {
     "message": "Failure",
     "description": "Label for failure"

--- a/src/i18n/en/seedream.json
+++ b/src/i18n/en/seedream.json
@@ -35,6 +35,10 @@
     "message": "Trace ID",
     "description": "Trace ID"
   },
+  "name.elapsed": {
+    "message": "Elapsed",
+    "description": "Elapsed time of the task in seconds"
+  },
   "name.prompt": {
     "message": "Image Prompt",
     "description": "Prompt for generating/editing"

--- a/src/i18n/en/sora.json
+++ b/src/i18n/en/sora.json
@@ -19,6 +19,10 @@
     "message": "Trace ID",
     "description": "The trace ID of the task"
   },
+  "name.elapsed": {
+    "message": "Elapsed",
+    "description": "Elapsed time of the task in seconds"
+  },
   "name.createdAt": {
     "message": "Created At",
     "description": "The date and time the Sora video was generated"

--- a/src/i18n/en/veo.json
+++ b/src/i18n/en/veo.json
@@ -27,6 +27,10 @@
     "message": "Trace ID",
     "description": "The trace ID of the task"
   },
+  "name.elapsed": {
+    "message": "Elapsed",
+    "description": "Elapsed time of the task in seconds"
+  },
   "name.createdAt": {
     "message": "Created At",
     "description": "The date and time the Veo video was generated"

--- a/src/i18n/en/wan.json
+++ b/src/i18n/en/wan.json
@@ -23,6 +23,10 @@
     "message": "Trace ID",
     "description": "The trace ID of the task"
   },
+  "name.elapsed": {
+    "message": "Elapsed",
+    "description": "Elapsed time of the task in seconds"
+  },
   "name.createdAt": {
     "message": "Created At",
     "description": "Creation time of the video"

--- a/src/i18n/zh-CN/flux.json
+++ b/src/i18n/zh-CN/flux.json
@@ -39,6 +39,10 @@
     "message": "追踪 ID",
     "description": "任务的追踪 ID"
   },
+  "name.elapsed": {
+    "message": "耗时",
+    "description": "任务的耗时（秒）"
+  },
   "name.createdAt": {
     "message": "创建时间",
     "description": "生成 Flux 图片的日期和时间"

--- a/src/i18n/zh-CN/hailuo.json
+++ b/src/i18n/zh-CN/hailuo.json
@@ -23,6 +23,10 @@
     "message": "追踪 ID",
     "description": "任务的追踪 ID"
   },
+  "name.elapsed": {
+    "message": "耗时",
+    "description": "任务的耗时（秒）"
+  },
   "name.createdAt": {
     "message": "创建时间",
     "description": "生成 Hailuo 视频的日期和时间"

--- a/src/i18n/zh-CN/headshots.json
+++ b/src/i18n/zh-CN/headshots.json
@@ -27,6 +27,10 @@
     "message": "追踪 ID",
     "description": "任务的追踪 ID"
   },
+  "name.elapsed": {
+    "message": "耗时",
+    "description": "任务的耗时（秒）"
+  },
   "name.size": {
     "message": "尺寸",
     "description": "要生成的 QR 码的尺寸"

--- a/src/i18n/zh-CN/kling.json
+++ b/src/i18n/zh-CN/kling.json
@@ -371,6 +371,10 @@
     "message": "追踪 ID",
     "description": "任务的追踪 ID"
   },
+  "name.elapsed": {
+    "message": "耗时",
+    "description": "任务的耗时（秒）"
+  },
   "name.createdAt": {
     "message": "创建时间",
     "description": "生成 Kling 视频的日期和时间"

--- a/src/i18n/zh-CN/luma.json
+++ b/src/i18n/zh-CN/luma.json
@@ -23,6 +23,10 @@
     "message": "追踪 ID",
     "description": "任务的追踪 ID"
   },
+  "name.elapsed": {
+    "message": "耗时",
+    "description": "任务的耗时（秒）"
+  },
   "name.size": {
     "message": "尺寸",
     "description": "要生成的 QR 码的尺寸"

--- a/src/i18n/zh-CN/nanobanana.json
+++ b/src/i18n/zh-CN/nanobanana.json
@@ -35,6 +35,10 @@
     "message": "追踪 ID",
     "description": "追踪 ID"
   },
+  "name.elapsed": {
+    "message": "耗时",
+    "description": "任务的耗时（秒）"
+  },
   "name.prompt": {
     "message": "图像提示",
     "description": "生成/编辑的提示词"

--- a/src/i18n/zh-CN/openaiimage.json
+++ b/src/i18n/zh-CN/openaiimage.json
@@ -35,6 +35,10 @@
     "message": "追踪 ID",
     "description": "追踪 ID"
   },
+  "name.elapsed": {
+    "message": "耗时",
+    "description": "任务的耗时（秒）"
+  },
   "name.prompt": {
     "message": "图像提示",
     "description": "生成/编辑的提示词"

--- a/src/i18n/zh-CN/pika.json
+++ b/src/i18n/zh-CN/pika.json
@@ -75,6 +75,10 @@
     "message": "追踪 ID",
     "description": "任务的追踪 ID"
   },
+  "name.elapsed": {
+    "message": "耗时",
+    "description": "任务的耗时（秒）"
+  },
   "name.createdAt": {
     "message": "创建时间",
     "description": "生成 Pika 视频的日期和时间"

--- a/src/i18n/zh-CN/pixverse.json
+++ b/src/i18n/zh-CN/pixverse.json
@@ -23,6 +23,10 @@
     "message": "追踪 ID",
     "description": "任务的追踪 ID"
   },
+  "name.elapsed": {
+    "message": "耗时",
+    "description": "任务的耗时（秒）"
+  },
   "name.createdAt": {
     "message": "创建时间",
     "description": "生成 Pixverse 视频的日期和时间"

--- a/src/i18n/zh-CN/qrart.json
+++ b/src/i18n/zh-CN/qrart.json
@@ -23,6 +23,10 @@
     "message": "追踪 ID",
     "description": "任务的追踪 ID"
   },
+  "name.elapsed": {
+    "message": "耗时",
+    "description": "任务的耗时（秒）"
+  },
   "name.size": {
     "message": "尺寸",
     "description": "要生成的 QR 码的尺寸"

--- a/src/i18n/zh-CN/seedance.json
+++ b/src/i18n/zh-CN/seedance.json
@@ -45,6 +45,7 @@
   "status.processing": { "message": "生成中", "description": "生成中状态" },
   "name.taskId": { "message": "任务 ID", "description": "任务 ID 标签" },
   "name.traceId": { "message": "Trace ID", "description": "Trace ID 标签" },
+  "name.elapsed": { "message": "耗时", "description": "任务的耗时（秒）" },
   "name.failure": { "message": "失败", "description": "失败标签" },
   "name.failureReason": { "message": "失败原因", "description": "失败原因标签" },
   "name.status": { "message": "状态", "description": "状态标签" }

--- a/src/i18n/zh-CN/seedream.json
+++ b/src/i18n/zh-CN/seedream.json
@@ -35,6 +35,10 @@
     "message": "追踪 ID",
     "description": "追踪 ID"
   },
+  "name.elapsed": {
+    "message": "耗时",
+    "description": "任务的耗时（秒）"
+  },
   "name.prompt": {
     "message": "图像提示",
     "description": "生成/编辑的提示词"

--- a/src/i18n/zh-CN/sora.json
+++ b/src/i18n/zh-CN/sora.json
@@ -19,6 +19,10 @@
     "message": "追踪 ID",
     "description": "任务的追踪 ID"
   },
+  "name.elapsed": {
+    "message": "耗时",
+    "description": "任务的耗时（秒）"
+  },
   "name.createdAt": {
     "message": "创建时间",
     "description": "生成 Sora 视频的日期和时间"

--- a/src/i18n/zh-CN/veo.json
+++ b/src/i18n/zh-CN/veo.json
@@ -27,6 +27,10 @@
     "message": "追踪 ID",
     "description": "任务的追踪 ID"
   },
+  "name.elapsed": {
+    "message": "耗时",
+    "description": "任务的耗时（秒）"
+  },
   "name.createdAt": {
     "message": "创建时间",
     "description": "生成 Veo 视频的日期和时间"

--- a/src/i18n/zh-CN/wan.json
+++ b/src/i18n/zh-CN/wan.json
@@ -23,6 +23,10 @@
     "message": "追踪 ID",
     "description": "任务的追踪 ID"
   },
+  "name.elapsed": {
+    "message": "耗时",
+    "description": "任务的耗时（秒）"
+  },
   "name.createdAt": {
     "message": "创建时间",
     "description": "通义万象视频创建时间"

--- a/src/models/flux.ts
+++ b/src/models/flux.ts
@@ -38,6 +38,7 @@ export interface IFluxGenerateResponse {
 export interface IFluxTask {
   id: string;
   created_at?: number;
+  elapsed?: number;
   request?: IFluxGenerateRequest;
   response?: IFluxGenerateResponse;
 }

--- a/src/models/hailuo.ts
+++ b/src/models/hailuo.ts
@@ -42,6 +42,7 @@ export interface IHailuoGenerateResponse {
 export interface IHailuoTask {
   id: string;
   created_at?: number;
+  elapsed?: number;
   request?: IHailuoGenerateRequest;
   response?: IHailuoGenerateResponse;
 }

--- a/src/models/headshots.ts
+++ b/src/models/headshots.ts
@@ -40,6 +40,7 @@ export interface IHeadshotsTask {
   api_id?: string;
   application_id?: string;
   created_at?: number;
+  elapsed?: number;
   credential_id?: string;
   trace_id?: string;
   user_id?: string;

--- a/src/models/kling.ts
+++ b/src/models/kling.ts
@@ -111,6 +111,7 @@ export interface IKlingGenerateResponse {
 export interface IKlingTask {
   id: string;
   created_at?: number;
+  elapsed?: number;
   type?: IKlingTaskType;
   request?: IKlingGenerateRequest & IKlingMotionRequest;
   response?: IKlingGenerateResponse;

--- a/src/models/luma.ts
+++ b/src/models/luma.ts
@@ -49,6 +49,7 @@ export interface ILumaGenerateResponse {
 export interface ILumaTask {
   id: string;
   created_at?: number;
+  elapsed?: number;
   trace_id?: string;
   request?: ILumaGenerateRequest;
   response?: ILumaGenerateResponse;

--- a/src/models/nanobanana.ts
+++ b/src/models/nanobanana.ts
@@ -38,6 +38,7 @@ export interface INanobananaGenerateResponse {
 export interface INanobananaTask {
   id: string;
   created_at?: number;
+  elapsed?: number;
   request?: INanobananaGenerateRequest;
   response?: INanobananaGenerateResponse;
 }

--- a/src/models/openaiimage.ts
+++ b/src/models/openaiimage.ts
@@ -46,6 +46,7 @@ export interface IOpenAIImageTask {
   id: string;
   type?: string;
   created_at?: number;
+  elapsed?: number;
   request?: IOpenAIImageGenerateRequest | IOpenAIImageEditRequest;
   response?: IOpenAIImageGenerateResponse;
 }

--- a/src/models/pika.ts
+++ b/src/models/pika.ts
@@ -44,6 +44,7 @@ export interface IPikaGenerateResponse {
 export interface IPikaTask {
   id: string;
   created_at?: number;
+  elapsed?: number;
   request?: IPikaGenerateRequest;
   response?: IPikaGenerateResponse;
 }

--- a/src/models/pixverse.ts
+++ b/src/models/pixverse.ts
@@ -60,6 +60,7 @@ export interface IPixverseGenerateResponse {
 export interface IPixverseTask {
   id: string;
   created_at?: number;
+  elapsed?: number;
   request?: IPixverseGenerateRequest;
   response?: IPixverseGenerateResponse;
 }

--- a/src/models/qrart.ts
+++ b/src/models/qrart.ts
@@ -59,6 +59,7 @@ export interface IQrartGenerateResponse {
 export interface IQrartTask {
   id: string;
   created_at?: number;
+  elapsed?: number;
   request?: IQrartGenerateRequest;
   response?: IQrartGenerateResponse;
 }

--- a/src/models/seedance.ts
+++ b/src/models/seedance.ts
@@ -58,6 +58,7 @@ export interface ISeedanceGenerateResponse {
 export interface ISeedanceTask {
   id: string;
   created_at?: number;
+  elapsed?: number;
   request?: ISeedanceGenerateRequest;
   response?: ISeedanceGenerateResponse;
 }

--- a/src/models/seedream.ts
+++ b/src/models/seedream.ts
@@ -46,6 +46,7 @@ export interface ISeedreamGenerateResponse {
 export interface ISeedreamTask {
   id: string;
   created_at?: number;
+  elapsed?: number;
   request?: ISeedreamGenerateRequest;
   response?: ISeedreamGenerateResponse;
 }

--- a/src/models/sora.ts
+++ b/src/models/sora.ts
@@ -45,6 +45,7 @@ export interface ISoraGenerateResponse {
 export interface ISoraTask {
   id: string;
   created_at?: number;
+  elapsed?: number;
   request?: ISoraGenerateRequest;
   response?: ISoraGenerateResponse;
 }

--- a/src/models/veo.ts
+++ b/src/models/veo.ts
@@ -55,6 +55,7 @@ export interface IVeoGenerateResponse {
 export interface IVeoTask {
   id: string;
   created_at?: number;
+  elapsed?: number;
   request?: IVeoGenerateRequest;
   response?: IVeoGenerateResponse;
 }

--- a/src/models/wan.ts
+++ b/src/models/wan.ts
@@ -50,6 +50,7 @@ export interface IWanGenerateResponse {
 export interface IWanTask {
   id: string;
   created_at?: number;
+  elapsed?: number;
   request?: IWanGenerateRequest;
   response?: IWanGenerateResponse;
 }


### PR DESCRIPTION
## Summary

Adds an **Elapsed: `<seconds>`s** line to the task summary alert across 15 generation scenarios so users can see how long each task took without opening DevTools or CLS logs.

In the platform's existing `tasks` API every completed task already returns a top-level `elapsed` field (gateway-side wall-clock seconds, e.g. `116.397`). It just wasn't shown anywhere in Nexior. The screenshot below shows the current state — the user only sees model / resolution / task type / Task ID / Trace ID, but no elapsed time.

## Scenarios updated

`nanobanana`, `seedream`, `seedance`, `veo`, `sora`, `flux`, `luma`, `hailuo`, `wan`, `kling`, `pixverse`, `qrart`, `headshots`, `openaiimage`, `pika`.

(`suno`, `producer`, `midjourney` use a different per-track / per-image card layout without a unified summary alert and are intentionally left out.)

## Changes

- **Models** — adds an optional `elapsed?: number` field on every `I*Task` interface above.
- **i18n** — adds a `name.elapsed` key to `src/i18n/en/<scenario>.json` and `src/i18n/zh-CN/<scenario>.json` for every scenario. Other locales will be auto-translated by `translate.py` per the project convention.
- **Preview.vue** — inserts a new `<p>` entry with a clock icon under the task summary `<el-alert>`, guarded by `v-if="modelValue?.elapsed"` so pending / in-flight tasks remain unchanged. Value is formatted with `toFixed(2)` and suffixed with `s`. Inserted in both the success and failure branches where elapsed is meaningful.

## Display

```
模型: nano-banana-pro
分辨率: 2K
任务类型: 编辑图片
任务 ID: 63434d7f-3936-49f4-9427-43da903f0b4b
耗时: 116.40s         ← new
追踪 ID: 88d76577-bd83-4e1a-85d6-aaba167e944b
```

## Validation

- `npx vue-tsc --noEmit` — passes
- `npm run lint` — passes (eslint --fix)
- Conditional rendering means existing pending / in-flight task cards are untouched (no `elapsed` shown until the gateway populates the field on completion).
