### PR TITLE
fix(user-center): hide Mobile App entry in user dropdown on native iOS/Android

### DIFF
--- a/change/@acedatacloud-nexior-hide-mobile-app-entry-on-native.json
+++ b/change/@acedatacloud-nexior-hide-mobile-app-entry-on-native.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(user-center): hide \"Mobile App\" download entry in user dropdown when running on native iOS/Android",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/user/Center.vue
+++ b/src/components/user/Center.vue
@@ -8,7 +8,7 @@
         </div>
         <el-divider v-if="user.email" class="mb-1 mt-1" />
         <el-dropdown-menu>
-          <el-dropdown-item class="py-2" @click="onDownload">
+          <el-dropdown-item v-if="!isNative" class="py-2" @click="onDownload">
             <font-awesome-icon icon="fa-solid fa-mobile-screen-button" class="mr-2" />
             {{ $t('common.nav.mobileApp') }}
           </el-dropdown-item>
@@ -42,6 +42,7 @@ import UserAvatar from '@/components/user/Avatar.vue';
 import UserSetting from '@/components/user/Setting.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { ROUTE_CONSOLE_ROOT, ROUTE_DISTRIBUTION_INDEX, ROUTE_DOWNLOAD } from '@/router';
+import { SURFACE_ANDROID, SURFACE_IOS } from '@/constants';
 import { ElDivider } from 'element-plus';
 import { ElDropdownMenu, ElDropdownItem, ElDropdown } from 'element-plus';
 
@@ -66,6 +67,10 @@ export default defineComponent({
   computed: {
     user() {
       return this.$store.getters?.user;
+    },
+    isNative() {
+      const surface = import.meta.env.VITE_SURFACE;
+      return surface === SURFACE_IOS || surface === SURFACE_ANDROID;
     }
   },
   mounted() {


### PR DESCRIPTION
## Problem

The user-avatar dropdown shows a **Mobile App** entry that links to the web `/download` page. When the bundle is already running natively (Capacitor on iOS / Android), that entry is:

- Useless — the user is already on the native app.
- A potential App Store reviewer flag (Guideline 3.1.1: in-app linking to outside-of-IAP download / purchase paths).

## Fix

Hide the dropdown item whenever `VITE_SURFACE` is `ios` or `android`. Web builds are unchanged.

```vue
<el-dropdown-item v-if="!isNative" class="py-2" @click="onDownload">
  ...
  {{ $t('common.nav.mobileApp') }}
</el-dropdown-item>
```

`isNative` reads the same `VITE_SURFACE` env that `AuthPanel.vue`, `baseUrl.ts`, `site.ts` and `store/common/actions.ts` already use, with the shared `SURFACE_IOS` / `SURFACE_ANDROID` constants.

## Scope

Only the user-center dropdown, per the request. `TopHeader.vue` and `BottomFooter.vue` still show the entry — those surfaces are primarily web nav and were not in scope for this fix.
