### PR TITLE
feat(chat): add gpt-5.4-nano as free default model

### DIFF
--- a/change/@acedatacloud-nexior-gpt54-nano-default.json
+++ b/change/@acedatacloud-nexior-gpt54-nano-default.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(chat): add gpt-5.4-nano model, mark as free and use as default",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/ModelSelector.vue
+++ b/src/components/chat/ModelSelector.vue
@@ -17,7 +17,10 @@
             <div class="item">
               <img v-if="option?.icon" :src="option.icon" class="item-icon" />
               <div class="item-info">
-                <p v-if="option?.getDisplayName" class="item-name">{{ option?.getDisplayName() }}</p>
+                <p v-if="option?.getDisplayName" class="item-name">
+                  {{ option?.getDisplayName() }}
+                  <span v-if="option?.isFree" class="item-free-tag">{{ $t('chat.model.freeTag') }}</span>
+                </p>
                 <p v-if="option?.getDescription" class="item-desc">{{ option?.getDescription() }}</p>
               </div>
               <font-awesome-icon v-if="model?.name === option?.name" icon="fa-solid fa-check" class="item-check" />
@@ -192,6 +195,22 @@ export default defineComponent({
     color: var(--el-text-color-primary);
     margin: 0;
     line-height: 1.4;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .item-free-tag {
+    display: inline-flex;
+    align-items: center;
+    padding: 1px 6px;
+    border-radius: 4px;
+    font-size: 10px;
+    font-weight: 600;
+    line-height: 1.3;
+    color: var(--el-color-success);
+    background-color: var(--el-color-success-light-9);
+    border: 1px solid var(--el-color-success-light-7);
   }
 
   .item-desc {

--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -8,6 +8,7 @@ export const ROLE_USER = 'user';
 export const CHAT_MODEL_NAME_GPT_5_5 = 'gpt-5.5';
 export const CHAT_MODEL_NAME_GPT_5_4 = 'gpt-5.4';
 export const CHAT_MODEL_NAME_GPT_5_4_MINI = 'gpt-5.4-mini';
+export const CHAT_MODEL_NAME_GPT_5_4_NANO = 'gpt-5.4-nano';
 export const CHAT_MODEL_NAME_DEEPSEEK_CHAT = 'deepseek-v3';
 export const CHAT_MODEL_NAME_DEEPSEEK32_CHAT = 'deepseek-v3.2-exp';
 export const CHAT_MODEL_NAME_DEEPSEEK_V4_FLASH = 'deepseek-v4-flash';
@@ -69,6 +70,18 @@ export const CHAT_MODEL_GPT_5_4_MINI: IChatModel = {
   isImageSupported: true,
   getDisplayName: () => i18n.global.t('chat.model.54Mini'),
   getDescription: () => i18n.global.t('chat.model.54MiniDescription')
+};
+
+export const CHAT_MODEL_GPT_5_4_NANO: IChatModel = {
+  enabled: true,
+  name: CHAT_MODEL_NAME_GPT_5_4_NANO,
+  icon: CHAT_MODEL_ICON_CHATGPT,
+  modelGroup: 'chatgpt',
+  isFileSupported: true,
+  isImageSupported: true,
+  isFree: true,
+  getDisplayName: () => i18n.global.t('chat.model.54Nano'),
+  getDescription: () => i18n.global.t('chat.model.54NanoDescription')
 };
 
 export const CHAT_MODEL_DEEPSEEK_CHAT: IChatModel = {
@@ -251,7 +264,7 @@ export const CHAT_MODEL_GROUP_CHATGPT: IChatModelGroup = {
   name: 'chatgpt',
   getDisplayName: () => i18n.global.t('chat.modelGroup.chatgpt'),
   getDescription: () => i18n.global.t('chat.modelGroup.chatgptDescription'),
-  models: [CHAT_MODEL_GPT_5_5, CHAT_MODEL_GPT_5_4, CHAT_MODEL_GPT_5_4_MINI]
+  models: [CHAT_MODEL_GPT_5_4_NANO, CHAT_MODEL_GPT_5_5, CHAT_MODEL_GPT_5_4, CHAT_MODEL_GPT_5_4_MINI]
 };
 
 export const CHAT_MODEL_GROUP_DEEPSEEK: IChatModelGroup = {
@@ -308,6 +321,7 @@ export const CHAT_MODEL_GROUP_GLM: IChatModelGroup = {
 };
 
 export const CHAT_MODELS: IChatModel[] = [
+  CHAT_MODEL_GPT_5_4_NANO,
   CHAT_MODEL_GPT_5_5,
   CHAT_MODEL_GPT_5_4,
   CHAT_MODEL_GPT_5_4_MINI,

--- a/src/i18n/ar/chat.json
+++ b/src/i18n/ar/chat.json
@@ -103,6 +103,18 @@
     "message": "نموذج GPT 5.4 الأسرع والأخف",
     "description": "وصف نموذج GPT 5.4 Mini"
   },
+  "model.54Nano": {
+    "message": "gpt-5.4-nano",
+    "description": "اسم نموذج الخدمة، أي GPT 5.4 Nano"
+  },
+  "model.54NanoDescription": {
+    "message": "أخف نموذج GPT 5.4 وأكثرها اقتصادًا، مناسب للمحادثات اليومية",
+    "description": "وصف نموذج GPT 5.4 Nano"
+  },
+  "model.freeTag": {
+    "message": "مجاني",
+    "description": "شارة تظهر بجانب النماذج المجانية في محدد النموذج"
+  },
   "model.deepseekChat": {
     "message": "3.0",
     "description": "اسم النموذج للخدمة، أي DeepSeek Chat"

--- a/src/i18n/de/chat.json
+++ b/src/i18n/de/chat.json
@@ -103,6 +103,18 @@
     "message": "Schnelleres und leichteres GPT 5.4-Modell",
     "description": "Beschreibung des GPT 5.4 Mini-Modells"
   },
+  "model.54Nano": {
+    "message": "gpt-5.4-nano",
+    "description": "Name des Dienstmodells, d. h. GPT 5.4 Nano"
+  },
+  "model.54NanoDescription": {
+    "message": "Das leichteste und günstigste GPT-5.4-Modell, ideal für alltägliche Konversationen",
+    "description": "Beschreibung des Modells GPT 5.4 Nano"
+  },
+  "model.freeTag": {
+    "message": "Kostenlos",
+    "description": "Badge, das neben kostenlosen Modellen im Modellauswahlmenü angezeigt wird"
+  },
   "model.deepseekChat": {
     "message": "3.0",
     "description": "Name des Modells des Dienstes, d.h. DeepSeek Chat"

--- a/src/i18n/el/chat.json
+++ b/src/i18n/el/chat.json
@@ -103,6 +103,18 @@
     "message": "Ταχύτερο και ελαφρύτερο μοντέλο GPT 5.4",
     "description": "Περιγραφή του μοντέλου GPT 5.4 Mini"
   },
+  "model.54Nano": {
+    "message": "gpt-5.4-nano",
+    "description": "Όνομα του μοντέλου υπηρεσίας, δηλαδή GPT 5.4 Nano"
+  },
+  "model.54NanoDescription": {
+    "message": "Το πιο ελαφρύ και οικονομικό μοντέλο GPT-5.4, ιδανικό για καθημερινές συνομιλίες",
+    "description": "Περιγραφή του μοντέλου GPT 5.4 Nano"
+  },
+  "model.freeTag": {
+    "message": "Δωρεάν",
+    "description": "Σήμα που εμφανίζεται δίπλα στα δωρεάν μοντέλα στον επιλογέα μοντέλων"
+  },
   "model.deepseekChat": {
     "message": "3.0",
     "description": "Όνομα του μοντέλου υπηρεσίας, δηλαδή DeepSeek Chat"

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -103,6 +103,18 @@
     "message": "Faster and lighter GPT 5.4 model",
     "description": "Description of the GPT 5.4 Mini model"
   },
+  "model.54Nano": {
+    "message": "gpt-5.4-nano",
+    "description": "Name of the service model, i.e., GPT 5.4 Nano"
+  },
+  "model.54NanoDescription": {
+    "message": "Lightest and most affordable GPT 5.4 model, great for everyday chats",
+    "description": "Description of the GPT 5.4 Nano model"
+  },
+  "model.freeTag": {
+    "message": "Free",
+    "description": "Badge shown next to free models in the model selector"
+  },
   "model.deepseekChat": {
     "message": "3.0",
     "description": "Name of the service model, i.e., DeepSeek Chat"

--- a/src/i18n/es/chat.json
+++ b/src/i18n/es/chat.json
@@ -103,6 +103,18 @@
     "message": "Modelo GPT 5.4 más rápido y ligero",
     "description": "Descripción del modelo GPT 5.4 Mini"
   },
+  "model.54Nano": {
+    "message": "gpt-5.4-nano",
+    "description": "Nombre del modelo del servicio, es decir, GPT 5.4 Nano"
+  },
+  "model.54NanoDescription": {
+    "message": "El modelo GPT-5.4 más ligero y económico, ideal para conversaciones cotidianas",
+    "description": "Descripción del modelo GPT 5.4 Nano"
+  },
+  "model.freeTag": {
+    "message": "Gratis",
+    "description": "Insignia mostrada junto a los modelos gratuitos en el selector de modelos"
+  },
   "model.deepseekChat": {
     "message": "3.0",
     "description": "Nombre del modelo del servicio, es decir, DeepSeek Chat"

--- a/src/i18n/fi/chat.json
+++ b/src/i18n/fi/chat.json
@@ -103,6 +103,18 @@
     "message": "Nopeampi ja kevyempi GPT 5.4 -malli",
     "description": "GPT 5.4 Mini -mallin kuvaus"
   },
+  "model.54Nano": {
+    "message": "gpt-5.4-nano",
+    "description": "Palvelumallin nimi, eli GPT 5.4 Nano"
+  },
+  "model.54NanoDescription": {
+    "message": "Kevyin ja edullisin GPT-5.4-malli, sopii arkikäyttöön ja keskusteluihin",
+    "description": "Kuvaus GPT 5.4 Nano -mallista"
+  },
+  "model.freeTag": {
+    "message": "Ilmainen",
+    "description": "Merkki, joka näkyy ilmaisten mallien vieressä mallinvalitsimessa"
+  },
   "model.deepseekChat": {
     "message": "3.0",
     "description": "Palvelun mallin nimi, eli DeepSeek Chat"

--- a/src/i18n/fr/chat.json
+++ b/src/i18n/fr/chat.json
@@ -103,6 +103,18 @@
     "message": "Modèle GPT 5.4 plus rapide et plus léger",
     "description": "Description du modèle GPT 5.4 Mini"
   },
+  "model.54Nano": {
+    "message": "gpt-5.4-nano",
+    "description": "Nom du modèle de service, c'est-à-dire GPT 5.4 Nano"
+  },
+  "model.54NanoDescription": {
+    "message": "Le modèle GPT-5.4 le plus léger et le plus économique, idéal pour les conversations quotidiennes",
+    "description": "Description du modèle GPT 5.4 Nano"
+  },
+  "model.freeTag": {
+    "message": "Gratuit",
+    "description": "Badge affiché à côté des modèles gratuits dans le sélecteur de modèles"
+  },
   "model.deepseekChat": {
     "message": "3.0",
     "description": "Nom du modèle du service, c'est-à-dire DeepSeek Chat"

--- a/src/i18n/it/chat.json
+++ b/src/i18n/it/chat.json
@@ -103,6 +103,18 @@
     "message": "Modello GPT 5.4 più veloce e leggero",
     "description": "Descrizione del modello GPT 5.4 Mini"
   },
+  "model.54Nano": {
+    "message": "gpt-5.4-nano",
+    "description": "Nome del modello di servizio, ovvero GPT 5.4 Nano"
+  },
+  "model.54NanoDescription": {
+    "message": "Il modello GPT-5.4 più leggero ed economico, ideale per le conversazioni di tutti i giorni",
+    "description": "Descrizione del modello GPT 5.4 Nano"
+  },
+  "model.freeTag": {
+    "message": "Gratis",
+    "description": "Badge mostrato accanto ai modelli gratuiti nel selettore modello"
+  },
   "model.deepseekChat": {
     "message": "3.0",
     "description": "Nome del modello del servizio, ovvero DeepSeek Chat"

--- a/src/i18n/ja/chat.json
+++ b/src/i18n/ja/chat.json
@@ -103,6 +103,18 @@
     "message": "より速く、軽量なGPT 5.4モデル",
     "description": "GPT 5.4 Miniモデルの説明"
   },
+  "model.54Nano": {
+    "message": "gpt-5.4-nano",
+    "description": "サービスモデルの名前、つまりGPT 5.4 Nano"
+  },
+  "model.54NanoDescription": {
+    "message": "最も軽量で経済的なGPT-5.4モデル、日常的な会話に最適",
+    "description": "GPT 5.4 Nano モデルの説明"
+  },
+  "model.freeTag": {
+    "message": "無料",
+    "description": "モデルセレクターで無料モデルの横に表示されるバッジ"
+  },
   "model.deepseekChat": {
     "message": "3.0",
     "description": "サービスのモデル名、すなわち DeepSeek チャット"

--- a/src/i18n/ko/chat.json
+++ b/src/i18n/ko/chat.json
@@ -103,6 +103,18 @@
     "message": "더 빠르고 가벼운 GPT 5.4 모델",
     "description": "GPT 5.4 Mini 모델의 설명"
   },
+  "model.54Nano": {
+    "message": "gpt-5.4-nano",
+    "description": "서비스 모델 이름, 즉 GPT 5.4 Nano"
+  },
+  "model.54NanoDescription": {
+    "message": "가장 가볍고 경제적인 GPT-5.4 모델로, 일상적인 대화에 적합합니다",
+    "description": "GPT 5.4 Nano 모델 설명"
+  },
+  "model.freeTag": {
+    "message": "무료",
+    "description": "모델 선택기에서 무료 모델 옆에 표시되는 배지"
+  },
   "model.deepseekChat": {
     "message": "3.0",
     "description": "서비스의 모델 이름, 즉 DeepSeek 채팅"

--- a/src/i18n/pl/chat.json
+++ b/src/i18n/pl/chat.json
@@ -103,6 +103,18 @@
     "message": "Szybszy i lżejszy model GPT 5.4",
     "description": "Opis modelu GPT 5.4 Mini"
   },
+  "model.54Nano": {
+    "message": "gpt-5.4-nano",
+    "description": "Nazwa modelu usługi, tj. GPT 5.4 Nano"
+  },
+  "model.54NanoDescription": {
+    "message": "Najlżejszy i najtańszy model GPT-5.4, idealny do codziennych rozmów",
+    "description": "Opis modelu GPT 5.4 Nano"
+  },
+  "model.freeTag": {
+    "message": "Bezpłatny",
+    "description": "Odznaka wyświetlana obok darmowych modeli w selektorze modeli"
+  },
   "model.deepseekChat": {
     "message": "3.0",
     "description": "Nazwa modelu usługi, czyli DeepSeek Chat"

--- a/src/i18n/pt/chat.json
+++ b/src/i18n/pt/chat.json
@@ -103,6 +103,18 @@
     "message": "Modelo GPT 5.4 mais rápido e leve",
     "description": "Descrição do modelo GPT 5.4 Mini"
   },
+  "model.54Nano": {
+    "message": "gpt-5.4-nano",
+    "description": "Nome do modelo de serviço, ou seja, GPT 5.4 Nano"
+  },
+  "model.54NanoDescription": {
+    "message": "O modelo GPT-5.4 mais leve e econômico, ideal para conversas do dia a dia",
+    "description": "Descrição do modelo GPT 5.4 Nano"
+  },
+  "model.freeTag": {
+    "message": "Grátis",
+    "description": "Selo exibido ao lado de modelos gratuitos no seletor de modelos"
+  },
   "model.deepseekChat": {
     "message": "3.0",
     "description": "Nome do modelo do serviço, ou seja, DeepSeek Chat"

--- a/src/i18n/ru/chat.json
+++ b/src/i18n/ru/chat.json
@@ -103,6 +103,18 @@
     "message": "Более быстрая и легкая модель GPT 5.4",
     "description": "Описание модели GPT 5.4 Mini"
   },
+  "model.54Nano": {
+    "message": "gpt-5.4-nano",
+    "description": "Имя модели сервиса, т.е. GPT 5.4 Nano"
+  },
+  "model.54NanoDescription": {
+    "message": "Самая лёгкая и экономичная модель GPT-5.4, отлично подходит для повседневного общения",
+    "description": "Описание модели GPT 5.4 Nano"
+  },
+  "model.freeTag": {
+    "message": "Бесплатно",
+    "description": "Значок, отображаемый рядом с бесплатными моделями в селекторе моделей"
+  },
   "model.deepseekChat": {
     "message": "3.0",
     "description": "Название модели сервиса, то есть DeepSeek Chat"

--- a/src/i18n/sr/chat.json
+++ b/src/i18n/sr/chat.json
@@ -103,6 +103,18 @@
     "message": "Brži i lakši GPT 5.4 model",
     "description": "Opis GPT 5.4 Mini modela"
   },
+  "model.54Nano": {
+    "message": "gpt-5.4-nano",
+    "description": "Назив модела услуге, тј. GPT 5.4 Nano"
+  },
+  "model.54NanoDescription": {
+    "message": "Најлакши и најекономичнији GPT-5.4 модел, идеалан за свакодневне разговоре",
+    "description": "Опис модела GPT 5.4 Nano"
+  },
+  "model.freeTag": {
+    "message": "Бесплатно",
+    "description": "Ознака приказана поред бесплатних модела у бирачу модела"
+  },
   "model.deepseekChat": {
     "message": "3.0",
     "description": "Naziv modela usluge, tj. DeepSeek chat"

--- a/src/i18n/sv/chat.json
+++ b/src/i18n/sv/chat.json
@@ -103,6 +103,18 @@
     "message": "Snabbare och lättare GPT 5.4-modell",
     "description": "Beskrivning av GPT 5.4 Mini-modellen"
   },
+  "model.54Nano": {
+    "message": "gpt-5.4-nano",
+    "description": "Namn på tjänstmodellen, dvs. GPT 5.4 Nano"
+  },
+  "model.54NanoDescription": {
+    "message": "Den lättaste och mest prisvärda GPT-5.4-modellen, perfekt för vardagliga samtal",
+    "description": "Beskrivning av modellen GPT 5.4 Nano"
+  },
+  "model.freeTag": {
+    "message": "Gratis",
+    "description": "Märke som visas bredvid gratismodeller i modellväljaren"
+  },
   "model.deepseekChat": {
     "message": "3.0",
     "description": "Modellnamnet för tjänsten, det vill säga DeepSeek Chat"

--- a/src/i18n/uk/chat.json
+++ b/src/i18n/uk/chat.json
@@ -103,6 +103,18 @@
     "message": "Швидша та легша модель GPT 5.4",
     "description": "Опис моделі GPT 5.4 Mini"
   },
+  "model.54Nano": {
+    "message": "gpt-5.4-nano",
+    "description": "Назва моделі сервісу, тобто GPT 5.4 Nano"
+  },
+  "model.54NanoDescription": {
+    "message": "Найлегша та найекономічніша модель GPT-5.4, ідеальна для повсякденних розмов",
+    "description": "Опис моделі GPT 5.4 Nano"
+  },
+  "model.freeTag": {
+    "message": "Безкоштовно",
+    "description": "Значок, що відображається поруч із безкоштовними моделями в селекторі моделей"
+  },
   "model.deepseekChat": {
     "message": "3.0",
     "description": "Назва моделі сервісу, тобто DeepSeek Chat"

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -103,6 +103,18 @@
     "message": "更快更轻量的 GPT 5.4 模型",
     "description": "GPT 5.4 Mini 模型的描述"
   },
+  "model.54Nano": {
+    "message": "gpt-5.4-nano",
+    "description": "服务的模型名称，即 GPT 5.4 Nano"
+  },
+  "model.54NanoDescription": {
+    "message": "最轻量、最经济的 GPT 5.4 模型，适合日常对话",
+    "description": "GPT 5.4 Nano 模型的描述"
+  },
+  "model.freeTag": {
+    "message": "免费",
+    "description": "模型选择器中免费模型旁的角标文案"
+  },
   "model.deepseekChat": {
     "message": "3.0",
     "description": "服务的模型名称，即 DeepSeek 聊天"

--- a/src/i18n/zh-TW/chat.json
+++ b/src/i18n/zh-TW/chat.json
@@ -103,6 +103,18 @@
     "message": "更快更輕量的 GPT 5.4 模型",
     "description": "GPT 5.4 Mini 模型的描述"
   },
+  "model.54Nano": {
+    "message": "gpt-5.4-nano",
+    "description": "服務的模型名稱，即 GPT 5.4 Nano"
+  },
+  "model.54NanoDescription": {
+    "message": "最輕量、最經濟的 GPT 5.4 模型，適合日常對話",
+    "description": "GPT 5.4 Nano 模型的描述"
+  },
+  "model.freeTag": {
+    "message": "免費",
+    "description": "模型選擇器中免費模型旁的角標文案"
+  },
   "model.deepseekChat": {
     "message": "3.0",
     "description": "服务的模型名称，即 DeepSeek 聊天"

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -10,6 +10,7 @@ import {
   CHAT_MODEL_NAME_GPT_5_5,
   CHAT_MODEL_NAME_GPT_5_4,
   CHAT_MODEL_NAME_GPT_5_4_MINI,
+  CHAT_MODEL_NAME_GPT_5_4_NANO,
   CHAT_MODEL_NAME_GROK_4,
   CHAT_MODEL_NAME_GEMINI_2_5_FLASH,
   CHAT_MODEL_NAME_GEMINI_2_5_PRO,
@@ -28,6 +29,7 @@ export type IChatModelName =
   | typeof CHAT_MODEL_NAME_GPT_5_5
   | typeof CHAT_MODEL_NAME_GPT_5_4
   | typeof CHAT_MODEL_NAME_GPT_5_4_MINI
+  | typeof CHAT_MODEL_NAME_GPT_5_4_NANO
   | typeof CHAT_MODEL_NAME_DEEPSEEK_CHAT
   | typeof CHAT_MODEL_NAME_DEEPSEEK32_CHAT
   | typeof CHAT_MODEL_NAME_DEEPSEEK_V4_FLASH
@@ -58,6 +60,7 @@ export interface IChatModel {
   isFileSupported?: boolean;
   isReasoningSupported?: boolean;
   isDeepSearchSupported?: boolean;
+  isFree?: boolean;
 }
 
 export interface IChatModelGroup {

--- a/src/store/chat/state.ts
+++ b/src/store/chat/state.ts
@@ -1,10 +1,10 @@
-import { CHAT_MODEL_GPT_5_5, CHAT_MODEL_GROUP_CHATGPT } from '@/constants';
+import { CHAT_MODEL_GPT_5_4_NANO, CHAT_MODEL_GROUP_CHATGPT } from '@/constants';
 import { IChatState } from './models';
 import { Status } from '@/models';
 
 export default (): IChatState => {
   return {
-    model: CHAT_MODEL_GPT_5_5,
+    model: CHAT_MODEL_GPT_5_4_NANO,
     modelGroup: CHAT_MODEL_GROUP_CHATGPT,
     applications: undefined,
     application: undefined,


### PR DESCRIPTION
## Summary

Add `gpt-5.4-nano` to Nexior's chat model catalog, mark it as **Free** with a visible badge, and make it the default model for new users.

## Changes

- **`src/constants/chat.ts`** — add `CHAT_MODEL_NAME_GPT_5_4_NANO` + `CHAT_MODEL_GPT_5_4_NANO` (with `isFree: true`). Insert as first entry in `CHAT_MODEL_GROUP_CHATGPT.models` and `CHAT_MODELS`.
- **`src/models/chat.ts`** — extend `IChatModelName` union and add `isFree?: boolean` to `IChatModel` interface.
- **`src/store/chat/state.ts`** — change initial chat model from `CHAT_MODEL_GPT_5_5` to `CHAT_MODEL_GPT_5_4_NANO`.
- **`src/components/chat/ModelSelector.vue`** — render a small green "Free / 免费" badge next to model names when `option.isFree` is true.
- **i18n** — add `chat.model.54Nano`, `chat.model.54NanoDescription`, `chat.model.freeTag` in `zh-CN` and `en` only; other 16 locales will be auto-filled by the platform's `translate.py` CronJob.

## Default-model semantics

`chat.model` is persisted via `vuex-persistedstate` (see `src/store/chat/persist.ts`). Existing users keep their last-selected model on refresh — only **new users** or users who clear local storage will land on `gpt-5.4-nano` by default. This was confirmed with the requester (acedata).

## Pricing / billing note

Backend cost rules in `PlatformBackend/cost/api/_chat_models.json` already include `gpt-5.4-nano` priced per token (OpenAI official: $0.20 in / $0.02 cached / $1.25 out per MTok). The **"Free" badge in this PR is a UI marker only** — actual per-token billing still applies.

Making the model genuinely free for Nexior users is intentionally **out of scope here** and is a follow-up backend change (e.g. `ConsumptionDiscount` row for the chat service scoped to `model = gpt-5.4-nano`, or bumping the chat `Service.free_amount` to cover nano usage). The frontend in this PR is ready: once that backend change lands, no further UI work is needed.

## Test plan

- Open `/chatgpt/conversations` as a fresh user / incognito → default model is `gpt-5.4-nano` with "Free" badge in the trigger and dropdown.
- Existing user with persisted `gpt-5.5` → unchanged.
- Switch between models, refresh → selection persists.
- Other groups (DeepSeek, Grok, Gemini, Claude, Kimi, GLM) → no Free badge, no behavioral change.
