### PR TITLE
feat(coding-bridge): remote working-directory picker

### DIFF
--- a/change/@acedatacloud-nexior-a24b57e9-7295-4d25-99b8-4131600ac4a9.json
+++ b/change/@acedatacloud-nexior-a24b57e9-7295-4d25-99b8-4131600ac4a9.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Coding Bridge: remote working-directory picker (browse the device's filesystem to choose cwd)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/codingBridge/DirectoryDialog.vue
+++ b/src/components/codingBridge/DirectoryDialog.vue
@@ -1,0 +1,166 @@
+<template>
+  <el-dialog
+    :model-value="visible"
+    :title="$t('codingBridge.directory.title')"
+    width="520px"
+    append-to-body
+    @update:model-value="onVisibleChange"
+    @open="onOpen"
+  >
+    <div class="flex flex-col gap-2">
+      <!-- Current path + parent navigation -->
+      <div class="flex items-center gap-2 min-w-0">
+        <el-button
+          size="small"
+          circle
+          :disabled="!listing || !listing.parent || loading"
+          :title="$t('codingBridge.directory.up')"
+          @click="goParent"
+        >
+          <font-awesome-icon icon="fa-solid fa-arrow-up" />
+        </el-button>
+        <span class="text-xs text-[var(--app-text-subtle)] truncate flex-1" dir="ltr">
+          {{ listing ? listing.path : '…' }}
+        </span>
+        <el-button
+          size="small"
+          circle
+          :disabled="loading"
+          :title="$t('codingBridge.directory.refresh')"
+          @click="refresh"
+        >
+          <font-awesome-icon icon="fa-solid fa-rotate-right" :spin="loading" />
+        </el-button>
+      </div>
+
+      <!-- Listing -->
+      <div
+        class="h-72 overflow-y-auto border border-[var(--app-border-subtle)] rounded-md divide-y divide-[var(--app-border-subtle)]"
+      >
+        <div
+          v-if="loading && !listing"
+          class="h-full flex items-center justify-center text-sm text-[var(--app-text-subtle)]"
+        >
+          {{ $t('codingBridge.directory.loading') }}
+        </div>
+        <div
+          v-else-if="listing && listing.error"
+          class="h-full flex items-center justify-center text-sm text-[var(--el-color-danger)]"
+        >
+          {{ listing.error }}
+        </div>
+        <template v-else>
+          <button
+            v-for="entry in directories"
+            :key="entry.path"
+            type="button"
+            class="w-full flex items-center gap-2 px-3 py-2 text-left text-sm hover:bg-[var(--app-content-hover-bg)]"
+            @click="openDir(entry.path)"
+          >
+            <font-awesome-icon icon="fa-solid fa-folder" class="text-[var(--el-color-warning)]" />
+            <span class="truncate" dir="ltr">{{ entry.name }}</span>
+          </button>
+          <div
+            v-for="entry in files"
+            :key="entry.path"
+            class="w-full flex items-center gap-2 px-3 py-2 text-sm text-[var(--app-text-subtle)]"
+          >
+            <font-awesome-icon icon="fa-solid fa-file" />
+            <span class="truncate" dir="ltr">{{ entry.name }}</span>
+          </div>
+          <div
+            v-if="isEmpty"
+            class="h-full flex items-center justify-center text-sm text-[var(--app-text-subtle)] py-8"
+          >
+            {{ $t('codingBridge.directory.empty') }}
+          </div>
+        </template>
+      </div>
+      <p v-if="listing && listing.truncated" class="text-[11px] text-[var(--app-text-subtle)] px-1">
+        {{ $t('codingBridge.directory.truncated') }}
+      </p>
+    </div>
+
+    <template #footer>
+      <div class="flex items-center justify-end gap-2">
+        <el-button round @click="onVisibleChange(false)">{{ $t('common.button.cancel') }}</el-button>
+        <el-button type="primary" round :disabled="!listing || !!listing.error" @click="chooseCurrent">
+          {{ $t('codingBridge.directory.choose') }}
+        </el-button>
+      </div>
+    </template>
+  </el-dialog>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElDialog, ElButton } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { ICodingBridgeDirEntry, ICodingBridgeDirListing } from '@/models';
+
+export default defineComponent({
+  name: 'CodingBridgeDirectoryDialog',
+  components: {
+    ElDialog,
+    ElButton,
+    FontAwesomeIcon
+  },
+  props: {
+    visible: {
+      type: Boolean,
+      default: false
+    },
+    // Initial directory to open at; empty browses the node's home directory.
+    initialPath: {
+      type: String,
+      default: ''
+    }
+  },
+  emits: ['update:visible', 'select'],
+  computed: {
+    listing(): ICodingBridgeDirListing | undefined {
+      return this.$store.state.codingBridge?.directory;
+    },
+    loading(): boolean {
+      return this.$store.state.codingBridge?.directoryLoading === true;
+    },
+    directories(): ICodingBridgeDirEntry[] {
+      return (this.listing?.entries ?? []).filter((entry) => entry.type === 'dir');
+    },
+    files(): ICodingBridgeDirEntry[] {
+      return (this.listing?.entries ?? []).filter((entry) => entry.type === 'file');
+    },
+    isEmpty(): boolean {
+      return !!this.listing && !this.listing.error && (this.listing.entries ?? []).length === 0;
+    }
+  },
+  methods: {
+    onOpen() {
+      this.$store.dispatch('codingBridge/browseDir', this.initialPath || undefined);
+    },
+    onVisibleChange(value: boolean) {
+      this.$emit('update:visible', value);
+      if (!value) {
+        this.$store.dispatch('codingBridge/clearDirectory');
+      }
+    },
+    openDir(path: string) {
+      this.$store.dispatch('codingBridge/browseDir', path);
+    },
+    goParent() {
+      if (this.listing?.parent) {
+        this.$store.dispatch('codingBridge/browseDir', this.listing.parent);
+      }
+    },
+    refresh() {
+      this.$store.dispatch('codingBridge/browseDir', this.listing?.path || this.initialPath || undefined);
+    },
+    chooseCurrent() {
+      if (this.listing && !this.listing.error) {
+        this.$emit('select', this.listing.path);
+        this.onVisibleChange(false);
+      }
+    }
+  }
+});
+</script>

--- a/src/components/codingBridge/SessionView.vue
+++ b/src/components/codingBridge/SessionView.vue
@@ -102,7 +102,13 @@
               class="flex-1 min-w-[160px]"
               :placeholder="$t('codingBridge.session.cwdPlaceholder')"
               clearable
-            />
+            >
+              <template #append>
+                <el-button :title="$t('codingBridge.directory.title')" @click="openDirectory">
+                  <font-awesome-icon icon="fa-solid fa-folder-open" />
+                </el-button>
+              </template>
+            </el-input>
           </div>
           <div class="flex items-end gap-2">
             <el-input
@@ -127,6 +133,8 @@
         </template>
       </div>
     </template>
+
+    <directory-dialog v-model:visible="directoryVisible" :initial-path="cwd" @select="onDirectorySelect" />
   </div>
 </template>
 
@@ -135,6 +143,7 @@ import { defineComponent } from 'vue';
 import { ElInput, ElButton, ElSelect, ElOption } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import TranscriptItem from './TranscriptItem.vue';
+import DirectoryDialog from './DirectoryDialog.vue';
 import { ICodingBridgeEvent, ICodingBridgeNode, ICodingBridgeSession } from '@/models';
 
 export default defineComponent({
@@ -145,7 +154,8 @@ export default defineComponent({
     ElSelect,
     ElOption,
     FontAwesomeIcon,
-    TranscriptItem
+    TranscriptItem,
+    DirectoryDialog
   },
   emits: ['history'],
   data() {
@@ -155,7 +165,8 @@ export default defineComponent({
       model: '',
       permissionMode: 'default',
       provider: 'claude',
-      effort: ''
+      effort: '',
+      directoryVisible: false
     };
   },
   computed: {
@@ -315,6 +326,12 @@ export default defineComponent({
     },
     onInterrupt() {
       this.$store.dispatch('codingBridge/interruptSession');
+    },
+    openDirectory() {
+      this.directoryVisible = true;
+    },
+    onDirectorySelect(path: string) {
+      this.cwd = path;
     },
     onNewSession() {
       this.$store.dispatch('codingBridge/newSession');

--- a/src/constants/codingBridge.ts
+++ b/src/constants/codingBridge.ts
@@ -24,6 +24,7 @@ export const CB_ACTION_PERMISSION_RESOLVE = 'permission.resolve';
 export const CB_ACTION_SESSIONS_LIST = 'sessions.list';
 export const CB_ACTION_HISTORY_LIST = 'history.list';
 export const CB_ACTION_HISTORY_GET = 'history.get';
+export const CB_ACTION_FS_LIST = 'fs.list';
 export const CB_ACTION_PING = 'ping';
 
 // --- Inner events: node -> browser -----------------------------------------
@@ -40,6 +41,7 @@ export const CB_EVENT_SESSION_CLOSED = 'session.closed';
 export const CB_EVENT_SESSIONS_SNAPSHOT = 'sessions.snapshot';
 export const CB_EVENT_HISTORY_SNAPSHOT = 'history.snapshot';
 export const CB_EVENT_HISTORY_DETAIL = 'history.detail';
+export const CB_EVENT_FS_LIST = 'fs.list';
 export const CB_EVENT_PONG = 'pong';
 
 // Reconnect backoff for the browser WebSocket (milliseconds).

--- a/src/i18n/ar/codingBridge.json
+++ b/src/i18n/ar/codingBridge.json
@@ -262,5 +262,33 @@
   "session.effortMax": {
     "message": "أقصى",
     "description": "Reasoning effort: maximum (Claude only)"
+  },
+  "directory.title": {
+    "message": "اختر دليل العمل",
+    "description": "Working-directory picker dialog title"
+  },
+  "directory.choose": {
+    "message": "استخدم هذا الدليل",
+    "description": "Button: select the current directory"
+  },
+  "directory.up": {
+    "message": "الدليل الأصل",
+    "description": "Button: go to the parent directory"
+  },
+  "directory.refresh": {
+    "message": "تحديث",
+    "description": "Button: reload the current directory"
+  },
+  "directory.loading": {
+    "message": "جارٍ التحميل…",
+    "description": "Directory listing loading hint"
+  },
+  "directory.empty": {
+    "message": "هذا الدليل فارغ.",
+    "description": "Empty directory hint"
+  },
+  "directory.truncated": {
+    "message": "عرض أول 1000 عنصر.",
+    "description": "Hint shown when the listing was truncated"
   }
 }

--- a/src/i18n/de/codingBridge.json
+++ b/src/i18n/de/codingBridge.json
@@ -262,5 +262,33 @@
   "session.effortMax": {
     "message": "Maximal",
     "description": "Reasoning effort: maximum (Claude only)"
+  },
+  "directory.title": {
+    "message": "Arbeitsverzeichnis wählen",
+    "description": "Working-directory picker dialog title"
+  },
+  "directory.choose": {
+    "message": "Dieses Verzeichnis verwenden",
+    "description": "Button: select the current directory"
+  },
+  "directory.up": {
+    "message": "Übergeordnetes Verzeichnis",
+    "description": "Button: go to the parent directory"
+  },
+  "directory.refresh": {
+    "message": "Aktualisieren",
+    "description": "Button: reload the current directory"
+  },
+  "directory.loading": {
+    "message": "Wird geladen…",
+    "description": "Directory listing loading hint"
+  },
+  "directory.empty": {
+    "message": "Dieses Verzeichnis ist leer.",
+    "description": "Empty directory hint"
+  },
+  "directory.truncated": {
+    "message": "Die ersten 1000 Einträge werden angezeigt.",
+    "description": "Hint shown when the listing was truncated"
   }
 }

--- a/src/i18n/el/codingBridge.json
+++ b/src/i18n/el/codingBridge.json
@@ -262,5 +262,33 @@
   "session.effortMax": {
     "message": "Μέγιστη",
     "description": "Reasoning effort: maximum (Claude only)"
+  },
+  "directory.title": {
+    "message": "Επιλογή καταλόγου εργασίας",
+    "description": "Working-directory picker dialog title"
+  },
+  "directory.choose": {
+    "message": "Χρήση αυτού του καταλόγου",
+    "description": "Button: select the current directory"
+  },
+  "directory.up": {
+    "message": "Γονικός κατάλογος",
+    "description": "Button: go to the parent directory"
+  },
+  "directory.refresh": {
+    "message": "Ανανέωση",
+    "description": "Button: reload the current directory"
+  },
+  "directory.loading": {
+    "message": "Φόρτωση…",
+    "description": "Directory listing loading hint"
+  },
+  "directory.empty": {
+    "message": "Αυτός ο κατάλογος είναι κενός.",
+    "description": "Empty directory hint"
+  },
+  "directory.truncated": {
+    "message": "Εμφάνιση των πρώτων 1000 στοιχείων.",
+    "description": "Hint shown when the listing was truncated"
   }
 }

--- a/src/i18n/en/codingBridge.json
+++ b/src/i18n/en/codingBridge.json
@@ -262,5 +262,33 @@
   "session.effortMax": {
     "message": "Max",
     "description": "Reasoning effort: maximum (Claude only)"
+  },
+  "directory.title": {
+    "message": "Choose working directory",
+    "description": "Working-directory picker dialog title"
+  },
+  "directory.choose": {
+    "message": "Use this directory",
+    "description": "Button: select the current directory"
+  },
+  "directory.up": {
+    "message": "Parent directory",
+    "description": "Button: go to the parent directory"
+  },
+  "directory.refresh": {
+    "message": "Refresh",
+    "description": "Button: reload the current directory"
+  },
+  "directory.loading": {
+    "message": "Loading…",
+    "description": "Directory listing loading hint"
+  },
+  "directory.empty": {
+    "message": "This directory is empty.",
+    "description": "Empty directory hint"
+  },
+  "directory.truncated": {
+    "message": "Showing the first 1000 entries.",
+    "description": "Hint shown when the listing was truncated"
   }
 }

--- a/src/i18n/es/codingBridge.json
+++ b/src/i18n/es/codingBridge.json
@@ -262,5 +262,33 @@
   "session.effortMax": {
     "message": "Máximo",
     "description": "Reasoning effort: maximum (Claude only)"
+  },
+  "directory.title": {
+    "message": "Elegir directorio de trabajo",
+    "description": "Working-directory picker dialog title"
+  },
+  "directory.choose": {
+    "message": "Usar este directorio",
+    "description": "Button: select the current directory"
+  },
+  "directory.up": {
+    "message": "Directorio superior",
+    "description": "Button: go to the parent directory"
+  },
+  "directory.refresh": {
+    "message": "Actualizar",
+    "description": "Button: reload the current directory"
+  },
+  "directory.loading": {
+    "message": "Cargando…",
+    "description": "Directory listing loading hint"
+  },
+  "directory.empty": {
+    "message": "Este directorio está vacío.",
+    "description": "Empty directory hint"
+  },
+  "directory.truncated": {
+    "message": "Mostrando las primeras 1000 entradas.",
+    "description": "Hint shown when the listing was truncated"
   }
 }

--- a/src/i18n/fi/codingBridge.json
+++ b/src/i18n/fi/codingBridge.json
@@ -262,5 +262,33 @@
   "session.effortMax": {
     "message": "Maksimi",
     "description": "Reasoning effort: maximum (Claude only)"
+  },
+  "directory.title": {
+    "message": "Valitse työhakemisto",
+    "description": "Working-directory picker dialog title"
+  },
+  "directory.choose": {
+    "message": "Käytä tätä hakemistoa",
+    "description": "Button: select the current directory"
+  },
+  "directory.up": {
+    "message": "Ylähakemisto",
+    "description": "Button: go to the parent directory"
+  },
+  "directory.refresh": {
+    "message": "Päivitä",
+    "description": "Button: reload the current directory"
+  },
+  "directory.loading": {
+    "message": "Ladataan…",
+    "description": "Directory listing loading hint"
+  },
+  "directory.empty": {
+    "message": "Tämä hakemisto on tyhjä.",
+    "description": "Empty directory hint"
+  },
+  "directory.truncated": {
+    "message": "Näytetään ensimmäiset 1000 kohdetta.",
+    "description": "Hint shown when the listing was truncated"
   }
 }

--- a/src/i18n/fr/codingBridge.json
+++ b/src/i18n/fr/codingBridge.json
@@ -262,5 +262,33 @@
   "session.effortMax": {
     "message": "Maximum",
     "description": "Reasoning effort: maximum (Claude only)"
+  },
+  "directory.title": {
+    "message": "Choisir le répertoire de travail",
+    "description": "Working-directory picker dialog title"
+  },
+  "directory.choose": {
+    "message": "Utiliser ce répertoire",
+    "description": "Button: select the current directory"
+  },
+  "directory.up": {
+    "message": "Répertoire parent",
+    "description": "Button: go to the parent directory"
+  },
+  "directory.refresh": {
+    "message": "Actualiser",
+    "description": "Button: reload the current directory"
+  },
+  "directory.loading": {
+    "message": "Chargement…",
+    "description": "Directory listing loading hint"
+  },
+  "directory.empty": {
+    "message": "Ce répertoire est vide.",
+    "description": "Empty directory hint"
+  },
+  "directory.truncated": {
+    "message": "Affichage des 1000 premières entrées.",
+    "description": "Hint shown when the listing was truncated"
   }
 }

--- a/src/i18n/it/codingBridge.json
+++ b/src/i18n/it/codingBridge.json
@@ -262,5 +262,33 @@
   "session.effortMax": {
     "message": "Massimo",
     "description": "Reasoning effort: maximum (Claude only)"
+  },
+  "directory.title": {
+    "message": "Scegli la directory di lavoro",
+    "description": "Working-directory picker dialog title"
+  },
+  "directory.choose": {
+    "message": "Usa questa directory",
+    "description": "Button: select the current directory"
+  },
+  "directory.up": {
+    "message": "Directory superiore",
+    "description": "Button: go to the parent directory"
+  },
+  "directory.refresh": {
+    "message": "Aggiorna",
+    "description": "Button: reload the current directory"
+  },
+  "directory.loading": {
+    "message": "Caricamento…",
+    "description": "Directory listing loading hint"
+  },
+  "directory.empty": {
+    "message": "Questa directory è vuota.",
+    "description": "Empty directory hint"
+  },
+  "directory.truncated": {
+    "message": "Mostrate le prime 1000 voci.",
+    "description": "Hint shown when the listing was truncated"
   }
 }

--- a/src/i18n/ja/codingBridge.json
+++ b/src/i18n/ja/codingBridge.json
@@ -262,5 +262,33 @@
   "session.effortMax": {
     "message": "最大",
     "description": "Reasoning effort: maximum (Claude only)"
+  },
+  "directory.title": {
+    "message": "作業ディレクトリを選択",
+    "description": "Working-directory picker dialog title"
+  },
+  "directory.choose": {
+    "message": "このディレクトリを使用",
+    "description": "Button: select the current directory"
+  },
+  "directory.up": {
+    "message": "親ディレクトリ",
+    "description": "Button: go to the parent directory"
+  },
+  "directory.refresh": {
+    "message": "更新",
+    "description": "Button: reload the current directory"
+  },
+  "directory.loading": {
+    "message": "読み込み中…",
+    "description": "Directory listing loading hint"
+  },
+  "directory.empty": {
+    "message": "このディレクトリは空です。",
+    "description": "Empty directory hint"
+  },
+  "directory.truncated": {
+    "message": "最初の 1000 件を表示しています。",
+    "description": "Hint shown when the listing was truncated"
   }
 }

--- a/src/i18n/ko/codingBridge.json
+++ b/src/i18n/ko/codingBridge.json
@@ -262,5 +262,33 @@
   "session.effortMax": {
     "message": "최대",
     "description": "Reasoning effort: maximum (Claude only)"
+  },
+  "directory.title": {
+    "message": "작업 디렉터리 선택",
+    "description": "Working-directory picker dialog title"
+  },
+  "directory.choose": {
+    "message": "이 디렉터리 사용",
+    "description": "Button: select the current directory"
+  },
+  "directory.up": {
+    "message": "상위 디렉터리",
+    "description": "Button: go to the parent directory"
+  },
+  "directory.refresh": {
+    "message": "새로 고침",
+    "description": "Button: reload the current directory"
+  },
+  "directory.loading": {
+    "message": "불러오는 중…",
+    "description": "Directory listing loading hint"
+  },
+  "directory.empty": {
+    "message": "이 디렉터리는 비어 있습니다.",
+    "description": "Empty directory hint"
+  },
+  "directory.truncated": {
+    "message": "처음 1000개 항목을 표시합니다.",
+    "description": "Hint shown when the listing was truncated"
   }
 }

--- a/src/i18n/pl/codingBridge.json
+++ b/src/i18n/pl/codingBridge.json
@@ -262,5 +262,33 @@
   "session.effortMax": {
     "message": "Maksymalny",
     "description": "Reasoning effort: maximum (Claude only)"
+  },
+  "directory.title": {
+    "message": "Wybierz katalog roboczy",
+    "description": "Working-directory picker dialog title"
+  },
+  "directory.choose": {
+    "message": "Użyj tego katalogu",
+    "description": "Button: select the current directory"
+  },
+  "directory.up": {
+    "message": "Katalog nadrzędny",
+    "description": "Button: go to the parent directory"
+  },
+  "directory.refresh": {
+    "message": "Odśwież",
+    "description": "Button: reload the current directory"
+  },
+  "directory.loading": {
+    "message": "Ładowanie…",
+    "description": "Directory listing loading hint"
+  },
+  "directory.empty": {
+    "message": "Ten katalog jest pusty.",
+    "description": "Empty directory hint"
+  },
+  "directory.truncated": {
+    "message": "Wyświetlono pierwsze 1000 pozycji.",
+    "description": "Hint shown when the listing was truncated"
   }
 }

--- a/src/i18n/pt/codingBridge.json
+++ b/src/i18n/pt/codingBridge.json
@@ -262,5 +262,33 @@
   "session.effortMax": {
     "message": "Máximo",
     "description": "Reasoning effort: maximum (Claude only)"
+  },
+  "directory.title": {
+    "message": "Escolher diretório de trabalho",
+    "description": "Working-directory picker dialog title"
+  },
+  "directory.choose": {
+    "message": "Usar este diretório",
+    "description": "Button: select the current directory"
+  },
+  "directory.up": {
+    "message": "Diretório pai",
+    "description": "Button: go to the parent directory"
+  },
+  "directory.refresh": {
+    "message": "Atualizar",
+    "description": "Button: reload the current directory"
+  },
+  "directory.loading": {
+    "message": "A carregar…",
+    "description": "Directory listing loading hint"
+  },
+  "directory.empty": {
+    "message": "Este diretório está vazio.",
+    "description": "Empty directory hint"
+  },
+  "directory.truncated": {
+    "message": "A mostrar as primeiras 1000 entradas.",
+    "description": "Hint shown when the listing was truncated"
   }
 }

--- a/src/i18n/ru/codingBridge.json
+++ b/src/i18n/ru/codingBridge.json
@@ -262,5 +262,33 @@
   "session.effortMax": {
     "message": "Максимальный",
     "description": "Reasoning effort: maximum (Claude only)"
+  },
+  "directory.title": {
+    "message": "Выберите рабочий каталог",
+    "description": "Working-directory picker dialog title"
+  },
+  "directory.choose": {
+    "message": "Использовать этот каталог",
+    "description": "Button: select the current directory"
+  },
+  "directory.up": {
+    "message": "Родительский каталог",
+    "description": "Button: go to the parent directory"
+  },
+  "directory.refresh": {
+    "message": "Обновить",
+    "description": "Button: reload the current directory"
+  },
+  "directory.loading": {
+    "message": "Загрузка…",
+    "description": "Directory listing loading hint"
+  },
+  "directory.empty": {
+    "message": "Этот каталог пуст.",
+    "description": "Empty directory hint"
+  },
+  "directory.truncated": {
+    "message": "Показаны первые 1000 записей.",
+    "description": "Hint shown when the listing was truncated"
   }
 }

--- a/src/i18n/sr/codingBridge.json
+++ b/src/i18n/sr/codingBridge.json
@@ -262,5 +262,33 @@
   "session.effortMax": {
     "message": "Максималан",
     "description": "Reasoning effort: maximum (Claude only)"
+  },
+  "directory.title": {
+    "message": "Изаберите радни директоријум",
+    "description": "Working-directory picker dialog title"
+  },
+  "directory.choose": {
+    "message": "Користи овај директоријум",
+    "description": "Button: select the current directory"
+  },
+  "directory.up": {
+    "message": "Надређени директоријум",
+    "description": "Button: go to the parent directory"
+  },
+  "directory.refresh": {
+    "message": "Освежи",
+    "description": "Button: reload the current directory"
+  },
+  "directory.loading": {
+    "message": "Учитавање…",
+    "description": "Directory listing loading hint"
+  },
+  "directory.empty": {
+    "message": "Овај директоријум је празан.",
+    "description": "Empty directory hint"
+  },
+  "directory.truncated": {
+    "message": "Приказано првих 1000 ставки.",
+    "description": "Hint shown when the listing was truncated"
   }
 }

--- a/src/i18n/sv/codingBridge.json
+++ b/src/i18n/sv/codingBridge.json
@@ -262,5 +262,33 @@
   "session.effortMax": {
     "message": "Max",
     "description": "Reasoning effort: maximum (Claude only)"
+  },
+  "directory.title": {
+    "message": "Välj arbetskatalog",
+    "description": "Working-directory picker dialog title"
+  },
+  "directory.choose": {
+    "message": "Använd den här katalogen",
+    "description": "Button: select the current directory"
+  },
+  "directory.up": {
+    "message": "Överordnad katalog",
+    "description": "Button: go to the parent directory"
+  },
+  "directory.refresh": {
+    "message": "Uppdatera",
+    "description": "Button: reload the current directory"
+  },
+  "directory.loading": {
+    "message": "Läser in…",
+    "description": "Directory listing loading hint"
+  },
+  "directory.empty": {
+    "message": "Den här katalogen är tom.",
+    "description": "Empty directory hint"
+  },
+  "directory.truncated": {
+    "message": "Visar de första 1000 posterna.",
+    "description": "Hint shown when the listing was truncated"
   }
 }

--- a/src/i18n/uk/codingBridge.json
+++ b/src/i18n/uk/codingBridge.json
@@ -262,5 +262,33 @@
   "session.effortMax": {
     "message": "Максимальний",
     "description": "Reasoning effort: maximum (Claude only)"
+  },
+  "directory.title": {
+    "message": "Виберіть робочий каталог",
+    "description": "Working-directory picker dialog title"
+  },
+  "directory.choose": {
+    "message": "Використати цей каталог",
+    "description": "Button: select the current directory"
+  },
+  "directory.up": {
+    "message": "Батьківський каталог",
+    "description": "Button: go to the parent directory"
+  },
+  "directory.refresh": {
+    "message": "Оновити",
+    "description": "Button: reload the current directory"
+  },
+  "directory.loading": {
+    "message": "Завантаження…",
+    "description": "Directory listing loading hint"
+  },
+  "directory.empty": {
+    "message": "Цей каталог порожній.",
+    "description": "Empty directory hint"
+  },
+  "directory.truncated": {
+    "message": "Показано перші 1000 записів.",
+    "description": "Hint shown when the listing was truncated"
   }
 }

--- a/src/i18n/zh-CN/codingBridge.json
+++ b/src/i18n/zh-CN/codingBridge.json
@@ -262,5 +262,33 @@
   "session.effortMax": {
     "message": "最高",
     "description": "Reasoning effort: maximum (Claude only)"
+  },
+  "directory.title": {
+    "message": "选择工作目录",
+    "description": "Working-directory picker dialog title"
+  },
+  "directory.choose": {
+    "message": "使用此目录",
+    "description": "Button: select the current directory"
+  },
+  "directory.up": {
+    "message": "上级目录",
+    "description": "Button: go to the parent directory"
+  },
+  "directory.refresh": {
+    "message": "刷新",
+    "description": "Button: reload the current directory"
+  },
+  "directory.loading": {
+    "message": "正在加载…",
+    "description": "Directory listing loading hint"
+  },
+  "directory.empty": {
+    "message": "此目录为空。",
+    "description": "Empty directory hint"
+  },
+  "directory.truncated": {
+    "message": "仅显示前 1000 项。",
+    "description": "Hint shown when the listing was truncated"
   }
 }

--- a/src/i18n/zh-TW/codingBridge.json
+++ b/src/i18n/zh-TW/codingBridge.json
@@ -262,5 +262,33 @@
   "session.effortMax": {
     "message": "最高",
     "description": "Reasoning effort: maximum (Claude only)"
+  },
+  "directory.title": {
+    "message": "選擇工作目錄",
+    "description": "Working-directory picker dialog title"
+  },
+  "directory.choose": {
+    "message": "使用此目錄",
+    "description": "Button: select the current directory"
+  },
+  "directory.up": {
+    "message": "上層目錄",
+    "description": "Button: go to the parent directory"
+  },
+  "directory.refresh": {
+    "message": "重新整理",
+    "description": "Button: reload the current directory"
+  },
+  "directory.loading": {
+    "message": "正在載入…",
+    "description": "Directory listing loading hint"
+  },
+  "directory.empty": {
+    "message": "此目錄為空。",
+    "description": "Empty directory hint"
+  },
+  "directory.truncated": {
+    "message": "僅顯示前 1000 項。",
+    "description": "Hint shown when the listing was truncated"
   }
 }

--- a/src/models/codingBridge.ts
+++ b/src/models/codingBridge.ts
@@ -80,6 +80,23 @@ export interface ICodingBridgeEvent {
   cost_usd?: number;
 }
 
+/** One entry returned by a node's `fs.list` directory listing. */
+export interface ICodingBridgeDirEntry {
+  name: string;
+  path: string;
+  type: 'dir' | 'file';
+}
+
+/** A directory snapshot from a node, used by the working-directory picker. */
+export interface ICodingBridgeDirListing {
+  path: string;
+  parent: string | null;
+  sep: string;
+  entries: ICodingBridgeDirEntry[];
+  truncated?: boolean;
+  error?: string;
+}
+
 /** A pending tool-permission request awaiting the user's approval. */
 export interface ICodingBridgePermissionRequest {
   request_id: string;

--- a/src/plugins/font-awesome.ts
+++ b/src/plugins/font-awesome.ts
@@ -135,7 +135,10 @@ import {
   faUserXmark as faSolidUserXmark,
   faClockRotateLeft as faSolidClockRotateLeft,
   faEye as faSolidEye,
-  faTerminal as faSolidTerminal
+  faTerminal as faSolidTerminal,
+  faFolder as faSolidFolder,
+  faFolderOpen as faSolidFolderOpen,
+  faFile as faSolidFile
 } from '@fortawesome/free-solid-svg-icons';
 // add icons
 library.add(faSolidEllipsis);
@@ -270,3 +273,6 @@ library.add(faSolidBookOpen);
 library.add(faSolidReceipt);
 library.add(faSolidDollarSign);
 library.add(faSolidFileExport);
+library.add(faSolidFolder);
+library.add(faSolidFolderOpen);
+library.add(faSolidFile);

--- a/src/store/codingBridge/actions.ts
+++ b/src/store/codingBridge/actions.ts
@@ -12,6 +12,7 @@ import {
   CB_ACTION_PERMISSION_RESOLVE,
   CB_ACTION_HISTORY_LIST,
   CB_ACTION_HISTORY_GET,
+  CB_ACTION_FS_LIST,
   CB_EVENT_SESSION_STARTED,
   CB_EVENT_SESSION_TEXT,
   CB_EVENT_SESSION_THINKING,
@@ -24,7 +25,8 @@ import {
   CB_EVENT_SESSION_CLOSED,
   CB_EVENT_SESSIONS_SNAPSHOT,
   CB_EVENT_HISTORY_SNAPSHOT,
-  CB_EVENT_HISTORY_DETAIL
+  CB_EVENT_HISTORY_DETAIL,
+  CB_EVENT_FS_LIST
 } from '@/constants';
 
 // The live WebSocket is intentionally kept OUT of Vuex state (it is not
@@ -155,6 +157,18 @@ const applyNodeEvent = (
       break;
     case CB_EVENT_HISTORY_DETAIL:
       applyHistoryDetail(commit, payload, fromNode);
+      break;
+    case CB_EVENT_FS_LIST:
+      // Directory listings are node-scoped (no session_id) and feed the
+      // working-directory picker directly.
+      commit('setDirectory', {
+        path: payload.path,
+        parent: payload.parent ?? null,
+        sep: payload.sep ?? '/',
+        entries: payload.entries ?? [],
+        truncated: payload.truncated,
+        error: payload.error
+      });
       break;
     default:
       break;
@@ -477,6 +491,23 @@ export const getHistoryDetail = (
   });
 };
 
+// Ask the current node to list a directory for the working-directory picker.
+export const browseDir = (
+  { commit, state }: ActionContext<ICodingBridgeState, IRootState>,
+  path?: string
+): void => {
+  const nodeId = state.currentNodeId;
+  if (!nodeId || !socket) {
+    return;
+  }
+  commit('setDirectoryLoading', true);
+  socket.sendToNode(nodeId, { action: CB_ACTION_FS_LIST, path: path || undefined });
+};
+
+export const clearDirectory = ({ commit }: ActionContext<ICodingBridgeState, IRootState>): void => {
+  commit('setDirectory', undefined);
+};
+
 export default {
   resetAll,
   getApplications,
@@ -493,5 +524,7 @@ export default {
   closeSession,
   resolvePermission,
   getHistory,
-  getHistoryDetail
+  getHistoryDetail,
+  browseDir,
+  clearDirectory
 };

--- a/src/store/codingBridge/models.ts
+++ b/src/store/codingBridge/models.ts
@@ -1,6 +1,7 @@
 import { Status } from '@/models';
 import {
   ICodingBridgeConnectionStatus,
+  ICodingBridgeDirListing,
   ICodingBridgeEvent,
   ICodingBridgeHistorySummary,
   ICodingBridgeNode,
@@ -26,6 +27,10 @@ export interface ICodingBridgeState {
   historyRef: ICodingBridgeHistoryRef | undefined;
   permissions: ICodingBridgePermissionRequest[];
   connection: ICodingBridgeConnectionStatus;
+  // Latest directory snapshot for the working-directory picker (node-scoped,
+  // transient: replaced on each `fs.list` and never persisted).
+  directory: ICodingBridgeDirListing | undefined;
+  directoryLoading: boolean;
   // Coding Bridge is not a billed API service, so it owns no application /
   // service / credential. These fields exist only so the shared `Main.vue`
   // layout (which is generic over per-app modules) reads `undefined` and

--- a/src/store/codingBridge/mutations.ts
+++ b/src/store/codingBridge/mutations.ts
@@ -2,6 +2,7 @@ import initialState from './state';
 import { ICodingBridgeHistoryRef, ICodingBridgeState } from './models';
 import {
   ICodingBridgeConnectionStatus,
+  ICodingBridgeDirListing,
   ICodingBridgeEvent,
   ICodingBridgeHistorySummary,
   ICodingBridgeNode,
@@ -102,6 +103,15 @@ export const setHistoryRef = (state: ICodingBridgeState, payload: ICodingBridgeH
   state.historyRef = payload;
 };
 
+export const setDirectory = (state: ICodingBridgeState, payload: ICodingBridgeDirListing | undefined): void => {
+  state.directory = payload;
+  state.directoryLoading = false;
+};
+
+export const setDirectoryLoading = (state: ICodingBridgeState, payload: boolean): void => {
+  state.directoryLoading = payload;
+};
+
 export const addPermission = (state: ICodingBridgeState, payload: ICodingBridgePermissionRequest): void => {
   if (state.permissions.some((item) => item.request_id === payload.request_id)) {
     return;
@@ -144,6 +154,8 @@ export default {
   setEvents,
   setHistory,
   setHistoryRef,
+  setDirectory,
+  setDirectoryLoading,
   addPermission,
   removePermission,
   removeNodeData

--- a/src/store/codingBridge/state.ts
+++ b/src/store/codingBridge/state.ts
@@ -12,6 +12,8 @@ export default (): ICodingBridgeState => {
     historyRef: undefined,
     permissions: [],
     connection: 'disconnected',
+    directory: undefined,
+    directoryLoading: false,
     application: undefined,
     applications: undefined,
     service: undefined,


### PR DESCRIPTION
Consumes CodingBridgeAgent #8 (the node's `fs.list` directory listing).

## What

Adds a working-directory **file browser** so a user no longer has to type an
absolute path into the cwd box — they can browse their device's filesystem and
pick a folder.

- A folder button on the cwd input opens a `DirectoryDialog`.
- The dialog lists the chosen directory via the node's `fs.list` action:
  directories first (clickable to descend), files shown read-only.
- Parent (`..`) navigation, refresh, and a "Use this directory" action that
  writes the selected absolute path back into the composer's cwd field.
- Honours the agent's safety caps: a `truncated` notice when a directory has
  more than 1000 entries, and surfaces `permission denied` / `not found`
  errors returned by the node.

## Wiring

- `constants/codingBridge.ts` — `CB_ACTION_FS_LIST` / `CB_EVENT_FS_LIST`.
- `models/codingBridge.ts` — `ICodingBridgeDirEntry` / `ICodingBridgeDirListing`.
- `store/codingBridge` — `browseDir(path?)` + `clearDirectory` actions, a
  `directory` / `directoryLoading` slice, and `setDirectory` /
  `setDirectoryLoading` mutations. The `fs.list` event is node-scoped (no
  `session_id`) and feeds the picker directly. The listing is transient and
  never persisted.
- `components/codingBridge/DirectoryDialog.vue` — new dialog.
- `plugins/font-awesome.ts` — register `folder`, `folder-open`, `file` solid
  icons (per the repo's centralized-registration convention).

## i18n

7 new keys (`directory.title/choose/up/refresh/loading/empty/truncated`) added
to all 18 locales.

## Validation

- `vue-tsc -b --force` — clean (build mode, matches CI)
- `eslint` — clean
- `npm run test:run` — 141 tests pass
- `scripts/check_i18n_coverage.py` — 17 locales × 40 namespaces match zh-CN
- beachball change file included