### PR TITLE
feat(coding-bridge): paste and attach images to coding sessions

### DIFF
--- a/change/@acedatacloud-nexior-cd8bed3b-8218-408e-8e41-75577e14d125.json
+++ b/change/@acedatacloud-nexior-cd8bed3b-8218-408e-8e41-75577e14d125.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(coding-bridge): paste and attach images to coding sessions",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/codingBridge/SessionView.vue
+++ b/src/components/codingBridge/SessionView.vue
@@ -110,6 +110,24 @@
               </template>
             </el-input>
           </div>
+          <!-- Attached image thumbnails -->
+          <div v-if="images.length" class="flex flex-wrap gap-2 mb-2">
+            <div
+              v-for="(image, index) in images"
+              :key="index"
+              class="relative w-14 h-14 rounded-md overflow-hidden border border-[var(--app-border-subtle)]"
+            >
+              <img :src="image" class="w-full h-full object-cover" :alt="$t('codingBridge.session.imageAlt')" />
+              <button
+                type="button"
+                class="absolute top-0 right-0 w-4 h-4 flex items-center justify-center bg-black/55 text-white text-[10px]"
+                :title="$t('codingBridge.session.removeImage')"
+                @click="removeImage(index)"
+              >
+                <font-awesome-icon icon="fa-solid fa-xmark" />
+              </button>
+            </div>
+          </div>
           <div class="flex items-end gap-2">
             <el-input
               v-model="prompt"
@@ -119,7 +137,11 @@
               class="flex-1"
               :placeholder="$t('codingBridge.session.promptPlaceholder')"
               @keydown.enter="onComposerEnter"
+              @paste="onPaste"
             />
+            <el-button round :title="$t('codingBridge.session.attachImage')" @click="onPickImages">
+              <font-awesome-icon icon="fa-solid fa-image" />
+            </el-button>
             <el-button v-if="running" round @click="onInterrupt">
               <font-awesome-icon icon="fa-solid fa-stop" />
             </el-button>
@@ -127,6 +149,7 @@
               {{ $t('codingBridge.session.send') }}
             </el-button>
           </div>
+          <input ref="imageInput" type="file" accept="image/*" multiple class="hidden" @change="onImageInputChange" />
           <p class="text-[11px] text-[var(--app-text-subtle)] mt-1 px-1">
             {{ resumeHint ? $t('codingBridge.history.resumeHint') : $t('codingBridge.session.enterHint') }}
           </p>
@@ -140,11 +163,15 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElInput, ElButton, ElSelect, ElOption } from 'element-plus';
+import { ElInput, ElButton, ElSelect, ElOption, ElMessage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import TranscriptItem from './TranscriptItem.vue';
 import DirectoryDialog from './DirectoryDialog.vue';
 import { ICodingBridgeEvent, ICodingBridgeNode, ICodingBridgeSession } from '@/models';
+
+// Mirror the agent's per-image cap (12 MB) and bound how many attach per turn.
+const MAX_IMAGE_BYTES = 12 * 1024 * 1024;
+const MAX_IMAGES = 8;
 
 export default defineComponent({
   name: 'CodingBridgeSessionView',
@@ -166,7 +193,8 @@ export default defineComponent({
       permissionMode: 'default',
       provider: 'claude',
       effort: '',
-      directoryVisible: false
+      directoryVisible: false,
+      images: [] as string[]
     };
   },
   computed: {
@@ -216,7 +244,7 @@ export default defineComponent({
       return this.$store.state.codingBridge?.connection === 'connected';
     },
     canSend(): boolean {
-      return !!this.prompt.trim() && this.connected && this.nodeOnline;
+      return (!!this.prompt.trim() || this.images.length > 0) && this.connected && this.nodeOnline;
     },
     providerOptions(): { label: string; value: string }[] {
       return [
@@ -320,9 +348,72 @@ export default defineComponent({
         model: this.model,
         permissionMode: this.permissionMode,
         provider: this.provider,
-        effort: this.effort
+        effort: this.effort,
+        images: this.images.length ? [...this.images] : undefined
       });
       this.prompt = '';
+      this.images = [];
+    },
+    onPaste(event: ClipboardEvent) {
+      const items = event.clipboardData?.items;
+      if (!items) {
+        return;
+      }
+      const files: File[] = [];
+      for (const item of Array.from(items)) {
+        if (item.kind === 'file' && item.type.startsWith('image/')) {
+          const file = item.getAsFile();
+          if (file) {
+            files.push(file);
+          }
+        }
+      }
+      if (files.length) {
+        event.preventDefault();
+        this.addFiles(files);
+      }
+    },
+    onPickImages() {
+      (this.$refs.imageInput as HTMLInputElement | undefined)?.click();
+    },
+    onImageInputChange(event: Event) {
+      const input = event.target as HTMLInputElement;
+      if (input.files?.length) {
+        this.addFiles(Array.from(input.files));
+      }
+      input.value = '';
+    },
+    async addFiles(files: File[]) {
+      for (const file of files) {
+        if (this.images.length >= MAX_IMAGES) {
+          ElMessage.warning(this.$t('codingBridge.session.imageLimit', { count: MAX_IMAGES }) as string);
+          break;
+        }
+        if (!file.type.startsWith('image/')) {
+          continue;
+        }
+        if (file.size > MAX_IMAGE_BYTES) {
+          ElMessage.warning(this.$t('codingBridge.session.imageTooLarge') as string);
+          continue;
+        }
+        try {
+          const dataUrl = await this.readFileAsDataUrl(file);
+          this.images.push(dataUrl);
+        } catch {
+          // Ignore unreadable files rather than failing the whole paste.
+        }
+      }
+    },
+    removeImage(index: number) {
+      this.images.splice(index, 1);
+    },
+    readFileAsDataUrl(file: File): Promise<string> {
+      return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result as string);
+        reader.onerror = () => reject(reader.error);
+        reader.readAsDataURL(file);
+      });
     },
     onInterrupt() {
       this.$store.dispatch('codingBridge/interruptSession');
@@ -341,6 +432,7 @@ export default defineComponent({
       this.provider = 'claude';
       this.effort = '';
       this.prompt = '';
+      this.images = [];
     },
     scrollToBottom() {
       this.$nextTick(() => {

--- a/src/components/codingBridge/TranscriptItem.vue
+++ b/src/components/codingBridge/TranscriptItem.vue
@@ -5,7 +5,20 @@
       <div
         class="max-w-[85%] rounded-lg px-3 py-2 bg-[var(--el-color-primary)] text-white whitespace-pre-wrap break-words"
       >
-        {{ event.text }}
+        <div
+          v-if="event.images && event.images.length"
+          class="flex flex-wrap gap-1.5"
+          :class="{ 'mb-1.5': event.text }"
+        >
+          <img
+            v-for="(image, index) in event.images"
+            :key="index"
+            :src="image"
+            class="w-16 h-16 rounded object-cover"
+            alt=""
+          />
+        </div>
+        <span v-if="event.text">{{ event.text }}</span>
       </div>
     </div>
 

--- a/src/i18n/ar/codingBridge.json
+++ b/src/i18n/ar/codingBridge.json
@@ -290,5 +290,25 @@
   "directory.truncated": {
     "message": "عرض أول 1000 عنصر.",
     "description": "Hint shown when the listing was truncated"
+  },
+  "session.attachImage": {
+    "message": "إرفاق صورة",
+    "description": "Attach image button title"
+  },
+  "session.removeImage": {
+    "message": "إزالة الصورة",
+    "description": "Remove attached image button title"
+  },
+  "session.imageAlt": {
+    "message": "الصورة المرفقة",
+    "description": "Attached image thumbnail alt text"
+  },
+  "session.imageTooLarge": {
+    "message": "الصورة كبيرة جدًا؛ يجب أن تكون كل صورة أقل من 12 ميغابايت.",
+    "description": "Warning shown when an image exceeds the size limit"
+  },
+  "session.imageLimit": {
+    "message": "يمكنك إرفاق ما يصل إلى {count} صورة.",
+    "description": "Warning shown when exceeding the max number of images"
   }
 }

--- a/src/i18n/de/codingBridge.json
+++ b/src/i18n/de/codingBridge.json
@@ -290,5 +290,25 @@
   "directory.truncated": {
     "message": "Die ersten 1000 Einträge werden angezeigt.",
     "description": "Hint shown when the listing was truncated"
+  },
+  "session.attachImage": {
+    "message": "Bild anhängen",
+    "description": "Attach image button title"
+  },
+  "session.removeImage": {
+    "message": "Bild entfernen",
+    "description": "Remove attached image button title"
+  },
+  "session.imageAlt": {
+    "message": "Angehängtes Bild",
+    "description": "Attached image thumbnail alt text"
+  },
+  "session.imageTooLarge": {
+    "message": "Bild ist zu groß; halte jedes unter 12 MB.",
+    "description": "Warning shown when an image exceeds the size limit"
+  },
+  "session.imageLimit": {
+    "message": "Du kannst bis zu {count} Bilder anhängen.",
+    "description": "Warning shown when exceeding the max number of images"
   }
 }

--- a/src/i18n/el/codingBridge.json
+++ b/src/i18n/el/codingBridge.json
@@ -290,5 +290,25 @@
   "directory.truncated": {
     "message": "Εμφάνιση των πρώτων 1000 στοιχείων.",
     "description": "Hint shown when the listing was truncated"
+  },
+  "session.attachImage": {
+    "message": "Επισύναψη εικόνας",
+    "description": "Attach image button title"
+  },
+  "session.removeImage": {
+    "message": "Αφαίρεση εικόνας",
+    "description": "Remove attached image button title"
+  },
+  "session.imageAlt": {
+    "message": "Συνημμένη εικόνα",
+    "description": "Attached image thumbnail alt text"
+  },
+  "session.imageTooLarge": {
+    "message": "Η εικόνα είναι πολύ μεγάλη· κράτησε κάθε εικόνα κάτω από 12 MB.",
+    "description": "Warning shown when an image exceeds the size limit"
+  },
+  "session.imageLimit": {
+    "message": "Μπορείς να επισυνάψεις έως {count} εικόνες.",
+    "description": "Warning shown when exceeding the max number of images"
   }
 }

--- a/src/i18n/en/codingBridge.json
+++ b/src/i18n/en/codingBridge.json
@@ -290,5 +290,25 @@
   "directory.truncated": {
     "message": "Showing the first 1000 entries.",
     "description": "Hint shown when the listing was truncated"
+  },
+  "session.attachImage": {
+    "message": "Attach image",
+    "description": "Attach image button title"
+  },
+  "session.removeImage": {
+    "message": "Remove image",
+    "description": "Remove attached image button title"
+  },
+  "session.imageAlt": {
+    "message": "Attached image",
+    "description": "Attached image thumbnail alt text"
+  },
+  "session.imageTooLarge": {
+    "message": "Image is too large; keep each under 12 MB.",
+    "description": "Warning shown when an image exceeds the size limit"
+  },
+  "session.imageLimit": {
+    "message": "You can attach up to {count} images.",
+    "description": "Warning shown when exceeding the max number of images"
   }
 }

--- a/src/i18n/es/codingBridge.json
+++ b/src/i18n/es/codingBridge.json
@@ -290,5 +290,25 @@
   "directory.truncated": {
     "message": "Mostrando las primeras 1000 entradas.",
     "description": "Hint shown when the listing was truncated"
+  },
+  "session.attachImage": {
+    "message": "Adjuntar imagen",
+    "description": "Attach image button title"
+  },
+  "session.removeImage": {
+    "message": "Quitar imagen",
+    "description": "Remove attached image button title"
+  },
+  "session.imageAlt": {
+    "message": "Imagen adjunta",
+    "description": "Attached image thumbnail alt text"
+  },
+  "session.imageTooLarge": {
+    "message": "La imagen es demasiado grande; mantén cada una por debajo de 12 MB.",
+    "description": "Warning shown when an image exceeds the size limit"
+  },
+  "session.imageLimit": {
+    "message": "Puedes adjuntar hasta {count} imágenes.",
+    "description": "Warning shown when exceeding the max number of images"
   }
 }

--- a/src/i18n/fi/codingBridge.json
+++ b/src/i18n/fi/codingBridge.json
@@ -290,5 +290,25 @@
   "directory.truncated": {
     "message": "Näytetään ensimmäiset 1000 kohdetta.",
     "description": "Hint shown when the listing was truncated"
+  },
+  "session.attachImage": {
+    "message": "Liitä kuva",
+    "description": "Attach image button title"
+  },
+  "session.removeImage": {
+    "message": "Poista kuva",
+    "description": "Remove attached image button title"
+  },
+  "session.imageAlt": {
+    "message": "Liitetty kuva",
+    "description": "Attached image thumbnail alt text"
+  },
+  "session.imageTooLarge": {
+    "message": "Kuva on liian suuri; pidä jokainen alle 12 Mt.",
+    "description": "Warning shown when an image exceeds the size limit"
+  },
+  "session.imageLimit": {
+    "message": "Voit liittää enintään {count} kuvaa.",
+    "description": "Warning shown when exceeding the max number of images"
   }
 }

--- a/src/i18n/fr/codingBridge.json
+++ b/src/i18n/fr/codingBridge.json
@@ -290,5 +290,25 @@
   "directory.truncated": {
     "message": "Affichage des 1000 premières entrées.",
     "description": "Hint shown when the listing was truncated"
+  },
+  "session.attachImage": {
+    "message": "Joindre une image",
+    "description": "Attach image button title"
+  },
+  "session.removeImage": {
+    "message": "Supprimer l'image",
+    "description": "Remove attached image button title"
+  },
+  "session.imageAlt": {
+    "message": "Image jointe",
+    "description": "Attached image thumbnail alt text"
+  },
+  "session.imageTooLarge": {
+    "message": "L'image est trop volumineuse ; gardez chacune sous 12 Mo.",
+    "description": "Warning shown when an image exceeds the size limit"
+  },
+  "session.imageLimit": {
+    "message": "Vous pouvez joindre jusqu'à {count} images.",
+    "description": "Warning shown when exceeding the max number of images"
   }
 }

--- a/src/i18n/it/codingBridge.json
+++ b/src/i18n/it/codingBridge.json
@@ -290,5 +290,25 @@
   "directory.truncated": {
     "message": "Mostrate le prime 1000 voci.",
     "description": "Hint shown when the listing was truncated"
+  },
+  "session.attachImage": {
+    "message": "Allega immagine",
+    "description": "Attach image button title"
+  },
+  "session.removeImage": {
+    "message": "Rimuovi immagine",
+    "description": "Remove attached image button title"
+  },
+  "session.imageAlt": {
+    "message": "Immagine allegata",
+    "description": "Attached image thumbnail alt text"
+  },
+  "session.imageTooLarge": {
+    "message": "L'immagine è troppo grande; mantieni ciascuna sotto i 12 MB.",
+    "description": "Warning shown when an image exceeds the size limit"
+  },
+  "session.imageLimit": {
+    "message": "Puoi allegare fino a {count} immagini.",
+    "description": "Warning shown when exceeding the max number of images"
   }
 }

--- a/src/i18n/ja/codingBridge.json
+++ b/src/i18n/ja/codingBridge.json
@@ -290,5 +290,25 @@
   "directory.truncated": {
     "message": "最初の 1000 件を表示しています。",
     "description": "Hint shown when the listing was truncated"
+  },
+  "session.attachImage": {
+    "message": "画像を添付",
+    "description": "Attach image button title"
+  },
+  "session.removeImage": {
+    "message": "画像を削除",
+    "description": "Remove attached image button title"
+  },
+  "session.imageAlt": {
+    "message": "添付された画像",
+    "description": "Attached image thumbnail alt text"
+  },
+  "session.imageTooLarge": {
+    "message": "画像が大きすぎます。1 枚あたり 12 MB 以内にしてください。",
+    "description": "Warning shown when an image exceeds the size limit"
+  },
+  "session.imageLimit": {
+    "message": "画像は最大 {count} 枚まで添付できます。",
+    "description": "Warning shown when exceeding the max number of images"
   }
 }

--- a/src/i18n/ko/codingBridge.json
+++ b/src/i18n/ko/codingBridge.json
@@ -290,5 +290,25 @@
   "directory.truncated": {
     "message": "처음 1000개 항목을 표시합니다.",
     "description": "Hint shown when the listing was truncated"
+  },
+  "session.attachImage": {
+    "message": "이미지 첨부",
+    "description": "Attach image button title"
+  },
+  "session.removeImage": {
+    "message": "이미지 제거",
+    "description": "Remove attached image button title"
+  },
+  "session.imageAlt": {
+    "message": "첨부된 이미지",
+    "description": "Attached image thumbnail alt text"
+  },
+  "session.imageTooLarge": {
+    "message": "이미지가 너무 큽니다. 각 이미지를 12MB 이하로 유지하세요.",
+    "description": "Warning shown when an image exceeds the size limit"
+  },
+  "session.imageLimit": {
+    "message": "최대 {count}개의 이미지를 첨부할 수 있습니다.",
+    "description": "Warning shown when exceeding the max number of images"
   }
 }

--- a/src/i18n/pl/codingBridge.json
+++ b/src/i18n/pl/codingBridge.json
@@ -290,5 +290,25 @@
   "directory.truncated": {
     "message": "Wyświetlono pierwsze 1000 pozycji.",
     "description": "Hint shown when the listing was truncated"
+  },
+  "session.attachImage": {
+    "message": "Załącz obraz",
+    "description": "Attach image button title"
+  },
+  "session.removeImage": {
+    "message": "Usuń obraz",
+    "description": "Remove attached image button title"
+  },
+  "session.imageAlt": {
+    "message": "Załączony obraz",
+    "description": "Attached image thumbnail alt text"
+  },
+  "session.imageTooLarge": {
+    "message": "Obraz jest za duży; każdy powinien mieć mniej niż 12 MB.",
+    "description": "Warning shown when an image exceeds the size limit"
+  },
+  "session.imageLimit": {
+    "message": "Możesz załączyć maksymalnie {count} obrazów.",
+    "description": "Warning shown when exceeding the max number of images"
   }
 }

--- a/src/i18n/pt/codingBridge.json
+++ b/src/i18n/pt/codingBridge.json
@@ -290,5 +290,25 @@
   "directory.truncated": {
     "message": "A mostrar as primeiras 1000 entradas.",
     "description": "Hint shown when the listing was truncated"
+  },
+  "session.attachImage": {
+    "message": "Anexar imagem",
+    "description": "Attach image button title"
+  },
+  "session.removeImage": {
+    "message": "Remover imagem",
+    "description": "Remove attached image button title"
+  },
+  "session.imageAlt": {
+    "message": "Imagem anexada",
+    "description": "Attached image thumbnail alt text"
+  },
+  "session.imageTooLarge": {
+    "message": "A imagem é muito grande; mantenha cada uma abaixo de 12 MB.",
+    "description": "Warning shown when an image exceeds the size limit"
+  },
+  "session.imageLimit": {
+    "message": "Você pode anexar até {count} imagens.",
+    "description": "Warning shown when exceeding the max number of images"
   }
 }

--- a/src/i18n/ru/codingBridge.json
+++ b/src/i18n/ru/codingBridge.json
@@ -290,5 +290,25 @@
   "directory.truncated": {
     "message": "Показаны первые 1000 записей.",
     "description": "Hint shown when the listing was truncated"
+  },
+  "session.attachImage": {
+    "message": "Прикрепить изображение",
+    "description": "Attach image button title"
+  },
+  "session.removeImage": {
+    "message": "Удалить изображение",
+    "description": "Remove attached image button title"
+  },
+  "session.imageAlt": {
+    "message": "Прикреплённое изображение",
+    "description": "Attached image thumbnail alt text"
+  },
+  "session.imageTooLarge": {
+    "message": "Изображение слишком большое; размер каждого должен быть меньше 12 МБ.",
+    "description": "Warning shown when an image exceeds the size limit"
+  },
+  "session.imageLimit": {
+    "message": "Можно прикрепить до {count} изображений.",
+    "description": "Warning shown when exceeding the max number of images"
   }
 }

--- a/src/i18n/sr/codingBridge.json
+++ b/src/i18n/sr/codingBridge.json
@@ -290,5 +290,25 @@
   "directory.truncated": {
     "message": "Приказано првих 1000 ставки.",
     "description": "Hint shown when the listing was truncated"
+  },
+  "session.attachImage": {
+    "message": "Приложи слику",
+    "description": "Attach image button title"
+  },
+  "session.removeImage": {
+    "message": "Уклони слику",
+    "description": "Remove attached image button title"
+  },
+  "session.imageAlt": {
+    "message": "Приложена слика",
+    "description": "Attached image thumbnail alt text"
+  },
+  "session.imageTooLarge": {
+    "message": "Слика је превелика; нека свака буде испод 12 MB.",
+    "description": "Warning shown when an image exceeds the size limit"
+  },
+  "session.imageLimit": {
+    "message": "Можеш приложити највише {count} слика.",
+    "description": "Warning shown when exceeding the max number of images"
   }
 }

--- a/src/i18n/sv/codingBridge.json
+++ b/src/i18n/sv/codingBridge.json
@@ -290,5 +290,25 @@
   "directory.truncated": {
     "message": "Visar de första 1000 posterna.",
     "description": "Hint shown when the listing was truncated"
+  },
+  "session.attachImage": {
+    "message": "Bifoga bild",
+    "description": "Attach image button title"
+  },
+  "session.removeImage": {
+    "message": "Ta bort bild",
+    "description": "Remove attached image button title"
+  },
+  "session.imageAlt": {
+    "message": "Bifogad bild",
+    "description": "Attached image thumbnail alt text"
+  },
+  "session.imageTooLarge": {
+    "message": "Bilden är för stor; håll varje under 12 MB.",
+    "description": "Warning shown when an image exceeds the size limit"
+  },
+  "session.imageLimit": {
+    "message": "Du kan bifoga upp till {count} bilder.",
+    "description": "Warning shown when exceeding the max number of images"
   }
 }

--- a/src/i18n/uk/codingBridge.json
+++ b/src/i18n/uk/codingBridge.json
@@ -290,5 +290,25 @@
   "directory.truncated": {
     "message": "Показано перші 1000 записів.",
     "description": "Hint shown when the listing was truncated"
+  },
+  "session.attachImage": {
+    "message": "Прикріпити зображення",
+    "description": "Attach image button title"
+  },
+  "session.removeImage": {
+    "message": "Видалити зображення",
+    "description": "Remove attached image button title"
+  },
+  "session.imageAlt": {
+    "message": "Прикріплене зображення",
+    "description": "Attached image thumbnail alt text"
+  },
+  "session.imageTooLarge": {
+    "message": "Зображення занадто велике; кожне має бути менше 12 МБ.",
+    "description": "Warning shown when an image exceeds the size limit"
+  },
+  "session.imageLimit": {
+    "message": "Можна прикріпити до {count} зображень.",
+    "description": "Warning shown when exceeding the max number of images"
   }
 }

--- a/src/i18n/zh-CN/codingBridge.json
+++ b/src/i18n/zh-CN/codingBridge.json
@@ -290,5 +290,25 @@
   "directory.truncated": {
     "message": "仅显示前 1000 项。",
     "description": "Hint shown when the listing was truncated"
+  },
+  "session.attachImage": {
+    "message": "添加图片",
+    "description": "Attach image button title"
+  },
+  "session.removeImage": {
+    "message": "移除图片",
+    "description": "Remove attached image button title"
+  },
+  "session.imageAlt": {
+    "message": "附加的图片",
+    "description": "Attached image thumbnail alt text"
+  },
+  "session.imageTooLarge": {
+    "message": "图片过大，单张请控制在 12 MB 以内。",
+    "description": "Warning shown when an image exceeds the size limit"
+  },
+  "session.imageLimit": {
+    "message": "最多可附加 {count} 张图片。",
+    "description": "Warning shown when exceeding the max number of images"
   }
 }

--- a/src/i18n/zh-TW/codingBridge.json
+++ b/src/i18n/zh-TW/codingBridge.json
@@ -290,5 +290,25 @@
   "directory.truncated": {
     "message": "僅顯示前 1000 項。",
     "description": "Hint shown when the listing was truncated"
+  },
+  "session.attachImage": {
+    "message": "新增圖片",
+    "description": "Attach image button title"
+  },
+  "session.removeImage": {
+    "message": "移除圖片",
+    "description": "Remove attached image button title"
+  },
+  "session.imageAlt": {
+    "message": "附加的圖片",
+    "description": "Attached image thumbnail alt text"
+  },
+  "session.imageTooLarge": {
+    "message": "圖片過大，單張請控制在 12 MB 以內。",
+    "description": "Warning shown when an image exceeds the size limit"
+  },
+  "session.imageLimit": {
+    "message": "最多可附加 {count} 張圖片。",
+    "description": "Warning shown when exceeding the max number of images"
   }
 }

--- a/src/models/codingBridge.ts
+++ b/src/models/codingBridge.ts
@@ -78,6 +78,8 @@ export interface ICodingBridgeEvent {
   is_error?: boolean;
   subtype?: string;
   cost_usd?: number;
+  // Data-URL previews of images the user attached to a prompt turn.
+  images?: string[];
 }
 
 /** One entry returned by a node's `fs.list` directory listing. */

--- a/src/store/codingBridge/actions.ts
+++ b/src/store/codingBridge/actions.ts
@@ -368,11 +368,13 @@ export const sendPrompt = (
     permissionMode?: string;
     provider?: string;
     effort?: string;
+    images?: string[];
   }
 ): void => {
   const nodeId = state.currentNodeId;
   const prompt = payload.prompt?.trim();
-  if (!nodeId || !prompt || !socket) {
+  const images = payload.images?.length ? payload.images : undefined;
+  if (!nodeId || !socket || (!prompt && !images)) {
     return;
   }
   let sessionId = state.currentSessionId;
@@ -399,7 +401,7 @@ export const sendPrompt = (
       sessionId = existing.session_id;
       commit('updateSession', { session_id: sessionId, status: 'starting' });
     }
-    commit('appendEvent', makeEvent(sessionId as string, 'prompt', { text: prompt }));
+    commit('appendEvent', makeEvent(sessionId as string, 'prompt', { text: prompt, images }));
     commit('updateSession', { session_id: sessionId as string, started: true });
     socket.sendToNode(nodeId, {
       action: CB_ACTION_SESSION_START,
@@ -410,15 +412,17 @@ export const sendPrompt = (
       permission_mode: payload.permissionMode || 'default',
       provider,
       effort: payload.effort || undefined,
+      images,
       resume_session_id: existing?.resume_session_id || undefined
     });
   } else {
-    commit('appendEvent', makeEvent(sessionId as string, 'prompt', { text: prompt }));
+    commit('appendEvent', makeEvent(sessionId as string, 'prompt', { text: prompt, images }));
     commit('updateSession', { session_id: sessionId as string, status: 'running' });
     socket.sendToNode(nodeId, {
       action: CB_ACTION_SESSION_SEND,
       session_id: sessionId,
-      prompt
+      prompt,
+      images
     });
   }
 };
@@ -492,10 +496,7 @@ export const getHistoryDetail = (
 };
 
 // Ask the current node to list a directory for the working-directory picker.
-export const browseDir = (
-  { commit, state }: ActionContext<ICodingBridgeState, IRootState>,
-  path?: string
-): void => {
+export const browseDir = ({ commit, state }: ActionContext<ICodingBridgeState, IRootState>, path?: string): void => {
   const nodeId = state.currentNodeId;
   if (!nodeId || !socket) {
     return;


### PR DESCRIPTION
## Summary

Adds image input to the CodingBridge composer, completing VibeBridge parity for visual prompts. Users can paste screenshots directly or attach image files; the images are sent to the paired node where the agent (Claude/Codex) saves and reads them.

## Changes

- **Composer (`SessionView.vue`)**: clipboard `@paste` handler captures image items; an image button opens a hidden file picker (`accept="image/*" multiple`). Attached images render as removable thumbnails above the textarea. Files are encoded to base64 data URLs via `FileReader`. Per-image cap 12 MB (matches the agent's `MAX_IMAGE_BYTES`), max 8 per turn — both surfaced via `ElMessage` warnings.
- **Store (`actions.ts`)**: `sendPrompt` accepts an `images?: string[]` payload and threads it into both `session.start` and `session.send` envelopes (the agent reads `payload.images`). Image-only turns are now allowed (empty prompt + ≥1 image).
- **Transcript (`TranscriptItem.vue`, `models/codingBridge.ts`)**: the user's attached images echo back as thumbnails in their own prompt bubble.
- **i18n**: 5 new `session.*` keys (`attachImage`, `removeImage`, `imageAlt`, `imageTooLarge`, `imageLimit`) across all 18 locales.

## Validation

- `vue-tsc -b --force` — clean
- `npm run lint` — clean
- `npm run test:run` — 141 passed
- `python3 scripts/check_i18n_coverage.py` — 17 locales × 40 namespaces all match zh-CN

🤖 Generated with GitHub Copilot