### PR TITLE
[codex] fix: validate empty generation prompts

### DIFF
--- a/src/i18n/en/luma.json
+++ b/src/i18n/en/luma.json
@@ -347,6 +347,10 @@
     "message": "Enter a sentence describing the image to generate, e.g., a cute cat. Additional parameters will override default preset parameters",
     "description": "Placeholder text in the prompt field"
   },
+  "message.promptRequired": {
+    "message": "Please enter a prompt",
+    "description": "Error message when the prompt is missing"
+  },
   "message.uploadReferencesExceed": {
     "message": "You can upload up to 5 images",
     "description": "Error message when the number of uploaded images exceeds the limit"

--- a/src/i18n/en/openaiimage.json
+++ b/src/i18n/en/openaiimage.json
@@ -139,6 +139,10 @@
     "message": "Starting task...",
     "description": "Message indicating task is starting"
   },
+  "message.promptRequired": {
+    "message": "Please enter a prompt",
+    "description": "Error message when the prompt is missing"
+  },
   "message.startTaskSuccess": {
     "message": "Successfully initiated generation task",
     "description": "Task successfully created"

--- a/src/i18n/en/suno.json
+++ b/src/i18n/en/suno.json
@@ -495,6 +495,10 @@
     "message": "Starting task...",
     "description": "Message when starting the music generation task"
   },
+  "message.promptRequired": {
+    "message": "Please enter a prompt or music details",
+    "description": "Error message when music generation input is missing"
+  },
   "message.startingUploadAudio": {
     "message": "Uploading custom music...",
     "description": "Message when starting the music generation task"

--- a/src/i18n/zh-CN/luma.json
+++ b/src/i18n/zh-CN/luma.json
@@ -347,6 +347,10 @@
     "message": "请输入描述要生成的图像的句子，例如：一只可爱的猫。额外参数将覆盖默认预设参数",
     "description": "提示字段中的占位文本"
   },
+  "message.promptRequired": {
+    "message": "请输入提示词",
+    "description": "提示词缺失时的错误消息"
+  },
   "message.uploadReferencesExceed": {
     "message": "最多可上传 5 张图片",
     "description": "上传的图片数量超过限制时的错误消息"

--- a/src/i18n/zh-CN/openaiimage.json
+++ b/src/i18n/zh-CN/openaiimage.json
@@ -139,6 +139,10 @@
     "message": "正在启动任务...",
     "description": "开始任务消息"
   },
+  "message.promptRequired": {
+    "message": "请输入提示词",
+    "description": "提示词缺失时的错误消息"
+  },
   "message.startTaskSuccess": {
     "message": "成功发起生成任务",
     "description": "任务成功创建"

--- a/src/i18n/zh-CN/suno.json
+++ b/src/i18n/zh-CN/suno.json
@@ -495,6 +495,10 @@
     "message": "正在启动任务...",
     "description": "音乐生成任务开始时的消息"
   },
+  "message.promptRequired": {
+    "message": "请输入提示词或音乐信息",
+    "description": "音乐生成输入缺失时的错误消息"
+  },
   "message.startingUploadAudio": {
     "message": "正在上传自定义音乐...",
     "description": "音乐生成任务开始时的消息"

--- a/src/pages/luma/Index.vue
+++ b/src/pages/luma/Index.vue
@@ -157,6 +157,11 @@ export default defineComponent({
         ...this.config,
         callback_url: CALLBACK_URL
       } as ILumaGenerateRequest;
+      if (!this.hasText(request.prompt)) {
+        ElMessage.error(this.$t('luma.message.promptRequired'));
+        return;
+      }
+      request.prompt = request.prompt?.trim();
       const token = this.credential?.token;
       if (!token) {
         console.error('no token specified');
@@ -185,6 +190,9 @@ export default defineComponent({
     getTasksScrollElement(): HTMLElement | undefined {
       const panel = this.$refs.recentPanel as any;
       return panel?.getScrollElement?.();
+    },
+    hasText(value: unknown): value is string {
+      return typeof value === 'string' && value.trim().length > 0;
     }
   }
 });

--- a/src/pages/openaiimage/Index.vue
+++ b/src/pages/openaiimage/Index.vue
@@ -142,6 +142,12 @@ export default defineComponent({
       const cfg: any = { ...(this.config || {}) };
       const hasReferenceImages = Array.isArray(cfg?.image_urls) && cfg.image_urls.length > 0;
 
+      if (!this.hasText(cfg.prompt)) {
+        ElMessage.error(this.$t('openaiimage.message.promptRequired'));
+        return;
+      }
+      cfg.prompt = cfg.prompt.trim();
+
       if (!hasReferenceImages && 'image_urls' in cfg) {
         delete cfg.image_urls;
       }
@@ -203,6 +209,9 @@ export default defineComponent({
     getTasksScrollElement(): HTMLElement | undefined {
       const panel = this.$refs.recentPanel as any;
       return panel?.getScrollElement?.();
+    },
+    hasText(value: unknown): value is string {
+      return typeof value === 'string' && value.trim().length > 0;
     }
   }
 });

--- a/src/pages/suno/Index.vue
+++ b/src/pages/suno/Index.vue
@@ -188,6 +188,13 @@ export default defineComponent({
         ...this.config,
         callback_url: CALLBACK_URL
       } as ISunoAudioRequest;
+      if (!this.hasSunoInput(request)) {
+        ElMessage.error(this.$t('suno.message.promptRequired'));
+        return;
+      }
+      if (this.hasText(request.prompt)) {
+        request.prompt = request.prompt.trim();
+      }
       const token = this.credential?.token;
       if (!token) {
         console.error('no token specified');
@@ -211,6 +218,17 @@ export default defineComponent({
     getTasksScrollElement(): HTMLElement | undefined {
       const panel = this.$refs.recentPanel as any;
       return panel?.getScrollElement?.();
+    },
+    hasText(value: unknown): value is string {
+      return typeof value === 'string' && value.trim().length > 0;
+    },
+    hasSunoInput(request: ISunoAudioRequest): boolean {
+      const textFields = [request.prompt, request.lyric, request.lyric_prompt, request.style, request.title];
+      return (
+        textFields.some((value) => this.hasText(value)) ||
+        this.hasText(request.audio_id) ||
+        (Array.isArray(request.mashup_audio_ids) && request.mashup_audio_ids.length > 0)
+      );
     }
   }
 });


### PR DESCRIPTION
## Summary
- block empty Luma and OpenAI Image prompts before sending generation requests
- block empty Suno generation requests unless prompt, music detail, or audio inputs are present
- add validation copy in maintained `zh-CN` and `en` locale files only

## Why
Several generation forms could submit empty payloads from Android, creating avoidable failed API calls and confusing task state.

## Impact
Users get immediate client-side feedback before spending time or quota on invalid generation requests.

## Verification
- `git diff --check`
- JSON parse check for modified locale files
- `npx vue-tsc -b --pretty false`
- `npm run build:android`