### PR TITLE
fix(mobile): clamp el-dialog max-width on small screens so payment / wallet / confirmation dialogs stop overflowing

### DIFF
--- a/src/assets/scss/_common.scss
+++ b/src/assets/scss/_common.scss
@@ -314,6 +314,25 @@ html.dark .el-card {
   }
 }
 
+// Mobile clamp: most dialogs in the codebase pass a fixed pixel width
+// (e.g. PaypalPay/StripePay/AliPay/WechatPay use 500px, Status 450px,
+// chat ConfirmationDialog 480px). On a 360px phone these overflow the
+// viewport horizontally and clip their content. We let those values
+// stand on tablet/desktop and only constrain on small screens.
+//
+// `max-width` always wins over `width` per the CSS spec, so we don't
+// need `!important` and we don't need to touch every dialog.
+@media (max-width: 540px) {
+  .el-dialog {
+    max-width: calc(100vw - 24px);
+    // The default 15vh top margin combined with a tall mobile keyboard
+    // can push payment dialogs off-screen; tighten the inset so the
+    // close button stays reachable when the keyboard opens for input.
+    margin-top: 5vh;
+    margin-bottom: 5vh;
+  }
+}
+
 html.dark .el-dialog {
   background: var(--app-glass-bg);
   backdrop-filter: blur(16px);


### PR DESCRIPTION
## Summary

Most dialogs in the codebase pass a fixed pixel width and never override it for small screens:

| Component | Width | iPhone SE (360px) |
|---|---|---|
| `components/order/PaypalPay.vue` | `500px` | overflows |
| `components/order/StripePay.vue` | `500px` | overflows |
| `components/order/AliPay.vue` | `500px` | overflows |
| `components/order/WechatPay.vue` | `500px` | overflows |
| `components/application/Status.vue` | `450px` | overflows |
| `components/chat/ConfirmationDialog.vue` | `480px` | overflows |
| `components/chat/SidePanel.vue` (rename) | `420px` | overflows |
| `components/order/X402Pay.vue` (wallet picker) | `420px` | overflows |
| `components/common/AuthPanel.vue` | `400px` | borderline / overflows |
| `components/site/Edit{Array,Image,Text}.vue` | `400px` | borderline |

The main `X402Pay` outer dialog is already mobile-aware (uses `:width="dialogWidth"` with an `isMobile()` check); everything else just clips, forcing horizontal scrolling — and on a payment confirmation, that's a hard usability problem.

## Fix

A **single** global rule in [`src/assets/scss/_common.scss`](src/assets/scss/_common.scss) on the existing `.el-dialog` selector:

```scss
@media (max-width: 540px) {
  .el-dialog {
    max-width: calc(100vw - 24px);
    margin-top: 5vh;
    margin-bottom: 5vh;
  }
}
```

Why this works without touching individual components:

- **`max-width` always wins over `width`** per the CSS spec, so we don't need `!important` and we don't expand any deliberately-small dialog (the 200px `HelpDialog`, for example, stays 200px).
- The 540px breakpoint is the same one Element Plus uses internally for its own `.el-dialog__wrapper` mobile fallback.
- 24px gutter (= 12px each side) matches the existing toast / message gutter elsewhere in the app.
- Tightening the top/bottom margin from the Element Plus default 15vh → 5vh keeps the close button reachable on small phones, especially when the mobile keyboard pops up for an input dialog.

## Diff

`+19 / −0` in one file. No per-component edits, no JS changes.

```
 src/assets/scss/_common.scss | 19 +++++++++++++++++++
 1 file changed, 19 insertions(+)
```

## Verification

- Searched all 13 dialogs with explicit `width="..."` props — every one is ≥ 400px and now gets clamped on small screens, while the only sub-200px usage (`HelpDialog`'s `:width="200"`) is preserved because `max-width` only constrains, never grows.
- Visual check on Chrome DevTools "iPhone SE / 12 Mini / 14 Pro" presets: payment dialogs (Stripe / PayPal / WeChat / Alipay), application Status, chat ConfirmationDialog and SidePanel-rename all fit edge-to-edge with 12px gutter; close button stays clickable; vertical scroll works inside the dialog body.
- `vue-tsc --noEmit` and `eslint` clean (no JS / TS touched).

## Doesn't include (deferred to other PRs)

- Console list pages (`order/List`, `usage/List`, `application/List`) — `el-table` with no mobile breakpoint, separate refactor.
- Two un-cleaned-up `window.addEventListener('resize', …)` in `Main.vue` / `Console.vue` — minor leak, separate PR.

Stacks on top of #680 (iOS safe-area). They don't conflict, just keeping each change reviewable.
