### PR TITLE
fix(welcome): only toast on actual first global application creation

### DIFF
--- a/src/layouts/Main.vue
+++ b/src/layouts/Main.vue
@@ -45,8 +45,7 @@ export default defineComponent({
       initialized: false,
       applying: false,
       mobile: window.innerWidth < 768,
-      initializeRunId: 0,
-      welcomeShown: false
+      initializeRunId: 0
     };
   },
   computed: {
@@ -106,13 +105,12 @@ export default defineComponent({
         return;
       }
       console.debug('Fetched all applications', this.applications);
-      // Auto-create the global application silently for first-time users and
-      // greet them with a welcome toast. Avoid the previous "apply for service"
-      // confirm dialog that interrupted every first service visit.
+      // First-time users: silently create the global application. The welcome
+      // toast only fires inside onAutoApply(), so users who already had a
+      // global application (returning visitors, top-ups, multi-device logins)
+      // never see the credit-grant message.
       if (this.$store.state.applications?.length === 0) {
         await this.onAutoApply();
-      } else if (!this.welcomeShown && this.$store.state.token?.access) {
-        this.showWelcomeToast(false);
       }
       // set the application if it exists
       const currentApplication = this.$store.state[this.appName]?.application;
@@ -140,7 +138,7 @@ export default defineComponent({
         });
         this.applying = false;
         await this.$store.dispatch('getApplications');
-        this.showWelcomeToast(true);
+        this.showWelcomeToast();
       } catch (error: any) {
         if (error?.response?.data?.code === ERROR_CODE_DUPLICATION) {
           // Backend already had the global app — refresh and continue silently.
@@ -150,15 +148,10 @@ export default defineComponent({
         }
       }
     },
-    showWelcomeToast(firstTime: boolean) {
-      if (this.welcomeShown) return;
-      const userId = this.$store.state.user?.id;
-      if (!userId) return;
-      const storageKey = `nexior:welcomeShown:${userId}`;
-      if (!firstTime && localStorage.getItem(storageKey)) {
-        this.welcomeShown = true;
-        return;
-      }
+    showWelcomeToast() {
+      // Called only after a successful applicationOperator.create() for a
+      // GLOBAL application — i.e. the user genuinely just got their first
+      // free-credit grant. No localStorage gate needed.
       const globalApp = this.$store.state.applications?.[0];
       const credits = Math.floor(globalApp?.remaining_amount ?? 0);
       const message =
@@ -166,8 +159,6 @@ export default defineComponent({
           ? this.$t('application.message.welcomeWithCredits', { credits })
           : this.$t('application.message.welcomeNoCredits');
       ElMessage({ message: message as string, type: 'success', duration: 6000, showClose: true });
-      localStorage.setItem(storageKey, '1');
-      this.welcomeShown = true;
     }
   }
 });


### PR DESCRIPTION
## Summary

Bug report: after logging in to Nexior / Studio, every visit shows the *"🎉 we credited your account with N free credits"* toast — including for users who just topped up. Should only fire on the genuine first creation of a global application.

## Root cause

PR #677 added two paths that emit the welcome toast:

1. `onAutoApply()` — fires after a successful `applicationOperator.create({ scope: GLOBAL })`. ✅ correct semantics.
2. `initialize()` *else* branch — for users who already have a global application, gated by `welcomeShown` (component data) + `localStorage["nexior:welcomeShown:<userId>"]`. ❌ the misbehaving path.

The localStorage gate fails in two cases that both trigger the user report:

- `Main.vue` is re-mounted on **every** service-page navigation, so `welcomeShown` (component-local state) is `false` again on each mount.
- When `user.id` lands in the store *after* the first `showWelcomeToast()` call, the function bails (`if (!userId) return`) **before** writing the localStorage key, so the next mount has nothing to gate on and shows the toast again.

Outcome: returning users, top-ups, multi-tab logins, and second navigations all kept seeing "we credited you with N credits" — looks like a refund notification, exactly the user complaint.

## Fix

Drop the entire existing-user path:

- Remove `welcomeShown` data field.
- Remove the `else if (!this.welcomeShown && this.$store.state.token?.access)` branch in `initialize()`.
- Simplify `showWelcomeToast()` — no `firstTime` arg, no localStorage. It is now called from exactly **one** place: right after `applicationOperator.create()` resolves successfully inside `onAutoApply()`.

The `ERROR_CODE_DUPLICATION` race path (backend already had a global app for this user) stays silent. So the toast strictly maps to "this client just created the global application for the first time" — which is the only scenario where the credit grant story is true.

## Behaviour after fix

| Scenario | Toast? |
|---|---|
| Brand-new user, first service visit (no global app yet) | ✅ once |
| Same user, navigates between services later | ❌ |
| Returning user with existing global app, fresh browser | ❌ |
| User just topped up via Stripe / WeChat | ❌ |
| Race: another tab created the global app first → DUPLICATION | ❌ |
| Backend `create` failed with another error | ❌ (just an error toast) |

## Verification

`eslint src/layouts/Main.vue` clean, `vue-tsc --noEmit` clean. `git diff` is `+10 / -19` — pure deletion of the misbehaving path.
