### PR TITLE
feat(i18n): rename 'Platform Token' → 'Account Token' in console menu

### DIFF
--- a/src/i18n/en/console.json
+++ b/src/i18n/en/console.json
@@ -124,8 +124,8 @@
     "description": "Text in the website menu referring to cryptocurrency integration"
   },
   "menu.platformTokenIndex": {
-    "message": "Platform Token",
-    "description": "Text in the website menu, platform token refers to the token used to access the Ace Data Cloud platform"
+    "message": "Account Token",
+    "description": "Text in the website menu, account token (previously 'platform token') refers to the token used to access the Ace Data Cloud account"
   },
   "menu.publishIndex": {
     "message": "Publishing Center",

--- a/src/i18n/zh-CN/console.json
+++ b/src/i18n/zh-CN/console.json
@@ -124,8 +124,8 @@
     "description": "网站菜单中的文本，指的是加密货币的集成"
   },
   "menu.platformTokenIndex": {
-    "message": "平台令牌",
-    "description": "网站菜单中的文本，平台令牌指的是用于访问Ace Data Cloud平台的令牌"
+    "message": "账户令牌",
+    "description": "网站菜单中的文本，账户令牌（原“平台令牌”）指的是用于访问 Ace Data Cloud 账户的令牌"
   },
   "menu.publishIndex": {
     "message": "发布中心",

--- a/src/i18n/zh-TW/console.json
+++ b/src/i18n/zh-TW/console.json
@@ -124,8 +124,8 @@
     "description": "網站菜單中的文本，指的是加密貨幣的整合"
   },
   "menu.platformTokenIndex": {
-    "message": "平台令牌",
-    "description": "網站菜單中的文本，平台令牌指的是用於訪問Ace Data Cloud平台的令牌"
+    "message": "帳戶令牌",
+    "description": "網站菜單中的文本，帳戶令牌（原「平台令牌」）指的是用於訪問 Ace Data Cloud 帳戶的令牌"
   },
   "menu.publishIndex": {
     "message": "發布中心",


### PR DESCRIPTION
## Why

Customers report 「平台令牌 / Platform Token」 feels confusing — they read it as "a token for the platform" rather than "a token that represents my account". Align Nexior's console menu with the upstream PlatformFrontend rename to **「账户令牌 / Account Token」** (semantics similar to GitHub PAT — "a personal access token that represents your account").

## What

Value-only rename of the `menu.platformTokenIndex` entry in the 3 user-facing locales:

| File | Change |
| --- | --- |
| `src/i18n/zh-CN/console.json` | 平台令牌 → **账户令牌** |
| `src/i18n/zh-TW/console.json` | 平台令牌 → **帳戶令牌** |
| `src/i18n/en/console.json` | Platform Token → **Account Token** |

The `description` field on each entry was updated to match. Total diff: 3 files, 6 / 6.

## Intentionally NOT changed

- **i18n key** `menu.platformTokenIndex` — unchanged so the menu router config keeps resolving.
- **Route URL** `/console/platform-tokens` on platform.acedata.cloud — unchanged.
- **All non-EN/zh-CN/zh-TW locale files** — the same `menu.platformTokenIndex` key remains in the other 14 locales; no key set change means no fallback regression.

## CI

`python3 scripts/check_i18n_coverage.py` locally:

```
i18n key coverage OK: 17 locale(s) × 38 namespace(s) all match zh-CN.
```

(The coverage gate is key-based set equality, so a value-only rename does not require translating the other 14 locales.)

## Companion PRs

- **PlatformFrontend** — full console page + menu rename, same 3 locales.
- **PlatformBackend** — zh-CN dev docs canonical doc retitled with a 「旧称」 migration note, plus 20 satellite docs link-text sweep.
