### PR TITLE
fix(top-header): keep external links inside in-app Browser on native

### DIFF
--- a/change/@acedatacloud-nexior-481048ba-e064-4106-98b1-d0a60b8ac4b3.json
+++ b/change/@acedatacloud-nexior-481048ba-e064-4106-98b1-d0a60b8ac4b3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(top-header): keep external links inside in-app Browser on native",
+  "packageName": "@acedatacloud/nexior",
+  "email": "cqc@cuiqingcai.com",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/TopHeader.vue
+++ b/src/components/common/TopHeader.vue
@@ -73,6 +73,8 @@ import { getBaseUrlAuth, withCurrentUserIdAndSite } from '@/utils';
 import { ROUTE_AUTH_LOGIN, ROUTE_CONSOLE_ROOT, ROUTE_DOWNLOAD, ROUTE_INDEX } from '@/router';
 import { ElCol, ElRow, ElDropdown, ElMenu, ElSubMenu, ElMenuItem, ElDropdownItem, ElButton } from 'element-plus';
 import Logo from './Logo.vue';
+import { Browser } from '@capacitor/browser';
+import { isNative } from '@/utils/surface';
 
 export default defineComponent({
   name: 'TopHeader',
@@ -111,7 +113,19 @@ export default defineComponent({
     }
   },
   methods: {
+    // Open an external URL. On Capacitor (iOS / Android) we want the
+    // Capacitor in-app Browser so the user stays inside the app shell;
+    // `window.open(url, '_blank')` on native ejects out to the OS default
+    // browser (Chrome / Safari) and breaks the experience. On web we
+    // keep the historical `_blank` behaviour.
     openTab(url: string) {
+      if (isNative()) {
+        Browser.open({ url }).catch((e) => {
+          console.warn('Browser.open failed, falling back to window.open', e);
+          window.open(url, '_blank');
+        });
+        return;
+      }
       window.open(url, '_blank');
     },
     onSelect(val: string | undefined) {
@@ -136,11 +150,11 @@ export default defineComponent({
     },
     onProfile() {
       const baseUrlAuth = getBaseUrlAuth();
-      window.open(withCurrentUserIdAndSite(`${baseUrlAuth}/user/profile`), '_blank');
+      this.openTab(withCurrentUserIdAndSite(`${baseUrlAuth}/user/profile`));
     },
     onVerify() {
       const baseUrlAuth = getBaseUrlAuth();
-      window.open(withCurrentUserIdAndSite(`${baseUrlAuth}/user/verify`), '_blank');
+      this.openTab(withCurrentUserIdAndSite(`${baseUrlAuth}/user/verify`));
     },
     onConsole() {
       this.$router.push({


### PR DESCRIPTION
## Symptom

On iOS / Android (Capacitor) builds, tapping any of these links in the top-right header **ejects the user out of the app** to the OS default browser (Chrome on Android, Safari on iOS):

- "API Platform" → `https://platform.acedata.cloud`
- "Support" → `https://platform.acedata.cloud/support`
- "Referral" → `https://platform.acedata.cloud/earning`
- Account dropdown → "Profile" / "Verify" → `https://auth.acedata.cloud/user/profile|verify`

The user has to tap the OS app switcher to come back, frequently losing scroll/state. Every other cross-host jump in the codebase (`AuthPanel.vue` for OAuth, `Center.vue`) already routes through `Browser.open(...)` from `@capacitor/browser`, which keeps a native in-app Safari/Chrome custom tab inside the app shell — except the `TopHeader` openings.

## Root cause

`TopHeader.vue` uses `window.open(url, '_blank')` for `openTab()`, `onProfile()`, `onVerify()`. In a Capacitor WebView `_blank` falls through to the OS browser handler and breaks the in-app experience.

## Fix

`src/components/common/TopHeader.vue`:

- Import `Browser` from `@capacitor/browser` and `isNative` from `@/utils/surface` (same pattern as `AuthPanel.vue` and `App.vue`).
- Centralise external-link opening in the existing `openTab(url)` method: on `isNative()` it calls `Browser.open({ url })` and falls back to `window.open(url, '_blank')` if that promise rejects (defensive — it shouldn't on a properly-installed plugin, but if it does the user still gets *some* browser).
- Switch `onProfile()` and `onVerify()` to call `this.openTab(...)` instead of inlining `window.open(..., '_blank')`. They were the two stragglers that bypassed the helper.

Web behaviour is unchanged (still `window.open(url, '_blank')` → new tab). Native behaviour now matches the rest of the app.

## Verification

- `npx vue-tsc --noEmit` — clean.
- `npx eslint src/components/common/TopHeader.vue` — clean.
- Browser plugin already installed (`@capacitor/browser ^8.0.1` in `package.json`, used by `App.vue` & `AuthPanel.vue`), so no new dependency.
- Manual on iOS dev build: tap "API Platform" / "Profile" → in-app Safari sheet pops up; "Done" returns to the app instead of context-switching to Safari.

## Risk

Low. Web is bytewise unchanged. Native gains the same in-app browsing the OAuth flow already uses successfully. The fallback try/catch covers the rare edge where the plugin isn't loaded (e.g. a stale build).
