### PR TITLE
chore(infra): document new studio-proxy.acedata.cloud public CNAME

### DIFF
--- a/deploy/production/studio-proxy.yaml
+++ b/deploy/production/studio-proxy.yaml
@@ -12,9 +12,11 @@
 #   * cbs PVC at /data so ACME account, certs, and locks survive pod restarts.
 #
 # Tenant flow:
-#   1. Tenant adds CNAME mybrand.com -> tenant-proxy.acedata.cloud at their
-#      DNS provider (the public hostname stays `tenant-proxy.acedata.cloud`
-#      for backwards compatibility; only the internal K8s names changed).
+#   1. Tenant adds CNAME mybrand.com -> studio-proxy.acedata.cloud at their
+#      DNS provider. The legacy hostname `tenant-proxy.acedata.cloud`
+#      keeps resolving to the same CLB as a permanent alias, so any
+#      tenants provisioned before the rename keep working without
+#      touching their DNS.
 #   2. First HTTPS request hits Caddy. Caddy GETs the ask URL, sees the
 #      domain is registered in SiteDomain, runs ACME HTTP-01, signs the
 #      cert, persists it to /data, and serves the request.
@@ -23,7 +25,8 @@
 # DNS one-time setup AFTER first apply:
 #   kubectl get svc caddy-studio-proxy -n acedatacloud
 #   # take the EXTERNAL-IP, then in DNSPod:
-#   tenant-proxy.acedata.cloud  A  <EIP>
+#   studio-proxy.acedata.cloud  A  <EIP>
+#   # (and keep the legacy `tenant-proxy` A-record pointing at the same EIP)
 # --------------------------------------------------------------------------
 
 apiVersion: v1


### PR DESCRIPTION
## What

Doc-only update to [deploy/production/studio-proxy.yaml](https://github.com/AceDataCloud/Nexior/blob/main/deploy/production/studio-proxy.yaml). Tenant CNAME instructions and the post-apply DNS step now reference the new public hostname `studio-proxy.acedata.cloud` instead of the legacy `tenant-proxy.acedata.cloud`.

## Why

Internal K8s svc was renamed from `caddy-tenant-proxy` to `caddy-studio-proxy` in [#688](https://github.com/AceDataCloud/Nexior/pull/688). The public-facing hostname stayed on `tenant-proxy.acedata.cloud` purely because no one had updated DNS yet — that's now done. Lining the docs up with reality avoids the next person being confused about which name customers should CNAME to.

## Compatibility

`tenant-proxy.acedata.cloud` is **kept permanently as a DNS alias** of `studio-proxy.acedata.cloud` (both A-records point at the same studio CLB EIP `43.162.221.129`). Tenants provisioned before the rename — including the 5 existing `SiteDomain` rows that store `proxy_cname = tenant-proxy.acedata.cloud` — continue to work without changing their DNS. Comment 16 explicitly notes this.

## Files

- [deploy/production/studio-proxy.yaml](https://github.com/AceDataCloud/Nexior/blob/main/deploy/production/studio-proxy.yaml) — header comment + `# DNS one-time setup AFTER first apply` block

## Test plan

- Doc-only change. No K8s manifest body is touched.
- Companion PRs: [PlatformBackend#435](https://github.com/AceDataCloud/PlatformBackend/pull/435) (Python `DEFAULT_PROXY_CNAME`) + the imminent PlatformFrontend PR (`platform-proxy.yaml` comment).
