### PR TITLE
feat(coding-bridge): token-level text streaming in transcripts

### DIFF
--- a/change/@acedatacloud-nexior-48fe076f-bd32-4113-b545-43995efb6977.json
+++ b/change/@acedatacloud-nexior-48fe076f-bd32-4113-b545-43995efb6977.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Stream Coding Bridge assistant text token-by-token (Claude native deltas + Codex typewriter) with a live caret",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/codingBridge/TranscriptItem.vue
+++ b/src/components/codingBridge/TranscriptItem.vue
@@ -38,13 +38,14 @@
       </div>
     </div>
 
-    <!-- Assistant text (markdown) -->
-    <vue-markdown
-      v-else-if="event.kind === 'text'"
-      v-highlight
-      :source="event.text || ''"
-      class="markdown-body bg-transparent text-[var(--app-text)]"
-    />
+    <!-- Assistant text (markdown); a blinking caret trails while streaming. -->
+    <div v-else-if="event.kind === 'text'" class="cb-stream-text" :class="{ 'is-streaming': event.streaming }">
+      <vue-markdown
+        v-highlight
+        :source="event.text || ''"
+        class="markdown-body bg-transparent text-[var(--app-text)]"
+      />
+    </div>
 
     <!-- Thinking -->
     <div
@@ -314,6 +315,30 @@ export default defineComponent({
   }
   pre code {
     color: #fff;
+  }
+}
+
+// Blinking typewriter caret trailing the last line while text streams in.
+.cb-stream-text.is-streaming :deep(.markdown-body > :last-child)::after {
+  content: '';
+  display: inline-block;
+  width: 0.45em;
+  height: 1em;
+  margin-left: 2px;
+  vertical-align: text-bottom;
+  background: var(--el-color-primary);
+  border-radius: 1px;
+  animation: cb-caret-blink 1s steps(1, end) infinite;
+}
+
+@keyframes cb-caret-blink {
+  0%,
+  50% {
+    opacity: 1;
+  }
+  50.01%,
+  100% {
+    opacity: 0;
   }
 }
 </style>

--- a/src/constants/codingBridge.ts
+++ b/src/constants/codingBridge.ts
@@ -31,6 +31,7 @@ export const CB_ACTION_PING = 'ping';
 // --- Inner events: node -> browser -----------------------------------------
 export const CB_EVENT_SESSION_STARTED = 'session.started';
 export const CB_EVENT_SESSION_TEXT = 'session.text';
+export const CB_EVENT_SESSION_TEXT_DELTA = 'session.text_delta';
 export const CB_EVENT_SESSION_THINKING = 'session.thinking';
 export const CB_EVENT_SESSION_TOOL_USE = 'session.tool_use';
 export const CB_EVENT_SESSION_TOOL_RESULT = 'session.tool_result';

--- a/src/models/codingBridge.ts
+++ b/src/models/codingBridge.ts
@@ -128,6 +128,10 @@ export interface ICodingBridgeEvent {
   // the user typed, so the UI can render a localized message.
   command?: string;
   level?: string;
+  // Streaming assistant text: `stream_id` ties text_delta chunks to their
+  // final `session.text` commit; `streaming` stays true while deltas arrive.
+  stream_id?: string;
+  streaming?: boolean;
   // Legacy data-URL previews of images the user attached to a prompt turn.
   images?: string[];
   attachments?: ICodingBridgeAttachment[];

--- a/src/store/codingBridge/actions.ts
+++ b/src/store/codingBridge/actions.ts
@@ -22,6 +22,7 @@ import {
   CB_ACTION_CAPABILITIES_GET,
   CB_EVENT_SESSION_STARTED,
   CB_EVENT_SESSION_TEXT,
+  CB_EVENT_SESSION_TEXT_DELTA,
   CB_EVENT_SESSION_THINKING,
   CB_EVENT_SESSION_TOOL_USE,
   CB_EVENT_SESSION_TOOL_RESULT,
@@ -104,9 +105,35 @@ const applyNodeEvent = (
         model: payload.model
       });
       break;
-    case CB_EVENT_SESSION_TEXT:
-      commit('appendEvent', makeEvent(sessionId, 'text', { text: payload.text }));
+    case CB_EVENT_SESSION_TEXT_DELTA: {
+      // Streaming chunk: grow the open bubble for this stream id, or open a
+      // new streaming bubble if this is the first delta seen for it.
+      const streamId = payload.id;
+      const open =
+        streamId && state.events[sessionId]?.find((item) => item.kind === 'text' && item.stream_id === streamId);
+      if (open) {
+        commit('appendDelta', { session_id: sessionId, stream_id: streamId, text: payload.text ?? '' });
+      } else {
+        commit(
+          'appendEvent',
+          makeEvent(sessionId, 'text', { text: payload.text ?? '', stream_id: streamId, streaming: true })
+        );
+      }
       break;
+    }
+    case CB_EVENT_SESSION_TEXT: {
+      // Final commit: close the matching streaming bubble with the
+      // authoritative text, or render a standalone (non-streamed) message.
+      const streamId = payload.id;
+      const open =
+        streamId && state.events[sessionId]?.find((item) => item.kind === 'text' && item.stream_id === streamId);
+      if (open) {
+        commit('finalizeStream', { session_id: sessionId, stream_id: streamId, text: payload.text });
+      } else {
+        commit('appendEvent', makeEvent(sessionId, 'text', { text: payload.text }));
+      }
+      break;
+    }
     case CB_EVENT_SESSION_THINKING:
       commit('appendEvent', makeEvent(sessionId, 'thinking', { text: payload.text }));
       break;
@@ -146,6 +173,8 @@ const applyNodeEvent = (
       commit('removePermission', payload.request_id);
       break;
     case CB_EVENT_SESSION_RESULT:
+      // A turn ended: close any still-open streaming bubble before the result.
+      commit('finalizeAllStreams', { session_id: sessionId });
       commit(
         'appendEvent',
         makeEvent(sessionId, 'result', {
@@ -171,10 +200,12 @@ const applyNodeEvent = (
       );
       break;
     case CB_EVENT_SESSION_ERROR:
+      commit('finalizeAllStreams', { session_id: sessionId });
       commit('appendEvent', makeEvent(sessionId, 'error', { text: payload.message }));
       commit('updateSession', { session_id: sessionId, status: 'error' });
       break;
     case CB_EVENT_SESSION_CLOSED:
+      commit('finalizeAllStreams', { session_id: sessionId });
       commit('updateSession', { session_id: sessionId, status: 'closed' });
       break;
     case CB_EVENT_SESSIONS_SNAPSHOT:

--- a/src/store/codingBridge/mutations.test.ts
+++ b/src/store/codingBridge/mutations.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import createState from './state';
+import { appendDelta, appendEvent, finalizeAllStreams, finalizeStream } from './mutations';
+import type { ICodingBridgeEvent } from '@/models';
+
+const textEvent = (overrides: Partial<ICodingBridgeEvent> = {}): ICodingBridgeEvent => ({
+  id: 'e1',
+  session_id: 's1',
+  kind: 'text',
+  ts: 0,
+  ...overrides
+});
+
+describe('coding bridge streaming mutations', () => {
+  it('appendDelta grows the open bubble matching the stream id', () => {
+    const state = createState();
+    appendEvent(state, textEvent({ text: 'He', stream_id: 'st1', streaming: true }));
+    appendDelta(state, { session_id: 's1', stream_id: 'st1', text: 'llo' });
+    expect(state.events['s1'][0].text).toBe('Hello');
+    expect(state.events['s1'][0].streaming).toBe(true);
+  });
+
+  it('appendDelta is a no-op when no bubble matches the stream id', () => {
+    const state = createState();
+    appendEvent(state, textEvent({ text: 'He', stream_id: 'st1', streaming: true }));
+    appendDelta(state, { session_id: 's1', stream_id: 'other', text: 'llo' });
+    expect(state.events['s1'][0].text).toBe('He');
+  });
+
+  it('appendDelta ignores unknown sessions', () => {
+    const state = createState();
+    expect(() => appendDelta(state, { session_id: 'missing', stream_id: 'st1', text: 'x' })).not.toThrow();
+    expect(state.events['missing']).toBeUndefined();
+  });
+
+  it('finalizeStream replaces text and clears the streaming flag', () => {
+    const state = createState();
+    appendEvent(state, textEvent({ text: 'Partial', stream_id: 'st1', streaming: true }));
+    finalizeStream(state, { session_id: 's1', stream_id: 'st1', text: 'Partial final' });
+    expect(state.events['s1'][0].text).toBe('Partial final');
+    expect(state.events['s1'][0].streaming).toBe(false);
+  });
+
+  it('finalizeStream keeps existing text when none is provided', () => {
+    const state = createState();
+    appendEvent(state, textEvent({ text: 'Kept', stream_id: 'st1', streaming: true }));
+    finalizeStream(state, { session_id: 's1', stream_id: 'st1' });
+    expect(state.events['s1'][0].text).toBe('Kept');
+    expect(state.events['s1'][0].streaming).toBe(false);
+  });
+
+  it('finalizeAllStreams closes every open bubble but leaves plain text alone', () => {
+    const state = createState();
+    appendEvent(state, textEvent({ id: 'a', text: 'one', stream_id: 'st1', streaming: true }));
+    appendEvent(state, textEvent({ id: 'b', text: 'two', stream_id: 'st2', streaming: true }));
+    appendEvent(state, textEvent({ id: 'c', text: 'plain' }));
+    finalizeAllStreams(state, { session_id: 's1' });
+    expect(state.events['s1'].map((item) => item.streaming)).toEqual([false, false, undefined]);
+  });
+});

--- a/src/store/codingBridge/mutations.ts
+++ b/src/store/codingBridge/mutations.ts
@@ -85,6 +85,54 @@ export const appendEvent = (state: ICodingBridgeState, payload: ICodingBridgeEve
   state.events[payload.session_id].push(payload);
 };
 
+// Streaming: append an incremental text chunk onto the open bubble matching
+// `stream_id`. No-op if the bubble was already finalized or never created.
+export const appendDelta = (
+  state: ICodingBridgeState,
+  payload: { session_id: string; stream_id: string; text: string }
+): void => {
+  const events = state.events[payload.session_id];
+  if (!events) {
+    return;
+  }
+  const target = events.find((item) => item.kind === 'text' && item.stream_id === payload.stream_id);
+  if (target) {
+    target.text = (target.text ?? '') + (payload.text ?? '');
+  }
+};
+
+// Streaming: close the bubble matching `stream_id`, optionally replacing its
+// text with the authoritative final value from the node.
+export const finalizeStream = (
+  state: ICodingBridgeState,
+  payload: { session_id: string; stream_id: string; text?: string }
+): void => {
+  const events = state.events[payload.session_id];
+  if (!events) {
+    return;
+  }
+  const target = events.find((item) => item.kind === 'text' && item.stream_id === payload.stream_id);
+  if (target) {
+    if (typeof payload.text === 'string') {
+      target.text = payload.text;
+    }
+    target.streaming = false;
+  }
+};
+
+// Streaming: close every still-open bubble in a session (turn ended / errored).
+export const finalizeAllStreams = (state: ICodingBridgeState, payload: { session_id: string }): void => {
+  const events = state.events[payload.session_id];
+  if (!events) {
+    return;
+  }
+  for (const item of events) {
+    if (item.streaming) {
+      item.streaming = false;
+    }
+  }
+};
+
 // Replace a session's transcript wholesale (used when replaying history).
 export const setEvents = (
   state: ICodingBridgeState,
@@ -160,6 +208,9 @@ export default {
   upsertSession,
   updateSession,
   appendEvent,
+  appendDelta,
+  finalizeStream,
+  finalizeAllStreams,
   setEvents,
   setHistory,
   setHistoryRef,


### PR DESCRIPTION
## What

Renders Coding Bridge assistant replies **token-by-token** as they arrive, instead of popping in as one block at turn end. This is the frontend half of the streaming feature; the node half shipped in [CodingBridgeAgent#14](https://github.com/AceDataCloud/CodingBridgeAgent/pull/14) (published as `coding-bridge-agent` 2026.6.9.3, already deployed to the CVM node).

## How

The node now emits a new `session.text_delta` event for each incremental chunk, followed by a final `session.text` commit that carries the same `id`:

- **Claude** streams natively via the Agent SDK's `include_partial_messages` (real Anthropic `content_block_delta` events).
- **Codex** has no native token streaming, so the node typewriter-chunks the completed message for visual parity.

Frontend changes:

- `constants/codingBridge.ts` — add `CB_EVENT_SESSION_TEXT_DELTA = 'session.text_delta'`.
- `models/codingBridge.ts` — add `stream_id?` / `streaming?` to `ICodingBridgeEvent` (reuses the existing `text` kind, no new kind).
- `store/codingBridge/mutations.ts` — `appendDelta` (grow the open bubble), `finalizeStream` (commit authoritative text + clear flag), `finalizeAllStreams` (close any open bubble on turn end).
- `store/codingBridge/actions.ts` — correlate `text_delta` → `text` by `id`: first delta opens a streaming bubble, subsequent deltas append, the final `session.text` finalizes it. Any still-open bubble is finalized on `session.result` / `session.error` / `session.closed`.
- `components/codingBridge/TranscriptItem.vue` — a CSS-only blinking caret trails the last line while `streaming` is true (no new i18n keys).

## Tests

- New `store/codingBridge/mutations.test.ts` (6 cases): delta growth, no-match no-op, unknown session, finalize replace/keep, finalize-all leaves plain text alone.
- Full suite: 147 passed. `vue-tsc -b` + `vite build` clean. ESLint clean. i18n coverage OK (no new keys).