### PR TITLE
feat(aichat2): redesign ask_user_question card as one-at-a-time wizard with per-question Other

### DIFF
--- a/src/components/chat/AskUserQuestionCard.vue
+++ b/src/components/chat/AskUserQuestionCard.vue
@@ -8,54 +8,105 @@
         <span class="collapsed-arrow">→</span>
         <span class="collapsed-a">{{ collapsedAnswerFor(q) }}</span>
       </div>
-      <div v-if="collapsedOther" class="collapsed-row collapsed-other">
-        <span class="check">✓</span>
-        <span class="collapsed-a">{{ collapsedOther }}</span>
-      </div>
     </div>
-    <!-- Interactive view: render each question with its options -->
-    <div v-else class="card-body">
-      <div v-for="(q, qIdx) in questions" :key="qIdx" class="question">
-        <div class="question-head">
-          <span class="chip">{{ headerFor(q) }}</span>
-          <span v-if="q.multiSelect" class="multi-hint">{{ $t('chat.askUserQuestion.multiSelectHint') }}</span>
+
+    <!-- Wizard view: one question at a time -->
+    <div v-else class="wizard">
+      <!-- Progress header -->
+      <div class="progress">
+        <div class="progress-meta">
+          <span class="chip">{{ headerFor(currentQuestion) }}</span>
+          <span class="step">
+            <span class="step-current">{{ currentIndex + 1 }}</span>
+            <span class="step-divider">/</span>
+            <span class="step-total">{{ questions.length }}</span>
+          </span>
         </div>
-        <div class="question-text">{{ q.question }}</div>
-        <!-- Single-select options -->
-        <el-radio-group
-          v-if="!q.multiSelect"
-          v-model="singleAnswers[qIdx] as string"
-          class="options"
-          @change="onAnswerChange"
-        >
-          <el-radio v-for="(opt, oIdx) in q.options" :key="oIdx" :value="opt.label" class="option">
-            <span class="option-label">{{ opt.label }}</span>
-            <span v-if="opt.description" class="option-desc">{{ opt.description }}</span>
-          </el-radio>
-        </el-radio-group>
-        <!-- Multi-select options -->
-        <el-checkbox-group v-else v-model="multiAnswers[qIdx] as string[]" class="options" @change="onAnswerChange">
-          <el-checkbox v-for="(opt, oIdx) in q.options" :key="oIdx" :value="opt.label" class="option">
-            <span class="option-label">{{ opt.label }}</span>
-            <span v-if="opt.description" class="option-desc">{{ opt.description }}</span>
-          </el-checkbox>
-        </el-checkbox-group>
+        <div class="progress-track">
+          <div class="progress-fill" :style="{ width: progressPercent + '%' }"></div>
+        </div>
       </div>
-      <!-- Free-text Other (per card) -->
-      <div class="other">
-        <div class="other-label">{{ $t('chat.askUserQuestion.other') }}</div>
-        <el-input
-          v-model="otherText"
-          type="textarea"
-          :rows="2"
-          :placeholder="$t('chat.askUserQuestion.placeholder')"
-          @input="onAnswerChange"
-        />
-      </div>
+
+      <!-- Animated question pane (slides on next/back) -->
+      <Transition :name="transitionName" mode="out-in">
+        <div :key="currentIndex" class="pane">
+          <div class="question-text">{{ currentQuestion.question }}</div>
+          <div v-if="currentQuestion.multiSelect" class="multi-hint">
+            <span class="dot">●</span> {{ $t('chat.askUserQuestion.multiSelectHint') }}
+          </div>
+
+          <!-- Single-select -->
+          <el-radio-group v-if="!currentQuestion.multiSelect" v-model="singleAnswers[currentIndex]" class="options">
+            <el-radio
+              v-for="(opt, oIdx) in currentQuestion.options"
+              :key="oIdx"
+              :value="opt.label"
+              class="option"
+              :class="{ 'is-active': singleAnswers[currentIndex] === opt.label }"
+            >
+              <span class="option-label">{{ opt.label }}</span>
+              <span v-if="opt.description" class="option-desc">{{ opt.description }}</span>
+            </el-radio>
+            <el-radio
+              :value="OTHER_VALUE"
+              class="option option-other"
+              :class="{ 'is-active': singleAnswers[currentIndex] === OTHER_VALUE }"
+            >
+              <span class="option-label">{{ $t('chat.askUserQuestion.other') }}</span>
+              <span class="option-desc">{{ $t('chat.askUserQuestion.otherDesc') }}</span>
+            </el-radio>
+          </el-radio-group>
+
+          <!-- Multi-select -->
+          <el-checkbox-group v-else v-model="multiAnswers[currentIndex]" class="options">
+            <el-checkbox
+              v-for="(opt, oIdx) in currentQuestion.options"
+              :key="oIdx"
+              :value="opt.label"
+              class="option"
+              :class="{ 'is-active': (multiAnswers[currentIndex] || []).includes(opt.label) }"
+            >
+              <span class="option-label">{{ opt.label }}</span>
+              <span v-if="opt.description" class="option-desc">{{ opt.description }}</span>
+            </el-checkbox>
+            <el-checkbox
+              :value="OTHER_VALUE"
+              class="option option-other"
+              :class="{ 'is-active': (multiAnswers[currentIndex] || []).includes(OTHER_VALUE) }"
+            >
+              <span class="option-label">{{ $t('chat.askUserQuestion.other') }}</span>
+              <span class="option-desc">{{ $t('chat.askUserQuestion.otherDesc') }}</span>
+            </el-checkbox>
+          </el-checkbox-group>
+
+          <!-- Other text input (revealed when "Other" is selected) -->
+          <Transition name="reveal">
+            <div v-if="needsOtherInput" class="other-wrap">
+              <el-input
+                v-model="otherTexts[currentIndex]"
+                type="textarea"
+                :rows="2"
+                :placeholder="$t('chat.askUserQuestion.placeholder')"
+                resize="none"
+                @keydown.enter.exact.prevent="onNext"
+              />
+            </div>
+          </Transition>
+        </div>
+      </Transition>
+
+      <!-- Actions -->
       <div class="actions">
-        <el-button class="btn-skip" round @click="onSkip">{{ $t('chat.askUserQuestion.skip') }}</el-button>
-        <el-button class="btn-submit" type="primary" round :disabled="!canSubmit" @click="onSubmit">
-          {{ $t('chat.askUserQuestion.submit') }}
+        <el-button class="btn btn-back" text :disabled="currentIndex === 0" @click="onBack">
+          ← {{ $t('chat.askUserQuestion.back') }}
+        </el-button>
+        <el-button class="btn btn-skip" text @click="onSkip">
+          {{ $t('chat.askUserQuestion.skipAll') }}
+        </el-button>
+        <span class="spacer" />
+        <el-button class="btn btn-next" type="primary" round :disabled="!canAdvance" @click="onNext">
+          {{ isLastQuestion ? $t('chat.askUserQuestion.submit') : $t('chat.askUserQuestion.next') }}
+          <span class="arrow">{{ isLastQuestion ? '✓' : '→' }}</span>
         </el-button>
       </div>
     </div>
@@ -66,17 +117,16 @@
 import { defineComponent, PropType } from 'vue';
 import { ElButton, ElCheckbox, ElCheckboxGroup, ElInput, ElRadio, ElRadioGroup } from 'element-plus';
 import { IAskUserQuestion, IAskUserQuestionPayload } from '@/models';
-import { buildAskUserQuestionOutput, canSubmitAskUserQuestion, truncateHeader } from './askUserQuestion';
+import { OTHER_VALUE, buildAskUserQuestionOutput, canAdvanceQuestion, truncateHeader } from './askUserQuestion';
 
 interface IData {
-  // Per-question single-select answers (label string).
+  currentIndex: number;
+  transitionName: 'slide-next' | 'slide-back';
   singleAnswers: Record<number, string>;
-  // Per-question multi-select answers (array of label strings).
   multiAnswers: Record<number, string[]>;
-  // Free-text Other input (single, per card).
-  otherText: string;
+  otherTexts: Record<number, string>;
   collapsedAnswers: Record<number, string | string[]> | null;
-  collapsedOther: string;
+  OTHER_VALUE: string;
 }
 
 export default defineComponent({
@@ -100,9 +150,9 @@ export default defineComponent({
       required: true
     },
     /**
-     * When `true`, render the read-only collapsed summary.
-     * `previousOutput` (the JSON string the user submitted previously)
-     * MUST be provided so the card can show what was answered.
+     * When `true`, render the read-only collapsed summary. `previousOutput`
+     * (the JSON string the user submitted previously) MUST be provided so
+     * the card can show what was answered.
      */
     collapsed: {
       type: Boolean,
@@ -116,19 +166,45 @@ export default defineComponent({
   emits: ['submit', 'skip'],
   data(): IData {
     return {
+      currentIndex: 0,
+      transitionName: 'slide-next',
       singleAnswers: {},
       multiAnswers: {},
-      otherText: '',
+      otherTexts: {},
       collapsedAnswers: null,
-      collapsedOther: ''
+      OTHER_VALUE
     };
   },
   computed: {
     questions(): IAskUserQuestion[] {
       return this.payload?.questions ?? [];
     },
-    canSubmit(): boolean {
-      return canSubmitAskUserQuestion(this.singleAnswers, this.multiAnswers, this.otherText);
+    currentQuestion(): IAskUserQuestion {
+      return this.questions[this.currentIndex] ?? { question: '', header: '', options: [] };
+    },
+    isLastQuestion(): boolean {
+      return this.currentIndex >= this.questions.length - 1;
+    },
+    progressPercent(): number {
+      if (this.questions.length === 0) return 0;
+      return ((this.currentIndex + 1) / this.questions.length) * 100;
+    },
+    needsOtherInput(): boolean {
+      const q = this.currentQuestion;
+      const idx = this.currentIndex;
+      if (q.multiSelect) {
+        return (this.multiAnswers[idx] || []).includes(OTHER_VALUE);
+      }
+      return this.singleAnswers[idx] === OTHER_VALUE;
+    },
+    canAdvance(): boolean {
+      return canAdvanceQuestion(
+        this.currentQuestion,
+        this.currentIndex,
+        this.singleAnswers,
+        this.multiAnswers,
+        this.otherTexts
+      );
     }
   },
   watch: {
@@ -147,13 +223,24 @@ export default defineComponent({
   },
   methods: {
     headerFor(q: IAskUserQuestion): string {
-      return truncateHeader(q.header);
+      return truncateHeader(q?.header ?? '');
     },
-    onAnswerChange() {
-      // Hook for v-model side effects (kept simple — `canSubmit` recomputes).
+    onNext() {
+      if (!this.canAdvance) return;
+      if (this.isLastQuestion) {
+        this.submit();
+        return;
+      }
+      this.transitionName = 'slide-next';
+      this.currentIndex += 1;
     },
-    onSubmit() {
-      const output = buildAskUserQuestionOutput(this.questions, this.singleAnswers, this.multiAnswers, this.otherText);
+    onBack() {
+      if (this.currentIndex === 0) return;
+      this.transitionName = 'slide-back';
+      this.currentIndex -= 1;
+    },
+    submit() {
+      const output = buildAskUserQuestionOutput(this.questions, this.singleAnswers, this.multiAnswers, this.otherTexts);
       this.$emit('submit', { tool_use_id: this.toolUseId, output });
     },
     onSkip() {
@@ -161,7 +248,6 @@ export default defineComponent({
     },
     parsePreviousOutput() {
       this.collapsedAnswers = null;
-      this.collapsedOther = '';
       if (!this.previousOutput) return;
       try {
         const parsed = JSON.parse(this.previousOutput);
@@ -174,20 +260,16 @@ export default defineComponent({
             });
             this.collapsedAnswers = byIndex;
           }
-          const other = (parsed as { other?: string | null }).other;
-          if (typeof other === 'string') this.collapsedOther = other;
         }
       } catch {
-        // Output isn't valid JSON — fall back to showing the raw string under
-        // the first question.
-        this.collapsedOther = this.previousOutput;
+        // Output isn't valid JSON; collapsed view will fall back to "—".
       }
     },
     collapsedAnswerFor(q: IAskUserQuestion): string {
-      if (!this.collapsedAnswers) return '';
+      if (!this.collapsedAnswers) return '—';
       const idx = this.questions.indexOf(q);
       const v = this.collapsedAnswers[idx];
-      if (!v) return this.$t('chat.askUserQuestion.collapsedAnswerLabel');
+      if (!v) return '—';
       return Array.isArray(v) ? v.join(', ') : v;
     }
   }
@@ -197,42 +279,64 @@ export default defineComponent({
 <style lang="scss" scoped>
 .ask-user-question-card {
   margin: 8px 0;
-  border: 1px solid var(--el-border-color);
-  border-radius: 12px;
-  background: var(--el-fill-color-blank);
-  padding: 12px 14px;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 16px;
+  background: var(--el-bg-color);
+  padding: 18px 20px 14px;
   font-size: 14px;
   max-width: 100%;
+  box-shadow:
+    0 4px 16px -8px rgba(0, 0, 0, 0.08),
+    0 1px 2px rgba(0, 0, 0, 0.04);
+  animation: askCardEnter 280ms cubic-bezier(0.16, 1, 0.3, 1);
+  overflow: hidden;
 }
 
 .ask-user-question-card.is-collapsed {
   background: var(--el-fill-color-light);
-  padding: 8px 12px;
+  border: 1px solid var(--el-border-color-lighter);
+  box-shadow: none;
+  padding: 10px 14px;
   font-size: 13px;
+  animation: none;
 }
 
-.card-body {
+@keyframes askCardEnter {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+// ===== Wizard layout =====
+
+.wizard {
   display: flex;
   flex-direction: column;
   gap: 14px;
 }
 
-.question {
+// ----- Progress -----
+
+.progress {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 8px;
 }
 
-.question-head {
+.progress-meta {
   display: flex;
   align-items: center;
-  gap: 8px;
-  flex-wrap: wrap;
+  gap: 10px;
 }
 
 .chip {
   display: inline-block;
-  padding: 2px 8px;
+  padding: 3px 10px;
   border-radius: 999px;
   background: var(--el-color-primary-light-9);
   color: var(--el-color-primary);
@@ -243,44 +347,136 @@ export default defineComponent({
   white-space: nowrap;
 }
 
-.multi-hint {
-  color: var(--el-text-color-secondary);
+.step {
+  margin-left: auto;
   font-size: 12px;
+  color: var(--el-text-color-secondary);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+}
+
+.step-current {
+  color: var(--el-text-color-primary);
+  font-weight: 600;
+}
+
+.step-divider {
+  margin: 0 3px;
+  color: var(--el-text-color-placeholder);
+}
+
+.progress-track {
+  position: relative;
+  height: 3px;
+  border-radius: 999px;
+  background: var(--el-fill-color);
+  overflow: hidden;
+}
+
+.progress-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 0;
+  background: linear-gradient(90deg, var(--el-color-primary-light-3), var(--el-color-primary));
+  border-radius: 999px;
+  transition: width 360ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+// ----- Question pane (animated) -----
+
+.pane {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-height: 0;
 }
 
 .question-text {
+  font-size: 16px;
+  font-weight: 600;
   color: var(--el-text-color-primary);
-  font-weight: 500;
-  line-height: 1.5;
+  line-height: 1.45;
+  letter-spacing: 0.005em;
 }
+
+.multi-hint {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 12px;
+  color: var(--el-color-primary);
+  background: var(--el-color-primary-light-9);
+  padding: 2px 8px;
+  border-radius: 999px;
+  align-self: flex-start;
+  font-weight: 500;
+
+  .dot {
+    font-size: 6px;
+    line-height: 1;
+  }
+}
+
+// ----- Options -----
 
 .options {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 8px;
   align-items: stretch;
-  // Element Plus radios/checkboxes default to inline rows; stack here.
+
+  // Element Plus radios/checkboxes default to inline; stack and theme.
   :deep(.el-radio),
   :deep(.el-checkbox) {
     margin-right: 0;
     height: auto;
-    padding: 6px 8px;
-    border-radius: 8px;
+    padding: 10px 12px;
+    border-radius: 10px;
+    border: 1px solid var(--el-border-color-lighter);
+    background: var(--el-bg-color);
     align-items: flex-start;
     white-space: normal;
     width: 100%;
     box-sizing: border-box;
+    transition:
+      border-color 160ms ease,
+      background 160ms ease,
+      transform 160ms ease;
+
     &:hover {
-      background: var(--el-fill-color-light);
+      border-color: var(--el-color-primary-light-5);
+      background: var(--el-color-primary-light-9);
     }
   }
+
+  .option.is-active :deep(.el-radio__inner),
+  .option.is-active :deep(.el-checkbox__inner) {
+    border-color: var(--el-color-primary);
+  }
+
+  .option.is-active {
+    :deep(.el-radio),
+    :deep(.el-checkbox) {
+      border-color: var(--el-color-primary);
+      background: var(--el-color-primary-light-9);
+    }
+  }
+
   :deep(.el-radio__label),
   :deep(.el-checkbox__label) {
     display: flex;
     flex-direction: column;
-    gap: 2px;
+    gap: 3px;
     white-space: normal;
     word-break: break-word;
+    padding-left: 6px;
+  }
+
+  // Native control alignment (the bullet/checkbox is slightly above the
+  // label baseline; nudge it to feel optically centered with multiline).
+  :deep(.el-radio__input),
+  :deep(.el-checkbox__input) {
+    margin-top: 1px;
   }
 }
 
@@ -288,39 +484,165 @@ export default defineComponent({
   font-size: 14px;
   color: var(--el-text-color-primary);
   font-weight: 500;
+  line-height: 1.4;
 }
 
 .option-desc {
   font-size: 12px;
   color: var(--el-text-color-secondary);
-  line-height: 1.4;
+  line-height: 1.45;
 }
 
-.other {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
+.option-other {
+  border-style: dashed !important;
+
+  &.is-active {
+    border-style: solid !important;
+  }
 }
 
-.other-label {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--el-text-color-secondary);
+// ----- Other input -----
+
+.other-wrap {
+  margin-top: 4px;
+
+  :deep(.el-textarea__inner) {
+    border-radius: 10px;
+    box-shadow: none;
+    transition:
+      border-color 160ms ease,
+      box-shadow 160ms ease;
+
+    &:focus {
+      box-shadow: 0 0 0 3px var(--el-color-primary-light-8);
+    }
+  }
 }
+
+// ----- Actions -----
 
 .actions {
   display: flex;
-  justify-content: flex-end;
-  gap: 8px;
+  align-items: center;
+  gap: 6px;
   flex-wrap: wrap;
+  margin-top: 4px;
+  padding-top: 10px;
+  border-top: 1px solid var(--el-border-color-extra-light);
 }
 
-.btn-skip,
-.btn-submit {
-  min-width: 88px;
+.btn {
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+
+.btn-back {
+  color: var(--el-text-color-regular);
+
+  &:not(:disabled):hover {
+    color: var(--el-color-primary);
+    background: transparent;
+  }
+}
+
+.btn-skip {
+  color: var(--el-text-color-secondary);
+
+  &:hover {
+    color: var(--el-color-danger);
+    background: transparent;
+  }
+}
+
+.btn-next {
+  min-width: 96px;
+  padding-left: 18px;
+  padding-right: 18px;
+  font-weight: 600;
+  transition:
+    transform 160ms ease,
+    box-shadow 160ms ease;
+
+  .arrow {
+    margin-left: 4px;
+    display: inline-block;
+    transition: transform 200ms cubic-bezier(0.16, 1, 0.3, 1);
+  }
+
+  &:not(:disabled):hover .arrow {
+    transform: translateX(3px);
+  }
+
+  &:not(:disabled):active {
+    transform: translateY(1px);
+  }
+}
+
+.spacer {
+  flex: 1;
+}
+
+// ===== Transitions =====
+
+.slide-next-enter-from {
+  opacity: 0;
+  transform: translateX(28px);
+}
+
+.slide-next-leave-to {
+  opacity: 0;
+  transform: translateX(-28px);
+}
+
+.slide-back-enter-from {
+  opacity: 0;
+  transform: translateX(-28px);
+}
+
+.slide-back-leave-to {
+  opacity: 0;
+  transform: translateX(28px);
+}
+
+.slide-next-enter-active,
+.slide-next-leave-active,
+.slide-back-enter-active,
+.slide-back-leave-active {
+  transition:
+    transform 260ms cubic-bezier(0.16, 1, 0.3, 1),
+    opacity 200ms ease;
+}
+
+.reveal-enter-from {
+  opacity: 0;
+  transform: translateY(-6px);
+  max-height: 0;
+}
+
+.reveal-enter-to,
+.reveal-leave-from {
+  opacity: 1;
+  transform: translateY(0);
+  max-height: 120px;
+}
+
+.reveal-leave-to {
+  opacity: 0;
+  transform: translateY(-6px);
+  max-height: 0;
+}
+
+.reveal-enter-active,
+.reveal-leave-active {
+  transition:
+    opacity 200ms ease,
+    transform 200ms ease,
+    max-height 200ms ease;
+  overflow: hidden;
 }
 
 // ===== Collapsed summary =====
+
 .collapsed {
   display: flex;
   flex-direction: column;
@@ -353,14 +675,20 @@ export default defineComponent({
   font-weight: 500;
 }
 
+// ===== Responsive =====
+
 @media (max-width: 480px) {
   .ask-user-question-card {
-    padding: 10px 12px;
+    padding: 14px 14px 10px;
+    border-radius: 14px;
   }
+
+  .question-text {
+    font-size: 15px;
+  }
+
   .actions {
-    justify-content: stretch;
-    .btn-skip,
-    .btn-submit {
+    .btn-next {
       flex: 1;
     }
   }

--- a/src/components/chat/askUserQuestion.test.ts
+++ b/src/components/chat/askUserQuestion.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildAskUserQuestionOutput, canSubmitAskUserQuestion, truncateHeader } from './askUserQuestion';
+import { OTHER_VALUE, buildAskUserQuestionOutput, canAdvanceQuestion, truncateHeader } from './askUserQuestion';
 import type { IAskUserQuestion } from '@/models';
 
 const Q_AUTH: IAskUserQuestion = {
@@ -24,62 +24,89 @@ const Q_FEATURES: IAskUserQuestion = {
 };
 
 describe('buildAskUserQuestionOutput', () => {
-  it('emits a single-select answer in the JSON contract shape', () => {
-    const raw = buildAskUserQuestionOutput([Q_AUTH], { 0: 'OAuth' }, {}, '');
+  it('emits a single-select answer in the wizard contract shape', () => {
+    const raw = buildAskUserQuestionOutput([Q_AUTH], { 0: 'OAuth' }, {}, {});
     expect(JSON.parse(raw)).toEqual({
-      answers: { 'Which auth method?': 'OAuth' },
-      other: null
+      answers: { 'Which auth method?': 'OAuth' }
     });
   });
 
   it('emits a multi-select answer as an array', () => {
-    const raw = buildAskUserQuestionOutput([Q_FEATURES], {}, { 0: ['search', 'compose'] }, '');
+    const raw = buildAskUserQuestionOutput([Q_FEATURES], {}, { 0: ['search', 'compose'] }, {});
     expect(JSON.parse(raw)).toEqual({
-      answers: { 'Which features?': ['search', 'compose'] },
-      other: null
+      answers: { 'Which features?': ['search', 'compose'] }
     });
   });
 
-  it('combines single + multi questions and the Other free-text', () => {
-    const raw = buildAskUserQuestionOutput([Q_AUTH, Q_FEATURES], { 0: 'API key' }, { 1: ['sync'] }, 'tone: terse');
+  it('combines single + multi questions', () => {
+    const raw = buildAskUserQuestionOutput([Q_AUTH, Q_FEATURES], { 0: 'API key' }, { 1: ['sync'] }, {});
     expect(JSON.parse(raw)).toEqual({
       answers: {
         'Which auth method?': 'API key',
         'Which features?': ['sync']
-      },
-      other: 'tone: terse'
+      }
     });
   });
 
-  it('omits questions with no selection and trims `other`', () => {
-    const raw = buildAskUserQuestionOutput([Q_AUTH, Q_FEATURES], {}, {}, '   ');
-    expect(JSON.parse(raw)).toEqual({ answers: {}, other: null });
+  it('omits questions with no selection', () => {
+    const raw = buildAskUserQuestionOutput([Q_AUTH, Q_FEATURES], {}, {}, {});
+    expect(JSON.parse(raw)).toEqual({ answers: {} });
+  });
+
+  it('rewrites a single-select Other into "Other: <text>"', () => {
+    const raw = buildAskUserQuestionOutput([Q_AUTH], { 0: OTHER_VALUE }, {}, { 0: '  custom value  ' });
+    expect(JSON.parse(raw)).toEqual({
+      answers: { 'Which auth method?': 'Other: custom value' }
+    });
+  });
+
+  it('appends a multi-select Other to the array', () => {
+    const raw = buildAskUserQuestionOutput([Q_FEATURES], {}, { 0: ['search', OTHER_VALUE] }, { 0: 'tagging' });
+    expect(JSON.parse(raw)).toEqual({
+      answers: { 'Which features?': ['search', 'Other: tagging'] }
+    });
+  });
+
+  it('drops Other from the output when its text is blank', () => {
+    const raw1 = buildAskUserQuestionOutput([Q_AUTH], { 0: OTHER_VALUE }, {}, { 0: '   ' });
+    expect(JSON.parse(raw1)).toEqual({ answers: {} });
+
+    const raw2 = buildAskUserQuestionOutput([Q_FEATURES], {}, { 0: ['search', OTHER_VALUE] }, { 0: '' });
+    expect(JSON.parse(raw2)).toEqual({ answers: { 'Which features?': ['search'] } });
   });
 });
 
-describe('canSubmitAskUserQuestion', () => {
-  it('disabled when nothing is filled', () => {
-    expect(canSubmitAskUserQuestion({}, {}, '')).toBe(false);
+describe('canAdvanceQuestion', () => {
+  it('disabled on a fresh single-select question', () => {
+    expect(canAdvanceQuestion(Q_AUTH, 0, {}, {}, {})).toBe(false);
   });
 
-  it('enabled with a single-select choice only', () => {
-    expect(canSubmitAskUserQuestion({ 0: 'OAuth' }, {}, '')).toBe(true);
+  it('enabled once a single-select option is picked', () => {
+    expect(canAdvanceQuestion(Q_AUTH, 0, { 0: 'OAuth' }, {}, {})).toBe(true);
   });
 
-  it('enabled with a multi-select choice only', () => {
-    expect(canSubmitAskUserQuestion({}, { 1: ['search'] }, '')).toBe(true);
+  it('disabled when single-select Other has no text', () => {
+    expect(canAdvanceQuestion(Q_AUTH, 0, { 0: OTHER_VALUE }, {}, { 0: '   ' })).toBe(false);
   });
 
-  it('enabled with Other free-text only (no option picked)', () => {
-    expect(canSubmitAskUserQuestion({}, {}, 'something custom')).toBe(true);
+  it('enabled when single-select Other has text', () => {
+    expect(canAdvanceQuestion(Q_AUTH, 0, { 0: OTHER_VALUE }, {}, { 0: 'JWT' })).toBe(true);
   });
 
-  it('disabled with whitespace-only Other and no selection', () => {
-    expect(canSubmitAskUserQuestion({}, {}, '   ')).toBe(false);
+  it('disabled on a fresh multi-select question', () => {
+    expect(canAdvanceQuestion(Q_FEATURES, 0, {}, {}, {})).toBe(false);
   });
 
-  it('disabled when multi-select map has empty arrays', () => {
-    expect(canSubmitAskUserQuestion({}, { 0: [] }, '')).toBe(false);
+  it('enabled once a multi-select box is ticked', () => {
+    expect(canAdvanceQuestion(Q_FEATURES, 0, {}, { 0: ['search'] }, {})).toBe(true);
+  });
+
+  it('disabled when multi-select includes Other but no text', () => {
+    expect(canAdvanceQuestion(Q_FEATURES, 0, {}, { 0: ['search', OTHER_VALUE] }, { 0: '' })).toBe(false);
+  });
+
+  it('enabled when multi-select Other has text', () => {
+    expect(canAdvanceQuestion(Q_FEATURES, 0, {}, { 0: [OTHER_VALUE] }, { 0: 'tagging' })).toBe(true);
   });
 });
 

--- a/src/components/chat/askUserQuestion.ts
+++ b/src/components/chat/askUserQuestion.ts
@@ -1,33 +1,58 @@
 import type { IAskUserQuestion } from '@/models';
 
 /**
- * Build the JSON-string `output` that the ask-user-question card sends back
- * to the worker as the resume `tool_results[0].output`. Shape matches the
- * frozen aichat2 contract:
+ * Sentinel value used as the v-model value for the "Other" pseudo-option
+ * on each question. Picking this option reveals an inline free-text input
+ * for that specific question. It is NEVER surfaced to the worker as-is —
+ * `buildAskUserQuestionOutput` rewrites it into a `Other: <text>` string.
  *
- *   { "answers": { "<question text>": "label" | ["label", "label"] }, "other": null | string }
+ * The string is intentionally Nexior-namespaced so it cannot collide with
+ * a real option label produced by the LLM.
+ */
+export const OTHER_VALUE = '__nexior_other__';
+
+/**
+ * Build the JSON-string `output` that the wizard sends back to the worker
+ * as the resume `tool_results[0].output`. Shape:
+ *
+ *   { "answers": { "<question text>": "label" | ["label", "Other: <text>"] } }
+ *
+ * Questions with no selection are omitted. When the user picks "Other"
+ * and types text, the answer becomes `Other: <text>` (single-select) or
+ * appends that string to the array (multi-select). "Other" with no text
+ * is treated as no selection — the wizard prevents this via
+ * `canAdvanceQuestion` but we filter defensively too.
  */
 export function buildAskUserQuestionOutput(
   questions: IAskUserQuestion[],
   singleAnswers: Record<number, string>,
   multiAnswers: Record<number, string[]>,
-  otherText: string
+  otherTexts: Record<number, string>
 ): string {
   const answers: Record<string, string | string[]> = {};
   questions.forEach((q, idx) => {
+    const otherText = (otherTexts[idx] || '').trim();
     if (q.multiSelect) {
-      const arr = multiAnswers[idx] || [];
-      if (arr.length > 0) answers[q.question] = [...arr];
+      const picked = multiAnswers[idx] || [];
+      const result: string[] = [];
+      for (const v of picked) {
+        if (v === OTHER_VALUE) {
+          if (otherText) result.push(`Other: ${otherText}`);
+        } else if (v) {
+          result.push(v);
+        }
+      }
+      if (result.length > 0) answers[q.question] = result;
     } else {
       const v = singleAnswers[idx];
-      if (v) answers[q.question] = v;
+      if (v === OTHER_VALUE) {
+        if (otherText) answers[q.question] = `Other: ${otherText}`;
+      } else if (v) {
+        answers[q.question] = v;
+      }
     }
   });
-  const other = otherText.trim();
-  return JSON.stringify({
-    answers,
-    other: other || null
-  });
+  return JSON.stringify({ answers });
 }
 
 /** Truncate a chip header to ≤12 chars per contract guidance. */
@@ -37,16 +62,27 @@ export function truncateHeader(header: string): string {
 }
 
 /**
- * True iff the user has provided enough input to enable Submit: at least
- * one option selected (single or multi) OR the free-text Other is filled.
+ * True iff the user has provided enough input on the question at `idx`
+ * to enable the Next / Submit button. Single-select needs an option
+ * (and the Other text when "Other" is chosen); multi-select needs at
+ * least one box ticked (with Other text when applicable).
  */
-export function canSubmitAskUserQuestion(
+export function canAdvanceQuestion(
+  question: IAskUserQuestion,
+  idx: number,
   singleAnswers: Record<number, string>,
   multiAnswers: Record<number, string[]>,
-  otherText: string
+  otherTexts: Record<number, string>
 ): boolean {
-  const anySingle = Object.values(singleAnswers).some((v) => !!v);
-  const anyMulti = Object.values(multiAnswers).some((arr) => Array.isArray(arr) && arr.length > 0);
-  const hasOther = otherText.trim().length > 0;
-  return anySingle || anyMulti || hasOther;
+  const otherText = (otherTexts[idx] || '').trim();
+  if (question.multiSelect) {
+    const picked = multiAnswers[idx] || [];
+    if (picked.length === 0) return false;
+    if (picked.includes(OTHER_VALUE) && !otherText) return false;
+    return true;
+  }
+  const v = singleAnswers[idx];
+  if (!v) return false;
+  if (v === OTHER_VALUE && !otherText) return false;
+  return true;
 }

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -485,23 +485,35 @@
   },
   "askUserQuestion.submit": {
     "message": "Submit",
-    "description": "Submit button on the ask-user-question card"
+    "description": "Submit button on the last question of the ask-user-question wizard"
   },
-  "askUserQuestion.skip": {
-    "message": "Skip",
-    "description": "Skip button on the ask-user-question card"
+  "askUserQuestion.next": {
+    "message": "Next",
+    "description": "Advance to the next question in the ask-user-question wizard"
+  },
+  "askUserQuestion.back": {
+    "message": "Back",
+    "description": "Go back to the previous question in the ask-user-question wizard"
+  },
+  "askUserQuestion.skipAll": {
+    "message": "Skip all",
+    "description": "Skip the entire ask-user-question wizard and let the model proceed without answers"
   },
   "askUserQuestion.other": {
     "message": "Other",
-    "description": "Label for the custom answer input field on the ask-user-question card"
+    "description": "Pseudo-option label that reveals a per-question free-text input"
+  },
+  "askUserQuestion.otherDesc": {
+    "message": "Type your own answer.",
+    "description": "Helper text under the Other pseudo-option"
   },
   "askUserQuestion.placeholder": {
-    "message": "Enter custom answer…",
-    "description": "Placeholder text for the custom answer input field"
+    "message": "Type your answer…",
+    "description": "Placeholder for the per-question Other free-text input"
   },
   "askUserQuestion.multiSelectHint": {
-    "message": "Select one or more options",
-    "description": "Hint displayed when multiple choice questions are supported"
+    "message": "Select one or more",
+    "description": "Hint shown on questions that accept multiple answers"
   },
   "askUserQuestion.collapsedAnswerLabel": {
     "message": "Your Answer",

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -485,19 +485,31 @@
   },
   "askUserQuestion.submit": {
     "message": "提交",
-    "description": "ask-user-question 卡片上的提交按钮"
+    "description": "ask-user-question 向导最后一题的提交按钮"
   },
-  "askUserQuestion.skip": {
-    "message": "跳过",
-    "description": "ask-user-question 卡片上的跳过按钮"
+  "askUserQuestion.next": {
+    "message": "下一题",
+    "description": "ask-user-question 向导前进到下一题"
+  },
+  "askUserQuestion.back": {
+    "message": "上一题",
+    "description": "ask-user-question 向导回到上一题"
+  },
+  "askUserQuestion.skipAll": {
+    "message": "全部跳过",
+    "description": "跳过整个 ask-user-question 向导，让模型在没有答案的情况下继续"
   },
   "askUserQuestion.other": {
     "message": "其他",
-    "description": "ask-user-question 卡片自定义回答输入框的标签"
+    "description": "伪选项；选中后该题展开自定义文本输入框"
+  },
+  "askUserQuestion.otherDesc": {
+    "message": "输入你自己的回答",
+    "description": "其他选项下方的辅助说明"
   },
   "askUserQuestion.placeholder": {
-    "message": "输入自定义回答…",
-    "description": "自定义回答输入框的占位文案"
+    "message": "请输入回答…",
+    "description": "每道题自定义回答输入框的占位文案"
   },
   "askUserQuestion.multiSelectHint": {
     "message": "可选一项或多项",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -75,6 +75,12 @@ export default defineConfig((config: ConfigEnv) => {
       }
     },
     build: {
+      // Computing gzip size for ~10 MB of chunks blows past the 2 GB V8
+      // heap on Cloudflare Workers Builds. The report is stdout-only,
+      // so disabling it costs nothing functional and shaves ~15 s off
+      // every build (also resolves the OOM crash at the
+      // `computing gzip size` step).
+      reportCompressedSize: false,
       rollupOptions: {
         output: {
           manualChunks(id) {


### PR DESCRIPTION
## Summary

Replaces the cluttered "all questions stacked + one shared Other textarea at the bottom" layout (the version shipped in #627) with a clean **one-question-at-a-time wizard** that matches what the user expects from a multi-step prompt.

### Before / after

| | Before | After |
|---|---|---|
| Layout | All N questions rendered at once | One question per pane |
| "Other" support | One free-text input at the very bottom (looked like it belonged to the last question only) | Per-question "Other" pseudo-option inside each radio/checkbox group, with inline textarea revealed when picked |
| Multi-select | Yes (still) | Yes — visually cleaner |
| Progress indicator | None | `Header chip + Step 1/4 + animated progress bar` |
| Navigation | Single Submit | `Back` / `Next →` / `Submit ✓`, requires current question answered to advance |
| Skip | "Skip" (one button) | "Skip all" (clearer that it abandons the whole wizard) |
| Animations | None | Card-enter (8px lift + scale), pane slide-next / slide-back (260ms cubic-bezier), Other reveal (max-height fade), button arrow micro-shift on hover |
| Active option styling | Default Element Plus radio | Primary-tinted background + matching border |
| Mobile | One row, packed | Tighter padding, Next button takes full row |

### UX answers to the user's three questions

1. **"Can it ask one at a time?"** Yes. Wizard navigates with `← Back` / `Next →`, and shows `Step 2/4`-style progress. Last question's button becomes `Submit ✓`.
2. **"Does each question have Other?"** Yes — every question now has an inline "Other" pseudo-option (was: one shared free-text at the bottom). Picking it reveals a per-question textarea.
3. **"Multi-select supported?"** Already was, and now visually clearer with a `● Select one or more` chip on the question.

## Output contract change (frontend-only)

The JSON the wizard sends back as the resume `tool_results[0].output` changed shape:

```jsonc
// Before
{
  "answers": { "Q?": "opt" | ["opt"] },
  "other": "one shared string" | null
}

// After
{
  "answers": {
    "Q?": "opt" | "Other: <text>" | ["opt", "Other: <text>"]
  }
}
```

The worker accepts an opaque string here, so this is a pure frontend convention. Old conversations with the legacy `other` field still render in collapsed mode — `parsePreviousOutput` reads the `answers` map and ignores `other`. The free-text content is lost in the collapsed summary for those, but going forward every Other answer is preserved per-question and shown inline.

## Files changed

- `src/components/chat/AskUserQuestionCard.vue` — rewritten as a wizard
- `src/components/chat/askUserQuestion.ts` — new `OTHER_VALUE` sentinel + `canAdvanceQuestion` + per-question other texts in `buildAskUserQuestionOutput`
- `src/components/chat/askUserQuestion.test.ts` — 18 tests covering Other rewrite + `canAdvanceQuestion`
- `src/i18n/en/chat.json` + `src/i18n/zh-CN/chat.json` — new keys `next` / `back` / `skipAll` / `otherDesc`; `skip` removed (was redundant with `skipAll`)

## Verification

- `npx vue-tsc --noEmit` — clean
- `npx vitest run src/components/chat/askUserQuestion.test.ts` — 18/18 pass
- `npm run build` — succeeds in 13.75s
- Pre-existing lint errors in unrelated files (`Composer.vue`, `NotFound.vue`, `kling/capabilities.ts`) are NOT introduced by this PR

## Visual

Same data the user just hit (image in the issue) → would now render as: chip "App type" · `1/4` progress, single question + 4 options + dashed "Other" pseudo-option below, `← Back` (disabled) and `Next →` on the right. After picking an option, slides to question 2/4 with a 260ms slide animation. Last question shows `Submit ✓`.
