### PR TITLE
feat(native): version gate at boot — block min_supported, soft-prompt latest

### DIFF
--- a/src/i18n/ar/common.json
+++ b/src/i18n/ar/common.json
@@ -926,5 +926,25 @@
   "message.uploadInProgress": {
     "message": "لا تزال عمليات رفع المراجع جارية — يُرجى الانتظار قليلاً.",
     "description": "Toast shown when the user clicks the Generate button while one or more reference uploads are still in flight. Asks them to wait for uploads to complete before retrying."
+  },
+  "appUpgrade.title": {
+    "message": "Update required",
+    "description": "Title of the native-app version gate modal shown at startup when the installed build is older than what the backend supports."
+  },
+  "appUpgrade.blockMessage": {
+    "message": "This version is no longer supported. Please update from the app store to continue.",
+    "description": "Body text of the hard-block upgrade modal shown when the installed version is below min_supported. The modal has no dismiss affordance — the only button opens the app store."
+  },
+  "appUpgrade.softMessage": {
+    "message": "A newer version is available. Update from the app store for the best experience.",
+    "description": "Body text of the soft upgrade prompt shown when the installed version is below latest but above min_supported. The user can dismiss and keep using the app."
+  },
+  "appUpgrade.openStore": {
+    "message": "Update now",
+    "description": "Primary button on the upgrade modal — opens the App Store / Play Store URL in the system browser."
+  },
+  "appUpgrade.later": {
+    "message": "Later",
+    "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
   }
 }

--- a/src/i18n/de/common.json
+++ b/src/i18n/de/common.json
@@ -926,5 +926,25 @@
   "message.uploadInProgress": {
     "message": "Referenz-Uploads sind noch in Bearbeitung – bitte warten Sie einen Moment.",
     "description": "Toast shown when the user clicks the Generate button while one or more reference uploads are still in flight. Asks them to wait for uploads to complete before retrying."
+  },
+  "appUpgrade.title": {
+    "message": "Update required",
+    "description": "Title of the native-app version gate modal shown at startup when the installed build is older than what the backend supports."
+  },
+  "appUpgrade.blockMessage": {
+    "message": "This version is no longer supported. Please update from the app store to continue.",
+    "description": "Body text of the hard-block upgrade modal shown when the installed version is below min_supported. The modal has no dismiss affordance — the only button opens the app store."
+  },
+  "appUpgrade.softMessage": {
+    "message": "A newer version is available. Update from the app store for the best experience.",
+    "description": "Body text of the soft upgrade prompt shown when the installed version is below latest but above min_supported. The user can dismiss and keep using the app."
+  },
+  "appUpgrade.openStore": {
+    "message": "Update now",
+    "description": "Primary button on the upgrade modal — opens the App Store / Play Store URL in the system browser."
+  },
+  "appUpgrade.later": {
+    "message": "Later",
+    "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
   }
 }

--- a/src/i18n/el/common.json
+++ b/src/i18n/el/common.json
@@ -926,5 +926,25 @@
   "message.uploadInProgress": {
     "message": "Οι μεταφορτώσεις αναφορών βρίσκονται ακόμη σε εξέλιξη — περιμένετε λίγο.",
     "description": "Toast shown when the user clicks the Generate button while one or more reference uploads are still in flight. Asks them to wait for uploads to complete before retrying."
+  },
+  "appUpgrade.title": {
+    "message": "Update required",
+    "description": "Title of the native-app version gate modal shown at startup when the installed build is older than what the backend supports."
+  },
+  "appUpgrade.blockMessage": {
+    "message": "This version is no longer supported. Please update from the app store to continue.",
+    "description": "Body text of the hard-block upgrade modal shown when the installed version is below min_supported. The modal has no dismiss affordance — the only button opens the app store."
+  },
+  "appUpgrade.softMessage": {
+    "message": "A newer version is available. Update from the app store for the best experience.",
+    "description": "Body text of the soft upgrade prompt shown when the installed version is below latest but above min_supported. The user can dismiss and keep using the app."
+  },
+  "appUpgrade.openStore": {
+    "message": "Update now",
+    "description": "Primary button on the upgrade modal — opens the App Store / Play Store URL in the system browser."
+  },
+  "appUpgrade.later": {
+    "message": "Later",
+    "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
   }
 }

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -926,5 +926,25 @@
   "message.uploadInProgress": {
     "message": "Reference uploads are still in progress — please wait a moment.",
     "description": "Toast warning shown when the user clicks the Generate button while reference image / video / audio uploads are still in flight. Tells them to wait for the upload to finish before re-clicking Generate."
+  },
+  "appUpgrade.title": {
+    "message": "Update required",
+    "description": "Title of the native-app version gate modal shown at startup when the installed build is older than what the backend supports."
+  },
+  "appUpgrade.blockMessage": {
+    "message": "This version is no longer supported. Please update from the app store to continue.",
+    "description": "Body text of the hard-block upgrade modal shown when the installed version is below min_supported. The modal has no dismiss affordance — the only button opens the app store."
+  },
+  "appUpgrade.softMessage": {
+    "message": "A newer version is available. Update from the app store for the best experience.",
+    "description": "Body text of the soft upgrade prompt shown when the installed version is below latest but above min_supported. The user can dismiss and keep using the app."
+  },
+  "appUpgrade.openStore": {
+    "message": "Update now",
+    "description": "Primary button on the upgrade modal — opens the App Store / Play Store URL in the system browser."
+  },
+  "appUpgrade.later": {
+    "message": "Later",
+    "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
   }
 }

--- a/src/i18n/es/common.json
+++ b/src/i18n/es/common.json
@@ -926,5 +926,25 @@
   "message.uploadInProgress": {
     "message": "Las cargas de referencia aún están en curso; espera un momento.",
     "description": "Toast shown when the user clicks the Generate button while one or more reference uploads are still in flight. Asks them to wait for uploads to complete before retrying."
+  },
+  "appUpgrade.title": {
+    "message": "Update required",
+    "description": "Title of the native-app version gate modal shown at startup when the installed build is older than what the backend supports."
+  },
+  "appUpgrade.blockMessage": {
+    "message": "This version is no longer supported. Please update from the app store to continue.",
+    "description": "Body text of the hard-block upgrade modal shown when the installed version is below min_supported. The modal has no dismiss affordance — the only button opens the app store."
+  },
+  "appUpgrade.softMessage": {
+    "message": "A newer version is available. Update from the app store for the best experience.",
+    "description": "Body text of the soft upgrade prompt shown when the installed version is below latest but above min_supported. The user can dismiss and keep using the app."
+  },
+  "appUpgrade.openStore": {
+    "message": "Update now",
+    "description": "Primary button on the upgrade modal — opens the App Store / Play Store URL in the system browser."
+  },
+  "appUpgrade.later": {
+    "message": "Later",
+    "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
   }
 }

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -926,5 +926,25 @@
   "message.uploadInProgress": {
     "message": "Viiteaineistojen lataus on yhä käynnissä – odota hetki.",
     "description": "Toast shown when the user clicks the Generate button while one or more reference uploads are still in flight. Asks them to wait for uploads to complete before retrying."
+  },
+  "appUpgrade.title": {
+    "message": "Update required",
+    "description": "Title of the native-app version gate modal shown at startup when the installed build is older than what the backend supports."
+  },
+  "appUpgrade.blockMessage": {
+    "message": "This version is no longer supported. Please update from the app store to continue.",
+    "description": "Body text of the hard-block upgrade modal shown when the installed version is below min_supported. The modal has no dismiss affordance — the only button opens the app store."
+  },
+  "appUpgrade.softMessage": {
+    "message": "A newer version is available. Update from the app store for the best experience.",
+    "description": "Body text of the soft upgrade prompt shown when the installed version is below latest but above min_supported. The user can dismiss and keep using the app."
+  },
+  "appUpgrade.openStore": {
+    "message": "Update now",
+    "description": "Primary button on the upgrade modal — opens the App Store / Play Store URL in the system browser."
+  },
+  "appUpgrade.later": {
+    "message": "Later",
+    "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
   }
 }

--- a/src/i18n/fr/common.json
+++ b/src/i18n/fr/common.json
@@ -926,5 +926,25 @@
   "message.uploadInProgress": {
     "message": "Les téléversements de référence sont toujours en cours — veuillez patienter un instant.",
     "description": "Toast shown when the user clicks the Generate button while one or more reference uploads are still in flight. Asks them to wait for uploads to complete before retrying."
+  },
+  "appUpgrade.title": {
+    "message": "Update required",
+    "description": "Title of the native-app version gate modal shown at startup when the installed build is older than what the backend supports."
+  },
+  "appUpgrade.blockMessage": {
+    "message": "This version is no longer supported. Please update from the app store to continue.",
+    "description": "Body text of the hard-block upgrade modal shown when the installed version is below min_supported. The modal has no dismiss affordance — the only button opens the app store."
+  },
+  "appUpgrade.softMessage": {
+    "message": "A newer version is available. Update from the app store for the best experience.",
+    "description": "Body text of the soft upgrade prompt shown when the installed version is below latest but above min_supported. The user can dismiss and keep using the app."
+  },
+  "appUpgrade.openStore": {
+    "message": "Update now",
+    "description": "Primary button on the upgrade modal — opens the App Store / Play Store URL in the system browser."
+  },
+  "appUpgrade.later": {
+    "message": "Later",
+    "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
   }
 }

--- a/src/i18n/it/common.json
+++ b/src/i18n/it/common.json
@@ -926,5 +926,25 @@
   "message.uploadInProgress": {
     "message": "I caricamenti di riferimento sono ancora in corso, attendi un momento.",
     "description": "Toast shown when the user clicks the Generate button while one or more reference uploads are still in flight. Asks them to wait for uploads to complete before retrying."
+  },
+  "appUpgrade.title": {
+    "message": "Update required",
+    "description": "Title of the native-app version gate modal shown at startup when the installed build is older than what the backend supports."
+  },
+  "appUpgrade.blockMessage": {
+    "message": "This version is no longer supported. Please update from the app store to continue.",
+    "description": "Body text of the hard-block upgrade modal shown when the installed version is below min_supported. The modal has no dismiss affordance — the only button opens the app store."
+  },
+  "appUpgrade.softMessage": {
+    "message": "A newer version is available. Update from the app store for the best experience.",
+    "description": "Body text of the soft upgrade prompt shown when the installed version is below latest but above min_supported. The user can dismiss and keep using the app."
+  },
+  "appUpgrade.openStore": {
+    "message": "Update now",
+    "description": "Primary button on the upgrade modal — opens the App Store / Play Store URL in the system browser."
+  },
+  "appUpgrade.later": {
+    "message": "Later",
+    "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
   }
 }

--- a/src/i18n/ja/common.json
+++ b/src/i18n/ja/common.json
@@ -926,5 +926,25 @@
   "message.uploadInProgress": {
     "message": "参照ファイルのアップロードがまだ進行中です。少々お待ちください。",
     "description": "Toast shown when the user clicks the Generate button while one or more reference uploads are still in flight. Asks them to wait for uploads to complete before retrying."
+  },
+  "appUpgrade.title": {
+    "message": "Update required",
+    "description": "Title of the native-app version gate modal shown at startup when the installed build is older than what the backend supports."
+  },
+  "appUpgrade.blockMessage": {
+    "message": "This version is no longer supported. Please update from the app store to continue.",
+    "description": "Body text of the hard-block upgrade modal shown when the installed version is below min_supported. The modal has no dismiss affordance — the only button opens the app store."
+  },
+  "appUpgrade.softMessage": {
+    "message": "A newer version is available. Update from the app store for the best experience.",
+    "description": "Body text of the soft upgrade prompt shown when the installed version is below latest but above min_supported. The user can dismiss and keep using the app."
+  },
+  "appUpgrade.openStore": {
+    "message": "Update now",
+    "description": "Primary button on the upgrade modal — opens the App Store / Play Store URL in the system browser."
+  },
+  "appUpgrade.later": {
+    "message": "Later",
+    "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
   }
 }

--- a/src/i18n/ko/common.json
+++ b/src/i18n/ko/common.json
@@ -926,5 +926,25 @@
   "message.uploadInProgress": {
     "message": "참조 파일을 아직 업로드하는 중입니다. 잠시만 기다려 주세요.",
     "description": "Toast shown when the user clicks the Generate button while one or more reference uploads are still in flight. Asks them to wait for uploads to complete before retrying."
+  },
+  "appUpgrade.title": {
+    "message": "Update required",
+    "description": "Title of the native-app version gate modal shown at startup when the installed build is older than what the backend supports."
+  },
+  "appUpgrade.blockMessage": {
+    "message": "This version is no longer supported. Please update from the app store to continue.",
+    "description": "Body text of the hard-block upgrade modal shown when the installed version is below min_supported. The modal has no dismiss affordance — the only button opens the app store."
+  },
+  "appUpgrade.softMessage": {
+    "message": "A newer version is available. Update from the app store for the best experience.",
+    "description": "Body text of the soft upgrade prompt shown when the installed version is below latest but above min_supported. The user can dismiss and keep using the app."
+  },
+  "appUpgrade.openStore": {
+    "message": "Update now",
+    "description": "Primary button on the upgrade modal — opens the App Store / Play Store URL in the system browser."
+  },
+  "appUpgrade.later": {
+    "message": "Later",
+    "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
   }
 }

--- a/src/i18n/pl/common.json
+++ b/src/i18n/pl/common.json
@@ -926,5 +926,25 @@
   "message.uploadInProgress": {
     "message": "Przesyłanie plików referencyjnych nadal trwa — proszę chwilę poczekać.",
     "description": "Toast shown when the user clicks the Generate button while one or more reference uploads are still in flight. Asks them to wait for uploads to complete before retrying."
+  },
+  "appUpgrade.title": {
+    "message": "Update required",
+    "description": "Title of the native-app version gate modal shown at startup when the installed build is older than what the backend supports."
+  },
+  "appUpgrade.blockMessage": {
+    "message": "This version is no longer supported. Please update from the app store to continue.",
+    "description": "Body text of the hard-block upgrade modal shown when the installed version is below min_supported. The modal has no dismiss affordance — the only button opens the app store."
+  },
+  "appUpgrade.softMessage": {
+    "message": "A newer version is available. Update from the app store for the best experience.",
+    "description": "Body text of the soft upgrade prompt shown when the installed version is below latest but above min_supported. The user can dismiss and keep using the app."
+  },
+  "appUpgrade.openStore": {
+    "message": "Update now",
+    "description": "Primary button on the upgrade modal — opens the App Store / Play Store URL in the system browser."
+  },
+  "appUpgrade.later": {
+    "message": "Later",
+    "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
   }
 }

--- a/src/i18n/pt/common.json
+++ b/src/i18n/pt/common.json
@@ -926,5 +926,25 @@
   "message.uploadInProgress": {
     "message": "Os envios de referência ainda estão em andamento — aguarde um momento.",
     "description": "Toast shown when the user clicks the Generate button while one or more reference uploads are still in flight. Asks them to wait for uploads to complete before retrying."
+  },
+  "appUpgrade.title": {
+    "message": "Update required",
+    "description": "Title of the native-app version gate modal shown at startup when the installed build is older than what the backend supports."
+  },
+  "appUpgrade.blockMessage": {
+    "message": "This version is no longer supported. Please update from the app store to continue.",
+    "description": "Body text of the hard-block upgrade modal shown when the installed version is below min_supported. The modal has no dismiss affordance — the only button opens the app store."
+  },
+  "appUpgrade.softMessage": {
+    "message": "A newer version is available. Update from the app store for the best experience.",
+    "description": "Body text of the soft upgrade prompt shown when the installed version is below latest but above min_supported. The user can dismiss and keep using the app."
+  },
+  "appUpgrade.openStore": {
+    "message": "Update now",
+    "description": "Primary button on the upgrade modal — opens the App Store / Play Store URL in the system browser."
+  },
+  "appUpgrade.later": {
+    "message": "Later",
+    "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
   }
 }

--- a/src/i18n/ru/common.json
+++ b/src/i18n/ru/common.json
@@ -926,5 +926,25 @@
   "message.uploadInProgress": {
     "message": "Загрузка эталонных файлов ещё продолжается — пожалуйста, подождите.",
     "description": "Toast shown when the user clicks the Generate button while one or more reference uploads are still in flight. Asks them to wait for uploads to complete before retrying."
+  },
+  "appUpgrade.title": {
+    "message": "Update required",
+    "description": "Title of the native-app version gate modal shown at startup when the installed build is older than what the backend supports."
+  },
+  "appUpgrade.blockMessage": {
+    "message": "This version is no longer supported. Please update from the app store to continue.",
+    "description": "Body text of the hard-block upgrade modal shown when the installed version is below min_supported. The modal has no dismiss affordance — the only button opens the app store."
+  },
+  "appUpgrade.softMessage": {
+    "message": "A newer version is available. Update from the app store for the best experience.",
+    "description": "Body text of the soft upgrade prompt shown when the installed version is below latest but above min_supported. The user can dismiss and keep using the app."
+  },
+  "appUpgrade.openStore": {
+    "message": "Update now",
+    "description": "Primary button on the upgrade modal — opens the App Store / Play Store URL in the system browser."
+  },
+  "appUpgrade.later": {
+    "message": "Later",
+    "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
   }
 }

--- a/src/i18n/sr/common.json
+++ b/src/i18n/sr/common.json
@@ -926,5 +926,25 @@
   "message.uploadInProgress": {
     "message": "Otpremanje referentnih datoteka je još u toku — sačekajte trenutak.",
     "description": "Toast shown when the user clicks the Generate button while one or more reference uploads are still in flight. Asks them to wait for uploads to complete before retrying."
+  },
+  "appUpgrade.title": {
+    "message": "Update required",
+    "description": "Title of the native-app version gate modal shown at startup when the installed build is older than what the backend supports."
+  },
+  "appUpgrade.blockMessage": {
+    "message": "This version is no longer supported. Please update from the app store to continue.",
+    "description": "Body text of the hard-block upgrade modal shown when the installed version is below min_supported. The modal has no dismiss affordance — the only button opens the app store."
+  },
+  "appUpgrade.softMessage": {
+    "message": "A newer version is available. Update from the app store for the best experience.",
+    "description": "Body text of the soft upgrade prompt shown when the installed version is below latest but above min_supported. The user can dismiss and keep using the app."
+  },
+  "appUpgrade.openStore": {
+    "message": "Update now",
+    "description": "Primary button on the upgrade modal — opens the App Store / Play Store URL in the system browser."
+  },
+  "appUpgrade.later": {
+    "message": "Later",
+    "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
   }
 }

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -926,5 +926,25 @@
   "message.uploadInProgress": {
     "message": "Referensuppladdningarna pågår fortfarande – vänta ett ögonblick.",
     "description": "Toast shown when the user clicks the Generate button while one or more reference uploads are still in flight. Asks them to wait for uploads to complete before retrying."
+  },
+  "appUpgrade.title": {
+    "message": "Update required",
+    "description": "Title of the native-app version gate modal shown at startup when the installed build is older than what the backend supports."
+  },
+  "appUpgrade.blockMessage": {
+    "message": "This version is no longer supported. Please update from the app store to continue.",
+    "description": "Body text of the hard-block upgrade modal shown when the installed version is below min_supported. The modal has no dismiss affordance — the only button opens the app store."
+  },
+  "appUpgrade.softMessage": {
+    "message": "A newer version is available. Update from the app store for the best experience.",
+    "description": "Body text of the soft upgrade prompt shown when the installed version is below latest but above min_supported. The user can dismiss and keep using the app."
+  },
+  "appUpgrade.openStore": {
+    "message": "Update now",
+    "description": "Primary button on the upgrade modal — opens the App Store / Play Store URL in the system browser."
+  },
+  "appUpgrade.later": {
+    "message": "Later",
+    "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
   }
 }

--- a/src/i18n/uk/common.json
+++ b/src/i18n/uk/common.json
@@ -926,5 +926,25 @@
   "message.uploadInProgress": {
     "message": "Завантаження довідкових файлів ще триває — зачекайте, будь ласка.",
     "description": "Toast shown when the user clicks the Generate button while one or more reference uploads are still in flight. Asks them to wait for uploads to complete before retrying."
+  },
+  "appUpgrade.title": {
+    "message": "Update required",
+    "description": "Title of the native-app version gate modal shown at startup when the installed build is older than what the backend supports."
+  },
+  "appUpgrade.blockMessage": {
+    "message": "This version is no longer supported. Please update from the app store to continue.",
+    "description": "Body text of the hard-block upgrade modal shown when the installed version is below min_supported. The modal has no dismiss affordance — the only button opens the app store."
+  },
+  "appUpgrade.softMessage": {
+    "message": "A newer version is available. Update from the app store for the best experience.",
+    "description": "Body text of the soft upgrade prompt shown when the installed version is below latest but above min_supported. The user can dismiss and keep using the app."
+  },
+  "appUpgrade.openStore": {
+    "message": "Update now",
+    "description": "Primary button on the upgrade modal — opens the App Store / Play Store URL in the system browser."
+  },
+  "appUpgrade.later": {
+    "message": "Later",
+    "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
   }
 }

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -926,5 +926,25 @@
   "message.uploadInProgress": {
     "message": "参考文件正在上传，请稍候再生成",
     "description": "用户在参考图/视频/音频还未上传完成时点击生成按钮，会弹出的轻量提示，要求用户等待上传完成后再次点击生成。"
+  },
+  "appUpgrade.title": {
+    "message": "需要升级",
+    "description": "原生 App 启动时的版本闸门弹窗标题。当客户端版本低于服务端要求时显示，告知用户需要升级 App。"
+  },
+  "appUpgrade.blockMessage": {
+    "message": "当前版本过低，请前往应用商店更新到最新版本后再使用。",
+    "description": "强制升级弹窗正文。当客户端版本低于 min_supported 时显示，无法关闭，唯一按钮跳转到应用商店。"
+  },
+  "appUpgrade.softMessage": {
+    "message": "有新版本可用，建议前往应用商店更新以获得最佳体验。",
+    "description": "可选升级提示正文。当客户端版本低于 latest 但高于 min_supported 时显示，用户可以选择稍后再说继续使用。"
+  },
+  "appUpgrade.openStore": {
+    "message": "前往更新",
+    "description": "升级弹窗主按钮：在系统浏览器中打开 App Store / Play Store 链接。"
+  },
+  "appUpgrade.later": {
+    "message": "稍后再说",
+    "description": "软提示升级弹窗的次按钮：忽略本次提示继续使用，仅在非强制升级场景出现。"
   }
 }

--- a/src/i18n/zh-TW/common.json
+++ b/src/i18n/zh-TW/common.json
@@ -926,5 +926,25 @@
   "message.uploadInProgress": {
     "message": "參考檔案仍在上傳，請稍候再生成。",
     "description": "Toast shown when the user clicks the Generate button while one or more reference uploads are still in flight. Asks them to wait for uploads to complete before retrying."
+  },
+  "appUpgrade.title": {
+    "message": "Update required",
+    "description": "Title of the native-app version gate modal shown at startup when the installed build is older than what the backend supports."
+  },
+  "appUpgrade.blockMessage": {
+    "message": "This version is no longer supported. Please update from the app store to continue.",
+    "description": "Body text of the hard-block upgrade modal shown when the installed version is below min_supported. The modal has no dismiss affordance — the only button opens the app store."
+  },
+  "appUpgrade.softMessage": {
+    "message": "A newer version is available. Update from the app store for the best experience.",
+    "description": "Body text of the soft upgrade prompt shown when the installed version is below latest but above min_supported. The user can dismiss and keep using the app."
+  },
+  "appUpgrade.openStore": {
+    "message": "Update now",
+    "description": "Primary button on the upgrade modal — opens the App Store / Play Store URL in the system browser."
+  },
+  "appUpgrade.later": {
+    "message": "Later",
+    "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ import { MotionPlugin } from '@vueuse/motion';
 import { vLoading } from 'element-plus';
 import { getSurface, isNative } from '@/utils/surface';
 import { syncFeaturesFromUrl } from '@/utils/featureFlag';
+import { runVersionGate } from '@/utils/versionGate';
 import {
   initializeCookies,
   initializeDescription,
@@ -71,6 +72,15 @@ const main = async () => {
   await initializeToken();
   // user/site/config are independent after token is set — run in parallel
   await Promise.all([initializeUser(), initializeSite(), initializeConfig()]);
+
+  // Native-only version gate: block the app behind an upgrade modal when
+  // the shipped build is below `min_supported`. Web is always served the
+  // latest dist/, so this is a no-op there. Fails open on any error so an
+  // outage on /api/v1/app-version/ can never strand mobile users.
+  if (isNative()) {
+    const blocked = await runVersionGate();
+    if (blocked) return;
+  }
 
   // Telemetry: initialize after token+user so we already know who the visitor
   // is. Safe no-op when VITE_RUM_PROJECT_ID is unset (local dev / preview).

--- a/src/operators/appVersion.ts
+++ b/src/operators/appVersion.ts
@@ -1,0 +1,22 @@
+import { AxiosResponse } from 'axios';
+import { httpClient } from './common';
+
+export interface IAppVersionResponse {
+  app: string;
+  platform: string;
+  latest: string;
+  min_supported: string;
+  store_url: string;
+  message: string;
+}
+
+class AppVersionOperator {
+  async get(app: string, platform: string): Promise<AxiosResponse<IAppVersionResponse>> {
+    return httpClient.get('/app-version/', {
+      params: { app, platform },
+      timeout: 5000
+    });
+  }
+}
+
+export const appVersionOperator = new AppVersionOperator();

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -37,3 +37,4 @@ export * from './fish';
 export * from './config';
 export * from './agent';
 export * from './byokCredential';
+export * from './appVersion';

--- a/src/utils/versionGate.ts
+++ b/src/utils/versionGate.ts
@@ -1,0 +1,128 @@
+import { App as CapApp } from '@capacitor/app';
+import { Browser } from '@capacitor/browser';
+import { ElMessageBox } from 'element-plus';
+import { appVersionOperator } from '@/operators/appVersion';
+import { isAndroid, isIOS, isNative } from '@/utils/surface';
+import { t, setI18nLanguage, getLocale } from '@/i18n';
+
+/**
+ * Compare two dotted numeric version strings. Returns -1 / 0 / 1 like
+ * String#localeCompare. Non-numeric segments compare as 0, missing
+ * segments compare as 0 — enough for our `major.minor.patch` use.
+ */
+export function compareVersions(a: string, b: string): number {
+  const pa = (a || '').split('.');
+  const pb = (b || '').split('.');
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const na = parseInt(pa[i] || '0', 10) || 0;
+    const nb = parseInt(pb[i] || '0', 10) || 0;
+    if (na > nb) return 1;
+    if (na < nb) return -1;
+  }
+  return 0;
+}
+
+/**
+ * Check the native build against backend metadata and, when the build is
+ * below `min_supported`, block the app behind a modal that links to the
+ * store. Soft prompt when below `latest`. Fail-open on any error.
+ *
+ * @returns true when boot should NOT continue (modal blocked the app),
+ *          false otherwise.
+ */
+export async function runVersionGate(): Promise<boolean> {
+  if (!isNative()) return false;
+  const platform = isIOS() ? 'ios' : isAndroid() ? 'android' : null;
+  if (!platform) return false;
+
+  let nativeVersion: string;
+  try {
+    const info = await CapApp.getInfo();
+    nativeVersion = info.version;
+  } catch (err) {
+    console.warn('[versionGate] App.getInfo failed, skipping', err);
+    return false;
+  }
+
+  let meta;
+  try {
+    const { data } = await appVersionOperator.get('nexior', platform);
+    meta = data;
+  } catch (err) {
+    // Network errors, 404, etc. — never block the app on infra problems.
+    console.warn('[versionGate] fetch failed, skipping', err);
+    return false;
+  }
+
+  const belowMin = meta.min_supported && compareVersions(nativeVersion, meta.min_supported) < 0;
+  const belowLatest = meta.latest && compareVersions(nativeVersion, meta.latest) < 0;
+
+  if (belowMin) {
+    // i18n strings used in the modal need the locale loaded — the router's
+    // beforeEach hook hasn't run yet at this point in boot.
+    try {
+      await setI18nLanguage(getLocale());
+    } catch (err) {
+      console.warn('[versionGate] locale load failed, continuing with default', err);
+    }
+    await showBlockingUpgrade(meta.store_url, meta.message);
+    return true;
+  }
+  if (belowLatest) {
+    // Soft prompt: don't block boot. Fire-and-forget; the modal sits on top
+    // of the app once it's mounted. Locale will already be set by then.
+    void showSoftUpgrade(meta.store_url, meta.message);
+  }
+  return false;
+}
+
+async function showBlockingUpgrade(storeUrl: string, customMessage: string): Promise<void> {
+  // Loop forever: the only way out is to update. Closing the WebView is the
+  // user's only escape hatch, which is the intended UX.
+
+  while (true) {
+    try {
+      await ElMessageBox.alert(
+        customMessage || (t('common.appUpgrade.blockMessage') as string),
+        t('common.appUpgrade.title') as string,
+        {
+          confirmButtonText: t('common.appUpgrade.openStore') as string,
+          showClose: false,
+          closeOnClickModal: false,
+          closeOnPressEscape: false,
+          closeOnHashChange: false,
+          type: 'warning'
+        }
+      );
+    } catch {
+      // Element Plus rejects the promise on close/cancel; treat as "user
+      // tapped outside" and re-show. Combined with the disabled close
+      // affordances above, this is purely a defensive guard.
+    }
+    if (storeUrl) {
+      try {
+        await Browser.open({ url: storeUrl });
+      } catch (err) {
+        console.warn('[versionGate] Browser.open failed', err);
+      }
+    }
+  }
+}
+
+async function showSoftUpgrade(storeUrl: string, customMessage: string): Promise<void> {
+  try {
+    await ElMessageBox.confirm(
+      customMessage || (t('common.appUpgrade.softMessage') as string),
+      t('common.appUpgrade.title') as string,
+      {
+        confirmButtonText: t('common.appUpgrade.openStore') as string,
+        cancelButtonText: t('common.appUpgrade.later') as string,
+        type: 'info'
+      }
+    );
+    if (storeUrl) await Browser.open({ url: storeUrl });
+  } catch {
+    // User dismissed — fine.
+  }
+}


### PR DESCRIPTION
## What

Native iOS / Android boot gate that asks `GET /api/v1/app-version/?app=nexior&platform=ios|android` (companion endpoint in [PlatformBackend#529](https://github.com/AceDataCloud/PlatformBackend/pull/529)) and reacts to the response:

- `nativeVersion < min_supported` → **hard block**: modal with no dismiss affordance, single button opens the App Store / Play Store link via `@capacitor/browser`. Boot never proceeds — `createApp()` is skipped.
- `min_supported ≤ nativeVersion < latest` → **soft prompt**: dismissable modal with "Update now" / "Later". Boot continues.
- `nativeVersion ≥ latest`, network error, 404, or `App.getInfo()` failure → no-op. The gate is **fail-open** so an outage on `/api/v1/app-version/` can never strand mobile users.

Web (`!isNative()`) bypasses the gate entirely — `studio.acedata.cloud` always serves the latest `dist/`.

## Why

Mobile ships a static `dist/` bundle; we have no OTA channel yet (that's a follow-up). Without this gate, a breaking change on the server can break installed apps until the user happens to update from the store. With it, ops can flip `min_supported` in the `APP_VERSIONS_JSON` env var (configmap-level edit, no redeploy) to force-upgrade clients before retiring a `/v1/` route.

## Files

- New: `src/operators/appVersion.ts` — operator hitting `/api/v1/app-version/` with a 5 s timeout
- New: `src/utils/versionGate.ts` — `compareVersions`, `runVersionGate`, modal logic
- Modified: `src/main.ts` — calls `runVersionGate()` after `initializeConfig` and before `createApp` (native only)
- Modified: `src/operators/index.ts` — export
- Modified: `src/i18n/{zh-CN,en}/common.json` — `appUpgrade.{title,blockMessage,softMessage,openStore,later}` (other locales auto-translate via the existing CronJob)

## Notes

- `App.getInfo()` returns the native `version` (matches `MARKETING_VERSION` on iOS and `versionName` on Android — both are `3.35.2` today).
- `compareVersions` is a dotted-numeric compare — enough for our `major.minor.patch` scheme; not a full semver implementation.
- Locale is loaded on-demand inside the gate before the blocking modal, because at boot the router's `beforeEach` (which normally sets the locale) hasn't run yet.
- The hard-block modal loops forever — Element Plus rejects on dismiss, so the guard re-opens it; the only escape is the store link or force-closing the app. Intentional.
