### PR TITLE
fix(chat): re-fetch conversations once credential token arrives

### DIFF
--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -206,6 +206,17 @@ export default defineComponent({
       this.$store.commit('chat/setConversations', []);
       await this.$store.dispatch('chat/getConversations');
     },
+    // First-load race: Main.vue creates the credential asynchronously,
+    // in parallel with this component's mounted() hook. If credential
+    // isn't ready when onGetConversations() fires, the action bails
+    // (no token → empty list, status=Error) and the side panel stays
+    // empty until the user manually interacts. Re-dispatch once the
+    // token finally lands.
+    async 'credential.token'(val: string | undefined) {
+      if (!val) return;
+      if (this.$store.state.chat.status.getConversations === Status.Success) return;
+      await this.$store.dispatch('chat/getConversations');
+    },
     async conversationId(val: string | undefined) {
       console.debug('conversationId changed', val);
       // URL is the source of truth: load (or reset) the conversation


### PR DESCRIPTION
## Symptom

On the first cold load after login at `/chatgpt/conversations` (or any other chat group), the side panel sometimes shows no conversations even though the server has them. Refreshing or interacting with the UI usually makes them appear.

## Cause

Race between `Main.vue` and the routed `Conversation.vue`:

1. `Main.vue` mounts and calls `initialize()`, which fetches global + individual applications and then dispatches `chat/setApplication` → which (re)creates the credential. All async.
2. `Conversation.vue` mounts in parallel. Its `mounted()` runs:
   ```ts
   await this.onGetService();
   await this.onGetApplication();   // only fetches the apps list — does NOT pick
                                    // the current application/credential; that's
                                    // Main.vue's job
   await this.onGetConversations(); // requires state.credential.token
   ```
3. If Main.vue's credential creation hasn't completed by step 3, `getConversations` bails out:
   ```ts
   if (!token || !modelGroup) {
     state.status.getConversations = Status.Error;
     commit('setConversations', []);
     return [];
   }
   ```
4. Nothing re-triggers the fetch. The existing `modelGroup` watcher only fires when the group *changes*, which doesn't happen on a fresh load (vuex-persistedstate restores the same value).

## Fix

Add a watcher on `credential.token` that re-dispatches `chat/getConversations` once the token transitions from undefined → truthy, unless the fetch already succeeded.

Idempotent on warm loads (the previously cached token doesn't change → watcher doesn't fire).

## Test plan

- Hard-refresh `/chatgpt/conversations` after login → side panel should populate without manual interaction.
- Same for the other chat groups (`/claude`, `/gemini`, `/grok`, `/deepseek`, `/kimi`) — they all use this same component.
- Switching model groups still refetches via the existing `modelGroup` watcher.

## Reported on

Preview deployment of `feat/ask-user-question-wizard` (https://feat-ask-user-question-wizard-nexior.plain-river-2dfc.workers.dev/chatgpt/conversations) — but the bug exists on `main`. After this lands, the wizard branch can pull it in.
