### PR TITLE
fix(ota): use COS global accelerate endpoint

### DIFF
--- a/change/@acedatacloud-nexior-ota-accel-1779601460.json
+++ b/change/@acedatacloud-nexior-ota-accel-1779601460.json
@@ -1,0 +1,1 @@
+{"type":"patch","comment":"fix(ota): use COS global accelerate endpoint to avoid GH Actions->ap-beijing timeouts","packageName":"@acedatacloud/nexior","email":"dev@acedata.cloud","dependentChangeType":"patch"}

--- a/scripts/publish_ota_bundle.py
+++ b/scripts/publish_ota_bundle.py
@@ -53,7 +53,18 @@ def get_client(region: str):
     if not secret_id or not secret_key:
         print("ERROR: TENCENT_CLOUD_SECRET_ID / TENCENT_CLOUD_SECRET_KEY must be set", file=sys.stderr)
         sys.exit(2)
-    return CosS3Client(CosConfig(Region=region, SecretId=secret_id, SecretKey=secret_key, Scheme="https"))
+    # Global Accelerate endpoint — uploads from GH Actions runners (US/EU)
+    # to ap-beijing time out without this. The bucket has Accelerate
+    # enabled bucket-side; see .claude/memories repo/cos-accelerate-rollout.md.
+    return CosS3Client(
+        CosConfig(
+            Region=region,
+            SecretId=secret_id,
+            SecretKey=secret_key,
+            Scheme="https",
+            Endpoint="cos.accelerate.myqcloud.com",
+        )
+    )
 
 
 def upload(client, bucket: str, key: str, body: bytes, content_type: str, *, dry_run: bool) -> None:


### PR DESCRIPTION
publish-ota run 26353127937 hit a connection timeout PUTing the bundle to ap-beijing from a GitHub Actions runner — international upload over the GFW is too slow.

Bucket `acedatacloud2-1256437459` already has Accelerate enabled bucket-side (see `cos-accelerate-rollout.md` repo memory; PlatformBackend #509/#510, PlatformService #914, Wisdom #18, PlatformPublisher #501 all already use this). Adding `Endpoint=cos.accelerate.myqcloud.com` to the COS client routes the upload through Tencent's global edge — same pattern, ~30s instead of timing out.

Will re-dispatch publish-ota right after merge.