### PR TITLE
fix: remove accidental node_modules symlink from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ bower_components
 build/Release
 
 # Dependency directories
+node_modules
 node_modules/
 jspm_packages/
 

--- a/change/@acedatacloud-nexior-0f782ae4-3033-481c-843e-92020e1a4a13.json
+++ b/change/@acedatacloud-nexior-0f782ae4-3033-481c-843e-92020e1a4a13.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Cleanup: remove accidentally committed node_modules symlink and harden ignore rule",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/qicu/Projects/AceDataCloud/Nexior/node_modules


### PR DESCRIPTION
## What happened\nA symlink-like file named `node_modules` was accidentally committed (content: an absolute local path), which should never be tracked.\n\n## Fix\n- Remove tracked `node_modules` from git history moving forward (delete from index/repo).\n- Harden ignore rules by adding plain `node_modules` in [.gitignore](Nexior/.gitignore) in addition to `node_modules/`, so symlink/file forms are also ignored.\n- Add beachball change file.\n\n## Impact\n- No runtime logic change.\n- Prevents local absolute-path artifacts from leaking into PRs again.