### PR TITLE
fix(task-preview): drop stray margin on last metadata row across all studios

### DIFF
--- a/src/components/fish/task/Preview.vue
+++ b/src/components/fish/task/Preview.vue
@@ -155,6 +155,11 @@ $left-width: 70px;
     .content {
       word-break: break-word;
       overflow-wrap: anywhere;
+      // Drop the trailing `mb-2` on whichever `<p>` ends up rendered
+      // last (elapsed / reference_id are conditional).
+      .el-alert :deep(p:last-child) {
+        margin-bottom: 0;
+      }
     }
   }
 }

--- a/src/components/flux/task/Preview.vue
+++ b/src/components/flux/task/Preview.vue
@@ -233,6 +233,11 @@ $left-width: 70px;
         &.info {
           border-color: var(--el-color-info);
         }
+        // Drop the trailing `mb-2` on whichever `<p>` ends up rendered
+        // last (trace_id / elapsed are conditional — e.g. pending tasks).
+        :deep(p:last-child) {
+          margin-bottom: 0;
+        }
       }
     }
   }

--- a/src/components/hailuo/task/Preview.vue
+++ b/src/components/hailuo/task/Preview.vue
@@ -230,6 +230,11 @@ $left-width: 70px;
         &.info {
           border-color: var(--el-color-info);
         }
+        // Drop the trailing `mb-2` on whichever `<p>` ends up rendered
+        // last (trace_id / elapsed are conditional — e.g. pending tasks).
+        :deep(p:last-child) {
+          margin-bottom: 0;
+        }
       }
     }
   }

--- a/src/components/headshots/task/Preview.vue
+++ b/src/components/headshots/task/Preview.vue
@@ -242,6 +242,11 @@ $left-width: 70px;
         &.info {
           border-color: var(--el-color-info);
         }
+        // Drop the trailing `mb-2` on whichever `<p>` ends up rendered
+        // last (trace_id / elapsed are conditional — e.g. pending tasks).
+        :deep(p:last-child) {
+          margin-bottom: 0;
+        }
       }
     }
 

--- a/src/components/kling/task/Preview.vue
+++ b/src/components/kling/task/Preview.vue
@@ -267,6 +267,11 @@ $left-width: 70px;
         &.info {
           border-color: var(--el-color-info);
         }
+        // Drop the trailing `mb-2` on whichever `<p>` ends up rendered
+        // last (trace_id / elapsed are conditional — e.g. pending tasks).
+        :deep(p:last-child) {
+          margin-bottom: 0;
+        }
       }
     }
 

--- a/src/components/luma/task/Preview.vue
+++ b/src/components/luma/task/Preview.vue
@@ -248,6 +248,11 @@ $left-width: 70px;
         &.info {
           border-color: var(--el-color-info);
         }
+        // Drop the trailing `mb-2` on whichever `<p>` ends up rendered
+        // last (trace_id / elapsed are conditional — e.g. pending tasks).
+        :deep(p:last-child) {
+          margin-bottom: 0;
+        }
       }
     }
   }

--- a/src/components/nanobanana/task/Preview.vue
+++ b/src/components/nanobanana/task/Preview.vue
@@ -303,6 +303,11 @@ $left-width: 70px;
         &.info {
           border-color: var(--el-color-info);
         }
+        // Drop the trailing `mb-2` on whichever `<p>` ends up rendered
+        // last (trace_id / elapsed are conditional — e.g. pending tasks).
+        :deep(p:last-child) {
+          margin-bottom: 0;
+        }
       }
     }
 

--- a/src/components/pika/task/Preview.vue
+++ b/src/components/pika/task/Preview.vue
@@ -279,6 +279,11 @@ $left-width: 70px;
         &.info {
           border-color: var(--el-color-info);
         }
+        // Drop the trailing `mb-2` on whichever `<p>` ends up rendered
+        // last (trace_id / elapsed are conditional — e.g. pending tasks).
+        :deep(p:last-child) {
+          margin-bottom: 0;
+        }
       }
     }
 

--- a/src/components/pixverse/task/Preview.vue
+++ b/src/components/pixverse/task/Preview.vue
@@ -227,6 +227,11 @@ $left-width: 70px;
         &.info {
           border-color: var(--el-color-info);
         }
+        // Drop the trailing `mb-2` on whichever `<p>` ends up rendered
+        // last (trace_id / elapsed are conditional — e.g. pending tasks).
+        :deep(p:last-child) {
+          margin-bottom: 0;
+        }
       }
     }
 

--- a/src/components/qrart/task/Preview.vue
+++ b/src/components/qrart/task/Preview.vue
@@ -266,6 +266,11 @@ $left-width: 70px;
         &.info {
           border-color: var(--el-color-info);
         }
+        // Drop the trailing `mb-2` on whichever `<p>` ends up rendered
+        // last (trace_id / elapsed are conditional — e.g. pending tasks).
+        :deep(p:last-child) {
+          margin-bottom: 0;
+        }
       }
     }
 

--- a/src/components/seedance/task/Preview.vue
+++ b/src/components/seedance/task/Preview.vue
@@ -301,6 +301,11 @@ $left-width: 70px;
         &.info {
           border-color: var(--el-color-info);
         }
+        // Drop the trailing `mb-2` on whichever `<p>` ends up rendered
+        // last (trace_id / elapsed are conditional — e.g. pending tasks).
+        :deep(p:last-child) {
+          margin-bottom: 0;
+        }
       }
     }
   }

--- a/src/components/seedream/task/Preview.vue
+++ b/src/components/seedream/task/Preview.vue
@@ -292,6 +292,11 @@ $left-width: 70px;
         &.info {
           border-color: var(--el-color-info);
         }
+        // Drop the trailing `mb-2` on whichever `<p>` ends up rendered
+        // last (trace_id / elapsed are conditional — e.g. pending tasks).
+        :deep(p:last-child) {
+          margin-bottom: 0;
+        }
       }
     }
 

--- a/src/components/sora/task/Preview.vue
+++ b/src/components/sora/task/Preview.vue
@@ -238,6 +238,11 @@ $left-width: 70px;
         &.info {
           border-color: var(--el-color-info);
         }
+        // Drop the trailing `mb-2` on whichever `<p>` ends up rendered
+        // last (trace_id / elapsed are conditional — e.g. pending tasks).
+        :deep(p:last-child) {
+          margin-bottom: 0;
+        }
       }
     }
 

--- a/src/components/veo/task/Preview.vue
+++ b/src/components/veo/task/Preview.vue
@@ -317,6 +317,11 @@ $left-width: 70px;
         &.info {
           border-color: var(--el-color-info);
         }
+        // Drop the trailing `mb-2` on whichever `<p>` ends up rendered
+        // last (trace_id / elapsed are conditional — e.g. pending tasks).
+        :deep(p:last-child) {
+          margin-bottom: 0;
+        }
       }
     }
 

--- a/src/components/wan/task/Preview.vue
+++ b/src/components/wan/task/Preview.vue
@@ -226,6 +226,11 @@ $left-width: 70px;
         &.info {
           border-color: var(--el-color-info);
         }
+        // Drop the trailing `mb-2` on whichever `<p>` ends up rendered
+        // last (trace_id / elapsed are conditional — e.g. pending tasks).
+        :deep(p:last-child) {
+          margin-bottom: 0;
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

Same fix as Nexior #754 (openaiimage), now applied to the remaining **15** studio task previews — `fish`, `flux`, `hailuo`, `headshots`, `kling`, `luma`, `nanobanana`, `pika`, `pixverse`, `qrart`, `seedance`, `seedream`, `sora`, `veo`, `wan`.

## The bug, restated

Every studio's task preview renders its metadata block inside `<el-alert>` as a list of `<p class="... mb-2">` rows (`模型 / 尺寸 / 任务 / 任务 ID / 耗时 / 追踪 ID` and friends). Only the **template-last** row is marked `mb-0`. When the conditional rows (`trace_id`, `elapsed`, `reference_id`, …) aren't rendered — most visibly **while a task is still pending and only model + taskId are shown** — the actually-rendered last `<p>` keeps its `0.5rem` bottom margin, leaving a stray gap inside the alert.

This is the exact same pattern that #754 fixed for `openaiimage`; the user flagged it on https://studio.acedata.cloud/openai-image and asked whether other studios were affected. They are — all 15.

## Fix

Reset the trailing margin on whichever `<p>` actually renders last, regardless of which optional fields are present. Identical 5-line CSS block per file.

For the **14 standard files** (`flux`, `hailuo`, `headshots`, `kling`, `luma`, `nanobanana`, `pika`, `pixverse`, `qrart`, `seedance`, `seedream`, `sora`, `veo`, `wan`), inject it inside the existing `.content .el-alert {}` rule:

```scss
.content .el-alert {
  // …existing border-left styles…
  :deep(p:last-child) {
    margin-bottom: 0;
  }
}
```

For **fish** (which had no scoped `.el-alert` rule yet), add the selector directly under `.content`:

```scss
.content {
  // …existing…
  .el-alert :deep(p:last-child) {
    margin-bottom: 0;
  }
}
```

`p:last-child` (specificity 0,1,1) outranks Tailwind's `.mb-2` (0,1,0), so no override flag is needed. The `:deep()` is required because Element Plus's `el-alert` slot wraps its description in shadow-classed content that scoped selectors don't otherwise reach.

## Why a CSS rule instead of template edits

Each Preview.vue has 3 branches (success / failure / pending), each rendering a different subset of `<p>` rows depending on what the upstream returned. Putting `mb-0` on every possible last-row would duplicate logic three times *per file × 15 files* and would still drift the next time a metadata field is added. A single `:last-child` rule collapses cleanly in every case for every studio.

## Diff shape

```
 src/components/fish/task/Preview.vue       | 5 +++++
 src/components/flux/task/Preview.vue       | 5 +++++
 src/components/hailuo/task/Preview.vue     | 5 +++++
 src/components/headshots/task/Preview.vue  | 5 +++++
 src/components/kling/task/Preview.vue      | 5 +++++
 src/components/luma/task/Preview.vue       | 5 +++++
 src/components/nanobanana/task/Preview.vue | 5 +++++
 src/components/pika/task/Preview.vue       | 5 +++++
 src/components/pixverse/task/Preview.vue   | 5 +++++
 src/components/qrart/task/Preview.vue      | 5 +++++
 src/components/seedance/task/Preview.vue   | 5 +++++
 src/components/seedream/task/Preview.vue   | 5 +++++
 src/components/sora/task/Preview.vue       | 5 +++++
 src/components/veo/task/Preview.vue        | 5 +++++
 src/components/wan/task/Preview.vue        | 5 +++++
 15 files changed, 75 insertions(+)
```

Identical block in each file — easy to audit, easy to revert.

## Verification

- The 14 standard files share the exact same scoped SCSS structure (4-space `.content { … .el-alert { border-left-width: 2px; … &.failure {} &.success {} &.info {} } }`); the injection anchor (`&.info { … }` then the closing `}` for `.el-alert`) is unique within each file. Confirmed via Python `text.count(OLD) == 1` for every file.
- `fish` is the only outlier: it has no nested `.el-alert {}` rule. Its `.content` block was extended with a new `.el-alert :deep(p:last-child) { … }` selector — same effective rule, slightly different nesting.
- No template changes anywhere. No i18n keys touched. No tests changed (these visuals don't have existing screenshot tests).
- The previously-merged `openaiimage` fix (#754) is intentionally not included here — it's already shipped.

## Out of scope

- Same Element Plus version assumption as #754: any `<p>` direct-children inside the alert slot. If a future PR replaces `<p>` with `<div>` rows, the selector will need updating.

---
*This pull request was generated and committed by the [GitHub Copilot](https://github.com/copilot) coding agent on behalf of @CQUPTQiCu.*
