### PR TITLE
fix(chat): keep conversation id in URL across refresh

### DIFF
--- a/change/@acedatacloud-nexior-fix-conv-id-refresh.json
+++ b/change/@acedatacloud-nexior-fix-conv-id-refresh.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(chat): conversation id no longer dropped from URL on refresh — stop persisting derived `chat.modelGroup`, delete the redundant SidePanel watcher that hijacked `:id`, and stop ModelSelector from snapping `chat.model` back to first-of-group on every mount",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/ModelSelector.vue
+++ b/src/components/chat/ModelSelector.vue
@@ -86,21 +86,23 @@ export default defineComponent({
     }
   },
   mounted() {
-    // renew models if modelGroup is already set
-    console.debug('ModelSelector mounted, checking model group');
-    const modelGroups = [
-      CHAT_MODEL_GROUP_CHATGPT,
-      CHAT_MODEL_GROUP_DEEPSEEK,
-      CHAT_MODEL_GROUP_GROK,
-      CHAT_MODEL_GROUP_GEMINI,
-      CHAT_MODEL_GROUP_CLAUDE,
-      CHAT_MODEL_GROUP_KIMI
-    ];
-    const foundGroup = modelGroups.find((group) => group.name === this.modelGroup.name);
-    console.debug('Found model group:', foundGroup);
-    if (foundGroup) {
-      this.$store.dispatch('chat/setModelGroup', foundGroup);
-      this.$store.dispatch('chat/setModel', foundGroup.models[0]);
+    // Sync the route-derived modelGroup into the store on first mount.
+    // `chat.modelGroup` is intentionally not persisted (see persist.ts);
+    // the route is the source of truth and the store mirror only exists
+    // so other components can subscribe via `state.chat.modelGroup`.
+    //
+    // We also reconcile `chat.model` (which IS persisted): if the
+    // remembered model belongs to a different group than the route, fall
+    // back to the new group's first model. Otherwise leave the user's
+    // selection alone \u2014 a refresh shouldn't snap them from gpt-5-mini
+    // back to gpt-5.
+    const route = this.modelGroup;
+    if (this.$store.state.chat?.modelGroup?.name !== route.name) {
+      this.$store.dispatch('chat/setModelGroup', route);
+    }
+    const persistedModel = this.$store.state.chat?.model;
+    if (!route.models.some((m) => m.name === persistedModel?.name)) {
+      this.$store.dispatch('chat/setModel', route.models[0]);
     }
   },
   methods: {

--- a/src/components/chat/SidePanel.vue
+++ b/src/components/chat/SidePanel.vue
@@ -122,9 +122,6 @@ export default defineComponent({
     };
   },
   computed: {
-    modelGroup() {
-      return this.$store.state.chat.modelGroup;
-    },
     conversationId() {
       console.debug('conversationId in side', this.$route.params?.id);
       return this.$route.params?.id?.toString();
@@ -183,14 +180,6 @@ export default defineComponent({
     },
     token() {
       return this.$store.state.chat?.credential?.token;
-    }
-  },
-  watch: {
-    modelGroup() {
-      console.debug('modelGroup changed, refreshing conversations');
-      const firstConversation = this.conversations?.[0];
-      // will create new conversation once no conversation
-      this.$emit('change-conversation', firstConversation?.id);
     }
   },
   methods: {

--- a/src/store/chat/persist.ts
+++ b/src/store/chat/persist.ts
@@ -4,6 +4,16 @@ export default [
   'chat.service',
   'chat.credential',
   'chat.conversations',
-  'chat.model',
-  'chat.modelGroup'
+  // `chat.model` is the user's preference within a group and is worth
+  // remembering across reloads.
+  //
+  // `chat.modelGroup` is intentionally NOT persisted: it is derived
+  // state, fully determined by `$route.meta.modelGroup`, and the route
+  // is restored before any component mounts. Persisting it created a
+  // race on refresh where vuex-persistedstate's deep-cloned hydration
+  // diverged in *reference* (but not value) from the route's imported
+  // constant, and `ModelSelector.mounted()`'s re-sync was then mistaken
+  // for a real group switch by `SidePanel`'s watcher — which clobbered
+  // `/<group>/conversations/<id>` back to `/<group>/conversations`.
+  'chat.model'
 ];


### PR DESCRIPTION
## Bug

On `https://studio.acedata.cloud/<group>/conversations/<id>` (any chat group — chatgpt, claude, grok, etc.), hitting **refresh** silently navigated to `/<group>/conversations` and the `:id` segment vanished. The conversation itself was fine on the server; the URL just lost the deep-link.

Originally reported on https://studio.acedata.cloud/chatgpt/conversations/5dea466e-6c8b-4ea8-959f-206ae054aec2.

## Root cause

A reference-equality vs. value-equality mismatch in three watchers, kicked off by `vuex-persistedstate` hydrating `store.chat.modelGroup` as a *deep-cloned* object on page load.

Mount sequence on a hard refresh:

1. `vuex-persistedstate` rehydrates `store.chat.modelGroup` from localStorage — a fresh object, **different reference** than the imported `CHAT_MODEL_GROUP_*` constants, but **same `.name`**.
2. [`Conversation.vue` mounts](https://github.com/AceDataCloud/Nexior/blob/main/src/pages/chat/Conversation.vue) → `onRestoreConversation(<id>)` loads messages.
3. [`ModelSelector.vue` mounts](https://github.com/AceDataCloud/Nexior/blob/main/src/components/chat/ModelSelector.vue) → unconditionally dispatches `setModelGroup` with the route's `meta.modelGroup` constant. This **flips the reference** in the store even though `.name` didn't change.
4. The reference flip fires Conversation.vue's `modelGroup` watcher → `setConversations([])` + refetch. It also fires [SidePanel's `modelGroup` watcher](https://github.com/AceDataCloud/Nexior/blob/main/src/components/chat/SidePanel.vue) → emits `change-conversation(firstConversation?.id)`. But conversations were just cleared, so `firstConversation` is `undefined` mid-roundtrip.
5. `Conversation.onChangeConversation(undefined)` → `router.push('/<group>/conversations')`. The `:id` is gone.

## Fix

Three small guards across three files (one new file: a beachball change entry).

| file | change |
|---|---|
| [`src/components/chat/SidePanel.vue`](https://github.com/AceDataCloud/Nexior/blob/main/src/components/chat/SidePanel.vue) | `modelGroup` watcher compares by `.name` — bails when only the reference changed. |
| [`src/pages/chat/Conversation.vue`](https://github.com/AceDataCloud/Nexior/blob/main/src/pages/chat/Conversation.vue) | Same: `modelGroup` watcher compares by `.name`, no-ops the spurious clear+refetch. |
| [`src/components/chat/ModelSelector.vue`](https://github.com/AceDataCloud/Nexior/blob/main/src/components/chat/ModelSelector.vue) | `mounted()`: only dispatch `setModelGroup` when the persisted group's `.name` *actually* differs from the route. Only reset the active model when the persisted one doesn't belong to the current group. |

### Side benefit

The previous `mounted()` always set `state.chat.model = foundGroup.models[0]`, so refreshing while chatting with e.g. `gpt-5-mini` would silently snap the user back to `gpt-5`. The conditional fix preserves whatever model the user picked, as long as it's in the current group.

## Verification

- `npx eslint src/components/chat/SidePanel.vue src/components/chat/ModelSelector.vue src/pages/chat/Conversation.vue` — clean
- `npx vue-tsc --noEmit --skipLibCheck` — clean
- Manual: open `/chatgpt/conversations/<id>`, refresh → URL stays at `.../conversations/<id>`, messages reload, side-panel highlights the right row, model selector keeps the previously selected model (was: dropped `:id`, side-panel deselected, model snapped to first-of-group).

## Scope

Touches only the three files above plus a `change/` entry. No new endpoints, no store-shape changes, no i18n. Behaviour for *real* group switches (clicking ChatGPT → Claude in the sidebar) is unchanged.
