### PR TITLE
fix(chat): drop chat.model/modelGroup from persisted vuex paths (fixes top-2 RUM errors)

### DIFF
--- a/src/components/chat/ModelSelector.vue
+++ b/src/components/chat/ModelSelector.vue
@@ -3,7 +3,7 @@
     <el-dropdown trigger="click" popper-class="model-selector-popper">
       <div class="trigger">
         <img v-if="model?.icon" :src="model.icon" class="trigger-icon" />
-        <span class="trigger-name">{{ model?.getDisplayName() }}</span>
+        <span class="trigger-name">{{ model?.getDisplayName?.() ?? model?.name ?? '' }}</span>
         <font-awesome-icon icon="fa-solid fa-chevron-down" class="trigger-arrow" />
       </div>
       <template #dropdown>
@@ -17,8 +17,8 @@
             <div class="item">
               <img v-if="option?.icon" :src="option.icon" class="item-icon" />
               <div class="item-info">
-                <p v-if="option?.getDisplayName" class="item-name">{{ option?.getDisplayName() }}</p>
-                <p v-if="option?.getDescription" class="item-desc">{{ option?.getDescription() }}</p>
+                <p v-if="option?.getDisplayName" class="item-name">{{ option.getDisplayName() }}</p>
+                <p v-if="option?.getDescription" class="item-desc">{{ option.getDescription() }}</p>
               </div>
               <font-awesome-icon v-if="model?.name === option?.name" icon="fa-solid fa-check" class="item-check" />
             </div>

--- a/src/store/chat/persist.ts
+++ b/src/store/chat/persist.ts
@@ -1,9 +1,4 @@
-export default [
-  'chat.application',
-  'chat.applications',
-  'chat.service',
-  'chat.credential',
-  'chat.conversations',
-  'chat.model',
-  'chat.modelGroup'
-];
+// Do NOT persist `chat.model` / `chat.modelGroup`: their `getDisplayName()` /
+// `getDescription()` methods are dropped by JSON round-trip, and the empty
+// objects then crash `ModelSelector.vue` (re-derived from route on mount).
+export default ['chat.application', 'chat.applications', 'chat.service', 'chat.credential', 'chat.conversations'];

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -25,6 +25,25 @@ const lazyPersistModules = import.meta.glob<{ default: string[] }>(['./*/persist
 
 const lazyPersistPaths: string[] = Object.values(lazyPersistModules).flatMap((m) => m.default);
 
+// One-shot migration: strip stale `chat.model` / `chat.modelGroup` from any
+// previously persisted snapshot — they used to be persisted but their
+// methods get dropped by JSON, crashing ModelSelector.vue on rehydration.
+try {
+  if (typeof localStorage !== 'undefined') {
+    const raw = localStorage.getItem('vuex');
+    if (raw) {
+      const data = JSON.parse(raw);
+      if (data && data.chat && (data.chat.model !== undefined || data.chat.modelGroup !== undefined)) {
+        delete data.chat.model;
+        delete data.chat.modelGroup;
+        localStorage.setItem('vuex', JSON.stringify(data));
+      }
+    }
+  }
+} catch {
+  // ignore: storage unavailable / corrupted JSON
+}
+
 const store = createStore({
   ...root,
   plugins: [


### PR DESCRIPTION
## What

Top-2 errors from Aegis RUM on Nexior are tightly coupled and have a single root cause:

| error | hits | users |
|---|---|---|
| `e.model?.getDisplayName is not a function` | 28 (54%) | 5 (100%) |
| `w.getBoundingClientRect is not a function` | 14 (27%) | 5 (100%) |

`IChatModel` / `IChatModelGroup` carry arrow-function methods (`getDisplayName()`, `getDescription()`) — see [`src/constants/chat.ts`](src/constants/chat.ts).

`vuex-persistedstate` round-trips state through `JSON.stringify` → `localStorage` → `JSON.parse`, which silently drops function properties. After any reload, `store.state.chat.model` is a plain object with no methods, so [`ModelSelector.vue`](src/components/chat/ModelSelector.vue)'s `<span class="trigger-name">{{ model?.getDisplayName() }}</span>` throws.

The thrown render then turns the whole `<el-dropdown>` trigger into a Vue comment node. element-plus's popper code on the next tick calls `trigger.getBoundingClientRect()` — that's the second error.

## Fix

1. Remove `chat.model` and `chat.modelGroup` from [`src/store/chat/persist.ts`](src/store/chat/persist.ts). `ModelSelector.vue`'s `mounted()` hook already re-derives both from `route.meta.modelGroup` on every page load, so persisting them was a no-op for UX but a reliable source of runtime errors.

2. One-shot localStorage migration in [`src/store/index.ts`](src/store/index.ts) strips the stale `chat.model` / `chat.modelGroup` keys from the existing `'vuex'` blob before the plugin loads — so the 5 already-affected users get the fix on next page load without having to clear storage.

3. Defensive `?.()` in [`ModelSelector.vue`](src/components/chat/ModelSelector.vue) trigger label, so any future similar regression degrades to `model.name` instead of crashing the whole shell.

## Verification

- `eslint src/store/chat/persist.ts src/store/index.ts src/components/chat/ModelSelector.vue` — clean
- `vue-tsc --noEmit --skipLibCheck` — clean
- Manual: stuff `localStorage.vuex.chat.model = {name: 'gpt-5.5'}` (no methods), reload — pre-fix throws both errors immediately; post-fix the migration strips the bad value, ModelSelector remounts, dropdown renders normally.
