### PR TITLE
feat(profile): iOS-only delete entry with strict typed confirmation

### DIFF
--- a/change/@acedatacloud-nexior-delete-account-strict.json
+++ b/change/@acedatacloud-nexior-delete-account-strict.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Restrict the in-app Delete account entry to iOS and require typed-username confirmation before deletion",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "none"
+}

--- a/src/i18n/ar/common.json
+++ b/src/i18n/ar/common.json
@@ -966,5 +966,25 @@
   "appUpgrade.later": {
     "message": "Later",
     "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
+  },
+  "button.deletePermanently": {
+    "message": "حذف الحساب نهائيًا",
+    "description": "Final red delete button at the bottom of the delete confirmation dialog"
+  },
+  "message.deleteAccountWarning": {
+    "message": "هذا الإجراء لا يمكن التراجع عنه! سيتم حذف حسابك وجميع بياناته نهائيًا ولا يمكن استعادتها.",
+    "description": "Red warning banner at the top of the delete confirmation dialog"
+  },
+  "message.deleteAccountConsequences": {
+    "message": "سيتم حذفها نهائيًا: الملف الشخصي، الرصيد والنقاط، التطبيقات والاشتراكات، مفاتيح API، وروابط تسجيل الدخول من جهات خارجية.",
+    "description": "Explains what data will be removed in the delete confirmation dialog"
+  },
+  "message.deleteAccountTypePrompt": {
+    "message": "اكتب اسم المستخدم لتأكيد الحذف:",
+    "description": "Instructs the user to type their username to confirm; the username is shown separately below"
+  },
+  "message.deleteAccountPlaceholder": {
+    "message": "أدخل اسم المستخدم هنا",
+    "description": "Placeholder for the username confirmation input"
   }
 }

--- a/src/i18n/de/common.json
+++ b/src/i18n/de/common.json
@@ -966,5 +966,25 @@
   "appUpgrade.later": {
     "message": "Later",
     "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
+  },
+  "button.deletePermanently": {
+    "message": "Konto dauerhaft löschen",
+    "description": "Final red delete button at the bottom of the delete confirmation dialog"
+  },
+  "message.deleteAccountWarning": {
+    "message": "Diese Aktion ist unwiderruflich! Dein Konto und alle zugehörigen Daten werden dauerhaft gelöscht und können nicht wiederhergestellt werden.",
+    "description": "Red warning banner at the top of the delete confirmation dialog"
+  },
+  "message.deleteAccountConsequences": {
+    "message": "Dauerhaft gelöscht: Profil, Guthaben und Credits, Anwendungen und Abonnements, API-Schlüssel sowie Drittanbieter-Login-Verknüpfungen.",
+    "description": "Explains what data will be removed in the delete confirmation dialog"
+  },
+  "message.deleteAccountTypePrompt": {
+    "message": "Gib deinen Benutzernamen ein, um die Löschung zu bestätigen:",
+    "description": "Instructs the user to type their username to confirm; the username is shown separately below"
+  },
+  "message.deleteAccountPlaceholder": {
+    "message": "Gib hier deinen Benutzernamen ein",
+    "description": "Placeholder for the username confirmation input"
   }
 }

--- a/src/i18n/el/common.json
+++ b/src/i18n/el/common.json
@@ -966,5 +966,25 @@
   "appUpgrade.later": {
     "message": "Later",
     "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
+  },
+  "button.deletePermanently": {
+    "message": "Οριστική διαγραφή λογαριασμού",
+    "description": "Final red delete button at the bottom of the delete confirmation dialog"
+  },
+  "message.deleteAccountWarning": {
+    "message": "Αυτή η ενέργεια είναι μη αναστρέψιμη! Ο λογαριασμός σας και όλα τα δεδομένα του θα διαγραφούν οριστικά και δεν μπορούν να ανακτηθούν.",
+    "description": "Red warning banner at the top of the delete confirmation dialog"
+  },
+  "message.deleteAccountConsequences": {
+    "message": "Διαγράφονται οριστικά: προφίλ, υπόλοιπο και μονάδες, εφαρμογές και συνδρομές, κλειδιά API και συνδέσεις σύνδεσης τρίτων.",
+    "description": "Explains what data will be removed in the delete confirmation dialog"
+  },
+  "message.deleteAccountTypePrompt": {
+    "message": "Πληκτρολογήστε το όνομα χρήστη σας για να επιβεβαιώσετε τη διαγραφή:",
+    "description": "Instructs the user to type their username to confirm; the username is shown separately below"
+  },
+  "message.deleteAccountPlaceholder": {
+    "message": "Εισαγάγετε εδώ το όνομα χρήστη σας",
+    "description": "Placeholder for the username confirmation input"
   }
 }

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -966,5 +966,25 @@
   "appUpgrade.later": {
     "message": "Later",
     "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
+  },
+  "button.deletePermanently": {
+    "message": "Permanently delete account",
+    "description": "Final red delete button at the bottom of the delete confirmation dialog"
+  },
+  "message.deleteAccountWarning": {
+    "message": "This action is irreversible! Your account and all of its data will be permanently deleted and cannot be recovered.",
+    "description": "Red warning banner at the top of the delete confirmation dialog"
+  },
+  "message.deleteAccountConsequences": {
+    "message": "Permanently deleted: profile, balance and credits, applications and subscriptions, API keys, and third-party login bindings.",
+    "description": "Explains what data will be removed in the delete confirmation dialog"
+  },
+  "message.deleteAccountTypePrompt": {
+    "message": "Type your username to confirm deletion:",
+    "description": "Instructs the user to type their username to confirm; the username is shown separately below"
+  },
+  "message.deleteAccountPlaceholder": {
+    "message": "Enter your username here",
+    "description": "Placeholder for the username confirmation input"
   }
 }

--- a/src/i18n/es/common.json
+++ b/src/i18n/es/common.json
@@ -966,5 +966,25 @@
   "appUpgrade.later": {
     "message": "Later",
     "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
+  },
+  "button.deletePermanently": {
+    "message": "Eliminar cuenta permanentemente",
+    "description": "Final red delete button at the bottom of the delete confirmation dialog"
+  },
+  "message.deleteAccountWarning": {
+    "message": "¡Esta acción es irreversible! Tu cuenta y todos sus datos se eliminarán de forma permanente y no se podrán recuperar.",
+    "description": "Red warning banner at the top of the delete confirmation dialog"
+  },
+  "message.deleteAccountConsequences": {
+    "message": "Se eliminan de forma permanente: perfil, saldo y créditos, aplicaciones y suscripciones, claves de API y vínculos de inicio de sesión de terceros.",
+    "description": "Explains what data will be removed in the delete confirmation dialog"
+  },
+  "message.deleteAccountTypePrompt": {
+    "message": "Escribe tu nombre de usuario para confirmar la eliminación:",
+    "description": "Instructs the user to type their username to confirm; the username is shown separately below"
+  },
+  "message.deleteAccountPlaceholder": {
+    "message": "Escribe aquí tu nombre de usuario",
+    "description": "Placeholder for the username confirmation input"
   }
 }

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -966,5 +966,25 @@
   "appUpgrade.later": {
     "message": "Later",
     "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
+  },
+  "button.deletePermanently": {
+    "message": "Poista tili pysyvästi",
+    "description": "Final red delete button at the bottom of the delete confirmation dialog"
+  },
+  "message.deleteAccountWarning": {
+    "message": "Tätä toimintoa ei voi peruuttaa! Tilisi ja kaikki sen tiedot poistetaan pysyvästi eikä niitä voi palauttaa.",
+    "description": "Red warning banner at the top of the delete confirmation dialog"
+  },
+  "message.deleteAccountConsequences": {
+    "message": "Poistetaan pysyvästi: profiili, saldo ja krediitit, sovellukset ja tilaukset, API-avaimet sekä kolmannen osapuolen kirjautumissidokset.",
+    "description": "Explains what data will be removed in the delete confirmation dialog"
+  },
+  "message.deleteAccountTypePrompt": {
+    "message": "Kirjoita käyttäjänimesi vahvistaaksesi poiston:",
+    "description": "Instructs the user to type their username to confirm; the username is shown separately below"
+  },
+  "message.deleteAccountPlaceholder": {
+    "message": "Kirjoita käyttäjänimesi tähän",
+    "description": "Placeholder for the username confirmation input"
   }
 }

--- a/src/i18n/fr/common.json
+++ b/src/i18n/fr/common.json
@@ -966,5 +966,25 @@
   "appUpgrade.later": {
     "message": "Later",
     "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
+  },
+  "button.deletePermanently": {
+    "message": "Supprimer définitivement le compte",
+    "description": "Final red delete button at the bottom of the delete confirmation dialog"
+  },
+  "message.deleteAccountWarning": {
+    "message": "Cette action est irréversible ! Votre compte et toutes ses données seront définitivement supprimés et ne pourront pas être récupérés.",
+    "description": "Red warning banner at the top of the delete confirmation dialog"
+  },
+  "message.deleteAccountConsequences": {
+    "message": "Supprimés définitivement : profil, solde et crédits, applications et abonnements, clés API et liaisons de connexion tierces.",
+    "description": "Explains what data will be removed in the delete confirmation dialog"
+  },
+  "message.deleteAccountTypePrompt": {
+    "message": "Saisissez votre nom d'utilisateur pour confirmer la suppression :",
+    "description": "Instructs the user to type their username to confirm; the username is shown separately below"
+  },
+  "message.deleteAccountPlaceholder": {
+    "message": "Saisissez votre nom d'utilisateur ici",
+    "description": "Placeholder for the username confirmation input"
   }
 }

--- a/src/i18n/it/common.json
+++ b/src/i18n/it/common.json
@@ -966,5 +966,25 @@
   "appUpgrade.later": {
     "message": "Later",
     "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
+  },
+  "button.deletePermanently": {
+    "message": "Elimina account in modo permanente",
+    "description": "Final red delete button at the bottom of the delete confirmation dialog"
+  },
+  "message.deleteAccountWarning": {
+    "message": "Questa azione è irreversibile! Il tuo account e tutti i suoi dati verranno eliminati definitivamente e non potranno essere recuperati.",
+    "description": "Red warning banner at the top of the delete confirmation dialog"
+  },
+  "message.deleteAccountConsequences": {
+    "message": "Eliminati definitivamente: profilo, saldo e crediti, applicazioni e abbonamenti, chiavi API e collegamenti di accesso di terze parti.",
+    "description": "Explains what data will be removed in the delete confirmation dialog"
+  },
+  "message.deleteAccountTypePrompt": {
+    "message": "Digita il tuo nome utente per confermare l'eliminazione:",
+    "description": "Instructs the user to type their username to confirm; the username is shown separately below"
+  },
+  "message.deleteAccountPlaceholder": {
+    "message": "Inserisci qui il tuo nome utente",
+    "description": "Placeholder for the username confirmation input"
   }
 }

--- a/src/i18n/ja/common.json
+++ b/src/i18n/ja/common.json
@@ -966,5 +966,25 @@
   "appUpgrade.later": {
     "message": "Later",
     "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
+  },
+  "button.deletePermanently": {
+    "message": "アカウントを完全に削除",
+    "description": "Final red delete button at the bottom of the delete confirmation dialog"
+  },
+  "message.deleteAccountWarning": {
+    "message": "この操作は取り消せません！アカウントとそのすべてのデータは完全に削除され、復元できません。",
+    "description": "Red warning banner at the top of the delete confirmation dialog"
+  },
+  "message.deleteAccountConsequences": {
+    "message": "完全に削除されるもの：プロフィール、残高とクレジット、アプリケーションとサブスクリプション、API キー、サードパーティのログイン連携。",
+    "description": "Explains what data will be removed in the delete confirmation dialog"
+  },
+  "message.deleteAccountTypePrompt": {
+    "message": "削除を確認するには、ユーザー名を入力してください：",
+    "description": "Instructs the user to type their username to confirm; the username is shown separately below"
+  },
+  "message.deleteAccountPlaceholder": {
+    "message": "ここにユーザー名を入力",
+    "description": "Placeholder for the username confirmation input"
   }
 }

--- a/src/i18n/ko/common.json
+++ b/src/i18n/ko/common.json
@@ -966,5 +966,25 @@
   "appUpgrade.later": {
     "message": "Later",
     "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
+  },
+  "button.deletePermanently": {
+    "message": "계정 영구 삭제",
+    "description": "Final red delete button at the bottom of the delete confirmation dialog"
+  },
+  "message.deleteAccountWarning": {
+    "message": "이 작업은 되돌릴 수 없습니다! 계정과 모든 데이터가 영구적으로 삭제되며 복구할 수 없습니다.",
+    "description": "Red warning banner at the top of the delete confirmation dialog"
+  },
+  "message.deleteAccountConsequences": {
+    "message": "영구 삭제: 프로필, 잔액 및 크레딧, 애플리케이션 및 구독, API 키, 타사 로그인 연결.",
+    "description": "Explains what data will be removed in the delete confirmation dialog"
+  },
+  "message.deleteAccountTypePrompt": {
+    "message": "삭제를 확인하려면 사용자 이름을 입력하세요:",
+    "description": "Instructs the user to type their username to confirm; the username is shown separately below"
+  },
+  "message.deleteAccountPlaceholder": {
+    "message": "여기에 사용자 이름을 입력하세요",
+    "description": "Placeholder for the username confirmation input"
   }
 }

--- a/src/i18n/pl/common.json
+++ b/src/i18n/pl/common.json
@@ -966,5 +966,25 @@
   "appUpgrade.later": {
     "message": "Later",
     "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
+  },
+  "button.deletePermanently": {
+    "message": "Trwale usuń konto",
+    "description": "Final red delete button at the bottom of the delete confirmation dialog"
+  },
+  "message.deleteAccountWarning": {
+    "message": "Tej czynności nie można cofnąć! Twoje konto i wszystkie jego dane zostaną trwale usunięte i nie będzie można ich odzyskać.",
+    "description": "Red warning banner at the top of the delete confirmation dialog"
+  },
+  "message.deleteAccountConsequences": {
+    "message": "Trwale usunięte: profil, saldo i kredyty, aplikacje i subskrypcje, klucze API oraz powiązania logowania zewnętrznego.",
+    "description": "Explains what data will be removed in the delete confirmation dialog"
+  },
+  "message.deleteAccountTypePrompt": {
+    "message": "Wpisz swoją nazwę użytkownika, aby potwierdzić usunięcie:",
+    "description": "Instructs the user to type their username to confirm; the username is shown separately below"
+  },
+  "message.deleteAccountPlaceholder": {
+    "message": "Wpisz tutaj swoją nazwę użytkownika",
+    "description": "Placeholder for the username confirmation input"
   }
 }

--- a/src/i18n/pt/common.json
+++ b/src/i18n/pt/common.json
@@ -966,5 +966,25 @@
   "appUpgrade.later": {
     "message": "Later",
     "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
+  },
+  "button.deletePermanently": {
+    "message": "Excluir conta permanentemente",
+    "description": "Final red delete button at the bottom of the delete confirmation dialog"
+  },
+  "message.deleteAccountWarning": {
+    "message": "Esta ação é irreversível! Sua conta e todos os seus dados serão excluídos permanentemente e não poderão ser recuperados.",
+    "description": "Red warning banner at the top of the delete confirmation dialog"
+  },
+  "message.deleteAccountConsequences": {
+    "message": "Excluídos permanentemente: perfil, saldo e créditos, aplicativos e assinaturas, chaves de API e vínculos de login de terceiros.",
+    "description": "Explains what data will be removed in the delete confirmation dialog"
+  },
+  "message.deleteAccountTypePrompt": {
+    "message": "Digite seu nome de usuário para confirmar a exclusão:",
+    "description": "Instructs the user to type their username to confirm; the username is shown separately below"
+  },
+  "message.deleteAccountPlaceholder": {
+    "message": "Digite seu nome de usuário aqui",
+    "description": "Placeholder for the username confirmation input"
   }
 }

--- a/src/i18n/ru/common.json
+++ b/src/i18n/ru/common.json
@@ -966,5 +966,25 @@
   "appUpgrade.later": {
     "message": "Later",
     "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
+  },
+  "button.deletePermanently": {
+    "message": "Удалить аккаунт навсегда",
+    "description": "Final red delete button at the bottom of the delete confirmation dialog"
+  },
+  "message.deleteAccountWarning": {
+    "message": "Это действие необратимо! Ваш аккаунт и все его данные будут безвозвратно удалены и не подлежат восстановлению.",
+    "description": "Red warning banner at the top of the delete confirmation dialog"
+  },
+  "message.deleteAccountConsequences": {
+    "message": "Будут удалены навсегда: профиль, баланс и кредиты, приложения и подписки, ключи API и привязки сторонних входов.",
+    "description": "Explains what data will be removed in the delete confirmation dialog"
+  },
+  "message.deleteAccountTypePrompt": {
+    "message": "Введите имя пользователя, чтобы подтвердить удаление:",
+    "description": "Instructs the user to type their username to confirm; the username is shown separately below"
+  },
+  "message.deleteAccountPlaceholder": {
+    "message": "Введите имя пользователя здесь",
+    "description": "Placeholder for the username confirmation input"
   }
 }

--- a/src/i18n/sr/common.json
+++ b/src/i18n/sr/common.json
@@ -966,5 +966,25 @@
   "appUpgrade.later": {
     "message": "Later",
     "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
+  },
+  "button.deletePermanently": {
+    "message": "Трајно обриши налог",
+    "description": "Final red delete button at the bottom of the delete confirmation dialog"
+  },
+  "message.deleteAccountWarning": {
+    "message": "Ова радња је неповратна! Ваш налог и сви његови подаци биће трајно обрисани и не могу се повратити.",
+    "description": "Red warning banner at the top of the delete confirmation dialog"
+  },
+  "message.deleteAccountConsequences": {
+    "message": "Трајно се бришу: профил, стање и кредити, апликације и претплате, API кључеви и везе за пријаву трећих страна.",
+    "description": "Explains what data will be removed in the delete confirmation dialog"
+  },
+  "message.deleteAccountTypePrompt": {
+    "message": "Унесите своје корисничко име да бисте потврдили брисање:",
+    "description": "Instructs the user to type their username to confirm; the username is shown separately below"
+  },
+  "message.deleteAccountPlaceholder": {
+    "message": "Овде унесите своје корисничко име",
+    "description": "Placeholder for the username confirmation input"
   }
 }

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -966,5 +966,25 @@
   "appUpgrade.later": {
     "message": "Later",
     "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
+  },
+  "button.deletePermanently": {
+    "message": "Radera kontot permanent",
+    "description": "Final red delete button at the bottom of the delete confirmation dialog"
+  },
+  "message.deleteAccountWarning": {
+    "message": "Den här åtgärden kan inte ångras! Ditt konto och all dess data raderas permanent och kan inte återställas.",
+    "description": "Red warning banner at the top of the delete confirmation dialog"
+  },
+  "message.deleteAccountConsequences": {
+    "message": "Raderas permanent: profil, saldo och krediter, applikationer och prenumerationer, API-nycklar och tredjeparts inloggningskopplingar.",
+    "description": "Explains what data will be removed in the delete confirmation dialog"
+  },
+  "message.deleteAccountTypePrompt": {
+    "message": "Skriv ditt användarnamn för att bekräfta raderingen:",
+    "description": "Instructs the user to type their username to confirm; the username is shown separately below"
+  },
+  "message.deleteAccountPlaceholder": {
+    "message": "Ange ditt användarnamn här",
+    "description": "Placeholder for the username confirmation input"
   }
 }

--- a/src/i18n/uk/common.json
+++ b/src/i18n/uk/common.json
@@ -966,5 +966,25 @@
   "appUpgrade.later": {
     "message": "Later",
     "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
+  },
+  "button.deletePermanently": {
+    "message": "Назавжди видалити акаунт",
+    "description": "Final red delete button at the bottom of the delete confirmation dialog"
+  },
+  "message.deleteAccountWarning": {
+    "message": "Цю дію неможливо скасувати! Ваш акаунт і всі його дані буде назавжди видалено без можливості відновлення.",
+    "description": "Red warning banner at the top of the delete confirmation dialog"
+  },
+  "message.deleteAccountConsequences": {
+    "message": "Буде видалено назавжди: профіль, баланс і кредити, застосунки та підписки, ключі API та прив'язки сторонніх входів.",
+    "description": "Explains what data will be removed in the delete confirmation dialog"
+  },
+  "message.deleteAccountTypePrompt": {
+    "message": "Введіть своє ім'я користувача, щоб підтвердити видалення:",
+    "description": "Instructs the user to type their username to confirm; the username is shown separately below"
+  },
+  "message.deleteAccountPlaceholder": {
+    "message": "Введіть своє ім'я користувача тут",
+    "description": "Placeholder for the username confirmation input"
   }
 }

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -51,6 +51,10 @@
     "message": "删除",
     "description": "按钮中的文本，用于删除内容"
   },
+  "button.deletePermanently": {
+    "message": "永久删除账号",
+    "description": "删除账号确认对话框底部的红色最终删除按钮文本，translate to 'Permanently delete account'"
+  },
   "button.confirm": {
     "message": "确认",
     "description": "按钮中的文本，用于确认某项操作"
@@ -358,6 +362,22 @@
   "message.deleteAccountFailed": {
     "message": "删除账号失败，请稍后重试。",
     "description": "删除账号失败时显示的消息"
+  },
+  "message.deleteAccountWarning": {
+    "message": "此操作不可逆！您的账号及其所有数据将被永久删除，无法找回。",
+    "description": "删除账号确认对话框顶部的红色警示横幅文本，必须强烈警告操作不可撤销"
+  },
+  "message.deleteAccountConsequences": {
+    "message": "将永久删除：个人资料、余额与积分、应用与订阅、API 密钥及第三方登录绑定。",
+    "description": "删除账号确认对话框中列出将被删除内容的说明文本"
+  },
+  "message.deleteAccountTypePrompt": {
+    "message": "请输入您的用户名以确认删除：",
+    "description": "提示用户必须逐字输入自己的用户名才能确认删除；紧随其后会单独显示该用户名"
+  },
+  "message.deleteAccountPlaceholder": {
+    "message": "在此输入您的用户名",
+    "description": "用户名确认输入框的占位符"
   },
   "message.info": {
     "message": "提示",

--- a/src/i18n/zh-TW/common.json
+++ b/src/i18n/zh-TW/common.json
@@ -966,5 +966,25 @@
   "appUpgrade.later": {
     "message": "Later",
     "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
+  },
+  "button.deletePermanently": {
+    "message": "永久刪除帳號",
+    "description": "Final red delete button at the bottom of the delete confirmation dialog"
+  },
+  "message.deleteAccountWarning": {
+    "message": "此操作不可逆！您的帳號及其所有資料將被永久刪除，無法找回。",
+    "description": "Red warning banner at the top of the delete confirmation dialog"
+  },
+  "message.deleteAccountConsequences": {
+    "message": "將永久刪除：個人資料、餘額與點數、應用與訂閱、API 金鑰及第三方登入綁定。",
+    "description": "Explains what data will be removed in the delete confirmation dialog"
+  },
+  "message.deleteAccountTypePrompt": {
+    "message": "請輸入您的使用者名稱以確認刪除：",
+    "description": "Instructs the user to type their username to confirm; the username is shown separately below"
+  },
+  "message.deleteAccountPlaceholder": {
+    "message": "在此輸入您的使用者名稱",
+    "description": "Placeholder for the username confirmation input"
   }
 }

--- a/src/pages/profile/Index.vue
+++ b/src/pages/profile/Index.vue
@@ -25,12 +25,50 @@
     </div>
     <locale-selector :visible="operating.locale == true" @close="operating.locale = false" />
     <help-dialog :visible="operating.help == true" @close="operating.help = false" />
+    <el-dialog
+      v-model="deleteDialogVisible"
+      :title="$t('common.nav.deleteAccount')"
+      width="90%"
+      align-center
+      class="delete-account-dialog"
+      @closed="onDeleteDialogClosed"
+    >
+      <el-alert
+        :title="$t('common.message.deleteAccountWarning')"
+        type="error"
+        :closable="false"
+        show-icon
+        class="mb-3"
+      />
+      <p class="delete-consequences">{{ $t('common.message.deleteAccountConsequences') }}</p>
+      <p class="delete-type-prompt">{{ $t('common.message.deleteAccountTypePrompt') }}</p>
+      <p class="delete-username">{{ user.username }}</p>
+      <el-input
+        v-model="deleteConfirmText"
+        :placeholder="$t('common.message.deleteAccountPlaceholder')"
+        autocomplete="off"
+      />
+      <template #footer>
+        <el-button round @click="deleteDialogVisible = false">
+          {{ $t('common.button.cancel') }}
+        </el-button>
+        <el-button
+          type="danger"
+          round
+          :disabled="!deleteConfirmMatched"
+          :loading="deleting"
+          @click="confirmDeleteAccount"
+        >
+          {{ $t('common.button.deletePermanently') }}
+        </el-button>
+      </template>
+    </el-dialog>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElImage, ElMessage, ElMessageBox } from 'element-plus';
+import { ElImage, ElMessage, ElDialog, ElInput, ElButton, ElAlert } from 'element-plus';
 import {
   ROUTE_CONSOLE_APPLICATION_LIST,
   ROUTE_CONSOLE_ORDER_LIST,
@@ -40,7 +78,7 @@ import {
   ROUTE_SETTINGS_INDEX
 } from '@/router';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlAuth, getBaseUrlPlatform, withCurrentUserIdAndSite } from '@/utils';
+import { getBaseUrlAuth, getBaseUrlPlatform, isIOS, withCurrentUserIdAndSite } from '@/utils';
 import { userOperator } from '@/operators';
 import HelpDialog from '@/components/common/HelpDialog.vue';
 
@@ -57,6 +95,10 @@ export default defineComponent({
   name: 'ProfileIndex',
   components: {
     ElImage,
+    ElDialog,
+    ElInput,
+    ElButton,
+    ElAlert,
     HelpDialog,
     FontAwesomeIcon
   },
@@ -66,12 +108,21 @@ export default defineComponent({
         locale: false,
         dark: false,
         help: false
-      }
+      },
+      deleteDialogVisible: false,
+      deleteConfirmText: '',
+      deleting: false
     };
   },
   computed: {
     user() {
       return this.$store.getters.user;
+    },
+    // Require the user to type their exact username to unlock the
+    // irreversible delete — a locale-independent guard against misclicks.
+    deleteConfirmMatched(): boolean {
+      const username = this.$store.getters.user?.username;
+      return !!username && this.deleteConfirmText.trim() === username;
     },
     showSupport() {
       return (
@@ -159,14 +210,18 @@ export default defineComponent({
               }
             ]
           : []),
-        {
-          key: 'delete-account',
-          text: this.$t('common.nav.deleteAccount'),
-          icon: 'fa-solid fa-user-xmark',
-          callback: () => {
-            this.onDeleteAccount();
-          }
-        },
+        ...(isIOS()
+          ? [
+              {
+                key: 'delete-account',
+                text: this.$t('common.nav.deleteAccount'),
+                icon: 'fa-solid fa-user-xmark',
+                callback: () => {
+                  this.onDeleteAccount();
+                }
+              }
+            ]
+          : []),
         {
           key: 'logout',
           text: this.$t('common.nav.logOut'),
@@ -186,28 +241,29 @@ export default defineComponent({
         name: ROUTE_INDEX
       });
     },
-    async onDeleteAccount() {
-      try {
-        await ElMessageBox.confirm(
-          this.$t('common.message.deleteAccountConfirm').toString(),
-          this.$t('common.nav.deleteAccount').toString(),
-          {
-            type: 'warning',
-            confirmButtonText: this.$t('common.button.delete').toString(),
-            cancelButtonText: this.$t('common.button.cancel').toString()
-          }
-        );
-      } catch {
+    onDeleteAccount() {
+      this.deleteConfirmText = '';
+      this.deleteDialogVisible = true;
+    },
+    async confirmDeleteAccount() {
+      if (!this.deleteConfirmMatched || this.deleting) {
         return;
       }
+      this.deleting = true;
       try {
         await userOperator.deleteMe();
+        this.deleting = false;
+        this.deleteDialogVisible = false;
         ElMessage.success(this.$t('common.message.deleteAccountSuccess').toString());
         await this.$store.dispatch('logout');
         this.$router.push({ name: ROUTE_INDEX });
       } catch {
+        this.deleting = false;
         ElMessage.error(this.$t('common.message.deleteAccountFailed').toString());
       }
+    },
+    onDeleteDialogClosed() {
+      this.deleteConfirmText = '';
     },
     onNavigate(link: ILink) {
       if (link.name) {
@@ -312,6 +368,31 @@ $padding-left: 10px;
     .text {
       font-size: 14px;
     }
+  }
+}
+</style>
+
+<style lang="scss" scoped>
+.delete-account-dialog {
+  .mb-3 {
+    margin-bottom: 12px;
+  }
+  .delete-consequences {
+    margin: 12px 0;
+    font-size: 13px;
+    line-height: 1.6;
+    color: var(--el-text-color-regular);
+  }
+  .delete-type-prompt {
+    margin: 12px 0 4px;
+    font-size: 13px;
+  }
+  .delete-username {
+    margin: 0 0 10px;
+    font-weight: 700;
+    font-size: 15px;
+    word-break: break-all;
+    color: var(--el-color-danger);
   }
 }
 </style>


### PR DESCRIPTION
## What

Hardens the in-app account-deletion entry on the profile page.

## How

- **iOS-only entry** — the `Delete account` menu item now renders only when `isIOS()` is true. Web and Android surfaces use the AuthFrontend web flow instead; iOS shows it in-app to satisfy App Store Guideline 5.1.1(v).
- **Strict typed confirmation** — replaced the one-tap `ElMessageBox.confirm` with a danger dialog that:
  - shows a red irreversible-action warning banner,
  - lists exactly what gets deleted (profile, balance & credits, applications, API keys, third-party logins),
  - requires the user to **type their exact username** to enable the red **Permanently delete account** button.
- On success: calls `DELETE /users/me` (AuthBackend self-delete, #170), shows a toast, logs out, and returns to the home page.

## i18n

New keys (`button.deletePermanently`, `message.deleteAccountWarning/Consequences/TypePrompt/Placeholder`) added to `zh-CN` and backfilled across all 17 target locales. `scripts/check_i18n_coverage.py` passes locally.

## Notes

A beachball change file is included (minor). Backend already supports the call (#170); no backend change needed.