### PR TITLE
fix(chat): add loading placeholder + soften image-card caption

### DIFF
--- a/src/components/chat/EntityCard.vue
+++ b/src/components/chat/EntityCard.vue
@@ -37,8 +37,15 @@
         :preview-src-list="[card.url]"
         :initial-index="0"
         :hide-on-click-modal="true"
-      />
-      <div v-if="card.title" class="title" :title="card.title">{{ card.title }}</div>
+      >
+        <template #placeholder>
+          <div class="image-placeholder" />
+        </template>
+        <template #error>
+          <div class="image-placeholder image-placeholder--error" />
+        </template>
+      </el-image>
+      <div v-if="card.title" class="caption" :title="card.title">{{ card.title }}</div>
     </div>
 
     <!-- File / fallback -->
@@ -211,12 +218,56 @@ export default defineComponent({
 .image-card {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 6px;
 
   .image {
-    max-width: 100%;
+    display: block;
+    width: 100%;
+    min-height: 240px;
     max-height: 400px;
     border-radius: 8px;
+    overflow: hidden;
+  }
+  .image-placeholder {
+    width: 100%;
+    height: 100%;
+    min-height: 240px;
+    border-radius: 8px;
+    background: linear-gradient(
+      90deg,
+      var(--el-fill-color) 0%,
+      var(--el-fill-color-light) 50%,
+      var(--el-fill-color) 100%
+    );
+    background-size: 200% 100%;
+    animation: image-card-shimmer 1.4s ease-in-out infinite;
+  }
+  .image-placeholder--error {
+    animation: none;
+    background: var(--el-fill-color);
+  }
+  .caption {
+    font-size: 12px;
+    font-weight: 400;
+    color: var(--el-text-color-secondary);
+    text-align: center;
+    line-height: 1.4;
+    white-space: normal;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    opacity: 0.75;
+  }
+}
+
+@keyframes image-card-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
   }
 }
 


### PR DESCRIPTION
## Why

Two complaints from the screenshotted chat reply (a `<acard type=\"image\">` rendered inside `Conversation.vue`):

1. **No loading state.** [`EntityCard.vue`](src/components/chat/EntityCard.vue) wired `<el-image>` without `placeholder` / `error` slots, so the image area collapsed to 0px until the underlying `<img>` resolved, then snapped in. On slow remotes (e.g. \`commons.wikimedia.org/wiki/Special:FilePath/...\` which 302-redirects to upload.wikimedia) you saw nothing → broken-image flash → image. The user wants \"don't show the picture initially, show a loader\".
2. **Caption looks ugly.** The label rendered as left-aligned, single-line, **font-weight: 600**, full-strength text color — because the parent rule \`.entity-card .title { font-weight: 600; white-space: nowrap; ... }\` was leaking into `.image-card .title`. Visually this overpowered the photo it was supposed to caption (see screenshot in the issue thread — the red circle around \"大熊猫 Tian Tian\").

## What

Single-file change in [`src/components/chat/EntityCard.vue`](src/components/chat/EntityCard.vue), `image` branch only — audio / video / file branches untouched.

### Loading placeholder

\`\`\`vue
<el-image ...>
  <template #placeholder>
    <div class=\"image-placeholder\" />
  </template>
  <template #error>
    <div class=\"image-placeholder image-placeholder--error\" />
  </template>
</el-image>
\`\`\`

- \`.image-placeholder\` is a CSS-only shimmering skeleton (1.4s gradient sweep across \`--el-fill-color\` ↔ \`--el-fill-color-light\`). No spinner, no font-awesome icon — keeps the bundle clean and matches Element Plus' visual language.
- \`.image-placeholder--error\` reuses the same box but kills the animation and stays a flat fill, so a 404 photo doesn't pretend to still be loading.
- Reserved \`min-height: 240px\` on the \`.image\` container itself, because \`<el-image>\`'s default wrapper has no intrinsic height pre-load and the placeholder slot would otherwise render at 0px.

### Caption restyle

Renamed the label class from \`.title\` to \`.caption\` so the parent \`.entity-card .title\` rule no longer hits it. The new \`.caption\`:

| property | before (inherited) | after |
|---|---|---|
| \`text-align\` | left | **center** |
| \`font-weight\` | 600 | 400 |
| \`font-size\` | 14px (default) | **12px** |
| \`color\` | \`--el-text-color-primary\` | \`--el-text-color-secondary\` @ 0.75 opacity |
| \`white-space\` | \`nowrap\` (truncated) | \`normal\`, 2-line clamp |

Result: a quiet, centered, secondary-looking caption that doesn't compete with the photo — exactly what the user asked for (\"显示在 text center，字体颜色淡一点，小一点\").

## Visual

| before | after |
|---|---|
| 0-height area → broken-image flash → photo. Caption: bold, left, full color. | shimmering skeleton at fixed height → photo fades in via \`<el-image>\`'s built-in transition. Caption: centered, 12px, secondary color, two-line clamp. |

## Scope discipline

- No new font-awesome icons (avoids touching \`src/plugins/font-awesome.ts\`).
- No new i18n strings.
- No changes to \`Conversation.vue\` or the \`<acard>\` parser — the data contract is unchanged.
- Audio / Video / File card variants untouched.