### PR TITLE
fix(UserPicker): show 未找到该用户 when /users/resolve/ returns []

### DIFF
--- a/src/components/site/UserPicker.vue
+++ b/src/components/site/UserPicker.vue
@@ -18,15 +18,21 @@
       <el-icon><search-icon /></el-icon>
     </template>
     <template #default="{ item }">
-      <div class="user-picker__option">
-        <el-avatar v-if="item.avatar" :src="item.avatar" :size="32" class="user-picker__avatar" />
-        <el-avatar v-else :size="32" class="user-picker__avatar">
-          <el-icon><user-icon /></el-icon>
-        </el-avatar>
-        <div class="user-picker__option-text">
-          <div class="user-picker__option-name">{{ item.display_name }}</div>
-          <div class="user-picker__option-contact">{{ item.contact || shortIdOf(item) }}</div>
-        </div>
+      <div class="user-picker__option" :class="{ 'user-picker__option--empty': item.__empty }">
+        <template v-if="item.__empty">
+          <el-icon class="user-picker__empty-icon"><warning-filled /></el-icon>
+          <span class="user-picker__empty-text">{{ $t('site.message.userNotFound') }}</span>
+        </template>
+        <template v-else>
+          <el-avatar v-if="item.avatar" :src="item.avatar" :size="32" class="user-picker__avatar" />
+          <el-avatar v-else :size="32" class="user-picker__avatar">
+            <el-icon><user-icon /></el-icon>
+          </el-avatar>
+          <div class="user-picker__option-text">
+            <div class="user-picker__option-name">{{ item.display_name }}</div>
+            <div class="user-picker__option-contact">{{ item.contact || shortIdOf(item) }}</div>
+          </div>
+        </template>
       </div>
     </template>
   </el-autocomplete>
@@ -35,12 +41,16 @@
 <script lang="ts">
 import { defineComponent, type PropType } from 'vue';
 import { ElAutocomplete, ElAvatar, ElIcon } from 'element-plus';
-import { Search as SearchIcon, User as UserIcon } from '@element-plus/icons-vue';
+import { Search as SearchIcon, User as UserIcon, WarningFilled } from '@element-plus/icons-vue';
 import { userOperator } from '@/operators';
 import type { IUserPublic } from '@/models';
 import { seedUserChipCache } from '@/components/site/UserChip.vue';
 
-type Suggestion = IUserPublic & { value: string };
+type UserSuggestion = IUserPublic & { value: string; __empty?: false };
+type EmptySuggestion = { __empty: true; value: ''; id: '' };
+type Suggestion = UserSuggestion | EmptySuggestion;
+
+const EMPTY_SUGGESTION: EmptySuggestion = { __empty: true, value: '', id: '' };
 
 export default defineComponent({
   name: 'UserPicker',
@@ -49,7 +59,8 @@ export default defineComponent({
     ElAvatar,
     ElIcon,
     SearchIcon,
-    UserIcon
+    UserIcon,
+    WarningFilled
   },
   props: {
     placeholder: {
@@ -82,17 +93,35 @@ export default defineComponent({
       if (!q) return [];
       try {
         const res = await userOperator.resolve(q);
-        return (res.data || [])
+        const items: UserSuggestion[] = (res.data || [])
           .filter((u) => !this.excludeIds.includes(u.id))
           .map((u) => {
             seedUserChipCache(u);
-            return { ...u, value: u.display_name || u.nickname || this.shortIdOf(u) } as Suggestion;
+            return { ...u, value: u.display_name || u.nickname || this.shortIdOf(u) } as UserSuggestion;
           });
+        // The backend (`/users/resolve/`) does exact-match-only on
+        // username / email / phone / UUID for privacy. When the query
+        // doesn't hit, the API returns []. Without a sentinel the
+        // el-autocomplete dropdown stays hidden (it only shows when
+        // `suggestions.length > 0`), leaving the user with no feedback
+        // — which looked like "the dropdown is broken". Inject a
+        // non-selectable empty-state row so the dropdown surfaces
+        // `site.message.userNotFound` instead.
+        if (items.length === 0) return [EMPTY_SUGGESTION];
+        return items;
       } catch {
-        return [];
+        // Same UX treatment for network errors: better to show
+        // "未找到该用户" than to silently swallow the failure.
+        return [EMPTY_SUGGESTION];
       }
     },
     onSelect(item: Record<string, unknown>) {
+      // Ignore clicks on the "user not found" sentinel — it is not a
+      // real user and selecting it would emit a bogus id.
+      if (item && (item as { __empty?: boolean }).__empty) {
+        this.input = '';
+        return;
+      }
       const user = item as unknown as IUserPublic;
       seedUserChipCache(user);
       this.$emit('select', user);
@@ -120,6 +149,25 @@ export default defineComponent({
   align-items: center;
   gap: 10px;
   padding: 4px 0;
+}
+
+.user-picker__option--empty {
+  color: var(--el-text-color-secondary);
+  font-size: 13px;
+  cursor: default;
+}
+
+.user-picker__empty-icon {
+  font-size: 14px;
+  color: var(--el-color-warning);
+  flex-shrink: 0;
+}
+
+.user-picker__empty-text {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .user-picker__avatar {


### PR DESCRIPTION
## 问题复现

截图：在 **站点设置 → 编辑管理员 → 添加用户** 里输入 `germey3`，请求 `/users/resolve/?q=germey3` 已经发了，但下拉框始终不出现，用户的体感是"下拉坏了"。

## 根因

`/users/resolve/` 在 AuthBackend 端是**严格精确匹配**（出于隐私考虑，避免用任意片段去枚举其他账户的邮箱/手机号），文档注释明确写着 `NEVER use __icontains / prefix match here`。当 q 不能精确命中 username / email / phone / UUID 时，后端会直接返回 `[]`。

而前端 `UserPicker.vue` 在 `onFetch` 里只是把这个空数组原样返回给 `el-autocomplete`。Element Plus 2.x 的 `suggestionVisible` 计算属性是：

```ts
const isValidData = suggestions.value.length > 0;
return (isValidData || loading.value) && activated.value;
```

—— `suggestions.length === 0` 时下拉框直接不开。结果就是：**API 返回正常，前端静默吞掉，用户没有任何反馈**。

更尴尬的是，仓库里早就有一份 `site.message.userNotFound` ("未找到该用户") 的 i18n key，所有 18 个语种都翻译好了，注释里也写着 _"Shown when the user lookup endpoint returns 404 in the picker preview."_ —— 但代码里压根没引用过这个 key。

## 修复

在 `UserPicker.vue` 里塞一个 **非可选中的 sentinel 行**（`{ __empty: true, ... }`）：

- `onFetch`：当 `items.length === 0`（或网络异常 catch）时返回 `[EMPTY_SUGGESTION]`，让 `suggestions.length > 0` 把下拉框撑开。
- `#default` 槽：识别 `item.__empty`，渲染一个带警告小图标的灰色 "未找到该用户" 行（不显示头像/用户名）。
- `onSelect`：守卫 `item.__empty`，点到 sentinel 时只清空输入框，**不 emit**，避免抛出假用户 id。

## 没动的部分（特意保留）

- 后端 `/users/resolve/` 仍然只做精确匹配 —— 隐私约束不变。
- 没新增 i18n key（`site.message.userNotFound` 18 个语种全都有），`python3 scripts/check_i18n_coverage.py` ✅。
- `EditUser.vue` / `EditUsers.vue` 没改 —— sentinel 完全收敛在 UserPicker 里。

## 验证

- `npx eslint src/components/site/UserPicker.vue` ✅
- `npx vue-tsc -b --noEmit` ✅（仅有一个不相关的 `ApiCodeDialog.vue` mustache 报错，跟本 PR 无关）
- `python3 scripts/check_i18n_coverage.py` → `17 locale(s) × 39 namespace(s) all match zh-CN`

## 期望表现

输入 `germey3` 这种不存在的精确名时：

```
搜索框
┌─────────────────────────────────┐
│ ⚠  未找到该用户                  │   ← 灰色，不可点
└─────────────────────────────────┘
```

输入存在的用户名（例如 `germey`）时：行为不变，仍然显示头像 + 昵称 + 脱敏联系方式。

---
*This pull request was generated and committed by the [GitHub Copilot](https://github.com/copilot) coding agent on behalf of @CQUPTQiCu.*
