### PR TITLE
refactor(consent): drop catalog_identifier BC alias on IUserConnectionSummary

### DIFF
--- a/change/@acedatacloud-nexior-stage4-bc-1779614337.json
+++ b/change/@acedatacloud-nexior-stage4-bc-1779614337.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "refactor(consent): drop catalog_identifier BC alias on IUserConnectionSummary (AuthBackend Stage 3 emits only connector_identifier).",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/ConnectorConsentCard.test.ts
+++ b/src/components/chat/ConnectorConsentCard.test.ts
@@ -269,9 +269,7 @@ describe('ConnectorConsentCard — post-OAuth status refresh', () => {
     setLocation('http://localhost/chat?consent=req-1');
     mockedListMyConnections.mockResolvedValue([
       // expired / revoked rows are ignored by the case-insensitive `active` check.
-      // Also exercises the legacy `catalog_identifier` alias path (BC during the
-      // catalog→connector rename rollout) — the entry should still resolve.
-      { id: 'conn-1', catalog_identifier: 'acedatacloud/gmail', status: 'expired' }
+      { id: 'conn-1', connector_identifier: 'acedatacloud/gmail', status: 'expired' }
     ]);
     const wrapper = mount(ConnectorConsentCard, {
       props: { toolUseId: 'tu-1', payload: PAYLOAD_TWO_OPTIONS },

--- a/src/components/chat/ConnectorConsentCard.vue
+++ b/src/components/chat/ConnectorConsentCard.vue
@@ -416,7 +416,7 @@ export default defineComponent({
         const connections = await listMyConnections();
         const connectedIds = new Set<string>();
         for (const c of connections) {
-          const id = c.connector_identifier || c.catalog_identifier;
+          const id = c.connector_identifier;
           if (!id) continue;
           if (String(c.status).toLowerCase() === 'active') {
             connectedIds.add(id);

--- a/src/components/chat/connectorCatalogCache.ts
+++ b/src/components/chat/connectorCatalogCache.ts
@@ -78,18 +78,14 @@ export interface IConnectorCatalogInstallResponse {
  *  to detect which entries are now actively connected for the calling
  *  user. The full schema (profile, scopes, expires_at, …) is ignored —
  *  this is purely a presence + status check keyed on the connector
- *  identifier. AuthBackend Stage 1 emits both `connector_identifier`
- *  (canonical) and `catalog_identifier` (legacy alias); we accept either. */
+ *  identifier. */
 export interface IUserConnectionSummary {
   id: string;
   /** Connector identifier (e.g. `acedatacloud/google-drive`).
    *  Empty string for legacy / non-connector installs — those rows can't
    *  match a consent entry's `connector` field so they're effectively
-   *  ignored. Canonical field. */
+   *  ignored. */
   connector_identifier?: string;
-  /** Deprecated alias for {@link connector_identifier}; emitted by
-   *  AuthBackend during the catalog→connector rename rollout. */
-  catalog_identifier?: string;
   /** Backend ships both lowercase and uppercase variants — see
    *  AuthFrontend `ConnectionStatus`. Callers should compare
    *  case-insensitively. */


### PR DESCRIPTION
## Why

AuthBackend Stage 3 (AuthBackend#160) finalised the catalog→connector rename. `/connections/` now emits **only** `connector_identifier` — the legacy `catalog_identifier` alias is gone server-side.

Confirmed against production:

```
curl /api/v1/connections/ -> 14 items
  union_keys: [connector_identifier, created_at, expires_at, id, kind,
               last_error, last_refreshed_at, last_used_at, metadata, profile,
               provider, scopes, server_url, status, supports_refresh,
               updated_at]
  any has connector_identifier: True
  any has catalog_identifier:   False
```

So the BC alias on `IUserConnectionSummary` is dead, and the `|| c.catalog_identifier` fallback in the consent card's status-refresh loop can never fire.

## What

- `src/components/chat/connectorCatalogCache.ts` — drop `IUserConnectionSummary.catalog_identifier?: string` and trim its BC-rollout comment.
- `src/components/chat/ConnectorConsentCard.vue` — remove the `c.connector_identifier || c.catalog_identifier` fallback in `refreshConnectionStatuses()`.
- `src/components/chat/ConnectorConsentCard.test.ts` — flip the legacy-alias test case to use `connector_identifier` (still exercises the expired-status filter — that's what the test actually asserts).

Pure type / dead-code cleanup. No runtime behaviour change.

## Verification

- ✅ `vue-tsc --noEmit` clean
- ✅ `vitest run src/components/chat/ConnectorConsentCard.test.ts` — 15/15 pass
- ✅ `beachball check` — change file added
- ✅ `grep catalog_identifier src/` returns nothing

## Follow-ups (deliberately out of scope)

- File rename `connectorCatalogCache.ts` → `connectorsCache.ts` (touches 4 imports — separate PR).
- Type renames `IConnectorCatalogSummary` → `IConnectorSummary` — broad ripple, separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)