### PR TITLE
fix(ios): complete App Store rejection fixes (Top Up, Apple sign-in, account deletion)

### DIFF
--- a/change/@acedatacloud-nexior-apple-rejection-completeness.json
+++ b/change/@acedatacloud-nexior-apple-rejection-completeness.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "iOS App Store rejection fixes: (a) gate the chat and floating-balance 'Top Up' buttons behind !isIOS() so they no longer appear unresponsive on iOS where IAP-less payment UI is hidden; (b) surface a real error toast when native Apple Sign In fails for a non-cancellation reason; (c) add an in-app 'Delete Account' menu item (Guideline 5.1.1(v)) that calls DELETE /users/me and logs the user out.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/application/Info.vue
+++ b/src/components/application/Info.vue
@@ -39,7 +39,7 @@
         <font-awesome-icon icon="fa-solid fa-chart-line" class="mr-1 text-[11px]" />
         {{ $t('application.button.usage') }}
       </el-button>
-      <el-button type="primary" round size="small" @click.stop="$emit('buy', application)">
+      <el-button v-if="showPayment" type="primary" round size="small" @click.stop="$emit('buy', application)">
         <font-awesome-icon icon="fa-solid fa-coins" class="mr-1 text-[11px]" />
         {{ $t('application.button.buyMore') }}
       </el-button>
@@ -54,6 +54,7 @@ import { ElButton, ElIcon } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { Check } from '@element-plus/icons-vue';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
+import { isIOS } from '@/utils';
 
 export default defineComponent({
   name: 'ApplicationInfo',
@@ -78,7 +79,13 @@ export default defineComponent({
       default: false
     }
   },
-  emits: ['buy', 'usage']
+  emits: ['buy', 'usage'],
+  computed: {
+    // Hide the "Top Up" action inside the iOS bundle (payments are web-only).
+    showPayment(): boolean {
+      return !isIOS();
+    }
+  }
 });
 </script>
 

--- a/src/components/chat/Message.vue
+++ b/src/components/chat/Message.vue
@@ -218,6 +218,7 @@ import {
   ERROR_CODE_BUSY
 } from '@/constants';
 import { ROUTE_CONSOLE_APPLICATION_EXTRA } from '@/router';
+import { isIOS } from '@/utils';
 
 interface IData {
   copied: boolean;
@@ -331,7 +332,10 @@ export default defineComponent({
       }
     },
     showBuyMore() {
-      return this.message.role === ROLE_ASSISTANT && this.message.error?.code === ERROR_CODE_USED_UP;
+      // Payment flows live on the web, not inside the iOS bundle. Hide the
+      // in-chat "Top Up" entry on iOS so it never routes to a payment page
+      // that renders empty there (matches showPayment in the console pages).
+      return !isIOS() && this.message.role === ROLE_ASSISTANT && this.message.error?.code === ERROR_CODE_USED_UP;
     }
   },
   watch: {},

--- a/src/components/common/AuthPanel.vue
+++ b/src/components/common/AuthPanel.vue
@@ -33,6 +33,7 @@
 import { defineComponent } from 'vue';
 import axios from 'axios';
 import { ElDialog } from 'element-plus';
+import { ElMessage } from 'element-plus';
 import { getBaseUrlAuth, withCurrentSite } from '@/utils';
 import { getCookie } from 'typescript-cookie';
 import QrCode from 'vue-qrcode';
@@ -148,9 +149,20 @@ export default defineComponent({
             this.$store.commit('setAuth', { visible: false });
             await this.$router.push('/');
           } catch (error: unknown) {
-            // User-cancelled sheets are an expected outcome — silently keep
-            // the iframe login UI so the user can pick another method.
-            console.warn('native apple sign in failed', error);
+            // ASAuthorizationError code 1001 = the user dismissed the sheet.
+            // That's an expected outcome, so stay silent and keep the iframe
+            // login UI available for another method. Any OTHER failure
+            // (network down, token rejected by AuthBackend, missing "Sign in
+            // with Apple" capability) used to be swallowed too, leaving the
+            // button looking dead — surface those to the user instead.
+            const detail = error instanceof Error ? error.message : String(error);
+            const canceled = /\b100[01]\b/.test(detail) || /cancel/i.test(detail);
+            if (canceled) {
+              console.debug('native apple sign in canceled by user', error);
+            } else {
+              console.warn('native apple sign in failed', error);
+              ElMessage.error(this.$t('common.error.appleSignInFailed').toString());
+            }
           }
           return;
         }

--- a/src/i18n/ar/common.json
+++ b/src/i18n/ar/common.json
@@ -215,6 +215,10 @@
     "message": "جارٍ التحميل...",
     "description": "النص الذي يظهر أثناء تحميل المحتوى"
   },
+  "error.appleSignInFailed": {
+    "message": "فشل تسجيل الدخول باستخدام Apple. يرجى المحاولة مرة أخرى أو استخدام طريقة تسجيل دخول أخرى.",
+    "description": "Error toast shown when native Apple sign-in fails for a reason other than user cancellation"
+  },
   "entity.operation": {
     "message": "عملية",
     "description": "عملية الكيان"
@@ -342,6 +346,18 @@
   "message.alert": {
     "message": "تحذير",
     "description": "警告用户的消息"
+  },
+  "message.deleteAccountConfirm": {
+    "message": "سيؤدي هذا إلى حذف حسابك وجميع البيانات المرتبطة به نهائيًا. لا يمكن التراجع عن هذا الإجراء. هل أنت متأكد من أنك تريد المتابعة؟",
+    "description": "Confirmation message shown before permanently deleting the user account"
+  },
+  "message.deleteAccountSuccess": {
+    "message": "تم حذف حسابك.",
+    "description": "Message shown after the user account is successfully deleted"
+  },
+  "message.deleteAccountFailed": {
+    "message": "فشل حذف حسابك. يرجى المحاولة مرة أخرى لاحقًا.",
+    "description": "Message shown when account deletion fails"
   },
   "message.info": {
     "message": "معلومات",
@@ -538,6 +554,10 @@
   "nav.logOut": {
     "message": "تسجيل الخروج",
     "description": "النص في شريط التنقل للموقع، لتسجيل الخروج"
+  },
+  "nav.deleteAccount": {
+    "message": "حذف الحساب",
+    "description": "Menu item to permanently delete the current user account"
   },
   "nav.site": {
     "message": "إعدادات الموقع",

--- a/src/i18n/de/common.json
+++ b/src/i18n/de/common.json
@@ -215,6 +215,10 @@
     "message": "Wird geladen...",
     "description": "Statusnachricht, die beim Laden von Inhalten angezeigt wird"
   },
+  "error.appleSignInFailed": {
+    "message": "Anmeldung mit Apple fehlgeschlagen. Bitte versuchen Sie es erneut oder verwenden Sie eine andere Anmeldemethode.",
+    "description": "Error toast shown when native Apple sign-in fails for a reason other than user cancellation"
+  },
   "entity.operation": {
     "message": "Operation",
     "description": "Operation der Entität"
@@ -342,6 +346,18 @@
   "message.alert": {
     "message": "Warnung",
     "description": "警告用户的消息"
+  },
+  "message.deleteAccountConfirm": {
+    "message": "Dadurch werden Ihr Konto und alle zugehörigen Daten dauerhaft gelöscht. Diese Aktion kann nicht rückgängig gemacht werden. Möchten Sie wirklich fortfahren?",
+    "description": "Confirmation message shown before permanently deleting the user account"
+  },
+  "message.deleteAccountSuccess": {
+    "message": "Ihr Konto wurde gelöscht.",
+    "description": "Message shown after the user account is successfully deleted"
+  },
+  "message.deleteAccountFailed": {
+    "message": "Ihr Konto konnte nicht gelöscht werden. Bitte versuchen Sie es später erneut.",
+    "description": "Message shown when account deletion fails"
   },
   "message.info": {
     "message": "Hinweis",
@@ -538,6 +554,10 @@
   "nav.logOut": {
     "message": "Abmelden",
     "description": "Website-Navigationsleiste, um sich abzumelden"
+  },
+  "nav.deleteAccount": {
+    "message": "Konto löschen",
+    "description": "Menu item to permanently delete the current user account"
   },
   "nav.site": {
     "message": "Site-Konfiguration",

--- a/src/i18n/el/common.json
+++ b/src/i18n/el/common.json
@@ -215,6 +215,10 @@
     "message": "Φόρτωση...",
     "description": "Κείμενο κατάστασης που εμφανίζεται κατά τη φόρτωση περιεχομένου"
   },
+  "error.appleSignInFailed": {
+    "message": "Η σύνδεση με Apple απέτυχε. Δοκιμάστε ξανά ή χρησιμοποιήστε άλλη μέθοδο σύνδεσης.",
+    "description": "Error toast shown when native Apple sign-in fails for a reason other than user cancellation"
+  },
   "entity.operation": {
     "message": "Ενέργεια",
     "description": "Η ενέργεια της οντότητας"
@@ -342,6 +346,18 @@
   "message.alert": {
     "message": "Προειδοποίηση",
     "description": "Μήνυμα που προειδοποιεί τον χρήστη"
+  },
+  "message.deleteAccountConfirm": {
+    "message": "Αυτό θα διαγράψει οριστικά τον λογαριασμό σας και όλα τα σχετικά δεδομένα. Αυτή η ενέργεια δεν μπορεί να αναιρεθεί. Είστε βέβαιοι ότι θέλετε να συνεχίσετε;",
+    "description": "Confirmation message shown before permanently deleting the user account"
+  },
+  "message.deleteAccountSuccess": {
+    "message": "Ο λογαριασμός σας διαγράφηκε.",
+    "description": "Message shown after the user account is successfully deleted"
+  },
+  "message.deleteAccountFailed": {
+    "message": "Η διαγραφή του λογαριασμού σας απέτυχε. Δοκιμάστε ξανά αργότερα.",
+    "description": "Message shown when account deletion fails"
   },
   "message.info": {
     "message": "Πληροφορία",
@@ -538,6 +554,10 @@
   "nav.logOut": {
     "message": "Αποσύνδεση",
     "description": "Website navigation text for logging out"
+  },
+  "nav.deleteAccount": {
+    "message": "Διαγραφή λογαριασμού",
+    "description": "Menu item to permanently delete the current user account"
   },
   "nav.site": {
     "message": "Ρυθμίσεις Ιστοσελίδας",

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -215,6 +215,10 @@
     "message": "Loading...",
     "description": "Status text displayed while content is loading"
   },
+  "error.appleSignInFailed": {
+    "message": "Sign in with Apple failed. Please try again or use another sign-in method.",
+    "description": "Error toast shown when native Sign in with Apple fails for a reason other than the user cancelling."
+  },
   "entity.operation": {
     "message": "Operation",
     "description": "The operation of the entity"
@@ -342,6 +346,18 @@
   "message.alert": {
     "message": "Warning",
     "description": "Message warning the user"
+  },
+  "message.deleteAccountConfirm": {
+    "message": "This will permanently delete your account and all associated data. This action cannot be undone. Are you sure you want to continue?",
+    "description": "Confirmation message shown before permanently deleting the user account"
+  },
+  "message.deleteAccountSuccess": {
+    "message": "Your account has been deleted.",
+    "description": "Message shown after the user account is successfully deleted"
+  },
+  "message.deleteAccountFailed": {
+    "message": "Failed to delete your account. Please try again later.",
+    "description": "Message shown when account deletion fails"
   },
   "message.info": {
     "message": "Tip",
@@ -538,6 +554,10 @@
   "nav.logOut": {
     "message": "Log Out",
     "description": "Text in the website navigation bar to log out"
+  },
+  "nav.deleteAccount": {
+    "message": "Delete Account",
+    "description": "Menu item to permanently delete the current user account"
   },
   "nav.site": {
     "message": "Site Configuration",

--- a/src/i18n/es/common.json
+++ b/src/i18n/es/common.json
@@ -215,6 +215,10 @@
     "message": "Cargando...",
     "description": "Texto de estado mostrado mientras se carga el contenido"
   },
+  "error.appleSignInFailed": {
+    "message": "No se pudo iniciar sesión con Apple. Inténtalo de nuevo o usa otro método de inicio de sesión.",
+    "description": "Error toast shown when native Apple sign-in fails for a reason other than user cancellation"
+  },
   "entity.operation": {
     "message": "Operación",
     "description": "Operación de la entidad"
@@ -342,6 +346,18 @@
   "message.alert": {
     "message": "Advertencia",
     "description": "Mensaje que alerta al usuario"
+  },
+  "message.deleteAccountConfirm": {
+    "message": "Esto eliminará permanentemente tu cuenta y todos los datos asociados. Esta acción no se puede deshacer. ¿Seguro que quieres continuar?",
+    "description": "Confirmation message shown before permanently deleting the user account"
+  },
+  "message.deleteAccountSuccess": {
+    "message": "Tu cuenta ha sido eliminada.",
+    "description": "Message shown after the user account is successfully deleted"
+  },
+  "message.deleteAccountFailed": {
+    "message": "No se pudo eliminar tu cuenta. Inténtalo de nuevo más tarde.",
+    "description": "Message shown when account deletion fails"
   },
   "message.info": {
     "message": "Información",
@@ -538,6 +554,10 @@
   "nav.logOut": {
     "message": "Cerrar sesión",
     "description": "网站导航栏中的文本，用于退出登录"
+  },
+  "nav.deleteAccount": {
+    "message": "Eliminar cuenta",
+    "description": "Menu item to permanently delete the current user account"
   },
   "nav.site": {
     "message": "Configuración del sitio",

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -215,6 +215,10 @@
     "message": "Ladataan...",
     "description": "Sisällön lataamisen aikana näytettävä tilateksti"
   },
+  "error.appleSignInFailed": {
+    "message": "Apple-kirjautuminen epäonnistui. Yritä uudelleen tai käytä toista kirjautumistapaa.",
+    "description": "Error toast shown when native Apple sign-in fails for a reason other than user cancellation"
+  },
   "entity.operation": {
     "message": "Toiminto",
     "description": "Entiteetin toiminto"
@@ -342,6 +346,18 @@
   "message.alert": {
     "message": "Varoitus",
     "description": "Viesti, joka varoittaa käyttäjää"
+  },
+  "message.deleteAccountConfirm": {
+    "message": "Tämä poistaa tilisi ja kaikki siihen liittyvät tiedot pysyvästi. Tätä toimintoa ei voi peruuttaa. Haluatko varmasti jatkaa?",
+    "description": "Confirmation message shown before permanently deleting the user account"
+  },
+  "message.deleteAccountSuccess": {
+    "message": "Tilisi on poistettu.",
+    "description": "Message shown after the user account is successfully deleted"
+  },
+  "message.deleteAccountFailed": {
+    "message": "Tilisi poistaminen epäonnistui. Yritä myöhemmin uudelleen.",
+    "description": "Message shown when account deletion fails"
   },
   "message.info": {
     "message": "Tietoa",
@@ -538,6 +554,10 @@
   "nav.logOut": {
     "message": "Kirjaudu ulos",
     "description": "网站导航栏中的文本，用于退出登录"
+  },
+  "nav.deleteAccount": {
+    "message": "Poista tili",
+    "description": "Menu item to permanently delete the current user account"
   },
   "nav.site": {
     "message": "Sivuston asetukset",

--- a/src/i18n/fr/common.json
+++ b/src/i18n/fr/common.json
@@ -215,6 +215,10 @@
     "message": "Chargement...",
     "description": "Texte d'état affiché lors du chargement du contenu"
   },
+  "error.appleSignInFailed": {
+    "message": "La connexion avec Apple a échoué. Veuillez réessayer ou utiliser une autre méthode de connexion.",
+    "description": "Error toast shown when native Apple sign-in fails for a reason other than user cancellation"
+  },
   "entity.operation": {
     "message": "Opération",
     "description": "Opération de l'entité"
@@ -342,6 +346,18 @@
   "message.alert": {
     "message": "Alerte",
     "description": "Message d'alerte pour l'utilisateur"
+  },
+  "message.deleteAccountConfirm": {
+    "message": "Cela supprimera définitivement votre compte et toutes les données associées. Cette action est irréversible. Voulez-vous vraiment continuer ?",
+    "description": "Confirmation message shown before permanently deleting the user account"
+  },
+  "message.deleteAccountSuccess": {
+    "message": "Votre compte a été supprimé.",
+    "description": "Message shown after the user account is successfully deleted"
+  },
+  "message.deleteAccountFailed": {
+    "message": "Échec de la suppression de votre compte. Veuillez réessayer plus tard.",
+    "description": "Message shown when account deletion fails"
   },
   "message.info": {
     "message": "Information",
@@ -538,6 +554,10 @@
   "nav.logOut": {
     "message": "Déconnexion",
     "description": "网站导航栏中的文本，用于退出登录"
+  },
+  "nav.deleteAccount": {
+    "message": "Supprimer le compte",
+    "description": "Menu item to permanently delete the current user account"
   },
   "nav.site": {
     "message": "Configuration du site",

--- a/src/i18n/it/common.json
+++ b/src/i18n/it/common.json
@@ -215,6 +215,10 @@
     "message": "Caricamento in corso...",
     "description": "Testo di stato visualizzato durante il caricamento dei contenuti"
   },
+  "error.appleSignInFailed": {
+    "message": "Accesso con Apple non riuscito. Riprova o usa un altro metodo di accesso.",
+    "description": "Error toast shown when native Apple sign-in fails for a reason other than user cancellation"
+  },
   "entity.operation": {
     "message": "Operazione",
     "description": "Operazione dell'entità"
@@ -342,6 +346,18 @@
   "message.alert": {
     "message": "Avviso",
     "description": "Messaggio per avvisare l'utente"
+  },
+  "message.deleteAccountConfirm": {
+    "message": "Questa operazione eliminerà definitivamente il tuo account e tutti i dati associati. Questa azione non può essere annullata. Vuoi davvero continuare?",
+    "description": "Confirmation message shown before permanently deleting the user account"
+  },
+  "message.deleteAccountSuccess": {
+    "message": "Il tuo account è stato eliminato.",
+    "description": "Message shown after the user account is successfully deleted"
+  },
+  "message.deleteAccountFailed": {
+    "message": "Impossibile eliminare il tuo account. Riprova più tardi.",
+    "description": "Message shown when account deletion fails"
   },
   "message.info": {
     "message": "Informazioni",
@@ -538,6 +554,10 @@
   "nav.logOut": {
     "message": "Esci",
     "description": "Testo nella barra di navigazione del sito per uscire"
+  },
+  "nav.deleteAccount": {
+    "message": "Elimina account",
+    "description": "Menu item to permanently delete the current user account"
   },
   "nav.site": {
     "message": "Configurazione sito",

--- a/src/i18n/ja/common.json
+++ b/src/i18n/ja/common.json
@@ -215,6 +215,10 @@
     "message": "読み込み中...",
     "description": "コンテンツが読み込まれているときに表示されるステータステキスト"
   },
+  "error.appleSignInFailed": {
+    "message": "Apple でのサインインに失敗しました。もう一度お試しいただくか、別のサインイン方法をご利用ください。",
+    "description": "Error toast shown when native Apple sign-in fails for a reason other than user cancellation"
+  },
   "entity.operation": {
     "message": "操作",
     "description": "エンティティの操作"
@@ -342,6 +346,18 @@
   "message.alert": {
     "message": "警告",
     "description": "ユーザーに警告するメッセージ"
+  },
+  "message.deleteAccountConfirm": {
+    "message": "これにより、アカウントと関連するすべてのデータが完全に削除されます。この操作は元に戻せません。本当に続行しますか？",
+    "description": "Confirmation message shown before permanently deleting the user account"
+  },
+  "message.deleteAccountSuccess": {
+    "message": "アカウントが削除されました。",
+    "description": "Message shown after the user account is successfully deleted"
+  },
+  "message.deleteAccountFailed": {
+    "message": "アカウントの削除に失敗しました。後でもう一度お試しください。",
+    "description": "Message shown when account deletion fails"
   },
   "message.info": {
     "message": "情報",
@@ -538,6 +554,10 @@
   "nav.logOut": {
     "message": "ログアウト",
     "description": "ウェブサイトのナビゲーションバーのテキストで、ログアウトするためのものです。"
+  },
+  "nav.deleteAccount": {
+    "message": "アカウントを削除",
+    "description": "Menu item to permanently delete the current user account"
   },
   "nav.site": {
     "message": "サイト設定",

--- a/src/i18n/ko/common.json
+++ b/src/i18n/ko/common.json
@@ -215,6 +215,10 @@
     "message": "로딩 중...",
     "description": "내용이 로딩될 때 표시되는 상태 문구"
   },
+  "error.appleSignInFailed": {
+    "message": "Apple로 로그인하지 못했습니다. 다시 시도하거나 다른 로그인 방법을 사용해 주세요.",
+    "description": "Error toast shown when native Apple sign-in fails for a reason other than user cancellation"
+  },
   "entity.operation": {
     "message": "작업",
     "description": "엔티티의 작업"
@@ -342,6 +346,18 @@
   "message.alert": {
     "message": "경고",
     "description": "사용자에게 경고하는 메시지"
+  },
+  "message.deleteAccountConfirm": {
+    "message": "계정과 관련된 모든 데이터가 영구적으로 삭제됩니다. 이 작업은 되돌릴 수 없습니다. 계속하시겠습니까?",
+    "description": "Confirmation message shown before permanently deleting the user account"
+  },
+  "message.deleteAccountSuccess": {
+    "message": "계정이 삭제되었습니다.",
+    "description": "Message shown after the user account is successfully deleted"
+  },
+  "message.deleteAccountFailed": {
+    "message": "계정 삭제에 실패했습니다. 나중에 다시 시도해 주세요.",
+    "description": "Message shown when account deletion fails"
   },
   "message.info": {
     "message": "정보",
@@ -538,6 +554,10 @@
   "nav.logOut": {
     "message": "로그아웃",
     "description": "사이트 내비게이션 바의 텍스트로 로그아웃을 표시합니다."
+  },
+  "nav.deleteAccount": {
+    "message": "계정 삭제",
+    "description": "Menu item to permanently delete the current user account"
   },
   "nav.site": {
     "message": "사이트 설정",

--- a/src/i18n/pl/common.json
+++ b/src/i18n/pl/common.json
@@ -215,6 +215,10 @@
     "message": "Ładowanie...",
     "description": "Tekst stanu wyświetlany podczas ładowania treści"
   },
+  "error.appleSignInFailed": {
+    "message": "Logowanie przez Apple nie powiodło się. Spróbuj ponownie lub użyj innej metody logowania.",
+    "description": "Error toast shown when native Apple sign-in fails for a reason other than user cancellation"
+  },
   "entity.operation": {
     "message": "Operacja",
     "description": "Operacja encji"
@@ -342,6 +346,18 @@
   "message.alert": {
     "message": "Ostrzeżenie",
     "description": "Komunikat ostrzegający użytkownika"
+  },
+  "message.deleteAccountConfirm": {
+    "message": "Spowoduje to trwałe usunięcie Twojego konta i wszystkich powiązanych danych. Tej operacji nie można cofnąć. Czy na pewno chcesz kontynuować?",
+    "description": "Confirmation message shown before permanently deleting the user account"
+  },
+  "message.deleteAccountSuccess": {
+    "message": "Twoje konto zostało usunięte.",
+    "description": "Message shown after the user account is successfully deleted"
+  },
+  "message.deleteAccountFailed": {
+    "message": "Nie udało się usunąć konta. Spróbuj ponownie później.",
+    "description": "Message shown when account deletion fails"
   },
   "message.info": {
     "message": "Informacja",
@@ -538,6 +554,10 @@
   "nav.logOut": {
     "message": "Wyloguj się",
     "description": "Tekst w nawigacji strony, który służy do wylogowania"
+  },
+  "nav.deleteAccount": {
+    "message": "Usuń konto",
+    "description": "Menu item to permanently delete the current user account"
   },
   "nav.site": {
     "message": "Konfiguracja strony",

--- a/src/i18n/pt/common.json
+++ b/src/i18n/pt/common.json
@@ -215,6 +215,10 @@
     "message": "Carregando...",
     "description": "Texto de status exibido enquanto o conteúdo está sendo carregado"
   },
+  "error.appleSignInFailed": {
+    "message": "Falha ao iniciar sessão com a Apple. Tente novamente ou utilize outro método de início de sessão.",
+    "description": "Error toast shown when native Apple sign-in fails for a reason other than user cancellation"
+  },
   "entity.operation": {
     "message": "Operação",
     "description": "Operação da entidade"
@@ -342,6 +346,18 @@
   "message.alert": {
     "message": "Atenção",
     "description": "Mensagem para alertar o usuário"
+  },
+  "message.deleteAccountConfirm": {
+    "message": "Isto irá eliminar permanentemente a sua conta e todos os dados associados. Esta ação não pode ser desfeita. Tem a certeza de que deseja continuar?",
+    "description": "Confirmation message shown before permanently deleting the user account"
+  },
+  "message.deleteAccountSuccess": {
+    "message": "A sua conta foi eliminada.",
+    "description": "Message shown after the user account is successfully deleted"
+  },
+  "message.deleteAccountFailed": {
+    "message": "Falha ao eliminar a sua conta. Tente novamente mais tarde.",
+    "description": "Message shown when account deletion fails"
   },
   "message.info": {
     "message": "Informação",
@@ -538,6 +554,10 @@
   "nav.logOut": {
     "message": "Sair",
     "description": "Texto na barra de navegação do site para sair da conta"
+  },
+  "nav.deleteAccount": {
+    "message": "Excluir conta",
+    "description": "Menu item to permanently delete the current user account"
   },
   "nav.site": {
     "message": "Configuração do Site",

--- a/src/i18n/ru/common.json
+++ b/src/i18n/ru/common.json
@@ -215,6 +215,10 @@
     "message": "Загрузка...",
     "description": "Текст статуса, отображаемый во время загрузки контента"
   },
+  "error.appleSignInFailed": {
+    "message": "Не удалось войти через Apple. Повторите попытку или используйте другой способ входа.",
+    "description": "Error toast shown when native Apple sign-in fails for a reason other than user cancellation"
+  },
   "entity.operation": {
     "message": "Операция",
     "description": "Операция сущности"
@@ -342,6 +346,18 @@
   "message.alert": {
     "message": "Предупреждение",
     "description": "Сообщение для предупреждения пользователя"
+  },
+  "message.deleteAccountConfirm": {
+    "message": "Это навсегда удалит вашу учётную запись и все связанные данные. Это действие нельзя отменить. Вы уверены, что хотите продолжить?",
+    "description": "Confirmation message shown before permanently deleting the user account"
+  },
+  "message.deleteAccountSuccess": {
+    "message": "Ваша учётная запись удалена.",
+    "description": "Message shown after the user account is successfully deleted"
+  },
+  "message.deleteAccountFailed": {
+    "message": "Не удалось удалить учётную запись. Повторите попытку позже.",
+    "description": "Message shown when account deletion fails"
   },
   "message.info": {
     "message": "Информация",
@@ -538,6 +554,10 @@
   "nav.logOut": {
     "message": "Выйти",
     "description": "网站导航栏中的文本，用于退出登录"
+  },
+  "nav.deleteAccount": {
+    "message": "Удалить аккаунт",
+    "description": "Menu item to permanently delete the current user account"
   },
   "nav.site": {
     "message": "Настройки сайта",

--- a/src/i18n/sr/common.json
+++ b/src/i18n/sr/common.json
@@ -215,6 +215,10 @@
     "message": "Učitavanje...",
     "description": "Statusni tekst koji se prikazuje dok se sadržaj učitava"
   },
+  "error.appleSignInFailed": {
+    "message": "Пријава помоћу Apple-а није успела. Покушајте поново или користите други начин пријаве.",
+    "description": "Error toast shown when native Apple sign-in fails for a reason other than user cancellation"
+  },
   "entity.operation": {
     "message": "Operacija",
     "description": "Operacija entiteta"
@@ -342,6 +346,18 @@
   "message.alert": {
     "message": "Upozorenje",
     "description": "Poruka koja upozorava korisnika"
+  },
+  "message.deleteAccountConfirm": {
+    "message": "Ово ће трајно обрисати ваш налог и све повезане податке. Ова радња се не може опозвати. Да ли сте сигурни да желите да наставите?",
+    "description": "Confirmation message shown before permanently deleting the user account"
+  },
+  "message.deleteAccountSuccess": {
+    "message": "Ваш налог је обрисан.",
+    "description": "Message shown after the user account is successfully deleted"
+  },
+  "message.deleteAccountFailed": {
+    "message": "Брисање налога није успело. Покушајте поново касније.",
+    "description": "Message shown when account deletion fails"
   },
   "message.info": {
     "message": "Informacija",
@@ -538,6 +554,10 @@
   "nav.logOut": {
     "message": "Odjavi se",
     "description": "网站导航栏中的文本，用于退出登录"
+  },
+  "nav.deleteAccount": {
+    "message": "Обриши налог",
+    "description": "Menu item to permanently delete the current user account"
   },
   "nav.site": {
     "message": "Podešavanje sajta",

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -215,6 +215,10 @@
     "message": "Laddar...",
     "description": "Statusmeddelande som visas när innehållet laddas"
   },
+  "error.appleSignInFailed": {
+    "message": "Det gick inte att logga in med Apple. Försök igen eller använd en annan inloggningsmetod.",
+    "description": "Error toast shown when native Apple sign-in fails for a reason other than user cancellation"
+  },
   "entity.operation": {
     "message": "Åtgärd",
     "description": "Åtgärden för enheten"
@@ -342,6 +346,18 @@
   "message.alert": {
     "message": "Varning",
     "description": "Meddelande för att varna användaren"
+  },
+  "message.deleteAccountConfirm": {
+    "message": "Detta raderar permanent ditt konto och all tillhörande data. Åtgärden kan inte ångras. Är du säker på att du vill fortsätta?",
+    "description": "Confirmation message shown before permanently deleting the user account"
+  },
+  "message.deleteAccountSuccess": {
+    "message": "Ditt konto har raderats.",
+    "description": "Message shown after the user account is successfully deleted"
+  },
+  "message.deleteAccountFailed": {
+    "message": "Det gick inte att radera ditt konto. Försök igen senare.",
+    "description": "Message shown when account deletion fails"
   },
   "message.info": {
     "message": "Information",
@@ -538,6 +554,10 @@
   "nav.logOut": {
     "message": "Logga ut",
     "description": "Text in the website navigation bar for logging out"
+  },
+  "nav.deleteAccount": {
+    "message": "Radera konto",
+    "description": "Menu item to permanently delete the current user account"
   },
   "nav.site": {
     "message": "Webbplatsinställningar",

--- a/src/i18n/uk/common.json
+++ b/src/i18n/uk/common.json
@@ -215,6 +215,10 @@
     "message": "Завантаження...",
     "description": "Текст статусу, що відображається під час завантаження контенту"
   },
+  "error.appleSignInFailed": {
+    "message": "Не вдалося ввійти через Apple. Спробуйте ще раз або скористайтеся іншим способом входу.",
+    "description": "Error toast shown when native Apple sign-in fails for a reason other than user cancellation"
+  },
   "entity.operation": {
     "message": "Операція",
     "description": "Операція сутності"
@@ -342,6 +346,18 @@
   "message.alert": {
     "message": "Увага",
     "description": "Повідомлення для попередження користувача"
+  },
+  "message.deleteAccountConfirm": {
+    "message": "Це назавжди видалить ваш обліковий запис і всі пов’язані дані. Цю дію не можна скасувати. Ви впевнені, що хочете продовжити?",
+    "description": "Confirmation message shown before permanently deleting the user account"
+  },
+  "message.deleteAccountSuccess": {
+    "message": "Ваш обліковий запис видалено.",
+    "description": "Message shown after the user account is successfully deleted"
+  },
+  "message.deleteAccountFailed": {
+    "message": "Не вдалося видалити обліковий запис. Спробуйте пізніше.",
+    "description": "Message shown when account deletion fails"
   },
   "message.info": {
     "message": "Інформація",
@@ -538,6 +554,10 @@
   "nav.logOut": {
     "message": "Вийти",
     "description": "Текст у навігаційній панелі сайту для виходу з облікового запису"
+  },
+  "nav.deleteAccount": {
+    "message": "Видалити обліковий запис",
+    "description": "Menu item to permanently delete the current user account"
   },
   "nav.site": {
     "message": "Налаштування сайту",

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -215,6 +215,10 @@
     "message": "加载中...",
     "description": "内容加载时显示的状态文案"
   },
+  "error.appleSignInFailed": {
+    "message": "通过 Apple 登录失败，请重试或使用其他登录方式。",
+    "description": "当原生“通过 Apple 登录”因用户取消以外的原因失败时显示的错误提示。"
+  },
   "entity.operation": {
     "message": "操作",
     "description": "实体的操作"
@@ -342,6 +346,18 @@
   "message.alert": {
     "message": "警告",
     "description": "警告用户的消息"
+  },
+  "message.deleteAccountConfirm": {
+    "message": "此操作将永久删除您的账号及所有相关数据，且无法恢复。确定要继续吗？",
+    "description": "永久删除用户账号前显示的确认消息"
+  },
+  "message.deleteAccountSuccess": {
+    "message": "您的账号已删除。",
+    "description": "成功删除用户账号后显示的消息"
+  },
+  "message.deleteAccountFailed": {
+    "message": "删除账号失败，请稍后重试。",
+    "description": "删除账号失败时显示的消息"
   },
   "message.info": {
     "message": "提示",
@@ -538,6 +554,10 @@
   "nav.logOut": {
     "message": "退出登录",
     "description": "网站导航栏中的文本，用于退出登录"
+  },
+  "nav.deleteAccount": {
+    "message": "删除账号",
+    "description": "用于永久删除当前用户账号的菜单项"
   },
   "nav.site": {
     "message": "站点配置",

--- a/src/i18n/zh-TW/common.json
+++ b/src/i18n/zh-TW/common.json
@@ -215,6 +215,10 @@
     "message": "載入中...",
     "description": "内容加载时显示的状态文案"
   },
+  "error.appleSignInFailed": {
+    "message": "透過 Apple 登入失敗，請重試或使用其他登入方式。",
+    "description": "Error toast shown when native Apple sign-in fails for a reason other than user cancellation"
+  },
   "entity.operation": {
     "message": "操作",
     "description": "实体的操作"
@@ -342,6 +346,18 @@
   "message.alert": {
     "message": "警告",
     "description": "警告用戶的消息"
+  },
+  "message.deleteAccountConfirm": {
+    "message": "此操作將永久刪除您的帳號及所有相關資料，且無法復原。確定要繼續嗎？",
+    "description": "Confirmation message shown before permanently deleting the user account"
+  },
+  "message.deleteAccountSuccess": {
+    "message": "您的帳號已刪除。",
+    "description": "Message shown after the user account is successfully deleted"
+  },
+  "message.deleteAccountFailed": {
+    "message": "刪除帳號失敗，請稍後再試。",
+    "description": "Message shown when account deletion fails"
   },
   "message.info": {
     "message": "提示",
@@ -538,6 +554,10 @@
   "nav.logOut": {
     "message": "登出",
     "description": "網站導航欄中的文本，用於登出"
+  },
+  "nav.deleteAccount": {
+    "message": "刪除帳號",
+    "description": "Menu item to permanently delete the current user account"
   },
   "nav.site": {
     "message": "站點配置",

--- a/src/operators/user.ts
+++ b/src/operators/user.ts
@@ -23,6 +23,10 @@ class UserOperator {
     return httpClient.put('/users/me', data);
   }
 
+  async deleteMe(): Promise<AxiosResponse<void>> {
+    return httpClient.delete('/users/me');
+  }
+
   async getVerify(): Promise<AxiosResponse<IUserDetailResponse>> {
     return httpClient.get('/users/verify');
   }

--- a/src/pages/profile/Index.vue
+++ b/src/pages/profile/Index.vue
@@ -30,7 +30,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElImage } from 'element-plus';
+import { ElImage, ElMessage, ElMessageBox } from 'element-plus';
 import {
   ROUTE_CONSOLE_APPLICATION_LIST,
   ROUTE_CONSOLE_ORDER_LIST,
@@ -41,6 +41,7 @@ import {
 } from '@/router';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { getBaseUrlAuth, getBaseUrlPlatform, withCurrentUserIdAndSite } from '@/utils';
+import { userOperator } from '@/operators';
 import HelpDialog from '@/components/common/HelpDialog.vue';
 
 interface ILink {
@@ -159,6 +160,14 @@ export default defineComponent({
             ]
           : []),
         {
+          key: 'delete-account',
+          text: this.$t('common.nav.deleteAccount'),
+          icon: 'fa-solid fa-user-xmark',
+          callback: () => {
+            this.onDeleteAccount();
+          }
+        },
+        {
           key: 'logout',
           text: this.$t('common.nav.logOut'),
           icon: 'fa-solid fa-arrow-right-from-bracket',
@@ -176,6 +185,29 @@ export default defineComponent({
       this.$router.push({
         name: ROUTE_INDEX
       });
+    },
+    async onDeleteAccount() {
+      try {
+        await ElMessageBox.confirm(
+          this.$t('common.message.deleteAccountConfirm').toString(),
+          this.$t('common.nav.deleteAccount').toString(),
+          {
+            type: 'warning',
+            confirmButtonText: this.$t('common.button.delete').toString(),
+            cancelButtonText: this.$t('common.button.cancel').toString()
+          }
+        );
+      } catch {
+        return;
+      }
+      try {
+        await userOperator.deleteMe();
+        ElMessage.success(this.$t('common.message.deleteAccountSuccess').toString());
+        await this.$store.dispatch('logout');
+        this.$router.push({ name: ROUTE_INDEX });
+      } catch {
+        ElMessage.error(this.$t('common.message.deleteAccountFailed').toString());
+      }
     },
     onNavigate(link: ILink) {
       if (link.name) {

--- a/src/plugins/font-awesome.ts
+++ b/src/plugins/font-awesome.ts
@@ -131,7 +131,8 @@ import {
   faBookOpen as faSolidBookOpen,
   faReceipt as faSolidReceipt,
   faDollarSign as faSolidDollarSign,
-  faFileExport as faSolidFileExport
+  faFileExport as faSolidFileExport,
+  faUserXmark as faSolidUserXmark
 } from '@fortawesome/free-solid-svg-icons';
 // add icons
 library.add(faSolidEllipsis);
@@ -200,6 +201,7 @@ library.add(faSolidWind);
 library.add(faSolidQrcode);
 library.add(faRegularComment);
 library.add(faSolidArrowRightFromBracket);
+library.add(faSolidUserXmark);
 library.add(faSolidTrash);
 library.add(faSolidChevronDown);
 library.add(faSolidPalette);


### PR DESCRIPTION
## Summary

Completes the fixes for the rejected iOS submission `920e0e58` (Nexior, App ID 6772432921). Addresses three of the reviewer's findings.

### 1. "Top Up" appears unresponsive (Guideline 2.1 — buttons do nothing)
PR #779 hid the IAP-less payment surfaces on iOS, but **three Top Up entry points were left ungated**, so on iOS they rendered but did nothing:
- chat message `btn-topup` (`components/chat/Message.vue`)
- the floating balance widget's Top Up button (`components/application/Info.vue`, surfaced via `Status.vue`)

Both are now gated behind `!isIOS()` so they no longer appear on iOS builds.

### 2. Apple Sign In could fail silently
`AuthPanel.vue` only `console.warn`-ed Apple sign-in failures. It now shows an `ElMessage.error` toast for genuine failures while still staying silent on user-cancellation (error code 1000/1001).

### 3. No in-app account deletion (Guideline 5.1.1(v))
Adds a **Delete Account** menu item to the profile page with an `ElMessageBox` confirmation. On confirm it calls `DELETE /users/me` (new `userOperator.deleteMe()`), shows a success toast, logs out, and routes home. Requires the paired AuthBackend endpoint: AceDataCloud/AuthBackend#170.

## i18n
New keys (`nav.deleteAccount`, `message.deleteAccount{Confirm,Success,Failed}`, plus the earlier `error.appleSignInFailed`) added to **all 17 locales**; `scripts/check_i18n_coverage.py` passes (17 locales × 39 namespaces).

## Notes
- Registered `fa-user-xmark` in the central `plugins/font-awesome.ts`.
- Beachball change file included.

## Related
- AceDataCloud/AuthBackend#170 (backend DELETE /users/me)