### PR TITLE
feat(seedream): expose full set of API parameters in studio panel

### DIFF
--- a/change/@acedatacloud-nexior-feat-seedream-full-panel.json
+++ b/change/@acedatacloud-nexior-feat-seedream-full-panel.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(seedream): expand panel with watermark, seed, guidance scale, output format and richer size presets",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/seedream/ConfigPanel.vue
+++ b/src/components/seedream/ConfigPanel.vue
@@ -4,6 +4,10 @@
       <model-selector class="mb-4" />
       <size-selector class="mb-4" />
       <max-images-selector class="mb-4" />
+      <output-format-selector class="mb-4" />
+      <seed-input class="mb-4" />
+      <guidance-scale-input class="mb-4" />
+      <watermark-switch class="mb-4" />
       <prompt-input class="mb-4" />
       <image-input class="mb-4" />
     </div>
@@ -28,6 +32,10 @@ import { getConsumption } from '@/utils';
 import ModelSelector from './config/ModelSelector.vue';
 import SizeSelector from './config/SizeSelector.vue';
 import MaxImagesSelector from './config/MaxImagesSelector.vue';
+import OutputFormatSelector from './config/OutputFormatSelector.vue';
+import SeedInput from './config/SeedInput.vue';
+import GuidanceScaleInput from './config/GuidanceScaleInput.vue';
+import WatermarkSwitch from './config/WatermarkSwitch.vue';
 import { getSeedreamShortModel } from '@/constants';
 
 export default defineComponent({
@@ -40,7 +48,11 @@ export default defineComponent({
     ImageInput,
     ModelSelector,
     SizeSelector,
-    MaxImagesSelector
+    MaxImagesSelector,
+    OutputFormatSelector,
+    SeedInput,
+    GuidanceScaleInput,
+    WatermarkSwitch
   },
   emits: ['generate'],
   computed: {

--- a/src/components/seedream/config/GuidanceScaleInput.vue
+++ b/src/components/seedream/config/GuidanceScaleInput.vue
@@ -1,0 +1,114 @@
+<template>
+  <div v-if="supported" class="field">
+    <div class="label">
+      <div class="box">
+        <h2 class="title font-bold">{{ $t('seedream.name.guidanceScale') }}</h2>
+        <info-icon :content="$t('seedream.description.guidanceScale')" class="info" />
+      </div>
+    </div>
+    <div class="value">
+      <el-input-number
+        v-model="value"
+        :min="1"
+        :max="10"
+        :step="0.1"
+        :precision="1"
+        size="default"
+        controls-position="right"
+        class="counter"
+      />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElInputNumber } from 'element-plus';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+import { SEEDREAM_GUIDANCE_SCALE_DEFAULTS, supportsSeedreamGuidanceScale } from '@/constants';
+
+export default defineComponent({
+  name: 'SeedreamGuidanceScaleInput',
+  components: {
+    ElInputNumber,
+    InfoIcon
+  },
+  computed: {
+    config(): any {
+      return this.$store.state.seedream?.config || {};
+    },
+    supported(): boolean {
+      return supportsSeedreamGuidanceScale(this.config?.model);
+    },
+    defaultValue(): number {
+      const m: string | undefined = this.config?.model;
+      return (m && SEEDREAM_GUIDANCE_SCALE_DEFAULTS[m]) || 2.5;
+    },
+    value: {
+      get(): number {
+        const v = this.config?.guidance_scale;
+        return typeof v === 'number' ? v : this.defaultValue;
+      },
+      set(val: number) {
+        const cfg = { ...(this.config || {}) };
+        const next = typeof val === 'number' && val >= 1 && val <= 10 ? val : this.defaultValue;
+        cfg.guidance_scale = next;
+        this.$store.commit('seedream/setConfig', cfg);
+      }
+    }
+  },
+  watch: {
+    supported: {
+      immediate: true,
+      handler(v: boolean) {
+        if (v) return;
+        const cfg = { ...(this.config || {}) };
+        if (cfg.guidance_scale !== undefined) {
+          delete cfg.guidance_scale;
+          this.$store.commit('seedream/setConfig', cfg);
+        }
+      }
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.field {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+
+  .label {
+    width: 30%;
+    display: flex;
+    align-items: center;
+
+    .box {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+
+      .title {
+        font-size: 14px;
+        margin: 0;
+      }
+
+      .info {
+        margin-left: 6px;
+      }
+    }
+  }
+
+  .value {
+    width: 160px;
+    display: flex;
+    justify-content: flex-end;
+
+    .counter {
+      width: 140px;
+    }
+  }
+}
+</style>

--- a/src/components/seedream/config/OutputFormatSelector.vue
+++ b/src/components/seedream/config/OutputFormatSelector.vue
@@ -1,0 +1,99 @@
+<template>
+  <div v-if="supported" class="field">
+    <div class="label">
+      <div class="box">
+        <h2 class="title font-bold">{{ $t('seedream.name.outputFormat') }}</h2>
+        <info-icon :content="$t('seedream.description.outputFormat')" class="info" />
+      </div>
+    </div>
+    <el-select v-model="value" class="value" :placeholder="$t('seedream.placeholder.select')">
+      <el-option v-for="item in options" :key="item" :label="item.toUpperCase()" :value="item" />
+    </el-select>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElSelect, ElOption } from 'element-plus';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+import { SEEDREAM_OUTPUT_FORMATS, supportsSeedreamOutputFormat } from '@/constants';
+
+export default defineComponent({
+  name: 'SeedreamOutputFormatSelector',
+  components: {
+    ElSelect,
+    ElOption,
+    InfoIcon
+  },
+  data() {
+    return {
+      options: [...SEEDREAM_OUTPUT_FORMATS]
+    };
+  },
+  computed: {
+    config(): any {
+      return this.$store.state.seedream?.config || {};
+    },
+    supported(): boolean {
+      return supportsSeedreamOutputFormat(this.config?.model);
+    },
+    value: {
+      get(): string | undefined {
+        return this.config?.output_format;
+      },
+      set(val: string) {
+        const cfg = { ...(this.config || {}) };
+        cfg.output_format = val;
+        this.$store.commit('seedream/setConfig', cfg);
+      }
+    }
+  },
+  watch: {
+    supported: {
+      immediate: true,
+      handler(v: boolean) {
+        if (v) return;
+        const cfg = { ...(this.config || {}) };
+        if (cfg.output_format !== undefined) {
+          delete cfg.output_format;
+          this.$store.commit('seedream/setConfig', cfg);
+        }
+      }
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.field {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+
+  .label {
+    width: 30%;
+    display: flex;
+    align-items: center;
+
+    .box {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+
+      .title {
+        font-size: 14px;
+        margin: 0;
+      }
+
+      .info {
+        margin-left: 6px;
+      }
+    }
+  }
+
+  .value {
+    width: 160px;
+  }
+}
+</style>

--- a/src/components/seedream/config/SeedInput.vue
+++ b/src/components/seedream/config/SeedInput.vue
@@ -1,0 +1,111 @@
+<template>
+  <div v-if="supported" class="field">
+    <div class="label">
+      <div class="box">
+        <h2 class="title font-bold">{{ $t('seedream.name.seed') }}</h2>
+        <info-icon :content="$t('seedream.description.seed')" class="info" />
+      </div>
+    </div>
+    <div class="value">
+      <el-input-number
+        v-model="value"
+        :min="-1"
+        :max="2147483647"
+        :step="1"
+        size="default"
+        controls-position="right"
+        class="counter"
+      />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElInputNumber } from 'element-plus';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+import { supportsSeedreamSeed } from '@/constants';
+
+export default defineComponent({
+  name: 'SeedreamSeedInput',
+  components: {
+    ElInputNumber,
+    InfoIcon
+  },
+  computed: {
+    config(): any {
+      return this.$store.state.seedream?.config || {};
+    },
+    supported(): boolean {
+      return supportsSeedreamSeed(this.config?.model);
+    },
+    value: {
+      get(): number {
+        const v = this.config?.seed;
+        return typeof v === 'number' ? v : -1;
+      },
+      set(val: number) {
+        const cfg = { ...(this.config || {}) };
+        const next = typeof val === 'number' && Number.isInteger(val) ? val : -1;
+        cfg.seed = next;
+        this.$store.commit('seedream/setConfig', cfg);
+      }
+    }
+  },
+  watch: {
+    // Drop `seed` when the user picks a model that doesn't support it so the
+    // request doesn't get rejected upstream.
+    supported: {
+      immediate: true,
+      handler(v: boolean) {
+        if (v) return;
+        const cfg = { ...(this.config || {}) };
+        if (cfg.seed !== undefined) {
+          delete cfg.seed;
+          this.$store.commit('seedream/setConfig', cfg);
+        }
+      }
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.field {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+
+  .label {
+    width: 30%;
+    display: flex;
+    align-items: center;
+
+    .box {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+
+      .title {
+        font-size: 14px;
+        margin: 0;
+      }
+
+      .info {
+        margin-left: 6px;
+      }
+    }
+  }
+
+  .value {
+    width: 160px;
+    display: flex;
+    justify-content: flex-end;
+
+    .counter {
+      width: 140px;
+    }
+  }
+}
+</style>

--- a/src/components/seedream/config/SizeSelector.vue
+++ b/src/components/seedream/config/SizeSelector.vue
@@ -14,21 +14,40 @@
       allow-create
       default-first-option
     >
-      <el-option v-for="item in options" :key="item.value" :label="item.label" :value="item.value" />
+      <el-option-group :label="$t('seedream.size.group.tier')">
+        <el-option v-for="item in tierOptions" :key="item.value" :label="item.label" :value="item.value" />
+      </el-option-group>
+      <el-option-group :label="$t('seedream.size.group.adaptive')">
+        <el-option
+          :key="SEEDREAM_SIZE_ADAPTIVE"
+          :label="$t('seedream.size.adaptive')"
+          :value="SEEDREAM_SIZE_ADAPTIVE"
+        />
+      </el-option-group>
+      <el-option-group :label="$t('seedream.size.group.pixel')">
+        <el-option
+          v-for="item in pixelOptions"
+          :key="item.value"
+          :label="`${item.value} (${item.ratio})`"
+          :value="item.value"
+        />
+      </el-option-group>
     </el-select>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElSelect, ElOption } from 'element-plus';
+import { ElSelect, ElOption, ElOptionGroup } from 'element-plus';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import {
   SEEDREAM_DEFAULT_SIZE,
+  SEEDREAM_PIXEL_PRESETS,
   SEEDREAM_SIZE_1K,
   SEEDREAM_SIZE_2K,
   SEEDREAM_SIZE_3K,
-  SEEDREAM_SIZE_4K
+  SEEDREAM_SIZE_4K,
+  SEEDREAM_SIZE_ADAPTIVE
 } from '@/constants';
 
 export default defineComponent({
@@ -36,16 +55,19 @@ export default defineComponent({
   components: {
     ElSelect,
     ElOption,
+    ElOptionGroup,
     InfoIcon
   },
   data() {
     return {
-      options: [
+      SEEDREAM_SIZE_ADAPTIVE,
+      tierOptions: [
         { value: SEEDREAM_SIZE_1K, label: SEEDREAM_SIZE_1K },
         { value: SEEDREAM_SIZE_2K, label: SEEDREAM_SIZE_2K },
         { value: SEEDREAM_SIZE_3K, label: SEEDREAM_SIZE_3K },
         { value: SEEDREAM_SIZE_4K, label: SEEDREAM_SIZE_4K }
-      ]
+      ],
+      pixelOptions: SEEDREAM_PIXEL_PRESETS
     };
   },
   computed: {
@@ -98,7 +120,7 @@ export default defineComponent({
   }
 
   .value {
-    width: 160px;
+    width: 200px;
   }
 }
 </style>

--- a/src/constants/seedream.ts
+++ b/src/constants/seedream.ts
@@ -14,10 +14,52 @@ export const SEEDREAM_SIZE_1K = '1K';
 export const SEEDREAM_SIZE_2K = '2K';
 export const SEEDREAM_SIZE_3K = '3K';
 export const SEEDREAM_SIZE_4K = '4K';
+export const SEEDREAM_SIZE_ADAPTIVE = 'adaptive';
 
 export const SEEDREAM_DEFAULT_SIZE = SEEDREAM_SIZE_2K;
 
 export const SEEDREAM_DEFAULT_WATERMARK = false;
+
+// Common explicit width×height presets (aspect ratio + pixel dimensions).
+// The Volcengine LAS API accepts any `<width>x<height>` string in addition to
+// the 1K-4K tier presets and `adaptive`. These cover the most useful aspect
+// ratios at 1K (~1MP) and 2K (~4MP).
+export const SEEDREAM_PIXEL_PRESETS: { value: string; ratio: string }[] = [
+  { value: '1024x1024', ratio: '1:1' },
+  { value: '1280x720', ratio: '16:9' },
+  { value: '720x1280', ratio: '9:16' },
+  { value: '1152x864', ratio: '4:3' },
+  { value: '864x1152', ratio: '3:4' },
+  { value: '1216x832', ratio: '3:2' },
+  { value: '832x1216', ratio: '2:3' },
+  { value: '2048x2048', ratio: '1:1' },
+  { value: '2560x1440', ratio: '16:9' },
+  { value: '1440x2560', ratio: '9:16' },
+  { value: '2304x1728', ratio: '4:3' },
+  { value: '1728x2304', ratio: '3:4' }
+];
+
+// Models that support `seed` and `guidance_scale`. Mirrors the upstream
+// validation in PlatformService/volcengine/worker/src/handlers/seedream/images.ts.
+export const SEEDREAM_SEED_MODELS: string[] = [SEEDREAM_MODEL_3_0_T2I, SEEDREAM_MODEL_SEEDEDIT_3_0_I2I];
+
+export const SEEDREAM_GUIDANCE_SCALE_DEFAULTS: Record<string, number> = {
+  [SEEDREAM_MODEL_3_0_T2I]: 2.5,
+  [SEEDREAM_MODEL_SEEDEDIT_3_0_I2I]: 5.5
+};
+
+// `output_format` is only accepted for doubao-seedream-5.0 by the upstream.
+export const SEEDREAM_OUTPUT_FORMAT_MODELS: string[] = [SEEDREAM_MODEL_5_0];
+export const SEEDREAM_OUTPUT_FORMATS = ['jpeg', 'png'] as const;
+
+export const supportsSeedreamSeed = (model?: string): boolean =>
+  !!model && SEEDREAM_SEED_MODELS.includes(model);
+
+export const supportsSeedreamGuidanceScale = (model?: string): boolean =>
+  !!model && SEEDREAM_SEED_MODELS.includes(model);
+
+export const supportsSeedreamOutputFormat = (model?: string): boolean =>
+  !!model && SEEDREAM_OUTPUT_FORMAT_MODELS.includes(model);
 
 // Group / multi-image generation:
 // Volcengine LAS supports up to 15 images per request when

--- a/src/i18n/en/seedream.json
+++ b/src/i18n/en/seedream.json
@@ -64,7 +64,7 @@
     "description": "Description of the model parameter"
   },
   "description.size": {
-    "message": "Image size. Supports presets `1K`, `2K`, `4K` or custom `<width>x<height>`.",
+    "message": "Image size. Pick a resolution tier (1K-4K), `adaptive` (match the reference image), or an explicit `<width>x<height>` like `1024x1024` or `1280x720`. You can also type any `<width>x<height>` directly into the dropdown.",
     "description": "Description of the size parameter"
   },
   "description.watermark": {
@@ -150,5 +150,45 @@
   "description.maxImages": {
     "message": "Number of images generated in a single request (1-15). Set to 1 for single image mode; greater than 1 automatically enables image sets (sequential_image_generation=auto), maintaining character, style, and detail consistency across images. Only supports doubao-seedream-5.0 / 4.5 / 4.0; if reference images are uploaded, must satisfy (number of reference images + number generated) ≤ 15. Billing is based on the actual number of images generated.",
     "description": "Description of the max_images parameter"
+  },
+  "name.seed": {
+    "message": "Seed",
+    "description": "seed parameter label"
+  },
+  "description.seed": {
+    "message": "Random seed for reproducible results, range [-1, 2147483647]. -1 means random each time. Only supported by doubao-seedream-3.0-t2i and doubao-seededit-3.0-i2i.",
+    "description": "Description of the seed parameter"
+  },
+  "name.guidanceScale": {
+    "message": "Guidance Scale",
+    "description": "guidance_scale parameter label"
+  },
+  "description.guidanceScale": {
+    "message": "Prompt-following strength, range [1, 10]. Higher values follow the prompt more closely. Default 2.5 for doubao-seedream-3.0-t2i, 5.5 for doubao-seededit-3.0-i2i.",
+    "description": "Description of the guidance_scale parameter"
+  },
+  "name.outputFormat": {
+    "message": "Output Format",
+    "description": "output_format parameter label"
+  },
+  "description.outputFormat": {
+    "message": "File format of the generated image, jpeg or png. Default is jpeg. Only supported by doubao-seedream-5.0.",
+    "description": "Description of the output_format parameter"
+  },
+  "size.group.tier": {
+    "message": "Resolution tier",
+    "description": "Group label for the 1K-4K presets in the size dropdown"
+  },
+  "size.group.adaptive": {
+    "message": "Adaptive",
+    "description": "Group label for the adaptive option in the size dropdown"
+  },
+  "size.group.pixel": {
+    "message": "Explicit dimensions",
+    "description": "Group label for the pixel presets in the size dropdown"
+  },
+  "size.adaptive": {
+    "message": "Adaptive (match reference)",
+    "description": "Label for the adaptive option"
   }
 }

--- a/src/i18n/zh-CN/seedream.json
+++ b/src/i18n/zh-CN/seedream.json
@@ -64,7 +64,7 @@
     "description": "model 参数说明"
   },
   "description.size": {
-    "message": "图片尺寸。支持预设 `1K`、`2K`、`4K` 或自定义 `<宽>x<高>`。",
+    "message": "图片尺寸。可选分辨率档位（1K-4K）、自适应（与参考图比例一致）或具体像素尺寸如 `1024x1024`、`1280x720`，也可在下拉框中直接输入任意 `<宽>x<高>`。",
     "description": "size 参数说明"
   },
   "description.watermark": {
@@ -150,5 +150,45 @@
   "description.maxImages": {
     "message": "一次请求生成的图片数量（1-15）。设为 1 时为单图模式；大于 1 时自动启用组图（sequential_image_generation=auto），跨图保持角色、风格与细节一致。仅支持 doubao-seedream-5.0 / 4.5 / 4.0；如同时上传参考图，需满足 (参考图数 + 生成数) ≤ 15。计费按实际生成的图片张数。",
     "description": "max_images 参数说明"
+  },
+  "name.seed": {
+    "message": "随机种子",
+    "description": "seed 参数标签"
+  },
+  "description.seed": {
+    "message": "用于复现的随机种子，范围 [-1, 2147483647]。-1 表示每次随机。仅支持 doubao-seedream-3.0-t2i 与 doubao-seededit-3.0-i2i。",
+    "description": "seed 参数说明"
+  },
+  "name.guidanceScale": {
+    "message": "提示词权重",
+    "description": "guidance_scale 参数标签"
+  },
+  "description.guidanceScale": {
+    "message": "提示词遵循强度，范围 [1, 10]。值越大越贴近提示词。doubao-seedream-3.0-t2i 默认 2.5，doubao-seededit-3.0-i2i 默认 5.5。",
+    "description": "guidance_scale 参数说明"
+  },
+  "name.outputFormat": {
+    "message": "输出格式",
+    "description": "output_format 参数标签"
+  },
+  "description.outputFormat": {
+    "message": "生成图片的文件格式，jpeg 或 png，默认 jpeg。仅 doubao-seedream-5.0 支持。",
+    "description": "output_format 参数说明"
+  },
+  "size.group.tier": {
+    "message": "分辨率档位",
+    "description": "尺寸下拉的档位分组（1K-4K）"
+  },
+  "size.group.adaptive": {
+    "message": "自适应",
+    "description": "尺寸下拉的自适应分组"
+  },
+  "size.group.pixel": {
+    "message": "具体像素尺寸",
+    "description": "尺寸下拉的像素尺寸分组"
+  },
+  "size.adaptive": {
+    "message": "自适应（与参考图一致）",
+    "description": "adaptive 选项标签"
   }
 }

--- a/src/models/seedream.ts
+++ b/src/models/seedream.ts
@@ -14,6 +14,7 @@ export interface ISeedreamConfig {
   guidance_scale?: number;
   response_format?: 'url' | 'b64_json';
   watermark?: boolean;
+  output_format?: 'jpeg' | 'png';
   callback_url?: string;
 }
 
@@ -29,6 +30,7 @@ export interface ISeedreamGenerateRequest {
   guidance_scale?: number;
   response_format?: 'url' | 'b64_json';
   watermark?: boolean;
+  output_format?: 'jpeg' | 'png';
   callback_url?: string;
 }
 


### PR DESCRIPTION
## Summary

User report on https://studio.acedata.cloud/seedream — the panel exposed only Model / Size (coarse 1K-4K) / Number of Images / Prompt / Reference Images, hiding most of what the upstream `/seedream/images` API actually accepts. Audited the OpenAPI spec (`PlatformBackend/openapi/86ad30f3-…json`) and the worker validation in `PlatformService/volcengine/worker/src/handlers/seedream/images.ts` and added the missing controls.

## What changed

### 1. Hooked up the existing WatermarkSwitch
`src/components/seedream/config/WatermarkSwitch.vue` was already implemented (and i18n'd) but never imported into `ConfigPanel.vue` — pure wiring fix.

### 2. New SeedInput (model-gated)
`-1` to `2147483647` integer, visible only when the active model is `doubao-seedream-3.0-t2i` or `doubao-seededit-3.0-i2i` — those are the only models the worker accepts `seed` for. Auto-clears from the store when the user switches to an unsupported model so the request stays valid.

### 3. New GuidanceScaleInput (model-gated)
Float in [1, 10] with model-specific defaults (2.5 for `3.0-t2i`, 5.5 for `seededit-3.0-i2i`), same model gating as Seed.

### 4. New OutputFormatSelector (model-gated)
`jpeg` / `png`, only shown for `doubao-seedream-5.0` (the only model the upstream accepts `output_format` for).

### 5. Richer Size dropdown
Previously only the four `1K`-`4K` tier presets. The API also accepts `adaptive` (match the reference image) and arbitrary `<width>x<height>`. The selector now groups options:

- **Resolution tier**: 1K / 2K / 3K / 4K
- **Adaptive**: matches reference image aspect ratio
- **Explicit dimensions**: curated 1:1 / 16:9 / 9:16 / 4:3 / 3:4 / 3:2 / 2:3 presets at both 1K (~1MP) and 2K (~4MP) — `1024x1024`, `1280x720`, `720x1280`, `1152x864`, `864x1152`, `1216x832`, `832x1216`, `2048x2048`, `2560x1440`, `1440x2560`, `2304x1728`, `1728x2304`

Free-form `<width>x<height>` typing still works via the existing `allow-create filterable` flags.

## Why this is safe

Every new control mirrors the upstream worker's validation exactly:

- `SEED_MODELS` / `GUIDANCE_SCALE_MODELS` / `OUTPUT_FORMAT_MODELS` lists in `src/constants/seedream.ts` match the corresponding constants in `images.ts`.
- Each component watches `supported` and strips its field from the store when the active model doesn't accept it, so we never ship a payload the worker would 400 on.

## Files

- `src/components/seedream/ConfigPanel.vue` — import + mount the four new fields
- `src/components/seedream/config/SizeSelector.vue` — grouped dropdown
- `src/components/seedream/config/SeedInput.vue` — new
- `src/components/seedream/config/GuidanceScaleInput.vue` — new
- `src/components/seedream/config/OutputFormatSelector.vue` — new
- `src/constants/seedream.ts` — pixel presets, model capability lists, helpers
- `src/models/seedream.ts` — `output_format?: 'jpeg' | 'png'` on `ISeedreamConfig` / `ISeedreamGenerateRequest`
- `src/i18n/{zh-CN,en}/seedream.json` — labels + descriptions for new fields and size groups (other locales auto-translate later, per house rules)

## Verification

- `./node_modules/.bin/eslint src/components/seedream src/constants/seedream.ts src/models/seedream.ts` — clean
- `./node_modules/.bin/vue-tsc --noEmit` — clean
- JSON validity check on both locale files — passes