### PR TITLE
feat(coding-bridge): editing a prompt rewinds the conversation (fork, not append)

### DIFF
--- a/src/components/codingBridge/SessionView.vue
+++ b/src/components/codingBridge/SessionView.vue
@@ -62,7 +62,13 @@
         <div v-if="!events.length" class="m-auto text-center text-sm text-[var(--app-text-subtle)]">
           {{ $t('codingBridge.session.startHint') }}
         </div>
-        <transcript-item v-for="event in events" :key="event.id" :event="event" @edit="onEditPrompt" />
+        <transcript-item
+          v-for="event in events"
+          :key="event.id"
+          :event="event"
+          :editable="canEdit"
+          @edit="onEditPrompt"
+        />
         <!-- Live "thinking" status while the agent works between/before outputs. -->
         <thinking-indicator v-if="thinking" />
         <!-- Retry: re-run the last prompt after a turn ends in error. -->
@@ -93,6 +99,22 @@
           </el-button>
         </div>
         <template v-else>
+          <!-- Editing a past prompt: sending rewinds the conversation to here. -->
+          <div
+            v-if="editingActive"
+            class="mb-2 flex flex-wrap items-center gap-x-3 gap-y-1.5 rounded-lg bg-[var(--el-color-primary-light-9)] px-3 py-2 text-xs text-[var(--app-text)]"
+          >
+            <span class="inline-flex items-center gap-1.5">
+              <font-awesome-icon icon="fa-solid fa-pen" class="text-[var(--el-color-primary)]" />
+              {{ $t('codingBridge.session.editingBanner') }}
+            </span>
+            <el-checkbox v-if="canRestoreCode" v-model="restoreCode" size="small" class="cb-restore-code">
+              {{ $t('codingBridge.session.editRestoreCode') }}
+            </el-checkbox>
+            <button type="button" class="ml-auto cb-edit-cancel" @click="cancelEdit">
+              {{ $t('codingBridge.session.editCancel') }}
+            </button>
+          </div>
           <div
             class="cb-composer rounded-2xl border border-[var(--app-border-subtle)] bg-[var(--app-content-bg)] px-3 py-2.5 transition-colors focus-within:border-[var(--el-color-primary-light-5)]"
           >
@@ -372,7 +394,7 @@
                 <font-awesome-icon icon="fa-solid fa-stop" />
               </el-button>
               <el-button type="primary" round :disabled="!canSend" @click="onSend">
-                {{ $t('codingBridge.session.send') }}
+                {{ editingActive ? $t('codingBridge.session.editSubmit') : $t('codingBridge.session.send') }}
               </el-button>
             </div>
           </div>
@@ -398,6 +420,7 @@ import {
   ElDropdownMenu,
   ElDropdownItem,
   ElUpload,
+  ElCheckbox,
   UploadFile,
   UploadFiles
 } from 'element-plus';
@@ -443,6 +466,7 @@ export default defineComponent({
     ElDropdownMenu,
     ElDropdownItem,
     ElUpload,
+    ElCheckbox,
     FontAwesomeIcon,
     TranscriptItem,
     ThinkingIndicator,
@@ -464,6 +488,10 @@ export default defineComponent({
       directoryVisible: false,
       slashMenuOpen: false,
       slashActiveIndex: 0,
+      // Id of the prompt event being edited; when set, sending rewinds the
+      // conversation to that turn instead of appending a new one.
+      editingEventId: '' as string,
+      restoreCode: false,
       attachmentFileList: [] as UploadFiles,
       uploadUrl: getBaseUrlPlatform() + '/api/v1/files/',
       maxAttachments: MAX_ATTACHMENTS
@@ -611,6 +639,23 @@ export default defineComponent({
     currentProviderCap(): ICodingBridgeProviderCapability | undefined {
       return this.providerCaps.find((cap) => cap.name === this.provider);
     },
+    // Editing rewinds the conversation, so it's gated on the running session's
+    // backend (Claude supports it; Codex doesn't) and disabled for read-only
+    // replays. Unknown until capabilities load → don't offer it yet.
+    canEdit(): boolean {
+      if (this.readonly) {
+        return false;
+      }
+      const cap = this.providerCaps.find((item) => item.name === this.activeProviderName);
+      return !!cap?.supports_edit;
+    },
+    canRestoreCode(): boolean {
+      const cap = this.providerCaps.find((item) => item.name === this.activeProviderName);
+      return !!cap?.supports_code_restore;
+    },
+    editingActive(): boolean {
+      return !!this.editingEventId;
+    },
     // Unknown until capabilities load → treat as available so the composer is
     // never blocked before the node has reported anything.
     currentProviderAvailable(): boolean {
@@ -721,6 +766,9 @@ export default defineComponent({
     },
     currentSessionId() {
       this.scrollToBottom();
+      // Switching conversations cancels any in-progress edit.
+      this.editingEventId = '';
+      this.restoreCode = false;
       // Seed the composer (provider/model/cwd) from the session we switched to.
       this.syncSessionSettings();
     },
@@ -920,6 +968,21 @@ export default defineComponent({
         return;
       }
       const attachments = this.attachments;
+      // Editing a past prompt rewinds the conversation to that turn instead of
+      // appending — so the original prompt and everything after leave context.
+      if (this.editingEventId) {
+        this.$store.dispatch('codingBridge/editPrompt', {
+          eventId: this.editingEventId,
+          prompt: this.prompt,
+          model: this.model,
+          permissionMode: this.permissionMode,
+          effort: this.effort,
+          attachments: attachments.length ? attachments : undefined,
+          restoreCode: this.restoreCode
+        });
+        this.resetComposer();
+        return;
+      }
       // Remember this device's setup so the next new session pre-fills it.
       if (this.currentNodeId) {
         this.$store.commit('codingBridge/setLastComposer', {
@@ -942,10 +1005,19 @@ export default defineComponent({
         effort: this.effort,
         attachments: attachments.length ? attachments : undefined
       });
+      this.resetComposer();
+    },
+    // Clear the input, slash menu, attachments and any active edit state.
+    resetComposer() {
       this.prompt = '';
       this.slashMenuOpen = false;
       this.slashActiveIndex = 0;
+      this.editingEventId = '';
+      this.restoreCode = false;
       this.clearAttachments();
+    },
+    cancelEdit() {
+      this.resetComposer();
     },
     onAnswerQuestion(payload: { tool_use_id: string; output: string }) {
       this.$store.dispatch('codingBridge/answerQuestion', {
@@ -1043,13 +1115,16 @@ export default defineComponent({
     onRetry() {
       this.$store.dispatch('codingBridge/retryLastPrompt');
     },
-    // Reload a previously sent prompt into the composer so the user can tweak
-    // the text/attachments (and switch the model) and resend it as a new turn.
-    // The agent transcript is append-only, so the original prompt stays put.
+    // Enter edit mode for a past prompt: reload its text/attachments into the
+    // composer so the user can tweak it (and switch the model). On send the
+    // conversation is rewound to this turn — the original prompt and everything
+    // after it are dropped from the agent's context (see editPrompt).
     onEditPrompt(event: ICodingBridgeEvent) {
-      if (this.readonly) {
+      if (!this.canEdit) {
         return;
       }
+      this.editingEventId = event.id;
+      this.restoreCode = false;
       this.prompt = event.text ?? '';
       this.slashMenuOpen = false;
       this.slashActiveIndex = 0;
@@ -1080,10 +1155,7 @@ export default defineComponent({
       this.$store.dispatch('codingBridge/newSession');
       // Restore the last setup used on this device instead of resetting it all.
       this.restoreComposerPrefs();
-      this.prompt = '';
-      this.slashMenuOpen = false;
-      this.slashActiveIndex = 0;
-      this.clearAttachments();
+      this.resetComposer();
     },
     // Pre-fill the composer from the last setup used on the current device.
     // Falls back to defaults for anything not recorded yet. Model and effort
@@ -1203,6 +1275,25 @@ export default defineComponent({
     white-space: nowrap;
     font-size: 12px;
     color: var(--app-text-subtle);
+  }
+}
+
+.cb-edit-cancel {
+  flex: none;
+  color: var(--app-text-subtle);
+  cursor: pointer;
+  transition: color 0.15s ease;
+
+  &:hover {
+    color: var(--el-color-primary);
+  }
+}
+
+.cb-restore-code {
+  height: auto;
+
+  :deep(.el-checkbox__label) {
+    font-size: 12px;
   }
 }
 

--- a/src/components/codingBridge/TranscriptItem.vue
+++ b/src/components/codingBridge/TranscriptItem.vue
@@ -2,9 +2,10 @@
   <div class="transcript-item text-sm leading-relaxed" :class="`kind-${event.kind}`">
     <!-- User prompt -->
     <div v-if="event.kind === 'prompt'" class="group flex items-end justify-end gap-1.5">
-      <!-- Edit: reload this prompt (text + attachments) into the composer to
-           tweak and resend as a new turn; model can be switched there too. -->
+      <!-- Edit: reload this prompt into the composer; on send the conversation
+           is rewound to this turn. Only shown when the backend supports it. -->
       <button
+        v-if="editable"
         type="button"
         class="cb-edit-btn opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
         :title="$t('codingBridge.session.editPrompt')"
@@ -170,6 +171,11 @@ export default defineComponent({
     event: {
       type: Object as PropType<ICodingBridgeEvent>,
       required: true
+    },
+    // Whether this prompt can be edited (backend supports conversation rewind).
+    editable: {
+      type: Boolean,
+      default: false
     }
   },
   emits: ['edit'],

--- a/src/constants/codingBridge.ts
+++ b/src/constants/codingBridge.ts
@@ -18,6 +18,8 @@ export const CB_ERROR = 'error';
 // --- Inner actions: browser -> node ----------------------------------------
 export const CB_ACTION_SESSION_START = 'session.start';
 export const CB_ACTION_SESSION_SEND = 'session.send';
+// Edit a past prompt: fork the conversation at `cut_uuid` and re-run it.
+export const CB_ACTION_SESSION_EDIT = 'session.edit';
 export const CB_ACTION_SESSION_INTERRUPT = 'session.interrupt';
 export const CB_ACTION_SESSION_CLOSE = 'session.close';
 export const CB_ACTION_PERMISSION_RESOLVE = 'permission.resolve';

--- a/src/i18n/ar/codingBridge.json
+++ b/src/i18n/ar/codingBridge.json
@@ -171,6 +171,22 @@
     "message": "Edit",
     "description": "Edit a sent prompt and resend it as a new turn"
   },
+  "session.editingBanner": {
+    "message": "Editing — sending rewinds the conversation to this point.",
+    "description": "Banner shown while editing a past prompt"
+  },
+  "session.editRestoreCode": {
+    "message": "Also restore code",
+    "description": "Checkbox to also roll back file changes when editing"
+  },
+  "session.editCancel": {
+    "message": "Cancel",
+    "description": "Cancel editing a past prompt"
+  },
+  "session.editSubmit": {
+    "message": "Update",
+    "description": "Submit an edited prompt (rewind and re-run)"
+  },
   "session.enterHint": {
     "message": "Enter to send, Shift+Enter for a new line.",
     "description": "Composer keyboard hint"

--- a/src/i18n/de/codingBridge.json
+++ b/src/i18n/de/codingBridge.json
@@ -171,6 +171,22 @@
     "message": "Edit",
     "description": "Edit a sent prompt and resend it as a new turn"
   },
+  "session.editingBanner": {
+    "message": "Editing — sending rewinds the conversation to this point.",
+    "description": "Banner shown while editing a past prompt"
+  },
+  "session.editRestoreCode": {
+    "message": "Also restore code",
+    "description": "Checkbox to also roll back file changes when editing"
+  },
+  "session.editCancel": {
+    "message": "Cancel",
+    "description": "Cancel editing a past prompt"
+  },
+  "session.editSubmit": {
+    "message": "Update",
+    "description": "Submit an edited prompt (rewind and re-run)"
+  },
   "session.enterHint": {
     "message": "Enter to send, Shift+Enter for a new line.",
     "description": "Composer keyboard hint"

--- a/src/i18n/el/codingBridge.json
+++ b/src/i18n/el/codingBridge.json
@@ -171,6 +171,22 @@
     "message": "Edit",
     "description": "Edit a sent prompt and resend it as a new turn"
   },
+  "session.editingBanner": {
+    "message": "Editing — sending rewinds the conversation to this point.",
+    "description": "Banner shown while editing a past prompt"
+  },
+  "session.editRestoreCode": {
+    "message": "Also restore code",
+    "description": "Checkbox to also roll back file changes when editing"
+  },
+  "session.editCancel": {
+    "message": "Cancel",
+    "description": "Cancel editing a past prompt"
+  },
+  "session.editSubmit": {
+    "message": "Update",
+    "description": "Submit an edited prompt (rewind and re-run)"
+  },
   "session.enterHint": {
     "message": "Enter to send, Shift+Enter for a new line.",
     "description": "Composer keyboard hint"

--- a/src/i18n/en/codingBridge.json
+++ b/src/i18n/en/codingBridge.json
@@ -171,6 +171,22 @@
     "message": "Edit",
     "description": "Edit a sent prompt and resend it as a new turn"
   },
+  "session.editingBanner": {
+    "message": "Editing — sending rewinds the conversation to this point.",
+    "description": "Banner shown while editing a past prompt"
+  },
+  "session.editRestoreCode": {
+    "message": "Also restore code",
+    "description": "Checkbox to also roll back file changes when editing"
+  },
+  "session.editCancel": {
+    "message": "Cancel",
+    "description": "Cancel editing a past prompt"
+  },
+  "session.editSubmit": {
+    "message": "Update",
+    "description": "Submit an edited prompt (rewind and re-run)"
+  },
   "session.enterHint": {
     "message": "Enter to send, Shift+Enter for a new line.",
     "description": "Composer keyboard hint"

--- a/src/i18n/es/codingBridge.json
+++ b/src/i18n/es/codingBridge.json
@@ -171,6 +171,22 @@
     "message": "Edit",
     "description": "Edit a sent prompt and resend it as a new turn"
   },
+  "session.editingBanner": {
+    "message": "Editing — sending rewinds the conversation to this point.",
+    "description": "Banner shown while editing a past prompt"
+  },
+  "session.editRestoreCode": {
+    "message": "Also restore code",
+    "description": "Checkbox to also roll back file changes when editing"
+  },
+  "session.editCancel": {
+    "message": "Cancel",
+    "description": "Cancel editing a past prompt"
+  },
+  "session.editSubmit": {
+    "message": "Update",
+    "description": "Submit an edited prompt (rewind and re-run)"
+  },
   "session.enterHint": {
     "message": "Enter to send, Shift+Enter for a new line.",
     "description": "Composer keyboard hint"

--- a/src/i18n/fi/codingBridge.json
+++ b/src/i18n/fi/codingBridge.json
@@ -171,6 +171,22 @@
     "message": "Edit",
     "description": "Edit a sent prompt and resend it as a new turn"
   },
+  "session.editingBanner": {
+    "message": "Editing — sending rewinds the conversation to this point.",
+    "description": "Banner shown while editing a past prompt"
+  },
+  "session.editRestoreCode": {
+    "message": "Also restore code",
+    "description": "Checkbox to also roll back file changes when editing"
+  },
+  "session.editCancel": {
+    "message": "Cancel",
+    "description": "Cancel editing a past prompt"
+  },
+  "session.editSubmit": {
+    "message": "Update",
+    "description": "Submit an edited prompt (rewind and re-run)"
+  },
   "session.enterHint": {
     "message": "Enter to send, Shift+Enter for a new line.",
     "description": "Composer keyboard hint"

--- a/src/i18n/fr/codingBridge.json
+++ b/src/i18n/fr/codingBridge.json
@@ -171,6 +171,22 @@
     "message": "Edit",
     "description": "Edit a sent prompt and resend it as a new turn"
   },
+  "session.editingBanner": {
+    "message": "Editing — sending rewinds the conversation to this point.",
+    "description": "Banner shown while editing a past prompt"
+  },
+  "session.editRestoreCode": {
+    "message": "Also restore code",
+    "description": "Checkbox to also roll back file changes when editing"
+  },
+  "session.editCancel": {
+    "message": "Cancel",
+    "description": "Cancel editing a past prompt"
+  },
+  "session.editSubmit": {
+    "message": "Update",
+    "description": "Submit an edited prompt (rewind and re-run)"
+  },
   "session.enterHint": {
     "message": "Enter to send, Shift+Enter for a new line.",
     "description": "Composer keyboard hint"

--- a/src/i18n/it/codingBridge.json
+++ b/src/i18n/it/codingBridge.json
@@ -171,6 +171,22 @@
     "message": "Edit",
     "description": "Edit a sent prompt and resend it as a new turn"
   },
+  "session.editingBanner": {
+    "message": "Editing — sending rewinds the conversation to this point.",
+    "description": "Banner shown while editing a past prompt"
+  },
+  "session.editRestoreCode": {
+    "message": "Also restore code",
+    "description": "Checkbox to also roll back file changes when editing"
+  },
+  "session.editCancel": {
+    "message": "Cancel",
+    "description": "Cancel editing a past prompt"
+  },
+  "session.editSubmit": {
+    "message": "Update",
+    "description": "Submit an edited prompt (rewind and re-run)"
+  },
   "session.enterHint": {
     "message": "Enter to send, Shift+Enter for a new line.",
     "description": "Composer keyboard hint"

--- a/src/i18n/ja/codingBridge.json
+++ b/src/i18n/ja/codingBridge.json
@@ -171,6 +171,22 @@
     "message": "Edit",
     "description": "Edit a sent prompt and resend it as a new turn"
   },
+  "session.editingBanner": {
+    "message": "Editing — sending rewinds the conversation to this point.",
+    "description": "Banner shown while editing a past prompt"
+  },
+  "session.editRestoreCode": {
+    "message": "Also restore code",
+    "description": "Checkbox to also roll back file changes when editing"
+  },
+  "session.editCancel": {
+    "message": "Cancel",
+    "description": "Cancel editing a past prompt"
+  },
+  "session.editSubmit": {
+    "message": "Update",
+    "description": "Submit an edited prompt (rewind and re-run)"
+  },
   "session.enterHint": {
     "message": "Enter to send, Shift+Enter for a new line.",
     "description": "Composer keyboard hint"

--- a/src/i18n/ko/codingBridge.json
+++ b/src/i18n/ko/codingBridge.json
@@ -171,6 +171,22 @@
     "message": "Edit",
     "description": "Edit a sent prompt and resend it as a new turn"
   },
+  "session.editingBanner": {
+    "message": "Editing — sending rewinds the conversation to this point.",
+    "description": "Banner shown while editing a past prompt"
+  },
+  "session.editRestoreCode": {
+    "message": "Also restore code",
+    "description": "Checkbox to also roll back file changes when editing"
+  },
+  "session.editCancel": {
+    "message": "Cancel",
+    "description": "Cancel editing a past prompt"
+  },
+  "session.editSubmit": {
+    "message": "Update",
+    "description": "Submit an edited prompt (rewind and re-run)"
+  },
   "session.enterHint": {
     "message": "Enter to send, Shift+Enter for a new line.",
     "description": "Composer keyboard hint"

--- a/src/i18n/pl/codingBridge.json
+++ b/src/i18n/pl/codingBridge.json
@@ -171,6 +171,22 @@
     "message": "Edit",
     "description": "Edit a sent prompt and resend it as a new turn"
   },
+  "session.editingBanner": {
+    "message": "Editing — sending rewinds the conversation to this point.",
+    "description": "Banner shown while editing a past prompt"
+  },
+  "session.editRestoreCode": {
+    "message": "Also restore code",
+    "description": "Checkbox to also roll back file changes when editing"
+  },
+  "session.editCancel": {
+    "message": "Cancel",
+    "description": "Cancel editing a past prompt"
+  },
+  "session.editSubmit": {
+    "message": "Update",
+    "description": "Submit an edited prompt (rewind and re-run)"
+  },
   "session.enterHint": {
     "message": "Enter to send, Shift+Enter for a new line.",
     "description": "Composer keyboard hint"

--- a/src/i18n/pt/codingBridge.json
+++ b/src/i18n/pt/codingBridge.json
@@ -171,6 +171,22 @@
     "message": "Edit",
     "description": "Edit a sent prompt and resend it as a new turn"
   },
+  "session.editingBanner": {
+    "message": "Editing — sending rewinds the conversation to this point.",
+    "description": "Banner shown while editing a past prompt"
+  },
+  "session.editRestoreCode": {
+    "message": "Also restore code",
+    "description": "Checkbox to also roll back file changes when editing"
+  },
+  "session.editCancel": {
+    "message": "Cancel",
+    "description": "Cancel editing a past prompt"
+  },
+  "session.editSubmit": {
+    "message": "Update",
+    "description": "Submit an edited prompt (rewind and re-run)"
+  },
   "session.enterHint": {
     "message": "Enter to send, Shift+Enter for a new line.",
     "description": "Composer keyboard hint"

--- a/src/i18n/ru/codingBridge.json
+++ b/src/i18n/ru/codingBridge.json
@@ -171,6 +171,22 @@
     "message": "Edit",
     "description": "Edit a sent prompt and resend it as a new turn"
   },
+  "session.editingBanner": {
+    "message": "Editing — sending rewinds the conversation to this point.",
+    "description": "Banner shown while editing a past prompt"
+  },
+  "session.editRestoreCode": {
+    "message": "Also restore code",
+    "description": "Checkbox to also roll back file changes when editing"
+  },
+  "session.editCancel": {
+    "message": "Cancel",
+    "description": "Cancel editing a past prompt"
+  },
+  "session.editSubmit": {
+    "message": "Update",
+    "description": "Submit an edited prompt (rewind and re-run)"
+  },
   "session.enterHint": {
     "message": "Enter to send, Shift+Enter for a new line.",
     "description": "Composer keyboard hint"

--- a/src/i18n/sr/codingBridge.json
+++ b/src/i18n/sr/codingBridge.json
@@ -171,6 +171,22 @@
     "message": "Edit",
     "description": "Edit a sent prompt and resend it as a new turn"
   },
+  "session.editingBanner": {
+    "message": "Editing — sending rewinds the conversation to this point.",
+    "description": "Banner shown while editing a past prompt"
+  },
+  "session.editRestoreCode": {
+    "message": "Also restore code",
+    "description": "Checkbox to also roll back file changes when editing"
+  },
+  "session.editCancel": {
+    "message": "Cancel",
+    "description": "Cancel editing a past prompt"
+  },
+  "session.editSubmit": {
+    "message": "Update",
+    "description": "Submit an edited prompt (rewind and re-run)"
+  },
   "session.enterHint": {
     "message": "Enter to send, Shift+Enter for a new line.",
     "description": "Composer keyboard hint"

--- a/src/i18n/sv/codingBridge.json
+++ b/src/i18n/sv/codingBridge.json
@@ -171,6 +171,22 @@
     "message": "Edit",
     "description": "Edit a sent prompt and resend it as a new turn"
   },
+  "session.editingBanner": {
+    "message": "Editing — sending rewinds the conversation to this point.",
+    "description": "Banner shown while editing a past prompt"
+  },
+  "session.editRestoreCode": {
+    "message": "Also restore code",
+    "description": "Checkbox to also roll back file changes when editing"
+  },
+  "session.editCancel": {
+    "message": "Cancel",
+    "description": "Cancel editing a past prompt"
+  },
+  "session.editSubmit": {
+    "message": "Update",
+    "description": "Submit an edited prompt (rewind and re-run)"
+  },
   "session.enterHint": {
     "message": "Enter to send, Shift+Enter for a new line.",
     "description": "Composer keyboard hint"

--- a/src/i18n/uk/codingBridge.json
+++ b/src/i18n/uk/codingBridge.json
@@ -171,6 +171,22 @@
     "message": "Edit",
     "description": "Edit a sent prompt and resend it as a new turn"
   },
+  "session.editingBanner": {
+    "message": "Editing — sending rewinds the conversation to this point.",
+    "description": "Banner shown while editing a past prompt"
+  },
+  "session.editRestoreCode": {
+    "message": "Also restore code",
+    "description": "Checkbox to also roll back file changes when editing"
+  },
+  "session.editCancel": {
+    "message": "Cancel",
+    "description": "Cancel editing a past prompt"
+  },
+  "session.editSubmit": {
+    "message": "Update",
+    "description": "Submit an edited prompt (rewind and re-run)"
+  },
   "session.enterHint": {
     "message": "Enter to send, Shift+Enter for a new line.",
     "description": "Composer keyboard hint"

--- a/src/i18n/zh-CN/codingBridge.json
+++ b/src/i18n/zh-CN/codingBridge.json
@@ -171,6 +171,22 @@
     "message": "编辑",
     "description": "编辑已发送的提示词并作为新一轮重新发送"
   },
+  "session.editingBanner": {
+    "message": "编辑中 — 发送将把对话回退到此处",
+    "description": "Banner shown while editing a past prompt"
+  },
+  "session.editRestoreCode": {
+    "message": "同时回退代码",
+    "description": "Checkbox to also roll back file changes when editing"
+  },
+  "session.editCancel": {
+    "message": "取消",
+    "description": "Cancel editing a past prompt"
+  },
+  "session.editSubmit": {
+    "message": "更新",
+    "description": "Submit an edited prompt (rewind and re-run)"
+  },
   "session.enterHint": {
     "message": "回车发送，Shift+回车换行。",
     "description": "输入框键盘提示"

--- a/src/i18n/zh-TW/codingBridge.json
+++ b/src/i18n/zh-TW/codingBridge.json
@@ -171,6 +171,22 @@
     "message": "Edit",
     "description": "Edit a sent prompt and resend it as a new turn"
   },
+  "session.editingBanner": {
+    "message": "Editing — sending rewinds the conversation to this point.",
+    "description": "Banner shown while editing a past prompt"
+  },
+  "session.editRestoreCode": {
+    "message": "Also restore code",
+    "description": "Checkbox to also roll back file changes when editing"
+  },
+  "session.editCancel": {
+    "message": "Cancel",
+    "description": "Cancel editing a past prompt"
+  },
+  "session.editSubmit": {
+    "message": "Update",
+    "description": "Submit an edited prompt (rewind and re-run)"
+  },
   "session.enterHint": {
     "message": "Enter 傳送，Shift+Enter 換行。",
     "description": "輸入框鍵盤提示"

--- a/src/models/codingBridge.ts
+++ b/src/models/codingBridge.ts
@@ -51,6 +51,12 @@ export interface ICodingBridgeProviderCapability {
   efforts: string[];
   permission_modes: string[];
   allow_custom_model: boolean;
+  // Whether a past prompt can be edited (the conversation forked at that turn).
+  // Claude supports it; Codex does not. Absent on older nodes → treat as false.
+  supports_edit?: boolean;
+  // Whether editing can also roll back on-disk file changes, so the UI can
+  // offer a "restore code" choice. Absent on older nodes → treat as false.
+  supports_code_restore?: boolean;
   // Slash commands this backend can actually run in a remote session, used to
   // drive the composer autocomplete. Absent on older nodes.
   commands?: ICodingBridgeSlashCommand[];
@@ -81,6 +87,9 @@ export interface ICodingBridgeSession {
   provider?: ICodingBridgeHistoryProvider;
   // Provider session id to resume when the first prompt is sent (Claude only).
   resume_session_id?: string;
+  // The SDK/CLI's own session id for a live session, reported by the node on
+  // each turn's result. The fork target when editing a past prompt.
+  sdk_session_id?: string;
   // A live turn has been started on the node for this session.
   started?: boolean;
   // Replay of past history that cannot be continued (e.g. Codex).
@@ -140,6 +149,10 @@ export interface ICodingBridgeEvent {
   is_error?: boolean;
   subtype?: string;
   cost_usd?: number;
+  // Result events only: the fork point for editing the NEXT prompt — the uuid
+  // of the last kept transcript message — and the session to resume from.
+  cut_uuid?: string;
+  sdk_session_id?: string;
   // Notice events: a machine code (e.g. 'slash_unavailable') and the command
   // the user typed, so the UI can render a localized message.
   command?: string;

--- a/src/store/codingBridge/actions.ts
+++ b/src/store/codingBridge/actions.ts
@@ -13,6 +13,7 @@ import { CodingBridgeSocket } from '@/utils/codingBridgeSocket';
 import {
   CB_ACTION_SESSION_START,
   CB_ACTION_SESSION_SEND,
+  CB_ACTION_SESSION_EDIT,
   CB_ACTION_SESSION_INTERRUPT,
   CB_ACTION_SESSION_CLOSE,
   CB_ACTION_PERMISSION_RESOLVE,
@@ -195,10 +196,19 @@ const applyNodeEvent = (
           is_error: payload.is_error,
           text: payload.result,
           cost_usd: payload.cost_usd,
+          // Fork point for editing the next prompt (Claude reports these).
+          cut_uuid: payload.cut_uuid,
+          sdk_session_id: payload.sdk_session_id,
           trace_id: traceId
         })
       );
-      commit('updateSession', { session_id: sessionId, status: 'idle', cost_usd: payload.cost_usd });
+      commit('updateSession', {
+        session_id: sessionId,
+        status: 'idle',
+        cost_usd: payload.cost_usd,
+        // Keep the live SDK session id current so an edit can fork from it.
+        ...(payload.sdk_session_id ? { sdk_session_id: payload.sdk_session_id } : {})
+      });
       break;
     case CB_EVENT_SESSION_NOTICE:
       // A friendly heads-up (e.g. a slash command that can't run remotely).
@@ -552,6 +562,73 @@ export const sendPrompt = (
   }
 };
 
+// Edit a past prompt: fork the conversation at that turn instead of appending.
+// The visible transcript is rewound to before the edited prompt and the node is
+// asked to truncate the agent's context to the same point, so the original
+// (wrong) prompt and everything after it leave the model's context entirely.
+export const editPrompt = (
+  { commit, state }: ActionContext<ICodingBridgeState, IRootState>,
+  payload: {
+    eventId: string;
+    prompt: string;
+    model?: string;
+    permissionMode?: string;
+    effort?: string;
+    images?: string[];
+    attachments?: ICodingBridgeAttachment[];
+    restoreCode?: boolean;
+  }
+): void => {
+  const nodeId = state.currentNodeId;
+  const sessionId = state.currentSessionId;
+  const prompt = payload.prompt?.trim();
+  if (!nodeId || !sessionId || !socket || !prompt) {
+    return;
+  }
+  const session = state.sessions[sessionId];
+  const events = state.events[sessionId] ?? [];
+  const index = events.findIndex((event) => event.id === payload.eventId);
+  if (!session || index < 0) {
+    return;
+  }
+  // Fork point: the cut_uuid of the last result before the edited prompt (the
+  // end of the previous turn). None → editing the first prompt, so the node
+  // starts a fresh session rather than forking.
+  let cutUuid: string | undefined;
+  for (let i = index - 1; i >= 0; i--) {
+    if (events[i].kind === 'result' && events[i].cut_uuid) {
+      cutUuid = events[i].cut_uuid;
+      break;
+    }
+  }
+  const images = payload.images?.length ? payload.images : undefined;
+  const attachments = payload.attachments?.length ? payload.attachments : undefined;
+  const traceId = uid();
+  // Rewind the visible transcript, then echo the edited prompt as the new turn.
+  commit('truncateEventsBefore', { session_id: sessionId, event_id: payload.eventId });
+  commit('updateSession', {
+    session_id: sessionId,
+    status: 'running',
+    trace_id: traceId,
+    model: payload.model || session.model || undefined
+  });
+  commit('appendEvent', makeEvent(sessionId, 'prompt', { text: prompt, images, attachments, trace_id: traceId }));
+  socket.sendToNode(nodeId, {
+    action: CB_ACTION_SESSION_EDIT,
+    session_id: sessionId,
+    trace_id: traceId,
+    cut_uuid: cutUuid,
+    prompt,
+    // Sent verbatim so an empty value keeps the node's default model.
+    model: payload.model || session.model || undefined,
+    permission_mode: payload.permissionMode || undefined,
+    effort: payload.effort || undefined,
+    images,
+    attachments,
+    restore_code: !!payload.restoreCode
+  });
+};
+
 // Re-run the most recent user prompt after a turn failed. We force a fresh
 // start (clear `started`) so the node re-spawns the agent — the common failure
 // is the agent process crashing before the session is really alive on the node.
@@ -704,6 +781,7 @@ export default {
   selectNode,
   newSession,
   sendPrompt,
+  editPrompt,
   retryLastPrompt,
   interruptSession,
   closeSession,

--- a/src/store/codingBridge/mutations.test.ts
+++ b/src/store/codingBridge/mutations.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from 'vitest';
 import createState from './state';
-import { appendDelta, appendEvent, finalizeAllStreams, finalizeStream } from './mutations';
+import { appendDelta, appendEvent, finalizeAllStreams, finalizeStream, truncateEventsBefore } from './mutations';
 import type { ICodingBridgeEvent } from '@/models';
 
 const textEvent = (overrides: Partial<ICodingBridgeEvent> = {}): ICodingBridgeEvent => ({
@@ -57,5 +57,21 @@ describe('coding bridge streaming mutations', () => {
     appendEvent(state, textEvent({ id: 'c', text: 'plain' }));
     finalizeAllStreams(state, { session_id: 's1' });
     expect(state.events['s1'].map((item) => item.streaming)).toEqual([false, false, undefined]);
+  });
+
+  it('truncateEventsBefore drops the event and everything after it', () => {
+    const state = createState();
+    appendEvent(state, textEvent({ id: 'a' }));
+    appendEvent(state, textEvent({ id: 'b', kind: 'prompt' }));
+    appendEvent(state, textEvent({ id: 'c' }));
+    truncateEventsBefore(state, { session_id: 's1', event_id: 'b' });
+    expect(state.events['s1'].map((item) => item.id)).toEqual(['a']);
+  });
+
+  it('truncateEventsBefore is a no-op for an unknown event id', () => {
+    const state = createState();
+    appendEvent(state, textEvent({ id: 'a' }));
+    truncateEventsBefore(state, { session_id: 's1', event_id: 'missing' });
+    expect(state.events['s1'].map((item) => item.id)).toEqual(['a']);
   });
 });

--- a/src/store/codingBridge/mutations.ts
+++ b/src/store/codingBridge/mutations.ts
@@ -86,6 +86,23 @@ export const appendEvent = (state: ICodingBridgeState, payload: ICodingBridgeEve
   state.events[payload.session_id].push(payload);
 };
 
+// Drop the event with `event_id` and everything after it. Used when editing a
+// past prompt: the transcript is rewound to before that prompt so the UI
+// mirrors the conversation fork the node performs.
+export const truncateEventsBefore = (
+  state: ICodingBridgeState,
+  payload: { session_id: string; event_id: string }
+): void => {
+  const events = state.events[payload.session_id];
+  if (!events) {
+    return;
+  }
+  const index = events.findIndex((event) => event.id === payload.event_id);
+  if (index >= 0) {
+    state.events[payload.session_id] = events.slice(0, index);
+  }
+};
+
 // Streaming: append an incremental text chunk onto the open bubble matching
 // `stream_id`. No-op if the bubble was already finalized or never created.
 export const appendDelta = (
@@ -219,6 +236,7 @@ export default {
   upsertSession,
   updateSession,
   appendEvent,
+  truncateEventsBefore,
   appendDelta,
   finalizeStream,
   finalizeAllStreams,


### PR DESCRIPTION
## Why

#907 implemented prompt editing as **append** (a new turn). That's the wrong semantics — the mistaken prompt and everything after it stay in the agent's context. The correct behavior, **benchmarked against Claude Code's own rewind**, is to truncate the conversation at that turn and re-run it, dropping the bad branch. This PR replaces the append behavior with a real **rewind/fork**.

Pairs with the node side: **AceDataCloud/CodingBridgeAgent#18** (already CI-green), which forks the Claude session with `--fork-session --resume-session-at <uuid>`.

## How it works

- The node reports a **fork point** (`cut_uuid`) + `sdk_session_id` on each turn's `session.result`. The store records these on the result event and the session.
- Clicking ✏️ on a prompt enters **edit mode**: the prompt's text/attachments reload into the composer (model is switchable as usual).
- On **send** while editing, `editPrompt`:
  1. `truncateEventsBefore` — rewinds the visible transcript to before the edited prompt;
  2. echoes the edited prompt as the new turn;
  3. sends `session.edit` to the node with `cut_uuid` = the previous turn's reported fork point (none → editing the first prompt → fresh session).
- The node forks the conversation at `cut_uuid`, so the original (wrong) prompt and everything after it leave the model's context. The original session stays intact (fork).

## UX

- Edit is **gated by the backend's `supports_edit`** capability — shown for Claude, hidden for Codex (Codex has no rewind primitive; see #18).
- An editing banner explains "sending rewinds the conversation to this point", with a **Cancel** and, when the backend supports it, an **Also restore code** checkbox (rolls the working tree back via the node's `rewind_files`). Send button becomes **Update**.

## Changes

- `constants`/`models` — `session.edit` action; `cut_uuid` + `sdk_session_id` on results; `supports_edit`/`supports_code_restore` capability flags
- `store` — `editPrompt` action, `truncateEventsBefore` mutation, fork-id capture
- `SessionView.vue` — edit mode + banner + restore-code, gated by `canEdit`
- `TranscriptItem.vue` — edit button shown only when `editable`
- i18n — 4 new keys (zh-CN + en localized; others English placeholder)
- tests — `truncateEventsBefore` (vitest)

## Verification

Type-check + eslint clean; vitest store tests pass. **End-to-end (real Claude node fork/replay) needs a paired device + Claude login** — to validate alongside #18 before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)