### PR TITLE
feat(coding-bridge): resume the live stream on reconnect, no history refresh (Phase 3)

### DIFF
--- a/src/constants/codingBridge.ts
+++ b/src/constants/codingBridge.ts
@@ -45,6 +45,12 @@ export const CB_EVENT_SESSION_RESULT = 'session.result';
 export const CB_EVENT_SESSION_NOTICE = 'session.notice';
 export const CB_EVENT_SESSION_ERROR = 'session.error';
 export const CB_EVENT_SESSION_CLOSED = 'session.closed';
+// A past prompt was edited: the conversation forked at `cut_uuid`. The browser
+// folds this into a transcript truncation (rewind), live and on replay.
+export const CB_EVENT_SESSION_REWOUND = 'session.rewound';
+// The live stream lost events that could not be replayed (cursor too old /
+// outbox overflow); resync the session from history.
+export const CB_EVENT_SESSION_STREAM_TRUNCATED = 'session.stream_truncated';
 export const CB_EVENT_SESSIONS_SNAPSHOT = 'sessions.snapshot';
 export const CB_EVENT_HISTORY_SNAPSHOT = 'history.snapshot';
 export const CB_EVENT_HISTORY_DETAIL = 'history.detail';

--- a/src/constants/codingBridge.ts
+++ b/src/constants/codingBridge.ts
@@ -10,6 +10,8 @@
 // --- Outer envelope types (relay) ------------------------------------------
 export const CB_BROWSER_TO_NODE = 'browser.to_node';
 export const CB_BROWSER_LIST_NODES = 'browser.list_nodes';
+// Reconnect: ask the relay to replay each session's events past a cursor.
+export const CB_BROWSER_RESUME = 'browser.resume';
 export const CB_NODE_TO_BROWSER = 'node.to_browser';
 export const CB_NODES_SNAPSHOT = 'nodes.snapshot';
 export const CB_NODE_STATUS = 'node.status';

--- a/src/store/codingBridge/actions.ts
+++ b/src/store/codingBridge/actions.ts
@@ -33,6 +33,8 @@ import {
   CB_EVENT_SESSION_NOTICE,
   CB_EVENT_SESSION_ERROR,
   CB_EVENT_SESSION_CLOSED,
+  CB_EVENT_SESSION_REWOUND,
+  CB_EVENT_SESSION_STREAM_TRUNCATED,
   CB_EVENT_SESSIONS_SNAPSHOT,
   CB_EVENT_HISTORY_SNAPSHOT,
   CB_EVENT_HISTORY_DETAIL,
@@ -97,6 +99,17 @@ const applyNodeEvent = (
   const event = payload?.event;
   const sessionId = payload?.session_id;
   const traceId = payload?.trace_id;
+  // Reliable delivery: durable events carry a monotonic relay-assigned `seq`.
+  // Drop any we have already applied (replay/live overlap on reconnect) and
+  // advance the cursor used to resume after the next disconnect.
+  const seq = payload?.seq;
+  if (typeof seq === 'number' && sessionId) {
+    const last = state.lastSeq[sessionId];
+    if (last !== undefined && seq <= last) {
+      return;
+    }
+    commit('setLastSeq', { session_id: sessionId, seq });
+  }
   // Keep the session's trace id current with whatever turn the node is on.
   if (sessionId && traceId) {
     commit('updateSession', { session_id: sessionId, trace_id: traceId });
@@ -231,6 +244,24 @@ const applyNodeEvent = (
     case CB_EVENT_SESSION_CLOSED:
       commit('finalizeAllStreams', { session_id: sessionId });
       commit('updateSession', { session_id: sessionId, status: 'closed' });
+      break;
+    case CB_EVENT_SESSION_REWOUND:
+      // A past prompt was edited: fold the fork into the transcript by rewinding
+      // to the cut point, then re-echo the edited prompt. Authoritative and
+      // deterministic, so a reconnect replay rebuilds the right branch (the live
+      // path already did this optimistically in editPrompt; re-applying is a
+      // no-op that yields the same state).
+      commit('rewindToCut', { session_id: sessionId, cut_uuid: payload.cut_uuid });
+      if (payload.prompt) {
+        commit('appendEvent', makeEvent(sessionId, 'prompt', { text: payload.prompt, trace_id: traceId }));
+      }
+      commit('updateSession', { session_id: sessionId, status: 'running' });
+      break;
+    case CB_EVENT_SESSION_STREAM_TRUNCATED:
+      // The live stream lost events neither relay nor node could retain (cursor
+      // too old / outbox overflow). Resync the session from the device transcript
+      // rather than trust the cursor — never a silent gap.
+      dispatch('resyncSession', sessionId);
       break;
     case CB_EVENT_SESSIONS_SNAPSHOT:
       for (const item of payload.sessions ?? []) {
@@ -417,6 +448,14 @@ export const connect = ({
   socket = new CodingBridgeSocket(token, {
     onOpen: () => {
       commit('setConnection', 'connected');
+      // Reconnect: resume each session's live stream from the seq we last saw,
+      // so in-flight output is replayed instead of lost. Empty after a full page
+      // reload (lastSeq is in-memory) — there the history restore below rebuilds
+      // the transcript instead.
+      const cursors = { ...state.lastSeq };
+      if (Object.keys(cursors).length) {
+        socket?.resume(cursors);
+      }
       if (state.currentNodeId) {
         dispatch('getHistory', state.currentNodeId);
         dispatch('getCapabilities', state.currentNodeId);
@@ -745,6 +784,25 @@ export const getHistoryDetail = (
   });
 };
 
+// Resync a live session from the device transcript after the live stream lost
+// events it could not replay (stream_truncated). Pulls the full history detail,
+// which replaces the session's events; later live events (higher seq) still
+// apply, so the stream picks back up cleanly.
+export const resyncSession = (
+  { state, dispatch }: ActionContext<ICodingBridgeState, IRootState>,
+  sessionId: string
+): void => {
+  const session = state.sessions[sessionId];
+  if (!session?.node_id) {
+    return;
+  }
+  dispatch('getHistoryDetail', {
+    node_id: session.node_id,
+    session_id: sessionId,
+    provider: session.provider ?? 'claude'
+  });
+};
+
 // Ask the current node to list a directory for the working-directory picker.
 export const browseDir = ({ commit, state }: ActionContext<ICodingBridgeState, IRootState>, path?: string): void => {
   const nodeId = state.currentNodeId;
@@ -789,6 +847,7 @@ export default {
   answerQuestion,
   getHistory,
   getHistoryDetail,
+  resyncSession,
   browseDir,
   clearDirectory,
   getCapabilities

--- a/src/store/codingBridge/models.ts
+++ b/src/store/codingBridge/models.ts
@@ -24,6 +24,10 @@ export interface ICodingBridgeState {
   currentSessionId: string | undefined;
   sessions: Record<string, ICodingBridgeSession>;
   events: Record<string, ICodingBridgeEvent[]>;
+  // Highest relay-assigned event `seq` applied per session. Drives reconnect
+  // replay (resume_from) and dedups overlapping events. In-memory only: a full
+  // reload rebuilds the transcript from history instead of a seq cursor.
+  lastSeq: Record<string, number>;
   // Past on-device sessions per node, sourced live from `history.list`.
   history: Record<string, ICodingBridgeHistorySummary[]>;
   // What each node can do (providers/models/efforts), from `capabilities.get`.

--- a/src/store/codingBridge/mutations.test.ts
+++ b/src/store/codingBridge/mutations.test.ts
@@ -1,7 +1,15 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from 'vitest';
 import createState from './state';
-import { appendDelta, appendEvent, finalizeAllStreams, finalizeStream, truncateEventsBefore } from './mutations';
+import {
+  appendDelta,
+  appendEvent,
+  finalizeAllStreams,
+  finalizeStream,
+  rewindToCut,
+  setLastSeq,
+  truncateEventsBefore
+} from './mutations';
 import type { ICodingBridgeEvent } from '@/models';
 
 const textEvent = (overrides: Partial<ICodingBridgeEvent> = {}): ICodingBridgeEvent => ({
@@ -73,5 +81,42 @@ describe('coding bridge streaming mutations', () => {
     appendEvent(state, textEvent({ id: 'a' }));
     truncateEventsBefore(state, { session_id: 's1', event_id: 'missing' });
     expect(state.events['s1'].map((item) => item.id)).toEqual(['a']);
+  });
+});
+
+describe('coding bridge reliable-delivery mutations', () => {
+  it('rewindToCut keeps the transcript up to and including the matching result', () => {
+    const state = createState();
+    appendEvent(state, textEvent({ id: 'a', kind: 'prompt' }));
+    appendEvent(state, textEvent({ id: 'b', kind: 'result', cut_uuid: 'u1' }));
+    appendEvent(state, textEvent({ id: 'c', kind: 'prompt' }));
+    appendEvent(state, textEvent({ id: 'd', kind: 'text' }));
+    rewindToCut(state, { session_id: 's1', cut_uuid: 'u1' });
+    expect(state.events['s1'].map((item) => item.id)).toEqual(['a', 'b']);
+  });
+
+  it('rewindToCut clears the whole transcript when there is no cut point', () => {
+    const state = createState();
+    appendEvent(state, textEvent({ id: 'a', kind: 'prompt' }));
+    appendEvent(state, textEvent({ id: 'b', kind: 'text' }));
+    rewindToCut(state, { session_id: 's1', cut_uuid: undefined });
+    expect(state.events['s1']).toEqual([]);
+  });
+
+  it('rewindToCut is a no-op when the cut uuid is not found', () => {
+    const state = createState();
+    appendEvent(state, textEvent({ id: 'a', kind: 'result', cut_uuid: 'u1' }));
+    rewindToCut(state, { session_id: 's1', cut_uuid: 'missing' });
+    expect(state.events['s1'].map((item) => item.id)).toEqual(['a']);
+  });
+
+  it('setLastSeq advances the cursor monotonically and ignores stale seqs', () => {
+    const state = createState();
+    setLastSeq(state, { session_id: 's1', seq: 5 });
+    expect(state.lastSeq['s1']).toBe(5);
+    setLastSeq(state, { session_id: 's1', seq: 3 });
+    expect(state.lastSeq['s1']).toBe(5);
+    setLastSeq(state, { session_id: 's1', seq: 9 });
+    expect(state.lastSeq['s1']).toBe(9);
   });
 });

--- a/src/store/codingBridge/mutations.ts
+++ b/src/store/codingBridge/mutations.ts
@@ -103,6 +103,34 @@ export const truncateEventsBefore = (
   }
 };
 
+// Apply a node-authoritative rewind (the `session.rewound` event): keep the
+// transcript up to and including the result whose `cut_uuid` matches, dropping
+// the abandoned turns after it. `cut_uuid` empty → editing the first prompt, so
+// the whole transcript is cleared. This is what makes a reconnect-after-edit
+// rebuild the correct branch from the log instead of replaying the old turns.
+export const rewindToCut = (state: ICodingBridgeState, payload: { session_id: string; cut_uuid?: string }): void => {
+  const events = state.events[payload.session_id];
+  if (!events) {
+    return;
+  }
+  if (!payload.cut_uuid) {
+    state.events[payload.session_id] = [];
+    return;
+  }
+  const index = events.findIndex((event) => event.kind === 'result' && event.cut_uuid === payload.cut_uuid);
+  if (index >= 0) {
+    state.events[payload.session_id] = events.slice(0, index + 1);
+  }
+};
+
+// Remember the highest event seq applied for a session (reconnect cursor).
+export const setLastSeq = (state: ICodingBridgeState, payload: { session_id: string; seq: number }): void => {
+  const current = state.lastSeq[payload.session_id] ?? 0;
+  if (payload.seq > current) {
+    state.lastSeq[payload.session_id] = payload.seq;
+  }
+};
+
 // Streaming: append an incremental text chunk onto the open bubble matching
 // `stream_id`. No-op if the bubble was already finalized or never created.
 export const appendDelta = (
@@ -217,6 +245,7 @@ export const removeNodeData = (state: ICodingBridgeState, nodeId: string): void 
     if (session.node_id === nodeId) {
       delete state.sessions[session.session_id];
       delete state.events[session.session_id];
+      delete state.lastSeq[session.session_id];
       if (state.currentSessionId === session.session_id) {
         state.currentSessionId = undefined;
       }
@@ -237,6 +266,8 @@ export default {
   updateSession,
   appendEvent,
   truncateEventsBefore,
+  rewindToCut,
+  setLastSeq,
   appendDelta,
   finalizeStream,
   finalizeAllStreams,

--- a/src/store/codingBridge/state.ts
+++ b/src/store/codingBridge/state.ts
@@ -8,6 +8,7 @@ export default (): ICodingBridgeState => {
     currentSessionId: undefined,
     sessions: {},
     events: {},
+    lastSeq: {},
     history: {},
     capabilities: {},
     historyRef: undefined,

--- a/src/utils/codingBridgeSocket.ts
+++ b/src/utils/codingBridgeSocket.ts
@@ -2,6 +2,7 @@ import {
   WS_URL_CODING_BRIDGE,
   CB_BROWSER_TO_NODE,
   CB_BROWSER_LIST_NODES,
+  CB_BROWSER_RESUME,
   CB_NODE_TO_BROWSER,
   CB_NODES_SNAPSHOT,
   CB_NODE_STATUS,
@@ -159,7 +160,7 @@ export class CodingBridgeSocket {
     if (!this.isOpen) {
       return;
     }
-    const envelope = { v: 1, id: makeId(), ts: Date.now(), type, ...extra };
+    const envelope = { v: 2, id: makeId(), ts: Date.now(), type, ...extra };
     logEnvelope('send', envelope);
     this.ws?.send(JSON.stringify(envelope));
   }
@@ -172,6 +173,15 @@ export class CodingBridgeSocket {
   /** Ask the relay to re-send the live node snapshot. */
   listNodes(): void {
     this.sendEnvelope(CB_BROWSER_LIST_NODES, {});
+  }
+
+  /**
+   * Reconnect: ask the relay to replay each session's events past the cursor we
+   * last applied, so the live stream resumes seamlessly instead of relying on a
+   * history refresh. The relay dedups; the browser also dedups by `seq`.
+   */
+  resume(cursors: Record<string, number>): void {
+    this.sendEnvelope(CB_BROWSER_RESUME, { payload: { resume_from: cursors } });
   }
 
   close(): void {


### PR DESCRIPTION
**Phase 3 (browser) of the reliable event delivery design** ([CodingBridgeAgent#19](https://github.com/AceDataCloud/CodingBridgeAgent/pull/19)). Completes the end-to-end fix with the relay log ([PlatformService#1010](https://github.com/AceDataCloud/PlatformService/pull/1010)) and the node outbox ([CodingBridgeAgent#20](https://github.com/AceDataCloud/CodingBridgeAgent/pull/20)).

## Problem
On any reconnect (WS blip, tab sleep/wake, network change), the browser only re-requested `history.list` + `capabilities` — it **never replayed the live events** lost while it was away. The answer "appeared from history only after a refresh." The store also had no `seq`, dedup, or rewind-aware replay.

## Changes
- **Cursor + dedup.** Track the highest relay-assigned **`seq`** applied per session (in-memory `lastSeq`) and drop any event with `seq <= lastSeq` — so replayed and live events never duplicate or reorder.
- **Resume on reconnect.** `onOpen` now sends **`browser.resume {resume_from:{session_id:last_seq}}`**; the relay replays everything past the cursor and the live stream resumes seamlessly. No refresh, no dependence on history.
- **Rewind as a projection.** Handle **`session.rewound`**: rewind the transcript to the result with the matching `cut_uuid` and re-echo the edited prompt — so a reconnect *after* an edit rebuilds the correct branch instead of replaying the abandoned turns. The optimistic local truncation in `editPrompt` stays as a UI prediction the event idempotently confirms.
- **Graceful degradation.** Handle **`session.stream_truncated`** (cursor too old / node outbox overflow) → `resyncSession` pulls the device transcript. Never a silent gap.
- Envelope bumped to **v2**; `lastSeq` is in-memory by design, so a full page reload still rebuilds the transcript from history (the existing path), while WS reconnects use the seq cursor.

## Tests / checks
- `mutations.test.ts`: added `rewindToCut` (match / clear-all / not-found) and `setLastSeq` (monotonic, ignores stale) — **12 passed**.
- `vue-tsc --noEmit`: **0 errors**. `eslint`: clean.

## End-to-end
With all three phases, a node→relay→browser reconnect at any hop replays from a cursor and continues live — the "blank wait, refresh to see the answer" behaviour is gone. `history.get` reverts to deep/cross-device archive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)