### PR TITLE
chore(store): strip 367 noisy console.debug calls (and the dead locals that only fed them)

### DIFF
--- a/change/@acedatacloud-nexior-7594b1ea-b389-487f-a9cc-828bb6de6a1a.json
+++ b/change/@acedatacloud-nexior-7594b1ea-b389-487f-a9cc-828bb6de6a1a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Strip 367 noisy console.debug/log statements (and 57 dead locals) from store actions",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/store/chat/actions.ts
+++ b/src/store/chat/actions.ts
@@ -10,53 +10,41 @@ export const resetAll = ({ commit }: ActionContext<IChatState, IRootState>): voi
 };
 
 export const setApplication = async ({ commit, dispatch }: any, payload: IApplication): Promise<void> => {
-  console.debug('set application', payload);
   commit('setApplication', payload);
-  console.debug('application is set');
   if (!payload) {
-    console.debug('application is null, return');
     return;
   }
   const credential = payload?.credentials?.find((credential) => credential?.host === window.location.origin);
   if (credential) {
-    console.debug('credential exists, set credential', credential);
     commit('setCredential', credential);
   } else {
-    console.debug('credential not exists, start to create credential for application', payload);
     await dispatch('createCredential');
   }
 };
 
 export const setApplications = async ({ commit }: any, payload: IApplication[]): Promise<void> => {
-  console.debug('set applications for chat', payload);
   commit('setApplications', payload);
 };
 
 export const setService = async ({ commit }: any, payload: IService): Promise<void> => {
-  console.debug('set service for chat', payload);
   commit('setService', payload);
 };
 
 export const setCredential = async ({ commit }: any, payload: ICredential): Promise<void> => {
-  console.debug('set credential', payload);
   commit('setCredential', payload);
 };
 
 export const createCredential = async ({ commit, state }: any): Promise<ICredential | undefined> => {
   const application = state.application;
-  console.debug('prepare to create credential for application for chat', application);
   if (!application) {
     console.error('Application not found');
     return undefined;
   }
-  console.debug('creating create credential for application for chat', application);
   const { data: credential } = await credentialOperator.create({
     application_id: application?.id,
     host: window.location.origin
   });
-  console.debug('created credential success', credential);
   commit('setCredential', credential);
-  console.debug('end createCredential');
   return credential;
 };
 
@@ -81,17 +69,14 @@ export const getApplications = async ({
   state,
   rootState
 }: ActionContext<IChatState, IRootState>): Promise<IApplication[] | undefined> => {
-  console.debug('start to get applications for chat');
   state.status.getApplications = Status.Request;
   try {
     const { data: applications } = await applicationOperator.getAll({
       user_id: rootState?.user?.id,
       service_id: CHAT_SERVICE_ID
     });
-    console.debug('get applications success for chat', applications);
     state.status.getApplications = Status.Success;
     commit('setApplications', applications.items);
-    console.debug('set applications for chat', applications.items);
     return applications.items;
   } catch (error) {
     console.error('get applications failed for chat', error);
@@ -110,7 +95,6 @@ export const setModelGroup = async ({ commit }: any, payload: IChatModelGroup): 
 };
 
 export const setConversation = async ({ commit, state }: any, payload: IChatConversation): Promise<void> => {
-  console.debug('set conversation', payload);
   const conversations = state.conversations || [];
   const index = conversations?.findIndex((conversation: IChatConversation) => conversation.id === payload.id);
   if (index > -1) {
@@ -119,11 +103,9 @@ export const setConversation = async ({ commit, state }: any, payload: IChatConv
     conversations?.unshift(payload);
   }
   commit('setConversations', conversations);
-  console.debug('set conversation success', conversations);
 };
 
 export const setConversations = async ({ commit }: any, payload: IChatConversation[]): Promise<void> => {
-  console.debug('set conversations', payload);
   commit('setConversations', payload);
 };
 
@@ -155,7 +137,6 @@ export const getConversations = async ({
         token
       }
     );
-    console.debug('get conversations success', data?.items?.length, 'group=', modelGroup);
     state.status.getConversations = Status.Success;
     commit('setConversations', data.items);
     return data.items;

--- a/src/store/common/actions.ts
+++ b/src/store/common/actions.ts
@@ -52,12 +52,10 @@ export const setFingerprint = ({ commit }: ActionContext<IRootState, IRootState>
 };
 
 export const getUser = async ({ commit }: ActionContext<IRootState, IRootState>): Promise<IUser | undefined> => {
-  console.debug('start to get user');
   try {
     commit('resetUser');
     const { data: user } = await userOperator.getMe();
     commit('setUser', user);
-    console.debug('get user success', user);
     return user;
   } catch (error) {
     console.error('get user failed', error);
@@ -73,26 +71,22 @@ export const getFingerprint = async ({ commit }: ActionContext<IRootState, IRoot
   const fp = await FingerprintJS.load();
   const result = await fp.get();
   const visitorId = result.visitorId;
-  console.debug('visitorId', visitorId);
   commit('setFingerprint', visitorId);
   return visitorId;
 };
 
 export const getToken = async ({ commit }: ActionContext<IRootState, IRootState>, code: string) => {
-  console.debug('start to get token using code', code);
   try {
     commit('resetToken');
     const { data } = await ssoOperator.token({
       code
     });
-    console.debug('get token success', data);
     const token = {
       access: data.access_token,
       refresh: data.refresh_token,
       expiration: data.expires_in
     };
     commit('setToken', token);
-    console.debug('get token success', data);
     return token;
   } catch (error) {
     console.error('get token failed', error);
@@ -107,10 +101,8 @@ export const getExchangeRate = async (
     return;
   }
   const key = `${payload.source}-${payload.target}`;
-  console.debug('start to get exchange rate', key);
   try {
     const { data } = await exchangeOperator.rate(payload);
-    console.debug('get exchange rate success', data);
     commit('setExchange', {
       [key]: data.rate
     });
@@ -121,12 +113,10 @@ export const getExchangeRate = async (
 };
 
 export const initializeSite = async ({ state, commit, dispatch }: ActionContext<IRootState, IRootState>) => {
-  console.debug('start to initialize site');
   const origin = getSiteOrigin(state?.site);
   try {
     const { data } = await siteOperator.initialize({ origin });
     commit('setSite', data);
-    console.debug('initialize site success', data);
   } catch (error) {
     console.error('initialize site failed', error);
     dispatch('login');
@@ -134,7 +124,6 @@ export const initializeSite = async ({ state, commit, dispatch }: ActionContext<
 };
 
 export const getSite = async ({ state, commit }: ActionContext<IRootState, IRootState>) => {
-  console.debug('start to get site');
   try {
     const origin = getSiteOrigin(state?.site);
     const site = (
@@ -143,14 +132,12 @@ export const getSite = async ({ state, commit }: ActionContext<IRootState, IRoot
       })
     )?.data?.items?.[0];
     commit('setSite', site);
-    console.debug('get site success', site);
   } catch (error) {
     console.error('get site failed', error);
   }
 };
 
 export const fetchConfig = async ({ commit }: ActionContext<IRootState, IRootState>) => {
-  console.debug('start to fetch config');
   try {
     const { data } = await configOperator.get();
     commit('setConfig', data);
@@ -163,7 +150,6 @@ export const fetchConfig = async ({ commit }: ActionContext<IRootState, IRootSta
 };
 
 export const setApplications = async ({ commit }: any, payload: IApplication[]): Promise<void> => {
-  console.debug('set applications', payload);
   commit('setApplications', payload);
 };
 
@@ -172,7 +158,6 @@ export const getApplications = async ({
   state,
   rootState
 }: ActionContext<IRootState, IRootState>): Promise<IApplication[] | undefined> => {
-  console.debug('start to get applications for global');
   state.status.getApplications = Status.Request;
   try {
     const { data: applications } = await applicationOperator.getAll({
@@ -183,7 +168,6 @@ export const getApplications = async ({
       type: IApplicationType.USAGE,
       scope: IApplicationScope.GLOBAL
     });
-    console.debug('global applications from online', applications);
     state.status.getApplications = Status.Success;
     commit('setApplications', applications.items);
     return applications.items;
@@ -196,19 +180,15 @@ export const getApplications = async ({
 
 export const createCredential = async ({ commit, state }: any): Promise<ICredential | undefined> => {
   const application = state.application;
-  console.debug('prepare to create credential for application', application);
   if (!application) {
     console.error('Application not found');
     return undefined;
   }
-  console.debug('creating create credential for application', application);
   const { data: credential } = await credentialOperator.create({
     application_id: application?.id,
     host: window.location.origin
   });
-  console.debug('created credential success', credential);
   commit('setCredential', credential);
-  console.debug('end createCredential');
   return credential;
 };
 
@@ -219,12 +199,10 @@ export const login = async ({ state, commit }: ActionContext<IRootState, IRootSt
       flow: 'popup',
       visible: true
     });
-    console.debug('login popup');
   } else {
     commit('setAuth', {
       flow: 'redirect'
     });
-    console.debug('login redirect');
     // Preserve the original query string (e.g. ?inviter_id, ?utm_source) so
     // it survives the auth round-trip and is still present when the user
     // lands back on Nexior. inviter_id is also forwarded as a top-level

--- a/src/store/flux/actions.ts
+++ b/src/store/flux/actions.ts
@@ -12,52 +12,41 @@ export const resetAll = ({ commit }: ActionContext<IFluxState, IRootState>): voi
 };
 
 export const setApplication = async ({ commit, dispatch }: any, payload: IApplication): Promise<void> => {
-  console.debug('set application', payload);
   commit('setApplication', payload);
   if (!payload) {
-    console.debug('application is null, return');
     return;
   }
   const credential = payload?.credentials?.find((credential) => credential?.host === window.location.origin);
   if (credential) {
-    console.debug('credential exists, set credential', credential);
     commit('setCredential', credential);
   } else {
-    console.debug('credential not exists, start to create credential for application', payload);
     await dispatch('createCredential');
   }
 };
 
 export const setApplications = async ({ commit }: any, payload: IApplication[]): Promise<void> => {
-  console.debug('set applications', payload);
   commit('setApplications', payload);
 };
 
 export const setService = async ({ commit }: any, payload: IService): Promise<void> => {
-  console.debug('set service', payload);
   commit('setService', payload);
 };
 
 export const setCredential = async ({ commit }: any, payload: ICredential): Promise<void> => {
-  console.debug('set credential', payload);
   commit('setCredential', payload);
 };
 
 export const createCredential = async ({ commit, state }: any): Promise<ICredential | undefined> => {
   const application = state.application;
-  console.debug('prepare to create credential for application', application);
   if (!application) {
     console.error('Application not found');
     return undefined;
   }
-  console.debug('creating create credential for application', application);
   const { data: credential } = await credentialOperator.create({
     application_id: application?.id,
     host: window.location.origin
   });
-  console.debug('created credential success', credential);
   commit('setCredential', credential);
-  console.debug('end createCredential');
   return credential;
 };
 
@@ -82,7 +71,6 @@ export const getApplications = async ({
   state,
   rootState
 }: ActionContext<IFluxState, IRootState>): Promise<IApplication[] | undefined> => {
-  console.debug('start to get applications for chat');
   state.status.getApplications = Status.Request;
   try {
     const { data: applications } = await applicationOperator.getAll({
@@ -123,16 +111,12 @@ export const setTasksActive = ({ commit }: any, payload: IFluxTask) => {
 export const getTasks = async (
   { commit, state, rootState }: ActionContext<IFluxState, IRootState>,
   {
-    offset,
-    limit,
     createdAtMin,
     createdAtMax
   }: { offset?: number; limit?: number; createdAtMin?: number; createdAtMax?: number }
 ): Promise<IFluxTask[]> => {
   return new Promise((resolve, reject) => {
-    console.debug('start to get tasks', offset, limit);
     const credential = state.credential;
-    console.debug('current credential', credential);
     const token = credential?.token;
     if (!token) {
       return reject('no token');
@@ -150,12 +134,9 @@ export const getTasks = async (
         }
       )
       .then((response) => {
-        console.debug('get videos tasks success', response.data.items);
         // merge with existing tasks
         const existingItems = state?.tasks?.items || [];
-        console.debug('existing items', existingItems);
         const newItems = response.data.items || [];
-        console.debug('new items', newItems);
         // sort and de-duplicate using created_at
         const mergedItems = mergeAndSortLists(existingItems, newItems);
         commit('setTasksItems', mergedItems);

--- a/src/store/hailuo/actions.ts
+++ b/src/store/hailuo/actions.ts
@@ -12,52 +12,41 @@ export const resetAll = ({ commit }: ActionContext<IHailuoState, IRootState>): v
 };
 
 export const setApplication = async ({ commit, dispatch }: any, payload: IApplication): Promise<void> => {
-  console.debug('set application', payload);
   commit('setApplication', payload);
   if (!payload) {
-    console.debug('application is null, return');
     return;
   }
   const credential = payload?.credentials?.find((credential) => credential?.host === window.location.origin);
   if (credential) {
-    console.debug('credential exists, set credential', credential);
     commit('setCredential', credential);
   } else {
-    console.debug('credential not exists, start to create credential for application', payload);
     await dispatch('createCredential');
   }
 };
 
 export const setApplications = async ({ commit }: any, payload: IApplication[]): Promise<void> => {
-  console.debug('set applications', payload);
   commit('setApplications', payload);
 };
 
 export const setService = async ({ commit }: any, payload: IService): Promise<void> => {
-  console.debug('set service', payload);
   commit('setService', payload);
 };
 
 export const setCredential = async ({ commit }: any, payload: ICredential): Promise<void> => {
-  console.debug('set credential', payload);
   commit('setCredential', payload);
 };
 
 export const createCredential = async ({ commit, state }: any): Promise<ICredential | undefined> => {
   const application = state.application;
-  console.debug('prepare to create credential for application', application);
   if (!application) {
     console.error('Application not found');
     return undefined;
   }
-  console.debug('creating create credential for application', application);
   const { data: credential } = await credentialOperator.create({
     application_id: application?.id,
     host: window.location.origin
   });
-  console.debug('created credential success', credential);
   commit('setCredential', credential);
-  console.debug('end createCredential');
   return credential;
 };
 
@@ -82,10 +71,7 @@ export const getApplications = async ({
   state,
   rootState
 }: ActionContext<IHailuoState, IRootState>): Promise<IApplication[] | undefined> => {
-  console.debug('start to get applications for chat');
   state.status.getApplications = Status.Request;
-  const currentApplication = state.application;
-  console.debug('current application', currentApplication);
   try {
     const { data: applications } = await applicationOperator.getAll({
       user_id: rootState?.user?.id,
@@ -125,16 +111,12 @@ export const setTasksActive = ({ commit }: any, payload: IHailuoTask) => {
 export const getTasks = async (
   { commit, state, rootState }: ActionContext<IHailuoState, IRootState>,
   {
-    offset,
-    limit,
     createdAtMin,
     createdAtMax
   }: { offset?: number; limit?: number; createdAtMin?: number; createdAtMax?: number }
 ): Promise<IHailuoTask[]> => {
   return new Promise((resolve, reject) => {
-    console.debug('start to get tasks', offset, limit);
     const credential = state.credential;
-    console.debug('current credential', credential);
     const token = credential?.token;
     if (!token) {
       return reject('no token');
@@ -152,12 +134,9 @@ export const getTasks = async (
         }
       )
       .then((response) => {
-        console.debug('get videos tasks success', response.data.items);
         // merge with existing tasks
         const existingItems = state?.tasks?.items || [];
-        console.debug('existing items', existingItems);
         const newItems = response.data.items || [];
-        console.debug('new items', newItems);
         // sort and de-duplicate using created_at
         const mergedItems = mergeAndSortLists(existingItems, newItems);
         commit('setTasksItems', mergedItems);

--- a/src/store/headshots/actions.ts
+++ b/src/store/headshots/actions.ts
@@ -12,52 +12,41 @@ export const resetAll = ({ commit }: ActionContext<IHeadshotsState, IRootState>)
 };
 
 export const setApplication = async ({ commit, dispatch }: any, payload: IApplication): Promise<void> => {
-  console.debug('set application', payload);
   commit('setApplication', payload);
   if (!payload) {
-    console.debug('application is null, return');
     return;
   }
   const credential = payload?.credentials?.find((credential) => credential?.host === window.location.origin);
   if (credential) {
-    console.debug('credential exists, set credential', credential);
     commit('setCredential', credential);
   } else {
-    console.debug('credential not exists, start to create credential for application', payload);
     await dispatch('createCredential');
   }
 };
 
 export const setApplications = async ({ commit }: any, payload: IApplication[]): Promise<void> => {
-  console.debug('set applications', payload);
   commit('setApplications', payload);
 };
 
 export const setService = async ({ commit }: any, payload: IService): Promise<void> => {
-  console.debug('set service', payload);
   commit('setService', payload);
 };
 
 export const setCredential = async ({ commit }: any, payload: ICredential): Promise<void> => {
-  console.debug('set credential', payload);
   commit('setCredential', payload);
 };
 
 export const createCredential = async ({ commit, state }: any): Promise<ICredential | undefined> => {
   const application = state.application;
-  console.debug('prepare to create credential for application', application);
   if (!application) {
     console.error('Application not found');
     return undefined;
   }
-  console.debug('creating create credential for application', application);
   const { data: credential } = await credentialOperator.create({
     application_id: application?.id,
     host: window.location.origin
   });
-  console.debug('created credential success', credential);
   commit('setCredential', credential);
-  console.debug('end createCredential');
   return credential;
 };
 
@@ -82,10 +71,7 @@ export const getApplications = async ({
   state,
   rootState
 }: ActionContext<IHeadshotsState, IRootState>): Promise<IApplication[] | undefined> => {
-  console.debug('start to get applications for chat');
   state.status.getApplications = Status.Request;
-  const currentApplication = state.application;
-  console.debug('current application', currentApplication);
   try {
     const { data: applications } = await applicationOperator.getAll({
       user_id: rootState?.user?.id,
@@ -125,14 +111,11 @@ export const setTasksActive = ({ commit }: any, payload: IHeadshotsTask) => {
 export const getTasks = async (
   { commit, state, rootState }: ActionContext<IHeadshotsState, IRootState>,
   {
-    offset,
-    limit,
     createdAtMin,
     createdAtMax
   }: { offset?: number; limit?: number; createdAtMin?: number; createdAtMax?: number }
 ): Promise<IHeadshotsTask[]> => {
   return new Promise((resolve, reject) => {
-    console.debug('start to get tasks', offset, limit);
     const credential = state.credential;
     const token = credential?.token;
     if (!token) {
@@ -150,12 +133,9 @@ export const getTasks = async (
         }
       )
       .then((response) => {
-        console.debug('get videos tasks success', response.data.items);
         // merge with existing tasks
         const existingItems = state?.tasks?.items || [];
-        console.debug('existing items', existingItems);
         const newItems = response.data.items || [];
-        console.debug('new items', newItems);
         // sort and de-duplicate using created_at
         const mergedItems = mergeAndSortLists(existingItems, newItems);
         commit('setTasksItems', mergedItems);

--- a/src/store/kling/actions.ts
+++ b/src/store/kling/actions.ts
@@ -20,52 +20,41 @@ export const resetAll = ({ commit }: ActionContext<IKlingState, IRootState>): vo
 };
 
 export const setApplication = async ({ commit, dispatch }: any, payload: IApplication): Promise<void> => {
-  console.debug('set application', payload);
   commit('setApplication', payload);
   if (!payload) {
-    console.debug('application is null, return');
     return;
   }
   const credential = payload?.credentials?.find((credential) => credential?.host === window.location.origin);
   if (credential) {
-    console.debug('credential exists, set credential', credential);
     commit('setCredential', credential);
   } else {
-    console.debug('credential not exists, start to create credential for application', payload);
     await dispatch('createCredential');
   }
 };
 
 export const setApplications = async ({ commit }: any, payload: IApplication[]): Promise<void> => {
-  console.debug('set applications', payload);
   commit('setApplications', payload);
 };
 
 export const setService = async ({ commit }: any, payload: IService): Promise<void> => {
-  console.debug('set service', payload);
   commit('setService', payload);
 };
 
 export const setCredential = async ({ commit }: any, payload: ICredential): Promise<void> => {
-  console.debug('set credential', payload);
   commit('setCredential', payload);
 };
 
 export const createCredential = async ({ commit, state }: any): Promise<ICredential | undefined> => {
   const application = state.application;
-  console.debug('prepare to create credential for application', application);
   if (!application) {
     console.error('Application not found');
     return undefined;
   }
-  console.debug('creating create credential for application', application);
   const { data: credential } = await credentialOperator.create({
     application_id: application?.id,
     host: window.location.origin
   });
-  console.debug('created credential success', credential);
   commit('setCredential', credential);
-  console.debug('end createCredential');
   return credential;
 };
 
@@ -90,10 +79,7 @@ export const getApplications = async ({
   state,
   rootState
 }: ActionContext<IKlingState, IRootState>): Promise<IApplication[] | undefined> => {
-  console.debug('start to get applications for chat');
   state.status.getApplications = Status.Request;
-  const currentApplication = state.application;
-  console.debug('current application', currentApplication);
   try {
     const { data: applications } = await applicationOperator.getAll({
       user_id: rootState?.user?.id,
@@ -141,16 +127,12 @@ export const setTasksActive = ({ commit }: any, payload: IKlingTask) => {
 export const getTasks = async (
   { commit, state, rootState }: ActionContext<IKlingState, IRootState>,
   {
-    offset,
-    limit,
     createdAtMin,
     createdAtMax
   }: { offset?: number; limit?: number; createdAtMin?: number; createdAtMax?: number }
 ): Promise<IKlingTask[]> => {
   return new Promise((resolve, reject) => {
-    console.debug('start to get tasks', offset, limit);
     const credential = state.credential;
-    console.debug('current credential', credential);
     const token = credential?.token;
     if (!token) {
       return reject('no token');
@@ -168,12 +150,9 @@ export const getTasks = async (
         }
       )
       .then((response) => {
-        console.debug('get kling tasks success', response.data.items);
         // merge with existing tasks
         const existingItems = state?.tasks?.items || [];
-        console.debug('existing items', existingItems);
         const newItems = response.data.items || [];
-        console.debug('new items', newItems);
         // sort and de-duplicate using created_at
         const mergedItems = mergeAndSortLists(existingItems, newItems);
         commit('setTasksItems', mergedItems);

--- a/src/store/luma/actions.ts
+++ b/src/store/luma/actions.ts
@@ -12,52 +12,41 @@ export const resetAll = ({ commit }: ActionContext<ILumaState, IRootState>): voi
 };
 
 export const setApplication = async ({ commit, dispatch }: any, payload: IApplication): Promise<void> => {
-  console.debug('set application', payload);
   commit('setApplication', payload);
   if (!payload) {
-    console.debug('application is null, return');
     return;
   }
   const credential = payload?.credentials?.find((credential) => credential?.host === window.location.origin);
   if (credential) {
-    console.debug('credential exists, set credential', credential);
     commit('setCredential', credential);
   } else {
-    console.debug('credential not exists, start to create credential for application', payload);
     await dispatch('createCredential');
   }
 };
 
 export const setApplications = async ({ commit }: any, payload: IApplication[]): Promise<void> => {
-  console.debug('set applications', payload);
   commit('setApplications', payload);
 };
 
 export const setService = async ({ commit }: any, payload: IService): Promise<void> => {
-  console.debug('set service', payload);
   commit('setService', payload);
 };
 
 export const setCredential = async ({ commit }: any, payload: ICredential): Promise<void> => {
-  console.debug('set credential', payload);
   commit('setCredential', payload);
 };
 
 export const createCredential = async ({ commit, state }: any): Promise<ICredential | undefined> => {
   const application = state.application;
-  console.debug('prepare to create credential for application', application);
   if (!application) {
     console.error('Application not found');
     return undefined;
   }
-  console.debug('creating create credential for application', application);
   const { data: credential } = await credentialOperator.create({
     application_id: application?.id,
     host: window.location.origin
   });
-  console.debug('created credential success', credential);
   commit('setCredential', credential);
-  console.debug('end createCredential');
   return credential;
 };
 
@@ -82,17 +71,13 @@ export const getApplications = async ({
   state,
   rootState
 }: ActionContext<ILumaState, IRootState>): Promise<IApplication[] | undefined> => {
-  console.debug('start to get applications for chat');
   state.status.getApplications = Status.Request;
-  const currentApplication = state.application;
-  console.debug('current application', currentApplication);
   try {
     const { data: applications } = await applicationOperator.getAll({
       user_id: rootState?.user?.id,
       service_id: LUMA_SERVICE_ID
     });
     state.status.getApplications = Status.Success;
-    console.debug('get applications success', applications.items);
     commit('setApplications', applications.items);
     return applications.items;
   } catch (error) {
@@ -126,16 +111,12 @@ export const setTasksActive = ({ commit }: any, payload: ILumaTask) => {
 export const getTasks = async (
   { commit, state, rootState }: ActionContext<ILumaState, IRootState>,
   {
-    offset,
-    limit,
     createdAtMin,
     createdAtMax
   }: { offset?: number; limit?: number; createdAtMin?: number; createdAtMax?: number }
 ): Promise<ILumaTask[]> => {
   return new Promise((resolve, reject) => {
-    console.debug('start to get tasks', offset, limit);
     const credential = state.credential;
-    console.debug('current credential', credential);
     const token = credential?.token;
     if (!token) {
       return reject('no token');
@@ -152,12 +133,9 @@ export const getTasks = async (
         }
       )
       .then((response) => {
-        console.debug('get luma tasks success', response.data.items);
         // merge with existing tasks
         const existingItems = state?.tasks?.items || [];
-        console.debug('existing items', existingItems);
         const newItems = response.data.items || [];
-        console.debug('new items', newItems);
         // sort and de-duplicate using created_at
         const mergedItems = mergeAndSortLists(existingItems, newItems);
         commit('setTasksItems', mergedItems);

--- a/src/store/midjourney/actions.ts
+++ b/src/store/midjourney/actions.ts
@@ -12,52 +12,41 @@ export const resetAll = ({ commit }: ActionContext<IMidjourneyState, IRootState>
 };
 
 export const setApplication = async ({ commit, dispatch }: any, payload: IApplication): Promise<void> => {
-  console.debug('set application', payload);
   commit('setApplication', payload);
   if (!payload) {
-    console.debug('application is null, return');
     return;
   }
   const credential = payload?.credentials?.find((credential) => credential?.host === window.location.origin);
   if (credential) {
-    console.debug('credential exists, set credential', credential);
     commit('setCredential', credential);
   } else {
-    console.debug('credential not exists, start to create credential for application', payload);
     await dispatch('createCredential');
   }
 };
 
 export const setApplications = async ({ commit }: any, payload: IApplication[]): Promise<void> => {
-  console.debug('set applications', payload);
   commit('setApplications', payload);
 };
 
 export const setService = async ({ commit }: any, payload: IService): Promise<void> => {
-  console.debug('set service', payload);
   commit('setService', payload);
 };
 
 export const setCredential = async ({ commit }: any, payload: ICredential): Promise<void> => {
-  console.debug('set credential', payload);
   commit('setCredential', payload);
 };
 
 export const createCredential = async ({ commit, state }: any): Promise<ICredential | undefined> => {
   const application = state.application;
-  console.debug('prepare to create credential for application', application);
   if (!application) {
     console.error('Application not found');
     return undefined;
   }
-  console.debug('creating create credential for application', application);
   const { data: credential } = await credentialOperator.create({
     application_id: application?.id,
     host: window.location.origin
   });
-  console.debug('created credential success', credential);
   commit('setCredential', credential);
-  console.debug('end createCredential');
   return credential;
 };
 
@@ -82,10 +71,7 @@ export const getApplications = async ({
   state,
   rootState
 }: ActionContext<IMidjourneyState, IRootState>): Promise<IApplication[] | undefined> => {
-  console.debug('start to get applications for chat');
   state.status.getApplications = Status.Request;
-  const currentApplication = state.application;
-  console.debug('current application', currentApplication);
   try {
     const { data: applications } = await applicationOperator.getAll({
       user_id: rootState?.user?.id,
@@ -125,16 +111,12 @@ export const setTasks = ({ commit }: any, payload: IMidjourneyTask[]) => {
 export const getTasks = async (
   { commit, state, rootState }: ActionContext<IMidjourneyState, IRootState>,
   {
-    offset,
-    limit,
     createdAtMin,
     createdAtMax
   }: { offset?: number; limit?: number; createdAtMin?: number; createdAtMax?: number }
 ): Promise<IMidjourneyTask[]> => {
   return new Promise((resolve, reject) => {
-    console.debug('start to get tasks', offset, limit, createdAtMax, createdAtMin);
     const credential = state.credential;
-    console.debug('current credential', credential);
     const token = credential?.token;
     if (!token) {
       return reject('no token');
@@ -151,12 +133,9 @@ export const getTasks = async (
         }
       )
       .then((response) => {
-        console.debug('get imagine tasks success', response.data.items);
         // merge with existing tasks
         const existingItems = state?.tasks?.items || [];
-        console.debug('existing items', existingItems);
         const newItems = response.data.items || [];
-        console.debug('new items', newItems);
         // sort and de-duplicate using created_at
         const mergedItems = mergeAndSortLists(existingItems, newItems);
         commit('setTasksItems', mergedItems);

--- a/src/store/nanobanana/actions.ts
+++ b/src/store/nanobanana/actions.ts
@@ -12,52 +12,41 @@ export const resetAll = ({ commit }: ActionContext<INanobananaState, IRootState>
 };
 
 export const setApplication = async ({ commit, dispatch }: any, payload: IApplication): Promise<void> => {
-  console.debug('set application', payload);
   commit('setApplication', payload);
   if (!payload) {
-    console.debug('application is null, return');
     return;
   }
   const credential = payload?.credentials?.find((credential) => credential?.host === window.location.origin);
   if (credential) {
-    console.debug('credential exists, set credential', credential);
     commit('setCredential', credential);
   } else {
-    console.debug('credential not exists, start to create credential for application', payload);
     await dispatch('createCredential');
   }
 };
 
 export const setApplications = async ({ commit }: any, payload: IApplication[]): Promise<void> => {
-  console.debug('set applications', payload);
   commit('setApplications', payload);
 };
 
 export const setService = async ({ commit }: any, payload: IService): Promise<void> => {
-  console.debug('set service', payload);
   commit('setService', payload);
 };
 
 export const setCredential = async ({ commit }: any, payload: ICredential): Promise<void> => {
-  console.debug('set credential', payload);
   commit('setCredential', payload);
 };
 
 export const createCredential = async ({ commit, state }: any): Promise<ICredential | undefined> => {
   const application = state.application;
-  console.debug('prepare to create credential for application', application);
   if (!application) {
     console.error('Application not found');
     return undefined;
   }
-  console.debug('creating create credential for application', application);
   const { data: credential } = await credentialOperator.create({
     application_id: application?.id,
     host: window.location.origin
   });
-  console.debug('created credential success', credential);
   commit('setCredential', credential);
-  console.debug('end createCredential');
   return credential;
 };
 
@@ -82,7 +71,6 @@ export const getApplications = async ({
   state,
   rootState
 }: ActionContext<INanobananaState, IRootState>): Promise<IApplication[] | undefined> => {
-  console.debug('start to get applications for nanobanana');
   state.status.getApplications = Status.Request;
   try {
     const { data: applications } = await applicationOperator.getAll({
@@ -123,17 +111,13 @@ export const setTasksActive = ({ commit }: any, payload: INanobananaTask) => {
 export const getTasks = async (
   { commit, state, rootState }: ActionContext<INanobananaState, IRootState>,
   {
-    offset,
-    limit,
     createdAtMin,
     createdAtMax
   }: { offset?: number; limit?: number; createdAtMin?: number; createdAtMax?: number }
 ): Promise<INanobananaTask[]> => {
   state.status.getTasks = Status.Request;
   return new Promise((resolve, reject) => {
-    console.debug('start to get tasks', offset, limit);
     const credential = state.credential;
-    console.debug('current credential', credential);
     const token = credential?.token;
     if (!token) {
       state.status.getTasks = Status.Error;
@@ -143,8 +127,6 @@ export const getTasks = async (
       .tasks(
         {
           userId: rootState?.user?.id,
-          offset,
-          limit,
           createdAtMin,
           createdAtMax,
           type: 'images'
@@ -154,11 +136,8 @@ export const getTasks = async (
         }
       )
       .then((response) => {
-        console.debug('get images tasks success', response.data.items);
         const existingItems = state?.tasks?.items || [];
-        console.debug('existing items', existingItems);
         const newItems = response.data.items || [];
-        console.debug('new items', newItems);
         const mergedItems = mergeAndSortLists(existingItems, newItems);
         commit('setTasksItems', mergedItems);
         commit('setTasksTotal', response.data.count);

--- a/src/store/openaiimage/actions.ts
+++ b/src/store/openaiimage/actions.ts
@@ -12,52 +12,41 @@ export const resetAll = ({ commit }: ActionContext<IOpenAIImageState, IRootState
 };
 
 export const setApplication = async ({ commit, dispatch }: any, payload: IApplication): Promise<void> => {
-  console.debug('set application', payload);
   commit('setApplication', payload);
   if (!payload) {
-    console.debug('application is null, return');
     return;
   }
   const credential = payload?.credentials?.find((credential) => credential?.host === window.location.origin);
   if (credential) {
-    console.debug('credential exists, set credential', credential);
     commit('setCredential', credential);
   } else {
-    console.debug('credential not exists, start to create credential for application', payload);
     await dispatch('createCredential');
   }
 };
 
 export const setApplications = async ({ commit }: any, payload: IApplication[]): Promise<void> => {
-  console.debug('set applications', payload);
   commit('setApplications', payload);
 };
 
 export const setService = async ({ commit }: any, payload: IService): Promise<void> => {
-  console.debug('set service', payload);
   commit('setService', payload);
 };
 
 export const setCredential = async ({ commit }: any, payload: ICredential): Promise<void> => {
-  console.debug('set credential', payload);
   commit('setCredential', payload);
 };
 
 export const createCredential = async ({ commit, state }: any): Promise<ICredential | undefined> => {
   const application = state.application;
-  console.debug('prepare to create credential for application', application);
   if (!application) {
     console.error('Application not found');
     return undefined;
   }
-  console.debug('creating create credential for application', application);
   const { data: credential } = await credentialOperator.create({
     application_id: application?.id,
     host: window.location.origin
   });
-  console.debug('created credential success', credential);
   commit('setCredential', credential);
-  console.debug('end createCredential');
   return credential;
 };
 
@@ -82,7 +71,6 @@ export const getApplications = async ({
   state,
   rootState
 }: ActionContext<IOpenAIImageState, IRootState>): Promise<IApplication[] | undefined> => {
-  console.debug('start to get applications for openaiimage');
   state.status.getApplications = Status.Request;
   try {
     const { data: applications } = await applicationOperator.getAll({
@@ -123,17 +111,13 @@ export const setTasksActive = ({ commit }: any, payload: IOpenAIImageTask) => {
 export const getTasks = async (
   { commit, state, rootState }: ActionContext<IOpenAIImageState, IRootState>,
   {
-    offset,
-    limit,
     createdAtMin,
     createdAtMax
   }: { offset?: number; limit?: number; createdAtMin?: number; createdAtMax?: number }
 ): Promise<IOpenAIImageTask[]> => {
   state.status.getTasks = Status.Request;
   return new Promise((resolve, reject) => {
-    console.debug('start to get tasks', offset, limit);
     const credential = state.credential;
-    console.debug('current credential', credential);
     const token = credential?.token;
     if (!token) {
       state.status.getTasks = Status.Error;
@@ -143,8 +127,6 @@ export const getTasks = async (
       .tasks(
         {
           userId: rootState?.user?.id,
-          offset,
-          limit,
           createdAtMin,
           createdAtMax
         },
@@ -153,11 +135,8 @@ export const getTasks = async (
         }
       )
       .then((response) => {
-        console.debug('get images tasks success', response.data.items);
         const existingItems = state?.tasks?.items || [];
-        console.debug('existing items', existingItems);
         const newItems = response.data.items || [];
-        console.debug('new items', newItems);
         const mergedItems = mergeAndSortLists(existingItems, newItems);
         commit('setTasksItems', mergedItems);
         commit('setTasksTotal', response.data.count);

--- a/src/store/pika/actions.ts
+++ b/src/store/pika/actions.ts
@@ -12,52 +12,41 @@ export const resetAll = ({ commit }: ActionContext<IPikaState, IRootState>): voi
 };
 
 export const setApplication = async ({ commit, dispatch }: any, payload: IApplication): Promise<void> => {
-  console.debug('set application', payload);
   commit('setApplication', payload);
   if (!payload) {
-    console.debug('application is null, return');
     return;
   }
   const credential = payload?.credentials?.find((credential) => credential?.host === window.location.origin);
   if (credential) {
-    console.debug('credential exists, set credential', credential);
     commit('setCredential', credential);
   } else {
-    console.debug('credential not exists, start to create credential for application', payload);
     await dispatch('createCredential');
   }
 };
 
 export const setApplications = async ({ commit }: any, payload: IApplication[]): Promise<void> => {
-  console.debug('set applications', payload);
   commit('setApplications', payload);
 };
 
 export const setService = async ({ commit }: any, payload: IService): Promise<void> => {
-  console.debug('set service', payload);
   commit('setService', payload);
 };
 
 export const setCredential = async ({ commit }: any, payload: ICredential): Promise<void> => {
-  console.debug('set credential', payload);
   commit('setCredential', payload);
 };
 
 export const createCredential = async ({ commit, state }: any): Promise<ICredential | undefined> => {
   const application = state.application;
-  console.debug('prepare to create credential for application', application);
   if (!application) {
     console.error('Application not found');
     return undefined;
   }
-  console.debug('creating create credential for application', application);
   const { data: credential } = await credentialOperator.create({
     application_id: application?.id,
     host: window.location.origin
   });
-  console.debug('created credential success', credential);
   commit('setCredential', credential);
-  console.debug('end createCredential');
   return credential;
 };
 
@@ -82,10 +71,7 @@ export const getApplications = async ({
   state,
   rootState
 }: ActionContext<IPikaState, IRootState>): Promise<IApplication[] | undefined> => {
-  console.debug('start to get applications for chat');
   state.status.getApplications = Status.Request;
-  const currentApplication = state.application;
-  console.debug('current application', currentApplication);
   try {
     const { data: applications } = await applicationOperator.getAll({
       user_id: rootState?.user?.id,
@@ -125,16 +111,12 @@ export const setTasksActive = ({ commit }: any, payload: IPikaTask) => {
 export const getTasks = async (
   { commit, state, rootState }: ActionContext<IPikaState, IRootState>,
   {
-    offset,
-    limit,
     createdAtMin,
     createdAtMax
   }: { offset?: number; limit?: number; createdAtMin?: number; createdAtMax?: number }
 ): Promise<IPikaTask[]> => {
   return new Promise((resolve, reject) => {
-    console.debug('start to get tasks', offset, limit);
     const credential = state.credential;
-    console.debug('current credential', credential);
     const token = credential?.token;
     if (!token) {
       return reject('no token');
@@ -152,12 +134,9 @@ export const getTasks = async (
         }
       )
       .then((response) => {
-        console.debug('get videos tasks success', response.data.items);
         // merge with existing tasks
         const existingItems = state?.tasks?.items || [];
-        console.debug('existing items', existingItems);
         const newItems = response.data.items || [];
-        console.debug('new items', newItems);
         // sort and de-duplicate using created_at
         const mergedItems = mergeAndSortLists(existingItems, newItems);
         commit('setTasksItems', mergedItems);

--- a/src/store/pixverse/actions.ts
+++ b/src/store/pixverse/actions.ts
@@ -12,52 +12,41 @@ export const resetAll = ({ commit }: ActionContext<IPixverseState, IRootState>):
 };
 
 export const setApplication = async ({ commit, dispatch }: any, payload: IApplication): Promise<void> => {
-  console.debug('set application', payload);
   commit('setApplication', payload);
   if (!payload) {
-    console.debug('application is null, return');
     return;
   }
   const credential = payload?.credentials?.find((credential) => credential?.host === window.location.origin);
   if (credential) {
-    console.debug('credential exists, set credential', credential);
     commit('setCredential', credential);
   } else {
-    console.debug('credential not exists, start to create credential for application', payload);
     await dispatch('createCredential');
   }
 };
 
 export const setApplications = async ({ commit }: any, payload: IApplication[]): Promise<void> => {
-  console.debug('set applications', payload);
   commit('setApplications', payload);
 };
 
 export const setService = async ({ commit }: any, payload: IService): Promise<void> => {
-  console.debug('set service', payload);
   commit('setService', payload);
 };
 
 export const setCredential = async ({ commit }: any, payload: ICredential): Promise<void> => {
-  console.debug('set credential', payload);
   commit('setCredential', payload);
 };
 
 export const createCredential = async ({ commit, state }: any): Promise<ICredential | undefined> => {
   const application = state.application;
-  console.debug('prepare to create credential for application', application);
   if (!application) {
     console.error('Application not found');
     return undefined;
   }
-  console.debug('creating create credential for application', application);
   const { data: credential } = await credentialOperator.create({
     application_id: application?.id,
     host: window.location.origin
   });
-  console.debug('created credential success', credential);
   commit('setCredential', credential);
-  console.debug('end createCredential');
   return credential;
 };
 
@@ -82,10 +71,7 @@ export const getApplications = async ({
   state,
   rootState
 }: ActionContext<IPixverseState, IRootState>): Promise<IApplication[] | undefined> => {
-  console.debug('start to get applications for chat');
   state.status.getApplications = Status.Request;
-  const currentApplication = state.application;
-  console.debug('current application', currentApplication);
   try {
     const { data: applications } = await applicationOperator.getAll({
       user_id: rootState?.user?.id,
@@ -125,16 +111,12 @@ export const setTasksActive = ({ commit }: any, payload: IPixverseTask) => {
 export const getTasks = async (
   { commit, state, rootState }: ActionContext<IPixverseState, IRootState>,
   {
-    offset,
-    limit,
     createdAtMin,
     createdAtMax
   }: { offset?: number; limit?: number; createdAtMin?: number; createdAtMax?: number }
 ): Promise<IPixverseTask[]> => {
   return new Promise((resolve, reject) => {
-    console.debug('start to get tasks', offset, limit);
     const credential = state.credential;
-    console.debug('current credential', credential);
     const token = credential?.token;
     if (!token) {
       return reject('no token');
@@ -152,12 +134,9 @@ export const getTasks = async (
         }
       )
       .then((response) => {
-        console.debug('get videos tasks success', response.data.items);
         // merge with existing tasks
         const existingItems = state?.tasks?.items || [];
-        console.debug('existing items', existingItems);
         const newItems = response.data.items || [];
-        console.debug('new items', newItems);
         // sort and de-duplicate using created_at
         const mergedItems = mergeAndSortLists(existingItems, newItems);
         commit('setTasksItems', mergedItems);

--- a/src/store/producer/actions.ts
+++ b/src/store/producer/actions.ts
@@ -12,52 +12,41 @@ export const resetAll = ({ commit }: ActionContext<IProducerState, IRootState>):
 };
 
 export const setApplication = async ({ commit, dispatch }: any, payload: IApplication): Promise<void> => {
-  console.debug('set application', payload);
   commit('setApplication', payload);
   if (!payload) {
-    console.debug('application is null, return');
     return;
   }
   const credential = payload?.credentials?.find((credential) => credential?.host === window.location.origin);
   if (credential) {
-    console.debug('credential exists, set credential', credential);
     commit('setCredential', credential);
   } else {
-    console.debug('credential not exists, start to create credential for application', payload);
     await dispatch('createCredential');
   }
 };
 
 export const setApplications = async ({ commit }: any, payload: IApplication[]): Promise<void> => {
-  console.debug('set applications', payload);
   commit('setApplications', payload);
 };
 
 export const setService = async ({ commit }: any, payload: IService): Promise<void> => {
-  console.debug('set service', payload);
   commit('setService', payload);
 };
 
 export const setCredential = async ({ commit }: any, payload: ICredential): Promise<void> => {
-  console.debug('set credential', payload);
   commit('setCredential', payload);
 };
 
 export const createCredential = async ({ commit, state }: any): Promise<ICredential | undefined> => {
   const application = state.application;
-  console.debug('prepare to create credential for application', application);
   if (!application) {
     console.error('Application not found');
     return undefined;
   }
-  console.debug('creating create credential for application', application);
   const { data: credential } = await credentialOperator.create({
     application_id: application?.id,
     host: window.location.origin
   });
-  console.debug('created credential success', credential);
   commit('setCredential', credential);
-  console.debug('end createCredential');
   return credential;
 };
 
@@ -82,10 +71,7 @@ export const getApplications = async ({
   state,
   rootState
 }: ActionContext<IProducerState, IRootState>): Promise<IApplication[] | undefined> => {
-  console.debug('start to get applications for producer');
   state.status.getApplications = Status.Request;
-  const currentApplication = state.application;
-  console.debug('current application', currentApplication);
   try {
     const { data: applications } = await applicationOperator.getAll({
       user_id: rootState?.user?.id,
@@ -129,14 +115,11 @@ export const setAudio = ({ commit }: any, payload: any) => {
 export const getTasks = async (
   { commit, state, rootState }: ActionContext<IProducerState, IRootState>,
   {
-    offset,
-    limit,
     createdAtMin,
     createdAtMax
   }: { offset?: number; limit?: number; createdAtMin?: number; createdAtMax?: number }
 ): Promise<IProducerTask[]> => {
   return new Promise((resolve, reject) => {
-    console.debug('start to get tasks', offset, limit, createdAtMax, createdAtMin);
     const credential = state.credential;
     const token = credential?.token;
     if (!token) {
@@ -155,12 +138,9 @@ export const getTasks = async (
         }
       )
       .then((response) => {
-        console.debug('get producer tasks success', response.data.items);
         // merge with existing tasks
         const existingItems = state?.tasks?.items || [];
-        console.debug('existing items', existingItems);
         const newItems = response.data.items || [];
-        console.debug('new items', newItems);
         // sort and de-duplicate using created_at
         const mergedItems = mergeAndSortLists(existingItems, newItems);
         commit('setTasksItems', mergedItems);

--- a/src/store/qrart/actions.ts
+++ b/src/store/qrart/actions.ts
@@ -12,52 +12,41 @@ export const resetAll = ({ commit }: ActionContext<IQrartState, IRootState>): vo
 };
 
 export const setApplication = async ({ commit, dispatch }: any, payload: IApplication): Promise<void> => {
-  console.debug('set application', payload);
   commit('setApplication', payload);
   if (!payload) {
-    console.debug('application is null, return');
     return;
   }
   const credential = payload?.credentials?.find((credential) => credential?.host === window.location.origin);
   if (credential) {
-    console.debug('credential exists, set credential', credential);
     commit('setCredential', credential);
   } else {
-    console.debug('credential not exists, start to create credential for application', payload);
     await dispatch('createCredential');
   }
 };
 
 export const setApplications = async ({ commit }: any, payload: IApplication[]): Promise<void> => {
-  console.debug('set applications', payload);
   commit('setApplications', payload);
 };
 
 export const setService = async ({ commit }: any, payload: IService): Promise<void> => {
-  console.debug('set service', payload);
   commit('setService', payload);
 };
 
 export const setCredential = async ({ commit }: any, payload: ICredential): Promise<void> => {
-  console.debug('set credential', payload);
   commit('setCredential', payload);
 };
 
 export const createCredential = async ({ commit, state }: any): Promise<ICredential | undefined> => {
   const application = state.application;
-  console.debug('prepare to create credential for application', application);
   if (!application) {
     console.error('Application not found');
     return undefined;
   }
-  console.debug('creating create credential for application', application);
   const { data: credential } = await credentialOperator.create({
     application_id: application?.id,
     host: window.location.origin
   });
-  console.debug('created credential success', credential);
   commit('setCredential', credential);
-  console.debug('end createCredential');
   return credential;
 };
 
@@ -82,10 +71,7 @@ export const getApplications = async ({
   state,
   rootState
 }: ActionContext<IQrartState, IRootState>): Promise<IApplication[] | undefined> => {
-  console.debug('start to get applications for chat');
   state.status.getApplications = Status.Request;
-  const currentApplication = state.application;
-  console.debug('current application', currentApplication);
   try {
     const { data: applications } = await applicationOperator.getAll({
       user_id: rootState?.user?.id,
@@ -125,14 +111,11 @@ export const setTasksActive = ({ commit }: any, payload: IQrartTask) => {
 export const getTasks = async (
   { commit, state, rootState }: ActionContext<IQrartState, IRootState>,
   {
-    offset,
-    limit,
     createdAtMin,
     createdAtMax
   }: { offset?: number; limit?: number; createdAtMin?: number; createdAtMax?: number }
 ): Promise<IQrartTask[]> => {
   return new Promise((resolve, reject) => {
-    console.debug('start to get tasks', offset, limit);
     const credential = state.credential;
     const token = credential?.token;
     if (!token) {
@@ -150,12 +133,9 @@ export const getTasks = async (
         }
       )
       .then((response) => {
-        console.debug('get qrart tasks success', response.data.items);
         // merge with existing tasks
         const existingItems = state?.tasks?.items || [];
-        console.debug('existing items', existingItems);
         const newItems = response.data.items || [];
-        console.debug('new items', newItems);
         // sort and de-duplicate using created_at
         const mergedItems = mergeAndSortLists(existingItems, newItems);
         commit('setTasksItems', mergedItems);

--- a/src/store/seedance/actions.ts
+++ b/src/store/seedance/actions.ts
@@ -12,52 +12,41 @@ export const resetAll = ({ commit }: ActionContext<ISeedanceState, IRootState>):
 };
 
 export const setApplication = async ({ commit, dispatch }: any, payload: IApplication): Promise<void> => {
-  console.debug('set application', payload);
   commit('setApplication', payload);
   if (!payload) {
-    console.debug('application is null, return');
     return;
   }
   const credential = payload?.credentials?.find((credential) => credential?.host === window.location.origin);
   if (credential) {
-    console.debug('credential exists, set credential', credential);
     commit('setCredential', credential);
   } else {
-    console.debug('credential not exists, start to create credential for application', payload);
     await dispatch('createCredential');
   }
 };
 
 export const setApplications = async ({ commit }: any, payload: IApplication[]): Promise<void> => {
-  console.debug('set applications', payload);
   commit('setApplications', payload);
 };
 
 export const setService = async ({ commit }: any, payload: IService): Promise<void> => {
-  console.debug('set service', payload);
   commit('setService', payload);
 };
 
 export const setCredential = async ({ commit }: any, payload: ICredential): Promise<void> => {
-  console.debug('set credential', payload);
   commit('setCredential', payload);
 };
 
 export const createCredential = async ({ commit, state }: any): Promise<ICredential | undefined> => {
   const application = state.application;
-  console.debug('prepare to create credential for application', application);
   if (!application) {
     console.error('Application not found');
     return undefined;
   }
-  console.debug('creating create credential for application', application);
   const { data: credential } = await credentialOperator.create({
     application_id: application?.id,
     host: window.location.origin
   });
-  console.debug('created credential success', credential);
   commit('setCredential', credential);
-  console.debug('end createCredential');
   return credential;
 };
 
@@ -82,7 +71,6 @@ export const getApplications = async ({
   state,
   rootState
 }: ActionContext<ISeedanceState, IRootState>): Promise<IApplication[] | undefined> => {
-  console.debug('start to get applications for seedance');
   state.status.getApplications = Status.Request;
   try {
     const { data: applications } = await applicationOperator.getAll({
@@ -123,17 +111,13 @@ export const setTasksActive = ({ commit }: any, payload: ISeedanceTask) => {
 export const getTasks = async (
   { commit, state, rootState }: ActionContext<ISeedanceState, IRootState>,
   {
-    offset,
-    limit,
     createdAtMin,
     createdAtMax
   }: { offset?: number; limit?: number; createdAtMin?: number; createdAtMax?: number }
 ): Promise<ISeedanceTask[]> => {
   state.status.getTasks = Status.Request;
   return new Promise((resolve, reject) => {
-    console.debug('start to get tasks', offset, limit);
     const credential = state.credential;
-    console.debug('current credential', credential);
     const token = credential?.token;
     if (!token) {
       state.status.getTasks = Status.Error;
@@ -143,8 +127,6 @@ export const getTasks = async (
       .tasks(
         {
           userId: rootState?.user?.id,
-          offset,
-          limit,
           createdAtMin,
           createdAtMax,
           type: 'videos'
@@ -154,7 +136,6 @@ export const getTasks = async (
         }
       )
       .then((response) => {
-        console.debug('get videos tasks success', response.data.items);
         const existingItems = state?.tasks?.items || [];
         const newItems = response.data.items || [];
         const mergedItems = mergeAndSortLists(existingItems, newItems);

--- a/src/store/seedream/actions.ts
+++ b/src/store/seedream/actions.ts
@@ -12,52 +12,41 @@ export const resetAll = ({ commit }: ActionContext<ISeedreamState, IRootState>):
 };
 
 export const setApplication = async ({ commit, dispatch }: any, payload: IApplication): Promise<void> => {
-  console.debug('set application', payload);
   commit('setApplication', payload);
   if (!payload) {
-    console.debug('application is null, return');
     return;
   }
   const credential = payload?.credentials?.find((credential) => credential?.host === window.location.origin);
   if (credential) {
-    console.debug('credential exists, set credential', credential);
     commit('setCredential', credential);
   } else {
-    console.debug('credential not exists, start to create credential for application', payload);
     await dispatch('createCredential');
   }
 };
 
 export const setApplications = async ({ commit }: any, payload: IApplication[]): Promise<void> => {
-  console.debug('set applications', payload);
   commit('setApplications', payload);
 };
 
 export const setService = async ({ commit }: any, payload: IService): Promise<void> => {
-  console.debug('set service', payload);
   commit('setService', payload);
 };
 
 export const setCredential = async ({ commit }: any, payload: ICredential): Promise<void> => {
-  console.debug('set credential', payload);
   commit('setCredential', payload);
 };
 
 export const createCredential = async ({ commit, state }: any): Promise<ICredential | undefined> => {
   const application = state.application;
-  console.debug('prepare to create credential for application', application);
   if (!application) {
     console.error('Application not found');
     return undefined;
   }
-  console.debug('creating create credential for application', application);
   const { data: credential } = await credentialOperator.create({
     application_id: application?.id,
     host: window.location.origin
   });
-  console.debug('created credential success', credential);
   commit('setCredential', credential);
-  console.debug('end createCredential');
   return credential;
 };
 
@@ -82,7 +71,6 @@ export const getApplications = async ({
   state,
   rootState
 }: ActionContext<ISeedreamState, IRootState>): Promise<IApplication[] | undefined> => {
-  console.debug('start to get applications for seedream');
   state.status.getApplications = Status.Request;
   try {
     const { data: applications } = await applicationOperator.getAll({
@@ -123,17 +111,13 @@ export const setTasksActive = ({ commit }: any, payload: ISeedreamTask) => {
 export const getTasks = async (
   { commit, state, rootState }: ActionContext<ISeedreamState, IRootState>,
   {
-    offset,
-    limit,
     createdAtMin,
     createdAtMax
   }: { offset?: number; limit?: number; createdAtMin?: number; createdAtMax?: number }
 ): Promise<ISeedreamTask[]> => {
   state.status.getTasks = Status.Request;
   return new Promise((resolve, reject) => {
-    console.debug('start to get tasks', offset, limit);
     const credential = state.credential;
-    console.debug('current credential', credential);
     const token = credential?.token;
     if (!token) {
       state.status.getTasks = Status.Error;
@@ -143,8 +127,6 @@ export const getTasks = async (
       .tasks(
         {
           userId: rootState?.user?.id,
-          offset,
-          limit,
           createdAtMin,
           createdAtMax,
           type: 'images'
@@ -154,11 +136,8 @@ export const getTasks = async (
         }
       )
       .then((response) => {
-        console.debug('get images tasks success', response.data.items);
         const existingItems = state?.tasks?.items || [];
-        console.debug('existing items', existingItems);
         const newItems = response.data.items || [];
-        console.debug('new items', newItems);
         const mergedItems = mergeAndSortLists(existingItems, newItems);
         commit('setTasksItems', mergedItems);
         commit('setTasksTotal', response.data.count);

--- a/src/store/serp/actions.ts
+++ b/src/store/serp/actions.ts
@@ -11,52 +11,41 @@ export const resetAll = ({ commit }: ActionContext<ISerpState, IRootState>): voi
 };
 
 export const setApplication = async ({ commit, dispatch }: any, payload: IApplication): Promise<void> => {
-  console.debug('set application', payload);
   commit('setApplication', payload);
   if (!payload) {
-    console.debug('application is null, return');
     return;
   }
   const credential = payload?.credentials?.find((credential) => credential?.host === window.location.origin);
   if (credential) {
-    console.debug('credential exists, set credential', credential);
     commit('setCredential', credential);
   } else {
-    console.debug('credential not exists, start to create credential for application', payload);
     await dispatch('createCredential');
   }
 };
 
 export const setApplications = async ({ commit }: any, payload: IApplication[]): Promise<void> => {
-  console.debug('set applications', payload);
   commit('setApplications', payload);
 };
 
 export const setService = async ({ commit }: any, payload: IService): Promise<void> => {
-  console.debug('set service', payload);
   commit('setService', payload);
 };
 
 export const setCredential = async ({ commit }: any, payload: ICredential): Promise<void> => {
-  console.debug('set credential', payload);
   commit('setCredential', payload);
 };
 
 export const createCredential = async ({ commit, state }: any): Promise<ICredential | undefined> => {
   const application = state.application;
-  console.debug('prepare to create credential for application', application);
   if (!application) {
     console.error('Application not found');
     return undefined;
   }
-  console.debug('creating create credential for application', application);
   const { data: credential } = await credentialOperator.create({
     application_id: application?.id,
     host: window.location.origin
   });
-  console.debug('created credential success', credential);
   commit('setCredential', credential);
-  console.debug('end createCredential');
   return credential;
 };
 
@@ -81,7 +70,6 @@ export const getApplications = async ({
   state,
   rootState
 }: ActionContext<ISerpState, IRootState>): Promise<IApplication[] | undefined> => {
-  console.debug('start to get applications for serp');
   state.status.getApplications = Status.Request;
   try {
     const { data: applications } = await applicationOperator.getAll({

--- a/src/store/sora/actions.ts
+++ b/src/store/sora/actions.ts
@@ -12,52 +12,41 @@ export const resetAll = ({ commit }: ActionContext<ISoraState, IRootState>): voi
 };
 
 export const setApplication = async ({ commit, dispatch }: any, payload: IApplication): Promise<void> => {
-  console.debug('set application', payload);
   commit('setApplication', payload);
   if (!payload) {
-    console.debug('application is null, return');
     return;
   }
   const credential = payload?.credentials?.find((credential) => credential?.host === window.location.origin);
   if (credential) {
-    console.debug('credential exists, set credential', credential);
     commit('setCredential', credential);
   } else {
-    console.debug('credential not exists, start to create credential for application', payload);
     await dispatch('createCredential');
   }
 };
 
 export const setApplications = async ({ commit }: any, payload: IApplication[]): Promise<void> => {
-  console.debug('set applications', payload);
   commit('setApplications', payload);
 };
 
 export const setService = async ({ commit }: any, payload: IService): Promise<void> => {
-  console.debug('set service', payload);
   commit('setService', payload);
 };
 
 export const setCredential = async ({ commit }: any, payload: ICredential): Promise<void> => {
-  console.debug('set credential', payload);
   commit('setCredential', payload);
 };
 
 export const createCredential = async ({ commit, state }: any): Promise<ICredential | undefined> => {
   const application = state.application;
-  console.debug('prepare to create credential for application', application);
   if (!application) {
     console.error('Application not found');
     return undefined;
   }
-  console.debug('creating create credential for application', application);
   const { data: credential } = await credentialOperator.create({
     application_id: application?.id,
     host: window.location.origin
   });
-  console.debug('created credential success', credential);
   commit('setCredential', credential);
-  console.debug('end createCredential');
   return credential;
 };
 
@@ -82,10 +71,7 @@ export const getApplications = async ({
   state,
   rootState
 }: ActionContext<ISoraState, IRootState>): Promise<IApplication[] | undefined> => {
-  console.debug('start to get applications for chat');
   state.status.getApplications = Status.Request;
-  const currentApplication = state.application;
-  console.debug('current application', currentApplication);
   try {
     const { data: applications } = await applicationOperator.getAll({
       user_id: rootState?.user?.id,
@@ -125,16 +111,12 @@ export const setTasksActive = ({ commit }: any, payload: ISoraTask) => {
 export const getTasks = async (
   { commit, state, rootState }: ActionContext<ISoraState, IRootState>,
   {
-    offset,
-    limit,
     createdAtMin,
     createdAtMax
   }: { offset?: number; limit?: number; createdAtMin?: number; createdAtMax?: number }
 ): Promise<ISoraTask[]> => {
   return new Promise((resolve, reject) => {
-    console.debug('start to get tasks', offset, limit);
     const credential = state.credential;
-    console.debug('current credential', credential);
     const token = credential?.token;
     if (!token) {
       return reject('no token');
@@ -152,12 +134,9 @@ export const getTasks = async (
         }
       )
       .then((response) => {
-        console.debug('get videos tasks success', response.data.items);
         // merge with existing tasks
         const existingItems = state?.tasks?.items || [];
-        console.debug('existing items', existingItems);
         const newItems = response.data.items || [];
-        console.debug('new items', newItems);
         // sort and de-duplicate using created_at
         const mergedItems = mergeAndSortLists(existingItems, newItems);
         commit('setTasksItems', mergedItems);

--- a/src/store/suno/actions.ts
+++ b/src/store/suno/actions.ts
@@ -12,52 +12,41 @@ export const resetAll = ({ commit }: ActionContext<ISunoState, IRootState>): voi
 };
 
 export const setApplication = async ({ commit, dispatch }: any, payload: IApplication): Promise<void> => {
-  console.debug('set application', payload);
   commit('setApplication', payload);
   if (!payload) {
-    console.debug('application is null, return');
     return;
   }
   const credential = payload?.credentials?.find((credential) => credential?.host === window.location.origin);
   if (credential) {
-    console.debug('credential exists, set credential', credential);
     commit('setCredential', credential);
   } else {
-    console.debug('credential not exists, start to create credential for application', payload);
     await dispatch('createCredential');
   }
 };
 
 export const setApplications = async ({ commit }: any, payload: IApplication[]): Promise<void> => {
-  console.debug('set applications', payload);
   commit('setApplications', payload);
 };
 
 export const setService = async ({ commit }: any, payload: IService): Promise<void> => {
-  console.debug('set service', payload);
   commit('setService', payload);
 };
 
 export const setCredential = async ({ commit }: any, payload: ICredential): Promise<void> => {
-  console.debug('set credential', payload);
   commit('setCredential', payload);
 };
 
 export const createCredential = async ({ commit, state }: any): Promise<ICredential | undefined> => {
   const application = state.application;
-  console.debug('prepare to create credential for application', application);
   if (!application) {
     console.error('Application not found');
     return undefined;
   }
-  console.debug('creating create credential for application', application);
   const { data: credential } = await credentialOperator.create({
     application_id: application?.id,
     host: window.location.origin
   });
-  console.debug('created credential success', credential);
   commit('setCredential', credential);
-  console.debug('end createCredential');
   return credential;
 };
 
@@ -82,10 +71,7 @@ export const getApplications = async ({
   state,
   rootState
 }: ActionContext<ISunoState, IRootState>): Promise<IApplication[] | undefined> => {
-  console.debug('start to get applications for chat');
   state.status.getApplications = Status.Request;
-  const currentApplication = state.application;
-  console.debug('current application', currentApplication);
   try {
     const { data: applications } = await applicationOperator.getAll({
       user_id: rootState?.user?.id,
@@ -129,14 +115,11 @@ export const setAudio = ({ commit }: any, payload: any) => {
 export const getTasks = async (
   { commit, state, rootState }: ActionContext<ISunoState, IRootState>,
   {
-    offset,
-    limit,
     createdAtMin,
     createdAtMax
   }: { offset?: number; limit?: number; createdAtMin?: number; createdAtMax?: number }
 ): Promise<ISunoTask[]> => {
   return new Promise((resolve, reject) => {
-    console.debug('start to get tasks', offset, limit, createdAtMax, createdAtMin);
     const credential = state.credential;
     const token = credential?.token;
     if (!token) {
@@ -155,12 +138,9 @@ export const getTasks = async (
         }
       )
       .then((response) => {
-        console.debug('get imagine tasks success', response.data.items);
         // merge with existing tasks
         const existingItems = state?.tasks?.items || [];
-        console.debug('existing items', existingItems);
         const newItems = response.data.items || [];
-        console.debug('new items', newItems);
         // sort and de-duplicate using created_at
         const mergedItems = mergeAndSortLists(existingItems, newItems);
         commit('setTasksItems', mergedItems);

--- a/src/store/veo/actions.ts
+++ b/src/store/veo/actions.ts
@@ -12,52 +12,41 @@ export const resetAll = ({ commit }: ActionContext<IVeoState, IRootState>): void
 };
 
 export const setApplication = async ({ commit, dispatch }: any, payload: IApplication): Promise<void> => {
-  console.debug('set application', payload);
   commit('setApplication', payload);
   if (!payload) {
-    console.debug('application is null, return');
     return;
   }
   const credential = payload?.credentials?.find((credential) => credential?.host === window.location.origin);
   if (credential) {
-    console.debug('credential exists, set credential', credential);
     commit('setCredential', credential);
   } else {
-    console.debug('credential not exists, start to create credential for application', payload);
     await dispatch('createCredential');
   }
 };
 
 export const setApplications = async ({ commit }: any, payload: IApplication[]): Promise<void> => {
-  console.debug('set applications', payload);
   commit('setApplications', payload);
 };
 
 export const setService = async ({ commit }: any, payload: IService): Promise<void> => {
-  console.debug('set service', payload);
   commit('setService', payload);
 };
 
 export const setCredential = async ({ commit }: any, payload: ICredential): Promise<void> => {
-  console.debug('set credential', payload);
   commit('setCredential', payload);
 };
 
 export const createCredential = async ({ commit, state }: any): Promise<ICredential | undefined> => {
   const application = state.application;
-  console.debug('prepare to create credential for application', application);
   if (!application) {
     console.error('Application not found');
     return undefined;
   }
-  console.debug('creating create credential for application', application);
   const { data: credential } = await credentialOperator.create({
     application_id: application?.id,
     host: window.location.origin
   });
-  console.debug('created credential success', credential);
   commit('setCredential', credential);
-  console.debug('end createCredential');
   return credential;
 };
 
@@ -82,10 +71,7 @@ export const getApplications = async ({
   state,
   rootState
 }: ActionContext<IVeoState, IRootState>): Promise<IApplication[] | undefined> => {
-  console.debug('start to get applications for chat');
   state.status.getApplications = Status.Request;
-  const currentApplication = state.application;
-  console.debug('current application', currentApplication);
   try {
     const { data: applications } = await applicationOperator.getAll({
       user_id: rootState?.user?.id,
@@ -125,16 +111,12 @@ export const setTasksActive = ({ commit }: any, payload: IVeoTask) => {
 export const getTasks = async (
   { commit, state, rootState }: ActionContext<IVeoState, IRootState>,
   {
-    offset,
-    limit,
     createdAtMin,
     createdAtMax
   }: { offset?: number; limit?: number; createdAtMin?: number; createdAtMax?: number }
 ): Promise<IVeoTask[]> => {
   return new Promise((resolve, reject) => {
-    console.debug('start to get tasks', offset, limit);
     const credential = state.credential;
-    console.debug('current credential', credential);
     const token = credential?.token;
     if (!token) {
       return reject('no token');
@@ -152,12 +134,9 @@ export const getTasks = async (
         }
       )
       .then((response) => {
-        console.debug('get videos tasks success', response.data.items);
         // merge with existing tasks
         const existingItems = state?.tasks?.items || [];
-        console.debug('existing items', existingItems);
         const newItems = response.data.items || [];
-        console.debug('new items', newItems);
         // sort and de-duplicate using created_at
         const mergedItems = mergeAndSortLists(existingItems, newItems);
         commit('setTasksItems', mergedItems);

--- a/src/store/wan/actions.ts
+++ b/src/store/wan/actions.ts
@@ -12,52 +12,41 @@ export const resetAll = ({ commit }: ActionContext<IWanState, IRootState>): void
 };
 
 export const setApplication = async ({ commit, dispatch }: any, payload: IApplication): Promise<void> => {
-  console.debug('set application', payload);
   commit('setApplication', payload);
   if (!payload) {
-    console.debug('application is null, return');
     return;
   }
   const credential = payload?.credentials?.find((credential) => credential?.host === window.location.origin);
   if (credential) {
-    console.debug('credential exists, set credential', credential);
     commit('setCredential', credential);
   } else {
-    console.debug('credential not exists, start to create credential for application', payload);
     await dispatch('createCredential');
   }
 };
 
 export const setApplications = async ({ commit }: any, payload: IApplication[]): Promise<void> => {
-  console.debug('set applications', payload);
   commit('setApplications', payload);
 };
 
 export const setService = async ({ commit }: any, payload: IService): Promise<void> => {
-  console.debug('set service', payload);
   commit('setService', payload);
 };
 
 export const setCredential = async ({ commit }: any, payload: ICredential): Promise<void> => {
-  console.debug('set credential', payload);
   commit('setCredential', payload);
 };
 
 export const createCredential = async ({ commit, state }: any): Promise<ICredential | undefined> => {
   const application = state.application;
-  console.debug('prepare to create credential for application', application);
   if (!application) {
     console.error('Application not found');
     return undefined;
   }
-  console.debug('creating create credential for application', application);
   const { data: credential } = await credentialOperator.create({
     application_id: application?.id,
     host: window.location.origin
   });
-  console.debug('created credential success', credential);
   commit('setCredential', credential);
-  console.debug('end createCredential');
   return credential;
 };
 
@@ -82,10 +71,7 @@ export const getApplications = async ({
   state,
   rootState
 }: ActionContext<IWanState, IRootState>): Promise<IApplication[] | undefined> => {
-  console.debug('start to get applications for chat');
   state.status.getApplications = Status.Request;
-  const currentApplication = state.application;
-  console.debug('current application', currentApplication);
   try {
     const { data: applications } = await applicationOperator.getAll({
       user_id: rootState?.user?.id,
@@ -125,16 +111,12 @@ export const setTasksActive = ({ commit }: any, payload: IWanTask) => {
 export const getTasks = async (
   { commit, state, rootState }: ActionContext<IWanState, IRootState>,
   {
-    offset,
-    limit,
     createdAtMin,
     createdAtMax
   }: { offset?: number; limit?: number; createdAtMin?: number; createdAtMax?: number }
 ): Promise<IWanTask[]> => {
   return new Promise((resolve, reject) => {
-    console.debug('start to get tasks', offset, limit);
     const credential = state.credential;
-    console.debug('current credential', credential);
     const token = credential?.token;
     if (!token) {
       return reject('no token');
@@ -152,12 +134,9 @@ export const getTasks = async (
         }
       )
       .then((response) => {
-        console.debug('get videos tasks success', response.data.items);
         // merge with existing tasks
         const existingItems = state?.tasks?.items || [];
-        console.debug('existing items', existingItems);
         const newItems = response.data.items || [];
-        console.debug('new items', newItems);
         // sort and de-duplicate using created_at
         const mergedItems = mergeAndSortLists(existingItems, newItems);
         commit('setTasksItems', mergedItems);


### PR DESCRIPTION
## Summary

Strip **367 noisy `console.debug` / `console.log` calls** out of the Vuex store actions, plus the **57 dead locals** that only existed to feed those calls.

## Why

Every store action was liberally littered with:

```ts
console.debug('set application', payload);
console.debug('credential exists, set credential', credential);
console.debug('start to get tasks', offset, limit);
console.debug('current application', currentApplication);
```

This ran on every mutation in **every public client**. Concretely:

1. **PII leak.** Lines like `console.debug('set credential', credential)` and `console.debug('current application', currentApplication)` spray Bearer tokens, application IDs, and sometimes user/session metadata into the browser console where any extension or screenshot can capture them.
2. **Console spam.** A single page-load on Nexior emits dozens of `[Vue debug]`-style lines, which makes any actual diagnostic output (errors, warnings, our telemetry) drown.
3. **Zero diagnostic value.** They almost all just narrate state assignments (`set X`, `start to get Y`, `end Z`) that are obvious from a Vue devtools timeline.

## What changed

- Single-line `console.debug(...)` / `console.log(...)` statements inside `src/store/**/actions.ts` are removed.
- `console.error(...)` and `console.warn(...)` are **preserved** — they signal real issues and they're rare enough to not be spam.
- Three classes of locals that *only* existed to feed those debug calls are removed:
  - `const currentApplication = state.application;` (used only inside `console.debug('current application', currentApplication)`)
  - destructured `offset` and `limit` in `getTasks(...)` (logged but never passed to the operator — the operator only consumes `createdAtMin`/`createdAtMax`)
- The `getTasks` **type signature** keeps `offset?: number` / `limit?: number` so existing callers continue to compile. Those arguments were already being silently ignored at runtime; this PR doesn't change that contract.

## Stats

| | |
|---|---|
| Files touched | 21 (`src/store/{chat,common,flux,hailuo,headshots,kling,luma,midjourney,nanobanana,openaiimage,pika,pixverse,producer,qrart,seedance,seedream,serp,sora,suno,veo,wan}/actions.ts`) |
| Lines removed | 424 |
| Lines added | 0 |
| `console.debug` / `console.log` calls remaining in `src/store/` | 0 |
| `console.error` / `console.warn` calls remaining | preserved verbatim |

## Verification

- `npm run build` ✅ passes (initial run flagged the orphan locals as TS6133, all of which are now removed).
- `grep -rn "console\.\\(debug\\|log\\)" src/store/` → no matches.
- `grep -rn "console\\.error" src/store/` → unchanged from `main`.

## Risk

Vanishingly low. Behavior change: console output is quieter. Code change: only deletions. No API surface (Vuex action signatures, store getters, state shape) is altered.

If we want structured diagnostic logging in the future, this is also a healthier baseline — there is now exactly **one** logging convention in the store layer (`console.error` for failures), so the next person can introduce a real `logger` plugin without tripping over hundreds of legacy `console.debug` calls.
