### PR TITLE
fix(order/wechat): show mobile-friendly long-press QR when opened inside WeChat

### DIFF
--- a/change/@acedatacloud-nexior-d84b70a8-719e-45cd-b8ec-a07af9ea0b3b.json
+++ b/change/@acedatacloud-nexior-d84b70a8-719e-45cd-b8ec-a07af9ea0b3b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(order/wechat): show mobile-friendly long-press QR when the WeChat pay dialog is opened inside the WeChat in-app browser",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/order/WechatPay.vue
+++ b/src/components/order/WechatPay.vue
@@ -24,7 +24,26 @@
       </p>
     </div>
 
-    <!-- State C: PC / desktop — original QR code layout -->
+    <!-- State C: mobile inside WeChat — long-press the Native QR to recognise and pay. -->
+    <!-- The same `weixin://wxpay/bizpayurl?pr=…` Native URL the desktop QR encodes also  -->
+    <!-- works in mobile WeChat: long-press the image and the WeChat client opens the pay -->
+    <!-- sheet directly. So we render the QR mobile-friendly (single column, no PC tutorial -->
+    <!-- image) and tell the user to long-press. No JSAPI / openid required.               -->
+    <div v-else-if="isMobileInsideWechat" class="wechat-pay-longpress text-center py-[20px] px-[10px]">
+      <p class="text-[14px] mb-4 leading-relaxed">
+        {{ $t('order.message.wechatPayLongPressTip') }}
+      </p>
+      <qr-code
+        v-if="modelValue?.pay_url"
+        :value="modelValue?.pay_url"
+        :size="240"
+        class="qrcode mx-auto"
+        type="image/png"
+        :color="{ dark: '#000000', light: '#ffffff' }"
+      />
+    </div>
+
+    <!-- State D: PC / desktop — original QR code layout -->
     <el-row v-else class="paycodes py-[30px] w-[500px] mx-auto">
       <el-col :span="12">
         <div class="paycode wechat">
@@ -106,9 +125,12 @@ export default defineComponent({
     isMobileOutsideWechat(): boolean {
       return isMobileBrowser() && !isInWeChat();
     },
+    isMobileInsideWechat(): boolean {
+      return isMobileBrowser() && isInWeChat();
+    },
     dialogWidth(): string {
-      // Tighter dialog for the mobile guide / JSAPI button views.
-      if (this.jsapiPayload || this.isMobileOutsideWechat) {
+      // Tighter dialog for any of the phone-sized views; keep 500px only for PC QR.
+      if (this.jsapiPayload || this.isMobileOutsideWechat || this.isMobileInsideWechat) {
         return '90%';
       }
       return '500px';

--- a/src/i18n/ar/order.json
+++ b/src/i18n/ar/order.json
@@ -534,5 +534,9 @@
   "title.updateDiscount": {
     "message": "تحديث الخصم",
     "description": "عنوان نافذة تعديل الخصم."
+  },
+  "message.wechatPayLongPressTip": {
+    "message": "اضغط مطولا على رمز الاستجابة السريعة ادناه واختر 'التعرف على رمز QR' لاكمال الدفع في WeChat.",
+    "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   }
 }

--- a/src/i18n/de/order.json
+++ b/src/i18n/de/order.json
@@ -534,5 +534,9 @@
   "title.updateDiscount": {
     "message": "Rabatt aktualisieren",
     "description": "Titel des Popups zur Bearbeitung eines Rabatts."
+  },
+  "message.wechatPayLongPressTip": {
+    "message": "Halten Sie den QR-Code unten gedrueckt und waehlen Sie 'QR-Code erkennen', um die Zahlung in WeChat abzuschliessen.",
+    "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   }
 }

--- a/src/i18n/el/order.json
+++ b/src/i18n/el/order.json
@@ -534,5 +534,9 @@
   "title.updateDiscount": {
     "message": "Ενημέρωση Έκπτωσης",
     "description": "Τίτλος παραθύρου επεξεργασίας έκπτωσης."
+  },
+  "message.wechatPayLongPressTip": {
+    "message": "Πατήστε παρατεταμένα τον παρακάτω κωδικό QR και επιλέξτε 'Αναγνώριση κωδικού QR' για να ολοκληρώσετε την πληρωμή στο WeChat.",
+    "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   }
 }

--- a/src/i18n/en/order.json
+++ b/src/i18n/en/order.json
@@ -534,5 +534,9 @@
   "title.updateDiscount": {
     "message": "Update Discount",
     "description": "Title of the popup for editing a discount."
+  },
+  "message.wechatPayLongPressTip": {
+    "message": "Long-press the QR code below and tap 'Recognise QR code' to complete payment in WeChat.",
+    "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   }
 }

--- a/src/i18n/es/order.json
+++ b/src/i18n/es/order.json
@@ -534,5 +534,9 @@
   "title.updateDiscount": {
     "message": "Actualizar descuento",
     "description": "Título del cuadro de diálogo para editar un descuento."
+  },
+  "message.wechatPayLongPressTip": {
+    "message": "Mantenga pulsado el siguiente codigo QR y toque 'Reconocer codigo QR' para completar el pago en WeChat.",
+    "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   }
 }

--- a/src/i18n/fi/order.json
+++ b/src/i18n/fi/order.json
@@ -534,5 +534,9 @@
   "title.updateDiscount": {
     "message": "Päivitä alennus",
     "description": "Alennuksen muokkausikkunan otsikko."
+  },
+  "message.wechatPayLongPressTip": {
+    "message": "Paina alla olevaa QR-koodia pitkaan ja valitse 'Tunnista QR-koodi' suorittaaksesi maksun WeChatissa.",
+    "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   }
 }

--- a/src/i18n/fr/order.json
+++ b/src/i18n/fr/order.json
@@ -534,5 +534,9 @@
   "title.updateDiscount": {
     "message": "Mettre à jour le rabais",
     "description": "Titre de la fenêtre contextuelle pour modifier un rabais."
+  },
+  "message.wechatPayLongPressTip": {
+    "message": "Appuyez longuement sur le QR code ci-dessous et choisissez 'Reconnaitre le QR code' pour finaliser le paiement dans WeChat.",
+    "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   }
 }

--- a/src/i18n/it/order.json
+++ b/src/i18n/it/order.json
@@ -534,5 +534,9 @@
   "title.updateDiscount": {
     "message": "Aggiorna sconto",
     "description": "Titolo del popup per modificare uno sconto."
+  },
+  "message.wechatPayLongPressTip": {
+    "message": "Tieni premuto il codice QR qui sotto e seleziona 'Riconosci codice QR' per completare il pagamento in WeChat.",
+    "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   }
 }

--- a/src/i18n/ja/order.json
+++ b/src/i18n/ja/order.json
@@ -534,5 +534,9 @@
   "title.updateDiscount": {
     "message": "割引を更新",
     "description": "割引編集ポップアップのタイトル。"
+  },
+  "message.wechatPayLongPressTip": {
+    "message": "下のQRコードを長押しし、「QRコードを認識」を選択してWeChatで支払いを完了してください。",
+    "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   }
 }

--- a/src/i18n/ko/order.json
+++ b/src/i18n/ko/order.json
@@ -534,5 +534,9 @@
   "title.updateDiscount": {
     "message": "할인 업데이트",
     "description": "할인 수정 팝업 제목."
+  },
+  "message.wechatPayLongPressTip": {
+    "message": "아래 QR 코드를 길게 눌러 'QR 코드 인식'을 선택해 WeChat에서 결제를 완료하세요.",
+    "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   }
 }

--- a/src/i18n/pl/order.json
+++ b/src/i18n/pl/order.json
@@ -534,5 +534,9 @@
   "title.updateDiscount": {
     "message": "Aktualizuj zniżkę",
     "description": "Tytuł okna edycji zniżki."
+  },
+  "message.wechatPayLongPressTip": {
+    "message": "Przytrzymaj ponizszy kod QR i wybierz 'Rozpoznaj kod QR', aby dokonczyc platnosc w WeChat.",
+    "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   }
 }

--- a/src/i18n/pt/order.json
+++ b/src/i18n/pt/order.json
@@ -534,5 +534,9 @@
   "title.updateDiscount": {
     "message": "Atualizar Desconto",
     "description": "Título da janela de edição de desconto."
+  },
+  "message.wechatPayLongPressTip": {
+    "message": "Mantenha pressionado o codigo QR abaixo e selecione 'Reconhecer codigo QR' para concluir o pagamento no WeChat.",
+    "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   }
 }

--- a/src/i18n/ru/order.json
+++ b/src/i18n/ru/order.json
@@ -534,5 +534,9 @@
   "title.updateDiscount": {
     "message": "Обновить скидку",
     "description": "Заголовок всплывающего окна редактирования скидки."
+  },
+  "message.wechatPayLongPressTip": {
+    "message": "Удерживайте QR-код ниже и выберите 'Распознать QR-код', чтобы завершить оплату в WeChat.",
+    "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   }
 }

--- a/src/i18n/sr/order.json
+++ b/src/i18n/sr/order.json
@@ -534,5 +534,9 @@
   "title.updateDiscount": {
     "message": "Ažuriraj popust",
     "description": "Naslov prozora za uređivanje popusta."
+  },
+  "message.wechatPayLongPressTip": {
+    "message": "Drzite pritisnutim QR kod ispod i izaberite 'Prepoznaj QR kod' da biste zavrsili placanje u WeChat-u.",
+    "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   }
 }

--- a/src/i18n/sv/order.json
+++ b/src/i18n/sv/order.json
@@ -534,5 +534,9 @@
   "title.updateDiscount": {
     "message": "Uppdatera rabatt",
     "description": "Titel på popup-fönstret för att redigera rabatt."
+  },
+  "message.wechatPayLongPressTip": {
+    "message": "Hall in QR-koden nedan och valj 'Identifiera QR-kod' for att slutfora betalningen i WeChat.",
+    "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   }
 }

--- a/src/i18n/uk/order.json
+++ b/src/i18n/uk/order.json
@@ -534,5 +534,9 @@
   "title.updateDiscount": {
     "message": "Оновити знижку",
     "description": "Заголовок вікна редагування знижки."
+  },
+  "message.wechatPayLongPressTip": {
+    "message": "Утримуйте QR-код нижче та виберіть 'Розпізнати QR-код', щоб завершити оплату в WeChat.",
+    "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   }
 }

--- a/src/i18n/zh-CN/order.json
+++ b/src/i18n/zh-CN/order.json
@@ -534,5 +534,9 @@
   "title.updateDiscount": {
     "message": "更新折扣",
     "description": "编辑折扣弹窗标题。"
+  },
+  "message.wechatPayLongPressTip": {
+    "message": "请长按下方二维码识别图中二维码完成支付。",
+    "description": "手机微信内部浏览器打开订单页时，二维码上方的引导文案。用户长按二维码即可识别并完成支付，无需跳出微信。"
   }
 }

--- a/src/i18n/zh-TW/order.json
+++ b/src/i18n/zh-TW/order.json
@@ -534,5 +534,9 @@
   "title.updateDiscount": {
     "message": "更新折扣",
     "description": "編輯折扣彈窗標題。"
+  },
+  "message.wechatPayLongPressTip": {
+    "message": "請長按下方二維碼，識別圖中二維碼完成支付。",
+    "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   }
 }


### PR DESCRIPTION
## Summary

When the order page is opened **inside the WeChat in-app browser on mobile**, the WeChat Pay dialog used to fall through to the PC layout: a 500px-wide two-column panel with the desktop QR code plus an iPhone-scanning tutorial image. On phones that looked broken — cramped, off-canvas, and the tutorial image is irrelevant since the user is already in WeChat.

## What this PR does

Adds a dedicated **mobile-in-WeChat** dialog state, sitting between the existing mobile-outside-WeChat ("copy link") guide and the PC QR layout:

- **Single-column 240px QR** (no PC tutorial image).
- **Long-press instruction copy** (new i18n key `order.message.wechatPayLongPressTip` across all 18 locales).
- **Dialog width reduced to 90%** to match the existing mobile-outside-WeChat guide state.

The same `weixin://wxpay/bizpayurl?pr=…` Native URL the desktop QR encodes is recognised by the WeChat client when the user long-presses the QR image — the pay sheet opens directly. No JSAPI / openid required.

## Backend is untouched

The PC, mobile-outside-WeChat, and (dead-code) JSAPI states are unchanged — this only adds the new branch between them. Tested by the reporter: long-pressing the existing PC QR inside mobile WeChat already opens the pay sheet successfully end-to-end. This PR is a pure layout fix so users no longer have to guess.

## Test plan

- ✅ `python3 scripts/check_i18n_coverage.py` — `17 locale(s) × 39 namespace(s) all match zh-CN`
- ✅ `npx eslint src/components/order/WechatPay.vue` — clean
- ✅ beachball change file added (`patch`)
- Manual: opens cleanly on mobile WeChat (90% width, single column, no tutorial image); PC and mobile-Safari paths visually unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
