### PR TITLE
fix(subsite): clean up 'Open subsite' dialog (inline buttons + skip when no custom domain)

### DIFF
--- a/change/@acedatacloud-nexior-subsite-open-ux.json
+++ b/change/@acedatacloud-nexior-subsite-open-ux.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(subsite): inline open-URL choices into dialog footer; skip dialog when no custom domain",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/setting/Subsite.vue
+++ b/src/components/setting/Subsite.vue
@@ -73,30 +73,23 @@
     <el-dialog
       v-model="opening.visible"
       :title="$t('subsite.title.openSite')"
-      width="460px"
+      width="auto"
       class="open-dialog"
       append-to-body
     >
-      <p class="open-hint">{{ $t('subsite.message.openSiteHint') }}</p>
-      <div class="open-urls">
-        <button
-          v-for="url in opening.urls"
-          :key="url.href"
-          type="button"
-          class="open-url"
-          @click="onConfirmOpen(url.href)"
-        >
-          <span class="open-url-host">{{ url.hostname }}</span>
-          <el-tag v-if="!url.isCustom" size="small" type="info" effect="plain" round>
-            {{ $t('subsite.field.defaultLabel') }}
-          </el-tag>
-          <el-tag v-else size="small" type="success" effect="plain" round>
-            {{ $t('subsite.field.customLabel') }}
-          </el-tag>
-        </button>
-      </div>
       <template #footer>
-        <el-button round @click="opening.visible = false">{{ $t('common.button.cancel') }}</el-button>
+        <div class="open-actions">
+          <el-button round @click="opening.visible = false">{{ $t('common.button.cancel') }}</el-button>
+          <el-button
+            v-for="url in opening.urls"
+            :key="url.href"
+            round
+            :type="url.isCustom ? 'success' : 'primary'"
+            @click="onConfirmOpen(url.href)"
+          >
+            {{ url.hostname }}
+          </el-button>
+        </div>
       </template>
     </el-dialog>
 
@@ -405,6 +398,14 @@ export default defineComponent({
           urls.push({ href: `https://${d.hostname}/`, hostname: d.hostname, isCustom: true });
         }
       }
+      // Single URL → no point asking the user to "choose"; open it
+      // straight away. Only show the picker dialog when the tenant has
+      // bound at least one Active custom domain and the default
+      // subdomain coexists.
+      if (urls.length <= 1) {
+        window.open(urls[0].href, '_blank', 'noopener');
+        return;
+      }
       this.opening.urls = urls;
       this.opening.visible = true;
     },
@@ -545,48 +546,12 @@ export default defineComponent({
 // same <style scoped> block avoids leaking selectors globally while
 // still reaching the teleported nodes.
 .open-dialog {
-  :deep(.open-hint) {
-    margin: 0 0 12px 0;
-    color: var(--el-text-color-secondary);
-    font-size: 13px;
-    line-height: 1.5;
-  }
-  :deep(.open-urls) {
+  :deep(.open-actions) {
     display: flex;
-    flex-direction: column;
-    gap: 8px;
-  }
-  :deep(.open-url) {
-    display: flex;
+    flex-wrap: wrap;
     align-items: center;
-    justify-content: space-between;
+    justify-content: flex-end;
     gap: 8px;
-    width: 100%;
-    padding: 10px 14px;
-    border: 1px solid var(--el-border-color);
-    border-radius: 999px;
-    background: var(--el-fill-color-blank);
-    color: var(--el-color-primary);
-    font-size: 14px;
-    font-weight: 500;
-    cursor: pointer;
-    transition:
-      border-color 0.15s,
-      background-color 0.15s,
-      box-shadow 0.15s;
-
-    &:hover {
-      border-color: var(--el-color-primary);
-      background: var(--el-color-primary-light-9);
-    }
-    &:focus-visible {
-      outline: none;
-      box-shadow: 0 0 0 2px var(--el-color-primary-light-7);
-    }
-    .open-url-host {
-      word-break: break-all;
-      text-align: left;
-    }
   }
 }
 </style>


### PR DESCRIPTION
## Summary

PR #759 added a brand-new "Open Subsite" picker dialog so tenants with a custom domain can pick which URL to land on. Reported visual feedback (see screenshot in the report): the dialog looks unfinished — a stacked column of rounded pill-buttons inside the body, with a lonely **Cancel** floating in the footer. It also shows up even when the user has *no* custom domain bound, where it asks them to pick between one option and Cancel.

## What changes

1. **Skip the dialog when there's nothing to choose.** `onOpenSite()` now short-circuits when the URL list collapses to just the default `*.studio.acedata.cloud` URL — it opens immediately in a new tab. The picker only appears when ≥1 **Active** custom domain coexists with the default subdomain.
2. **Reflow the picker.** Drop the body content entirely (hint paragraph + pill list + custom CSS). Render each URL as a normal `<el-button>` in the dialog footer, sitting in the same row as Cancel.
   - Default subdomain → `type="primary"` (brand color).
   - Active custom domain → `type="success"` (green, matches the **Active** tag in the column).
   - Dialog `width="auto"` lets it size to fit the buttons instead of locking at 460px.

```diff
-<el-dialog … width="460px" …>
-  <p class="open-hint">{{ $t('subsite.message.openSiteHint') }}</p>
-  <div class="open-urls">
-    <button v-for="…" class="open-url">…</button>
-  </div>
-  <template #footer>
-    <el-button round @click="opening.visible = false">{{ $t('common.button.cancel') }}</el-button>
-  </template>
-</el-dialog>
+<el-dialog … width="auto" …>
+  <template #footer>
+    <div class="open-actions">
+      <el-button round @click="opening.visible = false">{{ $t('common.button.cancel') }}</el-button>
+      <el-button v-for="url in opening.urls" :key="url.href" round
+        :type="url.isCustom ? 'success' : 'primary'" @click="onConfirmOpen(url.href)">
+        {{ url.hostname }}
+      </el-button>
+    </div>
+  </template>
+</el-dialog>
```

## i18n

`subsite.title.openSite` is still used. The three keys that are no longer referenced (`subsite.message.openSiteHint`, `subsite.field.defaultLabel`, `subsite.field.customLabel`) are intentionally **kept** so the `translate.py` CronJob doesn't have to repropagate them across the 18 locales if we want to bring them back later — they're harmless leftovers.

## Verification

- ESLint clean on `src/components/setting/Subsite.vue`.
- Two-URL case (default + 1 active custom): dialog still pops, now showing `Cancel · germey123.studio.acedata.cloud (primary) · studio.zhishuyun.com (success)` in one row.
- One-URL case (default only): no dialog — clicking **Open** in the row opens `https://<slug>.studio.acedata.cloud/` in a new tab immediately.
- No-active-custom case (only Pending/Failed bindings): treated as one-URL — also opens immediately.

---
*This pull request was generated and committed by the [GitHub Copilot](https://github.com/copilot) coding agent on behalf of @CQUPTQiCu.*
