### PR TITLE
[codex] fix: tighten Console mobile layout

### DIFF
--- a/src/components/console/SidePanel.vue
+++ b/src/components/console/SidePanel.vue
@@ -168,4 +168,40 @@ $padding-left: 12px;
     }
   }
 }
+
+@media screen and (max-width: 767px) {
+  .side {
+    width: 100%;
+    height: auto;
+    padding: 0;
+  }
+
+  .links {
+    width: 100%;
+    flex-direction: row;
+    gap: 8px;
+    overflow-x: auto;
+    padding-bottom: 2px;
+
+    .link {
+      flex: 1 0 max-content;
+      min-width: 96px;
+      height: 36px;
+      line-height: 36px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0 12px;
+      white-space: nowrap;
+
+      .icon {
+        margin-right: 6px;
+      }
+
+      .suffix {
+        display: none;
+      }
+    }
+  }
+}
 </style>

--- a/src/layouts/Console.vue
+++ b/src/layouts/Console.vue
@@ -81,41 +81,45 @@ export default defineComponent({
 
 @media screen and (max-width: 767px) {
   .console {
+    --console-safe-bottom: max(env(safe-area-inset-bottom, 0px), 10px);
+
     width: 100%;
     height: 100%;
     display: flex;
     flex-direction: column;
     .navigator {
       width: 100%;
-      // Reserve room for the iOS home indicator below the navigator links.
-      height: calc(60px + env(safe-area-inset-bottom));
-      padding-bottom: env(safe-area-inset-bottom);
+      height: calc(60px + var(--console-safe-bottom));
+      padding-bottom: var(--console-safe-bottom);
       position: fixed;
       bottom: 0;
       z-index: 10000;
     }
     .main {
-      height: calc(100% - 60px - env(safe-area-inset-bottom));
+      height: calc(100% - 60px - var(--console-safe-bottom));
       width: 100%;
       flex: 1;
       display: flex;
       flex-direction: column;
+      min-height: 0;
+      overflow: hidden;
       .panel {
         width: 100%;
-        // 30px x 2 padding on a 360px phone leaves 300px for tables that
-        // hardcode ~1100px of column widths. Tighten to 12px on mobile so
-        // the el-table container has more room before horizontal scroll.
         padding: 12px;
         background-color: var(--el-bg-color-page);
-        padding-bottom: calc(80px + env(safe-area-inset-bottom));
+        padding-bottom: calc(80px + var(--console-safe-bottom));
         box-sizing: border-box;
-        overflow-x: hidden;
+        min-height: 0;
+        overflow-x: auto;
         overflow-y: auto;
       }
       .side {
         width: 100%;
-        height: fit-content;
-        padding: 20px 0 20px 10px;
+        height: auto;
+        flex: 0 0 auto;
+        padding: 8px 10px;
+        background: var(--app-sidebar-bg);
+        border-bottom: 1px solid var(--app-border-subtle);
       }
     }
   }

--- a/src/pages/console/application/List.vue
+++ b/src/pages/console/application/List.vue
@@ -1,5 +1,5 @@
 <template>
-  <el-row class="panel p-[30px]">
+  <el-row class="application-list">
     <el-col :span="24">
       <el-row>
         <el-col :span="24">
@@ -73,12 +73,12 @@
       </el-row>
       <el-row>
         <el-col :span="24">
-          <el-card shadow="hover">
+          <el-card shadow="hover" class="applications-table-card">
             <el-table
               v-loading="loading"
               :data="individualApplications"
               stripe
-              class="!min-h-[calc(100vh-420px)]"
+              class="applications-table !min-h-[calc(100vh-420px)]"
               table-layout="fixed"
               :empty-text="$t('common.message.noData')"
             >
@@ -444,6 +444,35 @@ export default defineComponent({
     color: var(--el-text-color-secondary);
     font-size: 12px;
     margin: 4px 0 0 0;
+  }
+}
+
+.application-list {
+  width: 100%;
+  margin: 0;
+}
+
+@media screen and (max-width: 767px) {
+  .application-list {
+    display: block;
+  }
+
+  .summary-card {
+    .value {
+      font-size: 24px;
+      line-height: 30px;
+    }
+  }
+
+  .applications-table-card {
+    :deep(.el-card__body) {
+      padding: 0;
+      overflow-x: auto;
+    }
+  }
+
+  .applications-table {
+    min-width: 620px;
   }
 }
 </style>


### PR DESCRIPTION
## Summary
- turn the mobile Console side menu into a compact horizontal nav
- prevent the Applications page padding from squeezing mobile content
- keep the Applications table scrollable inside its card on phones

## Why
The Android/mobile Console view used desktop spacing and a vertical side panel, which made the app management screen cramped and easy to clip on small screens.

## Impact
Console navigation and Applications management remain usable on mobile without changing the desktop layout intent.

## Verification
- `git diff --check`
- `npx vue-tsc -b --pretty false`
- `npm run build:android`