### PR TITLE
feat(commonfrontend): wire CommonFrontend submodule via @common alias

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "commonfrontend"]
+	path = commonfrontend
+	url = git@github.com:AceDataCloud/CommonFrontend.git

--- a/change/@acedatacloud-nexior-commonfrontend-pilot.json
+++ b/change/@acedatacloud-nexior-commonfrontend-pilot.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore(commonfrontend): wire CommonFrontend submodule via @common alias; re-export IUser/IUserDetailResponse from @common/types/user",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -1,20 +1,18 @@
-export interface IUser {
-  id?: string;
-  username?: string;
-  first_name?: string;
-  last_name?: string;
-  email?: string;
-  nickname?: string;
-  gender?: number;
-  city?: string;
-  province?: string;
-  country?: string;
-  avatar?: string;
-}
+// `IUser` and `IUserDetailResponse` are re-exported from
+// `@acedatacloud/common-frontend` (the `commonfrontend/` git submodule)
+// so AuthFrontend / Nexior / PlatformFrontend share one source of truth
+// for the account-user shape. The shared type is a strict superset of
+// what Nexior used to declare locally (it adds optional fields like
+// `description`, `phone`, `is_verified`, `*_id`, …) — Nexior's existing
+// callers only touch the original 12 fields, so widening is safe.
+//
+// `IUserListResponse` stays local because Nexior is the only consumer
+// of a paginated user list today (admin-side flows). If a second
+// consumer needs it later, promote it to `@common/types/user` then.
+export type { IUser, IUserDetailResponse } from '@common/types/user';
+import type { IUser } from '@common/types/user';
 
 export interface IUserListResponse {
   count: number;
   items: IUser[];
 }
-
-export interface IUserDetailResponse extends IUser {}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -4,7 +4,8 @@
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@common/*": ["./commonfrontend/src/*"]
     },
     "moduleResolution": "node",
     "skipLibCheck": true,
@@ -15,5 +16,11 @@
     "noUncheckedSideEffectImports": true,
     "verbatimModuleSyntax": false
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue", "src/**/*.d.ts"]
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "src/**/*.vue",
+    "src/**/*.d.ts",
+    "commonfrontend/src/**/*.ts"
+  ]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -71,7 +71,8 @@ export default defineConfig((config: ConfigEnv) => {
     ],
     resolve: {
       alias: {
-        '@': path.resolve(__dirname, './src')
+        '@': path.resolve(__dirname, './src'),
+        '@common': path.resolve(__dirname, './commonfrontend/src')
       }
     },
     build: {


### PR DESCRIPTION
## What

Pilot the source-imported [CommonFrontend](https://github.com/AceDataCloud/CommonFrontend) repo (mirrors AuthFrontend [PR #111](https://github.com/AceDataCloud/AuthFrontend/pull/111)) so Nexior can start consuming shared types and (later) shared Vue components from a single source of truth.

This unlocks the `<ProfileCard>` / `<ConnectionsManager>` / `<SkillsManager>` / `<OAuthAppsManager>` extraction work that follows: once the wiring is proven across all three frontends, each shared page lands in its own PR.

## Why source-import (submodule) instead of npm

The three consumer apps sit at very different toolchain versions:

| App              | Vue   | Vite | Element Plus | vue-i18n | axios |
| ---------------- | ----- | ---- | ------------ | -------- | ----- |
| AuthFrontend     | 3.2.6 | 2.x  | 2.2.28       | 9.x      | 0.21  |
| Nexior           | 3.5   | 7.x  | 2.10.4       | 11.x     | 1.6   |
| PlatformFrontend | 3.5   | 7.x  | 2.13.7       | 11.1     | 1.15  |

A pre-built dist would force a single compile-time toolchain on all three. Source-imported files let each app's Vite pipeline transpile the shared code with its own deps — same trick that monorepos use under the hood.

## What's in this PR

- **`.gitmodules`** + **`commonfrontend/`** — adds CommonFrontend as a git submodule pinned to [AceDataCloud/CommonFrontend@5f9bd73](https://github.com/AceDataCloud/CommonFrontend/commit/5f9bd73) (initial skeleton: types, base-URL constants, base-URL utilities — no Vue components yet).
- **`vite.config.ts`** — adds `'@common': path.resolve(__dirname, './commonfrontend/src')` alongside the existing `'@'` alias.
- **`tsconfig.app.json`** — adds `"@common/*": ["./commonfrontend/src/*"]` to `paths` and `commonfrontend/src/**/*.ts` to `include`.
- **`src/models/user.ts`** — re-exports `IUser` and `IUserDetailResponse` from `@common/types/user`. Local `IUserListResponse` stays put (Nexior is the only consumer today; promote later).
- **`change/`** — beachball patch changefile.

## Why pick `IUser` for the pilot

CommonFrontend's `IUser` is a **strict superset** of Nexior's previous local declaration:

| Field                                                | Nexior (old) | CommonFrontend |
| ---------------------------------------------------- | ------------ | -------------- |
| `id, username, first_name, last_name, email`         | ✅            | ✅              |
| `nickname, gender, city, province, country, avatar`  | ✅            | ✅              |
| `description, phone, sms_code, is_verified, banner`  | —            | ✅ (added)      |
| `realname, idcard, password, email_code, *_id, code` | —            | ✅ (added)      |

Every previously-declared field is preserved. Widening with new **optional** fields is safe for existing Nexior callers, which only read/write the original 12 keys.

## Verification

```
$ npx vue-tsc -p tsconfig.app.json --noEmit --skipLibCheck
$ echo "exit=$?"
exit=0
```

Zero TypeScript errors with my changes — same as `origin/main`. `@common/types/user` resolves cleanly through the alias chain (vite + tsconfig).

## Risk

Trivially low. The user-type widening is purely additive; no existing field changed type or got removed. Submodule pin is to a specific commit, so even if CommonFrontend's `main` moves, this build doesn't drift until we explicitly bump the pin.

If the submodule fails to clone in CI, the build fails fast (import resolution error) — no risk of a runtime regression.

## Setup for reviewers

After checking out this branch:

```sh
git submodule update --init --recursive
```

If you forget, `npm run dev` / `npm run build` will fail at module-resolution time with `Cannot find module '@common/types/user'`.

## Follow-up

- [ ] PlatformFrontend will get the same submodule wiring (next PR).
- [ ] Tier 1 page extractions in order, each in its own PR:
      `<ProfileCard>` -> `<ConnectionsManager>` -> `<SkillsManager>` -> `<OAuthAppsManager>`.
- [ ] Optionally add CommonFrontend to the [Index](https://github.com/AceDataCloud/Index) monorepo's `.gitmodules`.

## References

- [AceDataCloud/CommonFrontend](https://github.com/AceDataCloud/CommonFrontend) — the new shared repo
- [AuthFrontend PR #111](https://github.com/AceDataCloud/AuthFrontend/pull/111) — companion pilot in AuthFrontend
- [Nexior PR #705](https://github.com/AceDataCloud/Nexior/pull/705) — already-merged `chore: remove dead /chat/oauth/callback page`, prep for the shared Connections page
