### PR TITLE
fix(settings): show admin/official-only hint at top of restricted tabs

### DIFF
--- a/src/components/setting/CustomDomain.vue
+++ b/src/components/setting/CustomDomain.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="custom-domain-settings">
+    <section-notice tone="admin" :text="$t('common.settings.adminOnlyHint')" />
     <div class="header">
       <p class="settings-title">{{ $t('common.settings.customDomain') }}</p>
       <p class="settings-tip">{{ $t('subsite.message.domainsIntro') }}</p>
@@ -112,6 +113,7 @@ import {
   vLoading
 } from 'element-plus';
 import { siteDomainOperator } from '@/operators';
+import SectionNotice from '@/components/setting/SectionNotice.vue';
 import type { ISite, ISiteDomain } from '@/models';
 
 // Mirror of the backend hostname validator. Keep in sync with
@@ -170,7 +172,8 @@ export default defineComponent({
     ElFormItem,
     ElInput,
     ElTag,
-    ElDivider
+    ElDivider,
+    SectionNotice
   },
   directives: {
     loading: vLoading

--- a/src/components/setting/Distribution.vue
+++ b/src/components/setting/Distribution.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="settings-list">
+    <section-notice tone="admin" :text="$t('common.settings.adminOnlyHint')" />
     <section class="settings-item">
       <div class="settings-label">
         <p class="settings-title">{{ $t('site.field.distributionDefaultInviterId') }}</p>
@@ -55,12 +56,14 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import EditText from '@/components/site/EditText.vue';
+import SectionNotice from '@/components/setting/SectionNotice.vue';
 import { siteOperator } from '@/operators';
 
 export default defineComponent({
   name: 'DistributionSetting',
   components: {
-    EditText
+    EditText,
+    SectionNotice
   },
   computed: {
     site() {

--- a/src/components/setting/Function.vue
+++ b/src/components/setting/Function.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="settings-list">
+    <section-notice tone="admin" :text="$t('common.settings.adminOnlyHint')" />
     <section v-for="feature in featureKeys" :key="feature" class="settings-item">
       <div class="settings-label">
         <p class="settings-title">{{ featureLabel(feature) }}</p>
@@ -85,6 +86,7 @@ import { defineComponent } from 'vue';
 import { ElImage, ElSwitch } from 'element-plus';
 import EditText from '@/components/site/EditText.vue';
 import EditImage from '@/components/site/EditImage.vue';
+import SectionNotice from '@/components/setting/SectionNotice.vue';
 import { siteOperator } from '@/operators';
 
 const FEATURE_KEYS = [
@@ -122,7 +124,8 @@ export default defineComponent({
     EditText,
     EditImage,
     ElImage,
-    ElSwitch
+    ElSwitch,
+    SectionNotice
   },
   computed: {
     site() {

--- a/src/components/setting/SectionNotice.vue
+++ b/src/components/setting/SectionNotice.vue
@@ -1,0 +1,92 @@
+<template>
+  <div :class="['setting-notice', tone]">
+    <font-awesome-icon :icon="resolvedIcon" class="icon" />
+    <span class="text">
+      <slot>{{ text }}</slot>
+    </span>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, type PropType } from 'vue';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { faCircleInfo, faShieldHalved, faGlobe } from '@fortawesome/free-solid-svg-icons';
+import type { IconDefinition } from '@fortawesome/fontawesome-svg-core';
+
+type Tone = 'info' | 'admin' | 'official';
+
+const TONE_ICON: Record<Tone, IconDefinition> = {
+  info: faCircleInfo,
+  admin: faShieldHalved,
+  official: faGlobe
+};
+
+export default defineComponent({
+  name: 'SettingSectionNotice',
+  components: { FontAwesomeIcon },
+  props: {
+    text: {
+      type: String,
+      default: ''
+    },
+    tone: {
+      type: String as PropType<Tone>,
+      default: 'info',
+      validator: (value: string) => ['info', 'admin', 'official'].includes(value)
+    },
+    icon: {
+      type: Object as PropType<IconDefinition | null>,
+      default: null
+    }
+  },
+  computed: {
+    resolvedIcon(): IconDefinition {
+      return this.icon || TONE_ICON[this.tone as Tone] || faCircleInfo;
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.setting-notice {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  font-size: 12px;
+  line-height: 1.5;
+  border-radius: 8px;
+  background: var(--el-color-info-light-9);
+  border: 1px solid var(--el-color-info-light-7);
+  color: var(--el-text-color-regular);
+
+  .icon {
+    flex-shrink: 0;
+    font-size: 13px;
+    color: var(--el-color-info);
+  }
+
+  .text {
+    flex: 1;
+    word-break: break-word;
+  }
+
+  &.admin {
+    background: var(--el-color-primary-light-9);
+    border-color: var(--el-color-primary-light-7);
+
+    .icon {
+      color: var(--el-color-primary);
+    }
+  }
+
+  &.official {
+    background: var(--el-color-success-light-9);
+    border-color: var(--el-color-success-light-7);
+
+    .icon {
+      color: var(--el-color-success);
+    }
+  }
+}
+</style>

--- a/src/components/setting/Seo.vue
+++ b/src/components/setting/Seo.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="settings-list">
+    <section-notice tone="admin" :text="$t('common.settings.adminOnlyHint')" />
     <section class="settings-item">
       <div class="settings-label">
         <p class="settings-title">{{ $t('site.field.description') }}</p>
@@ -43,13 +44,15 @@
 import { defineComponent } from 'vue';
 import EditText from '@/components/site/EditText.vue';
 import EditArray from '@/components/site/EditArray.vue';
+import SectionNotice from '@/components/setting/SectionNotice.vue';
 import { siteOperator } from '@/operators';
 
 export default defineComponent({
   name: 'SettingSeo',
   components: {
     EditText,
-    EditArray
+    EditArray,
+    SectionNotice
   },
   computed: {
     site() {

--- a/src/components/setting/Site.vue
+++ b/src/components/setting/Site.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="settings-list">
+    <section-notice tone="admin" :text="$t('common.settings.adminOnlyHint')" />
     <section class="settings-item">
       <div class="settings-label">
         <p class="settings-title">{{ $t('site.field.origin') }}</p>
@@ -99,6 +100,7 @@ import { ElImage } from 'element-plus';
 import EditText from '@/components/site/EditText.vue';
 import EditImage from '@/components/site/EditImage.vue';
 import EditArray from '@/components/site/EditArray.vue';
+import SectionNotice from '@/components/setting/SectionNotice.vue';
 import { siteOperator } from '@/operators';
 
 export default defineComponent({
@@ -107,7 +109,8 @@ export default defineComponent({
     EditText,
     EditImage,
     EditArray,
-    ElImage
+    ElImage,
+    SectionNotice
   },
   computed: {
     site() {

--- a/src/components/setting/Subsite.vue
+++ b/src/components/setting/Subsite.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="subsite-settings">
+    <section-notice tone="official" :text="$t('common.settings.officialOnlyHint')" />
     <div class="header">
       <div>
         <p class="settings-title">{{ $t('subsite.title.index') }}</p>
@@ -95,6 +96,7 @@ import {
 } from 'element-plus';
 import { Plus } from '@element-plus/icons-vue';
 import { siteOperator } from '@/operators';
+import SectionNotice from '@/components/setting/SectionNotice.vue';
 import type { ISite } from '@/models';
 
 const SLUG_RE = /^(?!.*--)[a-z0-9][a-z0-9-]{1,30}[a-z0-9]$/;
@@ -120,7 +122,8 @@ export default defineComponent({
     ElDialog,
     ElForm,
     ElFormItem,
-    ElInput
+    ElInput,
+    SectionNotice
   },
   directives: {
     loading: vLoading

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -819,6 +819,14 @@
     "message": "My Subsites",
     "description": "Title for the subsites management tab in the settings popup. Visible only on the official main site; subsites are not displayed."
   },
+  "settings.adminOnlyHint": {
+    "message": "Only site administrators can see this section. Regular users do not have access.",
+    "description": "Hint shown at the top of admin-only settings tabs (Site / SEO / Distribution / Function)."
+  },
+  "settings.officialOnlyHint": {
+    "message": "Only the official main site can see this section. Subsites do not show this entry.",
+    "description": "Hint shown at the top of the My Subsites tab, explaining the entry only appears on the official main site."
+  },
   "settings.customDomain": {
     "message": "Custom Domain",
     "description": "Title for the custom-domain management tab in the settings popup. Visible only on subsites (non-main-official hosts) for site admins."

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -819,6 +819,14 @@
     "message": "我的分站",
     "description": "设置弹窗中分站管理 tab 的标题。仅在 official 主站可见，分站不显示。"
   },
+  "settings.adminOnlyHint": {
+    "message": "此栏目仅站点管理员可见，普通用户无法访问。",
+    "description": "在站点设置 / SEO 设置 / 分发设置 / 功能设置 等仅管理员可见的设置 tab 顶部展示的提示语。"
+  },
+  "settings.officialOnlyHint": {
+    "message": "此栏目仅主站可见，分站不会显示。",
+    "description": "在『我的分站』tab 顶部展示的提示语，说明该入口只在 official 主站出现。"
+  },
   "settings.customDomain": {
     "message": "自定义域名",
     "description": "Title for the custom-domain management tab in the settings popup. Visible only on subsites (non-main-official hosts) for site admins."


### PR DESCRIPTION
## What

Tiny visual polish for the user-settings dialog. Adds a small inline notice (icon + light-tinted pill) at the very top of every settings tab that's already gated by access rules, stating up front who the tab is for.

| Tab | Gating (already enforced in `Setting.vue`) | New tip |
|---|---|---|
| 站点设置 / Site | `isSiteAdmin` | "此栏目仅站点管理员可见，普通用户无法访问。" |
| SEO 设置 / SEO | `isSiteAdmin` | same |
| 分发设置 / Distribution | `isSiteAdmin` | same |
| 功能设置 / Function | `isSiteAdmin` | same |
| 自定义域名 / Custom Domain | `isSiteAdmin && !isMainOfficialHost` | same |
| 我的分站 / My Subsites | `isMainOfficialHost` | "此栏目仅主站可见，分站不会显示。" |

The user [@CongqiUyas](https://github.com/CongqiUyas) opened the settings dialog on a sub-account session, saw "SEO 设置" in the sidebar, and wanted a quick visual cue about why this is even visible to them — instead of digging into the menu logic. This adds exactly that hint.

## How

New reusable component `src/components/setting/SectionNotice.vue` — a small flexbox pill (`8px 12px` padding, `8px` radius) with three tones:

- `tone="info"` (default) — neutral grey
- `tone="admin"` — primary tint + shield icon → used for admin-only tabs
- `tone="official"` — success tint + globe icon → used for the My Subsites tab

Each gated tab imports the component and renders it as the first child of the existing flex column container. The parent `gap` already handles vertical spacing, so the notice has no margin of its own.

## Tasks

- [x] New `src/components/setting/SectionNotice.vue`
- [x] Wire into `Site.vue` / `Seo.vue` / `Distribution.vue` / `Function.vue` / `CustomDomain.vue` (admin tone)
- [x] Wire into `Subsite.vue` (official tone)
- [x] New i18n keys `common.settings.adminOnlyHint` + `common.settings.officialOnlyHint` in `zh-CN` and `en` (per repo convention — other locales auto-translate via the platform CronJob)

## Verification

- `npx eslint <7 touched files>` — clean.
- `npx vue-tsc --noEmit` — clean.
- JSON lint of both `common.json` files — passes.
- No behaviour change: gating itself is untouched; the tabs are still hidden for non-admins / non-official sites. This is purely a UX hint for the people who *can* see them.

## Risk

Trivial. Pure additive UI. Falls back to the parent's flex layout if styles don't apply for any reason. The admin tone uses Element Plus' primary palette via `--el-color-primary-light-*` so it adapts to whatever brand color a white-label tenant has configured.
