### PR TITLE
refactor(webhook): centralize webhook.acedata.cloud callback URL behind getWebhookCallbackUrl()

### DIFF
--- a/change/@acedatacloud-nexior-ac3a9767-96e7-4876-a4f6-d8b88ec30e4a.json
+++ b/change/@acedatacloud-nexior-ac3a9767-96e7-4876-a4f6-d8b88ec30e4a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Centralize webhook callback URL behind getWebhookCallbackUrl(service) helper",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/producer/task/Preview.vue
+++ b/src/components/producer/task/Preview.vue
@@ -114,6 +114,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
+import { getWebhookCallbackUrl } from '@/constants';
 import { useFormatDuring } from '@/utils/number';
 import { IProducerAudio, IProducerTask } from '@/models';
 import { ElImage, ElIcon, ElTooltip, ElDropdown, ElDropdownMenu, ElDropdownItem, ElMessage } from 'element-plus';
@@ -124,7 +125,7 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { saveAs } from 'file-saver';
 import { producerOperator } from '@/operators';
 
-const CALLBACK_URL = 'https://webhook.acedata.cloud/producer';
+const CALLBACK_URL = getWebhookCallbackUrl('producer');
 
 export default defineComponent({
   name: 'TaskPreview',

--- a/src/components/suno/task/Preview.vue
+++ b/src/components/suno/task/Preview.vue
@@ -222,6 +222,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
+import { getWebhookCallbackUrl } from '@/constants';
 import { useFormatDuring } from '@/utils/number';
 import { ISunoAudio, ISunoTask } from '@/models';
 import {
@@ -244,7 +245,7 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { saveAs } from 'file-saver';
 import { sunoOperator } from '@/operators';
 
-const CALLBACK_URL = 'https://webhook.acedata.cloud/suno';
+const CALLBACK_URL = getWebhookCallbackUrl('suno');
 
 export default defineComponent({
   name: 'TaskPreview',

--- a/src/constants/endpoint.ts
+++ b/src/constants/endpoint.ts
@@ -9,3 +9,12 @@ export const BASE_HOST_PLATFORM = new URL(BASE_URL_PLATFORM).host;
 export const BASE_HOST_HUB = new URL(BASE_URL_HUB).host;
 export const BASE_HOST_AUTH = new URL(BASE_URL_AUTH).host;
 export const BASE_HOST_API = new URL(BASE_URL_API).host;
+
+export const BASE_URL_WEBHOOK = 'https://webhook.acedata.cloud';
+
+/**
+ * Build the upstream webhook callback URL for a given service alias.
+ * Used by every `<service>/Index.vue` to advertise where the upstream
+ * provider should POST task results.
+ */
+export const getWebhookCallbackUrl = (service: string): string => `${BASE_URL_WEBHOOK}/${service}`;

--- a/src/pages/flux/Index.vue
+++ b/src/pages/flux/Index.vue
@@ -17,12 +17,12 @@ import { fluxOperator } from '@/operators';
 import { instrumentGeneration } from '@/plugins/telemetry';
 import { IFluxGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
-import { ERROR_CODE_USED_UP } from '@/constants';
+import { ERROR_CODE_USED_UP, getWebhookCallbackUrl } from '@/constants';
 import RecentPanel from '@/components/flux/RecentPanel.vue';
 import { IFluxTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
 
-const CALLBACK_URL = 'https://webhook.acedata.cloud/flux';
+const CALLBACK_URL = getWebhookCallbackUrl('flux');
 
 interface IData {
   task: IFluxTask | undefined;

--- a/src/pages/hailuo/Index.vue
+++ b/src/pages/hailuo/Index.vue
@@ -17,12 +17,12 @@ import { hailuoOperator } from '@/operators';
 import { instrumentGeneration } from '@/plugins/telemetry';
 import { IHailuoGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
-import { ERROR_CODE_USED_UP } from '@/constants';
+import { ERROR_CODE_USED_UP, getWebhookCallbackUrl } from '@/constants';
 import RecentPanel from '@/components/hailuo/RecentPanel.vue';
 import { IHailuoTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
 
-const CALLBACK_URL = 'https://webhook.acedata.cloud/hailuo';
+const CALLBACK_URL = getWebhookCallbackUrl('hailuo');
 
 interface IData {
   task: IHailuoTask | undefined;

--- a/src/pages/headshots/Index.vue
+++ b/src/pages/headshots/Index.vue
@@ -28,13 +28,13 @@ import { applicationOperator, headshotsOperator } from '@/operators';
 import { instrumentGeneration } from '@/plugins/telemetry';
 import { IApplicationDetailResponse, IHeadshotsGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
-import { ERROR_CODE_DUPLICATION, ERROR_CODE_USED_UP } from '@/constants';
+import { ERROR_CODE_DUPLICATION, ERROR_CODE_USED_UP, getWebhookCallbackUrl } from '@/constants';
 import ApplicationStatus from '@/components/application/Status.vue';
 import RecentPanel from '@/components/headshots/RecentPanel.vue';
 import { IHeadshotsTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
 
-const CALLBACK_URL = 'https://webhook.acedata.cloud/headshots';
+const CALLBACK_URL = getWebhookCallbackUrl('headshots');
 
 interface IData {
   task: IHeadshotsTask | undefined;

--- a/src/pages/kling/Index.vue
+++ b/src/pages/kling/Index.vue
@@ -25,12 +25,12 @@ import { klingOperator } from '@/operators';
 import { instrumentGeneration } from '@/plugins/telemetry';
 import { IKlingGenerateRequest, IKlingMotionRequest, IKlingTaskType, Status } from '@/models';
 import { ElMessage } from 'element-plus';
-import { ERROR_CODE_USED_UP } from '@/constants';
+import { ERROR_CODE_USED_UP, getWebhookCallbackUrl } from '@/constants';
 import RecentPanel from '@/components/kling/RecentPanel.vue';
 import { IKlingTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
 
-const CALLBACK_URL = 'https://webhook.acedata.cloud/kling';
+const CALLBACK_URL = getWebhookCallbackUrl('kling');
 
 interface IData {
   task: IKlingTask | undefined;

--- a/src/pages/luma/Index.vue
+++ b/src/pages/luma/Index.vue
@@ -17,12 +17,12 @@ import { lumaOperator } from '@/operators';
 import { instrumentGeneration } from '@/plugins/telemetry';
 import { ILumaGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
-import { ERROR_CODE_USED_UP } from '@/constants';
+import { ERROR_CODE_USED_UP, getWebhookCallbackUrl } from '@/constants';
 import RecentPanel from '@/components/luma/RecentPanel.vue';
 import { ILumaTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
 
-const CALLBACK_URL = 'https://webhook.acedata.cloud/luma';
+const CALLBACK_URL = getWebhookCallbackUrl('luma');
 
 interface IData {
   task: ILumaTask | undefined;

--- a/src/pages/midjourney/Index.vue
+++ b/src/pages/midjourney/Index.vue
@@ -31,7 +31,8 @@ import {
   MIDJOURNEY_DEFAULT_STYLIZE,
   MIDJOURNEY_DEFAULT_WIRED,
   MIDJOURNEY_DEFAULT_MODE,
-  MIDJOURNEY_DEFAULT_QUALITY
+  MIDJOURNEY_DEFAULT_QUALITY,
+  getWebhookCallbackUrl
 } from '@/constants';
 import { loadPreviousPage } from '@/utils/pagination';
 
@@ -42,7 +43,7 @@ interface IData {
   fetchingTasks: boolean;
 }
 
-const CALLBACK_URL = 'https://webhook.acedata.cloud/midjourney';
+const CALLBACK_URL = getWebhookCallbackUrl('midjourney');
 
 export default defineComponent({
   name: 'MidjourneyIndex',

--- a/src/pages/nanobanana/Index.vue
+++ b/src/pages/nanobanana/Index.vue
@@ -17,12 +17,12 @@ import { nanobananaOperator } from '@/operators';
 import { instrumentGeneration } from '@/plugins/telemetry';
 import { INanobananaGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
-import { ERROR_CODE_USED_UP, NANOBANANA_DEFAULT_RESOLUTION, NANOBANANA_MODEL_NANO_BANANA_PRO } from '@/constants';
+import { ERROR_CODE_USED_UP, NANOBANANA_DEFAULT_RESOLUTION, NANOBANANA_MODEL_NANO_BANANA_PRO, getWebhookCallbackUrl } from '@/constants';
 import RecentPanel from '@/components/nanobanana/RecentPanel.vue';
 import { INanobananaTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
 
-const CALLBACK_URL = 'https://webhook.acedata.cloud/nanobanana';
+const CALLBACK_URL = getWebhookCallbackUrl('nanobanana');
 
 interface IData {
   task: INanobananaTask | undefined;

--- a/src/pages/openaiimage/Index.vue
+++ b/src/pages/openaiimage/Index.vue
@@ -17,12 +17,12 @@ import { openaiimageOperator } from '@/operators';
 import { instrumentGeneration } from '@/plugins/telemetry';
 import { IOpenAIImageEditRequest, IOpenAIImageGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
-import { ERROR_CODE_USED_UP } from '@/constants';
+import { ERROR_CODE_USED_UP, getWebhookCallbackUrl } from '@/constants';
 import RecentPanel from '@/components/openaiimage/RecentPanel.vue';
 import { loadPreviousPage } from '@/utils/pagination';
 import { IOpenAIImageTask } from '@/models';
 
-const CALLBACK_URL = 'https://webhook.acedata.cloud/openaiimage';
+const CALLBACK_URL = getWebhookCallbackUrl('openaiimage');
 
 interface IData {
   task: IOpenAIImageTask | undefined;

--- a/src/pages/pika/Index.vue
+++ b/src/pages/pika/Index.vue
@@ -17,12 +17,12 @@ import { applicationOperator, pikaOperator } from '@/operators';
 import { instrumentGeneration } from '@/plugins/telemetry';
 import { IApplicationDetailResponse, IPikaGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
-import { ERROR_CODE_DUPLICATION, ERROR_CODE_USED_UP } from '@/constants';
+import { ERROR_CODE_DUPLICATION, ERROR_CODE_USED_UP, getWebhookCallbackUrl } from '@/constants';
 import RecentPanel from '@/components/pika/RecentPanel.vue';
 import { IPikaTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
 
-const CALLBACK_URL = 'https://webhook.acedata.cloud/pika';
+const CALLBACK_URL = getWebhookCallbackUrl('pika');
 
 interface IData {
   task: IPikaTask | undefined;

--- a/src/pages/pixverse/Index.vue
+++ b/src/pages/pixverse/Index.vue
@@ -17,12 +17,12 @@ import { pixverseOperator } from '@/operators';
 import { instrumentGeneration } from '@/plugins/telemetry';
 import { IPixverseGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
-import { ERROR_CODE_USED_UP } from '@/constants';
+import { ERROR_CODE_USED_UP, getWebhookCallbackUrl } from '@/constants';
 import RecentPanel from '@/components/pixverse/RecentPanel.vue';
 import { IPixverseTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
 
-const CALLBACK_URL = 'https://webhook.acedata.cloud/pixverse';
+const CALLBACK_URL = getWebhookCallbackUrl('pixverse');
 
 interface IData {
   task: IPixverseTask | undefined;

--- a/src/pages/producer/Index.vue
+++ b/src/pages/producer/Index.vue
@@ -20,13 +20,13 @@ import { instrumentGeneration } from '@/plugins/telemetry';
 import { IApplicationDetailResponse, IProducerAudioRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
 import { IProducerTask } from '@/models';
-import { ERROR_CODE_DUPLICATION } from '@/constants';
+import { ERROR_CODE_DUPLICATION, getWebhookCallbackUrl } from '@/constants';
 import ConfigPanel from '@/components/producer/ConfigPanel.vue';
 import RecentPanel from '@/components/producer/RecentPanel.vue';
 import PreviewPanel from '@/components/producer/PreviewPanel.vue';
 import { loadPreviousPage } from '@/utils/pagination';
 
-const CALLBACK_URL = 'https://webhook.acedata.cloud/producer';
+const CALLBACK_URL = getWebhookCallbackUrl('producer');
 
 interface IData {
   task: IProducerTask | undefined;

--- a/src/pages/qrart/Index.vue
+++ b/src/pages/qrart/Index.vue
@@ -27,13 +27,13 @@ import { applicationOperator, qrartOperator } from '@/operators';
 import { instrumentGeneration } from '@/plugins/telemetry';
 import { IApplicationDetailResponse, IQrartGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
-import { ERROR_CODE_DUPLICATION, ERROR_CODE_USED_UP } from '@/constants';
+import { ERROR_CODE_DUPLICATION, ERROR_CODE_USED_UP, getWebhookCallbackUrl } from '@/constants';
 import ApplicationStatus from '@/components/application/Status.vue';
 import RecentPanel from '@/components/qrart/RecentPanel.vue';
 import { IQrartTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
 
-const CALLBACK_URL = 'https://webhook.acedata.cloud/qrart';
+const CALLBACK_URL = getWebhookCallbackUrl('qrart');
 
 interface IData {
   task: IQrartTask | undefined;

--- a/src/pages/seedance/Index.vue
+++ b/src/pages/seedance/Index.vue
@@ -18,11 +18,11 @@ import { seedanceOperator } from '@/operators';
 import { instrumentGeneration } from '@/plugins/telemetry';
 import { ISeedanceGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
-import { ERROR_CODE_USED_UP } from '@/constants';
+import { ERROR_CODE_USED_UP, getWebhookCallbackUrl } from '@/constants';
 import { ISeedanceTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
 
-const CALLBACK_URL = 'https://webhook.acedata.cloud/seedance';
+const CALLBACK_URL = getWebhookCallbackUrl('seedance');
 
 interface IData {
   task: ISeedanceTask | undefined;

--- a/src/pages/seedream/Index.vue
+++ b/src/pages/seedream/Index.vue
@@ -17,12 +17,12 @@ import { seedreamOperator } from '@/operators';
 import { instrumentGeneration } from '@/plugins/telemetry';
 import { ISeedreamGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
-import { ERROR_CODE_USED_UP } from '@/constants';
+import { ERROR_CODE_USED_UP, getWebhookCallbackUrl } from '@/constants';
 import RecentPanel from '@/components/seedream/RecentPanel.vue';
 import { loadPreviousPage } from '@/utils/pagination';
 import { ISeedreamTask } from '@/models';
 
-const CALLBACK_URL = 'https://webhook.acedata.cloud/seedream';
+const CALLBACK_URL = getWebhookCallbackUrl('seedream');
 
 interface IData {
   task: ISeedreamTask | undefined;

--- a/src/pages/sora/Index.vue
+++ b/src/pages/sora/Index.vue
@@ -17,12 +17,12 @@ import { soraOperator } from '@/operators';
 import { instrumentGeneration } from '@/plugins/telemetry';
 import { ISoraGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
-import { ERROR_CODE_USED_UP } from '@/constants';
+import { ERROR_CODE_USED_UP, getWebhookCallbackUrl } from '@/constants';
 import RecentPanel from '@/components/sora/RecentPanel.vue';
 import { ISoraTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
 
-const CALLBACK_URL = 'https://webhook.acedata.cloud/sora';
+const CALLBACK_URL = getWebhookCallbackUrl('sora');
 
 interface IData {
   task: ISoraTask | undefined;

--- a/src/pages/suno/Index.vue
+++ b/src/pages/suno/Index.vue
@@ -19,14 +19,14 @@ import { applicationOperator, sunoOperator } from '@/operators';
 import { IApplicationDetailResponse, ISunoAudioRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
 import { ISunoTask } from '@/models';
-import { ERROR_CODE_DUPLICATION } from '@/constants';
+import { ERROR_CODE_DUPLICATION, getWebhookCallbackUrl } from '@/constants';
 import { instrumentGeneration } from '@/plugins/telemetry';
 import ConfigPanel from '@/components/suno/ConfigPanel.vue';
 import RecentPanel from '@/components/suno/RecentPanel.vue';
 import PreviewPanel from '@/components/suno/PreviewPanel.vue';
 import { loadPreviousPage } from '@/utils/pagination';
 
-const CALLBACK_URL = 'https://webhook.acedata.cloud/suno';
+const CALLBACK_URL = getWebhookCallbackUrl('suno');
 
 interface IData {
   task: ISunoTask | undefined;

--- a/src/pages/veo/Index.vue
+++ b/src/pages/veo/Index.vue
@@ -17,12 +17,12 @@ import { veoOperator } from '@/operators';
 import { instrumentGeneration } from '@/plugins/telemetry';
 import { IVeoGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
-import { ERROR_CODE_USED_UP } from '@/constants';
+import { ERROR_CODE_USED_UP, getWebhookCallbackUrl } from '@/constants';
 import RecentPanel from '@/components/veo/RecentPanel.vue';
 import { IVeoTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
 
-const CALLBACK_URL = 'https://webhook.acedata.cloud/veo';
+const CALLBACK_URL = getWebhookCallbackUrl('veo');
 
 interface IData {
   task: IVeoTask | undefined;

--- a/src/pages/wan/Index.vue
+++ b/src/pages/wan/Index.vue
@@ -17,12 +17,12 @@ import { wanOperator } from '@/operators';
 import { instrumentGeneration } from '@/plugins/telemetry';
 import { IWanGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
-import { ERROR_CODE_USED_UP } from '@/constants';
+import { ERROR_CODE_USED_UP, getWebhookCallbackUrl } from '@/constants';
 import RecentPanel from '@/components/wan/RecentPanel.vue';
 import { IWanTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
 
-const CALLBACK_URL = 'https://webhook.acedata.cloud/wan';
+const CALLBACK_URL = getWebhookCallbackUrl('wan');
 
 interface IData {
   task: IWanTask | undefined;


### PR DESCRIPTION
## Summary

Stop hard-coding `https://webhook.acedata.cloud/<service>` in 20 separate files. Move it to a single helper in `src/constants/endpoint.ts`.

## Why

```bash
$ grep -rn "webhook.acedata.cloud" src/ | wc -l
20
```

…each declared as its own top-level `const CALLBACK_URL = 'https://webhook.acedata.cloud/<service>';`. If we ever need to migrate to a different webhook host (regional, staging, blue/green), that's 20 atomic edits with no compile-time guarantee that any are missed.

## Changes

### `src/constants/endpoint.ts`

```ts
export const BASE_URL_WEBHOOK = 'https://webhook.acedata.cloud';
export const getWebhookCallbackUrl = (service: string): string =>
  `${BASE_URL_WEBHOOK}/${service}`;
```

### Each call site

```diff
+ import { getWebhookCallbackUrl } from '@/constants';
- const CALLBACK_URL = 'https://webhook.acedata.cloud/luma';
+ const CALLBACK_URL = getWebhookCallbackUrl('luma');
```

20 files touched: `pages/{luma,suno,seedance,seedream,veo,sora,kling,hailuo,wan,flux,nanobanana,pika,pixverse,qrart,openaiimage,headshots,midjourney,producer}/Index.vue` + `components/{suno,producer}/task/Preview.vue`.

The local `CALLBACK_URL` identifier is preserved deliberately so every existing `callback_url: CALLBACK_URL` reference continues to compile — keeps the diff minimal and the runtime payload identical.

## Verification

- `grep -rn "webhook.acedata.cloud" src/` after this PR returns exactly **one** match — the central definition in `endpoint.ts`.
- `npm run build` (web surface) ✅ passes.

## Risk

Zero behavior change. Each `getWebhookCallbackUrl('luma')` evaluates to the exact same string the old `'https://webhook.acedata.cloud/luma'` literal used to produce.
