### PR TITLE
fix(boot): match PlatformFrontend spinner colors, drop boot title/subtitle

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,9 +151,9 @@
         --boot-bg: #ffffff;
         --boot-fg: #0b0b0b;
         --boot-muted: rgba(0, 0, 0, 0.55);
-        --boot-spinner-1: #7c3aed;
-        --boot-spinner-2: #818cf8;
-        --boot-spinner-3: #a78bfa;
+        --boot-spinner-1: #07eea6;
+        --boot-spinner-2: #29bee4;
+        --boot-spinner-3: #23abff;
       }
 
       /*
@@ -238,20 +238,6 @@
         }
       }
 
-      .boot__title {
-        font-size: 14px;
-        letter-spacing: 0.24em;
-        text-transform: uppercase;
-        opacity: 0.92;
-        user-select: none;
-      }
-
-      .boot__subtitle {
-        font-size: 12px;
-        color: var(--boot-muted);
-        user-select: none;
-      }
-
       @media (prefers-reduced-motion: reduce) {
         .boot__loader::before,
         .boot__loader::after {
@@ -265,8 +251,6 @@
       <div class="boot" aria-label="Loading" role="status">
         <div class="boot__content">
           <div class="boot__loader" aria-hidden="true"></div>
-          <div class="boot__title">Ace Data Cloud</div>
-          <div class="boot__subtitle">Loading…</div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## What

Two tiny tweaks to `index.html`'s pre-app boot screen:

1. Drop `Ace Data Cloud` (title) and `Loading…` (subtitle). Leave only the spinner circle.
2. Swap the spinner conic-gradient palette to match PlatformFrontend's:
   - Old: purple `#7c3aed` / `#818cf8` / `#a78bfa`
   - New: green-cyan-blue `#07eea6` / `#29bee4` / `#23abff` (identical to `PlatformFrontend/index.html`).

## Why

Now that Nexior's boot screen and the developer-portal boot screen sit side-by-side in user flows (cross-site SSO, embedded login, etc.), the purple spinner felt off-brand vs. PlatformFrontend's brand teal/blue. User asked to converge on the PF palette and reduce the boot screen to just the circle.

## What changed

- `index.html`: only the boot-screen block.
  - `--boot-spinner-{1,2,3}` values updated.
  - Removed two `<div class="boot__title">` / `<div class="boot__subtitle">` nodes.
  - Removed the now-dead `.boot__title` / `.boot__subtitle` CSS rules (no other consumers — grep confirms only `index.html` references those classes).
- No JS, no app code, no framework changes.

## Verification

- `git diff --stat`: `index.html | 22 +++-------------------` (3 / 19).
- Manually opened `file:///.../index.html` in a browser — only the spinner shows, with the new palette, both light and dark themes.
- Reduced-motion media query still applies (the `.boot__loader::before, .boot__loader::after` selectors are unchanged).

## Risk

Minimal — pre-paint static markup only. Bundle size shrinks slightly.
