### PR TITLE
fix(chat): pass `site` to AuthFrontend when opening skills/connections

### DIFF
--- a/src/components/chat/Composer.vue
+++ b/src/components/chat/Composer.vue
@@ -126,7 +126,7 @@ import {
 } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { IChatModel, IChatReference } from '@/models';
-import { getBaseUrlPlatform, isImageUrl, pasteUploadMixin, withCurrentUserId } from '@/utils';
+import { getBaseUrlPlatform, isImageUrl, pasteUploadMixin, withCurrentUserIdAndSite } from '@/utils';
 import FilePreview from '@/components/common/FilePreview.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 
@@ -314,13 +314,14 @@ export default defineComponent({
     onOpenSkills() {
       // Skills are managed exclusively at auth.acedata.cloud/user/skills.
       // Nexior is a thin entry point - clicking opens the canonical
-      // management page in a new tab.
-      window.open(withCurrentUserId('https://auth.acedata.cloud/user/skills'), '_blank', 'noopener');
+      // management page in a new tab. Pass `site` so AuthFrontend renders
+      // the calling subsite's white-label logo (no-op on the main host).
+      window.open(withCurrentUserIdAndSite('https://auth.acedata.cloud/user/skills'), '_blank', 'noopener');
     },
     onOpenConnections() {
       // Connections (MCP + OAuth connectors) are managed exclusively at
       // auth.acedata.cloud/user/connections.
-      window.open(withCurrentUserId('https://auth.acedata.cloud/user/connections'), '_blank', 'noopener');
+      window.open(withCurrentUserIdAndSite('https://auth.acedata.cloud/user/connections'), '_blank', 'noopener');
     }
   }
 });

--- a/src/utils/crossSiteUser.ts
+++ b/src/utils/crossSiteUser.ts
@@ -1,5 +1,6 @@
 import store from '@/store';
 import { RouteLocationNormalized, RouteLocationRaw } from 'vue-router';
+import { isMainOfficial } from './is';
 import { loginRedirect } from './login';
 
 /**
@@ -24,6 +25,7 @@ import { loginRedirect } from './login';
  * infinite loop on the next round-trip.
  */
 export const USER_ID_QUERY_PARAM = 'user_id';
+export const SITE_QUERY_PARAM = 'site';
 
 /**
  * Append `?user_id=<currentUserId>` to a URL when there is a logged-in user.
@@ -47,6 +49,40 @@ export const withCurrentUserId = (url: string): string => {
     return `${url}${sep}${USER_ID_QUERY_PARAM}=${encodeURIComponent(String(userId))}`;
   }
 };
+
+/**
+ * Append `?site=<window.location.origin>` to a URL so the destination site
+ * (typically AuthFrontend) can render the calling Site's white-label
+ * branding (logo, name, theme) instead of the default Ace Data Cloud one.
+ *
+ * Skipped on the bare main official host (`studio.acedata.cloud`), where the
+ * default branding is already correct and the param would be redundant.
+ *
+ * Mirrors how `loginRedirect()` already passes `site` to the SSO login page.
+ */
+export const withCurrentSite = (url: string): string => {
+  if (isMainOfficial()) return url;
+  const origin = typeof window !== 'undefined' ? window.location?.origin : '';
+  if (!origin) return url;
+  try {
+    const u = new URL(url);
+    if (!u.searchParams.has(SITE_QUERY_PARAM)) {
+      u.searchParams.set(SITE_QUERY_PARAM, origin);
+    }
+    return u.toString();
+  } catch {
+    const sep = url.includes('?') ? '&' : '?';
+    return `${url}${sep}${SITE_QUERY_PARAM}=${encodeURIComponent(origin)}`;
+  }
+};
+
+/**
+ * Convenience: decorate a cross-site URL with both `user_id` (identity) and
+ * `site` (white-label branding context). Use this for outbound links that
+ * end up at AuthFrontend pages where the user expects to see the calling
+ * subsite's logo (e.g. /user/skills, /user/connections).
+ */
+export const withCurrentUserIdAndSite = (url: string): string => withCurrentSite(withCurrentUserId(url));
 
 /** Build a path+query string for `to`, omitting `user_id`. */
 const buildRedirectWithoutUserId = (to: RouteLocationNormalized): string => {


### PR DESCRIPTION
## Symptom

On a Nexior subsite (white-label tenant or `*.studio.acedata.cloud`), clicking the chat composer's **+** menu → **Skills** or **Connections** opens `https://auth.acedata.cloud/user/skills` (or `/user/connections`) in a new tab — but the AuthFrontend page shows the **default Ace Data Cloud logo** instead of the calling subsite's branded logo. Visually it looks like the user "fell off" their tenant.

## Why

`Composer.vue`'s `onOpenSkills` / `onOpenConnections` methods only annotate the URL with `?user_id=…` (cross-site identity) — they don't pass any branding context. AuthFrontend has no way to know which Site initiated the redirect, so it defaults to the official branding.

We already solved this exact problem for the SSO login redirect: `utils/login.ts → loginRedirect()` always passes `site=<window.location.origin>` to `https://auth.acedata.cloud/auth/login`, and AuthFrontend reads it and swaps its logo accordingly. The skills/connections links just never picked up the same convention.

## Fix

`src/utils/crossSiteUser.ts`:
- Add `withCurrentSite(url)` — appends `?site=<window.location.origin>` to a URL, **skipping** when running on the bare main official host (`studio.acedata.cloud`) via `isMainOfficial()`. On the main host the default branding is already correct and the param would be redundant.
- Add `withCurrentUserIdAndSite(url)` — convenience wrapper that decorates a URL with both `user_id` (identity) and `site` (white-label branding context) for outbound AuthFrontend links.

`src/components/chat/Composer.vue`:
- Switch the two `+`-menu methods (`onOpenSkills`, `onOpenConnections`) from `withCurrentUserId(...)` to `withCurrentUserIdAndSite(...)`.

That's it — 2 files, +41 / −4.

## Behaviour matrix

| Caller origin                              | Resulting URL                                                                                                          |
| ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
| `studio.acedata.cloud` (main official)     | `…/user/skills?user_id=…` (no `site` — `isMainOfficial()` short-circuits)                                              |
| `my-brand.studio.acedata.cloud` (subsite)  | `…/user/skills?user_id=…&site=https%3A%2F%2Fmy-brand.studio.acedata.cloud` → AuthFrontend renders the subsite's logo   |
| `chat.example.com` (white-label tenant)    | `…/user/skills?user_id=…&site=https%3A%2F%2Fchat.example.com` → AuthFrontend renders the tenant's logo                 |

Mirrors the contract `loginRedirect()` already uses.

## Verification

- `npx vue-tsc --noEmit` — clean.
- `npx eslint src/utils/crossSiteUser.ts src/components/chat/Composer.vue` — only two pre-existing prettier nits at lines 63 / 395 of `Composer.vue` (untouched code, present on `origin/main`); my hunks at lines ~129 / ~315–325 are clean.
- Manual smoke (against staging by editing `auth.acedata.cloud` to a debug printer): on a subsite, the outbound URL now carries both `user_id` and `site`; on `studio.acedata.cloud`, only `user_id` (as designed).

## Risk

Low. Same pattern AuthFrontend already accepts on its login page. No behaviour change on the bare main official host. Only adds a query param to two already-cross-site `window.open` calls; if AuthFrontend doesn't recognise the param it just gets ignored.
