### PR TITLE
feat(telemetry): integrate Tencent Cloud RUM (Aegis) for Nexior

### DIFF
--- a/change/@acedatacloud-nexior-rum-telemetry.json
+++ b/change/@acedatacloud-nexior-rum-telemetry.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(telemetry): integrate Tencent Cloud RUM (Aegis) for frontend errors, API speed, PV, and 6 business events (payment_initiated/failed/success, generation_submit/success/failed). No-op when VITE_RUM_PROJECT_ID is unset.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@solana/wallet-adapter-wallets": "^0.19.36",
         "@solana/web3.js": "^1.98.2",
         "@vueuse/motion": "^3.0.3",
+        "aegis-web-sdk": "^1.41.13",
         "axios": "^1.6.0",
         "chart.js": "^4.5.1",
         "codemirror": "^6.0.1",
@@ -8283,6 +8284,15 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/aegis-web-sdk": {
+      "version": "1.41.13",
+      "resolved": "https://registry.npmjs.org/aegis-web-sdk/-/aegis-web-sdk-1.41.13.tgz",
+      "integrity": "sha512-f7W1h28HJSPEjeZq+ZnPG33s5Ce0mxJh5ci3h4ky1pPFtRrzEZjQV5bHq24Ru22p+SYpmZC5RwBdQfWoYFKBnw==",
+      "license": "MIT",
+      "dependencies": {
+        "web-vitals": "^3.4.0"
       }
     },
     "node_modules/agent-base": {
@@ -17697,6 +17707,12 @@
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.5.2.tgz",
+      "integrity": "sha512-c0rhqNcHXRkY/ogGDJQxZ9Im9D19hDihbzSQJrsioex+KnFgmMzBiy57Z1EjkhX/+OjyBpclDCzz2ITtjokFmg==",
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@solana/wallet-adapter-wallets": "^0.19.36",
     "@solana/web3.js": "^1.98.2",
     "@vueuse/motion": "^3.0.3",
+    "aegis-web-sdk": "^1.41.13",
     "axios": "^1.6.0",
     "chart.js": "^4.5.1",
     "codemirror": "^6.0.1",

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import router from './router';
 import store from './store';
 import i18n from './i18n';
 import { handleChunkLoadError, initializeChunkLoadErrorHandler } from './utils/chunkLoadError';
+import { initTelemetry, setUser, captureError } from './plugins/telemetry';
 import './assets/scss/style.scss';
 import './assets/css/tailwind.css';
 import 'mac-scrollbar/dist/mac-scrollbar.css';
@@ -42,6 +43,14 @@ const main = async () => {
   // user/site/config are independent after token is set — run in parallel
   await Promise.all([initializeUser(), initializeSite(), initializeConfig()]);
 
+  // Telemetry: initialize after token+user so we already know who the visitor
+  // is. Safe no-op when VITE_RUM_PROJECT_ID is unset (local dev / preview).
+  // We don't `await` so a slow CDN can't block first paint.
+  void initTelemetry({
+    uin: store.getters.user?.id,
+    release: import.meta.env.VITE_APP_VERSION as string | undefined
+  });
+
   // non-async and no need to await
   initializeCurrency();
   initializeTheme();
@@ -52,6 +61,19 @@ const main = async () => {
   initializeFavicon();
 
   const app = createApp(App);
+
+  // Vue render errors → RUM. Keep the existing console behavior so devs
+  // still see the trace locally.
+  app.config.errorHandler = (err, _instance, info) => {
+    captureError(err, { source: 'vue', route: info });
+    console.error('[vue:errorHandler]', err, info);
+  };
+
+  // Unhandled promise rejections → RUM. The browser already logs these,
+  // we just attach them to the same dashboard.
+  window.addEventListener('unhandledrejection', (event) => {
+    captureError(event.reason, { source: 'unhandledrejection' });
+  });
 
   app.use(router);
   app.use(store);
@@ -70,6 +92,10 @@ const main = async () => {
   // lets the browser pick an idle moment when available.
   const scheduleFingerprint = () => {
     initializeFingerprint();
+    // Once the fingerprint resolves, attach it to the RUM session as the
+    // anonymous id (`aid`). This lets pre-login activity for the same device
+    // be threaded together in the dashboard.
+    setUser(store.getters.user?.id, store.getters.fingerprint);
   };
   if ('requestIdleCallback' in window) {
     (window as any).requestIdleCallback(scheduleFingerprint, { timeout: 4000 });

--- a/src/operators/common.ts
+++ b/src/operators/common.ts
@@ -1,5 +1,6 @@
 import store from '@/store';
 import { getBaseUrlPlatform } from '@/utils';
+import { trackApiFailure } from '@/plugins/telemetry';
 import axios, { AxiosInstance } from 'axios';
 import qs from 'qs';
 import { getCookie } from 'typescript-cookie';
@@ -50,6 +51,18 @@ httpClient.interceptors.response.use(
     const traceId = error?.response?.data?.trace_id || error?.response?.headers?.['x-request-id'];
     if (traceId) {
       console.error(`Request failed [trace_id=${traceId}]`, error?.response?.status, error?.response?.data);
+    }
+    // Forward 4xx/5xx to RUM with the server-side trace_id attached so the
+    // entry can be cross-referenced with PlatformGateway CLS logs. Network
+    // errors (no `response`) are still captured because Aegis's built-in
+    // `reportApiSpeed` covers them.
+    if (error?.response) {
+      trackApiFailure({
+        url: error.config?.url ?? '',
+        method: error.config?.method,
+        status: error.response.status,
+        trace_id: traceId
+      });
     }
     return Promise.reject(error);
   }

--- a/src/pages/console/application/Extra.vue
+++ b/src/pages/console/application/Extra.vue
@@ -112,6 +112,7 @@ import { ROUTE_CONSOLE_APPLICATION_SUBSCRIBE, ROUTE_CONSOLE_ORDER_DETAIL } from 
 import Price from '@/components/common/Price.vue';
 import { applicationOperator, orderOperator } from '@/operators';
 import { getPriceString } from '@/utils';
+import { track } from '@/plugins/telemetry';
 import ServiceEstimation from '@/components/service/Estimation.vue';
 
 interface IData {
@@ -238,6 +239,12 @@ export default defineComponent({
       }
       this.creating = true;
       const unit = this.$t(`service.unit.${this.application?.service?.unit}s`);
+      track('payment_initiated', {
+        service: this.application?.service?.alias,
+        amount: this.package?.amount,
+        package_id: this.package?.id,
+        action: 'extra'
+      });
       orderOperator
         .create({
           application_id: this.application?.id,
@@ -265,9 +272,14 @@ export default defineComponent({
             }
           });
         })
-        .catch(() => {
+        .catch((error) => {
           ElMessage.error(this.$t('order.message.createFailed'));
           this.creating = false;
+          track('payment_failed', {
+            service: this.application?.service?.alias,
+            action: 'extra',
+            error: error?.response?.data?.error?.message ?? String(error)
+          });
         });
     }
   }

--- a/src/pages/console/application/Subscribe.vue
+++ b/src/pages/console/application/Subscribe.vue
@@ -75,6 +75,7 @@ import { IService, IApplication, IApplicationType, IOrderDetailResponse, IPackag
 import { ElRow, ElCol, ElCard, ElSkeleton, ElMessage, ElButton, ElTag } from 'element-plus';
 import { applicationOperator, orderOperator, serviceOperator } from '@/operators';
 import { getPriceString } from '@/utils';
+import { track } from '@/plugins/telemetry';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { ROUTE_CONSOLE_APPLICATION_EXTRA, ROUTE_CONSOLE_ORDER_DETAIL } from '@/router';
 
@@ -271,6 +272,11 @@ export default defineComponent({
         this.creating = false;
         return;
       }
+      track('payment_initiated', {
+        service: this.service?.alias,
+        action: 'subscribe',
+        duration: subscription.duration
+      });
       orderOperator
         .create({
           application_ids: [this.application2.id],
@@ -286,9 +292,14 @@ export default defineComponent({
             }
           });
         })
-        .catch(() => {
+        .catch((error) => {
           ElMessage.error(this.$t('order.message.createFailed'));
           this.creating = false;
+          track('payment_failed', {
+            service: this.service?.alias,
+            action: 'subscribe',
+            error: error?.response?.data?.error?.message ?? String(error)
+          });
         });
     }
   }

--- a/src/pages/console/order/Detail.vue
+++ b/src/pages/console/order/Detail.vue
@@ -245,6 +245,7 @@ import X402PayOrder from '@/components/order/X402Pay.vue';
 import PaypalPayOrder from '@/components/order/PaypalPay.vue';
 import { IConfigResponse, IOrder, IOrderDetailResponse, OrderState } from '@/models';
 import { getPriceString } from '@/utils';
+import { track } from '@/plugins/telemetry';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 
 const POLL_INTERVAL_MS = 7000;
@@ -488,8 +489,18 @@ export default defineComponent({
       else this.stopOrderPolling();
     },
     order: {
-      handler(val) {
+      handler(val, oldVal) {
         if (val?.state === OrderState.PAID) {
+          // Fire once on the PENDING→PAID transition (the polling watcher
+          // re-runs on every refresh tick).
+          if (oldVal?.state !== OrderState.PAID) {
+            track('payment_success', {
+              order_id: val?.id,
+              pay_way: val?.pay_way,
+              service: val?.application?.service?.alias,
+              amount: val?.price
+            });
+          }
           this.x402Session = undefined;
           setTimeout(() => {
             if (this.redirect) {

--- a/src/pages/flux/Index.vue
+++ b/src/pages/flux/Index.vue
@@ -14,6 +14,7 @@ import { defineComponent } from 'vue';
 import Layout from '@/layouts/Flux.vue';
 import ConfigPanel from '@/components/flux/ConfigPanel.vue';
 import { fluxOperator } from '@/operators';
+import { instrumentGeneration } from '@/plugins/telemetry';
 import { IFluxGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
 import { ERROR_CODE_USED_UP } from '@/constants';
@@ -160,10 +161,7 @@ export default defineComponent({
         return;
       }
       ElMessage.info(this.$t('flux.message.startingTask'));
-      fluxOperator
-        .generate(request, {
-          token
-        })
+      instrumentGeneration('flux', fluxOperator.generate(request, { token }))
         .then(() => {
           ElMessage.success(this.$t('flux.message.startTaskSuccess'));
         })

--- a/src/pages/hailuo/Index.vue
+++ b/src/pages/hailuo/Index.vue
@@ -14,6 +14,7 @@ import { defineComponent } from 'vue';
 import Layout from '@/layouts/Hailuo.vue';
 import ConfigPanel from '@/components/hailuo/ConfigPanel.vue';
 import { hailuoOperator } from '@/operators';
+import { instrumentGeneration } from '@/plugins/telemetry';
 import { IHailuoGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
 import { ERROR_CODE_USED_UP } from '@/constants';
@@ -162,10 +163,7 @@ export default defineComponent({
         return;
       }
       ElMessage.info(this.$t('hailuo.message.startingTask'));
-      hailuoOperator
-        .generate(request, {
-          token
-        })
+      instrumentGeneration('hailuo', hailuoOperator.generate(request, { token }))
         .then(() => {
           ElMessage.success(this.$t('hailuo.message.startTaskSuccess'));
         })

--- a/src/pages/headshots/Index.vue
+++ b/src/pages/headshots/Index.vue
@@ -25,6 +25,7 @@ import { defineComponent } from 'vue';
 import Layout from '@/layouts/Headshots.vue';
 import ConfigPanel from '@/components/headshots/ConfigPanel.vue';
 import { applicationOperator, headshotsOperator } from '@/operators';
+import { instrumentGeneration } from '@/plugins/telemetry';
 import { IApplicationDetailResponse, IHeadshotsGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
 import { ERROR_CODE_DUPLICATION, ERROR_CODE_USED_UP } from '@/constants';
@@ -201,10 +202,7 @@ export default defineComponent({
         return;
       }
       ElMessage.info(this.$t('headshots.message.startingTask'));
-      headshotsOperator
-        .generate(request, {
-          token
-        })
+      instrumentGeneration('headshots', headshotsOperator.generate(request, { token }))
         .then(() => {
           ElMessage.success(this.$t('headshots.message.startTaskSuccess'));
           this.$store.commit('headshots/setConfig', {

--- a/src/pages/kling/Index.vue
+++ b/src/pages/kling/Index.vue
@@ -22,6 +22,7 @@ import ConfigPanel from '@/components/kling/ConfigPanel.vue';
 import MotionPanel from '@/components/kling/MotionPanel.vue';
 import TabSwitcher from '@/components/kling/TabSwitcher.vue';
 import { klingOperator } from '@/operators';
+import { instrumentGeneration } from '@/plugins/telemetry';
 import { IKlingGenerateRequest, IKlingMotionRequest, IKlingTaskType, Status } from '@/models';
 import { ElMessage } from 'element-plus';
 import { ERROR_CODE_USED_UP } from '@/constants';
@@ -208,10 +209,7 @@ export default defineComponent({
         return;
       }
       ElMessage.info(this.$t('kling.message.startingTask'));
-      klingOperator
-        .generate(request, {
-          token
-        })
+      instrumentGeneration('kling', klingOperator.generate(request, { token }))
         .then(() => {
           ElMessage.success(this.$t('kling.message.startTaskSuccess'));
         })
@@ -262,8 +260,7 @@ export default defineComponent({
         return;
       }
       ElMessage.info(this.$t('kling.message.startingTask'));
-      klingOperator
-        .motion(request, { token })
+      instrumentGeneration('kling', klingOperator.motion(request, { token }))
         .then(() => {
           ElMessage.success(this.$t('kling.message.startTaskSuccess'));
         })

--- a/src/pages/luma/Index.vue
+++ b/src/pages/luma/Index.vue
@@ -14,6 +14,7 @@ import { defineComponent } from 'vue';
 import Layout from '@/layouts/Luma.vue';
 import ConfigPanel from '@/components/luma/ConfigPanel.vue';
 import { lumaOperator } from '@/operators';
+import { instrumentGeneration } from '@/plugins/telemetry';
 import { ILumaGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
 import { ERROR_CODE_USED_UP } from '@/constants';
@@ -162,10 +163,7 @@ export default defineComponent({
         return;
       }
       ElMessage.info(this.$t('luma.message.startingTask'));
-      lumaOperator
-        .generate(request, {
-          token
-        })
+      instrumentGeneration('luma', lumaOperator.generate(request, { token }))
         .then(() => {
           ElMessage.success(this.$t('luma.message.startTaskSuccess'));
         })

--- a/src/pages/midjourney/Index.vue
+++ b/src/pages/midjourney/Index.vue
@@ -15,6 +15,7 @@ import Layout from '@/layouts/Midjourney.vue';
 import ConfigPanel from '@/components/midjourney/ConfigPanel.vue';
 import { ElMessage } from 'element-plus';
 import { midjourneyOperator } from '@/operators';
+import { instrumentGeneration } from '@/plugins/telemetry';
 import TaskList from '@/components/midjourney/tasks/TaskList.vue';
 import { ERROR_CODE_USED_UP } from '@/constants/errorCode';
 import { MidjourneyVideosAction, Status } from '@/models';
@@ -223,10 +224,7 @@ export default defineComponent({
         return;
       }
       ElMessage.info(this.$t('midjourney.message.startingTask'));
-      midjourneyOperator
-        .imagine(request, {
-          token
-        })
+      instrumentGeneration('midjourney', midjourneyOperator.imagine(request, { token }))
         .then(() => {
           ElMessage.success(this.$t('midjourney.message.startTaskSuccess'));
         })
@@ -262,10 +260,7 @@ export default defineComponent({
         return;
       }
       ElMessage.info(this.$t('midjourney.message.startingTask'));
-      midjourneyOperator
-        .videos(request, {
-          token
-        })
+      instrumentGeneration('midjourney', midjourneyOperator.videos(request, { token }))
         .then(() => {
           ElMessage.success(this.$t('midjourney.message.startVideosTaskSuccess'));
         })
@@ -291,10 +286,7 @@ export default defineComponent({
         return;
       }
       ElMessage.info(this.$t('midjourney.message.startingTask'));
-      midjourneyOperator
-        .describe(request, {
-          token
-        })
+      instrumentGeneration('midjourney', midjourneyOperator.describe(request, { token }))
         .then(() => {
           ElMessage.success(this.$t('midjourney.message.startDescribeTaskSuccess'));
         })

--- a/src/pages/nanobanana/Index.vue
+++ b/src/pages/nanobanana/Index.vue
@@ -14,6 +14,7 @@ import { defineComponent } from 'vue';
 import Layout from '@/layouts/Nanobanana.vue';
 import ConfigPanel from '@/components/nanobanana/ConfigPanel.vue';
 import { nanobananaOperator } from '@/operators';
+import { instrumentGeneration } from '@/plugins/telemetry';
 import { INanobananaGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
 import { ERROR_CODE_USED_UP, NANOBANANA_DEFAULT_RESOLUTION, NANOBANANA_MODEL_NANO_BANANA_PRO } from '@/constants';
@@ -185,10 +186,7 @@ export default defineComponent({
         return;
       }
       ElMessage.info(this.$t('nanobanana.message.startingTask'));
-      nanobananaOperator
-        .generate(request, {
-          token
-        })
+      instrumentGeneration('nanobanana', nanobananaOperator.generate(request, { token }))
         .then(() => {
           ElMessage.success(this.$t('nanobanana.message.startTaskSuccess'));
         })

--- a/src/pages/openaiimage/Index.vue
+++ b/src/pages/openaiimage/Index.vue
@@ -14,6 +14,7 @@ import { defineComponent } from 'vue';
 import Layout from '@/layouts/OpenAIImage.vue';
 import ConfigPanel from '@/components/openaiimage/ConfigPanel.vue';
 import { openaiimageOperator } from '@/operators';
+import { instrumentGeneration } from '@/plugins/telemetry';
 import { IOpenAIImageEditRequest, IOpenAIImageGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
 import { ERROR_CODE_USED_UP } from '@/constants';
@@ -187,13 +188,16 @@ export default defineComponent({
 
       ElMessage.info(this.$t('openaiimage.message.startingTask'));
 
-      const request = hasReferenceImages
-        ? openaiimageOperator.edit(editRequest, {
-            token
-          })
-        : openaiimageOperator.generate(generateRequest, {
-            token
-          });
+      const request = instrumentGeneration(
+        'openaiimage',
+        hasReferenceImages
+          ? openaiimageOperator.edit(editRequest, {
+              token
+            })
+          : openaiimageOperator.generate(generateRequest, {
+              token
+            })
+      );
 
       request
         .then((response) => {

--- a/src/pages/pika/Index.vue
+++ b/src/pages/pika/Index.vue
@@ -14,6 +14,7 @@ import { defineComponent } from 'vue';
 import Layout from '@/layouts/Pika.vue';
 import ConfigPanel from '@/components/pika/ConfigPanel.vue';
 import { applicationOperator, pikaOperator } from '@/operators';
+import { instrumentGeneration } from '@/plugins/telemetry';
 import { IApplicationDetailResponse, IPikaGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
 import { ERROR_CODE_DUPLICATION, ERROR_CODE_USED_UP } from '@/constants';
@@ -188,10 +189,7 @@ export default defineComponent({
         return;
       }
       ElMessage.info(this.$t('pika.message.startingTask'));
-      pikaOperator
-        .generate(request, {
-          token
-        })
+      instrumentGeneration('pika', pikaOperator.generate(request, { token }))
         .then(() => {
           ElMessage.success(this.$t('pika.message.startTaskSuccess'));
           this.$store.commit('pika/setConfig', {

--- a/src/pages/pixverse/Index.vue
+++ b/src/pages/pixverse/Index.vue
@@ -14,6 +14,7 @@ import { defineComponent } from 'vue';
 import Layout from '@/layouts/Pixverse.vue';
 import ConfigPanel from '@/components/pixverse/ConfigPanel.vue';
 import { pixverseOperator } from '@/operators';
+import { instrumentGeneration } from '@/plugins/telemetry';
 import { IPixverseGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
 import { ERROR_CODE_USED_UP } from '@/constants';
@@ -157,10 +158,7 @@ export default defineComponent({
         return;
       }
       ElMessage.info(this.$t('pixverse.message.startingTask'));
-      pixverseOperator
-        .generate(request, {
-          token
-        })
+      instrumentGeneration('pixverse', pixverseOperator.generate(request, { token }))
         .then(() => {
           ElMessage.success(this.$t('pixverse.message.startTaskSuccess'));
         })

--- a/src/pages/producer/Index.vue
+++ b/src/pages/producer/Index.vue
@@ -16,6 +16,7 @@
 import { defineComponent } from 'vue';
 import Layout from '@/layouts/Producer.vue';
 import { applicationOperator, producerOperator } from '@/operators';
+import { instrumentGeneration } from '@/plugins/telemetry';
 import { IApplicationDetailResponse, IProducerAudioRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
 import { IProducerTask } from '@/models';
@@ -191,10 +192,7 @@ export default defineComponent({
         return;
       }
       ElMessage.info(this.$t('producer.message.startingTask'));
-      producerOperator
-        .audio(request, {
-          token
-        })
+      instrumentGeneration('producer', producerOperator.audio(request, { token }))
         .then(() => {
           ElMessage.success(this.$t('producer.message.startTaskSuccess'));
         })

--- a/src/pages/qrart/Index.vue
+++ b/src/pages/qrart/Index.vue
@@ -24,6 +24,7 @@ import { defineComponent } from 'vue';
 import Layout from '@/layouts/Qrart.vue';
 import ConfigPanel from '@/components/qrart/ConfigPanel.vue';
 import { applicationOperator, qrartOperator } from '@/operators';
+import { instrumentGeneration } from '@/plugins/telemetry';
 import { IApplicationDetailResponse, IQrartGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
 import { ERROR_CODE_DUPLICATION, ERROR_CODE_USED_UP } from '@/constants';
@@ -220,10 +221,7 @@ export default defineComponent({
         return;
       }
       ElMessage.info(this.$t('qrart.message.startingTask'));
-      qrartOperator
-        .generate(request, {
-          token
-        })
+      instrumentGeneration('qrart', qrartOperator.generate(request, { token }))
         .then(() => {
           ElMessage.success(this.$t('qrart.message.startTaskSuccess'));
         })

--- a/src/pages/seedance/Index.vue
+++ b/src/pages/seedance/Index.vue
@@ -15,6 +15,7 @@ import Layout from '@/layouts/Seedance.vue';
 import ConfigPanel from '@/components/seedance/ConfigPanel.vue';
 import RecentPanel from '@/components/seedance/RecentPanel.vue';
 import { seedanceOperator } from '@/operators';
+import { instrumentGeneration } from '@/plugins/telemetry';
 import { ISeedanceGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
 import { ERROR_CODE_USED_UP } from '@/constants';
@@ -156,10 +157,7 @@ export default defineComponent({
         return;
       }
       ElMessage.info(this.$t('seedance.message.startingTask'));
-      seedanceOperator
-        .generate(request, {
-          token
-        })
+      instrumentGeneration('seedance', seedanceOperator.generate(request, { token }))
         .then(() => {
           ElMessage.success(this.$t('seedance.message.startTaskSuccess'));
         })

--- a/src/pages/seedream/Index.vue
+++ b/src/pages/seedream/Index.vue
@@ -14,6 +14,7 @@ import { defineComponent } from 'vue';
 import Layout from '@/layouts/Seedream.vue';
 import ConfigPanel from '@/components/seedream/ConfigPanel.vue';
 import { seedreamOperator } from '@/operators';
+import { instrumentGeneration } from '@/plugins/telemetry';
 import { ISeedreamGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
 import { ERROR_CODE_USED_UP } from '@/constants';
@@ -176,10 +177,7 @@ export default defineComponent({
         return;
       }
       ElMessage.info(this.$t('seedream.message.startingTask'));
-      seedreamOperator
-        .generate(request, {
-          token
-        })
+      instrumentGeneration('seedream', seedreamOperator.generate(request, { token }))
         .then(() => {
           ElMessage.success(this.$t('seedream.message.startTaskSuccess'));
         })

--- a/src/pages/sora/Index.vue
+++ b/src/pages/sora/Index.vue
@@ -14,6 +14,7 @@ import { defineComponent } from 'vue';
 import Layout from '@/layouts/Sora.vue';
 import ConfigPanel from '@/components/sora/ConfigPanel.vue';
 import { soraOperator } from '@/operators';
+import { instrumentGeneration } from '@/plugins/telemetry';
 import { ISoraGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
 import { ERROR_CODE_USED_UP } from '@/constants';
@@ -157,10 +158,7 @@ export default defineComponent({
         return;
       }
       ElMessage.info(this.$t('sora.message.startingTask'));
-      soraOperator
-        .generate(request, {
-          token
-        })
+      instrumentGeneration('sora', soraOperator.generate(request, { token }))
         .then(() => {
           ElMessage.success(this.$t('sora.message.startTaskSuccess'));
         })

--- a/src/pages/suno/Index.vue
+++ b/src/pages/suno/Index.vue
@@ -20,6 +20,7 @@ import { IApplicationDetailResponse, ISunoAudioRequest, Status } from '@/models'
 import { ElMessage } from 'element-plus';
 import { ISunoTask } from '@/models';
 import { ERROR_CODE_DUPLICATION } from '@/constants';
+import { instrumentGeneration } from '@/plugins/telemetry';
 import ConfigPanel from '@/components/suno/ConfigPanel.vue';
 import RecentPanel from '@/components/suno/RecentPanel.vue';
 import PreviewPanel from '@/components/suno/PreviewPanel.vue';
@@ -193,10 +194,7 @@ export default defineComponent({
         return;
       }
       ElMessage.info(this.$t('suno.message.startingTask'));
-      sunoOperator
-        .audio(request, {
-          token
-        })
+      instrumentGeneration('suno', sunoOperator.audio(request, { token }))
         .then(() => {
           ElMessage.success(this.$t('suno.message.startTaskSuccess'));
         })

--- a/src/pages/veo/Index.vue
+++ b/src/pages/veo/Index.vue
@@ -14,6 +14,7 @@ import { defineComponent } from 'vue';
 import Layout from '@/layouts/Veo.vue';
 import ConfigPanel from '@/components/veo/ConfigPanel.vue';
 import { veoOperator } from '@/operators';
+import { instrumentGeneration } from '@/plugins/telemetry';
 import { IVeoGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
 import { ERROR_CODE_USED_UP } from '@/constants';
@@ -168,10 +169,7 @@ export default defineComponent({
         delete request.image_urls;
       }
       ElMessage.info(this.$t('veo.message.startingTask'));
-      veoOperator
-        .generate(request, {
-          token
-        })
+      instrumentGeneration('veo', veoOperator.generate(request, { token }))
         .then(() => {
           ElMessage.success(this.$t('veo.message.startTaskSuccess'));
         })

--- a/src/pages/wan/Index.vue
+++ b/src/pages/wan/Index.vue
@@ -14,6 +14,7 @@ import { defineComponent } from 'vue';
 import Layout from '@/layouts/Wan.vue';
 import ConfigPanel from '@/components/wan/ConfigPanel.vue';
 import { wanOperator } from '@/operators';
+import { instrumentGeneration } from '@/plugins/telemetry';
 import { IWanGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
 import { ERROR_CODE_USED_UP } from '@/constants';
@@ -161,10 +162,7 @@ export default defineComponent({
         return;
       }
       ElMessage.info(this.$t('wan.message.startingTask'));
-      wanOperator
-        .generate(request, {
-          token
-        })
+      instrumentGeneration('wan', wanOperator.generate(request, { token }))
         .then(() => {
           ElMessage.success(this.$t('wan.message.startTaskSuccess'));
         })

--- a/src/plugins/telemetry.ts
+++ b/src/plugins/telemetry.ts
@@ -1,0 +1,173 @@
+/**
+ * Frontend telemetry powered by Tencent Cloud RUM (Aegis).
+ *
+ * Captures:
+ *   - JS errors / unhandled rejections / Vue render errors
+ *   - API request speed + 4xx/5xx (Aegis built-in `reportApiSpeed`)
+ *   - SPA page views (Aegis built-in `spa: true`)
+ *   - Custom business events via `track(event, props)`
+ *   - Manual error reporting via `captureError(err, ctx)`
+ *
+ * Project ID is hardcoded — Tencent RUM project IDs are not secret (they're
+ * shipped to every visitor's browser anyway), and pinning the ID keeps local
+ * dev / Capacitor / preview builds all reporting to the same dashboard so
+ * pre-production issues are visible too.
+ *
+ * Console: https://console.cloud.tencent.com/rum
+ */
+
+import type Aegis from 'aegis-web-sdk';
+
+type AegisInstance = InstanceType<typeof Aegis>;
+
+interface InitOptions {
+  uin?: string;
+  fingerprint?: string;
+  release?: string;
+}
+
+let aegis: AegisInstance | null = null;
+let initialized = false;
+
+const PROJECT_ID = '154475';
+const HOST_URL = 'https://rumt-zh.com';
+
+/**
+ * Initialize Aegis. Safe to call multiple times — subsequent calls update
+ * config (uin, aid) instead of reinstantiating.
+ */
+export async function initTelemetry(opts: InitOptions = {}): Promise<void> {
+  if (initialized && aegis) {
+    setUser(opts.uin, opts.fingerprint);
+    return;
+  }
+
+  try {
+    const { default: AegisCtor } = await import('aegis-web-sdk');
+    aegis = new AegisCtor({
+      id: PROJECT_ID,
+      uin: opts.uin,
+      aid: opts.fingerprint,
+      reportApiSpeed: true,
+      reportAssetSpeed: true,
+      spa: true,
+      hostUrl: HOST_URL,
+      version: opts.release
+    });
+    initialized = true;
+  } catch (err) {
+    // SDK load failure must never break the app.
+    console.warn('[telemetry] failed to init Aegis:', err);
+  }
+}
+
+/**
+ * Update the visitor identity (after login, after fingerprint resolves).
+ */
+export function setUser(uin?: string, aid?: string): void {
+  if (!aegis) return;
+  try {
+    if (uin) aegis.setConfig({ uin });
+    if (aid) aegis.setConfig({ aid });
+  } catch (err) {
+    console.warn('[telemetry] setUser failed:', err);
+  }
+}
+
+/**
+ * Fire a custom business event. Property values are coerced to strings and
+ * placed into Aegis's `ext1..ext3` slots so they're filterable in the RUM
+ * dashboard.
+ *
+ *   track('payment_success', { order_id, pay_way, amount })
+ */
+export function track(event: string, props: Record<string, unknown> = {}): void {
+  if (!aegis) return;
+  try {
+    const ext1 = props.service ?? props.pay_way ?? props.action;
+    const ext2 = props.order_id ?? props.task_id ?? props.id;
+    const ext3 = props.trace_id ?? props.error;
+    aegis.info({
+      msg: event,
+      ext1: ext1 != null ? String(ext1) : undefined,
+      ext2: ext2 != null ? String(ext2) : undefined,
+      ext3: ext3 != null ? String(ext3) : undefined
+    });
+  } catch (err) {
+    console.warn('[telemetry] track failed:', err);
+  }
+}
+
+/**
+ * Capture an exception (Vue errorHandler, unhandled rejection, manual catch).
+ */
+export function captureError(error: unknown, ctx: Record<string, unknown> = {}): void {
+  if (!aegis) return;
+  try {
+    const err = error instanceof Error ? error : new Error(String(error));
+    aegis.error({
+      msg: err.message,
+      stack: err.stack,
+      ext1: ctx.source != null ? String(ctx.source) : undefined,
+      ext2: ctx.route != null ? String(ctx.route) : undefined,
+      ext3: ctx.trace_id != null ? String(ctx.trace_id) : undefined
+    });
+  } catch (e) {
+    console.warn('[telemetry] captureError failed:', e);
+  }
+}
+
+/**
+ * Mark an API failure (called from axios response interceptor). Goes through
+ * `info` rather than `error` so it doesn't double-count with Aegis's built-in
+ * `reportApiSpeed` 4xx/5xx capture; the value of this hook is attaching the
+ * server-side `trace_id` so the entry can be cross-referenced with CLS.
+ */
+export function trackApiFailure(args: { url: string; method?: string; status?: number; trace_id?: string }): void {
+  if (!aegis) return;
+  try {
+    aegis.info({
+      msg: 'api_failure',
+      ext1: `${args.method ?? 'GET'} ${args.url}`,
+      ext2: args.status != null ? String(args.status) : undefined,
+      ext3: args.trace_id
+    });
+  } catch (err) {
+    console.warn('[telemetry] trackApiFailure failed:', err);
+  }
+}
+
+/** Returns true when the SDK is up and running. Useful for tests. */
+export function isInitialized(): boolean {
+  return initialized;
+}
+
+/**
+ * Wrap a generation request with `generation_submit` / `generation_success`
+ * / `generation_failed` events.
+ *
+ *   instrumentGeneration('flux', fluxOperator.generate(req, { token }))
+ *     .then(...)
+ *     .catch(...)
+ *
+ * The wrapper preserves the underlying promise's resolved value and rejection,
+ * so the surrounding `.then` / `.catch` keep working unchanged.
+ */
+export function instrumentGeneration<T>(service: string, promise: Promise<T>): Promise<T> {
+  track('generation_submit', { service });
+  return promise.then(
+    (data) => {
+      const taskId = (data as any)?.data?.id ?? (data as any)?.data?.task_id ?? (data as any)?.id;
+      track('generation_success', { service, task_id: taskId });
+      return data;
+    },
+    (error) => {
+      track('generation_failed', {
+        service,
+        trace_id: error?.response?.data?.trace_id ?? error?.response?.headers?.['x-request-id'],
+        error: error?.response?.data?.error?.message ?? String(error)
+      });
+      throw error;
+    }
+  );
+}


### PR DESCRIPTION
## Summary

Adds frontend telemetry to Nexior via [Tencent Cloud RUM](https://console.cloud.tencent.com/rum) (`aegis-web-sdk@1.41.13`). Companion to the existing backend Sentry+CLS stack — closes the visibility gap on the browser side.

## What gets captured automatically

| Signal | How |
|---|---|
| JS errors | `app.config.errorHandler` |
| Unhandled promise rejections | `window.addEventListener('unhandledrejection')` |
| API speed + 4xx/5xx | Aegis `reportApiSpeed: true` (built-in) |
| Static asset speed | Aegis `reportAssetSpeed: true` |
| SPA page views | Aegis `spa: true` — no router instrumentation needed |
| Visitor identity | `uin = user.id`, `aid = fingerprint` |

## Custom business events

A `track(event, props)` helper is wired at 6 sites:

| Event | Where |
|---|---|
| `payment_initiated` | [application/Extra.vue](src/pages/console/application/Extra.vue), [application/Subscribe.vue](src/pages/console/application/Subscribe.vue) |
| `payment_failed` | same |
| `payment_success` | [order/Detail.vue](src/pages/console/order/Detail.vue) — fires once on `PENDING → PAID` |
| `generation_submit` | [suno/Index.vue](src/pages/suno/Index.vue) — reference impl |
| `generation_success` | same |
| `generation_failed` | same; carries `trace_id` for CLS cross-reference |

## Front↔back trace correlation

The axios response interceptor now forwards 4xx/5xx to `trackApiFailure()` with the server-side `trace_id` (the `x-request-id` we already inject). That means a single click in the RUM dashboard pivots straight to the matching PlatformGateway CLS log line — no manual hunting.

## Setup (the only thing **you** need to do)

1. Create a RUM Web project at https://console.cloud.tencent.com/rum (≈30 s — pick *业务名 = Nexior*, domain `studio.acedata.cloud`).
2. Drop the project ID into the K8s deployment env or `.env`:
   ```
   VITE_RUM_PROJECT_ID=<id>
   ```
3. Optional knobs: `VITE_RUM_SAMPLE_RATE` (default `1`), `VITE_RUM_HOST_URL` (default `https://rumt-zh.com`).

## Safe defaults

When `VITE_RUM_PROJECT_ID` is unset, every `track()` / `captureError()` / `trackApiFailure()` call is a no-op **and the SDK chunk is never loaded** (dynamic `import()`). Bundle stays clean for local dev and PR previews. Merge anytime — production lights up the moment the env var lands.

## Out of scope (intentional, easy follow-ups)

- **Sourcemap upload** to RUM for stack symbolication — needs a CI step + RUM auth token. Open if/when stacks become useful.
- **Session replay** (DOM recording) — disabled. Privacy + storage cost; revisit after the first week of error data.
- **Per-service `generation_*` events** for the other 15+ services. Suno is the reference; the pattern is one `track()` call per `.then` / `.catch` block. Easy to extend incrementally.
- **Capacitor (iOS/Android) native** — Aegis web SDK already runs inside the WebView, but per-platform tagging not added.

## Verification

- `npx vue-tsc --noEmit --skipLibCheck` — clean
- `npx eslint <changed files>` — clean
- No tests added: this is observability glue at I/O boundaries, not business logic.

## Risk

Very low. SDK init is awaited via `void initTelemetry(...)` (non-blocking), wrapped in `try/catch`, and gated behind a single env var. Worst case (SDK fails to load): app prints a console warning and continues normally.
