### PR TITLE
fix(ios): disable code signing for Pods targets

### DIFF
--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -22,4 +22,14 @@ end
 
 post_install do |installer|
   assertDeploymentTarget(installer)
+  # Disable code signing for Pods targets so manual signing of the App target
+  # (via xcodebuild PROVISIONING_PROFILE_SPECIFIER on CI) doesn't cascade to
+  # Capacitor frameworks, which don't support provisioning profiles.
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      config.build_settings['EXPANDED_CODE_SIGN_IDENTITY'] = ''
+      config.build_settings['CODE_SIGNING_REQUIRED'] = 'NO'
+      config.build_settings['CODE_SIGNING_ALLOWED'] = 'NO'
+    end
+  end
 end


### PR DESCRIPTION
## What

Extend Podfile `post_install` hook to set `CODE_SIGNING_ALLOWED=NO` and `CODE_SIGNING_REQUIRED=NO` on every Pods target.

## Why

The first iOS CI build (tag `ios-v3.35.1`, run `26324898293`) failed at `Build archive` with:

```
error: CapacitorBrowser does not support provisioning profiles, but
       provisioning profile *** has been manually specified.
```

`xcodebuild` applies command-line `PROVISIONING_PROFILE_SPECIFIER` to every target in the workspace, including Pods. Capacitor pod targets are dynamic frameworks that get embedded into the .ipa — they're code-signed by the App target's sign step, not individually. So they don't accept a provisioning profile.

The classic fix is to disable code signing for all Pods targets in the Podfile's `post_install` hook. Then xcodebuild's PROVISIONING_PROFILE_SPECIFIER becomes a no-op for pods, and only the App target gets signed with the AceData App Store profile.

## Test

Local: existing `pod install` workflow still works; no .pbxproj changes.

Remote: after merge, push tag `ios-v3.35.2` to re-trigger build-ios.yaml. Expected: 'Build archive' → 'Export IPA' → 'Upload to TestFlight' all green.

## Notes

- Production-tested fix used by every Capacitor / Cordova / Ionic iOS template since 2020.
- No effect on Debug builds via Xcode IDE (CODE_SIGNING_ALLOWED only matters when xcodebuild forces it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)