### PR TITLE
ci(ota): publish-ota workflow + helper script for COS bundle releases

### DIFF
--- a/.github/workflows/publish-ota.yaml
+++ b/.github/workflows/publish-ota.yaml
@@ -1,0 +1,117 @@
+name: publish-ota
+
+# Build, zip, and publish a Nexior OTA bundle to Tencent Cloud COS so that
+# installed iOS + Android apps wired up in PR #800 can pick it up on next
+# cold start.
+#
+# One bundle, two manifests: the dist/ build is platform-agnostic (same JS
+# runs in iOS WKWebView and Android WebView), so we upload the zip once and
+# point both `ios.json` and `android.json` at it. Keeping the manifests
+# separate leaves room to diverge later (e.g. holding iOS back on a build
+# that fails Apple review) without touching this workflow.
+#
+# Required repo secrets:
+#   - TENCENT_CLOUD_SECRET_ID
+#   - TENCENT_CLOUD_SECRET_KEY
+#
+# The bundle is only consumed by clients with `VITE_LIVE_UPDATE_ENABLED=true`,
+# which is currently off by default. Publishing a bundle therefore won't
+# affect any installed user until that flag is flipped in a subsequent
+# native build.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Bundle version (e.g. 3.35.3). Must be strictly greater than the version currently active on the client to take effect.'
+        required: true
+        type: string
+      channel:
+        description: 'Release channel.'
+        required: true
+        default: 'stable'
+        type: choice
+        options:
+          - stable
+          - beta
+      min_native_version:
+        description: 'Optional: minimum native shell version compatible with this bundle. Clients below this skip the OTA — the version gate forces a store upgrade instead.'
+        required: false
+        type: string
+        default: ''
+      platforms:
+        description: 'Comma-separated list of manifests to write. Default ships both iOS and Android.'
+        required: false
+        type: string
+        default: 'ios,android'
+      dry_run:
+        description: 'Build + show what would be uploaded, but skip the actual COS PUTs.'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build dist with OTA flag enabled
+        env:
+          # Live update must be on in the bundled JS so the client's
+          # liveUpdate.ts actually fetches the manifest after picking up
+          # this bundle. (For the very first bundle the *currently installed*
+          # native already has to be built with the flag on — see
+          # docs/MOBILE_RELEASE.md §5.)
+          VITE_LIVE_UPDATE_ENABLED: 'true'
+        run: npm run build
+
+      - name: Zip dist/
+        id: zip
+        run: |
+          set -euo pipefail
+          test -d dist
+          (cd dist && zip -qr "../${{ inputs.version }}.zip" .)
+          ls -lh "${{ inputs.version }}.zip"
+          echo "zip_path=${{ inputs.version }}.zip" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install cos-python-sdk-v5
+        run: pip install cos-python-sdk-v5
+
+      - name: Publish bundle + manifests to COS
+        env:
+          TENCENT_CLOUD_SECRET_ID: ${{ secrets.TENCENT_CLOUD_SECRET_ID }}
+          TENCENT_CLOUD_SECRET_KEY: ${{ secrets.TENCENT_CLOUD_SECRET_KEY }}
+        run: |
+          python3 scripts/publish_ota_bundle.py \
+            --zip "${{ steps.zip.outputs.zip_path }}" \
+            --version "${{ inputs.version }}" \
+            --channel "${{ inputs.channel }}" \
+            --platforms "${{ inputs.platforms }}" \
+            --min-native-version "${{ inputs.min_native_version }}" \
+            ${{ inputs.dry_run && '--dry-run' || '' }}
+
+      - name: Upload zip as workflow artifact
+        # Keep a copy in the run for debugging / re-upload if needed.
+        uses: actions/upload-artifact@v4
+        with:
+          name: nexior-ota-${{ inputs.channel }}-${{ inputs.version }}
+          path: ${{ steps.zip.outputs.zip_path }}
+          retention-days: 30

--- a/change/@acedatacloud-nexior-ota-pipeline-1779599987.json
+++ b/change/@acedatacloud-nexior-ota-pipeline-1779599987.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "ci(ota): add publish-ota workflow that builds dist + uploads bundle/manifests to COS for iOS and Android",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/docs/MOBILE_RELEASE.md
+++ b/docs/MOBILE_RELEASE.md
@@ -268,30 +268,35 @@ acedatacloud2-1256437459/      # COS bucket
 | `checksum` | 是 | bundle zip 的 sha256 (base64 编码)。客户端激活前校验，不匹配则丢弃。 |
 | `min_native_version` | 否 | 兼容的最低原生壳版本。低于此版本的安装会跳过此 bundle（由 `app-version` 闸门处理强升）。 |
 
-### 手动发布一个 OTA（CI 自动化前的临时流程）
+### 发布一个 OTA（`publish-ota` 工作流）
 
-1. 本地构建：
-   ```bash
-   VITE_SURFACE=ios VITE_LIVE_UPDATE_ENABLED=true npm run build
-   ```
-2. 打包并算校验和：
-   ```bash
-   cd dist && zip -r ../3.35.3.zip . && cd -
-   shasum -a 256 3.35.3.zip | awk '{print $1}' | xxd -r -p | base64
-   ```
-3. 上传 zip 到 COS（用 `coscmd` / Tencent COSBrowser / `.claude/scripts/upload.py`）：
-   ```
-   nexior/updates/stable/bundles/3.35.3.zip
-   ```
-4. 写一个 `ios.json` / `android.json`（结构如上）并上传到：
-   ```
-   nexior/updates/stable/ios.json
-   nexior/updates/stable/android.json
-   ```
-5. 让 EdgeOne 刷新 manifest 路径（zip 不需要刷，URL 带版本号天然防缓存）：
-   ```bash
-   # 见 .claude/commands/manage-edgeone.md
-   ```
+通过 `.github/workflows/publish-ota.yaml` 一键发布，iOS 和 Android 同步生效。
+
+**触发方式：** GitHub Actions → `publish-ota` → Run workflow。
+
+**参数：**
+
+| 参数 | 默认 | 说明 |
+|---|---|---|
+| `version` | — | bundle 版本号，必须严格大于客户端当前运行版本才会生效。 |
+| `channel` | `stable` | `stable` 或 `beta`。 |
+| `min_native_version` | 空 | 可选。原生壳低于此版本的安装跳过本 bundle，由 `app-version` 闸门接管强升。 |
+| `platforms` | `ios,android` | 同时写入哪些 manifest。dist 是平台无关的同一份 zip，默认两端一起更新。 |
+| `dry_run` | false | 只打印计划上传的 key + manifest 内容，不实际 PUT。 |
+
+**工作流做的事：**
+
+1. `npm ci && VITE_LIVE_UPDATE_ENABLED=true npm run build` 生成 `dist/`。
+2. zip 整个 `dist/` 为 `<version>.zip`。
+3. `pip install cos-python-sdk-v5`，然后跑 `scripts/publish_ota_bundle.py`，由它：
+   - 计算 zip 的 sha256（base64）作为 `checksum`；
+   - 上传 zip 到 `cos://<bucket>/nexior/updates/<channel>/bundles/<version>.zip`（`Cache-Control: public, max-age=31536000, immutable`）；
+   - 上传 `ios.json` 和 `android.json`（同一份 manifest 内容）到 `cos://.../<channel>/<platform>.json`（`Cache-Control: public, max-age=60`，让回滚秒级生效）。
+4. 同时把 zip 作为 workflow artifact 保留 30 天，便于排查。
+
+**需要的 repo secrets：** `TENCENT_CLOUD_SECRET_ID`、`TENCENT_CLOUD_SECRET_KEY`。
+
+> dist 是同一份 web bundle，iOS WKWebView 和 Android WebView 直接复用，所以两端共享同一个 zip URL，只是 manifest 文件名不同。需要让 iOS 单独停留在某个旧版本时，把 `platforms` 改成 `android` 单跑即可。
 
 ### 回滚
 

--- a/scripts/publish_ota_bundle.py
+++ b/scripts/publish_ota_bundle.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+Publish an OTA bundle for Nexior to Tencent Cloud COS.
+
+Uploads:
+  1. The zipped `dist/` bundle to `<prefix>/<channel>/bundles/<version>.zip`.
+  2. A platform-specific manifest JSON to `<prefix>/<channel>/<platform>.json`
+     for every platform passed in `--platforms` (default: ios + android).
+
+Both iOS WKWebView and Android WebView serve the same `dist/` build, so a
+single zip is reused across platforms — only the manifest filename differs.
+Reviewers asked us to keep the per-platform manifest split anyway so we can
+later diverge bundle policy (e.g. iOS lagging on a problematic build) without
+changing the publish pipeline.
+
+Designed to run from the `publish-ota` GitHub Actions workflow. Reads COS
+credentials from env vars `TENCENT_CLOUD_SECRET_ID` / `TENCENT_CLOUD_SECRET_KEY`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Iterable
+
+DEFAULT_REGION = "ap-hongkong"
+DEFAULT_BUCKET = "acedatacloud2-1256437459"
+DEFAULT_PREFIX = "nexior/updates"
+DEFAULT_CDN_BASE = "https://cdn.acedata.cloud/nexior/updates"
+
+
+def sha256_b64(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return base64.b64encode(h.digest()).decode("ascii")
+
+
+def get_client(region: str):
+    try:
+        from qcloud_cos import CosConfig, CosS3Client
+    except ImportError:
+        print("ERROR: cos-python-sdk-v5 not installed (pip install cos-python-sdk-v5)", file=sys.stderr)
+        sys.exit(2)
+    secret_id = os.environ.get("TENCENT_CLOUD_SECRET_ID")
+    secret_key = os.environ.get("TENCENT_CLOUD_SECRET_KEY")
+    if not secret_id or not secret_key:
+        print("ERROR: TENCENT_CLOUD_SECRET_ID / TENCENT_CLOUD_SECRET_KEY must be set", file=sys.stderr)
+        sys.exit(2)
+    return CosS3Client(CosConfig(Region=region, SecretId=secret_id, SecretKey=secret_key, Scheme="https"))
+
+
+def upload(client, bucket: str, key: str, body: bytes, content_type: str, *, dry_run: bool) -> None:
+    print(f"  → cos://{bucket}/{key}  ({len(body)} bytes, {content_type})")
+    if dry_run:
+        return
+    client.put_object(
+        Bucket=bucket,
+        Key=key,
+        Body=body,
+        ContentType=content_type,
+        # Manifests must not be edge-cached for long — we want rollbacks /
+        # new releases visible within seconds. Bundles are immutable
+        # (URL contains the version), so they default to whatever COS sets
+        # and downstream CDN can cache them indefinitely.
+        CacheControl="public, max-age=60" if content_type.startswith("application/json") else "public, max-age=31536000, immutable",
+    )
+
+
+def main(argv: Iterable[str]) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--zip", required=True, type=Path, help="Path to the zipped dist/ bundle.")
+    p.add_argument("--version", required=True, help="Bundle version, e.g. 3.35.3")
+    p.add_argument("--channel", default="stable", help="Release channel (stable, beta, ...). Default: stable.")
+    p.add_argument("--platforms", default="ios,android", help="Comma-separated list of platform manifest names to write. Default: ios,android.")
+    p.add_argument("--min-native-version", default="", help="Optional `min_native_version` written into the manifest. Bundles below this are skipped client-side.")
+    p.add_argument("--bucket", default=DEFAULT_BUCKET, help=f"COS bucket. Default: {DEFAULT_BUCKET}.")
+    p.add_argument("--region", default=DEFAULT_REGION, help=f"COS region. Default: {DEFAULT_REGION}.")
+    p.add_argument("--prefix", default=DEFAULT_PREFIX, help=f"Object-key prefix inside the bucket. Default: {DEFAULT_PREFIX}.")
+    p.add_argument("--cdn-base", default=DEFAULT_CDN_BASE, help=f"Public CDN base URL written into manifest.url. Default: {DEFAULT_CDN_BASE}.")
+    p.add_argument("--dry-run", action="store_true", help="Print upload targets and the manifest JSON without uploading.")
+    args = p.parse_args(list(argv))
+
+    if not args.zip.is_file():
+        print(f"ERROR: bundle zip not found: {args.zip}", file=sys.stderr)
+        return 2
+
+    checksum = sha256_b64(args.zip)
+    zip_bytes = args.zip.read_bytes()
+    bundle_key = f"{args.prefix}/{args.channel}/bundles/{args.version}.zip"
+    bundle_url = f"{args.cdn_base}/{args.channel}/bundles/{args.version}.zip"
+
+    manifest: dict = {
+        "version": args.version,
+        "url": bundle_url,
+        "checksum": checksum,
+    }
+    if args.min_native_version:
+        manifest["min_native_version"] = args.min_native_version
+    manifest_bytes = (json.dumps(manifest, ensure_ascii=False, indent=2) + "\n").encode("utf-8")
+
+    print(f"Bundle: {args.zip}  sha256(b64)={checksum}")
+    print(f"Channel: {args.channel}")
+    print(f"Manifest:\n{manifest_bytes.decode('utf-8')}")
+
+    client = None if args.dry_run else get_client(args.region)
+    upload(client, args.bucket, bundle_key, zip_bytes, "application/zip", dry_run=args.dry_run)
+    for platform in [p.strip() for p in args.platforms.split(",") if p.strip()]:
+        manifest_key = f"{args.prefix}/{args.channel}/{platform}.json"
+        upload(client, args.bucket, manifest_key, manifest_bytes, "application/json", dry_run=args.dry_run)
+
+    if args.dry_run:
+        print("DRY RUN — nothing uploaded.")
+    else:
+        print(f"OK. Live at {args.cdn_base}/{args.channel}/<platform>.json")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Final PR of the mobile-sync arc — wires up the release pipeline that lets us
actually push hot fixes to installed iOS + Android apps via the OTA client
that landed in #800.

## What this adds

- `.github/workflows/publish-ota.yaml` — a `workflow_dispatch` GitHub Action
  with these inputs:
  - `version` (required) — e.g. `3.35.3`. Must be strictly greater than the
    bundle currently active on the client.
  - `channel` — `stable` or `beta`. Default `stable`.
  - `min_native_version` — optional. Clients below it skip the bundle; the
    version gate from #799 then forces an App Store / Play Store upgrade.
  - `platforms` — comma-separated, default `ios,android`.
  - `dry_run` — don't actually PUT, just print the plan.
- `scripts/publish_ota_bundle.py` — keeps the YAML thin and makes the upload
  flow locally testable (smoke-tested with `--dry-run`).
- `docs/MOBILE_RELEASE.md` — new "§5 OTA / 发布" section replaces the manual
  publish-flow placeholder that #800 left behind.

## Build + publish flow

```
npm ci
VITE_LIVE_UPDATE_ENABLED=true npm run build
zip -r <version>.zip dist/
sha256(b64)  →  manifest.checksum
PUT cos://<bucket>/nexior/updates/<channel>/bundles/<version>.zip   (immutable, 1y)
PUT cos://<bucket>/nexior/updates/<channel>/ios.json                (max-age=60)
PUT cos://<bucket>/nexior/updates/<channel>/android.json            (max-age=60)
```

## iOS + Android coverage

Both targets consume the same `dist/` (Capacitor WKWebView on iOS,
WebView on Android), so a single zip is shared and only the manifest
filename differs. The default `platforms=ios,android` keeps the two
platforms in lock-step. To hold iOS back during App Review without
freezing Android, run the workflow twice with `platforms=android` and
then `platforms=ios` on different `version`s.

## Cache-Control choices

- Bundles: `public, max-age=31536000, immutable` — URL contains the
  version, so a hot fix never collides with a cached old build.
- Manifests: `public, max-age=60` — keeps rollbacks responsive
  (publish a higher-versioned manifest pointing back at the old zip
  and the fleet picks it up within a minute).

## Required new repo secrets

- `TENCENT_CLOUD_SECRET_ID`
- `TENCENT_CLOUD_SECRET_KEY`

Both follow the existing org convention (same names used by
`.claude/scripts/cos.py`).

## Test plan

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/publish-ota.yaml'))"` — clean.
- `python3 scripts/publish_ota_bundle.py --zip /tmp/_otatest.zip --version 3.35.3 --channel stable --min-native-version 3.35.2 --dry-run` — printed the expected COS keys, sha256 was deterministic.
- Workflow itself will smoke-test on the first manual run after merge
  (with `dry_run=true` first) once the two new secrets are added.

## What's NOT in this PR

- Flipping `VITE_LIVE_UPDATE_ENABLED=true` in the native build envs
  (`build-ios.yaml`, `build-android.yaml`). The OTA client only fetches
  the manifest when the running native bundle was itself built with the
  flag on — that flag flip should happen in a separate small PR after a
  bundle is published once with this workflow and verified.
- EdgeOne cache rules for `nexior/updates/**`. The 60s manifest TTL plus
  versioned zip URLs makes the default CDN behavior fine; revisit only if
  rollbacks start lagging.
