### PR TITLE
fix(router): use stable priority list for default landing route

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -227,50 +227,53 @@ const ROUTE_SEO: Record<string, { title: string; description: string; keywords: 
   }
 };
 
-// Map every routeable feature key to the route name it should land on.
-// Note: this map only declares "this feature has a landing page". The order
-// of the user's default route is taken from the site's `features` config
-// (insertion order returned by the API), NOT from this map — so operators
-// can control which feature greets new visitors by ordering site.features.
-const FEATURE_ROUTE_NAME: Record<string, string> = {
-  chatgpt: ROUTE_CHATGPT_CONVERSATION_NEW,
-  deepseek: ROUTE_DEEPSEEK_CONVERSATION_NEW,
-  grok: ROUTE_GROK_CONVERSATION_NEW,
-  gemini: ROUTE_GEMINI_CONVERSATION_NEW,
-  claude: ROUTE_CLAUDE_CONVERSATION_NEW,
-  kimi: ROUTE_KIMI_CONVERSATION_NEW,
-  midjourney: ROUTE_MIDJOURNEY_INDEX,
-  flux: ROUTE_FLUX_INDEX,
-  nanobanana: ROUTE_NANOBANANA_INDEX,
-  openaiimage: ROUTE_OPENAIIMAGE_INDEX,
-  seedream: ROUTE_SEEDREAM_INDEX,
-  suno: ROUTE_SUNO_INDEX,
-  producer: ROUTE_PRODUCER_INDEX,
-  seedance: ROUTE_SEEDANCE_INDEX,
-  luma: ROUTE_LUMA_INDEX,
-  hailuo: ROUTE_HAILUO_INDEX,
-  kling: ROUTE_KLING_INDEX,
-  veo: ROUTE_VEO_INDEX,
-  sora: ROUTE_SORA_INDEX,
-  pixverse: ROUTE_PIXVERSE_INDEX,
-  wan: ROUTE_WAN_INDEX,
-  serp: ROUTE_SERP_INDEX
-};
+// Ordered priority list: each entry is [feature key, landing route name].
+// `getDefaultRoute()` walks this list top-to-bottom and picks the first
+// feature that is enabled in `site.features`. This order — NOT the order
+// of keys in the API response — controls which feature greets new visitors.
+//
+// Why not trust `site.features` insertion order? `Site.features` is stored
+// in PostgreSQL `jsonb`, which does NOT preserve key order across writes:
+// any partial update can shuffle keys. Relying on that order has bitten us
+// (e.g. studio.acedata.cloud landed on /veo because `veo` happened to be
+// the first key after a feature toggle re-serialized the jsonb blob).
+const FEATURE_ROUTE_PRIORITY: Array<[string, string]> = [
+  ['chatgpt', ROUTE_CHATGPT_CONVERSATION_NEW],
+  ['claude', ROUTE_CLAUDE_CONVERSATION_NEW],
+  ['gemini', ROUTE_GEMINI_CONVERSATION_NEW],
+  ['grok', ROUTE_GROK_CONVERSATION_NEW],
+  ['deepseek', ROUTE_DEEPSEEK_CONVERSATION_NEW],
+  ['kimi', ROUTE_KIMI_CONVERSATION_NEW],
+  ['midjourney', ROUTE_MIDJOURNEY_INDEX],
+  ['nanobanana', ROUTE_NANOBANANA_INDEX],
+  ['flux', ROUTE_FLUX_INDEX],
+  ['seedream', ROUTE_SEEDREAM_INDEX],
+  ['openaiimage', ROUTE_OPENAIIMAGE_INDEX],
+  ['suno', ROUTE_SUNO_INDEX],
+  ['producer', ROUTE_PRODUCER_INDEX],
+  ['veo', ROUTE_VEO_INDEX],
+  ['sora', ROUTE_SORA_INDEX],
+  ['kling', ROUTE_KLING_INDEX],
+  ['luma', ROUTE_LUMA_INDEX],
+  ['hailuo', ROUTE_HAILUO_INDEX],
+  ['seedance', ROUTE_SEEDANCE_INDEX],
+  ['pixverse', ROUTE_PIXVERSE_INDEX],
+  ['wan', ROUTE_WAN_INDEX],
+  ['serp', ROUTE_SERP_INDEX]
+];
 
 const getDefaultRoute = (): { name: string } => {
   const features = (store.state.site?.features ?? {}) as Record<string, { enabled?: boolean } | undefined>;
-  // Walk site.features in the order the API returned them and pick the
-  // first enabled feature that maps to a known landing route.
-  for (const key of Object.keys(features)) {
-    if (!features[key]?.enabled) continue;
-    const name = FEATURE_ROUTE_NAME[key];
-    // IMPORTANT: must return { name } — returning a bare string makes
-    // vue-router treat it as a *path*, which would navigate to e.g.
-    // /chatgpt-conversation-new (the route name) instead of the actual
-    // path /chatgpt/conversations.
-    if (name) return { name };
+  for (const [key, name] of FEATURE_ROUTE_PRIORITY) {
+    if (features[key]?.enabled) {
+      // IMPORTANT: must return { name } — returning a bare string makes
+      // vue-router treat it as a *path*, which would navigate to e.g.
+      // /chatgpt-conversation-new (the route name) instead of the actual
+      // path /chatgpt/conversations.
+      return { name };
+    }
   }
-  // Fallback: if no enabled feature has a landing route, use chatgpt.
+  // Fallback: if no priority feature is enabled, use chatgpt.
   return { name: ROUTE_CHATGPT_CONVERSATION_NEW };
 };
 


### PR DESCRIPTION
## Problem

`studio.acedata.cloud` was redirecting every logged-in user to **`/veo`** on the root path (`/`), instead of the expected `/chatgpt/conversations`.

## Root cause

`getDefaultRoute()` in [`src/router/index.ts`](src/router/index.ts) walked `Object.keys(site.features)` and picked the first `enabled` feature with a known landing route:

```ts
for (const key of Object.keys(features)) {
  if (!features[key]?.enabled) continue;
  const name = FEATURE_ROUTE_NAME[key];
  if (name) return { name };
}
```

The assumption was that `site.features` insertion order is stable and operator-controlled. It isn't.

`Site.features` is stored as PostgreSQL **`jsonb`**, which does not preserve key insertion order across writes. After any partial feature update (e.g. toggling one feature on/off through the admin UI, which `{...site.features, [feature]: {...}}` re-serializes the entire blob), keys can shuffle.

Verified live (`curl https://platform.acedata.cloud/api/v1/sites/?origin=studio.acedata.cloud`): the studio Site row now returns features with `veo` as the first key, even though the backend's `DEFAULT_FEATURES` constant has `chatgpt` first.

So the bug isn't a frontend regression per se — it's a latent ordering dependency that broke once jsonb re-serialized the column.

## Fix

Replace the unordered `FEATURE_ROUTE_NAME` map with an explicit, ordered `FEATURE_ROUTE_PRIORITY` array. Iteration order is now developer-controlled and stable, regardless of what the API returns:

```
chatgpt → claude → gemini → grok → deepseek → kimi
       → midjourney → nanobanana → flux → seedream → openaiimage
       → suno → producer
       → veo → sora → kling → luma → hailuo → seedance → pixverse → wan
       → serp
```

The first enabled feature in this list wins. Fallback remains `chatgpt`.

## Verification

- `npx vue-tsc --noEmit` ✅
- `npx eslint src/router/index.ts` ✅
- After deploy: visiting `https://studio.acedata.cloud/` while logged in should land on `/chatgpt/conversations` (since `chatgpt` is `enabled: true` in the live Site row), not `/veo`.

## Notes

- We could also have fixed this server-side by sorting `Site.features` keys before save in PlatformBackend. That's a more invasive change and would not protect us from the same class of bug if any other client ever relied on insertion order. Doing it here gives us a single, audit-able source of truth for landing-route priority.
- The old map's wording suggested operators could "control which feature greets new visitors by ordering site.features" — that was never reliable and is now removed.
