### PR TITLE
fix(suno): unify section headers and tighten lyrics font

### DIFF
--- a/change/@acedatacloud-nexior-a5f7ff77-ef24-472f-95a0-8ce1fd5af3b9.json
+++ b/change/@acedatacloud-nexior-a5f7ff77-ef24-472f-95a0-8ce1fd5af3b9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Suno UI follow-up: drop redundant vocal-gender wrapper margin, switch persona heading to span (match other sections), bump lyrics textarea font 12.5px -> 13px",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/suno/config/LyricInput.vue
+++ b/src/components/suno/config/LyricInput.vue
@@ -260,7 +260,7 @@ export default defineComponent({
 .field {
   :deep(.el-textarea__inner) {
     font-family: monospace;
-    font-size: 12.5px;
+    font-size: 13px;
     line-height: 1.6;
   }
 }

--- a/src/components/suno/config/PersonaInput.vue
+++ b/src/components/suno/config/PersonaInput.vue
@@ -2,7 +2,7 @@
   <div class="field">
     <div class="flex items-center justify-between mb-2">
       <div class="flex items-center">
-        <h2 class="text-sm font-bold m-0">{{ $t('suno.name.persona') }}</h2>
+        <span class="text-sm font-bold">{{ $t('suno.name.persona') }}</span>
         <info-icon :content="$t('suno.description.persona')" />
       </div>
       <el-button size="small" round @click="showManager = true">

--- a/src/components/suno/config/VocalGenderSelector.vue
+++ b/src/components/suno/config/VocalGenderSelector.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="mb-2">
+  <div>
     <div class="flex items-center mb-1">
       <span class="text-sm font-bold">{{ $t('suno.name.vocalGender') }}</span>
       <info-icon :content="$t('suno.description.vocalGender')" />


### PR DESCRIPTION
Follow-up polish on top of #642.

- **`VocalGenderSelector.vue`** — drop the outer `mb-2` wrapper; the panel-level `mb-4` already provides spacing, the extra margin caused the Vocal Gender block to sit slightly farther from its neighbors than every other section.
- **`PersonaInput.vue`** — switch the section title from `<h2 class="... m-0">` to a plain `<span class="text-sm font-bold">` so it matches every other section heading (Vocal Gender, Style, Title, Lyrics, etc.). Even with `m-0`, the `<h2>` still picked up user-agent baseline differences that made the row sit slightly higher than the sibling sections.
- **`LyricInput.vue`** — bump the in-panel lyrics textarea font from `12.5px` -> `13px`. 12.5 was a hair too tight; 13 reads cleanly at default zoom while still being smaller than the default 14px so multi-section lyrics don't dominate the panel.

No behavior changes.