### PR TITLE
fix(ApiCodeDialog): widen gap between API platform logo and label

### DIFF
--- a/change/@acedatacloud-nexior-api-platform-btn-gap.json
+++ b/change/@acedatacloud-nexior-api-platform-btn-gap.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(ApiCodeDialog): widen gap between API platform logo and label so the favicon no longer touches the text inside the el-button slot",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/ApiCodeDialog.vue
+++ b/src/components/common/ApiCodeDialog.vue
@@ -397,13 +397,16 @@ export default defineComponent({
   .platform-btn {
     display: inline-flex;
     align-items: center;
-    gap: 14px;
     font-weight: 500;
 
+    // el-button wraps slot content in <span class="el-button__text">, so a
+    // `gap` on the button has no effect between siblings — use an explicit
+    // inline-end margin (RTL-safe) on the leading logo instead.
     .platform-icon {
       width: 16px;
       height: 16px;
       object-fit: contain;
+      margin-inline-end: 10px;
     }
 
     .ext-icon {


### PR DESCRIPTION
## Summary

In the API code dialog footer, the **API Platform** action button rendered its favicon and label nearly touching (see screenshot in the report). Visually the logo looked like it was glued to the `API Platform` text.

## Root cause

`ApiCodeDialog.vue` styled the button with `display: inline-flex; gap: 14px` on `.platform-btn` — but `el-button` (Element Plus 2.10.4) wraps slot content in an internal `<span class="el-button__text">`. That means the flex container's only child is the wrapping span, so the `gap` never applied between the `<img>`, the text node, and the trailing `<font-awesome-icon>`. The right-side icon still had visible breathing room only because it carries the Tailwind `ml-2` utility (which is a real margin, not a flex gap).

## Fix

Drop the no-op `gap` and put an explicit `margin-inline-end: 10px` on `.platform-icon`. This is RTL-safe so the `ar` locale still keeps the logo on the visual leading side with proper spacing.

```diff
   .platform-btn {
     display: inline-flex;
     align-items: center;
-    gap: 14px;
     font-weight: 500;

     .platform-icon {
       width: 16px;
       height: 16px;
       object-fit: contain;
+      margin-inline-end: 10px;
     }
```

## Test plan

- Open the **API code** dialog from any model studio page (e.g. `/openai-image`).
- Confirm the favicon and `API Platform` label now have a comfortable gap, matching the spacing to the external-link icon on the right.
- Switch to the Arabic (`ar`) locale and verify the spacing flips to the leading side automatically.

Closes the visual issue raised internally about `API Platform` logo/text spacing.

---
*This pull request was generated and committed by the [GitHub Copilot](https://github.com/copilot) coding agent on behalf of @CQUPTQiCu.*