### PR TITLE
fix(coding-bridge): show full session/trace/device IDs

### DIFF
--- a/src/components/codingBridge/SessionView.vue
+++ b/src/components/codingBridge/SessionView.vue
@@ -51,9 +51,9 @@
         class="flex flex-wrap items-center gap-x-4 gap-y-1 px-5 py-1.5 text-[11px] text-[var(--app-text-subtle)] border-b border-[var(--app-border-subtle)]"
       >
         <span v-for="item in diagnostics" :key="item.label" class="inline-flex items-center gap-1 min-w-0">
-          <span class="opacity-70">{{ item.label }}:</span>
-          <span class="font-mono truncate max-w-[160px]" :title="item.value">{{ item.value }}</span>
-          <copy-to-clipboard :content="item.value" class="inline-block" />
+          <span class="opacity-70 flex-none">{{ item.label }}:</span>
+          <span class="font-mono break-all" :title="item.value">{{ item.value }}</span>
+          <copy-to-clipboard :content="item.value" class="inline-block flex-none" />
         </span>
       </div>
 


### PR DESCRIPTION
## Problem

On the Coding Bridge page (`studio.acedata.cloud/coding-bridge`), the diagnostic identifiers (Device/Node ID, Session ID, Trace ID) were clamped with `truncate max-w-[160px]`, so they showed as e.g. `node_0zi6WeaEu0l4ECp1hC…` — cut off with an ellipsis. Users couldn't read or visually copy the full value.

## Fix

Replace `truncate max-w-[160px]` with `break-all` on the value span so the full ID renders and wraps within the existing `flex-wrap` row. Kept the `:title` tooltip and the copy-to-clipboard button. Marked the label and copy icon `flex-none` so only the value wraps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)