### PR TITLE
feat(aichat2): render ask_user_question card and resume on submit

### DIFF
--- a/change/@acedatacloud-nexior-ask-user-question-card.json
+++ b/change/@acedatacloud-nexior-ask-user-question-card.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(aichat2): render ask_user_question card and resume on submit",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/AskUserQuestionCard.vue
+++ b/src/components/chat/AskUserQuestionCard.vue
@@ -1,0 +1,368 @@
+<template>
+  <div class="ask-user-question-card" :class="{ 'is-collapsed': collapsed }">
+    <!-- Collapsed view: one-line summary per question after submit / restore -->
+    <div v-if="collapsed" class="collapsed">
+      <div v-for="(q, idx) in questions" :key="idx" class="collapsed-row">
+        <span class="check">✓</span>
+        <span class="collapsed-q">{{ q.question }}</span>
+        <span class="collapsed-arrow">→</span>
+        <span class="collapsed-a">{{ collapsedAnswerFor(q) }}</span>
+      </div>
+      <div v-if="collapsedOther" class="collapsed-row collapsed-other">
+        <span class="check">✓</span>
+        <span class="collapsed-a">{{ collapsedOther }}</span>
+      </div>
+    </div>
+    <!-- Interactive view: render each question with its options -->
+    <div v-else class="card-body">
+      <div v-for="(q, qIdx) in questions" :key="qIdx" class="question">
+        <div class="question-head">
+          <span class="chip">{{ headerFor(q) }}</span>
+          <span v-if="q.multiSelect" class="multi-hint">{{ $t('chat.askUserQuestion.multiSelectHint') }}</span>
+        </div>
+        <div class="question-text">{{ q.question }}</div>
+        <!-- Single-select options -->
+        <el-radio-group
+          v-if="!q.multiSelect"
+          v-model="singleAnswers[qIdx] as string"
+          class="options"
+          @change="onAnswerChange"
+        >
+          <el-radio v-for="(opt, oIdx) in q.options" :key="oIdx" :value="opt.label" class="option">
+            <span class="option-label">{{ opt.label }}</span>
+            <span v-if="opt.description" class="option-desc">{{ opt.description }}</span>
+          </el-radio>
+        </el-radio-group>
+        <!-- Multi-select options -->
+        <el-checkbox-group v-else v-model="multiAnswers[qIdx] as string[]" class="options" @change="onAnswerChange">
+          <el-checkbox v-for="(opt, oIdx) in q.options" :key="oIdx" :value="opt.label" class="option">
+            <span class="option-label">{{ opt.label }}</span>
+            <span v-if="opt.description" class="option-desc">{{ opt.description }}</span>
+          </el-checkbox>
+        </el-checkbox-group>
+      </div>
+      <!-- Free-text Other (per card) -->
+      <div class="other">
+        <div class="other-label">{{ $t('chat.askUserQuestion.other') }}</div>
+        <el-input
+          v-model="otherText"
+          type="textarea"
+          :rows="2"
+          :placeholder="$t('chat.askUserQuestion.placeholder')"
+          @input="onAnswerChange"
+        />
+      </div>
+      <div class="actions">
+        <el-button class="btn-skip" round @click="onSkip">{{ $t('chat.askUserQuestion.skip') }}</el-button>
+        <el-button class="btn-submit" type="primary" round :disabled="!canSubmit" @click="onSubmit">
+          {{ $t('chat.askUserQuestion.submit') }}
+        </el-button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, PropType } from 'vue';
+import { ElButton, ElCheckbox, ElCheckboxGroup, ElInput, ElRadio, ElRadioGroup } from 'element-plus';
+import { IAskUserQuestion, IAskUserQuestionPayload } from '@/models';
+import { buildAskUserQuestionOutput, canSubmitAskUserQuestion, truncateHeader } from './askUserQuestion';
+
+interface IData {
+  // Per-question single-select answers (label string).
+  singleAnswers: Record<number, string>;
+  // Per-question multi-select answers (array of label strings).
+  multiAnswers: Record<number, string[]>;
+  // Free-text Other input (single, per card).
+  otherText: string;
+  collapsedAnswers: Record<number, string | string[]> | null;
+  collapsedOther: string;
+}
+
+export default defineComponent({
+  name: 'AskUserQuestionCard',
+  components: {
+    ElButton,
+    ElInput,
+    ElRadio,
+    ElRadioGroup,
+    ElCheckbox,
+    ElCheckboxGroup
+  },
+  props: {
+    /** Tool-use block id; sent back as `tool_use_id` on resume. */
+    toolUseId: {
+      type: String,
+      required: true
+    },
+    payload: {
+      type: Object as PropType<IAskUserQuestionPayload>,
+      required: true
+    },
+    /**
+     * When `true`, render the read-only collapsed summary.
+     * `previousOutput` (the JSON string the user submitted previously)
+     * MUST be provided so the card can show what was answered.
+     */
+    collapsed: {
+      type: Boolean,
+      default: false
+    },
+    previousOutput: {
+      type: String,
+      default: ''
+    }
+  },
+  emits: ['submit', 'skip'],
+  data(): IData {
+    return {
+      singleAnswers: {},
+      multiAnswers: {},
+      otherText: '',
+      collapsedAnswers: null,
+      collapsedOther: ''
+    };
+  },
+  computed: {
+    questions(): IAskUserQuestion[] {
+      return this.payload?.questions ?? [];
+    },
+    canSubmit(): boolean {
+      return canSubmitAskUserQuestion(this.singleAnswers, this.multiAnswers, this.otherText);
+    }
+  },
+  watch: {
+    collapsed: {
+      immediate: true,
+      handler(val: boolean) {
+        if (val) this.parsePreviousOutput();
+      }
+    },
+    previousOutput: {
+      immediate: false,
+      handler() {
+        if (this.collapsed) this.parsePreviousOutput();
+      }
+    }
+  },
+  methods: {
+    headerFor(q: IAskUserQuestion): string {
+      return truncateHeader(q.header);
+    },
+    onAnswerChange() {
+      // Hook for v-model side effects (kept simple — `canSubmit` recomputes).
+    },
+    onSubmit() {
+      const output = buildAskUserQuestionOutput(this.questions, this.singleAnswers, this.multiAnswers, this.otherText);
+      this.$emit('submit', { tool_use_id: this.toolUseId, output });
+    },
+    onSkip() {
+      this.$emit('skip', { tool_use_id: this.toolUseId });
+    },
+    parsePreviousOutput() {
+      this.collapsedAnswers = null;
+      this.collapsedOther = '';
+      if (!this.previousOutput) return;
+      try {
+        const parsed = JSON.parse(this.previousOutput);
+        if (parsed && typeof parsed === 'object') {
+          const ans = (parsed as { answers?: Record<string, string | string[]> }).answers;
+          if (ans && typeof ans === 'object') {
+            const byIndex: Record<number, string | string[]> = {};
+            this.questions.forEach((q, idx) => {
+              if (q.question in ans) byIndex[idx] = ans[q.question];
+            });
+            this.collapsedAnswers = byIndex;
+          }
+          const other = (parsed as { other?: string | null }).other;
+          if (typeof other === 'string') this.collapsedOther = other;
+        }
+      } catch {
+        // Output isn't valid JSON — fall back to showing the raw string under
+        // the first question.
+        this.collapsedOther = this.previousOutput;
+      }
+    },
+    collapsedAnswerFor(q: IAskUserQuestion): string {
+      if (!this.collapsedAnswers) return '';
+      const idx = this.questions.indexOf(q);
+      const v = this.collapsedAnswers[idx];
+      if (!v) return this.$t('chat.askUserQuestion.collapsedAnswerLabel');
+      return Array.isArray(v) ? v.join(', ') : v;
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.ask-user-question-card {
+  margin: 8px 0;
+  border: 1px solid var(--el-border-color);
+  border-radius: 12px;
+  background: var(--el-fill-color-blank);
+  padding: 12px 14px;
+  font-size: 14px;
+  max-width: 100%;
+}
+
+.ask-user-question-card.is-collapsed {
+  background: var(--el-fill-color-light);
+  padding: 8px 12px;
+  font-size: 13px;
+}
+
+.card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.question {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.question-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.chip {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--el-color-primary-light-9);
+  color: var(--el-color-primary);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.4;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+
+.multi-hint {
+  color: var(--el-text-color-secondary);
+  font-size: 12px;
+}
+
+.question-text {
+  color: var(--el-text-color-primary);
+  font-weight: 500;
+  line-height: 1.5;
+}
+
+.options {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: stretch;
+  // Element Plus radios/checkboxes default to inline rows; stack here.
+  :deep(.el-radio),
+  :deep(.el-checkbox) {
+    margin-right: 0;
+    height: auto;
+    padding: 6px 8px;
+    border-radius: 8px;
+    align-items: flex-start;
+    white-space: normal;
+    width: 100%;
+    box-sizing: border-box;
+    &:hover {
+      background: var(--el-fill-color-light);
+    }
+  }
+  :deep(.el-radio__label),
+  :deep(.el-checkbox__label) {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    white-space: normal;
+    word-break: break-word;
+  }
+}
+
+.option-label {
+  font-size: 14px;
+  color: var(--el-text-color-primary);
+  font-weight: 500;
+}
+
+.option-desc {
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+  line-height: 1.4;
+}
+
+.other {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.other-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--el-text-color-secondary);
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.btn-skip,
+.btn-submit {
+  min-width: 88px;
+}
+
+// ===== Collapsed summary =====
+.collapsed {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.collapsed-row {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  flex-wrap: wrap;
+  color: var(--el-text-color-regular);
+}
+
+.check {
+  color: var(--el-color-success);
+  font-weight: 700;
+}
+
+.collapsed-q {
+  color: var(--el-text-color-secondary);
+}
+
+.collapsed-arrow {
+  color: var(--el-text-color-placeholder);
+}
+
+.collapsed-a {
+  color: var(--el-text-color-primary);
+  font-weight: 500;
+}
+
+@media (max-width: 480px) {
+  .ask-user-question-card {
+    padding: 10px 12px;
+  }
+  .actions {
+    justify-content: stretch;
+    .btn-skip,
+    .btn-submit {
+      flex: 1;
+    }
+  }
+}
+</style>

--- a/src/components/chat/Message.vue
+++ b/src/components/chat/Message.vue
@@ -60,7 +60,36 @@
                 />
                 <pre v-else class="whitespace-pre-wrap break-words w-fit max-w-full py-1">{{ item.text?.trim() }}</pre>
               </div>
-              <tool-activity v-if="item.type === 'tool_use'" :item="item" />
+              <tool-activity
+                v-if="
+                  item.type === 'tool_use' &&
+                  !(
+                    item.tool_name === 'ask_user_question' &&
+                    (item.status === 'awaiting_input' || item.status === 'done')
+                  )
+                "
+                :item="item"
+              />
+              <ask-user-question-card
+                v-if="
+                  item.type === 'tool_use' &&
+                  item.tool_name === 'ask_user_question' &&
+                  item.status === 'awaiting_input' &&
+                  item.pending_question
+                "
+                :tool-use-id="item.tool_id || ''"
+                :payload="item.pending_question"
+                :collapsed="false"
+                @submit="onAskUserQuestionSubmit"
+                @skip="onAskUserQuestionSkip"
+              />
+              <ask-user-question-card
+                v-if="item.type === 'tool_use' && item.tool_name === 'ask_user_question' && item.status === 'done'"
+                :tool-use-id="item.tool_id || ''"
+                :payload="askUserQuestionPayloadFromBlock(item)"
+                :collapsed="true"
+                :previous-output="item.output || ''"
+              />
               <entity-card v-if="item.type === 'card' && item.card" :card="item.card" />
             </div>
           </div>
@@ -136,6 +165,7 @@ import { ElButton, ElImage, ElInput } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import MarkdownRenderer from '@/components/common/MarkdownRenderer.vue';
 import { IApplication, IChatMessage, IChatMessageState } from '@/models';
+import type { IAskUserQuestionPayload, IChatMessageContentItem } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import RestartToGenerate from './RestartToGenerate.vue';
 import EditMessage from './EditMessage.vue';
@@ -143,6 +173,7 @@ import FilePreview from '@/components/common/FilePreview.vue';
 import ToolActivity from './ToolActivity.vue';
 import EntityCard from './EntityCard.vue';
 import ThinkingBlock from './ThinkingBlock.vue';
+import AskUserQuestionCard from './AskUserQuestionCard.vue';
 import {
   ERROR_CODE_API_ERROR,
   ERROR_CODE_BAD_REQUEST,
@@ -177,6 +208,7 @@ export default defineComponent({
     ToolActivity,
     EntityCard,
     ThinkingBlock,
+    AskUserQuestionCard,
     ElButton,
     ElImage,
     ElInput,
@@ -197,7 +229,7 @@ export default defineComponent({
       required: true
     }
   },
-  emits: ['stop', 'edit', 'restart'],
+  emits: ['stop', 'edit', 'restart', 'answerAskUserQuestion', 'skipAskUserQuestion'],
   data(): IData {
     return {
       copied: false,
@@ -310,6 +342,21 @@ export default defineComponent({
           id: this.application?.id
         }
       });
+    },
+    onAskUserQuestionSubmit(payload: { tool_use_id: string; output: string }) {
+      this.$emit('answerAskUserQuestion', payload);
+    },
+    onAskUserQuestionSkip(payload: { tool_use_id: string }) {
+      this.$emit('skipAskUserQuestion', payload);
+    },
+    askUserQuestionPayloadFromBlock(item: IChatMessageContentItem): IAskUserQuestionPayload {
+      // Done blocks shouldn't carry `pending_question` per the contract,
+      // but we still want a payload to render the collapsed summary against.
+      // Reconstruct it from `input.questions` (the model's tool input).
+      if (item.pending_question) return item.pending_question;
+      const input = item.input as { questions?: unknown } | undefined;
+      const qs = (input?.questions as IAskUserQuestionPayload['questions']) || [];
+      return { questions: qs };
     }
   }
 });

--- a/src/components/chat/askUserQuestion.test.ts
+++ b/src/components/chat/askUserQuestion.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { buildAskUserQuestionOutput, canSubmitAskUserQuestion, truncateHeader } from './askUserQuestion';
+import type { IAskUserQuestion } from '@/models';
+
+const Q_AUTH: IAskUserQuestion = {
+  header: 'Auth',
+  question: 'Which auth method?',
+  options: [
+    { label: 'OAuth', description: 'Delegated' },
+    { label: 'Session', description: 'Cookie-based' },
+    { label: 'API key', description: 'Static' }
+  ]
+};
+
+const Q_FEATURES: IAskUserQuestion = {
+  header: 'Features',
+  question: 'Which features?',
+  multiSelect: true,
+  options: [
+    { label: 'search', description: 'Full-text' },
+    { label: 'compose', description: 'Editor' },
+    { label: 'sync', description: 'Background' }
+  ]
+};
+
+describe('buildAskUserQuestionOutput', () => {
+  it('emits a single-select answer in the JSON contract shape', () => {
+    const raw = buildAskUserQuestionOutput([Q_AUTH], { 0: 'OAuth' }, {}, '');
+    expect(JSON.parse(raw)).toEqual({
+      answers: { 'Which auth method?': 'OAuth' },
+      other: null
+    });
+  });
+
+  it('emits a multi-select answer as an array', () => {
+    const raw = buildAskUserQuestionOutput([Q_FEATURES], {}, { 0: ['search', 'compose'] }, '');
+    expect(JSON.parse(raw)).toEqual({
+      answers: { 'Which features?': ['search', 'compose'] },
+      other: null
+    });
+  });
+
+  it('combines single + multi questions and the Other free-text', () => {
+    const raw = buildAskUserQuestionOutput([Q_AUTH, Q_FEATURES], { 0: 'API key' }, { 1: ['sync'] }, 'tone: terse');
+    expect(JSON.parse(raw)).toEqual({
+      answers: {
+        'Which auth method?': 'API key',
+        'Which features?': ['sync']
+      },
+      other: 'tone: terse'
+    });
+  });
+
+  it('omits questions with no selection and trims `other`', () => {
+    const raw = buildAskUserQuestionOutput([Q_AUTH, Q_FEATURES], {}, {}, '   ');
+    expect(JSON.parse(raw)).toEqual({ answers: {}, other: null });
+  });
+});
+
+describe('canSubmitAskUserQuestion', () => {
+  it('disabled when nothing is filled', () => {
+    expect(canSubmitAskUserQuestion({}, {}, '')).toBe(false);
+  });
+
+  it('enabled with a single-select choice only', () => {
+    expect(canSubmitAskUserQuestion({ 0: 'OAuth' }, {}, '')).toBe(true);
+  });
+
+  it('enabled with a multi-select choice only', () => {
+    expect(canSubmitAskUserQuestion({}, { 1: ['search'] }, '')).toBe(true);
+  });
+
+  it('enabled with Other free-text only (no option picked)', () => {
+    expect(canSubmitAskUserQuestion({}, {}, 'something custom')).toBe(true);
+  });
+
+  it('disabled with whitespace-only Other and no selection', () => {
+    expect(canSubmitAskUserQuestion({}, {}, '   ')).toBe(false);
+  });
+
+  it('disabled when multi-select map has empty arrays', () => {
+    expect(canSubmitAskUserQuestion({}, { 0: [] }, '')).toBe(false);
+  });
+});
+
+describe('truncateHeader', () => {
+  it('returns short headers unchanged', () => {
+    expect(truncateHeader('Auth')).toBe('Auth');
+  });
+
+  it('truncates headers over 12 chars with ellipsis', () => {
+    // 11 retained chars + ellipsis = 12 chars total per contract.
+    expect(truncateHeader('NotAVeryShortHeader')).toBe('NotAVerySho…');
+  });
+
+  it('handles empty input', () => {
+    expect(truncateHeader('')).toBe('');
+  });
+});

--- a/src/components/chat/askUserQuestion.ts
+++ b/src/components/chat/askUserQuestion.ts
@@ -1,0 +1,52 @@
+import type { IAskUserQuestion } from '@/models';
+
+/**
+ * Build the JSON-string `output` that the ask-user-question card sends back
+ * to the worker as the resume `tool_results[0].output`. Shape matches the
+ * frozen aichat2 contract:
+ *
+ *   { "answers": { "<question text>": "label" | ["label", "label"] }, "other": null | string }
+ */
+export function buildAskUserQuestionOutput(
+  questions: IAskUserQuestion[],
+  singleAnswers: Record<number, string>,
+  multiAnswers: Record<number, string[]>,
+  otherText: string
+): string {
+  const answers: Record<string, string | string[]> = {};
+  questions.forEach((q, idx) => {
+    if (q.multiSelect) {
+      const arr = multiAnswers[idx] || [];
+      if (arr.length > 0) answers[q.question] = [...arr];
+    } else {
+      const v = singleAnswers[idx];
+      if (v) answers[q.question] = v;
+    }
+  });
+  const other = otherText.trim();
+  return JSON.stringify({
+    answers,
+    other: other || null
+  });
+}
+
+/** Truncate a chip header to ≤12 chars per contract guidance. */
+export function truncateHeader(header: string): string {
+  const h = header ?? '';
+  return h.length > 12 ? h.slice(0, 11) + '…' : h;
+}
+
+/**
+ * True iff the user has provided enough input to enable Submit: at least
+ * one option selected (single or multi) OR the free-text Other is filled.
+ */
+export function canSubmitAskUserQuestion(
+  singleAnswers: Record<number, string>,
+  multiAnswers: Record<number, string[]>,
+  otherText: string
+): boolean {
+  const anySingle = Object.values(singleAnswers).some((v) => !!v);
+  const anyMulti = Object.values(multiAnswers).some((arr) => Array.isArray(arr) && arr.length > 0);
+  const hasOther = otherText.trim().length > 0;
+  return anySingle || anyMulti || hasOther;
+}

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -482,5 +482,29 @@
   "agent.runLabel": {
     "message": "Run Agent:",
     "description": "Label for running instructions"
+  },
+  "askUserQuestion.submit": {
+    "message": "Submit",
+    "description": "Submit button on the ask-user-question card"
+  },
+  "askUserQuestion.skip": {
+    "message": "Skip",
+    "description": "Skip button on the ask-user-question card"
+  },
+  "askUserQuestion.other": {
+    "message": "Other",
+    "description": "Label for the free-text fallback input on the ask-user-question card"
+  },
+  "askUserQuestion.placeholder": {
+    "message": "Type a custom answer…",
+    "description": "Placeholder for the free-text Other input"
+  },
+  "askUserQuestion.multiSelectHint": {
+    "message": "Select one or more",
+    "description": "Hint shown next to questions that accept multiple answers"
+  },
+  "askUserQuestion.collapsedAnswerLabel": {
+    "message": "Your answer",
+    "description": "Fallback label when the collapsed summary cannot extract a specific answer"
   }
 }

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -482,5 +482,29 @@
   "agent.runLabel": {
     "message": "运行代理：",
     "description": "运行说明标签"
+  },
+  "askUserQuestion.submit": {
+    "message": "提交",
+    "description": "ask-user-question 卡片上的提交按钮"
+  },
+  "askUserQuestion.skip": {
+    "message": "跳过",
+    "description": "ask-user-question 卡片上的跳过按钮"
+  },
+  "askUserQuestion.other": {
+    "message": "其他",
+    "description": "ask-user-question 卡片自定义回答输入框的标签"
+  },
+  "askUserQuestion.placeholder": {
+    "message": "输入自定义回答…",
+    "description": "自定义回答输入框的占位文案"
+  },
+  "askUserQuestion.multiSelectHint": {
+    "message": "可选一项或多项",
+    "description": "支持多选问题时显示的提示"
+  },
+  "askUserQuestion.collapsedAnswerLabel": {
+    "message": "你的回答",
+    "description": "无法从历史输出中提取具体答案时的兜底文案"
   }
 }

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -95,13 +95,48 @@ export interface IChatMessageContentItem {
   output?: string;
   is_error?: boolean;
   duration_ms?: number;
-  status?: 'running' | 'done';
+  // `awaiting_input` is set on a `tool_use` block when the worker pauses the
+  // turn for a user reply (see `ask_user_question` tool). `output` is absent
+  // until the user submits an answer, which folds the block back to `done`.
+  status?: 'running' | 'awaiting_input' | 'done';
+  // Present iff `status === 'awaiting_input'` and `tool_name === 'ask_user_question'`.
+  // The card UI renders this; on submit, it's stripped and `output` is set.
+  pending_question?: IAskUserQuestionPayload;
   // Rich-output entity card (type='card') — payload mirrors the
   // worker's `CardData` SSE event. `type` inside `card` is open-ended:
   // 'audio' | 'video' | 'image' | 'file' today, with room for future
   // entity types (e.g. 'task', 'location', 'code-canvas') that the
   // EntityCard component can dispatch on without changing this shape.
   card?: IChatCard;
+}
+
+// ===== ask_user_question tool payload =====
+// Mirrors aichat2 worker contract (frozen). When the model calls the
+// `ask_user_question` tool, the worker pauses the turn and emits a single
+// SSE event of type `ask_user_question` carrying this payload, followed by
+// a terminal `done` with `terminal_reason: 'awaiting_user_input'`.
+
+export interface IAskUserQuestionOption {
+  /** Display label, 1–5 words. */
+  label: string;
+  /** Free-text explanation; what choosing this means / its trade-off. */
+  description: string;
+}
+
+export interface IAskUserQuestion {
+  /** Complete question, ends with '?'. */
+  question: string;
+  /** Very short chip/tag label, ≤12 chars. */
+  header: string;
+  /** 2–4 distinct options. */
+  options: IAskUserQuestionOption[];
+  /** When true, multiple options can be selected. Default false. */
+  multiSelect?: boolean;
+}
+
+export interface IAskUserQuestionPayload {
+  /** 1–4 questions. */
+  questions: IAskUserQuestion[];
 }
 
 /**
@@ -187,6 +222,11 @@ export interface IChatConversationRequest {
   mcp_servers?: string[];
   connectors?: string[];
   skills?: string[];
+  // Resume payload for a paused conversation. When present, the conversation
+  // MUST be in `awaiting_user_input` state and `tool_results` MUST contain
+  // exactly one entry whose `tool_use_id` matches the pending `tool_use`
+  // block. `question` / `message` / `references` are ignored when this is set.
+  tool_results?: { tool_use_id: string; output: string; is_error?: boolean }[];
 }
 
 export interface IChatConversationResponse {
@@ -218,6 +258,10 @@ export interface IChatConversationResponse {
   // the assistant turn; the frontend merges them into
   // `IChatMessage.citations` keyed by `id`.
   citation?: IChatCitation;
+  // ask_user_question SSE event (`type === 'ask_user_question'`). The worker
+  // pauses the turn and asks the user one or more multi-choice questions; the
+  // payload is rendered as a card (see AskUserQuestionCard.vue).
+  payload?: IAskUserQuestionPayload;
 }
 
 export interface IChatConversationsResponse {

--- a/src/operators/chat.ts
+++ b/src/operators/chat.ts
@@ -112,7 +112,8 @@ class ChatOperator {
                     content: json.content,
                     artifact: json.artifact,
                     card: json.card,
-                    citation: json.citation
+                    citation: json.citation,
+                    payload: json.payload
                   });
                 }
               } catch (err) {

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -36,6 +36,8 @@
             @update:question="question = $event"
             @edit="onEdit"
             @restart="onRestart"
+            @answer-ask-user-question="onAnswerAskUserQuestion"
+            @skip-ask-user-question="onSkipAskUserQuestion"
           />
         </div>
         <div class="starter">
@@ -615,6 +617,95 @@ export default defineComponent({
       // request server to get answer
       this.answering = true;
       this.canceler = new AbortController();
+      this._streamAssistantTurn(
+        {
+          question,
+          model: this.model.name,
+          references,
+          id: this.conversationId,
+          stateful: true
+        },
+        token,
+        conversationId
+      );
+    },
+    /**
+     * Resume a paused conversation by submitting a tool result for the
+     * `ask_user_question` block on the last assistant message. Marks the
+     * pending block as `done` locally (so the card collapses immediately
+     * to the readonly summary), pushes a fresh pending assistant message,
+     * and runs the next streaming turn against `tool_results`.
+     */
+    async onAnswerAskUserQuestion(payload: { tool_use_id: string; output: string }) {
+      const token = this.credential?.token;
+      if (!token || !this.conversationId) {
+        console.error('cannot resume: no token or no conversation id');
+        return;
+      }
+      // Locally fold the pending block so the card flips to the collapsed
+      // summary instantly (the worker will fold its own copy on the resume
+      // request — both stay in sync).
+      const lastAssistant = [...this.messages].reverse().find((m) => m.role === ROLE_ASSISTANT);
+      if (lastAssistant && Array.isArray(lastAssistant.content)) {
+        const block = (lastAssistant.content as IChatMessageContentItem[]).find(
+          (b) => b.type === 'tool_use' && b.tool_id === payload.tool_use_id
+        );
+        if (block) {
+          block.status = 'done';
+          block.output = payload.output;
+          delete block.pending_question;
+        }
+      }
+      // Push fresh pending assistant message for the resumed turn.
+      this.messages.push({
+        content: '',
+        role: ROLE_ASSISTANT,
+        state: IChatMessageState.PENDING
+      });
+      this.onScrollDown();
+      this.answering = true;
+      this.canceler = new AbortController();
+      this._streamAssistantTurn(
+        {
+          id: this.conversationId,
+          model: this.model.name,
+          stateful: true,
+          tool_results: [{ tool_use_id: payload.tool_use_id, output: payload.output }]
+        },
+        token,
+        this.conversationId
+      );
+    },
+    /**
+     * Visual-only "skip" of an ask_user_question card. Marks the pending
+     * block as done with a sentinel error output so the card collapses
+     * locally; no resume request is sent. The next user message they type
+     * goes through the worker's "user skipped" branch (see contract §5).
+     */
+    onSkipAskUserQuestion(payload: { tool_use_id: string }) {
+      const lastAssistant = [...this.messages].reverse().find((m) => m.role === ROLE_ASSISTANT);
+      if (!lastAssistant || !Array.isArray(lastAssistant.content)) return;
+      const block = (lastAssistant.content as IChatMessageContentItem[]).find(
+        (b) => b.type === 'tool_use' && b.tool_id === payload.tool_use_id
+      );
+      if (!block) return;
+      block.status = 'done';
+      block.is_error = true;
+      block.output = block.output || '';
+      delete block.pending_question;
+    },
+    /**
+     * Shared SSE-driven assistant-turn streamer. Handles deltas, tool_use,
+     * cards, citations, ask_user_question, and final state transitions.
+     * Caller is responsible for pushing the pending assistant message,
+     * resetting `answering`/`canceler`, and providing the request body.
+     */
+    _streamAssistantTurn(
+      body: Parameters<typeof chatOperator.chatConversation>[0],
+      token: string,
+      initialConversationId: string | undefined
+    ) {
+      let conversationId = initialConversationId;
       // Track content parts for tool-calling interleaving
       const contentParts: IChatMessageContentItem[] = [];
       const toolMap = new Map<string, IChatMessageContentItem>();
@@ -629,127 +720,133 @@ export default defineComponent({
       let answerOffset = 0;
 
       chatOperator
-        .chatConversation(
-          {
-            question,
-            model: this.model.name,
-            references,
-            id: this.conversationId,
-            stateful: true
-          },
-          {
-            token,
-            stream: (response: IChatConversationResponse) => {
-              console.debug('stream response', response);
-              const lastMessage = this.messages[this.messages.length - 1];
+        .chatConversation(body, {
+          token,
+          stream: (response: IChatConversationResponse) => {
+            console.debug('stream response', response);
+            const lastMessage = this.messages[this.messages.length - 1];
 
-              // Handle tool-calling events
-              if (response.type === 'thinking' && response.content) {
-                // Streamed chain-of-thought from a reasoning model.
-                // Accumulate on the assistant message; rendered above the
-                // visible answer by `<thinking-block>` in `Message.vue`.
-                const target = this.messages[this.messages.length - 1];
-                target.thinking = (target.thinking ?? '') + response.content;
-              } else if (response.type === 'tool_use_start' && response.tool_id) {
-                // Flush any accumulated text before tool
-                if (currentText) {
-                  contentParts.push({ type: 'text', text: currentText });
-                  currentText = '';
-                  answerOffset = response.answer?.length ?? 0;
-                }
-                const toolItem: IChatMessageContentItem = {
-                  type: 'tool_use',
-                  tool_id: response.tool_id,
-                  tool_name: response.tool_name,
-                  tool_display_name: response.tool_display_name,
-                  input: response.input,
-                  status: 'running'
-                };
-                contentParts.push(toolItem);
-                toolMap.set(response.tool_id, toolItem);
-              } else if (response.type === 'tool_result' && response.tool_id) {
-                const toolItem = toolMap.get(response.tool_id);
-                if (toolItem) {
-                  toolItem.output = response.output;
-                  toolItem.is_error = response.is_error;
-                  toolItem.duration_ms = response.duration_ms;
-                  toolItem.status = 'done';
-                }
-              } else if (response.type === 'artifact' && response.artifact) {
-                if (response.artifact.type === 'image' || response.artifact.mimeType?.startsWith('image/')) {
-                  contentParts.push({
-                    type: 'image_url',
-                    image_url: response.artifact.url,
-                    name: response.artifact.name,
-                    mimeType: response.artifact.mimeType
-                  });
-                } else {
-                  contentParts.push({
-                    type: 'file_url',
-                    file_url: response.artifact.url,
-                    name: response.artifact.name,
-                    mimeType: response.artifact.mimeType
-                  });
-                }
-              } else if (response.type === 'card' && response.card) {
-                // Rich-output entity card from the worker's <acard> stream
-                // parser. Flush any text we'd accumulated up to this
-                // point as its own block first so the card lands at the
-                // right position in the message; this mirrors how
-                // tool_use blocks bracket the text stream.
-                if (currentText) {
-                  contentParts.push({ type: 'text', text: currentText });
-                  currentText = '';
-                  answerOffset = response.answer?.length ?? 0;
-                }
-                contentParts.push({ type: 'card', card: response.card });
-              } else if (response.type === 'citation' && response.citation) {
-                // Source citation footnote from the worker's <acite>
-                // stream parser. Unlike `card`, citations DO NOT split
-                // the text stream — the worker injected a stable marker
-                // token `[^acite:<id>]` into the text where the chip
-                // should land, so we just stash the metadata on the
-                // assistant message's sidecar `citations` map. The
-                // markdown renderer pairs marker → metadata at render
-                // time. Last-write-wins on duplicate ids matches the
-                // worker's semantics (the model is taught to reuse the
-                // same id for the same source).
-                const target = this.messages[this.messages.length - 1];
-                target.citations = { ...(target.citations ?? {}), [response.citation.id]: response.citation };
-              } else if (response.delta_answer) {
-                currentText = (response.answer || '').slice(answerOffset);
-              }
-
-              // Build display content: parts + trailing text
-              const displayParts: IChatMessageContentItem[] = [...contentParts];
+            // Handle tool-calling events
+            if (response.type === 'thinking' && response.content) {
+              // Streamed chain-of-thought from a reasoning model.
+              // Accumulate on the assistant message; rendered above the
+              // visible answer by `<thinking-block>` in `Message.vue`.
+              const target = this.messages[this.messages.length - 1];
+              target.thinking = (target.thinking ?? '') + response.content;
+            } else if (response.type === 'tool_use_start' && response.tool_id) {
+              // Flush any accumulated text before tool
               if (currentText) {
-                displayParts.push({ type: 'text', text: currentText });
+                contentParts.push({ type: 'text', text: currentText });
+                currentText = '';
+                answerOffset = response.answer?.length ?? 0;
               }
-
-              if (displayParts.length > 0) {
-                this.messages[this.messages.length - 1] = {
-                  role: ROLE_ASSISTANT,
-                  content: displayParts,
-                  thinking: lastMessage?.thinking,
-                  citations: lastMessage?.citations,
-                  state:
-                    lastMessage?.state !== IChatMessageState.FINISHED ? IChatMessageState.ANSWERING : lastMessage?.state
-                };
+              const toolItem: IChatMessageContentItem = {
+                type: 'tool_use',
+                tool_id: response.tool_id,
+                tool_name: response.tool_name,
+                tool_display_name: response.tool_display_name,
+                input: response.input,
+                status: 'running'
+              };
+              contentParts.push(toolItem);
+              toolMap.set(response.tool_id, toolItem);
+            } else if (response.type === 'tool_result' && response.tool_id) {
+              const toolItem = toolMap.get(response.tool_id);
+              if (toolItem) {
+                toolItem.output = response.output;
+                toolItem.is_error = response.is_error;
+                toolItem.duration_ms = response.duration_ms;
+                toolItem.status = 'done';
+                // Strip stale pending_question after fold (defensive — the
+                // worker shouldn't emit tool_result for an awaiting block,
+                // but if it does, the card must collapse cleanly).
+                delete toolItem.pending_question;
+              }
+            } else if (response.type === 'ask_user_question' && response.tool_id && response.payload) {
+              // Worker pauses the turn for a user reply. Find the matching
+              // tool_use block on the in-flight assistant message and flip
+              // it to `awaiting_input`; the renderer will swap in
+              // <AskUserQuestionCard>. SSE then ends with terminal_reason
+              // 'awaiting_user_input'.
+              const toolItem = toolMap.get(response.tool_id);
+              if (toolItem) {
+                toolItem.status = 'awaiting_input';
+                toolItem.pending_question = response.payload;
+              }
+            } else if (response.type === 'artifact' && response.artifact) {
+              if (response.artifact.type === 'image' || response.artifact.mimeType?.startsWith('image/')) {
+                contentParts.push({
+                  type: 'image_url',
+                  image_url: response.artifact.url,
+                  name: response.artifact.name,
+                  mimeType: response.artifact.mimeType
+                });
               } else {
-                this.messages[this.messages.length - 1] = {
-                  role: ROLE_ASSISTANT,
-                  content: response.answer,
-                  thinking: lastMessage?.thinking,
-                  citations: lastMessage?.citations,
-                  state:
-                    lastMessage?.state !== IChatMessageState.FINISHED ? IChatMessageState.ANSWERING : lastMessage?.state
-                };
+                contentParts.push({
+                  type: 'file_url',
+                  file_url: response.artifact.url,
+                  name: response.artifact.name,
+                  mimeType: response.artifact.mimeType
+                });
               }
-              conversationId = response?.id;
-            },
-            signal: this.canceler.signal
-          }
-        )
+            } else if (response.type === 'card' && response.card) {
+              // Rich-output entity card from the worker's <acard> stream
+              // parser. Flush any text we'd accumulated up to this
+              // point as its own block first so the card lands at the
+              // right position in the message; this mirrors how
+              // tool_use blocks bracket the text stream.
+              if (currentText) {
+                contentParts.push({ type: 'text', text: currentText });
+                currentText = '';
+                answerOffset = response.answer?.length ?? 0;
+              }
+              contentParts.push({ type: 'card', card: response.card });
+            } else if (response.type === 'citation' && response.citation) {
+              // Source citation footnote from the worker's <acite>
+              // stream parser. Unlike `card`, citations DO NOT split
+              // the text stream — the worker injected a stable marker
+              // token `[^acite:<id>]` into the text where the chip
+              // should land, so we just stash the metadata on the
+              // assistant message's sidecar `citations` map. The
+              // markdown renderer pairs marker → metadata at render
+              // time. Last-write-wins on duplicate ids matches the
+              // worker's semantics (the model is taught to reuse the
+              // same id for the same source).
+              const target = this.messages[this.messages.length - 1];
+              target.citations = { ...(target.citations ?? {}), [response.citation.id]: response.citation };
+            } else if (response.delta_answer) {
+              currentText = (response.answer || '').slice(answerOffset);
+            }
+
+            // Build display content: parts + trailing text
+            const displayParts: IChatMessageContentItem[] = [...contentParts];
+            if (currentText) {
+              displayParts.push({ type: 'text', text: currentText });
+            }
+
+            if (displayParts.length > 0) {
+              this.messages[this.messages.length - 1] = {
+                role: ROLE_ASSISTANT,
+                content: displayParts,
+                thinking: lastMessage?.thinking,
+                citations: lastMessage?.citations,
+                state:
+                  lastMessage?.state !== IChatMessageState.FINISHED ? IChatMessageState.ANSWERING : lastMessage?.state
+              };
+            } else {
+              this.messages[this.messages.length - 1] = {
+                role: ROLE_ASSISTANT,
+                content: response.answer,
+                thinking: lastMessage?.thinking,
+                citations: lastMessage?.citations,
+                state:
+                  lastMessage?.state !== IChatMessageState.FINISHED ? IChatMessageState.ANSWERING : lastMessage?.state
+              };
+            }
+            conversationId = response?.id;
+          },
+          signal: this.canceler!.signal
+        })
         .then(async () => {
           console.debug('finished fetch answer', this.messages);
           this.messages[this.messages.length - 1].state = IChatMessageState.FINISHED;


### PR DESCRIPTION
Implements the Nexior frontend half of the aichat2 ask-user-question pause/resume protocol (frozen contract §1, §2, §7).

## Behaviour

- When the worker emits an `ask_user_question` SSE event, the matching `tool_use` block on the in-flight assistant message flips to `status='awaiting_input'` and stores the payload on `pending_question`. The renderer swaps in `<AskUserQuestionCard>`.
- The card renders 1–4 questions with 2–4 options each (radio for single-select, checkbox for multi-select), per-option helper text, and a free-text "Other" fallback. **Submit** is enabled when at least one option (or Other) is filled.
- On submit, the card emits a `tool_use_id` + JSON-stringified output matching the contract shape `{ answers: { questionText: string | string[] }, other: string | null }`. `Conversation.vue` resumes the conversation by POSTing `{ id, model, tool_results: [{ tool_use_id, output }] }` and streams the next assistant turn into a fresh pending message.
- After submit (or on restore for an already-folded `done` block with `tool_name === 'ask_user_question'`), the card collapses to a one-line `✓ Question → Answer` summary per question.
- A non-network **Skip** button collapses the card locally; the next fresh user message goes through the worker's user-skipped branch.
- Layout is responsive — buttons stretch to full width at ≤480px (mobile).

## Files added

- `src/components/chat/AskUserQuestionCard.vue` — the card component (single + multi select, Other free-text, Skip + Submit, collapsed read-only mode).
- `src/components/chat/askUserQuestion.ts` — pure helpers (`buildAskUserQuestionOutput`, `canSubmitAskUserQuestion`, `truncateHeader`) extracted for testability.
- `src/components/chat/askUserQuestion.test.ts` — vitest spec covering output shape (single, multi, combined, Other-only), submit-enable logic, header truncation. **13 tests, all green.**

## Files changed

- `src/models/chat.ts` — extend `IChatMessageContentItem.status` to include `'awaiting_input'`, add `pending_question`. New `IAskUserQuestion`, `IAskUserQuestionOption`, `IAskUserQuestionPayload` types. Extend `IChatConversationRequest` with `tool_results?: { tool_use_id; output; is_error? }[]` and `IChatConversationResponse` with `payload?` for the new SSE event.
- `src/operators/chat.ts` — forward `payload` from SSE events to the stream callback so the new `ask_user_question` event reaches the view layer.
- `src/pages/chat/Conversation.vue` — handle `ask_user_question` SSE event; extract the streaming closure into `_streamAssistantTurn` so the same pipeline serves both `onRequest` (composer prompt) and `onAnswerAskUserQuestion` (resume with `tool_results`); also collapses the local pending block instantly on submit. Adds a visual `onSkipAskUserQuestion` collapse path.
- `src/components/chat/Message.vue` — render `<AskUserQuestionCard>` for tool_use blocks whose `tool_name === 'ask_user_question'` (`awaiting_input` → interactive card; `done` → collapsed summary reconstructed from `input.questions` + parsed `output` JSON); re-emit submit/skip events upward to `Conversation.vue`.
- `src/i18n/{en,zh-CN}/chat.json` — add 6 keys under `askUserQuestion.*` (zh-CN + en only; per project rule we don't auto-translate other locales).

## Verification

- `npx vue-tsc -b` ✓ (no type errors)
- `npm run lint:check` — 4 pre-existing prettier errors on origin/main (Composer.vue, NotFound.vue, capabilities.ts) untouched by this PR; all errors in files this PR touches are fixed.
- `npm run build` ✓ (`built in 12.14s`)
- `npm run test:run` ✓ — 99 tests passed (13 new + 86 existing)

## Worker side

This PR implements the frontend; the worker side ships in:

- PR1 (PlatformService aichat2 protocol scaffold): adds `ToolUseContent.status='awaiting_input'`, `AskUserQuestionEvent`, `TerminalReason='awaiting_user_input'`, validator updates, and the `ask_user_question` tool (registered but not yet exposed to the LLM).
- PR2 (PlatformService aichat2 queryLoop pause/resume): hooks `applyToolOutcome` to emit the SSE event, accepts the `tool_results` resume body, gates on `stateful=true`, and registers the tool.

Older clients receive an `awaiting_input` block in retrieved conversations; they render the JSON input as-is (no card). Acceptable per contract §10.
