### PR TITLE
fix(chat): enable image/file upload for DeepSeek V4 Flash

### DIFF
--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -94,6 +94,8 @@ export const CHAT_MODEL_DEEPSEEK_V4_FLASH: IChatModel = {
   name: CHAT_MODEL_NAME_DEEPSEEK_V4_FLASH,
   icon: CHAT_MODEL_ICON_DEEPSEEK,
   modelGroup: 'deepseek',
+  isImageSupported: true,
+  isFileSupported: true,
   getDisplayName: () => i18n.global.t('chat.model.deepseekV4Flash'),
   getDescription: () => i18n.global.t('chat.model.deepseekV4FlashDescription')
 };


### PR DESCRIPTION
## Why

User report:

> deepseek V4 不支持传图吗？到现在？？？？你仔细看看？？？你调研下就是 vision 模型啊

\`deepseek-v4-flash\` is a vision-capable model — its checker entries in \`PlatformService/openai/checker/config/{ephone,wcnb,openaihk}.json\` route live traffic the same way other vision-capable models do, and the model is exposed in [\`aichat\` OpenAPI](https://github.com/AceDataCloud/PlatformBackend/blob/main/openapi/1d58971c-e3cd-4713-a3ce-854a731adb14.json#L339) and [\`deepseek\` OpenAPI](https://github.com/AceDataCloud/PlatformBackend/blob/main/openapi/f416edc1-a771-4a31-90e7-b14ca3a3d674.json#L487) — but in https://studio.acedata.cloud the **\"添加照片或文件\"** entry is greyed out whenever DeepSeek V4 Flash is selected.

## Root cause

[\`Composer.vue\`](src/components/chat/Composer.vue#L12) gates the \`+\` upload menu on the per-model \`isImageSupported\` / \`isFileSupported\` flags:

\`\`\`vue
<el-dropdown-item
  :disabled=\"(!isFileSupported && !isImageSupported) || answering\"
  @click=\"onTriggerUpload\"
>
\`\`\`

[\`CHAT_MODEL_DEEPSEEK_V4_FLASH\`](src/constants/chat.ts) was registered with neither flag, so both eval to \`undefined\` → the menu item stays disabled. Every other vision-capable model in this file — GPT-5.5/5.4/5.4-mini, Gemini 3.0 Pro / 2.5 Pro / 2.5 Flash, Claude Opus 4.7 / Sonnet 4.6 / Haiku 4.5 — explicitly carries both flags.

## Fix

Add \`isImageSupported: true\` and \`isFileSupported: true\` to \`CHAT_MODEL_DEEPSEEK_V4_FLASH\`, matching the other vision-capable entries.

\`\`\`diff
 export const CHAT_MODEL_DEEPSEEK_V4_FLASH: IChatModel = {
   enabled: true,
   name: CHAT_MODEL_NAME_DEEPSEEK_V4_FLASH,
   icon: CHAT_MODEL_ICON_DEEPSEEK,
   modelGroup: 'deepseek',
+  isImageSupported: true,
+  isFileSupported: true,
   getDisplayName: () => i18n.global.t('chat.model.deepseekV4Flash'),
   getDescription: () => i18n.global.t('chat.model.deepseekV4FlashDescription')
 };
\`\`\`

DeepSeek V3 / V3.2-Exp / R1 were left as-is — they remain text-only per their existing registration; this PR only addresses the V4 vision regression the user flagged.

## Verification

- \`npx vue-tsc --noEmit --skipLibCheck\` → clean.
- After deploy, on https://studio.acedata.cloud pick DeepSeek V4 Flash → \`+\` menu \"添加照片或文件\" becomes enabled, drag-and-drop accepts images, and the image rides through as a \`references\` URL on the aichat call.