### PR TITLE
fix(chat): teleport image viewer so it overlays the whole viewport

### DIFF
--- a/src/components/chat/ArtifactBlock.vue
+++ b/src/components/chat/ArtifactBlock.vue
@@ -8,6 +8,7 @@
         fit="contain"
         style="max-width: 400px; max-height: 400px; border-radius: 8px"
         :preview-src-list="[artifact.url]"
+        :preview-teleported="true"
       />
       <div class="artifact-name">{{ artifact.name }}</div>
     </div>

--- a/src/components/chat/EntityCard.vue
+++ b/src/components/chat/EntityCard.vue
@@ -51,6 +51,7 @@
         :preview-src-list="[card.url]"
         :initial-index="0"
         :hide-on-click-modal="true"
+        :preview-teleported="true"
       >
         <template #placeholder>
           <div class="image-placeholder" />


### PR DESCRIPTION
## What the user hit

In a chat at https://studio.acedata.cloud/chatgpt/conversations/<id>, clicking an image attachment in an assistant reply opens an Element Plus image viewer that:

- shows the toolbar (zoom in / zoom out / fit / rotate)
- but does **not** dim the rest of the page
- the image, sidebar (`开始新对话` / chat list), top bar and composer all stay visible behind it
- the image stays the same size as it was inline in the bubble

Expected: the viewer covers the entire viewport (dark backdrop + centered, freely-zoomable image), the way `<el-image-viewer>` works on every other site that uses Element Plus.

## Why

[`<el-image>`](https://element-plus.org/en-US/component/image.html#image-attributes)'s `preview-teleported` prop defaults to **`false`** in Element Plus 2.x. With the default, the previewer is rendered as a child of the same DOM node the `<el-image>` sits in — i.e. inside the message bubble inside the scrollable conversation column. The viewer's `position: fixed` rules end up scoped to that subtree (any ancestor with stacking context, transform, or overflow constraints traps it), so visually it looks like the modal is inert.

`preview-teleported="true"` mounts the viewer on `<body>` instead, where its `position: fixed; inset: 0; z-index: 2000` overlay actually fills the screen.

## What

One-line addition on the two chat image entry points:

| File | Component used |
|---|---|
| [`src/components/chat/EntityCard.vue`](src/components/chat/EntityCard.vue#L46-L62) | `image`-typed `<acard>` rendered in assistant replies (the case in the user's screenshot) |
| [`src/components/chat/ArtifactBlock.vue`](src/components/chat/ArtifactBlock.vue#L4-L13) | image-typed artifacts |

Both now pass `:preview-teleported="true"`. No styling, layout, or component-API changes — just the viewer mount target.

Other `preview-src-list` consumers in the app (e.g. `src/components/qrart/task/Detail.vue`) live in their own dedicated detail pages where the inline-mount default is fine, so they're left alone.