### PR TITLE
fix(chat): render video entity cards as iframes by default

### DIFF
--- a/src/components/chat/EntityCard.vue
+++ b/src/components/chat/EntityCard.vue
@@ -18,9 +18,23 @@
       </div>
     </div>
 
-    <!-- Video -->
+    <!-- Video — rendered as an iframe by default. The aichat2 worker
+         normalizes YouTube watch URLs to the canonical embed form, and
+         iframes also play direct media URLs (browser shows its native
+         video viewer) so a single renderer covers both. -->
     <div v-else-if="cardType === 'video'" class="video-card">
-      <video class="player" controls preload="metadata" :src="card.url" :poster="card.thumbnail || undefined" />
+      <div class="frame">
+        <iframe
+          class="player"
+          :src="card.url"
+          :title="card.title || ''"
+          frameborder="0"
+          loading="lazy"
+          referrerpolicy="strict-origin-when-cross-origin"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          allowfullscreen
+        />
+      </div>
       <div v-if="card.title || card.duration" class="meta">
         <span v-if="card.title" class="title" :title="card.title">{{ card.title }}</span>
         <span v-if="card.duration" class="sub">{{ formattedDuration }}</span>
@@ -76,10 +90,14 @@ export default defineComponent({
     }
   },
   computed: {
-    /** Normalize the card type into one of the four primary renderers. */
+    /** Normalize the card type into one of the primary renderers. The
+     * legacy `embed` type (briefly emitted by PlatformService #826) is
+     * folded back into `video` so historical cards still render — the
+     * worker no longer flips type, see PlatformService #827. */
     cardType(): 'audio' | 'video' | 'image' | 'file' {
       const t = (this.card.type || '').toLowerCase();
-      if (t === 'audio' || t === 'video' || t === 'image') return t;
+      if (t === 'audio' || t === 'image') return t;
+      if (t === 'video' || t === 'embed') return 'video';
       if (this.card.mimeType?.startsWith('audio/')) return 'audio';
       if (this.card.mimeType?.startsWith('video/')) return 'video';
       if (this.card.mimeType?.startsWith('image/')) return 'image';
@@ -191,9 +209,18 @@ export default defineComponent({
   overflow: hidden;
   background: #000;
 
-  .player {
+  .frame {
+    position: relative;
     width: 100%;
-    max-height: 360px;
+    aspect-ratio: 16 / 9;
+    background: #000;
+  }
+  .player {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
     display: block;
     background: #000;
   }


### PR DESCRIPTION
## Why

When the assistant emits a video card for a YouTube URL:

```
<acard type="video" url="https://www.youtube.com/watch?v=i1ubhpdFo4s" title="4K Beautiful Places" />
```

[`EntityCard.vue`](src/components/chat/EntityCard.vue) dropped the URL into an HTML5 `<video>` element, which can't play YouTube watch / shorts / youtu.be URLs. The user saw a black box with a 0:00 timeline — exactly the bug visible in the user-attached grok-4 conversation.

## What

Single template + style change in [`src/components/chat/EntityCard.vue`](src/components/chat/EntityCard.vue): render the `video` card as an `<iframe>` instead of `<video>`.

The aichat2 worker (PlatformService #826 + #827) already normalizes YouTube watch / shorts / youtu.be URLs to canonical `https://www.youtube.com/embed/<id>` form, so:

- **YouTube embed URLs** → play correctly via the YouTube iframe player.
- **Direct media URLs** (Luma `.mp4`, Veo `.mp4`, etc.) → still play; the browser's built-in viewer takes over inside the iframe.

A single renderer covers both — no separate `embed` type needed. The `cardType` computed folds the legacy `embed` value (briefly produced by #826 before #827 reverted it) back into `video` so historical conversations keep rendering.

### Style

- 16:9 `<iframe>` with the standard YouTube allow-list (`autoplay; picture-in-picture; fullscreen; …`).
- Same border / rounded / dark background as before.
- `title` + `duration` meta strip kept underneath so MP4 cards still get their caption.

## Compatibility

Safe in any deploy order with the backend PRs:

| Backend | Frontend | Behaviour |
|---|---|---|
| pre-#826 | pre-this PR | bare YouTube URL → empty `<video>` (today's bug) |
| #826 only | pre-this PR | URL rewritten + type=embed → falls into file fallback (link card) |
| #826 + #827 | pre-this PR | URL rewritten, type=video → still empty `<video>` |
| #826 + #827 | this PR | URL rewritten, type=video → iframe → ✅ |
| #826 only | this PR | type=embed → folded to video → iframe → ✅ |

## Verification

Manual smoke post-merge: ask grok-4 / claude / gpt to "搜索一些 YouTube 上好看的视频" — every recommended video should render as a playable inline YouTube embed instead of an empty player.