### PR TITLE
fix(veo): expose aspect ratio selector for text2video

### DIFF
--- a/src/components/veo/ConfigPanel.vue
+++ b/src/components/veo/ConfigPanel.vue
@@ -26,10 +26,7 @@
       <!-- Generation actions: text2video, image2video, ingredients2video -->
       <template v-if="isGeneration">
         <translation-selector class="mb-4" />
-        <aspect-ratio-selector
-          v-if="config?.action === 'image2video' || config?.action === 'ingredients2video'"
-          class="mb-4"
-        />
+        <aspect-ratio-selector class="mb-4" />
         <prompt-input class="mb-4" />
         <model-selector v-if="config?.action !== 'ingredients2video'" class="mb-4" />
         <start-end-image


### PR DESCRIPTION
## Problem

The Veo studio page (https://studio.acedata.cloud/veo) only renders four controls when `Actions = Text to Video`:

- Actions
- Auto Translation
- Video Prompt
- Model Version

Aspect ratio is missing, so users cannot pick `9:16` (vertical) or any non-default ratio for text2video. They are silently stuck on the default `16:9`.

## Root cause

`src/components/veo/ConfigPanel.vue` gates `<aspect-ratio-selector>` on `action === 'image2video' || action === 'ingredients2video'`. text2video falls through and never renders the selector.

This is wrong:

- `PlatformBackend/openapi/<veo>.json` lists `aspect_ratio` as a valid request field with enum `[9:16, 1:1, 3:4, 4:3, 16:9]`. The description ("only valid when action is image2video") is stale doc text.
- `PlatformService/mountsea/worker/src/handlers/veo/videos.ts` validates `aspect_ratio` for **all** actions against the same enum.
- `PlatformService/mountsea/worker/src/core.ts#generateVeoVideos` propagates `aspectRatio` to the upstream Mountsea `/gemini/video/generate` payload for the `text2video` branch (`ACTION_GENERATE1`).

So the API has supported `aspect_ratio` for text2video the whole time — only the Nexior UI was hiding it.

## Fix

Drop the `v-if` on `<aspect-ratio-selector>` so the selector renders for every generation action (`text2video`, `image2video`, `ingredients2video`). `AspectRatioSelector.vue` already initializes from `VEO_DEFAULT_ASPECT_RATIO = '16:9'` on mount, so the previous default behaviour is preserved when the user doesn't touch it.

## Billing impact

None — `PlatformBackend/cost/api/<veo>.json` doesn't reference `aspect_ratio`. Pricing is by model + resolution + action only.

## Verification

Loaded the page locally; `Text to Video` now shows the same five-option ratio picker (1:1 / 4:3 / 3:4 / 16:9 / 9:16) used by image2video, with 16:9 selected by default. Generated a quick text2video at 9:16 and confirmed the request payload includes `"aspect_ratio": "9:16"`.