### PR TITLE
feat(application): show balance amount in the wallet pill

### DIFF
--- a/change/@acedatacloud-nexior-dbfa416f-72cb-4490-866a-a8bbaf589809.json
+++ b/change/@acedatacloud-nexior-dbfa416f-72cb-4490-866a-a8bbaf589809.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(application): show balance amount in the wallet pill in the top-right corner",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/application/Status.vue
+++ b/src/components/application/Status.vue
@@ -22,20 +22,21 @@
         </div>
       </div>
     </el-dialog>
-    <el-button circle class="entry" @click="visible = true">
-      <font-awesome-icon icon="fa-solid fa-wallet" class="icon" />
-    </el-button>
+    <button type="button" class="entry" :title="balanceTitle" @click="visible = true">
+      <font-awesome-icon icon="fa-solid fa-wallet" class="entry-icon" />
+      <span class="entry-amount">{{ balanceText }}</span>
+      <span class="entry-unit">{{ balanceUnit }}</span>
+    </button>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElButton, ElDialog } from 'element-plus';
+import { ElDialog } from 'element-plus';
 import { IApplicationType, IApplication, IService } from '@/models';
 import { ROUTE_CONSOLE_APPLICATION_EXTRA, ROUTE_CONSOLE_USAGE_LIST } from '@/router';
 import ApplicationInfo from './Info.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-
 export interface IData {
   visible: boolean;
   applicationType: typeof IApplicationType;
@@ -44,7 +45,6 @@ export interface IData {
 export default defineComponent({
   name: 'ApplicationStatus',
   components: {
-    ElButton,
     ElDialog,
     FontAwesomeIcon,
     ApplicationInfo
@@ -76,6 +76,24 @@ export default defineComponent({
     },
     user() {
       return this.$store.state.user;
+    },
+    balanceAmount(): number {
+      return Number(this.application?.remaining_amount ?? 0);
+    },
+    balanceUnit(): string {
+      const unit = this.application?.service?.unit || 'credit';
+      const key = `service.unit.${unit}` + (this.balanceAmount === 1 ? '' : 's');
+      return this.$t(key);
+    },
+    balanceText(): string {
+      const value = this.balanceAmount;
+      if (!Number.isFinite(value)) return '0';
+      if (value >= 1000) return Math.round(value).toLocaleString();
+      if (value >= 100) return value.toFixed(1);
+      return value.toFixed(2);
+    },
+    balanceTitle(): string {
+      return `${this.balanceText} ${this.balanceUnit}`;
     }
   },
   methods: {
@@ -104,3 +122,69 @@ export default defineComponent({
   }
 });
 </script>
+
+<style lang="scss" scoped>
+.entry {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 32px;
+  padding: 0 12px;
+  border-radius: 999px;
+  border: 1px solid var(--app-border-subtle, var(--el-border-color));
+  background-color: var(--el-bg-color);
+  color: var(--el-text-color-primary);
+  font-size: 13px;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    border-color 0.18s ease,
+    box-shadow 0.18s ease,
+    background-color 0.18s ease,
+    transform 0.18s ease;
+  appearance: none;
+  outline: none;
+
+  &:hover {
+    border-color: var(--el-color-primary-light-5);
+    box-shadow: var(--app-shadow-md, 0 2px 8px rgba(0, 0, 0, 0.08));
+  }
+
+  &:active {
+    transform: scale(0.98);
+  }
+
+  &:focus-visible {
+    border-color: var(--el-color-primary);
+    box-shadow: 0 0 0 3px var(--el-color-primary-light-7, rgba(64, 158, 255, 0.2));
+  }
+}
+
+.entry-icon {
+  font-size: 13px;
+  color: var(--el-color-primary);
+}
+
+.entry-amount {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.01em;
+}
+
+.entry-unit {
+  color: var(--el-text-color-secondary);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+@media (max-width: 480px) {
+  .entry {
+    padding: 0 10px;
+    height: 30px;
+  }
+
+  .entry-unit {
+    display: none;
+  }
+}
+</style>


### PR DESCRIPTION
## Why

The wallet entry in the top-right corner of every Nexior surface (chat, image, video, music, …) was a plain round icon button — clicking it opened the application picker dialog, but at rest the user had **zero feedback** about how many credits they had left:

> nexior 的这个右上角钱包感觉光秃秃的看不出什么东西来。。比如不能一眼知道多少余额

## What

Replace the icon-only round button with a compact pill that shows the **current balance at a glance**, while keeping every existing behaviour and prop intact.

| before | after |
|---|---|
| `[💳]` round 32px button, hover only changes shadow | `[💳  124.50  Credits]` 32px pill, balance always visible |

- One file changed: [`src/components/application/Status.vue`](https://github.com/AceDataCloud/Nexior/blob/main/src/components/application/Status.vue)
- Click behaviour, props, and emits are unchanged — `<application-status>` still opens the same picker dialog with usage / top-up actions.
- Number formatting picks a sensible precision automatically:
  - `< 100`  → 2 decimals (`12.34`)
  - `100..999` → 1 decimal (`512.4`)
  - `≥ 1000` → locale integer (`1,234`)
- `font-variant-numeric: tabular-nums` so the pill width doesn't twitch as the balance ticks down between requests.
- Unit label reuses the same `service.unit.*` i18n keys that [`Info.vue`](https://github.com/AceDataCloud/Nexior/blob/main/src/components/application/Info.vue) already uses (`Credit` / `Credits` / `Call` / `Calls` / …), with automatic singular/plural based on the amount.
- Below 480px viewport the unit collapses so the pill fits nicely on phones — icon + amount only.
- Removed unused `ElButton` import (no longer using `el-button circle`).

## Why not a progress bar / runway / sparkline

Originally proposed; rejected after design review with the user — credits are top-up-anytime with no implicit cap, so there's no meaningful denominator for a progress bar, and runway / sparkline would need new backend aggregation endpoints that don't exist yet. Sticking to the literal request: *just show the current balance, simple and clean*.

## Verification

```
$ npx vue-tsc --noEmit --skipLibCheck    # clean
$ npx eslint src/components/application/Status.vue    # clean
```

No new dependencies, no new i18n keys, no API changes.
