### PR TITLE
fix(kling): remove disabled "数字人" (Avatar) tab from sidebar

### DIFF
--- a/src/components/kling/TabSwitcher.vue
+++ b/src/components/kling/TabSwitcher.vue
@@ -17,7 +17,7 @@ import { ElTabs, ElTabPane, ElTag } from 'element-plus';
 import { IKlingTaskType } from '@/models';
 
 interface ITab {
-  value: IKlingTaskType | 'avatar';
+  value: IKlingTaskType;
   label: string;
   disabled?: boolean;
   disabledReason?: string;
@@ -48,20 +48,12 @@ export default defineComponent({
         {
           value: 'motion',
           label: this.$t('kling.tab.motionControl')
-        },
-        {
-          value: 'avatar',
-          label: this.$t('kling.tab.avatar'),
-          disabled: true,
-          disabledReason: this.$t('kling.tab.avatarComingSoon'),
-          badge: this.$t('kling.tab.comingSoon')
         }
       ];
     }
   },
   methods: {
     onUpdate(value: string | number) {
-      if (value === 'avatar') return;
       this.$emit('update:modelValue', value as IKlingTaskType);
     }
   }

--- a/src/i18n/en/kling.json
+++ b/src/i18n/en/kling.json
@@ -7,18 +7,6 @@
     "message": "Motion Control",
     "description": "Tab label: Motion Control"
   },
-  "tab.avatar": {
-    "message": "Avatar",
-    "description": "Tab label: Avatar / AI-Human"
-  },
-  "tab.comingSoon": {
-    "message": "Coming Soon",
-    "description": "Label for upcoming features"
-  },
-  "tab.avatarComingSoon": {
-    "message": "Avatar (Face + Voice Synthesis Video) Coming Soon, Stay Tuned",
-    "description": "Tooltip description for disabled Avatar Tab"
-  },
   "name.motionImage": {
     "message": "Character Reference Image",
     "description": "Input for character image in Motion Control"

--- a/src/i18n/zh-CN/kling.json
+++ b/src/i18n/zh-CN/kling.json
@@ -7,18 +7,6 @@
     "message": "动作控制",
     "description": "Tab 标签：Motion Control"
   },
-  "tab.avatar": {
-    "message": "数字人",
-    "description": "Tab 标签：Avatar / AI-Human"
-  },
-  "tab.comingSoon": {
-    "message": "即将上线",
-    "description": "即将上线的起骨标签"
-  },
-  "tab.avatarComingSoon": {
-    "message": "数字人（股脸 + 语音合成说话视频）即将上线，敬请期待",
-    "description": "Avatar Tab 被禁用的 Tooltip 说明"
-  },
   "name.motionImage": {
     "message": "人物参考图片",
     "description": "Motion Control 中的人物图输入"


### PR DESCRIPTION
## Why

The Kling sidebar's top tab strip has carried a third `数字人` (Avatar) tab that is permanently `disabled` with a `Coming Soon` warning badge — see [`src/components/kling/TabSwitcher.vue`](src/components/kling/TabSwitcher.vue#L52-L58) on `main`. There is no scheduled delivery for the avatar (face-swap + voice synthesis) feature, so the tab has only ever served as visual noise: users tap it, see a tooltip, and have to back out. Drop it until the feature actually ships.

## What

- [`src/components/kling/TabSwitcher.vue`](src/components/kling/TabSwitcher.vue) — remove the `avatar` entry from `tabs`, narrow the `ITab.value` union back to `IKlingTaskType`, and drop the now-dead `if (value === 'avatar') return;` short-circuit in `onUpdate`.
- [`src/i18n/zh-CN/kling.json`](src/i18n/zh-CN/kling.json), [`src/i18n/en/kling.json`](src/i18n/en/kling.json) — drop the three orphaned keys: `tab.avatar`, `tab.comingSoon`, `tab.avatarComingSoon`. Per CLAUDE.md the other 16 locales are CronJob-managed and not edited manually here; their unused keys are harmless and will roll out of `translate.py`'s working set naturally.

After this change Kling only shows the two actionable tabs:

| | |
|---|---|
| 视频生成 / Video Generation | `videos` |
| 动作控制 / Motion Control | `motion` |

## Verification

- `grep -rn 'avatar\|comingSoon' src/components/kling/ src/i18n/zh-CN/kling.json src/i18n/en/kling.json` → only the unrelated `<el-image class="avatar">` placeholder asset in `task/Preview.vue` remains (unrelated to the tab).
- `python3 -c "import json; json.load(open(...))"` on both modified locale files passes.
- `onUpdate` is now a thin emit; no other call site depends on the `'avatar'` literal.