### PR TITLE
fix(midjourney): wrap long prompts in task list instead of truncating with ellipsis

### DIFF
--- a/src/components/midjourney/tasks/TaskItem.vue
+++ b/src/components/midjourney/tasks/TaskItem.vue
@@ -514,8 +514,6 @@ $left-width: 70px;
     }
 
     .info {
-      display: flex;
-      flex-direction: row;
       width: 100%;
       overflow: hidden;
 
@@ -524,9 +522,9 @@ $left-width: 70px;
         font-weight: bold;
         color: var(--el-text-color-regular);
         margin-bottom: 10px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+        white-space: normal;
+        word-break: break-word;
+        overflow-wrap: anywhere;
       }
 
       .mode {


### PR DESCRIPTION
## Problem

Reported on https://studio.acedata.cloud/midjourney: when the right-side task panel renders a long prompt, the prompt is truncated with `…` instead of wrapping to the next line, so the user can't see what they actually generated.

## Root cause

`src/components/midjourney/tasks/TaskItem.vue` is the only AI-service preview in Nexior that styles `.prompt` with `overflow: hidden; text-overflow: ellipsis; white-space: nowrap;`. To make matters worse, its parent `.info` is `display: flex; flex-direction: row;` — even if we removed `nowrap`, a `<p>` inside a flex row without `min-width: 0` still won't wrap reliably.

Every other AI-service preview in Nexior already does the right thing:

| service | `.prompt` rule |
|---|---|
| flux | `white-space: normal; word-break: break-word; overflow-wrap: anywhere;` |
| luma / sora / veo / wan | same |
| seedream / seedance / seedance / nanobanana / openai-image | same |
| hailuo / kling / pika / pixverse / qrart / headshots | same |
| **midjourney** | **`nowrap` + `ellipsis`** ← outlier |

So the fix is to bring midjourney in line.

## Fix

Single SCSS block in `TaskItem.vue`:

```diff
 .info {
-  display: flex;
-  flex-direction: row;
   width: 100%;
   overflow: hidden;

   .prompt {
     font-size: 14px;
     font-weight: bold;
     color: var(--el-text-color-regular);
     margin-bottom: 10px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    white-space: normal;
+    word-break: break-word;
+    overflow-wrap: anywhere;
   }
```

This applies to both `imagine` tasks and `videos` tasks because both reuse the same `.preview > .info > .prompt` structure.

`.bot` (the row with "Midjourney Bot · timestamp" above the prompt) keeps its single-line ellipsis behavior — that's intentional and matches every other service.

## Other places checked

I grepped every Vue file in Nexior for `.prompt { … white-space: nowrap }`. Midjourney was the only hit; nothing else needs to change.

## Verification

- `npx eslint src/components/midjourney/tasks/TaskItem.vue` — clean
- `npx vue-tsc --noEmit --skipLibCheck` — clean
