### PR TITLE
feat(nav): add Coding Bridge sidebar entry gated by codingBridge feature

### DIFF
--- a/change/@acedatacloud-nexior-coding-bridge-nav.json
+++ b/change/@acedatacloud-nexior-coding-bridge-nav.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add a Coding Bridge entry to the sidebar navigation, gated by the codingBridge site feature with an admin settings toggle (disabled by default)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "none"
+}

--- a/src/components/common/Navigator.vue
+++ b/src/components/common/Navigator.vue
@@ -98,11 +98,13 @@ import {
   ROUTE_FISH_MODEL_INDEX,
   ROUTE_KIMI_CONVERSATION,
   ROUTE_KIMI_CONVERSATION_NEW,
-  ROUTE_WEBEXTRATOR_INDEX
+  ROUTE_WEBEXTRATOR_INDEX,
+  ROUTE_CODING_BRIDGE_INDEX
 } from '@/router/constants';
 import { SERP_LOGO } from '@/constants';
 import { ROUTE_SERP_INDEX } from '@/constants/serp';
 import { WEBEXTRATOR_LOGO } from '@/constants/webextrator';
+import { CODING_BRIDGE_LOGO } from '@/constants/codingBridge';
 import {
   CHAT_MODEL_ICON_CHATGPT,
   CHAT_MODEL_ICON_DEEPSEEK,
@@ -387,6 +389,15 @@ export default defineComponent({
           displayName: this.$t('common.nav.webextrator'),
           logo: WEBEXTRATOR_LOGO,
           routes: [ROUTE_WEBEXTRATOR_INDEX],
+          category: 'data'
+        });
+      }
+      if (this.$store?.state?.site?.features?.codingBridge?.enabled) {
+        result.push({
+          route: { name: ROUTE_CODING_BRIDGE_INDEX },
+          displayName: this.$t('common.nav.codingBridge'),
+          logo: CODING_BRIDGE_LOGO,
+          routes: [ROUTE_CODING_BRIDGE_INDEX],
           category: 'data'
         });
       }

--- a/src/components/setting/Function.vue
+++ b/src/components/setting/Function.vue
@@ -116,7 +116,8 @@ const FEATURE_KEYS = [
   'kimi',
   'serp',
   'fish',
-  'webextrator'
+  'webextrator',
+  'codingBridge'
 ];
 
 export default defineComponent({

--- a/src/constants/codingBridge.ts
+++ b/src/constants/codingBridge.ts
@@ -45,3 +45,6 @@ export const CB_EVENT_PONG = 'pong';
 // Reconnect backoff for the browser WebSocket (milliseconds).
 export const CB_RECONNECT_MIN_MS = 1000;
 export const CB_RECONNECT_MAX_MS = 15000;
+
+// Sidebar navigation logo for the Coding Bridge feature.
+export const CODING_BRIDGE_LOGO = 'https://cdn.acedata.cloud/0b28123f35.png';

--- a/src/i18n/ar/common.json
+++ b/src/i18n/ar/common.json
@@ -527,6 +527,10 @@
     "message": "SERP",
     "description": "النص في شريط التنقل للموقع، لعرض صفحة SERP، يجب عدم ترجمة هذا الحقل، يجب أن يبقى 'SERP'"
   },
+  "nav.codingBridge": {
+    "message": "Coding Bridge",
+    "description": "Text in the website navigation bar to display the Coding Bridge page, must remain as 'Coding Bridge'"
+  },
   "nav.webextrator": {
     "message": "WebExtrator",
     "description": "Text in the website navigation bar to display the WebExtrator page, must remain as 'WebExtrator'"

--- a/src/i18n/ar/site.json
+++ b/src/i18n/ar/site.json
@@ -183,6 +183,10 @@
     "message": "صوت السمك",
     "description": "العنوان المعروض في مربع التحرير"
   },
+  "field.featuresCodingBridge": {
+    "message": "Coding Bridge",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresWebextrator": {
     "message": "WebExtrator",
     "description": "Displayed as the title in the editing box"
@@ -506,6 +510,10 @@
   "message.featuresFish": {
     "message": "قم بتشغيل أو إيقاف وحدة ميزة صوت السمك.",
     "description": "وصف ميزة صوت السمك"
+  },
+  "message.featuresCodingBridge": {
+    "message": "Enable or disable the Coding Bridge feature module.",
+    "description": "Description of the Coding Bridge feature"
   },
   "message.featuresWebextrator": {
     "message": "Enable or disable the WebExtrator feature module.",

--- a/src/i18n/de/common.json
+++ b/src/i18n/de/common.json
@@ -527,6 +527,10 @@
     "message": "SERP",
     "description": "Website-Navigationsleiste, um die SERP-Seite anzuzeigen, bitte dieses Feld nicht übersetzen, muss als 'SERP' beibehalten werden"
   },
+  "nav.codingBridge": {
+    "message": "Coding Bridge",
+    "description": "Text in the website navigation bar to display the Coding Bridge page, must remain as 'Coding Bridge'"
+  },
   "nav.webextrator": {
     "message": "WebExtrator",
     "description": "Text in the website navigation bar to display the WebExtrator page, must remain as 'WebExtrator'"

--- a/src/i18n/de/site.json
+++ b/src/i18n/de/site.json
@@ -183,6 +183,10 @@
     "message": "Fisch Audio",
     "description": "Titel, der im Bearbeitungsfeld angezeigt wird"
   },
+  "field.featuresCodingBridge": {
+    "message": "Coding Bridge",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresWebextrator": {
     "message": "WebExtrator",
     "description": "Displayed as the title in the editing box"
@@ -506,6 +510,10 @@
   "message.featuresFish": {
     "message": "Aktivieren oder Deaktivieren des Fisch Audio Funktionsmoduls.",
     "description": "Beschreibung der Fisch Audio Funktion"
+  },
+  "message.featuresCodingBridge": {
+    "message": "Enable or disable the Coding Bridge feature module.",
+    "description": "Description of the Coding Bridge feature"
   },
   "message.featuresWebextrator": {
     "message": "Enable or disable the WebExtrator feature module.",

--- a/src/i18n/el/common.json
+++ b/src/i18n/el/common.json
@@ -527,6 +527,10 @@
     "message": "SERP",
     "description": "Website navigation text for displaying the SERP page, must remain as 'SERP'"
   },
+  "nav.codingBridge": {
+    "message": "Coding Bridge",
+    "description": "Text in the website navigation bar to display the Coding Bridge page, must remain as 'Coding Bridge'"
+  },
   "nav.webextrator": {
     "message": "WebExtrator",
     "description": "Text in the website navigation bar to display the WebExtrator page, must remain as 'WebExtrator'"

--- a/src/i18n/el/site.json
+++ b/src/i18n/el/site.json
@@ -183,6 +183,10 @@
     "message": "Ήχος Ψαριών",
     "description": "Τίτλος που εμφανίζεται στο πλαίσιο επεξεργασίας"
   },
+  "field.featuresCodingBridge": {
+    "message": "Coding Bridge",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresWebextrator": {
     "message": "WebExtrator",
     "description": "Displayed as the title in the editing box"
@@ -506,6 +510,10 @@
   "message.featuresFish": {
     "message": "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Ήχου Ψαριών.",
     "description": "Περιγραφή της λειτουργίας Ήχου Ψαριών"
+  },
+  "message.featuresCodingBridge": {
+    "message": "Enable or disable the Coding Bridge feature module.",
+    "description": "Description of the Coding Bridge feature"
   },
   "message.featuresWebextrator": {
     "message": "Enable or disable the WebExtrator feature module.",

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -527,6 +527,10 @@
     "message": "SERP",
     "description": "Text in the website navigation bar to display the SERP page, must remain as 'SERP'"
   },
+  "nav.codingBridge": {
+    "message": "Coding Bridge",
+    "description": "Text in the website navigation bar to display the Coding Bridge page, must remain as 'Coding Bridge'"
+  },
   "nav.webextrator": {
     "message": "WebExtrator",
     "description": "Text in the website navigation bar to display the WebExtrator page, must remain as 'WebExtrator'"

--- a/src/i18n/en/site.json
+++ b/src/i18n/en/site.json
@@ -183,6 +183,10 @@
     "message": "Fish Audio",
     "description": "Displayed as the title in the editing box"
   },
+  "field.featuresCodingBridge": {
+    "message": "Coding Bridge",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresWebextrator": {
     "message": "WebExtrator",
     "description": "Displayed as the title in the editing box"
@@ -506,6 +510,10 @@
   "message.featuresFish": {
     "message": "Enable or disable the Fish Audio feature module.",
     "description": "Description of the Fish Audio feature"
+  },
+  "message.featuresCodingBridge": {
+    "message": "Enable or disable the Coding Bridge feature module.",
+    "description": "Description of the Coding Bridge feature"
   },
   "message.featuresWebextrator": {
     "message": "Enable or disable the WebExtrator feature module.",

--- a/src/i18n/es/common.json
+++ b/src/i18n/es/common.json
@@ -527,6 +527,10 @@
     "message": "SERP",
     "description": "网站导航栏中的文本，用于显示SERP页面，请不要翻译此字段，必须保持为'SERP'"
   },
+  "nav.codingBridge": {
+    "message": "Coding Bridge",
+    "description": "Text in the website navigation bar to display the Coding Bridge page, must remain as 'Coding Bridge'"
+  },
   "nav.webextrator": {
     "message": "WebExtrator",
     "description": "Text in the website navigation bar to display the WebExtrator page, must remain as 'WebExtrator'"

--- a/src/i18n/es/site.json
+++ b/src/i18n/es/site.json
@@ -183,6 +183,10 @@
     "message": "Audio de Pescado",
     "description": "Título mostrado en el cuadro de edición"
   },
+  "field.featuresCodingBridge": {
+    "message": "Coding Bridge",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresWebextrator": {
     "message": "WebExtrator",
     "description": "Displayed as the title in the editing box"
@@ -506,6 +510,10 @@
   "message.featuresFish": {
     "message": "Activar o desactivar el módulo de Audio de Pescado.",
     "description": "Descripción de la función de Audio de Pescado"
+  },
+  "message.featuresCodingBridge": {
+    "message": "Enable or disable the Coding Bridge feature module.",
+    "description": "Description of the Coding Bridge feature"
   },
   "message.featuresWebextrator": {
     "message": "Enable or disable the WebExtrator feature module.",

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -527,6 +527,10 @@
     "message": "SERP",
     "description": "网站导航栏中的文本，用于显示SERP页面，请不要翻译此字段，必须保持为'SERP'"
   },
+  "nav.codingBridge": {
+    "message": "Coding Bridge",
+    "description": "Text in the website navigation bar to display the Coding Bridge page, must remain as 'Coding Bridge'"
+  },
   "nav.webextrator": {
     "message": "WebExtrator",
     "description": "Text in the website navigation bar to display the WebExtrator page, must remain as 'WebExtrator'"

--- a/src/i18n/fi/site.json
+++ b/src/i18n/fi/site.json
@@ -183,6 +183,10 @@
     "message": "Kalojen ääni",
     "description": "Näytetään muokkausruudun otsikkona."
   },
+  "field.featuresCodingBridge": {
+    "message": "Coding Bridge",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresWebextrator": {
     "message": "WebExtrator",
     "description": "Displayed as the title in the editing box"
@@ -506,6 +510,10 @@
   "message.featuresFish": {
     "message": "Avaa tai sulje Kalojen ääni -toimintomoduuli.",
     "description": "Kalojen ääni -toiminnon kuvaus."
+  },
+  "message.featuresCodingBridge": {
+    "message": "Enable or disable the Coding Bridge feature module.",
+    "description": "Description of the Coding Bridge feature"
   },
   "message.featuresWebextrator": {
     "message": "Enable or disable the WebExtrator feature module.",

--- a/src/i18n/fr/common.json
+++ b/src/i18n/fr/common.json
@@ -527,6 +527,10 @@
     "message": "SERP",
     "description": "网站导航栏中的文本，用于显示SERP页面，请不要翻译此字段，必须保持为'SERP'"
   },
+  "nav.codingBridge": {
+    "message": "Coding Bridge",
+    "description": "Text in the website navigation bar to display the Coding Bridge page, must remain as 'Coding Bridge'"
+  },
   "nav.webextrator": {
     "message": "WebExtrator",
     "description": "Text in the website navigation bar to display the WebExtrator page, must remain as 'WebExtrator'"

--- a/src/i18n/fr/site.json
+++ b/src/i18n/fr/site.json
@@ -183,6 +183,10 @@
     "message": "Audio de poisson",
     "description": "Titre affiché dans la zone d'édition"
   },
+  "field.featuresCodingBridge": {
+    "message": "Coding Bridge",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresWebextrator": {
     "message": "WebExtrator",
     "description": "Displayed as the title in the editing box"
@@ -506,6 +510,10 @@
   "message.featuresFish": {
     "message": "Activer ou désactiver le module de fonction Audio de poisson.",
     "description": "Description de la fonction Audio de poisson"
+  },
+  "message.featuresCodingBridge": {
+    "message": "Enable or disable the Coding Bridge feature module.",
+    "description": "Description of the Coding Bridge feature"
   },
   "message.featuresWebextrator": {
     "message": "Enable or disable the WebExtrator feature module.",

--- a/src/i18n/it/common.json
+++ b/src/i18n/it/common.json
@@ -527,6 +527,10 @@
     "message": "SERP",
     "description": "Testo nella barra di navigazione del sito per visualizzare la pagina SERP, non tradurre questo campo, deve rimanere 'SERP'"
   },
+  "nav.codingBridge": {
+    "message": "Coding Bridge",
+    "description": "Text in the website navigation bar to display the Coding Bridge page, must remain as 'Coding Bridge'"
+  },
   "nav.webextrator": {
     "message": "WebExtrator",
     "description": "Text in the website navigation bar to display the WebExtrator page, must remain as 'WebExtrator'"

--- a/src/i18n/it/site.json
+++ b/src/i18n/it/site.json
@@ -183,6 +183,10 @@
     "message": "Fish Audio",
     "description": "Titolo mostrato nella casella di modifica"
   },
+  "field.featuresCodingBridge": {
+    "message": "Coding Bridge",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresWebextrator": {
     "message": "WebExtrator",
     "description": "Displayed as the title in the editing box"
@@ -506,6 +510,10 @@
   "message.featuresFish": {
     "message": "Attiva o disattiva il modulo Fish Audio.",
     "description": "Descrizione della funzionalità Fish Audio"
+  },
+  "message.featuresCodingBridge": {
+    "message": "Enable or disable the Coding Bridge feature module.",
+    "description": "Description of the Coding Bridge feature"
   },
   "message.featuresWebextrator": {
     "message": "Enable or disable the WebExtrator feature module.",

--- a/src/i18n/ja/common.json
+++ b/src/i18n/ja/common.json
@@ -527,6 +527,10 @@
     "message": "SERP",
     "description": "ウェブサイトのナビゲーションバーのテキストで、SERPページを表示するためのものです。このフィールドは翻訳しないでください。'SERP'のままにしてください。"
   },
+  "nav.codingBridge": {
+    "message": "Coding Bridge",
+    "description": "Text in the website navigation bar to display the Coding Bridge page, must remain as 'Coding Bridge'"
+  },
   "nav.webextrator": {
     "message": "WebExtrator",
     "description": "Text in the website navigation bar to display the WebExtrator page, must remain as 'WebExtrator'"

--- a/src/i18n/ja/site.json
+++ b/src/i18n/ja/site.json
@@ -183,6 +183,10 @@
     "message": "フィッシュオーディオ",
     "description": "編集ボックスに表示されるタイトル"
   },
+  "field.featuresCodingBridge": {
+    "message": "Coding Bridge",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresWebextrator": {
     "message": "WebExtrator",
     "description": "Displayed as the title in the editing box"
@@ -506,6 +510,10 @@
   "message.featuresFish": {
     "message": "フィッシュオーディオ機能モジュールをオンまたはオフにします。",
     "description": "フィッシュオーディオ機能の説明"
+  },
+  "message.featuresCodingBridge": {
+    "message": "Enable or disable the Coding Bridge feature module.",
+    "description": "Description of the Coding Bridge feature"
   },
   "message.featuresWebextrator": {
     "message": "Enable or disable the WebExtrator feature module.",

--- a/src/i18n/ko/common.json
+++ b/src/i18n/ko/common.json
@@ -527,6 +527,10 @@
     "message": "SERP",
     "description": "사이트 내비게이션 바의 텍스트로 SERP 페이지를 표시합니다. 이 필드는 번역하지 말고 'SERP'로 유지해야 합니다."
   },
+  "nav.codingBridge": {
+    "message": "Coding Bridge",
+    "description": "Text in the website navigation bar to display the Coding Bridge page, must remain as 'Coding Bridge'"
+  },
   "nav.webextrator": {
     "message": "WebExtrator",
     "description": "Text in the website navigation bar to display the WebExtrator page, must remain as 'WebExtrator'"

--- a/src/i18n/ko/site.json
+++ b/src/i18n/ko/site.json
@@ -183,6 +183,10 @@
     "message": "물고기 오디오",
     "description": "편집 상자에 표시되는 제목"
   },
+  "field.featuresCodingBridge": {
+    "message": "Coding Bridge",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresWebextrator": {
     "message": "WebExtrator",
     "description": "Displayed as the title in the editing box"
@@ -506,6 +510,10 @@
   "message.featuresFish": {
     "message": "물고기 오디오 기능 모듈을 켜거나 끕니다.",
     "description": "물고기 오디오 기능에 대한 설명"
+  },
+  "message.featuresCodingBridge": {
+    "message": "Enable or disable the Coding Bridge feature module.",
+    "description": "Description of the Coding Bridge feature"
   },
   "message.featuresWebextrator": {
     "message": "Enable or disable the WebExtrator feature module.",

--- a/src/i18n/pl/common.json
+++ b/src/i18n/pl/common.json
@@ -527,6 +527,10 @@
     "message": "SERP",
     "description": "Tekst w nawigacji strony, który wyświetla stronę SERP, nie tłumaczyć, musi pozostać 'SERP'"
   },
+  "nav.codingBridge": {
+    "message": "Coding Bridge",
+    "description": "Text in the website navigation bar to display the Coding Bridge page, must remain as 'Coding Bridge'"
+  },
   "nav.webextrator": {
     "message": "WebExtrator",
     "description": "Text in the website navigation bar to display the WebExtrator page, must remain as 'WebExtrator'"

--- a/src/i18n/pl/site.json
+++ b/src/i18n/pl/site.json
@@ -183,6 +183,10 @@
     "message": "Dźwięk ryb",
     "description": "Tytuł wyświetlany w polu edycji"
   },
+  "field.featuresCodingBridge": {
+    "message": "Coding Bridge",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresWebextrator": {
     "message": "WebExtrator",
     "description": "Displayed as the title in the editing box"
@@ -506,6 +510,10 @@
   "message.featuresFish": {
     "message": "Włącz lub wyłącz moduł funkcji Dźwięk ryb.",
     "description": "Opis funkcji Dźwięk ryb"
+  },
+  "message.featuresCodingBridge": {
+    "message": "Enable or disable the Coding Bridge feature module.",
+    "description": "Description of the Coding Bridge feature"
   },
   "message.featuresWebextrator": {
     "message": "Enable or disable the WebExtrator feature module.",

--- a/src/i18n/pt/common.json
+++ b/src/i18n/pt/common.json
@@ -527,6 +527,10 @@
     "message": "SERP",
     "description": "Texto na barra de navegação do site para exibir a página SERP, não deve ser traduzido, deve permanecer como 'SERP'"
   },
+  "nav.codingBridge": {
+    "message": "Coding Bridge",
+    "description": "Text in the website navigation bar to display the Coding Bridge page, must remain as 'Coding Bridge'"
+  },
   "nav.webextrator": {
     "message": "WebExtrator",
     "description": "Text in the website navigation bar to display the WebExtrator page, must remain as 'WebExtrator'"

--- a/src/i18n/pt/site.json
+++ b/src/i18n/pt/site.json
@@ -183,6 +183,10 @@
     "message": "Áudio Fish",
     "description": "Título exibido na caixa de edição"
   },
+  "field.featuresCodingBridge": {
+    "message": "Coding Bridge",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresWebextrator": {
     "message": "WebExtrator",
     "description": "Displayed as the title in the editing box"
@@ -506,6 +510,10 @@
   "message.featuresFish": {
     "message": "Ative ou desative o módulo de recursos Áudio Fish.",
     "description": "Descrição da funcionalidade Áudio Fish"
+  },
+  "message.featuresCodingBridge": {
+    "message": "Enable or disable the Coding Bridge feature module.",
+    "description": "Description of the Coding Bridge feature"
   },
   "message.featuresWebextrator": {
     "message": "Enable or disable the WebExtrator feature module.",

--- a/src/i18n/ru/common.json
+++ b/src/i18n/ru/common.json
@@ -527,6 +527,10 @@
     "message": "SERP",
     "description": "网站导航栏中的文本，用于显示SERP页面，请不要翻译此字段，必须保持为'SERP'"
   },
+  "nav.codingBridge": {
+    "message": "Coding Bridge",
+    "description": "Text in the website navigation bar to display the Coding Bridge page, must remain as 'Coding Bridge'"
+  },
   "nav.webextrator": {
     "message": "WebExtrator",
     "description": "Text in the website navigation bar to display the WebExtrator page, must remain as 'WebExtrator'"

--- a/src/i18n/ru/site.json
+++ b/src/i18n/ru/site.json
@@ -183,6 +183,10 @@
     "message": "Аудио Рыбы",
     "description": "Заголовок, отображаемый в редакторе."
   },
+  "field.featuresCodingBridge": {
+    "message": "Coding Bridge",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresWebextrator": {
     "message": "WebExtrator",
     "description": "Displayed as the title in the editing box"
@@ -506,6 +510,10 @@
   "message.featuresFish": {
     "message": "Включить или отключить модуль функции Аудио Рыбы.",
     "description": "Описание функции Аудио Рыбы."
+  },
+  "message.featuresCodingBridge": {
+    "message": "Enable or disable the Coding Bridge feature module.",
+    "description": "Description of the Coding Bridge feature"
   },
   "message.featuresWebextrator": {
     "message": "Enable or disable the WebExtrator feature module.",

--- a/src/i18n/sr/common.json
+++ b/src/i18n/sr/common.json
@@ -527,6 +527,10 @@
     "message": "SERP",
     "description": "网站导航栏中的文本，用于显示SERP页面，请不要翻译此字段，必须保持为'SERP'"
   },
+  "nav.codingBridge": {
+    "message": "Coding Bridge",
+    "description": "Text in the website navigation bar to display the Coding Bridge page, must remain as 'Coding Bridge'"
+  },
   "nav.webextrator": {
     "message": "WebExtrator",
     "description": "Text in the website navigation bar to display the WebExtrator page, must remain as 'WebExtrator'"

--- a/src/i18n/sr/site.json
+++ b/src/i18n/sr/site.json
@@ -183,6 +183,10 @@
     "message": "Riblja Audio",
     "description": "Naslov prikazan u okviru za uređivanje"
   },
+  "field.featuresCodingBridge": {
+    "message": "Coding Bridge",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresWebextrator": {
     "message": "WebExtrator",
     "description": "Displayed as the title in the editing box"
@@ -506,6 +510,10 @@
   "message.featuresFish": {
     "message": "Uključi ili isključi modul Riblja Audio.",
     "description": "Opis funkcionalnosti Riblja Audio"
+  },
+  "message.featuresCodingBridge": {
+    "message": "Enable or disable the Coding Bridge feature module.",
+    "description": "Description of the Coding Bridge feature"
   },
   "message.featuresWebextrator": {
     "message": "Enable or disable the WebExtrator feature module.",

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -527,6 +527,10 @@
     "message": "SERP",
     "description": "Text in the website navigation bar for displaying the SERP page, must remain 'SERP'"
   },
+  "nav.codingBridge": {
+    "message": "Coding Bridge",
+    "description": "Text in the website navigation bar to display the Coding Bridge page, must remain as 'Coding Bridge'"
+  },
   "nav.webextrator": {
     "message": "WebExtrator",
     "description": "Text in the website navigation bar to display the WebExtrator page, must remain as 'WebExtrator'"

--- a/src/i18n/sv/site.json
+++ b/src/i18n/sv/site.json
@@ -183,6 +183,10 @@
     "message": "Fiskljud",
     "description": "Titeln som visas i redigeringsrutan"
   },
+  "field.featuresCodingBridge": {
+    "message": "Coding Bridge",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresWebextrator": {
     "message": "WebExtrator",
     "description": "Displayed as the title in the editing box"
@@ -506,6 +510,10 @@
   "message.featuresFish": {
     "message": "Aktivera eller inaktivera Fiskljud-funktionaliteten.",
     "description": "Beskrivning av Fiskljud-funktionen"
+  },
+  "message.featuresCodingBridge": {
+    "message": "Enable or disable the Coding Bridge feature module.",
+    "description": "Description of the Coding Bridge feature"
   },
   "message.featuresWebextrator": {
     "message": "Enable or disable the WebExtrator feature module.",

--- a/src/i18n/uk/common.json
+++ b/src/i18n/uk/common.json
@@ -527,6 +527,10 @@
     "message": "SERP",
     "description": "Текст у навігаційній панелі сайту для відображення сторінки SERP, не перекладати, має залишатися 'SERP'"
   },
+  "nav.codingBridge": {
+    "message": "Coding Bridge",
+    "description": "Text in the website navigation bar to display the Coding Bridge page, must remain as 'Coding Bridge'"
+  },
   "nav.webextrator": {
     "message": "WebExtrator",
     "description": "Text in the website navigation bar to display the WebExtrator page, must remain as 'WebExtrator'"

--- a/src/i18n/uk/site.json
+++ b/src/i18n/uk/site.json
@@ -183,6 +183,10 @@
     "message": "Аудіо риби",
     "description": "Заголовок, що відображається в редакторі"
   },
+  "field.featuresCodingBridge": {
+    "message": "Coding Bridge",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresWebextrator": {
     "message": "WebExtrator",
     "description": "Displayed as the title in the editing box"
@@ -506,6 +510,10 @@
   "message.featuresFish": {
     "message": "Увімкнути або вимкнути модуль функції Аудіо риби.",
     "description": "Опис функції Аудіо риби"
+  },
+  "message.featuresCodingBridge": {
+    "message": "Enable or disable the Coding Bridge feature module.",
+    "description": "Description of the Coding Bridge feature"
   },
   "message.featuresWebextrator": {
     "message": "Enable or disable the WebExtrator feature module.",

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -547,6 +547,10 @@
     "message": "SERP",
     "description": "网站导航栏中的文本，用于显示SERP页面，请不要翻译此字段，必须保持为'SERP'"
   },
+  "nav.codingBridge": {
+    "message": "Coding Bridge",
+    "description": "网站导航栏中的文本，用于显示 Coding Bridge 页面，请不要翻译此字段，必须保持为'Coding Bridge'"
+  },
   "nav.webextrator": {
     "message": "WebExtrator",
     "description": "网站导航栏中的文本，用于显示WebExtrator页面，请不要翻译此字段，必须保持为'WebExtrator'"

--- a/src/i18n/zh-CN/site.json
+++ b/src/i18n/zh-CN/site.json
@@ -183,6 +183,10 @@
     "message": "Fish Audio",
     "description": "展示在编辑框的标题"
   },
+  "field.featuresCodingBridge": {
+    "message": "Coding Bridge",
+    "description": "展示在编辑框的标题"
+  },
   "field.featuresWebextrator": {
     "message": "WebExtrator",
     "description": "展示在编辑框的标题"
@@ -506,6 +510,10 @@
   "message.featuresFish": {
     "message": "打开或关闭 Fish Audio 功能模块。",
     "description": "Fish Audio 功能的描述"
+  },
+  "message.featuresCodingBridge": {
+    "message": "打开或关闭 Coding Bridge 功能模块。",
+    "description": "Coding Bridge 功能的描述"
   },
   "message.featuresWebextrator": {
     "message": "打开或关闭 WebExtrator 功能模块。",

--- a/src/i18n/zh-TW/common.json
+++ b/src/i18n/zh-TW/common.json
@@ -527,6 +527,10 @@
     "message": "SERP",
     "description": "網站導航欄中的文本，用於顯示SERP頁面，請不要翻譯此字段，必須保持為'SERP'"
   },
+  "nav.codingBridge": {
+    "message": "Coding Bridge",
+    "description": "Text in the website navigation bar to display the Coding Bridge page, must remain as 'Coding Bridge'"
+  },
   "nav.webextrator": {
     "message": "WebExtrator",
     "description": "Text in the website navigation bar to display the WebExtrator page, must remain as 'WebExtrator'"

--- a/src/i18n/zh-TW/site.json
+++ b/src/i18n/zh-TW/site.json
@@ -183,6 +183,10 @@
     "message": "魚音頻",
     "description": "展示在編輯框的標題"
   },
+  "field.featuresCodingBridge": {
+    "message": "Coding Bridge",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresWebextrator": {
     "message": "WebExtrator",
     "description": "Displayed as the title in the editing box"
@@ -506,6 +510,10 @@
   "message.featuresFish": {
     "message": "打開或關閉魚音頻功能模塊。",
     "description": "魚音頻功能的描述"
+  },
+  "message.featuresCodingBridge": {
+    "message": "Enable or disable the Coding Bridge feature module.",
+    "description": "Description of the Coding Bridge feature"
   },
   "message.featuresWebextrator": {
     "message": "Enable or disable the WebExtrator feature module.",

--- a/src/models/site.ts
+++ b/src/models/site.ts
@@ -26,6 +26,7 @@ export interface ISiteFeatures {
   serp?: any;
   fish?: any;
   webextrator?: any;
+  codingBridge?: any;
   support?: any;
   subsite?: ISiteSubsiteFeature;
 }


### PR DESCRIPTION
## What

Adds a **Coding Bridge** entry to the left sidebar navigation so users can reach `/coding-bridge` from the UI. It follows the exact same feature-flag pattern as the other services (ChatGPT, Suno, WebExtrator, etc.).

## Changes

- **`Navigator.vue`** — push a nav link when `site.features.codingBridge.enabled` is true. The link uses a Font Awesome `laptop-code` icon (no image asset). Extended the main list, the overflow folder-preview, and the overflow menu so icon-based links render alongside the existing image logos.
- **`setting/Function.vue`** — added `codingBridge` to the admin **Settings → Functions** toggle list, so site admins can turn it on/off.
- **`models/site.ts`** — added `codingBridge?` to `ISiteFeatures`.
- **i18n (all 18 locales)** — added `common.nav.codingBridge`, `site.field.featuresCodingBridge`, and `site.message.featuresCodingBridge`. The brand name "Coding Bridge" is kept verbatim; non-`zh-CN` toggle copy uses the English placeholder, matching how `webextrator` was added.

## Default behavior

The feature is **off by default** (gated on the site feature flag). A site admin enables it via the new Settings toggle. The matching backend default (`codingBridge` disabled) is added in a separate PlatformBackend PR.

## Validation

- `vue-tsc -b` — clean
- `eslint --fix` — clean
- `scripts/check_i18n_coverage.py` — 17 locales × 40 namespaces all match zh-CN
- `beachball check` — OK (minor change file included)
- `prettier --check` — clean