### PR TITLE
fix(ci): ASC version lookup 400 + soft-warn on iOS submit step

### DIFF
--- a/.github/workflows/build-ios.yaml
+++ b/.github/workflows/build-ios.yaml
@@ -496,13 +496,17 @@ jobs:
               print(f'::warning::{msg}')
               sys.exit(0)
 
-          # 1) Look up existing iOS App Store versions on this app.
+          # 1) Look up existing iOS App Store versions matching our versionString.
+          # /v1/apps/{id}/appStoreVersions only allows sort on a small set
+          # (appStoreState, platform, versionString) — not createdDate — so we
+          # filter by versionString directly instead.
           r = requests.get(
               f'https://api.appstoreconnect.apple.com/v1/apps/{app_id}/appStoreVersions',
-              params={'filter[platform]': 'IOS', 'limit': 20, 'sort': '-createdDate'},
+              params={'filter[platform]': 'IOS', 'filter[versionString]': version_name, 'limit': 50},
               headers=H(), timeout=30,
           )
-          r.raise_for_status()
+          if r.status_code != 200:
+              die_soft(f'Failed to list App Store versions: {r.status_code} {r.text[:400]}')
           versions = r.json().get('data') or []
 
           editable_states = {
@@ -512,7 +516,7 @@ jobs:
           version_id, version_state = None, None
           for v in versions:
               attrs = v['attributes']
-              if attrs.get('versionString') == version_name and attrs.get('appStoreState') in editable_states:
+              if attrs.get('appStoreState') in editable_states:
                   version_id = v['id']
                   version_state = attrs.get('appStoreState')
                   print(f'Reusing existing App Store version {version_id} (state={version_state}).')
@@ -562,10 +566,19 @@ jobs:
               json=sub_payload, headers=H(), timeout=30,
           )
           if sr.status_code == 409:
-              # An open submission already exists; find it.
+              # An open submission already exists; find it. Apple's API expects
+              # repeated filter[state] params, not a single comma-joined value.
               ex = requests.get(
                   'https://api.appstoreconnect.apple.com/v1/reviewSubmissions',
-                  params={'filter[app]': app_id, 'filter[platform]': 'IOS', 'filter[state]': 'READY_FOR_REVIEW,IN_REVIEW,UNRESOLVED_ISSUES,WAITING_FOR_REVIEW,COMPLETING'},
+                  params=[
+                      ('filter[app]', app_id),
+                      ('filter[platform]', 'IOS'),
+                      ('filter[state]', 'READY_FOR_REVIEW'),
+                      ('filter[state]', 'WAITING_FOR_REVIEW'),
+                      ('filter[state]', 'IN_REVIEW'),
+                      ('filter[state]', 'UNRESOLVED_ISSUES'),
+                      ('filter[state]', 'COMPLETING'),
+                  ],
                   headers=H(), timeout=30,
               )
               if ex.status_code != 200 or not (ex.json().get('data') or []):


### PR DESCRIPTION
## Why

First end-to-end run of the auto-distribute / auto-submit pipeline ([iOS run 26679633966](https://github.com/AceDataCloud/Nexior/actions/runs/26679633966)) crashed the **Submit build for App Store review** step with:

```
400 Bad Request for
GET /v1/apps/{id}/appStoreVersions?filter[platform]=IOS&limit=20&sort=-createdDate
```

`continue-on-error: true` masked it at the job level (job still went green), but the actual submission silently never happened.

## What's fixed

1. **400 root cause** — `/v1/apps/{id}/appStoreVersions` only accepts `appStoreState | platform | versionString` as `sort` fields. `createdDate` is invalid → 400. Switched the lookup to `filter[versionString]={version_name}` (no sort needed — we know the exact version we want).
2. **Soft-warn consistency** — replaced `r.raise_for_status()` with an explicit `die_soft` call so a non-2xx surfaces as `::warning::` instead of an uncaught exception. Matches the pattern used by every other ASC call in this step.
3. **409 fallback filter** — Apple's `/v1/reviewSubmissions` `filter[state]` must be passed as **repeated** params, not a single comma-joined value. Switched `params=` from dict to list-of-tuples so `requests` serializes it correctly. Only triggers on 409 (existing submission), so we didn't hit it yet, but the previous form would have failed too.

## Validation

- YAML lints clean (`python3 -c "import yaml; yaml.safe_load(...)"`).
- Previous run's TestFlight processing wait + distribute-to-groups steps already succeeded — they're untouched here. Only the Submit step needed surgery.
- Will validate end-to-end via a fresh `release-mobile.yaml` dispatch once this merges.

## Outstanding (separate concerns, not blocking)

- **No external TestFlight groups configured** in ASC for App ID `6772432921`, so the "Distribute to external groups" step always logs `No external TestFlight groups configured. Skipping.` You need to create one in App Store Connect → TestFlight → External Testing if you want auto-external-distribute to actually do something.
