### PR TITLE
feat(consent): catalog metadata, in-card scope picker, and post-OAuth Continue button

### DIFF
--- a/change/@acedatacloud-nexior-connector-catalog-display.json
+++ b/change/@acedatacloud-nexior-connector-catalog-display.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "feat(consent): show connector logo + localized name in consent card",
+  "comment": "feat(consent): show connector logo + localized name in consent card, and pop a scope picker that calls AuthBackend's catalog install endpoint on Authorize",
   "packageName": "@acedatacloud/nexior",
   "email": "dev@acedata.cloud",
   "dependentChangeType": "patch"

--- a/change/@acedatacloud-nexior-connector-catalog-display.json
+++ b/change/@acedatacloud-nexior-connector-catalog-display.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "feat(consent): show connector logo + localized name in consent card, and pop a scope picker that calls AuthBackend's catalog install endpoint on Authorize",
+  "comment": "feat(consent): show connector logo + localized name in consent card, pop a scope picker that calls AuthBackend's catalog install endpoint on Authorize, and refresh connection status after the OAuth round-trip so the card surfaces a Continue button once the connector is connected",
   "packageName": "@acedatacloud/nexior",
   "email": "dev@acedata.cloud",
   "dependentChangeType": "patch"

--- a/change/@acedatacloud-nexior-connector-catalog-display.json
+++ b/change/@acedatacloud-nexior-connector-catalog-display.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(consent): show connector logo + localized name in consent card",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/ConnectorConsentCard.test.ts
+++ b/src/components/chat/ConnectorConsentCard.test.ts
@@ -34,11 +34,13 @@ const PAYLOAD_TWO_OPTIONS: IConsentRequestPayload = {
       entries: [
         {
           connector: 'acedatacloud/gmail',
+          catalog_id: 'cat_gmail',
           status: 'unconnected',
           install_url: 'https://example.com/gmail'
         },
         {
           connector: 'acedatacloud/outlook',
+          catalog_id: 'cat_outlook',
           status: 'unconnected',
           install_url: 'https://example.com/outlook'
         }
@@ -54,7 +56,7 @@ const PAYLOAD_SATISFIED: IConsentRequestPayload = {
       requirement_index: 0,
       match: 'any',
       satisfied: true,
-      entries: [{ connector: 'acedatacloud/gmail', status: 'connected' }]
+      entries: [{ connector: 'acedatacloud/gmail', catalog_id: 'cat_gmail', status: 'connected' }]
     }
   ]
 };

--- a/src/components/chat/ConnectorConsentCard.test.ts
+++ b/src/components/chat/ConnectorConsentCard.test.ts
@@ -1,8 +1,22 @@
 // @vitest-environment jsdom
-import { mount } from '@vue/test-utils';
-import { describe, expect, it } from 'vitest';
+import { flushPromises, mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock `connectorCatalogCache` so the card's mount-time
+// `refreshCatalogs` (and the new `refreshConnectionStatuses`) don't
+// hit the real `httpClient`. Tests opt into specific return values via
+// the `mockResolvedValue` hooks below.
+vi.mock('./connectorCatalogCache', () => ({
+  getCatalogItem: vi.fn().mockResolvedValue(undefined),
+  installFromCatalog: vi.fn(),
+  listMyConnections: vi.fn().mockResolvedValue([])
+}));
+
 import ConnectorConsentCard from './ConnectorConsentCard.vue';
+import { listMyConnections } from './connectorCatalogCache';
 import type { IConsentRequestPayload } from '@/models';
+
+const mockedListMyConnections = vi.mocked(listMyConnections);
 
 // Minimal globals: stub $t to echo the key (+ list of params), and stub
 // FontAwesomeIcon so the test environment doesn't need the icon registry.
@@ -179,5 +193,131 @@ describe('ConnectorConsentCard', () => {
       tool_use_id: 'tu-1',
       entry: PAYLOAD_TWO_OPTIONS.requirements[0].entries[0]
     });
+  });
+});
+
+describe('ConnectorConsentCard — post-OAuth status refresh', () => {
+  // jsdom's default URL (``about:blank``) refuses ``replaceState`` to
+  // any cross-origin target, so we stub ``window.location`` directly
+  // via ``defineProperty``. The card only reads ``href`` so a URL
+  // instance is sufficient — `.assign` / `.replace` are unused.
+  const originalLocation = window.location;
+  const setLocation = (href: string): void => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: new URL(href)
+    });
+  };
+
+  beforeEach(() => {
+    mockedListMyConnections.mockReset();
+    mockedListMyConnections.mockResolvedValue([]);
+  });
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: originalLocation
+    });
+  });
+
+  it('does NOT refresh when the URL is missing the consent beacon', async () => {
+    setLocation('http://localhost/chat');
+    mount(ConnectorConsentCard, {
+      props: { toolUseId: 'tu-1', payload: PAYLOAD_TWO_OPTIONS },
+      global
+    });
+    await flushPromises();
+    expect(mockedListMyConnections).not.toHaveBeenCalled();
+  });
+
+  it('does NOT refresh when ?consent= belongs to a different consent_request_id', async () => {
+    setLocation('http://localhost/chat?consent=req-other');
+    mount(ConnectorConsentCard, {
+      props: { toolUseId: 'tu-1', payload: PAYLOAD_TWO_OPTIONS },
+      global
+    });
+    await flushPromises();
+    expect(mockedListMyConnections).not.toHaveBeenCalled();
+  });
+
+  it('flips the matching entry to Connected and shows Continue when the live API returns an active connection', async () => {
+    setLocation('http://localhost/chat?consent=req-1');
+    mockedListMyConnections.mockResolvedValue([
+      { id: 'conn-1', catalog_identifier: 'acedatacloud/gmail', status: 'active' }
+    ]);
+    const wrapper = mount(ConnectorConsentCard, {
+      props: { toolUseId: 'tu-1', payload: PAYLOAD_TWO_OPTIONS },
+      global
+    });
+    await flushPromises();
+    expect(mockedListMyConnections).toHaveBeenCalledTimes(1);
+    const rows = wrapper.findAllComponents({ name: 'ConnectorEntryRow' });
+    // First entry (gmail) is now connected, second (outlook) stays unconnected.
+    expect((rows[0].props('entry') as { status: string }).status).toBe('connected');
+    expect((rows[1].props('entry') as { status: string }).status).toBe('unconnected');
+    // Requirement is `match: 'any'` so one connected entry satisfies it →
+    // Continue button surfaces; Skip is hidden because nothing's left
+    // to skip.
+    const actionButtons = wrapper.findAll('.ccc-actions button');
+    expect(actionButtons.length).toBe(1);
+    expect(actionButtons[0].text()).toBe('chat.consent.continue');
+  });
+
+  it('keeps Skip + hides Continue when the live API still reports no active connection', async () => {
+    setLocation('http://localhost/chat?consent=req-1');
+    mockedListMyConnections.mockResolvedValue([
+      // expired / revoked rows are ignored by the case-insensitive `active` check.
+      { id: 'conn-1', catalog_identifier: 'acedatacloud/gmail', status: 'expired' }
+    ]);
+    const wrapper = mount(ConnectorConsentCard, {
+      props: { toolUseId: 'tu-1', payload: PAYLOAD_TWO_OPTIONS },
+      global
+    });
+    await flushPromises();
+    const actionButtons = wrapper.findAll('.ccc-actions button');
+    expect(actionButtons.length).toBe(1);
+    expect(actionButtons[0].text()).toBe('chat.consent.skip');
+  });
+
+  it('Continue emits submit with all effectively-connected connectors marked authorized', async () => {
+    setLocation('http://localhost/chat?consent=req-1');
+    mockedListMyConnections.mockResolvedValue([
+      { id: 'conn-1', catalog_identifier: 'acedatacloud/gmail', status: 'ACTIVE' }
+    ]);
+    const wrapper = mount(ConnectorConsentCard, {
+      props: { toolUseId: 'tu-1', payload: PAYLOAD_TWO_OPTIONS },
+      global
+    });
+    await flushPromises();
+    await wrapper.find('.ccc-actions button').trigger('click');
+    const emitted = wrapper.emitted('submit');
+    expect(emitted).toBeTruthy();
+    const evt = emitted![0][0] as { tool_use_id: string; output: string };
+    expect(evt.tool_use_id).toBe('tu-1');
+    expect(JSON.parse(evt.output)).toEqual({
+      consent_request_id: 'req-1',
+      authorized: ['acedatacloud/gmail'],
+      skipped: []
+    });
+  });
+
+  it('swallows refresh errors without surfacing Continue', async () => {
+    setLocation('http://localhost/chat?consent=req-1');
+    mockedListMyConnections.mockRejectedValue(new Error('network down'));
+    // Silence the expected console.warn from `refreshConnectionStatuses`.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const wrapper = mount(ConnectorConsentCard, {
+      props: { toolUseId: 'tu-1', payload: PAYLOAD_TWO_OPTIONS },
+      global
+    });
+    await flushPromises();
+    expect(mockedListMyConnections).toHaveBeenCalledTimes(1);
+    // No Continue button — overlay never landed.
+    const actionButtons = wrapper.findAll('.ccc-actions button');
+    expect(actionButtons.length).toBe(1);
+    expect(actionButtons[0].text()).toBe('chat.consent.skip');
+    warnSpy.mockRestore();
   });
 });

--- a/src/components/chat/ConnectorConsentCard.vue
+++ b/src/components/chat/ConnectorConsentCard.vue
@@ -10,13 +10,13 @@
       v-for="req in requirements"
       :key="req.requirement_index"
       class="ccc-requirement"
-      :class="{ 'is-satisfied': req.satisfied }"
+      :class="{ 'is-satisfied': effectiveSatisfiedFor(req) }"
     >
       <div v-if="showMatchLabel(req)" class="ccc-req-match">
         {{ req.match === 'any' ? $t('chat.consent.matchAny') : $t('chat.consent.matchAll') }}
       </div>
       <ConnectorEntryRow
-        v-for="entry in req.entries"
+        v-for="entry in effectiveEntriesFor(req)"
         :key="entry.connector"
         :entry="entry"
         :catalog="catalogFor(entry)"
@@ -25,9 +25,18 @@
       />
     </div>
 
-    <div v-if="!resolved && hasUnsatisfied" class="ccc-actions">
-      <el-button text :disabled="authorizingConnector !== ''" @click="onSkip">
+    <div v-if="!resolved && (hasUnsatisfied || showContinueButton)" class="ccc-actions">
+      <el-button v-if="hasUnsatisfied" text :disabled="authorizingConnector !== ''" @click="onSkip">
         {{ $t('chat.consent.skip') }}
+      </el-button>
+      <el-button
+        v-if="showContinueButton"
+        type="primary"
+        :loading="refreshingStatus"
+        :disabled="authorizingConnector !== ''"
+        @click="onContinue"
+      >
+        {{ $t('chat.consent.continue') }}
       </el-button>
     </div>
 
@@ -77,7 +86,12 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import type { IConsentRequestEntry, IConsentRequestPayload, IConsentRequestRequirement } from '@/models';
 import ConnectorEntryRow from './ConnectorEntryRow.vue';
 import { buildConsentOutput, unsatisfiedConnectors } from './connectorConsent';
-import { getCatalogItem, installFromCatalog, type IConnectorCatalogSummary } from './connectorCatalogCache';
+import {
+  getCatalogItem,
+  installFromCatalog,
+  listMyConnections,
+  type IConnectorCatalogSummary
+} from './connectorCatalogCache';
 
 interface IData {
   resolvedAuthorized: string[];
@@ -98,6 +112,22 @@ interface IData {
   /** Tracks the entry currently being installed so its row button (and
    *  the dialog Confirm button) can show a loading spinner. */
   authorizingConnector: string;
+  /** Live entry statuses fetched from AuthBackend after the OAuth
+   *  round-trip — keyed by `IConsentRequestEntry.connector` (the
+   *  catalog identifier). The worker-supplied `entry.status` is frozen
+   *  at the moment the pending tool_use was emitted, so a successful
+   *  install needs this overlay to flip the row from "Authorize" to
+   *  "Connected". Empty until `refreshConnectionStatuses` runs. */
+  liveStatuses: Record<string, 'connected' | 'unconnected'>;
+  /** Becomes `true` after the first successful `listMyConnections`
+   *  call. Gates the "Continue" CTA so we don't surface it before
+   *  we've actually verified the install — a worker payload that
+   *  arrives already-satisfied (no live re-check) still renders the
+   *  no-action layout. */
+  hasCheckedStatuses: boolean;
+  /** Loading flag for the in-flight `listMyConnections` call; drives
+   *  the spinner on the "Continue" button. */
+  refreshingStatus: boolean;
 }
 
 export default defineComponent({
@@ -137,15 +167,66 @@ export default defineComponent({
       scopeDialogEntry: null,
       scopeDialogCatalog: null,
       selectedScopes: [],
-      authorizingConnector: ''
+      authorizingConnector: '',
+      liveStatuses: {},
+      hasCheckedStatuses: false,
+      refreshingStatus: false
     };
   },
   computed: {
     requirements(): IConsentRequestRequirement[] {
       return this.payload?.requirements ?? [];
     },
+    /** Per-entry overlay: if a live status came back from AuthBackend
+     *  after the OAuth round-trip, use it; otherwise fall back to the
+     *  worker-supplied `entry.status`. Centralized here so template +
+     *  `onContinue` agree on the same effective status without each
+     *  spreading the override inline. */
+    effectiveStatus() {
+      return (entry: IConsentRequestEntry): 'connected' | 'unconnected' => {
+        return this.liveStatuses[entry.connector] ?? entry.status;
+      };
+    },
+    /** Entries with `status` rebound to the live-overlaid value, so
+     *  `<ConnectorEntryRow>` (which keys its display off `entry.status`)
+     *  flips from Authorize → Connected without us mutating the prop. */
+    effectiveEntriesFor() {
+      return (req: IConsentRequestRequirement): IConsentRequestEntry[] => {
+        return req.entries.map((entry) => {
+          const live = this.liveStatuses[entry.connector];
+          if (!live || live === entry.status) return entry;
+          return { ...entry, status: live };
+        });
+      };
+    },
+    /** A requirement is effectively satisfied when:
+     *  - `match === 'any'` and ≥1 effective entry is connected, OR
+     *  - `match === 'all'` and every effective entry is connected.
+     *  This mirrors the worker-side ``satisfied`` rule so the live
+     *  overlay can flip a not-yet-resolved requirement to satisfied
+     *  after a successful install. */
+    effectiveSatisfiedFor() {
+      return (req: IConsentRequestRequirement): boolean => {
+        const statuses = req.entries.map((e) => this.effectiveStatus(e));
+        if (statuses.length === 0) return req.satisfied;
+        if (req.match === 'all') return statuses.every((s) => s === 'connected');
+        return statuses.some((s) => s === 'connected');
+      };
+    },
     hasUnsatisfied(): boolean {
-      return this.requirements.some((r) => !r.satisfied);
+      return this.requirements.some((r) => !this.effectiveSatisfiedFor(r));
+    },
+    /** Continue CTA visibility. We only show Continue after the live
+     *  refresh has lifted at least one entry from unconnected → connected
+     *  (`hasCheckedStatuses === true`) AND every requirement is now
+     *  effectively satisfied. Without `hasCheckedStatuses` an already-
+     *  satisfied worker payload (e.g. the model proactively asked
+     *  consent for an already-connected provider) would surface a
+     *  Continue button the user never asked for. */
+    showContinueButton(): boolean {
+      if (this.resolved) return false;
+      if (!this.hasCheckedStatuses) return false;
+      return !this.hasUnsatisfied;
     },
     resolvedSummary(): string {
       if (this.resolvedAuthorized.length > 0) {
@@ -177,12 +258,23 @@ export default defineComponent({
       }
     }
   },
+  mounted() {
+    // After the OAuth full-page redirect, the user lands back on the
+    // chat URL we stamped in `performInstall` — `?consent=<rid>` where
+    // `<rid>` is THIS card's `consent_request_id`. The frozen
+    // worker-supplied `entry.status` won't reflect the just-created
+    // connection, so we re-read the calling user's connections from
+    // AuthBackend and overlay statuses. No URL match → no refresh.
+    if (this.shouldRefreshFromReturn()) {
+      this.refreshConnectionStatuses();
+    }
+  },
   methods: {
     showMatchLabel(req: IConsentRequestRequirement): boolean {
       // Only meaningful when there are 2+ candidates AND the requirement
-      // hasn't been auto-satisfied (one connected entry hides the
-      // "either of these" prompt).
-      return req.entries.length > 1 && !req.satisfied;
+      // hasn't been satisfied yet — once the live overlay flips an
+      // entry to connected the "either of these" prompt is stale.
+      return req.entries.length > 1 && !this.effectiveSatisfiedFor(req);
     },
     /** Look up the catalog row a `ConnectorEntryRow` should render with.
      *  Returns `null` until `refreshCatalogs` has populated the entry. */
@@ -296,6 +388,68 @@ export default defineComponent({
     onSkip() {
       const skipped = unsatisfiedConnectors(this.payload);
       const output = buildConsentOutput(this.payload, [], skipped);
+      this.$emit('submit', { tool_use_id: this.toolUseId, output });
+    },
+    /** True when the current URL carries `?consent=<my_consent_id>` —
+     *  the beacon `performInstall` stamps on its `return_url` before
+     *  the OAuth redirect. Read directly from `window.location` rather
+     *  than the Vue Router query bag so the card doesn't have to be
+     *  rendered inside a router context to work (the unit tests don't
+     *  install vue-router, and the prod tree never renders the card
+     *  outside one). */
+    shouldRefreshFromReturn(): boolean {
+      if (typeof window === 'undefined') return false;
+      try {
+        const params = new URL(window.location.href).searchParams;
+        return params.get('consent') === this.payload?.consent_request_id;
+      } catch {
+        return false;
+      }
+    },
+    /** Fetch the user's connections from AuthBackend and overlay any
+     *  `status === 'active'` entries onto `liveStatuses`. Failures are
+     *  logged but never surfaced — the user can still click Authorize
+     *  again to retry. */
+    async refreshConnectionStatuses(): Promise<void> {
+      this.refreshingStatus = true;
+      try {
+        const connections = await listMyConnections();
+        const connectedIds = new Set<string>();
+        for (const c of connections) {
+          if (!c.catalog_identifier) continue;
+          if (String(c.status).toLowerCase() === 'active') {
+            connectedIds.add(c.catalog_identifier);
+          }
+        }
+        const next: Record<string, 'connected' | 'unconnected'> = {};
+        for (const req of this.requirements) {
+          for (const entry of req.entries) {
+            next[entry.connector] = connectedIds.has(entry.connector) ? 'connected' : 'unconnected';
+          }
+        }
+        this.liveStatuses = next;
+        this.hasCheckedStatuses = true;
+      } catch (error) {
+        console.warn('listMyConnections failed', error);
+      } finally {
+        this.refreshingStatus = false;
+      }
+    },
+    /** Continue submits the resolved consent with every effectively
+     *  connected entry marked `authorized`. Only reachable when the
+     *  live overlay has lifted every requirement into the satisfied
+     *  state — see `showContinueButton`. Mirrors `onSkip`'s output
+     *  shape so the worker resume contract stays uniform. */
+    onContinue() {
+      const authorized: string[] = [];
+      for (const req of this.requirements) {
+        for (const entry of req.entries) {
+          if (this.effectiveStatus(entry) === 'connected') {
+            authorized.push(entry.connector);
+          }
+        }
+      }
+      const output = buildConsentOutput(this.payload, authorized, []);
       this.$emit('submit', { tool_use_id: this.toolUseId, output });
     },
     parsePreviousOutput() {

--- a/src/components/chat/ConnectorConsentCard.vue
+++ b/src/components/chat/ConnectorConsentCard.vue
@@ -19,6 +19,7 @@
         v-for="entry in req.entries"
         :key="entry.connector"
         :entry="entry"
+        :catalog="catalogFor(entry)"
         :disabled="resolved"
         @authorize="onAuthorize"
       />
@@ -43,10 +44,15 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import type { IConsentRequestEntry, IConsentRequestPayload, IConsentRequestRequirement } from '@/models';
 import ConnectorEntryRow from './ConnectorEntryRow.vue';
 import { buildConsentOutput, unsatisfiedConnectors } from './connectorConsent';
+import { getCatalogItem, type IConnectorCatalogSummary } from './connectorCatalogCache';
 
 interface IData {
   resolvedAuthorized: string[];
   resolvedSkipped: string[];
+  /** Catalog rows resolved from AuthBackend, keyed by `catalog_id`.
+   *  Empty entries stay absent so the row renders the slug fallback
+   *  until the fetch lands. */
+  catalogs: Record<string, IConnectorCatalogSummary>;
 }
 
 export default defineComponent({
@@ -80,7 +86,8 @@ export default defineComponent({
   data(): IData {
     return {
       resolvedAuthorized: [],
-      resolvedSkipped: []
+      resolvedSkipped: [],
+      catalogs: {}
     };
   },
   computed: {
@@ -111,6 +118,13 @@ export default defineComponent({
       handler() {
         if (this.resolved) this.parsePreviousOutput();
       }
+    },
+    payload: {
+      immediate: true,
+      deep: false,
+      handler() {
+        this.refreshCatalogs();
+      }
     }
   },
   methods: {
@@ -119,6 +133,31 @@ export default defineComponent({
       // hasn't been auto-satisfied (one connected entry hides the
       // "either of these" prompt).
       return req.entries.length > 1 && !req.satisfied;
+    },
+    /** Look up the catalog row a `ConnectorEntryRow` should render with.
+     *  Returns `null` until `refreshCatalogs` has populated the entry. */
+    catalogFor(entry: IConsentRequestEntry): IConnectorCatalogSummary | null {
+      return this.catalogs[entry.catalog_id] || null;
+    },
+    /** Fetch catalog rows for every unique `catalog_id` in the payload.
+     *  De-duped at the cache layer; safe to call repeatedly. */
+    async refreshCatalogs(): Promise<void> {
+      const ids = new Set<string>();
+      for (const req of this.requirements) {
+        for (const entry of req.entries) {
+          if (entry.catalog_id) ids.add(entry.catalog_id);
+        }
+      }
+      await Promise.all(
+        Array.from(ids).map(async (id) => {
+          if (this.catalogs[id]) return;
+          const item = await getCatalogItem(id);
+          if (item) {
+            // Re-assign so Vue 3 reactivity picks up the new key.
+            this.catalogs = { ...this.catalogs, [id]: item };
+          }
+        })
+      );
     },
     onAuthorize(entry: IConsentRequestEntry) {
       // PR-6 wires the OAuth return path. For now the parent decides what

--- a/src/components/chat/ConnectorConsentCard.vue
+++ b/src/components/chat/ConnectorConsentCard.vue
@@ -20,13 +20,13 @@
         :key="entry.connector"
         :entry="entry"
         :catalog="catalogFor(entry)"
-        :disabled="resolved"
+        :disabled="resolved || authorizingConnector !== ''"
         @authorize="onAuthorize"
       />
     </div>
 
     <div v-if="!resolved && hasUnsatisfied" class="ccc-actions">
-      <el-button text @click="onSkip">
+      <el-button text :disabled="authorizingConnector !== ''" @click="onSkip">
         {{ $t('chat.consent.skip') }}
       </el-button>
     </div>
@@ -34,17 +34,50 @@
     <div v-if="resolved" class="ccc-resolved-banner">
       {{ resolvedSummary }}
     </div>
+
+    <!-- Scope picker — mirrors AuthFrontend's `pages/user/Connections.vue`
+         so a multi-permission OAuth provider gives the user the same
+         opt-out checklist regardless of entry surface. -->
+    <el-dialog
+      v-model="scopeDialogVisible"
+      :title="scopeDialogCatalog ? ($t('chat.consent.selectScopes', { provider: scopeDialogCatalog.name }) as string) : ''"
+      width="480px"
+      :close-on-click-modal="false"
+      append-to-body
+    >
+      <p class="ccc-scope-hint">{{ $t('chat.consent.selectScopesHint') }}</p>
+      <el-checkbox-group v-model="selectedScopes">
+        <div
+          v-for="perm in (scopeDialogCatalog?.permissions || [])"
+          :key="perm.id"
+          class="ccc-scope-row"
+        >
+          <el-checkbox :value="perm.id" :label="perm.id">
+            <span class="ccc-scope-label">{{ perm.label || perm.id }}</span>
+          </el-checkbox>
+          <p v-if="perm.desc" class="ccc-scope-desc">{{ perm.desc }}</p>
+        </div>
+      </el-checkbox-group>
+      <template #footer>
+        <el-button :disabled="authorizingConnector !== ''" @click="scopeDialogVisible = false">
+          {{ $t('common.button.cancel') }}
+        </el-button>
+        <el-button type="primary" :loading="authorizingConnector !== ''" @click="onConfirmScopes">
+          {{ $t('common.button.confirm') }}
+        </el-button>
+      </template>
+    </el-dialog>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent, PropType } from 'vue';
-import { ElButton } from 'element-plus';
+import { ElButton, ElCheckbox, ElCheckboxGroup, ElDialog, ElMessage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import type { IConsentRequestEntry, IConsentRequestPayload, IConsentRequestRequirement } from '@/models';
 import ConnectorEntryRow from './ConnectorEntryRow.vue';
 import { buildConsentOutput, unsatisfiedConnectors } from './connectorConsent';
-import { getCatalogItem, type IConnectorCatalogSummary } from './connectorCatalogCache';
+import { getCatalogItem, installFromCatalog, type IConnectorCatalogSummary } from './connectorCatalogCache';
 
 interface IData {
   resolvedAuthorized: string[];
@@ -53,11 +86,23 @@ interface IData {
    *  Empty entries stay absent so the row renders the slug fallback
    *  until the fetch lands. */
   catalogs: Record<string, IConnectorCatalogSummary>;
+  /** Scope-picker dialog state. The dialog opens when the user clicks
+   *  Authorize on an entry whose catalog declares multiple permissions
+   *  and `auth_mode !== 'byoc'`. Mirrors AuthFrontend's
+   *  `pages/user/Connections.vue` flow so users see the same picker
+   *  regardless of which surface they triggered it from. */
+  scopeDialogVisible: boolean;
+  scopeDialogEntry: IConsentRequestEntry | null;
+  scopeDialogCatalog: IConnectorCatalogSummary | null;
+  selectedScopes: string[];
+  /** Tracks the entry currently being installed so its row button (and
+   *  the dialog Confirm button) can show a loading spinner. */
+  authorizingConnector: string;
 }
 
 export default defineComponent({
   name: 'ConnectorConsentCard',
-  components: { ConnectorEntryRow, ElButton, FontAwesomeIcon },
+  components: { ConnectorEntryRow, ElButton, ElCheckbox, ElCheckboxGroup, ElDialog, FontAwesomeIcon },
   props: {
     /** Tool-use block id; sent back as `tool_use_id` on resume. */
     toolUseId: {
@@ -87,7 +132,12 @@ export default defineComponent({
     return {
       resolvedAuthorized: [],
       resolvedSkipped: [],
-      catalogs: {}
+      catalogs: {},
+      scopeDialogVisible: false,
+      scopeDialogEntry: null,
+      scopeDialogCatalog: null,
+      selectedScopes: [],
+      authorizingConnector: ''
     };
   },
   computed: {
@@ -160,9 +210,88 @@ export default defineComponent({
       );
     },
     onAuthorize(entry: IConsentRequestEntry) {
-      // PR-6 wires the OAuth return path. For now the parent decides what
-      // happens — typically `window.open(entry.install_url, '_blank')`.
-      this.$emit('authorize', { tool_use_id: this.toolUseId, entry });
+      // Decision tree (mirrors AuthFrontend's `pages/user/Connections.vue`
+      // so the picker UX is identical regardless of surface):
+      //
+      //   1. Catalog not yet loaded (or unknown id) → fall through to the
+      //      legacy `authorize` emit so the parent can use the
+      //      worker-provided `entry.install_url` as a hard fallback.
+      //   2. `auth_mode === 'byoc'` → emit; BYOC needs the AuthFrontend
+      //      credential form which Nexior does not host.
+      //   3. `installable === false` → emit; the catalog row is in a
+      //      state where AuthBackend would refuse the inline install
+      //      anyway, so let AuthFrontend render whatever copy it wants.
+      //   4. `permissions.length > 1` → open the scope picker.
+      //   5. Otherwise → install immediately with no `scopes` (server
+      //      picks the catalog default).
+      const catalog = this.catalogFor(entry);
+      if (!catalog || catalog.auth_mode === 'byoc' || !catalog.installable) {
+        this.$emit('authorize', { tool_use_id: this.toolUseId, entry });
+        return;
+      }
+      const perms = catalog.permissions || [];
+      if (perms.length > 1) {
+        this.scopeDialogEntry = entry;
+        this.scopeDialogCatalog = catalog;
+        // Default-check every scope so the user has to opt OUT of perms
+        // rather than opt IN — matches AuthFrontend behavior.
+        this.selectedScopes = perms.map((p) => p.id);
+        this.scopeDialogVisible = true;
+        return;
+      }
+      this.performInstall(entry, undefined);
+    },
+    onConfirmScopes() {
+      const entry = this.scopeDialogEntry;
+      if (!entry) {
+        this.scopeDialogVisible = false;
+        return;
+      }
+      const scopes = [...this.selectedScopes];
+      this.scopeDialogVisible = false;
+      this.performInstall(entry, scopes);
+    },
+    /** POST to AuthBackend's catalog install endpoint and act on the
+     *  response.
+     *  - `type === 'redirect'`: navigate to the OAuth authorize URL.
+     *  - `type === 'form'`: BYOC schema came back inline; we don't host
+     *    the form so fall back to the legacy emit (AuthFrontend handles
+     *    it via `entry.install_url`).
+     *  - `type === 'active'`: zero-step provider — emit so the parent
+     *    can mark the entry connected on the next refresh.
+     *  - Any error: toast + emit as a last-ditch fallback. */
+    async performInstall(entry: IConsentRequestEntry, scopes: string[] | undefined): Promise<void> {
+      this.authorizingConnector = entry.connector;
+      try {
+        // Compose a return URL that brings the user back to the current
+        // chat with the consent-resolution beacon (`?consent=<id>`)
+        // matching the format `consentReturn` watches for. We strip any
+        // stale `?connector=…` from a previous flow so AuthFrontend's
+        // post-install redirect doesn't bounce us into another picker.
+        const returnUrl = new URL(window.location.href);
+        returnUrl.searchParams.set('consent', this.payload.consent_request_id);
+        returnUrl.searchParams.delete('connector');
+        const result = await installFromCatalog(entry.catalog_id, {
+          scopes,
+          return_url: returnUrl.toString()
+        });
+        if (result.type === 'redirect' && result.authorization_url) {
+          window.location.href = result.authorization_url;
+          return;
+        }
+        // `form` (BYOC schema returned inline) or `active` (zero-step) —
+        // both are handled by the existing parent flow, which navigates
+        // to `entry.install_url` (AuthFrontend's install page) where the
+        // BYOC form is hosted and zero-step installs are confirmed.
+        this.$emit('authorize', { tool_use_id: this.toolUseId, entry });
+      } catch (error) {
+        console.error('installFromCatalog failed', error);
+        ElMessage.error(this.$t('chat.consent.installFailed') as string);
+        // Last-ditch fallback: hand off to the worker's deep-link.
+        this.$emit('authorize', { tool_use_id: this.toolUseId, entry });
+      } finally {
+        this.authorizingConnector = '';
+      }
     },
     onSkip() {
       const skipped = unsatisfiedConnectors(this.payload);
@@ -288,5 +417,32 @@ export default defineComponent({
   color: var(--el-text-color-regular);
   font-size: 13px;
   line-height: 1.5;
+}
+
+.ccc-scope-hint {
+  margin: 0 0 12px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--el-text-color-secondary);
+}
+
+.ccc-scope-row {
+  padding: 6px 0;
+
+  &:not(:last-child) {
+    border-bottom: 1px solid var(--el-border-color-lighter);
+  }
+}
+
+.ccc-scope-label {
+  font-weight: 500;
+  color: var(--el-text-color-primary);
+}
+
+.ccc-scope-desc {
+  margin: 4px 0 0 24px;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--el-text-color-secondary);
 }
 </style>

--- a/src/components/chat/ConnectorEntryRow.vue
+++ b/src/components/chat/ConnectorEntryRow.vue
@@ -1,12 +1,17 @@
 <template>
   <div class="connector-entry-row" :class="{ 'is-connected': entry.status === 'connected' }">
     <div class="entry-icon" aria-hidden="true">
-      <font-awesome-icon v-if="entry.status === 'connected'" icon="fa-solid fa-circle-check" class="icon-connected" />
+      <img v-if="iconUrl" :src="iconUrl" class="icon-logo" :alt="displayName" @error="onLogoError" />
+      <font-awesome-icon
+        v-else-if="entry.status === 'connected'"
+        icon="fa-solid fa-circle-check"
+        class="icon-connected"
+      />
       <font-awesome-icon v-else icon="fa-solid fa-plug" class="icon-unconnected" />
     </div>
     <div class="entry-text">
       <div class="entry-name">{{ displayName }}</div>
-      <div v-if="entry.context" class="entry-context">{{ entry.context }}</div>
+      <div v-if="secondaryText" class="entry-context">{{ secondaryText }}</div>
     </div>
     <div class="entry-action">
       <span v-if="entry.status === 'connected'" class="status-pill connected">
@@ -27,6 +32,7 @@ import { defineComponent, PropType } from 'vue';
 import { ElButton } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import type { IConsentRequestEntry } from '@/models';
+import type { IConnectorCatalogSummary } from './connectorCatalogCache';
 
 export default defineComponent({
   name: 'ConnectorEntryRow',
@@ -36,6 +42,14 @@ export default defineComponent({
       type: Object as PropType<IConsentRequestEntry>,
       required: true
     },
+    /** Catalog row resolved by the parent via `connectorCatalogCache`.
+     *  When `null` the row falls back to the plug-icon + slug display
+     *  used before PR-3b (e.g. while the fetch is in flight or after a
+     *  cache miss). */
+    catalog: {
+      type: Object as PropType<IConnectorCatalogSummary | null>,
+      default: null
+    },
     /** When true, hide the action button (resolved card / no-op state). */
     disabled: {
       type: Boolean,
@@ -43,23 +57,55 @@ export default defineComponent({
     }
   },
   emits: ['authorize'],
+  data() {
+    return {
+      // Flips to `true` if `<img>` errors so the template falls back to
+      // the FA icon — common case is a stale `icon_url` (404 / CORS).
+      logoError: false
+    };
+  },
   computed: {
-    /**
-     * Catalog ids look like `acedatacloud/suno` or `notion`. Strip the
-     * `acedatacloud/` namespace so the bare service name (`suno`) is the
-     * primary label; fall back to the raw slug for third-party rows.
-     */
-    displayName(): string {
+    /** Slug-derived label used when the catalog row hasn't arrived yet.
+     *  Strips the `acedatacloud/` namespace so first-party connectors
+     *  read as `suno` / `producer` instead of the full identifier. */
+    fallbackName(): string {
       const slug = this.entry.connector ?? '';
       if (slug.startsWith('acedatacloud/')) {
         return slug.slice('acedatacloud/'.length);
       }
       return slug;
+    },
+    displayName(): string {
+      return this.catalog?.name?.trim() || this.fallbackName;
+    },
+    iconUrl(): string {
+      if (this.logoError) return '';
+      return this.catalog?.icon_url || '';
+    },
+    /** Two-line layout: the model-supplied `context` wins because it's
+     *  hand-written for THIS conversation. When absent, fall back to
+     *  the catalog's `short_description` so the row still has a useful
+     *  subtitle. */
+    secondaryText(): string {
+      if (this.entry.context && this.entry.context.trim()) {
+        return this.entry.context;
+      }
+      return this.catalog?.short_description || '';
+    }
+  },
+  watch: {
+    'catalog.icon_url'() {
+      // Catalog refresh — re-allow the image to render in case the
+      // previous load errored on a stale URL.
+      this.logoError = false;
     }
   },
   methods: {
     onAuthorize() {
       this.$emit('authorize', this.entry);
+    },
+    onLogoError() {
+      this.logoError = true;
     }
   }
 });
@@ -92,6 +138,14 @@ export default defineComponent({
   border-radius: 50%;
   background: var(--el-bg-color);
   font-size: 14px;
+  overflow: hidden;
+}
+
+.icon-logo {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  border-radius: 50%;
 }
 
 .icon-connected {

--- a/src/components/chat/connectorCatalogCache.ts
+++ b/src/components/chat/connectorCatalogCache.ts
@@ -72,6 +72,41 @@ export interface IConnectorCatalogInstallResponse {
   schema?: unknown;
 }
 
+/** Subset of AuthBackend's `IConnection` fields the consent card needs
+ *  to detect which entries are now actively connected for the calling
+ *  user. The full schema (profile, scopes, expires_at, …) is ignored —
+ *  this is purely a presence + status check keyed on
+ *  `catalog_identifier`. */
+export interface IUserConnectionSummary {
+  id: string;
+  /** Catalog item identifier (e.g. `acedatacloud/google-drive`).
+   *  Empty string for legacy / non-catalog installs — those rows can't
+   *  match a consent entry's `connector` field so they're effectively
+   *  ignored. */
+  catalog_identifier: string;
+  /** Backend ships both lowercase and uppercase variants — see
+   *  AuthFrontend `ConnectionStatus`. Callers should compare
+   *  case-insensitively. */
+  status: string;
+}
+
+/** Fetch the calling user's connections from AuthBackend. Used by the
+ *  consent card to refresh entry statuses after an OAuth round-trip —
+ *  the worker-supplied `entry.status` is frozen at the moment the
+ *  pending tool_use was emitted, so a successful install needs a live
+ *  re-read to flip the card from "Authorize" to "Connected" + show
+ *  the "Continue" CTA.
+ *
+ *  Throws on network / HTTP errors so the caller can decide whether
+ *  to fall back to the stale status or surface a toast. */
+export async function listMyConnections(): Promise<IUserConnectionSummary[]> {
+  const response: AxiosResponse<IUserConnectionSummary[]> = await httpClient.get(
+    `/connections/`,
+    { baseURL: `${getBaseUrlAuth()}/api/v1` }
+  );
+  return Array.isArray(response.data) ? response.data : [];
+}
+
 const cache = new Map<string, IConnectorCatalogSummary>();
 const inFlight = new Map<string, Promise<IConnectorCatalogSummary | undefined>>();
 

--- a/src/components/chat/connectorCatalogCache.ts
+++ b/src/components/chat/connectorCatalogCache.ts
@@ -1,0 +1,93 @@
+/**
+ * In-process cache for AuthBackend's connector catalog (
+ * `GET /api/v1/connections/catalog/<id>/`). The consent card renders the
+ * upstream brand (logo, localized name, permission descriptions) instead
+ * of the opaque catalog identifier the worker emits — see
+ * `IConsentRequestEntry.catalog_id`.
+ *
+ * Why module-level instead of a Vuex module:
+ * - The cache is read-only side data and never round-trips back to a
+ *   persistence layer. A full Vuex module would add 5+ files and force
+ *   wiring into `store/common/{models,state}.ts`; an in-memory `Map` is
+ *   sufficient because the data is small (one row per catalog id) and
+ *   non-sensitive.
+ * - Surviving across consent-card remounts is enough — once the user
+ *   reloads the chat tab the catalog will be refetched, which is fine
+ *   because the upstream payload rarely changes.
+ *
+ * Auth: Nexior's `Authorization: Bearer <access_token>` is an AuthBackend
+ * JWT (minted by `POST /sso/v1/token`), so the same token works against
+ * `auth.acedata.cloud` directly. We reuse the existing `httpClient`
+ * instance from `@/operators/common` which already injects the bearer
+ * token, fingerprint, x-user-id and accept-language headers — the only
+ * override is `baseURL`, which points at AuthBackend instead of
+ * PlatformBackend for this single endpoint.
+ */
+import { httpClient } from '@/operators/common';
+import { getBaseUrlAuth } from '@/utils';
+import type { AxiosResponse } from 'axios';
+
+/** Localized permission entry on a catalog row — mirrors AuthBackend's
+ *  `IConnectorPermission` (server-side translated via Accept-Language). */
+export interface IConnectorPermission {
+  id: string;
+  label: string;
+  desc: string;
+}
+
+/** Subset of AuthBackend's `IConnectorCatalogItem` fields the consent card
+ *  needs — there's no benefit to mirroring the entire schema. Adding more
+ *  fields later is safe because the AuthBackend payload is a superset. */
+export interface IConnectorCatalogSummary {
+  id: string;
+  identifier: string;
+  name: string;
+  short_description: string;
+  icon_url: string;
+  publisher: string;
+  publisher_logo_url: string;
+  permissions: IConnectorPermission[];
+  auth_mode: string;
+}
+
+const cache = new Map<string, IConnectorCatalogSummary>();
+const inFlight = new Map<string, Promise<IConnectorCatalogSummary | undefined>>();
+
+/**
+ * Fetch one catalog row by id, caching the result in-process. Concurrent
+ * calls for the same id de-dupe to a single AuthBackend round-trip. On
+ * error the cache stays empty so the next render-cycle retries
+ * automatically.
+ */
+export async function getCatalogItem(catalogId: string): Promise<IConnectorCatalogSummary | undefined> {
+  if (!catalogId) return undefined;
+  const cached = cache.get(catalogId);
+  if (cached) return cached;
+  const existing = inFlight.get(catalogId);
+  if (existing) return existing;
+  const task = (async () => {
+    try {
+      const response: AxiosResponse<IConnectorCatalogSummary> = await httpClient.get(
+        `/connections/catalog/${catalogId}/`,
+        { baseURL: `${getBaseUrlAuth()}/api/v1` }
+      );
+      const item = response.data;
+      cache.set(catalogId, item);
+      return item;
+    } catch (error) {
+      // Logged but not surfaced — the card falls back to the slug.
+      console.warn('connector catalog fetch failed', catalogId, error);
+      return undefined;
+    }
+  })().finally(() => {
+    inFlight.delete(catalogId);
+  });
+  inFlight.set(catalogId, task);
+  return task;
+}
+
+/** Test / cleanup helper. */
+export function clearConnectorCatalogCache(): void {
+  cache.clear();
+  inFlight.clear();
+}

--- a/src/components/chat/connectorCatalogCache.ts
+++ b/src/components/chat/connectorCatalogCache.ts
@@ -48,6 +48,28 @@ export interface IConnectorCatalogSummary {
   publisher_logo_url: string;
   permissions: IConnectorPermission[];
   auth_mode: string;
+  /** `true` when the catalog row is in a state where the install endpoint
+   *  will provision a connection (currently always `true` for visible
+   *  rows, but the field is honored so a feature-flagged row doesn't
+   *  break the flow). When `false` the card falls back to emitting the
+   *  legacy `authorize` event so the AuthFrontend deep-link install page
+   *  can render whatever non-self-serve copy it wants. */
+  installable: boolean;
+}
+
+/** Response shape of AuthBackend's
+ *  `POST /api/v1/connections/catalog/<id>/install/`. See
+ *  `app.services.connector_catalog.install_for_user`. */
+export interface IConnectorCatalogInstallResponse {
+  type: 'redirect' | 'form' | 'active';
+  /** Present iff `type === 'redirect'` — the upstream provider's OAuth
+   *  authorize URL the browser should navigate to. */
+  authorization_url?: string;
+  /** Present iff `type === 'form'` — credential schema the AuthFrontend
+   *  BYOC dialog renders. The consent card does NOT handle this case
+   *  inline; the parent emits the legacy `authorize` event and the user
+   *  finishes BYOC on the AuthFrontend install page. */
+  schema?: unknown;
 }
 
 const cache = new Map<string, IConnectorCatalogSummary>();
@@ -90,4 +112,25 @@ export async function getCatalogItem(catalogId: string): Promise<IConnectorCatal
 export function clearConnectorCatalogCache(): void {
   cache.clear();
   inFlight.clear();
+}
+
+/**
+ * Provision (or kick off OAuth for) a connection for the calling user.
+ * Mirrors AuthFrontend's `connectionOperator.installFromCatalog` — same
+ * AuthBackend endpoint, same response shape.
+ *
+ * Throws on network / HTTP errors so the caller can fall back to the
+ * worker-supplied `entry.install_url` deep-link (which AuthFrontend then
+ * handles, including BYOC credential forms).
+ */
+export async function installFromCatalog(
+  catalogId: string,
+  payload: { scopes?: string[]; return_url: string }
+): Promise<IConnectorCatalogInstallResponse> {
+  const response: AxiosResponse<IConnectorCatalogInstallResponse> = await httpClient.post(
+    `/connections/catalog/${catalogId}/install/`,
+    payload,
+    { baseURL: `${getBaseUrlAuth()}/api/v1` }
+  );
+  return response.data;
 }

--- a/src/components/chat/connectorConsent.test.ts
+++ b/src/components/chat/connectorConsent.test.ts
@@ -13,11 +13,13 @@ const REQUIRE_GMAIL: IConsentRequestPayload = {
       entries: [
         {
           connector: 'acedatacloud/gmail',
+          catalog_id: 'cat_gmail',
           status: 'unconnected',
           install_url: 'https://example.com/oauth/gmail'
         },
         {
           connector: 'acedatacloud/outlook',
+          catalog_id: 'cat_outlook',
           status: 'unconnected',
           install_url: 'https://example.com/oauth/outlook'
         }
@@ -34,15 +36,20 @@ const REQUIRE_GMAIL_AND_DRIVE: IConsentRequestPayload = {
       match: 'all',
       satisfied: false,
       entries: [
-        { connector: 'acedatacloud/gmail', status: 'connected' },
-        { connector: 'acedatacloud/drive', status: 'unconnected', install_url: 'https://x/drive' }
+        { connector: 'acedatacloud/gmail', catalog_id: 'cat_gmail', status: 'connected' },
+        {
+          connector: 'acedatacloud/drive',
+          catalog_id: 'cat_drive',
+          status: 'unconnected',
+          install_url: 'https://x/drive'
+        }
       ]
     },
     {
       requirement_index: 1,
       match: 'any',
       satisfied: true,
-      entries: [{ connector: 'acedatacloud/calendar', status: 'connected' }]
+      entries: [{ connector: 'acedatacloud/calendar', catalog_id: 'cat_calendar', status: 'connected' }]
     }
   ]
 };
@@ -67,13 +74,13 @@ describe('unsatisfiedConnectors', () => {
           requirement_index: 0,
           match: 'any',
           satisfied: false,
-          entries: [{ connector: 'acedatacloud/gmail', status: 'unconnected' }]
+          entries: [{ connector: 'acedatacloud/gmail', catalog_id: 'cat_gmail', status: 'unconnected' }]
         },
         {
           requirement_index: 1,
           match: 'any',
           satisfied: false,
-          entries: [{ connector: 'acedatacloud/gmail', status: 'unconnected' }]
+          entries: [{ connector: 'acedatacloud/gmail', catalog_id: 'cat_gmail', status: 'unconnected' }]
         }
       ]
     };
@@ -119,7 +126,7 @@ describe('isAllSatisfied', () => {
           requirement_index: 0,
           match: 'any',
           satisfied: true,
-          entries: [{ connector: 'acedatacloud/x', status: 'connected' }]
+          entries: [{ connector: 'acedatacloud/x', catalog_id: 'cat_x', status: 'connected' }]
         }
       ]
     };

--- a/src/components/chat/consentReturn.test.ts
+++ b/src/components/chat/consentReturn.test.ts
@@ -11,8 +11,13 @@ const PAYLOAD: IConsentRequestPayload = {
       match: 'any',
       satisfied: false,
       entries: [
-        { connector: 'acedatacloud/gmail', status: 'unconnected', install_url: 'https://x/g' },
-        { connector: 'acedatacloud/outlook', status: 'unconnected', install_url: 'https://x/o' }
+        { connector: 'acedatacloud/gmail', catalog_id: 'cat_gmail', status: 'unconnected', install_url: 'https://x/g' },
+        {
+          connector: 'acedatacloud/outlook',
+          catalog_id: 'cat_outlook',
+          status: 'unconnected',
+          install_url: 'https://x/o'
+        }
       ]
     }
   ]

--- a/src/i18n/ar/chat.json
+++ b/src/i18n/ar/chat.json
@@ -527,6 +527,10 @@
     "message": "تخطي التفويض",
     "description": "زر لتخطي التفويض، بعد النقر سيستمر النموذج بدون هذا الموصل"
   },
+  "consent.continue": {
+    "message": "متابعة",
+    "description": "زر المتابعة الذي يظهر بعد اكتشاف أن الموصل أصبح متصلاً بعد عودة OAuth؛ النقر يقدّم التفويض."
+  },
   "consent.selectScopes": {
     "message": "اختر نطاقات تفويض {provider}",
     "description": "Title of the scope picker dialog opened from the consent card; {provider} is the upstream provider name (e.g. Gmail)."

--- a/src/i18n/ar/chat.json
+++ b/src/i18n/ar/chat.json
@@ -527,6 +527,18 @@
     "message": "تخطي التفويض",
     "description": "زر لتخطي التفويض، بعد النقر سيستمر النموذج بدون هذا الموصل"
   },
+  "consent.selectScopes": {
+    "message": "اختر نطاقات تفويض {provider}",
+    "description": "Title of the scope picker dialog opened from the consent card; {provider} is the upstream provider name (e.g. Gmail)."
+  },
+  "consent.selectScopesHint": {
+    "message": "اختر الأذونات التي ترغب في تفويضها. يمكنك اختيار أكثر من واحدة، وإذا لم يتم اختيار أي منها، سيتم منح معلومات تسجيل الدخول الأساسية فقط.",
+    "description": "Body copy explaining that the user can opt out of specific scopes; rendered above the checkbox group."
+  },
+  "consent.installFailed": {
+    "message": "فشل التفويض. يرجى المحاولة مرة أخرى.",
+    "description": "Toast shown when the AuthBackend install endpoint returns an error from the consent card."
+  },
   "consent.statusConnected": {
     "message": "متصل",
     "description": "شارة الحالة للموصلات المتصلة"

--- a/src/i18n/de/chat.json
+++ b/src/i18n/de/chat.json
@@ -527,6 +527,18 @@
     "message": "Vorübergehend nicht autorisieren",
     "description": "Button zum Überspringen der Autorisierung, nach dem Überspringen wird das Modell ohne diesen Connector fortgesetzt"
   },
+  "consent.selectScopes": {
+    "message": "Wählen Sie die Berechtigungen von {provider}",
+    "description": "Title of the scope picker dialog opened from the consent card; {provider} is the upstream provider name (e.g. Gmail)."
+  },
+  "consent.selectScopesHint": {
+    "message": "Wählen Sie die Berechtigungen aus, die Sie autorisieren möchten. Mehrfachauswahl möglich, nicht ausgewählte Berechtigungen gewähren standardmäßig nur grundlegende Anmeldeinformationen.",
+    "description": "Body copy explaining that the user can opt out of specific scopes; rendered above the checkbox group."
+  },
+  "consent.installFailed": {
+    "message": "Autorisierung fehlgeschlagen. Bitte versuchen Sie es erneut.",
+    "description": "Toast shown when the AuthBackend install endpoint returns an error from the consent card."
+  },
   "consent.statusConnected": {
     "message": "Verbunden",
     "description": "Statussymbol für verbundene Connectoren"

--- a/src/i18n/de/chat.json
+++ b/src/i18n/de/chat.json
@@ -527,6 +527,10 @@
     "message": "Vorübergehend nicht autorisieren",
     "description": "Button zum Überspringen der Autorisierung, nach dem Überspringen wird das Modell ohne diesen Connector fortgesetzt"
   },
+  "consent.continue": {
+    "message": "Fortfahren",
+    "description": "Schaltfläche „Fortfahren“ erscheint, sobald nach der OAuth-Rückkehr erkannt wird, dass der Connector verbunden ist; ein Klick reicht die Autorisierung ein."
+  },
   "consent.selectScopes": {
     "message": "Wählen Sie die Berechtigungen von {provider}",
     "description": "Title of the scope picker dialog opened from the consent card; {provider} is the upstream provider name (e.g. Gmail)."

--- a/src/i18n/el/chat.json
+++ b/src/i18n/el/chat.json
@@ -527,6 +527,18 @@
     "message": "Παράλειψη εξουσιοδότησης",
     "description": "Κουμπί παράλειψης εξουσιοδότησης, μετά την παράλειψη το μοντέλο συνεχίζει χωρίς αυτόν τον σύνδεσμο"
   },
+  "consent.selectScopes": {
+    "message": "Επιλέξτε εξουσιοδοτήσεις {provider}",
+    "description": "Title of the scope picker dialog opened from the consent card; {provider} is the upstream provider name (e.g. Gmail)."
+  },
+  "consent.selectScopesHint": {
+    "message": "Επιλέξτε τις εξουσιοδοτήσεις που θέλετε να δώσετε. Μπορείτε να επιλέξετε πολλές, αν δεν επιλέξετε, θα δοθούν μόνο οι βασικές πληροφορίες σύνδεσης.",
+    "description": "Body copy explaining that the user can opt out of specific scopes; rendered above the checkbox group."
+  },
+  "consent.installFailed": {
+    "message": "Η εξουσιοδότηση απέτυχε. Παρακαλώ προσπαθήστε ξανά.",
+    "description": "Toast shown when the AuthBackend install endpoint returns an error from the consent card."
+  },
   "consent.statusConnected": {
     "message": "Συνδεδεμένο",
     "description": "Εικονίδιο κατάστασης για συνδέσεις που έχουν συνδεθεί"

--- a/src/i18n/el/chat.json
+++ b/src/i18n/el/chat.json
@@ -527,6 +527,10 @@
     "message": "Παράλειψη εξουσιοδότησης",
     "description": "Κουμπί παράλειψης εξουσιοδότησης, μετά την παράλειψη το μοντέλο συνεχίζει χωρίς αυτόν τον σύνδεσμο"
   },
+  "consent.continue": {
+    "message": "Συνέχεια",
+    "description": "Κουμπί «Συνέχεια» που εμφανίζεται όταν μετά την επιστροφή OAuth ανιχνεύεται ότι ο σύνδεσμος έχει συνδεθεί· το κλικ υποβάλλει την εξουσιοδότηση."
+  },
   "consent.selectScopes": {
     "message": "Επιλέξτε εξουσιοδοτήσεις {provider}",
     "description": "Title of the scope picker dialog opened from the consent card; {provider} is the upstream provider name (e.g. Gmail)."

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -527,6 +527,10 @@
     "message": "Skip",
     "description": "Skip button; continue without authorizing any connector"
   },
+  "consent.continue": {
+    "message": "Continue",
+    "description": "Continue button shown after we detect (post-OAuth) that the connector is now connected; submitting authorizes it."
+  },
   "consent.selectScopes": {
     "message": "Select {provider} Authorization Scopes",
     "description": "Title of the scope picker dialog opened from the consent card; {provider} is the upstream provider name (e.g. Gmail)."

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -527,6 +527,18 @@
     "message": "Skip",
     "description": "Skip button; continue without authorizing any connector"
   },
+  "consent.selectScopes": {
+    "message": "Select {provider} Authorization Scopes",
+    "description": "Title of the scope picker dialog opened from the consent card; {provider} is the upstream provider name (e.g. Gmail)."
+  },
+  "consent.selectScopesHint": {
+    "message": "Select the permissions you wish to authorize. Multiple selections are allowed; by default, only basic login information is granted.",
+    "description": "Body copy explaining that the user can opt out of specific scopes; rendered above the checkbox group."
+  },
+  "consent.installFailed": {
+    "message": "Authorization failed. Please try again.",
+    "description": "Toast shown when the AuthBackend install endpoint returns an error from the consent card."
+  },
   "consent.statusConnected": {
     "message": "Connected",
     "description": "Pill badge for already-connected connectors"

--- a/src/i18n/es/chat.json
+++ b/src/i18n/es/chat.json
@@ -527,6 +527,18 @@
     "message": "Omitir autorización",
     "description": "Botón para saltarse la autorización; tras hacerlo, el modelo continuará sin este conector"
   },
+  "consent.selectScopes": {
+    "message": "Selecciona los ámbitos de autorización de {provider}",
+    "description": "Title of the scope picker dialog opened from the consent card; {provider} is the upstream provider name (e.g. Gmail)."
+  },
+  "consent.selectScopesHint": {
+    "message": "Selecciona los permisos que deseas autorizar. Puedes seleccionar múltiples, si no seleccionas, solo se otorgarán los datos básicos de inicio de sesión.",
+    "description": "Body copy explaining that the user can opt out of specific scopes; rendered above the checkbox group."
+  },
+  "consent.installFailed": {
+    "message": "La autorización falló. Por favor, inténtalo de nuevo.",
+    "description": "Toast shown when the AuthBackend install endpoint returns an error from the consent card."
+  },
   "consent.statusConnected": {
     "message": "Conectado",
     "description": "Etiqueta de estado para un conector ya conectado"

--- a/src/i18n/es/chat.json
+++ b/src/i18n/es/chat.json
@@ -527,6 +527,10 @@
     "message": "Omitir autorización",
     "description": "Botón para saltarse la autorización; tras hacerlo, el modelo continuará sin este conector"
   },
+  "consent.continue": {
+    "message": "Continuar",
+    "description": "Botón Continuar que aparece tras detectar (post-OAuth) que el conector ya está conectado; al pulsarlo se envía la autorización."
+  },
   "consent.selectScopes": {
     "message": "Selecciona los ámbitos de autorización de {provider}",
     "description": "Title of the scope picker dialog opened from the consent card; {provider} is the upstream provider name (e.g. Gmail)."

--- a/src/i18n/fi/chat.json
+++ b/src/i18n/fi/chat.json
@@ -527,6 +527,18 @@
     "message": "Ohita valtuutus",
     "description": "Ohita valtuutuspainike; ohituksen jälkeen malli jatkaa ilman tätä liitintä"
   },
+  "consent.selectScopes": {
+    "message": "Valitse {provider} -valtuutusalueet",
+    "description": "Title of the scope picker dialog opened from the consent card; {provider} is the upstream provider name (e.g. Gmail)."
+  },
+  "consent.selectScopesHint": {
+    "message": "Valitse haluamasi valtuutukset. Voit valita useita, mutta oletuksena vain peruskirjautumistiedot myönnetään.",
+    "description": "Body copy explaining that the user can opt out of specific scopes; rendered above the checkbox group."
+  },
+  "consent.installFailed": {
+    "message": "Valtuutus epäonnistui. Yritä uudelleen.",
+    "description": "Toast shown when the AuthBackend install endpoint returns an error from the consent card."
+  },
   "consent.statusConnected": {
     "message": "Yhdistetty",
     "description": "Valtuutetun liittimen tilasymboli"

--- a/src/i18n/fi/chat.json
+++ b/src/i18n/fi/chat.json
@@ -527,6 +527,10 @@
     "message": "Ohita valtuutus",
     "description": "Ohita valtuutuspainike; ohituksen jälkeen malli jatkaa ilman tätä liitintä"
   },
+  "consent.continue": {
+    "message": "Jatka",
+    "description": "Jatka-painike, joka näytetään, kun OAuth-paluun jälkeen havaitaan, että liitin on yhdistetty; napsautus lähettää valtuutuksen."
+  },
   "consent.selectScopes": {
     "message": "Valitse {provider} -valtuutusalueet",
     "description": "Title of the scope picker dialog opened from the consent card; {provider} is the upstream provider name (e.g. Gmail)."

--- a/src/i18n/fr/chat.json
+++ b/src/i18n/fr/chat.json
@@ -527,6 +527,18 @@
     "message": "Ignorer pour l'instant",
     "description": "Bouton pour passer l'autorisation, le modèle continuera sans ce connecteur"
   },
+  "consent.selectScopes": {
+    "message": "Sélectionnez les portées d'autorisation {provider}",
+    "description": "Title of the scope picker dialog opened from the consent card; {provider} is the upstream provider name (e.g. Gmail)."
+  },
+  "consent.selectScopesHint": {
+    "message": "Sélectionnez les permissions que vous souhaitez autoriser. Plusieurs choix possibles, par défaut, seules les informations de connexion de base sont accordées.",
+    "description": "Body copy explaining that the user can opt out of specific scopes; rendered above the checkbox group."
+  },
+  "consent.installFailed": {
+    "message": "L'autorisation a échoué. Veuillez réessayer.",
+    "description": "Toast shown when the AuthBackend install endpoint returns an error from the consent card."
+  },
   "consent.statusConnected": {
     "message": "Connecté",
     "description": "Badge indiquant qu'un connecteur est connecté"

--- a/src/i18n/fr/chat.json
+++ b/src/i18n/fr/chat.json
@@ -527,6 +527,10 @@
     "message": "Ignorer pour l'instant",
     "description": "Bouton pour passer l'autorisation, le modèle continuera sans ce connecteur"
   },
+  "consent.continue": {
+    "message": "Continuer",
+    "description": "Bouton Continuer affiché lorsque, après le retour OAuth, on détecte que le connecteur est connecté ; un clic soumet l'autorisation."
+  },
   "consent.selectScopes": {
     "message": "Sélectionnez les portées d'autorisation {provider}",
     "description": "Title of the scope picker dialog opened from the consent card; {provider} is the upstream provider name (e.g. Gmail)."

--- a/src/i18n/it/chat.json
+++ b/src/i18n/it/chat.json
@@ -527,6 +527,18 @@
     "message": "Non autorizzare per ora",
     "description": "Pulsante per saltare l'autorizzazione; il modello continuerà senza il connettore"
   },
+  "consent.selectScopes": {
+    "message": "Seleziona gli ambiti di autorizzazione per {provider}",
+    "description": "Title of the scope picker dialog opened from the consent card; {provider} is the upstream provider name (e.g. Gmail)."
+  },
+  "consent.selectScopesHint": {
+    "message": "Seleziona i permessi che desideri autorizzare. Puoi selezionare più opzioni; se non selezionato, verranno concessi solo i dati di accesso di base.",
+    "description": "Body copy explaining that the user can opt out of specific scopes; rendered above the checkbox group."
+  },
+  "consent.installFailed": {
+    "message": "Autorizzazione fallita. Si prega di riprovare.",
+    "description": "Toast shown when the AuthBackend install endpoint returns an error from the consent card."
+  },
   "consent.statusConnected": {
     "message": "Connesso",
     "description": "Indicatore di stato per connettore già connesso"

--- a/src/i18n/it/chat.json
+++ b/src/i18n/it/chat.json
@@ -527,6 +527,10 @@
     "message": "Non autorizzare per ora",
     "description": "Pulsante per saltare l'autorizzazione; il modello continuerà senza il connettore"
   },
+  "consent.continue": {
+    "message": "Continua",
+    "description": "Pulsante Continua mostrato dopo aver rilevato (post-OAuth) che il connettore è ora collegato; il clic invia l'autorizzazione."
+  },
   "consent.selectScopes": {
     "message": "Seleziona gli ambiti di autorizzazione per {provider}",
     "description": "Title of the scope picker dialog opened from the consent card; {provider} is the upstream provider name (e.g. Gmail)."

--- a/src/i18n/ja/chat.json
+++ b/src/i18n/ja/chat.json
@@ -527,6 +527,18 @@
     "message": "あとで認可",
     "description": "認可をスキップするボタン。スキップ後、モデルはそのコネクタなしで進行します"
   },
+  "consent.selectScopes": {
+    "message": "{provider}の権限範囲を選択",
+    "description": "Title of the scope picker dialog opened from the consent card; {provider} is the upstream provider name (e.g. Gmail)."
+  },
+  "consent.selectScopesHint": {
+    "message": "付与したい権限範囲を選択してください。複数選択可能で、未選択の場合は基本的なログイン情報のみが付与されます。",
+    "description": "Body copy explaining that the user can opt out of specific scopes; rendered above the checkbox group."
+  },
+  "consent.installFailed": {
+    "message": "認証に失敗しました。もう一度お試しください。",
+    "description": "Toast shown when the AuthBackend install endpoint returns an error from the consent card."
+  },
   "consent.statusConnected": {
     "message": "接続済み",
     "description": "接続済みコネクタのステータスバッジ"

--- a/src/i18n/ja/chat.json
+++ b/src/i18n/ja/chat.json
@@ -527,6 +527,10 @@
     "message": "あとで認可",
     "description": "認可をスキップするボタン。スキップ後、モデルはそのコネクタなしで進行します"
   },
+  "consent.continue": {
+    "message": "続ける",
+    "description": "OAuth 復帰後にコネクタが接続済みになったことを検知した際に表示する『続ける』ボタン。クリックすると認可を送信します。"
+  },
   "consent.selectScopes": {
     "message": "{provider}の権限範囲を選択",
     "description": "Title of the scope picker dialog opened from the consent card; {provider} is the upstream provider name (e.g. Gmail)."

--- a/src/i18n/ko/chat.json
+++ b/src/i18n/ko/chat.json
@@ -527,6 +527,18 @@
     "message": "권한 부여 건너뛰기",
     "description": "권한 부여를 건너뛰는 버튼으로, 건너뛴 후 모델은 해당 커넥터 없이 계속 진행됩니다."
   },
+  "consent.selectScopes": {
+    "message": "{provider} 권한 범위 선택",
+    "description": "Title of the scope picker dialog opened from the consent card; {provider} is the upstream provider name (e.g. Gmail)."
+  },
+  "consent.selectScopesHint": {
+    "message": "부여할 권한 범위를 선택하세요. 여러 개 선택할 수 있으며, 선택하지 않으면 기본 로그인 정보만 부여됩니다.",
+    "description": "Body copy explaining that the user can opt out of specific scopes; rendered above the checkbox group."
+  },
+  "consent.installFailed": {
+    "message": "권한 부여에 실패했습니다. 다시 시도해 주세요.",
+    "description": "Toast shown when the AuthBackend install endpoint returns an error from the consent card."
+  },
   "consent.statusConnected": {
     "message": "연결됨",
     "description": "연결된 커넥터의 상태 아이콘입니다."

--- a/src/i18n/ko/chat.json
+++ b/src/i18n/ko/chat.json
@@ -527,6 +527,10 @@
     "message": "권한 부여 건너뛰기",
     "description": "권한 부여를 건너뛰는 버튼으로, 건너뛴 후 모델은 해당 커넥터 없이 계속 진행됩니다."
   },
+  "consent.continue": {
+    "message": "계속",
+    "description": "OAuth 복귀 후 커넥터가 연결된 것으로 감지되었을 때 표시되는 계속 버튼입니다. 클릭하면 권한 부여를 제출합니다."
+  },
   "consent.selectScopes": {
     "message": "{provider} 권한 범위 선택",
     "description": "Title of the scope picker dialog opened from the consent card; {provider} is the upstream provider name (e.g. Gmail)."

--- a/src/i18n/pl/chat.json
+++ b/src/i18n/pl/chat.json
@@ -527,6 +527,10 @@
     "message": "Pomiń autoryzację",
     "description": "Przycisk pominięcia autoryzacji; po pominięciu model kontynuuje bez tego konektora"
   },
+  "consent.continue": {
+    "message": "Kontynuuj",
+    "description": "Przycisk Kontynuuj wyświetlany, gdy po powrocie z OAuth wykryto, że konektor jest podłączony; kliknięcie wysyła autoryzację."
+  },
   "consent.selectScopes": {
     "message": "Wybierz zakresy autoryzacji {provider}",
     "description": "Title of the scope picker dialog opened from the consent card; {provider} is the upstream provider name (e.g. Gmail)."

--- a/src/i18n/pl/chat.json
+++ b/src/i18n/pl/chat.json
@@ -527,6 +527,18 @@
     "message": "Pomiń autoryzację",
     "description": "Przycisk pominięcia autoryzacji; po pominięciu model kontynuuje bez tego konektora"
   },
+  "consent.selectScopes": {
+    "message": "Wybierz zakresy autoryzacji {provider}",
+    "description": "Title of the scope picker dialog opened from the consent card; {provider} is the upstream provider name (e.g. Gmail)."
+  },
+  "consent.selectScopesHint": {
+    "message": "Wybierz uprawnienia, które chcesz autoryzować. Możesz wybrać wiele, domyślnie przyznawane są tylko podstawowe informacje logowania.",
+    "description": "Body copy explaining that the user can opt out of specific scopes; rendered above the checkbox group."
+  },
+  "consent.installFailed": {
+    "message": "Autoryzacja nie powiodła się. Spróbuj ponownie.",
+    "description": "Toast shown when the AuthBackend install endpoint returns an error from the consent card."
+  },
   "consent.statusConnected": {
     "message": "Połączono",
     "description": "Znacznik statusu dla konektora, który jest połączony"

--- a/src/i18n/pt/chat.json
+++ b/src/i18n/pt/chat.json
@@ -527,6 +527,10 @@
     "message": "Ignorar por enquanto",
     "description": "Botão para pular a autorização; ao pular, o modelo continuará sem este conector"
   },
+  "consent.continue": {
+    "message": "Continuar",
+    "description": "Botão Continuar exibido após detectar (pós-OAuth) que o conector está conectado; o clique envia a autorização."
+  },
   "consent.selectScopes": {
     "message": "Selecione os Escopos de Autorização do {provider}",
     "description": "Title of the scope picker dialog opened from the consent card; {provider} is the upstream provider name (e.g. Gmail)."

--- a/src/i18n/pt/chat.json
+++ b/src/i18n/pt/chat.json
@@ -527,6 +527,18 @@
     "message": "Ignorar por enquanto",
     "description": "Botão para pular a autorização; ao pular, o modelo continuará sem este conector"
   },
+  "consent.selectScopes": {
+    "message": "Selecione os Escopos de Autorização do {provider}",
+    "description": "Title of the scope picker dialog opened from the consent card; {provider} is the upstream provider name (e.g. Gmail)."
+  },
+  "consent.selectScopesHint": {
+    "message": "Escolha as permissões que você deseja autorizar. Você pode selecionar múltiplas opções; se não selecionar, apenas as informações básicas de login serão concedidas.",
+    "description": "Body copy explaining that the user can opt out of specific scopes; rendered above the checkbox group."
+  },
+  "consent.installFailed": {
+    "message": "A autorização falhou. Por favor, tente novamente.",
+    "description": "Toast shown when the AuthBackend install endpoint returns an error from the consent card."
+  },
   "consent.statusConnected": {
     "message": "Conectado",
     "description": "Indicador de status para conectores já conectados"

--- a/src/i18n/ru/chat.json
+++ b/src/i18n/ru/chat.json
@@ -527,6 +527,10 @@
     "message": "Пропустить",
     "description": "Кнопка пропуска авторизации, после нажатия модель продолжит работу без этого коннектора"
   },
+  "consent.continue": {
+    "message": "Продолжить",
+    "description": "Кнопка «Продолжить», появляется после возврата OAuth, когда обнаружено, что коннектор подключён; нажатие отправляет авторизацию."
+  },
   "consent.selectScopes": {
     "message": "Выберите разрешения {provider}",
     "description": "Title of the scope picker dialog opened from the consent card; {provider} is the upstream provider name (e.g. Gmail)."

--- a/src/i18n/ru/chat.json
+++ b/src/i18n/ru/chat.json
@@ -527,6 +527,18 @@
     "message": "Пропустить",
     "description": "Кнопка пропуска авторизации, после нажатия модель продолжит работу без этого коннектора"
   },
+  "consent.selectScopes": {
+    "message": "Выберите разрешения {provider}",
+    "description": "Title of the scope picker dialog opened from the consent card; {provider} is the upstream provider name (e.g. Gmail)."
+  },
+  "consent.selectScopesHint": {
+    "message": "Выберите разрешения, которые вы хотите предоставить. Можно выбрать несколько, по умолчанию предоставляются только основные данные для входа.",
+    "description": "Body copy explaining that the user can opt out of specific scopes; rendered above the checkbox group."
+  },
+  "consent.installFailed": {
+    "message": "Авторизация не удалась. Пожалуйста, попробуйте снова.",
+    "description": "Toast shown when the AuthBackend install endpoint returns an error from the consent card."
+  },
   "consent.statusConnected": {
     "message": "Подключено",
     "description": "Индикатор статуса для подключенного коннектора"

--- a/src/i18n/sr/chat.json
+++ b/src/i18n/sr/chat.json
@@ -527,6 +527,10 @@
     "message": "Тренутно не овлашћујем",
     "description": "Дугме за прескакање овлашћења, након прескакања модел ће наставити без тог конектора"
   },
+  "consent.continue": {
+    "message": "Настави",
+    "description": "Дугме „Настави“ приказује се када се после повратка са OAuth-а открије да је конектор повезан; кликом се шаље овлашћење."
+  },
   "consent.selectScopes": {
     "message": "Izaberite ovlašćenja {provider}",
     "description": "Title of the scope picker dialog opened from the consent card; {provider} is the upstream provider name (e.g. Gmail)."

--- a/src/i18n/sr/chat.json
+++ b/src/i18n/sr/chat.json
@@ -527,6 +527,18 @@
     "message": "Тренутно не овлашћујем",
     "description": "Дугме за прескакање овлашћења, након прескакања модел ће наставити без тог конектора"
   },
+  "consent.selectScopes": {
+    "message": "Izaberite ovlašćenja {provider}",
+    "description": "Title of the scope picker dialog opened from the consent card; {provider} is the upstream provider name (e.g. Gmail)."
+  },
+  "consent.selectScopesHint": {
+    "message": "Izaberite ovlašćenja koja želite da odobrite. Možete izabrati više opcija, a neizabrana će podrazumevano odobriti samo osnovne informacije za prijavu.",
+    "description": "Body copy explaining that the user can opt out of specific scopes; rendered above the checkbox group."
+  },
+  "consent.installFailed": {
+    "message": "Autorizacija nije uspela. Molimo pokušajte ponovo.",
+    "description": "Toast shown when the AuthBackend install endpoint returns an error from the consent card."
+  },
   "consent.statusConnected": {
     "message": "Повезано",
     "description": "Статусни значак за повезане конекторе"

--- a/src/i18n/sv/chat.json
+++ b/src/i18n/sv/chat.json
@@ -527,6 +527,18 @@
     "message": "Hoppa över",
     "description": "Knapp för att hoppa över behörighet, modellen fortsätter utan denna koppling"
   },
+  "consent.selectScopes": {
+    "message": "Välj {provider} behörighetsområden",
+    "description": "Title of the scope picker dialog opened from the consent card; {provider} is the upstream provider name (e.g. Gmail)."
+  },
+  "consent.selectScopesHint": {
+    "message": "Välj de behörigheter du vill auktorisera. Flera val är möjliga, om inget väljs ges endast grundläggande inloggningsinformation.",
+    "description": "Body copy explaining that the user can opt out of specific scopes; rendered above the checkbox group."
+  },
+  "consent.installFailed": {
+    "message": "Auktoriseringen misslyckades. Försök igen.",
+    "description": "Toast shown when the AuthBackend install endpoint returns an error from the consent card."
+  },
   "consent.statusConnected": {
     "message": "Ansluten",
     "description": "Statusmärke för en ansluten koppling"

--- a/src/i18n/sv/chat.json
+++ b/src/i18n/sv/chat.json
@@ -527,6 +527,10 @@
     "message": "Hoppa över",
     "description": "Knapp för att hoppa över behörighet, modellen fortsätter utan denna koppling"
   },
+  "consent.continue": {
+    "message": "Fortsätt",
+    "description": "Fortsätt-knapp som visas när vi efter OAuth-returen upptäcker att kopplingen är ansluten; klick skickar in behörigheten."
+  },
   "consent.selectScopes": {
     "message": "Välj {provider} behörighetsområden",
     "description": "Title of the scope picker dialog opened from the consent card; {provider} is the upstream provider name (e.g. Gmail)."

--- a/src/i18n/uk/chat.json
+++ b/src/i18n/uk/chat.json
@@ -527,6 +527,10 @@
     "message": "Пропустити авторизацію",
     "description": "Кнопка пропуску авторизації, після натискання модель продовжить роботу без цього конектора"
   },
+  "consent.continue": {
+    "message": "Продовжити",
+    "description": "Кнопка «Продовжити», з'являється після повернення з OAuth, коли виявлено, що конектор підключено; натискання надсилає авторизацію."
+  },
   "consent.selectScopes": {
     "message": "Виберіть авторизаційні області {provider}",
     "description": "Title of the scope picker dialog opened from the consent card; {provider} is the upstream provider name (e.g. Gmail)."

--- a/src/i18n/uk/chat.json
+++ b/src/i18n/uk/chat.json
@@ -527,6 +527,18 @@
     "message": "Пропустити авторизацію",
     "description": "Кнопка пропуску авторизації, після натискання модель продовжить роботу без цього конектора"
   },
+  "consent.selectScopes": {
+    "message": "Виберіть авторизаційні області {provider}",
+    "description": "Title of the scope picker dialog opened from the consent card; {provider} is the upstream provider name (e.g. Gmail)."
+  },
+  "consent.selectScopesHint": {
+    "message": "Виберіть дозволи, які ви хочете надати. Можна вибрати кілька, за замовчуванням надається лише базова інформація для входу.",
+    "description": "Body copy explaining that the user can opt out of specific scopes; rendered above the checkbox group."
+  },
+  "consent.installFailed": {
+    "message": "Авторизація не вдалася. Будь ласка, спробуйте ще раз.",
+    "description": "Toast shown when the AuthBackend install endpoint returns an error from the consent card."
+  },
   "consent.statusConnected": {
     "message": "Підключено",
     "description": "Позначка стану для підключеного конектора"

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -527,6 +527,18 @@
     "message": "暂不授权",
     "description": "跳过授权按钮，跳过后模型将在没有该连接器的情况下继续"
   },
+  "consent.selectScopes": {
+    "message": "选择 {provider} 授权范围",
+    "description": "Title of the scope picker dialog opened from the consent card; {provider} is the upstream provider name (e.g. Gmail)."
+  },
+  "consent.selectScopesHint": {
+    "message": "选择您希望授权的权限范围。可多选，未选中默认仅授予基础登录信息。",
+    "description": "Body copy explaining that the user can opt out of specific scopes; rendered above the checkbox group."
+  },
+  "consent.installFailed": {
+    "message": "授权失败，请稍后重试。",
+    "description": "Toast shown when the AuthBackend install endpoint returns an error from the consent card."
+  },
   "consent.statusConnected": {
     "message": "已连接",
     "description": "已连接连接器的状态徽标"

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -527,6 +527,10 @@
     "message": "暂不授权",
     "description": "跳过授权按钮，跳过后模型将在没有该连接器的情况下继续"
   },
+  "consent.continue": {
+    "message": "继续",
+    "description": "继续按钮，OAuth 回跳后检测到连接器已连接时显示，点击后提交本次授权"
+  },
   "consent.selectScopes": {
     "message": "选择 {provider} 授权范围",
     "description": "Title of the scope picker dialog opened from the consent card; {provider} is the upstream provider name (e.g. Gmail)."

--- a/src/i18n/zh-TW/chat.json
+++ b/src/i18n/zh-TW/chat.json
@@ -527,6 +527,10 @@
     "message": "暫不授權",
     "description": "跳過授權按鈕，跳過後模型將在沒有該連接器的情況下繼續"
   },
+  "consent.continue": {
+    "message": "繼續",
+    "description": "繼續按鈕，OAuth 回跳後偵測到連接器已連接時顯示，點擊後提交本次授權"
+  },
   "consent.selectScopes": {
     "message": "選擇 {provider} 授權範圍",
     "description": "Title of the scope picker dialog opened from the consent card; {provider} is the upstream provider name (e.g. Gmail)."

--- a/src/i18n/zh-TW/chat.json
+++ b/src/i18n/zh-TW/chat.json
@@ -527,6 +527,18 @@
     "message": "暫不授權",
     "description": "跳過授權按鈕，跳過後模型將在沒有該連接器的情況下繼續"
   },
+  "consent.selectScopes": {
+    "message": "選擇 {provider} 授權範圍",
+    "description": "Title of the scope picker dialog opened from the consent card; {provider} is the upstream provider name (e.g. Gmail)."
+  },
+  "consent.selectScopesHint": {
+    "message": "選擇您希望授權的權限範圍。可多選，未選中默認僅授予基礎登錄信息。",
+    "description": "Body copy explaining that the user can opt out of specific scopes; rendered above the checkbox group."
+  },
+  "consent.installFailed": {
+    "message": "授權失敗，請稍後重試。",
+    "description": "Toast shown when the AuthBackend install endpoint returns an error from the consent card."
+  },
   "consent.statusConnected": {
     "message": "已連接",
     "description": "已連接連接器的狀態徽章"

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -157,6 +157,14 @@ export interface IAskUserQuestionPayload {
 export interface IConsentRequestEntry {
   /** Catalog identifier, e.g. `acedatacloud/suno`. */
   connector: string;
+  /** Stable UUID of the matching `ConnectorCatalogItem` row in AuthBackend
+   *  (`/api/v1/connections/catalog/<id>/`). Required: the consent card uses
+   *  this to fetch logo / localized name / permission list so each row can
+   *  show the upstream brand instead of the opaque slug. Emitted by the
+   *  worker's `get_connector_status` tool — there is no fallback because
+   *  Layer-2 validation guarantees every entry's `connector` resolves to
+   *  a catalog row. */
+  catalog_id: string;
   /** Short, user-facing phrase explaining why this connector is needed.
    *  May be empty/undefined if the model omitted it. */
   context?: string;


### PR DESCRIPTION
## Summary

Extends the consent card UX with two improvements, layered on top of the existing OAuth flow:

1. **Catalog metadata + in-card scope picker** — the card now resolves each connector's catalog entry (logo + localized name + available scopes) so the user sees a real connector instead of a raw identifier, and `Authorize` opens an in-card scope picker that calls AuthBackend's catalog install endpoint directly (no Authorize tab roundtrip for trivial cases).
2. **Post-OAuth status refresh + `Continue` button** — when the user returns to Nexior with `?consent=<id>` after the upstream OAuth handshake, the card queries AuthBackend's connections list, overlays each entry's status with the live result, and surfaces a `Continue` button. Clicking `Continue` submits the consent with all effectively-connected connectors marked authorized, so the user explicitly confirms instead of being silently auto-resumed.

The legacy `consentReturn.ts` auto-resume path (which keys on `?connector=`) is left intact for any URL shape that still produces it, but the new flow does not depend on it.

## Changes

**Cache + API client**
- `src/components/chat/connectorCatalogCache.ts`
  - `getCatalogItem(id)` — fetches catalog item by identifier, with module-level cache.
  - `installFromCatalog(...)` — calls AuthBackend's catalog install endpoint (returns `redirect_url` for OAuth) used by the scope picker.
  - **NEW** `listMyConnections()` — calls `GET /api/v1/connections/` on AuthBackend, used by the post-OAuth refresh.

**Consent card component**
- `src/components/chat/ConnectorConsentCard.vue`
  - Logo + localized name rendering, scope picker dialog, direct install call.
  - **NEW** `liveStatuses` overlay + `refreshingStatus` flag.
  - **NEW** `effectiveStatus` / `effectiveEntriesFor` / `effectiveSatisfiedFor` computed — overlay-aware variants of the entry-status computations.
  - **NEW** `shouldRefreshFromReturn()` — only refreshes when `?consent=<id>` in URL matches the card's `consent_request_id`, so the AuthBackend call is gated.
  - **NEW** `refreshConnectionStatuses()` — async; runs on mount when the URL beacon matches; treats `status.toLowerCase() === 'active'` as connected; errors are swallowed via `console.warn`.
  - **NEW** `onContinue()` — collects effectively-connected entries and emits `submit` with `buildConsentOutput(payload, authorized, [])`.
  - **NEW** template: `Continue` button gated by `showContinueButton = !resolved && hasCheckedStatuses && !hasUnsatisfied`, sits alongside `Skip` (which now only renders while there are unsatisfied entries).

**i18n** (18 locales)
- `src/i18n/<locale>/chat.json` — new `consent.continue` key with `{ message, description }`. zh-CN is the base; `scripts/check_i18n_coverage.py` confirms parity.

**Tests**
- `src/components/chat/ConnectorConsentCard.test.ts`
  - Top-level `vi.mock('./connectorCatalogCache', ...)` covering `getCatalogItem`, `installFromCatalog`, and `listMyConnections`.
  - **NEW** describe block `ConnectorConsentCard — post-OAuth status refresh` with 6 cases:
    1. Does **not** refresh when the URL is missing the consent beacon.
    2. Does **not** refresh when `?consent=` belongs to a different `consent_request_id`.
    3. Flips the matching entry to `Connected` and shows `Continue` when the live API returns an active connection.
    4. Keeps `Skip` and **hides** `Continue` when the live API still reports no active connection.
    5. `Continue` emits `submit` with all effectively-connected connectors marked authorized.
    6. Swallows refresh errors without surfacing `Continue`.
  - Uses `Object.defineProperty(window, 'location', ...)` to stub URL per test (jsdom's `replaceState` refuses cross-origin targets).

## Validation

- `npx vitest run src/components/chat/` — **55 / 55 tests pass** (4 files: connectorConsent, askUserQuestion, consentReturn, ConnectorConsentCard).
- `npx vue-tsc -b --force` — clean.
- `python3 scripts/check_i18n_coverage.py` — `17 locale(s) × 39 namespace(s) all match zh-CN`.

## Related

- AuthBackend already exposes `GET /api/v1/connections/` (no schema change needed).
- PlatformService PR [#929](https://github.com/AceDataCloud/PlatformService/pull/929) adds `catalog_id` to the consent payload so the card can resolve catalog metadata in the first place — still open.

## Notes

- The `Continue` button is intentionally **not** silent auto-resume — the user reviews the now-Connected entry, then clicks. This matches the user's explicit ask: "如果是连接成功了，那 consent 上就能显示 continue 吧？"
- `hasCheckedStatuses` gates the `Continue` button so the legacy "already-satisfied from worker payload" case still suppresses it (preserves the existing `does NOT render the Skip button when all requirements are already satisfied` test).