### PR TITLE
fix(veo): restrict aspect ratio selector to 16:9 and 9:16

### DIFF
--- a/src/components/veo/config/AspectRatioSelector.vue
+++ b/src/components/veo/config/AspectRatioSelector.vue
@@ -27,25 +27,8 @@ export default defineComponent({
   name: 'AspectRatioSelector',
   data() {
     return {
+      // Upstream Veo only supports 16:9 and 9:16; other ratios get rejected.
       options: [
-        {
-          value: '1:1',
-          label: '1:1',
-          width: 20,
-          height: 20
-        },
-        {
-          value: '4:3',
-          label: '4:3',
-          width: 20,
-          height: 15
-        },
-        {
-          value: '3:4',
-          label: '3:4',
-          width: 15,
-          height: 20
-        },
         {
           value: '16:9',
           label: '16:9',


### PR DESCRIPTION
## Why

Google Veo upstream only supports two aspect ratios: `16:9` and `9:16`. Anything else is rejected by the provider after credits are already reserved by the gateway, leaving the user with an opaque `upstream bizCode=unsupported_aspect_ratio, msg=1:1 is not supported, use 16:9 or 9:16` error.

Production trace `dc9871d7-3f76-474b-a39a-0c938b1be8ac` is one such case (UI sent `1:1` → mountsea returned 400). Independent verification against the cqtai upstream produced the same error.

## What

`AspectRatioSelector.vue` previously exposed five options: 1:1, 4:3, 3:4, 16:9, 9:16. This PR narrows the visible options to the two values Veo actually supports.

The default `VEO_DEFAULT_ASPECT_RATIO` is already `16:9`, so:

- New users → land on `16:9` (unchanged behavior).
- Existing users with a persisted invalid choice (`1:1`/`3:4`/`4:3` in `vuex-persistedstate`) → `computed.active` falls back to `0` (the first option), `mounted()` keeps the persisted value but the UI now highlights `16:9`. On next click the persisted value is overwritten with a valid one. No code change needed there.

## Companion PRs

- PlatformBackend (OpenAPI `aspect_ratio.enum`)
- PlatformService (mountsea / cqtai / wcnb worker validation)

## Test plan

- Open Veo card → only `16:9` and `9:16` rendered.
- Click `9:16` → `aspect_ratio: '9:16'` stored in `$store.veo.config`.
- Existing `localStorage` with `aspect_ratio: '1:1'` → card still loads, no crash, `16:9` shown as active.