### PR TITLE
chore(subsite): list user subsites by origin suffix from backend

### DIFF
--- a/change/@acedatacloud-nexior-41228d66-b5c2-455a-8ffa-d64758ba37b7.json
+++ b/change/@acedatacloud-nexior-41228d66-b5c2-455a-8ffa-d64758ba37b7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore(subsite): list by origin suffix from backend (origin__endswith)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/change/@acedatacloud-nexior-7e07336b-62f3-453c-8726-83bae9c3bba8.json
+++ b/change/@acedatacloud-nexior-7e07336b-62f3-453c-8726-83bae9c3bba8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore(subsite): drop dead parent-id defensive filter",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/setting/Subsite.vue
+++ b/src/components/setting/Subsite.vue
@@ -208,24 +208,18 @@ export default defineComponent({
       }
       this.loading = true;
       try {
-        // Scope by DNS suffix: the leading dot excludes the parent
-        // (`studio.acedata.cloud`) while matching every subsite
-        // (`<slug>.studio.acedata.cloud`). This is the canonical filter
-        // because it works regardless of how the row was provisioned —
-        // the regular subsite path stamps `metadata.parent_site_id` but
-        // the superuser fast path doesn't, so the previous metadata-based
-        // filter silently hid superuser-created subsites.
+        // Listing is fully scoped by (user_id, origin__endswith=.{zone}).
+        // The leading dot excludes the parent (`studio.acedata.cloud`) by
+        // DNS-hierarchy semantics and matches every subsite
+        // (`<slug>.studio.acedata.cloud`). No `parent_site_id` needed —
+        // the superuser fast path doesn't stamp `metadata.parent_site_id`
+        // anyway, which is why the previous metadata filter hid rows.
         const { data } = await siteOperator.getAll({
           user_id: userId,
           origin__endswith: `.${zone}`,
           ordering: '-created_at'
         });
-        const items = (data?.items || []) as ISite[];
-        const parentId = this.parentSite?.id;
-        // Defensive: even though `.${zone}` excludes the parent on the
-        // backend, drop anything matching the parent id client-side too,
-        // so a non-canonical origin row (e.g. legacy seed data) can't leak in.
-        this.items = parentId ? items.filter((s) => s.id !== parentId) : items;
+        this.items = (data?.items || []) as ISite[];
       } catch (e) {
         console.error('failed to load subsites', e);
         ElMessage.error(this.$t('subsite.message.loadFailed'));

--- a/src/components/setting/Subsite.vue
+++ b/src/components/setting/Subsite.vue
@@ -198,17 +198,34 @@ export default defineComponent({
         this.items = [];
         return;
       }
+      const zone = this.subdomainZone;
+      if (!zone) {
+        // Parent site hasn't been seeded with a subdomain zone yet —
+        // surface the empty state rather than dumping every site the
+        // user happens to own elsewhere.
+        this.items = [];
+        return;
+      }
       this.loading = true;
       try {
-        const { data } = await siteOperator.getAll({ user_id: userId });
-        const all = (data?.items || []) as ISite[];
-        const parentId = this.parentSite?.id;
-        this.items = all.filter((s) => {
-          if (s.id === parentId) return false;
-          const meta = (s.metadata || {}) as Record<string, unknown>;
-          if (parentId && meta.parent_site_id) return meta.parent_site_id === parentId;
-          return Boolean(s.origin && this.subdomainZone && s.origin.endsWith(`.${this.subdomainZone}`));
+        // Scope by DNS suffix: the leading dot excludes the parent
+        // (`studio.acedata.cloud`) while matching every subsite
+        // (`<slug>.studio.acedata.cloud`). This is the canonical filter
+        // because it works regardless of how the row was provisioned —
+        // the regular subsite path stamps `metadata.parent_site_id` but
+        // the superuser fast path doesn't, so the previous metadata-based
+        // filter silently hid superuser-created subsites.
+        const { data } = await siteOperator.getAll({
+          user_id: userId,
+          origin__endswith: `.${zone}`,
+          ordering: '-created_at'
         });
+        const items = (data?.items || []) as ISite[];
+        const parentId = this.parentSite?.id;
+        // Defensive: even though `.${zone}` excludes the parent on the
+        // backend, drop anything matching the parent id client-side too,
+        // so a non-canonical origin row (e.g. legacy seed data) can't leak in.
+        this.items = parentId ? items.filter((s) => s.id !== parentId) : items;
       } catch (e) {
         console.error('failed to load subsites', e);
         ElMessage.error(this.$t('subsite.message.loadFailed'));

--- a/src/operators/site.ts
+++ b/src/operators/site.ts
@@ -4,7 +4,9 @@ import { ISite, ISiteDetailResponse, ISiteListResponse } from '@/models';
 
 export interface ISiteQuery {
   origin?: string;
+  origin__endswith?: string;
   user_id?: string;
+  ordering?: string;
   offset?: number;
   limit?: number;
 }


### PR DESCRIPTION
## What

Switch `Subsite.vue::fetchSubsites()` from the existing "fetch-all + filter client-side on metadata.parent_site_id" approach to the new PlatformBackend `origin__endswith` filter, and add `origin__endswith` + `ordering` to `ISiteQuery`.

```ts
const { data } = await siteOperator.getAll({
  user_id,
  origin__endswith: `.${subdomainZone}`,
  ordering: '-created_at'
});
```

## Why

The previous flow fetched every site the user owned and matched on `metadata.parent_site_id === parentSite.id`. This silently hid superuser-created subsites because PlatformBackend's superuser create fast path (`with_site_owner_defaults`) does **not** stamp `metadata.parent_site_id` — only the regular subsite-create path does. Users with subsites created from the admin UI / shell saw an empty list in their Nexior settings page.

The DNS suffix is the canonical scope — the parent zone is set at provision time and never moves — so filtering by `.${subdomainZone}` works regardless of which create branch ran. The leading dot excludes the parent (`studio.acedata.cloud`) while matching every subsite (`<slug>.studio.acedata.cloud`).

## Preserved behavior

We still load `parentSite` because the create dialog and gating logic need:

- `parentSite.features.subsite.subdomain_zone` — drives the slug→FQDN preview
- `parentSite.features.subsite.max_per_user` — quota gate
- `parentSite.features.subsite.enabled` — feature flag

Only the listing filter changes.

## Depends on

- AceDataCloud/PlatformBackend#474 — exposes the `origin__endswith` filter on `/api/v1/sites/`

The new query field is additive on the backend; this PR is safe to land after #474 deploys.

## Beachball

Included a `change/` file (patch bump).