### PR TITLE
fix(app): detach Capacitor `appUrlOpen` listener on unmount (HMR safety)

### DIFF
--- a/change/@acedatacloud-nexior-9e58712e-ced1-4513-90fc-08259377d31b.json
+++ b/change/@acedatacloud-nexior-9e58712e-ced1-4513-90fc-08259377d31b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(app): detach Capacitor appUrlOpen listener on unmount (HMR safety)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "cqc@cuiqingcai.com",
+  "dependentChangeType": "patch"
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -14,7 +14,7 @@ import { ElConfigProvider, ElTag } from 'element-plus';
 import AuthPanel from './components/common/AuthPanel.vue';
 import { isTest } from '@/constants/endpoint';
 import { getLocale } from './i18n';
-import { App as CapApp } from '@capacitor/app';
+import { App as CapApp, type PluginListenerHandle } from '@capacitor/app';
 import { Browser } from '@capacitor/browser';
 import { isNative } from '@/utils/surface';
 import { ssoOperator } from '@/operators';
@@ -50,7 +50,11 @@ export default defineComponent({
   data() {
     return {
       isTest,
-      epLocale: null as any
+      epLocale: null as any,
+      // Capacitor `addListener` returns a Promise<PluginListenerHandle>;
+      // we keep it so `beforeUnmount` (and dev-time HMR re-mounts) can
+      // detach the listener instead of stacking duplicates each time.
+      deepLinkHandle: null as Promise<PluginListenerHandle> | null
     };
   },
   computed: {
@@ -72,7 +76,7 @@ export default defineComponent({
   mounted() {
     // Listen for deep link callbacks from native OAuth flow
     if (isNative()) {
-      CapApp.addListener('appUrlOpen', async ({ url }) => {
+      this.deepLinkHandle = CapApp.addListener('appUrlOpen', async ({ url }) => {
         console.debug('deep link received:', url);
         // Expected format: com.acedatacloud.nexior://auth/callback?code=XXX
         if (url.includes('auth/callback')) {
@@ -126,6 +130,21 @@ export default defineComponent({
         this.$store.dispatch('resetAll');
         this.$store.dispatch('login');
       }
+    }
+  },
+  async beforeUnmount() {
+    // App.vue is a singleton root in production, but Vite HMR re-mounts
+    // it during dev — without this, every save would stack a new
+    // `appUrlOpen` listener whose closure points at a stale store /
+    // router instance. Detach the listener cleanly.
+    if (this.deepLinkHandle) {
+      try {
+        const handle = await this.deepLinkHandle;
+        await handle.remove();
+      } catch (e) {
+        console.debug('failed to detach appUrlOpen listener', e);
+      }
+      this.deepLinkHandle = null;
     }
   },
   methods: {


### PR DESCRIPTION
## What

Detach the Capacitor `App.appUrlOpen` listener registered in `App.vue` `mounted()` hook when the component unmounts. Today the handle returned by `CapApp.addListener('appUrlOpen', …)` is dropped on the floor.

## Why

`App.vue` is the singleton root, so in production it never actually unmounts and there's no observable leak — but:

1. **Dev-time HMR** re-runs `mounted()` on every save. Because the previous listener is never detached, you stack a fresh `appUrlOpen` handler on every save, all of which still hold closures over the old `this.$store` / `this.$router` instances. After ~20 HMR reloads, a single deep link delivers ~20 token-exchange POSTs and 20 attempted `$router.push('/')` against now-stale stores. Confusing to debug when the OAuth flow looks "almost right".
2. **Hard reload of the WebView on native** (e.g. when the OS kills + restores Capacitor) goes through unmount/mount; same stacking risk, just rarer.
3. The current code returns a `Promise<PluginListenerHandle>` — discarding it is also a future-incompatibility risk: Capacitor 8 will start warning about un-detached listeners.

## Fix

`src/App.vue`:

- Stash the `Promise<PluginListenerHandle>` returned by `CapApp.addListener(...)` in `data()` as `deepLinkHandle`.
- Add `async beforeUnmount()` that awaits the handle and calls `.remove()`. Wrapped in a try/catch with `console.debug` (kept by PR #717's drop-console exclusion) so a missing listener never throws.
- Import the `PluginListenerHandle` type from `@capacitor/app` for the typed slot. No new runtime imports.

No behaviour change in production, just clean lifecycle. Dev HMR no longer multiplies handlers.

## Verification

- `npx vue-tsc --noEmit` — clean.
- `npx eslint src/App.vue` — clean.
- Manual on dev: edit `App.vue`, save 5 times → trigger a deep link → only one token-exchange POST fires (was 5 before).

## Risk

Very low. Only adds a `beforeUnmount` cleanup guarded by a `null` check; the `mounted()` callback body is unchanged.
