### PR TITLE
fix(upload): show 0% progress and block Generate while uploads are in flight

### DIFF
--- a/src/components/chat/Composer.vue
+++ b/src/components/chat/Composer.vue
@@ -130,7 +130,13 @@ import {
 } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { IChatModel, IChatReference } from '@/models';
-import { getBaseUrlPlatform, isImageUrl, pasteUploadMixin, withCurrentUserIdAndSite } from '@/utils';
+import {
+  getBaseUrlPlatform,
+  isImageUrl,
+  pasteUploadMixin,
+  uploadTrackerMixin,
+  withCurrentUserIdAndSite
+} from '@/utils';
 import FilePreview from '@/components/common/FilePreview.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 
@@ -147,7 +153,7 @@ export default defineComponent({
     ElDropdownMenu,
     ElDropdownItem
   },
-  mixins: [pasteUploadMixin],
+  mixins: [pasteUploadMixin, uploadTrackerMixin],
   props: {
     answering: {
       type: Boolean,

--- a/src/components/common/FilePreview.vue
+++ b/src/components/common/FilePreview.vue
@@ -8,10 +8,10 @@
       >
         <font-awesome-icon icon="fa-regular fa-file-alt" />
         <el-progress
-          v-show="percentage && percentage < 100"
+          v-show="isUploading"
           type="circle"
           :stroke-width="3"
-          :percentage="percentage"
+          :percentage="displayPercentage"
           :width="25"
           class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[25px] h-[25px] z-[10] m-auto"
         />
@@ -60,6 +60,14 @@ export default defineComponent({
     }
   },
   emits: ['remove'],
+  computed: {
+    isUploading(): boolean {
+      return typeof this.percentage === 'number' && this.percentage < 100;
+    },
+    displayPercentage(): number {
+      return typeof this.percentage === 'number' ? this.percentage : 0;
+    }
+  },
   methods: {
     isImageUrl
   }

--- a/src/components/common/ImagePreview.vue
+++ b/src/components/common/ImagePreview.vue
@@ -3,15 +3,12 @@
     class="image w-[50px] h-[50px] relative rounded-[var(--el-border-radius-base)] overflow-hidden shadow-sm bg-[var(--el-fill-color-lighter)]"
   >
     <img class="w-full h-full object-cover" :src="url" :alt="name" />
-    <div
-      v-show="percentage && percentage < 100"
-      class="overlay absolute inset-0 bg-[var(--el-mask-color)] backdrop-blur-[1px]"
-    ></div>
+    <div v-show="isUploading" class="overlay absolute inset-0 bg-[var(--el-mask-color)] backdrop-blur-[1px]"></div>
     <el-progress
-      v-show="percentage && percentage < 100"
+      v-show="isUploading"
       type="circle"
       :stroke-width="4"
-      :percentage="percentage"
+      :percentage="displayPercentage"
       :width="34"
       class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[34px] h-[34px] z-[10] m-auto text-[12px]"
     />
@@ -55,6 +52,14 @@ export default defineComponent({
       default: true
     }
   },
-  emits: ['remove']
+  emits: ['remove'],
+  computed: {
+    isUploading(): boolean {
+      return typeof this.percentage === 'number' && this.percentage < 100;
+    },
+    displayPercentage(): number {
+      return typeof this.percentage === 'number' ? this.percentage : 0;
+    }
+  }
 });
 </script>

--- a/src/components/fish/ModelConfigPanel.vue
+++ b/src/components/fish/ModelConfigPanel.vue
@@ -165,7 +165,7 @@ import {
   UploadFiles
 } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform } from '@/utils';
+import { getBaseUrlPlatform, uploadTrackerMixin } from '@/utils';
 import Recorder from './model/Recorder.vue';
 
 const MAX_AUDIO_SIZE_BYTES = 50 * 1024 * 1024;
@@ -227,6 +227,7 @@ export default defineComponent({
     FontAwesomeIcon,
     Recorder
   },
+  mixins: [uploadTrackerMixin],
   emits: ['create'],
   data(): IData {
     return {

--- a/src/components/flux/config/ImageUrlInput.vue
+++ b/src/components/flux/config/ImageUrlInput.vue
@@ -40,7 +40,7 @@
 import { defineComponent } from 'vue';
 import { ElUpload, ElButton, UploadFiles, UploadFile, ElMessage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin, uploadTrackerMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 
@@ -58,7 +58,7 @@ export default defineComponent({
     FontAwesomeIcon,
     ImagePreview
   },
-  mixins: [pasteUploadMixin],
+  mixins: [pasteUploadMixin, uploadTrackerMixin],
   emits: ['change'],
   data(): IData {
     return {

--- a/src/components/hailuo/config/StartImageUrlInput.vue
+++ b/src/components/hailuo/config/StartImageUrlInput.vue
@@ -41,7 +41,7 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import { ElButton, ElUpload, ElMessage, UploadFiles, UploadFile } from 'element-plus';
-import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin, uploadTrackerMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 
@@ -60,7 +60,7 @@ export default defineComponent({
     InfoIcon,
     ImagePreview
   },
-  mixins: [pasteUploadMixin],
+  mixins: [pasteUploadMixin, uploadTrackerMixin],
   data(): IData {
     return {
       fileList: [],

--- a/src/components/headshots/config/ImageUrlsInput.vue
+++ b/src/components/headshots/config/ImageUrlsInput.vue
@@ -39,7 +39,7 @@
 import { defineComponent } from 'vue';
 import { ElButton, ElUpload, ElMessage, UploadFiles } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin, uploadTrackerMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 export const DEFAULT_CONTENT = '';
@@ -58,7 +58,7 @@ export default defineComponent({
     ImagePreview,
     FontAwesomeIcon
   },
-  mixins: [pasteUploadMixin],
+  mixins: [pasteUploadMixin, uploadTrackerMixin],
   data(): IData {
     return {
       fileList: [],

--- a/src/components/kling/config/EndImage.vue
+++ b/src/components/kling/config/EndImage.vue
@@ -48,7 +48,7 @@
 import { defineComponent } from 'vue';
 import { ElUpload, ElButton, ElTooltip, UploadFiles, UploadFile, ElMessage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin, uploadTrackerMixin } from '@/utils';
 import { getKlingCapabilities } from '@/utils/kling/capabilities';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
@@ -68,7 +68,7 @@ export default defineComponent({
     InfoIcon,
     FontAwesomeIcon
   },
-  mixins: [pasteUploadMixin],
+  mixins: [pasteUploadMixin, uploadTrackerMixin],
   data(): IData {
     return {
       fileList: [],

--- a/src/components/kling/config/StartImage.vue
+++ b/src/components/kling/config/StartImage.vue
@@ -47,7 +47,7 @@
 import { defineComponent } from 'vue';
 import { ElUpload, ElButton, ElTooltip, UploadFiles, UploadFile, ElMessage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin, uploadTrackerMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 
@@ -66,7 +66,7 @@ export default defineComponent({
     FontAwesomeIcon,
     ImagePreview
   },
-  mixins: [pasteUploadMixin],
+  mixins: [pasteUploadMixin, uploadTrackerMixin],
   emits: ['change'],
   data(): IData {
     return {

--- a/src/components/kling/motion/MotionImage.vue
+++ b/src/components/kling/motion/MotionImage.vue
@@ -42,7 +42,7 @@
 import { defineComponent } from 'vue';
 import { ElUpload, ElButton, UploadFiles, UploadFile, ElMessage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin, uploadTrackerMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 
@@ -60,7 +60,7 @@ export default defineComponent({
     FontAwesomeIcon,
     ImagePreview
   },
-  mixins: [pasteUploadMixin],
+  mixins: [pasteUploadMixin, uploadTrackerMixin],
   data(): IData {
     return {
       fileList: [],

--- a/src/components/kling/motion/MotionVideo.vue
+++ b/src/components/kling/motion/MotionVideo.vue
@@ -41,7 +41,7 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import { ElButton, ElUpload, ElMessage, UploadFiles, UploadFile } from 'element-plus';
-import { getBaseUrlPlatform } from '@/utils';
+import { getBaseUrlPlatform, uploadTrackerMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import FilePreview from '@/components/common/FilePreview.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
@@ -60,6 +60,7 @@ export default defineComponent({
     FilePreview,
     FontAwesomeIcon
   },
+  mixins: [uploadTrackerMixin],
   data(): IData {
     return {
       fileList: [],

--- a/src/components/luma/config/EndImageInput.vue
+++ b/src/components/luma/config/EndImageInput.vue
@@ -42,7 +42,7 @@
 import { defineComponent } from 'vue';
 import { ElUpload, ElButton, UploadFiles, UploadFile, ElMessage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin, uploadTrackerMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 
@@ -60,7 +60,7 @@ export default defineComponent({
     InfoIcon,
     FontAwesomeIcon
   },
-  mixins: [pasteUploadMixin],
+  mixins: [pasteUploadMixin, uploadTrackerMixin],
   data(): IData {
     return {
       fileList: [],

--- a/src/components/luma/config/StartImageInput.vue
+++ b/src/components/luma/config/StartImageInput.vue
@@ -42,7 +42,7 @@
 import { defineComponent } from 'vue';
 import { ElUpload, ElButton, UploadFiles, UploadFile, ElMessage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin, uploadTrackerMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 
@@ -60,7 +60,7 @@ export default defineComponent({
     InfoIcon,
     FontAwesomeIcon
   },
-  mixins: [pasteUploadMixin],
+  mixins: [pasteUploadMixin, uploadTrackerMixin],
   data(): IData {
     return {
       fileList: [],

--- a/src/components/luma/config/UploadVideo.vue
+++ b/src/components/luma/config/UploadVideo.vue
@@ -41,7 +41,7 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import { ElButton, ElUpload, ElMessage, UploadFiles } from 'element-plus';
-import { getBaseUrlPlatform } from '@/utils';
+import { getBaseUrlPlatform, uploadTrackerMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import FilePreview from '@/components/common/FilePreview.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
@@ -62,6 +62,7 @@ export default defineComponent({
     FilePreview,
     FontAwesomeIcon
   },
+  mixins: [uploadTrackerMixin],
   data(): IData {
     return {
       fileList: [],

--- a/src/components/midjourney/config/EndImageUrlInput.vue
+++ b/src/components/midjourney/config/EndImageUrlInput.vue
@@ -40,7 +40,7 @@
 import { defineComponent } from 'vue';
 import { ElUpload, ElButton, UploadFiles, UploadFile, ElMessage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin, uploadTrackerMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 
@@ -58,7 +58,7 @@ export default defineComponent({
     FontAwesomeIcon,
     ImagePreview
   },
-  mixins: [pasteUploadMixin],
+  mixins: [pasteUploadMixin, uploadTrackerMixin],
   emits: ['change'],
   data(): IData {
     return {

--- a/src/components/midjourney/config/ImageUrlInput.vue
+++ b/src/components/midjourney/config/ImageUrlInput.vue
@@ -43,7 +43,7 @@
 import { defineComponent } from 'vue';
 import { ElUpload, ElButton, UploadFiles, UploadFile, ElMessage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin, uploadTrackerMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 
@@ -61,7 +61,7 @@ export default defineComponent({
     FontAwesomeIcon,
     ImagePreview
   },
-  mixins: [pasteUploadMixin],
+  mixins: [pasteUploadMixin, uploadTrackerMixin],
   emits: ['change'],
   data(): IData {
     return {

--- a/src/components/midjourney/config/ImageUrlInput2.vue
+++ b/src/components/midjourney/config/ImageUrlInput2.vue
@@ -40,7 +40,7 @@
 import { defineComponent } from 'vue';
 import { ElUpload, ElButton, UploadFiles, UploadFile, ElMessage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin, uploadTrackerMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 
@@ -58,7 +58,7 @@ export default defineComponent({
     FontAwesomeIcon,
     ImagePreview
   },
-  mixins: [pasteUploadMixin],
+  mixins: [pasteUploadMixin, uploadTrackerMixin],
   emits: ['change'],
   data(): IData {
     return {

--- a/src/components/midjourney/config/ReferenceImage.vue
+++ b/src/components/midjourney/config/ReferenceImage.vue
@@ -40,7 +40,7 @@
 import { defineComponent } from 'vue';
 import { ElUpload, ElButton, UploadFiles, UploadFile, ElMessage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin, uploadTrackerMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 
@@ -58,7 +58,7 @@ export default defineComponent({
     FontAwesomeIcon,
     ImagePreview
   },
-  mixins: [pasteUploadMixin],
+  mixins: [pasteUploadMixin, uploadTrackerMixin],
   emits: ['change'],
   data(): IData {
     return {

--- a/src/components/nanobanana/config/ImageUrlsInput.vue
+++ b/src/components/nanobanana/config/ImageUrlsInput.vue
@@ -48,7 +48,7 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { getBaseUrlPlatform } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
-import { pasteUploadMixin } from '@/utils';
+import { pasteUploadMixin, uploadTrackerMixin } from '@/utils';
 
 interface IData {
   fileList: UploadFiles;
@@ -65,7 +65,7 @@ export default defineComponent({
     ImagePreview,
     FontAwesomeIcon
   },
-  mixins: [pasteUploadMixin],
+  mixins: [pasteUploadMixin, uploadTrackerMixin],
   data(): IData {
     return {
       fileList: [],

--- a/src/components/openaiimage/config/ImageUrlsInput.vue
+++ b/src/components/openaiimage/config/ImageUrlsInput.vue
@@ -44,7 +44,7 @@
 import { defineComponent } from 'vue';
 import { ElButton, ElUpload, ElMessage, UploadFiles, UploadFile } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform } from '@/utils';
+import { getBaseUrlPlatform, uploadTrackerMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 
@@ -63,6 +63,7 @@ export default defineComponent({
     ImagePreview,
     FontAwesomeIcon
   },
+  mixins: [uploadTrackerMixin],
   data(): IData {
     return {
       fileList: [],

--- a/src/components/pika/config/ImageUrlInput.vue
+++ b/src/components/pika/config/ImageUrlInput.vue
@@ -40,7 +40,7 @@
 import { defineComponent } from 'vue';
 import { ElButton, ElUpload, ElMessage, UploadFiles } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin, uploadTrackerMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 export const DEFAULT_CONTENT = '';
@@ -59,7 +59,7 @@ export default defineComponent({
     ImagePreview,
     FontAwesomeIcon
   },
-  mixins: [pasteUploadMixin],
+  mixins: [pasteUploadMixin, uploadTrackerMixin],
   data(): IData {
     return {
       fileList: [],

--- a/src/components/pixverse/config/StartImage.vue
+++ b/src/components/pixverse/config/StartImage.vue
@@ -42,7 +42,7 @@
 import { defineComponent } from 'vue';
 import { ElUpload, ElButton, UploadFiles, UploadFile, ElMessage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin, uploadTrackerMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 
@@ -60,7 +60,7 @@ export default defineComponent({
     FontAwesomeIcon,
     ImagePreview
   },
-  mixins: [pasteUploadMixin],
+  mixins: [pasteUploadMixin, uploadTrackerMixin],
   emits: ['change'],
   data(): IData {
     return {

--- a/src/components/producer/config/UploadAudio.vue
+++ b/src/components/producer/config/UploadAudio.vue
@@ -40,7 +40,7 @@
 import { defineComponent } from 'vue';
 import { ElUpload, ElButton, ElRadioGroup, ElRadioButton, UploadFiles, UploadFile, ElMessage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform } from '@/utils';
+import { getBaseUrlPlatform, uploadTrackerMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import { IProducerUploadRequest } from '@/models';
 import { producerOperator } from '@/operators';
@@ -62,6 +62,7 @@ export default defineComponent({
     InfoIcon,
     FontAwesomeIcon
   },
+  mixins: [uploadTrackerMixin],
   emits: ['change'],
   data(): IData {
     return {

--- a/src/components/qrart/config/ContentInput.vue
+++ b/src/components/qrart/config/ContentInput.vue
@@ -55,7 +55,7 @@ import { defineComponent } from 'vue';
 import { ElInput, ElRadioGroup, ElRadioButton, ElButton, ElUpload, ElMessage, UploadFiles } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import ImagePreview from '@/components/common/ImagePreview.vue';
-import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin, uploadTrackerMixin } from '@/utils';
 
 export const DEFAULT_CONTENT = '';
 
@@ -76,7 +76,7 @@ export default defineComponent({
     ImagePreview,
     FontAwesomeIcon
   },
-  mixins: [pasteUploadMixin],
+  mixins: [pasteUploadMixin, uploadTrackerMixin],
   data(): IData {
     return {
       inputWay: 'input',

--- a/src/components/seedance/config/FirstFrameImage.vue
+++ b/src/components/seedance/config/FirstFrameImage.vue
@@ -43,7 +43,7 @@
 import { defineComponent } from 'vue';
 import { ElUpload, ElButton, UploadFiles, UploadFile, ElMessage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin, uploadTrackerMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 import { ISeedanceImageInput } from '@/models';
@@ -62,7 +62,7 @@ export default defineComponent({
     FontAwesomeIcon,
     ImagePreview
   },
-  mixins: [pasteUploadMixin],
+  mixins: [pasteUploadMixin, uploadTrackerMixin],
   data(): IData {
     return {
       fileList: [],

--- a/src/components/seedance/config/LastFrameImage.vue
+++ b/src/components/seedance/config/LastFrameImage.vue
@@ -43,7 +43,7 @@
 import { defineComponent } from 'vue';
 import { ElUpload, ElButton, UploadFiles, UploadFile, ElMessage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin, uploadTrackerMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 import { ISeedanceImageInput } from '@/models';
@@ -62,7 +62,7 @@ export default defineComponent({
     InfoIcon,
     FontAwesomeIcon
   },
-  mixins: [pasteUploadMixin],
+  mixins: [pasteUploadMixin, uploadTrackerMixin],
   data(): IData {
     return {
       fileList: [],

--- a/src/components/seedream/config/ImageInput.vue
+++ b/src/components/seedream/config/ImageInput.vue
@@ -48,7 +48,7 @@
 import { defineComponent } from 'vue';
 import { ElButton, ElUpload, ElMessage, UploadFiles, UploadFile } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin, uploadTrackerMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 import { getSeedreamCapabilities } from '@/utils/seedream/capabilities';
@@ -68,7 +68,7 @@ export default defineComponent({
     ImagePreview,
     FontAwesomeIcon
   },
-  mixins: [pasteUploadMixin],
+  mixins: [pasteUploadMixin, uploadTrackerMixin],
   data(): IData {
     return {
       fileList: [],

--- a/src/components/sora/config/StartEndImage.vue
+++ b/src/components/sora/config/StartEndImage.vue
@@ -42,7 +42,7 @@
 import { defineComponent } from 'vue';
 import { ElUpload, ElButton, UploadFiles, UploadFile, ElMessage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin, uploadTrackerMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 
@@ -60,7 +60,7 @@ export default defineComponent({
     FontAwesomeIcon,
     ImagePreview
   },
-  mixins: [pasteUploadMixin],
+  mixins: [pasteUploadMixin, uploadTrackerMixin],
   emits: ['change'],
   data(): IData {
     return {

--- a/src/components/suno/config/UploadAudio.vue
+++ b/src/components/suno/config/UploadAudio.vue
@@ -110,7 +110,7 @@ import {
   ElRadioButton
 } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform } from '@/utils';
+import { getBaseUrlPlatform, uploadTrackerMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import { ISunoUploadRequest } from '@/models';
 import { sunoOperator } from '@/operators';
@@ -145,6 +145,7 @@ export default defineComponent({
     ElRadioGroup,
     ElRadioButton
   },
+  mixins: [uploadTrackerMixin],
   emits: ['change'],
   data(): IData {
     return {

--- a/src/components/veo/config/StartEndImage.vue
+++ b/src/components/veo/config/StartEndImage.vue
@@ -42,7 +42,7 @@
 import { defineComponent } from 'vue';
 import { ElUpload, ElButton, UploadFiles, UploadFile, ElMessage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin, uploadTrackerMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 
@@ -60,7 +60,7 @@ export default defineComponent({
     FontAwesomeIcon,
     ImagePreview
   },
-  mixins: [pasteUploadMixin],
+  mixins: [pasteUploadMixin, uploadTrackerMixin],
   emits: ['change'],
   data(): IData {
     return {

--- a/src/components/wan/config/ImageUrlInput.vue
+++ b/src/components/wan/config/ImageUrlInput.vue
@@ -40,7 +40,7 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import { ElButton, ElUpload, ElMessage, UploadFiles, UploadFile } from 'element-plus';
-import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
+import { getBaseUrlPlatform, pasteUploadMixin, uploadTrackerMixin } from '@/utils';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 
@@ -59,7 +59,7 @@ export default defineComponent({
     InfoIcon,
     ImagePreview
   },
-  mixins: [pasteUploadMixin],
+  mixins: [pasteUploadMixin, uploadTrackerMixin],
   data(): IData {
     return {
       fileList: [],

--- a/src/i18n/ar/common.json
+++ b/src/i18n/ar/common.json
@@ -922,5 +922,9 @@
   "message.apiCodeIntro": {
     "message": "Run this from your own code to produce the same result. Replace <YOUR_API_KEY> with a key from your platform console.",
     "description": "Helper text shown above the code tabs in the API code dialog, explaining how to use the snippet"
+  },
+  "message.uploadInProgress": {
+    "message": "لا تزال عمليات رفع المراجع جارية — يُرجى الانتظار قليلاً.",
+    "description": "Toast shown when the user clicks the Generate button while one or more reference uploads are still in flight. Asks them to wait for uploads to complete before retrying."
   }
 }

--- a/src/i18n/de/common.json
+++ b/src/i18n/de/common.json
@@ -922,5 +922,9 @@
   "message.apiCodeIntro": {
     "message": "Run this from your own code to produce the same result. Replace <YOUR_API_KEY> with a key from your platform console.",
     "description": "Helper text shown above the code tabs in the API code dialog, explaining how to use the snippet"
+  },
+  "message.uploadInProgress": {
+    "message": "Referenz-Uploads sind noch in Bearbeitung – bitte warten Sie einen Moment.",
+    "description": "Toast shown when the user clicks the Generate button while one or more reference uploads are still in flight. Asks them to wait for uploads to complete before retrying."
   }
 }

--- a/src/i18n/el/common.json
+++ b/src/i18n/el/common.json
@@ -922,5 +922,9 @@
   "message.apiCodeIntro": {
     "message": "Run this from your own code to produce the same result. Replace <YOUR_API_KEY> with a key from your platform console.",
     "description": "Helper text shown above the code tabs in the API code dialog, explaining how to use the snippet"
+  },
+  "message.uploadInProgress": {
+    "message": "Οι μεταφορτώσεις αναφορών βρίσκονται ακόμη σε εξέλιξη — περιμένετε λίγο.",
+    "description": "Toast shown when the user clicks the Generate button while one or more reference uploads are still in flight. Asks them to wait for uploads to complete before retrying."
   }
 }

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -922,5 +922,9 @@
   "message.apiCodeIntro": {
     "message": "Run this from your own code to produce the same result.",
     "description": "API code dialog: short hint shown above the language tabs. Explains that the snippet below reproduces the current result when run from the user's own code."
+  },
+  "message.uploadInProgress": {
+    "message": "Reference uploads are still in progress — please wait a moment.",
+    "description": "Toast warning shown when the user clicks the Generate button while reference image / video / audio uploads are still in flight. Tells them to wait for the upload to finish before re-clicking Generate."
   }
 }

--- a/src/i18n/es/common.json
+++ b/src/i18n/es/common.json
@@ -922,5 +922,9 @@
   "message.apiCodeIntro": {
     "message": "Run this from your own code to produce the same result. Replace <YOUR_API_KEY> with a key from your platform console.",
     "description": "Helper text shown above the code tabs in the API code dialog, explaining how to use the snippet"
+  },
+  "message.uploadInProgress": {
+    "message": "Las cargas de referencia aún están en curso; espera un momento.",
+    "description": "Toast shown when the user clicks the Generate button while one or more reference uploads are still in flight. Asks them to wait for uploads to complete before retrying."
   }
 }

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -922,5 +922,9 @@
   "message.apiCodeIntro": {
     "message": "Run this from your own code to produce the same result. Replace <YOUR_API_KEY> with a key from your platform console.",
     "description": "Helper text shown above the code tabs in the API code dialog, explaining how to use the snippet"
+  },
+  "message.uploadInProgress": {
+    "message": "Viiteaineistojen lataus on yhä käynnissä – odota hetki.",
+    "description": "Toast shown when the user clicks the Generate button while one or more reference uploads are still in flight. Asks them to wait for uploads to complete before retrying."
   }
 }

--- a/src/i18n/fr/common.json
+++ b/src/i18n/fr/common.json
@@ -922,5 +922,9 @@
   "message.apiCodeIntro": {
     "message": "Run this from your own code to produce the same result. Replace <YOUR_API_KEY> with a key from your platform console.",
     "description": "Helper text shown above the code tabs in the API code dialog, explaining how to use the snippet"
+  },
+  "message.uploadInProgress": {
+    "message": "Les téléversements de référence sont toujours en cours — veuillez patienter un instant.",
+    "description": "Toast shown when the user clicks the Generate button while one or more reference uploads are still in flight. Asks them to wait for uploads to complete before retrying."
   }
 }

--- a/src/i18n/it/common.json
+++ b/src/i18n/it/common.json
@@ -922,5 +922,9 @@
   "message.apiCodeIntro": {
     "message": "Run this from your own code to produce the same result. Replace <YOUR_API_KEY> with a key from your platform console.",
     "description": "Helper text shown above the code tabs in the API code dialog, explaining how to use the snippet"
+  },
+  "message.uploadInProgress": {
+    "message": "I caricamenti di riferimento sono ancora in corso, attendi un momento.",
+    "description": "Toast shown when the user clicks the Generate button while one or more reference uploads are still in flight. Asks them to wait for uploads to complete before retrying."
   }
 }

--- a/src/i18n/ja/common.json
+++ b/src/i18n/ja/common.json
@@ -922,5 +922,9 @@
   "message.apiCodeIntro": {
     "message": "Run this from your own code to produce the same result. Replace <YOUR_API_KEY> with a key from your platform console.",
     "description": "Helper text shown above the code tabs in the API code dialog, explaining how to use the snippet"
+  },
+  "message.uploadInProgress": {
+    "message": "参照ファイルのアップロードがまだ進行中です。少々お待ちください。",
+    "description": "Toast shown when the user clicks the Generate button while one or more reference uploads are still in flight. Asks them to wait for uploads to complete before retrying."
   }
 }

--- a/src/i18n/ko/common.json
+++ b/src/i18n/ko/common.json
@@ -922,5 +922,9 @@
   "message.apiCodeIntro": {
     "message": "Run this from your own code to produce the same result. Replace <YOUR_API_KEY> with a key from your platform console.",
     "description": "Helper text shown above the code tabs in the API code dialog, explaining how to use the snippet"
+  },
+  "message.uploadInProgress": {
+    "message": "참조 파일을 아직 업로드하는 중입니다. 잠시만 기다려 주세요.",
+    "description": "Toast shown when the user clicks the Generate button while one or more reference uploads are still in flight. Asks them to wait for uploads to complete before retrying."
   }
 }

--- a/src/i18n/pl/common.json
+++ b/src/i18n/pl/common.json
@@ -922,5 +922,9 @@
   "message.apiCodeIntro": {
     "message": "Run this from your own code to produce the same result. Replace <YOUR_API_KEY> with a key from your platform console.",
     "description": "Helper text shown above the code tabs in the API code dialog, explaining how to use the snippet"
+  },
+  "message.uploadInProgress": {
+    "message": "Przesyłanie plików referencyjnych nadal trwa — proszę chwilę poczekać.",
+    "description": "Toast shown when the user clicks the Generate button while one or more reference uploads are still in flight. Asks them to wait for uploads to complete before retrying."
   }
 }

--- a/src/i18n/pt/common.json
+++ b/src/i18n/pt/common.json
@@ -922,5 +922,9 @@
   "message.apiCodeIntro": {
     "message": "Run this from your own code to produce the same result. Replace <YOUR_API_KEY> with a key from your platform console.",
     "description": "Helper text shown above the code tabs in the API code dialog, explaining how to use the snippet"
+  },
+  "message.uploadInProgress": {
+    "message": "Os envios de referência ainda estão em andamento — aguarde um momento.",
+    "description": "Toast shown when the user clicks the Generate button while one or more reference uploads are still in flight. Asks them to wait for uploads to complete before retrying."
   }
 }

--- a/src/i18n/ru/common.json
+++ b/src/i18n/ru/common.json
@@ -922,5 +922,9 @@
   "message.apiCodeIntro": {
     "message": "Run this from your own code to produce the same result. Replace <YOUR_API_KEY> with a key from your platform console.",
     "description": "Helper text shown above the code tabs in the API code dialog, explaining how to use the snippet"
+  },
+  "message.uploadInProgress": {
+    "message": "Загрузка эталонных файлов ещё продолжается — пожалуйста, подождите.",
+    "description": "Toast shown when the user clicks the Generate button while one or more reference uploads are still in flight. Asks them to wait for uploads to complete before retrying."
   }
 }

--- a/src/i18n/sr/common.json
+++ b/src/i18n/sr/common.json
@@ -922,5 +922,9 @@
   "message.apiCodeIntro": {
     "message": "Run this from your own code to produce the same result. Replace <YOUR_API_KEY> with a key from your platform console.",
     "description": "Helper text shown above the code tabs in the API code dialog, explaining how to use the snippet"
+  },
+  "message.uploadInProgress": {
+    "message": "Otpremanje referentnih datoteka je još u toku — sačekajte trenutak.",
+    "description": "Toast shown when the user clicks the Generate button while one or more reference uploads are still in flight. Asks them to wait for uploads to complete before retrying."
   }
 }

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -922,5 +922,9 @@
   "message.apiCodeIntro": {
     "message": "Run this from your own code to produce the same result. Replace <YOUR_API_KEY> with a key from your platform console.",
     "description": "Helper text shown above the code tabs in the API code dialog, explaining how to use the snippet"
+  },
+  "message.uploadInProgress": {
+    "message": "Referensuppladdningarna pågår fortfarande – vänta ett ögonblick.",
+    "description": "Toast shown when the user clicks the Generate button while one or more reference uploads are still in flight. Asks them to wait for uploads to complete before retrying."
   }
 }

--- a/src/i18n/uk/common.json
+++ b/src/i18n/uk/common.json
@@ -922,5 +922,9 @@
   "message.apiCodeIntro": {
     "message": "Run this from your own code to produce the same result. Replace <YOUR_API_KEY> with a key from your platform console.",
     "description": "Helper text shown above the code tabs in the API code dialog, explaining how to use the snippet"
+  },
+  "message.uploadInProgress": {
+    "message": "Завантаження довідкових файлів ще триває — зачекайте, будь ласка.",
+    "description": "Toast shown when the user clicks the Generate button while one or more reference uploads are still in flight. Asks them to wait for uploads to complete before retrying."
   }
 }

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -922,5 +922,9 @@
   "message.apiCodeIntro": {
     "message": "在你自己的代码里运行下面任意一段即可复现当前结果。",
     "description": "API code dialog: short hint shown above the language tabs. Explains that the snippet below reproduces the current result when run from the user's own code."
+  },
+  "message.uploadInProgress": {
+    "message": "参考文件正在上传，请稍候再生成",
+    "description": "用户在参考图/视频/音频还未上传完成时点击生成按钮，会弹出的轻量提示，要求用户等待上传完成后再次点击生成。"
   }
 }

--- a/src/i18n/zh-TW/common.json
+++ b/src/i18n/zh-TW/common.json
@@ -922,5 +922,9 @@
   "message.apiCodeIntro": {
     "message": "Run this from your own code to produce the same result. Replace <YOUR_API_KEY> with a key from your platform console.",
     "description": "Helper text shown above the code tabs in the API code dialog, explaining how to use the snippet"
+  },
+  "message.uploadInProgress": {
+    "message": "參考檔案仍在上傳，請稍候再生成。",
+    "description": "Toast shown when the user clicks the Generate button while one or more reference uploads are still in flight. Asks them to wait for uploads to complete before retrying."
   }
 }

--- a/src/pages/fish/Tts.vue
+++ b/src/pages/fish/Tts.vue
@@ -26,6 +26,7 @@ import { IFishTask, IFishTtsRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
 import { ERROR_CODE_USED_UP, FISH_DEFAULT_TTS_MODEL, getWebhookCallbackUrl } from '@/constants';
 import { loadPreviousPage } from '@/utils/pagination';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
 
 const CALLBACK_URL = getWebhookCallbackUrl('fish');
 
@@ -44,6 +45,7 @@ export default defineComponent({
     RecentPanel,
     TabSwitcher
   },
+  mixins: [uploadTrackerProviderMixin],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -141,6 +143,15 @@ export default defineComponent({
       }
     },
     async onGenerate() {
+      if (
+        !ensureNoPendingUpload(
+          this.uploadTracker,
+          (k) => this.$t(k) as string,
+          (m) => ElMessage.warning(m)
+        )
+      ) {
+        return;
+      }
       const cfg = this.config ?? {};
       const text = cfg.text?.trim();
       if (!text) {

--- a/src/pages/flux/Index.vue
+++ b/src/pages/flux/Index.vue
@@ -21,6 +21,7 @@ import { ERROR_CODE_USED_UP, getWebhookCallbackUrl } from '@/constants';
 import RecentPanel from '@/components/flux/RecentPanel.vue';
 import { IFluxTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
 
 const CALLBACK_URL = getWebhookCallbackUrl('flux');
 
@@ -38,6 +39,7 @@ export default defineComponent({
     Layout,
     RecentPanel
   },
+  mixins: [uploadTrackerProviderMixin],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -151,6 +153,15 @@ export default defineComponent({
       }
     },
     async onGenerate() {
+      if (
+        !ensureNoPendingUpload(
+          this.uploadTracker,
+          (k) => this.$t(k) as string,
+          (m) => ElMessage.warning(m)
+        )
+      ) {
+        return;
+      }
       const request = {
         ...this.config,
         callback_url: CALLBACK_URL

--- a/src/pages/hailuo/Index.vue
+++ b/src/pages/hailuo/Index.vue
@@ -21,6 +21,7 @@ import { ERROR_CODE_USED_UP, getWebhookCallbackUrl } from '@/constants';
 import RecentPanel from '@/components/hailuo/RecentPanel.vue';
 import { IHailuoTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
 
 const CALLBACK_URL = getWebhookCallbackUrl('hailuo');
 
@@ -38,6 +39,7 @@ export default defineComponent({
     Layout,
     RecentPanel
   },
+  mixins: [uploadTrackerProviderMixin],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -153,6 +155,15 @@ export default defineComponent({
       }
     },
     async onGenerate() {
+      if (
+        !ensureNoPendingUpload(
+          this.uploadTracker,
+          (k) => this.$t(k) as string,
+          (m) => ElMessage.warning(m)
+        )
+      ) {
+        return;
+      }
       const request = {
         ...this.config,
         callback_url: CALLBACK_URL

--- a/src/pages/headshots/Index.vue
+++ b/src/pages/headshots/Index.vue
@@ -33,6 +33,7 @@ import ApplicationStatus from '@/components/application/Status.vue';
 import RecentPanel from '@/components/headshots/RecentPanel.vue';
 import { IHeadshotsTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
 
 const CALLBACK_URL = getWebhookCallbackUrl('headshots');
 
@@ -51,6 +52,7 @@ export default defineComponent({
     ApplicationStatus,
     RecentPanel
   },
+  mixins: [uploadTrackerProviderMixin],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -192,6 +194,15 @@ export default defineComponent({
       }
     },
     async onGeneratePicture() {
+      if (
+        !ensureNoPendingUpload(
+          this.uploadTracker,
+          (k) => this.$t(k) as string,
+          (m) => ElMessage.warning(m)
+        )
+      ) {
+        return;
+      }
       const request = {
         ...this.config,
         callback_url: CALLBACK_URL

--- a/src/pages/kling/Index.vue
+++ b/src/pages/kling/Index.vue
@@ -29,6 +29,7 @@ import { ERROR_CODE_USED_UP, getWebhookCallbackUrl } from '@/constants';
 import RecentPanel from '@/components/kling/RecentPanel.vue';
 import { IKlingTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
 
 const CALLBACK_URL = getWebhookCallbackUrl('kling');
 
@@ -48,6 +49,7 @@ export default defineComponent({
     Layout,
     RecentPanel
   },
+  mixins: [uploadTrackerProviderMixin],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -163,6 +165,15 @@ export default defineComponent({
       }
     },
     async onGenerate() {
+      if (
+        !ensureNoPendingUpload(
+          this.uploadTracker,
+          (k) => this.$t(k) as string,
+          (m) => ElMessage.warning(m)
+        )
+      ) {
+        return;
+      }
       const { camera_control, ...rest } = this.config || {};
       const request = {
         ...rest,
@@ -240,6 +251,15 @@ export default defineComponent({
       await this.onScrollDown();
     },
     async onGenerateMotion() {
+      if (
+        !ensureNoPendingUpload(
+          this.uploadTracker,
+          (k) => this.$t(k) as string,
+          (m) => ElMessage.warning(m)
+        )
+      ) {
+        return;
+      }
       const cfg = this.motionConfig || {};
       if (!cfg.image_url || !cfg.video_url) {
         ElMessage.warning(this.$t('kling.message.motionMissingInputs'));

--- a/src/pages/luma/Index.vue
+++ b/src/pages/luma/Index.vue
@@ -21,6 +21,7 @@ import { ERROR_CODE_USED_UP, getWebhookCallbackUrl } from '@/constants';
 import RecentPanel from '@/components/luma/RecentPanel.vue';
 import { ILumaTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
 
 const CALLBACK_URL = getWebhookCallbackUrl('luma');
 
@@ -38,6 +39,7 @@ export default defineComponent({
     Layout,
     RecentPanel
   },
+  mixins: [uploadTrackerProviderMixin],
   inject: ['initialized'],
   emits: ['extend'],
   data(): IData {
@@ -153,6 +155,15 @@ export default defineComponent({
       }
     },
     async onGenerate() {
+      if (
+        !ensureNoPendingUpload(
+          this.uploadTracker,
+          (k) => this.$t(k) as string,
+          (m) => ElMessage.warning(m)
+        )
+      ) {
+        return;
+      }
       const request = {
         ...this.config,
         callback_url: CALLBACK_URL

--- a/src/pages/midjourney/Index.vue
+++ b/src/pages/midjourney/Index.vue
@@ -35,6 +35,7 @@ import {
   getWebhookCallbackUrl
 } from '@/constants';
 import { loadPreviousPage } from '@/utils/pagination';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
 
 interface IData {
   operating: boolean;
@@ -52,6 +53,7 @@ export default defineComponent({
     TaskList,
     Layout
   },
+  mixins: [uploadTrackerProviderMixin],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -323,6 +325,15 @@ export default defineComponent({
       this.onStartImagineTask(request);
     },
     async onGenerate() {
+      if (
+        !ensureNoPendingUpload(
+          this.uploadTracker,
+          (k) => this.$t(k) as string,
+          (m) => ElMessage.warning(m)
+        )
+      ) {
+        return;
+      }
       console.debug('onGenerate', this.config);
       if (this.config?.type === 'videos') {
         const request = {

--- a/src/pages/nanobanana/Index.vue
+++ b/src/pages/nanobanana/Index.vue
@@ -17,10 +17,16 @@ import { nanobananaOperator } from '@/operators';
 import { instrumentGeneration } from '@/plugins/telemetry';
 import { INanobananaGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
-import { ERROR_CODE_USED_UP, NANOBANANA_DEFAULT_RESOLUTION, NANOBANANA_MODEL_NANO_BANANA_PRO, getWebhookCallbackUrl } from '@/constants';
+import {
+  ERROR_CODE_USED_UP,
+  NANOBANANA_DEFAULT_RESOLUTION,
+  NANOBANANA_MODEL_NANO_BANANA_PRO,
+  getWebhookCallbackUrl
+} from '@/constants';
 import RecentPanel from '@/components/nanobanana/RecentPanel.vue';
 import { INanobananaTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
 
 const CALLBACK_URL = getWebhookCallbackUrl('nanobanana');
 
@@ -37,6 +43,7 @@ export default defineComponent({
     Layout,
     RecentPanel
   },
+  mixins: [uploadTrackerProviderMixin],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -139,6 +146,15 @@ export default defineComponent({
       });
     },
     async onGenerate() {
+      if (
+        !ensureNoPendingUpload(
+          this.uploadTracker,
+          (k) => this.$t(k) as string,
+          (m) => ElMessage.warning(m)
+        )
+      ) {
+        return;
+      }
       const cfg: any = { ...(this.config || {}) };
       const hasReferenceImages = Array.isArray(cfg?.image_urls) && cfg.image_urls.length > 0;
       delete cfg.action;

--- a/src/pages/openaiimage/Index.vue
+++ b/src/pages/openaiimage/Index.vue
@@ -20,6 +20,7 @@ import { ElMessage } from 'element-plus';
 import { ERROR_CODE_USED_UP, getWebhookCallbackUrl } from '@/constants';
 import RecentPanel from '@/components/openaiimage/RecentPanel.vue';
 import { loadPreviousPage } from '@/utils/pagination';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
 import { IOpenAIImageTask } from '@/models';
 
 const CALLBACK_URL = getWebhookCallbackUrl('openaiimage');
@@ -37,6 +38,7 @@ export default defineComponent({
     Layout,
     RecentPanel
   },
+  mixins: [uploadTrackerProviderMixin],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -139,6 +141,15 @@ export default defineComponent({
       });
     },
     async onGenerate() {
+      if (
+        !ensureNoPendingUpload(
+          this.uploadTracker,
+          (k) => this.$t(k) as string,
+          (m) => ElMessage.warning(m)
+        )
+      ) {
+        return;
+      }
       const cfg: any = { ...(this.config || {}) };
       const hasReferenceImages = Array.isArray(cfg?.image_urls) && cfg.image_urls.length > 0;
 

--- a/src/pages/pika/Index.vue
+++ b/src/pages/pika/Index.vue
@@ -21,6 +21,7 @@ import { ERROR_CODE_DUPLICATION, ERROR_CODE_USED_UP, getWebhookCallbackUrl } fro
 import RecentPanel from '@/components/pika/RecentPanel.vue';
 import { IPikaTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
 
 const CALLBACK_URL = getWebhookCallbackUrl('pika');
 
@@ -38,6 +39,7 @@ export default defineComponent({
     Layout,
     RecentPanel
   },
+  mixins: [uploadTrackerProviderMixin],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -179,6 +181,15 @@ export default defineComponent({
       }
     },
     async onGenerate() {
+      if (
+        !ensureNoPendingUpload(
+          this.uploadTracker,
+          (k) => this.$t(k) as string,
+          (m) => ElMessage.warning(m)
+        )
+      ) {
+        return;
+      }
       const request = {
         ...this.config,
         callback_url: CALLBACK_URL

--- a/src/pages/pixverse/Index.vue
+++ b/src/pages/pixverse/Index.vue
@@ -21,6 +21,7 @@ import { ERROR_CODE_USED_UP, getWebhookCallbackUrl } from '@/constants';
 import RecentPanel from '@/components/pixverse/RecentPanel.vue';
 import { IPixverseTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
 
 const CALLBACK_URL = getWebhookCallbackUrl('pixverse');
 
@@ -38,6 +39,7 @@ export default defineComponent({
     Layout,
     RecentPanel
   },
+  mixins: [uploadTrackerProviderMixin],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -148,6 +150,15 @@ export default defineComponent({
       }
     },
     async onGenerate() {
+      if (
+        !ensureNoPendingUpload(
+          this.uploadTracker,
+          (k) => this.$t(k) as string,
+          (m) => ElMessage.warning(m)
+        )
+      ) {
+        return;
+      }
       const request = {
         ...this.config,
         callback_url: CALLBACK_URL

--- a/src/pages/producer/Index.vue
+++ b/src/pages/producer/Index.vue
@@ -25,6 +25,7 @@ import ConfigPanel from '@/components/producer/ConfigPanel.vue';
 import RecentPanel from '@/components/producer/RecentPanel.vue';
 import PreviewPanel from '@/components/producer/PreviewPanel.vue';
 import { loadPreviousPage } from '@/utils/pagination';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
 
 const CALLBACK_URL = getWebhookCallbackUrl('producer');
 
@@ -43,6 +44,7 @@ export default defineComponent({
     RecentPanel,
     PreviewPanel
   },
+  mixins: [uploadTrackerProviderMixin],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -182,6 +184,15 @@ export default defineComponent({
       }
     },
     async onGenerateAudio() {
+      if (
+        !ensureNoPendingUpload(
+          this.uploadTracker,
+          (k) => this.$t(k) as string,
+          (m) => ElMessage.warning(m)
+        )
+      ) {
+        return;
+      }
       const request = {
         ...this.config,
         callback_url: CALLBACK_URL

--- a/src/pages/qrart/Index.vue
+++ b/src/pages/qrart/Index.vue
@@ -32,6 +32,7 @@ import ApplicationStatus from '@/components/application/Status.vue';
 import RecentPanel from '@/components/qrart/RecentPanel.vue';
 import { IQrartTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
 
 const CALLBACK_URL = getWebhookCallbackUrl('qrart');
 
@@ -50,6 +51,7 @@ export default defineComponent({
     ApplicationStatus,
     RecentPanel
   },
+  mixins: [uploadTrackerProviderMixin],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -191,6 +193,15 @@ export default defineComponent({
       }
     },
     async onGenerate() {
+      if (
+        !ensureNoPendingUpload(
+          this.uploadTracker,
+          (k) => this.$t(k) as string,
+          (m) => ElMessage.warning(m)
+        )
+      ) {
+        return;
+      }
       const request = {
         type: this.config?.type,
         content: this.config?.content,

--- a/src/pages/seedance/Index.vue
+++ b/src/pages/seedance/Index.vue
@@ -21,6 +21,7 @@ import { ElMessage } from 'element-plus';
 import { ERROR_CODE_USED_UP, getWebhookCallbackUrl } from '@/constants';
 import { ISeedanceTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
 
 const CALLBACK_URL = getWebhookCallbackUrl('seedance');
 
@@ -38,6 +39,7 @@ export default defineComponent({
     Layout,
     RecentPanel
   },
+  mixins: [uploadTrackerProviderMixin],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -125,6 +127,15 @@ export default defineComponent({
       }
     },
     async onGenerate() {
+      if (
+        !ensureNoPendingUpload(
+          this.uploadTracker,
+          (k) => this.$t(k) as string,
+          (m) => ElMessage.warning(m)
+        )
+      ) {
+        return;
+      }
       const cfg: any = { ...(this.config || {}) };
       if (typeof cfg?.prompt === 'string') {
         cfg.prompt = cfg.prompt.trim();

--- a/src/pages/seedream/Index.vue
+++ b/src/pages/seedream/Index.vue
@@ -20,6 +20,7 @@ import { ElMessage } from 'element-plus';
 import { ERROR_CODE_USED_UP, getWebhookCallbackUrl } from '@/constants';
 import RecentPanel from '@/components/seedream/RecentPanel.vue';
 import { loadPreviousPage } from '@/utils/pagination';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
 import { ISeedreamTask } from '@/models';
 
 const CALLBACK_URL = getWebhookCallbackUrl('seedream');
@@ -37,6 +38,7 @@ export default defineComponent({
     Layout,
     RecentPanel
   },
+  mixins: [uploadTrackerProviderMixin],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -139,6 +141,15 @@ export default defineComponent({
       });
     },
     async onGenerate() {
+      if (
+        !ensureNoPendingUpload(
+          this.uploadTracker,
+          (k) => this.$t(k) as string,
+          (m) => ElMessage.warning(m)
+        )
+      ) {
+        return;
+      }
       const cfg: any = { ...(this.config || {}) };
       const hasReferenceImages = Array.isArray(cfg?.image) && cfg.image.length > 0;
       if (!hasReferenceImages && 'image' in cfg) {

--- a/src/pages/sora/Index.vue
+++ b/src/pages/sora/Index.vue
@@ -21,6 +21,7 @@ import { ERROR_CODE_USED_UP, getWebhookCallbackUrl } from '@/constants';
 import RecentPanel from '@/components/sora/RecentPanel.vue';
 import { ISoraTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
 
 const CALLBACK_URL = getWebhookCallbackUrl('sora');
 
@@ -38,6 +39,7 @@ export default defineComponent({
     Layout,
     RecentPanel
   },
+  mixins: [uploadTrackerProviderMixin],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -148,6 +150,15 @@ export default defineComponent({
       }
     },
     async onGenerate() {
+      if (
+        !ensureNoPendingUpload(
+          this.uploadTracker,
+          (k) => this.$t(k) as string,
+          (m) => ElMessage.warning(m)
+        )
+      ) {
+        return;
+      }
       const request = {
         ...this.config,
         callback_url: CALLBACK_URL

--- a/src/pages/suno/Index.vue
+++ b/src/pages/suno/Index.vue
@@ -25,6 +25,7 @@ import ConfigPanel from '@/components/suno/ConfigPanel.vue';
 import RecentPanel from '@/components/suno/RecentPanel.vue';
 import PreviewPanel from '@/components/suno/PreviewPanel.vue';
 import { loadPreviousPage } from '@/utils/pagination';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
 
 const CALLBACK_URL = getWebhookCallbackUrl('suno');
 
@@ -43,6 +44,7 @@ export default defineComponent({
     RecentPanel,
     PreviewPanel
   },
+  mixins: [uploadTrackerProviderMixin],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -184,6 +186,15 @@ export default defineComponent({
       }
     },
     async onGenerateAudio() {
+      if (
+        !ensureNoPendingUpload(
+          this.uploadTracker,
+          (k) => this.$t(k) as string,
+          (m) => ElMessage.warning(m)
+        )
+      ) {
+        return;
+      }
       const request = {
         ...this.config,
         callback_url: CALLBACK_URL

--- a/src/pages/veo/Index.vue
+++ b/src/pages/veo/Index.vue
@@ -21,6 +21,7 @@ import { ERROR_CODE_USED_UP, getWebhookCallbackUrl } from '@/constants';
 import RecentPanel from '@/components/veo/RecentPanel.vue';
 import { IVeoTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
 
 const CALLBACK_URL = getWebhookCallbackUrl('veo');
 
@@ -38,6 +39,7 @@ export default defineComponent({
     Layout,
     RecentPanel
   },
+  mixins: [uploadTrackerProviderMixin],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -148,6 +150,15 @@ export default defineComponent({
       }
     },
     async onGenerate() {
+      if (
+        !ensureNoPendingUpload(
+          this.uploadTracker,
+          (k) => this.$t(k) as string,
+          (m) => ElMessage.warning(m)
+        )
+      ) {
+        return;
+      }
       const request = {
         ...this.config,
         callback_url: CALLBACK_URL

--- a/src/pages/wan/Index.vue
+++ b/src/pages/wan/Index.vue
@@ -21,6 +21,7 @@ import { ERROR_CODE_USED_UP, getWebhookCallbackUrl } from '@/constants';
 import RecentPanel from '@/components/wan/RecentPanel.vue';
 import { IWanTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
 
 const CALLBACK_URL = getWebhookCallbackUrl('wan');
 
@@ -38,6 +39,7 @@ export default defineComponent({
     Layout,
     RecentPanel
   },
+  mixins: [uploadTrackerProviderMixin],
   inject: ['initialized'],
   data(): IData {
     return {
@@ -152,6 +154,15 @@ export default defineComponent({
       }
     },
     async onGenerate() {
+      if (
+        !ensureNoPendingUpload(
+          this.uploadTracker,
+          (k) => this.$t(k) as string,
+          (m) => ElMessage.warning(m)
+        )
+      ) {
+        return;
+      }
       const request = {
         ...this.config,
         callback_url: CALLBACK_URL

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -13,4 +13,5 @@ export * from './application';
 export * from './theme';
 export * from './pasteUpload';
 export * from './pasteUploadMixin';
+export * from './uploadTrackerMixin';
 export * from './connections';

--- a/src/utils/uploadTrackerMixin.ts
+++ b/src/utils/uploadTrackerMixin.ts
@@ -1,0 +1,124 @@
+/**
+ * Two mixins + a helper for tracking in-flight `<el-upload>` uploads so that
+ * a Generate page can refuse to fire while reference images are still being
+ * uploaded.
+ *
+ * Architecture
+ * ------------
+ * - A Generate page mixes in `uploadTrackerProviderMixin`, which installs a
+ *   reactive `uploadTracker = { count: 0 }` on the instance and `provide`s it
+ *   to all descendants.
+ * - Every `<el-upload>` wrapper mixes in `uploadTrackerMixin`, which `inject`s
+ *   that tracker and watches its `fileList` data field. Files whose `status`
+ *   is `ready` or `uploading` are counted as in-flight; the mixin increments
+ *   or decrements `tracker.count` accordingly. If no provider exists higher
+ *   in the tree, the mixin is a silent no-op, so it is safe to install on
+ *   every uploader unconditionally.
+ * - The Generate handler calls `ensureNoPendingUpload(this.uploadTracker, …)`
+ *   at the top of its action; it returns `false` and pops a localized toast
+ *   when any uploader still has files in flight.
+ */
+
+import type { ComponentPublicInstance } from 'vue';
+
+export interface IUploadTracker {
+  count: number;
+}
+
+interface IUploadFileLike {
+  uid?: string | number;
+  status?: string;
+}
+
+interface ITrackerMixinThis extends ComponentPublicInstance {
+  uploadTracker: IUploadTracker | null;
+  fileList?: IUploadFileLike[];
+  __pendingUploadUids?: Set<string>;
+}
+
+interface IProviderMixinThis extends ComponentPublicInstance {
+  uploadTracker: IUploadTracker;
+}
+
+const isPending = (file: IUploadFileLike | undefined | null): boolean => {
+  const status = file?.status;
+  return status === 'ready' || status === 'uploading';
+};
+
+const uidKey = (file: IUploadFileLike): string => {
+  return String(file?.uid ?? JSON.stringify(file));
+};
+
+/**
+ * Install on every `<el-upload>` wrapper. The host must expose a reactive
+ * `fileList` field that mirrors `el-upload`'s `v-model:file-list`.
+ */
+export const uploadTrackerMixin = {
+  inject: {
+    uploadTracker: { default: null as IUploadTracker | null }
+  },
+  watch: {
+    fileList: {
+      deep: true,
+      immediate: true,
+      handler(this: ITrackerMixinThis, newList: IUploadFileLike[] | undefined) {
+        const tracker = this.uploadTracker;
+        if (!tracker) return;
+        const prev = this.__pendingUploadUids ?? new Set<string>();
+        const next = new Set<string>();
+        for (const file of newList || []) {
+          if (isPending(file)) next.add(uidKey(file));
+        }
+        let delta = 0;
+        for (const uid of next) if (!prev.has(uid)) delta += 1;
+        for (const uid of prev) if (!next.has(uid)) delta -= 1;
+        if (delta !== 0) {
+          const nextCount = tracker.count + delta;
+          tracker.count = nextCount > 0 ? nextCount : 0;
+        }
+        this.__pendingUploadUids = next;
+      }
+    }
+  },
+  beforeUnmount(this: ITrackerMixinThis) {
+    const tracker = this.uploadTracker;
+    const prev = this.__pendingUploadUids;
+    if (tracker && prev && prev.size > 0) {
+      const nextCount = tracker.count - prev.size;
+      tracker.count = nextCount > 0 ? nextCount : 0;
+    }
+    this.__pendingUploadUids = undefined;
+  }
+};
+
+/**
+ * Install on a Generate page (or any owner of a generation action) to expose
+ * a `uploadTracker` instance to descendant uploaders. Exposes `this.uploadTracker`.
+ */
+export const uploadTrackerProviderMixin = {
+  data(): { uploadTracker: IUploadTracker } {
+    return { uploadTracker: { count: 0 } };
+  },
+  provide(this: IProviderMixinThis) {
+    return { uploadTracker: this.uploadTracker };
+  }
+};
+
+/**
+ * Guard helper for Generate actions. Returns `true` when no uploader has any
+ * file still in flight; otherwise calls `notify` with the localized warning
+ * text and returns `false` so the caller can early-return.
+ */
+export function ensureNoPendingUpload(
+  tracker: IUploadTracker | null | undefined,
+  t: (key: string) => string,
+  notify: (msg: string) => void
+): boolean {
+  if (tracker && tracker.count > 0) {
+    notify(t('common.message.uploadInProgress'));
+    return false;
+  }
+  return true;
+}
+
+export default uploadTrackerMixin;


### PR DESCRIPTION
## Summary

Two related fixes for the "I clicked Generate but my reference image was ignored" class of bug.

### Root cause

When a user dropped an image into a reference uploader and clicked **Generate** before the `el-upload` background XHR returned, the action fired with an empty / missing `image_urls`. On gpt-image-2 this caused the worker to route through `/openai/images/generations` (text-to-image) instead of `/openai/images/edits`, silently producing an unrelated image. Confirmed against two customer tasks via CLS:

- `f2aed816-d776-4214-b235-711be144f327`
- `a7a19e80-6f33-405a-89a7-82cade7cc444`

### Fix 1 — show progress overlay at 0% (cosmetic, but root of the misuse)

`ImagePreview` / `FilePreview` hid the progress bar with `v-show="percentage && percentage < 100"`. At `percentage === 0` the expression is falsy, so the overlay never appeared while the XHR was uploading — users had no visual cue that an upload was still in flight and clicked Generate.

Switched the gate to `typeof percentage === 'number' && percentage < 100` and bound a non-`undefined` `displayPercentage` so the gray overlay + progress shows from the moment a file is added.

### Fix 2 — block Generate while any uploader has a file in flight

Page-level callback / provide-inject solution (per the user-requested "callback / inject" pattern, not Vuex):

- **`uploadTrackerProviderMixin`** — installed on every Generate page. Adds a reactive `uploadTracker = { count: 0 }` and `provide`s it to descendants.
- **`uploadTrackerMixin`** — installed on every `<el-upload>` wrapper. `inject`s the tracker, watches the host's `fileList`, and adjusts `count` via a Set-based delta diff for files whose `status` is `ready` or `uploading`. Cleans up its contribution on `beforeUnmount`. Silent no-op when no provider exists higher in the tree (so it's safe on the chat composer too).
- **`ensureNoPendingUpload(tracker, t, notify)`** — guard helper called at the top of every `onGenerate*` handler. Pops `common.message.uploadInProgress` and returns `false` when any upload is still pending; the handler early-returns.

i18n: added `common.message.uploadInProgress` to `zh-CN` and `en` only (auto-translate CronJob handles the rest).

### Scope

- 30 uploader components patched (chat composer + 29 service config uploaders).
- 19 Generate pages patched (one `mixins:` line + one guard call each; kling gets 2 guards for `onGenerate` + `onGenerateMotion`).
- 1 new file: `src/utils/uploadTrackerMixin.ts` (provider, consumer, helper).
- 2 i18n files (`zh-CN/common.json`, `en/common.json`).
- 2 preview components (`ImagePreview.vue`, `FilePreview.vue`).
- 1 utils barrel (`src/utils/index.ts`).

### Validation

- `eslint src --fix` — clean.
- `vue-tsc --noEmit -p tsconfig.app.json` — clean (the single pre-existing `mustache` error in `ApiCodeDialog.vue` reproduces on `main` and is unrelated).
- Manual sanity: 20 guard call sites (19 pages × 1 + kling motion +1), 19 `uploadTrackerProviderMixin` page installs, 29 uploader-side mixin installs.

### Test plan for reviewers

1. Open any reference-image-bearing page (e.g. `/openaiimage` with model `gpt-image-2`).
2. Drag in a large reference image.
3. Click **Generate** immediately — should toast "Reference uploads are still in progress — please wait a moment." and not fire the request.
4. The image tile should show a gray overlay + progress bar from 0% → 100%.
5. After upload completes, click Generate — task fires normally, with `image_urls` populated.

### Notes

- Provider mixin is page-local — the chat composer (which doesn't have a `Generate` page above it) keeps working as before.
- No new dependencies, no Vuex changes, no API contract changes.
