### PR TITLE
refactor(consent): use connector_identifier and /connectors/ URL alias

### DIFF
--- a/src/components/chat/ConnectorConsentCard.test.ts
+++ b/src/components/chat/ConnectorConsentCard.test.ts
@@ -245,7 +245,7 @@ describe('ConnectorConsentCard — post-OAuth status refresh', () => {
   it('flips the matching entry to Connected and shows Continue when the live API returns an active connection', async () => {
     setLocation('http://localhost/chat?consent=req-1');
     mockedListMyConnections.mockResolvedValue([
-      { id: 'conn-1', catalog_identifier: 'acedatacloud/gmail', status: 'active' }
+      { id: 'conn-1', connector_identifier: 'acedatacloud/gmail', status: 'active' }
     ]);
     const wrapper = mount(ConnectorConsentCard, {
       props: { toolUseId: 'tu-1', payload: PAYLOAD_TWO_OPTIONS },
@@ -269,6 +269,8 @@ describe('ConnectorConsentCard — post-OAuth status refresh', () => {
     setLocation('http://localhost/chat?consent=req-1');
     mockedListMyConnections.mockResolvedValue([
       // expired / revoked rows are ignored by the case-insensitive `active` check.
+      // Also exercises the legacy `catalog_identifier` alias path (BC during the
+      // catalog→connector rename rollout) — the entry should still resolve.
       { id: 'conn-1', catalog_identifier: 'acedatacloud/gmail', status: 'expired' }
     ]);
     const wrapper = mount(ConnectorConsentCard, {
@@ -284,7 +286,7 @@ describe('ConnectorConsentCard — post-OAuth status refresh', () => {
   it('Continue emits submit with all effectively-connected connectors marked authorized', async () => {
     setLocation('http://localhost/chat?consent=req-1');
     mockedListMyConnections.mockResolvedValue([
-      { id: 'conn-1', catalog_identifier: 'acedatacloud/gmail', status: 'ACTIVE' }
+      { id: 'conn-1', connector_identifier: 'acedatacloud/gmail', status: 'ACTIVE' }
     ]);
     const wrapper = mount(ConnectorConsentCard, {
       props: { toolUseId: 'tu-1', payload: PAYLOAD_TWO_OPTIONS },

--- a/src/components/chat/ConnectorConsentCard.vue
+++ b/src/components/chat/ConnectorConsentCard.vue
@@ -416,9 +416,10 @@ export default defineComponent({
         const connections = await listMyConnections();
         const connectedIds = new Set<string>();
         for (const c of connections) {
-          if (!c.catalog_identifier) continue;
+          const id = c.connector_identifier || c.catalog_identifier;
+          if (!id) continue;
           if (String(c.status).toLowerCase() === 'active') {
-            connectedIds.add(c.catalog_identifier);
+            connectedIds.add(id);
           }
         }
         const next: Record<string, 'connected' | 'unconnected'> = {};

--- a/src/components/chat/connectorCatalogCache.ts
+++ b/src/components/chat/connectorCatalogCache.ts
@@ -1,8 +1,9 @@
 /**
  * In-process cache for AuthBackend's connector catalog (
- * `GET /api/v1/connections/catalog/<id>/`). The consent card renders the
- * upstream brand (logo, localized name, permission descriptions) instead
- * of the opaque catalog identifier the worker emits — see
+ * `GET /api/v1/connectors/<id>/`, legacy alias
+ * `GET /api/v1/connections/catalog/<id>/`). The consent card renders
+ * the upstream brand (logo, localized name, permission descriptions)
+ * instead of the opaque catalog identifier the worker emits — see
  * `IConsentRequestEntry.catalog_id`.
  *
  * Why module-level instead of a Vuex module:
@@ -58,7 +59,8 @@ export interface IConnectorCatalogSummary {
 }
 
 /** Response shape of AuthBackend's
- *  `POST /api/v1/connections/catalog/<id>/install/`. See
+ *  `POST /api/v1/connectors/<id>/install/` (legacy alias
+ *  `POST /api/v1/connections/catalog/<id>/install/`). See
  *  `app.services.connector_catalog.install_for_user`. */
 export interface IConnectorCatalogInstallResponse {
   type: 'redirect' | 'form' | 'active';
@@ -75,15 +77,19 @@ export interface IConnectorCatalogInstallResponse {
 /** Subset of AuthBackend's `IConnection` fields the consent card needs
  *  to detect which entries are now actively connected for the calling
  *  user. The full schema (profile, scopes, expires_at, …) is ignored —
- *  this is purely a presence + status check keyed on
- *  `catalog_identifier`. */
+ *  this is purely a presence + status check keyed on the connector
+ *  identifier. AuthBackend Stage 1 emits both `connector_identifier`
+ *  (canonical) and `catalog_identifier` (legacy alias); we accept either. */
 export interface IUserConnectionSummary {
   id: string;
-  /** Catalog item identifier (e.g. `acedatacloud/google-drive`).
-   *  Empty string for legacy / non-catalog installs — those rows can't
+  /** Connector identifier (e.g. `acedatacloud/google-drive`).
+   *  Empty string for legacy / non-connector installs — those rows can't
    *  match a consent entry's `connector` field so they're effectively
-   *  ignored. */
-  catalog_identifier: string;
+   *  ignored. Canonical field. */
+  connector_identifier?: string;
+  /** Deprecated alias for {@link connector_identifier}; emitted by
+   *  AuthBackend during the catalog→connector rename rollout. */
+  catalog_identifier?: string;
   /** Backend ships both lowercase and uppercase variants — see
    *  AuthFrontend `ConnectionStatus`. Callers should compare
    *  case-insensitively. */
@@ -125,7 +131,7 @@ export async function getCatalogItem(catalogId: string): Promise<IConnectorCatal
   const task = (async () => {
     try {
       const response: AxiosResponse<IConnectorCatalogSummary> = await httpClient.get(
-        `/connections/catalog/${catalogId}/`,
+        `/connectors/${catalogId}/`,
         { baseURL: `${getBaseUrlAuth()}/api/v1` }
       );
       const item = response.data;
@@ -163,7 +169,7 @@ export async function installFromCatalog(
   payload: { scopes?: string[]; return_url: string }
 ): Promise<IConnectorCatalogInstallResponse> {
   const response: AxiosResponse<IConnectorCatalogInstallResponse> = await httpClient.post(
-    `/connections/catalog/${catalogId}/install/`,
+    `/connectors/${catalogId}/install/`,
     payload,
     { baseURL: `${getBaseUrlAuth()}/api/v1` }
   );

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -157,8 +157,9 @@ export interface IAskUserQuestionPayload {
 export interface IConsentRequestEntry {
   /** Catalog identifier, e.g. `acedatacloud/suno`. */
   connector: string;
-  /** Stable UUID of the matching `ConnectorCatalogItem` row in AuthBackend
-   *  (`/api/v1/connections/catalog/<id>/`). Required: the consent card uses
+  /** Stable UUID of the matching `Connector` (à la `ConnectorCatalogItem`)
+   *  row in AuthBackend (`/api/v1/connectors/<id>/`, legacy alias
+   *  `/api/v1/connections/catalog/<id>/`). Required: the consent card uses
    *  this to fetch logo / localized name / permission list so each row can
    *  show the upstream brand instead of the opaque slug. Emitted by the
    *  worker's `get_connector_status` tool — there is no fallback because


### PR DESCRIPTION
Part of the platform-wide `catalog` → `connector`/`skill` rename rollout.
Stage 2 client PR — depends on AuthBackend Stage 1 (https://github.com/AceDataCloud/AuthBackend/pull/159).

## Why

AuthBackend renames `Connection.catalog_identifier` → `connector_identifier` (PR #159) and adds a `/api/v1/connectors/` URL alias alongside `/api/v1/connections/catalog/`. AuthBackend stays BC for both column reads and URL paths until Stage 3, so this PR can ship in any order relative to the Stage 1 deploy.

## Changes

- `IUserConnectionSummary`: add `connector_identifier?: string` as the canonical field; mark `catalog_identifier?: string` as a deprecated alias. AuthBackend Stage 1 emits both.
- `connectorCatalogCache.getCatalogItem` / `installFromCatalog`: switch URLs from `/connections/catalog/<id>/` → `/connectors/<id>/` and `/connections/catalog/<id>/install/` → `/connectors/<id>/install/`. AuthBackend Stage 1 keeps the legacy URLs working, so any pre-Stage-1 server still resolves through the alias on its side.
- `ConnectorConsentCard.refreshConnectionStatuses`: read `c.connector_identifier || c.catalog_identifier` so the live-status flip works against either Stage 0 (alias only) or Stage 1+ (both keys) AuthBackend builds.
- Doc-comment refs (`models/chat.ts`, `connectorCatalogCache.ts` block comments) updated to mention the new URL alongside the legacy alias.

## Tests

Switched primary-path fixtures in `ConnectorConsentCard.test.ts` to `connector_identifier`; kept one explicit BC-fallback fixture on `catalog_identifier` (with an in-line comment) so the legacy-alias path stays covered until Stage 3 removes it.

```
Test Files  5 passed (5)
     Tests  141 passed (141)
```

`npx vue-tsc --noEmit` — clean.

## Rollout

Safe to merge / deploy in any order relative to AuthBackend Stage 1; both sides emit and accept both keys + both URLs during the rollout window. The `catalog_identifier` alias and legacy URL fallback can be dropped from this repo after AuthBackend Stage 3 cleanup ships.

Rollout stack:
1. **AuthBackend Stage 1** — https://github.com/AceDataCloud/AuthBackend/pull/159 ✅ approved
2. **This PR** + 3 other Stage 2 client PRs (PlatformService aichat2 #934, AuthFrontend #131, CommonFrontend #1)
3. **AuthBackend Stage 3 cleanup** — opened separately, stacked on Stage 1
