### PR TITLE
feat(coding-bridge): sync & replay local Claude Code and Codex history

### DIFF
--- a/change/@acedatacloud-nexior-7bf20a23-b870-40de-84bf-e8dc3e56052d.json
+++ b/change/@acedatacloud-nexior-7bf20a23-b870-40de-84bf-e8dc3e56052d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Sync and replay local Claude Code & Codex history in Coding Bridge",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/codingBridge/HistoryDrawer.vue
+++ b/src/components/codingBridge/HistoryDrawer.vue
@@ -1,0 +1,147 @@
+<template>
+  <el-drawer
+    :model-value="visible"
+    direction="rtl"
+    size="380px"
+    :title="$t('codingBridge.history.title')"
+    @update:model-value="$emit('update:visible', $event)"
+  >
+    <div class="flex flex-col h-full">
+      <div class="flex items-center justify-between mb-3">
+        <p class="text-xs text-[var(--app-text-subtle)] m-0">
+          {{ $t('codingBridge.history.intro') }}
+        </p>
+        <el-button size="small" round :loading="loading" @click="refresh">
+          <font-awesome-icon v-if="!loading" icon="fa-solid fa-rotate-right" class="mr-1" />
+          {{ $t('codingBridge.history.refresh') }}
+        </el-button>
+      </div>
+
+      <div v-if="!currentNodeId" class="m-auto text-sm text-[var(--app-text-subtle)]">
+        {{ $t('codingBridge.session.noDevice') }}
+      </div>
+      <div v-else-if="loading && !sessions.length" class="m-auto text-sm text-[var(--app-text-subtle)]">
+        {{ $t('codingBridge.history.loading') }}
+      </div>
+      <div v-else-if="!sessions.length" class="m-auto text-sm text-[var(--app-text-subtle)] text-center">
+        {{ $t('codingBridge.history.empty') }}
+      </div>
+
+      <ul v-else class="list-none m-0 p-0 flex-1 overflow-y-auto flex flex-col gap-2">
+        <li
+          v-for="item in sessions"
+          :key="item.provider + ':' + item.session_id"
+          class="item rounded-lg p-3 cursor-pointer border border-[var(--app-border-subtle)]"
+          @click="open(item)"
+        >
+          <div class="flex items-center gap-2 mb-1">
+            <span class="provider-tag" :class="item.provider">
+              {{ item.provider === 'codex' ? 'Codex' : 'Claude' }}
+            </span>
+            <span class="text-sm font-medium truncate flex-1">{{ item.title }}</span>
+          </div>
+          <div class="text-[11px] text-[var(--app-text-subtle)] truncate">
+            <span v-if="item.cwd">{{ item.cwd }}</span>
+            <span v-if="item.git_branch"> · {{ item.git_branch }}</span>
+          </div>
+          <div class="text-[11px] text-[var(--app-text-subtle)] mt-0.5">
+            <span v-if="item.updated_at">{{ formatTime(item.updated_at) }}</span>
+            <span v-if="item.message_count">
+              · {{ $t('codingBridge.history.messages', { count: item.message_count }) }}</span
+            >
+          </div>
+        </li>
+      </ul>
+    </div>
+  </el-drawer>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElDrawer, ElButton } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { ICodingBridgeHistorySummary, Status } from '@/models';
+
+export default defineComponent({
+  name: 'CodingBridgeHistoryDrawer',
+  components: {
+    ElDrawer,
+    ElButton,
+    FontAwesomeIcon
+  },
+  props: {
+    visible: {
+      type: Boolean,
+      default: false
+    }
+  },
+  emits: ['update:visible'],
+  computed: {
+    currentNodeId(): string | undefined {
+      return this.$store.state.codingBridge?.currentNodeId;
+    },
+    loading(): boolean {
+      return this.$store.state.codingBridge?.status?.getHistory === Status.Request;
+    },
+    sessions(): ICodingBridgeHistorySummary[] {
+      const id = this.currentNodeId;
+      const list = id ? (this.$store.state.codingBridge?.history?.[id] ?? []) : [];
+      return [...list].sort((a, b) => (b.updated_at ?? 0) - (a.updated_at ?? 0));
+    }
+  },
+  watch: {
+    visible(value: boolean) {
+      if (value && this.currentNodeId) {
+        this.$store.dispatch('codingBridge/getHistory', this.currentNodeId);
+      }
+    }
+  },
+  methods: {
+    refresh() {
+      if (this.currentNodeId) {
+        this.$store.dispatch('codingBridge/getHistory', this.currentNodeId);
+      }
+    },
+    open(item: ICodingBridgeHistorySummary) {
+      if (!this.currentNodeId) {
+        return;
+      }
+      this.$store.dispatch('codingBridge/getHistoryDetail', {
+        node_id: this.currentNodeId,
+        provider: item.provider,
+        session_id: item.session_id
+      });
+      this.$emit('update:visible', false);
+    },
+    formatTime(ts: number): string {
+      try {
+        return new Date(ts).toLocaleString();
+      } catch {
+        return '';
+      }
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.item {
+  transition: border-color 0.15s ease;
+  &:hover {
+    border-color: var(--el-color-primary);
+  }
+}
+
+.provider-tag {
+  flex: none;
+  font-size: 11px;
+  line-height: 1;
+  padding: 3px 6px;
+  border-radius: 4px;
+  color: #fff;
+  background: var(--el-color-primary);
+  &.codex {
+    background: var(--el-color-info, #909399);
+  }
+}
+</style>

--- a/src/components/codingBridge/SessionView.vue
+++ b/src/components/codingBridge/SessionView.vue
@@ -23,12 +23,19 @@
           <div v-if="currentSession" class="text-xs text-[var(--app-text-subtle)] truncate">
             <span v-if="currentSession.cwd">{{ currentSession.cwd }}</span>
             <span v-if="currentSession.model"> · {{ currentSession.model }}</span>
+            <span v-if="replayLabel" class="text-[var(--el-color-primary)]"> · {{ replayLabel }}</span>
           </div>
         </div>
-        <el-button v-if="currentSessionId" size="small" round @click="onNewSession">
-          <font-awesome-icon icon="fa-solid fa-plus" class="mr-1" />
-          {{ $t('codingBridge.session.newSession') }}
-        </el-button>
+        <div class="flex items-center gap-2 flex-none">
+          <el-button size="small" round @click="$emit('history')">
+            <font-awesome-icon icon="fa-solid fa-clock-rotate-left" class="mr-1" />
+            {{ $t('codingBridge.history.button') }}
+          </el-button>
+          <el-button v-if="currentSessionId" size="small" round @click="onNewSession">
+            <font-awesome-icon icon="fa-solid fa-plus" class="mr-1" />
+            {{ $t('codingBridge.session.newSession') }}
+          </el-button>
+        </div>
       </div>
 
       <!-- Offline warning -->
@@ -49,30 +56,45 @@
 
       <!-- Composer -->
       <div class="border-t border-[var(--app-border-subtle)] p-3">
-        <div v-if="isNewSession" class="flex gap-2 mb-2">
-          <el-input v-model="cwd" size="small" :placeholder="$t('codingBridge.session.cwdPlaceholder')" clearable />
-          <el-input v-model="model" size="small" :placeholder="$t('codingBridge.session.modelPlaceholder')" clearable />
-        </div>
-        <div class="flex items-end gap-2">
-          <el-input
-            v-model="prompt"
-            type="textarea"
-            :autosize="{ minRows: 1, maxRows: 6 }"
-            resize="none"
-            class="flex-1"
-            :placeholder="$t('codingBridge.session.promptPlaceholder')"
-            @keydown.enter.exact.prevent="onSend"
-          />
-          <el-button v-if="running" round @click="onInterrupt">
-            <font-awesome-icon icon="fa-solid fa-stop" />
-          </el-button>
-          <el-button type="primary" round :disabled="!canSend" @click="onSend">
-            {{ $t('codingBridge.session.send') }}
+        <!-- Read-only replay (e.g. Codex history cannot be resumed). -->
+        <div v-if="readonly" class="flex items-center gap-2 text-xs text-[var(--app-text-subtle)] px-1 py-2">
+          <font-awesome-icon icon="fa-solid fa-eye" />
+          <span>{{ $t('codingBridge.history.readonly') }}</span>
+          <el-button class="ml-auto" size="small" round @click="onNewSession">
+            {{ $t('codingBridge.session.newSession') }}
           </el-button>
         </div>
-        <p class="text-[11px] text-[var(--app-text-subtle)] mt-1 px-1">
-          {{ $t('codingBridge.session.enterHint') }}
-        </p>
+        <template v-else>
+          <div v-if="isNewSession" class="flex gap-2 mb-2">
+            <el-input v-model="cwd" size="small" :placeholder="$t('codingBridge.session.cwdPlaceholder')" clearable />
+            <el-input
+              v-model="model"
+              size="small"
+              :placeholder="$t('codingBridge.session.modelPlaceholder')"
+              clearable
+            />
+          </div>
+          <div class="flex items-end gap-2">
+            <el-input
+              v-model="prompt"
+              type="textarea"
+              :autosize="{ minRows: 1, maxRows: 6 }"
+              resize="none"
+              class="flex-1"
+              :placeholder="$t('codingBridge.session.promptPlaceholder')"
+              @keydown.enter.exact.prevent="onSend"
+            />
+            <el-button v-if="running" round @click="onInterrupt">
+              <font-awesome-icon icon="fa-solid fa-stop" />
+            </el-button>
+            <el-button type="primary" round :disabled="!canSend" @click="onSend">
+              {{ $t('codingBridge.session.send') }}
+            </el-button>
+          </div>
+          <p class="text-[11px] text-[var(--app-text-subtle)] mt-1 px-1">
+            {{ resumeHint ? $t('codingBridge.history.resumeHint') : $t('codingBridge.session.enterHint') }}
+          </p>
+        </template>
       </div>
     </template>
   </div>
@@ -93,6 +115,7 @@ export default defineComponent({
     FontAwesomeIcon,
     TranscriptItem
   },
+  emits: ['history'],
   data() {
     return {
       prompt: '',
@@ -123,6 +146,21 @@ export default defineComponent({
     },
     isNewSession(): boolean {
       return !this.currentSessionId;
+    },
+    readonly(): boolean {
+      return this.currentSession?.readonly === true;
+    },
+    // A history conversation that has been opened but not yet resumed.
+    resumeHint(): boolean {
+      return !!this.currentSession?.provider && !this.currentSession?.started && !this.readonly;
+    },
+    replayLabel(): string {
+      if (!this.currentSession?.provider || this.currentSession?.started) {
+        return '';
+      }
+      return this.currentSession.provider === 'codex'
+        ? (this.$t('codingBridge.history.codexLabel') as string)
+        : (this.$t('codingBridge.history.claudeLabel') as string);
     },
     running(): boolean {
       const status = this.currentSession?.status;

--- a/src/constants/codingBridge.ts
+++ b/src/constants/codingBridge.ts
@@ -22,6 +22,8 @@ export const CB_ACTION_SESSION_INTERRUPT = 'session.interrupt';
 export const CB_ACTION_SESSION_CLOSE = 'session.close';
 export const CB_ACTION_PERMISSION_RESOLVE = 'permission.resolve';
 export const CB_ACTION_SESSIONS_LIST = 'sessions.list';
+export const CB_ACTION_HISTORY_LIST = 'history.list';
+export const CB_ACTION_HISTORY_GET = 'history.get';
 export const CB_ACTION_PING = 'ping';
 
 // --- Inner events: node -> browser -----------------------------------------
@@ -36,6 +38,8 @@ export const CB_EVENT_SESSION_RESULT = 'session.result';
 export const CB_EVENT_SESSION_ERROR = 'session.error';
 export const CB_EVENT_SESSION_CLOSED = 'session.closed';
 export const CB_EVENT_SESSIONS_SNAPSHOT = 'sessions.snapshot';
+export const CB_EVENT_HISTORY_SNAPSHOT = 'history.snapshot';
+export const CB_EVENT_HISTORY_DETAIL = 'history.detail';
 export const CB_EVENT_PONG = 'pong';
 
 // Reconnect backoff for the browser WebSocket (milliseconds).

--- a/src/i18n/ar/codingBridge.json
+++ b/src/i18n/ar/codingBridge.json
@@ -162,5 +162,49 @@
   "transcript.turnDone": {
     "message": "Done",
     "description": "Turn result done label"
+  },
+  "history.button": {
+    "message": "السجل",
+    "description": "Open the conversation history drawer"
+  },
+  "history.title": {
+    "message": "سجل المحادثات",
+    "description": "History drawer title"
+  },
+  "history.intro": {
+    "message": "جلسات Claude Code وCodex السابقة على هذا الجهاز.",
+    "description": "History drawer intro"
+  },
+  "history.refresh": {
+    "message": "تحديث",
+    "description": "Reload the history list"
+  },
+  "history.loading": {
+    "message": "جارٍ تحميل السجل…",
+    "description": "History loading message"
+  },
+  "history.empty": {
+    "message": "لا يوجد سجل على هذا الجهاز.",
+    "description": "Empty history message"
+  },
+  "history.messages": {
+    "message": "{count} رسالة",
+    "description": "History item message count"
+  },
+  "history.readonly": {
+    "message": "محادثة Codex هذه للقراءة فقط ولا يمكن متابعتها. ابدأ جلسة جديدة لمواصلة البرمجة.",
+    "description": "Read-only replay notice"
+  },
+  "history.resumeHint": {
+    "message": "سيؤدي إرسال رسالة إلى استئناف هذه المحادثة على الجهاز.",
+    "description": "Resume composer hint"
+  },
+  "history.claudeLabel": {
+    "message": "سجل Claude",
+    "description": "Replayed Claude session label"
+  },
+  "history.codexLabel": {
+    "message": "سجل Codex (للقراءة فقط)",
+    "description": "Replayed Codex session label"
   }
 }

--- a/src/i18n/de/codingBridge.json
+++ b/src/i18n/de/codingBridge.json
@@ -162,5 +162,49 @@
   "transcript.turnDone": {
     "message": "Done",
     "description": "Turn result done label"
+  },
+  "history.button": {
+    "message": "Verlauf",
+    "description": "Open the conversation history drawer"
+  },
+  "history.title": {
+    "message": "Konversationsverlauf",
+    "description": "History drawer title"
+  },
+  "history.intro": {
+    "message": "Frühere Claude-Code- und Codex-Sitzungen auf diesem Gerät.",
+    "description": "History drawer intro"
+  },
+  "history.refresh": {
+    "message": "Aktualisieren",
+    "description": "Reload the history list"
+  },
+  "history.loading": {
+    "message": "Verlauf wird geladen…",
+    "description": "History loading message"
+  },
+  "history.empty": {
+    "message": "Kein Verlauf auf diesem Gerät gefunden.",
+    "description": "Empty history message"
+  },
+  "history.messages": {
+    "message": "{count} Nachrichten",
+    "description": "History item message count"
+  },
+  "history.readonly": {
+    "message": "Diese Codex-Konversation ist schreibgeschützt und kann nicht fortgesetzt werden. Starte eine neue Sitzung, um weiterzuarbeiten.",
+    "description": "Read-only replay notice"
+  },
+  "history.resumeHint": {
+    "message": "Eine Nachricht setzt diese Konversation auf dem Gerät fort.",
+    "description": "Resume composer hint"
+  },
+  "history.claudeLabel": {
+    "message": "Claude-Verlauf",
+    "description": "Replayed Claude session label"
+  },
+  "history.codexLabel": {
+    "message": "Codex-Verlauf (schreibgeschützt)",
+    "description": "Replayed Codex session label"
   }
 }

--- a/src/i18n/el/codingBridge.json
+++ b/src/i18n/el/codingBridge.json
@@ -162,5 +162,49 @@
   "transcript.turnDone": {
     "message": "Done",
     "description": "Turn result done label"
+  },
+  "history.button": {
+    "message": "Ιστορικό",
+    "description": "Open the conversation history drawer"
+  },
+  "history.title": {
+    "message": "Ιστορικό συνομιλιών",
+    "description": "History drawer title"
+  },
+  "history.intro": {
+    "message": "Προηγούμενες συνεδρίες Claude Code και Codex σε αυτή τη συσκευή.",
+    "description": "History drawer intro"
+  },
+  "history.refresh": {
+    "message": "Ανανέωση",
+    "description": "Reload the history list"
+  },
+  "history.loading": {
+    "message": "Φόρτωση ιστορικού…",
+    "description": "History loading message"
+  },
+  "history.empty": {
+    "message": "Δεν βρέθηκε ιστορικό σε αυτή τη συσκευή.",
+    "description": "Empty history message"
+  },
+  "history.messages": {
+    "message": "{count} μηνύματα",
+    "description": "History item message count"
+  },
+  "history.readonly": {
+    "message": "Αυτή η συνομιλία Codex είναι μόνο για ανάγνωση και δεν μπορεί να συνεχιστεί. Ξεκινήστε νέα συνεδρία για να συνεχίσετε.",
+    "description": "Read-only replay notice"
+  },
+  "history.resumeHint": {
+    "message": "Η αποστολή μηνύματος θα συνεχίσει αυτή τη συνομιλία στη συσκευή.",
+    "description": "Resume composer hint"
+  },
+  "history.claudeLabel": {
+    "message": "Ιστορικό Claude",
+    "description": "Replayed Claude session label"
+  },
+  "history.codexLabel": {
+    "message": "Ιστορικό Codex (μόνο για ανάγνωση)",
+    "description": "Replayed Codex session label"
   }
 }

--- a/src/i18n/en/codingBridge.json
+++ b/src/i18n/en/codingBridge.json
@@ -162,5 +162,49 @@
   "transcript.turnDone": {
     "message": "Done",
     "description": "Turn result done label"
+  },
+  "history.button": {
+    "message": "History",
+    "description": "Open the conversation history drawer"
+  },
+  "history.title": {
+    "message": "Conversation history",
+    "description": "History drawer title"
+  },
+  "history.intro": {
+    "message": "Past Claude Code & Codex sessions on this device.",
+    "description": "History drawer intro"
+  },
+  "history.refresh": {
+    "message": "Refresh",
+    "description": "Reload the history list"
+  },
+  "history.loading": {
+    "message": "Loading history…",
+    "description": "History loading message"
+  },
+  "history.empty": {
+    "message": "No history found on this device.",
+    "description": "Empty history message"
+  },
+  "history.messages": {
+    "message": "{count} messages",
+    "description": "History item message count"
+  },
+  "history.readonly": {
+    "message": "This Codex conversation is read-only and cannot be continued. Start a new session to keep coding.",
+    "description": "Read-only replay notice"
+  },
+  "history.resumeHint": {
+    "message": "Sending a message will resume this conversation on the device.",
+    "description": "Resume composer hint"
+  },
+  "history.claudeLabel": {
+    "message": "Claude history",
+    "description": "Replayed Claude session label"
+  },
+  "history.codexLabel": {
+    "message": "Codex history (read-only)",
+    "description": "Replayed Codex session label"
   }
 }

--- a/src/i18n/es/codingBridge.json
+++ b/src/i18n/es/codingBridge.json
@@ -162,5 +162,49 @@
   "transcript.turnDone": {
     "message": "Done",
     "description": "Turn result done label"
+  },
+  "history.button": {
+    "message": "Historial",
+    "description": "Open the conversation history drawer"
+  },
+  "history.title": {
+    "message": "Historial de conversaciones",
+    "description": "History drawer title"
+  },
+  "history.intro": {
+    "message": "Sesiones anteriores de Claude Code y Codex en este dispositivo.",
+    "description": "History drawer intro"
+  },
+  "history.refresh": {
+    "message": "Actualizar",
+    "description": "Reload the history list"
+  },
+  "history.loading": {
+    "message": "Cargando historial…",
+    "description": "History loading message"
+  },
+  "history.empty": {
+    "message": "No se encontró historial en este dispositivo.",
+    "description": "Empty history message"
+  },
+  "history.messages": {
+    "message": "{count} mensajes",
+    "description": "History item message count"
+  },
+  "history.readonly": {
+    "message": "Esta conversación de Codex es de solo lectura y no se puede continuar. Inicia una nueva sesión para seguir programando.",
+    "description": "Read-only replay notice"
+  },
+  "history.resumeHint": {
+    "message": "Enviar un mensaje reanudará esta conversación en el dispositivo.",
+    "description": "Resume composer hint"
+  },
+  "history.claudeLabel": {
+    "message": "Historial de Claude",
+    "description": "Replayed Claude session label"
+  },
+  "history.codexLabel": {
+    "message": "Historial de Codex (solo lectura)",
+    "description": "Replayed Codex session label"
   }
 }

--- a/src/i18n/fi/codingBridge.json
+++ b/src/i18n/fi/codingBridge.json
@@ -162,5 +162,49 @@
   "transcript.turnDone": {
     "message": "Done",
     "description": "Turn result done label"
+  },
+  "history.button": {
+    "message": "Historia",
+    "description": "Open the conversation history drawer"
+  },
+  "history.title": {
+    "message": "Keskusteluhistoria",
+    "description": "History drawer title"
+  },
+  "history.intro": {
+    "message": "Aiemmat Claude Code- ja Codex-istunnot tällä laitteella.",
+    "description": "History drawer intro"
+  },
+  "history.refresh": {
+    "message": "Päivitä",
+    "description": "Reload the history list"
+  },
+  "history.loading": {
+    "message": "Ladataan historiaa…",
+    "description": "History loading message"
+  },
+  "history.empty": {
+    "message": "Tältä laitteelta ei löytynyt historiaa.",
+    "description": "Empty history message"
+  },
+  "history.messages": {
+    "message": "{count} viestiä",
+    "description": "History item message count"
+  },
+  "history.readonly": {
+    "message": "Tämä Codex-keskustelu on vain luettavissa, eikä sitä voi jatkaa. Aloita uusi istunto jatkaaksesi koodausta.",
+    "description": "Read-only replay notice"
+  },
+  "history.resumeHint": {
+    "message": "Viestin lähettäminen jatkaa tätä keskustelua laitteella.",
+    "description": "Resume composer hint"
+  },
+  "history.claudeLabel": {
+    "message": "Claude-historia",
+    "description": "Replayed Claude session label"
+  },
+  "history.codexLabel": {
+    "message": "Codex-historia (vain luku)",
+    "description": "Replayed Codex session label"
   }
 }

--- a/src/i18n/fr/codingBridge.json
+++ b/src/i18n/fr/codingBridge.json
@@ -162,5 +162,49 @@
   "transcript.turnDone": {
     "message": "Done",
     "description": "Turn result done label"
+  },
+  "history.button": {
+    "message": "Historique",
+    "description": "Open the conversation history drawer"
+  },
+  "history.title": {
+    "message": "Historique des conversations",
+    "description": "History drawer title"
+  },
+  "history.intro": {
+    "message": "Sessions Claude Code et Codex précédentes sur cet appareil.",
+    "description": "History drawer intro"
+  },
+  "history.refresh": {
+    "message": "Actualiser",
+    "description": "Reload the history list"
+  },
+  "history.loading": {
+    "message": "Chargement de l’historique…",
+    "description": "History loading message"
+  },
+  "history.empty": {
+    "message": "Aucun historique trouvé sur cet appareil.",
+    "description": "Empty history message"
+  },
+  "history.messages": {
+    "message": "{count} messages",
+    "description": "History item message count"
+  },
+  "history.readonly": {
+    "message": "Cette conversation Codex est en lecture seule et ne peut pas être poursuivie. Démarrez une nouvelle session pour continuer à coder.",
+    "description": "Read-only replay notice"
+  },
+  "history.resumeHint": {
+    "message": "Envoyer un message reprendra cette conversation sur l’appareil.",
+    "description": "Resume composer hint"
+  },
+  "history.claudeLabel": {
+    "message": "Historique Claude",
+    "description": "Replayed Claude session label"
+  },
+  "history.codexLabel": {
+    "message": "Historique Codex (lecture seule)",
+    "description": "Replayed Codex session label"
   }
 }

--- a/src/i18n/it/codingBridge.json
+++ b/src/i18n/it/codingBridge.json
@@ -162,5 +162,49 @@
   "transcript.turnDone": {
     "message": "Done",
     "description": "Turn result done label"
+  },
+  "history.button": {
+    "message": "Cronologia",
+    "description": "Open the conversation history drawer"
+  },
+  "history.title": {
+    "message": "Cronologia delle conversazioni",
+    "description": "History drawer title"
+  },
+  "history.intro": {
+    "message": "Sessioni Claude Code e Codex precedenti su questo dispositivo.",
+    "description": "History drawer intro"
+  },
+  "history.refresh": {
+    "message": "Aggiorna",
+    "description": "Reload the history list"
+  },
+  "history.loading": {
+    "message": "Caricamento della cronologia…",
+    "description": "History loading message"
+  },
+  "history.empty": {
+    "message": "Nessuna cronologia trovata su questo dispositivo.",
+    "description": "Empty history message"
+  },
+  "history.messages": {
+    "message": "{count} messaggi",
+    "description": "History item message count"
+  },
+  "history.readonly": {
+    "message": "Questa conversazione Codex è di sola lettura e non può essere continuata. Avvia una nuova sessione per continuare a programmare.",
+    "description": "Read-only replay notice"
+  },
+  "history.resumeHint": {
+    "message": "L’invio di un messaggio riprenderà questa conversazione sul dispositivo.",
+    "description": "Resume composer hint"
+  },
+  "history.claudeLabel": {
+    "message": "Cronologia Claude",
+    "description": "Replayed Claude session label"
+  },
+  "history.codexLabel": {
+    "message": "Cronologia Codex (sola lettura)",
+    "description": "Replayed Codex session label"
   }
 }

--- a/src/i18n/ja/codingBridge.json
+++ b/src/i18n/ja/codingBridge.json
@@ -162,5 +162,49 @@
   "transcript.turnDone": {
     "message": "Done",
     "description": "Turn result done label"
+  },
+  "history.button": {
+    "message": "履歴",
+    "description": "Open the conversation history drawer"
+  },
+  "history.title": {
+    "message": "会話履歴",
+    "description": "History drawer title"
+  },
+  "history.intro": {
+    "message": "このデバイス上の過去の Claude Code および Codex セッション。",
+    "description": "History drawer intro"
+  },
+  "history.refresh": {
+    "message": "更新",
+    "description": "Reload the history list"
+  },
+  "history.loading": {
+    "message": "履歴を読み込み中…",
+    "description": "History loading message"
+  },
+  "history.empty": {
+    "message": "このデバイスに履歴が見つかりません。",
+    "description": "Empty history message"
+  },
+  "history.messages": {
+    "message": "{count} 件のメッセージ",
+    "description": "History item message count"
+  },
+  "history.readonly": {
+    "message": "この Codex の会話は読み取り専用で続行できません。コーディングを続けるには新しいセッションを開始してください。",
+    "description": "Read-only replay notice"
+  },
+  "history.resumeHint": {
+    "message": "メッセージを送信すると、デバイス上でこの会話が再開されます。",
+    "description": "Resume composer hint"
+  },
+  "history.claudeLabel": {
+    "message": "Claude 履歴",
+    "description": "Replayed Claude session label"
+  },
+  "history.codexLabel": {
+    "message": "Codex 履歴（読み取り専用）",
+    "description": "Replayed Codex session label"
   }
 }

--- a/src/i18n/ko/codingBridge.json
+++ b/src/i18n/ko/codingBridge.json
@@ -162,5 +162,49 @@
   "transcript.turnDone": {
     "message": "Done",
     "description": "Turn result done label"
+  },
+  "history.button": {
+    "message": "기록",
+    "description": "Open the conversation history drawer"
+  },
+  "history.title": {
+    "message": "대화 기록",
+    "description": "History drawer title"
+  },
+  "history.intro": {
+    "message": "이 기기의 이전 Claude Code 및 Codex 세션입니다.",
+    "description": "History drawer intro"
+  },
+  "history.refresh": {
+    "message": "새로 고침",
+    "description": "Reload the history list"
+  },
+  "history.loading": {
+    "message": "기록을 불러오는 중…",
+    "description": "History loading message"
+  },
+  "history.empty": {
+    "message": "이 기기에서 기록을 찾을 수 없습니다.",
+    "description": "Empty history message"
+  },
+  "history.messages": {
+    "message": "메시지 {count}개",
+    "description": "History item message count"
+  },
+  "history.readonly": {
+    "message": "이 Codex 대화는 읽기 전용이라 이어갈 수 없습니다. 계속 코딩하려면 새 세션을 시작하세요.",
+    "description": "Read-only replay notice"
+  },
+  "history.resumeHint": {
+    "message": "메시지를 보내면 기기에서 이 대화가 다시 시작됩니다.",
+    "description": "Resume composer hint"
+  },
+  "history.claudeLabel": {
+    "message": "Claude 기록",
+    "description": "Replayed Claude session label"
+  },
+  "history.codexLabel": {
+    "message": "Codex 기록 (읽기 전용)",
+    "description": "Replayed Codex session label"
   }
 }

--- a/src/i18n/pl/codingBridge.json
+++ b/src/i18n/pl/codingBridge.json
@@ -162,5 +162,49 @@
   "transcript.turnDone": {
     "message": "Done",
     "description": "Turn result done label"
+  },
+  "history.button": {
+    "message": "Historia",
+    "description": "Open the conversation history drawer"
+  },
+  "history.title": {
+    "message": "Historia rozmów",
+    "description": "History drawer title"
+  },
+  "history.intro": {
+    "message": "Poprzednie sesje Claude Code i Codex na tym urządzeniu.",
+    "description": "History drawer intro"
+  },
+  "history.refresh": {
+    "message": "Odśwież",
+    "description": "Reload the history list"
+  },
+  "history.loading": {
+    "message": "Ładowanie historii…",
+    "description": "History loading message"
+  },
+  "history.empty": {
+    "message": "Nie znaleziono historii na tym urządzeniu.",
+    "description": "Empty history message"
+  },
+  "history.messages": {
+    "message": "Wiadomości: {count}",
+    "description": "History item message count"
+  },
+  "history.readonly": {
+    "message": "Ta rozmowa Codex jest tylko do odczytu i nie można jej kontynuować. Rozpocznij nową sesję, aby kontynuować kodowanie.",
+    "description": "Read-only replay notice"
+  },
+  "history.resumeHint": {
+    "message": "Wysłanie wiadomości wznowi tę rozmowę na urządzeniu.",
+    "description": "Resume composer hint"
+  },
+  "history.claudeLabel": {
+    "message": "Historia Claude",
+    "description": "Replayed Claude session label"
+  },
+  "history.codexLabel": {
+    "message": "Historia Codex (tylko do odczytu)",
+    "description": "Replayed Codex session label"
   }
 }

--- a/src/i18n/pt/codingBridge.json
+++ b/src/i18n/pt/codingBridge.json
@@ -162,5 +162,49 @@
   "transcript.turnDone": {
     "message": "Done",
     "description": "Turn result done label"
+  },
+  "history.button": {
+    "message": "Histórico",
+    "description": "Open the conversation history drawer"
+  },
+  "history.title": {
+    "message": "Histórico de conversas",
+    "description": "History drawer title"
+  },
+  "history.intro": {
+    "message": "Sessões anteriores do Claude Code e do Codex neste dispositivo.",
+    "description": "History drawer intro"
+  },
+  "history.refresh": {
+    "message": "Atualizar",
+    "description": "Reload the history list"
+  },
+  "history.loading": {
+    "message": "Carregando histórico…",
+    "description": "History loading message"
+  },
+  "history.empty": {
+    "message": "Nenhum histórico encontrado neste dispositivo.",
+    "description": "Empty history message"
+  },
+  "history.messages": {
+    "message": "{count} mensagens",
+    "description": "History item message count"
+  },
+  "history.readonly": {
+    "message": "Esta conversa do Codex é somente leitura e não pode ser continuada. Inicie uma nova sessão para continuar programando.",
+    "description": "Read-only replay notice"
+  },
+  "history.resumeHint": {
+    "message": "Enviar uma mensagem retomará esta conversa no dispositivo.",
+    "description": "Resume composer hint"
+  },
+  "history.claudeLabel": {
+    "message": "Histórico do Claude",
+    "description": "Replayed Claude session label"
+  },
+  "history.codexLabel": {
+    "message": "Histórico do Codex (somente leitura)",
+    "description": "Replayed Codex session label"
   }
 }

--- a/src/i18n/ru/codingBridge.json
+++ b/src/i18n/ru/codingBridge.json
@@ -162,5 +162,49 @@
   "transcript.turnDone": {
     "message": "Done",
     "description": "Turn result done label"
+  },
+  "history.button": {
+    "message": "История",
+    "description": "Open the conversation history drawer"
+  },
+  "history.title": {
+    "message": "История разговоров",
+    "description": "History drawer title"
+  },
+  "history.intro": {
+    "message": "Прошлые сессии Claude Code и Codex на этом устройстве.",
+    "description": "History drawer intro"
+  },
+  "history.refresh": {
+    "message": "Обновить",
+    "description": "Reload the history list"
+  },
+  "history.loading": {
+    "message": "Загрузка истории…",
+    "description": "History loading message"
+  },
+  "history.empty": {
+    "message": "История на этом устройстве не найдена.",
+    "description": "Empty history message"
+  },
+  "history.messages": {
+    "message": "Сообщений: {count}",
+    "description": "History item message count"
+  },
+  "history.readonly": {
+    "message": "Этот разговор Codex доступен только для чтения и не может быть продолжен. Начните новую сессию, чтобы продолжить программировать.",
+    "description": "Read-only replay notice"
+  },
+  "history.resumeHint": {
+    "message": "Отправка сообщения возобновит этот разговор на устройстве.",
+    "description": "Resume composer hint"
+  },
+  "history.claudeLabel": {
+    "message": "История Claude",
+    "description": "Replayed Claude session label"
+  },
+  "history.codexLabel": {
+    "message": "История Codex (только чтение)",
+    "description": "Replayed Codex session label"
   }
 }

--- a/src/i18n/sr/codingBridge.json
+++ b/src/i18n/sr/codingBridge.json
@@ -162,5 +162,49 @@
   "transcript.turnDone": {
     "message": "Done",
     "description": "Turn result done label"
+  },
+  "history.button": {
+    "message": "Историја",
+    "description": "Open the conversation history drawer"
+  },
+  "history.title": {
+    "message": "Историја разговора",
+    "description": "History drawer title"
+  },
+  "history.intro": {
+    "message": "Претходне Claude Code и Codex сесије на овом уређају.",
+    "description": "History drawer intro"
+  },
+  "history.refresh": {
+    "message": "Освежи",
+    "description": "Reload the history list"
+  },
+  "history.loading": {
+    "message": "Учитавање историје…",
+    "description": "History loading message"
+  },
+  "history.empty": {
+    "message": "Историја није пронађена на овом уређају.",
+    "description": "Empty history message"
+  },
+  "history.messages": {
+    "message": "Поруке: {count}",
+    "description": "History item message count"
+  },
+  "history.readonly": {
+    "message": "Овај Codex разговор је само за читање и не може се наставити. Покрените нову сесију да наставите са кодирањем.",
+    "description": "Read-only replay notice"
+  },
+  "history.resumeHint": {
+    "message": "Слање поруке ће наставити овај разговор на уређају.",
+    "description": "Resume composer hint"
+  },
+  "history.claudeLabel": {
+    "message": "Claude историја",
+    "description": "Replayed Claude session label"
+  },
+  "history.codexLabel": {
+    "message": "Codex историја (само за читање)",
+    "description": "Replayed Codex session label"
   }
 }

--- a/src/i18n/sv/codingBridge.json
+++ b/src/i18n/sv/codingBridge.json
@@ -162,5 +162,49 @@
   "transcript.turnDone": {
     "message": "Done",
     "description": "Turn result done label"
+  },
+  "history.button": {
+    "message": "Historik",
+    "description": "Open the conversation history drawer"
+  },
+  "history.title": {
+    "message": "Konversationshistorik",
+    "description": "History drawer title"
+  },
+  "history.intro": {
+    "message": "Tidigare Claude Code- och Codex-sessioner på den här enheten.",
+    "description": "History drawer intro"
+  },
+  "history.refresh": {
+    "message": "Uppdatera",
+    "description": "Reload the history list"
+  },
+  "history.loading": {
+    "message": "Laddar historik…",
+    "description": "History loading message"
+  },
+  "history.empty": {
+    "message": "Ingen historik hittades på den här enheten.",
+    "description": "Empty history message"
+  },
+  "history.messages": {
+    "message": "{count} meddelanden",
+    "description": "History item message count"
+  },
+  "history.readonly": {
+    "message": "Den här Codex-konversationen är skrivskyddad och kan inte fortsättas. Starta en ny session för att fortsätta koda.",
+    "description": "Read-only replay notice"
+  },
+  "history.resumeHint": {
+    "message": "Att skicka ett meddelande återupptar konversationen på enheten.",
+    "description": "Resume composer hint"
+  },
+  "history.claudeLabel": {
+    "message": "Claude-historik",
+    "description": "Replayed Claude session label"
+  },
+  "history.codexLabel": {
+    "message": "Codex-historik (skrivskyddad)",
+    "description": "Replayed Codex session label"
   }
 }

--- a/src/i18n/uk/codingBridge.json
+++ b/src/i18n/uk/codingBridge.json
@@ -162,5 +162,49 @@
   "transcript.turnDone": {
     "message": "Done",
     "description": "Turn result done label"
+  },
+  "history.button": {
+    "message": "Історія",
+    "description": "Open the conversation history drawer"
+  },
+  "history.title": {
+    "message": "Історія розмов",
+    "description": "History drawer title"
+  },
+  "history.intro": {
+    "message": "Попередні сесії Claude Code та Codex на цьому пристрої.",
+    "description": "History drawer intro"
+  },
+  "history.refresh": {
+    "message": "Оновити",
+    "description": "Reload the history list"
+  },
+  "history.loading": {
+    "message": "Завантаження історії…",
+    "description": "History loading message"
+  },
+  "history.empty": {
+    "message": "Історію на цьому пристрої не знайдено.",
+    "description": "Empty history message"
+  },
+  "history.messages": {
+    "message": "Повідомлень: {count}",
+    "description": "History item message count"
+  },
+  "history.readonly": {
+    "message": "Ця розмова Codex доступна лише для читання й не може бути продовжена. Почніть нову сесію, щоб продовжити програмувати.",
+    "description": "Read-only replay notice"
+  },
+  "history.resumeHint": {
+    "message": "Надсилання повідомлення відновить цю розмову на пристрої.",
+    "description": "Resume composer hint"
+  },
+  "history.claudeLabel": {
+    "message": "Історія Claude",
+    "description": "Replayed Claude session label"
+  },
+  "history.codexLabel": {
+    "message": "Історія Codex (лише читання)",
+    "description": "Replayed Codex session label"
   }
 }

--- a/src/i18n/zh-CN/codingBridge.json
+++ b/src/i18n/zh-CN/codingBridge.json
@@ -162,5 +162,49 @@
   "transcript.turnDone": {
     "message": "完成",
     "description": "回合结果完成标签"
+  },
+  "history.button": {
+    "message": "历史会话",
+    "description": "打开历史会话抽屉"
+  },
+  "history.title": {
+    "message": "历史会话",
+    "description": "历史会话抽屉标题"
+  },
+  "history.intro": {
+    "message": "此设备上的 Claude Code 与 Codex 历史会话。",
+    "description": "历史会话抽屉说明"
+  },
+  "history.refresh": {
+    "message": "刷新",
+    "description": "重新加载历史列表"
+  },
+  "history.loading": {
+    "message": "正在加载历史…",
+    "description": "历史加载提示"
+  },
+  "history.empty": {
+    "message": "此设备上没有找到历史会话。",
+    "description": "历史为空提示"
+  },
+  "history.messages": {
+    "message": "{count} 条消息",
+    "description": "历史条目消息数"
+  },
+  "history.readonly": {
+    "message": "此 Codex 会话为只读，无法继续。开始新会话以继续编码。",
+    "description": "只读回放提示"
+  },
+  "history.resumeHint": {
+    "message": "发送消息将在设备上续接此会话。",
+    "description": "续接输入框提示"
+  },
+  "history.claudeLabel": {
+    "message": "Claude 历史",
+    "description": "回放的 Claude 会话标签"
+  },
+  "history.codexLabel": {
+    "message": "Codex 历史（只读）",
+    "description": "回放的 Codex 会话标签"
   }
 }

--- a/src/i18n/zh-TW/codingBridge.json
+++ b/src/i18n/zh-TW/codingBridge.json
@@ -162,5 +162,49 @@
   "transcript.turnDone": {
     "message": "完成",
     "description": "回合結果完成標籤"
+  },
+  "history.button": {
+    "message": "歷史會話",
+    "description": "Open the conversation history drawer"
+  },
+  "history.title": {
+    "message": "歷史會話",
+    "description": "History drawer title"
+  },
+  "history.intro": {
+    "message": "此裝置上的 Claude Code 與 Codex 歷史會話。",
+    "description": "History drawer intro"
+  },
+  "history.refresh": {
+    "message": "重新整理",
+    "description": "Reload the history list"
+  },
+  "history.loading": {
+    "message": "正在載入歷史…",
+    "description": "History loading message"
+  },
+  "history.empty": {
+    "message": "此裝置上找不到歷史會話。",
+    "description": "Empty history message"
+  },
+  "history.messages": {
+    "message": "{count} 則訊息",
+    "description": "History item message count"
+  },
+  "history.readonly": {
+    "message": "此 Codex 會話為唯讀，無法繼續。開始新會話以繼續編碼。",
+    "description": "Read-only replay notice"
+  },
+  "history.resumeHint": {
+    "message": "傳送訊息將在裝置上接續此會話。",
+    "description": "Resume composer hint"
+  },
+  "history.claudeLabel": {
+    "message": "Claude 歷史",
+    "description": "Replayed Claude session label"
+  },
+  "history.codexLabel": {
+    "message": "Codex 歷史（唯讀）",
+    "description": "Replayed Codex session label"
   }
 }

--- a/src/models/codingBridge.ts
+++ b/src/models/codingBridge.ts
@@ -16,6 +16,8 @@ export interface ICodingBridgeNode {
 
 export type ICodingBridgeSessionStatus = 'starting' | 'running' | 'idle' | 'closed' | 'error';
 
+export type ICodingBridgeHistoryProvider = 'claude' | 'codex';
+
 /** A live agent session running inside one node. */
 export interface ICodingBridgeSession {
   session_id: string;
@@ -24,6 +26,36 @@ export interface ICodingBridgeSession {
   cwd?: string;
   model?: string;
   cost_usd?: number;
+  // Which backend this session targets; defaults to Claude Code.
+  provider?: ICodingBridgeHistoryProvider;
+  // Provider session id to resume when the first prompt is sent (Claude only).
+  resume_session_id?: string;
+  // A live turn has been started on the node for this session.
+  started?: boolean;
+  // Replay of past history that cannot be continued (e.g. Codex).
+  readonly?: boolean;
+}
+
+/** One past on-device session as listed by `history.list`. */
+export interface ICodingBridgeHistorySummary {
+  provider: ICodingBridgeHistoryProvider;
+  session_id: string;
+  title: string;
+  cwd?: string;
+  git_branch?: string;
+  updated_at?: number;
+  message_count?: number;
+}
+
+/** A normalised transcript returned by `history.get`. */
+export interface ICodingBridgeHistoryDetail {
+  provider: ICodingBridgeHistoryProvider;
+  session_id: string;
+  title?: string;
+  cwd?: string;
+  git_branch?: string;
+  model?: string;
+  events: Array<Partial<ICodingBridgeEvent> & { kind: ICodingBridgeEventKind }>;
 }
 
 /**

--- a/src/pages/codingBridge/Index.vue
+++ b/src/pages/codingBridge/Index.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="coding-bridge flex flex-row h-full relative">
     <node-list class="sidebar w-[300px] flex-none" @pair="openPair" />
-    <session-view class="flex-1 min-w-0" />
+    <session-view class="flex-1 min-w-0" @history="historyVisible = true" />
 
     <el-button circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-laptop-code" />
@@ -12,6 +12,7 @@
 
     <pair-dialog v-model:visible="pairVisible" :initial-code="initialCode" />
     <permission-dialog />
+    <history-drawer v-model:visible="historyVisible" />
   </div>
 </template>
 
@@ -23,6 +24,7 @@ import NodeList from '@/components/codingBridge/NodeList.vue';
 import SessionView from '@/components/codingBridge/SessionView.vue';
 import PairDialog from '@/components/codingBridge/PairDialog.vue';
 import PermissionDialog from '@/components/codingBridge/PermissionDialog.vue';
+import HistoryDrawer from '@/components/codingBridge/HistoryDrawer.vue';
 
 export default defineComponent({
   name: 'CodingBridgeIndex',
@@ -33,12 +35,14 @@ export default defineComponent({
     NodeList,
     SessionView,
     PairDialog,
-    PermissionDialog
+    PermissionDialog,
+    HistoryDrawer
   },
   data() {
     return {
       drawer: false,
       pairVisible: false,
+      historyVisible: false,
       initialCode: ''
     };
   },

--- a/src/plugins/font-awesome.ts
+++ b/src/plugins/font-awesome.ts
@@ -132,13 +132,17 @@ import {
   faReceipt as faSolidReceipt,
   faDollarSign as faSolidDollarSign,
   faFileExport as faSolidFileExport,
-  faUserXmark as faSolidUserXmark
+  faUserXmark as faSolidUserXmark,
+  faClockRotateLeft as faSolidClockRotateLeft,
+  faEye as faSolidEye
 } from '@fortawesome/free-solid-svg-icons';
 // add icons
 library.add(faSolidEllipsis);
 library.add(faSolidCode);
 library.add(faSolidGlobe);
 library.add(faRegularLightbulb);
+library.add(faSolidClockRotateLeft);
+library.add(faSolidEye);
 library.add(faSolidIdCard);
 library.add(faSolidStopCircle);
 library.add(faRegularFile);

--- a/src/store/codingBridge/actions.ts
+++ b/src/store/codingBridge/actions.ts
@@ -1,6 +1,6 @@
 import { ActionContext } from 'vuex';
 import { codingBridgeOperator } from '@/operators';
-import { ICodingBridgeState } from './models';
+import { ICodingBridgeHistoryRef, ICodingBridgeState } from './models';
 import { IRootState } from '../common/models';
 import { Status, ICodingBridgeEvent, ICodingBridgeEventKind, ICodingBridgeNode } from '@/models';
 import { CodingBridgeSocket } from '@/utils/codingBridgeSocket';
@@ -10,6 +10,8 @@ import {
   CB_ACTION_SESSION_INTERRUPT,
   CB_ACTION_SESSION_CLOSE,
   CB_ACTION_PERMISSION_RESOLVE,
+  CB_ACTION_HISTORY_LIST,
+  CB_ACTION_HISTORY_GET,
   CB_EVENT_SESSION_STARTED,
   CB_EVENT_SESSION_TEXT,
   CB_EVENT_SESSION_THINKING,
@@ -20,7 +22,9 @@ import {
   CB_EVENT_SESSION_RESULT,
   CB_EVENT_SESSION_ERROR,
   CB_EVENT_SESSION_CLOSED,
-  CB_EVENT_SESSIONS_SNAPSHOT
+  CB_EVENT_SESSIONS_SNAPSHOT,
+  CB_EVENT_HISTORY_SNAPSHOT,
+  CB_EVENT_HISTORY_DETAIL
 } from '@/constants';
 
 // The live WebSocket is intentionally kept OUT of Vuex state (it is not
@@ -50,6 +54,8 @@ const makeEvent = (
 // Translate one inner node event into the matching mutation(s).
 const applyNodeEvent = (
   commit: ActionContext<ICodingBridgeState, IRootState>['commit'],
+  dispatch: ActionContext<ICodingBridgeState, IRootState>['dispatch'],
+  state: ICodingBridgeState,
   payload: Record<string, any>,
   fromNode: string | undefined
 ): void => {
@@ -136,9 +142,66 @@ const applyNodeEvent = (
         });
       }
       break;
+    case CB_EVENT_HISTORY_SNAPSHOT:
+      if (fromNode) {
+        commit('setHistory', { node_id: fromNode, sessions: payload.sessions ?? [] });
+        commit('updateStatus', { key: 'getHistory', value: Status.Success });
+        // Restore the conversation that was open before a reload.
+        const ref = state.historyRef;
+        if (ref && ref.node_id === fromNode && !state.currentSessionId) {
+          dispatch('getHistoryDetail', ref);
+        }
+      }
+      break;
+    case CB_EVENT_HISTORY_DETAIL:
+      applyHistoryDetail(commit, payload, fromNode);
+      break;
     default:
       break;
   }
+};
+
+// Materialise a replayed transcript as a (resumable) session.
+const applyHistoryDetail = (
+  commit: ActionContext<ICodingBridgeState, IRootState>['commit'],
+  payload: Record<string, any>,
+  fromNode: string | undefined
+): void => {
+  const sessionId = payload?.session_id;
+  const provider = payload?.provider === 'codex' ? 'codex' : 'claude';
+  if (!sessionId || !fromNode) {
+    return;
+  }
+  const resumable = provider === 'claude';
+  commit('upsertSession', {
+    session_id: sessionId,
+    node_id: fromNode,
+    status: 'idle',
+    cwd: payload.cwd,
+    model: payload.model,
+    provider,
+    started: false,
+    readonly: !resumable,
+    resume_session_id: resumable ? sessionId : undefined
+  });
+  const events: ICodingBridgeEvent[] = (payload.events ?? []).map((item: any, index: number) => ({
+    id: uid(),
+    session_id: sessionId,
+    kind: item.kind as ICodingBridgeEventKind,
+    ts: typeof item.ts === 'number' ? item.ts : Date.now() + index,
+    text: item.text,
+    tool: item.tool,
+    tool_use_id: item.tool_use_id,
+    input: item.input,
+    content: item.content,
+    is_error: item.is_error,
+    subtype: item.subtype,
+    cost_usd: item.cost_usd
+  }));
+  commit('setEvents', { session_id: sessionId, events });
+  commit('setCurrentNode', fromNode);
+  commit('setCurrentSession', sessionId);
+  commit('setHistoryRef', { node_id: fromNode, provider, session_id: sessionId });
 };
 
 export const resetAll = ({ commit }: ActionContext<ICodingBridgeState, IRootState>): void => {
@@ -215,7 +278,12 @@ export const deleteNode = async (
   }
 };
 
-export const connect = ({ commit, rootState }: ActionContext<ICodingBridgeState, IRootState>): void => {
+export const connect = ({
+  commit,
+  dispatch,
+  state,
+  rootState
+}: ActionContext<ICodingBridgeState, IRootState>): void => {
   const token = rootState.token?.access;
   if (!token) {
     return;
@@ -226,15 +294,25 @@ export const connect = ({ commit, rootState }: ActionContext<ICodingBridgeState,
   socket?.close();
   commit('setConnection', 'connecting');
   socket = new CodingBridgeSocket(token, {
-    onOpen: () => commit('setConnection', 'connected'),
+    onOpen: () => {
+      commit('setConnection', 'connected');
+      if (state.currentNodeId) {
+        dispatch('getHistory', state.currentNodeId);
+      }
+    },
     onClose: () => commit('setConnection', 'disconnected'),
-    onEvent: (payload, fromNode) => applyNodeEvent(commit, payload, fromNode),
+    onEvent: (payload, fromNode) => applyNodeEvent(commit, dispatch, state, payload, fromNode),
     onNodesSnapshot: (nodes) => {
       // Merge live online flags onto the REST-sourced list without dropping
       // offline nodes the snapshot omits.
       commit('mergeNodeSnapshot', nodes);
     },
-    onNodeStatus: (nodeId, status) => commit('setNodeStatus', { node_id: nodeId, status }),
+    onNodeStatus: (nodeId, status) => {
+      commit('setNodeStatus', { node_id: nodeId, status });
+      if (status === 'online' && nodeId === state.currentNodeId) {
+        dispatch('getHistory', nodeId);
+      }
+    },
     onRelayError: (code, message) => console.warn('[codingBridge] relay error', code, message)
   });
   socket.connect();
@@ -247,7 +325,7 @@ export const disconnect = ({ commit }: ActionContext<ICodingBridgeState, IRootSt
 };
 
 export const selectNode = (
-  { commit, state }: ActionContext<ICodingBridgeState, IRootState>,
+  { commit, dispatch, state }: ActionContext<ICodingBridgeState, IRootState>,
   nodeId: string | undefined
 ): void => {
   commit('setCurrentNode', nodeId);
@@ -259,10 +337,12 @@ export const selectNode = (
     .filter((session) => session.node_id === nodeId)
     .map((session) => session.session_id);
   commit('setCurrentSession', ids.length ? ids[ids.length - 1] : undefined);
+  dispatch('getHistory', nodeId);
 };
 
 export const newSession = ({ commit }: ActionContext<ICodingBridgeState, IRootState>): void => {
   commit('setCurrentSession', undefined);
+  commit('setHistoryRef', undefined);
 };
 
 export const sendPrompt = (
@@ -275,25 +355,36 @@ export const sendPrompt = (
     return;
   }
   let sessionId = state.currentSessionId;
-  const isNew = !sessionId || !state.sessions[sessionId];
-  if (isNew) {
-    sessionId = uid();
-    commit('upsertSession', {
-      session_id: sessionId,
-      node_id: nodeId,
-      status: 'starting',
-      cwd: payload.cwd,
-      model: payload.model
-    });
-    commit('setCurrentSession', sessionId);
-    commit('appendEvent', makeEvent(sessionId, 'prompt', { text: prompt }));
+  const existing = sessionId ? state.sessions[sessionId] : undefined;
+  // A turn must be started when there is no session yet, or when the current
+  // session is a replayed history conversation that has not been resumed.
+  const needsStart = !existing || !existing.started;
+  if (needsStart) {
+    if (!existing) {
+      sessionId = uid();
+      commit('upsertSession', {
+        session_id: sessionId,
+        node_id: nodeId,
+        status: 'starting',
+        cwd: payload.cwd,
+        model: payload.model
+      });
+      commit('setCurrentSession', sessionId);
+    } else {
+      sessionId = existing.session_id;
+      commit('updateSession', { session_id: sessionId, status: 'starting' });
+    }
+    commit('appendEvent', makeEvent(sessionId as string, 'prompt', { text: prompt }));
+    commit('updateSession', { session_id: sessionId as string, started: true });
     socket.sendToNode(nodeId, {
       action: CB_ACTION_SESSION_START,
       session_id: sessionId,
       prompt,
-      cwd: payload.cwd || undefined,
-      model: payload.model || undefined,
-      permission_mode: 'default'
+      cwd: payload.cwd || existing?.cwd || undefined,
+      model: payload.model || existing?.model || undefined,
+      permission_mode: 'default',
+      provider: existing?.provider || undefined,
+      resume_session_id: existing?.resume_session_id || undefined
     });
   } else {
     commit('appendEvent', makeEvent(sessionId as string, 'prompt', { text: prompt }));
@@ -347,6 +438,31 @@ export const resolvePermission = (
     decision: payload.decision
   });
   commit('removePermission', payload.request_id);
+};
+
+// Ask a node to list its local Claude Code / Codex transcripts.
+export const getHistory = ({ commit, state }: ActionContext<ICodingBridgeState, IRootState>, nodeId?: string): void => {
+  const target = nodeId ?? state.currentNodeId;
+  if (!target || !socket) {
+    return;
+  }
+  commit('updateStatus', { key: 'getHistory', value: Status.Request });
+  socket.sendToNode(target, { action: CB_ACTION_HISTORY_LIST, limit: 200 });
+};
+
+// Ask a node to replay one past transcript so it can be viewed / resumed.
+export const getHistoryDetail = (
+  _context: ActionContext<ICodingBridgeState, IRootState>,
+  payload: ICodingBridgeHistoryRef
+): void => {
+  if (!payload?.node_id || !payload?.session_id || !socket) {
+    return;
+  }
+  socket.sendToNode(payload.node_id, {
+    action: CB_ACTION_HISTORY_GET,
+    provider: payload.provider,
+    session_id: payload.session_id
+  });
 };
 
 export default {

--- a/src/store/codingBridge/models.ts
+++ b/src/store/codingBridge/models.ts
@@ -2,10 +2,18 @@ import { Status } from '@/models';
 import {
   ICodingBridgeConnectionStatus,
   ICodingBridgeEvent,
+  ICodingBridgeHistorySummary,
   ICodingBridgeNode,
   ICodingBridgePermissionRequest,
   ICodingBridgeSession
 } from '@/models';
+
+/** Pointer to the last-opened history conversation, restored after a reload. */
+export interface ICodingBridgeHistoryRef {
+  node_id: string;
+  provider: 'claude' | 'codex';
+  session_id: string;
+}
 
 export interface ICodingBridgeState {
   nodes: ICodingBridgeNode[];
@@ -13,6 +21,9 @@ export interface ICodingBridgeState {
   currentSessionId: string | undefined;
   sessions: Record<string, ICodingBridgeSession>;
   events: Record<string, ICodingBridgeEvent[]>;
+  // Past on-device sessions per node, sourced live from `history.list`.
+  history: Record<string, ICodingBridgeHistorySummary[]>;
+  historyRef: ICodingBridgeHistoryRef | undefined;
   permissions: ICodingBridgePermissionRequest[];
   connection: ICodingBridgeConnectionStatus;
   // Coding Bridge is not a billed API service, so it owns no application /
@@ -27,5 +38,6 @@ export interface ICodingBridgeState {
     claimPair: Status;
     deleteNode: Status;
     getApplications: Status;
+    getHistory: Status;
   };
 }

--- a/src/store/codingBridge/mutations.ts
+++ b/src/store/codingBridge/mutations.ts
@@ -1,8 +1,9 @@
 import initialState from './state';
-import { ICodingBridgeState } from './models';
+import { ICodingBridgeHistoryRef, ICodingBridgeState } from './models';
 import {
   ICodingBridgeConnectionStatus,
   ICodingBridgeEvent,
+  ICodingBridgeHistorySummary,
   ICodingBridgeNode,
   ICodingBridgePermissionRequest,
   ICodingBridgeSession,
@@ -82,6 +83,25 @@ export const appendEvent = (state: ICodingBridgeState, payload: ICodingBridgeEve
   state.events[payload.session_id].push(payload);
 };
 
+// Replace a session's transcript wholesale (used when replaying history).
+export const setEvents = (
+  state: ICodingBridgeState,
+  payload: { session_id: string; events: ICodingBridgeEvent[] }
+): void => {
+  state.events[payload.session_id] = payload.events;
+};
+
+export const setHistory = (
+  state: ICodingBridgeState,
+  payload: { node_id: string; sessions: ICodingBridgeHistorySummary[] }
+): void => {
+  state.history[payload.node_id] = payload.sessions;
+};
+
+export const setHistoryRef = (state: ICodingBridgeState, payload: ICodingBridgeHistoryRef | undefined): void => {
+  state.historyRef = payload;
+};
+
 export const addPermission = (state: ICodingBridgeState, payload: ICodingBridgePermissionRequest): void => {
   if (state.permissions.some((item) => item.request_id === payload.request_id)) {
     return;
@@ -94,6 +114,10 @@ export const removePermission = (state: ICodingBridgeState, requestId: string): 
 };
 
 export const removeNodeData = (state: ICodingBridgeState, nodeId: string): void => {
+  delete state.history[nodeId];
+  if (state.historyRef?.node_id === nodeId) {
+    state.historyRef = undefined;
+  }
   for (const session of Object.values(state.sessions)) {
     if (session.node_id === nodeId) {
       delete state.sessions[session.session_id];
@@ -117,6 +141,9 @@ export default {
   upsertSession,
   updateSession,
   appendEvent,
+  setEvents,
+  setHistory,
+  setHistoryRef,
   addPermission,
   removePermission,
   removeNodeData

--- a/src/store/codingBridge/persist.ts
+++ b/src/store/codingBridge/persist.ts
@@ -1,4 +1,5 @@
-// Only the selected node survives a reload. Live nodes, sessions, events and
-// permission prompts are rebuilt from the relay on reconnect, so persisting
-// them would only show stale data.
-export default ['codingBridge.currentNodeId'];
+// Only the selected node and the last-opened history pointer survive a reload.
+// Live nodes, sessions, events and permission prompts are rebuilt from the
+// relay on reconnect, and the open conversation is re-read from the device, so
+// persisting their contents would only show stale data.
+export default ['codingBridge.currentNodeId', 'codingBridge.historyRef'];

--- a/src/store/codingBridge/state.ts
+++ b/src/store/codingBridge/state.ts
@@ -8,6 +8,8 @@ export default (): ICodingBridgeState => {
     currentSessionId: undefined,
     sessions: {},
     events: {},
+    history: {},
+    historyRef: undefined,
     permissions: [],
     connection: 'disconnected',
     application: undefined,
@@ -17,7 +19,8 @@ export default (): ICodingBridgeState => {
       getNodes: Status.None,
       claimPair: Status.None,
       deleteNode: Status.None,
-      getApplications: Status.None
+      getApplications: Status.None,
+      getHistory: Status.None
     }
   };
 };


### PR DESCRIPTION
## What

Adds device history sync + replay to the Coding Bridge studio page, so a page refresh no longer loses the conversation.

- **History drawer** lists past on-device sessions from **Claude Code** (`~/.claude/projects/**.jsonl`) and **Codex** (`~/.codex/sessions/**.jsonl`), read **live** from the paired node — the relay never stores transcripts.
- **Replay** opens the selected transcript in the existing `TranscriptItem` viewer (prompt / text / thinking / tool_use / tool_result).
- **Resume**: Claude sessions can be continued (the next prompt resumes the underlying session); **Codex** replays are **read-only**.
- **Refresh-safe**: only a small pointer (`historyRef`) is persisted; on reload the agent re-reads the transcript from disk, so no stale content is cached in the browser.

## How it works

New inner protocol actions/events (opaque to the relay, forwarded verbatim):

| Action | Event | Purpose |
|---|---|---|
| `history.list` | `history.snapshot` | list device sessions |
| `history.get` | `history.detail` | replay one transcript |

Store: new `history` map (per node) + `getHistory` status; `sendPrompt` is now resume-aware (`resume_session_id` / `provider` / `started`); `selectNode` and reconnect auto-fetch history.

## Scope

- No relay changes (it already forwards `payload` verbatim).
- Agent side is in a companion PR on `AceDataCloud/CodingBridgeAgent`.
- i18n: `zh-CN` + `en` only.

## Verification

- `npx eslint --fix` clean
- `npx vue-tsc --noEmit` passes (exit 0)