### PR TITLE
feat(chat): persist composer draft across chat-group route changes

### DIFF
--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -173,6 +173,16 @@ export default defineComponent({
     async references(val) {
       console.log('references changed', val);
     },
+    /**
+     * Mirror the unsubmitted composer text into vuex on every
+     * keystroke so a route-level remount (clicking ChatGPT in the
+     * sidebar while editing a draft on Claude) can pick it back up
+     * via ``onConsumePendingDraft`` in the new component instance.
+     * Cleared once the message is submitted (see ``onRequest``).
+     */
+    question(val: string) {
+      this.$store.commit('chat/setPendingDraft', val || '');
+    },
     async modelGroup(val) {
       console.debug('modelGroup changed', val);
       // Side-panel list is server-filtered by model_group, so any change
@@ -211,6 +221,15 @@ export default defineComponent({
     if (this.conversationId) {
       await this.onRestoreConversation(this.conversationId);
     }
+    // Cross-group draft persistence: when the user clicks a different
+    // chat group in the sidebar (e.g. Claude → ChatGPT), Vue Router
+    // remounts this component because the route changes, which would
+    // otherwise drop ``this.question``. We mirror the composer text
+    // into ``store.chat.pendingDraft`` on every keystroke (see the
+    // ``question`` watcher) and consume it back here. URL ``?query=``
+    // (deep-link from AuthFrontend connector chips) wins over the
+    // mirrored draft because it represents fresher user intent.
+    this.onConsumePendingDraft();
     // Cross-site deep-link: AuthFrontend's connector detail "Try It"
     // chips open ``/<group>/conversations?query=<prompt>`` in a new
     // tab. Paste the prompt into the composer (intentionally NOT
@@ -236,6 +255,29 @@ export default defineComponent({
       }
     },
     /**
+     * Restore the unsubmitted composer draft after a route-level
+     * remount (typically: user clicks a different chat group in the
+     * sidebar — Claude → ChatGPT). The draft was mirrored into
+     * ``store.chat.pendingDraft`` keystroke-by-keystroke by the
+     * ``question`` watcher, and lives in-memory only (NOT in
+     * ``persist.ts``) so it doesn't leak across browser sessions.
+     *
+     * Skips when:
+     *   - There's a ``:id`` in the route — restoring an existing
+     *     chat already populates its own state; the pending draft
+     *     belonged to a different (new) conversation.
+     *   - The composer is non-empty — preserves anything the user
+     *     just started typing in this fresh mount.
+     *   - The pending draft is empty.
+     */
+    onConsumePendingDraft() {
+      if (this.conversationId) return;
+      if (this.question && this.question.trim().length > 0) return;
+      const draft: string | undefined = this.$store.state.chat?.pendingDraft;
+      if (!draft) return;
+      this.question = draft;
+    },
+    /**
      * Cross-site entry-point: AuthFrontend's connector "Try It" chips
      * (PR https://github.com/AceDataCloud/AuthFrontend/pull/83) open
      * this page with ``?query=<prompt>`` so the prompt arrives
@@ -245,9 +287,9 @@ export default defineComponent({
      *   - Only fires on a NEW conversation (no `:id` in the route).
      *     A restored conversation already has its own state — we
      *     don't want to clobber the composer mid-edit.
-     *   - Only fires when the composer is empty. If the user already
-     *     started typing locally (vuex-persistedstate restores the
-     *     ``question`` field across reloads), we keep their draft.
+     *   - When ``?query=`` is present we DO override an in-memory
+     *     pendingDraft from a prior group, because a fresh
+     *     deep-link is the user's most recent intent.
      *   - Does NOT auto-submit. Studio shows the prompt; user reads,
      *     optionally tweaks, presses Enter. This matches the
      *     ChatGPT / Claude suggestion-chip UX and prevents a
@@ -262,7 +304,16 @@ export default defineComponent({
       const queryStr = Array.isArray(raw) ? raw[0] : raw;
       if (!queryStr || typeof queryStr !== 'string') return;
       if (this.conversationId) return;
-      if (this.question && this.question.trim().length > 0) return;
+      // Override pendingDraft from a stale prior group, but still
+      // never clobber a draft the user is actively typing in this
+      // mount — same guard as before, only relaxed against the
+      // mirrored ``pendingDraft`` (which we want to overwrite when
+      // the user explicitly clicked a deep-link).
+      if (this.question && this.question.trim().length > 0) {
+        const draft: string | undefined = this.$store.state.chat?.pendingDraft;
+        const isMirroredDraft = draft != null && this.question === draft;
+        if (!isMirroredDraft) return;
+      }
       this.question = queryStr;
       // Drop the deep-link params so a refresh / share doesn't replay
       // the prompt. Keep any unrelated query keys the route may carry

--- a/src/store/chat/models.ts
+++ b/src/store/chat/models.ts
@@ -8,6 +8,15 @@ export interface IChatState {
   service: IService | undefined;
   conversations: IChatConversation[] | undefined;
   credential: ICredential | undefined;
+  /** Composer text that should survive a route-level remount, e.g.
+   *  the user clicks ChatGPT in the sidebar while editing a draft
+   *  in the Claude page. The Conversation page mirrors
+   *  ``this.question`` here on every keystroke and consumes it
+   *  back into local state on mount. Cleared once the message is
+   *  submitted. Also used by the cross-site ``?query=`` deep-link
+   *  entry-point (AuthFrontend connector "Try It" chips) so the
+   *  prompt persists across an in-flight model-group switch. */
+  pendingDraft: string;
   status: {
     getService: Status;
     getApplications: Status;

--- a/src/store/chat/mutations.ts
+++ b/src/store/chat/mutations.ts
@@ -34,6 +34,10 @@ export const setConversations = (state: IChatState, payload: IChatConversation[]
   state.conversations = payload;
 };
 
+export const setPendingDraft = (state: IChatState, payload: string): void => {
+  state.pendingDraft = payload || '';
+};
+
 export default {
   setModel,
   setModelGroup,
@@ -42,5 +46,6 @@ export default {
   setConversations,
   setApplication,
   setApplications,
+  setPendingDraft,
   resetAll
 };

--- a/src/store/chat/state.ts
+++ b/src/store/chat/state.ts
@@ -11,6 +11,7 @@ export default (): IChatState => {
     conversations: undefined,
     service: undefined,
     credential: undefined,
+    pendingDraft: '',
     status: {
       getService: Status.None,
       getApplications: Status.None,


### PR DESCRIPTION
## Why

Followup to #588. Today an unsubmitted composer draft is dropped the moment the user clicks a different chat group in the sidebar:

```
/claude/conversations  ← user is typing 'compare gpt and claude…'
       ↓ click ChatGPT in the sidebar
/chatgpt/conversations ← Vue Router treats this as a route change,
                          remounts Conversation.vue,
                          data().question is reset to ''
```

This bites two real flows:

1. **Plain mid-edit:** user starts typing on Claude, decides to try GPT first — draft gone.
2. **Connector "Try It" deep-link** (https://github.com/AceDataCloud/AuthFrontend/pull/83): user clicks "试一试", composer prefills on `/chatgpt/conversations`, user changes their mind and switches to Claude — prompt gone, has to reopen the connector page.

## What

One in-memory store slot, [`chat.pendingDraft`](src/store/chat/models.ts), that the page mirrors on every keystroke and consumes back on mount. Three small pieces:

| File | Change |
|---|---|
| [`src/store/chat/models.ts`](src/store/chat/models.ts) | + `pendingDraft: string` on `IChatState` |
| [`src/store/chat/state.ts`](src/store/chat/state.ts) | initialise to `''` |
| [`src/store/chat/mutations.ts`](src/store/chat/mutations.ts) | + `setPendingDraft` mutation |
| [`src/pages/chat/Conversation.vue`](src/pages/chat/Conversation.vue) | watcher mirrors `question → store`; new `onConsumePendingDraft()` runs in `mounted()` BEFORE `onApplyQueryFromUrl()` |

### Lifecycle

```
keystroke              → watch.question fires → store.pendingDraft = question
clicks Claude→ChatGPT  → component unmounts (store keeps draft)
new component mounts   → onConsumePendingDraft() → this.question = store.pendingDraft
                       → onApplyQueryFromUrl() → if URL ?query= present, override
user submits           → onRequest sets question = '' → watch fires → pendingDraft cleared
```

### Why NOT in `persist.ts`

Session-only by design. We don't want stale prompts surfacing across browser sessions or weeks-old drafts haunting the user.

### Edge cases handled

- **Existing chat (`:id` in route):** `onConsumePendingDraft` returns early — restored chats get their own state, no draft injection.
- **User started typing on the new mount before mount fully completed:** `onConsumePendingDraft` checks `this.question` is empty before injecting.
- **`?query=` deep-link beats stale draft:** `onApplyQueryFromUrl` was previously gated on `question === ''`. Now it tolerates an in-flight `question` IF the value matches the mirrored `pendingDraft` (i.e. it's stale, not actively-typed). Direct user typing on this fresh mount is still preserved.
- **"New conversation" reset:** the existing `conversationId` watcher resets `question = ''` when the user navigates to the bare `/claude/conversations` route, which now also clears `pendingDraft` via the new watcher — keeps behaviour intuitive.

## Verification

Suggest manual smoke test post-merge:

1. Open https://studio.acedata.cloud/claude/conversations, type `hello`, switch to ChatGPT in sidebar → composer should still show `hello`.
2. Click any "Try It" chip on https://auth.acedata.cloud/user/connections → switch group before pressing Enter → prompt rides along.
3. Open an existing chat `/claude/conversations/<id>` → no draft injection (chat history intact).
