### PR TITLE
feat(coding-bridge): remember last composer setup per device

### DIFF
--- a/src/components/codingBridge/SessionView.vue
+++ b/src/components/codingBridge/SessionView.vue
@@ -403,6 +403,7 @@ import {
   IAskUserQuestionPayload,
   ICodingBridgeAttachment,
   ICodingBridgeCapabilities,
+  ICodingBridgeComposerPrefs,
   ICodingBridgeEvent,
   ICodingBridgeNode,
   ICodingBridgeProviderCapability,
@@ -465,6 +466,11 @@ export default defineComponent({
     },
     currentNodeId(): string | undefined {
       return this.$store.state.codingBridge?.currentNodeId;
+    },
+    // Last composer setup used on this device, restored from localStorage.
+    lastComposer(): ICodingBridgeComposerPrefs {
+      const id = this.currentNodeId;
+      return (id ? this.$store.state.codingBridge?.lastComposer?.[id] : undefined) ?? {};
     },
     currentNode(): ICodingBridgeNode | undefined {
       return this.$store.state.codingBridge?.nodes?.find((node) => node.node_id === this.currentNodeId);
@@ -691,6 +697,11 @@ export default defineComponent({
     currentNodeId() {
       // Refresh capabilities when switching devices.
       this.requestCapabilities();
+      // On a new session, swap the composer to the new device's last setup —
+      // a folder / model from the previous device is meaningless here.
+      if (this.isNewSession) {
+        this.restoreComposerPrefs();
+      }
     },
     providerCaps() {
       // Prefer a backend the node actually has installed. Fall back to the
@@ -776,6 +787,9 @@ export default defineComponent({
     syncSessionSettings() {
       const session = this.currentSession;
       if (!session) {
+        // New session: restore the last setup used on this device so the user
+        // doesn't have to re-pick folder / model / mode every time.
+        this.restoreComposerPrefs();
         return;
       }
       if (session.provider) {
@@ -876,6 +890,19 @@ export default defineComponent({
         return;
       }
       const attachments = this.attachments;
+      // Remember this device's setup so the next new session pre-fills it.
+      if (this.currentNodeId) {
+        this.$store.commit('codingBridge/setLastComposer', {
+          node_id: this.currentNodeId,
+          prefs: {
+            cwd: this.cwd,
+            provider: this.provider,
+            model: this.model,
+            permissionMode: this.permissionMode,
+            effort: this.effort
+          }
+        });
+      }
       this.$store.dispatch('codingBridge/sendPrompt', {
         prompt: this.prompt,
         cwd: this.cwd,
@@ -991,16 +1018,27 @@ export default defineComponent({
     },
     onNewSession() {
       this.$store.dispatch('codingBridge/newSession');
-      this.cwd = '';
-      this.model = '';
-      this.customModelDraft = '';
-      this.permissionMode = 'default';
-      this.provider = 'claude';
-      this.effort = '';
+      // Restore the last setup used on this device instead of resetting it all.
+      this.restoreComposerPrefs();
       this.prompt = '';
       this.slashMenuOpen = false;
       this.slashActiveIndex = 0;
       this.clearAttachments();
+    },
+    // Pre-fill the composer from the last setup used on the current device.
+    // Falls back to defaults for anything not recorded yet. Model and effort
+    // are applied after the `provider` watcher's reset runs, so a restored
+    // provider doesn't wipe them.
+    restoreComposerPrefs() {
+      const prefs = this.lastComposer;
+      this.cwd = prefs.cwd ?? '';
+      this.provider = prefs.provider ?? 'claude';
+      this.permissionMode = prefs.permissionMode ?? 'default';
+      this.customModelDraft = '';
+      this.$nextTick(() => {
+        this.model = prefs.model ?? '';
+        this.effort = prefs.effort ?? '';
+      });
     },
     scrollToBottom() {
       this.$nextTick(() => {

--- a/src/models/codingBridge.ts
+++ b/src/models/codingBridge.ts
@@ -25,6 +25,19 @@ export interface ICodingBridgeModelOption {
 }
 
 /**
+ * Last composer setup used on a node, so a new session pre-fills it instead of
+ * resetting to defaults every time. Node-scoped because cwd / provider / model
+ * are all device-specific. Persisted to localStorage.
+ */
+export interface ICodingBridgeComposerPrefs {
+  cwd?: string;
+  provider?: string;
+  model?: string;
+  permissionMode?: string;
+  effort?: string;
+}
+
+/**
  * What one backend on a node can do, reported by the node's `capabilities.get`.
  * The UI renders dropdowns from this instead of hard-coding models / efforts,
  * so a new model only needs a node update (or a typed-in custom value).

--- a/src/store/codingBridge/models.ts
+++ b/src/store/codingBridge/models.ts
@@ -1,6 +1,7 @@
 import { Status } from '@/models';
 import {
   ICodingBridgeCapabilities,
+  ICodingBridgeComposerPrefs,
   ICodingBridgeConnectionStatus,
   ICodingBridgeDirListing,
   ICodingBridgeEvent,
@@ -34,6 +35,9 @@ export interface ICodingBridgeState {
   // transient: replaced on each `fs.list` and never persisted).
   directory: ICodingBridgeDirListing | undefined;
   directoryLoading: boolean;
+  // Last composer setup (cwd/provider/model/effort/mode) used per node, so a
+  // new session on a known device pre-fills it instead of resetting. Persisted.
+  lastComposer: Record<string, ICodingBridgeComposerPrefs>;
   // Coding Bridge is not a billed API service, so it owns no application /
   // service / credential. These fields exist only so the shared `Main.vue`
   // layout (which is generic over per-app modules) reads `undefined` and

--- a/src/store/codingBridge/mutations.ts
+++ b/src/store/codingBridge/mutations.ts
@@ -2,6 +2,7 @@ import initialState from './state';
 import { ICodingBridgeHistoryRef, ICodingBridgeState } from './models';
 import {
   ICodingBridgeCapabilities,
+  ICodingBridgeComposerPrefs,
   ICodingBridgeConnectionStatus,
   ICodingBridgeDirListing,
   ICodingBridgeEvent,
@@ -161,6 +162,16 @@ export const setDirectoryLoading = (state: ICodingBridgeState, payload: boolean)
   state.directoryLoading = payload;
 };
 
+export const setLastComposer = (
+  state: ICodingBridgeState,
+  payload: { node_id: string; prefs: ICodingBridgeComposerPrefs }
+): void => {
+  state.lastComposer = {
+    ...state.lastComposer,
+    [payload.node_id]: { ...state.lastComposer[payload.node_id], ...payload.prefs }
+  };
+};
+
 export const setCapabilities = (
   state: ICodingBridgeState,
   payload: { node_id: string; capabilities: ICodingBridgeCapabilities }
@@ -216,6 +227,7 @@ export default {
   setHistoryRef,
   setDirectory,
   setDirectoryLoading,
+  setLastComposer,
   setCapabilities,
   addPermission,
   removePermission,

--- a/src/store/codingBridge/persist.ts
+++ b/src/store/codingBridge/persist.ts
@@ -2,4 +2,4 @@
 // Live nodes, sessions, events and permission prompts are rebuilt from the
 // relay on reconnect, and the open conversation is re-read from the device, so
 // persisting their contents would only show stale data.
-export default ['codingBridge.currentNodeId', 'codingBridge.historyRef'];
+export default ['codingBridge.currentNodeId', 'codingBridge.historyRef', 'codingBridge.lastComposer'];

--- a/src/store/codingBridge/state.ts
+++ b/src/store/codingBridge/state.ts
@@ -15,6 +15,7 @@ export default (): ICodingBridgeState => {
     connection: 'disconnected',
     directory: undefined,
     directoryLoading: false,
+    lastComposer: {},
     application: undefined,
     applications: undefined,
     service: undefined,


### PR DESCRIPTION
## Problem

When creating a new Coding Bridge session, the composer is reset to defaults every time — working directory cleared, provider back to Claude, model/effort/permission-mode wiped. Users have to re-pick all of it on every new session, even when it's identical to what they just used on the same device.

## Fix

Persist the **last composer setup used per node** and pre-fill it for new sessions on that device:

- working directory (`cwd`)
- provider (claude / codex)
- model
- reasoning effort
- permission mode

### How

- New `lastComposer: Record<string, ICodingBridgeComposerPrefs>` (keyed by `node_id`) in the `codingBridge` store, added to the persisted paths so it survives reloads.
- `setLastComposer` mutation records the setup on **send** (the moment it's actually used), merging into any existing prefs.
- `SessionView.restoreComposerPrefs()` pre-fills the composer on new session, on mount, and when switching devices. Model & effort are re-applied in `$nextTick` **after** the existing `provider`-change watcher resets them, so a restored provider doesn't wipe the restored model/effort.

Per-device keying because folder / provider / model are all machine-specific — a path or model from one device is meaningless on another. If a saved provider is no longer available on the node, the existing `providerCaps` watcher still falls back to an available one. Existing / running sessions are unaffected — they still show their own recorded settings.

## Testing

- `npx vue-tsc --noEmit` — passes
- `npx eslint` on changed files — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)