### PR TITLE
feat(coding-bridge): edit a sent prompt and resend with model switch

### DIFF
--- a/src/components/codingBridge/SessionView.vue
+++ b/src/components/codingBridge/SessionView.vue
@@ -62,7 +62,7 @@
         <div v-if="!events.length" class="m-auto text-center text-sm text-[var(--app-text-subtle)]">
           {{ $t('codingBridge.session.startHint') }}
         </div>
-        <transcript-item v-for="event in events" :key="event.id" :event="event" />
+        <transcript-item v-for="event in events" :key="event.id" :event="event" @edit="onEditPrompt" />
         <!-- Retry: re-run the last prompt after a turn ends in error. -->
         <div v-if="canRetry" class="flex justify-center pt-1">
           <el-button size="small" round @click="onRetry">
@@ -1030,6 +1030,34 @@ export default defineComponent({
     },
     onRetry() {
       this.$store.dispatch('codingBridge/retryLastPrompt');
+    },
+    // Reload a previously sent prompt into the composer so the user can tweak
+    // the text/attachments (and switch the model) and resend it as a new turn.
+    // The agent transcript is append-only, so the original prompt stays put.
+    onEditPrompt(event: ICodingBridgeEvent) {
+      if (this.readonly) {
+        return;
+      }
+      this.prompt = event.text ?? '';
+      this.slashMenuOpen = false;
+      this.slashActiveIndex = 0;
+      this.clearAttachments();
+      this.attachmentFileList = (event.attachments ?? []).map((attachment, index) => {
+        const isImage = attachment.type === 'image';
+        return {
+          name: attachment.name || attachment.url,
+          url: attachment.url,
+          status: 'success',
+          percentage: 100,
+          uid: Date.now() + index,
+          response: { file_url: attachment.url },
+          mime_type: attachment.mime_type
+        } as unknown as UploadFile;
+      });
+      this.$nextTick(() => {
+        const textarea = this.$el?.querySelector?.('.cb-composer__input textarea') as HTMLTextAreaElement | null;
+        textarea?.focus();
+      });
     },
     openDirectory() {
       this.directoryVisible = true;

--- a/src/components/codingBridge/SessionView.vue
+++ b/src/components/codingBridge/SessionView.vue
@@ -1043,7 +1043,6 @@ export default defineComponent({
       this.slashActiveIndex = 0;
       this.clearAttachments();
       this.attachmentFileList = (event.attachments ?? []).map((attachment, index) => {
-        const isImage = attachment.type === 'image';
         return {
           name: attachment.name || attachment.url,
           url: attachment.url,

--- a/src/components/codingBridge/TranscriptItem.vue
+++ b/src/components/codingBridge/TranscriptItem.vue
@@ -1,7 +1,18 @@
 <template>
   <div class="transcript-item text-sm leading-relaxed" :class="`kind-${event.kind}`">
     <!-- User prompt -->
-    <div v-if="event.kind === 'prompt'" class="flex justify-end">
+    <div v-if="event.kind === 'prompt'" class="group flex items-end justify-end gap-1.5">
+      <!-- Edit: reload this prompt (text + attachments) into the composer to
+           tweak and resend as a new turn; model can be switched there too. -->
+      <button
+        type="button"
+        class="cb-edit-btn opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+        :title="$t('codingBridge.session.editPrompt')"
+        :aria-label="$t('codingBridge.session.editPrompt')"
+        @click="$emit('edit', event)"
+      >
+        <font-awesome-icon icon="fa-solid fa-pen" />
+      </button>
       <div
         class="max-w-[85%] rounded-lg px-3 py-2 bg-[var(--el-color-primary)] text-white whitespace-pre-wrap break-words"
       >
@@ -161,6 +172,7 @@ export default defineComponent({
       required: true
     }
   },
+  emits: ['edit'],
   computed: {
     commandText(): string {
       const input = this.event.input;
@@ -290,6 +302,30 @@ export default defineComponent({
 </style>
 
 <style lang="scss" scoped>
+.cb-edit-btn {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 9999px;
+  border: 1px solid var(--app-border-subtle);
+  background: var(--app-content-bg);
+  color: var(--app-text-subtle);
+  font-size: 11px;
+  cursor: pointer;
+  transition:
+    color 0.15s ease,
+    border-color 0.15s ease,
+    opacity 0.15s ease;
+
+  &:hover {
+    color: var(--el-color-primary);
+    border-color: var(--el-color-primary-light-5);
+  }
+}
+
 .transcript-item :deep(.markdown-body) {
   background: transparent;
   color: inherit;

--- a/src/i18n/ar/codingBridge.json
+++ b/src/i18n/ar/codingBridge.json
@@ -167,6 +167,10 @@
     "message": "إعادة المحاولة",
     "description": "Re-run the last prompt after a failure"
   },
+  "session.editPrompt": {
+    "message": "Edit",
+    "description": "Edit a sent prompt and resend it as a new turn"
+  },
   "session.enterHint": {
     "message": "Enter to send, Shift+Enter for a new line.",
     "description": "Composer keyboard hint"

--- a/src/i18n/de/codingBridge.json
+++ b/src/i18n/de/codingBridge.json
@@ -167,6 +167,10 @@
     "message": "Erneut versuchen",
     "description": "Re-run the last prompt after a failure"
   },
+  "session.editPrompt": {
+    "message": "Edit",
+    "description": "Edit a sent prompt and resend it as a new turn"
+  },
   "session.enterHint": {
     "message": "Enter to send, Shift+Enter for a new line.",
     "description": "Composer keyboard hint"

--- a/src/i18n/el/codingBridge.json
+++ b/src/i18n/el/codingBridge.json
@@ -167,6 +167,10 @@
     "message": "Επανάληψη",
     "description": "Re-run the last prompt after a failure"
   },
+  "session.editPrompt": {
+    "message": "Edit",
+    "description": "Edit a sent prompt and resend it as a new turn"
+  },
   "session.enterHint": {
     "message": "Enter to send, Shift+Enter for a new line.",
     "description": "Composer keyboard hint"

--- a/src/i18n/en/codingBridge.json
+++ b/src/i18n/en/codingBridge.json
@@ -167,6 +167,10 @@
     "message": "Retry",
     "description": "Re-run the last prompt after a failure"
   },
+  "session.editPrompt": {
+    "message": "Edit",
+    "description": "Edit a sent prompt and resend it as a new turn"
+  },
   "session.enterHint": {
     "message": "Enter to send, Shift+Enter for a new line.",
     "description": "Composer keyboard hint"

--- a/src/i18n/es/codingBridge.json
+++ b/src/i18n/es/codingBridge.json
@@ -167,6 +167,10 @@
     "message": "Reintentar",
     "description": "Re-run the last prompt after a failure"
   },
+  "session.editPrompt": {
+    "message": "Edit",
+    "description": "Edit a sent prompt and resend it as a new turn"
+  },
   "session.enterHint": {
     "message": "Enter to send, Shift+Enter for a new line.",
     "description": "Composer keyboard hint"

--- a/src/i18n/fi/codingBridge.json
+++ b/src/i18n/fi/codingBridge.json
@@ -167,6 +167,10 @@
     "message": "Yritä uudelleen",
     "description": "Re-run the last prompt after a failure"
   },
+  "session.editPrompt": {
+    "message": "Edit",
+    "description": "Edit a sent prompt and resend it as a new turn"
+  },
   "session.enterHint": {
     "message": "Enter to send, Shift+Enter for a new line.",
     "description": "Composer keyboard hint"

--- a/src/i18n/fr/codingBridge.json
+++ b/src/i18n/fr/codingBridge.json
@@ -167,6 +167,10 @@
     "message": "Réessayer",
     "description": "Re-run the last prompt after a failure"
   },
+  "session.editPrompt": {
+    "message": "Edit",
+    "description": "Edit a sent prompt and resend it as a new turn"
+  },
   "session.enterHint": {
     "message": "Enter to send, Shift+Enter for a new line.",
     "description": "Composer keyboard hint"

--- a/src/i18n/it/codingBridge.json
+++ b/src/i18n/it/codingBridge.json
@@ -167,6 +167,10 @@
     "message": "Riprova",
     "description": "Re-run the last prompt after a failure"
   },
+  "session.editPrompt": {
+    "message": "Edit",
+    "description": "Edit a sent prompt and resend it as a new turn"
+  },
   "session.enterHint": {
     "message": "Enter to send, Shift+Enter for a new line.",
     "description": "Composer keyboard hint"

--- a/src/i18n/ja/codingBridge.json
+++ b/src/i18n/ja/codingBridge.json
@@ -167,6 +167,10 @@
     "message": "再試行",
     "description": "Re-run the last prompt after a failure"
   },
+  "session.editPrompt": {
+    "message": "Edit",
+    "description": "Edit a sent prompt and resend it as a new turn"
+  },
   "session.enterHint": {
     "message": "Enter to send, Shift+Enter for a new line.",
     "description": "Composer keyboard hint"

--- a/src/i18n/ko/codingBridge.json
+++ b/src/i18n/ko/codingBridge.json
@@ -167,6 +167,10 @@
     "message": "다시 시도",
     "description": "Re-run the last prompt after a failure"
   },
+  "session.editPrompt": {
+    "message": "Edit",
+    "description": "Edit a sent prompt and resend it as a new turn"
+  },
   "session.enterHint": {
     "message": "Enter to send, Shift+Enter for a new line.",
     "description": "Composer keyboard hint"

--- a/src/i18n/pl/codingBridge.json
+++ b/src/i18n/pl/codingBridge.json
@@ -167,6 +167,10 @@
     "message": "Ponów",
     "description": "Re-run the last prompt after a failure"
   },
+  "session.editPrompt": {
+    "message": "Edit",
+    "description": "Edit a sent prompt and resend it as a new turn"
+  },
   "session.enterHint": {
     "message": "Enter to send, Shift+Enter for a new line.",
     "description": "Composer keyboard hint"

--- a/src/i18n/pt/codingBridge.json
+++ b/src/i18n/pt/codingBridge.json
@@ -167,6 +167,10 @@
     "message": "Tentar novamente",
     "description": "Re-run the last prompt after a failure"
   },
+  "session.editPrompt": {
+    "message": "Edit",
+    "description": "Edit a sent prompt and resend it as a new turn"
+  },
   "session.enterHint": {
     "message": "Enter to send, Shift+Enter for a new line.",
     "description": "Composer keyboard hint"

--- a/src/i18n/ru/codingBridge.json
+++ b/src/i18n/ru/codingBridge.json
@@ -167,6 +167,10 @@
     "message": "Повторить",
     "description": "Re-run the last prompt after a failure"
   },
+  "session.editPrompt": {
+    "message": "Edit",
+    "description": "Edit a sent prompt and resend it as a new turn"
+  },
   "session.enterHint": {
     "message": "Enter to send, Shift+Enter for a new line.",
     "description": "Composer keyboard hint"

--- a/src/i18n/sr/codingBridge.json
+++ b/src/i18n/sr/codingBridge.json
@@ -167,6 +167,10 @@
     "message": "Покушај поново",
     "description": "Re-run the last prompt after a failure"
   },
+  "session.editPrompt": {
+    "message": "Edit",
+    "description": "Edit a sent prompt and resend it as a new turn"
+  },
   "session.enterHint": {
     "message": "Enter to send, Shift+Enter for a new line.",
     "description": "Composer keyboard hint"

--- a/src/i18n/sv/codingBridge.json
+++ b/src/i18n/sv/codingBridge.json
@@ -167,6 +167,10 @@
     "message": "Försök igen",
     "description": "Re-run the last prompt after a failure"
   },
+  "session.editPrompt": {
+    "message": "Edit",
+    "description": "Edit a sent prompt and resend it as a new turn"
+  },
   "session.enterHint": {
     "message": "Enter to send, Shift+Enter for a new line.",
     "description": "Composer keyboard hint"

--- a/src/i18n/uk/codingBridge.json
+++ b/src/i18n/uk/codingBridge.json
@@ -167,6 +167,10 @@
     "message": "Повторити",
     "description": "Re-run the last prompt after a failure"
   },
+  "session.editPrompt": {
+    "message": "Edit",
+    "description": "Edit a sent prompt and resend it as a new turn"
+  },
   "session.enterHint": {
     "message": "Enter to send, Shift+Enter for a new line.",
     "description": "Composer keyboard hint"

--- a/src/i18n/zh-CN/codingBridge.json
+++ b/src/i18n/zh-CN/codingBridge.json
@@ -167,6 +167,10 @@
     "message": "重试",
     "description": "失败后重新执行上一条提示词"
   },
+  "session.editPrompt": {
+    "message": "编辑",
+    "description": "编辑已发送的提示词并作为新一轮重新发送"
+  },
   "session.enterHint": {
     "message": "回车发送，Shift+回车换行。",
     "description": "输入框键盘提示"

--- a/src/i18n/zh-TW/codingBridge.json
+++ b/src/i18n/zh-TW/codingBridge.json
@@ -167,6 +167,10 @@
     "message": "重試",
     "description": "Re-run the last prompt after a failure"
   },
+  "session.editPrompt": {
+    "message": "Edit",
+    "description": "Edit a sent prompt and resend it as a new turn"
+  },
   "session.enterHint": {
     "message": "Enter 傳送，Shift+Enter 換行。",
     "description": "輸入框鍵盤提示"


### PR DESCRIPTION
## What

On the Coding Bridge session view (`studio.acedata.cloud/coding-bridge`), a **sent prompt is now clickable to edit**. Hovering a user prompt bubble reveals a ✏️ Edit button; clicking it reloads that prompt's text + attachments back into the composer so the user can tweak it — and switch the **model** (and other composer pills) — then resend.

## Why this shape

A Coding Bridge session is **append-only**: the browser only relays prompts to the Claude Code / Codex CLI running on the user's node, which has already consumed the message into its context. There is no rewind/fork in the current protocol, so a literal in-place rewrite isn't possible. Instead this is an honest **edit-and-resend**: the original prompt stays in the transcript and the edited version is sent as a new turn — the same interaction class as the existing Retry button.

Mid-session model switching already works (`set_model` in the node's Claude provider; `SESSION_SEND` carries `model` each turn), so "change the model while editing" comes for free via the existing model pill.

## Changes

- `TranscriptItem.vue` — hover Edit button on prompt bubbles, emits `edit`.
- `SessionView.vue` — `onEditPrompt` reloads text + attachments into the composer and focuses it.
- i18n `session.editPrompt` (zh-CN + en only).

## Out of scope

True context rewind/fork (delete or replace a prior turn so the agent answers as if it never happened) — would require node + protocol changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)