### PR TITLE
fix(suno): polish config panel sizing and persona button

### DIFF
--- a/change/@acedatacloud-nexior-f8acee0e-c642-4764-a31f-5aac2ac55e90.json
+++ b/change/@acedatacloud-nexior-f8acee0e-c642-4764-a31f-5aac2ac55e90.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Suno UI polish: shrink radio groups (Vocal Gender, Variation Type, Lyrics Mode) and Advanced Parameters inputs; restore visibility of Manage Voices button; align Artist Style select sizing; reduce lyrics textarea font size",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/suno/config/AdvancedParams.vue
+++ b/src/components/suno/config/AdvancedParams.vue
@@ -6,7 +6,7 @@
         <div class="flex items-center mb-1">
           <span class="text-xs font-bold">{{ $t('suno.name.styleNegative') }}</span>
         </div>
-        <el-input v-model="styleNegative" :placeholder="$t('suno.placeholder.styleNegative')" />
+        <el-input v-model="styleNegative" size="small" :placeholder="$t('suno.placeholder.styleNegative')" />
       </div>
 
       <!-- Lyric Prompt (auto-generate lyrics) -->
@@ -14,7 +14,7 @@
         <div class="flex items-center mb-1">
           <span class="text-xs font-bold">{{ $t('suno.name.lyricPrompt') }}</span>
         </div>
-        <el-input v-model="lyricPrompt" :placeholder="$t('suno.placeholder.lyricPrompt')" />
+        <el-input v-model="lyricPrompt" size="small" :placeholder="$t('suno.placeholder.lyricPrompt')" />
       </div>
 
       <!-- Weirdness -->
@@ -40,7 +40,7 @@
         <div class="flex items-center mb-1">
           <span class="text-xs font-bold">{{ $t('suno.name.variationCategory') }}</span>
         </div>
-        <el-radio-group v-model="variationCategory">
+        <el-radio-group v-model="variationCategory" size="small">
           <el-radio-button value="">{{ $t('suno.gender.auto') }}</el-radio-button>
           <el-radio-button value="high">{{ $t('suno.variation.high') }}</el-radio-button>
           <el-radio-button value="low">{{ $t('suno.variation.low') }}</el-radio-button>
@@ -60,7 +60,7 @@
         <div class="flex items-center mb-1">
           <span class="text-xs font-bold">{{ $t('suno.name.lyricsMode') }}</span>
         </div>
-        <el-radio-group v-model="lyricsMode">
+        <el-radio-group v-model="lyricsMode" size="small">
           <el-radio-button value="manual">{{ $t('suno.lyricsMode.manual') }}</el-radio-button>
           <el-radio-button value="auto">{{ $t('suno.lyricsMode.auto') }}</el-radio-button>
         </el-radio-group>

--- a/src/components/suno/config/LyricInput.vue
+++ b/src/components/suno/config/LyricInput.vue
@@ -260,6 +260,7 @@ export default defineComponent({
 .field {
   :deep(.el-textarea__inner) {
     font-family: monospace;
+    font-size: 12.5px;
     line-height: 1.6;
   }
 }

--- a/src/components/suno/config/PersonaInput.vue
+++ b/src/components/suno/config/PersonaInput.vue
@@ -5,14 +5,13 @@
         <h2 class="text-sm font-bold m-0">{{ $t('suno.name.persona') }}</h2>
         <info-icon :content="$t('suno.description.persona')" />
       </div>
-      <el-button type="primary" size="small" text @click="showManager = true">
+      <el-button size="small" round @click="showManager = true">
         <font-awesome-icon icon="fa-solid fa-microphone" class="mr-1" />
         {{ $t('suno.voice.manage') }}
       </el-button>
     </div>
     <el-select
       v-model="personaId"
-      size="small"
       :placeholder="$t('suno.placeholder.personaId')"
       clearable
       filterable

--- a/src/components/suno/config/VocalGenderSelector.vue
+++ b/src/components/suno/config/VocalGenderSelector.vue
@@ -4,7 +4,7 @@
       <span class="text-sm font-bold">{{ $t('suno.name.vocalGender') }}</span>
       <info-icon :content="$t('suno.description.vocalGender')" />
     </div>
-    <el-radio-group v-model="vocalGender">
+    <el-radio-group v-model="vocalGender" size="small">
       <el-radio-button value="">{{ $t('suno.gender.auto') }}</el-radio-button>
       <el-radio-button value="f">{{ $t('suno.gender.female') }}</el-radio-button>
       <el-radio-button value="m">{{ $t('suno.gender.male') }}</el-radio-button>


### PR DESCRIPTION
Tightens Suno config panel UI to match the rest of Nexior's compact look:

- Add `size="small"` to **Vocal Gender**, **Variation Type**, **Lyrics Mode** `el-radio-group`s so the buttons stop wrapping onto multiple lines.
- Add `size="small"` to **Style Negative** and **Lyric Prompt** inputs in Advanced Parameters for visual consistency with the surrounding sliders.
- Restore visibility of the **Manage Voices** button in Artist Style: drop `type="primary" text` (the dim/transparent treatment was unreadable on the dark theme), use a regular small rounded button instead.
- Align Artist Style `el-select` size with sibling inputs (`Title`, `Style`) by removing the inconsistent `size="small"`.
- Shrink the **Lyrics** textarea font from default 14px to 12.5px so multi-section lyrics no longer dominate the panel; the expanded fullscreen editor keeps 14px.

No behavior changes.