### PR TITLE
fix(subsite): tidy open-subsite dialog layout

### DIFF
--- a/src/components/setting/Subsite.vue
+++ b/src/components/setting/Subsite.vue
@@ -75,18 +75,12 @@
       :title="$t('subsite.title.openSite')"
       width="420px"
       class="open-dialog"
+      align-center
       append-to-body
     >
       <p class="open-hint">{{ $t('subsite.message.openSiteHint') }}</p>
       <div class="open-actions">
-        <el-button
-          v-for="url in opening.urls"
-          :key="url.href"
-          round
-          type="primary"
-          size="large"
-          @click="onConfirmOpen(url.href)"
-        >
+        <el-button v-for="url in opening.urls" :key="url.href" round type="primary" @click="onConfirmOpen(url.href)">
           {{ $t('subsite.button.open') }} {{ url.hostname }}
         </el-button>
       </div>
@@ -557,10 +551,12 @@ export default defineComponent({
   :deep(.open-actions) {
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    align-items: center;
+    gap: 14px;
 
     .el-button {
-      width: 100%;
+      min-width: 220px;
+      max-width: 100%;
       margin-left: 0;
     }
     .el-button + .el-button {


### PR DESCRIPTION
## Why

The "打开分站" dialog (Settings → 分站设置 → 打开) felt cramped:

- the dialog opened anchored to the top of the viewport instead of being centered
- the URL-choice buttons were forced to `width: 100%` and `size="large"`, so they ran edge-to-edge and looked oversized for a small confirmation dialog
- with only a 10 px gap and full-width buttons, the two choices visually ran together

## What changed

`src/components/setting/Subsite.vue`

- added `align-center` to the open-subsite `<el-dialog>` so it sits in the middle of the viewport
- dropped `size="large"` on the URL buttons — they now use the default size to match the rest of the settings dialogs
- replaced `width: 100%` + `gap: 10px` with `min-width: 220px`, `align-items: center`, and `gap: 14px`, so the buttons are comfortably centered with real breathing room between them

No template logic or i18n strings were touched — purely a visual tidy-up of the existing dialog.