### PR TITLE
feat(features): add URL feature-flag util backed by 1-day sliding cookie

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ import './plugins/font-awesome';
 import { MotionPlugin } from '@vueuse/motion';
 import { vLoading } from 'element-plus';
 import { getSurface, isNative } from '@/utils/surface';
+import { syncFeaturesFromUrl } from '@/utils/featureFlag';
 import {
   initializeCookies,
   initializeDescription,
@@ -30,6 +31,11 @@ import {
   initializeRedirect,
   initializeFingerprint
 } from './utils/initializer';
+
+// Pick up `?features=...` overrides and persist them to the FEATURES
+// cookie before anything else runs — router guards / store hydration /
+// component setup all consult `isFeatureEnabled()` synchronously.
+syncFeaturesFromUrl();
 
 initializeChunkLoadErrorHandler();
 

--- a/src/utils/featureFlag.ts
+++ b/src/utils/featureFlag.ts
@@ -1,0 +1,127 @@
+// URL-driven feature flags, backed by a 1-day sliding host-only cookie.
+//
+// Usage:
+//   import { isFeatureEnabled, syncFeaturesFromUrl } from '@/utils/featureFlag';
+//   syncFeaturesFromUrl(); // call once at app boot, before router runs
+//   if (isFeatureEnabled('experimental-foo')) { ... }
+//
+// Visit any page with `?features=foo` to enable a flag. Multiple flags can
+// be comma- or space-separated: `?features=foo,bar`. Prefix with `-` (or
+// `!`) to disable a single flag: `?features=-foo`. Use `?features=none`
+// (also `off`, `clear`) to drop the cookie entirely. `?features=all` (or
+// `*`) flips every flag the FE consults; combine with `-foo` to opt out
+// of a single one.
+//
+// Why a cookie:
+//
+// - The cookie has a 1-day **sliding** expiry — every URL sync rewrites
+//   it with `expires: now + 1d`, so an actively-testing user stays on
+//   while an idle one self-clears after 24h. Stale flags can't survive
+//   a deploy.
+// - Host-only (no `domain=`) so the cookie does not collide with the
+//   sibling PlatformFrontend / AuthFrontend cookies of the same name.
+
+import { getCookie, removeCookie, setCookie } from 'typescript-cookie';
+
+const COOKIE_NAME = 'FEATURES';
+const ALL_TOKEN = '__all__';
+const EXPIRY_DAYS = 1;
+
+let cachedFeatures: Set<string> | null = null;
+
+function isHttps(): boolean {
+  if (typeof window === 'undefined') return true;
+  return window.location.protocol === 'https:';
+}
+
+function readStoredFeatures(): Set<string> {
+  if (typeof document === 'undefined') return new Set();
+  try {
+    const raw = getCookie(COOKIE_NAME);
+    if (!raw) return new Set();
+    return new Set(JSON.parse(raw) as string[]);
+  } catch {
+    return new Set();
+  }
+}
+
+function writeStoredFeatures(features: Set<string>): void {
+  if (typeof document === 'undefined') return;
+  try {
+    if (features.size === 0) {
+      removeCookie(COOKIE_NAME, { path: '/' });
+      return;
+    }
+    setCookie(COOKIE_NAME, JSON.stringify(Array.from(features)), {
+      expires: EXPIRY_DAYS,
+      path: '/',
+      sameSite: 'lax',
+      secure: isHttps()
+    });
+  } catch {
+    // private mode / quota — silently ignore
+  }
+}
+
+function parseTokens(raw: string): {
+  clear: boolean;
+  all: boolean;
+  add: Set<string>;
+  remove: Set<string>;
+} {
+  const add = new Set<string>();
+  const remove = new Set<string>();
+  let clear = false;
+  let all = false;
+  for (const piece of raw.split(/[\s,]+/)) {
+    const t = piece.trim().toLowerCase();
+    if (!t) continue;
+    if (t === 'clear' || t === 'none' || t === 'off') {
+      clear = true;
+      continue;
+    }
+    if (t === 'all' || t === '*') {
+      all = true;
+      continue;
+    }
+    if (t.startsWith('-') || t.startsWith('!')) {
+      remove.add(t.slice(1));
+      continue;
+    }
+    add.add(t);
+  }
+  return { clear, all, add, remove };
+}
+
+export function isFeatureEnabled(name: string): boolean {
+  const set = cachedFeatures ?? readStoredFeatures();
+  if (set.has(ALL_TOKEN)) return true;
+  return set.has(name.toLowerCase());
+}
+
+export function syncFeaturesFromUrl(): Set<string> {
+  if (typeof window === 'undefined') {
+    cachedFeatures = new Set();
+    return cachedFeatures;
+  }
+
+  const features = readStoredFeatures();
+  const params = new URLSearchParams(window.location.search);
+  const raw = params.get('features');
+
+  if (raw === null) {
+    cachedFeatures = features;
+    return features;
+  }
+
+  const { clear, all, add, remove } = parseTokens(raw);
+  if (clear) features.clear();
+  if (all) features.add(ALL_TOKEN);
+  add.forEach((f) => features.add(f));
+  remove.forEach((f) => features.delete(f));
+  if (remove.size > 0) features.delete(ALL_TOKEN);
+
+  writeStoredFeatures(features);
+  cachedFeatures = features;
+  return features;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -15,3 +15,4 @@ export * from './pasteUpload';
 export * from './pasteUploadMixin';
 export * from './uploadTrackerMixin';
 export * from './connections';
+export * from './featureFlag';


### PR DESCRIPTION
Adds a small URL-driven feature-flag system to Nexior, matching the one already used in PlatformFrontend and AuthFrontend (also being switched to cookie storage in sibling PRs). Persistence is a **host-only cookie with a 1-day sliding expiry**, so a tester can re-open the tab without losing their flag, but a forgotten flag self-clears after a day idle.

### Why

Nexior didn't have a ``?features=...`` URL escape hatch at all. Several upcoming experiments (new payment flows, alternate model surfaces) want a low-cost way to flip themselves on per-tester without going through a full feature-flag service or a settings UI. The sibling apps already have this in some form; aligning all three under the same cookie + grammar keeps the muscle memory portable across the platform.

A short-lived cookie is the right backing store:

- **Bounded TTL.** PR #390-style \"stale flag stuck in localStorage breaks a deploy\" is impossible because the cookie is gone within 24h of last use.
- **Sliding.** ``syncFeaturesFromUrl()`` rewrites ``expires: now + 1d`` on every boot, so an actively-testing user is never abruptly logged out.
- **Host-only** (no ``domain=``). PlatformFrontend / AuthFrontend each get their own isolated ``FEATURES`` cookie — a flag in one app can't leak into another.
- **SameSite=Lax** and **Secure** in production. No behavior change on ``http://localhost``.

### What changed

- ``src/utils/featureFlag.ts`` (new) — exposes ``syncFeaturesFromUrl()`` and ``isFeatureEnabled(name)``. Uses the already-installed ``typescript-cookie`` dep. Cookie name ``FEATURES``, value ``JSON.stringify(string[])``, ``expires: 1`` day, ``path: '/'``, ``sameSite: 'lax'``, ``secure: window.location.protocol === 'https:'``.
- ``src/utils/index.ts`` — re-export the new util.
- ``src/main.ts`` — call ``syncFeaturesFromUrl()`` once at boot, before ``main()`` runs router / store / config initialization, so any router guard or store hydration step that consults ``isFeatureEnabled()`` reads the current value synchronously.

No call sites consume ``isFeatureEnabled()`` yet — that comes with the actual experiments that need it. This PR is just the plumbing.

### Grammar

Unified across PlatformFrontend / AuthFrontend / Nexior:

- ``?features=foo`` — enable one
- ``?features=foo,bar`` (or space-separated) — enable several
- ``?features=all`` or ``?features=*`` — enable everything the FE consults
- ``?features=none`` / ``?features=off`` / ``?features=clear`` — drop all flags (cookie removed)
- ``?features=-foo`` / ``?features=!foo`` — disable a single flag
- ``?features=all,-foo`` — enable all except one

Tokens are case-insensitive.

### Test plan

- Open the app with \`?features=foo\` → DevTools → Application → Cookies shows ``FEATURES`` with ``[\"foo\"]`` and ``Expires`` ~24h from now.
- Re-open an hour later with any URL → cookie ``Expires`` is refreshed to ~24h from the new visit (sliding).
- ``?features=foo,bar`` → cookie value is ``[\"foo\",\"bar\"]``.
- ``?features=clear`` (or \`none\`/\`off\`) → cookie ``FEATURES`` is removed.
- ``?features=all,-foo`` → ``isFeatureEnabled('bar')`` is true, ``isFeatureEnabled('foo')`` is false.
- Lower the system clock 25 hours forward, reload with no query string → cookie is gone, flags are off.
- Verify there's no cross-origin bleed: open both \`platform.acedata.cloud\` (sibling PR) and \`studio.acedata.cloud\` (this PR) with \`?features=foo\` on each — each app has its own host-only ``FEATURES`` cookie.

### Companion PRs

- ``PlatformFrontend`` — sessionStorage → cookie.
- ``AuthFrontend`` — localStorage → cookie.