### PR TITLE
feat(app): silently grant global application and welcome users with free credits

### DIFF
--- a/src/i18n/en/application.json
+++ b/src/i18n/en/application.json
@@ -135,6 +135,18 @@
     "message": "Application Successful",
     "description": "Message displayed when the user successfully applies for this service."
   },
+  "message.applyFailed": {
+    "message": "Failed to activate your free trial. Please refresh and try again.",
+    "description": "Toast shown when the silent global application creation fails."
+  },
+  "message.welcomeWithCredits": {
+    "message": "🎉 Welcome! We've credited your account with {credits} free credits — enjoy every service on Nexior.",
+    "description": "Welcome toast shown after the global application is created or on the first visit when one already exists. {credits} is the remaining balance of the global application."
+  },
+  "message.welcomeNoCredits": {
+    "message": "🎉 Welcome to Nexior! Your account is ready — feel free to explore every service.",
+    "description": "Welcome toast shown when the global application has no remaining free credits to highlight."
+  },
   "message.notApplied": {
     "message": "You have not applied for this service, please apply before use.",
     "description": "Message displayed when the user has not applied for this service."

--- a/src/i18n/zh-CN/application.json
+++ b/src/i18n/zh-CN/application.json
@@ -135,6 +135,18 @@
     "message": "申请成功",
     "description": "当用户成功申请了此服务时向用户显示的消息。"
   },
+  "message.applyFailed": {
+    "message": "开通免费试用失败，请刷新页面后重试。",
+    "description": "自动创建全局申请失败时显示的提示。"
+  },
+  "message.welcomeWithCredits": {
+    "message": "🎉 欢迎使用 Nexior！我们已为您赠送 {credits} 积分，可在全站任意服务中体验。",
+    "description": "自动创建全局申请成功后或首次进入时显示的欢迎提示。{credits} 为全局申请的剩余额度。"
+  },
+  "message.welcomeNoCredits": {
+    "message": "🎉 欢迎使用 Nexior！您的账户已就绪，可以体验全站任意服务。",
+    "description": "全局申请没有可用免费额度时显示的欢迎提示。"
+  },
   "message.notApplied": {
     "message": "您尚未申请此服务，请在使用之前申请该服务",
     "description": "当用户尚未申请此服务时向用户显示的消息。"

--- a/src/layouts/Main.vue
+++ b/src/layouts/Main.vue
@@ -45,7 +45,8 @@ export default defineComponent({
       initialized: false,
       applying: false,
       mobile: window.innerWidth < 768,
-      initializeRunId: 0
+      initializeRunId: 0,
+      welcomeShown: false
     };
   },
   computed: {
@@ -105,10 +106,13 @@ export default defineComponent({
         return;
       }
       console.debug('Fetched all applications', this.applications);
-      // Check if we need to apply for a global application
+      // Auto-create the global application silently for first-time users and
+      // greet them with a welcome toast. Avoid the previous "apply for service"
+      // confirm dialog that interrupted every first service visit.
       if (this.$store.state.applications?.length === 0) {
-        // If no global applications exist, we need to apply
-        this.applying = true;
+        await this.onAutoApply();
+      } else if (!this.welcomeShown && this.$store.state.token?.access) {
+        this.showWelcomeToast(false);
       }
       // set the application if it exists
       const currentApplication = this.$store.state[this.appName]?.application;
@@ -123,23 +127,47 @@ export default defineComponent({
       this.initialized = true;
     },
     onApply() {
-      // Only can apply for global application, not individual application
-      applicationOperator
-        .create({
+      // Legacy entry kept for the <application-confirm> dialog (no longer
+      // auto-opened, but still emits 'apply' if some other path triggers it).
+      this.onAutoApply();
+    },
+    async onAutoApply() {
+      try {
+        await applicationOperator.create({
           type: IApplicationType.USAGE,
           scope: IApplicationScope.GLOBAL,
           user_id: this.$store.getters.user.id
-        })
-        .then(() => {
-          ElMessage.success(this.$t('application.message.applySuccessfully'));
-          this.initialize();
-          this.applying = false;
-        })
-        .catch((error) => {
-          if (error?.response?.data?.code === ERROR_CODE_DUPLICATION) {
-            ElMessage.error(this.$t('application.message.alreadyApplied'));
-          }
         });
+        this.applying = false;
+        await this.$store.dispatch('getApplications');
+        this.showWelcomeToast(true);
+      } catch (error: any) {
+        if (error?.response?.data?.code === ERROR_CODE_DUPLICATION) {
+          // Backend already had the global app — refresh and continue silently.
+          await this.$store.dispatch('getApplications');
+        } else {
+          ElMessage.error(this.$t('application.message.applyFailed'));
+        }
+      }
+    },
+    showWelcomeToast(firstTime: boolean) {
+      if (this.welcomeShown) return;
+      const userId = this.$store.state.user?.id;
+      if (!userId) return;
+      const storageKey = `nexior:welcomeShown:${userId}`;
+      if (!firstTime && localStorage.getItem(storageKey)) {
+        this.welcomeShown = true;
+        return;
+      }
+      const globalApp = this.$store.state.applications?.[0];
+      const credits = Math.floor(globalApp?.remaining_amount ?? 0);
+      const message =
+        credits > 0
+          ? this.$t('application.message.welcomeWithCredits', { credits })
+          : this.$t('application.message.welcomeNoCredits');
+      ElMessage({ message: message as string, type: 'success', duration: 6000, showClose: true });
+      localStorage.setItem(storageKey, '1');
+      this.welcomeShown = true;
     }
   }
 });


### PR DESCRIPTION
## Summary

User report: every time a new user enters a service page (Suno, Midjourney, …) Nexior pops a modal asking them to "apply" for the service. The user wants this replaced with a silent auto-grant + a friendly welcome toast that mentions the free credits we already give them.

## Fact-finding

- The dialog comes from `src/layouts/Main.vue` → `<application-confirm>` (`src/components/application/Confirm.vue`).
- It opens whenever `$store.state.applications?.length === 0` (i.e. the user has no global application yet).
- Clicking *Start* in the dialog calls `applicationOperator.create({ scope: GLOBAL, type: USAGE })`. The backend then issues the user a global application that comes with the existing free-credit grant (`remaining_amount`).
- So the dialog adds no information — it just gates a call we want to make anyway.

## Fix

In `Main.vue`:

1. When `applications.length === 0` on first visit, skip the modal and call the same `applicationOperator.create` directly (`onAutoApply()`).
2. After the create resolves, refresh `getApplications` and show a success toast:
   - `"🎉 Welcome! We've credited your account with N free credits — enjoy every service on Nexior."` (uses `remaining_amount` of the new global application)
   - Falls back to a no-credits variant if the backend returned 0.
3. For users who *already* had a global application, the same toast fires **once per browser** (gated by `localStorage["nexior:welcomeShown:<userId>"]`) so existing users also see the friendly welcome the first time they reload after this ships.
4. If the create fails with `ERROR_CODE_DUPLICATION` (race), refresh quietly. Other errors show a single error toast.

The legacy `<application-confirm>` dialog template entry stays in place (kept for safety in case something else triggers `applying = true`); its `@apply` callback now reuses the silent flow.

## i18n

Added to **zh-CN** and **en** only (per repo policy — no auto-translate to other locales):

- `application.message.welcomeWithCredits` (with `{credits}` placeholder)
- `application.message.welcomeNoCredits`
- `application.message.applyFailed`

## Verification

- `node_modules/.bin/eslint src/layouts/Main.vue` — clean
- `node_modules/.bin/vue-tsc --noEmit` — clean
- Behaviour walk-through:
  - First-time user → no modal, app created in background, toast `"🎉 Welcome! We've credited your account with N free credits …"`.
  - Returning user with global app, first visit after deploy → same toast once.
  - Same user, subsequent visits → no toast, no modal.
  - Backend already had the global app (race) → no error surfaced.
