### PR TITLE
[codex] fix: harden video playback fallback

### DIFF
--- a/src/components/common/VideoPlayer.vue
+++ b/src/components/common/VideoPlayer.vue
@@ -1,15 +1,23 @@
 <template>
   <div class="video max-w-[800px] max-h-[450px] rounded-[15px] overflow-hidden">
-    <vue-plyr :options="mergedOptions">
-      <video controls crossorigin="anonymous" playsinline class="w-full h-full aspect-[16/9]">
-        <source size="1080" :src="src" type="video/mp4" />
+    <vue-plyr v-if="!failed && safeSrc" :key="safeSrc" :options="mergedOptions">
+      <video controls playsinline preload="metadata" class="w-full h-full aspect-[16/9]" @error="onError">
+        <source size="1080" :src="safeSrc" type="video/mp4" />
       </video>
     </vue-plyr>
+    <div v-else-if="safeSrc" class="video-fallback">
+      <el-button type="primary" round @click="onOpen">
+        <font-awesome-icon icon="fa-solid fa-up-right-from-square" class="mr-2" />
+        {{ $t('common.button.download') }}
+      </el-button>
+    </div>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
+import { ElButton } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 // @ts-ignore
 import VuePlyr from '@skjnldsv/vue-plyr';
 // @ts-ignore
@@ -17,7 +25,7 @@ import '@skjnldsv/vue-plyr/dist/vue-plyr.css';
 
 export default defineComponent({
   name: 'VideoPlayer',
-  components: { VuePlyr },
+  components: { ElButton, FontAwesomeIcon, VuePlyr },
   props: {
     src: {
       type: String,
@@ -31,6 +39,7 @@ export default defineComponent({
   },
   data() {
     return {
+      failed: false,
       mergedOptions: {
         controls: [
           'play-large',
@@ -45,10 +54,41 @@ export default defineComponent({
           'fullscreen'
         ],
         iconUrl: 'https://cdn.acedata.cloud/7jq4t0.svg',
-        quality: { default: '1080p', ...this.options.quality },
+        quality: { default: 1080, options: [1080], ...this.options.quality },
         ...this.options
       }
     };
+  },
+  computed: {
+    safeSrc(): string {
+      return this.src.trim();
+    }
+  },
+  watch: {
+    safeSrc() {
+      this.failed = false;
+    }
+  },
+  methods: {
+    onError() {
+      this.failed = true;
+    },
+    onOpen() {
+      window.open(this.safeSrc, '_blank', 'noopener,noreferrer');
+    }
   }
 });
 </script>
+
+<style lang="scss" scoped>
+.video {
+  background: var(--el-fill-color-light);
+}
+
+.video-fallback {
+  min-height: 180px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+</style>

--- a/src/components/pika/VideoPlayer.vue
+++ b/src/components/pika/VideoPlayer.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <vue-plyr :options="options" class="video">
-      <video controls crossorigin="" playsinline :data-poster="modelValue?.image_url">
+      <video controls playsinline preload="metadata" :data-poster="modelValue?.image_url">
         <source size="1080" :src="modelValue?.video_url" type="video/mp4" />
       </video>
     </vue-plyr>
@@ -26,7 +26,7 @@ export default defineComponent({
   },
   data() {
     return {
-      options: { quality: { default: '1080p' } }
+      options: { quality: { default: 1080, options: [1080] } }
     };
   }
 });


### PR DESCRIPTION
## Summary
- stop forcing CORS on generated video playback
- remount Plyr when the video source changes and use numeric quality config
- show a direct open/download fallback when media loading fails

## Why
Generated videos can be served from CDNs that do not expose browser CORS headers. Forcing `crossorigin` makes Android WebView playback more fragile and can leave users without a recovery path.

## Impact
Video previews should load more reliably, and failed loads now expose a direct fallback action instead of an empty player.

## Verification
- `git diff --check`
- `npx vue-tsc -b --pretty false`
- `npm run build:android`