### PR TITLE
fix(android): enable edge-to-edge and replace deprecated cutout mode

### DIFF
--- a/android/app/src/main/java/com/acedatacloud/nexior/MainActivity.java
+++ b/android/app/src/main/java/com/acedatacloud/nexior/MainActivity.java
@@ -1,9 +1,17 @@
 package com.acedatacloud.nexior;
 
+import android.os.Bundle;
+import androidx.activity.EdgeToEdge;
 import com.getcapacitor.BridgeActivity;
 
 /**
  * MainActivity is the main entry point for the Nexior Android application.
  * It extends BridgeActivity to provide Capacitor functionality.
  */
-public class MainActivity extends BridgeActivity {}
+public class MainActivity extends BridgeActivity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        EdgeToEdge.enable(this);
+        super.onCreate(savedInstanceState);
+    }
+}

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -13,5 +13,6 @@
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
         <item name="android:background">@null</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">always</item>
     </style>
 </resources>

--- a/change/@acedatacloud-nexior-android-edge-to-edge.json
+++ b/change/@acedatacloud-nexior-android-edge-to-edge.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(android): enable edge-to-edge and replace deprecated cutout mode",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
## Summary

Resolves the two **recommended actions** Play Console flagged for release **33503**:

1. **Edge-to-edge may not display for all users** — apps targeting SDK 35 on Android 15+ display edge-to-edge by default. We now call `EdgeToEdge.enable()` in `MainActivity.onCreate` so the Capacitor `WebView` is composed correctly under the transparent system bars.
2. **App uses deprecated APIs / parameters for edge-to-edge** — the `LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES` value used internally by `androidx.activity` is deprecated on Android 15. The activity theme now sets `android:windowLayoutInDisplayCutoutMode="always"` so the cutout area is drawable in all orientations.

## Files

- `android/app/src/main/java/com/acedatacloud/nexior/MainActivity.java` — `EdgeToEdge.enable(this)` before `super.onCreate(...)`
- `android/app/src/main/res/values/styles.xml` — `windowLayoutInDisplayCutoutMode=always` on `AppTheme.NoActionBar`

## Verification

Built debug APK locally on the `fix/android-edge-to-edge` branch:

```
./gradlew assembleDebug
BUILD SUCCESSFUL in 1m 5s
```

Installed and launched on an `arm64` Pixel-class **API 36 / Android 16** AVD (Google Play system image). Status bar and gesture bar render transparently over the apps blue background; the login card sits inside the safe area; no content is clipped under the simulated cutout.

## Risk

- Touches only native Android module. No web code, no API surface change.
- `EdgeToEdge.enable()` is provided by `androidx.activity` which is already on the classpath via Capacitor 8.
- Capacitor `BridgeActivity` calls `setTheme(R.style.AppTheme_NoActionBar)` in its own `onCreate`, so the theme change is picked up automatically.

After this lands, the next CI build will produce versionCode 33504 (or whichever the release manager bumps to); promote it to **Internal testing** and confirm the two warnings disappear from the Production track recommendations panel.