### PR TITLE
fix(application): show effective balance and Shared badge for granted apps

### DIFF
--- a/change/acedatacloud-nexior-cc9775a9-704f-46aa-bcbd-a08772a8a2a2.json
+++ b/change/acedatacloud-nexior-cc9775a9-704f-46aa-bcbd-a08772a8a2a2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Show effective balance and a Shared badge for granted (shared) applications",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/application/Info.vue
+++ b/src/components/application/Info.vue
@@ -19,9 +19,12 @@
         <p class="description">
           <span v-if="!application.service">{{ $t('application.title.globalBalance') }}</span>
           <span v-else>{{ $t('application.title.applicationBalance', { service: application.service?.title }) }}</span>
+          <el-tag v-if="application.role === 'grantee'" class="shared-badge" size="small" type="info" effect="plain">
+            {{ $t('application.badge.shared') }}
+          </el-tag>
         </p>
         <p class="value">
-          {{ application?.remaining_amount?.toFixed(2) }}
+          {{ remainingAmountText }}
           {{ $t(`service.unit.` + (application?.service?.unit || 'credit') + 's') }}
         </p>
         <p class="description2">
@@ -84,6 +87,13 @@ export default defineComponent({
     // Hide the "Top Up" action inside the iOS bundle (payments are web-only).
     showPayment(): boolean {
       return !isIOS();
+    },
+    remainingAmountText(): string {
+      const amount = Number(this.application?.remaining_amount ?? 0);
+      if (!Number.isFinite(amount) || amount < 0) {
+        return '0.00';
+      }
+      return amount.toFixed(2);
     }
   }
 });
@@ -203,6 +213,13 @@ export default defineComponent({
 .description {
   color: var(--el-text-color-regular);
   font-size: 14px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.shared-badge {
+  margin-left: 2px;
 }
 .description2 {
   color: var(--el-text-color-secondary);


### PR DESCRIPTION
## Problem

In the studio app, applications that an owner **granted/shared** to the current user (grantee) showed up in the application picker with:

1. A **blank Credits value** — `application.remaining_amount` came back `null` from the API, so `remaining_amount?.toFixed(2)` rendered nothing.
2. **No visual indicator** that the application is shared (vs. owned), so users couldn't tell which keys were lent to them.

## Fix

`src/components/application/Info.vue`:

- Add a **Shared** badge (`el-tag`) next to the balance label when `application.role === 'grantee'`. Uses the existing `application.badge.shared` i18n key (already present in all 18 locales).
- Render the balance through a new `remainingAmountText` computed that coerces `null`/invalid/negative to `'0.00'`, so grantees see a real number instead of a blank.

Pairs with the PlatformBackend change (AceDataCloud/PlatformBackend#618) that now returns the grantee's effective remaining quota instead of `null`.

## Notes

- No new i18n keys — `application.badge.shared` already exists across locales.
- Beachball patch change file included.