### PR TITLE
chore(ios): bump TestFlight build to 3.35.2

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -24,8 +24,8 @@ android {
         applicationId "com.acedatacloud.nexior"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 33501
-        versionName "3.35.1"
+        versionCode 33502
+        versionName "3.35.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -352,11 +352,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 33501;
+				CURRENT_PROJECT_VERSION = 33502;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 3.35.1;
+				MARKETING_VERSION = 3.35.2;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.acedatacloud.nexior;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -372,11 +372,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 33501;
+				CURRENT_PROJECT_VERSION = 33502;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 3.35.1;
+				MARKETING_VERSION = 3.35.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.acedatacloud.nexior;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acedatacloud/nexior",
-  "version": "3.35.1",
+  "version": "3.35.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acedatacloud/nexior",
-      "version": "3.35.1",
+      "version": "3.35.2",
       "license": "MIT",
       "dependencies": {
         "@capacitor/app": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acedatacloud/nexior",
-  "version": "3.35.1",
+  "version": "3.35.2",
   "author": "Ace Data Cloud <office@acedata.cloud>",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- Bump Nexior package/native versions from 3.35.1 to 3.35.2
- Bump iOS CURRENT_PROJECT_VERSION from 33501 to 33502 for the next TestFlight upload
- Keep Android version metadata in sync

## Test plan

- Version-only release metadata change
- iOS TestFlight workflow will run from tag `ios-v3.35.2` after merge