### PR TITLE
chore(capacitor): migrate Capacitor v7 → v8 (Node 22, Android SDK bumps)

### DIFF
--- a/.github/workflows/build-android.yaml
+++ b/.github/workflows/build-android.yaml
@@ -21,7 +21,7 @@ permissions:
   contents: read
 
 env:
-  NODE_VERSION: '20'
+  NODE_VERSION: '22'
   JAVA_VERSION: '17'
 
 jobs:

--- a/.github/workflows/build-ios.yaml
+++ b/.github/workflows/build-ios.yaml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 env:
-  NODE_VERSION: '20'
+  NODE_VERSION: '22'
 
 jobs:
   build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: npm
 
       - name: Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM node:20 as build-stage
+FROM node:22 as build-stage
 WORKDIR /app
 COPY package.json package-lock.json .npmrc ./
 RUN npm ci

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
         android:theme="@style/AppTheme">
 
         <activity
-            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode"
+            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode|density"
             android:name=".MainActivity"
             android:label="@string/title_activity_main"
             android:launchMode="singleTask"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.13.2'
-        classpath 'com.google.gms:google-services:4.4.0'
+        classpath 'com.google.gms:google-services:4.4.4'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/android/variables.gradle
+++ b/android/variables.gradle
@@ -1,16 +1,16 @@
 ext {
-    minSdkVersion = 23
+    minSdkVersion = 24
     compileSdkVersion = 36
-    targetSdkVersion = 35
-    androidxActivityVersion = '1.9.0'
-    androidxAppCompatVersion = '1.7.0'
-    androidxCoordinatorLayoutVersion = '1.2.0'
-    androidxCoreVersion = '1.15.0'
-    androidxFragmentVersion = '1.8.0'
-    coreSplashScreenVersion = '1.0.1'
-    androidxWebkitVersion = '1.12.0'
+    targetSdkVersion = 36
+    androidxActivityVersion = '1.11.0'
+    androidxAppCompatVersion = '1.7.1'
+    androidxCoordinatorLayoutVersion = '1.3.0'
+    androidxCoreVersion = '1.17.0'
+    androidxFragmentVersion = '1.8.9'
+    coreSplashScreenVersion = '1.2.0'
+    androidxWebkitVersion = '1.14.0'
     junitVersion = '4.13.2'
-    androidxJunitVersion = '1.2.1'
-    androidxEspressoCoreVersion = '3.6.1'
-    cordovaAndroidVersion = '10.1.1'
+    androidxJunitVersion = '1.3.0'
+    androidxEspressoCoreVersion = '3.7.0'
+    cordovaAndroidVersion = '14.0.1'
 }

--- a/change/@acedatacloud-nexior-capacitor-v8-migration.json
+++ b/change/@acedatacloud-nexior-capacitor-v8-migration.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore(capacitor): migrate Capacitor v7 \u2192 v8 — bump @capacitor/{cli,core,android,ios} to ^8.3.4, Node engine and CI/Dockerfile to 22, Android minSdk 24 / targetSdk 36 / Gradle 8.14.3 / google-services 4.4.4 / androidx + cordova-android bumps, add density to MainActivity configChanges. iOS already on deployment target 16.0 (no native change).",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/ios/App/Podfile.lock
+++ b/ios/App/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
-  - Capacitor (7.5.0):
+  - Capacitor (8.3.4):
     - CapacitorCordova
-  - CapacitorApp (8.0.1):
+  - CapacitorApp (8.1.0):
     - Capacitor
-  - CapacitorBrowser (8.0.1):
+  - CapacitorBrowser (8.0.3):
     - Capacitor
-  - CapacitorCordova (7.5.0)
+  - CapacitorCordova (8.3.4)
 
 DEPENDENCIES:
   - "Capacitor (from `../../node_modules/@capacitor/ios`)"
@@ -24,10 +24,10 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/@capacitor/ios"
 
 SPEC CHECKSUMS:
-  Capacitor: 0a78ec6b54580fa055c11744a4e83cd7942d98ca
-  CapacitorApp: 942306cd1acf7774a00e89a3986af3a67c8cad7a
-  CapacitorBrowser: e72e572d5dbdbb854fda5950586a2451e981f2d6
-  CapacitorCordova: ae35646a9b46cfd00d637f195509c86594026aad
+  Capacitor: d13cad5fa09155679672808cc4ca9fbc2997e1b4
+  CapacitorApp: 449ffe26375e96f8aaaee625ac6e01e5c57c8650
+  CapacitorBrowser: c987c73d09d8bd3b5ec13f06338b1e14d5d2be69
+  CapacitorCordova: c07921bdcfec6f691bae22274446b4d606ebf6a4
 
 PODFILE CHECKSUM: 55f50f9985ef91db876d804e5d39061113f88c5e
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,10 +68,10 @@
         "vuex-persistedstate": "^4.0.0"
       },
       "devDependencies": {
-        "@capacitor/android": "^7.5.0",
-        "@capacitor/cli": "^7.5.0",
-        "@capacitor/core": "^7.5.0",
-        "@capacitor/ios": "^7.5.0",
+        "@capacitor/android": "^8.3.4",
+        "@capacitor/cli": "^8.3.4",
+        "@capacitor/core": "^8.3.4",
+        "@capacitor/ios": "^8.3.4",
         "@rollup/plugin-replace": "^6.0.2",
         "@types/file-saver": "^2.0.7",
         "@types/json-logic-js": "^2.0.8",
@@ -103,7 +103,7 @@
         "vue-tsc": "^2.2.12"
       },
       "engines": {
-        "node": "20.x"
+        "node": "22.x"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -211,13 +211,13 @@
       }
     },
     "node_modules/@capacitor/android": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-7.6.2.tgz",
-      "integrity": "sha512-zRIn10uTPbOQaFVRqkTGKwrrDypmn3L3I/x4XZSVLiCYt3zs8MUCPoqrMudNvOD+s6nQ5m0cX4GW8JRpMxKOkQ==",
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-8.3.4.tgz",
+      "integrity": "sha512-7gJjrG3X32Am1QMLqgMztWTYMLMVNE+VZwhekNxhvYizH4mOV05vH+rC9B+f17bCkYZfyu/qXQX6hoY7kLeVZw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@capacitor/core": "^7.6.0"
+        "@capacitor/core": "^8.3.0"
       }
     },
     "node_modules/@capacitor/app": {
@@ -239,9 +239,9 @@
       }
     },
     "node_modules/@capacitor/cli": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-7.6.2.tgz",
-      "integrity": "sha512-uPm+GDVhdWrM/DBWZ/L6c8uBVaEcge4MAXhqrIJWSkwad/9vNoVfUjtHaVgXxPE1g399PhlGm4kU8U7Qdfmwow==",
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-8.3.4.tgz",
+      "integrity": "sha512-QEmyNdiDDVNYl0Mahm7YTVA/3t2tKcy7FWYDapeKGavS6HDNHZSjyTVwQpUXQbDZrrs/PS2Wau3Aii+LIFwm/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -268,13 +268,13 @@
         "capacitor": "bin/capacitor"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@capacitor/core": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-7.6.2.tgz",
-      "integrity": "sha512-8HRKEUlYpCOeRec8bCHZwEA4o/E2q5dhHSd0v/Cr6+ume08fZY/gniF+ZCKF+6DO0T/nRaBeNRQn6Up+45J1mg==",
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-8.3.4.tgz",
+      "integrity": "sha512-CqRQCkb6HXxcx/N7s+hHTN6ef2CmamFiRMITwm4qB840ph56mS42bzUgn6tKCP+RZjdDweiRHj9ytDDeN6jFag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -282,13 +282,13 @@
       }
     },
     "node_modules/@capacitor/ios": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-7.6.2.tgz",
-      "integrity": "sha512-TZOXn7ZSEMsetrIEb8EHT4X9Nwsed1itqMwe+z5QOCDvm9XZ7i2YsjnrinUC1ZOIgva9IE2l+azus7qOpQ0aCg==",
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-8.3.4.tgz",
+      "integrity": "sha512-XvvnPFWWP/gwwO811ue7nEBKSZqDCIB8hxGgWV6iXA7DSVLqMOEmQdfHj94kkVxof2wL9XWHypu3ayDULo7U5w==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@capacitor/core": "^7.6.0"
+        "@capacitor/core": "^8.3.0"
       }
     },
     "node_modules/@codemirror/autocomplete": {

--- a/package.json
+++ b/package.json
@@ -93,10 +93,10 @@
     "vuex-persistedstate": "^4.0.0"
   },
   "devDependencies": {
-    "@capacitor/android": "^7.5.0",
-    "@capacitor/cli": "^7.5.0",
-    "@capacitor/core": "^7.5.0",
-    "@capacitor/ios": "^7.5.0",
+    "@capacitor/android": "^8.3.4",
+    "@capacitor/cli": "^8.3.4",
+    "@capacitor/core": "^8.3.4",
+    "@capacitor/ios": "^8.3.4",
     "@rollup/plugin-replace": "^6.0.2",
     "@types/file-saver": "^2.0.7",
     "@types/json-logic-js": "^2.0.8",
@@ -129,7 +129,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": "20.x"
+    "node": "22.x"
   },
   "lint-staged": {
     "src/**/*.{ts,tsx,vue,js,jsx}": [


### PR DESCRIPTION
Coordinated upgrade of the Capacitor toolchain from v7 to v8. Replaces the standalone Dependabot CLI bump in #744 (now closed) which would have left a v8 CLI driving a v7 native project and broken the new Node ≥22 engine requirement.

## Why one PR

\`@capacitor/cli\` v8 declares \`engines.node >= 22.0.0\` and the CLI / core / android / ios packages move in lockstep — bumping the CLI alone leaves the toolchain mismatched. The migration must also touch the Android native project (minSdk, Gradle, AndroidManifest) and the Node version everywhere CI runs npm.

## Toolchain (package.json + CI)

| Surface | Before | After |
| --- | --- | --- |
| \`@capacitor/{cli,core,android,ios}\` | \`^7.5.0\` | \`^8.3.4\` |
| \`@capacitor/{app,browser}\` | \`^8.0.1\` | unchanged (plugins version independently — \`app\` resolved to 8.1.0, \`browser\` to 8.0.3) |
| \`engines.node\` | \`20.x\` | \`22.x\` |
| \`ci.yaml\` / \`build-ios.yaml\` / \`build-android.yaml\` / \`github-release.yaml\` / \`publish.yaml\` | Node 20 | Node 22 |
| \`Dockerfile\` build stage | \`node:20\` | \`node:22\` |

\`deploy.yaml\` and \`claude.yml\` do not call setup-node, so no change.

## Android native (per the [Capacitor 8 migration guide](https://capacitorjs.com/docs/updating/8-0))

- \`minSdkVersion\` 23 → 24
- \`targetSdkVersion\` 35 → 36 (compileSdk already 36)
- Gradle wrapper 8.13 → 8.14.3
- \`com.google.gms:google-services\` 4.4.0 → 4.4.4 (AGP 8.13.2 already ≥ guide's 8.13.0, kept as-is)
- \`cordova-android\` 10.1.1 → 14.0.1
- androidx bumps: activity 1.9.0→1.11.0, appcompat 1.7.0→1.7.1, coordinatorlayout 1.2.0→1.3.0, core 1.15.0→1.17.0, fragment 1.8.0→1.8.9, core-splashscreen 1.0.1→1.2.0, webkit 1.12.0→1.14.0, test.ext.junit 1.2.1→1.3.0, espresso-core 3.6.1→3.7.0
- \`AndroidManifest.xml\`: add \`density\` to \`MainActivity\` \`android:configChanges\` (the only configChanges entry the v8 guide mandates)

## iOS native

The Podfile and \`IPHONEOS_DEPLOYMENT_TARGET\` are already on 16.0 (guide minimum is 15.0) — **no native change required**. \`ios/App/Podfile.lock\` is updated by \`npx cap update\` to reflect the new Capacitor / CapacitorCordova / CapacitorApp / CapacitorBrowser pod versions.

## Local validation

- \`npm install\`: clean, 965 packages, no resolution conflicts
- \`npx cap doctor\` reports all 4 deps on 8.3.4
- \`npx cap copy\` + \`npx cap update\`: both platforms green; \`pod install\` runs to completion locally
- \`npm run test:run\`: 104/104 tests pass
- \`npm run build\` (web): builds cleanly, no new warnings
- \`npm run lint:check\` reports pre-existing prettier issues in 4 unrelated files (PlayerSlider.vue, PersonaInput.vue, NotFound.vue, nanobanana/Index.vue) that are already on \`main\`; CI runs \`npm run lint\` with \`--fix\` so they will not block

## CI to watch

- \`check\` (ci.yaml): lint + i18n coverage + vitest + web build on Node 22
- Tag-driven \`Build Android\` / \`Build iOS\` won't run on the PR but pick up the new Node + AGP/Gradle/SDK matrix once a release tag lands

## Follow-ups

- Once green, future Dependabot v8 minor/patch bumps for \`@capacitor/*\` are safe to auto-merge.
- The \`@dependabot ignore this major version\` comment left on #744 prevents Dependabot from re-opening a duplicate CLI-only major bump.

Closes follow-up to #744.