### PR TITLE
fix(applications): restore picker scope + switch to user_id+affiliation contract

### DIFF
--- a/change/@acedatacloud-nexior-global-scope-fix.json
+++ b/change/@acedatacloud-nexior-global-scope-fix.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Restore scope=GLOBAL filter on cross-service application picker so the chat/midjourney/etc. pages no longer leak unrelated INDIVIDUAL apps (Wisdom, GLM, Kimi, …). Granted INDIVIDUAL apps continue to surface via each per-service module's own request; granted GLOBAL apps still come through include_granted=true. Regression introduced in #810.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/change/@acedatacloud-nexior-global-scope-fix.json
+++ b/change/@acedatacloud-nexior-global-scope-fix.json
@@ -1,7 +1,8 @@
 {
   "type": "patch",
-  "comment": "Restore scope=GLOBAL filter on cross-service application picker so the chat/midjourney/etc. pages no longer leak unrelated INDIVIDUAL apps (Wisdom, GLM, Kimi, …). Granted INDIVIDUAL apps continue to surface via each per-service module's own request; granted GLOBAL apps still come through include_granted=true. Regression introduced in #810.",
+  "comment": "Fix application picker on every Nexior service page: (a) restore scope=GLOBAL on the cross-service getApplications call so other-service INDIVIDUAL apps (Wisdom, GLM, Kimi, ...) no longer leak into the picker; (b) migrate to the new PlatformBackend two-axis filter (PR #561): pass user_id='me' + affiliation=['owner','granted'] so apps granted to me actually surface alongside my owned ones, replacing the deprecated role / include_granted / roles= params. Regression originally introduced in #810.",
   "packageName": "@acedatacloud/nexior",
   "email": "dev@acedata.cloud",
   "dependentChangeType": "patch"
 }
+

--- a/src/operators/application.ts
+++ b/src/operators/application.ts
@@ -9,18 +9,23 @@ import {
 } from '@/models';
 
 export interface IApplicationQuery {
-  user_id?: string;
+  // ``user_id=me`` is sugar for the caller's id; pass an explicit UUID
+  // to look up someone else (superuser only). Repeatable.
+  user_id?: string | string[];
   offset?: number;
   limit?: number;
   type?: IApplicationType | IApplicationType[];
   service_id?: string | string[];
   ordering?: string;
   scope?: IApplicationScope | IApplicationScope[];
-  // Credential-as-Authorization (PR #540): when true the backend also
-  // includes applications where the caller is a grantee. Each item carries
-  // ``role: 'owner' | 'grantee'``.
-  include_granted?: boolean;
-  role?: 'owner' | 'granted';
+  // Credential-as-Authorization (PR #561): only meaningful when
+  // ``user_id`` is set. Repeat ``affiliation=owner`` and/or
+  // ``affiliation=granted`` to scope to apps the subject owns, apps
+  // someone granted the subject (they hold a credential but are not the
+  // owner), or the union of both. Defaults to ``owner`` when ``user_id``
+  // is set. Serialized as repeated query params via axios paramsSerializer
+  // (qs.stringify with arrayFormat: 'repeat').
+  affiliation?: Array<'owner' | 'granted'> | 'owner' | 'granted';
 }
 
 class ApplicationOperator {

--- a/src/store/chat/actions.ts
+++ b/src/store/chat/actions.ts
@@ -88,16 +88,15 @@ export const getService = async ({
 
 export const getApplications = async ({
   commit,
-  state,
-  rootState
+  state
 }: ActionContext<IChatState, IRootState>): Promise<IApplication[] | undefined> => {
   console.debug('start to get applications for chat');
   state.status.getApplications = Status.Request;
   try {
     const { data: applications } = await applicationOperator.getAll({
-      user_id: rootState?.user?.id,
+      user_id: 'me',
       service_id: CHAT_SERVICE_ID,
-      include_granted: true
+      affiliation: ['owner', 'granted']
     });
     console.debug('get applications success for chat', applications);
     state.status.getApplications = Status.Success;

--- a/src/store/common/actions.ts
+++ b/src/store/common/actions.ts
@@ -169,8 +169,7 @@ export const setApplications = async ({ commit }: any, payload: IApplication[]):
 
 export const getApplications = async ({
   commit,
-  state,
-  rootState
+  state
 }: ActionContext<IRootState, IRootState>): Promise<IApplication[] | undefined> => {
   console.debug('start to get applications for global');
   state.status.getApplications = Status.Request;
@@ -178,7 +177,7 @@ export const getApplications = async ({
     const { data: applications } = await applicationOperator.getAll({
       limit: 100,
       offset: 0,
-      user_id: rootState?.user?.id,
+      user_id: 'me',
       ordering: '-created_at',
       type: IApplicationType.USAGE,
       // Cross-service picker: only apps usable on every service page.
@@ -186,9 +185,8 @@ export const getApplications = async ({
       // (owned or granted) come from each page's own per-service module,
       // so they MUST NOT leak in here.
       scope: IApplicationScope.GLOBAL,
-      // Still honour Credential-as-Authorization for GLOBAL apps another
-      // user shared with us — those remain cross-service usable.
-      include_granted: true
+      // Apps I own + GLOBAL apps another user granted me access to.
+      affiliation: ['owner', 'granted']
     });
     console.debug('global applications from online', applications);
     state.status.getApplications = Status.Success;

--- a/src/store/common/actions.ts
+++ b/src/store/common/actions.ts
@@ -9,7 +9,7 @@ import {
   applicationOperator,
   credentialOperator
 } from '@/operators';
-import { IApplication, IApplicationType, ICredential, IToken, IUser, Status } from '@/models';
+import { IApplication, IApplicationScope, IApplicationType, ICredential, IToken, IUser, Status } from '@/models';
 import { getSiteOrigin } from '@/utils/site';
 import { getBaseUrlAuth, getBaseUrlHub, getInviterId, loginRedirect } from '@/utils';
 import { isNative } from '@/utils/surface';
@@ -181,10 +181,13 @@ export const getApplications = async ({
       user_id: rootState?.user?.id,
       ordering: '-created_at',
       type: IApplicationType.USAGE,
-      // Credential-as-Authorization: also include apps shared TO me. Each
-      // item carries ``role: 'owner' | 'grantee'``. Dropping the previous
-      // ``scope: GLOBAL`` filter so granted INDIVIDUAL apps come back too
-      // (selection A in the design doc).
+      // Cross-service picker: only apps usable on every service page.
+      // GLOBAL-scope apps fit that bill; service-specific INDIVIDUAL apps
+      // (owned or granted) come from each page's own per-service module,
+      // so they MUST NOT leak in here.
+      scope: IApplicationScope.GLOBAL,
+      // Still honour Credential-as-Authorization for GLOBAL apps another
+      // user shared with us — those remain cross-service usable.
       include_granted: true
     });
     console.debug('global applications from online', applications);

--- a/src/store/midjourney/actions.ts
+++ b/src/store/midjourney/actions.ts
@@ -89,8 +89,7 @@ export const getService = async ({
 
 export const getApplications = async ({
   commit,
-  state,
-  rootState
+  state
 }: ActionContext<IMidjourneyState, IRootState>): Promise<IApplication[] | undefined> => {
   console.debug('start to get applications for chat');
   state.status.getApplications = Status.Request;
@@ -98,9 +97,9 @@ export const getApplications = async ({
   console.debug('current application', currentApplication);
   try {
     const { data: applications } = await applicationOperator.getAll({
-      user_id: rootState?.user?.id,
+      user_id: 'me',
       service_id: MIDJOURNEY_SERVICE_ID,
-      include_granted: true
+      affiliation: ['owner', 'granted']
     });
     state.status.getApplications = Status.Success;
     commit('setApplications', applications.items);

--- a/src/store/producer/actions.ts
+++ b/src/store/producer/actions.ts
@@ -89,8 +89,7 @@ export const getService = async ({
 
 export const getApplications = async ({
   commit,
-  state,
-  rootState
+  state
 }: ActionContext<IProducerState, IRootState>): Promise<IApplication[] | undefined> => {
   console.debug('start to get applications for producer');
   state.status.getApplications = Status.Request;
@@ -98,9 +97,9 @@ export const getApplications = async ({
   console.debug('current application', currentApplication);
   try {
     const { data: applications } = await applicationOperator.getAll({
-      user_id: rootState?.user?.id,
+      user_id: 'me',
       service_id: PRODUCER_SERVICE_ID,
-      include_granted: true
+      affiliation: ['owner', 'granted']
     });
     state.status.getApplications = Status.Success;
     commit('setApplications', applications.items);

--- a/src/store/seedream/actions.ts
+++ b/src/store/seedream/actions.ts
@@ -89,16 +89,15 @@ export const getService = async ({
 
 export const getApplications = async ({
   commit,
-  state,
-  rootState
+  state
 }: ActionContext<ISeedreamState, IRootState>): Promise<IApplication[] | undefined> => {
   console.debug('start to get applications for seedream');
   state.status.getApplications = Status.Request;
   try {
     const { data: applications } = await applicationOperator.getAll({
-      user_id: rootState?.user?.id,
+      user_id: 'me',
       service_id: SEEDREAM_SERVICE_ID,
-      include_granted: true
+      affiliation: ['owner', 'granted']
     });
     state.status.getApplications = Status.Success;
     commit('setApplications', applications.items);

--- a/src/store/serp/actions.ts
+++ b/src/store/serp/actions.ts
@@ -88,16 +88,15 @@ export const getService = async ({
 
 export const getApplications = async ({
   commit,
-  state,
-  rootState
+  state
 }: ActionContext<ISerpState, IRootState>): Promise<IApplication[] | undefined> => {
   console.debug('start to get applications for serp');
   state.status.getApplications = Status.Request;
   try {
     const { data: applications } = await applicationOperator.getAll({
-      user_id: rootState?.user?.id,
+      user_id: 'me',
       service_id: SERP_SERVICE_ID,
-      include_granted: true
+      affiliation: ['owner', 'granted']
     });
     state.status.getApplications = Status.Success;
     commit('setApplications', applications.items);

--- a/src/store/suno/actions.ts
+++ b/src/store/suno/actions.ts
@@ -91,8 +91,7 @@ export const getService = async ({
 
 export const getApplications = async ({
   commit,
-  state,
-  rootState
+  state
 }: ActionContext<ISunoState, IRootState>): Promise<IApplication[] | undefined> => {
   console.debug('start to get applications for chat');
   state.status.getApplications = Status.Request;
@@ -100,9 +99,9 @@ export const getApplications = async ({
   console.debug('current application', currentApplication);
   try {
     const { data: applications } = await applicationOperator.getAll({
-      user_id: rootState?.user?.id,
+      user_id: 'me',
       service_id: SUNO_SERVICE_ID,
-      include_granted: true
+      affiliation: ['owner', 'granted']
     });
     state.status.getApplications = Status.Success;
     commit('setApplications', applications.items);

--- a/src/store/webextrator/actions.ts
+++ b/src/store/webextrator/actions.ts
@@ -77,15 +77,14 @@ export const getService = async ({
 
 export const getApplications = async ({
   commit,
-  state,
-  rootState
+  state
 }: ActionContext<IWebextratorState, IRootState>): Promise<IApplication[] | undefined> => {
   state.status.getApplications = Status.Request;
   try {
     const { data: applications } = await applicationOperator.getAll({
-      user_id: rootState?.user?.id,
+      user_id: 'me',
       service_id: WEBEXTRATOR_SERVICE_ID,
-      include_granted: true
+      affiliation: ['owner', 'granted']
     });
     state.status.getApplications = Status.Success;
     commit('setApplications', applications.items);


### PR DESCRIPTION
## What

Fix the application picker on every Nexior service page, in two coherent steps:

### 1. `fix(applications): restore scope=GLOBAL on cross-service picker` ([c20b310d](https://github.com/AceDataCloud/Nexior/commit/c20b310d))

Cross-service usage cards must only list apps that work on every service page. GLOBAL-scope apps fit that bill; per-service INDIVIDUAL apps (Wisdom, GLM, Kimi, …) come from each service module's own picker. This restores the `scope: IApplicationScope.GLOBAL` filter on the common `getApplications` call that #810 accidentally dropped, plus a load-bearing comment so the next change doesn't drop it again.

### 2. `refactor(applications): switch to user_id + affiliation contract` *(new)*

Track PlatformBackend [#561](https://github.com/AceDataCloud/PlatformBackend/pull/561), which replaces the short-lived `?roles=` API from PB #560 with a clearer GitHub-style two-axis design:

| Axis | Param | Behaviour |
| --- | --- | --- |
| WHO | `?user_id=<uuid>` (repeatable) | `?user_id=me` is sugar for the caller's id. Without `user_id` the server applies no WHO filter (regular users still get 403 from the per-row permission). |
| HOW | `?affiliation=owner\|granted` (repeatable) | Only meaningful when `user_id` is set. Defaults to `owner`. `granted` joins through credentials and excludes apps owned by the subject so `owner∪granted` never overlaps. |

Every Nexior application-listing callsite now passes `user_id: 'me'` + `affiliation: ['owner', 'granted']` — no more apologetic "no `user_id`, otherwise we cancel the union" comment, no more risk of accidentally pre-empting the granted side.

## Files

- `src/operators/application.ts` — `IApplicationQuery`: drop `roles` + the `include_granted` relic, add `affiliation`; widen `user_id` to `string | string[]`.
- `src/store/{chat,midjourney,producer,seedream,serp,suno,webextrator}/actions.ts` — per-service picker: `user_id: 'me'`, `service_id`, `affiliation: ['owner','granted']`. `rootState` destructure no longer needed.
- `src/store/common/actions.ts` — cross-service picker: keeps `scope: GLOBAL` + adds `user_id: 'me'`, `affiliation: ['owner','granted']`.
- `change/@acedatacloud-nexior-global-scope-fix.json` — refreshed comment.

## Coupling

The second commit depends on PlatformBackend #561 being deployed first. Order:

1. Merge PB #561
2. Merge PlatformFrontend [#382](https://github.com/AceDataCloud/PlatformFrontend/pull/382)
3. Merge this PR (#840)

Regression originally introduced in #810.
