### PR TITLE
fix(coding-bridge): support freeform AskUserQuestion without options

### DIFF
--- a/change/@acedatacloud-nexior-e826890a-d672-483c-8c05-76de8ea7365a.json
+++ b/change/@acedatacloud-nexior-e826890a-d672-483c-8c05-76de8ea7365a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Allow AskUserQuestion cards to accept freeform input when tool payload omits options",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/AskUserQuestionCard.vue
+++ b/src/components/chat/AskUserQuestionCard.vue
@@ -35,8 +35,24 @@
             <span class="dot">●</span> {{ $t('chat.askUserQuestion.multiSelectHint') }}
           </div>
 
+          <!-- Freeform question: no options provided by tool payload. -->
+          <div v-if="isFreeformQuestion" class="other-wrap">
+            <el-input
+              v-model="otherTexts[currentIndex]"
+              type="textarea"
+              :rows="3"
+              :placeholder="$t('chat.askUserQuestion.placeholder')"
+              resize="none"
+              @keydown.enter.exact.prevent="onNext"
+            />
+          </div>
+
           <!-- Single-select -->
-          <el-radio-group v-if="!currentQuestion.multiSelect" v-model="singleAnswers[currentIndex]" class="options">
+          <el-radio-group
+            v-else-if="!currentQuestion.multiSelect"
+            v-model="singleAnswers[currentIndex]"
+            class="options"
+          >
             <el-radio
               v-for="(opt, oIdx) in currentQuestion.options"
               :key="oIdx"
@@ -189,7 +205,13 @@ export default defineComponent({
       if (this.questions.length === 0) return 0;
       return ((this.currentIndex + 1) / this.questions.length) * 100;
     },
+    isFreeformQuestion(): boolean {
+      return !Array.isArray(this.currentQuestion.options) || this.currentQuestion.options.length === 0;
+    },
     needsOtherInput(): boolean {
+      if (this.isFreeformQuestion) {
+        return false;
+      }
       const q = this.currentQuestion;
       const idx = this.currentIndex;
       if (q.multiSelect) {

--- a/src/components/chat/askUserQuestion.ts
+++ b/src/components/chat/askUserQuestion.ts
@@ -32,6 +32,10 @@ export function buildAskUserQuestionOutput(
   const answers: Record<string, string | string[]> = {};
   questions.forEach((q, idx) => {
     const otherText = (otherTexts[idx] || '').trim();
+    if (!Array.isArray(q.options) || q.options.length === 0) {
+      if (otherText) answers[q.question] = otherText;
+      return;
+    }
     if (q.multiSelect) {
       const picked = multiAnswers[idx] || [];
       const result: string[] = [];
@@ -75,6 +79,9 @@ export function canAdvanceQuestion(
   otherTexts: Record<number, string>
 ): boolean {
   const otherText = (otherTexts[idx] || '').trim();
+  if (!Array.isArray(question.options) || question.options.length === 0) {
+    return !!otherText;
+  }
   if (question.multiSelect) {
     const picked = multiAnswers[idx] || [];
     if (picked.length === 0) return false;


### PR DESCRIPTION
## Problem

Coding Bridge already renders AskUserQuestion as an interactive card, but some tool payloads only provide question text and omit options. In that case, the card showed question blocks without any selectable controls, so users could not interact or submit.

## Fix

Handle "no options" as a freeform question:

- `src/components/chat/askUserQuestion.ts`
  - `canAdvanceQuestion(...)`: when a question has no `options`, allow advancing once freeform text is non-empty.
  - `buildAskUserQuestionOutput(...)`: when a question has no `options`, serialize the typed text directly as the answer value.
- `src/components/chat/AskUserQuestionCard.vue`
  - Add `isFreeformQuestion` computed.
  - Render a textarea input when `currentQuestion.options` is empty.
  - Keep existing option/radio/checkbox behavior unchanged for normal payloads.
  - Skip the "Other" toggle logic for freeform questions.

No i18n keys added (reuses existing placeholder key).

## Verification

- `npx vue-tsc --noEmit`
- `npx eslint src/components/chat/askUserQuestion.ts src/components/chat/AskUserQuestionCard.vue`
- `python3 scripts/check_i18n_coverage.py`