### PR TITLE
feat(openai-image): per-model size dropdown + custom size for gpt-image-2

### DIFF
--- a/src/components/openaiimage/config/ResolutionSelector.vue
+++ b/src/components/openaiimage/config/ResolutionSelector.vue
@@ -84,6 +84,7 @@ interface IGroup {
 }
 
 interface IData {
+  customMode: boolean;
   customWidth: number;
   customHeight: number;
 }
@@ -107,6 +108,7 @@ export default defineComponent({
   },
   data(): IData {
     return {
+      customMode: false,
       customWidth: 1024,
       customHeight: 1024
     };
@@ -136,13 +138,13 @@ export default defineComponent({
     },
     useCustom: {
       get(): boolean {
-        if (!this.customSupported) return false;
-        const size = this.storedSize;
-        if (!size) return false;
-        return !this.presets.includes(size);
+        return this.customSupported && this.customMode;
       },
       set(val: boolean) {
+        if (val && !this.customSupported) return;
+        this.customMode = val;
         if (val) {
+          if (this.customError) return;
           this.commitSize(`${this.customWidth}x${this.customHeight}`);
         } else {
           const fallback = this.presets[0] ?? OPENAIIMAGE_SIZE_1024;
@@ -157,6 +159,7 @@ export default defineComponent({
         return this.presets[0] ?? OPENAIIMAGE_SIZE_1024;
       },
       set(val: string) {
+        this.customMode = false;
         this.commitSize(val);
       }
     },
@@ -196,24 +199,26 @@ export default defineComponent({
     model: {
       immediate: false,
       handler() {
-        // When switching to a model whose preset list doesn't include the
-        // current size and which doesn't support custom, snap to the model's
-        // first preset to avoid sending a size the model rejects.
-        const size = this.storedSize;
-        if (!size) {
-          this.commitSize(this.presets[0] ?? OPENAIIMAGE_SIZE_1024);
-          return;
-        }
-        if (this.presets.includes(size)) return;
-        if (this.customSupported && parseSize(size)) {
-          const parsed = parseSize(size);
-          if (parsed) {
-            this.customWidth = parsed.w;
-            this.customHeight = parsed.h;
+        // Reset custom mode when switching to a model that doesn't support
+        // custom sizes; snap stored size to a valid preset if needed.
+        if (!this.customSupported) {
+          this.customMode = false;
+          const size = this.storedSize;
+          if (!size || !this.presets.includes(size)) {
+            this.commitSize(this.presets[0] ?? OPENAIIMAGE_SIZE_1024);
           }
           return;
         }
-        this.commitSize(this.presets[0] ?? OPENAIIMAGE_SIZE_1024);
+        // Custom-supported model: keep customMode if active and current
+        // dims are valid; otherwise fall back to first preset.
+        const size = this.storedSize;
+        if (this.customMode && !this.customError) {
+          this.commitSize(`${this.customWidth}x${this.customHeight}`);
+          return;
+        }
+        if (!size || !this.presets.includes(size)) {
+          this.commitSize(this.presets[0] ?? OPENAIIMAGE_SIZE_1024);
+        }
       }
     },
     customWidth() {
@@ -228,8 +233,10 @@ export default defineComponent({
       this.commitSize(this.presets[0] ?? OPENAIIMAGE_SIZE_1024);
       return;
     }
+    // Re-hydrate custom mode if the stored size came from a previous custom entry.
     const parsed = parseSize(this.storedSize);
-    if (parsed && !this.presets.includes(this.storedSize) && this.customSupported) {
+    if (parsed && this.customSupported && !this.presets.includes(this.storedSize)) {
+      this.customMode = true;
       this.customWidth = parsed.w;
       this.customHeight = parsed.h;
     }

--- a/src/components/openaiimage/config/ResolutionSelector.vue
+++ b/src/components/openaiimage/config/ResolutionSelector.vue
@@ -1,75 +1,262 @@
 <template>
-  <div class="field">
-    <div class="label">
-      <div class="box">
-        <h2 class="title font-bold">{{ $t('openaiimage.name.size') }}</h2>
-        <info-icon :content="$t('openaiimage.description.size')" class="info" />
+  <div class="resolution">
+    <div class="field">
+      <div class="label">
+        <div class="box">
+          <h2 class="title font-bold">{{ $t('openaiimage.name.size') }}</h2>
+          <info-icon :content="$t('openaiimage.description.size')" class="info" />
+        </div>
       </div>
+      <el-select
+        v-model="presetValue"
+        class="value"
+        :placeholder="$t('openaiimage.placeholder.select')"
+        :disabled="useCustom"
+      >
+        <el-option-group v-for="group in presetGroups" :key="group.label" :label="group.label">
+          <el-option v-for="item in group.options" :key="item" :label="item" :value="item" />
+        </el-option-group>
+      </el-select>
     </div>
-    <el-select v-model="value" class="value" :placeholder="$t('openaiimage.placeholder.select')">
-      <el-option v-for="item in options" :key="item.value" :label="item.label" :value="item.value" />
-    </el-select>
+    <template v-if="customSupported">
+      <div class="field custom-toggle">
+        <div class="label">
+          <div class="box">
+            <h2 class="title font-bold">{{ $t('openaiimage.name.customSize') }}</h2>
+            <info-icon :content="$t('openaiimage.description.customSize')" class="info" />
+          </div>
+        </div>
+        <el-switch v-model="useCustom" class="value-switch" />
+      </div>
+      <div v-if="useCustom" class="custom-inputs">
+        <div class="row">
+          <span class="row-label">{{ $t('openaiimage.name.width') }}</span>
+          <el-input-number
+            v-model="customWidth"
+            class="row-input"
+            :min="minSide"
+            :max="maxSide"
+            :step="multiple"
+            :step-strictly="true"
+            controls-position="right"
+          />
+        </div>
+        <div class="row">
+          <span class="row-label">{{ $t('openaiimage.name.height') }}</span>
+          <el-input-number
+            v-model="customHeight"
+            class="row-input"
+            :min="minSide"
+            :max="maxSide"
+            :step="multiple"
+            :step-strictly="true"
+            controls-position="right"
+          />
+        </div>
+        <div v-if="customError" class="error">{{ customError }}</div>
+      </div>
+    </template>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElSelect, ElOption } from 'element-plus';
+import { ElSelect, ElOption, ElOptionGroup, ElSwitch, ElInputNumber } from 'element-plus';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import {
-  OPENAIIMAGE_DEFAULT_SIZE,
+  OPENAIIMAGE_CUSTOM_SIZE_MAX,
+  OPENAIIMAGE_CUSTOM_SIZE_MAX_PIXELS,
+  OPENAIIMAGE_CUSTOM_SIZE_MIN,
+  OPENAIIMAGE_CUSTOM_SIZE_MODELS,
+  OPENAIIMAGE_CUSTOM_SIZE_MULTIPLE,
+  OPENAIIMAGE_DEFAULT_MODEL,
+  OPENAIIMAGE_MODEL_GPT_IMAGE_2,
+  OPENAIIMAGE_MODEL_SIZES,
   OPENAIIMAGE_SIZE_1024,
-  OPENAIIMAGE_SIZE_1024_1536,
-  OPENAIIMAGE_SIZE_1536_1024
+  OPENAIIMAGE_SIZES_GPT_IMAGE_2_1K,
+  OPENAIIMAGE_SIZES_GPT_IMAGE_2_2K,
+  OPENAIIMAGE_SIZES_GPT_IMAGE_2_4K
 } from '@/constants';
+
+interface IGroup {
+  label: string;
+  options: string[];
+}
+
+interface IData {
+  customWidth: number;
+  customHeight: number;
+}
+
+function parseSize(size: string | undefined): { w: number; h: number } | undefined {
+  if (!size) return undefined;
+  const m = /^(\d+)x(\d+)$/.exec(size);
+  if (!m) return undefined;
+  return { w: Number(m[1]), h: Number(m[2]) };
+}
 
 export default defineComponent({
   name: 'OpenAIImageSizeSelector',
   components: {
     ElSelect,
     ElOption,
+    ElOptionGroup,
+    ElSwitch,
+    ElInputNumber,
     InfoIcon
   },
-  data() {
+  data(): IData {
     return {
-      options: [
-        {
-          value: OPENAIIMAGE_SIZE_1024,
-          label: OPENAIIMAGE_SIZE_1024
-        },
-        {
-          value: OPENAIIMAGE_SIZE_1536_1024,
-          label: OPENAIIMAGE_SIZE_1536_1024
-        },
-        {
-          value: OPENAIIMAGE_SIZE_1024_1536,
-          label: OPENAIIMAGE_SIZE_1024_1536
-        }
-      ]
+      customWidth: 1024,
+      customHeight: 1024
     };
   },
   computed: {
-    value: {
-      get() {
-        return this.$store.state.openaiimage?.config?.size;
+    model(): string {
+      return this.$store.state.openaiimage?.config?.model || OPENAIIMAGE_DEFAULT_MODEL;
+    },
+    storedSize(): string | undefined {
+      return this.$store.state.openaiimage?.config?.size;
+    },
+    customSupported(): boolean {
+      return OPENAIIMAGE_CUSTOM_SIZE_MODELS.includes(this.model);
+    },
+    presets(): string[] {
+      return OPENAIIMAGE_MODEL_SIZES[this.model] ?? OPENAIIMAGE_MODEL_SIZES[OPENAIIMAGE_DEFAULT_MODEL] ?? [];
+    },
+    presetGroups(): IGroup[] {
+      if (this.model === OPENAIIMAGE_MODEL_GPT_IMAGE_2) {
+        return [
+          { label: this.$t('openaiimage.sizeGroup.standard1k'), options: OPENAIIMAGE_SIZES_GPT_IMAGE_2_1K },
+          { label: this.$t('openaiimage.sizeGroup.preset2k'), options: OPENAIIMAGE_SIZES_GPT_IMAGE_2_2K },
+          { label: this.$t('openaiimage.sizeGroup.preset4k'), options: OPENAIIMAGE_SIZES_GPT_IMAGE_2_4K }
+        ];
+      }
+      return [{ label: this.$t('openaiimage.sizeGroup.standard1k'), options: this.presets }];
+    },
+    useCustom: {
+      get(): boolean {
+        if (!this.customSupported) return false;
+        const size = this.storedSize;
+        if (!size) return false;
+        return !this.presets.includes(size);
+      },
+      set(val: boolean) {
+        if (val) {
+          this.commitSize(`${this.customWidth}x${this.customHeight}`);
+        } else {
+          const fallback = this.presets[0] ?? OPENAIIMAGE_SIZE_1024;
+          this.commitSize(fallback);
+        }
+      }
+    },
+    presetValue: {
+      get(): string {
+        const size = this.storedSize;
+        if (size && this.presets.includes(size)) return size;
+        return this.presets[0] ?? OPENAIIMAGE_SIZE_1024;
       },
       set(val: string) {
-        this.$store.commit('openaiimage/setConfig', {
-          ...this.$store.state.openaiimage?.config,
-          size: val
-        });
+        this.commitSize(val);
       }
+    },
+    multiple(): number {
+      return OPENAIIMAGE_CUSTOM_SIZE_MULTIPLE;
+    },
+    minSide(): number {
+      return OPENAIIMAGE_CUSTOM_SIZE_MIN;
+    },
+    maxSide(): number {
+      return OPENAIIMAGE_CUSTOM_SIZE_MAX;
+    },
+    customError(): string {
+      const w = this.customWidth;
+      const h = this.customHeight;
+      if (!Number.isFinite(w) || !Number.isFinite(h) || w <= 0 || h <= 0) {
+        return this.$t('openaiimage.error.customSizePositive') as string;
+      }
+      if (w % this.multiple !== 0 || h % this.multiple !== 0) {
+        return this.$t('openaiimage.error.customSizeMultiple', { multiple: this.multiple }) as string;
+      }
+      if (w < this.minSide || h < this.minSide) {
+        return this.$t('openaiimage.error.customSizeMin', { min: this.minSide }) as string;
+      }
+      if (Math.max(w, h) > this.maxSide) {
+        return this.$t('openaiimage.error.customSizeMax', { max: this.maxSide }) as string;
+      }
+      if (w * h > OPENAIIMAGE_CUSTOM_SIZE_MAX_PIXELS) {
+        return this.$t('openaiimage.error.customSizePixels', {
+          pixels: OPENAIIMAGE_CUSTOM_SIZE_MAX_PIXELS.toLocaleString()
+        }) as string;
+      }
+      return '';
+    }
+  },
+  watch: {
+    model: {
+      immediate: false,
+      handler() {
+        // When switching to a model whose preset list doesn't include the
+        // current size and which doesn't support custom, snap to the model's
+        // first preset to avoid sending a size the model rejects.
+        const size = this.storedSize;
+        if (!size) {
+          this.commitSize(this.presets[0] ?? OPENAIIMAGE_SIZE_1024);
+          return;
+        }
+        if (this.presets.includes(size)) return;
+        if (this.customSupported && parseSize(size)) {
+          const parsed = parseSize(size);
+          if (parsed) {
+            this.customWidth = parsed.w;
+            this.customHeight = parsed.h;
+          }
+          return;
+        }
+        this.commitSize(this.presets[0] ?? OPENAIIMAGE_SIZE_1024);
+      }
+    },
+    customWidth() {
+      this.syncCustomToStore();
+    },
+    customHeight() {
+      this.syncCustomToStore();
     }
   },
   mounted() {
-    if (!this.value) {
-      this.value = OPENAIIMAGE_DEFAULT_SIZE;
+    if (!this.storedSize) {
+      this.commitSize(this.presets[0] ?? OPENAIIMAGE_SIZE_1024);
+      return;
+    }
+    const parsed = parseSize(this.storedSize);
+    if (parsed && !this.presets.includes(this.storedSize) && this.customSupported) {
+      this.customWidth = parsed.w;
+      this.customHeight = parsed.h;
+    }
+  },
+  methods: {
+    commitSize(size: string) {
+      this.$store.commit('openaiimage/setConfig', {
+        ...this.$store.state.openaiimage?.config,
+        size
+      });
+    },
+    syncCustomToStore() {
+      if (!this.useCustom) return;
+      if (this.customError) return;
+      this.commitSize(`${this.customWidth}x${this.customHeight}`);
     }
   }
 });
 </script>
 
 <style lang="scss" scoped>
+.resolution {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
 .field {
   display: flex;
   flex-direction: row;
@@ -99,6 +286,39 @@ export default defineComponent({
 
   .value {
     width: 160px;
+  }
+}
+
+.custom-toggle .value-switch {
+  margin-right: 4px;
+}
+
+.custom-inputs {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-left: 30%;
+
+  .row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+
+    .row-label {
+      font-size: 13px;
+      color: var(--el-text-color-regular);
+    }
+
+    .row-input {
+      width: 160px;
+    }
+  }
+
+  .error {
+    color: var(--el-color-danger);
+    font-size: 12px;
+    margin-top: 2px;
   }
 }
 </style>

--- a/src/constants/openaiimage.ts
+++ b/src/constants/openaiimage.ts
@@ -9,8 +9,91 @@ export const OPENAIIMAGE_MODEL_GPT_IMAGE_2 = 'gpt-image-2';
 
 export const OPENAIIMAGE_DEFAULT_MODEL = OPENAIIMAGE_MODEL_GPT_IMAGE_2;
 
+// Common 1K presets (shared across all models)
 export const OPENAIIMAGE_SIZE_1024 = '1024x1024';
 export const OPENAIIMAGE_SIZE_1536_1024 = '1536x1024';
 export const OPENAIIMAGE_SIZE_1024_1536 = '1024x1536';
 
+// gpt-image-2 extra 1K presets
+export const OPENAIIMAGE_SIZE_1792_1024 = '1792x1024';
+export const OPENAIIMAGE_SIZE_1024_1792 = '1024x1792';
+
+// gpt-image-2 2K presets (billed at "other" 1.5x tier)
+export const OPENAIIMAGE_SIZE_2048_2048 = '2048x2048';
+export const OPENAIIMAGE_SIZE_2048_1536 = '2048x1536';
+export const OPENAIIMAGE_SIZE_1536_2048 = '1536x2048';
+export const OPENAIIMAGE_SIZE_2048_1152 = '2048x1152';
+export const OPENAIIMAGE_SIZE_1152_2048 = '1152x2048';
+
+// gpt-image-2 4K presets (billed at "other" 1.5x tier)
+export const OPENAIIMAGE_SIZE_2880_2880 = '2880x2880';
+export const OPENAIIMAGE_SIZE_3264_2448 = '3264x2448';
+export const OPENAIIMAGE_SIZE_2448_3264 = '2448x3264';
+export const OPENAIIMAGE_SIZE_3840_2160 = '3840x2160';
+export const OPENAIIMAGE_SIZE_2160_3840 = '2160x3840';
+
 export const OPENAIIMAGE_DEFAULT_SIZE = OPENAIIMAGE_SIZE_1024;
+
+// Per-model preset lists. Mirrors the OpenAPI `size` description on
+// `/openai/images/generations` and `/openai/images/edits`.
+export const OPENAIIMAGE_SIZES_GPT_IMAGE_1: string[] = [
+  OPENAIIMAGE_SIZE_1024,
+  OPENAIIMAGE_SIZE_1536_1024,
+  OPENAIIMAGE_SIZE_1024_1536
+];
+
+export const OPENAIIMAGE_SIZES_GPT_IMAGE_15: string[] = [
+  OPENAIIMAGE_SIZE_1024,
+  OPENAIIMAGE_SIZE_1536_1024,
+  OPENAIIMAGE_SIZE_1024_1536
+];
+
+// gpt-image-2 1K group → 0.2 credits/image
+export const OPENAIIMAGE_SIZES_GPT_IMAGE_2_1K: string[] = [
+  OPENAIIMAGE_SIZE_1024,
+  OPENAIIMAGE_SIZE_1536_1024,
+  OPENAIIMAGE_SIZE_1024_1536,
+  OPENAIIMAGE_SIZE_1792_1024,
+  OPENAIIMAGE_SIZE_1024_1792
+];
+
+// gpt-image-2 2K group → 0.3 credits/image (1.5x tier)
+export const OPENAIIMAGE_SIZES_GPT_IMAGE_2_2K: string[] = [
+  OPENAIIMAGE_SIZE_2048_2048,
+  OPENAIIMAGE_SIZE_2048_1536,
+  OPENAIIMAGE_SIZE_1536_2048,
+  OPENAIIMAGE_SIZE_2048_1152,
+  OPENAIIMAGE_SIZE_1152_2048
+];
+
+// gpt-image-2 4K group → 0.3 credits/image (1.5x tier)
+export const OPENAIIMAGE_SIZES_GPT_IMAGE_2_4K: string[] = [
+  OPENAIIMAGE_SIZE_2880_2880,
+  OPENAIIMAGE_SIZE_3264_2448,
+  OPENAIIMAGE_SIZE_2448_3264,
+  OPENAIIMAGE_SIZE_3840_2160,
+  OPENAIIMAGE_SIZE_2160_3840
+];
+
+export const OPENAIIMAGE_SIZES_GPT_IMAGE_2: string[] = [
+  ...OPENAIIMAGE_SIZES_GPT_IMAGE_2_1K,
+  ...OPENAIIMAGE_SIZES_GPT_IMAGE_2_2K,
+  ...OPENAIIMAGE_SIZES_GPT_IMAGE_2_4K
+];
+
+export const OPENAIIMAGE_MODEL_SIZES: Record<string, string[]> = {
+  [OPENAIIMAGE_MODEL_GPT_IMAGE_1]: OPENAIIMAGE_SIZES_GPT_IMAGE_1,
+  [OPENAIIMAGE_MODEL_GPT_IMAGE_15]: OPENAIIMAGE_SIZES_GPT_IMAGE_15,
+  [OPENAIIMAGE_MODEL_GPT_IMAGE_2]: OPENAIIMAGE_SIZES_GPT_IMAGE_2
+};
+
+// Models that allow arbitrary WIDTHxHEIGHT (subject to validation).
+export const OPENAIIMAGE_CUSTOM_SIZE_MODELS: string[] = [OPENAIIMAGE_MODEL_GPT_IMAGE_2];
+
+// Custom-size validation constants for gpt-image-2. Mirrors upstream constraints
+// documented in the OpenAPI `size` description: multiples of 16, longer side
+// ≤ 3840, total pixels ≤ 8,294,400.
+export const OPENAIIMAGE_CUSTOM_SIZE_MULTIPLE = 16;
+export const OPENAIIMAGE_CUSTOM_SIZE_MIN = 256;
+export const OPENAIIMAGE_CUSTOM_SIZE_MAX = 3840;
+export const OPENAIIMAGE_CUSTOM_SIZE_MAX_PIXELS = 8294400;

--- a/src/i18n/en/openaiimage.json
+++ b/src/i18n/en/openaiimage.json
@@ -52,8 +52,56 @@
     "description": "Output image size"
   },
   "description.size": {
-    "message": "Output size for generated images, common values: 1024x1024, 1536x1024, 1024x1536.",
+    "message": "Output image size. Supported values vary by model: gpt-image-1 / gpt-image-1.5 only accept 1024x1024, 1536x1024, 1024x1536. gpt-image-2 additionally supports 1792x1024, 1024x1792 and 2K/4K presets, and allows custom dimensions.",
     "description": "Size description"
+  },
+  "sizeGroup.standard1k": {
+    "message": "1K Standard (base rate)",
+    "description": "Heading for the 1K size group billed at the base rate"
+  },
+  "sizeGroup.preset2k": {
+    "message": "2K Presets (1.5× rate)",
+    "description": "Heading for the 2K size group billed at 1.5×"
+  },
+  "sizeGroup.preset4k": {
+    "message": "4K Presets (1.5× rate)",
+    "description": "Heading for the 4K size group billed at 1.5×"
+  },
+  "name.customSize": {
+    "message": "Custom Size",
+    "description": "Custom-size toggle label"
+  },
+  "description.customSize": {
+    "message": "Enable to set width and height freely (gpt-image-2 only). Each side must be a multiple of 16, the longer side ≤ 3840, and total pixels ≤ 8,294,400. Non-1K standard sizes are billed at 1.5× the base rate.",
+    "description": "Custom-size toggle description"
+  },
+  "name.width": {
+    "message": "Width",
+    "description": "Width input label"
+  },
+  "name.height": {
+    "message": "Height",
+    "description": "Height input label"
+  },
+  "error.customSizePositive": {
+    "message": "Width and height must be positive integers",
+    "description": "Custom-size positive validation"
+  },
+  "error.customSizeMultiple": {
+    "message": "Width and height must be multiples of {multiple}",
+    "description": "Custom-size multiple validation"
+  },
+  "error.customSizeMin": {
+    "message": "Width and height must be at least {min}",
+    "description": "Custom-size minimum validation"
+  },
+  "error.customSizeMax": {
+    "message": "Longer side cannot exceed {max}",
+    "description": "Custom-size maximum validation"
+  },
+  "error.customSizePixels": {
+    "message": "Total pixels cannot exceed {pixels}",
+    "description": "Custom-size pixel-budget validation"
   },
   "description.prompt": {
     "message": "Prompt for generating or editing images",

--- a/src/i18n/zh-CN/openaiimage.json
+++ b/src/i18n/zh-CN/openaiimage.json
@@ -52,8 +52,56 @@
     "description": "输出图像尺寸"
   },
   "description.size": {
-    "message": "用于生成图片的输出尺寸，常用值：1024x1024、1536x1024、1024x1536。",
+    "message": "输出图像尺寸。不同模型支持的尺寸不同：gpt-image-1 / gpt-image-1.5 仅支持 1024x1024、1536x1024、1024x1536；gpt-image-2 还支持 1792x1024、1024x1792，以及 2K/4K 预设；gpt-image-2 可启用自定义尺寸。",
     "description": "尺寸说明"
+  },
+  "sizeGroup.standard1k": {
+    "message": "1K 标准（基础价）",
+    "description": "1K 尺寸分组标题，按基础价计费"
+  },
+  "sizeGroup.preset2k": {
+    "message": "2K 预设（1.5 倍价）",
+    "description": "2K 尺寸分组标题，按 1.5 倍价计费"
+  },
+  "sizeGroup.preset4k": {
+    "message": "4K 预设（1.5 倍价）",
+    "description": "4K 尺寸分组标题，按 1.5 倍价计费"
+  },
+  "name.customSize": {
+    "message": "自定义尺寸",
+    "description": "自定义尺寸开关标签"
+  },
+  "description.customSize": {
+    "message": "启用后可自由设置宽高（仅 gpt-image-2 支持）。需为 16 的倍数，最长边 ≤ 3840，总像素 ≤ 8,294,400。非 1K 标准尺寸按 1.5 倍价计费。",
+    "description": "自定义尺寸说明"
+  },
+  "name.width": {
+    "message": "宽",
+    "description": "宽度输入框标签"
+  },
+  "name.height": {
+    "message": "高",
+    "description": "高度输入框标签"
+  },
+  "error.customSizePositive": {
+    "message": "宽高必须为正整数",
+    "description": "自定义尺寸必须为正整数"
+  },
+  "error.customSizeMultiple": {
+    "message": "宽高必须为 {multiple} 的倍数",
+    "description": "自定义尺寸必须为 16 的倍数"
+  },
+  "error.customSizeMin": {
+    "message": "宽高不能小于 {min}",
+    "description": "自定义尺寸下限"
+  },
+  "error.customSizeMax": {
+    "message": "最长边不能超过 {max}",
+    "description": "自定义尺寸最长边上限"
+  },
+  "error.customSizePixels": {
+    "message": "总像素不能超过 {pixels}",
+    "description": "自定义尺寸总像素上限"
   },
   "description.prompt": {
     "message": "生成或编辑图像的提示词",

--- a/src/models/openaiimage.ts
+++ b/src/models/openaiimage.ts
@@ -21,6 +21,7 @@ export interface IOpenAIImageEditRequest {
   action?: 'generate' | 'edit';
   model?: string;
   prompt?: string;
+  size?: string;
   image_urls?: string[];
   callback_url?: string;
 }

--- a/src/pages/openaiimage/Index.vue
+++ b/src/pages/openaiimage/Index.vue
@@ -156,6 +156,7 @@ export default defineComponent({
         action: 'edit',
         model: cfg?.model,
         prompt: cfg?.prompt,
+        size: cfg?.size,
         image_urls: cfg?.image_urls || [],
         callback_url: CALLBACK_URL
       } as IOpenAIImageEditRequest;


### PR DESCRIPTION
## Summary

The Size dropdown on https://studio.acedata.cloud/openai-image was hard-coded to a single 3-size list (\`1024x1024\`, \`1536x1024\`, \`1024x1536\`) regardless of the model picked. That misses every size that `gpt-image-2` actually supports per the [`/openai/images/generations` OpenAPI spec](https://platform.acedata.cloud/services/06f2acb7-e4d4-43de-9909-76e27b4e2355) — including the 1K aliases (`1792x1024`, `1024x1792`), the recommended 2K / 4K presets, and arbitrary `WIDTHxHEIGHT` custom dimensions.

This PR drives the dropdown from a per-model preset list and exposes the custom-size capability behind a toggle (gpt-image-2 only).

## What changed

- **`src/constants/openaiimage.ts`** — adds the full preset list per model. `gpt-image-1` / `gpt-image-1.5` keep the three 1K standard sizes upstream supports; `gpt-image-2` gets:
  - 1K Standard (base rate, $0.20 / credit 0.2 per image): `1024x1024`, `1536x1024`, `1024x1536`, `1792x1024`, `1024x1792`
  - 2K Presets (1.5× rate): `2048x2048`, `2048x1536`, `1536x2048`, `2048x1152`, `1152x2048`
  - 4K Presets (1.5× rate): `2880x2880`, `3264x2448`, `2448x3264`, `3840x2160`, `2160x3840`
  - Plus custom (any `WIDTHxHEIGHT` matching upstream constraints)
- **`src/components/openaiimage/config/ResolutionSelector.vue`** — refactor:
  - Dropdown now uses `el-option-group` with the labels above so users can see which group bills at the 1.5× tier.
  - Adds a `Custom Size` switch (only rendered for gpt-image-2) plus width / height number inputs with `:step-strictly` snapping to multiples of 16.
  - Inline validation mirrors the upstream constraints documented in the OpenAPI `size` description: each side must be a multiple of **16**, longer side **≤ 3840**, total pixels **≤ 8,294,400**, sensible 256 minimum. The custom dims only sync to the store while validation passes, so an invalid value never leaves the page.
  - When the user switches model, the watcher snaps the stored size to the new model's first preset if it isn't supported (and the new model doesn't allow custom). For gpt-image-2 a parseable custom size is preserved on switch.
- **`src/i18n/{zh-CN,en}/openaiimage.json`** — adds strings for the new size groups, the custom toggle, width / height labels, and the validation error messages. Other locales are intentionally left to the translation CronJob.

## Pricing alignment

The display price on the page comes from the merged service cost rules in `cost/service/06f2acb7-...json` ([PR #409 in PlatformBackend](https://github.com/AceDataCloud/PlatformBackend/pull/409) prepended the actual API billing rules). Concretely:

| Model       | Size group                                       | Display & billing |
| ----------- | ------------------------------------------------ | ----------------- |
| gpt-image-1 | any preset                                       | 0.2 cr / image    |
| gpt-image-1.5 | any preset                                     | 0.55 cr / image   |
| gpt-image-2 | 1K (1024², 1536×1024, 1024×1536, 1792×1024, 1024×1792, plus 1K aliases 1254², 1672×941, 941×1672) | 0.2 cr / image |
| gpt-image-2 | 2K / 4K preset or any other custom size          | 0.3 cr / image    |

The 1K-alias check in the cost rules already covers a few non-standard 1K dimensions upstream returns; everything else (including all 2K/4K presets and any custom value) falls into the `other → 1.5×` tier. Since `getConsumption()` evaluates the same rules, the displayed price stays in sync no matter what the user picks.

## Manual checks

- `npx eslint src/components/openaiimage/config/ResolutionSelector.vue src/constants/openaiimage.ts` — clean
- `npx vue-tsc --noEmit` — clean
- `python3 -c "import json; json.load(...)"` on both i18n files — valid

## Screenshots

Before: single 3-item dropdown for every model.

After: grouped dropdown (1K / 2K / 4K), plus optional Custom toggle for gpt-image-2 with width/height inputs and live validation.