### PR TITLE
feat(ios): hide non-IAP payment UI and add PrivacyInfo.xcprivacy

### DIFF
--- a/change/@acedatacloud-nexior-ios-app-store-prep-202605231110.json
+++ b/change/@acedatacloud-nexior-ios-app-store-prep-202605231110.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(ios): hide all non-IAP payment UI on iOS surface (App Store Review Guideline 3.1.1) and register PrivacyInfo.xcprivacy for App Store submission",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		504EC3121FED79650016851F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 504EC3101FED79650016851F /* LaunchScreen.storyboard */; };
 		50B271D11FEDC1A000F3C39B /* public in Resources */ = {isa = PBXBuildFile; fileRef = 50B271D01FEDC1A000F3C39B /* public */; };
 		A084ECDBA7D38E1E42DFC39D /* Pods_App.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AF277DCFFFF123FFC6DF26C7 /* Pods_App.framework */; };
+		ACEDA7AC1000000000000002 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = ACEDA7AC1000000000000001 /* PrivacyInfo.xcprivacy */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -27,6 +28,7 @@
 		504EC3111FED79650016851F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		504EC3131FED79650016851F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		50B271D01FEDC1A000F3C39B /* public */ = {isa = PBXFileReference; lastKnownFileType = folder; path = public; sourceTree = "<group>"; };
+		ACEDA7AC1000000000000001 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		AF277DCFFFF123FFC6DF26C7 /* Pods_App.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_App.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AF51FD2D460BCFE21FA515B2 /* Pods-App.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-App.release.xcconfig"; path = "Pods/Target Support Files/Pods-App/Pods-App.release.xcconfig"; sourceTree = "<group>"; };
 		FC68EB0AF532CFC21C3344DD /* Pods-App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-App.debug.xcconfig"; path = "Pods/Target Support Files/Pods-App/Pods-App.debug.xcconfig"; sourceTree = "<group>"; };
@@ -79,6 +81,7 @@
 				504EC30E1FED79650016851F /* Assets.xcassets */,
 				504EC3101FED79650016851F /* LaunchScreen.storyboard */,
 				504EC3131FED79650016851F /* Info.plist */,
+				ACEDA7AC1000000000000001 /* PrivacyInfo.xcprivacy */,
 				2FAD9762203C412B000D30F8 /* config.xml */,
 				50B271D01FEDC1A000F3C39B /* public */,
 			);
@@ -163,6 +166,7 @@
 				50379B232058CBB4000EE86E /* capacitor.config.json in Resources */,
 				504EC30D1FED79650016851F /* Main.storyboard in Resources */,
 				2FAD9763203C412B000D30F8 /* config.xml in Resources */,
+				ACEDA7AC1000000000000002 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/App/App/PrivacyInfo.xcprivacy
+++ b/ios/App/App/PrivacyInfo.xcprivacy
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>NSPrivacyTracking</key>
+  <false/>
+  <key>NSPrivacyTrackingDomains</key>
+  <array/>
+  <key>NSPrivacyCollectedDataTypes</key>
+  <array>
+    <dict>
+      <key>NSPrivacyCollectedDataType</key>
+      <string>NSPrivacyCollectedDataTypeEmailAddress</string>
+      <key>NSPrivacyCollectedDataTypeLinked</key>
+      <true/>
+      <key>NSPrivacyCollectedDataTypeTracking</key>
+      <false/>
+      <key>NSPrivacyCollectedDataTypePurposes</key>
+      <array>
+        <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+        <string>NSPrivacyCollectedDataTypePurposeAccountManagement</string>
+      </array>
+    </dict>
+    <dict>
+      <key>NSPrivacyCollectedDataType</key>
+      <string>NSPrivacyCollectedDataTypeUserID</string>
+      <key>NSPrivacyCollectedDataTypeLinked</key>
+      <true/>
+      <key>NSPrivacyCollectedDataTypeTracking</key>
+      <false/>
+      <key>NSPrivacyCollectedDataTypePurposes</key>
+      <array>
+        <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+      </array>
+    </dict>
+  </array>
+  <key>NSPrivacyAccessedAPITypes</key>
+  <array>
+    <dict>
+      <key>NSPrivacyAccessedAPIType</key>
+      <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+      <key>NSPrivacyAccessedAPITypeReasons</key>
+      <array>
+        <string>CA92.1</string>
+      </array>
+    </dict>
+  </array>
+</dict>
+</plist>

--- a/src/components/console/SidePanel.vue
+++ b/src/components/console/SidePanel.vue
@@ -33,7 +33,7 @@ import {
   ROUTE_INDEX
 } from '@/router';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { isOfficial } from '@/utils';
+import { isOfficial, isIOS } from '@/utils';
 
 interface ILink {
   key: string;
@@ -80,6 +80,14 @@ export default defineComponent({
           icon: 'fa-solid fa-rotate-left'
         }
       ];
+
+      // App Store Review Guideline 3.1.1: hide all order/payment entry
+      // points when running inside the iOS native bundle. Users can still
+      // reach order routes via deep link, but they will see no actionable
+      // payment UI (see the v-if guards in order/Detail.vue etc.).
+      if (isIOS()) {
+        links = links.filter((link) => link.key !== 'order-list');
+      }
 
       return links;
     }

--- a/src/pages/console/application/Extra.vue
+++ b/src/pages/console/application/Extra.vue
@@ -65,6 +65,7 @@
                   </el-form-item>
                   <el-form-item>
                     <el-button
+                      v-if="showPayment"
                       type="primary"
                       size="large"
                       class="btn-create"
@@ -112,6 +113,7 @@ import { ROUTE_CONSOLE_APPLICATION_SUBSCRIBE, ROUTE_CONSOLE_ORDER_DETAIL } from 
 import Price from '@/components/common/Price.vue';
 import { applicationOperator, orderOperator } from '@/operators';
 import { getPriceString } from '@/utils';
+import { isIOS } from '@/utils';
 import { track } from '@/plugins/telemetry';
 import ServiceEstimation from '@/components/service/Estimation.vue';
 
@@ -162,6 +164,12 @@ export default defineComponent({
     },
     id() {
       return this.$route.params?.id?.toString();
+    },
+    // App Store Review Guideline 3.1.1: hide non-IAP purchase actions on
+    // the iOS surface. The form still renders for deep-linked users but
+    // the "Create Order" submit button is removed.
+    showPayment(): boolean {
+      return !isIOS();
     },
     price() {
       if (this.application?.service?.price && this.form.amount) {

--- a/src/pages/console/application/List.vue
+++ b/src/pages/console/application/List.vue
@@ -24,7 +24,7 @@
             </div>
           </el-card>
         </el-col>
-        <el-col v-if="globalApplications?.length > 0" :md="12" :xs="24">
+        <el-col v-if="showPayment && globalApplications?.length > 0" :md="12" :xs="24">
           <el-card shadow="hover" class="relative min-h-[180px] mb-2" :body-style="{ padding: '18px 20px' }">
             <el-skeleton v-if="loading" />
             <div v-else class="flex flex-row justify-between align-center">
@@ -57,6 +57,7 @@
                   {{ $t('application.button.usage') }}
                 </el-button>
                 <el-button
+                  v-if="showPayment"
                   class="!m-0 !px-2"
                   type="primary"
                   round
@@ -165,7 +166,7 @@
                       <font-awesome-icon icon="fa-solid fa-chart-line" class="mr-1 text-[12px]" />
                       {{ $t('application.button.usage') }}
                     </el-button>
-                    <el-button class="!m-0 !px-2" type="primary" round size="small" @click="onBuyMore(scope?.row)">
+                    <el-button v-if="showPayment" class="!m-0 !px-2" type="primary" round size="small" @click="onBuyMore(scope?.row)">
                       <font-awesome-icon icon="fa-solid fa-coins" class="mr-1 text-[12px]" />
                       {{ $t('application.button.buyMore') }}
                     </el-button>
@@ -211,6 +212,7 @@ import {
   ElMessage
 } from 'element-plus';
 import { ROUTE_CONSOLE_APPLICATION_EXTRA, ROUTE_CONSOLE_USAGE_LIST } from '@/router/constants';
+import { isIOS } from '@/utils';
 import {
   IApplication,
   IApplicationListResponse,
@@ -283,6 +285,14 @@ export default defineComponent({
     },
     page() {
       return parseInt(this.$route.query.page?.toString() || '1');
+    },
+    // App Store Review Guideline 3.1.1 forbids exposing non-IAP purchase
+    // flows inside the iOS bundle. Hide every "Buy More" / order entry
+    // on the iOS surface; the page remains reachable via deep link but
+    // shows no payment UI (see also order/Detail.vue, Subscribe.vue,
+    // Extra.vue, components/console/SidePanel.vue).
+    showPayment(): boolean {
+      return !isIOS();
     }
   },
   watch: {

--- a/src/pages/console/application/Subscribe.vue
+++ b/src/pages/console/application/Subscribe.vue
@@ -44,6 +44,7 @@
                       </div>
                       <div class="operations">
                         <el-button
+                          v-if="showPayment"
                           class="btn btn-subscribe"
                           :type="subscription?.name === item?.name ? 'primary' : ''"
                           round
@@ -54,7 +55,7 @@
                     </el-card>
                   </el-col>
                 </el-row>
-                <div v-if="!loading" class="extra">
+                <div v-if="!loading && showPayment" class="extra">
                   <span>{{ $t('console.message.doNotWantSubscribe') }}</span>
                   <el-button type="primary" class="btn btn-extra" round size="small" @click="onBuyExtra">
                     {{ $t('console.message.buyExtra') }}
@@ -75,6 +76,7 @@ import { IService, IApplication, IApplicationType, IOrderDetailResponse, IPackag
 import { ElRow, ElCol, ElCard, ElSkeleton, ElMessage, ElButton, ElTag } from 'element-plus';
 import { applicationOperator, orderOperator, serviceOperator } from '@/operators';
 import { getPriceString } from '@/utils';
+import { isIOS } from '@/utils';
 import { track } from '@/plugins/telemetry';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { ROUTE_CONSOLE_APPLICATION_EXTRA, ROUTE_CONSOLE_ORDER_DETAIL } from '@/router';
@@ -128,6 +130,12 @@ export default defineComponent({
     },
     applicationId() {
       return this.$route.params?.id?.toString();
+    },
+    // App Store Review Guideline 3.1.1: hide non-IAP purchase actions
+    // inside the iOS bundle. The cards still render so deep-linked users
+    // can see the package info, but the buy buttons are removed.
+    showPayment(): boolean {
+      return !isIOS();
     },
     subscriptions(): ISubscription[] {
       const items: ISubscription[] = [

--- a/src/pages/console/order/Detail.vue
+++ b/src/pages/console/order/Detail.vue
@@ -101,7 +101,7 @@
             <el-row v-if="order?.state === OrderState.PENDING">
               <el-col :span="16" :offset="4">
                 <el-divider border-style="dashed" />
-                <div v-if="showPayWays && order.price && order.price > 0 && !order.pay_way" class="payways mb-6">
+                <div v-if="showPayment && showPayWays && order.price && order.price > 0 && !order.pay_way" class="payways mb-6">
                   <div
                     :class="{
                       payway: true,
@@ -169,12 +169,12 @@
                     <span class="payname">{{ $t('order.title.paypal') }}</span>
                   </div>
                 </div>
-                <div v-if="!order?.pay_way">
+                <div v-if="showPayment && !order?.pay_way">
                   <el-button :loading="prepaying" round type="primary" size="large" class="btn-pay" @click="onPay">{{
                     $t('common.button.pay')
                   }}</el-button>
                 </div>
-                <div v-else>
+                <div v-else-if="showPayment">
                   <el-button type="primary" round size="large" class="btn-repay" @click="onRepay">{{
                     $t('common.button.repay')
                   }}</el-button>
@@ -245,6 +245,7 @@ import X402PayOrder from '@/components/order/X402Pay.vue';
 import PaypalPayOrder from '@/components/order/PaypalPay.vue';
 import { IConfigResponse, IOrder, IOrderDetailResponse, OrderState } from '@/models';
 import { getPriceString } from '@/utils';
+import { isIOS } from '@/utils';
 import { track } from '@/plugins/telemetry';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 
@@ -316,6 +317,12 @@ export default defineComponent({
     },
     redirect() {
       return this.$route.query?.redirect;
+    },
+    // App Store Review Guideline 3.1.1: do not expose any non-IAP payment
+    // UI inside the iOS bundle. We keep the order details visible (read
+    // only) but hide every pay-way selector and the Pay / Repay buttons.
+    showPayment(): boolean {
+      return !isIOS();
     },
     pricingInfo(): {
       original: number;


### PR DESCRIPTION
Prepares the iOS bundle for App Store submission.

## What this PR does

### 1. Hide non-IAP payment UI on the iOS surface

App Store Review Guideline 3.1.1 forbids non-IAP digital purchases inside the iOS app bundle. This PR introduces a single source-of-truth toggle (\`isIOS()\` from \`src/utils/surface.ts\`, already in the codebase) and applies it to every payment entry point:

| File | Hidden on iOS |
| --- | --- |
| \`src/components/console/SidePanel.vue\` | The \"Orders\" sidebar menu item |
| \`src/pages/console/application/List.vue\` | Top-of-page global balance \"Buy More\" card and the per-row \"Buy More\" buttons |
| \`src/pages/console/application/Subscribe.vue\` | Per-package buy buttons and the \"Buy Extra\" shortcut |
| \`src/pages/console/application/Extra.vue\` | The \"Create Order\" submit button (form fields remain visible for deep-link reach) |
| \`src/pages/console/order/Detail.vue\` | The pay-way picker and Pay / Repay buttons (order details remain readable) |

Web and Android surfaces are unaffected — the toggle keys off \`import.meta.env.VITE_SURFACE === 'ios'\`, which is only set when running \`npm run build:ios\`.

### 2. Add a Privacy Manifest

Adds \`ios/App/App/PrivacyInfo.xcprivacy\` and registers it in \`ios/App/App.xcodeproj/project.pbxproj\` (PBXBuildFile, PBXFileReference, App group children, PBXResourcesBuildPhase). Apple requires this for new submissions.

Declared:

* \`NSPrivacyCollectedDataTypeEmailAddress\` — Linked = true, Tracking = false; purposes: \`AppFunctionality\`, \`AccountManagement\`
* \`NSPrivacyCollectedDataTypeUserID\` — Linked = true, Tracking = false; purpose: \`AppFunctionality\`
* \`NSPrivacyAccessedAPICategoryUserDefaults\` with reason \`CA92.1\` (app's own preferences)
* \`NSPrivacyTracking = false\`

## Local verification

\`\`\`
npm run build:ios                                 # vite build, VITE_SURFACE=ios   ✓
npx cap sync ios                                  # copy assets, pod install       ✓
xcodebuild -workspace App.xcworkspace ... build   # BUILD SUCCEEDED                ✓
plutil -lint ios/App/App/PrivacyInfo.xcprivacy    # OK                             ✓
plutil -lint ios/App/App.xcodeproj/project.pbxproj # OK                            ✓
\`\`\`

PrivacyInfo.xcprivacy is present inside the built \`.app\` bundle (verified via \`plutil -p\`). The app launches cleanly on the iPhone 17 simulator.

## Out of scope (follow-up)

* **Sign in with Apple (Guideline 4.8 blocker)** — the current login page already offers Google, GitHub, WeChat, Phone Number and Passkey logins, so Apple Review will require an Apple sign-in option of equal prominence. Tracked as Phase 2 of the iOS release plan: needs work in \`AuthBackend\` (new Apple OIDC provider + \`apple_id\` user field) and \`AuthFrontend\` (Apple button + callback page).
* **App Store Connect record + TestFlight upload** — covered by the release manual in a separate PR.

## Risk

Low. All changes are gated on \`isIOS()\`. Web / Android bundles are byte-identical to \`main\`.