### PR TITLE
chore(subsite): drop parentSite fetch and switch canCreate to isOfficial gate

### DIFF
--- a/change/@acedatacloud-nexior-41228d66-b5c2-455a-8ffa-d64758ba37b7.json
+++ b/change/@acedatacloud-nexior-41228d66-b5c2-455a-8ffa-d64758ba37b7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore(subsite): list by origin suffix from backend (origin__endswith)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/change/@acedatacloud-nexior-7e07336b-62f3-453c-8726-83bae9c3bba8.json
+++ b/change/@acedatacloud-nexior-7e07336b-62f3-453c-8726-83bae9c3bba8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore(subsite): drop dead parent-id defensive filter",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/change/@acedatacloud-nexior-a1b22f5a-ee2c-4499-ab9e-aba69ee0d718.json
+++ b/change/@acedatacloud-nexior-a1b22f5a-ee2c-4499-ab9e-aba69ee0d718.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore(subsite): drop parentSite dependence and switch canCreate to isOfficial gate",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/setting/Subsite.vue
+++ b/src/components/setting/Subsite.vue
@@ -208,24 +208,18 @@ export default defineComponent({
       }
       this.loading = true;
       try {
-        // Scope by DNS suffix: the leading dot excludes the parent
-        // (`studio.acedata.cloud`) while matching every subsite
-        // (`<slug>.studio.acedata.cloud`). This is the canonical filter
-        // because it works regardless of how the row was provisioned —
-        // the regular subsite path stamps `metadata.parent_site_id` but
-        // the superuser fast path doesn't, so the previous metadata-based
-        // filter silently hid superuser-created subsites.
+        // Listing is fully scoped by (user_id, origin__endswith=.{zone}).
+        // The leading dot excludes the parent (`studio.acedata.cloud`) by
+        // DNS-hierarchy semantics and matches every subsite
+        // (`<slug>.studio.acedata.cloud`). No `parent_site_id` needed —
+        // the superuser fast path doesn't stamp `metadata.parent_site_id`
+        // anyway, which is why the previous metadata filter hid rows.
         const { data } = await siteOperator.getAll({
           user_id: userId,
           origin__endswith: `.${zone}`,
           ordering: '-created_at'
         });
-        const items = (data?.items || []) as ISite[];
-        const parentId = this.parentSite?.id;
-        // Defensive: even though `.${zone}` excludes the parent on the
-        // backend, drop anything matching the parent id client-side too,
-        // so a non-canonical origin row (e.g. legacy seed data) can't leak in.
-        this.items = parentId ? items.filter((s) => s.id !== parentId) : items;
+        this.items = (data?.items || []) as ISite[];
       } catch (e) {
         console.error('failed to load subsites', e);
         ElMessage.error(this.$t('subsite.message.loadFailed'));

--- a/src/components/setting/Subsite.vue
+++ b/src/components/setting/Subsite.vue
@@ -98,8 +98,15 @@ import { Plus } from '@element-plus/icons-vue';
 import { siteOperator } from '@/operators';
 import SectionNotice from '@/components/setting/SectionNotice.vue';
 import type { ISite } from '@/models';
+import { isOfficial, isSubOfficial } from '@/utils/is';
+import { BASE_HOST_HUB } from '@/constants';
 
 const SLUG_RE = /^(?!.*--)[a-z0-9][a-z0-9-]{1,30}[a-z0-9]$/;
+
+/** Maximum number of subsites a single user can spin up.  Mirrors the
+ *  default the backend's subsite-create path enforces when the parent
+ *  Site row hasn't been seeded with an explicit per-user quota. */
+const MAX_SUBSITES_PER_USER = 5;
 
 /**
  * Settings tab — manage white-label subsites for the parent (official)
@@ -153,28 +160,41 @@ export default defineComponent({
     };
   },
   computed: {
-    parentSite(): ISite | undefined {
-      return this.$store.state.site;
-    },
     user() {
       return this.$store.getters.user;
     },
+    /**
+     * DNS suffix new subsites are spawned under — always the canonical
+     * Hub host (`BASE_HOST_HUB`, e.g. `studio.acedata.cloud`). The backend's
+     * subsite-create path pins ``origin = f"{slug}.{parent.origin}"`` against
+     * this same value, so we don't need to fetch the parent Site row just to
+     * read it back from ``parent.features.subsite.subdomain_zone``.
+     */
     subdomainZone(): string {
-      const zone = this.parentSite?.features?.subsite?.subdomain_zone;
-      if (zone) return zone;
-      // Fall back to the bare current host so the create dialog can render
-      // even if `state.site` hasn't been hydrated with the subsite block yet.
-      if (typeof window !== 'undefined' && window.location?.host) {
-        return window.location.host.split(':')[0];
-      }
-      return this.parentSite?.origin || '';
+      return BASE_HOST_HUB;
     },
-    maxSubsitesPerUser(): number {
-      const max = this.parentSite?.features?.subsite?.max_subsites_per_user;
-      return typeof max === 'number' && max > 0 ? max : 5;
-    },
+    /**
+     * Whether the current user can spin up another subsite right now.
+     *
+     *   * Must be on the canonical Hub host (`isOfficial()`),
+     *   * NOT on a subsite under it (`!isSubOfficial()`) — subsites can't
+     *     themselves spawn further subsites,
+     *   * Must be signed in (`user.id`),
+     *   * Must be under the per-user quota.
+     *
+     * Mirrors PlatformFrontend's Sites console gate; replaces the previous
+     * `parent.features.subsite.{enabled,subdomain_zone}` lookup which required
+     * fetching the parent Site row just to gate one button + read back a
+     * value (`BASE_HOST_HUB`) that's already a build-time constant on this
+     * side of the wire.
+     */
     canCreate(): boolean {
-      return Boolean(this.subdomainZone) && Boolean(this.user?.id) && this.items.length < this.maxSubsitesPerUser;
+      return (
+        isOfficial() &&
+        !isSubOfficial() &&
+        Boolean(this.user?.id) &&
+        this.items.length < MAX_SUBSITES_PER_USER
+      );
     }
   },
   watch: {
@@ -200,9 +220,10 @@ export default defineComponent({
       }
       const zone = this.subdomainZone;
       if (!zone) {
-        // Parent site hasn't been seeded with a subdomain zone yet —
-        // surface the empty state rather than dumping every site the
-        // user happens to own elsewhere.
+        // SSR / pre-mount path — BASE_HOST_HUB is a constant so this branch
+        // is effectively dead, but keep the guard cheap so we never POST
+        // a query with a blank suffix filter and end up listing every site
+        // the user owns under any host.
         this.items = [];
         return;
       }

--- a/src/components/setting/Subsite.vue
+++ b/src/components/setting/Subsite.vue
@@ -198,17 +198,34 @@ export default defineComponent({
         this.items = [];
         return;
       }
+      const zone = this.subdomainZone;
+      if (!zone) {
+        // Parent site hasn't been seeded with a subdomain zone yet —
+        // surface the empty state rather than dumping every site the
+        // user happens to own elsewhere.
+        this.items = [];
+        return;
+      }
       this.loading = true;
       try {
-        const { data } = await siteOperator.getAll({ user_id: userId });
-        const all = (data?.items || []) as ISite[];
-        const parentId = this.parentSite?.id;
-        this.items = all.filter((s) => {
-          if (s.id === parentId) return false;
-          const meta = (s.metadata || {}) as Record<string, unknown>;
-          if (parentId && meta.parent_site_id) return meta.parent_site_id === parentId;
-          return Boolean(s.origin && this.subdomainZone && s.origin.endsWith(`.${this.subdomainZone}`));
+        // Scope by DNS suffix: the leading dot excludes the parent
+        // (`studio.acedata.cloud`) while matching every subsite
+        // (`<slug>.studio.acedata.cloud`). This is the canonical filter
+        // because it works regardless of how the row was provisioned —
+        // the regular subsite path stamps `metadata.parent_site_id` but
+        // the superuser fast path doesn't, so the previous metadata-based
+        // filter silently hid superuser-created subsites.
+        const { data } = await siteOperator.getAll({
+          user_id: userId,
+          origin__endswith: `.${zone}`,
+          ordering: '-created_at'
         });
+        const items = (data?.items || []) as ISite[];
+        const parentId = this.parentSite?.id;
+        // Defensive: even though `.${zone}` excludes the parent on the
+        // backend, drop anything matching the parent id client-side too,
+        // so a non-canonical origin row (e.g. legacy seed data) can't leak in.
+        this.items = parentId ? items.filter((s) => s.id !== parentId) : items;
       } catch (e) {
         console.error('failed to load subsites', e);
         ElMessage.error(this.$t('subsite.message.loadFailed'));

--- a/src/operators/site.ts
+++ b/src/operators/site.ts
@@ -4,7 +4,9 @@ import { ISite, ISiteDetailResponse, ISiteListResponse } from '@/models';
 
 export interface ISiteQuery {
   origin?: string;
+  origin__endswith?: string;
   user_id?: string;
+  ordering?: string;
   offset?: number;
   limit?: number;
 }


### PR DESCRIPTION
## Summary

The Subsite settings tab (`src/components/setting/Subsite.vue`) no longer
derives `subdomainZone` / `maxSubsitesPerUser` / `canCreate` from
`$store.state.site.features.subsite`. The parent Site row is fetched
elsewhere for branding purposes, but its subsite block isn't needed
here — `subdomainZone` is always the canonical Hub host
(`BASE_HOST_HUB`, e.g. `studio.acedata.cloud`), and the per-user quota
the backend enforces matches our default of 5.

## Changes

* **`src/components/setting/Subsite.vue`**
  * Drop the `parentSite` computed and its dependents (`subdomainZone`,
    `maxSubsitesPerUser`).
  * Add a local `MAX_SUBSITES_PER_USER = 5` constant.
  * `subdomainZone` now returns `BASE_HOST_HUB` unconditionally.
  * Rewrite `canCreate` to `isOfficial() && !isSubOfficial() && Boolean(user?.id) && items.length < MAX_SUBSITES_PER_USER` — same gate shape as PlatformFrontend `console/sites/Index.vue` ([PR #315](https://github.com/AceDataCloud/PlatformFrontend/pull/315)).
  * Imports `isOfficial`, `isSubOfficial` from `@/utils/is` and `BASE_HOST_HUB` from `@/constants`.
* **`change/@acedatacloud-nexior-a1b22f5a-ee2c-4499-ab9e-aba69ee0d718.json`** — beachball patch bump.

## Why

This is the last leg of a three-PR cleanup that removes the
`parent_site_id` surface and the parent-site-row lookup as a
precondition for subsite UI gating:

| # | Repo | PR | What it does |
|---|------|----|--------------|
| A | PlatformBackend | [#477](https://github.com/AceDataCloud/PlatformBackend/pull/477) | Stop writing `metadata.parent_site_id`; drop the proxy_cname resolver branch that consumed it. Quota count uses `origin__endswith=.{parent.origin}`. |
| B | PlatformFrontend | [#315](https://github.com/AceDataCloud/PlatformFrontend/pull/315) | Drop `parent_site_id` from `ISiteMetadata` / `ISiteQuery` / `Advanced.vue` descriptions; rewrite `canCreate` to use `isOfficial()`. |
| C | Nexior | _this PR_ | Mirror the same `isOfficial()` gate; drop the `parent.features.subsite` lookup. |

After all three land, `parent_site_id` is gone from the create / list
/ gate paths end-to-end. Existing rows are untouched; the field simply
stops being written or read.

## Backwards compatibility

* **Existing subsites continue to load.** The listing is fully scoped by
  `(user_id, origin__endswith=.{BASE_HOST_HUB})`, which is exactly what
  the old parent-derived `subdomainZone` resolved to in practice on
  `studio.acedata.cloud`. The leading dot excludes the parent and
  matches every `<slug>.studio.acedata.cloud`.
* **Subsite-tab visibility unchanged.** The upstream `Setting.vue` gate
  already hides this tab on non-official hosts; the
  `SectionNotice tone="official"` banner also stays. The new
  `!isSubOfficial()` check is belt-and-suspenders so the Create button
  never lights up on a subsite even if the upstream gate is ever
  relaxed.
* **No router / route changes.** This tab is invoked from the user
  settings dialog only.

## Risks

* The hardcoded `MAX_SUBSITES_PER_USER = 5` no longer reads
  `parent.features.subsite.max_subsites_per_user`. The backend still
  enforces its own quota on `POST /sites/`, so a stale UI just gets a
  duplication / quota error from the API rather than silently
  over-creating — same as the PlatformFrontend side.
* No new network calls. We're removing the implicit `getAll` of the
  parent site that this code used to depend on (it now isn't fetched
  here at all).

## Verification

* `grep -rn 'parentSite\|maxSubsitesPerUser' src/` → no matches.
* `git log --oneline` confirms one logical commit with the beachball
  change file alongside.
