### PR TITLE
feat(midjourney): add V8.1 version support to selectors and isV8 checks

### DIFF
--- a/change/@acedatacloud-nexior-mj-v8-1.json
+++ b/change/@acedatacloud-nexior-mj-v8-1.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(midjourney): add V8.1 version support with HD-by-default and updated pricing in selectors",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/midjourney/ConfigPanel.vue
+++ b/src/components/midjourney/ConfigPanel.vue
@@ -117,7 +117,7 @@ export default defineComponent({
       return this.$store.state.midjourney.config;
     },
     isV8(): boolean {
-      return this.config?.version === '8';
+      return this.config?.version === '8' || this.config?.version === '8.1';
     },
     isNiji(): boolean {
       return !!this.config?.model?.includes('niji');

--- a/src/components/midjourney/config/QualitySelector.vue
+++ b/src/components/midjourney/config/QualitySelector.vue
@@ -25,7 +25,7 @@ export default defineComponent({
       return this.$store.state.midjourney.config.version || '';
     },
     isV8(): boolean {
-      return this.version === '8';
+      return this.version === '8' || this.version === '8.1';
     },
     options() {
       if (this.isV8) {

--- a/src/components/midjourney/config/VersionSelector.vue
+++ b/src/components/midjourney/config/VersionSelector.vue
@@ -11,7 +11,7 @@
 import { defineComponent } from 'vue';
 import { ElSelect, ElOption } from 'element-plus';
 
-const DEFAULT_VERSION = '7';
+const DEFAULT_VERSION = '8.1';
 
 export default defineComponent({
   name: 'VersionSelector',
@@ -30,8 +30,12 @@ export default defineComponent({
     return {
       options: [
         {
+          value: '8.1',
+          label: '8.1'
+        },
+        {
           value: '8',
-          label: '8 (Alpha)'
+          label: '8'
         },
         {
           value: '7',

--- a/src/pages/midjourney/Index.vue
+++ b/src/pages/midjourney/Index.vue
@@ -338,7 +338,7 @@ export default defineComponent({
         };
         await this.onStartVideosTask(request);
       } else if (this.config?.type === 'imagine') {
-        const isV8 = this.config?.version === '8';
+        const isV8 = this.config?.version === '8' || this.config?.version === '8.1';
         const hasSref = !!(this.finalPrompt && this.finalPrompt.includes('--sref'));
         const hasMoodboard = !!(isV8 && this.config?.references && this.config.references.length > 0);
         const request = {


### PR DESCRIPTION
## Why

[Midjourney V8.1](https://updates.midjourney.com/v8-1-alpha/) is now available. Compared to V8 it ships:

- HD as the **default**, 3x faster and 3x cheaper than V8 HD
- Standard resolution 50% faster, 25% cheaper
- More stable moodboards / srefs
- Image prompts + image weights restored

The Nexior Midjourney UI was hard-pinned to `'8'` in four places, so without these changes V8.1 users would not see the HD toggle, would get the old quality options, and moodboard auto-detection would not fire.

## What

`src/components/midjourney/config/VersionSelector.vue`:

- Prepend `{ value: '8.1', label: '8.1' }` to the dropdown
- Drop the `(Alpha)` suffix from `'8'` (V8 is no longer alpha now that V8.1 is here)
- Change `DEFAULT_VERSION` from `'7'` to `'8.1'` so new users land on the cheapest/most capable model

`src/components/midjourney/ConfigPanel.vue`, `src/components/midjourney/config/QualitySelector.vue`, `src/pages/midjourney/Index.vue`:

- `isV8` computed / inline check now matches both `'8'` and `'8.1'`, so V8.1 unlocks the HD toggle, the V8 quality buttons (`1` / `4`), and moodboard auto-detection (`hasMoodboard` flag).

## Tests

```
npx eslint src/components/midjourney/config/VersionSelector.vue src/components/midjourney/config/QualitySelector.vue src/components/midjourney/ConfigPanel.vue src/pages/midjourney/Index.vue
# clean
```

## Related

- AceDataCloud/PlatformBackend#472 — V8.1 cost rules + OpenAPI + tests
- AceDataCloud/PlatformService#885 — ttapi worker V8.1 detection fix