### PR TITLE
fix(chat): show original filename in user bubble instead of CDN URL

### DIFF
--- a/src/components/chat/Composer.vue
+++ b/src/components/chat/Composer.vue
@@ -125,7 +125,7 @@ import {
   ElDropdownItem
 } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { IChatModel } from '@/models';
+import { IChatModel, IChatReference } from '@/models';
 import { getBaseUrlPlatform, isImageUrl, pasteUploadMixin, withCurrentUserId } from '@/utils';
 import FilePreview from '@/components/common/FilePreview.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
@@ -165,7 +165,7 @@ export default defineComponent({
       required: true
     }
   },
-  emits: ['update:question', 'update:references', 'update:referenceNames', 'submit', 'stop'],
+  emits: ['update:question', 'update:references', 'submit', 'stop'],
   data() {
     return {
       inputHeight: '35px',
@@ -192,23 +192,19 @@ export default defineComponent({
         Authorization: `Bearer ${this.$store.state.token.access}`
       };
     },
-    urls(): string[] {
-      // @ts-ignore
-      return this.fileList.map((file: UploadFile) => file?.response?.file_url);
-    },
-    // Map of uploaded file URL -> original display name. Emitted in
-    // parallel with `urls` so the parent can render the filename in the
-    // chat bubble instead of the opaque CDN URL (see Message.vue).
-    urlNames(): Record<string, string> {
-      const names: Record<string, string> = {};
+    // Fully-formed `{ url, name }` references derived from the upload
+    // pipeline. Emitted as a single value to the parent so it can both
+    // POST the URLs to the chat API and render the original filename in
+    // the user message bubble (see Message.vue / IChatReference).
+    refs(): IChatReference[] {
+      const out: IChatReference[] = [];
       for (const file of this.fileList) {
-        // @ts-ignore
+        // @ts-ignore — el-upload types `response` as unknown.
         const url = file?.response?.file_url as string | undefined;
-        if (url && file?.name) {
-          names[url] = file.name;
-        }
+        if (!url) continue;
+        out.push(file?.name ? { url, name: file.name } : { url });
       }
-      return names;
+      return out;
     },
     uploading() {
       // if at least file is uploading, return true
@@ -230,11 +226,10 @@ export default defineComponent({
     }
   },
   watch: {
-    urls(val) {
-      console.debug('File URLs:', val);
+    refs(val: IChatReference[]) {
+      console.debug('References:', val);
       if (val.length > 0) {
         this.$emit('update:references', val);
-        this.$emit('update:referenceNames', this.urlNames);
       }
     },
     questionValue(val: string) {
@@ -245,7 +240,7 @@ export default defineComponent({
         this.questionValue = val;
       }
     },
-    references(val: string[]) {
+    references(val: IChatReference[]) {
       console.debug('References updated:', val);
       if (val.length === 0) {
         this.fileList = [];

--- a/src/components/chat/Composer.vue
+++ b/src/components/chat/Composer.vue
@@ -165,7 +165,7 @@ export default defineComponent({
       required: true
     }
   },
-  emits: ['update:question', 'update:references', 'submit', 'stop'],
+  emits: ['update:question', 'update:references', 'update:referenceNames', 'submit', 'stop'],
   data() {
     return {
       inputHeight: '35px',
@@ -196,6 +196,20 @@ export default defineComponent({
       // @ts-ignore
       return this.fileList.map((file: UploadFile) => file?.response?.file_url);
     },
+    // Map of uploaded file URL -> original display name. Emitted in
+    // parallel with `urls` so the parent can render the filename in the
+    // chat bubble instead of the opaque CDN URL (see Message.vue).
+    urlNames(): Record<string, string> {
+      const names: Record<string, string> = {};
+      for (const file of this.fileList) {
+        // @ts-ignore
+        const url = file?.response?.file_url as string | undefined;
+        if (url && file?.name) {
+          names[url] = file.name;
+        }
+      }
+      return names;
+    },
     uploading() {
       // if at least file is uploading, return true
       return !!this.fileList.find(
@@ -220,6 +234,7 @@ export default defineComponent({
       console.debug('File URLs:', val);
       if (val.length > 0) {
         this.$emit('update:references', val);
+        this.$emit('update:referenceNames', this.urlNames);
       }
     },
     questionValue(val: string) {

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -104,6 +104,17 @@ export interface IChatMessageContentItem {
   card?: IChatCard;
 }
 
+/**
+ * A user-attached reference (image or file) carried alongside the
+ * composer prompt. The chat API only needs the URL on the wire, but
+ * the chat UI also wants the original display filename so the message
+ * bubble can render `report.pdf` instead of an opaque CDN URL.
+ */
+export interface IChatReference {
+  url: string;
+  name?: string;
+}
+
 export interface IChatMessage {
   state?: IChatMessageState;
   content?: string | IChatMessageContentItem[];

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -45,7 +45,6 @@
             :ready="ready"
             :references="references"
             @update:references="references = $event"
-            @update:reference-names="referenceNames = $event"
             @submit="onSubmit"
             @stop="onStop"
           />
@@ -61,7 +60,7 @@ import axios from 'axios';
 import { defineComponent } from 'vue';
 import Message from '@/components/chat/Message.vue';
 import { CHAT_MODEL_GROUPS, CHAT_MODELS, ROLE_ASSISTANT, ROLE_USER } from '@/constants';
-import { IChatMessageState, IChatConversationResponse, IChatConversation, IChatMessage, BaseError } from '@/models';
+import { IChatMessageState, IChatConversationResponse, IChatConversation, IChatMessage, IChatReference, BaseError } from '@/models';
 import Composer from '@/components/chat/Composer.vue';
 import ModelSelector from '@/components/chat/ModelSelector.vue';
 import DesktopAgentManager from '@/components/chat/DesktopAgentManager.vue';
@@ -80,15 +79,13 @@ export interface IData {
   drawer: boolean;
   question: string;
   upload: boolean;
-  references: string[];
   /**
-   * Map of uploaded reference URL → original display filename. The chat
-   * API only takes URL strings (`IChatConversationRequest.references`),
-   * but the message bubble shows the *name* (Message.vue reads
-   * `item.name`). We carry the names in this parallel map so they
-   * survive into the rendered content items below.
+   * User-attached references (uploaded images / files) for the next
+   * outgoing message. Each entry carries the CDN URL plus the original
+   * filename so the message bubble can render `report.pdf` instead of
+   * the opaque URL. The chat API gets the URLs only — see `onRequest`.
    */
-  referenceNames: Record<string, string>;
+  references: IChatReference[];
   answering: boolean;
   messages: IChatMessage[];
   canceler: AbortController | undefined;
@@ -124,7 +121,6 @@ export default defineComponent({
       drawer: false,
       question: '',
       references: [],
-      referenceNames: {},
       upload: false,
       answering: false,
       canceler: undefined,
@@ -200,7 +196,6 @@ export default defineComponent({
         this.messages = [];
         this.question = '';
         this.references = [];
-        this.referenceNames = {};
         return;
       }
       // Just-completed chat already populated `this.messages` locally;
@@ -327,47 +322,19 @@ export default defineComponent({
         // @ts-ignore
         updatedMessages = this.messages.slice(0, targetIndex - 1);
         this.messages = this.messages.slice(0, targetIndex);
-        // @ts-ignore
         this.references = [];
-        this.referenceNames = {};
         if (typeof problemMessage.content === 'string') {
           this.question = problemMessage.content;
         } else if (Array.isArray(problemMessage.content)) {
-          for (let i = 0; i < problemMessage?.content.length; i++) {
-            if (problemMessage.content[i].type === 'image_url') {
-              if (typeof problemMessage?.content?.[i]?.image_url === 'string') {
-                // @ts-ignore
-                this.references.push(problemMessage?.content?.[i]?.image_url);
-              } else {
-                // @ts-ignore
-                this.references.push(problemMessage?.content?.[i]?.image_url?.url);
-              }
-            }
-            if (problemMessage.content[i].type === 'file_url') {
-              if (typeof problemMessage?.content?.[i]?.file_url === 'string') {
-                // @ts-ignore
-                this.references.push(problemMessage?.content?.[i]?.file_url);
-              } else {
-                // @ts-ignore
-                this.references.push(problemMessage?.content?.[i]?.file_url?.url);
-              }
-            }
-            // Re-hydrate the URL→name map so the regenerated user
-            // message bubble keeps showing the filename instead of
-            // falling back to the URL (Message.vue line ~46).
-            const item: IChatMessageContentItem = problemMessage.content[i];
-            const itemName = item.name;
-            if (itemName) {
-              const ref =
-                item.type === 'image_url' ? item.image_url : item.type === 'file_url' ? item.file_url : undefined;
+          for (const item of problemMessage.content) {
+            if (item.type === 'image_url' || item.type === 'file_url') {
+              const ref = item.type === 'image_url' ? item.image_url : item.file_url;
               const url = typeof ref === 'string' ? ref : ref?.url;
               if (url) {
-                this.referenceNames[url] = itemName;
+                this.references.push(item.name ? { url, name: item.name } : { url });
               }
-            }
-            if (problemMessage.content[i].type === 'text') {
-              // @ts-ignore
-              this.question = problemMessage.content[i].text;
+            } else if (item.type === 'text' && item.text) {
+              this.question = item.text;
             }
           }
         }
@@ -487,7 +454,6 @@ export default defineComponent({
         this.messages = [];
         this.question = '';
         this.references = [];
-        this.referenceNames = {};
       }
     },
     async onRestoreConversation(id: string) {
@@ -528,34 +494,24 @@ export default defineComponent({
     },
     async onSubmit() {
       if (this.references.length > 0) {
-        let content = [];
-        content.push({
-          type: 'text',
-          text: this.question.trim()
-        });
-        for (let i = 0; i < this.references.length; i++) {
-          const url = this.references[i];
+        const content: IChatMessageContentItem[] = [
+          {
+            type: 'text',
+            text: this.question.trim()
+          }
+        ];
+        for (const ref of this.references) {
           // Carry the original filename forward so the chat bubble shows
           // e.g. `report.pdf` instead of the opaque CDN URL
           // (Message.vue reads `item.name` first).
-          const name = this.referenceNames[url];
-          if (isImageUrl(url)) {
-            content.push({
-              type: 'image_url',
-              image_url: url,
-              ...(name ? { name } : {})
-            });
-          } else {
-            content.push({
-              type: 'file_url',
-              file_url: url,
-              ...(name ? { name } : {})
-            });
-          }
+          const item: IChatMessageContentItem = isImageUrl(ref.url)
+            ? { type: 'image_url', image_url: ref.url }
+            : { type: 'file_url', file_url: ref.url };
+          if (ref.name) item.name = ref.name;
+          content.push(item);
         }
         this.messages.push({
-          // @ts-ignore
-          content: content,
+          content,
           role: ROLE_USER
         });
       } else {
@@ -572,12 +528,13 @@ export default defineComponent({
       console.debug('start to get answer', this.messages);
       const token = this.credential?.token;
       const question = this.question.trim();
-      const references = this.references;
+      // Wire format only takes URL strings; the names live on the
+      // rendered message item via `IChatReference.name`.
+      const references = this.references.map((r) => r.url);
       console.debug('validated', question, references);
       // reset question and references
       this.question = '';
       this.references = [];
-      this.referenceNames = {};
       if (!token || !question) {
         console.error('no token or endpoint or question');
         this.messages.push({

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -355,20 +355,14 @@ export default defineComponent({
             // Re-hydrate the URL→name map so the regenerated user
             // message bubble keeps showing the filename instead of
             // falling back to the URL (Message.vue line ~46).
-            const item = problemMessage.content[i];
-            if (item.name) {
-              const url =
-                item.type === 'image_url'
-                  ? typeof item.image_url === 'string'
-                    ? item.image_url
-                    : item.image_url?.url
-                  : item.type === 'file_url'
-                    ? typeof item.file_url === 'string'
-                      ? item.file_url
-                      : item.file_url?.url
-                    : undefined;
+            const item: IChatMessageContentItem = problemMessage.content[i];
+            const itemName = item.name;
+            if (itemName) {
+              const ref =
+                item.type === 'image_url' ? item.image_url : item.type === 'file_url' ? item.file_url : undefined;
+              const url = typeof ref === 'string' ? ref : ref?.url;
               if (url) {
-                this.referenceNames[url] = item.name;
+                this.referenceNames[url] = itemName;
               }
             }
             if (problemMessage.content[i].type === 'text') {

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -45,6 +45,7 @@
             :ready="ready"
             :references="references"
             @update:references="references = $event"
+            @update:reference-names="referenceNames = $event"
             @submit="onSubmit"
             @stop="onStop"
           />
@@ -80,6 +81,14 @@ export interface IData {
   question: string;
   upload: boolean;
   references: string[];
+  /**
+   * Map of uploaded reference URL → original display filename. The chat
+   * API only takes URL strings (`IChatConversationRequest.references`),
+   * but the message bubble shows the *name* (Message.vue reads
+   * `item.name`). We carry the names in this parallel map so they
+   * survive into the rendered content items below.
+   */
+  referenceNames: Record<string, string>;
   answering: boolean;
   messages: IChatMessage[];
   canceler: AbortController | undefined;
@@ -115,6 +124,7 @@ export default defineComponent({
       drawer: false,
       question: '',
       references: [],
+      referenceNames: {},
       upload: false,
       answering: false,
       canceler: undefined,
@@ -190,6 +200,7 @@ export default defineComponent({
         this.messages = [];
         this.question = '';
         this.references = [];
+        this.referenceNames = {};
         return;
       }
       // Just-completed chat already populated `this.messages` locally;
@@ -318,6 +329,7 @@ export default defineComponent({
         this.messages = this.messages.slice(0, targetIndex);
         // @ts-ignore
         this.references = [];
+        this.referenceNames = {};
         if (typeof problemMessage.content === 'string') {
           this.question = problemMessage.content;
         } else if (Array.isArray(problemMessage.content)) {
@@ -338,6 +350,25 @@ export default defineComponent({
               } else {
                 // @ts-ignore
                 this.references.push(problemMessage?.content?.[i]?.file_url?.url);
+              }
+            }
+            // Re-hydrate the URL→name map so the regenerated user
+            // message bubble keeps showing the filename instead of
+            // falling back to the URL (Message.vue line ~46).
+            const item = problemMessage.content[i];
+            if (item.name) {
+              const url =
+                item.type === 'image_url'
+                  ? typeof item.image_url === 'string'
+                    ? item.image_url
+                    : item.image_url?.url
+                  : item.type === 'file_url'
+                    ? typeof item.file_url === 'string'
+                      ? item.file_url
+                      : item.file_url?.url
+                    : undefined;
+              if (url) {
+                this.referenceNames[url] = item.name;
               }
             }
             if (problemMessage.content[i].type === 'text') {
@@ -462,6 +493,7 @@ export default defineComponent({
         this.messages = [];
         this.question = '';
         this.references = [];
+        this.referenceNames = {};
       }
     },
     async onRestoreConversation(id: string) {
@@ -508,15 +540,22 @@ export default defineComponent({
           text: this.question.trim()
         });
         for (let i = 0; i < this.references.length; i++) {
-          if (isImageUrl(this.references[i])) {
+          const url = this.references[i];
+          // Carry the original filename forward so the chat bubble shows
+          // e.g. `report.pdf` instead of the opaque CDN URL
+          // (Message.vue reads `item.name` first).
+          const name = this.referenceNames[url];
+          if (isImageUrl(url)) {
             content.push({
               type: 'image_url',
-              image_url: this.references[i]
+              image_url: url,
+              ...(name ? { name } : {})
             });
           } else {
             content.push({
               type: 'file_url',
-              file_url: this.references[i]
+              file_url: url,
+              ...(name ? { name } : {})
             });
           }
         }
@@ -544,6 +583,7 @@ export default defineComponent({
       // reset question and references
       this.question = '';
       this.references = [];
+      this.referenceNames = {};
       if (!token || !question) {
         console.error('no token or endpoint or question');
         this.messages.push({


### PR DESCRIPTION
## Why

When a user uploads a file in the chat composer (e.g. on https://studio.acedata.cloud/grok/conversations) and sends the message, the bubble that bounces back into the message list shows the **opaque CDN URL** (e.g. \`https://cdn.acedata.cloud/1c96…\`) instead of the friendly filename (e.g. \`report.pdf\`).

\`\`\`
看看这里面有啥?
[file] https://cdn.acedata.cloud/1c96…   ← ugly, no extension hint, no original name
\`\`\`

The file *list above the textarea* (\`Composer.vue\` \`.file-previews\`) renders the filename correctly because it has \`UploadFile.name\` in scope. But once the user hits send, only the URLs survive the trip into \`messages\` — by the time \`Message.vue\` looks at the content item, it has nothing but the URL to fall back on, so it falls back to the URL.

\`Message.vue\` was already coded to *prefer* an \`item.name\` field if present:

\`\`\`vue
<file-preview
  v-if=\"item.file_url\"
  :name=\"item.name || (typeof item?.file_url === 'string' ? item.file_url : item.file_url?.url)\"
\`\`\`

…and the type \`IChatMessageContentItem\` already has an optional \`name?: string\` slot. We just never populated it on the user side.

## What

Carry the filename from \`Composer\` → \`Conversation\` → message bubble.

| File | Change |
|---|---|
| [\`src/components/chat/Composer.vue\`](src/components/chat/Composer.vue) | New \`urlNames\` computed (\`Record<URL, originalFilename>\`) + new \`update:referenceNames\` emit fired alongside \`update:references\`. |
| [\`src/pages/chat/Conversation.vue\`](src/pages/chat/Conversation.vue) | New \`referenceNames: Record<string,string>\` data field. \`onSubmit\` stamps \`name\` onto each \`image_url\` / \`file_url\` content item when a name is known. \`onRestart\` re-hydrates the map from the previous user bubble so a regenerated message keeps showing names. All reset sites (\`onNewConversation\`, \`onRequest\` post-send, \`conversationId\` watcher) clear the map. |

The wire-format \`IChatConversationRequest.references\` is unchanged — it remains a flat \`string[]\` of URLs. The names live purely in the local message rendering, so no backend change is needed.

## Lifecycle

\`\`\`
upload completes (Composer)
  → fileList[i].name = 'report.pdf'
  → fileList[i].response.file_url = 'https://cdn.acedata.cloud/1c96…'
  → urlNames = { 'https://cdn.acedata.cloud/1c96…': 'report.pdf' }
  → emit update:references([...]) + update:referenceNames({...})

user clicks send (Conversation.onSubmit)
  → for each url, push { type:'file_url', file_url: url, name: referenceNames[url] }
  → Message.vue renders \`item.name\` = 'report.pdf'  ✓

regenerate (onRestart)
  → walk previous user message content
  → re-populate referenceNames from item.name → url so the redo bubble keeps the name
\`\`\`

## Out of scope

- The upload endpoint (\`/api/v1/files/\`) and the chat API contract are unchanged. We could *also* push \`name\` upstream so non-Nexior clients benefit, but that's a backend-side decision to be made separately.
- Old conversations restored from history that don't have \`name\` on their content items will continue to fall back to the URL — same as today, no regression.

## Verification

- TypeScript / template diagnostics: \`get_errors\` clean on both touched files.
- Manual smoke test (post-deploy): on https://studio.acedata.cloud/grok/conversations, attach a file → send → bubble shows original filename. Click \"regenerate\" on the assistant reply → user bubble still shows the filename.