### PR TITLE
feat(order): align AliPay surface + add WeChat mobile scan-album guide

### DIFF
--- a/src/components/order/WechatPay.vue
+++ b/src/components/order/WechatPay.vue
@@ -1,16 +1,26 @@
 <template>
   <el-dialog :model-value="visible" :title="$t('application.title.buyService')" :width="dialogWidth" center>
-    <!-- Mobile browser outside WeChat (H5 unavailable on our merchant) -->
-    <div v-if="isMobileOutsideWechat" class="wechat-pay-guide text-center py-[20px] px-[10px]">
-      <p class="text-[14px] mb-4 leading-relaxed">
-        {{ $t('order.message.wechatPayMobileGuide') }}
+    <!-- Mobile browser outside WeChat: render the Native QR plus a guide telling the -->
+    <!-- user to save / screenshot it, then open WeChat -> Scan -> Album to pay. Still -->
+    <!-- expose Copy Link as a fallback for users who prefer URL-based hand-off.       -->
+    <div v-if="isMobileOutsideWechat" class="wechat-pay-mobile text-center py-[20px] px-[10px]">
+      <p class="text-[14px] mb-3 leading-relaxed">
+        {{ $t('order.message.wechatPayMobileScanTip') }}
       </p>
-      <el-button type="success" size="large" round class="w-[220px]" @click="onCopyLink">
-        {{ copied ? $t('common.message.copied') : $t('order.button.copyPayLink') }}
-      </el-button>
-      <p class="text-[12px] text-gray-500 mt-3 leading-relaxed">
+      <qr-code
+        v-if="modelValue?.pay_url"
+        :value="modelValue?.pay_url"
+        :size="220"
+        class="qrcode m-auto mb-3"
+        type="image/png"
+        :color="{ dark: '#000000', light: '#ffffff' }"
+      />
+      <p class="text-[12px] text-gray-500 mb-4 leading-relaxed">
         {{ $t('order.message.wechatPayMobileHint') }}
       </p>
+      <el-button v-if="payPageUrl" size="default" round class="w-[220px]" @click="onCopyLink">
+        {{ copied ? $t('common.message.copied') : $t('order.button.copyPayLink') }}
+      </el-button>
     </div>
 
     <!-- Mobile inside WeChat — long-press the Native QR to recognise and pay. -->
@@ -110,6 +120,15 @@ export default defineComponent({
     isMobileInsideWechat(): boolean {
       return isMobileBrowser() && isInWeChat();
     },
+    payPageUrl(): string {
+      // Always copy the public anonymous /orders/:id link (not the current console
+      // URL) so the recipient can complete payment without logging in.
+      const id = this.modelValue?.id;
+      if (!id || typeof window === 'undefined') {
+        return '';
+      }
+      return `${window.location.origin}/orders/${id}`;
+    },
     dialogWidth(): string {
       // Tighter dialog for any of the phone-sized views; keep 500px only for PC QR.
       if (this.isMobileOutsideWechat || this.isMobileInsideWechat) {
@@ -156,7 +175,7 @@ export default defineComponent({
         });
     },
     async onCopyLink() {
-      const url = typeof window !== 'undefined' ? window.location.href : '';
+      const url = this.payPageUrl;
       if (!url) {
         return;
       }

--- a/src/components/order/public/WechatPay.vue
+++ b/src/components/order/public/WechatPay.vue
@@ -6,16 +6,24 @@
     center
     @close="$emit('hide')"
   >
-    <div v-if="isMobileOutsideWechat" class="wechat-pay-guide text-center py-[20px] px-[10px]">
-      <p class="text-[14px] mb-4 leading-relaxed">
-        {{ $t('order.message.wechatPayMobileGuide') }}
+    <div v-if="isMobileOutsideWechat" class="wechat-pay-mobile text-center py-[20px] px-[10px]">
+      <p class="text-[14px] mb-3 leading-relaxed">
+        {{ $t('order.message.wechatPayMobileScanTip') }}
       </p>
-      <el-button type="success" size="large" round class="w-[220px]" @click="onCopyLink">
-        {{ copied ? $t('common.message.copied') : $t('order.button.copyPayLink') }}
-      </el-button>
-      <p class="text-[12px] text-gray-500 mt-3 leading-relaxed">
+      <qr-code
+        v-if="order?.pay_url"
+        :value="order?.pay_url"
+        :size="220"
+        class="qrcode m-auto mb-3"
+        type="image/png"
+        :color="{ dark: '#000000', light: '#ffffff' }"
+      />
+      <p class="text-[12px] text-gray-500 mb-4 leading-relaxed">
         {{ $t('order.message.wechatPayMobileHint') }}
       </p>
+      <el-button size="default" round class="w-[220px]" @click="onCopyLink">
+        {{ copied ? $t('common.message.copied') : $t('order.button.copyPayLink') }}
+      </el-button>
     </div>
 
     <div v-else-if="isMobileInsideWechat" class="wechat-pay-longpress text-center py-[20px] px-[10px]">

--- a/src/i18n/ar/order.json
+++ b/src/i18n/ar/order.json
@@ -523,6 +523,10 @@
     "message": "اضغط مطولا على رمز الاستجابة السريعة ادناه واختر 'التعرف على رمز QR' لاكمال الدفع في WeChat.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   },
+  "message.wechatPayMobileScanTip": {
+    "message": "احفظ أو التقط صورة للرمز الشريطي أدناه، افتح وي تشات، انقر على مسح، اختر الزاوية اليمنى العليا من الألبوم، واختر الصورة التي حفظتها للتو لإكمال الدفع.",
+    "description": "نص إرشادي يظهر فوق الرمز الشريطي في متصفح الهاتف المحمول غير الخاص بوي تشات. يوجه المستخدمين لحفظ صورة الرمز الشريطي ثم استخدام وظيفة الألبوم في وي تشات لمسحها لإكمال الدفع."
+  },
   "message.creditsValue": {
     "message": "{value} رصيد",
     "description": "Display of credits amount for an order, e.g. '5 credits'. {value} is the formatted credit number."

--- a/src/i18n/de/order.json
+++ b/src/i18n/de/order.json
@@ -523,6 +523,10 @@
     "message": "Halten Sie den QR-Code unten gedrueckt und waehlen Sie 'QR-Code erkennen', um die Zahlung in WeChat abzuschliessen.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   },
+  "message.wechatPayMobileScanTip": {
+    "message": "Speichern oder machen Sie einen Screenshot des QR-Codes unten, öffnen Sie WeChat, klicken Sie auf 'Scannen', wählen Sie das Album in der oberen rechten Ecke und wählen Sie das gerade gespeicherte Bild aus, um die Zahlung abzuschließen.",
+    "description": "Anleitungstext, der über dem QR-Code in einem mobilen Browser angezeigt wird, der nicht WeChat ist. Leitet den Benutzer an, das QR-Code-Bild zu speichern und es über die Album-Funktion von WeChat zu scannen, um die Zahlung abzuschließen."
+  },
   "message.creditsValue": {
     "message": "{value} Credits",
     "description": "Display of credits amount for an order, e.g. '5 credits'. {value} is the formatted credit number."

--- a/src/i18n/el/order.json
+++ b/src/i18n/el/order.json
@@ -523,6 +523,10 @@
     "message": "Πατήστε παρατεταμένα τον παρακάτω κωδικό QR και επιλέξτε 'Αναγνώριση κωδικού QR' για να ολοκληρώσετε την πληρωμή στο WeChat.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   },
+  "message.wechatPayMobileScanTip": {
+    "message": "Αποθηκεύστε ή τραβήξτε μια φωτογραφία του παρακάτω QR code, ανοίξτε το WeChat, κάντε κλικ στο Σαρώστε, επιλέξτε την γωνία επάνω δεξιά την γκαλερί και επιλέξτε την εικόνα που αποθηκεύσατε για να ολοκληρώσετε την πληρωμή.",
+    "description": "Εμφανίζεται πάνω από το QR code σε κινητό πρόγραμμα περιήγησης που δεν είναι WeChat. Οδηγεί τον χρήστη να αποθηκεύσει την εικόνα του QR code και να την αναγνωρίσει μέσω της λειτουργίας γκαλερί του WeChat."
+  },
   "message.creditsValue": {
     "message": "{value} πιστώσεις",
     "description": "Display of credits amount for an order, e.g. '5 credits'. {value} is the formatted credit number."

--- a/src/i18n/en/order.json
+++ b/src/i18n/en/order.json
@@ -523,6 +523,10 @@
     "message": "Long-press the QR code below and tap 'Recognise QR code' to complete payment in WeChat.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   },
+  "message.wechatPayMobileScanTip": {
+    "message": "Save or screenshot the QR code below, open WeChat, click on Scan, select the album in the upper right corner, and choose the saved image to complete the payment.",
+    "description": "Displayed above the QR code in non-WeChat mobile browsers. Guides users to save the QR code image and use WeChat's scan feature to recognize it from the album to complete the payment."
+  },
   "message.creditsValue": {
     "message": "{value} credits",
     "description": "Display of credits amount for an order, e.g. '5 credits'. {value} is the formatted credit number."

--- a/src/i18n/es/order.json
+++ b/src/i18n/es/order.json
@@ -523,6 +523,10 @@
     "message": "Mantenga pulsado el siguiente codigo QR y toque 'Reconocer codigo QR' para completar el pago en WeChat.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   },
+  "message.wechatPayMobileScanTip": {
+    "message": "Guarda o toma una captura de pantalla del código QR de abajo, abre WeChat, haz clic en 'Escanear', selecciona la galería en la esquina superior derecha y elige la imagen que guardaste para completar el pago.",
+    "description": "Texto de guía que se muestra sobre el código QR en navegadores móviles que no son WeChat. Indica a los usuarios que guarden la imagen del código QR y la reconozcan a través de la función de galería de WeChat para completar el pago."
+  },
   "message.creditsValue": {
     "message": "{value} créditos",
     "description": "Display of credits amount for an order, e.g. '5 credits'. {value} is the formatted credit number."

--- a/src/i18n/fi/order.json
+++ b/src/i18n/fi/order.json
@@ -523,6 +523,10 @@
     "message": "Paina alla olevaa QR-koodia pitkaan ja valitse 'Tunnista QR-koodi' suorittaaksesi maksun WeChatissa.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   },
+  "message.wechatPayMobileScanTip": {
+    "message": "Tallenna tai ota kuvakaappaus alla olevasta QR-koodista, avaa WeChat, napsauta Skannaa, valitse oikeassa yläkulmassa oleva galleria ja valitse juuri tallennettu kuva maksamisen suorittamiseksi.",
+    "description": "Näytetään QR-koodin yläpuolella mobiiliselainympäristössä, joka ei ole WeChat. Ohjeistaa käyttäjää tallentamaan QR-koodikuva ja tunnistamaan se WeChatin gallerian kautta maksamisen suorittamiseksi."
+  },
   "message.creditsValue": {
     "message": "{value} krediittiä",
     "description": "Display of credits amount for an order, e.g. '5 credits'. {value} is the formatted credit number."

--- a/src/i18n/fr/order.json
+++ b/src/i18n/fr/order.json
@@ -523,6 +523,10 @@
     "message": "Appuyez longuement sur le QR code ci-dessous et choisissez 'Reconnaitre le QR code' pour finaliser le paiement dans WeChat.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   },
+  "message.wechatPayMobileScanTip": {
+    "message": "Enregistrez ou capturez le code QR ci-dessous, ouvrez WeChat, cliquez sur Scanner, sélectionnez l'album en haut à droite, puis choisissez l'image que vous venez d'enregistrer pour finaliser le paiement.",
+    "description": "Texte d'instruction affiché au-dessus du code QR dans un navigateur mobile non WeChat. Guide les utilisateurs à enregistrer l'image du code QR et à utiliser la fonction album de WeChat pour effectuer le paiement."
+  },
   "message.creditsValue": {
     "message": "{value} crédits",
     "description": "Display of credits amount for an order, e.g. '5 credits'. {value} is the formatted credit number."

--- a/src/i18n/it/order.json
+++ b/src/i18n/it/order.json
@@ -523,6 +523,10 @@
     "message": "Tieni premuto il codice QR qui sotto e seleziona 'Riconosci codice QR' per completare il pagamento in WeChat.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   },
+  "message.wechatPayMobileScanTip": {
+    "message": "Salva o fai uno screenshot del codice QR qui sotto, apri WeChat, clicca su Scansiona, seleziona l'album in alto a destra e scegli l'immagine salvata per completare il pagamento.",
+    "description": "Testo guida mostrato sopra il codice QR in un browser mobile non WeChat. Guida l'utente a salvare l'immagine del codice QR e a utilizzare la funzione album di WeChat per riconoscerlo e completare il pagamento."
+  },
   "message.creditsValue": {
     "message": "{value} crediti",
     "description": "Display of credits amount for an order, e.g. '5 credits'. {value} is the formatted credit number."

--- a/src/i18n/ja/order.json
+++ b/src/i18n/ja/order.json
@@ -523,6 +523,10 @@
     "message": "下のQRコードを長押しし、「QRコードを認識」を選択してWeChatで支払いを完了してください。",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   },
+  "message.wechatPayMobileScanTip": {
+    "message": "下のQRコードを保存またはスクリーンショットを撮り、WeChatを開いて、スキャンをクリックし、右上のアルバムを選択して、先ほど保存した画像を選択することで支払いが完了します。",
+    "description": "非WeChatのモバイルブラウザでQRコードの上に表示されるガイド文です。ユーザーがQRコードの画像を保存し、WeChatのスキャン機能でアルバムから選択して支払いを完了する方法を案内します。"
+  },
   "message.creditsValue": {
     "message": "{value} クレジット",
     "description": "Display of credits amount for an order, e.g. '5 credits'. {value} is the formatted credit number."

--- a/src/i18n/ko/order.json
+++ b/src/i18n/ko/order.json
@@ -523,6 +523,10 @@
     "message": "아래 QR 코드를 길게 눌러 'QR 코드 인식'을 선택해 WeChat에서 결제를 완료하세요.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   },
+  "message.wechatPayMobileScanTip": {
+    "message": "아래 QR 코드를 저장하거나 스크린샷을 찍고, WeChat을 열어 스캔하기를 클릭한 후 오른쪽 상단의 앨범을 선택하여 방금 저장한 이미지를 선택하면 결제가 완료됩니다.",
+    "description": "비-WeChat 모바일 브라우저에서 QR 코드 위에 표시되는 안내 문구입니다. 사용자가 QR 코드 이미지를 저장한 후 WeChat의 스캔 기능을 통해 결제를 완료하도록 안내합니다."
+  },
   "message.creditsValue": {
     "message": "{value} 크레딧",
     "description": "Display of credits amount for an order, e.g. '5 credits'. {value} is the formatted credit number."

--- a/src/i18n/pl/order.json
+++ b/src/i18n/pl/order.json
@@ -523,6 +523,10 @@
     "message": "Przytrzymaj ponizszy kod QR i wybierz 'Rozpoznaj kod QR', aby dokonczyc platnosc w WeChat.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   },
+  "message.wechatPayMobileScanTip": {
+    "message": "Zapisz lub wykonaj zrzut ekranu poniższego kodu QR, otwórz WeChat, stuknij „Skanuj”, następnie wybierz album w prawym górnym rogu i wskaż zapisany obraz, aby dokończyć płatność.",
+    "description": "Tekst instruktażowy wyświetlany nad kodem QR w przeglądarkach mobilnych innych niż WeChat. Wyjaśnia użytkownikowi, jak zapisać obraz kodu QR i rozpoznać go za pomocą funkcji wyboru zdjęcia z albumu w skanerze WeChat, aby sfinalizować płatność."
+  },
   "message.creditsValue": {
     "message": "{value} kredytów",
     "description": "Display of credits amount for an order, e.g. '5 credits'. {value} is the formatted credit number."

--- a/src/i18n/pt/order.json
+++ b/src/i18n/pt/order.json
@@ -523,6 +523,10 @@
     "message": "Mantenha pressionado o codigo QR abaixo e selecione 'Reconhecer codigo QR' para concluir o pagamento no WeChat.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   },
+  "message.wechatPayMobileScanTip": {
+    "message": "Salve ou tire uma captura de tela do código QR abaixo, abra o WeChat, clique em 'Escanear', selecione o álbum no canto superior direito e escolha a imagem que você salvou para concluir o pagamento.",
+    "description": "Texto de orientação exibido acima do código QR em navegadores móveis que não são do WeChat. Orienta o usuário a salvar a imagem do código QR e usar a função de álbum do WeChat para escanear e concluir o pagamento."
+  },
   "message.creditsValue": {
     "message": "{value} créditos",
     "description": "Display of credits amount for an order, e.g. '5 credits'. {value} is the formatted credit number."

--- a/src/i18n/ru/order.json
+++ b/src/i18n/ru/order.json
@@ -523,6 +523,10 @@
     "message": "Удерживайте QR-код ниже и выберите 'Распознать QR-код', чтобы завершить оплату в WeChat.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   },
+  "message.wechatPayMobileScanTip": {
+    "message": "Сохраните или сделайте скриншот QR-кода ниже, откройте WeChat, нажмите 'Сканировать', выберите альбом в правом верхнем углу и выберите только что сохраненное изображение для завершения оплаты.",
+    "description": "Текст, отображаемый над QR-кодом в мобильном браузере, не относящемся к WeChat. Инструктирует пользователя сохранить изображение QR-кода и использовать функцию альбома в WeChat для завершения оплаты."
+  },
   "message.creditsValue": {
     "message": "{value} кредитов",
     "description": "Display of credits amount for an order, e.g. '5 credits'. {value} is the formatted credit number."

--- a/src/i18n/sr/order.json
+++ b/src/i18n/sr/order.json
@@ -523,6 +523,10 @@
     "message": "Drzite pritisnutim QR kod ispod i izaberite 'Prepoznaj QR kod' da biste zavrsili placanje u WeChat-u.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   },
+  "message.wechatPayMobileScanTip": {
+    "message": "Sačuvajte ili napravite snimak ekrana donjeg QR koda, otvorite WeChat, kliknite na 'Skeniraj', izaberite album u gornjem desnom uglu, i odaberite sliku koju ste upravo sačuvali da biste završili plaćanje.",
+    "description": "Prikazuje se kao uputstvo iznad QR koda u mobilnom pretraživaču koji nije WeChat. Vodi korisnike da sačuvaju sliku QR koda i koriste funkciju albuma u WeChat-u za skeniranje i završavanje plaćanja."
+  },
   "message.creditsValue": {
     "message": "{value} kredita",
     "description": "Display of credits amount for an order, e.g. '5 credits'. {value} is the formatted credit number."

--- a/src/i18n/sv/order.json
+++ b/src/i18n/sv/order.json
@@ -523,6 +523,10 @@
     "message": "Hall in QR-koden nedan och valj 'Identifiera QR-kod' for att slutfora betalningen i WeChat.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   },
+  "message.wechatPayMobileScanTip": {
+    "message": "Spara eller ta en skärmbild av QR-koden nedan, öppna WeChat, tryck på Skanna, välj albumet uppe till höger och välj sedan den sparade bilden för att slutföra betalningen.",
+    "description": "Vägledande text som visas ovanför QR-koden i mobila webbläsare utanför WeChat. Den instruerar användaren att spara QR-kodsbilden och sedan använda albumfunktionen i WeChats skanningsverktyg för att identifiera koden och slutföra betalningen."
+  },
   "message.creditsValue": {
     "message": "{value} krediter",
     "description": "Display of credits amount for an order, e.g. '5 credits'. {value} is the formatted credit number."

--- a/src/i18n/uk/order.json
+++ b/src/i18n/uk/order.json
@@ -523,6 +523,10 @@
     "message": "Утримуйте QR-код нижче та виберіть 'Розпізнати QR-код', щоб завершити оплату в WeChat.",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   },
+  "message.wechatPayMobileScanTip": {
+    "message": "Збережіть або зробіть скріншот нижче QR-коду, відкрийте WeChat, натисніть «Сканувати», виберіть у правому верхньому куті альбом, оберіть щойно збережене зображення, щоб завершити оплату.",
+    "description": "Текст, що відображається над QR-кодом у мобільному браузері, не пов'язаному з WeChat. Інструктує користувачів зберегти зображення QR-коду та використовувати функцію альбому у WeChat для сканування та завершення оплати."
+  },
   "message.creditsValue": {
     "message": "{value} кредитів",
     "description": "Display of credits amount for an order, e.g. '5 credits'. {value} is the formatted credit number."

--- a/src/i18n/zh-CN/order.json
+++ b/src/i18n/zh-CN/order.json
@@ -523,6 +523,10 @@
     "message": "请长按下方二维码识别图中二维码完成支付。",
     "description": "手机微信内部浏览器打开订单页时，二维码上方的引导文案。用户长按二维码即可识别并完成支付，无需跳出微信。"
   },
+  "message.wechatPayMobileScanTip": {
+    "message": "保存或截图下方二维码，打开微信，点击扫一扫，选择右上角的相册，挑选刚才保存的图片即可完成支付。",
+    "description": "在非微信的移动端浏览器中显示在二维码上方的引导文案。指导用户保存二维码图片后通过微信扫一扫的相册功能识别完成支付。"
+  },
   "message.creditsValue": {
     "message": "{value} 积分",
     "description": "Display of credits amount for an order, e.g. '5 credits'. {value} is the formatted credit number."

--- a/src/i18n/zh-TW/order.json
+++ b/src/i18n/zh-TW/order.json
@@ -523,6 +523,10 @@
     "message": "請長按下方二維碼，識別圖中二維碼完成支付。",
     "description": "Tip shown above the Native QR on mobile-WeChat. The user long-presses to recognise the `weixin://wxpay/bizpayurl` URL and pays without leaving WeChat."
   },
+  "message.wechatPayMobileScanTip": {
+    "message": "保存或截圖下方二維碼，打開微信，點擊掃一掃，選擇右上角的相冊，挑選剛才保存的圖片即可完成支付。",
+    "description": "在非微信的移動端瀏覽器中顯示在二維碼上方的引導文案。指導用戶保存二維碼圖片後通過微信掃一掃的相冊功能識別完成支付。"
+  },
   "message.creditsValue": {
     "message": "{value} 積分",
     "description": "Display of credits amount for an order, e.g. '5 credits'. {value} is the formatted credit number."

--- a/src/pages/console/order/Detail.vue
+++ b/src/pages/console/order/Detail.vue
@@ -102,7 +102,10 @@
             <el-row v-if="order?.state === OrderState.PENDING">
               <el-col :span="16" :offset="4">
                 <el-divider border-style="dashed" />
-                <div v-if="showPayment && showPayWays && order.price && order.price > 0 && !order.pay_way" class="payways mb-6">
+                <div
+                  v-if="showPayment && showPayWays && order.price && order.price > 0 && !order.pay_way"
+                  class="payways mb-6"
+                >
                   <div
                     :class="{
                       payway: true,
@@ -246,7 +249,7 @@ import X402PayOrder from '@/components/order/X402Pay.vue';
 import PaypalPayOrder from '@/components/order/PaypalPay.vue';
 import { IConfigResponse, IOrder, IOrderDetailResponse, OrderState } from '@/models';
 import { getPriceString } from '@/utils';
-import { isAndroid, isIOS } from '@/utils';
+import { getPaymentSurface, isAndroid, isIOS } from '@/utils';
 import { track } from '@/plugins/telemetry';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 
@@ -620,11 +623,15 @@ export default defineComponent({
         this.x402Session = undefined;
       }
       // PayBackend always issues a Native QR for WeChat Pay (our merchant
-      // has no JSAPI/H5 enabled), so the surface field is omitted here.
-      const payload: Record<string, unknown> = { pay_way: this.payWay };
+      // has no JSAPI/H5 enabled), so the surface field is omitted there.
+      // AliPay's backend serves Page (PC) vs Wap (mobile) based on `surface`,
+      // so the field is required to keep mobile users out of the desktop form.
       // Android Stripe uses the native PaymentSheet, which needs a
       // PaymentIntent (not a PaymentLink). The backend routes on this hint.
-      if (this.payWay === PayWay.Stripe && isAndroid()) {
+      const payload: Record<string, unknown> = { pay_way: this.payWay };
+      if (this.payWay === PayWay.AliPay) {
+        payload.surface = getPaymentSurface();
+      } else if (this.payWay === PayWay.Stripe && isAndroid()) {
         payload.surface = 'android';
       }
       orderOperator

--- a/src/pages/order/Pay.vue
+++ b/src/pages/order/Pay.vue
@@ -135,7 +135,7 @@ import PublicWechatPay from '@/components/order/public/WechatPay.vue';
 import PublicStripePay from '@/components/order/public/StripePay.vue';
 import PublicAlipayPay from '@/components/order/public/AliPay.vue';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
-import { getPriceString } from '@/utils';
+import { getPaymentSurface, getPriceString } from '@/utils';
 
 // Polls the AllowAny GET /orders/<id> endpoint — POST /orders/<id>/refresh/
 // is IsAuthenticated and would 401 here.
@@ -274,10 +274,16 @@ export default defineComponent({
     onPay() {
       if (!this.id) return;
       this.prepaying = true;
+      // AliPay's backend serves Page (PC) and Wap (mobile) URLs based on
+      // the `surface` hint. WeChat Pay is pinned to Native QR on our
+      // merchant so we omit surface there. Stripe doesn't have a native
+      // app variant on the anonymous page so 'pc' / 'wap' is moot.
+      const payload: Record<string, unknown> = { pay_way: this.payWay };
+      if (this.payWay === PayWay.AliPay) {
+        payload.surface = getPaymentSurface();
+      }
       orderOperator
-        .pay(this.id, {
-          pay_way: this.payWay
-        } as any)
+        .pay(this.id, payload as any)
         .then(({ data }: { data: IOrderDetailResponse }) => {
           this.prepaying = false;
           if (data?.id) {

--- a/src/utils/surface.ts
+++ b/src/utils/surface.ts
@@ -28,3 +28,13 @@ export function isMobile(): boolean {
   const ua = navigator.userAgent.toLowerCase();
   return /iphone|ipad|ipod|android|windows phone/i.test(ua);
 }
+
+// AliPay's backend issues different URLs for Page (PC) vs Wap (mobile web).
+// Native apps still want their own "ios" / "android" surface so the backend
+// can pick the right SDK path. Otherwise mobile-web users receive a PC Page
+// URL and have to deal with a desktop-sized form.
+export function getPaymentSurface(): 'pc' | 'wap' | 'ios' | 'android' {
+  if (isIOS()) return 'ios';
+  if (isAndroid()) return 'android';
+  return isMobile() ? 'wap' : 'pc';
+}


### PR DESCRIPTION
## Summary

Two payment-flow fixes uncovered during a side-by-side Nexior ↔ PlatformFrontend payment behaviour audit:

1. **AliPay surface routing** — the anonymous `/orders/:id` page and the console order detail page now pass a `surface` hint when the user picks AliPay, so PayBackend issues a Wap URL on mobile-web (instead of the desktop Page URL) and the right SDK path on iOS/Android. WeChat Pay is left untouched (our merchant is hard-pinned to Native QR), and the existing Stripe-on-Android branch keeps working.
2. **WeChat Pay on mobile-outside-WeChat** — the previous mobile-outside-WeChat branch only offered "Copy Link". On a phone with no other WeChat session, the link is dead-end. We now render the same Native QR the desktop dialog uses, plus an i18n tip telling the user to save / screenshot the QR and open WeChat → Scan → Album to pay. "Copy Link" stays as a fallback (and now copies the public `/orders/:id` URL, not the in-app console URL).

Both fixes already exist in PlatformFrontend; this brings Nexior to behavioural parity.

## Changes

### Surface helper
- `src/utils/surface.ts` — new `getPaymentSurface(): 'pc'|'wap'|'ios'|'android'`. Returns native surface when running in the Capacitor wrapper, otherwise `'wap'` for mobile-web UAs and `'pc'` for desktop.

### AliPay surface threading
- `src/pages/order/Pay.vue` — anonymous pay page sends `surface` for AliPay only (Stripe is anonymous-only and doesn't differentiate).
- `src/pages/console/order/Detail.vue` — console pay flow sends `surface` for AliPay; existing Stripe-Android `surface: 'android'` branch preserved.

### WeChat Pay mobile-outside-WeChat
- `src/components/order/WechatPay.vue` (logged-in dialog)
- `src/components/order/public/WechatPay.vue` (anonymous dialog)

Both now render: scan-tip text → 220px Native QR → existing copy-fallback hint → Copy Link button. The logged-in variant copies `${origin}/orders/${id}` instead of `window.location.href` so the recipient lands on the public pay page.

### i18n
- New flat key `message.wechatPayMobileScanTip` added to zh-CN (baseline), backfilled by `scripts/translate_i18n.py` across all 17 other locales.

## Validation
- `npm run build` ✅ (12s)
- `npm run test:run` ✅ (141 / 141)
- `npm run lint` ✅
- `python3 scripts/check_i18n_coverage.py` ✅ (17 locales × 39 namespaces all match zh-CN)

## Compatibility
- WeChat Pay behaviour unchanged for desktop / inside-WeChat branches.
- AliPay backend already accepts `surface` (see PlatformFrontend's existing behaviour); passing it is additive.
- `getPaymentSurface()` is additive; no existing `getSurface` / `isAndroid` / `isIOS` semantics change.
