### PR TITLE
fix(suno): correct WAV/MIDI download response shapes (frontend-only)

### DIFF
--- a/src/components/suno/task/Preview.vue
+++ b/src/components/suno/task/Preview.vue
@@ -623,14 +623,17 @@ export default defineComponent({
         this.isFetchingWav = true;
         ElMessage.info(this.$t('suno.message.fetchingWav'));
         const response = await sunoOperator.wav({ audio_id: audio.id }, { token });
-        const wavUrl = response.data?.data?.audio_url;
+        // Worker returns `data: [{ file_url }]` (array, not an object).
+        const wavUrl = response.data?.data?.[0]?.file_url;
         if (wavUrl) {
           this.onDownload(null, wavUrl);
         } else {
           ElMessage.error(this.$t('suno.message.fetchWavFailed'));
         }
-      } catch {
-        ElMessage.error(this.$t('suno.message.fetchWavFailed'));
+      } catch (error) {
+        const message = (error as { response?: { data?: { error?: { message?: string } } } })?.response?.data?.error
+          ?.message;
+        ElMessage.error(message || this.$t('suno.message.fetchWavFailed'));
       } finally {
         this.isFetchingWav = false;
       }
@@ -643,14 +646,19 @@ export default defineComponent({
         this.isFetchingMidi = true;
         ElMessage.info(this.$t('suno.message.fetchingMidi'));
         const response = await sunoOperator.midi({ audio_id: audio.id }, { token });
-        const midiUrl = response.data?.data?.midi_url;
-        if (midiUrl) {
-          this.onDownload(null, midiUrl);
-        } else {
+        // Worker returns structured note data, no URL — save raw JSON for the user.
+        const data = response.data?.data;
+        if (!data?.length) {
           ElMessage.error(this.$t('suno.message.fetchMidiFailed'));
+          return;
         }
-      } catch {
-        ElMessage.error(this.$t('suno.message.fetchMidiFailed'));
+        const filename = (audio.title || audio.id || 'suno').replace(/[^\w.-]+/g, '_') + '.json';
+        const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+        saveAs(blob, filename);
+      } catch (error) {
+        const message = (error as { response?: { data?: { error?: { message?: string } } } })?.response?.data?.error
+          ?.message;
+        ElMessage.error(message || this.$t('suno.message.fetchMidiFailed'));
       } finally {
         this.isFetchingMidi = false;
       }

--- a/src/operators/suno.ts
+++ b/src/operators/suno.ts
@@ -194,13 +194,13 @@ class SunoOperator {
     });
   }
 
-  // suno/wav - get WAV format
+  // suno/wav - get WAV format. Worker returns `data: [{ file_url }]`.
   async wav(
     data: { audio_id: string },
     options: {
       token: string;
     }
-  ): Promise<AxiosResponse<{ data: { audio_url: string } }>> {
+  ): Promise<AxiosResponse<{ data: Array<{ file_url: string }> }>> {
     return await axios.post('/suno/wav', data, {
       headers: {
         authorization: `Bearer ${options.token}`,
@@ -210,13 +210,25 @@ class SunoOperator {
     });
   }
 
-  // suno/midi - get MIDI data
+  // suno/midi - get structured MIDI note data. Worker returns
+  // `data: [{ state, instruments: [{ name, notes: [{pitch,start,end,velocity}] }] }]`.
+  // No URL — the caller is expected to assemble a .mid file client-side.
   async midi(
     data: { audio_id: string },
     options: {
       token: string;
     }
-  ): Promise<AxiosResponse<{ data: { midi_url: string } }>> {
+  ): Promise<
+    AxiosResponse<{
+      data: Array<{
+        state?: string;
+        instruments: Array<{
+          name?: string;
+          notes: Array<{ pitch: number; start: number; end: number; velocity: number }>;
+        }>;
+      }>;
+    }>
+  > {
     return await axios.post('/suno/midi', data, {
       headers: {
         authorization: `Bearer ${options.token}`,


### PR DESCRIPTION
## Summary

Both **Download WAV** and **Download MIDI** dropdown items on https://studio.acedata.cloud/suno fail unconditionally — Nexior reads response fields the worker never returns. Reproduced via trace `a407b6a3-ac45-478f-8da5-a87401376b70` (this user's MIDI click on audio `1425ce0e…`) and the WAV calls immediately preceding it.

Frontend-only fix per user request — backend/upstream routing out of scope.

## Root cause

`src/operators/suno.ts` typed the responses as `{ data: { audio_url } }` / `{ data: { midi_url } }` and `Preview.vue` read them the same way. Actual worker shapes (verified live + against `PlatformService/openaihk/worker/src/handlers/suno/{wav,midi}.ts`):

| Endpoint | Worker actually returns |
|---|---|
| `/suno/wav`  | `data: [{ file_url: "..." }]` |
| `/suno/midi` | `data: [{ state, instruments: [{ name, notes: [{pitch, start, end, velocity}, …] }] }]` — **no URL** |

So the dropdown always fell into `else` and toasted *“Failed to fetch …”*. The `catch {}` block also swallowed the upstream error.

## Changes

- **`src/operators/suno.ts`** — corrected `wav()` / `midi()` response generics to match real worker shapes.
- **`src/components/suno/task/Preview.vue`** —
  - WAV: read `data?.[0]?.file_url`, hand to existing `onDownload` flow.
  - MIDI: worker only returns structured note JSON (no file URL). Save it as a `.json` file via `file-saver` (already a dep) — the user can convert to a `.mid` themselves if needed. No new dependency, no client-side MIDI assembly.
  - Both `catch` blocks now surface `error.response.data.error.message` (matching `onGetTiming`) before falling back to the generic toast.

## Verification

- `npx vue-tsc --noEmit` — clean
- `npx eslint src/operators/suno.ts src/components/suno/task/Preview.vue` — clean

## Out of scope

- Kong upstream rotation between `ankit` (ttapi) and `cortex` (openai-hk) frequently lands MIDI/WAV requests on a channel that doesn't know about the parent job (returns 400 `Job [...] unsuccessful`) or has run out of upstream credit (500 `Insufficient credits.`). PlatformService / Kong concern.
- The OpenAPI spec at `PlatformBackend/openapi/be1de4f0-…json` documents `/suno/midi` as returning `{ file_url }`, never matched the worker. Should be regenerated once the response shape is finalised.
