### PR TITLE
feat(coding-bridge): Claude/Codex backend switch + reasoning-effort selector

### DIFF
--- a/change/@acedatacloud-nexior-4ccadf93-d8a9-463d-a1f2-07f23c484b52.json
+++ b/change/@acedatacloud-nexior-4ccadf93-d8a9-463d-a1f2-07f23c484b52.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Coding Bridge: Claude/Codex backend switch and reasoning-effort selector",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/codingBridge/SessionView.vue
+++ b/src/components/codingBridge/SessionView.vue
@@ -21,8 +21,7 @@
             />
           </div>
           <div v-if="currentSession" class="text-xs text-[var(--app-text-subtle)] truncate">
-            <span v-if="currentSession.cwd">{{ currentSession.cwd }}</span>
-            <span v-if="currentSession.model"> · {{ currentSession.model }}</span>
+            <span>{{ sessionMeta }}</span>
             <span v-if="replayLabel" class="text-[var(--el-color-primary)]"> · {{ replayLabel }}</span>
           </div>
         </div>
@@ -66,13 +65,14 @@
         </div>
         <template v-else>
           <div v-if="isNewSession" class="flex flex-wrap gap-2 mb-2">
-            <el-input
-              v-model="cwd"
+            <el-select
+              v-model="provider"
               size="small"
-              class="flex-1 min-w-[160px]"
-              :placeholder="$t('codingBridge.session.cwdPlaceholder')"
-              clearable
-            />
+              class="w-32"
+              :placeholder="$t('codingBridge.session.providerLabel')"
+            >
+              <el-option v-for="opt in providerOptions" :key="opt.value" :label="opt.label" :value="opt.value" />
+            </el-select>
             <el-select
               v-model="model"
               size="small"
@@ -85,6 +85,9 @@
             >
               <el-option v-for="opt in modelOptions" :key="opt.value" :label="opt.label" :value="opt.value" />
             </el-select>
+            <el-select v-model="effort" size="small" class="w-32" :placeholder="$t('codingBridge.session.effortLabel')">
+              <el-option v-for="opt in effortOptions" :key="opt.value" :label="opt.label" :value="opt.value" />
+            </el-select>
             <el-select
               v-model="permissionMode"
               size="small"
@@ -93,6 +96,13 @@
             >
               <el-option v-for="opt in permissionModeOptions" :key="opt.value" :label="opt.label" :value="opt.value" />
             </el-select>
+            <el-input
+              v-model="cwd"
+              size="small"
+              class="flex-1 min-w-[160px]"
+              :placeholder="$t('codingBridge.session.cwdPlaceholder')"
+              clearable
+            />
           </div>
           <div class="flex items-end gap-2">
             <el-input
@@ -143,7 +153,9 @@ export default defineComponent({
       prompt: '',
       cwd: '',
       model: '',
-      permissionMode: 'default'
+      permissionMode: 'default',
+      provider: 'claude',
+      effort: ''
     };
   },
   computed: {
@@ -195,12 +207,38 @@ export default defineComponent({
     canSend(): boolean {
       return !!this.prompt.trim() && this.connected && this.nodeOnline;
     },
+    providerOptions(): { label: string; value: string }[] {
+      return [
+        { label: this.$t('codingBridge.session.providerClaude') as string, value: 'claude' },
+        { label: this.$t('codingBridge.session.providerCodex') as string, value: 'codex' }
+      ];
+    },
     modelOptions(): { label: string; value: string }[] {
+      if (this.provider === 'codex') {
+        return [
+          { label: 'GPT-5 Codex', value: 'gpt-5-codex' },
+          { label: 'GPT-5', value: 'gpt-5' },
+          { label: 'o3', value: 'o3' }
+        ];
+      }
       return [
         { label: 'Claude Sonnet', value: 'sonnet' },
         { label: 'Claude Opus', value: 'opus' },
         { label: 'Claude Haiku', value: 'haiku' }
       ];
+    },
+    effortOptions(): { label: string; value: string }[] {
+      const options = [
+        { label: this.$t('codingBridge.session.effortDefault') as string, value: '' },
+        { label: this.$t('codingBridge.session.effortLow') as string, value: 'low' },
+        { label: this.$t('codingBridge.session.effortMedium') as string, value: 'medium' },
+        { label: this.$t('codingBridge.session.effortHigh') as string, value: 'high' }
+      ];
+      // Claude exposes an extra "max" tier; Codex reasoning tops out at "high".
+      if (this.provider !== 'codex') {
+        options.push({ label: this.$t('codingBridge.session.effortMax') as string, value: 'max' });
+      }
+      return options;
     },
     permissionModeOptions(): { label: string; value: string }[] {
       return [
@@ -209,6 +247,23 @@ export default defineComponent({
         { label: this.$t('codingBridge.session.permissionModePlan') as string, value: 'plan' },
         { label: this.$t('codingBridge.session.permissionModeBypass') as string, value: 'bypassPermissions' }
       ];
+    },
+    sessionMeta(): string {
+      const session = this.currentSession;
+      if (!session) {
+        return '';
+      }
+      const parts: string[] = [];
+      if (session.provider) {
+        parts.push(this.providerName(session.provider));
+      }
+      if (session.cwd) {
+        parts.push(session.cwd);
+      }
+      if (session.model) {
+        parts.push(session.model);
+      }
+      return parts.join(' · ');
     }
   },
   watch: {
@@ -217,9 +272,19 @@ export default defineComponent({
     },
     currentSessionId() {
       this.scrollToBottom();
+    },
+    provider() {
+      // Model lists and effort tiers differ per backend, so reset both.
+      this.model = '';
+      this.effort = '';
     }
   },
   methods: {
+    providerName(provider: string): string {
+      return provider === 'codex'
+        ? (this.$t('codingBridge.session.providerCodex') as string)
+        : (this.$t('codingBridge.session.providerClaude') as string);
+    },
     onComposerEnter(event: KeyboardEvent | Event) {
       // Ignore Enter while an IME (e.g. pinyin) composition is active so that
       // confirming candidates never sends the message. Modifier+Enter inserts
@@ -242,7 +307,9 @@ export default defineComponent({
         prompt: this.prompt,
         cwd: this.cwd,
         model: this.model,
-        permissionMode: this.permissionMode
+        permissionMode: this.permissionMode,
+        provider: this.provider,
+        effort: this.effort
       });
       this.prompt = '';
     },
@@ -254,6 +321,8 @@ export default defineComponent({
       this.cwd = '';
       this.model = '';
       this.permissionMode = 'default';
+      this.provider = 'claude';
+      this.effort = '';
       this.prompt = '';
     },
     scrollToBottom() {

--- a/src/i18n/ar/codingBridge.json
+++ b/src/i18n/ar/codingBridge.json
@@ -226,5 +226,41 @@
   "session.permissionModeBypass": {
     "message": "تجاوز كل الأذونات",
     "description": "Permission mode: bypass all permission prompts"
+  },
+  "session.providerLabel": {
+    "message": "الخلفية",
+    "description": "Agent backend selector label"
+  },
+  "session.providerClaude": {
+    "message": "Claude Code",
+    "description": "Backend option: Claude Code"
+  },
+  "session.providerCodex": {
+    "message": "Codex",
+    "description": "Backend option: Codex"
+  },
+  "session.effortLabel": {
+    "message": "مستوى الاستدلال",
+    "description": "Reasoning-effort selector label"
+  },
+  "session.effortDefault": {
+    "message": "افتراضي",
+    "description": "Reasoning effort: backend default"
+  },
+  "session.effortLow": {
+    "message": "منخفض",
+    "description": "Reasoning effort: low"
+  },
+  "session.effortMedium": {
+    "message": "متوسط",
+    "description": "Reasoning effort: medium"
+  },
+  "session.effortHigh": {
+    "message": "مرتفع",
+    "description": "Reasoning effort: high"
+  },
+  "session.effortMax": {
+    "message": "أقصى",
+    "description": "Reasoning effort: maximum (Claude only)"
   }
 }

--- a/src/i18n/de/codingBridge.json
+++ b/src/i18n/de/codingBridge.json
@@ -226,5 +226,41 @@
   "session.permissionModeBypass": {
     "message": "Alle Berechtigungen umgehen",
     "description": "Permission mode: bypass all permission prompts"
+  },
+  "session.providerLabel": {
+    "message": "Backend",
+    "description": "Agent backend selector label"
+  },
+  "session.providerClaude": {
+    "message": "Claude Code",
+    "description": "Backend option: Claude Code"
+  },
+  "session.providerCodex": {
+    "message": "Codex",
+    "description": "Backend option: Codex"
+  },
+  "session.effortLabel": {
+    "message": "Denkaufwand",
+    "description": "Reasoning-effort selector label"
+  },
+  "session.effortDefault": {
+    "message": "Standard",
+    "description": "Reasoning effort: backend default"
+  },
+  "session.effortLow": {
+    "message": "Niedrig",
+    "description": "Reasoning effort: low"
+  },
+  "session.effortMedium": {
+    "message": "Mittel",
+    "description": "Reasoning effort: medium"
+  },
+  "session.effortHigh": {
+    "message": "Hoch",
+    "description": "Reasoning effort: high"
+  },
+  "session.effortMax": {
+    "message": "Maximal",
+    "description": "Reasoning effort: maximum (Claude only)"
   }
 }

--- a/src/i18n/el/codingBridge.json
+++ b/src/i18n/el/codingBridge.json
@@ -226,5 +226,41 @@
   "session.permissionModeBypass": {
     "message": "Παράκαμψη όλων των δικαιωμάτων",
     "description": "Permission mode: bypass all permission prompts"
+  },
+  "session.providerLabel": {
+    "message": "Σύστημα",
+    "description": "Agent backend selector label"
+  },
+  "session.providerClaude": {
+    "message": "Claude Code",
+    "description": "Backend option: Claude Code"
+  },
+  "session.providerCodex": {
+    "message": "Codex",
+    "description": "Backend option: Codex"
+  },
+  "session.effortLabel": {
+    "message": "Προσπάθεια συλλογισμού",
+    "description": "Reasoning-effort selector label"
+  },
+  "session.effortDefault": {
+    "message": "Προεπιλογή",
+    "description": "Reasoning effort: backend default"
+  },
+  "session.effortLow": {
+    "message": "Χαμηλή",
+    "description": "Reasoning effort: low"
+  },
+  "session.effortMedium": {
+    "message": "Μεσαία",
+    "description": "Reasoning effort: medium"
+  },
+  "session.effortHigh": {
+    "message": "Υψηλή",
+    "description": "Reasoning effort: high"
+  },
+  "session.effortMax": {
+    "message": "Μέγιστη",
+    "description": "Reasoning effort: maximum (Claude only)"
   }
 }

--- a/src/i18n/en/codingBridge.json
+++ b/src/i18n/en/codingBridge.json
@@ -226,5 +226,41 @@
   "session.permissionModeBypass": {
     "message": "Bypass all permissions",
     "description": "Permission mode: bypass all permission prompts"
+  },
+  "session.providerLabel": {
+    "message": "Backend",
+    "description": "Agent backend selector label"
+  },
+  "session.providerClaude": {
+    "message": "Claude Code",
+    "description": "Backend option: Claude Code"
+  },
+  "session.providerCodex": {
+    "message": "Codex",
+    "description": "Backend option: Codex"
+  },
+  "session.effortLabel": {
+    "message": "Reasoning effort",
+    "description": "Reasoning-effort selector label"
+  },
+  "session.effortDefault": {
+    "message": "Default",
+    "description": "Reasoning effort: backend default"
+  },
+  "session.effortLow": {
+    "message": "Low",
+    "description": "Reasoning effort: low"
+  },
+  "session.effortMedium": {
+    "message": "Medium",
+    "description": "Reasoning effort: medium"
+  },
+  "session.effortHigh": {
+    "message": "High",
+    "description": "Reasoning effort: high"
+  },
+  "session.effortMax": {
+    "message": "Max",
+    "description": "Reasoning effort: maximum (Claude only)"
   }
 }

--- a/src/i18n/es/codingBridge.json
+++ b/src/i18n/es/codingBridge.json
@@ -226,5 +226,41 @@
   "session.permissionModeBypass": {
     "message": "Omitir todos los permisos",
     "description": "Permission mode: bypass all permission prompts"
+  },
+  "session.providerLabel": {
+    "message": "Backend",
+    "description": "Agent backend selector label"
+  },
+  "session.providerClaude": {
+    "message": "Claude Code",
+    "description": "Backend option: Claude Code"
+  },
+  "session.providerCodex": {
+    "message": "Codex",
+    "description": "Backend option: Codex"
+  },
+  "session.effortLabel": {
+    "message": "Esfuerzo de razonamiento",
+    "description": "Reasoning-effort selector label"
+  },
+  "session.effortDefault": {
+    "message": "Predeterminado",
+    "description": "Reasoning effort: backend default"
+  },
+  "session.effortLow": {
+    "message": "Bajo",
+    "description": "Reasoning effort: low"
+  },
+  "session.effortMedium": {
+    "message": "Medio",
+    "description": "Reasoning effort: medium"
+  },
+  "session.effortHigh": {
+    "message": "Alto",
+    "description": "Reasoning effort: high"
+  },
+  "session.effortMax": {
+    "message": "Máximo",
+    "description": "Reasoning effort: maximum (Claude only)"
   }
 }

--- a/src/i18n/fi/codingBridge.json
+++ b/src/i18n/fi/codingBridge.json
@@ -226,5 +226,41 @@
   "session.permissionModeBypass": {
     "message": "Ohita kaikki käyttöoikeudet",
     "description": "Permission mode: bypass all permission prompts"
+  },
+  "session.providerLabel": {
+    "message": "Taustajärjestelmä",
+    "description": "Agent backend selector label"
+  },
+  "session.providerClaude": {
+    "message": "Claude Code",
+    "description": "Backend option: Claude Code"
+  },
+  "session.providerCodex": {
+    "message": "Codex",
+    "description": "Backend option: Codex"
+  },
+  "session.effortLabel": {
+    "message": "Päättelyn taso",
+    "description": "Reasoning-effort selector label"
+  },
+  "session.effortDefault": {
+    "message": "Oletus",
+    "description": "Reasoning effort: backend default"
+  },
+  "session.effortLow": {
+    "message": "Matala",
+    "description": "Reasoning effort: low"
+  },
+  "session.effortMedium": {
+    "message": "Keskitaso",
+    "description": "Reasoning effort: medium"
+  },
+  "session.effortHigh": {
+    "message": "Korkea",
+    "description": "Reasoning effort: high"
+  },
+  "session.effortMax": {
+    "message": "Maksimi",
+    "description": "Reasoning effort: maximum (Claude only)"
   }
 }

--- a/src/i18n/fr/codingBridge.json
+++ b/src/i18n/fr/codingBridge.json
@@ -226,5 +226,41 @@
   "session.permissionModeBypass": {
     "message": "Ignorer toutes les autorisations",
     "description": "Permission mode: bypass all permission prompts"
+  },
+  "session.providerLabel": {
+    "message": "Backend",
+    "description": "Agent backend selector label"
+  },
+  "session.providerClaude": {
+    "message": "Claude Code",
+    "description": "Backend option: Claude Code"
+  },
+  "session.providerCodex": {
+    "message": "Codex",
+    "description": "Backend option: Codex"
+  },
+  "session.effortLabel": {
+    "message": "Effort de raisonnement",
+    "description": "Reasoning-effort selector label"
+  },
+  "session.effortDefault": {
+    "message": "Par défaut",
+    "description": "Reasoning effort: backend default"
+  },
+  "session.effortLow": {
+    "message": "Faible",
+    "description": "Reasoning effort: low"
+  },
+  "session.effortMedium": {
+    "message": "Moyen",
+    "description": "Reasoning effort: medium"
+  },
+  "session.effortHigh": {
+    "message": "Élevé",
+    "description": "Reasoning effort: high"
+  },
+  "session.effortMax": {
+    "message": "Maximum",
+    "description": "Reasoning effort: maximum (Claude only)"
   }
 }

--- a/src/i18n/it/codingBridge.json
+++ b/src/i18n/it/codingBridge.json
@@ -226,5 +226,41 @@
   "session.permissionModeBypass": {
     "message": "Ignora tutte le autorizzazioni",
     "description": "Permission mode: bypass all permission prompts"
+  },
+  "session.providerLabel": {
+    "message": "Backend",
+    "description": "Agent backend selector label"
+  },
+  "session.providerClaude": {
+    "message": "Claude Code",
+    "description": "Backend option: Claude Code"
+  },
+  "session.providerCodex": {
+    "message": "Codex",
+    "description": "Backend option: Codex"
+  },
+  "session.effortLabel": {
+    "message": "Sforzo di ragionamento",
+    "description": "Reasoning-effort selector label"
+  },
+  "session.effortDefault": {
+    "message": "Predefinito",
+    "description": "Reasoning effort: backend default"
+  },
+  "session.effortLow": {
+    "message": "Basso",
+    "description": "Reasoning effort: low"
+  },
+  "session.effortMedium": {
+    "message": "Medio",
+    "description": "Reasoning effort: medium"
+  },
+  "session.effortHigh": {
+    "message": "Alto",
+    "description": "Reasoning effort: high"
+  },
+  "session.effortMax": {
+    "message": "Massimo",
+    "description": "Reasoning effort: maximum (Claude only)"
   }
 }

--- a/src/i18n/ja/codingBridge.json
+++ b/src/i18n/ja/codingBridge.json
@@ -226,5 +226,41 @@
   "session.permissionModeBypass": {
     "message": "すべての権限をバイパス",
     "description": "Permission mode: bypass all permission prompts"
+  },
+  "session.providerLabel": {
+    "message": "バックエンド",
+    "description": "Agent backend selector label"
+  },
+  "session.providerClaude": {
+    "message": "Claude Code",
+    "description": "Backend option: Claude Code"
+  },
+  "session.providerCodex": {
+    "message": "Codex",
+    "description": "Backend option: Codex"
+  },
+  "session.effortLabel": {
+    "message": "推論の強度",
+    "description": "Reasoning-effort selector label"
+  },
+  "session.effortDefault": {
+    "message": "デフォルト",
+    "description": "Reasoning effort: backend default"
+  },
+  "session.effortLow": {
+    "message": "低",
+    "description": "Reasoning effort: low"
+  },
+  "session.effortMedium": {
+    "message": "中",
+    "description": "Reasoning effort: medium"
+  },
+  "session.effortHigh": {
+    "message": "高",
+    "description": "Reasoning effort: high"
+  },
+  "session.effortMax": {
+    "message": "最大",
+    "description": "Reasoning effort: maximum (Claude only)"
   }
 }

--- a/src/i18n/ko/codingBridge.json
+++ b/src/i18n/ko/codingBridge.json
@@ -226,5 +226,41 @@
   "session.permissionModeBypass": {
     "message": "모든 권한 우회",
     "description": "Permission mode: bypass all permission prompts"
+  },
+  "session.providerLabel": {
+    "message": "백엔드",
+    "description": "Agent backend selector label"
+  },
+  "session.providerClaude": {
+    "message": "Claude Code",
+    "description": "Backend option: Claude Code"
+  },
+  "session.providerCodex": {
+    "message": "Codex",
+    "description": "Backend option: Codex"
+  },
+  "session.effortLabel": {
+    "message": "추론 강도",
+    "description": "Reasoning-effort selector label"
+  },
+  "session.effortDefault": {
+    "message": "기본값",
+    "description": "Reasoning effort: backend default"
+  },
+  "session.effortLow": {
+    "message": "낮음",
+    "description": "Reasoning effort: low"
+  },
+  "session.effortMedium": {
+    "message": "보통",
+    "description": "Reasoning effort: medium"
+  },
+  "session.effortHigh": {
+    "message": "높음",
+    "description": "Reasoning effort: high"
+  },
+  "session.effortMax": {
+    "message": "최대",
+    "description": "Reasoning effort: maximum (Claude only)"
   }
 }

--- a/src/i18n/pl/codingBridge.json
+++ b/src/i18n/pl/codingBridge.json
@@ -226,5 +226,41 @@
   "session.permissionModeBypass": {
     "message": "Pomiń wszystkie uprawnienia",
     "description": "Permission mode: bypass all permission prompts"
+  },
+  "session.providerLabel": {
+    "message": "Backend",
+    "description": "Agent backend selector label"
+  },
+  "session.providerClaude": {
+    "message": "Claude Code",
+    "description": "Backend option: Claude Code"
+  },
+  "session.providerCodex": {
+    "message": "Codex",
+    "description": "Backend option: Codex"
+  },
+  "session.effortLabel": {
+    "message": "Wysiłek rozumowania",
+    "description": "Reasoning-effort selector label"
+  },
+  "session.effortDefault": {
+    "message": "Domyślny",
+    "description": "Reasoning effort: backend default"
+  },
+  "session.effortLow": {
+    "message": "Niski",
+    "description": "Reasoning effort: low"
+  },
+  "session.effortMedium": {
+    "message": "Średni",
+    "description": "Reasoning effort: medium"
+  },
+  "session.effortHigh": {
+    "message": "Wysoki",
+    "description": "Reasoning effort: high"
+  },
+  "session.effortMax": {
+    "message": "Maksymalny",
+    "description": "Reasoning effort: maximum (Claude only)"
   }
 }

--- a/src/i18n/pt/codingBridge.json
+++ b/src/i18n/pt/codingBridge.json
@@ -226,5 +226,41 @@
   "session.permissionModeBypass": {
     "message": "Ignorar todas as permissões",
     "description": "Permission mode: bypass all permission prompts"
+  },
+  "session.providerLabel": {
+    "message": "Backend",
+    "description": "Agent backend selector label"
+  },
+  "session.providerClaude": {
+    "message": "Claude Code",
+    "description": "Backend option: Claude Code"
+  },
+  "session.providerCodex": {
+    "message": "Codex",
+    "description": "Backend option: Codex"
+  },
+  "session.effortLabel": {
+    "message": "Esforço de raciocínio",
+    "description": "Reasoning-effort selector label"
+  },
+  "session.effortDefault": {
+    "message": "Padrão",
+    "description": "Reasoning effort: backend default"
+  },
+  "session.effortLow": {
+    "message": "Baixo",
+    "description": "Reasoning effort: low"
+  },
+  "session.effortMedium": {
+    "message": "Médio",
+    "description": "Reasoning effort: medium"
+  },
+  "session.effortHigh": {
+    "message": "Alto",
+    "description": "Reasoning effort: high"
+  },
+  "session.effortMax": {
+    "message": "Máximo",
+    "description": "Reasoning effort: maximum (Claude only)"
   }
 }

--- a/src/i18n/ru/codingBridge.json
+++ b/src/i18n/ru/codingBridge.json
@@ -226,5 +226,41 @@
   "session.permissionModeBypass": {
     "message": "Обойти все разрешения",
     "description": "Permission mode: bypass all permission prompts"
+  },
+  "session.providerLabel": {
+    "message": "Бэкенд",
+    "description": "Agent backend selector label"
+  },
+  "session.providerClaude": {
+    "message": "Claude Code",
+    "description": "Backend option: Claude Code"
+  },
+  "session.providerCodex": {
+    "message": "Codex",
+    "description": "Backend option: Codex"
+  },
+  "session.effortLabel": {
+    "message": "Уровень рассуждений",
+    "description": "Reasoning-effort selector label"
+  },
+  "session.effortDefault": {
+    "message": "По умолчанию",
+    "description": "Reasoning effort: backend default"
+  },
+  "session.effortLow": {
+    "message": "Низкий",
+    "description": "Reasoning effort: low"
+  },
+  "session.effortMedium": {
+    "message": "Средний",
+    "description": "Reasoning effort: medium"
+  },
+  "session.effortHigh": {
+    "message": "Высокий",
+    "description": "Reasoning effort: high"
+  },
+  "session.effortMax": {
+    "message": "Максимальный",
+    "description": "Reasoning effort: maximum (Claude only)"
   }
 }

--- a/src/i18n/sr/codingBridge.json
+++ b/src/i18n/sr/codingBridge.json
@@ -226,5 +226,41 @@
   "session.permissionModeBypass": {
     "message": "Заобиђи све дозволе",
     "description": "Permission mode: bypass all permission prompts"
+  },
+  "session.providerLabel": {
+    "message": "Бекенд",
+    "description": "Agent backend selector label"
+  },
+  "session.providerClaude": {
+    "message": "Claude Code",
+    "description": "Backend option: Claude Code"
+  },
+  "session.providerCodex": {
+    "message": "Codex",
+    "description": "Backend option: Codex"
+  },
+  "session.effortLabel": {
+    "message": "Ниво размишљања",
+    "description": "Reasoning-effort selector label"
+  },
+  "session.effortDefault": {
+    "message": "Подразумевано",
+    "description": "Reasoning effort: backend default"
+  },
+  "session.effortLow": {
+    "message": "Низак",
+    "description": "Reasoning effort: low"
+  },
+  "session.effortMedium": {
+    "message": "Средњи",
+    "description": "Reasoning effort: medium"
+  },
+  "session.effortHigh": {
+    "message": "Висок",
+    "description": "Reasoning effort: high"
+  },
+  "session.effortMax": {
+    "message": "Максималан",
+    "description": "Reasoning effort: maximum (Claude only)"
   }
 }

--- a/src/i18n/sv/codingBridge.json
+++ b/src/i18n/sv/codingBridge.json
@@ -226,5 +226,41 @@
   "session.permissionModeBypass": {
     "message": "Kringgå alla behörigheter",
     "description": "Permission mode: bypass all permission prompts"
+  },
+  "session.providerLabel": {
+    "message": "Backend",
+    "description": "Agent backend selector label"
+  },
+  "session.providerClaude": {
+    "message": "Claude Code",
+    "description": "Backend option: Claude Code"
+  },
+  "session.providerCodex": {
+    "message": "Codex",
+    "description": "Backend option: Codex"
+  },
+  "session.effortLabel": {
+    "message": "Resonemangsnivå",
+    "description": "Reasoning-effort selector label"
+  },
+  "session.effortDefault": {
+    "message": "Standard",
+    "description": "Reasoning effort: backend default"
+  },
+  "session.effortLow": {
+    "message": "Låg",
+    "description": "Reasoning effort: low"
+  },
+  "session.effortMedium": {
+    "message": "Medel",
+    "description": "Reasoning effort: medium"
+  },
+  "session.effortHigh": {
+    "message": "Hög",
+    "description": "Reasoning effort: high"
+  },
+  "session.effortMax": {
+    "message": "Max",
+    "description": "Reasoning effort: maximum (Claude only)"
   }
 }

--- a/src/i18n/uk/codingBridge.json
+++ b/src/i18n/uk/codingBridge.json
@@ -226,5 +226,41 @@
   "session.permissionModeBypass": {
     "message": "Обійти всі дозволи",
     "description": "Permission mode: bypass all permission prompts"
+  },
+  "session.providerLabel": {
+    "message": "Бекенд",
+    "description": "Agent backend selector label"
+  },
+  "session.providerClaude": {
+    "message": "Claude Code",
+    "description": "Backend option: Claude Code"
+  },
+  "session.providerCodex": {
+    "message": "Codex",
+    "description": "Backend option: Codex"
+  },
+  "session.effortLabel": {
+    "message": "Рівень міркувань",
+    "description": "Reasoning-effort selector label"
+  },
+  "session.effortDefault": {
+    "message": "За замовчуванням",
+    "description": "Reasoning effort: backend default"
+  },
+  "session.effortLow": {
+    "message": "Низький",
+    "description": "Reasoning effort: low"
+  },
+  "session.effortMedium": {
+    "message": "Середній",
+    "description": "Reasoning effort: medium"
+  },
+  "session.effortHigh": {
+    "message": "Високий",
+    "description": "Reasoning effort: high"
+  },
+  "session.effortMax": {
+    "message": "Максимальний",
+    "description": "Reasoning effort: maximum (Claude only)"
   }
 }

--- a/src/i18n/zh-CN/codingBridge.json
+++ b/src/i18n/zh-CN/codingBridge.json
@@ -226,5 +226,41 @@
   "session.permissionModeBypass": {
     "message": "绕过所有权限",
     "description": "Permission mode: bypass all permission prompts"
+  },
+  "session.providerLabel": {
+    "message": "后端",
+    "description": "Agent backend selector label"
+  },
+  "session.providerClaude": {
+    "message": "Claude Code",
+    "description": "Backend option: Claude Code"
+  },
+  "session.providerCodex": {
+    "message": "Codex",
+    "description": "Backend option: Codex"
+  },
+  "session.effortLabel": {
+    "message": "推理强度",
+    "description": "Reasoning-effort selector label"
+  },
+  "session.effortDefault": {
+    "message": "默认",
+    "description": "Reasoning effort: backend default"
+  },
+  "session.effortLow": {
+    "message": "低",
+    "description": "Reasoning effort: low"
+  },
+  "session.effortMedium": {
+    "message": "中",
+    "description": "Reasoning effort: medium"
+  },
+  "session.effortHigh": {
+    "message": "高",
+    "description": "Reasoning effort: high"
+  },
+  "session.effortMax": {
+    "message": "最高",
+    "description": "Reasoning effort: maximum (Claude only)"
   }
 }

--- a/src/i18n/zh-TW/codingBridge.json
+++ b/src/i18n/zh-TW/codingBridge.json
@@ -226,5 +226,41 @@
   "session.permissionModeBypass": {
     "message": "略過所有權限",
     "description": "Permission mode: bypass all permission prompts"
+  },
+  "session.providerLabel": {
+    "message": "後端",
+    "description": "Agent backend selector label"
+  },
+  "session.providerClaude": {
+    "message": "Claude Code",
+    "description": "Backend option: Claude Code"
+  },
+  "session.providerCodex": {
+    "message": "Codex",
+    "description": "Backend option: Codex"
+  },
+  "session.effortLabel": {
+    "message": "推理強度",
+    "description": "Reasoning-effort selector label"
+  },
+  "session.effortDefault": {
+    "message": "預設",
+    "description": "Reasoning effort: backend default"
+  },
+  "session.effortLow": {
+    "message": "低",
+    "description": "Reasoning effort: low"
+  },
+  "session.effortMedium": {
+    "message": "中",
+    "description": "Reasoning effort: medium"
+  },
+  "session.effortHigh": {
+    "message": "高",
+    "description": "Reasoning effort: high"
+  },
+  "session.effortMax": {
+    "message": "最高",
+    "description": "Reasoning effort: maximum (Claude only)"
   }
 }

--- a/src/store/codingBridge/actions.ts
+++ b/src/store/codingBridge/actions.ts
@@ -347,7 +347,14 @@ export const newSession = ({ commit }: ActionContext<ICodingBridgeState, IRootSt
 
 export const sendPrompt = (
   { commit, state }: ActionContext<ICodingBridgeState, IRootState>,
-  payload: { prompt: string; cwd?: string; model?: string; permissionMode?: string }
+  payload: {
+    prompt: string;
+    cwd?: string;
+    model?: string;
+    permissionMode?: string;
+    provider?: string;
+    effort?: string;
+  }
 ): void => {
   const nodeId = state.currentNodeId;
   const prompt = payload.prompt?.trim();
@@ -360,6 +367,9 @@ export const sendPrompt = (
   // session is a replayed history conversation that has not been resumed.
   const needsStart = !existing || !existing.started;
   if (needsStart) {
+    // Resuming a past conversation keeps its original backend; a brand-new
+    // session uses the one picked in the composer (defaulting to Claude).
+    const provider = existing?.provider || payload.provider || 'claude';
     if (!existing) {
       sessionId = uid();
       commit('upsertSession', {
@@ -367,7 +377,8 @@ export const sendPrompt = (
         node_id: nodeId,
         status: 'starting',
         cwd: payload.cwd,
-        model: payload.model
+        model: payload.model,
+        provider
       });
       commit('setCurrentSession', sessionId);
     } else {
@@ -383,7 +394,8 @@ export const sendPrompt = (
       cwd: payload.cwd || existing?.cwd || undefined,
       model: payload.model || existing?.model || undefined,
       permission_mode: payload.permissionMode || 'default',
-      provider: existing?.provider || undefined,
+      provider,
+      effort: payload.effort || undefined,
       resume_session_id: existing?.resume_session_id || undefined
     });
   } else {


### PR DESCRIPTION
Builds on the merged composer-UX work (#867). Consumes CodingBridgeAgent #7 (live Codex provider + reasoning effort).

## What

Answers the headline ask "怎么切换 claude 和 codex" plus per-backend options:

- **Backend selector** — `Claude Code` / `Codex` dropdown in the new-session
  composer. Sent as `provider` on `session.start`; resuming a past conversation
  keeps its original backend.
- **Reasoning-effort selector** — `Default / Low / Medium / High` for both
  backends, plus `Max` for Claude only (Codex tops out at high). Sent as `effort`.
- **Per-backend model list** — the model dropdown offers Codex models
  (`gpt-5-codex`, `gpt-5`, `o3`) when Codex is selected, Claude models otherwise.
  Switching backend resets model + effort.
- **Session header** shows the active backend (e.g. `Codex · ~/proj · gpt-5-codex`).

## Wiring

- `store/codingBridge/actions.ts` — `sendPrompt` forwards `provider` and `effort`
  on the `session.start` envelope (passed verbatim through the relay).
- `components/codingBridge/SessionView.vue` — backend + effort selects,
  per-backend computed option lists, header `sessionMeta`.

## i18n

9 new keys added to all 18 locales; product names kept verbatim.

## Validation

- `vue-tsc -b --force` — clean (build mode, matches CI)
- `eslint` — clean
- `scripts/check_i18n_coverage.py` — 17 locales × 40 namespaces match zh-CN
- beachball change file included