### PR TITLE
ci(mobile): preflight skip when version already on TestFlight/Play

### DIFF
--- a/.github/workflows/build-android.yaml
+++ b/.github/workflows/build-android.yaml
@@ -16,6 +16,11 @@ on:
           - alpha
           - beta
           - production
+      force:
+        description: 'Build even if this versionCode is already uploaded to Play (default: skip duplicates).'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -25,8 +30,121 @@ env:
   JAVA_VERSION: '21'
 
 jobs:
+  preflight:
+    name: Preflight (skip if Play already has this versionCode)
+    runs-on: ubuntu-latest
+    outputs:
+      should-build: ${{ steps.check.outputs.should-build }}
+      version-name: ${{ steps.version.outputs.name }}
+      version-code: ${{ steps.version.outputs.code }}
+      track: ${{ steps.track.outputs.track }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Determine version from package.json
+        id: version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          IFS='.' read -r major minor patch <<< "$VERSION"
+          CODE=$((major * 10000 + minor * 100 + patch))
+          echo "name=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "code=$CODE"   >> "$GITHUB_OUTPUT"
+          echo "Version: $VERSION  Code: $CODE"
+
+      - name: Determine Play Store track
+        id: track
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "track=${{ inputs.track }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "track=internal" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Check Play Console for existing AAB/APK
+        id: check
+        env:
+          FORCE: ${{ inputs.force }}
+          SA_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          PACKAGE_NAME: com.acedatacloud.nexior
+          VERSION_CODE: ${{ steps.version.outputs.code }}
+        # Opens a Play Console edit, lists all previously uploaded bundles/apks,
+        # and aborts the edit. If the target versionCode already appears, we set
+        # should-build=false so the heavy build job is skipped. Fail-open on any
+        # API failure so a flaky preflight never blocks a release.
+        run: |
+          if [ "$FORCE" = "true" ]; then
+            echo "::notice::force=true → skipping Play duplicate check."
+            echo "should-build=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          python3 -m pip install --quiet 'pyjwt[crypto]==2.10.1' requests
+          python3 <<'PY'
+          import json, os, time, requests, jwt
+          try:
+              sa = json.loads(os.environ['SA_JSON'])
+              package = os.environ['PACKAGE_NAME']
+              wanted = int(os.environ['VERSION_CODE'])
+
+              # Exchange the service-account JWT for an access token.
+              now = int(time.time())
+              assertion = jwt.encode(
+                  {
+                      'iss': sa['client_email'],
+                      'scope': 'https://www.googleapis.com/auth/androidpublisher',
+                      'aud': 'https://oauth2.googleapis.com/token',
+                      'iat': now, 'exp': now + 3600,
+                  },
+                  sa['private_key'], algorithm='RS256',
+              )
+              tok = requests.post(
+                  'https://oauth2.googleapis.com/token',
+                  data={
+                      'grant_type': 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                      'assertion': assertion,
+                  }, timeout=30,
+              )
+              tok.raise_for_status()
+              access = tok.json()['access_token']
+              h = {'Authorization': f'Bearer {access}'}
+              base = f'https://androidpublisher.googleapis.com/androidpublisher/v3/applications/{package}'
+
+              edit = requests.post(f'{base}/edits', headers=h, json={}, timeout=30)
+              edit.raise_for_status()
+              edit_id = edit.json()['id']
+              try:
+                  codes = set()
+                  for kind in ('bundles', 'apks'):
+                      r = requests.get(f'{base}/edits/{edit_id}/{kind}', headers=h, timeout=30)
+                      if r.status_code == 200:
+                          for item in r.json().get(kind, []):
+                              codes.add(int(item['versionCode']))
+              finally:
+                  requests.delete(f'{base}/edits/{edit_id}', headers=h, timeout=30)
+
+              if wanted in codes:
+                  print(f"::notice::Play already has versionCode {wanted} for {package} (uploaded: {sorted(codes)[-10:]}) — skipping.")
+                  should = 'false'
+              else:
+                  print(f"versionCode {wanted} not yet uploaded (last 10 uploaded: {sorted(codes)[-10:]}) — proceeding.")
+                  should = 'true'
+          except Exception as e:
+              print(f"::warning::Play preflight check failed ({e!r}) — letting build proceed.")
+              should = 'true'
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+              f.write(f'should-build={should}\n')
+          print(f'should-build={should}')
+          PY
+
   build:
     name: Build & Upload to Play Store
+    needs: preflight
+    if: needs.preflight.outputs.should-build == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -60,21 +178,13 @@ jobs:
           echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > android/app/release.keystore
         shell: bash
 
-      - name: Determine version
-        id: version
-        run: |
-          VERSION=$(node -p "require('./package.json').version")
-          # versionCode: major*10000 + minor*100 + patch
-          IFS='.' read -r major minor patch <<< "$VERSION"
-          CODE=$((major * 10000 + minor * 100 + patch))
-          echo "name=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "code=$CODE" >> "$GITHUB_OUTPUT"
-          echo "Version: $VERSION  Code: $CODE"
-
       - name: Set version in build.gradle
+        env:
+          VERSION_NAME: ${{ needs.preflight.outputs.version-name }}
+          VERSION_CODE: ${{ needs.preflight.outputs.version-code }}
         run: |
-          sed -i "s/versionCode [0-9]*/versionCode ${{ steps.version.outputs.code }}/" android/app/build.gradle
-          sed -i "s/versionName \"[^\"]*\"/versionName \"${{ steps.version.outputs.name }}\"/" android/app/build.gradle
+          sed -i "s/versionCode [0-9]*/versionCode $VERSION_CODE/" android/app/build.gradle
+          sed -i "s/versionName \"[^\"]*\"/versionName \"$VERSION_NAME\"/" android/app/build.gradle
         shell: bash
 
       - name: Build release AAB
@@ -99,23 +209,14 @@ jobs:
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4
         with:
-          name: nexior-${{ steps.version.outputs.name }}.apk
+          name: nexior-${{ needs.preflight.outputs.version-name }}.apk
           path: android/app/build/outputs/apk/release/app-release.apk
 
       - name: Upload AAB artifact
         uses: actions/upload-artifact@v4
         with:
-          name: nexior-${{ steps.version.outputs.name }}.aab
+          name: nexior-${{ needs.preflight.outputs.version-name }}.aab
           path: android/app/build/outputs/bundle/release/app-release.aab
-
-      - name: Determine Play Store track
-        id: track
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "track=${{ inputs.track }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "track=internal" >> "$GITHUB_OUTPUT"
-          fi
 
       - name: Upload to Play Store
         uses: r0adkll/upload-google-play@v1
@@ -123,5 +224,5 @@ jobs:
           serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: com.acedatacloud.nexior
           releaseFiles: android/app/build/outputs/bundle/release/app-release.aab
-          tracks: ${{ steps.track.outputs.track }}
+          tracks: ${{ needs.preflight.outputs.track }}
           status: completed

--- a/.github/workflows/build-ios.yaml
+++ b/.github/workflows/build-ios.yaml
@@ -5,6 +5,12 @@ on:
     tags:
       - 'ios-v*'
   workflow_dispatch:
+    inputs:
+      force:
+        description: 'Build even if this version already exists in TestFlight (default: skip duplicates).'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -13,8 +19,103 @@ env:
   NODE_VERSION: '22'
 
 jobs:
+  preflight:
+    name: Preflight (skip if TestFlight already has this build)
+    runs-on: ubuntu-latest
+    outputs:
+      should-build: ${{ steps.check.outputs.should-build }}
+      version-name: ${{ steps.version.outputs.name }}
+      version-code: ${{ steps.version.outputs.code }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Determine version from package.json
+        id: version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          IFS='.' read -r major minor patch <<< "$VERSION"
+          CODE=$((major * 10000 + minor * 100 + patch))
+          echo "name=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "code=$CODE"   >> "$GITHUB_OUTPUT"
+          echo "Version: $VERSION  Code: $CODE"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Check TestFlight for existing build
+        id: check
+        env:
+          FORCE: ${{ inputs.force }}
+          ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          ASC_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_KEY_BASE64 }}
+          BUNDLE_ID: com.acedatacloud.nexior
+          BUILD_NUMBER: ${{ steps.version.outputs.code }}
+        # Queries App Store Connect for a build with CFBundleVersion == BUILD_NUMBER
+        # under our app and sets should-build=false if one already exists. On any
+        # API failure we fail-open (should-build=true) so a flaky preflight never
+        # blocks a release; the actual altool upload will surface the real error.
+        run: |
+          if [ "$FORCE" = "true" ]; then
+            echo "::notice::force=true → skipping TestFlight duplicate check."
+            echo "should-build=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          python3 -m pip install --quiet 'pyjwt[crypto]==2.10.1' requests
+          python3 <<'PY'
+          import base64, os, time, requests, jwt
+          try:
+              now = int(time.time())
+              key_pem = base64.b64decode(os.environ['ASC_KEY_BASE64']).decode()
+              token = jwt.encode(
+                  {'iss': os.environ['ASC_ISSUER_ID'], 'iat': now, 'exp': now + 1200, 'aud': 'appstoreconnect-v1'},
+                  key_pem,
+                  algorithm='ES256',
+                  headers={'kid': os.environ['ASC_KEY_ID'], 'typ': 'JWT'},
+              )
+              h = {'Authorization': f'Bearer {token}'}
+              bundle = os.environ['BUNDLE_ID']
+              build_num = os.environ['BUILD_NUMBER']
+              r = requests.get(
+                  'https://api.appstoreconnect.apple.com/v1/apps',
+                  headers=h, params={'filter[bundleId]': bundle}, timeout=30,
+              )
+              r.raise_for_status()
+              apps = r.json().get('data', [])
+              if not apps:
+                  print(f"::warning::No App Store Connect app for bundleId={bundle} — letting build proceed.")
+                  should = 'true'
+              else:
+                  app_id = apps[0]['id']
+                  r = requests.get(
+                      'https://api.appstoreconnect.apple.com/v1/builds',
+                      headers=h,
+                      params={'filter[app]': app_id, 'filter[version]': build_num, 'limit': 1},
+                      timeout=30,
+                  )
+                  r.raise_for_status()
+                  builds = r.json().get('data', [])
+                  if builds:
+                      print(f"::notice::TestFlight already has build {build_num} for {bundle} — skipping.")
+                      should = 'false'
+                  else:
+                      print(f"Build {build_num} not yet uploaded — proceeding.")
+                      should = 'true'
+          except Exception as e:
+              print(f"::warning::TestFlight preflight check failed ({e!r}) — letting build proceed.")
+              should = 'true'
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+              f.write(f'should-build={should}\n')
+          print(f'should-build={should}')
+          PY
+
   build:
     name: Build & Upload to TestFlight
+    needs: preflight
+    if: needs.preflight.outputs.should-build == 'true'
     runs-on: macos-15
 
     steps:
@@ -56,21 +157,14 @@ jobs:
         working-directory: ios/App
         run: pod install
 
-      - name: Determine version
-        id: version
-        run: |
-          VERSION=$(node -p "require('./package.json').version")
-          IFS='.' read -r major minor patch <<< "$VERSION"
-          CODE=$((major * 10000 + minor * 100 + patch))
-          echo "name=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "code=$CODE" >> "$GITHUB_OUTPUT"
-          echo "Version: $VERSION  Code: $CODE"
-
       - name: Set version in Xcode project
+        env:
+          VERSION_NAME: ${{ needs.preflight.outputs.version-name }}
+          VERSION_CODE: ${{ needs.preflight.outputs.version-code }}
         run: |
           cd ios/App
-          agvtool new-marketing-version "${{ steps.version.outputs.name }}"
-          agvtool new-version -all "${{ steps.version.outputs.code }}"
+          agvtool new-marketing-version "$VERSION_NAME"
+          agvtool new-version -all "$VERSION_CODE"
 
       - name: Install Apple certificate and provisioning profile
         env:
@@ -154,7 +248,7 @@ jobs:
       - name: Upload IPA artifact
         uses: actions/upload-artifact@v4
         with:
-          name: nexior-${{ steps.version.outputs.name }}.ipa
+          name: nexior-${{ needs.preflight.outputs.version-name }}.ipa
           path: ${{ runner.temp }}/export/*.ipa
 
       - name: Upload to TestFlight


### PR DESCRIPTION
## Summary

Both `build-ios` and `build-android` workflows now run a cheap preflight job that queries the relevant store API for the target version. If the version is already present on TestFlight / Play Console, the heavy build job is gated off via `needs:` + `if:` — re-triggering the workflow on an already-published version is a no-op (UI shows **Skipped**, overall run reports success) instead of failing with a confusing duplicate error from `altool` / `r0adkll-upload-google-play`.

## Why

> 'ios 和 android 的 yaml，必须 push tag 才能发布吗？能不能这样？只要 trigger 了 ios 和 android 的版本，就 trigger pipeline 发布，不会自动触发，可以手动触发。然后如果有重复版本，就跳过。'

Today, when an operator re-runs a workflow against a version that has already shipped, the build runs end-to-end and fails late at the upload step. This wastes ~10 min of macOS runner time per iOS retry. After this change, the duplicate is caught in <30 s by a single API call.

## How

### `build-ios.yaml`
- New `preflight` job on `ubuntu-latest`. Generates an App Store Connect ES256 JWT from the existing `APP_STORE_CONNECT_*` secrets, queries:
  - `GET /v1/apps?filter[bundleId]=com.acedatacloud.nexior` → app id
  - `GET /v1/builds?filter[app]=<id>&filter[version]=<buildCode>`
- Sets `should-build=false` only when a build with the same `CFBundleVersion` is found.
- Also computes `version-name` / `version-code` once and exposes them as job outputs so the `build` job no longer needs its own 'Determine version' step.

### `build-android.yaml`
- New `preflight` job. Generates a Google Play RS256 JWT from the existing `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` secret, exchanges for an OAuth2 access token, opens a Play Console edit, lists all uploaded bundles + apks (collects every `versionCode` ever uploaded), then deletes the edit.
- Sets `should-build=false` only when the target `versionCode` is already in that set.
- Also computes `version-*` / `track` once for downstream consumption.

### Shared design choices
- **Triggers unchanged.** Both workflows still trigger on the same `push.tags` pattern + `workflow_dispatch`. The PR explicitly does **not** add an `on: push:` to `main` — releases remain operator-driven.
- **`force` boolean input.** Each `workflow_dispatch` gains a `force` toggle (default false). Useful for legitimate re-uploads (e.g. a TestFlight build was rejected and you need to re-cut the same version after fixing it).
- **Fail-open.** The preflight script wraps the API call in `try / except Exception`. Any failure (network blip, API outage, expired token) logs `::warning::` and lets the build proceed. The preflight must never *block* a release.
- **Cheap.** Preflight is ~30 s on `ubuntu-latest`; only the expensive macOS / Gradle work is gated.
- Uses `actions/setup-python@v5` so `pip install` isn't blocked by PEP 668 on `ubuntu-24.04`.

## Operator workflow after this lands

1. Bump `package.json` version, merge.
2. Push tag `ios-vX.Y.Z` and/or `android-vX.Y.Z` (or click 'Run workflow' in the Actions UI).
3. If the version is already on TestFlight / Play, the run shows up as 'Skipped' — no confusing red ❌. Re-run as many times as needed.
4. To force a re-upload (rare, e.g. metadata fix on the same version), use 'Run workflow' → set `force = true`.

## Risk

- Low. No source changes, only CI YAML.
- The fail-open behaviour means the absolute worst case is 'preflight didn't help, build runs and fails late' — i.e. today's behaviour.

## Test plan

After merge, manually `workflow_dispatch` both workflows against an already-published version. Expect:
- `preflight` job: green, with a `::notice::` line naming the version.
- `build` job: skipped.
- Overall run: success.