### PR TITLE
fix(midjourney): mark first-frame image as required in video tab

### DIFF
--- a/src/components/midjourney/config/ImageUrlInput.vue
+++ b/src/components/midjourney/config/ImageUrlInput.vue
@@ -2,7 +2,10 @@
   <div class="relative">
     <div class="flex justify-between">
       <div class="flex justify-start items-center">
-        <span class="text-sm font-bold">{{ $t('midjourney.name.imageUrl') }}</span>
+        <span class="text-sm font-bold">
+          {{ $t('midjourney.name.imageUrl') }}
+          <span class="text-red-500" aria-hidden="true">*</span>
+        </span>
         <info-icon :content="$t('midjourney.description.imageUrl')" />
       </div>
     </div>

--- a/src/pages/midjourney/Index.vue
+++ b/src/pages/midjourney/Index.vue
@@ -255,6 +255,12 @@ export default defineComponent({
         ElMessage.error(this.$t('midjourney.message.promptRequired'));
         return;
       }
+      // Midjourney video generation is image-to-video only; pure text-to-video is not supported.
+      // For action=extend, image_url is replaced by video_id.
+      if (request.action !== MidjourneyVideosAction.EXTEND && !request.image_url) {
+        ElMessage.error(this.$t('midjourney.message.imageUrlRequired'));
+        return;
+      }
       ElMessage.info(this.$t('midjourney.message.startingTask'));
       midjourneyOperator
         .videos(request, {


### PR DESCRIPTION
## Why

Companion to https://github.com/AceDataCloud/PlatformBackend/pull/401 (cc @qicu).

Midjourney `/midjourney/videos` is **image-to-video only** — pure text-to-video isn't supported. Submitting without an `image_url` returns a 400 from `PlatformService/ephone` with `Please provide a image url.` (real example: trace `901a0cf5-f8e9-4dba-b9e4-65ba8a233385`).

Today the UI lets that request through and surfaces the upstream 400 verbatim. Since the field has no required marker and there's no client-side guard, users have no way to discover the requirement except by trying.

## What

Two small UX fixes:

| File | Change |
|---|---|
| [`src/components/midjourney/config/ImageUrlInput.vue`](src/components/midjourney/config/ImageUrlInput.vue) | Append a red `*` after the **首帧图片 / First-frame image** label. Component is only mounted under the 视频生成 tab so the marker is unambiguous. Matches Element Plus form convention. |
| [`src/pages/midjourney/Index.vue`](src/pages/midjourney/Index.vue) — `onStartVideosTask` | Short-circuit with `midjourney.message.imageUrlRequired` (`请上传图片`, already translated for all 17 locales) when `action !== 'extend'` and `image_url` is missing. Same pattern as the existing `promptRequired` guard right above it. The `extend` action legitimately omits `image_url` (it carries `video_id` instead), so the check excludes it. |

## Verification

```
$ npx vue-tsc --noEmit --skipLibCheck    # exit 0, no diagnostics
$ npx eslint src/components/midjourney/config/ImageUrlInput.vue src/pages/midjourney/Index.vue
                                          # exit 0, no warnings
```

Manual smoke (post-merge):

1. Open https://studio.acedata.cloud/midjourney → 视频生成 tab
2. Type a prompt, do NOT upload an image, click 生成
3. Should see toast `请上传图片` instead of the previous `无法开始视频生成任务Please provide a image url.`
4. Upload an image → click 生成 → request goes through as before.

## Out of scope

- Localised wording for non-zh-CN locales already exists for `message.imageUrlRequired` from prior work — no i18n changes here. The new `*` is a non-translated visual marker.
- The companion PB PR (#401) updates the OpenAPI spec at https://docs.acedata.cloud to mark `image_url` as required for `action=generate`, and fixes the live consumption display so switching 480p ↔ 720p / fast ↔ turbo updates the credit cost shown above the 生成 button.
