### PR TITLE
style: apply prettier formatting to 6 components

### DIFF
--- a/src/components/chat/ConnectorConsentCard.vue
+++ b/src/components/chat/ConnectorConsentCard.vue
@@ -49,18 +49,16 @@
          opt-out checklist regardless of entry surface. -->
     <el-dialog
       v-model="scopeDialogVisible"
-      :title="scopeDialogCatalog ? ($t('chat.consent.selectScopes', { provider: scopeDialogCatalog.name }) as string) : ''"
+      :title="
+        scopeDialogCatalog ? ($t('chat.consent.selectScopes', { provider: scopeDialogCatalog.name }) as string) : ''
+      "
       width="480px"
       :close-on-click-modal="false"
       append-to-body
     >
       <p class="ccc-scope-hint">{{ $t('chat.consent.selectScopesHint') }}</p>
       <el-checkbox-group v-model="selectedScopes">
-        <div
-          v-for="perm in (scopeDialogCatalog?.permissions || [])"
-          :key="perm.id"
-          class="ccc-scope-row"
-        >
+        <div v-for="perm in scopeDialogCatalog?.permissions || []" :key="perm.id" class="ccc-scope-row">
           <el-checkbox :value="perm.id" :label="perm.id">
             <span class="ccc-scope-label">{{ perm.label || perm.id }}</span>
           </el-checkbox>

--- a/src/components/chat/connectorCatalogCache.ts
+++ b/src/components/chat/connectorCatalogCache.ts
@@ -102,10 +102,9 @@ export interface IUserConnectionSummary {
  *  Throws on network / HTTP errors so the caller can decide whether
  *  to fall back to the stale status or surface a toast. */
 export async function listMyConnections(): Promise<IUserConnectionSummary[]> {
-  const response: AxiosResponse<IUserConnectionSummary[]> = await httpClient.get(
-    `/connections/`,
-    { baseURL: `${getBaseUrlAuth()}/api/v1` }
-  );
+  const response: AxiosResponse<IUserConnectionSummary[]> = await httpClient.get(`/connections/`, {
+    baseURL: `${getBaseUrlAuth()}/api/v1`
+  });
   return Array.isArray(response.data) ? response.data : [];
 }
 
@@ -126,10 +125,9 @@ export async function getCatalogItem(catalogId: string): Promise<IConnectorCatal
   if (existing) return existing;
   const task = (async () => {
     try {
-      const response: AxiosResponse<IConnectorCatalogSummary> = await httpClient.get(
-        `/connectors/${catalogId}/`,
-        { baseURL: `${getBaseUrlAuth()}/api/v1` }
-      );
+      const response: AxiosResponse<IConnectorCatalogSummary> = await httpClient.get(`/connectors/${catalogId}/`, {
+        baseURL: `${getBaseUrlAuth()}/api/v1`
+      });
       const item = response.data;
       cache.set(catalogId, item);
       return item;

--- a/src/components/common/player/PlayerSlider.vue
+++ b/src/components/common/player/PlayerSlider.vue
@@ -21,8 +21,7 @@ const progress = field<number>('progress');
 const duration = field<number>('duration');
 
 const onSliderInput = () => {};
-const onSliderChange = (val: number | number[]) =>
-  dispatchAudio({ progress: Array.isArray(val) ? val[0] : val });
+const onSliderChange = (val: number | number[]) => dispatchAudio({ progress: Array.isArray(val) ? val[0] : val });
 </script>
 
 <style lang="scss">

--- a/src/components/suno/config/PersonaInput.vue
+++ b/src/components/suno/config/PersonaInput.vue
@@ -10,13 +10,7 @@
         {{ $t('suno.voice.manage') }}
       </el-button>
     </div>
-    <el-select
-      v-model="personaId"
-      :placeholder="$t('suno.placeholder.personaId')"
-      clearable
-      filterable
-      class="w-full"
-    >
+    <el-select v-model="personaId" :placeholder="$t('suno.placeholder.personaId')" clearable filterable class="w-full">
       <el-option
         v-for="persona in personas"
         :key="persona.persona_id || ''"

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -19,7 +19,15 @@ export interface IUserListResponse {
 
 export interface IUserDetailResponse extends IUser {}
 
-export type IUserPublicRegistrationMethod = 'email' | 'phone' | 'github' | 'google' | 'apple' | 'wechat' | 'username' | 'unknown';
+export type IUserPublicRegistrationMethod =
+  | 'email'
+  | 'phone'
+  | 'github'
+  | 'google'
+  | 'apple'
+  | 'wechat'
+  | 'username'
+  | 'unknown';
 
 export interface IUserPublic {
   id: string;

--- a/src/pages/error/NotFound.vue
+++ b/src/pages/error/NotFound.vue
@@ -317,7 +317,11 @@ export default defineComponent({
       align-items: center;
       justify-content: center;
       gap: 8px;
-      font-family: 'Inter', system-ui, -apple-system, sans-serif;
+      font-family:
+        'Inter',
+        system-ui,
+        -apple-system,
+        sans-serif;
       font-size: clamp(96px, 18vw, 200px);
       font-weight: 800;
       letter-spacing: -0.04em;


### PR DESCRIPTION
## What

Pure Prettier formatting cleanup across 6 files — **no behavior change**:

- `src/components/chat/ConnectorConsentCard.vue` — wrap long `:title`, collapse `v-for` attrs, add trailing newline
- `src/components/chat/connectorCatalogCache.ts` — collapse multi-line `httpClient.get` args
- `src/components/common/player/PlayerSlider.vue` — single-line `onSliderChange`
- `src/components/suno/config/PersonaInput.vue` — single-line `<el-select>`
- `src/models/user.ts` — multi-line union type
- `src/pages/error/NotFound.vue` — multi-line `font-family`

## Why

These files were left mildly non-conformant with the repo's Prettier config (`printWidth=120`, trailing newline). Reformatting brings them into line.

## Verification

`npx prettier --check` passes on all 6 files.

> Note: a parallel batch of stale `codingBridge` edits in the same working tree was intentionally **discarded** — that feature had already been merged upstream (local main was 33 commits behind), so committing those would have regressed ~850 lines of newer code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)