### PR TITLE
feat(order-detail): align Console order detail with PlatformFrontend

### DIFF
--- a/change/@acedatacloud-nexior-order-detail-align.json
+++ b/change/@acedatacloud-nexior-order-detail-align.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Align Console order detail with PlatformFrontend: tag-styled pay_way display and credits amount row.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/i18n/ar/order.json
+++ b/src/i18n/ar/order.json
@@ -519,6 +519,10 @@
     "message": "اضغط مطولا على رمز الاستجابة السريعة ادناه واختر 'التعرف على رمز QR' لاكمال الدفع في WeChat.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   },
+  "message.creditsValue": {
+    "message": "{value} رصيد",
+    "description": "Display of credits amount for an order, e.g. '5 credits'. {value} is the formatted credit number."
+  },
   "title.totalOrders": {
     "message": "Total Orders",
     "description": "Summary card: total number of orders matching the current filters."

--- a/src/i18n/de/order.json
+++ b/src/i18n/de/order.json
@@ -519,6 +519,10 @@
     "message": "Halten Sie den QR-Code unten gedrueckt und waehlen Sie 'QR-Code erkennen', um die Zahlung in WeChat abzuschliessen.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   },
+  "message.creditsValue": {
+    "message": "{value} Credits",
+    "description": "Display of credits amount for an order, e.g. '5 credits'. {value} is the formatted credit number."
+  },
   "title.totalOrders": {
     "message": "Total Orders",
     "description": "Summary card: total number of orders matching the current filters."

--- a/src/i18n/el/order.json
+++ b/src/i18n/el/order.json
@@ -519,6 +519,10 @@
     "message": "Πατήστε παρατεταμένα τον παρακάτω κωδικό QR και επιλέξτε 'Αναγνώριση κωδικού QR' για να ολοκληρώσετε την πληρωμή στο WeChat.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   },
+  "message.creditsValue": {
+    "message": "{value} πιστώσεις",
+    "description": "Display of credits amount for an order, e.g. '5 credits'. {value} is the formatted credit number."
+  },
   "title.totalOrders": {
     "message": "Total Orders",
     "description": "Summary card: total number of orders matching the current filters."

--- a/src/i18n/en/order.json
+++ b/src/i18n/en/order.json
@@ -519,6 +519,10 @@
     "message": "Long-press the QR code below and tap 'Recognise QR code' to complete payment in WeChat.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   },
+  "message.creditsValue": {
+    "message": "{value} credits",
+    "description": "Display of credits amount for an order, e.g. '5 credits'. {value} is the formatted credit number."
+  },
   "title.totalOrders": {
     "message": "Total Orders",
     "description": "Summary card: total number of orders matching the current filters."

--- a/src/i18n/es/order.json
+++ b/src/i18n/es/order.json
@@ -519,6 +519,10 @@
     "message": "Mantenga pulsado el siguiente codigo QR y toque 'Reconocer codigo QR' para completar el pago en WeChat.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   },
+  "message.creditsValue": {
+    "message": "{value} créditos",
+    "description": "Display of credits amount for an order, e.g. '5 credits'. {value} is the formatted credit number."
+  },
   "title.totalOrders": {
     "message": "Total Orders",
     "description": "Summary card: total number of orders matching the current filters."

--- a/src/i18n/fi/order.json
+++ b/src/i18n/fi/order.json
@@ -519,6 +519,10 @@
     "message": "Paina alla olevaa QR-koodia pitkaan ja valitse 'Tunnista QR-koodi' suorittaaksesi maksun WeChatissa.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   },
+  "message.creditsValue": {
+    "message": "{value} krediittiä",
+    "description": "Display of credits amount for an order, e.g. '5 credits'. {value} is the formatted credit number."
+  },
   "title.totalOrders": {
     "message": "Total Orders",
     "description": "Summary card: total number of orders matching the current filters."

--- a/src/i18n/fr/order.json
+++ b/src/i18n/fr/order.json
@@ -519,6 +519,10 @@
     "message": "Appuyez longuement sur le QR code ci-dessous et choisissez 'Reconnaitre le QR code' pour finaliser le paiement dans WeChat.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   },
+  "message.creditsValue": {
+    "message": "{value} crédits",
+    "description": "Display of credits amount for an order, e.g. '5 credits'. {value} is the formatted credit number."
+  },
   "title.totalOrders": {
     "message": "Total Orders",
     "description": "Summary card: total number of orders matching the current filters."

--- a/src/i18n/it/order.json
+++ b/src/i18n/it/order.json
@@ -519,6 +519,10 @@
     "message": "Tieni premuto il codice QR qui sotto e seleziona 'Riconosci codice QR' per completare il pagamento in WeChat.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   },
+  "message.creditsValue": {
+    "message": "{value} crediti",
+    "description": "Display of credits amount for an order, e.g. '5 credits'. {value} is the formatted credit number."
+  },
   "title.totalOrders": {
     "message": "Total Orders",
     "description": "Summary card: total number of orders matching the current filters."

--- a/src/i18n/ja/order.json
+++ b/src/i18n/ja/order.json
@@ -519,6 +519,10 @@
     "message": "下のQRコードを長押しし、「QRコードを認識」を選択してWeChatで支払いを完了してください。",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   },
+  "message.creditsValue": {
+    "message": "{value} クレジット",
+    "description": "Display of credits amount for an order, e.g. '5 credits'. {value} is the formatted credit number."
+  },
   "title.totalOrders": {
     "message": "Total Orders",
     "description": "Summary card: total number of orders matching the current filters."

--- a/src/i18n/ko/order.json
+++ b/src/i18n/ko/order.json
@@ -519,6 +519,10 @@
     "message": "아래 QR 코드를 길게 눌러 'QR 코드 인식'을 선택해 WeChat에서 결제를 완료하세요.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   },
+  "message.creditsValue": {
+    "message": "{value} 크레딧",
+    "description": "Display of credits amount for an order, e.g. '5 credits'. {value} is the formatted credit number."
+  },
   "title.totalOrders": {
     "message": "Total Orders",
     "description": "Summary card: total number of orders matching the current filters."

--- a/src/i18n/pl/order.json
+++ b/src/i18n/pl/order.json
@@ -519,6 +519,10 @@
     "message": "Przytrzymaj ponizszy kod QR i wybierz 'Rozpoznaj kod QR', aby dokonczyc platnosc w WeChat.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   },
+  "message.creditsValue": {
+    "message": "{value} kredytów",
+    "description": "Display of credits amount for an order, e.g. '5 credits'. {value} is the formatted credit number."
+  },
   "title.totalOrders": {
     "message": "Total Orders",
     "description": "Summary card: total number of orders matching the current filters."

--- a/src/i18n/pt/order.json
+++ b/src/i18n/pt/order.json
@@ -519,6 +519,10 @@
     "message": "Mantenha pressionado o codigo QR abaixo e selecione 'Reconhecer codigo QR' para concluir o pagamento no WeChat.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   },
+  "message.creditsValue": {
+    "message": "{value} créditos",
+    "description": "Display of credits amount for an order, e.g. '5 credits'. {value} is the formatted credit number."
+  },
   "title.totalOrders": {
     "message": "Total Orders",
     "description": "Summary card: total number of orders matching the current filters."

--- a/src/i18n/ru/order.json
+++ b/src/i18n/ru/order.json
@@ -519,6 +519,10 @@
     "message": "Удерживайте QR-код ниже и выберите 'Распознать QR-код', чтобы завершить оплату в WeChat.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   },
+  "message.creditsValue": {
+    "message": "{value} кредитов",
+    "description": "Display of credits amount for an order, e.g. '5 credits'. {value} is the formatted credit number."
+  },
   "title.totalOrders": {
     "message": "Total Orders",
     "description": "Summary card: total number of orders matching the current filters."

--- a/src/i18n/sr/order.json
+++ b/src/i18n/sr/order.json
@@ -519,6 +519,10 @@
     "message": "Drzite pritisnutim QR kod ispod i izaberite 'Prepoznaj QR kod' da biste zavrsili placanje u WeChat-u.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   },
+  "message.creditsValue": {
+    "message": "{value} kredita",
+    "description": "Display of credits amount for an order, e.g. '5 credits'. {value} is the formatted credit number."
+  },
   "title.totalOrders": {
     "message": "Total Orders",
     "description": "Summary card: total number of orders matching the current filters."

--- a/src/i18n/sv/order.json
+++ b/src/i18n/sv/order.json
@@ -519,6 +519,10 @@
     "message": "Hall in QR-koden nedan och valj 'Identifiera QR-kod' for att slutfora betalningen i WeChat.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   },
+  "message.creditsValue": {
+    "message": "{value} krediter",
+    "description": "Display of credits amount for an order, e.g. '5 credits'. {value} is the formatted credit number."
+  },
   "title.totalOrders": {
     "message": "Total Orders",
     "description": "Summary card: total number of orders matching the current filters."

--- a/src/i18n/uk/order.json
+++ b/src/i18n/uk/order.json
@@ -519,6 +519,10 @@
     "message": "Утримуйте QR-код нижче та виберіть 'Розпізнати QR-код', щоб завершити оплату в WeChat.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   },
+  "message.creditsValue": {
+    "message": "{value} кредитів",
+    "description": "Display of credits amount for an order, e.g. '5 credits'. {value} is the formatted credit number."
+  },
   "title.totalOrders": {
     "message": "Total Orders",
     "description": "Summary card: total number of orders matching the current filters."

--- a/src/i18n/zh-CN/order.json
+++ b/src/i18n/zh-CN/order.json
@@ -519,6 +519,10 @@
     "message": "请长按下方二维码识别图中二维码完成支付。",
     "description": "手机微信内部浏览器打开订单页时，二维码上方的引导文案。用户长按二维码即可识别并完成支付，无需跳出微信。"
   },
+  "message.creditsValue": {
+    "message": "{value} 积分",
+    "description": "Display of credits amount for an order, e.g. '5 credits'. {value} is the formatted credit number."
+  },
   "title.totalOrders": {
     "message": "订单总数",
     "description": "汇总卡片：当前筛选条件下的订单总数。"

--- a/src/i18n/zh-TW/order.json
+++ b/src/i18n/zh-TW/order.json
@@ -519,6 +519,10 @@
     "message": "請長按下方二維碼，識別圖中二維碼完成支付。",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   },
+  "message.creditsValue": {
+    "message": "{value} 積分",
+    "description": "Display of credits amount for an order, e.g. '5 credits'. {value} is the formatted credit number."
+  },
   "title.totalOrders": {
     "message": "訂單總數",
     "description": "彙總卡片：目前篩選條件下的訂單總數。"

--- a/src/pages/console/order/Detail.vue
+++ b/src/pages/console/order/Detail.vue
@@ -27,11 +27,12 @@
                       {{ order?.application?.service?.title }}
                     </el-descriptions-item>
                     <el-descriptions-item v-if="order?.pay_way" :label="$t('order.field.payWay')">
-                      <span v-if="order?.pay_way === PayWay.WechatPay">{{ $t('order.title.wechatPay') }}</span>
-                      <span v-else-if="order?.pay_way === PayWay.Stripe">{{ $t('order.title.stripe') }}</span>
-                      <span v-else-if="order?.pay_way === PayWay.AliPay">{{ $t('order.title.aliPay') }}</span>
-                      <span v-else-if="order?.pay_way === PayWay.X402">{{ $t('order.title.x402') }}</span>
-                      <span v-else-if="order?.pay_way === PayWay.PayPal">{{ $t('order.title.paypal') }}</span>
+                      <el-tag :type="payWayTagType(order.pay_way)" effect="dark" round size="small">
+                        {{ payWayLabel(order.pay_way) }}
+                      </el-tag>
+                    </el-descriptions-item>
+                    <el-descriptions-item v-if="order?.amount && order.amount > 0" :label="$t('order.field.amount')">
+                      {{ $t('order.message.creditsValue', { value: formatCredits(order.amount) }) }}
                     </el-descriptions-item>
                     <el-descriptions-item :label="$t('order.field.createdAt')">
                       {{ $dayjs.format(order?.created_at) }}
@@ -539,6 +540,29 @@ export default defineComponent({
   },
   methods: {
     getPriceString,
+    formatCredits(value: number): string {
+      if (!Number.isFinite(value)) return '0';
+      return Number.isInteger(value) ? String(value) : value.toFixed(2);
+    },
+    payWayLabel(payWay: string): string {
+      switch (payWay) {
+        case PayWay.WechatPay:
+          return this.$t('order.title.wechatPay') as string;
+        case PayWay.Stripe:
+          return this.$t('order.title.stripe') as string;
+        case PayWay.AliPay:
+          return this.$t('order.title.aliPay') as string;
+        case PayWay.X402:
+          return this.$t('order.title.x402') as string;
+        case PayWay.PayPal:
+          return this.$t('order.title.paypal') as string;
+        default:
+          return payWay;
+      }
+    },
+    payWayTagType(_payWay: string): 'success' | 'info' {
+      return 'info';
+    },
     startOrderPolling(delay = 0) {
       this.stopOrderPolling();
       const poll = async () => {


### PR DESCRIPTION
## Summary

Brings Nexior's Console order detail (`/console/orders/:id`) into visual parity with PlatformFrontend by adopting two presentational patterns from PF's `order/Detail.vue`:

1. **Tag-styled pay_way display** — replaces the five-arm `<span v-if/v-else-if>` chain with a single `<el-tag>` rendered via two tiny helpers (`payWayLabel()` + `payWayTagType()`).
2. **Credits amount row** — adds a new `order.field.amount` row that renders `order.amount` as `{value} credits` (i18n via `order.message.creditsValue`) when present.

Nexior-specific behavior is **preserved untouched**:
- `showPayment` iOS gating
- Android Stripe surface hint
- `payment_success` telemetry
- `orderOperator.refresh()` polling lifecycle

## Changes

- `src/pages/console/order/Detail.vue`
  - Template: replace pay_way `<span>` chain with `<el-tag>`; add amount row
  - Methods: `formatCredits()`, `payWayLabel()`, `payWayTagType()`
- `src/i18n/<18 locales>/order.json`: add `message.creditsValue` (`{value} 积分` / `{value} credits` / …) in all 18 locales
- `change/`: beachball patch change file

## Verification

```
npm run lint        ✅
npm run test:run    ✅ 141/141 tests pass
npm run build       ✅ vue-tsc + vite build succeed
python3 scripts/check_i18n_coverage.py   ✅ 17 locales × 39 namespaces match zh-CN
```

PR #2 in the Nexior-vs-PlatformFrontend parity series (after #834).