### PR TITLE
chore(release): bump to 3.35.3 for TestFlight + Play internal

### DIFF
--- a/change/@acedatacloud-nexior-release-3-35-3-1779608996.json
+++ b/change/@acedatacloud-nexior-release-3-35-3-1779608996.json
@@ -1,0 +1,1 @@
+{"type":"patch","comment":"chore(release): bump to 3.35.3 for TestFlight + Play internal","packageName":"@acedatacloud/nexior","email":"dev@acedata.cloud","dependentChangeType":"patch"}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acedatacloud/nexior",
-  "version": "3.35.2",
+  "version": "3.35.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acedatacloud/nexior",
-      "version": "3.35.2",
+      "version": "3.35.3",
       "license": "MIT",
       "dependencies": {
         "@capacitor/app": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acedatacloud/nexior",
-  "version": "3.35.2",
+  "version": "3.35.3",
   "author": "Ace Data Cloud <office@acedata.cloud>",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Native version bump for the matching 3.35.3 release shell.

- `package.json`: 3.35.2 → 3.35.3
- `package-lock.json` regenerated
- iOS `MARKETING_VERSION` / `CFBundleVersion` will be `3.35.3` / `33503` (derived in build-ios.yaml)
- Android `versionName` / `versionCode` will be `3.35.3` / `33503` (derived in build-android.yaml)

The 3.35.3 web bundle is already live at `https://cdn.acedata.cloud/nexior/updates/stable/{ios,android}.json` (published by run [#26355367463](https://github.com/AceDataCloud/Nexior/actions/runs/26355367463)). After this merges I'll dispatch:

1. `build-ios.yaml` (workflow_dispatch) → TestFlight
2. `build-android.yaml` (workflow_dispatch, track=internal) → Play internal track