### PR TITLE
feat(site): port auto-translate toggle to Nexior subsite settings

### DIFF
--- a/change/@acedatacloud-nexior-site-autotranslate.json
+++ b/change/@acedatacloud-nexior-site-autotranslate.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(site): port auto-translate toggle to Nexior subsite settings (General/Title and SEO/Description), backed by /v1/translations/{enable,disable}",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/setting/Seo.vue
+++ b/src/components/setting/Seo.vue
@@ -9,13 +9,24 @@
         </p>
       </div>
       <div class="settings-content">
-        <span class="settings-value">{{ site.description }}</span>
-        <edit-text
-          :model-value="site.description"
-          :title="$t('site.title.editDescription')"
-          :placeholder="$t('site.placeholder.description')"
-          @confirm="onSave({ description: $event })"
-        />
+        <span class="settings-value">{{ descriptionSource }}</span>
+        <div class="settings-actions">
+          <edit-text
+            :model-value="descriptionSource"
+            :title="$t('site.title.editDescription')"
+            :placeholder="$t('site.placeholder.description')"
+            @confirm="onSave({ description: $event })"
+          />
+          <auto-translate-toggle
+            model="site"
+            field="description"
+            :object-id="site.id"
+            :enabled="autoTranslatedFields.includes('description')"
+            :current-value="descriptionSource"
+            @enabled-success="onTranslationChanged"
+            @disabled-success="onTranslationChanged"
+          />
+        </div>
       </div>
     </section>
 
@@ -44,6 +55,7 @@
 import { defineComponent } from 'vue';
 import EditText from '@/components/site/EditText.vue';
 import EditArray from '@/components/site/EditArray.vue';
+import AutoTranslateToggle from '@/components/site/AutoTranslateToggle.vue';
 import SectionNotice from '@/components/setting/SectionNotice.vue';
 import { siteOperator } from '@/operators';
 
@@ -52,11 +64,21 @@ export default defineComponent({
   components: {
     EditText,
     EditArray,
+    AutoTranslateToggle,
     SectionNotice
   },
   computed: {
     site() {
       return this.$store.getters.site || {};
+    },
+    // See ``Site.vue`` ``titleSource`` — same rationale: the
+    // ``description`` column may be a ``$t(...)`` ref when
+    // auto-translate is ON, so we always edit the raw zh-cn source.
+    descriptionSource(): string {
+      return this.site?.description_source ?? this.site?.description ?? '';
+    },
+    autoTranslatedFields(): string[] {
+      return this.site?.auto_translated_fields ?? [];
     }
   },
   methods: {
@@ -69,7 +91,21 @@ export default defineComponent({
         console.debug('getSite for id', this.site?.id);
         this.$store.dispatch('getSite');
       });
+    },
+    onTranslationChanged() {
+      // Toggle endpoints mutate the row server-side; refresh so the
+      // ``description`` / ``description_source`` /
+      // ``auto_translated_fields`` we bind to come back in sync.
+      this.$store.dispatch('getSite');
     }
   }
 });
 </script>
+
+<style lang="scss" scoped>
+.settings-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+</style>

--- a/src/components/setting/Site.vue
+++ b/src/components/setting/Site.vue
@@ -21,13 +21,24 @@
         </p>
       </div>
       <div class="settings-content">
-        <span class="settings-value">{{ site.title }}</span>
-        <edit-text
-          :model-value="site.title"
-          :title="$t('site.title.editTitle')"
-          :placeholder="$t('site.placeholder.title')"
-          @confirm="onSave({ title: $event })"
-        />
+        <span class="settings-value">{{ titleSource }}</span>
+        <div class="settings-actions">
+          <edit-text
+            :model-value="titleSource"
+            :title="$t('site.title.editTitle')"
+            :placeholder="$t('site.placeholder.title')"
+            @confirm="onSave({ title: $event })"
+          />
+          <auto-translate-toggle
+            model="site"
+            field="title"
+            :object-id="site.id"
+            :enabled="autoTranslatedFields.includes('title')"
+            :current-value="titleSource"
+            @enabled-success="onTranslationChanged"
+            @disabled-success="onTranslationChanged"
+          />
+        </div>
       </div>
     </section>
 
@@ -122,6 +133,7 @@ import EditText from '@/components/site/EditText.vue';
 import EditImage from '@/components/site/EditImage.vue';
 import EditUsers from '@/components/site/EditUsers.vue';
 import UserChip from '@/components/site/UserChip.vue';
+import AutoTranslateToggle from '@/components/site/AutoTranslateToggle.vue';
 import SectionNotice from '@/components/setting/SectionNotice.vue';
 import { siteOperator } from '@/operators';
 import { DEFAULT_PRIMARY_COLOR, applyAccentColor } from '@/utils/theme';
@@ -148,6 +160,7 @@ export default defineComponent({
     EditImage,
     EditUsers,
     UserChip,
+    AutoTranslateToggle,
     ElButton,
     ElColorPicker,
     ElImage,
@@ -161,6 +174,17 @@ export default defineComponent({
   computed: {
     site() {
       return this.$store.getters.site || {};
+    },
+    // Raw zh-cn source for ``title``. When auto-translate is OFF the
+    // server echoes the literal back in ``title_source``; when ON the
+    // ``title`` column is a ``$t(...)`` ref evaluated to the viewer's
+    // locale, so we always edit the source value to avoid clobbering
+    // the zh-cn original with a rendered English/etc. string.
+    titleSource(): string {
+      return this.site?.title_source ?? this.site?.title ?? '';
+    },
+    autoTranslatedFields(): string[] {
+      return this.site?.auto_translated_fields ?? [];
     },
     storedPrimaryColor(): string | undefined {
       return this.site?.theme?.primary_color;
@@ -183,6 +207,12 @@ export default defineComponent({
         console.debug('getSite for id', this.site?.id);
         this.$store.dispatch('getSite');
       });
+    },
+    onTranslationChanged() {
+      // Toggle endpoints mutate the row server-side; refresh so the
+      // ``title`` / ``title_source`` / ``auto_translated_fields`` we
+      // bind to come back in sync.
+      this.$store.dispatch('getSite');
     },
     onPrimaryColorPicked(value: string | null) {
       // `el-color-picker` emits `null` if the user clears the swatch and
@@ -219,6 +249,12 @@ export default defineComponent({
   max-width: 120px;
   border-radius: 8px;
   background-color: var(--el-fill-color-light);
+}
+
+.settings-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
 }
 
 .favicon {

--- a/src/components/site/AutoTranslateToggle.vue
+++ b/src/components/site/AutoTranslateToggle.vue
@@ -1,0 +1,203 @@
+<template>
+  <el-tooltip effect="dark" :content="tooltipContent" placement="top">
+    <el-button
+      class="auto-translate-toggle"
+      :class="{ 'is-on': enabled, 'is-off': !enabled }"
+      :loading="busy"
+      :disabled="isDisabled"
+      circle
+      size="small"
+      :type="enabled ? 'primary' : 'default'"
+      @click="onClick"
+    >
+      <span class="icon-wrap">
+        <font-awesome-icon icon="fa-solid fa-globe" />
+        <span v-if="enabled" class="dot" />
+      </span>
+    </el-button>
+  </el-tooltip>
+</template>
+
+<script lang="ts">
+import { defineComponent, type PropType } from 'vue';
+import { ElButton, ElMessage, ElMessageBox, ElTooltip } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { translationOperator } from '@/operators/translation';
+import type { ITranslationDisableResponse, ITranslationEnableResponse } from '@/operators/translation';
+
+export default defineComponent({
+  name: 'AutoTranslateToggle',
+  components: {
+    ElButton,
+    ElTooltip,
+    FontAwesomeIcon
+  },
+  props: {
+    model: {
+      type: String,
+      required: true
+    },
+    objectId: {
+      type: String as PropType<string | undefined>,
+      default: undefined
+    },
+    field: {
+      type: String,
+      required: true
+    },
+    enabled: {
+      type: Boolean,
+      default: false
+    },
+    currentValue: {
+      type: String,
+      default: ''
+    },
+    disabledReason: {
+      type: String,
+      default: ''
+    }
+  },
+  emits: ['update:enabled', 'enabled-success', 'disabled-success'],
+  data() {
+    return {
+      busy: false
+    };
+  },
+  computed: {
+    isDisabled(): boolean {
+      return !this.objectId;
+    },
+    tooltipContent(): string {
+      if (this.isDisabled) {
+        return this.disabledReason || (this.$t('site.autoTranslate.tooltipDisabledNotSaved') as string);
+      }
+      return this.enabled
+        ? (this.$t('site.autoTranslate.tooltipOn') as string)
+        : (this.$t('site.autoTranslate.tooltipOff') as string);
+    }
+  },
+  methods: {
+    async onClick(): Promise<void> {
+      if (this.busy || this.isDisabled || !this.objectId) return;
+      if (this.enabled) {
+        await this.onDisable();
+      } else {
+        await this.onEnable();
+      }
+    },
+    async onEnable(): Promise<void> {
+      if (!this.objectId) return;
+      const content = (this.currentValue ?? '').trim();
+      if (!content) {
+        ElMessage.warning(this.$t('site.autoTranslate.empty') as string);
+        return;
+      }
+      try {
+        await ElMessageBox.confirm(
+          this.$t('site.autoTranslate.confirmEnable') as string,
+          this.$t('site.autoTranslate.tooltipOff') as string,
+          {
+            type: 'info',
+            confirmButtonText: this.$t('common.button.confirm') as string,
+            cancelButtonText: this.$t('common.button.cancel') as string
+          }
+        );
+      } catch {
+        return;
+      }
+      this.busy = true;
+      try {
+        const { data } = await translationOperator.enable({
+          model: this.model,
+          object_id: this.objectId,
+          field: this.field,
+          content
+        });
+        this.$emit('update:enabled', true);
+        const payload: { source: string; fieldValue: string } = {
+          source: (data as ITranslationEnableResponse).source,
+          fieldValue: (data as ITranslationEnableResponse).field_value
+        };
+        this.$emit('enabled-success', payload);
+      } catch (err) {
+        this.handleError(err);
+      } finally {
+        this.busy = false;
+      }
+    },
+    async onDisable(): Promise<void> {
+      if (!this.objectId) return;
+      try {
+        await ElMessageBox.confirm(
+          this.$t('site.autoTranslate.confirmDisable') as string,
+          this.$t('site.autoTranslate.tooltipOn') as string,
+          {
+            type: 'warning',
+            confirmButtonText: this.$t('common.button.confirm') as string,
+            cancelButtonText: this.$t('common.button.cancel') as string
+          }
+        );
+      } catch {
+        return;
+      }
+      this.busy = true;
+      try {
+        const { data } = await translationOperator.disable({
+          model: this.model,
+          object_id: this.objectId,
+          field: this.field
+        });
+        this.$emit('update:enabled', false);
+        const payload: { fieldValue: string | null } = {
+          fieldValue: (data as ITranslationDisableResponse).field_value
+        };
+        this.$emit('disabled-success', payload);
+      } catch (err) {
+        this.handleError(err);
+      } finally {
+        this.busy = false;
+      }
+    },
+    handleError(err: unknown): void {
+      const detail = (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
+      ElMessage.error(detail || (this.$t('site.autoTranslate.error') as string));
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.auto-translate-toggle {
+  // Sized to sit alongside ``<edit-text>``'s edit button on each
+  // settings row without dominating it — height matches a small
+  // Element Plus button glyph.
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  margin-left: 6px;
+
+  .icon-wrap {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 13px;
+  }
+
+  &.is-off {
+    color: var(--el-text-color-secondary);
+  }
+
+  .dot {
+    position: absolute;
+    top: -2px;
+    right: -3px;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--el-color-success);
+    box-shadow: 0 0 0 1px var(--el-color-white);
+  }
+}
+</style>

--- a/src/i18n/ar/site.json
+++ b/src/i18n/ar/site.json
@@ -594,5 +594,33 @@
   "button.addUser": {
     "message": "إضافة",
     "description": "Button label to add the resolved user to the admins list."
+  },
+  "autoTranslate.tooltipOn": {
+    "message": "الترجمة التلقائية مفعلة — يتم عرض المحتوى بلغة الزائر",
+    "description": "Tooltip on the auto-translate toggle when it is ON"
+  },
+  "autoTranslate.tooltipOff": {
+    "message": "تخزين حرفي — انقر لتفعيل الترجمة التلقائية",
+    "description": "Tooltip on the auto-translate toggle when it is OFF"
+  },
+  "autoTranslate.tooltipDisabledNotSaved": {
+    "message": "احفظ الصف قبل تفعيل الترجمة التلقائية",
+    "description": "Tooltip shown when the toggle is disabled because the row has no id yet (create-dialog state)"
+  },
+  "autoTranslate.confirmEnable": {
+    "message": "ستتم ترجمة هذا المحتوى إلى 17 لغة خلال ساعة واحدة تقريبًا. متابعة؟",
+    "description": "Body text of the confirm dialog shown before enabling auto-translation"
+  },
+  "autoTranslate.confirmDisable": {
+    "message": "سيؤدي التعطيل إلى إزالة جميع ترجمات الـ 18 لغة، مع الاحتفاظ بالقيمة الحالية فقط. متابعة؟",
+    "description": "Body text of the confirm dialog shown before disabling auto-translation"
+  },
+  "autoTranslate.empty": {
+    "message": "أدخل بعض المحتوى قبل تفعيل الترجمة التلقائية",
+    "description": "Warning shown when the user tries to enable auto-translation on an empty field"
+  },
+  "autoTranslate.error": {
+    "message": "فشل تبديل الترجمة التلقائية، يُرجى المحاولة مرة أخرى",
+    "description": "Fallback error toast when the enable/disable HTTP call fails with no detail"
   }
 }

--- a/src/i18n/de/site.json
+++ b/src/i18n/de/site.json
@@ -594,5 +594,33 @@
   "button.addUser": {
     "message": "Hinzufügen",
     "description": "Button label to add the resolved user to the admins list."
+  },
+  "autoTranslate.tooltipOn": {
+    "message": "Automatische Übersetzung AKTIVIERT — Inhalt wird in der Sprache des Besuchers angezeigt",
+    "description": "Tooltip on the auto-translate toggle when it is ON"
+  },
+  "autoTranslate.tooltipOff": {
+    "message": "Wörtliche Speicherung — klicken zum Aktivieren der automatischen Übersetzung",
+    "description": "Tooltip on the auto-translate toggle when it is OFF"
+  },
+  "autoTranslate.tooltipDisabledNotSaved": {
+    "message": "Bitte zuerst speichern, bevor die automatische Übersetzung aktiviert wird",
+    "description": "Tooltip shown when the toggle is disabled because the row has no id yet (create-dialog state)"
+  },
+  "autoTranslate.confirmEnable": {
+    "message": "Dieser Inhalt wird innerhalb von ca. 1 Stunde in 17 Sprachen übersetzt. Fortfahren?",
+    "description": "Body text of the confirm dialog shown before enabling auto-translation"
+  },
+  "autoTranslate.confirmDisable": {
+    "message": "Beim Deaktivieren werden alle 18 Sprachversionen entfernt, nur der aktuelle Wert bleibt erhalten. Fortfahren?",
+    "description": "Body text of the confirm dialog shown before disabling auto-translation"
+  },
+  "autoTranslate.empty": {
+    "message": "Bitte zuerst Inhalt eingeben, bevor die automatische Übersetzung aktiviert wird",
+    "description": "Warning shown when the user tries to enable auto-translation on an empty field"
+  },
+  "autoTranslate.error": {
+    "message": "Umschalten der automatischen Übersetzung fehlgeschlagen, bitte erneut versuchen",
+    "description": "Fallback error toast when the enable/disable HTTP call fails with no detail"
   }
 }

--- a/src/i18n/el/site.json
+++ b/src/i18n/el/site.json
@@ -594,5 +594,33 @@
   "button.addUser": {
     "message": "Προσθήκη",
     "description": "Button label to add the resolved user to the admins list."
+  },
+  "autoTranslate.tooltipOn": {
+    "message": "Αυτόματη μετάφραση ΕΝΕΡΓΗ — το περιεχόμενο εμφανίζεται στη γλώσσα του επισκέπτη",
+    "description": "Tooltip on the auto-translate toggle when it is ON"
+  },
+  "autoTranslate.tooltipOff": {
+    "message": "Αποθήκευση κειμένου ως έχει — κάντε κλικ για ενεργοποίηση αυτόματης μετάφρασης",
+    "description": "Tooltip on the auto-translate toggle when it is OFF"
+  },
+  "autoTranslate.tooltipDisabledNotSaved": {
+    "message": "Αποθηκεύστε τη γραμμή πριν ενεργοποιήσετε την αυτόματη μετάφραση",
+    "description": "Tooltip shown when the toggle is disabled because the row has no id yet (create-dialog state)"
+  },
+  "autoTranslate.confirmEnable": {
+    "message": "Αυτό το περιεχόμενο θα μεταφραστεί σε 17 γλώσσες εντός ~1 ώρας. Συνέχεια;",
+    "description": "Body text of the confirm dialog shown before enabling auto-translation"
+  },
+  "autoTranslate.confirmDisable": {
+    "message": "Η απενεργοποίηση διαγράφει και τις 18 μεταφράσεις και διατηρεί μόνο την τρέχουσα τιμή. Συνέχεια;",
+    "description": "Body text of the confirm dialog shown before disabling auto-translation"
+  },
+  "autoTranslate.empty": {
+    "message": "Εισάγετε κάποιο περιεχόμενο πριν ενεργοποιήσετε την αυτόματη μετάφραση",
+    "description": "Warning shown when the user tries to enable auto-translation on an empty field"
+  },
+  "autoTranslate.error": {
+    "message": "Η εναλλαγή αυτόματης μετάφρασης απέτυχε, δοκιμάστε ξανά",
+    "description": "Fallback error toast when the enable/disable HTTP call fails with no detail"
   }
 }

--- a/src/i18n/en/site.json
+++ b/src/i18n/en/site.json
@@ -594,5 +594,33 @@
   "button.addUser": {
     "message": "Add",
     "description": "Button label to add the resolved user to the admins list."
+  },
+  "autoTranslate.tooltipOn": {
+    "message": "Auto-translation ON — content shows in visitor's language",
+    "description": "Tooltip on the auto-translate toggle when it is ON"
+  },
+  "autoTranslate.tooltipOff": {
+    "message": "Literal storage — click to enable auto-translation",
+    "description": "Tooltip on the auto-translate toggle when it is OFF"
+  },
+  "autoTranslate.tooltipDisabledNotSaved": {
+    "message": "Save the row before enabling auto-translation",
+    "description": "Tooltip shown when the toggle is disabled because the row has no id yet (create-dialog state)"
+  },
+  "autoTranslate.confirmEnable": {
+    "message": "This content will be translated into 17 languages within ~1 hour. Continue?",
+    "description": "Body text of the confirm dialog shown before enabling auto-translation"
+  },
+  "autoTranslate.confirmDisable": {
+    "message": "Disabling removes all 18 languages of translation, keeping only the current value. Continue?",
+    "description": "Body text of the confirm dialog shown before disabling auto-translation"
+  },
+  "autoTranslate.empty": {
+    "message": "Enter some content before enabling auto-translation",
+    "description": "Warning shown when the user tries to enable auto-translation on an empty field"
+  },
+  "autoTranslate.error": {
+    "message": "Failed to toggle auto-translation, please retry",
+    "description": "Fallback error toast when the enable/disable HTTP call fails with no detail"
   }
 }

--- a/src/i18n/es/site.json
+++ b/src/i18n/es/site.json
@@ -594,5 +594,33 @@
   "button.addUser": {
     "message": "Agregar",
     "description": "Button label to add the resolved user to the admins list."
+  },
+  "autoTranslate.tooltipOn": {
+    "message": "Traducción automática ACTIVADA — el contenido se muestra en el idioma del visitante",
+    "description": "Tooltip on the auto-translate toggle when it is ON"
+  },
+  "autoTranslate.tooltipOff": {
+    "message": "Almacenamiento literal — haz clic para activar la traducción automática",
+    "description": "Tooltip on the auto-translate toggle when it is OFF"
+  },
+  "autoTranslate.tooltipDisabledNotSaved": {
+    "message": "Guarda la fila antes de activar la traducción automática",
+    "description": "Tooltip shown when the toggle is disabled because the row has no id yet (create-dialog state)"
+  },
+  "autoTranslate.confirmEnable": {
+    "message": "Este contenido se traducirá a 17 idiomas en aproximadamente 1 hora. ¿Continuar?",
+    "description": "Body text of the confirm dialog shown before enabling auto-translation"
+  },
+  "autoTranslate.confirmDisable": {
+    "message": "Desactivar eliminará las 18 traducciones de idioma, manteniendo solo el valor actual. ¿Continuar?",
+    "description": "Body text of the confirm dialog shown before disabling auto-translation"
+  },
+  "autoTranslate.empty": {
+    "message": "Introduce contenido antes de activar la traducción automática",
+    "description": "Warning shown when the user tries to enable auto-translation on an empty field"
+  },
+  "autoTranslate.error": {
+    "message": "Error al cambiar la traducción automática, inténtalo de nuevo",
+    "description": "Fallback error toast when the enable/disable HTTP call fails with no detail"
   }
 }

--- a/src/i18n/fi/site.json
+++ b/src/i18n/fi/site.json
@@ -594,5 +594,33 @@
   "button.addUser": {
     "message": "Lisää",
     "description": "Button label to add the resolved user to the admins list."
+  },
+  "autoTranslate.tooltipOn": {
+    "message": "Automaattinen käännös PÄÄLLÄ — sisältö näkyy kävijän kielellä",
+    "description": "Tooltip on the auto-translate toggle when it is ON"
+  },
+  "autoTranslate.tooltipOff": {
+    "message": "Tallennetaan sellaisenaan — napsauta ottaaksesi automaattisen käännöksen käyttöön",
+    "description": "Tooltip on the auto-translate toggle when it is OFF"
+  },
+  "autoTranslate.tooltipDisabledNotSaved": {
+    "message": "Tallenna rivi ennen automaattisen käännöksen käyttöönottoa",
+    "description": "Tooltip shown when the toggle is disabled because the row has no id yet (create-dialog state)"
+  },
+  "autoTranslate.confirmEnable": {
+    "message": "Tämä sisältö käännetään 17 kielelle ~1 tunnin sisällä. Jatketaanko?",
+    "description": "Body text of the confirm dialog shown before enabling auto-translation"
+  },
+  "autoTranslate.confirmDisable": {
+    "message": "Käytöstä poistaminen poistaa kaikki 18 käännöstä ja säilyttää vain nykyisen arvon. Jatketaanko?",
+    "description": "Body text of the confirm dialog shown before disabling auto-translation"
+  },
+  "autoTranslate.empty": {
+    "message": "Syötä sisältöä ennen automaattisen käännöksen käyttöönottoa",
+    "description": "Warning shown when the user tries to enable auto-translation on an empty field"
+  },
+  "autoTranslate.error": {
+    "message": "Automaattisen käännöksen vaihtaminen epäonnistui, yritä uudelleen",
+    "description": "Fallback error toast when the enable/disable HTTP call fails with no detail"
   }
 }

--- a/src/i18n/fr/site.json
+++ b/src/i18n/fr/site.json
@@ -594,5 +594,33 @@
   "button.addUser": {
     "message": "Ajouter",
     "description": "Button label to add the resolved user to the admins list."
+  },
+  "autoTranslate.tooltipOn": {
+    "message": "Traduction automatique ACTIVÉE — le contenu s'affiche dans la langue du visiteur",
+    "description": "Tooltip on the auto-translate toggle when it is ON"
+  },
+  "autoTranslate.tooltipOff": {
+    "message": "Stockage littéral — cliquez pour activer la traduction automatique",
+    "description": "Tooltip on the auto-translate toggle when it is OFF"
+  },
+  "autoTranslate.tooltipDisabledNotSaved": {
+    "message": "Enregistrez la ligne avant d'activer la traduction automatique",
+    "description": "Tooltip shown when the toggle is disabled because the row has no id yet (create-dialog state)"
+  },
+  "autoTranslate.confirmEnable": {
+    "message": "Ce contenu sera traduit dans 17 langues en environ 1 heure. Continuer ?",
+    "description": "Body text of the confirm dialog shown before enabling auto-translation"
+  },
+  "autoTranslate.confirmDisable": {
+    "message": "La désactivation supprimera les 18 traductions linguistiques, ne conservant que la valeur actuelle. Continuer ?",
+    "description": "Body text of the confirm dialog shown before disabling auto-translation"
+  },
+  "autoTranslate.empty": {
+    "message": "Saisissez du contenu avant d'activer la traduction automatique",
+    "description": "Warning shown when the user tries to enable auto-translation on an empty field"
+  },
+  "autoTranslate.error": {
+    "message": "Échec du basculement de la traduction automatique, veuillez réessayer",
+    "description": "Fallback error toast when the enable/disable HTTP call fails with no detail"
   }
 }

--- a/src/i18n/it/site.json
+++ b/src/i18n/it/site.json
@@ -594,5 +594,33 @@
   "button.addUser": {
     "message": "Aggiungi",
     "description": "Button label to add the resolved user to the admins list."
+  },
+  "autoTranslate.tooltipOn": {
+    "message": "Traduzione automatica ATTIVATA — il contenuto viene mostrato nella lingua del visitatore",
+    "description": "Tooltip on the auto-translate toggle when it is ON"
+  },
+  "autoTranslate.tooltipOff": {
+    "message": "Memorizzazione letterale — clicca per attivare la traduzione automatica",
+    "description": "Tooltip on the auto-translate toggle when it is OFF"
+  },
+  "autoTranslate.tooltipDisabledNotSaved": {
+    "message": "Salva la riga prima di attivare la traduzione automatica",
+    "description": "Tooltip shown when the toggle is disabled because the row has no id yet (create-dialog state)"
+  },
+  "autoTranslate.confirmEnable": {
+    "message": "Questo contenuto sarà tradotto in 17 lingue entro circa 1 ora. Continuare?",
+    "description": "Body text of the confirm dialog shown before enabling auto-translation"
+  },
+  "autoTranslate.confirmDisable": {
+    "message": "Disattivando si rimuoveranno tutte le 18 traduzioni linguistiche, mantenendo solo il valore attuale. Continuare?",
+    "description": "Body text of the confirm dialog shown before disabling auto-translation"
+  },
+  "autoTranslate.empty": {
+    "message": "Inserisci del contenuto prima di attivare la traduzione automatica",
+    "description": "Warning shown when the user tries to enable auto-translation on an empty field"
+  },
+  "autoTranslate.error": {
+    "message": "Impossibile cambiare la traduzione automatica, riprova",
+    "description": "Fallback error toast when the enable/disable HTTP call fails with no detail"
   }
 }

--- a/src/i18n/ja/site.json
+++ b/src/i18n/ja/site.json
@@ -594,5 +594,33 @@
   "button.addUser": {
     "message": "追加",
     "description": "Button label to add the resolved user to the admins list."
+  },
+  "autoTranslate.tooltipOn": {
+    "message": "自動翻訳オン — コンテンツは訪問者の言語で表示されます",
+    "description": "Tooltip on the auto-translate toggle when it is ON"
+  },
+  "autoTranslate.tooltipOff": {
+    "message": "リテラル保存 — クリックして自動翻訳を有効化",
+    "description": "Tooltip on the auto-translate toggle when it is OFF"
+  },
+  "autoTranslate.tooltipDisabledNotSaved": {
+    "message": "自動翻訳を有効にする前に行を保存してください",
+    "description": "Tooltip shown when the toggle is disabled because the row has no id yet (create-dialog state)"
+  },
+  "autoTranslate.confirmEnable": {
+    "message": "このコンテンツは約 1 時間以内に 17 言語に翻訳されます。続行しますか？",
+    "description": "Body text of the confirm dialog shown before enabling auto-translation"
+  },
+  "autoTranslate.confirmDisable": {
+    "message": "無効にすると 18 言語のすべての翻訳が削除され、現在の値のみが保持されます。続行しますか？",
+    "description": "Body text of the confirm dialog shown before disabling auto-translation"
+  },
+  "autoTranslate.empty": {
+    "message": "自動翻訳を有効にする前にコンテンツを入力してください",
+    "description": "Warning shown when the user tries to enable auto-translation on an empty field"
+  },
+  "autoTranslate.error": {
+    "message": "自動翻訳の切り替えに失敗しました。再試行してください",
+    "description": "Fallback error toast when the enable/disable HTTP call fails with no detail"
   }
 }

--- a/src/i18n/ko/site.json
+++ b/src/i18n/ko/site.json
@@ -594,5 +594,33 @@
   "button.addUser": {
     "message": "추가",
     "description": "Button label to add the resolved user to the admins list."
+  },
+  "autoTranslate.tooltipOn": {
+    "message": "자동 번역 켜짐 — 콘텐츠가 방문자의 언어로 표시됩니다",
+    "description": "Tooltip on the auto-translate toggle when it is ON"
+  },
+  "autoTranslate.tooltipOff": {
+    "message": "리터럴 저장 — 자동 번역을 켜려면 클릭하세요",
+    "description": "Tooltip on the auto-translate toggle when it is OFF"
+  },
+  "autoTranslate.tooltipDisabledNotSaved": {
+    "message": "자동 번역을 켜기 전에 행을 저장하세요",
+    "description": "Tooltip shown when the toggle is disabled because the row has no id yet (create-dialog state)"
+  },
+  "autoTranslate.confirmEnable": {
+    "message": "이 콘텐츠는 약 1시간 이내에 17개 언어로 번역됩니다. 계속하시겠습니까?",
+    "description": "Body text of the confirm dialog shown before enabling auto-translation"
+  },
+  "autoTranslate.confirmDisable": {
+    "message": "비활성화하면 18개 언어의 모든 번역이 제거되고 현재 값만 유지됩니다. 계속하시겠습니까?",
+    "description": "Body text of the confirm dialog shown before disabling auto-translation"
+  },
+  "autoTranslate.empty": {
+    "message": "자동 번역을 켜기 전에 콘텐츠를 입력하세요",
+    "description": "Warning shown when the user tries to enable auto-translation on an empty field"
+  },
+  "autoTranslate.error": {
+    "message": "자동 번역을 전환하지 못했습니다. 다시 시도해 주세요",
+    "description": "Fallback error toast when the enable/disable HTTP call fails with no detail"
   }
 }

--- a/src/i18n/pl/site.json
+++ b/src/i18n/pl/site.json
@@ -594,5 +594,33 @@
   "button.addUser": {
     "message": "Dodaj",
     "description": "Button label to add the resolved user to the admins list."
+  },
+  "autoTranslate.tooltipOn": {
+    "message": "Automatyczne tłumaczenie WŁĄCZONE — treść wyświetla się w języku odwiedzającego",
+    "description": "Tooltip on the auto-translate toggle when it is ON"
+  },
+  "autoTranslate.tooltipOff": {
+    "message": "Zapis dosłowny — kliknij, aby włączyć automatyczne tłumaczenie",
+    "description": "Tooltip on the auto-translate toggle when it is OFF"
+  },
+  "autoTranslate.tooltipDisabledNotSaved": {
+    "message": "Zapisz wiersz przed włączeniem automatycznego tłumaczenia",
+    "description": "Tooltip shown when the toggle is disabled because the row has no id yet (create-dialog state)"
+  },
+  "autoTranslate.confirmEnable": {
+    "message": "Ta treść zostanie przetłumaczona na 17 języków w ciągu ~1 godziny. Kontynuować?",
+    "description": "Body text of the confirm dialog shown before enabling auto-translation"
+  },
+  "autoTranslate.confirmDisable": {
+    "message": "Wyłączenie usunie wszystkie 18 tłumaczeń i pozostawi tylko bieżącą wartość. Kontynuować?",
+    "description": "Body text of the confirm dialog shown before disabling auto-translation"
+  },
+  "autoTranslate.empty": {
+    "message": "Wprowadź jakąś treść przed włączeniem automatycznego tłumaczenia",
+    "description": "Warning shown when the user tries to enable auto-translation on an empty field"
+  },
+  "autoTranslate.error": {
+    "message": "Nie udało się przełączyć automatycznego tłumaczenia, spróbuj ponownie",
+    "description": "Fallback error toast when the enable/disable HTTP call fails with no detail"
   }
 }

--- a/src/i18n/pt/site.json
+++ b/src/i18n/pt/site.json
@@ -594,5 +594,33 @@
   "button.addUser": {
     "message": "Adicionar",
     "description": "Button label to add the resolved user to the admins list."
+  },
+  "autoTranslate.tooltipOn": {
+    "message": "Tradução automática ATIVADA — o conteúdo é exibido no idioma do visitante",
+    "description": "Tooltip on the auto-translate toggle when it is ON"
+  },
+  "autoTranslate.tooltipOff": {
+    "message": "Armazenamento literal — clique para ativar a tradução automática",
+    "description": "Tooltip on the auto-translate toggle when it is OFF"
+  },
+  "autoTranslate.tooltipDisabledNotSaved": {
+    "message": "Salve a linha antes de ativar a tradução automática",
+    "description": "Tooltip shown when the toggle is disabled because the row has no id yet (create-dialog state)"
+  },
+  "autoTranslate.confirmEnable": {
+    "message": "Este conteúdo será traduzido para 17 idiomas em cerca de 1 hora. Continuar?",
+    "description": "Body text of the confirm dialog shown before enabling auto-translation"
+  },
+  "autoTranslate.confirmDisable": {
+    "message": "Desativar removerá todas as 18 traduções de idioma, mantendo apenas o valor atual. Continuar?",
+    "description": "Body text of the confirm dialog shown before disabling auto-translation"
+  },
+  "autoTranslate.empty": {
+    "message": "Insira algum conteúdo antes de ativar a tradução automática",
+    "description": "Warning shown when the user tries to enable auto-translation on an empty field"
+  },
+  "autoTranslate.error": {
+    "message": "Falha ao alternar a tradução automática, tente novamente",
+    "description": "Fallback error toast when the enable/disable HTTP call fails with no detail"
   }
 }

--- a/src/i18n/ru/site.json
+++ b/src/i18n/ru/site.json
@@ -594,5 +594,33 @@
   "button.addUser": {
     "message": "Добавить",
     "description": "Button label to add the resolved user to the admins list."
+  },
+  "autoTranslate.tooltipOn": {
+    "message": "Автоперевод ВКЛЮЧЁН — контент отображается на языке посетителя",
+    "description": "Tooltip on the auto-translate toggle when it is ON"
+  },
+  "autoTranslate.tooltipOff": {
+    "message": "Литеральное хранение — нажмите, чтобы включить автоперевод",
+    "description": "Tooltip on the auto-translate toggle when it is OFF"
+  },
+  "autoTranslate.tooltipDisabledNotSaved": {
+    "message": "Сохраните строку перед включением автоперевода",
+    "description": "Tooltip shown when the toggle is disabled because the row has no id yet (create-dialog state)"
+  },
+  "autoTranslate.confirmEnable": {
+    "message": "Этот контент будет переведён на 17 языков примерно за 1 час. Продолжить?",
+    "description": "Body text of the confirm dialog shown before enabling auto-translation"
+  },
+  "autoTranslate.confirmDisable": {
+    "message": "Отключение удалит все 18 языковых переводов, оставив только текущее значение. Продолжить?",
+    "description": "Body text of the confirm dialog shown before disabling auto-translation"
+  },
+  "autoTranslate.empty": {
+    "message": "Введите содержимое перед включением автоперевода",
+    "description": "Warning shown when the user tries to enable auto-translation on an empty field"
+  },
+  "autoTranslate.error": {
+    "message": "Не удалось переключить автоперевод, попробуйте ещё раз",
+    "description": "Fallback error toast when the enable/disable HTTP call fails with no detail"
   }
 }

--- a/src/i18n/sr/site.json
+++ b/src/i18n/sr/site.json
@@ -594,5 +594,33 @@
   "button.addUser": {
     "message": "Dodaj",
     "description": "Button label to add the resolved user to the admins list."
+  },
+  "autoTranslate.tooltipOn": {
+    "message": "Aуто-превод УКЉУЧЕН — садржај се приказује на језику посетиоца",
+    "description": "Tooltip on the auto-translate toggle when it is ON"
+  },
+  "autoTranslate.tooltipOff": {
+    "message": "Дословни запис — кликните да укључите аутоматски превод",
+    "description": "Tooltip on the auto-translate toggle when it is OFF"
+  },
+  "autoTranslate.tooltipDisabledNotSaved": {
+    "message": "Сачувајте ред пре него што укључите аутоматски превод",
+    "description": "Tooltip shown when the toggle is disabled because the row has no id yet (create-dialog state)"
+  },
+  "autoTranslate.confirmEnable": {
+    "message": "Овај садржај ће бити преведен на 17 језика у року од ~1 сата. Наставити?",
+    "description": "Body text of the confirm dialog shown before enabling auto-translation"
+  },
+  "autoTranslate.confirmDisable": {
+    "message": "Искључивање брише свих 18 превода и задржава само тренутну вредност. Наставити?",
+    "description": "Body text of the confirm dialog shown before disabling auto-translation"
+  },
+  "autoTranslate.empty": {
+    "message": "Унесите неки садржај пре него што укључите аутоматски превод",
+    "description": "Warning shown when the user tries to enable auto-translation on an empty field"
+  },
+  "autoTranslate.error": {
+    "message": "Промена аутоматског превода није успела, покушајте поново",
+    "description": "Fallback error toast when the enable/disable HTTP call fails with no detail"
   }
 }

--- a/src/i18n/sv/site.json
+++ b/src/i18n/sv/site.json
@@ -594,5 +594,33 @@
   "button.addUser": {
     "message": "Lägg till",
     "description": "Button label to add the resolved user to the admins list."
+  },
+  "autoTranslate.tooltipOn": {
+    "message": "Automatisk översättning PÅ — innehållet visas på besökarens språk",
+    "description": "Tooltip on the auto-translate toggle when it is ON"
+  },
+  "autoTranslate.tooltipOff": {
+    "message": "Sparas ordagrant — klicka för att aktivera automatisk översättning",
+    "description": "Tooltip on the auto-translate toggle when it is OFF"
+  },
+  "autoTranslate.tooltipDisabledNotSaved": {
+    "message": "Spara raden innan du aktiverar automatisk översättning",
+    "description": "Tooltip shown when the toggle is disabled because the row has no id yet (create-dialog state)"
+  },
+  "autoTranslate.confirmEnable": {
+    "message": "Detta innehåll översätts till 17 språk inom ~1 timme. Fortsätt?",
+    "description": "Body text of the confirm dialog shown before enabling auto-translation"
+  },
+  "autoTranslate.confirmDisable": {
+    "message": "Inaktivering tar bort alla 18 översättningarna och behåller endast det aktuella värdet. Fortsätt?",
+    "description": "Body text of the confirm dialog shown before disabling auto-translation"
+  },
+  "autoTranslate.empty": {
+    "message": "Ange innehåll innan du aktiverar automatisk översättning",
+    "description": "Warning shown when the user tries to enable auto-translation on an empty field"
+  },
+  "autoTranslate.error": {
+    "message": "Det gick inte att växla automatisk översättning, försök igen",
+    "description": "Fallback error toast when the enable/disable HTTP call fails with no detail"
   }
 }

--- a/src/i18n/uk/site.json
+++ b/src/i18n/uk/site.json
@@ -594,5 +594,33 @@
   "button.addUser": {
     "message": "Додати",
     "description": "Button label to add the resolved user to the admins list."
+  },
+  "autoTranslate.tooltipOn": {
+    "message": "Автопереклад УВІМКНЕНО — вміст відображається мовою відвідувача",
+    "description": "Tooltip on the auto-translate toggle when it is ON"
+  },
+  "autoTranslate.tooltipOff": {
+    "message": "Зберігання дослівне — натисніть, щоб увімкнути автопереклад",
+    "description": "Tooltip on the auto-translate toggle when it is OFF"
+  },
+  "autoTranslate.tooltipDisabledNotSaved": {
+    "message": "Збережіть рядок, перш ніж вмикати автопереклад",
+    "description": "Tooltip shown when the toggle is disabled because the row has no id yet (create-dialog state)"
+  },
+  "autoTranslate.confirmEnable": {
+    "message": "Цей вміст буде перекладено на 17 мов протягом ~1 години. Продовжити?",
+    "description": "Body text of the confirm dialog shown before enabling auto-translation"
+  },
+  "autoTranslate.confirmDisable": {
+    "message": "Вимкнення видалить усі 18 перекладів і збереже лише поточне значення. Продовжити?",
+    "description": "Body text of the confirm dialog shown before disabling auto-translation"
+  },
+  "autoTranslate.empty": {
+    "message": "Введіть якийсь вміст, перш ніж вмикати автопереклад",
+    "description": "Warning shown when the user tries to enable auto-translation on an empty field"
+  },
+  "autoTranslate.error": {
+    "message": "Не вдалося перемкнути автопереклад, спробуйте знову",
+    "description": "Fallback error toast when the enable/disable HTTP call fails with no detail"
   }
 }

--- a/src/i18n/zh-CN/site.json
+++ b/src/i18n/zh-CN/site.json
@@ -594,5 +594,33 @@
   "button.addUser": {
     "message": "添加",
     "description": "Button label to add the resolved user to the admins list."
+  },
+  "autoTranslate.tooltipOn": {
+    "message": "已开启 — 内容将自动翻译为 17 种语言显示",
+    "description": "自动翻译切换按钮在开启状态下的 hover 提示"
+  },
+  "autoTranslate.tooltipOff": {
+    "message": "字面量存储 — 点击开启自动翻译为 17 种语言",
+    "description": "自动翻译切换按钮在关闭状态下的 hover 提示"
+  },
+  "autoTranslate.tooltipDisabledNotSaved": {
+    "message": "请先保存后再开启自动翻译",
+    "description": "在创建对话框中（尚未保存）按钮被禁用的提示"
+  },
+  "autoTranslate.confirmEnable": {
+    "message": "当前内容将被翻译为 17 种语言，约 1 小时生效。继续吗？",
+    "description": "点击开启自动翻译时的二次确认弹窗正文"
+  },
+  "autoTranslate.confirmDisable": {
+    "message": "关闭后将删除所有 18 种语言的翻译，仅保留当前编辑框内容。继续吗？",
+    "description": "点击关闭自动翻译时的二次确认弹窗正文"
+  },
+  "autoTranslate.empty": {
+    "message": "请先输入内容，再开启自动翻译",
+    "description": "字段为空时尝试开启自动翻译的警告提示"
+  },
+  "autoTranslate.error": {
+    "message": "切换自动翻译失败，请稍后重试",
+    "description": "切换自动翻译接口返回错误时的兜底文案"
   }
 }

--- a/src/i18n/zh-TW/site.json
+++ b/src/i18n/zh-TW/site.json
@@ -594,5 +594,33 @@
   "button.addUser": {
     "message": "新增",
     "description": "Button label to add the resolved user to the admins list."
+  },
+  "autoTranslate.tooltipOn": {
+    "message": "已啟用 — 內容將自動翻譯為 17 種語言顯示",
+    "description": "Tooltip on the auto-translate toggle when it is ON"
+  },
+  "autoTranslate.tooltipOff": {
+    "message": "字面量儲存 — 點擊啟用自動翻譯為 17 種語言",
+    "description": "Tooltip on the auto-translate toggle when it is OFF"
+  },
+  "autoTranslate.tooltipDisabledNotSaved": {
+    "message": "請先儲存後再啟用自動翻譯",
+    "description": "Tooltip shown when the toggle is disabled because the row has no id yet (create-dialog state)"
+  },
+  "autoTranslate.confirmEnable": {
+    "message": "目前內容將被翻譯為 17 種語言，約 1 小時生效。繼續嗎？",
+    "description": "Body text of the confirm dialog shown before enabling auto-translation"
+  },
+  "autoTranslate.confirmDisable": {
+    "message": "關閉後將刪除所有 18 種語言的翻譯，僅保留目前編輯框內容。繼續嗎？",
+    "description": "Body text of the confirm dialog shown before disabling auto-translation"
+  },
+  "autoTranslate.empty": {
+    "message": "請先輸入內容，再啟用自動翻譯",
+    "description": "Warning shown when the user tries to enable auto-translation on an empty field"
+  },
+  "autoTranslate.error": {
+    "message": "切換自動翻譯失敗，請稍後重試",
+    "description": "Fallback error toast when the enable/disable HTTP call fails with no detail"
   }
 }

--- a/src/models/site.ts
+++ b/src/models/site.ts
@@ -89,6 +89,16 @@ export interface ISite {
   metadata?: any;
   theme?: ISiteTheme | null;
   tags?: string[];
+  // Server-derived metadata for the per-field auto-translate toggle
+  // (PlatformBackend PR #511/#513). When a field is in
+  // ``auto_translated_fields``, the rendered column (``title`` /
+  // ``description``) is JSONLocalizationRenderer-evaluated to the
+  // viewer's language and the raw zh-cn source lives in the matching
+  // ``<field>_source`` key. When the toggle is OFF, ``<field>_source``
+  // mirrors the column. Read-only on the wire.
+  title_source?: string;
+  description_source?: string;
+  auto_translated_fields?: string[];
 }
 
 export interface ISiteListResponse {

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -22,6 +22,7 @@ export * from './hailuo';
 export * from './headshots';
 export * from './site';
 export * from './site_domain';
+export * from './translation';
 export * from './suno';
 export * from './producer';
 export * from './exchange';

--- a/src/operators/translation/index.ts
+++ b/src/operators/translation/index.ts
@@ -1,0 +1,2 @@
+export * from './models';
+export * from './operator';

--- a/src/operators/translation/models.ts
+++ b/src/operators/translation/models.ts
@@ -1,0 +1,48 @@
+/**
+ * Per-field auto-translate toggle — mirrors PlatformBackend's
+ * ``/api/v1/translations/`` endpoints (see PRs ``feat/translations-api``
+ * and ``feat/translations-serializer-bool``).
+ *
+ * The model + field pair is whitelisted server-side via the
+ * ``capabilities`` endpoint; only those (model, field) combinations
+ * may be flipped on/off. Enabling stores the literal into the
+ * ``Translation`` table (zh-cn source) and replaces the column with a
+ * ``$t(<key>)`` reference, which the ``translate.py`` cron then fans
+ * out to 17 locales. Disabling deletes all 18 locale rows and writes
+ * the literal back into the column.
+ */
+
+export interface ITranslationCapability {
+  model: string;
+  key_prefix: string;
+  fields: string[];
+}
+
+export interface ITranslationCapabilitiesResponse {
+  items: ITranslationCapability[];
+}
+
+export interface ITranslationEnableRequest {
+  model: string;
+  object_id: string;
+  field: string;
+  content: string;
+}
+
+export interface ITranslationEnableResponse {
+  key: string;
+  field_value: string;
+  source: string;
+  auto_translate: true;
+}
+
+export interface ITranslationDisableRequest {
+  model: string;
+  object_id: string;
+  field: string;
+}
+
+export interface ITranslationDisableResponse {
+  field_value: string | null;
+  auto_translate: false;
+}

--- a/src/operators/translation/operator.ts
+++ b/src/operators/translation/operator.ts
@@ -1,0 +1,27 @@
+import { AxiosResponse } from 'axios';
+import { httpClient } from '../common';
+import {
+  ITranslationCapabilitiesResponse,
+  ITranslationDisableRequest,
+  ITranslationDisableResponse,
+  ITranslationEnableRequest,
+  ITranslationEnableResponse
+} from './models';
+
+class TranslationOperator {
+  key = 'translations';
+
+  async getCapabilities(): Promise<AxiosResponse<ITranslationCapabilitiesResponse>> {
+    return await httpClient.get(`/${this.key}/capabilities/`);
+  }
+
+  async enable(payload: ITranslationEnableRequest): Promise<AxiosResponse<ITranslationEnableResponse>> {
+    return await httpClient.post(`/${this.key}/enable`, payload);
+  }
+
+  async disable(payload: ITranslationDisableRequest): Promise<AxiosResponse<ITranslationDisableResponse>> {
+    return await httpClient.post(`/${this.key}/disable`, payload);
+  }
+}
+
+export const translationOperator = new TranslationOperator();


### PR DESCRIPTION
## Summary

Subsite admins managing their site via Nexior previously had to switch
to the PlatformFrontend dev portal to flip auto-translate on `Site.title`
or `Site.description`. This PR ports the toggle into Nexior itself so
it lives next to the edit pencil on the **General** tab (title) and
the **SEO** tab (description).

## What changed

- **New operator** `src/operators/translation/` wrapping
  `/v1/translations/capabilities/`, `/v1/translations/enable`,
  `/v1/translations/disable` (mirrors PlatformFrontend's
  `translationOperator`).
- **New component** `src/components/site/AutoTranslateToggle.vue`
  (Options API, verbatim port of PlatformFrontend's
  `AutoTranslateToggle.vue` with cosmetic margin tweaks).
- **`ISite`** extended with `title_source`, `description_source`,
  `auto_translated_fields` (read-only fields surfaced by
  PlatformBackend #513).
- **`Site.vue` / `Seo.vue`**: the edit-text input is now bound to
  `title_source ?? title` / `description_source ?? description`,
  and the toggle sits in a flex row next to the edit pencil. When
  auto-translate is ON, the displayed value stays in sync with the
  source field, so editing it doesn't lose the translations.
- **i18n**: `autoTranslate.*` keys (`tooltipOn`, `tooltipOff`,
  `tooltipDisabledNotSaved`, `confirmEnable`, `confirmDisable`,
  `empty`, `error`) added to all 18 locales.
  - 11 locales (ar, de, en, es, fr, it, ja, ko, pt, ru, zh-TW) reshape-
    ported from the strings already shipped in PlatformFrontend #351.
  - 6 Nexior-exclusive locales (el, fi, pl, sr, sv, uk) hand-translated.
  - zh-CN and en authored from scratch.

## Backend / cross-stack

This PR depends on serializer fields added by **PlatformBackend
#513** (`title_source`, `description_source`,
`auto_translated_fields`) — already merged.

Endpoints used (`/v1/translations/enable` and `.../disable`) ship
in **PlatformBackend #511** — already merged.

## Mirrors

- PlatformFrontend #351 (General/Site title toggle)
- PlatformFrontend #352 (SEO/Description toggle)

## Validation

- `npm run lint` — clean
- `npm run build` — `vue-tsc -b` + `vite build` succeed
- `npm run test:run` — 104 / 104 pass
- `python3 scripts/check_i18n_coverage.py` — OK (17 locales × 39 namespaces)
- `npx beachball check` — OK (change file included)
