### PR TITLE
fix(byok): prevent provider dropdown option overflow in Add API Key dialog

### DIFF
--- a/src/components/setting/byok/Dialog.vue
+++ b/src/components/setting/byok/Dialog.vue
@@ -12,6 +12,7 @@
           v-model="form.provider"
           :placeholder="$t('byok.field.provider')"
           :disabled="!!credential"
+          popper-class="byok-provider-select-popper"
           class="w-full"
         >
           <el-option v-for="opt in providers" :key="opt.id" :label="opt.label" :value="opt.id">
@@ -370,7 +371,6 @@ export default defineComponent({
   display: flex;
   flex-direction: column;
   line-height: 1.3;
-  padding: 4px 0;
   gap: 2px;
 }
 
@@ -433,6 +433,22 @@ export default defineComponent({
     background: rgba(0, 0, 0, 0.04);
     padding: 1px 6px;
     border-radius: 4px;
+  }
+}
+</style>
+
+<style lang="scss">
+// Element Plus teleports the select popper to <body>, so scoped styles
+// can't reach it. The default .el-select-dropdown__item has a fixed
+// 34px height / line-height that clips our 2-line custom option slot
+// (provider name + description), causing the description to overlap
+// the next option. Unset both for this dialog's popper only.
+.byok-provider-select-popper {
+  .el-select-dropdown__item {
+    height: auto;
+    line-height: 1.4;
+    padding-top: 8px;
+    padding-bottom: 8px;
   }
 }
 </style>


### PR DESCRIPTION
## Problem

In **Settings → API Key → 添加 API Key (Add API Key)**, the provider `<el-select>` dropdown renders each option as a **two-line custom slot** (provider name + localized one-liner description). The description was clipping and visually overlapping with the next option's name, like this:

> OpenAI
> ~~替换本站 ChatGPT （GPT-4 / GPT-4o / o1 / o3 等）对话请求~~ ← overflowing into the next item
> Anthropic
> ~~替换本站 Claude （Sonnet / Opus / Haiku 等）对话请求~~ ← overflowing
> Google AI
> …

(reproduced on every provider row in the dropdown)

## Root cause

Element Plus' default styling for select options is:

```css
.el-select-dropdown__item {
  height: 34px;
  line-height: 34px;
}
```

That fixed `34px` height was designed for single-line plain-text options. With our custom 2-line slot (provider name + description), the inner content is taller than the item box, so the second line spills downward and renders on top of the next option.

Scoped styles in `Dialog.vue` can't reach the dropdown because **Element Plus teleports the popper to `<body>`** — it's outside the component's DOM subtree.

## Fix

1. Tag the select with a unique [`popper-class="byok-provider-select-popper"`](https://element-plus.org/en-US/component/select.html#select-attributes) so we have a stable selector for the teleported dropdown.
2. Add an **unscoped** `<style lang="scss">` block that scopes its rules to that popper class only, overriding the default item height/line-height and giving each item proper vertical padding.
3. Drop the now-redundant `padding: 4px 0` on `.provider-option` (the option item itself owns the vertical padding now), so the gap between rows comes from the item box, not from inside the slot.

The popper-class scope means **no other `el-select` on the page is affected** — this is a targeted patch for the BYOK dialog only.

## Diff

```diff
       <el-form-item :label="$t('byok.field.provider')" prop="provider">
         <el-select
           v-model="form.provider"
           :placeholder="$t('byok.field.provider')"
           :disabled="!!credential"
+          popper-class="byok-provider-select-popper"
           class="w-full"
         >
```

```diff
 .provider-option {
   display: flex;
   flex-direction: column;
   line-height: 1.3;
-  padding: 4px 0;
   gap: 2px;
 }
```

```scss
// Appended as a non-scoped block at the bottom of the SFC
.byok-provider-select-popper {
  .el-select-dropdown__item {
    height: auto;
    line-height: 1.4;
    padding-top: 8px;
    padding-bottom: 8px;
  }
}
```

## Verification

- ESLint: clean (`./node_modules/.bin/eslint src/components/setting/byok/Dialog.vue` → 0 errors).
- `vue-tsc --noEmit`: clean (0 errors).
- File scope: only `src/components/setting/byok/Dialog.vue` is touched. No i18n, no logic, no API surface change.
- No other `<el-select>` is affected — the override is keyed on the dialog-specific popper class.
