### PR TITLE
fix(midjourney): inset config-tab content so input focus ring doesn't clip

### DIFF
--- a/src/components/midjourney/ConfigPanel.vue
+++ b/src/components/midjourney/ConfigPanel.vue
@@ -3,7 +3,7 @@
     <div class="flex-1 overflow-y-auto p-5">
       <el-tabs v-model="type" class="demo-tabs" stretch>
         <el-tab-pane :label="$t('midjourney.tab.images')" name="imagine">
-          <div class="pt-2">
+          <div class="pt-2 px-1">
             <model-selector class="mb-2" />
             <prompt-input class="mb-4" />
             <reference-image class="mb-2" />
@@ -23,7 +23,7 @@
           </div>
         </el-tab-pane>
         <el-tab-pane :label="$t('midjourney.tab.videos')" name="videos">
-          <div class="pt-2">
+          <div class="pt-2 px-1">
             <video-from-input v-show="config?.action === 'extend'" class="mb-4" />
             <image-url-input class="mb-2" />
             <end-image-url-input class="mb-2" />
@@ -33,7 +33,7 @@
           </div>
         </el-tab-pane>
         <el-tab-pane :label="$t('midjourney.tab.describe')" name="describe">
-          <div class="pt-2">
+          <div class="pt-2 px-1">
             <image-url-input2 class="mb-2" />
           </div>
         </el-tab-pane>


### PR DESCRIPTION
## Symptom

User reported on https://studio.acedata.cloud/midjourney that the **提示** prompt input box looks like its left edge is cut off (see attached screenshot). Same applies to all other inputs (`<el-input>`, `<el-select>`, ratio buttons) inside the 视频生成 / 图像描述 tabs of the left config panel.

## Root cause

[`ConfigPanel.vue`](src/components/midjourney/ConfigPanel.vue) wraps everything in `<el-tabs>`. Element Plus's `.el-tabs__content` is `overflow: hidden` by default to support its slide animation between panes.

Our [`_common.scss`](src/assets/scss/_common.scss#L282-L313) gives every `el-textarea` / `el-input` / `el-select` an outer focus ring:

```scss
&:focus,
&.is-focus,
&.is-focused {
  box-shadow: 0 0 0 1px var(--el-color-primary) inset, 0 0 0 3px var(--el-color-primary-light-8);
}
```

The 3px outer glow lives **outside** the input's bounding box on every side. Inside the MJ tab pane, inputs fill 100% of pane width and sit flush against the pane edges, so the left/right 3px of glow falls outside `.el-tabs__content` and gets clipped — reading as "the input border is cut off". Only MJ's panel embeds inputs in `<el-tabs>`, which is why the bug is page-specific.

## Fix

Inset the tab-pane content from the pane edge by 4px (`px-1`) so the 3px focus glow has room to render. **No** `overflow: visible` override — keeping `el-tabs__content`'s default clip preserves the established containment guarantees (e.g. focus rings on inputs at the bottom of the panel won't bleed into the consumption / Generate button area below).

```diff
       <el-tabs v-model="type" class="demo-tabs" stretch>
         <el-tab-pane :label="$t('midjourney.tab.images')" name="imagine">
-          <div class="pt-2">
+          <div class="pt-2 px-1">
             <model-selector class="mb-2" />
             ...
```

Same change applied to all three tab panes (`imagine`, `videos`, `describe`).

## Verification

```
$ git diff --stat
 src/components/midjourney/ConfigPanel.vue | 6 +++---
```

Manual smoke (post-merge, on https://studio.acedata.cloud/midjourney):

1. Click into 提示 textarea → focus ring is now an even 3px on all four sides instead of clipped at left/right.
2. Switch between 图像生成 / 视频生成 / 图像描述 tabs → no visual regression.
3. Other inputs (画质 selector, 比例 buttons, 版本 dropdown, 首帧图片 url input) all show their focus ring fully.
4. Inputs near the bottom of the panel still clip cleanly above the Generate button area (no glow bleed into the action zone — the original `overflow: hidden` on `el-tabs__content` is preserved).