### PR TITLE
feat(webextrator): integrate WebExtrator render + extract on /webextrator

### DIFF
--- a/change/@acedatacloud-nexior-webextrator-integration.json
+++ b/change/@acedatacloud-nexior-webextrator-integration.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(webextrator): integrate WebExtrator with /webextrator page (render + extract modes)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/Navigator.vue
+++ b/src/components/common/Navigator.vue
@@ -98,10 +98,12 @@ import {
   ROUTE_FISH_TTS_INDEX,
   ROUTE_FISH_MODEL_INDEX,
   ROUTE_KIMI_CONVERSATION,
-  ROUTE_KIMI_CONVERSATION_NEW
+  ROUTE_KIMI_CONVERSATION_NEW,
+  ROUTE_WEBEXTRATOR_INDEX
 } from '@/router/constants';
 import { SERP_LOGO } from '@/constants';
 import { ROUTE_SERP_INDEX } from '@/constants/serp';
+import { WEBEXTRATOR_LOGO } from '@/constants/webextrator';
 import {
   CHAT_MODEL_ICON_CHATGPT,
   CHAT_MODEL_ICON_DEEPSEEK,
@@ -378,6 +380,15 @@ export default defineComponent({
           logo: SERP_LOGO,
           routes: [ROUTE_SERP_INDEX],
           category: 'search'
+        });
+      }
+      if (this.$store?.state?.site?.features?.webextrator?.enabled) {
+        result.push({
+          route: { name: ROUTE_WEBEXTRATOR_INDEX },
+          displayName: this.$t('common.nav.webextrator'),
+          logo: WEBEXTRATOR_LOGO,
+          routes: [ROUTE_WEBEXTRATOR_INDEX],
+          category: 'data'
         });
       }
       if (this.direction === 'row') {

--- a/src/components/setting/Function.vue
+++ b/src/components/setting/Function.vue
@@ -115,7 +115,8 @@ const FEATURE_KEYS = [
   'producer',
   'kimi',
   'serp',
-  'fish'
+  'fish',
+  'webextrator'
 ];
 
 export default defineComponent({

--- a/src/components/webextrator/ConfigPanel.vue
+++ b/src/components/webextrator/ConfigPanel.vue
@@ -1,0 +1,78 @@
+<template>
+  <div class="flex flex-col h-full">
+    <div class="flex-1 overflow-y-auto p-5">
+      <mode-selector class="mb-4" />
+      <url-input class="mb-4" @submit="onRun" />
+      <template v-if="isExtract">
+        <expected-type-selector class="mb-4" />
+        <llm-toggle class="mb-4" />
+      </template>
+      <advanced-options class="mb-4" />
+    </div>
+    <div class="flex flex-col items-center justify-center px-5 pb-5">
+      <consumption :value="consumption" :service="service" />
+      <el-button type="primary" class="w-full" round :loading="running" :disabled="!canRun" @click="onRun">
+        <font-awesome-icon icon="fa-solid fa-bolt" class="mr-2" />
+        {{ $t(isExtract ? 'webextrator.button.extract' : 'webextrator.button.render') }}
+      </el-button>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElButton } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import ModeSelector from './config/ModeSelector.vue';
+import UrlInput from './config/UrlInput.vue';
+import ExpectedTypeSelector from './config/ExpectedTypeSelector.vue';
+import LlmToggle from './config/LlmToggle.vue';
+import AdvancedOptions from './config/AdvancedOptions.vue';
+import Consumption from '../common/Consumption.vue';
+import { getConsumption } from '@/utils';
+import { Status } from '@/models';
+
+export default defineComponent({
+  name: 'WebextratorConfigPanel',
+  components: {
+    ElButton,
+    FontAwesomeIcon,
+    ModeSelector,
+    UrlInput,
+    ExpectedTypeSelector,
+    LlmToggle,
+    AdvancedOptions,
+    Consumption
+  },
+  emits: ['run'],
+  computed: {
+    config() {
+      return this.$store.state.webextrator?.config;
+    },
+    service() {
+      return this.$store.state.webextrator?.service;
+    },
+    consumption(): number | undefined {
+      return getConsumption(this.config || {}, this.service?.cost);
+    },
+    running(): boolean {
+      return this.$store.state.webextrator?.status?.run === Status.Request;
+    },
+    isExtract(): boolean {
+      return (this.config?.mode || 'extract') === 'extract';
+    },
+    canRun(): boolean {
+      const url = (this.config?.url || '').trim();
+      // Don't fight the API with an in-browser regex; just require a scheme.
+      return /^https?:\/\//i.test(url);
+    }
+  },
+  methods: {
+    onRun() {
+      if (this.canRun) {
+        this.$emit('run');
+      }
+    }
+  }
+});
+</script>

--- a/src/components/webextrator/ResultPanel.vue
+++ b/src/components/webextrator/ResultPanel.vue
@@ -1,0 +1,313 @@
+<template>
+  <div class="h-full overflow-y-auto p-6">
+    <!-- Loading skeleton -->
+    <div v-if="running" class="max-w-4xl mx-auto py-4">
+      <div class="flex items-center gap-2 mb-3 text-[var(--el-color-primary)] text-sm">
+        <font-awesome-icon icon="fa-solid fa-circle-notch" spin />
+        <span>{{ $t('webextrator.message.running') }}</span>
+      </div>
+      <div class="mb-6 animate-pulse">
+        <div class="h-5 w-3/5 rounded bg-[var(--el-fill-color-dark)] mb-2" />
+        <div class="h-3 w-2/5 rounded bg-[var(--el-fill-color)] mb-4" />
+        <div class="h-64 w-full rounded bg-[var(--el-fill-color)] mb-3" />
+        <div class="h-3 w-full rounded bg-[var(--el-fill-color)] mb-1" />
+        <div class="h-3 w-5/6 rounded bg-[var(--el-fill-color)] mb-1" />
+        <div class="h-3 w-4/6 rounded bg-[var(--el-fill-color)]" />
+      </div>
+    </div>
+
+    <!-- Empty / initial state -->
+    <div
+      v-else-if="!response && !errorMessage"
+      class="flex flex-col items-center justify-center py-24 text-[var(--el-text-color-disabled)]"
+    >
+      <font-awesome-icon icon="fa-solid fa-globe" class="text-6xl mb-4 opacity-30" />
+      <p class="text-base mb-1">{{ $t('webextrator.description.intro') }}</p>
+      <p class="text-xs opacity-70">{{ $t('webextrator.description.introHint') }}</p>
+    </div>
+
+    <!-- Error state -->
+    <div v-else-if="errorMessage" class="max-w-4xl mx-auto py-4">
+      <el-alert type="error" :closable="false" show-icon :title="$t('webextrator.message.failed')">
+        <pre class="text-xs whitespace-pre-wrap break-words">{{ errorMessage }}</pre>
+      </el-alert>
+    </div>
+
+    <!-- Success result -->
+    <div v-else-if="data" class="max-w-4xl mx-auto">
+      <!-- Header: title, final URL, status, elapsed -->
+      <header class="mb-4">
+        <h1 class="text-xl font-semibold leading-snug mb-1 break-words text-[var(--el-text-color-primary)]">
+          {{ data.title || $t('webextrator.message.untitled') }}
+        </h1>
+        <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-[var(--el-text-color-secondary)]">
+          <a
+            v-if="finalUrl"
+            :href="finalUrl"
+            target="_blank"
+            rel="noopener"
+            class="hover:underline truncate max-w-[60%]"
+          >
+            <font-awesome-icon icon="fa-solid fa-up-right-from-square" class="mr-1" />{{ finalUrl }}
+          </a>
+          <span v-if="renderData?.status">
+            <font-awesome-icon icon="fa-solid fa-signal" class="mr-1" />{{ renderData.status }}
+          </span>
+          <span v-if="response?.elapsed">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />{{ response.elapsed.toFixed(2) }}s
+          </span>
+          <span v-if="contentTypeLabel">
+            <font-awesome-icon icon="fa-solid fa-tag" class="mr-1" />{{ contentTypeLabel }}
+          </span>
+        </div>
+        <p
+          v-if="extractData?.description"
+          class="mt-2 text-sm text-[var(--el-text-color-regular)] leading-relaxed line-clamp-3"
+        >
+          {{ extractData.description }}
+        </p>
+      </header>
+
+      <!-- Screenshot if available -->
+      <figure v-if="screenshotSrc" class="mb-5">
+        <el-image
+          :src="screenshotSrc"
+          fit="contain"
+          :preview-src-list="[screenshotSrc]"
+          preview-teleported
+          hide-on-click-modal
+          class="w-full max-h-[480px] rounded border border-[var(--app-border-subtle)] bg-[var(--el-fill-color-light)]"
+        />
+      </figure>
+
+      <!-- Tabs -->
+      <el-tabs v-model="activeTab" class="result-tabs">
+        <el-tab-pane v-if="markdown" :label="$t('webextrator.tab.markdown')" name="markdown">
+          <div class="tab-toolbar">
+            <copy-to-clipboard :content="markdown" />
+          </div>
+          <pre class="content-block">{{ markdown }}</pre>
+        </el-tab-pane>
+        <el-tab-pane v-if="plainText" :label="$t('webextrator.tab.text')" name="text">
+          <div class="tab-toolbar">
+            <copy-to-clipboard :content="plainText" />
+          </div>
+          <pre class="content-block">{{ plainText }}</pre>
+        </el-tab-pane>
+        <el-tab-pane v-if="extractData?.structured" :label="$t('webextrator.tab.structured')" name="structured">
+          <div class="tab-toolbar">
+            <copy-to-clipboard :content="structuredPretty" />
+          </div>
+          <pre class="content-block code">{{ structuredPretty }}</pre>
+        </el-tab-pane>
+        <el-tab-pane v-if="links.length" :label="`${$t('webextrator.tab.links')} (${links.length})`" name="links">
+          <div class="tab-toolbar">
+            <copy-to-clipboard :content="linksPlain" />
+          </div>
+          <ul class="links-list">
+            <li v-for="(href, i) in links" :key="i" class="truncate">
+              <a :href="href" target="_blank" rel="noopener">{{ href }}</a>
+            </li>
+          </ul>
+        </el-tab-pane>
+        <el-tab-pane v-if="images.length" :label="`${$t('webextrator.tab.images')} (${images.length})`" name="images">
+          <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-2">
+            <el-image
+              v-for="(src, i) in images"
+              :key="i"
+              :src="src"
+              fit="cover"
+              loading="lazy"
+              :preview-src-list="images"
+              :initial-index="i"
+              preview-teleported
+              hide-on-click-modal
+              class="aspect-square w-full rounded bg-[var(--el-fill-color-light)]"
+            />
+          </div>
+        </el-tab-pane>
+        <el-tab-pane v-if="html" :label="$t('webextrator.tab.html')" name="html">
+          <div class="tab-toolbar">
+            <copy-to-clipboard :content="html" />
+          </div>
+          <pre class="content-block code">{{ html }}</pre>
+        </el-tab-pane>
+        <el-tab-pane :label="$t('webextrator.tab.raw')" name="raw">
+          <div class="tab-toolbar">
+            <copy-to-clipboard :content="rawPretty" />
+          </div>
+          <pre class="content-block code">{{ rawPretty }}</pre>
+        </el-tab-pane>
+      </el-tabs>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElAlert, ElImage, ElTabs, ElTabPane } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
+import { IWebextratorExtractData, IWebextratorRenderData, IWebextratorResponse, Status } from '@/models';
+
+const isExtractData = (d: any): d is IWebextratorExtractData => !!d && d.kind !== 'render';
+
+export default defineComponent({
+  name: 'WebextratorResultPanel',
+  components: {
+    ElAlert,
+    ElImage,
+    ElTabs,
+    ElTabPane,
+    FontAwesomeIcon,
+    CopyToClipboard
+  },
+  data() {
+    return {
+      activeTab: 'markdown'
+    };
+  },
+  computed: {
+    response(): IWebextratorResponse | undefined {
+      return this.$store.state.webextrator?.response;
+    },
+    running(): boolean {
+      return this.$store.state.webextrator?.status?.run === Status.Request;
+    },
+    data() {
+      return this.response?.data;
+    },
+    renderData(): IWebextratorRenderData | undefined {
+      return this.data && (this.data as IWebextratorRenderData).kind === 'render'
+        ? (this.data as IWebextratorRenderData)
+        : undefined;
+    },
+    extractData(): IWebextratorExtractData | undefined {
+      return isExtractData(this.data) ? (this.data as IWebextratorExtractData) : undefined;
+    },
+    finalUrl(): string | undefined {
+      const d: any = this.data;
+      return d?.finalUrl || d?.final_url || d?.url;
+    },
+    contentTypeLabel(): string | undefined {
+      const d: any = this.data;
+      return d?.contentType || d?.content_type || d?.expected_type;
+    },
+    screenshotSrc(): string | undefined {
+      const src: string | undefined = (this.data as any)?.screenshot;
+      if (!src) return undefined;
+      // Accept both bare base64 and data: URLs.
+      if (src.startsWith('data:') || src.startsWith('http')) return src;
+      return `data:image/png;base64,${src}`;
+    },
+    markdown(): string {
+      const d: any = this.data;
+      return d?.markdown || d?.content || '';
+    },
+    plainText(): string {
+      const d: any = this.data;
+      return d?.text || '';
+    },
+    html(): string {
+      return (this.data as any)?.html || '';
+    },
+    links(): string[] {
+      return Array.isArray((this.data as any)?.links) ? ((this.data as any).links as string[]) : [];
+    },
+    linksPlain(): string {
+      return this.links.join('\n');
+    },
+    images(): string[] {
+      return Array.isArray((this.data as any)?.images) ? ((this.data as any).images as string[]) : [];
+    },
+    structuredPretty(): string {
+      return this.extractData?.structured ? JSON.stringify(this.extractData.structured, null, 2) : '';
+    },
+    rawPretty(): string {
+      return this.response ? JSON.stringify(this.response, null, 2) : '';
+    },
+    errorMessage(): string | undefined {
+      if (this.response?.success === false) {
+        const err = this.response?.error;
+        return err?.message || err?.code || this.$t('webextrator.message.failed');
+      }
+      return undefined;
+    }
+  },
+  watch: {
+    response: {
+      handler() {
+        this.resetTab();
+      },
+      immediate: true
+    }
+  },
+  methods: {
+    resetTab() {
+      // Pick the most useful tab automatically based on what came back.
+      if (this.markdown) {
+        this.activeTab = 'markdown';
+      } else if (this.extractData?.structured) {
+        this.activeTab = 'structured';
+      } else if (this.plainText) {
+        this.activeTab = 'text';
+      } else if (this.html) {
+        this.activeTab = 'html';
+      } else {
+        this.activeTab = 'raw';
+      }
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.result-tabs {
+  :deep(.el-tabs__content) {
+    overflow: visible;
+  }
+}
+.tab-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 6px;
+  color: var(--el-text-color-secondary);
+}
+.content-block {
+  background-color: var(--el-fill-color-light);
+  color: var(--el-text-color-primary);
+  border: 1px solid var(--app-border-subtle);
+  border-radius: 6px;
+  padding: 12px 14px;
+  max-height: 520px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 13px;
+  line-height: 1.55;
+  &.code {
+    font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+    font-size: 12px;
+    white-space: pre;
+    word-break: normal;
+  }
+}
+.links-list {
+  background-color: var(--el-fill-color-light);
+  border: 1px solid var(--app-border-subtle);
+  border-radius: 6px;
+  padding: 8px 12px;
+  max-height: 520px;
+  overflow: auto;
+  font-size: 13px;
+  li {
+    padding: 2px 0;
+    a {
+      color: var(--el-color-primary);
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+}
+</style>

--- a/src/components/webextrator/config/AdvancedOptions.vue
+++ b/src/components/webextrator/config/AdvancedOptions.vue
@@ -1,0 +1,157 @@
+<template>
+  <el-collapse v-model="active" class="advanced">
+    <el-collapse-item :title="$t('webextrator.name.advanced')" name="advanced">
+      <div class="field">
+        <h2 class="sub-title">{{ $t('webextrator.name.waitUntil') }}</h2>
+        <el-select v-model="waitUntil" class="value">
+          <el-option value="networkidle" :label="$t('webextrator.waitUntil.networkidle')" />
+          <el-option value="load" :label="$t('webextrator.waitUntil.load')" />
+          <el-option value="domcontentloaded" :label="$t('webextrator.waitUntil.domcontentloaded')" />
+          <el-option value="commit" :label="$t('webextrator.waitUntil.commit')" />
+        </el-select>
+      </div>
+      <div class="field">
+        <h2 class="sub-title">{{ $t('webextrator.name.waitForSelector') }}</h2>
+        <el-input v-model="waitForSelector" :placeholder="$t('webextrator.placeholder.waitForSelector')" />
+      </div>
+      <div class="field">
+        <h2 class="sub-title">{{ $t('webextrator.name.timeout') }}</h2>
+        <el-input-number v-model="timeout" :min="1" :max="120" :step="5" controls-position="right" class="w-full" />
+      </div>
+      <div class="field">
+        <h2 class="sub-title">{{ $t('webextrator.name.delay') }}</h2>
+        <el-input-number v-model="delay" :min="0" :max="30" :step="1" controls-position="right" class="w-full" />
+      </div>
+      <div class="field">
+        <h2 class="sub-title">{{ $t('webextrator.name.blockResources') }}</h2>
+        <el-select
+          v-model="blockResources"
+          multiple
+          collapse-tags
+          :placeholder="$t('webextrator.placeholder.blockResources')"
+          class="w-full"
+        >
+          <el-option
+            v-for="kind in resourceKinds"
+            :key="kind"
+            :label="$t(`webextrator.blockResource.${kind}`)"
+            :value="kind"
+          />
+        </el-select>
+      </div>
+    </el-collapse-item>
+  </el-collapse>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElCollapse, ElCollapseItem, ElInput, ElInputNumber, ElSelect, ElOption } from 'element-plus';
+import { IWebextratorBlockResource, IWebextratorWaitUntil } from '@/models';
+
+const RESOURCE_KINDS: IWebextratorBlockResource[] = ['image', 'font', 'media', 'stylesheet', 'xhr', 'fetch'];
+
+export default defineComponent({
+  name: 'AdvancedOptions',
+  components: {
+    ElCollapse,
+    ElCollapseItem,
+    ElInput,
+    ElInputNumber,
+    ElSelect,
+    ElOption
+  },
+  data() {
+    return {
+      // Collapse opens whenever any of its child fields is non-default;
+      // we keep it open by default since the panel is short and discovery matters.
+      active: [] as string[]
+    };
+  },
+  computed: {
+    resourceKinds() {
+      return RESOURCE_KINDS;
+    },
+    waitUntil: {
+      get(): IWebextratorWaitUntil {
+        return this.$store.state.webextrator?.config?.wait_until || 'networkidle';
+      },
+      set(val: IWebextratorWaitUntil) {
+        this.commit({ wait_until: val });
+      }
+    },
+    waitForSelector: {
+      get(): string {
+        return this.$store.state.webextrator?.config?.wait_for_selector || '';
+      },
+      set(val: string) {
+        this.commit({ wait_for_selector: val });
+      }
+    },
+    timeout: {
+      get(): number {
+        return this.$store.state.webextrator?.config?.timeout ?? 30;
+      },
+      set(val: number) {
+        this.commit({ timeout: val });
+      }
+    },
+    delay: {
+      get(): number {
+        return this.$store.state.webextrator?.config?.delay ?? 0;
+      },
+      set(val: number) {
+        this.commit({ delay: val });
+      }
+    },
+    blockResources: {
+      get(): IWebextratorBlockResource[] {
+        return this.$store.state.webextrator?.config?.block_resources || [];
+      },
+      set(val: IWebextratorBlockResource[]) {
+        this.commit({ block_resources: val });
+      }
+    }
+  },
+  methods: {
+    commit(patch: Record<string, unknown>) {
+      this.$store.commit('webextrator/setConfig', {
+        ...this.$store.state.webextrator?.config,
+        ...patch
+      });
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.advanced {
+  border: none;
+  background: transparent;
+  :deep(.el-collapse-item__header) {
+    background: transparent;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--el-text-color-regular);
+    border-bottom: none;
+  }
+  :deep(.el-collapse-item__wrap) {
+    background: transparent;
+    border-bottom: none;
+  }
+  :deep(.el-collapse-item__content) {
+    padding-bottom: 8px;
+  }
+  .field {
+    margin-bottom: 12px;
+    .sub-title {
+      font-size: 12px;
+      font-weight: 500;
+      color: var(--el-text-color-regular);
+      margin: 0 0 6px 0;
+    }
+    .value {
+      width: 100%;
+    }
+  }
+}
+</style>

--- a/src/components/webextrator/config/ExpectedTypeSelector.vue
+++ b/src/components/webextrator/config/ExpectedTypeSelector.vue
@@ -1,0 +1,60 @@
+<template>
+  <div class="field">
+    <h2 class="title font-bold">{{ $t('webextrator.name.expectedType') }}</h2>
+    <el-select v-model="value" class="value">
+      <el-option value="general" :label="$t('webextrator.expectedType.general')" />
+      <el-option value="article" :label="$t('webextrator.expectedType.article')" />
+      <el-option value="product" :label="$t('webextrator.expectedType.product')" />
+    </el-select>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElSelect, ElOption } from 'element-plus';
+import { IWebextratorExpectedType } from '@/models';
+
+export default defineComponent({
+  name: 'ExpectedTypeSelector',
+  components: {
+    ElSelect,
+    ElOption
+  },
+  computed: {
+    value: {
+      get(): IWebextratorExpectedType | undefined {
+        return this.$store.state.webextrator?.config?.expected_type;
+      },
+      set(val: IWebextratorExpectedType) {
+        this.$store.commit('webextrator/setConfig', {
+          ...this.$store.state.webextrator?.config,
+          expected_type: val
+        });
+      }
+    }
+  },
+  mounted() {
+    if (!this.value) {
+      this.value = 'general';
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.field {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+
+  .title {
+    font-size: 14px;
+    margin: 0;
+    width: 40%;
+  }
+  .value {
+    flex: 1;
+  }
+}
+</style>

--- a/src/components/webextrator/config/LlmToggle.vue
+++ b/src/components/webextrator/config/LlmToggle.vue
@@ -1,0 +1,53 @@
+<template>
+  <div class="field">
+    <h2 class="title font-bold">
+      {{ $t('webextrator.name.enableLlm') }}
+      <el-tooltip effect="dark" :content="$t('webextrator.description.enableLlm')" placement="top">
+        <font-awesome-icon icon="fa-solid fa-circle-info" class="ml-1 text-[var(--el-text-color-secondary)] text-xs" />
+      </el-tooltip>
+    </h2>
+    <el-switch v-model="value" class="value" />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElSwitch, ElTooltip } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+
+export default defineComponent({
+  name: 'LlmToggle',
+  components: {
+    ElSwitch,
+    ElTooltip,
+    FontAwesomeIcon
+  },
+  computed: {
+    value: {
+      get(): boolean {
+        return !!this.$store.state.webextrator?.config?.enable_llm;
+      },
+      set(val: boolean) {
+        this.$store.commit('webextrator/setConfig', {
+          ...this.$store.state.webextrator?.config,
+          enable_llm: val
+        });
+      }
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.field {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+
+  .title {
+    font-size: 14px;
+    margin: 0;
+  }
+}
+</style>

--- a/src/components/webextrator/config/ModeSelector.vue
+++ b/src/components/webextrator/config/ModeSelector.vue
@@ -1,0 +1,59 @@
+<template>
+  <div class="field">
+    <h2 class="title font-bold">{{ $t('webextrator.name.mode') }}</h2>
+    <el-radio-group v-model="value" class="value w-full">
+      <el-radio-button label="extract" value="extract">
+        <font-awesome-icon icon="fa-solid fa-wand-magic-sparkles" class="mr-1" />
+        {{ $t('webextrator.mode.extract') }}
+      </el-radio-button>
+      <el-radio-button label="render" value="render">
+        <font-awesome-icon icon="fa-solid fa-globe" class="mr-1" />
+        {{ $t('webextrator.mode.render') }}
+      </el-radio-button>
+    </el-radio-group>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElRadioGroup, ElRadioButton } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { IWebextratorMode } from '@/models';
+
+export default defineComponent({
+  name: 'ModeSelector',
+  components: {
+    ElRadioGroup,
+    ElRadioButton,
+    FontAwesomeIcon
+  },
+  computed: {
+    value: {
+      get(): IWebextratorMode | undefined {
+        return this.$store.state.webextrator?.config?.mode;
+      },
+      set(val: IWebextratorMode) {
+        this.$store.commit('webextrator/setConfig', {
+          ...this.$store.state.webextrator?.config,
+          mode: val
+        });
+      }
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.field {
+  .title {
+    font-size: 14px;
+    margin-bottom: 8px;
+  }
+  :deep(.el-radio-button) {
+    flex: 1;
+  }
+  :deep(.el-radio-button__inner) {
+    width: 100%;
+  }
+}
+</style>

--- a/src/components/webextrator/config/UrlInput.vue
+++ b/src/components/webextrator/config/UrlInput.vue
@@ -1,0 +1,56 @@
+<template>
+  <div class="field">
+    <h2 class="title font-bold">{{ $t('webextrator.name.url') }}</h2>
+    <el-input
+      v-model="url"
+      type="textarea"
+      :rows="2"
+      class="prompt"
+      :placeholder="$t('webextrator.placeholder.url')"
+      @keydown.enter.exact.prevent="onEnter"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElInput } from 'element-plus';
+
+export default defineComponent({
+  name: 'UrlInput',
+  components: {
+    ElInput
+  },
+  emits: ['submit'],
+  computed: {
+    url: {
+      get(): string {
+        return this.$store.state.webextrator?.config?.url || '';
+      },
+      set(val: string) {
+        this.$store.commit('webextrator/setConfig', {
+          ...this.$store.state.webextrator?.config,
+          url: val
+        });
+      }
+    }
+  },
+  methods: {
+    onEnter() {
+      this.$emit('submit');
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.field {
+  .title {
+    font-size: 14px;
+    margin-bottom: 8px;
+  }
+  .prompt {
+    resize: none;
+  }
+}
+</style>

--- a/src/constants/i18n.ts
+++ b/src/constants/i18n.ts
@@ -59,5 +59,6 @@ export const I18N_SCOPES = [
   'serp',
   'connector',
   'byok',
-  'subsite'
+  'subsite',
+  'webextrator'
 ];

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -22,6 +22,7 @@ export * from './seedream';
 export * from './seedance';
 export * from './serp';
 export * from './wan';
+export * from './webextrator';
 export * from './fish';
 export * from './mapping';
 export * from './surface';

--- a/src/constants/webextrator.ts
+++ b/src/constants/webextrator.ts
@@ -1,0 +1,6 @@
+export const WEBEXTRATOR_SERVICE_ID = '38bebded-b12d-4c1c-9a91-cdaccdd71745';
+
+export const WEBEXTRATOR_LOGO = 'https://cdn.acedata.cloud/782648959c.png';
+
+// Route name constant (defined here to avoid circular dependency with @/router/constants)
+export const ROUTE_WEBEXTRATOR_INDEX = 'webextrator-index';

--- a/src/i18n/ar/common.json
+++ b/src/i18n/ar/common.json
@@ -511,6 +511,10 @@
     "message": "SERP",
     "description": "النص في شريط التنقل للموقع، لعرض صفحة SERP، يجب عدم ترجمة هذا الحقل، يجب أن يبقى 'SERP'"
   },
+  "nav.webextrator": {
+    "message": "WebExtrator",
+    "description": "Text in the website navigation bar to display the WebExtrator page, must remain as 'WebExtrator'"
+  },
   "nav.image": {
     "message": "صورة",
     "description": "النص في شريط التنقل للموقع، لعرض صفحة الصور"

--- a/src/i18n/ar/site.json
+++ b/src/i18n/ar/site.json
@@ -151,6 +151,10 @@
     "message": "صوت السمك",
     "description": "العنوان المعروض في مربع التحرير"
   },
+  "field.featuresWebextrator": {
+    "message": "WebExtrator",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresSupport": {
     "message": "دعم العملاء",
     "description": "عرض في مربع التحرير"
@@ -454,6 +458,10 @@
   "message.featuresFish": {
     "message": "قم بتشغيل أو إيقاف وحدة ميزة صوت السمك.",
     "description": "وصف ميزة صوت السمك"
+  },
+  "message.featuresWebextrator": {
+    "message": "Enable or disable the WebExtrator feature module.",
+    "description": "Description of the WebExtrator feature"
   },
   "message.featuresLuma": {
     "message": "قم بتفعيل أو تعطيل وحدة ميزات Luma.",

--- a/src/i18n/ar/webextrator.json
+++ b/src/i18n/ar/webextrator.json
@@ -1,0 +1,202 @@
+{
+  "name.mode": {
+    "message": "Mode",
+    "description": "Label for render/extract mode toggle"
+  },
+  "name.url": {
+    "message": "URL",
+    "description": "Label for the URL input"
+  },
+  "name.expectedType": {
+    "message": "Expected Type",
+    "description": "Label for expected content type"
+  },
+  "name.enableLlm": {
+    "message": "LLM Cleanup",
+    "description": "Label for enable LLM toggle"
+  },
+  "name.advanced": {
+    "message": "Advanced",
+    "description": "Label for advanced options collapse"
+  },
+  "name.waitUntil": {
+    "message": "Wait Until",
+    "description": "Label for the wait_until field"
+  },
+  "name.waitForSelector": {
+    "message": "Wait For Selector",
+    "description": "Label for the wait_for_selector field"
+  },
+  "name.timeout": {
+    "message": "Timeout (s)",
+    "description": "Label for the timeout field"
+  },
+  "name.delay": {
+    "message": "Delay (s)",
+    "description": "Label for the delay_after_load field"
+  },
+  "name.blockResources": {
+    "message": "Block Resources",
+    "description": "Label for the block_resources multi-select"
+  },
+  "name.consumption": {
+    "message": "Cost",
+    "description": "Label for the per-call cost"
+  },
+  "mode.extract": {
+    "message": "Extract",
+    "description": "Extract mode option"
+  },
+  "mode.render": {
+    "message": "Render",
+    "description": "Render mode option"
+  },
+  "expectedType.general": {
+    "message": "General",
+    "description": "General expected type option"
+  },
+  "expectedType.article": {
+    "message": "Article",
+    "description": "Article expected type option"
+  },
+  "expectedType.product": {
+    "message": "Product",
+    "description": "Product expected type option"
+  },
+  "waitUntil.networkidle": {
+    "message": "Network Idle",
+    "description": "Wait until network idle option"
+  },
+  "waitUntil.load": {
+    "message": "Load",
+    "description": "Wait until load option"
+  },
+  "waitUntil.domcontentloaded": {
+    "message": "DOM Ready",
+    "description": "Wait until DOM content loaded option"
+  },
+  "waitUntil.commit": {
+    "message": "Commit",
+    "description": "Wait until commit option"
+  },
+  "blockResource.image": {
+    "message": "Images",
+    "description": "Block images option"
+  },
+  "blockResource.font": {
+    "message": "Fonts",
+    "description": "Block fonts option"
+  },
+  "blockResource.media": {
+    "message": "Media",
+    "description": "Block media option"
+  },
+  "blockResource.stylesheet": {
+    "message": "Stylesheets",
+    "description": "Block stylesheets option"
+  },
+  "blockResource.xhr": {
+    "message": "XHR",
+    "description": "Block XHR option"
+  },
+  "blockResource.fetch": {
+    "message": "Fetch",
+    "description": "Block fetch option"
+  },
+  "placeholder.url": {
+    "message": "https://example.com",
+    "description": "Placeholder for the URL input"
+  },
+  "placeholder.waitForSelector": {
+    "message": "CSS selector, e.g. .article-body",
+    "description": "Placeholder for the wait_for_selector input"
+  },
+  "placeholder.blockResources": {
+    "message": "Resource types to block",
+    "description": "Placeholder for the block_resources multi-select"
+  },
+  "button.extract": {
+    "message": "Extract",
+    "description": "Run extract button label"
+  },
+  "button.render": {
+    "message": "Render",
+    "description": "Run render button label"
+  },
+  "description.intro": {
+    "message": "Render and extract any web page",
+    "description": "Intro line shown in the empty result state"
+  },
+  "description.introHint": {
+    "message": "Enter a URL and choose Extract or Render to get clean content, markdown, links, screenshots, and more.",
+    "description": "Hint shown below the intro line"
+  },
+  "description.enableLlm": {
+    "message": "Use an LLM to clean and structure the extracted content. Costs additional credits.",
+    "description": "Tooltip explaining the LLM cleanup toggle"
+  },
+  "message.running": {
+    "message": "Working on it…",
+    "description": "Status while a request is in flight"
+  },
+  "message.extracting": {
+    "message": "Extracting…",
+    "description": "Status shown when extract is running"
+  },
+  "message.rendering": {
+    "message": "Rendering…",
+    "description": "Status shown when render is running"
+  },
+  "message.success": {
+    "message": "Done",
+    "description": "Toast shown on success"
+  },
+  "message.failed": {
+    "message": "Request failed",
+    "description": "Generic error message"
+  },
+  "message.usedUp": {
+    "message": "Your quota has been used up. Please top up to continue.",
+    "description": "Error shown when balance is exhausted"
+  },
+  "message.busy": {
+    "message": "Service is busy. Please try again in a moment.",
+    "description": "Error shown on rate limit"
+  },
+  "message.timeout": {
+    "message": "The page took too long to load. Try a different URL or increase the timeout.",
+    "description": "Error shown on timeout"
+  },
+  "message.untitled": {
+    "message": "Untitled",
+    "description": "Fallback title when the page has no title"
+  },
+  "tab.markdown": {
+    "message": "Markdown",
+    "description": "Markdown tab label"
+  },
+  "tab.text": {
+    "message": "Text",
+    "description": "Plain text tab label"
+  },
+  "tab.structured": {
+    "message": "Structured",
+    "description": "Structured data tab label"
+  },
+  "tab.links": {
+    "message": "Links",
+    "description": "Links tab label"
+  },
+  "tab.images": {
+    "message": "Images",
+    "description": "Images tab label"
+  },
+  "tab.html": {
+    "message": "HTML",
+    "description": "HTML tab label"
+  },
+  "tab.raw": {
+    "message": "Raw JSON",
+    "description": "Raw response tab label"
+  }
+}

--- a/src/i18n/de/common.json
+++ b/src/i18n/de/common.json
@@ -511,6 +511,10 @@
     "message": "SERP",
     "description": "Website-Navigationsleiste, um die SERP-Seite anzuzeigen, bitte dieses Feld nicht übersetzen, muss als 'SERP' beibehalten werden"
   },
+  "nav.webextrator": {
+    "message": "WebExtrator",
+    "description": "Text in the website navigation bar to display the WebExtrator page, must remain as 'WebExtrator'"
+  },
   "nav.image": {
     "message": "Bild",
     "description": "Website-Navigationsleiste, um die Bildseite anzuzeigen"

--- a/src/i18n/de/site.json
+++ b/src/i18n/de/site.json
@@ -151,6 +151,10 @@
     "message": "Fisch Audio",
     "description": "Titel, der im Bearbeitungsfeld angezeigt wird"
   },
+  "field.featuresWebextrator": {
+    "message": "WebExtrator",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresSupport": {
     "message": "Kundensupport",
     "description": "Anzeige im Bearbeitungsfeld"
@@ -454,6 +458,10 @@
   "message.featuresFish": {
     "message": "Aktivieren oder Deaktivieren des Fisch Audio Funktionsmoduls.",
     "description": "Beschreibung der Fisch Audio Funktion"
+  },
+  "message.featuresWebextrator": {
+    "message": "Enable or disable the WebExtrator feature module.",
+    "description": "Description of the WebExtrator feature"
   },
   "message.featuresLuma": {
     "message": "Luma-Funktion aktivieren oder deaktivieren.",

--- a/src/i18n/de/webextrator.json
+++ b/src/i18n/de/webextrator.json
@@ -1,0 +1,202 @@
+{
+  "name.mode": {
+    "message": "Mode",
+    "description": "Label for render/extract mode toggle"
+  },
+  "name.url": {
+    "message": "URL",
+    "description": "Label for the URL input"
+  },
+  "name.expectedType": {
+    "message": "Expected Type",
+    "description": "Label for expected content type"
+  },
+  "name.enableLlm": {
+    "message": "LLM Cleanup",
+    "description": "Label for enable LLM toggle"
+  },
+  "name.advanced": {
+    "message": "Advanced",
+    "description": "Label for advanced options collapse"
+  },
+  "name.waitUntil": {
+    "message": "Wait Until",
+    "description": "Label for the wait_until field"
+  },
+  "name.waitForSelector": {
+    "message": "Wait For Selector",
+    "description": "Label for the wait_for_selector field"
+  },
+  "name.timeout": {
+    "message": "Timeout (s)",
+    "description": "Label for the timeout field"
+  },
+  "name.delay": {
+    "message": "Delay (s)",
+    "description": "Label for the delay_after_load field"
+  },
+  "name.blockResources": {
+    "message": "Block Resources",
+    "description": "Label for the block_resources multi-select"
+  },
+  "name.consumption": {
+    "message": "Cost",
+    "description": "Label for the per-call cost"
+  },
+  "mode.extract": {
+    "message": "Extract",
+    "description": "Extract mode option"
+  },
+  "mode.render": {
+    "message": "Render",
+    "description": "Render mode option"
+  },
+  "expectedType.general": {
+    "message": "General",
+    "description": "General expected type option"
+  },
+  "expectedType.article": {
+    "message": "Article",
+    "description": "Article expected type option"
+  },
+  "expectedType.product": {
+    "message": "Product",
+    "description": "Product expected type option"
+  },
+  "waitUntil.networkidle": {
+    "message": "Network Idle",
+    "description": "Wait until network idle option"
+  },
+  "waitUntil.load": {
+    "message": "Load",
+    "description": "Wait until load option"
+  },
+  "waitUntil.domcontentloaded": {
+    "message": "DOM Ready",
+    "description": "Wait until DOM content loaded option"
+  },
+  "waitUntil.commit": {
+    "message": "Commit",
+    "description": "Wait until commit option"
+  },
+  "blockResource.image": {
+    "message": "Images",
+    "description": "Block images option"
+  },
+  "blockResource.font": {
+    "message": "Fonts",
+    "description": "Block fonts option"
+  },
+  "blockResource.media": {
+    "message": "Media",
+    "description": "Block media option"
+  },
+  "blockResource.stylesheet": {
+    "message": "Stylesheets",
+    "description": "Block stylesheets option"
+  },
+  "blockResource.xhr": {
+    "message": "XHR",
+    "description": "Block XHR option"
+  },
+  "blockResource.fetch": {
+    "message": "Fetch",
+    "description": "Block fetch option"
+  },
+  "placeholder.url": {
+    "message": "https://example.com",
+    "description": "Placeholder for the URL input"
+  },
+  "placeholder.waitForSelector": {
+    "message": "CSS selector, e.g. .article-body",
+    "description": "Placeholder for the wait_for_selector input"
+  },
+  "placeholder.blockResources": {
+    "message": "Resource types to block",
+    "description": "Placeholder for the block_resources multi-select"
+  },
+  "button.extract": {
+    "message": "Extract",
+    "description": "Run extract button label"
+  },
+  "button.render": {
+    "message": "Render",
+    "description": "Run render button label"
+  },
+  "description.intro": {
+    "message": "Render and extract any web page",
+    "description": "Intro line shown in the empty result state"
+  },
+  "description.introHint": {
+    "message": "Enter a URL and choose Extract or Render to get clean content, markdown, links, screenshots, and more.",
+    "description": "Hint shown below the intro line"
+  },
+  "description.enableLlm": {
+    "message": "Use an LLM to clean and structure the extracted content. Costs additional credits.",
+    "description": "Tooltip explaining the LLM cleanup toggle"
+  },
+  "message.running": {
+    "message": "Working on it…",
+    "description": "Status while a request is in flight"
+  },
+  "message.extracting": {
+    "message": "Extracting…",
+    "description": "Status shown when extract is running"
+  },
+  "message.rendering": {
+    "message": "Rendering…",
+    "description": "Status shown when render is running"
+  },
+  "message.success": {
+    "message": "Done",
+    "description": "Toast shown on success"
+  },
+  "message.failed": {
+    "message": "Request failed",
+    "description": "Generic error message"
+  },
+  "message.usedUp": {
+    "message": "Your quota has been used up. Please top up to continue.",
+    "description": "Error shown when balance is exhausted"
+  },
+  "message.busy": {
+    "message": "Service is busy. Please try again in a moment.",
+    "description": "Error shown on rate limit"
+  },
+  "message.timeout": {
+    "message": "The page took too long to load. Try a different URL or increase the timeout.",
+    "description": "Error shown on timeout"
+  },
+  "message.untitled": {
+    "message": "Untitled",
+    "description": "Fallback title when the page has no title"
+  },
+  "tab.markdown": {
+    "message": "Markdown",
+    "description": "Markdown tab label"
+  },
+  "tab.text": {
+    "message": "Text",
+    "description": "Plain text tab label"
+  },
+  "tab.structured": {
+    "message": "Structured",
+    "description": "Structured data tab label"
+  },
+  "tab.links": {
+    "message": "Links",
+    "description": "Links tab label"
+  },
+  "tab.images": {
+    "message": "Images",
+    "description": "Images tab label"
+  },
+  "tab.html": {
+    "message": "HTML",
+    "description": "HTML tab label"
+  },
+  "tab.raw": {
+    "message": "Raw JSON",
+    "description": "Raw response tab label"
+  }
+}

--- a/src/i18n/el/common.json
+++ b/src/i18n/el/common.json
@@ -511,6 +511,10 @@
     "message": "SERP",
     "description": "Website navigation text for displaying the SERP page, must remain as 'SERP'"
   },
+  "nav.webextrator": {
+    "message": "WebExtrator",
+    "description": "Text in the website navigation bar to display the WebExtrator page, must remain as 'WebExtrator'"
+  },
   "nav.image": {
     "message": "Εικόνα",
     "description": "Website navigation text for displaying the image page"

--- a/src/i18n/el/site.json
+++ b/src/i18n/el/site.json
@@ -151,6 +151,10 @@
     "message": "Ήχος Ψαριών",
     "description": "Τίτλος που εμφανίζεται στο πλαίσιο επεξεργασίας"
   },
+  "field.featuresWebextrator": {
+    "message": "WebExtrator",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresSupport": {
     "message": "Υποστήριξη Πελατών",
     "description": "展示在编辑框的标题"
@@ -454,6 +458,10 @@
   "message.featuresFish": {
     "message": "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Ήχου Ψαριών.",
     "description": "Περιγραφή της λειτουργίας Ήχου Ψαριών"
+  },
+  "message.featuresWebextrator": {
+    "message": "Enable or disable the WebExtrator feature module.",
+    "description": "Description of the WebExtrator feature"
   },
   "message.featuresLuma": {
     "message": "Ενεργοποίηση ή απενεργοποίηση της λειτουργίας Luma.",

--- a/src/i18n/el/webextrator.json
+++ b/src/i18n/el/webextrator.json
@@ -1,0 +1,202 @@
+{
+  "name.mode": {
+    "message": "Mode",
+    "description": "Label for render/extract mode toggle"
+  },
+  "name.url": {
+    "message": "URL",
+    "description": "Label for the URL input"
+  },
+  "name.expectedType": {
+    "message": "Expected Type",
+    "description": "Label for expected content type"
+  },
+  "name.enableLlm": {
+    "message": "LLM Cleanup",
+    "description": "Label for enable LLM toggle"
+  },
+  "name.advanced": {
+    "message": "Advanced",
+    "description": "Label for advanced options collapse"
+  },
+  "name.waitUntil": {
+    "message": "Wait Until",
+    "description": "Label for the wait_until field"
+  },
+  "name.waitForSelector": {
+    "message": "Wait For Selector",
+    "description": "Label for the wait_for_selector field"
+  },
+  "name.timeout": {
+    "message": "Timeout (s)",
+    "description": "Label for the timeout field"
+  },
+  "name.delay": {
+    "message": "Delay (s)",
+    "description": "Label for the delay_after_load field"
+  },
+  "name.blockResources": {
+    "message": "Block Resources",
+    "description": "Label for the block_resources multi-select"
+  },
+  "name.consumption": {
+    "message": "Cost",
+    "description": "Label for the per-call cost"
+  },
+  "mode.extract": {
+    "message": "Extract",
+    "description": "Extract mode option"
+  },
+  "mode.render": {
+    "message": "Render",
+    "description": "Render mode option"
+  },
+  "expectedType.general": {
+    "message": "General",
+    "description": "General expected type option"
+  },
+  "expectedType.article": {
+    "message": "Article",
+    "description": "Article expected type option"
+  },
+  "expectedType.product": {
+    "message": "Product",
+    "description": "Product expected type option"
+  },
+  "waitUntil.networkidle": {
+    "message": "Network Idle",
+    "description": "Wait until network idle option"
+  },
+  "waitUntil.load": {
+    "message": "Load",
+    "description": "Wait until load option"
+  },
+  "waitUntil.domcontentloaded": {
+    "message": "DOM Ready",
+    "description": "Wait until DOM content loaded option"
+  },
+  "waitUntil.commit": {
+    "message": "Commit",
+    "description": "Wait until commit option"
+  },
+  "blockResource.image": {
+    "message": "Images",
+    "description": "Block images option"
+  },
+  "blockResource.font": {
+    "message": "Fonts",
+    "description": "Block fonts option"
+  },
+  "blockResource.media": {
+    "message": "Media",
+    "description": "Block media option"
+  },
+  "blockResource.stylesheet": {
+    "message": "Stylesheets",
+    "description": "Block stylesheets option"
+  },
+  "blockResource.xhr": {
+    "message": "XHR",
+    "description": "Block XHR option"
+  },
+  "blockResource.fetch": {
+    "message": "Fetch",
+    "description": "Block fetch option"
+  },
+  "placeholder.url": {
+    "message": "https://example.com",
+    "description": "Placeholder for the URL input"
+  },
+  "placeholder.waitForSelector": {
+    "message": "CSS selector, e.g. .article-body",
+    "description": "Placeholder for the wait_for_selector input"
+  },
+  "placeholder.blockResources": {
+    "message": "Resource types to block",
+    "description": "Placeholder for the block_resources multi-select"
+  },
+  "button.extract": {
+    "message": "Extract",
+    "description": "Run extract button label"
+  },
+  "button.render": {
+    "message": "Render",
+    "description": "Run render button label"
+  },
+  "description.intro": {
+    "message": "Render and extract any web page",
+    "description": "Intro line shown in the empty result state"
+  },
+  "description.introHint": {
+    "message": "Enter a URL and choose Extract or Render to get clean content, markdown, links, screenshots, and more.",
+    "description": "Hint shown below the intro line"
+  },
+  "description.enableLlm": {
+    "message": "Use an LLM to clean and structure the extracted content. Costs additional credits.",
+    "description": "Tooltip explaining the LLM cleanup toggle"
+  },
+  "message.running": {
+    "message": "Working on it…",
+    "description": "Status while a request is in flight"
+  },
+  "message.extracting": {
+    "message": "Extracting…",
+    "description": "Status shown when extract is running"
+  },
+  "message.rendering": {
+    "message": "Rendering…",
+    "description": "Status shown when render is running"
+  },
+  "message.success": {
+    "message": "Done",
+    "description": "Toast shown on success"
+  },
+  "message.failed": {
+    "message": "Request failed",
+    "description": "Generic error message"
+  },
+  "message.usedUp": {
+    "message": "Your quota has been used up. Please top up to continue.",
+    "description": "Error shown when balance is exhausted"
+  },
+  "message.busy": {
+    "message": "Service is busy. Please try again in a moment.",
+    "description": "Error shown on rate limit"
+  },
+  "message.timeout": {
+    "message": "The page took too long to load. Try a different URL or increase the timeout.",
+    "description": "Error shown on timeout"
+  },
+  "message.untitled": {
+    "message": "Untitled",
+    "description": "Fallback title when the page has no title"
+  },
+  "tab.markdown": {
+    "message": "Markdown",
+    "description": "Markdown tab label"
+  },
+  "tab.text": {
+    "message": "Text",
+    "description": "Plain text tab label"
+  },
+  "tab.structured": {
+    "message": "Structured",
+    "description": "Structured data tab label"
+  },
+  "tab.links": {
+    "message": "Links",
+    "description": "Links tab label"
+  },
+  "tab.images": {
+    "message": "Images",
+    "description": "Images tab label"
+  },
+  "tab.html": {
+    "message": "HTML",
+    "description": "HTML tab label"
+  },
+  "tab.raw": {
+    "message": "Raw JSON",
+    "description": "Raw response tab label"
+  }
+}

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -511,6 +511,10 @@
     "message": "SERP",
     "description": "Text in the website navigation bar to display the SERP page, must remain as 'SERP'"
   },
+  "nav.webextrator": {
+    "message": "WebExtrator",
+    "description": "Text in the website navigation bar to display the WebExtrator page, must remain as 'WebExtrator'"
+  },
   "nav.image": {
     "message": "Image",
     "description": "Text in the website navigation bar to display the image page"

--- a/src/i18n/en/site.json
+++ b/src/i18n/en/site.json
@@ -151,6 +151,10 @@
     "message": "Fish Audio",
     "description": "Displayed as the title in the editing box"
   },
+  "field.featuresWebextrator": {
+    "message": "WebExtrator",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresSupport": {
     "message": "Customer Support",
     "description": "Displayed as the title in the editing box"
@@ -454,6 +458,10 @@
   "message.featuresFish": {
     "message": "Enable or disable the Fish Audio feature module.",
     "description": "Description of the Fish Audio feature"
+  },
+  "message.featuresWebextrator": {
+    "message": "Enable or disable the WebExtrator feature module.",
+    "description": "Description of the WebExtrator feature"
   },
   "message.featuresLuma": {
     "message": "Enable or disable the Luma feature module.",

--- a/src/i18n/en/webextrator.json
+++ b/src/i18n/en/webextrator.json
@@ -1,0 +1,202 @@
+{
+  "name.mode": {
+    "message": "Mode",
+    "description": "Label for render/extract mode toggle"
+  },
+  "name.url": {
+    "message": "URL",
+    "description": "Label for the URL input"
+  },
+  "name.expectedType": {
+    "message": "Expected Type",
+    "description": "Label for expected content type"
+  },
+  "name.enableLlm": {
+    "message": "LLM Cleanup",
+    "description": "Label for enable LLM toggle"
+  },
+  "name.advanced": {
+    "message": "Advanced",
+    "description": "Label for advanced options collapse"
+  },
+  "name.waitUntil": {
+    "message": "Wait Until",
+    "description": "Label for the wait_until field"
+  },
+  "name.waitForSelector": {
+    "message": "Wait For Selector",
+    "description": "Label for the wait_for_selector field"
+  },
+  "name.timeout": {
+    "message": "Timeout (s)",
+    "description": "Label for the timeout field"
+  },
+  "name.delay": {
+    "message": "Delay (s)",
+    "description": "Label for the delay_after_load field"
+  },
+  "name.blockResources": {
+    "message": "Block Resources",
+    "description": "Label for the block_resources multi-select"
+  },
+  "name.consumption": {
+    "message": "Cost",
+    "description": "Label for the per-call cost"
+  },
+  "mode.extract": {
+    "message": "Extract",
+    "description": "Extract mode option"
+  },
+  "mode.render": {
+    "message": "Render",
+    "description": "Render mode option"
+  },
+  "expectedType.general": {
+    "message": "General",
+    "description": "General expected type option"
+  },
+  "expectedType.article": {
+    "message": "Article",
+    "description": "Article expected type option"
+  },
+  "expectedType.product": {
+    "message": "Product",
+    "description": "Product expected type option"
+  },
+  "waitUntil.networkidle": {
+    "message": "Network Idle",
+    "description": "Wait until network idle option"
+  },
+  "waitUntil.load": {
+    "message": "Load",
+    "description": "Wait until load option"
+  },
+  "waitUntil.domcontentloaded": {
+    "message": "DOM Ready",
+    "description": "Wait until DOM content loaded option"
+  },
+  "waitUntil.commit": {
+    "message": "Commit",
+    "description": "Wait until commit option"
+  },
+  "blockResource.image": {
+    "message": "Images",
+    "description": "Block images option"
+  },
+  "blockResource.font": {
+    "message": "Fonts",
+    "description": "Block fonts option"
+  },
+  "blockResource.media": {
+    "message": "Media",
+    "description": "Block media option"
+  },
+  "blockResource.stylesheet": {
+    "message": "Stylesheets",
+    "description": "Block stylesheets option"
+  },
+  "blockResource.xhr": {
+    "message": "XHR",
+    "description": "Block XHR option"
+  },
+  "blockResource.fetch": {
+    "message": "Fetch",
+    "description": "Block fetch option"
+  },
+  "placeholder.url": {
+    "message": "https://example.com",
+    "description": "Placeholder for the URL input"
+  },
+  "placeholder.waitForSelector": {
+    "message": "CSS selector, e.g. .article-body",
+    "description": "Placeholder for the wait_for_selector input"
+  },
+  "placeholder.blockResources": {
+    "message": "Resource types to block",
+    "description": "Placeholder for the block_resources multi-select"
+  },
+  "button.extract": {
+    "message": "Extract",
+    "description": "Run extract button label"
+  },
+  "button.render": {
+    "message": "Render",
+    "description": "Run render button label"
+  },
+  "description.intro": {
+    "message": "Render and extract any web page",
+    "description": "Intro line shown in the empty result state"
+  },
+  "description.introHint": {
+    "message": "Enter a URL and choose Extract or Render to get clean content, markdown, links, screenshots, and more.",
+    "description": "Hint shown below the intro line"
+  },
+  "description.enableLlm": {
+    "message": "Use an LLM to clean and structure the extracted content. Costs additional credits.",
+    "description": "Tooltip explaining the LLM cleanup toggle"
+  },
+  "message.running": {
+    "message": "Working on it…",
+    "description": "Status while a request is in flight"
+  },
+  "message.extracting": {
+    "message": "Extracting…",
+    "description": "Status shown when extract is running"
+  },
+  "message.rendering": {
+    "message": "Rendering…",
+    "description": "Status shown when render is running"
+  },
+  "message.success": {
+    "message": "Done",
+    "description": "Toast shown on success"
+  },
+  "message.failed": {
+    "message": "Request failed",
+    "description": "Generic error message"
+  },
+  "message.usedUp": {
+    "message": "Your quota has been used up. Please top up to continue.",
+    "description": "Error shown when balance is exhausted"
+  },
+  "message.busy": {
+    "message": "Service is busy. Please try again in a moment.",
+    "description": "Error shown on rate limit"
+  },
+  "message.timeout": {
+    "message": "The page took too long to load. Try a different URL or increase the timeout.",
+    "description": "Error shown on timeout"
+  },
+  "message.untitled": {
+    "message": "Untitled",
+    "description": "Fallback title when the page has no title"
+  },
+  "tab.markdown": {
+    "message": "Markdown",
+    "description": "Markdown tab label"
+  },
+  "tab.text": {
+    "message": "Text",
+    "description": "Plain text tab label"
+  },
+  "tab.structured": {
+    "message": "Structured",
+    "description": "Structured data tab label"
+  },
+  "tab.links": {
+    "message": "Links",
+    "description": "Links tab label"
+  },
+  "tab.images": {
+    "message": "Images",
+    "description": "Images tab label"
+  },
+  "tab.html": {
+    "message": "HTML",
+    "description": "HTML tab label"
+  },
+  "tab.raw": {
+    "message": "Raw JSON",
+    "description": "Raw response tab label"
+  }
+}

--- a/src/i18n/es/common.json
+++ b/src/i18n/es/common.json
@@ -511,6 +511,10 @@
     "message": "SERP",
     "description": "网站导航栏中的文本，用于显示SERP页面，请不要翻译此字段，必须保持为'SERP'"
   },
+  "nav.webextrator": {
+    "message": "WebExtrator",
+    "description": "Text in the website navigation bar to display the WebExtrator page, must remain as 'WebExtrator'"
+  },
   "nav.image": {
     "message": "Imagen",
     "description": "网站导航栏中的文本，用于显示图片页面"

--- a/src/i18n/es/site.json
+++ b/src/i18n/es/site.json
@@ -151,6 +151,10 @@
     "message": "Audio de Pescado",
     "description": "Título mostrado en el cuadro de edición"
   },
+  "field.featuresWebextrator": {
+    "message": "WebExtrator",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresSupport": {
     "message": "Soporte al cliente",
     "description": "Texto que se muestra en el cuadro de edición"
@@ -454,6 +458,10 @@
   "message.featuresFish": {
     "message": "Activar o desactivar el módulo de Audio de Pescado.",
     "description": "Descripción de la función de Audio de Pescado"
+  },
+  "message.featuresWebextrator": {
+    "message": "Enable or disable the WebExtrator feature module.",
+    "description": "Description of the WebExtrator feature"
   },
   "message.featuresLuma": {
     "message": "Activar o desactivar el módulo de funciones de Luma.",

--- a/src/i18n/es/webextrator.json
+++ b/src/i18n/es/webextrator.json
@@ -1,0 +1,202 @@
+{
+  "name.mode": {
+    "message": "Mode",
+    "description": "Label for render/extract mode toggle"
+  },
+  "name.url": {
+    "message": "URL",
+    "description": "Label for the URL input"
+  },
+  "name.expectedType": {
+    "message": "Expected Type",
+    "description": "Label for expected content type"
+  },
+  "name.enableLlm": {
+    "message": "LLM Cleanup",
+    "description": "Label for enable LLM toggle"
+  },
+  "name.advanced": {
+    "message": "Advanced",
+    "description": "Label for advanced options collapse"
+  },
+  "name.waitUntil": {
+    "message": "Wait Until",
+    "description": "Label for the wait_until field"
+  },
+  "name.waitForSelector": {
+    "message": "Wait For Selector",
+    "description": "Label for the wait_for_selector field"
+  },
+  "name.timeout": {
+    "message": "Timeout (s)",
+    "description": "Label for the timeout field"
+  },
+  "name.delay": {
+    "message": "Delay (s)",
+    "description": "Label for the delay_after_load field"
+  },
+  "name.blockResources": {
+    "message": "Block Resources",
+    "description": "Label for the block_resources multi-select"
+  },
+  "name.consumption": {
+    "message": "Cost",
+    "description": "Label for the per-call cost"
+  },
+  "mode.extract": {
+    "message": "Extract",
+    "description": "Extract mode option"
+  },
+  "mode.render": {
+    "message": "Render",
+    "description": "Render mode option"
+  },
+  "expectedType.general": {
+    "message": "General",
+    "description": "General expected type option"
+  },
+  "expectedType.article": {
+    "message": "Article",
+    "description": "Article expected type option"
+  },
+  "expectedType.product": {
+    "message": "Product",
+    "description": "Product expected type option"
+  },
+  "waitUntil.networkidle": {
+    "message": "Network Idle",
+    "description": "Wait until network idle option"
+  },
+  "waitUntil.load": {
+    "message": "Load",
+    "description": "Wait until load option"
+  },
+  "waitUntil.domcontentloaded": {
+    "message": "DOM Ready",
+    "description": "Wait until DOM content loaded option"
+  },
+  "waitUntil.commit": {
+    "message": "Commit",
+    "description": "Wait until commit option"
+  },
+  "blockResource.image": {
+    "message": "Images",
+    "description": "Block images option"
+  },
+  "blockResource.font": {
+    "message": "Fonts",
+    "description": "Block fonts option"
+  },
+  "blockResource.media": {
+    "message": "Media",
+    "description": "Block media option"
+  },
+  "blockResource.stylesheet": {
+    "message": "Stylesheets",
+    "description": "Block stylesheets option"
+  },
+  "blockResource.xhr": {
+    "message": "XHR",
+    "description": "Block XHR option"
+  },
+  "blockResource.fetch": {
+    "message": "Fetch",
+    "description": "Block fetch option"
+  },
+  "placeholder.url": {
+    "message": "https://example.com",
+    "description": "Placeholder for the URL input"
+  },
+  "placeholder.waitForSelector": {
+    "message": "CSS selector, e.g. .article-body",
+    "description": "Placeholder for the wait_for_selector input"
+  },
+  "placeholder.blockResources": {
+    "message": "Resource types to block",
+    "description": "Placeholder for the block_resources multi-select"
+  },
+  "button.extract": {
+    "message": "Extract",
+    "description": "Run extract button label"
+  },
+  "button.render": {
+    "message": "Render",
+    "description": "Run render button label"
+  },
+  "description.intro": {
+    "message": "Render and extract any web page",
+    "description": "Intro line shown in the empty result state"
+  },
+  "description.introHint": {
+    "message": "Enter a URL and choose Extract or Render to get clean content, markdown, links, screenshots, and more.",
+    "description": "Hint shown below the intro line"
+  },
+  "description.enableLlm": {
+    "message": "Use an LLM to clean and structure the extracted content. Costs additional credits.",
+    "description": "Tooltip explaining the LLM cleanup toggle"
+  },
+  "message.running": {
+    "message": "Working on it…",
+    "description": "Status while a request is in flight"
+  },
+  "message.extracting": {
+    "message": "Extracting…",
+    "description": "Status shown when extract is running"
+  },
+  "message.rendering": {
+    "message": "Rendering…",
+    "description": "Status shown when render is running"
+  },
+  "message.success": {
+    "message": "Done",
+    "description": "Toast shown on success"
+  },
+  "message.failed": {
+    "message": "Request failed",
+    "description": "Generic error message"
+  },
+  "message.usedUp": {
+    "message": "Your quota has been used up. Please top up to continue.",
+    "description": "Error shown when balance is exhausted"
+  },
+  "message.busy": {
+    "message": "Service is busy. Please try again in a moment.",
+    "description": "Error shown on rate limit"
+  },
+  "message.timeout": {
+    "message": "The page took too long to load. Try a different URL or increase the timeout.",
+    "description": "Error shown on timeout"
+  },
+  "message.untitled": {
+    "message": "Untitled",
+    "description": "Fallback title when the page has no title"
+  },
+  "tab.markdown": {
+    "message": "Markdown",
+    "description": "Markdown tab label"
+  },
+  "tab.text": {
+    "message": "Text",
+    "description": "Plain text tab label"
+  },
+  "tab.structured": {
+    "message": "Structured",
+    "description": "Structured data tab label"
+  },
+  "tab.links": {
+    "message": "Links",
+    "description": "Links tab label"
+  },
+  "tab.images": {
+    "message": "Images",
+    "description": "Images tab label"
+  },
+  "tab.html": {
+    "message": "HTML",
+    "description": "HTML tab label"
+  },
+  "tab.raw": {
+    "message": "Raw JSON",
+    "description": "Raw response tab label"
+  }
+}

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -511,6 +511,10 @@
     "message": "SERP",
     "description": "网站导航栏中的文本，用于显示SERP页面，请不要翻译此字段，必须保持为'SERP'"
   },
+  "nav.webextrator": {
+    "message": "WebExtrator",
+    "description": "Text in the website navigation bar to display the WebExtrator page, must remain as 'WebExtrator'"
+  },
   "nav.image": {
     "message": "Kuva",
     "description": "网站导航栏中的文本，用于显示图片页面"

--- a/src/i18n/fi/site.json
+++ b/src/i18n/fi/site.json
@@ -151,6 +151,10 @@
     "message": "Kalojen ääni",
     "description": "Näytetään muokkausruudun otsikkona."
   },
+  "field.featuresWebextrator": {
+    "message": "WebExtrator",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresSupport": {
     "message": "Asiakastuki",
     "description": "Näytetään muokkausruudun otsikkona"
@@ -454,6 +458,10 @@
   "message.featuresFish": {
     "message": "Avaa tai sulje Kalojen ääni -toimintomoduuli.",
     "description": "Kalojen ääni -toiminnon kuvaus."
+  },
+  "message.featuresWebextrator": {
+    "message": "Enable or disable the WebExtrator feature module.",
+    "description": "Description of the WebExtrator feature"
   },
   "message.featuresLuma": {
     "message": "Ota käyttöön tai poista käytöstä Luma-ominaisuusmoduuli.",

--- a/src/i18n/fi/webextrator.json
+++ b/src/i18n/fi/webextrator.json
@@ -1,0 +1,202 @@
+{
+  "name.mode": {
+    "message": "Mode",
+    "description": "Label for render/extract mode toggle"
+  },
+  "name.url": {
+    "message": "URL",
+    "description": "Label for the URL input"
+  },
+  "name.expectedType": {
+    "message": "Expected Type",
+    "description": "Label for expected content type"
+  },
+  "name.enableLlm": {
+    "message": "LLM Cleanup",
+    "description": "Label for enable LLM toggle"
+  },
+  "name.advanced": {
+    "message": "Advanced",
+    "description": "Label for advanced options collapse"
+  },
+  "name.waitUntil": {
+    "message": "Wait Until",
+    "description": "Label for the wait_until field"
+  },
+  "name.waitForSelector": {
+    "message": "Wait For Selector",
+    "description": "Label for the wait_for_selector field"
+  },
+  "name.timeout": {
+    "message": "Timeout (s)",
+    "description": "Label for the timeout field"
+  },
+  "name.delay": {
+    "message": "Delay (s)",
+    "description": "Label for the delay_after_load field"
+  },
+  "name.blockResources": {
+    "message": "Block Resources",
+    "description": "Label for the block_resources multi-select"
+  },
+  "name.consumption": {
+    "message": "Cost",
+    "description": "Label for the per-call cost"
+  },
+  "mode.extract": {
+    "message": "Extract",
+    "description": "Extract mode option"
+  },
+  "mode.render": {
+    "message": "Render",
+    "description": "Render mode option"
+  },
+  "expectedType.general": {
+    "message": "General",
+    "description": "General expected type option"
+  },
+  "expectedType.article": {
+    "message": "Article",
+    "description": "Article expected type option"
+  },
+  "expectedType.product": {
+    "message": "Product",
+    "description": "Product expected type option"
+  },
+  "waitUntil.networkidle": {
+    "message": "Network Idle",
+    "description": "Wait until network idle option"
+  },
+  "waitUntil.load": {
+    "message": "Load",
+    "description": "Wait until load option"
+  },
+  "waitUntil.domcontentloaded": {
+    "message": "DOM Ready",
+    "description": "Wait until DOM content loaded option"
+  },
+  "waitUntil.commit": {
+    "message": "Commit",
+    "description": "Wait until commit option"
+  },
+  "blockResource.image": {
+    "message": "Images",
+    "description": "Block images option"
+  },
+  "blockResource.font": {
+    "message": "Fonts",
+    "description": "Block fonts option"
+  },
+  "blockResource.media": {
+    "message": "Media",
+    "description": "Block media option"
+  },
+  "blockResource.stylesheet": {
+    "message": "Stylesheets",
+    "description": "Block stylesheets option"
+  },
+  "blockResource.xhr": {
+    "message": "XHR",
+    "description": "Block XHR option"
+  },
+  "blockResource.fetch": {
+    "message": "Fetch",
+    "description": "Block fetch option"
+  },
+  "placeholder.url": {
+    "message": "https://example.com",
+    "description": "Placeholder for the URL input"
+  },
+  "placeholder.waitForSelector": {
+    "message": "CSS selector, e.g. .article-body",
+    "description": "Placeholder for the wait_for_selector input"
+  },
+  "placeholder.blockResources": {
+    "message": "Resource types to block",
+    "description": "Placeholder for the block_resources multi-select"
+  },
+  "button.extract": {
+    "message": "Extract",
+    "description": "Run extract button label"
+  },
+  "button.render": {
+    "message": "Render",
+    "description": "Run render button label"
+  },
+  "description.intro": {
+    "message": "Render and extract any web page",
+    "description": "Intro line shown in the empty result state"
+  },
+  "description.introHint": {
+    "message": "Enter a URL and choose Extract or Render to get clean content, markdown, links, screenshots, and more.",
+    "description": "Hint shown below the intro line"
+  },
+  "description.enableLlm": {
+    "message": "Use an LLM to clean and structure the extracted content. Costs additional credits.",
+    "description": "Tooltip explaining the LLM cleanup toggle"
+  },
+  "message.running": {
+    "message": "Working on it…",
+    "description": "Status while a request is in flight"
+  },
+  "message.extracting": {
+    "message": "Extracting…",
+    "description": "Status shown when extract is running"
+  },
+  "message.rendering": {
+    "message": "Rendering…",
+    "description": "Status shown when render is running"
+  },
+  "message.success": {
+    "message": "Done",
+    "description": "Toast shown on success"
+  },
+  "message.failed": {
+    "message": "Request failed",
+    "description": "Generic error message"
+  },
+  "message.usedUp": {
+    "message": "Your quota has been used up. Please top up to continue.",
+    "description": "Error shown when balance is exhausted"
+  },
+  "message.busy": {
+    "message": "Service is busy. Please try again in a moment.",
+    "description": "Error shown on rate limit"
+  },
+  "message.timeout": {
+    "message": "The page took too long to load. Try a different URL or increase the timeout.",
+    "description": "Error shown on timeout"
+  },
+  "message.untitled": {
+    "message": "Untitled",
+    "description": "Fallback title when the page has no title"
+  },
+  "tab.markdown": {
+    "message": "Markdown",
+    "description": "Markdown tab label"
+  },
+  "tab.text": {
+    "message": "Text",
+    "description": "Plain text tab label"
+  },
+  "tab.structured": {
+    "message": "Structured",
+    "description": "Structured data tab label"
+  },
+  "tab.links": {
+    "message": "Links",
+    "description": "Links tab label"
+  },
+  "tab.images": {
+    "message": "Images",
+    "description": "Images tab label"
+  },
+  "tab.html": {
+    "message": "HTML",
+    "description": "HTML tab label"
+  },
+  "tab.raw": {
+    "message": "Raw JSON",
+    "description": "Raw response tab label"
+  }
+}

--- a/src/i18n/fr/common.json
+++ b/src/i18n/fr/common.json
@@ -511,6 +511,10 @@
     "message": "SERP",
     "description": "网站导航栏中的文本，用于显示SERP页面，请不要翻译此字段，必须保持为'SERP'"
   },
+  "nav.webextrator": {
+    "message": "WebExtrator",
+    "description": "Text in the website navigation bar to display the WebExtrator page, must remain as 'WebExtrator'"
+  },
   "nav.image": {
     "message": "Image",
     "description": "网站导航栏中的文本，用于显示图片页面"

--- a/src/i18n/fr/site.json
+++ b/src/i18n/fr/site.json
@@ -151,6 +151,10 @@
     "message": "Audio de poisson",
     "description": "Titre affiché dans la zone d'édition"
   },
+  "field.featuresWebextrator": {
+    "message": "WebExtrator",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresSupport": {
     "message": "Support client",
     "description": "Affiché comme titre dans la zone d'édition"
@@ -454,6 +458,10 @@
   "message.featuresFish": {
     "message": "Activer ou désactiver le module de fonction Audio de poisson.",
     "description": "Description de la fonction Audio de poisson"
+  },
+  "message.featuresWebextrator": {
+    "message": "Enable or disable the WebExtrator feature module.",
+    "description": "Description of the WebExtrator feature"
   },
   "message.featuresLuma": {
     "message": "Activer ou désactiver le module de fonctionnalités Luma.",

--- a/src/i18n/fr/webextrator.json
+++ b/src/i18n/fr/webextrator.json
@@ -1,0 +1,202 @@
+{
+  "name.mode": {
+    "message": "Mode",
+    "description": "Label for render/extract mode toggle"
+  },
+  "name.url": {
+    "message": "URL",
+    "description": "Label for the URL input"
+  },
+  "name.expectedType": {
+    "message": "Expected Type",
+    "description": "Label for expected content type"
+  },
+  "name.enableLlm": {
+    "message": "LLM Cleanup",
+    "description": "Label for enable LLM toggle"
+  },
+  "name.advanced": {
+    "message": "Advanced",
+    "description": "Label for advanced options collapse"
+  },
+  "name.waitUntil": {
+    "message": "Wait Until",
+    "description": "Label for the wait_until field"
+  },
+  "name.waitForSelector": {
+    "message": "Wait For Selector",
+    "description": "Label for the wait_for_selector field"
+  },
+  "name.timeout": {
+    "message": "Timeout (s)",
+    "description": "Label for the timeout field"
+  },
+  "name.delay": {
+    "message": "Delay (s)",
+    "description": "Label for the delay_after_load field"
+  },
+  "name.blockResources": {
+    "message": "Block Resources",
+    "description": "Label for the block_resources multi-select"
+  },
+  "name.consumption": {
+    "message": "Cost",
+    "description": "Label for the per-call cost"
+  },
+  "mode.extract": {
+    "message": "Extract",
+    "description": "Extract mode option"
+  },
+  "mode.render": {
+    "message": "Render",
+    "description": "Render mode option"
+  },
+  "expectedType.general": {
+    "message": "General",
+    "description": "General expected type option"
+  },
+  "expectedType.article": {
+    "message": "Article",
+    "description": "Article expected type option"
+  },
+  "expectedType.product": {
+    "message": "Product",
+    "description": "Product expected type option"
+  },
+  "waitUntil.networkidle": {
+    "message": "Network Idle",
+    "description": "Wait until network idle option"
+  },
+  "waitUntil.load": {
+    "message": "Load",
+    "description": "Wait until load option"
+  },
+  "waitUntil.domcontentloaded": {
+    "message": "DOM Ready",
+    "description": "Wait until DOM content loaded option"
+  },
+  "waitUntil.commit": {
+    "message": "Commit",
+    "description": "Wait until commit option"
+  },
+  "blockResource.image": {
+    "message": "Images",
+    "description": "Block images option"
+  },
+  "blockResource.font": {
+    "message": "Fonts",
+    "description": "Block fonts option"
+  },
+  "blockResource.media": {
+    "message": "Media",
+    "description": "Block media option"
+  },
+  "blockResource.stylesheet": {
+    "message": "Stylesheets",
+    "description": "Block stylesheets option"
+  },
+  "blockResource.xhr": {
+    "message": "XHR",
+    "description": "Block XHR option"
+  },
+  "blockResource.fetch": {
+    "message": "Fetch",
+    "description": "Block fetch option"
+  },
+  "placeholder.url": {
+    "message": "https://example.com",
+    "description": "Placeholder for the URL input"
+  },
+  "placeholder.waitForSelector": {
+    "message": "CSS selector, e.g. .article-body",
+    "description": "Placeholder for the wait_for_selector input"
+  },
+  "placeholder.blockResources": {
+    "message": "Resource types to block",
+    "description": "Placeholder for the block_resources multi-select"
+  },
+  "button.extract": {
+    "message": "Extract",
+    "description": "Run extract button label"
+  },
+  "button.render": {
+    "message": "Render",
+    "description": "Run render button label"
+  },
+  "description.intro": {
+    "message": "Render and extract any web page",
+    "description": "Intro line shown in the empty result state"
+  },
+  "description.introHint": {
+    "message": "Enter a URL and choose Extract or Render to get clean content, markdown, links, screenshots, and more.",
+    "description": "Hint shown below the intro line"
+  },
+  "description.enableLlm": {
+    "message": "Use an LLM to clean and structure the extracted content. Costs additional credits.",
+    "description": "Tooltip explaining the LLM cleanup toggle"
+  },
+  "message.running": {
+    "message": "Working on it…",
+    "description": "Status while a request is in flight"
+  },
+  "message.extracting": {
+    "message": "Extracting…",
+    "description": "Status shown when extract is running"
+  },
+  "message.rendering": {
+    "message": "Rendering…",
+    "description": "Status shown when render is running"
+  },
+  "message.success": {
+    "message": "Done",
+    "description": "Toast shown on success"
+  },
+  "message.failed": {
+    "message": "Request failed",
+    "description": "Generic error message"
+  },
+  "message.usedUp": {
+    "message": "Your quota has been used up. Please top up to continue.",
+    "description": "Error shown when balance is exhausted"
+  },
+  "message.busy": {
+    "message": "Service is busy. Please try again in a moment.",
+    "description": "Error shown on rate limit"
+  },
+  "message.timeout": {
+    "message": "The page took too long to load. Try a different URL or increase the timeout.",
+    "description": "Error shown on timeout"
+  },
+  "message.untitled": {
+    "message": "Untitled",
+    "description": "Fallback title when the page has no title"
+  },
+  "tab.markdown": {
+    "message": "Markdown",
+    "description": "Markdown tab label"
+  },
+  "tab.text": {
+    "message": "Text",
+    "description": "Plain text tab label"
+  },
+  "tab.structured": {
+    "message": "Structured",
+    "description": "Structured data tab label"
+  },
+  "tab.links": {
+    "message": "Links",
+    "description": "Links tab label"
+  },
+  "tab.images": {
+    "message": "Images",
+    "description": "Images tab label"
+  },
+  "tab.html": {
+    "message": "HTML",
+    "description": "HTML tab label"
+  },
+  "tab.raw": {
+    "message": "Raw JSON",
+    "description": "Raw response tab label"
+  }
+}

--- a/src/i18n/it/common.json
+++ b/src/i18n/it/common.json
@@ -511,6 +511,10 @@
     "message": "SERP",
     "description": "Testo nella barra di navigazione del sito per visualizzare la pagina SERP, non tradurre questo campo, deve rimanere 'SERP'"
   },
+  "nav.webextrator": {
+    "message": "WebExtrator",
+    "description": "Text in the website navigation bar to display the WebExtrator page, must remain as 'WebExtrator'"
+  },
   "nav.image": {
     "message": "Immagini",
     "description": "Testo nella barra di navigazione del sito per visualizzare la pagina delle immagini"

--- a/src/i18n/it/site.json
+++ b/src/i18n/it/site.json
@@ -151,6 +151,10 @@
     "message": "Fish Audio",
     "description": "Titolo mostrato nella casella di modifica"
   },
+  "field.featuresWebextrator": {
+    "message": "WebExtrator",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresSupport": {
     "message": "Supporto clienti",
     "description": "Mostrato nel campo di modifica del titolo"
@@ -454,6 +458,10 @@
   "message.featuresFish": {
     "message": "Attiva o disattiva il modulo Fish Audio.",
     "description": "Descrizione della funzionalità Fish Audio"
+  },
+  "message.featuresWebextrator": {
+    "message": "Enable or disable the WebExtrator feature module.",
+    "description": "Description of the WebExtrator feature"
   },
   "message.featuresLuma": {
     "message": "Attiva o disattiva il modulo funzionale Luma.",

--- a/src/i18n/it/webextrator.json
+++ b/src/i18n/it/webextrator.json
@@ -1,0 +1,202 @@
+{
+  "name.mode": {
+    "message": "Mode",
+    "description": "Label for render/extract mode toggle"
+  },
+  "name.url": {
+    "message": "URL",
+    "description": "Label for the URL input"
+  },
+  "name.expectedType": {
+    "message": "Expected Type",
+    "description": "Label for expected content type"
+  },
+  "name.enableLlm": {
+    "message": "LLM Cleanup",
+    "description": "Label for enable LLM toggle"
+  },
+  "name.advanced": {
+    "message": "Advanced",
+    "description": "Label for advanced options collapse"
+  },
+  "name.waitUntil": {
+    "message": "Wait Until",
+    "description": "Label for the wait_until field"
+  },
+  "name.waitForSelector": {
+    "message": "Wait For Selector",
+    "description": "Label for the wait_for_selector field"
+  },
+  "name.timeout": {
+    "message": "Timeout (s)",
+    "description": "Label for the timeout field"
+  },
+  "name.delay": {
+    "message": "Delay (s)",
+    "description": "Label for the delay_after_load field"
+  },
+  "name.blockResources": {
+    "message": "Block Resources",
+    "description": "Label for the block_resources multi-select"
+  },
+  "name.consumption": {
+    "message": "Cost",
+    "description": "Label for the per-call cost"
+  },
+  "mode.extract": {
+    "message": "Extract",
+    "description": "Extract mode option"
+  },
+  "mode.render": {
+    "message": "Render",
+    "description": "Render mode option"
+  },
+  "expectedType.general": {
+    "message": "General",
+    "description": "General expected type option"
+  },
+  "expectedType.article": {
+    "message": "Article",
+    "description": "Article expected type option"
+  },
+  "expectedType.product": {
+    "message": "Product",
+    "description": "Product expected type option"
+  },
+  "waitUntil.networkidle": {
+    "message": "Network Idle",
+    "description": "Wait until network idle option"
+  },
+  "waitUntil.load": {
+    "message": "Load",
+    "description": "Wait until load option"
+  },
+  "waitUntil.domcontentloaded": {
+    "message": "DOM Ready",
+    "description": "Wait until DOM content loaded option"
+  },
+  "waitUntil.commit": {
+    "message": "Commit",
+    "description": "Wait until commit option"
+  },
+  "blockResource.image": {
+    "message": "Images",
+    "description": "Block images option"
+  },
+  "blockResource.font": {
+    "message": "Fonts",
+    "description": "Block fonts option"
+  },
+  "blockResource.media": {
+    "message": "Media",
+    "description": "Block media option"
+  },
+  "blockResource.stylesheet": {
+    "message": "Stylesheets",
+    "description": "Block stylesheets option"
+  },
+  "blockResource.xhr": {
+    "message": "XHR",
+    "description": "Block XHR option"
+  },
+  "blockResource.fetch": {
+    "message": "Fetch",
+    "description": "Block fetch option"
+  },
+  "placeholder.url": {
+    "message": "https://example.com",
+    "description": "Placeholder for the URL input"
+  },
+  "placeholder.waitForSelector": {
+    "message": "CSS selector, e.g. .article-body",
+    "description": "Placeholder for the wait_for_selector input"
+  },
+  "placeholder.blockResources": {
+    "message": "Resource types to block",
+    "description": "Placeholder for the block_resources multi-select"
+  },
+  "button.extract": {
+    "message": "Extract",
+    "description": "Run extract button label"
+  },
+  "button.render": {
+    "message": "Render",
+    "description": "Run render button label"
+  },
+  "description.intro": {
+    "message": "Render and extract any web page",
+    "description": "Intro line shown in the empty result state"
+  },
+  "description.introHint": {
+    "message": "Enter a URL and choose Extract or Render to get clean content, markdown, links, screenshots, and more.",
+    "description": "Hint shown below the intro line"
+  },
+  "description.enableLlm": {
+    "message": "Use an LLM to clean and structure the extracted content. Costs additional credits.",
+    "description": "Tooltip explaining the LLM cleanup toggle"
+  },
+  "message.running": {
+    "message": "Working on it…",
+    "description": "Status while a request is in flight"
+  },
+  "message.extracting": {
+    "message": "Extracting…",
+    "description": "Status shown when extract is running"
+  },
+  "message.rendering": {
+    "message": "Rendering…",
+    "description": "Status shown when render is running"
+  },
+  "message.success": {
+    "message": "Done",
+    "description": "Toast shown on success"
+  },
+  "message.failed": {
+    "message": "Request failed",
+    "description": "Generic error message"
+  },
+  "message.usedUp": {
+    "message": "Your quota has been used up. Please top up to continue.",
+    "description": "Error shown when balance is exhausted"
+  },
+  "message.busy": {
+    "message": "Service is busy. Please try again in a moment.",
+    "description": "Error shown on rate limit"
+  },
+  "message.timeout": {
+    "message": "The page took too long to load. Try a different URL or increase the timeout.",
+    "description": "Error shown on timeout"
+  },
+  "message.untitled": {
+    "message": "Untitled",
+    "description": "Fallback title when the page has no title"
+  },
+  "tab.markdown": {
+    "message": "Markdown",
+    "description": "Markdown tab label"
+  },
+  "tab.text": {
+    "message": "Text",
+    "description": "Plain text tab label"
+  },
+  "tab.structured": {
+    "message": "Structured",
+    "description": "Structured data tab label"
+  },
+  "tab.links": {
+    "message": "Links",
+    "description": "Links tab label"
+  },
+  "tab.images": {
+    "message": "Images",
+    "description": "Images tab label"
+  },
+  "tab.html": {
+    "message": "HTML",
+    "description": "HTML tab label"
+  },
+  "tab.raw": {
+    "message": "Raw JSON",
+    "description": "Raw response tab label"
+  }
+}

--- a/src/i18n/ja/common.json
+++ b/src/i18n/ja/common.json
@@ -511,6 +511,10 @@
     "message": "SERP",
     "description": "ウェブサイトのナビゲーションバーのテキストで、SERPページを表示するためのものです。このフィールドは翻訳しないでください。'SERP'のままにしてください。"
   },
+  "nav.webextrator": {
+    "message": "WebExtrator",
+    "description": "Text in the website navigation bar to display the WebExtrator page, must remain as 'WebExtrator'"
+  },
   "nav.image": {
     "message": "画像",
     "description": "ウェブサイトのナビゲーションバーのテキストで、画像ページを表示するためのものです。"

--- a/src/i18n/ja/site.json
+++ b/src/i18n/ja/site.json
@@ -151,6 +151,10 @@
     "message": "フィッシュオーディオ",
     "description": "編集ボックスに表示されるタイトル"
   },
+  "field.featuresWebextrator": {
+    "message": "WebExtrator",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresSupport": {
     "message": "カスタマーサポート",
     "description": "編集ボックスに表示されるタイトル"
@@ -454,6 +458,10 @@
   "message.featuresFish": {
     "message": "フィッシュオーディオ機能モジュールをオンまたはオフにします。",
     "description": "フィッシュオーディオ機能の説明"
+  },
+  "message.featuresWebextrator": {
+    "message": "Enable or disable the WebExtrator feature module.",
+    "description": "Description of the WebExtrator feature"
   },
   "message.featuresLuma": {
     "message": "Luma 機能モジュールを有効または無効にします。",

--- a/src/i18n/ja/webextrator.json
+++ b/src/i18n/ja/webextrator.json
@@ -1,0 +1,202 @@
+{
+  "name.mode": {
+    "message": "Mode",
+    "description": "Label for render/extract mode toggle"
+  },
+  "name.url": {
+    "message": "URL",
+    "description": "Label for the URL input"
+  },
+  "name.expectedType": {
+    "message": "Expected Type",
+    "description": "Label for expected content type"
+  },
+  "name.enableLlm": {
+    "message": "LLM Cleanup",
+    "description": "Label for enable LLM toggle"
+  },
+  "name.advanced": {
+    "message": "Advanced",
+    "description": "Label for advanced options collapse"
+  },
+  "name.waitUntil": {
+    "message": "Wait Until",
+    "description": "Label for the wait_until field"
+  },
+  "name.waitForSelector": {
+    "message": "Wait For Selector",
+    "description": "Label for the wait_for_selector field"
+  },
+  "name.timeout": {
+    "message": "Timeout (s)",
+    "description": "Label for the timeout field"
+  },
+  "name.delay": {
+    "message": "Delay (s)",
+    "description": "Label for the delay_after_load field"
+  },
+  "name.blockResources": {
+    "message": "Block Resources",
+    "description": "Label for the block_resources multi-select"
+  },
+  "name.consumption": {
+    "message": "Cost",
+    "description": "Label for the per-call cost"
+  },
+  "mode.extract": {
+    "message": "Extract",
+    "description": "Extract mode option"
+  },
+  "mode.render": {
+    "message": "Render",
+    "description": "Render mode option"
+  },
+  "expectedType.general": {
+    "message": "General",
+    "description": "General expected type option"
+  },
+  "expectedType.article": {
+    "message": "Article",
+    "description": "Article expected type option"
+  },
+  "expectedType.product": {
+    "message": "Product",
+    "description": "Product expected type option"
+  },
+  "waitUntil.networkidle": {
+    "message": "Network Idle",
+    "description": "Wait until network idle option"
+  },
+  "waitUntil.load": {
+    "message": "Load",
+    "description": "Wait until load option"
+  },
+  "waitUntil.domcontentloaded": {
+    "message": "DOM Ready",
+    "description": "Wait until DOM content loaded option"
+  },
+  "waitUntil.commit": {
+    "message": "Commit",
+    "description": "Wait until commit option"
+  },
+  "blockResource.image": {
+    "message": "Images",
+    "description": "Block images option"
+  },
+  "blockResource.font": {
+    "message": "Fonts",
+    "description": "Block fonts option"
+  },
+  "blockResource.media": {
+    "message": "Media",
+    "description": "Block media option"
+  },
+  "blockResource.stylesheet": {
+    "message": "Stylesheets",
+    "description": "Block stylesheets option"
+  },
+  "blockResource.xhr": {
+    "message": "XHR",
+    "description": "Block XHR option"
+  },
+  "blockResource.fetch": {
+    "message": "Fetch",
+    "description": "Block fetch option"
+  },
+  "placeholder.url": {
+    "message": "https://example.com",
+    "description": "Placeholder for the URL input"
+  },
+  "placeholder.waitForSelector": {
+    "message": "CSS selector, e.g. .article-body",
+    "description": "Placeholder for the wait_for_selector input"
+  },
+  "placeholder.blockResources": {
+    "message": "Resource types to block",
+    "description": "Placeholder for the block_resources multi-select"
+  },
+  "button.extract": {
+    "message": "Extract",
+    "description": "Run extract button label"
+  },
+  "button.render": {
+    "message": "Render",
+    "description": "Run render button label"
+  },
+  "description.intro": {
+    "message": "Render and extract any web page",
+    "description": "Intro line shown in the empty result state"
+  },
+  "description.introHint": {
+    "message": "Enter a URL and choose Extract or Render to get clean content, markdown, links, screenshots, and more.",
+    "description": "Hint shown below the intro line"
+  },
+  "description.enableLlm": {
+    "message": "Use an LLM to clean and structure the extracted content. Costs additional credits.",
+    "description": "Tooltip explaining the LLM cleanup toggle"
+  },
+  "message.running": {
+    "message": "Working on it…",
+    "description": "Status while a request is in flight"
+  },
+  "message.extracting": {
+    "message": "Extracting…",
+    "description": "Status shown when extract is running"
+  },
+  "message.rendering": {
+    "message": "Rendering…",
+    "description": "Status shown when render is running"
+  },
+  "message.success": {
+    "message": "Done",
+    "description": "Toast shown on success"
+  },
+  "message.failed": {
+    "message": "Request failed",
+    "description": "Generic error message"
+  },
+  "message.usedUp": {
+    "message": "Your quota has been used up. Please top up to continue.",
+    "description": "Error shown when balance is exhausted"
+  },
+  "message.busy": {
+    "message": "Service is busy. Please try again in a moment.",
+    "description": "Error shown on rate limit"
+  },
+  "message.timeout": {
+    "message": "The page took too long to load. Try a different URL or increase the timeout.",
+    "description": "Error shown on timeout"
+  },
+  "message.untitled": {
+    "message": "Untitled",
+    "description": "Fallback title when the page has no title"
+  },
+  "tab.markdown": {
+    "message": "Markdown",
+    "description": "Markdown tab label"
+  },
+  "tab.text": {
+    "message": "Text",
+    "description": "Plain text tab label"
+  },
+  "tab.structured": {
+    "message": "Structured",
+    "description": "Structured data tab label"
+  },
+  "tab.links": {
+    "message": "Links",
+    "description": "Links tab label"
+  },
+  "tab.images": {
+    "message": "Images",
+    "description": "Images tab label"
+  },
+  "tab.html": {
+    "message": "HTML",
+    "description": "HTML tab label"
+  },
+  "tab.raw": {
+    "message": "Raw JSON",
+    "description": "Raw response tab label"
+  }
+}

--- a/src/i18n/ko/common.json
+++ b/src/i18n/ko/common.json
@@ -511,6 +511,10 @@
     "message": "SERP",
     "description": "사이트 내비게이션 바의 텍스트로 SERP 페이지를 표시합니다. 이 필드는 번역하지 말고 'SERP'로 유지해야 합니다."
   },
+  "nav.webextrator": {
+    "message": "WebExtrator",
+    "description": "Text in the website navigation bar to display the WebExtrator page, must remain as 'WebExtrator'"
+  },
   "nav.image": {
     "message": "이미지",
     "description": "사이트 내비게이션 바의 텍스트로 이미지 페이지를 표시합니다."

--- a/src/i18n/ko/site.json
+++ b/src/i18n/ko/site.json
@@ -151,6 +151,10 @@
     "message": "물고기 오디오",
     "description": "편집 상자에 표시되는 제목"
   },
+  "field.featuresWebextrator": {
+    "message": "WebExtrator",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresSupport": {
     "message": "고객 지원",
     "description": "편집 상자에 표시되는 제목"
@@ -454,6 +458,10 @@
   "message.featuresFish": {
     "message": "물고기 오디오 기능 모듈을 켜거나 끕니다.",
     "description": "물고기 오디오 기능에 대한 설명"
+  },
+  "message.featuresWebextrator": {
+    "message": "Enable or disable the WebExtrator feature module.",
+    "description": "Description of the WebExtrator feature"
   },
   "message.featuresLuma": {
     "message": "Luma 기능 모듈을 켜거나 끕니다.",

--- a/src/i18n/ko/webextrator.json
+++ b/src/i18n/ko/webextrator.json
@@ -1,0 +1,202 @@
+{
+  "name.mode": {
+    "message": "Mode",
+    "description": "Label for render/extract mode toggle"
+  },
+  "name.url": {
+    "message": "URL",
+    "description": "Label for the URL input"
+  },
+  "name.expectedType": {
+    "message": "Expected Type",
+    "description": "Label for expected content type"
+  },
+  "name.enableLlm": {
+    "message": "LLM Cleanup",
+    "description": "Label for enable LLM toggle"
+  },
+  "name.advanced": {
+    "message": "Advanced",
+    "description": "Label for advanced options collapse"
+  },
+  "name.waitUntil": {
+    "message": "Wait Until",
+    "description": "Label for the wait_until field"
+  },
+  "name.waitForSelector": {
+    "message": "Wait For Selector",
+    "description": "Label for the wait_for_selector field"
+  },
+  "name.timeout": {
+    "message": "Timeout (s)",
+    "description": "Label for the timeout field"
+  },
+  "name.delay": {
+    "message": "Delay (s)",
+    "description": "Label for the delay_after_load field"
+  },
+  "name.blockResources": {
+    "message": "Block Resources",
+    "description": "Label for the block_resources multi-select"
+  },
+  "name.consumption": {
+    "message": "Cost",
+    "description": "Label for the per-call cost"
+  },
+  "mode.extract": {
+    "message": "Extract",
+    "description": "Extract mode option"
+  },
+  "mode.render": {
+    "message": "Render",
+    "description": "Render mode option"
+  },
+  "expectedType.general": {
+    "message": "General",
+    "description": "General expected type option"
+  },
+  "expectedType.article": {
+    "message": "Article",
+    "description": "Article expected type option"
+  },
+  "expectedType.product": {
+    "message": "Product",
+    "description": "Product expected type option"
+  },
+  "waitUntil.networkidle": {
+    "message": "Network Idle",
+    "description": "Wait until network idle option"
+  },
+  "waitUntil.load": {
+    "message": "Load",
+    "description": "Wait until load option"
+  },
+  "waitUntil.domcontentloaded": {
+    "message": "DOM Ready",
+    "description": "Wait until DOM content loaded option"
+  },
+  "waitUntil.commit": {
+    "message": "Commit",
+    "description": "Wait until commit option"
+  },
+  "blockResource.image": {
+    "message": "Images",
+    "description": "Block images option"
+  },
+  "blockResource.font": {
+    "message": "Fonts",
+    "description": "Block fonts option"
+  },
+  "blockResource.media": {
+    "message": "Media",
+    "description": "Block media option"
+  },
+  "blockResource.stylesheet": {
+    "message": "Stylesheets",
+    "description": "Block stylesheets option"
+  },
+  "blockResource.xhr": {
+    "message": "XHR",
+    "description": "Block XHR option"
+  },
+  "blockResource.fetch": {
+    "message": "Fetch",
+    "description": "Block fetch option"
+  },
+  "placeholder.url": {
+    "message": "https://example.com",
+    "description": "Placeholder for the URL input"
+  },
+  "placeholder.waitForSelector": {
+    "message": "CSS selector, e.g. .article-body",
+    "description": "Placeholder for the wait_for_selector input"
+  },
+  "placeholder.blockResources": {
+    "message": "Resource types to block",
+    "description": "Placeholder for the block_resources multi-select"
+  },
+  "button.extract": {
+    "message": "Extract",
+    "description": "Run extract button label"
+  },
+  "button.render": {
+    "message": "Render",
+    "description": "Run render button label"
+  },
+  "description.intro": {
+    "message": "Render and extract any web page",
+    "description": "Intro line shown in the empty result state"
+  },
+  "description.introHint": {
+    "message": "Enter a URL and choose Extract or Render to get clean content, markdown, links, screenshots, and more.",
+    "description": "Hint shown below the intro line"
+  },
+  "description.enableLlm": {
+    "message": "Use an LLM to clean and structure the extracted content. Costs additional credits.",
+    "description": "Tooltip explaining the LLM cleanup toggle"
+  },
+  "message.running": {
+    "message": "Working on it…",
+    "description": "Status while a request is in flight"
+  },
+  "message.extracting": {
+    "message": "Extracting…",
+    "description": "Status shown when extract is running"
+  },
+  "message.rendering": {
+    "message": "Rendering…",
+    "description": "Status shown when render is running"
+  },
+  "message.success": {
+    "message": "Done",
+    "description": "Toast shown on success"
+  },
+  "message.failed": {
+    "message": "Request failed",
+    "description": "Generic error message"
+  },
+  "message.usedUp": {
+    "message": "Your quota has been used up. Please top up to continue.",
+    "description": "Error shown when balance is exhausted"
+  },
+  "message.busy": {
+    "message": "Service is busy. Please try again in a moment.",
+    "description": "Error shown on rate limit"
+  },
+  "message.timeout": {
+    "message": "The page took too long to load. Try a different URL or increase the timeout.",
+    "description": "Error shown on timeout"
+  },
+  "message.untitled": {
+    "message": "Untitled",
+    "description": "Fallback title when the page has no title"
+  },
+  "tab.markdown": {
+    "message": "Markdown",
+    "description": "Markdown tab label"
+  },
+  "tab.text": {
+    "message": "Text",
+    "description": "Plain text tab label"
+  },
+  "tab.structured": {
+    "message": "Structured",
+    "description": "Structured data tab label"
+  },
+  "tab.links": {
+    "message": "Links",
+    "description": "Links tab label"
+  },
+  "tab.images": {
+    "message": "Images",
+    "description": "Images tab label"
+  },
+  "tab.html": {
+    "message": "HTML",
+    "description": "HTML tab label"
+  },
+  "tab.raw": {
+    "message": "Raw JSON",
+    "description": "Raw response tab label"
+  }
+}

--- a/src/i18n/pl/common.json
+++ b/src/i18n/pl/common.json
@@ -511,6 +511,10 @@
     "message": "SERP",
     "description": "Tekst w nawigacji strony, który wyświetla stronę SERP, nie tłumaczyć, musi pozostać 'SERP'"
   },
+  "nav.webextrator": {
+    "message": "WebExtrator",
+    "description": "Text in the website navigation bar to display the WebExtrator page, must remain as 'WebExtrator'"
+  },
   "nav.image": {
     "message": "Obraz",
     "description": "Tekst w nawigacji strony, który wyświetla stronę obrazu"

--- a/src/i18n/pl/site.json
+++ b/src/i18n/pl/site.json
@@ -151,6 +151,10 @@
     "message": "Dźwięk ryb",
     "description": "Tytuł wyświetlany w polu edycji"
   },
+  "field.featuresWebextrator": {
+    "message": "WebExtrator",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresSupport": {
     "message": "Wsparcie klienta",
     "description": "Wyświetlane w tytule edytora"
@@ -454,6 +458,10 @@
   "message.featuresFish": {
     "message": "Włącz lub wyłącz moduł funkcji Dźwięk ryb.",
     "description": "Opis funkcji Dźwięk ryb"
+  },
+  "message.featuresWebextrator": {
+    "message": "Enable or disable the WebExtrator feature module.",
+    "description": "Description of the WebExtrator feature"
   },
   "message.featuresLuma": {
     "message": "Włącz lub wyłącz moduł funkcji Luma.",

--- a/src/i18n/pl/webextrator.json
+++ b/src/i18n/pl/webextrator.json
@@ -1,0 +1,202 @@
+{
+  "name.mode": {
+    "message": "Mode",
+    "description": "Label for render/extract mode toggle"
+  },
+  "name.url": {
+    "message": "URL",
+    "description": "Label for the URL input"
+  },
+  "name.expectedType": {
+    "message": "Expected Type",
+    "description": "Label for expected content type"
+  },
+  "name.enableLlm": {
+    "message": "LLM Cleanup",
+    "description": "Label for enable LLM toggle"
+  },
+  "name.advanced": {
+    "message": "Advanced",
+    "description": "Label for advanced options collapse"
+  },
+  "name.waitUntil": {
+    "message": "Wait Until",
+    "description": "Label for the wait_until field"
+  },
+  "name.waitForSelector": {
+    "message": "Wait For Selector",
+    "description": "Label for the wait_for_selector field"
+  },
+  "name.timeout": {
+    "message": "Timeout (s)",
+    "description": "Label for the timeout field"
+  },
+  "name.delay": {
+    "message": "Delay (s)",
+    "description": "Label for the delay_after_load field"
+  },
+  "name.blockResources": {
+    "message": "Block Resources",
+    "description": "Label for the block_resources multi-select"
+  },
+  "name.consumption": {
+    "message": "Cost",
+    "description": "Label for the per-call cost"
+  },
+  "mode.extract": {
+    "message": "Extract",
+    "description": "Extract mode option"
+  },
+  "mode.render": {
+    "message": "Render",
+    "description": "Render mode option"
+  },
+  "expectedType.general": {
+    "message": "General",
+    "description": "General expected type option"
+  },
+  "expectedType.article": {
+    "message": "Article",
+    "description": "Article expected type option"
+  },
+  "expectedType.product": {
+    "message": "Product",
+    "description": "Product expected type option"
+  },
+  "waitUntil.networkidle": {
+    "message": "Network Idle",
+    "description": "Wait until network idle option"
+  },
+  "waitUntil.load": {
+    "message": "Load",
+    "description": "Wait until load option"
+  },
+  "waitUntil.domcontentloaded": {
+    "message": "DOM Ready",
+    "description": "Wait until DOM content loaded option"
+  },
+  "waitUntil.commit": {
+    "message": "Commit",
+    "description": "Wait until commit option"
+  },
+  "blockResource.image": {
+    "message": "Images",
+    "description": "Block images option"
+  },
+  "blockResource.font": {
+    "message": "Fonts",
+    "description": "Block fonts option"
+  },
+  "blockResource.media": {
+    "message": "Media",
+    "description": "Block media option"
+  },
+  "blockResource.stylesheet": {
+    "message": "Stylesheets",
+    "description": "Block stylesheets option"
+  },
+  "blockResource.xhr": {
+    "message": "XHR",
+    "description": "Block XHR option"
+  },
+  "blockResource.fetch": {
+    "message": "Fetch",
+    "description": "Block fetch option"
+  },
+  "placeholder.url": {
+    "message": "https://example.com",
+    "description": "Placeholder for the URL input"
+  },
+  "placeholder.waitForSelector": {
+    "message": "CSS selector, e.g. .article-body",
+    "description": "Placeholder for the wait_for_selector input"
+  },
+  "placeholder.blockResources": {
+    "message": "Resource types to block",
+    "description": "Placeholder for the block_resources multi-select"
+  },
+  "button.extract": {
+    "message": "Extract",
+    "description": "Run extract button label"
+  },
+  "button.render": {
+    "message": "Render",
+    "description": "Run render button label"
+  },
+  "description.intro": {
+    "message": "Render and extract any web page",
+    "description": "Intro line shown in the empty result state"
+  },
+  "description.introHint": {
+    "message": "Enter a URL and choose Extract or Render to get clean content, markdown, links, screenshots, and more.",
+    "description": "Hint shown below the intro line"
+  },
+  "description.enableLlm": {
+    "message": "Use an LLM to clean and structure the extracted content. Costs additional credits.",
+    "description": "Tooltip explaining the LLM cleanup toggle"
+  },
+  "message.running": {
+    "message": "Working on it…",
+    "description": "Status while a request is in flight"
+  },
+  "message.extracting": {
+    "message": "Extracting…",
+    "description": "Status shown when extract is running"
+  },
+  "message.rendering": {
+    "message": "Rendering…",
+    "description": "Status shown when render is running"
+  },
+  "message.success": {
+    "message": "Done",
+    "description": "Toast shown on success"
+  },
+  "message.failed": {
+    "message": "Request failed",
+    "description": "Generic error message"
+  },
+  "message.usedUp": {
+    "message": "Your quota has been used up. Please top up to continue.",
+    "description": "Error shown when balance is exhausted"
+  },
+  "message.busy": {
+    "message": "Service is busy. Please try again in a moment.",
+    "description": "Error shown on rate limit"
+  },
+  "message.timeout": {
+    "message": "The page took too long to load. Try a different URL or increase the timeout.",
+    "description": "Error shown on timeout"
+  },
+  "message.untitled": {
+    "message": "Untitled",
+    "description": "Fallback title when the page has no title"
+  },
+  "tab.markdown": {
+    "message": "Markdown",
+    "description": "Markdown tab label"
+  },
+  "tab.text": {
+    "message": "Text",
+    "description": "Plain text tab label"
+  },
+  "tab.structured": {
+    "message": "Structured",
+    "description": "Structured data tab label"
+  },
+  "tab.links": {
+    "message": "Links",
+    "description": "Links tab label"
+  },
+  "tab.images": {
+    "message": "Images",
+    "description": "Images tab label"
+  },
+  "tab.html": {
+    "message": "HTML",
+    "description": "HTML tab label"
+  },
+  "tab.raw": {
+    "message": "Raw JSON",
+    "description": "Raw response tab label"
+  }
+}

--- a/src/i18n/pt/common.json
+++ b/src/i18n/pt/common.json
@@ -511,6 +511,10 @@
     "message": "SERP",
     "description": "Texto na barra de navegação do site para exibir a página SERP, não deve ser traduzido, deve permanecer como 'SERP'"
   },
+  "nav.webextrator": {
+    "message": "WebExtrator",
+    "description": "Text in the website navigation bar to display the WebExtrator page, must remain as 'WebExtrator'"
+  },
   "nav.image": {
     "message": "Imagem",
     "description": "Texto na barra de navegação do site para exibir a página de imagens"

--- a/src/i18n/pt/site.json
+++ b/src/i18n/pt/site.json
@@ -151,6 +151,10 @@
     "message": "Áudio Fish",
     "description": "Título exibido na caixa de edição"
   },
+  "field.featuresWebextrator": {
+    "message": "WebExtrator",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresSupport": {
     "message": "Suporte ao cliente",
     "description": "Exibido como o título na caixa de edição"
@@ -454,6 +458,10 @@
   "message.featuresFish": {
     "message": "Ative ou desative o módulo de recursos Áudio Fish.",
     "description": "Descrição da funcionalidade Áudio Fish"
+  },
+  "message.featuresWebextrator": {
+    "message": "Enable or disable the WebExtrator feature module.",
+    "description": "Description of the WebExtrator feature"
   },
   "message.featuresLuma": {
     "message": "Ativar ou desativar o módulo de recursos do Luma.",

--- a/src/i18n/pt/webextrator.json
+++ b/src/i18n/pt/webextrator.json
@@ -1,0 +1,202 @@
+{
+  "name.mode": {
+    "message": "Mode",
+    "description": "Label for render/extract mode toggle"
+  },
+  "name.url": {
+    "message": "URL",
+    "description": "Label for the URL input"
+  },
+  "name.expectedType": {
+    "message": "Expected Type",
+    "description": "Label for expected content type"
+  },
+  "name.enableLlm": {
+    "message": "LLM Cleanup",
+    "description": "Label for enable LLM toggle"
+  },
+  "name.advanced": {
+    "message": "Advanced",
+    "description": "Label for advanced options collapse"
+  },
+  "name.waitUntil": {
+    "message": "Wait Until",
+    "description": "Label for the wait_until field"
+  },
+  "name.waitForSelector": {
+    "message": "Wait For Selector",
+    "description": "Label for the wait_for_selector field"
+  },
+  "name.timeout": {
+    "message": "Timeout (s)",
+    "description": "Label for the timeout field"
+  },
+  "name.delay": {
+    "message": "Delay (s)",
+    "description": "Label for the delay_after_load field"
+  },
+  "name.blockResources": {
+    "message": "Block Resources",
+    "description": "Label for the block_resources multi-select"
+  },
+  "name.consumption": {
+    "message": "Cost",
+    "description": "Label for the per-call cost"
+  },
+  "mode.extract": {
+    "message": "Extract",
+    "description": "Extract mode option"
+  },
+  "mode.render": {
+    "message": "Render",
+    "description": "Render mode option"
+  },
+  "expectedType.general": {
+    "message": "General",
+    "description": "General expected type option"
+  },
+  "expectedType.article": {
+    "message": "Article",
+    "description": "Article expected type option"
+  },
+  "expectedType.product": {
+    "message": "Product",
+    "description": "Product expected type option"
+  },
+  "waitUntil.networkidle": {
+    "message": "Network Idle",
+    "description": "Wait until network idle option"
+  },
+  "waitUntil.load": {
+    "message": "Load",
+    "description": "Wait until load option"
+  },
+  "waitUntil.domcontentloaded": {
+    "message": "DOM Ready",
+    "description": "Wait until DOM content loaded option"
+  },
+  "waitUntil.commit": {
+    "message": "Commit",
+    "description": "Wait until commit option"
+  },
+  "blockResource.image": {
+    "message": "Images",
+    "description": "Block images option"
+  },
+  "blockResource.font": {
+    "message": "Fonts",
+    "description": "Block fonts option"
+  },
+  "blockResource.media": {
+    "message": "Media",
+    "description": "Block media option"
+  },
+  "blockResource.stylesheet": {
+    "message": "Stylesheets",
+    "description": "Block stylesheets option"
+  },
+  "blockResource.xhr": {
+    "message": "XHR",
+    "description": "Block XHR option"
+  },
+  "blockResource.fetch": {
+    "message": "Fetch",
+    "description": "Block fetch option"
+  },
+  "placeholder.url": {
+    "message": "https://example.com",
+    "description": "Placeholder for the URL input"
+  },
+  "placeholder.waitForSelector": {
+    "message": "CSS selector, e.g. .article-body",
+    "description": "Placeholder for the wait_for_selector input"
+  },
+  "placeholder.blockResources": {
+    "message": "Resource types to block",
+    "description": "Placeholder for the block_resources multi-select"
+  },
+  "button.extract": {
+    "message": "Extract",
+    "description": "Run extract button label"
+  },
+  "button.render": {
+    "message": "Render",
+    "description": "Run render button label"
+  },
+  "description.intro": {
+    "message": "Render and extract any web page",
+    "description": "Intro line shown in the empty result state"
+  },
+  "description.introHint": {
+    "message": "Enter a URL and choose Extract or Render to get clean content, markdown, links, screenshots, and more.",
+    "description": "Hint shown below the intro line"
+  },
+  "description.enableLlm": {
+    "message": "Use an LLM to clean and structure the extracted content. Costs additional credits.",
+    "description": "Tooltip explaining the LLM cleanup toggle"
+  },
+  "message.running": {
+    "message": "Working on it…",
+    "description": "Status while a request is in flight"
+  },
+  "message.extracting": {
+    "message": "Extracting…",
+    "description": "Status shown when extract is running"
+  },
+  "message.rendering": {
+    "message": "Rendering…",
+    "description": "Status shown when render is running"
+  },
+  "message.success": {
+    "message": "Done",
+    "description": "Toast shown on success"
+  },
+  "message.failed": {
+    "message": "Request failed",
+    "description": "Generic error message"
+  },
+  "message.usedUp": {
+    "message": "Your quota has been used up. Please top up to continue.",
+    "description": "Error shown when balance is exhausted"
+  },
+  "message.busy": {
+    "message": "Service is busy. Please try again in a moment.",
+    "description": "Error shown on rate limit"
+  },
+  "message.timeout": {
+    "message": "The page took too long to load. Try a different URL or increase the timeout.",
+    "description": "Error shown on timeout"
+  },
+  "message.untitled": {
+    "message": "Untitled",
+    "description": "Fallback title when the page has no title"
+  },
+  "tab.markdown": {
+    "message": "Markdown",
+    "description": "Markdown tab label"
+  },
+  "tab.text": {
+    "message": "Text",
+    "description": "Plain text tab label"
+  },
+  "tab.structured": {
+    "message": "Structured",
+    "description": "Structured data tab label"
+  },
+  "tab.links": {
+    "message": "Links",
+    "description": "Links tab label"
+  },
+  "tab.images": {
+    "message": "Images",
+    "description": "Images tab label"
+  },
+  "tab.html": {
+    "message": "HTML",
+    "description": "HTML tab label"
+  },
+  "tab.raw": {
+    "message": "Raw JSON",
+    "description": "Raw response tab label"
+  }
+}

--- a/src/i18n/ru/common.json
+++ b/src/i18n/ru/common.json
@@ -511,6 +511,10 @@
     "message": "SERP",
     "description": "网站导航栏中的文本，用于显示SERP页面，请不要翻译此字段，必须保持为'SERP'"
   },
+  "nav.webextrator": {
+    "message": "WebExtrator",
+    "description": "Text in the website navigation bar to display the WebExtrator page, must remain as 'WebExtrator'"
+  },
   "nav.image": {
     "message": "Изображение",
     "description": "网站导航栏中的文本，用于显示图片页面"

--- a/src/i18n/ru/site.json
+++ b/src/i18n/ru/site.json
@@ -151,6 +151,10 @@
     "message": "Аудио Рыбы",
     "description": "Заголовок, отображаемый в редакторе."
   },
+  "field.featuresWebextrator": {
+    "message": "WebExtrator",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresSupport": {
     "message": "Поддержка клиентов",
     "description": "展示在编辑框的标题"
@@ -454,6 +458,10 @@
   "message.featuresFish": {
     "message": "Включить или отключить модуль функции Аудио Рыбы.",
     "description": "Описание функции Аудио Рыбы."
+  },
+  "message.featuresWebextrator": {
+    "message": "Enable or disable the WebExtrator feature module.",
+    "description": "Description of the WebExtrator feature"
   },
   "message.featuresLuma": {
     "message": "Включить или отключить модуль функций Luma.",

--- a/src/i18n/ru/webextrator.json
+++ b/src/i18n/ru/webextrator.json
@@ -1,0 +1,202 @@
+{
+  "name.mode": {
+    "message": "Mode",
+    "description": "Label for render/extract mode toggle"
+  },
+  "name.url": {
+    "message": "URL",
+    "description": "Label for the URL input"
+  },
+  "name.expectedType": {
+    "message": "Expected Type",
+    "description": "Label for expected content type"
+  },
+  "name.enableLlm": {
+    "message": "LLM Cleanup",
+    "description": "Label for enable LLM toggle"
+  },
+  "name.advanced": {
+    "message": "Advanced",
+    "description": "Label for advanced options collapse"
+  },
+  "name.waitUntil": {
+    "message": "Wait Until",
+    "description": "Label for the wait_until field"
+  },
+  "name.waitForSelector": {
+    "message": "Wait For Selector",
+    "description": "Label for the wait_for_selector field"
+  },
+  "name.timeout": {
+    "message": "Timeout (s)",
+    "description": "Label for the timeout field"
+  },
+  "name.delay": {
+    "message": "Delay (s)",
+    "description": "Label for the delay_after_load field"
+  },
+  "name.blockResources": {
+    "message": "Block Resources",
+    "description": "Label for the block_resources multi-select"
+  },
+  "name.consumption": {
+    "message": "Cost",
+    "description": "Label for the per-call cost"
+  },
+  "mode.extract": {
+    "message": "Extract",
+    "description": "Extract mode option"
+  },
+  "mode.render": {
+    "message": "Render",
+    "description": "Render mode option"
+  },
+  "expectedType.general": {
+    "message": "General",
+    "description": "General expected type option"
+  },
+  "expectedType.article": {
+    "message": "Article",
+    "description": "Article expected type option"
+  },
+  "expectedType.product": {
+    "message": "Product",
+    "description": "Product expected type option"
+  },
+  "waitUntil.networkidle": {
+    "message": "Network Idle",
+    "description": "Wait until network idle option"
+  },
+  "waitUntil.load": {
+    "message": "Load",
+    "description": "Wait until load option"
+  },
+  "waitUntil.domcontentloaded": {
+    "message": "DOM Ready",
+    "description": "Wait until DOM content loaded option"
+  },
+  "waitUntil.commit": {
+    "message": "Commit",
+    "description": "Wait until commit option"
+  },
+  "blockResource.image": {
+    "message": "Images",
+    "description": "Block images option"
+  },
+  "blockResource.font": {
+    "message": "Fonts",
+    "description": "Block fonts option"
+  },
+  "blockResource.media": {
+    "message": "Media",
+    "description": "Block media option"
+  },
+  "blockResource.stylesheet": {
+    "message": "Stylesheets",
+    "description": "Block stylesheets option"
+  },
+  "blockResource.xhr": {
+    "message": "XHR",
+    "description": "Block XHR option"
+  },
+  "blockResource.fetch": {
+    "message": "Fetch",
+    "description": "Block fetch option"
+  },
+  "placeholder.url": {
+    "message": "https://example.com",
+    "description": "Placeholder for the URL input"
+  },
+  "placeholder.waitForSelector": {
+    "message": "CSS selector, e.g. .article-body",
+    "description": "Placeholder for the wait_for_selector input"
+  },
+  "placeholder.blockResources": {
+    "message": "Resource types to block",
+    "description": "Placeholder for the block_resources multi-select"
+  },
+  "button.extract": {
+    "message": "Extract",
+    "description": "Run extract button label"
+  },
+  "button.render": {
+    "message": "Render",
+    "description": "Run render button label"
+  },
+  "description.intro": {
+    "message": "Render and extract any web page",
+    "description": "Intro line shown in the empty result state"
+  },
+  "description.introHint": {
+    "message": "Enter a URL and choose Extract or Render to get clean content, markdown, links, screenshots, and more.",
+    "description": "Hint shown below the intro line"
+  },
+  "description.enableLlm": {
+    "message": "Use an LLM to clean and structure the extracted content. Costs additional credits.",
+    "description": "Tooltip explaining the LLM cleanup toggle"
+  },
+  "message.running": {
+    "message": "Working on it…",
+    "description": "Status while a request is in flight"
+  },
+  "message.extracting": {
+    "message": "Extracting…",
+    "description": "Status shown when extract is running"
+  },
+  "message.rendering": {
+    "message": "Rendering…",
+    "description": "Status shown when render is running"
+  },
+  "message.success": {
+    "message": "Done",
+    "description": "Toast shown on success"
+  },
+  "message.failed": {
+    "message": "Request failed",
+    "description": "Generic error message"
+  },
+  "message.usedUp": {
+    "message": "Your quota has been used up. Please top up to continue.",
+    "description": "Error shown when balance is exhausted"
+  },
+  "message.busy": {
+    "message": "Service is busy. Please try again in a moment.",
+    "description": "Error shown on rate limit"
+  },
+  "message.timeout": {
+    "message": "The page took too long to load. Try a different URL or increase the timeout.",
+    "description": "Error shown on timeout"
+  },
+  "message.untitled": {
+    "message": "Untitled",
+    "description": "Fallback title when the page has no title"
+  },
+  "tab.markdown": {
+    "message": "Markdown",
+    "description": "Markdown tab label"
+  },
+  "tab.text": {
+    "message": "Text",
+    "description": "Plain text tab label"
+  },
+  "tab.structured": {
+    "message": "Structured",
+    "description": "Structured data tab label"
+  },
+  "tab.links": {
+    "message": "Links",
+    "description": "Links tab label"
+  },
+  "tab.images": {
+    "message": "Images",
+    "description": "Images tab label"
+  },
+  "tab.html": {
+    "message": "HTML",
+    "description": "HTML tab label"
+  },
+  "tab.raw": {
+    "message": "Raw JSON",
+    "description": "Raw response tab label"
+  }
+}

--- a/src/i18n/sr/common.json
+++ b/src/i18n/sr/common.json
@@ -511,6 +511,10 @@
     "message": "SERP",
     "description": "网站导航栏中的文本，用于显示SERP页面，请不要翻译此字段，必须保持为'SERP'"
   },
+  "nav.webextrator": {
+    "message": "WebExtrator",
+    "description": "Text in the website navigation bar to display the WebExtrator page, must remain as 'WebExtrator'"
+  },
   "nav.image": {
     "message": "Slika",
     "description": "网站导航栏中的文本，用于显示图片页面"

--- a/src/i18n/sr/site.json
+++ b/src/i18n/sr/site.json
@@ -151,6 +151,10 @@
     "message": "Riblja Audio",
     "description": "Naslov prikazan u okviru za uređivanje"
   },
+  "field.featuresWebextrator": {
+    "message": "WebExtrator",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresSupport": {
     "message": "Korisnička podrška",
     "description": "Prikazuje se kao naslov u okviru za uređivanje"
@@ -454,6 +458,10 @@
   "message.featuresFish": {
     "message": "Uključi ili isključi modul Riblja Audio.",
     "description": "Opis funkcionalnosti Riblja Audio"
+  },
+  "message.featuresWebextrator": {
+    "message": "Enable or disable the WebExtrator feature module.",
+    "description": "Description of the WebExtrator feature"
   },
   "message.featuresLuma": {
     "message": "Uključi ili isključi Luma funkcionalnost.",

--- a/src/i18n/sr/webextrator.json
+++ b/src/i18n/sr/webextrator.json
@@ -1,0 +1,202 @@
+{
+  "name.mode": {
+    "message": "Mode",
+    "description": "Label for render/extract mode toggle"
+  },
+  "name.url": {
+    "message": "URL",
+    "description": "Label for the URL input"
+  },
+  "name.expectedType": {
+    "message": "Expected Type",
+    "description": "Label for expected content type"
+  },
+  "name.enableLlm": {
+    "message": "LLM Cleanup",
+    "description": "Label for enable LLM toggle"
+  },
+  "name.advanced": {
+    "message": "Advanced",
+    "description": "Label for advanced options collapse"
+  },
+  "name.waitUntil": {
+    "message": "Wait Until",
+    "description": "Label for the wait_until field"
+  },
+  "name.waitForSelector": {
+    "message": "Wait For Selector",
+    "description": "Label for the wait_for_selector field"
+  },
+  "name.timeout": {
+    "message": "Timeout (s)",
+    "description": "Label for the timeout field"
+  },
+  "name.delay": {
+    "message": "Delay (s)",
+    "description": "Label for the delay_after_load field"
+  },
+  "name.blockResources": {
+    "message": "Block Resources",
+    "description": "Label for the block_resources multi-select"
+  },
+  "name.consumption": {
+    "message": "Cost",
+    "description": "Label for the per-call cost"
+  },
+  "mode.extract": {
+    "message": "Extract",
+    "description": "Extract mode option"
+  },
+  "mode.render": {
+    "message": "Render",
+    "description": "Render mode option"
+  },
+  "expectedType.general": {
+    "message": "General",
+    "description": "General expected type option"
+  },
+  "expectedType.article": {
+    "message": "Article",
+    "description": "Article expected type option"
+  },
+  "expectedType.product": {
+    "message": "Product",
+    "description": "Product expected type option"
+  },
+  "waitUntil.networkidle": {
+    "message": "Network Idle",
+    "description": "Wait until network idle option"
+  },
+  "waitUntil.load": {
+    "message": "Load",
+    "description": "Wait until load option"
+  },
+  "waitUntil.domcontentloaded": {
+    "message": "DOM Ready",
+    "description": "Wait until DOM content loaded option"
+  },
+  "waitUntil.commit": {
+    "message": "Commit",
+    "description": "Wait until commit option"
+  },
+  "blockResource.image": {
+    "message": "Images",
+    "description": "Block images option"
+  },
+  "blockResource.font": {
+    "message": "Fonts",
+    "description": "Block fonts option"
+  },
+  "blockResource.media": {
+    "message": "Media",
+    "description": "Block media option"
+  },
+  "blockResource.stylesheet": {
+    "message": "Stylesheets",
+    "description": "Block stylesheets option"
+  },
+  "blockResource.xhr": {
+    "message": "XHR",
+    "description": "Block XHR option"
+  },
+  "blockResource.fetch": {
+    "message": "Fetch",
+    "description": "Block fetch option"
+  },
+  "placeholder.url": {
+    "message": "https://example.com",
+    "description": "Placeholder for the URL input"
+  },
+  "placeholder.waitForSelector": {
+    "message": "CSS selector, e.g. .article-body",
+    "description": "Placeholder for the wait_for_selector input"
+  },
+  "placeholder.blockResources": {
+    "message": "Resource types to block",
+    "description": "Placeholder for the block_resources multi-select"
+  },
+  "button.extract": {
+    "message": "Extract",
+    "description": "Run extract button label"
+  },
+  "button.render": {
+    "message": "Render",
+    "description": "Run render button label"
+  },
+  "description.intro": {
+    "message": "Render and extract any web page",
+    "description": "Intro line shown in the empty result state"
+  },
+  "description.introHint": {
+    "message": "Enter a URL and choose Extract or Render to get clean content, markdown, links, screenshots, and more.",
+    "description": "Hint shown below the intro line"
+  },
+  "description.enableLlm": {
+    "message": "Use an LLM to clean and structure the extracted content. Costs additional credits.",
+    "description": "Tooltip explaining the LLM cleanup toggle"
+  },
+  "message.running": {
+    "message": "Working on it…",
+    "description": "Status while a request is in flight"
+  },
+  "message.extracting": {
+    "message": "Extracting…",
+    "description": "Status shown when extract is running"
+  },
+  "message.rendering": {
+    "message": "Rendering…",
+    "description": "Status shown when render is running"
+  },
+  "message.success": {
+    "message": "Done",
+    "description": "Toast shown on success"
+  },
+  "message.failed": {
+    "message": "Request failed",
+    "description": "Generic error message"
+  },
+  "message.usedUp": {
+    "message": "Your quota has been used up. Please top up to continue.",
+    "description": "Error shown when balance is exhausted"
+  },
+  "message.busy": {
+    "message": "Service is busy. Please try again in a moment.",
+    "description": "Error shown on rate limit"
+  },
+  "message.timeout": {
+    "message": "The page took too long to load. Try a different URL or increase the timeout.",
+    "description": "Error shown on timeout"
+  },
+  "message.untitled": {
+    "message": "Untitled",
+    "description": "Fallback title when the page has no title"
+  },
+  "tab.markdown": {
+    "message": "Markdown",
+    "description": "Markdown tab label"
+  },
+  "tab.text": {
+    "message": "Text",
+    "description": "Plain text tab label"
+  },
+  "tab.structured": {
+    "message": "Structured",
+    "description": "Structured data tab label"
+  },
+  "tab.links": {
+    "message": "Links",
+    "description": "Links tab label"
+  },
+  "tab.images": {
+    "message": "Images",
+    "description": "Images tab label"
+  },
+  "tab.html": {
+    "message": "HTML",
+    "description": "HTML tab label"
+  },
+  "tab.raw": {
+    "message": "Raw JSON",
+    "description": "Raw response tab label"
+  }
+}

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -511,6 +511,10 @@
     "message": "SERP",
     "description": "Text in the website navigation bar for displaying the SERP page, must remain 'SERP'"
   },
+  "nav.webextrator": {
+    "message": "WebExtrator",
+    "description": "Text in the website navigation bar to display the WebExtrator page, must remain as 'WebExtrator'"
+  },
   "nav.image": {
     "message": "Bild",
     "description": "Text in the website navigation bar for displaying the image page"

--- a/src/i18n/sv/site.json
+++ b/src/i18n/sv/site.json
@@ -151,6 +151,10 @@
     "message": "Fiskljud",
     "description": "Titeln som visas i redigeringsrutan"
   },
+  "field.featuresWebextrator": {
+    "message": "WebExtrator",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresSupport": {
     "message": "Kundsupport",
     "description": "Visas som titeln i redigeringsrutan"
@@ -454,6 +458,10 @@
   "message.featuresFish": {
     "message": "Aktivera eller inaktivera Fiskljud-funktionaliteten.",
     "description": "Beskrivning av Fiskljud-funktionen"
+  },
+  "message.featuresWebextrator": {
+    "message": "Enable or disable the WebExtrator feature module.",
+    "description": "Description of the WebExtrator feature"
   },
   "message.featuresLuma": {
     "message": "Aktivera eller inaktivera Luma-funktionmodulen.",

--- a/src/i18n/sv/webextrator.json
+++ b/src/i18n/sv/webextrator.json
@@ -1,0 +1,202 @@
+{
+  "name.mode": {
+    "message": "Mode",
+    "description": "Label for render/extract mode toggle"
+  },
+  "name.url": {
+    "message": "URL",
+    "description": "Label for the URL input"
+  },
+  "name.expectedType": {
+    "message": "Expected Type",
+    "description": "Label for expected content type"
+  },
+  "name.enableLlm": {
+    "message": "LLM Cleanup",
+    "description": "Label for enable LLM toggle"
+  },
+  "name.advanced": {
+    "message": "Advanced",
+    "description": "Label for advanced options collapse"
+  },
+  "name.waitUntil": {
+    "message": "Wait Until",
+    "description": "Label for the wait_until field"
+  },
+  "name.waitForSelector": {
+    "message": "Wait For Selector",
+    "description": "Label for the wait_for_selector field"
+  },
+  "name.timeout": {
+    "message": "Timeout (s)",
+    "description": "Label for the timeout field"
+  },
+  "name.delay": {
+    "message": "Delay (s)",
+    "description": "Label for the delay_after_load field"
+  },
+  "name.blockResources": {
+    "message": "Block Resources",
+    "description": "Label for the block_resources multi-select"
+  },
+  "name.consumption": {
+    "message": "Cost",
+    "description": "Label for the per-call cost"
+  },
+  "mode.extract": {
+    "message": "Extract",
+    "description": "Extract mode option"
+  },
+  "mode.render": {
+    "message": "Render",
+    "description": "Render mode option"
+  },
+  "expectedType.general": {
+    "message": "General",
+    "description": "General expected type option"
+  },
+  "expectedType.article": {
+    "message": "Article",
+    "description": "Article expected type option"
+  },
+  "expectedType.product": {
+    "message": "Product",
+    "description": "Product expected type option"
+  },
+  "waitUntil.networkidle": {
+    "message": "Network Idle",
+    "description": "Wait until network idle option"
+  },
+  "waitUntil.load": {
+    "message": "Load",
+    "description": "Wait until load option"
+  },
+  "waitUntil.domcontentloaded": {
+    "message": "DOM Ready",
+    "description": "Wait until DOM content loaded option"
+  },
+  "waitUntil.commit": {
+    "message": "Commit",
+    "description": "Wait until commit option"
+  },
+  "blockResource.image": {
+    "message": "Images",
+    "description": "Block images option"
+  },
+  "blockResource.font": {
+    "message": "Fonts",
+    "description": "Block fonts option"
+  },
+  "blockResource.media": {
+    "message": "Media",
+    "description": "Block media option"
+  },
+  "blockResource.stylesheet": {
+    "message": "Stylesheets",
+    "description": "Block stylesheets option"
+  },
+  "blockResource.xhr": {
+    "message": "XHR",
+    "description": "Block XHR option"
+  },
+  "blockResource.fetch": {
+    "message": "Fetch",
+    "description": "Block fetch option"
+  },
+  "placeholder.url": {
+    "message": "https://example.com",
+    "description": "Placeholder for the URL input"
+  },
+  "placeholder.waitForSelector": {
+    "message": "CSS selector, e.g. .article-body",
+    "description": "Placeholder for the wait_for_selector input"
+  },
+  "placeholder.blockResources": {
+    "message": "Resource types to block",
+    "description": "Placeholder for the block_resources multi-select"
+  },
+  "button.extract": {
+    "message": "Extract",
+    "description": "Run extract button label"
+  },
+  "button.render": {
+    "message": "Render",
+    "description": "Run render button label"
+  },
+  "description.intro": {
+    "message": "Render and extract any web page",
+    "description": "Intro line shown in the empty result state"
+  },
+  "description.introHint": {
+    "message": "Enter a URL and choose Extract or Render to get clean content, markdown, links, screenshots, and more.",
+    "description": "Hint shown below the intro line"
+  },
+  "description.enableLlm": {
+    "message": "Use an LLM to clean and structure the extracted content. Costs additional credits.",
+    "description": "Tooltip explaining the LLM cleanup toggle"
+  },
+  "message.running": {
+    "message": "Working on it…",
+    "description": "Status while a request is in flight"
+  },
+  "message.extracting": {
+    "message": "Extracting…",
+    "description": "Status shown when extract is running"
+  },
+  "message.rendering": {
+    "message": "Rendering…",
+    "description": "Status shown when render is running"
+  },
+  "message.success": {
+    "message": "Done",
+    "description": "Toast shown on success"
+  },
+  "message.failed": {
+    "message": "Request failed",
+    "description": "Generic error message"
+  },
+  "message.usedUp": {
+    "message": "Your quota has been used up. Please top up to continue.",
+    "description": "Error shown when balance is exhausted"
+  },
+  "message.busy": {
+    "message": "Service is busy. Please try again in a moment.",
+    "description": "Error shown on rate limit"
+  },
+  "message.timeout": {
+    "message": "The page took too long to load. Try a different URL or increase the timeout.",
+    "description": "Error shown on timeout"
+  },
+  "message.untitled": {
+    "message": "Untitled",
+    "description": "Fallback title when the page has no title"
+  },
+  "tab.markdown": {
+    "message": "Markdown",
+    "description": "Markdown tab label"
+  },
+  "tab.text": {
+    "message": "Text",
+    "description": "Plain text tab label"
+  },
+  "tab.structured": {
+    "message": "Structured",
+    "description": "Structured data tab label"
+  },
+  "tab.links": {
+    "message": "Links",
+    "description": "Links tab label"
+  },
+  "tab.images": {
+    "message": "Images",
+    "description": "Images tab label"
+  },
+  "tab.html": {
+    "message": "HTML",
+    "description": "HTML tab label"
+  },
+  "tab.raw": {
+    "message": "Raw JSON",
+    "description": "Raw response tab label"
+  }
+}

--- a/src/i18n/uk/common.json
+++ b/src/i18n/uk/common.json
@@ -511,6 +511,10 @@
     "message": "SERP",
     "description": "Текст у навігаційній панелі сайту для відображення сторінки SERP, не перекладати, має залишатися 'SERP'"
   },
+  "nav.webextrator": {
+    "message": "WebExtrator",
+    "description": "Text in the website navigation bar to display the WebExtrator page, must remain as 'WebExtrator'"
+  },
   "nav.image": {
     "message": "Зображення",
     "description": "Текст у навігаційній панелі сайту для відображення сторінки зображень"

--- a/src/i18n/uk/site.json
+++ b/src/i18n/uk/site.json
@@ -151,6 +151,10 @@
     "message": "Аудіо риби",
     "description": "Заголовок, що відображається в редакторі"
   },
+  "field.featuresWebextrator": {
+    "message": "WebExtrator",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresSupport": {
     "message": "Підтримка клієнтів",
     "description": "展示在编辑框的标题"
@@ -454,6 +458,10 @@
   "message.featuresFish": {
     "message": "Увімкнути або вимкнути модуль функції Аудіо риби.",
     "description": "Опис функції Аудіо риби"
+  },
+  "message.featuresWebextrator": {
+    "message": "Enable or disable the WebExtrator feature module.",
+    "description": "Description of the WebExtrator feature"
   },
   "message.featuresLuma": {
     "message": "Увімкнути або вимкнути модуль функцій Luma.",

--- a/src/i18n/uk/webextrator.json
+++ b/src/i18n/uk/webextrator.json
@@ -1,0 +1,202 @@
+{
+  "name.mode": {
+    "message": "Mode",
+    "description": "Label for render/extract mode toggle"
+  },
+  "name.url": {
+    "message": "URL",
+    "description": "Label for the URL input"
+  },
+  "name.expectedType": {
+    "message": "Expected Type",
+    "description": "Label for expected content type"
+  },
+  "name.enableLlm": {
+    "message": "LLM Cleanup",
+    "description": "Label for enable LLM toggle"
+  },
+  "name.advanced": {
+    "message": "Advanced",
+    "description": "Label for advanced options collapse"
+  },
+  "name.waitUntil": {
+    "message": "Wait Until",
+    "description": "Label for the wait_until field"
+  },
+  "name.waitForSelector": {
+    "message": "Wait For Selector",
+    "description": "Label for the wait_for_selector field"
+  },
+  "name.timeout": {
+    "message": "Timeout (s)",
+    "description": "Label for the timeout field"
+  },
+  "name.delay": {
+    "message": "Delay (s)",
+    "description": "Label for the delay_after_load field"
+  },
+  "name.blockResources": {
+    "message": "Block Resources",
+    "description": "Label for the block_resources multi-select"
+  },
+  "name.consumption": {
+    "message": "Cost",
+    "description": "Label for the per-call cost"
+  },
+  "mode.extract": {
+    "message": "Extract",
+    "description": "Extract mode option"
+  },
+  "mode.render": {
+    "message": "Render",
+    "description": "Render mode option"
+  },
+  "expectedType.general": {
+    "message": "General",
+    "description": "General expected type option"
+  },
+  "expectedType.article": {
+    "message": "Article",
+    "description": "Article expected type option"
+  },
+  "expectedType.product": {
+    "message": "Product",
+    "description": "Product expected type option"
+  },
+  "waitUntil.networkidle": {
+    "message": "Network Idle",
+    "description": "Wait until network idle option"
+  },
+  "waitUntil.load": {
+    "message": "Load",
+    "description": "Wait until load option"
+  },
+  "waitUntil.domcontentloaded": {
+    "message": "DOM Ready",
+    "description": "Wait until DOM content loaded option"
+  },
+  "waitUntil.commit": {
+    "message": "Commit",
+    "description": "Wait until commit option"
+  },
+  "blockResource.image": {
+    "message": "Images",
+    "description": "Block images option"
+  },
+  "blockResource.font": {
+    "message": "Fonts",
+    "description": "Block fonts option"
+  },
+  "blockResource.media": {
+    "message": "Media",
+    "description": "Block media option"
+  },
+  "blockResource.stylesheet": {
+    "message": "Stylesheets",
+    "description": "Block stylesheets option"
+  },
+  "blockResource.xhr": {
+    "message": "XHR",
+    "description": "Block XHR option"
+  },
+  "blockResource.fetch": {
+    "message": "Fetch",
+    "description": "Block fetch option"
+  },
+  "placeholder.url": {
+    "message": "https://example.com",
+    "description": "Placeholder for the URL input"
+  },
+  "placeholder.waitForSelector": {
+    "message": "CSS selector, e.g. .article-body",
+    "description": "Placeholder for the wait_for_selector input"
+  },
+  "placeholder.blockResources": {
+    "message": "Resource types to block",
+    "description": "Placeholder for the block_resources multi-select"
+  },
+  "button.extract": {
+    "message": "Extract",
+    "description": "Run extract button label"
+  },
+  "button.render": {
+    "message": "Render",
+    "description": "Run render button label"
+  },
+  "description.intro": {
+    "message": "Render and extract any web page",
+    "description": "Intro line shown in the empty result state"
+  },
+  "description.introHint": {
+    "message": "Enter a URL and choose Extract or Render to get clean content, markdown, links, screenshots, and more.",
+    "description": "Hint shown below the intro line"
+  },
+  "description.enableLlm": {
+    "message": "Use an LLM to clean and structure the extracted content. Costs additional credits.",
+    "description": "Tooltip explaining the LLM cleanup toggle"
+  },
+  "message.running": {
+    "message": "Working on it…",
+    "description": "Status while a request is in flight"
+  },
+  "message.extracting": {
+    "message": "Extracting…",
+    "description": "Status shown when extract is running"
+  },
+  "message.rendering": {
+    "message": "Rendering…",
+    "description": "Status shown when render is running"
+  },
+  "message.success": {
+    "message": "Done",
+    "description": "Toast shown on success"
+  },
+  "message.failed": {
+    "message": "Request failed",
+    "description": "Generic error message"
+  },
+  "message.usedUp": {
+    "message": "Your quota has been used up. Please top up to continue.",
+    "description": "Error shown when balance is exhausted"
+  },
+  "message.busy": {
+    "message": "Service is busy. Please try again in a moment.",
+    "description": "Error shown on rate limit"
+  },
+  "message.timeout": {
+    "message": "The page took too long to load. Try a different URL or increase the timeout.",
+    "description": "Error shown on timeout"
+  },
+  "message.untitled": {
+    "message": "Untitled",
+    "description": "Fallback title when the page has no title"
+  },
+  "tab.markdown": {
+    "message": "Markdown",
+    "description": "Markdown tab label"
+  },
+  "tab.text": {
+    "message": "Text",
+    "description": "Plain text tab label"
+  },
+  "tab.structured": {
+    "message": "Structured",
+    "description": "Structured data tab label"
+  },
+  "tab.links": {
+    "message": "Links",
+    "description": "Links tab label"
+  },
+  "tab.images": {
+    "message": "Images",
+    "description": "Images tab label"
+  },
+  "tab.html": {
+    "message": "HTML",
+    "description": "HTML tab label"
+  },
+  "tab.raw": {
+    "message": "Raw JSON",
+    "description": "Raw response tab label"
+  }
+}

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -511,6 +511,10 @@
     "message": "SERP",
     "description": "网站导航栏中的文本，用于显示SERP页面，请不要翻译此字段，必须保持为'SERP'"
   },
+  "nav.webextrator": {
+    "message": "WebExtrator",
+    "description": "网站导航栏中的文本，用于显示WebExtrator页面，请不要翻译此字段，必须保持为'WebExtrator'"
+  },
   "nav.image": {
     "message": "图片",
     "description": "网站导航栏中的文本，用于显示图片页面"

--- a/src/i18n/zh-CN/site.json
+++ b/src/i18n/zh-CN/site.json
@@ -151,6 +151,10 @@
     "message": "Fish Audio",
     "description": "展示在编辑框的标题"
   },
+  "field.featuresWebextrator": {
+    "message": "WebExtrator",
+    "description": "展示在编辑框的标题"
+  },
   "field.featuresSupport": {
     "message": "客服支持",
     "description": "展示在编辑框的标题"
@@ -454,6 +458,10 @@
   "message.featuresFish": {
     "message": "打开或关闭 Fish Audio 功能模块。",
     "description": "Fish Audio 功能的描述"
+  },
+  "message.featuresWebextrator": {
+    "message": "打开或关闭 WebExtrator 功能模块。",
+    "description": "WebExtrator 功能的描述"
   },
   "message.featuresLuma": {
     "message": "打开或关闭 Luma 功能模块。",

--- a/src/i18n/zh-CN/webextrator.json
+++ b/src/i18n/zh-CN/webextrator.json
@@ -1,0 +1,202 @@
+{
+  "name.mode": {
+    "message": "模式",
+    "description": "Label for render/extract mode toggle"
+  },
+  "name.url": {
+    "message": "网址",
+    "description": "Label for the URL input"
+  },
+  "name.expectedType": {
+    "message": "内容类型",
+    "description": "Label for expected content type"
+  },
+  "name.enableLlm": {
+    "message": "LLM 智能清洗",
+    "description": "Label for enable LLM toggle"
+  },
+  "name.advanced": {
+    "message": "高级选项",
+    "description": "Label for advanced options collapse"
+  },
+  "name.waitUntil": {
+    "message": "等待条件",
+    "description": "Label for the wait_until field"
+  },
+  "name.waitForSelector": {
+    "message": "等待选择器",
+    "description": "Label for the wait_for_selector field"
+  },
+  "name.timeout": {
+    "message": "超时(秒)",
+    "description": "Label for the timeout field"
+  },
+  "name.delay": {
+    "message": "加载后延迟(秒)",
+    "description": "Label for the delay_after_load field"
+  },
+  "name.blockResources": {
+    "message": "屏蔽资源",
+    "description": "Label for the block_resources multi-select"
+  },
+  "name.consumption": {
+    "message": "单次消耗",
+    "description": "Label for the per-call cost"
+  },
+  "mode.extract": {
+    "message": "抽取内容",
+    "description": "Extract mode option"
+  },
+  "mode.render": {
+    "message": "渲染页面",
+    "description": "Render mode option"
+  },
+  "expectedType.general": {
+    "message": "通用",
+    "description": "General expected type option"
+  },
+  "expectedType.article": {
+    "message": "文章",
+    "description": "Article expected type option"
+  },
+  "expectedType.product": {
+    "message": "商品",
+    "description": "Product expected type option"
+  },
+  "waitUntil.networkidle": {
+    "message": "网络空闲",
+    "description": "Wait until network idle option"
+  },
+  "waitUntil.load": {
+    "message": "页面加载完成",
+    "description": "Wait until load option"
+  },
+  "waitUntil.domcontentloaded": {
+    "message": "DOM 就绪",
+    "description": "Wait until DOM content loaded option"
+  },
+  "waitUntil.commit": {
+    "message": "导航开始",
+    "description": "Wait until commit option"
+  },
+  "blockResource.image": {
+    "message": "图片",
+    "description": "Block images option"
+  },
+  "blockResource.font": {
+    "message": "字体",
+    "description": "Block fonts option"
+  },
+  "blockResource.media": {
+    "message": "媒体",
+    "description": "Block media option"
+  },
+  "blockResource.stylesheet": {
+    "message": "样式表",
+    "description": "Block stylesheets option"
+  },
+  "blockResource.xhr": {
+    "message": "XHR",
+    "description": "Block XHR option"
+  },
+  "blockResource.fetch": {
+    "message": "Fetch",
+    "description": "Block fetch option"
+  },
+  "placeholder.url": {
+    "message": "https://example.com",
+    "description": "Placeholder for the URL input"
+  },
+  "placeholder.waitForSelector": {
+    "message": "CSS 选择器，例如 .article-body",
+    "description": "Placeholder for the wait_for_selector input"
+  },
+  "placeholder.blockResources": {
+    "message": "选择要屏蔽的资源类型",
+    "description": "Placeholder for the block_resources multi-select"
+  },
+  "button.extract": {
+    "message": "抽取",
+    "description": "Run extract button label"
+  },
+  "button.render": {
+    "message": "渲染",
+    "description": "Run render button label"
+  },
+  "description.intro": {
+    "message": "渲染并抽取任意网页",
+    "description": "Intro line shown in the empty result state"
+  },
+  "description.introHint": {
+    "message": "输入网址，选择「抽取」或「渲染」即可获取干净的正文、Markdown、链接、截图等。",
+    "description": "Hint shown below the intro line"
+  },
+  "description.enableLlm": {
+    "message": "使用 LLM 对抽取出的内容进行二次清洗与结构化整理，会额外消耗积分。",
+    "description": "Tooltip explaining the LLM cleanup toggle"
+  },
+  "message.running": {
+    "message": "正在处理…",
+    "description": "Status while a request is in flight"
+  },
+  "message.extracting": {
+    "message": "正在抽取…",
+    "description": "Status shown when extract is running"
+  },
+  "message.rendering": {
+    "message": "正在渲染…",
+    "description": "Status shown when render is running"
+  },
+  "message.success": {
+    "message": "完成",
+    "description": "Toast shown on success"
+  },
+  "message.failed": {
+    "message": "请求失败",
+    "description": "Generic error message"
+  },
+  "message.usedUp": {
+    "message": "额度已用完，请充值后再试。",
+    "description": "Error shown when balance is exhausted"
+  },
+  "message.busy": {
+    "message": "服务繁忙，请稍后再试。",
+    "description": "Error shown on rate limit"
+  },
+  "message.timeout": {
+    "message": "页面加载超时，请更换网址或调大超时时间。",
+    "description": "Error shown on timeout"
+  },
+  "message.untitled": {
+    "message": "未命名页面",
+    "description": "Fallback title when the page has no title"
+  },
+  "tab.markdown": {
+    "message": "Markdown",
+    "description": "Markdown tab label"
+  },
+  "tab.text": {
+    "message": "纯文本",
+    "description": "Plain text tab label"
+  },
+  "tab.structured": {
+    "message": "结构化",
+    "description": "Structured data tab label"
+  },
+  "tab.links": {
+    "message": "链接",
+    "description": "Links tab label"
+  },
+  "tab.images": {
+    "message": "图片",
+    "description": "Images tab label"
+  },
+  "tab.html": {
+    "message": "HTML",
+    "description": "HTML tab label"
+  },
+  "tab.raw": {
+    "message": "原始 JSON",
+    "description": "Raw response tab label"
+  }
+}

--- a/src/i18n/zh-TW/common.json
+++ b/src/i18n/zh-TW/common.json
@@ -511,6 +511,10 @@
     "message": "SERP",
     "description": "網站導航欄中的文本，用於顯示SERP頁面，請不要翻譯此字段，必須保持為'SERP'"
   },
+  "nav.webextrator": {
+    "message": "WebExtrator",
+    "description": "Text in the website navigation bar to display the WebExtrator page, must remain as 'WebExtrator'"
+  },
   "nav.image": {
     "message": "圖片",
     "description": "網站導航欄中的文本，用於顯示圖片頁面"

--- a/src/i18n/zh-TW/site.json
+++ b/src/i18n/zh-TW/site.json
@@ -151,6 +151,10 @@
     "message": "魚音頻",
     "description": "展示在編輯框的標題"
   },
+  "field.featuresWebextrator": {
+    "message": "WebExtrator",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresSupport": {
     "message": "客服支持",
     "description": "展示在編輯框的標題"
@@ -454,6 +458,10 @@
   "message.featuresFish": {
     "message": "打開或關閉魚音頻功能模塊。",
     "description": "魚音頻功能的描述"
+  },
+  "message.featuresWebextrator": {
+    "message": "Enable or disable the WebExtrator feature module.",
+    "description": "Description of the WebExtrator feature"
   },
   "message.featuresLuma": {
     "message": "開啟或關閉 Luma 功能模組。",

--- a/src/i18n/zh-TW/webextrator.json
+++ b/src/i18n/zh-TW/webextrator.json
@@ -1,0 +1,202 @@
+{
+  "name.mode": {
+    "message": "Mode",
+    "description": "Label for render/extract mode toggle"
+  },
+  "name.url": {
+    "message": "URL",
+    "description": "Label for the URL input"
+  },
+  "name.expectedType": {
+    "message": "Expected Type",
+    "description": "Label for expected content type"
+  },
+  "name.enableLlm": {
+    "message": "LLM Cleanup",
+    "description": "Label for enable LLM toggle"
+  },
+  "name.advanced": {
+    "message": "Advanced",
+    "description": "Label for advanced options collapse"
+  },
+  "name.waitUntil": {
+    "message": "Wait Until",
+    "description": "Label for the wait_until field"
+  },
+  "name.waitForSelector": {
+    "message": "Wait For Selector",
+    "description": "Label for the wait_for_selector field"
+  },
+  "name.timeout": {
+    "message": "Timeout (s)",
+    "description": "Label for the timeout field"
+  },
+  "name.delay": {
+    "message": "Delay (s)",
+    "description": "Label for the delay_after_load field"
+  },
+  "name.blockResources": {
+    "message": "Block Resources",
+    "description": "Label for the block_resources multi-select"
+  },
+  "name.consumption": {
+    "message": "Cost",
+    "description": "Label for the per-call cost"
+  },
+  "mode.extract": {
+    "message": "Extract",
+    "description": "Extract mode option"
+  },
+  "mode.render": {
+    "message": "Render",
+    "description": "Render mode option"
+  },
+  "expectedType.general": {
+    "message": "General",
+    "description": "General expected type option"
+  },
+  "expectedType.article": {
+    "message": "Article",
+    "description": "Article expected type option"
+  },
+  "expectedType.product": {
+    "message": "Product",
+    "description": "Product expected type option"
+  },
+  "waitUntil.networkidle": {
+    "message": "Network Idle",
+    "description": "Wait until network idle option"
+  },
+  "waitUntil.load": {
+    "message": "Load",
+    "description": "Wait until load option"
+  },
+  "waitUntil.domcontentloaded": {
+    "message": "DOM Ready",
+    "description": "Wait until DOM content loaded option"
+  },
+  "waitUntil.commit": {
+    "message": "Commit",
+    "description": "Wait until commit option"
+  },
+  "blockResource.image": {
+    "message": "Images",
+    "description": "Block images option"
+  },
+  "blockResource.font": {
+    "message": "Fonts",
+    "description": "Block fonts option"
+  },
+  "blockResource.media": {
+    "message": "Media",
+    "description": "Block media option"
+  },
+  "blockResource.stylesheet": {
+    "message": "Stylesheets",
+    "description": "Block stylesheets option"
+  },
+  "blockResource.xhr": {
+    "message": "XHR",
+    "description": "Block XHR option"
+  },
+  "blockResource.fetch": {
+    "message": "Fetch",
+    "description": "Block fetch option"
+  },
+  "placeholder.url": {
+    "message": "https://example.com",
+    "description": "Placeholder for the URL input"
+  },
+  "placeholder.waitForSelector": {
+    "message": "CSS selector, e.g. .article-body",
+    "description": "Placeholder for the wait_for_selector input"
+  },
+  "placeholder.blockResources": {
+    "message": "Resource types to block",
+    "description": "Placeholder for the block_resources multi-select"
+  },
+  "button.extract": {
+    "message": "Extract",
+    "description": "Run extract button label"
+  },
+  "button.render": {
+    "message": "Render",
+    "description": "Run render button label"
+  },
+  "description.intro": {
+    "message": "Render and extract any web page",
+    "description": "Intro line shown in the empty result state"
+  },
+  "description.introHint": {
+    "message": "Enter a URL and choose Extract or Render to get clean content, markdown, links, screenshots, and more.",
+    "description": "Hint shown below the intro line"
+  },
+  "description.enableLlm": {
+    "message": "Use an LLM to clean and structure the extracted content. Costs additional credits.",
+    "description": "Tooltip explaining the LLM cleanup toggle"
+  },
+  "message.running": {
+    "message": "Working on it…",
+    "description": "Status while a request is in flight"
+  },
+  "message.extracting": {
+    "message": "Extracting…",
+    "description": "Status shown when extract is running"
+  },
+  "message.rendering": {
+    "message": "Rendering…",
+    "description": "Status shown when render is running"
+  },
+  "message.success": {
+    "message": "Done",
+    "description": "Toast shown on success"
+  },
+  "message.failed": {
+    "message": "Request failed",
+    "description": "Generic error message"
+  },
+  "message.usedUp": {
+    "message": "Your quota has been used up. Please top up to continue.",
+    "description": "Error shown when balance is exhausted"
+  },
+  "message.busy": {
+    "message": "Service is busy. Please try again in a moment.",
+    "description": "Error shown on rate limit"
+  },
+  "message.timeout": {
+    "message": "The page took too long to load. Try a different URL or increase the timeout.",
+    "description": "Error shown on timeout"
+  },
+  "message.untitled": {
+    "message": "Untitled",
+    "description": "Fallback title when the page has no title"
+  },
+  "tab.markdown": {
+    "message": "Markdown",
+    "description": "Markdown tab label"
+  },
+  "tab.text": {
+    "message": "Text",
+    "description": "Plain text tab label"
+  },
+  "tab.structured": {
+    "message": "Structured",
+    "description": "Structured data tab label"
+  },
+  "tab.links": {
+    "message": "Links",
+    "description": "Links tab label"
+  },
+  "tab.images": {
+    "message": "Images",
+    "description": "Images tab label"
+  },
+  "tab.html": {
+    "message": "HTML",
+    "description": "HTML tab label"
+  },
+  "tab.raw": {
+    "message": "Raw JSON",
+    "description": "Raw response tab label"
+  }
+}

--- a/src/layouts/Webextrator.vue
+++ b/src/layouts/Webextrator.vue
@@ -1,0 +1,60 @@
+<template>
+  <div class="main flex flex-row flex-1">
+    <div
+      class="config w-[340px] flex-none h-full overflow-y-auto bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+    >
+      <slot name="config" />
+    </div>
+    <div class="result h-full flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
+      <slot name="result" />
+    </div>
+    <el-button circle class="menu" @click="drawer = true">
+      <font-awesome-icon icon="fa-solid fa-sliders" />
+    </el-button>
+    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px" class="drawer">
+      <slot name="config" />
+    </el-drawer>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElDrawer, ElButton } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+
+export default defineComponent({
+  name: 'LayoutWebextrator',
+  components: {
+    ElDrawer,
+    ElButton,
+    FontAwesomeIcon
+  },
+  data() {
+    return {
+      drawer: false
+    };
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.menu {
+  display: none;
+}
+
+@media (max-width: 767px) {
+  .config {
+    display: none;
+  }
+  .result {
+    width: 100%;
+  }
+  .menu {
+    display: block;
+    position: absolute;
+    right: 8px;
+    top: 45px;
+    z-index: 1000;
+  }
+}
+</style>

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -28,6 +28,7 @@ export * from './seedream';
 export * from './seedance';
 export * from './serp';
 export * from './wan';
+export * from './webextrator';
 export * from './fish';
 export * from './site';
 export * from './site_domain';

--- a/src/models/site.ts
+++ b/src/models/site.ts
@@ -25,6 +25,7 @@ export interface ISiteFeatures {
   kimi?: any;
   serp?: any;
   fish?: any;
+  webextrator?: any;
   support?: any;
   subsite?: ISiteSubsiteFeature;
 }

--- a/src/models/webextrator.ts
+++ b/src/models/webextrator.ts
@@ -1,0 +1,97 @@
+export type IWebextratorMode = 'render' | 'extract';
+
+export type IWebextratorWaitUntil = 'load' | 'domcontentloaded' | 'networkidle' | 'commit';
+
+export type IWebextratorExpectedType = 'general' | 'article' | 'product';
+
+export type IWebextratorBlockResource = 'image' | 'font' | 'media' | 'stylesheet' | 'xhr' | 'fetch';
+
+export interface IWebextratorConfig {
+  mode?: IWebextratorMode;
+  url?: string;
+  wait_until?: IWebextratorWaitUntil;
+  wait_for_selector?: string;
+  timeout?: number;
+  delay?: number;
+  block_resources?: IWebextratorBlockResource[];
+  user_agent?: string;
+  expected_type?: IWebextratorExpectedType;
+  enable_llm?: boolean;
+}
+
+export interface IWebextratorRenderRequest {
+  url: string;
+  wait_until?: IWebextratorWaitUntil;
+  wait_for_selector?: string;
+  timeout?: number;
+  delay?: number;
+  block_resources?: IWebextratorBlockResource[];
+  user_agent?: string;
+}
+
+export interface IWebextratorExtractRequest extends IWebextratorRenderRequest {
+  expected_type?: IWebextratorExpectedType;
+  enable_llm?: boolean;
+}
+
+export interface IWebextratorErrorBody {
+  code?: string;
+  message?: string;
+}
+
+export interface IWebextratorRenderData {
+  kind?: 'render';
+  url?: string;
+  finalUrl?: string;
+  final_url?: string;
+  title?: string;
+  status?: number;
+  html?: string;
+  text?: string;
+  markdown?: string;
+  screenshot?: string;
+  links?: string[];
+  userAgent?: string;
+  user_agent?: string;
+  elapsedMs?: number;
+  elapsed_ms?: number;
+}
+
+export interface IWebextratorExtractData {
+  kind?: 'extract';
+  url?: string;
+  finalUrl?: string;
+  final_url?: string;
+  title?: string;
+  description?: string;
+  byline?: string;
+  author?: string;
+  published_at?: string;
+  siteName?: string;
+  site_name?: string;
+  contentType?: string;
+  content_type?: string;
+  expected_type?: string;
+  content?: string;
+  summary?: string;
+  markdown?: string;
+  text?: string;
+  html?: string;
+  screenshot?: string;
+  images?: string[];
+  links?: string[];
+  structured?: Record<string, unknown>;
+}
+
+export type IWebextratorData = IWebextratorRenderData | IWebextratorExtractData;
+
+export interface IWebextratorResponse {
+  success?: boolean;
+  task_id?: string;
+  trace_id?: string;
+  started_at?: string;
+  finished_at?: string;
+  elapsed?: number;
+  data?: IWebextratorData;
+  error?: IWebextratorErrorBody;
+}

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -31,6 +31,7 @@ export * from './seedream';
 export * from './seedance';
 export * from './serp';
 export * from './wan';
+export * from './webextrator';
 export * from './fish';
 export * from './config';
 export * from './agent';

--- a/src/operators/webextrator.ts
+++ b/src/operators/webextrator.ts
@@ -1,0 +1,40 @@
+import axios, { AxiosResponse } from 'axios';
+import { IWebextratorExtractRequest, IWebextratorRenderRequest, IWebextratorResponse } from '@/models';
+import { BASE_URL_API } from '@/constants';
+
+class WebextratorOperator {
+  async render(
+    data: IWebextratorRenderRequest,
+    options: { token: string }
+  ): Promise<AxiosResponse<IWebextratorResponse>> {
+    return await axios.post('/webextrator/render', data, {
+      headers: {
+        authorization: `Bearer ${options.token}`,
+        'content-type': 'application/json',
+        accept: 'application/json'
+      },
+      baseURL: BASE_URL_API,
+      // Long page renders can legitimately take 60-120s; let the API's own
+      // `timeout` field (passed through the body) be the deciding factor and
+      // give the network another 30s of headroom on top.
+      timeout: 150_000
+    });
+  }
+
+  async extract(
+    data: IWebextratorExtractRequest,
+    options: { token: string }
+  ): Promise<AxiosResponse<IWebextratorResponse>> {
+    return await axios.post('/webextrator/extract', data, {
+      headers: {
+        authorization: `Bearer ${options.token}`,
+        'content-type': 'application/json',
+        accept: 'application/json'
+      },
+      baseURL: BASE_URL_API,
+      timeout: 180_000
+    });
+  }
+}
+
+export const webextratorOperator = new WebextratorOperator();

--- a/src/pages/webextrator/Index.vue
+++ b/src/pages/webextrator/Index.vue
@@ -1,0 +1,55 @@
+<template>
+  <layout>
+    <template #config>
+      <config-panel @run="onRun" />
+    </template>
+    <template #result>
+      <result-panel />
+    </template>
+  </layout>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import Layout from '@/layouts/Webextrator.vue';
+import ConfigPanel from '@/components/webextrator/ConfigPanel.vue';
+import ResultPanel from '@/components/webextrator/ResultPanel.vue';
+import { ElMessage } from 'element-plus';
+import { ERROR_CODE_USED_UP } from '@/constants';
+
+export default defineComponent({
+  name: 'WebextratorIndex',
+  components: {
+    Layout,
+    ConfigPanel,
+    ResultPanel
+  },
+  inject: ['initialized'],
+  async mounted() {
+    await this.$store.dispatch('webextrator/getService');
+  },
+  methods: {
+    async onRun() {
+      const config = this.$store.state.webextrator?.config;
+      if (!config?.url) return;
+      const isExtract = (config.mode || 'extract') === 'extract';
+      ElMessage.info(this.$t(isExtract ? 'webextrator.message.extracting' : 'webextrator.message.rendering'));
+      try {
+        await this.$store.dispatch('webextrator/run');
+        ElMessage.success(this.$t('webextrator.message.success'));
+      } catch (error: any) {
+        const code = error?.response?.data?.error?.code || error?.response?.data?.code;
+        if (code === ERROR_CODE_USED_UP) {
+          ElMessage.error(this.$t('webextrator.message.usedUp'));
+        } else if (code === 'too_many_requests') {
+          ElMessage.error(this.$t('webextrator.message.busy'));
+        } else if (code === 'timeout') {
+          ElMessage.error(this.$t('webextrator.message.timeout'));
+        } else {
+          ElMessage.error(this.$t('webextrator.message.failed'));
+        }
+      }
+    }
+  }
+});
+</script>

--- a/src/router/constants.ts
+++ b/src/router/constants.ts
@@ -73,6 +73,8 @@ export const ROUTE_WAN_INDEX = 'wan-index';
 export const ROUTE_FISH_TTS_INDEX = 'fish-tts-index';
 export const ROUTE_FISH_MODEL_INDEX = 'fish-model-index';
 
+export const ROUTE_WEBEXTRATOR_INDEX = 'webextrator-index';
+
 export const ROUTE_PROFILE_INDEX = 'profile-index';
 
 export const ROUTE_CONSOLE_ROOT = 'console-root';

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -30,6 +30,7 @@ import seedance from './seedance';
 import serp from './serp';
 import wan from './wan';
 import fish from './fish';
+import webextrator from './webextrator';
 import settings from './settings';
 import profile from './profile';
 
@@ -57,6 +58,7 @@ import {
   ROUTE_WAN_INDEX,
   ROUTE_SERP_INDEX,
   ROUTE_FISH_TTS_INDEX,
+  ROUTE_WEBEXTRATOR_INDEX,
   ROUTE_NOT_FOUND
 } from './constants';
 import { getCookie } from 'typescript-cookie';
@@ -232,6 +234,13 @@ const ROUTE_SEO: Record<string, { title: string; description: string; keywords: 
       'Search the web with Google — powered by SERP API. Get organic results, knowledge graphs, images, and more.',
     keywords: ['Search', 'Google Search', 'SERP', 'Web Search'],
     category: 'Web Search'
+  },
+  webextrator: {
+    title: 'WebExtrator',
+    description:
+      'Render and extract any web page with WebExtrator — get HTML, markdown, plain text, structured data, links, and screenshots from any URL.',
+    keywords: ['WebExtrator', 'Web Scraping', 'Web Render', 'Content Extraction', 'Markdown', 'Headless Browser'],
+    category: 'Web Data'
   }
 };
 
@@ -268,7 +277,8 @@ const FEATURE_ROUTE_PRIORITY: Array<[string, string]> = [
   ['seedance', ROUTE_SEEDANCE_INDEX],
   ['pixverse', ROUTE_PIXVERSE_INDEX],
   ['wan', ROUTE_WAN_INDEX],
-  ['serp', ROUTE_SERP_INDEX]
+  ['serp', ROUTE_SERP_INDEX],
+  ['webextrator', ROUTE_WEBEXTRATOR_INDEX]
 ];
 
 const getDefaultRoute = (): { name: string } => {
@@ -318,6 +328,7 @@ const routes = [
   serp,
   wan,
   fish,
+  webextrator,
   midjourney,
   distribution,
   download,

--- a/src/router/webextrator.ts
+++ b/src/router/webextrator.ts
@@ -1,0 +1,17 @@
+import { ROUTE_WEBEXTRATOR_INDEX } from './constants';
+
+export default {
+  path: '/webextrator',
+  meta: {
+    auth: true,
+    appName: 'webextrator'
+  },
+  component: () => import('@/layouts/Main.vue'),
+  children: [
+    {
+      path: '',
+      name: ROUTE_WEBEXTRATOR_INDEX,
+      component: () => import('@/pages/webextrator/Index.vue')
+    }
+  ]
+};

--- a/src/store/common/models.ts
+++ b/src/store/common/models.ts
@@ -20,6 +20,7 @@ import { ISeedanceState } from '../seedance/models';
 import { ISerpState } from '../serp/models';
 import { IWanState } from '../wan/models';
 import { IFishState } from '../fish/models';
+import { IWebextratorState } from '../webextrator/models';
 
 export interface ISetting {}
 
@@ -70,6 +71,7 @@ export interface IAppState {
   serp: ISerpState;
   wan: IWanState;
   fish: IFishState;
+  webextrator: IWebextratorState;
 }
 
 export interface IRootState extends ICommonState, IAppState {}

--- a/src/store/common/state.ts
+++ b/src/store/common/state.ts
@@ -20,6 +20,7 @@ import seedanceState from '../seedance/state';
 import serpState from '../serp/state';
 import wanState from '../wan/state';
 import fishState from '../fish/state';
+import webextratorState from '../webextrator/state';
 
 export default (): IRootState => {
   return {
@@ -65,6 +66,7 @@ export default (): IRootState => {
     seedance: seedanceState(),
     serp: serpState(),
     wan: wanState(),
-    fish: fishState()
+    fish: fishState(),
+    webextrator: webextratorState()
   };
 };

--- a/src/store/lazy.ts
+++ b/src/store/lazy.ts
@@ -42,7 +42,8 @@ const moduleLoaders: Record<string, () => Promise<{ default: AnyVuexModule }>> =
   seedance: () => import('./seedance'),
   serp: () => import('./serp'),
   wan: () => import('./wan'),
-  fish: () => import('./fish')
+  fish: () => import('./fish'),
+  webextrator: () => import('./webextrator')
 };
 
 /** Names of every lazy-registerable per-app module (single source of truth). */

--- a/src/store/webextrator/actions.ts
+++ b/src/store/webextrator/actions.ts
@@ -1,0 +1,156 @@
+import { applicationOperator, credentialOperator, serviceOperator, webextratorOperator } from '@/operators';
+import { ActionContext } from 'vuex';
+import { IApplication, ICredential, IService, IWebextratorConfig, Status } from '@/models';
+import { IRootState } from '../common/models';
+import { IWebextratorState } from './models';
+import { WEBEXTRATOR_SERVICE_ID } from '@/constants';
+
+export const resetAll = ({ commit }: ActionContext<IWebextratorState, IRootState>): void => {
+  commit('resetAll');
+};
+
+export const setApplication = async ({ commit, dispatch }: any, payload: IApplication): Promise<void> => {
+  console.debug('webextrator: set application', payload);
+  commit('setApplication', payload);
+  if (!payload) {
+    return;
+  }
+  const credential = payload?.credentials?.find((credential) => credential?.host === window.location.origin);
+  if (credential) {
+    commit('setCredential', credential);
+  } else {
+    await dispatch('createCredential');
+  }
+};
+
+export const setApplications = async ({ commit }: any, payload: IApplication[]): Promise<void> => {
+  commit('setApplications', payload);
+};
+
+export const setService = async ({ commit }: any, payload: IService): Promise<void> => {
+  commit('setService', payload);
+};
+
+export const setCredential = async ({ commit }: any, payload: ICredential): Promise<void> => {
+  commit('setCredential', payload);
+};
+
+export const createCredential = async ({ commit, state }: any): Promise<ICredential | undefined> => {
+  const application = state.application;
+  if (!application) {
+    console.error('webextrator: application not found');
+    return undefined;
+  }
+  const { data: credential } = await credentialOperator.create({
+    application_id: application?.id,
+    host: window.location.origin
+  });
+  commit('setCredential', credential);
+  return credential;
+};
+
+export const getService = async ({
+  commit,
+  state
+}: ActionContext<IWebextratorState, IRootState>): Promise<IService | undefined> => {
+  state.status.getService = Status.Request;
+  try {
+    const { data: service } = await serviceOperator.get(WEBEXTRATOR_SERVICE_ID);
+    state.status.getService = Status.Success;
+    commit('setService', service);
+    return service;
+  } catch (error) {
+    state.status.getService = Status.Error;
+    commit('setService', undefined);
+  }
+};
+
+export const getApplications = async ({
+  commit,
+  state,
+  rootState
+}: ActionContext<IWebextratorState, IRootState>): Promise<IApplication[] | undefined> => {
+  state.status.getApplications = Status.Request;
+  try {
+    const { data: applications } = await applicationOperator.getAll({
+      user_id: rootState?.user?.id,
+      service_id: WEBEXTRATOR_SERVICE_ID
+    });
+    state.status.getApplications = Status.Success;
+    commit('setApplications', applications.items);
+    return applications.items;
+  } catch (error) {
+    console.error('webextrator: get applications failed', error);
+    state.status.getApplications = Status.Error;
+    commit('setApplications', undefined);
+    commit('setApplication', undefined);
+  }
+};
+
+export const setConfig = ({ commit }: any, payload: IWebextratorConfig) => {
+  commit('setConfig', payload);
+};
+
+export const run = async ({ commit, state }: ActionContext<IWebextratorState, IRootState>): Promise<void> => {
+  const credential = state.credential;
+  const token = credential?.token;
+  if (!token) {
+    console.error('webextrator: no token specified');
+    return;
+  }
+  const config = state.config;
+  if (!config?.url) {
+    console.error('webextrator: no url specified');
+    return;
+  }
+  state.status.run = Status.Request;
+  // Trim empty optional fields before sending.
+  const base = {
+    url: config.url,
+    wait_until: config.wait_until,
+    timeout: config.timeout,
+    delay: config.delay,
+    wait_for_selector: config.wait_for_selector || undefined,
+    block_resources: config.block_resources?.length ? config.block_resources : undefined,
+    user_agent: config.user_agent || undefined
+  };
+  try {
+    const { data } =
+      config.mode === 'render'
+        ? await webextratorOperator.render(base, { token })
+        : await webextratorOperator.extract(
+            {
+              ...base,
+              expected_type: config.expected_type,
+              enable_llm: !!config.enable_llm
+            },
+            { token }
+          );
+    state.status.run = Status.Success;
+    commit('setResponse', data);
+  } catch (error: any) {
+    state.status.run = Status.Error;
+    // Try to surface the structured error body so the page can react to it
+    // (e.g. ERROR_CODE_USED_UP) without re-throwing.
+    const responseBody = error?.response?.data;
+    if (responseBody && typeof responseBody === 'object') {
+      commit('setResponse', responseBody);
+    } else {
+      commit('setResponse', undefined);
+    }
+    throw error;
+  }
+};
+
+export default {
+  createCredential,
+  setService,
+  getService,
+  resetAll,
+  setCredential,
+  setConfig,
+  setApplications,
+  setApplication,
+  getApplications,
+  run
+};

--- a/src/store/webextrator/index.ts
+++ b/src/store/webextrator/index.ts
@@ -1,0 +1,14 @@
+import { Module } from 'vuex';
+import { IWebextratorState } from './models';
+import actions from './actions';
+import mutations from './mutations';
+import state from './state';
+
+export const webextrator: Module<IWebextratorState, any> = {
+  namespaced: true,
+  state,
+  mutations,
+  actions
+};
+
+export default webextrator;

--- a/src/store/webextrator/models.ts
+++ b/src/store/webextrator/models.ts
@@ -1,0 +1,15 @@
+import { IApplication, ICredential, IService, IWebextratorConfig, IWebextratorResponse, Status } from '@/models';
+
+export interface IWebextratorState {
+  application: IApplication | undefined;
+  applications: IApplication[] | undefined;
+  service: IService | undefined;
+  credential: ICredential | undefined;
+  config: IWebextratorConfig | undefined;
+  response: IWebextratorResponse | undefined;
+  status: {
+    getService: Status;
+    getApplications: Status;
+    run: Status;
+  };
+}

--- a/src/store/webextrator/mutations.ts
+++ b/src/store/webextrator/mutations.ts
@@ -1,0 +1,41 @@
+import { IApplication, ICredential, IService, IWebextratorConfig, IWebextratorResponse } from '@/models';
+import initialState from './state';
+import { IWebextratorState } from './models';
+
+export const resetAll = (state: IWebextratorState): void => {
+  Object.assign(state, initialState());
+};
+
+export const setService = (state: IWebextratorState, payload: IService): void => {
+  state.service = payload;
+};
+
+export const setCredential = (state: IWebextratorState, payload: ICredential): void => {
+  state.credential = payload;
+};
+
+export const setApplication = (state: IWebextratorState, payload: IApplication): void => {
+  state.application = payload;
+};
+
+export const setApplications = (state: IWebextratorState, payload: IApplication[]): void => {
+  state.applications = payload;
+};
+
+export const setConfig = (state: IWebextratorState, payload: IWebextratorConfig): void => {
+  state.config = payload;
+};
+
+export const setResponse = (state: IWebextratorState, payload: IWebextratorResponse | undefined): void => {
+  state.response = payload;
+};
+
+export default {
+  setApplication,
+  setApplications,
+  setConfig,
+  setCredential,
+  setService,
+  setResponse,
+  resetAll
+};

--- a/src/store/webextrator/persist.ts
+++ b/src/store/webextrator/persist.ts
@@ -1,0 +1,1 @@
+export default ['webextrator.credential', 'webextrator.application', 'webextrator.applications', 'webextrator.config'];

--- a/src/store/webextrator/state.ts
+++ b/src/store/webextrator/state.ts
@@ -1,0 +1,25 @@
+import { IWebextratorState } from './models';
+import { Status } from '@/models';
+
+export default (): IWebextratorState => {
+  return {
+    service: undefined,
+    application: undefined,
+    applications: undefined,
+    credential: undefined,
+    config: {
+      mode: 'extract',
+      wait_until: 'networkidle',
+      expected_type: 'general',
+      enable_llm: false,
+      timeout: 30,
+      block_resources: ['image', 'font', 'media']
+    },
+    response: undefined,
+    status: {
+      getService: Status.None,
+      getApplications: Status.None,
+      run: Status.None
+    }
+  };
+};


### PR DESCRIPTION
## Summary

Adds a brand-new **/webextrator** page that lets users hit the WebExtrator API (`api.acedata.cloud/webextrator/{render,extract}`) directly from Nexior — both **Render** (full HTML / headless browser dump) and **Extract** (cleaned title / markdown / structured data / links / images / screenshot) modes are exposed in a single, two-pane page modelled after the existing **Serp** and **Fish** integrations.

## UX

**Left config sidebar (340 px):**
- Render / Extract mode toggle (radio chips).
- URL input — submit on `Enter`, validated as `http(s)://…` before the run button enables.
- Extract-only fields: Expected Type (general/article/product) + LLM-cleanup switch (with explanation tooltip).
- Advanced collapse: `wait_until`, `wait_for_selector`, `timeout`, `delay_after_load`, `block_resources` multiselect.
- Cost line + primary action button. Button label switches between **Extract** / **Render** based on mode.

**Right result panel:**
- Skeleton + status line while a request is in flight.
- Empty-state intro with icon when nothing has been run yet.
- On success: title, final URL, status code, elapsed time, content-type label, optional inline screenshot preview (handles both `data:` URLs and bare base64).
- Auto-selected `el-tabs`: **Markdown / Text / Structured / Links / Images / HTML / Raw JSON**. Tabs that have no data are hidden; the most useful tab is selected automatically each time a new response arrives.
- Every text tab has a `<copy-to-clipboard>` action; image/link tabs have native previews / clickable lists.
- Errors render as an `el-alert` with the API's `error.message` / `code`. Known error codes are mapped to friendly toasts (`used_up`, `too_many_requests`, `timeout`).

## Plumbing

- New constants (`src/constants/webextrator.ts`): service id `38bebded-b12d-4c1c-9a91-cdaccdd71745`, alias `webextrator`, logo `https://cdn.acedata.cloud/782648959c.png`, route name.
- New models (`src/models/webextrator.ts`): `IWebextratorMode`, `IWebextratorRenderRequest`, `IWebextratorExtractRequest`, `IWebextratorRenderData`, `IWebextratorExtractData`, `IWebextratorResponse`, `IWebextratorConfig`. Tolerates both `camelCase` and `snake_case` aliases coming back from the API.
- New operator (`src/operators/webextrator.ts`): `WebextratorOperator.render(...)` (150 s timeout) and `.extract(...)` (180 s timeout) — POSTs to `${BASE_URL_API}/webextrator/render|extract` with `Authorization: Bearer ${token}`.
- New Vuex module (`src/store/webextrator/*`) — lazy-loaded via `src/store/lazy.ts`, persisted credential/application/applications/config via the standard `persist.ts` glob.
- New layout (`src/layouts/Webextrator.vue`) — same shell as Serp (340 px config + flex-1 result + mobile drawer).
- New page (`src/pages/webextrator/Index.vue`) — dispatches `webextrator/getService` on mount and `webextrator/run` on the config-panel `@run` event.
- New router (`src/router/webextrator.ts`) + `ROUTE_WEBEXTRATOR_INDEX` in `src/router/constants.ts` + entry in `routes`, `FEATURE_ROUTE_PRIORITY`, and `ROUTE_SEO` inside `src/router/index.ts`.
- Sidebar entry in `src/components/common/Navigator.vue` gated by `site.features.webextrator.enabled`.
- Admin toggle: `'webextrator'` added to `FEATURE_KEYS` in `src/components/setting/Function.vue`, plus matching `ISiteFeatures.webextrator` field in `src/models/site.ts`.
- Full **zh-CN** + **en** i18n: new `src/i18n/{zh-CN,en}/webextrator.json` namespace (registered in `I18N_SCOPES`), plus `nav.webextrator` in `common.json` and `field.featuresWebextrator` / `message.featuresWebextrator` in `site.json`.

## Touched / untouched

- New files only under `webextrator/` paths, plus narrow additions to the shared registries (constants barrel, models barrel, router index/constants, navigator, function settings, site model, lazy store, i18n scope list, two locale shared files).
- No existing routes / pages / styles refactored.

## Verification

- `npx vue-tsc --noEmit` ✅ clean.
- `npm run lint` (eslint --fix) ✅ clean (only intended files staged; incidental formatting changes elsewhere from lint --fix were reverted).
- Manual flow not exercised against a live token in this PR; the operator follows the same shape as the published WebExtrator OpenAPI spec.

## Out of scope

- No backend / cost changes — the service definition + cost (`0.005` credits flat) already exists on PlatformBackend.
- No Docs site update.
