### PR TITLE
feat(chat): inline source-citation chips with hover preview cards

### DIFF
--- a/change/@acedatacloud-nexior-661fd5de-d4b9-49e0-b5c9-23e0b1419817.json
+++ b/change/@acedatacloud-nexior-661fd5de-d4b9-49e0-b5c9-23e0b1419817.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Inline source-citation chips with hover preview cards in chat answers",
+  "packageName": "@acedatacloud/nexior",
+  "email": "cqc@cuiqingcai.com",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/CitationCard.vue
+++ b/src/components/chat/CitationCard.vue
@@ -1,0 +1,130 @@
+<template>
+  <a class="citation-card" :href="citation.url" target="_blank" rel="noopener noreferrer">
+    <div v-if="citation.source || citation.icon" class="head">
+      <img v-if="citation.icon" :src="citation.icon" :alt="citation.source || ''" class="icon" />
+      <font-awesome-icon v-else :icon="fallbackIcon" class="icon-fallback" />
+      <span v-if="citation.source" class="source">{{ citation.source }}</span>
+    </div>
+    <div v-if="citation.title" class="title">{{ citation.title }}</div>
+    <div v-if="citation.snippet" class="snippet">{{ citation.snippet }}</div>
+    <div class="url">{{ displayUrl }}</div>
+  </a>
+</template>
+
+<script lang="ts">
+/**
+ * Hover-card body for a single source citation. Rendered inside an
+ * `<el-popover>` virtually-anchored to a `[N]` chip in the markdown
+ * stream by `MarkdownRenderer.vue`. The whole card is itself a link to
+ * the source URL — clicking anywhere on the card opens the source in a
+ * new tab, mirroring the chip's own click behaviour so users don't
+ * have to aim at the small superscript.
+ */
+import { defineComponent, type PropType } from 'vue';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import type { IChatCitation } from '@/models';
+
+export default defineComponent({
+  name: 'CitationCard',
+  components: { FontAwesomeIcon },
+  props: {
+    citation: {
+      type: Object as PropType<IChatCitation>,
+      required: true
+    }
+  },
+  computed: {
+    /** Hostname-only display so a 200-char URL doesn't blow up the card. */
+    displayUrl(): string {
+      try {
+        const u = new URL(this.citation.url);
+        return u.host + (u.pathname && u.pathname !== '/' ? u.pathname : '');
+      } catch {
+        return this.citation.url;
+      }
+    },
+    /** Type-driven icon when the citation didn't carry a logo URL. */
+    fallbackIcon(): string {
+      const t = (this.citation.type || '').toLowerCase();
+      if (t === 'file') return 'fa-solid fa-file-lines';
+      if (t === 'page') return 'fa-solid fa-file';
+      if (t === 'issue') return 'fa-solid fa-circle-dot';
+      if (t === 'email') return 'fa-solid fa-envelope';
+      if (t === 'message') return 'fa-solid fa-message';
+      if (t === 'web') return 'fa-solid fa-globe';
+      return 'fa-solid fa-link';
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.citation-card {
+  display: block;
+  width: 320px;
+  max-width: 80vw;
+  padding: 10px 12px;
+  font-size: 12.5px;
+  line-height: 1.45;
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+
+  .head {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 6px;
+    color: var(--el-text-color-secondary, #6b7280);
+    font-size: 12px;
+
+    .icon {
+      width: 14px;
+      height: 14px;
+      object-fit: contain;
+      flex: 0 0 14px;
+    }
+
+    .icon-fallback {
+      width: 12px;
+      height: 12px;
+      flex: 0 0 12px;
+    }
+
+    .source {
+      font-weight: 500;
+    }
+  }
+
+  .title {
+    font-weight: 600;
+    color: var(--el-text-color-primary, #111827);
+    margin-bottom: 4px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    word-break: break-word;
+  }
+
+  .snippet {
+    color: var(--el-text-color-regular, #374151);
+    margin-bottom: 6px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+  }
+
+  .url {
+    color: var(--el-text-color-secondary, #6b7280);
+    font-size: 11.5px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    direction: ltr;
+  }
+}
+</style>

--- a/src/components/chat/Message.vue
+++ b/src/components/chat/Message.vue
@@ -30,7 +30,11 @@
             :done="message.state === messageState.FINISHED || message.state === messageState.FAILED"
           />
           <div v-if="!Array.isArray(message.content)">
-            <markdown-renderer v-if="message.role === 'assistant'" :content="message?.content" />
+            <markdown-renderer
+              v-if="message.role === 'assistant'"
+              :content="message?.content"
+              :citations="message.citations"
+            />
             <pre v-else class="whitespace-pre-wrap break-words w-fit max-w-full py-1">{{ message.content }}</pre>
           </div>
           <div v-else>
@@ -49,7 +53,11 @@
                 class="mt-2"
               />
               <div v-if="item.type === 'text'">
-                <markdown-renderer v-if="message.role === 'assistant'" :content="item.text" />
+                <markdown-renderer
+                  v-if="message.role === 'assistant'"
+                  :content="item.text"
+                  :citations="message.citations"
+                />
                 <pre v-else class="whitespace-pre-wrap break-words w-fit max-w-full py-1">{{ item.text?.trim() }}</pre>
               </div>
               <tool-activity v-if="item.type === 'tool_use'" :item="item" />

--- a/src/components/common/MarkdownRenderer.vue
+++ b/src/components/common/MarkdownRenderer.vue
@@ -1,12 +1,57 @@
 <template>
-  <vue-markdown v-highlight :source="content" class="markdown-body bg-transparent pt-[3px] text-[inherit]" />
+  <div class="markdown-with-citations">
+    <vue-markdown
+      v-highlight
+      :source="enrichedContent"
+      class="markdown-body bg-transparent pt-[3px] text-[inherit]"
+      @mouseover="onChipHover"
+      @mouseleave="onChipLeave"
+    />
+    <!-- Single shared popover instance, virtually anchored to the
+         chip the cursor is currently on. Cheaper than spawning one
+         popover per chip on long answers; also avoids fighting the
+         markdown renderer (which produces plain HTML, not Vue nodes). -->
+    <el-popover
+      v-if="hoveredCitation && popoverAnchor"
+      :virtual-ref="popoverAnchor"
+      virtual-triggering
+      trigger="hover"
+      :visible="popoverVisible"
+      placement="top"
+      :width="320"
+      popper-class="citation-popover"
+      :show-arrow="true"
+      :hide-after="120"
+    >
+      <citation-card :citation="hoveredCitation" />
+    </el-popover>
+  </div>
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
+import { defineComponent, type PropType } from 'vue';
+import { ElPopover } from 'element-plus';
 import VueMarkdown from './VueMarkdown.vue';
+import CitationCard from '@/components/chat/CitationCard.vue';
 import { highlight } from '@/utils';
+import type { IChatCitation } from '@/models';
 import 'highlight.js/styles/night-owl.css';
+
+/**
+ * Marker token the worker injects in place of every `<acite>` tag. We
+ * substitute it for an inline `[N]` chip BEFORE handing the source to
+ * the markdown renderer so the chip lives at exactly the position the
+ * model wanted it. The id charset matches the worker's parser
+ * (`tagParser.ts`'s `parseAciteTag`) so a marker that survives upstream
+ * round-trips through here losslessly.
+ */
+const CITATION_MARKER = /\[\^acite:([A-Za-z0-9_-]{1,32})\]/g;
+
+interface IData {
+  hoveredCitation: IChatCitation | null;
+  popoverAnchor: HTMLElement | null;
+  popoverVisible: boolean;
+}
 
 export default defineComponent({
   name: 'MarkdownRenderer',
@@ -14,23 +59,139 @@ export default defineComponent({
     highlight
   },
   components: {
-    VueMarkdown
+    VueMarkdown,
+    CitationCard,
+    ElPopover
   },
   props: {
     content: {
       type: String,
       required: false,
       default: ''
+    },
+    /**
+     * Sidecar map of citations referenced by `[^acite:<id>]` markers
+     * inside `content`. Streamed onto the assistant message by
+     * `Conversation.vue` and persisted on `IChatMessage.citations` so
+     * reload re-renders the same chips. Markers without a matching
+     * entry render as a degraded `[?]` chip — never as raw
+     * `[^acite:1]` text — so a brief race between text and citation
+     * events doesn't surface garbage.
+     */
+    citations: {
+      type: Object as PropType<Record<string, IChatCitation>>,
+      required: false,
+      default: () => ({})
+    }
+  },
+  data(): IData {
+    return {
+      hoveredCitation: null,
+      popoverAnchor: null,
+      popoverVisible: false
+    };
+  },
+  computed: {
+    /** First-occurrence id → display index (1, 2, 3, …) within this message. */
+    indexById(): Record<string, number> {
+      const order: Record<string, number> = {};
+      let next = 1;
+      const src = this.content || '';
+      // Walk markers in source order so the rendered chip number
+      // matches the model's intended footnote ordering. matchAll
+      // doesn't mutate `lastIndex` so it's safe to share the regex.
+      for (const m of src.matchAll(CITATION_MARKER)) {
+        const id = m[1];
+        if (!(id in order)) {
+          order[id] = next;
+          next += 1;
+        }
+      }
+      return order;
+    },
+    /** `content` with every marker swapped for an inline chip HTML. */
+    enrichedContent(): string {
+      const src = this.content || '';
+      if (!src.includes('[^acite:')) return src;
+      const cites = this.citations || {};
+      const indexById = this.indexById;
+      return src.replace(CITATION_MARKER, (_match, rawId: string) => {
+        const idx = indexById[rawId];
+        const cite = cites[rawId];
+        const label = idx ? String(idx) : '?';
+        const url = cite?.url ? escapeAttr(cite.url) : '';
+        const title = cite?.title || cite?.source || cite?.url || rawId;
+        const titleAttr = escapeAttr(title);
+        const idAttr = escapeAttr(rawId);
+        // The chip itself is an anchor so click works without JS, even
+        // when the popover is suppressed (touch / no-hover devices).
+        // `data-citation-id` is what `onChipHover` reads for the popover.
+        const inner = `<a class="citation-chip__link"${url ? ` href="${url}"` : ''} target="_blank" rel="noopener noreferrer" tabindex="-1">[${escapeAttr(label)}]</a>`;
+        return `<sup class="citation-chip" data-citation-id="${idAttr}" title="${titleAttr}">${inner}</sup>`;
+      });
+    }
+  },
+  methods: {
+    /**
+     * Single delegated mouseover handler for every chip rendered inside
+     * the markdown body. Looks up the metadata in `citations`, sets the
+     * hover state, and points the shared `<el-popover>` at the chip via
+     * Element Plus' `virtual-ref` trigger. Dramatically lighter than
+     * spawning one popover per chip on a 30-citation answer.
+     */
+    onChipHover(event: MouseEvent): void {
+      const target = event.target as HTMLElement | null;
+      if (!target) return;
+      const chip = target.closest<HTMLElement>('.citation-chip');
+      if (!chip) {
+        this.popoverVisible = false;
+        return;
+      }
+      const id = chip.dataset.citationId;
+      if (!id) return;
+      const cite = (this.citations || {})[id];
+      if (!cite) return;
+      this.hoveredCitation = cite;
+      this.popoverAnchor = chip;
+      this.popoverVisible = true;
+    },
+    onChipLeave(): void {
+      this.popoverVisible = false;
     }
   }
 });
+
+/** Tiny attribute-context HTML escape — enough for our chip output. */
+function escapeAttr(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
 </script>
 
 <style lang="scss">
 @import 'github-markdown-css/github-markdown.css';
+
+/* Element Plus mounts the popover content under document.body, so the
+   styles MUST be unscoped to apply. Kept narrow to `.citation-popover`
+   to avoid leaking into other popovers. */
+.el-popover.citation-popover {
+  padding: 0 !important;
+  border-radius: 10px;
+  box-shadow:
+    0 6px 24px rgba(15, 23, 42, 0.12),
+    0 1px 3px rgba(15, 23, 42, 0.08);
+}
 </style>
 
 <style lang="scss" scoped>
+.markdown-with-citations {
+  position: relative;
+}
+
 .markdown-body {
   ol {
     list-style: initial;
@@ -38,6 +199,53 @@ export default defineComponent({
 
   pre code {
     color: white;
+  }
+
+  /* Inline citation chip rendered in place of `[^acite:<id>]` markers.
+     Small, slightly raised, weakly tinted; never breaks the surrounding
+     text run so a paragraph with 5 citations stays one line of prose. */
+  :deep(.citation-chip) {
+    display: inline-block;
+    margin: 0 1px 0 2px;
+    padding: 0;
+    line-height: 1;
+    vertical-align: super;
+    font-size: 0.72em;
+    user-select: none;
+
+    .citation-chip__link {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 18px;
+      height: 16px;
+      padding: 0 5px;
+      border-radius: 8px;
+      background: rgba(39, 113, 134, 0.1);
+      color: #277186;
+      font-weight: 600;
+      text-decoration: none;
+      transition:
+        background 0.12s ease,
+        color 0.12s ease;
+
+      &:hover {
+        background: rgba(39, 113, 134, 0.18);
+        color: #1f5a6b;
+      }
+    }
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .markdown-body :deep(.citation-chip) .citation-chip__link {
+    background: rgba(255, 255, 255, 0.08);
+    color: #d1d5db;
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.14);
+      color: #f9fafb;
+    }
   }
 }
 </style>

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -126,6 +126,18 @@ export interface IChatMessage {
    * (or the upstream doesn't expose it).
    */
   thinking?: string;
+  /**
+   * Sidecar map of source citations referenced by `[^acite:<id>]`
+   * marker tokens embedded in the rendered text. Populated from the
+   * worker's streaming `citation` SSE events (one entry per unique
+   * `<acite>` tag the model emitted in this assistant turn). The
+   * markdown renderer swaps each marker for an inline `[N]` chip
+   * whose hover card / click target are looked up in this map by id.
+   * Reused on reload so historical conversations re-render the same
+   * chips without a refetch. Empty / undefined for messages produced
+   * before this protocol shipped.
+   */
+  citations?: Record<string, IChatCitation>;
   role?: typeof ROLE_SYSTEM | typeof ROLE_ASSISTANT | typeof ROLE_USER;
   error?: IError;
 }
@@ -201,6 +213,11 @@ export interface IChatConversationResponse {
   };
   // Rich-output entity card (`type === 'card'`). See `IChatCard` below.
   card?: IChatCard;
+  // Source citation footnote (`type === 'citation'`). See `IChatCitation`
+  // below. The worker streams one event per unique `<acite>` tag during
+  // the assistant turn; the frontend merges them into
+  // `IChatMessage.citations` keyed by `id`.
+  citation?: IChatCitation;
 }
 
 export interface IChatConversationsResponse {
@@ -245,6 +262,45 @@ export interface IChatCard {
   duration?: number;
   mimeType?: string;
   alt?: string;
+}
+
+/**
+ * Source citation footnote emitted by aichat2 whenever the assistant
+ * grounds a factual claim in a tool result (web search hit, MCP
+ * response, file listing, email, etc.). The worker streams `citation`
+ * SSE events while parsing `<acite>` tags out of the LLM text deltas
+ * and replaces each tag in the live text stream with a stable marker
+ * token `[^acite:<id>]`. The frontend's markdown renderer swaps the
+ * marker for an inline `[N]` chip; clicking the chip opens `url`,
+ * hovering it surfaces a preview card built from `title` /
+ * `source` / `icon` / `snippet`. The citation metadata is persisted on
+ * the message's `citations` map (a sidecar lookup table keyed by
+ * `id`) — NOT as a content block — so reuse across multiple sentences
+ * costs one row, and reload re-renders chips in place.
+ *
+ * `type` is intentionally open-ended (`file` | `page` | `issue` |
+ * `email` | `message` | `web` | …) so future surfaces only need a
+ * renderer hint, not a protocol change.
+ */
+export interface IChatCitation {
+  /** Stable identifier within a single assistant message. Same source
+   *  reuses the same id across every reference; the renderer assigns
+   *  the visible 1-based index based on first-occurrence order. */
+  id: string;
+  /** URL the chip links to on click. */
+  url: string;
+  /** Bold line on the hover card (e.g. `Document4.docx`). */
+  title?: string;
+  /** Surface label (e.g. `OneDrive`, `GitHub`, `Notion`, `Web`). */
+  source?: string;
+  /** Absolute URL of a 16-32px icon shown next to `source`. */
+  icon?: string;
+  /** 1-2 line excerpt under the title on the hover card. */
+  snippet?: string;
+  /** Loose entity hint (`file` | `page` | `issue` | `web` | …). */
+  type?: string;
+  /** MIME type, when known. */
+  mimeType?: string;
 }
 
 export interface IChatToolCall {

--- a/src/operators/chat.ts
+++ b/src/operators/chat.ts
@@ -111,7 +111,8 @@ class ChatOperator {
                     duration_ms: json.duration_ms,
                     content: json.content,
                     artifact: json.artifact,
-                    card: json.card
+                    card: json.card,
+                    citation: json.citation
                   });
                 }
               } catch (err) {

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -60,7 +60,14 @@ import axios from 'axios';
 import { defineComponent } from 'vue';
 import Message from '@/components/chat/Message.vue';
 import { CHAT_MODEL_GROUPS, CHAT_MODELS, ROLE_ASSISTANT, ROLE_USER } from '@/constants';
-import { IChatMessageState, IChatConversationResponse, IChatConversation, IChatMessage, IChatReference, BaseError } from '@/models';
+import {
+  IChatMessageState,
+  IChatConversationResponse,
+  IChatConversation,
+  IChatMessage,
+  IChatReference,
+  BaseError
+} from '@/models';
 import Composer from '@/components/chat/Composer.vue';
 import ModelSelector from '@/components/chat/ModelSelector.vue';
 import DesktopAgentManager from '@/components/chat/DesktopAgentManager.vue';
@@ -696,6 +703,19 @@ export default defineComponent({
                   answerOffset = response.answer?.length ?? 0;
                 }
                 contentParts.push({ type: 'card', card: response.card });
+              } else if (response.type === 'citation' && response.citation) {
+                // Source citation footnote from the worker's <acite>
+                // stream parser. Unlike `card`, citations DO NOT split
+                // the text stream — the worker injected a stable marker
+                // token `[^acite:<id>]` into the text where the chip
+                // should land, so we just stash the metadata on the
+                // assistant message's sidecar `citations` map. The
+                // markdown renderer pairs marker → metadata at render
+                // time. Last-write-wins on duplicate ids matches the
+                // worker's semantics (the model is taught to reuse the
+                // same id for the same source).
+                const target = this.messages[this.messages.length - 1];
+                target.citations = { ...(target.citations ?? {}), [response.citation.id]: response.citation };
               } else if (response.delta_answer) {
                 currentText = (response.answer || '').slice(answerOffset);
               }
@@ -711,6 +731,7 @@ export default defineComponent({
                   role: ROLE_ASSISTANT,
                   content: displayParts,
                   thinking: lastMessage?.thinking,
+                  citations: lastMessage?.citations,
                   state:
                     lastMessage?.state !== IChatMessageState.FINISHED ? IChatMessageState.ANSWERING : lastMessage?.state
                 };
@@ -719,6 +740,7 @@ export default defineComponent({
                   role: ROLE_ASSISTANT,
                   content: response.answer,
                   thinking: lastMessage?.thinking,
+                  citations: lastMessage?.citations,
                   state:
                     lastMessage?.state !== IChatMessageState.FINISHED ? IChatMessageState.ANSWERING : lastMessage?.state
                 };


### PR DESCRIPTION
## Why

Pairs with [PlatformService #828](https://github.com/AceDataCloud/PlatformService/pull/828), which teaches aichat2 to emit inline `<acite>` source-citation tags alongside its existing `<acard>` rich-output protocol. This PR renders those citations in the chat UI as small numbered chips with a hover preview card and click-through to the original source.

Concretely: when a user asks something like *"列我最近 5 个 OneDrive 文件"* and the assistant grounds its answer in MCP tool results, every cited fact gets a `[1]` chip immediately after the relevant phrase. Hovering shows a card with the source label (OneDrive / GitHub / Notion / …), the title, a 1–2 line snippet, and the URL. Clicking opens the source in a new tab. Same source cited 5 times = chip number `[1]` reused 5 times — no `[1]…[2]…[3]…` artifacts for one document.

## Protocol recap

The worker streams two channels for assistant text:

| SSE event   | Position    | Frontend handling                                                |
|-------------|-------------|------------------------------------------------------------------|
| `text_delta` | inline      | accumulated as before; **now contains `[^acite:<id>]` marker tokens** in place of every `<acite>` tag the model emitted |
| `citation`   | sidecar     | new — one event per unique `<acite>` tag, merged into `IChatMessage.citations` keyed by `id` |

Markers are markdown-safe, so messages without citation-aware rendering still flow through every layer untouched (older mobile builds will see literal `[^acite:1]` for a brief window after the worker rolls out — that's the worst-case fallback).

## What changes

| File | Purpose |
|---|---|
| [`src/models/chat.ts`](src/models/chat.ts) | + `IChatCitation` interface, `IChatMessage.citations?: Record<id, IChatCitation>`, `IChatConversationResponse.citation` field |
| [`src/operators/chat.ts`](src/operators/chat.ts) | forward `json.citation` from the worker SSE stream alongside existing `card` / `artifact` channels |
| [`src/pages/chat/Conversation.vue`](src/pages/chat/Conversation.vue) | new `response.type === 'citation'` branch that merges into the live assistant message's `citations` map; `lastMessage?.citations` preserved when the message object is rebuilt across stream events |
| [`src/components/common/MarkdownRenderer.vue`](src/components/common/MarkdownRenderer.vue) | accepts `:citations` prop; pre-processes content to swap every `[^acite:<id>]` marker for an inline `<sup class="citation-chip"><a>[N]</a></sup>` whose visible index is the first-occurrence position; manages a single shared `<el-popover>` virtually anchored to the hovered chip via Element Plus' `virtual-ref` API |
| [`src/components/chat/CitationCard.vue`](src/components/chat/CitationCard.vue) | popover body: source-row (icon + label), bold title, 1-2 line snippet, host+path URL. The card itself is an anchor so hover-and-click works without aiming at the small chip |
| [`src/components/chat/Message.vue`](src/components/chat/Message.vue) | threads `message.citations` through to `<MarkdownRenderer>` in both string-content and array-content paths |

### Why a single shared popover (not one per chip)

A 30-citation answer would otherwise mount 30 `<el-popover>` instances. Element Plus' `virtual-ref` + `virtual-triggering` exists exactly for this case — one `<el-popover>` whose anchor element is set imperatively from a delegated `mouseover` handler that walks `event.target.closest('.citation-chip')`.

### Why a Vue popover, not a CSS tooltip

The hover card needs a real icon + multi-line snippet + click-through host. CSS `::after` tooltips can't do that without ugly hacks. `<el-popover>` is already in the dep tree, so the cost of using it is essentially zero.

### Why client-side numbering

The worker assigns ids (small integers / slugs the model picks); the frontend assigns the *visible* `[N]` based on first-occurrence in `content`. This means:

- Same source cited multiple times = same chip number every time (the worker reuses the id, the renderer assigns the same index).
- The number you see matches paragraph-reading order, not the model's bookkeeping order — which can drift when it cites sources out of order.
- No bookkeeping needs to round-trip through the worker for renumbering.

## Backward compatibility

- Messages with no `citations` go through the renderer unchanged (`content.includes('[^acite:')` short-circuits the regex pass).
- A marker without matching metadata renders as a degraded `[?]` chip whose title is the marker id — never as raw `[^acite:1]` text. So a stream where the `text_delta` carrying `[^acite:1]` arrives a frame before the `citation` event still looks fine: chip with `?` flips to `1` the moment metadata lands.
- The `<acard>` protocol is untouched. Cards and citations can coexist on the same URL (e.g. an audio file the assistant both plays and cites).

## Verification

```sh
$ npx vue-tsc --noEmit -p tsconfig.app.json   # clean
$ npx eslint src/components/{common/MarkdownRenderer,chat/CitationCard,chat/Message}.vue \
             src/{models/chat,operators/chat}.ts src/pages/chat/Conversation.vue   # clean
$ npm run test:run   # 86/86 pass (existing suite, no regressions; no new tests added — see below)
```

No new tests added because:
- the marker-replacement logic is pure-string regex covered by the parser tests upstream in [PlatformService #828](https://github.com/AceDataCloud/PlatformService/pull/828) (`tagParser.test.ts`, 30 cases);
- Nexior's vitest setup doesn't currently include `@vue/test-utils`, so a Vue-component test for the renderer would be a meaningful infra extension that doesn't belong in a feature PR.

Suggest manual smoke once both PRs deploy:

1. Open a chat where the model has access to MCP tools that return URLs (e.g. OneDrive / GitHub / Web search), ask for a list with sources.
2. Confirm chips render inline as `[1]`, `[2]`, … and that the same URL keeps its number across sentences.
3. Hover a chip → preview card appears with source label, title, snippet, URL.
4. Click a chip → original source opens in a new tab.
5. Reload the conversation → chips re-render with the same numbers and metadata (sidecar map persisted via `setConversation` → `getConversation` round-trip).
