### PR TITLE
chore(infra): rename caddy-tenant-proxy → caddy-studio-proxy

### DIFF
--- a/deploy/production/studio-proxy.yaml
+++ b/deploy/production/studio-proxy.yaml
@@ -1,8 +1,9 @@
 # --------------------------------------------------------------------------
-# tenant-proxy.yaml
+# studio-proxy.yaml
 #
-# Caddy reverse proxy that fronts ALL tenant custom domains
-# (mybrand.com -> studio-frontend) with on-demand Let's Encrypt TLS.
+# Caddy reverse proxy that fronts ALL tenant custom domains whose parent
+# Site is studio.acedata.cloud (mybrand.com -> studio-frontend) with
+# on-demand Let's Encrypt TLS.
 #
 # Provides:
 #   * 80/443 LoadBalancer (separate public CLB; do NOT share with nginx-router)
@@ -12,14 +13,15 @@
 #
 # Tenant flow:
 #   1. Tenant adds CNAME mybrand.com -> tenant-proxy.acedata.cloud at their
-#      DNS provider.
+#      DNS provider (the public hostname stays `tenant-proxy.acedata.cloud`
+#      for backwards compatibility; only the internal K8s names changed).
 #   2. First HTTPS request hits Caddy. Caddy GETs the ask URL, sees the
 #      domain is registered in SiteDomain, runs ACME HTTP-01, signs the
 #      cert, persists it to /data, and serves the request.
 #   3. Caddy renews automatically 30 days before expiry.
 #
 # DNS one-time setup AFTER first apply:
-#   kubectl get svc caddy-tenant-proxy -n acedatacloud
+#   kubectl get svc caddy-studio-proxy -n acedatacloud
 #   # take the EXTERNAL-IP, then in DNSPod:
 #   tenant-proxy.acedata.cloud  A  <EIP>
 # --------------------------------------------------------------------------
@@ -27,10 +29,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: caddy-tenant-proxy-config
+  name: caddy-studio-proxy-config
   namespace: acedatacloud
   labels:
-    app: caddy-tenant-proxy
+    app: caddy-studio-proxy
 data:
   Caddyfile: |
     {
@@ -89,10 +91,10 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: caddy-tenant-proxy
+  name: caddy-studio-proxy
   namespace: acedatacloud
   labels:
-    app: caddy-tenant-proxy
+    app: caddy-studio-proxy
 spec:
   # Single replica today. The mounted PVC (`caddy`, RWX cfs) supports
   # multiple attachments, so future HA can scale this up if traffic
@@ -107,11 +109,11 @@ spec:
       maxUnavailable: 0
   selector:
     matchLabels:
-      app: caddy-tenant-proxy
+      app: caddy-studio-proxy
   template:
     metadata:
       labels:
-        app: caddy-tenant-proxy
+        app: caddy-studio-proxy
     spec:
       containers:
         - name: caddy
@@ -160,7 +162,7 @@ spec:
       volumes:
         - name: caddyfile
           configMap:
-            name: caddy-tenant-proxy-config
+            name: caddy-studio-proxy-config
             items:
               - key: Caddyfile
                 path: Caddyfile
@@ -176,10 +178,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: caddy-tenant-proxy
+  name: caddy-studio-proxy
   namespace: acedatacloud
   labels:
-    app: caddy-tenant-proxy
+    app: caddy-studio-proxy
   annotations:
     # Ask TKE to create a NEW public CLB for this Service (do NOT share
     # the nginx-router LB; that one already terminates 80/443 and would
@@ -193,4 +195,4 @@ spec:
     - { name: http,  port: 80,  targetPort: 80,  protocol: TCP }
     - { name: https, port: 443, targetPort: 443, protocol: TCP }
   selector:
-    app: caddy-tenant-proxy
+    app: caddy-studio-proxy

--- a/deploy/run.sh
+++ b/deploy/run.sh
@@ -9,4 +9,4 @@ kubectl apply -f deploy/production/studio-ingress.yaml
 # with on-demand Let's Encrypt TLS). Idempotent; safe to re-apply on every
 # deploy. The Service provisions a separate public CLB the first time it
 # runs; subsequent applies are no-ops on the LB.
-kubectl apply -f deploy/production/tenant-proxy.yaml
+kubectl apply -f deploy/production/studio-proxy.yaml

--- a/src/models/site_domain.ts
+++ b/src/models/site_domain.ts
@@ -7,7 +7,7 @@
  * tenant CNAME their own apex/sub from a registrar they control.
  *
  * The actual TLS provisioning happens at the edge (Caddy +
- * Let's Encrypt on-demand-TLS, see Nexior `deploy/production/tenant-proxy.yaml`),
+ * Let's Encrypt on-demand-TLS, see Nexior `deploy/production/studio-proxy.yaml`),
  * so the row only carries `hostname`, `status`, `proxy_cname`, and
  * audit fields. `dns_instructions` is a UI-friendly hint the backend
  * appends to the GET / verify response so the page doesn't have to


### PR DESCRIPTION
## Why

`caddy-tenant-proxy` is ambiguous — it suggests it fronts every tenant, but it actually fronts only sub-sites whose parent is `studio.acedata.cloud` (i.e. studio-frontend). The platform-side counterpart in PlatformFrontend has the symmetric problem (`caddy-platform-tenant-proxy` is mostly noise). Renaming both to `{caddy-studio-proxy, caddy-platform-proxy}` matches what they actually front.

Parallel PR: AceDataCloud/PlatformFrontend#TBD (`caddy-platform-tenant-proxy → caddy-platform-proxy`).

## Scope

Internal-only rename. **DNS is untouched** — customer-facing CNAME target stays `tenant-proxy.acedata.cloud` for backwards compatibility. Only the K8s resource names + the YAML file name change.

- `deploy/production/tenant-proxy.yaml` → `deploy/production/studio-proxy.yaml`
- ConfigMap, Deployment, Service, label selector: `caddy-tenant-proxy*` → `caddy-studio-proxy*`
- PVC `caddy` (no "tenant" in the name) is left alone
- `deploy/run.sh` updated to apply the renamed file
- One stale doc-comment in `src/models/site_domain.ts` updated

## Post-deploy ops (manual, after this PR + PF PR merge & roll out)

1. `kubectl apply` runs automatically via deploy CI → new `caddy-studio-proxy` svc provisions a fresh public CLB.
2. Manually delete the old K8s resources:
   ```sh
   kubectl -n acedatacloud delete \
     svc/caddy-tenant-proxy \
     deploy/caddy-tenant-proxy \
     cm/caddy-tenant-proxy-config
   ```
   The `caddy` PVC stays.
3. Re-point DNSPod `tenant-proxy.acedata.cloud` CNAME at the new CLB hostname.

User already confirmed: no production tenants on this proxy yet, so the brief HTTPS-cert-cache reset (new PVC == fresh `/data`) is acceptable — Caddy will re-mint LE certs on first hit per registered SiteDomain.