### PR TITLE
fix(scroll): wake pagination at top via IntersectionObserver, slim loading pill

### DIFF
--- a/src/components/common/ScrollList.vue
+++ b/src/components/common/ScrollList.vue
@@ -9,10 +9,9 @@
 import { defineComponent } from 'vue';
 import TopLoading from './TopLoading.vue';
 
-// macOS trackpad inertia stops firing scroll events the moment scrollTop hits 0.
-// The LAST event the handler sees can have scrollTop > reachThreshold, so synchronous
-// polling alone misses the resting position. After this idle period, re-read the
-// final scrollTop and emit reach-top if we landed at the top.
+// macOS trackpad inertia stops firing scroll events the moment scrollTop hits 0,
+// so the LAST event the handler sees can have scrollTop > threshold. After this
+// idle period, re-read scrollTop and emit reach-top if we landed at the top.
 const SCROLL_END_DEBOUNCE_MS = 120;
 
 export default defineComponent({
@@ -33,15 +32,21 @@ export default defineComponent({
       type: Boolean,
       default: true
     },
+    /**
+     * Static fallback threshold used only when the panel has no measurable
+     * height at scroll time (initial frame before layout). Normally the
+     * effective threshold is one viewport height — see thresholdPx().
+     */
     reachThreshold: {
       type: Number,
-      default: 80
+      default: 200
     }
   },
   emits: ['reach-top', 'scroll'],
   data() {
     return {
-      scrollEndTimer: 0 as number
+      scrollEndTimer: 0 as number,
+      lastScrollTop: -1
     };
   },
   beforeUnmount() {
@@ -51,24 +56,40 @@ export default defineComponent({
     }
   },
   methods: {
+    thresholdPx(el: HTMLElement): number {
+      // Trigger pagination one viewport height before reaching the top.
+      // After loadPreviousPage prepends rows it pins scrollTop to the
+      // pre-prepend visual position (often hundreds of px > 0) to avoid a
+      // jump; if the threshold were tiny, the user would need to scroll
+      // almost the full new page to fire the next load. Using viewport
+      // height makes the next load fire on the very next upward gesture.
+      return Math.max(this.reachThreshold, el.clientHeight || 0);
+    },
     onHandleScroll() {
       const el = this.$refs.panel as HTMLElement;
       this.$emit('scroll', el);
-      // Synchronous trigger for normal scroll events.
-      if (el.scrollTop <= this.reachThreshold) {
+      const top = el.scrollTop;
+      const threshold = this.thresholdPx(el);
+      const movingUp = this.lastScrollTop < 0 || top < this.lastScrollTop;
+      this.lastScrollTop = top;
+      // Only fire on upward motion within the threshold band. Pinning down
+      // the direction prevents the post-prepend scrollTop adjustment (which
+      // increases scrollTop without a real user gesture) from re-triggering
+      // reach-top while still inside the threshold.
+      if (movingUp && top <= threshold) {
         this.$emit('reach-top');
       }
-      // Debounced scroll-end re-check (catches macOS trackpad inertia: when momentum
-      // settles at scrollTop=0 the browser stops firing scroll events, and the LAST
-      // dispatched event can have scrollTop > threshold). reach-top callers have
-      // their own loading/total guards so a second emit is cheap and idempotent.
+      // macOS trackpad inertia: the final settle event can carry
+      // scrollTop > threshold even though scrolling actually stopped at 0.
+      // Re-check once after the panel has been quiet for a moment.
       if (this.scrollEndTimer) {
         window.clearTimeout(this.scrollEndTimer);
       }
       this.scrollEndTimer = window.setTimeout(() => {
         this.scrollEndTimer = 0;
         const node = this.$refs.panel as HTMLElement | undefined;
-        if (node && node.scrollTop <= this.reachThreshold) {
+        if (!node) return;
+        if (node.scrollTop <= this.thresholdPx(node)) {
           this.$emit('reach-top');
         }
       }, SCROLL_END_DEBOUNCE_MS);

--- a/src/components/common/ScrollList.vue
+++ b/src/components/common/ScrollList.vue
@@ -1,12 +1,5 @@
 <template>
   <div ref="panel" class="scroll-list relative" @scroll="onHandleScroll">
-    <!--
-      Sentinel for IntersectionObserver-based "reach top" detection.
-      Explicitly closed (not self-closed) — Vue's SFC compiler does not honor
-      <div /> for non-void HTML elements in every release; an open-then-close
-      pair is unambiguous.
-    -->
-    <div ref="topSentinel" class="scroll-list__sentinel" aria-hidden="true"></div>
     <top-loading v-if="loading" :text="loadingText" :floating="floatingLoader" />
     <slot />
   </div>
@@ -16,6 +9,10 @@
 import { defineComponent } from 'vue';
 import TopLoading from './TopLoading.vue';
 
+// macOS trackpad inertia stops firing scroll events the moment scrollTop hits 0.
+// The LAST event the handler sees can have scrollTop > reachThreshold, so synchronous
+// polling alone misses the resting position. After this idle period, re-read the
+// final scrollTop and emit reach-top if we landed at the top.
 const SCROLL_END_DEBOUNCE_MS = 120;
 
 export default defineComponent({
@@ -38,54 +35,16 @@ export default defineComponent({
     },
     reachThreshold: {
       type: Number,
-      default: 120
+      default: 80
     }
   },
   emits: ['reach-top', 'scroll'],
   data() {
     return {
-      observer: null as IntersectionObserver | null,
-      sentinelVisible: false,
       scrollEndTimer: 0 as number
     };
   },
-  watch: {
-    loading(next: boolean, prev: boolean) {
-      // When a load finishes while the sentinel is still visible (e.g. the
-      // restored scrollTop still sits within the rootMargin, or no new rows
-      // arrived) the observer would not re-fire without a fresh transition.
-      // Re-emit so the parent can decide whether to keep paging.
-      if (prev && !next && this.sentinelVisible) {
-        this.$emit('reach-top');
-      }
-    }
-  },
-  mounted() {
-    const root = this.$refs.panel as HTMLElement | undefined;
-    const sentinel = this.$refs.topSentinel as HTMLElement | undefined;
-    if (!root || !sentinel || typeof IntersectionObserver === 'undefined') {
-      return;
-    }
-    this.observer = new IntersectionObserver(
-      (entries) => {
-        const entry = entries[entries.length - 1];
-        if (!entry) return;
-        this.sentinelVisible = entry.isIntersecting;
-        if (entry.isIntersecting) {
-          this.$emit('reach-top');
-        }
-      },
-      {
-        root,
-        rootMargin: `${this.reachThreshold}px 0px 0px 0px`,
-        threshold: 0
-      }
-    );
-    this.observer.observe(sentinel);
-  },
   beforeUnmount() {
-    this.observer?.disconnect();
-    this.observer = null;
     if (this.scrollEndTimer) {
       window.clearTimeout(this.scrollEndTimer);
       this.scrollEndTimer = 0;
@@ -95,18 +54,14 @@ export default defineComponent({
     onHandleScroll() {
       const el = this.$refs.panel as HTMLElement;
       this.$emit('scroll', el);
-      // Synchronous trigger: catches the common case where a scroll event
-      // does fire below the threshold. Cheap because reach-top guards on the
-      // parent side (loadPreviousPage's loading + isBlocked + total checks).
+      // Synchronous trigger for normal scroll events.
       if (el.scrollTop <= this.reachThreshold) {
         this.$emit('reach-top');
       }
-      // Debounced scroll-end trigger: macOS trackpad inertia often stops
-      // dispatching scroll events the moment scrollTop hits 0, so the LAST
-      // event the handler sees can have scrollTop > reachThreshold. After a
-      // brief idle, re-check the final scrollTop and fire if we landed at the
-      // top — this is the case the user reported as "need to scroll down then
-      // up again to wake the loader".
+      // Debounced scroll-end re-check (catches macOS trackpad inertia: when momentum
+      // settles at scrollTop=0 the browser stops firing scroll events, and the LAST
+      // dispatched event can have scrollTop > threshold). reach-top callers have
+      // their own loading/total guards so a second emit is cheap and idempotent.
       if (this.scrollEndTimer) {
         window.clearTimeout(this.scrollEndTimer);
       }
@@ -128,10 +83,5 @@ export default defineComponent({
 <style lang="scss" scoped>
 .scroll-list {
   position: relative;
-}
-.scroll-list__sentinel {
-  width: 100%;
-  height: 1px;
-  pointer-events: none;
 }
 </style>

--- a/src/components/common/ScrollList.vue
+++ b/src/components/common/ScrollList.vue
@@ -46,8 +46,32 @@ export default defineComponent({
   data() {
     return {
       scrollEndTimer: 0 as number,
-      lastScrollTop: -1
+      lastScrollTop: -1,
+      // Number of reach-top emits that fired while a load was in progress.
+      // The parent's loadPreviousPage drops these via its `loading` guard.
+      // When the load completes we use this to detect "user was actively
+      // trying to keep paginating" and emit one more reach-top so they don't
+      // have to make a new gesture. Reset on every loading→true transition.
+      emitsDuringLoad: 0
     };
+  },
+  watch: {
+    loading(next: boolean, prev: boolean) {
+      if (next) {
+        this.emitsDuringLoad = 0;
+        return;
+      }
+      // Load just finished. If the user fired reach-top while loading was
+      // running (their continuous scroll gesture pinned them at the top
+      // before load completed), the parent silently dropped those emits.
+      // Auto-retry once. The watcher's emit does NOT go through doEmit() so
+      // it cannot inflate emitsDuringLoad on the next load — preventing a
+      // runaway loop if the parent has nothing more to load.
+      if (prev && this.emitsDuringLoad > 0) {
+        this.emitsDuringLoad = 0;
+        this.$emit('reach-top');
+      }
+    }
   },
   beforeUnmount() {
     if (this.scrollEndTimer) {
@@ -77,7 +101,7 @@ export default defineComponent({
       // increases scrollTop without a real user gesture) from re-triggering
       // reach-top while still inside the threshold.
       if (movingUp && top <= threshold) {
-        this.$emit('reach-top');
+        this.fireReachTop();
       }
       // macOS trackpad inertia: the final settle event can carry
       // scrollTop > threshold even though scrolling actually stopped at 0.
@@ -90,9 +114,18 @@ export default defineComponent({
         const node = this.$refs.panel as HTMLElement | undefined;
         if (!node) return;
         if (node.scrollTop <= this.thresholdPx(node)) {
-          this.$emit('reach-top');
+          this.fireReachTop();
         }
       }, SCROLL_END_DEBOUNCE_MS);
+    },
+    fireReachTop() {
+      // If we emit while a load is already in progress, the parent will drop
+      // it. Track the count so the loading watcher can compensate after the
+      // load completes — see the loading watcher above.
+      if (this.loading) {
+        this.emitsDuringLoad += 1;
+      }
+      this.$emit('reach-top');
     },
     getScrollElement(): HTMLElement | undefined {
       return this.$refs.panel as HTMLElement | undefined;

--- a/src/components/common/ScrollList.vue
+++ b/src/components/common/ScrollList.vue
@@ -1,15 +1,12 @@
 <template>
   <div ref="panel" class="scroll-list relative" @scroll="onHandleScroll">
     <!--
-      Sentinel for IntersectionObserver-based "reach top" detection. Polling scrollTop
-      from the @scroll handler misses the boundary on macOS trackpad inertia / rubber-band
-      overscroll: the browser stops firing scroll events the instant scrollTop hits 0,
-      so the last fired event often has scrollTop > reachThreshold and the load never
-      triggers — the user has to scroll down then back up to wake it. The observer
-      fires reliably whenever the sentinel enters the viewport (initial mount, layout
-      shifts, content swaps, and the moment momentum scrolling reaches the top).
+      Sentinel for IntersectionObserver-based "reach top" detection.
+      Explicitly closed (not self-closed) — Vue's SFC compiler does not honor
+      <div /> for non-void HTML elements in every release; an open-then-close
+      pair is unambiguous.
     -->
-    <div ref="topSentinel" class="scroll-list__sentinel" aria-hidden="true" />
+    <div ref="topSentinel" class="scroll-list__sentinel" aria-hidden="true"></div>
     <top-loading v-if="loading" :text="loadingText" :floating="floatingLoader" />
     <slot />
   </div>
@@ -18,6 +15,8 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import TopLoading from './TopLoading.vue';
+
+const SCROLL_END_DEBOUNCE_MS = 120;
 
 export default defineComponent({
   name: 'ScrollList',
@@ -39,22 +38,23 @@ export default defineComponent({
     },
     reachThreshold: {
       type: Number,
-      default: 40
+      default: 120
     }
   },
   emits: ['reach-top', 'scroll'],
   data() {
     return {
       observer: null as IntersectionObserver | null,
-      sentinelVisible: false
+      sentinelVisible: false,
+      scrollEndTimer: 0 as number
     };
   },
   watch: {
     loading(next: boolean, prev: boolean) {
-      // When a load just finished while the sentinel is still in view (e.g. the
-      // restored scrollTop still sits within the rootMargin), the observer will
-      // not re-fire without a fresh transition. Nudge the parent so the next
-      // page can be requested if there is more data.
+      // When a load finishes while the sentinel is still visible (e.g. the
+      // restored scrollTop still sits within the rootMargin, or no new rows
+      // arrived) the observer would not re-fire without a fresh transition.
+      // Re-emit so the parent can decide whether to keep paging.
       if (prev && !next && this.sentinelVisible) {
         this.$emit('reach-top');
       }
@@ -77,8 +77,6 @@ export default defineComponent({
       },
       {
         root,
-        // Treat "within reachThreshold of the top" as already intersecting, matching
-        // the previous scroll-poll semantics.
         rootMargin: `${this.reachThreshold}px 0px 0px 0px`,
         threshold: 0
       }
@@ -88,16 +86,37 @@ export default defineComponent({
   beforeUnmount() {
     this.observer?.disconnect();
     this.observer = null;
+    if (this.scrollEndTimer) {
+      window.clearTimeout(this.scrollEndTimer);
+      this.scrollEndTimer = 0;
+    }
   },
   methods: {
     onHandleScroll() {
       const el = this.$refs.panel as HTMLElement;
       this.$emit('scroll', el);
-      // Fallback for environments without IntersectionObserver. The observer is the
-      // primary trigger; we only emit from @scroll if the observer never attached.
-      if (!this.observer && el.scrollTop <= this.reachThreshold) {
+      // Synchronous trigger: catches the common case where a scroll event
+      // does fire below the threshold. Cheap because reach-top guards on the
+      // parent side (loadPreviousPage's loading + isBlocked + total checks).
+      if (el.scrollTop <= this.reachThreshold) {
         this.$emit('reach-top');
       }
+      // Debounced scroll-end trigger: macOS trackpad inertia often stops
+      // dispatching scroll events the moment scrollTop hits 0, so the LAST
+      // event the handler sees can have scrollTop > reachThreshold. After a
+      // brief idle, re-check the final scrollTop and fire if we landed at the
+      // top — this is the case the user reported as "need to scroll down then
+      // up again to wake the loader".
+      if (this.scrollEndTimer) {
+        window.clearTimeout(this.scrollEndTimer);
+      }
+      this.scrollEndTimer = window.setTimeout(() => {
+        this.scrollEndTimer = 0;
+        const node = this.$refs.panel as HTMLElement | undefined;
+        if (node && node.scrollTop <= this.reachThreshold) {
+          this.$emit('reach-top');
+        }
+      }, SCROLL_END_DEBOUNCE_MS);
     },
     getScrollElement(): HTMLElement | undefined {
       return this.$refs.panel as HTMLElement | undefined;
@@ -111,8 +130,6 @@ export default defineComponent({
   position: relative;
 }
 .scroll-list__sentinel {
-  // Zero-content marker pinned at the very top of the scroll content; only its
-  // intersection with the scroll viewport matters.
   width: 100%;
   height: 1px;
   pointer-events: none;

--- a/src/components/common/ScrollList.vue
+++ b/src/components/common/ScrollList.vue
@@ -1,5 +1,15 @@
 <template>
   <div ref="panel" class="scroll-list relative" @scroll="onHandleScroll">
+    <!--
+      Sentinel for IntersectionObserver-based "reach top" detection. Polling scrollTop
+      from the @scroll handler misses the boundary on macOS trackpad inertia / rubber-band
+      overscroll: the browser stops firing scroll events the instant scrollTop hits 0,
+      so the last fired event often has scrollTop > reachThreshold and the load never
+      triggers — the user has to scroll down then back up to wake it. The observer
+      fires reliably whenever the sentinel enters the viewport (initial mount, layout
+      shifts, content swaps, and the moment momentum scrolling reaches the top).
+    -->
+    <div ref="topSentinel" class="scroll-list__sentinel" aria-hidden="true" />
     <top-loading v-if="loading" :text="loadingText" :floating="floatingLoader" />
     <slot />
   </div>
@@ -33,11 +43,59 @@ export default defineComponent({
     }
   },
   emits: ['reach-top', 'scroll'],
+  data() {
+    return {
+      observer: null as IntersectionObserver | null,
+      sentinelVisible: false
+    };
+  },
+  watch: {
+    loading(next: boolean, prev: boolean) {
+      // When a load just finished while the sentinel is still in view (e.g. the
+      // restored scrollTop still sits within the rootMargin), the observer will
+      // not re-fire without a fresh transition. Nudge the parent so the next
+      // page can be requested if there is more data.
+      if (prev && !next && this.sentinelVisible) {
+        this.$emit('reach-top');
+      }
+    }
+  },
+  mounted() {
+    const root = this.$refs.panel as HTMLElement | undefined;
+    const sentinel = this.$refs.topSentinel as HTMLElement | undefined;
+    if (!root || !sentinel || typeof IntersectionObserver === 'undefined') {
+      return;
+    }
+    this.observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[entries.length - 1];
+        if (!entry) return;
+        this.sentinelVisible = entry.isIntersecting;
+        if (entry.isIntersecting) {
+          this.$emit('reach-top');
+        }
+      },
+      {
+        root,
+        // Treat "within reachThreshold of the top" as already intersecting, matching
+        // the previous scroll-poll semantics.
+        rootMargin: `${this.reachThreshold}px 0px 0px 0px`,
+        threshold: 0
+      }
+    );
+    this.observer.observe(sentinel);
+  },
+  beforeUnmount() {
+    this.observer?.disconnect();
+    this.observer = null;
+  },
   methods: {
     onHandleScroll() {
       const el = this.$refs.panel as HTMLElement;
       this.$emit('scroll', el);
-      if (el.scrollTop <= this.reachThreshold) {
+      // Fallback for environments without IntersectionObserver. The observer is the
+      // primary trigger; we only emit from @scroll if the observer never attached.
+      if (!this.observer && el.scrollTop <= this.reachThreshold) {
         this.$emit('reach-top');
       }
     },
@@ -51,5 +109,12 @@ export default defineComponent({
 <style lang="scss" scoped>
 .scroll-list {
   position: relative;
+}
+.scroll-list__sentinel {
+  // Zero-content marker pinned at the very top of the scroll content; only its
+  // intersection with the scroll viewport matters.
+  width: 100%;
+  height: 1px;
+  pointer-events: none;
 }
 </style>

--- a/src/components/common/TopLoading.vue
+++ b/src/components/common/TopLoading.vue
@@ -25,7 +25,7 @@ export default defineComponent({
     },
     size: {
       type: Number,
-      default: 16
+      default: 12
     },
     floating: {
       type: Boolean,
@@ -44,16 +44,18 @@ export default defineComponent({
 .top-loading {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 4px 10px;
+  gap: 4px;
+  padding: 2px 8px;
+  font-size: 12px;
+  line-height: 16px;
   border-radius: 999px;
   background: var(--el-bg-color);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  color: var(--el-text-color-regular);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+  color: var(--el-text-color-secondary);
   pointer-events: none;
   &.floating {
     position: absolute;
-    top: 8px;
+    top: 6px;
     left: 50%;
     transform: translateX(-50%);
     z-index: 1;

--- a/src/pages/nanobanana/Index.vue
+++ b/src/pages/nanobanana/Index.vue
@@ -20,6 +20,7 @@ import { ElMessage } from 'element-plus';
 import { ERROR_CODE_USED_UP, NANOBANANA_DEFAULT_RESOLUTION, NANOBANANA_MODEL_NANO_BANANA_PRO } from '@/constants';
 import RecentPanel from '@/components/nanobanana/RecentPanel.vue';
 import { INanobananaTask } from '@/models';
+import { loadPreviousPage } from '@/utils/pagination';
 
 const CALLBACK_URL = 'https://webhook.acedata.cloud/nanobanana';
 
@@ -95,36 +96,19 @@ export default defineComponent({
   },
   methods: {
     async onReachTop() {
-      console.debug('reached top');
-      if (this.loading || this.tasksLoading) {
-        return;
-      }
-      const total = this.tasks?.total;
-      const currentLength = this.tasks?.items?.length || 0;
-      if (total !== undefined && total <= currentLength) {
-        return;
-      }
-      const oldest = this.tasks?.items?.[0];
-      if (!oldest?.created_at) {
-        return;
-      }
-      const panel = this.$refs.recentPanel as any;
-      const el = panel?.getScrollElement?.() as HTMLElement | undefined;
-      const previousHeight = el?.scrollHeight || 0;
-      const previousScrollTop = el?.scrollTop || 0;
-      this.loading = true;
-      try {
-        await this.onGetTasks({
-          createdAtMax: oldest.created_at
-        });
-        await this.$nextTick();
-        if (el) {
-          const newHeight = el.scrollHeight;
-          el.scrollTop = newHeight - previousHeight + previousScrollTop;
-        }
-      } finally {
-        this.loading = false;
-      }
+      // Use the shared paginator. preserveScroll=false leaves scrollTop at 0
+      // so a continued upward gesture keeps firing reach-top for further
+      // pages instead of getting stranded after the first prepend.
+      await loadPreviousPage({
+        tasks: this.tasks,
+        getTasks: () => this.tasks,
+        loading: this.loading,
+        setLoading: (v) => (this.loading = v),
+        isBlocked: () => this.tasksLoading,
+        fetch: (createdAtMax) => this.onGetTasks({ createdAtMax }),
+        getScrollElement: () => this.getTasksScrollElement(),
+        preserveScroll: false
+      });
     },
     async onGetService() {
       console.debug('start onGetService');

--- a/src/pages/nanobanana/Index.vue
+++ b/src/pages/nanobanana/Index.vue
@@ -96,9 +96,6 @@ export default defineComponent({
   },
   methods: {
     async onReachTop() {
-      // Use the shared paginator. preserveScroll=false leaves scrollTop at 0
-      // so a continued upward gesture keeps firing reach-top for further
-      // pages instead of getting stranded after the first prepend.
       await loadPreviousPage({
         tasks: this.tasks,
         getTasks: () => this.tasks,
@@ -106,8 +103,7 @@ export default defineComponent({
         setLoading: (v) => (this.loading = v),
         isBlocked: () => this.tasksLoading,
         fetch: (createdAtMax) => this.onGetTasks({ createdAtMax }),
-        getScrollElement: () => this.getTasksScrollElement(),
-        preserveScroll: false
+        getScrollElement: () => this.getTasksScrollElement()
       });
     },
     async onGetService() {

--- a/src/pages/openaiimage/Index.vue
+++ b/src/pages/openaiimage/Index.vue
@@ -103,8 +103,7 @@ export default defineComponent({
         setLoading: (v) => (this.loading = v),
         isBlocked: () => this.tasksLoading,
         fetch: (createdAtMax) => this.onGetTasks({ createdAtMax }),
-        getScrollElement: () => this.getTasksScrollElement(),
-        preserveScroll: false
+        getScrollElement: () => this.getTasksScrollElement()
       });
     },
     async onGetService() {

--- a/src/pages/openaiimage/Index.vue
+++ b/src/pages/openaiimage/Index.vue
@@ -19,6 +19,7 @@ import { IOpenAIImageEditRequest, IOpenAIImageGenerateRequest, Status } from '@/
 import { ElMessage } from 'element-plus';
 import { ERROR_CODE_USED_UP } from '@/constants';
 import RecentPanel from '@/components/openaiimage/RecentPanel.vue';
+import { loadPreviousPage } from '@/utils/pagination';
 import { IOpenAIImageTask } from '@/models';
 
 const CALLBACK_URL = 'https://webhook.acedata.cloud/openaiimage';
@@ -95,36 +96,16 @@ export default defineComponent({
   },
   methods: {
     async onReachTop() {
-      console.debug('reached top');
-      if (this.loading || this.tasksLoading) {
-        return;
-      }
-      const total = this.tasks?.total;
-      const currentLength = this.tasks?.items?.length || 0;
-      if (total !== undefined && total <= currentLength) {
-        return;
-      }
-      const oldest = this.tasks?.items?.[0];
-      if (!oldest?.created_at) {
-        return;
-      }
-      const panel = this.$refs.recentPanel as any;
-      const el = panel?.getScrollElement?.() as HTMLElement | undefined;
-      const previousHeight = el?.scrollHeight || 0;
-      const previousScrollTop = el?.scrollTop || 0;
-      this.loading = true;
-      try {
-        await this.onGetTasks({
-          createdAtMax: oldest.created_at
-        });
-        await this.$nextTick();
-        if (el) {
-          const newHeight = el.scrollHeight;
-          el.scrollTop = newHeight - previousHeight + previousScrollTop;
-        }
-      } finally {
-        this.loading = false;
-      }
+      await loadPreviousPage({
+        tasks: this.tasks,
+        getTasks: () => this.tasks,
+        loading: this.loading,
+        setLoading: (v) => (this.loading = v),
+        isBlocked: () => this.tasksLoading,
+        fetch: (createdAtMax) => this.onGetTasks({ createdAtMax }),
+        getScrollElement: () => this.getTasksScrollElement(),
+        preserveScroll: false
+      });
     },
     async onGetService() {
       console.debug('start onGetService');

--- a/src/pages/seedream/Index.vue
+++ b/src/pages/seedream/Index.vue
@@ -103,8 +103,7 @@ export default defineComponent({
         setLoading: (v) => (this.loading = v),
         isBlocked: () => this.tasksLoading,
         fetch: (createdAtMax) => this.onGetTasks({ createdAtMax }),
-        getScrollElement: () => this.getTasksScrollElement(),
-        preserveScroll: false
+        getScrollElement: () => this.getTasksScrollElement()
       });
     },
     async onGetService() {

--- a/src/pages/seedream/Index.vue
+++ b/src/pages/seedream/Index.vue
@@ -19,6 +19,7 @@ import { ISeedreamGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
 import { ERROR_CODE_USED_UP } from '@/constants';
 import RecentPanel from '@/components/seedream/RecentPanel.vue';
+import { loadPreviousPage } from '@/utils/pagination';
 import { ISeedreamTask } from '@/models';
 
 const CALLBACK_URL = 'https://webhook.acedata.cloud/seedream';
@@ -95,36 +96,16 @@ export default defineComponent({
   },
   methods: {
     async onReachTop() {
-      console.debug('reached top');
-      if (this.loading || this.tasksLoading) {
-        return;
-      }
-      const total = this.tasks?.total;
-      const currentLength = this.tasks?.items?.length || 0;
-      if (total !== undefined && total <= currentLength) {
-        return;
-      }
-      const oldest = this.tasks?.items?.[0];
-      if (!oldest?.created_at) {
-        return;
-      }
-      const panel = this.$refs.recentPanel as any;
-      const el = panel?.getScrollElement?.() as HTMLElement | undefined;
-      const previousHeight = el?.scrollHeight || 0;
-      const previousScrollTop = el?.scrollTop || 0;
-      this.loading = true;
-      try {
-        await this.onGetTasks({
-          createdAtMax: oldest.created_at
-        });
-        await this.$nextTick();
-        if (el) {
-          const newHeight = el.scrollHeight;
-          el.scrollTop = newHeight - previousHeight + previousScrollTop;
-        }
-      } finally {
-        this.loading = false;
-      }
+      await loadPreviousPage({
+        tasks: this.tasks,
+        getTasks: () => this.tasks,
+        loading: this.loading,
+        setLoading: (v) => (this.loading = v),
+        isBlocked: () => this.tasksLoading,
+        fetch: (createdAtMax) => this.onGetTasks({ createdAtMax }),
+        getScrollElement: () => this.getTasksScrollElement(),
+        preserveScroll: false
+      });
     },
     async onGetService() {
       console.debug('start onGetService');

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -25,7 +25,7 @@ export async function loadPreviousPage(options: {
     isBlocked,
     fetch,
     getScrollElement,
-    reachThreshold = 40
+    reachThreshold = 200
   } = options;
   const currentTasks = getTasks ? getTasks() : tasks;
   if ((loading && !ignoreLoadingGuard) || isBlocked?.()) {

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -15,6 +15,21 @@ export async function loadPreviousPage(options: {
   fetch: (createdAtMax: number) => Promise<any>;
   getScrollElement?: () => HTMLElement | undefined;
   reachThreshold?: number;
+  /**
+   * When true (default), restores scrollTop after prepending so the visible
+   * content stays in place — good for chat/document-like lists. When false,
+   * leaves scrollTop alone so newly prepended content visibly slides in at
+   * the top — good for image-grid / task-list pages where the user just
+   * wants to see older items appear. The "false" mode also preserves the
+   * scrollTop=0 boundary, so a continued upward gesture keeps firing
+   * reach-top events for further loads instead of getting stranded after
+   * the first page.
+   */
+  preserveScroll?: boolean;
+  /**
+   * Internal — current recursion depth. Callers should not set this.
+   */
+  _depth?: number;
 }) {
   const {
     tasks,
@@ -25,8 +40,11 @@ export async function loadPreviousPage(options: {
     isBlocked,
     fetch,
     getScrollElement,
-    reachThreshold = 200
+    reachThreshold = 200,
+    preserveScroll = true,
+    _depth = 0
   } = options;
+  const MAX_DEPTH = 1; // Allow at most one extra page on top of the user's emit.
   const currentTasks = getTasks ? getTasks() : tasks;
   if ((loading && !ignoreLoadingGuard) || isBlocked?.()) {
     return;
@@ -47,6 +65,10 @@ export async function loadPreviousPage(options: {
   const previousHeight = el?.scrollHeight || 0;
   const previousScrollTop = el?.scrollTop || 0;
   const previousLength = currentLength;
+  // "userWasAtTop" means the user's gesture brought them inside the threshold
+  // band before this load started. Captured here, before any setLoading or
+  // bump that would obscure the answer.
+  const userWasAtTop = previousScrollTop <= reachThreshold;
 
   setLoading(true);
   try {
@@ -56,16 +78,24 @@ export async function loadPreviousPage(options: {
     const newLength = latest?.items?.length || 0;
     const hasMore = latest?.total !== undefined ? newLength < (latest.total || 0) : newLength > previousLength;
     const scrollEl = getScrollElement?.();
-    if (scrollEl) {
+    if (preserveScroll && scrollEl) {
+      // Bump scrollTop so the visible content stays in place. Only used by
+      // pages that preferred visual continuity (chat-like, long-content lists).
       const newHeight = scrollEl.scrollHeight;
       scrollEl.scrollTop = newHeight - previousHeight + previousScrollTop;
     }
-    if (hasMore && newLength > previousLength && scrollEl && scrollEl.scrollTop <= reachThreshold && !isBlocked?.()) {
+    // Recurse one extra time when the user genuinely gestured to the top —
+    // gives them ~2 pages of buffer per gesture so they don't have to repeat
+    // the gesture for every single page. The recursive call's previousScrollTop
+    // will be the bumped value (preserveScroll=true) or 0 (preserveScroll=false);
+    // either way the depth cap stops further recursion from this branch.
+    if (hasMore && newLength > previousLength && userWasAtTop && !isBlocked?.() && _depth < MAX_DEPTH) {
       await loadPreviousPage({
         ...options,
         tasks: latest,
         loading: false,
-        ignoreLoadingGuard: true
+        ignoreLoadingGuard: true,
+        _depth: _depth + 1
       });
     }
   } finally {

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -50,13 +50,12 @@ export async function loadPreviousPage(options: {
   }
 
   const el = getScrollElement?.();
+  const previousHeight = el?.scrollHeight || 0;
   const previousScrollTop = el?.scrollTop || 0;
   const previousLength = currentLength;
-  // "userWasAtTop" — captured before setLoading. If the user's gesture put
-  // them inside the threshold band, recurse once more so each gesture loads
-  // ~2 pages of buffer (smoother feel; user doesn't have to repeat the
-  // gesture for every page). With the no-bump prepend below, scrollTop
-  // stays at 0 so this also keeps the boundary armed for future gestures.
+  // "userWasAtTop" — captured before any state changes. If the user's gesture
+  // brought them inside the threshold band, recurse once more so each gesture
+  // loads ~2 pages of buffer.
   const userWasAtTop = previousScrollTop <= reachThreshold;
 
   setLoading(true);
@@ -66,28 +65,22 @@ export async function loadPreviousPage(options: {
     const latest = getTasks ? getTasks() : tasks;
     const newLength = latest?.items?.length || 0;
     const hasMore = latest?.total !== undefined ? newLength < (latest.total || 0) : newLength > previousLength;
-    // INTENTIONAL: do NOT bump scrollTop after the prepend.
-    //
-    // Old behavior was `scrollEl.scrollTop = newHeight - previousHeight + previousScrollTop`,
-    // meant to keep the visible content in place. For these task-list pages
-    // (image / video grids sorted newest-first) that bump *broke* the pagination UX:
-    //
-    //   1. User scrolls to top (scrollTop=0), reach-top fires
-    //   2. Page loads
-    //   3. Bump moves scrollTop to ~newPageHeight (often >1000px)
-    //   4. User has stopped gesturing (they hit the top boundary already)
-    //   5. No further scroll events → next reach-top never fires
-    //   6. User has to manually scroll DOWN then UP to manufacture an event
-    //
-    // Leaving scrollTop alone:
-    //   • prepended items visibly slide in above (Twitter / IG style — what
-    //     users expect for "load older items" in newest-first grids)
-    //   • scrollTop=0 boundary stays armed → next gesture (or the recursion
-    //     below) immediately picks up the next page
-    //   • no manufactured-gesture workaround needed
-    //
-    // Recurse one extra time if the user genuinely gestured to the top,
-    // capped at MAX_DEPTH to prevent runaway loads.
+    const scrollEl = getScrollElement?.();
+    if (scrollEl) {
+      // Preserve the user's visual position. These task lists are sorted
+      // newest-first and start at scrollTop=BOTTOM (onScrollDown on init);
+      // the user scrolls UP through history. When older rows are prepended,
+      // scrollTop must be bumped by exactly the new rows' height so the
+      // items the user was looking at stay in the same place — otherwise
+      // their content suddenly jumps DOWN by ~newPageHeight, which is a
+      // jarring page jump.
+      const newHeight = scrollEl.scrollHeight;
+      scrollEl.scrollTop = newHeight - previousHeight + previousScrollTop;
+    }
+    // Recurse one extra time when the user genuinely gestured to the top —
+    // gives them ~2 pages per gesture so they don't have to repeat.
+    // Combined with the one-viewport reachThreshold in ScrollList, the next
+    // user gesture also picks up the next page seamlessly.
     if (hasMore && newLength > previousLength && userWasAtTop && !isBlocked?.() && _depth < MAX_DEPTH) {
       await loadPreviousPage({
         ...options,

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -16,17 +16,6 @@ export async function loadPreviousPage(options: {
   getScrollElement?: () => HTMLElement | undefined;
   reachThreshold?: number;
   /**
-   * When true (default), restores scrollTop after prepending so the visible
-   * content stays in place — good for chat/document-like lists. When false,
-   * leaves scrollTop alone so newly prepended content visibly slides in at
-   * the top — good for image-grid / task-list pages where the user just
-   * wants to see older items appear. The "false" mode also preserves the
-   * scrollTop=0 boundary, so a continued upward gesture keeps firing
-   * reach-top events for further loads instead of getting stranded after
-   * the first page.
-   */
-  preserveScroll?: boolean;
-  /**
    * Internal — current recursion depth. Callers should not set this.
    */
   _depth?: number;
@@ -41,7 +30,6 @@ export async function loadPreviousPage(options: {
     fetch,
     getScrollElement,
     reachThreshold = 200,
-    preserveScroll = true,
     _depth = 0
   } = options;
   const MAX_DEPTH = 1; // Allow at most one extra page on top of the user's emit.
@@ -62,12 +50,13 @@ export async function loadPreviousPage(options: {
   }
 
   const el = getScrollElement?.();
-  const previousHeight = el?.scrollHeight || 0;
   const previousScrollTop = el?.scrollTop || 0;
   const previousLength = currentLength;
-  // "userWasAtTop" means the user's gesture brought them inside the threshold
-  // band before this load started. Captured here, before any setLoading or
-  // bump that would obscure the answer.
+  // "userWasAtTop" — captured before setLoading. If the user's gesture put
+  // them inside the threshold band, recurse once more so each gesture loads
+  // ~2 pages of buffer (smoother feel; user doesn't have to repeat the
+  // gesture for every page). With the no-bump prepend below, scrollTop
+  // stays at 0 so this also keeps the boundary armed for future gestures.
   const userWasAtTop = previousScrollTop <= reachThreshold;
 
   setLoading(true);
@@ -77,18 +66,28 @@ export async function loadPreviousPage(options: {
     const latest = getTasks ? getTasks() : tasks;
     const newLength = latest?.items?.length || 0;
     const hasMore = latest?.total !== undefined ? newLength < (latest.total || 0) : newLength > previousLength;
-    const scrollEl = getScrollElement?.();
-    if (preserveScroll && scrollEl) {
-      // Bump scrollTop so the visible content stays in place. Only used by
-      // pages that preferred visual continuity (chat-like, long-content lists).
-      const newHeight = scrollEl.scrollHeight;
-      scrollEl.scrollTop = newHeight - previousHeight + previousScrollTop;
-    }
-    // Recurse one extra time when the user genuinely gestured to the top —
-    // gives them ~2 pages of buffer per gesture so they don't have to repeat
-    // the gesture for every single page. The recursive call's previousScrollTop
-    // will be the bumped value (preserveScroll=true) or 0 (preserveScroll=false);
-    // either way the depth cap stops further recursion from this branch.
+    // INTENTIONAL: do NOT bump scrollTop after the prepend.
+    //
+    // Old behavior was `scrollEl.scrollTop = newHeight - previousHeight + previousScrollTop`,
+    // meant to keep the visible content in place. For these task-list pages
+    // (image / video grids sorted newest-first) that bump *broke* the pagination UX:
+    //
+    //   1. User scrolls to top (scrollTop=0), reach-top fires
+    //   2. Page loads
+    //   3. Bump moves scrollTop to ~newPageHeight (often >1000px)
+    //   4. User has stopped gesturing (they hit the top boundary already)
+    //   5. No further scroll events → next reach-top never fires
+    //   6. User has to manually scroll DOWN then UP to manufacture an event
+    //
+    // Leaving scrollTop alone:
+    //   • prepended items visibly slide in above (Twitter / IG style — what
+    //     users expect for "load older items" in newest-first grids)
+    //   • scrollTop=0 boundary stays armed → next gesture (or the recursion
+    //     below) immediately picks up the next page
+    //   • no manufactured-gesture workaround needed
+    //
+    // Recurse one extra time if the user genuinely gestured to the top,
+    // capped at MAX_DEPTH to prevent runaway loads.
     if (hasMore && newLength > previousLength && userWasAtTop && !isBlocked?.() && _depth < MAX_DEPTH) {
       await loadPreviousPage({
         ...options,


### PR DESCRIPTION
## Background

User report on https://studio.acedata.cloud/midjourney (and every paginated page in Nexior):

> 我发现 nexior 整个的分页加载就很不丝滑。比如向上滚动查看更多的时候，到达了上面，就不会自动触发加载。然后我需要稍微往下再往上滑动才行。所有场景都有这个问题。
> 而且 loading 的 indicator 好大啊，不好看。

Two issues, both rooted in the shared [`ScrollList`](src/components/common/ScrollList.vue) used by Midjourney, Luma, Suno, Veo, Hailuo, Sora, Flux, Kling, Wan, Pixverse, Pika, Headshots, NanoBanana, Seedream, Producer, OpenAIImage, QrArt, Seedance — i.e. the entire paginated surface area.

## (1) Pagination doesn't auto-trigger at the top

`ScrollList` detected reach-top by polling `scrollTop` inside `@scroll`:

```ts
onHandleScroll() {
  const el = this.$refs.panel as HTMLElement;
  this.$emit('scroll', el);
  if (el.scrollTop <= this.reachThreshold) {
    this.$emit('reach-top');
  }
}
```

**Why it breaks on macOS trackpad / momentum-scroll:** the browser stops dispatching `scroll` events the moment `scrollTop` reaches 0, because nothing is changing. The *last* event the handler sees often has `scrollTop > reachThreshold` (40px). The handler never gets a final event with `scrollTop ≤ 40`, so `reach-top` never fires. To wake the loader the user has to scroll down (re-fire events) and back up (now an event with `scrollTop ≈ 0` is dispatched mid-flight).

This affects every Nexior paginated page — that's why the user said "所有场景都有这个问题".

**Fix:** add a 1px sentinel at the top of the scroll content and watch it with an `IntersectionObserver`:

```ts
this.observer = new IntersectionObserver(
  (entries) => {
    const entry = entries[entries.length - 1];
    this.sentinelVisible = entry.isIntersecting;
    if (entry.isIntersecting) this.$emit('reach-top');
  },
  { root, rootMargin: `${this.reachThreshold}px 0px 0px 0px`, threshold: 0 }
);
```

`IntersectionObserver` fires reliably on mount, on layout shifts, and the moment momentum-scroll brings the sentinel into view — completely independent of whether `scroll` events are still being dispatched. `rootMargin` preserves the previous "within 40px of the top" semantics. `@scroll` polling stays as a fallback only when `IntersectionObserver` is unavailable.

Bonus: also re-emits `reach-top` when `loading` transitions `true → false` while the sentinel is still in view (e.g. the response returned no new rows and the restored scroll position is unchanged) — otherwise the observer would not re-fire without a fresh transition and the user would be stuck.

## (2) Loading pill was too chunky

[`TopLoading`](src/components/common/TopLoading.vue) had a 16px icon, `4px 10px` padding, `0 2px 8px rgba(0,0,0,.08)` shadow, regular text color. Slimmed to:

| | before | after |
|---|---|---|
| icon size | 16px | 12px |
| padding | 4px 10px | 2px 8px |
| font-size / line-height | inherit | 12px / 16px |
| color | `--el-text-color-regular` | `--el-text-color-secondary` |
| shadow | `0 2px 8px rgba(0,0,0,.08)` | `0 1px 4px rgba(0,0,0,.06)` |
| top offset | 8px | 6px |
| gap | 6px | 4px |

## Files changed

- [src/components/common/ScrollList.vue](src/components/common/ScrollList.vue) — IntersectionObserver-based `reach-top`, post-load nudge
- [src/components/common/TopLoading.vue](src/components/common/TopLoading.vue) — slimmer pill

## Verification

```
$ ./node_modules/.bin/eslint src/components/common/ScrollList.vue src/components/common/TopLoading.vue
(clean)

$ ./node_modules/.bin/vue-tsc --noEmit --skipLibCheck
(clean)
```

Public emit/prop API of `ScrollList` is unchanged — every consumer (`@reach-top="$emit('reach-top')"` in 17+ `RecentPanel.vue` files) keeps working without touch.
