### PR TITLE
refactor(chat): rename consent tool to request_user_consent

### DIFF
--- a/change/@acedatacloud-nexior-request-user-consent.json
+++ b/change/@acedatacloud-nexior-request-user-consent.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "refactor(chat): rename consent tool from `get_connector_status` to `request_user_consent`",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/Message.vue
+++ b/src/components/chat/Message.vue
@@ -68,7 +68,7 @@
                     (item.status === 'awaiting_input' || item.status === 'done')
                   ) &&
                   !(
-                    item.tool_name === 'get_connector_status' &&
+                    item.tool_name === 'request_user_consent' &&
                     (item.status === 'awaiting_input' || item.status === 'done')
                   )
                 "
@@ -97,7 +97,7 @@
               <connector-consent-card
                 v-if="
                   item.type === 'tool_use' &&
-                  item.tool_name === 'get_connector_status' &&
+                  item.tool_name === 'request_user_consent' &&
                   item.status === 'awaiting_input' &&
                   item.pending_consent_request
                 "
@@ -110,7 +110,7 @@
               <connector-consent-card
                 v-if="
                   item.type === 'tool_use' &&
-                  item.tool_name === 'get_connector_status' &&
+                  item.tool_name === 'request_user_consent' &&
                   item.status === 'done' &&
                   consentPayloadFromBlock(item)
                 "

--- a/src/components/chat/consentReturn.test.ts
+++ b/src/components/chat/consentReturn.test.ts
@@ -27,7 +27,7 @@ function awaitingBlock(toolUseId: string, payload: IConsentRequestPayload) {
   return {
     type: 'tool_use' as const,
     tool_id: toolUseId,
-    tool_name: 'get_connector_status',
+    tool_name: 'request_user_consent',
     status: 'awaiting_input' as const,
     pending_consent_request: payload
   };
@@ -101,7 +101,7 @@ describe('findPendingConsentBlock', () => {
           {
             type: 'tool_use',
             tool_id: 'tool_xyz',
-            tool_name: 'get_connector_status',
+            tool_name: 'request_user_consent',
             status: 'done',
             pending_consent_request: PAYLOAD,
             output: '{}'

--- a/src/components/chat/consentReturn.ts
+++ b/src/components/chat/consentReturn.ts
@@ -14,7 +14,7 @@ import { buildConsentOutput } from './connectorConsent';
  *   /chat/c/<conversation>?consent=<request-id>&connector=<identifier>
  *
  * `consent` is the original `consent_request_id` emitted by PR-3's
- * `get_connector_status` tool; `connector` is the canonical catalog
+ * `request_user_consent` tool; `connector` is the canonical catalog
  * identifier of the connector the user just authorized — stamped onto
  * `return_to` by AuthFrontend's `/connections/install/:id` page (the
  * worker omits it because the OAuth state machine doesn't round-trip
@@ -51,7 +51,7 @@ export function parseConsentReturnFromQuery(
 /**
  * Walk backwards through `messages` looking for the assistant message
  * whose last tool_use block:
- *   - was called via `get_connector_status`,
+ *   - was called via `request_user_consent`,
  *   - is still `awaiting_input` (i.e. not yet folded by a prior
  *     resume),
  *   - and whose `pending_consent_request.consent_request_id` matches
@@ -74,7 +74,7 @@ export function findPendingConsentBlock(
     for (let j = m.content.length - 1; j >= 0; j--) {
       const block = m.content[j] as IChatMessageContentItem;
       if (block.type !== 'tool_use') continue;
-      if (block.tool_name !== 'get_connector_status') continue;
+      if (block.tool_name !== 'request_user_consent') continue;
       if (block.status !== 'awaiting_input') continue;
       const payload = block.pending_consent_request;
       if (!payload || payload.consent_request_id !== consentRequestId) continue;
@@ -88,7 +88,7 @@ export function findPendingConsentBlock(
 
 /**
  * Build the `tool_results[0].output` JSON that resumes the paused
- * `get_connector_status` block after a successful OAuth round-trip.
+ * `request_user_consent` block after a successful OAuth round-trip.
  * Marks the just-authorized `connector` as ``authorized`` and leaves
  * ``skipped`` empty — if other unsatisfied requirements remain, the
  * worker will re-pause with a fresh consent card so the user can

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -104,7 +104,7 @@ export interface IChatMessageContentItem {
   // The card UI renders this; on submit, it's stripped and `output` is set.
   pending_question?: IAskUserQuestionPayload;
   // Present iff `status === 'awaiting_input'` and the pause was driven by
-  // `get_connector_status`. Carries the consent payload so the frontend can
+  // `request_user_consent`. Carries the consent payload so the frontend can
   // render `<ConnectorConsentCard>`; on resume the resume detector strips it
   // and folds `output` (the user's authorize/skip JSON) into the block.
   pending_consent_request?: IConsentRequestPayload;
@@ -145,9 +145,9 @@ export interface IAskUserQuestionPayload {
   questions: IAskUserQuestion[];
 }
 
-// ===== get_connector_status tool payload =====
+// ===== request_user_consent tool payload =====
 // Mirrors aichat2 worker contract (frozen). When the model calls the
-// `get_connector_status` tool with unsatisfied requirements, the worker
+// `request_user_consent` tool with unsatisfied requirements, the worker
 // pauses the turn and emits a single SSE event of type `consent_request`
 // carrying this payload, followed by a terminal `done` with
 // `terminal_reason: 'awaiting_user_input'`. The card UI renders this and,
@@ -162,7 +162,7 @@ export interface IConsentRequestEntry {
    *  `/api/v1/connections/catalog/<id>/`). Required: the consent card uses
    *  this to fetch logo / localized name / permission list so each row can
    *  show the upstream brand instead of the opaque slug. Emitted by the
-   *  worker's `get_connector_status` tool — there is no fallback because
+   *  worker's `request_user_consent` tool — there is no fallback because
    *  Layer-2 validation guarantees every entry's `connector` resolves to
    *  a catalog row. */
   catalog_id: string;

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -121,7 +121,7 @@ export interface IData {
    * Stashed on mount from the `?consent=&connector=` deep-link the
    * AuthFrontend install page redirects back to after a successful
    * OAuth round-trip. The `messages` watcher consumes it as soon as
-   * the matching awaiting `get_connector_status` block is in the
+   * the matching awaiting `request_user_consent` block is in the
    * conversation, then clears it. Set to ``null`` when there's no
    * pending return (the common case).
    */
@@ -732,7 +732,7 @@ export default defineComponent({
     },
     /**
      * Resume a paused conversation by submitting a tool result for the
-     * `get_connector_status` block. Mirrors `onAnswerAskUserQuestion`:
+     * `request_user_consent` block. Mirrors `onAnswerAskUserQuestion`:
      * folds the pending block locally so the card flips to the resolved
      * banner immediately, pushes a fresh pending assistant message, and
      * runs the next streaming turn against `tool_results`.
@@ -782,7 +782,7 @@ export default defineComponent({
      * than popping a new window. AuthFrontend completes the OAuth
      * dance and redirects back here with
      * ``?consent=<rid>&connector=<id>``; the `messages` watcher then
-     * spots the matching awaiting `get_connector_status` block and
+     * spots the matching awaiting `request_user_consent` block and
      * resumes the paused turn automatically (see
      * ``onConsumePendingConsentReturn``).
      *
@@ -816,7 +816,7 @@ export default defineComponent({
     },
     /**
      * Try to consume ``pendingConsentReturn`` by locating the matching
-     * awaiting ``get_connector_status`` block in ``messages`` and
+     * awaiting ``request_user_consent`` block in ``messages`` and
      * dispatching ``onRespondConnectorConsent`` with the just-authorized
      * connector. Called by the `messages` watcher on every mutation so
      * we run as soon as ``onRestoreCurrentConversation`` populates the
@@ -940,7 +940,7 @@ export default defineComponent({
                 toolItem.pending_question = response.payload as IAskUserQuestionPayload;
               }
             } else if (response.type === 'consent_request' && response.tool_id && response.payload) {
-              // Worker pauses the turn on `get_connector_status` with unmet
+              // Worker pauses the turn on `request_user_consent` with unmet
               // requirements. Flip the matching tool_use block to
               // `awaiting_input`; the renderer swaps in
               // <ConnectorConsentCard>. SSE then ends with terminal_reason


### PR DESCRIPTION
# refactor(chat): rename consent tool to `request_user_consent`

## Why

[PlatformService PR #936](https://github.com/AceDataCloud/PlatformService/pull/936)
renames the worker tool that triggers the consent card from
`get_connector_status` to `request_user_consent`. This PR migrates the
frontend to the new name everywhere it dispatches on the consent tool
block.

No backward compatibility for the old name — the wire shape is
unchanged on both sides, but the persisted `tool_name` on historic
`tool_use` blocks created before PlatformService #936 ships will not
match this code, so historic conversations created before the rollout
will fall back to the generic `<ToolActivity>` row. The product call
is that this drift is acceptable.

## Changes

* `src/components/chat/Message.vue` — three `v-if` checks (the
  `ToolActivity` suppression + `ConnectorConsentCard` rendering for
  the awaiting and resolved branches) now match
  `'request_user_consent'` directly.
* `src/components/chat/consentReturn.ts` — `findPendingConsentBlock`
  runtime filter + surrounding JSDoc updated.
* `src/models/chat.ts` — JSDoc + section header for the tool payload
  model.
* `src/pages/chat/Conversation.vue` — JSDoc on consent-related
  methods.
* `src/components/chat/consentReturn.test.ts` — fixture `tool_name`
  string updated.

## Wire shape is unchanged

* SSE event `consent_request` + `ConsentRequestPayload`.
* `terminal_reason: 'awaiting_user_input'`.
* Resume contract via `/conversations/{id}/consent`.

## Validation

* `npx vitest run` -> **141/141 pass (5 files)**.
* `npx vue-tsc --noEmit -p tsconfig.json` -> clean.

## Deploy

Ship together with [AceDataCloud/PlatformService#936](https://github.com/AceDataCloud/PlatformService/pull/936).
The wire is unchanged so deploy order is not strictly enforced -- but
note that conversations resolved between the two rollouts will mismatch
on `tool_name`, so prefer rolling both forward in the same window.
