### PR TITLE
fix(UserPicker): keep already-added users in dropdown, mark them '已添加'

### DIFF
--- a/src/components/site/UserPicker.vue
+++ b/src/components/site/UserPicker.vue
@@ -18,7 +18,13 @@
       <el-icon><search-icon /></el-icon>
     </template>
     <template #default="{ item }">
-      <div class="user-picker__option" :class="{ 'user-picker__option--empty': item.__empty }">
+      <div
+        class="user-picker__option"
+        :class="{
+          'user-picker__option--empty': item.__empty,
+          'user-picker__option--excluded': item.__excluded
+        }"
+      >
         <template v-if="item.__empty">
           <el-icon class="user-picker__empty-icon"><warning-filled /></el-icon>
           <span class="user-picker__empty-text">{{ $t('site.message.userNotFound') }}</span>
@@ -32,6 +38,9 @@
             <div class="user-picker__option-name">{{ item.display_name }}</div>
             <div class="user-picker__option-contact">{{ item.contact || shortIdOf(item) }}</div>
           </div>
+          <span v-if="item.__excluded" class="user-picker__excluded-tag">{{
+            $t('site.message.userAlreadyAdded')
+          }}</span>
         </template>
       </div>
     </template>
@@ -46,7 +55,7 @@ import { userOperator } from '@/operators';
 import type { IUserPublic } from '@/models';
 import { seedUserChipCache } from '@/components/site/UserChip.vue';
 
-type UserSuggestion = IUserPublic & { value: string; __empty?: false };
+type UserSuggestion = IUserPublic & { value: string; __empty?: false; __excluded?: boolean };
 type EmptySuggestion = { __empty: true; value: ''; id: '' };
 type Suggestion = UserSuggestion | EmptySuggestion;
 
@@ -93,20 +102,26 @@ export default defineComponent({
       if (!q) return [];
       try {
         const res = await userOperator.resolve(q);
-        const items: UserSuggestion[] = (res.data || [])
-          .filter((u) => !this.excludeIds.includes(u.id))
-          .map((u) => {
-            seedUserChipCache(u);
-            return { ...u, value: u.display_name || u.nickname || this.shortIdOf(u) } as UserSuggestion;
-          });
+        // Don't filter out already-added users — instead surface them
+        // tagged as `__excluded` so the dropdown shows them with an
+        // "已添加" badge. The previous behaviour silently dropped them,
+        // which made it look like the picker couldn't even find the
+        // user — the actual report was "搜其他用户就行，搜已经在的就不行".
+        const items: UserSuggestion[] = (res.data || []).map((u) => {
+          seedUserChipCache(u);
+          const excluded = this.excludeIds.includes(u.id);
+          return {
+            ...u,
+            value: u.display_name || u.nickname || this.shortIdOf(u),
+            __excluded: excluded
+          } as UserSuggestion;
+        });
         // The backend (`/users/resolve/`) does exact-match-only on
         // username / email / phone / UUID for privacy. When the query
-        // doesn't hit, the API returns []. Without a sentinel the
-        // el-autocomplete dropdown stays hidden (it only shows when
-        // `suggestions.length > 0`), leaving the user with no feedback
-        // — which looked like "the dropdown is broken". Inject a
-        // non-selectable empty-state row so the dropdown surfaces
-        // `site.message.userNotFound` instead.
+        // doesn't hit, the API really returns [] and the autocomplete
+        // dropdown would stay hidden (Element Plus only opens it when
+        // `suggestions.length > 0`). Inject a non-selectable sentinel
+        // so the user gets feedback (`site.message.userNotFound`).
         if (items.length === 0) return [EMPTY_SUGGESTION];
         return items;
       } catch {
@@ -116,9 +131,9 @@ export default defineComponent({
       }
     },
     onSelect(item: Record<string, unknown>) {
-      // Ignore clicks on the "user not found" sentinel — it is not a
-      // real user and selecting it would emit a bogus id.
-      if (item && (item as { __empty?: boolean }).__empty) {
+      // Ignore clicks on the not-found sentinel and on already-added
+      // entries — neither should emit a selection.
+      if (item && ((item as { __empty?: boolean }).__empty || (item as { __excluded?: boolean }).__excluded)) {
         this.input = '';
         return;
       }
@@ -157,6 +172,11 @@ export default defineComponent({
   cursor: default;
 }
 
+.user-picker__option--excluded {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
 .user-picker__empty-icon {
   font-size: 14px;
   color: var(--el-color-warning);
@@ -168,6 +188,17 @@ export default defineComponent({
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.user-picker__excluded-tag {
+  flex-shrink: 0;
+  margin-inline-start: 6px;
+  padding: 2px 6px;
+  font-size: 11px;
+  border-radius: 4px;
+  background: var(--el-fill-color-light);
+  color: var(--el-text-color-secondary);
+  line-height: 1.4;
 }
 
 .user-picker__avatar {


### PR DESCRIPTION
## 背景

PR #758 修了 `UserPicker` 在 API 返回 `[]` 时下拉框不显示的问题。

合并后用户给了更准确的反馈：

> 不是的。。实际上返回了，我发现搜其他用户就行，搜已经在的就不行？

也就是说真正的触发条件是：**搜已经在管理员列表里的用户** —— 这种情况下后端
`/users/resolve/` 是有返回数据的，但 `UserPicker.vue` 在客户端用
`.filter((u) => !this.excludeIds.includes(u.id))` 把已添加的用户从结果里
**悄悄过滤掉了**，导致 `items.length === 0` → 走到 PR #758 加的兜底 →
显示「未找到该用户」。

但这句话此时是**误导性的**：用户其实是找到了，只是已经在列表里。

## 修改

`Nexior/src/components/site/UserPicker.vue`：

- **不再过滤** 已添加的用户。改成 `.map()` 时给已添加的条目打上
  `__excluded: true` 标记。
- 模板里给 `__excluded` 条目加 `user-picker__option--excluded`（`opacity:
  0.6 + cursor: not-allowed`），并在右侧加一个 `已添加` 小标签（用现有的
  `site.message.userAlreadyAdded` i18n key —— 这个 key 原本就在 18 个 locale
  里，但一直没被渲染过）。
- `onSelect` 加上 `__excluded` 的拦截，跟 `__empty` sentinel 同样的 no-op
  路径：清空输入框，不 emit `select` 事件。
- `EditUsers.vue` / `EditUser.vue` **没改动**。`EditUsers.vue` 里的去重护栏
  `this.working.includes(user.id)` 仍然有效（它只在 `onAdd` 真的拿到 user 时
  才跑，而 `__excluded` 行不会 emit，所以根本走不到那里）。

## 期望表现

输入一个**已经在管理员列表里**的用户名 / 邮箱 / 手机号：

```
搜索框
┌──────────────────────────────────────────┐
│ [头像]  Germey      o****e@germey.cn   已添加│  ← 灰色，不可点
└──────────────────────────────────────────┘
```

输入一个**不存在的**精确名（例如 `germey3`）：仍然走 PR #758 的兜底，显示
「未找到该用户」。

输入一个**存在但不在列表里**的用户：行为完全不变，正常显示头像 + 昵称 + 脱敏
联系方式，可点击添加。

## 验证

- `npx eslint src/components/site/UserPicker.vue` ✅ clean
- `npx vue-tsc -b --noEmit` ✅ clean（除了仓库里那个跟本 PR 无关的
  `ApiCodeDialog.vue → mustache` 报错）
- `python3 scripts/check_i18n_coverage.py` ✅ `17 locale(s) × 39 namespace(s)
  all match zh-CN`

## 没碰的东西

- **后端**：`/users/resolve/` 仍是 exact-match-only（用户名 / email / phone
  / UUID），符合 `AuthBackend/app/views/user.py` 里写明的隐私不变量
  （"NEVER use \_\_icontains / prefix match here"）。
- **i18n**：没有新增 key。`site.message.userAlreadyAdded`（"已添加"）和
  `site.message.userNotFound`（"未找到该用户"）原本就都在 18 个 locale 里。

---
*This pull request was generated and committed by the [GitHub Copilot](https://github.com/copilot) coding agent on behalf of @CQUPTQiCu.*
