### PR TITLE
feat(seedream): expose group generation (1-15 images) + add 5.0 model

### DIFF
--- a/src/components/seedream/ConfigPanel.vue
+++ b/src/components/seedream/ConfigPanel.vue
@@ -3,6 +3,7 @@
     <div class="flex-1 overflow-y-auto p-5">
       <model-selector class="mb-4" />
       <size-selector class="mb-4" />
+      <max-images-selector class="mb-4" />
       <prompt-input class="mb-4" />
       <image-input class="mb-4" />
     </div>
@@ -26,6 +27,7 @@ import Consumption from '../common/Consumption.vue';
 import { getConsumption } from '@/utils';
 import ModelSelector from './config/ModelSelector.vue';
 import SizeSelector from './config/SizeSelector.vue';
+import MaxImagesSelector from './config/MaxImagesSelector.vue';
 import { getSeedreamShortModel } from '@/constants';
 
 export default defineComponent({
@@ -37,7 +39,8 @@ export default defineComponent({
     Consumption,
     ImageInput,
     ModelSelector,
-    SizeSelector
+    SizeSelector,
+    MaxImagesSelector
   },
   emits: ['generate'],
   computed: {
@@ -47,12 +50,19 @@ export default defineComponent({
     consumption() {
       const cfg: any = { ...(this.config || {}) };
       const hasReferenceImages = Array.isArray(cfg?.image) && cfg.image.length > 0;
+      // Per-image billing: cost/api/86ad30f3-…json multiplies the unit price by
+      // `count`. When the user opts into group generation we forward the
+      // selected `max_images`; otherwise default to 1 to match the upstream.
+      const requestedCount =
+        cfg?.sequential_image_generation === 'auto'
+          ? Math.max(1, Math.floor(cfg?.sequential_image_generation_options?.max_images || 1))
+          : 1;
       return getConsumption(
         {
           ...cfg,
           action: hasReferenceImages ? 'edit' : 'generate',
           model: getSeedreamShortModel(cfg?.model),
-          count: 1
+          count: requestedCount
         },
         this.service?.cost
       );

--- a/src/components/seedream/config/MaxImagesSelector.vue
+++ b/src/components/seedream/config/MaxImagesSelector.vue
@@ -1,0 +1,150 @@
+<template>
+  <div v-if="supported" class="field">
+    <div class="label">
+      <div class="box">
+        <h2 class="title font-bold">{{ $t('seedream.name.maxImages') }}</h2>
+        <info-icon :content="$t('seedream.description.maxImages')" class="info" />
+      </div>
+    </div>
+    <div class="value">
+      <el-input-number
+        v-model="value"
+        :min="1"
+        :max="effectiveMax"
+        :step="1"
+        size="default"
+        controls-position="right"
+        class="counter"
+      />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElInputNumber } from 'element-plus';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+import { SEEDREAM_DEFAULT_MAX_IMAGES, SEEDREAM_MAX_IMAGES_LIMIT, supportsSeedreamGroupGeneration } from '@/constants';
+
+export default defineComponent({
+  name: 'SeedreamMaxImagesSelector',
+  components: {
+    ElInputNumber,
+    InfoIcon
+  },
+  computed: {
+    config(): any {
+      return this.$store.state.seedream?.config || {};
+    },
+    supported(): boolean {
+      return supportsSeedreamGroupGeneration(this.config?.model);
+    },
+    referenceImageCount(): number {
+      const image = this.config?.image;
+      return Array.isArray(image) ? image.length : 0;
+    },
+    // Volcengine LAS rule: (input reference images) + (generated images) <= 15.
+    // Cap the spinner upper bound dynamically so the user can't pick a value
+    // that the upstream will reject. Floor at 1 so the input never becomes
+    // unusable when the user uploads exactly 14 references (15 - 14 = 1).
+    effectiveMax(): number {
+      const remaining = SEEDREAM_MAX_IMAGES_LIMIT - this.referenceImageCount;
+      return Math.max(1, Math.min(SEEDREAM_MAX_IMAGES_LIMIT, remaining));
+    },
+    value: {
+      get(): number {
+        const v = this.config?.sequential_image_generation_options?.max_images;
+        return typeof v === 'number' && v >= 1 ? v : SEEDREAM_DEFAULT_MAX_IMAGES;
+      },
+      set(val: number) {
+        const cfg = { ...(this.config || {}) };
+        const next = Math.max(1, Math.min(this.effectiveMax, Math.floor(val || 1)));
+        if (next > 1) {
+          cfg.sequential_image_generation = 'auto';
+          cfg.sequential_image_generation_options = {
+            ...(cfg.sequential_image_generation_options || {}),
+            max_images: next
+          };
+        } else {
+          // count=1 -> revert to single-image mode and drop the options object
+          // so we don't ship a misleading payload to the upstream.
+          cfg.sequential_image_generation = 'disabled';
+          if (cfg.sequential_image_generation_options) {
+            delete cfg.sequential_image_generation_options;
+          }
+        }
+        this.$store.commit('seedream/setConfig', cfg);
+      }
+    }
+  },
+  watch: {
+    // If the user switches to a model that doesn't support group generation
+    // (e.g. doubao-seedream-3.0-t2i), strip the multi-image fields so the
+    // request stays valid.
+    supported: {
+      immediate: true,
+      handler(v: boolean) {
+        if (v) return;
+        const cfg = { ...(this.config || {}) };
+        let dirty = false;
+        if (cfg.sequential_image_generation) {
+          delete cfg.sequential_image_generation;
+          dirty = true;
+        }
+        if (cfg.sequential_image_generation_options) {
+          delete cfg.sequential_image_generation_options;
+          dirty = true;
+        }
+        if (dirty) this.$store.commit('seedream/setConfig', cfg);
+      }
+    },
+    // If the user shrinks the picker by uploading more reference images,
+    // clamp the stored value so it stays valid.
+    effectiveMax(max: number) {
+      if (this.value > max) {
+        this.value = max;
+      }
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.field {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+
+  .label {
+    width: 30%;
+    display: flex;
+    align-items: center;
+
+    .box {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+
+      .title {
+        font-size: 14px;
+        margin: 0;
+      }
+
+      .info {
+        margin-left: 6px;
+      }
+    }
+  }
+
+  .value {
+    width: 160px;
+    display: flex;
+    justify-content: flex-end;
+
+    .counter {
+      width: 140px;
+    }
+  }
+}
+</style>

--- a/src/components/seedream/config/ModelSelector.vue
+++ b/src/components/seedream/config/ModelSelector.vue
@@ -21,6 +21,7 @@ import {
   SEEDREAM_MODEL_3_0_T2I,
   SEEDREAM_MODEL_4_0,
   SEEDREAM_MODEL_4_5,
+  SEEDREAM_MODEL_5_0,
   SEEDREAM_MODEL_SEEDEDIT_3_0_I2I
 } from '@/constants';
 
@@ -34,6 +35,10 @@ export default defineComponent({
   data() {
     return {
       options: [
+        {
+          value: SEEDREAM_MODEL_5_0,
+          label: this.$t('seedream.model.seedream50')
+        },
         {
           value: SEEDREAM_MODEL_4_5,
           label: this.$t('seedream.model.seedream45')

--- a/src/components/seedream/config/SizeSelector.vue
+++ b/src/components/seedream/config/SizeSelector.vue
@@ -23,7 +23,13 @@
 import { defineComponent } from 'vue';
 import { ElSelect, ElOption } from 'element-plus';
 import InfoIcon from '@/components/common/InfoIcon.vue';
-import { SEEDREAM_DEFAULT_SIZE, SEEDREAM_SIZE_1K, SEEDREAM_SIZE_2K, SEEDREAM_SIZE_4K } from '@/constants';
+import {
+  SEEDREAM_DEFAULT_SIZE,
+  SEEDREAM_SIZE_1K,
+  SEEDREAM_SIZE_2K,
+  SEEDREAM_SIZE_3K,
+  SEEDREAM_SIZE_4K
+} from '@/constants';
 
 export default defineComponent({
   name: 'SeedreamSizeSelector',
@@ -37,6 +43,7 @@ export default defineComponent({
       options: [
         { value: SEEDREAM_SIZE_1K, label: SEEDREAM_SIZE_1K },
         { value: SEEDREAM_SIZE_2K, label: SEEDREAM_SIZE_2K },
+        { value: SEEDREAM_SIZE_3K, label: SEEDREAM_SIZE_3K },
         { value: SEEDREAM_SIZE_4K, label: SEEDREAM_SIZE_4K }
       ]
     };

--- a/src/constants/seedream.ts
+++ b/src/constants/seedream.ts
@@ -4,6 +4,7 @@ export const SEEDREAM_LOGO = 'https://cdn.acedata.cloud/9egrbn.png';
 
 export const SEEDREAM_MODEL_4_0 = 'doubao-seedream-4-0-250828';
 export const SEEDREAM_MODEL_4_5 = 'doubao-seedream-4-5-251128';
+export const SEEDREAM_MODEL_5_0 = 'doubao-seedream-5-0-260128';
 export const SEEDREAM_MODEL_3_0_T2I = 'doubao-seedream-3-0-t2i-250415';
 export const SEEDREAM_MODEL_SEEDEDIT_3_0_I2I = 'doubao-seededit-3-0-i2i-250628';
 
@@ -11,13 +12,30 @@ export const SEEDREAM_DEFAULT_MODEL = SEEDREAM_MODEL_4_5;
 
 export const SEEDREAM_SIZE_1K = '1K';
 export const SEEDREAM_SIZE_2K = '2K';
+export const SEEDREAM_SIZE_3K = '3K';
 export const SEEDREAM_SIZE_4K = '4K';
 
 export const SEEDREAM_DEFAULT_SIZE = SEEDREAM_SIZE_2K;
 
 export const SEEDREAM_DEFAULT_WATERMARK = false;
 
+// Group / multi-image generation:
+// Volcengine LAS supports up to 15 images per request when
+// `sequential_image_generation=auto`, gated by:
+//   (input reference images) + (generated images) <= 15.
+// 4.0 / 4.5 / 5.0 are the only models that support it; 3.0-t2i and
+// seededit-3.0-i2i are single-image only.
+export const SEEDREAM_MAX_IMAGES_LIMIT = 15;
+export const SEEDREAM_DEFAULT_MAX_IMAGES = 1;
+export const SEEDREAM_GROUP_GENERATION_MODELS: string[] = [SEEDREAM_MODEL_5_0, SEEDREAM_MODEL_4_5, SEEDREAM_MODEL_4_0];
+
+export const supportsSeedreamGroupGeneration = (model?: string): boolean => {
+  if (!model) return false;
+  return SEEDREAM_GROUP_GENERATION_MODELS.includes(model);
+};
+
 export const SEEDREAM_MODEL_FULL_TO_SHORT: Record<string, string> = {
+  [SEEDREAM_MODEL_5_0]: 'doubao-seedream-5.0',
   [SEEDREAM_MODEL_4_5]: 'doubao-seedream-4.5',
   [SEEDREAM_MODEL_4_0]: 'doubao-seedream-4.0',
   [SEEDREAM_MODEL_3_0_T2I]: 'doubao-seedream-3.0-t2i',

--- a/src/i18n/en/seedream.json
+++ b/src/i18n/en/seedream.json
@@ -138,5 +138,17 @@
   "model.seededit30i2i": {
     "message": "doubao-seededit-3.0-i2i",
     "description": "SeeEdit 3.0 i2i model option"
+  },
+  "model.seedream50": {
+    "message": "doubao-seedream-5.0",
+    "description": "SeeDream 5.0 model option (supports group generation and streaming)"
+  },
+  "name.maxImages": {
+    "message": "Image count",
+    "description": "Number of images for group generation (max_images)"
+  },
+  "description.maxImages": {
+    "message": "How many images to generate in a single request (1-15). Set to 1 for single-image mode; values >1 automatically enable group generation (sequential_image_generation=auto) which keeps character, style and details consistent across images. Supported on doubao-seedream-5.0 / 4.5 / 4.0 only. With reference images, the constraint is (reference image count + generated count) ≤ 15. Billed per actually generated image.",
+    "description": "Description of the max_images parameter"
   }
 }

--- a/src/i18n/zh-CN/seedream.json
+++ b/src/i18n/zh-CN/seedream.json
@@ -138,5 +138,17 @@
   "model.seededit30i2i": {
     "message": "doubao-seededit-3.0-i2i",
     "description": "SeeEdit 3.0 i2i 模型选项"
+  },
+  "model.seedream50": {
+    "message": "doubao-seedream-5.0",
+    "description": "SeeDream 5.0 模型选项（支持组图与流式输出）"
+  },
+  "name.maxImages": {
+    "message": "图片张数",
+    "description": "组图生成的图片张数（max_images）"
+  },
+  "description.maxImages": {
+    "message": "一次请求生成的图片数量（1-15）。设为 1 时为单图模式；大于 1 时自动启用组图（sequential_image_generation=auto），跨图保持角色、风格与细节一致。仅支持 doubao-seedream-5.0 / 4.5 / 4.0；如同时上传参考图，需满足 (参考图数 + 生成数) ≤ 15。计费按实际生成的图片张数。",
+    "description": "max_images 参数说明"
   }
 }

--- a/src/models/seedream.ts
+++ b/src/models/seedream.ts
@@ -1,3 +1,7 @@
+export interface ISeedreamSequentialOptions {
+  max_images?: number;
+}
+
 export interface ISeedreamConfig {
   model?: string;
   prompt?: string;
@@ -5,6 +9,7 @@ export interface ISeedreamConfig {
   size?: string;
   seed?: number;
   sequential_image_generation?: 'auto' | 'disabled';
+  sequential_image_generation_options?: ISeedreamSequentialOptions;
   stream?: boolean;
   guidance_scale?: number;
   response_format?: 'url' | 'b64_json';
@@ -19,6 +24,7 @@ export interface ISeedreamGenerateRequest {
   size?: string;
   seed?: number;
   sequential_image_generation?: 'auto' | 'disabled';
+  sequential_image_generation_options?: ISeedreamSequentialOptions;
   stream?: boolean;
   guidance_scale?: number;
   response_format?: 'url' | 'b64_json';


### PR DESCRIPTION
## Why

Followup to https://github.com/AceDataCloud/PlatformBackend/pull/403 + https://github.com/AceDataCloud/PlatformService/pull/833, which exposed Seedream's group-generation capability through OpenAPI and fixed the per-image billing path. The Nexior Studio UI at https://studio.acedata.cloud/seedream/index still only ever asked for a single image.

## What

Three user-visible improvements in the Seedream tab:

| | Before | After |
|---|---|---|
| Models | 4.5 / 4.0 / 3.0-t2i / seededit-3.0-i2i | + **doubao-seedream-5.0** (260128) |
| Sizes | 1K / 2K / 4K | + **3K** (5.0 supports it) |
| Image count | always 1 | **1-15** spinner (`Image count` field) — values >1 auto-enable `sequential_image_generation=auto` and group generation kicks in |
| Cost preview | always `unit × 1` | `unit × selectedCount` so users see the real Credits cost (e.g. 5.0 × 4 = 1.4 Credits, not 0.35) |

Group generation keeps character / style / details consistent across the returned set — the headline use case behind the upstream feature.

### Files

| File | Change |
|---|---|
| [`src/constants/seedream.ts`](src/constants/seedream.ts) | `SEEDREAM_MODEL_5_0`, `SEEDREAM_SIZE_3K`, `SEEDREAM_MAX_IMAGES_LIMIT=15`, `SEEDREAM_GROUP_GENERATION_MODELS`, `supportsSeedreamGroupGeneration()` helper. Adds 5.0 to `SEEDREAM_MODEL_FULL_TO_SHORT` so the cost-rule lookup matches. |
| [`src/models/seedream.ts`](src/models/seedream.ts) | New `ISeedreamSequentialOptions`; `sequential_image_generation_options` added to `ISeedreamConfig` and `ISeedreamGenerateRequest`. |
| [`src/components/seedream/config/MaxImagesSelector.vue`](src/components/seedream/config/MaxImagesSelector.vue) **(new)** | `el-input-number`, hidden when the active model doesn't support group generation. Upper bound auto-clamps to `15 - referenceImageCount` so the user can't pick a value upstream will reject. When the user switches to a single-image-only model the watcher strips the multi-image fields so the request stays valid. |
| [`src/components/seedream/config/SizeSelector.vue`](src/components/seedream/config/SizeSelector.vue) | + 3K option. |
| [`src/components/seedream/config/ModelSelector.vue`](src/components/seedream/config/ModelSelector.vue) | + 5.0 option. |
| [`src/components/seedream/ConfigPanel.vue`](src/components/seedream/ConfigPanel.vue) | Render `<max-images-selector />`; consumption display multiplies by `sequential_image_generation_options.max_images` when group generation is active. |
| [`src/i18n/zh-CN/seedream.json`](src/i18n/zh-CN/seedream.json) + [`src/i18n/en/seedream.json`](src/i18n/en/seedream.json) | `name.maxImages` / `description.maxImages` / `model.seedream50`. Other 16 locales picked up by translate.py CronJob. |

### Edge cases handled

- **Switch model away from 4.x/5.0** → watcher in `MaxImagesSelector.vue` strips `sequential_image_generation` + `sequential_image_generation_options`, so a switch to seededit-3.0 doesn't ship invalid params.
- **Upload many reference images** → spinner upper bound shrinks live; if the stored value exceeds the new max it's clamped down.
- **Spinner set back to 1** → `sequential_image_generation` flips back to `disabled` and the options object is dropped, restoring the exact single-image payload that's been working.
- **Cost rule already supports `count`** ([`PlatformBackend/cost/api/86ad30f3-…json`](https://github.com/AceDataCloud/PlatformBackend/blob/main/cost/api/86ad30f3-0bc8-4b9b-b019-b9fa5b05672e.json)) — no backend change needed.

## Verification

```
$ npx vue-tsc --noEmit --skipLibCheck     # clean
$ npx eslint src/components/seedream src/constants/seedream.ts src/models/seedream.ts
0 errors, 0 warnings
```

Suggest manual smoke test post-deploy at https://studio.acedata.cloud/seedream/index:

1. Pick `doubao-seedream-5.0` → Image count spinner appears.
2. Set count = 4, prompt 「The same orange tabby in 4 different poses, sunset beach, photorealistic」, Generate → 4 consistent images returned, Credits deducted = `4 × 0.35 = 1.40`.
3. Switch to `doubao-seedream-3.0-t2i` → Image count spinner disappears, request shape reverts to single-image.
4. Upload 14 reference images → spinner caps at 1 (15 - 14 = 1).
