### PR TITLE
feat(suno): use el-tabs for Simple/Custom mode switcher

### DIFF
--- a/src/components/suno/ConfigPanel.vue
+++ b/src/components/suno/ConfigPanel.vue
@@ -1,22 +1,42 @@
 <template>
   <div class="flex flex-col h-full">
     <div class="flex-1 overflow-y-auto p-5">
-      <type-selector class="mb-4" />
-      <upload-audio class="mb-4" />
-      <prompt-input v-if="!config?.custom" class="mb-4" />
-      <lyric-input v-if="config?.custom && !config.instrumental" class="mb-4" />
-      <style-input v-if="config?.custom" class="mb-4" />
-      <title-input v-if="config?.custom" class="mb-4" />
-      <vocal-gender-selector v-if="config?.custom && !config.instrumental && supportsVocalGender" class="mb-4" />
-      <persona-input v-if="config?.custom && supportsPersona" class="mb-4" />
-      <extend-from-input v-if="config?.action === 'extend'" class="mb-4" />
-      <cover-from-input v-if="config?.action === 'cover'" class="mb-4" />
-      <replace-section-input v-if="config?.action === 'replace_section'" class="mb-4" />
-      <overpainting-input v-if="config?.action === 'overpainting'" class="mb-4" />
-      <underpainting-input v-if="config?.action === 'underpainting'" class="mb-4" />
-      <samples-input v-if="config?.action === 'samples'" class="mb-4" />
-      <adjust-speed-input v-if="config?.action === 'adjust_speed'" class="mb-4" />
-      <advanced-params class="mb-4" />
+      <el-tabs v-model="mode" class="suno-mode-tabs" stretch>
+        <el-tab-pane :label="$t('suno.mode.simple')" name="simple">
+          <div class="pt-2 px-1">
+            <type-selector class="mb-4" />
+            <upload-audio class="mb-4" />
+            <prompt-input class="mb-4" />
+            <extend-from-input v-if="config?.action === 'extend'" class="mb-4" />
+            <cover-from-input v-if="config?.action === 'cover'" class="mb-4" />
+            <replace-section-input v-if="config?.action === 'replace_section'" class="mb-4" />
+            <overpainting-input v-if="config?.action === 'overpainting'" class="mb-4" />
+            <underpainting-input v-if="config?.action === 'underpainting'" class="mb-4" />
+            <samples-input v-if="config?.action === 'samples'" class="mb-4" />
+            <adjust-speed-input v-if="config?.action === 'adjust_speed'" class="mb-4" />
+            <advanced-params class="mb-4" />
+          </div>
+        </el-tab-pane>
+        <el-tab-pane :label="$t('suno.mode.custom')" name="custom">
+          <div class="pt-2 px-1">
+            <type-selector class="mb-4" />
+            <upload-audio class="mb-4" />
+            <lyric-input v-if="!config?.instrumental" class="mb-4" />
+            <style-input class="mb-4" />
+            <title-input class="mb-4" />
+            <vocal-gender-selector v-if="!config?.instrumental && supportsVocalGender" class="mb-4" />
+            <persona-input v-if="supportsPersona" class="mb-4" />
+            <extend-from-input v-if="config?.action === 'extend'" class="mb-4" />
+            <cover-from-input v-if="config?.action === 'cover'" class="mb-4" />
+            <replace-section-input v-if="config?.action === 'replace_section'" class="mb-4" />
+            <overpainting-input v-if="config?.action === 'overpainting'" class="mb-4" />
+            <underpainting-input v-if="config?.action === 'underpainting'" class="mb-4" />
+            <samples-input v-if="config?.action === 'samples'" class="mb-4" />
+            <adjust-speed-input v-if="config?.action === 'adjust_speed'" class="mb-4" />
+            <advanced-params class="mb-4" />
+          </div>
+        </el-tab-pane>
+      </el-tabs>
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5 gap-2">
       <consumption :value="consumption" :service="service" />
@@ -36,7 +56,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElButton } from 'element-plus';
+import { ElButton, ElTabs, ElTabPane } from 'element-plus';
 import TypeSelector from './config/TypeSelector.vue';
 import UploadAudio from './config/UploadAudio.vue';
 import PromptInput from './config/PromptInput.vue';
@@ -78,12 +98,25 @@ export default defineComponent({
     PersonaInput,
     FontAwesomeIcon,
     ElButton,
+    ElTabs,
+    ElTabPane,
     Consumption
   },
   emits: ['generate'],
   computed: {
     config() {
       return this.$store.state.suno?.config;
+    },
+    mode: {
+      get(): 'simple' | 'custom' {
+        return this.$store.state.suno?.config?.custom ? 'custom' : 'simple';
+      },
+      set(val: 'simple' | 'custom') {
+        this.$store.commit('suno/setConfig', {
+          ...this.$store.state.suno?.config,
+          custom: val === 'custom'
+        });
+      }
     },
     consumption() {
       return getConsumption(this.config, this.service?.cost);

--- a/src/components/suno/config/TypeSelector.vue
+++ b/src/components/suno/config/TypeSelector.vue
@@ -1,15 +1,5 @@
 <template>
   <div>
-    <!-- Creation Mode Tabs -->
-    <div class="mode-tabs mb-3">
-      <button class="mode-tab" :class="{ active: !custom }" @click="custom = false">
-        {{ $t('suno.mode.simple') }}
-      </button>
-      <button class="mode-tab" :class="{ active: custom }" @click="custom = true">
-        {{ $t('suno.mode.custom') }}
-      </button>
-    </div>
-
     <!-- Model Selection -->
     <div class="mb-3">
       <div class="flex items-center mb-1">
@@ -158,37 +148,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-.mode-tabs {
-  display: flex;
-  gap: 4px;
-  background: var(--el-fill-color-light);
-  border-radius: 8px;
-  padding: 3px;
-}
-
-.mode-tab {
-  flex: 1;
-  padding: 6px 12px;
-  border: none;
-  border-radius: 6px;
-  background: transparent;
-  color: var(--el-text-color-secondary);
-  font-size: 13px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.2s;
-
-  &.active {
-    background: var(--el-bg-color);
-    color: var(--el-text-color-primary);
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-  }
-
-  &:hover:not(.active) {
-    color: var(--el-text-color-primary);
-  }
-}
-
 .model-option {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## What

In the Suno page's left config panel, replace the hand-rolled `Simple / Custom` mode buttons inside `TypeSelector` with an `el-tabs` component at the top of `ConfigPanel`, matching the same pattern Midjourney uses (`tab.images` / `tab.videos`).

## Why

Per design feedback: 'neixor，suno 的话…左侧上方，要不用 el-tab？和 Midjourney 类似的那种？'

The previous custom buttons reimplemented tab styling with bespoke SCSS. Switching to `el-tabs` gives:

- visual consistency with Midjourney's config panel
- automatic theming via Element Plus tokens (no custom hover/active styles)
- cleaner separation: each tab pane only renders fields relevant to that mode

## How

- [`Nexior/src/components/suno/ConfigPanel.vue`](https://github.com/AceDataCloud/Nexior/blob/feat/suno-config-tabs/src/components/suno/ConfigPanel.vue) — wrap the form area in `<el-tabs v-model="mode" stretch>` with two `el-tab-pane` (Simple / Custom). Add a `mode` computed (`'simple' | 'custom'`) that proxies the existing `config.custom` flag, so the store shape and downstream behavior are unchanged.
- [`Nexior/src/components/suno/config/TypeSelector.vue`](https://github.com/AceDataCloud/Nexior/blob/feat/suno-config-tabs/src/components/suno/config/TypeSelector.vue) — remove the custom mode-tab buttons and their SCSS. `TypeSelector` now only owns the model picker and the (custom-only) instrumental switch.

i18n keys `suno.mode.simple` / `suno.mode.custom` already exist for all locales — no locale changes needed.

## Test

- preview deploy: https://feat-ask-user-question-wizard-nexior.plain-river-2dfc.workers.dev/suno (visual reference for the previous version)
- after merge, the Suno page's left config panel will show the same tab-bar shape as the Midjourney page.
