### PR TITLE
fix(ios): surface Delete Account in the account menu

### DIFF
--- a/src/components/user/Center.vue
+++ b/src/components/user/Center.vue
@@ -25,6 +25,10 @@
             <font-awesome-icon icon="fa-solid fa-compass" class="mr-2" />
             {{ $t('common.nav.console') }}
           </el-dropdown-item>
+          <el-dropdown-item v-if="isIOS" class="py-2" @click="onDeleteAccount">
+            <font-awesome-icon icon="fa-solid fa-user-xmark" class="mr-2" />
+            {{ $t('common.nav.deleteAccount') }}
+          </el-dropdown-item>
           <el-dropdown-item class="py-2" @click="onLogout">
             <font-awesome-icon icon="fa-solid fa-arrow-right-from-bracket" class="mr-2" />
             {{ $t('common.nav.logOut') }}
@@ -34,15 +38,17 @@
     </el-dropdown>
   </div>
   <user-setting v-model:visible="showSetting" :initial-tab="settingTab" />
+  <delete-account-dialog v-model:visible="showDeleteAccount" />
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
 import UserAvatar from '@/components/user/Avatar.vue';
 import UserSetting from '@/components/user/Setting.vue';
+import DeleteAccountDialog from '@/components/user/DeleteAccountDialog.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { ROUTE_CONSOLE_ROOT, ROUTE_DISTRIBUTION_INDEX, ROUTE_DOWNLOAD } from '@/router';
-import { isNative as isNativeSurface } from '@/utils/surface';
+import { isIOS as isIOSSurface, isNative as isNativeSurface } from '@/utils/surface';
 import { ElDivider } from 'element-plus';
 import { ElDropdownMenu, ElDropdownItem, ElDropdown } from 'element-plus';
 
@@ -51,6 +57,7 @@ export default defineComponent({
   components: {
     UserAvatar,
     UserSetting,
+    DeleteAccountDialog,
     FontAwesomeIcon,
     ElDivider,
     ElDropdownMenu,
@@ -61,6 +68,7 @@ export default defineComponent({
     return {
       showMenu: false,
       showSetting: false,
+      showDeleteAccount: false,
       settingTab: ''
     };
   },
@@ -70,6 +78,9 @@ export default defineComponent({
     },
     isNative() {
       return isNativeSurface();
+    },
+    isIOS() {
+      return isIOSSurface();
     }
   },
   mounted() {
@@ -113,6 +124,9 @@ export default defineComponent({
       this.$router.push({
         name: ROUTE_DISTRIBUTION_INDEX
       });
+    },
+    onDeleteAccount() {
+      this.showDeleteAccount = true;
     },
     onSettings() {
       this.settingTab = '';

--- a/src/components/user/DeleteAccountDialog.vue
+++ b/src/components/user/DeleteAccountDialog.vue
@@ -1,0 +1,129 @@
+<template>
+  <el-dialog
+    :model-value="visible"
+    :title="$t('common.nav.deleteAccount')"
+    width="90%"
+    align-center
+    class="delete-account-dialog"
+    @update:model-value="$emit('update:visible', $event)"
+    @closed="onClosed"
+  >
+    <el-alert
+      :title="$t('common.message.deleteAccountWarning')"
+      type="error"
+      :closable="false"
+      show-icon
+      class="mb-3"
+    />
+    <p class="delete-consequences">{{ $t('common.message.deleteAccountConsequences') }}</p>
+    <p class="delete-type-prompt">{{ $t('common.message.deleteAccountTypePrompt') }}</p>
+    <p class="delete-username">{{ user.username }}</p>
+    <el-input
+      v-model="deleteConfirmText"
+      :placeholder="$t('common.message.deleteAccountPlaceholder')"
+      autocomplete="off"
+    />
+    <template #footer>
+      <el-button round @click="$emit('update:visible', false)">
+        {{ $t('common.button.cancel') }}
+      </el-button>
+      <el-button
+        type="danger"
+        round
+        :disabled="!deleteConfirmMatched"
+        :loading="deleting"
+        @click="confirmDeleteAccount"
+      >
+        {{ $t('common.button.deletePermanently') }}
+      </el-button>
+    </template>
+  </el-dialog>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElMessage, ElDialog, ElInput, ElButton, ElAlert } from 'element-plus';
+import { ROUTE_INDEX } from '@/router';
+import { userOperator } from '@/operators';
+
+export default defineComponent({
+  name: 'DeleteAccountDialog',
+  components: {
+    ElDialog,
+    ElInput,
+    ElButton,
+    ElAlert
+  },
+  props: {
+    visible: {
+      type: Boolean,
+      default: false
+    }
+  },
+  emits: ['update:visible'],
+  data() {
+    return {
+      deleteConfirmText: '',
+      deleting: false
+    };
+  },
+  computed: {
+    user() {
+      return this.$store.getters.user;
+    },
+    // Require the user to type their exact username to unlock the
+    // irreversible delete — a locale-independent guard against misclicks.
+    deleteConfirmMatched(): boolean {
+      const username = this.$store.getters.user?.username;
+      return !!username && this.deleteConfirmText.trim() === username;
+    }
+  },
+  methods: {
+    async confirmDeleteAccount() {
+      if (!this.deleteConfirmMatched || this.deleting) {
+        return;
+      }
+      this.deleting = true;
+      try {
+        await userOperator.deleteMe();
+        this.deleting = false;
+        this.$emit('update:visible', false);
+        ElMessage.success(this.$t('common.message.deleteAccountSuccess').toString());
+        await this.$store.dispatch('logout');
+        this.$router.push({ name: ROUTE_INDEX });
+      } catch {
+        this.deleting = false;
+        ElMessage.error(this.$t('common.message.deleteAccountFailed').toString());
+      }
+    },
+    onClosed() {
+      this.deleteConfirmText = '';
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.delete-account-dialog {
+  .mb-3 {
+    margin-bottom: 12px;
+  }
+  .delete-consequences {
+    margin: 12px 0;
+    font-size: 13px;
+    line-height: 1.6;
+    color: var(--el-text-color-regular);
+  }
+  .delete-type-prompt {
+    margin: 12px 0 4px;
+    font-size: 13px;
+  }
+  .delete-username {
+    margin: 0 0 10px;
+    font-weight: 700;
+    font-size: 15px;
+    word-break: break-all;
+    color: var(--el-color-danger);
+  }
+}
+</style>

--- a/src/pages/profile/Index.vue
+++ b/src/pages/profile/Index.vue
@@ -25,50 +25,13 @@
     </div>
     <locale-selector :visible="operating.locale == true" @close="operating.locale = false" />
     <help-dialog :visible="operating.help == true" @close="operating.help = false" />
-    <el-dialog
-      v-model="deleteDialogVisible"
-      :title="$t('common.nav.deleteAccount')"
-      width="90%"
-      align-center
-      class="delete-account-dialog"
-      @closed="onDeleteDialogClosed"
-    >
-      <el-alert
-        :title="$t('common.message.deleteAccountWarning')"
-        type="error"
-        :closable="false"
-        show-icon
-        class="mb-3"
-      />
-      <p class="delete-consequences">{{ $t('common.message.deleteAccountConsequences') }}</p>
-      <p class="delete-type-prompt">{{ $t('common.message.deleteAccountTypePrompt') }}</p>
-      <p class="delete-username">{{ user.username }}</p>
-      <el-input
-        v-model="deleteConfirmText"
-        :placeholder="$t('common.message.deleteAccountPlaceholder')"
-        autocomplete="off"
-      />
-      <template #footer>
-        <el-button round @click="deleteDialogVisible = false">
-          {{ $t('common.button.cancel') }}
-        </el-button>
-        <el-button
-          type="danger"
-          round
-          :disabled="!deleteConfirmMatched"
-          :loading="deleting"
-          @click="confirmDeleteAccount"
-        >
-          {{ $t('common.button.deletePermanently') }}
-        </el-button>
-      </template>
-    </el-dialog>
+    <delete-account-dialog v-model:visible="deleteDialogVisible" />
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElImage, ElMessage, ElDialog, ElInput, ElButton, ElAlert } from 'element-plus';
+import { ElImage } from 'element-plus';
 import {
   ROUTE_CONSOLE_APPLICATION_LIST,
   ROUTE_CONSOLE_ORDER_LIST,
@@ -79,8 +42,8 @@ import {
 } from '@/router';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { getBaseUrlAuth, getBaseUrlPlatform, isIOS, withCurrentUserIdAndSite } from '@/utils';
-import { userOperator } from '@/operators';
 import HelpDialog from '@/components/common/HelpDialog.vue';
+import DeleteAccountDialog from '@/components/user/DeleteAccountDialog.vue';
 
 interface ILink {
   key: string;
@@ -95,11 +58,8 @@ export default defineComponent({
   name: 'ProfileIndex',
   components: {
     ElImage,
-    ElDialog,
-    ElInput,
-    ElButton,
-    ElAlert,
     HelpDialog,
+    DeleteAccountDialog,
     FontAwesomeIcon
   },
   data() {
@@ -109,20 +69,12 @@ export default defineComponent({
         dark: false,
         help: false
       },
-      deleteDialogVisible: false,
-      deleteConfirmText: '',
-      deleting: false
+      deleteDialogVisible: false
     };
   },
   computed: {
     user() {
       return this.$store.getters.user;
-    },
-    // Require the user to type their exact username to unlock the
-    // irreversible delete — a locale-independent guard against misclicks.
-    deleteConfirmMatched(): boolean {
-      const username = this.$store.getters.user?.username;
-      return !!username && this.deleteConfirmText.trim() === username;
     },
     showSupport() {
       return (
@@ -242,28 +194,7 @@ export default defineComponent({
       });
     },
     onDeleteAccount() {
-      this.deleteConfirmText = '';
       this.deleteDialogVisible = true;
-    },
-    async confirmDeleteAccount() {
-      if (!this.deleteConfirmMatched || this.deleting) {
-        return;
-      }
-      this.deleting = true;
-      try {
-        await userOperator.deleteMe();
-        this.deleting = false;
-        this.deleteDialogVisible = false;
-        ElMessage.success(this.$t('common.message.deleteAccountSuccess').toString());
-        await this.$store.dispatch('logout');
-        this.$router.push({ name: ROUTE_INDEX });
-      } catch {
-        this.deleting = false;
-        ElMessage.error(this.$t('common.message.deleteAccountFailed').toString());
-      }
-    },
-    onDeleteDialogClosed() {
-      this.deleteConfirmText = '';
     },
     onNavigate(link: ILink) {
       if (link.name) {
@@ -368,31 +299,6 @@ $padding-left: 10px;
     .text {
       font-size: 14px;
     }
-  }
-}
-</style>
-
-<style lang="scss" scoped>
-.delete-account-dialog {
-  .mb-3 {
-    margin-bottom: 12px;
-  }
-  .delete-consequences {
-    margin: 12px 0;
-    font-size: 13px;
-    line-height: 1.6;
-    color: var(--el-text-color-regular);
-  }
-  .delete-type-prompt {
-    margin: 12px 0 4px;
-    font-size: 13px;
-  }
-  .delete-username {
-    margin: 0 0 10px;
-    font-weight: 700;
-    font-size: 15px;
-    word-break: break-all;
-    color: var(--el-color-danger);
   }
 }
 </style>


### PR DESCRIPTION
## Problem

User installed TestFlight build 3.256.1/55601 and could not find **Delete Account** anywhere. Root cause is discoverability, not a missing feature:

- The **avatar dropdown** (`UserCenter`) that users naturally open only had *Settings / Distribution / Console / Log Out* — **no Delete Account**.
- The Delete Account entry only lived on the **`/profile` page**, which:
  - on **iPhone** is buried in the bottom-bar **More (…)** overflow, and
  - on **iPad / wide screens (≥768px)** is **unreachable** — the profile nav entry is only added when `direction === 'row'` (mobile layout).

This blocks Apple **5.1.1(v)** (account deletion must be easy to find).

## Fix

- Extract the delete flow into a reusable `components/user/DeleteAccountDialog.vue` (confirm-by-typing-username → `DELETE /users/me` → logout → home).
- Add a **Delete Account** item to the avatar dropdown, right above **Log Out**, **iOS only** (`isIOS()`), so it is reachable on every device.
- `ProfileIndex` now reuses the same dialog instead of duplicating the logic.

## Notes

- iOS-only via build-time `VITE_SURFACE=ios` (`isIOS()`); web/Android unaffected.
- No new i18n keys — reuses existing `common.nav.deleteAccount` + `common.message.deleteAccount*`.
- `vue-tsc --noEmit` and ESLint pass clean.
- Requires a **new build** to reach TestFlight/App Store; not present in 55601.