### PR TITLE
fix(veo): show upsample/extend/reshoot/objects tasks in recent panel

### DIFF
--- a/src/store/veo/actions.ts
+++ b/src/store/veo/actions.ts
@@ -3,10 +3,11 @@ import { IVeoConfig, IVeoTask } from '@/models';
 import { VEO_SERVICE_ID } from '@/constants';
 import { createTaskActions } from '@/store/factories/createTaskActions';
 
+// No `type` filter: /veo/tasks aggregates videos / upsample / extend / reshoot / objects.
+// Hard-coding 'videos' would hide every post-processing task the user submits.
 const actions = createTaskActions<IVeoConfig, IVeoTask, Record<string, unknown>>({
   serviceId: VEO_SERVICE_ID,
-  operator: veoOperator,
-  type: 'videos'
+  operator: veoOperator
 });
 
 export default actions;


### PR DESCRIPTION
## Symptom (https://studio.acedata.cloud/veo)

User clicks **Upsample to 1080P / 4K**, **Export GIF**, **Extend Video**, **Reshoot with Different Angles**, **Add Object**, **Remove Object** on a finished veo task. Each click correctly seeds the config form (model + video_id + video_url + per-action fields), the user adjusts inputs and clicks **Generate**, the operator dispatches to the right endpoint (`/veo/upsample`, `/veo/extend`, `/veo/reshoot`, `/veo/objects`), the worker accepts the request, the task runs and persists.

But the task **never shows up in the recent-tasks panel**, leading to *"提交了，居然不展示？？？"*. `GET /veo/tasks` returns only `text2video` / `image2video` records — every post-processing task is missing.

## Root cause

`Nexior/src/store/veo/actions.ts` passes `type: 'videos'` to `createTaskActions`:

```ts
const actions = createTaskActions<IVeoConfig, IVeoTask, Record<string, unknown>>({
  serviceId: VEO_SERVICE_ID,
  operator: veoOperator,
  type: 'videos'   // ← always filters
});
```

That static `type` is forwarded as a filter to the worker's `POST /veo/tasks { action: 'retrieve_batch', type: 'videos', ... }`, and the Mongo persister applies it server-side:

```ts
// PlatformService/mountsea/worker/src/persister.ts
...(filter?.type && { type: filter?.type }),
```

Each veo handler stores tasks with its own discriminator:

| Endpoint | `this.type` |
|---|---|
| `/veo/videos` | `videos` ✅ shown |
| `/veo/upsample` | `upsample` ❌ filtered out |
| `/veo/extend` | `extend` ❌ filtered out |
| `/veo/reshoot` | `reshoot` ❌ filtered out |
| `/veo/objects` | `objects` ❌ filtered out |

So the four post-processing endpoints succeed end-to-end but their tasks are invisible to the user.

## Fix

Drop the static `type` filter so the panel aggregates **all** veo task types — matching what `store/midjourney/actions.ts` already does (no `type` filter, mixed-type list rendered through one Preview component).

The `TaskPreview` component renders generically off `response.data[0].video_url` + `request.prompt` + the standard alert blocks, so the new task types display correctly without any further changes; the upsample/extend/reshoot/objects handlers all return the same `{ success, data: [{ video_url, ... }] }` shape.

## Verification

- `npx eslint src/store/veo/actions.ts` — clean
- `npx vue-tsc --noEmit` — clean

After deploy, archived upsample/extend/reshoot/object_insert/object_remove tasks will appear alongside text2video/image2video tasks in the recent panel and become re-fetchable on poll.