### PR TITLE
fix(coding-bridge): show all slash commands in a scrollable menu

### DIFF
--- a/change/@acedatacloud-nexior-c2047f17-9081-4fa2-bc7b-b0698285161d.json
+++ b/change/@acedatacloud-nexior-c2047f17-9081-4fa2-bc7b-b0698285161d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Coding Bridge: slash command menu lists all available commands (scrollable) instead of only the first 8",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/qicu/Projects/AceDataCloud/Nexior/node_modules

--- a/src/components/codingBridge/SessionView.vue
+++ b/src/components/codingBridge/SessionView.vue
@@ -650,12 +650,10 @@ export default defineComponent({
         return [];
       }
       const query = match[1].toLowerCase();
-      return this.slashCommands
-        .filter((command) => {
-          const names = [command.name, ...(command.aliases ?? [])];
-          return names.some((name) => name.toLowerCase().startsWith(query));
-        })
-        .slice(0, 8);
+      return this.slashCommands.filter((command) => {
+        const names = [command.name, ...(command.aliases ?? [])];
+        return names.some((name) => name.toLowerCase().startsWith(query));
+      });
     },
     slashMenuVisible(): boolean {
       return this.slashMenuOpen && this.slashMatches.length > 0;
@@ -859,6 +857,11 @@ export default defineComponent({
         return;
       }
       this.slashActiveIndex = (this.slashActiveIndex + delta + count) % count;
+      // Keep the highlighted command visible as the list scrolls.
+      this.$nextTick(() => {
+        const active = this.$el?.querySelector?.('.cb-slash-menu__item--active');
+        (active as HTMLElement | null)?.scrollIntoView({ block: 'nearest' });
+      });
     },
     applySlash(command?: ICodingBridgeSlashCommand) {
       if (!command) {


### PR DESCRIPTION
## Problem

When typing `/` in the Coding Bridge composer, the slash-command autocomplete menu only showed the **first 8** commands and could not scroll, so commands further down the catalog (e.g. `/goal`) were unreachable — even though typing `/goal` in full did surface it.

## Root cause

`slashMatches()` in `SessionView.vue` applied a hard `.slice(0, 8)` to the filtered command list. The Claude catalog has ~27 commands, but only the first 8 were ever rendered. Those 8 fit inside the menu's `max-height: 260px`, so there was nothing to scroll, and any command past position 8 was dropped from the DOM entirely. Typing a longer query (`/goal`) narrowed the filter to a single match that fell within the cap, which is why it appeared only when fully typed.

## Fix

- Remove the `.slice(0, 8)` cap so **all** matching commands render. The menu CSS already has `max-height: 260px; overflow-y: auto`, so the full list is now scrollable.
- `moveSlash()` now scrolls the keyboard-active item into view (`scrollIntoView({ block: 'nearest' })`) so arrow-key navigation follows the scroll through the longer list.

No new i18n keys, no new dependencies. CSS unchanged.

## Validation

- eslint clean, `vue-tsc --noEmit` exit 0
- i18n coverage OK (17 locales × 40 namespaces)
- 147 vitest pass
- `npm run build` success