### PR TITLE
feat(coding-bridge): interactive AskUserQuestion card instead of raw JSON deny

### DIFF
--- a/change/@acedatacloud-nexior-799c0edf-40bf-44b0-ac6d-6e456215809a.json
+++ b/change/@acedatacloud-nexior-799c0edf-40bf-44b0-ac6d-6e456215809a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Render an interactive question card for Coding Bridge AskUserQuestion tool calls instead of raw JSON + deny-only",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/codingBridge/PermissionDialog.vue
+++ b/src/components/codingBridge/PermissionDialog.vue
@@ -46,6 +46,7 @@ import { defineComponent } from 'vue';
 import { ElDialog, ElButton } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { ICodingBridgePermissionRequest } from '@/models';
+import { isAskUserQuestionRequest } from './askUserQuestion';
 
 export default defineComponent({
   name: 'CodingBridgePermissionDialog',
@@ -56,7 +57,11 @@ export default defineComponent({
   },
   computed: {
     request(): ICodingBridgePermissionRequest | undefined {
-      return this.$store.state.codingBridge?.permissions?.[0];
+      // AskUserQuestion requests render as an inline question card in the
+      // session view, so the generic allow/deny modal skips them.
+      return (this.$store.state.codingBridge?.permissions ?? []).find(
+        (item: ICodingBridgePermissionRequest) => !isAskUserQuestionRequest(item)
+      );
     },
     hasInput(): boolean {
       return !!this.request?.input && Object.keys(this.request.input).length > 0;

--- a/src/components/codingBridge/SessionView.vue
+++ b/src/components/codingBridge/SessionView.vue
@@ -51,6 +51,14 @@
           {{ $t('codingBridge.session.startHint') }}
         </div>
         <transcript-item v-for="event in events" :key="event.id" :event="event" />
+        <ask-user-question-card
+          v-if="pendingQuestion"
+          :key="pendingQuestion.request_id"
+          :tool-use-id="pendingQuestion.request_id"
+          :payload="pendingQuestion.payload"
+          @submit="onAnswerQuestion"
+          @skip="onSkipQuestion"
+        />
       </div>
 
       <!-- Composer -->
@@ -298,8 +306,11 @@ import {
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import TranscriptItem from './TranscriptItem.vue';
 import DirectoryDialog from './DirectoryDialog.vue';
+import AskUserQuestionCard from '@/components/chat/AskUserQuestionCard.vue';
+import { isAskUserQuestionRequest, questionPayload } from './askUserQuestion';
 import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
 import {
+  IAskUserQuestionPayload,
   ICodingBridgeAttachment,
   ICodingBridgeCapabilities,
   ICodingBridgeEvent,
@@ -325,7 +336,8 @@ export default defineComponent({
     ElUpload,
     FontAwesomeIcon,
     TranscriptItem,
-    DirectoryDialog
+    DirectoryDialog,
+    AskUserQuestionCard
   },
   mixins: [pasteUploadMixin],
   emits: ['history'],
@@ -368,6 +380,17 @@ export default defineComponent({
     events(): ICodingBridgeEvent[] {
       const id = this.currentSessionId;
       return id ? (this.$store.state.codingBridge?.events?.[id] ?? []) : [];
+    },
+    // The agent's pending AskUserQuestion for this session, if any. Rendered as
+    // an inline question card instead of the generic allow/deny modal.
+    pendingQuestion(): { request_id: string; payload: IAskUserQuestionPayload } | undefined {
+      const sessionId = this.currentSessionId;
+      if (!sessionId) {
+        return undefined;
+      }
+      const permissions = this.$store.state.codingBridge?.permissions ?? [];
+      const request = permissions.find((item) => item.session_id === sessionId && isAskUserQuestionRequest(item));
+      return request ? { request_id: request.request_id, payload: questionPayload(request) } : undefined;
     },
     isNewSession(): boolean {
       return !this.currentSessionId;
@@ -495,6 +518,9 @@ export default defineComponent({
     events() {
       this.scrollToBottom();
     },
+    pendingQuestion() {
+      this.scrollToBottom();
+    },
     currentSessionId() {
       this.scrollToBottom();
     },
@@ -586,6 +612,18 @@ export default defineComponent({
       });
       this.prompt = '';
       this.clearAttachments();
+    },
+    onAnswerQuestion(payload: { tool_use_id: string; output: string }) {
+      this.$store.dispatch('codingBridge/answerQuestion', {
+        request_id: payload.tool_use_id,
+        output: payload.output
+      });
+    },
+    onSkipQuestion(payload: { tool_use_id: string }) {
+      this.$store.dispatch('codingBridge/resolvePermission', {
+        request_id: payload.tool_use_id,
+        decision: 'deny'
+      });
     },
     beforeAttachmentUpload(file: File): boolean {
       if (this.attachmentFileList.length >= MAX_ATTACHMENTS) {

--- a/src/components/codingBridge/TranscriptItem.vue
+++ b/src/components/codingBridge/TranscriptItem.vue
@@ -66,8 +66,19 @@
           toolDescription
         }}</span>
       </div>
+      <!-- AskUserQuestion: list the question(s) instead of raw JSON. -->
+      <div v-if="questionLines.length" class="flex flex-col gap-1.5 px-2.5 pb-2">
+        <div
+          v-for="(line, index) in questionLines"
+          :key="index"
+          class="rounded border border-[var(--app-border-subtle)] bg-[var(--app-content-bg)] px-2.5 py-1.5 text-xs"
+        >
+          <div v-if="line.header" class="font-medium text-[var(--app-text)]">{{ line.header }}</div>
+          <div class="whitespace-pre-wrap break-words text-[var(--app-text-subtle)]">{{ line.question }}</div>
+        </div>
+      </div>
       <!-- Shell-style tools render as a terminal command line. -->
-      <div v-if="commandText" class="px-2.5 pb-2">
+      <div v-else-if="commandText" class="px-2.5 pb-2">
         <div
           class="flex gap-2 overflow-x-auto rounded border border-[var(--app-border-subtle)] bg-[var(--app-content-bg)] px-2.5 py-1.5 font-mono text-xs"
         >
@@ -122,6 +133,7 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import VueMarkdown from '@/components/common/VueMarkdown.vue';
 import { highlight } from '@/utils';
 import { ICodingBridgeEvent } from '@/models';
+import { ASK_USER_QUESTION_TOOL } from './askUserQuestion';
 import 'highlight.js/styles/night-owl.css';
 
 export default defineComponent({
@@ -185,6 +197,22 @@ export default defineComponent({
         return 'fa-solid fa-magnifying-glass';
       }
       return 'fa-solid fa-code';
+    },
+    // AskUserQuestion is relayed as a tool_use; surface the question text
+    // instead of the raw `{questions:[...]}` JSON.
+    questionLines(): { header: string; question: string }[] {
+      const tool = (this.event.tool ?? '').toLowerCase();
+      const questions = this.event.input?.questions;
+      const looksLikeAsk = tool === ASK_USER_QUESTION_TOOL.toLowerCase() || Array.isArray(questions);
+      if (!looksLikeAsk || !Array.isArray(questions)) {
+        return [];
+      }
+      return questions
+        .filter((q) => q && typeof q.question === 'string')
+        .map((q) => ({
+          header: typeof q.header === 'string' ? q.header : '',
+          question: q.question as string
+        }));
     },
     inputText(): string {
       const input = this.event.input;

--- a/src/components/codingBridge/askUserQuestion.ts
+++ b/src/components/codingBridge/askUserQuestion.ts
@@ -1,0 +1,44 @@
+import type { IAskUserQuestionPayload, ICodingBridgePermissionRequest } from '@/models';
+
+/**
+ * Claude Code's built-in interactive-questions tool. When the agent calls it,
+ * the node relays a `permission.request` instead of a normal tool gate — the
+ * user is meant to pick an option, not just allow/deny. We special-case it so
+ * the transcript renders an `<AskUserQuestionCard>` rather than the generic
+ * permission dialog with raw JSON.
+ */
+export const ASK_USER_QUESTION_TOOL = 'AskUserQuestion';
+
+const hasQuestions = (input: Record<string, unknown> | undefined): boolean => {
+  const questions = input?.questions;
+  return (
+    Array.isArray(questions) &&
+    questions.length > 0 &&
+    questions.every(
+      (q) =>
+        q &&
+        typeof (q as { question?: unknown }).question === 'string' &&
+        Array.isArray((q as { options?: unknown }).options)
+    )
+  );
+};
+
+/**
+ * True when a permission request is really an `AskUserQuestion` call. We match
+ * on the tool name (Claude Code) and fall back to a well-formed `questions`
+ * array so a provider that names the tool differently still renders the card.
+ */
+export const isAskUserQuestionRequest = (request: ICodingBridgePermissionRequest | undefined): boolean => {
+  if (!request) {
+    return false;
+  }
+  if ((request.tool || '').toLowerCase() === ASK_USER_QUESTION_TOOL.toLowerCase()) {
+    return true;
+  }
+  return hasQuestions(request.input);
+};
+
+/** Extract the question payload the `<AskUserQuestionCard>` renders. */
+export const questionPayload = (request: ICodingBridgePermissionRequest): IAskUserQuestionPayload => ({
+  questions: (request.input?.questions ?? []) as IAskUserQuestionPayload['questions']
+});

--- a/src/store/codingBridge/actions.ts
+++ b/src/store/codingBridge/actions.ts
@@ -61,6 +61,28 @@ const makeEvent = (
   ...fields
 });
 
+// Parse the AskUserQuestion wizard's JSON output (`{"answers": {...}}`).
+const parseAnswers = (output: string): Record<string, unknown> => {
+  try {
+    const parsed = JSON.parse(output);
+    if (parsed && typeof parsed === 'object') {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // Malformed output: fall back to an empty answer set below.
+  }
+  return { answers: {} };
+};
+
+// Render answers as `question → choice` lines for nodes that surface the
+// reply as plain text rather than reading the structured `answer`.
+const formatAnswerText = (output: string): string => {
+  const answers = (parseAnswers(output).answers ?? {}) as Record<string, string | string[]>;
+  return Object.entries(answers)
+    .map(([question, value]) => `${question} → ${Array.isArray(value) ? value.join(', ') : value}`)
+    .join('\n');
+};
+
 // Translate one inner node event into the matching mutation(s).
 const applyNodeEvent = (
   commit: ActionContext<ICodingBridgeState, IRootState>['commit'],
@@ -493,6 +515,30 @@ export const resolvePermission = (
   commit('removePermission', payload.request_id);
 };
 
+// Resolve an `AskUserQuestion` permission with the user's actual selection
+// rather than a bare allow/deny. The node maps `decision: 'allow'` onto the
+// agent's permission callback and feeds the answer back as the tool result, so
+// the turn continues with the user's choice. `answer` is the structured
+// `{ answers: { <question>: <label | label[]> } }` produced by the wizard;
+// `answer_text` is a readable rendering for nodes that prefer plain text.
+export const answerQuestion = (
+  { commit, state }: ActionContext<ICodingBridgeState, IRootState>,
+  payload: { request_id: string; output: string }
+): void => {
+  const request = state.permissions.find((item) => item.request_id === payload.request_id);
+  if (!request) {
+    return;
+  }
+  socket?.sendToNode(request.node_id, {
+    action: CB_ACTION_PERMISSION_RESOLVE,
+    request_id: payload.request_id,
+    decision: 'allow',
+    answer: parseAnswers(payload.output),
+    answer_text: formatAnswerText(payload.output)
+  });
+  commit('removePermission', payload.request_id);
+};
+
 // Ask a node to list its local Claude Code / Codex transcripts.
 export const getHistory = ({ commit, state }: ActionContext<ICodingBridgeState, IRootState>, nodeId?: string): void => {
   const target = nodeId ?? state.currentNodeId;
@@ -557,6 +603,7 @@ export default {
   interruptSession,
   closeSession,
   resolvePermission,
+  answerQuestion,
   getHistory,
   getHistoryDetail,
   browseDir,


### PR DESCRIPTION
## Problem

When a Claude Code agent driven through **Coding Bridge** calls its built-in `AskUserQuestion` tool, the node relays it as a generic `permission.request`. The browser rendered it as a **raw JSON code block** plus the generic allow/deny modal — so the only thing a user could do was *deny*, which surfaced as red "Denied by user via Coding Bridge" text and stalled the turn. There was no way to actually pick an answer.

## Fix

Reuse the existing chat `AskUserQuestionCard.vue` (the aichat2 implementation) to render an **interactive question card** inline in the session transcript, exactly like the in-app chat does:

- **`components/codingBridge/askUserQuestion.ts`** (new) — detection helper (`isAskUserQuestionRequest`) + payload extraction (`questionPayload`). Matches on the `AskUserQuestion` tool name and falls back to a well-formed `questions` array.
- **`SessionView.vue`** — renders `<AskUserQuestionCard>` inline below the transcript when the current session has a pending question; `submit` → `answerQuestion` store action, `skip` → existing `resolvePermission` deny.
- **`PermissionDialog.vue`** — the generic allow/deny modal now skips `AskUserQuestion` requests (the card handles them).
- **`store/codingBridge/actions.ts`** — new `answerQuestion` action sends `permission.resolve` with `decision: 'allow'`, a structured `answer` (`{ answers: { <question>: <label | label[]> } }`), and a human-readable `answer_text`.
- **`TranscriptItem.vue`** — historical `AskUserQuestion` tool_use rows now show the question text instead of raw JSON.

No new i18n keys — reuses the existing `chat.askUserQuestion.*` keys (present in all 18 locales).

## ⚠️ Node daemon follow-up required

This is the **browser-side** half. For the end-to-end loop, the **Node daemon** (separate GPL repo, not in this monorepo) must consume the new fields on `permission.resolve` for `AskUserQuestion`:

- `answer` — structured `{ answers: { <question>: <label> | <label[]> } }`
- `answer_text` — readable fallback string

It should map `decision: 'allow'` + `answer` onto the agent's permission callback so the selected option is fed back as the tool result and the turn continues. `decision: 'deny'` (skip) keeps today's behavior.

Until the daemon is updated, the card renders and submits correctly, but the agent still sees a plain allow/deny. The FE change is self-contained and already removes the raw-JSON + deny-only regression.

## Verification

- `vue-tsc --noEmit` — clean
- `eslint` on changed files — clean
- `scripts/check_i18n_coverage.py` — 17 locales × 40 namespaces all match zh-CN