### PR TITLE
feat(public-pay): anonymous order pay page at /orders/:id

### DIFF
--- a/change/@acedatacloud-nexior-public-order-pay.json
+++ b/change/@acedatacloud-nexior-public-order-pay.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add anonymous (no-login) order pay page at /orders/:id — parity with PlatformFrontend.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/order/public/AliPay.vue
+++ b/src/components/order/public/AliPay.vue
@@ -1,0 +1,47 @@
+<template>
+  <el-dialog
+    :model-value="visible"
+    :title="$t('application.title.buyService')"
+    width="500px"
+    center
+    @close="$emit('hide')"
+  >
+    <p class="text-center">
+      {{ $t('order.message.buyInExternalUrl') }}
+    </p>
+  </el-dialog>
+</template>
+
+<script lang="ts">
+import { IOrder } from '@/models';
+import { defineComponent } from 'vue';
+import { ElDialog } from 'element-plus';
+
+export default defineComponent({
+  name: 'PublicAlipayPayDialog',
+  components: {
+    ElDialog
+  },
+  props: {
+    order: {
+      type: Object as () => IOrder,
+      required: true
+    },
+    visible: {
+      type: Boolean,
+      required: false,
+      default: false
+    }
+  },
+  emits: ['hide'],
+  watch: {
+    visible: {
+      handler(val) {
+        if (val && this.order?.pay_url) {
+          window.open(this.order.pay_url, '_blank');
+        }
+      }
+    }
+  }
+});
+</script>

--- a/src/components/order/public/StripePay.vue
+++ b/src/components/order/public/StripePay.vue
@@ -1,0 +1,47 @@
+<template>
+  <el-dialog
+    :model-value="visible"
+    :title="$t('application.title.buyService')"
+    width="500px"
+    center
+    @close="$emit('hide')"
+  >
+    <p class="text-center">
+      {{ $t('order.message.buyInExternalUrl') }}
+    </p>
+  </el-dialog>
+</template>
+
+<script lang="ts">
+import { IOrder } from '@/models';
+import { defineComponent } from 'vue';
+import { ElDialog } from 'element-plus';
+
+export default defineComponent({
+  name: 'PublicStripePayDialog',
+  components: {
+    ElDialog
+  },
+  props: {
+    order: {
+      type: Object as () => IOrder,
+      required: true
+    },
+    visible: {
+      type: Boolean,
+      required: false,
+      default: false
+    }
+  },
+  emits: ['hide'],
+  watch: {
+    visible: {
+      handler(val) {
+        if (val && this.order?.pay_url) {
+          window.open(this.order.pay_url, '_blank');
+        }
+      }
+    }
+  }
+});
+</script>

--- a/src/components/order/public/WechatPay.vue
+++ b/src/components/order/public/WechatPay.vue
@@ -1,0 +1,143 @@
+<template>
+  <el-dialog
+    :model-value="visible"
+    :title="$t('application.title.buyService')"
+    :width="dialogWidth"
+    center
+    @close="$emit('hide')"
+  >
+    <div v-if="isMobileOutsideWechat" class="wechat-pay-guide text-center py-[20px] px-[10px]">
+      <p class="text-[14px] mb-4 leading-relaxed">
+        {{ $t('order.message.wechatPayMobileGuide') }}
+      </p>
+      <el-button type="success" size="large" round class="w-[220px]" @click="onCopyLink">
+        {{ copied ? $t('common.message.copied') : $t('order.button.copyPayLink') }}
+      </el-button>
+      <p class="text-[12px] text-gray-500 mt-3 leading-relaxed">
+        {{ $t('order.message.wechatPayMobileHint') }}
+      </p>
+    </div>
+
+    <div v-else-if="isMobileInsideWechat" class="wechat-pay-longpress text-center py-[20px] px-[10px]">
+      <p class="text-[14px] mb-4 leading-relaxed">
+        {{ $t('order.message.wechatPayLongPressTip') }}
+      </p>
+      <qr-code
+        v-if="order?.pay_url"
+        :value="order?.pay_url"
+        :size="240"
+        class="qrcode mx-auto"
+        type="image/png"
+        :color="{ dark: '#000000', light: '#ffffff' }"
+      />
+    </div>
+
+    <el-row v-else class="paycodes py-[30px] w-[500px] mx-auto">
+      <el-col :span="12">
+        <div class="paycode wechat">
+          <qr-code
+            v-if="order?.pay_url"
+            :value="order?.pay_url"
+            :size="200"
+            class="qrcode m-auto w-[200px] h-[200px]"
+            type="image/png"
+            :color="{ dark: '#000000', light: '#ffffff' }"
+          />
+          <p
+            class="help-text block bg-[#00c800] text-white text-[14px] h-[35px] w-[240px] text-center leading-[35px] mt-[10px] mx-auto"
+          >
+            {{ $t('order.message.wechatPayHelp') }}
+          </p>
+        </div>
+      </el-col>
+      <el-col :span="12">
+        <div class="help-img">
+          <img src="https://midas.gtimg.cn/enterprise/images/ep_sys_wx_tip.jpg" />
+        </div>
+      </el-col>
+    </el-row>
+  </el-dialog>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElDialog, ElRow, ElCol, ElButton, ElMessage } from 'element-plus';
+import QrCode from 'vue-qrcode';
+import copy from 'copy-to-clipboard';
+import { IOrder } from '@/models';
+import { isInWeChat, isMobileBrowser } from '@/utils/wechat';
+
+interface IData {
+  copied: boolean;
+  copiedTimer: number | undefined;
+}
+
+export default defineComponent({
+  name: 'PublicWechatPayDialog',
+  components: {
+    ElDialog,
+    ElButton,
+    QrCode,
+    ElRow,
+    ElCol
+  },
+  props: {
+    order: {
+      type: Object as () => IOrder,
+      required: true
+    },
+    visible: {
+      type: Boolean,
+      required: false,
+      default: false
+    }
+  },
+  emits: ['hide'],
+  data(): IData {
+    return {
+      copied: false,
+      copiedTimer: undefined
+    };
+  },
+  computed: {
+    isMobileOutsideWechat(): boolean {
+      return isMobileBrowser() && !isInWeChat();
+    },
+    isMobileInsideWechat(): boolean {
+      return isMobileBrowser() && isInWeChat();
+    },
+    dialogWidth(): string {
+      if (this.isMobileOutsideWechat || this.isMobileInsideWechat) {
+        return '90%';
+      }
+      return '500px';
+    }
+  },
+  unmounted() {
+    if (this.copiedTimer) {
+      clearTimeout(this.copiedTimer);
+    }
+  },
+  methods: {
+    async onCopyLink() {
+      const url = typeof window !== 'undefined' ? window.location.href : '';
+      if (!url) return;
+      let ok = false;
+      try {
+        ok = await copy(url, { debug: false });
+      } catch {
+        ok = false;
+      }
+      if (ok) {
+        this.copied = true;
+        if (this.copiedTimer) clearTimeout(this.copiedTimer);
+        this.copiedTimer = window.setTimeout(() => {
+          this.copied = false;
+        }, 2000);
+      } else {
+        ElMessage.error(String(this.$t('common.message.copyFailed') || 'Copy failed'));
+      }
+    }
+  }
+});
+</script>

--- a/src/i18n/ar/order.json
+++ b/src/i18n/ar/order.json
@@ -383,6 +383,10 @@
     "message": "محفظة Solana",
     "description": "عنوان بطاقة الاتصال بمحفظة Solana."
   },
+  "message.publicPayNotFound": {
+    "message": "الطلب غير موجود أو انتهت صلاحيته.",
+    "description": "Shown on public pay page when the order GET returns 404."
+  },
   "message.x402WalletStatusDetected": {
     "message": "تم الكشف",
     "description": "تسمية حالة المحفظة التي تم الكشف عنها/تثبيتها."

--- a/src/i18n/de/order.json
+++ b/src/i18n/de/order.json
@@ -383,6 +383,10 @@
     "message": "Solana Brieftasche",
     "description": "Titel der Solana Brieftaschenverbindungskarte."
   },
+  "message.publicPayNotFound": {
+    "message": "Bestellung nicht gefunden oder abgelaufen.",
+    "description": "Shown on public pay page when the order GET returns 404."
+  },
   "message.x402WalletStatusDetected": {
     "message": "Erkannt",
     "description": "Statuslabel für erkannte/installierte Brieftaschen."

--- a/src/i18n/el/order.json
+++ b/src/i18n/el/order.json
@@ -383,6 +383,10 @@
     "message": "Πορτοφόλι Solana",
     "description": "Τίτλος κάρτας σύνδεσης πορτοφολιού Solana."
   },
+  "message.publicPayNotFound": {
+    "message": "Η παραγγελία δεν βρέθηκε ή έχει λήξει.",
+    "description": "Shown on public pay page when the order GET returns 404."
+  },
   "message.x402WalletStatusDetected": {
     "message": "Ανιχνεύθηκε",
     "description": "Ετικέτα κατάστασης πορτοφολιού που έχει ανιχνευθεί/εγκατασταθεί."

--- a/src/i18n/en/order.json
+++ b/src/i18n/en/order.json
@@ -383,6 +383,10 @@
     "message": "Solana Wallet",
     "description": "Title for the Solana wallet connection card."
   },
+  "message.publicPayNotFound": {
+    "message": "Order not found or has expired.",
+    "description": "Shown on public pay page when the order GET returns 404."
+  },
   "message.x402WalletStatusDetected": {
     "message": "Detected",
     "description": "Label for the detected/installed wallet status."

--- a/src/i18n/es/order.json
+++ b/src/i18n/es/order.json
@@ -383,6 +383,10 @@
     "message": "Billetera Solana",
     "description": "Título de la tarjeta de conexión de la billetera Solana."
   },
+  "message.publicPayNotFound": {
+    "message": "Pedido no encontrado o caducado.",
+    "description": "Shown on public pay page when the order GET returns 404."
+  },
   "message.x402WalletStatusDetected": {
     "message": "Detectado",
     "description": "Etiqueta de estado para billeteras detectadas/instaladas."

--- a/src/i18n/fi/order.json
+++ b/src/i18n/fi/order.json
@@ -383,6 +383,10 @@
     "message": "Solana Lompakko",
     "description": "Solana lompakon yhdistämiskortin otsikko."
   },
+  "message.publicPayNotFound": {
+    "message": "Tilausta ei löytynyt tai se on vanhentunut.",
+    "description": "Shown on public pay page when the order GET returns 404."
+  },
   "message.x402WalletStatusDetected": {
     "message": "Havaittu",
     "description": "Havaittu/Asennettu lompakon tilan etiketti."

--- a/src/i18n/fr/order.json
+++ b/src/i18n/fr/order.json
@@ -383,6 +383,10 @@
     "message": "Portefeuille Solana",
     "description": "Titre de la carte de connexion du portefeuille Solana."
   },
+  "message.publicPayNotFound": {
+    "message": "Commande introuvable ou expirée.",
+    "description": "Shown on public pay page when the order GET returns 404."
+  },
   "message.x402WalletStatusDetected": {
     "message": "Détecté",
     "description": "Étiquette d'état pour un portefeuille détecté/installé."

--- a/src/i18n/it/order.json
+++ b/src/i18n/it/order.json
@@ -383,6 +383,10 @@
     "message": "Portafoglio Solana",
     "description": "Titolo della scheda di connessione del portafoglio Solana."
   },
+  "message.publicPayNotFound": {
+    "message": "Ordine non trovato o scaduto.",
+    "description": "Shown on public pay page when the order GET returns 404."
+  },
   "message.x402WalletStatusDetected": {
     "message": "Rilevato",
     "description": "Etichetta dello stato del portafoglio rilevato/installato."

--- a/src/i18n/ja/order.json
+++ b/src/i18n/ja/order.json
@@ -383,6 +383,10 @@
     "message": "Solana ウォレット",
     "description": "Solana ウォレット接続カードのタイトル。"
   },
+  "message.publicPayNotFound": {
+    "message": "注文が見つからないか期限切れです。",
+    "description": "Shown on public pay page when the order GET returns 404."
+  },
   "message.x402WalletStatusDetected": {
     "message": "検出済み",
     "description": "検出済み/インストール済みのウォレット状態ラベル。"

--- a/src/i18n/ko/order.json
+++ b/src/i18n/ko/order.json
@@ -383,6 +383,10 @@
     "message": "Solana 지갑",
     "description": "Solana 지갑 연결 카드 제목."
   },
+  "message.publicPayNotFound": {
+    "message": "주문을 찾을 수 없거나 만료되었습니다.",
+    "description": "Shown on public pay page when the order GET returns 404."
+  },
   "message.x402WalletStatusDetected": {
     "message": "감지됨",
     "description": "감지된/설치된 지갑 상태 레이블."

--- a/src/i18n/pl/order.json
+++ b/src/i18n/pl/order.json
@@ -383,6 +383,10 @@
     "message": "Portfel Solana",
     "description": "Tytuł karty połączenia portfela Solana."
   },
+  "message.publicPayNotFound": {
+    "message": "Nie znaleziono zamówienia lub jego ważność wygasła.",
+    "description": "Shown on public pay page when the order GET returns 404."
+  },
   "message.x402WalletStatusDetected": {
     "message": "Wykryto",
     "description": "Etykieta statusu portfela wykrytego/zainstalowanego."

--- a/src/i18n/pt/order.json
+++ b/src/i18n/pt/order.json
@@ -383,6 +383,10 @@
     "message": "Carteira Solana",
     "description": "Título do cartão de conexão da carteira Solana."
   },
+  "message.publicPayNotFound": {
+    "message": "Pedido não encontrado ou expirado.",
+    "description": "Shown on public pay page when the order GET returns 404."
+  },
   "message.x402WalletStatusDetected": {
     "message": "Detectado",
     "description": "Etiqueta de status para carteira detectada/instalada."

--- a/src/i18n/ru/order.json
+++ b/src/i18n/ru/order.json
@@ -383,6 +383,10 @@
     "message": "Solana Кошелек",
     "description": "Заголовок карточки подключения Solana кошелька."
   },
+  "message.publicPayNotFound": {
+    "message": "Заказ не найден или срок его действия истёк.",
+    "description": "Shown on public pay page when the order GET returns 404."
+  },
   "message.x402WalletStatusDetected": {
     "message": "Обнаружено",
     "description": "Метка статуса кошелька, который был обнаружен/установлен."

--- a/src/i18n/sr/order.json
+++ b/src/i18n/sr/order.json
@@ -383,6 +383,10 @@
     "message": "Solana novčanik",
     "description": "Naslov kartice za povezivanje Solana novčanika."
   },
+  "message.publicPayNotFound": {
+    "message": "Narudžbina nije pronađena ili je istekla.",
+    "description": "Shown on public pay page when the order GET returns 404."
+  },
   "message.x402WalletStatusDetected": {
     "message": "Otkriveno",
     "description": "Oznaka statusa za otkrivene/instalirane novčanike."

--- a/src/i18n/sv/order.json
+++ b/src/i18n/sv/order.json
@@ -383,6 +383,10 @@
     "message": "Solana Plånbok",
     "description": "Rubrik för Solana plånboksanslutningskort."
   },
+  "message.publicPayNotFound": {
+    "message": "Beställningen hittades inte eller har gått ut.",
+    "description": "Shown on public pay page when the order GET returns 404."
+  },
   "message.x402WalletStatusDetected": {
     "message": "Upptäckt",
     "description": "Statusetikett för upptäckta/installera plånböcker."

--- a/src/i18n/uk/order.json
+++ b/src/i18n/uk/order.json
@@ -383,6 +383,10 @@
     "message": "Solana гаманець",
     "description": "Заголовок картки підключення Solana гаманця."
   },
+  "message.publicPayNotFound": {
+    "message": "Замовлення не знайдено або термін його дії минув.",
+    "description": "Shown on public pay page when the order GET returns 404."
+  },
   "message.x402WalletStatusDetected": {
     "message": "Виявлено",
     "description": "Мітка статусу гаманця, що виявлений/встановлений."

--- a/src/i18n/zh-CN/order.json
+++ b/src/i18n/zh-CN/order.json
@@ -383,6 +383,10 @@
     "message": "Solana 钱包",
     "description": "Solana 钱包连接卡片标题。"
   },
+  "message.publicPayNotFound": {
+    "message": "订单不存在或已失效。",
+    "description": "Shown on public pay page when the order GET returns 404."
+  },
   "message.x402WalletStatusDetected": {
     "message": "已检测",
     "description": "已检测/已安装的钱包状态标签。"

--- a/src/i18n/zh-TW/order.json
+++ b/src/i18n/zh-TW/order.json
@@ -383,6 +383,10 @@
     "message": "Solana 錢包",
     "description": "Solana 錢包連接卡片標題。"
   },
+  "message.publicPayNotFound": {
+    "message": "訂單不存在或已失效。",
+    "description": "Shown on public pay page when the order GET returns 404."
+  },
   "message.x402WalletStatusDetected": {
     "message": "已檢測",
     "description": "已檢測/已安裝的錢包狀態標籤。"

--- a/src/pages/order/Pay.vue
+++ b/src/pages/order/Pay.vue
@@ -1,0 +1,383 @@
+<template>
+  <el-row class="wrapper">
+    <el-col :span="24">
+      <el-row>
+        <el-col :span="24">
+          <h2 class="title">{{ $t('order.title.info') }}</h2>
+        </el-col>
+      </el-row>
+      <el-row class="panel">
+        <el-col :span="24">
+          <el-card shadow="hover">
+            <el-row>
+              <el-col :xs="{ span: 22, offset: 1 }" :sm="{ span: 16, offset: 4 }">
+                <div v-if="loading" class="pt-5">
+                  <el-skeleton animated />
+                </div>
+                <div v-else-if="!order" class="pt-10 text-center">
+                  <el-alert :title="$t('order.message.publicPayNotFound')" type="error" show-icon :closable="false" />
+                </div>
+                <div v-else class="order">
+                  <el-descriptions :column="1">
+                    <el-descriptions-item :label="$t('order.field.id')">
+                      <span>{{ order.id }} </span>
+                      <copy-to-clipboard v-if="order.id" :content="order.id" class="inline-block" />
+                    </el-descriptions-item>
+                    <el-descriptions-item :label="$t('order.field.description')">
+                      {{ order.description }}
+                    </el-descriptions-item>
+                    <el-descriptions-item v-if="order.pay_way" :label="$t('order.field.payWay')">
+                      <el-tag type="info" effect="dark" round size="small">
+                        {{ payWayLabel(order.pay_way) }}
+                      </el-tag>
+                    </el-descriptions-item>
+                    <el-descriptions-item :label="$t('order.field.createdAt')">
+                      {{ $dayjs.format(order.created_at || '') }}
+                    </el-descriptions-item>
+                    <el-descriptions-item :label="$t('order.field.price')">
+                      <span v-if="order.price && order.price > 0" class="price current unfree">
+                        {{ getPriceString({ value: order.price }) }}
+                      </span>
+                      <span v-else class="price free"> {{ $t('order.message.free') }} </span>
+                    </el-descriptions-item>
+                  </el-descriptions>
+                </div>
+              </el-col>
+            </el-row>
+            <el-row v-if="order?.state === OrderState.PAID || order?.state === OrderState.FINISHED" class="mb-5">
+              <el-col :xs="{ span: 22, offset: 1 }" :sm="{ span: 16, offset: 4 }">
+                <el-divider border-style="dashed" />
+                <el-alert :title="$t('order.message.paidSuccessfully')" type="success" show-icon :closable="false" />
+              </el-col>
+            </el-row>
+            <el-row v-if="order?.state === OrderState.EXPIRED" class="mb-5">
+              <el-col :xs="{ span: 22, offset: 1 }" :sm="{ span: 16, offset: 4 }">
+                <el-divider border-style="dashed" />
+                <el-alert :title="$t('order.message.orderExpired')" type="error" show-icon :closable="false" />
+              </el-col>
+            </el-row>
+            <el-row v-if="order?.state === OrderState.FAILED" class="mb-5">
+              <el-col :xs="{ span: 22, offset: 1 }" :sm="{ span: 16, offset: 4 }">
+                <el-divider border-style="dashed" />
+                <el-alert :title="$t('order.state.failed')" type="error" show-icon :closable="false" />
+              </el-col>
+            </el-row>
+            <el-row v-if="order?.state === OrderState.PENDING">
+              <el-col :xs="{ span: 22, offset: 1 }" :sm="{ span: 16, offset: 4 }">
+                <el-divider border-style="dashed" />
+                <div v-if="!order.pay_way && order.price && order.price > 0" class="payways mb-6">
+                  <div
+                    :class="{ payway: true, wechatpay: true, active: payWay === PayWay.WechatPay }"
+                    @click="payWay = PayWay.WechatPay"
+                  >
+                    <span class="payicon wechatpay"></span>
+                    <span class="payname">{{ $t('order.title.wechatPay') }}</span>
+                  </div>
+                  <div
+                    :class="{ payway: true, alipay: true, active: payWay === PayWay.AliPay }"
+                    @click="payWay = PayWay.AliPay"
+                  >
+                    <span class="payicon alipay"></span>
+                    <span class="payname">{{ $t('order.title.aliPay') }}</span>
+                  </div>
+                  <div
+                    :class="{ payway: true, stripe: true, active: payWay === PayWay.Stripe }"
+                    @click="payWay = PayWay.Stripe"
+                  >
+                    <span class="payicon stripe"></span>
+                    <span class="payname">{{ $t('order.title.stripe') }}</span>
+                  </div>
+                </div>
+                <div v-if="!order.pay_way">
+                  <el-button :loading="prepaying" round type="primary" size="large" class="btn-pay" @click="onPay">
+                    {{ $t('common.button.pay') }}
+                  </el-button>
+                </div>
+                <div v-else>
+                  <el-button type="primary" round size="large" class="btn-repay" @click="onRepay">
+                    {{ $t('common.button.repay') }}
+                  </el-button>
+                </div>
+              </el-col>
+            </el-row>
+          </el-card>
+        </el-col>
+      </el-row>
+    </el-col>
+  </el-row>
+  <public-wechat-pay
+    v-if="order && payWay === PayWay.WechatPay"
+    :order="order"
+    :visible="paying"
+    @hide="paying = false"
+  />
+  <public-stripe-pay v-if="order && payWay === PayWay.Stripe" :order="order" :visible="paying" @hide="paying = false" />
+  <public-alipay-pay v-if="order && payWay === PayWay.AliPay" :order="order" :visible="paying" @hide="paying = false" />
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { orderOperator } from '@/operators';
+import { IOrder, IOrderDetailResponse, OrderState } from '@/models';
+import {
+  ElRow,
+  ElCol,
+  ElCard,
+  ElSkeleton,
+  ElDivider,
+  ElAlert,
+  ElDescriptions,
+  ElDescriptionsItem,
+  ElButton,
+  ElTag
+} from 'element-plus';
+import PublicWechatPay from '@/components/order/public/WechatPay.vue';
+import PublicStripePay from '@/components/order/public/StripePay.vue';
+import PublicAlipayPay from '@/components/order/public/AliPay.vue';
+import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
+import { getPriceString } from '@/utils';
+
+// Polls the AllowAny GET /orders/<id> endpoint — POST /orders/<id>/refresh/
+// is IsAuthenticated and would 401 here.
+const POLL_INTERVAL_MS = 7000;
+const POLL_INITIAL_DELAY_MS = 2000;
+
+// Mirrors PlatformBackend's ANON_ALLOWED_PAY_WAYS. X402/PayPal need a
+// request.user the anonymous flow can't supply and would 403 server-side.
+enum PayWay {
+  WechatPay = 'WechatPay',
+  Stripe = 'Stripe',
+  AliPay = 'AliPay'
+}
+
+interface IData {
+  PayWay: typeof PayWay;
+  OrderState: typeof OrderState;
+  payWay: PayWay;
+  order: IOrder | undefined;
+  loading: boolean;
+  paying: boolean;
+  prepaying: boolean;
+}
+
+export default defineComponent({
+  name: 'OrderPublicPay',
+  components: {
+    ElButton,
+    ElRow,
+    ElCol,
+    ElCard,
+    ElSkeleton,
+    ElDivider,
+    ElAlert,
+    ElDescriptions,
+    ElDescriptionsItem,
+    ElTag,
+    PublicWechatPay,
+    PublicStripePay,
+    PublicAlipayPay,
+    CopyToClipboard
+  },
+  data(): IData {
+    return {
+      PayWay,
+      OrderState,
+      payWay: PayWay.WechatPay,
+      order: undefined,
+      loading: false,
+      paying: false,
+      prepaying: false
+    };
+  },
+  computed: {
+    id(): string {
+      return this.$route.params?.id?.toString() ?? '';
+    }
+  },
+  watch: {
+    paying(val: boolean) {
+      if (val) this.startOrderPolling(POLL_INITIAL_DELAY_MS);
+      else this.stopOrderPolling();
+    }
+  },
+  created() {
+    (this as any)._orderRefreshTimer = undefined;
+  },
+  mounted() {
+    this.onFetchData();
+  },
+  beforeUnmount() {
+    this.stopOrderPolling();
+  },
+  methods: {
+    getPriceString,
+    payWayLabel(payWay: string): string {
+      const map: Record<string, string> = {
+        WechatPay: this.$t('order.title.wechatPay') as string,
+        Stripe: this.$t('order.title.stripe') as string,
+        AliPay: this.$t('order.title.aliPay') as string
+      };
+      return map[payWay] || payWay;
+    },
+    onFetchData() {
+      if (!this.id) return;
+      this.loading = true;
+      orderOperator
+        .get(this.id)
+        .then(({ data }: { data: IOrderDetailResponse }) => {
+          this.order = data;
+          if (data?.pay_way && (data.pay_way as any) in PayWay) {
+            this.payWay = data.pay_way as PayWay;
+          }
+          this.loading = false;
+        })
+        .catch(() => {
+          this.order = undefined;
+          this.loading = false;
+        });
+    },
+    startOrderPolling(delay = 0) {
+      this.stopOrderPolling();
+      const poll = async () => {
+        try {
+          const { data } = await orderOperator.get(this.id);
+          this.order = data;
+          if (
+            data?.state === OrderState.PAID ||
+            data?.state === OrderState.FINISHED ||
+            data?.state === OrderState.FAILED ||
+            data?.state === OrderState.EXPIRED
+          ) {
+            this.paying = false;
+            this.stopOrderPolling();
+            return;
+          }
+        } catch {
+          // Network blip — keep polling while dialog is open.
+        }
+        if (this.paying) {
+          (this as any)._orderRefreshTimer = window.setTimeout(poll, POLL_INTERVAL_MS);
+        }
+      };
+      (this as any)._orderRefreshTimer = window.setTimeout(poll, delay);
+    },
+    stopOrderPolling() {
+      const t = (this as any)._orderRefreshTimer as number | undefined;
+      if (t) {
+        clearTimeout(t);
+        (this as any)._orderRefreshTimer = undefined;
+      }
+    },
+    onRepay() {
+      this.paying = true;
+    },
+    onPay() {
+      if (!this.id) return;
+      this.prepaying = true;
+      orderOperator
+        .pay(this.id, {
+          pay_way: this.payWay
+        } as any)
+        .then(({ data }: { data: IOrderDetailResponse }) => {
+          this.prepaying = false;
+          if (data?.id) {
+            this.order = data;
+          }
+          if (this.order && this.order.price && this.order.price > 0) {
+            this.paying = true;
+          }
+        })
+        .catch(() => {
+          this.prepaying = false;
+        });
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.title {
+  font-size: 26px;
+  font-weight: bold;
+  margin-bottom: 20px;
+  color: var(--el-text-color-primary);
+}
+
+.wrapper {
+  padding: 24px 12px;
+  max-width: 960px;
+  margin: 0 auto;
+  .panel {
+    .el-card {
+      min-height: 400px;
+    }
+    .order {
+      padding-top: 30px;
+      .price {
+        font-size: 20px;
+        font-weight: bold;
+        &.current {
+          font-size: 24px;
+        }
+        &.unfree {
+          color: #ff5441;
+        }
+        &.free {
+          color: #29c287;
+        }
+      }
+    }
+    .payways {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      margin-top: 20px;
+      .payway {
+        cursor: pointer;
+        font-size: 13px;
+        padding: 0 18px;
+        height: 40px;
+        border: 2px solid var(--el-border-color);
+        border-radius: 10px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+        line-height: 1;
+        &.active {
+          border: 2px solid var(--el-color-primary);
+        }
+      }
+      .payname {
+        display: inline-block;
+        font-size: 13px;
+        font-weight: 500;
+      }
+      .payicon {
+        width: 22px;
+        height: 22px;
+        display: inline-block;
+        background-position: center;
+        background-repeat: no-repeat;
+        &.wechatpay {
+          background-image: url(//midas.gtimg.cn/enterprise/images/ep_new_sprites@2x.png);
+          background-size: 60px 250px;
+          background-position: 0 -50px;
+        }
+        &.stripe {
+          background-image: url(//cdn.acedata.cloud/2023-08-27-164440.png);
+          background-size: contain;
+        }
+        &.alipay {
+          background-image: url(//cdn.acedata.cloud/alipay.webp);
+          background-size: contain;
+        }
+      }
+    }
+    .btn-pay,
+    .btn-repay {
+      width: 150px;
+    }
+  }
+}
+</style>

--- a/src/router/constants.ts
+++ b/src/router/constants.ts
@@ -77,6 +77,8 @@ export const ROUTE_WEBEXTRATOR_INDEX = 'webextrator-index';
 
 export const ROUTE_PROFILE_INDEX = 'profile-index';
 
+export const ROUTE_ORDER_PUBLIC_PAY = 'order-public-pay';
+
 export const ROUTE_CONSOLE_ROOT = 'console-root';
 export const ROUTE_CONSOLE_ORDER_LIST = 'console-order-list';
 export const ROUTE_CONSOLE_ORDER_DETAIL = 'console-order-detail';

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -11,6 +11,7 @@ import chatgpt from './chatgpt';
 import midjourney from './midjourney';
 import distribution from './distribution';
 import download from './download';
+import order from './order';
 import qrart from './qrart';
 import luma from './luma';
 import pika from './pika';
@@ -301,6 +302,7 @@ const routes = [
     path: '/',
     redirect: (to: RouteLocationGeneric) => ({ ...getDefaultRoute(), query: to.query })
   },
+  order,
   console,
   auth,
   chatgpt,

--- a/src/router/order.ts
+++ b/src/router/order.ts
@@ -1,0 +1,14 @@
+import { ROUTE_ORDER_PUBLIC_PAY } from './constants';
+
+export default {
+  path: '/orders',
+  component: () => import('@/layouts/Index.vue'),
+  children: [
+    {
+      path: ':id',
+      name: ROUTE_ORDER_PUBLIC_PAY,
+      component: () => import('@/pages/order/Pay.vue'),
+      meta: { auth: false }
+    }
+  ]
+};


### PR DESCRIPTION
## Summary

Brings Nexior to parity with PlatformFrontend's public (no-login) order pay page. An unauthenticated visitor who lands on `/orders/<uuid>` (typically from a payment link sent by email / shared link) can now pick a pay method and complete checkout — exactly the same flow that already works on platform.acedata.cloud.

## What's new

- **`src/pages/order/Pay.vue`** — new `OrderPublicPay` page:
  - Polls the **AllowAny** `GET /orders/<id>` endpoint (`orderOperator.get`). Does **not** call `POST /orders/<id>/refresh/` (`orderOperator.refresh`) — that endpoint is `IsAuthenticated` and would 401 anonymously.
  - Local `PayWay` enum restricted to `{WechatPay, Stripe, AliPay}` to mirror the backend's `ANON_ALLOWED_PAY_WAYS`. X402 and PayPal need `request.user` and would 403 server-side, so they're intentionally hidden in the anonymous flow.
  - Free / paid / failed / expired states all surfaced with appropriate alerts.
- **`src/components/order/public/{WechatPay,AliPay,StripePay}.vue`** — dedicated dialog shells with **no self-polling**. Pure presentation; the parent page owns refresh. (The existing `src/components/order/{WechatPay,AliPay,StripePay}.vue` self-call `orderOperator.refresh()` which 401s anonymously, so they can't be reused as-is.)
- **`src/router/order.ts`** + `ROUTE_ORDER_PUBLIC_PAY` — mounted under `@/layouts/Index.vue` (TopHeader + BottomFooter), `meta.auth: false`.
- **`src/i18n/<18 locales>/order.json`** — adds `message.publicPayNotFound` (all 18 locales). Every other string already existed.

## Why a dedicated component tree

Nexior's existing pay dialogs (`src/components/order/{WechatPay,AliPay,StripePay}.vue`) drive their own polling via `orderOperator.refresh()` — that's a POST and the backend gates it on `IsAuthenticated`. Anonymous visitors would see 401 loops. PlatformFrontend solved this with separate presentational dialogs; this PR copies that pattern instead of cross-mode branching inside the existing components.

## Verification

- `npm run build` — green (vue-tsc + vite, ~11s).
- `npm run test:run` — 141/141 passed.
- `npm run lint` — clean.
- `python3 scripts/check_i18n_coverage.py` — 17 locales × 39 namespaces all match zh-CN.

## Manual test plan

1. `POST /orders/` with `pay_way` empty to create a pending order in PlatformBackend.
2. Open `/orders/<uuid>` in an incognito window.
3. Order detail loads, pay method picker shows WeChat / Alipay / Stripe (no X402, no PayPal).
4. Pick Stripe → `POST /orders/<id>/pay/` → `pay_url` opens in new tab → page polls until `state == paid`.
5. Repeat with WechatPay (QR rendered) and AliPay.

## Out of scope (next PRs)

- PR #4: usage list parity (filters + Elapsed/Remaining columns + CSV export).
- PR #5: move distribution pages into Console.

Sequential parity series: #834 (merged), #835 (merged), **this**, #4 (next), #5 (after).
