### PR TITLE
fix(chat): guard model.getDisplayName() in ModelSelector trigger (production JS crash)

### DIFF
--- a/src/components/chat/ModelSelector.vue
+++ b/src/components/chat/ModelSelector.vue
@@ -3,7 +3,7 @@
     <el-dropdown trigger="click" popper-class="model-selector-popper">
       <div class="trigger">
         <img v-if="model?.icon" :src="model.icon" class="trigger-icon" />
-        <span class="trigger-name">{{ model?.getDisplayName() }}</span>
+        <span class="trigger-name">{{ model?.getDisplayName?.() ?? model?.name ?? '' }}</span>
         <font-awesome-icon icon="fa-solid fa-chevron-down" class="trigger-arrow" />
       </div>
       <template #dropdown>


### PR DESCRIPTION
## Symptom

Tencent CLS RUM reported 16 production JS errors on iPhone Safari (and others) coming from `https://studio.acedata.cloud/chatgpt/conversations` over a ~10‑minute window:

```
e.model?.getDisplayName is not a function.
(In 'e.model?.getDisplayName()', 'e.model?.getDisplayName' is undefined)
```

Source: `https://vuejs.org/error-reference/#runtime-1` (Vue render error), version `1.41.13`.

## Root cause

`ModelSelector.vue` renders the trigger label via:

```vue
<span class="trigger-name">{{ model?.getDisplayName() }}</span>
```

`model` comes from Vuex (`state.chat.model`), and `chat.model` is in the
[`vuex-persistedstate` whitelist](https://github.com/AceDataCloud/Nexior/blob/main/src/store/chat/persist.ts):

```ts
// src/store/chat/persist.ts
export default [
  'chat.application',
  ...
  'chat.model',
  'chat.modelGroup'
];
```

`vuex-persistedstate` defaults to `JSON.stringify` for serialization, which **drops function properties**. After a page refresh, the rehydrated `model` is a plain object like `{ name: 'gpt-5-5', icon: '…', enabled: true, … }` — `getDisplayName` (and `getDescription`) are gone.

The dropdown items already guard with `v-if="option?.getDisplayName"` (added in an earlier fix), so the dropdown menu renders fine. The **trigger** call site never got the same guard, so the first render after a refresh on `/chatgpt/conversations` throws `getDisplayName is not a function`, which Vue surfaces as the runtime error captured by Aegis RUM.

A proper structural fix (don't persist the model factory object — persist only `model.name` and resolve from the `CHAT_MODEL_GROUP_*` constants on rehydrate) is bigger and out of scope here. This PR is the minimum change that stops the production crash.

## Fix

`src/components/chat/ModelSelector.vue` — guard the trigger the same way the dropdown items already do, with a graceful fallback to `model.name` (which always survives JSON round-trip):

```diff
-        <span class="trigger-name">{{ model?.getDisplayName() }}</span>
+        <span class="trigger-name">{{ model?.getDisplayName?.() ?? model?.name ?? '' }}</span>
```

After this:

- fresh load (no persisted state): unchanged — `getDisplayName()` returns the i18n string.
- reloaded tab (persisted state, methods stripped): trigger shows the model `name` (e.g. `gpt-5-5`) instead of throwing. The dropdown items continue to be guarded.
- after the user clicks any model in the dropdown, `setModel` re-stores the live factory object in memory and `getDisplayName()` works again until the next reload.

## Verification

- `eslint src/components/chat/ModelSelector.vue` — clean.
- Reproduces the original crash on `main` by running:
  ```js
  // in DevTools, simulating what happens after a refresh
  store.commit('chat/setModel', JSON.parse(JSON.stringify(store.state.chat.model)));
  ```
  Without this PR, the trigger throws. With this PR, the trigger renders `gpt-5-5` and the dropdown still works.

## Aegis RUM hits this matched

URL pattern: `https://studio.acedata.cloud/chatgpt/conversations*`
Window observed: 2026-05-05 03:24 → 09:24 (UTC+8), 16 events.
