### PR TITLE
Polish Coding Bridge transcript tool rendering

### DIFF
--- a/change/@acedatacloud-nexior-8ff5be6c-fadb-4ada-8cbf-5f73416ec12a.json
+++ b/change/@acedatacloud-nexior-8ff5be6c-fadb-4ada-8cbf-5f73416ec12a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Polish Coding Bridge transcript: terminal-style tool commands, bounded scroll for tool output",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/codingBridge/TranscriptItem.vue
+++ b/src/components/codingBridge/TranscriptItem.vue
@@ -25,15 +25,32 @@
     <!-- Tool use -->
     <div
       v-else-if="event.kind === 'tool_use'"
-      class="rounded-md bg-[var(--app-sidebar-bg)] border border-[var(--app-border-subtle)] p-2"
+      class="overflow-hidden rounded-md bg-[var(--app-sidebar-bg)] border border-[var(--app-border-subtle)]"
     >
-      <div class="flex items-center gap-2 text-[var(--app-text-subtle)] font-medium">
-        <font-awesome-icon icon="fa-solid fa-code" />
+      <div class="flex items-center gap-2 px-2.5 py-1.5 font-medium text-[var(--app-text-subtle)]">
+        <font-awesome-icon :icon="toolIcon" class="text-[var(--el-color-primary)]" />
         <span>{{ event.tool }}</span>
+        <span v-if="toolDescription" class="min-w-0 truncate text-xs font-normal opacity-70">{{
+          toolDescription
+        }}</span>
       </div>
+      <!-- Shell-style tools render as a terminal command line. -->
+      <div v-if="commandText" class="px-2.5 pb-2">
+        <div
+          class="flex gap-2 overflow-x-auto rounded border border-[var(--app-border-subtle)] bg-[var(--app-content-bg)] px-2.5 py-1.5 font-mono text-xs"
+        >
+          <span class="select-none text-[var(--el-color-success)]">$</span>
+          <span class="whitespace-pre-wrap break-words">{{ commandText }}</span>
+        </div>
+      </div>
+      <!-- File tools show just the target path. -->
+      <div v-else-if="filePath" class="px-2.5 pb-2 font-mono text-xs break-all text-[var(--app-text-subtle)]">
+        {{ filePath }}
+      </div>
+      <!-- Fallback: compact JSON without noisy keys. -->
       <pre
-        v-if="hasInput"
-        class="mt-1 text-xs overflow-x-auto whitespace-pre-wrap break-words text-[var(--app-text-subtle)]"
+        v-else-if="inputText"
+        class="m-0 overflow-x-auto whitespace-pre-wrap break-words px-2.5 pb-2 text-xs text-[var(--app-text-subtle)]"
         >{{ inputText }}</pre
       >
     </div>
@@ -41,14 +58,14 @@
     <!-- Tool result -->
     <div
       v-else-if="event.kind === 'tool_result'"
-      class="rounded-md p-2 text-xs whitespace-pre-wrap break-words overflow-x-auto"
-      :class="
-        event.is_error
-          ? 'bg-[var(--el-color-danger-light-9)] text-[var(--el-color-danger)]'
-          : 'bg-[var(--app-sidebar-bg)] text-[var(--app-text-subtle)]'
-      "
+      class="overflow-hidden rounded-md"
+      :class="event.is_error ? 'bg-[var(--el-color-danger-light-9)]' : 'bg-[var(--app-sidebar-bg)]'"
     >
-      {{ event.content }}
+      <pre
+        class="m-0 max-h-72 overflow-auto whitespace-pre-wrap break-words px-2.5 py-2 font-mono text-xs"
+        :class="event.is_error ? 'text-[var(--el-color-danger)]' : 'text-[var(--app-text-subtle)]'"
+        >{{ resultText }}</pre
+      >
     </div>
 
     <!-- Turn result -->
@@ -84,15 +101,76 @@ export default defineComponent({
     }
   },
   computed: {
-    hasInput(): boolean {
-      return !!this.event.input && Object.keys(this.event.input).length > 0;
+    commandText(): string {
+      const input = this.event.input;
+      if (!input) {
+        return '';
+      }
+      for (const key of ['command', 'cmd', 'script']) {
+        const value = input[key];
+        if (typeof value === 'string' && value.trim()) {
+          return value;
+        }
+      }
+      return '';
+    },
+    filePath(): string {
+      const input = this.event.input;
+      if (!input) {
+        return '';
+      }
+      for (const key of ['file_path', 'filePath', 'path', 'notebook_path', 'filename']) {
+        const value = input[key];
+        if (typeof value === 'string' && value.trim()) {
+          return value;
+        }
+      }
+      return '';
+    },
+    toolDescription(): string {
+      const description = this.event.input?.description;
+      return typeof description === 'string' ? description : '';
+    },
+    toolIcon(): string {
+      if (this.commandText) {
+        return 'fa-solid fa-terminal';
+      }
+      const tool = (this.event.tool ?? '').toLowerCase();
+      if (/read|cat|view/.test(tool)) {
+        return 'fa-solid fa-file-lines';
+      }
+      if (/write|edit|create|update|insert/.test(tool)) {
+        return 'fa-solid fa-pen';
+      }
+      if (/grep|glob|search|find|list/.test(tool)) {
+        return 'fa-solid fa-magnifying-glass';
+      }
+      return 'fa-solid fa-code';
     },
     inputText(): string {
-      try {
-        return JSON.stringify(this.event.input, null, 2);
-      } catch {
-        return String(this.event.input ?? '');
+      const input = this.event.input;
+      if (!input) {
+        return '';
       }
+      const filtered: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(input)) {
+        if (key === 'timeout' || key === 'description') {
+          continue;
+        }
+        filtered[key] = value;
+      }
+      if (Object.keys(filtered).length === 0) {
+        return '';
+      }
+      try {
+        return JSON.stringify(filtered, null, 2);
+      } catch {
+        return String(input);
+      }
+    },
+    resultText(): string {
+      const content = this.event.content;
+      return typeof content === 'string' && content.length > 0 ? content : '—';
     },
     resultLabel(): string {
       const parts: string[] = [];

--- a/src/plugins/font-awesome.ts
+++ b/src/plugins/font-awesome.ts
@@ -134,7 +134,8 @@ import {
   faFileExport as faSolidFileExport,
   faUserXmark as faSolidUserXmark,
   faClockRotateLeft as faSolidClockRotateLeft,
-  faEye as faSolidEye
+  faEye as faSolidEye,
+  faTerminal as faSolidTerminal
 } from '@fortawesome/free-solid-svg-icons';
 // add icons
 library.add(faSolidEllipsis);
@@ -143,6 +144,7 @@ library.add(faSolidGlobe);
 library.add(faRegularLightbulb);
 library.add(faSolidClockRotateLeft);
 library.add(faSolidEye);
+library.add(faSolidTerminal);
 library.add(faSolidIdCard);
 library.add(faSolidStopCircle);
 library.add(faRegularFile);


### PR DESCRIPTION
## What

The Coding Bridge session view replayed remote agent tool calls correctly, but the rendering was hard to read:

- `tool_use` events dumped the raw arguments object as JSON (e.g. `{"command": "...", "description": "...", "timeout": 300000}`).
- `tool_result` events rendered unbounded raw text, so a single long command output (winget logs, download progress, etc.) flooded the transcript.

## Changes (`TranscriptItem.vue`)

- **Shell tools** (`command`/`cmd`/`script`) now render as a terminal-style line: a `$` prompt + the command in a monospaced, bordered block.
- **File tools** (`file_path`/`path`/`notebook_path`/...) show just the target path.
- **Other tools** fall back to compact JSON with the noisy `timeout` / `description` keys stripped.
- The tool's `description` is shown as a muted inline subtitle.
- Per-tool icon (terminal / file / pen / search / code) based on the tool name.
- **`tool_result`** is now monospaced and capped at `max-h-72` with internal scroll, preserving the error styling.

Registered `fa-terminal` in the font-awesome plugin (following the existing registration pattern). No new i18n keys.

## Validation

- `vue-tsc --noEmit` — clean
- `eslint` — clean
- beachball change file included