### PR TITLE
feat(ios): use native Sign in with Apple instead of web fallback

### DIFF
--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		504EC30E1FED79650016851F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		504EC3111FED79650016851F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		504EC3131FED79650016851F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		ACEDA7AC1000000000000003 /* App.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = App.entitlements; sourceTree = "<group>"; };
 		50B271D01FEDC1A000F3C39B /* public */ = {isa = PBXFileReference; lastKnownFileType = folder; path = public; sourceTree = "<group>"; };
 		ACEDA7AC1000000000000001 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		AF277DCFFFF123FFC6DF26C7 /* Pods_App.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_App.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -81,6 +82,7 @@
 				504EC30E1FED79650016851F /* Assets.xcassets */,
 				504EC3101FED79650016851F /* LaunchScreen.storyboard */,
 				504EC3131FED79650016851F /* Info.plist */,
+				ACEDA7AC1000000000000003 /* App.entitlements */,
 				ACEDA7AC1000000000000001 /* PrivacyInfo.xcprivacy */,
 				2FAD9762203C412B000D30F8 /* config.xml */,
 				50B271D01FEDC1A000F3C39B /* public */,
@@ -351,6 +353,7 @@
 			baseConfigurationReference = FC68EB0AF532CFC21C3344DD /* Pods-App.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 33502;
 				INFOPLIST_FILE = App/Info.plist;
@@ -371,6 +374,7 @@
 			baseConfigurationReference = AF51FD2D460BCFE21FA515B2 /* Pods-App.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 33502;
 				INFOPLIST_FILE = App/Info.plist;

--- a/ios/App/App/App.entitlements
+++ b/ios/App/App/App.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -11,8 +11,10 @@ install! 'cocoapods', :disable_input_output_paths => true
 def capacitor_pods
   pod 'Capacitor', :path => '../../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../../node_modules/@capacitor/ios'
+  pod 'CapacitorCommunityAppleSignIn', :path => '../../node_modules/@capacitor-community/apple-sign-in'
   pod 'CapacitorApp', :path => '../../node_modules/@capacitor/app'
   pod 'CapacitorBrowser', :path => '../../node_modules/@capacitor/browser'
+  pod 'CapgoCapacitorUpdater', :path => '../../node_modules/@capgo/capacitor-updater'
 end
 
 target 'App' do

--- a/ios/App/Podfile.lock
+++ b/ios/App/Podfile.lock
@@ -1,17 +1,38 @@
 PODS:
+  - Alamofire (5.10.2)
+  - BigInt (5.2.0)
   - Capacitor (8.3.4):
     - CapacitorCordova
   - CapacitorApp (8.1.0):
     - Capacitor
   - CapacitorBrowser (8.0.3):
     - Capacitor
+  - CapacitorCommunityAppleSignIn (7.1.0):
+    - Capacitor
   - CapacitorCordova (8.3.4)
+  - CapgoCapacitorUpdater (8.47.3):
+    - Alamofire (= 5.10.2)
+    - BigInt (= 5.2.0)
+    - Capacitor
+    - Version (= 0.8.0)
+    - ZIPFoundation (~> 0.9)
+  - Version (0.8.0)
+  - ZIPFoundation (0.9.20)
 
 DEPENDENCIES:
   - "Capacitor (from `../../node_modules/@capacitor/ios`)"
   - "CapacitorApp (from `../../node_modules/@capacitor/app`)"
   - "CapacitorBrowser (from `../../node_modules/@capacitor/browser`)"
+  - "CapacitorCommunityAppleSignIn (from `../../node_modules/@capacitor-community/apple-sign-in`)"
   - "CapacitorCordova (from `../../node_modules/@capacitor/ios`)"
+  - "CapgoCapacitorUpdater (from `../../node_modules/@capgo/capacitor-updater`)"
+
+SPEC REPOS:
+  trunk:
+    - Alamofire
+    - BigInt
+    - Version
+    - ZIPFoundation
 
 EXTERNAL SOURCES:
   Capacitor:
@@ -20,15 +41,25 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/@capacitor/app"
   CapacitorBrowser:
     :path: "../../node_modules/@capacitor/browser"
+  CapacitorCommunityAppleSignIn:
+    :path: "../../node_modules/@capacitor-community/apple-sign-in"
   CapacitorCordova:
     :path: "../../node_modules/@capacitor/ios"
+  CapgoCapacitorUpdater:
+    :path: "../../node_modules/@capgo/capacitor-updater"
 
 SPEC CHECKSUMS:
+  Alamofire: 7193b3b92c74a07f85569e1a6c4f4237291e7496
+  BigInt: f668a80089607f521586bbe29513d708491ef2f7
   Capacitor: d13cad5fa09155679672808cc4ca9fbc2997e1b4
   CapacitorApp: 449ffe26375e96f8aaaee625ac6e01e5c57c8650
   CapacitorBrowser: c987c73d09d8bd3b5ec13f06338b1e14d5d2be69
+  CapacitorCommunityAppleSignIn: 271cb2860576fd2961508bbfa7a82117d93eadca
   CapacitorCordova: c07921bdcfec6f691bae22274446b4d606ebf6a4
+  CapgoCapacitorUpdater: ce307147fe77a339112ac11d52842e6adf1339a5
+  Version: de5907f2c5d0f3cf21708db7801d1d5401139486
+  ZIPFoundation: dfd3d681c4053ff7e2f7350bc4e53b5dba3f5351
 
-PODFILE CHECKSUM: 55f50f9985ef91db876d804e5d39061113f88c5e
+PODFILE CHECKSUM: b2bd6bb67028ff98ed5edc68368a9b32ae195764
 
 COCOAPODS: 1.16.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "3.35.3",
       "license": "MIT",
       "dependencies": {
+        "@capacitor-community/apple-sign-in": "^7.1.0",
         "@capacitor/app": "^8.0.1",
         "@capacitor/browser": "^8.0.1",
         "@capgo/capacitor-updater": "^8.47.3",
@@ -322,6 +323,19 @@
       },
       "bin": {
         "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@capacitor-community/apple-sign-in": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@capacitor-community/apple-sign-in/-/apple-sign-in-7.1.0.tgz",
+      "integrity": "sha512-df7cA7vfvvvilTtpJKeVvxO31W+py5t3HK9233GBD5MvgAgtGvCqeQ3pI0noNkVsKPF9B1g/po8Mph6s4bVSmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/scriptjs": "0.0.2",
+        "scriptjs": "^2.5.9"
+      },
+      "peerDependencies": {
+        "@capacitor/core": ">=7.0.0"
       }
     },
     "node_modules/@capacitor/android": {
@@ -4792,6 +4806,12 @@
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
       "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/scriptjs": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@types/scriptjs/-/scriptjs-0.0.2.tgz",
+      "integrity": "sha512-GFrUgzGYfNX3VWZwMyzr0JrBwzLv5Kes4BQBvo6hXdRy14/GBbpCiVwwB7v1o2xIEvFf+9GyznmYhuesQQjSag==",
       "license": "MIT"
     },
     "node_modules/@types/slice-ansi": {
@@ -12336,6 +12356,12 @@
       "engines": {
         "node": ">=v12.22.7"
       }
+    },
+    "node_modules/scriptjs": {
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/scriptjs/-/scriptjs-2.5.9.tgz",
+      "integrity": "sha512-qGVDoreyYiP1pkQnbnFAUIS5AjenNwwQBdl7zeos9etl+hYKWahjRTfzAZZYBv5xNHx7vNKCmaLDQZ6Fr2AEXg==",
+      "license": "MIT"
     },
     "node_modules/scule": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "analyze": "vite-bundle-visualizer"
   },
   "dependencies": {
+    "@capacitor-community/apple-sign-in": "^7.1.0",
     "@capacitor/app": "^8.0.1",
     "@capacitor/browser": "^8.0.1",
     "@capgo/capacitor-updater": "^8.47.3",

--- a/src/components/common/AuthPanel.vue
+++ b/src/components/common/AuthPanel.vue
@@ -31,13 +31,20 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
+import axios from 'axios';
 import { ElDialog } from 'element-plus';
 import { getBaseUrlAuth, withCurrentSite } from '@/utils';
 import { getCookie } from 'typescript-cookie';
 import QrCode from 'vue-qrcode';
 import { ROUTE_SETTINGS_INDEX } from '@/router';
 import { Browser } from '@capacitor/browser';
-import { isNative as isNativeSurface } from '@/utils/surface';
+import { SignInWithApple } from '@capacitor-community/apple-sign-in';
+import { isNative as isNativeSurface, isIOS } from '@/utils/surface';
+
+// Native Sign In with Apple is keyed by the iOS bundle identifier, NOT
+// the web Services ID. The same Apple `sub` is returned for both, so
+// accounts stay linked across native and web.
+const APPLE_NATIVE_CLIENT_ID = 'com.acedatacloud.nexior';
 
 export default defineComponent({
   name: 'AuthPanel',
@@ -98,9 +105,57 @@ export default defineComponent({
       }
       console.debug('received from child page', event);
       if (event.data.name === 'nativeOAuth' && this.isNative) {
+        const provider = event.data.data?.provider;
+        // On iOS, Apple Sign In must use the native ASAuthorization sheet —
+        // SFSafariViewController lacks the system bridge that Apple's JS SDK
+        // needs, so it falls back to a webpage that asks for the iCloud
+        // password instead of using Face ID.
+        if (provider === 'apple' && isIOS()) {
+          try {
+            const { response } = await SignInWithApple.authorize({
+              clientId: APPLE_NATIVE_CLIENT_ID,
+              redirectURI: '',
+              scopes: 'email name'
+            });
+            if (!response?.identityToken) {
+              throw new Error('apple identity_token missing');
+            }
+            // POST the identity_token directly to AuthBackend. Same endpoint
+            // as the web Apple JS flow — apple_get_user_data verifies the JWT
+            // against Apple's JWKS, no client_secret needed.
+            const loginResp = await axios.post(`${getBaseUrlAuth()}/api/v1/auth/login/`, {
+              platform: 'apple',
+              identity_token: response.identityToken,
+              inviter_id: this.inviterId,
+              user: {
+                name: {
+                  firstName: response.givenName ?? '',
+                  lastName: response.familyName ?? ''
+                }
+              }
+            });
+            const data = loginResp.data;
+            const token = {
+              access: data.access_token,
+              refresh: data.refresh_token,
+              expiration: data.expires_in
+            };
+            await this.$store.dispatch('setToken', token);
+            await this.$store.dispatch('getUser');
+            if (!this.$store.state.site?.origin) {
+              await this.$store.dispatch('initializeSite');
+            }
+            this.$store.commit('setAuth', { visible: false });
+            await this.$router.push('/');
+          } catch (error: unknown) {
+            // User-cancelled sheets are an expected outcome — silently keep
+            // the iframe login UI so the user can pick another method.
+            console.warn('native apple sign in failed', error);
+          }
+          return;
+        }
         // AuthFrontend in iframe can't do OAuth popups/redirects (X-Frame-Options).
         // Open the auth page in an in-app browser with the provider pre-selected.
-        const provider = event.data.data?.provider;
         this.useBrowser = true;
         const authUrl = withCurrentSite(
           `${getBaseUrlAuth()}/auth/login?inviter_id=${this.inviterId}&native_redirect=com.acedatacloud.nexior&provider=${provider}`


### PR DESCRIPTION
## Why

Inside the iOS app, tapping **Sign in with Apple** today opens an in-app SFSafariViewController, which loads `auth.acedata.cloud` and lets Apple's JS SDK take over. That SDK falls back to a redirect-mode webpage at `appleid.apple.com` that asks the user to **type their iCloud password** — a much worse UX than the native Face ID / Touch ID sheet they get when the same page is opened in real Safari.

Root cause: SFSafariViewController doesn't expose the system bridge Apple's JS SDK uses to invoke the native sheet, so it always degrades to the password webpage.

## What

- Add [`@capacitor-community/apple-sign-in@^7.1.0`](https://github.com/capacitor-community/apple-sign-in) — thin wrapper around `ASAuthorizationAppleIDProvider`.
- Add `com.apple.developer.applesignin` entitlement (`ios/App/App/App.entitlements`) and wire it into the Xcode project (`CODE_SIGN_ENTITLEMENTS` for Debug + Release).
- In `AuthPanel.vue`, intercept the iframe's `nativeOAuth` postMessage when the provider is `apple` **and** the surface is iOS — call `SignInWithApple.authorize` to present the native sheet, then POST the returned `identityToken` to AuthBackend's existing `/api/v1/auth/login/` endpoint.

The backend already supports both web JS and native iOS identity tokens through the same JWKS-verified path (`AuthBackend/app/views/auth.py` `elif platform == 'apple'`), so no backend changes are needed.

## Scope

- **iOS only** — Android keeps the existing web fallback (there is no native Sign in with Apple on Android).
- **No account fork** — Apple returns the same `sub` for native and web flows under the same Team + App ID, so existing Apple-signed users keep their accounts.
- Other providers (Google, GitHub, WeChat) continue to use the existing `Browser.open()` path.

## Apple Developer portal

The App ID `com.acedatacloud.nexior` must have the **Sign In with Apple** capability enabled. Manual one-time step (cannot be scripted): https://developer.apple.com/account → Identifiers → `com.acedatacloud.nexior` → Capabilities → enable *Sign In with Apple* → re-download / re-generate the provisioning profile if Xcode complains.

## Test plan

- [x] `npm run build:ios` — Vite + vue-tsc green
- [x] `npx cap sync ios` — recognizes the new plugin
- [x] `xcodebuild -workspace App.xcworkspace -scheme App -sdk iphonesimulator … build` — BUILD SUCCEEDED with the new entitlement in place
- [ ] On a real iOS device (or a simulator signed into iCloud), tap *Sign in with Apple* in Nexior → confirm the native sheet appears (Face ID, not a password webpage), then verify a successful login lands on `/`
- [ ] Confirm an existing Apple-signed user keeps the same account after this PR ships
