### PR TITLE
chore(orders): drop dead WeChat jsapi UI + i18n keys

### DIFF
--- a/src/components/order/WechatPay.vue
+++ b/src/components/order/WechatPay.vue
@@ -1,18 +1,7 @@
 <template>
   <el-dialog :model-value="visible" :title="$t('application.title.buyService')" :width="dialogWidth" center>
-    <!-- State A: in WeChat with a JSAPI payload from backend -->
-    <div v-if="jsapiPayload" class="wechat-pay-jsapi text-center py-[20px] px-[10px]">
-      <p class="text-[14px] mb-4 leading-relaxed">
-        {{ $t('order.message.wechatPayInWechatTip') }}
-      </p>
-      <el-button type="success" size="large" round class="w-[220px]" :loading="jsapiInvoking" @click="onInvokeJsapi">
-        {{ $t('order.button.wechatPayNow') }}
-      </el-button>
-      <p v-if="jsapiError" class="text-[12px] text-red-500 mt-3 break-words">{{ jsapiError }}</p>
-    </div>
-
-    <!-- State B: mobile browser outside WeChat (H5 unavailable on our merchant) -->
-    <div v-else-if="isMobileOutsideWechat" class="wechat-pay-guide text-center py-[20px] px-[10px]">
+    <!-- Mobile browser outside WeChat (H5 unavailable on our merchant) -->
+    <div v-if="isMobileOutsideWechat" class="wechat-pay-guide text-center py-[20px] px-[10px]">
       <p class="text-[14px] mb-4 leading-relaxed">
         {{ $t('order.message.wechatPayMobileGuide') }}
       </p>
@@ -24,7 +13,7 @@
       </p>
     </div>
 
-    <!-- State C: mobile inside WeChat — long-press the Native QR to recognise and pay. -->
+    <!-- Mobile inside WeChat — long-press the Native QR to recognise and pay. -->
     <!-- The same `weixin://wxpay/bizpayurl?pr=…` Native URL the desktop QR encodes also  -->
     <!-- works in mobile WeChat: long-press the image and the WeChat client opens the pay -->
     <!-- sheet directly. So we render the QR mobile-friendly (single column, no PC tutorial -->
@@ -43,7 +32,7 @@
       />
     </div>
 
-    <!-- State D: PC / desktop — original QR code layout -->
+    <!-- PC / desktop — original QR code layout -->
     <el-row v-else class="paycodes py-[30px] w-[500px] mx-auto">
       <el-col :span="12">
         <div class="paycode wechat">
@@ -78,14 +67,12 @@ import { ElDialog, ElRow, ElCol, ElButton, ElMessage } from 'element-plus';
 import QrCode from 'vue-qrcode';
 import copy from 'copy-to-clipboard';
 import { IOrder, IOrderDetailResponse, OrderState } from '@/models';
-import { isInWeChat, isMobileBrowser, parseJsapiPayload, invokeWechatJsapi, IWechatJsapiPayload } from '@/utils/wechat';
+import { isInWeChat, isMobileBrowser } from '@/utils/wechat';
 
 interface IData {
   refreshTimer: number | undefined;
   copied: boolean;
   copiedTimer: number | undefined;
-  jsapiInvoking: boolean;
-  jsapiError: string;
 }
 
 export default defineComponent({
@@ -113,15 +100,10 @@ export default defineComponent({
     return {
       refreshTimer: undefined,
       copied: false,
-      copiedTimer: undefined,
-      jsapiInvoking: false,
-      jsapiError: ''
+      copiedTimer: undefined
     };
   },
   computed: {
-    jsapiPayload(): IWechatJsapiPayload | null {
-      return parseJsapiPayload(this.modelValue?.pay_url);
-    },
     isMobileOutsideWechat(): boolean {
       return isMobileBrowser() && !isInWeChat();
     },
@@ -130,29 +112,14 @@ export default defineComponent({
     },
     dialogWidth(): string {
       // Tighter dialog for any of the phone-sized views; keep 500px only for PC QR.
-      if (this.jsapiPayload || this.isMobileOutsideWechat || this.isMobileInsideWechat) {
+      if (this.isMobileOutsideWechat || this.isMobileInsideWechat) {
         return '90%';
       }
       return '500px';
     }
   },
-  watch: {
-    'modelValue.pay_url'() {
-      // Reset transient state when the pay payload changes.
-      this.jsapiError = '';
-    },
-    visible(value: boolean) {
-      if (value && this.jsapiPayload) {
-        // Auto-trigger the JSAPI bridge when the dialog opens with a payload.
-        this.onInvokeJsapi();
-      }
-    }
-  },
   mounted() {
     this.onRefresh();
-    if (this.visible && this.jsapiPayload) {
-      this.onInvokeJsapi();
-    }
   },
   unmounted() {
     if (this.refreshTimer) {
@@ -211,30 +178,6 @@ export default defineComponent({
         }, 2000);
       } else {
         ElMessage.error(String(this.$t('common.message.copyFailed') || 'Copy failed'));
-      }
-    },
-    async onInvokeJsapi() {
-      const payload = this.jsapiPayload;
-      if (!payload || this.jsapiInvoking) {
-        return;
-      }
-      this.jsapiInvoking = true;
-      this.jsapiError = '';
-      try {
-        const result = await invokeWechatJsapi(payload);
-        if (result === 'ok') {
-          // Backend webhook will flip the order to PAID; the refresh poller
-          // will detect it and close the dialog.
-          ElMessage.success(String(this.$t('order.message.paidSuccessfully')));
-        } else if (result === 'cancel') {
-          this.jsapiError = String(this.$t('order.message.wechatPayCancelled'));
-        } else {
-          this.jsapiError = String(this.$t('order.message.wechatPayFailed'));
-        }
-      } catch (err) {
-        this.jsapiError = String(this.$t('order.message.wechatPayBridgeUnavailable'));
-      } finally {
-        this.jsapiInvoking = false;
       }
     }
   }

--- a/src/i18n/ar/order.json
+++ b/src/i18n/ar/order.json
@@ -79,14 +79,6 @@
     "message": "يرجى فتح WeChat على الهاتف، ومسح الرمز لإكمال الدفع",
     "description": "رسالة مساعدة للدفع عبر WeChat."
   },
-  "message.wechatPayInWechatTip": {
-    "message": "Tap the button below to pay with WeChat.",
-    "description": "Hint shown above the JSAPI 'Pay with WeChat' button when the page is opened inside the WeChat browser."
-  },
-  "button.wechatPayNow": {
-    "message": "Pay with WeChat",
-    "description": "Label for the in-WeChat JSAPI pay action button."
-  },
   "message.wechatPayMobileGuide": {
     "message": "Mobile browsers can't open WeChat Pay directly. Copy the payment link below and open it inside WeChat to continue.",
     "description": "Guide shown to users on a mobile browser outside WeChat, where H5 WeChat Pay is unavailable."
@@ -98,18 +90,6 @@
   "message.wechatPayMobileHint": {
     "message": "After copying, open WeChat, paste the link into any chat or the search bar, and tap it to complete payment.",
     "description": "Secondary hint shown beneath the copy-link button to guide users through pasting the link inside WeChat."
-  },
-  "message.wechatPayCancelled": {
-    "message": "Payment cancelled.",
-    "description": "Shown when the user dismisses the WeChat JSAPI pay sheet without paying."
-  },
-  "message.wechatPayFailed": {
-    "message": "Payment failed. Please try again.",
-    "description": "Shown when the WeChat JSAPI bridge reports a failure."
-  },
-  "message.wechatPayBridgeUnavailable": {
-    "message": "Please open this page inside WeChat to pay.",
-    "description": "Shown when the WeChat JSAPI bridge cannot be reached (page not running inside WeChat)."
   },
   "message.free": {
     "message": "مجاني",

--- a/src/i18n/de/order.json
+++ b/src/i18n/de/order.json
@@ -79,14 +79,6 @@
     "message": "Bitte öffnen Sie WeChat auf Ihrem Handy und scannen Sie, um die Zahlung abzuschließen.",
     "description": "Nachricht zur Hilfe bei WeChat-Zahlungen."
   },
-  "message.wechatPayInWechatTip": {
-    "message": "Tap the button below to pay with WeChat.",
-    "description": "Hint shown above the JSAPI 'Pay with WeChat' button when the page is opened inside the WeChat browser."
-  },
-  "button.wechatPayNow": {
-    "message": "Pay with WeChat",
-    "description": "Label for the in-WeChat JSAPI pay action button."
-  },
   "message.wechatPayMobileGuide": {
     "message": "Mobile browsers can't open WeChat Pay directly. Copy the payment link below and open it inside WeChat to continue.",
     "description": "Guide shown to users on a mobile browser outside WeChat, where H5 WeChat Pay is unavailable."
@@ -98,18 +90,6 @@
   "message.wechatPayMobileHint": {
     "message": "After copying, open WeChat, paste the link into any chat or the search bar, and tap it to complete payment.",
     "description": "Secondary hint shown beneath the copy-link button to guide users through pasting the link inside WeChat."
-  },
-  "message.wechatPayCancelled": {
-    "message": "Payment cancelled.",
-    "description": "Shown when the user dismisses the WeChat JSAPI pay sheet without paying."
-  },
-  "message.wechatPayFailed": {
-    "message": "Payment failed. Please try again.",
-    "description": "Shown when the WeChat JSAPI bridge reports a failure."
-  },
-  "message.wechatPayBridgeUnavailable": {
-    "message": "Please open this page inside WeChat to pay.",
-    "description": "Shown when the WeChat JSAPI bridge cannot be reached (page not running inside WeChat)."
   },
   "message.free": {
     "message": "Kostenlos",

--- a/src/i18n/el/order.json
+++ b/src/i18n/el/order.json
@@ -79,14 +79,6 @@
     "message": "Παρακαλώ ανοίξτε το WeChat στο κινητό σας και σαρώστε για να ολοκληρώσετε την πληρωμή.",
     "description": "Μήνυμα βοήθειας για πληρωμή μέσω WeChat."
   },
-  "message.wechatPayInWechatTip": {
-    "message": "Tap the button below to pay with WeChat.",
-    "description": "Hint shown above the JSAPI 'Pay with WeChat' button when the page is opened inside the WeChat browser."
-  },
-  "button.wechatPayNow": {
-    "message": "Pay with WeChat",
-    "description": "Label for the in-WeChat JSAPI pay action button."
-  },
   "message.wechatPayMobileGuide": {
     "message": "Mobile browsers can't open WeChat Pay directly. Copy the payment link below and open it inside WeChat to continue.",
     "description": "Guide shown to users on a mobile browser outside WeChat, where H5 WeChat Pay is unavailable."
@@ -98,18 +90,6 @@
   "message.wechatPayMobileHint": {
     "message": "After copying, open WeChat, paste the link into any chat or the search bar, and tap it to complete payment.",
     "description": "Secondary hint shown beneath the copy-link button to guide users through pasting the link inside WeChat."
-  },
-  "message.wechatPayCancelled": {
-    "message": "Payment cancelled.",
-    "description": "Shown when the user dismisses the WeChat JSAPI pay sheet without paying."
-  },
-  "message.wechatPayFailed": {
-    "message": "Payment failed. Please try again.",
-    "description": "Shown when the WeChat JSAPI bridge reports a failure."
-  },
-  "message.wechatPayBridgeUnavailable": {
-    "message": "Please open this page inside WeChat to pay.",
-    "description": "Shown when the WeChat JSAPI bridge cannot be reached (page not running inside WeChat)."
   },
   "message.free": {
     "message": "Δωρεάν",

--- a/src/i18n/en/order.json
+++ b/src/i18n/en/order.json
@@ -79,14 +79,6 @@
     "message": "Please open WeChat on your phone and scan to complete the payment.",
     "description": "Message for WeChat payment help."
   },
-  "message.wechatPayInWechatTip": {
-    "message": "Tap the button below to pay with WeChat.",
-    "description": "Hint shown above the JSAPI 'Pay with WeChat' button when the page is opened inside the WeChat browser."
-  },
-  "button.wechatPayNow": {
-    "message": "Pay with WeChat",
-    "description": "Label for the in-WeChat JSAPI pay action button."
-  },
   "message.wechatPayMobileGuide": {
     "message": "Mobile browsers can't open WeChat Pay directly. Copy the payment link below and open it inside WeChat to continue.",
     "description": "Guide shown to users on a mobile browser outside WeChat, where H5 WeChat Pay is unavailable."
@@ -98,18 +90,6 @@
   "message.wechatPayMobileHint": {
     "message": "After copying, open WeChat, paste the link into any chat or the search bar, and tap it to complete payment.",
     "description": "Secondary hint shown beneath the copy-link button to guide users through pasting the link inside WeChat."
-  },
-  "message.wechatPayCancelled": {
-    "message": "Payment cancelled.",
-    "description": "Shown when the user dismisses the WeChat JSAPI pay sheet without paying."
-  },
-  "message.wechatPayFailed": {
-    "message": "Payment failed. Please try again.",
-    "description": "Shown when the WeChat JSAPI bridge reports a failure."
-  },
-  "message.wechatPayBridgeUnavailable": {
-    "message": "Please open this page inside WeChat to pay.",
-    "description": "Shown when the WeChat JSAPI bridge cannot be reached (page not running inside WeChat)."
   },
   "message.free": {
     "message": "Free",

--- a/src/i18n/es/order.json
+++ b/src/i18n/es/order.json
@@ -79,14 +79,6 @@
     "message": "Por favor, abre WeChat en tu teléfono y escanea para completar el pago.",
     "description": "Mensaje de ayuda para el pago con WeChat."
   },
-  "message.wechatPayInWechatTip": {
-    "message": "Tap the button below to pay with WeChat.",
-    "description": "Hint shown above the JSAPI 'Pay with WeChat' button when the page is opened inside the WeChat browser."
-  },
-  "button.wechatPayNow": {
-    "message": "Pay with WeChat",
-    "description": "Label for the in-WeChat JSAPI pay action button."
-  },
   "message.wechatPayMobileGuide": {
     "message": "Mobile browsers can't open WeChat Pay directly. Copy the payment link below and open it inside WeChat to continue.",
     "description": "Guide shown to users on a mobile browser outside WeChat, where H5 WeChat Pay is unavailable."
@@ -98,18 +90,6 @@
   "message.wechatPayMobileHint": {
     "message": "After copying, open WeChat, paste the link into any chat or the search bar, and tap it to complete payment.",
     "description": "Secondary hint shown beneath the copy-link button to guide users through pasting the link inside WeChat."
-  },
-  "message.wechatPayCancelled": {
-    "message": "Payment cancelled.",
-    "description": "Shown when the user dismisses the WeChat JSAPI pay sheet without paying."
-  },
-  "message.wechatPayFailed": {
-    "message": "Payment failed. Please try again.",
-    "description": "Shown when the WeChat JSAPI bridge reports a failure."
-  },
-  "message.wechatPayBridgeUnavailable": {
-    "message": "Please open this page inside WeChat to pay.",
-    "description": "Shown when the WeChat JSAPI bridge cannot be reached (page not running inside WeChat)."
   },
   "message.free": {
     "message": "Gratis",

--- a/src/i18n/fi/order.json
+++ b/src/i18n/fi/order.json
@@ -79,14 +79,6 @@
     "message": "Avaa WeChat puhelimessasi ja skannaa maksun suorittamiseksi",
     "description": "WeChat-maksuohjeen viesti."
   },
-  "message.wechatPayInWechatTip": {
-    "message": "Tap the button below to pay with WeChat.",
-    "description": "Hint shown above the JSAPI 'Pay with WeChat' button when the page is opened inside the WeChat browser."
-  },
-  "button.wechatPayNow": {
-    "message": "Pay with WeChat",
-    "description": "Label for the in-WeChat JSAPI pay action button."
-  },
   "message.wechatPayMobileGuide": {
     "message": "Mobile browsers can't open WeChat Pay directly. Copy the payment link below and open it inside WeChat to continue.",
     "description": "Guide shown to users on a mobile browser outside WeChat, where H5 WeChat Pay is unavailable."
@@ -98,18 +90,6 @@
   "message.wechatPayMobileHint": {
     "message": "After copying, open WeChat, paste the link into any chat or the search bar, and tap it to complete payment.",
     "description": "Secondary hint shown beneath the copy-link button to guide users through pasting the link inside WeChat."
-  },
-  "message.wechatPayCancelled": {
-    "message": "Payment cancelled.",
-    "description": "Shown when the user dismisses the WeChat JSAPI pay sheet without paying."
-  },
-  "message.wechatPayFailed": {
-    "message": "Payment failed. Please try again.",
-    "description": "Shown when the WeChat JSAPI bridge reports a failure."
-  },
-  "message.wechatPayBridgeUnavailable": {
-    "message": "Please open this page inside WeChat to pay.",
-    "description": "Shown when the WeChat JSAPI bridge cannot be reached (page not running inside WeChat)."
   },
   "message.free": {
     "message": "Ilmainen",

--- a/src/i18n/fr/order.json
+++ b/src/i18n/fr/order.json
@@ -79,14 +79,6 @@
     "message": "Veuillez ouvrir WeChat sur votre téléphone et scanner pour terminer le paiement",
     "description": "Message d'aide pour le paiement WeChat."
   },
-  "message.wechatPayInWechatTip": {
-    "message": "Tap the button below to pay with WeChat.",
-    "description": "Hint shown above the JSAPI 'Pay with WeChat' button when the page is opened inside the WeChat browser."
-  },
-  "button.wechatPayNow": {
-    "message": "Pay with WeChat",
-    "description": "Label for the in-WeChat JSAPI pay action button."
-  },
   "message.wechatPayMobileGuide": {
     "message": "Mobile browsers can't open WeChat Pay directly. Copy the payment link below and open it inside WeChat to continue.",
     "description": "Guide shown to users on a mobile browser outside WeChat, where H5 WeChat Pay is unavailable."
@@ -98,18 +90,6 @@
   "message.wechatPayMobileHint": {
     "message": "After copying, open WeChat, paste the link into any chat or the search bar, and tap it to complete payment.",
     "description": "Secondary hint shown beneath the copy-link button to guide users through pasting the link inside WeChat."
-  },
-  "message.wechatPayCancelled": {
-    "message": "Payment cancelled.",
-    "description": "Shown when the user dismisses the WeChat JSAPI pay sheet without paying."
-  },
-  "message.wechatPayFailed": {
-    "message": "Payment failed. Please try again.",
-    "description": "Shown when the WeChat JSAPI bridge reports a failure."
-  },
-  "message.wechatPayBridgeUnavailable": {
-    "message": "Please open this page inside WeChat to pay.",
-    "description": "Shown when the WeChat JSAPI bridge cannot be reached (page not running inside WeChat)."
   },
   "message.free": {
     "message": "Gratuit",

--- a/src/i18n/it/order.json
+++ b/src/i18n/it/order.json
@@ -79,14 +79,6 @@
     "message": "Apri WeChat sul telefono e scansiona per completare il pagamento",
     "description": "Messaggio di aiuto per il pagamento WeChat."
   },
-  "message.wechatPayInWechatTip": {
-    "message": "Tap the button below to pay with WeChat.",
-    "description": "Hint shown above the JSAPI 'Pay with WeChat' button when the page is opened inside the WeChat browser."
-  },
-  "button.wechatPayNow": {
-    "message": "Pay with WeChat",
-    "description": "Label for the in-WeChat JSAPI pay action button."
-  },
   "message.wechatPayMobileGuide": {
     "message": "Mobile browsers can't open WeChat Pay directly. Copy the payment link below and open it inside WeChat to continue.",
     "description": "Guide shown to users on a mobile browser outside WeChat, where H5 WeChat Pay is unavailable."
@@ -98,18 +90,6 @@
   "message.wechatPayMobileHint": {
     "message": "After copying, open WeChat, paste the link into any chat or the search bar, and tap it to complete payment.",
     "description": "Secondary hint shown beneath the copy-link button to guide users through pasting the link inside WeChat."
-  },
-  "message.wechatPayCancelled": {
-    "message": "Payment cancelled.",
-    "description": "Shown when the user dismisses the WeChat JSAPI pay sheet without paying."
-  },
-  "message.wechatPayFailed": {
-    "message": "Payment failed. Please try again.",
-    "description": "Shown when the WeChat JSAPI bridge reports a failure."
-  },
-  "message.wechatPayBridgeUnavailable": {
-    "message": "Please open this page inside WeChat to pay.",
-    "description": "Shown when the WeChat JSAPI bridge cannot be reached (page not running inside WeChat)."
   },
   "message.free": {
     "message": "Gratuito",

--- a/src/i18n/ja/order.json
+++ b/src/i18n/ja/order.json
@@ -79,14 +79,6 @@
     "message": "携帯電話でWeChatを開き、支払いを完了するためにスキャンしてください。",
     "description": "WeChat支払いのヘルプメッセージです。"
   },
-  "message.wechatPayInWechatTip": {
-    "message": "Tap the button below to pay with WeChat.",
-    "description": "Hint shown above the JSAPI 'Pay with WeChat' button when the page is opened inside the WeChat browser."
-  },
-  "button.wechatPayNow": {
-    "message": "Pay with WeChat",
-    "description": "Label for the in-WeChat JSAPI pay action button."
-  },
   "message.wechatPayMobileGuide": {
     "message": "Mobile browsers can't open WeChat Pay directly. Copy the payment link below and open it inside WeChat to continue.",
     "description": "Guide shown to users on a mobile browser outside WeChat, where H5 WeChat Pay is unavailable."
@@ -98,18 +90,6 @@
   "message.wechatPayMobileHint": {
     "message": "After copying, open WeChat, paste the link into any chat or the search bar, and tap it to complete payment.",
     "description": "Secondary hint shown beneath the copy-link button to guide users through pasting the link inside WeChat."
-  },
-  "message.wechatPayCancelled": {
-    "message": "Payment cancelled.",
-    "description": "Shown when the user dismisses the WeChat JSAPI pay sheet without paying."
-  },
-  "message.wechatPayFailed": {
-    "message": "Payment failed. Please try again.",
-    "description": "Shown when the WeChat JSAPI bridge reports a failure."
-  },
-  "message.wechatPayBridgeUnavailable": {
-    "message": "Please open this page inside WeChat to pay.",
-    "description": "Shown when the WeChat JSAPI bridge cannot be reached (page not running inside WeChat)."
   },
   "message.free": {
     "message": "無料",

--- a/src/i18n/ko/order.json
+++ b/src/i18n/ko/order.json
@@ -79,14 +79,6 @@
     "message": "휴대폰에서 WeChat을 열고 결제를 완료하세요.",
     "description": "WeChat 결제 도움말에 대한 메시지입니다."
   },
-  "message.wechatPayInWechatTip": {
-    "message": "Tap the button below to pay with WeChat.",
-    "description": "Hint shown above the JSAPI 'Pay with WeChat' button when the page is opened inside the WeChat browser."
-  },
-  "button.wechatPayNow": {
-    "message": "Pay with WeChat",
-    "description": "Label for the in-WeChat JSAPI pay action button."
-  },
   "message.wechatPayMobileGuide": {
     "message": "Mobile browsers can't open WeChat Pay directly. Copy the payment link below and open it inside WeChat to continue.",
     "description": "Guide shown to users on a mobile browser outside WeChat, where H5 WeChat Pay is unavailable."
@@ -98,18 +90,6 @@
   "message.wechatPayMobileHint": {
     "message": "After copying, open WeChat, paste the link into any chat or the search bar, and tap it to complete payment.",
     "description": "Secondary hint shown beneath the copy-link button to guide users through pasting the link inside WeChat."
-  },
-  "message.wechatPayCancelled": {
-    "message": "Payment cancelled.",
-    "description": "Shown when the user dismisses the WeChat JSAPI pay sheet without paying."
-  },
-  "message.wechatPayFailed": {
-    "message": "Payment failed. Please try again.",
-    "description": "Shown when the WeChat JSAPI bridge reports a failure."
-  },
-  "message.wechatPayBridgeUnavailable": {
-    "message": "Please open this page inside WeChat to pay.",
-    "description": "Shown when the WeChat JSAPI bridge cannot be reached (page not running inside WeChat)."
   },
   "message.free": {
     "message": "무료",

--- a/src/i18n/pl/order.json
+++ b/src/i18n/pl/order.json
@@ -79,14 +79,6 @@
     "message": "Proszę otworzyć WeChat na telefonie i zeskanować, aby zakończyć płatność",
     "description": "Wiadomość pomocy dotyczącej płatności WeChat."
   },
-  "message.wechatPayInWechatTip": {
-    "message": "Tap the button below to pay with WeChat.",
-    "description": "Hint shown above the JSAPI 'Pay with WeChat' button when the page is opened inside the WeChat browser."
-  },
-  "button.wechatPayNow": {
-    "message": "Pay with WeChat",
-    "description": "Label for the in-WeChat JSAPI pay action button."
-  },
   "message.wechatPayMobileGuide": {
     "message": "Mobile browsers can't open WeChat Pay directly. Copy the payment link below and open it inside WeChat to continue.",
     "description": "Guide shown to users on a mobile browser outside WeChat, where H5 WeChat Pay is unavailable."
@@ -98,18 +90,6 @@
   "message.wechatPayMobileHint": {
     "message": "After copying, open WeChat, paste the link into any chat or the search bar, and tap it to complete payment.",
     "description": "Secondary hint shown beneath the copy-link button to guide users through pasting the link inside WeChat."
-  },
-  "message.wechatPayCancelled": {
-    "message": "Payment cancelled.",
-    "description": "Shown when the user dismisses the WeChat JSAPI pay sheet without paying."
-  },
-  "message.wechatPayFailed": {
-    "message": "Payment failed. Please try again.",
-    "description": "Shown when the WeChat JSAPI bridge reports a failure."
-  },
-  "message.wechatPayBridgeUnavailable": {
-    "message": "Please open this page inside WeChat to pay.",
-    "description": "Shown when the WeChat JSAPI bridge cannot be reached (page not running inside WeChat)."
   },
   "message.free": {
     "message": "Darmowe",

--- a/src/i18n/pt/order.json
+++ b/src/i18n/pt/order.json
@@ -79,14 +79,6 @@
     "message": "Abra o WeChat no celular e escaneie para concluir o pagamento.",
     "description": "Mensagem de ajuda para pagamento via WeChat."
   },
-  "message.wechatPayInWechatTip": {
-    "message": "Tap the button below to pay with WeChat.",
-    "description": "Hint shown above the JSAPI 'Pay with WeChat' button when the page is opened inside the WeChat browser."
-  },
-  "button.wechatPayNow": {
-    "message": "Pay with WeChat",
-    "description": "Label for the in-WeChat JSAPI pay action button."
-  },
   "message.wechatPayMobileGuide": {
     "message": "Mobile browsers can't open WeChat Pay directly. Copy the payment link below and open it inside WeChat to continue.",
     "description": "Guide shown to users on a mobile browser outside WeChat, where H5 WeChat Pay is unavailable."
@@ -98,18 +90,6 @@
   "message.wechatPayMobileHint": {
     "message": "After copying, open WeChat, paste the link into any chat or the search bar, and tap it to complete payment.",
     "description": "Secondary hint shown beneath the copy-link button to guide users through pasting the link inside WeChat."
-  },
-  "message.wechatPayCancelled": {
-    "message": "Payment cancelled.",
-    "description": "Shown when the user dismisses the WeChat JSAPI pay sheet without paying."
-  },
-  "message.wechatPayFailed": {
-    "message": "Payment failed. Please try again.",
-    "description": "Shown when the WeChat JSAPI bridge reports a failure."
-  },
-  "message.wechatPayBridgeUnavailable": {
-    "message": "Please open this page inside WeChat to pay.",
-    "description": "Shown when the WeChat JSAPI bridge cannot be reached (page not running inside WeChat)."
   },
   "message.free": {
     "message": "Gratuito",

--- a/src/i18n/ru/order.json
+++ b/src/i18n/ru/order.json
@@ -79,14 +79,6 @@
     "message": "Пожалуйста, откройте WeChat на телефоне и отсканируйте для завершения оплаты",
     "description": "Сообщение помощи по оплате через WeChat."
   },
-  "message.wechatPayInWechatTip": {
-    "message": "Tap the button below to pay with WeChat.",
-    "description": "Hint shown above the JSAPI 'Pay with WeChat' button when the page is opened inside the WeChat browser."
-  },
-  "button.wechatPayNow": {
-    "message": "Pay with WeChat",
-    "description": "Label for the in-WeChat JSAPI pay action button."
-  },
   "message.wechatPayMobileGuide": {
     "message": "Mobile browsers can't open WeChat Pay directly. Copy the payment link below and open it inside WeChat to continue.",
     "description": "Guide shown to users on a mobile browser outside WeChat, where H5 WeChat Pay is unavailable."
@@ -98,18 +90,6 @@
   "message.wechatPayMobileHint": {
     "message": "After copying, open WeChat, paste the link into any chat or the search bar, and tap it to complete payment.",
     "description": "Secondary hint shown beneath the copy-link button to guide users through pasting the link inside WeChat."
-  },
-  "message.wechatPayCancelled": {
-    "message": "Payment cancelled.",
-    "description": "Shown when the user dismisses the WeChat JSAPI pay sheet without paying."
-  },
-  "message.wechatPayFailed": {
-    "message": "Payment failed. Please try again.",
-    "description": "Shown when the WeChat JSAPI bridge reports a failure."
-  },
-  "message.wechatPayBridgeUnavailable": {
-    "message": "Please open this page inside WeChat to pay.",
-    "description": "Shown when the WeChat JSAPI bridge cannot be reached (page not running inside WeChat)."
   },
   "message.free": {
     "message": "Бесплатно",

--- a/src/i18n/sr/order.json
+++ b/src/i18n/sr/order.json
@@ -79,14 +79,6 @@
     "message": "Molimo otvorite WeChat na telefonu i skenirajte za završetak plaćanja",
     "description": "Poruka o pomoći za WeChat plaćanje."
   },
-  "message.wechatPayInWechatTip": {
-    "message": "Tap the button below to pay with WeChat.",
-    "description": "Hint shown above the JSAPI 'Pay with WeChat' button when the page is opened inside the WeChat browser."
-  },
-  "button.wechatPayNow": {
-    "message": "Pay with WeChat",
-    "description": "Label for the in-WeChat JSAPI pay action button."
-  },
   "message.wechatPayMobileGuide": {
     "message": "Mobile browsers can't open WeChat Pay directly. Copy the payment link below and open it inside WeChat to continue.",
     "description": "Guide shown to users on a mobile browser outside WeChat, where H5 WeChat Pay is unavailable."
@@ -98,18 +90,6 @@
   "message.wechatPayMobileHint": {
     "message": "After copying, open WeChat, paste the link into any chat or the search bar, and tap it to complete payment.",
     "description": "Secondary hint shown beneath the copy-link button to guide users through pasting the link inside WeChat."
-  },
-  "message.wechatPayCancelled": {
-    "message": "Payment cancelled.",
-    "description": "Shown when the user dismisses the WeChat JSAPI pay sheet without paying."
-  },
-  "message.wechatPayFailed": {
-    "message": "Payment failed. Please try again.",
-    "description": "Shown when the WeChat JSAPI bridge reports a failure."
-  },
-  "message.wechatPayBridgeUnavailable": {
-    "message": "Please open this page inside WeChat to pay.",
-    "description": "Shown when the WeChat JSAPI bridge cannot be reached (page not running inside WeChat)."
   },
   "message.free": {
     "message": "Besplatno",

--- a/src/i18n/sv/order.json
+++ b/src/i18n/sv/order.json
@@ -79,14 +79,6 @@
     "message": "Öppna WeChat på din telefon och skanna för att slutföra betalningen",
     "description": "Meddelande om hjälp med WeChat-betalning."
   },
-  "message.wechatPayInWechatTip": {
-    "message": "Tap the button below to pay with WeChat.",
-    "description": "Hint shown above the JSAPI 'Pay with WeChat' button when the page is opened inside the WeChat browser."
-  },
-  "button.wechatPayNow": {
-    "message": "Pay with WeChat",
-    "description": "Label for the in-WeChat JSAPI pay action button."
-  },
   "message.wechatPayMobileGuide": {
     "message": "Mobile browsers can't open WeChat Pay directly. Copy the payment link below and open it inside WeChat to continue.",
     "description": "Guide shown to users on a mobile browser outside WeChat, where H5 WeChat Pay is unavailable."
@@ -98,18 +90,6 @@
   "message.wechatPayMobileHint": {
     "message": "After copying, open WeChat, paste the link into any chat or the search bar, and tap it to complete payment.",
     "description": "Secondary hint shown beneath the copy-link button to guide users through pasting the link inside WeChat."
-  },
-  "message.wechatPayCancelled": {
-    "message": "Payment cancelled.",
-    "description": "Shown when the user dismisses the WeChat JSAPI pay sheet without paying."
-  },
-  "message.wechatPayFailed": {
-    "message": "Payment failed. Please try again.",
-    "description": "Shown when the WeChat JSAPI bridge reports a failure."
-  },
-  "message.wechatPayBridgeUnavailable": {
-    "message": "Please open this page inside WeChat to pay.",
-    "description": "Shown when the WeChat JSAPI bridge cannot be reached (page not running inside WeChat)."
   },
   "message.free": {
     "message": "Gratis",

--- a/src/i18n/uk/order.json
+++ b/src/i18n/uk/order.json
@@ -79,14 +79,6 @@
     "message": "Будь ласка, відкрийте WeChat на телефоні та відскануйте для завершення оплати",
     "description": "Повідомлення про допомогу з оплатою через WeChat."
   },
-  "message.wechatPayInWechatTip": {
-    "message": "Tap the button below to pay with WeChat.",
-    "description": "Hint shown above the JSAPI 'Pay with WeChat' button when the page is opened inside the WeChat browser."
-  },
-  "button.wechatPayNow": {
-    "message": "Pay with WeChat",
-    "description": "Label for the in-WeChat JSAPI pay action button."
-  },
   "message.wechatPayMobileGuide": {
     "message": "Mobile browsers can't open WeChat Pay directly. Copy the payment link below and open it inside WeChat to continue.",
     "description": "Guide shown to users on a mobile browser outside WeChat, where H5 WeChat Pay is unavailable."
@@ -98,18 +90,6 @@
   "message.wechatPayMobileHint": {
     "message": "After copying, open WeChat, paste the link into any chat or the search bar, and tap it to complete payment.",
     "description": "Secondary hint shown beneath the copy-link button to guide users through pasting the link inside WeChat."
-  },
-  "message.wechatPayCancelled": {
-    "message": "Payment cancelled.",
-    "description": "Shown when the user dismisses the WeChat JSAPI pay sheet without paying."
-  },
-  "message.wechatPayFailed": {
-    "message": "Payment failed. Please try again.",
-    "description": "Shown when the WeChat JSAPI bridge reports a failure."
-  },
-  "message.wechatPayBridgeUnavailable": {
-    "message": "Please open this page inside WeChat to pay.",
-    "description": "Shown when the WeChat JSAPI bridge cannot be reached (page not running inside WeChat)."
   },
   "message.free": {
     "message": "Безкоштовно",

--- a/src/i18n/zh-CN/order.json
+++ b/src/i18n/zh-CN/order.json
@@ -79,14 +79,6 @@
     "message": "请在手机上打开微信，扫描完成支付",
     "description": "微信支付帮助的消息。"
   },
-  "message.wechatPayInWechatTip": {
-    "message": "点击下方按钮，使用微信完成支付。",
-    "description": "在微信内部浏览器打开时，JSAPI 支付按钮上方的提示文案。"
-  },
-  "button.wechatPayNow": {
-    "message": "使用微信支付",
-    "description": "微信内部 JSAPI 支付按钮的文案。"
-  },
   "message.wechatPayMobileGuide": {
     "message": "当前浏览器不支持直接调用微信支付。请复制下方链接，在微信中打开后继续完成支付。",
     "description": "在非微信的移动端浏览器中显示的引导文案。"
@@ -98,18 +90,6 @@
   "message.wechatPayMobileHint": {
     "message": "复制成功后，打开微信，将链接粘贴到任意聊天框或顶部搜索框，点击链接即可完成支付。",
     "description": "复制链接按钮下方的二级引导提示。"
-  },
-  "message.wechatPayCancelled": {
-    "message": "已取消支付。",
-    "description": "用户在微信 JSAPI 支付面板中取消时显示的提示。"
-  },
-  "message.wechatPayFailed": {
-    "message": "支付失败，请重试。",
-    "description": "微信 JSAPI 桥返回失败时的提示。"
-  },
-  "message.wechatPayBridgeUnavailable": {
-    "message": "请在微信中打开本页面后再发起支付。",
-    "description": "页面未在微信内打开导致 JSAPI 桥不可用时的提示。"
   },
   "message.free": {
     "message": "免费",

--- a/src/i18n/zh-TW/order.json
+++ b/src/i18n/zh-TW/order.json
@@ -79,14 +79,6 @@
     "message": "請在手機上打開微信，掃描完成支付",
     "description": "微信支付幫助的消息。"
   },
-  "message.wechatPayInWechatTip": {
-    "message": "Tap the button below to pay with WeChat.",
-    "description": "Hint shown above the JSAPI 'Pay with WeChat' button when the page is opened inside the WeChat browser."
-  },
-  "button.wechatPayNow": {
-    "message": "Pay with WeChat",
-    "description": "Label for the in-WeChat JSAPI pay action button."
-  },
   "message.wechatPayMobileGuide": {
     "message": "Mobile browsers can't open WeChat Pay directly. Copy the payment link below and open it inside WeChat to continue.",
     "description": "Guide shown to users on a mobile browser outside WeChat, where H5 WeChat Pay is unavailable."
@@ -98,18 +90,6 @@
   "message.wechatPayMobileHint": {
     "message": "After copying, open WeChat, paste the link into any chat or the search bar, and tap it to complete payment.",
     "description": "Secondary hint shown beneath the copy-link button to guide users through pasting the link inside WeChat."
-  },
-  "message.wechatPayCancelled": {
-    "message": "Payment cancelled.",
-    "description": "Shown when the user dismisses the WeChat JSAPI pay sheet without paying."
-  },
-  "message.wechatPayFailed": {
-    "message": "Payment failed. Please try again.",
-    "description": "Shown when the WeChat JSAPI bridge reports a failure."
-  },
-  "message.wechatPayBridgeUnavailable": {
-    "message": "Please open this page inside WeChat to pay.",
-    "description": "Shown when the WeChat JSAPI bridge cannot be reached (page not running inside WeChat)."
   },
   "message.free": {
     "message": "免費",

--- a/src/pages/console/order/Detail.vue
+++ b/src/pages/console/order/Detail.vue
@@ -245,7 +245,6 @@ import X402PayOrder from '@/components/order/X402Pay.vue';
 import PaypalPayOrder from '@/components/order/PaypalPay.vue';
 import { IConfigResponse, IOrder, IOrderDetailResponse, OrderState } from '@/models';
 import { getPriceString } from '@/utils';
-import { getWechatPaySurface } from '@/utils/wechat';
 import { track } from '@/plugins/telemetry';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 
@@ -589,13 +588,9 @@ export default defineComponent({
       if (this.payWay === PayWay.X402) {
         this.x402Session = undefined;
       }
-      // For WeChat Pay, tell the backend which surface to prepay against
-      // (pc = Native QR, jsapi = in-WeChat browser). openid wiring lands in a
-      // follow-up; PlatformBackend safely downgrades jsapi -> pc when omitted.
+      // PayBackend always issues a Native QR for WeChat Pay (our merchant
+      // has no JSAPI/H5 enabled), so the surface field is omitted here.
       const payload: Record<string, unknown> = { pay_way: this.payWay };
-      if (this.payWay === PayWay.WechatPay) {
-        payload.surface = getWechatPaySurface();
-      }
       orderOperator
         .pay(this.id, payload as unknown as IOrder)
         .then(({ data: data }: { data: IOrderDetailResponse }) => {

--- a/src/utils/wechat.ts
+++ b/src/utils/wechat.ts
@@ -1,17 +1,12 @@
 /**
- * Detection helpers for WeChat payment flows.
+ * Detection helpers for WeChat-related UI branching.
  *
- * WeChat Pay surfaces:
- *   - "pc"    -> Native QR-code pay (desktop browser scan).
- *   - "jsapi" -> In-WeChat browser JSAPI pay (requires openid).
- *
- * H5 ("wap") is intentionally NOT exposed here because our merchant
- * account does not have H5 pay enabled. For mobile browsers outside
- * WeChat, the UI should guide the user to open the link in WeChat.
- *
- * Note: do not conflate this with `src/utils/surface.ts`, which is a
- * Capacitor build-time surface flag (web/android/ios) — unrelated to
- * the runtime WeChat detection here.
+ * Our merchant only has WeChat Pay Native (QR-code) enabled, so the
+ * frontend never needs to switch the pay surface — backend always
+ * issues a Native QR. These helpers exist purely so the WeChat-pay
+ * dialog can pick the right layout (PC QR, long-press QR inside the
+ * WeChat in-app browser, or "copy link" guide for mobile browsers
+ * outside WeChat).
  */
 
 /** True when the current page is running inside the WeChat in-app browser. */
@@ -30,115 +25,4 @@ export function isMobileBrowser(): boolean {
   return /(iPhone|iPad|iPod|Android|HarmonyOS|Mobile|Windows Phone|BlackBerry|Opera Mini)/i.test(
     navigator.userAgent || ''
   );
-}
-
-/**
- * Returns the WeChat pay surface that the backend should use.
- *
- * - "jsapi" inside the WeChat in-app browser (will also require openid).
- * - "pc"    everywhere else, including mobile browsers outside WeChat —
- *           the frontend then renders a guide to open the link in WeChat
- *           rather than attempting H5 pay.
- */
-export function getWechatPaySurface(): 'pc' | 'jsapi' {
-  return isInWeChat() ? 'jsapi' : 'pc';
-}
-
-/** Payload returned by PayBackend when surface=jsapi (serialized in pay_url). */
-export interface IWechatJsapiPayload {
-  appId: string;
-  timeStamp: string;
-  nonceStr: string;
-  package: string;
-  signType: 'RSA';
-  paySign: string;
-}
-
-/**
- * Attempt to parse `pay_url` as a WeChat JSAPI payload. Returns null when the
- * value is not JSON (e.g. a Native `weixin://...` URL or empty).
- */
-export function parseJsapiPayload(payUrl: string | null | undefined): IWechatJsapiPayload | null {
-  if (!payUrl || typeof payUrl !== 'string') {
-    return null;
-  }
-  const trimmed = payUrl.trim();
-  if (!trimmed.startsWith('{')) {
-    return null;
-  }
-  try {
-    const parsed = JSON.parse(trimmed);
-    if (
-      parsed &&
-      typeof parsed === 'object' &&
-      typeof parsed.appId === 'string' &&
-      typeof parsed.timeStamp === 'string' &&
-      typeof parsed.nonceStr === 'string' &&
-      typeof parsed.package === 'string' &&
-      typeof parsed.paySign === 'string'
-    ) {
-      return parsed as IWechatJsapiPayload;
-    }
-  } catch {
-    return null;
-  }
-  return null;
-}
-
-interface IWeixinJSBridge {
-  invoke(
-    api: 'getBrandWCPayRequest',
-    payload: IWechatJsapiPayload,
-    callback: (res: { err_msg?: string; errMsg?: string }) => void
-  ): void;
-}
-
-declare global {
-  interface Window {
-    WeixinJSBridge?: IWeixinJSBridge;
-  }
-}
-
-export type WechatJsapiResult = 'ok' | 'cancel' | 'fail';
-
-/**
- * Invoke the WeChat in-app JSAPI bridge to launch the pay UI.
- *
- * Resolves with:
- *   - "ok"     when the user successfully paid
- *   - "cancel" when the user dismissed the pay sheet
- *   - "fail"   for any other error
- *
- * Rejects only if the bridge is unavailable after waiting for ready.
- */
-export function invokeWechatJsapi(payload: IWechatJsapiPayload): Promise<WechatJsapiResult> {
-  return new Promise((resolve, reject) => {
-    const run = () => {
-      const bridge = window.WeixinJSBridge;
-      if (!bridge) {
-        reject(new Error('WeixinJSBridge unavailable'));
-        return;
-      }
-      bridge.invoke('getBrandWCPayRequest', payload, (res) => {
-        const msg = res?.err_msg ?? res?.errMsg ?? '';
-        if (msg === 'get_brand_wcpay_request:ok') {
-          resolve('ok');
-        } else if (msg === 'get_brand_wcpay_request:cancel') {
-          resolve('cancel');
-        } else {
-          resolve('fail');
-        }
-      });
-    };
-
-    if (window.WeixinJSBridge) {
-      run();
-    } else {
-      const handler = () => {
-        document.removeEventListener('WeixinJSBridgeReady', handler);
-        run();
-      };
-      document.addEventListener('WeixinJSBridgeReady', handler, false);
-    }
-  });
 }


### PR DESCRIPTION
## Why

Follow-up cleanup matching AceDataCloud/PlatformBackend#500 and
AceDataCloud/PlatformFrontend#337. The WeChat JSAPI / `openid`
plumbing on PayBackend + PlatformBackend was always dead code:

* `PayBackend.Payment.surface` is a Pydantic
  `Literal["pc", "wap", "android", "ios"]` — `"jsapi"` is rejected.
* `PlatformBackend.create_wechat_payment` downgraded any
  `jsapi/wap/android/ios` request without an `openid` back to
  Native QR, and Nexior never resolved an `openid` (no WeChat
  public-account OAuth2 flow is wired up here).

Net effect: every WeChat order ended up on the Native QR path
regardless, so the State-A `v-if="jsapiPayload"` branch in
`WechatPay.vue` could never render. The mobile-inside-WeChat case
is already covered by State C (long-press Native QR), which works
without JSAPI.

## What

* `src/utils/wechat.ts` (130 → 28 lines): drop `getWechatPaySurface`,
  `IWechatJsapiPayload`, `parseJsapiPayload`, `invokeWechatJsapi`,
  `WechatJsapiResult`, the `Window.WeixinJSBridge` global. Keep only
  `isInWeChat` / `isMobileBrowser` for the three remaining QR/guide
  branches.
* `src/components/order/WechatPay.vue`: remove the State-A
  `<div v-if="jsapiPayload">` block, `jsapiPayload` / `jsapiInvoking`
  / `jsapiError` state, the `onInvokeJsapi` method, and the mounted /
  watch auto-trigger. State B (mobile guide), State C (long-press),
  and State D (PC QR) are unchanged.
* `src/pages/console/order/Detail.vue`: drop the `getWechatPaySurface`
  import and the WeChat-specific `payload.surface =
  getWechatPaySurface()` branch in `onPay`. Backend pins WeChat to
  Native QR regardless of `surface`, so omitting the field is correct.
* i18n (18 locales): delete the 5 jsapi-only keys
  (`message.wechatPayInWechatTip`, `button.wechatPayNow`,
  `message.wechatPayCancelled`, `message.wechatPayFailed`,
  `message.wechatPayBridgeUnavailable`). 5 keys × 18 locales = 90
  keys removed. `message.wechatPayLongPressTip` and `button.copyPayLink`
  are kept (still used by the long-press / mobile-guide views).

## Behaviour delta

None. The JSAPI code path was unreachable end-to-end before this PR.

## Verification

Mechanical text-deletion patch; relying on CI for the typecheck +
build. No new code added.
