### PR TITLE
fix(midjourney): show frame thumbnails and request params on video tasks

### DIFF
--- a/change/@acedatacloud-nexior-mj-video-task-display.json
+++ b/change/@acedatacloud-nexior-mj-video-task-display.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(midjourney): show frame thumbnails and request params on video tasks",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/midjourney/tasks/TaskItem.vue
+++ b/src/components/midjourney/tasks/TaskItem.vue
@@ -129,6 +129,23 @@
         </span>
       </div>
       <div class="info">
+        <div
+          v-if="modelValue?.request?.image_url || modelValue?.request?.end_image_url"
+          class="flex justify-start items-center gap-2 mt-2 w-full overflow-x-auto"
+        >
+          <image-preview
+            v-if="modelValue?.request?.image_url"
+            :url="modelValue.request.image_url"
+            :name="$t('midjourney.name.imageUrl')"
+            :closable="false"
+          />
+          <image-preview
+            v-if="modelValue?.request?.end_image_url"
+            :url="modelValue.request.end_image_url"
+            :name="$t('midjourney.name.endImageUrl')"
+            :closable="false"
+          />
+        </div>
         <p v-if="modelValue?.request?.prompt" class="prompt">
           {{ modelValue?.request?.prompt }}
           <span v-if="!modelValue?.response"> - ({{ $t('midjourney.status.pending') }}) </span>
@@ -146,6 +163,26 @@
       <!-- response error -->
       <div v-if="modelValue?.response?.success === false" :class="{ content: true, full: full, failed: true }">
         <el-alert :closable="false" class="failure">
+          <p v-if="modelValue?.request?.action" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-bolt" class="mr-1" />
+            {{ $t('midjourney.field.action') }}:
+            {{ modelValue?.request?.action }}
+          </p>
+          <p v-if="modelValue?.request?.resolution" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-gauge-high" class="mr-1" />
+            {{ $t('midjourney.name.resolution') }}:
+            {{ modelValue?.request?.resolution }}
+          </p>
+          <p v-if="modelValue?.request?.mode" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('midjourney.name.mode') }}:
+            {{ modelValue?.request?.mode }}
+          </p>
+          <p v-if="modelValue?.request?.loop !== undefined" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-arrows-rotate" class="mr-1" />
+            {{ $t('midjourney.name.loop') }}:
+            {{ modelValue?.request?.loop ? $t('midjourney.field.on') : $t('midjourney.field.off') }}
+          </p>
           <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
             <font-awesome-icon icon="fa-solid fa-magic" class="mr-1" />
             {{ $t('midjourney.field.taskId') }}:
@@ -196,6 +233,26 @@
           </el-tooltip>
         </div>
         <el-alert :closable="false" class="mt-2 success">
+          <p v-if="modelValue?.request?.action" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-bolt" class="mr-1" />
+            {{ $t('midjourney.field.action') }}:
+            {{ modelValue?.request?.action }}
+          </p>
+          <p v-if="modelValue?.request?.resolution" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-gauge-high" class="mr-1" />
+            {{ $t('midjourney.name.resolution') }}:
+            {{ modelValue?.request?.resolution }}
+          </p>
+          <p v-if="modelValue?.request?.mode" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('midjourney.name.mode') }}:
+            {{ modelValue?.request?.mode }}
+          </p>
+          <p v-if="modelValue?.request?.loop !== undefined" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-arrows-rotate" class="mr-1" />
+            {{ $t('midjourney.name.loop') }}:
+            {{ modelValue?.request?.loop ? $t('midjourney.field.on') : $t('midjourney.field.off') }}
+          </p>
           <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
             <font-awesome-icon icon="fa-solid fa-magic" class="mr-1" />
             {{ $t('midjourney.field.taskId') }}:
@@ -223,6 +280,26 @@
       <!-- response pending -->
       <div v-if="!modelValue?.response">
         <el-alert :closable="false" class="info">
+          <p v-if="modelValue?.request?.action" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-bolt" class="mr-1" />
+            {{ $t('midjourney.field.action') }}:
+            {{ modelValue?.request?.action }}
+          </p>
+          <p v-if="modelValue?.request?.resolution" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-gauge-high" class="mr-1" />
+            {{ $t('midjourney.name.resolution') }}:
+            {{ modelValue?.request?.resolution }}
+          </p>
+          <p v-if="modelValue?.request?.mode" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('midjourney.name.mode') }}:
+            {{ modelValue?.request?.mode }}
+          </p>
+          <p v-if="modelValue?.request?.loop !== undefined" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-arrows-rotate" class="mr-1" />
+            {{ $t('midjourney.name.loop') }}:
+            {{ modelValue?.request?.loop ? $t('midjourney.field.on') : $t('midjourney.field.off') }}
+          </p>
           <p class="text-[var(--el-text-color-regular)] text-xs mb-0">
             <font-awesome-icon icon="fa-solid fa-magic" class="mr-1" />
             {{ $t('midjourney.field.taskId') }}:
@@ -344,6 +421,7 @@ import { IMidjourneyTask, MidjourneyImagineAction, MidjourneyImagineState, IMidj
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import ImageWrapper from '@/components/common/ImageWrapper.vue';
+import ImagePreview from '@/components/common/ImagePreview.vue';
 import VideoPlayer from '@/components/common/VideoPlayer.vue';
 import { getConsumption } from '@/utils';
 interface IData {
@@ -357,6 +435,7 @@ export default defineComponent({
   components: {
     ElImage,
     ImageWrapper,
+    ImagePreview,
     ElButton,
     FontAwesomeIcon,
     ElTooltip,

--- a/src/i18n/en/midjourney.json
+++ b/src/i18n/en/midjourney.json
@@ -1547,6 +1547,18 @@
     "message": "Elapsed Time",
     "description": "Time taken for the task (seconds)"
   },
+  "field.action": {
+    "message": "Action",
+    "description": "Name of the action performed by the request (e.g. generate / extend)"
+  },
+  "field.on": {
+    "message": "On",
+    "description": "Text shown when a boolean parameter is true"
+  },
+  "field.off": {
+    "message": "Off",
+    "description": "Text shown when a boolean parameter is false"
+  },
   "description.model": {
     "message": "Select the model for generating images; 'General' is suitable for most scenarios, 'Niji' is suitable for anime style.",
     "description": "Description of the model parameter"

--- a/src/i18n/zh-CN/midjourney.json
+++ b/src/i18n/zh-CN/midjourney.json
@@ -1547,6 +1547,18 @@
     "message": "耗时",
     "description": "任务的耗时（秒）"
   },
+  "field.action": {
+    "message": "操作",
+    "description": "请求所执行操作的名称（例如 generate / extend）"
+  },
+  "field.on": {
+    "message": "开启",
+    "description": "布尔参数为 true 时显示的文本"
+  },
+  "field.off": {
+    "message": "关闭",
+    "description": "布尔参数为 false 时显示的文本"
+  },
   "description.model": {
     "message": "选择生成图像的模型，通用适合大多数场景，Niji适合动漫风格",
     "description": "模型参数的描述"


### PR DESCRIPTION
## Summary

Two UX gaps on https://studio.acedata.cloud/midjourney Video Generation reported by user:

1. **No thumbnail of the uploaded first/last frame image.** Only the prompt text was shown next to the bot avatar — same as nano-banana shows uploaded `image_urls`, but Midjourney video tasks dropped this entirely.
2. **None of the request parameters were displayed.** Resolution / mode / loop / action all live on `request` but the success / failure / pending alert blocks only printed task ID / trace ID / video ID.

## Changes

`src/components/midjourney/tasks/TaskItem.vue` (videos branch only — imagine and describe blocks untouched):

- Add `<image-preview>` chips for `request.image_url` and `request.end_image_url` inside the `.info` row, above the prompt line. This is the exact pattern used in `src/components/nanobanana/task/Preview.vue`.
- Add four parameter rows (Action / Video Quality / Speed / Video Loop) to every video alert state (failure, success, pending), using existing FontAwesome icons (`fa-bolt`, `fa-gauge-high`, `fa-clock`, `fa-arrows-rotate`).

## i18n

Adds `midjourney.field.action`, `midjourney.field.on`, `midjourney.field.off` to **en** and **zh-CN** locale files only. Other locales will be filled by `translate.py` CronJob.

The labels for resolution / loop / mode reuse the existing config-panel keys (`name.resolution` / `name.loop` / `name.mode`) so no extra translation churn there.

## Verification

- ESLint clean on the touched component
- New chips only render when the corresponding request field is present, so existing tasks without `image_url` (e.g. videos in `extend` mode where `video_id` replaces it) are unaffected
- The new param rows are all `v-if`-guarded on `request.*`, so legacy task records without those fields render exactly as before
