### PR TITLE
Render Coding Bridge assistant text as markdown

### DIFF
--- a/change/@acedatacloud-nexior-f950f39f-33f8-461b-8b8f-6c83d3ea76f9.json
+++ b/change/@acedatacloud-nexior-f950f39f-33f8-461b-8b8f-6c83d3ea76f9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Render Coding Bridge assistant transcript text as markdown",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/codingBridge/TranscriptItem.vue
+++ b/src/components/codingBridge/TranscriptItem.vue
@@ -9,10 +9,13 @@
       </div>
     </div>
 
-    <!-- Assistant text -->
-    <div v-else-if="event.kind === 'text'" class="whitespace-pre-wrap break-words text-[var(--app-text)]">
-      {{ event.text }}
-    </div>
+    <!-- Assistant text (markdown) -->
+    <vue-markdown
+      v-else-if="event.kind === 'text'"
+      v-highlight
+      :source="event.text || ''"
+      class="markdown-body bg-transparent text-[var(--app-text)]"
+    />
 
     <!-- Thinking -->
     <div
@@ -87,12 +90,19 @@
 <script lang="ts">
 import { defineComponent, PropType } from 'vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import VueMarkdown from '@/components/common/VueMarkdown.vue';
+import { highlight } from '@/utils';
 import { ICodingBridgeEvent } from '@/models';
+import 'highlight.js/styles/night-owl.css';
 
 export default defineComponent({
   name: 'CodingBridgeTranscriptItem',
+  directives: {
+    highlight
+  },
   components: {
-    FontAwesomeIcon
+    FontAwesomeIcon,
+    VueMarkdown
   },
   props: {
     event: {
@@ -187,3 +197,39 @@ export default defineComponent({
   }
 });
 </script>
+
+<style lang="scss">
+/* Unscoped: VueMarkdown emits raw HTML, so the base github-markdown
+   styles must reach those elements. Bundler dedupes the shared import. */
+@import 'github-markdown-css/github-markdown.css';
+</style>
+
+<style lang="scss" scoped>
+.transcript-item :deep(.markdown-body) {
+  background: transparent;
+  color: inherit;
+  font-size: inherit;
+  line-height: inherit;
+
+  > :first-child {
+    margin-top: 0;
+  }
+  > :last-child {
+    margin-bottom: 0;
+  }
+
+  ol {
+    list-style: decimal;
+  }
+  ul {
+    list-style: disc;
+  }
+
+  pre {
+    border-radius: 6px;
+  }
+  pre code {
+    color: #fff;
+  }
+}
+</style>


### PR DESCRIPTION
## What

Assistant `text` events in the Coding Bridge transcript were rendered as raw plain text (`whitespace-pre-wrap`), so markdown the agent emitted — headings, lists, **bold**, inline `code`, fenced code blocks, tables — showed up as literal syntax.

## Change

Reuse Nexior's existing `VueMarkdown` component (the same markdown-it + KaTeX renderer used by chat) for the assistant `text` block:

- `text` events now render through `<vue-markdown>` with the `v-highlight` directive for syntax-highlighted code blocks.
- Pulled in `github-markdown-css` (unscoped, deduped by the bundler) + scoped overrides so the body is transparent, inherits the transcript's text color, and trims leading/trailing margins.
- User `prompt` and `thinking` blocks stay plain (prompts are user input; thinking is shown muted/italic).

No new i18n keys.

## Validation

- `vue-tsc --noEmit` — clean
- `eslint` — clean
- `vite build` — succeeds
- beachball change file included