### PR TITLE
feat(site): show user chips next to inviter/admin IDs and add lookup-by-contact picker

### DIFF
--- a/src/components/setting/Distribution.vue
+++ b/src/components/setting/Distribution.vue
@@ -13,7 +13,6 @@
         <edit-user
           :model-value="site.distribution?.default_inviter_id || ''"
           :title="$t('site.title.editDistributionDefaultInviterId')"
-          :placeholder="$t('site.placeholder.editDistributionDefaultInviterId')"
           @confirm="
             onSave({
               distribution: {
@@ -38,7 +37,6 @@
         <edit-user
           :model-value="site.distribution?.force_inviter_id || ''"
           :title="$t('site.title.editDistributionForceInviterId')"
-          :placeholder="$t('site.placeholder.editDistributionForceInviterId')"
           @confirm="
             onSave({
               distribution: {

--- a/src/components/setting/Distribution.vue
+++ b/src/components/setting/Distribution.vue
@@ -9,9 +9,9 @@
         </p>
       </div>
       <div class="settings-content">
-        <span class="settings-value">{{ site.distribution?.default_inviter_id }}</span>
-        <edit-text
-          :model-value="site.distribution?.default_inviter_id"
+        <user-chip :user-id="site.distribution?.default_inviter_id" />
+        <edit-user
+          :model-value="site.distribution?.default_inviter_id || ''"
           :title="$t('site.title.editDistributionDefaultInviterId')"
           :placeholder="$t('site.placeholder.editDistributionDefaultInviterId')"
           @confirm="
@@ -34,9 +34,9 @@
         </p>
       </div>
       <div class="settings-content">
-        <span class="settings-value">{{ site.distribution?.force_inviter_id }}</span>
-        <edit-text
-          :model-value="site.distribution?.force_inviter_id"
+        <user-chip :user-id="site.distribution?.force_inviter_id" />
+        <edit-user
+          :model-value="site.distribution?.force_inviter_id || ''"
           :title="$t('site.title.editDistributionForceInviterId')"
           :placeholder="$t('site.placeholder.editDistributionForceInviterId')"
           @confirm="
@@ -55,14 +55,16 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import EditText from '@/components/site/EditText.vue';
+import EditUser from '@/components/site/EditUser.vue';
+import UserChip from '@/components/site/UserChip.vue';
 import SectionNotice from '@/components/setting/SectionNotice.vue';
 import { siteOperator } from '@/operators';
 
 export default defineComponent({
   name: 'DistributionSetting',
   components: {
-    EditText,
+    EditUser,
+    UserChip,
     SectionNotice
   },
   computed: {

--- a/src/components/setting/Site.vue
+++ b/src/components/setting/Site.vue
@@ -79,8 +79,10 @@
         </p>
       </div>
       <div class="settings-content">
-        <span class="settings-value">{{ site.admins?.join(', ') }}</span>
-        <edit-array
+        <div class="admins-list">
+          <user-chip v-for="adminId in site.admins || []" :key="adminId" :user-id="adminId" class="admins-chip" />
+        </div>
+        <edit-users
           :model-value="site?.admins || []"
           :title="$t('site.title.editAdmins')"
           :placeholder="$t('site.placeholder.admins')"
@@ -99,7 +101,8 @@ import { defineComponent } from 'vue';
 import { ElImage } from 'element-plus';
 import EditText from '@/components/site/EditText.vue';
 import EditImage from '@/components/site/EditImage.vue';
-import EditArray from '@/components/site/EditArray.vue';
+import EditUsers from '@/components/site/EditUsers.vue';
+import UserChip from '@/components/site/UserChip.vue';
 import SectionNotice from '@/components/setting/SectionNotice.vue';
 import { siteOperator } from '@/operators';
 
@@ -108,7 +111,8 @@ export default defineComponent({
   components: {
     EditText,
     EditImage,
-    EditArray,
+    EditUsers,
+    UserChip,
     ElImage,
     SectionNotice
   },
@@ -141,5 +145,23 @@ export default defineComponent({
 
 .favicon {
   max-width: 64px;
+}
+
+.admins-list {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+  max-width: 100%;
+}
+
+.admins-chip {
+  max-width: 100%;
+}
+
+@media (max-width: 640px) {
+  .admins-list {
+    align-items: flex-start;
+  }
 }
 </style>

--- a/src/components/setting/Site.vue
+++ b/src/components/setting/Site.vue
@@ -85,8 +85,6 @@
         <edit-users
           :model-value="site?.admins || []"
           :title="$t('site.title.editAdmins')"
-          :placeholder="$t('site.placeholder.admins')"
-          :tip="$t('site.message.adminsTip2')"
           :min="1"
           :min-error-message="$t('site.message.atLeastOneAdmin')"
           @confirm="onSave({ admins: $event })"

--- a/src/components/site/EditUser.vue
+++ b/src/components/site/EditUser.vue
@@ -1,33 +1,19 @@
 <template>
-  <el-dialog v-model="editing" :title="title" width="440px" class="edit-dialog">
+  <el-dialog v-model="editing" :title="title" width="480px" class="edit-dialog">
     <div class="edit-body">
-      <el-input
-        ref="input"
-        v-model="query"
-        :placeholder="placeholder"
-        clearable
-        @input="onQueryChange"
-        @clear="onClear"
-      />
-      <p v-if="tip" class="tip">{{ tip }}</p>
-      <p v-else class="tip">{{ $t('site.message.editUserHint') }}</p>
-      <div v-if="query.trim()" class="preview">
-        <template v-if="state === 'loading'">
-          <span class="preview-empty">{{ $t('common.status.loading') }}</span>
-        </template>
-        <template v-else-if="state === 'missing'">
-          <el-icon class="preview-icon"><warning-filled /></el-icon>
-          <span class="preview-empty">{{ $t('site.message.userNotFound') }}</span>
-        </template>
-        <template v-else-if="resolved">
-          <user-chip :user-id="resolved.id" />
-        </template>
+      <user-picker @select="onSelect" />
+      <div v-if="resolved" class="preview">
+        <user-chip :user-id="resolved.id" />
       </div>
+      <p v-else class="tip">{{ $t('site.message.editUserHint') }}</p>
     </div>
     <template #footer>
       <span class="dialog-footer">
         <el-button round @click="onCancel">{{ $t('common.button.cancel') }}</el-button>
-        <el-button round type="primary" :disabled="!canConfirm" @click="onConfirm">
+        <el-button v-if="modelValue" round type="warning" @click="onClearValue">
+          {{ $t('common.button.delete') }}
+        </el-button>
+        <el-button round type="primary" :disabled="!resolved" @click="onConfirm">
           {{ $t('common.button.confirm') }}
         </el-button>
       </span>
@@ -42,34 +28,21 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElDialog, ElInput, ElButton, ElIcon } from 'element-plus';
-import { Edit, WarningFilled } from '@element-plus/icons-vue';
+import { ElDialog, ElButton, ElIcon } from 'element-plus';
+import { Edit } from '@element-plus/icons-vue';
 import UserChip from '@/components/site/UserChip.vue';
-import { userOperator } from '@/operators';
+import UserPicker from '@/components/site/UserPicker.vue';
 import type { IUserPublic } from '@/models';
-import type { IUserResolveQuery } from '@/operators/user';
-
-const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
-const PHONE_RE = /^\+?[\d\s\-()]{6,}$/;
-
-function classify(input: string): keyof IUserResolveQuery {
-  const value = input.trim();
-  if (UUID_RE.test(value)) return 'id';
-  if (value.includes('@')) return 'email';
-  if (PHONE_RE.test(value)) return 'phone';
-  return 'username';
-}
 
 export default defineComponent({
   name: 'EditUser',
   components: {
     ElDialog,
-    ElInput,
     ElButton,
     ElIcon,
     Edit,
-    WarningFilled,
-    UserChip
+    UserChip,
+    UserPicker
   },
   props: {
     modelValue: {
@@ -79,91 +52,33 @@ export default defineComponent({
     title: {
       type: String,
       required: true
-    },
-    placeholder: {
-      type: String,
-      default: ''
-    },
-    tip: {
-      type: String,
-      default: ''
     }
   },
   emits: ['confirm', 'cancel'],
   data() {
     return {
       editing: false,
-      query: this.modelValue || '',
-      resolved: null as IUserPublic | null,
-      state: 'idle' as 'idle' | 'loading' | 'ready' | 'missing',
-      debounceTimer: null as ReturnType<typeof setTimeout> | null,
-      requestSeq: 0
+      resolved: null as IUserPublic | null
     };
-  },
-  computed: {
-    canConfirm(): boolean {
-      const trimmed = this.query.trim();
-      if (!trimmed) return true; // allow clearing the field
-      return this.state === 'ready' && !!this.resolved?.id;
-    }
   },
   methods: {
     onOpen() {
       this.editing = true;
-      this.query = this.modelValue || '';
       this.resolved = null;
-      this.state = 'idle';
-      if (this.query.trim()) {
-        this.scheduleLookup(0);
-      }
     },
-    onClear() {
-      this.resolved = null;
-      this.state = 'idle';
-    },
-    onQueryChange() {
-      this.scheduleLookup(400);
-    },
-    scheduleLookup(delay: number) {
-      if (this.debounceTimer) {
-        clearTimeout(this.debounceTimer);
-        this.debounceTimer = null;
-      }
-      const trimmed = this.query.trim();
-      if (!trimmed) {
-        this.resolved = null;
-        this.state = 'idle';
-        return;
-      }
-      this.state = 'loading';
-      this.debounceTimer = setTimeout(() => this.runLookup(trimmed), delay);
-    },
-    async runLookup(value: string) {
-      const seq = ++this.requestSeq;
-      const key = classify(value);
-      try {
-        const res = await userOperator.resolve({ [key]: value } as IUserResolveQuery);
-        if (seq !== this.requestSeq) return;
-        this.resolved = res.data;
-        this.state = 'ready';
-      } catch {
-        if (seq !== this.requestSeq) return;
-        this.resolved = null;
-        this.state = 'missing';
-      }
+    onSelect(user: IUserPublic) {
+      this.resolved = user;
     },
     onCancel() {
       this.editing = false;
       this.$emit('cancel');
     },
+    onClearValue() {
+      this.$emit('confirm', '');
+      this.editing = false;
+    },
     onConfirm() {
-      const trimmed = this.query.trim();
-      if (!trimmed) {
-        this.$emit('confirm', '');
-        this.editing = false;
-        return;
-      }
-      if (this.state === 'ready' && this.resolved?.id) {
+      if (this.resolved?.id) {
         this.$emit('confirm', this.resolved.id);
         this.editing = false;
       }
@@ -178,44 +93,34 @@ export default defineComponent({
   margin-left: 5px;
   position: relative;
   top: 2px;
+
   .icon {
     font-size: 14px;
   }
 }
 
 .edit-body {
-  width: 100%;
   display: flex;
   flex-direction: column;
-  align-items: stretch;
   gap: 12px;
+  width: 100%;
+}
 
-  .tip {
-    color: var(--el-text-color-secondary);
-    font-size: 12px;
-    margin: 0;
-  }
+.tip {
+  margin: 0;
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+}
 
-  .preview {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    min-height: 28px;
-    padding: 6px 10px;
-    border: 1px dashed var(--el-border-color);
-    border-radius: 6px;
-    background: var(--el-fill-color-light);
-  }
-
-  .preview-empty {
-    color: var(--el-text-color-secondary);
-    font-size: 12px;
-  }
-
-  .preview-icon {
-    color: var(--el-color-warning);
-    font-size: 14px;
-  }
+.preview {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 32px;
+  padding: 8px 10px;
+  border: 1px dashed var(--el-border-color);
+  border-radius: 6px;
+  background: var(--el-fill-color-light);
 }
 
 .dialog-footer {

--- a/src/components/site/EditUser.vue
+++ b/src/components/site/EditUser.vue
@@ -46,7 +46,8 @@ import { ElDialog, ElInput, ElButton, ElIcon } from 'element-plus';
 import { Edit, WarningFilled } from '@element-plus/icons-vue';
 import UserChip from '@/components/site/UserChip.vue';
 import { userOperator } from '@/operators';
-import type { IUserPublic, IUserResolveQuery } from '@/operators/user';
+import type { IUserPublic } from '@/models';
+import type { IUserResolveQuery } from '@/operators/user';
 
 const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
 const PHONE_RE = /^\+?[\d\s\-()]{6,}$/;

--- a/src/components/site/EditUser.vue
+++ b/src/components/site/EditUser.vue
@@ -10,7 +10,7 @@
     <template #footer>
       <span class="dialog-footer">
         <el-button round @click="onCancel">{{ $t('common.button.cancel') }}</el-button>
-        <el-button v-if="modelValue" round type="warning" @click="onClearValue">
+        <el-button v-if="modelValue" round type="danger" @click="onClearValue">
           {{ $t('common.button.delete') }}
         </el-button>
         <el-button round type="primary" :disabled="!resolved" @click="onConfirm">

--- a/src/components/site/EditUser.vue
+++ b/src/components/site/EditUser.vue
@@ -1,0 +1,226 @@
+<template>
+  <el-dialog v-model="editing" :title="title" width="440px" class="edit-dialog">
+    <div class="edit-body">
+      <el-input
+        ref="input"
+        v-model="query"
+        :placeholder="placeholder"
+        clearable
+        @input="onQueryChange"
+        @clear="onClear"
+      />
+      <p v-if="tip" class="tip">{{ tip }}</p>
+      <p v-else class="tip">{{ $t('site.message.editUserHint') }}</p>
+      <div v-if="query.trim()" class="preview">
+        <template v-if="state === 'loading'">
+          <span class="preview-empty">{{ $t('common.status.loading') }}</span>
+        </template>
+        <template v-else-if="state === 'missing'">
+          <el-icon class="preview-icon"><warning-filled /></el-icon>
+          <span class="preview-empty">{{ $t('site.message.userNotFound') }}</span>
+        </template>
+        <template v-else-if="resolved">
+          <user-chip :user-id="resolved.id" />
+        </template>
+      </div>
+    </div>
+    <template #footer>
+      <span class="dialog-footer">
+        <el-button round @click="onCancel">{{ $t('common.button.cancel') }}</el-button>
+        <el-button round type="primary" :disabled="!canConfirm" @click="onConfirm">
+          {{ $t('common.button.confirm') }}
+        </el-button>
+      </span>
+    </template>
+  </el-dialog>
+  <span class="edit" @click="onOpen">
+    <el-icon class="icon">
+      <edit />
+    </el-icon>
+  </span>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElDialog, ElInput, ElButton, ElIcon } from 'element-plus';
+import { Edit, WarningFilled } from '@element-plus/icons-vue';
+import UserChip from '@/components/site/UserChip.vue';
+import { userOperator } from '@/operators';
+import type { IUserPublic, IUserResolveQuery } from '@/operators/user';
+
+const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+const PHONE_RE = /^\+?[\d\s\-()]{6,}$/;
+
+function classify(input: string): keyof IUserResolveQuery {
+  const value = input.trim();
+  if (UUID_RE.test(value)) return 'id';
+  if (value.includes('@')) return 'email';
+  if (PHONE_RE.test(value)) return 'phone';
+  return 'username';
+}
+
+export default defineComponent({
+  name: 'EditUser',
+  components: {
+    ElDialog,
+    ElInput,
+    ElButton,
+    ElIcon,
+    Edit,
+    WarningFilled,
+    UserChip
+  },
+  props: {
+    modelValue: {
+      type: String,
+      default: ''
+    },
+    title: {
+      type: String,
+      required: true
+    },
+    placeholder: {
+      type: String,
+      default: ''
+    },
+    tip: {
+      type: String,
+      default: ''
+    }
+  },
+  emits: ['confirm', 'cancel'],
+  data() {
+    return {
+      editing: false,
+      query: this.modelValue || '',
+      resolved: null as IUserPublic | null,
+      state: 'idle' as 'idle' | 'loading' | 'ready' | 'missing',
+      debounceTimer: null as ReturnType<typeof setTimeout> | null,
+      requestSeq: 0
+    };
+  },
+  computed: {
+    canConfirm(): boolean {
+      const trimmed = this.query.trim();
+      if (!trimmed) return true; // allow clearing the field
+      return this.state === 'ready' && !!this.resolved?.id;
+    }
+  },
+  methods: {
+    onOpen() {
+      this.editing = true;
+      this.query = this.modelValue || '';
+      this.resolved = null;
+      this.state = 'idle';
+      if (this.query.trim()) {
+        this.scheduleLookup(0);
+      }
+    },
+    onClear() {
+      this.resolved = null;
+      this.state = 'idle';
+    },
+    onQueryChange() {
+      this.scheduleLookup(400);
+    },
+    scheduleLookup(delay: number) {
+      if (this.debounceTimer) {
+        clearTimeout(this.debounceTimer);
+        this.debounceTimer = null;
+      }
+      const trimmed = this.query.trim();
+      if (!trimmed) {
+        this.resolved = null;
+        this.state = 'idle';
+        return;
+      }
+      this.state = 'loading';
+      this.debounceTimer = setTimeout(() => this.runLookup(trimmed), delay);
+    },
+    async runLookup(value: string) {
+      const seq = ++this.requestSeq;
+      const key = classify(value);
+      try {
+        const res = await userOperator.resolve({ [key]: value } as IUserResolveQuery);
+        if (seq !== this.requestSeq) return;
+        this.resolved = res.data;
+        this.state = 'ready';
+      } catch {
+        if (seq !== this.requestSeq) return;
+        this.resolved = null;
+        this.state = 'missing';
+      }
+    },
+    onCancel() {
+      this.editing = false;
+      this.$emit('cancel');
+    },
+    onConfirm() {
+      const trimmed = this.query.trim();
+      if (!trimmed) {
+        this.$emit('confirm', '');
+        this.editing = false;
+        return;
+      }
+      if (this.state === 'ready' && this.resolved?.id) {
+        this.$emit('confirm', this.resolved.id);
+        this.editing = false;
+      }
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.edit {
+  cursor: pointer;
+  margin-left: 5px;
+  position: relative;
+  top: 2px;
+  .icon {
+    font-size: 14px;
+  }
+}
+
+.edit-body {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 12px;
+
+  .tip {
+    color: var(--el-text-color-secondary);
+    font-size: 12px;
+    margin: 0;
+  }
+
+  .preview {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 28px;
+    padding: 6px 10px;
+    border: 1px dashed var(--el-border-color);
+    border-radius: 6px;
+    background: var(--el-fill-color-light);
+  }
+
+  .preview-empty {
+    color: var(--el-text-color-secondary);
+    font-size: 12px;
+  }
+
+  .preview-icon {
+    color: var(--el-color-warning);
+    font-size: 14px;
+  }
+}
+
+.dialog-footer {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  width: 100%;
+}
+</style>

--- a/src/components/site/EditUser.vue
+++ b/src/components/site/EditUser.vue
@@ -30,7 +30,7 @@
 import { defineComponent } from 'vue';
 import { ElDialog, ElButton, ElIcon } from 'element-plus';
 import { Edit } from '@element-plus/icons-vue';
-import UserChip from '@/components/site/UserChip.vue';
+import UserChip, { prefetchUserChip } from '@/components/site/UserChip.vue';
 import UserPicker from '@/components/site/UserPicker.vue';
 import type { IUserPublic } from '@/models';
 
@@ -62,9 +62,22 @@ export default defineComponent({
     };
   },
   methods: {
-    onOpen() {
+    async onOpen() {
       this.editing = true;
+      // Pre-fill the preview from the existing inviter UUID so opening Edit
+      // on an already-set value doesn't look empty. The chip rendered next
+      // to the Edit button has almost certainly populated the cache already,
+      // so this is a synchronous cache hit in the common case.
       this.resolved = null;
+      const currentId = this.modelValue;
+      if (currentId) {
+        const user = await prefetchUserChip(currentId);
+        // Guard: user may have cancelled and reopened with a different id by
+        // the time the network call returns.
+        if (this.editing && this.modelValue === currentId) {
+          this.resolved = user;
+        }
+      }
     },
     onSelect(user: IUserPublic) {
       this.resolved = user;

--- a/src/components/site/EditUsers.vue
+++ b/src/components/site/EditUsers.vue
@@ -1,0 +1,307 @@
+<template>
+  <el-dialog v-model="editing" :title="title" width="480px" class="edit-dialog">
+    <div class="edit-body">
+      <p v-if="tip" class="tip">{{ tip }}</p>
+      <div v-if="value.length === 0" class="empty">
+        <span class="empty-text">{{ $t('site.message.editUsersEmpty') }}</span>
+      </div>
+      <ul v-else class="user-list">
+        <li v-for="(item, idx) in value" :key="`${item}-${idx}`" class="user-list__item">
+          <user-chip :user-id="item" />
+          <el-icon class="user-list__remove" @click="onRemove(idx)">
+            <close />
+          </el-icon>
+        </li>
+      </ul>
+
+      <el-divider class="user-divider">{{ $t('site.title.addUser') }}</el-divider>
+
+      <el-input
+        ref="input"
+        v-model="query"
+        :placeholder="placeholder"
+        clearable
+        @input="onQueryChange"
+        @clear="onClear"
+      />
+      <div v-if="query.trim()" class="preview">
+        <template v-if="state === 'loading'">
+          <span class="preview-empty">{{ $t('common.status.loading') }}</span>
+        </template>
+        <template v-else-if="state === 'missing'">
+          <el-icon class="preview-icon"><warning-filled /></el-icon>
+          <span class="preview-empty">{{ $t('site.message.userNotFound') }}</span>
+        </template>
+        <template v-else-if="resolved">
+          <user-chip :user-id="resolved.id" />
+          <el-button size="small" round type="primary" :disabled="alreadyAdded" class="preview-add" @click="onAdd">
+            {{ alreadyAdded ? $t('site.message.userAlreadyAdded') : $t('site.button.addUser') }}
+          </el-button>
+        </template>
+      </div>
+    </div>
+    <template #footer>
+      <span class="dialog-footer">
+        <el-button round @click="onCancel">{{ $t('common.button.cancel') }}</el-button>
+        <el-button round type="primary" @click="onConfirm">{{ $t('common.button.confirm') }}</el-button>
+      </span>
+    </template>
+  </el-dialog>
+  <span class="edit" @click="onOpen">
+    <el-icon class="icon">
+      <edit />
+    </el-icon>
+  </span>
+</template>
+
+<script lang="ts">
+import { defineComponent, type PropType } from 'vue';
+import { ElDialog, ElInput, ElButton, ElIcon, ElDivider, ElMessage } from 'element-plus';
+import { Edit, Close, WarningFilled } from '@element-plus/icons-vue';
+import UserChip from '@/components/site/UserChip.vue';
+import { userOperator } from '@/operators';
+import type { IUserPublic, IUserResolveQuery } from '@/operators/user';
+
+const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+const PHONE_RE = /^\+?[\d\s\-()]{6,}$/;
+
+function classify(input: string): keyof IUserResolveQuery {
+  const value = input.trim();
+  if (UUID_RE.test(value)) return 'id';
+  if (value.includes('@')) return 'email';
+  if (PHONE_RE.test(value)) return 'phone';
+  return 'username';
+}
+
+export default defineComponent({
+  name: 'EditUsers',
+  components: {
+    ElDialog,
+    ElInput,
+    ElButton,
+    ElIcon,
+    ElDivider,
+    Edit,
+    Close,
+    WarningFilled,
+    UserChip
+  },
+  props: {
+    modelValue: {
+      type: Array as PropType<string[]>,
+      required: true
+    },
+    title: {
+      type: String,
+      required: true
+    },
+    placeholder: {
+      type: String,
+      default: ''
+    },
+    tip: {
+      type: String,
+      default: ''
+    },
+    min: {
+      type: Number,
+      default: undefined
+    },
+    minErrorMessage: {
+      type: String,
+      default: ''
+    }
+  },
+  emits: ['confirm', 'cancel'],
+  data() {
+    return {
+      editing: false,
+      value: [...(this.modelValue || [])] as string[],
+      query: '',
+      resolved: null as IUserPublic | null,
+      state: 'idle' as 'idle' | 'loading' | 'ready' | 'missing',
+      debounceTimer: null as ReturnType<typeof setTimeout> | null,
+      requestSeq: 0
+    };
+  },
+  computed: {
+    alreadyAdded(): boolean {
+      return !!this.resolved?.id && this.value.includes(this.resolved.id);
+    }
+  },
+  methods: {
+    onOpen() {
+      this.editing = true;
+      this.value = [...(this.modelValue || [])];
+      this.query = '';
+      this.resolved = null;
+      this.state = 'idle';
+    },
+    onRemove(idx: number) {
+      this.value.splice(idx, 1);
+    },
+    onClear() {
+      this.resolved = null;
+      this.state = 'idle';
+    },
+    onQueryChange() {
+      this.scheduleLookup(400);
+    },
+    scheduleLookup(delay: number) {
+      if (this.debounceTimer) {
+        clearTimeout(this.debounceTimer);
+        this.debounceTimer = null;
+      }
+      const trimmed = this.query.trim();
+      if (!trimmed) {
+        this.resolved = null;
+        this.state = 'idle';
+        return;
+      }
+      this.state = 'loading';
+      this.debounceTimer = setTimeout(() => this.runLookup(trimmed), delay);
+    },
+    async runLookup(value: string) {
+      const seq = ++this.requestSeq;
+      const key = classify(value);
+      try {
+        const res = await userOperator.resolve({ [key]: value } as IUserResolveQuery);
+        if (seq !== this.requestSeq) return;
+        this.resolved = res.data;
+        this.state = 'ready';
+      } catch {
+        if (seq !== this.requestSeq) return;
+        this.resolved = null;
+        this.state = 'missing';
+      }
+    },
+    onAdd() {
+      if (this.state !== 'ready' || !this.resolved?.id) return;
+      if (this.value.includes(this.resolved.id)) return;
+      this.value.push(this.resolved.id);
+      this.query = '';
+      this.resolved = null;
+      this.state = 'idle';
+    },
+    onCancel() {
+      this.editing = false;
+      this.$emit('cancel');
+    },
+    onConfirm() {
+      if (this.min !== undefined && this.value.length < this.min) {
+        if (this.minErrorMessage) ElMessage.error(this.minErrorMessage);
+        return;
+      }
+      this.$emit('confirm', [...this.value]);
+      this.editing = false;
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.edit {
+  cursor: pointer;
+  margin-left: 5px;
+  position: relative;
+  top: 2px;
+  .icon {
+    font-size: 14px;
+  }
+}
+
+.edit-body {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+
+  .tip {
+    color: var(--el-text-color-secondary);
+    font-size: 12px;
+    margin: 0;
+  }
+
+  .empty {
+    padding: 12px;
+    text-align: center;
+    color: var(--el-text-color-secondary);
+    border: 1px dashed var(--el-border-color);
+    border-radius: 6px;
+    background: var(--el-fill-color-light);
+  }
+
+  .empty-text {
+    font-size: 12px;
+  }
+
+  .user-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .user-list__item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 6px 10px;
+    border: 1px solid var(--el-border-color-lighter);
+    border-radius: 6px;
+    background: var(--el-fill-color-blank);
+  }
+
+  .user-list__remove {
+    cursor: pointer;
+    color: var(--el-text-color-secondary);
+    font-size: 14px;
+    margin-left: 8px;
+    flex-shrink: 0;
+
+    &:hover {
+      color: var(--el-color-danger);
+    }
+  }
+
+  .user-divider {
+    margin: 4px 0;
+    font-size: 12px;
+    color: var(--el-text-color-secondary);
+  }
+
+  .preview {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 28px;
+    padding: 6px 10px;
+    border: 1px dashed var(--el-border-color);
+    border-radius: 6px;
+    background: var(--el-fill-color-light);
+  }
+
+  .preview-empty {
+    color: var(--el-text-color-secondary);
+    font-size: 12px;
+  }
+
+  .preview-icon {
+    color: var(--el-color-warning);
+    font-size: 14px;
+  }
+
+  .preview-add {
+    margin-left: auto;
+  }
+}
+
+.dialog-footer {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  width: 100%;
+}
+</style>

--- a/src/components/site/EditUsers.vue
+++ b/src/components/site/EditUsers.vue
@@ -60,7 +60,8 @@ import { ElDialog, ElInput, ElButton, ElIcon, ElDivider, ElMessage } from 'eleme
 import { Edit, Close, WarningFilled } from '@element-plus/icons-vue';
 import UserChip from '@/components/site/UserChip.vue';
 import { userOperator } from '@/operators';
-import type { IUserPublic, IUserResolveQuery } from '@/operators/user';
+import type { IUserPublic } from '@/models';
+import type { IUserResolveQuery } from '@/operators/user';
 
 const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
 const PHONE_RE = /^\+?[\d\s\-()]{6,}$/;

--- a/src/components/site/EditUsers.vue
+++ b/src/components/site/EditUsers.vue
@@ -1,49 +1,31 @@
 <template>
-  <el-dialog v-model="editing" :title="title" width="480px" class="edit-dialog">
+  <el-dialog v-model="editing" :title="title" width="520px" class="edit-dialog">
     <div class="edit-body">
-      <p v-if="tip" class="tip">{{ tip }}</p>
-      <div v-if="value.length === 0" class="empty">
+      <div v-if="working.length === 0" class="empty">
         <span class="empty-text">{{ $t('site.message.editUsersEmpty') }}</span>
       </div>
-      <ul v-else class="user-list">
-        <li v-for="(item, idx) in value" :key="`${item}-${idx}`" class="user-list__item">
-          <user-chip :user-id="item" />
-          <el-icon class="user-list__remove" @click="onRemove(idx)">
+      <ul v-else class="chip-list">
+        <li v-for="id in working" :key="id" class="chip-item">
+          <user-chip :user-id="id" />
+          <el-icon class="chip-remove" :title="removeLabel" @click="onRemove(id)">
             <close />
           </el-icon>
         </li>
       </ul>
-
-      <el-divider class="user-divider">{{ $t('site.title.addUser') }}</el-divider>
-
-      <el-input
-        ref="input"
-        v-model="query"
-        :placeholder="placeholder"
-        clearable
-        @input="onQueryChange"
-        @clear="onClear"
-      />
-      <div v-if="query.trim()" class="preview">
-        <template v-if="state === 'loading'">
-          <span class="preview-empty">{{ $t('common.status.loading') }}</span>
-        </template>
-        <template v-else-if="state === 'missing'">
-          <el-icon class="preview-icon"><warning-filled /></el-icon>
-          <span class="preview-empty">{{ $t('site.message.userNotFound') }}</span>
-        </template>
-        <template v-else-if="resolved">
-          <user-chip :user-id="resolved.id" />
-          <el-button size="small" round type="primary" :disabled="alreadyAdded" class="preview-add" @click="onAdd">
-            {{ alreadyAdded ? $t('site.message.userAlreadyAdded') : $t('site.button.addUser') }}
-          </el-button>
-        </template>
-      </div>
+      <el-divider class="divider">{{ $t('site.title.addUser') }}</el-divider>
+      <user-picker :exclude-ids="working" @select="onAdd" />
+      <p class="tip">{{ $t('site.message.editUserHint') }}</p>
+      <p v-if="errorMessage" class="error">
+        <el-icon class="error-icon"><warning-filled /></el-icon>
+        {{ errorMessage }}
+      </p>
     </div>
     <template #footer>
       <span class="dialog-footer">
         <el-button round @click="onCancel">{{ $t('common.button.cancel') }}</el-button>
-        <el-button round type="primary" @click="onConfirm">{{ $t('common.button.confirm') }}</el-button>
+        <el-button round type="primary" :disabled="!canConfirm" @click="onConfirm">
+          {{ $t('common.button.confirm') }}
+        </el-button>
       </span>
     </template>
   </el-dialog>
@@ -56,59 +38,43 @@
 
 <script lang="ts">
 import { defineComponent, type PropType } from 'vue';
-import { ElDialog, ElInput, ElButton, ElIcon, ElDivider, ElMessage } from 'element-plus';
+import { ElDialog, ElButton, ElIcon, ElDivider } from 'element-plus';
 import { Edit, Close, WarningFilled } from '@element-plus/icons-vue';
 import UserChip from '@/components/site/UserChip.vue';
-import { userOperator } from '@/operators';
+import UserPicker from '@/components/site/UserPicker.vue';
 import type { IUserPublic } from '@/models';
-import type { IUserResolveQuery } from '@/operators/user';
-
-const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
-const PHONE_RE = /^\+?[\d\s\-()]{6,}$/;
-
-function classify(input: string): keyof IUserResolveQuery {
-  const value = input.trim();
-  if (UUID_RE.test(value)) return 'id';
-  if (value.includes('@')) return 'email';
-  if (PHONE_RE.test(value)) return 'phone';
-  return 'username';
-}
 
 export default defineComponent({
   name: 'EditUsers',
   components: {
     ElDialog,
-    ElInput,
     ElButton,
     ElIcon,
     ElDivider,
     Edit,
     Close,
     WarningFilled,
-    UserChip
+    UserChip,
+    UserPicker
   },
   props: {
     modelValue: {
       type: Array as PropType<string[]>,
-      required: true
+      default: () => []
     },
     title: {
       type: String,
       required: true
     },
-    placeholder: {
-      type: String,
-      default: ''
-    },
-    tip: {
-      type: String,
-      default: ''
-    },
     min: {
       type: Number,
-      default: undefined
+      default: 0
     },
     minErrorMessage: {
+      type: String,
+      default: ''
+    },
+    removeLabel: {
       type: String,
       default: ''
     }
@@ -117,83 +83,44 @@ export default defineComponent({
   data() {
     return {
       editing: false,
-      value: [...(this.modelValue || [])] as string[],
-      query: '',
-      resolved: null as IUserPublic | null,
-      state: 'idle' as 'idle' | 'loading' | 'ready' | 'missing',
-      debounceTimer: null as ReturnType<typeof setTimeout> | null,
-      requestSeq: 0
+      working: [] as string[],
+      errorMessage: ''
     };
   },
   computed: {
-    alreadyAdded(): boolean {
-      return !!this.resolved?.id && this.value.includes(this.resolved.id);
+    canConfirm(): boolean {
+      return this.working.length >= this.min;
     }
   },
   methods: {
     onOpen() {
       this.editing = true;
-      this.value = [...(this.modelValue || [])];
-      this.query = '';
-      this.resolved = null;
-      this.state = 'idle';
+      this.working = [...this.modelValue];
+      this.errorMessage = '';
     },
-    onRemove(idx: number) {
-      this.value.splice(idx, 1);
+    onAdd(user: IUserPublic) {
+      if (!user?.id) return;
+      if (this.working.includes(user.id)) return;
+      this.working = [...this.working, user.id];
+      this.errorMessage = '';
     },
-    onClear() {
-      this.resolved = null;
-      this.state = 'idle';
-    },
-    onQueryChange() {
-      this.scheduleLookup(400);
-    },
-    scheduleLookup(delay: number) {
-      if (this.debounceTimer) {
-        clearTimeout(this.debounceTimer);
-        this.debounceTimer = null;
-      }
-      const trimmed = this.query.trim();
-      if (!trimmed) {
-        this.resolved = null;
-        this.state = 'idle';
+    onRemove(id: string) {
+      if (this.working.length <= this.min) {
+        this.errorMessage = this.minErrorMessage;
         return;
       }
-      this.state = 'loading';
-      this.debounceTimer = setTimeout(() => this.runLookup(trimmed), delay);
-    },
-    async runLookup(value: string) {
-      const seq = ++this.requestSeq;
-      const key = classify(value);
-      try {
-        const res = await userOperator.resolve({ [key]: value } as IUserResolveQuery);
-        if (seq !== this.requestSeq) return;
-        this.resolved = res.data;
-        this.state = 'ready';
-      } catch {
-        if (seq !== this.requestSeq) return;
-        this.resolved = null;
-        this.state = 'missing';
-      }
-    },
-    onAdd() {
-      if (this.state !== 'ready' || !this.resolved?.id) return;
-      if (this.value.includes(this.resolved.id)) return;
-      this.value.push(this.resolved.id);
-      this.query = '';
-      this.resolved = null;
-      this.state = 'idle';
+      this.working = this.working.filter((x) => x !== id);
     },
     onCancel() {
       this.editing = false;
       this.$emit('cancel');
     },
     onConfirm() {
-      if (this.min !== undefined && this.value.length < this.min) {
-        if (this.minErrorMessage) ElMessage.error(this.minErrorMessage);
+      if (!this.canConfirm) {
+        this.errorMessage = this.minErrorMessage;
         return;
       }
-      this.$emit('confirm', [...this.value]);
+      this.$emit('confirm', this.working);
       this.editing = false;
     }
   }
@@ -206,96 +133,85 @@ export default defineComponent({
   margin-left: 5px;
   position: relative;
   top: 2px;
+
   .icon {
     font-size: 14px;
   }
 }
 
 .edit-body {
-  width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 8px;
+  width: 100%;
+}
 
-  .tip {
-    color: var(--el-text-color-secondary);
-    font-size: 12px;
-    margin: 0;
-  }
-
-  .empty {
-    padding: 12px;
-    text-align: center;
-    color: var(--el-text-color-secondary);
-    border: 1px dashed var(--el-border-color);
-    border-radius: 6px;
-    background: var(--el-fill-color-light);
-  }
+.empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 36px;
+  padding: 8px;
+  border: 1px dashed var(--el-border-color);
+  border-radius: 6px;
+  background: var(--el-fill-color-light);
 
   .empty-text {
-    font-size: 12px;
+    color: var(--el-text-color-secondary);
+    font-size: 13px;
   }
+}
 
-  .user-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-  }
+.chip-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
 
-  .user-list__item {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 6px 10px;
-    border: 1px solid var(--el-border-color-lighter);
-    border-radius: 6px;
-    background: var(--el-fill-color-blank);
-  }
+.chip-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 6px 10px;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 6px;
+  background: var(--el-fill-color-blank);
 
-  .user-list__remove {
+  .chip-remove {
     cursor: pointer;
     color: var(--el-text-color-secondary);
     font-size: 14px;
-    margin-left: 8px;
-    flex-shrink: 0;
 
     &:hover {
       color: var(--el-color-danger);
     }
   }
+}
 
-  .user-divider {
-    margin: 4px 0;
-    font-size: 12px;
-    color: var(--el-text-color-secondary);
-  }
+.divider {
+  margin: 4px 0;
+}
 
-  .preview {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    min-height: 28px;
-    padding: 6px 10px;
-    border: 1px dashed var(--el-border-color);
-    border-radius: 6px;
-    background: var(--el-fill-color-light);
-  }
+.tip {
+  margin: 0;
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+}
 
-  .preview-empty {
-    color: var(--el-text-color-secondary);
-    font-size: 12px;
-  }
+.error {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+  font-size: 12px;
+  color: var(--el-color-danger);
 
-  .preview-icon {
-    color: var(--el-color-warning);
+  .error-icon {
     font-size: 14px;
-  }
-
-  .preview-add {
-    margin-left: auto;
   }
 }
 

--- a/src/components/site/UserChip.vue
+++ b/src/components/site/UserChip.vue
@@ -1,0 +1,219 @@
+<template>
+  <span class="user-chip" :class="{ 'is-empty': !userId, 'is-missing': !!userId && state === 'missing' }">
+    <template v-if="!userId">
+      <span class="user-chip__placeholder">—</span>
+    </template>
+    <template v-else-if="state === 'loading'">
+      <span class="user-chip__id" :title="userId">{{ shortId }}</span>
+    </template>
+    <template v-else-if="state === 'missing'">
+      <el-icon class="user-chip__icon">
+        <warning-filled />
+      </el-icon>
+      <span class="user-chip__id" :title="userId">{{ shortId }}</span>
+    </template>
+    <template v-else>
+      <el-avatar v-if="user?.avatar" :src="user.avatar" :size="22" class="user-chip__avatar" />
+      <el-avatar v-else :size="22" class="user-chip__avatar">
+        <el-icon><user-icon /></el-icon>
+      </el-avatar>
+      <span class="user-chip__name" :title="userId">{{ user?.display_name || shortId }}</span>
+      <el-icon v-if="methodIcon" class="user-chip__icon" :title="methodLabel">
+        <component :is="methodIcon" />
+      </el-icon>
+      <span v-if="user?.contact" class="user-chip__contact">{{ user.contact }}</span>
+    </template>
+  </span>
+</template>
+
+<script lang="ts">
+import { defineComponent, type PropType } from 'vue';
+import { ElAvatar, ElIcon } from 'element-plus';
+import {
+  User as UserIcon,
+  Message,
+  Iphone,
+  ChatDotRound,
+  Promotion,
+  Link as LinkIcon,
+  WarningFilled
+} from '@element-plus/icons-vue';
+import { userOperator } from '@/operators';
+import type { IUserPublic, IUserPublicRegistrationMethod } from '@/models';
+
+type ChipState = 'loading' | 'ready' | 'missing';
+
+// Module-level cache so the same UUID rendered in many chips only fetches once.
+const cache = new Map<string, IUserPublic>();
+const inflight = new Map<string, Promise<IUserPublic | null>>();
+// Negative cache: ids we already saw 404 for. Stops endless retries.
+const missing = new Set<string>();
+
+async function resolveUser(id: string): Promise<IUserPublic | null> {
+  if (cache.has(id)) return cache.get(id) as IUserPublic;
+  if (missing.has(id)) return null;
+  let promise = inflight.get(id);
+  if (!promise) {
+    promise = userOperator
+      .resolve({ id })
+      .then((res) => {
+        cache.set(id, res.data);
+        return res.data;
+      })
+      .catch(() => {
+        missing.add(id);
+        return null;
+      })
+      .finally(() => {
+        inflight.delete(id);
+      });
+    inflight.set(id, promise);
+  }
+  return promise;
+}
+
+const METHOD_ICONS: Record<IUserPublicRegistrationMethod, unknown> = {
+  email: Message,
+  phone: Iphone,
+  github: LinkIcon,
+  google: Promotion,
+  wechat: ChatDotRound,
+  username: UserIcon,
+  unknown: UserIcon
+};
+
+export default defineComponent({
+  name: 'UserChip',
+  components: {
+    ElAvatar,
+    ElIcon,
+    UserIcon,
+    Message,
+    Iphone,
+    ChatDotRound,
+    Promotion,
+    LinkIcon,
+    WarningFilled
+  },
+  props: {
+    userId: {
+      type: String as PropType<string | undefined>,
+      default: ''
+    }
+  },
+  data() {
+    return {
+      user: null as IUserPublic | null,
+      state: 'loading' as ChipState
+    };
+  },
+  computed: {
+    shortId(): string {
+      const id = this.userId || '';
+      return id.length > 8 ? id.slice(0, 8) : id;
+    },
+    methodIcon(): unknown {
+      const method = this.user?.registration_method;
+      if (!method) return null;
+      return METHOD_ICONS[method] || null;
+    },
+    methodLabel(): string {
+      const method = this.user?.registration_method;
+      if (!method) return '';
+      const key = `site.label.method.${method}`;
+      const translated = this.$t(key);
+      // i18n returns the key itself if missing — fall back to the raw method.
+      return translated === key ? method : (translated as string);
+    }
+  },
+  watch: {
+    userId: {
+      immediate: true,
+      handler(newId: string) {
+        this.load(newId);
+      }
+    }
+  },
+  methods: {
+    async load(id: string) {
+      if (!id) {
+        this.user = null;
+        this.state = 'ready';
+        return;
+      }
+      if (cache.has(id)) {
+        this.user = cache.get(id) as IUserPublic;
+        this.state = 'ready';
+        return;
+      }
+      if (missing.has(id)) {
+        this.user = null;
+        this.state = 'missing';
+        return;
+      }
+      this.state = 'loading';
+      const result = await resolveUser(id);
+      // Guard against the prop changing while we awaited.
+      if (this.userId !== id) return;
+      if (result) {
+        this.user = result;
+        this.state = 'ready';
+      } else {
+        this.user = null;
+        this.state = 'missing';
+      }
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.user-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 100%;
+  font-size: 13px;
+  line-height: 1.4;
+  color: var(--el-text-color-regular);
+
+  &.is-empty {
+    color: var(--el-text-color-secondary);
+  }
+
+  &.is-missing {
+    color: var(--el-text-color-secondary);
+    font-style: italic;
+  }
+
+  .user-chip__avatar {
+    flex-shrink: 0;
+  }
+
+  .user-chip__name {
+    font-weight: 500;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 160px;
+  }
+
+  .user-chip__icon {
+    font-size: 14px;
+    color: var(--el-text-color-secondary);
+    flex-shrink: 0;
+  }
+
+  .user-chip__contact {
+    color: var(--el-text-color-secondary);
+    font-size: 12px;
+    font-family: var(--el-font-family-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+    white-space: nowrap;
+  }
+
+  .user-chip__id {
+    font-family: var(--el-font-family-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+    font-size: 12px;
+  }
+}
+</style>

--- a/src/components/site/UserChip.vue
+++ b/src/components/site/UserChip.vue
@@ -49,16 +49,33 @@ const inflight = new Map<string, Promise<IUserPublic | null>>();
 // Negative cache: ids we already saw 404 for. Stops endless retries.
 const missing = new Set<string>();
 
+/**
+ * Seed the chip cache from outside (e.g. after the autocomplete picker
+ * fetches a user, we don't want UserChip to round-trip the API again
+ * when it renders that same id).
+ */
+export function seedUserChipCache(user: IUserPublic): void {
+  if (user?.id) {
+    cache.set(user.id, user);
+    missing.delete(user.id);
+  }
+}
+
 async function resolveUser(id: string): Promise<IUserPublic | null> {
   if (cache.has(id)) return cache.get(id) as IUserPublic;
   if (missing.has(id)) return null;
   let promise = inflight.get(id);
   if (!promise) {
     promise = userOperator
-      .resolve({ id })
+      .resolve(id)
       .then((res) => {
-        cache.set(id, res.data);
-        return res.data;
+        const hit = (res.data || []).find((u) => u.id === id) || null;
+        if (hit) {
+          cache.set(id, hit);
+        } else {
+          missing.add(id);
+        }
+        return hit;
       })
       .catch(() => {
         missing.add(id);

--- a/src/components/site/UserChip.vue
+++ b/src/components/site/UserChip.vue
@@ -18,9 +18,6 @@
         <el-icon><user-icon /></el-icon>
       </el-avatar>
       <span class="user-chip__name" :title="userId">{{ user?.display_name || shortId }}</span>
-      <el-icon v-if="methodIcon" class="user-chip__icon" :title="methodLabel">
-        <component :is="methodIcon" />
-      </el-icon>
       <span v-if="user?.contact" class="user-chip__contact">{{ user.contact }}</span>
     </template>
   </span>
@@ -29,17 +26,9 @@
 <script lang="ts">
 import { defineComponent, type PropType } from 'vue';
 import { ElAvatar, ElIcon } from 'element-plus';
-import {
-  User as UserIcon,
-  Message,
-  Iphone,
-  ChatDotRound,
-  Promotion,
-  Link as LinkIcon,
-  WarningFilled
-} from '@element-plus/icons-vue';
+import { User as UserIcon, WarningFilled } from '@element-plus/icons-vue';
 import { userOperator } from '@/operators';
-import type { IUserPublic, IUserPublicRegistrationMethod } from '@/models';
+import type { IUserPublic } from '@/models';
 
 type ChipState = 'loading' | 'ready' | 'missing';
 
@@ -59,6 +48,19 @@ export function seedUserChipCache(user: IUserPublic): void {
     cache.set(user.id, user);
     missing.delete(user.id);
   }
+}
+
+/**
+ * Read-through accessor for the chip cache. Returns cached user immediately
+ * if present, otherwise fires the same network request UserChip would.
+ * Used by EditUser so the dialog can pre-fill the preview chip without
+ * waiting for the chip in the page to render.
+ */
+export async function prefetchUserChip(id: string): Promise<IUserPublic | null> {
+  if (!id) return null;
+  if (cache.has(id)) return cache.get(id) as IUserPublic;
+  if (missing.has(id)) return null;
+  return resolveUser(id);
 }
 
 async function resolveUser(id: string): Promise<IUserPublic | null> {
@@ -89,27 +91,12 @@ async function resolveUser(id: string): Promise<IUserPublic | null> {
   return promise;
 }
 
-const METHOD_ICONS: Record<IUserPublicRegistrationMethod, unknown> = {
-  email: Message,
-  phone: Iphone,
-  github: LinkIcon,
-  google: Promotion,
-  wechat: ChatDotRound,
-  username: UserIcon,
-  unknown: UserIcon
-};
-
 export default defineComponent({
   name: 'UserChip',
   components: {
     ElAvatar,
     ElIcon,
     UserIcon,
-    Message,
-    Iphone,
-    ChatDotRound,
-    Promotion,
-    LinkIcon,
     WarningFilled
   },
   props: {
@@ -128,19 +115,6 @@ export default defineComponent({
     shortId(): string {
       const id = this.userId || '';
       return id.length > 8 ? id.slice(0, 8) : id;
-    },
-    methodIcon(): unknown {
-      const method = this.user?.registration_method;
-      if (!method) return null;
-      return METHOD_ICONS[method] || null;
-    },
-    methodLabel(): string {
-      const method = this.user?.registration_method;
-      if (!method) return '';
-      const key = `site.label.method.${method}`;
-      const translated = this.$t(key);
-      // i18n returns the key itself if missing — fall back to the raw method.
-      return translated === key ? method : (translated as string);
     }
   },
   watch: {
@@ -210,9 +184,6 @@ export default defineComponent({
   .user-chip__name {
     font-weight: 500;
     white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    max-width: 160px;
   }
 
   .user-chip__icon {

--- a/src/components/site/UserPicker.vue
+++ b/src/components/site/UserPicker.vue
@@ -1,0 +1,210 @@
+<template>
+  <el-autocomplete
+    ref="auto"
+    v-model="input"
+    :fetch-suggestions="onFetch"
+    :placeholder="placeholderText"
+    :debounce="350"
+    :trigger-on-focus="false"
+    :hide-loading="false"
+    value-key="value"
+    popper-class="user-picker__popper"
+    clearable
+    @select="onSelect"
+    @clear="onClear"
+    @input="onInput"
+  >
+    <template #prefix>
+      <el-icon><search-icon /></el-icon>
+    </template>
+    <template #default="{ item }">
+      <div class="user-picker__option">
+        <el-avatar v-if="item.avatar" :src="item.avatar" :size="32" class="user-picker__avatar" />
+        <el-avatar v-else :size="32" class="user-picker__avatar">
+          <el-icon><user-icon /></el-icon>
+        </el-avatar>
+        <div class="user-picker__option-text">
+          <div class="user-picker__option-name">
+            {{ item.display_name }}
+            <el-icon v-if="iconFor(item)" class="user-picker__option-method" :title="item.registration_method">
+              <component :is="iconFor(item)" />
+            </el-icon>
+          </div>
+          <div class="user-picker__option-contact">{{ item.contact || shortIdOf(item) }}</div>
+        </div>
+      </div>
+    </template>
+  </el-autocomplete>
+</template>
+
+<script lang="ts">
+import { defineComponent, type PropType } from 'vue';
+import { ElAutocomplete, ElAvatar, ElIcon } from 'element-plus';
+import {
+  Search as SearchIcon,
+  User as UserIcon,
+  Message,
+  Iphone,
+  ChatDotRound,
+  Promotion,
+  Link as LinkIcon
+} from '@element-plus/icons-vue';
+import { userOperator } from '@/operators';
+import type { IUserPublic, IUserPublicRegistrationMethod } from '@/models';
+import { seedUserChipCache } from '@/components/site/UserChip.vue';
+
+type Suggestion = IUserPublic & { value: string };
+
+const METHOD_ICONS: Record<IUserPublicRegistrationMethod, unknown> = {
+  email: Message,
+  phone: Iphone,
+  github: LinkIcon,
+  google: Promotion,
+  wechat: ChatDotRound,
+  username: UserIcon,
+  unknown: UserIcon
+};
+
+export default defineComponent({
+  name: 'UserPicker',
+  components: {
+    ElAutocomplete,
+    ElAvatar,
+    ElIcon,
+    SearchIcon,
+    UserIcon,
+    Message,
+    Iphone,
+    ChatDotRound,
+    Promotion,
+    LinkIcon
+  },
+  props: {
+    placeholder: {
+      type: String,
+      default: ''
+    },
+    excludeIds: {
+      type: Array as PropType<string[]>,
+      default: () => []
+    }
+  },
+  emits: ['select'],
+  data() {
+    return {
+      input: ''
+    };
+  },
+  computed: {
+    placeholderText(): string {
+      return this.placeholder || (this.$t('site.message.editUserHint') as string);
+    }
+  },
+  methods: {
+    iconFor(item: { registration_method?: IUserPublicRegistrationMethod }): unknown {
+      const method = item.registration_method;
+      if (!method) return null;
+      return METHOD_ICONS[method] || null;
+    },
+    shortIdOf(item: { id?: string }): string {
+      const id = item.id || '';
+      return id.length > 8 ? id.slice(0, 8) : id;
+    },
+    async onFetch(query: string): Promise<Suggestion[]> {
+      const q = (query || '').trim();
+      if (!q) return [];
+      try {
+        const res = await userOperator.resolve(q);
+        return (res.data || [])
+          .filter((u) => !this.excludeIds.includes(u.id))
+          .map((u) => {
+            seedUserChipCache(u);
+            return { ...u, value: u.display_name || u.nickname || this.shortIdOf(u) } as Suggestion;
+          });
+      } catch {
+        return [];
+      }
+    },
+    onSelect(item: Record<string, unknown>) {
+      const user = item as unknown as IUserPublic;
+      seedUserChipCache(user);
+      this.$emit('select', user);
+      // Reset input so the picker is ready for another lookup.
+      this.input = '';
+    },
+    onClear() {
+      this.input = '';
+    },
+    onInput() {
+      // No-op: the autocomplete's debounced fetch handles it. We just keep
+      // the v-model binding so the input is controlled.
+    },
+    focus() {
+      const el = (this.$refs.auto as { focus?: () => void } | undefined)?.focus;
+      if (typeof el === 'function') el.call(this.$refs.auto);
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.user-picker__option {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 4px 0;
+}
+
+.user-picker__avatar {
+  flex-shrink: 0;
+}
+
+.user-picker__option-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1;
+}
+
+.user-picker__option-name {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 500;
+  font-size: 14px;
+  color: var(--el-text-color-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.user-picker__option-method {
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+  flex-shrink: 0;
+}
+
+.user-picker__option-contact {
+  font-size: 12px;
+  font-family: var(--el-font-family-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  color: var(--el-text-color-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+</style>
+
+<style lang="scss">
+.user-picker__popper {
+  .el-autocomplete-suggestion__list {
+    max-height: 320px;
+  }
+
+  .el-autocomplete-suggestion li {
+    height: auto;
+    line-height: 1.4;
+    padding: 6px 12px;
+  }
+}
+</style>

--- a/src/components/site/UserPicker.vue
+++ b/src/components/site/UserPicker.vue
@@ -24,12 +24,7 @@
           <el-icon><user-icon /></el-icon>
         </el-avatar>
         <div class="user-picker__option-text">
-          <div class="user-picker__option-name">
-            {{ item.display_name }}
-            <el-icon v-if="iconFor(item)" class="user-picker__option-method" :title="item.registration_method">
-              <component :is="iconFor(item)" />
-            </el-icon>
-          </div>
+          <div class="user-picker__option-name">{{ item.display_name }}</div>
           <div class="user-picker__option-contact">{{ item.contact || shortIdOf(item) }}</div>
         </div>
       </div>
@@ -40,30 +35,12 @@
 <script lang="ts">
 import { defineComponent, type PropType } from 'vue';
 import { ElAutocomplete, ElAvatar, ElIcon } from 'element-plus';
-import {
-  Search as SearchIcon,
-  User as UserIcon,
-  Message,
-  Iphone,
-  ChatDotRound,
-  Promotion,
-  Link as LinkIcon
-} from '@element-plus/icons-vue';
+import { Search as SearchIcon, User as UserIcon } from '@element-plus/icons-vue';
 import { userOperator } from '@/operators';
-import type { IUserPublic, IUserPublicRegistrationMethod } from '@/models';
+import type { IUserPublic } from '@/models';
 import { seedUserChipCache } from '@/components/site/UserChip.vue';
 
 type Suggestion = IUserPublic & { value: string };
-
-const METHOD_ICONS: Record<IUserPublicRegistrationMethod, unknown> = {
-  email: Message,
-  phone: Iphone,
-  github: LinkIcon,
-  google: Promotion,
-  wechat: ChatDotRound,
-  username: UserIcon,
-  unknown: UserIcon
-};
 
 export default defineComponent({
   name: 'UserPicker',
@@ -72,12 +49,7 @@ export default defineComponent({
     ElAvatar,
     ElIcon,
     SearchIcon,
-    UserIcon,
-    Message,
-    Iphone,
-    ChatDotRound,
-    Promotion,
-    LinkIcon
+    UserIcon
   },
   props: {
     placeholder: {
@@ -101,11 +73,6 @@ export default defineComponent({
     }
   },
   methods: {
-    iconFor(item: { registration_method?: IUserPublicRegistrationMethod }): unknown {
-      const method = item.registration_method;
-      if (!method) return null;
-      return METHOD_ICONS[method] || null;
-    },
     shortIdOf(item: { id?: string }): string {
       const id = item.id || '';
       return id.length > 8 ? id.slice(0, 8) : id;
@@ -177,12 +144,6 @@ export default defineComponent({
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.user-picker__option-method {
-  font-size: 12px;
-  color: var(--el-text-color-secondary);
-  flex-shrink: 0;
 }
 
 .user-picker__option-contact {

--- a/src/i18n/ar/site.json
+++ b/src/i18n/ar/site.json
@@ -507,27 +507,27 @@
     "message": "أدخل معرف مستخدم المسؤول",
     "description": "نص العنصر النائب في صندوق تحرير المسؤول في إعدادات الموقع"
   },
-  "site.message.userNotFound": {
+  "message.userNotFound": {
     "message": "المستخدم غير موجود",
     "description": "Shown when the user lookup endpoint returns 404 in the picker preview."
   },
-  "site.message.editUserHint": {
+  "message.editUserHint": {
     "message": "الصق UUID للمستخدم، أو اكتب البريد الإلكتروني أو رقم الهاتف أو اسم المستخدم للبحث.",
     "description": "Tip below the lookup input in the inviter / admin user picker dialog."
   },
-  "site.message.editUsersEmpty": {
+  "message.editUsersEmpty": {
     "message": "لا يوجد مسؤولون بعد.",
     "description": "Empty-state text shown when the admins list has no users."
   },
-  "site.message.userAlreadyAdded": {
+  "message.userAlreadyAdded": {
     "message": "تمت الإضافة بالفعل",
     "description": "Disabled-state label on the Add button when the resolved user is already in the admin list."
   },
-  "site.title.addUser": {
+  "title.addUser": {
     "message": "إضافة مستخدم",
     "description": "Divider title in the admins picker, between the existing-admins list and the lookup input."
   },
-  "site.button.addUser": {
+  "button.addUser": {
     "message": "إضافة",
     "description": "Button label to add the resolved user to the admins list."
   }

--- a/src/i18n/ar/site.json
+++ b/src/i18n/ar/site.json
@@ -506,5 +506,29 @@
   "placeholder.admins": {
     "message": "أدخل معرف مستخدم المسؤول",
     "description": "نص العنصر النائب في صندوق تحرير المسؤول في إعدادات الموقع"
+  },
+  "site.message.userNotFound": {
+    "message": "المستخدم غير موجود",
+    "description": "Shown when the user lookup endpoint returns 404 in the picker preview."
+  },
+  "site.message.editUserHint": {
+    "message": "الصق UUID للمستخدم، أو اكتب البريد الإلكتروني أو رقم الهاتف أو اسم المستخدم للبحث.",
+    "description": "Tip below the lookup input in the inviter / admin user picker dialog."
+  },
+  "site.message.editUsersEmpty": {
+    "message": "لا يوجد مسؤولون بعد.",
+    "description": "Empty-state text shown when the admins list has no users."
+  },
+  "site.message.userAlreadyAdded": {
+    "message": "تمت الإضافة بالفعل",
+    "description": "Disabled-state label on the Add button when the resolved user is already in the admin list."
+  },
+  "site.title.addUser": {
+    "message": "إضافة مستخدم",
+    "description": "Divider title in the admins picker, between the existing-admins list and the lookup input."
+  },
+  "site.button.addUser": {
+    "message": "إضافة",
+    "description": "Button label to add the resolved user to the admins list."
   }
 }

--- a/src/i18n/de/site.json
+++ b/src/i18n/de/site.json
@@ -507,27 +507,27 @@
     "message": "Bitte geben Sie die Administrator-Benutzer-ID ein",
     "description": "Platzhalter im Bearbeitungsfeld für Administratoren in den Seiteneinstellungen"
   },
-  "site.message.userNotFound": {
+  "message.userNotFound": {
     "message": "Nutzer nicht gefunden",
     "description": "Shown when the user lookup endpoint returns 404 in the picker preview."
   },
-  "site.message.editUserHint": {
+  "message.editUserHint": {
     "message": "Füge eine Nutzer-UUID ein oder gib eine E-Mail, Telefonnummer oder einen Nutzernamen ein, um zu suchen.",
     "description": "Tip below the lookup input in the inviter / admin user picker dialog."
   },
-  "site.message.editUsersEmpty": {
+  "message.editUsersEmpty": {
     "message": "Noch keine Administratoren.",
     "description": "Empty-state text shown when the admins list has no users."
   },
-  "site.message.userAlreadyAdded": {
+  "message.userAlreadyAdded": {
     "message": "Bereits hinzugefügt",
     "description": "Disabled-state label on the Add button when the resolved user is already in the admin list."
   },
-  "site.title.addUser": {
+  "title.addUser": {
     "message": "Nutzer hinzufügen",
     "description": "Divider title in the admins picker, between the existing-admins list and the lookup input."
   },
-  "site.button.addUser": {
+  "button.addUser": {
     "message": "Hinzufügen",
     "description": "Button label to add the resolved user to the admins list."
   }

--- a/src/i18n/de/site.json
+++ b/src/i18n/de/site.json
@@ -506,5 +506,29 @@
   "placeholder.admins": {
     "message": "Bitte geben Sie die Administrator-Benutzer-ID ein",
     "description": "Platzhalter im Bearbeitungsfeld für Administratoren in den Seiteneinstellungen"
+  },
+  "site.message.userNotFound": {
+    "message": "Nutzer nicht gefunden",
+    "description": "Shown when the user lookup endpoint returns 404 in the picker preview."
+  },
+  "site.message.editUserHint": {
+    "message": "Füge eine Nutzer-UUID ein oder gib eine E-Mail, Telefonnummer oder einen Nutzernamen ein, um zu suchen.",
+    "description": "Tip below the lookup input in the inviter / admin user picker dialog."
+  },
+  "site.message.editUsersEmpty": {
+    "message": "Noch keine Administratoren.",
+    "description": "Empty-state text shown when the admins list has no users."
+  },
+  "site.message.userAlreadyAdded": {
+    "message": "Bereits hinzugefügt",
+    "description": "Disabled-state label on the Add button when the resolved user is already in the admin list."
+  },
+  "site.title.addUser": {
+    "message": "Nutzer hinzufügen",
+    "description": "Divider title in the admins picker, between the existing-admins list and the lookup input."
+  },
+  "site.button.addUser": {
+    "message": "Hinzufügen",
+    "description": "Button label to add the resolved user to the admins list."
   }
 }

--- a/src/i18n/el/site.json
+++ b/src/i18n/el/site.json
@@ -507,27 +507,27 @@
     "message": "Εισάγετε το ID χρήστη διαχειριστή",
     "description": "Placeholder στο πλαίσιο επεξεργασίας διαχειριστή στις ρυθμίσεις του ιστότοπου"
   },
-  "site.message.userNotFound": {
+  "message.userNotFound": {
     "message": "Ο χρήστης δεν βρέθηκε",
     "description": "Shown when the user lookup endpoint returns 404 in the picker preview."
   },
-  "site.message.editUserHint": {
+  "message.editUserHint": {
     "message": "Επικολλήστε ένα UUID χρήστη, ή πληκτρολογήστε email, τηλέφωνο ή όνομα χρήστη για αναζήτηση.",
     "description": "Tip below the lookup input in the inviter / admin user picker dialog."
   },
-  "site.message.editUsersEmpty": {
+  "message.editUsersEmpty": {
     "message": "Δεν υπάρχουν ακόμη διαχειριστές.",
     "description": "Empty-state text shown when the admins list has no users."
   },
-  "site.message.userAlreadyAdded": {
+  "message.userAlreadyAdded": {
     "message": "Έχει ήδη προστεθεί",
     "description": "Disabled-state label on the Add button when the resolved user is already in the admin list."
   },
-  "site.title.addUser": {
+  "title.addUser": {
     "message": "Προσθήκη χρήστη",
     "description": "Divider title in the admins picker, between the existing-admins list and the lookup input."
   },
-  "site.button.addUser": {
+  "button.addUser": {
     "message": "Προσθήκη",
     "description": "Button label to add the resolved user to the admins list."
   }

--- a/src/i18n/el/site.json
+++ b/src/i18n/el/site.json
@@ -506,5 +506,29 @@
   "placeholder.admins": {
     "message": "Εισάγετε το ID χρήστη διαχειριστή",
     "description": "Placeholder στο πλαίσιο επεξεργασίας διαχειριστή στις ρυθμίσεις του ιστότοπου"
+  },
+  "site.message.userNotFound": {
+    "message": "Ο χρήστης δεν βρέθηκε",
+    "description": "Shown when the user lookup endpoint returns 404 in the picker preview."
+  },
+  "site.message.editUserHint": {
+    "message": "Επικολλήστε ένα UUID χρήστη, ή πληκτρολογήστε email, τηλέφωνο ή όνομα χρήστη για αναζήτηση.",
+    "description": "Tip below the lookup input in the inviter / admin user picker dialog."
+  },
+  "site.message.editUsersEmpty": {
+    "message": "Δεν υπάρχουν ακόμη διαχειριστές.",
+    "description": "Empty-state text shown when the admins list has no users."
+  },
+  "site.message.userAlreadyAdded": {
+    "message": "Έχει ήδη προστεθεί",
+    "description": "Disabled-state label on the Add button when the resolved user is already in the admin list."
+  },
+  "site.title.addUser": {
+    "message": "Προσθήκη χρήστη",
+    "description": "Divider title in the admins picker, between the existing-admins list and the lookup input."
+  },
+  "site.button.addUser": {
+    "message": "Προσθήκη",
+    "description": "Button label to add the resolved user to the admins list."
   }
 }

--- a/src/i18n/en/site.json
+++ b/src/i18n/en/site.json
@@ -507,27 +507,27 @@
     "message": "Enter admin user ID",
     "description": "Placeholder in the admin editing box in site settings"
   },
-  "site.message.userNotFound": {
+  "message.userNotFound": {
     "message": "User not found",
     "description": "Shown when the user lookup endpoint returns 404 in the picker preview."
   },
-  "site.message.editUserHint": {
-    "message": "Paste a user UUID, or type an email, phone, or username to find someone.",
+  "message.editUserHint": {
+    "message": "Type a full UUID, username, email or phone to look up a user.",
     "description": "Tip below the lookup input in the inviter / admin user picker dialog."
   },
-  "site.message.editUsersEmpty": {
+  "message.editUsersEmpty": {
     "message": "No admins yet.",
     "description": "Empty-state text shown when the admins list has no users."
   },
-  "site.message.userAlreadyAdded": {
+  "message.userAlreadyAdded": {
     "message": "Already added",
     "description": "Disabled-state label on the Add button when the resolved user is already in the admin list."
   },
-  "site.title.addUser": {
+  "title.addUser": {
     "message": "Add user",
     "description": "Divider title in the admins picker, between the existing-admins list and the lookup input."
   },
-  "site.button.addUser": {
+  "button.addUser": {
     "message": "Add",
     "description": "Button label to add the resolved user to the admins list."
   }

--- a/src/i18n/en/site.json
+++ b/src/i18n/en/site.json
@@ -506,5 +506,29 @@
   "placeholder.admins": {
     "message": "Enter admin user ID",
     "description": "Placeholder in the admin editing box in site settings"
+  },
+  "site.message.userNotFound": {
+    "message": "User not found",
+    "description": "Shown when the user lookup endpoint returns 404 in the picker preview."
+  },
+  "site.message.editUserHint": {
+    "message": "Paste a user UUID, or type an email, phone, or username to find someone.",
+    "description": "Tip below the lookup input in the inviter / admin user picker dialog."
+  },
+  "site.message.editUsersEmpty": {
+    "message": "No admins yet.",
+    "description": "Empty-state text shown when the admins list has no users."
+  },
+  "site.message.userAlreadyAdded": {
+    "message": "Already added",
+    "description": "Disabled-state label on the Add button when the resolved user is already in the admin list."
+  },
+  "site.title.addUser": {
+    "message": "Add user",
+    "description": "Divider title in the admins picker, between the existing-admins list and the lookup input."
+  },
+  "site.button.addUser": {
+    "message": "Add",
+    "description": "Button label to add the resolved user to the admins list."
   }
 }

--- a/src/i18n/es/site.json
+++ b/src/i18n/es/site.json
@@ -506,5 +506,29 @@
   "placeholder.admins": {
     "message": "Ingrese el ID de usuario del administrador",
     "description": "Marcador de posición en el cuadro de edición de administrador en la configuración del sitio"
+  },
+  "site.message.userNotFound": {
+    "message": "Usuario no encontrado",
+    "description": "Shown when the user lookup endpoint returns 404 in the picker preview."
+  },
+  "site.message.editUserHint": {
+    "message": "Pega un UUID de usuario, o escribe un correo, teléfono o nombre de usuario para buscarlo.",
+    "description": "Tip below the lookup input in the inviter / admin user picker dialog."
+  },
+  "site.message.editUsersEmpty": {
+    "message": "Aún no hay administradores.",
+    "description": "Empty-state text shown when the admins list has no users."
+  },
+  "site.message.userAlreadyAdded": {
+    "message": "Ya agregado",
+    "description": "Disabled-state label on the Add button when the resolved user is already in the admin list."
+  },
+  "site.title.addUser": {
+    "message": "Agregar usuario",
+    "description": "Divider title in the admins picker, between the existing-admins list and the lookup input."
+  },
+  "site.button.addUser": {
+    "message": "Agregar",
+    "description": "Button label to add the resolved user to the admins list."
   }
 }

--- a/src/i18n/es/site.json
+++ b/src/i18n/es/site.json
@@ -507,27 +507,27 @@
     "message": "Ingrese el ID de usuario del administrador",
     "description": "Marcador de posición en el cuadro de edición de administrador en la configuración del sitio"
   },
-  "site.message.userNotFound": {
+  "message.userNotFound": {
     "message": "Usuario no encontrado",
     "description": "Shown when the user lookup endpoint returns 404 in the picker preview."
   },
-  "site.message.editUserHint": {
+  "message.editUserHint": {
     "message": "Pega un UUID de usuario, o escribe un correo, teléfono o nombre de usuario para buscarlo.",
     "description": "Tip below the lookup input in the inviter / admin user picker dialog."
   },
-  "site.message.editUsersEmpty": {
+  "message.editUsersEmpty": {
     "message": "Aún no hay administradores.",
     "description": "Empty-state text shown when the admins list has no users."
   },
-  "site.message.userAlreadyAdded": {
+  "message.userAlreadyAdded": {
     "message": "Ya agregado",
     "description": "Disabled-state label on the Add button when the resolved user is already in the admin list."
   },
-  "site.title.addUser": {
+  "title.addUser": {
     "message": "Agregar usuario",
     "description": "Divider title in the admins picker, between the existing-admins list and the lookup input."
   },
-  "site.button.addUser": {
+  "button.addUser": {
     "message": "Agregar",
     "description": "Button label to add the resolved user to the admins list."
   }

--- a/src/i18n/fi/site.json
+++ b/src/i18n/fi/site.json
@@ -507,27 +507,27 @@
     "message": "Syötä ylläpitäjän käyttäjä ID",
     "description": "Ylläpitäjän muokkausruudun paikkamerkki sivuston asetuksissa"
   },
-  "site.message.userNotFound": {
+  "message.userNotFound": {
     "message": "Käyttäjää ei löytynyt",
     "description": "Shown when the user lookup endpoint returns 404 in the picker preview."
   },
-  "site.message.editUserHint": {
+  "message.editUserHint": {
     "message": "Liitä käyttäjän UUID tai kirjoita sähköposti, puhelinnumero tai käyttäjänimi etsiäksesi.",
     "description": "Tip below the lookup input in the inviter / admin user picker dialog."
   },
-  "site.message.editUsersEmpty": {
+  "message.editUsersEmpty": {
     "message": "Ei vielä ylläpitäjiä.",
     "description": "Empty-state text shown when the admins list has no users."
   },
-  "site.message.userAlreadyAdded": {
+  "message.userAlreadyAdded": {
     "message": "Jo lisätty",
     "description": "Disabled-state label on the Add button when the resolved user is already in the admin list."
   },
-  "site.title.addUser": {
+  "title.addUser": {
     "message": "Lisää käyttäjä",
     "description": "Divider title in the admins picker, between the existing-admins list and the lookup input."
   },
-  "site.button.addUser": {
+  "button.addUser": {
     "message": "Lisää",
     "description": "Button label to add the resolved user to the admins list."
   }

--- a/src/i18n/fi/site.json
+++ b/src/i18n/fi/site.json
@@ -506,5 +506,29 @@
   "placeholder.admins": {
     "message": "Syötä ylläpitäjän käyttäjä ID",
     "description": "Ylläpitäjän muokkausruudun paikkamerkki sivuston asetuksissa"
+  },
+  "site.message.userNotFound": {
+    "message": "Käyttäjää ei löytynyt",
+    "description": "Shown when the user lookup endpoint returns 404 in the picker preview."
+  },
+  "site.message.editUserHint": {
+    "message": "Liitä käyttäjän UUID tai kirjoita sähköposti, puhelinnumero tai käyttäjänimi etsiäksesi.",
+    "description": "Tip below the lookup input in the inviter / admin user picker dialog."
+  },
+  "site.message.editUsersEmpty": {
+    "message": "Ei vielä ylläpitäjiä.",
+    "description": "Empty-state text shown when the admins list has no users."
+  },
+  "site.message.userAlreadyAdded": {
+    "message": "Jo lisätty",
+    "description": "Disabled-state label on the Add button when the resolved user is already in the admin list."
+  },
+  "site.title.addUser": {
+    "message": "Lisää käyttäjä",
+    "description": "Divider title in the admins picker, between the existing-admins list and the lookup input."
+  },
+  "site.button.addUser": {
+    "message": "Lisää",
+    "description": "Button label to add the resolved user to the admins list."
   }
 }

--- a/src/i18n/fr/site.json
+++ b/src/i18n/fr/site.json
@@ -507,27 +507,27 @@
     "message": "Veuillez entrer l'ID utilisateur administrateur",
     "description": "Espace réservé dans la boîte d'édition des administrateurs dans les paramètres du site"
   },
-  "site.message.userNotFound": {
+  "message.userNotFound": {
     "message": "Utilisateur introuvable",
     "description": "Shown when the user lookup endpoint returns 404 in the picker preview."
   },
-  "site.message.editUserHint": {
+  "message.editUserHint": {
     "message": "Collez un UUID utilisateur, ou saisissez un e-mail, un téléphone ou un nom d’utilisateur pour rechercher.",
     "description": "Tip below the lookup input in the inviter / admin user picker dialog."
   },
-  "site.message.editUsersEmpty": {
+  "message.editUsersEmpty": {
     "message": "Aucun administrateur pour le moment.",
     "description": "Empty-state text shown when the admins list has no users."
   },
-  "site.message.userAlreadyAdded": {
+  "message.userAlreadyAdded": {
     "message": "Déjà ajouté",
     "description": "Disabled-state label on the Add button when the resolved user is already in the admin list."
   },
-  "site.title.addUser": {
+  "title.addUser": {
     "message": "Ajouter un utilisateur",
     "description": "Divider title in the admins picker, between the existing-admins list and the lookup input."
   },
-  "site.button.addUser": {
+  "button.addUser": {
     "message": "Ajouter",
     "description": "Button label to add the resolved user to the admins list."
   }

--- a/src/i18n/fr/site.json
+++ b/src/i18n/fr/site.json
@@ -506,5 +506,29 @@
   "placeholder.admins": {
     "message": "Veuillez entrer l'ID utilisateur administrateur",
     "description": "Espace réservé dans la boîte d'édition des administrateurs dans les paramètres du site"
+  },
+  "site.message.userNotFound": {
+    "message": "Utilisateur introuvable",
+    "description": "Shown when the user lookup endpoint returns 404 in the picker preview."
+  },
+  "site.message.editUserHint": {
+    "message": "Collez un UUID utilisateur, ou saisissez un e-mail, un téléphone ou un nom d’utilisateur pour rechercher.",
+    "description": "Tip below the lookup input in the inviter / admin user picker dialog."
+  },
+  "site.message.editUsersEmpty": {
+    "message": "Aucun administrateur pour le moment.",
+    "description": "Empty-state text shown when the admins list has no users."
+  },
+  "site.message.userAlreadyAdded": {
+    "message": "Déjà ajouté",
+    "description": "Disabled-state label on the Add button when the resolved user is already in the admin list."
+  },
+  "site.title.addUser": {
+    "message": "Ajouter un utilisateur",
+    "description": "Divider title in the admins picker, between the existing-admins list and the lookup input."
+  },
+  "site.button.addUser": {
+    "message": "Ajouter",
+    "description": "Button label to add the resolved user to the admins list."
   }
 }

--- a/src/i18n/it/site.json
+++ b/src/i18n/it/site.json
@@ -507,27 +507,27 @@
     "message": "Inserisci l'ID utente amministratore",
     "description": "Segnaposto nella casella di modifica degli amministratori nelle impostazioni del sito"
   },
-  "site.message.userNotFound": {
+  "message.userNotFound": {
     "message": "Utente non trovato",
     "description": "Shown when the user lookup endpoint returns 404 in the picker preview."
   },
-  "site.message.editUserHint": {
+  "message.editUserHint": {
     "message": "Incolla un UUID utente o digita un’email, un telefono o un nome utente per cercarlo.",
     "description": "Tip below the lookup input in the inviter / admin user picker dialog."
   },
-  "site.message.editUsersEmpty": {
+  "message.editUsersEmpty": {
     "message": "Nessun amministratore ancora.",
     "description": "Empty-state text shown when the admins list has no users."
   },
-  "site.message.userAlreadyAdded": {
+  "message.userAlreadyAdded": {
     "message": "Già aggiunto",
     "description": "Disabled-state label on the Add button when the resolved user is already in the admin list."
   },
-  "site.title.addUser": {
+  "title.addUser": {
     "message": "Aggiungi utente",
     "description": "Divider title in the admins picker, between the existing-admins list and the lookup input."
   },
-  "site.button.addUser": {
+  "button.addUser": {
     "message": "Aggiungi",
     "description": "Button label to add the resolved user to the admins list."
   }

--- a/src/i18n/it/site.json
+++ b/src/i18n/it/site.json
@@ -506,5 +506,29 @@
   "placeholder.admins": {
     "message": "Inserisci l'ID utente amministratore",
     "description": "Segnaposto nella casella di modifica degli amministratori nelle impostazioni del sito"
+  },
+  "site.message.userNotFound": {
+    "message": "Utente non trovato",
+    "description": "Shown when the user lookup endpoint returns 404 in the picker preview."
+  },
+  "site.message.editUserHint": {
+    "message": "Incolla un UUID utente o digita un’email, un telefono o un nome utente per cercarlo.",
+    "description": "Tip below the lookup input in the inviter / admin user picker dialog."
+  },
+  "site.message.editUsersEmpty": {
+    "message": "Nessun amministratore ancora.",
+    "description": "Empty-state text shown when the admins list has no users."
+  },
+  "site.message.userAlreadyAdded": {
+    "message": "Già aggiunto",
+    "description": "Disabled-state label on the Add button when the resolved user is already in the admin list."
+  },
+  "site.title.addUser": {
+    "message": "Aggiungi utente",
+    "description": "Divider title in the admins picker, between the existing-admins list and the lookup input."
+  },
+  "site.button.addUser": {
+    "message": "Aggiungi",
+    "description": "Button label to add the resolved user to the admins list."
   }
 }

--- a/src/i18n/ja/site.json
+++ b/src/i18n/ja/site.json
@@ -507,27 +507,27 @@
     "message": "管理者ユーザー ID を入力してください",
     "description": "サイト設定の管理者編集ボックスのプレースホルダー"
   },
-  "site.message.userNotFound": {
+  "message.userNotFound": {
     "message": "ユーザーが見つかりません",
     "description": "Shown when the user lookup endpoint returns 404 in the picker preview."
   },
-  "site.message.editUserHint": {
+  "message.editUserHint": {
     "message": "ユーザー UUID を貼り付けるか、メール、電話番号、ユーザー名で検索してください。",
     "description": "Tip below the lookup input in the inviter / admin user picker dialog."
   },
-  "site.message.editUsersEmpty": {
+  "message.editUsersEmpty": {
     "message": "まだ管理者がいません",
     "description": "Empty-state text shown when the admins list has no users."
   },
-  "site.message.userAlreadyAdded": {
+  "message.userAlreadyAdded": {
     "message": "追加済み",
     "description": "Disabled-state label on the Add button when the resolved user is already in the admin list."
   },
-  "site.title.addUser": {
+  "title.addUser": {
     "message": "ユーザーを追加",
     "description": "Divider title in the admins picker, between the existing-admins list and the lookup input."
   },
-  "site.button.addUser": {
+  "button.addUser": {
     "message": "追加",
     "description": "Button label to add the resolved user to the admins list."
   }

--- a/src/i18n/ja/site.json
+++ b/src/i18n/ja/site.json
@@ -506,5 +506,29 @@
   "placeholder.admins": {
     "message": "管理者ユーザー ID を入力してください",
     "description": "サイト設定の管理者編集ボックスのプレースホルダー"
+  },
+  "site.message.userNotFound": {
+    "message": "ユーザーが見つかりません",
+    "description": "Shown when the user lookup endpoint returns 404 in the picker preview."
+  },
+  "site.message.editUserHint": {
+    "message": "ユーザー UUID を貼り付けるか、メール、電話番号、ユーザー名で検索してください。",
+    "description": "Tip below the lookup input in the inviter / admin user picker dialog."
+  },
+  "site.message.editUsersEmpty": {
+    "message": "まだ管理者がいません",
+    "description": "Empty-state text shown when the admins list has no users."
+  },
+  "site.message.userAlreadyAdded": {
+    "message": "追加済み",
+    "description": "Disabled-state label on the Add button when the resolved user is already in the admin list."
+  },
+  "site.title.addUser": {
+    "message": "ユーザーを追加",
+    "description": "Divider title in the admins picker, between the existing-admins list and the lookup input."
+  },
+  "site.button.addUser": {
+    "message": "追加",
+    "description": "Button label to add the resolved user to the admins list."
   }
 }

--- a/src/i18n/ko/site.json
+++ b/src/i18n/ko/site.json
@@ -506,5 +506,29 @@
   "placeholder.admins": {
     "message": "관리자 사용자 ID를 입력하세요.",
     "description": "사이트 설정에서 관리자 편집 상자의 자리 표시자"
+  },
+  "site.message.userNotFound": {
+    "message": "사용자를 찾을 수 없습니다",
+    "description": "Shown when the user lookup endpoint returns 404 in the picker preview."
+  },
+  "site.message.editUserHint": {
+    "message": "사용자 UUID를 붙여넣거나 이메일, 휴대전화 번호, 사용자 이름으로 검색하세요.",
+    "description": "Tip below the lookup input in the inviter / admin user picker dialog."
+  },
+  "site.message.editUsersEmpty": {
+    "message": "아직 관리자가 없습니다",
+    "description": "Empty-state text shown when the admins list has no users."
+  },
+  "site.message.userAlreadyAdded": {
+    "message": "이미 추가됨",
+    "description": "Disabled-state label on the Add button when the resolved user is already in the admin list."
+  },
+  "site.title.addUser": {
+    "message": "사용자 추가",
+    "description": "Divider title in the admins picker, between the existing-admins list and the lookup input."
+  },
+  "site.button.addUser": {
+    "message": "추가",
+    "description": "Button label to add the resolved user to the admins list."
   }
 }

--- a/src/i18n/ko/site.json
+++ b/src/i18n/ko/site.json
@@ -507,27 +507,27 @@
     "message": "관리자 사용자 ID를 입력하세요.",
     "description": "사이트 설정에서 관리자 편집 상자의 자리 표시자"
   },
-  "site.message.userNotFound": {
+  "message.userNotFound": {
     "message": "사용자를 찾을 수 없습니다",
     "description": "Shown when the user lookup endpoint returns 404 in the picker preview."
   },
-  "site.message.editUserHint": {
+  "message.editUserHint": {
     "message": "사용자 UUID를 붙여넣거나 이메일, 휴대전화 번호, 사용자 이름으로 검색하세요.",
     "description": "Tip below the lookup input in the inviter / admin user picker dialog."
   },
-  "site.message.editUsersEmpty": {
+  "message.editUsersEmpty": {
     "message": "아직 관리자가 없습니다",
     "description": "Empty-state text shown when the admins list has no users."
   },
-  "site.message.userAlreadyAdded": {
+  "message.userAlreadyAdded": {
     "message": "이미 추가됨",
     "description": "Disabled-state label on the Add button when the resolved user is already in the admin list."
   },
-  "site.title.addUser": {
+  "title.addUser": {
     "message": "사용자 추가",
     "description": "Divider title in the admins picker, between the existing-admins list and the lookup input."
   },
-  "site.button.addUser": {
+  "button.addUser": {
     "message": "추가",
     "description": "Button label to add the resolved user to the admins list."
   }

--- a/src/i18n/pl/site.json
+++ b/src/i18n/pl/site.json
@@ -506,5 +506,29 @@
   "placeholder.admins": {
     "message": "Wprowadź identyfikator użytkownika administratora",
     "description": "Placeholder w polu edycji administratora w ustawieniach witryny"
+  },
+  "site.message.userNotFound": {
+    "message": "Nie znaleziono użytkownika",
+    "description": "Shown when the user lookup endpoint returns 404 in the picker preview."
+  },
+  "site.message.editUserHint": {
+    "message": "Wklej UUID użytkownika lub wpisz email, telefon albo nazwę użytkownika, aby go znaleźć.",
+    "description": "Tip below the lookup input in the inviter / admin user picker dialog."
+  },
+  "site.message.editUsersEmpty": {
+    "message": "Brak administratorów.",
+    "description": "Empty-state text shown when the admins list has no users."
+  },
+  "site.message.userAlreadyAdded": {
+    "message": "Już dodany",
+    "description": "Disabled-state label on the Add button when the resolved user is already in the admin list."
+  },
+  "site.title.addUser": {
+    "message": "Dodaj użytkownika",
+    "description": "Divider title in the admins picker, between the existing-admins list and the lookup input."
+  },
+  "site.button.addUser": {
+    "message": "Dodaj",
+    "description": "Button label to add the resolved user to the admins list."
   }
 }

--- a/src/i18n/pl/site.json
+++ b/src/i18n/pl/site.json
@@ -507,27 +507,27 @@
     "message": "Wprowadź identyfikator użytkownika administratora",
     "description": "Placeholder w polu edycji administratora w ustawieniach witryny"
   },
-  "site.message.userNotFound": {
+  "message.userNotFound": {
     "message": "Nie znaleziono użytkownika",
     "description": "Shown when the user lookup endpoint returns 404 in the picker preview."
   },
-  "site.message.editUserHint": {
+  "message.editUserHint": {
     "message": "Wklej UUID użytkownika lub wpisz email, telefon albo nazwę użytkownika, aby go znaleźć.",
     "description": "Tip below the lookup input in the inviter / admin user picker dialog."
   },
-  "site.message.editUsersEmpty": {
+  "message.editUsersEmpty": {
     "message": "Brak administratorów.",
     "description": "Empty-state text shown when the admins list has no users."
   },
-  "site.message.userAlreadyAdded": {
+  "message.userAlreadyAdded": {
     "message": "Już dodany",
     "description": "Disabled-state label on the Add button when the resolved user is already in the admin list."
   },
-  "site.title.addUser": {
+  "title.addUser": {
     "message": "Dodaj użytkownika",
     "description": "Divider title in the admins picker, between the existing-admins list and the lookup input."
   },
-  "site.button.addUser": {
+  "button.addUser": {
     "message": "Dodaj",
     "description": "Button label to add the resolved user to the admins list."
   }

--- a/src/i18n/pt/site.json
+++ b/src/i18n/pt/site.json
@@ -507,27 +507,27 @@
     "message": "Digite o ID do usuário administrador",
     "description": "Placeholder na caixa de edição de administrador nas configurações do site"
   },
-  "site.message.userNotFound": {
+  "message.userNotFound": {
     "message": "Utilizador não encontrado",
     "description": "Shown when the user lookup endpoint returns 404 in the picker preview."
   },
-  "site.message.editUserHint": {
+  "message.editUserHint": {
     "message": "Cola um UUID de utilizador, ou escreve um email, telefone ou nome de utilizador para o encontrar.",
     "description": "Tip below the lookup input in the inviter / admin user picker dialog."
   },
-  "site.message.editUsersEmpty": {
+  "message.editUsersEmpty": {
     "message": "Ainda não há administradores.",
     "description": "Empty-state text shown when the admins list has no users."
   },
-  "site.message.userAlreadyAdded": {
+  "message.userAlreadyAdded": {
     "message": "Já adicionado",
     "description": "Disabled-state label on the Add button when the resolved user is already in the admin list."
   },
-  "site.title.addUser": {
+  "title.addUser": {
     "message": "Adicionar utilizador",
     "description": "Divider title in the admins picker, between the existing-admins list and the lookup input."
   },
-  "site.button.addUser": {
+  "button.addUser": {
     "message": "Adicionar",
     "description": "Button label to add the resolved user to the admins list."
   }

--- a/src/i18n/pt/site.json
+++ b/src/i18n/pt/site.json
@@ -506,5 +506,29 @@
   "placeholder.admins": {
     "message": "Digite o ID do usuário administrador",
     "description": "Placeholder na caixa de edição de administrador nas configurações do site"
+  },
+  "site.message.userNotFound": {
+    "message": "Utilizador não encontrado",
+    "description": "Shown when the user lookup endpoint returns 404 in the picker preview."
+  },
+  "site.message.editUserHint": {
+    "message": "Cola um UUID de utilizador, ou escreve um email, telefone ou nome de utilizador para o encontrar.",
+    "description": "Tip below the lookup input in the inviter / admin user picker dialog."
+  },
+  "site.message.editUsersEmpty": {
+    "message": "Ainda não há administradores.",
+    "description": "Empty-state text shown when the admins list has no users."
+  },
+  "site.message.userAlreadyAdded": {
+    "message": "Já adicionado",
+    "description": "Disabled-state label on the Add button when the resolved user is already in the admin list."
+  },
+  "site.title.addUser": {
+    "message": "Adicionar utilizador",
+    "description": "Divider title in the admins picker, between the existing-admins list and the lookup input."
+  },
+  "site.button.addUser": {
+    "message": "Adicionar",
+    "description": "Button label to add the resolved user to the admins list."
   }
 }

--- a/src/i18n/ru/site.json
+++ b/src/i18n/ru/site.json
@@ -506,5 +506,29 @@
   "placeholder.admins": {
     "message": "Введите ID пользователя администратора",
     "description": "Заполнитель в поле редактирования администратора в настройках сайта"
+  },
+  "site.message.userNotFound": {
+    "message": "Пользователь не найден",
+    "description": "Shown when the user lookup endpoint returns 404 in the picker preview."
+  },
+  "site.message.editUserHint": {
+    "message": "Вставьте UUID пользователя или введите email, телефон или имя пользователя для поиска.",
+    "description": "Tip below the lookup input in the inviter / admin user picker dialog."
+  },
+  "site.message.editUsersEmpty": {
+    "message": "Администраторов пока нет.",
+    "description": "Empty-state text shown when the admins list has no users."
+  },
+  "site.message.userAlreadyAdded": {
+    "message": "Уже добавлен",
+    "description": "Disabled-state label on the Add button when the resolved user is already in the admin list."
+  },
+  "site.title.addUser": {
+    "message": "Добавить пользователя",
+    "description": "Divider title in the admins picker, between the existing-admins list and the lookup input."
+  },
+  "site.button.addUser": {
+    "message": "Добавить",
+    "description": "Button label to add the resolved user to the admins list."
   }
 }

--- a/src/i18n/ru/site.json
+++ b/src/i18n/ru/site.json
@@ -507,27 +507,27 @@
     "message": "Введите ID пользователя администратора",
     "description": "Заполнитель в поле редактирования администратора в настройках сайта"
   },
-  "site.message.userNotFound": {
+  "message.userNotFound": {
     "message": "Пользователь не найден",
     "description": "Shown when the user lookup endpoint returns 404 in the picker preview."
   },
-  "site.message.editUserHint": {
+  "message.editUserHint": {
     "message": "Вставьте UUID пользователя или введите email, телефон или имя пользователя для поиска.",
     "description": "Tip below the lookup input in the inviter / admin user picker dialog."
   },
-  "site.message.editUsersEmpty": {
+  "message.editUsersEmpty": {
     "message": "Администраторов пока нет.",
     "description": "Empty-state text shown when the admins list has no users."
   },
-  "site.message.userAlreadyAdded": {
+  "message.userAlreadyAdded": {
     "message": "Уже добавлен",
     "description": "Disabled-state label on the Add button when the resolved user is already in the admin list."
   },
-  "site.title.addUser": {
+  "title.addUser": {
     "message": "Добавить пользователя",
     "description": "Divider title in the admins picker, between the existing-admins list and the lookup input."
   },
-  "site.button.addUser": {
+  "button.addUser": {
     "message": "Добавить",
     "description": "Button label to add the resolved user to the admins list."
   }

--- a/src/i18n/sr/site.json
+++ b/src/i18n/sr/site.json
@@ -506,5 +506,29 @@
   "placeholder.admins": {
     "message": "Unesite ID korisnika administratora",
     "description": "Placeholder u okviru za uređivanje administratora u podešavanjima sajta"
+  },
+  "site.message.userNotFound": {
+    "message": "Korisnik nije pronađen",
+    "description": "Shown when the user lookup endpoint returns 404 in the picker preview."
+  },
+  "site.message.editUserHint": {
+    "message": "Nalepite UUID korisnika ili unesite email, telefon ili korisničko ime da biste pronašli korisnika.",
+    "description": "Tip below the lookup input in the inviter / admin user picker dialog."
+  },
+  "site.message.editUsersEmpty": {
+    "message": "Još uvek nema administratora.",
+    "description": "Empty-state text shown when the admins list has no users."
+  },
+  "site.message.userAlreadyAdded": {
+    "message": "Već dodato",
+    "description": "Disabled-state label on the Add button when the resolved user is already in the admin list."
+  },
+  "site.title.addUser": {
+    "message": "Dodaj korisnika",
+    "description": "Divider title in the admins picker, between the existing-admins list and the lookup input."
+  },
+  "site.button.addUser": {
+    "message": "Dodaj",
+    "description": "Button label to add the resolved user to the admins list."
   }
 }

--- a/src/i18n/sr/site.json
+++ b/src/i18n/sr/site.json
@@ -507,27 +507,27 @@
     "message": "Unesite ID korisnika administratora",
     "description": "Placeholder u okviru za uređivanje administratora u podešavanjima sajta"
   },
-  "site.message.userNotFound": {
+  "message.userNotFound": {
     "message": "Korisnik nije pronađen",
     "description": "Shown when the user lookup endpoint returns 404 in the picker preview."
   },
-  "site.message.editUserHint": {
+  "message.editUserHint": {
     "message": "Nalepite UUID korisnika ili unesite email, telefon ili korisničko ime da biste pronašli korisnika.",
     "description": "Tip below the lookup input in the inviter / admin user picker dialog."
   },
-  "site.message.editUsersEmpty": {
+  "message.editUsersEmpty": {
     "message": "Još uvek nema administratora.",
     "description": "Empty-state text shown when the admins list has no users."
   },
-  "site.message.userAlreadyAdded": {
+  "message.userAlreadyAdded": {
     "message": "Već dodato",
     "description": "Disabled-state label on the Add button when the resolved user is already in the admin list."
   },
-  "site.title.addUser": {
+  "title.addUser": {
     "message": "Dodaj korisnika",
     "description": "Divider title in the admins picker, between the existing-admins list and the lookup input."
   },
-  "site.button.addUser": {
+  "button.addUser": {
     "message": "Dodaj",
     "description": "Button label to add the resolved user to the admins list."
   }

--- a/src/i18n/sv/site.json
+++ b/src/i18n/sv/site.json
@@ -506,5 +506,29 @@
   "placeholder.admins": {
     "message": "Ange administratörs användar-ID",
     "description": "Platshållare i redigeringsrutan för administratörer i webbplatsinställningar"
+  },
+  "site.message.userNotFound": {
+    "message": "Användaren hittades inte",
+    "description": "Shown when the user lookup endpoint returns 404 in the picker preview."
+  },
+  "site.message.editUserHint": {
+    "message": "Klistra in en användar-UUID, eller skriv en e-post, telefon eller användarnamn för att hitta någon.",
+    "description": "Tip below the lookup input in the inviter / admin user picker dialog."
+  },
+  "site.message.editUsersEmpty": {
+    "message": "Inga administratörer än.",
+    "description": "Empty-state text shown when the admins list has no users."
+  },
+  "site.message.userAlreadyAdded": {
+    "message": "Redan tillagd",
+    "description": "Disabled-state label on the Add button when the resolved user is already in the admin list."
+  },
+  "site.title.addUser": {
+    "message": "Lägg till användare",
+    "description": "Divider title in the admins picker, between the existing-admins list and the lookup input."
+  },
+  "site.button.addUser": {
+    "message": "Lägg till",
+    "description": "Button label to add the resolved user to the admins list."
   }
 }

--- a/src/i18n/sv/site.json
+++ b/src/i18n/sv/site.json
@@ -507,27 +507,27 @@
     "message": "Ange administratörs användar-ID",
     "description": "Platshållare i redigeringsrutan för administratörer i webbplatsinställningar"
   },
-  "site.message.userNotFound": {
+  "message.userNotFound": {
     "message": "Användaren hittades inte",
     "description": "Shown when the user lookup endpoint returns 404 in the picker preview."
   },
-  "site.message.editUserHint": {
+  "message.editUserHint": {
     "message": "Klistra in en användar-UUID, eller skriv en e-post, telefon eller användarnamn för att hitta någon.",
     "description": "Tip below the lookup input in the inviter / admin user picker dialog."
   },
-  "site.message.editUsersEmpty": {
+  "message.editUsersEmpty": {
     "message": "Inga administratörer än.",
     "description": "Empty-state text shown when the admins list has no users."
   },
-  "site.message.userAlreadyAdded": {
+  "message.userAlreadyAdded": {
     "message": "Redan tillagd",
     "description": "Disabled-state label on the Add button when the resolved user is already in the admin list."
   },
-  "site.title.addUser": {
+  "title.addUser": {
     "message": "Lägg till användare",
     "description": "Divider title in the admins picker, between the existing-admins list and the lookup input."
   },
-  "site.button.addUser": {
+  "button.addUser": {
     "message": "Lägg till",
     "description": "Button label to add the resolved user to the admins list."
   }

--- a/src/i18n/uk/site.json
+++ b/src/i18n/uk/site.json
@@ -506,5 +506,29 @@
   "placeholder.admins": {
     "message": "Введіть ID адміністратора",
     "description": "Плейсхолдер у полі редагування адміністратора в налаштуваннях сайту"
+  },
+  "site.message.userNotFound": {
+    "message": "Користувача не знайдено",
+    "description": "Shown when the user lookup endpoint returns 404 in the picker preview."
+  },
+  "site.message.editUserHint": {
+    "message": "Вставте UUID користувача або введіть email, телефон чи ім'я користувача для пошуку.",
+    "description": "Tip below the lookup input in the inviter / admin user picker dialog."
+  },
+  "site.message.editUsersEmpty": {
+    "message": "Ще немає адміністраторів.",
+    "description": "Empty-state text shown when the admins list has no users."
+  },
+  "site.message.userAlreadyAdded": {
+    "message": "Уже додано",
+    "description": "Disabled-state label on the Add button when the resolved user is already in the admin list."
+  },
+  "site.title.addUser": {
+    "message": "Додати користувача",
+    "description": "Divider title in the admins picker, between the existing-admins list and the lookup input."
+  },
+  "site.button.addUser": {
+    "message": "Додати",
+    "description": "Button label to add the resolved user to the admins list."
   }
 }

--- a/src/i18n/uk/site.json
+++ b/src/i18n/uk/site.json
@@ -507,27 +507,27 @@
     "message": "Введіть ID адміністратора",
     "description": "Плейсхолдер у полі редагування адміністратора в налаштуваннях сайту"
   },
-  "site.message.userNotFound": {
+  "message.userNotFound": {
     "message": "Користувача не знайдено",
     "description": "Shown when the user lookup endpoint returns 404 in the picker preview."
   },
-  "site.message.editUserHint": {
+  "message.editUserHint": {
     "message": "Вставте UUID користувача або введіть email, телефон чи ім'я користувача для пошуку.",
     "description": "Tip below the lookup input in the inviter / admin user picker dialog."
   },
-  "site.message.editUsersEmpty": {
+  "message.editUsersEmpty": {
     "message": "Ще немає адміністраторів.",
     "description": "Empty-state text shown when the admins list has no users."
   },
-  "site.message.userAlreadyAdded": {
+  "message.userAlreadyAdded": {
     "message": "Уже додано",
     "description": "Disabled-state label on the Add button when the resolved user is already in the admin list."
   },
-  "site.title.addUser": {
+  "title.addUser": {
     "message": "Додати користувача",
     "description": "Divider title in the admins picker, between the existing-admins list and the lookup input."
   },
-  "site.button.addUser": {
+  "button.addUser": {
     "message": "Додати",
     "description": "Button label to add the resolved user to the admins list."
   }

--- a/src/i18n/zh-CN/site.json
+++ b/src/i18n/zh-CN/site.json
@@ -507,27 +507,27 @@
     "message": "请输入管理员用户 ID",
     "description": "站点设置中管理员编辑框的占位符"
   },
-  "site.message.userNotFound": {
+  "message.userNotFound": {
     "message": "未找到该用户",
     "description": "Shown when the user lookup endpoint returns 404 in the picker preview."
   },
-  "site.message.editUserHint": {
-    "message": "粘贴用户 UUID，或输入邮箱、手机号或用户名以查找用户。",
+  "message.editUserHint": {
+    "message": "输入完整 UUID、用户名、邮箱或手机号查找用户。",
     "description": "Tip below the lookup input in the inviter / admin user picker dialog."
   },
-  "site.message.editUsersEmpty": {
+  "message.editUsersEmpty": {
     "message": "尚未添加管理员",
     "description": "Empty-state text shown when the admins list has no users."
   },
-  "site.message.userAlreadyAdded": {
+  "message.userAlreadyAdded": {
     "message": "已添加",
     "description": "Disabled-state label on the Add button when the resolved user is already in the admin list."
   },
-  "site.title.addUser": {
+  "title.addUser": {
     "message": "添加用户",
     "description": "Divider title in the admins picker, between the existing-admins list and the lookup input."
   },
-  "site.button.addUser": {
+  "button.addUser": {
     "message": "添加",
     "description": "Button label to add the resolved user to the admins list."
   }

--- a/src/i18n/zh-CN/site.json
+++ b/src/i18n/zh-CN/site.json
@@ -506,5 +506,29 @@
   "placeholder.admins": {
     "message": "请输入管理员用户 ID",
     "description": "站点设置中管理员编辑框的占位符"
+  },
+  "site.message.userNotFound": {
+    "message": "未找到该用户",
+    "description": "Shown when the user lookup endpoint returns 404 in the picker preview."
+  },
+  "site.message.editUserHint": {
+    "message": "粘贴用户 UUID，或输入邮箱、手机号或用户名以查找用户。",
+    "description": "Tip below the lookup input in the inviter / admin user picker dialog."
+  },
+  "site.message.editUsersEmpty": {
+    "message": "尚未添加管理员",
+    "description": "Empty-state text shown when the admins list has no users."
+  },
+  "site.message.userAlreadyAdded": {
+    "message": "已添加",
+    "description": "Disabled-state label on the Add button when the resolved user is already in the admin list."
+  },
+  "site.title.addUser": {
+    "message": "添加用户",
+    "description": "Divider title in the admins picker, between the existing-admins list and the lookup input."
+  },
+  "site.button.addUser": {
+    "message": "添加",
+    "description": "Button label to add the resolved user to the admins list."
   }
 }

--- a/src/i18n/zh-TW/site.json
+++ b/src/i18n/zh-TW/site.json
@@ -506,5 +506,29 @@
   "placeholder.admins": {
     "message": "請輸入管理員用戶 ID",
     "description": "站點設置中管理員編輯框的佔位符"
+  },
+  "site.message.userNotFound": {
+    "message": "未找到此使用者",
+    "description": "Shown when the user lookup endpoint returns 404 in the picker preview."
+  },
+  "site.message.editUserHint": {
+    "message": "貼上使用者 UUID，或輸入 Email、手機號碼或使用者名稱以尋找使用者。",
+    "description": "Tip below the lookup input in the inviter / admin user picker dialog."
+  },
+  "site.message.editUsersEmpty": {
+    "message": "尚未新增管理員",
+    "description": "Empty-state text shown when the admins list has no users."
+  },
+  "site.message.userAlreadyAdded": {
+    "message": "已新增",
+    "description": "Disabled-state label on the Add button when the resolved user is already in the admin list."
+  },
+  "site.title.addUser": {
+    "message": "新增使用者",
+    "description": "Divider title in the admins picker, between the existing-admins list and the lookup input."
+  },
+  "site.button.addUser": {
+    "message": "新增",
+    "description": "Button label to add the resolved user to the admins list."
   }
 }

--- a/src/i18n/zh-TW/site.json
+++ b/src/i18n/zh-TW/site.json
@@ -507,27 +507,27 @@
     "message": "請輸入管理員用戶 ID",
     "description": "站點設置中管理員編輯框的佔位符"
   },
-  "site.message.userNotFound": {
+  "message.userNotFound": {
     "message": "未找到此使用者",
     "description": "Shown when the user lookup endpoint returns 404 in the picker preview."
   },
-  "site.message.editUserHint": {
-    "message": "貼上使用者 UUID，或輸入 Email、手機號碼或使用者名稱以尋找使用者。",
+  "message.editUserHint": {
+    "message": "輸入完整 UUID、使用者名稱、信箱或手機號碼查找使用者。",
     "description": "Tip below the lookup input in the inviter / admin user picker dialog."
   },
-  "site.message.editUsersEmpty": {
+  "message.editUsersEmpty": {
     "message": "尚未新增管理員",
     "description": "Empty-state text shown when the admins list has no users."
   },
-  "site.message.userAlreadyAdded": {
+  "message.userAlreadyAdded": {
     "message": "已新增",
     "description": "Disabled-state label on the Add button when the resolved user is already in the admin list."
   },
-  "site.title.addUser": {
+  "title.addUser": {
     "message": "新增使用者",
     "description": "Divider title in the admins picker, between the existing-admins list and the lookup input."
   },
-  "site.button.addUser": {
+  "button.addUser": {
     "message": "新增",
     "description": "Button label to add the resolved user to the admins list."
   }

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -18,3 +18,14 @@ export interface IUserListResponse {
 }
 
 export interface IUserDetailResponse extends IUser {}
+
+export type IUserPublicRegistrationMethod = 'email' | 'phone' | 'github' | 'google' | 'wechat' | 'username' | 'unknown';
+
+export interface IUserPublic {
+  id: string;
+  display_name?: string;
+  nickname?: string;
+  avatar?: string;
+  registration_method?: IUserPublicRegistrationMethod;
+  contact?: string;
+}

--- a/src/operators/user.ts
+++ b/src/operators/user.ts
@@ -8,13 +8,6 @@ export interface IInviteesQuery {
   ordering?: string;
 }
 
-export interface IUserResolveQuery {
-  id?: string;
-  email?: string;
-  phone?: string;
-  username?: string;
-}
-
 class UserOperator {
   async getMe(): Promise<AxiosResponse<IUserDetailResponse>> {
     return httpClient.get('/users/me');
@@ -38,15 +31,8 @@ class UserOperator {
     return httpClient.put('/users/verify', data);
   }
 
-  async resolve(query: IUserResolveQuery): Promise<AxiosResponse<IUserPublic>> {
-    const params: Record<string, string> = {};
-    (Object.keys(query) as Array<keyof IUserResolveQuery>).forEach((key) => {
-      const value = query[key];
-      if (value) {
-        params[key] = value;
-      }
-    });
-    return httpClient.get('/users/resolve', { params });
+  async resolve(q: string): Promise<AxiosResponse<IUserPublic[]>> {
+    return httpClient.get('/users/resolve', { params: { q } });
   }
 }
 

--- a/src/operators/user.ts
+++ b/src/operators/user.ts
@@ -1,11 +1,18 @@
 import { AxiosResponse } from 'axios';
 import { httpClient } from './common';
-import { IUserDetailResponse, IUser, IUserListResponse } from '@/models';
+import { IUserDetailResponse, IUser, IUserListResponse, IUserPublic } from '@/models';
 
 export interface IInviteesQuery {
   offset?: number;
   limit?: number;
   ordering?: string;
+}
+
+export interface IUserResolveQuery {
+  id?: string;
+  email?: string;
+  phone?: string;
+  username?: string;
 }
 
 class UserOperator {
@@ -29,6 +36,17 @@ class UserOperator {
 
   async updateVerify(data: IUser): Promise<AxiosResponse<IUserDetailResponse>> {
     return httpClient.put('/users/verify', data);
+  }
+
+  async resolve(query: IUserResolveQuery): Promise<AxiosResponse<IUserPublic>> {
+    const params: Record<string, string> = {};
+    (Object.keys(query) as Array<keyof IUserResolveQuery>).forEach((key) => {
+      const value = query[key];
+      if (value) {
+        params[key] = value;
+      }
+    });
+    return httpClient.get('/users/resolve', { params });
   }
 }
 

--- a/src/operators/user.ts
+++ b/src/operators/user.ts
@@ -32,7 +32,10 @@ class UserOperator {
   }
 
   async resolve(q: string): Promise<AxiosResponse<IUserPublic[]>> {
-    return httpClient.get('/users/resolve', { params: { q } });
+    // NOTE: trailing slash is REQUIRED — `/users/<pk>` (the generic retrieve
+    // route) is registered before the router and would otherwise match
+    // `pk="resolve"` and return 404.
+    return httpClient.get('/users/resolve/', { params: { q } });
   }
 }
 


### PR DESCRIPTION
## Why

The Distribution and Site settings panels currently show three opaque UUIDs to administrators:

- `distribution.default_inviter_id`
- `distribution.force_inviter_id`
- `admins[]`

Operators have to memorize or copy/paste raw UUIDs to know who they belong to. This PR replaces the raw text/array editors with two new "aware" editors backed by AuthBackend's privacy-safe `/users/resolve/` endpoint.

## What's new

- **`IUserPublic` model + `userOperator.resolve(query)`** — calls `GET /users/resolve/?id=...&email=...&phone=...&username=...` and returns `id`, `display_name`, `nickname`, `avatar`, `registration_method` (`email|phone|github|google|wechat|username|unknown`), and a **masked** `contact` (`q***i@host` or `138***1234`, never a raw email or phone).
- **`UserChip.vue`** — small inline chip rendering avatar + display name + registration-method icon + masked contact. Module-level cache + negative-cache so the same UUID rendered in many places only fetches once. Falls back gracefully on 404 (italic short-id) and on empty input (`—` placeholder).
- **`EditUser.vue`** — replaces `EditText` for inviter id pickers. The dialog takes a single input and auto-detects what was typed (UUID / email / phone / username), debounces 400ms, and previews the matched user with a `UserChip`. Confirm only emits a real UUID — never the raw email/phone the operator typed in.
- **`EditUsers.vue`** — replaces `EditArray` for `admins[]`. Same lookup flow, but adds resolved users to a chip list with × buttons. Preserves the existing `:min='1'` / `atLeastOneAdmin` guard.
- **`Distribution.vue`** and **`Site.vue`** swap the `EditText`/`EditArray` usages for the new components and replace the raw-UUID `<span>` with stacked `UserChip`s.

## Privacy notes

- The frontend never echoes typed-in emails/phones back into the URL — the resolve query goes to `/users/resolve/`, then we drop the contact string from memory once we have the UUID.
- We never call the older `IsSuperUser`-only `/users/query/` from this UI. All resolution goes through `/users/resolve/`, which only returns the masked profile any authenticated caller is allowed to see.

## Backend dependency

- AuthBackend PR [AceDataCloud/AuthBackend#135](https://github.com/AceDataCloud/AuthBackend/pull/135) ships `/users/resolve/` + `UserPublicSerializer`. Until it deploys, the chips will silently render as 404 "unknown user" badges with the short-id fallback — the panel stays usable.

## i18n

- Added 6 new keys to all 17 locales' `site.json`: `message.userNotFound`, `message.editUserHint`, `message.editUsersEmpty`, `message.userAlreadyAdded`, `title.addUser`, `button.addUser`.
- ⚠️ The pre-existing `common.json` gap (`settings.adminOnlyHint` / `settings.officialOnlyHint` missing in 16 locales — introduced by #713) is **unrelated** to this PR and is being filled by the open auto-translate PR #714. CI's i18n-coverage check will be red until that lands; this PR adds zero new gaps.

## Screenshots

_None — pure refactor of existing settings UX, validated locally with `npx vue-tsc --noEmit` + ESLint clean._
