### PR TITLE
fix(coding-bridge): integrate working-directory browse button into the input

### DIFF
--- a/change/@acedatacloud-nexior-84d9be52-6249-423b-b7ce-c1aef139622e.json
+++ b/change/@acedatacloud-nexior-84d9be52-6249-423b-b7ce-c1aef139622e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Integrate the Coding Bridge working-directory browse button into the input as a suffix icon so it no longer looks detached",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/codingBridge/SessionView.vue
+++ b/src/components/codingBridge/SessionView.vue
@@ -263,12 +263,22 @@
                       v-model="cwd"
                       size="small"
                       clearable
+                      class="cb-cwd-input"
                       :placeholder="$t('codingBridge.session.cwdPlaceholder')"
                     >
-                      <template #append>
-                        <el-button :title="$t('codingBridge.directory.title')" @click="openDirectory">
+                      <template #suffix>
+                        <span
+                          class="cb-cwd-browse"
+                          role="button"
+                          tabindex="0"
+                          :title="$t('codingBridge.directory.title')"
+                          :aria-label="$t('codingBridge.directory.title')"
+                          @click="openDirectory"
+                          @keydown.enter.prevent="openDirectory"
+                          @keydown.space.prevent="openDirectory"
+                        >
                           <font-awesome-icon icon="fa-solid fa-folder-open" />
-                        </el-button>
+                        </span>
                       </template>
                     </el-input>
                   </el-popover>
@@ -816,6 +826,29 @@ export default defineComponent({
       font-size: 14px;
       line-height: 1.5;
     }
+  }
+}
+
+// Working-directory picker: the folder-browse trigger lives inside the input
+// as a suffix icon so it reads as one control instead of a detached button.
+.cb-cwd-input {
+  :deep(.el-input__wrapper) {
+    border-radius: 9999px;
+  }
+}
+
+.cb-cwd-browse {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--app-text-subtle);
+  cursor: pointer;
+  transition: color 0.15s ease;
+
+  &:hover,
+  &:focus-visible {
+    color: var(--el-color-primary);
+    outline: none;
   }
 }
 


### PR DESCRIPTION
## What

Polish the Coding Bridge composer's **working-directory** popover so the folder-browse trigger no longer looks detached from the input.

Previously the browse control used Element Plus's `#append` slot, which renders a separate grey, box-shadow-bordered box. That created a visible seam between the input (left) and the button (right) — the "割裂" look.

## Change

- Moved the folder-browse trigger **inside** the input as a `#suffix` icon, so it reads as one cohesive control instead of two glued-together boxes.
- The icon uses the composer's subtle text color and turns primary on hover/focus.
- Rounded the input wrapper to match the composer's pill aesthetic.
- Kept full keyboard a11y: `role=button`, `tabindex=0`, Enter/Space activate browse, plus `aria-label`/`title`.
- `clearable` still works — Element Plus 2.10.4 renders the suffix slot alongside the clear icon (verified in source).

## Validation

- `vue-tsc -b --force` — exit 0
- `eslint src/components/codingBridge/SessionView.vue` — exit 0
- `npm run build` — ✓ built (only pre-existing reown/dynamic-import warnings)
- `npm run test:run` — 141/141 passing

Scope: `SessionView.vue` only (composer working-directory popover). No behavior change to directory selection.