### PR TITLE
fix(telemetry): use Aegis 'report id' (RUM /collect/* was 403)

### DIFF
--- a/change/@acedatacloud-nexior-rum-fix-report-id.json
+++ b/change/@acedatacloud-nexior-rum-fix-report-id.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(telemetry): use Aegis 'report id' instead of numeric 应用ID — RUM /collect/* was returning 403 because the numeric ID is not a valid SDK identifier",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/plugins/telemetry.ts
+++ b/src/plugins/telemetry.ts
@@ -29,7 +29,15 @@ interface InitOptions {
 let aegis: AegisInstance | null = null;
 let initialized = false;
 
-const PROJECT_ID = '154475';
+// Aegis "report id" — the alphanumeric token shown on each Web app's "应用接入"
+// row in the RUM console (NOT the numeric "应用ID" / "业务系统 ID").
+// Pinned here intentionally: this value is shipped to every visitor anyway,
+// so there's nothing to gain from sourcing it from env vars, and pinning
+// keeps local dev / Capacitor / preview builds reporting to the same
+// dashboard as production.
+//   Console:  https://console.cloud.tencent.com/rum
+//   App:      Ace Data Cloud (numeric 应用ID 154475, business system rum-vK9sZMBo)
+const PROJECT_ID = 'LlKeKIj1mDzkYrY6na';
 const HOST_URL = 'https://rumt-zh.com';
 
 /**


### PR DESCRIPTION
## Problem

After [#612](https://github.com/AceDataCloud/Nexior/pull/612) shipped, no data showed up in the Tencent Cloud RUM dashboard for ~30 min after deploy. Live diagnosis from the browser:

```
GET https://rumt-zh.com/rateConfig?id=154475          → 200 ✅
GET https://rumt-zh.com/collect/whitelist?id=154475   → 403 ❌
GET https://rumt-zh.com/collect/pv?id=154475          → 403 ❌
```

So the SDK loaded, sessions opened, requests fired — but every `/collect/*` was rejected.

## Root cause

I used the wrong identifier. The Tencent RUM console exposes **two** numbers per Web app and they are not interchangeable:

| Field shown in console | Example | Used for |
|---|---|---|
| **应用ID** (numeric) | `154475` | Display only; appears in URLs & project list |
| **上报id** (alphanumeric) | `LlKeKIj1mDzkYrY6na` | **The value Aegis SDK's `id` field expects** |

The official sample even shows the right shape (`new Aegis({ id: 'LlKeKIj1mDzkYrY6na', ... })`) — I just grabbed the wrong column. `/rateConfig` accepts the numeric ID (project-level lookup), but `/collect/*` strictly validates against the report id and returns 403 when it doesn't match.

## Fix

One-line change in [src/plugins/telemetry.ts](src/plugins/telemetry.ts):

```diff
-const PROJECT_ID = '154475';
+// Aegis "report id" — the alphanumeric token shown on the Web app's
+// "应用接入" row in the RUM console (NOT the numeric "应用ID").
+const PROJECT_ID = 'LlKeKIj1mDzkYrY6na';
```

Comment expanded so future readers don't fall into the same trap.

## Expected behavior after deploy

- `/collect/whitelist` → 200 instead of 403
- `/collect/pv` → 200 instead of 403
- Data appears in the **数据总览** / **页面访问** / **API 监控** dashboards within ~1-2 min of the rollout completing
- No code path changes — same events, same wrappers, same instrumentation as #612

## Verification plan

After CI deploys, I'll re-open https://studio.acedata.cloud/ and confirm `/collect/*` returns 200 in the network panel. Will reply on the PR with the result.
