### PR TITLE
fix(seedream): correct 4.5 size tiers and remove seed from seededit-3.0-i2i

### DIFF
--- a/src/utils/seedream/capabilities.ts
+++ b/src/utils/seedream/capabilities.ts
@@ -84,8 +84,23 @@ export function getSeedreamCapabilities(model?: string): ISeedreamCapability {
         tools: true
       };
     case SEEDREAM_MODEL_4_5:
+      // 4.5: tier presets 2K/4K (no 1K, no 3K). Verified live —
+      // 4.5 + 1K returns "the specified size is not supported for model
+      // doubao-seedream-4-5". Pixel min is 3,686,400 (≈2K), same as 5.0.
+      return {
+        image: true,
+        imageRequired: false,
+        sizeTiers: [SEEDREAM_SIZE_2K, SEEDREAM_SIZE_4K],
+        sizeAdaptive: true,
+        sizePixel: true,
+        groupGeneration: true,
+        seed: false,
+        guidanceScale: false,
+        outputFormat: false,
+        tools: false
+      };
     case SEEDREAM_MODEL_4_0:
-      // 4.5 / 4.0: tier presets 1K/2K/4K (no 3K).
+      // 4.0: tier presets 1K/2K/4K (no 3K). Pixel min is 921,600 (≈1K).
       return {
         image: true,
         imageRequired: false,
@@ -116,6 +131,9 @@ export function getSeedreamCapabilities(model?: string): ISeedreamCapability {
       };
     case SEEDREAM_MODEL_SEEDEDIT_3_0_I2I:
       // seededit-3.0-i2i: image-to-image only, pixel-only sizes.
+      // Note: official Volcengine docs limit `seed` to 3.0-t2i only — our
+      // worker is permissive but upstream Volcengine rejects seed on
+      // seededit-3.0-i2i. Keep seed=false here.
       return {
         image: true,
         imageRequired: true,
@@ -124,7 +142,7 @@ export function getSeedreamCapabilities(model?: string): ISeedreamCapability {
         sizePixel: true,
         sizePixelDefault: '1024x1024',
         groupGeneration: false,
-        seed: true,
+        seed: false,
         guidanceScale: true,
         guidanceScaleDefault: SEEDREAM_GUIDANCE_SCALE_DEFAULTS[SEEDREAM_MODEL_SEEDEDIT_3_0_I2I],
         outputFormat: false,


### PR DESCRIPTION
## Summary

Two corrections to the Seedream capability matrix introduced in #657, found by re-checking against the official [Volcengine docs](https://www.volcengine.com/docs/82379/1541523) and probing the live API.

### 1. `doubao-seedream-4.5` only accepts tier presets **2K and 4K**

The previous PR (#657) copied 4.5's tier list from 4.0, giving `1K / 2K / 4K`. That's wrong:

```
$ curl -X POST .../seedream/images -d '{"model":"doubao-seedream-4-5-251128","prompt":"a cat","size":"1K"}'
{"error":{"code":"bad_request","message":"The parameter `size` specified in the request is not valid: the specified size is not supported for model doubao-seedream-4-5"}}

$ curl -X POST .../seedream/images -d '{"model":"doubao-seedream-4-5-251128","prompt":"a cat","size":"1024x1024"}'
{"error":{"code":"bad_request","message":"The parameter `size` specified in the request is not valid: image size must be at least 3686400 pixels"}}

$ curl -X POST .../seedream/images -d '{"model":"doubao-seedream-4-5-251128","prompt":"a cat","size":"2K"}'   → ok 2048x2048
$ curl -X POST .../seedream/images -d '{"model":"doubao-seedream-4-5-251128","prompt":"a cat","size":"4K"}'   → ok 4096x4096
```

So 4.5's tier set and pixel-minimum both match 5.0 (≈3.69M pixels), not 4.0 (≈0.92M). Reverted 4.5 to its own case-block with `sizeTiers = [2K, 4K]`.

### 2. `seed` is only supported on `doubao-seedream-3.0-t2i`

The Volcengine docs say verbatim:

> seed integer 默认值 -1
> **仅 doubao-seedream-3.0-t2i 支持该参数**

Our PlatformService Volcengine worker has a permissive `SEED_MODELS = ['doubao-seedream-3.0-t2i', 'doubao-seededit-3.0-i2i']`, but **upstream Volcengine rejects** `seed` on seededit-3.0-i2i regardless of what our worker accepts. PR #657 copied the worker's wrong list. Corrected to match the docs.

## Why this matters

Both bugs have the same shape: the Studio dropdown lets the user pick a value that the upstream then 400s on, with a confusing error like "the specified size is not supported for model doubao-seedream-4-5" or `seed must be valid for the model`. The capability map exists precisely to keep the UI in sync with what upstream actually accepts, so it has to be correct.

## Diff

`src/utils/seedream/capabilities.ts` only — six lines of behavioural change. All other selectors / store / i18n code is untouched and inherits the corrected map automatically.

## Verification

- `eslint src/utils/seedream/capabilities.ts` clean
- `vue-tsc --noEmit` clean
- Live API probes (above) re-run and match the new map

## Companion update

PlatformBackend docs (`docs/zh-CN/development_seedream_images.md`) and OpenAPI spec for this endpoint had the same two errors propagated from the original Volcengine doc-summary I read. Will be updated in a companion PR against the PlatformBackend repo.
