### PR TITLE
fix(seedream): make size and image inputs model-aware

### DIFF
--- a/src/components/seedream/config/GuidanceScaleInput.vue
+++ b/src/components/seedream/config/GuidanceScaleInput.vue
@@ -25,7 +25,7 @@
 import { defineComponent } from 'vue';
 import { ElInputNumber } from 'element-plus';
 import InfoIcon from '@/components/common/InfoIcon.vue';
-import { SEEDREAM_GUIDANCE_SCALE_DEFAULTS, supportsSeedreamGuidanceScale } from '@/constants';
+import { getSeedreamCapabilities } from '@/utils/seedream/capabilities';
 
 export default defineComponent({
   name: 'SeedreamGuidanceScaleInput',
@@ -38,11 +38,10 @@ export default defineComponent({
       return this.$store.state.seedream?.config || {};
     },
     supported(): boolean {
-      return supportsSeedreamGuidanceScale(this.config?.model);
+      return getSeedreamCapabilities(this.config?.model).guidanceScale;
     },
     defaultValue(): number {
-      const m: string | undefined = this.config?.model;
-      return (m && SEEDREAM_GUIDANCE_SCALE_DEFAULTS[m]) || 2.5;
+      return getSeedreamCapabilities(this.config?.model).guidanceScaleDefault ?? 2.5;
     },
     value: {
       get(): number {
@@ -54,19 +53,6 @@ export default defineComponent({
         const next = typeof val === 'number' && val >= 1 && val <= 10 ? val : this.defaultValue;
         cfg.guidance_scale = next;
         this.$store.commit('seedream/setConfig', cfg);
-      }
-    }
-  },
-  watch: {
-    supported: {
-      immediate: true,
-      handler(v: boolean) {
-        if (v) return;
-        const cfg = { ...(this.config || {}) };
-        if (cfg.guidance_scale !== undefined) {
-          delete cfg.guidance_scale;
-          this.$store.commit('seedream/setConfig', cfg);
-        }
       }
     }
   }

--- a/src/components/seedream/config/ImageInput.vue
+++ b/src/components/seedream/config/ImageInput.vue
@@ -1,44 +1,46 @@
 <template>
-  <div class="field">
-    <div class="label">
-      <div class="box">
-        <h2 class="title font-bold">{{ $t('seedream.name.imageUrls') }}</h2>
-        <info-icon :content="$t('seedream.description.imageUrls')" class="info" />
+  <div v-if="supported">
+    <div class="field">
+      <div class="label">
+        <div class="box">
+          <h2 class="title font-bold">{{ $t('seedream.name.imageUrls') }}</h2>
+          <info-icon :content="$t('seedream.description.imageUrls')" class="info" />
+        </div>
+      </div>
+      <div class="value">
+        <el-upload
+          ref="uploader"
+          v-model:file-list="fileList"
+          accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
+          name="file"
+          :limit="14"
+          :multiple="true"
+          :show-file-list="false"
+          :action="uploadUrl"
+          :on-exceed="onExceed"
+          :on-error="onError"
+          :on-success="onSuccess"
+          :on-change="onChange"
+          :on-remove="onRemove"
+          :headers="headers"
+        >
+          <el-button size="small" type="primary" round>
+            <font-awesome-icon icon="fa-solid fa-upload" class="mr-1" />
+            {{ $t('seedream.button.uploadImageUrls') }}
+          </el-button>
+        </el-upload>
       </div>
     </div>
-    <div class="value">
-      <el-upload
-        ref="uploader"
-        v-model:file-list="fileList"
-        accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
-        name="file"
-        :limit="14"
-        :multiple="true"
-        :show-file-list="false"
-        :action="uploadUrl"
-        :on-exceed="onExceed"
-        :on-error="onError"
-        :on-success="onSuccess"
-        :on-change="onChange"
-        :on-remove="onRemove"
-        :headers="headers"
-      >
-        <el-button size="small" type="primary" round>
-          <font-awesome-icon icon="fa-solid fa-upload" class="mr-1" />
-          {{ $t('seedream.button.uploadImageUrls') }}
-        </el-button>
-      </el-upload>
+    <div class="file-list mt-2 flex flex-wrap gap-[10px]">
+      <image-preview
+        v-for="(file, idx) in fileList"
+        :key="(file as any).uid || (file as any)?.response?.file_url || (file as any).url || idx"
+        :url="(file as any).url || (file as any)?.response?.file_url"
+        :name="(file as any).name"
+        :percentage="(file as any).percentage"
+        @remove="onRemovePreview(idx, file)"
+      />
     </div>
-  </div>
-  <div class="file-list mt-2 flex flex-wrap gap-[10px]">
-    <image-preview
-      v-for="(file, idx) in fileList"
-      :key="(file as any).uid || (file as any)?.response?.file_url || (file as any).url || idx"
-      :url="(file as any).url || (file as any)?.response?.file_url"
-      :name="(file as any).name"
-      :percentage="(file as any).percentage"
-      @remove="onRemovePreview(idx, file)"
-    />
   </div>
 </template>
 
@@ -49,6 +51,7 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
+import { getSeedreamCapabilities } from '@/utils/seedream/capabilities';
 
 interface IData {
   fileList: UploadFiles;
@@ -91,6 +94,12 @@ export default defineComponent({
     },
     value(): string[] | undefined {
       return this.$store.state.seedream?.config?.image;
+    },
+    model(): string | undefined {
+      return this.$store.state.seedream?.config?.model;
+    },
+    supported(): boolean {
+      return getSeedreamCapabilities(this.model).image;
     }
   },
   watch: {

--- a/src/components/seedream/config/MaxImagesSelector.vue
+++ b/src/components/seedream/config/MaxImagesSelector.vue
@@ -24,7 +24,8 @@
 import { defineComponent } from 'vue';
 import { ElInputNumber } from 'element-plus';
 import InfoIcon from '@/components/common/InfoIcon.vue';
-import { SEEDREAM_DEFAULT_MAX_IMAGES, SEEDREAM_MAX_IMAGES_LIMIT, supportsSeedreamGroupGeneration } from '@/constants';
+import { SEEDREAM_DEFAULT_MAX_IMAGES, SEEDREAM_MAX_IMAGES_LIMIT } from '@/constants';
+import { getSeedreamCapabilities } from '@/utils/seedream/capabilities';
 
 export default defineComponent({
   name: 'SeedreamMaxImagesSelector',
@@ -37,7 +38,7 @@ export default defineComponent({
       return this.$store.state.seedream?.config || {};
     },
     supported(): boolean {
-      return supportsSeedreamGroupGeneration(this.config?.model);
+      return getSeedreamCapabilities(this.config?.model).groupGeneration;
     },
     referenceImageCount(): number {
       const image = this.config?.image;
@@ -78,26 +79,6 @@ export default defineComponent({
     }
   },
   watch: {
-    // If the user switches to a model that doesn't support group generation
-    // (e.g. doubao-seedream-3.0-t2i), strip the multi-image fields so the
-    // request stays valid.
-    supported: {
-      immediate: true,
-      handler(v: boolean) {
-        if (v) return;
-        const cfg = { ...(this.config || {}) };
-        let dirty = false;
-        if (cfg.sequential_image_generation) {
-          delete cfg.sequential_image_generation;
-          dirty = true;
-        }
-        if (cfg.sequential_image_generation_options) {
-          delete cfg.sequential_image_generation_options;
-          dirty = true;
-        }
-        if (dirty) this.$store.commit('seedream/setConfig', cfg);
-      }
-    },
     // If the user shrinks the picker by uploading more reference images,
     // clamp the stored value so it stays valid.
     effectiveMax(max: number) {

--- a/src/components/seedream/config/ModelSelector.vue
+++ b/src/components/seedream/config/ModelSelector.vue
@@ -6,7 +6,13 @@
         <info-icon :content="$t('seedream.description.model')" class="info" />
       </div>
     </div>
-    <el-select v-model="value" class="value" :placeholder="$t('seedream.placeholder.select')">
+    <el-select
+      :key="revertKey"
+      :model-value="value"
+      class="value"
+      :placeholder="$t('seedream.placeholder.select')"
+      @change="onChange"
+    >
       <el-option v-for="item in options" :key="item.value" :label="item.label" :value="item.value" />
     </el-select>
   </div>
@@ -14,7 +20,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElSelect, ElOption } from 'element-plus';
+import { ElSelect, ElOption, ElMessage, ElMessageBox } from 'element-plus';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import {
   SEEDREAM_DEFAULT_MODEL,
@@ -24,6 +30,7 @@ import {
   SEEDREAM_MODEL_5_0,
   SEEDREAM_MODEL_SEEDEDIT_3_0_I2I
 } from '@/constants';
+import { findSeedreamConflicts, clearSeedreamConflicts } from '@/utils/seedream/capabilities';
 
 export default defineComponent({
   name: 'SeedreamModelSelector',
@@ -34,46 +41,60 @@ export default defineComponent({
   },
   data() {
     return {
+      // Bumped to force el-select to re-render and revert its internal display
+      // when the user cancels a model switch.
+      revertKey: 0,
       options: [
-        {
-          value: SEEDREAM_MODEL_5_0,
-          label: this.$t('seedream.model.seedream50')
-        },
-        {
-          value: SEEDREAM_MODEL_4_5,
-          label: this.$t('seedream.model.seedream45')
-        },
-        {
-          value: SEEDREAM_MODEL_4_0,
-          label: this.$t('seedream.model.seedream40')
-        },
-        {
-          value: SEEDREAM_MODEL_3_0_T2I,
-          label: this.$t('seedream.model.seedream30t2i')
-        },
-        {
-          value: SEEDREAM_MODEL_SEEDEDIT_3_0_I2I,
-          label: this.$t('seedream.model.seededit30i2i')
-        }
+        { value: SEEDREAM_MODEL_5_0, label: this.$t('seedream.model.seedream50') },
+        { value: SEEDREAM_MODEL_4_5, label: this.$t('seedream.model.seedream45') },
+        { value: SEEDREAM_MODEL_4_0, label: this.$t('seedream.model.seedream40') },
+        { value: SEEDREAM_MODEL_3_0_T2I, label: this.$t('seedream.model.seedream30t2i') },
+        { value: SEEDREAM_MODEL_SEEDEDIT_3_0_I2I, label: this.$t('seedream.model.seededit30i2i') }
       ]
     };
   },
   computed: {
-    value: {
-      get() {
-        return this.$store.state.seedream?.config?.model;
-      },
-      set(val: string) {
-        this.$store.commit('seedream/setConfig', {
-          ...this.$store.state.seedream?.config,
-          model: val
-        });
-      }
+    value(): string | undefined {
+      return this.$store.state.seedream?.config?.model;
     }
   },
   mounted() {
     if (!this.value) {
-      this.value = SEEDREAM_DEFAULT_MODEL;
+      this.applyModel(SEEDREAM_DEFAULT_MODEL);
+    }
+  },
+  methods: {
+    async onChange(val: string) {
+      const config = this.$store.state.seedream?.config || {};
+      const conflicts = findSeedreamConflicts(config, { model: val });
+      if (conflicts.length === 0) {
+        this.applyModel(val);
+        return;
+      }
+      const fields = conflicts.map((c) => this.$t(c.i18nLabel)).join('、');
+      try {
+        await ElMessageBox.confirm(
+          this.$t('seedream.message.featureNotSupportedBody', { fields }),
+          this.$t('seedream.message.featureNotSupportedTitle'),
+          {
+            confirmButtonText: this.$t('seedream.button.confirmContinue'),
+            cancelButtonText: this.$t('seedream.button.cancelSwitch'),
+            type: 'warning'
+          }
+        );
+        const cleared = clearSeedreamConflicts({ ...config, model: val }, conflicts, { model: val });
+        this.$store.commit('seedream/setConfig', cleared);
+        ElMessage.success(this.$t('seedream.message.featureRemovedNotice', { fields }));
+      } catch {
+        // User cancelled — force el-select to repaint with the current store value.
+        this.revertKey += 1;
+      }
+    },
+    applyModel(val: string) {
+      this.$store.commit('seedream/setConfig', {
+        ...this.$store.state.seedream?.config,
+        model: val
+      });
     }
   }
 });

--- a/src/components/seedream/config/OutputFormatSelector.vue
+++ b/src/components/seedream/config/OutputFormatSelector.vue
@@ -16,7 +16,8 @@
 import { defineComponent } from 'vue';
 import { ElSelect, ElOption } from 'element-plus';
 import InfoIcon from '@/components/common/InfoIcon.vue';
-import { SEEDREAM_OUTPUT_FORMATS, supportsSeedreamOutputFormat } from '@/constants';
+import { SEEDREAM_OUTPUT_FORMATS } from '@/constants';
+import { getSeedreamCapabilities } from '@/utils/seedream/capabilities';
 
 export default defineComponent({
   name: 'SeedreamOutputFormatSelector',
@@ -35,7 +36,7 @@ export default defineComponent({
       return this.$store.state.seedream?.config || {};
     },
     supported(): boolean {
-      return supportsSeedreamOutputFormat(this.config?.model);
+      return getSeedreamCapabilities(this.config?.model).outputFormat;
     },
     value: {
       get(): string | undefined {
@@ -45,19 +46,6 @@ export default defineComponent({
         const cfg = { ...(this.config || {}) };
         cfg.output_format = val;
         this.$store.commit('seedream/setConfig', cfg);
-      }
-    }
-  },
-  watch: {
-    supported: {
-      immediate: true,
-      handler(v: boolean) {
-        if (v) return;
-        const cfg = { ...(this.config || {}) };
-        if (cfg.output_format !== undefined) {
-          delete cfg.output_format;
-          this.$store.commit('seedream/setConfig', cfg);
-        }
       }
     }
   }

--- a/src/components/seedream/config/SeedInput.vue
+++ b/src/components/seedream/config/SeedInput.vue
@@ -24,7 +24,7 @@
 import { defineComponent } from 'vue';
 import { ElInputNumber } from 'element-plus';
 import InfoIcon from '@/components/common/InfoIcon.vue';
-import { supportsSeedreamSeed } from '@/constants';
+import { getSeedreamCapabilities } from '@/utils/seedream/capabilities';
 
 export default defineComponent({
   name: 'SeedreamSeedInput',
@@ -37,7 +37,7 @@ export default defineComponent({
       return this.$store.state.seedream?.config || {};
     },
     supported(): boolean {
-      return supportsSeedreamSeed(this.config?.model);
+      return getSeedreamCapabilities(this.config?.model).seed;
     },
     value: {
       get(): number {
@@ -49,21 +49,6 @@ export default defineComponent({
         const next = typeof val === 'number' && Number.isInteger(val) ? val : -1;
         cfg.seed = next;
         this.$store.commit('seedream/setConfig', cfg);
-      }
-    }
-  },
-  watch: {
-    // Drop `seed` when the user picks a model that doesn't support it so the
-    // request doesn't get rejected upstream.
-    supported: {
-      immediate: true,
-      handler(v: boolean) {
-        if (v) return;
-        const cfg = { ...(this.config || {}) };
-        if (cfg.seed !== undefined) {
-          delete cfg.seed;
-          this.$store.commit('seedream/setConfig', cfg);
-        }
       }
     }
   }

--- a/src/components/seedream/config/SizeSelector.vue
+++ b/src/components/seedream/config/SizeSelector.vue
@@ -9,15 +9,15 @@
     <el-select
       v-model="value"
       class="value"
-      :placeholder="$t('seedream.placeholder.select')"
+      :placeholder="$t('seedream.placeholder.size')"
       filterable
       allow-create
       default-first-option
     >
-      <el-option-group :label="$t('seedream.size.group.tier')">
-        <el-option v-for="item in tierOptions" :key="item.value" :label="item.label" :value="item.value" />
+      <el-option-group v-if="capabilities.sizeTiers.length" :label="$t('seedream.size.group.tier')">
+        <el-option v-for="item in capabilities.sizeTiers" :key="item" :label="item" :value="item" />
       </el-option-group>
-      <el-option-group :label="$t('seedream.size.group.adaptive')">
+      <el-option-group v-if="capabilities.sizeAdaptive" :label="$t('seedream.size.group.adaptive')">
         <el-option
           :key="SEEDREAM_SIZE_ADAPTIVE"
           :label="$t('seedream.size.adaptive')"
@@ -40,15 +40,8 @@
 import { defineComponent } from 'vue';
 import { ElSelect, ElOption, ElOptionGroup } from 'element-plus';
 import InfoIcon from '@/components/common/InfoIcon.vue';
-import {
-  SEEDREAM_DEFAULT_SIZE,
-  SEEDREAM_PIXEL_PRESETS,
-  SEEDREAM_SIZE_1K,
-  SEEDREAM_SIZE_2K,
-  SEEDREAM_SIZE_3K,
-  SEEDREAM_SIZE_4K,
-  SEEDREAM_SIZE_ADAPTIVE
-} from '@/constants';
+import { SEEDREAM_DEFAULT_SIZE, SEEDREAM_PIXEL_PRESETS, SEEDREAM_SIZE_ADAPTIVE } from '@/constants';
+import { getSeedreamCapabilities, ISeedreamCapability } from '@/utils/seedream/capabilities';
 
 export default defineComponent({
   name: 'SeedreamSizeSelector',
@@ -61,18 +54,18 @@ export default defineComponent({
   data() {
     return {
       SEEDREAM_SIZE_ADAPTIVE,
-      tierOptions: [
-        { value: SEEDREAM_SIZE_1K, label: SEEDREAM_SIZE_1K },
-        { value: SEEDREAM_SIZE_2K, label: SEEDREAM_SIZE_2K },
-        { value: SEEDREAM_SIZE_3K, label: SEEDREAM_SIZE_3K },
-        { value: SEEDREAM_SIZE_4K, label: SEEDREAM_SIZE_4K }
-      ],
       pixelOptions: SEEDREAM_PIXEL_PRESETS
     };
   },
   computed: {
+    model(): string | undefined {
+      return this.$store.state.seedream?.config?.model;
+    },
+    capabilities(): ISeedreamCapability {
+      return getSeedreamCapabilities(this.model);
+    },
     value: {
-      get() {
+      get(): string | undefined {
         return this.$store.state.seedream?.config?.size;
       },
       set(val: string) {
@@ -83,9 +76,21 @@ export default defineComponent({
       }
     }
   },
-  mounted() {
-    if (!this.value) {
-      this.value = SEEDREAM_DEFAULT_SIZE;
+  watch: {
+    // Seed a sensible default when the size is unset (initial load, or after
+    // ModelSelector cleared it as part of a conflict-resolution flow). Real
+    // model-switch clamping is owned by ModelSelector via findSeedreamConflicts.
+    model: {
+      immediate: true,
+      handler() {
+        if (this.value) return;
+        const caps = this.capabilities;
+        if (caps.sizeTiers.length) {
+          this.value = caps.sizeTiers.includes(SEEDREAM_DEFAULT_SIZE) ? SEEDREAM_DEFAULT_SIZE : caps.sizeTiers[0];
+        } else if (caps.sizePixelDefault) {
+          this.value = caps.sizePixelDefault;
+        }
+      }
     }
   }
 });

--- a/src/constants/seedream.ts
+++ b/src/constants/seedream.ts
@@ -39,42 +39,22 @@ export const SEEDREAM_PIXEL_PRESETS: { value: string; ratio: string }[] = [
   { value: '1728x2304', ratio: '3:4' }
 ];
 
-// Models that support `seed` and `guidance_scale`. Mirrors the upstream
-// validation in PlatformService/volcengine/worker/src/handlers/seedream/images.ts.
-export const SEEDREAM_SEED_MODELS: string[] = [SEEDREAM_MODEL_3_0_T2I, SEEDREAM_MODEL_SEEDEDIT_3_0_I2I];
-
+// Per-model `guidance_scale` defaults — read by both GuidanceScaleInput and
+// `utils/seedream/capabilities.ts`. Mirrors the upstream defaults at
+// PlatformService/volcengine/worker/src/handlers/seedream/images.ts.
 export const SEEDREAM_GUIDANCE_SCALE_DEFAULTS: Record<string, number> = {
   [SEEDREAM_MODEL_3_0_T2I]: 2.5,
   [SEEDREAM_MODEL_SEEDEDIT_3_0_I2I]: 5.5
 };
 
-// `output_format` is only accepted for doubao-seedream-5.0 by the upstream.
-export const SEEDREAM_OUTPUT_FORMAT_MODELS: string[] = [SEEDREAM_MODEL_5_0];
 export const SEEDREAM_OUTPUT_FORMATS = ['jpeg', 'png'] as const;
-
-export const supportsSeedreamSeed = (model?: string): boolean =>
-  !!model && SEEDREAM_SEED_MODELS.includes(model);
-
-export const supportsSeedreamGuidanceScale = (model?: string): boolean =>
-  !!model && SEEDREAM_SEED_MODELS.includes(model);
-
-export const supportsSeedreamOutputFormat = (model?: string): boolean =>
-  !!model && SEEDREAM_OUTPUT_FORMAT_MODELS.includes(model);
 
 // Group / multi-image generation:
 // Volcengine LAS supports up to 15 images per request when
 // `sequential_image_generation=auto`, gated by:
 //   (input reference images) + (generated images) <= 15.
-// 4.0 / 4.5 / 5.0 are the only models that support it; 3.0-t2i and
-// seededit-3.0-i2i are single-image only.
 export const SEEDREAM_MAX_IMAGES_LIMIT = 15;
 export const SEEDREAM_DEFAULT_MAX_IMAGES = 1;
-export const SEEDREAM_GROUP_GENERATION_MODELS: string[] = [SEEDREAM_MODEL_5_0, SEEDREAM_MODEL_4_5, SEEDREAM_MODEL_4_0];
-
-export const supportsSeedreamGroupGeneration = (model?: string): boolean => {
-  if (!model) return false;
-  return SEEDREAM_GROUP_GENERATION_MODELS.includes(model);
-};
 
 export const SEEDREAM_MODEL_FULL_TO_SHORT: Record<string, string> = {
   [SEEDREAM_MODEL_5_0]: 'doubao-seedream-5.0',

--- a/src/i18n/en/seedream.json
+++ b/src/i18n/en/seedream.json
@@ -64,8 +64,8 @@
     "description": "Description of the model parameter"
   },
   "description.size": {
-    "message": "Image size. Pick a resolution tier (1K-4K), `adaptive` (match the reference image), or an explicit `<width>x<height>` like `1024x1024` or `1280x720`. You can also type any `<width>x<height>` directly into the dropdown.",
-    "description": "Description of the size parameter"
+    "message": "Image size. Allowed tier presets vary by model: 5.0 supports 2K/3K/4K, 4.5/4.0 support 1K/2K/4K, and 3.0-t2i / seededit-3.0-i2i only accept explicit `<width>x<height>` pixel values (e.g. 1024x1024, 1280x720). On preset-supporting models you can also pick `adaptive` (match the reference image) or type any `<width>x<height>` directly into the dropdown.",
+    "description": "Description of the size parameter (per-model)"
   },
   "description.watermark": {
     "message": "Whether to add an AI watermark to the generated image. Enabled by default.",
@@ -83,6 +83,10 @@
     "message": "Select",
     "description": "Selection placeholder"
   },
+  "placeholder.size": {
+    "message": "Pick a preset or type <width>x<height>",
+    "description": "size selector placeholder (el-select allow-create)"
+  },
   "placeholder.prompt": {
     "message": "Enter prompt, e.g., a white Siamese cat",
     "description": "Prompt placeholder"
@@ -94,6 +98,14 @@
   "button.uploadImageUrls": {
     "message": "Upload",
     "description": "Upload reference images button (simplified to 'Upload')"
+  },
+  "button.confirmContinue": {
+    "message": "Continue Switching",
+    "description": "Confirm button on the capability-conflict prompt"
+  },
+  "button.cancelSwitch": {
+    "message": "Cancel",
+    "description": "Cancel button on the capability-conflict prompt"
   },
   "message.startingTask": {
     "message": "Starting task...",
@@ -118,6 +130,18 @@
   "message.uploadImageError": {
     "message": "Image upload failed, please try again later",
     "description": "Upload failure"
+  },
+  "message.featureNotSupportedTitle": {
+    "message": "Confirmation Required",
+    "description": "Title of the capability-conflict prompt"
+  },
+  "message.featureNotSupportedBody": {
+    "message": "The current selection does not support the following enabled settings: {fields}. Continuing will clear these settings.",
+    "description": "Body of the capability-conflict prompt"
+  },
+  "message.featureRemovedNotice": {
+    "message": "Cleared unsupported settings: {fields}",
+    "description": "Toast shown after the user confirms the capability-conflict prompt"
   },
   "name.model": {
     "message": "Model",

--- a/src/i18n/zh-CN/seedream.json
+++ b/src/i18n/zh-CN/seedream.json
@@ -64,8 +64,8 @@
     "description": "model 参数说明"
   },
   "description.size": {
-    "message": "图片尺寸。可选分辨率档位（1K-4K）、自适应（与参考图比例一致）或具体像素尺寸如 `1024x1024`、`1280x720`，也可在下拉框中直接输入任意 `<宽>x<高>`。",
-    "description": "size 参数说明"
+    "message": "图片尺寸。不同模型支持的预设不同：5.0 仅支持 2K/3K/4K，4.5/4.0 支持 1K/2K/4K，3.0-t2i 与 seededit-3.0-i2i 仅支持 `<宽>x<高>` 像素值（如 1024x1024、1280x720）。预设模型还可选择「自适应」（与参考图保持一致比例），也可在下拉框中直接输入任意 `<宽>x<高>`。",
+    "description": "size 参数说明（按模型）"
   },
   "description.watermark": {
     "message": "是否在生成的图片中添加 AI 水印。默认开启。",
@@ -83,6 +83,10 @@
     "message": "选择",
     "description": "选择占位"
   },
+  "placeholder.size": {
+    "message": "选择预设或输入 <宽>x<高>",
+    "description": "size 选择/输入占位（el-select allow-create）"
+  },
   "placeholder.prompt": {
     "message": "输入提示词，例如：一只白色的暹罗猫",
     "description": "提示占位"
@@ -94,6 +98,14 @@
   "button.uploadImageUrls": {
     "message": "上传图片",
     "description": "上传参考图片按钮（英文请简化为“Upload”，不要用“Upload Images”）"
+  },
+  "button.confirmContinue": {
+    "message": "继续切换",
+    "description": "能力冲突提示框的确认按钮"
+  },
+  "button.cancelSwitch": {
+    "message": "取消",
+    "description": "能力冲突提示框的取消按钮"
   },
   "message.startingTask": {
     "message": "正在启动任务...",
@@ -118,6 +130,18 @@
   "message.uploadImageError": {
     "message": "上传图片失败，请稍后重试",
     "description": "上传失败"
+  },
+  "message.featureNotSupportedTitle": {
+    "message": "需要确认",
+    "description": "能力冲突提示框标题"
+  },
+  "message.featureNotSupportedBody": {
+    "message": "当前选择不支持以下已启用的设置：{fields}。继续将清理这些设置。",
+    "description": "能力冲突提示框正文"
+  },
+  "message.featureRemovedNotice": {
+    "message": "已清理不支持的设置：{fields}",
+    "description": "能力冲突清理后的提示消息"
   },
   "name.model": {
     "message": "模型",

--- a/src/utils/seedream/capabilities.ts
+++ b/src/utils/seedream/capabilities.ts
@@ -1,0 +1,256 @@
+// Capability matrix for Seedream / SeedEdit image models.
+//
+// Single source of truth derived from the Volcengine Ark image-generation docs:
+// https://www.volcengine.com/docs/82379/1541523
+//
+// Mirrors the pattern used by `utils/kling/capabilities.ts`. Used by the
+// Seedream config UI to:
+//   - decide which selectors are visible for the current model
+//   - filter the set of valid `size` presets
+//   - prompt the user before silently dropping config that is no longer
+//     supported (image upload, custom seed, group generation, etc.)
+
+import {
+  SEEDREAM_GUIDANCE_SCALE_DEFAULTS,
+  SEEDREAM_MODEL_3_0_T2I,
+  SEEDREAM_MODEL_4_0,
+  SEEDREAM_MODEL_4_5,
+  SEEDREAM_MODEL_5_0,
+  SEEDREAM_MODEL_SEEDEDIT_3_0_I2I,
+  SEEDREAM_SIZE_1K,
+  SEEDREAM_SIZE_2K,
+  SEEDREAM_SIZE_3K,
+  SEEDREAM_SIZE_4K
+} from '@/constants';
+
+export interface ISeedreamCapability {
+  /** Accepts the `image` request parameter (reference / edit images). */
+  image: boolean;
+  /** `image` is *required* (image-to-image only). */
+  imageRequired: boolean;
+  /** Allowed tier presets. Empty array means the model only accepts an
+   *  explicit `<W>x<H>` value. */
+  sizeTiers: string[];
+  /** Accepts the `adaptive` size value (matches the reference image ratio). */
+  sizeAdaptive: boolean;
+  /** Accepts `<W>x<H>` pixel-value sizes. (Always true at the moment, kept
+   *  for symmetry with the other flags.) */
+  sizePixel: boolean;
+  /** Default `<W>x<H>` to seed when the model rejects every preset. */
+  sizePixelDefault?: string;
+  /** Supports `sequential_image_generation=auto` group generation. */
+  groupGeneration: boolean;
+  /** Supports the `seed` parameter. */
+  seed: boolean;
+  /** Supports the `guidance_scale` parameter. */
+  guidanceScale: boolean;
+  /** Default `guidance_scale` value, when supported. */
+  guidanceScaleDefault?: number;
+  /** Supports the `output_format` parameter (jpeg / png). */
+  outputFormat: boolean;
+  /** Supports the `tools=[{type:"web_search"}]` parameter. */
+  tools: boolean;
+}
+
+const FALLBACK: ISeedreamCapability = {
+  image: true,
+  imageRequired: false,
+  sizeTiers: [SEEDREAM_SIZE_1K, SEEDREAM_SIZE_2K, SEEDREAM_SIZE_3K, SEEDREAM_SIZE_4K],
+  sizeAdaptive: true,
+  sizePixel: true,
+  sizePixelDefault: undefined,
+  groupGeneration: false,
+  seed: false,
+  guidanceScale: false,
+  outputFormat: false,
+  tools: false
+};
+
+/** Return the support matrix for a given model. */
+export function getSeedreamCapabilities(model?: string): ISeedreamCapability {
+  switch (model) {
+    case SEEDREAM_MODEL_5_0:
+      // 5.0-lite: tier presets 2K/3K/4K (no 1K — min ~3.7M pixels).
+      return {
+        image: true,
+        imageRequired: false,
+        sizeTiers: [SEEDREAM_SIZE_2K, SEEDREAM_SIZE_3K, SEEDREAM_SIZE_4K],
+        sizeAdaptive: true,
+        sizePixel: true,
+        groupGeneration: true,
+        seed: false,
+        guidanceScale: false,
+        outputFormat: true,
+        tools: true
+      };
+    case SEEDREAM_MODEL_4_5:
+    case SEEDREAM_MODEL_4_0:
+      // 4.5 / 4.0: tier presets 1K/2K/4K (no 3K).
+      return {
+        image: true,
+        imageRequired: false,
+        sizeTiers: [SEEDREAM_SIZE_1K, SEEDREAM_SIZE_2K, SEEDREAM_SIZE_4K],
+        sizeAdaptive: true,
+        sizePixel: true,
+        groupGeneration: true,
+        seed: false,
+        guidanceScale: false,
+        outputFormat: false,
+        tools: false
+      };
+    case SEEDREAM_MODEL_3_0_T2I:
+      // 3.0-t2i: text-to-image only, pixel-only sizes.
+      return {
+        image: false,
+        imageRequired: false,
+        sizeTiers: [],
+        sizeAdaptive: false,
+        sizePixel: true,
+        sizePixelDefault: '1024x1024',
+        groupGeneration: false,
+        seed: true,
+        guidanceScale: true,
+        guidanceScaleDefault: SEEDREAM_GUIDANCE_SCALE_DEFAULTS[SEEDREAM_MODEL_3_0_T2I],
+        outputFormat: false,
+        tools: false
+      };
+    case SEEDREAM_MODEL_SEEDEDIT_3_0_I2I:
+      // seededit-3.0-i2i: image-to-image only, pixel-only sizes.
+      return {
+        image: true,
+        imageRequired: true,
+        sizeTiers: [],
+        sizeAdaptive: false,
+        sizePixel: true,
+        sizePixelDefault: '1024x1024',
+        groupGeneration: false,
+        seed: true,
+        guidanceScale: true,
+        guidanceScaleDefault: SEEDREAM_GUIDANCE_SCALE_DEFAULTS[SEEDREAM_MODEL_SEEDEDIT_3_0_I2I],
+        outputFormat: false,
+        tools: false
+      };
+    default:
+      return FALLBACK;
+  }
+}
+
+export type SeedreamConflictField =
+  | 'image'
+  | 'size'
+  | 'sequential_image_generation'
+  | 'seed'
+  | 'guidance_scale'
+  | 'output_format'
+  | 'tools';
+
+export interface ISeedreamConflict {
+  field: SeedreamConflictField;
+  /** i18n key for the user-facing label of the field. */
+  i18nLabel: string;
+}
+
+const TIER_PRESETS = [SEEDREAM_SIZE_1K, SEEDREAM_SIZE_2K, SEEDREAM_SIZE_3K, SEEDREAM_SIZE_4K];
+
+/**
+ * Compute which currently-set config fields will be unsupported under the
+ * proposed `next` change (typically a model switch).
+ */
+export function findSeedreamConflicts(
+  config: Record<string, any> | undefined,
+  next: { model?: string }
+): ISeedreamConflict[] {
+  if (!config) return [];
+  const model = next.model ?? config.model;
+  if (!model) return [];
+
+  const caps = getSeedreamCapabilities(model);
+  const conflicts: ISeedreamConflict[] = [];
+
+  if (Array.isArray(config.image) && config.image.length > 0 && !caps.image) {
+    conflicts.push({ field: 'image', i18nLabel: 'seedream.name.imageUrls' });
+  }
+
+  // Size: flag tier presets the new model rejects, and `adaptive` when the
+  // new model is pixel-only. Free-form `<W>x<H>` is always accepted.
+  const size = typeof config.size === 'string' ? config.size : undefined;
+  if (size) {
+    const upper = size.toUpperCase();
+    if (TIER_PRESETS.includes(upper) && !caps.sizeTiers.includes(upper)) {
+      conflicts.push({ field: 'size', i18nLabel: 'seedream.name.size' });
+    } else if (size === 'adaptive' && !caps.sizeAdaptive) {
+      conflicts.push({ field: 'size', i18nLabel: 'seedream.name.size' });
+    }
+  }
+
+  if (config.sequential_image_generation === 'auto' && !caps.groupGeneration) {
+    conflicts.push({ field: 'sequential_image_generation', i18nLabel: 'seedream.name.maxImages' });
+  }
+
+  if (config.seed !== undefined && config.seed !== null && !caps.seed) {
+    conflicts.push({ field: 'seed', i18nLabel: 'seedream.name.seed' });
+  }
+
+  if (config.guidance_scale !== undefined && config.guidance_scale !== null && !caps.guidanceScale) {
+    conflicts.push({ field: 'guidance_scale', i18nLabel: 'seedream.name.guidanceScale' });
+  }
+
+  if (config.output_format && !caps.outputFormat) {
+    conflicts.push({ field: 'output_format', i18nLabel: 'seedream.name.outputFormat' });
+  }
+
+  if (Array.isArray(config.tools) && config.tools.length > 0 && !caps.tools) {
+    conflicts.push({ field: 'tools', i18nLabel: 'seedream.name.tools' });
+  }
+
+  return conflicts;
+}
+
+/**
+ * Apply conflict resolutions to a config object. Returns a new object with the
+ * offending fields cleared (or, for `size` on pixel-only models, replaced with
+ * the model's pixel default).
+ */
+export function clearSeedreamConflicts(
+  config: Record<string, any>,
+  conflicts: ISeedreamConflict[],
+  next: { model?: string }
+): Record<string, any> {
+  const result = { ...config };
+  const targetModel = next.model ?? config.model;
+  const caps = getSeedreamCapabilities(targetModel);
+
+  for (const c of conflicts) {
+    switch (c.field) {
+      case 'image':
+        delete result.image;
+        break;
+      case 'size':
+        // Replace with the model's pixel default if it has no tier presets,
+        // otherwise drop the field and let SizeSelector seed a tier default.
+        if (caps.sizePixelDefault) {
+          result.size = caps.sizePixelDefault;
+        } else {
+          delete result.size;
+        }
+        break;
+      case 'sequential_image_generation':
+        result.sequential_image_generation = 'disabled';
+        delete result.sequential_image_generation_options;
+        break;
+      case 'seed':
+        delete result.seed;
+        break;
+      case 'guidance_scale':
+        delete result.guidance_scale;
+        break;
+      case 'output_format':
+        delete result.output_format;
+        break;
+      case 'tools':
+        delete result.tools;
+        break;
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary

User reported two upstream 400s on https://studio.acedata.cloud/seedream:

```
The parameter `image` specified in the request is not valid: the parameter `image` is not supported by the current model.
The parameter `size` specified in the request is not valid: size must be one of 'WIDTHxHEIGHT', '2k', '3k', or '4k'.
```

These are upstream Volcengine errors — Nexior was sending request bodies that don't match the chosen model's contract:

| Model | `image` | `size` presets |
|---|---|---|
| `doubao-seedream-5.0` (5-0-260128) | optional | **2K / 3K / 4K** (no 1K) |
| `doubao-seedream-4.5` (4-5-251128) | optional | **1K / 2K / 4K** (no 3K) |
| `doubao-seedream-4.0` (4-0-250828) | optional | **1K / 2K / 4K** (no 3K) |
| `doubao-seedream-3.0-t2i` (3-0-t2i-250415) | **rejected — T2I only** | **none — only `<W>x<H>`** |
| `doubao-seededit-3.0-i2i` (3-0-i2i-250628) | required | **none — only `<W>x<H>`** |

Source: https://www.volcengine.com/docs/82379/1541523

So:

- **Error 1** = user picked `doubao-seedream-3.0-t2i` (text-to-image only) and uploaded a reference image — the upstream rejects `image` for this model.
- **Error 2** = user picked `doubao-seedream-5.0` with `1K`, but 5.0-lite's minimum total pixels is ~3.7M (≈2K). The error message lists `2k/3k/4k` (lowercase only because Volcengine echoes lowercase strings; uppercase works for the supported presets, but `1K` itself is not in the allow-list).

## What this PR changes (Nexior frontend guards)

1. **`SizeSelector`** is now model-aware. The dropdown only renders presets the upstream actually accepts. For the two pixel-only models (3.0-t2i, seededit-3.0-i2i) no preset is shown — the user types a literal `<W>x<H>` value via the existing `allow-create` select. When the model changes, any preset that's no longer valid is auto-clamped to a sensible default; pixel-only models are seeded with `1024x1024`.
2. **`ImageInput`** is hidden entirely when the active model is `doubao-seedream-3.0-t2i`, and any previously-stored `image[]` URLs are cleared from the Vuex config so the next request body is consistent. Other models keep their existing upload UI.
3. Adds `seedream.placeholder.size` and refreshes `seedream.description.size` (zh-CN + en only — other locales pick up via transmart). The new help text spells out which presets each model supports.

No backend / worker / openapi changes — the upstream constraint is correct as-is, this PR just stops Nexior from constructing payloads that violate it.

## Verification

- `eslint src/components/seedream/config/{SizeSelector,ImageInput}.vue src/constants/seedream.ts` — clean
- `vue-tsc --noEmit` — clean
- JSON locale files parse cleanly