### PR TITLE
feat(coding-bridge): render composer options from node capabilities, not hard-coded

### DIFF
--- a/change/@acedatacloud-nexior-coding-bridge-dynamic-options.json
+++ b/change/@acedatacloud-nexior-coding-bridge-dynamic-options.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Coding Bridge: render composer provider/model/effort/permission-mode options from the node's capabilities.get instead of hard-coding them",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/codingBridge/SessionView.vue
+++ b/src/components/codingBridge/SessionView.vue
@@ -77,7 +77,7 @@
               v-model="model"
               size="small"
               filterable
-              allow-create
+              :allow-create="allowCustomModel"
               default-first-option
               clearable
               class="w-40"
@@ -144,7 +144,13 @@ import { ElInput, ElButton, ElSelect, ElOption } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import TranscriptItem from './TranscriptItem.vue';
 import DirectoryDialog from './DirectoryDialog.vue';
-import { ICodingBridgeEvent, ICodingBridgeNode, ICodingBridgeSession } from '@/models';
+import {
+  ICodingBridgeCapabilities,
+  ICodingBridgeEvent,
+  ICodingBridgeNode,
+  ICodingBridgeProviderCapability,
+  ICodingBridgeSession
+} from '@/models';
 
 export default defineComponent({
   name: 'CodingBridgeSessionView',
@@ -218,46 +224,44 @@ export default defineComponent({
     canSend(): boolean {
       return !!this.prompt.trim() && this.connected && this.nodeOnline;
     },
+    // Everything below is sourced from the node's `capabilities.get` so the UI
+    // never hard-codes providers / models / efforts. The fallbacks only apply
+    // before capabilities have loaded (or for an offline node).
+    nodeCapabilities(): ICodingBridgeCapabilities | undefined {
+      const id = this.currentNodeId;
+      return id ? this.$store.state.codingBridge?.capabilities?.[id] : undefined;
+    },
+    providerCaps(): ICodingBridgeProviderCapability[] {
+      return this.nodeCapabilities?.providers ?? [];
+    },
+    currentProviderCap(): ICodingBridgeProviderCapability | undefined {
+      return this.providerCaps.find((cap) => cap.name === this.provider);
+    },
     providerOptions(): { label: string; value: string }[] {
+      if (this.providerCaps.length) {
+        return this.providerCaps.map((cap) => ({ value: cap.name, label: cap.label }));
+      }
       return [
         { label: this.$t('codingBridge.session.providerClaude') as string, value: 'claude' },
         { label: this.$t('codingBridge.session.providerCodex') as string, value: 'codex' }
       ];
     },
     modelOptions(): { label: string; value: string }[] {
-      if (this.provider === 'codex') {
-        return [
-          { label: 'GPT-5 Codex', value: 'gpt-5-codex' },
-          { label: 'GPT-5', value: 'gpt-5' },
-          { label: 'o3', value: 'o3' }
-        ];
-      }
-      return [
-        { label: 'Claude Sonnet', value: 'sonnet' },
-        { label: 'Claude Opus', value: 'opus' },
-        { label: 'Claude Haiku', value: 'haiku' }
-      ];
+      return this.currentProviderCap?.models ?? [];
+    },
+    // Free-typed models stay allowed by default so a brand-new model always works.
+    allowCustomModel(): boolean {
+      return this.currentProviderCap?.allow_custom_model ?? true;
     },
     effortOptions(): { label: string; value: string }[] {
-      const options = [
-        { label: this.$t('codingBridge.session.effortDefault') as string, value: '' },
-        { label: this.$t('codingBridge.session.effortLow') as string, value: 'low' },
-        { label: this.$t('codingBridge.session.effortMedium') as string, value: 'medium' },
-        { label: this.$t('codingBridge.session.effortHigh') as string, value: 'high' }
-      ];
-      // Claude exposes an extra "max" tier; Codex reasoning tops out at "high".
-      if (this.provider !== 'codex') {
-        options.push({ label: this.$t('codingBridge.session.effortMax') as string, value: 'max' });
-      }
-      return options;
+      const efforts = this.currentProviderCap?.efforts;
+      const tokens = efforts && efforts.length ? efforts : [''];
+      return tokens.map((token) => ({ value: token, label: this.effortLabel(token) }));
     },
     permissionModeOptions(): { label: string; value: string }[] {
-      return [
-        { label: this.$t('codingBridge.session.permissionModeDefault') as string, value: 'default' },
-        { label: this.$t('codingBridge.session.permissionModeAcceptEdits') as string, value: 'acceptEdits' },
-        { label: this.$t('codingBridge.session.permissionModePlan') as string, value: 'plan' },
-        { label: this.$t('codingBridge.session.permissionModeBypass') as string, value: 'bypassPermissions' }
-      ];
+      const modes = this.currentProviderCap?.permission_modes;
+      const tokens = modes && modes.length ? modes : ['default', 'acceptEdits', 'plan', 'bypassPermissions'];
+      return tokens.map((token) => ({ value: token, label: this.permissionModeLabel(token) }));
     },
     sessionMeta(): string {
       const session = this.currentSession;
@@ -284,14 +288,60 @@ export default defineComponent({
     currentSessionId() {
       this.scrollToBottom();
     },
+    currentNodeId() {
+      // Refresh capabilities when switching devices.
+      this.requestCapabilities();
+    },
+    providerCaps() {
+      // If the picked backend isn't offered by this node, fall back to the
+      // first one it reports so the model list always matches.
+      if (this.providerCaps.length && !this.providerCaps.some((cap) => cap.name === this.provider)) {
+        this.provider = this.providerCaps[0].name;
+      }
+    },
     provider() {
       // Model lists and effort tiers differ per backend, so reset both.
       this.model = '';
       this.effort = '';
     }
   },
+  mounted() {
+    this.requestCapabilities();
+  },
   methods: {
+    requestCapabilities() {
+      if (this.currentNodeId) {
+        this.$store.dispatch('codingBridge/getCapabilities', this.currentNodeId);
+      }
+    },
+    // Localize a known effort token; show the raw token for anything new so a
+    // node can introduce a tier without a web release.
+    effortLabel(token: string): string {
+      const keys: Record<string, string> = {
+        '': 'codingBridge.session.effortDefault',
+        low: 'codingBridge.session.effortLow',
+        medium: 'codingBridge.session.effortMedium',
+        high: 'codingBridge.session.effortHigh',
+        max: 'codingBridge.session.effortMax'
+      };
+      const key = keys[token];
+      return key ? (this.$t(key) as string) : token;
+    },
+    permissionModeLabel(token: string): string {
+      const keys: Record<string, string> = {
+        default: 'codingBridge.session.permissionModeDefault',
+        acceptEdits: 'codingBridge.session.permissionModeAcceptEdits',
+        plan: 'codingBridge.session.permissionModePlan',
+        bypassPermissions: 'codingBridge.session.permissionModeBypass'
+      };
+      const key = keys[token];
+      return key ? (this.$t(key) as string) : token;
+    },
     providerName(provider: string): string {
+      const cap = this.providerCaps.find((item) => item.name === provider);
+      if (cap) {
+        return cap.label;
+      }
       return provider === 'codex'
         ? (this.$t('codingBridge.session.providerCodex') as string)
         : (this.$t('codingBridge.session.providerClaude') as string);

--- a/src/constants/codingBridge.ts
+++ b/src/constants/codingBridge.ts
@@ -25,6 +25,7 @@ export const CB_ACTION_SESSIONS_LIST = 'sessions.list';
 export const CB_ACTION_HISTORY_LIST = 'history.list';
 export const CB_ACTION_HISTORY_GET = 'history.get';
 export const CB_ACTION_FS_LIST = 'fs.list';
+export const CB_ACTION_CAPABILITIES_GET = 'capabilities.get';
 export const CB_ACTION_PING = 'ping';
 
 // --- Inner events: node -> browser -----------------------------------------
@@ -42,6 +43,7 @@ export const CB_EVENT_SESSIONS_SNAPSHOT = 'sessions.snapshot';
 export const CB_EVENT_HISTORY_SNAPSHOT = 'history.snapshot';
 export const CB_EVENT_HISTORY_DETAIL = 'history.detail';
 export const CB_EVENT_FS_LIST = 'fs.list';
+export const CB_EVENT_CAPABILITIES = 'capabilities';
 export const CB_EVENT_PONG = 'pong';
 
 // Reconnect backoff for the browser WebSocket (milliseconds).

--- a/src/models/codingBridge.ts
+++ b/src/models/codingBridge.ts
@@ -18,6 +18,33 @@ export type ICodingBridgeSessionStatus = 'starting' | 'running' | 'idle' | 'clos
 
 export type ICodingBridgeHistoryProvider = 'claude' | 'codex';
 
+/** One selectable model offered by a provider, as reported by the node. */
+export interface ICodingBridgeModelOption {
+  value: string;
+  label: string;
+}
+
+/**
+ * What one backend on a node can do, reported by the node's `capabilities.get`.
+ * The UI renders dropdowns from this instead of hard-coding models / efforts,
+ * so a new model only needs a node update (or a typed-in custom value).
+ */
+export interface ICodingBridgeProviderCapability {
+  name: string;
+  label: string;
+  available: boolean;
+  models: ICodingBridgeModelOption[];
+  // Effort tokens ('' = backend default); the UI localizes known ones.
+  efforts: string[];
+  permission_modes: string[];
+  allow_custom_model: boolean;
+}
+
+/** The full capabilities descriptor a node advertises. */
+export interface ICodingBridgeCapabilities {
+  providers: ICodingBridgeProviderCapability[];
+}
+
 /** A live agent session running inside one node. */
 export interface ICodingBridgeSession {
   session_id: string;

--- a/src/store/codingBridge/actions.ts
+++ b/src/store/codingBridge/actions.ts
@@ -13,6 +13,7 @@ import {
   CB_ACTION_HISTORY_LIST,
   CB_ACTION_HISTORY_GET,
   CB_ACTION_FS_LIST,
+  CB_ACTION_CAPABILITIES_GET,
   CB_EVENT_SESSION_STARTED,
   CB_EVENT_SESSION_TEXT,
   CB_EVENT_SESSION_THINKING,
@@ -26,7 +27,8 @@ import {
   CB_EVENT_SESSIONS_SNAPSHOT,
   CB_EVENT_HISTORY_SNAPSHOT,
   CB_EVENT_HISTORY_DETAIL,
-  CB_EVENT_FS_LIST
+  CB_EVENT_FS_LIST,
+  CB_EVENT_CAPABILITIES
 } from '@/constants';
 
 // The live WebSocket is intentionally kept OUT of Vuex state (it is not
@@ -170,6 +172,14 @@ const applyNodeEvent = (
         error: payload.error
       });
       break;
+    case CB_EVENT_CAPABILITIES:
+      if (fromNode) {
+        commit('setCapabilities', {
+          node_id: fromNode,
+          capabilities: { providers: payload.providers ?? [] }
+        });
+      }
+      break;
     default:
       break;
   }
@@ -312,6 +322,7 @@ export const connect = ({
       commit('setConnection', 'connected');
       if (state.currentNodeId) {
         dispatch('getHistory', state.currentNodeId);
+        dispatch('getCapabilities', state.currentNodeId);
       }
     },
     onClose: () => commit('setConnection', 'disconnected'),
@@ -325,6 +336,7 @@ export const connect = ({
       commit('setNodeStatus', { node_id: nodeId, status });
       if (status === 'online' && nodeId === state.currentNodeId) {
         dispatch('getHistory', nodeId);
+        dispatch('getCapabilities', nodeId);
       }
     },
     onRelayError: (code, message) => console.warn('[codingBridge] relay error', code, message)
@@ -352,6 +364,7 @@ export const selectNode = (
     .map((session) => session.session_id);
   commit('setCurrentSession', ids.length ? ids[ids.length - 1] : undefined);
   dispatch('getHistory', nodeId);
+  dispatch('getCapabilities', nodeId);
 };
 
 export const newSession = ({ commit }: ActionContext<ICodingBridgeState, IRootState>): void => {
@@ -492,10 +505,7 @@ export const getHistoryDetail = (
 };
 
 // Ask the current node to list a directory for the working-directory picker.
-export const browseDir = (
-  { commit, state }: ActionContext<ICodingBridgeState, IRootState>,
-  path?: string
-): void => {
+export const browseDir = ({ commit, state }: ActionContext<ICodingBridgeState, IRootState>, path?: string): void => {
   const nodeId = state.currentNodeId;
   if (!nodeId || !socket) {
     return;
@@ -506,6 +516,16 @@ export const browseDir = (
 
 export const clearDirectory = ({ commit }: ActionContext<ICodingBridgeState, IRootState>): void => {
   commit('setDirectory', undefined);
+};
+
+// Ask a node what providers / models / efforts it offers so the UI can render
+// the composer dropdowns without hard-coding any of them.
+export const getCapabilities = ({ state }: ActionContext<ICodingBridgeState, IRootState>, nodeId?: string): void => {
+  const target = nodeId ?? state.currentNodeId;
+  if (!target || !socket) {
+    return;
+  }
+  socket.sendToNode(target, { action: CB_ACTION_CAPABILITIES_GET });
 };
 
 export default {
@@ -526,5 +546,6 @@ export default {
   getHistory,
   getHistoryDetail,
   browseDir,
-  clearDirectory
+  clearDirectory,
+  getCapabilities
 };

--- a/src/store/codingBridge/models.ts
+++ b/src/store/codingBridge/models.ts
@@ -1,5 +1,6 @@
 import { Status } from '@/models';
 import {
+  ICodingBridgeCapabilities,
   ICodingBridgeConnectionStatus,
   ICodingBridgeDirListing,
   ICodingBridgeEvent,
@@ -24,6 +25,8 @@ export interface ICodingBridgeState {
   events: Record<string, ICodingBridgeEvent[]>;
   // Past on-device sessions per node, sourced live from `history.list`.
   history: Record<string, ICodingBridgeHistorySummary[]>;
+  // What each node can do (providers/models/efforts), from `capabilities.get`.
+  capabilities: Record<string, ICodingBridgeCapabilities>;
   historyRef: ICodingBridgeHistoryRef | undefined;
   permissions: ICodingBridgePermissionRequest[];
   connection: ICodingBridgeConnectionStatus;

--- a/src/store/codingBridge/mutations.ts
+++ b/src/store/codingBridge/mutations.ts
@@ -1,6 +1,7 @@
 import initialState from './state';
 import { ICodingBridgeHistoryRef, ICodingBridgeState } from './models';
 import {
+  ICodingBridgeCapabilities,
   ICodingBridgeConnectionStatus,
   ICodingBridgeDirListing,
   ICodingBridgeEvent,
@@ -112,6 +113,13 @@ export const setDirectoryLoading = (state: ICodingBridgeState, payload: boolean)
   state.directoryLoading = payload;
 };
 
+export const setCapabilities = (
+  state: ICodingBridgeState,
+  payload: { node_id: string; capabilities: ICodingBridgeCapabilities }
+): void => {
+  state.capabilities[payload.node_id] = payload.capabilities;
+};
+
 export const addPermission = (state: ICodingBridgeState, payload: ICodingBridgePermissionRequest): void => {
   if (state.permissions.some((item) => item.request_id === payload.request_id)) {
     return;
@@ -125,6 +133,7 @@ export const removePermission = (state: ICodingBridgeState, requestId: string): 
 
 export const removeNodeData = (state: ICodingBridgeState, nodeId: string): void => {
   delete state.history[nodeId];
+  delete state.capabilities[nodeId];
   if (state.historyRef?.node_id === nodeId) {
     state.historyRef = undefined;
   }
@@ -156,6 +165,7 @@ export default {
   setHistoryRef,
   setDirectory,
   setDirectoryLoading,
+  setCapabilities,
   addPermission,
   removePermission,
   removeNodeData

--- a/src/store/codingBridge/state.ts
+++ b/src/store/codingBridge/state.ts
@@ -9,6 +9,7 @@ export default (): ICodingBridgeState => {
     sessions: {},
     events: {},
     history: {},
+    capabilities: {},
     historyRef: undefined,
     permissions: [],
     connection: 'disconnected',


### PR DESCRIPTION
## Why

The Coding Bridge composer's **provider**, **model**, **reasoning-effort** and
**permission-mode** dropdowns were hard-coded in the web app (#867 / #873). So
the day Claude ships `opus-4.9`, or a backend adds a new effort tier, we'd have
to edit Vue code and redeploy the web app. The node — where the `claude` /
`codex` CLIs actually live — should be the source of truth.

## What

Consumes the new `capabilities.get` round-trip from the node daemon
(CodingBridgeAgent #9). The node reports, per provider: its models, effort tiers,
permission modes, install status, and whether custom models are allowed. The UI
now renders every dropdown from that descriptor.

- **Store**: `capabilities` map per node; `getCapabilities` action (sends
  `capabilities.get`); `capabilities` event → `setCapabilities` mutation.
  Requested on node select / connect / node-online; cleared with node data.
- **SessionView**: `providerOptions` / `modelOptions` / `effortOptions` /
  `permissionModeOptions` derive from the selected node's capabilities. Known
  effort & permission tokens stay localized (i18n); unknown tokens render raw,
  so a node can introduce a tier with no web release. The model box stays
  free-typeable when `allow_custom_model` is set, so a brand-new model works
  the instant it exists. Provider falls back to the node's first backend if the
  current pick isn't offered.
- Minimal hard-coded fallbacks remain ONLY for the pre-load / offline window.

## Result

New model / new effort tier ⇒ update the node (or just type it). **Never the web app.**

## Tests

`vue-tsc -b` clean, eslint clean, full vitest suite green (141). No new i18n
keys (reuses those from #867 / #873), so locale coverage is unaffected.

Depends on CodingBridgeAgent #9 (capabilities descriptor). Relay passes the new
action/event through verbatim — no relay change needed.