### PR TITLE
fix(suno): prompt for theme on AI lyrics generation

### DIFF
--- a/src/components/suno/config/LyricInput.vue
+++ b/src/components/suno/config/LyricInput.vue
@@ -134,7 +134,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElInput, ElButton, ElMessage, ElTooltip, ElDialog } from 'element-plus';
+import { ElInput, ElButton, ElMessage, ElMessageBox, ElTooltip, ElDialog } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import { sunoOperator } from '@/operators';
@@ -227,13 +227,33 @@ export default defineComponent({
       const token = this.credential?.token;
       if (!token) return;
 
+      let theme: string;
+      try {
+        const result = await ElMessageBox.prompt(
+          this.$t('suno.message.lyricsThemePromptMessage') as string,
+          this.$t('suno.message.lyricsThemePromptTitle') as string,
+          {
+            confirmButtonText: this.$t('common.button.confirm') as string,
+            cancelButtonText: this.$t('common.button.cancel') as string,
+            inputPlaceholder: this.$t('suno.placeholder.lyricsTheme') as string,
+            inputValue: this.config?.title || '',
+            inputType: 'textarea',
+            inputValidator: (v) =>
+              (typeof v === 'string' && v.trim().length > 0) || (this.$t('suno.message.lyricsThemeRequired') as string)
+          }
+        );
+        theme = ((result as { value: string }).value || '').trim();
+      } catch {
+        return;
+      }
+      if (!theme) return;
+
       this.pushHistory();
-      const prompt = this.config?.style || this.config?.title || 'a beautiful song';
       this.generatingLyrics = true;
       ElMessage.info(this.$t('suno.message.generatingLyrics'));
 
       try {
-        const response = await sunoOperator.lyric({ prompt }, { token });
+        const response = await sunoOperator.lyric({ prompt: theme }, { token });
         const data = response.data?.data;
         if (data?.text) {
           this.lyric = data.text;

--- a/src/i18n/en/suno.json
+++ b/src/i18n/en/suno.json
@@ -767,6 +767,22 @@
     "message": "Enter modification instructions, e.g., make the lyrics more cheerful...",
     "description": "Placeholder for lyrics enhancement input"
   },
+  "placeholder.lyricsTheme": {
+    "message": "e.g. a mellow folk song about autumn longing",
+    "description": "Placeholder for the AI lyrics theme input"
+  },
+  "message.lyricsThemePromptTitle": {
+    "message": "Generate Lyrics with AI",
+    "description": "Title of the AI lyrics theme prompt dialog"
+  },
+  "message.lyricsThemePromptMessage": {
+    "message": "Describe what the song should be about. The AI will write lyrics based on it.",
+    "description": "Body text of the AI lyrics theme prompt dialog"
+  },
+  "message.lyricsThemeRequired": {
+    "message": "Please describe the song's theme first",
+    "description": "Validation message when the theme input is empty"
+  },
   "message.enhancingLyrics": {
     "message": "Enhancing lyrics...",
     "description": "Message during lyrics enhancement"

--- a/src/i18n/zh-CN/suno.json
+++ b/src/i18n/zh-CN/suno.json
@@ -767,6 +767,22 @@
     "message": "输入修改指令，例如：让歌词更欢快...",
     "description": "歌词增强输入占位符"
   },
+  "placeholder.lyricsTheme": {
+    "message": "例如：一首关于秋日思念的舒缓民谣",
+    "description": "AI 生成歌词主题输入占位符"
+  },
+  "message.lyricsThemePromptTitle": {
+    "message": "AI 生成歌词",
+    "description": "AI 生成歌词输入弹窗标题"
+  },
+  "message.lyricsThemePromptMessage": {
+    "message": "请描述这首歌想表达的主题或故事，AI 会据此生成歌词",
+    "description": "AI 生成歌词输入弹窗的说明文本"
+  },
+  "message.lyricsThemeRequired": {
+    "message": "请先描述一下歌曲主题",
+    "description": "主题输入为空时的校验提示"
+  },
   "message.enhancingLyrics": {
     "message": "正在增强歌词...",
     "description": "增强歌词时的消息"


### PR DESCRIPTION
## Problem

On the Suno page, the **AI Generate Lyrics** button (`✨ Generate Lyrics` next to the Lyrics field, see [LyricInput.vue](https://github.com/AceDataCloud/Nexior/blob/main/src/components/suno/config/LyricInput.vue)) silently used:

```ts
const prompt = this.config?.style || this.config?.title || 'a beautiful song';
```

That is — it sent whatever is in the **Style** field (which is for genre keywords like "acoustic pop, jazz, R&B, electronic"), then fell back to Title, then to a hardcoded `'a beautiful song'`. None of those match what a user thinks they're providing when they ask AI to write *lyrics*. With both fields empty, every click produces near-identical output. Users have reported the feature as broken / useless.

## Fix

Replace the silent fallback with an explicit `ElMessageBox.prompt` that asks the user to describe the song's theme. Implementation details:

- Textarea (multi-line) input, prefilled with the current **Title** (closer semantic match than Style for "what the song is about").
- Empty submission is rejected via `inputValidator`, with a clear localized message.
- Cancelling the dialog cleanly aborts (no error toast).
- The trimmed theme text is sent as the Suno lyrics API `prompt`.
- All other behavior (history push, generating toast, success/failure handling, auto-fill of title from response) is preserved.

The Enhance Lyrics flow (separate `enhance-bar` shown after lyrics exist) is untouched — that one already takes explicit user input.

## i18n

Added keys to `zh-CN` and `en` only (per project guidelines — `yarn translate` is not run from PRs):

| Key | en | zh-CN |
|---|---|---|
| `suno.message.lyricsThemePromptTitle` | Generate Lyrics with AI | AI 生成歌词 |
| `suno.message.lyricsThemePromptMessage` | Describe what the song should be about. The AI will write lyrics based on it. | 请描述这首歌想表达的主题或故事，AI 会据此生成歌词 |
| `suno.placeholder.lyricsTheme` | e.g. a mellow folk song about autumn longing | 例如：一首关于秋日思念的舒缓民谣 |
| `suno.message.lyricsThemeRequired` | Please describe the song's theme first | 请先描述一下歌曲主题 |

## Verification

- `eslint src/components/suno/config/LyricInput.vue` — clean
- `vue-tsc --noEmit` — clean
- JSON validity for both modified locale files — valid

## Files

- `src/components/suno/config/LyricInput.vue`
- `src/i18n/zh-CN/suno.json`
- `src/i18n/en/suno.json`