### PR TITLE
feat(coding-bridge): thread trace ids end-to-end and surface diagnostic ids

### DIFF
--- a/change/@acedatacloud-nexior-32cb8c96-3bbb-4280-bf22-4879e03ccad2.json
+++ b/change/@acedatacloud-nexior-32cb8c96-3bbb-4280-bf22-4879e03ccad2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add end-to-end trace ids and a copyable diagnostic id strip to Coding Bridge",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/codingBridge/SessionView.vue
+++ b/src/components/codingBridge/SessionView.vue
@@ -45,6 +45,18 @@
         {{ $t('codingBridge.session.deviceOffline') }}
       </div>
 
+      <!-- Diagnostic ids: copyable identifiers for issue reports / log lookups. -->
+      <div
+        v-if="diagnostics.length"
+        class="flex flex-wrap items-center gap-x-4 gap-y-1 px-5 py-1.5 text-[11px] text-[var(--app-text-subtle)] border-b border-[var(--app-border-subtle)]"
+      >
+        <span v-for="item in diagnostics" :key="item.label" class="inline-flex items-center gap-1 min-w-0">
+          <span class="opacity-70">{{ item.label }}:</span>
+          <span class="font-mono truncate max-w-[160px]" :title="item.value">{{ item.value }}</span>
+          <copy-to-clipboard :content="item.value" class="inline-block" />
+        </span>
+      </div>
+
       <!-- Transcript -->
       <div ref="transcript" class="flex-1 overflow-y-auto px-5 py-4 flex flex-col gap-3">
         <div v-if="!events.length" class="m-auto text-center text-sm text-[var(--app-text-subtle)]">
@@ -386,6 +398,7 @@ import DirectoryDialog from './DirectoryDialog.vue';
 import AskUserQuestionCard from '@/components/chat/AskUserQuestionCard.vue';
 import { isAskUserQuestionRequest, questionPayload } from './askUserQuestion';
 import { getBaseUrlPlatform, pasteUploadMixin } from '@/utils';
+import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import {
   IAskUserQuestionPayload,
   ICodingBridgeAttachment,
@@ -422,7 +435,8 @@ export default defineComponent({
     FontAwesomeIcon,
     TranscriptItem,
     DirectoryDialog,
-    AskUserQuestionCard
+    AskUserQuestionCard,
+    CopyToClipboard
   },
   mixins: [pasteUploadMixin],
   emits: ['history'],
@@ -645,6 +659,23 @@ export default defineComponent({
     },
     slashMenuVisible(): boolean {
       return this.slashMenuOpen && this.slashMatches.length > 0;
+    },
+    // Copyable identifiers for issue reports and CLS log lookups.
+    diagnostics(): { label: string; value: string }[] {
+      const items: { label: string; value: string }[] = [];
+      if (this.currentNodeId) {
+        items.push({ label: this.$t('codingBridge.session.nodeId') as string, value: this.currentNodeId });
+      }
+      if (this.currentSessionId) {
+        items.push({ label: this.$t('codingBridge.session.sessionId') as string, value: this.currentSessionId });
+      }
+      if (this.currentSession?.trace_id) {
+        items.push({
+          label: this.$t('codingBridge.session.traceId') as string,
+          value: this.currentSession.trace_id
+        });
+      }
+      return items;
     }
   },
   watch: {

--- a/src/i18n/ar/codingBridge.json
+++ b/src/i18n/ar/codingBridge.json
@@ -131,6 +131,18 @@
     "message": "This device is offline. Start the Coding Bridge agent on it to continue.",
     "description": "Device offline warning"
   },
+  "session.nodeId": {
+    "message": "معرّف الجهاز",
+    "description": "Diagnostic label for the node id"
+  },
+  "session.sessionId": {
+    "message": "معرّف الجلسة",
+    "description": "Diagnostic label for the session id"
+  },
+  "session.traceId": {
+    "message": "معرّف التتبع",
+    "description": "Diagnostic label for the trace id"
+  },
   "session.startHint": {
     "message": "Send a message to start a session on this device.",
     "description": "Empty transcript hint"

--- a/src/i18n/de/codingBridge.json
+++ b/src/i18n/de/codingBridge.json
@@ -131,6 +131,18 @@
     "message": "This device is offline. Start the Coding Bridge agent on it to continue.",
     "description": "Device offline warning"
   },
+  "session.nodeId": {
+    "message": "Geräte-ID",
+    "description": "Diagnostic label for the node id"
+  },
+  "session.sessionId": {
+    "message": "Sitzungs-ID",
+    "description": "Diagnostic label for the session id"
+  },
+  "session.traceId": {
+    "message": "Trace-ID",
+    "description": "Diagnostic label for the trace id"
+  },
   "session.startHint": {
     "message": "Send a message to start a session on this device.",
     "description": "Empty transcript hint"

--- a/src/i18n/el/codingBridge.json
+++ b/src/i18n/el/codingBridge.json
@@ -131,6 +131,18 @@
     "message": "This device is offline. Start the Coding Bridge agent on it to continue.",
     "description": "Device offline warning"
   },
+  "session.nodeId": {
+    "message": "Αναγνωριστικό συσκευής",
+    "description": "Diagnostic label for the node id"
+  },
+  "session.sessionId": {
+    "message": "Αναγνωριστικό συνεδρίας",
+    "description": "Diagnostic label for the session id"
+  },
+  "session.traceId": {
+    "message": "Αναγνωριστικό ίχνους",
+    "description": "Diagnostic label for the trace id"
+  },
   "session.startHint": {
     "message": "Send a message to start a session on this device.",
     "description": "Empty transcript hint"

--- a/src/i18n/en/codingBridge.json
+++ b/src/i18n/en/codingBridge.json
@@ -131,6 +131,18 @@
     "message": "This device is offline. Start the Coding Bridge agent on it to continue.",
     "description": "Device offline warning"
   },
+  "session.nodeId": {
+    "message": "Device ID",
+    "description": "Diagnostic label for the node id"
+  },
+  "session.sessionId": {
+    "message": "Session ID",
+    "description": "Diagnostic label for the session id"
+  },
+  "session.traceId": {
+    "message": "Trace ID",
+    "description": "Diagnostic label for the trace id"
+  },
   "session.startHint": {
     "message": "Send a message to start a session on this device.",
     "description": "Empty transcript hint"

--- a/src/i18n/es/codingBridge.json
+++ b/src/i18n/es/codingBridge.json
@@ -131,6 +131,18 @@
     "message": "This device is offline. Start the Coding Bridge agent on it to continue.",
     "description": "Device offline warning"
   },
+  "session.nodeId": {
+    "message": "ID de dispositivo",
+    "description": "Diagnostic label for the node id"
+  },
+  "session.sessionId": {
+    "message": "ID de sesión",
+    "description": "Diagnostic label for the session id"
+  },
+  "session.traceId": {
+    "message": "ID de seguimiento",
+    "description": "Diagnostic label for the trace id"
+  },
   "session.startHint": {
     "message": "Send a message to start a session on this device.",
     "description": "Empty transcript hint"

--- a/src/i18n/fi/codingBridge.json
+++ b/src/i18n/fi/codingBridge.json
@@ -131,6 +131,18 @@
     "message": "This device is offline. Start the Coding Bridge agent on it to continue.",
     "description": "Device offline warning"
   },
+  "session.nodeId": {
+    "message": "Laitetunnus",
+    "description": "Diagnostic label for the node id"
+  },
+  "session.sessionId": {
+    "message": "Istuntotunnus",
+    "description": "Diagnostic label for the session id"
+  },
+  "session.traceId": {
+    "message": "Jäljitystunnus",
+    "description": "Diagnostic label for the trace id"
+  },
   "session.startHint": {
     "message": "Send a message to start a session on this device.",
     "description": "Empty transcript hint"

--- a/src/i18n/fr/codingBridge.json
+++ b/src/i18n/fr/codingBridge.json
@@ -131,6 +131,18 @@
     "message": "This device is offline. Start the Coding Bridge agent on it to continue.",
     "description": "Device offline warning"
   },
+  "session.nodeId": {
+    "message": "ID de l'appareil",
+    "description": "Diagnostic label for the node id"
+  },
+  "session.sessionId": {
+    "message": "ID de session",
+    "description": "Diagnostic label for the session id"
+  },
+  "session.traceId": {
+    "message": "ID de trace",
+    "description": "Diagnostic label for the trace id"
+  },
   "session.startHint": {
     "message": "Send a message to start a session on this device.",
     "description": "Empty transcript hint"

--- a/src/i18n/it/codingBridge.json
+++ b/src/i18n/it/codingBridge.json
@@ -131,6 +131,18 @@
     "message": "This device is offline. Start the Coding Bridge agent on it to continue.",
     "description": "Device offline warning"
   },
+  "session.nodeId": {
+    "message": "ID dispositivo",
+    "description": "Diagnostic label for the node id"
+  },
+  "session.sessionId": {
+    "message": "ID sessione",
+    "description": "Diagnostic label for the session id"
+  },
+  "session.traceId": {
+    "message": "ID traccia",
+    "description": "Diagnostic label for the trace id"
+  },
   "session.startHint": {
     "message": "Send a message to start a session on this device.",
     "description": "Empty transcript hint"

--- a/src/i18n/ja/codingBridge.json
+++ b/src/i18n/ja/codingBridge.json
@@ -131,6 +131,18 @@
     "message": "This device is offline. Start the Coding Bridge agent on it to continue.",
     "description": "Device offline warning"
   },
+  "session.nodeId": {
+    "message": "デバイス ID",
+    "description": "Diagnostic label for the node id"
+  },
+  "session.sessionId": {
+    "message": "セッション ID",
+    "description": "Diagnostic label for the session id"
+  },
+  "session.traceId": {
+    "message": "トレース ID",
+    "description": "Diagnostic label for the trace id"
+  },
   "session.startHint": {
     "message": "Send a message to start a session on this device.",
     "description": "Empty transcript hint"

--- a/src/i18n/ko/codingBridge.json
+++ b/src/i18n/ko/codingBridge.json
@@ -131,6 +131,18 @@
     "message": "This device is offline. Start the Coding Bridge agent on it to continue.",
     "description": "Device offline warning"
   },
+  "session.nodeId": {
+    "message": "기기 ID",
+    "description": "Diagnostic label for the node id"
+  },
+  "session.sessionId": {
+    "message": "세션 ID",
+    "description": "Diagnostic label for the session id"
+  },
+  "session.traceId": {
+    "message": "추적 ID",
+    "description": "Diagnostic label for the trace id"
+  },
   "session.startHint": {
     "message": "Send a message to start a session on this device.",
     "description": "Empty transcript hint"

--- a/src/i18n/pl/codingBridge.json
+++ b/src/i18n/pl/codingBridge.json
@@ -131,6 +131,18 @@
     "message": "This device is offline. Start the Coding Bridge agent on it to continue.",
     "description": "Device offline warning"
   },
+  "session.nodeId": {
+    "message": "Identyfikator urządzenia",
+    "description": "Diagnostic label for the node id"
+  },
+  "session.sessionId": {
+    "message": "Identyfikator sesji",
+    "description": "Diagnostic label for the session id"
+  },
+  "session.traceId": {
+    "message": "Identyfikator śledzenia",
+    "description": "Diagnostic label for the trace id"
+  },
   "session.startHint": {
     "message": "Send a message to start a session on this device.",
     "description": "Empty transcript hint"

--- a/src/i18n/pt/codingBridge.json
+++ b/src/i18n/pt/codingBridge.json
@@ -131,6 +131,18 @@
     "message": "This device is offline. Start the Coding Bridge agent on it to continue.",
     "description": "Device offline warning"
   },
+  "session.nodeId": {
+    "message": "ID do dispositivo",
+    "description": "Diagnostic label for the node id"
+  },
+  "session.sessionId": {
+    "message": "ID da sessão",
+    "description": "Diagnostic label for the session id"
+  },
+  "session.traceId": {
+    "message": "ID de rastreamento",
+    "description": "Diagnostic label for the trace id"
+  },
   "session.startHint": {
     "message": "Send a message to start a session on this device.",
     "description": "Empty transcript hint"

--- a/src/i18n/ru/codingBridge.json
+++ b/src/i18n/ru/codingBridge.json
@@ -131,6 +131,18 @@
     "message": "This device is offline. Start the Coding Bridge agent on it to continue.",
     "description": "Device offline warning"
   },
+  "session.nodeId": {
+    "message": "ID устройства",
+    "description": "Diagnostic label for the node id"
+  },
+  "session.sessionId": {
+    "message": "ID сессии",
+    "description": "Diagnostic label for the session id"
+  },
+  "session.traceId": {
+    "message": "ID трассировки",
+    "description": "Diagnostic label for the trace id"
+  },
   "session.startHint": {
     "message": "Send a message to start a session on this device.",
     "description": "Empty transcript hint"

--- a/src/i18n/sr/codingBridge.json
+++ b/src/i18n/sr/codingBridge.json
@@ -131,6 +131,18 @@
     "message": "This device is offline. Start the Coding Bridge agent on it to continue.",
     "description": "Device offline warning"
   },
+  "session.nodeId": {
+    "message": "ID uređaja",
+    "description": "Diagnostic label for the node id"
+  },
+  "session.sessionId": {
+    "message": "ID sesije",
+    "description": "Diagnostic label for the session id"
+  },
+  "session.traceId": {
+    "message": "ID praćenja",
+    "description": "Diagnostic label for the trace id"
+  },
   "session.startHint": {
     "message": "Send a message to start a session on this device.",
     "description": "Empty transcript hint"

--- a/src/i18n/sv/codingBridge.json
+++ b/src/i18n/sv/codingBridge.json
@@ -131,6 +131,18 @@
     "message": "This device is offline. Start the Coding Bridge agent on it to continue.",
     "description": "Device offline warning"
   },
+  "session.nodeId": {
+    "message": "Enhets-ID",
+    "description": "Diagnostic label for the node id"
+  },
+  "session.sessionId": {
+    "message": "Sessions-ID",
+    "description": "Diagnostic label for the session id"
+  },
+  "session.traceId": {
+    "message": "Spårnings-ID",
+    "description": "Diagnostic label for the trace id"
+  },
   "session.startHint": {
     "message": "Send a message to start a session on this device.",
     "description": "Empty transcript hint"

--- a/src/i18n/uk/codingBridge.json
+++ b/src/i18n/uk/codingBridge.json
@@ -131,6 +131,18 @@
     "message": "This device is offline. Start the Coding Bridge agent on it to continue.",
     "description": "Device offline warning"
   },
+  "session.nodeId": {
+    "message": "ID пристрою",
+    "description": "Diagnostic label for the node id"
+  },
+  "session.sessionId": {
+    "message": "ID сеансу",
+    "description": "Diagnostic label for the session id"
+  },
+  "session.traceId": {
+    "message": "ID трасування",
+    "description": "Diagnostic label for the trace id"
+  },
   "session.startHint": {
     "message": "Send a message to start a session on this device.",
     "description": "Empty transcript hint"

--- a/src/i18n/zh-CN/codingBridge.json
+++ b/src/i18n/zh-CN/codingBridge.json
@@ -131,6 +131,18 @@
     "message": "该设备已离线。请在该设备上启动 Coding Bridge 代理后继续。",
     "description": "设备离线警告"
   },
+  "session.nodeId": {
+    "message": "设备 ID",
+    "description": "节点 id 的诊断标签"
+  },
+  "session.sessionId": {
+    "message": "会话 ID",
+    "description": "会话 id 的诊断标签"
+  },
+  "session.traceId": {
+    "message": "追踪 ID",
+    "description": "追踪 id 的诊断标签"
+  },
   "session.startHint": {
     "message": "发送一条消息以在该设备上开始会话。",
     "description": "空白记录提示"

--- a/src/i18n/zh-TW/codingBridge.json
+++ b/src/i18n/zh-TW/codingBridge.json
@@ -131,6 +131,18 @@
     "message": "此裝置已離線。請在該裝置上啟動 Coding Bridge 代理程式後繼續。",
     "description": "裝置離線警告"
   },
+  "session.nodeId": {
+    "message": "裝置 ID",
+    "description": "Diagnostic label for the node id"
+  },
+  "session.sessionId": {
+    "message": "工作階段 ID",
+    "description": "Diagnostic label for the session id"
+  },
+  "session.traceId": {
+    "message": "追蹤 ID",
+    "description": "Diagnostic label for the trace id"
+  },
   "session.startHint": {
     "message": "傳送一則訊息以在此裝置上開始工作階段。",
     "description": "空白記錄提示"

--- a/src/models/codingBridge.ts
+++ b/src/models/codingBridge.ts
@@ -72,6 +72,9 @@ export interface ICodingBridgeSession {
   started?: boolean;
   // Replay of past history that cannot be continued (e.g. Codex).
   readonly?: boolean;
+  // Trace id of the most recent turn, threaded browser → relay → node and back
+  // for end-to-end correlation in logs.
+  trace_id?: string;
 }
 
 /** One past on-device session as listed by `history.list`. */
@@ -131,6 +134,8 @@ export interface ICodingBridgeEvent {
   // Legacy data-URL previews of images the user attached to a prompt turn.
   images?: string[];
   attachments?: ICodingBridgeAttachment[];
+  // Trace id correlating this event with the turn that produced it.
+  trace_id?: string;
 }
 
 /** One browser-uploaded file/image attached to a prompt turn. */

--- a/src/store/codingBridge/actions.ts
+++ b/src/store/codingBridge/actions.ts
@@ -94,6 +94,11 @@ const applyNodeEvent = (
 ): void => {
   const event = payload?.event;
   const sessionId = payload?.session_id;
+  const traceId = payload?.trace_id;
+  // Keep the session's trace id current with whatever turn the node is on.
+  if (sessionId && traceId) {
+    commit('updateSession', { session_id: sessionId, trace_id: traceId });
+  }
   switch (event) {
     case CB_EVENT_SESSION_STARTED:
       commit('upsertSession', {
@@ -101,14 +106,15 @@ const applyNodeEvent = (
         node_id: fromNode,
         status: 'idle',
         cwd: payload.cwd,
-        model: payload.model
+        model: payload.model,
+        trace_id: traceId
       });
       break;
     case CB_EVENT_SESSION_TEXT:
-      commit('appendEvent', makeEvent(sessionId, 'text', { text: payload.text }));
+      commit('appendEvent', makeEvent(sessionId, 'text', { text: payload.text, trace_id: traceId }));
       break;
     case CB_EVENT_SESSION_THINKING:
-      commit('appendEvent', makeEvent(sessionId, 'thinking', { text: payload.text }));
+      commit('appendEvent', makeEvent(sessionId, 'thinking', { text: payload.text, trace_id: traceId }));
       break;
     case CB_EVENT_SESSION_TOOL_USE:
       commit(
@@ -116,7 +122,8 @@ const applyNodeEvent = (
         makeEvent(sessionId, 'tool_use', {
           tool: payload.tool,
           tool_use_id: payload.tool_use_id,
-          input: payload.input
+          input: payload.input,
+          trace_id: traceId
         })
       );
       break;
@@ -126,7 +133,8 @@ const applyNodeEvent = (
         makeEvent(sessionId, 'tool_result', {
           tool_use_id: payload.tool_use_id,
           content: payload.content,
-          is_error: payload.is_error
+          is_error: payload.is_error,
+          trace_id: traceId
         })
       );
       break;
@@ -152,7 +160,8 @@ const applyNodeEvent = (
           subtype: payload.subtype,
           is_error: payload.is_error,
           text: payload.result,
-          cost_usd: payload.cost_usd
+          cost_usd: payload.cost_usd,
+          trace_id: traceId
         })
       );
       commit('updateSession', { session_id: sessionId, status: 'idle', cost_usd: payload.cost_usd });
@@ -171,7 +180,7 @@ const applyNodeEvent = (
       );
       break;
     case CB_EVENT_SESSION_ERROR:
-      commit('appendEvent', makeEvent(sessionId, 'error', { text: payload.message }));
+      commit('appendEvent', makeEvent(sessionId, 'error', { text: payload.message, trace_id: traceId }));
       commit('updateSession', { session_id: sessionId, status: 'error' });
       break;
     case CB_EVENT_SESSION_CLOSED:
@@ -434,6 +443,9 @@ export const sendPrompt = (
   if (!nodeId || !socket || (!prompt && !images && !attachments)) {
     return;
   }
+  // One trace id per turn, threaded browser → relay → node and echoed back on
+  // every resulting event so a single id correlates the whole round-trip.
+  const traceId = uid();
   let sessionId = state.currentSessionId;
   const existing = sessionId ? state.sessions[sessionId] : undefined;
   // A turn must be started when there is no session yet, or when the current
@@ -451,18 +463,23 @@ export const sendPrompt = (
         status: 'starting',
         cwd: payload.cwd,
         model: payload.model,
-        provider
+        provider,
+        trace_id: traceId
       });
       commit('setCurrentSession', sessionId);
     } else {
       sessionId = existing.session_id;
-      commit('updateSession', { session_id: sessionId, status: 'starting' });
+      commit('updateSession', { session_id: sessionId, status: 'starting', trace_id: traceId });
     }
-    commit('appendEvent', makeEvent(sessionId as string, 'prompt', { text: prompt, images, attachments }));
+    commit(
+      'appendEvent',
+      makeEvent(sessionId as string, 'prompt', { text: prompt, images, attachments, trace_id: traceId })
+    );
     commit('updateSession', { session_id: sessionId as string, started: true });
     socket.sendToNode(nodeId, {
       action: CB_ACTION_SESSION_START,
       session_id: sessionId,
+      trace_id: traceId,
       prompt,
       cwd: payload.cwd || existing?.cwd || undefined,
       model: payload.model || existing?.model || undefined,
@@ -474,7 +491,11 @@ export const sendPrompt = (
       resume_session_id: existing?.resume_session_id || undefined
     });
   } else {
-    commit('appendEvent', makeEvent(sessionId as string, 'prompt', { text: prompt, images, attachments }));
+    commit('updateSession', { session_id: sessionId as string, trace_id: traceId });
+    commit(
+      'appendEvent',
+      makeEvent(sessionId as string, 'prompt', { text: prompt, images, attachments, trace_id: traceId })
+    );
     commit('updateSession', {
       session_id: sessionId as string,
       status: 'running',
@@ -484,6 +505,7 @@ export const sendPrompt = (
     socket.sendToNode(nodeId, {
       action: CB_ACTION_SESSION_SEND,
       session_id: sessionId,
+      trace_id: traceId,
       prompt,
       // Allow switching the model mid-session; sent verbatim so an empty value
       // resets the node to its default model.

--- a/src/utils/codingBridgeSocket.ts
+++ b/src/utils/codingBridgeSocket.ts
@@ -28,6 +28,33 @@ const makeId = (): string => {
   return `${Date.now().toString(16)}${Math.random().toString(16).slice(2)}`;
 };
 
+// Verbose envelope tracing is opt-in (set `localStorage.cbDebug = '1'`) so the
+// console stays quiet for normal users but a single flag surfaces the full
+// browser → relay → node trace when diagnosing an issue.
+const debugEnabled = (): boolean => {
+  try {
+    return typeof localStorage !== 'undefined' && localStorage.getItem('cbDebug') === '1';
+  } catch {
+    return false;
+  }
+};
+
+const logEnvelope = (direction: 'send' | 'recv', message: Record<string, any>): void => {
+  if (!debugEnabled()) {
+    return;
+  }
+  const payload = message?.payload ?? {};
+  console.debug('[codingBridge]', direction, {
+    type: message?.type,
+    id: message?.id,
+    node_id: message?.node_id ?? message?.from_node,
+    action: payload?.action,
+    event: payload?.event,
+    session_id: payload?.session_id,
+    trace_id: payload?.trace_id
+  });
+};
+
 /**
  * Single browser WebSocket toward the `coding-bridge` relay.
  *
@@ -97,6 +124,7 @@ export class CodingBridgeSocket {
       return;
     }
     const payload = message?.payload ?? {};
+    logEnvelope('recv', message);
     switch (message?.type) {
       case CB_NODE_TO_BROWSER:
         this.handlers.onEvent?.(payload, message?.from_node);
@@ -132,6 +160,7 @@ export class CodingBridgeSocket {
       return;
     }
     const envelope = { v: 1, id: makeId(), ts: Date.now(), type, ...extra };
+    logEnvelope('send', envelope);
     this.ws?.send(JSON.stringify(envelope));
   }
 


### PR DESCRIPTION
## What

The browser side of making Coding Bridge debuggable end-to-end. Generates one **trace id per turn** and threads it through the whole round-trip, then surfaces the device / session / trace ids in the UI so they can be copied straight into an issue or used for a CLS log lookup.

## Why

Coding Bridge spans three processes (browser → relay → node). Without a shared id there is no way to follow a single prompt across all of them. The browser is where a turn originates, so it is the natural place to mint the trace id.

## Changes

- **`models/codingBridge.ts`**: add `trace_id` to `ICodingBridgeSession` and `ICodingBridgeEvent`.
- **`store/codingBridge/actions.ts`**: `sendPrompt` mints a trace id per turn and threads it into the session, the prompt event and the `SESSION_START` / `SESSION_SEND` payloads. `applyNodeEvent` stamps the session and every inbound event with the trace id the node echoes back.
- **`utils/codingBridgeSocket.ts`**: opt-in structured `console.debug` for sent and received envelopes (enable with `localStorage.cbDebug = '1'`), logging type / id / node / action / event / session / trace. Silent by default.
- **`components/codingBridge/SessionView.vue`**: a compact, copyable diagnostic strip showing the device, session and trace ids (reuses the shared `CopyToClipboard` component).
- **i18n**: `zh-CN` + `en` written by hand; the three new label keys backfilled to all other locales so the coverage guard stays green (no `yarn translate`).

## Testing

- `vue-tsc --noEmit` — clean
- `eslint` (cb files) — clean
- `check_i18n_coverage.py` — OK (17 locales × 40 namespaces)
- `npm run build` — succeeds

## Companion PRs

- Relay sink: AceDataCloud/PlatformService#995
- Node agent: AceDataCloud/CodingBridgeAgent#15