### PR TITLE
fix(coding-bridge): register history actions so Conversation History works

### DIFF
--- a/change/@acedatacloud-nexior-06533035-510f-4c78-a42a-a0b75b51ce14.json
+++ b/change/@acedatacloud-nexior-06533035-510f-4c78-a42a-a0b75b51ce14.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(coding-bridge): register history actions so the Conversation History panel and Refresh work",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/store/codingBridge/actions.ts
+++ b/src/store/codingBridge/actions.ts
@@ -479,5 +479,7 @@ export default {
   sendPrompt,
   interruptSession,
   closeSession,
-  resolvePermission
+  resolvePermission,
+  getHistory,
+  getHistoryDetail
 };


### PR DESCRIPTION
## Problem

On `/coding-bridge`, the **Conversation History** panel showed nothing, the **Refresh** button did nothing, and reloading the page lost the conversation.

## Root cause

`getHistory` and `getHistoryDetail` were defined as named exports in `src/store/codingBridge/actions.ts` but were **missing from the `export default {...}` object**. The store module registers actions via that default export, so Vuex never registered the two history actions. Every `dispatch('codingBridge/getHistory')` / `getHistoryDetail` threw `[vuex] unknown action type` and failed silently:

- initial `getHistory` (on connect / node online / drawer open) → panel renders the empty state
- `refresh()` button → no-op
- `getHistoryDetail` restore-on-reload → conversation lost after refresh

Because the dispatch never ran, `status.getHistory` stayed at `None`, so the drawer showed the *empty* state (not the *loading* state) — confirming the agent/relay were fine and this was purely a missing registration.

## Fix

Add `getHistory` and `getHistoryDetail` to the actions default export. No behavior change beyond registering the already-implemented actions.

## Verification

- `npx vue-tsc --noEmit` → clean
- `npx eslint src/store/codingBridge/actions.ts` → clean