### PR TITLE
feat(ota): wire @capgo/capacitor-updater for live updates

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -3,7 +3,18 @@ import type { CapacitorConfig } from '@capacitor/cli';
 const config: CapacitorConfig = {
   appId: 'com.acedatacloud.nexior',
   appName: 'AceData',
-  webDir: 'dist'
+  webDir: 'dist',
+  plugins: {
+    // We drive @capgo/capacitor-updater manually from `src/utils/liveUpdate.ts`
+    // against our own COS-hosted manifest, so the plugin's built-in
+    // auto-update / Capgo cloud features must stay off.
+    CapacitorUpdater: {
+      autoUpdate: false,
+      autoDeleteFailed: true,
+      autoDeletePrevious: true,
+      resetWhenUpdate: false
+    }
+  }
 };
 
 export default config;

--- a/change/@acedatacloud-nexior-ota-client-1779598970.json
+++ b/change/@acedatacloud-nexior-ota-client-1779598970.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(ota): integrate @capgo/capacitor-updater for COS-hosted live updates",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/docs/MOBILE_RELEASE.md
+++ b/docs/MOBILE_RELEASE.md
@@ -206,3 +206,99 @@ Android 可通过 GitHub Actions 手动选择 track 逐步放量：`internal →
 | `APP_STORE_CONNECT_KEY_ID` | API Key ID | iOS |
 | `APP_STORE_CONNECT_ISSUER_ID` | Issuer ID | iOS |
 | `APP_STORE_CONNECT_KEY_BASE64` | API Key 文件 | iOS |
+
+---
+
+## 五、Live Update（OTA 热更新 / `@capgo/capacitor-updater`）
+
+App 通过 `@capgo/capacitor-updater` 从 COS 自托管的 manifest 拉新 `dist/` bundle，实现免商店审核的前端代码热更新（仅 JS/HTML/CSS，符合 Apple/Google 政策）。
+
+> **当前 PR**（feat/ota-client）只接入了客户端 SDK，发布流水线还未自动化。手动发布 OTA 流程见下文；CI 集成在后续 PR 中完成。
+
+### 启用
+
+构建时设置环境变量（默认关闭，合并后不会立即生效）：
+
+```bash
+# .env.production / GitHub Actions 环境变量
+VITE_LIVE_UPDATE_ENABLED=true
+VITE_LIVE_UPDATE_BASE_URL=https://cdn.acedata.cloud/nexior/updates   # 可选，默认值
+VITE_LIVE_UPDATE_CHANNEL=stable                                       # 可选，默认 stable
+```
+
+App 启动时会异步检查 manifest，发现新版本则后台下载并切换到下次冷启动生效。任何环节失败都安静跳过，不影响启动。
+
+### COS 目录布局
+
+```
+acedatacloud2-1256437459/      # COS bucket
+└── nexior/updates/
+    ├── stable/
+    │   ├── ios.json           # 当前 stable iOS manifest
+    │   ├── android.json       # 当前 stable Android manifest
+    │   └── bundles/
+    │       ├── 3.35.3.zip     # zipped dist/
+    │       └── 3.35.4.zip
+    └── beta/                  # 预留：灰度通道
+        ├── ios.json
+        └── android.json
+```
+
+公开 CDN URL：`https://cdn.acedata.cloud/nexior/updates/...`
+
+### Manifest 格式
+
+`stable/ios.json` 示例：
+
+```json
+{
+  "version": "3.35.3",
+  "url": "https://cdn.acedata.cloud/nexior/updates/stable/bundles/3.35.3.zip",
+  "checksum": "ZGVhZGJlZWY...",
+  "min_native_version": "3.35.2"
+}
+```
+
+字段说明：
+
+| 字段 | 必填 | 含义 |
+|---|---|---|
+| `version` | 是 | bundle 版本号。客户端只在 `version > 当前运行的 bundle.version` 时下载。 |
+| `url` | 是 | bundle zip 的绝对 https URL。 |
+| `checksum` | 是 | bundle zip 的 sha256 (base64 编码)。客户端激活前校验，不匹配则丢弃。 |
+| `min_native_version` | 否 | 兼容的最低原生壳版本。低于此版本的安装会跳过此 bundle（由 `app-version` 闸门处理强升）。 |
+
+### 手动发布一个 OTA（CI 自动化前的临时流程）
+
+1. 本地构建：
+   ```bash
+   VITE_SURFACE=ios VITE_LIVE_UPDATE_ENABLED=true npm run build
+   ```
+2. 打包并算校验和：
+   ```bash
+   cd dist && zip -r ../3.35.3.zip . && cd -
+   shasum -a 256 3.35.3.zip | awk '{print $1}' | xxd -r -p | base64
+   ```
+3. 上传 zip 到 COS（用 `coscmd` / Tencent COSBrowser / `.claude/scripts/upload.py`）：
+   ```
+   nexior/updates/stable/bundles/3.35.3.zip
+   ```
+4. 写一个 `ios.json` / `android.json`（结构如上）并上传到：
+   ```
+   nexior/updates/stable/ios.json
+   nexior/updates/stable/android.json
+   ```
+5. 让 EdgeOne 刷新 manifest 路径（zip 不需要刷，URL 带版本号天然防缓存）：
+   ```bash
+   # 见 .claude/commands/manage-edgeone.md
+   ```
+
+### 回滚
+
+把 `*.json` 改回上一版本的 manifest 即可。下次冷启动 App 会发现 `manifest.version <= current` 自动跳过下载，但 **不会自动回滚已激活的更新**——这需要发一个 `version` 比当前高的 manifest，指向旧 zip。如需立即回滚已激活的坏 bundle，需要在新 manifest 里 `version` 写一个比坏 bundle 更高的值，`url` 指向上一个好 zip。
+
+### Apple / Google 合规要点
+
+- 只热更新 web 资源（`dist/` 内容），**绝不**改 native 代码、不下载可执行二进制、不绕过 App Review 添加新功能（已审核功能的 bugfix / 文案 / UI 调整 OK）。
+- `@capgo/capacitor-updater` 在 iOS 上使用 WKWebView 加载本地文件，符合 [App Store Guideline 3.3.2](https://developer.apple.com/app-store/review/guidelines/#3.3.2) 关于解释性代码的例外条款（与 React Native CodePush、Expo Updates 同类机制）。
+- 引入大版本特性时仍需走商店审核 + 提升 `app-version` 接口里的 `min_supported`。

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@capacitor/app": "^8.0.1",
         "@capacitor/browser": "^8.0.1",
+        "@capgo/capacitor-updater": "^8.47.3",
         "@codemirror/lang-java": "^6.0.1",
         "@codemirror/lang-javascript": "^6.1.2",
         "@codemirror/lang-json": "^6.0.1",
@@ -402,6 +403,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": "^8.3.0"
+      }
+    },
+    "node_modules/@capgo/capacitor-updater": {
+      "version": "8.47.3",
+      "resolved": "https://registry.npmjs.org/@capgo/capacitor-updater/-/capacitor-updater-8.47.3.tgz",
+      "integrity": "sha512-IKLr0vAMHjJ/4qEfCt4lenLYNxRneA6kqh09ytuqNIwwnB3rwtljKeLEjlccHaOSbkDJ19TVK3x1O4YETIb3zQ==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@capacitor/core": "^8.0.0"
       }
     },
     "node_modules/@codemirror/autocomplete": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@capacitor/app": "^8.0.1",
     "@capacitor/browser": "^8.0.1",
+    "@capgo/capacitor-updater": "^8.47.3",
     "@codemirror/lang-java": "^6.0.1",
     "@codemirror/lang-javascript": "^6.1.2",
     "@codemirror/lang-json": "^6.0.1",

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@ import { vLoading } from 'element-plus';
 import { getSurface, isNative } from '@/utils/surface';
 import { syncFeaturesFromUrl } from '@/utils/featureFlag';
 import { runVersionGate } from '@/utils/versionGate';
+import { runLiveUpdate } from '@/utils/liveUpdate';
 import {
   initializeCookies,
   initializeDescription,
@@ -81,6 +82,13 @@ const main = async () => {
     const blocked = await runVersionGate();
     if (blocked) return;
   }
+
+  // Native OTA: check the COS-hosted manifest for a newer JS bundle and
+  // queue it for next launch. Fire-and-forget so a slow CDN can't delay
+  // mount; also a no-op on web and when VITE_LIVE_UPDATE_ENABLED isn't
+  // set. Internally still calls `notifyAppReady()` on every cold start so
+  // previously-installed bundles don't get rolled back.
+  void runLiveUpdate();
 
   // Telemetry: initialize after token+user so we already know who the visitor
   // is. Safe no-op when VITE_RUM_PROJECT_ID is unset (local dev / preview).

--- a/src/utils/liveUpdate.ts
+++ b/src/utils/liveUpdate.ts
@@ -1,0 +1,123 @@
+import { CapacitorUpdater } from '@capgo/capacitor-updater';
+import { App as CapApp } from '@capacitor/app';
+import axios from 'axios';
+import { compareVersions } from '@/utils/versionGate';
+import { isAndroid, isIOS, isNative } from '@/utils/surface';
+
+/**
+ * Shape of the manifest we host at
+ * `<base>/<channel>/<platform>.json` (e.g. `stable/ios.json`). The
+ * release pipeline (PR-4, separate) is responsible for producing this
+ * file plus the matching `*.zip` bundle and uploading both to COS.
+ */
+interface LiveUpdateManifest {
+  /** Bundle version — must be strictly newer than what's currently running for the update to apply. Format: `major.minor.patch[.build]`. */
+  version: string;
+  /** Absolute https URL to the zipped bundle (zipped contents of `dist/`). */
+  url: string;
+  /** Base64-encoded sha256 of the zip. Plugin verifies before activating; mismatch aborts the install. */
+  checksum: string;
+  /** Lowest native shell version this bundle is compatible with. Skip silently when the installed native is below this — the version gate (`src/utils/versionGate.ts`) will hard-block the user separately. */
+  min_native_version?: string;
+}
+
+const BASE = import.meta.env.VITE_LIVE_UPDATE_BASE_URL || 'https://cdn.acedata.cloud/nexior/updates';
+const CHANNEL = (import.meta.env.VITE_LIVE_UPDATE_CHANNEL as string) || 'stable';
+const ENABLED = String(import.meta.env.VITE_LIVE_UPDATE_ENABLED).toLowerCase() === 'true';
+
+/**
+ * Fire-and-forget OTA check at boot. The flow:
+ *
+ *  1. `notifyAppReady()` — mark the currently-running bundle as good so the
+ *     plugin doesn't roll it back on next launch. MUST run on every cold
+ *     start, regardless of whether we end up downloading anything.
+ *  2. Fetch the platform-specific manifest from COS.
+ *  3. If `manifest.min_native_version` is set and the installed native shell
+ *     is older, skip — that scenario is handled by the version gate which
+ *     forces a store upgrade.
+ *  4. If `manifest.version` is newer than the currently active bundle's
+ *     version (or the bundled `dist/` for first-run), download + queue for
+ *     next launch via `set({id})`. We do NOT call `reload()` because mid-
+ *     session reloads are jarring; the user picks up the new bundle the
+ *     next time they cold-start the app.
+ *
+ * Fails open on every error. OTA must never wedge boot.
+ */
+export async function runLiveUpdate(): Promise<void> {
+  if (!isNative()) return;
+  // Even when disabled, fire `notifyAppReady` so older builds that DID
+  // download a bundle won't get rolled back when this flag is flipped.
+  try {
+    await CapacitorUpdater.notifyAppReady();
+  } catch (err) {
+    console.warn('[liveUpdate] notifyAppReady failed', err);
+  }
+
+  if (!ENABLED) {
+    console.debug('[liveUpdate] disabled via VITE_LIVE_UPDATE_ENABLED');
+    return;
+  }
+
+  const platform = isIOS() ? 'ios' : isAndroid() ? 'android' : null;
+  if (!platform) return;
+
+  let manifest: LiveUpdateManifest;
+  try {
+    const resp = await axios.get<LiveUpdateManifest>(`${BASE}/${CHANNEL}/${platform}.json`, {
+      timeout: 8000,
+      // Add a cache-buster — CDNs aggressively cache JSON otherwise.
+      params: { t: Date.now() }
+    });
+    manifest = resp.data;
+  } catch (err) {
+    console.warn('[liveUpdate] manifest fetch failed', err);
+    return;
+  }
+
+  if (!manifest?.version || !manifest?.url) {
+    console.warn('[liveUpdate] manifest missing required fields', manifest);
+    return;
+  }
+
+  if (manifest.min_native_version) {
+    try {
+      const info = await CapApp.getInfo();
+      if (compareVersions(info.version, manifest.min_native_version) < 0) {
+        console.info('[liveUpdate] native too old for this bundle; skipping');
+        return;
+      }
+    } catch (err) {
+      console.warn('[liveUpdate] App.getInfo failed; skipping bundle check', err);
+      return;
+    }
+  }
+
+  // Compare against the *currently active* bundle (which may be the builtin
+  // dist/ on a fresh install — in that case `current().bundle.version`
+  // reports the version baked into the native binary, e.g. "3.35.2").
+  let currentVersion = '0.0.0';
+  try {
+    const current = await CapacitorUpdater.current();
+    currentVersion = current.bundle?.version || '0.0.0';
+  } catch (err) {
+    console.warn('[liveUpdate] current() failed; assuming 0.0.0', err);
+  }
+
+  if (compareVersions(manifest.version, currentVersion) <= 0) {
+    console.debug(`[liveUpdate] up to date (current=${currentVersion}, manifest=${manifest.version})`);
+    return;
+  }
+
+  console.info(`[liveUpdate] downloading bundle ${manifest.version} (current=${currentVersion})`);
+  try {
+    const bundle = await CapacitorUpdater.download({
+      url: manifest.url,
+      version: manifest.version,
+      checksum: manifest.checksum
+    });
+    await CapacitorUpdater.set({ id: bundle.id });
+    console.info(`[liveUpdate] bundle ${manifest.version} queued for next launch`);
+  } catch (err) {
+    console.warn('[liveUpdate] download/set failed', err);
+  }
+}


### PR DESCRIPTION
Third (and final client-side) PR of the mobile-sync work — adds OTA so we can
ship JS/HTML/CSS hotfixes to installed iOS/Android builds without going through
App Store / Play Store review.

> **Stacked on #799** (`feat/app-version-gate`). Merge #799 first so the diff
> here is just the OTA pieces.

## What this PR does

- Adds `@capgo/capacitor-updater@^8.47.3` and a thin wrapper at
  [src/utils/liveUpdate.ts](src/utils/liveUpdate.ts) that drives the plugin
  manually against our own COS-hosted manifest (no Capgo cloud).
- Boots OTA from `src/main.ts` **after** the version gate runs and as a
  fire-and-forget — slow CDN can never delay app mount.
- Registers the plugin in `capacitor.config.ts` with `autoUpdate: false` and
  `autoDelete{Failed,Previous}: true`.
- Appends a new "Live Update" section to `docs/MOBILE_RELEASE.md` covering
  COS layout, manifest schema, manual publish flow, rollback, and store
  compliance notes.

## How the runtime check works

1. `CapacitorUpdater.notifyAppReady()` on every cold start (even when OTA is
   disabled), so previously-installed bundles don't get auto-rolled-back.
2. If `VITE_LIVE_UPDATE_ENABLED=true`, fetch
   `https://cdn.acedata.cloud/nexior/updates/<channel>/<platform>.json`.
3. Skip when `manifest.min_native_version` exceeds the installed native — the
   version gate from #799 handles that scenario with a hard-block modal.
4. If `manifest.version > current bundle version`, download → set for next
   launch. Never calls `reload()` mid-session.

All errors fail open and only log to the console.

## Feature-flagged — safe to merge

OTA is **disabled by default**. To turn it on for a build you need

\`\`\`
VITE_LIVE_UPDATE_ENABLED=true
VITE_LIVE_UPDATE_BASE_URL=https://cdn.acedata.cloud/nexior/updates   # optional
VITE_LIVE_UPDATE_CHANNEL=stable                                       # optional
\`\`\`

Merging this PR before PR-4 (release pipeline) lands will NOT do anything at
runtime, because the flag stays unset and `notifyAppReady()` is a no-op when
no bundle has ever been installed.

## What's NOT in this PR (next PR)

- The GitHub Actions workflow that produces \`<version>.zip\` + the
  matching manifest and uploads both to COS — PR-4.
- Flipping \`VITE_LIVE_UPDATE_ENABLED=true\` on the production build —
  done after PR-4 ships a working manifest.

## Test plan

- \`npx vue-tsc --noEmit\` — clean.
- \`npx eslint src/main.ts src/utils/liveUpdate.ts\` — clean.
- Web build is unaffected (\`isNative()\` short-circuits both \`runVersionGate\`
  and \`runLiveUpdate\`).
- Once PR-4 lands we'll smoke-test on iOS TestFlight + Android internal
  testing by publishing a tiny copy-change bundle and verifying it activates
  on the next cold start.

## Store compliance

The plugin loads bundles via WKWebView / Android WebView and only touches
\`dist/\` contents (JS / HTML / CSS). No native code is ever updated, no
remote-code execution. Same model as React Native CodePush and Expo Updates,
which Apple/Google both allow under
[App Store Guideline 3.3.2](https://developer.apple.com/app-store/review/guidelines/#3.3.2).