### PR TITLE
feat: add Coding Bridge remote agent control

### DIFF
--- a/change/@acedatacloud-nexior-coding-bridge-feature.json
+++ b/change/@acedatacloud-nexior-coding-bridge-feature.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add Coding Bridge remote agent control (device pairing + live agent session UI)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "none"
+}

--- a/src/components/codingBridge/NodeList.vue
+++ b/src/components/codingBridge/NodeList.vue
@@ -1,0 +1,138 @@
+<template>
+  <div class="node-list flex flex-col h-full bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]">
+    <div class="flex items-center justify-between px-4 py-3 border-b border-[var(--app-border-subtle)]">
+      <div class="flex items-center gap-2 font-medium">
+        <font-awesome-icon icon="fa-solid fa-laptop-code" />
+        <span>{{ $t('codingBridge.nodeList.title') }}</span>
+      </div>
+      <div class="flex items-center gap-1">
+        <el-button circle size="small" :title="$t('codingBridge.nodeList.refresh')" @click="onRefresh">
+          <font-awesome-icon icon="fa-solid fa-rotate-right" />
+        </el-button>
+        <el-button type="primary" circle size="small" :title="$t('codingBridge.nodeList.pair')" @click="$emit('pair')">
+          <font-awesome-icon icon="fa-solid fa-plus" />
+        </el-button>
+      </div>
+    </div>
+
+    <div class="flex items-center gap-2 px-4 py-2 text-xs border-b border-[var(--app-border-subtle)]">
+      <span class="inline-block w-2 h-2 rounded-full" :class="connectionDotClass" />
+      <span class="text-[var(--app-text-subtle)]">{{ connectionLabel }}</span>
+    </div>
+
+    <div class="flex-1 overflow-y-auto">
+      <div v-if="!nodes.length" class="p-6 text-center text-sm text-[var(--app-text-subtle)]">
+        <p class="mb-3">{{ $t('codingBridge.nodeList.empty') }}</p>
+        <el-button type="primary" round size="small" @click="$emit('pair')">
+          <font-awesome-icon icon="fa-solid fa-plus" class="mr-1" />
+          {{ $t('codingBridge.nodeList.pairFirst') }}
+        </el-button>
+      </div>
+      <ul v-else class="list-none m-0 p-0">
+        <li
+          v-for="node in nodes"
+          :key="node.node_id"
+          class="group flex items-center gap-3 px-4 py-3 cursor-pointer border-b border-[var(--app-border-subtle)] hover:bg-[var(--app-content-bg)]"
+          :class="{ 'bg-[var(--app-content-bg)]': node.node_id === currentNodeId }"
+          @click="onSelect(node.node_id)"
+        >
+          <font-awesome-icon icon="fa-solid fa-desktop" class="text-[var(--app-text-subtle)]" />
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center gap-2">
+              <span class="truncate font-medium">{{ node.name }}</span>
+              <span
+                class="inline-block w-2 h-2 rounded-full flex-none"
+                :class="node.status === 'online' ? 'bg-[var(--el-color-success)]' : 'bg-[var(--app-text-subtle)]'"
+                :title="node.status === 'online' ? $t('codingBridge.status.online') : $t('codingBridge.status.offline')"
+              />
+            </div>
+            <div class="text-xs text-[var(--app-text-subtle)] truncate">
+              {{ node.status === 'online' ? $t('codingBridge.status.online') : $t('codingBridge.status.offline') }}
+            </div>
+          </div>
+          <el-button
+            class="opacity-0 group-hover:opacity-100"
+            text
+            circle
+            size="small"
+            :title="$t('codingBridge.nodeList.remove')"
+            @click.stop="onDelete(node)"
+          >
+            <font-awesome-icon icon="fa-solid fa-trash" />
+          </el-button>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElButton, ElMessage, ElMessageBox } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { ICodingBridgeConnectionStatus, ICodingBridgeNode } from '@/models';
+
+export default defineComponent({
+  name: 'CodingBridgeNodeList',
+  components: {
+    ElButton,
+    FontAwesomeIcon
+  },
+  emits: ['pair'],
+  computed: {
+    nodes(): ICodingBridgeNode[] {
+      return this.$store.state.codingBridge?.nodes ?? [];
+    },
+    currentNodeId(): string | undefined {
+      return this.$store.state.codingBridge?.currentNodeId;
+    },
+    connection(): ICodingBridgeConnectionStatus {
+      return this.$store.state.codingBridge?.connection ?? 'disconnected';
+    },
+    connectionLabel(): string {
+      return this.$t(`codingBridge.connection.${this.connection}`) as string;
+    },
+    connectionDotClass(): string {
+      switch (this.connection) {
+        case 'connected':
+          return 'bg-[var(--el-color-success)]';
+        case 'connecting':
+          return 'bg-[var(--el-color-warning)]';
+        case 'error':
+          return 'bg-[var(--el-color-danger)]';
+        default:
+          return 'bg-[var(--app-text-subtle)]';
+      }
+    }
+  },
+  methods: {
+    onSelect(nodeId: string) {
+      this.$store.dispatch('codingBridge/selectNode', nodeId);
+    },
+    onRefresh() {
+      this.$store.dispatch('codingBridge/getNodes');
+    },
+    async onDelete(node: ICodingBridgeNode) {
+      try {
+        await ElMessageBox.confirm(
+          this.$t('codingBridge.nodeList.removeConfirm', { name: node.name }) as string,
+          this.$t('codingBridge.nodeList.remove') as string,
+          {
+            confirmButtonText: this.$t('codingBridge.nodeList.remove') as string,
+            cancelButtonText: this.$t('common.button.cancel') as string,
+            type: 'warning'
+          }
+        );
+      } catch {
+        return;
+      }
+      try {
+        await this.$store.dispatch('codingBridge/deleteNode', node.node_id);
+        ElMessage.success(this.$t('codingBridge.nodeList.removeSuccess') as string);
+      } catch {
+        ElMessage.error(this.$t('codingBridge.nodeList.removeFailed') as string);
+      }
+    }
+  }
+});
+</script>

--- a/src/components/codingBridge/PairDialog.vue
+++ b/src/components/codingBridge/PairDialog.vue
@@ -1,0 +1,151 @@
+<template>
+  <el-dialog
+    :model-value="visible"
+    width="520px"
+    :title="$t('codingBridge.pair.title')"
+    center
+    @update:model-value="$emit('update:visible', $event)"
+  >
+    <div class="content">
+      <p class="text-sm text-[var(--app-text-subtle)] mb-4">
+        {{ $t('codingBridge.pair.intro') }}
+      </p>
+
+      <ol class="steps list-none m-0 p-0 mb-4">
+        <li class="flex gap-3 mb-3">
+          <span class="step-index">1</span>
+          <div class="flex-1 min-w-0">
+            <p class="text-sm mb-1">{{ $t('codingBridge.pair.step1') }}</p>
+            <code class="cmd">pip install coding-bridge-agent</code>
+          </div>
+        </li>
+        <li class="flex gap-3 mb-3">
+          <span class="step-index">2</span>
+          <div class="flex-1 min-w-0">
+            <p class="text-sm mb-1">{{ $t('codingBridge.pair.step2') }}</p>
+            <code class="cmd">coding-bridge-agent up</code>
+          </div>
+        </li>
+        <li class="flex gap-3">
+          <span class="step-index">3</span>
+          <div class="flex-1 min-w-0">
+            <p class="text-sm">{{ $t('codingBridge.pair.step3') }}</p>
+          </div>
+        </li>
+      </ol>
+
+      <el-input
+        v-model="code"
+        size="large"
+        class="mb-3"
+        :placeholder="$t('codingBridge.pair.codePlaceholder')"
+        clearable
+        @keyup.enter="onClaim"
+      />
+      <el-button type="primary" round class="w-full" :loading="claiming" :disabled="!code.trim()" @click="onClaim">
+        <font-awesome-icon icon="fa-solid fa-link" class="mr-1" />
+        {{ $t('codingBridge.pair.claim') }}
+      </el-button>
+    </div>
+  </el-dialog>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElDialog, ElInput, ElButton, ElMessage } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { Status } from '@/models';
+
+export default defineComponent({
+  name: 'CodingBridgePairDialog',
+  components: {
+    ElDialog,
+    ElInput,
+    ElButton,
+    FontAwesomeIcon
+  },
+  props: {
+    visible: {
+      type: Boolean,
+      default: false
+    },
+    initialCode: {
+      type: String,
+      default: ''
+    }
+  },
+  emits: ['update:visible'],
+  data() {
+    return {
+      code: ''
+    };
+  },
+  computed: {
+    claiming(): boolean {
+      return this.$store.state.codingBridge?.status?.claimPair === Status.Request;
+    }
+  },
+  watch: {
+    visible(value: boolean) {
+      if (value && this.initialCode) {
+        this.code = this.initialCode;
+      }
+    },
+    initialCode(value: string) {
+      if (value) {
+        this.code = value;
+      }
+    }
+  },
+  methods: {
+    async onClaim() {
+      const code = this.code.trim();
+      if (!code) {
+        return;
+      }
+      try {
+        const name = await this.$store.dispatch('codingBridge/claimPair', code);
+        ElMessage.success(this.$t('codingBridge.pair.success', { name }) as string);
+        this.code = '';
+        this.$emit('update:visible', false);
+      } catch (error: any) {
+        const status = error?.response?.status;
+        if (status === 404) {
+          ElMessage.error(this.$t('codingBridge.pair.invalidCode') as string);
+        } else if (status === 409) {
+          ElMessage.error(this.$t('codingBridge.pair.usedCode') as string);
+        } else {
+          ElMessage.error(this.$t('codingBridge.pair.failed') as string);
+        }
+      }
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.step-index {
+  flex: none;
+  width: 24px;
+  height: 24px;
+  border-radius: 9999px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  color: #fff;
+  background-color: var(--el-color-primary);
+}
+
+.cmd {
+  display: block;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  padding: 6px 10px;
+  border-radius: 6px;
+  background-color: var(--app-sidebar-bg);
+  border: 1px solid var(--app-border-subtle);
+  overflow-x: auto;
+  white-space: nowrap;
+}
+</style>

--- a/src/components/codingBridge/PermissionDialog.vue
+++ b/src/components/codingBridge/PermissionDialog.vue
@@ -1,0 +1,93 @@
+<template>
+  <el-dialog
+    :model-value="!!request"
+    width="480px"
+    :title="$t('codingBridge.permission.title')"
+    :close-on-click-modal="false"
+    :show-close="false"
+    center
+  >
+    <div v-if="request" class="content">
+      <p class="text-sm text-[var(--app-text-subtle)] mb-3">
+        {{ $t('codingBridge.permission.subtitle') }}
+      </p>
+      <div class="rounded-md border border-[var(--app-border-subtle)] p-3 mb-3">
+        <div class="flex items-center gap-2 font-medium">
+          <font-awesome-icon icon="fa-solid fa-code" />
+          <span>{{ request.display_name || request.title || request.tool }}</span>
+        </div>
+        <p v-if="request.description" class="text-xs text-[var(--app-text-subtle)] mt-1">
+          {{ request.description }}
+        </p>
+        <pre
+          v-if="hasInput"
+          class="mt-2 text-xs overflow-x-auto whitespace-pre-wrap break-words text-[var(--app-text-subtle)] max-h-[200px]"
+          >{{ inputText }}</pre
+        >
+      </div>
+    </div>
+    <template #footer>
+      <div class="flex justify-end gap-2">
+        <el-button round @click="onDeny">
+          <font-awesome-icon icon="fa-solid fa-xmark" class="mr-1" />
+          {{ $t('codingBridge.permission.deny') }}
+        </el-button>
+        <el-button type="primary" round @click="onAllow">
+          <font-awesome-icon icon="fa-solid fa-check" class="mr-1" />
+          {{ $t('codingBridge.permission.allow') }}
+        </el-button>
+      </div>
+    </template>
+  </el-dialog>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElDialog, ElButton } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { ICodingBridgePermissionRequest } from '@/models';
+
+export default defineComponent({
+  name: 'CodingBridgePermissionDialog',
+  components: {
+    ElDialog,
+    ElButton,
+    FontAwesomeIcon
+  },
+  computed: {
+    request(): ICodingBridgePermissionRequest | undefined {
+      return this.$store.state.codingBridge?.permissions?.[0];
+    },
+    hasInput(): boolean {
+      return !!this.request?.input && Object.keys(this.request.input).length > 0;
+    },
+    inputText(): string {
+      try {
+        return JSON.stringify(this.request?.input, null, 2);
+      } catch {
+        return String(this.request?.input ?? '');
+      }
+    }
+  },
+  methods: {
+    onAllow() {
+      if (!this.request) {
+        return;
+      }
+      this.$store.dispatch('codingBridge/resolvePermission', {
+        request_id: this.request.request_id,
+        decision: 'allow'
+      });
+    },
+    onDeny() {
+      if (!this.request) {
+        return;
+      }
+      this.$store.dispatch('codingBridge/resolvePermission', {
+        request_id: this.request.request_id,
+        decision: 'deny'
+      });
+    }
+  }
+});
+</script>

--- a/src/components/codingBridge/SessionView.vue
+++ b/src/components/codingBridge/SessionView.vue
@@ -1,0 +1,177 @@
+<template>
+  <div class="session-view flex flex-col h-full bg-[var(--app-content-bg)]">
+    <!-- Empty: no device selected -->
+    <div
+      v-if="!currentNode"
+      class="flex-1 flex flex-col items-center justify-center text-center p-8 text-[var(--app-text-subtle)]"
+    >
+      <font-awesome-icon icon="fa-solid fa-laptop-code" class="text-4xl mb-3" />
+      <p class="text-sm">{{ $t('codingBridge.session.noDevice') }}</p>
+    </div>
+
+    <template v-else>
+      <!-- Header -->
+      <div class="flex items-center justify-between gap-3 px-5 py-3 border-b border-[var(--app-border-subtle)]">
+        <div class="min-w-0">
+          <div class="flex items-center gap-2 font-medium">
+            <span class="truncate">{{ currentNode.name }}</span>
+            <span
+              class="inline-block w-2 h-2 rounded-full flex-none"
+              :class="nodeOnline ? 'bg-[var(--el-color-success)]' : 'bg-[var(--app-text-subtle)]'"
+            />
+          </div>
+          <div v-if="currentSession" class="text-xs text-[var(--app-text-subtle)] truncate">
+            <span v-if="currentSession.cwd">{{ currentSession.cwd }}</span>
+            <span v-if="currentSession.model"> · {{ currentSession.model }}</span>
+          </div>
+        </div>
+        <el-button v-if="currentSessionId" size="small" round @click="onNewSession">
+          <font-awesome-icon icon="fa-solid fa-plus" class="mr-1" />
+          {{ $t('codingBridge.session.newSession') }}
+        </el-button>
+      </div>
+
+      <!-- Offline warning -->
+      <div
+        v-if="!nodeOnline"
+        class="px-5 py-2 text-xs bg-[var(--el-color-warning-light-9)] text-[var(--el-color-warning)] border-b border-[var(--app-border-subtle)]"
+      >
+        {{ $t('codingBridge.session.deviceOffline') }}
+      </div>
+
+      <!-- Transcript -->
+      <div ref="transcript" class="flex-1 overflow-y-auto px-5 py-4 flex flex-col gap-3">
+        <div v-if="!events.length" class="m-auto text-center text-sm text-[var(--app-text-subtle)]">
+          {{ $t('codingBridge.session.startHint') }}
+        </div>
+        <transcript-item v-for="event in events" :key="event.id" :event="event" />
+      </div>
+
+      <!-- Composer -->
+      <div class="border-t border-[var(--app-border-subtle)] p-3">
+        <div v-if="isNewSession" class="flex gap-2 mb-2">
+          <el-input v-model="cwd" size="small" :placeholder="$t('codingBridge.session.cwdPlaceholder')" clearable />
+          <el-input v-model="model" size="small" :placeholder="$t('codingBridge.session.modelPlaceholder')" clearable />
+        </div>
+        <div class="flex items-end gap-2">
+          <el-input
+            v-model="prompt"
+            type="textarea"
+            :autosize="{ minRows: 1, maxRows: 6 }"
+            resize="none"
+            class="flex-1"
+            :placeholder="$t('codingBridge.session.promptPlaceholder')"
+            @keydown.enter.exact.prevent="onSend"
+          />
+          <el-button v-if="running" round @click="onInterrupt">
+            <font-awesome-icon icon="fa-solid fa-stop" />
+          </el-button>
+          <el-button type="primary" round :disabled="!canSend" @click="onSend">
+            {{ $t('codingBridge.session.send') }}
+          </el-button>
+        </div>
+        <p class="text-[11px] text-[var(--app-text-subtle)] mt-1 px-1">
+          {{ $t('codingBridge.session.enterHint') }}
+        </p>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElInput, ElButton } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import TranscriptItem from './TranscriptItem.vue';
+import { ICodingBridgeEvent, ICodingBridgeNode, ICodingBridgeSession } from '@/models';
+
+export default defineComponent({
+  name: 'CodingBridgeSessionView',
+  components: {
+    ElInput,
+    ElButton,
+    FontAwesomeIcon,
+    TranscriptItem
+  },
+  data() {
+    return {
+      prompt: '',
+      cwd: '',
+      model: ''
+    };
+  },
+  computed: {
+    currentNodeId(): string | undefined {
+      return this.$store.state.codingBridge?.currentNodeId;
+    },
+    currentNode(): ICodingBridgeNode | undefined {
+      return this.$store.state.codingBridge?.nodes?.find((node) => node.node_id === this.currentNodeId);
+    },
+    nodeOnline(): boolean {
+      return this.currentNode?.status === 'online';
+    },
+    currentSessionId(): string | undefined {
+      return this.$store.state.codingBridge?.currentSessionId;
+    },
+    currentSession(): ICodingBridgeSession | undefined {
+      const id = this.currentSessionId;
+      return id ? this.$store.state.codingBridge?.sessions?.[id] : undefined;
+    },
+    events(): ICodingBridgeEvent[] {
+      const id = this.currentSessionId;
+      return id ? (this.$store.state.codingBridge?.events?.[id] ?? []) : [];
+    },
+    isNewSession(): boolean {
+      return !this.currentSessionId;
+    },
+    running(): boolean {
+      const status = this.currentSession?.status;
+      return status === 'running' || status === 'starting';
+    },
+    connected(): boolean {
+      return this.$store.state.codingBridge?.connection === 'connected';
+    },
+    canSend(): boolean {
+      return !!this.prompt.trim() && this.connected && this.nodeOnline;
+    }
+  },
+  watch: {
+    events() {
+      this.scrollToBottom();
+    },
+    currentSessionId() {
+      this.scrollToBottom();
+    }
+  },
+  methods: {
+    onSend() {
+      if (!this.canSend) {
+        return;
+      }
+      this.$store.dispatch('codingBridge/sendPrompt', {
+        prompt: this.prompt,
+        cwd: this.cwd,
+        model: this.model
+      });
+      this.prompt = '';
+    },
+    onInterrupt() {
+      this.$store.dispatch('codingBridge/interruptSession');
+    },
+    onNewSession() {
+      this.$store.dispatch('codingBridge/newSession');
+      this.cwd = '';
+      this.model = '';
+      this.prompt = '';
+    },
+    scrollToBottom() {
+      this.$nextTick(() => {
+        const el = this.$refs.transcript as HTMLElement | undefined;
+        if (el) {
+          el.scrollTop = el.scrollHeight;
+        }
+      });
+    }
+  }
+});
+</script>

--- a/src/components/codingBridge/TranscriptItem.vue
+++ b/src/components/codingBridge/TranscriptItem.vue
@@ -1,0 +1,111 @@
+<template>
+  <div class="transcript-item text-sm leading-relaxed" :class="`kind-${event.kind}`">
+    <!-- User prompt -->
+    <div v-if="event.kind === 'prompt'" class="flex justify-end">
+      <div
+        class="max-w-[85%] rounded-lg px-3 py-2 bg-[var(--el-color-primary)] text-white whitespace-pre-wrap break-words"
+      >
+        {{ event.text }}
+      </div>
+    </div>
+
+    <!-- Assistant text -->
+    <div v-else-if="event.kind === 'text'" class="whitespace-pre-wrap break-words text-[var(--app-text)]">
+      {{ event.text }}
+    </div>
+
+    <!-- Thinking -->
+    <div
+      v-else-if="event.kind === 'thinking'"
+      class="whitespace-pre-wrap break-words italic text-[var(--app-text-subtle)] border-l-2 border-[var(--app-border-subtle)] pl-3"
+    >
+      {{ event.text }}
+    </div>
+
+    <!-- Tool use -->
+    <div
+      v-else-if="event.kind === 'tool_use'"
+      class="rounded-md bg-[var(--app-sidebar-bg)] border border-[var(--app-border-subtle)] p-2"
+    >
+      <div class="flex items-center gap-2 text-[var(--app-text-subtle)] font-medium">
+        <font-awesome-icon icon="fa-solid fa-code" />
+        <span>{{ event.tool }}</span>
+      </div>
+      <pre
+        v-if="hasInput"
+        class="mt-1 text-xs overflow-x-auto whitespace-pre-wrap break-words text-[var(--app-text-subtle)]"
+        >{{ inputText }}</pre
+      >
+    </div>
+
+    <!-- Tool result -->
+    <div
+      v-else-if="event.kind === 'tool_result'"
+      class="rounded-md p-2 text-xs whitespace-pre-wrap break-words overflow-x-auto"
+      :class="
+        event.is_error
+          ? 'bg-[var(--el-color-danger-light-9)] text-[var(--el-color-danger)]'
+          : 'bg-[var(--app-sidebar-bg)] text-[var(--app-text-subtle)]'
+      "
+    >
+      {{ event.content }}
+    </div>
+
+    <!-- Turn result -->
+    <div v-else-if="event.kind === 'result'" class="flex items-center gap-2 text-xs text-[var(--app-text-subtle)]">
+      <font-awesome-icon :icon="event.is_error ? 'fa-solid fa-xmark' : 'fa-solid fa-check'" />
+      <span>{{ resultLabel }}</span>
+    </div>
+
+    <!-- Error -->
+    <div
+      v-else-if="event.kind === 'error'"
+      class="rounded-md bg-[var(--el-color-danger-light-9)] text-[var(--el-color-danger)] px-3 py-2 whitespace-pre-wrap break-words"
+    >
+      {{ event.text }}
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, PropType } from 'vue';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { ICodingBridgeEvent } from '@/models';
+
+export default defineComponent({
+  name: 'CodingBridgeTranscriptItem',
+  components: {
+    FontAwesomeIcon
+  },
+  props: {
+    event: {
+      type: Object as PropType<ICodingBridgeEvent>,
+      required: true
+    }
+  },
+  computed: {
+    hasInput(): boolean {
+      return !!this.event.input && Object.keys(this.event.input).length > 0;
+    },
+    inputText(): string {
+      try {
+        return JSON.stringify(this.event.input, null, 2);
+      } catch {
+        return String(this.event.input ?? '');
+      }
+    },
+    resultLabel(): string {
+      const parts: string[] = [];
+      if (this.event.is_error) {
+        parts.push(this.$t('codingBridge.transcript.turnFailed') as string);
+      } else {
+        parts.push(this.$t('codingBridge.transcript.turnDone') as string);
+      }
+      if (typeof this.event.cost_usd === 'number' && this.event.cost_usd > 0) {
+        parts.push(`$${this.event.cost_usd.toFixed(4)}`);
+      }
+      return parts.join(' · ');
+    }
+  }
+});
+</script>

--- a/src/constants/codingBridge.ts
+++ b/src/constants/codingBridge.ts
@@ -1,0 +1,43 @@
+/**
+ * Wire protocol shared with the `coding-bridge` relay and the node daemon.
+ *
+ * The OUTER envelope `type` is interpreted by the relay; the INNER payload
+ * (carrying `action` / `event`) is opaque to the relay and understood only by
+ * the browser and the node. These string values must stay in lock-step with
+ * `coding-bridge/worker/app/protocol.py` and the node daemon's `protocol.py`.
+ */
+
+// --- Outer envelope types (relay) ------------------------------------------
+export const CB_BROWSER_TO_NODE = 'browser.to_node';
+export const CB_BROWSER_LIST_NODES = 'browser.list_nodes';
+export const CB_NODE_TO_BROWSER = 'node.to_browser';
+export const CB_NODES_SNAPSHOT = 'nodes.snapshot';
+export const CB_NODE_STATUS = 'node.status';
+export const CB_ERROR = 'error';
+
+// --- Inner actions: browser -> node ----------------------------------------
+export const CB_ACTION_SESSION_START = 'session.start';
+export const CB_ACTION_SESSION_SEND = 'session.send';
+export const CB_ACTION_SESSION_INTERRUPT = 'session.interrupt';
+export const CB_ACTION_SESSION_CLOSE = 'session.close';
+export const CB_ACTION_PERMISSION_RESOLVE = 'permission.resolve';
+export const CB_ACTION_SESSIONS_LIST = 'sessions.list';
+export const CB_ACTION_PING = 'ping';
+
+// --- Inner events: node -> browser -----------------------------------------
+export const CB_EVENT_SESSION_STARTED = 'session.started';
+export const CB_EVENT_SESSION_TEXT = 'session.text';
+export const CB_EVENT_SESSION_THINKING = 'session.thinking';
+export const CB_EVENT_SESSION_TOOL_USE = 'session.tool_use';
+export const CB_EVENT_SESSION_TOOL_RESULT = 'session.tool_result';
+export const CB_EVENT_PERMISSION_REQUEST = 'permission.request';
+export const CB_EVENT_PERMISSION_RESOLVED = 'permission.resolved';
+export const CB_EVENT_SESSION_RESULT = 'session.result';
+export const CB_EVENT_SESSION_ERROR = 'session.error';
+export const CB_EVENT_SESSION_CLOSED = 'session.closed';
+export const CB_EVENT_SESSIONS_SNAPSHOT = 'sessions.snapshot';
+export const CB_EVENT_PONG = 'pong';
+
+// Reconnect backoff for the browser WebSocket (milliseconds).
+export const CB_RECONNECT_MIN_MS = 1000;
+export const CB_RECONNECT_MAX_MS = 15000;

--- a/src/constants/endpoint.ts
+++ b/src/constants/endpoint.ts
@@ -5,6 +5,15 @@ export const BASE_URL_HUB = isTest ? 'https://hub-test.acedata.cloud' : 'https:/
 export const BASE_URL_AUTH = isTest ? 'https://auth-test.acedata.cloud' : 'https://auth.acedata.cloud';
 export const BASE_URL_API = isTest ? 'https://api-test.acedata.cloud' : 'https://api.acedata.cloud';
 
+// Coding Bridge relay (stateful WebSocket hub). REST for pairing / node
+// management, plus a single browser WebSocket derived from the same origin.
+export const BASE_URL_CODING_BRIDGE = isTest
+  ? 'https://coding-bridge-test.acedata.cloud'
+  : 'https://coding-bridge.acedata.cloud';
+
+// Browser WebSocket endpoint: same host, https -> wss / http -> ws, path `/ws`.
+export const WS_URL_CODING_BRIDGE = `${BASE_URL_CODING_BRIDGE.replace(/^http/, 'ws')}/ws`;
+
 export const BASE_HOST_PLATFORM = new URL(BASE_URL_PLATFORM).host;
 export const BASE_HOST_HUB = new URL(BASE_URL_HUB).host;
 export const BASE_HOST_AUTH = new URL(BASE_URL_AUTH).host;

--- a/src/constants/i18n.ts
+++ b/src/constants/i18n.ts
@@ -60,5 +60,6 @@ export const I18N_SCOPES = [
   'connector',
   'byok',
   'subsite',
-  'webextrator'
+  'webextrator',
+  'codingBridge'
 ];

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -28,3 +28,4 @@ export * from './mapping';
 export * from './surface';
 export * from './mobile';
 export * from './setting';
+export * from './codingBridge';

--- a/src/i18n/ar/codingBridge.json
+++ b/src/i18n/ar/codingBridge.json
@@ -1,0 +1,166 @@
+{
+  "nodeList.title": {
+    "message": "Devices",
+    "description": "Coding Bridge device list title"
+  },
+  "nodeList.refresh": {
+    "message": "Refresh",
+    "description": "Refresh the device list"
+  },
+  "nodeList.pair": {
+    "message": "Pair device",
+    "description": "Open the pairing dialog"
+  },
+  "nodeList.empty": {
+    "message": "No devices paired yet.",
+    "description": "Empty device list message"
+  },
+  "nodeList.pairFirst": {
+    "message": "Pair your first device",
+    "description": "Empty-state pairing button"
+  },
+  "nodeList.remove": {
+    "message": "Remove",
+    "description": "Remove a device"
+  },
+  "nodeList.removeConfirm": {
+    "message": "Remove device \"{name}\"? It will need to be paired again.",
+    "description": "Device removal confirmation"
+  },
+  "nodeList.removeSuccess": {
+    "message": "Device removed.",
+    "description": "Device removed toast"
+  },
+  "nodeList.removeFailed": {
+    "message": "Failed to remove device.",
+    "description": "Device removal error toast"
+  },
+  "status.online": {
+    "message": "Online",
+    "description": "Device online status"
+  },
+  "status.offline": {
+    "message": "Offline",
+    "description": "Device offline status"
+  },
+  "connection.disconnected": {
+    "message": "Disconnected",
+    "description": "Relay connection disconnected"
+  },
+  "connection.connecting": {
+    "message": "Connecting…",
+    "description": "Relay connection connecting"
+  },
+  "connection.connected": {
+    "message": "Connected",
+    "description": "Relay connection connected"
+  },
+  "connection.error": {
+    "message": "Connection error",
+    "description": "Relay connection error"
+  },
+  "pair.title": {
+    "message": "Pair a device",
+    "description": "Pairing dialog title"
+  },
+  "pair.intro": {
+    "message": "Run the Coding Bridge agent on your computer, then enter its pairing code here to control it from the web.",
+    "description": "Pairing dialog intro"
+  },
+  "pair.step1": {
+    "message": "Install the agent (requires Python 3.10+):",
+    "description": "Pairing step 1"
+  },
+  "pair.step2": {
+    "message": "Start it and follow the prompt:",
+    "description": "Pairing step 2"
+  },
+  "pair.step3": {
+    "message": "Enter the pairing code it shows below.",
+    "description": "Pairing step 3"
+  },
+  "pair.codePlaceholder": {
+    "message": "Pairing code",
+    "description": "Pairing code input placeholder"
+  },
+  "pair.claim": {
+    "message": "Pair device",
+    "description": "Pairing confirm button"
+  },
+  "pair.success": {
+    "message": "Device \"{name}\" paired.",
+    "description": "Pairing success toast"
+  },
+  "pair.invalidCode": {
+    "message": "Invalid or expired pairing code.",
+    "description": "Pairing invalid code error"
+  },
+  "pair.usedCode": {
+    "message": "This pairing code has already been used.",
+    "description": "Pairing used code error"
+  },
+  "pair.failed": {
+    "message": "Failed to pair device.",
+    "description": "Pairing generic error"
+  },
+  "permission.title": {
+    "message": "Permission required",
+    "description": "Permission dialog title"
+  },
+  "permission.subtitle": {
+    "message": "The agent wants to use a tool. Approve to continue.",
+    "description": "Permission dialog subtitle"
+  },
+  "permission.deny": {
+    "message": "Deny",
+    "description": "Deny a tool permission"
+  },
+  "permission.allow": {
+    "message": "Allow",
+    "description": "Allow a tool permission"
+  },
+  "session.noDevice": {
+    "message": "Select a device to start coding.",
+    "description": "No device selected placeholder"
+  },
+  "session.newSession": {
+    "message": "New session",
+    "description": "Start a new session"
+  },
+  "session.deviceOffline": {
+    "message": "This device is offline. Start the Coding Bridge agent on it to continue.",
+    "description": "Device offline warning"
+  },
+  "session.startHint": {
+    "message": "Send a message to start a session on this device.",
+    "description": "Empty transcript hint"
+  },
+  "session.cwdPlaceholder": {
+    "message": "Working directory (optional)",
+    "description": "Working directory input placeholder"
+  },
+  "session.modelPlaceholder": {
+    "message": "Model (optional)",
+    "description": "Model input placeholder"
+  },
+  "session.promptPlaceholder": {
+    "message": "Send a message to the agent…",
+    "description": "Prompt input placeholder"
+  },
+  "session.send": {
+    "message": "Send",
+    "description": "Send prompt button"
+  },
+  "session.enterHint": {
+    "message": "Enter to send, Shift+Enter for a new line.",
+    "description": "Composer keyboard hint"
+  },
+  "transcript.turnFailed": {
+    "message": "Turn failed",
+    "description": "Turn result failed label"
+  },
+  "transcript.turnDone": {
+    "message": "Done",
+    "description": "Turn result done label"
+  }
+}

--- a/src/i18n/de/codingBridge.json
+++ b/src/i18n/de/codingBridge.json
@@ -1,0 +1,166 @@
+{
+  "nodeList.title": {
+    "message": "Devices",
+    "description": "Coding Bridge device list title"
+  },
+  "nodeList.refresh": {
+    "message": "Refresh",
+    "description": "Refresh the device list"
+  },
+  "nodeList.pair": {
+    "message": "Pair device",
+    "description": "Open the pairing dialog"
+  },
+  "nodeList.empty": {
+    "message": "No devices paired yet.",
+    "description": "Empty device list message"
+  },
+  "nodeList.pairFirst": {
+    "message": "Pair your first device",
+    "description": "Empty-state pairing button"
+  },
+  "nodeList.remove": {
+    "message": "Remove",
+    "description": "Remove a device"
+  },
+  "nodeList.removeConfirm": {
+    "message": "Remove device \"{name}\"? It will need to be paired again.",
+    "description": "Device removal confirmation"
+  },
+  "nodeList.removeSuccess": {
+    "message": "Device removed.",
+    "description": "Device removed toast"
+  },
+  "nodeList.removeFailed": {
+    "message": "Failed to remove device.",
+    "description": "Device removal error toast"
+  },
+  "status.online": {
+    "message": "Online",
+    "description": "Device online status"
+  },
+  "status.offline": {
+    "message": "Offline",
+    "description": "Device offline status"
+  },
+  "connection.disconnected": {
+    "message": "Disconnected",
+    "description": "Relay connection disconnected"
+  },
+  "connection.connecting": {
+    "message": "Connecting…",
+    "description": "Relay connection connecting"
+  },
+  "connection.connected": {
+    "message": "Connected",
+    "description": "Relay connection connected"
+  },
+  "connection.error": {
+    "message": "Connection error",
+    "description": "Relay connection error"
+  },
+  "pair.title": {
+    "message": "Pair a device",
+    "description": "Pairing dialog title"
+  },
+  "pair.intro": {
+    "message": "Run the Coding Bridge agent on your computer, then enter its pairing code here to control it from the web.",
+    "description": "Pairing dialog intro"
+  },
+  "pair.step1": {
+    "message": "Install the agent (requires Python 3.10+):",
+    "description": "Pairing step 1"
+  },
+  "pair.step2": {
+    "message": "Start it and follow the prompt:",
+    "description": "Pairing step 2"
+  },
+  "pair.step3": {
+    "message": "Enter the pairing code it shows below.",
+    "description": "Pairing step 3"
+  },
+  "pair.codePlaceholder": {
+    "message": "Pairing code",
+    "description": "Pairing code input placeholder"
+  },
+  "pair.claim": {
+    "message": "Pair device",
+    "description": "Pairing confirm button"
+  },
+  "pair.success": {
+    "message": "Device \"{name}\" paired.",
+    "description": "Pairing success toast"
+  },
+  "pair.invalidCode": {
+    "message": "Invalid or expired pairing code.",
+    "description": "Pairing invalid code error"
+  },
+  "pair.usedCode": {
+    "message": "This pairing code has already been used.",
+    "description": "Pairing used code error"
+  },
+  "pair.failed": {
+    "message": "Failed to pair device.",
+    "description": "Pairing generic error"
+  },
+  "permission.title": {
+    "message": "Permission required",
+    "description": "Permission dialog title"
+  },
+  "permission.subtitle": {
+    "message": "The agent wants to use a tool. Approve to continue.",
+    "description": "Permission dialog subtitle"
+  },
+  "permission.deny": {
+    "message": "Deny",
+    "description": "Deny a tool permission"
+  },
+  "permission.allow": {
+    "message": "Allow",
+    "description": "Allow a tool permission"
+  },
+  "session.noDevice": {
+    "message": "Select a device to start coding.",
+    "description": "No device selected placeholder"
+  },
+  "session.newSession": {
+    "message": "New session",
+    "description": "Start a new session"
+  },
+  "session.deviceOffline": {
+    "message": "This device is offline. Start the Coding Bridge agent on it to continue.",
+    "description": "Device offline warning"
+  },
+  "session.startHint": {
+    "message": "Send a message to start a session on this device.",
+    "description": "Empty transcript hint"
+  },
+  "session.cwdPlaceholder": {
+    "message": "Working directory (optional)",
+    "description": "Working directory input placeholder"
+  },
+  "session.modelPlaceholder": {
+    "message": "Model (optional)",
+    "description": "Model input placeholder"
+  },
+  "session.promptPlaceholder": {
+    "message": "Send a message to the agent…",
+    "description": "Prompt input placeholder"
+  },
+  "session.send": {
+    "message": "Send",
+    "description": "Send prompt button"
+  },
+  "session.enterHint": {
+    "message": "Enter to send, Shift+Enter for a new line.",
+    "description": "Composer keyboard hint"
+  },
+  "transcript.turnFailed": {
+    "message": "Turn failed",
+    "description": "Turn result failed label"
+  },
+  "transcript.turnDone": {
+    "message": "Done",
+    "description": "Turn result done label"
+  }
+}

--- a/src/i18n/el/codingBridge.json
+++ b/src/i18n/el/codingBridge.json
@@ -1,0 +1,166 @@
+{
+  "nodeList.title": {
+    "message": "Devices",
+    "description": "Coding Bridge device list title"
+  },
+  "nodeList.refresh": {
+    "message": "Refresh",
+    "description": "Refresh the device list"
+  },
+  "nodeList.pair": {
+    "message": "Pair device",
+    "description": "Open the pairing dialog"
+  },
+  "nodeList.empty": {
+    "message": "No devices paired yet.",
+    "description": "Empty device list message"
+  },
+  "nodeList.pairFirst": {
+    "message": "Pair your first device",
+    "description": "Empty-state pairing button"
+  },
+  "nodeList.remove": {
+    "message": "Remove",
+    "description": "Remove a device"
+  },
+  "nodeList.removeConfirm": {
+    "message": "Remove device \"{name}\"? It will need to be paired again.",
+    "description": "Device removal confirmation"
+  },
+  "nodeList.removeSuccess": {
+    "message": "Device removed.",
+    "description": "Device removed toast"
+  },
+  "nodeList.removeFailed": {
+    "message": "Failed to remove device.",
+    "description": "Device removal error toast"
+  },
+  "status.online": {
+    "message": "Online",
+    "description": "Device online status"
+  },
+  "status.offline": {
+    "message": "Offline",
+    "description": "Device offline status"
+  },
+  "connection.disconnected": {
+    "message": "Disconnected",
+    "description": "Relay connection disconnected"
+  },
+  "connection.connecting": {
+    "message": "Connecting…",
+    "description": "Relay connection connecting"
+  },
+  "connection.connected": {
+    "message": "Connected",
+    "description": "Relay connection connected"
+  },
+  "connection.error": {
+    "message": "Connection error",
+    "description": "Relay connection error"
+  },
+  "pair.title": {
+    "message": "Pair a device",
+    "description": "Pairing dialog title"
+  },
+  "pair.intro": {
+    "message": "Run the Coding Bridge agent on your computer, then enter its pairing code here to control it from the web.",
+    "description": "Pairing dialog intro"
+  },
+  "pair.step1": {
+    "message": "Install the agent (requires Python 3.10+):",
+    "description": "Pairing step 1"
+  },
+  "pair.step2": {
+    "message": "Start it and follow the prompt:",
+    "description": "Pairing step 2"
+  },
+  "pair.step3": {
+    "message": "Enter the pairing code it shows below.",
+    "description": "Pairing step 3"
+  },
+  "pair.codePlaceholder": {
+    "message": "Pairing code",
+    "description": "Pairing code input placeholder"
+  },
+  "pair.claim": {
+    "message": "Pair device",
+    "description": "Pairing confirm button"
+  },
+  "pair.success": {
+    "message": "Device \"{name}\" paired.",
+    "description": "Pairing success toast"
+  },
+  "pair.invalidCode": {
+    "message": "Invalid or expired pairing code.",
+    "description": "Pairing invalid code error"
+  },
+  "pair.usedCode": {
+    "message": "This pairing code has already been used.",
+    "description": "Pairing used code error"
+  },
+  "pair.failed": {
+    "message": "Failed to pair device.",
+    "description": "Pairing generic error"
+  },
+  "permission.title": {
+    "message": "Permission required",
+    "description": "Permission dialog title"
+  },
+  "permission.subtitle": {
+    "message": "The agent wants to use a tool. Approve to continue.",
+    "description": "Permission dialog subtitle"
+  },
+  "permission.deny": {
+    "message": "Deny",
+    "description": "Deny a tool permission"
+  },
+  "permission.allow": {
+    "message": "Allow",
+    "description": "Allow a tool permission"
+  },
+  "session.noDevice": {
+    "message": "Select a device to start coding.",
+    "description": "No device selected placeholder"
+  },
+  "session.newSession": {
+    "message": "New session",
+    "description": "Start a new session"
+  },
+  "session.deviceOffline": {
+    "message": "This device is offline. Start the Coding Bridge agent on it to continue.",
+    "description": "Device offline warning"
+  },
+  "session.startHint": {
+    "message": "Send a message to start a session on this device.",
+    "description": "Empty transcript hint"
+  },
+  "session.cwdPlaceholder": {
+    "message": "Working directory (optional)",
+    "description": "Working directory input placeholder"
+  },
+  "session.modelPlaceholder": {
+    "message": "Model (optional)",
+    "description": "Model input placeholder"
+  },
+  "session.promptPlaceholder": {
+    "message": "Send a message to the agent…",
+    "description": "Prompt input placeholder"
+  },
+  "session.send": {
+    "message": "Send",
+    "description": "Send prompt button"
+  },
+  "session.enterHint": {
+    "message": "Enter to send, Shift+Enter for a new line.",
+    "description": "Composer keyboard hint"
+  },
+  "transcript.turnFailed": {
+    "message": "Turn failed",
+    "description": "Turn result failed label"
+  },
+  "transcript.turnDone": {
+    "message": "Done",
+    "description": "Turn result done label"
+  }
+}

--- a/src/i18n/en/codingBridge.json
+++ b/src/i18n/en/codingBridge.json
@@ -1,0 +1,166 @@
+{
+  "nodeList.title": {
+    "message": "Devices",
+    "description": "Coding Bridge device list title"
+  },
+  "nodeList.refresh": {
+    "message": "Refresh",
+    "description": "Refresh the device list"
+  },
+  "nodeList.pair": {
+    "message": "Pair device",
+    "description": "Open the pairing dialog"
+  },
+  "nodeList.empty": {
+    "message": "No devices paired yet.",
+    "description": "Empty device list message"
+  },
+  "nodeList.pairFirst": {
+    "message": "Pair your first device",
+    "description": "Empty-state pairing button"
+  },
+  "nodeList.remove": {
+    "message": "Remove",
+    "description": "Remove a device"
+  },
+  "nodeList.removeConfirm": {
+    "message": "Remove device \"{name}\"? It will need to be paired again.",
+    "description": "Device removal confirmation"
+  },
+  "nodeList.removeSuccess": {
+    "message": "Device removed.",
+    "description": "Device removed toast"
+  },
+  "nodeList.removeFailed": {
+    "message": "Failed to remove device.",
+    "description": "Device removal error toast"
+  },
+  "status.online": {
+    "message": "Online",
+    "description": "Device online status"
+  },
+  "status.offline": {
+    "message": "Offline",
+    "description": "Device offline status"
+  },
+  "connection.disconnected": {
+    "message": "Disconnected",
+    "description": "Relay connection disconnected"
+  },
+  "connection.connecting": {
+    "message": "Connecting…",
+    "description": "Relay connection connecting"
+  },
+  "connection.connected": {
+    "message": "Connected",
+    "description": "Relay connection connected"
+  },
+  "connection.error": {
+    "message": "Connection error",
+    "description": "Relay connection error"
+  },
+  "pair.title": {
+    "message": "Pair a device",
+    "description": "Pairing dialog title"
+  },
+  "pair.intro": {
+    "message": "Run the Coding Bridge agent on your computer, then enter its pairing code here to control it from the web.",
+    "description": "Pairing dialog intro"
+  },
+  "pair.step1": {
+    "message": "Install the agent (requires Python 3.10+):",
+    "description": "Pairing step 1"
+  },
+  "pair.step2": {
+    "message": "Start it and follow the prompt:",
+    "description": "Pairing step 2"
+  },
+  "pair.step3": {
+    "message": "Enter the pairing code it shows below.",
+    "description": "Pairing step 3"
+  },
+  "pair.codePlaceholder": {
+    "message": "Pairing code",
+    "description": "Pairing code input placeholder"
+  },
+  "pair.claim": {
+    "message": "Pair device",
+    "description": "Pairing confirm button"
+  },
+  "pair.success": {
+    "message": "Device \"{name}\" paired.",
+    "description": "Pairing success toast"
+  },
+  "pair.invalidCode": {
+    "message": "Invalid or expired pairing code.",
+    "description": "Pairing invalid code error"
+  },
+  "pair.usedCode": {
+    "message": "This pairing code has already been used.",
+    "description": "Pairing used code error"
+  },
+  "pair.failed": {
+    "message": "Failed to pair device.",
+    "description": "Pairing generic error"
+  },
+  "permission.title": {
+    "message": "Permission required",
+    "description": "Permission dialog title"
+  },
+  "permission.subtitle": {
+    "message": "The agent wants to use a tool. Approve to continue.",
+    "description": "Permission dialog subtitle"
+  },
+  "permission.deny": {
+    "message": "Deny",
+    "description": "Deny a tool permission"
+  },
+  "permission.allow": {
+    "message": "Allow",
+    "description": "Allow a tool permission"
+  },
+  "session.noDevice": {
+    "message": "Select a device to start coding.",
+    "description": "No device selected placeholder"
+  },
+  "session.newSession": {
+    "message": "New session",
+    "description": "Start a new session"
+  },
+  "session.deviceOffline": {
+    "message": "This device is offline. Start the Coding Bridge agent on it to continue.",
+    "description": "Device offline warning"
+  },
+  "session.startHint": {
+    "message": "Send a message to start a session on this device.",
+    "description": "Empty transcript hint"
+  },
+  "session.cwdPlaceholder": {
+    "message": "Working directory (optional)",
+    "description": "Working directory input placeholder"
+  },
+  "session.modelPlaceholder": {
+    "message": "Model (optional)",
+    "description": "Model input placeholder"
+  },
+  "session.promptPlaceholder": {
+    "message": "Send a message to the agent…",
+    "description": "Prompt input placeholder"
+  },
+  "session.send": {
+    "message": "Send",
+    "description": "Send prompt button"
+  },
+  "session.enterHint": {
+    "message": "Enter to send, Shift+Enter for a new line.",
+    "description": "Composer keyboard hint"
+  },
+  "transcript.turnFailed": {
+    "message": "Turn failed",
+    "description": "Turn result failed label"
+  },
+  "transcript.turnDone": {
+    "message": "Done",
+    "description": "Turn result done label"
+  }
+}

--- a/src/i18n/es/codingBridge.json
+++ b/src/i18n/es/codingBridge.json
@@ -1,0 +1,166 @@
+{
+  "nodeList.title": {
+    "message": "Devices",
+    "description": "Coding Bridge device list title"
+  },
+  "nodeList.refresh": {
+    "message": "Refresh",
+    "description": "Refresh the device list"
+  },
+  "nodeList.pair": {
+    "message": "Pair device",
+    "description": "Open the pairing dialog"
+  },
+  "nodeList.empty": {
+    "message": "No devices paired yet.",
+    "description": "Empty device list message"
+  },
+  "nodeList.pairFirst": {
+    "message": "Pair your first device",
+    "description": "Empty-state pairing button"
+  },
+  "nodeList.remove": {
+    "message": "Remove",
+    "description": "Remove a device"
+  },
+  "nodeList.removeConfirm": {
+    "message": "Remove device \"{name}\"? It will need to be paired again.",
+    "description": "Device removal confirmation"
+  },
+  "nodeList.removeSuccess": {
+    "message": "Device removed.",
+    "description": "Device removed toast"
+  },
+  "nodeList.removeFailed": {
+    "message": "Failed to remove device.",
+    "description": "Device removal error toast"
+  },
+  "status.online": {
+    "message": "Online",
+    "description": "Device online status"
+  },
+  "status.offline": {
+    "message": "Offline",
+    "description": "Device offline status"
+  },
+  "connection.disconnected": {
+    "message": "Disconnected",
+    "description": "Relay connection disconnected"
+  },
+  "connection.connecting": {
+    "message": "Connecting…",
+    "description": "Relay connection connecting"
+  },
+  "connection.connected": {
+    "message": "Connected",
+    "description": "Relay connection connected"
+  },
+  "connection.error": {
+    "message": "Connection error",
+    "description": "Relay connection error"
+  },
+  "pair.title": {
+    "message": "Pair a device",
+    "description": "Pairing dialog title"
+  },
+  "pair.intro": {
+    "message": "Run the Coding Bridge agent on your computer, then enter its pairing code here to control it from the web.",
+    "description": "Pairing dialog intro"
+  },
+  "pair.step1": {
+    "message": "Install the agent (requires Python 3.10+):",
+    "description": "Pairing step 1"
+  },
+  "pair.step2": {
+    "message": "Start it and follow the prompt:",
+    "description": "Pairing step 2"
+  },
+  "pair.step3": {
+    "message": "Enter the pairing code it shows below.",
+    "description": "Pairing step 3"
+  },
+  "pair.codePlaceholder": {
+    "message": "Pairing code",
+    "description": "Pairing code input placeholder"
+  },
+  "pair.claim": {
+    "message": "Pair device",
+    "description": "Pairing confirm button"
+  },
+  "pair.success": {
+    "message": "Device \"{name}\" paired.",
+    "description": "Pairing success toast"
+  },
+  "pair.invalidCode": {
+    "message": "Invalid or expired pairing code.",
+    "description": "Pairing invalid code error"
+  },
+  "pair.usedCode": {
+    "message": "This pairing code has already been used.",
+    "description": "Pairing used code error"
+  },
+  "pair.failed": {
+    "message": "Failed to pair device.",
+    "description": "Pairing generic error"
+  },
+  "permission.title": {
+    "message": "Permission required",
+    "description": "Permission dialog title"
+  },
+  "permission.subtitle": {
+    "message": "The agent wants to use a tool. Approve to continue.",
+    "description": "Permission dialog subtitle"
+  },
+  "permission.deny": {
+    "message": "Deny",
+    "description": "Deny a tool permission"
+  },
+  "permission.allow": {
+    "message": "Allow",
+    "description": "Allow a tool permission"
+  },
+  "session.noDevice": {
+    "message": "Select a device to start coding.",
+    "description": "No device selected placeholder"
+  },
+  "session.newSession": {
+    "message": "New session",
+    "description": "Start a new session"
+  },
+  "session.deviceOffline": {
+    "message": "This device is offline. Start the Coding Bridge agent on it to continue.",
+    "description": "Device offline warning"
+  },
+  "session.startHint": {
+    "message": "Send a message to start a session on this device.",
+    "description": "Empty transcript hint"
+  },
+  "session.cwdPlaceholder": {
+    "message": "Working directory (optional)",
+    "description": "Working directory input placeholder"
+  },
+  "session.modelPlaceholder": {
+    "message": "Model (optional)",
+    "description": "Model input placeholder"
+  },
+  "session.promptPlaceholder": {
+    "message": "Send a message to the agent…",
+    "description": "Prompt input placeholder"
+  },
+  "session.send": {
+    "message": "Send",
+    "description": "Send prompt button"
+  },
+  "session.enterHint": {
+    "message": "Enter to send, Shift+Enter for a new line.",
+    "description": "Composer keyboard hint"
+  },
+  "transcript.turnFailed": {
+    "message": "Turn failed",
+    "description": "Turn result failed label"
+  },
+  "transcript.turnDone": {
+    "message": "Done",
+    "description": "Turn result done label"
+  }
+}

--- a/src/i18n/fi/codingBridge.json
+++ b/src/i18n/fi/codingBridge.json
@@ -1,0 +1,166 @@
+{
+  "nodeList.title": {
+    "message": "Devices",
+    "description": "Coding Bridge device list title"
+  },
+  "nodeList.refresh": {
+    "message": "Refresh",
+    "description": "Refresh the device list"
+  },
+  "nodeList.pair": {
+    "message": "Pair device",
+    "description": "Open the pairing dialog"
+  },
+  "nodeList.empty": {
+    "message": "No devices paired yet.",
+    "description": "Empty device list message"
+  },
+  "nodeList.pairFirst": {
+    "message": "Pair your first device",
+    "description": "Empty-state pairing button"
+  },
+  "nodeList.remove": {
+    "message": "Remove",
+    "description": "Remove a device"
+  },
+  "nodeList.removeConfirm": {
+    "message": "Remove device \"{name}\"? It will need to be paired again.",
+    "description": "Device removal confirmation"
+  },
+  "nodeList.removeSuccess": {
+    "message": "Device removed.",
+    "description": "Device removed toast"
+  },
+  "nodeList.removeFailed": {
+    "message": "Failed to remove device.",
+    "description": "Device removal error toast"
+  },
+  "status.online": {
+    "message": "Online",
+    "description": "Device online status"
+  },
+  "status.offline": {
+    "message": "Offline",
+    "description": "Device offline status"
+  },
+  "connection.disconnected": {
+    "message": "Disconnected",
+    "description": "Relay connection disconnected"
+  },
+  "connection.connecting": {
+    "message": "Connecting…",
+    "description": "Relay connection connecting"
+  },
+  "connection.connected": {
+    "message": "Connected",
+    "description": "Relay connection connected"
+  },
+  "connection.error": {
+    "message": "Connection error",
+    "description": "Relay connection error"
+  },
+  "pair.title": {
+    "message": "Pair a device",
+    "description": "Pairing dialog title"
+  },
+  "pair.intro": {
+    "message": "Run the Coding Bridge agent on your computer, then enter its pairing code here to control it from the web.",
+    "description": "Pairing dialog intro"
+  },
+  "pair.step1": {
+    "message": "Install the agent (requires Python 3.10+):",
+    "description": "Pairing step 1"
+  },
+  "pair.step2": {
+    "message": "Start it and follow the prompt:",
+    "description": "Pairing step 2"
+  },
+  "pair.step3": {
+    "message": "Enter the pairing code it shows below.",
+    "description": "Pairing step 3"
+  },
+  "pair.codePlaceholder": {
+    "message": "Pairing code",
+    "description": "Pairing code input placeholder"
+  },
+  "pair.claim": {
+    "message": "Pair device",
+    "description": "Pairing confirm button"
+  },
+  "pair.success": {
+    "message": "Device \"{name}\" paired.",
+    "description": "Pairing success toast"
+  },
+  "pair.invalidCode": {
+    "message": "Invalid or expired pairing code.",
+    "description": "Pairing invalid code error"
+  },
+  "pair.usedCode": {
+    "message": "This pairing code has already been used.",
+    "description": "Pairing used code error"
+  },
+  "pair.failed": {
+    "message": "Failed to pair device.",
+    "description": "Pairing generic error"
+  },
+  "permission.title": {
+    "message": "Permission required",
+    "description": "Permission dialog title"
+  },
+  "permission.subtitle": {
+    "message": "The agent wants to use a tool. Approve to continue.",
+    "description": "Permission dialog subtitle"
+  },
+  "permission.deny": {
+    "message": "Deny",
+    "description": "Deny a tool permission"
+  },
+  "permission.allow": {
+    "message": "Allow",
+    "description": "Allow a tool permission"
+  },
+  "session.noDevice": {
+    "message": "Select a device to start coding.",
+    "description": "No device selected placeholder"
+  },
+  "session.newSession": {
+    "message": "New session",
+    "description": "Start a new session"
+  },
+  "session.deviceOffline": {
+    "message": "This device is offline. Start the Coding Bridge agent on it to continue.",
+    "description": "Device offline warning"
+  },
+  "session.startHint": {
+    "message": "Send a message to start a session on this device.",
+    "description": "Empty transcript hint"
+  },
+  "session.cwdPlaceholder": {
+    "message": "Working directory (optional)",
+    "description": "Working directory input placeholder"
+  },
+  "session.modelPlaceholder": {
+    "message": "Model (optional)",
+    "description": "Model input placeholder"
+  },
+  "session.promptPlaceholder": {
+    "message": "Send a message to the agent…",
+    "description": "Prompt input placeholder"
+  },
+  "session.send": {
+    "message": "Send",
+    "description": "Send prompt button"
+  },
+  "session.enterHint": {
+    "message": "Enter to send, Shift+Enter for a new line.",
+    "description": "Composer keyboard hint"
+  },
+  "transcript.turnFailed": {
+    "message": "Turn failed",
+    "description": "Turn result failed label"
+  },
+  "transcript.turnDone": {
+    "message": "Done",
+    "description": "Turn result done label"
+  }
+}

--- a/src/i18n/fr/codingBridge.json
+++ b/src/i18n/fr/codingBridge.json
@@ -1,0 +1,166 @@
+{
+  "nodeList.title": {
+    "message": "Devices",
+    "description": "Coding Bridge device list title"
+  },
+  "nodeList.refresh": {
+    "message": "Refresh",
+    "description": "Refresh the device list"
+  },
+  "nodeList.pair": {
+    "message": "Pair device",
+    "description": "Open the pairing dialog"
+  },
+  "nodeList.empty": {
+    "message": "No devices paired yet.",
+    "description": "Empty device list message"
+  },
+  "nodeList.pairFirst": {
+    "message": "Pair your first device",
+    "description": "Empty-state pairing button"
+  },
+  "nodeList.remove": {
+    "message": "Remove",
+    "description": "Remove a device"
+  },
+  "nodeList.removeConfirm": {
+    "message": "Remove device \"{name}\"? It will need to be paired again.",
+    "description": "Device removal confirmation"
+  },
+  "nodeList.removeSuccess": {
+    "message": "Device removed.",
+    "description": "Device removed toast"
+  },
+  "nodeList.removeFailed": {
+    "message": "Failed to remove device.",
+    "description": "Device removal error toast"
+  },
+  "status.online": {
+    "message": "Online",
+    "description": "Device online status"
+  },
+  "status.offline": {
+    "message": "Offline",
+    "description": "Device offline status"
+  },
+  "connection.disconnected": {
+    "message": "Disconnected",
+    "description": "Relay connection disconnected"
+  },
+  "connection.connecting": {
+    "message": "Connecting…",
+    "description": "Relay connection connecting"
+  },
+  "connection.connected": {
+    "message": "Connected",
+    "description": "Relay connection connected"
+  },
+  "connection.error": {
+    "message": "Connection error",
+    "description": "Relay connection error"
+  },
+  "pair.title": {
+    "message": "Pair a device",
+    "description": "Pairing dialog title"
+  },
+  "pair.intro": {
+    "message": "Run the Coding Bridge agent on your computer, then enter its pairing code here to control it from the web.",
+    "description": "Pairing dialog intro"
+  },
+  "pair.step1": {
+    "message": "Install the agent (requires Python 3.10+):",
+    "description": "Pairing step 1"
+  },
+  "pair.step2": {
+    "message": "Start it and follow the prompt:",
+    "description": "Pairing step 2"
+  },
+  "pair.step3": {
+    "message": "Enter the pairing code it shows below.",
+    "description": "Pairing step 3"
+  },
+  "pair.codePlaceholder": {
+    "message": "Pairing code",
+    "description": "Pairing code input placeholder"
+  },
+  "pair.claim": {
+    "message": "Pair device",
+    "description": "Pairing confirm button"
+  },
+  "pair.success": {
+    "message": "Device \"{name}\" paired.",
+    "description": "Pairing success toast"
+  },
+  "pair.invalidCode": {
+    "message": "Invalid or expired pairing code.",
+    "description": "Pairing invalid code error"
+  },
+  "pair.usedCode": {
+    "message": "This pairing code has already been used.",
+    "description": "Pairing used code error"
+  },
+  "pair.failed": {
+    "message": "Failed to pair device.",
+    "description": "Pairing generic error"
+  },
+  "permission.title": {
+    "message": "Permission required",
+    "description": "Permission dialog title"
+  },
+  "permission.subtitle": {
+    "message": "The agent wants to use a tool. Approve to continue.",
+    "description": "Permission dialog subtitle"
+  },
+  "permission.deny": {
+    "message": "Deny",
+    "description": "Deny a tool permission"
+  },
+  "permission.allow": {
+    "message": "Allow",
+    "description": "Allow a tool permission"
+  },
+  "session.noDevice": {
+    "message": "Select a device to start coding.",
+    "description": "No device selected placeholder"
+  },
+  "session.newSession": {
+    "message": "New session",
+    "description": "Start a new session"
+  },
+  "session.deviceOffline": {
+    "message": "This device is offline. Start the Coding Bridge agent on it to continue.",
+    "description": "Device offline warning"
+  },
+  "session.startHint": {
+    "message": "Send a message to start a session on this device.",
+    "description": "Empty transcript hint"
+  },
+  "session.cwdPlaceholder": {
+    "message": "Working directory (optional)",
+    "description": "Working directory input placeholder"
+  },
+  "session.modelPlaceholder": {
+    "message": "Model (optional)",
+    "description": "Model input placeholder"
+  },
+  "session.promptPlaceholder": {
+    "message": "Send a message to the agent…",
+    "description": "Prompt input placeholder"
+  },
+  "session.send": {
+    "message": "Send",
+    "description": "Send prompt button"
+  },
+  "session.enterHint": {
+    "message": "Enter to send, Shift+Enter for a new line.",
+    "description": "Composer keyboard hint"
+  },
+  "transcript.turnFailed": {
+    "message": "Turn failed",
+    "description": "Turn result failed label"
+  },
+  "transcript.turnDone": {
+    "message": "Done",
+    "description": "Turn result done label"
+  }
+}

--- a/src/i18n/it/codingBridge.json
+++ b/src/i18n/it/codingBridge.json
@@ -1,0 +1,166 @@
+{
+  "nodeList.title": {
+    "message": "Devices",
+    "description": "Coding Bridge device list title"
+  },
+  "nodeList.refresh": {
+    "message": "Refresh",
+    "description": "Refresh the device list"
+  },
+  "nodeList.pair": {
+    "message": "Pair device",
+    "description": "Open the pairing dialog"
+  },
+  "nodeList.empty": {
+    "message": "No devices paired yet.",
+    "description": "Empty device list message"
+  },
+  "nodeList.pairFirst": {
+    "message": "Pair your first device",
+    "description": "Empty-state pairing button"
+  },
+  "nodeList.remove": {
+    "message": "Remove",
+    "description": "Remove a device"
+  },
+  "nodeList.removeConfirm": {
+    "message": "Remove device \"{name}\"? It will need to be paired again.",
+    "description": "Device removal confirmation"
+  },
+  "nodeList.removeSuccess": {
+    "message": "Device removed.",
+    "description": "Device removed toast"
+  },
+  "nodeList.removeFailed": {
+    "message": "Failed to remove device.",
+    "description": "Device removal error toast"
+  },
+  "status.online": {
+    "message": "Online",
+    "description": "Device online status"
+  },
+  "status.offline": {
+    "message": "Offline",
+    "description": "Device offline status"
+  },
+  "connection.disconnected": {
+    "message": "Disconnected",
+    "description": "Relay connection disconnected"
+  },
+  "connection.connecting": {
+    "message": "Connecting…",
+    "description": "Relay connection connecting"
+  },
+  "connection.connected": {
+    "message": "Connected",
+    "description": "Relay connection connected"
+  },
+  "connection.error": {
+    "message": "Connection error",
+    "description": "Relay connection error"
+  },
+  "pair.title": {
+    "message": "Pair a device",
+    "description": "Pairing dialog title"
+  },
+  "pair.intro": {
+    "message": "Run the Coding Bridge agent on your computer, then enter its pairing code here to control it from the web.",
+    "description": "Pairing dialog intro"
+  },
+  "pair.step1": {
+    "message": "Install the agent (requires Python 3.10+):",
+    "description": "Pairing step 1"
+  },
+  "pair.step2": {
+    "message": "Start it and follow the prompt:",
+    "description": "Pairing step 2"
+  },
+  "pair.step3": {
+    "message": "Enter the pairing code it shows below.",
+    "description": "Pairing step 3"
+  },
+  "pair.codePlaceholder": {
+    "message": "Pairing code",
+    "description": "Pairing code input placeholder"
+  },
+  "pair.claim": {
+    "message": "Pair device",
+    "description": "Pairing confirm button"
+  },
+  "pair.success": {
+    "message": "Device \"{name}\" paired.",
+    "description": "Pairing success toast"
+  },
+  "pair.invalidCode": {
+    "message": "Invalid or expired pairing code.",
+    "description": "Pairing invalid code error"
+  },
+  "pair.usedCode": {
+    "message": "This pairing code has already been used.",
+    "description": "Pairing used code error"
+  },
+  "pair.failed": {
+    "message": "Failed to pair device.",
+    "description": "Pairing generic error"
+  },
+  "permission.title": {
+    "message": "Permission required",
+    "description": "Permission dialog title"
+  },
+  "permission.subtitle": {
+    "message": "The agent wants to use a tool. Approve to continue.",
+    "description": "Permission dialog subtitle"
+  },
+  "permission.deny": {
+    "message": "Deny",
+    "description": "Deny a tool permission"
+  },
+  "permission.allow": {
+    "message": "Allow",
+    "description": "Allow a tool permission"
+  },
+  "session.noDevice": {
+    "message": "Select a device to start coding.",
+    "description": "No device selected placeholder"
+  },
+  "session.newSession": {
+    "message": "New session",
+    "description": "Start a new session"
+  },
+  "session.deviceOffline": {
+    "message": "This device is offline. Start the Coding Bridge agent on it to continue.",
+    "description": "Device offline warning"
+  },
+  "session.startHint": {
+    "message": "Send a message to start a session on this device.",
+    "description": "Empty transcript hint"
+  },
+  "session.cwdPlaceholder": {
+    "message": "Working directory (optional)",
+    "description": "Working directory input placeholder"
+  },
+  "session.modelPlaceholder": {
+    "message": "Model (optional)",
+    "description": "Model input placeholder"
+  },
+  "session.promptPlaceholder": {
+    "message": "Send a message to the agent…",
+    "description": "Prompt input placeholder"
+  },
+  "session.send": {
+    "message": "Send",
+    "description": "Send prompt button"
+  },
+  "session.enterHint": {
+    "message": "Enter to send, Shift+Enter for a new line.",
+    "description": "Composer keyboard hint"
+  },
+  "transcript.turnFailed": {
+    "message": "Turn failed",
+    "description": "Turn result failed label"
+  },
+  "transcript.turnDone": {
+    "message": "Done",
+    "description": "Turn result done label"
+  }
+}

--- a/src/i18n/ja/codingBridge.json
+++ b/src/i18n/ja/codingBridge.json
@@ -1,0 +1,166 @@
+{
+  "nodeList.title": {
+    "message": "Devices",
+    "description": "Coding Bridge device list title"
+  },
+  "nodeList.refresh": {
+    "message": "Refresh",
+    "description": "Refresh the device list"
+  },
+  "nodeList.pair": {
+    "message": "Pair device",
+    "description": "Open the pairing dialog"
+  },
+  "nodeList.empty": {
+    "message": "No devices paired yet.",
+    "description": "Empty device list message"
+  },
+  "nodeList.pairFirst": {
+    "message": "Pair your first device",
+    "description": "Empty-state pairing button"
+  },
+  "nodeList.remove": {
+    "message": "Remove",
+    "description": "Remove a device"
+  },
+  "nodeList.removeConfirm": {
+    "message": "Remove device \"{name}\"? It will need to be paired again.",
+    "description": "Device removal confirmation"
+  },
+  "nodeList.removeSuccess": {
+    "message": "Device removed.",
+    "description": "Device removed toast"
+  },
+  "nodeList.removeFailed": {
+    "message": "Failed to remove device.",
+    "description": "Device removal error toast"
+  },
+  "status.online": {
+    "message": "Online",
+    "description": "Device online status"
+  },
+  "status.offline": {
+    "message": "Offline",
+    "description": "Device offline status"
+  },
+  "connection.disconnected": {
+    "message": "Disconnected",
+    "description": "Relay connection disconnected"
+  },
+  "connection.connecting": {
+    "message": "Connecting…",
+    "description": "Relay connection connecting"
+  },
+  "connection.connected": {
+    "message": "Connected",
+    "description": "Relay connection connected"
+  },
+  "connection.error": {
+    "message": "Connection error",
+    "description": "Relay connection error"
+  },
+  "pair.title": {
+    "message": "Pair a device",
+    "description": "Pairing dialog title"
+  },
+  "pair.intro": {
+    "message": "Run the Coding Bridge agent on your computer, then enter its pairing code here to control it from the web.",
+    "description": "Pairing dialog intro"
+  },
+  "pair.step1": {
+    "message": "Install the agent (requires Python 3.10+):",
+    "description": "Pairing step 1"
+  },
+  "pair.step2": {
+    "message": "Start it and follow the prompt:",
+    "description": "Pairing step 2"
+  },
+  "pair.step3": {
+    "message": "Enter the pairing code it shows below.",
+    "description": "Pairing step 3"
+  },
+  "pair.codePlaceholder": {
+    "message": "Pairing code",
+    "description": "Pairing code input placeholder"
+  },
+  "pair.claim": {
+    "message": "Pair device",
+    "description": "Pairing confirm button"
+  },
+  "pair.success": {
+    "message": "Device \"{name}\" paired.",
+    "description": "Pairing success toast"
+  },
+  "pair.invalidCode": {
+    "message": "Invalid or expired pairing code.",
+    "description": "Pairing invalid code error"
+  },
+  "pair.usedCode": {
+    "message": "This pairing code has already been used.",
+    "description": "Pairing used code error"
+  },
+  "pair.failed": {
+    "message": "Failed to pair device.",
+    "description": "Pairing generic error"
+  },
+  "permission.title": {
+    "message": "Permission required",
+    "description": "Permission dialog title"
+  },
+  "permission.subtitle": {
+    "message": "The agent wants to use a tool. Approve to continue.",
+    "description": "Permission dialog subtitle"
+  },
+  "permission.deny": {
+    "message": "Deny",
+    "description": "Deny a tool permission"
+  },
+  "permission.allow": {
+    "message": "Allow",
+    "description": "Allow a tool permission"
+  },
+  "session.noDevice": {
+    "message": "Select a device to start coding.",
+    "description": "No device selected placeholder"
+  },
+  "session.newSession": {
+    "message": "New session",
+    "description": "Start a new session"
+  },
+  "session.deviceOffline": {
+    "message": "This device is offline. Start the Coding Bridge agent on it to continue.",
+    "description": "Device offline warning"
+  },
+  "session.startHint": {
+    "message": "Send a message to start a session on this device.",
+    "description": "Empty transcript hint"
+  },
+  "session.cwdPlaceholder": {
+    "message": "Working directory (optional)",
+    "description": "Working directory input placeholder"
+  },
+  "session.modelPlaceholder": {
+    "message": "Model (optional)",
+    "description": "Model input placeholder"
+  },
+  "session.promptPlaceholder": {
+    "message": "Send a message to the agent…",
+    "description": "Prompt input placeholder"
+  },
+  "session.send": {
+    "message": "Send",
+    "description": "Send prompt button"
+  },
+  "session.enterHint": {
+    "message": "Enter to send, Shift+Enter for a new line.",
+    "description": "Composer keyboard hint"
+  },
+  "transcript.turnFailed": {
+    "message": "Turn failed",
+    "description": "Turn result failed label"
+  },
+  "transcript.turnDone": {
+    "message": "Done",
+    "description": "Turn result done label"
+  }
+}

--- a/src/i18n/ko/codingBridge.json
+++ b/src/i18n/ko/codingBridge.json
@@ -1,0 +1,166 @@
+{
+  "nodeList.title": {
+    "message": "Devices",
+    "description": "Coding Bridge device list title"
+  },
+  "nodeList.refresh": {
+    "message": "Refresh",
+    "description": "Refresh the device list"
+  },
+  "nodeList.pair": {
+    "message": "Pair device",
+    "description": "Open the pairing dialog"
+  },
+  "nodeList.empty": {
+    "message": "No devices paired yet.",
+    "description": "Empty device list message"
+  },
+  "nodeList.pairFirst": {
+    "message": "Pair your first device",
+    "description": "Empty-state pairing button"
+  },
+  "nodeList.remove": {
+    "message": "Remove",
+    "description": "Remove a device"
+  },
+  "nodeList.removeConfirm": {
+    "message": "Remove device \"{name}\"? It will need to be paired again.",
+    "description": "Device removal confirmation"
+  },
+  "nodeList.removeSuccess": {
+    "message": "Device removed.",
+    "description": "Device removed toast"
+  },
+  "nodeList.removeFailed": {
+    "message": "Failed to remove device.",
+    "description": "Device removal error toast"
+  },
+  "status.online": {
+    "message": "Online",
+    "description": "Device online status"
+  },
+  "status.offline": {
+    "message": "Offline",
+    "description": "Device offline status"
+  },
+  "connection.disconnected": {
+    "message": "Disconnected",
+    "description": "Relay connection disconnected"
+  },
+  "connection.connecting": {
+    "message": "Connecting…",
+    "description": "Relay connection connecting"
+  },
+  "connection.connected": {
+    "message": "Connected",
+    "description": "Relay connection connected"
+  },
+  "connection.error": {
+    "message": "Connection error",
+    "description": "Relay connection error"
+  },
+  "pair.title": {
+    "message": "Pair a device",
+    "description": "Pairing dialog title"
+  },
+  "pair.intro": {
+    "message": "Run the Coding Bridge agent on your computer, then enter its pairing code here to control it from the web.",
+    "description": "Pairing dialog intro"
+  },
+  "pair.step1": {
+    "message": "Install the agent (requires Python 3.10+):",
+    "description": "Pairing step 1"
+  },
+  "pair.step2": {
+    "message": "Start it and follow the prompt:",
+    "description": "Pairing step 2"
+  },
+  "pair.step3": {
+    "message": "Enter the pairing code it shows below.",
+    "description": "Pairing step 3"
+  },
+  "pair.codePlaceholder": {
+    "message": "Pairing code",
+    "description": "Pairing code input placeholder"
+  },
+  "pair.claim": {
+    "message": "Pair device",
+    "description": "Pairing confirm button"
+  },
+  "pair.success": {
+    "message": "Device \"{name}\" paired.",
+    "description": "Pairing success toast"
+  },
+  "pair.invalidCode": {
+    "message": "Invalid or expired pairing code.",
+    "description": "Pairing invalid code error"
+  },
+  "pair.usedCode": {
+    "message": "This pairing code has already been used.",
+    "description": "Pairing used code error"
+  },
+  "pair.failed": {
+    "message": "Failed to pair device.",
+    "description": "Pairing generic error"
+  },
+  "permission.title": {
+    "message": "Permission required",
+    "description": "Permission dialog title"
+  },
+  "permission.subtitle": {
+    "message": "The agent wants to use a tool. Approve to continue.",
+    "description": "Permission dialog subtitle"
+  },
+  "permission.deny": {
+    "message": "Deny",
+    "description": "Deny a tool permission"
+  },
+  "permission.allow": {
+    "message": "Allow",
+    "description": "Allow a tool permission"
+  },
+  "session.noDevice": {
+    "message": "Select a device to start coding.",
+    "description": "No device selected placeholder"
+  },
+  "session.newSession": {
+    "message": "New session",
+    "description": "Start a new session"
+  },
+  "session.deviceOffline": {
+    "message": "This device is offline. Start the Coding Bridge agent on it to continue.",
+    "description": "Device offline warning"
+  },
+  "session.startHint": {
+    "message": "Send a message to start a session on this device.",
+    "description": "Empty transcript hint"
+  },
+  "session.cwdPlaceholder": {
+    "message": "Working directory (optional)",
+    "description": "Working directory input placeholder"
+  },
+  "session.modelPlaceholder": {
+    "message": "Model (optional)",
+    "description": "Model input placeholder"
+  },
+  "session.promptPlaceholder": {
+    "message": "Send a message to the agent…",
+    "description": "Prompt input placeholder"
+  },
+  "session.send": {
+    "message": "Send",
+    "description": "Send prompt button"
+  },
+  "session.enterHint": {
+    "message": "Enter to send, Shift+Enter for a new line.",
+    "description": "Composer keyboard hint"
+  },
+  "transcript.turnFailed": {
+    "message": "Turn failed",
+    "description": "Turn result failed label"
+  },
+  "transcript.turnDone": {
+    "message": "Done",
+    "description": "Turn result done label"
+  }
+}

--- a/src/i18n/pl/codingBridge.json
+++ b/src/i18n/pl/codingBridge.json
@@ -1,0 +1,166 @@
+{
+  "nodeList.title": {
+    "message": "Devices",
+    "description": "Coding Bridge device list title"
+  },
+  "nodeList.refresh": {
+    "message": "Refresh",
+    "description": "Refresh the device list"
+  },
+  "nodeList.pair": {
+    "message": "Pair device",
+    "description": "Open the pairing dialog"
+  },
+  "nodeList.empty": {
+    "message": "No devices paired yet.",
+    "description": "Empty device list message"
+  },
+  "nodeList.pairFirst": {
+    "message": "Pair your first device",
+    "description": "Empty-state pairing button"
+  },
+  "nodeList.remove": {
+    "message": "Remove",
+    "description": "Remove a device"
+  },
+  "nodeList.removeConfirm": {
+    "message": "Remove device \"{name}\"? It will need to be paired again.",
+    "description": "Device removal confirmation"
+  },
+  "nodeList.removeSuccess": {
+    "message": "Device removed.",
+    "description": "Device removed toast"
+  },
+  "nodeList.removeFailed": {
+    "message": "Failed to remove device.",
+    "description": "Device removal error toast"
+  },
+  "status.online": {
+    "message": "Online",
+    "description": "Device online status"
+  },
+  "status.offline": {
+    "message": "Offline",
+    "description": "Device offline status"
+  },
+  "connection.disconnected": {
+    "message": "Disconnected",
+    "description": "Relay connection disconnected"
+  },
+  "connection.connecting": {
+    "message": "Connecting…",
+    "description": "Relay connection connecting"
+  },
+  "connection.connected": {
+    "message": "Connected",
+    "description": "Relay connection connected"
+  },
+  "connection.error": {
+    "message": "Connection error",
+    "description": "Relay connection error"
+  },
+  "pair.title": {
+    "message": "Pair a device",
+    "description": "Pairing dialog title"
+  },
+  "pair.intro": {
+    "message": "Run the Coding Bridge agent on your computer, then enter its pairing code here to control it from the web.",
+    "description": "Pairing dialog intro"
+  },
+  "pair.step1": {
+    "message": "Install the agent (requires Python 3.10+):",
+    "description": "Pairing step 1"
+  },
+  "pair.step2": {
+    "message": "Start it and follow the prompt:",
+    "description": "Pairing step 2"
+  },
+  "pair.step3": {
+    "message": "Enter the pairing code it shows below.",
+    "description": "Pairing step 3"
+  },
+  "pair.codePlaceholder": {
+    "message": "Pairing code",
+    "description": "Pairing code input placeholder"
+  },
+  "pair.claim": {
+    "message": "Pair device",
+    "description": "Pairing confirm button"
+  },
+  "pair.success": {
+    "message": "Device \"{name}\" paired.",
+    "description": "Pairing success toast"
+  },
+  "pair.invalidCode": {
+    "message": "Invalid or expired pairing code.",
+    "description": "Pairing invalid code error"
+  },
+  "pair.usedCode": {
+    "message": "This pairing code has already been used.",
+    "description": "Pairing used code error"
+  },
+  "pair.failed": {
+    "message": "Failed to pair device.",
+    "description": "Pairing generic error"
+  },
+  "permission.title": {
+    "message": "Permission required",
+    "description": "Permission dialog title"
+  },
+  "permission.subtitle": {
+    "message": "The agent wants to use a tool. Approve to continue.",
+    "description": "Permission dialog subtitle"
+  },
+  "permission.deny": {
+    "message": "Deny",
+    "description": "Deny a tool permission"
+  },
+  "permission.allow": {
+    "message": "Allow",
+    "description": "Allow a tool permission"
+  },
+  "session.noDevice": {
+    "message": "Select a device to start coding.",
+    "description": "No device selected placeholder"
+  },
+  "session.newSession": {
+    "message": "New session",
+    "description": "Start a new session"
+  },
+  "session.deviceOffline": {
+    "message": "This device is offline. Start the Coding Bridge agent on it to continue.",
+    "description": "Device offline warning"
+  },
+  "session.startHint": {
+    "message": "Send a message to start a session on this device.",
+    "description": "Empty transcript hint"
+  },
+  "session.cwdPlaceholder": {
+    "message": "Working directory (optional)",
+    "description": "Working directory input placeholder"
+  },
+  "session.modelPlaceholder": {
+    "message": "Model (optional)",
+    "description": "Model input placeholder"
+  },
+  "session.promptPlaceholder": {
+    "message": "Send a message to the agent…",
+    "description": "Prompt input placeholder"
+  },
+  "session.send": {
+    "message": "Send",
+    "description": "Send prompt button"
+  },
+  "session.enterHint": {
+    "message": "Enter to send, Shift+Enter for a new line.",
+    "description": "Composer keyboard hint"
+  },
+  "transcript.turnFailed": {
+    "message": "Turn failed",
+    "description": "Turn result failed label"
+  },
+  "transcript.turnDone": {
+    "message": "Done",
+    "description": "Turn result done label"
+  }
+}

--- a/src/i18n/pt/codingBridge.json
+++ b/src/i18n/pt/codingBridge.json
@@ -1,0 +1,166 @@
+{
+  "nodeList.title": {
+    "message": "Devices",
+    "description": "Coding Bridge device list title"
+  },
+  "nodeList.refresh": {
+    "message": "Refresh",
+    "description": "Refresh the device list"
+  },
+  "nodeList.pair": {
+    "message": "Pair device",
+    "description": "Open the pairing dialog"
+  },
+  "nodeList.empty": {
+    "message": "No devices paired yet.",
+    "description": "Empty device list message"
+  },
+  "nodeList.pairFirst": {
+    "message": "Pair your first device",
+    "description": "Empty-state pairing button"
+  },
+  "nodeList.remove": {
+    "message": "Remove",
+    "description": "Remove a device"
+  },
+  "nodeList.removeConfirm": {
+    "message": "Remove device \"{name}\"? It will need to be paired again.",
+    "description": "Device removal confirmation"
+  },
+  "nodeList.removeSuccess": {
+    "message": "Device removed.",
+    "description": "Device removed toast"
+  },
+  "nodeList.removeFailed": {
+    "message": "Failed to remove device.",
+    "description": "Device removal error toast"
+  },
+  "status.online": {
+    "message": "Online",
+    "description": "Device online status"
+  },
+  "status.offline": {
+    "message": "Offline",
+    "description": "Device offline status"
+  },
+  "connection.disconnected": {
+    "message": "Disconnected",
+    "description": "Relay connection disconnected"
+  },
+  "connection.connecting": {
+    "message": "Connecting…",
+    "description": "Relay connection connecting"
+  },
+  "connection.connected": {
+    "message": "Connected",
+    "description": "Relay connection connected"
+  },
+  "connection.error": {
+    "message": "Connection error",
+    "description": "Relay connection error"
+  },
+  "pair.title": {
+    "message": "Pair a device",
+    "description": "Pairing dialog title"
+  },
+  "pair.intro": {
+    "message": "Run the Coding Bridge agent on your computer, then enter its pairing code here to control it from the web.",
+    "description": "Pairing dialog intro"
+  },
+  "pair.step1": {
+    "message": "Install the agent (requires Python 3.10+):",
+    "description": "Pairing step 1"
+  },
+  "pair.step2": {
+    "message": "Start it and follow the prompt:",
+    "description": "Pairing step 2"
+  },
+  "pair.step3": {
+    "message": "Enter the pairing code it shows below.",
+    "description": "Pairing step 3"
+  },
+  "pair.codePlaceholder": {
+    "message": "Pairing code",
+    "description": "Pairing code input placeholder"
+  },
+  "pair.claim": {
+    "message": "Pair device",
+    "description": "Pairing confirm button"
+  },
+  "pair.success": {
+    "message": "Device \"{name}\" paired.",
+    "description": "Pairing success toast"
+  },
+  "pair.invalidCode": {
+    "message": "Invalid or expired pairing code.",
+    "description": "Pairing invalid code error"
+  },
+  "pair.usedCode": {
+    "message": "This pairing code has already been used.",
+    "description": "Pairing used code error"
+  },
+  "pair.failed": {
+    "message": "Failed to pair device.",
+    "description": "Pairing generic error"
+  },
+  "permission.title": {
+    "message": "Permission required",
+    "description": "Permission dialog title"
+  },
+  "permission.subtitle": {
+    "message": "The agent wants to use a tool. Approve to continue.",
+    "description": "Permission dialog subtitle"
+  },
+  "permission.deny": {
+    "message": "Deny",
+    "description": "Deny a tool permission"
+  },
+  "permission.allow": {
+    "message": "Allow",
+    "description": "Allow a tool permission"
+  },
+  "session.noDevice": {
+    "message": "Select a device to start coding.",
+    "description": "No device selected placeholder"
+  },
+  "session.newSession": {
+    "message": "New session",
+    "description": "Start a new session"
+  },
+  "session.deviceOffline": {
+    "message": "This device is offline. Start the Coding Bridge agent on it to continue.",
+    "description": "Device offline warning"
+  },
+  "session.startHint": {
+    "message": "Send a message to start a session on this device.",
+    "description": "Empty transcript hint"
+  },
+  "session.cwdPlaceholder": {
+    "message": "Working directory (optional)",
+    "description": "Working directory input placeholder"
+  },
+  "session.modelPlaceholder": {
+    "message": "Model (optional)",
+    "description": "Model input placeholder"
+  },
+  "session.promptPlaceholder": {
+    "message": "Send a message to the agent…",
+    "description": "Prompt input placeholder"
+  },
+  "session.send": {
+    "message": "Send",
+    "description": "Send prompt button"
+  },
+  "session.enterHint": {
+    "message": "Enter to send, Shift+Enter for a new line.",
+    "description": "Composer keyboard hint"
+  },
+  "transcript.turnFailed": {
+    "message": "Turn failed",
+    "description": "Turn result failed label"
+  },
+  "transcript.turnDone": {
+    "message": "Done",
+    "description": "Turn result done label"
+  }
+}

--- a/src/i18n/ru/codingBridge.json
+++ b/src/i18n/ru/codingBridge.json
@@ -1,0 +1,166 @@
+{
+  "nodeList.title": {
+    "message": "Devices",
+    "description": "Coding Bridge device list title"
+  },
+  "nodeList.refresh": {
+    "message": "Refresh",
+    "description": "Refresh the device list"
+  },
+  "nodeList.pair": {
+    "message": "Pair device",
+    "description": "Open the pairing dialog"
+  },
+  "nodeList.empty": {
+    "message": "No devices paired yet.",
+    "description": "Empty device list message"
+  },
+  "nodeList.pairFirst": {
+    "message": "Pair your first device",
+    "description": "Empty-state pairing button"
+  },
+  "nodeList.remove": {
+    "message": "Remove",
+    "description": "Remove a device"
+  },
+  "nodeList.removeConfirm": {
+    "message": "Remove device \"{name}\"? It will need to be paired again.",
+    "description": "Device removal confirmation"
+  },
+  "nodeList.removeSuccess": {
+    "message": "Device removed.",
+    "description": "Device removed toast"
+  },
+  "nodeList.removeFailed": {
+    "message": "Failed to remove device.",
+    "description": "Device removal error toast"
+  },
+  "status.online": {
+    "message": "Online",
+    "description": "Device online status"
+  },
+  "status.offline": {
+    "message": "Offline",
+    "description": "Device offline status"
+  },
+  "connection.disconnected": {
+    "message": "Disconnected",
+    "description": "Relay connection disconnected"
+  },
+  "connection.connecting": {
+    "message": "Connecting…",
+    "description": "Relay connection connecting"
+  },
+  "connection.connected": {
+    "message": "Connected",
+    "description": "Relay connection connected"
+  },
+  "connection.error": {
+    "message": "Connection error",
+    "description": "Relay connection error"
+  },
+  "pair.title": {
+    "message": "Pair a device",
+    "description": "Pairing dialog title"
+  },
+  "pair.intro": {
+    "message": "Run the Coding Bridge agent on your computer, then enter its pairing code here to control it from the web.",
+    "description": "Pairing dialog intro"
+  },
+  "pair.step1": {
+    "message": "Install the agent (requires Python 3.10+):",
+    "description": "Pairing step 1"
+  },
+  "pair.step2": {
+    "message": "Start it and follow the prompt:",
+    "description": "Pairing step 2"
+  },
+  "pair.step3": {
+    "message": "Enter the pairing code it shows below.",
+    "description": "Pairing step 3"
+  },
+  "pair.codePlaceholder": {
+    "message": "Pairing code",
+    "description": "Pairing code input placeholder"
+  },
+  "pair.claim": {
+    "message": "Pair device",
+    "description": "Pairing confirm button"
+  },
+  "pair.success": {
+    "message": "Device \"{name}\" paired.",
+    "description": "Pairing success toast"
+  },
+  "pair.invalidCode": {
+    "message": "Invalid or expired pairing code.",
+    "description": "Pairing invalid code error"
+  },
+  "pair.usedCode": {
+    "message": "This pairing code has already been used.",
+    "description": "Pairing used code error"
+  },
+  "pair.failed": {
+    "message": "Failed to pair device.",
+    "description": "Pairing generic error"
+  },
+  "permission.title": {
+    "message": "Permission required",
+    "description": "Permission dialog title"
+  },
+  "permission.subtitle": {
+    "message": "The agent wants to use a tool. Approve to continue.",
+    "description": "Permission dialog subtitle"
+  },
+  "permission.deny": {
+    "message": "Deny",
+    "description": "Deny a tool permission"
+  },
+  "permission.allow": {
+    "message": "Allow",
+    "description": "Allow a tool permission"
+  },
+  "session.noDevice": {
+    "message": "Select a device to start coding.",
+    "description": "No device selected placeholder"
+  },
+  "session.newSession": {
+    "message": "New session",
+    "description": "Start a new session"
+  },
+  "session.deviceOffline": {
+    "message": "This device is offline. Start the Coding Bridge agent on it to continue.",
+    "description": "Device offline warning"
+  },
+  "session.startHint": {
+    "message": "Send a message to start a session on this device.",
+    "description": "Empty transcript hint"
+  },
+  "session.cwdPlaceholder": {
+    "message": "Working directory (optional)",
+    "description": "Working directory input placeholder"
+  },
+  "session.modelPlaceholder": {
+    "message": "Model (optional)",
+    "description": "Model input placeholder"
+  },
+  "session.promptPlaceholder": {
+    "message": "Send a message to the agent…",
+    "description": "Prompt input placeholder"
+  },
+  "session.send": {
+    "message": "Send",
+    "description": "Send prompt button"
+  },
+  "session.enterHint": {
+    "message": "Enter to send, Shift+Enter for a new line.",
+    "description": "Composer keyboard hint"
+  },
+  "transcript.turnFailed": {
+    "message": "Turn failed",
+    "description": "Turn result failed label"
+  },
+  "transcript.turnDone": {
+    "message": "Done",
+    "description": "Turn result done label"
+  }
+}

--- a/src/i18n/sr/codingBridge.json
+++ b/src/i18n/sr/codingBridge.json
@@ -1,0 +1,166 @@
+{
+  "nodeList.title": {
+    "message": "Devices",
+    "description": "Coding Bridge device list title"
+  },
+  "nodeList.refresh": {
+    "message": "Refresh",
+    "description": "Refresh the device list"
+  },
+  "nodeList.pair": {
+    "message": "Pair device",
+    "description": "Open the pairing dialog"
+  },
+  "nodeList.empty": {
+    "message": "No devices paired yet.",
+    "description": "Empty device list message"
+  },
+  "nodeList.pairFirst": {
+    "message": "Pair your first device",
+    "description": "Empty-state pairing button"
+  },
+  "nodeList.remove": {
+    "message": "Remove",
+    "description": "Remove a device"
+  },
+  "nodeList.removeConfirm": {
+    "message": "Remove device \"{name}\"? It will need to be paired again.",
+    "description": "Device removal confirmation"
+  },
+  "nodeList.removeSuccess": {
+    "message": "Device removed.",
+    "description": "Device removed toast"
+  },
+  "nodeList.removeFailed": {
+    "message": "Failed to remove device.",
+    "description": "Device removal error toast"
+  },
+  "status.online": {
+    "message": "Online",
+    "description": "Device online status"
+  },
+  "status.offline": {
+    "message": "Offline",
+    "description": "Device offline status"
+  },
+  "connection.disconnected": {
+    "message": "Disconnected",
+    "description": "Relay connection disconnected"
+  },
+  "connection.connecting": {
+    "message": "Connecting…",
+    "description": "Relay connection connecting"
+  },
+  "connection.connected": {
+    "message": "Connected",
+    "description": "Relay connection connected"
+  },
+  "connection.error": {
+    "message": "Connection error",
+    "description": "Relay connection error"
+  },
+  "pair.title": {
+    "message": "Pair a device",
+    "description": "Pairing dialog title"
+  },
+  "pair.intro": {
+    "message": "Run the Coding Bridge agent on your computer, then enter its pairing code here to control it from the web.",
+    "description": "Pairing dialog intro"
+  },
+  "pair.step1": {
+    "message": "Install the agent (requires Python 3.10+):",
+    "description": "Pairing step 1"
+  },
+  "pair.step2": {
+    "message": "Start it and follow the prompt:",
+    "description": "Pairing step 2"
+  },
+  "pair.step3": {
+    "message": "Enter the pairing code it shows below.",
+    "description": "Pairing step 3"
+  },
+  "pair.codePlaceholder": {
+    "message": "Pairing code",
+    "description": "Pairing code input placeholder"
+  },
+  "pair.claim": {
+    "message": "Pair device",
+    "description": "Pairing confirm button"
+  },
+  "pair.success": {
+    "message": "Device \"{name}\" paired.",
+    "description": "Pairing success toast"
+  },
+  "pair.invalidCode": {
+    "message": "Invalid or expired pairing code.",
+    "description": "Pairing invalid code error"
+  },
+  "pair.usedCode": {
+    "message": "This pairing code has already been used.",
+    "description": "Pairing used code error"
+  },
+  "pair.failed": {
+    "message": "Failed to pair device.",
+    "description": "Pairing generic error"
+  },
+  "permission.title": {
+    "message": "Permission required",
+    "description": "Permission dialog title"
+  },
+  "permission.subtitle": {
+    "message": "The agent wants to use a tool. Approve to continue.",
+    "description": "Permission dialog subtitle"
+  },
+  "permission.deny": {
+    "message": "Deny",
+    "description": "Deny a tool permission"
+  },
+  "permission.allow": {
+    "message": "Allow",
+    "description": "Allow a tool permission"
+  },
+  "session.noDevice": {
+    "message": "Select a device to start coding.",
+    "description": "No device selected placeholder"
+  },
+  "session.newSession": {
+    "message": "New session",
+    "description": "Start a new session"
+  },
+  "session.deviceOffline": {
+    "message": "This device is offline. Start the Coding Bridge agent on it to continue.",
+    "description": "Device offline warning"
+  },
+  "session.startHint": {
+    "message": "Send a message to start a session on this device.",
+    "description": "Empty transcript hint"
+  },
+  "session.cwdPlaceholder": {
+    "message": "Working directory (optional)",
+    "description": "Working directory input placeholder"
+  },
+  "session.modelPlaceholder": {
+    "message": "Model (optional)",
+    "description": "Model input placeholder"
+  },
+  "session.promptPlaceholder": {
+    "message": "Send a message to the agent…",
+    "description": "Prompt input placeholder"
+  },
+  "session.send": {
+    "message": "Send",
+    "description": "Send prompt button"
+  },
+  "session.enterHint": {
+    "message": "Enter to send, Shift+Enter for a new line.",
+    "description": "Composer keyboard hint"
+  },
+  "transcript.turnFailed": {
+    "message": "Turn failed",
+    "description": "Turn result failed label"
+  },
+  "transcript.turnDone": {
+    "message": "Done",
+    "description": "Turn result done label"
+  }
+}

--- a/src/i18n/sv/codingBridge.json
+++ b/src/i18n/sv/codingBridge.json
@@ -1,0 +1,166 @@
+{
+  "nodeList.title": {
+    "message": "Devices",
+    "description": "Coding Bridge device list title"
+  },
+  "nodeList.refresh": {
+    "message": "Refresh",
+    "description": "Refresh the device list"
+  },
+  "nodeList.pair": {
+    "message": "Pair device",
+    "description": "Open the pairing dialog"
+  },
+  "nodeList.empty": {
+    "message": "No devices paired yet.",
+    "description": "Empty device list message"
+  },
+  "nodeList.pairFirst": {
+    "message": "Pair your first device",
+    "description": "Empty-state pairing button"
+  },
+  "nodeList.remove": {
+    "message": "Remove",
+    "description": "Remove a device"
+  },
+  "nodeList.removeConfirm": {
+    "message": "Remove device \"{name}\"? It will need to be paired again.",
+    "description": "Device removal confirmation"
+  },
+  "nodeList.removeSuccess": {
+    "message": "Device removed.",
+    "description": "Device removed toast"
+  },
+  "nodeList.removeFailed": {
+    "message": "Failed to remove device.",
+    "description": "Device removal error toast"
+  },
+  "status.online": {
+    "message": "Online",
+    "description": "Device online status"
+  },
+  "status.offline": {
+    "message": "Offline",
+    "description": "Device offline status"
+  },
+  "connection.disconnected": {
+    "message": "Disconnected",
+    "description": "Relay connection disconnected"
+  },
+  "connection.connecting": {
+    "message": "Connecting…",
+    "description": "Relay connection connecting"
+  },
+  "connection.connected": {
+    "message": "Connected",
+    "description": "Relay connection connected"
+  },
+  "connection.error": {
+    "message": "Connection error",
+    "description": "Relay connection error"
+  },
+  "pair.title": {
+    "message": "Pair a device",
+    "description": "Pairing dialog title"
+  },
+  "pair.intro": {
+    "message": "Run the Coding Bridge agent on your computer, then enter its pairing code here to control it from the web.",
+    "description": "Pairing dialog intro"
+  },
+  "pair.step1": {
+    "message": "Install the agent (requires Python 3.10+):",
+    "description": "Pairing step 1"
+  },
+  "pair.step2": {
+    "message": "Start it and follow the prompt:",
+    "description": "Pairing step 2"
+  },
+  "pair.step3": {
+    "message": "Enter the pairing code it shows below.",
+    "description": "Pairing step 3"
+  },
+  "pair.codePlaceholder": {
+    "message": "Pairing code",
+    "description": "Pairing code input placeholder"
+  },
+  "pair.claim": {
+    "message": "Pair device",
+    "description": "Pairing confirm button"
+  },
+  "pair.success": {
+    "message": "Device \"{name}\" paired.",
+    "description": "Pairing success toast"
+  },
+  "pair.invalidCode": {
+    "message": "Invalid or expired pairing code.",
+    "description": "Pairing invalid code error"
+  },
+  "pair.usedCode": {
+    "message": "This pairing code has already been used.",
+    "description": "Pairing used code error"
+  },
+  "pair.failed": {
+    "message": "Failed to pair device.",
+    "description": "Pairing generic error"
+  },
+  "permission.title": {
+    "message": "Permission required",
+    "description": "Permission dialog title"
+  },
+  "permission.subtitle": {
+    "message": "The agent wants to use a tool. Approve to continue.",
+    "description": "Permission dialog subtitle"
+  },
+  "permission.deny": {
+    "message": "Deny",
+    "description": "Deny a tool permission"
+  },
+  "permission.allow": {
+    "message": "Allow",
+    "description": "Allow a tool permission"
+  },
+  "session.noDevice": {
+    "message": "Select a device to start coding.",
+    "description": "No device selected placeholder"
+  },
+  "session.newSession": {
+    "message": "New session",
+    "description": "Start a new session"
+  },
+  "session.deviceOffline": {
+    "message": "This device is offline. Start the Coding Bridge agent on it to continue.",
+    "description": "Device offline warning"
+  },
+  "session.startHint": {
+    "message": "Send a message to start a session on this device.",
+    "description": "Empty transcript hint"
+  },
+  "session.cwdPlaceholder": {
+    "message": "Working directory (optional)",
+    "description": "Working directory input placeholder"
+  },
+  "session.modelPlaceholder": {
+    "message": "Model (optional)",
+    "description": "Model input placeholder"
+  },
+  "session.promptPlaceholder": {
+    "message": "Send a message to the agent…",
+    "description": "Prompt input placeholder"
+  },
+  "session.send": {
+    "message": "Send",
+    "description": "Send prompt button"
+  },
+  "session.enterHint": {
+    "message": "Enter to send, Shift+Enter for a new line.",
+    "description": "Composer keyboard hint"
+  },
+  "transcript.turnFailed": {
+    "message": "Turn failed",
+    "description": "Turn result failed label"
+  },
+  "transcript.turnDone": {
+    "message": "Done",
+    "description": "Turn result done label"
+  }
+}

--- a/src/i18n/uk/codingBridge.json
+++ b/src/i18n/uk/codingBridge.json
@@ -1,0 +1,166 @@
+{
+  "nodeList.title": {
+    "message": "Devices",
+    "description": "Coding Bridge device list title"
+  },
+  "nodeList.refresh": {
+    "message": "Refresh",
+    "description": "Refresh the device list"
+  },
+  "nodeList.pair": {
+    "message": "Pair device",
+    "description": "Open the pairing dialog"
+  },
+  "nodeList.empty": {
+    "message": "No devices paired yet.",
+    "description": "Empty device list message"
+  },
+  "nodeList.pairFirst": {
+    "message": "Pair your first device",
+    "description": "Empty-state pairing button"
+  },
+  "nodeList.remove": {
+    "message": "Remove",
+    "description": "Remove a device"
+  },
+  "nodeList.removeConfirm": {
+    "message": "Remove device \"{name}\"? It will need to be paired again.",
+    "description": "Device removal confirmation"
+  },
+  "nodeList.removeSuccess": {
+    "message": "Device removed.",
+    "description": "Device removed toast"
+  },
+  "nodeList.removeFailed": {
+    "message": "Failed to remove device.",
+    "description": "Device removal error toast"
+  },
+  "status.online": {
+    "message": "Online",
+    "description": "Device online status"
+  },
+  "status.offline": {
+    "message": "Offline",
+    "description": "Device offline status"
+  },
+  "connection.disconnected": {
+    "message": "Disconnected",
+    "description": "Relay connection disconnected"
+  },
+  "connection.connecting": {
+    "message": "Connecting…",
+    "description": "Relay connection connecting"
+  },
+  "connection.connected": {
+    "message": "Connected",
+    "description": "Relay connection connected"
+  },
+  "connection.error": {
+    "message": "Connection error",
+    "description": "Relay connection error"
+  },
+  "pair.title": {
+    "message": "Pair a device",
+    "description": "Pairing dialog title"
+  },
+  "pair.intro": {
+    "message": "Run the Coding Bridge agent on your computer, then enter its pairing code here to control it from the web.",
+    "description": "Pairing dialog intro"
+  },
+  "pair.step1": {
+    "message": "Install the agent (requires Python 3.10+):",
+    "description": "Pairing step 1"
+  },
+  "pair.step2": {
+    "message": "Start it and follow the prompt:",
+    "description": "Pairing step 2"
+  },
+  "pair.step3": {
+    "message": "Enter the pairing code it shows below.",
+    "description": "Pairing step 3"
+  },
+  "pair.codePlaceholder": {
+    "message": "Pairing code",
+    "description": "Pairing code input placeholder"
+  },
+  "pair.claim": {
+    "message": "Pair device",
+    "description": "Pairing confirm button"
+  },
+  "pair.success": {
+    "message": "Device \"{name}\" paired.",
+    "description": "Pairing success toast"
+  },
+  "pair.invalidCode": {
+    "message": "Invalid or expired pairing code.",
+    "description": "Pairing invalid code error"
+  },
+  "pair.usedCode": {
+    "message": "This pairing code has already been used.",
+    "description": "Pairing used code error"
+  },
+  "pair.failed": {
+    "message": "Failed to pair device.",
+    "description": "Pairing generic error"
+  },
+  "permission.title": {
+    "message": "Permission required",
+    "description": "Permission dialog title"
+  },
+  "permission.subtitle": {
+    "message": "The agent wants to use a tool. Approve to continue.",
+    "description": "Permission dialog subtitle"
+  },
+  "permission.deny": {
+    "message": "Deny",
+    "description": "Deny a tool permission"
+  },
+  "permission.allow": {
+    "message": "Allow",
+    "description": "Allow a tool permission"
+  },
+  "session.noDevice": {
+    "message": "Select a device to start coding.",
+    "description": "No device selected placeholder"
+  },
+  "session.newSession": {
+    "message": "New session",
+    "description": "Start a new session"
+  },
+  "session.deviceOffline": {
+    "message": "This device is offline. Start the Coding Bridge agent on it to continue.",
+    "description": "Device offline warning"
+  },
+  "session.startHint": {
+    "message": "Send a message to start a session on this device.",
+    "description": "Empty transcript hint"
+  },
+  "session.cwdPlaceholder": {
+    "message": "Working directory (optional)",
+    "description": "Working directory input placeholder"
+  },
+  "session.modelPlaceholder": {
+    "message": "Model (optional)",
+    "description": "Model input placeholder"
+  },
+  "session.promptPlaceholder": {
+    "message": "Send a message to the agent…",
+    "description": "Prompt input placeholder"
+  },
+  "session.send": {
+    "message": "Send",
+    "description": "Send prompt button"
+  },
+  "session.enterHint": {
+    "message": "Enter to send, Shift+Enter for a new line.",
+    "description": "Composer keyboard hint"
+  },
+  "transcript.turnFailed": {
+    "message": "Turn failed",
+    "description": "Turn result failed label"
+  },
+  "transcript.turnDone": {
+    "message": "Done",
+    "description": "Turn result done label"
+  }
+}

--- a/src/i18n/zh-CN/codingBridge.json
+++ b/src/i18n/zh-CN/codingBridge.json
@@ -1,0 +1,166 @@
+{
+  "nodeList.title": {
+    "message": "设备",
+    "description": "Coding Bridge 设备列表标题"
+  },
+  "nodeList.refresh": {
+    "message": "刷新",
+    "description": "刷新设备列表"
+  },
+  "nodeList.pair": {
+    "message": "配对设备",
+    "description": "打开配对对话框"
+  },
+  "nodeList.empty": {
+    "message": "尚未配对任何设备。",
+    "description": "设备列表为空时的提示"
+  },
+  "nodeList.pairFirst": {
+    "message": "配对第一台设备",
+    "description": "空状态下的配对按钮"
+  },
+  "nodeList.remove": {
+    "message": "移除",
+    "description": "移除设备"
+  },
+  "nodeList.removeConfirm": {
+    "message": "移除设备“{name}”？移除后需要重新配对。",
+    "description": "移除设备确认"
+  },
+  "nodeList.removeSuccess": {
+    "message": "设备已移除。",
+    "description": "移除设备成功提示"
+  },
+  "nodeList.removeFailed": {
+    "message": "移除设备失败。",
+    "description": "移除设备失败提示"
+  },
+  "status.online": {
+    "message": "在线",
+    "description": "设备在线状态"
+  },
+  "status.offline": {
+    "message": "离线",
+    "description": "设备离线状态"
+  },
+  "connection.disconnected": {
+    "message": "已断开",
+    "description": "中继连接已断开"
+  },
+  "connection.connecting": {
+    "message": "连接中…",
+    "description": "中继连接中"
+  },
+  "connection.connected": {
+    "message": "已连接",
+    "description": "中继已连接"
+  },
+  "connection.error": {
+    "message": "连接出错",
+    "description": "中继连接出错"
+  },
+  "pair.title": {
+    "message": "配对设备",
+    "description": "配对对话框标题"
+  },
+  "pair.intro": {
+    "message": "在你的电脑上运行 Coding Bridge 代理，然后在此输入配对码即可在网页端控制它。",
+    "description": "配对对话框介绍"
+  },
+  "pair.step1": {
+    "message": "安装代理（需要 Python 3.10+）：",
+    "description": "配对步骤 1"
+  },
+  "pair.step2": {
+    "message": "启动并按提示操作：",
+    "description": "配对步骤 2"
+  },
+  "pair.step3": {
+    "message": "输入下方显示的配对码。",
+    "description": "配对步骤 3"
+  },
+  "pair.codePlaceholder": {
+    "message": "配对码",
+    "description": "配对码输入框占位符"
+  },
+  "pair.claim": {
+    "message": "配对设备",
+    "description": "配对确认按钮"
+  },
+  "pair.success": {
+    "message": "设备“{name}”已配对。",
+    "description": "配对成功提示"
+  },
+  "pair.invalidCode": {
+    "message": "配对码无效或已过期。",
+    "description": "配对码无效错误"
+  },
+  "pair.usedCode": {
+    "message": "该配对码已被使用。",
+    "description": "配对码已使用错误"
+  },
+  "pair.failed": {
+    "message": "配对设备失败。",
+    "description": "配对通用错误"
+  },
+  "permission.title": {
+    "message": "需要授权",
+    "description": "授权对话框标题"
+  },
+  "permission.subtitle": {
+    "message": "代理请求使用一个工具，批准后继续。",
+    "description": "授权对话框副标题"
+  },
+  "permission.deny": {
+    "message": "拒绝",
+    "description": "拒绝工具授权"
+  },
+  "permission.allow": {
+    "message": "允许",
+    "description": "允许工具授权"
+  },
+  "session.noDevice": {
+    "message": "选择一台设备开始编码。",
+    "description": "未选择设备时的占位提示"
+  },
+  "session.newSession": {
+    "message": "新会话",
+    "description": "开始新会话"
+  },
+  "session.deviceOffline": {
+    "message": "该设备已离线。请在该设备上启动 Coding Bridge 代理后继续。",
+    "description": "设备离线警告"
+  },
+  "session.startHint": {
+    "message": "发送一条消息以在该设备上开始会话。",
+    "description": "空白记录提示"
+  },
+  "session.cwdPlaceholder": {
+    "message": "工作目录（可选）",
+    "description": "工作目录输入框占位符"
+  },
+  "session.modelPlaceholder": {
+    "message": "模型（可选）",
+    "description": "模型输入框占位符"
+  },
+  "session.promptPlaceholder": {
+    "message": "向代理发送消息…",
+    "description": "提示词输入框占位符"
+  },
+  "session.send": {
+    "message": "发送",
+    "description": "发送提示词按钮"
+  },
+  "session.enterHint": {
+    "message": "回车发送，Shift+回车换行。",
+    "description": "输入框键盘提示"
+  },
+  "transcript.turnFailed": {
+    "message": "执行失败",
+    "description": "回合结果失败标签"
+  },
+  "transcript.turnDone": {
+    "message": "完成",
+    "description": "回合结果完成标签"
+  }
+}

--- a/src/i18n/zh-TW/codingBridge.json
+++ b/src/i18n/zh-TW/codingBridge.json
@@ -1,0 +1,166 @@
+{
+  "nodeList.title": {
+    "message": "裝置",
+    "description": "Coding Bridge 裝置清單標題"
+  },
+  "nodeList.refresh": {
+    "message": "重新整理",
+    "description": "重新整理裝置清單"
+  },
+  "nodeList.pair": {
+    "message": "配對裝置",
+    "description": "開啟配對對話框"
+  },
+  "nodeList.empty": {
+    "message": "尚未配對任何裝置。",
+    "description": "裝置清單為空時的提示"
+  },
+  "nodeList.pairFirst": {
+    "message": "配對第一台裝置",
+    "description": "空狀態下的配對按鈕"
+  },
+  "nodeList.remove": {
+    "message": "移除",
+    "description": "移除裝置"
+  },
+  "nodeList.removeConfirm": {
+    "message": "移除裝置「{name}」？移除後需要重新配對。",
+    "description": "移除裝置確認"
+  },
+  "nodeList.removeSuccess": {
+    "message": "裝置已移除。",
+    "description": "移除裝置成功提示"
+  },
+  "nodeList.removeFailed": {
+    "message": "移除裝置失敗。",
+    "description": "移除裝置失敗提示"
+  },
+  "status.online": {
+    "message": "線上",
+    "description": "裝置線上狀態"
+  },
+  "status.offline": {
+    "message": "離線",
+    "description": "裝置離線狀態"
+  },
+  "connection.disconnected": {
+    "message": "已斷線",
+    "description": "中繼連線已斷線"
+  },
+  "connection.connecting": {
+    "message": "連線中…",
+    "description": "中繼連線中"
+  },
+  "connection.connected": {
+    "message": "已連線",
+    "description": "中繼已連線"
+  },
+  "connection.error": {
+    "message": "連線錯誤",
+    "description": "中繼連線錯誤"
+  },
+  "pair.title": {
+    "message": "配對裝置",
+    "description": "配對對話框標題"
+  },
+  "pair.intro": {
+    "message": "在你的電腦上執行 Coding Bridge 代理程式，然後在此輸入配對碼即可從網頁端控制它。",
+    "description": "配對對話框介紹"
+  },
+  "pair.step1": {
+    "message": "安裝代理程式（需要 Python 3.10+）：",
+    "description": "配對步驟 1"
+  },
+  "pair.step2": {
+    "message": "啟動並依提示操作：",
+    "description": "配對步驟 2"
+  },
+  "pair.step3": {
+    "message": "輸入下方顯示的配對碼。",
+    "description": "配對步驟 3"
+  },
+  "pair.codePlaceholder": {
+    "message": "配對碼",
+    "description": "配對碼輸入框佔位符"
+  },
+  "pair.claim": {
+    "message": "配對裝置",
+    "description": "配對確認按鈕"
+  },
+  "pair.success": {
+    "message": "裝置「{name}」已配對。",
+    "description": "配對成功提示"
+  },
+  "pair.invalidCode": {
+    "message": "配對碼無效或已過期。",
+    "description": "配對碼無效錯誤"
+  },
+  "pair.usedCode": {
+    "message": "此配對碼已被使用。",
+    "description": "配對碼已使用錯誤"
+  },
+  "pair.failed": {
+    "message": "配對裝置失敗。",
+    "description": "配對通用錯誤"
+  },
+  "permission.title": {
+    "message": "需要授權",
+    "description": "授權對話框標題"
+  },
+  "permission.subtitle": {
+    "message": "代理程式請求使用工具，核准後繼續。",
+    "description": "授權對話框副標題"
+  },
+  "permission.deny": {
+    "message": "拒絕",
+    "description": "拒絕工具授權"
+  },
+  "permission.allow": {
+    "message": "允許",
+    "description": "允許工具授權"
+  },
+  "session.noDevice": {
+    "message": "選擇一台裝置開始編碼。",
+    "description": "未選擇裝置時的佔位提示"
+  },
+  "session.newSession": {
+    "message": "新工作階段",
+    "description": "開始新工作階段"
+  },
+  "session.deviceOffline": {
+    "message": "此裝置已離線。請在該裝置上啟動 Coding Bridge 代理程式後繼續。",
+    "description": "裝置離線警告"
+  },
+  "session.startHint": {
+    "message": "傳送一則訊息以在此裝置上開始工作階段。",
+    "description": "空白記錄提示"
+  },
+  "session.cwdPlaceholder": {
+    "message": "工作目錄（選填）",
+    "description": "工作目錄輸入框佔位符"
+  },
+  "session.modelPlaceholder": {
+    "message": "模型（選填）",
+    "description": "模型輸入框佔位符"
+  },
+  "session.promptPlaceholder": {
+    "message": "向代理程式傳送訊息…",
+    "description": "提示詞輸入框佔位符"
+  },
+  "session.send": {
+    "message": "傳送",
+    "description": "傳送提示詞按鈕"
+  },
+  "session.enterHint": {
+    "message": "Enter 傳送，Shift+Enter 換行。",
+    "description": "輸入框鍵盤提示"
+  },
+  "transcript.turnFailed": {
+    "message": "執行失敗",
+    "description": "回合結果失敗標籤"
+  },
+  "transcript.turnDone": {
+    "message": "完成",
+    "description": "回合結果完成標籤"
+  }
+}

--- a/src/models/codingBridge.ts
+++ b/src/models/codingBridge.ts
@@ -1,0 +1,69 @@
+/**
+ * Coding Bridge lets a signed-in user drive a Claude Code / Codex agent that
+ * runs on their own machine (a "node" daemon) from the web UI. The browser
+ * never executes anything: it only relays JSON envelopes to the node through
+ * the stateful `coding-bridge` relay over a single authenticated WebSocket.
+ */
+
+/** A node daemon owned by the current user, as returned by `GET /api/nodes`. */
+export interface ICodingBridgeNode {
+  node_id: string;
+  name: string;
+  status: 'online' | 'offline';
+  capabilities?: string[];
+  last_seen?: number;
+}
+
+export type ICodingBridgeSessionStatus = 'starting' | 'running' | 'idle' | 'closed' | 'error';
+
+/** A live agent session running inside one node. */
+export interface ICodingBridgeSession {
+  session_id: string;
+  node_id: string;
+  status: ICodingBridgeSessionStatus;
+  cwd?: string;
+  model?: string;
+  cost_usd?: number;
+}
+
+/**
+ * A single rendered item in a session transcript. We flatten every node event
+ * (and the locally-echoed user prompt) into this one shape so the transcript
+ * view can render a uniform, append-only list.
+ */
+export type ICodingBridgeEventKind = 'prompt' | 'text' | 'thinking' | 'tool_use' | 'tool_result' | 'result' | 'error';
+
+export interface ICodingBridgeEvent {
+  id: string;
+  session_id: string;
+  kind: ICodingBridgeEventKind;
+  ts: number;
+  text?: string;
+  tool?: string;
+  tool_use_id?: string;
+  input?: Record<string, any>;
+  content?: string;
+  is_error?: boolean;
+  subtype?: string;
+  cost_usd?: number;
+}
+
+/** A pending tool-permission request awaiting the user's approval. */
+export interface ICodingBridgePermissionRequest {
+  request_id: string;
+  session_id: string;
+  node_id: string;
+  tool: string;
+  title?: string;
+  display_name?: string;
+  description?: string;
+  input?: Record<string, any>;
+}
+
+export type ICodingBridgeConnectionStatus = 'disconnected' | 'connecting' | 'connected' | 'error';
+
+/** Response of `POST /pair/claim`. */
+export interface ICodingBridgeClaimResponse {
+  ok: boolean;
+  node_name: string;
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -36,3 +36,4 @@ export * from './exchange';
 export * from './error';
 export * from './config';
 export * from './byok';
+export * from './codingBridge';

--- a/src/operators/codingBridge.ts
+++ b/src/operators/codingBridge.ts
@@ -1,0 +1,46 @@
+import axios, { AxiosResponse } from 'axios';
+import { ICodingBridgeClaimResponse, ICodingBridgeNode } from '@/models';
+import { BASE_URL_CODING_BRIDGE } from '@/constants';
+
+/**
+ * REST client for the `coding-bridge` relay (browser side, Ace JWT).
+ * Live session traffic does NOT go through here — it runs over the WebSocket
+ * in `src/utils/codingBridgeSocket.ts`. This operator only covers pairing and
+ * node lifecycle management.
+ */
+class CodingBridgeOperator {
+  private headers(token: string) {
+    return {
+      authorization: `Bearer ${token}`,
+      'content-type': 'application/json',
+      accept: 'application/json'
+    };
+  }
+
+  /** Bind a node's pairing code to the signed-in user. */
+  async claimPair(pairCode: string, options: { token: string }): Promise<AxiosResponse<ICodingBridgeClaimResponse>> {
+    return await axios.post(
+      '/pair/claim',
+      { pair_code: pairCode },
+      { headers: this.headers(options.token), baseURL: BASE_URL_CODING_BRIDGE }
+    );
+  }
+
+  /** List the nodes owned by the signed-in user. */
+  async getNodes(options: { token: string }): Promise<AxiosResponse<{ nodes: ICodingBridgeNode[] }>> {
+    return await axios.get('/api/nodes', {
+      headers: this.headers(options.token),
+      baseURL: BASE_URL_CODING_BRIDGE
+    });
+  }
+
+  /** Revoke a node and drop any live connection it holds. */
+  async deleteNode(nodeId: string, options: { token: string }): Promise<AxiosResponse<{ ok: boolean }>> {
+    return await axios.delete(`/api/nodes/${encodeURIComponent(nodeId)}`, {
+      headers: this.headers(options.token),
+      baseURL: BASE_URL_CODING_BRIDGE
+    });
+  }
+}
+
+export const codingBridgeOperator = new CodingBridgeOperator();

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -38,3 +38,4 @@ export * from './config';
 export * from './agent';
 export * from './byokCredential';
 export * from './appVersion';
+export * from './codingBridge';

--- a/src/pages/codingBridge/Index.vue
+++ b/src/pages/codingBridge/Index.vue
@@ -1,0 +1,87 @@
+<template>
+  <div class="coding-bridge flex flex-row h-full relative">
+    <node-list class="sidebar w-[300px] flex-none" @pair="openPair" />
+    <session-view class="flex-1 min-w-0" />
+
+    <el-button circle class="menu" @click="drawer = true">
+      <font-awesome-icon icon="fa-solid fa-laptop-code" />
+    </el-button>
+    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="300px" class="drawer">
+      <node-list @pair="openPairFromDrawer" />
+    </el-drawer>
+
+    <pair-dialog v-model:visible="pairVisible" :initial-code="initialCode" />
+    <permission-dialog />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElButton, ElDrawer } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import NodeList from '@/components/codingBridge/NodeList.vue';
+import SessionView from '@/components/codingBridge/SessionView.vue';
+import PairDialog from '@/components/codingBridge/PairDialog.vue';
+import PermissionDialog from '@/components/codingBridge/PermissionDialog.vue';
+
+export default defineComponent({
+  name: 'CodingBridgeIndex',
+  components: {
+    ElButton,
+    ElDrawer,
+    FontAwesomeIcon,
+    NodeList,
+    SessionView,
+    PairDialog,
+    PermissionDialog
+  },
+  data() {
+    return {
+      drawer: false,
+      pairVisible: false,
+      initialCode: ''
+    };
+  },
+  mounted() {
+    this.$store.dispatch('codingBridge/connect');
+    this.$store.dispatch('codingBridge/getNodes');
+    const code = this.$route.query.code;
+    if (typeof code === 'string' && code) {
+      this.initialCode = code;
+      this.pairVisible = true;
+    }
+  },
+  beforeUnmount() {
+    this.$store.dispatch('codingBridge/disconnect');
+  },
+  methods: {
+    openPair() {
+      this.initialCode = '';
+      this.pairVisible = true;
+    },
+    openPairFromDrawer() {
+      this.drawer = false;
+      this.openPair();
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.menu {
+  display: none;
+}
+
+@media (max-width: 767px) {
+  .sidebar {
+    display: none;
+  }
+  .menu {
+    display: block;
+    position: absolute;
+    left: 8px;
+    top: calc(45px + var(--app-safe-area-top));
+    z-index: 1000;
+  }
+}
+</style>

--- a/src/router/codingBridge.ts
+++ b/src/router/codingBridge.ts
@@ -1,0 +1,17 @@
+import { ROUTE_CODING_BRIDGE_INDEX } from './constants';
+
+export default {
+  path: '/coding-bridge',
+  meta: {
+    auth: true,
+    appName: 'codingBridge'
+  },
+  component: () => import('@/layouts/Main.vue'),
+  children: [
+    {
+      path: '',
+      name: ROUTE_CODING_BRIDGE_INDEX,
+      component: () => import('@/pages/codingBridge/Index.vue')
+    }
+  ]
+};

--- a/src/router/constants.ts
+++ b/src/router/constants.ts
@@ -75,6 +75,8 @@ export const ROUTE_FISH_MODEL_INDEX = 'fish-model-index';
 
 export const ROUTE_WEBEXTRATOR_INDEX = 'webextrator-index';
 
+export const ROUTE_CODING_BRIDGE_INDEX = 'coding-bridge-index';
+
 export const ROUTE_PROFILE_INDEX = 'profile-index';
 
 export const ROUTE_ORDER_PUBLIC_PAY = 'order-public-pay';

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -32,6 +32,7 @@ import serp from './serp';
 import wan from './wan';
 import fish from './fish';
 import webextrator from './webextrator';
+import codingBridge from './codingBridge';
 import settings from './settings';
 import profile from './profile';
 
@@ -242,6 +243,13 @@ const ROUTE_SEO: Record<string, { title: string; description: string; keywords: 
       'Render and extract any web page with WebExtrator — get HTML, markdown, plain text, structured data, links, and screenshots from any URL.',
     keywords: ['WebExtrator', 'Web Scraping', 'Web Render', 'Content Extraction', 'Markdown', 'Headless Browser'],
     category: 'Web Data'
+  },
+  'coding-bridge': {
+    title: 'Coding Bridge',
+    description:
+      'Drive Claude Code and Codex on your own machine from the web — pair a local node and run coding agents remotely with per-tool approval.',
+    keywords: ['Coding Bridge', 'Claude Code', 'Codex', 'Remote Agent', 'AI Coding'],
+    category: 'AI Coding'
   }
 };
 
@@ -331,6 +339,7 @@ const routes = [
   wan,
   fish,
   webextrator,
+  codingBridge,
   midjourney,
   distribution,
   download,

--- a/src/store/codingBridge/actions.ts
+++ b/src/store/codingBridge/actions.ts
@@ -1,0 +1,367 @@
+import { ActionContext } from 'vuex';
+import { codingBridgeOperator } from '@/operators';
+import { ICodingBridgeState } from './models';
+import { IRootState } from '../common/models';
+import { Status, ICodingBridgeEvent, ICodingBridgeEventKind, ICodingBridgeNode } from '@/models';
+import { CodingBridgeSocket } from '@/utils/codingBridgeSocket';
+import {
+  CB_ACTION_SESSION_START,
+  CB_ACTION_SESSION_SEND,
+  CB_ACTION_SESSION_INTERRUPT,
+  CB_ACTION_SESSION_CLOSE,
+  CB_ACTION_PERMISSION_RESOLVE,
+  CB_EVENT_SESSION_STARTED,
+  CB_EVENT_SESSION_TEXT,
+  CB_EVENT_SESSION_THINKING,
+  CB_EVENT_SESSION_TOOL_USE,
+  CB_EVENT_SESSION_TOOL_RESULT,
+  CB_EVENT_PERMISSION_REQUEST,
+  CB_EVENT_PERMISSION_RESOLVED,
+  CB_EVENT_SESSION_RESULT,
+  CB_EVENT_SESSION_ERROR,
+  CB_EVENT_SESSION_CLOSED,
+  CB_EVENT_SESSIONS_SNAPSHOT
+} from '@/constants';
+
+// The live WebSocket is intentionally kept OUT of Vuex state (it is not
+// serialisable and must survive `vuex-persistedstate`). It is a module-level
+// singleton owned by the actions that open and close it.
+let socket: CodingBridgeSocket | undefined;
+
+const uid = (): string => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID().replace(/-/g, '');
+  }
+  return `${Date.now().toString(16)}${Math.random().toString(16).slice(2)}`;
+};
+
+const makeEvent = (
+  sessionId: string,
+  kind: ICodingBridgeEventKind,
+  fields: Partial<ICodingBridgeEvent>
+): ICodingBridgeEvent => ({
+  id: uid(),
+  session_id: sessionId,
+  kind,
+  ts: Date.now(),
+  ...fields
+});
+
+// Translate one inner node event into the matching mutation(s).
+const applyNodeEvent = (
+  commit: ActionContext<ICodingBridgeState, IRootState>['commit'],
+  payload: Record<string, any>,
+  fromNode: string | undefined
+): void => {
+  const event = payload?.event;
+  const sessionId = payload?.session_id;
+  switch (event) {
+    case CB_EVENT_SESSION_STARTED:
+      commit('upsertSession', {
+        session_id: sessionId,
+        node_id: fromNode,
+        status: 'idle',
+        cwd: payload.cwd,
+        model: payload.model
+      });
+      break;
+    case CB_EVENT_SESSION_TEXT:
+      commit('appendEvent', makeEvent(sessionId, 'text', { text: payload.text }));
+      break;
+    case CB_EVENT_SESSION_THINKING:
+      commit('appendEvent', makeEvent(sessionId, 'thinking', { text: payload.text }));
+      break;
+    case CB_EVENT_SESSION_TOOL_USE:
+      commit(
+        'appendEvent',
+        makeEvent(sessionId, 'tool_use', {
+          tool: payload.tool,
+          tool_use_id: payload.tool_use_id,
+          input: payload.input
+        })
+      );
+      break;
+    case CB_EVENT_SESSION_TOOL_RESULT:
+      commit(
+        'appendEvent',
+        makeEvent(sessionId, 'tool_result', {
+          tool_use_id: payload.tool_use_id,
+          content: payload.content,
+          is_error: payload.is_error
+        })
+      );
+      break;
+    case CB_EVENT_PERMISSION_REQUEST:
+      commit('addPermission', {
+        request_id: payload.request_id,
+        session_id: sessionId,
+        node_id: fromNode,
+        tool: payload.tool,
+        input: payload.input,
+        title: payload.title,
+        display_name: payload.display_name,
+        description: payload.description
+      });
+      break;
+    case CB_EVENT_PERMISSION_RESOLVED:
+      commit('removePermission', payload.request_id);
+      break;
+    case CB_EVENT_SESSION_RESULT:
+      commit(
+        'appendEvent',
+        makeEvent(sessionId, 'result', {
+          subtype: payload.subtype,
+          is_error: payload.is_error,
+          text: payload.result,
+          cost_usd: payload.cost_usd
+        })
+      );
+      commit('updateSession', { session_id: sessionId, status: 'idle', cost_usd: payload.cost_usd });
+      break;
+    case CB_EVENT_SESSION_ERROR:
+      commit('appendEvent', makeEvent(sessionId, 'error', { text: payload.message }));
+      commit('updateSession', { session_id: sessionId, status: 'error' });
+      break;
+    case CB_EVENT_SESSION_CLOSED:
+      commit('updateSession', { session_id: sessionId, status: 'closed' });
+      break;
+    case CB_EVENT_SESSIONS_SNAPSHOT:
+      for (const item of payload.sessions ?? []) {
+        commit('upsertSession', {
+          session_id: item.session_id,
+          node_id: fromNode,
+          status: item.status ?? 'idle',
+          cwd: item.cwd,
+          model: item.model
+        });
+      }
+      break;
+    default:
+      break;
+  }
+};
+
+export const resetAll = ({ commit }: ActionContext<ICodingBridgeState, IRootState>): void => {
+  commit('resetAll');
+};
+
+// --- Layout no-ops: Coding Bridge is not a billed service. `Main.vue` calls
+// `<appName>/getApplications` and `<appName>/setApplication` generically; these
+// stubs keep that contract without pulling in any billing concept. ----------
+export const getApplications = async (): Promise<void> => {};
+export const setApplication = async (): Promise<void> => {};
+
+export const getNodes = async ({
+  commit,
+  rootState
+}: ActionContext<ICodingBridgeState, IRootState>): Promise<ICodingBridgeNode[]> => {
+  const token = rootState.token?.access;
+  if (!token) {
+    return [];
+  }
+  commit('updateStatus', { key: 'getNodes', value: Status.Request });
+  try {
+    const { data } = await codingBridgeOperator.getNodes({ token });
+    commit('setNodes', data.nodes ?? []);
+    commit('updateStatus', { key: 'getNodes', value: Status.Success });
+    return data.nodes ?? [];
+  } catch (error) {
+    commit('updateStatus', { key: 'getNodes', value: Status.Error });
+    throw error;
+  }
+};
+
+export const claimPair = async (
+  { commit, dispatch, rootState }: ActionContext<ICodingBridgeState, IRootState>,
+  pairCode: string
+): Promise<string> => {
+  const token = rootState.token?.access;
+  if (!token) {
+    throw new Error('not authenticated');
+  }
+  commit('updateStatus', { key: 'claimPair', value: Status.Request });
+  try {
+    const { data } = await codingBridgeOperator.claimPair(pairCode.trim(), { token });
+    commit('updateStatus', { key: 'claimPair', value: Status.Success });
+    await dispatch('getNodes');
+    return data.node_name;
+  } catch (error) {
+    commit('updateStatus', { key: 'claimPair', value: Status.Error });
+    throw error;
+  }
+};
+
+export const deleteNode = async (
+  { commit, dispatch, state, rootState }: ActionContext<ICodingBridgeState, IRootState>,
+  nodeId: string
+): Promise<void> => {
+  const token = rootState.token?.access;
+  if (!token) {
+    throw new Error('not authenticated');
+  }
+  commit('updateStatus', { key: 'deleteNode', value: Status.Request });
+  try {
+    await codingBridgeOperator.deleteNode(nodeId, { token });
+    commit('removeNodeData', nodeId);
+    if (state.currentNodeId === nodeId) {
+      commit('setCurrentNode', undefined);
+      commit('setCurrentSession', undefined);
+    }
+    commit('updateStatus', { key: 'deleteNode', value: Status.Success });
+    await dispatch('getNodes');
+  } catch (error) {
+    commit('updateStatus', { key: 'deleteNode', value: Status.Error });
+    throw error;
+  }
+};
+
+export const connect = ({ commit, rootState }: ActionContext<ICodingBridgeState, IRootState>): void => {
+  const token = rootState.token?.access;
+  if (!token) {
+    return;
+  }
+  if (socket?.isOpen) {
+    return;
+  }
+  socket?.close();
+  commit('setConnection', 'connecting');
+  socket = new CodingBridgeSocket(token, {
+    onOpen: () => commit('setConnection', 'connected'),
+    onClose: () => commit('setConnection', 'disconnected'),
+    onEvent: (payload, fromNode) => applyNodeEvent(commit, payload, fromNode),
+    onNodesSnapshot: (nodes) => {
+      // Merge live online flags onto the REST-sourced list without dropping
+      // offline nodes the snapshot omits.
+      commit('mergeNodeSnapshot', nodes);
+    },
+    onNodeStatus: (nodeId, status) => commit('setNodeStatus', { node_id: nodeId, status }),
+    onRelayError: (code, message) => console.warn('[codingBridge] relay error', code, message)
+  });
+  socket.connect();
+};
+
+export const disconnect = ({ commit }: ActionContext<ICodingBridgeState, IRootState>): void => {
+  socket?.close();
+  socket = undefined;
+  commit('setConnection', 'disconnected');
+};
+
+export const selectNode = (
+  { commit, state }: ActionContext<ICodingBridgeState, IRootState>,
+  nodeId: string | undefined
+): void => {
+  commit('setCurrentNode', nodeId);
+  if (!nodeId) {
+    commit('setCurrentSession', undefined);
+    return;
+  }
+  const ids = Object.values(state.sessions)
+    .filter((session) => session.node_id === nodeId)
+    .map((session) => session.session_id);
+  commit('setCurrentSession', ids.length ? ids[ids.length - 1] : undefined);
+};
+
+export const newSession = ({ commit }: ActionContext<ICodingBridgeState, IRootState>): void => {
+  commit('setCurrentSession', undefined);
+};
+
+export const sendPrompt = (
+  { commit, state }: ActionContext<ICodingBridgeState, IRootState>,
+  payload: { prompt: string; cwd?: string; model?: string }
+): void => {
+  const nodeId = state.currentNodeId;
+  const prompt = payload.prompt?.trim();
+  if (!nodeId || !prompt || !socket) {
+    return;
+  }
+  let sessionId = state.currentSessionId;
+  const isNew = !sessionId || !state.sessions[sessionId];
+  if (isNew) {
+    sessionId = uid();
+    commit('upsertSession', {
+      session_id: sessionId,
+      node_id: nodeId,
+      status: 'starting',
+      cwd: payload.cwd,
+      model: payload.model
+    });
+    commit('setCurrentSession', sessionId);
+    commit('appendEvent', makeEvent(sessionId, 'prompt', { text: prompt }));
+    socket.sendToNode(nodeId, {
+      action: CB_ACTION_SESSION_START,
+      session_id: sessionId,
+      prompt,
+      cwd: payload.cwd || undefined,
+      model: payload.model || undefined,
+      permission_mode: 'default'
+    });
+  } else {
+    commit('appendEvent', makeEvent(sessionId as string, 'prompt', { text: prompt }));
+    commit('updateSession', { session_id: sessionId as string, status: 'running' });
+    socket.sendToNode(nodeId, {
+      action: CB_ACTION_SESSION_SEND,
+      session_id: sessionId,
+      prompt
+    });
+  }
+};
+
+export const interruptSession = ({ state }: ActionContext<ICodingBridgeState, IRootState>): void => {
+  const sessionId = state.currentSessionId;
+  const nodeId = state.currentNodeId;
+  if (!sessionId || !nodeId || !socket) {
+    return;
+  }
+  socket.sendToNode(nodeId, { action: CB_ACTION_SESSION_INTERRUPT, session_id: sessionId });
+};
+
+export const closeSession = (
+  { commit, state }: ActionContext<ICodingBridgeState, IRootState>,
+  sessionId?: string
+): void => {
+  const sid = sessionId ?? state.currentSessionId;
+  if (!sid) {
+    return;
+  }
+  const nodeId = state.sessions[sid]?.node_id ?? state.currentNodeId;
+  if (nodeId && socket) {
+    socket.sendToNode(nodeId, { action: CB_ACTION_SESSION_CLOSE, session_id: sid });
+  }
+  commit('updateSession', { session_id: sid, status: 'closed' });
+  if (state.currentSessionId === sid) {
+    commit('setCurrentSession', undefined);
+  }
+};
+
+export const resolvePermission = (
+  { commit, state }: ActionContext<ICodingBridgeState, IRootState>,
+  payload: { request_id: string; decision: 'allow' | 'deny' }
+): void => {
+  const request = state.permissions.find((item) => item.request_id === payload.request_id);
+  if (!request) {
+    return;
+  }
+  socket?.sendToNode(request.node_id, {
+    action: CB_ACTION_PERMISSION_RESOLVE,
+    request_id: payload.request_id,
+    decision: payload.decision
+  });
+  commit('removePermission', payload.request_id);
+};
+
+export default {
+  resetAll,
+  getApplications,
+  setApplication,
+  getNodes,
+  claimPair,
+  deleteNode,
+  connect,
+  disconnect,
+  selectNode,
+  newSession,
+  sendPrompt,
+  interruptSession,
+  closeSession,
+  resolvePermission
+};

--- a/src/store/codingBridge/index.ts
+++ b/src/store/codingBridge/index.ts
@@ -1,0 +1,14 @@
+import { Module } from 'vuex';
+import { ICodingBridgeState } from './models';
+import actions from './actions';
+import mutations from './mutations';
+import state from './state';
+
+export const codingBridge: Module<ICodingBridgeState, any> = {
+  namespaced: true,
+  state,
+  mutations,
+  actions
+};
+
+export default codingBridge;

--- a/src/store/codingBridge/models.ts
+++ b/src/store/codingBridge/models.ts
@@ -1,0 +1,31 @@
+import { Status } from '@/models';
+import {
+  ICodingBridgeConnectionStatus,
+  ICodingBridgeEvent,
+  ICodingBridgeNode,
+  ICodingBridgePermissionRequest,
+  ICodingBridgeSession
+} from '@/models';
+
+export interface ICodingBridgeState {
+  nodes: ICodingBridgeNode[];
+  currentNodeId: string | undefined;
+  currentSessionId: string | undefined;
+  sessions: Record<string, ICodingBridgeSession>;
+  events: Record<string, ICodingBridgeEvent[]>;
+  permissions: ICodingBridgePermissionRequest[];
+  connection: ICodingBridgeConnectionStatus;
+  // Coding Bridge is not a billed API service, so it owns no application /
+  // service / credential. These fields exist only so the shared `Main.vue`
+  // layout (which is generic over per-app modules) reads `undefined` and
+  // hides the application widget instead of throwing.
+  application: undefined;
+  applications: undefined;
+  service: undefined;
+  status: {
+    getNodes: Status;
+    claimPair: Status;
+    deleteNode: Status;
+    getApplications: Status;
+  };
+}

--- a/src/store/codingBridge/mutations.ts
+++ b/src/store/codingBridge/mutations.ts
@@ -1,0 +1,123 @@
+import initialState from './state';
+import { ICodingBridgeState } from './models';
+import {
+  ICodingBridgeConnectionStatus,
+  ICodingBridgeEvent,
+  ICodingBridgeNode,
+  ICodingBridgePermissionRequest,
+  ICodingBridgeSession,
+  Status
+} from '@/models';
+
+export const resetAll = (state: ICodingBridgeState): void => {
+  Object.assign(state, initialState());
+};
+
+export const updateStatus = (
+  state: ICodingBridgeState,
+  payload: { key: keyof ICodingBridgeState['status']; value: Status }
+): void => {
+  state.status[payload.key] = payload.value;
+};
+
+export const setConnection = (state: ICodingBridgeState, payload: ICodingBridgeConnectionStatus): void => {
+  state.connection = payload;
+};
+
+export const setNodes = (state: ICodingBridgeState, payload: ICodingBridgeNode[]): void => {
+  state.nodes = payload;
+};
+
+export const mergeNodeSnapshot = (state: ICodingBridgeState, snapshot: ICodingBridgeNode[]): void => {
+  const online = new Set(snapshot.map((node) => node.node_id));
+  for (const node of state.nodes) {
+    node.status = online.has(node.node_id) ? 'online' : 'offline';
+  }
+  for (const snap of snapshot) {
+    if (!state.nodes.some((node) => node.node_id === snap.node_id)) {
+      state.nodes.push({ ...snap, status: 'online' });
+    }
+  }
+};
+
+export const setNodeStatus = (
+  state: ICodingBridgeState,
+  payload: { node_id: string; status: 'online' | 'offline' }
+): void => {
+  const node = state.nodes.find((item) => item.node_id === payload.node_id);
+  if (node) {
+    node.status = payload.status;
+  }
+};
+
+export const setCurrentNode = (state: ICodingBridgeState, payload: string | undefined): void => {
+  state.currentNodeId = payload;
+};
+
+export const setCurrentSession = (state: ICodingBridgeState, payload: string | undefined): void => {
+  state.currentSessionId = payload;
+};
+
+export const upsertSession = (state: ICodingBridgeState, payload: ICodingBridgeSession): void => {
+  state.sessions[payload.session_id] = { ...state.sessions[payload.session_id], ...payload };
+  if (!state.events[payload.session_id]) {
+    state.events[payload.session_id] = [];
+  }
+};
+
+export const updateSession = (
+  state: ICodingBridgeState,
+  payload: { session_id: string } & Partial<ICodingBridgeSession>
+): void => {
+  const existing = state.sessions[payload.session_id];
+  if (existing) {
+    state.sessions[payload.session_id] = { ...existing, ...payload };
+  }
+};
+
+export const appendEvent = (state: ICodingBridgeState, payload: ICodingBridgeEvent): void => {
+  if (!state.events[payload.session_id]) {
+    state.events[payload.session_id] = [];
+  }
+  state.events[payload.session_id].push(payload);
+};
+
+export const addPermission = (state: ICodingBridgeState, payload: ICodingBridgePermissionRequest): void => {
+  if (state.permissions.some((item) => item.request_id === payload.request_id)) {
+    return;
+  }
+  state.permissions.push(payload);
+};
+
+export const removePermission = (state: ICodingBridgeState, requestId: string): void => {
+  state.permissions = state.permissions.filter((item) => item.request_id !== requestId);
+};
+
+export const removeNodeData = (state: ICodingBridgeState, nodeId: string): void => {
+  for (const session of Object.values(state.sessions)) {
+    if (session.node_id === nodeId) {
+      delete state.sessions[session.session_id];
+      delete state.events[session.session_id];
+      if (state.currentSessionId === session.session_id) {
+        state.currentSessionId = undefined;
+      }
+    }
+  }
+};
+
+export default {
+  resetAll,
+  updateStatus,
+  setConnection,
+  setNodes,
+  mergeNodeSnapshot,
+  setNodeStatus,
+  setCurrentNode,
+  setCurrentSession,
+  upsertSession,
+  updateSession,
+  appendEvent,
+  addPermission,
+  removePermission,
+  removeNodeData
+};

--- a/src/store/codingBridge/persist.ts
+++ b/src/store/codingBridge/persist.ts
@@ -1,0 +1,4 @@
+// Only the selected node survives a reload. Live nodes, sessions, events and
+// permission prompts are rebuilt from the relay on reconnect, so persisting
+// them would only show stale data.
+export default ['codingBridge.currentNodeId'];

--- a/src/store/codingBridge/state.ts
+++ b/src/store/codingBridge/state.ts
@@ -1,0 +1,23 @@
+import { ICodingBridgeState } from './models';
+import { Status } from '@/models';
+
+export default (): ICodingBridgeState => {
+  return {
+    nodes: [],
+    currentNodeId: undefined,
+    currentSessionId: undefined,
+    sessions: {},
+    events: {},
+    permissions: [],
+    connection: 'disconnected',
+    application: undefined,
+    applications: undefined,
+    service: undefined,
+    status: {
+      getNodes: Status.None,
+      claimPair: Status.None,
+      deleteNode: Status.None,
+      getApplications: Status.None
+    }
+  };
+};

--- a/src/store/common/models.ts
+++ b/src/store/common/models.ts
@@ -21,6 +21,7 @@ import { ISerpState } from '../serp/models';
 import { IWanState } from '../wan/models';
 import { IFishState } from '../fish/models';
 import { IWebextratorState } from '../webextrator/models';
+import { ICodingBridgeState } from '../codingBridge/models';
 
 export interface ISetting {}
 
@@ -72,6 +73,7 @@ export interface IAppState {
   wan: IWanState;
   fish: IFishState;
   webextrator: IWebextratorState;
+  codingBridge: ICodingBridgeState;
 }
 
 export interface IRootState extends ICommonState, IAppState {}

--- a/src/store/common/state.ts
+++ b/src/store/common/state.ts
@@ -21,6 +21,7 @@ import serpState from '../serp/state';
 import wanState from '../wan/state';
 import fishState from '../fish/state';
 import webextratorState from '../webextrator/state';
+import codingBridgeState from '../codingBridge/state';
 
 export default (): IRootState => {
   return {
@@ -67,6 +68,7 @@ export default (): IRootState => {
     serp: serpState(),
     wan: wanState(),
     fish: fishState(),
-    webextrator: webextratorState()
+    webextrator: webextratorState(),
+    codingBridge: codingBridgeState()
   };
 };

--- a/src/store/lazy.ts
+++ b/src/store/lazy.ts
@@ -43,7 +43,8 @@ const moduleLoaders: Record<string, () => Promise<{ default: AnyVuexModule }>> =
   serp: () => import('./serp'),
   wan: () => import('./wan'),
   fish: () => import('./fish'),
-  webextrator: () => import('./webextrator')
+  webextrator: () => import('./webextrator'),
+  codingBridge: () => import('./codingBridge')
 };
 
 /** Names of every lazy-registerable per-app module (single source of truth). */

--- a/src/utils/codingBridgeSocket.ts
+++ b/src/utils/codingBridgeSocket.ts
@@ -1,0 +1,167 @@
+import {
+  WS_URL_CODING_BRIDGE,
+  CB_BROWSER_TO_NODE,
+  CB_BROWSER_LIST_NODES,
+  CB_NODE_TO_BROWSER,
+  CB_NODES_SNAPSHOT,
+  CB_NODE_STATUS,
+  CB_ERROR,
+  CB_RECONNECT_MIN_MS,
+  CB_RECONNECT_MAX_MS
+} from '@/constants';
+import { ICodingBridgeNode } from '@/models';
+
+export interface ICodingBridgeSocketHandlers {
+  onOpen?: () => void;
+  onClose?: () => void;
+  /** Inner `node.to_browser` payload plus the originating node id. */
+  onEvent?: (payload: Record<string, any>, fromNode: string | undefined) => void;
+  onNodesSnapshot?: (nodes: ICodingBridgeNode[]) => void;
+  onNodeStatus?: (nodeId: string, status: 'online' | 'offline') => void;
+  onRelayError?: (code: string, message: string) => void;
+}
+
+const makeId = (): string => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID().replace(/-/g, '');
+  }
+  return `${Date.now().toString(16)}${Math.random().toString(16).slice(2)}`;
+};
+
+/**
+ * Single browser WebSocket toward the `coding-bridge` relay.
+ *
+ * The relay authenticates the Ace JWT passed as `?token=`, fans node events
+ * back to every browser the user has open, and routes browser commands to the
+ * addressed node. This client owns reconnection with exponential backoff and
+ * never executes anything itself — it only serialises envelopes.
+ */
+export class CodingBridgeSocket {
+  private ws: WebSocket | undefined;
+  private readonly token: string;
+  private readonly handlers: ICodingBridgeSocketHandlers;
+  private reconnectDelay = CB_RECONNECT_MIN_MS;
+  private reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+  private closedByUser = false;
+
+  constructor(token: string, handlers: ICodingBridgeSocketHandlers) {
+    this.token = token;
+    this.handlers = handlers;
+  }
+
+  get isOpen(): boolean {
+    return this.ws?.readyState === WebSocket.OPEN;
+  }
+
+  connect(): void {
+    this.closedByUser = false;
+    this.open();
+  }
+
+  private open(): void {
+    if (this.ws && (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING)) {
+      return;
+    }
+    const url = `${WS_URL_CODING_BRIDGE}?token=${encodeURIComponent(this.token)}`;
+    let socket: WebSocket;
+    try {
+      socket = new WebSocket(url);
+    } catch (error) {
+      console.warn('[codingBridge] failed to open socket', error);
+      this.scheduleReconnect();
+      return;
+    }
+    this.ws = socket;
+    socket.onopen = () => {
+      this.reconnectDelay = CB_RECONNECT_MIN_MS;
+      this.handlers.onOpen?.();
+    };
+    socket.onmessage = (event) => this.onMessage(event);
+    socket.onclose = () => {
+      this.handlers.onClose?.();
+      if (!this.closedByUser) {
+        this.scheduleReconnect();
+      }
+    };
+    socket.onerror = () => {
+      // `onclose` always follows `onerror`; reconnection is handled there.
+      socket.close();
+    };
+  }
+
+  private onMessage(event: MessageEvent): void {
+    let message: any;
+    try {
+      message = JSON.parse(event.data);
+    } catch {
+      return;
+    }
+    const payload = message?.payload ?? {};
+    switch (message?.type) {
+      case CB_NODE_TO_BROWSER:
+        this.handlers.onEvent?.(payload, message?.from_node);
+        break;
+      case CB_NODES_SNAPSHOT:
+        this.handlers.onNodesSnapshot?.((payload.nodes ?? []) as ICodingBridgeNode[]);
+        break;
+      case CB_NODE_STATUS:
+        this.handlers.onNodeStatus?.(payload.node_id, payload.status);
+        break;
+      case CB_ERROR:
+        this.handlers.onRelayError?.(payload.code ?? 'error', payload.message ?? '');
+        break;
+      default:
+        break;
+    }
+  }
+
+  private scheduleReconnect(): void {
+    if (this.closedByUser || this.reconnectTimer) {
+      return;
+    }
+    const delay = this.reconnectDelay;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = undefined;
+      this.open();
+    }, delay);
+    this.reconnectDelay = Math.min(this.reconnectDelay * 2, CB_RECONNECT_MAX_MS);
+  }
+
+  private sendEnvelope(type: string, extra: Record<string, any>): void {
+    if (!this.isOpen) {
+      return;
+    }
+    const envelope = { v: 1, id: makeId(), ts: Date.now(), type, ...extra };
+    this.ws?.send(JSON.stringify(envelope));
+  }
+
+  /** Forward an inner action payload to a specific node. */
+  sendToNode(nodeId: string, payload: Record<string, any>): void {
+    this.sendEnvelope(CB_BROWSER_TO_NODE, { node_id: nodeId, payload });
+  }
+
+  /** Ask the relay to re-send the live node snapshot. */
+  listNodes(): void {
+    this.sendEnvelope(CB_BROWSER_LIST_NODES, {});
+  }
+
+  close(): void {
+    this.closedByUser = true;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = undefined;
+    }
+    if (this.ws) {
+      this.ws.onclose = null;
+      this.ws.onerror = null;
+      this.ws.onmessage = null;
+      this.ws.onopen = null;
+      try {
+        this.ws.close();
+      } catch {
+        // ignore
+      }
+      this.ws = undefined;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds the **Coding Bridge** feature to Nexior: pair a local Coding Bridge agent
running on your own machine, then drive Claude Code / Codex coding sessions from
the web. The web app is a thin passthrough — all code execution stays on the
user's machine. Nexior talks to the stateful `coding-bridge` relay over an
authenticated WebSocket (Ace JWT); the relay forwards to the paired Node daemon.

## What's included

- **Data layer** — `models/`, `constants/`, `operators/codingBridge.ts` (REST:
  pair claim, list/delete nodes) and `utils/codingBridgeSocket.ts` (relay WS
  client with exponential-backoff reconnect).
- **Store** — namespaced lazy Vuex module `codingBridge` (nodes, sessions,
  transcript events, permission requests, connection state) wired into
  `lazy.ts`, `common/models.ts`, and root state.
- **UI** — `NodeList`, `PairDialog` (install + pairing-code flow),
  `SessionView` (live transcript + composer), `TranscriptItem` (text /
  thinking / tool_use / tool_result / result / error rendering), and
  `PermissionDialog` (allow/deny tool requests), assembled in
  `pages/codingBridge/Index.vue`.
- **Routing & config** — `/coding-bridge` route + SEO entry, endpoint config
  (`BASE_URL_CODING_BRIDGE` / `WS_URL_CODING_BRIDGE`), i18n scope registration.
- **i18n** — full coverage across all 18 locales (zh-CN base, zh-TW, en, +15).

## Protocol

Browser ⇅ relay envelopes: `browser.list_nodes` / `browser.to_node` /
`nodes.snapshot` / `node.to_browser` / `node.status` / `error`. Inner
session actions (`session.start/send/interrupt/close`, `permission.resolve`)
and events (`session.started/text/thinking/tool_use/tool_result/result/...`,
`permission.request`, `sessions.snapshot`) match the relay daemon contract.

## Validation

- `python3 scripts/check_i18n_coverage.py` → OK (17 locales × 40 namespaces)
- `npx vue-tsc -b` → clean
- `npx eslint` (new files) → clean
- `npx beachball check` → OK

## Notes

- The relay (`coding-bridge.acedata.cloud`) DNS provisioning is out of scope
  for this PR.