### PR TITLE
fix(suno/producer): release Audio element + listeners on track swap

### DIFF
--- a/change/@acedatacloud-nexior-cd0810e2-2686-46ef-b323-4d5cc50efbea.json
+++ b/change/@acedatacloud-nexior-cd0810e2-2686-46ef-b323-4d5cc50efbea.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(suno/producer): release Audio element + listeners on track swap",
+  "packageName": "@acedatacloud/nexior",
+  "email": "cqc@cuiqingcai.com",
+  "dependentChangeType": "patch"
+}

--- a/src/components/producer/player/PlayerSong.vue
+++ b/src/components/producer/player/PlayerSong.vue
@@ -14,7 +14,7 @@
 
 <script setup lang="ts">
 import OpticalDisk from '@/assets/images/disk.png';
-import { computed, watch } from 'vue';
+import { computed, onBeforeUnmount, watch } from 'vue';
 import { useStore } from 'vuex';
 
 const store = useStore();
@@ -23,50 +23,87 @@ const audio = computed({
   set: (value) => store.commit('producer/setAudio', value)
 });
 
+// Track the live `<audio>` element + an AbortController scoping its event
+// listeners outside the watcher, so we can release them when the URL
+// changes (or the component unmounts). Without this, every `audio_url`
+// swap leaked the previous Audio element AND its `loadedmetadata` /
+// `timeupdate` listeners — old tracks kept ticking timeupdate handlers
+// against a stale closure on every navigation.
+let currentAudio: HTMLAudioElement | null = null;
+let currentAbort: AbortController | null = null;
+
+const teardown = () => {
+  if (currentAudio) {
+    try {
+      currentAudio.pause();
+    } catch {
+      /* ignore — already detached */
+    }
+    // Detaching the source lets the browser GC the underlying decoder.
+    currentAudio.src = '';
+    currentAudio = null;
+  }
+  if (currentAbort) {
+    currentAbort.abort();
+    currentAbort = null;
+  }
+};
+
 // watch audio change and play
 watch(audio, (value, oldValue) => {
-  // url changed
+  // url changed — swap the underlying <audio> element
   if (value?.audio_url !== oldValue?.audio_url) {
-    console.log('audio changed', value);
-    if (value.object) {
-      console.log('111', value.object);
-      // delete old object
-      value.object.pause();
-      delete value.object;
+    teardown();
+    if (!value?.audio_url) {
+      return;
     }
     const object = new Audio(value.audio_url);
+    currentAudio = object;
+    currentAbort = new AbortController();
+    const { signal } = currentAbort;
+
     if (value.state === 'playing') {
-      object.play();
+      object.play().catch(() => {
+        /* autoplay may be blocked — ignore */
+      });
     } else {
       object.pause();
     }
 
-    // listen to the time change of audio
-    object.addEventListener('loadedmetadata', () => {
-      object.currentTime = 0;
-      object.addEventListener('timeupdate', () => {
+    object.addEventListener(
+      'loadedmetadata',
+      () => {
+        object.currentTime = 0;
+      },
+      { signal }
+    );
+    object.addEventListener(
+      'timeupdate',
+      () => {
         store.commit('producer/setAudio', {
           ...store.state.producer.audio,
           progress: object.currentTime
         });
-      });
-    });
+      },
+      { signal }
+    );
 
     store.commit('producer/setAudio', {
       ...store.state.producer.audio,
       object: object
     });
-  } else if (value?.progress !== oldValue?.progress && Math.abs(value.progress - value.object.currentTime) > 2) {
-    console.log('progress changed', value.progress);
-    const audio = store.state.producer.audio;
-    if (audio.object) {
-      audio.object.currentTime = audio.progress;
-    }
+  } else if (
+    value?.progress !== oldValue?.progress &&
+    value?.object &&
+    Math.abs(value.progress - value.object.currentTime) > 2
+  ) {
+    value.object.currentTime = value.progress;
   } else if (value?.state !== oldValue?.state) {
-    console.log('state changed', value.state);
-    if (value.object) {
+    if (value?.object) {
       if (value.state === 'playing') {
-        value.object.play();
+        value.object.play().catch(() => {
+          /* autoplay may be blocked — ignore */
+        });
       } else {
         value.object.pause();
       }
@@ -74,10 +111,11 @@ watch(audio, (value, oldValue) => {
   }
 
   if (value?.volume !== oldValue?.volume) {
-    console.log('volume changed', value.volume);
-    if (value.object) {
+    if (value?.object) {
       value.object.volume = value.volume / 100;
     }
   }
 });
+
+onBeforeUnmount(teardown);
 </script>

--- a/src/components/suno/player/PlayerSong.vue
+++ b/src/components/suno/player/PlayerSong.vue
@@ -14,7 +14,7 @@
 
 <script setup lang="ts">
 import OpticalDisk from '@/assets/images/disk.png';
-import { computed, watch } from 'vue';
+import { computed, onBeforeUnmount, watch } from 'vue';
 import { useStore } from 'vuex';
 
 const store = useStore();
@@ -23,50 +23,87 @@ const audio = computed({
   set: (value) => store.commit('suno/setAudio', value)
 });
 
+// Track the live `<audio>` element + an AbortController scoping its event
+// listeners outside the watcher, so we can release them when the URL
+// changes (or the component unmounts). Without this, every `audio_url`
+// swap leaked the previous Audio element AND its `loadedmetadata` /
+// `timeupdate` listeners — old tracks kept ticking timeupdate handlers
+// against a stale closure on every navigation.
+let currentAudio: HTMLAudioElement | null = null;
+let currentAbort: AbortController | null = null;
+
+const teardown = () => {
+  if (currentAudio) {
+    try {
+      currentAudio.pause();
+    } catch {
+      /* ignore — already detached */
+    }
+    // Detaching the source lets the browser GC the underlying decoder.
+    currentAudio.src = '';
+    currentAudio = null;
+  }
+  if (currentAbort) {
+    currentAbort.abort();
+    currentAbort = null;
+  }
+};
+
 // watch audio change and play
 watch(audio, (value, oldValue) => {
-  // url changed
+  // url changed — swap the underlying <audio> element
   if (value?.audio_url !== oldValue?.audio_url) {
-    console.log('audio changed', value);
-    if (value.object) {
-      console.log('111', value.object);
-      // delete old object
-      value.object.pause();
-      delete value.object;
+    teardown();
+    if (!value?.audio_url) {
+      return;
     }
     const object = new Audio(value.audio_url);
+    currentAudio = object;
+    currentAbort = new AbortController();
+    const { signal } = currentAbort;
+
     if (value.state === 'playing') {
-      object.play();
+      object.play().catch(() => {
+        /* autoplay may be blocked — ignore */
+      });
     } else {
       object.pause();
     }
 
-    // listen to the time change of audio
-    object.addEventListener('loadedmetadata', () => {
-      object.currentTime = 0;
-      object.addEventListener('timeupdate', () => {
+    object.addEventListener(
+      'loadedmetadata',
+      () => {
+        object.currentTime = 0;
+      },
+      { signal }
+    );
+    object.addEventListener(
+      'timeupdate',
+      () => {
         store.commit('suno/setAudio', {
           ...store.state.suno.audio,
           progress: object.currentTime
         });
-      });
-    });
+      },
+      { signal }
+    );
 
     store.commit('suno/setAudio', {
       ...store.state.suno.audio,
       object: object
     });
-  } else if (value?.progress !== oldValue?.progress && Math.abs(value.progress - value.object.currentTime) > 2) {
-    console.log('progress changed', value.progress);
-    const audio = store.state.suno.audio;
-    if (audio.object) {
-      audio.object.currentTime = audio.progress;
-    }
+  } else if (
+    value?.progress !== oldValue?.progress &&
+    value?.object &&
+    Math.abs(value.progress - value.object.currentTime) > 2
+  ) {
+    value.object.currentTime = value.progress;
   } else if (value?.state !== oldValue?.state) {
-    console.log('state changed', value.state);
-    if (value.object) {
+    if (value?.object) {
       if (value.state === 'playing') {
-        value.object.play();
+        value.object.play().catch(() => {
+          /* autoplay may be blocked — ignore */
+        });
       } else {
         value.object.pause();
       }
@@ -74,10 +111,11 @@ watch(audio, (value, oldValue) => {
   }
 
   if (value?.volume !== oldValue?.volume) {
-    console.log('volume changed', value.volume);
-    if (value.object) {
+    if (value?.object) {
       value.object.volume = value.volume / 100;
     }
   }
 });
+
+onBeforeUnmount(teardown);
 </script>


### PR DESCRIPTION
## Symptom

Suno / Producer pages leak a fresh `<audio>` element (and two event listeners) **on every track swap**:

- The user picks song A, song B, song C — the page now holds three live `HTMLAudioElement`s. The first two are paused but their decoder threads, `loadedmetadata`/`timeupdate` listeners and closures over the watcher are still alive.
- Across many swaps + page revisits this is visible as growing memory in DevTools and stale `timeupdate` callbacks firing into a closure that no longer matches what's playing.

## Root cause

Both `src/components/suno/player/PlayerSong.vue` and `src/components/producer/player/PlayerSong.vue` share the same broken pattern:

```ts
watch(audio, (value, oldValue) => {
  if (value?.audio_url !== oldValue?.audio_url) {
    if (value.object) {
      value.object.pause();
      delete value.object;          // (1) this just `delete`s a property on the
                                    //     reactive proxy — the previous Audio
                                    //     element is still rooted by closures.
    }
    const object = new Audio(value.audio_url);
    object.addEventListener('loadedmetadata', () => {
      object.currentTime = 0;
      object.addEventListener('timeupdate', () => { ... });   // (2) added but
                                                              //     never removed
    });
    ...
  }
});
```

Two compounding leaks:

1. `delete value.object` does not detach `<audio>` listeners or release the source — the browser keeps the decoder open until GC eventually picks it up (or never, while the listener closure is still live in (2)).
2. `loadedmetadata` and the nested `timeupdate` listeners are added but never `removeEventListener`-ed. They keep the old Audio reachable, defeating GC.

The component is also peppered with `console.log('audio changed', ...)`, `console.log('111', value.object)`, `console.log('progress changed', ...)`, etc.

## Fix

For both player components:

- Hoist a module-scoped `currentAudio: HTMLAudioElement | null` and `currentAbort: AbortController | null` outside the watcher so we can reach them from anywhere in the component.
- New `teardown()` helper:
  - `currentAudio.pause()` (try/catch — may already be detached)
  - `currentAudio.src = ''` so the browser can release the underlying decoder
  - `currentAbort.abort()` to detach **every** listener that was registered with the controller's `signal`.
- On URL change, call `teardown()` first, then create a fresh `Audio` + `AbortController`, register `loadedmetadata` / `timeupdate` with `{ signal }`, and stash the new refs.
- New `onBeforeUnmount(teardown)` so unmount also releases everything.
- Lifted the nested `addEventListener('timeupdate', …)` out of `loadedmetadata` — both listeners are now registered up-front and disposed together. (Behaviour unchanged: `timeupdate` only fires once playback actually starts; nothing relied on the registration being delayed.)
- Added missing `value?.object` guards in the *progress* and *state* branches (the original was already shielded for state but not progress, where `value.object.currentTime` would throw if state.audio existed without a hydrated Audio element).
- `play()` calls now `.catch(() => {})` so blocked autoplay (Safari iOS, Chrome no-gesture) doesn't surface as an unhandled rejection.
- Removed the four `console.log` debug statements per file.

The public API is unchanged: `state.suno.audio.object` (and `state.producer.audio.object`) is still the live `HTMLAudioElement` that the rest of the player components (`PlayerSlider`, `PlayerAction`, `PlayerController`, `PlayerVolumeSlider`) reach into for `currentTime`, `play()`, `pause()`, etc.

## Verification

- `npx vue-tsc --noEmit` — clean.
- `npx eslint <both files>` — clean.
- Manual: in DevTools, swap Suno tracks 5× and inspect `performance.memory.usedJSHeapSize` + the "Detached HTMLAudioElement" count in the Memory panel. Pre-fix the count grew monotonically; post-fix it returns to 1 after each swap (the live one).

## Risk

Low. Same Vuex shape, same external API. The visible behaviour change is the absence of the four debug `console.log` lines and that play() / pause() now propagates more cleanly when the user blocks autoplay.
