### PR TITLE
feat(top-header): forward identity+site on external links; add API Keys dropdown entry

### DIFF
--- a/src/components/common/TopHeader.vue
+++ b/src/components/common/TopHeader.vue
@@ -23,21 +23,9 @@
           ></el-menu-item>
         </el-sub-menu>
         <el-menu-item v-t="'common.nav.mobileApp'" @route="undefined" @click="onDownload"></el-menu-item>
-        <el-menu-item
-          v-t="'common.nav.apiPlatform'"
-          @route="undefined"
-          @click="openTab('https://platform.acedata.cloud')"
-        ></el-menu-item>
-        <el-menu-item
-          v-t="'common.nav.support'"
-          @route="undefined"
-          @click="openTab('https://platform.acedata.cloud/support')"
-        ></el-menu-item>
-        <el-menu-item
-          v-t="'common.nav.referral'"
-          @route="undefined"
-          @click="openTab('https://platform.acedata.cloud/earning')"
-        ></el-menu-item>
+        <el-menu-item v-t="'common.nav.apiPlatform'" @route="undefined" @click="onApiPlatform"></el-menu-item>
+        <el-menu-item v-t="'common.nav.support'" @route="undefined" @click="onSupport"></el-menu-item>
+        <el-menu-item v-t="'common.nav.referral'" @route="undefined" @click="onReferral"></el-menu-item>
       </el-menu>
     </el-col>
     <el-col :md="4" :xs="11">
@@ -57,6 +45,7 @@
           <template #dropdown>
             <el-dropdown-menu>
               <el-dropdown-item @click="onProfile">{{ $t('common.button.profile') }}</el-dropdown-item>
+              <el-dropdown-item divided @click="onApiKeys">{{ $t('common.button.apiKeys') }}</el-dropdown-item>
               <el-dropdown-item @click="onLogout">{{ $t('common.button.logout') }}</el-dropdown-item>
             </el-dropdown-menu>
           </template>
@@ -155,6 +144,18 @@ export default defineComponent({
     onVerify() {
       const baseUrlAuth = getBaseUrlAuth();
       this.openTab(withCurrentUserIdAndSite(`${baseUrlAuth}/user/verify`));
+    },
+    onApiPlatform() {
+      this.openTab(withCurrentUserIdAndSite('https://platform.acedata.cloud'));
+    },
+    onApiKeys() {
+      this.openTab(withCurrentUserIdAndSite('https://platform.acedata.cloud/console/platform-tokens'));
+    },
+    onSupport() {
+      this.openTab(withCurrentUserIdAndSite('https://platform.acedata.cloud/support'));
+    },
+    onReferral() {
+      this.openTab(withCurrentUserIdAndSite('https://platform.acedata.cloud/earning'));
     },
     onConsole() {
       this.$router.push({

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -91,6 +91,10 @@
     "message": "Profile",
     "description": "Text in button for displaying user profile"
   },
+  "button.apiKeys": {
+    "message": "API Keys",
+    "description": "Text in user menu item linking to the API Keys / developer credentials page on the API platform"
+  },
   "button.console": {
     "message": "Console",
     "description": "Text in button for displaying the console page to control content on the webpage"

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -91,6 +91,10 @@
     "message": "个人资料",
     "description": "按钮中的文本，用于显示个人资料"
   },
+  "button.apiKeys": {
+    "message": "API 密钥",
+    "description": "用户菜单中跳转到 API 平台密钥/开发者凭证页面的按钮文本"
+  },
   "button.console": {
     "message": "控制台",
     "description": "按钮中的文本，用于显示控制台页面，以控制网页中某项内容"


### PR DESCRIPTION
## Why

Two related tweaks to the top header that improve the developer on-ramp:

1. **Bug fix.** The three external menu links — `API Platform` / `Support` / `Referral` — are bare `window.open('https://platform.acedata.cloud/...')` calls. On a white-label tenant subsite, a logged-in user clicking these gets dropped on `platform.acedata.cloud` as a *guest*, with the default Ace Data Cloud branding instead of the tenant's. Same root cause #709 / #711 fixed for the chat composer and SSO jumps.
2. **Discoverability.** Customers who like the product and want to try the API have to dig — there's no signposted entry from inside Nexior. Adding a tiny `API Keys ↗` row to the avatar dropdown gives them one-click access to `/console/platform-tokens` without burning screen real estate on the primary product surface.

## What changed

- **`src/components/common/TopHeader.vue`**
  - Hoist the three inline `openTab('https://...')` handlers to named methods (`onApiPlatform`, `onSupport`, `onReferral`) so each one can be wrapped in `withCurrentUserIdAndSite(...)`. Same helper #709 / #711 introduced — already imported in this file.
  - Add `onApiKeys()` → `https://platform.acedata.cloud/console/platform-tokens` (the canonical platform-token route per `PlatformFrontend/src/router/console.ts`).
  - Add the matching `<el-dropdown-item divided @click="onApiKeys">` row between Profile and Logout. The `divided` modifier visually separates the "navigate-elsewhere" entry from the in-app actions.

- **`src/i18n/en/common.json` + `src/i18n/zh-CN/common.json`** — one new key `button.apiKeys`. Following project precedent (e.g. #713), new strings ship in en + zh-CN only; the translation pipeline picks up the other 22 locales on its next run.

## What didn't change

- `withCurrentUserIdAndSite` is a no-op when there is no logged-in user, AND on the main official host (`studio.acedata.cloud`) where the default branding is already correct. So behaviour on the parent site / for anonymous visitors is byte-identical.
- No new helpers — purely a consumer of #709 / #711's `withCurrentUserIdAndSite`.
- Capacitor in-app browser flow (`openTab` → `Browser.open` on native) is unaffected; we just feed it a different URL.

## Verification

- `npx eslint src/components/common/TopHeader.vue` — clean (exit 0).
- `npx vue-tsc --noEmit` — clean (exit 0).
- `python3 -m json.tool` on both updated `common.json` files — valid.
- Manually traced: avatar dropdown shows Profile → ────── → API Keys → Logout; clicking API Keys on a tenant subsite opens platform.acedata.cloud with `?user_id=...&site=https://tenant.example.com` query params (which AuthFrontend + Platform already understand for SSO + branding).

## Risk

Low. All the wire formats are already in production (`user_id` and `site` query params parsed by AuthFrontend / PlatformFrontend). Worst case the new dropdown item is dead-clicked once; no impact on rendering or unauthenticated flow.
