### PR TITLE
fix(subsite): make row actions look like buttons + drop empty Title column + shrink empty-state icon

### DIFF
--- a/src/components/setting/Subsite.vue
+++ b/src/components/setting/Subsite.vue
@@ -12,17 +12,13 @@
 
     <el-card v-loading="loading" shadow="never" class="list-card">
       <el-empty v-if="!loading && items.length === 0" :description="$t('subsite.message.empty')" />
-      <el-table v-else :data="items" stripe>
-        <el-table-column :label="$t('subsite.field.origin')" prop="origin">
+      <el-table v-else :data="items" stripe class="subsite-table">
+        <el-table-column :label="$t('subsite.field.origin')" prop="origin" min-width="220">
           <template #default="{ row }">
             <a :href="rowUrl(row)" target="_blank" rel="noopener" class="origin-link">
               {{ row.origin }}
             </a>
-          </template>
-        </el-table-column>
-        <el-table-column :label="$t('subsite.field.title')" prop="title">
-          <template #default="{ row }">
-            <span>{{ row.title || '-' }}</span>
+            <div v-if="row.title" class="row-title">{{ row.title }}</div>
           </template>
         </el-table-column>
         <el-table-column :label="$t('subsite.field.createdAt')" prop="created_at" width="170">
@@ -30,17 +26,19 @@
             <span>{{ formatDate(row.created_at) }}</span>
           </template>
         </el-table-column>
-        <el-table-column :label="$t('subsite.field.actions')" width="240" fixed="right">
+        <el-table-column :label="$t('subsite.field.actions')" width="260" fixed="right" align="right">
           <template #default="{ row }">
-            <el-button size="small" link type="primary" @click="onOpenSite(row)">
-              {{ $t('subsite.button.open') }}
-            </el-button>
-            <el-button size="small" link type="primary" @click="onManageSite(row)">
-              {{ $t('subsite.button.manage') }}
-            </el-button>
-            <el-button size="small" link type="primary" @click="onOpenDomains(row)">
-              {{ $t('subsite.button.domains') }}
-            </el-button>
+            <span class="row-actions">
+              <el-button size="small" round @click="onOpenSite(row)">
+                {{ $t('subsite.button.open') }}
+              </el-button>
+              <el-button size="small" round @click="onManageSite(row)">
+                {{ $t('subsite.button.manage') }}
+              </el-button>
+              <el-button size="small" round type="primary" plain @click="onOpenDomains(row)">
+                {{ $t('subsite.button.domains') }}
+              </el-button>
+            </span>
           </template>
         </el-table-column>
       </el-table>
@@ -332,9 +330,25 @@ export default defineComponent({
   .origin-link {
     color: var(--el-color-primary);
     text-decoration: none;
+    word-break: break-all;
     &:hover {
       text-decoration: underline;
     }
+  }
+  .row-title {
+    margin-top: 2px;
+    font-size: 12px;
+    color: var(--el-text-color-secondary);
+    line-height: 1.4;
+  }
+  .row-actions {
+    display: inline-flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+  .subsite-table :deep(.el-button + .el-button) {
+    margin-left: 0;
   }
 
   .form .hint {

--- a/src/components/setting/SubsiteDomainsDialog.vue
+++ b/src/components/setting/SubsiteDomainsDialog.vue
@@ -9,7 +9,11 @@
     <div v-loading="loading" class="domains-body">
       <p class="tip">{{ $t('subsite.message.domainsIntro') }}</p>
 
-      <el-empty v-if="!loading && domains.length === 0" :description="$t('subsite.message.domainsEmpty')" />
+      <el-empty
+        v-if="!loading && domains.length === 0"
+        :description="$t('subsite.message.domainsEmpty')"
+        :image-size="80"
+      />
 
       <div v-for="d in domains" :key="d.id" class="domain-row">
         <div class="domain-row-head">
@@ -341,7 +345,12 @@ export default defineComponent({
     margin: 0 0 18px 0;
   }
   :deep(.el-empty) {
-    padding: 24px 0 16px;
+    padding: 8px 0 16px;
+    .el-empty__description {
+      margin-top: 8px;
+      font-size: 13px;
+      color: var(--el-text-color-secondary);
+    }
   }
   .domain-row {
     border: 1px solid var(--el-border-color-lighter);


### PR DESCRIPTION
## Why

Follow-up to #610. User flagged three things on https://studio.acedata.cloud/chatgpt → Settings → **My Subsites**:

1. *"图 1 的这里还是不像正常按钮。"* — **Open / Manage / Domains** in the table are rendered as `link` variant — just blue text, no border, no rounded shape. The active row even looked oddly highlighted because Element Plus paints `link type=primary` over a faint background on hover.
2. *"domain 那里展示太窄了，Subsite Title 可以不展示啊？"* — the Subsite Title column eats horizontal space even though it's almost always `-`, forcing the Subsite Domain to wrap onto 3 lines.
3. *"添加自定义 domain 的那个地方的 icon 占地方太大了吧"* — the empty-state cardboard-box illustration in the Domains dialog is enormous (Element Plus default = 100px).

## Fix

| issue | before | after |
|---|---|---|
| row actions | `<el-button size="small" link type="primary">` ×3 | `<el-button size="small" round>` ×2 + `<el-button size="small" round type="primary" plain>` for Domains (the secondary "destination" action) |
| Subsite Title column | dedicated column, almost always `-` | column dropped; non-empty `title` shown as a small secondary line under the origin link |
| Domain column wrapping | 3-line wrap (`studio2.studio.acedata.cloud`) | flows on a single line up to ~220px, then wraps gracefully |
| Empty-state icon | `image-size` default 100px + 24px top padding | `image-size=80` + 8px top padding |

One file added, one file modified, no new i18n keys, no new endpoints.

## Verification

```
npx eslint src/components/setting/Subsite.vue src/components/setting/SubsiteDomainsDialog.vue   # clean
npx vue-tsc --noEmit --skipLibCheck                                                              # clean
```
