### PR TITLE
fix(suno): clamp song style description to 2 lines

### DIFF
--- a/change/@acedatacloud-nexior-fix-suno-style-clamp.json
+++ b/change/@acedatacloud-nexior-fix-suno-style-clamp.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(suno): clamp song style description to 2 lines in the recent panel so long descriptions no longer dominate the list",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/suno/task/Preview.vue
+++ b/src/components/suno/task/Preview.vue
@@ -889,6 +889,11 @@ export default defineComponent({
         white-space: normal;
         word-break: break-word;
         overflow-wrap: anywhere;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
       .progress-row {
         display: flex;


### PR DESCRIPTION
## What

Limit the song description () under each title in the Suno song list to **2 lines** with ellipsis instead of letting it expand to 5+ lines and dominate the recent panel.

## Why

In  →  the `.style` paragraph had no line clamp. Long descriptions made each row uncomfortably tall and the list looked cluttered.

## How

Added `-webkit-line-clamp: 2` (with the standard `-webkit-box` + `-webkit-box-orient: vertical` + `overflow: hidden` combo) to the `.info .style` rule in [src/components/suno/task/Preview.vue](src/components/suno/task/Preview.vue).

## Scope

CSS-only, no logic changes. Title row, edit icon, progress bar, and download/menu buttons are untouched.