### PR TITLE
fix(site): preserve transparency in favicon/logo cropper

### DIFF
--- a/change/@acedatacloud-nexior-favicon-transparency.json
+++ b/change/@acedatacloud-nexior-favicon-transparency.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(site): preserve transparency in favicon/logo cropper — encode PNG when source has alpha, swap dark preview for checkerboard",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/ImageCropper.vue
+++ b/src/components/common/ImageCropper.vue
@@ -124,6 +124,10 @@ export default defineComponent({
   data() {
     return {
       imageSrc: '' as string,
+      // Source mime captured at file pick time. PNG / WEBP / GIF carry an alpha
+      // channel — we must re-encode to PNG on confirm, otherwise JPEG flattens
+      // transparent pixels to black on upload (favicon bug).
+      sourceMime: '' as string,
       uploading: false,
       ZoomIn,
       ZoomOut,
@@ -195,11 +199,17 @@ export default defineComponent({
         ElMessage.error(this.$t('site.imageCropper.invalidType') as string);
         return;
       }
+      this.sourceMime = file.type;
       const reader = new FileReader();
       reader.onload = (e) => {
         this.imageSrc = (e.target?.result as string) || '';
       };
       reader.readAsDataURL(file);
+    },
+    /** Source has an alpha channel → keep PNG so transparency survives upload. */
+    hasAlpha(): boolean {
+      const m = this.sourceMime;
+      return m === 'image/png' || m === 'image/webp' || m === 'image/gif';
     },
     onZoom(factor: number) {
       const cropper = this.$refs.cropperRef as { zoom?: (f: number) => void } | undefined;
@@ -215,6 +225,7 @@ export default defineComponent({
     },
     onClosed() {
       this.imageSrc = '';
+      this.sourceMime = '';
       this.uploading = false;
     },
     async onConfirm() {
@@ -238,12 +249,17 @@ export default defineComponent({
       }
       ctx.drawImage(canvas, 0, 0, targetW, targetH);
 
+      const keepAlpha = this.hasAlpha();
+      const outMime = keepAlpha ? 'image/png' : 'image/jpeg';
+      const outExt = keepAlpha ? 'png' : 'jpg';
+
       this.uploading = true;
       try {
         const blob: Blob = await new Promise((resolve, reject) => {
-          out.toBlob((b) => (b ? resolve(b) : reject(new Error('toBlob failed'))), 'image/jpeg', 0.92);
+          // PNG ignores the quality arg; passing it is harmless.
+          out.toBlob((b) => (b ? resolve(b) : reject(new Error('toBlob failed'))), outMime, 0.92);
         });
-        const filename = `image-${Date.now()}.jpg`;
+        const filename = `image-${Date.now()}.${outExt}`;
         const formData = new FormData();
         formData.append('file', blob, filename);
         const { data } = await httpClient.post<{ file_url: string }>('/files/', formData, {
@@ -276,7 +292,18 @@ export default defineComponent({
   .cropper {
     width: 100%;
     height: 360px;
-    background: #1a1a1a;
+    // Checkerboard so transparent PNGs (e.g. favicons) read as transparent
+    // instead of looking like they have a black background.
+    background-color: #fafafa;
+    background-image:
+      linear-gradient(45deg, #d8d8d8 25%, transparent 25%), linear-gradient(-45deg, #d8d8d8 25%, transparent 25%),
+      linear-gradient(45deg, transparent 75%, #d8d8d8 75%), linear-gradient(-45deg, transparent 75%, #d8d8d8 75%);
+    background-size: 16px 16px;
+    background-position:
+      0 0,
+      0 8px,
+      8px -8px,
+      8px 0;
     border-radius: 8px;
     overflow: hidden;
   }

--- a/src/components/site/EditImage.vue
+++ b/src/components/site/EditImage.vue
@@ -67,9 +67,11 @@ export default defineComponent({
       return this.width / this.height;
     },
     /**
-     * Output JPEG width. We keep at least 512px on the longer edge so the
+     * Output canvas width. We keep at least 512px on the longer edge so the
      * uploaded asset remains crisp on hi-DPI screens, even when the on-page
-     * display size is small (e.g. a 32x32 favicon → 512x512 output).
+     * display size is small (e.g. a 32x32 favicon → 512x512 output). Encoding
+     * (PNG vs JPEG) is decided in ImageCropper based on the source mime so
+     * transparent favicons / logos round-trip without a black background.
      */
     outputWidth(): number {
       const longest = Math.max(this.width, this.height);


### PR DESCRIPTION
## Symptom

Uploading a transparent PNG as Site → Favicon (or Logo) results in a black-background image. The black background is visible:

1. **In the cropper dialog itself** — the preview area is dark grey, so the user assumes transparent pixels just look transparent in the dark.
2. **After Confirm** — the saved favicon on the server (and rendered in the browser tab) actually *is* black-backed. Refresh doesn't help; the image on COS already lost its alpha channel.

## Root cause

`src/components/common/ImageCropper.vue` (introduced in #686) had two stacked issues:

1. **Always encoded as JPEG.** `out.toBlob(..., 'image/jpeg', 0.92)` — JPEG has no alpha channel, so the browser flattens transparent pixels to the canvas default fill (black) before encoding. That black-backed JPEG is what's POSTed to `/files/` and what every visitor of the site sees in their tab thereafter. The filename was also hard-coded to `.jpg`.
2. **Dark cropper preview.** `.cropper { background: #1a1a1a; }` made transparent source images look like they had a solid dark background even *before* the user clicked Confirm — masking the bug visually and giving zero hint that anything was about to be flattened.

## Fix

`ImageCropper.vue`:

- Capture `file.type` at file pick time as `sourceMime`.
- New computed-style helper `hasAlpha()` returns `true` when source mime is `image/png`, `image/webp`, or `image/gif`.
- On Confirm, choose `'image/png'` (with `.png` filename) when alpha must be preserved; otherwise keep the existing JPEG path. Quality arg is harmless for PNG.
- Replace the `#1a1a1a` cropper background with a CSS-only checkerboard pattern (8 px squares, `#fafafa` / `#d8d8d8`) so transparency is *visible* during editing — same convention every image editor uses.
- Reset `sourceMime` in `onClosed()` alongside `imageSrc`.

`EditImage.vue`: just updated the stale "Output JPEG width" comment — the encoding decision now lives in the cropper.

## Verification

- `npx eslint src/components/common/ImageCropper.vue src/components/site/EditImage.vue` — clean (after one prettier autofix).
- `npx vue-tsc --noEmit` — clean.
- Manual: upload a transparent PNG favicon → cropper now shows a checkerboard background with the logo crisply on top, Confirm uploads `image-<ts>.png`, browser tab shows the favicon with proper transparency.
- Existing JPEG uploads (e.g. a photo for a site logo) still go through the JPEG path — no behaviour change for non-alpha sources.

## Risk

Low. Behaviour change is gated on the source mime; non-PNG/WEBP/GIF uploads keep producing the same JPEG output as before. Server-side `/files/` accepts both PNG and JPEG already (other parts of the app upload PNGs).
