### PR TITLE
feat: near-fully-automated Android + iOS release pipeline

### DIFF
--- a/.github/workflows/build-android.yaml
+++ b/.github/workflows/build-android.yaml
@@ -7,15 +7,25 @@ on:
   workflow_dispatch:
     inputs:
       track:
-        description: 'Play Store track (internal / alpha / beta / production)'
+        description: 'Initial Play Store track to upload to (default: beta = Open testing)'
         required: true
-        default: 'internal'
+        default: 'beta'
         type: choice
         options:
           - internal
           - alpha
           - beta
           - production
+      promote_to_production:
+        description: 'Auto-promote the same versionCode to Production after the initial upload succeeds.'
+        required: false
+        default: true
+        type: boolean
+      rollout_percent:
+        description: 'Production staged rollout fraction (0.0–1.0). 1.0 = full release.'
+        required: false
+        default: '1.0'
+        type: string
       force:
         description: 'Build even if this versionCode is already uploaded to Play (default: skip duplicates).'
         required: false
@@ -58,7 +68,8 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "track=${{ inputs.track }}" >> "$GITHUB_OUTPUT"
           else
-            echo "track=internal" >> "$GITHUB_OUTPUT"
+            # Tag push (android-v*) defaults to Open testing (beta) and then promotes to production.
+            echo "track=beta" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Set up Python
@@ -228,3 +239,115 @@ jobs:
           releaseFiles: android/app/build/outputs/bundle/release/app-release.aab
           tracks: ${{ needs.preflight.outputs.track }}
           status: completed
+
+  promote:
+    name: Promote to Production
+    needs: [preflight, build]
+    # Only auto-promote when the initial upload landed on a non-production track AND the
+    # caller asked for it (workflow_dispatch default = true; tag-push defaults to promote).
+    if: |
+      needs.preflight.outputs.should-build == 'true'
+      && needs.preflight.outputs.track != 'production'
+      && (github.event_name != 'workflow_dispatch' || inputs.promote_to_production)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Promote release to Production track
+        env:
+          SA_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          PACKAGE_NAME: com.acedatacloud.nexior
+          VERSION_CODE: ${{ needs.preflight.outputs.version-code }}
+          VERSION_NAME: ${{ needs.preflight.outputs.version-name }}
+          ROLLOUT: ${{ github.event_name == 'workflow_dispatch' && inputs.rollout_percent || '1.0' }}
+        # Creates a Play Console edit, points the production track at the same versionCode
+        # uploaded in the previous job, and commits. Uses staged rollout when ROLLOUT < 1.
+        run: |
+          python3 -m pip install --quiet 'pyjwt[crypto]==2.10.1' requests
+          python3 <<'PY'
+          import json, os, time, requests, jwt
+
+          sa = json.loads(os.environ['SA_JSON'])
+          package = os.environ['PACKAGE_NAME']
+          wanted = int(os.environ['VERSION_CODE'])
+          version_name = os.environ.get('VERSION_NAME') or str(wanted)
+          try:
+              rollout = float(os.environ.get('ROLLOUT', '1.0'))
+          except ValueError:
+              rollout = 1.0
+          rollout = max(0.0, min(1.0, rollout))
+
+          now = int(time.time())
+          assertion = jwt.encode(
+              {
+                  'iss': sa['client_email'],
+                  'scope': 'https://www.googleapis.com/auth/androidpublisher',
+                  'aud': 'https://oauth2.googleapis.com/token',
+                  'iat': now, 'exp': now + 3600,
+              },
+              sa['private_key'], algorithm='RS256',
+          )
+          tok = requests.post(
+              'https://oauth2.googleapis.com/token',
+              data={
+                  'grant_type': 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                  'assertion': assertion,
+              }, timeout=30,
+          )
+          tok.raise_for_status()
+          access = tok.json()['access_token']
+          h = {'Authorization': f'Bearer {access}', 'Content-Type': 'application/json'}
+          base = f'https://androidpublisher.googleapis.com/androidpublisher/v3/applications/{package}'
+
+          edit = requests.post(f'{base}/edits', headers=h, json={}, timeout=30)
+          edit.raise_for_status()
+          edit_id = edit.json()['id']
+          try:
+              bundles = requests.get(f'{base}/edits/{edit_id}/bundles', headers=h, timeout=30)
+              bundles.raise_for_status()
+              codes = {int(b['versionCode']) for b in bundles.json().get('bundles', [])}
+              if wanted not in codes:
+                  raise SystemExit(
+                      f'::error::versionCode {wanted} not found in uploaded bundles '
+                      f'(last 10: {sorted(codes)[-10:]})'
+                  )
+
+              release = {
+                  'name': version_name,
+                  'versionCodes': [str(wanted)],
+              }
+              if rollout >= 1.0:
+                  release['status'] = 'completed'
+              elif rollout > 0:
+                  release['status'] = 'inProgress'
+                  release['userFraction'] = rollout
+              else:
+                  release['status'] = 'draft'
+
+              r = requests.put(
+                  f'{base}/edits/{edit_id}/tracks/production',
+                  headers=h,
+                  json={'track': 'production', 'releases': [release]},
+                  timeout=30,
+              )
+              if r.status_code >= 400:
+                  print(f'::error::production track update failed: {r.status_code} {r.text}')
+                  r.raise_for_status()
+
+              c = requests.post(f'{base}/edits/{edit_id}:commit', headers=h, timeout=60)
+              if c.status_code >= 400:
+                  print(f'::error::commit failed: {c.status_code} {c.text}')
+                  c.raise_for_status()
+
+              print(f'::notice::Promoted versionCode {wanted} ({version_name}) to '
+                    f'production (rollout={rollout}).')
+          except Exception:
+              try:
+                  requests.delete(f'{base}/edits/{edit_id}', headers=h, timeout=30)
+              except Exception:
+                  pass
+              raise
+          PY

--- a/.github/workflows/build-ios.yaml
+++ b/.github/workflows/build-ios.yaml
@@ -11,6 +11,16 @@ on:
         required: false
         default: false
         type: boolean
+      auto_distribute_external:
+        description: 'After upload, automatically add the build to every external TestFlight group (Open testing).'
+        required: false
+        default: true
+        type: boolean
+      auto_submit_review:
+        description: 'After upload, attach the build to an App Store version and submit it for App Review.'
+        required: false
+        default: true
+        type: boolean
 
 permissions:
   contents: read
@@ -268,6 +278,315 @@ jobs:
             --file "$(find $RUNNER_TEMP/export -name '*.ipa')" \
             --apiKey "$APP_STORE_CONNECT_API_KEY_ID" \
             --apiIssuer "$APP_STORE_CONNECT_API_ISSUER_ID"
+
+      - name: Install ASC API client deps
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.auto_distribute_external || inputs.auto_submit_review }}
+        run: python3 -m pip install --quiet --user 'pyjwt[crypto]==2.10.1' requests
+
+      - name: Wait for TestFlight processing
+        id: tf_wait
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.auto_distribute_external || inputs.auto_submit_review }}
+        env:
+          ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          ASC_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_KEY_BASE64 }}
+          BUNDLE_ID: com.acedatacloud.nexior
+          VERSION_NAME: ${{ needs.preflight.outputs.version-name }}
+          BUILD_NUMBER: ${{ needs.preflight.outputs.version-code }}
+        # ASC takes ~5–20 min to finish processing an uploaded build before
+        # it can be added to a beta group or attached to an App Store version.
+        # Polls every 30s for up to 25 min, then sets build-id as a step output.
+        run: |
+          python3 <<'PY'
+          import base64, json, os, sys, time, requests, jwt
+
+          key_id = os.environ['ASC_KEY_ID']
+          issuer = os.environ['ASC_ISSUER_ID']
+          private_key = base64.b64decode(os.environ['ASC_KEY_BASE64']).decode('utf-8')
+          bundle_id = os.environ['BUNDLE_ID']
+          version_name = os.environ['VERSION_NAME']
+          build_number = os.environ['BUILD_NUMBER']
+
+          def asc_token():
+              now = int(time.time())
+              return jwt.encode(
+                  {'iss': issuer, 'iat': now, 'exp': now + 1200, 'aud': 'appstoreconnect-v1'},
+                  private_key, algorithm='ES256',
+                  headers={'kid': key_id, 'typ': 'JWT'},
+              )
+
+          def H():
+              return {'Authorization': f'Bearer {asc_token()}', 'Content-Type': 'application/json'}
+
+          apps = requests.get(
+              'https://api.appstoreconnect.apple.com/v1/apps',
+              params={'filter[bundleId]': bundle_id, 'limit': 1},
+              headers=H(), timeout=30,
+          )
+          apps.raise_for_status()
+          app_data = apps.json().get('data') or []
+          if not app_data:
+              sys.exit(f'::error::No ASC app found for bundle {bundle_id}')
+          app_id = app_data[0]['id']
+          print(f'::notice::App ID: {app_id}')
+
+          deadline = time.time() + 25 * 60
+          build_id = None
+          last_state = None
+          while time.time() < deadline:
+              r = requests.get(
+                  'https://api.appstoreconnect.apple.com/v1/builds',
+                  params={
+                      'filter[app]': app_id,
+                      'filter[version]': build_number,
+                      'filter[preReleaseVersion.version]': version_name,
+                      'limit': 5,
+                      'sort': '-uploadedDate',
+                  },
+                  headers=H(), timeout=30,
+              )
+              if r.status_code == 200:
+                  builds = r.json().get('data') or []
+                  if builds:
+                      b = builds[0]
+                      state = b['attributes'].get('processingState')
+                      if state != last_state:
+                          print(f'Build {b["id"]} state={state}')
+                          last_state = state
+                      if state == 'VALID':
+                          build_id = b['id']
+                          break
+                      if state == 'FAILED' or state == 'INVALID':
+                          sys.exit(f'::error::Build processing failed (state={state})')
+              else:
+                  print(f'::warning::ASC /v1/builds {r.status_code}: {r.text[:200]}')
+              time.sleep(30)
+
+          if not build_id:
+              print('::warning::Timed out waiting for build to become VALID. Subsequent steps will skip.')
+              sys.exit(0)
+
+          out = os.environ['GITHUB_OUTPUT']
+          with open(out, 'a') as fh:
+              fh.write(f'app-id={app_id}\n')
+              fh.write(f'build-id={build_id}\n')
+          print(f'::notice::Build {build_id} (v{version_name} build {build_number}) ready for distribution.')
+          PY
+
+      - name: Distribute to external TestFlight groups
+        if: ${{ steps.tf_wait.outputs.build-id != '' && (github.event_name != 'workflow_dispatch' || inputs.auto_distribute_external) }}
+        env:
+          ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          ASC_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_KEY_BASE64 }}
+          APP_ID: ${{ steps.tf_wait.outputs.app-id }}
+          BUILD_ID: ${{ steps.tf_wait.outputs.build-id }}
+        # Attaches the just-uploaded build to every external beta group on the
+        # app (Open testing). Internal groups receive the build automatically
+        # so we only target externally-shared groups here. Tolerates groups
+        # that already include this build (409 conflicts are ignored).
+        run: |
+          python3 <<'PY'
+          import base64, os, time, requests, jwt
+
+          key_id = os.environ['ASC_KEY_ID']
+          issuer = os.environ['ASC_ISSUER_ID']
+          private_key = base64.b64decode(os.environ['ASC_KEY_BASE64']).decode('utf-8')
+          app_id = os.environ['APP_ID']
+          build_id = os.environ['BUILD_ID']
+
+          def H():
+              now = int(time.time())
+              t = jwt.encode(
+                  {'iss': issuer, 'iat': now, 'exp': now + 1200, 'aud': 'appstoreconnect-v1'},
+                  private_key, algorithm='ES256',
+                  headers={'kid': key_id, 'typ': 'JWT'},
+              )
+              return {'Authorization': f'Bearer {t}', 'Content-Type': 'application/json'}
+
+          groups, next_url, params = [], (
+              f'https://api.appstoreconnect.apple.com/v1/apps/{app_id}/betaGroups'
+          ), {'limit': 200}
+          while next_url:
+              r = requests.get(next_url, params=params, headers=H(), timeout=30)
+              r.raise_for_status()
+              payload = r.json()
+              groups.extend(payload.get('data') or [])
+              next_url = (payload.get('links') or {}).get('next')
+              params = None
+
+          external = [g for g in groups if not g['attributes'].get('isInternalGroup', True)]
+          if not external:
+              print('::warning::No external TestFlight groups configured. Skipping.')
+          for g in external:
+              gid = g['id']
+              name = g['attributes'].get('name')
+              payload = {'data': [{'type': 'builds', 'id': build_id}]}
+              r = requests.post(
+                  f'https://api.appstoreconnect.apple.com/v1/betaGroups/{gid}/relationships/builds',
+                  json=payload, headers=H(), timeout=30,
+              )
+              if r.status_code in (200, 204):
+                  print(f'::notice::Added build {build_id} to group "{name}".')
+              elif r.status_code == 409:
+                  print(f'Group "{name}" already includes this build. Skipped.')
+              else:
+                  print(f'::warning::Failed to add to "{name}": {r.status_code} {r.text[:200]}')
+          PY
+
+      - name: Submit build for App Store review
+        if: ${{ steps.tf_wait.outputs.build-id != '' && (github.event_name != 'workflow_dispatch' || inputs.auto_submit_review) }}
+        continue-on-error: true
+        env:
+          ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          ASC_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_KEY_BASE64 }}
+          APP_ID: ${{ steps.tf_wait.outputs.app-id }}
+          BUILD_ID: ${{ steps.tf_wait.outputs.build-id }}
+          VERSION_NAME: ${{ needs.preflight.outputs.version-name }}
+        # Reuses any in-flight editable App Store version that matches our
+        # versionString (or creates one), attaches the new build, then files a
+        # review submission via the modern reviewSubmissions API. continue-on-error
+        # because review submission can fail for legitimate reasons (missing
+        # screenshots, no localized release notes, etc.) and we don't want
+        # those to fail the whole workflow — they require manual fixup.
+        run: |
+          python3 <<'PY'
+          import base64, os, sys, time, requests, jwt
+
+          key_id = os.environ['ASC_KEY_ID']
+          issuer = os.environ['ASC_ISSUER_ID']
+          private_key = base64.b64decode(os.environ['ASC_KEY_BASE64']).decode('utf-8')
+          app_id = os.environ['APP_ID']
+          build_id = os.environ['BUILD_ID']
+          version_name = os.environ['VERSION_NAME']
+
+          def H():
+              now = int(time.time())
+              t = jwt.encode(
+                  {'iss': issuer, 'iat': now, 'exp': now + 1200, 'aud': 'appstoreconnect-v1'},
+                  private_key, algorithm='ES256',
+                  headers={'kid': key_id, 'typ': 'JWT'},
+              )
+              return {'Authorization': f'Bearer {t}', 'Content-Type': 'application/json'}
+
+          def die_soft(msg):
+              print(f'::warning::{msg}')
+              sys.exit(0)
+
+          # 1) Look up existing iOS App Store versions on this app.
+          r = requests.get(
+              f'https://api.appstoreconnect.apple.com/v1/apps/{app_id}/appStoreVersions',
+              params={'filter[platform]': 'IOS', 'limit': 20, 'sort': '-createdDate'},
+              headers=H(), timeout=30,
+          )
+          r.raise_for_status()
+          versions = r.json().get('data') or []
+
+          editable_states = {
+              'PREPARE_FOR_SUBMISSION', 'DEVELOPER_REJECTED', 'METADATA_REJECTED',
+              'REJECTED', 'INVALID_BINARY', 'WAITING_FOR_REVIEW',
+          }
+          version_id, version_state = None, None
+          for v in versions:
+              attrs = v['attributes']
+              if attrs.get('versionString') == version_name and attrs.get('appStoreState') in editable_states:
+                  version_id = v['id']
+                  version_state = attrs.get('appStoreState')
+                  print(f'Reusing existing App Store version {version_id} (state={version_state}).')
+                  break
+
+          # 2) If no editable matching version exists, create one.
+          if not version_id:
+              create_payload = {
+                  'data': {
+                      'type': 'appStoreVersions',
+                      'attributes': {'platform': 'IOS', 'versionString': version_name},
+                      'relationships': {
+                          'app': {'data': {'type': 'apps', 'id': app_id}},
+                          'build': {'data': {'type': 'builds', 'id': build_id}},
+                      },
+                  }
+              }
+              c = requests.post(
+                  'https://api.appstoreconnect.apple.com/v1/appStoreVersions',
+                  json=create_payload, headers=H(), timeout=30,
+              )
+              if c.status_code not in (200, 201):
+                  die_soft(f'Failed to create App Store version: {c.status_code} {c.text[:400]}')
+              version_id = c.json()['data']['id']
+              print(f'::notice::Created App Store version {version_id} (v{version_name}).')
+          else:
+              # Attach our build to the existing editable version.
+              a = requests.patch(
+                  f'https://api.appstoreconnect.apple.com/v1/appStoreVersions/{version_id}/relationships/build',
+                  json={'data': {'type': 'builds', 'id': build_id}},
+                  headers=H(), timeout=30,
+              )
+              if a.status_code >= 400:
+                  die_soft(f'Failed to attach build to version: {a.status_code} {a.text[:400]}')
+              print(f'::notice::Attached build {build_id} to App Store version {version_id}.')
+
+          # 3) Open a review submission for this app (one open submission per app/platform).
+          sub_payload = {
+              'data': {
+                  'type': 'reviewSubmissions',
+                  'attributes': {'platform': 'IOS'},
+                  'relationships': {'app': {'data': {'type': 'apps', 'id': app_id}}},
+              }
+          }
+          sr = requests.post(
+              'https://api.appstoreconnect.apple.com/v1/reviewSubmissions',
+              json=sub_payload, headers=H(), timeout=30,
+          )
+          if sr.status_code == 409:
+              # An open submission already exists; find it.
+              ex = requests.get(
+                  'https://api.appstoreconnect.apple.com/v1/reviewSubmissions',
+                  params={'filter[app]': app_id, 'filter[platform]': 'IOS', 'filter[state]': 'READY_FOR_REVIEW,IN_REVIEW,UNRESOLVED_ISSUES,WAITING_FOR_REVIEW,COMPLETING'},
+                  headers=H(), timeout=30,
+              )
+              if ex.status_code != 200 or not (ex.json().get('data') or []):
+                  die_soft(f'Review submission exists but cannot list it: {ex.status_code} {ex.text[:400]}')
+              submission_id = ex.json()['data'][0]['id']
+              print(f'Reusing existing review submission {submission_id}.')
+          elif sr.status_code in (200, 201):
+              submission_id = sr.json()['data']['id']
+              print(f'::notice::Created review submission {submission_id}.')
+          else:
+              die_soft(f'Failed to create review submission: {sr.status_code} {sr.text[:400]}')
+
+          # 4) Add our App Store version as a submission item.
+          item_payload = {
+              'data': {
+                  'type': 'reviewSubmissionItems',
+                  'relationships': {
+                      'reviewSubmission': {'data': {'type': 'reviewSubmissions', 'id': submission_id}},
+                      'appStoreVersion': {'data': {'type': 'appStoreVersions', 'id': version_id}},
+                  },
+              }
+          }
+          it = requests.post(
+              'https://api.appstoreconnect.apple.com/v1/reviewSubmissionItems',
+              json=item_payload, headers=H(), timeout=30,
+          )
+          if it.status_code == 409:
+              print(f'Version {version_id} already in submission. Skipped.')
+          elif it.status_code not in (200, 201):
+              die_soft(f'Failed to add submission item: {it.status_code} {it.text[:400]}')
+          else:
+              print(f'::notice::Added version {version_id} to submission {submission_id}.')
+
+          # 5) Submit.
+          fin = requests.patch(
+              f'https://api.appstoreconnect.apple.com/v1/reviewSubmissions/{submission_id}',
+              json={'data': {'type': 'reviewSubmissions', 'id': submission_id, 'attributes': {'submitted': True}}},
+              headers=H(), timeout=30,
+          )
+          if fin.status_code >= 400:
+              die_soft(f'Failed to submit for review: {fin.status_code} {fin.text[:400]}')
+          print(f'::notice::Submitted review {submission_id} for App Store review.')
+          PY
 
       - name: Clean up keychain
         if: always()

--- a/.github/workflows/release-mobile.yaml
+++ b/.github/workflows/release-mobile.yaml
@@ -1,0 +1,96 @@
+name: Release Mobile
+
+# One-click orchestrator: fans out to build-android.yaml and/or build-ios.yaml.
+# Defaults are tuned for "near-fully automatic": Android Open testing → auto-promote
+# to production at 100% rollout, iOS TestFlight → external distribution → App Store
+# review submission. Use the inputs below to opt out of any step.
+
+on:
+  workflow_dispatch:
+    inputs:
+      platforms:
+        description: 'Which platforms to release'
+        required: true
+        default: 'both'
+        type: choice
+        options:
+          - both
+          - android
+          - ios
+      android_track:
+        description: 'Initial Android Play Store track'
+        required: false
+        default: 'beta'
+        type: choice
+        options:
+          - internal
+          - alpha
+          - beta
+          - production
+      android_promote_to_production:
+        description: 'Auto-promote Android release from initial track to Production'
+        required: false
+        default: true
+        type: boolean
+      android_rollout_percent:
+        description: 'Android production rollout fraction (0.0–1.0). 1.0 = full release.'
+        required: false
+        default: '1.0'
+        type: string
+      ios_auto_distribute_external:
+        description: 'Distribute new iOS build to every external TestFlight group'
+        required: false
+        default: true
+        type: boolean
+      ios_auto_submit_review:
+        description: 'Submit new iOS build for App Store review'
+        required: false
+        default: true
+        type: boolean
+      force:
+        description: 'Rebuild even if this version already exists on the store'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  fanout:
+    name: Trigger platform pipelines
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve version
+        id: ver
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "::notice::Releasing Nexior v$VERSION (platforms=${{ inputs.platforms }})"
+
+      - name: Trigger Android workflow
+        if: inputs.platforms == 'both' || inputs.platforms == 'android'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run build-android.yaml \
+            --ref "${{ github.ref_name }}" \
+            -f track="${{ inputs.android_track }}" \
+            -f promote_to_production="${{ inputs.android_promote_to_production }}" \
+            -f rollout_percent="${{ inputs.android_rollout_percent }}" \
+            -f force="${{ inputs.force }}"
+
+      - name: Trigger iOS workflow
+        if: inputs.platforms == 'both' || inputs.platforms == 'ios'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run build-ios.yaml \
+            --ref "${{ github.ref_name }}" \
+            -f auto_distribute_external="${{ inputs.ios_auto_distribute_external }}" \
+            -f auto_submit_review="${{ inputs.ios_auto_submit_review }}" \
+            -f force="${{ inputs.force }}"


### PR DESCRIPTION
## Summary

Make mobile releases _almost_ fully automatic. After this change, kicking off a release should not require opening the Google Play Console or App Store Connect unless Apple Review responds with a problem.

### `build-android.yaml`
- `inputs.track` default → `beta` (Google Play "Open testing"); tag pushes also default to `beta`.
- New input `promote_to_production` (default **true**) and `rollout_percent` (default **`1.0`**).
- New `promote` job: after the `build` job uploads to the initial track, it opens a Play Console edit and points the **production** track at the same `versionCode`. Staged rollout uses `status=inProgress` + `userFraction=<rollout_percent>` when the value is < 1.0; otherwise `status=completed`. Aborts the edit if anything fails midway, so we never leak half-applied edits.

### `build-ios.yaml`
- New inputs `auto_distribute_external` and `auto_submit_review` (both default **true**).
- After `Upload to TestFlight`:
  1. **Wait for processing** — polls `/v1/builds` for ~25 min until `processingState=VALID`, fail-soft so a slow processing run doesn't crash the workflow.
  2. **Distribute to external TF groups** — POSTs the build into every `betaGroups[].isInternalGroup=false` group on the app. Tolerates 409 (build already in the group).
  3. **Submit for App Review** — reuses or creates an editable iOS `appStoreVersion` matching `package.json`, attaches the build, then opens a `reviewSubmission`, adds a `reviewSubmissionItem`, and PATCHes `submitted=true`. **`continue-on-error: true`** because the submission can legitimately fail (missing screenshots, missing localized release notes, etc.) and those require manual fixup — they must not fail the whole pipeline.

### `release-mobile.yaml` (new)
One-click orchestrator. A single `workflow_dispatch` fans out to `build-android.yaml` and/or `build-ios.yaml` via `gh workflow run`, forwarding all relevant inputs. The default selection is `both` with both pipelines on their fully-automatic defaults.

## Manual steps that remain
- **Bump `package.json` version.** This is still the single source of truth for `versionName`/`versionCode`/`CFBundleVersion`.
- **Apple Review responses.** If Apple rejects (missing screenshot, metadata problem…), follow the link in the run logs or App Store Connect.
- **Google Play data-safety / content rating / new screenshots** when a release needs them. Listing changes are still managed in Play Console.

## Safety notes
- The promote job in Android validates the `versionCode` is actually present in the just-uploaded bundles before touching the production track; otherwise it bails (no edit is committed).
- All three workflows still honour the existing `force` input to opt out of duplicate-skip logic.
- The pre-existing `secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`, `APP_STORE_CONNECT_KEY_*` etc. are reused — no new secrets required.

## Testing
- Today's manual run of the unchanged workflows on `main` validated the upload paths for v3.251.0 → Android run [26676158574](https://github.com/AceDataCloud/Nexior/actions/runs/26676158574) and iOS run [26676159331](https://github.com/AceDataCloud/Nexior/actions/runs/26676159331).
- After merge, the next planned release will exercise the new promote/distribute/submit paths end-to-end. The submit-for-review step is fail-soft, so the worst case on first run is "everything else succeeded; submit needs a manual click".
