### PR TITLE
feat(coding-bridge): larger IME-safe composer, model & permission-mode selectors

### DIFF
--- a/change/@acedatacloud-nexior-38d994bc-0e16-4ce7-8768-a385c920c053.json
+++ b/change/@acedatacloud-nexior-38d994bc-0e16-4ce7-8768-a385c920c053.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Coding Bridge: larger IME-safe composer, model dropdown, and permission-mode selector",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/codingBridge/SessionView.vue
+++ b/src/components/codingBridge/SessionView.vue
@@ -65,24 +65,44 @@
           </el-button>
         </div>
         <template v-else>
-          <div v-if="isNewSession" class="flex gap-2 mb-2">
-            <el-input v-model="cwd" size="small" :placeholder="$t('codingBridge.session.cwdPlaceholder')" clearable />
+          <div v-if="isNewSession" class="flex flex-wrap gap-2 mb-2">
             <el-input
-              v-model="model"
+              v-model="cwd"
               size="small"
-              :placeholder="$t('codingBridge.session.modelPlaceholder')"
+              class="flex-1 min-w-[160px]"
+              :placeholder="$t('codingBridge.session.cwdPlaceholder')"
               clearable
             />
+            <el-select
+              v-model="model"
+              size="small"
+              filterable
+              allow-create
+              default-first-option
+              clearable
+              class="w-40"
+              :placeholder="$t('codingBridge.session.modelPlaceholder')"
+            >
+              <el-option v-for="opt in modelOptions" :key="opt.value" :label="opt.label" :value="opt.value" />
+            </el-select>
+            <el-select
+              v-model="permissionMode"
+              size="small"
+              class="w-44"
+              :placeholder="$t('codingBridge.session.permissionModeLabel')"
+            >
+              <el-option v-for="opt in permissionModeOptions" :key="opt.value" :label="opt.label" :value="opt.value" />
+            </el-select>
           </div>
           <div class="flex items-end gap-2">
             <el-input
               v-model="prompt"
               type="textarea"
-              :autosize="{ minRows: 1, maxRows: 6 }"
+              :autosize="{ minRows: 3, maxRows: 12 }"
               resize="none"
               class="flex-1"
               :placeholder="$t('codingBridge.session.promptPlaceholder')"
-              @keydown.enter.exact.prevent="onSend"
+              @keydown.enter="onComposerEnter"
             />
             <el-button v-if="running" round @click="onInterrupt">
               <font-awesome-icon icon="fa-solid fa-stop" />
@@ -102,7 +122,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElInput, ElButton } from 'element-plus';
+import { ElInput, ElButton, ElSelect, ElOption } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import TranscriptItem from './TranscriptItem.vue';
 import { ICodingBridgeEvent, ICodingBridgeNode, ICodingBridgeSession } from '@/models';
@@ -112,6 +132,8 @@ export default defineComponent({
   components: {
     ElInput,
     ElButton,
+    ElSelect,
+    ElOption,
     FontAwesomeIcon,
     TranscriptItem
   },
@@ -120,7 +142,8 @@ export default defineComponent({
     return {
       prompt: '',
       cwd: '',
-      model: ''
+      model: '',
+      permissionMode: 'default'
     };
   },
   computed: {
@@ -171,6 +194,21 @@ export default defineComponent({
     },
     canSend(): boolean {
       return !!this.prompt.trim() && this.connected && this.nodeOnline;
+    },
+    modelOptions(): { label: string; value: string }[] {
+      return [
+        { label: 'Claude Sonnet', value: 'sonnet' },
+        { label: 'Claude Opus', value: 'opus' },
+        { label: 'Claude Haiku', value: 'haiku' }
+      ];
+    },
+    permissionModeOptions(): { label: string; value: string }[] {
+      return [
+        { label: this.$t('codingBridge.session.permissionModeDefault') as string, value: 'default' },
+        { label: this.$t('codingBridge.session.permissionModeAcceptEdits') as string, value: 'acceptEdits' },
+        { label: this.$t('codingBridge.session.permissionModePlan') as string, value: 'plan' },
+        { label: this.$t('codingBridge.session.permissionModeBypass') as string, value: 'bypassPermissions' }
+      ];
     }
   },
   watch: {
@@ -182,6 +220,20 @@ export default defineComponent({
     }
   },
   methods: {
+    onComposerEnter(event: KeyboardEvent | Event) {
+      // Ignore Enter while an IME (e.g. pinyin) composition is active so that
+      // confirming candidates never sends the message. Modifier+Enter inserts
+      // a newline instead of sending.
+      const e = event as KeyboardEvent;
+      if (e.isComposing || e.keyCode === 229) {
+        return;
+      }
+      if (e.shiftKey || e.ctrlKey || e.metaKey || e.altKey) {
+        return;
+      }
+      e.preventDefault();
+      this.onSend();
+    },
     onSend() {
       if (!this.canSend) {
         return;
@@ -189,7 +241,8 @@ export default defineComponent({
       this.$store.dispatch('codingBridge/sendPrompt', {
         prompt: this.prompt,
         cwd: this.cwd,
-        model: this.model
+        model: this.model,
+        permissionMode: this.permissionMode
       });
       this.prompt = '';
     },
@@ -200,6 +253,7 @@ export default defineComponent({
       this.$store.dispatch('codingBridge/newSession');
       this.cwd = '';
       this.model = '';
+      this.permissionMode = 'default';
       this.prompt = '';
     },
     scrollToBottom() {

--- a/src/i18n/ar/codingBridge.json
+++ b/src/i18n/ar/codingBridge.json
@@ -206,5 +206,25 @@
   "history.codexLabel": {
     "message": "سجل Codex (للقراءة فقط)",
     "description": "Replayed Codex session label"
+  },
+  "session.permissionModeLabel": {
+    "message": "وضع الأذونات",
+    "description": "Permission-mode selector label"
+  },
+  "session.permissionModeDefault": {
+    "message": "افتراضي (السؤال في كل مرة)",
+    "description": "Permission mode: ask before each tool use"
+  },
+  "session.permissionModeAcceptEdits": {
+    "message": "قبول التعديلات تلقائيًا",
+    "description": "Permission mode: auto-accept file edits"
+  },
+  "session.permissionModePlan": {
+    "message": "وضع التخطيط (للقراءة فقط)",
+    "description": "Permission mode: read-only planning"
+  },
+  "session.permissionModeBypass": {
+    "message": "تجاوز كل الأذونات",
+    "description": "Permission mode: bypass all permission prompts"
   }
 }

--- a/src/i18n/de/codingBridge.json
+++ b/src/i18n/de/codingBridge.json
@@ -206,5 +206,25 @@
   "history.codexLabel": {
     "message": "Codex-Verlauf (schreibgeschützt)",
     "description": "Replayed Codex session label"
+  },
+  "session.permissionModeLabel": {
+    "message": "Berechtigungsmodus",
+    "description": "Permission-mode selector label"
+  },
+  "session.permissionModeDefault": {
+    "message": "Standard (jedes Mal fragen)",
+    "description": "Permission mode: ask before each tool use"
+  },
+  "session.permissionModeAcceptEdits": {
+    "message": "Änderungen automatisch akzeptieren",
+    "description": "Permission mode: auto-accept file edits"
+  },
+  "session.permissionModePlan": {
+    "message": "Planungsmodus (schreibgeschützt)",
+    "description": "Permission mode: read-only planning"
+  },
+  "session.permissionModeBypass": {
+    "message": "Alle Berechtigungen umgehen",
+    "description": "Permission mode: bypass all permission prompts"
   }
 }

--- a/src/i18n/el/codingBridge.json
+++ b/src/i18n/el/codingBridge.json
@@ -206,5 +206,25 @@
   "history.codexLabel": {
     "message": "Ιστορικό Codex (μόνο για ανάγνωση)",
     "description": "Replayed Codex session label"
+  },
+  "session.permissionModeLabel": {
+    "message": "Λειτουργία δικαιωμάτων",
+    "description": "Permission-mode selector label"
+  },
+  "session.permissionModeDefault": {
+    "message": "Προεπιλογή (ερώτηση κάθε φορά)",
+    "description": "Permission mode: ask before each tool use"
+  },
+  "session.permissionModeAcceptEdits": {
+    "message": "Αυτόματη αποδοχή αλλαγών",
+    "description": "Permission mode: auto-accept file edits"
+  },
+  "session.permissionModePlan": {
+    "message": "Λειτουργία σχεδιασμού (μόνο ανάγνωση)",
+    "description": "Permission mode: read-only planning"
+  },
+  "session.permissionModeBypass": {
+    "message": "Παράκαμψη όλων των δικαιωμάτων",
+    "description": "Permission mode: bypass all permission prompts"
   }
 }

--- a/src/i18n/en/codingBridge.json
+++ b/src/i18n/en/codingBridge.json
@@ -206,5 +206,25 @@
   "history.codexLabel": {
     "message": "Codex history (read-only)",
     "description": "Replayed Codex session label"
+  },
+  "session.permissionModeLabel": {
+    "message": "Permission mode",
+    "description": "Permission-mode selector label"
+  },
+  "session.permissionModeDefault": {
+    "message": "Default (ask each time)",
+    "description": "Permission mode: ask before each tool use"
+  },
+  "session.permissionModeAcceptEdits": {
+    "message": "Auto-accept edits",
+    "description": "Permission mode: auto-accept file edits"
+  },
+  "session.permissionModePlan": {
+    "message": "Plan mode (read-only)",
+    "description": "Permission mode: read-only planning"
+  },
+  "session.permissionModeBypass": {
+    "message": "Bypass all permissions",
+    "description": "Permission mode: bypass all permission prompts"
   }
 }

--- a/src/i18n/es/codingBridge.json
+++ b/src/i18n/es/codingBridge.json
@@ -206,5 +206,25 @@
   "history.codexLabel": {
     "message": "Historial de Codex (solo lectura)",
     "description": "Replayed Codex session label"
+  },
+  "session.permissionModeLabel": {
+    "message": "Modo de permisos",
+    "description": "Permission-mode selector label"
+  },
+  "session.permissionModeDefault": {
+    "message": "Predeterminado (preguntar cada vez)",
+    "description": "Permission mode: ask before each tool use"
+  },
+  "session.permissionModeAcceptEdits": {
+    "message": "Aceptar cambios automáticamente",
+    "description": "Permission mode: auto-accept file edits"
+  },
+  "session.permissionModePlan": {
+    "message": "Modo de planificación (solo lectura)",
+    "description": "Permission mode: read-only planning"
+  },
+  "session.permissionModeBypass": {
+    "message": "Omitir todos los permisos",
+    "description": "Permission mode: bypass all permission prompts"
   }
 }

--- a/src/i18n/fi/codingBridge.json
+++ b/src/i18n/fi/codingBridge.json
@@ -206,5 +206,25 @@
   "history.codexLabel": {
     "message": "Codex-historia (vain luku)",
     "description": "Replayed Codex session label"
+  },
+  "session.permissionModeLabel": {
+    "message": "Käyttöoikeustila",
+    "description": "Permission-mode selector label"
+  },
+  "session.permissionModeDefault": {
+    "message": "Oletus (kysy joka kerta)",
+    "description": "Permission mode: ask before each tool use"
+  },
+  "session.permissionModeAcceptEdits": {
+    "message": "Hyväksy muokkaukset automaattisesti",
+    "description": "Permission mode: auto-accept file edits"
+  },
+  "session.permissionModePlan": {
+    "message": "Suunnittelutila (vain luku)",
+    "description": "Permission mode: read-only planning"
+  },
+  "session.permissionModeBypass": {
+    "message": "Ohita kaikki käyttöoikeudet",
+    "description": "Permission mode: bypass all permission prompts"
   }
 }

--- a/src/i18n/fr/codingBridge.json
+++ b/src/i18n/fr/codingBridge.json
@@ -206,5 +206,25 @@
   "history.codexLabel": {
     "message": "Historique Codex (lecture seule)",
     "description": "Replayed Codex session label"
+  },
+  "session.permissionModeLabel": {
+    "message": "Mode d'autorisation",
+    "description": "Permission-mode selector label"
+  },
+  "session.permissionModeDefault": {
+    "message": "Par défaut (demander à chaque fois)",
+    "description": "Permission mode: ask before each tool use"
+  },
+  "session.permissionModeAcceptEdits": {
+    "message": "Accepter automatiquement les modifications",
+    "description": "Permission mode: auto-accept file edits"
+  },
+  "session.permissionModePlan": {
+    "message": "Mode plan (lecture seule)",
+    "description": "Permission mode: read-only planning"
+  },
+  "session.permissionModeBypass": {
+    "message": "Ignorer toutes les autorisations",
+    "description": "Permission mode: bypass all permission prompts"
   }
 }

--- a/src/i18n/it/codingBridge.json
+++ b/src/i18n/it/codingBridge.json
@@ -206,5 +206,25 @@
   "history.codexLabel": {
     "message": "Cronologia Codex (sola lettura)",
     "description": "Replayed Codex session label"
+  },
+  "session.permissionModeLabel": {
+    "message": "Modalità autorizzazioni",
+    "description": "Permission-mode selector label"
+  },
+  "session.permissionModeDefault": {
+    "message": "Predefinito (chiedi ogni volta)",
+    "description": "Permission mode: ask before each tool use"
+  },
+  "session.permissionModeAcceptEdits": {
+    "message": "Accetta automaticamente le modifiche",
+    "description": "Permission mode: auto-accept file edits"
+  },
+  "session.permissionModePlan": {
+    "message": "Modalità pianificazione (sola lettura)",
+    "description": "Permission mode: read-only planning"
+  },
+  "session.permissionModeBypass": {
+    "message": "Ignora tutte le autorizzazioni",
+    "description": "Permission mode: bypass all permission prompts"
   }
 }

--- a/src/i18n/ja/codingBridge.json
+++ b/src/i18n/ja/codingBridge.json
@@ -206,5 +206,25 @@
   "history.codexLabel": {
     "message": "Codex 履歴（読み取り専用）",
     "description": "Replayed Codex session label"
+  },
+  "session.permissionModeLabel": {
+    "message": "権限モード",
+    "description": "Permission-mode selector label"
+  },
+  "session.permissionModeDefault": {
+    "message": "デフォルト（毎回確認）",
+    "description": "Permission mode: ask before each tool use"
+  },
+  "session.permissionModeAcceptEdits": {
+    "message": "編集を自動承認",
+    "description": "Permission mode: auto-accept file edits"
+  },
+  "session.permissionModePlan": {
+    "message": "プランモード（読み取り専用）",
+    "description": "Permission mode: read-only planning"
+  },
+  "session.permissionModeBypass": {
+    "message": "すべての権限をバイパス",
+    "description": "Permission mode: bypass all permission prompts"
   }
 }

--- a/src/i18n/ko/codingBridge.json
+++ b/src/i18n/ko/codingBridge.json
@@ -206,5 +206,25 @@
   "history.codexLabel": {
     "message": "Codex 기록 (읽기 전용)",
     "description": "Replayed Codex session label"
+  },
+  "session.permissionModeLabel": {
+    "message": "권한 모드",
+    "description": "Permission-mode selector label"
+  },
+  "session.permissionModeDefault": {
+    "message": "기본값(매번 확인)",
+    "description": "Permission mode: ask before each tool use"
+  },
+  "session.permissionModeAcceptEdits": {
+    "message": "편집 자동 수락",
+    "description": "Permission mode: auto-accept file edits"
+  },
+  "session.permissionModePlan": {
+    "message": "계획 모드(읽기 전용)",
+    "description": "Permission mode: read-only planning"
+  },
+  "session.permissionModeBypass": {
+    "message": "모든 권한 우회",
+    "description": "Permission mode: bypass all permission prompts"
   }
 }

--- a/src/i18n/pl/codingBridge.json
+++ b/src/i18n/pl/codingBridge.json
@@ -206,5 +206,25 @@
   "history.codexLabel": {
     "message": "Historia Codex (tylko do odczytu)",
     "description": "Replayed Codex session label"
+  },
+  "session.permissionModeLabel": {
+    "message": "Tryb uprawnień",
+    "description": "Permission-mode selector label"
+  },
+  "session.permissionModeDefault": {
+    "message": "Domyślny (pytaj za każdym razem)",
+    "description": "Permission mode: ask before each tool use"
+  },
+  "session.permissionModeAcceptEdits": {
+    "message": "Automatycznie akceptuj zmiany",
+    "description": "Permission mode: auto-accept file edits"
+  },
+  "session.permissionModePlan": {
+    "message": "Tryb planowania (tylko do odczytu)",
+    "description": "Permission mode: read-only planning"
+  },
+  "session.permissionModeBypass": {
+    "message": "Pomiń wszystkie uprawnienia",
+    "description": "Permission mode: bypass all permission prompts"
   }
 }

--- a/src/i18n/pt/codingBridge.json
+++ b/src/i18n/pt/codingBridge.json
@@ -206,5 +206,25 @@
   "history.codexLabel": {
     "message": "Histórico do Codex (somente leitura)",
     "description": "Replayed Codex session label"
+  },
+  "session.permissionModeLabel": {
+    "message": "Modo de permissões",
+    "description": "Permission-mode selector label"
+  },
+  "session.permissionModeDefault": {
+    "message": "Padrão (perguntar sempre)",
+    "description": "Permission mode: ask before each tool use"
+  },
+  "session.permissionModeAcceptEdits": {
+    "message": "Aceitar edições automaticamente",
+    "description": "Permission mode: auto-accept file edits"
+  },
+  "session.permissionModePlan": {
+    "message": "Modo de planejamento (somente leitura)",
+    "description": "Permission mode: read-only planning"
+  },
+  "session.permissionModeBypass": {
+    "message": "Ignorar todas as permissões",
+    "description": "Permission mode: bypass all permission prompts"
   }
 }

--- a/src/i18n/ru/codingBridge.json
+++ b/src/i18n/ru/codingBridge.json
@@ -206,5 +206,25 @@
   "history.codexLabel": {
     "message": "История Codex (только чтение)",
     "description": "Replayed Codex session label"
+  },
+  "session.permissionModeLabel": {
+    "message": "Режим разрешений",
+    "description": "Permission-mode selector label"
+  },
+  "session.permissionModeDefault": {
+    "message": "По умолчанию (спрашивать каждый раз)",
+    "description": "Permission mode: ask before each tool use"
+  },
+  "session.permissionModeAcceptEdits": {
+    "message": "Автоматически принимать правки",
+    "description": "Permission mode: auto-accept file edits"
+  },
+  "session.permissionModePlan": {
+    "message": "Режим планирования (только чтение)",
+    "description": "Permission mode: read-only planning"
+  },
+  "session.permissionModeBypass": {
+    "message": "Обойти все разрешения",
+    "description": "Permission mode: bypass all permission prompts"
   }
 }

--- a/src/i18n/sr/codingBridge.json
+++ b/src/i18n/sr/codingBridge.json
@@ -206,5 +206,25 @@
   "history.codexLabel": {
     "message": "Codex историја (само за читање)",
     "description": "Replayed Codex session label"
+  },
+  "session.permissionModeLabel": {
+    "message": "Режим дозвола",
+    "description": "Permission-mode selector label"
+  },
+  "session.permissionModeDefault": {
+    "message": "Подразумевано (питај сваки пут)",
+    "description": "Permission mode: ask before each tool use"
+  },
+  "session.permissionModeAcceptEdits": {
+    "message": "Аутоматски прихватај измене",
+    "description": "Permission mode: auto-accept file edits"
+  },
+  "session.permissionModePlan": {
+    "message": "Режим планирања (само за читање)",
+    "description": "Permission mode: read-only planning"
+  },
+  "session.permissionModeBypass": {
+    "message": "Заобиђи све дозволе",
+    "description": "Permission mode: bypass all permission prompts"
   }
 }

--- a/src/i18n/sv/codingBridge.json
+++ b/src/i18n/sv/codingBridge.json
@@ -206,5 +206,25 @@
   "history.codexLabel": {
     "message": "Codex-historik (skrivskyddad)",
     "description": "Replayed Codex session label"
+  },
+  "session.permissionModeLabel": {
+    "message": "Behörighetsläge",
+    "description": "Permission-mode selector label"
+  },
+  "session.permissionModeDefault": {
+    "message": "Standard (fråga varje gång)",
+    "description": "Permission mode: ask before each tool use"
+  },
+  "session.permissionModeAcceptEdits": {
+    "message": "Acceptera ändringar automatiskt",
+    "description": "Permission mode: auto-accept file edits"
+  },
+  "session.permissionModePlan": {
+    "message": "Planeringsläge (skrivskyddat)",
+    "description": "Permission mode: read-only planning"
+  },
+  "session.permissionModeBypass": {
+    "message": "Kringgå alla behörigheter",
+    "description": "Permission mode: bypass all permission prompts"
   }
 }

--- a/src/i18n/uk/codingBridge.json
+++ b/src/i18n/uk/codingBridge.json
@@ -206,5 +206,25 @@
   "history.codexLabel": {
     "message": "Історія Codex (лише читання)",
     "description": "Replayed Codex session label"
+  },
+  "session.permissionModeLabel": {
+    "message": "Режим дозволів",
+    "description": "Permission-mode selector label"
+  },
+  "session.permissionModeDefault": {
+    "message": "За замовчуванням (запитувати щоразу)",
+    "description": "Permission mode: ask before each tool use"
+  },
+  "session.permissionModeAcceptEdits": {
+    "message": "Автоматично приймати зміни",
+    "description": "Permission mode: auto-accept file edits"
+  },
+  "session.permissionModePlan": {
+    "message": "Режим планування (лише читання)",
+    "description": "Permission mode: read-only planning"
+  },
+  "session.permissionModeBypass": {
+    "message": "Обійти всі дозволи",
+    "description": "Permission mode: bypass all permission prompts"
   }
 }

--- a/src/i18n/zh-CN/codingBridge.json
+++ b/src/i18n/zh-CN/codingBridge.json
@@ -206,5 +206,25 @@
   "history.codexLabel": {
     "message": "Codex 历史（只读）",
     "description": "回放的 Codex 会话标签"
+  },
+  "session.permissionModeLabel": {
+    "message": "权限模式",
+    "description": "Permission-mode selector label"
+  },
+  "session.permissionModeDefault": {
+    "message": "默认（每次询问）",
+    "description": "Permission mode: ask before each tool use"
+  },
+  "session.permissionModeAcceptEdits": {
+    "message": "自动接受修改",
+    "description": "Permission mode: auto-accept file edits"
+  },
+  "session.permissionModePlan": {
+    "message": "规划模式（只读）",
+    "description": "Permission mode: read-only planning"
+  },
+  "session.permissionModeBypass": {
+    "message": "绕过所有权限",
+    "description": "Permission mode: bypass all permission prompts"
   }
 }

--- a/src/i18n/zh-TW/codingBridge.json
+++ b/src/i18n/zh-TW/codingBridge.json
@@ -206,5 +206,25 @@
   "history.codexLabel": {
     "message": "Codex 歷史（唯讀）",
     "description": "Replayed Codex session label"
+  },
+  "session.permissionModeLabel": {
+    "message": "權限模式",
+    "description": "Permission-mode selector label"
+  },
+  "session.permissionModeDefault": {
+    "message": "預設（每次詢問）",
+    "description": "Permission mode: ask before each tool use"
+  },
+  "session.permissionModeAcceptEdits": {
+    "message": "自動接受修改",
+    "description": "Permission mode: auto-accept file edits"
+  },
+  "session.permissionModePlan": {
+    "message": "規劃模式（唯讀）",
+    "description": "Permission mode: read-only planning"
+  },
+  "session.permissionModeBypass": {
+    "message": "略過所有權限",
+    "description": "Permission mode: bypass all permission prompts"
   }
 }

--- a/src/store/codingBridge/actions.ts
+++ b/src/store/codingBridge/actions.ts
@@ -347,7 +347,7 @@ export const newSession = ({ commit }: ActionContext<ICodingBridgeState, IRootSt
 
 export const sendPrompt = (
   { commit, state }: ActionContext<ICodingBridgeState, IRootState>,
-  payload: { prompt: string; cwd?: string; model?: string }
+  payload: { prompt: string; cwd?: string; model?: string; permissionMode?: string }
 ): void => {
   const nodeId = state.currentNodeId;
   const prompt = payload.prompt?.trim();
@@ -382,7 +382,7 @@ export const sendPrompt = (
       prompt,
       cwd: payload.cwd || existing?.cwd || undefined,
       model: payload.model || existing?.model || undefined,
-      permission_mode: 'default',
+      permission_mode: payload.permissionMode || 'default',
       provider: existing?.provider || undefined,
       resume_session_id: existing?.resume_session_id || undefined
     });


### PR DESCRIPTION
## What

First batch of Coding Bridge composer UX fixes from the parity punch-list. Frontend-only — no agent/relay changes required.

- **Bigger send box** — the prompt textarea now autosizes `minRows: 3 → maxRows: 12` (was `1 → 6`), so multi-line prompts are comfortable to write.
- **IME-safe send (pinyin fix)** — Enter no longer fires mid-composition. `onComposerEnter` ignores the keystroke while `event.isComposing`/`keyCode === 229` (active IME), and any modifier (Shift/Ctrl/Cmd/Alt)+Enter inserts a newline instead of sending. Plain Enter still sends.
- **Model dropdown** — the new-session "Model" field is now an `el-select` (Claude Sonnet / Opus / Haiku) with `filterable allow-create`, so presets are one click but a custom model name can still be typed.
- **Permission-mode selector** — new `el-select` lets you pick `default` / `acceptEdits` / `plan` / `bypassPermissions` per session. The value is threaded through `sendPrompt` → `session.start` `permission_mode` (previously hardcoded to `default`).

## i18n

Added 5 `session.permissionMode*` keys to all 18 locale files (zh-CN base + 17 targets). `scripts/check_i18n_coverage.py` passes (17 locales × 40 namespaces).

## Notes

This is PR 1 of several. Still to come (each its own PR): full remote directory browser for `cwd`, Claude/Codex provider switch + reasoning-effort selector, and image paste — those require new agent-side APIs.

## Validation

- `eslint` clean on changed files
- `vue-tsc --noEmit` exit 0
- `scripts/check_i18n_coverage.py` OK