### PR TITLE
fix(ios): declare encryption exemption to avoid Missing Compliance

### DIFF
--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -20,6 +20,8 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>


### PR DESCRIPTION
## Why

After the first TestFlight upload (build 33501), App Store Connect flagged every
new build with **⚠️ Missing Compliance** until manually answered via the website
('Manage' → 'None of the algorithms mentioned above'). That manual step would
have to be repeated for every single upload (~weekly), which is pure friction.

## What

Adds `ITSAppUsesNonExemptEncryption=false` to `ios/App/App/Info.plist`.

Nexior only uses the iOS-provided HTTPS/TLS stack and Apple's standard
`URLSession`-based networking — there is no proprietary crypto, no
non-exempt encryption. Per Apple's encryption export rules (§740.17 EAR /
ECCN 5D992) that puts us under the standard exemption.

With this key set, ASC auto-accepts every uploaded build without the
manual compliance flow.

## Test plan

After merge:
1. Retag `ios-v3.35.1` (or bump to `3.35.2`).
2. CI uploads build → ASC.
3. New build should appear with green status (no Missing Compliance warning).

## Refs

- https://developer.apple.com/documentation/security/complying_with_encryption_export_regulations
- https://developer.apple.com/documentation/bundleresources/information_property_list/itsappusesnonexemptencryption