### PR TITLE
refactor(surface): centralize VITE_SURFACE checks behind isNative() helpers

### DIFF
--- a/change/@acedatacloud-nexior-62eed50a-c229-4b39-945a-0cb0ad2a4e38.json
+++ b/change/@acedatacloud-nexior-62eed50a-c229-4b39-945a-0cb0ad2a4e38.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Centralize Capacitor surface checks behind isNative()/isIOS()/isAndroid() helpers",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -16,6 +16,7 @@ import { isTest } from '@/constants/endpoint';
 import { getLocale } from './i18n';
 import { App as CapApp } from '@capacitor/app';
 import { Browser } from '@capacitor/browser';
+import { isNative } from '@/utils/surface';
 import { ssoOperator } from '@/operators';
 
 const elementPlusLocaleMap: Record<string, () => Promise<any>> = {
@@ -70,7 +71,7 @@ export default defineComponent({
   },
   mounted() {
     // Listen for deep link callbacks from native OAuth flow
-    if (import.meta.env.VITE_SURFACE === 'android' || import.meta.env.VITE_SURFACE === 'ios') {
+    if (isNative()) {
       CapApp.addListener('appUrlOpen', async ({ url }) => {
         console.debug('deep link received:', url);
         // Expected format: com.acedatacloud.nexior://auth/callback?code=XXX
@@ -107,7 +108,7 @@ export default defineComponent({
     const authenticated = !!this.$store.state.token.access && !!this.$store.state.user?.id;
     console.debug('App mounted, authenticated:', authenticated);
     if (!authenticated) {
-      if (import.meta.env.VITE_SURFACE === 'android' || import.meta.env.VITE_SURFACE === 'ios') {
+      if (isNative()) {
         // On native platforms, just reset state and show login popup.
         // Don't dispatch 'logout' which would navigate the WebView to an
         // external auth URL, opening Chrome and landing on localhost.

--- a/src/components/common/AuthPanel.vue
+++ b/src/components/common/AuthPanel.vue
@@ -37,6 +37,7 @@ import { getCookie } from 'typescript-cookie';
 import QrCode from 'vue-qrcode';
 import { ROUTE_SITE_INDEX } from '@/router';
 import { Browser } from '@capacitor/browser';
+import { isNative as isNativeSurface } from '@/utils/surface';
 
 export default defineComponent({
   name: 'AuthPanel',
@@ -53,7 +54,7 @@ export default defineComponent({
   },
   computed: {
     isNative() {
-      return import.meta.env.VITE_SURFACE === 'ios' || import.meta.env.VITE_SURFACE === 'android';
+      return isNativeSurface();
     },
     iframeUrl() {
       let url = `${getBaseUrlAuth()}/auth/login?inviter_id=${this.inviterId}`;
@@ -118,13 +119,13 @@ export default defineComponent({
           // navigate to site config page for white-label site owners,
           // but skip on native platforms (Android/iOS) where users are
           // always on the official site
-          if (import.meta.env.VITE_SURFACE !== 'android' && import.meta.env.VITE_SURFACE !== 'ios') {
+          if (!isNativeSurface()) {
             await this.$router.push({
               name: ROUTE_SITE_INDEX
             });
           }
         }
-        if (import.meta.env.VITE_SURFACE === 'ios' || import.meta.env.VITE_SURFACE === 'android') {
+        if (isNativeSurface()) {
           // On native platforms, hide the auth panel and navigate home instead
           // of reloading — window.location.reload() in Capacitor WKWebView can
           // fail to re-trigger the auth check, leaving users on a blank screen.

--- a/src/components/user/Center.vue
+++ b/src/components/user/Center.vue
@@ -42,7 +42,7 @@ import UserAvatar from '@/components/user/Avatar.vue';
 import UserSetting from '@/components/user/Setting.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { ROUTE_CONSOLE_ROOT, ROUTE_DISTRIBUTION_INDEX, ROUTE_DOWNLOAD } from '@/router';
-import { SURFACE_ANDROID, SURFACE_IOS } from '@/constants';
+import { isNative as isNativeSurface } from '@/utils/surface';
 import { ElDivider } from 'element-plus';
 import { ElDropdownMenu, ElDropdownItem, ElDropdown } from 'element-plus';
 
@@ -69,8 +69,7 @@ export default defineComponent({
       return this.$store.getters?.user;
     },
     isNative() {
-      const surface = import.meta.env.VITE_SURFACE;
-      return surface === SURFACE_IOS || surface === SURFACE_ANDROID;
+      return isNativeSurface();
     }
   },
   mounted() {

--- a/src/store/common/actions.ts
+++ b/src/store/common/actions.ts
@@ -12,7 +12,7 @@ import {
 import { IApplication, IApplicationScope, IApplicationType, ICredential, IToken, IUser, Status } from '@/models';
 import { getSiteOrigin } from '@/utils/site';
 import { getBaseUrlAuth, getBaseUrlHub, getInviterId, loginRedirect } from '@/utils';
-import { SURFACE_ANDROID, SURFACE_IOS } from '@/constants';
+import { isNative } from '@/utils/surface';
 
 export const resetAll = ({ commit }: ActionContext<IRootState, IRootState>) => {
   commit('resetToken');
@@ -214,7 +214,7 @@ export const createCredential = async ({ commit, state }: any): Promise<ICredent
 
 export const login = async ({ state, commit }: ActionContext<IRootState, IRootState>) => {
   const site = state?.site?.origin;
-  if (import.meta.env.VITE_SURFACE === SURFACE_IOS || import.meta.env.VITE_SURFACE === SURFACE_ANDROID) {
+  if (isNative()) {
     commit('setAuth', {
       flow: 'popup',
       visible: true
@@ -244,7 +244,7 @@ export const logout = async ({ dispatch, commit }: ActionContext<IRootState, IRo
   for (const name of getRegisteredLazyModules()) {
     await dispatch(`${name}/resetAll`);
   }
-  if (import.meta.env.VITE_SURFACE === SURFACE_IOS || import.meta.env.VITE_SURFACE === SURFACE_ANDROID) {
+  if (isNative()) {
     // On native platforms, show in-app login popup instead of navigating to
     // external auth URL (which would open Chrome and redirect to localhost)
     commit('setAuth', {

--- a/src/utils/baseUrl.ts
+++ b/src/utils/baseUrl.ts
@@ -1,4 +1,5 @@
 import { BASE_URL_AUTH, BASE_URL_PLATFORM, BASE_URL_HUB } from '@/constants';
+import { isNative } from './surface';
 
 /**
  * Get base url of platform app
@@ -21,7 +22,7 @@ export const getBaseUrlHub = () => {
   }
   // On native platforms (Capacitor), window.location.origin is http://localhost
   // which is not the real hub URL — use the hardcoded constant instead
-  if (import.meta.env.VITE_SURFACE === 'android' || import.meta.env.VITE_SURFACE === 'ios') {
+  if (isNative()) {
     return BASE_URL_HUB;
   }
   return window.location.origin || BASE_URL_HUB;

--- a/src/utils/site.ts
+++ b/src/utils/site.ts
@@ -1,6 +1,7 @@
 import { ISite } from '@/models';
 import { v4 as uuid } from 'uuid';
 import { BASE_HOST_HUB } from '@/constants';
+import { isNative } from './surface';
 
 /**
  * Resolve the origin we send to PlatformBackend's
@@ -35,7 +36,7 @@ export const getSiteOrigin = (site?: ISite) => {
   // On native shells (Capacitor on Android / iOS) window.location.host
   // is "localhost" and useless; fall back to studio's bare host so the
   // app boots against the canonical first-party Site row.
-  if (import.meta.env.VITE_SURFACE === 'android' || import.meta.env.VITE_SURFACE === 'ios') {
+  if (isNative()) {
     return STUDIO_HOST;
   }
   if (typeof window === 'undefined' || !window.location?.host) {

--- a/src/utils/surface.ts
+++ b/src/utils/surface.ts
@@ -1,3 +1,29 @@
+import { SURFACE_ANDROID, SURFACE_IOS, SURFACE_WEB } from '@/constants/surface';
+
+type Surface = typeof SURFACE_WEB | typeof SURFACE_ANDROID | typeof SURFACE_IOS;
+
+export function getSurface(): Surface {
+  const value = (import.meta.env.VITE_SURFACE as string | undefined) ?? SURFACE_WEB;
+  return value === SURFACE_IOS || value === SURFACE_ANDROID ? value : SURFACE_WEB;
+}
+
+export function isIOS(): boolean {
+  return getSurface() === SURFACE_IOS;
+}
+
+export function isAndroid(): boolean {
+  return getSurface() === SURFACE_ANDROID;
+}
+
+export function isNative(): boolean {
+  const surface = getSurface();
+  return surface === SURFACE_IOS || surface === SURFACE_ANDROID;
+}
+
+export function isWeb(): boolean {
+  return getSurface() === SURFACE_WEB;
+}
+
 export function isMobile(): boolean {
   const ua = navigator.userAgent.toLowerCase();
   return /iphone|ipad|ipod|android|windows phone/i.test(ua);


### PR DESCRIPTION
## Summary

The same Capacitor / native surface check —

```ts
import.meta.env.VITE_SURFACE === 'android' || import.meta.env.VITE_SURFACE === 'ios'
```

— was hand-rolled in **7 different places** across the codebase, in three slightly different forms (string literals, `SURFACE_*` constants, an `isNative` computed). Add a single utility and route every call site through it.

## What changed

### New helpers — `src/utils/surface.ts`

```ts
export function getSurface(): 'web' | 'android' | 'ios'
export function isIOS(): boolean
export function isAndroid(): boolean
export function isNative(): boolean   // ios || android
export function isWeb(): boolean
```

All backed by the existing `SURFACE_WEB` / `SURFACE_ANDROID` / `SURFACE_IOS` constants. The pre-existing `isMobile()` (UA sniff) is kept in the same file.

### Call sites refactored

| File | Before | After |
|---|---|---|
| [src/App.vue](src/App.vue#L72) (×2) | `VITE_SURFACE === 'android' \|\| === 'ios'` | `isNative()` |
| [src/utils/baseUrl.ts](src/utils/baseUrl.ts#L24) | same literal | `isNative()` |
| [src/utils/site.ts](src/utils/site.ts#L38) | same literal | `isNative()` |
| [src/store/common/actions.ts](src/store/common/actions.ts#L217) (×2) | `VITE_SURFACE === SURFACE_IOS \|\| === SURFACE_ANDROID` | `isNative()` |
| [src/components/common/AuthPanel.vue](src/components/common/AuthPanel.vue#L56) (×3) | string-literal variants | `isNativeSurface()` (aliased; component already has an `isNative` computed) |
| [src/components/user/Center.vue](src/components/user/Center.vue#L72) | inlined check | computed delegates to `isNativeSurface()` |

`grep -rn "VITE_SURFACE" src/` after this PR returns exactly **one** match — the central definition inside `src/utils/surface.ts`.

## Verification

- `npm run build` (web surface, `vue-tsc -b && vite build`) ✅ passes.
- `npm run lint:check` — the only failures are pre-existing on `main` in unrelated files (`pages/error/NotFound.vue`, `utils/kling/capabilities.ts`) and untouched by this PR.

## Risk

Zero behavior change. Every refactored predicate is logically identical to its previous form. The aliasing in `AuthPanel.vue` / `Center.vue` (`isNative as isNativeSurface`) is purely to avoid clashing with their existing `isNative` computed properties — those computeds now just delegate.
