### PR TITLE
chore: hide DeepSeek route and sidebar tile

### DIFF
--- a/src/components/common/Navigator.vue
+++ b/src/components/common/Navigator.vue
@@ -73,8 +73,10 @@ import {
   ROUTE_FLUX_INDEX,
   ROUTE_CHATGPT_CONVERSATION_NEW,
   ROUTE_CHATGPT_CONVERSATION,
-  ROUTE_DEEPSEEK_CONVERSATION_NEW,
-  ROUTE_DEEPSEEK_CONVERSATION,
+  // DeepSeek nav entry temporarily hidden from public sidebar.
+  // Route constants/module remain so we can re-enable by reverting this commit.
+  // ROUTE_DEEPSEEK_CONVERSATION_NEW,
+  // ROUTE_DEEPSEEK_CONVERSATION,
   ROUTE_GROK_CONVERSATION_NEW,
   ROUTE_GROK_CONVERSATION,
   ROUTE_GEMINI_CONVERSATION_NEW,
@@ -106,7 +108,7 @@ import { ROUTE_SERP_INDEX } from '@/constants/serp';
 import { WEBEXTRATOR_LOGO } from '@/constants/webextrator';
 import {
   CHAT_MODEL_ICON_CHATGPT,
-  CHAT_MODEL_ICON_DEEPSEEK,
+  // CHAT_MODEL_ICON_DEEPSEEK, // hidden along with the DeepSeek sidebar entry below
   CHAT_MODEL_ICON_GROK,
   CHAT_MODEL_ICON_GEMINI,
   CHAT_MODEL_ICON_CLAUDE,
@@ -180,15 +182,18 @@ export default defineComponent({
           category: 'chat'
         });
       }
-      if (this.$store?.state?.site?.features?.deepseek?.enabled) {
-        result.push({
-          route: { name: ROUTE_DEEPSEEK_CONVERSATION_NEW },
-          displayName: this.$t('common.nav.deepseek'),
-          logo: CHAT_MODEL_ICON_DEEPSEEK,
-          routes: [ROUTE_DEEPSEEK_CONVERSATION, ROUTE_DEEPSEEK_CONVERSATION_NEW],
-          category: 'chat'
-        });
-      }
+      // DeepSeek sidebar entry temporarily hidden from public navigation.
+      // Route constants, store module, icon and locale strings remain in
+      // place so the entry can be re-enabled by reverting this commit.
+      // if (this.$store?.state?.site?.features?.deepseek?.enabled) {
+      //   result.push({
+      //     route: { name: ROUTE_DEEPSEEK_CONVERSATION_NEW },
+      //     displayName: this.$t('common.nav.deepseek'),
+      //     logo: CHAT_MODEL_ICON_DEEPSEEK,
+      //     routes: [ROUTE_DEEPSEEK_CONVERSATION, ROUTE_DEEPSEEK_CONVERSATION_NEW],
+      //     category: 'chat'
+      //   });
+      // }
       if (this.$store?.state?.site?.features?.grok?.enabled) {
         result.push({
           route: { name: ROUTE_GROK_CONVERSATION_NEW },

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -5,7 +5,10 @@ import console from './console';
 import grok from './grok';
 import gemini from './gemini';
 import claude from './claude';
-import deepseek from './deepseek';
+// DeepSeek route temporarily hidden from public navigation.
+// Source file (./deepseek.ts), constants (ROUTE_DEEPSEEK_*) and Vuex module
+// are kept intact so the page can be re-enabled by reversing this commit.
+// import deepseek from './deepseek';
 import kimi from './kimi';
 import chatgpt from './chatgpt';
 import midjourney from './midjourney';
@@ -36,7 +39,7 @@ import profile from './profile';
 
 import {
   ROUTE_CHATGPT_CONVERSATION_NEW,
-  ROUTE_DEEPSEEK_CONVERSATION_NEW,
+  // ROUTE_DEEPSEEK_CONVERSATION_NEW, // hidden — see deepseek import note above
   ROUTE_GROK_CONVERSATION_NEW,
   ROUTE_GEMINI_CONVERSATION_NEW,
   ROUTE_CLAUDE_CONVERSATION_NEW,
@@ -95,12 +98,7 @@ const ROUTE_SEO: Record<string, { title: string; description: string; keywords: 
     keywords: ['Grok', 'xAI', 'AI Chat', 'Grok AI'],
     category: 'AI Chat'
   },
-  deepseek: {
-    title: 'DeepSeek',
-    description: 'Chat with DeepSeek AI — advanced reasoning and coding AI assistant.',
-    keywords: ['DeepSeek', 'AI Chat', 'AI Coding', 'DeepSeek AI'],
-    category: 'AI Chat'
-  },
+  // DeepSeek SEO metadata removed while the page is hidden from public nav.
   kimi: {
     title: 'Kimi',
     description: 'Chat with Kimi AI — advanced AI conversations powered by Moonshot AI.',
@@ -259,7 +257,7 @@ const FEATURE_ROUTE_PRIORITY: Array<[string, string]> = [
   ['claude', ROUTE_CLAUDE_CONVERSATION_NEW],
   ['gemini', ROUTE_GEMINI_CONVERSATION_NEW],
   ['grok', ROUTE_GROK_CONVERSATION_NEW],
-  ['deepseek', ROUTE_DEEPSEEK_CONVERSATION_NEW],
+  // ['deepseek', ROUTE_DEEPSEEK_CONVERSATION_NEW], // hidden
   ['kimi', ROUTE_KIMI_CONVERSATION_NEW],
   ['midjourney', ROUTE_MIDJOURNEY_INDEX],
   ['nanobanana', ROUTE_NANOBANANA_INDEX],
@@ -307,7 +305,7 @@ const routes = [
   grok,
   gemini,
   claude,
-  deepseek,
+  // deepseek, // hidden from public nav
   kimi,
   qrart,
   luma,


### PR DESCRIPTION
Per maintainer request: hide DeepSeek from the public Nexior navigation. Commented-out the DeepSeek route registration, the FEATURE_ROUTE_PRIORITY entry, and the Navigator sidebar tile. Source files (src/router/deepseek.ts), the Vuex deepseek module, route-name constants, and the chat-model icon constant are intentionally retained — only nav wiring is hidden. The /deepseek backend capability is unchanged.