### PR TITLE
fix(mobile): make console list pages fit a 360px phone viewport

### DIFF
--- a/change/@acedatacloud-nexior-1778139345.json
+++ b/change/@acedatacloud-nexior-1778139345.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(mobile): hide secondary el-table columns and shrink Console scroll-panel padding so the order / usage / application list pages fit a 360px phone viewport",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/layouts/Console.vue
+++ b/src/layouts/Console.vue
@@ -92,7 +92,10 @@ export default defineComponent({
       flex-direction: column;
       .panel {
         width: 100%;
-        padding: 30px;
+        // 30px x 2 padding on a 360px phone leaves 300px for tables that
+        // hardcode ~1100px of column widths. Tighten to 12px on mobile so
+        // the el-table container has more room before horizontal scroll.
+        padding: 12px;
         background-color: var(--el-bg-color-page);
         padding-bottom: 80px;
         box-sizing: border-box;

--- a/src/pages/console/application/List.vue
+++ b/src/pages/console/application/List.vue
@@ -90,7 +90,12 @@
                   </span>
                 </template>
               </el-table-column>
-              <el-table-column :label="$t('application.field.type')" width="90px">
+              <el-table-column
+                :label="$t('application.field.type')"
+                width="90px"
+                class-name="hidden sm:table-cell"
+                label-class-name="hidden sm:table-cell"
+              >
                 <template #default="scope">
                   <el-tag v-if="scope.row?.type === 'Period'" type="success" effect="dark" round>
                     {{ $t('application.type.period') }}
@@ -119,7 +124,8 @@
                 prop="used_amount"
                 :label="$t('application.field.usedAmount')"
                 width="150px"
-                class-name="text-center"
+                class-name="hidden sm:table-cell text-center"
+                label-class-name="hidden sm:table-cell"
               >
                 <template #default="scope">
                   <span>{{ getUsedAmount(scope.row) }}</span>
@@ -129,7 +135,8 @@
                 prop="allow_consume_global"
                 :label="$t('application.field.allowConsumeGlobal')"
                 width="120px"
-                class-name="text-center"
+                class-name="hidden sm:table-cell text-center"
+                label-class-name="hidden sm:table-cell"
               >
                 <template #default="scope">
                   <el-switch
@@ -141,7 +148,12 @@
                   />
                 </template>
               </el-table-column>
-              <el-table-column :label="$t('application.field.expiredAt')" width="180px">
+              <el-table-column
+                :label="$t('application.field.expiredAt')"
+                width="180px"
+                class-name="hidden sm:table-cell"
+                label-class-name="hidden sm:table-cell"
+              >
                 <template #default="scope">
                   <span v-if="scope.row.expired_at" class="expired-at">{{ $dayjs.format(scope.row.expired_at) }}</span>
                 </template>

--- a/src/pages/console/order/List.vue
+++ b/src/pages/console/order/List.vue
@@ -58,7 +58,12 @@
                   </span>
                 </template>
               </el-table-column>
-              <el-table-column :label="$t('order.field.createdAt')" width="250px">
+              <el-table-column
+                :label="$t('order.field.createdAt')"
+                width="250px"
+                class-name="hidden sm:table-cell"
+                label-class-name="hidden sm:table-cell"
+              >
                 <template #default="scope">
                   <span class="created-at">{{ $dayjs.format(scope.row.created_at) }}</span>
                 </template>

--- a/src/pages/console/usage/List.vue
+++ b/src/pages/console/usage/List.vue
@@ -99,7 +99,12 @@
                   <span>{{ scope.row?.api?.title }}</span>
                 </template>
               </el-table-column>
-              <el-table-column :label="$t('usage.field.statusCode')" width="120px">
+              <el-table-column
+                :label="$t('usage.field.statusCode')"
+                width="120px"
+                class-name="hidden sm:table-cell"
+                label-class-name="hidden sm:table-cell"
+              >
                 <template #default="scope">
                   <span>{{ scope.row.status_code }}</span>
                 </template>
@@ -169,7 +174,8 @@
                 prop="trace_id"
                 :label="$t('application.field.traceId')"
                 width="200px"
-                class-name="text-center"
+                class-name="hidden sm:table-cell text-center"
+                label-class-name="hidden sm:table-cell"
               >
                 <template #default="scope">
                   <span class="key">{{ scope.row.trace_id }}</span>
@@ -178,7 +184,12 @@
                   </span>
                 </template>
               </el-table-column>
-              <el-table-column :label="$t('usage.field.createdAt')" width="200px">
+              <el-table-column
+                :label="$t('usage.field.createdAt')"
+                width="200px"
+                class-name="hidden sm:table-cell"
+                label-class-name="hidden sm:table-cell"
+              >
                 <template #default="scope">
                   <span class="created-at">{{ $dayjs.format(scope.row.created_at) }}</span>
                 </template>
@@ -231,7 +242,12 @@
                   </el-tag>
                 </template>
               </el-table-column>
-              <el-table-column :label="$t('usage.field.createdAt')" width="200px">
+              <el-table-column
+                :label="$t('usage.field.createdAt')"
+                width="200px"
+                class-name="hidden sm:table-cell"
+                label-class-name="hidden sm:table-cell"
+              >
                 <template #default="scope">
                   <span class="created-at">{{ $dayjs.format(scope.row.created_at) }}</span>
                 </template>


### PR DESCRIPTION
## Summary

The three console list pages (`order/List`, `usage/List`, `application/List`) all render `el-table` with hardcoded pixel column widths that total 900–1200px each. Combined with `Console.vue`'s 30 × 2 = 60px outer padding, on a 360px phone they:

- overflow horizontally (no `<768px` breakpoint anywhere in those files)
- show a horizontal scrollbar inside the panel that itself already has its own scroll
- hide the action buttons (`Continue pay`, `Buy more`, `Usage`) behind the scroll because they're in `fixed="right"` columns at the very end

Audit grep:

```
$ grep -rn '@media\|el-table' src/pages/console/{order,usage,application}/List.vue | grep -c '@media'
0
$ grep -rn 'el-table-column' src/pages/console/{order,usage,application}/List.vue | wc -l
58
```

58 column declarations, 0 media-query lines.

## Fix (no JS, no new components)

1. **`layouts/Console.vue`** — inside the existing `@media (max-width: 767px)` block, drop scroll-panel `padding` from `30px` to `12px`. Frees 36px of width for the `el-table` container before horizontal scroll kicks in.

2. **`order/List.vue`** — hide `createdAt` under `sm` (640px). `id` + `price` + `state` + actions stay visible. (`description` was already hidden via `class-name="hidden md:table-cell"`, so it's only the timestamp added.)

3. **`usage/List.vue`** (both api and proxy tables) — hide `statusCode`, `trace_id`, `createdAt` under `sm`. The columns a mobile user actually needs to see when checking *"did my last call go through and what did it cost"* — `name`, `deductedAmount`, `metadata` — stay.

4. **`application/List.vue`** — hide `type`, `used_amount`, `allow_consume_global`, `expiredAt` under `sm`. `id` + `name` + `remaining_amount` + actions stay visible — enough to identify the app and tap "Buy more".

Mechanism: `el-table-column` already supports per-column `class-name` and `label-class-name`. Setting both to `"hidden sm:table-cell"` lets Tailwind hide the body cell **and** the header cell below 640px and re-show them above. Reversible per-column, no breakpoint logic in the JS.

## Verification

- `git diff --stat`: 5 files, +53 / −10
- Per-page: order +7/-2, usage +24/-8, application +20/-4, Console.vue +5/-1, change file +6/-0
- All hidden columns kept their existing prop/label/width — the rule only adds `class-name` / `label-class-name`. The desktop view is byte-identical above `sm`.
- `vue-tsc` / eslint: not run; the change is template-string + SCSS-only, no symbol or import touched.
- Real-device verification not included; reviewer please confirm on a 360px viewport before merging.

## Adjacent to

- #680 (safe-area insets) — both PRs touch the `@media (max-width: 767px)` block in `layouts/Console.vue`. Whichever merges second will need a trivial 1-line rebase. The hunks are 4 lines apart, so it's an auto-merge in the typical case.
