### PR TITLE
fix(seedance): show input frame images in result + tighten service tier row

### DIFF
--- a/src/components/seedance/config/ServiceTierSelector.vue
+++ b/src/components/seedance/config/ServiceTierSelector.vue
@@ -74,16 +74,18 @@ export default defineComponent({
       .title {
         font-size: 14px;
         margin: 0;
+        white-space: nowrap;
       }
 
       .info {
         margin-left: 6px;
+        flex-shrink: 0;
       }
     }
   }
 
   .value {
-    width: 160px;
+    width: 110px;
   }
 }
 </style>

--- a/src/components/seedance/task/Preview.vue
+++ b/src/components/seedance/task/Preview.vue
@@ -11,6 +11,18 @@
         </span>
       </div>
       <div class="info">
+        <div
+          v-if="referenceImages.length > 0"
+          class="flex justify-start items-center gap-2 mt-2 w-full overflow-x-auto"
+        >
+          <image-preview
+            v-for="(image, idx) in referenceImages"
+            :key="idx"
+            :url="image.url"
+            :name="image.name"
+            :closable="false"
+          />
+        </div>
         <p v-if="modelValue?.request?.prompt" class="prompt mt-2">
           {{ modelValue?.request?.prompt }}
           <span v-if="!modelValue?.response"> - ({{ $t('seedance.status.pending') }}) </span>
@@ -154,6 +166,7 @@ import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import VideoPlayer from '@/components/common/VideoPlayer.vue';
 import ImageWrapper from '@/components/common/ImageWrapper.vue';
+import ImagePreview from '@/components/common/ImagePreview.vue';
 import { SEEDANCE_LOGO } from '@/constants';
 
 export default defineComponent({
@@ -166,7 +179,8 @@ export default defineComponent({
     VideoPlayer,
     ElTooltip,
     ElButton,
-    ImageWrapper
+    ImageWrapper,
+    ImagePreview
   },
   props: {
     modelValue: {
@@ -182,6 +196,27 @@ export default defineComponent({
   computed: {
     video(): ISeedanceVideo | undefined {
       return this.modelValue?.response?.data;
+    },
+    referenceImages(): { url: string; name: string }[] {
+      const images = this.modelValue?.request?.images;
+      if (!Array.isArray(images)) {
+        return [];
+      }
+      const ordered: { url: string; name: string }[] = [];
+      const firstFrame = images.find((img) => img?.role === 'first_frame');
+      if (firstFrame?.url) {
+        ordered.push({ url: firstFrame.url, name: 'first-frame' });
+      }
+      const lastFrame = images.find((img) => img?.role === 'last_frame');
+      if (lastFrame?.url) {
+        ordered.push({ url: lastFrame.url, name: 'last-frame' });
+      }
+      images.forEach((img, idx) => {
+        if (img?.url && img.role !== 'first_frame' && img.role !== 'last_frame') {
+          ordered.push({ url: img.url, name: img.role || `image-${idx}` });
+        }
+      });
+      return ordered;
     }
   },
   methods: {


### PR DESCRIPTION
## Summary

Two small but visible UI gaps on https://studio.acedata.cloud/seedance.

## 1. Input First/Last Frame images vanish from the result column

When the user uploads a First Frame Image (or Last Frame Image) in the Seedance config panel and runs a task, the images appear only as tiny thumbnails inside the upload widget on the left. The chat-style **result** column on the right just shows the generated video — it never echoes back the input frames the task was conditioned on. So once the upload thumbnail scrolls out of view, the user has no way to see *which* image they fed in.

Other image-conditioned video tasks already do this. `kling/task/Preview.vue` renders a horizontal strip of `<image-preview>` thumbnails (start / end image) above the prompt for exactly this reason.

This PR ports that pattern to `seedance/task/Preview.vue`:

- New `referenceImages` computed reads `modelValue?.request?.images`, surfaces `first_frame` first, then `last_frame`, then anything else (currently just `reference_image` per `SeedanceImageRole`), filtering out entries without `url`.
- New block above the prompt renders the strip via the shared `ImagePreview` component (50×50, rounded, non-closable) — same look kling uses.
- No state mutation, no model changes — purely a read path.

## 2. `Service Tier` label crushes the (i) icon, dropdown is too wide

`ServiceTierSelector.vue` shares the row template used by Model/Duration: a 30%-width `.label` next to a fixed-width `.value`. With the longer text "Service Tier", the title `<h2>` wrapped to two lines, which both pushed the `<info-icon>` onto a second line *and* compressed it visually. Meanwhile `.value` was 160px wide for a dropdown that only ever contains "default" or "flex" — leaving a wide empty gap to the right.

Fix:

- `.title { white-space: nowrap }` so the label stays single-line.
- `.info { flex-shrink: 0 }` to guarantee the icon never gets squeezed regardless of locale.
- `.value { width: 110px }` (was 160px) — fits "default" / "flex" comfortably without the empty gap.

Only `ServiceTierSelector.vue` is touched; Model / Duration / Switches keep their existing widths.

## Manual checks

- `eslint src/components/seedance/task/Preview.vue src/components/seedance/config/ServiceTierSelector.vue` — clean
- `vue-tsc --noEmit` — clean

## Out of scope

- No i18n changes. Other locales already have a translation for `seedance.name.serviceTier`; the nowrap fix works across locales because we no longer rely on the title fitting in 30% width.