### PR TITLE
ci(android): bump JAVA_VERSION to 21 for Capacitor 8

### DIFF
--- a/.github/workflows/build-android.yaml
+++ b/.github/workflows/build-android.yaml
@@ -22,7 +22,7 @@ permissions:
 
 env:
   NODE_VERSION: '22'
-  JAVA_VERSION: '17'
+  JAVA_VERSION: '21'
 
 jobs:
   build:


### PR DESCRIPTION
Capacitor Android 8 generates `capacitor.build.gradle` with `sourceCompatibility / targetCompatibility = JavaVersion.VERSION_21`. The current workflow's JDK 17 caused:

```
> Task :capacitor-android:compileReleaseJavaWithJavac FAILED
> Java compilation initialization error
    error: invalid source release: 21
```

Failing run: https://github.com/AceDataCloud/Nexior/actions/runs/26323464027

Bumping `JAVA_VERSION` env to `21` (Temurin via `actions/setup-java@v5`). Follow-up to #782.