### PR TITLE
feat(chat): show soft character counter in composer for long prompts

### DIFF
--- a/change/@acedatacloud-nexior-f1671df9-a6d7-4557-b4aa-5d15431490cd.json
+++ b/change/@acedatacloud-nexior-f1671df9-a6d7-4557-b4aa-5d15431490cd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Show a soft character counter in the chat composer once prompts grow past 800 chars; warn at 50k. No hard cap.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/Composer.vue
+++ b/src/components/chat/Composer.vue
@@ -49,6 +49,27 @@
       @keydown.enter.exact="onEnterKey"
       @input="adjustTextareaHeight"
     ></textarea>
+    <!--
+      Soft character counter. Hidden for short prompts (<800 chars) to avoid
+      visual noise; shows once the input is non-trivial; turns warning-orange
+      past 50k chars to flag prompts that are likely to bump into model
+      context limits or upstream payload caps. Intentionally NOT a hard cap:
+      different models have very different context windows and we don't want
+      to falsely block a Claude/Gemini long-context user.
+    -->
+    <el-tooltip
+      v-if="questionValue && questionValue.length >= COUNTER_VISIBLE_AT"
+      :content="
+        questionValue.length >= COUNTER_WARN_AT
+          ? $t('chat.composer.charactersWarning')
+          : $t('chat.composer.charactersHint')
+      "
+      placement="top"
+    >
+      <span :class="['char-counter', { warning: questionValue.length >= COUNTER_WARN_AT }]" aria-live="polite">
+        {{ questionValue.length.toLocaleString() }}
+      </span>
+    </el-tooltip>
     <div class="tools">
       <el-dropdown trigger="click" placement="top-start" :hide-on-click="true" popper-class="composer-plus-popper">
         <!--
@@ -60,7 +81,11 @@
         -->
         <span class="btn-plus-trigger">
           <el-tooltip class="box-item" effect="dark" :content="$t('chat.composer.addAction')" placement="top">
-            <span :class="{ btn: true, 'btn-plus': true, disabled: answering }" :aria-disabled="answering" role="button">
+            <span
+              :class="{ btn: true, 'btn-plus': true, disabled: answering }"
+              :aria-disabled="answering"
+              role="button"
+            >
               <font-awesome-icon icon="fa-solid fa-plus" class="icon icon-plus" />
             </span>
           </el-tooltip>
@@ -171,7 +196,16 @@ export default defineComponent({
       inputHeight: '35px',
       questionValue: this.question || '',
       fileList: [] as UploadFile[],
-      uploadUrl: getBaseUrlPlatform() + '/api/v1/files/'
+      uploadUrl: getBaseUrlPlatform() + '/api/v1/files/',
+      // Soft thresholds for the composer character counter. Stay invisible
+      // during normal chat use (most messages are < 200 chars); show once
+      // the input is "essay-length"; warning-orange past a length where
+      // shorter-context endpoints (some image-edit / TTS / older models)
+      // start rejecting payloads. Intentionally NOT a hard cap — different
+      // models have very different context windows and a long-context
+      // Claude / Gemini user is legitimate.
+      COUNTER_VISIBLE_AT: 800,
+      COUNTER_WARN_AT: 50000
     };
   },
   computed: {
@@ -391,7 +425,9 @@ textarea.input:focus {
   box-shadow:
     0 2px 6px rgba(0, 0, 0, 0.04),
     0 1px 2px rgba(0, 0, 0, 0.04);
-  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
   padding: 6px;
 
   &:focus-within {
@@ -429,6 +465,31 @@ textarea.input:focus {
     margin-top: 5px;
     font-size: 16px;
     margin-bottom: 50px;
+  }
+  .char-counter {
+    // Sits in the bottom-right corner of the composer, immediately to the
+    // left of the send button. Subtle by default; the parent toggles a
+    // .warning class once the prompt is long enough to risk upstream
+    // rejection.
+    position: absolute;
+    right: 100px;
+    bottom: 18px;
+    font-size: 12px;
+    line-height: 1;
+    color: var(--el-text-color-secondary);
+    background-color: var(--el-fill-color-light);
+    border-radius: 10px;
+    padding: 3px 8px;
+    user-select: none;
+    pointer-events: auto;
+    transition:
+      color 0.15s ease,
+      background-color 0.15s ease;
+    &.warning {
+      color: var(--el-color-warning);
+      background-color: var(--el-color-warning-light-9);
+      font-weight: 600;
+    }
   }
   .tools {
     position: absolute;

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -439,6 +439,14 @@
     "message": "连接",
     "description": "加号按钮弹出菜单中的项：打开连接管理"
   },
+  "composer.charactersHint": {
+    "message": "字符数",
+    "description": "输入框右下角字符计数小标签的悬停提示，告知用户该数字代表已输入的字符数；徽标本身已显示数字，因此提示语只需补充含义"
+  },
+  "composer.charactersWarning": {
+    "message": "输入内容过长，可能超出部分模型的上下文限制，建议精简后再发送",
+    "description": "输入框右下角字符计数变成警告色（橙色）时显示的提示文案，提示用户提示词已过长、可能被部分模型拒绝；不会强制阻止发送"
+  },
   "agent.title": {
     "message": "桌面代理",
     "description": "代理管理对话框标题"


### PR DESCRIPTION
## Why

Followup to the user-feedback review tracked in `.plans/USER-FEEDBACK-2026-05-04.md` and `.plans/NEXIOR-GAPS-2026-05-04.md` (gap #5). The user reported wanting a per-model length check before pressing Generate — but **per-model hard caps are unsafe** in this codebase: we route to GPT-4o (128k tokens), Claude Sonnet 4.5 (200k), Gemini 2.5 (1M), short-context image-edit / TTS (≤4k chars), etc., and the active model can change mid-conversation. A wrong cap would falsely block legitimate long-context Claude / Gemini users.

So instead, this PR introduces a **soft, model-agnostic character counter** that:

- Is invisible during normal chat use (most messages are < 200 chars).
- Becomes visible once the prompt grows past 800 chars (`COUNTER_VISIBLE_AT`).
- Turns warning-orange past 50,000 chars (`COUNTER_WARN_AT`) — the length where the shorter-context models we route to (some image-edit endpoints, older models) start rejecting payloads.
- **Never disables the send button** — it's awareness, not policing. A user with a 200k-char Claude prompt is a fine user.

## What

Single component change in [`src/components/chat/Composer.vue`](src/components/chat/Composer.vue):

| Hunk | Change |
|---|---|
| Template | New `<el-tooltip><span class="char-counter">…</span></el-tooltip>` rendered when `questionValue.length >= COUNTER_VISIBLE_AT`. The `.warning` class flips on past `COUNTER_WARN_AT`. Tooltip content swaps between hint / warning copy. |
| `data()` | + `COUNTER_VISIBLE_AT: 800`, `COUNTER_WARN_AT: 50000` (kept on the instance so the template can reference them; documented inline so future changes don't drift) |
| Style block | New `.char-counter` block: bottom-right of the composer (next to the send button), `var(--el-fill-color-light)` rounded badge by default, `var(--el-color-warning-light-9)` orange when `.warning` is on. `aria-live="polite"` for a11y. |
| i18n | + `chat.composer.charactersHint` / `chat.composer.charactersWarning` in [`src/i18n/zh-CN/chat.json`](src/i18n/zh-CN/chat.json). The other 17 locales fan out via the existing translate workflow. |

## Why no hard cap

Looked at all the alternatives:

1. **Per-model `max_tokens` lookup** — would need a new `Service.metadata.context_window` field (PlatformBackend schema change), a per-message tokenizer estimation in the browser, and a real-time refetch when the user switches models mid-conversation. Disproportionate for this UX win.
2. **Simple character cap, e.g. 4000** — too small for Claude / Gemini long-context flows. Falsely blocks the most expensive, highest-LTV users.
3. **No counter at all** — the user explicitly asked for length awareness.

The soft counter is the smallest thing that meaningfully addresses the feedback without taking a risky stance on per-model limits. If we later expose `Service.metadata.input_limits` from PlatformBackend, the threshold can switch from a hardcoded constant to a model-aware lookup with no template change.

## Verification

```
$ vue-tsc --noEmit --skipLibCheck                # clean
$ eslint src/components/chat/Composer.vue        # clean
```

Suggest manual smoke once deployed:

1. Open https://studio.acedata.cloud/chatgpt/conversations.
2. Type a < 200-char message → no counter visible (normal chat).
3. Paste 1000 chars → small grey badge appears bottom-right showing `1,000`. Hover → tooltip "字符数" / "Characters".
4. Paste 60,000 chars → badge turns orange, bold; hover → tooltip "输入内容过长，可能超出部分模型的上下文限制，建议精简后再发送".
5. Send button still active throughout — never blocks the user.

## Closes

Item #5 in [`.plans/NEXIOR-GAPS-2026-05-04.md`](https://github.com/AceDataCloud/AceDataCloud/blob/main/.plans/NEXIOR-GAPS-2026-05-04.md).
