### PR TITLE
fix(ota): COS bucket region is ap-beijing, not ap-hongkong

### DIFF
--- a/change/@acedatacloud-nexior-ota-region-1779600999.json
+++ b/change/@acedatacloud-nexior-ota-region-1779600999.json
@@ -1,0 +1,1 @@
+{"type":"patch","comment":"fix(ota): COS bucket lives in ap-beijing, not ap-hongkong","packageName":"@acedatacloud/nexior","email":"dev@acedata.cloud","dependentChangeType":"patch"}

--- a/scripts/publish_ota_bundle.py
+++ b/scripts/publish_ota_bundle.py
@@ -28,7 +28,7 @@ import sys
 from pathlib import Path
 from typing import Iterable
 
-DEFAULT_REGION = "ap-hongkong"
+DEFAULT_REGION = "ap-beijing"
 DEFAULT_BUCKET = "acedatacloud2-1256437459"
 DEFAULT_PREFIX = "nexior/updates"
 DEFAULT_CDN_BASE = "https://cdn.acedata.cloud/nexior/updates"


### PR DESCRIPTION
Live publish-ota run 26352947035 failed with `NoSuchBucket`. Verified via Tencent EdgeOne `DescribeAccelerationDomains` that `cdn.acedata.cloud` actually fronts:

```
acedatacloud2-1256437459.cos.ap-beijing.myqcloud.com   (PrivateAccess: on)
```

So the bucket name `acedatacloud2-1256437459` was correct all along — only `DEFAULT_REGION` was wrong (`ap-hongkong` → `ap-beijing`). One-line fix. Re-dispatching publish-ota immediately after merge.