### PR TITLE
fix(midjourney): switch to Video Generation tab on Extend click

### DIFF
--- a/src/components/midjourney/tasks/TaskItem.vue
+++ b/src/components/midjourney/tasks/TaskItem.vue
@@ -451,7 +451,8 @@ export default defineComponent({
         // @ts-ignore
         video_url: response.video_urls?.[0],
         action: 'extend',
-        active_tab: 'video',
+        // switch ConfigPanel to the Video Generation tab so the extend form is visible
+        type: 'videos',
         is_videos: true
       });
     },


### PR DESCRIPTION
## Summary

On https://studio.acedata.cloud/midjourney, when a user is on the **Image Generation** (or **Describe**) tab and clicks **Extend** on a video task, the ConfigPanel does not switch to the **Video Generation** tab. The store gets the right `action: 'extend'` and `video_id` / `video_url` set, but the form for editing the extend request stays hidden because it lives inside the `videos` tab pane.

## Root cause

[`TaskItem.vue` `onExtend`](https://github.com/AceDataCloud/Nexior/blob/main/src/components/midjourney/tasks/TaskItem.vue) was committing a stray `active_tab: 'video'` field to the midjourney config. Nothing reads `active_tab` — the ConfigPanel tab is bound to `config.type` with allowed values `'imagine' | 'videos' | 'describe'` (see [`models/midjourney.ts`](https://github.com/AceDataCloud/Nexior/blob/main/src/models/midjourney.ts#L26) and [`ConfigPanel.vue` line 122–133](https://github.com/AceDataCloud/Nexior/blob/main/src/components/midjourney/ConfigPanel.vue#L122-L133)).

So the field name (`active_tab` vs `type`) **and** the value (`'video'` vs `'videos'`) were both wrong — the tab simply never moved.

## Fix

Replace `active_tab: 'video'` with `type: 'videos'`. `is_videos: true` is kept (legacy field, unrelated to tab routing). One-line behavioral change.

```diff
-        active_tab: 'video',
+        // switch ConfigPanel to the Video Generation tab so the extend form is visible
+        type: 'videos',
         is_videos: true
```

## Verification

After this change, clicking **Extend** on a Midjourney video task while on any other tab now switches the ConfigPanel to **Video Generation**, populates the extend-from-video field, and shows the **Extend** button — the flow the user expected.