### PR TITLE
Polish Coding Bridge composer and upload attachments

### DIFF
--- a/change/@acedatacloud-nexior-fd9faf29-b845-42f8-b9f6-36418c686bcf.json
+++ b/change/@acedatacloud-nexior-fd9faf29-b845-42f8-b9f6-36418c686bcf.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(coding-bridge): polish composer settings and upload file attachments",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/codingBridge/SessionView.vue
+++ b/src/components/codingBridge/SessionView.vue
@@ -64,94 +64,170 @@
           </el-button>
         </div>
         <template v-else>
-          <div v-if="isNewSession" class="flex flex-wrap gap-2 mb-2">
-            <el-select
-              v-model="provider"
-              size="small"
-              class="w-32"
-              :placeholder="$t('codingBridge.session.providerLabel')"
-            >
-              <el-option v-for="opt in providerOptions" :key="opt.value" :label="opt.label" :value="opt.value" />
-            </el-select>
-            <el-select
-              v-model="model"
-              size="small"
-              filterable
-              :allow-create="allowCustomModel"
-              default-first-option
-              clearable
-              class="w-40"
-              :placeholder="$t('codingBridge.session.modelPlaceholder')"
-            >
-              <el-option v-for="opt in modelOptions" :key="opt.value" :label="opt.label" :value="opt.value" />
-            </el-select>
-            <el-select v-model="effort" size="small" class="w-32" :placeholder="$t('codingBridge.session.effortLabel')">
-              <el-option v-for="opt in effortOptions" :key="opt.value" :label="opt.label" :value="opt.value" />
-            </el-select>
-            <el-select
-              v-model="permissionMode"
-              size="small"
-              class="w-44"
-              :placeholder="$t('codingBridge.session.permissionModeLabel')"
-            >
-              <el-option v-for="opt in permissionModeOptions" :key="opt.value" :label="opt.label" :value="opt.value" />
-            </el-select>
-            <el-input
-              v-model="cwd"
-              size="small"
-              class="flex-1 min-w-[160px]"
-              :placeholder="$t('codingBridge.session.cwdPlaceholder')"
-              clearable
-            >
-              <template #append>
-                <el-button :title="$t('codingBridge.directory.title')" @click="openDirectory">
-                  <font-awesome-icon icon="fa-solid fa-folder-open" />
-                </el-button>
-              </template>
-            </el-input>
-          </div>
-          <!-- Attached image thumbnails -->
-          <div v-if="images.length" class="flex flex-wrap gap-2 mb-2">
-            <div
-              v-for="(image, index) in images"
-              :key="index"
-              class="relative w-14 h-14 rounded-md overflow-hidden border border-[var(--app-border-subtle)]"
-            >
-              <img :src="image" class="w-full h-full object-cover" :alt="$t('codingBridge.session.imageAlt')" />
+          <div class="rounded-lg border border-[var(--app-border-subtle)] bg-[var(--app-content-bg)] px-3 py-2">
+            <div class="flex flex-wrap items-center gap-1.5 pb-2">
               <button
+                v-for="chip in configChips"
+                :key="chip.key"
                 type="button"
-                class="absolute top-0 right-0 w-4 h-4 flex items-center justify-center bg-black/55 text-white text-[10px]"
-                :title="$t('codingBridge.session.removeImage')"
-                @click="removeImage(index)"
+                class="max-w-[220px] truncate rounded-full border border-[var(--app-border-subtle)] px-2.5 py-1 text-[11px] text-[var(--app-text-subtle)] hover:border-[var(--el-color-primary-light-5)] hover:text-[var(--el-color-primary)]"
+                :disabled="!isNewSession"
+                @click="settingsVisible = isNewSession"
               >
-                <font-awesome-icon icon="fa-solid fa-xmark" />
+                <font-awesome-icon :icon="chip.icon" class="mr-1" />
+                {{ chip.label }}
               </button>
             </div>
+
+            <div v-if="attachmentFileList.length" class="flex flex-wrap gap-2 pb-2">
+              <div
+                v-for="(file, index) in attachmentFileList"
+                :key="(file as any).uid || file.name || index"
+                class="group relative flex max-w-[220px] items-center gap-2 rounded-md border border-[var(--app-border-subtle)] bg-[var(--app-sidebar-bg)] px-2 py-1.5 text-xs"
+              >
+                <img
+                  v-if="attachmentPreviewUrl(file)"
+                  :src="attachmentPreviewUrl(file)"
+                  class="h-8 w-8 rounded object-cover"
+                  :alt="$t('codingBridge.session.attachmentImageAlt')"
+                />
+                <span v-else class="flex h-8 w-8 items-center justify-center rounded bg-[var(--app-content-bg)]">
+                  <font-awesome-icon icon="fa-solid fa-file" />
+                </span>
+                <span class="min-w-0 flex-1 truncate" :title="file.name">{{ file.name }}</span>
+                <span v-if="isAttachmentUploading(file)" class="text-[10px] text-[var(--app-text-subtle)]">
+                  {{ Math.round(file.percentage || 0) }}%
+                </span>
+                <button
+                  type="button"
+                  class="flex h-5 w-5 items-center justify-center rounded-full text-[var(--app-text-subtle)] hover:bg-[var(--app-content-hover-bg)] hover:text-[var(--el-color-danger)]"
+                  :title="$t('codingBridge.session.removeAttachment')"
+                  @click="removeAttachment(index, file)"
+                >
+                  <font-awesome-icon icon="fa-solid fa-xmark" />
+                </button>
+              </div>
+            </div>
+
+            <div class="flex items-end gap-2">
+              <el-popover
+                v-if="isNewSession"
+                v-model:visible="settingsVisible"
+                trigger="click"
+                placement="top-start"
+                width="460"
+                popper-class="coding-bridge-settings-popover"
+              >
+                <template #reference>
+                  <el-button circle :title="$t('codingBridge.session.settings')">
+                    <font-awesome-icon icon="fa-solid fa-gear" />
+                  </el-button>
+                </template>
+                <div class="grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
+                  <label class="flex flex-col gap-1">
+                    <span class="text-xs font-medium text-[var(--app-text-subtle)]">
+                      {{ $t('codingBridge.session.providerLabel') }}
+                    </span>
+                    <el-select v-model="provider" size="small">
+                      <el-option
+                        v-for="opt in providerOptions"
+                        :key="opt.value"
+                        :label="opt.label"
+                        :value="opt.value"
+                      />
+                    </el-select>
+                  </label>
+                  <label class="flex flex-col gap-1">
+                    <span class="text-xs font-medium text-[var(--app-text-subtle)]">
+                      {{ $t('codingBridge.session.modelPlaceholder') }}
+                    </span>
+                    <el-select
+                      v-model="model"
+                      size="small"
+                      filterable
+                      :allow-create="allowCustomModel"
+                      default-first-option
+                      clearable
+                    >
+                      <el-option v-for="opt in modelOptions" :key="opt.value" :label="opt.label" :value="opt.value" />
+                    </el-select>
+                  </label>
+                  <label class="flex flex-col gap-1">
+                    <span class="text-xs font-medium text-[var(--app-text-subtle)]">
+                      {{ $t('codingBridge.session.effortLabel') }}
+                    </span>
+                    <el-select v-model="effort" size="small">
+                      <el-option v-for="opt in effortOptions" :key="opt.value" :label="opt.label" :value="opt.value" />
+                    </el-select>
+                  </label>
+                  <label class="flex flex-col gap-1">
+                    <span class="text-xs font-medium text-[var(--app-text-subtle)]">
+                      {{ $t('codingBridge.session.permissionModeLabel') }}
+                    </span>
+                    <el-select v-model="permissionMode" size="small">
+                      <el-option
+                        v-for="opt in permissionModeOptions"
+                        :key="opt.value"
+                        :label="opt.label"
+                        :value="opt.value"
+                      />
+                    </el-select>
+                  </label>
+                  <label class="col-span-1 flex flex-col gap-1 sm:col-span-2">
+                    <span class="text-xs font-medium text-[var(--app-text-subtle)]">
+                      {{ $t('codingBridge.session.cwdPlaceholder') }}
+                    </span>
+                    <el-input v-model="cwd" size="small" clearable>
+                      <template #append>
+                        <el-button :title="$t('codingBridge.directory.title')" @click="openDirectory">
+                          <font-awesome-icon icon="fa-solid fa-folder-open" />
+                        </el-button>
+                      </template>
+                    </el-input>
+                  </label>
+                </div>
+              </el-popover>
+              <el-button v-else circle :disabled="true" :title="$t('codingBridge.session.settingsLocked')">
+                <font-awesome-icon icon="fa-solid fa-gear" />
+              </el-button>
+              <el-upload
+                ref="uploader"
+                v-model:file-list="attachmentFileList"
+                name="file"
+                :action="uploadUrl"
+                :headers="headers"
+                :multiple="true"
+                :limit="maxAttachments"
+                :show-file-list="false"
+                :before-upload="beforeAttachmentUpload"
+                :on-change="onAttachmentChange"
+                :on-success="onAttachmentSuccess"
+                :on-error="onAttachmentError"
+                :on-exceed="onAttachmentExceed"
+              >
+                <el-button circle :title="$t('codingBridge.session.attachFile')">
+                  <font-awesome-icon icon="fa-solid fa-paperclip" />
+                </el-button>
+              </el-upload>
+              <el-input
+                v-model="prompt"
+                type="textarea"
+                :autosize="{ minRows: 3, maxRows: 12 }"
+                resize="none"
+                class="flex-1"
+                :placeholder="$t('codingBridge.session.promptPlaceholder')"
+                @keydown.enter="onComposerEnter"
+              />
+              <el-button v-if="running" round @click="onInterrupt">
+                <font-awesome-icon icon="fa-solid fa-stop" />
+              </el-button>
+              <el-button type="primary" round :disabled="!canSend" @click="onSend">
+                {{ $t('codingBridge.session.send') }}
+              </el-button>
+            </div>
           </div>
-          <div class="flex items-end gap-2">
-            <el-input
-              v-model="prompt"
-              type="textarea"
-              :autosize="{ minRows: 3, maxRows: 12 }"
-              resize="none"
-              class="flex-1"
-              :placeholder="$t('codingBridge.session.promptPlaceholder')"
-              @keydown.enter="onComposerEnter"
-              @paste="onPaste"
-            />
-            <el-button round :title="$t('codingBridge.session.attachImage')" @click="onPickImages">
-              <font-awesome-icon icon="fa-solid fa-image" />
-            </el-button>
-            <el-button v-if="running" round @click="onInterrupt">
-              <font-awesome-icon icon="fa-solid fa-stop" />
-            </el-button>
-            <el-button type="primary" round :disabled="!canSend" @click="onSend">
-              {{ $t('codingBridge.session.send') }}
-            </el-button>
-          </div>
-          <input ref="imageInput" type="file" accept="image/*" multiple class="hidden" @change="onImageInputChange" />
           <p class="text-[11px] text-[var(--app-text-subtle)] mt-1 px-1">
-            {{ resumeHint ? $t('codingBridge.history.resumeHint') : $t('codingBridge.session.enterHint') }}
+            {{ composerHint }}
           </p>
         </template>
       </div>
@@ -163,11 +239,23 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElInput, ElButton, ElSelect, ElOption, ElMessage } from 'element-plus';
+import {
+  ElInput,
+  ElButton,
+  ElSelect,
+  ElOption,
+  ElMessage,
+  ElPopover,
+  ElUpload,
+  UploadFile,
+  UploadFiles
+} from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import TranscriptItem from './TranscriptItem.vue';
 import DirectoryDialog from './DirectoryDialog.vue';
+import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
 import {
+  ICodingBridgeAttachment,
   ICodingBridgeCapabilities,
   ICodingBridgeEvent,
   ICodingBridgeNode,
@@ -175,9 +263,10 @@ import {
   ICodingBridgeSession
 } from '@/models';
 
-// Mirror the agent's per-image cap (12 MB) and bound how many attach per turn.
-const MAX_IMAGE_BYTES = 12 * 1024 * 1024;
-const MAX_IMAGES = 8;
+const MAX_ATTACHMENT_BYTES = 50 * 1024 * 1024;
+const MAX_ATTACHMENTS = 10;
+
+type ConfigChip = { key: string; label: string; icon: string };
 
 export default defineComponent({
   name: 'CodingBridgeSessionView',
@@ -186,10 +275,13 @@ export default defineComponent({
     ElButton,
     ElSelect,
     ElOption,
+    ElPopover,
+    ElUpload,
     FontAwesomeIcon,
     TranscriptItem,
     DirectoryDialog
   },
+  mixins: [pasteUploadMixin],
   emits: ['history'],
   data() {
     return {
@@ -200,10 +292,18 @@ export default defineComponent({
       provider: 'claude',
       effort: '',
       directoryVisible: false,
-      images: [] as string[]
+      settingsVisible: false,
+      attachmentFileList: [] as UploadFiles,
+      uploadUrl: getBaseUrlPlatform() + '/api/v1/files/',
+      maxAttachments: MAX_ATTACHMENTS
     };
   },
   computed: {
+    headers(): Record<string, string> {
+      return {
+        Authorization: `Bearer ${this.$store.state.token.access}`
+      };
+    },
     currentNodeId(): string | undefined {
       return this.$store.state.codingBridge?.currentNodeId;
     },
@@ -249,8 +349,82 @@ export default defineComponent({
     connected(): boolean {
       return this.$store.state.codingBridge?.connection === 'connected';
     },
+    attachments(): ICodingBridgeAttachment[] {
+      return (this.attachmentFileList || [])
+        .map((file: UploadFile) => {
+          const response = file.response as { file_url?: string } | undefined;
+          const url =
+            response?.file_url || (typeof file.url === 'string' && !file.url.startsWith('blob:') ? file.url : '');
+          if (!url) {
+            return undefined;
+          }
+          const raw = file.raw as File | undefined;
+          const mime = raw?.type || (file as any).mime_type || '';
+          return {
+            type: this.isImageAttachment(file) ? 'image' : 'file',
+            url,
+            name: file.name,
+            mime_type: mime,
+            size: raw?.size
+          } as ICodingBridgeAttachment;
+        })
+        .filter((item: ICodingBridgeAttachment | undefined): item is ICodingBridgeAttachment => !!item);
+    },
+    uploadingAttachments(): boolean {
+      return (this.attachmentFileList || []).some((file: UploadFile) => this.isAttachmentUploading(file));
+    },
     canSend(): boolean {
-      return (!!this.prompt.trim() || this.images.length > 0) && this.connected && this.nodeOnline;
+      return (
+        (!!this.prompt.trim() || this.attachments.length > 0) &&
+        !this.uploadingAttachments &&
+        this.connected &&
+        this.nodeOnline
+      );
+    },
+    composerHint(): string {
+      if (this.uploadingAttachments) {
+        return this.$t('codingBridge.session.uploadingAttachment') as string;
+      }
+      return this.resumeHint
+        ? (this.$t('codingBridge.history.resumeHint') as string)
+        : (this.$t('codingBridge.session.enterHint') as string);
+    },
+    configChips(): ConfigChip[] {
+      if (!this.isNewSession && this.currentSession) {
+        const chips: ConfigChip[] = [
+          {
+            key: 'session-provider',
+            label: this.providerName(this.currentSession.provider || 'claude'),
+            icon: 'fa-solid fa-code'
+          }
+        ];
+        if (this.currentSession.model) {
+          chips.push({ key: 'session-model', label: this.currentSession.model, icon: 'fa-solid fa-brain' });
+        }
+        if (this.currentSession.cwd) {
+          chips.push({ key: 'session-cwd', label: this.currentSession.cwd, icon: 'fa-solid fa-folder-open' });
+        }
+        return chips;
+      }
+      return [
+        { key: 'provider', label: this.providerName(this.provider), icon: 'fa-solid fa-code' },
+        {
+          key: 'model',
+          label: this.model || (this.$t('codingBridge.session.modelDefault') as string),
+          icon: 'fa-solid fa-brain'
+        },
+        { key: 'effort', label: this.effortLabel(this.effort), icon: 'fa-solid fa-gauge-high' },
+        {
+          key: 'permission',
+          label: this.permissionModeLabel(this.permissionMode),
+          icon: 'fa-solid fa-shield-halved'
+        },
+        {
+          key: 'cwd',
+          label: this.cwd || (this.$t('codingBridge.session.cwdDefault') as string),
+          icon: 'fa-solid fa-folder-open'
+        }
+      ];
     },
     // Everything below is sourced from the node's `capabilities.get` so the UI
     // never hard-codes providers / models / efforts. The fallbacks only apply
@@ -392,6 +566,7 @@ export default defineComponent({
       if (!this.canSend) {
         return;
       }
+      const attachments = this.attachments;
       this.$store.dispatch('codingBridge/sendPrompt', {
         prompt: this.prompt,
         cwd: this.cwd,
@@ -399,71 +574,78 @@ export default defineComponent({
         permissionMode: this.permissionMode,
         provider: this.provider,
         effort: this.effort,
-        images: this.images.length ? [...this.images] : undefined
+        attachments: attachments.length ? attachments : undefined
       });
       this.prompt = '';
-      this.images = [];
+      this.clearAttachments();
     },
-    onPaste(event: ClipboardEvent) {
-      const items = event.clipboardData?.items;
-      if (!items) {
-        return;
+    beforeAttachmentUpload(file: File): boolean {
+      if (this.attachmentFileList.length >= MAX_ATTACHMENTS) {
+        ElMessage.warning(this.$t('codingBridge.session.attachmentLimit', { count: MAX_ATTACHMENTS }) as string);
+        return false;
       }
-      const files: File[] = [];
-      for (const item of Array.from(items)) {
-        if (item.kind === 'file' && item.type.startsWith('image/')) {
-          const file = item.getAsFile();
-          if (file) {
-            files.push(file);
-          }
-        }
+      if (file.size > MAX_ATTACHMENT_BYTES) {
+        ElMessage.warning(this.$t('codingBridge.session.attachmentTooLarge') as string);
+        return false;
       }
-      if (files.length) {
-        event.preventDefault();
-        this.addFiles(files);
-      }
+      return true;
     },
-    onPickImages() {
-      (this.$refs.imageInput as HTMLInputElement | undefined)?.click();
-    },
-    onImageInputChange(event: Event) {
-      const input = event.target as HTMLInputElement;
-      if (input.files?.length) {
-        this.addFiles(Array.from(input.files));
-      }
-      input.value = '';
-    },
-    async addFiles(files: File[]) {
-      for (const file of files) {
-        if (this.images.length >= MAX_IMAGES) {
-          ElMessage.warning(this.$t('codingBridge.session.imageLimit', { count: MAX_IMAGES }) as string);
-          break;
-        }
-        if (!file.type.startsWith('image/')) {
-          continue;
-        }
-        if (file.size > MAX_IMAGE_BYTES) {
-          ElMessage.warning(this.$t('codingBridge.session.imageTooLarge') as string);
-          continue;
-        }
+    onAttachmentChange(file: UploadFile) {
+      if (!file.url && file.raw && this.isImageAttachment(file)) {
         try {
-          const dataUrl = await this.readFileAsDataUrl(file);
-          this.images.push(dataUrl);
+          file.url = URL.createObjectURL(file.raw);
         } catch {
-          // Ignore unreadable files rather than failing the whole paste.
+          // ignore preview failures
         }
       }
     },
-    removeImage(index: number) {
-      this.images.splice(index, 1);
+    onAttachmentSuccess(response: { file_url?: string } | undefined, file: UploadFile) {
+      if (response?.file_url) {
+        this.revokeBlobUrl(file);
+        file.url = response.file_url;
+        file.response = response;
+      }
     },
-    readFileAsDataUrl(file: File): Promise<string> {
-      return new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onload = () => resolve(reader.result as string);
-        reader.onerror = () => reject(reader.error);
-        reader.readAsDataURL(file);
-      });
+    onAttachmentError() {
+      ElMessage.error(this.$t('codingBridge.session.attachmentUploadError') as string);
+    },
+    onAttachmentExceed() {
+      ElMessage.warning(this.$t('codingBridge.session.attachmentLimit', { count: MAX_ATTACHMENTS }) as string);
+    },
+    isAttachmentUploading(file: UploadFile): boolean {
+      return file.status === 'ready' || file.status === 'uploading';
+    },
+    isImageAttachment(file: UploadFile): boolean {
+      const raw = file.raw as File | undefined;
+      const mime = raw?.type || '';
+      if (mime.startsWith('image/')) {
+        return true;
+      }
+      return /\.(png|jpe?g|gif|webp|bmp|svg)$/i.test(file.name || file.url || '');
+    },
+    attachmentPreviewUrl(file: UploadFile): string {
+      return this.isImageAttachment(file)
+        ? file.url || (file.response as { file_url?: string } | undefined)?.file_url || ''
+        : '';
+    },
+    removeAttachment(index: number, file: UploadFile) {
+      this.revokeBlobUrl(file);
+      this.attachmentFileList.splice(index, 1);
+    },
+    clearAttachments() {
+      for (const file of this.attachmentFileList) {
+        this.revokeBlobUrl(file);
+      }
+      this.attachmentFileList = [];
+    },
+    revokeBlobUrl(file: UploadFile) {
+      if (file.url?.startsWith('blob:')) {
+        try {
+          URL.revokeObjectURL(file.url);
+        } catch {
+          // ignore revoke failures
+        }
+      }
     },
     onInterrupt() {
       this.$store.dispatch('codingBridge/interruptSession');
@@ -482,7 +664,8 @@ export default defineComponent({
       this.provider = 'claude';
       this.effort = '';
       this.prompt = '';
-      this.images = [];
+      this.settingsVisible = false;
+      this.clearAttachments();
     },
     scrollToBottom() {
       this.$nextTick(() => {

--- a/src/components/codingBridge/TranscriptItem.vue
+++ b/src/components/codingBridge/TranscriptItem.vue
@@ -8,7 +8,7 @@
         <div
           v-if="event.images && event.images.length"
           class="flex flex-wrap gap-1.5"
-          :class="{ 'mb-1.5': event.text }"
+          :class="{ 'mb-1.5': event.text || hasAttachments }"
         >
           <img
             v-for="(image, index) in event.images"
@@ -17,6 +17,22 @@
             class="w-16 h-16 rounded object-cover"
             alt=""
           />
+        </div>
+        <div v-if="hasAttachments" class="flex flex-wrap gap-1.5" :class="{ 'mb-1.5': event.text }">
+          <a
+            v-for="(attachment, index) in event.attachments"
+            :key="`${attachment.url}-${index}`"
+            :href="attachment.url"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="flex max-w-[220px] items-center gap-2 rounded-md bg-white/15 px-2 py-1.5 text-xs text-white hover:bg-white/20"
+          >
+            <img v-if="attachment.type === 'image'" :src="attachment.url" class="h-9 w-9 rounded object-cover" alt="" />
+            <span v-else class="flex h-9 w-9 items-center justify-center rounded bg-white/15">
+              <font-awesome-icon icon="fa-solid fa-file" />
+            </span>
+            <span class="min-w-0 truncate">{{ attachment.name || attachment.url }}</span>
+          </a>
         </div>
         <span v-if="event.text">{{ event.text }}</span>
       </div>
@@ -206,6 +222,9 @@ export default defineComponent({
         parts.push(`$${this.event.cost_usd.toFixed(4)}`);
       }
       return parts.join(' · ');
+    },
+    hasAttachments(): boolean {
+      return !!this.event.attachments?.length;
     }
   }
 });

--- a/src/i18n/ar/codingBridge.json
+++ b/src/i18n/ar/codingBridge.json
@@ -310,5 +310,49 @@
   "session.imageLimit": {
     "message": "يمكنك إرفاق ما يصل إلى {count} صورة.",
     "description": "Warning shown when exceeding the max number of images"
+  },
+  "session.modelDefault": {
+    "message": "Default model",
+    "description": "Default model"
+  },
+  "session.cwdDefault": {
+    "message": "Default directory",
+    "description": "Default directory"
+  },
+  "session.settings": {
+    "message": "Session settings",
+    "description": "Session settings"
+  },
+  "session.settingsLocked": {
+    "message": "Settings are locked for this session",
+    "description": "Settings are locked for this session"
+  },
+  "session.attachFile": {
+    "message": "Attach file",
+    "description": "Attach file"
+  },
+  "session.attachmentImageAlt": {
+    "message": "Attached image",
+    "description": "Attached image"
+  },
+  "session.removeAttachment": {
+    "message": "Remove attachment",
+    "description": "Remove attachment"
+  },
+  "session.uploadingAttachment": {
+    "message": "Uploading attachments…",
+    "description": "Uploading attachments…"
+  },
+  "session.attachmentTooLarge": {
+    "message": "File is too large; keep each under 50 MB.",
+    "description": "File is too large; keep each under 50 MB."
+  },
+  "session.attachmentLimit": {
+    "message": "You can attach up to {count} files.",
+    "description": "You can attach up to {count} files."
+  },
+  "session.attachmentUploadError": {
+    "message": "Failed to upload attachment.",
+    "description": "Failed to upload attachment."
   }
 }

--- a/src/i18n/de/codingBridge.json
+++ b/src/i18n/de/codingBridge.json
@@ -310,5 +310,49 @@
   "session.imageLimit": {
     "message": "Du kannst bis zu {count} Bilder anhängen.",
     "description": "Warning shown when exceeding the max number of images"
+  },
+  "session.modelDefault": {
+    "message": "Default model",
+    "description": "Default model"
+  },
+  "session.cwdDefault": {
+    "message": "Default directory",
+    "description": "Default directory"
+  },
+  "session.settings": {
+    "message": "Session settings",
+    "description": "Session settings"
+  },
+  "session.settingsLocked": {
+    "message": "Settings are locked for this session",
+    "description": "Settings are locked for this session"
+  },
+  "session.attachFile": {
+    "message": "Attach file",
+    "description": "Attach file"
+  },
+  "session.attachmentImageAlt": {
+    "message": "Attached image",
+    "description": "Attached image"
+  },
+  "session.removeAttachment": {
+    "message": "Remove attachment",
+    "description": "Remove attachment"
+  },
+  "session.uploadingAttachment": {
+    "message": "Uploading attachments…",
+    "description": "Uploading attachments…"
+  },
+  "session.attachmentTooLarge": {
+    "message": "File is too large; keep each under 50 MB.",
+    "description": "File is too large; keep each under 50 MB."
+  },
+  "session.attachmentLimit": {
+    "message": "You can attach up to {count} files.",
+    "description": "You can attach up to {count} files."
+  },
+  "session.attachmentUploadError": {
+    "message": "Failed to upload attachment.",
+    "description": "Failed to upload attachment."
   }
 }

--- a/src/i18n/el/codingBridge.json
+++ b/src/i18n/el/codingBridge.json
@@ -310,5 +310,49 @@
   "session.imageLimit": {
     "message": "Μπορείς να επισυνάψεις έως {count} εικόνες.",
     "description": "Warning shown when exceeding the max number of images"
+  },
+  "session.modelDefault": {
+    "message": "Default model",
+    "description": "Default model"
+  },
+  "session.cwdDefault": {
+    "message": "Default directory",
+    "description": "Default directory"
+  },
+  "session.settings": {
+    "message": "Session settings",
+    "description": "Session settings"
+  },
+  "session.settingsLocked": {
+    "message": "Settings are locked for this session",
+    "description": "Settings are locked for this session"
+  },
+  "session.attachFile": {
+    "message": "Attach file",
+    "description": "Attach file"
+  },
+  "session.attachmentImageAlt": {
+    "message": "Attached image",
+    "description": "Attached image"
+  },
+  "session.removeAttachment": {
+    "message": "Remove attachment",
+    "description": "Remove attachment"
+  },
+  "session.uploadingAttachment": {
+    "message": "Uploading attachments…",
+    "description": "Uploading attachments…"
+  },
+  "session.attachmentTooLarge": {
+    "message": "File is too large; keep each under 50 MB.",
+    "description": "File is too large; keep each under 50 MB."
+  },
+  "session.attachmentLimit": {
+    "message": "You can attach up to {count} files.",
+    "description": "You can attach up to {count} files."
+  },
+  "session.attachmentUploadError": {
+    "message": "Failed to upload attachment.",
+    "description": "Failed to upload attachment."
   }
 }

--- a/src/i18n/en/codingBridge.json
+++ b/src/i18n/en/codingBridge.json
@@ -310,5 +310,49 @@
   "session.imageLimit": {
     "message": "You can attach up to {count} images.",
     "description": "Warning shown when exceeding the max number of images"
+  },
+  "session.modelDefault": {
+    "message": "Default model",
+    "description": "Default model"
+  },
+  "session.cwdDefault": {
+    "message": "Default directory",
+    "description": "Default directory"
+  },
+  "session.settings": {
+    "message": "Session settings",
+    "description": "Session settings"
+  },
+  "session.settingsLocked": {
+    "message": "Settings are locked for this session",
+    "description": "Settings are locked for this session"
+  },
+  "session.attachFile": {
+    "message": "Attach file",
+    "description": "Attach file"
+  },
+  "session.attachmentImageAlt": {
+    "message": "Attached image",
+    "description": "Attached image"
+  },
+  "session.removeAttachment": {
+    "message": "Remove attachment",
+    "description": "Remove attachment"
+  },
+  "session.uploadingAttachment": {
+    "message": "Uploading attachments…",
+    "description": "Uploading attachments…"
+  },
+  "session.attachmentTooLarge": {
+    "message": "File is too large; keep each under 50 MB.",
+    "description": "File is too large; keep each under 50 MB."
+  },
+  "session.attachmentLimit": {
+    "message": "You can attach up to {count} files.",
+    "description": "You can attach up to {count} files."
+  },
+  "session.attachmentUploadError": {
+    "message": "Failed to upload attachment.",
+    "description": "Failed to upload attachment."
   }
 }

--- a/src/i18n/es/codingBridge.json
+++ b/src/i18n/es/codingBridge.json
@@ -310,5 +310,49 @@
   "session.imageLimit": {
     "message": "Puedes adjuntar hasta {count} imágenes.",
     "description": "Warning shown when exceeding the max number of images"
+  },
+  "session.modelDefault": {
+    "message": "Default model",
+    "description": "Default model"
+  },
+  "session.cwdDefault": {
+    "message": "Default directory",
+    "description": "Default directory"
+  },
+  "session.settings": {
+    "message": "Session settings",
+    "description": "Session settings"
+  },
+  "session.settingsLocked": {
+    "message": "Settings are locked for this session",
+    "description": "Settings are locked for this session"
+  },
+  "session.attachFile": {
+    "message": "Attach file",
+    "description": "Attach file"
+  },
+  "session.attachmentImageAlt": {
+    "message": "Attached image",
+    "description": "Attached image"
+  },
+  "session.removeAttachment": {
+    "message": "Remove attachment",
+    "description": "Remove attachment"
+  },
+  "session.uploadingAttachment": {
+    "message": "Uploading attachments…",
+    "description": "Uploading attachments…"
+  },
+  "session.attachmentTooLarge": {
+    "message": "File is too large; keep each under 50 MB.",
+    "description": "File is too large; keep each under 50 MB."
+  },
+  "session.attachmentLimit": {
+    "message": "You can attach up to {count} files.",
+    "description": "You can attach up to {count} files."
+  },
+  "session.attachmentUploadError": {
+    "message": "Failed to upload attachment.",
+    "description": "Failed to upload attachment."
   }
 }

--- a/src/i18n/fi/codingBridge.json
+++ b/src/i18n/fi/codingBridge.json
@@ -310,5 +310,49 @@
   "session.imageLimit": {
     "message": "Voit liittää enintään {count} kuvaa.",
     "description": "Warning shown when exceeding the max number of images"
+  },
+  "session.modelDefault": {
+    "message": "Default model",
+    "description": "Default model"
+  },
+  "session.cwdDefault": {
+    "message": "Default directory",
+    "description": "Default directory"
+  },
+  "session.settings": {
+    "message": "Session settings",
+    "description": "Session settings"
+  },
+  "session.settingsLocked": {
+    "message": "Settings are locked for this session",
+    "description": "Settings are locked for this session"
+  },
+  "session.attachFile": {
+    "message": "Attach file",
+    "description": "Attach file"
+  },
+  "session.attachmentImageAlt": {
+    "message": "Attached image",
+    "description": "Attached image"
+  },
+  "session.removeAttachment": {
+    "message": "Remove attachment",
+    "description": "Remove attachment"
+  },
+  "session.uploadingAttachment": {
+    "message": "Uploading attachments…",
+    "description": "Uploading attachments…"
+  },
+  "session.attachmentTooLarge": {
+    "message": "File is too large; keep each under 50 MB.",
+    "description": "File is too large; keep each under 50 MB."
+  },
+  "session.attachmentLimit": {
+    "message": "You can attach up to {count} files.",
+    "description": "You can attach up to {count} files."
+  },
+  "session.attachmentUploadError": {
+    "message": "Failed to upload attachment.",
+    "description": "Failed to upload attachment."
   }
 }

--- a/src/i18n/fr/codingBridge.json
+++ b/src/i18n/fr/codingBridge.json
@@ -310,5 +310,49 @@
   "session.imageLimit": {
     "message": "Vous pouvez joindre jusqu'à {count} images.",
     "description": "Warning shown when exceeding the max number of images"
+  },
+  "session.modelDefault": {
+    "message": "Default model",
+    "description": "Default model"
+  },
+  "session.cwdDefault": {
+    "message": "Default directory",
+    "description": "Default directory"
+  },
+  "session.settings": {
+    "message": "Session settings",
+    "description": "Session settings"
+  },
+  "session.settingsLocked": {
+    "message": "Settings are locked for this session",
+    "description": "Settings are locked for this session"
+  },
+  "session.attachFile": {
+    "message": "Attach file",
+    "description": "Attach file"
+  },
+  "session.attachmentImageAlt": {
+    "message": "Attached image",
+    "description": "Attached image"
+  },
+  "session.removeAttachment": {
+    "message": "Remove attachment",
+    "description": "Remove attachment"
+  },
+  "session.uploadingAttachment": {
+    "message": "Uploading attachments…",
+    "description": "Uploading attachments…"
+  },
+  "session.attachmentTooLarge": {
+    "message": "File is too large; keep each under 50 MB.",
+    "description": "File is too large; keep each under 50 MB."
+  },
+  "session.attachmentLimit": {
+    "message": "You can attach up to {count} files.",
+    "description": "You can attach up to {count} files."
+  },
+  "session.attachmentUploadError": {
+    "message": "Failed to upload attachment.",
+    "description": "Failed to upload attachment."
   }
 }

--- a/src/i18n/it/codingBridge.json
+++ b/src/i18n/it/codingBridge.json
@@ -310,5 +310,49 @@
   "session.imageLimit": {
     "message": "Puoi allegare fino a {count} immagini.",
     "description": "Warning shown when exceeding the max number of images"
+  },
+  "session.modelDefault": {
+    "message": "Default model",
+    "description": "Default model"
+  },
+  "session.cwdDefault": {
+    "message": "Default directory",
+    "description": "Default directory"
+  },
+  "session.settings": {
+    "message": "Session settings",
+    "description": "Session settings"
+  },
+  "session.settingsLocked": {
+    "message": "Settings are locked for this session",
+    "description": "Settings are locked for this session"
+  },
+  "session.attachFile": {
+    "message": "Attach file",
+    "description": "Attach file"
+  },
+  "session.attachmentImageAlt": {
+    "message": "Attached image",
+    "description": "Attached image"
+  },
+  "session.removeAttachment": {
+    "message": "Remove attachment",
+    "description": "Remove attachment"
+  },
+  "session.uploadingAttachment": {
+    "message": "Uploading attachments…",
+    "description": "Uploading attachments…"
+  },
+  "session.attachmentTooLarge": {
+    "message": "File is too large; keep each under 50 MB.",
+    "description": "File is too large; keep each under 50 MB."
+  },
+  "session.attachmentLimit": {
+    "message": "You can attach up to {count} files.",
+    "description": "You can attach up to {count} files."
+  },
+  "session.attachmentUploadError": {
+    "message": "Failed to upload attachment.",
+    "description": "Failed to upload attachment."
   }
 }

--- a/src/i18n/ja/codingBridge.json
+++ b/src/i18n/ja/codingBridge.json
@@ -310,5 +310,49 @@
   "session.imageLimit": {
     "message": "画像は最大 {count} 枚まで添付できます。",
     "description": "Warning shown when exceeding the max number of images"
+  },
+  "session.modelDefault": {
+    "message": "Default model",
+    "description": "Default model"
+  },
+  "session.cwdDefault": {
+    "message": "Default directory",
+    "description": "Default directory"
+  },
+  "session.settings": {
+    "message": "Session settings",
+    "description": "Session settings"
+  },
+  "session.settingsLocked": {
+    "message": "Settings are locked for this session",
+    "description": "Settings are locked for this session"
+  },
+  "session.attachFile": {
+    "message": "Attach file",
+    "description": "Attach file"
+  },
+  "session.attachmentImageAlt": {
+    "message": "Attached image",
+    "description": "Attached image"
+  },
+  "session.removeAttachment": {
+    "message": "Remove attachment",
+    "description": "Remove attachment"
+  },
+  "session.uploadingAttachment": {
+    "message": "Uploading attachments…",
+    "description": "Uploading attachments…"
+  },
+  "session.attachmentTooLarge": {
+    "message": "File is too large; keep each under 50 MB.",
+    "description": "File is too large; keep each under 50 MB."
+  },
+  "session.attachmentLimit": {
+    "message": "You can attach up to {count} files.",
+    "description": "You can attach up to {count} files."
+  },
+  "session.attachmentUploadError": {
+    "message": "Failed to upload attachment.",
+    "description": "Failed to upload attachment."
   }
 }

--- a/src/i18n/ko/codingBridge.json
+++ b/src/i18n/ko/codingBridge.json
@@ -310,5 +310,49 @@
   "session.imageLimit": {
     "message": "최대 {count}개의 이미지를 첨부할 수 있습니다.",
     "description": "Warning shown when exceeding the max number of images"
+  },
+  "session.modelDefault": {
+    "message": "Default model",
+    "description": "Default model"
+  },
+  "session.cwdDefault": {
+    "message": "Default directory",
+    "description": "Default directory"
+  },
+  "session.settings": {
+    "message": "Session settings",
+    "description": "Session settings"
+  },
+  "session.settingsLocked": {
+    "message": "Settings are locked for this session",
+    "description": "Settings are locked for this session"
+  },
+  "session.attachFile": {
+    "message": "Attach file",
+    "description": "Attach file"
+  },
+  "session.attachmentImageAlt": {
+    "message": "Attached image",
+    "description": "Attached image"
+  },
+  "session.removeAttachment": {
+    "message": "Remove attachment",
+    "description": "Remove attachment"
+  },
+  "session.uploadingAttachment": {
+    "message": "Uploading attachments…",
+    "description": "Uploading attachments…"
+  },
+  "session.attachmentTooLarge": {
+    "message": "File is too large; keep each under 50 MB.",
+    "description": "File is too large; keep each under 50 MB."
+  },
+  "session.attachmentLimit": {
+    "message": "You can attach up to {count} files.",
+    "description": "You can attach up to {count} files."
+  },
+  "session.attachmentUploadError": {
+    "message": "Failed to upload attachment.",
+    "description": "Failed to upload attachment."
   }
 }

--- a/src/i18n/pl/codingBridge.json
+++ b/src/i18n/pl/codingBridge.json
@@ -310,5 +310,49 @@
   "session.imageLimit": {
     "message": "Możesz załączyć maksymalnie {count} obrazów.",
     "description": "Warning shown when exceeding the max number of images"
+  },
+  "session.modelDefault": {
+    "message": "Default model",
+    "description": "Default model"
+  },
+  "session.cwdDefault": {
+    "message": "Default directory",
+    "description": "Default directory"
+  },
+  "session.settings": {
+    "message": "Session settings",
+    "description": "Session settings"
+  },
+  "session.settingsLocked": {
+    "message": "Settings are locked for this session",
+    "description": "Settings are locked for this session"
+  },
+  "session.attachFile": {
+    "message": "Attach file",
+    "description": "Attach file"
+  },
+  "session.attachmentImageAlt": {
+    "message": "Attached image",
+    "description": "Attached image"
+  },
+  "session.removeAttachment": {
+    "message": "Remove attachment",
+    "description": "Remove attachment"
+  },
+  "session.uploadingAttachment": {
+    "message": "Uploading attachments…",
+    "description": "Uploading attachments…"
+  },
+  "session.attachmentTooLarge": {
+    "message": "File is too large; keep each under 50 MB.",
+    "description": "File is too large; keep each under 50 MB."
+  },
+  "session.attachmentLimit": {
+    "message": "You can attach up to {count} files.",
+    "description": "You can attach up to {count} files."
+  },
+  "session.attachmentUploadError": {
+    "message": "Failed to upload attachment.",
+    "description": "Failed to upload attachment."
   }
 }

--- a/src/i18n/pt/codingBridge.json
+++ b/src/i18n/pt/codingBridge.json
@@ -310,5 +310,49 @@
   "session.imageLimit": {
     "message": "Você pode anexar até {count} imagens.",
     "description": "Warning shown when exceeding the max number of images"
+  },
+  "session.modelDefault": {
+    "message": "Default model",
+    "description": "Default model"
+  },
+  "session.cwdDefault": {
+    "message": "Default directory",
+    "description": "Default directory"
+  },
+  "session.settings": {
+    "message": "Session settings",
+    "description": "Session settings"
+  },
+  "session.settingsLocked": {
+    "message": "Settings are locked for this session",
+    "description": "Settings are locked for this session"
+  },
+  "session.attachFile": {
+    "message": "Attach file",
+    "description": "Attach file"
+  },
+  "session.attachmentImageAlt": {
+    "message": "Attached image",
+    "description": "Attached image"
+  },
+  "session.removeAttachment": {
+    "message": "Remove attachment",
+    "description": "Remove attachment"
+  },
+  "session.uploadingAttachment": {
+    "message": "Uploading attachments…",
+    "description": "Uploading attachments…"
+  },
+  "session.attachmentTooLarge": {
+    "message": "File is too large; keep each under 50 MB.",
+    "description": "File is too large; keep each under 50 MB."
+  },
+  "session.attachmentLimit": {
+    "message": "You can attach up to {count} files.",
+    "description": "You can attach up to {count} files."
+  },
+  "session.attachmentUploadError": {
+    "message": "Failed to upload attachment.",
+    "description": "Failed to upload attachment."
   }
 }

--- a/src/i18n/ru/codingBridge.json
+++ b/src/i18n/ru/codingBridge.json
@@ -310,5 +310,49 @@
   "session.imageLimit": {
     "message": "Можно прикрепить до {count} изображений.",
     "description": "Warning shown when exceeding the max number of images"
+  },
+  "session.modelDefault": {
+    "message": "Default model",
+    "description": "Default model"
+  },
+  "session.cwdDefault": {
+    "message": "Default directory",
+    "description": "Default directory"
+  },
+  "session.settings": {
+    "message": "Session settings",
+    "description": "Session settings"
+  },
+  "session.settingsLocked": {
+    "message": "Settings are locked for this session",
+    "description": "Settings are locked for this session"
+  },
+  "session.attachFile": {
+    "message": "Attach file",
+    "description": "Attach file"
+  },
+  "session.attachmentImageAlt": {
+    "message": "Attached image",
+    "description": "Attached image"
+  },
+  "session.removeAttachment": {
+    "message": "Remove attachment",
+    "description": "Remove attachment"
+  },
+  "session.uploadingAttachment": {
+    "message": "Uploading attachments…",
+    "description": "Uploading attachments…"
+  },
+  "session.attachmentTooLarge": {
+    "message": "File is too large; keep each under 50 MB.",
+    "description": "File is too large; keep each under 50 MB."
+  },
+  "session.attachmentLimit": {
+    "message": "You can attach up to {count} files.",
+    "description": "You can attach up to {count} files."
+  },
+  "session.attachmentUploadError": {
+    "message": "Failed to upload attachment.",
+    "description": "Failed to upload attachment."
   }
 }

--- a/src/i18n/sr/codingBridge.json
+++ b/src/i18n/sr/codingBridge.json
@@ -310,5 +310,49 @@
   "session.imageLimit": {
     "message": "Можеш приложити највише {count} слика.",
     "description": "Warning shown when exceeding the max number of images"
+  },
+  "session.modelDefault": {
+    "message": "Default model",
+    "description": "Default model"
+  },
+  "session.cwdDefault": {
+    "message": "Default directory",
+    "description": "Default directory"
+  },
+  "session.settings": {
+    "message": "Session settings",
+    "description": "Session settings"
+  },
+  "session.settingsLocked": {
+    "message": "Settings are locked for this session",
+    "description": "Settings are locked for this session"
+  },
+  "session.attachFile": {
+    "message": "Attach file",
+    "description": "Attach file"
+  },
+  "session.attachmentImageAlt": {
+    "message": "Attached image",
+    "description": "Attached image"
+  },
+  "session.removeAttachment": {
+    "message": "Remove attachment",
+    "description": "Remove attachment"
+  },
+  "session.uploadingAttachment": {
+    "message": "Uploading attachments…",
+    "description": "Uploading attachments…"
+  },
+  "session.attachmentTooLarge": {
+    "message": "File is too large; keep each under 50 MB.",
+    "description": "File is too large; keep each under 50 MB."
+  },
+  "session.attachmentLimit": {
+    "message": "You can attach up to {count} files.",
+    "description": "You can attach up to {count} files."
+  },
+  "session.attachmentUploadError": {
+    "message": "Failed to upload attachment.",
+    "description": "Failed to upload attachment."
   }
 }

--- a/src/i18n/sv/codingBridge.json
+++ b/src/i18n/sv/codingBridge.json
@@ -310,5 +310,49 @@
   "session.imageLimit": {
     "message": "Du kan bifoga upp till {count} bilder.",
     "description": "Warning shown when exceeding the max number of images"
+  },
+  "session.modelDefault": {
+    "message": "Default model",
+    "description": "Default model"
+  },
+  "session.cwdDefault": {
+    "message": "Default directory",
+    "description": "Default directory"
+  },
+  "session.settings": {
+    "message": "Session settings",
+    "description": "Session settings"
+  },
+  "session.settingsLocked": {
+    "message": "Settings are locked for this session",
+    "description": "Settings are locked for this session"
+  },
+  "session.attachFile": {
+    "message": "Attach file",
+    "description": "Attach file"
+  },
+  "session.attachmentImageAlt": {
+    "message": "Attached image",
+    "description": "Attached image"
+  },
+  "session.removeAttachment": {
+    "message": "Remove attachment",
+    "description": "Remove attachment"
+  },
+  "session.uploadingAttachment": {
+    "message": "Uploading attachments…",
+    "description": "Uploading attachments…"
+  },
+  "session.attachmentTooLarge": {
+    "message": "File is too large; keep each under 50 MB.",
+    "description": "File is too large; keep each under 50 MB."
+  },
+  "session.attachmentLimit": {
+    "message": "You can attach up to {count} files.",
+    "description": "You can attach up to {count} files."
+  },
+  "session.attachmentUploadError": {
+    "message": "Failed to upload attachment.",
+    "description": "Failed to upload attachment."
   }
 }

--- a/src/i18n/uk/codingBridge.json
+++ b/src/i18n/uk/codingBridge.json
@@ -310,5 +310,49 @@
   "session.imageLimit": {
     "message": "Можна прикріпити до {count} зображень.",
     "description": "Warning shown when exceeding the max number of images"
+  },
+  "session.modelDefault": {
+    "message": "Default model",
+    "description": "Default model"
+  },
+  "session.cwdDefault": {
+    "message": "Default directory",
+    "description": "Default directory"
+  },
+  "session.settings": {
+    "message": "Session settings",
+    "description": "Session settings"
+  },
+  "session.settingsLocked": {
+    "message": "Settings are locked for this session",
+    "description": "Settings are locked for this session"
+  },
+  "session.attachFile": {
+    "message": "Attach file",
+    "description": "Attach file"
+  },
+  "session.attachmentImageAlt": {
+    "message": "Attached image",
+    "description": "Attached image"
+  },
+  "session.removeAttachment": {
+    "message": "Remove attachment",
+    "description": "Remove attachment"
+  },
+  "session.uploadingAttachment": {
+    "message": "Uploading attachments…",
+    "description": "Uploading attachments…"
+  },
+  "session.attachmentTooLarge": {
+    "message": "File is too large; keep each under 50 MB.",
+    "description": "File is too large; keep each under 50 MB."
+  },
+  "session.attachmentLimit": {
+    "message": "You can attach up to {count} files.",
+    "description": "You can attach up to {count} files."
+  },
+  "session.attachmentUploadError": {
+    "message": "Failed to upload attachment.",
+    "description": "Failed to upload attachment."
   }
 }

--- a/src/i18n/zh-CN/codingBridge.json
+++ b/src/i18n/zh-CN/codingBridge.json
@@ -310,5 +310,49 @@
   "session.imageLimit": {
     "message": "最多可附加 {count} 张图片。",
     "description": "Warning shown when exceeding the max number of images"
+  },
+  "session.modelDefault": {
+    "message": "默认模型",
+    "description": "Default model"
+  },
+  "session.cwdDefault": {
+    "message": "默认目录",
+    "description": "Default directory"
+  },
+  "session.settings": {
+    "message": "会话设置",
+    "description": "Session settings"
+  },
+  "session.settingsLocked": {
+    "message": "本会话设置已锁定",
+    "description": "Settings are locked for this session"
+  },
+  "session.attachFile": {
+    "message": "添加文件",
+    "description": "Attach file"
+  },
+  "session.attachmentImageAlt": {
+    "message": "已附加图片",
+    "description": "Attached image"
+  },
+  "session.removeAttachment": {
+    "message": "移除附件",
+    "description": "Remove attachment"
+  },
+  "session.uploadingAttachment": {
+    "message": "附件上传中…",
+    "description": "Uploading attachments…"
+  },
+  "session.attachmentTooLarge": {
+    "message": "文件过大，请保持每个文件不超过 50 MB。",
+    "description": "File is too large; keep each under 50 MB."
+  },
+  "session.attachmentLimit": {
+    "message": "最多可附加 {count} 个文件。",
+    "description": "You can attach up to {count} files."
+  },
+  "session.attachmentUploadError": {
+    "message": "附件上传失败。",
+    "description": "Failed to upload attachment."
   }
 }

--- a/src/i18n/zh-TW/codingBridge.json
+++ b/src/i18n/zh-TW/codingBridge.json
@@ -310,5 +310,49 @@
   "session.imageLimit": {
     "message": "最多可附加 {count} 張圖片。",
     "description": "Warning shown when exceeding the max number of images"
+  },
+  "session.modelDefault": {
+    "message": "Default model",
+    "description": "Default model"
+  },
+  "session.cwdDefault": {
+    "message": "Default directory",
+    "description": "Default directory"
+  },
+  "session.settings": {
+    "message": "Session settings",
+    "description": "Session settings"
+  },
+  "session.settingsLocked": {
+    "message": "Settings are locked for this session",
+    "description": "Settings are locked for this session"
+  },
+  "session.attachFile": {
+    "message": "Attach file",
+    "description": "Attach file"
+  },
+  "session.attachmentImageAlt": {
+    "message": "Attached image",
+    "description": "Attached image"
+  },
+  "session.removeAttachment": {
+    "message": "Remove attachment",
+    "description": "Remove attachment"
+  },
+  "session.uploadingAttachment": {
+    "message": "Uploading attachments…",
+    "description": "Uploading attachments…"
+  },
+  "session.attachmentTooLarge": {
+    "message": "File is too large; keep each under 50 MB.",
+    "description": "File is too large; keep each under 50 MB."
+  },
+  "session.attachmentLimit": {
+    "message": "You can attach up to {count} files.",
+    "description": "You can attach up to {count} files."
+  },
+  "session.attachmentUploadError": {
+    "message": "Failed to upload attachment.",
+    "description": "Failed to upload attachment."
   }
 }

--- a/src/models/codingBridge.ts
+++ b/src/models/codingBridge.ts
@@ -105,8 +105,18 @@ export interface ICodingBridgeEvent {
   is_error?: boolean;
   subtype?: string;
   cost_usd?: number;
-  // Data-URL previews of images the user attached to a prompt turn.
+  // Legacy data-URL previews of images the user attached to a prompt turn.
   images?: string[];
+  attachments?: ICodingBridgeAttachment[];
+}
+
+/** One browser-uploaded file/image attached to a prompt turn. */
+export interface ICodingBridgeAttachment {
+  type: 'image' | 'file';
+  url: string;
+  name?: string;
+  mime_type?: string;
+  size?: number;
 }
 
 /** One entry returned by a node's `fs.list` directory listing. */

--- a/src/store/codingBridge/actions.ts
+++ b/src/store/codingBridge/actions.ts
@@ -2,7 +2,13 @@ import { ActionContext } from 'vuex';
 import { codingBridgeOperator } from '@/operators';
 import { ICodingBridgeHistoryRef, ICodingBridgeState } from './models';
 import { IRootState } from '../common/models';
-import { Status, ICodingBridgeEvent, ICodingBridgeEventKind, ICodingBridgeNode } from '@/models';
+import {
+  Status,
+  ICodingBridgeAttachment,
+  ICodingBridgeEvent,
+  ICodingBridgeEventKind,
+  ICodingBridgeNode
+} from '@/models';
 import { CodingBridgeSocket } from '@/utils/codingBridgeSocket';
 import {
   CB_ACTION_SESSION_START,
@@ -382,12 +388,14 @@ export const sendPrompt = (
     provider?: string;
     effort?: string;
     images?: string[];
+    attachments?: ICodingBridgeAttachment[];
   }
 ): void => {
   const nodeId = state.currentNodeId;
   const prompt = payload.prompt?.trim();
   const images = payload.images?.length ? payload.images : undefined;
-  if (!nodeId || !socket || (!prompt && !images)) {
+  const attachments = payload.attachments?.length ? payload.attachments : undefined;
+  if (!nodeId || !socket || (!prompt && !images && !attachments)) {
     return;
   }
   let sessionId = state.currentSessionId;
@@ -414,7 +422,7 @@ export const sendPrompt = (
       sessionId = existing.session_id;
       commit('updateSession', { session_id: sessionId, status: 'starting' });
     }
-    commit('appendEvent', makeEvent(sessionId as string, 'prompt', { text: prompt, images }));
+    commit('appendEvent', makeEvent(sessionId as string, 'prompt', { text: prompt, images, attachments }));
     commit('updateSession', { session_id: sessionId as string, started: true });
     socket.sendToNode(nodeId, {
       action: CB_ACTION_SESSION_START,
@@ -426,16 +434,18 @@ export const sendPrompt = (
       provider,
       effort: payload.effort || undefined,
       images,
+      attachments,
       resume_session_id: existing?.resume_session_id || undefined
     });
   } else {
-    commit('appendEvent', makeEvent(sessionId as string, 'prompt', { text: prompt, images }));
+    commit('appendEvent', makeEvent(sessionId as string, 'prompt', { text: prompt, images, attachments }));
     commit('updateSession', { session_id: sessionId as string, status: 'running' });
     socket.sendToNode(nodeId, {
       action: CB_ACTION_SESSION_SEND,
       session_id: sessionId,
       prompt,
-      images
+      images,
+      attachments
     });
   }
 };


### PR DESCRIPTION
Cleans up the Coding Bridge composer and moves advanced session controls behind a settings entry, while switching prompt attachments to the existing CDN file upload path.

Summary:
- collapse backend/model/effort/permission/cwd controls into a settings popover
- show compact configuration chips instead of a row of form controls
- replace the hidden image input with Element Plus upload backed by /api/v1/files/
- support image and file attachments with upload progress, transcript rendering, and attachments payloads
- add i18n keys across all Coding Bridge locale files and a beachball change file

Validation:
- python3 scripts/check_i18n_coverage.py
- npm run lint
- npx vue-tsc -b --force
- npm run test:run
- npm run build