### PR TITLE
fix(midjourney): drop conflicting --version / --hd when niji model is selected

### DIFF
--- a/src/components/midjourney/ConfigPanel.vue
+++ b/src/components/midjourney/ConfigPanel.vue
@@ -9,8 +9,8 @@
             <reference-image class="mb-2" />
             <ratio-selector class="mb-4" />
             <quality-selector class="mb-4" />
-            <version-selector class="mb-4" />
-            <hd-selector v-if="isV8" class="mb-4" />
+            <version-selector v-if="!isNiji" class="mb-4" />
+            <hd-selector v-if="isV8 && !isNiji" class="mb-4" />
             <elements-selector class="mb-2" />
             <advanced-selector class="mb-2" />
             <div v-show="config?.advanced">
@@ -118,6 +118,9 @@ export default defineComponent({
     },
     isV8(): boolean {
       return this.config?.version === '8';
+    },
+    isNiji(): boolean {
+      return !!this.config?.model?.includes('niji');
     },
     type: {
       get() {

--- a/src/pages/midjourney/Index.vue
+++ b/src/pages/midjourney/Index.vue
@@ -91,10 +91,12 @@ export default defineComponent({
       if (this.config.elements && this.config.elements.length > 0) {
         content += ',' + this.config.elements.map((item) => item.value).join(',');
       }
+      const isNiji = this.config?.model?.includes('niji');
       if (this.config?.model && !content.includes(`--${this.config.model}`)) {
         content += ` --${this.config.model}`;
       }
-      if (this.config?.version && !content.includes(`--version `) && !content.includes(`--v `)) {
+      // niji models carry their own version (e.g. `niji 5`) and reject --version
+      if (!isNiji && this.config?.version && !content.includes(`--version `) && !content.includes(`--v `)) {
         content += ` --version ${this.config.version}`;
       }
       if (this.config?.chaos && this.config?.advanced && !content.includes(`--chaos `)) {
@@ -148,8 +150,8 @@ export default defineComponent({
       if (this.config?.style && this.config?.advanced && !content.includes(`--style`)) {
         content += ` --style ${this.config?.style}`;
       }
-      // V8 --hd parameter
-      if (this.config?.hd && !content.includes(`--hd`)) {
+      // V8 --hd parameter (not supported by niji models)
+      if (!isNiji && this.config?.hd && !content.includes(`--hd`)) {
         content += ` --hd`;
       }
       // remove `--fast`, `--relax`, `--turbo`


### PR DESCRIPTION
## Bug

Reported via failed task `60432e83-…`:

> `/imagine 变成紫色 ... --niji 5 --version 8 --chaos 54 --weird 643 --hd (fast)`
> → `invalid_parameter: The prompt word format is incorrect`

Midjourney's parser rejects a prompt that carries **both** `--niji <n>` *and* `--version <m>` because they are mutually exclusive model flags. `--hd` is also unsupported by niji. Today the Nexior UI lets a user mix them freely.

## Root cause

`src/pages/midjourney/Index.vue` builds `finalPrompt` by appending each `config.*` field independently:

```ts
if (this.config?.model)   content += ` --${this.config.model}`;        // e.g. --niji 5
if (this.config?.version) content += ` --version ${this.config.version}`; // e.g. --version 8
...
if (this.config?.hd)      content += ` --hd`;
```

`ModelSelector`, `VersionSelector` and `HdSelector` are independent — switching to niji never clears `config.version` or `config.hd`, and `ConfigPanel.vue` always renders the version / hd selectors. So a user can pick `niji 5` plus `version 8` plus `HD` and the frontend cheerfully ships an invalid prompt to the upstream.

## Fix

1. **Prompt builder** (`Index.vue`) — when `config.model` contains `'niji'`, skip `--version` and `--hd` entirely. This catches both new submissions and any existing persisted state.
2. **UI guardrail** (`ConfigPanel.vue`) — hide `VersionSelector` / `HdSelector` when niji is the active model (`v-if="!isNiji"` / `v-if="isV8 && !isNiji"`). Users no longer see options that would produce an invalid combo.

No store changes — `config.version` / `config.hd` stay around so they reappear unchanged once the user switches back from niji to the general model.

## Verification

- `vue-tsc --noEmit` clean.
- `eslint src/pages/midjourney/Index.vue src/components/midjourney/ConfigPanel.vue` clean.
- Manual prompt-build trace with `config = { model: 'niji 5', version: '8', hd: true, chaos: 54, weird: 643, prompt: '变成紫色', advanced: true }` now yields `变成紫色 --niji 5 --chaos 54 --weird 643` (no `--version`, no `--hd`).
