### PR TITLE
feat(android): native Stripe PaymentSheet via @capacitor-community/stripe

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -9,6 +9,7 @@ android {
 
 apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
+    implementation project(':capacitor-community-stripe')
     implementation project(':capacitor-app')
     implementation project(':capacitor-browser')
 

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -2,6 +2,9 @@
 include ':capacitor-android'
 project(':capacitor-android').projectDir = new File('../node_modules/@capacitor/android/capacitor')
 
+include ':capacitor-community-stripe'
+project(':capacitor-community-stripe').projectDir = new File('../node_modules/@capacitor-community/stripe/android')
+
 include ':capacitor-app'
 project(':capacitor-app').projectDir = new File('../node_modules/@capacitor/app/android')
 

--- a/change/@acedatacloud-nexior-stripe-android-paymentsheet.json
+++ b/change/@acedatacloud-nexior-stripe-android-paymentsheet.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(android): native Stripe PaymentSheet via @capacitor-community/stripe",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/docs/MOBILE_RELEASE.md
+++ b/docs/MOBILE_RELEASE.md
@@ -307,3 +307,56 @@ acedatacloud2-1256437459/      # COS bucket
 - 只热更新 web 资源（`dist/` 内容），**绝不**改 native 代码、不下载可执行二进制、不绕过 App Review 添加新功能（已审核功能的 bugfix / 文案 / UI 调整 OK）。
 - `@capgo/capacitor-updater` 在 iOS 上使用 WKWebView 加载本地文件，符合 [App Store Guideline 3.3.2](https://developer.apple.com/app-store/review/guidelines/#3.3.2) 关于解释性代码的例外条款（与 React Native CodePush、Expo Updates 同类机制）。
 - 引入大版本特性时仍需走商店审核 + 提升 `app-version` 接口里的 `min_supported`。
+
+## 六、Stripe（Android 原生 PaymentSheet）
+
+Android 客户端通过 `@capacitor-community/stripe` 调起 Stripe 原生 PaymentSheet，
+而不是再用 `window.open(pay_url)` 跳浏览器。后端为 Android 下单时返回的是
+`PaymentIntent client_secret`（写在 `order.metadata.stripe_client_secret` 里），
+而不是 PaymentLink 的 URL。
+
+> **iOS 不启用此通道**：iOS bundle 仍按 App Store Review Guideline 3.1.1 完全隐
+> 藏 Stripe / 微信 / 支付宝入口（`showPayment(): !isIOS()`）。Stripe Android 与
+> iOS IAP 是两条独立的轨道。
+
+### 构建环境变量
+
+| 变量 | 必填 | 说明 |
+|---|---|---|
+| `VITE_STRIPE_PUBLISHABLE_KEY` | 是（Android build） | Stripe Dashboard → 开
+发者 → API 密钥里取的 `pk_live_*` / `pk_test_*` 可发布密钥。**只用 publishable
+key**，绝不在前端嵌入 secret key。未设置时下单流程仍会成功，但 PaymentSheet 不会
+弹出（仅在控制台打 `VITE_STRIPE_PUBLISHABLE_KEY is not configured` 错误）。 |
+
+`pk_live_*` 与生产 PayBackend 的 `STRIPE_LIVE_SECRET_KEY` 必须属于**同一个**
+Stripe 账户，否则 client_secret 会被 SDK 拒绝（`No such payment_intent`）。
+
+### 链路
+
+```
+Nexior (Android)                PlatformBackend           PayBackend           Stripe
+  └─ onPay(payWay=Stripe,
+          surface=android)
+        ──► POST /orders/:id/pay
+              └─ create_stripe_payment_intent
+                    ──► POST /payment/stripe/intent
+                          └─ stripe.PaymentIntent.create
+                                ◄── { id: pi_xxx, client_secret }
+                    ◄── 同上
+              └─ order.pay_id = pi_xxx
+                 order.metadata.stripe_client_secret = ...
+              ◄── Order with metadata
+        ◄── 同上
+  └─ StripePay.vue watches visible:
+        └─ Stripe.initialize(publishableKey)
+        └─ Stripe.createPaymentSheet({ paymentIntentClientSecret })
+        └─ Stripe.presentPaymentSheet()
+              └─ user 完成 ──► Stripe 直接结算 ──► PaymentIntent.status = succeeded
+        └─ onRefresh() 立即拉一次 GET /orders/:id
+              └─ PlatformBackend → PayBackend GET /payment/stripe/pi_xxx
+                    └─ stripe.PaymentIntent.retrieve → succeeded → state=SUCCESS
+              └─ Order.state = PAID
+```
+
+PC / WAP 浏览器走的仍是旧的 PaymentLink 路径（`pay_url = https://buy.stripe.com/
+...`），后端通过 `surface == "android"` 区分。

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@capacitor-community/apple-sign-in": "^7.1.0",
+        "@capacitor-community/stripe": "^8.1.1",
         "@capacitor/app": "^8.0.1",
         "@capacitor/browser": "^8.0.1",
         "@capgo/capacitor-updater": "^8.47.3",
@@ -336,6 +337,21 @@
       },
       "peerDependencies": {
         "@capacitor/core": ">=7.0.0"
+      }
+    },
+    "node_modules/@capacitor-community/stripe": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@capacitor-community/stripe/-/stripe-8.1.1.tgz",
+      "integrity": "sha512-8Qqyq9BLURn1A1xax9vUkC13FNamSGmxPiExclGS9lJEKzwwZG3UL/NQ48uSxeflvSd7fQ2eRWFfCiIeKvwL0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0",
+        "@stripe/stripe-js": "^8.4.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "stripe-pwa-elements": "^3.0.0"
       }
     },
     "node_modules/@capacitor/android": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@capacitor-community/apple-sign-in": "^7.1.0",
+    "@capacitor-community/stripe": "^8.1.1",
     "@capacitor/app": "^8.0.1",
     "@capacitor/browser": "^8.0.1",
     "@capgo/capacitor-updater": "^8.47.3",

--- a/src/components/order/StripePay.vue
+++ b/src/components/order/StripePay.vue
@@ -11,9 +11,11 @@ import { orderOperator } from '@/operators';
 import { defineComponent } from 'vue';
 import { ElDialog } from 'element-plus';
 import { IOrder, IOrderDetailResponse, OrderState } from '@/models';
+import { isAndroid } from '@/utils';
 
 interface IData {
   refreshTimer: number | undefined;
+  androidSheetLaunched: boolean;
 }
 
 export default defineComponent({
@@ -35,13 +37,28 @@ export default defineComponent({
   emits: ['hide', 'update:modelValue'],
   data(): IData {
     return {
-      refreshTimer: undefined
+      refreshTimer: undefined,
+      androidSheetLaunched: false
     };
   },
   watch: {
     visible: {
       handler(val) {
-        if (val && this.modelValue.pay_url) {
+        if (!val) {
+          this.androidSheetLaunched = false;
+          return;
+        }
+        const clientSecret = this.modelValue?.metadata?.stripe_client_secret as string | undefined;
+        // Android native flow: pay_url is empty; payment is collected via
+        // the in-app Stripe PaymentSheet using the PaymentIntent client_secret
+        // returned by PayBackend.
+        if (isAndroid() && clientSecret) {
+          this.launchNativePaymentSheet(clientSecret).catch((err) => {
+            console.error('Stripe PaymentSheet failed', err);
+          });
+          return;
+        }
+        if (this.modelValue.pay_url) {
           window.open(this.modelValue.pay_url, '_blank');
         }
       }
@@ -56,6 +73,38 @@ export default defineComponent({
     }
   },
   methods: {
+    async launchNativePaymentSheet(clientSecret: string) {
+      if (this.androidSheetLaunched) return;
+      this.androidSheetLaunched = true;
+      const publishableKey = import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY as string | undefined;
+      if (!publishableKey) {
+        console.error('VITE_STRIPE_PUBLISHABLE_KEY is not configured');
+        return;
+      }
+      // Dynamic import keeps the plugin out of the web bundle for
+      // browsers / iOS, where it would never be invoked.
+      const { Stripe, PaymentSheetEventsEnum } = await import('@capacitor-community/stripe');
+      await Stripe.initialize({ publishableKey });
+      await Stripe.createPaymentSheet({
+        paymentIntentClientSecret: clientSecret,
+        merchantDisplayName: 'AceData'
+      });
+      // Listen for the user-driven outcomes; the polling loop is still our
+      // source of truth for PAID, but immediate emit/refresh feels snappier.
+      const completedHandler = await Stripe.addListener(PaymentSheetEventsEnum.Completed, () => {
+        this.onRefresh();
+        completedHandler.remove();
+      });
+      const canceledHandler = await Stripe.addListener(PaymentSheetEventsEnum.Canceled, () => {
+        this.$emit('hide');
+        canceledHandler.remove();
+      });
+      const failedHandler = await Stripe.addListener(PaymentSheetEventsEnum.FailedToLoad, () => {
+        this.$emit('hide');
+        failedHandler.remove();
+      });
+      await Stripe.presentPaymentSheet();
+    },
     onRefresh() {
       if (!this.modelValue.id) {
         console.error('id does not exist');

--- a/src/pages/console/order/Detail.vue
+++ b/src/pages/console/order/Detail.vue
@@ -245,7 +245,7 @@ import X402PayOrder from '@/components/order/X402Pay.vue';
 import PaypalPayOrder from '@/components/order/PaypalPay.vue';
 import { IConfigResponse, IOrder, IOrderDetailResponse, OrderState } from '@/models';
 import { getPriceString } from '@/utils';
-import { isIOS } from '@/utils';
+import { isAndroid, isIOS } from '@/utils';
 import { track } from '@/plugins/telemetry';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 
@@ -598,6 +598,11 @@ export default defineComponent({
       // PayBackend always issues a Native QR for WeChat Pay (our merchant
       // has no JSAPI/H5 enabled), so the surface field is omitted here.
       const payload: Record<string, unknown> = { pay_way: this.payWay };
+      // Android Stripe uses the native PaymentSheet, which needs a
+      // PaymentIntent (not a PaymentLink). The backend routes on this hint.
+      if (this.payWay === PayWay.Stripe && isAndroid()) {
+        payload.surface = 'android';
+      }
       orderOperator
         .pay(this.id, payload as unknown as IOrder)
         .then(({ data: data }: { data: IOrderDetailResponse }) => {


### PR DESCRIPTION
## What

Adds in-app **Stripe PaymentSheet** for Android. Instead of opening the hosted PaymentLink URL in a browser tab (current behavior), Android users get the native Stripe bottom-sheet for card entry and 3DS.

iOS bundle and web are unchanged.

## Why

- Browser-tab hand-off on Android = poor conversion + confusing redirect flow back to the app.
- Stripe's official Capacitor plugin gives us PCI-compliant card collection without bundling our own form, and supports 3DS / Apple Pay / Google Pay out of the box (Google Pay is out of scope for this PR, see Phase 2 below).

## Changes

| File | Change |
|---|---|
| `package.json` / `package-lock.json` | Adds `@capacitor-community/stripe@^8.1.1` |
| `android/app/capacitor.build.gradle` + `android/capacitor.settings.gradle` | `npx cap sync android` registered the plugin (com.stripe:paymentsheet:23.1.0 pulled transitively) |
| `src/pages/console/order/Detail.vue` | In `onPay()`: when payWay is Stripe AND `isAndroid()`, include `surface: 'android'` in the pay payload so backend returns a PaymentIntent client_secret |
| `src/components/order/StripePay.vue` | When dialog opens with `order.metadata.stripe_client_secret` present, dynamically import the Stripe plugin and present PaymentSheet. Falls back to the existing `window.open(pay_url)` path when no client_secret is present |
| `docs/MOBILE_RELEASE.md` | New section 六 documenting `VITE_STRIPE_PUBLISHABLE_KEY` and the full Android Stripe flow |

## Deps

Requires (in order):
1. AceDataCloud/PayBackend#34 — new `POST /payment/stripe/intent` endpoint
2. AceDataCloud/PlatformBackend#555 — wire `surface=android` → PaymentIntent

## New env

`VITE_STRIPE_PUBLISHABLE_KEY` — required for Android builds. Set to `pk_live_...` for production, `pk_test_...` for staging.

## iOS / web behavior

- **iOS:** unchanged. `Detail.vue.showPayment()` still returns `!isIOS()`, so the entire Stripe code path is dead on iOS (App Store Guideline 3.1.1 compliance).
- **Web / wap:** `payload.surface` stays `'pc'` / `'wap'`, backend returns a PaymentLink URL in `pay_url`, and `window.open(pay_url)` runs as before.

## Test plan

- [ ] Local Android build: `VITE_STRIPE_PUBLISHABLE_KEY=pk_test_... npm run build && npx cap sync android && npx cap open android` — install on a device, attempt a Stripe order, verify the PaymentSheet bottom sheet appears with the official Stripe UI.
- [ ] **Live $0.50 self-test** from a Play-Store-installed build using `pk_live_...`.
- [ ] iOS bundle: pull up Console → Order detail. Verify no Stripe / Alipay / WeChat buttons appear (existing behavior).
- [ ] Web: complete a Stripe order via desktop browser, verify the hosted PaymentLink page still opens.

## Out of scope (Phase 2)

- Apple Pay (needs iOS native support)
- Google Pay button
- Saved cards (`CustomerSession` / `EphemeralKey` from PayBackend)
- Webhook-driven PAID notification (current 2s polling still works)