### PR TITLE
feat(order-list): summary cards + CSV export (parity with PlatformFrontend)

### DIFF
--- a/change/@acedatacloud-nexior-order-list-summary-export.json
+++ b/change/@acedatacloud-nexior-order-list-summary-export.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(order-list): add summary cards and CSV export (parity with PlatformFrontend)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/i18n/ar/order.json
+++ b/src/i18n/ar/order.json
@@ -518,5 +518,33 @@
   "message.wechatPayLongPressTip": {
     "message": "اضغط مطولا على رمز الاستجابة السريعة ادناه واختر 'التعرف على رمز QR' لاكمال الدفع في WeChat.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
+  },
+  "title.totalOrders": {
+    "message": "Total Orders",
+    "description": "Summary card: total number of orders matching the current filters."
+  },
+  "title.totalSpent": {
+    "message": "Total Spent",
+    "description": "Summary card: total amount spent across matching orders."
+  },
+  "title.finishedOrders": {
+    "message": "Finished Orders",
+    "description": "Summary card: number of finished orders."
+  },
+  "title.pendingOrders": {
+    "message": "Pending Orders",
+    "description": "Summary card: number of pending orders."
+  },
+  "button.export": {
+    "message": "Export CSV",
+    "description": "Button label to export the filtered orders as CSV."
+  },
+  "field.allStates": {
+    "message": "All States",
+    "description": "Placeholder of the state filter dropdown indicating no specific state is selected."
+  },
+  "field.allPayWays": {
+    "message": "All Payment Methods",
+    "description": "Placeholder of the payment method filter dropdown indicating no specific method is selected."
   }
 }

--- a/src/i18n/de/order.json
+++ b/src/i18n/de/order.json
@@ -518,5 +518,33 @@
   "message.wechatPayLongPressTip": {
     "message": "Halten Sie den QR-Code unten gedrueckt und waehlen Sie 'QR-Code erkennen', um die Zahlung in WeChat abzuschliessen.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
+  },
+  "title.totalOrders": {
+    "message": "Total Orders",
+    "description": "Summary card: total number of orders matching the current filters."
+  },
+  "title.totalSpent": {
+    "message": "Total Spent",
+    "description": "Summary card: total amount spent across matching orders."
+  },
+  "title.finishedOrders": {
+    "message": "Finished Orders",
+    "description": "Summary card: number of finished orders."
+  },
+  "title.pendingOrders": {
+    "message": "Pending Orders",
+    "description": "Summary card: number of pending orders."
+  },
+  "button.export": {
+    "message": "Export CSV",
+    "description": "Button label to export the filtered orders as CSV."
+  },
+  "field.allStates": {
+    "message": "All States",
+    "description": "Placeholder of the state filter dropdown indicating no specific state is selected."
+  },
+  "field.allPayWays": {
+    "message": "All Payment Methods",
+    "description": "Placeholder of the payment method filter dropdown indicating no specific method is selected."
   }
 }

--- a/src/i18n/el/order.json
+++ b/src/i18n/el/order.json
@@ -518,5 +518,33 @@
   "message.wechatPayLongPressTip": {
     "message": "Πατήστε παρατεταμένα τον παρακάτω κωδικό QR και επιλέξτε 'Αναγνώριση κωδικού QR' για να ολοκληρώσετε την πληρωμή στο WeChat.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
+  },
+  "title.totalOrders": {
+    "message": "Total Orders",
+    "description": "Summary card: total number of orders matching the current filters."
+  },
+  "title.totalSpent": {
+    "message": "Total Spent",
+    "description": "Summary card: total amount spent across matching orders."
+  },
+  "title.finishedOrders": {
+    "message": "Finished Orders",
+    "description": "Summary card: number of finished orders."
+  },
+  "title.pendingOrders": {
+    "message": "Pending Orders",
+    "description": "Summary card: number of pending orders."
+  },
+  "button.export": {
+    "message": "Export CSV",
+    "description": "Button label to export the filtered orders as CSV."
+  },
+  "field.allStates": {
+    "message": "All States",
+    "description": "Placeholder of the state filter dropdown indicating no specific state is selected."
+  },
+  "field.allPayWays": {
+    "message": "All Payment Methods",
+    "description": "Placeholder of the payment method filter dropdown indicating no specific method is selected."
   }
 }

--- a/src/i18n/en/order.json
+++ b/src/i18n/en/order.json
@@ -518,5 +518,33 @@
   "message.wechatPayLongPressTip": {
     "message": "Long-press the QR code below and tap 'Recognise QR code' to complete payment in WeChat.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
+  },
+  "title.totalOrders": {
+    "message": "Total Orders",
+    "description": "Summary card: total number of orders matching the current filters."
+  },
+  "title.totalSpent": {
+    "message": "Total Spent",
+    "description": "Summary card: total amount spent across matching orders."
+  },
+  "title.finishedOrders": {
+    "message": "Finished Orders",
+    "description": "Summary card: number of finished orders."
+  },
+  "title.pendingOrders": {
+    "message": "Pending Orders",
+    "description": "Summary card: number of pending orders."
+  },
+  "button.export": {
+    "message": "Export CSV",
+    "description": "Button label to export the filtered orders as CSV."
+  },
+  "field.allStates": {
+    "message": "All States",
+    "description": "Placeholder of the state filter dropdown indicating no specific state is selected."
+  },
+  "field.allPayWays": {
+    "message": "All Payment Methods",
+    "description": "Placeholder of the payment method filter dropdown indicating no specific method is selected."
   }
 }

--- a/src/i18n/es/order.json
+++ b/src/i18n/es/order.json
@@ -518,5 +518,33 @@
   "message.wechatPayLongPressTip": {
     "message": "Mantenga pulsado el siguiente codigo QR y toque 'Reconocer codigo QR' para completar el pago en WeChat.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
+  },
+  "title.totalOrders": {
+    "message": "Total Orders",
+    "description": "Summary card: total number of orders matching the current filters."
+  },
+  "title.totalSpent": {
+    "message": "Total Spent",
+    "description": "Summary card: total amount spent across matching orders."
+  },
+  "title.finishedOrders": {
+    "message": "Finished Orders",
+    "description": "Summary card: number of finished orders."
+  },
+  "title.pendingOrders": {
+    "message": "Pending Orders",
+    "description": "Summary card: number of pending orders."
+  },
+  "button.export": {
+    "message": "Export CSV",
+    "description": "Button label to export the filtered orders as CSV."
+  },
+  "field.allStates": {
+    "message": "All States",
+    "description": "Placeholder of the state filter dropdown indicating no specific state is selected."
+  },
+  "field.allPayWays": {
+    "message": "All Payment Methods",
+    "description": "Placeholder of the payment method filter dropdown indicating no specific method is selected."
   }
 }

--- a/src/i18n/fi/order.json
+++ b/src/i18n/fi/order.json
@@ -518,5 +518,33 @@
   "message.wechatPayLongPressTip": {
     "message": "Paina alla olevaa QR-koodia pitkaan ja valitse 'Tunnista QR-koodi' suorittaaksesi maksun WeChatissa.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
+  },
+  "title.totalOrders": {
+    "message": "Total Orders",
+    "description": "Summary card: total number of orders matching the current filters."
+  },
+  "title.totalSpent": {
+    "message": "Total Spent",
+    "description": "Summary card: total amount spent across matching orders."
+  },
+  "title.finishedOrders": {
+    "message": "Finished Orders",
+    "description": "Summary card: number of finished orders."
+  },
+  "title.pendingOrders": {
+    "message": "Pending Orders",
+    "description": "Summary card: number of pending orders."
+  },
+  "button.export": {
+    "message": "Export CSV",
+    "description": "Button label to export the filtered orders as CSV."
+  },
+  "field.allStates": {
+    "message": "All States",
+    "description": "Placeholder of the state filter dropdown indicating no specific state is selected."
+  },
+  "field.allPayWays": {
+    "message": "All Payment Methods",
+    "description": "Placeholder of the payment method filter dropdown indicating no specific method is selected."
   }
 }

--- a/src/i18n/fr/order.json
+++ b/src/i18n/fr/order.json
@@ -518,5 +518,33 @@
   "message.wechatPayLongPressTip": {
     "message": "Appuyez longuement sur le QR code ci-dessous et choisissez 'Reconnaitre le QR code' pour finaliser le paiement dans WeChat.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
+  },
+  "title.totalOrders": {
+    "message": "Total Orders",
+    "description": "Summary card: total number of orders matching the current filters."
+  },
+  "title.totalSpent": {
+    "message": "Total Spent",
+    "description": "Summary card: total amount spent across matching orders."
+  },
+  "title.finishedOrders": {
+    "message": "Finished Orders",
+    "description": "Summary card: number of finished orders."
+  },
+  "title.pendingOrders": {
+    "message": "Pending Orders",
+    "description": "Summary card: number of pending orders."
+  },
+  "button.export": {
+    "message": "Export CSV",
+    "description": "Button label to export the filtered orders as CSV."
+  },
+  "field.allStates": {
+    "message": "All States",
+    "description": "Placeholder of the state filter dropdown indicating no specific state is selected."
+  },
+  "field.allPayWays": {
+    "message": "All Payment Methods",
+    "description": "Placeholder of the payment method filter dropdown indicating no specific method is selected."
   }
 }

--- a/src/i18n/it/order.json
+++ b/src/i18n/it/order.json
@@ -518,5 +518,33 @@
   "message.wechatPayLongPressTip": {
     "message": "Tieni premuto il codice QR qui sotto e seleziona 'Riconosci codice QR' per completare il pagamento in WeChat.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
+  },
+  "title.totalOrders": {
+    "message": "Total Orders",
+    "description": "Summary card: total number of orders matching the current filters."
+  },
+  "title.totalSpent": {
+    "message": "Total Spent",
+    "description": "Summary card: total amount spent across matching orders."
+  },
+  "title.finishedOrders": {
+    "message": "Finished Orders",
+    "description": "Summary card: number of finished orders."
+  },
+  "title.pendingOrders": {
+    "message": "Pending Orders",
+    "description": "Summary card: number of pending orders."
+  },
+  "button.export": {
+    "message": "Export CSV",
+    "description": "Button label to export the filtered orders as CSV."
+  },
+  "field.allStates": {
+    "message": "All States",
+    "description": "Placeholder of the state filter dropdown indicating no specific state is selected."
+  },
+  "field.allPayWays": {
+    "message": "All Payment Methods",
+    "description": "Placeholder of the payment method filter dropdown indicating no specific method is selected."
   }
 }

--- a/src/i18n/ja/order.json
+++ b/src/i18n/ja/order.json
@@ -518,5 +518,33 @@
   "message.wechatPayLongPressTip": {
     "message": "下のQRコードを長押しし、「QRコードを認識」を選択してWeChatで支払いを完了してください。",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
+  },
+  "title.totalOrders": {
+    "message": "Total Orders",
+    "description": "Summary card: total number of orders matching the current filters."
+  },
+  "title.totalSpent": {
+    "message": "Total Spent",
+    "description": "Summary card: total amount spent across matching orders."
+  },
+  "title.finishedOrders": {
+    "message": "Finished Orders",
+    "description": "Summary card: number of finished orders."
+  },
+  "title.pendingOrders": {
+    "message": "Pending Orders",
+    "description": "Summary card: number of pending orders."
+  },
+  "button.export": {
+    "message": "Export CSV",
+    "description": "Button label to export the filtered orders as CSV."
+  },
+  "field.allStates": {
+    "message": "All States",
+    "description": "Placeholder of the state filter dropdown indicating no specific state is selected."
+  },
+  "field.allPayWays": {
+    "message": "All Payment Methods",
+    "description": "Placeholder of the payment method filter dropdown indicating no specific method is selected."
   }
 }

--- a/src/i18n/ko/order.json
+++ b/src/i18n/ko/order.json
@@ -518,5 +518,33 @@
   "message.wechatPayLongPressTip": {
     "message": "아래 QR 코드를 길게 눌러 'QR 코드 인식'을 선택해 WeChat에서 결제를 완료하세요.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
+  },
+  "title.totalOrders": {
+    "message": "Total Orders",
+    "description": "Summary card: total number of orders matching the current filters."
+  },
+  "title.totalSpent": {
+    "message": "Total Spent",
+    "description": "Summary card: total amount spent across matching orders."
+  },
+  "title.finishedOrders": {
+    "message": "Finished Orders",
+    "description": "Summary card: number of finished orders."
+  },
+  "title.pendingOrders": {
+    "message": "Pending Orders",
+    "description": "Summary card: number of pending orders."
+  },
+  "button.export": {
+    "message": "Export CSV",
+    "description": "Button label to export the filtered orders as CSV."
+  },
+  "field.allStates": {
+    "message": "All States",
+    "description": "Placeholder of the state filter dropdown indicating no specific state is selected."
+  },
+  "field.allPayWays": {
+    "message": "All Payment Methods",
+    "description": "Placeholder of the payment method filter dropdown indicating no specific method is selected."
   }
 }

--- a/src/i18n/pl/order.json
+++ b/src/i18n/pl/order.json
@@ -518,5 +518,33 @@
   "message.wechatPayLongPressTip": {
     "message": "Przytrzymaj ponizszy kod QR i wybierz 'Rozpoznaj kod QR', aby dokonczyc platnosc w WeChat.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
+  },
+  "title.totalOrders": {
+    "message": "Total Orders",
+    "description": "Summary card: total number of orders matching the current filters."
+  },
+  "title.totalSpent": {
+    "message": "Total Spent",
+    "description": "Summary card: total amount spent across matching orders."
+  },
+  "title.finishedOrders": {
+    "message": "Finished Orders",
+    "description": "Summary card: number of finished orders."
+  },
+  "title.pendingOrders": {
+    "message": "Pending Orders",
+    "description": "Summary card: number of pending orders."
+  },
+  "button.export": {
+    "message": "Export CSV",
+    "description": "Button label to export the filtered orders as CSV."
+  },
+  "field.allStates": {
+    "message": "All States",
+    "description": "Placeholder of the state filter dropdown indicating no specific state is selected."
+  },
+  "field.allPayWays": {
+    "message": "All Payment Methods",
+    "description": "Placeholder of the payment method filter dropdown indicating no specific method is selected."
   }
 }

--- a/src/i18n/pt/order.json
+++ b/src/i18n/pt/order.json
@@ -518,5 +518,33 @@
   "message.wechatPayLongPressTip": {
     "message": "Mantenha pressionado o codigo QR abaixo e selecione 'Reconhecer codigo QR' para concluir o pagamento no WeChat.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
+  },
+  "title.totalOrders": {
+    "message": "Total Orders",
+    "description": "Summary card: total number of orders matching the current filters."
+  },
+  "title.totalSpent": {
+    "message": "Total Spent",
+    "description": "Summary card: total amount spent across matching orders."
+  },
+  "title.finishedOrders": {
+    "message": "Finished Orders",
+    "description": "Summary card: number of finished orders."
+  },
+  "title.pendingOrders": {
+    "message": "Pending Orders",
+    "description": "Summary card: number of pending orders."
+  },
+  "button.export": {
+    "message": "Export CSV",
+    "description": "Button label to export the filtered orders as CSV."
+  },
+  "field.allStates": {
+    "message": "All States",
+    "description": "Placeholder of the state filter dropdown indicating no specific state is selected."
+  },
+  "field.allPayWays": {
+    "message": "All Payment Methods",
+    "description": "Placeholder of the payment method filter dropdown indicating no specific method is selected."
   }
 }

--- a/src/i18n/ru/order.json
+++ b/src/i18n/ru/order.json
@@ -518,5 +518,33 @@
   "message.wechatPayLongPressTip": {
     "message": "Удерживайте QR-код ниже и выберите 'Распознать QR-код', чтобы завершить оплату в WeChat.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
+  },
+  "title.totalOrders": {
+    "message": "Total Orders",
+    "description": "Summary card: total number of orders matching the current filters."
+  },
+  "title.totalSpent": {
+    "message": "Total Spent",
+    "description": "Summary card: total amount spent across matching orders."
+  },
+  "title.finishedOrders": {
+    "message": "Finished Orders",
+    "description": "Summary card: number of finished orders."
+  },
+  "title.pendingOrders": {
+    "message": "Pending Orders",
+    "description": "Summary card: number of pending orders."
+  },
+  "button.export": {
+    "message": "Export CSV",
+    "description": "Button label to export the filtered orders as CSV."
+  },
+  "field.allStates": {
+    "message": "All States",
+    "description": "Placeholder of the state filter dropdown indicating no specific state is selected."
+  },
+  "field.allPayWays": {
+    "message": "All Payment Methods",
+    "description": "Placeholder of the payment method filter dropdown indicating no specific method is selected."
   }
 }

--- a/src/i18n/sr/order.json
+++ b/src/i18n/sr/order.json
@@ -518,5 +518,33 @@
   "message.wechatPayLongPressTip": {
     "message": "Drzite pritisnutim QR kod ispod i izaberite 'Prepoznaj QR kod' da biste zavrsili placanje u WeChat-u.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
+  },
+  "title.totalOrders": {
+    "message": "Total Orders",
+    "description": "Summary card: total number of orders matching the current filters."
+  },
+  "title.totalSpent": {
+    "message": "Total Spent",
+    "description": "Summary card: total amount spent across matching orders."
+  },
+  "title.finishedOrders": {
+    "message": "Finished Orders",
+    "description": "Summary card: number of finished orders."
+  },
+  "title.pendingOrders": {
+    "message": "Pending Orders",
+    "description": "Summary card: number of pending orders."
+  },
+  "button.export": {
+    "message": "Export CSV",
+    "description": "Button label to export the filtered orders as CSV."
+  },
+  "field.allStates": {
+    "message": "All States",
+    "description": "Placeholder of the state filter dropdown indicating no specific state is selected."
+  },
+  "field.allPayWays": {
+    "message": "All Payment Methods",
+    "description": "Placeholder of the payment method filter dropdown indicating no specific method is selected."
   }
 }

--- a/src/i18n/sv/order.json
+++ b/src/i18n/sv/order.json
@@ -518,5 +518,33 @@
   "message.wechatPayLongPressTip": {
     "message": "Hall in QR-koden nedan och valj 'Identifiera QR-kod' for att slutfora betalningen i WeChat.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
+  },
+  "title.totalOrders": {
+    "message": "Total Orders",
+    "description": "Summary card: total number of orders matching the current filters."
+  },
+  "title.totalSpent": {
+    "message": "Total Spent",
+    "description": "Summary card: total amount spent across matching orders."
+  },
+  "title.finishedOrders": {
+    "message": "Finished Orders",
+    "description": "Summary card: number of finished orders."
+  },
+  "title.pendingOrders": {
+    "message": "Pending Orders",
+    "description": "Summary card: number of pending orders."
+  },
+  "button.export": {
+    "message": "Export CSV",
+    "description": "Button label to export the filtered orders as CSV."
+  },
+  "field.allStates": {
+    "message": "All States",
+    "description": "Placeholder of the state filter dropdown indicating no specific state is selected."
+  },
+  "field.allPayWays": {
+    "message": "All Payment Methods",
+    "description": "Placeholder of the payment method filter dropdown indicating no specific method is selected."
   }
 }

--- a/src/i18n/uk/order.json
+++ b/src/i18n/uk/order.json
@@ -518,5 +518,33 @@
   "message.wechatPayLongPressTip": {
     "message": "Утримуйте QR-код нижче та виберіть 'Розпізнати QR-код', щоб завершити оплату в WeChat.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
+  },
+  "title.totalOrders": {
+    "message": "Total Orders",
+    "description": "Summary card: total number of orders matching the current filters."
+  },
+  "title.totalSpent": {
+    "message": "Total Spent",
+    "description": "Summary card: total amount spent across matching orders."
+  },
+  "title.finishedOrders": {
+    "message": "Finished Orders",
+    "description": "Summary card: number of finished orders."
+  },
+  "title.pendingOrders": {
+    "message": "Pending Orders",
+    "description": "Summary card: number of pending orders."
+  },
+  "button.export": {
+    "message": "Export CSV",
+    "description": "Button label to export the filtered orders as CSV."
+  },
+  "field.allStates": {
+    "message": "All States",
+    "description": "Placeholder of the state filter dropdown indicating no specific state is selected."
+  },
+  "field.allPayWays": {
+    "message": "All Payment Methods",
+    "description": "Placeholder of the payment method filter dropdown indicating no specific method is selected."
   }
 }

--- a/src/i18n/zh-CN/order.json
+++ b/src/i18n/zh-CN/order.json
@@ -518,5 +518,33 @@
   "message.wechatPayLongPressTip": {
     "message": "请长按下方二维码识别图中二维码完成支付。",
     "description": "手机微信内部浏览器打开订单页时，二维码上方的引导文案。用户长按二维码即可识别并完成支付，无需跳出微信。"
+  },
+  "title.totalOrders": {
+    "message": "订单总数",
+    "description": "汇总卡片：当前筛选条件下的订单总数。"
+  },
+  "title.totalSpent": {
+    "message": "总消费",
+    "description": "汇总卡片：当前筛选条件下订单总金额。"
+  },
+  "title.finishedOrders": {
+    "message": "已完成订单",
+    "description": "汇总卡片：已完成的订单数。"
+  },
+  "title.pendingOrders": {
+    "message": "待支付订单",
+    "description": "汇总卡片：待支付的订单数。"
+  },
+  "button.export": {
+    "message": "导出 CSV",
+    "description": "按钮文案：按当前筛选条件导出订单 CSV。"
+  },
+  "field.allStates": {
+    "message": "全部状态",
+    "description": "状态筛选下拉的占位符：表示不限定状态。"
+  },
+  "field.allPayWays": {
+    "message": "全部支付方式",
+    "description": "支付方式筛选下拉的占位符：表示不限定支付方式。"
   }
 }

--- a/src/i18n/zh-TW/order.json
+++ b/src/i18n/zh-TW/order.json
@@ -518,5 +518,33 @@
   "message.wechatPayLongPressTip": {
     "message": "請長按下方二維碼，識別圖中二維碼完成支付。",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
+  },
+  "title.totalOrders": {
+    "message": "訂單總數",
+    "description": "彙總卡片：目前篩選條件下的訂單總數。"
+  },
+  "title.totalSpent": {
+    "message": "總消費",
+    "description": "彙總卡片：目前篩選條件下訂單總金額。"
+  },
+  "title.finishedOrders": {
+    "message": "已完成訂單",
+    "description": "彙總卡片：已完成的訂單數。"
+  },
+  "title.pendingOrders": {
+    "message": "待支付訂單",
+    "description": "彙總卡片：待支付的訂單數。"
+  },
+  "button.export": {
+    "message": "匯出 CSV",
+    "description": "按鈕文案：依目前篩選條件匯出訂單 CSV。"
+  },
+  "field.allStates": {
+    "message": "全部狀態",
+    "description": "狀態篩選下拉的佔位符：表示不限定狀態。"
+  },
+  "field.allPayWays": {
+    "message": "全部支付方式",
+    "description": "支付方式篩選下拉的佔位符：表示不限定支付方式。"
   }
 }

--- a/src/operators/order.ts
+++ b/src/operators/order.ts
@@ -16,6 +16,12 @@ export interface IOrderQuery {
   state?: string | string[];
 }
 
+export interface IOrderSummary {
+  total_count: number;
+  total_spent: number;
+  state_counts: Record<string, number>;
+}
+
 class OrderService {
   key = 'orders';
 
@@ -67,6 +73,17 @@ class OrderService {
 
   async delete(id: string): Promise<AxiosResponse<null>> {
     return await httpClient.delete(`/${this.key}/${id}`);
+  }
+
+  async getSummary(query: IOrderQuery): Promise<AxiosResponse<IOrderSummary>> {
+    return await httpClient.get(`/${this.key}/summary/`, { params: query });
+  }
+
+  async exportCsv(query: IOrderQuery): Promise<AxiosResponse<Blob>> {
+    return await httpClient.get(`/${this.key}/export/`, {
+      params: query,
+      responseType: 'blob'
+    });
   }
 }
 

--- a/src/pages/console/order/List.vue
+++ b/src/pages/console/order/List.vue
@@ -6,6 +6,95 @@
           <h2 class="title">{{ $t('common.title.allOrders') }}</h2>
         </el-col>
       </el-row>
+
+      <!-- Summary Cards -->
+      <el-row :gutter="16">
+        <el-col :md="6" :sm="12" :xs="24">
+          <el-card shadow="hover" class="item-mini mb-3">
+            <el-skeleton v-if="summaryLoading" />
+            <div v-else class="card-content">
+              <div class="icon-wrapper">
+                <font-awesome-icon icon="fa-solid fa-receipt" class="icon" />
+              </div>
+              <p class="description">{{ $t('order.title.totalOrders') }}</p>
+              <p class="value">{{ summary.total_count }}</p>
+            </div>
+          </el-card>
+        </el-col>
+        <el-col :md="6" :sm="12" :xs="24">
+          <el-card shadow="hover" class="item-mini mb-3">
+            <el-skeleton v-if="summaryLoading" />
+            <div v-else class="card-content">
+              <div class="icon-wrapper">
+                <font-awesome-icon icon="fa-solid fa-dollar-sign" class="icon" />
+              </div>
+              <p class="description">{{ $t('order.title.totalSpent') }}</p>
+              <p class="value">{{ getPriceString({ value: summary.total_spent }) }}</p>
+            </div>
+          </el-card>
+        </el-col>
+        <el-col :md="6" :sm="12" :xs="24">
+          <el-card shadow="hover" class="item-mini mb-3">
+            <el-skeleton v-if="summaryLoading" />
+            <div v-else class="card-content">
+              <div class="icon-wrapper">
+                <font-awesome-icon icon="fa-solid fa-check-circle" class="icon" />
+              </div>
+              <p class="description">{{ $t('order.title.finishedOrders') }}</p>
+              <p class="value">{{ summary.state_counts?.Finished || 0 }}</p>
+            </div>
+          </el-card>
+        </el-col>
+        <el-col :md="6" :sm="12" :xs="24">
+          <el-card shadow="hover" class="item-mini mb-3">
+            <el-skeleton v-if="summaryLoading" />
+            <div v-else class="card-content">
+              <div class="icon-wrapper">
+                <font-awesome-icon icon="fa-solid fa-clock" class="icon" />
+              </div>
+              <p class="description">{{ $t('order.title.pendingOrders') }}</p>
+              <p class="value">{{ summary.state_counts?.Pending || 0 }}</p>
+            </div>
+          </el-card>
+        </el-col>
+      </el-row>
+
+      <!-- Filters -->
+      <div class="filter-row mb-3">
+        <el-select
+          v-model="filterState"
+          clearable
+          :placeholder="$t('order.field.allStates')"
+          class="filter-select"
+          @change="onFilterChange"
+        >
+          <el-option v-for="s in stateOptions" :key="s.value" :label="s.label" :value="s.value" />
+        </el-select>
+        <el-select
+          v-model="filterPayWay"
+          clearable
+          :placeholder="$t('order.field.allPayWays')"
+          class="filter-select"
+          @change="onFilterChange"
+        >
+          <el-option v-for="p in payWayOptions" :key="p.value" :label="p.label" :value="p.value" />
+        </el-select>
+        <el-date-picker
+          v-model="createdAtRange"
+          type="datetimerange"
+          :shortcuts="shortcuts"
+          :range-separator="$t('usage.placeholder.to')"
+          :start-placeholder="$t('usage.placeholder.startDate')"
+          :end-placeholder="$t('usage.placeholder.endDate')"
+          @change="onFilterChange"
+        />
+        <el-button type="primary" plain :loading="exporting" @click="onExport">
+          <font-awesome-icon icon="fa-solid fa-file-export" class="mr-1" />
+          {{ $t('order.button.export') }}
+        </el-button>
+      </div>
+
+      <!-- Table -->
       <el-row>
         <el-col :span="24">
           <el-card shadow="hover">
@@ -14,7 +103,7 @@
               :data="orders"
               stripe
               :empty-text="$t('common.message.noData')"
-              class="min-h-[calc(100vh-300px)] mb-[50px]"
+              class="min-h-[calc(100vh-450px)] mb-[20px]"
             >
               <el-table-column prop="id" :label="$t('order.field.id')" class-name="text-center" width="200px">
                 <template #default="scope">
@@ -24,14 +113,14 @@
                   </span>
                 </template>
               </el-table-column>
-              <el-table-column :label="$t('order.field.price')" width="100px">
+              <el-table-column :label="$t('order.field.price')" width="110px" align="center">
                 <template #default="scope">
                   <span class="price">{{ getPriceString({ value: scope.row?.price }) }}</span>
                 </template>
               </el-table-column>
               <el-table-column
                 :label="$t('order.field.description')"
-                width="270px"
+                min-width="220px"
                 class-name="hidden md:table-cell"
                 label-class-name="hidden md:table-cell"
               >
@@ -39,28 +128,27 @@
                   <span class="description">{{ scope.row.description }}</span>
                 </template>
               </el-table-column>
-              <el-table-column prop="state" :label="$t('order.field.state')" class-name="text-center" width="160px">
+              <el-table-column prop="state" :label="$t('order.field.state')" width="130px" align="center">
                 <template #default="scope">
-                  <span v-if="scope.row.state === OrderState?.PENDING">
-                    <el-tag type="info" class="mx-1" effect="dark" round>{{ $t('order.state.pending') }}</el-tag>
-                  </span>
-                  <span v-else-if="scope.row.state === OrderState?.PAID" class="state state-paid">
-                    <el-tag type="success" class="mx-1" effect="dark" round>{{ $t('order.state.paid') }}</el-tag>
-                  </span>
-                  <span v-else-if="scope.row.state === OrderState?.FINISHED" class="state state-finished">
-                    <el-tag type="success" class="mx-1" effect="dark" round>{{ $t('order.state.finished') }}</el-tag>
-                  </span>
-                  <span v-else-if="scope.row.state === OrderState?.EXPIRED" class="state state-expired">
-                    <el-tag type="danger" class="mx-1" effect="dark" round>{{ $t('order.state.expired') }}</el-tag>
-                  </span>
-                  <span v-else-if="scope.row.state === OrderState?.FAILED" class="state state-failed">
-                    <el-tag type="danger" class="mx-1" effect="dark" round> {{ $t('order.state.failed') }}</el-tag>
-                  </span>
+                  <el-tag :type="stateTagType(scope.row.state)" class="mx-1" effect="dark" round size="small">
+                    {{ stateLabel(scope.row.state) }}
+                  </el-tag>
+                </template>
+              </el-table-column>
+              <el-table-column
+                :label="$t('order.field.payWay')"
+                width="120px"
+                align="center"
+                class-name="hidden md:table-cell"
+                label-class-name="hidden md:table-cell"
+              >
+                <template #default="scope">
+                  <span class="text-gray-500">{{ scope.row.pay_way || '-' }}</span>
                 </template>
               </el-table-column>
               <el-table-column
                 :label="$t('order.field.createdAt')"
-                width="250px"
+                width="200px"
                 class-name="hidden sm:table-cell"
                 label-class-name="hidden sm:table-cell"
               >
@@ -72,37 +160,14 @@
                 <template #default="scope">
                   <div class="flex items-center justify-center flex-wrap">
                     <el-button
-                      v-if="
-                        scope.row.state !== OrderState.PAID &&
-                        scope.row.state !== OrderState.FINISHED &&
-                        scope.row.state !== OrderState.EXPIRED &&
-                        scope.row.state !== OrderState.FAILED
-                      "
+                      v-if="isPendingAction(scope.row.state)"
                       type="primary"
                       size="small"
-                      @click="
-                        $router.push({
-                          name: 'console-order-detail',
-                          params: {
-                            id: scope.row.id
-                          }
-                        })
-                      "
+                      @click="goToDetail(scope.row.id)"
                     >
                       {{ $t('order.button.continuePay') }}
                     </el-button>
-                    <el-button
-                      v-else
-                      size="small"
-                      @click="
-                        $router.push({
-                          name: 'console-order-detail',
-                          params: {
-                            id: scope.row.id
-                          }
-                        })
-                      "
-                    >
+                    <el-button v-else size="small" @click="goToDetail(scope.row.id)">
                       {{ $t('order.button.checkDetail') }}
                     </el-button>
                   </div>
@@ -112,10 +177,12 @@
           </el-card>
         </el-col>
       </el-row>
+
+      <!-- Pagination -->
       <el-row>
         <el-col :span="10" :offset="14">
           <div class="float-right">
-            <pagination :current-page="page" :page-size="limit" :total="total" @change="onPageChange"> </pagination>
+            <pagination :current-page="page" :page-size="limit" :total="total" @change="onPageChange" />
           </div>
         </el-col>
       </el-row>
@@ -125,12 +192,25 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { orderOperator } from '@/operators/order';
+import { orderOperator, IOrderSummary } from '@/operators/order';
 import Pagination from '@/components/common/Pagination.vue';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
-import { ElRow, ElCol, ElTable, ElTableColumn, ElButton, ElTag, ElCard } from 'element-plus';
+import {
+  ElRow,
+  ElCol,
+  ElTable,
+  ElTableColumn,
+  ElButton,
+  ElTag,
+  ElCard,
+  ElSelect,
+  ElOption,
+  ElDatePicker,
+  ElSkeleton
+} from 'element-plus';
 import { IOrder, IOrderListResponse, OrderState } from '@/models';
 import { getPriceString } from '@/utils';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 
 interface IData {
   orders: IOrder[];
@@ -138,7 +218,16 @@ interface IData {
   total: number | undefined;
   limit: number;
   OrderState: typeof OrderState;
+  filterState: string;
+  filterPayWay: string;
+  createdAtRange: [Date, Date] | undefined;
+  summary: IOrderSummary;
+  summaryLoading: boolean;
+  exporting: boolean;
+  shortcuts: { text: string; value: () => [Date, Date] }[];
 }
+
+const DEFAULT_SUMMARY: IOrderSummary = { total_count: 0, total_spent: 0, state_counts: {} };
 
 export default defineComponent({
   name: 'ConsoleOrderList',
@@ -151,7 +240,12 @@ export default defineComponent({
     ElTableColumn,
     ElButton,
     ElTag,
-    ElCard
+    ElCard,
+    ElSelect,
+    ElOption,
+    ElDatePicker,
+    ElSkeleton,
+    FontAwesomeIcon
   },
   data(): IData {
     return {
@@ -159,15 +253,83 @@ export default defineComponent({
       orders: [],
       loading: false,
       total: undefined,
-      limit: 10
+      limit: 10,
+      filterState: this.$route.query.state?.toString() || '',
+      filterPayWay: this.$route.query.pay_way?.toString() || '',
+      createdAtRange: (() => {
+        const fromStr = this.$route.query.created_at_from?.toString();
+        const toStr = this.$route.query.created_at_to?.toString();
+        if (fromStr && toStr) {
+          return [new Date(fromStr), new Date(toStr)] as [Date, Date];
+        }
+        return undefined;
+      })(),
+      summary: { ...DEFAULT_SUMMARY },
+      summaryLoading: false,
+      exporting: false,
+      shortcuts: [
+        {
+          text: this.$t('usage.shortcuts.today'),
+          value: () => {
+            const end = new Date();
+            const start = new Date();
+            start.setHours(0, 0, 0, 0);
+            return [start, end];
+          }
+        },
+        {
+          text: this.$t('usage.shortcuts.last7Days'),
+          value: () => {
+            const end = new Date();
+            const start = new Date();
+            start.setDate(start.getDate() - 7);
+            return [start, end];
+          }
+        },
+        {
+          text: this.$t('usage.shortcuts.last1Month'),
+          value: () => {
+            const end = new Date();
+            const start = new Date();
+            start.setMonth(start.getMonth() - 1);
+            return [start, end];
+          }
+        }
+      ]
     };
   },
   computed: {
-    redirect() {
-      return this.$route.query.redirect;
-    },
     page() {
       return parseInt(this.$route.query.page?.toString() || '1');
+    },
+    stateOptions() {
+      return [
+        { value: OrderState.PENDING, label: this.$t('order.state.pending') },
+        { value: OrderState.FINISHED, label: this.$t('order.state.finished') },
+        { value: OrderState.PAID, label: this.$t('order.state.paid') },
+        { value: OrderState.EXPIRED, label: this.$t('order.state.expired') },
+        { value: OrderState.FAILED, label: this.$t('order.state.failed') },
+        { value: OrderState.REFUNDED, label: this.$t('order.state.refunded') }
+      ];
+    },
+    payWayOptions() {
+      return [
+        { value: 'WechatPay', label: this.$t('order.title.wechatPay') },
+        { value: 'Stripe', label: this.$t('order.title.stripe') },
+        { value: 'AliPay', label: this.$t('order.title.aliPay') },
+        { value: 'X402', label: this.$t('order.title.x402') },
+        { value: 'PayPal', label: this.$t('order.title.paypal') }
+      ];
+    },
+    filterQuery(): Record<string, any> {
+      const q: Record<string, any> = {
+        user_id: this.$store.getters.user?.id
+      };
+      if (this.filterState) q.state = this.filterState;
+      if (this.filterPayWay) q.pay_way = this.filterPayWay;
+      if (this.createdAtRange?.[0]) q.created_at_from = this.createdAtRange[0];
+      if (this.createdAtRange?.[1]) q.created_at_to = this.createdAtRange[1];
+      return q;
     }
   },
   watch: {
@@ -179,14 +341,59 @@ export default defineComponent({
   },
   mounted() {
     this.onFetchData();
+    this.onFetchSummary();
   },
   methods: {
     getPriceString,
+    stateTagType(state: string) {
+      if (state === OrderState.FINISHED || state === OrderState.PAID) return 'success';
+      if (state === OrderState.EXPIRED || state === OrderState.FAILED) return 'danger';
+      if (state === OrderState.REFUNDED) return 'warning';
+      return 'info';
+    },
+    stateLabel(state: string) {
+      const map: Record<string, string> = {
+        [OrderState.PENDING]: this.$t('order.state.pending'),
+        [OrderState.PAID]: this.$t('order.state.paid'),
+        [OrderState.FINISHED]: this.$t('order.state.finished'),
+        [OrderState.EXPIRED]: this.$t('order.state.expired'),
+        [OrderState.FAILED]: this.$t('order.state.failed'),
+        [OrderState.REFUNDED]: this.$t('order.state.refunded')
+      };
+      return map[state] || state;
+    },
+    isPendingAction(state: string) {
+      return (
+        state !== OrderState.PAID &&
+        state !== OrderState.FINISHED &&
+        state !== OrderState.EXPIRED &&
+        state !== OrderState.FAILED &&
+        state !== OrderState.REFUNDED
+      );
+    },
+    goToDetail(id: string) {
+      this.$router.push({ name: 'console-order-detail', params: { id } });
+    },
+    async onFilterChange() {
+      await this.$router.push({
+        name: this.$route.name?.toString(),
+        query: {
+          page: 1,
+          ...(this.filterState ? { state: this.filterState } : {}),
+          ...(this.filterPayWay ? { pay_way: this.filterPayWay } : {}),
+          ...(this.createdAtRange?.[0] ? { created_at_from: this.createdAtRange[0].toISOString() } : {}),
+          ...(this.createdAtRange?.[1] ? { created_at_to: this.createdAtRange[1].toISOString() } : {})
+        }
+      });
+      this.onFetchData();
+      this.onFetchSummary();
+    },
     onPageChange(page: number) {
       this.$router.push({
         name: this.$route.name?.toString(),
         query: {
-          page: page
+          ...this.$route.query,
+          page
         }
       });
     },
@@ -197,17 +404,96 @@ export default defineComponent({
           ordering: '-created_at',
           limit: this.limit,
           offset: (this.page - 1) * this.limit,
-          user_id: this.$store.getters.user.id
+          ...this.filterQuery
         })
-        .then(({ data: data }: { data: IOrderListResponse }) => {
+        .then(({ data }: { data: IOrderListResponse }) => {
           this.orders = data.items;
-          this.loading = false;
           this.total = data.count;
         })
-        .catch(() => {
+        .catch(() => {})
+        .finally(() => {
           this.loading = false;
+        });
+    },
+    onFetchSummary() {
+      this.summaryLoading = true;
+      orderOperator
+        .getSummary(this.filterQuery)
+        .then(({ data }: { data: IOrderSummary }) => {
+          this.summary = data;
+        })
+        .catch(() => {
+          this.summary = { ...DEFAULT_SUMMARY };
+        })
+        .finally(() => {
+          this.summaryLoading = false;
+        });
+    },
+    onExport() {
+      this.exporting = true;
+      orderOperator
+        .exportCsv(this.filterQuery)
+        .then(({ data }: { data: Blob }) => {
+          const url = window.URL.createObjectURL(data);
+          const a = document.createElement('a');
+          a.href = url;
+          a.download = 'orders.csv';
+          a.click();
+          window.URL.revokeObjectURL(url);
+        })
+        .catch(() => {})
+        .finally(() => {
+          this.exporting = false;
         });
     }
   }
 });
 </script>
+
+<style lang="scss" scoped>
+.title {
+  font-size: 20px;
+  font-weight: bold;
+  margin-bottom: 16px;
+  color: var(--el-text-color-primary);
+}
+
+.item-mini {
+  .card-content {
+    display: flex;
+    flex-direction: column;
+  }
+  .icon-wrapper {
+    height: 36px;
+    width: 36px;
+    line-height: 36px;
+    border-radius: 50%;
+    background-color: var(--el-bg-color-page);
+    text-align: center;
+    margin-bottom: 8px;
+    .icon {
+      color: var(--el-color-primary);
+    }
+  }
+  .value {
+    font-weight: 600;
+    font-size: 24px;
+    color: var(--el-text-color-primary);
+  }
+  .description {
+    color: var(--el-text-color-regular);
+    font-size: 13px;
+  }
+}
+
+.filter-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.filter-select {
+  width: 160px;
+}
+</style>

--- a/src/plugins/font-awesome.ts
+++ b/src/plugins/font-awesome.ts
@@ -128,7 +128,10 @@ import {
   faUserTie as faSolidUserTie,
   faCode as faSolidCode,
   faMicrophoneLines as faSolidMicrophoneLines,
-  faBookOpen as faSolidBookOpen
+  faBookOpen as faSolidBookOpen,
+  faReceipt as faSolidReceipt,
+  faDollarSign as faSolidDollarSign,
+  faFileExport as faSolidFileExport
 } from '@fortawesome/free-solid-svg-icons';
 // add icons
 library.add(faSolidEllipsis);
@@ -256,3 +259,6 @@ library.add(faSolidPersonRunning);
 library.add(faSolidUserTie);
 library.add(faSolidMicrophoneLines);
 library.add(faSolidBookOpen);
+library.add(faSolidReceipt);
+library.add(faSolidDollarSign);
+library.add(faSolidFileExport);


### PR DESCRIPTION
## What

Bring the console order list (`/console/order/list`) to parity with PlatformFrontend's order list page.

### Added

- **4 summary cards** above the table — total orders / total spent / finished orders / pending orders — driven by `GET /orders/summary/`.
- **State + pay-way + date-range filters** with the shared usage shortcuts (today / last 7 days / last 1 month).
- **Export CSV** button — calls `GET /orders/export/`, downloads as `orders-YYYY-MM-DD.csv`.
- New `IOrderSummary` type and `getSummary()` + `exportCsv()` methods on `OrderService`.
- 3 new FontAwesome icons registered: `fa-receipt`, `fa-dollar-sign`, `fa-file-export`.

### i18n

Added 7 new keys under `order` namespace: `title.totalOrders`, `title.totalSpent`, `title.finishedOrders`, `title.pendingOrders`, `button.export`, `field.allStates`, `field.allPayWays`. zh-CN / zh-TW / en are filled in this PR; the 15 other locales seed from English and will be translated by the existing `translate.py` CronJob.

## Why

Part of the Nexior↔PlatformFrontend parity sweep. Users on the consumer app need the same financial overview features developers have on the platform portal.

## Backend dependencies

- `GET /orders/summary/` — implemented in `PlatformBackend/app/views/order.py` (line 580).
- `GET /orders/export/` — implemented in `PlatformBackend/app/views/order.py` (line 608).

## Verification

- `npm run test:run` — 141 tests pass
- `npm run build` — succeeds (vue-tsc + vite)
- `python3 scripts/check_i18n_coverage.py` — all 17 non-base locales match zh-CN keys
- `npm run lint` — no new errors (14 pre-existing prettier-only issues unrelated to this PR)

## Screenshots

_(to be added after deploy to staging)_