### PR TITLE
fix(store): load tasks for shared (granted) applications

### DIFF
--- a/change/@acedatacloud-nexior-91bbb7a1-09ce-4093-ace7-4503bd4a793f.json
+++ b/change/@acedatacloud-nexior-91bbb7a1-09ce-4093-ace7-4503bd4a793f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix shared (granted) application selection for task-based services: stop POSTing /credentials (404) and load tasks using the grantee's own credential",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/store/factories/createTaskActions.ts
+++ b/src/store/factories/createTaskActions.ts
@@ -85,16 +85,29 @@ export function createTaskActions<TConfig, TTask, TFilter>(opts: {
       }) as unknown as TFilter);
 
   const setApplication = async (
-    { commit, dispatch }: ActionContext<S, IRootState>,
+    { commit, dispatch, rootState }: ActionContext<S, IRootState>,
     payload: IApplication
   ): Promise<void> => {
     commit('setApplication', payload);
     if (!payload) return;
-    const credential = payload?.credentials?.find((c) => c?.host === window.location.origin);
+    // Credential-as-Authorization: skip auto-createCredential when the user is
+    // a grantee — pick the credential that already belongs to them. The
+    // backend (PR #540) returns only the caller's own credential for granted
+    // apps and 404s any grantee POST /credentials, so creating one here both
+    // fails and blocks the follow-up tasks fetch.
+    const me = rootState?.user?.id;
+    const isGranted = payload?.role === 'grantee';
+    let credential = payload?.credentials?.find((c) => c?.host === window.location.origin);
+    if (!credential && isGranted) {
+      credential = payload?.credentials?.find((c) => c?.user_id === me);
+    }
     if (credential) {
       commit('setCredential', credential);
-    } else {
+    } else if (!isGranted) {
       await dispatch('createCredential');
+    } else {
+      console.warn('no credential available for granted application', payload);
+      commit('setCredential', undefined);
     }
   };
 


### PR DESCRIPTION
## Problem

Selecting a **shared (granted) application** in any task-based service (e.g. `studio.acedata.cloud/nanobanana`) failed:

- `POST https://platform.acedata.cloud/api/v1/credentials/` → **404 Not Found**
- `POST https://api.acedata.cloud/<svc>/tasks` was never sent, so history/tasks never loaded.

## Root cause

`createTaskActions.setApplication` (the shared factory behind 15 services) only matched a credential by `host === window.location.origin`; if none matched it **always** dispatched `createCredential`, which `POST`s `/credentials`.

For a **grantee**, the backend (PlatformBackend #540) intentionally returns `404` for a grantee `POST /credentials` without `for_user_id` (`credential.py` `perform_create` → `raise NotFound()`). The rejected promise left the module with no credential, so `getTasks` aborted early with `no token` and never hit `/<svc>/tasks`.

The hand-rolled `chat`, `serp`, `webextrator`, `suno`, and `producer` modules already handle this; the factory never got the same fix.

## Fix

Mirror the credential-as-authorization handling in the factory:

- Read `role` from the application; when `role === 'grantee'`, **never** auto-create.
- Reuse the grantee's own credential (backend already filters `credentials` to `user_id == me` for granted apps).
- Only `createCredential` for owners.

## Impact

Fixes shared-app selection for all 15 factory-based services: nanobanana, fish, seedance, pixverse, qrart, openaiimage, wan, pika, kling, headshots, flux, sora, luma, hailuo, veo.

## Validation

- `npx vue-tsc -b` → clean
- `npx eslint src/store/factories/createTaskActions.ts` → clean
