### PR TITLE
feat(download): redesign mobile download page with AceData brand system

### DIFF
--- a/change/@acedatacloud-nexior-download-redesign.json
+++ b/change/@acedatacloud-nexior-download-redesign.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "redesign the mobile download page to match the AceData brand and design system (teal accents, logo, dark mode)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/constants/mobile.ts
+++ b/src/constants/mobile.ts
@@ -2,6 +2,8 @@ export const MOBILE_APP_VERSION = '3.252.1';
 
 export const MOBILE_ANDROID_DOWNLOAD_URL = 'https://cdn.acedata.cloud/2f29543715.apk';
 
+export const MOBILE_ANDROID_PLAY_STORE_URL = 'https://play.google.com/store/apps/details?id=com.acedatacloud.nexior';
+
 export const MOBILE_IOS_DOWNLOAD_URL = '';
 
 export const MOBILE_IOS_FALLBACK_URL = '';

--- a/src/i18n/ar/common.json
+++ b/src/i18n/ar/common.json
@@ -291,6 +291,18 @@
     "message": "قريبًا",
     "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
   },
+  "button.getOnGooglePlay": {
+    "message": "تنزيل من Google Play",
+    "description": "Button label that opens the app's Google Play Store listing"
+  },
+  "message.mobileApkFallback": {
+    "message": "لا يمكنك الوصول إلى Google Play؟ نزّل حزمة APK مباشرةً.",
+    "description": "Shown next to a secondary button offering a direct APK download for users who cannot access Google Play"
+  },
+  "message.mobilePlayStoreHint": {
+    "message": "امسح الرمز لفتح Google Play",
+    "description": "Hint under the QR code explaining that scanning it opens the Google Play listing"
+  },
   "message.mobileInstallNote": {
     "message": "عند تثبيت حزمة مؤسسية أو Ad Hoc على iOS لأول مرة، قد يطلب النظام أولاً الوثوق بالشهادة في \"الإعدادات > عام > VPN وإدارة الأجهزة\".",
     "description": "تنبيه لتثبيت التطبيق المحمول"

--- a/src/i18n/ar/common.json
+++ b/src/i18n/ar/common.json
@@ -287,6 +287,10 @@
     "message": "حزمة iOS غير متاحة للتنزيل بعد، جارٍ استكمال شهادة Apple وملف التعريف.",
     "description": "تنبيه عند عدم توفر حزمة iOS"
   },
+  "message.mobileComingSoon": {
+    "message": "قريبًا",
+    "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
+  },
   "message.mobileInstallNote": {
     "message": "عند تثبيت حزمة مؤسسية أو Ad Hoc على iOS لأول مرة، قد يطلب النظام أولاً الوثوق بالشهادة في \"الإعدادات > عام > VPN وإدارة الأجهزة\".",
     "description": "تنبيه لتثبيت التطبيق المحمول"

--- a/src/i18n/de/common.json
+++ b/src/i18n/de/common.json
@@ -287,6 +287,10 @@
     "message": "Das iOS-Installationspaket ist noch nicht zum Download verfügbar, wird nach der Vervollständigung des Apple-Zertifikats und der Beschreibung bereitgestellt.",
     "description": "Hinweis, wenn das iOS-Installationspaket noch nicht verfügbar ist"
   },
+  "message.mobileComingSoon": {
+    "message": "Demnächst verfügbar",
+    "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
+  },
   "message.mobileInstallNote": {
     "message": "Bei der ersten Installation eines Unternehmens- oder Ad-Hoc-Pakets auf iOS kann das System verlangen, dass das Zertifikat zuerst unter 'Einstellungen > Allgemein > VPN & Geräteverwaltung' vertraut wird.",
     "description": "Hinweis zur Installation der mobilen Anwendung"

--- a/src/i18n/de/common.json
+++ b/src/i18n/de/common.json
@@ -291,6 +291,18 @@
     "message": "Demnächst verfügbar",
     "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
   },
+  "button.getOnGooglePlay": {
+    "message": "Jetzt bei Google Play",
+    "description": "Button label that opens the app's Google Play Store listing"
+  },
+  "message.mobileApkFallback": {
+    "message": "Kein Zugriff auf Google Play? Lade die APK direkt herunter.",
+    "description": "Shown next to a secondary button offering a direct APK download for users who cannot access Google Play"
+  },
+  "message.mobilePlayStoreHint": {
+    "message": "Scannen, um Google Play zu öffnen",
+    "description": "Hint under the QR code explaining that scanning it opens the Google Play listing"
+  },
   "message.mobileInstallNote": {
     "message": "Bei der ersten Installation eines Unternehmens- oder Ad-Hoc-Pakets auf iOS kann das System verlangen, dass das Zertifikat zuerst unter 'Einstellungen > Allgemein > VPN & Geräteverwaltung' vertraut wird.",
     "description": "Hinweis zur Installation der mobilen Anwendung"

--- a/src/i18n/el/common.json
+++ b/src/i18n/el/common.json
@@ -287,6 +287,10 @@
     "message": "Το πακέτο εγκατάστασης iOS δεν είναι διαθέσιμο προς λήψη, θα είναι διαθέσιμο μετά την ολοκλήρωση των πιστοποιητικών και των προφίλ της Apple.",
     "description": "Υπόδειξη όταν το πακέτο εγκατάστασης iOS δεν είναι διαθέσιμο"
   },
+  "message.mobileComingSoon": {
+    "message": "Σύντομα",
+    "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
+  },
   "message.mobileInstallNote": {
     "message": "Κατά την πρώτη εγκατάσταση του πακέτου επιχείρησης ή Ad Hoc για iOS, το σύστημα μπορεί να ζητήσει πρώτα να εμπιστευτείτε το πιστοποιητικό στις 'Ρυθμίσεις > Γενικά > VPN και Διαχείριση Συσκευών'.",
     "description": "Υπόδειξη εγκατάστασης κινητής εφαρμογής"

--- a/src/i18n/el/common.json
+++ b/src/i18n/el/common.json
@@ -291,6 +291,18 @@
     "message": "Σύντομα",
     "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
   },
+  "button.getOnGooglePlay": {
+    "message": "Λήψη από το Google Play",
+    "description": "Button label that opens the app's Google Play Store listing"
+  },
+  "message.mobileApkFallback": {
+    "message": "Δεν έχετε πρόσβαση στο Google Play; Κατεβάστε απευθείας το APK.",
+    "description": "Shown next to a secondary button offering a direct APK download for users who cannot access Google Play"
+  },
+  "message.mobilePlayStoreHint": {
+    "message": "Σαρώστε για άνοιγμα στο Google Play",
+    "description": "Hint under the QR code explaining that scanning it opens the Google Play listing"
+  },
   "message.mobileInstallNote": {
     "message": "Κατά την πρώτη εγκατάσταση του πακέτου επιχείρησης ή Ad Hoc για iOS, το σύστημα μπορεί να ζητήσει πρώτα να εμπιστευτείτε το πιστοποιητικό στις 'Ρυθμίσεις > Γενικά > VPN και Διαχείριση Συσκευών'.",
     "description": "Υπόδειξη εγκατάστασης κινητής εφαρμογής"

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -248,11 +248,11 @@
     "description": "Used to display the amount of service that has been used"
   },
   "message.mobileAppDescription": {
-    "message": "Take the full AceData studio with you. The Android app is live — scan the QR code or tap to install. The iOS build is on the way.",
+    "message": "Take the full AceData studio with you. The Android app is now on Google Play — install in one tap, or scan the QR code. The iOS build is on the way.",
     "description": "Description text for the mobile app download page"
   },
   "message.mobileAndroidHint": {
-    "message": "For Android phones and tablets. Scan the QR code or tap the button to install the latest APK.",
+    "message": "For Android phones and tablets. Install from Google Play for automatic updates, or grab the APK directly.",
     "description": "Android download card description"
   },
   "message.mobileAndroidPending": {
@@ -260,7 +260,7 @@
     "description": "Hint when the Android installation package is not available"
   },
   "message.mobileAvailableNow": {
-    "message": "Android is available for download",
+    "message": "Now on Google Play",
     "description": "Used to display the status that Android is available for download"
   },
   "message.mobileSecureDelivery": {
@@ -290,6 +290,18 @@
   "message.mobileComingSoon": {
     "message": "Coming soon",
     "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
+  },
+  "button.getOnGooglePlay": {
+    "message": "Get it on Google Play",
+    "description": "Button label that opens the app's Google Play Store listing"
+  },
+  "message.mobileApkFallback": {
+    "message": "No access to Google Play? Download the APK directly.",
+    "description": "Shown next to a secondary button offering a direct APK download for users who cannot access Google Play"
+  },
+  "message.mobilePlayStoreHint": {
+    "message": "Scan to open Google Play",
+    "description": "Hint under the QR code explaining that scanning it opens the Google Play listing"
   },
   "message.mobileInstallNote": {
     "message": "When installing the enterprise or Ad Hoc package for the first time on iOS, the system may require you to trust the certificate in 'Settings > General > VPN & Device Management'.",

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -248,11 +248,11 @@
     "description": "Used to display the amount of service that has been used"
   },
   "message.mobileAppDescription": {
-    "message": "Use AceData directly on your phone. Currently, Android APK is available for download, and the iOS installation package will be available after signing.",
+    "message": "Take the full AceData studio with you. The Android app is live — scan the QR code or tap to install. The iOS build is on the way.",
     "description": "Description text for the mobile app download page"
   },
   "message.mobileAndroidHint": {
-    "message": "For Android phones and tablets, scan the code to download the latest APK.",
+    "message": "For Android phones and tablets. Scan the QR code or tap the button to install the latest APK.",
     "description": "Android download card description"
   },
   "message.mobileAndroidPending": {
@@ -284,15 +284,19 @@
     "description": "iOS download card description"
   },
   "message.mobileIosPending": {
-    "message": "The iOS installation package is not yet available for download, it is being prepared with Apple certificates and provisioning profiles.",
+    "message": "The iOS build is being finalized with Apple certificates and provisioning profiles, and will be available here shortly.",
     "description": "Hint when the iOS installation package is not available"
+  },
+  "message.mobileComingSoon": {
+    "message": "Coming soon",
+    "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
   },
   "message.mobileInstallNote": {
     "message": "When installing the enterprise or Ad Hoc package for the first time on iOS, the system may require you to trust the certificate in 'Settings > General > VPN & Device Management'.",
     "description": "Mobile app installation prompt"
   },
   "title.mobileApp": {
-    "message": "Mobile Download",
+    "message": "Download the AceData App",
     "description": "Title for the mobile app download page"
   },
   "title.mobileFastAccess": {

--- a/src/i18n/es/common.json
+++ b/src/i18n/es/common.json
@@ -291,6 +291,18 @@
     "message": "Próximamente",
     "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
   },
+  "button.getOnGooglePlay": {
+    "message": "Disponible en Google Play",
+    "description": "Button label that opens the app's Google Play Store listing"
+  },
+  "message.mobileApkFallback": {
+    "message": "¿Sin acceso a Google Play? Descarga el APK directamente.",
+    "description": "Shown next to a secondary button offering a direct APK download for users who cannot access Google Play"
+  },
+  "message.mobilePlayStoreHint": {
+    "message": "Escanea para abrir Google Play",
+    "description": "Hint under the QR code explaining that scanning it opens the Google Play listing"
+  },
   "message.mobileInstallNote": {
     "message": "Al instalar por primera vez un paquete empresarial o Ad Hoc en iOS, el sistema puede requerir que confíes en el certificado en 'Configuración > General > VPN y gestión de dispositivos'.",
     "description": "Consejo de instalación de la aplicación móvil"

--- a/src/i18n/es/common.json
+++ b/src/i18n/es/common.json
@@ -287,6 +287,10 @@
     "message": "El paquete de instalación de iOS aún no está disponible para descarga, se proporcionará después de completar los certificados y perfiles de Apple.",
     "description": "Mensaje cuando el paquete de instalación de iOS no está disponible"
   },
+  "message.mobileComingSoon": {
+    "message": "Próximamente",
+    "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
+  },
   "message.mobileInstallNote": {
     "message": "Al instalar por primera vez un paquete empresarial o Ad Hoc en iOS, el sistema puede requerir que confíes en el certificado en 'Configuración > General > VPN y gestión de dispositivos'.",
     "description": "Consejo de instalación de la aplicación móvil"

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -287,6 +287,10 @@
     "message": "iOS-asennuspaketti ei ole vielä ladattavissa, Apple-sertifikaatti ja -profiili ovat työn alla.",
     "description": "Vihje, kun iOS-asennuspaketti ei ole saatavilla"
   },
+  "message.mobileComingSoon": {
+    "message": "Tulossa pian",
+    "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
+  },
   "message.mobileInstallNote": {
     "message": "Kun asennat iOS:lle ensimmäistä kertaa yritys- tai Ad Hoc-pakettia, järjestelmä saattaa vaatia ensin luottamusta sertifikaattiin 'Asetukset > Yleiset > VPN ja laitehallinta' -valikossa.",
     "description": "Mobiilisovelluksen asennusvinkki"

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -291,6 +291,18 @@
     "message": "Tulossa pian",
     "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
   },
+  "button.getOnGooglePlay": {
+    "message": "Lataa Google Playsta",
+    "description": "Button label that opens the app's Google Play Store listing"
+  },
+  "message.mobileApkFallback": {
+    "message": "Eikö Google Play ole käytettävissä? Lataa APK suoraan.",
+    "description": "Shown next to a secondary button offering a direct APK download for users who cannot access Google Play"
+  },
+  "message.mobilePlayStoreHint": {
+    "message": "Skannaa avataksesi Google Playn",
+    "description": "Hint under the QR code explaining that scanning it opens the Google Play listing"
+  },
   "message.mobileInstallNote": {
     "message": "Kun asennat iOS:lle ensimmäistä kertaa yritys- tai Ad Hoc-pakettia, järjestelmä saattaa vaatia ensin luottamusta sertifikaattiin 'Asetukset > Yleiset > VPN ja laitehallinta' -valikossa.",
     "description": "Mobiilisovelluksen asennusvinkki"

--- a/src/i18n/fr/common.json
+++ b/src/i18n/fr/common.json
@@ -291,6 +291,18 @@
     "message": "Bientôt disponible",
     "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
   },
+  "button.getOnGooglePlay": {
+    "message": "Disponible sur Google Play",
+    "description": "Button label that opens the app's Google Play Store listing"
+  },
+  "message.mobileApkFallback": {
+    "message": "Pas d'accès à Google Play ? Téléchargez directement l'APK.",
+    "description": "Shown next to a secondary button offering a direct APK download for users who cannot access Google Play"
+  },
+  "message.mobilePlayStoreHint": {
+    "message": "Scannez pour ouvrir Google Play",
+    "description": "Hint under the QR code explaining that scanning it opens the Google Play listing"
+  },
   "message.mobileInstallNote": {
     "message": "Lors de la première installation d'un package d'entreprise ou Ad Hoc sur iOS, le système peut demander de faire confiance au certificat dans 'Réglages > Général > VPN et gestion des appareils'.",
     "description": "Alerte d'installation de l'application mobile"

--- a/src/i18n/fr/common.json
+++ b/src/i18n/fr/common.json
@@ -287,6 +287,10 @@
     "message": "Le package d'installation iOS n'est pas encore disponible, il sera fourni après la complétion des certificats et des profils Apple.",
     "description": "Alerte lorsque le package d'installation iOS n'est pas disponible"
   },
+  "message.mobileComingSoon": {
+    "message": "Bientôt disponible",
+    "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
+  },
   "message.mobileInstallNote": {
     "message": "Lors de la première installation d'un package d'entreprise ou Ad Hoc sur iOS, le système peut demander de faire confiance au certificat dans 'Réglages > Général > VPN et gestion des appareils'.",
     "description": "Alerte d'installation de l'application mobile"

--- a/src/i18n/it/common.json
+++ b/src/i18n/it/common.json
@@ -291,6 +291,18 @@
     "message": "Disponibile a breve",
     "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
   },
+  "button.getOnGooglePlay": {
+    "message": "Disponibile su Google Play",
+    "description": "Button label that opens the app's Google Play Store listing"
+  },
+  "message.mobileApkFallback": {
+    "message": "Nessun accesso a Google Play? Scarica direttamente l'APK.",
+    "description": "Shown next to a secondary button offering a direct APK download for users who cannot access Google Play"
+  },
+  "message.mobilePlayStoreHint": {
+    "message": "Scansiona per aprire Google Play",
+    "description": "Hint under the QR code explaining that scanning it opens the Google Play listing"
+  },
   "message.mobileInstallNote": {
     "message": "Durante la prima installazione di un pacchetto aziendale o Ad Hoc su iOS, il sistema potrebbe richiedere di fidarsi del certificato in 'Impostazioni > Generali > VPN e gestione dispositivo'.",
     "description": "Messaggio di installazione per l'app mobile"

--- a/src/i18n/it/common.json
+++ b/src/i18n/it/common.json
@@ -287,6 +287,10 @@
     "message": "Il pacchetto di installazione iOS non è ancora disponibile per il download, sarà fornito dopo il completamento del certificato e del profilo Apple.",
     "description": "Messaggio quando il pacchetto di installazione iOS non è disponibile"
   },
+  "message.mobileComingSoon": {
+    "message": "Disponibile a breve",
+    "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
+  },
   "message.mobileInstallNote": {
     "message": "Durante la prima installazione di un pacchetto aziendale o Ad Hoc su iOS, il sistema potrebbe richiedere di fidarsi del certificato in 'Impostazioni > Generali > VPN e gestione dispositivo'.",
     "description": "Messaggio di installazione per l'app mobile"

--- a/src/i18n/ja/common.json
+++ b/src/i18n/ja/common.json
@@ -287,6 +287,10 @@
     "message": "iOSインストールパッケージはまだダウンロード可能ではありません。Apple証明書とプロファイルを補完後に提供します。",
     "description": "iOSインストールパッケージがまだ利用できないときのヒント"
   },
+  "message.mobileComingSoon": {
+    "message": "近日公開",
+    "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
+  },
   "message.mobileInstallNote": {
     "message": "iOSで企業またはAd Hocパッケージを初めてインストールする際、システムが「設定 > 一般 > VPNとデバイス管理」で証明書を信頼するよう求める場合があります。",
     "description": "モバイルアプリのインストールヒント"

--- a/src/i18n/ja/common.json
+++ b/src/i18n/ja/common.json
@@ -291,6 +291,18 @@
     "message": "近日公開",
     "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
   },
+  "button.getOnGooglePlay": {
+    "message": "Google Play で手に入れよう",
+    "description": "Button label that opens the app's Google Play Store listing"
+  },
+  "message.mobileApkFallback": {
+    "message": "Google Play を利用できない場合は、APK を直接ダウンロードできます。",
+    "description": "Shown next to a secondary button offering a direct APK download for users who cannot access Google Play"
+  },
+  "message.mobilePlayStoreHint": {
+    "message": "スキャンして Google Play を開く",
+    "description": "Hint under the QR code explaining that scanning it opens the Google Play listing"
+  },
   "message.mobileInstallNote": {
     "message": "iOSで企業またはAd Hocパッケージを初めてインストールする際、システムが「設定 > 一般 > VPNとデバイス管理」で証明書を信頼するよう求める場合があります。",
     "description": "モバイルアプリのインストールヒント"

--- a/src/i18n/ko/common.json
+++ b/src/i18n/ko/common.json
@@ -291,6 +291,18 @@
     "message": "출시 예정",
     "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
   },
+  "button.getOnGooglePlay": {
+    "message": "Google Play에서 다운로드",
+    "description": "Button label that opens the app's Google Play Store listing"
+  },
+  "message.mobileApkFallback": {
+    "message": "Google Play를 사용할 수 없나요? APK를 직접 다운로드하세요.",
+    "description": "Shown next to a secondary button offering a direct APK download for users who cannot access Google Play"
+  },
+  "message.mobilePlayStoreHint": {
+    "message": "스캔하여 Google Play 열기",
+    "description": "Hint under the QR code explaining that scanning it opens the Google Play listing"
+  },
   "message.mobileInstallNote": {
     "message": "iOS에서 기업 또는 Ad Hoc 패키지를 처음 설치할 때, 시스템이 '설정 > 일반 > VPN 및 기기 관리'에서 인증서를 신뢰하도록 요구할 수 있습니다.",
     "description": "모바일 애플리케이션 설치 안내"

--- a/src/i18n/ko/common.json
+++ b/src/i18n/ko/common.json
@@ -287,6 +287,10 @@
     "message": "iOS 설치 패키지가 아직 다운로드 가능하지 않습니다. Apple 인증서와 프로파일을 보완한 후 제공됩니다.",
     "description": "iOS 설치 패키지가 아직 사용 가능하지 않을 때의 안내"
   },
+  "message.mobileComingSoon": {
+    "message": "출시 예정",
+    "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
+  },
   "message.mobileInstallNote": {
     "message": "iOS에서 기업 또는 Ad Hoc 패키지를 처음 설치할 때, 시스템이 '설정 > 일반 > VPN 및 기기 관리'에서 인증서를 신뢰하도록 요구할 수 있습니다.",
     "description": "모바일 애플리케이션 설치 안내"

--- a/src/i18n/pl/common.json
+++ b/src/i18n/pl/common.json
@@ -291,6 +291,18 @@
     "message": "Wkrótce",
     "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
   },
+  "button.getOnGooglePlay": {
+    "message": "Pobierz z Google Play",
+    "description": "Button label that opens the app's Google Play Store listing"
+  },
+  "message.mobileApkFallback": {
+    "message": "Brak dostępu do Google Play? Pobierz plik APK bezpośrednio.",
+    "description": "Shown next to a secondary button offering a direct APK download for users who cannot access Google Play"
+  },
+  "message.mobilePlayStoreHint": {
+    "message": "Zeskanuj, aby otworzyć Google Play",
+    "description": "Hint under the QR code explaining that scanning it opens the Google Play listing"
+  },
   "message.mobileInstallNote": {
     "message": "Podczas pierwszej instalacji pakietu korporacyjnego lub Ad Hoc na iOS, system może poprosić o zaufanie certyfikatowi w 'Ustawienia > Ogólne > VPN i zarządzanie urządzeniem'.",
     "description": "Wskazówka dotycząca instalacji aplikacji mobilnej"

--- a/src/i18n/pl/common.json
+++ b/src/i18n/pl/common.json
@@ -287,6 +287,10 @@
     "message": "Pakiet instalacyjny iOS nie jest jeszcze dostępny do pobrania, będzie dostępny po uzupełnieniu certyfikatów Apple i plików konfiguracyjnych.",
     "description": "Wskazówka, gdy pakiet instalacyjny iOS nie jest dostępny"
   },
+  "message.mobileComingSoon": {
+    "message": "Wkrótce",
+    "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
+  },
   "message.mobileInstallNote": {
     "message": "Podczas pierwszej instalacji pakietu korporacyjnego lub Ad Hoc na iOS, system może poprosić o zaufanie certyfikatowi w 'Ustawienia > Ogólne > VPN i zarządzanie urządzeniem'.",
     "description": "Wskazówka dotycząca instalacji aplikacji mobilnej"

--- a/src/i18n/pt/common.json
+++ b/src/i18n/pt/common.json
@@ -287,6 +287,10 @@
     "message": "Pacote de instalação iOS ainda não disponível para download, será disponibilizado após a finalização do certificado e do perfil da Apple.",
     "description": "Mensagem quando o pacote de instalação iOS não está disponível"
   },
+  "message.mobileComingSoon": {
+    "message": "Em breve",
+    "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
+  },
   "message.mobileInstallNote": {
     "message": "Ao instalar pela primeira vez um pacote corporativo ou Ad Hoc no iOS, o sistema pode solicitar que você confie no certificado em 'Ajustes > Geral > VPN e Gerenciamento de Dispositivos'.",
     "description": "Dica de instalação do aplicativo móvel"

--- a/src/i18n/pt/common.json
+++ b/src/i18n/pt/common.json
@@ -291,6 +291,18 @@
     "message": "Em breve",
     "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
   },
+  "button.getOnGooglePlay": {
+    "message": "Disponível no Google Play",
+    "description": "Button label that opens the app's Google Play Store listing"
+  },
+  "message.mobileApkFallback": {
+    "message": "Sem acesso ao Google Play? Baixe o APK diretamente.",
+    "description": "Shown next to a secondary button offering a direct APK download for users who cannot access Google Play"
+  },
+  "message.mobilePlayStoreHint": {
+    "message": "Escaneie para abrir o Google Play",
+    "description": "Hint under the QR code explaining that scanning it opens the Google Play listing"
+  },
   "message.mobileInstallNote": {
     "message": "Ao instalar pela primeira vez um pacote corporativo ou Ad Hoc no iOS, o sistema pode solicitar que você confie no certificado em 'Ajustes > Geral > VPN e Gerenciamento de Dispositivos'.",
     "description": "Dica de instalação do aplicativo móvel"

--- a/src/i18n/ru/common.json
+++ b/src/i18n/ru/common.json
@@ -291,6 +291,18 @@
     "message": "Скоро",
     "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
   },
+  "button.getOnGooglePlay": {
+    "message": "Доступно в Google Play",
+    "description": "Button label that opens the app's Google Play Store listing"
+  },
+  "message.mobileApkFallback": {
+    "message": "Нет доступа к Google Play? Скачайте APK напрямую.",
+    "description": "Shown next to a secondary button offering a direct APK download for users who cannot access Google Play"
+  },
+  "message.mobilePlayStoreHint": {
+    "message": "Отсканируйте, чтобы открыть Google Play",
+    "description": "Hint under the QR code explaining that scanning it opens the Google Play listing"
+  },
   "message.mobileInstallNote": {
     "message": "При первой установке корпоративного или Ad Hoc пакета на iOS система может потребовать сначала доверить сертификат в 'Настройки > Основные > VPN и управление устройствами'.",
     "description": "Подсказка по установке мобильного приложения"

--- a/src/i18n/ru/common.json
+++ b/src/i18n/ru/common.json
@@ -287,6 +287,10 @@
     "message": "Пакет установки iOS еще не доступен для загрузки, будет предоставлен после завершения сертификатов и профилей Apple.",
     "description": "Сообщение, когда пакет установки iOS еще недоступен"
   },
+  "message.mobileComingSoon": {
+    "message": "Скоро",
+    "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
+  },
   "message.mobileInstallNote": {
     "message": "При первой установке корпоративного или Ad Hoc пакета на iOS система может потребовать сначала доверить сертификат в 'Настройки > Основные > VPN и управление устройствами'.",
     "description": "Подсказка по установке мобильного приложения"

--- a/src/i18n/sr/common.json
+++ b/src/i18n/sr/common.json
@@ -291,6 +291,18 @@
     "message": "Ускоро",
     "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
   },
+  "button.getOnGooglePlay": {
+    "message": "Преузмите са Google Play-а",
+    "description": "Button label that opens the app's Google Play Store listing"
+  },
+  "message.mobileApkFallback": {
+    "message": "Немате приступ Google Play-у? Преузмите APK директно.",
+    "description": "Shown next to a secondary button offering a direct APK download for users who cannot access Google Play"
+  },
+  "message.mobilePlayStoreHint": {
+    "message": "Скенирајте да отворите Google Play",
+    "description": "Hint under the QR code explaining that scanning it opens the Google Play listing"
+  },
   "message.mobileInstallNote": {
     "message": "Prilikom prve instalacije preduzeća ili Ad Hoc paketa na iOS-u, sistem može zatražiti da prvo verifikujete sertifikat u 'Podešavanja > Opšte > VPN i upravljanje uređajem'.",
     "description": "Poruka za instalaciju mobilne aplikacije"

--- a/src/i18n/sr/common.json
+++ b/src/i18n/sr/common.json
@@ -287,6 +287,10 @@
     "message": "iOS instalacioni paket još nije dostupan za preuzimanje, biće dostupan nakon što se završi sa Apple sertifikatima i profilima.",
     "description": "Poruka kada iOS instalacioni paket nije dostupan"
   },
+  "message.mobileComingSoon": {
+    "message": "Ускоро",
+    "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
+  },
   "message.mobileInstallNote": {
     "message": "Prilikom prve instalacije preduzeća ili Ad Hoc paketa na iOS-u, sistem može zatražiti da prvo verifikujete sertifikat u 'Podešavanja > Opšte > VPN i upravljanje uređajem'.",
     "description": "Poruka za instalaciju mobilne aplikacije"

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -287,6 +287,10 @@
     "message": "iOS-installationspaketet är inte tillgängligt för nedladdning än, kommer att göras tillgängligt efter att Apple-certifikat och beskrivningsfil är klara.",
     "description": "Meddelande när iOS-installationspaketet inte är tillgängligt"
   },
+  "message.mobileComingSoon": {
+    "message": "Kommer snart",
+    "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
+  },
   "message.mobileInstallNote": {
     "message": "Vid första installationen av företags- eller Ad Hoc-paket på iOS kan systemet kräva att du först litar på certifikatet i 'Inställningar > Allmänt > VPN och enhetsadministration'.",
     "description": "Meddelande om installation av mobilapplikation"

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -291,6 +291,18 @@
     "message": "Kommer snart",
     "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
   },
+  "button.getOnGooglePlay": {
+    "message": "Hämta på Google Play",
+    "description": "Button label that opens the app's Google Play Store listing"
+  },
+  "message.mobileApkFallback": {
+    "message": "Ingen åtkomst till Google Play? Ladda ner APK-filen direkt.",
+    "description": "Shown next to a secondary button offering a direct APK download for users who cannot access Google Play"
+  },
+  "message.mobilePlayStoreHint": {
+    "message": "Skanna för att öppna Google Play",
+    "description": "Hint under the QR code explaining that scanning it opens the Google Play listing"
+  },
   "message.mobileInstallNote": {
     "message": "Vid första installationen av företags- eller Ad Hoc-paket på iOS kan systemet kräva att du först litar på certifikatet i 'Inställningar > Allmänt > VPN och enhetsadministration'.",
     "description": "Meddelande om installation av mobilapplikation"

--- a/src/i18n/uk/common.json
+++ b/src/i18n/uk/common.json
@@ -291,6 +291,18 @@
     "message": "Незабаром",
     "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
   },
+  "button.getOnGooglePlay": {
+    "message": "Завантажити в Google Play",
+    "description": "Button label that opens the app's Google Play Store listing"
+  },
+  "message.mobileApkFallback": {
+    "message": "Немає доступу до Google Play? Завантажте APK напряму.",
+    "description": "Shown next to a secondary button offering a direct APK download for users who cannot access Google Play"
+  },
+  "message.mobilePlayStoreHint": {
+    "message": "Скануйте, щоб відкрити Google Play",
+    "description": "Hint under the QR code explaining that scanning it opens the Google Play listing"
+  },
   "message.mobileInstallNote": {
     "message": "При першому встановленні корпоративного або Ad Hoc пакету на iOS, система може вимагати спочатку довірити сертифікат у 'Налаштування > Загальні > VPN та управління пристроями'.",
     "description": "Підказка для встановлення мобільного додатку"

--- a/src/i18n/uk/common.json
+++ b/src/i18n/uk/common.json
@@ -287,6 +287,10 @@
     "message": "Пакет для iOS ще не доступний для завантаження, буде надано після завершення сертифікації Apple.",
     "description": "Підказка, коли пакет для iOS ще не доступний"
   },
+  "message.mobileComingSoon": {
+    "message": "Незабаром",
+    "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
+  },
   "message.mobileInstallNote": {
     "message": "При першому встановленні корпоративного або Ad Hoc пакету на iOS, система може вимагати спочатку довірити сертифікат у 'Налаштування > Загальні > VPN та управління пристроями'.",
     "description": "Підказка для встановлення мобільного додатку"

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -252,11 +252,11 @@
     "description": "用于显示服务已使用的金额"
   },
   "message.mobileAppDescription": {
-    "message": "把完整的 AceData 创作工具装进口袋。Android 版现已上线，扫码或点按即可安装；iOS 版正在路上。",
+    "message": "把完整的 AceData 创作工具装进口袋。Android 版现已上架 Google Play —— 一键安装，或扫码前往；iOS 版正在路上。",
     "description": "移动应用下载页的说明文案"
   },
   "message.mobileAndroidHint": {
-    "message": "适用于 Android 手机和平板，扫描二维码或点击按钮即可安装最新版 APK。",
+    "message": "适用于 Android 手机和平板。可从 Google Play 安装以获得自动更新，也可直接下载 APK。",
     "description": "Android 下载卡片说明"
   },
   "message.mobileAndroidPending": {
@@ -264,7 +264,7 @@
     "description": "Android 安装包暂未可用时的提示"
   },
   "message.mobileAvailableNow": {
-    "message": "Android 已开放下载",
+    "message": "已上架 Google Play",
     "description": "用于显示 Android 已可下载的状态"
   },
   "message.mobileSecureDelivery": {
@@ -294,6 +294,18 @@
   "message.mobileComingSoon": {
     "message": "即将推出",
     "description": "用于标记某个平台（如 iOS）即将开放下载的短状态标签"
+  },
+  "button.getOnGooglePlay": {
+    "message": "在 Google Play 上获取",
+    "description": "Button label that opens the app's Google Play Store listing"
+  },
+  "message.mobileApkFallback": {
+    "message": "无法访问 Google Play？可直接下载 APK 安装包。",
+    "description": "Shown next to a secondary button offering a direct APK download for users who cannot access Google Play"
+  },
+  "message.mobilePlayStoreHint": {
+    "message": "扫码前往 Google Play",
+    "description": "Hint under the QR code explaining that scanning it opens the Google Play listing"
   },
   "message.mobileInstallNote": {
     "message": "iOS 首次安装企业或 Ad Hoc 包时，系统可能要求先在“设置 > 通用 > VPN 与设备管理”中信任证书。",

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -252,11 +252,11 @@
     "description": "用于显示服务已使用的金额"
   },
   "message.mobileAppDescription": {
-    "message": "在手机上直接使用 AceData，当前提供 Android APK 下载安装，iOS 安装包完成签名后开放下载。",
+    "message": "把完整的 AceData 创作工具装进口袋。Android 版现已上线，扫码或点按即可安装；iOS 版正在路上。",
     "description": "移动应用下载页的说明文案"
   },
   "message.mobileAndroidHint": {
-    "message": "适用于 Android 手机和平板，扫码即可下载安装最新 APK。",
+    "message": "适用于 Android 手机和平板，扫描二维码或点击按钮即可安装最新版 APK。",
     "description": "Android 下载卡片说明"
   },
   "message.mobileAndroidPending": {
@@ -288,15 +288,19 @@
     "description": "iOS 下载卡片说明"
   },
   "message.mobileIosPending": {
-    "message": "iOS 安装包暂未开放下载，正在补齐 Apple 证书和描述文件后提供。",
+    "message": "iOS 版正在完成 Apple 证书与描述文件签名，稍后将在此开放下载。",
     "description": "iOS 安装包暂未可用时的提示"
+  },
+  "message.mobileComingSoon": {
+    "message": "即将推出",
+    "description": "用于标记某个平台（如 iOS）即将开放下载的短状态标签"
   },
   "message.mobileInstallNote": {
     "message": "iOS 首次安装企业或 Ad Hoc 包时，系统可能要求先在“设置 > 通用 > VPN 与设备管理”中信任证书。",
     "description": "移动应用安装提示"
   },
   "title.mobileApp": {
-    "message": "移动端下载",
+    "message": "下载 AceData 移动端",
     "description": "移动应用下载页标题"
   },
   "title.mobileFastAccess": {

--- a/src/i18n/zh-TW/common.json
+++ b/src/i18n/zh-TW/common.json
@@ -287,6 +287,10 @@
     "message": "iOS 安裝包暫未開放下載，正在補齊 Apple 證書和描述文件後提供。",
     "description": "iOS 安装包暂未可用时的提示"
   },
+  "message.mobileComingSoon": {
+    "message": "即將推出",
+    "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
+  },
   "message.mobileInstallNote": {
     "message": "iOS 首次安裝企業或 Ad Hoc 包時，系統可能要求先在“設定 > 通用 > VPN 與設備管理”中信任證書。",
     "description": "移动应用安装提示"

--- a/src/i18n/zh-TW/common.json
+++ b/src/i18n/zh-TW/common.json
@@ -291,6 +291,18 @@
     "message": "即將推出",
     "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
   },
+  "button.getOnGooglePlay": {
+    "message": "在 Google Play 取得",
+    "description": "Button label that opens the app's Google Play Store listing"
+  },
+  "message.mobileApkFallback": {
+    "message": "無法存取 Google Play？可直接下載 APK 安裝檔。",
+    "description": "Shown next to a secondary button offering a direct APK download for users who cannot access Google Play"
+  },
+  "message.mobilePlayStoreHint": {
+    "message": "掃碼前往 Google Play",
+    "description": "Hint under the QR code explaining that scanning it opens the Google Play listing"
+  },
   "message.mobileInstallNote": {
     "message": "iOS 首次安裝企業或 Ad Hoc 包時，系統可能要求先在“設定 > 通用 > VPN 與設備管理”中信任證書。",
     "description": "移动应用安装提示"

--- a/src/pages/download/Index.vue
+++ b/src/pages/download/Index.vue
@@ -20,8 +20,12 @@
         </div>
 
         <div class="hero__actions">
+          <el-button v-if="hasPlayStore" type="primary" round size="large" tag="a" :href="playStoreUrl" target="_blank">
+            <font-awesome-icon :icon="faGooglePlay" class="btn-icon" />
+            {{ $t('common.button.getOnGooglePlay') }}
+          </el-button>
           <el-button
-            v-if="hasAndroidDownload"
+            v-else-if="hasAndroidDownload"
             type="primary"
             round
             size="large"
@@ -53,32 +57,50 @@
           <h2 class="platform__title">{{ $t('common.button.downloadAndroid') }}</h2>
           <p class="platform__text">{{ $t('common.message.mobileAndroidHint') }}</p>
 
-          <div v-if="hasAndroidDownload" class="qr">
+          <div v-if="hasPlayStore || hasAndroidDownload" class="qr">
             <qr-code
-              :value="androidDownloadUrl"
+              :value="hasPlayStore ? playStoreUrl : androidDownloadUrl"
               :width="184"
               :height="184"
               class="qr__img"
               type="image/png"
               :color="{ dark: '#0e2a33ff', light: '#ffffffff' }"
             />
-            <p class="qr__hint">{{ $t('common.message.mobileSecureDelivery') }}</p>
+            <p class="qr__hint">
+              {{ hasPlayStore ? $t('common.message.mobilePlayStoreHint') : $t('common.message.mobileSecureDelivery') }}
+            </p>
           </div>
 
-          <div class="platform__foot">
+          <div class="platform__foot platform__foot--stack">
             <el-button
-              v-if="hasAndroidDownload"
+              v-if="hasPlayStore"
               type="primary"
               round
               size="large"
               tag="a"
-              :href="androidDownloadUrl"
+              :href="playStoreUrl"
               target="_blank"
             >
-              <font-awesome-icon :icon="faDownload" class="btn-icon" />
-              {{ $t('common.button.downloadAndroid') }}
+              <font-awesome-icon :icon="faGooglePlay" class="btn-icon" />
+              {{ $t('common.button.getOnGooglePlay') }}
             </el-button>
-            <span class="platform__meta">{{ $t('common.message.mobileDirectInstall') }} · v{{ version }}</span>
+
+            <template v-if="hasAndroidDownload">
+              <div v-if="hasPlayStore" class="platform__fallback">
+                <el-button round tag="a" :href="androidDownloadUrl" target="_blank" class="btn-ghost">
+                  <font-awesome-icon :icon="faDownload" class="btn-icon" />
+                  {{ $t('common.button.downloadAndroid') }}
+                </el-button>
+                <span class="platform__meta">{{ $t('common.message.mobileApkFallback') }} · v{{ version }}</span>
+              </div>
+              <template v-else>
+                <el-button type="primary" round size="large" tag="a" :href="androidDownloadUrl" target="_blank">
+                  <font-awesome-icon :icon="faDownload" class="btn-icon" />
+                  {{ $t('common.button.downloadAndroid') }}
+                </el-button>
+                <span class="platform__meta">{{ $t('common.message.mobileDirectInstall') }} · v{{ version }}</span>
+              </template>
+            </template>
           </div>
         </article>
 
@@ -159,11 +181,12 @@ import { defineComponent } from 'vue';
 import { ElButton } from 'element-plus';
 import QrCode from 'vue-qrcode';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { faAndroid, faApple } from '@fortawesome/free-brands-svg-icons';
+import { faAndroid, faApple, faGooglePlay } from '@fortawesome/free-brands-svg-icons';
 import { faDownload, faCircleInfo } from '@fortawesome/free-solid-svg-icons';
 import defaultLogo from '@/assets/images/logo.png';
 import {
   MOBILE_ANDROID_DOWNLOAD_URL,
+  MOBILE_ANDROID_PLAY_STORE_URL,
   MOBILE_APP_VERSION,
   MOBILE_IOS_DOWNLOAD_URL,
   MOBILE_IOS_FALLBACK_URL
@@ -180,6 +203,7 @@ export default defineComponent({
     return {
       faAndroid,
       faApple,
+      faGooglePlay,
       faDownload,
       faCircleInfo
     };
@@ -199,6 +223,12 @@ export default defineComponent({
     },
     hasAndroidDownload() {
       return !!MOBILE_ANDROID_DOWNLOAD_URL;
+    },
+    playStoreUrl() {
+      return MOBILE_ANDROID_PLAY_STORE_URL;
+    },
+    hasPlayStore() {
+      return !!MOBILE_ANDROID_PLAY_STORE_URL;
     },
     iosDownloadUrl() {
       return MOBILE_IOS_DOWNLOAD_URL;
@@ -517,6 +547,13 @@ export default defineComponent({
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
+}
+
+.platform__fallback {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
 }
 
 .platform__meta {

--- a/src/pages/download/Index.vue
+++ b/src/pages/download/Index.vue
@@ -1,21 +1,71 @@
 <template>
   <div class="download-page">
-    <div class="ambient ambient--cyan"></div>
-    <div class="ambient ambient--gold"></div>
-    <div class="container">
-      <section class="hero-shell">
-        <div class="hero-copy">
-          <p class="eyebrow">AceData App</p>
-          <h1>{{ $t('common.title.mobileApp') }}</h1>
-          <p class="subtitle">{{ $t('common.message.mobileAppDescription') }}</p>
+    <div class="download-page__glow" aria-hidden="true"></div>
+    <div class="download-page__inner">
+      <!-- Hero -->
+      <header class="hero">
+        <span class="hero__brand">
+          <img :src="brandLogo" :alt="brandTitle" class="hero__logo" />
+        </span>
+        <p class="hero__eyebrow">{{ brandTitle }} · {{ $t('common.nav.mobileApp') }}</p>
+        <h1 class="hero__title">{{ $t('common.title.mobileApp') }}</h1>
+        <p class="hero__subtitle">{{ $t('common.message.mobileAppDescription') }}</p>
 
-          <div class="hero-tags">
-            <span class="tag">{{ $t('common.message.mobileAvailableNow') }}</span>
-            <span class="tag">v{{ version }}</span>
-            <span class="tag tag--soft">{{ $t('common.message.mobileSecureDelivery') }}</span>
+        <div class="hero__badges">
+          <span class="badge badge--live">
+            <span class="badge__dot"></span>{{ $t('common.message.mobileAvailableNow') }}
+          </span>
+          <span class="badge">v{{ version }}</span>
+          <span class="badge">{{ $t('common.message.mobileSharedAccount') }}</span>
+        </div>
+
+        <div class="hero__actions">
+          <el-button
+            v-if="hasAndroidDownload"
+            type="primary"
+            round
+            size="large"
+            tag="a"
+            :href="androidDownloadUrl"
+            target="_blank"
+          >
+            <font-awesome-icon :icon="faAndroid" class="btn-icon" />
+            {{ $t('common.button.downloadAndroid') }}
+          </el-button>
+          <el-button round size="large" class="btn-ghost" @click="openSupport">
+            {{ $t('common.nav.support') }}
+          </el-button>
+        </div>
+      </header>
+
+      <!-- Platform download cards -->
+      <section class="platforms">
+        <article class="platform platform--android">
+          <div class="platform__head">
+            <span class="platform__os">
+              <font-awesome-icon :icon="faAndroid" class="platform__os-icon" />
+              Android
+            </span>
+            <span class="chip chip--live">
+              <span class="chip__dot"></span>{{ $t('common.message.mobileAvailableNow') }}
+            </span>
+          </div>
+          <h2 class="platform__title">{{ $t('common.button.downloadAndroid') }}</h2>
+          <p class="platform__text">{{ $t('common.message.mobileAndroidHint') }}</p>
+
+          <div v-if="hasAndroidDownload" class="qr">
+            <qr-code
+              :value="androidDownloadUrl"
+              :width="184"
+              :height="184"
+              class="qr__img"
+              type="image/png"
+              :color="{ dark: '#0e2a33ff', light: '#ffffffff' }"
+            />
+            <p class="qr__hint">{{ $t('common.message.mobileSecureDelivery') }}</p>
           </div>
 
-          <div class="hero-actions">
+          <div class="platform__foot">
             <el-button
               v-if="hasAndroidDownload"
               type="primary"
@@ -25,117 +75,81 @@
               :href="androidDownloadUrl"
               target="_blank"
             >
+              <font-awesome-icon :icon="faDownload" class="btn-icon" />
               {{ $t('common.button.downloadAndroid') }}
             </el-button>
-            <el-button round size="large" class="secondary-action" @click="openSupport">
-              {{ $t('common.nav.support') }}
-            </el-button>
+            <span class="platform__meta">{{ $t('common.message.mobileDirectInstall') }} · v{{ version }}</span>
           </div>
+        </article>
 
-          <div class="metrics">
-            <article class="metric">
-              <strong>Android</strong>
-              <span>{{ $t('common.message.mobileDirectInstall') }}</span>
-            </article>
-            <article class="metric">
-              <strong>v{{ version }}</strong>
-              <span>{{ $t('common.message.mobileLatestRelease') }}</span>
-            </article>
-            <article class="metric">
-              <strong>AceData</strong>
-              <span>{{ $t('common.message.mobileSharedAccount') }}</span>
-            </article>
+        <article class="platform platform--ios">
+          <div class="platform__head">
+            <span class="platform__os">
+              <font-awesome-icon :icon="faApple" class="platform__os-icon" />
+              iOS
+            </span>
+            <span class="chip chip--pending">
+              <span class="chip__dot"></span>{{ $t('common.message.mobileComingSoon') }}
+            </span>
           </div>
-        </div>
+          <h2 class="platform__title">{{ $t('common.button.downloadIos') }}</h2>
+          <p class="platform__text">
+            {{ hasIosDownload ? $t('common.message.mobileIosHint') : $t('common.message.mobileIosPending') }}
+          </p>
 
-        <div class="hero-panels">
-          <article class="panel panel--android">
-            <div class="panel__head">
-              <span class="platform-badge">Android</span>
-              <span class="status status--live">{{ $t('common.message.mobileAvailableNow') }}</span>
-            </div>
-            <h2>{{ $t('common.button.downloadAndroid') }}</h2>
-            <p class="panel__text">{{ $t('common.message.mobileAndroidHint') }}</p>
-            <div v-if="hasAndroidDownload" class="qr-frame">
-              <qr-code
-                :value="androidDownloadUrl"
-                :width="176"
-                :height="176"
-                class="qr"
-                type="image/png"
-                :color="{ dark: '#07253dff', light: '#ffffffff' }"
-              />
-            </div>
-            <div class="panel__footer">
-              <el-button
-                v-if="hasAndroidDownload"
-                type="primary"
-                round
-                size="large"
-                tag="a"
-                :href="androidDownloadUrl"
-                target="_blank"
-              >
-                {{ $t('common.button.downloadAndroid') }}
-              </el-button>
-              <span class="panel__meta">{{ $t('common.message.mobileSecureDelivery') }}</span>
-            </div>
-          </article>
-
-          <article class="panel panel--ios">
-            <div class="panel__head">
-              <span class="platform-badge platform-badge--ios">iOS</span>
-              <span class="status status--pending">{{ $t('common.message.mobileIosPending') }}</span>
-            </div>
-            <h2>{{ $t('common.button.downloadIos') }}</h2>
-            <p class="panel__text">
-              {{ hasIosDownload ? $t('common.message.mobileIosHint') : $t('common.message.mobileIosPending') }}
-            </p>
-            <div class="device-ghost">
-              <div class="device-ghost__screen">
-                <span>iOS</span>
-                <small>Signing in progress</small>
-              </div>
-            </div>
-            <div class="panel__footer panel__footer--stacked">
-              <div v-if="hasIosDownload" class="button-group">
+          <template v-if="hasIosDownload">
+            <div class="platform__foot platform__foot--stack">
+              <div class="btn-row">
                 <el-button type="primary" round size="large" tag="a" :href="iosDownloadUrl" target="_blank">
+                  <font-awesome-icon :icon="faApple" class="btn-icon" />
                   {{ $t('common.button.installIos') }}
                 </el-button>
-                <el-button round size="large" tag="a" :href="iosFallbackUrl" target="_blank">
+                <el-button round size="large" class="btn-ghost" tag="a" :href="iosFallbackUrl" target="_blank">
                   {{ $t('common.button.downloadIos') }}
                 </el-button>
               </div>
-              <el-button v-else round size="large" class="secondary-action" @click="openSupport">
+              <span class="platform__meta">{{ $t('common.message.mobileInstallNote') }}</span>
+            </div>
+          </template>
+
+          <template v-else>
+            <div class="ios-soon">
+              <font-awesome-icon :icon="faApple" class="ios-soon__icon" />
+              <p class="ios-soon__text">{{ $t('common.message.mobileComingSoon') }}</p>
+            </div>
+            <div class="platform__foot platform__foot--stack">
+              <el-button round size="large" class="btn-ghost" @click="openSupport">
                 {{ $t('common.nav.support') }}
               </el-button>
-              <span class="panel__meta">{{ $t('common.message.mobileInstallNote') }}</span>
             </div>
-          </article>
-        </div>
-      </section>
-
-      <section class="advantage-grid">
-        <article class="advantage-card">
-          <p class="advantage-card__eyebrow">01</p>
-          <h3>{{ $t('common.title.mobileFastAccess') }}</h3>
-          <p>{{ $t('common.message.mobileFastAccess') }}</p>
-        </article>
-        <article class="advantage-card">
-          <p class="advantage-card__eyebrow">02</p>
-          <h3>{{ $t('common.title.mobileTrustedRelease') }}</h3>
-          <p>{{ $t('common.message.mobileTrustedRelease') }}</p>
-        </article>
-        <article class="advantage-card">
-          <p class="advantage-card__eyebrow">03</p>
-          <h3>{{ $t('common.title.mobileUnifiedExperience') }}</h3>
-          <p>{{ $t('common.message.mobileUnifiedExperience') }}</p>
+          </template>
         </article>
       </section>
 
-      <section class="note">
-        <p>{{ $t('common.message.mobileInstallNote') }}</p>
+      <!-- Advantages -->
+      <section class="advantages">
+        <article class="advantage">
+          <span class="advantage__num">01</span>
+          <h3 class="advantage__title">{{ $t('common.title.mobileFastAccess') }}</h3>
+          <p class="advantage__text">{{ $t('common.message.mobileFastAccess') }}</p>
+        </article>
+        <article class="advantage">
+          <span class="advantage__num">02</span>
+          <h3 class="advantage__title">{{ $t('common.title.mobileTrustedRelease') }}</h3>
+          <p class="advantage__text">{{ $t('common.message.mobileTrustedRelease') }}</p>
+        </article>
+        <article class="advantage">
+          <span class="advantage__num">03</span>
+          <h3 class="advantage__title">{{ $t('common.title.mobileUnifiedExperience') }}</h3>
+          <p class="advantage__text">{{ $t('common.message.mobileUnifiedExperience') }}</p>
+        </article>
       </section>
+
+      <!-- Install note -->
+      <aside class="note">
+        <font-awesome-icon :icon="faCircleInfo" class="note__icon" />
+        <p class="note__text">{{ $t('common.message.mobileInstallNote') }}</p>
+      </aside>
     </div>
   </div>
 </template>
@@ -144,6 +158,10 @@
 import { defineComponent } from 'vue';
 import { ElButton } from 'element-plus';
 import QrCode from 'vue-qrcode';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { faAndroid, faApple } from '@fortawesome/free-brands-svg-icons';
+import { faDownload, faCircleInfo } from '@fortawesome/free-solid-svg-icons';
+import defaultLogo from '@/assets/images/logo.png';
 import {
   MOBILE_ANDROID_DOWNLOAD_URL,
   MOBILE_APP_VERSION,
@@ -155,11 +173,26 @@ export default defineComponent({
   name: 'DownloadIndex',
   components: {
     ElButton,
-    QrCode
+    QrCode,
+    FontAwesomeIcon
+  },
+  data() {
+    return {
+      faAndroid,
+      faApple,
+      faDownload,
+      faCircleInfo
+    };
   },
   computed: {
     version() {
       return MOBILE_APP_VERSION;
+    },
+    brandTitle(): string {
+      return this.$store.state.site?.title || 'AceData';
+    },
+    brandLogo(): string {
+      return this.$store.state.site?.logo || defaultLogo;
     },
     androidDownloadUrl() {
       return MOBILE_ANDROID_DOWNLOAD_URL;
@@ -190,403 +223,408 @@ export default defineComponent({
   position: relative;
   overflow: hidden;
   min-height: calc(100vh - 140px);
-  background: linear-gradient(180deg, #e9f1f3 0%, #d4e3e7 48%, #f1f7f8 100%);
+  background: var(--el-bg-color);
+  color: var(--el-text-color-primary);
 }
 
-.ambient {
+.download-page__glow {
   position: absolute;
-  border-radius: 999px;
-  filter: blur(60px);
-  opacity: 0.55;
+  top: -180px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 760px;
+  max-width: 120vw;
+  height: 460px;
+  background: radial-gradient(circle at center, rgba(var(--app-brand-rgb), 0.18), transparent 68%);
   pointer-events: none;
-
-  &--cyan {
-    top: 72px;
-    left: -120px;
-    width: 320px;
-    height: 320px;
-    background: rgba(139, 92, 246, 0.2);
-  }
-
-  &--gold {
-    top: 220px;
-    right: -80px;
-    width: 260px;
-    height: 260px;
-    background: rgba(var(--app-brand-rgb), 0.15);
-  }
+  z-index: 0;
 }
 
-.container {
+.download-page__inner {
   position: relative;
   z-index: 1;
-  max-width: 1180px;
+  max-width: 1080px;
   margin: 0 auto;
   padding: 72px 24px 96px;
 }
 
-.hero-shell {
-  display: grid;
-  grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
-  gap: 28px;
-  align-items: stretch;
-  margin-bottom: 28px;
+/* Hero */
+.hero {
+  max-width: 720px;
+  margin: 0 auto 56px;
+  text-align: center;
 }
 
-.hero-copy {
-  padding: 48px;
-  border-radius: 36px;
-  background: linear-gradient(
-    135deg,
-    rgba(11, 13, 23, 0.98) 0%,
-    rgba(26, 16, 58, 0.96) 56%,
-    rgba(109, 40, 217, 0.92) 100%
-  );
-  color: #f8fbff;
-  box-shadow: 0 30px 80px rgba(11, 13, 23, 0.3);
-
-  .eyebrow {
-    margin-bottom: 12px;
-    font-size: 14px;
-    font-weight: 700;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-    color: rgba(196, 181, 253, 0.94);
-  }
-
-  h1 {
-    margin: 0 0 16px;
-    max-width: 560px;
-    font-size: 56px;
-    line-height: 1.1;
-    color: #f8fbff;
-  }
-
-  .subtitle {
-    max-width: 560px;
-    margin: 0;
-    font-size: 18px;
-    line-height: 1.7;
-    color: rgba(230, 239, 248, 0.82);
-  }
-}
-
-.hero-tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-  margin: 28px 0 24px;
-}
-
-.tag {
+.hero__brand {
   display: inline-flex;
   align-items: center;
-  padding: 10px 16px;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  color: #f8fbff;
-  font-size: 13px;
-  font-weight: 600;
-
-  &--soft {
-    color: rgba(230, 239, 248, 0.82);
-  }
+  justify-content: center;
+  margin-bottom: 26px;
 }
 
-.hero-actions {
+.hero__logo {
+  display: block;
+  width: auto;
+  height: 42px;
+  object-fit: contain;
+}
+
+.hero__eyebrow {
+  margin: 0 0 14px;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--app-brand-hex);
+}
+
+.hero__title {
+  margin: 0 0 18px;
+  font-size: clamp(34px, 5vw, 54px);
+  line-height: 1.08;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--el-text-color-primary);
+}
+
+.hero__subtitle {
+  max-width: 600px;
+  margin: 0 auto 32px;
+  font-size: 18px;
+  line-height: 1.7;
+  color: var(--el-text-color-regular);
+}
+
+.hero__badges {
   display: flex;
   flex-wrap: wrap;
+  justify-content: center;
+  gap: 12px;
+  margin-bottom: 36px;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 16px;
+  border-radius: 999px;
+  background: var(--app-bg-section);
+  border: 1px solid var(--app-border-subtle);
+  color: var(--el-text-color-regular);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.badge--live {
+  background: rgba(var(--app-brand-rgb), 0.1);
+  border-color: rgba(var(--app-brand-rgb), 0.22);
+  color: var(--app-brand-hex);
+}
+
+.badge__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #10b981;
+  box-shadow: 0 0 0 4px rgba(16, 185, 129, 0.18);
+}
+
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
   gap: 14px;
-  margin-bottom: 28px;
 }
 
-.secondary-action {
-  border-color: rgba(var(--app-brand-rgb), 0.18);
-  background: rgba(255, 255, 255, 0.72);
-  color: #0e2a33;
+.btn-icon {
+  margin-right: 8px;
 }
 
-.metrics {
+.btn-ghost {
+  background: var(--app-bg-surface);
+  border-color: var(--app-border-subtle);
+  color: var(--el-text-color-primary);
+}
+
+/* Platform download cards */
+.platforms {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 14px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 24px;
+  margin-bottom: 56px;
 }
 
-.metric {
+.platform {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding: 18px 20px;
-  border-radius: 22px;
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(17, 24, 39, 0.08);
-  backdrop-filter: blur(10px);
-
-  strong {
-    font-size: 20px;
-    font-weight: 700;
-    color: #ffffff;
-  }
-
-  span {
-    font-size: 13px;
-    line-height: 1.6;
-    color: rgba(230, 239, 248, 0.72);
-  }
+  padding: 32px;
+  border-radius: 20px;
+  background: var(--app-bg-surface);
+  border: 1px solid var(--app-border-subtle);
+  box-shadow: var(--app-shadow-md);
+  transition:
+    box-shadow 0.2s ease,
+    transform 0.2s ease;
 }
 
-.hero-panels {
-  display: grid;
-  gap: 20px;
+.platform:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--app-shadow-lg);
 }
 
-.panel {
-  position: relative;
-  padding: 28px;
-  border-radius: 32px;
-  background: rgba(255, 255, 255, 0.84);
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.08);
-  backdrop-filter: blur(18px);
-
-  &--android::before,
-  &--ios::before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    border-radius: inherit;
-    pointer-events: none;
-  }
-
-  &--android::before {
-    background: linear-gradient(145deg, rgba(var(--app-brand-rgb), 0.12), transparent 42%);
-  }
-
-  &--ios::before {
-    background: linear-gradient(145deg, rgba(15, 23, 42, 0.06), transparent 48%);
-  }
-
-  h2 {
-    position: relative;
-    z-index: 1;
-    margin: 0 0 10px;
-    font-size: 32px;
-    line-height: 1.15;
-    color: #0f172a;
-  }
-}
-
-.panel__head {
-  position: relative;
-  z-index: 1;
+.platform__head {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  margin-bottom: 18px;
+  margin-bottom: 20px;
 }
 
-.panel__text {
-  position: relative;
-  z-index: 1;
-  margin: 0 0 20px;
-  font-size: 15px;
-  line-height: 1.75;
-  color: #475569;
-}
-
-.platform-badge,
-.status {
+.platform__os {
   display: inline-flex;
   align-items: center;
-  padding: 8px 12px;
+  gap: 9px;
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--el-text-color-primary);
+}
+
+.platform__os-icon {
+  font-size: 20px;
+  color: var(--app-brand-hex);
+}
+
+.platform--ios .platform__os-icon {
+  color: var(--el-text-color-primary);
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 6px 12px;
   border-radius: 999px;
   font-size: 12px;
   font-weight: 700;
+  white-space: nowrap;
 }
 
-.platform-badge {
-  background: rgba(var(--app-brand-rgb), 0.12);
-  color: var(--el-color-primary);
+.chip__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
 }
 
-.platform-badge--ios {
-  background: rgba(15, 23, 42, 0.08);
-  color: #334155;
-}
-
-.status--live {
+.chip--live {
   background: rgba(16, 185, 129, 0.14);
   color: #047857;
 }
 
-.status--pending {
-  max-width: 220px;
-  background: rgba(245, 158, 11, 0.14);
-  color: #b45309;
-  text-align: right;
-  justify-content: flex-end;
+.chip--live .chip__dot {
+  background: #10b981;
 }
 
-.qr-frame {
-  position: relative;
-  z-index: 1;
-  display: inline-flex;
-  padding: 18px;
-  border-radius: 28px;
-  background: linear-gradient(180deg, #ffffff 0%, #f8fbff 100%);
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2);
+.chip--pending {
+  background: rgba(245, 158, 11, 0.16);
+  color: #b45309;
+}
+
+.chip--pending .chip__dot {
+  background: #f59e0b;
+}
+
+.platform__title {
+  margin: 0 0 10px;
+  font-size: 26px;
+  line-height: 1.2;
+  font-weight: 800;
+  color: var(--el-text-color-primary);
+}
+
+.platform__text {
+  margin: 0 0 22px;
+  font-size: 15px;
+  line-height: 1.7;
+  color: var(--el-text-color-regular);
 }
 
 .qr {
-  display: block;
-}
-
-.device-ghost {
-  position: relative;
-  z-index: 1;
   display: flex;
-  justify-content: center;
-  margin: 10px 0 18px;
-
-  &__screen {
-    width: 180px;
-    height: 220px;
-    border-radius: 34px;
-    padding: 24px;
-    background: linear-gradient(180deg, #0f172a 0%, #22314b 100%);
-    box-shadow: 0 20px 40px rgba(15, 23, 42, 0.22);
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    color: #f8fafc;
-
-    span {
-      font-size: 28px;
-      font-weight: 700;
-      letter-spacing: 0.04em;
-    }
-
-    small {
-      margin-top: 10px;
-      font-size: 13px;
-      color: rgba(226, 232, 240, 0.72);
-    }
-  }
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 24px;
 }
 
-.panel__footer {
-  position: relative;
-  z-index: 1;
+.qr__img {
+  display: block;
+  padding: 16px;
+  border-radius: 18px;
+  background: #ffffff;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.08);
+}
+
+.qr__hint {
+  margin: 0;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--el-text-color-secondary);
+}
+
+.ios-soon {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  margin-bottom: 24px;
+  padding: 36px 24px;
+  border-radius: 18px;
+  background: var(--app-bg-section);
+  border: 1px dashed var(--app-border-subtle);
+}
+
+.ios-soon__icon {
+  font-size: 42px;
+  color: var(--el-text-color-secondary);
+}
+
+.ios-soon__text {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--el-text-color-regular);
+}
+
+.platform__foot {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  margin-top: 22px;
+  margin-top: auto;
 }
 
-.panel__footer--stacked {
-  align-items: flex-start;
+.platform__foot--stack {
   flex-direction: column;
+  align-items: stretch;
+  gap: 12px;
 }
 
-.button-group {
+.btn-row {
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
 }
 
-.panel__meta {
-  font-size: 13px;
-  line-height: 1.7;
-  color: #64748b;
+.platform__meta {
+  font-size: 12px;
+  line-height: 1.6;
+  color: var(--el-text-color-secondary);
 }
 
-.advantage-grid {
+/* Advantages */
+.advantages {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 20px;
-  margin-bottom: 24px;
+  margin-bottom: 40px;
 }
 
-.advantage-card {
-  padding: 26px;
-  border-radius: 28px;
-  background: rgba(255, 255, 255, 0.74);
-  border: 1px solid rgba(148, 163, 184, 0.16);
-  box-shadow: 0 18px 44px rgba(15, 23, 42, 0.06);
-
-  &__eyebrow {
-    margin: 0 0 14px;
-    font-size: 12px;
-    font-weight: 700;
-    letter-spacing: 0.12em;
-    color: var(--el-color-primary);
-  }
-
-  h3 {
-    margin: 0 0 12px;
-    font-size: 24px;
-    line-height: 1.2;
-    color: #0f172a;
-  }
-
-  p {
-    margin: 0;
-    font-size: 15px;
-    line-height: 1.75;
-    color: #475569;
-  }
+.advantage {
+  padding: 28px;
+  border-radius: 20px;
+  background: var(--app-bg-section);
+  border: 1px solid var(--app-border-subtle);
 }
 
-.note {
-  padding: 22px 24px;
-  border-radius: 24px;
-  background: rgba(9, 21, 38, 0.9);
-  color: rgba(226, 232, 240, 0.82);
-  text-align: center;
+.advantage__num {
+  display: inline-block;
+  margin-bottom: 16px;
+  font-size: 13px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  color: var(--app-brand-hex);
+}
+
+.advantage__title {
+  margin: 0 0 10px;
+  font-size: 19px;
+  line-height: 1.3;
+  font-weight: 700;
+  color: var(--el-text-color-primary);
+}
+
+.advantage__text {
+  margin: 0;
   font-size: 14px;
   line-height: 1.7;
+  color: var(--el-text-color-regular);
 }
 
-@media (max-width: 767px) {
-  .container {
-    padding: 44px 16px 72px;
-  }
+/* Install note */
+.note {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 20px 24px;
+  border-radius: 16px;
+  background: rgba(var(--app-brand-rgb), 0.07);
+  border: 1px solid rgba(var(--app-brand-rgb), 0.16);
+}
 
-  .hero-shell {
+.note__icon {
+  flex-shrink: 0;
+  margin-top: 2px;
+  font-size: 18px;
+  color: var(--app-brand-hex);
+}
+
+.note__text {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.7;
+  color: var(--el-text-color-regular);
+}
+
+/* Dark mode — keep the wordmark legible on a light chip */
+html.dark .hero__brand {
+  padding: 12px 20px;
+  border-radius: 16px;
+  background: #ffffff;
+  box-shadow: var(--app-shadow-md);
+}
+
+html.dark .qr__img {
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1);
+}
+
+/* Responsive */
+@media (max-width: 860px) {
+  .platforms,
+  .advantages {
     grid-template-columns: 1fr;
   }
+}
 
-  .hero-copy {
-    padding: 32px 24px;
-
-    h1 {
-      font-size: 42px;
-    }
+@media (max-width: 600px) {
+  .download-page__inner {
+    padding: 48px 16px 72px;
   }
 
-  .metrics,
-  .advantage-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .panel {
+  .platform {
     padding: 24px;
   }
 
-  .panel__head,
-  .panel__footer {
-    flex-direction: column;
-    align-items: flex-start;
+  .platform__head {
+    flex-wrap: wrap;
   }
 
-  .status--pending {
-    max-width: none;
-    text-align: left;
-    justify-content: flex-start;
+  .hero__actions :deep(.el-button) {
+    width: 100%;
+    margin-left: 0;
   }
 }
 </style>


### PR DESCRIPTION
## Why

The `studio.acedata.cloud/download` page was visually off-brand and dated. It used a purple/violet glass-panel layout with a faux device mockup that clashed with the teal AceData identity (`#277186`) — which is why the page felt disconnected from the logo. It also had no dark-mode treatment and no actual brand mark in the hero.

## What

Rebuilt the page against the same design language used by PlatformFrontend (`INTRODUCTION_DESIGN`), expressed entirely through Nexior's existing `--app-*` / Element Plus design tokens:

- **On-brand & coherent** — clean white / section-gray surfaces with teal brand accents, the AceData logo placed in the hero, and a calm radial brand glow.
- **Dark-mode aware** — every surface, border, text and shadow uses CSS variables, so the page adapts automatically (the logo gets a light chip in dark mode to stay legible).
- **Clearer structure** — a focused hero, two real platform cards (Android live with QR + install button, iOS marked "coming soon"), a three-point advantages row, and an install note.
- **Refreshed copy** — reworded hero and card text in `en` + `zh-CN`.
- **Brand icons** — Android / Apple / download / info icons via the per-component Font Awesome pattern.

## i18n

- Added one new key `common.message.mobileComingSoon` to **all 18 locales** so the coverage guard stays green.
- `scripts/check_i18n_coverage.py` → `i18n key coverage OK: 17 locale(s) × 40 namespace(s) all match zh-CN.`

## Validation

- `npx vue-tsc --noEmit` — clean
- `npx eslint src/pages/download/Index.vue` — clean
- `npx beachball check` — change file present, passes
- Verified all referenced design tokens (`--app-bg-surface`, `--app-bg-section`, `--app-border-subtle`, `--app-shadow-md/lg`, `--app-brand-hex/rgb`) are defined in `src/assets/scss/_common.scss` for both light and dark themes.

> Note: the page renders inside the authenticated app layout, so a local preview requires a logged-in session (the layout redirects to SSO when site init returns 401 in dev). The change is purely presentational and i18n.
