### PR TITLE
refactor(operators): add BaseTaskOperator and migrate Luma as PoC

### DIFF
--- a/change/@acedatacloud-nexior-da6c4201-97e0-4fff-aa6d-3294ee2b3fa4.json
+++ b/change/@acedatacloud-nexior-da6c4201-97e0-4fff-aa6d-3294ee2b3fa4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add BaseTaskOperator and migrate Luma operator as proof-of-concept (12 more services share the same shape)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/operators/baseTaskOperator.ts
+++ b/src/operators/baseTaskOperator.ts
@@ -1,0 +1,134 @@
+import axios, { AxiosResponse } from 'axios';
+import { BASE_URL_API } from '@/constants';
+
+/**
+ * Filter shape accepted by every `*Operator.tasks(filter)` call.
+ *
+ * Concrete operators may extend this with service-specific keys
+ * (e.g. Seedance / Suno add `type`). Unknown keys with `undefined`
+ * value are simply omitted from the request body.
+ */
+export interface ITaskListFilter {
+  ids?: string[];
+  applicationId?: string;
+  userId?: string;
+  limit?: number;
+  offset?: number;
+  createdAtMax?: number;
+  createdAtMin?: number;
+  /**
+   * Service-specific filter keys may be passed via this index.
+   * Camel-case keys are auto-converted to snake_case in the request body.
+   */
+  [key: string]: unknown;
+}
+
+/** Constant request headers shared by every per-service task operator. */
+const COMMON_HEADERS = {
+  accept: 'application/json',
+  'content-type': 'application/json'
+};
+
+/** Headers specific to retrieve / retrieve_batch endpoints. */
+const TASK_HEADERS = {
+  ...COMMON_HEADERS,
+  'x-record-exempt': 'true'
+};
+
+/** Headers specific to generate endpoints. */
+const GENERATE_HEADERS = {
+  authorization: '',
+  'content-type': 'application/json',
+  accept: 'application/x-ndjson'
+};
+
+const camelToSnake = (s: string): string => s.replace(/[A-Z]/g, (c) => `_${c.toLowerCase()}`);
+
+/**
+ * Convert a camelCase filter object into a snake_case request body,
+ * dropping `undefined`, `null`, and empty-string values. The hand-rolled
+ * operators this replaces used a `filter.x ? { x } : {}` truthy check
+ * for string/array fields (which dropped `''`/`null`/`undefined` but
+ * KEPT `[]` since `Boolean([]) === true`) and a `!== undefined` check
+ * for numeric fields (which preserved `0`). Dropping `undefined`,
+ * `null`, and `''` reproduces both behaviors exactly: empty arrays are
+ * still sent, every numeric `0` is preserved, and string/array nullish
+ * values are still dropped.
+ */
+const toRequestBody = (filter: Record<string, unknown>): Record<string, unknown> => {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(filter)) {
+    if (v === undefined || v === null || v === '') continue;
+    out[camelToSnake(k)] = v;
+  }
+  return out;
+};
+
+/**
+ * Generic base for every per-service task operator (luma / seedance / sora /
+ * veo / kling / hailuo / wan / flux / nanobanana / pika / pixverse / etc.).
+ *
+ * Each subclass picks the concrete response/request types and provides the
+ * upstream paths via the constructor:
+ *
+ * ```ts
+ * class LumaOperator extends BaseTaskOperator<
+ *   ILumaGenerateRequest,
+ *   ILumaGenerateResponse,
+ *   ILumaTaskResponse,
+ *   ILumaTasksResponse
+ * > {
+ *   constructor() {
+ *     super({ tasksPath: '/luma/tasks', generatePath: '/luma/videos' });
+ *   }
+ * }
+ * ```
+ *
+ * Behavior of `task()`, `tasks()`, and `generate()` is byte-identical to the
+ * hand-rolled per-service implementations they replace — including request
+ * headers, body shape, and `BASE_URL_API` routing.
+ */
+export class BaseTaskOperator<
+  TGenerateRequest,
+  TGenerateResponse,
+  TTaskResponse,
+  TTasksResponse,
+  TFilter extends ITaskListFilter = ITaskListFilter
+> {
+  protected readonly tasksPath: string;
+  protected readonly generatePath: string;
+
+  constructor(paths: { tasksPath: string; generatePath: string }) {
+    this.tasksPath = paths.tasksPath;
+    this.generatePath = paths.generatePath;
+  }
+
+  async task(id: string, options: { token: string }): Promise<AxiosResponse<TTaskResponse>> {
+    return axios.post(
+      this.tasksPath,
+      { action: 'retrieve', id },
+      {
+        baseURL: BASE_URL_API,
+        headers: { ...TASK_HEADERS, authorization: `Bearer ${options.token}` }
+      }
+    );
+  }
+
+  async tasks(filter: TFilter, options: { token: string }): Promise<AxiosResponse<TTasksResponse>> {
+    return axios.post(
+      this.tasksPath,
+      { action: 'retrieve_batch', ...toRequestBody(filter as Record<string, unknown>) },
+      {
+        baseURL: BASE_URL_API,
+        headers: { ...TASK_HEADERS, authorization: `Bearer ${options.token}` }
+      }
+    );
+  }
+
+  async generate(data: TGenerateRequest, options: { token: string }): Promise<AxiosResponse<TGenerateResponse>> {
+    return axios.post(this.generatePath, data, {
+      baseURL: BASE_URL_API,
+      headers: { ...GENERATE_HEADERS, authorization: `Bearer ${options.token}` }
+    });
+  }
+}

--- a/src/operators/luma.ts
+++ b/src/operators/luma.ts
@@ -1,105 +1,15 @@
-import axios, { AxiosResponse } from 'axios';
 import { ILumaGenerateRequest, ILumaGenerateResponse, ILumaTaskResponse, ILumaTasksResponse } from '@/models';
-import { BASE_URL_API } from '@/constants';
+import { BaseTaskOperator, ITaskListFilter } from './baseTaskOperator';
 
-class LumaOperator {
-  async task(id: string, options: { token: string }): Promise<AxiosResponse<ILumaTaskResponse>> {
-    return await axios.post(
-      `/luma/tasks`,
-      {
-        action: 'retrieve',
-        id: id
-      },
-      {
-        headers: {
-          accept: 'application/json',
-          'content-type': 'application/json',
-          authorization: `Bearer ${options.token}`,
-          'x-record-exempt': 'true'
-        },
-        baseURL: BASE_URL_API
-      }
-    );
-  }
-
-  async tasks(
-    filter: {
-      ids?: string[];
-      applicationId?: string;
-      userId?: string;
-      limit?: number;
-      offset?: number;
-      createdAtMax?: number;
-      createdAtMin?: number;
-    },
-    options: { token: string }
-  ): Promise<AxiosResponse<ILumaTasksResponse>> {
-    return await axios.post(
-      `/luma/tasks`,
-      {
-        action: 'retrieve_batch',
-        ...(filter.ids
-          ? {
-              ids: filter.ids
-            }
-          : {}),
-        ...(filter.applicationId
-          ? {
-              application_id: filter.applicationId
-            }
-          : {}),
-        ...(filter.userId
-          ? {
-              user_id: filter.userId
-            }
-          : {}),
-        ...(filter.limit !== undefined
-          ? {
-              limit: filter.limit
-            }
-          : {}),
-        ...(filter.offset !== undefined
-          ? {
-              offset: filter.offset
-            }
-          : {}),
-        ...(filter.createdAtMax !== undefined
-          ? {
-              created_at_max: filter.createdAtMax
-            }
-          : {}),
-        ...(filter.createdAtMin !== undefined
-          ? {
-              created_at_min: filter.createdAtMin
-            }
-          : {})
-      },
-      {
-        headers: {
-          accept: 'application/json',
-          'content-type': 'application/json',
-          authorization: `Bearer ${options.token}`,
-          'x-record-exempt': 'true'
-        },
-        baseURL: BASE_URL_API
-      }
-    );
-  }
-
-  async generate(
-    data: ILumaGenerateRequest,
-    options: {
-      token: string;
-    }
-  ): Promise<AxiosResponse<ILumaGenerateResponse>> {
-    return await axios.post('/luma/videos', data, {
-      headers: {
-        authorization: `Bearer ${options.token}`,
-        'content-type': 'application/json',
-        accept: 'application/x-ndjson'
-      },
-      baseURL: BASE_URL_API
-    });
+class LumaOperator extends BaseTaskOperator<
+  ILumaGenerateRequest,
+  ILumaGenerateResponse,
+  ILumaTaskResponse,
+  ILumaTasksResponse,
+  ITaskListFilter
+> {
+  constructor() {
+    super({ tasksPath: '/luma/tasks', generatePath: '/luma/videos' });
   }
 }
 


### PR DESCRIPTION
## Summary

Twelve of the eighteen per-service operators (`luma`, `seedance`, `sora`, `veo`, `kling`, `hailuo`, `wan`, `flux`, `nanobanana`, `pika`, `pixverse`, `qrart`) are **byte-identical except for two strings** — the `/<service>/tasks` and `/<service>/<resource>` paths. Each one hand-rolls ~110 lines of axios + header + filter-unrolling boilerplate.

Add a generic `BaseTaskOperator` that encapsulates this once. Migrate **Luma** as a proof of concept; leave the other eleven untouched on this PR so the diff is easy to review.

## What's in `src/operators/baseTaskOperator.ts`

```ts
class BaseTaskOperator<TGenReq, TGenResp, TTaskResp, TTasksResp, TFilter> {
  constructor(paths: { tasksPath: string; generatePath: string });

  task(id, { token })          // -> { action: 'retrieve', id }
  tasks(filter, { token })     // -> { action: 'retrieve_batch', ...filter }
  generate(data, { token })    // -> data
}
```

Headers (`accept`, `content-type`, `authorization`, `x-record-exempt` for the task endpoints; `application/x-ndjson` for generate) and `BASE_URL_API` are wired up internally — same as before.

The filter helper converts `camelCase` → `snake_case` and drops `undefined`, `null`, and `''`. That reproduces the previous hand-rolled semantics **exactly**:

| Original code (per-key) | New helper |
|---|---|
| `filter.ids ? { ids } : {}` (truthy check) | drops `undefined`, `null`, `''`; **keeps `[]`** because `Boolean([]) === true` |
| `filter.userId ? { user_id } : {}` (truthy) | drops `undefined`, `null`, `''` |
| `filter.limit !== undefined ? { limit } : {}` | drops `undefined` only — `0` is preserved |

## Migrated: `src/operators/luma.ts` (106 → 16 lines)

```ts
class LumaOperator extends BaseTaskOperator<
  ILumaGenerateRequest, ILumaGenerateResponse,
  ILumaTaskResponse, ILumaTasksResponse, ITaskListFilter
> {
  constructor() {
    super({ tasksPath: '/luma/tasks', generatePath: '/luma/videos' });
  }
}
export const lumaOperator = new LumaOperator();
```

## Verification

### Equivalence test (9 cases, including edge cases)

```
{ userId: 'u1', createdAtMin: 1700000000, createdAtMax: 1700100000 }  ✓
{ userId: undefined, createdAtMin: 0 }            ← 0 preserved        ✓
{ ids: ['a','b'], applicationId: 'app1' }                              ✓
{ ids: [] }                ← kept (truthy)                             ✓
{ applicationId: '' }      ← dropped                                   ✓
{ applicationId: null }    ← dropped                                   ✓
{ limit: 10, offset: 0 }   ← 0 preserved                               ✓
{ limit: 0, offset: undefined }                                        ✓
{}                                                                     ✓

9 cases, 0 mismatches
```

### Build / lint

- `npm run build` (web surface) ✅ passes
- Lint failures shown in CI are pre-existing on `main` (`NotFound.vue`, `kling/capabilities.ts`, plus the auto-translate PR #608 fallout) — none touch files this PR modifies.

## Stats

| | |
|---|---|
| Lines removed (luma.ts) | 100 |
| Lines added (luma.ts) | 10 |
| Lines added (baseTaskOperator.ts) | 134 |
| **Net this PR** | **+44 lines** |
| **Per-service savings going forward** | **~95 lines / operator** |
| **Estimated savings if all 11 remaining services migrate** | **~1,000 lines** |

## Risk

Low. The base class produces functionally identical request bodies (proven by the equivalence test) and uses the same `BASE_URL_API`, headers, and HTTP verb. Behavior is preserved; only the location of the code changes.

## Why land this incrementally instead of migrating everything in one PR

1. Reviewable. A 1,200-line refactor PR is hard to merge cleanly when other Nexior PRs are in flight (Suno/Producer worktrees in particular touch their own operators).
2. Bisectable. If a regression is introduced for any one service, only that service's PR needs reverting — not the whole batch.
3. Each follow-up migration is mechanical and can be done in <15 minutes per operator (subclass declaration + exported instance). Future PRs can include 2-3 services at a time as those services are touched for other reasons.

The base class is intentionally generic over the request/response types so each subclass keeps its own typed contract — there is no loss of static safety from this refactor.
