### PR TITLE
Fix OpenAI Image edits API code snippets

### DIFF
--- a/change/@acedatacloud-nexior-openaiimage-edits-api-code.json
+++ b/change/@acedatacloud-nexior-openaiimage-edits-api-code.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix OpenAI Image API code snippets to use the edits endpoint when reference images are present.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/openaiimage/task/Preview.vue
+++ b/src/components/openaiimage/task/Preview.vue
@@ -48,7 +48,7 @@
               {{ $t('common.button.edit') }}
             </el-button>
           </el-tooltip>
-          <api-code-button :path="openaiimagePath" :body="modelValue?.request" />
+          <api-code-button :path="openaiimagePath" :body="openaiimageCodeBody" />
         </div>
         <el-alert :closable="false" class="mt-2 success">
           <p v-if="modelValue?.request?.model" class="text-[var(--el-text-color-regular)] text-xs mb-2">
@@ -61,14 +61,10 @@
             {{ $t('openaiimage.name.size') }}:
             {{ (modelValue?.request as any)?.size }}
           </p>
-          <p v-if="modelValue?.request?.action" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+          <p v-if="showTaskType" class="text-[var(--el-text-color-regular)] text-xs mb-2">
             <font-awesome-icon icon="fa-solid fa-bolt" class="mr-1" />
             {{ $t('openaiimage.name.task') }}:
-            {{
-              modelValue?.request?.action === 'generate'
-                ? $t('openaiimage.name.generate')
-                : $t('openaiimage.name.edits')
-            }}
+            {{ taskTypeLabel }}
           </p>
           <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
             <font-awesome-icon icon="fa-solid fa-magic" class="mr-1" />
@@ -104,14 +100,10 @@
             {{ $t('openaiimage.name.size') }}:
             {{ (modelValue?.request as any)?.size }}
           </p>
-          <p v-if="modelValue?.request?.action" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+          <p v-if="showTaskType" class="text-[var(--el-text-color-regular)] text-xs mb-2">
             <font-awesome-icon icon="fa-solid fa-bolt" class="mr-1" />
             {{ $t('openaiimage.name.task') }}:
-            {{
-              modelValue?.request?.action === 'generate'
-                ? $t('openaiimage.name.generate')
-                : $t('openaiimage.name.edits')
-            }}
+            {{ taskTypeLabel }}
           </p>
           <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
             <font-awesome-icon icon="fa-solid fa-magic" class="mr-1" />
@@ -153,14 +145,10 @@
             {{ $t('openaiimage.name.size') }}:
             {{ (modelValue?.request as any)?.size }}
           </p>
-          <p v-if="modelValue?.request?.action" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+          <p v-if="showTaskType" class="text-[var(--el-text-color-regular)] text-xs mb-2">
             <font-awesome-icon icon="fa-solid fa-bolt" class="mr-1" />
             {{ $t('openaiimage.name.task') }}:
-            {{
-              modelValue?.request?.action === 'generate'
-                ? $t('openaiimage.name.generate')
-                : $t('openaiimage.name.edits')
-            }}
+            {{ taskTypeLabel }}
           </p>
           <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
             <font-awesome-icon icon="fa-solid fa-magic" class="mr-1" />
@@ -208,8 +196,39 @@ export default defineComponent({
     return { OPENAIIMAGE_LOGO };
   },
   computed: {
+    isEditRequest(): boolean {
+      const req: any = this.modelValue?.request;
+      return this.modelValue?.type === 'images_edits' || req?.action === 'edit' || this.referenceImages.length > 0;
+    },
+    showTaskType(): boolean {
+      return Boolean(this.modelValue?.request?.action || this.modelValue?.type || this.referenceImages.length > 0);
+    },
+    taskTypeLabel() {
+      return this.isEditRequest ? this.$t('openaiimage.name.edits') : this.$t('openaiimage.name.generate');
+    },
     openaiimagePath(): string {
-      return this.modelValue?.request?.action === 'edit' ? '/openai/images/edits' : '/openai/images/generations';
+      return this.isEditRequest ? '/openai/images/edits' : '/openai/images/generations';
+    },
+    openaiimageCodeBody(): Record<string, unknown> | undefined {
+      const req = this.modelValue?.request as Record<string, unknown> | undefined;
+      if (!req) return undefined;
+      const body: Record<string, unknown> = { ...req };
+      delete body.action;
+      delete body.callback_url;
+      if (this.isEditRequest) {
+        delete body.image_urls;
+        delete body.image;
+        const images = this.referenceImages;
+        if (images.length === 1) {
+          body.image = images[0];
+        } else if (images.length > 1) {
+          body.image = images;
+        }
+      } else {
+        delete body.image_urls;
+        delete body.image;
+      }
+      return body;
     },
     images(): IOpenAIImageImage[] {
       const result: IOpenAIImageImage[] = [];
@@ -245,6 +264,15 @@ export default defineComponent({
       const raw = req.image;
       if (Array.isArray(raw)) return raw.filter((u: unknown): u is string => typeof u === 'string' && u.length > 0);
       if (typeof raw === 'string' && raw.length > 0) return [raw];
+      if (Array.isArray(req.images)) {
+        return req.images
+          .map((item: unknown) => {
+            if (typeof item === 'string') return item;
+            if (item && typeof item === 'object') return (item as { image_url?: unknown }).image_url;
+            return undefined;
+          })
+          .filter((u: unknown): u is string => typeof u === 'string' && u.length > 0);
+      }
       return [];
     }
   },

--- a/src/operators/openaiimage.ts
+++ b/src/operators/openaiimage.ts
@@ -27,6 +27,7 @@ class OpenAIImageOperator extends BaseTaskOperator<
     const formData = new FormData();
     if (data.model) formData.append('model', data.model);
     if (data.prompt) formData.append('prompt', data.prompt);
+    if (data.size) formData.append('size', data.size);
     if (data.callback_url) formData.append('callback_url', data.callback_url);
     (data.image_urls || []).forEach((url) => {
       formData.append('image', url);


### PR DESCRIPTION
## Summary
- Infer OpenAI Image edit requests from task type, action, or reference-image fields so API snippets use /openai/images/edits when references are present.
- Normalize edit snippet bodies from internal image_urls/action fields to the public image field accepted by the OpenAPI JSON mode.
- Pass size through multipart edit requests.

## Validation
- npx eslint src/components/openaiimage/task/Preview.vue src/operators/openaiimage.ts
- npx vue-tsc -b
- npm run verify
- git diff --check