### PR TITLE
feat(midjourney): show elapsed time in task result alerts

### DIFF
--- a/change/@acedatacloud-nexior-043e8a03-63cc-41e8-8ed1-892a67904d9c.json
+++ b/change/@acedatacloud-nexior-043e8a03-63cc-41e8-8ed1-892a67904d9c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(midjourney): show elapsed time in task result alerts",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/midjourney/tasks/TaskItem.vue
+++ b/src/components/midjourney/tasks/TaskItem.vue
@@ -40,6 +40,10 @@
             {{ modelValue?.response?.error?.message }}
             <copy-to-clipboard :content="modelValue?.response?.error?.message!" />
           </p>
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('midjourney.field.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
+          </p>
           <p class="text-[var(--el-text-color-regular)] text-xs mb-0">
             <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />
             {{ $t('midjourney.field.traceId') }}:
@@ -81,6 +85,10 @@
             {{ $t('midjourney.field.taskId') }}:
             {{ modelValue?.id }}
             <copy-to-clipboard :content="modelValue?.id!" />
+          </p>
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('midjourney.field.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
           </p>
           <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
             <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />
@@ -150,6 +158,10 @@
             {{ modelValue?.response?.error?.message }}
             <copy-to-clipboard :content="modelValue?.response?.error?.message!" />
           </p>
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('midjourney.field.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
+          </p>
           <p class="text-[var(--el-text-color-regular)] text-xs mb-0">
             <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />
             {{ $t('midjourney.field.traceId') }}:
@@ -189,6 +201,10 @@
             {{ $t('midjourney.field.taskId') }}:
             {{ modelValue?.id }}
             <copy-to-clipboard :content="modelValue?.id!" />
+          </p>
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('midjourney.field.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
           </p>
           <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
             <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />
@@ -253,6 +269,10 @@
             {{ modelValue?.response?.error?.message }}
             <copy-to-clipboard :content="modelValue?.response?.error?.message!" />
           </p>
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('midjourney.field.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
+          </p>
           <p class="text-[var(--el-text-color-regular)] text-xs mb-0">
             <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />
             {{ $t('midjourney.field.traceId') }}:
@@ -289,6 +309,10 @@
             {{ $t('midjourney.field.taskId') }}:
             {{ modelValue?.id }}
             <copy-to-clipboard :content="modelValue?.id!" />
+          </p>
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('midjourney.field.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
           </p>
           <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
             <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />

--- a/src/i18n/en/midjourney.json
+++ b/src/i18n/en/midjourney.json
@@ -1543,6 +1543,10 @@
     "message": "Trace ID",
     "description": "Trace ID used to track the image generation request, do not translate, keep as 'Trace ID'"
   },
+  "field.elapsed": {
+    "message": "Elapsed Time",
+    "description": "Time taken for the task (seconds)"
+  },
   "description.model": {
     "message": "Select the model for generating images; 'General' is suitable for most scenarios, 'Niji' is suitable for anime style.",
     "description": "Description of the model parameter"

--- a/src/i18n/zh-CN/midjourney.json
+++ b/src/i18n/zh-CN/midjourney.json
@@ -1543,6 +1543,10 @@
     "message": "追踪ID",
     "description": "用于跟踪生成图像请求的追踪ID，不要翻译，保持为'追踪ID'"
   },
+  "field.elapsed": {
+    "message": "耗时",
+    "description": "任务的耗时（秒）"
+  },
   "description.model": {
     "message": "选择生成图像的模型，通用适合大多数场景，Niji适合动漫风格",
     "description": "模型参数的描述"

--- a/src/models/midjourney.ts
+++ b/src/models/midjourney.ts
@@ -146,6 +146,7 @@ export interface IMidjourneyImagineTask {
   id: string;
   type: 'imagine';
   created_at?: number;
+  elapsed?: number;
   trace_id?: string;
   request?: IMidjourneyImagineRequest;
   response?: IMidjourneyImagineResponse;
@@ -155,6 +156,7 @@ export interface IMidjourneyVideosTask {
   id: string;
   type: 'videos';
   created_at?: number;
+  elapsed?: number;
   trace_id?: string;
   request?: IMidjourneyVideosRequest;
   response?: IMidjourneyVideosResponse;
@@ -165,6 +167,7 @@ export interface IMidjourneyDescribeTask {
   id: string;
   type: 'describe';
   created_at?: number;
+  elapsed?: number;
   request?: IMidjourneyDescribeRequest;
   response?: IMidjourneyDescribeResponse;
   trace_id?: string;


### PR DESCRIPTION
## Summary

Mirror what nano-banana / seedance / pixverse / qrart / seedream already do — render the upstream worker's reported `elapsed` (seconds) inside the success and failure alert blocks of every Midjourney task variant (imagine, videos, describe). Pending tasks still show only the Task ID.

User-reported context: looking at the MJ result cards in the studio, the metadata strip shows Task ID / Trace ID / Image ID but not the generation duration like Nano Banana does.

## What changed

- `src/models/midjourney.ts` — added `elapsed?: number` to `IMidjourneyImagineTask`, `IMidjourneyVideosTask`, `IMidjourneyDescribeTask`.
- `src/components/midjourney/tasks/TaskItem.vue` — added a clock-icon paragraph above the trace-id row in **6** alert blocks (success + failure for each of the 3 task types), guarded by `v-if=\"modelValue?.elapsed\"` so archived tasks without the field stay clean.
- `src/i18n/en/midjourney.json` + `src/i18n/zh-CN/midjourney.json` — added `field.elapsed` (\"Elapsed Time\" / \"耗时\"). Other locales will pick it up the next time transmart runs.

## Why no backend / operator changes

The PiAPI / ttapi / ephone Midjourney workers all already populate `elapsed` (and `finished_at`) in `postprocess()` on the persisted task — verified in `PlatformService/{piapi,ttapi,ephone}/worker/src/handlers/base.ts`. The existing `POST /midjourney/tasks { action: 'retrieve_batch' }` API already passes the full task row back, including `elapsed`. So this is a pure frontend display change.

## Verification

- `vue-tsc --noEmit` passes.
- `eslint src/components/midjourney/tasks/TaskItem.vue src/models/midjourney.ts` passes.
- Manual visual confirmation: archived tasks without `elapsed` render unchanged; new tasks show `耗时: 12.34s`.