### PR TITLE
fix(chat): citation chips show source name + favicon, suppress before metadata lands

### DIFF
--- a/src/components/chat/CitationCard.vue
+++ b/src/components/chat/CitationCard.vue
@@ -1,9 +1,17 @@
 <template>
   <a class="citation-card" :href="citation.url" target="_blank" rel="noopener noreferrer">
-    <div v-if="citation.source || citation.icon" class="head">
-      <img v-if="citation.icon" :src="citation.icon" :alt="citation.source || ''" class="icon" />
+    <div class="head">
+      <img
+        v-if="resolvedIcon"
+        :src="resolvedIcon"
+        :alt="citation.source || ''"
+        class="icon"
+        referrerpolicy="no-referrer"
+        loading="lazy"
+        @error="onIconError"
+      />
       <font-awesome-icon v-else :icon="fallbackIcon" class="icon-fallback" />
-      <span v-if="citation.source" class="source">{{ citation.source }}</span>
+      <span v-if="citation.source || hostLabel" class="source">{{ citation.source || hostLabel }}</span>
     </div>
     <div v-if="citation.title" class="title">{{ citation.title }}</div>
     <div v-if="citation.snippet" class="snippet">{{ citation.snippet }}</div>
@@ -14,15 +22,19 @@
 <script lang="ts">
 /**
  * Hover-card body for a single source citation. Rendered inside an
- * `<el-popover>` virtually-anchored to a `[N]` chip in the markdown
+ * `<el-popover>` virtually-anchored to a name-tag chip in the markdown
  * stream by `MarkdownRenderer.vue`. The whole card is itself a link to
  * the source URL — clicking anywhere on the card opens the source in a
  * new tab, mirroring the chip's own click behaviour so users don't
- * have to aim at the small superscript.
+ * have to aim at the small inline tag.
  */
 import { defineComponent, type PropType } from 'vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import type { IChatCitation } from '@/models';
+
+interface IData {
+  iconFailed: boolean;
+}
 
 export default defineComponent({
   name: 'CitationCard',
@@ -32,6 +44,9 @@ export default defineComponent({
       type: Object as PropType<IChatCitation>,
       required: true
     }
+  },
+  data(): IData {
+    return { iconFailed: false };
   },
   computed: {
     /** Hostname-only display so a 200-char URL doesn't blow up the card. */
@@ -43,7 +58,35 @@ export default defineComponent({
         return this.citation.url;
       }
     },
-    /** Type-driven icon when the citation didn't carry a logo URL. */
+    /** Bare host for the surface label fallback (`docs.google.com`). */
+    hostLabel(): string {
+      try {
+        return new URL(this.citation.url).host.replace(/^www\./, '');
+      } catch {
+        return '';
+      }
+    },
+    /**
+     * Icon URL to render at the top of the card. Preference:
+     *   1. `citation.icon` — model-supplied logo when it actually
+     *      knows the brand (e.g. an MCP server populates this).
+     *   2. Google's S2 favicon CDN keyed by the URL host. Free, no
+     *      auth, returns a transparent fallback for unknown sites.
+     * If both render attempts fail (rare CDN error), we drop back to
+     * the type-driven Font Awesome fallback below.
+     */
+    resolvedIcon(): string {
+      if (this.iconFailed) return '';
+      if (this.citation.icon) return this.citation.icon;
+      try {
+        const host = new URL(this.citation.url).host;
+        if (!host) return '';
+        return `https://www.google.com/s2/favicons?domain=${encodeURIComponent(host)}&sz=64`;
+      } catch {
+        return '';
+      }
+    },
+    /** Type-driven icon when neither `icon` nor a favicon is available. */
     fallbackIcon(): string {
       const t = (this.citation.type || '').toLowerCase();
       if (t === 'file') return 'fa-solid fa-file-lines';
@@ -54,6 +97,11 @@ export default defineComponent({
       if (t === 'web') return 'fa-solid fa-globe';
       return 'fa-solid fa-link';
     }
+  },
+  methods: {
+    onIconError(): void {
+      this.iconFailed = true;
+    }
   }
 });
 </script>
@@ -61,45 +109,57 @@ export default defineComponent({
 <style lang="scss" scoped>
 .citation-card {
   display: block;
-  width: 320px;
+  width: 340px;
   max-width: 80vw;
-  padding: 10px 12px;
+  padding: 14px 16px;
   font-size: 12.5px;
-  line-height: 1.45;
+  line-height: 1.5;
   color: inherit;
   text-decoration: none;
   cursor: pointer;
+  border-radius: 16px;
+  transition: background 0.15s ease;
+
+  &:hover {
+    background: rgba(15, 23, 42, 0.03);
+  }
 
   .head {
     display: flex;
     align-items: center;
-    gap: 6px;
-    margin-bottom: 6px;
+    gap: 8px;
+    margin-bottom: 8px;
     color: var(--el-text-color-secondary, #6b7280);
     font-size: 12px;
 
     .icon {
-      width: 14px;
-      height: 14px;
+      width: 18px;
+      height: 18px;
+      flex: 0 0 18px;
       object-fit: contain;
-      flex: 0 0 14px;
+      border-radius: 4px;
+      background: rgba(15, 23, 42, 0.04);
+      padding: 1px;
     }
 
     .icon-fallback {
-      width: 12px;
-      height: 12px;
-      flex: 0 0 12px;
+      width: 14px;
+      height: 14px;
+      flex: 0 0 14px;
     }
 
     .source {
-      font-weight: 500;
+      font-weight: 600;
+      letter-spacing: 0.01em;
+      color: var(--el-text-color-regular, #374151);
     }
   }
 
   .title {
     font-weight: 600;
     color: var(--el-text-color-primary, #111827);
-    margin-bottom: 4px;
+    margin-bottom: 6px;
+    font-size: 13.5px;
     overflow: hidden;
     text-overflow: ellipsis;
     display: -webkit-box;
@@ -110,7 +170,7 @@ export default defineComponent({
 
   .snippet {
     color: var(--el-text-color-regular, #374151);
-    margin-bottom: 6px;
+    margin-bottom: 8px;
     overflow: hidden;
     text-overflow: ellipsis;
     display: -webkit-box;
@@ -125,6 +185,42 @@ export default defineComponent({
     text-overflow: ellipsis;
     white-space: nowrap;
     direction: ltr;
+    border-top: 1px solid rgba(15, 23, 42, 0.06);
+    padding-top: 8px;
+    margin-top: 4px;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .citation-card {
+    &:hover {
+      background: rgba(255, 255, 255, 0.04);
+    }
+
+    .head {
+      color: rgba(255, 255, 255, 0.6);
+
+      .icon {
+        background: rgba(255, 255, 255, 0.06);
+      }
+
+      .source {
+        color: rgba(255, 255, 255, 0.85);
+      }
+    }
+
+    .title {
+      color: #f3f4f6;
+    }
+
+    .snippet {
+      color: rgba(255, 255, 255, 0.78);
+    }
+
+    .url {
+      color: rgba(255, 255, 255, 0.55);
+      border-top-color: rgba(255, 255, 255, 0.08);
+    }
   }
 }
 </style>

--- a/src/components/common/MarkdownRenderer.vue
+++ b/src/components/common/MarkdownRenderer.vue
@@ -18,7 +18,7 @@
       trigger="hover"
       :visible="popoverVisible"
       placement="top"
-      :width="320"
+      :width="340"
       popper-class="citation-popover"
       :show-arrow="true"
       :hide-after="120"
@@ -39,11 +39,11 @@ import 'highlight.js/styles/night-owl.css';
 
 /**
  * Marker token the worker injects in place of every `<acite>` tag. We
- * substitute it for an inline `[N]` chip BEFORE handing the source to
- * the markdown renderer so the chip lives at exactly the position the
- * model wanted it. The id charset matches the worker's parser
- * (`tagParser.ts`'s `parseAciteTag`) so a marker that survives upstream
- * round-trips through here losslessly.
+ * substitute it for an inline name-tag chip BEFORE handing the source
+ * to the markdown renderer so the chip lives at exactly the position
+ * the model wanted it. The id charset matches the worker's parser
+ * (`tagParser.ts`'s `parseAciteTag`) so a marker that survives
+ * upstream round-trips through here losslessly.
  */
 const CITATION_MARKER = /\[\^acite:([A-Za-z0-9_-]{1,32})\]/g;
 
@@ -73,10 +73,11 @@ export default defineComponent({
      * Sidecar map of citations referenced by `[^acite:<id>]` markers
      * inside `content`. Streamed onto the assistant message by
      * `Conversation.vue` and persisted on `IChatMessage.citations` so
-     * reload re-renders the same chips. Markers without a matching
-     * entry render as a degraded `[?]` chip — never as raw
-     * `[^acite:1]` text — so a brief race between text and citation
-     * events doesn't surface garbage.
+     * reload re-renders the same chips. Markers WITHOUT a matching
+     * entry are suppressed entirely (rendered as a 0-width span) —
+     * this prevents the brief "[?]"-then-"[Google Drive]" flicker that
+     * was visible when the SSE stream delivered the text delta one
+     * tick before the citation event.
      */
     citations: {
       type: Object as PropType<Record<string, IChatCitation>>,
@@ -92,42 +93,32 @@ export default defineComponent({
     };
   },
   computed: {
-    /** First-occurrence id → display index (1, 2, 3, …) within this message. */
-    indexById(): Record<string, number> {
-      const order: Record<string, number> = {};
-      let next = 1;
-      const src = this.content || '';
-      // Walk markers in source order so the rendered chip number
-      // matches the model's intended footnote ordering. matchAll
-      // doesn't mutate `lastIndex` so it's safe to share the regex.
-      for (const m of src.matchAll(CITATION_MARKER)) {
-        const id = m[1];
-        if (!(id in order)) {
-          order[id] = next;
-          next += 1;
-        }
-      }
-      return order;
-    },
     /** `content` with every marker swapped for an inline chip HTML. */
     enrichedContent(): string {
       const src = this.content || '';
       if (!src.includes('[^acite:')) return src;
       const cites = this.citations || {};
-      const indexById = this.indexById;
       return src.replace(CITATION_MARKER, (_match, rawId: string) => {
-        const idx = indexById[rawId];
         const cite = cites[rawId];
-        const label = idx ? String(idx) : '?';
-        const url = cite?.url ? escapeAttr(cite.url) : '';
-        const title = cite?.title || cite?.source || cite?.url || rawId;
-        const titleAttr = escapeAttr(title);
+        // No metadata yet — suppress the chip entirely. Once the
+        // citation SSE event lands, Vue re-renders this computed and
+        // the chip pops in. Beats showing "[?]" or raw "[acite:1]" in
+        // the meantime.
+        if (!cite) return '';
+
+        const label = labelFor(cite);
+        const url = cite.url ? escapeAttr(cite.url) : '';
+        const titleAttr = escapeAttr(cite.title || cite.source || cite.url || rawId);
         const idAttr = escapeAttr(rawId);
+        const favicon = faviconUrl(cite);
+        const iconHtml = favicon
+          ? `<img class="citation-chip__icon" src="${escapeAttr(favicon)}" alt="" referrerpolicy="no-referrer" loading="lazy" />`
+          : '';
         // The chip itself is an anchor so click works without JS, even
         // when the popover is suppressed (touch / no-hover devices).
         // `data-citation-id` is what `onChipHover` reads for the popover.
-        const inner = `<a class="citation-chip__link"${url ? ` href="${url}"` : ''} target="_blank" rel="noopener noreferrer" tabindex="-1">[${escapeAttr(label)}]</a>`;
-        return `<sup class="citation-chip" data-citation-id="${idAttr}" title="${titleAttr}">${inner}</sup>`;
+        const inner = `<a class="citation-chip__link"${url ? ` href="${url}"` : ''} target="_blank" rel="noopener noreferrer" tabindex="-1">${iconHtml}<span class="citation-chip__label">${escapeAttr(label)}</span></a>`;
+        return `<span class="citation-chip" data-citation-id="${idAttr}" title="${titleAttr}">${inner}</span>`;
       });
     }
   },
@@ -161,6 +152,49 @@ export default defineComponent({
   }
 });
 
+/**
+ * Pick the human-readable tag label. Order of preference:
+ *   1. `source` ("Google Drive", "GitHub", "Notion") — short, branded,
+ *      what the model meant.
+ *   2. URL hostname stripped of `www.` — "openai.com", "wikipedia.org".
+ *   3. Truncated `title` — last-resort, may be long.
+ * Truncated to 24 chars to keep the chip from breaking wrapping
+ * behaviour on narrow lines.
+ */
+function labelFor(c: IChatCitation): string {
+  const raw =
+    c.source ||
+    (() => {
+      try {
+        return new URL(c.url).host.replace(/^www\./, '');
+      } catch {
+        return '';
+      }
+    })() ||
+    c.title ||
+    'source';
+  return raw.length > 24 ? raw.slice(0, 23) + '\u2026' : raw;
+}
+
+/**
+ * Resolve the inline favicon URL for a chip. Preference:
+ *   1. Citation-supplied `icon` (the model can specify a brand logo).
+ *   2. Google's S2 favicon CDN keyed by the URL host (free, public,
+ *      no signup, returns a transparent fallback for unknown sites).
+ * Empty string when the URL is unparseable — the chip just won't show
+ * an icon, which is fine.
+ */
+function faviconUrl(c: IChatCitation): string {
+  if (c.icon) return c.icon;
+  try {
+    const host = new URL(c.url).host;
+    if (!host) return '';
+    return `https://www.google.com/s2/favicons?domain=${encodeURIComponent(host)}&sz=64`;
+  } catch {
+    return '';
+  }
+}
+
 /** Tiny attribute-context HTML escape — enough for our chip output. */
 function escapeAttr(s: string): string {
   return s
@@ -180,10 +214,22 @@ function escapeAttr(s: string): string {
    to avoid leaking into other popovers. */
 .el-popover.citation-popover {
   padding: 0 !important;
-  border-radius: 10px;
+  border-radius: 16px !important;
+  overflow: hidden;
   box-shadow:
-    0 6px 24px rgba(15, 23, 42, 0.12),
-    0 1px 3px rgba(15, 23, 42, 0.08);
+    0 10px 32px rgba(15, 23, 42, 0.14),
+    0 2px 6px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(15, 23, 42, 0.06) !important;
+}
+
+@media (prefers-color-scheme: dark) {
+  .el-popover.citation-popover {
+    background: #1f2937 !important;
+    border-color: rgba(255, 255, 255, 0.06) !important;
+    box-shadow:
+      0 10px 32px rgba(0, 0, 0, 0.45),
+      0 2px 6px rgba(0, 0, 0, 0.3);
+  }
 }
 </style>
 
@@ -202,49 +248,74 @@ function escapeAttr(s: string): string {
   }
 
   /* Inline citation chip rendered in place of `[^acite:<id>]` markers.
-     Small, slightly raised, weakly tinted; never breaks the surrounding
-     text run so a paragraph with 5 citations stays one line of prose. */
+     Pill-shaped name tag (e.g. `Google Drive`) instead of a numeric
+     `[1]` superscript — readers can tell at a glance what backed the
+     claim without hovering. Sits on the text baseline (no superscript
+     vertical-shift) so chips embedded in table cells / list items
+     don't push their row taller than its neighbours. */
   :deep(.citation-chip) {
     display: inline-block;
-    margin: 0 1px 0 2px;
+    margin: 0 2px;
     padding: 0;
     line-height: 1;
-    vertical-align: super;
-    font-size: 0.72em;
     user-select: none;
+    /* Prevent the chip's contents from getting split across two lines
+       — happens when a label is long and the chip lands at a line
+       boundary. The label itself is already truncated to 24 chars. */
+    white-space: nowrap;
+    vertical-align: -1px;
 
     .citation-chip__link {
       display: inline-flex;
       align-items: center;
-      justify-content: center;
-      min-width: 18px;
-      height: 16px;
-      padding: 0 5px;
-      border-radius: 8px;
+      gap: 4px;
+      height: 18px;
+      padding: 0 8px 0 6px;
+      border-radius: 999px;
       background: rgba(39, 113, 134, 0.1);
-      color: #277186;
-      font-weight: 600;
+      color: #1f5a6b;
+      font-size: 0.78em;
+      font-weight: 500;
       text-decoration: none;
       transition:
-        background 0.12s ease,
-        color 0.12s ease;
+        background 0.15s ease,
+        color 0.15s ease,
+        transform 0.15s ease;
 
       &:hover {
         background: rgba(39, 113, 134, 0.18);
-        color: #1f5a6b;
+        color: #144859;
+        text-decoration: none;
+        transform: translateY(-0.5px);
       }
+    }
+
+    .citation-chip__icon {
+      width: 12px;
+      height: 12px;
+      flex: 0 0 12px;
+      object-fit: contain;
+      border-radius: 2px;
+      /* Hide broken-icon glyph if the favicon CDN 404s (rare). */
+      &[src=''] {
+        display: none;
+      }
+    }
+
+    .citation-chip__label {
+      letter-spacing: 0.01em;
     }
   }
 }
 
 @media (prefers-color-scheme: dark) {
   .markdown-body :deep(.citation-chip) .citation-chip__link {
-    background: rgba(255, 255, 255, 0.08);
-    color: #d1d5db;
+    background: rgba(148, 197, 211, 0.14);
+    color: #c7e0e8;
 
     &:hover {
-      background: rgba(255, 255, 255, 0.14);
-      color: #f9fafb;
+      background: rgba(148, 197, 211, 0.22);
+      color: #e6f3f7;
     }
   }
 }


### PR DESCRIPTION
## Why

While debugging https://studio.acedata.cloud/chatgpt/conversations/88005fa5-1d5c-4fb9-8567-8da6720e446a a user reported three things wrong with the new source-citation chips:

> 1. 显示不稳定（chip flickered briefly, then settled）
> 2. UI 太丑了，要 tag 形式，里面是名字（"Google Drive"）而不是数字
> 3. 圆角更大点 / 没有 favicon

## Fix

### 1. Stability

`MarkdownRenderer.vue` no longer renders a chip for markers whose citation hasn't arrived yet — the chip just isn't emitted (zero-width substitution) and pops in once `target.citations[id]` exists. Combined with the companion PlatformService PR (which re-orders SSE events so the worker emits the citation *before* the text containing the marker), the `[?]` → `[Google Drive]` flicker is gone both for the streaming case and for any future race during persisted-message re-hydration.

### 2. Name-tag UI (no more bare numbers)

Chip label now comes from, in order of preference:
1. `citation.source` — the model's intended brand label (`"Google Drive"`, `"GitHub"`, `"Notion"`)
2. URL hostname stripped of `www.` (`"openai.com"`, `"wikipedia.org"`)
3. `citation.title`, truncated

Capped at 24 chars (`Google Drive Slid…`) to keep wrapping behaviour stable when a chip lands at a line boundary. The chip itself is now `display: inline-block` + pill-shaped + tinted, no more superscript shift — embedded chips stop pushing their row taller than its neighbours, which was visible inside table cells.

### 3. Favicons + bigger rounded corners

Both the inline chip and the hover card get an icon resolved via:
1. `citation.icon` — model-supplied, when an MCP server populates it
2. **Google's S2 favicon CDN keyed by URL host** — `https://www.google.com/s2/favicons?domain=<host>&sz=64`. Free, no auth, transparent fallback for unknown sites.
3. Type-driven Font Awesome glyph (`fa-file-lines`, `fa-circle-dot`, …) only when both fail.

Hover card:
- Border radius `10px` → `16px`
- Padding `10×12` → `14×16`
- Title font `12.5px` → `13.5px`
- Divider line above the URL row
- `:hover` state on the whole card so it feels button-like
- Polished dark-mode palette (icon plate, source label, divider all distinguishable on `#1f2937`)

## Visual

| before | after |
|---|---|
| `[1]` superscript chip | `[favicon] Google Drive` pill chip |
| `[?]` flicker before metadata loads | nothing renders until metadata is in |
| sharp 10px popover | 16px popover with shadow + border |

## Verification

- `npx vue-tsc --noEmit --skipLibCheck` — clean
- `npx eslint src/components/common/MarkdownRenderer.vue src/components/chat/CitationCard.vue` — clean

## Companion

PlatformService PR: emit citation event before text-with-marker (closes the streaming race at the source) + per-conversation logging so the next "why isn't this showing" report is one CLS query away.
