### PR TITLE
feat(codingBridge): slash-command autocomplete + unavailable notices

### DIFF
--- a/change/@acedatacloud-nexior-2b901c27-025b-4f44-91e1-69ca251860f5.json
+++ b/change/@acedatacloud-nexior-2b901c27-025b-4f44-91e1-69ca251860f5.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Coding Bridge: autocomplete a node's runnable slash commands in the composer and show a friendly notice for commands that can't run remotely",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/codingBridge/SessionView.vue
+++ b/src/components/codingBridge/SessionView.vue
@@ -105,6 +105,21 @@
               </div>
             </div>
 
+            <ul v-if="slashMenuVisible" class="cb-slash-menu">
+              <li
+                v-for="(command, index) in slashMatches"
+                :key="command.name"
+                class="cb-slash-menu__item"
+                :class="{ 'cb-slash-menu__item--active': index === slashActiveIndex }"
+                @mousedown.prevent="applySlash(command)"
+                @mouseenter="slashActiveIndex = index"
+              >
+                <span class="cb-slash-menu__name">/{{ command.name }}</span>
+                <span v-if="command.argument_hint" class="cb-slash-menu__hint">{{ command.argument_hint }}</span>
+                <span v-if="command.description" class="cb-slash-menu__desc">{{ command.description }}</span>
+              </li>
+            </ul>
+
             <el-input
               v-model="prompt"
               type="textarea"
@@ -112,7 +127,7 @@
               resize="none"
               class="cb-composer__input"
               :placeholder="$t('codingBridge.session.promptPlaceholder')"
-              @keydown.enter="onComposerEnter"
+              @keydown="onComposerKeydown"
             />
 
             <el-upload
@@ -357,7 +372,8 @@ import {
   ICodingBridgeEvent,
   ICodingBridgeNode,
   ICodingBridgeProviderCapability,
-  ICodingBridgeSession
+  ICodingBridgeSession,
+  ICodingBridgeSlashCommand
 } from '@/models';
 import claudeIcon from '@/assets/images/logos/claude.svg';
 import openaiIcon from '@/assets/images/logos/openai.svg';
@@ -400,6 +416,8 @@ export default defineComponent({
       provider: 'claude',
       effort: '',
       directoryVisible: false,
+      slashMenuOpen: false,
+      slashActiveIndex: 0,
       attachmentFileList: [] as UploadFiles,
       uploadUrl: getBaseUrlPlatform() + '/api/v1/files/',
       maxAttachments: MAX_ATTACHMENTS
@@ -580,6 +598,33 @@ export default defineComponent({
         parts.push(session.model);
       }
       return parts.join(' · ');
+    },
+    // The backend whose slash commands the composer should suggest: a running
+    // session keeps its own backend; a new session uses the picked provider.
+    activeProviderName(): string {
+      return this.currentSession?.provider || this.provider;
+    },
+    slashCommands(): ICodingBridgeSlashCommand[] {
+      const name = this.activeProviderName;
+      const cap = this.providerCaps.find((item) => item.name === name);
+      return cap?.commands ?? [];
+    },
+    // Matches while the user is still typing the command token (no space yet).
+    slashMatches(): ICodingBridgeSlashCommand[] {
+      const match = this.prompt.match(/^\/(\S*)$/);
+      if (!match) {
+        return [];
+      }
+      const query = match[1].toLowerCase();
+      return this.slashCommands
+        .filter((command) => {
+          const names = [command.name, ...(command.aliases ?? [])];
+          return names.some((name) => name.toLowerCase().startsWith(query));
+        })
+        .slice(0, 8);
+    },
+    slashMenuVisible(): boolean {
+      return this.slashMenuOpen && this.slashMatches.length > 0;
     }
   },
   watch: {
@@ -615,6 +660,13 @@ export default defineComponent({
       // Model lists and effort tiers differ per backend, so reset both.
       this.model = '';
       this.effort = '';
+    },
+    prompt(value: string) {
+      // Open the slash menu only while a leading command token is being typed.
+      this.slashMenuOpen = /^\/\S*$/.test(value);
+      if (this.slashActiveIndex >= this.slashMatches.length) {
+        this.slashActiveIndex = 0;
+      }
     }
   },
   mounted() {
@@ -676,6 +728,52 @@ export default defineComponent({
       e.preventDefault();
       this.onSend();
     },
+    // Route keys to the slash-command menu when it is open; otherwise fall back
+    // to the normal Enter-to-send behaviour.
+    onComposerKeydown(event: KeyboardEvent | Event) {
+      const e = event as KeyboardEvent;
+      if (this.slashMenuVisible && !e.isComposing && e.keyCode !== 229) {
+        if (e.key === 'ArrowDown') {
+          e.preventDefault();
+          this.moveSlash(1);
+          return;
+        }
+        if (e.key === 'ArrowUp') {
+          e.preventDefault();
+          this.moveSlash(-1);
+          return;
+        }
+        if (e.key === 'Escape') {
+          e.preventDefault();
+          this.slashMenuOpen = false;
+          return;
+        }
+        const accept = e.key === 'Tab' || (e.key === 'Enter' && !e.shiftKey);
+        if (accept) {
+          e.preventDefault();
+          this.applySlash(this.slashMatches[this.slashActiveIndex]);
+          return;
+        }
+      }
+      if (e.key === 'Enter') {
+        this.onComposerEnter(e);
+      }
+    },
+    moveSlash(delta: number) {
+      const count = this.slashMatches.length;
+      if (!count) {
+        return;
+      }
+      this.slashActiveIndex = (this.slashActiveIndex + delta + count) % count;
+    },
+    applySlash(command?: ICodingBridgeSlashCommand) {
+      if (!command) {
+        return;
+      }
+      this.prompt = `/${command.name} `;
+      this.slashMenuOpen = false;
+      this.slashActiveIndex = 0;
+    },
     onSend() {
       if (!this.canSend) {
         return;
@@ -691,6 +789,8 @@ export default defineComponent({
         attachments: attachments.length ? attachments : undefined
       });
       this.prompt = '';
+      this.slashMenuOpen = false;
+      this.slashActiveIndex = 0;
       this.clearAttachments();
     },
     onAnswerQuestion(payload: { tool_use_id: string; output: string }) {
@@ -800,6 +900,8 @@ export default defineComponent({
       this.provider = 'claude';
       this.effort = '';
       this.prompt = '';
+      this.slashMenuOpen = false;
+      this.slashActiveIndex = 0;
       this.clearAttachments();
     },
     scrollToBottom() {
@@ -816,6 +918,8 @@ export default defineComponent({
 
 <style scoped lang="scss">
 .cb-composer {
+  position: relative;
+
   &__input {
     :deep(.el-textarea__inner) {
       border: none;
@@ -849,6 +953,60 @@ export default defineComponent({
   &:focus-visible {
     color: var(--el-color-primary);
     outline: none;
+  }
+}
+
+.cb-slash-menu {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: calc(100% + 6px);
+  z-index: 20;
+  max-height: 260px;
+  overflow-y: auto;
+  margin: 0;
+  padding: 4px;
+  list-style: none;
+  border-radius: 12px;
+  border: 1px solid var(--app-border-subtle);
+  background: var(--app-content-bg);
+  box-shadow: 0 8px 24px rgb(0 0 0 / 12%);
+
+  &__item {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    padding: 6px 10px;
+    border-radius: 8px;
+    cursor: pointer;
+    font-size: 13px;
+    color: var(--app-text);
+
+    &--active {
+      background: var(--app-content-hover-bg);
+    }
+  }
+
+  &__name {
+    flex: none;
+    font-family: var(--el-font-family-mono, monospace);
+    color: var(--el-color-primary);
+  }
+
+  &__hint {
+    flex: none;
+    font-size: 11px;
+    color: var(--app-text-subtle);
+  }
+
+  &__desc {
+    min-width: 0;
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 12px;
+    color: var(--app-text-subtle);
   }
 }
 

--- a/src/components/codingBridge/TranscriptItem.vue
+++ b/src/components/codingBridge/TranscriptItem.vue
@@ -117,6 +117,15 @@
       <span>{{ resultLabel }}</span>
     </div>
 
+    <!-- Notice: a friendly heads-up such as a slash command that can't run remotely. -->
+    <div
+      v-else-if="event.kind === 'notice'"
+      class="flex items-start gap-2 rounded-md bg-[var(--app-sidebar-bg)] border border-[var(--app-border-subtle)] text-[var(--app-text-subtle)] px-3 py-2 text-xs"
+    >
+      <font-awesome-icon icon="fa-solid fa-circle-info" class="mt-0.5 flex-none text-[var(--el-color-primary)]" />
+      <span class="whitespace-pre-wrap break-words">{{ noticeText }}</span>
+    </div>
+
     <!-- Error -->
     <div
       v-else-if="event.kind === 'error'"
@@ -253,6 +262,21 @@ export default defineComponent({
     },
     hasAttachments(): boolean {
       return !!this.event.attachments?.length;
+    },
+    // Localize a notice from its machine code + command, falling back to the
+    // node-provided English text for codes the web app doesn't know yet.
+    noticeText(): string {
+      const code = this.event.subtype;
+      const command = this.event.command;
+      if (command) {
+        if (code === 'slash_unavailable') {
+          return this.$t('codingBridge.notice.slashUnavailable', { command }) as string;
+        }
+        if (code === 'slash_codex_unsupported') {
+          return this.$t('codingBridge.notice.slashCodexUnsupported', { command }) as string;
+        }
+      }
+      return this.event.text || '';
     }
   }
 });

--- a/src/constants/codingBridge.ts
+++ b/src/constants/codingBridge.ts
@@ -37,6 +37,7 @@ export const CB_EVENT_SESSION_TOOL_RESULT = 'session.tool_result';
 export const CB_EVENT_PERMISSION_REQUEST = 'permission.request';
 export const CB_EVENT_PERMISSION_RESOLVED = 'permission.resolved';
 export const CB_EVENT_SESSION_RESULT = 'session.result';
+export const CB_EVENT_SESSION_NOTICE = 'session.notice';
 export const CB_EVENT_SESSION_ERROR = 'session.error';
 export const CB_EVENT_SESSION_CLOSED = 'session.closed';
 export const CB_EVENT_SESSIONS_SNAPSHOT = 'sessions.snapshot';

--- a/src/i18n/ar/codingBridge.json
+++ b/src/i18n/ar/codingBridge.json
@@ -362,5 +362,13 @@
   "session.attachmentUploadError": {
     "message": "Failed to upload attachment.",
     "description": "Failed to upload attachment."
+  },
+  "notice.slashUnavailable": {
+    "message": "‏/{command} أمر تفاعلي ولا يمكن تشغيله في جلسة عن بُعد.",
+    "description": "Notice shown when a slash command can't run in a remote session"
+  },
+  "notice.slashCodexUnsupported": {
+    "message": "‏/{command} غير متاح لـ Codex في جلسة عن بُعد.",
+    "description": "Notice shown when a Codex slash command isn't supported remotely"
   }
 }

--- a/src/i18n/de/codingBridge.json
+++ b/src/i18n/de/codingBridge.json
@@ -362,5 +362,13 @@
   "session.attachmentUploadError": {
     "message": "Failed to upload attachment.",
     "description": "Failed to upload attachment."
+  },
+  "notice.slashUnavailable": {
+    "message": "/{command} ist ein interaktiver Befehl und kann in einer Remote-Sitzung nicht ausgeführt werden.",
+    "description": "Notice shown when a slash command can't run in a remote session"
+  },
+  "notice.slashCodexUnsupported": {
+    "message": "/{command} ist für Codex in einer Remote-Sitzung nicht verfügbar.",
+    "description": "Notice shown when a Codex slash command isn't supported remotely"
   }
 }

--- a/src/i18n/el/codingBridge.json
+++ b/src/i18n/el/codingBridge.json
@@ -362,5 +362,13 @@
   "session.attachmentUploadError": {
     "message": "Failed to upload attachment.",
     "description": "Failed to upload attachment."
+  },
+  "notice.slashUnavailable": {
+    "message": "Η /{command} είναι διαδραστική εντολή και δεν μπορεί να εκτελεστεί σε απομακρυσμένη συνεδρία.",
+    "description": "Notice shown when a slash command can't run in a remote session"
+  },
+  "notice.slashCodexUnsupported": {
+    "message": "Η /{command} δεν είναι διαθέσιμη για το Codex σε απομακρυσμένη συνεδρία.",
+    "description": "Notice shown when a Codex slash command isn't supported remotely"
   }
 }

--- a/src/i18n/en/codingBridge.json
+++ b/src/i18n/en/codingBridge.json
@@ -362,5 +362,13 @@
   "session.attachmentUploadError": {
     "message": "Failed to upload attachment.",
     "description": "Failed to upload attachment."
+  },
+  "notice.slashUnavailable": {
+    "message": "/{command} is an interactive command and isn't available in a remote session.",
+    "description": "Notice shown when a slash command can't run in a remote session"
+  },
+  "notice.slashCodexUnsupported": {
+    "message": "/{command} isn't available for Codex in a remote session.",
+    "description": "Notice shown when a Codex slash command isn't supported remotely"
   }
 }

--- a/src/i18n/es/codingBridge.json
+++ b/src/i18n/es/codingBridge.json
@@ -362,5 +362,13 @@
   "session.attachmentUploadError": {
     "message": "Failed to upload attachment.",
     "description": "Failed to upload attachment."
+  },
+  "notice.slashUnavailable": {
+    "message": "/{command} es un comando interactivo y no puede ejecutarse en una sesión remota.",
+    "description": "Notice shown when a slash command can't run in a remote session"
+  },
+  "notice.slashCodexUnsupported": {
+    "message": "/{command} no está disponible para Codex en una sesión remota.",
+    "description": "Notice shown when a Codex slash command isn't supported remotely"
   }
 }

--- a/src/i18n/fi/codingBridge.json
+++ b/src/i18n/fi/codingBridge.json
@@ -362,5 +362,13 @@
   "session.attachmentUploadError": {
     "message": "Failed to upload attachment.",
     "description": "Failed to upload attachment."
+  },
+  "notice.slashUnavailable": {
+    "message": "/{command} on vuorovaikutteinen komento, eikä sitä voi suorittaa etäistunnossa.",
+    "description": "Notice shown when a slash command can't run in a remote session"
+  },
+  "notice.slashCodexUnsupported": {
+    "message": "/{command} ei ole käytettävissä Codexille etäistunnossa.",
+    "description": "Notice shown when a Codex slash command isn't supported remotely"
   }
 }

--- a/src/i18n/fr/codingBridge.json
+++ b/src/i18n/fr/codingBridge.json
@@ -362,5 +362,13 @@
   "session.attachmentUploadError": {
     "message": "Failed to upload attachment.",
     "description": "Failed to upload attachment."
+  },
+  "notice.slashUnavailable": {
+    "message": "/{command} est une commande interactive et ne peut pas s'exécuter dans une session distante.",
+    "description": "Notice shown when a slash command can't run in a remote session"
+  },
+  "notice.slashCodexUnsupported": {
+    "message": "/{command} n'est pas disponible pour Codex dans une session distante.",
+    "description": "Notice shown when a Codex slash command isn't supported remotely"
   }
 }

--- a/src/i18n/it/codingBridge.json
+++ b/src/i18n/it/codingBridge.json
@@ -362,5 +362,13 @@
   "session.attachmentUploadError": {
     "message": "Failed to upload attachment.",
     "description": "Failed to upload attachment."
+  },
+  "notice.slashUnavailable": {
+    "message": "/{command} è un comando interattivo e non può essere eseguito in una sessione remota.",
+    "description": "Notice shown when a slash command can't run in a remote session"
+  },
+  "notice.slashCodexUnsupported": {
+    "message": "/{command} non è disponibile per Codex in una sessione remota.",
+    "description": "Notice shown when a Codex slash command isn't supported remotely"
   }
 }

--- a/src/i18n/ja/codingBridge.json
+++ b/src/i18n/ja/codingBridge.json
@@ -362,5 +362,13 @@
   "session.attachmentUploadError": {
     "message": "Failed to upload attachment.",
     "description": "Failed to upload attachment."
+  },
+  "notice.slashUnavailable": {
+    "message": "/{command} は対話型コマンドのため、リモートセッションでは実行できません。",
+    "description": "Notice shown when a slash command can't run in a remote session"
+  },
+  "notice.slashCodexUnsupported": {
+    "message": "/{command} はリモートセッションの Codex では利用できません。",
+    "description": "Notice shown when a Codex slash command isn't supported remotely"
   }
 }

--- a/src/i18n/ko/codingBridge.json
+++ b/src/i18n/ko/codingBridge.json
@@ -362,5 +362,13 @@
   "session.attachmentUploadError": {
     "message": "Failed to upload attachment.",
     "description": "Failed to upload attachment."
+  },
+  "notice.slashUnavailable": {
+    "message": "/{command} 은(는) 대화형 명령이라 원격 세션에서는 실행할 수 없습니다.",
+    "description": "Notice shown when a slash command can't run in a remote session"
+  },
+  "notice.slashCodexUnsupported": {
+    "message": "/{command} 은(는) 원격 세션의 Codex에서 사용할 수 없습니다.",
+    "description": "Notice shown when a Codex slash command isn't supported remotely"
   }
 }

--- a/src/i18n/pl/codingBridge.json
+++ b/src/i18n/pl/codingBridge.json
@@ -362,5 +362,13 @@
   "session.attachmentUploadError": {
     "message": "Failed to upload attachment.",
     "description": "Failed to upload attachment."
+  },
+  "notice.slashUnavailable": {
+    "message": "/{command} to polecenie interaktywne i nie może działać w sesji zdalnej.",
+    "description": "Notice shown when a slash command can't run in a remote session"
+  },
+  "notice.slashCodexUnsupported": {
+    "message": "/{command} nie jest dostępne dla Codex w sesji zdalnej.",
+    "description": "Notice shown when a Codex slash command isn't supported remotely"
   }
 }

--- a/src/i18n/pt/codingBridge.json
+++ b/src/i18n/pt/codingBridge.json
@@ -362,5 +362,13 @@
   "session.attachmentUploadError": {
     "message": "Failed to upload attachment.",
     "description": "Failed to upload attachment."
+  },
+  "notice.slashUnavailable": {
+    "message": "/{command} é um comando interativo e não pode ser executado numa sessão remota.",
+    "description": "Notice shown when a slash command can't run in a remote session"
+  },
+  "notice.slashCodexUnsupported": {
+    "message": "/{command} não está disponível para o Codex numa sessão remota.",
+    "description": "Notice shown when a Codex slash command isn't supported remotely"
   }
 }

--- a/src/i18n/ru/codingBridge.json
+++ b/src/i18n/ru/codingBridge.json
@@ -362,5 +362,13 @@
   "session.attachmentUploadError": {
     "message": "Failed to upload attachment.",
     "description": "Failed to upload attachment."
+  },
+  "notice.slashUnavailable": {
+    "message": "/{command} — интерактивная команда, её нельзя выполнить в удалённом сеансе.",
+    "description": "Notice shown when a slash command can't run in a remote session"
+  },
+  "notice.slashCodexUnsupported": {
+    "message": "/{command} недоступна для Codex в удалённом сеансе.",
+    "description": "Notice shown when a Codex slash command isn't supported remotely"
   }
 }

--- a/src/i18n/sr/codingBridge.json
+++ b/src/i18n/sr/codingBridge.json
@@ -362,5 +362,13 @@
   "session.attachmentUploadError": {
     "message": "Failed to upload attachment.",
     "description": "Failed to upload attachment."
+  },
+  "notice.slashUnavailable": {
+    "message": "/{command} је интерактивна команда и не може да се изврши у удаљеној сесији.",
+    "description": "Notice shown when a slash command can't run in a remote session"
+  },
+  "notice.slashCodexUnsupported": {
+    "message": "/{command} није доступна за Codex у удаљеној сесији.",
+    "description": "Notice shown when a Codex slash command isn't supported remotely"
   }
 }

--- a/src/i18n/sv/codingBridge.json
+++ b/src/i18n/sv/codingBridge.json
@@ -362,5 +362,13 @@
   "session.attachmentUploadError": {
     "message": "Failed to upload attachment.",
     "description": "Failed to upload attachment."
+  },
+  "notice.slashUnavailable": {
+    "message": "/{command} är ett interaktivt kommando och kan inte köras i en fjärrsession.",
+    "description": "Notice shown when a slash command can't run in a remote session"
+  },
+  "notice.slashCodexUnsupported": {
+    "message": "/{command} är inte tillgängligt för Codex i en fjärrsession.",
+    "description": "Notice shown when a Codex slash command isn't supported remotely"
   }
 }

--- a/src/i18n/uk/codingBridge.json
+++ b/src/i18n/uk/codingBridge.json
@@ -362,5 +362,13 @@
   "session.attachmentUploadError": {
     "message": "Failed to upload attachment.",
     "description": "Failed to upload attachment."
+  },
+  "notice.slashUnavailable": {
+    "message": "/{command} — інтерактивна команда, її не можна виконати у віддаленому сеансі.",
+    "description": "Notice shown when a slash command can't run in a remote session"
+  },
+  "notice.slashCodexUnsupported": {
+    "message": "/{command} недоступна для Codex у віддаленому сеансі.",
+    "description": "Notice shown when a Codex slash command isn't supported remotely"
   }
 }

--- a/src/i18n/zh-CN/codingBridge.json
+++ b/src/i18n/zh-CN/codingBridge.json
@@ -362,5 +362,13 @@
   "session.attachmentUploadError": {
     "message": "附件上传失败。",
     "description": "Failed to upload attachment."
+  },
+  "notice.slashUnavailable": {
+    "message": "/{command} 是交互式命令，无法在远程会话中运行。",
+    "description": "Notice shown when a slash command can't run in a remote session"
+  },
+  "notice.slashCodexUnsupported": {
+    "message": "/{command} 在远程会话中暂不支持 Codex。",
+    "description": "Notice shown when a Codex slash command isn't supported remotely"
   }
 }

--- a/src/i18n/zh-TW/codingBridge.json
+++ b/src/i18n/zh-TW/codingBridge.json
@@ -362,5 +362,13 @@
   "session.attachmentUploadError": {
     "message": "Failed to upload attachment.",
     "description": "Failed to upload attachment."
+  },
+  "notice.slashUnavailable": {
+    "message": "/{command} 是互動式指令，無法在遠端工作階段中執行。",
+    "description": "Notice shown when a slash command can't run in a remote session"
+  },
+  "notice.slashCodexUnsupported": {
+    "message": "/{command} 在遠端工作階段中暫不支援 Codex。",
+    "description": "Notice shown when a Codex slash command isn't supported remotely"
   }
 }

--- a/src/models/codingBridge.ts
+++ b/src/models/codingBridge.ts
@@ -38,6 +38,17 @@ export interface ICodingBridgeProviderCapability {
   efforts: string[];
   permission_modes: string[];
   allow_custom_model: boolean;
+  // Slash commands this backend can actually run in a remote session, used to
+  // drive the composer autocomplete. Absent on older nodes.
+  commands?: ICodingBridgeSlashCommand[];
+}
+
+/** One slash command a backend advertises as runnable in a remote session. */
+export interface ICodingBridgeSlashCommand {
+  name: string;
+  description?: string;
+  argument_hint?: string;
+  aliases?: string[];
 }
 
 /** The full capabilities descriptor a node advertises. */
@@ -90,7 +101,15 @@ export interface ICodingBridgeHistoryDetail {
  * (and the locally-echoed user prompt) into this one shape so the transcript
  * view can render a uniform, append-only list.
  */
-export type ICodingBridgeEventKind = 'prompt' | 'text' | 'thinking' | 'tool_use' | 'tool_result' | 'result' | 'error';
+export type ICodingBridgeEventKind =
+  | 'prompt'
+  | 'text'
+  | 'thinking'
+  | 'tool_use'
+  | 'tool_result'
+  | 'result'
+  | 'notice'
+  | 'error';
 
 export interface ICodingBridgeEvent {
   id: string;
@@ -105,6 +124,10 @@ export interface ICodingBridgeEvent {
   is_error?: boolean;
   subtype?: string;
   cost_usd?: number;
+  // Notice events: a machine code (e.g. 'slash_unavailable') and the command
+  // the user typed, so the UI can render a localized message.
+  command?: string;
+  level?: string;
   // Legacy data-URL previews of images the user attached to a prompt turn.
   images?: string[];
   attachments?: ICodingBridgeAttachment[];

--- a/src/store/codingBridge/actions.ts
+++ b/src/store/codingBridge/actions.ts
@@ -28,6 +28,7 @@ import {
   CB_EVENT_PERMISSION_REQUEST,
   CB_EVENT_PERMISSION_RESOLVED,
   CB_EVENT_SESSION_RESULT,
+  CB_EVENT_SESSION_NOTICE,
   CB_EVENT_SESSION_ERROR,
   CB_EVENT_SESSION_CLOSED,
   CB_EVENT_SESSIONS_SNAPSHOT,
@@ -155,6 +156,19 @@ const applyNodeEvent = (
         })
       );
       commit('updateSession', { session_id: sessionId, status: 'idle', cost_usd: payload.cost_usd });
+      break;
+    case CB_EVENT_SESSION_NOTICE:
+      // A friendly heads-up (e.g. a slash command that can't run remotely).
+      // The node already closes the turn with its own session.result.
+      commit(
+        'appendEvent',
+        makeEvent(sessionId, 'notice', {
+          text: payload.text,
+          subtype: payload.code,
+          command: payload.command,
+          level: payload.level
+        })
+      );
       break;
     case CB_EVENT_SESSION_ERROR:
       commit('appendEvent', makeEvent(sessionId, 'error', { text: payload.message }));


### PR DESCRIPTION
## What

Adds slash-command UX to the Coding Bridge session view, matching the new node-side capability (CodingBridgeAgent #12) that advertises each provider's runnable slash-command catalog and emits `session.notice` events for commands it can't run headlessly.

### Changes
- **Slash autocomplete menu** in `SessionView.vue`: typing `/` in the composer opens a keyboard-navigable menu (↑/↓/Tab/Enter/Esc) populated from the active provider's `commands` capability. Selecting one inserts `/<name> `.
- **Notice rendering** in `TranscriptItem.vue`: `session.notice` events render as an info banner (e.g. a TUI-only command rejected in headless mode, or Codex which has no slash processor).
- **Store**: handle `CB_EVENT_SESSION_NOTICE` → append a `notice` event; capabilities now carry `commands[]`.
- **Models**: `ICodingBridgeSlashCommand` (name/description/argument_hint/aliases); `commands?` on provider capability; `notice` event kind; `command`/`level` on events.
- **i18n**: `notice.slashUnavailable` / `notice.slashCodexUnsupported` added to **all 18 locales** (full translations, additive only).

### Graceful degradation
If the node side hasn't published the catalog yet, `commands` is empty and the menu simply doesn't appear — no errors. Notices fall back to the raw `text` when a code isn't recognized.

## Validation
- `vue-tsc --noEmit` clean
- `eslint` clean on changed files
- `check_i18n_coverage.py`: 17 locales × 40 namespaces all match zh-CN
- vitest suite green; production build succeeds

## Related
- Node: AceDataCloud/CodingBridgeAgent#12