### PR TITLE
feat(chat): auto-resume consent card on OAuth return

### DIFF
--- a/change/@acedatacloud-nexior-consent-return-pr6.json
+++ b/change/@acedatacloud-nexior-consent-return-pr6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(chat): auto-resume consent card on OAuth return via ?consent&connector deep-link",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/consentReturn.test.ts
+++ b/src/components/chat/consentReturn.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest';
+import { buildAuthorizedConsentOutput, findPendingConsentBlock, parseConsentReturnFromQuery } from './consentReturn';
+import { ROLE_ASSISTANT, ROLE_USER } from '@/constants/chat';
+import type { IChatMessage, IConsentRequestPayload } from '@/models';
+
+const PAYLOAD: IConsentRequestPayload = {
+  consent_request_id: 'consent_abc',
+  requirements: [
+    {
+      requirement_index: 0,
+      match: 'any',
+      satisfied: false,
+      entries: [
+        { connector: 'acedatacloud/gmail', status: 'unconnected', install_url: 'https://x/g' },
+        { connector: 'acedatacloud/outlook', status: 'unconnected', install_url: 'https://x/o' }
+      ]
+    }
+  ]
+};
+
+function awaitingBlock(toolUseId: string, payload: IConsentRequestPayload) {
+  return {
+    type: 'tool_use' as const,
+    tool_id: toolUseId,
+    tool_name: 'get_connector_status',
+    status: 'awaiting_input' as const,
+    pending_consent_request: payload
+  };
+}
+
+describe('parseConsentReturnFromQuery', () => {
+  it('extracts both params when present', () => {
+    expect(parseConsentReturnFromQuery({ consent: 'consent_abc', connector: 'acedatacloud/gmail' })).toEqual({
+      consentRequestId: 'consent_abc',
+      connector: 'acedatacloud/gmail'
+    });
+  });
+
+  it('returns null when either param is missing', () => {
+    expect(parseConsentReturnFromQuery({ consent: 'x' })).toBeNull();
+    expect(parseConsentReturnFromQuery({ connector: 'y' })).toBeNull();
+    expect(parseConsentReturnFromQuery({})).toBeNull();
+  });
+
+  it('returns null on empty / whitespace values', () => {
+    expect(parseConsentReturnFromQuery({ consent: '', connector: 'y' })).toBeNull();
+    expect(parseConsentReturnFromQuery({ consent: '   ', connector: 'y' })).toBeNull();
+  });
+
+  it('unwraps the first entry of an array-shaped query value', () => {
+    expect(
+      parseConsentReturnFromQuery({
+        consent: ['consent_abc', 'consent_other'],
+        connector: ['acedatacloud/gmail']
+      })
+    ).toEqual({ consentRequestId: 'consent_abc', connector: 'acedatacloud/gmail' });
+  });
+
+  it('ignores non-string types', () => {
+    // @ts-expect-error — intentionally pass invalid value shapes
+    expect(parseConsentReturnFromQuery({ consent: 123, connector: 'y' })).toBeNull();
+    expect(parseConsentReturnFromQuery({ consent: null, connector: undefined })).toBeNull();
+  });
+});
+
+describe('findPendingConsentBlock', () => {
+  it('returns the toolUseId + payload when the latest assistant has an awaiting block', () => {
+    const messages: IChatMessage[] = [
+      { role: ROLE_USER, content: 'send mail' },
+      {
+        role: ROLE_ASSISTANT,
+        content: [{ type: 'text', text: 'Need consent' }, awaitingBlock('tool_xyz', PAYLOAD)]
+      }
+    ];
+    expect(findPendingConsentBlock(messages, 'consent_abc')).toEqual({
+      toolUseId: 'tool_xyz',
+      payload: PAYLOAD
+    });
+  });
+
+  it('returns null when consent_request_id mismatches', () => {
+    const messages: IChatMessage[] = [
+      {
+        role: ROLE_ASSISTANT,
+        content: [awaitingBlock('tool_xyz', PAYLOAD)]
+      }
+    ];
+    expect(findPendingConsentBlock(messages, 'consent_other')).toBeNull();
+  });
+
+  it('returns null when the block is already done', () => {
+    const messages: IChatMessage[] = [
+      {
+        role: ROLE_ASSISTANT,
+        content: [
+          {
+            type: 'tool_use',
+            tool_id: 'tool_xyz',
+            tool_name: 'get_connector_status',
+            status: 'done',
+            pending_consent_request: PAYLOAD,
+            output: '{}'
+          }
+        ]
+      }
+    ];
+    expect(findPendingConsentBlock(messages, 'consent_abc')).toBeNull();
+  });
+
+  it('returns null when the tool name does not match', () => {
+    const messages: IChatMessage[] = [
+      {
+        role: ROLE_ASSISTANT,
+        content: [
+          {
+            type: 'tool_use',
+            tool_id: 'tool_xyz',
+            tool_name: 'ask_user_question',
+            status: 'awaiting_input'
+          }
+        ]
+      }
+    ];
+    expect(findPendingConsentBlock(messages, 'consent_abc')).toBeNull();
+  });
+
+  it('only inspects the latest assistant message', () => {
+    // An older assistant turn carries the awaiting block (shouldn't
+    // happen by the worker contract — only the tail can be awaiting —
+    // but we lock the invariant so a misbehaving server can't pull a
+    // stale block into a resumed turn).
+    const messages: IChatMessage[] = [
+      {
+        role: ROLE_ASSISTANT,
+        content: [awaitingBlock('tool_old', PAYLOAD)]
+      },
+      { role: ROLE_USER, content: 'next' },
+      { role: ROLE_ASSISTANT, content: [{ type: 'text', text: 'Done' }] }
+    ];
+    expect(findPendingConsentBlock(messages, 'consent_abc')).toBeNull();
+  });
+
+  it('returns null for an empty messages array', () => {
+    expect(findPendingConsentBlock([], 'consent_abc')).toBeNull();
+  });
+});
+
+describe('buildAuthorizedConsentOutput', () => {
+  it('marks one connector authorized and leaves skipped empty', () => {
+    const raw = buildAuthorizedConsentOutput(PAYLOAD, 'acedatacloud/gmail');
+    expect(JSON.parse(raw)).toEqual({
+      consent_request_id: 'consent_abc',
+      authorized: ['acedatacloud/gmail'],
+      skipped: []
+    });
+  });
+
+  it('echoes the consent_request_id verbatim', () => {
+    const payload: IConsentRequestPayload = {
+      consent_request_id: 'consent_other-id_42',
+      requirements: []
+    };
+    const raw = buildAuthorizedConsentOutput(payload, 'acedatacloud/slack');
+    expect(JSON.parse(raw)).toEqual({
+      consent_request_id: 'consent_other-id_42',
+      authorized: ['acedatacloud/slack'],
+      skipped: []
+    });
+  });
+});

--- a/src/components/chat/consentReturn.ts
+++ b/src/components/chat/consentReturn.ts
@@ -1,0 +1,100 @@
+import type { IChatMessage, IChatMessageContentItem, IConsentRequestPayload } from '@/models';
+// Direct subpath import (bypasses the `@/constants` barrel) so this
+// module — and its consumer ``Conversation.vue`` — can be unit-tested
+// under Node's default vitest environment. The barrel pulls in
+// ``endpoint.ts`` which references ``window.location.origin`` at load,
+// requiring a jsdom env for any importer otherwise.
+import { ROLE_ASSISTANT } from '@/constants/chat';
+import { buildConsentOutput } from './connectorConsent';
+
+/**
+ * Parsed pair of deep-link query params left over after AuthBackend
+ * completes an OAuth round-trip initiated from the consent card:
+ *
+ *   /chat/c/<conversation>?consent=<request-id>&connector=<identifier>
+ *
+ * `consent` is the original `consent_request_id` emitted by PR-3's
+ * `get_connector_status` tool; `connector` is the canonical catalog
+ * identifier of the connector the user just authorized — stamped onto
+ * `return_to` by AuthFrontend's `/connections/install/:id` page (the
+ * worker omits it because the OAuth state machine doesn't round-trip
+ * the identifier).
+ */
+export interface IConsentReturn {
+  consentRequestId: string;
+  connector: string;
+}
+
+function pickStr(v: unknown): string | null {
+  if (typeof v === 'string' && v.trim().length > 0) return v;
+  if (Array.isArray(v) && typeof v[0] === 'string' && (v[0] as string).trim().length > 0) {
+    return v[0] as string;
+  }
+  return null;
+}
+
+/**
+ * Read `?consent=` + `?connector=` from a Vue Router query bag and
+ * return them as a `{ consentRequestId, connector }` pair. Returns
+ * `null` when either is missing or non-string so the caller can short
+ * the auto-resume path cleanly.
+ */
+export function parseConsentReturnFromQuery(
+  query: Record<string, string | string[] | undefined | null>
+): IConsentReturn | null {
+  const consent = pickStr(query.consent);
+  const connector = pickStr(query.connector);
+  if (!consent || !connector) return null;
+  return { consentRequestId: consent, connector };
+}
+
+/**
+ * Walk backwards through `messages` looking for the assistant message
+ * whose last tool_use block:
+ *   - was called via `get_connector_status`,
+ *   - is still `awaiting_input` (i.e. not yet folded by a prior
+ *     resume),
+ *   - and whose `pending_consent_request.consent_request_id` matches
+ *     `consentRequestId`.
+ *
+ * Returns `null` when no such block exists (already resolved, never
+ * existed, or messages haven't loaded yet — the caller treats that as
+ * "try again on the next messages mutation"). Only the latest
+ * assistant message can carry an awaiting consent block — the worker
+ * pauses the turn — so we break after the first assistant scan.
+ */
+export function findPendingConsentBlock(
+  messages: IChatMessage[],
+  consentRequestId: string
+): { toolUseId: string; payload: IConsentRequestPayload } | null {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (m.role !== ROLE_ASSISTANT) continue;
+    if (!Array.isArray(m.content)) continue;
+    for (let j = m.content.length - 1; j >= 0; j--) {
+      const block = m.content[j] as IChatMessageContentItem;
+      if (block.type !== 'tool_use') continue;
+      if (block.tool_name !== 'get_connector_status') continue;
+      if (block.status !== 'awaiting_input') continue;
+      const payload = block.pending_consent_request;
+      if (!payload || payload.consent_request_id !== consentRequestId) continue;
+      if (!block.tool_id) continue;
+      return { toolUseId: block.tool_id, payload };
+    }
+    break;
+  }
+  return null;
+}
+
+/**
+ * Build the `tool_results[0].output` JSON that resumes the paused
+ * `get_connector_status` block after a successful OAuth round-trip.
+ * Marks the just-authorized `connector` as ``authorized`` and leaves
+ * ``skipped`` empty — if other unsatisfied requirements remain, the
+ * worker will re-pause with a fresh consent card so the user can
+ * authorize them one at a time. The worker dedupes resumes by
+ * `tool_use_id`, so an idempotent retry from a refresh is safe.
+ */
+export function buildAuthorizedConsentOutput(payload: IConsentRequestPayload, authorizedConnector: string): string {
+  return buildConsentOutput(payload, [authorizedConnector], []);
+}

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -82,6 +82,12 @@ import Disclaimer from '@/components/chat/Disclaimer.vue';
 import Layout from '@/layouts/Chat.vue';
 import { isImageUrl } from '@/utils/is';
 import { IAskUserQuestionPayload, IChatMessageContentItem, IConsentRequestPayload } from '@/models';
+import {
+  buildAuthorizedConsentOutput,
+  findPendingConsentBlock,
+  parseConsentReturnFromQuery,
+  type IConsentReturn
+} from '@/components/chat/consentReturn';
 import { chatOperator, agentOperator } from '@/operators';
 import { ElTooltip, ElButton } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
@@ -111,6 +117,15 @@ export interface IData {
    * locally” and skip the otherwise-redundant `retrieve` call.
    */
   skipNextRestoreId: string | undefined;
+  /**
+   * Stashed on mount from the `?consent=&connector=` deep-link the
+   * AuthFrontend install page redirects back to after a successful
+   * OAuth round-trip. The `messages` watcher consumes it as soon as
+   * the matching awaiting `get_connector_status` block is in the
+   * conversation, then clears it. Set to ``null`` when there's no
+   * pending return (the common case).
+   */
+  pendingConsentReturn: IConsentReturn | null;
 }
 
 export default defineComponent({
@@ -141,7 +156,8 @@ export default defineComponent({
       agentToolCount: 0,
       agentConnectedAt: '',
       skipNextRestoreId: undefined,
-      messages: []
+      messages: [],
+      pendingConsentReturn: null
     };
   },
   computed: {
@@ -232,9 +248,33 @@ export default defineComponent({
         return;
       }
       await this.onRestoreCurrentConversation();
+    },
+    /**
+     * Consent-return auto-resume: after the AuthFrontend install page
+     * completes a successful OAuth round-trip it redirects back to
+     * ``/chat/c/<conv>?consent=<rid>&connector=<id>``. ``mounted``
+     * stashes that pair on ``pendingConsentReturn`` and this watcher
+     * fires every time ``messages`` mutates (e.g. once
+     * ``onRestoreCurrentConversation`` finishes populating the
+     * restored history). The body is a cheap no-op while the pending
+     * return is null, so leaving it on a deep-less `messages` watcher
+     * during a streaming turn costs nothing.
+     */
+    messages: {
+      handler() {
+        if (!this.pendingConsentReturn) return;
+        this.onConsumePendingConsentReturn();
+      },
+      deep: false
     }
   },
   async mounted() {
+    // Stash the deep-link return params BEFORE anything else touches the
+    // route — `onApplyQueryFromUrl` (further down) strips `connector` from
+    // the URL as part of Studio's Try-It chip cleanup, so we have to grab
+    // our copy first. Strip happens later in `onConsumePendingConsentReturn`
+    // once we've successfully resumed the paused tool_use block.
+    this.onCaptureConsentReturnFromUrl();
     await this.onGetService();
     await this.onGetApplication();
     this.onConsumePendingDraft();
@@ -737,10 +777,19 @@ export default defineComponent({
       );
     },
     /**
-     * Open the connector's OAuth install URL. Desktop default: pop a new
-     * window; PR-6 will wire `postMessage` from the popup back to here so
-     * the card can auto-resume with `authorized=[<connector>]` once the
-     * connection is active.
+     * Open the connector's OAuth install URL. PR-6: navigate the
+     * current tab to the AuthFrontend deep-link install page rather
+     * than popping a new window. AuthFrontend completes the OAuth
+     * dance and redirects back here with
+     * ``?consent=<rid>&connector=<id>``; the `messages` watcher then
+     * spots the matching awaiting `get_connector_status` block and
+     * resumes the paused turn automatically (see
+     * ``onConsumePendingConsentReturn``).
+     *
+     * Same-tab nav loses any unsaved composer draft, which is
+     * acceptable for the consent flow: the user clicked Authorize
+     * deliberately and the rest of the conversation is persisted
+     * server-side and restored on return.
      */
     onAuthorizeConnector(payload: { tool_use_id: string; entry: { connector: string; install_url?: string } }) {
       const url = payload.entry?.install_url;
@@ -748,7 +797,68 @@ export default defineComponent({
         console.warn('authorize click with no install_url', payload);
         return;
       }
-      window.open(url, '_blank', 'noopener,noreferrer');
+      window.location.href = url;
+    },
+    /**
+     * Stash any ``?consent=<rid>&connector=<id>`` pair on
+     * ``pendingConsentReturn`` so the `messages` watcher can match
+     * them against the restored history. Called from ``mounted``
+     * BEFORE ``onApplyQueryFromUrl`` strips ``connector`` as part of
+     * Studio's Try-It chip cleanup. Safe to call on every mount —
+     * URLs without both params are simply ignored.
+     */
+    onCaptureConsentReturnFromUrl() {
+      const parsed = parseConsentReturnFromQuery(
+        (this.$route.query || {}) as Record<string, string | string[] | undefined | null>
+      );
+      if (!parsed) return;
+      this.pendingConsentReturn = parsed;
+    },
+    /**
+     * Try to consume ``pendingConsentReturn`` by locating the matching
+     * awaiting ``get_connector_status`` block in ``messages`` and
+     * dispatching ``onRespondConnectorConsent`` with the just-authorized
+     * connector. Called by the `messages` watcher on every mutation so
+     * we run as soon as ``onRestoreCurrentConversation`` populates the
+     * restored history.
+     *
+     * The block search is bounded to the latest assistant message — by
+     * the worker contract only the tail can carry an awaiting block —
+     * so the watcher hot-path stays O(1) for a typical assistant
+     * content array. ``pendingConsentReturn`` is cleared BEFORE
+     * dispatching the resume so that the new messages mutations from
+     * ``onRespondConnectorConsent`` (which folds the block and pushes
+     * a fresh pending assistant) re-enter this watcher as cheap no-ops
+     * instead of double-dispatching.
+     */
+    onConsumePendingConsentReturn() {
+      const pending = this.pendingConsentReturn;
+      if (!pending) return;
+      if (this.messages.length === 0) return;
+      const found = findPendingConsentBlock(this.messages, pending.consentRequestId);
+      if (!found) return;
+      this.pendingConsentReturn = null;
+      const output = buildAuthorizedConsentOutput(found.payload, pending.connector);
+      this.stripConsentReturnFromUrl();
+      this.onRespondConnectorConsent({
+        tool_use_id: found.toolUseId,
+        output
+      });
+    },
+    /**
+     * Drop the ``consent`` + ``connector`` deep-link params from the
+     * URL via ``router.replace`` so a manual refresh after the resume
+     * doesn't replay the request. Keeps any unrelated query keys the
+     * route may pick up in the future.
+     */
+    stripConsentReturnFromUrl() {
+      const query: Record<string, string | string[]> = {};
+      for (const [k, v] of Object.entries(this.$route.query || {})) {
+        if (k === 'consent' || k === 'connector') continue;
+        if (v == null) continue;
+        query[k] = v as string | string[];
+      }
+      this.$router.replace({ path: this.$route.path, query });
     },
     /**
      * Shared SSE-driven assistant-turn streamer. Handles deltas, tool_use,


### PR DESCRIPTION
## Summary

PR-6b of the connector-consent roadmap. Wires the final hop so the consent card emitted by [PR-5 #792](https://github.com/AceDataCloud/Nexior/pull/792) actually closes the loop after the user finishes the OAuth round-trip.

**Today (after PR-5):** user clicks Authorize on the consent card → a new tab opens at `auth.acedata.cloud/connections/install/<catalog>` → OAuth succeeds → connection lands → **the original tab is still stuck on the awaiting card**. Worker never learns the user is done.

**With this PR:** Same-tab nav from Authorize → AuthFrontend completes OAuth → redirects back to `/chat/c/<conv>?consent=<rid>&connector=<id>` → `Conversation.vue` captures the pair, matches the awaiting `get_connector_status` block by `consent_request_id`, and dispatches `onRespondConnectorConsent({ authorized: [<connector>], skipped: [] })`. Worker dedupes by `tool_use_id`, marks the requirement satisfied (or re-pauses with a fresh card if other requirements remain), turn resumes.

Pairs with **[AuthFrontend PR #126](https://github.com/AceDataCloud/AuthFrontend/pull/126)** which is the deep-link `/connections/install/:id` landing page that stamps `&connector=<id>` onto `return_to` and POSTs the install on the user's behalf.

## Roadmap status

| # | Repo | PR | Status |
|---|---|---|---|
| 1 | AuthBackend | [#149](https://github.com/AceDataCloud/AuthBackend/pull/149) | merged |
| 2 | PlatformService | [#918](https://github.com/AceDataCloud/PlatformService/pull/918) | merged |
| 3 | PlatformService | [#919](https://github.com/AceDataCloud/PlatformService/pull/919) | merged |
| 4 | PlatformService | [#920](https://github.com/AceDataCloud/PlatformService/pull/920) | merged |
| 5 | Nexior | [#792](https://github.com/AceDataCloud/Nexior/pull/792) | merged |
| 6a | AuthFrontend | [#126](https://github.com/AceDataCloud/AuthFrontend/pull/126) | open |
| **6b** | **Nexior** | **this PR** | open |

## Files

- ` + "`" + `src/components/chat/consentReturn.ts` + "`" + ` (new):
  - ` + "`" + `parseConsentReturnFromQuery` + "`" + ` — extract & validate ` + "`" + `?consent` + "`" + ` + ` + "`" + `?connector` + "`" + ` from ` + "`" + `\$route.query` + "`" + `.
  - ` + "`" + `findPendingConsentBlock` + "`" + ` — locate the matching awaiting ` + "`" + `get_connector_status` + "`" + ` block in the latest assistant message. O(1) in the content array because by the worker contract only the tail can carry an awaiting block.
  - ` + "`" + `buildAuthorizedConsentOutput` + "`" + ` — thin wrapper over PR-5's ` + "`" + `buildConsentOutput` + "`" + ` that marks one connector authorized with ` + "`" + `skipped: []` + "`" + ` so multi-requirement requests can be authorized one connector at a time across successive OAuth round-trips.
- ` + "`" + `src/components/chat/consentReturn.test.ts` + "`" + ` (new): 13 unit tests covering query parse edge cases, block lookup variants (mismatched id / wrong tool name / done status / older assistant turn / empty messages), and the authorized-output JSON shape.
- ` + "`" + `src/pages/chat/Conversation.vue` + "`" + `:
  - New ` + "`" + `pendingConsentReturn: IConsentReturn | null` + "`" + ` field, initialised null.
  - ` + "`" + `mounted()` + "`" + ` calls ` + "`" + `onCaptureConsentReturnFromUrl()` + "`" + ` **first** — before ` + "`" + `onApplyQueryFromUrl` + "`" + ` strips ` + "`" + `connector` + "`" + ` as part of Studio's Try-It chip cleanup.
  - New ` + "`" + `messages` + "`" + ` watcher (deep: false) — cheap no-op while pending is null, dispatches ` + "`" + `onConsumePendingConsentReturn` + "`" + ` once the restored history is in.
  - ` + "`" + `onAuthorizeConnector` + "`" + ` switched from ` + "`" + `window.open(_blank)` + "`" + ` → ` + "`" + `window.location.href` + "`" + ` so the OAuth round-trip returns the *same* tab, keeping the conversation in view.
  - ` + "`" + `stripConsentReturnFromUrl` + "`" + ` removes the deep-link params via ` + "`" + `router.replace` + "`" + ` after a successful resume so a manual refresh doesn't replay the dispatch.

## Design notes

- ` + "`" + `skipped: []` + "`" + ` (not the full unconnected list) so multi-requirement consent requests can be authorized one connector at a time across successive OAuth round-trips, with the worker re-pausing in between as each requirement settles. Cleaner UX than batch-skip.
- Same-tab nav loses any unsaved composer draft. Acceptable because the consent flow only fires on existing conversations whose state is persisted server-side, and the user clicked Authorize deliberately. A follow-up could persist ` + "`" + `pendingDraft` + "`" + ` to localStorage if real-world feedback wants it back.
- ` + "`" + `consentReturn.ts` + "`" + ` imports ` + "`" + `ROLE_ASSISTANT` + "`" + ` from ` + "`" + `@/constants/chat` + "`" + ` (subpath) rather than the ` + "`" + `@/constants` + "`" + ` barrel so its tests run under Node's default vitest environment. The barrel transitively imports ` + "`" + `endpoint.ts` + "`" + ` which touches ` + "`" + `window.location.origin` + "`" + ` at module-load, forcing jsdom on every importer otherwise.

## Verification

- ` + "`" + `npm run test:run` + "`" + ` — **135/135 passed** (13 new in ` + "`" + `consentReturn.test.ts` + "`" + `).
- ` + "`" + `npx vue-tsc -b --force` + "`" + ` — clean.
- ` + "`" + `npx eslint src/components/chat/consentReturn.ts src/components/chat/consentReturn.test.ts src/pages/chat/Conversation.vue` + "`" + ` — clean.
- ` + "`" + `python3 scripts/check_i18n_coverage.py` + "`" + ` — clean (no new i18n keys; existing PR-5 keys cover the resume UX).

## Out of scope

- Capacitor mobile flow: same-tab nav to an external URL in the in-app webview may behave differently from browser. Mobile consent UX is a separate hardening pass.
- Persisting ` + "`" + `pendingDraft` + "`" + ` across navigations: noted under design but deferred.
- The detached ` + "`" + `.worktrees/PlatformService-read-consent` + "`" + ` reference worktree (read-only PR-2..4 inspection) will be cleaned up after this PR + AuthFrontend #126 merge.