### PR TITLE
fix(kling): tighten frame preview and switch duration to dropdown

### DIFF
--- a/src/components/kling/config/DurationSelector.vue
+++ b/src/components/kling/config/DurationSelector.vue
@@ -1,27 +1,26 @@
 <template>
   <div class="field">
-    <div class="header">
-      <h2 class="title font-bold">{{ $t('kling.name.duration') }}</h2>
-      <info-icon :content="$t('kling.description.duration')" class="info-icon ml-1" />
-      <span class="value-display">{{ value }}s</span>
+    <div class="control">
+      <div class="label">
+        <h2 class="title font-bold">{{ $t('kling.name.duration') }}</h2>
+        <info-icon :content="$t('kling.description.duration')" class="info-icon ml-1" />
+      </div>
+      <el-select
+        :key="revertKey"
+        :model-value="selectValue"
+        class="value"
+        :placeholder="$t('kling.placeholder.select')"
+        @change="onChange"
+      >
+        <el-option v-for="d in allowedDurations" :key="d" :label="`${d}s`" :value="d" />
+      </el-select>
     </div>
-    <el-slider
-      :key="revertKey"
-      :model-value="sliderValue"
-      class="slider"
-      :min="sliderMin"
-      :max="sliderMax"
-      :step="sliderStep"
-      :marks="marks"
-      :show-tooltip="false"
-      @change="onChange"
-    />
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElSlider, ElMessage, ElMessageBox } from 'element-plus';
+import { ElSelect, ElOption, ElMessage, ElMessageBox } from 'element-plus';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import { KLING_DEFAULT_DURATION, KLING_V3_MODELS } from '@/constants';
 import { findKlingConflicts, clearKlingConflicts } from '@/utils/kling/capabilities';
@@ -32,18 +31,15 @@ const STANDARD_VALUES = [5, 10];
 export default defineComponent({
   name: 'DurationSelector',
   components: {
-    ElSlider,
+    ElSelect,
+    ElOption,
     InfoIcon
   },
-  props: {
-    modelValue: {
-      type: Number,
-      default: undefined
-    }
-  },
-  emits: ['update:modelValue'],
   data() {
     return {
+      // Bumped to force-rerender the select when the user cancels a
+      // conflict-resolution prompt, so the dropdown snaps back to the
+      // previous value.
       revertKey: 0
     };
   },
@@ -54,35 +50,23 @@ export default defineComponent({
     isV3Model(): boolean {
       return KLING_V3_MODELS.includes(this.selectedModel);
     },
-    sliderMin(): number {
-      return this.isV3Model ? 3 : 5;
-    },
-    sliderMax(): number {
-      return this.isV3Model ? 15 : 10;
-    },
-    sliderStep(): number {
-      return this.isV3Model ? 1 : 5;
-    },
-    marks() {
-      const values = this.isV3Model ? V3_VALUES : STANDARD_VALUES;
-      const m: Record<number, string> = {};
-      for (const v of values) m[v] = `${v}s`;
-      return m;
+    allowedDurations(): number[] {
+      return this.isV3Model ? V3_VALUES : STANDARD_VALUES;
     },
     value(): number {
       return this.$store.state.kling?.config?.duration ?? KLING_DEFAULT_DURATION;
     },
-    sliderValue(): number {
-      const v = this.value;
-      if (v < this.sliderMin) return this.sliderMin;
-      if (v > this.sliderMax) return this.sliderMax;
-      return v;
+    selectValue(): number {
+      // Clamp the displayed value to a member of allowedDurations so the
+      // select doesn't render a stale entry while a model switch is in flight.
+      const allowed = this.allowedDurations;
+      if (allowed.includes(this.value)) return this.value;
+      return allowed.includes(KLING_DEFAULT_DURATION) ? KLING_DEFAULT_DURATION : allowed[0];
     }
   },
   watch: {
-    isV3Model(_: boolean) {
-      const valid = this.isV3Model ? V3_VALUES : STANDARD_VALUES;
-      if (!valid.includes(this.value)) {
+    isV3Model() {
+      if (!this.allowedDurations.includes(this.value)) {
         this.applyDuration(KLING_DEFAULT_DURATION);
       }
     }
@@ -93,9 +77,7 @@ export default defineComponent({
     }
   },
   methods: {
-    async onChange(raw: number | number[]) {
-      // ElSlider supports range mode (number[]); we only use single mode.
-      const val = Array.isArray(raw) ? raw[0] : raw;
+    async onChange(val: number) {
       const config = this.$store.state.kling?.config || {};
       const conflicts = findKlingConflicts(config, { duration: val });
       if (conflicts.length === 0) {
@@ -117,7 +99,7 @@ export default defineComponent({
         this.$store.commit('kling/setConfig', cleared);
         ElMessage.success(this.$t('kling.message.featureRemovedNotice', { fields }));
       } catch {
-        // User cancelled — repaint slider with the previous value.
+        // User cancelled — repaint the dropdown with the previous value.
         this.revertKey += 1;
       }
     },
@@ -135,27 +117,23 @@ export default defineComponent({
 .field {
   display: flex;
   flex-direction: column;
-
-  .header {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-
-    .title {
-      font-size: 14px;
-      margin: 0;
-    }
-    .value-display {
-      margin-left: auto;
-      font-size: 13px;
-      font-weight: 600;
-      color: var(--el-color-primary);
-      min-width: 40px;
-      text-align: right;
-    }
-  }
-  .slider {
-    margin: 4px 8px 18px;
-  }
+}
+.control {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+}
+.label {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+.title {
+  font-size: 14px;
+  margin: 0;
+}
+.value {
+  width: 120px;
 }
 </style>

--- a/src/components/kling/config/StartImage.vue
+++ b/src/components/kling/config/StartImage.vue
@@ -147,5 +147,17 @@ export default defineComponent({
     margin: 0;
     width: 100%;
   }
+  // Element Plus's default `.el-upload-list--picture .el-upload-list__item` has
+  // 92px height and 90px left padding to host its built-in thumbnail. We use a
+  // custom #file slot rendering a 50x50 ImagePreview, so those defaults leave a
+  // big empty rectangle to the left of the preview. Neutralize them.
+  .el-upload-list--picture .el-upload-list__item {
+    height: auto;
+    padding: 0;
+    margin: 8px 0 0;
+    border: none;
+    background-color: transparent;
+    overflow: visible;
+  }
 }
 </style>

--- a/src/i18n/en/kling.json
+++ b/src/i18n/en/kling.json
@@ -694,5 +694,9 @@
   "message.noTasks": {
     "message": "No historical tasks, please click on the left to generate a video",
     "description": "Message when there are no tasks"
+  },
+  "placeholder.select": {
+    "message": "Select",
+    "description": "Placeholder text for select fields"
   }
 }

--- a/src/i18n/zh-CN/kling.json
+++ b/src/i18n/zh-CN/kling.json
@@ -694,5 +694,9 @@
   "message.noTasks": {
     "message": "没有历史任务，请点击左方生成视频",
     "description": "没有任务时的消息"
+  },
+  "placeholder.select": {
+    "message": "请选择",
+    "description": "下拉选择字段中的占位文本"
   }
 }


### PR DESCRIPTION
## Summary

Two UX issues on https://studio.acedata.cloud/kling reported by user.

### 1. First/last frame preview leaves an empty rectangle on the left

`StartImage.vue` / `EndImage.vue` use `<el-upload list-type="picture">` with a custom `#file` slot rendering a 50×50 `ImagePreview`. Element Plus's default `.el-upload-list--picture .el-upload-list__item` has `height: 92px; padding: 10px 10px 10px 90px; border: 1px solid var(--el-border-color)` baked in to host its built-in thumbnail. With the custom slot the thumbnail moves but the container chrome remains, leaving a large empty rectangle to the left of the actual preview.

Fix: add CSS overrides on `.upload-wrapper` to neutralize the default height, padding, border and background. The override lives in StartImage.vue's unscoped `<style>` block and covers EndImage.vue too (both share the same global `.upload-wrapper` class).

### 2. Video Duration slider is hard to use

The control was an `el-slider` with `step=1` for v3 models and marks at `[3, 5, 8, 10, 12, 15]`. Combined with `show-tooltip=false` and a value-display that only updates on `@change` (mouseup), the user reported they couldn't reliably drag to 8s — no live feedback during drag, and `step=1` means the thumb can land on any integer rather than snapping to the labelled marks.

Fix: replace the slider with an `el-select` dropdown listing only the allowed durations per model, matching the pattern used by Sora, Seedance, Wan and Hailuo. The existing conflict-resolution prompt (e.g. *"Switching to 10s will drop end-frame / audio / motion-control"*) is preserved with the same `findKlingConflicts` / `clearKlingConflicts` flow; on cancel the dropdown reverts via the existing `revertKey` remount trick.

## i18n

Adds `kling.placeholder.select` to zh-CN and en locale files only (per instructions, no auto-translate to other languages).

## Verification

- `npx eslint src/components/kling/config/{DurationSelector,StartImage,EndImage}.vue` — clean
- `npx vue-tsc --noEmit` — clean
