### PR TITLE
[codex] chore: sync Nexior mobile app version

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.acedatacloud.nexior"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 33002
-        versionName "3.30.2"
+        versionCode 33500
+        versionName "3.35.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -348,11 +348,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 33002;
+				CURRENT_PROJECT_VERSION = 33500;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 3.30.2;
+				MARKETING_VERSION = 3.35.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.acedatacloud.nexior;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -368,11 +368,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 33002;
+				CURRENT_PROJECT_VERSION = 33500;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 3.30.2;
+				MARKETING_VERSION = 3.35.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.acedatacloud.nexior;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/scripts/sync-native-version.js
+++ b/scripts/sync-native-version.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Sync version from package.json → Android build.gradle + iOS project.
+ * Sync version from package.json → Android build.gradle + iOS project + mobile constants.
  *
  * Usage:  node scripts/sync-native-version.js
  *
@@ -19,11 +19,18 @@ const code = major * 10000 + minor * 100 + patch
 
 console.log(`Syncing version: ${version} (code: ${code})`)
 
+function replaceOrThrow(content, pattern, replacement, filePath) {
+  if (!pattern.test(content)) {
+    throw new Error(`Could not find version pattern in ${filePath}`)
+  }
+  return content.replace(pattern, replacement)
+}
+
 // --- Android ---
 const gradlePath = path.join(__dirname, '..', 'android', 'app', 'build.gradle')
 let gradle = fs.readFileSync(gradlePath, 'utf8')
-gradle = gradle.replace(/versionCode \d+/, `versionCode ${code}`)
-gradle = gradle.replace(/versionName "[^"]*"/, `versionName "${version}"`)
+gradle = replaceOrThrow(gradle, /versionCode \d+/, `versionCode ${code}`, gradlePath)
+gradle = replaceOrThrow(gradle, /versionName "[^"]*"/, `versionName "${version}"`, gradlePath)
 fs.writeFileSync(gradlePath, gradle)
 console.log(`  ✓ android/app/build.gradle → ${version} (${code})`)
 
@@ -31,10 +38,22 @@ console.log(`  ✓ android/app/build.gradle → ${version} (${code})`)
 const pbxPath = path.join(__dirname, '..', 'ios', 'App', 'App.xcodeproj', 'project.pbxproj')
 if (fs.existsSync(pbxPath)) {
   let pbx = fs.readFileSync(pbxPath, 'utf8')
-  pbx = pbx.replace(/MARKETING_VERSION = [^;]+;/g, `MARKETING_VERSION = ${version};`)
-  pbx = pbx.replace(/CURRENT_PROJECT_VERSION = [^;]+;/g, `CURRENT_PROJECT_VERSION = ${code};`)
+  pbx = replaceOrThrow(pbx, /MARKETING_VERSION = [^;]+;/g, `MARKETING_VERSION = ${version};`, pbxPath)
+  pbx = replaceOrThrow(pbx, /CURRENT_PROJECT_VERSION = [^;]+;/g, `CURRENT_PROJECT_VERSION = ${code};`, pbxPath)
   fs.writeFileSync(pbxPath, pbx)
   console.log(`  ✓ ios project.pbxproj → ${version} (${code})`)
 }
+
+// --- Mobile download page constants ---
+const mobileConstantsPath = path.join(__dirname, '..', 'src', 'constants', 'mobile.ts')
+let mobileConstants = fs.readFileSync(mobileConstantsPath, 'utf8')
+mobileConstants = replaceOrThrow(
+  mobileConstants,
+  /MOBILE_APP_VERSION = '[^']*'/,
+  `MOBILE_APP_VERSION = '${version}'`,
+  mobileConstantsPath
+)
+fs.writeFileSync(mobileConstantsPath, mobileConstants)
+console.log(`  ✓ src/constants/mobile.ts → ${version}`)
 
 console.log('Done.')

--- a/src/constants/mobile.ts
+++ b/src/constants/mobile.ts
@@ -1,4 +1,4 @@
-export const MOBILE_APP_VERSION = '3.30.2';
+export const MOBILE_APP_VERSION = '3.35.0';
 
 export const MOBILE_ANDROID_DOWNLOAD_URL = 'https://cdn.acedata.cloud/2f29543715.apk';
 


### PR DESCRIPTION
## Summary
- sync Android and iOS native versions to package version 3.35.0
- include `src/constants/mobile.ts` in `scripts/sync-native-version.js`
- fail version sync if expected native/app patterns are missing

## Why
The app package was already at 3.35.0, but Android/iOS/native app constants still reported older 3.30.2/33002 values. That makes About/update checks and store metadata drift from the published app version.

## Impact
Native builds and in-app version display now stay aligned when `npm run sync-version` is run.

## Verification
- `npm run sync-version`
- `git diff --check`