### PR TITLE
fix(veo): tighten 16:9 / 9:16 ratio cards spacing

### DIFF
--- a/change/@acedatacloud-nexior-veo-aspect-ratio-layout.json
+++ b/change/@acedatacloud-nexior-veo-aspect-ratio-layout.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(veo): group 16:9 and 9:16 cards next to each other instead of spreading to opposite edges",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/veo/config/AspectRatioSelector.vue
+++ b/src/components/veo/config/AspectRatioSelector.vue
@@ -78,7 +78,8 @@ export default defineComponent({
   display: flex;
   flex-direction: row;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
+  gap: 10px;
 
   .item {
     width: 48px;


### PR DESCRIPTION
## Summary

After PR #783 narrowed the Veo aspect ratio selector to only `16:9` and `9:16`, the underlying flex layout still used `justify-content: space-between`, which was originally tuned for 5 cards (1:1, 4:3, 3:4, 16:9, 9:16). With only two cards left, the layout pushed them to opposite edges of the panel with a large empty gap in the middle — the two cards looked visually disconnected.

## Change

Switch `.items` from `justify-content: space-between` to `justify-content: flex-start` with a `gap: 10px` so the two surviving cards sit side-by-side at the left of the panel, matching the visual density of every other selector on the Veo config column.

```diff
 .items {
   display: flex;
   flex-direction: row;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
+  gap: 10px;
 }
```

## Visual

Before: `[16:9] ............................................. [9:16]`
After:  `[16:9] [9:16]`

## Touched files
- `src/components/veo/config/AspectRatioSelector.vue` — flex layout fix
- `change/@acedatacloud-nexior-veo-aspect-ratio-layout.json` — beachball patch entry

## Related
- Follow-up to #783 (which narrowed the option list)