### PR TITLE
[codex] Fix Android login reinitialization

### DIFF
--- a/src/layouts/Main.vue
+++ b/src/layouts/Main.vue
@@ -44,7 +44,8 @@ export default defineComponent({
     return {
       initialized: false,
       applying: false,
-      mobile: window.innerWidth < 768
+      mobile: window.innerWidth < 768,
+      initializeRunId: 0
     };
   },
   computed: {
@@ -68,11 +69,19 @@ export default defineComponent({
     },
     service() {
       return this.$store.state[this.appName]?.service;
+    },
+    userId() {
+      return this.$store.state.user?.id;
     }
   },
   watch: {
     appName() {
       this.initialize();
+    },
+    userId(newValue: string | undefined, oldValue: string | undefined) {
+      if (newValue && newValue !== oldValue) {
+        this.initialize();
+      }
     }
   },
   mounted() {
@@ -85,30 +94,33 @@ export default defineComponent({
   },
   methods: {
     async initialize() {
+      const runId = ++this.initializeRunId;
       this.initialized = false;
       console.debug('Fetching all individual and global applications for', this.appName);
-      Promise.all([
+      await Promise.allSettled([
         this.$store.dispatch('getApplications'),
         this.$store.dispatch(`${this.appName}/getApplications`)
-      ]).finally(async () => {
-        console.debug('Fetched all applications', this.applications);
-        // Check if we need to apply for a global application
-        if (this.$store.state.applications?.length === 0) {
-          // If no global applications exist, we need to apply
-          this.applying = true;
-        }
-        // set the application if it exists
-        const currentApplication = this.$store.state[this.appName]?.application;
-        console.debug('current application', currentApplication);
-        const finalApplication = getFinalApplication(this.applications, currentApplication);
-        console.debug('final application', finalApplication);
-        if (finalApplication) {
-          console.debug('set final application', finalApplication, finalApplication?.type);
-          await this.$store.dispatch(`${this.appName}/setApplication`, finalApplication);
-        }
-        console.debug('finished initialization');
-        this.initialized = true;
-      });
+      ]);
+      if (runId !== this.initializeRunId) {
+        return;
+      }
+      console.debug('Fetched all applications', this.applications);
+      // Check if we need to apply for a global application
+      if (this.$store.state.applications?.length === 0) {
+        // If no global applications exist, we need to apply
+        this.applying = true;
+      }
+      // set the application if it exists
+      const currentApplication = this.$store.state[this.appName]?.application;
+      console.debug('current application', currentApplication);
+      const finalApplication = getFinalApplication(this.applications, currentApplication);
+      console.debug('final application', finalApplication);
+      if (finalApplication) {
+        console.debug('set final application', finalApplication, finalApplication?.type);
+        await this.$store.dispatch(`${this.appName}/setApplication`, finalApplication);
+      }
+      console.debug('finished initialization');
+      this.initialized = true;
     },
     onApply() {
       // Only can apply for global application, not individual application


### PR DESCRIPTION
## What changed

- Re-runs the main app initialization when the authenticated user id becomes available after native login.
- Guards overlapping initialization runs with a monotonic run id so stale unauthenticated requests cannot overwrite the logged-in state.

## Why

On Android, the `/veo` page can initialize before the user logs in. Those unauthenticated requests return 401 and leave the app-specific application/credential empty. After login, the token and user are written successfully, but the page did not re-fetch applications/credentials, so the task panel stayed on the skeleton state until the app was restarted.

## Validation

- `npx eslint src/layouts/Main.vue`
- `npm run pack:android`
- `JAVA_HOME=/Applications/Android Studio.app/Contents/jbr/Contents/Home ./gradlew :app:assembleDebug --console=plain`
- Android emulator smoke test: install debug APK, clear app data, log in with the provided admin account, confirm `get user success`, `set final application`, `credential exists`, and `get videos tasks success` appear without restarting the app.