### PR TITLE
fix(application): preserve user's wallet selection across page reloads

### DIFF
--- a/change/@acedatacloud-nexior-35922c04-ec79-40c6-af8a-59eb3a2b7f06.json
+++ b/change/@acedatacloud-nexior-35922c04-ec79-40c6-af8a-59eb3a2b7f06.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(application): respect user's wallet selection across page reloads (no longer auto-replace expired/exhausted current pick)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "cqc@cuiqingcai.com",
+  "dependentChangeType": "patch"
+}

--- a/src/utils/application.ts
+++ b/src/utils/application.ts
@@ -46,7 +46,23 @@ export function isApplicationUsable(application: IApplication | undefined): bool
 
 /**
  * get final application from applications
- * @param applications
+ *
+ * If the user already has a `currentApplication` (either restored from
+ * localStorage on a page reload, or just-selected via the wallet dialog),
+ * we keep it as long as it still exists in the freshly-fetched list —
+ * regardless of whether it's expired or exhausted. The previous behaviour
+ * silently re-ran the auto-pick on every page load, which meant a user
+ * who explicitly selected a Period package that later expired (or one
+ * with depleted credits) would see their choice replaced by a different
+ * package on every refresh — see https://github.com/AceDataCloud/Nexior
+ * issue: "wallet selection doesn't stick after refresh".
+ *
+ * The auto-fallback (global > individual, period > usage) only runs when
+ * there is no current selection, or when the previously-selected
+ * application has been deleted server-side.
+ *
+ * @param applications full list of applications visible to the user
+ * @param currentApplication the persisted / freshly-selected one, if any
  * @returns application
  */
 export function getFinalApplication(
@@ -54,12 +70,8 @@ export function getFinalApplication(
   currentApplication?: IApplication
 ): IApplication | undefined {
   console.debug('start to execute getFinalApplication', applications, currentApplication);
-  if (
-    currentApplication &&
-    isApplicationUsable(currentApplication) &&
-    applications?.some((app) => app.id === currentApplication.id)
-  ) {
-    console.debug('current application is usable', currentApplication);
+  if (currentApplication && applications?.some((app) => app.id === currentApplication.id)) {
+    console.debug('current application is preserved (respect user selection)', currentApplication);
     return currentApplication;
   }
   console.debug('get final application from applications', applications);


### PR DESCRIPTION
## Problem

On https://studio.acedata.cloud/deepseek/conversations (and every other chat scenario — ChatGPT / Claude / Gemini / Grok / Kimi / GLM / DeepSeek), the wallet/package picker behind the 💰 button **does not remember the user's selection across page reloads**:

> 我选中了第三个，刷新页面，就变到了第二个

Reported case (real user data):

| # | App ID prefix | scope · type | balance | expiry |
|---|---|---|---|---|
| 1 | `d2fe0fa1…` | global · Usage | **−2.55** | never |
| 2 | `b41f8bfe…` | individual · Usage | 0.00 | never |
| 3 | `f1abbc47…` | individual · **Period** | 746.76 | **2025-09-17** (expired today, 2026-05-05) |

User explicitly clicks card 3 → reload → ends up on card 2.

## Root cause

[`getFinalApplication()`](https://github.com/AceDataCloud/Nexior/blob/main/src/utils/application.ts#L52) is called from [`layouts/Main.vue::initialize()`](https://github.com/AceDataCloud/Nexior/blob/main/src/layouts/Main.vue#L103) on every mount. Its first guard was:

```ts
if (currentApplication && isApplicationUsable(currentApplication) && applications?.some(...)) {
  return currentApplication;
}
// otherwise → fall through to global > individual / Period > Usage auto-pick
```

`isApplicationUsable()` returns `false` when the application is expired *or* `remaining_amount < 0`. So:

- Card 3 is expired → `isApplicationUsable` = false → guard fails → falls through
- Auto-pick walks the list: no global Period, global Usage = card 1 but exhausted (−2.55), individual Period = card 3 but expired, individual Usage = card 2 (0.00) → returns card 2 via the final `application1 || application2 || application3 || application4` fallback

Net effect: the user's deliberate click is silently overwritten on every refresh whenever the chosen package is expired or exhausted. `vuex-persistedstate` was correctly persisting `chat.application` to localStorage all along — the value was being overwritten *after* hydration, in `Main.vue`'s mount flow.

## Fix

Drop the `isApplicationUsable(currentApplication)` clause from the preservation guard. If the user has a current selection and that selection still exists server-side, **keep it** — even if expired or exhausted. The user clicked it on purpose; the dialog already shows the balance/expiry on each card so they can re-select if they want.

The auto-fallback chain (global > individual, Period > Usage) still runs when there is no current selection (first load) or when the previously-selected package has been deleted server-side (`!applications.some(app => app.id === currentApplication.id)`).

```diff
- if (currentApplication && isApplicationUsable(currentApplication) && applications?.some(...)) {
+ if (currentApplication && applications?.some((app) => app.id === currentApplication.id)) {
    return currentApplication;
  }
```

One file changed (`src/utils/application.ts`), plus updated docstring to call out the invariant.

## Verification

- `eslint src/utils/application.ts` — clean
- `vue-tsc --noEmit --skipLibCheck` — clean
- No tests reference `getFinalApplication` directly. The change strictly *widens* the preserve-current branch; the auto-fallback path that all other callers rely on is unchanged.

## Risk

Low. Behavioural delta is scoped to "user already had a current selection that was unusable". Old behaviour silently auto-replaced; new behaviour keeps it. Users who *want* a different package can still pick one from the dialog.
