### PR TITLE
chore(flux): align model list with TTApi backend

### DIFF
--- a/src/components/flux/config/ModelSelector.vue
+++ b/src/components/flux/config/ModelSelector.vue
@@ -37,20 +37,24 @@ export default defineComponent({
           label: 'flux-pro'
         },
         {
-          value: 'flux-pro-1.1',
-          label: 'flux-pro-1.1'
-        },
-        {
-          value: 'flux-pro-1.1-ultra',
-          label: 'flux-pro-1.1-ultra'
-        },
-        {
           value: 'flux-kontext-pro',
           label: 'flux-kontext-pro'
         },
         {
           value: 'flux-kontext-max',
           label: 'flux-kontext-max'
+        },
+        {
+          value: 'flux-2-flex',
+          label: 'flux-2-flex'
+        },
+        {
+          value: 'flux-2-pro',
+          label: 'flux-2-pro'
+        },
+        {
+          value: 'flux-2-max',
+          label: 'flux-2-max'
         }
       ]
     };


### PR DESCRIPTION
Drop `flux-pro-1.1` / `flux-pro-1.1-ultra` from the Flux model picker and replace them with the **Flux 2** family (`flux-2-flex`, `flux-2-pro`, `flux-2-max`) to match the new TTApi upstream.

### Why

The old openai-hk Flux channel is dead (all 6 models returning 500) so we are migrating to TTApi. TTApi carries the Flux 2 family but does **not** carry the legacy `flux-pro-1.1*` SKUs.

### Final lineup (7 models)
`flux-dev`, `flux-pro`, `flux-kontext-pro`, `flux-kontext-max`, `flux-2-flex`, `flux-2-pro`, `flux-2-max`

Default model (`flux-dev`) unchanged.

### Companion PRs
- PlatformService (worker): AceDataCloud/PlatformService#954
- PlatformBackend (cost + openapi + zh-CN docs): separate PR
- MCPs + Dify plugin: separate PRs