### PR TITLE
chore(actions): trim Actions usage — ci concurrency + expand paths-ignore

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,13 @@ on:
   pull_request:
     branches: [main]
 
+# Cancel any in-flight `check` run on the same PR branch when a new commit
+# lands. Without this, every PR push leaves the previous check still running
+# to completion — fine for safety, costly for the org Actions minute budget.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,6 +6,12 @@ on:
     paths-ignore:
       - .gitignore
       - README.md
+      - SECURITY.md
+      - LICENSE
+      - CHANGELOG.md
+      - CHANGELOG.json
+      - 'docs/**'
+      - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
 jobs:
   run:

--- a/.github/workflows/publish-dockerhub.yaml
+++ b/.github/workflows/publish-dockerhub.yaml
@@ -6,8 +6,12 @@ on:
     paths-ignore:
       - .gitignore
       - README.md
+      - SECURITY.md
+      - LICENSE
       - CHANGELOG.md
       - CHANGELOG.json
+      - 'docs/**'
+      - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
   workflow_dispatch:
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,6 +6,12 @@ on:
     paths-ignore:
       - .gitignore
       - README.md
+      - SECURITY.md
+      - LICENSE
+      - CHANGELOG.md
+      - CHANGELOG.json
+      - 'docs/**'
+      - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
 jobs:
   run:


### PR DESCRIPTION
## Why

Nexior alone burned ~5,300 Ubuntu min/month in May from GitHub Actions — the largest single repo consumer in the org. Two zero-risk reductions here.

## 1. ci.yaml — add per-branch concurrency

Before:

```yaml
on:
  pull_request:
    branches: [main]
# (no concurrency block — every PR push runs to completion)
```

After:

```yaml
concurrency:
  group: ci-${{ github.ref }}
  cancel-in-progress: true
```

When a PR receives a follow-up push, GitHub will cancel any still-running `check` run on the same branch and only run CI on the new tip. The merge gate cares about the tip-commit run anyway, so this is pure waste-elimination.

**Data:** 352 `check` runs in 15 days × ~106s avg. PRs typically push 2–4 times during their lifecycle, so meaningful cancellation savings.

**Expected savings:** ~300–500 Ubuntu min/month.

## 2. deploy / publish / publish-dockerhub — expand paths-ignore

All three workflows fire on every push to `main` (213 runs each in 15 days = ~14 main pushes/day). Their `paths-ignore` was inconsistent and missed obvious metadata categories. This PR aligns them all to ignore:

```
- .gitignore                       (already)
- README.md                        (already)
- SECURITY.md                      (NEW — pure security policy markdown)
- LICENSE                          (NEW — pure metadata)
- CHANGELOG.md                     (parity — already in publish-dockerhub)
- CHANGELOG.json                   (parity — already in publish-dockerhub)
- 'docs/**'                        (NEW — pure user docs, doesn't affect build)
- '.vscode/**'                     (NEW — editor config)
- '.github/ISSUE_TEMPLATE/**'      (already)
```

Files that intentionally **stay triggering** (because they DO affect the build/deploy artifact):

- `package.json` / `package-lock.json`
- `tsconfig*.json`
- `docker-compose.yaml`
- `vercel.json`
- `src/**`, `public/**`, `scripts/**`
- `.github/workflows/**` (so workflow changes themselves get a smoke deploy)

**Expected savings:** ~200–400 Ubuntu min/month (depends on commit mix; pure CHANGELOG/SECURITY/docs commits become free).

## Out of scope

- **Consolidating deploy + publish + publish-dockerhub into a shared-build pipeline** (would save another ~1500 min/month but needs careful artifact-passing design and per-target secrets review — separate PR).
- **github-release.yaml** (193 runs in 15 days, tag-driven only — can't easily reduce without reducing release cadence).
- **claude.yml** (already short-circuits via `if:` at the job level — ~2s billable per skipped run).

## Verification

```
python3 -c "import yaml; [yaml.safe_load(open(f)) for f in ['.github/workflows/ci.yaml','.github/workflows/deploy.yaml','.github/workflows/publish.yaml','.github/workflows/publish-dockerhub.yaml']]"
```

All 4 files parse cleanly. Triggers unchanged; only `concurrency` (added) and `paths-ignore` (expanded) are touched. No secrets, jobs, or steps modified.

---
*This pull request was generated and committed by the [GitHub Copilot](https://github.com/copilot) coding agent on behalf of @CQUPTQiCu.*