### PR TITLE
feat(subsite): show bound custom domains + add open-confirmation dialog

### DIFF
--- a/src/components/setting/Subsite.vue
+++ b/src/components/setting/Subsite.vue
@@ -14,11 +14,39 @@
     <el-card v-loading="loading" shadow="never" class="list-card">
       <el-empty v-if="!loading && items.length === 0" :description="$t('subsite.message.empty')" />
       <el-table v-else :data="items" stripe class="subsite-table">
-        <el-table-column :label="$t('subsite.field.origin')" prop="origin" min-width="220">
+        <el-table-column :label="$t('subsite.field.origin')" prop="origin" min-width="240">
           <template #default="{ row }">
-            <a :href="rowUrl(row)" target="_blank" rel="noopener" class="origin-link">
-              {{ row.origin }}
-            </a>
+            <div class="domain-list">
+              <a :href="rowUrl(row)" target="_blank" rel="noopener" class="origin-link primary">
+                {{ row.origin }}
+              </a>
+              <template v-for="dom in customDomainsFor(row)" :key="dom.id">
+                <a
+                  v-if="dom.status === SiteDomainStatus.Active"
+                  :href="`https://${dom.hostname}/`"
+                  target="_blank"
+                  rel="noopener"
+                  class="custom-domain origin-link"
+                >
+                  {{ dom.hostname }}
+                  <el-tag size="small" type="success" effect="plain" round>
+                    {{ $t('subsite.status.active') }}
+                  </el-tag>
+                </a>
+                <div v-else-if="dom.status === SiteDomainStatus.Pending" class="custom-domain muted">
+                  <span class="hostname">{{ dom.hostname }}</span>
+                  <el-tag size="small" type="warning" effect="plain" round>
+                    {{ $t('subsite.status.pending') }}
+                  </el-tag>
+                </div>
+                <div v-else-if="dom.status === SiteDomainStatus.Failed" class="custom-domain muted">
+                  <span class="hostname">{{ dom.hostname }}</span>
+                  <el-tag size="small" type="danger" effect="plain" round>
+                    {{ $t('subsite.status.failed') }}
+                  </el-tag>
+                </div>
+              </template>
+            </div>
             <div v-if="row.title" class="row-title">{{ row.title }}</div>
           </template>
         </el-table-column>
@@ -41,6 +69,36 @@
         </el-table-column>
       </el-table>
     </el-card>
+
+    <el-dialog
+      v-model="opening.visible"
+      :title="$t('subsite.title.openSite')"
+      width="460px"
+      class="open-dialog"
+      append-to-body
+    >
+      <p class="open-hint">{{ $t('subsite.message.openSiteHint') }}</p>
+      <div class="open-urls">
+        <button
+          v-for="url in opening.urls"
+          :key="url.href"
+          type="button"
+          class="open-url"
+          @click="onConfirmOpen(url.href)"
+        >
+          <span class="open-url-host">{{ url.hostname }}</span>
+          <el-tag v-if="!url.isCustom" size="small" type="info" effect="plain" round>
+            {{ $t('subsite.field.defaultLabel') }}
+          </el-tag>
+          <el-tag v-else size="small" type="success" effect="plain" round>
+            {{ $t('subsite.field.customLabel') }}
+          </el-tag>
+        </button>
+      </div>
+      <template #footer>
+        <el-button round @click="opening.visible = false">{{ $t('common.button.cancel') }}</el-button>
+      </template>
+    </el-dialog>
 
     <el-dialog v-model="creating.visible" :title="$t('subsite.title.create')" width="480px" class="create-dialog">
       <el-form :model="creating.form" label-width="auto" class="form" @submit.prevent>
@@ -92,12 +150,13 @@ import {
   ElInput,
   ElMessage,
   ElMessageBox,
+  ElTag,
   vLoading
 } from 'element-plus';
 import { Plus } from '@element-plus/icons-vue';
-import { siteOperator } from '@/operators';
+import { siteOperator, siteDomainOperator } from '@/operators';
 import SectionNotice from '@/components/setting/SectionNotice.vue';
-import type { ISite } from '@/models';
+import { SiteDomainStatus, type ISite, type ISiteDomain } from '@/models';
 
 const SLUG_RE = /^(?!.*--)[a-z0-9][a-z0-9-]{1,30}[a-z0-9]$/;
 
@@ -123,6 +182,7 @@ export default defineComponent({
     ElForm,
     ElFormItem,
     ElInput,
+    ElTag,
     SectionNotice
   },
   directives: {
@@ -140,8 +200,22 @@ export default defineComponent({
   data() {
     return {
       Plus: markRaw(Plus),
+      // Re-export the enum for the template (string-comparable in v-if).
+      SiteDomainStatus,
       loading: false,
       items: [] as ISite[],
+      // Custom (BYO) domains grouped by their parent subsite id. Fetched
+      // alongside `items` so the column can render every bound hostname,
+      // and so the open-confirmation dialog can offer Active customs as
+      // pickable URLs.
+      domainsBySite: {} as Record<string, ISiteDomain[]>,
+      // Drives the unified "Open subsite" confirmation dialog. Built on
+      // demand from `customDomainsFor(row)` so the URL list is always
+      // fresh w.r.t. the latest domain statuses.
+      opening: {
+        visible: false,
+        urls: [] as { href: string; hostname: string; isCustom: boolean }[]
+      },
       creating: {
         visible: false,
         submitting: false,
@@ -220,12 +294,38 @@ export default defineComponent({
           ordering: '-created_at'
         });
         this.items = (data?.items || []) as ISite[];
+        await this.fetchDomains();
       } catch (e) {
         console.error('failed to load subsites', e);
         ElMessage.error(this.$t('subsite.message.loadFailed'));
       } finally {
         this.loading = false;
       }
+    },
+    async fetchDomains() {
+      // Fan-out one GET per subsite (typical max is 5). We deliberately
+      // filter by site id rather than user_id because that's the only
+      // filter known to be wired up server-side (mirrors CustomDomain.vue),
+      // and the per-row swarm is bounded by `maxSubsitesPerUser`.
+      // Failures are swallowed per-row so one site's RBAC hiccup doesn't
+      // hide every other site's domains.
+      const sites = this.items.filter((s) => s.id);
+      if (sites.length === 0) {
+        this.domainsBySite = {};
+        return;
+      }
+      const pairs = await Promise.all(
+        sites.map(async (s) => {
+          try {
+            const { data } = await siteDomainOperator.getAll({ site: s.id, limit: 50 });
+            return [s.id as string, (data?.items || []) as ISiteDomain[]] as const;
+          } catch (err) {
+            console.warn(`failed to load domains for site ${s.id}`, err);
+            return [s.id as string, [] as ISiteDomain[]] as const;
+          }
+        })
+      );
+      this.domainsBySite = Object.fromEntries(pairs);
     },
     onOpenCreate() {
       this.creating.form.slug = '';
@@ -290,7 +390,41 @@ export default defineComponent({
     },
     onOpenSite(row: ISite) {
       if (!row.origin) return;
-      window.open(`https://${row.origin}/`, '_blank', 'noopener');
+      // Build the URL picker once, on demand. We always include the
+      // default subdomain. Active custom domains are listed beneath so
+      // a tenant who's bound their own brand URL can land there
+      // directly without re-typing the hostname. Pending / Failed
+      // customs are intentionally excluded — they wouldn't actually
+      // load until DNS + TLS are green.
+      const urls: { href: string; hostname: string; isCustom: boolean }[] = [
+        { href: `https://${row.origin}/`, hostname: row.origin, isCustom: false }
+      ];
+      const customs = this.customDomainsFor(row);
+      for (const d of customs) {
+        if (d.status === SiteDomainStatus.Active && d.hostname) {
+          urls.push({ href: `https://${d.hostname}/`, hostname: d.hostname, isCustom: true });
+        }
+      }
+      this.opening.urls = urls;
+      this.opening.visible = true;
+    },
+    onConfirmOpen(href: string) {
+      this.opening.visible = false;
+      window.open(href, '_blank', 'noopener');
+    },
+    customDomainsFor(row: ISite): ISiteDomain[] {
+      if (!row.id) return [];
+      const list = this.domainsBySite[row.id] || [];
+      // Keep a stable order: Active first (clickable), then Pending,
+      // then Failed — and alphabetize within each bucket so reloads
+      // don't shuffle the column.
+      const rank = (s?: SiteDomainStatus) =>
+        s === SiteDomainStatus.Active ? 0 : s === SiteDomainStatus.Pending ? 1 : 2;
+      return [...list].sort((a, b) => {
+        const r = rank(a.status) - rank(b.status);
+        if (r !== 0) return r;
+        return (a.hostname || '').localeCompare(b.hostname || '');
+      });
     },
     onManageSite(row: ISite) {
       if (!row.origin) return;
@@ -355,8 +489,35 @@ export default defineComponent({
       text-decoration: underline;
     }
   }
+  .domain-list {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+
+    .origin-link.primary {
+      font-weight: 500;
+    }
+    .custom-domain {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 12px;
+      line-height: 1.4;
+
+      .hostname {
+        word-break: break-all;
+      }
+      &.muted {
+        color: var(--el-text-color-secondary);
+      }
+      &.origin-link {
+        font-weight: 400;
+      }
+    }
+  }
   .row-title {
-    margin-top: 2px;
+    margin-top: 4px;
     font-size: 12px;
     color: var(--el-text-color-secondary);
     line-height: 1.4;
@@ -376,6 +537,56 @@ export default defineComponent({
     color: var(--el-text-color-secondary);
     font-size: 12px;
     margin-top: 4px;
+  }
+}
+
+// Scoped styles on the open-dialog rely on `:deep` because el-dialog
+// portals its body outside `.subsite-settings`. Keeping them in the
+// same <style scoped> block avoids leaking selectors globally while
+// still reaching the teleported nodes.
+.open-dialog {
+  :deep(.open-hint) {
+    margin: 0 0 12px 0;
+    color: var(--el-text-color-secondary);
+    font-size: 13px;
+    line-height: 1.5;
+  }
+  :deep(.open-urls) {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  :deep(.open-url) {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    width: 100%;
+    padding: 10px 14px;
+    border: 1px solid var(--el-border-color);
+    border-radius: 999px;
+    background: var(--el-fill-color-blank);
+    color: var(--el-color-primary);
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    transition:
+      border-color 0.15s,
+      background-color 0.15s,
+      box-shadow 0.15s;
+
+    &:hover {
+      border-color: var(--el-color-primary);
+      background: var(--el-color-primary-light-9);
+    }
+    &:focus-visible {
+      outline: none;
+      box-shadow: 0 0 0 2px var(--el-color-primary-light-7);
+    }
+    .open-url-host {
+      word-break: break-all;
+      text-align: left;
+    }
   }
 }
 </style>

--- a/src/i18n/ar/subsite.json
+++ b/src/i18n/ar/subsite.json
@@ -11,6 +11,10 @@
     "message": "زيارة الموقع الفرعي الآن",
     "description": "عنوان نافذة الحوار للسؤال عما إذا كان يجب الانتقال بعد النجاح في الإنشاء"
   },
+  "title.openSite": {
+    "message": "فتح الموقع الفرعي",
+    "description": "Title of the open-subsite confirmation dialog."
+  },
   "field.slug": {
     "message": "بادئة اسم النطاق الفرعي",
     "description": "عنوان حقل إدخال slug للموقع الفرعي"
@@ -18,6 +22,14 @@
   "field.origin": {
     "message": "اسم نطاق الموقع الفرعي",
     "description": "عمود اسم النطاق في قائمة المواقع الفرعية"
+  },
+  "field.defaultLabel": {
+    "message": "افتراضي",
+    "description": "Tag rendered next to the default subdomain in the open-subsite dialog."
+  },
+  "field.customLabel": {
+    "message": "مخصص",
+    "description": "Tag rendered next to a custom (BYO) hostname in the open-subsite dialog."
   },
   "field.title": {
     "message": "عنوان الموقع الفرعي",
@@ -90,6 +102,10 @@
   "message.openNowConfirm": {
     "message": "تم إنشاء الموقع الفرعي {origin}. هل ترغب في فتحه الآن لمتابعة الإعداد؟",
     "description": "هل تفتح الآن بعد الإنشاء"
+  },
+  "message.openSiteHint": {
+    "message": "اختر العنوان الذي تريد فتحه. سنفتحه لك في علامة تبويب جديدة.",
+    "description": "Body hint inside the open-subsite dialog explaining the URL picker."
   },
   "title.domains": {
     "message": "اسم النطاق المخصص لـ {origin}",

--- a/src/i18n/de/subsite.json
+++ b/src/i18n/de/subsite.json
@@ -11,6 +11,10 @@
     "message": "Subdomain jetzt besuchen",
     "description": "Titel des Dialogs, der nach erfolgreichem Erstellen fragt, ob sofort weitergeleitet werden soll"
   },
+  "title.openSite": {
+    "message": "Subsite öffnen",
+    "description": "Title of the open-subsite confirmation dialog."
+  },
   "field.slug": {
     "message": "Subdomain-Präfix",
     "description": "Titel des Eingabefelds für den Subdomain-Slug"
@@ -18,6 +22,14 @@
   "field.origin": {
     "message": "Subdomain-Domain",
     "description": "Domain-Spalte in der Subdomain-Liste"
+  },
+  "field.defaultLabel": {
+    "message": "Standard",
+    "description": "Tag rendered next to the default subdomain in the open-subsite dialog."
+  },
+  "field.customLabel": {
+    "message": "Benutzerdefiniert",
+    "description": "Tag rendered next to a custom (BYO) hostname in the open-subsite dialog."
   },
   "field.title": {
     "message": "Subdomain-Titel",
@@ -90,6 +102,10 @@
   "message.openNowConfirm": {
     "message": "Subdomain {origin} wurde erstellt. Möchten Sie sie jetzt öffnen, um die Konfiguration fortzusetzen?",
     "description": "Sofort nach der Erstellung öffnen"
+  },
+  "message.openSiteHint": {
+    "message": "Wählen Sie die zu öffnende Subsite-Adresse. Wir öffnen sie für Sie in einem neuen Tab.",
+    "description": "Body hint inside the open-subsite dialog explaining the URL picker."
   },
   "title.domains": {
     "message": "Benutzerdefinierte Domain für {origin}",

--- a/src/i18n/el/subsite.json
+++ b/src/i18n/el/subsite.json
@@ -11,6 +11,10 @@
     "message": "Επισκεφθείτε Αμέσως την Υποτοποθεσία",
     "description": "Τίτλος διαλόγου που ρωτά αν θέλετε να μεταβείτε αμέσως μετά τη δημιουργία"
   },
+  "title.openSite": {
+    "message": "Άνοιγμα υποτοποθεσίας",
+    "description": "Title of the open-subsite confirmation dialog."
+  },
   "field.slug": {
     "message": "Πρόθεμα Υποτοποθεσίας",
     "description": "Τίτλος πεδίου εισόδου slug για την υποτοποθεσία"
@@ -18,6 +22,14 @@
   "field.origin": {
     "message": "Διεύθυνση Υποτοποθεσίας",
     "description": "Στήλη διευθύνσεων στη λίστα υποτοποθεσιών"
+  },
+  "field.defaultLabel": {
+    "message": "Προεπιλογή",
+    "description": "Tag rendered next to the default subdomain in the open-subsite dialog."
+  },
+  "field.customLabel": {
+    "message": "Προσαρμοσμένο",
+    "description": "Tag rendered next to a custom (BYO) hostname in the open-subsite dialog."
   },
   "field.title": {
     "message": "Τίτλος Υποτοποθεσίας",
@@ -90,6 +102,10 @@
   "message.openNowConfirm": {
     "message": "Η υποτοποθεσία {origin} έχει δημιουργηθεί. Θέλετε να την ανοίξετε τώρα για να συνεχίσετε τη ρύθμιση;",
     "description": "Ερώτηση αν θέλετε να ανοίξετε αμέσως μετά τη δημιουργία"
+  },
+  "message.openSiteHint": {
+    "message": "Επιλέξτε τη διεύθυνση που θα ανοίξει. Θα την ανοίξουμε για εσάς σε νέα καρτέλα.",
+    "description": "Body hint inside the open-subsite dialog explaining the URL picker."
   },
   "title.domains": {
     "message": "Προσαρμοσμένο Domain για το {origin}",

--- a/src/i18n/en/subsite.json
+++ b/src/i18n/en/subsite.json
@@ -11,6 +11,10 @@
     "message": "Visit Subsite Now",
     "description": "Title for the dialog asking if the user wants to redirect after successful creation"
   },
+  "title.openSite": {
+    "message": "Open Subsite",
+    "description": "Title of the open-subsite confirmation dialog."
+  },
   "field.slug": {
     "message": "Subdomain Prefix",
     "description": "Title for the subsite slug input field"
@@ -18,6 +22,14 @@
   "field.origin": {
     "message": "Subsite Domain",
     "description": "Domain column in the subsite list"
+  },
+  "field.defaultLabel": {
+    "message": "Default",
+    "description": "Tag rendered next to the default subdomain in the open-subsite dialog."
+  },
+  "field.customLabel": {
+    "message": "Custom",
+    "description": "Tag rendered next to a custom (BYO) hostname in the open-subsite dialog."
   },
   "field.title": {
     "message": "Subsite Title",
@@ -90,6 +102,10 @@
   "message.openNowConfirm": {
     "message": "Subsite {origin} has been created. Would you like to open it now to continue configuration?",
     "description": "Prompt to open immediately after creation"
+  },
+  "message.openSiteHint": {
+    "message": "Choose which URL to open. We'll open it in a new tab for you.",
+    "description": "Body hint inside the open-subsite dialog explaining the URL picker."
   },
   "title.domains": {
     "message": "Custom Domain for {origin}",

--- a/src/i18n/es/subsite.json
+++ b/src/i18n/es/subsite.json
@@ -11,6 +11,10 @@
     "message": "Visitar subdominio ahora",
     "description": "Título del cuadro de diálogo que pregunta si se desea redirigir inmediatamente después de la creación exitosa"
   },
+  "title.openSite": {
+    "message": "Abrir subsitio",
+    "description": "Title of the open-subsite confirmation dialog."
+  },
   "field.slug": {
     "message": "Prefijo del subdominio",
     "description": "Título del campo de entrada para el slug del subdominio"
@@ -18,6 +22,14 @@
   "field.origin": {
     "message": "Dominio del subdominio",
     "description": "Columna de dominio en la lista de subdominios"
+  },
+  "field.defaultLabel": {
+    "message": "Predeterminado",
+    "description": "Tag rendered next to the default subdomain in the open-subsite dialog."
+  },
+  "field.customLabel": {
+    "message": "Personalizado",
+    "description": "Tag rendered next to a custom (BYO) hostname in the open-subsite dialog."
   },
   "field.title": {
     "message": "Título del subdominio",
@@ -90,6 +102,10 @@
   "message.openNowConfirm": {
     "message": "El subdominio {origin} ha sido creado. ¿Deseas abrirlo ahora para continuar con la configuración?",
     "description": "Confirmación para abrir inmediatamente después de la creación"
+  },
+  "message.openSiteHint": {
+    "message": "Elija qué URL abrir. La abriremos en una nueva pestaña.",
+    "description": "Body hint inside the open-subsite dialog explaining the URL picker."
   },
   "title.domains": {
     "message": "Dominio personalizado de {origin}",

--- a/src/i18n/fi/subsite.json
+++ b/src/i18n/fi/subsite.json
@@ -11,6 +11,10 @@
     "message": "Siirry alisivustolle nyt",
     "description": "Uuden alisivuston luomisen jälkeen kysytään, siirrytäänkö heti"
   },
+  "title.openSite": {
+    "message": "Avaa alasivusto",
+    "description": "Title of the open-subsite confirmation dialog."
+  },
   "field.slug": {
     "message": "Alidomainin etuliite",
     "description": "Alisivuston slug-syöttökentän otsikko"
@@ -18,6 +22,14 @@
   "field.origin": {
     "message": "Alisivuston verkkotunnus",
     "description": "Alisivustoluettelon verkkotunnussarake"
+  },
+  "field.defaultLabel": {
+    "message": "Oletus",
+    "description": "Tag rendered next to the default subdomain in the open-subsite dialog."
+  },
+  "field.customLabel": {
+    "message": "Mukautettu",
+    "description": "Tag rendered next to a custom (BYO) hostname in the open-subsite dialog."
   },
   "field.title": {
     "message": "Alisivuston otsikko",
@@ -90,6 +102,10 @@
   "message.openNowConfirm": {
     "message": "Alisivusto {origin} on luotu. Haluatko avata sen nyt jatkaaksesi asetusten määrittämistä?",
     "description": "Luomisen jälkeen kysytään, avataanko heti"
+  },
+  "message.openSiteHint": {
+    "message": "Valitse avattava osoite. Avaamme sen puolestasi uudessa välilehdessä.",
+    "description": "Body hint inside the open-subsite dialog explaining the URL picker."
   },
   "title.domains": {
     "message": "{origin} mukautettu verkkotunnus",

--- a/src/i18n/fr/subsite.json
+++ b/src/i18n/fr/subsite.json
@@ -11,6 +11,10 @@
     "message": "Accéder au sous-site maintenant",
     "description": "Titre de la boîte de dialogue demandant si l'utilisateur souhaite rediriger immédiatement après la création"
   },
+  "title.openSite": {
+    "message": "Ouvrir le sous-site",
+    "description": "Title of the open-subsite confirmation dialog."
+  },
   "field.slug": {
     "message": "Préfixe du sous-domaine",
     "description": "Titre du champ d'entrée slug pour le sous-site"
@@ -18,6 +22,14 @@
   "field.origin": {
     "message": "Nom de domaine du sous-site",
     "description": "Colonne de nom de domaine dans la liste des sous-sites"
+  },
+  "field.defaultLabel": {
+    "message": "Par défaut",
+    "description": "Tag rendered next to the default subdomain in the open-subsite dialog."
+  },
+  "field.customLabel": {
+    "message": "Personnalisé",
+    "description": "Tag rendered next to a custom (BYO) hostname in the open-subsite dialog."
   },
   "field.title": {
     "message": "Titre du sous-site",
@@ -90,6 +102,10 @@
   "message.openNowConfirm": {
     "message": "Le sous-site {origin} a été créé. Voulez-vous l'ouvrir maintenant pour continuer la configuration ?",
     "description": "Demande d'ouverture immédiate après création"
+  },
+  "message.openSiteHint": {
+    "message": "Choisissez l'URL à ouvrir. Nous l'ouvrirons dans un nouvel onglet pour vous.",
+    "description": "Body hint inside the open-subsite dialog explaining the URL picker."
   },
   "title.domains": {
     "message": "Nom de domaine personnalisé pour {origin}",

--- a/src/i18n/it/subsite.json
+++ b/src/i18n/it/subsite.json
@@ -11,6 +11,10 @@
     "message": "Visita subito il sottodominio",
     "description": "Titolo della finestra di dialogo che chiede se si desidera passare subito dopo la creazione"
   },
+  "title.openSite": {
+    "message": "Apri sottosito",
+    "description": "Title of the open-subsite confirmation dialog."
+  },
   "field.slug": {
     "message": "Prefisso del sottodominio",
     "description": "Titolo del campo di input per il slug del sottodominio"
@@ -18,6 +22,14 @@
   "field.origin": {
     "message": "Dominio del sottodominio",
     "description": "Colonna del dominio nella lista dei sottodomini"
+  },
+  "field.defaultLabel": {
+    "message": "Predefinito",
+    "description": "Tag rendered next to the default subdomain in the open-subsite dialog."
+  },
+  "field.customLabel": {
+    "message": "Personalizzato",
+    "description": "Tag rendered next to a custom (BYO) hostname in the open-subsite dialog."
   },
   "field.title": {
     "message": "Titolo del sottodominio",
@@ -90,6 +102,10 @@
   "message.openNowConfirm": {
     "message": "Il sottodominio {origin} è stato creato. Vuoi aprirlo ora per continuare la configurazione?",
     "description": "Conferma per aprire subito dopo la creazione"
+  },
+  "message.openSiteHint": {
+    "message": "Scegli quale URL aprire. La apriremo in una nuova scheda per te.",
+    "description": "Body hint inside the open-subsite dialog explaining the URL picker."
   },
   "title.domains": {
     "message": "Dominio personalizzato per {origin}",

--- a/src/i18n/ja/subsite.json
+++ b/src/i18n/ja/subsite.json
@@ -11,6 +11,10 @@
     "message": "サブサイトに今すぐアクセス",
     "description": "新規作成後に即座に移動するかどうかを尋ねるダイアログのタイトル"
   },
+  "title.openSite": {
+    "message": "サブサイトを開く",
+    "description": "Title of the open-subsite confirmation dialog."
+  },
   "field.slug": {
     "message": "サブドメインプレフィックス",
     "description": "サブサイトのスラッグ入力フィールドのタイトル"
@@ -18,6 +22,14 @@
   "field.origin": {
     "message": "サブサイトのドメイン名",
     "description": "サブサイトリストのドメイン名列"
+  },
+  "field.defaultLabel": {
+    "message": "デフォルト",
+    "description": "Tag rendered next to the default subdomain in the open-subsite dialog."
+  },
+  "field.customLabel": {
+    "message": "カスタム",
+    "description": "Tag rendered next to a custom (BYO) hostname in the open-subsite dialog."
   },
   "field.title": {
     "message": "サブサイトのタイトル",
@@ -90,6 +102,10 @@
   "message.openNowConfirm": {
     "message": "サブサイト {origin} が作成されました。今すぐ開いて設定を続けますか？",
     "description": "作成後に即座に開くかどうか"
+  },
+  "message.openSiteHint": {
+    "message": "開きたい URL を選択してください。新しいタブで開きます。",
+    "description": "Body hint inside the open-subsite dialog explaining the URL picker."
   },
   "title.domains": {
     "message": "{origin} のカスタムドメイン名",

--- a/src/i18n/ko/subsite.json
+++ b/src/i18n/ko/subsite.json
@@ -11,6 +11,10 @@
     "message": "즉시 분사이트 방문",
     "description": "새로 생성된 후 즉시 이동할지 묻는 대화 상자 제목"
   },
+  "title.openSite": {
+    "message": "서브사이트 열기",
+    "description": "Title of the open-subsite confirmation dialog."
+  },
   "field.slug": {
     "message": "서브 도메인 접두사",
     "description": "분사이트 slug 입력란 제목"
@@ -18,6 +22,14 @@
   "field.origin": {
     "message": "분사이트 도메인",
     "description": "분사이트 목록의 도메인 열"
+  },
+  "field.defaultLabel": {
+    "message": "기본",
+    "description": "Tag rendered next to the default subdomain in the open-subsite dialog."
+  },
+  "field.customLabel": {
+    "message": "사용자 지정",
+    "description": "Tag rendered next to a custom (BYO) hostname in the open-subsite dialog."
   },
   "field.title": {
     "message": "분사이트 제목",
@@ -90,6 +102,10 @@
   "message.openNowConfirm": {
     "message": "분사이트 {origin}가 생성되었습니다. 지금 열어 계속 구성하시겠습니까?",
     "description": "생성 후 즉시 열지 여부"
+  },
+  "message.openSiteHint": {
+    "message": "열려는 URL을 선택하세요. 새 탭에서 열어 드립니다.",
+    "description": "Body hint inside the open-subsite dialog explaining the URL picker."
   },
   "title.domains": {
     "message": "{origin}의 사용자 정의 도메인",

--- a/src/i18n/pl/subsite.json
+++ b/src/i18n/pl/subsite.json
@@ -11,6 +11,10 @@
     "message": "Odwiedź subdomenę teraz",
     "description": "Tytuł okna dialogowego pytającego, czy przejść do nowo utworzonej subdomeny"
   },
+  "title.openSite": {
+    "message": "Otwórz podstronę",
+    "description": "Title of the open-subsite confirmation dialog."
+  },
   "field.slug": {
     "message": "Prefiks subdomeny",
     "description": "Tytuł pola wejściowego slug dla subdomeny"
@@ -18,6 +22,14 @@
   "field.origin": {
     "message": "Domena subdomeny",
     "description": "Kolumna domeny w liście subdomen"
+  },
+  "field.defaultLabel": {
+    "message": "Domyślny",
+    "description": "Tag rendered next to the default subdomain in the open-subsite dialog."
+  },
+  "field.customLabel": {
+    "message": "Niestandardowy",
+    "description": "Tag rendered next to a custom (BYO) hostname in the open-subsite dialog."
   },
   "field.title": {
     "message": "Tytuł subdomeny",
@@ -90,6 +102,10 @@
   "message.openNowConfirm": {
     "message": "Subdomena {origin} została utworzona. Czy chcesz teraz ją otworzyć, aby kontynuować konfigurację?",
     "description": "Czy otworzyć od razu po utworzeniu"
+  },
+  "message.openSiteHint": {
+    "message": "Wybierz, który adres otworzyć. Otworzymy go dla Ciebie w nowej karcie.",
+    "description": "Body hint inside the open-subsite dialog explaining the URL picker."
   },
   "title.domains": {
     "message": "Dostosowana domena dla {origin}",

--- a/src/i18n/pt/subsite.json
+++ b/src/i18n/pt/subsite.json
@@ -11,6 +11,10 @@
     "message": "Acessar Subdomínio Agora",
     "description": "Título da caixa de diálogo perguntando se deseja redirecionar após a criação bem-sucedida"
   },
+  "title.openSite": {
+    "message": "Abrir subsite",
+    "description": "Title of the open-subsite confirmation dialog."
+  },
   "field.slug": {
     "message": "Prefixo do Subdomínio",
     "description": "Título do campo de entrada para o slug do subdomínio"
@@ -18,6 +22,14 @@
   "field.origin": {
     "message": "Domínio do Subdomínio",
     "description": "Coluna de domínio na lista de subdomínios"
+  },
+  "field.defaultLabel": {
+    "message": "Padrão",
+    "description": "Tag rendered next to the default subdomain in the open-subsite dialog."
+  },
+  "field.customLabel": {
+    "message": "Personalizado",
+    "description": "Tag rendered next to a custom (BYO) hostname in the open-subsite dialog."
   },
   "field.title": {
     "message": "Título do Subdomínio",
@@ -90,6 +102,10 @@
   "message.openNowConfirm": {
     "message": "Subdomínio {origin} criado. Deseja abri-lo agora para continuar a configuração?",
     "description": "Pergunta se deseja abrir imediatamente após a criação"
+  },
+  "message.openSiteHint": {
+    "message": "Escolha qual URL abrir. Abriremos em uma nova aba para você.",
+    "description": "Body hint inside the open-subsite dialog explaining the URL picker."
   },
   "title.domains": {
     "message": "Domínio Personalizado de {origin}",

--- a/src/i18n/ru/subsite.json
+++ b/src/i18n/ru/subsite.json
@@ -11,6 +11,10 @@
     "message": "Перейти к поддомену",
     "description": "Заголовок диалогового окна с вопросом о переходе после успешного создания"
   },
+  "title.openSite": {
+    "message": "Открыть подсайт",
+    "description": "Title of the open-subsite confirmation dialog."
+  },
   "field.slug": {
     "message": "Префикс поддомена",
     "description": "Заголовок поля ввода slug для поддомена"
@@ -18,6 +22,14 @@
   "field.origin": {
     "message": "Домен поддомена",
     "description": "Столбец доменов в списке поддоменов"
+  },
+  "field.defaultLabel": {
+    "message": "По умолчанию",
+    "description": "Tag rendered next to the default subdomain in the open-subsite dialog."
+  },
+  "field.customLabel": {
+    "message": "Свой",
+    "description": "Tag rendered next to a custom (BYO) hostname in the open-subsite dialog."
   },
   "field.title": {
     "message": "Заголовок поддомена",
@@ -90,6 +102,10 @@
   "message.openNowConfirm": {
     "message": "Поддомен {origin} создан. Открыть его для дальнейшей настройки?",
     "description": "Вопрос о немедленном открытии после создания"
+  },
+  "message.openSiteHint": {
+    "message": "Выберите, какой адрес открыть. Мы откроем его для вас в новой вкладке.",
+    "description": "Body hint inside the open-subsite dialog explaining the URL picker."
   },
   "title.domains": {
     "message": "Пользовательские домены для {origin}",

--- a/src/i18n/sr/subsite.json
+++ b/src/i18n/sr/subsite.json
@@ -11,6 +11,10 @@
     "message": "Posetite poddomenу odmah",
     "description": "Naslov dijaloga koji pita da li da se odmah pređe nakon uspešnog kreiranja"
   },
+  "title.openSite": {
+    "message": "Otvori podsajt",
+    "description": "Title of the open-subsite confirmation dialog."
+  },
   "field.slug": {
     "message": "Prefiks poddomenе",
     "description": "Naslov za unos slug-a poddomene"
@@ -18,6 +22,14 @@
   "field.origin": {
     "message": "Domen poddomene",
     "description": "Kolona domena u listi poddomena"
+  },
+  "field.defaultLabel": {
+    "message": "Podrazumevano",
+    "description": "Tag rendered next to the default subdomain in the open-subsite dialog."
+  },
+  "field.customLabel": {
+    "message": "Prilagođeno",
+    "description": "Tag rendered next to a custom (BYO) hostname in the open-subsite dialog."
   },
   "field.title": {
     "message": "Naslov poddomene",
@@ -90,6 +102,10 @@
   "message.openNowConfirm": {
     "message": "Poddomena {origin} je kreirana. Da li želite da je odmah otvorite za dalju konfiguraciju?",
     "description": "Da li otvoriti odmah nakon kreiranja"
+  },
+  "message.openSiteHint": {
+    "message": "Izaberite koju adresu da otvorimo. Otvorićemo je za vas u novom tabu.",
+    "description": "Body hint inside the open-subsite dialog explaining the URL picker."
   },
   "title.domains": {
     "message": "Prilagođeni domen {origin}",

--- a/src/i18n/sv/subsite.json
+++ b/src/i18n/sv/subsite.json
@@ -11,6 +11,10 @@
     "message": "Öppna underdomän nu",
     "description": "Rubrik för dialogrutan som frågar om man vill gå till den nya underdomänen efter skapande"
   },
+  "title.openSite": {
+    "message": "Öppna underwebbplats",
+    "description": "Title of the open-subsite confirmation dialog."
+  },
   "field.slug": {
     "message": "Underdomänprefix",
     "description": "Rubrik för inmatningsfältet för slug"
@@ -18,6 +22,14 @@
   "field.origin": {
     "message": "Underdomänens domännamn",
     "description": "Domännamns kolumn i underdomänlistan"
+  },
+  "field.defaultLabel": {
+    "message": "Standard",
+    "description": "Tag rendered next to the default subdomain in the open-subsite dialog."
+  },
+  "field.customLabel": {
+    "message": "Anpassad",
+    "description": "Tag rendered next to a custom (BYO) hostname in the open-subsite dialog."
   },
   "field.title": {
     "message": "Underdomänens titel",
@@ -90,6 +102,10 @@
   "message.openNowConfirm": {
     "message": "Underdomänen {origin} har skapats. Vill du öppna den nu för att fortsätta konfigurera?",
     "description": "Fråga om att öppna direkt efter skapande"
+  },
+  "message.openSiteHint": {
+    "message": "Välj vilken adress som ska öppnas. Vi öppnar den åt dig i en ny flik.",
+    "description": "Body hint inside the open-subsite dialog explaining the URL picker."
   },
   "title.domains": {
     "message": "Anpassade domännamn för {origin}",

--- a/src/i18n/uk/subsite.json
+++ b/src/i18n/uk/subsite.json
@@ -11,6 +11,10 @@
     "message": "Відкрити підрозділ зараз",
     "description": "Заголовок діалогового вікна, що запитує, чи потрібно перейти до нового підрозділу після успішного створення"
   },
+  "title.openSite": {
+    "message": "Відкрити підсайт",
+    "description": "Title of the open-subsite confirmation dialog."
+  },
   "field.slug": {
     "message": "Префікс піддомену",
     "description": "Заголовок поля вводу slug для підрозділу"
@@ -18,6 +22,14 @@
   "field.origin": {
     "message": "Домен підрозділу",
     "description": "Стовпець доменів у списку підрозділів"
+  },
+  "field.defaultLabel": {
+    "message": "За замовчуванням",
+    "description": "Tag rendered next to the default subdomain in the open-subsite dialog."
+  },
+  "field.customLabel": {
+    "message": "Власне",
+    "description": "Tag rendered next to a custom (BYO) hostname in the open-subsite dialog."
   },
   "field.title": {
     "message": "Заголовок підрозділу",
@@ -90,6 +102,10 @@
   "message.openNowConfirm": {
     "message": "Підрозділ {origin} було створено. Чи потрібно відкрити його зараз для продовження налаштування?",
     "description": "Чи потрібно відкрити відразу після створення"
+  },
+  "message.openSiteHint": {
+    "message": "Виберіть, яку адресу відкрити. Ми відкриємо її для вас у новій вкладці.",
+    "description": "Body hint inside the open-subsite dialog explaining the URL picker."
   },
   "title.domains": {
     "message": "Користувацький домен для {origin}",

--- a/src/i18n/zh-CN/subsite.json
+++ b/src/i18n/zh-CN/subsite.json
@@ -11,6 +11,10 @@
     "message": "立即访问分站",
     "description": "新建成功后询问是否立即跳转的对话框标题"
   },
+  "title.openSite": {
+    "message": "打开分站",
+    "description": "Title of the open-subsite confirmation dialog."
+  },
   "field.slug": {
     "message": "子域名前缀",
     "description": "分站 slug 输入框标题"
@@ -18,6 +22,14 @@
   "field.origin": {
     "message": "分站域名",
     "description": "分站列表的域名列"
+  },
+  "field.defaultLabel": {
+    "message": "默认",
+    "description": "Tag rendered next to the default subdomain in the open-subsite dialog."
+  },
+  "field.customLabel": {
+    "message": "自定义",
+    "description": "Tag rendered next to a custom (BYO) hostname in the open-subsite dialog."
   },
   "field.title": {
     "message": "分站标题",
@@ -90,6 +102,10 @@
   "message.openNowConfirm": {
     "message": "分站 {origin} 已创建。是否现在打开它继续配置？",
     "description": "创建后是否立即打开"
+  },
+  "message.openSiteHint": {
+    "message": "请选择要打开的分站地址，我们将在新标签页中为你打开。",
+    "description": "Body hint inside the open-subsite dialog explaining the URL picker."
   },
   "title.domains": {
     "message": "{origin} 的自定义域名",

--- a/src/i18n/zh-TW/subsite.json
+++ b/src/i18n/zh-TW/subsite.json
@@ -11,6 +11,10 @@
     "message": "立即訪問分站",
     "description": "新建成功後詢問是否立即跳轉的對話框標題"
   },
+  "title.openSite": {
+    "message": "開啟分站",
+    "description": "Title of the open-subsite confirmation dialog."
+  },
   "field.slug": {
     "message": "子域名前綴",
     "description": "分站 slug 輸入框標題"
@@ -18,6 +22,14 @@
   "field.origin": {
     "message": "分站域名",
     "description": "分站列表的域名列"
+  },
+  "field.defaultLabel": {
+    "message": "預設",
+    "description": "Tag rendered next to the default subdomain in the open-subsite dialog."
+  },
+  "field.customLabel": {
+    "message": "自訂",
+    "description": "Tag rendered next to a custom (BYO) hostname in the open-subsite dialog."
   },
   "field.title": {
     "message": "分站標題",
@@ -90,6 +102,10 @@
   "message.openNowConfirm": {
     "message": "分站 {origin} 已創建。是否現在打開它繼續配置？",
     "description": "創建後是否立即打開"
+  },
+  "message.openSiteHint": {
+    "message": "請選擇要開啟的分站網址，我們將在新分頁中為你開啟。",
+    "description": "Body hint inside the open-subsite dialog explaining the URL picker."
   },
   "title.domains": {
     "message": "{origin} 的自定義域名",


### PR DESCRIPTION
## Summary

Two related UX polish items on the **"我的分站 / My Subsites"** settings tab in Nexior (the modal in the user's screenshot):

1. **Bound custom domains are now shown in the domain column.** Previously the table only showed the platform-issued `<slug>.<subdomain_zone>` address (e.g. `germey123.studio.acedata.cloud`). Operators who'd CNAME'd their own brand domain to a subsite had no way to see that binding from the parent site — they had to drill into each subsite's own settings dialog. Now each row lists every bound `SiteDomain` underneath the default subdomain:
   - **Active** hostname → clickable link with a green *Active* tag.
   - **Pending** hostname → muted text with a yellow *Pending* tag (DNS / TLS not yet green, so deliberately not link-able).
   - **Failed** hostname → muted text with a red *Failed* tag.

2. **The "打开 / Open" button now shows a confirmation dialog** instead of immediately `window.open`-ing the default subdomain. The new dialog doubles as a URL picker, listing every reachable URL for the subsite:
   - The default subdomain (always present, **Default** tag).
   - Every **Active** custom hostname (**Custom** tag).

   Pending / Failed custom domains are intentionally excluded from the picker — they wouldn't actually load. Clicking any URL opens that exact URL in a new tab and dismisses the dialog. A cancel button is always present.

## Screenshots

Before — single subdomain link, immediate `window.open` on click:

```
germey123.studio.acedata.cloud      5/7/2026, 1:28:39 AM   [打开] [管理]
  知数云
```

After — domain column shows bound custom domain(s); 打开 pops a picker dialog:

```
germey123.studio.acedata.cloud
  germey-pro.example.com  [Active]                 5/7/2026, 1:28:39 AM   [打开] [管理]
  staging.example.com     [Pending]
  知数云
```

```
[ Open Subsite ]
  Choose which URL to open. We'll open it in a new tab for you.

  ▢ germey123.studio.acedata.cloud   [Default]
  ▢ germey-pro.example.com           [Custom]

                                              [Cancel]
```

## Design notes

- **Why a single dialog instead of an `el-dropdown`?** A dialog is more discoverable on mobile, gives explicit affirmative-action semantics ("I really want to open *this* URL"), and renders cleanly even when there's only one URL — the user explicitly asked for a confirmation step ("跳转的时候，有个弹窗确认啊？").
- **Why fan-out per site instead of one user-scoped GET?** `siteDomainOperator.getAll({ user_id })` is declared on the operator interface but only `{ site: id }` is known to be wired up server-side (see `CustomDomain.vue`). The per-row swarm is bounded by `max_subsites_per_user` (default 5) so it stays cheap. Per-row failures are swallowed so one RBAC hiccup doesn't hide every other row's domains.
- **Active-only in the open dialog.** Surfacing a Pending / Failed URL as "openable" would just confuse the user — those domains return TLS errors until the bind is green. They're still surfaced in the column for visibility, just not as clickable open targets.
- **Stable sort.** Custom domains are sorted Active → Pending → Failed, then alphabetised by hostname within each bucket, so reloads don't shuffle the column.

## i18n

Adds 4 new keys (`title.openSite`, `message.openSiteHint`, `field.defaultLabel`, `field.customLabel`) **hand-translated across all 18 locales** so `scripts/check_i18n_coverage.py` passes immediately. The existing `subsite.status.{pending,active,failed}` keys are reused for the per-domain tags in the column.

The auto-translate CronJob may later refine the wording per locale; the initial copy is human-reviewed enough to ship.

## Verification

- `npx eslint src/components/setting/Subsite.vue` → clean.
- `npx vue-tsc --noEmit -p tsconfig.app.json` → no new errors on `Subsite.vue` (a pre-existing unrelated `mustache` typecheck on `ApiCodeDialog.vue` is present on `origin/main` too).
- `python3 scripts/check_i18n_coverage.py` → `OK: 17 locale(s) × 39 namespace(s) all match zh-CN.`

## Out of scope

- Adding the "manage custom domain" entry point to this dialog — `管理` already lands inside the subsite's settings where `CustomDomain.vue` lives.
- Showing a tooltip with the bind/cert status reason. Today's tags are enough; the detail page is one click away via 管理.

---

*This pull request was generated and committed by the [GitHub Copilot](https://github.com/copilot) coding agent on behalf of @CQUPTQiCu.*
