### PR TITLE
feat(setting/auth): add Apple to the provider list

### DIFF
--- a/src/components/setting/Auth.vue
+++ b/src/components/setting/Auth.vue
@@ -76,7 +76,7 @@ import type { ISiteAuth, ISiteAuthProvider } from '@/models';
 // honour this config. The ``username`` provider is intentionally
 // omitted — it's an internal/admin-only mechanism and not something
 // site owners should expose to end users.
-const PROVIDER_IDS = ['email', 'google', 'github', 'phone', 'wechat'] as const;
+const PROVIDER_IDS = ['email', 'google', 'github', 'apple', 'phone', 'wechat'] as const;
 type ProviderId = (typeof PROVIDER_IDS)[number];
 
 interface ProviderOption {

--- a/src/i18n/ar/site.json
+++ b/src/i18n/ar/site.json
@@ -71,6 +71,10 @@
     "message": "GitHub",
     "description": "اسم طريقة تسجيل الدخول: تسجيل الدخول عبر GitHub كطرف ثالث"
   },
+  "field.authProvider_apple": {
+    "message": "Apple",
+    "description": "Login provider display name: Sign in with Apple."
+  },
   "field.authProvider_wechat": {
     "message": "WeChat",
     "description": "اسم طريقة تسجيل الدخول: تسجيل الدخول عبر WeChat كطرف ثالث"

--- a/src/i18n/de/site.json
+++ b/src/i18n/de/site.json
@@ -71,6 +71,10 @@
     "message": "GitHub",
     "description": "Name der Anmeldemethode: GitHub-Third-Party-Anmeldung."
   },
+  "field.authProvider_apple": {
+    "message": "Apple",
+    "description": "Login provider display name: Sign in with Apple."
+  },
   "field.authProvider_wechat": {
     "message": "WeChat",
     "description": "Name der Anmeldemethode: WeChat-Third-Party-Anmeldung."

--- a/src/i18n/el/site.json
+++ b/src/i18n/el/site.json
@@ -71,6 +71,10 @@
     "message": "GitHub",
     "description": "Όνομα τρόπου σύνδεσης: Σύνδεση μέσω τρίτου μέρους GitHub"
   },
+  "field.authProvider_apple": {
+    "message": "Apple",
+    "description": "Login provider display name: Sign in with Apple."
+  },
   "field.authProvider_wechat": {
     "message": "WeChat",
     "description": "Όνομα τρόπου σύνδεσης: Σύνδεση μέσω τρίτου μέρους WeChat"

--- a/src/i18n/en/site.json
+++ b/src/i18n/en/site.json
@@ -71,6 +71,10 @@
     "message": "GitHub",
     "description": "Login provider display name: GitHub OAuth."
   },
+  "field.authProvider_apple": {
+    "message": "Apple",
+    "description": "Login provider display name: Sign in with Apple."
+  },
   "field.authProvider_wechat": {
     "message": "WeChat",
     "description": "Login provider display name: WeChat OAuth."

--- a/src/i18n/es/site.json
+++ b/src/i18n/es/site.json
@@ -71,6 +71,10 @@
     "message": "GitHub",
     "description": "Nombre del método de inicio de sesión: inicio de sesión de terceros con GitHub."
   },
+  "field.authProvider_apple": {
+    "message": "Apple",
+    "description": "Login provider display name: Sign in with Apple."
+  },
   "field.authProvider_wechat": {
     "message": "WeChat",
     "description": "Nombre del método de inicio de sesión: inicio de sesión de terceros con WeChat."

--- a/src/i18n/fi/site.json
+++ b/src/i18n/fi/site.json
@@ -71,6 +71,10 @@
     "message": "GitHub",
     "description": "Kirjautumistavan nimi: GitHub kolmannen osapuolen kirjautuminen"
   },
+  "field.authProvider_apple": {
+    "message": "Apple",
+    "description": "Login provider display name: Sign in with Apple."
+  },
   "field.authProvider_wechat": {
     "message": "WeChat",
     "description": "Kirjautumistavan nimi: WeChat kolmannen osapuolen kirjautuminen"

--- a/src/i18n/fr/site.json
+++ b/src/i18n/fr/site.json
@@ -71,6 +71,10 @@
     "message": "GitHub",
     "description": "Nom de la méthode de connexion : Connexion tierce GitHub"
   },
+  "field.authProvider_apple": {
+    "message": "Apple",
+    "description": "Login provider display name: Sign in with Apple."
+  },
   "field.authProvider_wechat": {
     "message": "WeChat",
     "description": "Nom de la méthode de connexion : Connexion tierce WeChat"

--- a/src/i18n/it/site.json
+++ b/src/i18n/it/site.json
@@ -71,6 +71,10 @@
     "message": "GitHub",
     "description": "Nome del metodo di accesso: accesso di terze parti tramite GitHub"
   },
+  "field.authProvider_apple": {
+    "message": "Apple",
+    "description": "Login provider display name: Sign in with Apple."
+  },
   "field.authProvider_wechat": {
     "message": "WeChat",
     "description": "Nome del metodo di accesso: accesso di terze parti tramite WeChat"

--- a/src/i18n/ja/site.json
+++ b/src/i18n/ja/site.json
@@ -71,6 +71,10 @@
     "message": "GitHub",
     "description": "ログイン方式名：GitHubのサードパーティログイン"
   },
+  "field.authProvider_apple": {
+    "message": "Apple",
+    "description": "Login provider display name: Sign in with Apple."
+  },
   "field.authProvider_wechat": {
     "message": "WeChat",
     "description": "ログイン方式名：WeChatのサードパーティログイン"

--- a/src/i18n/ko/site.json
+++ b/src/i18n/ko/site.json
@@ -71,6 +71,10 @@
     "message": "GitHub",
     "description": "로그인 방식 이름: GitHub 제3자 로그인"
   },
+  "field.authProvider_apple": {
+    "message": "Apple",
+    "description": "Login provider display name: Sign in with Apple."
+  },
   "field.authProvider_wechat": {
     "message": "WeChat",
     "description": "로그인 방식 이름: WeChat 제3자 로그인"

--- a/src/i18n/pl/site.json
+++ b/src/i18n/pl/site.json
@@ -71,6 +71,10 @@
     "message": "GitHub",
     "description": "Nazwa sposobu logowania: logowanie przez GitHub"
   },
+  "field.authProvider_apple": {
+    "message": "Apple",
+    "description": "Login provider display name: Sign in with Apple."
+  },
   "field.authProvider_wechat": {
     "message": "WeChat",
     "description": "Nazwa sposobu logowania: logowanie przez WeChat"

--- a/src/i18n/pt/site.json
+++ b/src/i18n/pt/site.json
@@ -71,6 +71,10 @@
     "message": "GitHub",
     "description": "Nome do método de login: Login de terceiros com GitHub"
   },
+  "field.authProvider_apple": {
+    "message": "Apple",
+    "description": "Login provider display name: Sign in with Apple."
+  },
   "field.authProvider_wechat": {
     "message": "WeChat",
     "description": "Nome do método de login: Login de terceiros com WeChat"

--- a/src/i18n/ru/site.json
+++ b/src/i18n/ru/site.json
@@ -71,6 +71,10 @@
     "message": "GitHub",
     "description": "Название способа входа: сторонний вход через GitHub."
   },
+  "field.authProvider_apple": {
+    "message": "Apple",
+    "description": "Login provider display name: Sign in with Apple."
+  },
   "field.authProvider_wechat": {
     "message": "WeChat",
     "description": "Название способа входа: сторонний вход через WeChat."

--- a/src/i18n/sr/site.json
+++ b/src/i18n/sr/site.json
@@ -71,6 +71,10 @@
     "message": "GitHub",
     "description": "Naziv načina prijave: GitHub treća strana"
   },
+  "field.authProvider_apple": {
+    "message": "Apple",
+    "description": "Login provider display name: Sign in with Apple."
+  },
   "field.authProvider_wechat": {
     "message": "WeChat",
     "description": "Naziv načina prijave: WeChat treća strana"

--- a/src/i18n/sv/site.json
+++ b/src/i18n/sv/site.json
@@ -71,6 +71,10 @@
     "message": "GitHub",
     "description": "Namn på inloggningsmetod: GitHub tredjepartsinloggning"
   },
+  "field.authProvider_apple": {
+    "message": "Apple",
+    "description": "Login provider display name: Sign in with Apple."
+  },
   "field.authProvider_wechat": {
     "message": "WeChat",
     "description": "Namn på inloggningsmetod: WeChat tredjepartsinloggning"

--- a/src/i18n/uk/site.json
+++ b/src/i18n/uk/site.json
@@ -71,6 +71,10 @@
     "message": "GitHub",
     "description": "Назва типу авторизації: стороння авторизація через GitHub."
   },
+  "field.authProvider_apple": {
+    "message": "Apple",
+    "description": "Login provider display name: Sign in with Apple."
+  },
   "field.authProvider_wechat": {
     "message": "WeChat",
     "description": "Назва типу авторизації: стороння авторизація через WeChat."

--- a/src/i18n/zh-CN/site.json
+++ b/src/i18n/zh-CN/site.json
@@ -71,6 +71,10 @@
     "message": "GitHub",
     "description": "登录方式名称：GitHub 第三方登录"
   },
+  "field.authProvider_apple": {
+    "message": "Apple",
+    "description": "登录方式名称：Sign in with Apple；保留英文品牌名 'Apple' 不翻译"
+  },
   "field.authProvider_wechat": {
     "message": "微信",
     "description": "登录方式名称：微信第三方登录"

--- a/src/i18n/zh-TW/site.json
+++ b/src/i18n/zh-TW/site.json
@@ -71,6 +71,10 @@
     "message": "GitHub",
     "description": "登入方式名稱：GitHub 第三方登入"
   },
+  "field.authProvider_apple": {
+    "message": "Apple",
+    "description": "Login provider display name: Sign in with Apple."
+  },
   "field.authProvider_wechat": {
     "message": "微信",
     "description": "登入方式名稱：微信第三方登入"

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -19,7 +19,7 @@ export interface IUserListResponse {
 
 export interface IUserDetailResponse extends IUser {}
 
-export type IUserPublicRegistrationMethod = 'email' | 'phone' | 'github' | 'google' | 'wechat' | 'username' | 'unknown';
+export type IUserPublicRegistrationMethod = 'email' | 'phone' | 'github' | 'google' | 'apple' | 'wechat' | 'username' | 'unknown';
 
 export interface IUserPublic {
   id: string;


### PR DESCRIPTION
Now that AuthFrontend ships a working Sign in with Apple flow, **Apple** needs to appear in Nexior's own Auth settings panel.

## Changes

- `PROVIDER_IDS` gains `'apple'` (inserted between `github` and `phone`) — adds an **Apple** row to the Auth settings list and to the default-provider dropdown
- `IUserPublicRegistrationMethod` adds `'apple'`
- `site.field.authProvider_apple` i18n key in **zh-CN + en only** (per project rules — other locales get translated by the CronJob)

## Why

Without this entry:
- The settings page silently omits an Apple row
- The `registration_method` returned by the API would be mis-categorized as `'unknown'` on the client

## Pairs with

- AuthBackend https://github.com/AceDataCloud/AuthBackend/pull/152 — `POST /users/me/update-apple/` endpoint
- AuthFrontend https://github.com/AceDataCloud/AuthFrontend/pull/127 — Apple bind row in user profile Third Party panel