### PR TITLE
fix(mobile): add top safe-area padding so content clears iOS Dynamic Island / Android status bar

### DIFF
--- a/change/@acedatacloud-nexior-mobile-safe-area-top.json
+++ b/change/@acedatacloud-nexior-mobile-safe-area-top.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(mobile): add top safe-area padding to mobile page bodies so content no longer overlaps the iOS Dynamic Island / notch and the Android status bar (battery / time / icons)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/layouts/Auth.vue
+++ b/src/layouts/Auth.vue
@@ -1,6 +1,6 @@
 <template>
   <el-container>
-    <el-main class="h-[100vh]"> <router-view /> </el-main>
+    <el-main class="auth-main"> <router-view /> </el-main>
   </el-container>
 </template>
 
@@ -16,3 +16,14 @@ export default defineComponent({
   }
 });
 </script>
+
+<style lang="scss" scoped>
+.auth-main {
+  // Respect iOS Dynamic Island / notch and Android status bar so the login
+  // form doesn't slide under the system overlays.
+  height: 100vh;
+  padding-top: var(--app-safe-area-top);
+  padding-bottom: var(--app-safe-area-bottom);
+  box-sizing: border-box;
+}
+</style>

--- a/src/layouts/Console.vue
+++ b/src/layouts/Console.vue
@@ -82,11 +82,14 @@ export default defineComponent({
 @media screen and (max-width: 767px) {
   .console {
     --console-safe-bottom: max(env(safe-area-inset-bottom, 0px), 10px);
+    --console-safe-top: var(--app-safe-area-top);
 
     width: 100%;
     height: 100%;
     display: flex;
     flex-direction: column;
+    // Push content below iOS Dynamic Island / Android status bar.
+    padding-top: var(--console-safe-top);
     .navigator {
       width: 100%;
       height: calc(60px + var(--console-safe-bottom));
@@ -96,7 +99,7 @@ export default defineComponent({
       z-index: 10000;
     }
     .main {
-      height: calc(100% - 60px - var(--console-safe-bottom));
+      height: calc(100% - 60px - var(--console-safe-bottom) - var(--console-safe-top));
       width: 100%;
       flex: 1;
       display: flex;

--- a/src/layouts/Main.vue
+++ b/src/layouts/Main.vue
@@ -203,8 +203,13 @@ export default defineComponent({
     height: 100%;
     display: flex;
     flex-direction: column;
+    // Keep page content below the iOS Dynamic Island / notch and Android
+    // status bar (battery / time / icons). The bottom navigator already
+    // consumes `--app-safe-area-bottom`; the top inset has to be added at
+    // the layout wrapper so every routed service page inherits it.
+    padding-top: var(--app-safe-area-top);
     .main {
-      height: calc(100% - 60px - var(--app-safe-area-bottom));
+      height: calc(100% - 60px - var(--app-safe-area-bottom) - var(--app-safe-area-top));
       width: 100%;
       flex: 1;
     }


### PR DESCRIPTION
## Problem

On native mobile builds (iOS & Android Capacitor), the top of the app
overlaps the system status bar — Dynamic Island / notch on iPhone, the
status icons (time, battery, signal) on Android. The page body is drawn
*under* the system overlays.

This was partially fixed in #680 / #698 for floating widgets (wallet
pill, drawer "open" buttons, sidebars), which read `var(--app-safe-area-top)`.
But the actual scrollable / paint area of mobile pages (service result
panels, console, login form) still starts at `y=0` of the WebView, so
content keeps overlapping the system bar.

## Fix

Apply the existing `--app-safe-area-top` CSS var to the three mobile
layout containers that host page bodies:

| Layout | Change |
|---|---|
| `src/layouts/Main.vue` | mobile `.wrapper` gets `padding-top: var(--app-safe-area-top)`; `.main` height subtracts it |
| `src/layouts/Console.vue` | new `--console-safe-top` knob (mirror of existing `--console-safe-bottom`), applied as `padding-top` on `.console`, subtracted from `.main` height |
| `src/layouts/Auth.vue` | `.auth-main` honors both top and bottom insets so login/signup form doesn't slide under the status bar / home indicator |

Because **every service route** (`Suno`, `Veo`, `Flux`, `Midjourney`,
`Sora`, `Producer`, `Kling`, `Hailuo`, `Luma`, `Wan`, `Seedance`,
`Seedream`, `Pixverse`, `Pika`, `OpenAIImage`, `Nanobanana`, `Qrart`,
`Serp`, `Webextrator`, `Headshots`, `Fish`, `Kimi`, `ChatGPT`,
`DeepSeek`, `Settings`, `Distribution`, …) is registered with
`component: () => import('@/layouts/Main.vue')`, the single change in
`Main.vue` propagates to all of them — no per-service patches needed.

Chat conversation (`Conversation.vue` → `Chat.vue` layout) is rendered
*inside* `Main.vue`'s `.main` slot, so it already inherits the new
top inset without further changes; its hard-coded `52px` top padding
(which clears the floating drawer button) is correct relative to the
already-padded parent.

`TopHeader.vue` (used by the desktop / `Index.vue` layout) already
respects the inset, so non-Main layouts that use TopHeader stay correct.

## Verification

- `vue-tsc --noEmit` clean.
- `eslint` clean on all four changed files.
- CSS uses only variables that have been defined at `:root` since #680;
  no new plugins / native config required.
- Desktop (`min-width: 768px`) styles untouched — change is fully scoped
  inside the existing `@media (max-width: 767px)` mobile blocks.

## Visual

Before: page header / service title / login form / console nav items
sit under the iOS Dynamic Island and Android status icons.

After: the entire mobile UI starts at `safe-area-inset-top`, leaving
the system bar fully visible above the app.

## Out of scope

- `@capacitor/status-bar` plugin install + explicit
  `setOverlaysWebView(true)` / `setStyle(...)` — current CSS is enough
  to fix the visible overlap; an explicit native plugin would only add
  icon-color control (light vs dark icons over light/dark themes),
  which can ship in a follow-up if needed.
- Android `styles.xml` explicit `windowLightStatusBar` — Capacitor's
  runtime default already makes the status bar transparent and
  edge-to-edge; this PR fixes the rendering side without touching
  native theme XML.
