### PR TITLE
chore(infra): rename studio caddy PVC `caddy` → `caddy-studio`

### DIFF
--- a/deploy/production/studio-proxy.yaml
+++ b/deploy/production/studio-proxy.yaml
@@ -88,6 +88,29 @@ data:
       }
     }
 ---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: caddy-studio
+  namespace: acedatacloud
+  labels:
+    app: caddy-studio-proxy
+spec:
+  # Dedicated PVC so ACME state (account key, cached certs, on_demand
+  # rate-limit locks) is isolated from caddy-platform-proxy's PVC.
+  # Sharing /data between two Caddy deployments would mean one proxy's
+  # outage / rollback could corrupt the other's cert cache.
+  #
+  # cfs RWX matches caddy-platform's profile so future HA scaling can
+  # attach the same volume to multiple replicas without ReadWriteOnce
+  # contention.
+  accessModes:
+    - ReadWriteMany
+  storageClassName: cfs
+  resources:
+    requests:
+      storage: 10Gi
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -96,11 +119,11 @@ metadata:
   labels:
     app: caddy-studio-proxy
 spec:
-  # Single replica today. The mounted PVC (`caddy`, RWX cfs) supports
-  # multiple attachments, so future HA can scale this up if traffic
-  # ever justifies it -- Caddy will share `/data` (ACME account, certs,
-  # locks) across pods. RollingUpdate is fine because RWX volumes
-  # don't deadlock on pod transition.
+  # Single replica today. The mounted PVC (`caddy-studio`, RWX cfs)
+  # supports multiple attachments, so future HA can scale this up if
+  # traffic ever justifies it -- Caddy will share `/data` (ACME
+  # account, certs, locks) across pods. RollingUpdate is fine because
+  # RWX volumes don't deadlock on pod transition.
   replicas: 1
   strategy:
     type: RollingUpdate
@@ -168,10 +191,7 @@ spec:
                 path: Caddyfile
         - name: data
           persistentVolumeClaim:
-            # Pre-existing `caddy` PVC (10Gi cfs RWX) provisioned out
-            # of band; lets us share /data across replicas if we ever
-            # scale this up.
-            claimName: caddy
+            claimName: caddy-studio
         - name: config
           emptyDir: {}
 ---


### PR DESCRIPTION
## Why

Follow-up to #688. After that PR, the studio-side resources were `caddy-studio-proxy{,-config}` but the PVC was still called plain `caddy`, while the platform side has `caddy-platform`. That asymmetry isn't pulling its weight — better to either both have a tag or neither does. Going with `caddy-studio` so all four caddy-* resources follow the same prefix scheme:

```
studio:   caddy-studio-proxy{,-config}, caddy-studio (PVC)
platform: caddy-platform-proxy{,-config}, caddy-platform (PVC)
```

## What changed

- `studio-proxy.yaml`: inline the PVC declaration (mirrors `platform-proxy.yaml` in PlatformFrontend, instead of relying on out-of-band setup).
- Deployment's `claimName: caddy` → `claimName: caddy-studio`.
- Doc-comment touch-ups so they reference the new name.

## Post-deploy ops (after this PR + #688 + PF#291 land)

1. Deploy CI runs `kubectl apply` → new `caddy-studio` PVC provisioned, new `caddy-studio-proxy` Deployment binds to it.
2. Manually delete the old K8s resources:
   ```sh
   kubectl -n acedatacloud delete \
     svc/caddy-tenant-proxy \
     deploy/caddy-tenant-proxy \
     cm/caddy-tenant-proxy-config \
     svc/caddy-platform-tenant-proxy \
     deploy/caddy-platform-tenant-proxy \
     cm/caddy-platform-tenant-proxy-config \
     pvc/caddy
   ```
   The `caddy-platform` PVC stays (still in use).
3. Re-point DNSPod CNAMEs at the new CLB hostnames.

User already confirmed: no production tenants on these proxies yet, so the brief HTTPS-cert-cache reset (new PVC == fresh `/data`) is acceptable — Caddy will re-mint LE certs on first hit per registered SiteDomain.