### PR TITLE
refactor(subsite/domains): single CNAME flow; drop EdgeOne wizard

### DIFF
--- a/src/components/setting/SubsiteDomainsDialog.vue
+++ b/src/components/setting/SubsiteDomainsDialog.vue
@@ -19,16 +19,16 @@
           </el-tag>
           <span class="row-actions">
             <el-button
-              v-if="canVerify(d)"
+              v-if="d.status !== 'Active'"
               size="small"
               type="primary"
               :loading="busyId === d.id"
               link
               @click="onVerify(d)"
             >
-              {{ verifyButtonLabel(d.status) }}
+              {{ $t('subsite.button.verify') }}
             </el-button>
-            <el-button v-if="d.status !== 'Active'" size="small" link :loading="busyId === d.id" @click="onRefresh(d)">
+            <el-button v-if="d.status === 'Active'" size="small" link :loading="busyId === d.id" @click="onRefresh(d)">
               {{ $t('subsite.button.refresh') }}
             </el-button>
             <el-button size="small" link type="danger" :loading="busyId === d.id" @click="onDelete(d)">
@@ -226,18 +226,20 @@ export default defineComponent({
       if (!d.id) return;
       this.busyId = d.id;
       try {
+        // The backend verify endpoint always returns 200 with the
+        // updated row (status flipped to Active OR Failed); it never
+        // throws on a failed probe so the body's status_reason can
+        // surface the cause. We mirror that contract here.
         const { data } = await siteDomainOperator.verify(d.id);
         this.replaceRow(data);
         if (data.status === 'Active') {
           ElMessage.success(this.$t('subsite.message.domainActive'));
         } else if (data.status === 'Failed') {
           ElMessage.error(data.status_reason || this.$t('subsite.message.domainFailed'));
-        } else {
-          ElMessage.info(this.$t('subsite.message.domainProgressed'));
         }
       } catch (e: any) {
-        const detail =
-          e?.response?.data?.verification || e?.response?.data?.edgeone || e?.response?.data?.detail || e?.message;
+        // Reachable on auth / network errors only.
+        const detail = e?.response?.data?.detail || e?.message;
         ElMessage.error(typeof detail === 'string' ? detail : this.$t('subsite.message.domainVerifyFailed'));
       } finally {
         this.busyId = null;
@@ -286,22 +288,16 @@ export default defineComponent({
       if (idx >= 0) this.domains.splice(idx, 1, updated);
       else this.domains = [updated, ...this.domains];
     },
-    canVerify(d: ISiteDomain): boolean {
-      return d.status === 'PendingDnsVerification' || d.status === 'ProvisioningEo' || d.status === 'ProvisioningCert';
-    },
-    verifyButtonLabel(status?: string): string {
-      if (status === 'PendingDnsVerification') return this.$t('subsite.button.verify') as string;
-      return this.$t('subsite.button.checkProgress') as string;
-    },
     statusLabel(status?: string): string {
       if (!status) return '-';
+      // Lower-case the first char so 'Pending' -> 'subsite.status.pending'.
       const key = `subsite.status.${status.charAt(0).toLowerCase() + status.slice(1)}`;
       return this.$t(key) as string;
     },
     statusTagType(status?: string): 'success' | 'warning' | 'info' | 'danger' {
       if (status === 'Active') return 'success';
       if (status === 'Failed') return 'danger';
-      if (status === 'PendingDnsVerification') return 'info';
+      // 'Pending' (and any unknown future state) renders as a neutral warning tag.
       return 'warning';
     }
   }

--- a/src/i18n/en/subsite.json
+++ b/src/i18n/en/subsite.json
@@ -104,12 +104,8 @@
     "description": "Button to submit the binding of a new domain"
   },
   "button.verify": {
-    "message": "Verify",
-    "description": "Button to check if the TXT verification record is in place"
-  },
-  "button.checkProgress": {
-    "message": "Check Progress",
-    "description": "Button to sync the latest status from EdgeOne"
+    "message": "Verify Now",
+    "description": "Probe the domain through our reverse proxy to confirm DNS is in place and the certificate has been issued"
   },
   "button.refresh": {
     "message": "Refresh",
@@ -136,7 +132,7 @@
     "description": "Placeholder for the hostname input field"
   },
   "message.domainsIntro": {
-    "message": "Bind your owned domain to this subsite. You need to be able to modify the DNS of that domain. Once verified, we will automatically apply for a free HTTPS certificate and deploy it on EdgeOne.",
+    "message": "Bind your owned domain to this subsite. You need to be able to modify the DNS of that domain. Add the CNAME shown below and click 'Verify Now' — we'll automatically issue and renew a free HTTPS certificate via Let's Encrypt.",
     "description": "Description at the top of the dialog"
   },
   "message.domainsEmpty": {
@@ -152,7 +148,7 @@
     "description": "Local validation failed for hostname"
   },
   "message.domainCreated": {
-    "message": "Domain has been submitted, please follow the instructions to add DNS records.",
+    "message": "Domain has been submitted, please follow the instructions to add the CNAME record.",
     "description": "Successful POST /site-domains/"
   },
   "message.domainCreateFailed": {
@@ -163,10 +159,6 @@
     "message": "Failed to load the domain list.",
     "description": "Failed to load the domain list"
   },
-  "message.domainProgressed": {
-    "message": "Validation in progress, please wait.",
-    "description": "State machine advancement"
-  },
   "message.domainActive": {
     "message": "Domain is live! You can now access the substation via your custom HTTPS address.",
     "description": "Entering Active status"
@@ -176,7 +168,7 @@
     "description": "Failed status message"
   },
   "message.domainVerifyFailed": {
-    "message": "Verification failed, please check if the DNS records have taken effect.",
+    "message": "Verification failed. Check that the CNAME record points at our reverse proxy and DNS has propagated.",
     "description": "verify interface 4xx"
   },
   "message.domainDeleteConfirm": {
@@ -187,17 +179,9 @@
     "message": "Failed to delete the domain.",
     "description": "DELETE interface 5xx"
   },
-  "status.pendingDnsVerification": {
-    "message": "Pending DNS Verification",
-    "description": "PendingDnsVerification status label"
-  },
-  "status.provisioningEo": {
-    "message": "Connecting to edge",
-    "description": "ProvisioningEo status label"
-  },
-  "status.provisioningCert": {
-    "message": "Requesting certificate",
-    "description": "ProvisioningCert status label"
+  "status.pending": {
+    "message": "Pending",
+    "description": "Pending status label: waiting for the user to add the CNAME and click 'Verify Now'"
   },
   "status.active": {
     "message": "Live",

--- a/src/i18n/zh-CN/subsite.json
+++ b/src/i18n/zh-CN/subsite.json
@@ -104,12 +104,8 @@
     "description": "提交绑定新域名"
   },
   "button.verify": {
-    "message": "验证",
-    "description": "检查 TXT 验证记录是否到位"
-  },
-  "button.checkProgress": {
-    "message": "检查进度",
-    "description": "从 EdgeOne 同步最新状态"
+    "message": "立即验证",
+    "description": "通过我们的反向代理探测该域名是否已能正常解析并签发证书"
   },
   "button.refresh": {
     "message": "刷新",
@@ -136,7 +132,7 @@
     "description": "hostname 输入框占位符"
   },
   "message.domainsIntro": {
-    "message": "将你拥有的域名绑定到该分站。你需要能修改该域名的 DNS。验证通过后我们会自动为你申请免费 HTTPS 证书并在 EdgeOne 上部署。",
+    "message": "将你拥有的域名绑定到该分站。你需要能修改该域名的 DNS。按照下方提示添加一条 CNAME 后点击“立即验证”即可，我们会自动通过 Let's Encrypt 为你免费签发并续期 HTTPS 证书。",
     "description": "对话框顶部说明"
   },
   "message.domainsEmpty": {
@@ -152,7 +148,7 @@
     "description": "hostname 本地校验失败"
   },
   "message.domainCreated": {
-    "message": "域名已提交，请按提示添加 DNS 记录。",
+    "message": "域名已提交，请按提示添加 CNAME 记录。",
     "description": "POST /site-domains/ 成功"
   },
   "message.domainCreateFailed": {
@@ -163,10 +159,6 @@
     "message": "加载域名列表失败。",
     "description": "拉域名列表失败"
   },
-  "message.domainProgressed": {
-    "message": "验证进入下一阶段，请耐心等待。",
-    "description": "状态机推进"
-  },
   "message.domainActive": {
     "message": "域名已上线！现在可以通过你的自定义 HTTPS 地址访问分站。",
     "description": "进入 Active 状态"
@@ -176,7 +168,7 @@
     "description": "Failed 状态兑底文案"
   },
   "message.domainVerifyFailed": {
-    "message": "验证失败，请检查 DNS 记录是否已生效。",
+    "message": "验证失败，请检查 CNAME 记录是否已指向我们的反向代理并完成 DNS 传播。",
     "description": "verify 接口 4xx"
   },
   "message.domainDeleteConfirm": {
@@ -187,17 +179,9 @@
     "message": "删除域名失败。",
     "description": "DELETE 接口 5xx"
   },
-  "status.pendingDnsVerification": {
-    "message": "待验证 DNS",
-    "description": "PendingDnsVerification 状态标签"
-  },
-  "status.provisioningEo": {
-    "message": "接入边缘中",
-    "description": "ProvisioningEo 状态标签"
-  },
-  "status.provisioningCert": {
-    "message": "申请证书中",
-    "description": "ProvisioningCert 状态标签"
+  "status.pending": {
+    "message": "待验证",
+    "description": "Pending 状态标签：等待用户加 CNAME 并点击“立即验证”"
   },
   "status.active": {
     "message": "已上线",

--- a/src/models/site_domain.ts
+++ b/src/models/site_domain.ts
@@ -6,24 +6,25 @@
  * uses subdomains under <subdomain_zone>; Phase 2 (this model) lets the
  * tenant CNAME their own apex/sub from a registrar they control.
  *
- * The `status` field walks a small DAG; see `SiteDomainStatus` below.
- * `dns_instructions` is a UI-friendly hint the backend appends to the
- * GET / verify response so the page doesn't have to re-derive the TXT
- * or CNAME copy itself.
+ * The actual TLS provisioning happens at the edge (Caddy +
+ * Let's Encrypt on-demand-TLS, see Nexior `deploy/production/tenant-proxy.yaml`),
+ * so the row only carries `hostname`, `status`, `proxy_cname`, and
+ * audit fields. `dns_instructions` is a UI-friendly hint the backend
+ * appends to the GET / verify response so the page doesn't have to
+ * re-derive the CNAME copy itself.
  */
 
 export enum SiteDomainStatus {
-  PendingDnsVerification = 'PendingDnsVerification',
-  ProvisioningEo = 'ProvisioningEo',
-  ProvisioningCert = 'ProvisioningCert',
+  Pending = 'Pending',
   Active = 'Active',
   Failed = 'Failed'
 }
 
 export interface ISiteDomainDnsInstructions {
-  step: 'txt' | 'cname';
+  // Reserved for future protocol expansions; today only 'cname' is emitted.
+  step: 'cname';
   record_name: string;
-  record_type: 'TXT' | 'CNAME';
+  record_type: 'CNAME';
   record_value: string;
   instructions: string;
 }
@@ -34,16 +35,17 @@ export interface ISiteDomain {
   hostname?: string;
   status?: SiteDomainStatus;
   status_reason?: string | null;
-  verification_token?: string;
-  eo_zone_id?: string | null;
-  eo_cname?: string | null;
+  // CNAME target the tenant must point `hostname` at. Snapshotted on
+  // the row when it was created so historical rows keep their original
+  // instruction even if the platform default ever rotates.
+  proxy_cname?: string;
   user_id?: string | null;
   created_at?: string;
   updated_at?: string;
-  last_synced_at?: string | null;
   tags?: string[];
   metadata?: Record<string, unknown> | null;
-  // Server-appended hint, only present on detail / verify responses.
+  // Server-appended hint, only present on detail / verify responses
+  // (and only when the row is non-Active).
   dns_instructions?: ISiteDomainDnsInstructions | null;
 }
 


### PR DESCRIPTION
Companion PR-D to [PlatformBackend #400](https://github.com/AceDataCloud/PlatformBackend/pull/400). With the backend now talking to Caddy + Let's Encrypt instead of EdgeOne, the SiteDomain row collapses to `hostname + status + proxy_cname` and this dialog drops to a single CNAME instruction.

## Code

- [`src/models/site_domain.ts`](src/models/site_domain.ts): `SiteDomainStatus` 5 → 3 (`Pending`, `Active`, `Failed`). `ISiteDomainDnsInstructions` narrows `step` to `'cname'` and `record_type` to `'CNAME'`. Drop `verification_token`, `eo_zone_id`, `eo_cname`, `last_synced_at`; add `proxy_cname`.
- [`src/components/setting/SubsiteDomainsDialog.vue`](src/components/setting/SubsiteDomainsDialog.vue): drop the `canVerify` / `verifyButtonLabel` branching (every non-Active row now offers the same **Verify Now** action). `statusTagType` / `statusLabel` collapse to the three new states. The verify error path no longer reads the legacy `e.response.data.edgeone` field. The backend [never throws on a failed probe](https://github.com/AceDataCloud/PlatformBackend/pull/400/files#diff-app-views-site-domain-py) (200 with `status=Failed` + `status_reason`); inlined that contract in a comment.

## i18n

- `src/i18n/zh-CN/subsite.json` (transmart baseLocale): drop `button.checkProgress`, drop `message.domainProgressed`, drop the three legacy `status.*` keys, add `status.pending`. Rewrite `message.domainsIntro` / `message.domainCreated` / `message.domainVerifyFailed` / `button.verify` description to mention **CNAME + Let's Encrypt** instead of **TXT + EdgeOne**.
- `src/i18n/en/subsite.json` mirrored manually so the UI render isn't stale before [`translate.yaml`](.github/workflows/translate.yaml) runs (the workflow is `push-on-zh-CN`, so it'll regenerate the other 16 locales on next push to main as a separate auto-PR).

## Verification

```
$ npx vue-tsc --noEmit --skipLibCheck
EXIT=0
$ python3 -c 'import json; d=json.load(open("src/i18n/zh-CN/subsite.json")); print(len(d), [k for k in d if k.startswith("status.")])'
48 ['status.pending', 'status.active', 'status.failed']
$ git diff --stat
 src/components/setting/SubsiteDomainsDialog.vue | 26 +++++++++-----------
 src/i18n/en/subsite.json                        | 32 +++++++------------------
 src/i18n/zh-CN/subsite.json                     | 32 +++++++------------------
 src/models/site_domain.ts                       | 30 ++++++++++++-----------
 4 files changed, 43 insertions(+), 77 deletions(-)
```

## Rollout note

The auto-translate workflow only fires on `src/i18n/zh-CN/**` changes, so the other 16 locales (`de`/`pt`/`es`/`fr`/`zh-TW`/`it`/`ko`/`ja`/`ru`/`pl`/`fi`/`sv`/`el`/`uk`/`ar`/`sr`) will refresh in the followup auto-translate PR. The dialog will render the literal i18n key (e.g. `subsite.status.pending`) in those locales until that PR merges — not pretty but not breaking.

## Sequencing

| # | Repo | Status |
|---|---|---|
| A | PlatformBackend [#399](https://github.com/AceDataCloud/PlatformBackend/pull/399) — ask URL | merged |
| B | Nexior [#598](https://github.com/AceDataCloud/Nexior/pull/598) — tenant-proxy.yaml | merged |
| · | DNSPod CNAME `tenant-proxy.acedata.cloud` → new CLB | done |
| · | Nexior [#600](https://github.com/AceDataCloud/Nexior/pull/600) — fix readiness probe | open |
| **C** | PlatformBackend [#400](https://github.com/AceDataCloud/PlatformBackend/pull/400) — drop EO, simplify schema | open |
| **D** | **this PR** — frontend single-CNAME flow | open |

PR-C and this PR can merge in either order: backend tolerates an old client that still POSTs hostname-only, and the new dialog tolerates rows still in legacy statuses (they render with the literal status key until verify gets called once).