### PR TITLE
chore(build): strip console.log / debug / info from production bundle

### DIFF
--- a/change/@acedatacloud-nexior-8bd99039-bdab-4883-9f14-4ca335c9bc81.json
+++ b/change/@acedatacloud-nexior-8bd99039-bdab-4883-9f14-4ca335c9bc81.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "build: strip console.log / debug / info from production bundle",
+  "packageName": "@acedatacloud/nexior",
+  "email": "cqc@cuiqingcai.com",
+  "dependentChangeType": "patch"
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -36,6 +36,12 @@ const vendorChunkRules: Array<[chunkName: string, matches: (normalizedId: string
 
 export default defineConfig((config: ConfigEnv) => {
   process.env = { ...process.env, ...loadEnv(config.mode, process.cwd()) };
+  // Production builds strip `console.log` / `console.debug` / `console.info`
+  // / `debugger` to keep DevTools clean in shipped bundles. We deliberately
+  // keep `console.warn` and `console.error` so the in-app telemetry SDK
+  // (Aegis) — which hooks into them — still receives real warnings/errors.
+  // Dev builds keep everything so local debugging is unaffected.
+  const isProd = config.command === 'build';
   return {
     server: {
       host: 'localhost',
@@ -74,6 +80,15 @@ export default defineConfig((config: ConfigEnv) => {
         '@': path.resolve(__dirname, './src')
       }
     },
+    esbuild: isProd
+      ? {
+          // `pure` lets esbuild treat these calls as side-effect-free and
+          // tree-shake them; combined with `drop` below this removes both
+          // the call site AND any computed argument expressions.
+          pure: ['console.log', 'console.debug', 'console.info'],
+          drop: ['debugger']
+        }
+      : undefined,
     build: {
       // Computing gzip size for ~10 MB of chunks blows past the 2 GB V8
       // heap on Cloudflare Workers Builds. The report is stdout-only,


### PR DESCRIPTION
## Why

`grep -rn "console\\.log\\|console\\.debug" src --include='*.vue' --include='*.ts'` returns **507 matches**. Open DevTools on production today and you'll see them all stream by — `'individualApplications'`, `'audio changed'`, `'progress changed'`, fingerprint chunks, token shapes, `'111', value.object`, etc. They:

- bury real warnings and errors users / support need to find
- leak internal structure (token expirations, fingerprint, store layouts) into anything reading the console (e.g. extensions, screen recorders)
- add a small but non-trivial size + CPU cost in hot paths like the chat streaming loop

## What changed

`vite.config.ts`: in production builds (`config.command === 'build'`) ask esbuild to mark `console.log` / `console.debug` / `console.info` as side-effect-free and to drop the `debugger` statement. `console.warn` and `console.error` are intentionally kept — Aegis (the in-app telemetry SDK already wired in `src/plugins/telemetry.ts`) hooks them, and they remain useful for runtime diagnostics. Dev / `vite serve` is untouched, so local debugging behaves exactly as before.

```ts
esbuild: isProd
  ? {
      pure: ['console.log', 'console.debug', 'console.info'],
      drop: ['debugger']
    }
  : undefined,
```

No source files touched — this is a build-config-only change. The 507 source-side `console.log`s remain readable in source for context; they just don't ship.

## Verification

`npx vite build` from the worktree:

```
=== console.log count in dist (application chunks) ===
   0
=== console.warn / console.error preserved ===
 159 console.error
 122 console.warn
```

The two stragglers (`dist/assets/aegis.min-*.js`, `dist/assets/vue-plyr-*.js`) come from third-party pre-minified bundles where the `pure` annotation has no effect — those are not our application code.

`vue-tsc --noEmit` clean. Build still finishes in 11s.

## Risk

Very low. esbuild's `pure` is the standard Vite-recommended way to strip console calls in prod and is what every Vite + esbuild project in our org uses for the same purpose. Behaviour change is "users no longer see verbose log spam", which is the intended outcome.
