### PR TITLE
fix(download): remove top navigation header from the download page

### DIFF
--- a/change/@acedatacloud-nexior-download-no-header.json
+++ b/change/@acedatacloud-nexior-download-no-header.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "remove the top navigation header from the mobile download page (use a header-less layout)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/layouts/Bare.vue
+++ b/src/layouts/Bare.vue
@@ -1,0 +1,24 @@
+<template>
+  <el-container class="wrapper min-h-[100vh]">
+    <el-main class="main"> <router-view /> </el-main>
+    <el-footer class="footer p-0 h-auto">
+      <bottom-footer />
+    </el-footer>
+  </el-container>
+</template>
+
+<script lang="ts">
+import BottomFooter from '@/components/common/BottomFooter.vue';
+import { ElContainer, ElMain, ElFooter } from 'element-plus';
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'LayoutBare',
+  components: {
+    BottomFooter,
+    ElContainer,
+    ElMain,
+    ElFooter
+  }
+});
+</script>

--- a/src/pages/download/Index.vue
+++ b/src/pages/download/Index.vue
@@ -252,7 +252,7 @@ export default defineComponent({
 .download-page {
   position: relative;
   overflow: hidden;
-  min-height: calc(100vh - 140px);
+  min-height: calc(100vh - 80px);
   background: var(--el-bg-color);
   color: var(--el-text-color-primary);
 }

--- a/src/router/download.ts
+++ b/src/router/download.ts
@@ -2,7 +2,7 @@ import { ROUTE_DOWNLOAD } from './constants';
 
 export default {
   path: '/download',
-  component: () => import('@/layouts/Index.vue'),
+  component: () => import('@/layouts/Bare.vue'),
   children: [
     {
       path: '',


### PR DESCRIPTION
## Why

The standalone `studio.acedata.cloud/download` landing page inherited the shared `Index` layout's top navigation header (`TopHeader`), which looked out of place above the dedicated AceData hero.

## What

- Added a header-less `src/layouts/Bare.vue` (footer only) and routed `/download` through it, so the page leads straight with the hero.
- The shared `Index` layout is untouched, so `/order` and the 404 page keep their header.
- Relaxed the page `min-height` from `100vh - 140px` to `100vh - 80px` since the header is gone.

## Validation

- `npx vue-tsc --noEmit` — clean
- `npx eslint` on the changed files — clean
- `npx beachball check` — passes (change file included)