### PR TITLE
fix(view-code): pin View code button to flex-start to fix vertical offset

### DIFF
--- a/change/@acedatacloud-nexior-408ba3bb-defc-437e-b9d2-bf726268de11.json
+++ b/change/@acedatacloud-nexior-408ba3bb-defc-437e-b9d2-bf726268de11.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Pin View code button to flex-start to fix vertical offset on result rows",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/ApiCodeButton.vue
+++ b/src/components/common/ApiCodeButton.vue
@@ -148,11 +148,14 @@ export default defineComponent({
   // text-only and have a clean text baseline. This button mixes a
   // `<font-awesome-icon>` SVG with text, which shifts the synthesized
   // baseline and makes the button visually float a few pixels lower than
-  // its peers (reported by reviewers as "high inconsistency").
+  // its peers.
   //
-  // Opt out of baseline alignment for just this button and center it on
-  // the cross axis instead, so its box top/bottom edges line up with the
-  // pure-text siblings on the same row.
-  align-self: center;
+  // `align-self: center` was tried first but still produced a visible
+  // vertical offset on production (the synthesized baseline of the
+  // siblings already sits below their box midpoint, so centering this
+  // button puts its midpoint above theirs). Pinning to `flex-start` makes
+  // the top edges line up, which is what reviewers expect when comparing a
+  // row of equal-height chips.
+  align-self: flex-start;
 }
 </style>


### PR DESCRIPTION
## Why

PR #723 introduced the "View code" button on every generation result row. To work around the parent `.operations { align-items: baseline; }` baseline shift caused by mixing an SVG icon with text inside an `<el-button>`, that PR added `align-self: center` to `.btn-api-code`.

On production the button still renders ~1–2px lower than its peers (Edit, U1–U4, V1–V4 …). Visual inspection in DevTools confirmed the centered-on-cross-axis math does not actually line the box up with the text-only siblings: those siblings already sit slightly below their own box midpoint (their synthesized baseline is the inline text baseline), so centering this button puts its midpoint above theirs and the box edges no longer match.

## What

Single-line change: `align-self: center` → `align-self: flex-start` on `.btn-api-code`.

In a `flex-wrap: wrap` row of equal-height chip-style buttons, pinning the cross-axis-start lines the top edges up directly and skips baseline math entirely — which is what reviewers expect when they scan the row.

Comment in the SCSS block updated to record why `center` was tried first and why `flex-start` is what actually works on real fonts in production.

## Files

- `src/components/common/ApiCodeButton.vue` — `align-self: center` → `flex-start` + comment refresh.
- `change/…` — beachball patch entry.

## Validation

- `npx vue-tsc -b --force` clean.
- `npm run build` clean.
- No other behavior changes; this is CSS-only.

## Related

- Follow-up hotfix to #723.
