### PR TITLE
fix(openaiimage): drop stray margin on last metadata row in task preview

### DIFF
--- a/src/components/openaiimage/task/Preview.vue
+++ b/src/components/openaiimage/task/Preview.vue
@@ -330,6 +330,11 @@ $left-width: 70px;
         &.info {
           border-color: var(--el-color-info);
         }
+        // Drop the trailing `mb-2` on whichever `<p>` ends up rendered
+        // last (trace_id / elapsed are conditional — e.g. pending tasks).
+        :deep(p:last-child) {
+          margin-bottom: 0;
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

In the OpenAI Image studio task preview, the `el-alert` metadata block lists `模型 / 尺寸 / 任务 / 任务 ID / 耗时 / 追踪 ID` as `<p class="... mb-2">` rows, with only the *template-last* `trace_id` row marked `mb-0`. When the conditional rows (`trace_id`, `elapsed`) aren't rendered — most visibly **while the task is still pending** and only `模型` + `任务 ID` are shown — the actually-rendered last `<p>` keeps its 0.5rem bottom margin, leaving a stray gap inside the alert.

The same imbalance applies to the failure branch (when `trace_id` is missing, `elapsed` becomes last with `mb-2`) and to the success branch when either optional field is absent.

## Repro

1. `https://studio.acedata.cloud/openai-image`
2. Submit a prompt; while the task is pending, look at the second message's metadata box.
3. There's a visible empty strip below `任务 ID: …` inside the alert. (See the screenshot in the report.)

## Fix

Reset the trailing margin on whichever `<p>` ends up rendered last, regardless of which optional fields are present:

```scss
.content .el-alert {
  // …existing border styles…
  :deep(p:last-child) {
    margin-bottom: 0;
  }
}
```

`p:last-child` (specificity 0,1,1) outranks the Tailwind `.mb-2` (0,1,0), so no override flag is needed. The `:deep()` is required because Element Plus's `el-alert` slot wraps its description in shadow-classed content that scoped selectors don't otherwise reach.

## Why CSS instead of editing the template

Each of the three branches (success / failure / pending) renders a different subset of `<p>` rows. Putting `mb-0` on every possible last-row in the template would require duplicating logic three times and would still drift the next time a field is added. A single `:last-child` rule collapses cleanly in every case.

## Diff shape

```
 src/components/openaiimage/task/Preview.vue | 5 +++++
 1 file changed, 5 insertions(+)
```

## Verification

- Visual inspection of the `v-else` (pending) branch: gap below `任务 ID` is gone.
- Success branch unchanged when both `elapsed` + `trace_id` are present (the template-last `mb-0` and the new `:last-child` rule both produce `margin-bottom: 0`).
- Failure branch likewise collapses correctly when `trace_id` is absent.
- No other call sites of `.content .el-alert p` exist in this file's scoped styles.

## Out of scope

The same `mb-2 / mb-0` mismatch exists in the `nanobanana`, `veo`, etc. task previews. Those previews aren't in this PR's regression window; happy to follow up if you'd like to roll the same one-line fix across them.

---
*This pull request was generated and committed by the [GitHub Copilot](https://github.com/copilot) coding agent on behalf of @CQUPTQiCu.*
