### PR TITLE
feat(coding-bridge): disable a backend whose CLI is not installed on the node

### DIFF
--- a/change/@acedatacloud-nexior-cb-disable-unavailable-backend.json
+++ b/change/@acedatacloud-nexior-cb-disable-unavailable-backend.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(coding-bridge): disable a backend whose CLI is not installed on the node",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/codingBridge/SessionView.vue
+++ b/src/components/codingBridge/SessionView.vue
@@ -146,13 +146,21 @@
                     </button>
                     <template #dropdown>
                       <el-dropdown-menu>
-                        <el-dropdown-item v-for="opt in providerOptions" :key="opt.value" :command="opt.value">
+                        <el-dropdown-item
+                          v-for="opt in providerOptions"
+                          :key="opt.value"
+                          :command="opt.value"
+                          :disabled="!opt.available"
+                        >
                           <font-awesome-icon
                             icon="fa-solid fa-check"
                             class="mr-2"
                             :class="opt.value === provider ? 'opacity-100' : 'opacity-0'"
                           />
                           {{ opt.label }}
+                          <span v-if="!opt.available" class="ml-1 text-xs opacity-60">
+                            {{ $t('codingBridge.session.providerUnavailable') }}
+                          </span>
                         </el-dropdown-item>
                       </el-dropdown-menu>
                     </template>
@@ -423,12 +431,18 @@ export default defineComponent({
         (!!this.prompt.trim() || this.attachments.length > 0) &&
         !this.uploadingAttachments &&
         this.connected &&
-        this.nodeOnline
+        this.nodeOnline &&
+        this.currentProviderAvailable
       );
     },
     composerHint(): string {
       if (this.uploadingAttachments) {
         return this.$t('codingBridge.session.uploadingAttachment') as string;
+      }
+      if (this.providerCaps.length && !this.currentProviderAvailable) {
+        return this.$t('codingBridge.session.providerUnavailableHint', {
+          name: this.providerName(this.provider)
+        }) as string;
       }
       return this.resumeHint
         ? (this.$t('codingBridge.history.resumeHint') as string)
@@ -447,13 +461,25 @@ export default defineComponent({
     currentProviderCap(): ICodingBridgeProviderCapability | undefined {
       return this.providerCaps.find((cap) => cap.name === this.provider);
     },
-    providerOptions(): { label: string; value: string }[] {
+    // Unknown until capabilities load → treat as available so the composer is
+    // never blocked before the node has reported anything.
+    currentProviderAvailable(): boolean {
+      if (!this.providerCaps.length) {
+        return true;
+      }
+      return this.currentProviderCap?.available !== false;
+    },
+    providerOptions(): { label: string; value: string; available: boolean }[] {
       if (this.providerCaps.length) {
-        return this.providerCaps.map((cap) => ({ value: cap.name, label: cap.label }));
+        return this.providerCaps.map((cap) => ({
+          value: cap.name,
+          label: cap.label,
+          available: cap.available !== false
+        }));
       }
       return [
-        { label: this.$t('codingBridge.session.providerClaude') as string, value: 'claude' },
-        { label: this.$t('codingBridge.session.providerCodex') as string, value: 'codex' }
+        { label: this.$t('codingBridge.session.providerClaude') as string, value: 'claude', available: true },
+        { label: this.$t('codingBridge.session.providerCodex') as string, value: 'codex', available: true }
       ];
     },
     modelOptions(): { label: string; value: string }[] {
@@ -503,10 +529,18 @@ export default defineComponent({
       this.requestCapabilities();
     },
     providerCaps() {
-      // If the picked backend isn't offered by this node, fall back to the
-      // first one it reports so the model list always matches.
-      if (this.providerCaps.length && !this.providerCaps.some((cap) => cap.name === this.provider)) {
-        this.provider = this.providerCaps[0].name;
+      // Prefer a backend the node actually has installed. Fall back to the
+      // first available provider when the current pick is missing or its CLI
+      // isn't installed, so the model list and send button always match.
+      if (!this.providerCaps.length) {
+        return;
+      }
+      const current = this.providerCaps.find((cap) => cap.name === this.provider);
+      if (!current || current.available === false) {
+        const firstAvailable = this.providerCaps.find((cap) => cap.available !== false);
+        if (firstAvailable) {
+          this.provider = firstAvailable.name;
+        }
       }
     },
     provider() {

--- a/src/i18n/ar/codingBridge.json
+++ b/src/i18n/ar/codingBridge.json
@@ -239,6 +239,14 @@
     "message": "Codex",
     "description": "Backend option: Codex"
   },
+  "session.providerUnavailable": {
+    "message": "(غير مثبّت)",
+    "description": "Suffix shown next to a backend whose CLI is not installed on the node"
+  },
+  "session.providerUnavailableHint": {
+    "message": "‏{name} غير مثبّت على هذا الجهاز.",
+    "description": "Composer hint shown when the selected backend is not installed on the node"
+  },
   "session.effortLabel": {
     "message": "مستوى الاستدلال",
     "description": "Reasoning-effort selector label"

--- a/src/i18n/de/codingBridge.json
+++ b/src/i18n/de/codingBridge.json
@@ -239,6 +239,14 @@
     "message": "Codex",
     "description": "Backend option: Codex"
   },
+  "session.providerUnavailable": {
+    "message": "(nicht installiert)",
+    "description": "Suffix shown next to a backend whose CLI is not installed on the node"
+  },
+  "session.providerUnavailableHint": {
+    "message": "{name} ist auf diesem Gerät nicht installiert.",
+    "description": "Composer hint shown when the selected backend is not installed on the node"
+  },
   "session.effortLabel": {
     "message": "Denkaufwand",
     "description": "Reasoning-effort selector label"

--- a/src/i18n/el/codingBridge.json
+++ b/src/i18n/el/codingBridge.json
@@ -239,6 +239,14 @@
     "message": "Codex",
     "description": "Backend option: Codex"
   },
+  "session.providerUnavailable": {
+    "message": "(δεν έχει εγκατασταθεί)",
+    "description": "Suffix shown next to a backend whose CLI is not installed on the node"
+  },
+  "session.providerUnavailableHint": {
+    "message": "Το {name} δεν είναι εγκατεστημένο σε αυτή τη συσκευή.",
+    "description": "Composer hint shown when the selected backend is not installed on the node"
+  },
   "session.effortLabel": {
     "message": "Προσπάθεια συλλογισμού",
     "description": "Reasoning-effort selector label"

--- a/src/i18n/en/codingBridge.json
+++ b/src/i18n/en/codingBridge.json
@@ -239,6 +239,14 @@
     "message": "Codex",
     "description": "Backend option: Codex"
   },
+  "session.providerUnavailable": {
+    "message": "(not installed)",
+    "description": "Suffix shown next to a backend whose CLI is not installed on the node"
+  },
+  "session.providerUnavailableHint": {
+    "message": "{name} is not installed on this device.",
+    "description": "Composer hint shown when the selected backend is not installed on the node"
+  },
   "session.effortLabel": {
     "message": "Reasoning effort",
     "description": "Reasoning-effort selector label"

--- a/src/i18n/es/codingBridge.json
+++ b/src/i18n/es/codingBridge.json
@@ -239,6 +239,14 @@
     "message": "Codex",
     "description": "Backend option: Codex"
   },
+  "session.providerUnavailable": {
+    "message": "(no instalado)",
+    "description": "Suffix shown next to a backend whose CLI is not installed on the node"
+  },
+  "session.providerUnavailableHint": {
+    "message": "{name} no está instalado en este dispositivo.",
+    "description": "Composer hint shown when the selected backend is not installed on the node"
+  },
   "session.effortLabel": {
     "message": "Esfuerzo de razonamiento",
     "description": "Reasoning-effort selector label"

--- a/src/i18n/fi/codingBridge.json
+++ b/src/i18n/fi/codingBridge.json
@@ -239,6 +239,14 @@
     "message": "Codex",
     "description": "Backend option: Codex"
   },
+  "session.providerUnavailable": {
+    "message": "(ei asennettu)",
+    "description": "Suffix shown next to a backend whose CLI is not installed on the node"
+  },
+  "session.providerUnavailableHint": {
+    "message": "{name} ei ole asennettu tähän laitteeseen.",
+    "description": "Composer hint shown when the selected backend is not installed on the node"
+  },
   "session.effortLabel": {
     "message": "Päättelyn taso",
     "description": "Reasoning-effort selector label"

--- a/src/i18n/fr/codingBridge.json
+++ b/src/i18n/fr/codingBridge.json
@@ -239,6 +239,14 @@
     "message": "Codex",
     "description": "Backend option: Codex"
   },
+  "session.providerUnavailable": {
+    "message": "(non installé)",
+    "description": "Suffix shown next to a backend whose CLI is not installed on the node"
+  },
+  "session.providerUnavailableHint": {
+    "message": "{name} n'est pas installé sur cet appareil.",
+    "description": "Composer hint shown when the selected backend is not installed on the node"
+  },
   "session.effortLabel": {
     "message": "Effort de raisonnement",
     "description": "Reasoning-effort selector label"

--- a/src/i18n/it/codingBridge.json
+++ b/src/i18n/it/codingBridge.json
@@ -239,6 +239,14 @@
     "message": "Codex",
     "description": "Backend option: Codex"
   },
+  "session.providerUnavailable": {
+    "message": "(non installato)",
+    "description": "Suffix shown next to a backend whose CLI is not installed on the node"
+  },
+  "session.providerUnavailableHint": {
+    "message": "{name} non è installato su questo dispositivo.",
+    "description": "Composer hint shown when the selected backend is not installed on the node"
+  },
   "session.effortLabel": {
     "message": "Sforzo di ragionamento",
     "description": "Reasoning-effort selector label"

--- a/src/i18n/ja/codingBridge.json
+++ b/src/i18n/ja/codingBridge.json
@@ -239,6 +239,14 @@
     "message": "Codex",
     "description": "Backend option: Codex"
   },
+  "session.providerUnavailable": {
+    "message": "（未インストール）",
+    "description": "Suffix shown next to a backend whose CLI is not installed on the node"
+  },
+  "session.providerUnavailableHint": {
+    "message": "{name} はこのデバイスにインストールされていません。",
+    "description": "Composer hint shown when the selected backend is not installed on the node"
+  },
   "session.effortLabel": {
     "message": "推論の強度",
     "description": "Reasoning-effort selector label"

--- a/src/i18n/ko/codingBridge.json
+++ b/src/i18n/ko/codingBridge.json
@@ -239,6 +239,14 @@
     "message": "Codex",
     "description": "Backend option: Codex"
   },
+  "session.providerUnavailable": {
+    "message": "(설치되지 않음)",
+    "description": "Suffix shown next to a backend whose CLI is not installed on the node"
+  },
+  "session.providerUnavailableHint": {
+    "message": "{name}이(가) 이 기기에 설치되어 있지 않습니다.",
+    "description": "Composer hint shown when the selected backend is not installed on the node"
+  },
   "session.effortLabel": {
     "message": "추론 강도",
     "description": "Reasoning-effort selector label"

--- a/src/i18n/pl/codingBridge.json
+++ b/src/i18n/pl/codingBridge.json
@@ -239,6 +239,14 @@
     "message": "Codex",
     "description": "Backend option: Codex"
   },
+  "session.providerUnavailable": {
+    "message": "(niezainstalowane)",
+    "description": "Suffix shown next to a backend whose CLI is not installed on the node"
+  },
+  "session.providerUnavailableHint": {
+    "message": "{name} nie jest zainstalowany na tym urządzeniu.",
+    "description": "Composer hint shown when the selected backend is not installed on the node"
+  },
   "session.effortLabel": {
     "message": "Wysiłek rozumowania",
     "description": "Reasoning-effort selector label"

--- a/src/i18n/pt/codingBridge.json
+++ b/src/i18n/pt/codingBridge.json
@@ -239,6 +239,14 @@
     "message": "Codex",
     "description": "Backend option: Codex"
   },
+  "session.providerUnavailable": {
+    "message": "(não instalado)",
+    "description": "Suffix shown next to a backend whose CLI is not installed on the node"
+  },
+  "session.providerUnavailableHint": {
+    "message": "{name} não está instalado neste dispositivo.",
+    "description": "Composer hint shown when the selected backend is not installed on the node"
+  },
   "session.effortLabel": {
     "message": "Esforço de raciocínio",
     "description": "Reasoning-effort selector label"

--- a/src/i18n/ru/codingBridge.json
+++ b/src/i18n/ru/codingBridge.json
@@ -239,6 +239,14 @@
     "message": "Codex",
     "description": "Backend option: Codex"
   },
+  "session.providerUnavailable": {
+    "message": "(не установлено)",
+    "description": "Suffix shown next to a backend whose CLI is not installed on the node"
+  },
+  "session.providerUnavailableHint": {
+    "message": "{name} не установлен на этом устройстве.",
+    "description": "Composer hint shown when the selected backend is not installed on the node"
+  },
   "session.effortLabel": {
     "message": "Уровень рассуждений",
     "description": "Reasoning-effort selector label"

--- a/src/i18n/sr/codingBridge.json
+++ b/src/i18n/sr/codingBridge.json
@@ -239,6 +239,14 @@
     "message": "Codex",
     "description": "Backend option: Codex"
   },
+  "session.providerUnavailable": {
+    "message": "(није инсталирано)",
+    "description": "Suffix shown next to a backend whose CLI is not installed on the node"
+  },
+  "session.providerUnavailableHint": {
+    "message": "{name} није инсталиран на овом уређају.",
+    "description": "Composer hint shown when the selected backend is not installed on the node"
+  },
   "session.effortLabel": {
     "message": "Ниво размишљања",
     "description": "Reasoning-effort selector label"

--- a/src/i18n/sv/codingBridge.json
+++ b/src/i18n/sv/codingBridge.json
@@ -239,6 +239,14 @@
     "message": "Codex",
     "description": "Backend option: Codex"
   },
+  "session.providerUnavailable": {
+    "message": "(inte installerat)",
+    "description": "Suffix shown next to a backend whose CLI is not installed on the node"
+  },
+  "session.providerUnavailableHint": {
+    "message": "{name} är inte installerat på den här enheten.",
+    "description": "Composer hint shown when the selected backend is not installed on the node"
+  },
   "session.effortLabel": {
     "message": "Resonemangsnivå",
     "description": "Reasoning-effort selector label"

--- a/src/i18n/uk/codingBridge.json
+++ b/src/i18n/uk/codingBridge.json
@@ -239,6 +239,14 @@
     "message": "Codex",
     "description": "Backend option: Codex"
   },
+  "session.providerUnavailable": {
+    "message": "(не встановлено)",
+    "description": "Suffix shown next to a backend whose CLI is not installed on the node"
+  },
+  "session.providerUnavailableHint": {
+    "message": "{name} не встановлено на цьому пристрої.",
+    "description": "Composer hint shown when the selected backend is not installed on the node"
+  },
   "session.effortLabel": {
     "message": "Рівень міркувань",
     "description": "Reasoning-effort selector label"

--- a/src/i18n/zh-CN/codingBridge.json
+++ b/src/i18n/zh-CN/codingBridge.json
@@ -239,6 +239,14 @@
     "message": "Codex",
     "description": "Backend option: Codex"
   },
+  "session.providerUnavailable": {
+    "message": "（未安装）",
+    "description": "Suffix shown next to a backend whose CLI is not installed on the node"
+  },
+  "session.providerUnavailableHint": {
+    "message": "{name} 未安装在该设备上。",
+    "description": "Composer hint shown when the selected backend is not installed on the node"
+  },
   "session.effortLabel": {
     "message": "推理强度",
     "description": "Reasoning-effort selector label"

--- a/src/i18n/zh-TW/codingBridge.json
+++ b/src/i18n/zh-TW/codingBridge.json
@@ -239,6 +239,14 @@
     "message": "Codex",
     "description": "Backend option: Codex"
   },
+  "session.providerUnavailable": {
+    "message": "（未安裝）",
+    "description": "Suffix shown next to a backend whose CLI is not installed on the node"
+  },
+  "session.providerUnavailableHint": {
+    "message": "{name} 未安裝在此裝置上。",
+    "description": "Composer hint shown when the selected backend is not installed on the node"
+  },
   "session.effortLabel": {
     "message": "推理強度",
     "description": "Reasoning-effort selector label"


### PR DESCRIPTION
## What

In the Coding Bridge composer, the **Backend** picker now greys out and disables any backend whose CLI is **not installed** on the connected node — driven by the node-reported `capabilities.available` flag (no hard-coding).

Concretely:
- An unavailable backend (e.g. **Codex** when the `codex` CLI isn't installed) is rendered disabled in the Backend dropdown with a localized **"(not installed)"** suffix, so it can't be selected.
- When capabilities load, the session now defaults to the **first available** backend (previously the first *listed*), so a node that only has Claude installed never lands on an uninstalled Codex.
- The **Send** button is gated on the selected backend being available, and the composer shows a hint (`{name} is not installed on this device.`) in the rare case where no backend is installed.

## Why

If the selected backend's CLI isn't installed on the node, starting a turn fails on the node side (e.g. *"codex CLI is not installed"*). Surfacing the already-reported `available` flag in the UI prevents users from picking an unusable backend.

## i18n

Added `session.providerUnavailable` and `session.providerUnavailableHint` to **all 18 locales** (`check_i18n_coverage.py` passes: 17 locales × 40 namespaces match zh-CN).

## Validation

- `python3 scripts/check_i18n_coverage.py` — OK
- `npx eslint src/components/codingBridge/SessionView.vue` — OK
- `npx vue-tsc -b --force` — OK
- `npm run build` — OK
- `npm run test:run` — 141 passed