### PR TITLE
ci(android): inject Stripe publishable key into Vite build

### DIFF
--- a/.github/workflows/build-android.yaml
+++ b/.github/workflows/build-android.yaml
@@ -168,6 +168,8 @@ jobs:
         run: npm ci
 
       - name: Build web assets (Android surface)
+        env:
+          VITE_STRIPE_PUBLISHABLE_KEY: ${{ secrets.VITE_STRIPE_PUBLISHABLE_KEY }}
         run: npm run build:android
 
       - name: Sync Android project


### PR DESCRIPTION
## Summary

Wire the repository secret `VITE_STRIPE_PUBLISHABLE_KEY` into the Android web build step so `import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY` is available in production bundles.

## Change

- `.github/workflows/build-android.yaml`
  - Add:
    - `env.VITE_STRIPE_PUBLISHABLE_KEY: ${{ secrets.VITE_STRIPE_PUBLISHABLE_KEY }}`
  - On step: `Build web assets (Android surface)`

## Why

Stripe PaymentSheet on Android (PR #824) reads this key at runtime. Without injecting it during `vite build`, the app logs missing-key and cannot initialize PaymentSheet.

## Risk

Low. CI/workflow-only change; no runtime code changes.

## Validation

- Workflow yaml parses with the added env block.
- Change is scoped to Android build workflow only.