### PR TITLE
fix(application): use fresh app ref when preserving user selection

### DIFF
--- a/change/@acedatacloud-nexior-f814c629-dfcb-4c54-a7e6-c32d0e751650.json
+++ b/change/@acedatacloud-nexior-f814c629-dfcb-4c54-a7e6-c32d0e751650.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(application): return fresh ref of preserved selection so balance reflects server truth (not a stale persisted snapshot)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/utils/application.ts
+++ b/src/utils/application.ts
@@ -70,9 +70,17 @@ export function getFinalApplication(
   currentApplication?: IApplication
 ): IApplication | undefined {
   console.debug('start to execute getFinalApplication', applications, currentApplication);
-  if (currentApplication && applications?.some((app) => app.id === currentApplication.id)) {
-    console.debug('current application is preserved (respect user selection)', currentApplication);
-    return currentApplication;
+  if (currentApplication) {
+    const fresh = applications?.find((app) => app.id === currentApplication.id);
+    if (fresh) {
+      // The previously-selected app still exists. Return the FRESH copy
+      // from the just-fetched list (not `currentApplication` itself), so
+      // mutable fields like `remaining_amount` / `used_amount` /
+      // `expired_at` reflect server truth instead of a stale persisted
+      // snapshot.
+      console.debug('current application is preserved (respect user selection)', fresh);
+      return fresh;
+    }
   }
   console.debug('get final application from applications', applications);
   // check if there is any application with 'Global' scope and 'Period' type, if yes, use it


### PR DESCRIPTION
## Symptom

After PR #617 (wallet pill shows balance), the top-right pill displayed a *small, old* number while the application picker dialog (clicked-open) showed the *current* number on the **same** highlighted card:

| location | value |
|---|---|
| pill | `167.4 Credits` |
| dialog → highlighted "General Balance" card (`d2fe0fa1-…`) | `4907.15 Credits` |

DB lookup against the user's 55 applications: **no app has `remaining_amount` between 160 and 180**. The 167.4 was purely a frontend stale snapshot.

## Root cause

PR #616 (`fix(application): preserve user's wallet selection across page reloads`) introduced this in [`getFinalApplication`](https://github.com/AceDataCloud/Nexior/blob/main/src/utils/application.ts):

```ts
if (currentApplication && applications.some((app) => app.id === currentApplication.id)) {
  return currentApplication;   // ← whatever vuex-persistedstate restored
}
```

`currentApplication` is the value persisted in `localStorage["vuex"]` under `chat.application` — which can be hours / days / months stale. Its mutable fields (`remaining_amount`, `used_amount`, `expired_at`) drift away from server truth on every API call. `applications` *is* the freshly-fetched list with current values.

Returning the stored ref kept stale fields alive forever. They were invisible before #617 because the toolbar widget was an icon-only round button — no field of the application object was ever rendered. The dialog *did* render fresh values, but the highlight match-by-id made it look consistent. The moment #617 added `{{ application.remaining_amount }}` to the pill, the drift became loud and obvious.

## Fix

Return the fresh entry from the just-fetched list (matched by id), instead of the persisted ref:

```ts
if (currentApplication) {
  const fresh = applications?.find((app) => app.id === currentApplication.id);
  if (fresh) return fresh;     // mutable fields reflect server truth
}
```

Net result: the *selection* (which app the user picked) is still preserved across reloads — that's PR #616's contract — but the snapshot of *that app's mutable state* always comes from the latest fetch. PR #617's pill, the dialog cards, and `Status.vue`'s highlight all read from the same fresh object.

## Verification

```
$ npx vue-tsc --noEmit --skipLibCheck    # clean
$ npx eslint src/utils/application.ts    # clean
```

## What's not changed

- The auto-pick fallback (Global Period > Global Usage > Individual Period > Individual Usage) — still runs only when the persisted selection no longer exists in the list.
- Backwards compat with users who have no persisted selection — `currentApplication === undefined` falls through to the fallback exactly as before.
- API contract — no new fields, no new endpoints.

## Behavioural matrix

| persisted `chat.application` | freshly-fetched list | before this PR | after this PR |
|---|---|---|---|
| `{id:X, remaining: 167}` (stale) | contains `{id:X, remaining: 4907}` | returns stale (167) | returns fresh (4907) ✓ |
| `{id:Y}` (deleted server-side) | doesn't contain `Y` | falls through to auto-pick | falls through to auto-pick (unchanged) |
| `undefined` | anything | auto-pick (unchanged) | auto-pick (unchanged) |
