### PR TITLE
fix(store): stop persisting per-app .tasks to prevent vuex localStorage quota overflow

### DIFF
--- a/src/store/flux/persist.ts
+++ b/src/store/flux/persist.ts
@@ -1,1 +1,4 @@
-export default ['flux.credential', 'flux.application', 'flux.applications', 'flux.tasks'];
+// `flux.tasks` deliberately NOT persisted: paginated API cache, re-fetched on page mount.
+// Persisting it across all per-app modules grew the `vuex` localStorage blob past the
+// browser quota (~5 MB) for power users — see Failed to execute 'setItem' on 'Storage'.
+export default ['flux.credential', 'flux.application', 'flux.applications'];

--- a/src/store/hailuo/persist.ts
+++ b/src/store/hailuo/persist.ts
@@ -1,1 +1,2 @@
-export default ['hailuo.credential', 'hailuo.application', 'hailuo.applications', 'hailuo.tasks'];
+// See flux/persist.ts for why `.tasks` is no longer persisted.
+export default ['hailuo.credential', 'hailuo.application', 'hailuo.applications'];

--- a/src/store/headshots/persist.ts
+++ b/src/store/headshots/persist.ts
@@ -1,1 +1,2 @@
-export default ['headshots.credential', 'headshots.application', 'headshots.applications', 'headshots.tasks'];
+// See flux/persist.ts for why `.tasks` is no longer persisted.
+export default ['headshots.credential', 'headshots.application', 'headshots.applications'];

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -25,11 +25,47 @@ const lazyPersistModules = import.meta.glob<{ default: string[] }>(['./*/persist
 
 const lazyPersistPaths: string[] = Object.values(lazyPersistModules).flatMap((m) => m.default);
 
+// Quota-safe wrapper around localStorage. The `vuex` blob has, in the past,
+// grown past the ~5 MB browser quota for power users (mostly from per-app
+// `tasks` arrays — now removed from `paths`). When the next setItem still
+// overflows for any reason, drop the legacy key and retry once; if it still
+// fails, swallow silently so the user-facing flow isn't broken by
+// `QuotaExceededError: Setting the value of 'vuex' exceeded the quota.`
+const isQuotaError = (err: unknown): boolean => {
+  if (!err || typeof err !== 'object') return false;
+  const e = err as { name?: string; code?: number };
+  return e.name === 'QuotaExceededError' || e.name === 'NS_ERROR_DOM_QUOTA_REACHED' || e.code === 22 || e.code === 1014;
+};
+
+const safeStorage: Storage = {
+  get length() {
+    return window.localStorage.length;
+  },
+  clear: () => window.localStorage.clear(),
+  key: (index: number) => window.localStorage.key(index),
+  getItem: (key: string) => window.localStorage.getItem(key),
+  removeItem: (key: string) => window.localStorage.removeItem(key),
+  setItem: (key: string, value: string) => {
+    try {
+      window.localStorage.setItem(key, value);
+    } catch (err) {
+      if (!isQuotaError(err)) throw err;
+      try {
+        window.localStorage.removeItem(key);
+        window.localStorage.setItem(key, value);
+      } catch {
+        // Give up; better to lose persistence than crash the app.
+      }
+    }
+  }
+};
+
 const store = createStore({
   ...root,
   plugins: [
     createPersistedState({
-      paths: [...persistRoot, ...lazyPersistPaths]
+      paths: [...persistRoot, ...lazyPersistPaths],
+      storage: safeStorage
     })
   ]
 });

--- a/src/store/kling/persist.ts
+++ b/src/store/kling/persist.ts
@@ -1,1 +1,2 @@
-export default ['kling.credential', 'kling.application', 'kling.applications', 'kling.tasks', 'kling.taskType'];
+// See flux/persist.ts for why `.tasks` is no longer persisted.
+export default ['kling.credential', 'kling.application', 'kling.applications', 'kling.taskType'];

--- a/src/store/luma/persist.ts
+++ b/src/store/luma/persist.ts
@@ -1,1 +1,2 @@
-export default ['luma.credential', 'luma.application', 'luma.applications', 'luma.tasks'];
+// See flux/persist.ts for why `.tasks` is no longer persisted.
+export default ['luma.credential', 'luma.application', 'luma.applications'];

--- a/src/store/midjourney/persist.ts
+++ b/src/store/midjourney/persist.ts
@@ -1,7 +1,2 @@
-export default [
-  'midjourney.credential',
-  'midjourney.mode',
-  'midjourney.application',
-  'midjourney.applications',
-  'midjourney.tasks'
-];
+// See flux/persist.ts for why `.tasks` is no longer persisted.
+export default ['midjourney.credential', 'midjourney.mode', 'midjourney.application', 'midjourney.applications'];

--- a/src/store/nanobanana/persist.ts
+++ b/src/store/nanobanana/persist.ts
@@ -1,1 +1,2 @@
-export default ['nanobanana.credential', 'nanobanana.application', 'nanobanana.applications', 'nanobanana.tasks'];
+// See flux/persist.ts for why `.tasks` is no longer persisted.
+export default ['nanobanana.credential', 'nanobanana.application', 'nanobanana.applications'];

--- a/src/store/openaiimage/persist.ts
+++ b/src/store/openaiimage/persist.ts
@@ -1,1 +1,2 @@
-export default ['openaiimage.credential', 'openaiimage.application', 'openaiimage.applications', 'openaiimage.tasks'];
+// See flux/persist.ts for why `.tasks` is no longer persisted.
+export default ['openaiimage.credential', 'openaiimage.application', 'openaiimage.applications'];

--- a/src/store/pika/persist.ts
+++ b/src/store/pika/persist.ts
@@ -1,1 +1,2 @@
-export default ['pika.credential', 'pika.application', 'pika.applications', 'pika.tasks'];
+// See flux/persist.ts for why `.tasks` is no longer persisted.
+export default ['pika.credential', 'pika.application', 'pika.applications'];

--- a/src/store/pixverse/persist.ts
+++ b/src/store/pixverse/persist.ts
@@ -1,1 +1,2 @@
-export default ['pixverse.credential', 'pixverse.application', 'pixverse.applications', 'pixverse.tasks'];
+// See flux/persist.ts for why `.tasks` is no longer persisted.
+export default ['pixverse.credential', 'pixverse.application', 'pixverse.applications'];

--- a/src/store/producer/persist.ts
+++ b/src/store/producer/persist.ts
@@ -1,1 +1,2 @@
-export default ['producer.credential', 'producer.application', 'producer.applications', 'producer.tasks'];
+// See flux/persist.ts for why `.tasks` is no longer persisted.
+export default ['producer.credential', 'producer.application', 'producer.applications'];

--- a/src/store/qrart/persist.ts
+++ b/src/store/qrart/persist.ts
@@ -1,1 +1,2 @@
-export default ['qrart.credential', 'qrart.application', 'qrart.applications', 'qrart.tasks'];
+// See flux/persist.ts for why `.tasks` is no longer persisted.
+export default ['qrart.credential', 'qrart.application', 'qrart.applications'];

--- a/src/store/seedance/persist.ts
+++ b/src/store/seedance/persist.ts
@@ -1,1 +1,2 @@
-export default ['seedance.credential', 'seedance.application', 'seedance.applications', 'seedance.tasks'];
+// See flux/persist.ts for why `.tasks` is no longer persisted.
+export default ['seedance.credential', 'seedance.application', 'seedance.applications'];

--- a/src/store/seedream/persist.ts
+++ b/src/store/seedream/persist.ts
@@ -1,1 +1,2 @@
-export default ['seedream.credential', 'seedream.application', 'seedream.applications', 'seedream.tasks'];
+// See flux/persist.ts for why `.tasks` is no longer persisted.
+export default ['seedream.credential', 'seedream.application', 'seedream.applications'];

--- a/src/store/sora/persist.ts
+++ b/src/store/sora/persist.ts
@@ -1,1 +1,2 @@
-export default ['sora.credential', 'sora.application', 'sora.applications', 'sora.tasks'];
+// See flux/persist.ts for why `.tasks` is no longer persisted.
+export default ['sora.credential', 'sora.application', 'sora.applications'];

--- a/src/store/suno/persist.ts
+++ b/src/store/suno/persist.ts
@@ -1,1 +1,2 @@
-export default ['suno.credential', 'suno.application', 'suno.applications', 'suno.tasks', 'suno.favoritePersonaIds'];
+// See flux/persist.ts for why `.tasks` is no longer persisted.
+export default ['suno.credential', 'suno.application', 'suno.applications', 'suno.favoritePersonaIds'];

--- a/src/store/veo/persist.ts
+++ b/src/store/veo/persist.ts
@@ -1,1 +1,2 @@
-export default ['veo.credential', 'veo.application', 'veo.applications', 'veo.tasks'];
+// See flux/persist.ts for why `.tasks` is no longer persisted.
+export default ['veo.credential', 'veo.application', 'veo.applications'];

--- a/src/store/wan/persist.ts
+++ b/src/store/wan/persist.ts
@@ -1,1 +1,2 @@
-export default ['wan.credential', 'wan.application', 'wan.applications', 'wan.tasks'];
+// See flux/persist.ts for why `.tasks` is no longer persisted.
+export default ['wan.credential', 'wan.application', 'wan.applications'];


### PR DESCRIPTION
## Symptom

Error tracker is reporting (1 user, but the per-user count is climbing fast):

- **JS 错误** — `Failed to execute 'setItem' on 'Storage': Setting the value of 'vuex' exceeded the quota.` — 213 occurrences (29.42%)
- **Promise 错误** — same message — 212 occurrences (29.28%)

Both rows are the same root cause; the two error types just reflect whether the failing `setItem` happened on the synchronous Vuex commit path or inside an async action's microtask.

## Root cause

`vuex-persistedstate` writes the entire selected slice of state under the single `vuex` localStorage key on every commit. Browsers cap that key at roughly 5 MB.

In Nexior the persisted slice listed `<app>.tasks` for **every** per-app module:

```
suno.tasks, midjourney.tasks, luma.tasks, sora.tasks, kling.tasks,
hailuo.tasks, veo.tasks, flux.tasks, seedance.tasks, seedream.tasks,
nanobanana.tasks, openaiimage.tasks, pika.tasks, pixverse.tasks,
headshots.tasks, qrart.tasks, producer.tasks, wan.tasks
```

Each task entry carries image / audio / video URLs, prompts, full config, status, params, etc. For users who exercise multiple AI services, the tasks list balloons across reloads — `getTasks` merges new pages with previously-persisted ones rather than replacing — until the serialized blob crosses the quota and **every** subsequent commit throws.

## Fix

1. Remove all 18 `<app>.tasks` entries from per-app `persist.ts`. Tasks are paginated API caches that the page already re-fetches on mount via `getTasks`; they were never the source of truth. Credentials, applications, and small UI prefs (`kling.taskType`, `midjourney.mode`, `suno.favoritePersonaIds`) are kept.
2. Pass a `storage` adapter to `createPersistedState` that catches `QuotaExceededError` on `setItem`, drops the legacy `vuex` blob and retries once, then swallows silently. Better to skip a single persist than to crash the Vuex action pipeline.

After deploy, the next save overwrites the existing oversize `vuex` key with a fresh (much smaller) blob — no manual `localStorage.clear()` needed for affected users.

## Files

- `src/store/index.ts` — quota-safe storage shim around `localStorage` passed to `createPersistedState`.
- `src/store/{flux,hailuo,headshots,kling,luma,midjourney,nanobanana,openaiimage,pika,pixverse,producer,qrart,seedance,seedream,sora,suno,veo,wan}/persist.ts` — drop `<app>.tasks`.

## Verification

- `npx eslint src/store/index.ts src/store/*/persist.ts` — clean.
- `npx vue-tsc -b` — clean.
- `npm run build` — succeeds.

## Behavioral notes

- First load after deploy on the Suno / Midjourney / Luma / etc. pages will show the loading state for tasks once (instead of instantly showing the previously-cached list), then refresh from the API. This is what the page already does when there is no persisted blob — no new code path.
- Pagination, scroll position, and active-task selection are unaffected.
- Polling / status updates are unaffected (those run against in-memory state, not localStorage).
