### PR TITLE
fix(auth-jumps): pass `site` to AuthFrontend on profile / verify / connections / embedded login

### DIFF
--- a/src/components/common/AuthPanel.vue
+++ b/src/components/common/AuthPanel.vue
@@ -32,7 +32,7 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import { ElDialog } from 'element-plus';
-import { getBaseUrlAuth } from '@/utils';
+import { getBaseUrlAuth, withCurrentSite } from '@/utils';
 import { getCookie } from 'typescript-cookie';
 import QrCode from 'vue-qrcode';
 import { ROUTE_SETTINGS_INDEX } from '@/router';
@@ -61,7 +61,9 @@ export default defineComponent({
       if (this.isNative) {
         url += '&native_redirect=com.acedatacloud.nexior';
       }
-      return url;
+      // Pass `site` so the embedded AuthFrontend login form renders the
+      // calling subsite's white-label logo (no-op on the main official host).
+      return withCurrentSite(url);
     },
     inviterId() {
       // if forceInviterId is set, then use forceInviterId
@@ -100,7 +102,9 @@ export default defineComponent({
         // Open the auth page in an in-app browser with the provider pre-selected.
         const provider = event.data.data?.provider;
         this.useBrowser = true;
-        const authUrl = `${getBaseUrlAuth()}/auth/login?inviter_id=${this.inviterId}&native_redirect=com.acedatacloud.nexior&provider=${provider}`;
+        const authUrl = withCurrentSite(
+          `${getBaseUrlAuth()}/auth/login?inviter_id=${this.inviterId}&native_redirect=com.acedatacloud.nexior&provider=${provider}`
+        );
         Browser.open({ url: authUrl });
         return;
       }

--- a/src/components/common/TopHeader.vue
+++ b/src/components/common/TopHeader.vue
@@ -69,7 +69,7 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import defaultAvatar from '@/assets/images/avatar.png';
-import { getBaseUrlAuth, withCurrentUserId } from '@/utils';
+import { getBaseUrlAuth, withCurrentUserIdAndSite } from '@/utils';
 import { ROUTE_AUTH_LOGIN, ROUTE_CONSOLE_ROOT, ROUTE_DOWNLOAD, ROUTE_INDEX } from '@/router';
 import { ElCol, ElRow, ElDropdown, ElMenu, ElSubMenu, ElMenuItem, ElDropdownItem, ElButton } from 'element-plus';
 import Logo from './Logo.vue';
@@ -136,11 +136,11 @@ export default defineComponent({
     },
     onProfile() {
       const baseUrlAuth = getBaseUrlAuth();
-      window.open(withCurrentUserId(`${baseUrlAuth}/user/profile`), '_blank');
+      window.open(withCurrentUserIdAndSite(`${baseUrlAuth}/user/profile`), '_blank');
     },
     onVerify() {
       const baseUrlAuth = getBaseUrlAuth();
-      window.open(withCurrentUserId(`${baseUrlAuth}/user/verify`), '_blank');
+      window.open(withCurrentUserIdAndSite(`${baseUrlAuth}/user/verify`), '_blank');
     },
     onConsole() {
       this.$router.push({

--- a/src/pages/profile/Index.vue
+++ b/src/pages/profile/Index.vue
@@ -40,7 +40,7 @@ import {
   ROUTE_SETTINGS_INDEX
 } from '@/router';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlAuth, getBaseUrlPlatform, withCurrentUserId } from '@/utils';
+import { getBaseUrlAuth, getBaseUrlPlatform, withCurrentUserIdAndSite } from '@/utils';
 import HelpDialog from '@/components/common/HelpDialog.vue';
 
 interface ILink {
@@ -184,8 +184,10 @@ export default defineComponent({
         });
       } else if (link.href) {
         // Append `?user_id=<currentUserId>` so the destination site can
-        // detect a cross-site identity mismatch and re-auth.
-        window.open(withCurrentUserId(link.href), '_blank');
+        // detect a cross-site identity mismatch and re-auth, plus `?site=`
+        // so AuthFrontend renders the calling subsite's white-label logo
+        // (no-op on the bare main official host).
+        window.open(withCurrentUserIdAndSite(link.href), '_blank');
       } else if (link.callback) {
         link.callback();
       }

--- a/src/utils/connections.ts
+++ b/src/utils/connections.ts
@@ -6,7 +6,7 @@
  * via the `return_url` query parameter.
  */
 
-import { withCurrentUserId } from './crossSiteUser';
+import { withCurrentUserIdAndSite } from './crossSiteUser';
 
 const CONNECTIONS_MANAGER_URL = 'https://auth.acedata.cloud/user/connections';
 
@@ -18,7 +18,9 @@ const CONNECTIONS_MANAGER_URL = 'https://auth.acedata.cloud/user/connections';
  * their current Nexior context (chat draft, scroll position, etc.).
  *
  * Also annotates the URL with `?user_id=<currentUserId>` so AuthFrontend
- * can detect a cross-site identity mismatch and re-auth.
+ * can detect a cross-site identity mismatch and re-auth, and `?site=`
+ * so AuthFrontend renders the calling subsite's white-label logo (no-op
+ * on the bare main official host).
  */
 export function openConnectionsManager(provider?: string): void {
   const returnUrl = window.location.href;
@@ -27,5 +29,5 @@ export function openConnectionsManager(provider?: string): void {
   if (provider) {
     url.searchParams.set('provider', provider);
   }
-  window.open(withCurrentUserId(url.toString()), '_blank', 'noopener,noreferrer');
+  window.open(withCurrentUserIdAndSite(url.toString()), '_blank', 'noopener,noreferrer');
 }


### PR DESCRIPTION
## Context

Follow-up to #709 (chat composer **+** menu → Skills / Connections). Same root cause, applied to the rest of Nexior's outbound jumps to AuthFrontend.

## Problem

`?site=<origin>` is what AuthFrontend reads (via `getSiteOrigin()` → `store.getSite`) to look up the calling subsite and swap its logo / theme. Without it, AuthFrontend clears any persisted site and renders the default Ace Data Cloud branding.

#709 added that param to the chat composer's two `+`-menu links. The rest of the cross-site auth jumps were still passing only `?user_id=` (identity) and no `?site=` (branding), so on a white-label tenant or `*.studio.acedata.cloud` subsite the user would still see the wrong logo when:

1. **Top-right account dropdown** → "Profile" / "Verify"
2. **Console side-menu** → "User Profile" (and any other href-based link rendered by `onNavigate`)
3. **Connections manager helper** (currently unused but on the same pattern)
4. **Login form embedded in `AuthPanel.vue`** — both the iframe `auth/login?inviter_id=…` and the native in-app-browser variant

## Fix

Switches each call site to the helpers added in #709:

- **`src/components/common/TopHeader.vue`** — `onProfile()` / `onVerify()` use `withCurrentUserIdAndSite(...)` instead of `withCurrentUserId(...)`.
- **`src/pages/profile/Index.vue`** — generic `onNavigate(link)` handler upgraded the same way (covers the `/user/profile` entry in the Nexior console menu, plus any future `href` link).
- **`src/utils/connections.ts`** — `openConnectionsManager()` switched to `withCurrentUserIdAndSite`. Currently unused, but kept aligned so when it's wired up next it doesn't regress.
- **`src/components/common/AuthPanel.vue`** — `iframeUrl()` and the native `Browser.open(authUrl)` path now wrap the URL with `withCurrentSite(...)` (no `user_id` here — the iframe is for *logging in*, by definition there's no current user yet, and the existing `inviter_id` flow stays untouched).

No new helpers — just consumers of `withCurrentUserIdAndSite` / `withCurrentSite` from #709. All of these are no-ops on the bare main official host (`studio.acedata.cloud`), so behaviour on the parent site is unchanged.

## Verification

- `npx vue-tsc --noEmit` — clean.
- `npx eslint <four touched files>` — clean (exit 0).
- Branched off `1e0d6db3` (PR #709 already merged on `main`), so the helpers it introduced are guaranteed present.

## Risk

Low. Same wire format AuthFrontend has been parsing for the SSO login flow for ages (`getSiteOrigin()` is unchanged on `origin/main`). Adds one extra query param per outbound `window.open` / iframe `src`. If AuthFrontend doesn't recognise it, it gets ignored.
