### PR TITLE
fix(settings/auth): prevent description tip from overlapping toggle column

### DIFF
--- a/src/components/setting/Auth.vue
+++ b/src/components/setting/Auth.vue
@@ -209,10 +209,35 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
+// The settings row uses ``display:flex; justify-content:space-between``
+// from the parent ``user/Setting.vue`` (``:deep(.settings-item)``). Its
+// ``.settings-label`` ships without ``min-width: 0``, so when an inner
+// ``.settings-tip`` carries ``max-width: 440px`` the label's flex
+// preferred size resolves to ~440px. On the 50%-dialog the available
+// content width can be as little as ~400px, which pushes the right
+// switch column past the gutter and visually overlaps the tip text
+// with the provider labels (邮箱 / Google / GitHub / 手机号 / 微信).
+//
+// Force the label column to share the row by:
+//   * letting it grow into all remaining space (``flex: 1 1 0``)
+//   * unlocking flex-shrink below intrinsic min-content (``min-width:0``)
+//
+// And lock the right column to its content size so it never gets
+// squeezed below the toggle width either.
+:deep(.settings-item) {
+  .settings-label {
+    flex: 1 1 0;
+    min-width: 0;
+  }
+}
+
 .auth-providers-content {
   // Let the switch list stretch the full content column so each
-  // row aligns its label and toggle in a single visual gutter.
+  // row aligns its label and toggle in a single visual gutter, and
+  // pin the column to its intrinsic width so it never collides with
+  // the tip text on narrow viewports.
   align-items: stretch;
+  flex: 0 0 auto;
 }
 
 .auth-providers-list {
@@ -221,7 +246,10 @@ export default defineComponent({
   margin: 0;
   display: flex;
   flex-direction: column;
-  min-width: 240px;
+  // 220px is enough to render the longest provider label (``GitHub``)
+  // plus the el-switch comfortably; the earlier 240px was wide enough
+  // to monopolise the row on a 50%-width dialog and starve the tip.
+  min-width: 220px;
 }
 
 .auth-providers-row {


### PR DESCRIPTION
## Summary

In the **Settings → 登录方式 (Login Methods)** tab the description text for *启用的登录方式* visually overlaps with the right-hand switch column (邮箱 / Google / GitHub / 手机号 / 微信). The tip text bleeds past the gutter into the area where the provider labels render — see the original report screenshot.

## Root cause

`user/Setting.vue` defines the shared row layout via `:deep(.settings-item)`:

```scss
:deep(.settings-item) { display: flex; gap: 16px; ... }
:deep(.settings-tip)  { max-width: 440px; ... }
```

`.settings-label` (which contains the tip) has no `min-width: 0`, so the tip's `max-width: 440px` resolves to the label's preferred flex size of ~440px. On the 50%-width dialog the actual content area for a row is only ~400–420px, so flex shrinking has to fight the label's intrinsic min-content. The right column `.auth-providers-list` (Auth.vue) was also pinned to `min-width: 240px` — wide enough that the two columns can't both fit, pushing the label content past the gutter and visually overlapping the toggles.

## Fix

CSS-only and **scoped to Auth.vue** so other settings panels are untouched:

- `:deep(.settings-item) .settings-label { flex: 1 1 0; min-width: 0; }` — let the label column grow into remaining row space and shrink below intrinsic min-content.
- `.auth-providers-content { flex: 0 0 auto; }` — keep the right column at its content size so it can never push past the gutter.
- `.auth-providers-list { min-width: 220px; }` (was 240px) — still plenty for the longest label (`GitHub`) plus the `el-switch`, but no longer wide enough to starve the tip.

## Verification

- No template / script / i18n changes.
- Visually re-checked: at the 50% dialog width the description tip wraps cleanly inside its column and the switches sit in a separate gutter on the right.
- Mobile fallback (`@media (max-width: 640px)` in `user/Setting.vue`) flips the row to a column anyway, so the new rules are a no-op on phones.
- No interaction changes to the `enabled` toggles or the `default_provider` select.

---
*This pull request was generated and committed by the [GitHub Copilot](https://github.com/copilot) coding agent on behalf of @CQUPTQiCu.*