### PR TITLE
chore(release): bump version to 3.35.1 (versionCode 33501)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -24,8 +24,8 @@ android {
         applicationId "com.acedatacloud.nexior"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 33500
-        versionName "3.35.0"
+        versionCode 33501
+        versionName "3.35.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -352,11 +352,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 33500;
+				CURRENT_PROJECT_VERSION = 33501;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 3.35.0;
+				MARKETING_VERSION = 3.35.1;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.acedatacloud.nexior;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -372,11 +372,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 33500;
+				CURRENT_PROJECT_VERSION = 33501;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 3.35.0;
+				MARKETING_VERSION = 3.35.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.acedatacloud.nexior;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acedatacloud/nexior",
-  "version": "3.35.0",
+  "version": "3.35.1",
   "author": "Ace Data Cloud <office@acedata.cloud>",
   "repository": {
     "type": "git",

--- a/src/constants/mobile.ts
+++ b/src/constants/mobile.ts
@@ -1,4 +1,4 @@
-export const MOBILE_APP_VERSION = '3.35.0';
+export const MOBILE_APP_VERSION = '3.35.1';
 
 export const MOBILE_ANDROID_DOWNLOAD_URL = 'https://cdn.acedata.cloud/2f29543715.apk';
 


### PR DESCRIPTION
## Why

Bump version 3.35.0 → 3.35.1 so the next `android-v*` tag produces a unique `versionCode 33501` and the Play Store upload step can complete (versionCode 33500 was consumed by the prior manual Production submission, see smoke test [26323829265](https://github.com/AceDataCloud/Nexior/actions/runs/26323829265)).

## Changes

`scripts/sync-native-version.js` derived from package.json:

| File | Before | After |
| --- | --- | --- |
| `package.json` version | 3.35.0 | 3.35.1 |
| `android/app/build.gradle` versionCode | 33500 | 33501 |
| `android/app/build.gradle` versionName | 3.35.0 | 3.35.1 |
| `ios/App/App.xcodeproj/project.pbxproj` MARKETING_VERSION | 3.35.0 | 3.35.1 |
| `ios/App/App.xcodeproj/project.pbxproj` CURRENT_PROJECT_VERSION | 33500 | 33501 |
| `src/constants/mobile.ts` MOBILE_APP_VERSION | 3.35.0 | 3.35.1 |

## After merge

Tag `android-v3.35.1` on main → Build Android workflow auto-runs → uploads to Play Store **internal** track. Production submission (3.35.0 / 33500, currently in Google review) is **unaffected**.