### PR TITLE
fix(tenant-proxy): give kubelet a /healthz that bypasses 80->443 redirect

### DIFF
--- a/deploy/production/tenant-proxy.yaml
+++ b/deploy/production/tenant-proxy.yaml
@@ -70,11 +70,20 @@ data:
       }
     }
 
-    # Plain HTTP redirects to HTTPS. Caddy still serves the
-    # /.well-known/acme-challenge/* path for HTTP-01 challenges
-    # automatically, regardless of this redirect.
+    # Plain HTTP: serves /.well-known/acme-challenge/* for HTTP-01
+    # challenges (built-in), a /healthz endpoint for the kubelet
+    # readiness probe (so it doesn't follow the 80->443 redirect into
+    # on-demand-TLS land where Caddy would refuse to sign for an IP),
+    # and redirects everything else to HTTPS. `handle` blocks are
+    # mutually exclusive and override Caddy's default directive order
+    # (which would otherwise run `redir` before `respond`).
     http:// {
-      redir https://{host}{uri} permanent
+      handle /healthz {
+        respond "ok" 200
+      }
+      handle {
+        redir https://{host}{uri} permanent
+      }
     }
 ---
 apiVersion: apps/v1
@@ -130,9 +139,13 @@ spec:
             limits:
               cpu: 1
               memory: 1Gi
+          # Readiness hits the dedicated /healthz handler in the http://
+          # block above; we explicitly bypass Caddy's 80->443 redirect
+          # because the redirect target is the pod IP, which on-demand-tls
+          # rightly refuses to sign a cert for (`tls: internal error`).
           readinessProbe:
             httpGet:
-              path: /
+              path: /healthz
               port: 80
               scheme: HTTP
             initialDelaySeconds: 5


### PR DESCRIPTION
## Why

When [`tenant-proxy.yaml`](deploy/production/tenant-proxy.yaml) (#598) lands in the live cluster, the pod stays `Running 0/1 ready` indefinitely:

```
Warning  Unhealthy   Readiness probe failed:
  Get "https://10.4.41.41/": remote error: tls: internal error
```

The readiness probe is configured for `port 80, scheme HTTP, path /`, but Caddy answers it with a `308 https://10.4.41.41/` (the catch-all `http://` block redirects everything to HTTPS). The kubelet follows the redirect, on-demand-tls quite correctly refuses to sign a cert for the pod IP, and the probe loops forever — pod is never added to the Service endpoints.

## What

Two changes to [`deploy/production/tenant-proxy.yaml`](deploy/production/tenant-proxy.yaml):

1. **Carve a `/healthz` out of the http:// block** that bypasses the redirect, using mutually-exclusive `handle` blocks so directive ordering doesn't matter:

   ```caddy
   http:// {
     handle /healthz {
       respond "ok" 200
     }
     handle {
       redir https://{host}{uri} permanent
     }
   }
   ```

   *(My first attempt was a bare `@health path /healthz; respond @health "ok" 200` followed by `redir`, but Caddy's default directive order runs `redir` before `respond`, so the health response was unreachable. `handle` blocks are mutually exclusive and ignore the default order.)*

2. **Point the readinessProbe at `/healthz`** so the kubelet stays on port 80 and never trips on-demand-tls.

```diff
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 80
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 80
```

The livenessProbe stays on `tcpSocket: 443` — that one was always fine.

## Verification

Applied the fix to the live cluster + rolled the deployment:

```
$ kubectl rollout status deployment/caddy-tenant-proxy -n acedatacloud
deployment "caddy-tenant-proxy" successfully rolled out

$ kubectl get pod -n acedatacloud -l app=caddy-tenant-proxy
NAME                                  READY   STATUS    RESTARTS   AGE
caddy-tenant-proxy-d7b7d68d-lbscm     1/1     Running   0          12s
```

No other behaviour changes. Once merged, the next `run.sh` deploy is a no-op apply (configmap content matches) followed by a no-op rollout (pod template hash matches).
