### PR TITLE
fix(application): make grantee Shared badge a prominent warning pill

### DIFF
--- a/change/acedatacloud-nexior-1ef29305-5e3c-4d77-bfed-b4e8495367dc.json
+++ b/change/acedatacloud-nexior-1ef29305-5e3c-4d77-bfed-b4e8495367dc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "make grantee \"Shared\" badge a solid warning pill for better visibility",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/application/Info.vue
+++ b/src/components/application/Info.vue
@@ -19,7 +19,14 @@
         <p class="description">
           <span v-if="!application.service">{{ $t('application.title.globalBalance') }}</span>
           <span v-else>{{ $t('application.title.applicationBalance', { service: application.service?.title }) }}</span>
-          <el-tag v-if="application.role === 'grantee'" class="shared-badge" size="small" type="info" effect="plain">
+          <el-tag
+            v-if="application.role === 'grantee'"
+            class="shared-badge"
+            size="small"
+            type="warning"
+            effect="dark"
+            round
+          >
             {{ $t('application.badge.shared') }}
           </el-tag>
         </p>


### PR DESCRIPTION
## What

The grantee "Shared" badge on the application balance card (studio key picker) was rendered with `type="info" effect="plain"`, which looks like faint gray text and is easy to miss.

This changes it to a solid amber pill (`type="warning" effect="dark" round`), matching the codebase convention used elsewhere (e.g. `console/application/List.vue`, `order/Detail.vue`). The badge now clearly stands out so users can immediately tell a key was shared to them by another account.

## Scope

- Visual-only change in `src/components/application/Info.vue`.
- No new i18n keys (`application.badge.shared` already exists in all 18 locales).
- Follow-up to #864.

## Before / After

- Before: subtle gray `Shared` text.
- After: solid amber `Shared` pill.