### PR TITLE
feat(infra): add Caddy tenant-proxy for on-demand Let's Encrypt TLS

### DIFF
--- a/deploy/production/tenant-proxy.yaml
+++ b/deploy/production/tenant-proxy.yaml
@@ -77,23 +77,6 @@ data:
       redir https://{host}{uri} permanent
     }
 ---
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: caddy-tenant-proxy-data
-  namespace: acedatacloud
-  labels:
-    app: caddy-tenant-proxy
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      # Each Let's Encrypt cert + ACME state is ~10 KB. 5 GB is enough
-      # for ~50,000 tenant certs without any pruning policy.
-      storage: 5Gi
-  storageClassName: cbs
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -102,15 +85,17 @@ metadata:
   labels:
     app: caddy-tenant-proxy
 spec:
-  # Single replica for MVP. Caddy keeps cert state on a RWO PVC, so any
-  # multi-replica HA needs caddy-storage-redis (or postgres) as a
-  # follow-up; not worth the complexity until traffic justifies it.
+  # Single replica today. The mounted PVC (`caddy`, RWX cfs) supports
+  # multiple attachments, so future HA can scale this up if traffic
+  # ever justifies it -- Caddy will share `/data` (ACME account, certs,
+  # locks) across pods. RollingUpdate is fine because RWX volumes
+  # don't deadlock on pod transition.
   replicas: 1
   strategy:
-    # In-place restart so the new pod gets to attach the same RWO cbs
-    # volume the old one was using. RollingUpdate would deadlock
-    # (new pod can't bind RWO until old pod releases it).
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       app: caddy-tenant-proxy
@@ -168,7 +153,10 @@ spec:
                 path: Caddyfile
         - name: data
           persistentVolumeClaim:
-            claimName: caddy-tenant-proxy-data
+            # Pre-existing `caddy` PVC (10Gi cfs RWX) provisioned out
+            # of band; lets us share /data across replicas if we ever
+            # scale this up.
+            claimName: caddy
         - name: config
           emptyDir: {}
 ---

--- a/deploy/production/tenant-proxy.yaml
+++ b/deploy/production/tenant-proxy.yaml
@@ -1,0 +1,195 @@
+# --------------------------------------------------------------------------
+# tenant-proxy.yaml
+#
+# Caddy reverse proxy that fronts ALL tenant custom domains
+# (mybrand.com -> studio-frontend) with on-demand Let's Encrypt TLS.
+#
+# Provides:
+#   * 80/443 LoadBalancer (separate public CLB; do NOT share with nginx-router)
+#   * Caddy 2 with `tls { on_demand }` and an `ask` callback that consults
+#     PlatformBackend (/api/v1/site-domains/check) before signing a cert.
+#   * cbs PVC at /data so ACME account, certs, and locks survive pod restarts.
+#
+# Tenant flow:
+#   1. Tenant adds CNAME mybrand.com -> tenant-proxy.acedata.cloud at their
+#      DNS provider.
+#   2. First HTTPS request hits Caddy. Caddy GETs the ask URL, sees the
+#      domain is registered in SiteDomain, runs ACME HTTP-01, signs the
+#      cert, persists it to /data, and serves the request.
+#   3. Caddy renews automatically 30 days before expiry.
+#
+# DNS one-time setup AFTER first apply:
+#   kubectl get svc caddy-tenant-proxy -n acedatacloud
+#   # take the EXTERNAL-IP, then in DNSPod:
+#   tenant-proxy.acedata.cloud  A  <EIP>
+# --------------------------------------------------------------------------
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: caddy-tenant-proxy-config
+  namespace: acedatacloud
+  labels:
+    app: caddy-tenant-proxy
+data:
+  Caddyfile: |
+    {
+      # ACME registration email. Let's Encrypt sends renewal-failure notices here.
+      email ops@acedata.cloud
+
+      # Bind the admin API to localhost only (keep it off the public LB).
+      admin localhost:2019
+
+      # Global on-demand-tls policy: every cert request consults the ask URL.
+      on_demand_tls {
+        ask https://platform.acedata.cloud/api/v1/site-domains/check
+      }
+    }
+
+    # Catch-all HTTPS site. tls { on_demand } makes Caddy issue a cert
+    # via Let's Encrypt the first time any unknown SNI hits the listener,
+    # gated by the `ask` callback above.
+    https:// {
+      tls {
+        on_demand
+      }
+
+      # Reverse-proxy to studio-frontend with the original Host header
+      # preserved so Nexior's per-origin Site lookup keeps working.
+      reverse_proxy studio-frontend.acedatacloud.svc.cluster.local:8085 {
+        header_up Host {host}
+        header_up X-Real-IP {remote_host}
+        header_up X-Forwarded-For {remote_host}
+        header_up X-Forwarded-Proto https
+      }
+
+      # JSON access log to stdout; CLS picks it up automatically.
+      log {
+        output stdout
+        format json
+      }
+    }
+
+    # Plain HTTP redirects to HTTPS. Caddy still serves the
+    # /.well-known/acme-challenge/* path for HTTP-01 challenges
+    # automatically, regardless of this redirect.
+    http:// {
+      redir https://{host}{uri} permanent
+    }
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: caddy-tenant-proxy-data
+  namespace: acedatacloud
+  labels:
+    app: caddy-tenant-proxy
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      # Each Let's Encrypt cert + ACME state is ~10 KB. 5 GB is enough
+      # for ~50,000 tenant certs without any pruning policy.
+      storage: 5Gi
+  storageClassName: cbs
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: caddy-tenant-proxy
+  namespace: acedatacloud
+  labels:
+    app: caddy-tenant-proxy
+spec:
+  # Single replica for MVP. Caddy keeps cert state on a RWO PVC, so any
+  # multi-replica HA needs caddy-storage-redis (or postgres) as a
+  # follow-up; not worth the complexity until traffic justifies it.
+  replicas: 1
+  strategy:
+    # In-place restart so the new pod gets to attach the same RWO cbs
+    # volume the old one was using. RollingUpdate would deadlock
+    # (new pod can't bind RWO until old pod releases it).
+    type: Recreate
+  selector:
+    matchLabels:
+      app: caddy-tenant-proxy
+  template:
+    metadata:
+      labels:
+        app: caddy-tenant-proxy
+    spec:
+      containers:
+        - name: caddy
+          image: caddy:2.8-alpine
+          imagePullPolicy: IfNotPresent
+          args: ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]
+          ports:
+            - { name: http,  containerPort: 80,   protocol: TCP }
+            - { name: https, containerPort: 443,  protocol: TCP }
+            - { name: admin, containerPort: 2019, protocol: TCP }
+          env:
+            # Caddy stores everything (ACME account, certs, locks) under
+            # $XDG_DATA_HOME/caddy by default. Pin it to /data so the
+            # PVC mount actually catches it.
+            - { name: XDG_DATA_HOME,   value: /data }
+            - { name: XDG_CONFIG_HOME, value: /config }
+          volumeMounts:
+            - { name: caddyfile, mountPath: /etc/caddy }
+            - { name: data,      mountPath: /data }
+            - { name: config,    mountPath: /config }
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 1
+              memory: 1Gi
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            tcpSocket:
+              port: 443
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 3
+      volumes:
+        - name: caddyfile
+          configMap:
+            name: caddy-tenant-proxy-config
+            items:
+              - key: Caddyfile
+                path: Caddyfile
+        - name: data
+          persistentVolumeClaim:
+            claimName: caddy-tenant-proxy-data
+        - name: config
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: caddy-tenant-proxy
+  namespace: acedatacloud
+  labels:
+    app: caddy-tenant-proxy
+  annotations:
+    # Ask TKE to create a NEW public CLB for this Service (do NOT share
+    # the nginx-router LB; that one already terminates 80/443 and would
+    # collide). Postpaid traffic + standard accounting.
+    service.kubernetes.io/qcloud-loadbalancer-internet-charge-type: TRAFFIC_POSTPAID_BY_HOUR
+    service.kubernetes.io/qcloud-loadbalancer-internet-max-bandwidth-out: "200"
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  ports:
+    - { name: http,  port: 80,  targetPort: 80,  protocol: TCP }
+    - { name: https, port: 443, targetPort: 443, protocol: TCP }
+  selector:
+    app: caddy-tenant-proxy

--- a/deploy/run.sh
+++ b/deploy/run.sh
@@ -4,3 +4,9 @@ kubectl apply -f deploy/production/service.yaml
 cat deploy/production/studio-deployment.yaml | sed 's/\${TAG}/'"$BUILD_NUMBER"'/g' | kubectl apply -f - || true
 kubectl apply -f deploy/production/studio-service.yaml
 kubectl apply -f deploy/production/studio-ingress.yaml
+
+# Caddy reverse proxy for tenant custom domains (mybrand.com -> studio-frontend
+# with on-demand Let's Encrypt TLS). Idempotent; safe to re-apply on every
+# deploy. The Service provisions a separate public CLB the first time it
+# runs; subsequent applies are no-ops on the LB.
+kubectl apply -f deploy/production/tenant-proxy.yaml


### PR DESCRIPTION
PR-B of the Caddy on-demand TLS migration. Brings up the actual proxy that issues Let's Encrypt certs for tenant custom domains.

Pairs with [PlatformBackend #399](https://github.com/AceDataCloud/PlatformBackend/pull/399) (the ask URL the Caddyfile points at). Both must be deployed before any cert can be signed.

## Architecture

```
Tenant DNS:
  mybrand.com  CNAME  tenant-proxy.acedata.cloud   <-- tenant adds this once
                          │
                          ▼
       ┌──────────────────────────────────┐
       │  Tencent CLB (new public LB)      │  80, 443
       └──────────────────────────────────┘
                          │
                          ▼
       ┌──────────────────────────────────┐
       │  caddy-tenant-proxy (this PR)     │
       │    tls { on_demand }              │  catch-all https://
       │    ask URL: PlatformBackend       │  /api/v1/site-domains/check
       │    reverse_proxy host: $host      │
       └──────────────────────────────────┘
                          │
                          ▼
            studio-frontend.svc:8085
```

`studio-frontend` sees `Host: mybrand.com` and resolves the tenant Site row via the existing per-origin lookup → no Nexior code changes required.

## What this PR adds

`Nexior/deploy/production/tenant-proxy.yaml` — single file, four manifests:

| Resource | Purpose |
|---|---|
| `ConfigMap caddy-tenant-proxy-config` | Caddyfile (catch-all `https://`, `tls { on_demand }`, `ask` URL pointing at PB #399, HTTP → HTTPS redirect) |
| `PVC caddy-tenant-proxy-data` (5 Gi `cbs`) | Persists `/data` so ACME account + every signed cert + locks survive pod restarts. ~10 KB per cert → 5 Gi covers ~50,000 tenants |
| `Deployment caddy-tenant-proxy` | `caddy:2.8-alpine`, 1 replica, `strategy: Recreate` so the RWO volume reattaches without deadlocking |
| `Service caddy-tenant-proxy` (LoadBalancer) | New public CLB, traffic-postpaid. Does NOT share the existing nginx-router LB (that one already binds 80/443) |

`deploy/run.sh` gets one new line: `kubectl apply -f deploy/production/tenant-proxy.yaml` after the existing `studio-*` block.

## Storage details

- `XDG_DATA_HOME=/data` and `XDG_CONFIG_HOME=/config` env vars pin Caddy's storage location to the PVC. Default is `/root/.local/share/caddy/`, which would land on the ephemeral container FS.
- `RWO` cbs volume is bound to one node — that's why we use `strategy: Recreate` (RollingUpdate would have the new pod stuck in `Pending` waiting for the old to release).
- TKE's default cbs daily snapshot covers daily backup; if the volume is ever lost wholesale, Caddy automatically re-issues all certs on next handshake (well within Let's Encrypt's 50/week/registered-domain limit).

## Memory / CPU

`requests: cpu 100m / mem 128Mi`, `limits: cpu 1 / mem 1Gi`. Caddy is genuinely tiny — at 1000+ active certs it sits at ~50 MB RSS. Limits are headroom, not expectations.

## DNS one-time setup AFTER first apply

```bash
kubectl get svc caddy-tenant-proxy -n acedatacloud
# take the EXTERNAL-IP, then in DNSPod:
# tenant-proxy.acedata.cloud   A   <EIP>
```

This is the single manual step in the whole flow. After that:
1. Tenant adds `mybrand.com CNAME tenant-proxy.acedata.cloud`.
2. First HTTPS request → Caddy → ask URL OK → Let's Encrypt → cert deployed → traffic flows.
3. Auto-renewal 30 days before expiry.

## What's NOT in this PR

Kept tightly scoped — no PlatformBackend changes, no Nexior frontend changes:

- **PR-C** (PlatformBackend) will rip out `app/utils/edgeone.py` + the EO calls in `site_domain.py` and migrate the SiteDomain model (drop `verification_token` / `eo_zone_id` / `eo_cname`, add `proxy_cname` defaulting to `tenant-proxy.acedata.cloud`).
- **PR-D** (Nexior) will rewrite `DomainsDialog.vue` to show a single CNAME instruction and drop the TXT verify step (Caddy + the ask URL replace it).

## Verification

```sh
python -c "import yaml; list(yaml.safe_load_all(open('deploy/production/tenant-proxy.yaml')))"
# yaml ok (4 docs)
```

Once merged and deployed, manual smoke test:
1. `kubectl rollout status deploy/caddy-tenant-proxy -n acedatacloud`
2. `kubectl logs -l app=caddy-tenant-proxy -n acedatacloud` — should show `serving initial configuration` and an HTTPS listener on `:443`.
3. Add the DNS A record per above.
4. Curl from the bot account's test domain (e.g. `germey.tech`):
   ```
   # Register a SiteDomain row in DB
   POST /api/v1/site-domains/  with hostname=test.germey.tech
   # Add CNAME at DNSPod: test.germey.tech CNAME tenant-proxy.acedata.cloud
   # Wait for propagation, then:
   curl -v https://test.germey.tech/
   # First request: Caddy issues cert (~5 s pause for ACME), serves HTTP 200 from studio-frontend.
   # Subsequent requests: <50 ms.
   ```
