### PR TITLE
feat(producer): rebuild config panel to match Suno-class UX

### DIFF
--- a/src/components/producer/ConfigPanel.vue
+++ b/src/components/producer/ConfigPanel.vue
@@ -1,31 +1,53 @@
 <template>
   <div class="flex flex-col h-full">
     <div class="flex-1 overflow-y-auto p-5">
-      <type-selector class="mb-4" />
-      <upload-audio class="mb-4" />
-      <prompt-input v-if="!config?.custom" class="mb-4" />
-      <lyric-input v-if="config?.custom && !config.instrumental" class="mb-4" />
-      <style-input v-if="config?.custom" class="mb-4" />
-      <title-input v-if="config?.custom" class="mb-4" />
-      <vocal-gender-selector v-if="config?.custom && !config.instrumental" class="mb-4" />
-      <extend-from-input v-if="config?.action === 'extend'" class="mb-4" />
-      <cover-from-input v-if="config?.action === 'cover'" class="mb-4" />
-      <replace-section-input v-if="config?.action === 'replace_section'" class="mb-4" />
-      <advanced-params class="mb-4" />
+      <el-tabs v-model="mode" class="producer-mode-tabs" stretch>
+        <el-tab-pane :label="$t('producer.mode.simple')" name="simple">
+          <div class="pt-2 px-1">
+            <type-selector class="mb-4" />
+            <upload-audio class="mb-4" />
+            <prompt-input class="mb-4" />
+            <extend-from-input v-if="config?.action === 'extend'" class="mb-4" />
+            <cover-from-input v-if="config?.action === 'cover'" class="mb-4" />
+            <replace-section-input v-if="config?.action === 'replace_section'" class="mb-4" />
+            <advanced-params class="mb-4" />
+          </div>
+        </el-tab-pane>
+        <el-tab-pane :label="$t('producer.mode.custom')" name="custom">
+          <div class="pt-2 px-1">
+            <type-selector class="mb-4" />
+            <upload-audio class="mb-4" />
+            <lyric-input v-if="!config?.instrumental" class="mb-4" />
+            <style-input class="mb-4" />
+            <title-input class="mb-4" />
+            <vocal-gender-selector v-if="!config?.instrumental" class="mb-4" />
+            <extend-from-input v-if="config?.action === 'extend'" class="mb-4" />
+            <cover-from-input v-if="config?.action === 'cover'" class="mb-4" />
+            <replace-section-input v-if="config?.action === 'replace_section'" class="mb-4" />
+            <advanced-params class="mb-4" />
+          </div>
+        </el-tab-pane>
+      </el-tabs>
     </div>
-    <div class="flex flex-col items-center justify-center px-5 pb-5">
+    <div class="flex flex-col items-center justify-center px-5 pb-5 gap-2">
       <consumption :value="consumption" :service="service" />
-      <el-button type="primary" class="btn w-full" round @click="onGenerate">
-        <font-awesome-icon icon="fa-solid fa-magic" class="mr-2" />
-        {{ generateButtonText }}
-      </el-button>
+      <div class="flex gap-2 w-full">
+        <el-button class="flex-1" @click="onClearAll">
+          <font-awesome-icon icon="fa-solid fa-broom" class="mr-1" />
+          {{ $t('producer.button.clear_all') }}
+        </el-button>
+        <el-button type="primary" class="flex-1" round @click="onGenerate">
+          <font-awesome-icon icon="fa-solid fa-magic" class="mr-2" />
+          {{ generateButtonText }}
+        </el-button>
+      </div>
     </div>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElButton } from 'element-plus';
+import { ElButton, ElTabs, ElTabPane } from 'element-plus';
 import TypeSelector from './config/TypeSelector.vue';
 import UploadAudio from './config/UploadAudio.vue';
 import PromptInput from './config/PromptInput.vue';
@@ -57,12 +79,25 @@ export default defineComponent({
     ReplaceSectionInput,
     FontAwesomeIcon,
     ElButton,
+    ElTabs,
+    ElTabPane,
     Consumption
   },
   emits: ['generate'],
   computed: {
     config() {
       return this.$store.state.producer?.config;
+    },
+    mode: {
+      get(): 'simple' | 'custom' {
+        return this.$store.state.producer?.config?.custom ? 'custom' : 'simple';
+      },
+      set(val: 'simple' | 'custom') {
+        this.$store.commit('producer/setConfig', {
+          ...this.$store.state.producer?.config,
+          custom: val === 'custom'
+        });
+      }
     },
     consumption() {
       return getConsumption(this.config, this.service?.cost);
@@ -72,8 +107,8 @@ export default defineComponent({
     },
     generateButtonText() {
       const action = this.config?.action;
-      if (action === 'extend') return this.$t('producer.button.extend');
-      if (action === 'cover') return this.$t('producer.button.cover_music');
+      if (action === 'extend' || action === 'upload_extend') return this.$t('producer.button.extend');
+      if (action === 'cover' || action === 'upload_cover') return this.$t('producer.button.cover_music');
       if (action === 'variation') return this.$t('producer.button.variation');
       if (action === 'replace_section') return this.$t('producer.button.replace_section');
       if (action === 'stems') return this.$t('producer.button.get_stems');
@@ -85,31 +120,30 @@ export default defineComponent({
   methods: {
     onGenerate() {
       this.$emit('generate');
+    },
+    onClearAll() {
+      this.$store.commit('producer/setConfig', {
+        custom: this.$store.state.producer?.config?.custom || false,
+        instrumental: false,
+        prompt: '',
+        lyric: '',
+        style: '',
+        title: '',
+        model: this.$store.state.producer?.config?.model
+      });
     }
   }
 });
 </script>
 
 <style lang="scss" scoped>
-.panel {
-  height: 100%;
-  padding: 20px;
-  display: flex;
-  flex-direction: column;
-  .config {
-    width: 100%;
-    height: calc(100% - 50px);
-    flex: 1;
-    position: relative;
+.producer-mode-tabs {
+  :deep(.el-tabs__nav-wrap::after) {
+    height: 1px;
   }
-  .actions {
-    height: 50px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    .btn {
-      width: 100%;
-    }
+  :deep(.el-tabs__item) {
+    font-size: 14px;
+    font-weight: 500;
   }
 }
 </style>

--- a/src/components/producer/config/AdvancedParams.vue
+++ b/src/components/producer/config/AdvancedParams.vue
@@ -1,58 +1,71 @@
 <template>
   <el-collapse v-model="activeNames" class="advanced-collapse">
     <el-collapse-item :title="$t('producer.name.advancedParams')" name="advanced">
-      <!-- Style Negative -->
+      <!-- Style Negative (custom mode only) -->
       <div v-if="config?.custom" class="mb-3">
         <div class="flex items-center mb-1">
           <span class="text-xs font-bold">{{ $t('producer.name.styleNegative') }}</span>
+          <info-icon :content="$t('producer.description.styleNegative')" />
         </div>
-        <el-input v-model="styleNegative" :placeholder="$t('producer.placeholder.styleNegative')" />
+        <el-input v-model="styleNegative" size="small" :placeholder="$t('producer.placeholder.styleNegative')" />
       </div>
 
-      <!-- Lyric Prompt (auto-generate lyrics) -->
+      <!-- Lyric Prompt (auto-generate lyrics seed; only meaningful in custom + vocal) -->
       <div v-if="config?.custom && !config?.instrumental" class="mb-3">
         <div class="flex items-center mb-1">
           <span class="text-xs font-bold">{{ $t('producer.name.lyricPrompt') }}</span>
+          <info-icon :content="$t('producer.description.lyricPrompt')" />
         </div>
-        <el-input v-model="lyricPrompt" :placeholder="$t('producer.placeholder.lyricPrompt')" />
+        <el-input v-model="lyricPrompt" size="small" :placeholder="$t('producer.placeholder.lyricPrompt')" />
       </div>
 
-      <!-- Weirdness -->
-      <div v-if="config?.custom" class="mb-3">
+      <!-- Weirdness (always available) -->
+      <div class="mb-3">
         <div class="flex items-center justify-between mb-1">
-          <span class="text-xs font-bold">{{ $t('producer.name.weirdness') }}</span>
-          <span class="text-xs text-[var(--el-text-color-secondary)]">{{ weirdness ?? 0 }}</span>
+          <div class="flex items-center">
+            <span class="text-xs font-bold">{{ $t('producer.name.weirdness') }}</span>
+            <info-icon :content="$t('producer.description.weirdness')" />
+          </div>
+          <span class="text-xs text-[var(--el-text-color-secondary)]">{{ weirdness ?? 50 }}</span>
         </div>
         <el-slider v-model="weirdness" :min="0" :max="100" :step="1" />
       </div>
 
-      <!-- Sound Strength -->
-      <div v-if="config?.custom" class="mb-3">
+      <!-- Sound Strength (always available — drives audio prompt intensity) -->
+      <div class="mb-3">
         <div class="flex items-center justify-between mb-1">
-          <span class="text-xs font-bold">{{ $t('producer.name.soundStrength') }}</span>
+          <div class="flex items-center">
+            <span class="text-xs font-bold">{{ $t('producer.name.soundStrength') }}</span>
+            <info-icon :content="$t('producer.description.soundStrength')" />
+          </div>
           <span class="text-xs text-[var(--el-text-color-secondary)]">{{ soundStrength ?? 50 }}</span>
         </div>
         <el-slider v-model="soundStrength" :min="0" :max="100" :step="1" />
       </div>
 
-      <!-- Lyrics Strength -->
+      <!-- Lyrics Strength (custom + vocal only) -->
       <div v-if="config?.custom && !config?.instrumental" class="mb-3">
         <div class="flex items-center justify-between mb-1">
-          <span class="text-xs font-bold">{{ $t('producer.name.lyricsStrength') }}</span>
+          <div class="flex items-center">
+            <span class="text-xs font-bold">{{ $t('producer.name.lyricsStrength') }}</span>
+            <info-icon :content="$t('producer.description.lyricsStrength')" />
+          </div>
           <span class="text-xs text-[var(--el-text-color-secondary)]">{{ lyricsStrength ?? 50 }}</span>
         </div>
         <el-slider v-model="lyricsStrength" :min="0" :max="100" :step="1" />
       </div>
 
-      <!-- Seed -->
-      <div v-if="config?.custom" class="mb-3">
+      <!-- Seed (always available) -->
+      <div class="mb-3">
         <div class="flex items-center mb-1">
           <span class="text-xs font-bold">{{ $t('producer.name.seed') }}</span>
+          <info-icon :content="$t('producer.description.seed')" />
         </div>
         <el-input-number
           v-model="seed"
           :min="0"
           :controls="false"
+          size="small"
           :placeholder="$t('producer.placeholder.seed')"
           class="w-full"
         />
@@ -64,6 +77,7 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import { ElCollapse, ElCollapseItem, ElInput, ElSlider, ElInputNumber } from 'element-plus';
+import InfoIcon from '@/components/common/InfoIcon.vue';
 
 export default defineComponent({
   name: 'AdvancedParams',
@@ -72,7 +86,8 @@ export default defineComponent({
     ElCollapseItem,
     ElInput,
     ElSlider,
-    ElInputNumber
+    ElInputNumber,
+    InfoIcon
   },
   data() {
     return {
@@ -107,12 +122,12 @@ export default defineComponent({
     },
     weirdness: {
       get() {
-        return this.$store.state.producer?.config?.weirdness ?? 0;
+        return this.$store.state.producer?.config?.weirdness ?? 50;
       },
       set(val: number) {
         this.$store.commit('producer/setConfig', {
           ...this.$store.state.producer?.config,
-          weirdness: val || undefined
+          weirdness: val
         });
       }
     },
@@ -152,6 +167,27 @@ export default defineComponent({
   }
 });
 </script>
+
+<style lang="scss" scoped>
+.advanced-collapse {
+  border: none;
+  :deep(.el-collapse-item__header) {
+    font-size: 14px;
+    font-weight: bold;
+    background: transparent;
+    border: none;
+    height: 32px;
+    line-height: 32px;
+  }
+  :deep(.el-collapse-item__wrap) {
+    background: transparent;
+    border: none;
+  }
+  :deep(.el-collapse-item__content) {
+    padding-bottom: 0;
+  }
+}
+</style>
 
 <style lang="scss" scoped>
 .advanced-collapse {

--- a/src/components/producer/config/TypeSelector.vue
+++ b/src/components/producer/config/TypeSelector.vue
@@ -1,29 +1,31 @@
 <template>
   <div>
-    <!-- Custom Mode Toggle -->
-    <div class="flex items-center justify-between mb-3">
-      <span class="text-sm font-bold">{{ $t('producer.name.type') }}</span>
-      <el-switch v-model="custom" />
-    </div>
-
     <!-- Model Selection -->
     <div class="mb-3">
       <div class="flex items-center mb-1">
         <span class="text-sm font-bold">{{ $t('producer.name.model') }}</span>
       </div>
-      <el-select v-model="model" class="w-full" size="default" :placeholder="$t('producer.placeholder.select')">
+      <el-select
+        v-model="model"
+        class="w-full model-select"
+        size="default"
+        :placeholder="$t('producer.placeholder.select')"
+      >
         <el-option v-for="item in options" :key="item.value" :label="item.label" :value="item.value">
-          <div class="flex items-center justify-between w-full">
-            <span>{{ item.label }}</span>
-            <span class="text-xs text-[var(--el-text-color-placeholder)]">{{ item.info }}</span>
+          <div class="model-option">
+            <span class="model-option-name">{{ item.label }}</span>
+            <span class="model-option-desc">{{ item.desc }}</span>
           </div>
         </el-option>
       </el-select>
     </div>
 
-    <!-- Song Description / Instrumental Toggle -->
+    <!-- Instrumental Toggle (custom mode only) -->
     <div v-if="custom" class="flex items-center justify-between mb-3">
-      <span class="text-sm font-bold">{{ $t('producer.name.instrumental') }}</span>
+      <div class="flex items-center">
+        <span class="text-sm font-bold">{{ $t('producer.name.instrumental') }}</span>
+        <info-icon :content="$t('producer.description.instrumental')" />
+      </div>
       <el-switch v-model="instrumental" />
     </div>
   </div>
@@ -32,59 +34,35 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import { ElSelect, ElOption, ElSwitch } from 'element-plus';
+import InfoIcon from '@/components/common/InfoIcon.vue';
 import { PRODUCER_DEFAULT_MODEL } from '@/constants';
+
+interface ModelOption {
+  label: string;
+  value: string;
+  desc: string;
+}
 
 export default defineComponent({
   name: 'TypeSelector',
   components: {
     ElSelect,
     ElOption,
-    ElSwitch
+    ElSwitch,
+    InfoIcon
   },
   data() {
     return {
       options: [
-        {
-          label: 'FUZZ-2.0 Pro',
-          value: 'FUZZ-2.0 Pro',
-          info: '8 min'
-        },
-        {
-          label: 'FUZZ-2.0',
-          value: 'FUZZ-2.0',
-          info: '8 min'
-        },
-        {
-          label: 'FUZZ-2.0 Raw',
-          value: 'FUZZ-2.0 Raw',
-          info: '8 min'
-        },
-        {
-          label: 'FUZZ-1.1 Pro',
-          value: 'FUZZ-1.1 Pro',
-          info: '4 min'
-        },
-        {
-          label: 'FUZZ-1.0 Pro',
-          value: 'FUZZ-1.0 Pro',
-          info: '4 min'
-        },
-        {
-          label: 'FUZZ-1.1',
-          value: 'FUZZ-1.1',
-          info: '4 min'
-        },
-        {
-          label: 'FUZZ-1.0',
-          value: 'FUZZ-1.0',
-          info: '2 min'
-        },
-        {
-          label: 'FUZZ-0.8',
-          value: 'FUZZ-0.8',
-          info: '2 min'
-        }
-      ]
+        { label: 'FUZZ-2.0 Pro', value: 'FUZZ-2.0 Pro', desc: this.$t('producer.model.fuzz20proDesc') },
+        { label: 'FUZZ-2.0', value: 'FUZZ-2.0', desc: this.$t('producer.model.fuzz20desc') },
+        { label: 'FUZZ-2.0 Raw', value: 'FUZZ-2.0 Raw', desc: this.$t('producer.model.fuzz20rawDesc') },
+        { label: 'FUZZ-1.1 Pro', value: 'FUZZ-1.1 Pro', desc: this.$t('producer.model.fuzz11proDesc') },
+        { label: 'FUZZ-1.1', value: 'FUZZ-1.1', desc: this.$t('producer.model.fuzz11desc') },
+        { label: 'FUZZ-1.0 Pro', value: 'FUZZ-1.0 Pro', desc: this.$t('producer.model.fuzz10proDesc') },
+        { label: 'FUZZ-1.0', value: 'FUZZ-1.0', desc: this.$t('producer.model.fuzz10desc') },
+        { label: 'FUZZ-0.8', value: 'FUZZ-0.8', desc: this.$t('producer.model.fuzz08desc') }
+      ] as ModelOption[]
     };
   },
   computed: {
@@ -129,3 +107,24 @@ export default defineComponent({
   }
 });
 </script>
+
+<style lang="scss" scoped>
+.model-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 2px 0;
+}
+
+.model-option-name {
+  font-weight: 500;
+}
+
+.model-option-desc {
+  font-size: 12px;
+  color: var(--el-text-color-placeholder);
+  margin-left: 8px;
+  white-space: nowrap;
+}
+</style>

--- a/src/components/producer/config/UploadAudio.vue
+++ b/src/components/producer/config/UploadAudio.vue
@@ -1,43 +1,55 @@
 <template>
   <div class="relative">
-    <div class="flex justify-between">
+    <div class="flex justify-between items-center mb-2">
       <div class="flex justify-start items-center">
         <span class="text-sm font-bold">{{ $t('producer.name.referenceAudios') }}</span>
         <info-icon :content="$t('producer.description.uploadAudios')" />
       </div>
+      <el-upload
+        v-model:file-list="fileList"
+        name="file"
+        :limit="1"
+        class="upload-wrapper inline-upload"
+        :action="uploadUrl"
+        accept=".mp3,.wav,.m4a,audio/*"
+        :show-file-list="false"
+        :on-exceed="onExceed"
+        :on-error="onError"
+        :on-success="onSuccess"
+        :headers="headers"
+      >
+        <el-button round type="primary" size="small" :loading="uploading">
+          <font-awesome-icon icon="fa-solid fa-upload" class="icon mr-1" />
+          {{ $t('producer.button.uploadAudios') }}
+        </el-button>
+      </el-upload>
     </div>
-    <el-upload
-      v-model:file-list="fileList"
-      name="file"
-      :limit="1"
-      class="upload-wrapper"
-      :action="uploadUrl"
-      accept=".mp3"
-      :show-file-list="true"
-      :on-exceed="onExceed"
-      :on-error="onError"
-      :on-success="onSuccess"
-      :headers="headers"
-    >
-      <el-button round type="primary" size="small" class="btn btn-upload">
-        <font-awesome-icon icon="fa-solid fa-upload" class="icon mr-1" />
-        {{ $t('producer.button.uploadAudios') }}
-      </el-button>
-    </el-upload>
+    <div v-if="audioPreviewUrl" class="mb-2">
+      <audio :src="audioPreviewUrl" controls class="w-full" />
+    </div>
+    <div v-if="hasUploadedAudio" class="mt-1">
+      <el-radio-group v-model="uploadAction" size="small">
+        <el-radio-button value="upload_extend">{{ $t('producer.button.extend') }}</el-radio-button>
+        <el-radio-button value="upload_cover">{{ $t('producer.button.cover_music') }}</el-radio-button>
+      </el-radio-group>
+    </div>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElUpload, ElButton, UploadFiles, UploadFile, ElMessage } from 'element-plus';
+import { ElUpload, ElButton, ElRadioGroup, ElRadioButton, UploadFiles, UploadFile, ElMessage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { getBaseUrlPlatform } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import { IProducerUploadRequest } from '@/models';
 import { producerOperator } from '@/operators';
+
 interface IData {
   fileList: UploadFiles;
   uploadUrl: string;
+  audioPreviewUrl: string | null;
+  uploading: boolean;
 }
 
 export default defineComponent({
@@ -45,6 +57,8 @@ export default defineComponent({
   components: {
     ElUpload,
     ElButton,
+    ElRadioGroup,
+    ElRadioButton,
     InfoIcon,
     FontAwesomeIcon
   },
@@ -52,7 +66,9 @@ export default defineComponent({
   data(): IData {
     return {
       fileList: [],
-      uploadUrl: getBaseUrlPlatform() + '/api/v1/files/'
+      uploadUrl: getBaseUrlPlatform() + '/api/v1/files/',
+      audioPreviewUrl: null,
+      uploading: false
     };
   },
   computed: {
@@ -71,11 +87,20 @@ export default defineComponent({
       // @ts-ignore
       return this.fileList.map((file: UploadFile) => file?.response?.file_url);
     },
-    value: {
+    hasUploadedAudio() {
+      const action = this.$store.state.producer?.config?.action;
+      return action === 'upload_extend' || action === 'upload_cover';
+    },
+    uploadAction: {
       get() {
-        return this.$store.state.producer?.config?.audio_id;
+        return this.$store.state.producer?.config?.action || 'upload_extend';
       },
-      set() {}
+      set(val: string) {
+        this.$store.commit('producer/setConfig', {
+          ...this.$store.state.producer?.config,
+          action: val
+        });
+      }
     }
   },
   watch: {
@@ -85,78 +110,56 @@ export default defineComponent({
       }
     }
   },
-  mounted() {
-    if (!this.value) {
-      this.value = undefined;
-    }
-    this.onSetAudio();
-  },
   methods: {
     onExceed() {
       ElMessage.warning(this.$t('producer.message.uploadReferencesExceed'));
     },
     onError() {
+      this.uploading = false;
       ElMessage.error(this.$t('producer.message.uploadReferencesError'));
     },
     async onSuccess() {
       const url = this.urls?.[0];
+      if (!url) {
+        this.uploading = false;
+        return;
+      }
+      this.audioPreviewUrl = url;
       await this.onGenerateAudioId(url);
     },
     async onGenerateAudioId(audio_url: string) {
-      const request = {
-        audio_url
-      } as IProducerUploadRequest;
+      const request = { audio_url } as IProducerUploadRequest;
       const token = this.credential?.token;
       if (!token) {
         console.error('no token specified');
+        this.uploading = false;
         return;
       }
+      this.uploading = true;
       ElMessage.info(this.$t('producer.message.startingUploadAudio'));
-      producerOperator
-        .upload(request, {
-          token
-        })
-        .then((response) => {
-          console.debug('get upload music success', response.data);
-          const audio_id = response.data?.data.audio_id;
-          this.$store.commit('producer/setConfig', {
-            ...this.$store.state.producer?.config,
-            audio_id: audio_id,
-            action: 'upload_extend'
-          });
-          ElMessage.success(this.$t('producer.message.startUploadAudioSuccess'));
-        })
-        .catch((error) => {
-          ElMessage.error(error?.response?.data?.error?.message || this.$t('producer.message.startUploadAudioFailed'));
+      try {
+        const response = await producerOperator.upload(request, { token });
+        const audio_id = response.data?.data.audio_id;
+        this.$store.commit('producer/setConfig', {
+          ...this.$store.state.producer?.config,
+          audio_id,
+          action: 'upload_extend'
         });
-    },
-    onSetAudio() {
-      // placeholder for future logic
+        ElMessage.success(this.$t('producer.message.startUploadAudioSuccess'));
+      } catch (error: any) {
+        ElMessage.error(error?.response?.data?.error?.message || this.$t('producer.message.startUploadAudioFailed'));
+      } finally {
+        this.uploading = false;
+      }
     }
   }
 });
 </script>
 
 <style lang="scss" scoped>
-.title {
-  font-size: 14px;
-  margin-bottom: 0;
-  width: 30%;
-}
-.btn.btn-upload {
-  position: absolute;
-  top: 5px;
-  right: 0;
-}
-</style>
-
-<style lang="scss">
-.upload-wrapper {
-  height: auto;
-  display: flex;
-  .el-upload-list {
-    margin: 0;
-    width: 100%;
+.upload-wrapper.inline-upload {
+  :deep(.el-upload) {
+    display: inline-flex;
   }
 }
 </style>

--- a/src/i18n/en/producer.json
+++ b/src/i18n/en/producer.json
@@ -63,37 +63,81 @@
     "message": "Swap Instrumentals",
     "description": "Text for the button to swap instrumentals"
   },
+  "button.clear_all": {
+    "message": "Clear All",
+    "description": "Text for the button that clears all configuration fields"
+  },
+  "mode.simple": {
+    "message": "Simple",
+    "description": "Label for the simple generation mode tab"
+  },
+  "mode.custom": {
+    "message": "Custom",
+    "description": "Label for the custom generation mode tab"
+  },
   "model.fuzz20pro": {
     "message": "FUZZ-2.0 Pro",
     "description": "Model used for generating music"
+  },
+  "model.fuzz20proDesc": {
+    "message": "Up to 8 min · Highest quality",
+    "description": "Description shown next to FUZZ-2.0 Pro in the model selector"
   },
   "model.fuzz20": {
     "message": "FUZZ-2.0",
     "description": "Model used for generating music"
   },
+  "model.fuzz20desc": {
+    "message": "Up to 8 min · Balanced",
+    "description": "Description shown next to FUZZ-2.0 in the model selector"
+  },
   "model.fuzz20raw": {
     "message": "FUZZ-2.0 Raw",
     "description": "Model used for generating music"
+  },
+  "model.fuzz20rawDesc": {
+    "message": "Up to 8 min · Less polished, more raw",
+    "description": "Description shown next to FUZZ-2.0 Raw in the model selector"
   },
   "model.fuzz11pro": {
     "message": "FUZZ-1.1 Pro",
     "description": "Model used for generating music"
   },
+  "model.fuzz11proDesc": {
+    "message": "Up to 4 min · Refined v1",
+    "description": "Description shown next to FUZZ-1.1 Pro in the model selector"
+  },
   "model.fuzz10pro": {
     "message": "FUZZ-1.0 Pro",
     "description": "Model used for generating music"
+  },
+  "model.fuzz10proDesc": {
+    "message": "Up to 4 min · Stable",
+    "description": "Description shown next to FUZZ-1.0 Pro in the model selector"
   },
   "model.fuzz10": {
     "message": "FUZZ-1.0",
     "description": "Model used for generating music"
   },
+  "model.fuzz10desc": {
+    "message": "Up to 2 min · Legacy",
+    "description": "Description shown next to FUZZ-1.0 in the model selector"
+  },
   "model.fuzz11": {
     "message": "FUZZ-1.1",
     "description": "Model used for generating music"
   },
+  "model.fuzz11desc": {
+    "message": "Up to 4 min · Legacy refined",
+    "description": "Description shown next to FUZZ-1.1 in the model selector"
+  },
   "model.fuzz08": {
     "message": "FUZZ-0.8",
     "description": "Model used for generating music"
+  },
+  "model.fuzz08desc": {
+    "message": "Up to 2 min · Earliest",
+    "description": "Description shown next to FUZZ-0.8 in the model selector"
   },
   "name.instrumental": {
     "message": "Instrumental",
@@ -246,6 +290,10 @@
   "description.replaceSection": {
     "message": "Replace content in the specified time section of the song",
     "description": "Description for the replace segment feature"
+  },
+  "description.instrumental": {
+    "message": "Generate music without vocals; lyrics inputs are ignored",
+    "description": "Description shown next to the instrumental toggle"
   },
   "status.pending": {
     "message": "Pending",

--- a/src/i18n/zh-CN/producer.json
+++ b/src/i18n/zh-CN/producer.json
@@ -63,37 +63,81 @@
     "message": "伴奏替换",
     "description": "伴奏替换按钮文本"
   },
+  "button.clear_all": {
+    "message": "清空",
+    "description": "清空全部配置项的按钮文本"
+  },
+  "mode.simple": {
+    "message": "简单模式",
+    "description": "简单生成模式 Tab 的标签"
+  },
+  "mode.custom": {
+    "message": "定制模式",
+    "description": "定制生成模式 Tab 的标签"
+  },
   "model.fuzz20pro": {
     "message": "FUZZ-2.0 Pro",
     "description": "用于生成音乐的模型"
+  },
+  "model.fuzz20proDesc": {
+    "message": "最长 8 分钟 · 最佳音质",
+    "description": "FUZZ-2.0 Pro 在模型下拉中的描述"
   },
   "model.fuzz20": {
     "message": "FUZZ-2.0",
     "description": "用于生成音乐的模型"
   },
+  "model.fuzz20desc": {
+    "message": "最长 8 分钟 · 性价比均衡",
+    "description": "FUZZ-2.0 在模型下拉中的描述"
+  },
   "model.fuzz20raw": {
     "message": "FUZZ-2.0 Raw",
     "description": "用于生成音乐的模型"
+  },
+  "model.fuzz20rawDesc": {
+    "message": "最长 8 分钟 · 更原生粗糙的人声",
+    "description": "FUZZ-2.0 Raw 在模型下拉中的描述"
   },
   "model.fuzz11pro": {
     "message": "FUZZ-1.1 Pro",
     "description": "用于生成音乐的模型"
   },
+  "model.fuzz11proDesc": {
+    "message": "最长 4 分钟 · 旧版精修",
+    "description": "FUZZ-1.1 Pro 在模型下拉中的描述"
+  },
   "model.fuzz10pro": {
     "message": "FUZZ-1.0 Pro",
     "description": "用于生成音乐的模型"
+  },
+  "model.fuzz10proDesc": {
+    "message": "最长 4 分钟 · 旧版稳定",
+    "description": "FUZZ-1.0 Pro 在模型下拉中的描述"
   },
   "model.fuzz10": {
     "message": "FUZZ-1.0",
     "description": "用于生成音乐的模型"
   },
+  "model.fuzz10desc": {
+    "message": "最长 2 分钟 · 旧版",
+    "description": "FUZZ-1.0 在模型下拉中的描述"
+  },
   "model.fuzz11": {
     "message": "FUZZ-1.1",
     "description": "用于生成音乐的模型"
   },
+  "model.fuzz11desc": {
+    "message": "最长 4 分钟 · 旧版改良",
+    "description": "FUZZ-1.1 在模型下拉中的描述"
+  },
   "model.fuzz08": {
     "message": "FUZZ-0.8",
     "description": "用于生成音乐的模型"
+  },
+  "model.fuzz08desc": {
+    "message": "最长 2 分钟 · 早期版本",
+    "description": "FUZZ-0.8 在模型下拉中的描述"
   },
   "name.instrumental": {
     "message": "纯音乐",
@@ -246,6 +290,10 @@
   "description.replaceSection": {
     "message": "替换歌曲中指定时间段的内容",
     "description": "替换片段功能的描述"
+  },
+  "description.instrumental": {
+    "message": "生成不含人声的纯音乐，歌词输入将被忽略",
+    "description": "纯音乐开关的提示描述"
   },
   "status.pending": {
     "message": "等待中",


### PR DESCRIPTION
## Summary

The Producer panel at https://studio.acedata.cloud/producer was a stripped-down version of the Suno panel and didn't expose most of what `/producer/audios` actually supports. User report:

> 'producer 的 nexior 面板就这么简单吗？... Advanced Parameters 在普通模式都站不开 ... 高级模式为啥是个开关，为啥不能对标 suno'

This PR rebuilds the Producer config panel to match the Suno UX while keeping every Producer-specific knob.

## What was wrong

| Issue | Cause |
|---|---|
| Panel feels far simpler than Suno | All advanced inputs lived under a single `<el-switch>` Custom Mode toggle and most fields were gated behind `config?.custom` |
| 'Advanced Parameters' collapsible looks empty in non-custom mode | Every advanced field inside it was `v-if=\"config?.custom\"` — expanding it in Simple mode revealed nothing (the '站不开' complaint) |
| Custom Mode is a toggle, not tabs like Suno | Just a leftover from the original Producer scaffolding |
| After uploading a reference audio, the only achievable action is `upload_extend` | `UploadAudio.vue` hard-coded `action: 'upload_extend'` and exposed no UI to switch to `upload_cover` (which the API supports) |
| No 'Clear All' button | — |
| Model dropdown shows '8 min' for every FUZZ-2.0 variant — unhelpful | hard-coded `info` field |

## Changes

### Layout — `src/components/producer/ConfigPanel.vue`

Replaced the single-toggle layout with the Suno `<el-tabs>` 'Simple / Custom' pattern, plus a 'Clear All' button next to Generate. The action selector under upload now drives the generate button label (extend / cover).

### Model selector — `src/components/producer/config/TypeSelector.vue`

Removed the redundant 'Custom Mode' switch (the tabs own that now). Replaced `info: '8 min'` with per-model descriptions ('Up to 8 min · Highest quality', '· Less polished, more raw', '· Refined v1', etc.) for all 8 FUZZ variants. Added an info icon next to the Instrumental switch.

### Advanced parameters — `src/components/producer/config/AdvancedParams.vue`

Re-gated every field by where it's actually meaningful upstream:

| Field | Visibility | Reason |
|---|---|---|
| Style Negative | custom only | depends on `style` |
| Lyric Prompt | custom + vocal | feeds the lyric-generation helper |
| Lyrics Strength | custom + vocal | only affects lyric weight |
| Weirdness | always | accepted on every action |
| Sound Strength | always | accepted on every action including reference-driven cases |
| Seed | always | accepted on every action |

Result: the 'Advanced Parameters' collapse now has real content in Simple mode (Weirdness / Sound Strength / Seed) instead of an empty drawer.

### Reference audio — `src/components/producer/config/UploadAudio.vue`

Adopted the Suno pattern: after upload show an inline `<audio controls>` preview plus a small `upload_extend / upload_cover` radio group. The upload button is now next to the title (instead of an absolutely-positioned overlay) and accepts `.mp3, .wav, .m4a, audio/*` instead of MP3 only — the upstream backend (`PlatformService/ttapi/worker/src/handlers/producer/upload.ts`) is content-type-agnostic.

### i18n — zh-CN + en only

Added: `mode.simple`, `mode.custom`, `button.clear_all`, `description.instrumental`, `model.fuzz{20pro,20,20raw,11pro,11,10pro,10,08}Desc`. Per repo convention I'm not running any auto-translate; the translation CronJob will pick the rest up.

## API capabilities now reachable from the panel

Form-driven (this PR):

- `generate` — Simple (prompt) or Custom (lyric + style + title + vocal_gender + instrumental)
- `upload_extend` and `upload_cover` — exposed via the new radio group after upload
- `extend`, `cover`, `replace_section` — already exposed via the per-task 'more actions' dropdown in `task/Preview.vue`, and the Generate button label / `<extend-from-input>` / `<cover-from-input>` / `<replace-section-input>` blocks already render correctly when those actions are selected from there

Task-action-only (already covered by `task/Preview.vue` dropdowns, no form UI needed):

- `variation`, `swap_vocals`, `swap_instrumentals`, `stems`

## Verification

- `npx eslint src/components/producer/ConfigPanel.vue src/components/producer/config/{TypeSelector,AdvancedParams,UploadAudio}.vue` — clean
- `npx vue-tsc --noEmit` — clean
- JSON sanity check on both locale files — clean