### PR TITLE
chore(robots): explicit Disallow for known SEO/AI crawler bots

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,117 @@
+# --- AI training crawlers — opt out (also enforced at EdgeOne WAF) ---
+User-agent: GPTBot
+Disallow: /
+
+User-agent: ChatGPT-User
+Disallow: /
+
+User-agent: OAI-SearchBot
+Disallow: /
+
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: Claude-Web
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: PerplexityBot
+Disallow: /
+
+User-agent: Perplexity-User
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: GoogleOther
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: Amazonbot
+Disallow: /
+
+User-agent: cohere-ai
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: PetalBot
+Disallow: /
+
+User-agent: Applebot-Extended
+Disallow: /
+
+User-agent: Meta-ExternalAgent
+Disallow: /
+
+User-agent: FacebookBot
+Disallow: /
+
+User-agent: Diffbot
+Disallow: /
+
+User-agent: ImagesiftBot
+Disallow: /
+
+User-agent: Webzio-Extended
+Disallow: /
+
+User-agent: YouBot
+Disallow: /
+
+User-agent: TimpiBot
+Disallow: /
+
+User-agent: omgili
+Disallow: /
+
+User-agent: omgilibot
+Disallow: /
+
+# --- SEO scrapers — opt out ---
+User-agent: SemrushBot
+Disallow: /
+
+User-agent: AhrefsBot
+Disallow: /
+
+User-agent: MJ12bot
+Disallow: /
+
+User-agent: DotBot
+Disallow: /
+
+User-agent: BLEXBot
+Disallow: /
+
+User-agent: DataForSeoBot
+Disallow: /
+
+User-agent: SeekportBot
+Disallow: /
+
+User-agent: SerpstatBot
+Disallow: /
+
+User-agent: MegaIndex.ru
+Disallow: /
+
+User-agent: ZoomBot
+Disallow: /
+
+User-agent: Barkrowler
+Disallow: /
+
+User-agent: magpie-crawler
+Disallow: /
+
+# --- Default rules ---
 User-agent: *
 
 # Public pages


### PR DESCRIPTION
## Summary

Add explicit `User-agent` / `Disallow: /` sections to `public/robots.txt` for ~38 SEO and AI-training crawlers eating bandwidth without driving value.

## Why

EdgeOne offline-log analysis (Nov 2025) on the `acedata.cloud-global` zone showed bot UAs accounted for **~36% of CDN bandwidth**. Polite SEO / AI training bots (DataForSeoBot, AhrefsBot, SemrushBot, MJ12bot, PetalBot, GPTBot, ClaudeBot, PerplexityBot, Bytespider, etc.) are now explicitly opted out via `robots.txt`.

Aggressive scripted bots that ignore `robots.txt` (python-httpx, aiohttp, Wget, HeadlessChrome) are handled separately at the EdgeOne WAF layer via `BotManagementLite.AICrawlerDetection` — already deployed across all 4 EdgeOne zones (`acedata.cloud` global+intl, `zhishuyun.com`, `surl.id`) with `Action=Deny`.

Verified live:
```
$ curl -A 'Mozilla/5.0 (compatible; GPTBot/1.2)' https://cdn.acedata.cloud/robots.txt -I
HTTP/2 567   # EdgeOne blocked
server: EdgeOne_L7S_OC
$ curl -A 'Mozilla/5.0 (...) Chrome/120.0.0.0' https://cdn.acedata.cloud/robots.txt -I
HTTP/2 404   # normal browser passes through to COS
server: tencent-cos
```

## What this PR does

The static `public/robots.txt` served by Nexior gains 38 `User-agent` / `Disallow` blocks before the existing `User-agent: *` rules. All existing Allow / Disallow / Sitemap directives are preserved.

## Counterpart

PlatformBackend [PR #519](https://github.com/AceDataCloud/PlatformBackend/pull/519) does the same for `platform.acedata.cloud`.

## Expected savings

$50-200 / month CDN bandwidth on EdgeOne via robots.txt opt-out. WAF `AICrawlerDetection.Deny` delivers the bulk of the savings (most large bots ignore robots.txt).