### PR TITLE
fix(ci): split iOS distribute/submit into own job (PEP 668 + replay)

### DIFF
--- a/.github/workflows/build-android.yaml
+++ b/.github/workflows/build-android.yaml
@@ -243,10 +243,13 @@ jobs:
   promote:
     name: Promote to Production
     needs: [preflight, build]
-    # Only auto-promote when the initial upload landed on a non-production track AND the
-    # caller asked for it (workflow_dispatch default = true; tag-push defaults to promote).
+    # Run when preflight finished AND either the build job uploaded a fresh AAB
+    # or it was skipped because Play already had this versionCode (so the
+    # promote step can still push it from beta → production).
     if: |
-      needs.preflight.outputs.should-build == 'true'
+      always()
+      && needs.preflight.result == 'success'
+      && (needs.build.result == 'success' || needs.build.result == 'skipped')
       && needs.preflight.outputs.track != 'production'
       && (github.event_name != 'workflow_dispatch' || inputs.promote_to_production)
     runs-on: ubuntu-latest

--- a/.github/workflows/build-ios.yaml
+++ b/.github/workflows/build-ios.yaml
@@ -279,13 +279,35 @@ jobs:
             --apiKey "$APP_STORE_CONNECT_API_KEY_ID" \
             --apiIssuer "$APP_STORE_CONNECT_API_ISSUER_ID"
 
+      - name: Clean up keychain
+        if: always()
+        run: |
+          security delete-keychain $RUNNER_TEMP/app-signing.keychain-db 2>/dev/null || true
+
+  distribute:
+    name: Distribute & Submit (TestFlight + Review)
+    needs: [preflight, build]
+    # Run when preflight finished (either the build job uploaded a fresh binary
+    # or preflight detected an existing TF build and skipped the rebuild).
+    # Self-skip when both auto-toggles are disabled on a manual dispatch.
+    if: >-
+      always()
+      && needs.preflight.result == 'success'
+      && (needs.build.result == 'success' || needs.build.result == 'skipped')
+      && (github.event_name != 'workflow_dispatch' || inputs.auto_distribute_external || inputs.auto_submit_review)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
       - name: Install ASC API client deps
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.auto_distribute_external || inputs.auto_submit_review }}
-        run: python3 -m pip install --quiet --user 'pyjwt[crypto]==2.10.1' requests
+        run: python -m pip install --quiet 'pyjwt[crypto]==2.10.1' requests
 
       - name: Wait for TestFlight processing
         id: tf_wait
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.auto_distribute_external || inputs.auto_submit_review }}
         env:
           ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
@@ -297,7 +319,7 @@ jobs:
         # it can be added to a beta group or attached to an App Store version.
         # Polls every 30s for up to 25 min, then sets build-id as a step output.
         run: |
-          python3 <<'PY'
+          python <<'PY'
           import base64, json, os, sys, time, requests, jwt
 
           key_id = os.environ['ASC_KEY_ID']
@@ -386,7 +408,7 @@ jobs:
         # so we only target externally-shared groups here. Tolerates groups
         # that already include this build (409 conflicts are ignored).
         run: |
-          python3 <<'PY'
+          python <<'PY'
           import base64, os, time, requests, jwt
 
           key_id = os.environ['ASC_KEY_ID']
@@ -451,7 +473,7 @@ jobs:
         # screenshots, no localized release notes, etc.) and we don't want
         # those to fail the whole workflow — they require manual fixup.
         run: |
-          python3 <<'PY'
+          python <<'PY'
           import base64, os, sys, time, requests, jwt
 
           key_id = os.environ['ASC_KEY_ID']
@@ -587,8 +609,3 @@ jobs:
               die_soft(f'Failed to submit for review: {fin.status_code} {fin.text[:400]}')
           print(f'::notice::Submitted review {submission_id} for App Store review.')
           PY
-
-      - name: Clean up keychain
-        if: always()
-        run: |
-          security delete-keychain $RUNNER_TEMP/app-signing.keychain-db 2>/dev/null || true


### PR DESCRIPTION
## Why

Tonight's first real-run of `release-mobile.yaml` on `main` (run [26679288565](https://github.com/AceDataCloud/Nexior/actions/runs/26679288565)) revealed two issues in the iOS pipeline:

1. **PEP 668 trap on macos-15.** `pip install --user 'pyjwt[crypto]==2.10.1' requests` failed with `error: externally-managed-environment` because the runner's Homebrew Python now refuses `pip install` outside a venv. The TestFlight upload step itself succeeded — build **55201** is uploaded and processing — but the brand-new `Wait for TF processing` / `Distribute to external TestFlight groups` / `Submit build for App Store review` steps never ran.

2. **Distribute/submit was nested inside the build job.** Because those steps lived under `build:` (gated by `needs.preflight.outputs.should-build == 'true'`), once `preflight` detects an already-uploaded binary on a retry, the whole post-upload pipeline is skipped — even though TestFlight is sitting on a ready binary.

## What

- Hoist the four post-upload steps into a standalone **`distribute` job** on `ubuntu-latest`, with `actions/setup-python@v5` (sidesteps PEP 668).
- Run the new job when `needs.build.result == 'success' || 'skipped'`, so a retry against an existing TF build still drives external groups + review submission.
- Mirror the same `success || skipped` condition on Android's `promote` job so it can re-promote without rebuilding.

## Test plan

After merge, re-dispatch `release-mobile.yaml` on `main` with full defaults. Expected:

- iOS preflight finds build 55201 → skips rebuild.
- New `distribute` job runs on ubuntu, polls ASC, attaches build 55201 to external groups, files review submission.
- Android preflight finds versionCode 55201 → skips rebuild.
- `promote` job re-runs (no-op if already 100% in production) — confirms idempotency.

Validates against existing assets, no version bump required.
