### PR TITLE
fix(ios): select Xcode 26+ before archive (App Store requires iOS 26 SDK)

### DIFF
--- a/.github/workflows/build-ios.yaml
+++ b/.github/workflows/build-ios.yaml
@@ -21,6 +21,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Select Xcode 26+
+        # App Store Connect requires the iOS 26 SDK (Xcode 26+) for uploads
+        # starting April 2026. The macos-15 runner default is Xcode 16.4 which
+        # ships with the iOS 18.5 SDK and altool will reject the build with a
+        # 409 "SDK version issue" validation error.
+        run: |
+          LATEST_XCODE=$(ls -d /Applications/Xcode_26*.app 2>/dev/null | sort -V | tail -1)
+          if [ -z "$LATEST_XCODE" ]; then
+            echo "::error::No Xcode 26+ found on runner. Available Xcodes:"
+            ls -d /Applications/Xcode_*.app
+            exit 1
+          fi
+          echo "Selecting $LATEST_XCODE"
+          sudo xcode-select -s "$LATEST_XCODE"
+          xcodebuild -version
+
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## What

Add a 'Select Xcode 26+' step to `.github/workflows/build-ios.yaml`. Picks the newest `/Applications/Xcode_26*.app` on the macos-15 runner and fails fast if none is installed.

## Why

The previous fix (#789) successfully archived and exported the .ipa. But `altool --upload-app` was rejected by App Store Connect with HTTP 409:

```
SDK version issue. This app was built with the iOS 18.5 SDK. All iOS
and iPadOS apps must be built with the iOS 26 SDK or later, included
in Xcode 26 or later, in order to be uploaded to App Store Connect
or submitted for distribution. (ID: fdc9e676-...)
```

GitHub macos-15 runners ship with Xcode 16.4 as default (iOS SDK 18.5). Apple's policy since April 2026 requires iOS 26 SDK / Xcode 26+ for App Store uploads.

## How

```yaml
- name: Select Xcode 26+
  run: |
    LATEST_XCODE=$(ls -d /Applications/Xcode_26*.app 2>/dev/null | sort -V | tail -1)
    if [ -z "$LATEST_XCODE" ]; then
      echo "::error::No Xcode 26+ found on runner."
      ls -d /Applications/Xcode_*.app
      exit 1
    fi
    sudo xcode-select -s "$LATEST_XCODE"
    xcodebuild -version
```

GitHub Actions `macos-15` runners have included Xcode 26 since [2026-04 image updates](https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md).

## Test

Local: workflow YAML is syntactically valid; no other steps changed.

Remote: after merge, re-push tag `ios-v3.35.1` to retrigger. Expect 'Upload to TestFlight' to succeed → build appears in App Store Connect TestFlight tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)