### PR TITLE
feat(grokvideo): add Grok Imagine video studio

### DIFF
--- a/src/components/common/Navigator.vue
+++ b/src/components/common/Navigator.vue
@@ -92,6 +92,7 @@ import {
   ROUTE_OPENAIIMAGE_INDEX,
   ROUTE_SEEDREAM_INDEX,
   ROUTE_SEEDANCE_INDEX,
+  ROUTE_GROKVIDEO_INDEX,
   ROUTE_WAN_INDEX,
   ROUTE_PRODUCER_INDEX,
   ROUTE_FISH_TTS_INDEX,
@@ -117,6 +118,7 @@ import {
   OPENAIIMAGE_LOGO,
   SEEDREAM_LOGO,
   SEEDANCE_LOGO,
+  GROKVIDEO_LOGO,
   SUNO_LOGO,
   LUMA_LOGO,
   HAILUO_LOGO,
@@ -307,6 +309,15 @@ export default defineComponent({
           displayName: this.$t('common.nav.seedance'),
           logo: SEEDANCE_LOGO,
           routes: [ROUTE_SEEDANCE_INDEX],
+          category: 'video'
+        });
+      }
+      if (this.$store?.state?.site?.features?.grokvideo?.enabled) {
+        result.push({
+          route: { name: ROUTE_GROKVIDEO_INDEX },
+          displayName: this.$t('common.nav.grokvideo'),
+          logo: GROKVIDEO_LOGO,
+          routes: [ROUTE_GROKVIDEO_INDEX],
           category: 'video'
         });
       }

--- a/src/components/grokvideo/ConfigPanel.vue
+++ b/src/components/grokvideo/ConfigPanel.vue
@@ -1,0 +1,65 @@
+<template>
+  <div class="flex flex-col h-full">
+    <div class="flex-1 overflow-y-auto p-5">
+      <prompt-input class="mb-4" />
+      <model-selector class="mb-4" />
+      <ratio-selector class="mb-4" />
+      <resolution-selector class="mb-4" />
+      <duration-selector class="mb-4" />
+      <image-input class="mb-2" />
+    </div>
+    <div class="flex flex-col items-center justify-center px-5 pb-5">
+      <consumption :value="consumption" :service="service" />
+      <el-button type="primary" class="btn w-full" round @click="onGenerate">
+        <font-awesome-icon icon="fa-solid fa-magic" class="mr-2" />
+        {{ $t('grokvideo.button.generate') }}
+      </el-button>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElButton } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import PromptInput from './config/PromptInput.vue';
+import ModelSelector from './config/ModelSelector.vue';
+import DurationSelector from './config/DurationSelector.vue';
+import ResolutionSelector from './config/ResolutionSelector.vue';
+import RatioSelector from './config/RatioSelector.vue';
+import ImageInput from './config/ImageInput.vue';
+import Consumption from '../common/Consumption.vue';
+import { getConsumption } from '@/utils';
+
+export default defineComponent({
+  name: 'GrokVideoConfigPanel',
+  components: {
+    ElButton,
+    FontAwesomeIcon,
+    PromptInput,
+    ModelSelector,
+    DurationSelector,
+    ResolutionSelector,
+    RatioSelector,
+    ImageInput,
+    Consumption
+  },
+  emits: ['generate'],
+  computed: {
+    config() {
+      return this.$store.state.grokvideo?.config;
+    },
+    consumption() {
+      return getConsumption(this.config, this.service?.cost);
+    },
+    service() {
+      return this.$store.state.grokvideo?.service;
+    }
+  },
+  methods: {
+    onGenerate() {
+      this.$emit('generate');
+    }
+  }
+});
+</script>

--- a/src/components/grokvideo/RecentPanel.vue
+++ b/src/components/grokvideo/RecentPanel.vue
@@ -1,0 +1,56 @@
+<template>
+  <div v-if="tasks?.items === undefined">
+    <bot-placeholder />
+  </div>
+  <scroll-list
+    v-else-if="tasks?.items?.length && tasks?.items?.length > 0"
+    ref="scrollList"
+    class="tasks w-full h-full overflow-y-auto"
+    :loading="loading"
+    @reach-top="$emit('reach-top')"
+  >
+    <task-preview v-for="task in tasks?.items" :key="task.id" :model-value="task" />
+  </scroll-list>
+  <div v-if="tasks?.items?.length === 0" class="w-full h-full flex items-center justify-center">
+    <no-tasks />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import TaskPreview from './task/Preview.vue';
+import BotPlaceholder from '@/components/common/BotPlaceholder.vue';
+import NoTasks from '@/components/common/NoTasks.vue';
+import ScrollList from '@/components/common/ScrollList.vue';
+
+export default defineComponent({
+  name: 'GrokVideoRecentPanel',
+  components: {
+    TaskPreview,
+    BotPlaceholder,
+    NoTasks,
+    ScrollList
+  },
+  props: {
+    loading: {
+      type: Boolean,
+      default: false
+    }
+  },
+  emits: ['reach-top'],
+  computed: {
+    tasks() {
+      return {
+        ...this.$store.state.grokvideo?.tasks,
+        items: this.$store.state.grokvideo?.tasks?.items?.slice()
+      };
+    }
+  },
+  methods: {
+    getScrollElement(): HTMLElement | undefined {
+      const list = this.$refs.scrollList as any;
+      return list?.getScrollElement?.();
+    }
+  }
+});
+</script>

--- a/src/components/grokvideo/config/DurationSelector.vue
+++ b/src/components/grokvideo/config/DurationSelector.vue
@@ -1,0 +1,94 @@
+<template>
+  <div class="field">
+    <div class="label">
+      <div class="box">
+        <h2 class="title font-bold">{{ $t('grokvideo.name.duration') }}</h2>
+        <info-icon :content="$t('grokvideo.description.duration')" class="info" />
+      </div>
+    </div>
+    <el-select v-model="value" class="value" :placeholder="$t('grokvideo.placeholder.select')">
+      <el-option v-for="item in options" :key="item.value" :label="item.label" :value="item.value" />
+    </el-select>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElSelect, ElOption } from 'element-plus';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+import { GROKVIDEO_DEFAULT_DURATION } from '@/constants';
+
+export default defineComponent({
+  name: 'GrokVideoDurationSelector',
+  components: {
+    ElSelect,
+    ElOption,
+    InfoIcon
+  },
+  data() {
+    return {
+      options: [
+        { value: 3, label: '3s' },
+        { value: 5, label: '5s' },
+        { value: 6, label: '6s' },
+        { value: 8, label: '8s' },
+        { value: 10, label: '10s' },
+        { value: 12, label: '12s' },
+        { value: 15, label: '15s' }
+      ]
+    };
+  },
+  computed: {
+    value: {
+      get(): number | undefined {
+        return this.$store.state.grokvideo?.config?.duration;
+      },
+      set(val: number) {
+        this.$store.commit('grokvideo/setConfig', {
+          ...this.$store.state.grokvideo?.config,
+          duration: val
+        });
+      }
+    }
+  },
+  mounted() {
+    if (!this.value) {
+      this.value = GROKVIDEO_DEFAULT_DURATION;
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.field {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+
+  .label {
+    width: 30%;
+    display: flex;
+    align-items: center;
+
+    .box {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+
+      .title {
+        font-size: 14px;
+        margin: 0;
+      }
+
+      .info {
+        margin-left: 6px;
+      }
+    }
+  }
+
+  .value {
+    width: 80px;
+  }
+}
+</style>

--- a/src/components/grokvideo/config/ImageInput.vue
+++ b/src/components/grokvideo/config/ImageInput.vue
@@ -1,0 +1,140 @@
+<template>
+  <div class="relative">
+    <div class="flex justify-between">
+      <div class="flex justify-start items-center">
+        <span class="text-sm font-bold">{{ $t('grokvideo.name.image') }}</span>
+        <span v-if="required" class="required-badge">
+          {{ $t('grokvideo.name.required') }}
+        </span>
+        <info-icon :content="$t('grokvideo.description.image')" />
+      </div>
+    </div>
+    <el-upload
+      ref="uploader"
+      v-model:file-list="fileList"
+      name="file"
+      accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
+      :limit="1"
+      class="upload-wrapper"
+      :multiple="false"
+      :action="uploadUrl"
+      list-type="picture"
+      :on-exceed="onExceed"
+      :on-error="onError"
+      :on-success="onSuccess"
+      :on-remove="onRemove"
+      :headers="headers"
+    >
+      <template #file="{ file }">
+        <image-preview
+          v-if="file.url && file.percentage !== undefined"
+          :url="file.url"
+          :name="file.name"
+          :percentage="file.percentage"
+          @remove="fileList.splice(fileList.indexOf(file), 1)"
+        />
+      </template>
+      <el-button round type="primary" size="small" class="btn btn-upload">
+        <font-awesome-icon icon="fa-solid fa-upload" class="icon mr-1" />
+        {{ $t('grokvideo.button.upload') }}
+      </el-button>
+    </el-upload>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElUpload, ElButton, UploadFiles, UploadFile, ElMessage } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { getBaseUrlPlatform, pasteUploadMixin, uploadTrackerMixin } from '@/utils';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+import ImagePreview from '@/components/common/ImagePreview.vue';
+import { isGrokVideoImageOnlyModel } from '@/constants';
+
+interface IData {
+  fileList: UploadFiles;
+  uploadUrl: string;
+}
+
+export default defineComponent({
+  name: 'GrokVideoImageInput',
+  components: {
+    ElUpload,
+    ElButton,
+    InfoIcon,
+    FontAwesomeIcon,
+    ImagePreview
+  },
+  mixins: [pasteUploadMixin, uploadTrackerMixin],
+  data(): IData {
+    return {
+      fileList: [],
+      uploadUrl: getBaseUrlPlatform() + '/api/v1/files/'
+    };
+  },
+  computed: {
+    headers() {
+      return {
+        Authorization: `Bearer ${this.$store.state.token.access}`
+      };
+    },
+    required(): boolean {
+      return isGrokVideoImageOnlyModel(this.$store.state.grokvideo?.config?.model);
+    },
+    urls() {
+      // @ts-ignore
+      return this.fileList.map((file: UploadFile) => file?.response?.file_url);
+    }
+  },
+  methods: {
+    onExceed() {
+      ElMessage.warning(this.$t('grokvideo.message.uploadExceed'));
+    },
+    onError() {
+      ElMessage.error(this.$t('grokvideo.message.uploadError'));
+    },
+    onSetImageUrl() {
+      const url = this.urls?.[0];
+      this.$store.commit('grokvideo/setConfig', {
+        ...this.$store.state.grokvideo?.config,
+        image_url: url || undefined
+      });
+    },
+    async onSuccess() {
+      this.onSetImageUrl();
+    },
+    async onRemove() {
+      this.onSetImageUrl();
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.btn.btn-upload {
+  position: absolute;
+  top: 5px;
+  right: 0;
+}
+.required-badge {
+  margin-left: 6px;
+  padding: 0 6px;
+  font-size: 11px;
+  line-height: 16px;
+  border-radius: 8px;
+  color: var(--el-color-warning);
+  background-color: var(--el-color-warning-light-9);
+  border: 1px solid var(--el-color-warning-light-7);
+}
+</style>
+
+<style lang="scss">
+.upload-wrapper {
+  height: auto;
+  display: flex;
+  .el-upload-list {
+    margin: 0;
+    width: 100%;
+  }
+}
+</style>

--- a/src/components/grokvideo/config/ModelSelector.vue
+++ b/src/components/grokvideo/config/ModelSelector.vue
@@ -1,0 +1,89 @@
+<template>
+  <div class="field">
+    <div class="label">
+      <div class="box">
+        <h2 class="title font-bold">{{ $t('grokvideo.name.model') }}</h2>
+        <info-icon :content="$t('grokvideo.description.model')" class="info" />
+      </div>
+    </div>
+    <el-select v-model="value" class="value" :placeholder="$t('grokvideo.placeholder.select')">
+      <el-option v-for="item in options" :key="item.value" :label="item.label" :value="item.value" />
+    </el-select>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElSelect, ElOption } from 'element-plus';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+import { GROKVIDEO_DEFAULT_MODEL, GROKVIDEO_MODEL_1_5_PREVIEW, GROKVIDEO_MODEL_DEFAULT } from '@/constants';
+
+export default defineComponent({
+  name: 'GrokVideoModelSelector',
+  components: {
+    ElSelect,
+    ElOption,
+    InfoIcon
+  },
+  data() {
+    return {
+      options: [
+        { value: GROKVIDEO_MODEL_DEFAULT, label: this.$t('grokvideo.model.default') },
+        { value: GROKVIDEO_MODEL_1_5_PREVIEW, label: this.$t('grokvideo.model.preview15') }
+      ]
+    };
+  },
+  computed: {
+    value: {
+      get() {
+        return this.$store.state.grokvideo?.config?.model;
+      },
+      set(val: string) {
+        this.$store.commit('grokvideo/setConfig', {
+          ...this.$store.state.grokvideo?.config,
+          model: val
+        });
+      }
+    }
+  },
+  mounted() {
+    if (!this.value) {
+      this.value = GROKVIDEO_DEFAULT_MODEL;
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.field {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+
+  .label {
+    width: 30%;
+    display: flex;
+    align-items: center;
+
+    .box {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+
+      .title {
+        font-size: 14px;
+        margin: 0;
+      }
+
+      .info {
+        margin-left: 6px;
+      }
+    }
+  }
+
+  .value {
+    width: 200px;
+  }
+}
+</style>

--- a/src/components/grokvideo/config/PromptInput.vue
+++ b/src/components/grokvideo/config/PromptInput.vue
@@ -1,0 +1,41 @@
+<template>
+  <prompt-textarea
+    v-model="prompt"
+    :title="$t('grokvideo.name.prompt')"
+    :info="$t('grokvideo.description.prompt')"
+    :placeholder="$t('grokvideo.placeholder.prompt')"
+    :min-rows="5"
+  />
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import PromptTextarea from '@/components/common/PromptTextarea.vue';
+
+export const DEFAULT_PROMPT = '';
+
+export default defineComponent({
+  name: 'GrokVideoPromptInput',
+  components: {
+    PromptTextarea
+  },
+  computed: {
+    prompt: {
+      get() {
+        return this.$store.state.grokvideo?.config?.prompt;
+      },
+      set(val: string) {
+        this.$store.commit('grokvideo/setConfig', {
+          ...this.$store.state.grokvideo?.config,
+          prompt: val
+        });
+      }
+    }
+  },
+  mounted() {
+    if (!this.prompt) {
+      this.prompt = DEFAULT_PROMPT;
+    }
+  }
+});
+</script>

--- a/src/components/grokvideo/config/RatioSelector.vue
+++ b/src/components/grokvideo/config/RatioSelector.vue
@@ -1,0 +1,163 @@
+<template>
+  <div class="ratio">
+    <div class="header">
+      <h2 class="title font-bold">{{ $t('grokvideo.name.ratio') }}</h2>
+      <info-icon :content="$t('grokvideo.description.ratio')" class="info" />
+    </div>
+    <div class="items">
+      <div
+        v-for="item in options"
+        :key="item.value"
+        class="item"
+        :class="{ active: value === item.value }"
+        @click="value = item.value"
+      >
+        <div class="preview">
+          <div class="rect" :style="{ width: item.w + 'px', height: item.h + 'px' }" />
+        </div>
+        <div class="name">{{ item.label }}</div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+import {
+  GROKVIDEO_DEFAULT_RATIO,
+  GROKVIDEO_RATIO_16_9,
+  GROKVIDEO_RATIO_9_16,
+  GROKVIDEO_RATIO_1_1,
+  GROKVIDEO_RATIO_4_3,
+  GROKVIDEO_RATIO_3_4,
+  GROKVIDEO_RATIO_3_2,
+  GROKVIDEO_RATIO_2_3
+} from '@/constants';
+
+interface RatioOption {
+  value: string;
+  label: string;
+  w: number;
+  h: number;
+}
+
+export default defineComponent({
+  name: 'GrokVideoRatioSelector',
+  components: {
+    InfoIcon
+  },
+  computed: {
+    options(): RatioOption[] {
+      return [
+        { value: GROKVIDEO_RATIO_16_9, label: '16:9', w: 32, h: 18 },
+        { value: GROKVIDEO_RATIO_9_16, label: '9:16', w: 18, h: 32 },
+        { value: GROKVIDEO_RATIO_1_1, label: '1:1', w: 24, h: 24 },
+        { value: GROKVIDEO_RATIO_4_3, label: '4:3', w: 28, h: 21 },
+        { value: GROKVIDEO_RATIO_3_4, label: '3:4', w: 21, h: 28 },
+        { value: GROKVIDEO_RATIO_3_2, label: '3:2', w: 30, h: 20 },
+        { value: GROKVIDEO_RATIO_2_3, label: '2:3', w: 20, h: 30 }
+      ];
+    },
+    value: {
+      get(): string | undefined {
+        return this.$store.state.grokvideo?.config?.aspect_ratio;
+      },
+      set(val: string) {
+        this.$store.commit('grokvideo/setConfig', {
+          ...this.$store.state.grokvideo?.config,
+          aspect_ratio: val
+        });
+      }
+    }
+  },
+  mounted() {
+    if (!this.value) {
+      this.value = GROKVIDEO_DEFAULT_RATIO;
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.ratio {
+  .header {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    margin-bottom: 10px;
+
+    .title {
+      font-size: 14px;
+      margin: 0;
+    }
+
+    .info {
+      margin-left: 6px;
+    }
+  }
+
+  .items {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+
+    .item {
+      flex: 0 0 calc(25% - 6px);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 8px 0 6px;
+      border: 1px solid var(--el-border-color);
+      border-radius: 8px;
+      cursor: pointer;
+      transition:
+        background-color 0.15s ease,
+        border-color 0.15s ease,
+        color 0.15s ease;
+      background-color: var(--el-fill-color-lighter);
+
+      &:hover {
+        background-color: var(--el-fill-color);
+        border-color: var(--el-border-color-hover);
+      }
+
+      .preview {
+        width: 100%;
+        height: 40px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin-bottom: 4px;
+
+        .rect {
+          border: 1.5px solid var(--el-text-color-secondary);
+          border-radius: 2px;
+          background-color: transparent;
+        }
+      }
+
+      .name {
+        font-size: 12px;
+        color: var(--el-text-color-regular);
+        line-height: 1;
+      }
+
+      &.active {
+        border-color: var(--el-color-primary);
+        background-color: var(--el-color-primary-light-9);
+
+        .rect {
+          border-color: var(--el-color-primary);
+        }
+
+        .name {
+          color: var(--el-color-primary);
+          font-weight: 600;
+        }
+      }
+    }
+  }
+}
+</style>

--- a/src/components/grokvideo/config/ResolutionSelector.vue
+++ b/src/components/grokvideo/config/ResolutionSelector.vue
@@ -1,0 +1,112 @@
+<template>
+  <div class="resolution">
+    <div class="header">
+      <h2 class="title font-bold">{{ $t('grokvideo.name.resolution') }}</h2>
+      <info-icon :content="$t('grokvideo.description.resolution')" class="info" />
+    </div>
+    <div class="items">
+      <div
+        v-for="item in options"
+        :key="item.value"
+        class="item"
+        :class="{ active: value === item.value }"
+        @click="value = item.value"
+      >
+        {{ item.label }}
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+import { GROKVIDEO_DEFAULT_RESOLUTION, GROKVIDEO_RESOLUTION_480P, GROKVIDEO_RESOLUTION_720P } from '@/constants';
+
+export default defineComponent({
+  name: 'GrokVideoResolutionSelector',
+  components: {
+    InfoIcon
+  },
+  data() {
+    return {
+      options: [
+        { value: GROKVIDEO_RESOLUTION_480P, label: '480p' },
+        { value: GROKVIDEO_RESOLUTION_720P, label: '720p' }
+      ]
+    };
+  },
+  computed: {
+    value: {
+      get(): string | undefined {
+        return this.$store.state.grokvideo?.config?.resolution;
+      },
+      set(val: string) {
+        this.$store.commit('grokvideo/setConfig', {
+          ...this.$store.state.grokvideo?.config,
+          resolution: val
+        });
+      }
+    }
+  },
+  mounted() {
+    if (!this.value) {
+      this.value = GROKVIDEO_DEFAULT_RESOLUTION;
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.resolution {
+  .header {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    margin-bottom: 10px;
+
+    .title {
+      font-size: 14px;
+      margin: 0;
+    }
+
+    .info {
+      margin-left: 6px;
+    }
+  }
+
+  .items {
+    display: flex;
+    flex-direction: row;
+    gap: 8px;
+
+    .item {
+      flex: 1;
+      text-align: center;
+      padding: 8px 0;
+      font-size: 13px;
+      color: var(--el-text-color-regular);
+      border: 1px solid var(--el-border-color);
+      border-radius: 8px;
+      cursor: pointer;
+      transition:
+        background-color 0.15s ease,
+        border-color 0.15s ease,
+        color 0.15s ease;
+      background-color: var(--el-fill-color-lighter);
+
+      &:hover {
+        background-color: var(--el-fill-color);
+        border-color: var(--el-border-color-hover);
+      }
+
+      &.active {
+        color: var(--el-color-primary);
+        background-color: var(--el-color-primary-light-9);
+        border-color: var(--el-color-primary);
+        font-weight: 600;
+      }
+    }
+  }
+}
+</style>

--- a/src/components/grokvideo/task/Preview.vue
+++ b/src/components/grokvideo/task/Preview.vue
@@ -1,0 +1,263 @@
+<template>
+  <div class="preview">
+    <div class="left">
+      <el-image :src="grokVideoLogo" class="avatar" />
+    </div>
+    <div class="main">
+      <div class="bot">
+        {{ $t('grokvideo.name.bot') }}
+        <span class="datetime">
+          {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
+        </span>
+      </div>
+      <div class="info">
+        <div v-if="inputImage" class="flex justify-start items-center gap-2 mt-2 w-full overflow-x-auto">
+          <image-preview :url="inputImage" name="image" :closable="false" />
+        </div>
+        <p v-if="modelValue?.request?.prompt" class="prompt mt-2">
+          {{ modelValue?.request?.prompt }}
+          <span v-if="!modelValue?.response"> - ({{ $t('grokvideo.status.pending') }}) </span>
+          <span v-else-if="video?.state === 'processing' || video?.state === 'pending'">
+            - ({{ $t('grokvideo.status.processing') }})
+          </span>
+        </p>
+      </div>
+      <div v-if="!modelValue?.response" :class="{ content: true }">
+        <el-alert :closable="false" class="info">
+          <template #template>
+            <font-awesome-icon icon="fa-regular fa-clock" class="mr-1" />
+            {{ $t('grokvideo.status.pending') }}
+          </template>
+          <p class="text-[var(--el-text-color-regular)] text-xs mb-0">
+            <font-awesome-icon icon="fa-solid fa-magic" class="mr-1" />
+            {{ $t('grokvideo.name.taskId') }}:
+            {{ modelValue?.id }}
+            <copy-to-clipboard :content="modelValue?.id!" class="btn-copy inline-block" />
+          </p>
+        </el-alert>
+      </div>
+      <div v-else-if="modelValue?.response?.success === true" :class="{ content: true }">
+        <div v-if="video?.video_url" class="mb-4">
+          <video-player :src="video?.video_url" />
+        </div>
+        <div v-if="video?.video_url" :class="{ operations: true, 'mt-2': true, 'mb-2': true }">
+          <el-tooltip
+            class="box-item"
+            effect="dark"
+            :content="$t('grokvideo.message.downloadVideo')"
+            placement="top-start"
+          >
+            <el-button type="info" size="small" class="btn-action" @click.stop="onDownload(video?.video_url)">
+              {{ $t('grokvideo.button.download') }}
+            </el-button>
+          </el-tooltip>
+          <api-code-button path="/grok/videos" :body="modelValue?.request" />
+        </div>
+        <el-alert :closable="false" class="mt-2 success">
+          <p v-if="modelValue?.request?.model" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-cube" class="mr-1" />
+            {{ $t('grokvideo.name.model') }}:
+            {{ modelValue?.request?.model }}
+          </p>
+          <p v-if="video?.duration" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('grokvideo.name.duration') }}: {{ video?.duration }}s
+          </p>
+          <p v-if="modelValue?.request?.resolution" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-expand" class="mr-1" />
+            {{ $t('grokvideo.name.resolution') }}:
+            {{ modelValue?.request?.resolution }}
+            <span v-if="modelValue?.request?.aspect_ratio"> · {{ modelValue?.request?.aspect_ratio }}</span>
+          </p>
+          <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-magic" class="mr-1" />
+            {{ $t('grokvideo.name.taskId') }}:
+            {{ modelValue?.id }}
+            <copy-to-clipboard :content="modelValue?.id!" class="btn-copy inline-block" />
+          </p>
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('grokvideo.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
+          </p>
+          <p v-if="modelValue?.response?.trace_id" class="text-[var(--el-text-color-regular)] text-xs mb-0">
+            <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />
+            {{ $t('grokvideo.name.traceId') }}:
+            {{ modelValue?.response?.trace_id }}
+            <copy-to-clipboard :content="modelValue?.response?.trace_id" class="btn-copy inline-block" />
+          </p>
+        </el-alert>
+      </div>
+      <div v-else-if="modelValue?.response?.success === false" :class="{ content: true }">
+        <el-alert :closable="false" class="failure">
+          <template #template>
+            <font-awesome-icon icon="fa-solid fa-exclamation-triangle" class="mr-1" />
+            {{ $t('grokvideo.name.failure') }}
+          </template>
+          <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-magic" class="mr-1" />
+            {{ $t('grokvideo.name.taskId') }}:
+            {{ modelValue?.id }}
+            <copy-to-clipboard :content="modelValue?.id!" class="btn-copy inline-block" />
+          </p>
+          <p v-if="modelValue?.response?.error?.message" class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-circle-info" class="mr-1" />
+            {{ $t('grokvideo.name.failureReason') }}:
+            {{ modelValue?.response?.error?.message }}
+            <copy-to-clipboard :content="modelValue?.response?.error?.message!" class="btn-copy inline-block" />
+          </p>
+          <p v-if="modelValue?.response?.trace_id" class="text-[var(--el-text-color-regular)] text-xs mb-0">
+            <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />
+            {{ $t('grokvideo.name.traceId') }}:
+            {{ modelValue?.response?.trace_id }}
+            <copy-to-clipboard :content="modelValue?.response?.trace_id" class="btn-copy inline-block" />
+          </p>
+        </el-alert>
+      </div>
+      <div v-else :class="{ content: true }">
+        <el-alert :closable="false" class="info">
+          <template #template>
+            <font-awesome-icon icon="fa-solid fa-circle-info" class="mr-1" />
+            {{ $t('grokvideo.name.status') }}
+          </template>
+          <p class="text-[var(--el-text-color-regular)] text-xs mb-0">
+            <font-awesome-icon icon="fa-solid fa-magic" class="mr-1" />
+            {{ $t('grokvideo.name.taskId') }}:
+            {{ modelValue?.id }}
+            <copy-to-clipboard :content="modelValue?.id!" class="btn-copy inline-block" />
+          </p>
+        </el-alert>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElImage, ElAlert, ElButton, ElTooltip } from 'element-plus';
+import { IGrokVideoTask, IGrokVideoVideo } from '@/models';
+import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import VideoPlayer from '@/components/common/VideoPlayer.vue';
+import ImagePreview from '@/components/common/ImagePreview.vue';
+import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
+import { GROKVIDEO_LOGO } from '@/constants';
+
+export default defineComponent({
+  name: 'GrokVideoTaskPreview',
+  components: {
+    ElImage,
+    CopyToClipboard,
+    FontAwesomeIcon,
+    ElAlert,
+    VideoPlayer,
+    ElTooltip,
+    ElButton,
+    ImagePreview,
+    ApiCodeButton
+  },
+  props: {
+    modelValue: {
+      type: Object as () => IGrokVideoTask | undefined,
+      required: true
+    }
+  },
+  data() {
+    return {
+      grokVideoLogo: GROKVIDEO_LOGO
+    };
+  },
+  computed: {
+    video(): IGrokVideoVideo | undefined {
+      return this.modelValue?.response?.data?.[0];
+    },
+    inputImage(): string | undefined {
+      return this.modelValue?.request?.image_url;
+    }
+  },
+  methods: {
+    onDownload(videoUrl: string) {
+      window.open(videoUrl, '_blank');
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+$left-width: 70px;
+.preview {
+  width: 100%;
+  height: fit-content;
+  text-align: left;
+  display: flex;
+  flex-direction: row;
+  margin-bottom: 15px;
+  .left {
+    width: $left-width;
+    .avatar {
+      width: 50px;
+      height: 50px;
+      margin: 10px;
+      border-radius: 50%;
+      box-shadow: var(--app-shadow-xs);
+    }
+  }
+
+  .main {
+    flex: 1;
+    width: calc(100% - $left-width);
+    min-width: 0;
+    padding: 10px 10px 0 10px;
+
+    .bot {
+      font-size: 16px;
+      font-weight: bold;
+      color: var(--el-color-primary);
+      margin-bottom: 0;
+      margin-top: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      .datetime {
+        font-size: 12px;
+        font-weight: normal;
+        color: var(--el-text-color-secondary);
+        margin-left: 10px;
+      }
+    }
+
+    .info {
+      overflow: hidden;
+      .prompt {
+        font-size: 14px;
+        font-weight: bold;
+        color: var(--el-text-color-regular);
+        margin-bottom: 10px;
+        white-space: normal;
+        word-break: break-word;
+        overflow-wrap: anywhere;
+      }
+    }
+
+    .content {
+      word-break: break-word;
+      overflow-wrap: anywhere;
+      .el-alert {
+        border-left-width: 2px;
+        border-left-style: solid;
+        &.failure {
+          border-color: var(--el-color-danger);
+        }
+        &.success {
+          border-color: var(--el-color-success);
+        }
+        &.info {
+          border-color: var(--el-color-info);
+        }
+        :deep(p:last-child) {
+          margin-bottom: 0;
+        }
+      }
+    }
+  }
+}
+</style>

--- a/src/components/setting/Function.vue
+++ b/src/components/setting/Function.vue
@@ -111,6 +111,7 @@ const FEATURE_KEYS = [
   'openaiimage',
   'seedream',
   'seedance',
+  'grokvideo',
   'wan',
   'producer',
   'kimi',

--- a/src/constants/grokvideo.ts
+++ b/src/constants/grokvideo.ts
@@ -1,0 +1,28 @@
+export const GROKVIDEO_SERVICE_ID = 'a270a291-7cbc-44a6-88b9-80334e3e95a0';
+
+export const GROKVIDEO_LOGO = 'https://cdn.acedata.cloud/8nxyy9.jpg';
+
+export const GROKVIDEO_MODEL_DEFAULT = 'grok-imagine-video';
+export const GROKVIDEO_MODEL_1_5_PREVIEW = 'grok-imagine-video-1.5-preview';
+export const GROKVIDEO_DEFAULT_MODEL = GROKVIDEO_MODEL_DEFAULT;
+
+export const GROKVIDEO_RATIO_1_1 = '1:1';
+export const GROKVIDEO_RATIO_16_9 = '16:9';
+export const GROKVIDEO_RATIO_9_16 = '9:16';
+export const GROKVIDEO_RATIO_4_3 = '4:3';
+export const GROKVIDEO_RATIO_3_4 = '3:4';
+export const GROKVIDEO_RATIO_3_2 = '3:2';
+export const GROKVIDEO_RATIO_2_3 = '2:3';
+export const GROKVIDEO_DEFAULT_RATIO = GROKVIDEO_RATIO_16_9;
+
+export const GROKVIDEO_RESOLUTION_480P = '480p';
+export const GROKVIDEO_RESOLUTION_720P = '720p';
+export const GROKVIDEO_DEFAULT_RESOLUTION = GROKVIDEO_RESOLUTION_480P;
+
+export const GROKVIDEO_DEFAULT_DURATION = 8;
+
+/** Models that only support image-to-video (require an input image). */
+export const GROKVIDEO_IMAGE_ONLY_MODELS = [GROKVIDEO_MODEL_1_5_PREVIEW];
+
+export const isGrokVideoImageOnlyModel = (model?: string): boolean =>
+  !!model && GROKVIDEO_IMAGE_ONLY_MODELS.includes(model);

--- a/src/constants/i18n.ts
+++ b/src/constants/i18n.ts
@@ -37,6 +37,7 @@ export const I18N_SCOPES = [
   'openaiimage',
   'seedream',
   'seedance',
+  'grokvideo',
   'hailuo',
   'wan',
   'headshots',

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -20,6 +20,7 @@ export * from './nanobanana';
 export * from './openaiimage';
 export * from './seedream';
 export * from './seedance';
+export * from './grokvideo';
 export * from './serp';
 export * from './wan';
 export * from './webextrator';

--- a/src/i18n/ar/common.json
+++ b/src/i18n/ar/common.json
@@ -507,6 +507,10 @@
     "message": "SeeDance",
     "description": "النص في شريط التنقل للموقع، لعرض صفحة SeeDance، يجب عدم ترجمة هذا الحقل، يجب أن يبقى 'SeeDance'"
   },
+  "nav.grokvideo": {
+    "message": "Grok Video",
+    "description": "Text in the website navigation bar to display the Grok Imagine video page"
+  },
   "nav.luma": {
     "message": "Luma",
     "description": "النص في شريط التنقل للموقع، لعرض صفحة Luma، يجب عدم ترجمة هذا الحقل، يجب أن يبقى 'Luma'"

--- a/src/i18n/ar/grokvideo.json
+++ b/src/i18n/ar/grokvideo.json
@@ -1,0 +1,61 @@
+{
+  "name.bot": { "message": "Grok Video Bot", "description": "Name of the Grok video generator" },
+  "name.prompt": { "message": "Prompt", "description": "Prompt for generating the video" },
+  "name.model": { "message": "Model", "description": "Label for model selection" },
+  "name.ratio": { "message": "Aspect Ratio", "description": "Label for aspect ratio" },
+  "name.resolution": { "message": "Resolution", "description": "Label for resolution" },
+  "name.duration": { "message": "Duration", "description": "Label for duration" },
+  "name.image": { "message": "Image", "description": "Label for input image" },
+  "name.required": { "message": "Required", "description": "Required badge" },
+  "name.taskId": { "message": "Task ID", "description": "Task id label" },
+  "name.elapsed": { "message": "Elapsed", "description": "Elapsed time label" },
+  "name.traceId": { "message": "Trace ID", "description": "Trace id label" },
+  "name.failure": { "message": "Generation Failed", "description": "Failure title" },
+  "name.failureReason": { "message": "Reason", "description": "Failure reason label" },
+  "name.status": { "message": "Status", "description": "Status title" },
+  "description.prompt": {
+    "message": "Describe the video you want to generate (scene, subject, motion, camera, lighting, style).",
+    "description": "Instructions for prompt input"
+  },
+  "description.model": {
+    "message": "Choose the Grok Imagine model. grok-imagine-video supports text and image; 1.5-preview is image-to-video only.",
+    "description": "Instructions for model selection"
+  },
+  "description.ratio": { "message": "Select the output aspect ratio.", "description": "Instructions for aspect ratio" },
+  "description.resolution": {
+    "message": "Select the output resolution. Higher resolution costs more credits per second.",
+    "description": "Instructions for resolution"
+  },
+  "description.duration": {
+    "message": "Video duration in seconds. Billed per output second.",
+    "description": "Instructions for duration"
+  },
+  "description.image": {
+    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5-preview.",
+    "description": "Instructions for image input"
+  },
+  "placeholder.prompt": { "message": "Describe your video…", "description": "Placeholder for prompt" },
+  "placeholder.select": { "message": "Please select", "description": "Placeholder for selects" },
+  "model.default": { "message": "Grok Imagine Video", "description": "Default model label" },
+  "model.preview15": { "message": "Grok Imagine Video 1.5 (Preview, image-to-video)", "description": "1.5 preview model label" },
+  "button.upload": { "message": "Upload", "description": "Upload button" },
+  "button.generate": { "message": "Generate", "description": "Generate button" },
+  "button.download": { "message": "Download", "description": "Download button" },
+  "status.pending": { "message": "Pending", "description": "Pending status" },
+  "status.processing": { "message": "Processing", "description": "Processing status" },
+  "message.uploadExceed": { "message": "You can upload only one image.", "description": "Upload exceed warning" },
+  "message.uploadError": { "message": "Image upload failed, please try again.", "description": "Upload error" },
+  "message.downloadVideo": { "message": "Download video", "description": "Download tooltip" },
+  "message.modelRequiresImage": {
+    "message": "This model requires an input image (image-to-video).",
+    "description": "Model requires image warning"
+  },
+  "message.promptOrImageRequired": {
+    "message": "Please enter a prompt or upload an image.",
+    "description": "Prompt or image required warning"
+  },
+  "message.startingTask": { "message": "Submitting your video generation task…", "description": "Starting task" },
+  "message.startTaskSuccess": { "message": "Task submitted successfully.", "description": "Task success" },
+  "message.startTaskFailed": { "message": "Failed to submit task: ", "description": "Task failed" },
+  "message.usedUp": { "message": "Your quota has been used up. Please purchase more to continue.", "description": "Used up" }
+}

--- a/src/i18n/de/common.json
+++ b/src/i18n/de/common.json
@@ -507,6 +507,10 @@
     "message": "SeeDance",
     "description": "Website-Navigationsleiste, um die SeeDance-Seite anzuzeigen, bitte dieses Feld nicht übersetzen, muss als 'SeeDance' beibehalten werden"
   },
+  "nav.grokvideo": {
+    "message": "Grok Video",
+    "description": "Text in the website navigation bar to display the Grok Imagine video page"
+  },
   "nav.luma": {
     "message": "Luma",
     "description": "Website-Navigationsleiste, um die Luma-Seite anzuzeigen, bitte dieses Feld nicht übersetzen, muss als 'Luma' beibehalten werden"

--- a/src/i18n/de/grokvideo.json
+++ b/src/i18n/de/grokvideo.json
@@ -1,0 +1,61 @@
+{
+  "name.bot": { "message": "Grok Video Bot", "description": "Name of the Grok video generator" },
+  "name.prompt": { "message": "Prompt", "description": "Prompt for generating the video" },
+  "name.model": { "message": "Model", "description": "Label for model selection" },
+  "name.ratio": { "message": "Aspect Ratio", "description": "Label for aspect ratio" },
+  "name.resolution": { "message": "Resolution", "description": "Label for resolution" },
+  "name.duration": { "message": "Duration", "description": "Label for duration" },
+  "name.image": { "message": "Image", "description": "Label for input image" },
+  "name.required": { "message": "Required", "description": "Required badge" },
+  "name.taskId": { "message": "Task ID", "description": "Task id label" },
+  "name.elapsed": { "message": "Elapsed", "description": "Elapsed time label" },
+  "name.traceId": { "message": "Trace ID", "description": "Trace id label" },
+  "name.failure": { "message": "Generation Failed", "description": "Failure title" },
+  "name.failureReason": { "message": "Reason", "description": "Failure reason label" },
+  "name.status": { "message": "Status", "description": "Status title" },
+  "description.prompt": {
+    "message": "Describe the video you want to generate (scene, subject, motion, camera, lighting, style).",
+    "description": "Instructions for prompt input"
+  },
+  "description.model": {
+    "message": "Choose the Grok Imagine model. grok-imagine-video supports text and image; 1.5-preview is image-to-video only.",
+    "description": "Instructions for model selection"
+  },
+  "description.ratio": { "message": "Select the output aspect ratio.", "description": "Instructions for aspect ratio" },
+  "description.resolution": {
+    "message": "Select the output resolution. Higher resolution costs more credits per second.",
+    "description": "Instructions for resolution"
+  },
+  "description.duration": {
+    "message": "Video duration in seconds. Billed per output second.",
+    "description": "Instructions for duration"
+  },
+  "description.image": {
+    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5-preview.",
+    "description": "Instructions for image input"
+  },
+  "placeholder.prompt": { "message": "Describe your video…", "description": "Placeholder for prompt" },
+  "placeholder.select": { "message": "Please select", "description": "Placeholder for selects" },
+  "model.default": { "message": "Grok Imagine Video", "description": "Default model label" },
+  "model.preview15": { "message": "Grok Imagine Video 1.5 (Preview, image-to-video)", "description": "1.5 preview model label" },
+  "button.upload": { "message": "Upload", "description": "Upload button" },
+  "button.generate": { "message": "Generate", "description": "Generate button" },
+  "button.download": { "message": "Download", "description": "Download button" },
+  "status.pending": { "message": "Pending", "description": "Pending status" },
+  "status.processing": { "message": "Processing", "description": "Processing status" },
+  "message.uploadExceed": { "message": "You can upload only one image.", "description": "Upload exceed warning" },
+  "message.uploadError": { "message": "Image upload failed, please try again.", "description": "Upload error" },
+  "message.downloadVideo": { "message": "Download video", "description": "Download tooltip" },
+  "message.modelRequiresImage": {
+    "message": "This model requires an input image (image-to-video).",
+    "description": "Model requires image warning"
+  },
+  "message.promptOrImageRequired": {
+    "message": "Please enter a prompt or upload an image.",
+    "description": "Prompt or image required warning"
+  },
+  "message.startingTask": { "message": "Submitting your video generation task…", "description": "Starting task" },
+  "message.startTaskSuccess": { "message": "Task submitted successfully.", "description": "Task success" },
+  "message.startTaskFailed": { "message": "Failed to submit task: ", "description": "Task failed" },
+  "message.usedUp": { "message": "Your quota has been used up. Please purchase more to continue.", "description": "Used up" }
+}

--- a/src/i18n/el/common.json
+++ b/src/i18n/el/common.json
@@ -507,6 +507,10 @@
     "message": "SeeDance",
     "description": "Website navigation text for displaying the SeeDance page, must remain as 'SeeDance'"
   },
+  "nav.grokvideo": {
+    "message": "Grok Video",
+    "description": "Text in the website navigation bar to display the Grok Imagine video page"
+  },
   "nav.luma": {
     "message": "Luma",
     "description": "Website navigation text for displaying the Luma page, must remain as 'Luma'"

--- a/src/i18n/el/grokvideo.json
+++ b/src/i18n/el/grokvideo.json
@@ -1,0 +1,61 @@
+{
+  "name.bot": { "message": "Grok Video Bot", "description": "Name of the Grok video generator" },
+  "name.prompt": { "message": "Prompt", "description": "Prompt for generating the video" },
+  "name.model": { "message": "Model", "description": "Label for model selection" },
+  "name.ratio": { "message": "Aspect Ratio", "description": "Label for aspect ratio" },
+  "name.resolution": { "message": "Resolution", "description": "Label for resolution" },
+  "name.duration": { "message": "Duration", "description": "Label for duration" },
+  "name.image": { "message": "Image", "description": "Label for input image" },
+  "name.required": { "message": "Required", "description": "Required badge" },
+  "name.taskId": { "message": "Task ID", "description": "Task id label" },
+  "name.elapsed": { "message": "Elapsed", "description": "Elapsed time label" },
+  "name.traceId": { "message": "Trace ID", "description": "Trace id label" },
+  "name.failure": { "message": "Generation Failed", "description": "Failure title" },
+  "name.failureReason": { "message": "Reason", "description": "Failure reason label" },
+  "name.status": { "message": "Status", "description": "Status title" },
+  "description.prompt": {
+    "message": "Describe the video you want to generate (scene, subject, motion, camera, lighting, style).",
+    "description": "Instructions for prompt input"
+  },
+  "description.model": {
+    "message": "Choose the Grok Imagine model. grok-imagine-video supports text and image; 1.5-preview is image-to-video only.",
+    "description": "Instructions for model selection"
+  },
+  "description.ratio": { "message": "Select the output aspect ratio.", "description": "Instructions for aspect ratio" },
+  "description.resolution": {
+    "message": "Select the output resolution. Higher resolution costs more credits per second.",
+    "description": "Instructions for resolution"
+  },
+  "description.duration": {
+    "message": "Video duration in seconds. Billed per output second.",
+    "description": "Instructions for duration"
+  },
+  "description.image": {
+    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5-preview.",
+    "description": "Instructions for image input"
+  },
+  "placeholder.prompt": { "message": "Describe your video…", "description": "Placeholder for prompt" },
+  "placeholder.select": { "message": "Please select", "description": "Placeholder for selects" },
+  "model.default": { "message": "Grok Imagine Video", "description": "Default model label" },
+  "model.preview15": { "message": "Grok Imagine Video 1.5 (Preview, image-to-video)", "description": "1.5 preview model label" },
+  "button.upload": { "message": "Upload", "description": "Upload button" },
+  "button.generate": { "message": "Generate", "description": "Generate button" },
+  "button.download": { "message": "Download", "description": "Download button" },
+  "status.pending": { "message": "Pending", "description": "Pending status" },
+  "status.processing": { "message": "Processing", "description": "Processing status" },
+  "message.uploadExceed": { "message": "You can upload only one image.", "description": "Upload exceed warning" },
+  "message.uploadError": { "message": "Image upload failed, please try again.", "description": "Upload error" },
+  "message.downloadVideo": { "message": "Download video", "description": "Download tooltip" },
+  "message.modelRequiresImage": {
+    "message": "This model requires an input image (image-to-video).",
+    "description": "Model requires image warning"
+  },
+  "message.promptOrImageRequired": {
+    "message": "Please enter a prompt or upload an image.",
+    "description": "Prompt or image required warning"
+  },
+  "message.startingTask": { "message": "Submitting your video generation task…", "description": "Starting task" },
+  "message.startTaskSuccess": { "message": "Task submitted successfully.", "description": "Task success" },
+  "message.startTaskFailed": { "message": "Failed to submit task: ", "description": "Task failed" },
+  "message.usedUp": { "message": "Your quota has been used up. Please purchase more to continue.", "description": "Used up" }
+}

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -507,6 +507,10 @@
     "message": "SeeDance",
     "description": "Text in the website navigation bar to display the SeeDance page, must remain as 'SeeDance'"
   },
+  "nav.grokvideo": {
+    "message": "Grok Video",
+    "description": "Text in the website navigation bar to display the Grok Imagine video page"
+  },
   "nav.luma": {
     "message": "Luma",
     "description": "Text in the website navigation bar to display the Luma page, must remain as 'Luma'"

--- a/src/i18n/en/grokvideo.json
+++ b/src/i18n/en/grokvideo.json
@@ -1,0 +1,61 @@
+{
+  "name.bot": { "message": "Grok Video Bot", "description": "Name of the Grok video generator" },
+  "name.prompt": { "message": "Prompt", "description": "Prompt for generating the video" },
+  "name.model": { "message": "Model", "description": "Label for model selection" },
+  "name.ratio": { "message": "Aspect Ratio", "description": "Label for aspect ratio" },
+  "name.resolution": { "message": "Resolution", "description": "Label for resolution" },
+  "name.duration": { "message": "Duration", "description": "Label for duration" },
+  "name.image": { "message": "Image", "description": "Label for input image" },
+  "name.required": { "message": "Required", "description": "Required badge" },
+  "name.taskId": { "message": "Task ID", "description": "Task id label" },
+  "name.elapsed": { "message": "Elapsed", "description": "Elapsed time label" },
+  "name.traceId": { "message": "Trace ID", "description": "Trace id label" },
+  "name.failure": { "message": "Generation Failed", "description": "Failure title" },
+  "name.failureReason": { "message": "Reason", "description": "Failure reason label" },
+  "name.status": { "message": "Status", "description": "Status title" },
+  "description.prompt": {
+    "message": "Describe the video you want to generate (scene, subject, motion, camera, lighting, style).",
+    "description": "Instructions for prompt input"
+  },
+  "description.model": {
+    "message": "Choose the Grok Imagine model. grok-imagine-video supports text and image; 1.5-preview is image-to-video only.",
+    "description": "Instructions for model selection"
+  },
+  "description.ratio": { "message": "Select the output aspect ratio.", "description": "Instructions for aspect ratio" },
+  "description.resolution": {
+    "message": "Select the output resolution. Higher resolution costs more credits per second.",
+    "description": "Instructions for resolution"
+  },
+  "description.duration": {
+    "message": "Video duration in seconds. Billed per output second.",
+    "description": "Instructions for duration"
+  },
+  "description.image": {
+    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5-preview.",
+    "description": "Instructions for image input"
+  },
+  "placeholder.prompt": { "message": "Describe your video…", "description": "Placeholder for prompt" },
+  "placeholder.select": { "message": "Please select", "description": "Placeholder for selects" },
+  "model.default": { "message": "Grok Imagine Video", "description": "Default model label" },
+  "model.preview15": { "message": "Grok Imagine Video 1.5 (Preview, image-to-video)", "description": "1.5 preview model label" },
+  "button.upload": { "message": "Upload", "description": "Upload button" },
+  "button.generate": { "message": "Generate", "description": "Generate button" },
+  "button.download": { "message": "Download", "description": "Download button" },
+  "status.pending": { "message": "Pending", "description": "Pending status" },
+  "status.processing": { "message": "Processing", "description": "Processing status" },
+  "message.uploadExceed": { "message": "You can upload only one image.", "description": "Upload exceed warning" },
+  "message.uploadError": { "message": "Image upload failed, please try again.", "description": "Upload error" },
+  "message.downloadVideo": { "message": "Download video", "description": "Download tooltip" },
+  "message.modelRequiresImage": {
+    "message": "This model requires an input image (image-to-video).",
+    "description": "Model requires image warning"
+  },
+  "message.promptOrImageRequired": {
+    "message": "Please enter a prompt or upload an image.",
+    "description": "Prompt or image required warning"
+  },
+  "message.startingTask": { "message": "Submitting your video generation task…", "description": "Starting task" },
+  "message.startTaskSuccess": { "message": "Task submitted successfully.", "description": "Task success" },
+  "message.startTaskFailed": { "message": "Failed to submit task: ", "description": "Task failed" },
+  "message.usedUp": { "message": "Your quota has been used up. Please purchase more to continue.", "description": "Used up" }
+}

--- a/src/i18n/es/common.json
+++ b/src/i18n/es/common.json
@@ -507,6 +507,10 @@
     "message": "SeeDance",
     "description": "网站导航栏中的文本，用于显示SeeDance页面，请不要翻译此字段，必须保持为'SeeDance'"
   },
+  "nav.grokvideo": {
+    "message": "Grok Video",
+    "description": "Text in the website navigation bar to display the Grok Imagine video page"
+  },
   "nav.luma": {
     "message": "Luma",
     "description": "网站导航栏中的文本，用于显示Luma页面，请不要翻译此字段，必须保持为'Luma'"

--- a/src/i18n/es/grokvideo.json
+++ b/src/i18n/es/grokvideo.json
@@ -1,0 +1,61 @@
+{
+  "name.bot": { "message": "Grok Video Bot", "description": "Name of the Grok video generator" },
+  "name.prompt": { "message": "Prompt", "description": "Prompt for generating the video" },
+  "name.model": { "message": "Model", "description": "Label for model selection" },
+  "name.ratio": { "message": "Aspect Ratio", "description": "Label for aspect ratio" },
+  "name.resolution": { "message": "Resolution", "description": "Label for resolution" },
+  "name.duration": { "message": "Duration", "description": "Label for duration" },
+  "name.image": { "message": "Image", "description": "Label for input image" },
+  "name.required": { "message": "Required", "description": "Required badge" },
+  "name.taskId": { "message": "Task ID", "description": "Task id label" },
+  "name.elapsed": { "message": "Elapsed", "description": "Elapsed time label" },
+  "name.traceId": { "message": "Trace ID", "description": "Trace id label" },
+  "name.failure": { "message": "Generation Failed", "description": "Failure title" },
+  "name.failureReason": { "message": "Reason", "description": "Failure reason label" },
+  "name.status": { "message": "Status", "description": "Status title" },
+  "description.prompt": {
+    "message": "Describe the video you want to generate (scene, subject, motion, camera, lighting, style).",
+    "description": "Instructions for prompt input"
+  },
+  "description.model": {
+    "message": "Choose the Grok Imagine model. grok-imagine-video supports text and image; 1.5-preview is image-to-video only.",
+    "description": "Instructions for model selection"
+  },
+  "description.ratio": { "message": "Select the output aspect ratio.", "description": "Instructions for aspect ratio" },
+  "description.resolution": {
+    "message": "Select the output resolution. Higher resolution costs more credits per second.",
+    "description": "Instructions for resolution"
+  },
+  "description.duration": {
+    "message": "Video duration in seconds. Billed per output second.",
+    "description": "Instructions for duration"
+  },
+  "description.image": {
+    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5-preview.",
+    "description": "Instructions for image input"
+  },
+  "placeholder.prompt": { "message": "Describe your video…", "description": "Placeholder for prompt" },
+  "placeholder.select": { "message": "Please select", "description": "Placeholder for selects" },
+  "model.default": { "message": "Grok Imagine Video", "description": "Default model label" },
+  "model.preview15": { "message": "Grok Imagine Video 1.5 (Preview, image-to-video)", "description": "1.5 preview model label" },
+  "button.upload": { "message": "Upload", "description": "Upload button" },
+  "button.generate": { "message": "Generate", "description": "Generate button" },
+  "button.download": { "message": "Download", "description": "Download button" },
+  "status.pending": { "message": "Pending", "description": "Pending status" },
+  "status.processing": { "message": "Processing", "description": "Processing status" },
+  "message.uploadExceed": { "message": "You can upload only one image.", "description": "Upload exceed warning" },
+  "message.uploadError": { "message": "Image upload failed, please try again.", "description": "Upload error" },
+  "message.downloadVideo": { "message": "Download video", "description": "Download tooltip" },
+  "message.modelRequiresImage": {
+    "message": "This model requires an input image (image-to-video).",
+    "description": "Model requires image warning"
+  },
+  "message.promptOrImageRequired": {
+    "message": "Please enter a prompt or upload an image.",
+    "description": "Prompt or image required warning"
+  },
+  "message.startingTask": { "message": "Submitting your video generation task…", "description": "Starting task" },
+  "message.startTaskSuccess": { "message": "Task submitted successfully.", "description": "Task success" },
+  "message.startTaskFailed": { "message": "Failed to submit task: ", "description": "Task failed" },
+  "message.usedUp": { "message": "Your quota has been used up. Please purchase more to continue.", "description": "Used up" }
+}

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -507,6 +507,10 @@
     "message": "SeeDance",
     "description": "网站导航栏中的文本，用于显示SeeDance页面，请不要翻译此字段，必须保持为'SeeDance'"
   },
+  "nav.grokvideo": {
+    "message": "Grok Video",
+    "description": "Text in the website navigation bar to display the Grok Imagine video page"
+  },
   "nav.luma": {
     "message": "Luma",
     "description": "网站导航栏中的文本，用于显示Luma页面，请不要翻译此字段，必须保持为'Luma'"

--- a/src/i18n/fi/grokvideo.json
+++ b/src/i18n/fi/grokvideo.json
@@ -1,0 +1,61 @@
+{
+  "name.bot": { "message": "Grok Video Bot", "description": "Name of the Grok video generator" },
+  "name.prompt": { "message": "Prompt", "description": "Prompt for generating the video" },
+  "name.model": { "message": "Model", "description": "Label for model selection" },
+  "name.ratio": { "message": "Aspect Ratio", "description": "Label for aspect ratio" },
+  "name.resolution": { "message": "Resolution", "description": "Label for resolution" },
+  "name.duration": { "message": "Duration", "description": "Label for duration" },
+  "name.image": { "message": "Image", "description": "Label for input image" },
+  "name.required": { "message": "Required", "description": "Required badge" },
+  "name.taskId": { "message": "Task ID", "description": "Task id label" },
+  "name.elapsed": { "message": "Elapsed", "description": "Elapsed time label" },
+  "name.traceId": { "message": "Trace ID", "description": "Trace id label" },
+  "name.failure": { "message": "Generation Failed", "description": "Failure title" },
+  "name.failureReason": { "message": "Reason", "description": "Failure reason label" },
+  "name.status": { "message": "Status", "description": "Status title" },
+  "description.prompt": {
+    "message": "Describe the video you want to generate (scene, subject, motion, camera, lighting, style).",
+    "description": "Instructions for prompt input"
+  },
+  "description.model": {
+    "message": "Choose the Grok Imagine model. grok-imagine-video supports text and image; 1.5-preview is image-to-video only.",
+    "description": "Instructions for model selection"
+  },
+  "description.ratio": { "message": "Select the output aspect ratio.", "description": "Instructions for aspect ratio" },
+  "description.resolution": {
+    "message": "Select the output resolution. Higher resolution costs more credits per second.",
+    "description": "Instructions for resolution"
+  },
+  "description.duration": {
+    "message": "Video duration in seconds. Billed per output second.",
+    "description": "Instructions for duration"
+  },
+  "description.image": {
+    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5-preview.",
+    "description": "Instructions for image input"
+  },
+  "placeholder.prompt": { "message": "Describe your video…", "description": "Placeholder for prompt" },
+  "placeholder.select": { "message": "Please select", "description": "Placeholder for selects" },
+  "model.default": { "message": "Grok Imagine Video", "description": "Default model label" },
+  "model.preview15": { "message": "Grok Imagine Video 1.5 (Preview, image-to-video)", "description": "1.5 preview model label" },
+  "button.upload": { "message": "Upload", "description": "Upload button" },
+  "button.generate": { "message": "Generate", "description": "Generate button" },
+  "button.download": { "message": "Download", "description": "Download button" },
+  "status.pending": { "message": "Pending", "description": "Pending status" },
+  "status.processing": { "message": "Processing", "description": "Processing status" },
+  "message.uploadExceed": { "message": "You can upload only one image.", "description": "Upload exceed warning" },
+  "message.uploadError": { "message": "Image upload failed, please try again.", "description": "Upload error" },
+  "message.downloadVideo": { "message": "Download video", "description": "Download tooltip" },
+  "message.modelRequiresImage": {
+    "message": "This model requires an input image (image-to-video).",
+    "description": "Model requires image warning"
+  },
+  "message.promptOrImageRequired": {
+    "message": "Please enter a prompt or upload an image.",
+    "description": "Prompt or image required warning"
+  },
+  "message.startingTask": { "message": "Submitting your video generation task…", "description": "Starting task" },
+  "message.startTaskSuccess": { "message": "Task submitted successfully.", "description": "Task success" },
+  "message.startTaskFailed": { "message": "Failed to submit task: ", "description": "Task failed" },
+  "message.usedUp": { "message": "Your quota has been used up. Please purchase more to continue.", "description": "Used up" }
+}

--- a/src/i18n/fr/common.json
+++ b/src/i18n/fr/common.json
@@ -507,6 +507,10 @@
     "message": "SeeDance",
     "description": "网站导航栏中的文本，用于显示SeeDance页面，请不要翻译此字段，必须保持为'SeeDance'"
   },
+  "nav.grokvideo": {
+    "message": "Grok Video",
+    "description": "Text in the website navigation bar to display the Grok Imagine video page"
+  },
   "nav.luma": {
     "message": "Luma",
     "description": "网站导航栏中的文本，用于显示Luma页面，请不要翻译此字段，必须保持为'Luma'"

--- a/src/i18n/fr/grokvideo.json
+++ b/src/i18n/fr/grokvideo.json
@@ -1,0 +1,61 @@
+{
+  "name.bot": { "message": "Grok Video Bot", "description": "Name of the Grok video generator" },
+  "name.prompt": { "message": "Prompt", "description": "Prompt for generating the video" },
+  "name.model": { "message": "Model", "description": "Label for model selection" },
+  "name.ratio": { "message": "Aspect Ratio", "description": "Label for aspect ratio" },
+  "name.resolution": { "message": "Resolution", "description": "Label for resolution" },
+  "name.duration": { "message": "Duration", "description": "Label for duration" },
+  "name.image": { "message": "Image", "description": "Label for input image" },
+  "name.required": { "message": "Required", "description": "Required badge" },
+  "name.taskId": { "message": "Task ID", "description": "Task id label" },
+  "name.elapsed": { "message": "Elapsed", "description": "Elapsed time label" },
+  "name.traceId": { "message": "Trace ID", "description": "Trace id label" },
+  "name.failure": { "message": "Generation Failed", "description": "Failure title" },
+  "name.failureReason": { "message": "Reason", "description": "Failure reason label" },
+  "name.status": { "message": "Status", "description": "Status title" },
+  "description.prompt": {
+    "message": "Describe the video you want to generate (scene, subject, motion, camera, lighting, style).",
+    "description": "Instructions for prompt input"
+  },
+  "description.model": {
+    "message": "Choose the Grok Imagine model. grok-imagine-video supports text and image; 1.5-preview is image-to-video only.",
+    "description": "Instructions for model selection"
+  },
+  "description.ratio": { "message": "Select the output aspect ratio.", "description": "Instructions for aspect ratio" },
+  "description.resolution": {
+    "message": "Select the output resolution. Higher resolution costs more credits per second.",
+    "description": "Instructions for resolution"
+  },
+  "description.duration": {
+    "message": "Video duration in seconds. Billed per output second.",
+    "description": "Instructions for duration"
+  },
+  "description.image": {
+    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5-preview.",
+    "description": "Instructions for image input"
+  },
+  "placeholder.prompt": { "message": "Describe your video…", "description": "Placeholder for prompt" },
+  "placeholder.select": { "message": "Please select", "description": "Placeholder for selects" },
+  "model.default": { "message": "Grok Imagine Video", "description": "Default model label" },
+  "model.preview15": { "message": "Grok Imagine Video 1.5 (Preview, image-to-video)", "description": "1.5 preview model label" },
+  "button.upload": { "message": "Upload", "description": "Upload button" },
+  "button.generate": { "message": "Generate", "description": "Generate button" },
+  "button.download": { "message": "Download", "description": "Download button" },
+  "status.pending": { "message": "Pending", "description": "Pending status" },
+  "status.processing": { "message": "Processing", "description": "Processing status" },
+  "message.uploadExceed": { "message": "You can upload only one image.", "description": "Upload exceed warning" },
+  "message.uploadError": { "message": "Image upload failed, please try again.", "description": "Upload error" },
+  "message.downloadVideo": { "message": "Download video", "description": "Download tooltip" },
+  "message.modelRequiresImage": {
+    "message": "This model requires an input image (image-to-video).",
+    "description": "Model requires image warning"
+  },
+  "message.promptOrImageRequired": {
+    "message": "Please enter a prompt or upload an image.",
+    "description": "Prompt or image required warning"
+  },
+  "message.startingTask": { "message": "Submitting your video generation task…", "description": "Starting task" },
+  "message.startTaskSuccess": { "message": "Task submitted successfully.", "description": "Task success" },
+  "message.startTaskFailed": { "message": "Failed to submit task: ", "description": "Task failed" },
+  "message.usedUp": { "message": "Your quota has been used up. Please purchase more to continue.", "description": "Used up" }
+}

--- a/src/i18n/it/common.json
+++ b/src/i18n/it/common.json
@@ -507,6 +507,10 @@
     "message": "SeeDance",
     "description": "Testo nella barra di navigazione del sito per visualizzare la pagina SeeDance, non tradurre questo campo, deve rimanere 'SeeDance'"
   },
+  "nav.grokvideo": {
+    "message": "Grok Video",
+    "description": "Text in the website navigation bar to display the Grok Imagine video page"
+  },
   "nav.luma": {
     "message": "Luma",
     "description": "Testo nella barra di navigazione del sito per visualizzare la pagina Luma, non tradurre questo campo, deve rimanere 'Luma'"

--- a/src/i18n/it/grokvideo.json
+++ b/src/i18n/it/grokvideo.json
@@ -1,0 +1,61 @@
+{
+  "name.bot": { "message": "Grok Video Bot", "description": "Name of the Grok video generator" },
+  "name.prompt": { "message": "Prompt", "description": "Prompt for generating the video" },
+  "name.model": { "message": "Model", "description": "Label for model selection" },
+  "name.ratio": { "message": "Aspect Ratio", "description": "Label for aspect ratio" },
+  "name.resolution": { "message": "Resolution", "description": "Label for resolution" },
+  "name.duration": { "message": "Duration", "description": "Label for duration" },
+  "name.image": { "message": "Image", "description": "Label for input image" },
+  "name.required": { "message": "Required", "description": "Required badge" },
+  "name.taskId": { "message": "Task ID", "description": "Task id label" },
+  "name.elapsed": { "message": "Elapsed", "description": "Elapsed time label" },
+  "name.traceId": { "message": "Trace ID", "description": "Trace id label" },
+  "name.failure": { "message": "Generation Failed", "description": "Failure title" },
+  "name.failureReason": { "message": "Reason", "description": "Failure reason label" },
+  "name.status": { "message": "Status", "description": "Status title" },
+  "description.prompt": {
+    "message": "Describe the video you want to generate (scene, subject, motion, camera, lighting, style).",
+    "description": "Instructions for prompt input"
+  },
+  "description.model": {
+    "message": "Choose the Grok Imagine model. grok-imagine-video supports text and image; 1.5-preview is image-to-video only.",
+    "description": "Instructions for model selection"
+  },
+  "description.ratio": { "message": "Select the output aspect ratio.", "description": "Instructions for aspect ratio" },
+  "description.resolution": {
+    "message": "Select the output resolution. Higher resolution costs more credits per second.",
+    "description": "Instructions for resolution"
+  },
+  "description.duration": {
+    "message": "Video duration in seconds. Billed per output second.",
+    "description": "Instructions for duration"
+  },
+  "description.image": {
+    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5-preview.",
+    "description": "Instructions for image input"
+  },
+  "placeholder.prompt": { "message": "Describe your video…", "description": "Placeholder for prompt" },
+  "placeholder.select": { "message": "Please select", "description": "Placeholder for selects" },
+  "model.default": { "message": "Grok Imagine Video", "description": "Default model label" },
+  "model.preview15": { "message": "Grok Imagine Video 1.5 (Preview, image-to-video)", "description": "1.5 preview model label" },
+  "button.upload": { "message": "Upload", "description": "Upload button" },
+  "button.generate": { "message": "Generate", "description": "Generate button" },
+  "button.download": { "message": "Download", "description": "Download button" },
+  "status.pending": { "message": "Pending", "description": "Pending status" },
+  "status.processing": { "message": "Processing", "description": "Processing status" },
+  "message.uploadExceed": { "message": "You can upload only one image.", "description": "Upload exceed warning" },
+  "message.uploadError": { "message": "Image upload failed, please try again.", "description": "Upload error" },
+  "message.downloadVideo": { "message": "Download video", "description": "Download tooltip" },
+  "message.modelRequiresImage": {
+    "message": "This model requires an input image (image-to-video).",
+    "description": "Model requires image warning"
+  },
+  "message.promptOrImageRequired": {
+    "message": "Please enter a prompt or upload an image.",
+    "description": "Prompt or image required warning"
+  },
+  "message.startingTask": { "message": "Submitting your video generation task…", "description": "Starting task" },
+  "message.startTaskSuccess": { "message": "Task submitted successfully.", "description": "Task success" },
+  "message.startTaskFailed": { "message": "Failed to submit task: ", "description": "Task failed" },
+  "message.usedUp": { "message": "Your quota has been used up. Please purchase more to continue.", "description": "Used up" }
+}

--- a/src/i18n/ja/common.json
+++ b/src/i18n/ja/common.json
@@ -507,6 +507,10 @@
     "message": "SeeDance",
     "description": "ウェブサイトのナビゲーションバーのテキストで、SeeDanceページを表示するためのものです。このフィールドは翻訳しないでください。'SeeDance'のままにしてください。"
   },
+  "nav.grokvideo": {
+    "message": "Grok Video",
+    "description": "Text in the website navigation bar to display the Grok Imagine video page"
+  },
   "nav.luma": {
     "message": "Luma",
     "description": "ウェブサイトのナビゲーションバーのテキストで、Lumaページを表示するためのものです。このフィールドは翻訳しないでください。'Luma'のままにしてください。"

--- a/src/i18n/ja/grokvideo.json
+++ b/src/i18n/ja/grokvideo.json
@@ -1,0 +1,61 @@
+{
+  "name.bot": { "message": "Grok Video Bot", "description": "Name of the Grok video generator" },
+  "name.prompt": { "message": "Prompt", "description": "Prompt for generating the video" },
+  "name.model": { "message": "Model", "description": "Label for model selection" },
+  "name.ratio": { "message": "Aspect Ratio", "description": "Label for aspect ratio" },
+  "name.resolution": { "message": "Resolution", "description": "Label for resolution" },
+  "name.duration": { "message": "Duration", "description": "Label for duration" },
+  "name.image": { "message": "Image", "description": "Label for input image" },
+  "name.required": { "message": "Required", "description": "Required badge" },
+  "name.taskId": { "message": "Task ID", "description": "Task id label" },
+  "name.elapsed": { "message": "Elapsed", "description": "Elapsed time label" },
+  "name.traceId": { "message": "Trace ID", "description": "Trace id label" },
+  "name.failure": { "message": "Generation Failed", "description": "Failure title" },
+  "name.failureReason": { "message": "Reason", "description": "Failure reason label" },
+  "name.status": { "message": "Status", "description": "Status title" },
+  "description.prompt": {
+    "message": "Describe the video you want to generate (scene, subject, motion, camera, lighting, style).",
+    "description": "Instructions for prompt input"
+  },
+  "description.model": {
+    "message": "Choose the Grok Imagine model. grok-imagine-video supports text and image; 1.5-preview is image-to-video only.",
+    "description": "Instructions for model selection"
+  },
+  "description.ratio": { "message": "Select the output aspect ratio.", "description": "Instructions for aspect ratio" },
+  "description.resolution": {
+    "message": "Select the output resolution. Higher resolution costs more credits per second.",
+    "description": "Instructions for resolution"
+  },
+  "description.duration": {
+    "message": "Video duration in seconds. Billed per output second.",
+    "description": "Instructions for duration"
+  },
+  "description.image": {
+    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5-preview.",
+    "description": "Instructions for image input"
+  },
+  "placeholder.prompt": { "message": "Describe your video…", "description": "Placeholder for prompt" },
+  "placeholder.select": { "message": "Please select", "description": "Placeholder for selects" },
+  "model.default": { "message": "Grok Imagine Video", "description": "Default model label" },
+  "model.preview15": { "message": "Grok Imagine Video 1.5 (Preview, image-to-video)", "description": "1.5 preview model label" },
+  "button.upload": { "message": "Upload", "description": "Upload button" },
+  "button.generate": { "message": "Generate", "description": "Generate button" },
+  "button.download": { "message": "Download", "description": "Download button" },
+  "status.pending": { "message": "Pending", "description": "Pending status" },
+  "status.processing": { "message": "Processing", "description": "Processing status" },
+  "message.uploadExceed": { "message": "You can upload only one image.", "description": "Upload exceed warning" },
+  "message.uploadError": { "message": "Image upload failed, please try again.", "description": "Upload error" },
+  "message.downloadVideo": { "message": "Download video", "description": "Download tooltip" },
+  "message.modelRequiresImage": {
+    "message": "This model requires an input image (image-to-video).",
+    "description": "Model requires image warning"
+  },
+  "message.promptOrImageRequired": {
+    "message": "Please enter a prompt or upload an image.",
+    "description": "Prompt or image required warning"
+  },
+  "message.startingTask": { "message": "Submitting your video generation task…", "description": "Starting task" },
+  "message.startTaskSuccess": { "message": "Task submitted successfully.", "description": "Task success" },
+  "message.startTaskFailed": { "message": "Failed to submit task: ", "description": "Task failed" },
+  "message.usedUp": { "message": "Your quota has been used up. Please purchase more to continue.", "description": "Used up" }
+}

--- a/src/i18n/ko/common.json
+++ b/src/i18n/ko/common.json
@@ -507,6 +507,10 @@
     "message": "SeeDance",
     "description": "사이트 내비게이션 바의 텍스트로 SeeDance 페이지를 표시합니다. 이 필드는 번역하지 말고 'SeeDance'로 유지해야 합니다."
   },
+  "nav.grokvideo": {
+    "message": "Grok Video",
+    "description": "Text in the website navigation bar to display the Grok Imagine video page"
+  },
   "nav.luma": {
     "message": "Luma",
     "description": "사이트 내비게이션 바의 텍스트로 Luma 페이지를 표시합니다. 이 필드는 번역하지 말고 'Luma'로 유지해야 합니다."

--- a/src/i18n/ko/grokvideo.json
+++ b/src/i18n/ko/grokvideo.json
@@ -1,0 +1,61 @@
+{
+  "name.bot": { "message": "Grok Video Bot", "description": "Name of the Grok video generator" },
+  "name.prompt": { "message": "Prompt", "description": "Prompt for generating the video" },
+  "name.model": { "message": "Model", "description": "Label for model selection" },
+  "name.ratio": { "message": "Aspect Ratio", "description": "Label for aspect ratio" },
+  "name.resolution": { "message": "Resolution", "description": "Label for resolution" },
+  "name.duration": { "message": "Duration", "description": "Label for duration" },
+  "name.image": { "message": "Image", "description": "Label for input image" },
+  "name.required": { "message": "Required", "description": "Required badge" },
+  "name.taskId": { "message": "Task ID", "description": "Task id label" },
+  "name.elapsed": { "message": "Elapsed", "description": "Elapsed time label" },
+  "name.traceId": { "message": "Trace ID", "description": "Trace id label" },
+  "name.failure": { "message": "Generation Failed", "description": "Failure title" },
+  "name.failureReason": { "message": "Reason", "description": "Failure reason label" },
+  "name.status": { "message": "Status", "description": "Status title" },
+  "description.prompt": {
+    "message": "Describe the video you want to generate (scene, subject, motion, camera, lighting, style).",
+    "description": "Instructions for prompt input"
+  },
+  "description.model": {
+    "message": "Choose the Grok Imagine model. grok-imagine-video supports text and image; 1.5-preview is image-to-video only.",
+    "description": "Instructions for model selection"
+  },
+  "description.ratio": { "message": "Select the output aspect ratio.", "description": "Instructions for aspect ratio" },
+  "description.resolution": {
+    "message": "Select the output resolution. Higher resolution costs more credits per second.",
+    "description": "Instructions for resolution"
+  },
+  "description.duration": {
+    "message": "Video duration in seconds. Billed per output second.",
+    "description": "Instructions for duration"
+  },
+  "description.image": {
+    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5-preview.",
+    "description": "Instructions for image input"
+  },
+  "placeholder.prompt": { "message": "Describe your video…", "description": "Placeholder for prompt" },
+  "placeholder.select": { "message": "Please select", "description": "Placeholder for selects" },
+  "model.default": { "message": "Grok Imagine Video", "description": "Default model label" },
+  "model.preview15": { "message": "Grok Imagine Video 1.5 (Preview, image-to-video)", "description": "1.5 preview model label" },
+  "button.upload": { "message": "Upload", "description": "Upload button" },
+  "button.generate": { "message": "Generate", "description": "Generate button" },
+  "button.download": { "message": "Download", "description": "Download button" },
+  "status.pending": { "message": "Pending", "description": "Pending status" },
+  "status.processing": { "message": "Processing", "description": "Processing status" },
+  "message.uploadExceed": { "message": "You can upload only one image.", "description": "Upload exceed warning" },
+  "message.uploadError": { "message": "Image upload failed, please try again.", "description": "Upload error" },
+  "message.downloadVideo": { "message": "Download video", "description": "Download tooltip" },
+  "message.modelRequiresImage": {
+    "message": "This model requires an input image (image-to-video).",
+    "description": "Model requires image warning"
+  },
+  "message.promptOrImageRequired": {
+    "message": "Please enter a prompt or upload an image.",
+    "description": "Prompt or image required warning"
+  },
+  "message.startingTask": { "message": "Submitting your video generation task…", "description": "Starting task" },
+  "message.startTaskSuccess": { "message": "Task submitted successfully.", "description": "Task success" },
+  "message.startTaskFailed": { "message": "Failed to submit task: ", "description": "Task failed" },
+  "message.usedUp": { "message": "Your quota has been used up. Please purchase more to continue.", "description": "Used up" }
+}

--- a/src/i18n/pl/common.json
+++ b/src/i18n/pl/common.json
@@ -507,6 +507,10 @@
     "message": "SeeDance",
     "description": "Tekst w nawigacji strony, który wyświetla stronę SeeDance, nie tłumaczyć, musi pozostać 'SeeDance'"
   },
+  "nav.grokvideo": {
+    "message": "Grok Video",
+    "description": "Text in the website navigation bar to display the Grok Imagine video page"
+  },
   "nav.luma": {
     "message": "Luma",
     "description": "Tekst w nawigacji strony, który wyświetla stronę Luma, nie tłumaczyć, musi pozostać 'Luma'"

--- a/src/i18n/pl/grokvideo.json
+++ b/src/i18n/pl/grokvideo.json
@@ -1,0 +1,61 @@
+{
+  "name.bot": { "message": "Grok Video Bot", "description": "Name of the Grok video generator" },
+  "name.prompt": { "message": "Prompt", "description": "Prompt for generating the video" },
+  "name.model": { "message": "Model", "description": "Label for model selection" },
+  "name.ratio": { "message": "Aspect Ratio", "description": "Label for aspect ratio" },
+  "name.resolution": { "message": "Resolution", "description": "Label for resolution" },
+  "name.duration": { "message": "Duration", "description": "Label for duration" },
+  "name.image": { "message": "Image", "description": "Label for input image" },
+  "name.required": { "message": "Required", "description": "Required badge" },
+  "name.taskId": { "message": "Task ID", "description": "Task id label" },
+  "name.elapsed": { "message": "Elapsed", "description": "Elapsed time label" },
+  "name.traceId": { "message": "Trace ID", "description": "Trace id label" },
+  "name.failure": { "message": "Generation Failed", "description": "Failure title" },
+  "name.failureReason": { "message": "Reason", "description": "Failure reason label" },
+  "name.status": { "message": "Status", "description": "Status title" },
+  "description.prompt": {
+    "message": "Describe the video you want to generate (scene, subject, motion, camera, lighting, style).",
+    "description": "Instructions for prompt input"
+  },
+  "description.model": {
+    "message": "Choose the Grok Imagine model. grok-imagine-video supports text and image; 1.5-preview is image-to-video only.",
+    "description": "Instructions for model selection"
+  },
+  "description.ratio": { "message": "Select the output aspect ratio.", "description": "Instructions for aspect ratio" },
+  "description.resolution": {
+    "message": "Select the output resolution. Higher resolution costs more credits per second.",
+    "description": "Instructions for resolution"
+  },
+  "description.duration": {
+    "message": "Video duration in seconds. Billed per output second.",
+    "description": "Instructions for duration"
+  },
+  "description.image": {
+    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5-preview.",
+    "description": "Instructions for image input"
+  },
+  "placeholder.prompt": { "message": "Describe your video…", "description": "Placeholder for prompt" },
+  "placeholder.select": { "message": "Please select", "description": "Placeholder for selects" },
+  "model.default": { "message": "Grok Imagine Video", "description": "Default model label" },
+  "model.preview15": { "message": "Grok Imagine Video 1.5 (Preview, image-to-video)", "description": "1.5 preview model label" },
+  "button.upload": { "message": "Upload", "description": "Upload button" },
+  "button.generate": { "message": "Generate", "description": "Generate button" },
+  "button.download": { "message": "Download", "description": "Download button" },
+  "status.pending": { "message": "Pending", "description": "Pending status" },
+  "status.processing": { "message": "Processing", "description": "Processing status" },
+  "message.uploadExceed": { "message": "You can upload only one image.", "description": "Upload exceed warning" },
+  "message.uploadError": { "message": "Image upload failed, please try again.", "description": "Upload error" },
+  "message.downloadVideo": { "message": "Download video", "description": "Download tooltip" },
+  "message.modelRequiresImage": {
+    "message": "This model requires an input image (image-to-video).",
+    "description": "Model requires image warning"
+  },
+  "message.promptOrImageRequired": {
+    "message": "Please enter a prompt or upload an image.",
+    "description": "Prompt or image required warning"
+  },
+  "message.startingTask": { "message": "Submitting your video generation task…", "description": "Starting task" },
+  "message.startTaskSuccess": { "message": "Task submitted successfully.", "description": "Task success" },
+  "message.startTaskFailed": { "message": "Failed to submit task: ", "description": "Task failed" },
+  "message.usedUp": { "message": "Your quota has been used up. Please purchase more to continue.", "description": "Used up" }
+}

--- a/src/i18n/pt/common.json
+++ b/src/i18n/pt/common.json
@@ -507,6 +507,10 @@
     "message": "SeeDance",
     "description": "Texto na barra de navegação do site para exibir a página SeeDance, não deve ser traduzido, deve permanecer como 'SeeDance'"
   },
+  "nav.grokvideo": {
+    "message": "Grok Video",
+    "description": "Text in the website navigation bar to display the Grok Imagine video page"
+  },
   "nav.luma": {
     "message": "Luma",
     "description": "Texto na barra de navegação do site para exibir a página Luma, não deve ser traduzido, deve permanecer como 'Luma'"

--- a/src/i18n/pt/grokvideo.json
+++ b/src/i18n/pt/grokvideo.json
@@ -1,0 +1,61 @@
+{
+  "name.bot": { "message": "Grok Video Bot", "description": "Name of the Grok video generator" },
+  "name.prompt": { "message": "Prompt", "description": "Prompt for generating the video" },
+  "name.model": { "message": "Model", "description": "Label for model selection" },
+  "name.ratio": { "message": "Aspect Ratio", "description": "Label for aspect ratio" },
+  "name.resolution": { "message": "Resolution", "description": "Label for resolution" },
+  "name.duration": { "message": "Duration", "description": "Label for duration" },
+  "name.image": { "message": "Image", "description": "Label for input image" },
+  "name.required": { "message": "Required", "description": "Required badge" },
+  "name.taskId": { "message": "Task ID", "description": "Task id label" },
+  "name.elapsed": { "message": "Elapsed", "description": "Elapsed time label" },
+  "name.traceId": { "message": "Trace ID", "description": "Trace id label" },
+  "name.failure": { "message": "Generation Failed", "description": "Failure title" },
+  "name.failureReason": { "message": "Reason", "description": "Failure reason label" },
+  "name.status": { "message": "Status", "description": "Status title" },
+  "description.prompt": {
+    "message": "Describe the video you want to generate (scene, subject, motion, camera, lighting, style).",
+    "description": "Instructions for prompt input"
+  },
+  "description.model": {
+    "message": "Choose the Grok Imagine model. grok-imagine-video supports text and image; 1.5-preview is image-to-video only.",
+    "description": "Instructions for model selection"
+  },
+  "description.ratio": { "message": "Select the output aspect ratio.", "description": "Instructions for aspect ratio" },
+  "description.resolution": {
+    "message": "Select the output resolution. Higher resolution costs more credits per second.",
+    "description": "Instructions for resolution"
+  },
+  "description.duration": {
+    "message": "Video duration in seconds. Billed per output second.",
+    "description": "Instructions for duration"
+  },
+  "description.image": {
+    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5-preview.",
+    "description": "Instructions for image input"
+  },
+  "placeholder.prompt": { "message": "Describe your video…", "description": "Placeholder for prompt" },
+  "placeholder.select": { "message": "Please select", "description": "Placeholder for selects" },
+  "model.default": { "message": "Grok Imagine Video", "description": "Default model label" },
+  "model.preview15": { "message": "Grok Imagine Video 1.5 (Preview, image-to-video)", "description": "1.5 preview model label" },
+  "button.upload": { "message": "Upload", "description": "Upload button" },
+  "button.generate": { "message": "Generate", "description": "Generate button" },
+  "button.download": { "message": "Download", "description": "Download button" },
+  "status.pending": { "message": "Pending", "description": "Pending status" },
+  "status.processing": { "message": "Processing", "description": "Processing status" },
+  "message.uploadExceed": { "message": "You can upload only one image.", "description": "Upload exceed warning" },
+  "message.uploadError": { "message": "Image upload failed, please try again.", "description": "Upload error" },
+  "message.downloadVideo": { "message": "Download video", "description": "Download tooltip" },
+  "message.modelRequiresImage": {
+    "message": "This model requires an input image (image-to-video).",
+    "description": "Model requires image warning"
+  },
+  "message.promptOrImageRequired": {
+    "message": "Please enter a prompt or upload an image.",
+    "description": "Prompt or image required warning"
+  },
+  "message.startingTask": { "message": "Submitting your video generation task…", "description": "Starting task" },
+  "message.startTaskSuccess": { "message": "Task submitted successfully.", "description": "Task success" },
+  "message.startTaskFailed": { "message": "Failed to submit task: ", "description": "Task failed" },
+  "message.usedUp": { "message": "Your quota has been used up. Please purchase more to continue.", "description": "Used up" }
+}

--- a/src/i18n/ru/common.json
+++ b/src/i18n/ru/common.json
@@ -507,6 +507,10 @@
     "message": "SeeDance",
     "description": "网站导航栏中的文本，用于显示SeeDance页面，请不要翻译此字段，必须保持为'SeeDance'"
   },
+  "nav.grokvideo": {
+    "message": "Grok Video",
+    "description": "Text in the website navigation bar to display the Grok Imagine video page"
+  },
   "nav.luma": {
     "message": "Luma",
     "description": "网站导航栏中的文本，用于显示Luma页面，请不要翻译此字段，必须保持为'Luma'"

--- a/src/i18n/ru/grokvideo.json
+++ b/src/i18n/ru/grokvideo.json
@@ -1,0 +1,61 @@
+{
+  "name.bot": { "message": "Grok Video Bot", "description": "Name of the Grok video generator" },
+  "name.prompt": { "message": "Prompt", "description": "Prompt for generating the video" },
+  "name.model": { "message": "Model", "description": "Label for model selection" },
+  "name.ratio": { "message": "Aspect Ratio", "description": "Label for aspect ratio" },
+  "name.resolution": { "message": "Resolution", "description": "Label for resolution" },
+  "name.duration": { "message": "Duration", "description": "Label for duration" },
+  "name.image": { "message": "Image", "description": "Label for input image" },
+  "name.required": { "message": "Required", "description": "Required badge" },
+  "name.taskId": { "message": "Task ID", "description": "Task id label" },
+  "name.elapsed": { "message": "Elapsed", "description": "Elapsed time label" },
+  "name.traceId": { "message": "Trace ID", "description": "Trace id label" },
+  "name.failure": { "message": "Generation Failed", "description": "Failure title" },
+  "name.failureReason": { "message": "Reason", "description": "Failure reason label" },
+  "name.status": { "message": "Status", "description": "Status title" },
+  "description.prompt": {
+    "message": "Describe the video you want to generate (scene, subject, motion, camera, lighting, style).",
+    "description": "Instructions for prompt input"
+  },
+  "description.model": {
+    "message": "Choose the Grok Imagine model. grok-imagine-video supports text and image; 1.5-preview is image-to-video only.",
+    "description": "Instructions for model selection"
+  },
+  "description.ratio": { "message": "Select the output aspect ratio.", "description": "Instructions for aspect ratio" },
+  "description.resolution": {
+    "message": "Select the output resolution. Higher resolution costs more credits per second.",
+    "description": "Instructions for resolution"
+  },
+  "description.duration": {
+    "message": "Video duration in seconds. Billed per output second.",
+    "description": "Instructions for duration"
+  },
+  "description.image": {
+    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5-preview.",
+    "description": "Instructions for image input"
+  },
+  "placeholder.prompt": { "message": "Describe your video…", "description": "Placeholder for prompt" },
+  "placeholder.select": { "message": "Please select", "description": "Placeholder for selects" },
+  "model.default": { "message": "Grok Imagine Video", "description": "Default model label" },
+  "model.preview15": { "message": "Grok Imagine Video 1.5 (Preview, image-to-video)", "description": "1.5 preview model label" },
+  "button.upload": { "message": "Upload", "description": "Upload button" },
+  "button.generate": { "message": "Generate", "description": "Generate button" },
+  "button.download": { "message": "Download", "description": "Download button" },
+  "status.pending": { "message": "Pending", "description": "Pending status" },
+  "status.processing": { "message": "Processing", "description": "Processing status" },
+  "message.uploadExceed": { "message": "You can upload only one image.", "description": "Upload exceed warning" },
+  "message.uploadError": { "message": "Image upload failed, please try again.", "description": "Upload error" },
+  "message.downloadVideo": { "message": "Download video", "description": "Download tooltip" },
+  "message.modelRequiresImage": {
+    "message": "This model requires an input image (image-to-video).",
+    "description": "Model requires image warning"
+  },
+  "message.promptOrImageRequired": {
+    "message": "Please enter a prompt or upload an image.",
+    "description": "Prompt or image required warning"
+  },
+  "message.startingTask": { "message": "Submitting your video generation task…", "description": "Starting task" },
+  "message.startTaskSuccess": { "message": "Task submitted successfully.", "description": "Task success" },
+  "message.startTaskFailed": { "message": "Failed to submit task: ", "description": "Task failed" },
+  "message.usedUp": { "message": "Your quota has been used up. Please purchase more to continue.", "description": "Used up" }
+}

--- a/src/i18n/sr/common.json
+++ b/src/i18n/sr/common.json
@@ -507,6 +507,10 @@
     "message": "SeeDance",
     "description": "网站导航栏中的文本，用于显示SeeDance页面，请不要翻译此字段，必须保持为'SeeDance'"
   },
+  "nav.grokvideo": {
+    "message": "Grok Video",
+    "description": "Text in the website navigation bar to display the Grok Imagine video page"
+  },
   "nav.luma": {
     "message": "Luma",
     "description": "网站导航栏中的文本，用于显示Luma页面，请不要翻译此字段，必须保持为'Luma'"

--- a/src/i18n/sr/grokvideo.json
+++ b/src/i18n/sr/grokvideo.json
@@ -1,0 +1,61 @@
+{
+  "name.bot": { "message": "Grok Video Bot", "description": "Name of the Grok video generator" },
+  "name.prompt": { "message": "Prompt", "description": "Prompt for generating the video" },
+  "name.model": { "message": "Model", "description": "Label for model selection" },
+  "name.ratio": { "message": "Aspect Ratio", "description": "Label for aspect ratio" },
+  "name.resolution": { "message": "Resolution", "description": "Label for resolution" },
+  "name.duration": { "message": "Duration", "description": "Label for duration" },
+  "name.image": { "message": "Image", "description": "Label for input image" },
+  "name.required": { "message": "Required", "description": "Required badge" },
+  "name.taskId": { "message": "Task ID", "description": "Task id label" },
+  "name.elapsed": { "message": "Elapsed", "description": "Elapsed time label" },
+  "name.traceId": { "message": "Trace ID", "description": "Trace id label" },
+  "name.failure": { "message": "Generation Failed", "description": "Failure title" },
+  "name.failureReason": { "message": "Reason", "description": "Failure reason label" },
+  "name.status": { "message": "Status", "description": "Status title" },
+  "description.prompt": {
+    "message": "Describe the video you want to generate (scene, subject, motion, camera, lighting, style).",
+    "description": "Instructions for prompt input"
+  },
+  "description.model": {
+    "message": "Choose the Grok Imagine model. grok-imagine-video supports text and image; 1.5-preview is image-to-video only.",
+    "description": "Instructions for model selection"
+  },
+  "description.ratio": { "message": "Select the output aspect ratio.", "description": "Instructions for aspect ratio" },
+  "description.resolution": {
+    "message": "Select the output resolution. Higher resolution costs more credits per second.",
+    "description": "Instructions for resolution"
+  },
+  "description.duration": {
+    "message": "Video duration in seconds. Billed per output second.",
+    "description": "Instructions for duration"
+  },
+  "description.image": {
+    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5-preview.",
+    "description": "Instructions for image input"
+  },
+  "placeholder.prompt": { "message": "Describe your video…", "description": "Placeholder for prompt" },
+  "placeholder.select": { "message": "Please select", "description": "Placeholder for selects" },
+  "model.default": { "message": "Grok Imagine Video", "description": "Default model label" },
+  "model.preview15": { "message": "Grok Imagine Video 1.5 (Preview, image-to-video)", "description": "1.5 preview model label" },
+  "button.upload": { "message": "Upload", "description": "Upload button" },
+  "button.generate": { "message": "Generate", "description": "Generate button" },
+  "button.download": { "message": "Download", "description": "Download button" },
+  "status.pending": { "message": "Pending", "description": "Pending status" },
+  "status.processing": { "message": "Processing", "description": "Processing status" },
+  "message.uploadExceed": { "message": "You can upload only one image.", "description": "Upload exceed warning" },
+  "message.uploadError": { "message": "Image upload failed, please try again.", "description": "Upload error" },
+  "message.downloadVideo": { "message": "Download video", "description": "Download tooltip" },
+  "message.modelRequiresImage": {
+    "message": "This model requires an input image (image-to-video).",
+    "description": "Model requires image warning"
+  },
+  "message.promptOrImageRequired": {
+    "message": "Please enter a prompt or upload an image.",
+    "description": "Prompt or image required warning"
+  },
+  "message.startingTask": { "message": "Submitting your video generation task…", "description": "Starting task" },
+  "message.startTaskSuccess": { "message": "Task submitted successfully.", "description": "Task success" },
+  "message.startTaskFailed": { "message": "Failed to submit task: ", "description": "Task failed" },
+  "message.usedUp": { "message": "Your quota has been used up. Please purchase more to continue.", "description": "Used up" }
+}

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -507,6 +507,10 @@
     "message": "SeeDance",
     "description": "Text in the website navigation bar for displaying the SeeDance page, must remain 'SeeDance'"
   },
+  "nav.grokvideo": {
+    "message": "Grok Video",
+    "description": "Text in the website navigation bar to display the Grok Imagine video page"
+  },
   "nav.luma": {
     "message": "Luma",
     "description": "Text in the website navigation bar for displaying the Luma page, must remain 'Luma'"

--- a/src/i18n/sv/grokvideo.json
+++ b/src/i18n/sv/grokvideo.json
@@ -1,0 +1,61 @@
+{
+  "name.bot": { "message": "Grok Video Bot", "description": "Name of the Grok video generator" },
+  "name.prompt": { "message": "Prompt", "description": "Prompt for generating the video" },
+  "name.model": { "message": "Model", "description": "Label for model selection" },
+  "name.ratio": { "message": "Aspect Ratio", "description": "Label for aspect ratio" },
+  "name.resolution": { "message": "Resolution", "description": "Label for resolution" },
+  "name.duration": { "message": "Duration", "description": "Label for duration" },
+  "name.image": { "message": "Image", "description": "Label for input image" },
+  "name.required": { "message": "Required", "description": "Required badge" },
+  "name.taskId": { "message": "Task ID", "description": "Task id label" },
+  "name.elapsed": { "message": "Elapsed", "description": "Elapsed time label" },
+  "name.traceId": { "message": "Trace ID", "description": "Trace id label" },
+  "name.failure": { "message": "Generation Failed", "description": "Failure title" },
+  "name.failureReason": { "message": "Reason", "description": "Failure reason label" },
+  "name.status": { "message": "Status", "description": "Status title" },
+  "description.prompt": {
+    "message": "Describe the video you want to generate (scene, subject, motion, camera, lighting, style).",
+    "description": "Instructions for prompt input"
+  },
+  "description.model": {
+    "message": "Choose the Grok Imagine model. grok-imagine-video supports text and image; 1.5-preview is image-to-video only.",
+    "description": "Instructions for model selection"
+  },
+  "description.ratio": { "message": "Select the output aspect ratio.", "description": "Instructions for aspect ratio" },
+  "description.resolution": {
+    "message": "Select the output resolution. Higher resolution costs more credits per second.",
+    "description": "Instructions for resolution"
+  },
+  "description.duration": {
+    "message": "Video duration in seconds. Billed per output second.",
+    "description": "Instructions for duration"
+  },
+  "description.image": {
+    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5-preview.",
+    "description": "Instructions for image input"
+  },
+  "placeholder.prompt": { "message": "Describe your video…", "description": "Placeholder for prompt" },
+  "placeholder.select": { "message": "Please select", "description": "Placeholder for selects" },
+  "model.default": { "message": "Grok Imagine Video", "description": "Default model label" },
+  "model.preview15": { "message": "Grok Imagine Video 1.5 (Preview, image-to-video)", "description": "1.5 preview model label" },
+  "button.upload": { "message": "Upload", "description": "Upload button" },
+  "button.generate": { "message": "Generate", "description": "Generate button" },
+  "button.download": { "message": "Download", "description": "Download button" },
+  "status.pending": { "message": "Pending", "description": "Pending status" },
+  "status.processing": { "message": "Processing", "description": "Processing status" },
+  "message.uploadExceed": { "message": "You can upload only one image.", "description": "Upload exceed warning" },
+  "message.uploadError": { "message": "Image upload failed, please try again.", "description": "Upload error" },
+  "message.downloadVideo": { "message": "Download video", "description": "Download tooltip" },
+  "message.modelRequiresImage": {
+    "message": "This model requires an input image (image-to-video).",
+    "description": "Model requires image warning"
+  },
+  "message.promptOrImageRequired": {
+    "message": "Please enter a prompt or upload an image.",
+    "description": "Prompt or image required warning"
+  },
+  "message.startingTask": { "message": "Submitting your video generation task…", "description": "Starting task" },
+  "message.startTaskSuccess": { "message": "Task submitted successfully.", "description": "Task success" },
+  "message.startTaskFailed": { "message": "Failed to submit task: ", "description": "Task failed" },
+  "message.usedUp": { "message": "Your quota has been used up. Please purchase more to continue.", "description": "Used up" }
+}

--- a/src/i18n/uk/common.json
+++ b/src/i18n/uk/common.json
@@ -507,6 +507,10 @@
     "message": "SeeDance",
     "description": "Текст у навігаційній панелі сайту для відображення сторінки SeeDance, не перекладати, має залишатися 'SeeDance'"
   },
+  "nav.grokvideo": {
+    "message": "Grok Video",
+    "description": "Text in the website navigation bar to display the Grok Imagine video page"
+  },
   "nav.luma": {
     "message": "Luma",
     "description": "Текст у навігаційній панелі сайту для відображення сторінки Luma, не перекладати, має залишатися 'Luma'"

--- a/src/i18n/uk/grokvideo.json
+++ b/src/i18n/uk/grokvideo.json
@@ -1,0 +1,61 @@
+{
+  "name.bot": { "message": "Grok Video Bot", "description": "Name of the Grok video generator" },
+  "name.prompt": { "message": "Prompt", "description": "Prompt for generating the video" },
+  "name.model": { "message": "Model", "description": "Label for model selection" },
+  "name.ratio": { "message": "Aspect Ratio", "description": "Label for aspect ratio" },
+  "name.resolution": { "message": "Resolution", "description": "Label for resolution" },
+  "name.duration": { "message": "Duration", "description": "Label for duration" },
+  "name.image": { "message": "Image", "description": "Label for input image" },
+  "name.required": { "message": "Required", "description": "Required badge" },
+  "name.taskId": { "message": "Task ID", "description": "Task id label" },
+  "name.elapsed": { "message": "Elapsed", "description": "Elapsed time label" },
+  "name.traceId": { "message": "Trace ID", "description": "Trace id label" },
+  "name.failure": { "message": "Generation Failed", "description": "Failure title" },
+  "name.failureReason": { "message": "Reason", "description": "Failure reason label" },
+  "name.status": { "message": "Status", "description": "Status title" },
+  "description.prompt": {
+    "message": "Describe the video you want to generate (scene, subject, motion, camera, lighting, style).",
+    "description": "Instructions for prompt input"
+  },
+  "description.model": {
+    "message": "Choose the Grok Imagine model. grok-imagine-video supports text and image; 1.5-preview is image-to-video only.",
+    "description": "Instructions for model selection"
+  },
+  "description.ratio": { "message": "Select the output aspect ratio.", "description": "Instructions for aspect ratio" },
+  "description.resolution": {
+    "message": "Select the output resolution. Higher resolution costs more credits per second.",
+    "description": "Instructions for resolution"
+  },
+  "description.duration": {
+    "message": "Video duration in seconds. Billed per output second.",
+    "description": "Instructions for duration"
+  },
+  "description.image": {
+    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5-preview.",
+    "description": "Instructions for image input"
+  },
+  "placeholder.prompt": { "message": "Describe your video…", "description": "Placeholder for prompt" },
+  "placeholder.select": { "message": "Please select", "description": "Placeholder for selects" },
+  "model.default": { "message": "Grok Imagine Video", "description": "Default model label" },
+  "model.preview15": { "message": "Grok Imagine Video 1.5 (Preview, image-to-video)", "description": "1.5 preview model label" },
+  "button.upload": { "message": "Upload", "description": "Upload button" },
+  "button.generate": { "message": "Generate", "description": "Generate button" },
+  "button.download": { "message": "Download", "description": "Download button" },
+  "status.pending": { "message": "Pending", "description": "Pending status" },
+  "status.processing": { "message": "Processing", "description": "Processing status" },
+  "message.uploadExceed": { "message": "You can upload only one image.", "description": "Upload exceed warning" },
+  "message.uploadError": { "message": "Image upload failed, please try again.", "description": "Upload error" },
+  "message.downloadVideo": { "message": "Download video", "description": "Download tooltip" },
+  "message.modelRequiresImage": {
+    "message": "This model requires an input image (image-to-video).",
+    "description": "Model requires image warning"
+  },
+  "message.promptOrImageRequired": {
+    "message": "Please enter a prompt or upload an image.",
+    "description": "Prompt or image required warning"
+  },
+  "message.startingTask": { "message": "Submitting your video generation task…", "description": "Starting task" },
+  "message.startTaskSuccess": { "message": "Task submitted successfully.", "description": "Task success" },
+  "message.startTaskFailed": { "message": "Failed to submit task: ", "description": "Task failed" },
+  "message.usedUp": { "message": "Your quota has been used up. Please purchase more to continue.", "description": "Used up" }
+}

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -527,6 +527,10 @@
     "message": "SeeDance",
     "description": "网站导航栏中的文本，用于显示SeeDance页面，请不要翻译此字段，必须保持为'SeeDance'"
   },
+  "nav.grokvideo": {
+    "message": "Grok 视频",
+    "description": "网站导航栏中的文本，用于显示 Grok Imagine 视频页面"
+  },
   "nav.luma": {
     "message": "Luma",
     "description": "网站导航栏中的文本，用于显示Luma页面，请不要翻译此字段，必须保持为'Luma'"

--- a/src/i18n/zh-CN/grokvideo.json
+++ b/src/i18n/zh-CN/grokvideo.json
@@ -1,0 +1,61 @@
+{
+  "name.bot": { "message": "Grok 视频机器人", "description": "Name of the Grok video generator" },
+  "name.prompt": { "message": "提示词", "description": "Prompt for generating the video" },
+  "name.model": { "message": "模型", "description": "Label for model selection" },
+  "name.ratio": { "message": "画面比例", "description": "Label for aspect ratio" },
+  "name.resolution": { "message": "分辨率", "description": "Label for resolution" },
+  "name.duration": { "message": "时长", "description": "Label for duration" },
+  "name.image": { "message": "图片", "description": "Label for input image" },
+  "name.required": { "message": "必填", "description": "Required badge" },
+  "name.taskId": { "message": "任务 ID", "description": "Task id label" },
+  "name.elapsed": { "message": "耗时", "description": "Elapsed time label" },
+  "name.traceId": { "message": "追踪 ID", "description": "Trace id label" },
+  "name.failure": { "message": "生成失败", "description": "Failure title" },
+  "name.failureReason": { "message": "失败原因", "description": "Failure reason label" },
+  "name.status": { "message": "状态", "description": "Status title" },
+  "description.prompt": {
+    "message": "描述你想生成的视频（场景、主体、动作、镜头、光线、风格）。",
+    "description": "Instructions for prompt input"
+  },
+  "description.model": {
+    "message": "选择 Grok Imagine 模型。grok-imagine-video 支持文生与图生视频；1.5-preview 仅支持图生视频。",
+    "description": "Instructions for model selection"
+  },
+  "description.ratio": { "message": "选择输出画面比例。", "description": "Instructions for aspect ratio" },
+  "description.resolution": {
+    "message": "选择输出分辨率。分辨率越高，每秒消耗的额度越多。",
+    "description": "Instructions for resolution"
+  },
+  "description.duration": {
+    "message": "视频时长（秒），按输出秒数计费。",
+    "description": "Instructions for duration"
+  },
+  "description.image": {
+    "message": "可选的输入图片，用于图生视频。grok-imagine-video-1.5-preview 为必填。",
+    "description": "Instructions for image input"
+  },
+  "placeholder.prompt": { "message": "描述你的视频…", "description": "Placeholder for prompt" },
+  "placeholder.select": { "message": "请选择", "description": "Placeholder for selects" },
+  "model.default": { "message": "Grok Imagine 视频", "description": "Default model label" },
+  "model.preview15": { "message": "Grok Imagine 视频 1.5（预览，图生视频）", "description": "1.5 preview model label" },
+  "button.upload": { "message": "上传", "description": "Upload button" },
+  "button.generate": { "message": "生成", "description": "Generate button" },
+  "button.download": { "message": "下载", "description": "Download button" },
+  "status.pending": { "message": "排队中", "description": "Pending status" },
+  "status.processing": { "message": "生成中", "description": "Processing status" },
+  "message.uploadExceed": { "message": "只能上传一张图片。", "description": "Upload exceed warning" },
+  "message.uploadError": { "message": "图片上传失败，请重试。", "description": "Upload error" },
+  "message.downloadVideo": { "message": "下载视频", "description": "Download tooltip" },
+  "message.modelRequiresImage": {
+    "message": "该模型需要输入图片（图生视频）。",
+    "description": "Model requires image warning"
+  },
+  "message.promptOrImageRequired": {
+    "message": "请输入提示词或上传图片。",
+    "description": "Prompt or image required warning"
+  },
+  "message.startingTask": { "message": "正在提交视频生成任务…", "description": "Starting task" },
+  "message.startTaskSuccess": { "message": "任务提交成功。", "description": "Task success" },
+  "message.startTaskFailed": { "message": "任务提交失败：", "description": "Task failed" },
+  "message.usedUp": { "message": "额度已用尽，请购买后继续使用。", "description": "Used up" }
+}

--- a/src/i18n/zh-TW/common.json
+++ b/src/i18n/zh-TW/common.json
@@ -507,6 +507,10 @@
     "message": "SeeDance",
     "description": "網站導航欄中的文本，用於顯示SeeDance頁面，請不要翻譯此字段，必須保持為'SeeDance'"
   },
+  "nav.grokvideo": {
+    "message": "Grok Video",
+    "description": "Text in the website navigation bar to display the Grok Imagine video page"
+  },
   "nav.luma": {
     "message": "Luma",
     "description": "網站導航欄中的文本，用於顯示Luma頁面，請不要翻譯此字段，必須保持為'Luma'"

--- a/src/i18n/zh-TW/grokvideo.json
+++ b/src/i18n/zh-TW/grokvideo.json
@@ -1,0 +1,61 @@
+{
+  "name.bot": { "message": "Grok Video Bot", "description": "Name of the Grok video generator" },
+  "name.prompt": { "message": "Prompt", "description": "Prompt for generating the video" },
+  "name.model": { "message": "Model", "description": "Label for model selection" },
+  "name.ratio": { "message": "Aspect Ratio", "description": "Label for aspect ratio" },
+  "name.resolution": { "message": "Resolution", "description": "Label for resolution" },
+  "name.duration": { "message": "Duration", "description": "Label for duration" },
+  "name.image": { "message": "Image", "description": "Label for input image" },
+  "name.required": { "message": "Required", "description": "Required badge" },
+  "name.taskId": { "message": "Task ID", "description": "Task id label" },
+  "name.elapsed": { "message": "Elapsed", "description": "Elapsed time label" },
+  "name.traceId": { "message": "Trace ID", "description": "Trace id label" },
+  "name.failure": { "message": "Generation Failed", "description": "Failure title" },
+  "name.failureReason": { "message": "Reason", "description": "Failure reason label" },
+  "name.status": { "message": "Status", "description": "Status title" },
+  "description.prompt": {
+    "message": "Describe the video you want to generate (scene, subject, motion, camera, lighting, style).",
+    "description": "Instructions for prompt input"
+  },
+  "description.model": {
+    "message": "Choose the Grok Imagine model. grok-imagine-video supports text and image; 1.5-preview is image-to-video only.",
+    "description": "Instructions for model selection"
+  },
+  "description.ratio": { "message": "Select the output aspect ratio.", "description": "Instructions for aspect ratio" },
+  "description.resolution": {
+    "message": "Select the output resolution. Higher resolution costs more credits per second.",
+    "description": "Instructions for resolution"
+  },
+  "description.duration": {
+    "message": "Video duration in seconds. Billed per output second.",
+    "description": "Instructions for duration"
+  },
+  "description.image": {
+    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5-preview.",
+    "description": "Instructions for image input"
+  },
+  "placeholder.prompt": { "message": "Describe your video…", "description": "Placeholder for prompt" },
+  "placeholder.select": { "message": "Please select", "description": "Placeholder for selects" },
+  "model.default": { "message": "Grok Imagine Video", "description": "Default model label" },
+  "model.preview15": { "message": "Grok Imagine Video 1.5 (Preview, image-to-video)", "description": "1.5 preview model label" },
+  "button.upload": { "message": "Upload", "description": "Upload button" },
+  "button.generate": { "message": "Generate", "description": "Generate button" },
+  "button.download": { "message": "Download", "description": "Download button" },
+  "status.pending": { "message": "Pending", "description": "Pending status" },
+  "status.processing": { "message": "Processing", "description": "Processing status" },
+  "message.uploadExceed": { "message": "You can upload only one image.", "description": "Upload exceed warning" },
+  "message.uploadError": { "message": "Image upload failed, please try again.", "description": "Upload error" },
+  "message.downloadVideo": { "message": "Download video", "description": "Download tooltip" },
+  "message.modelRequiresImage": {
+    "message": "This model requires an input image (image-to-video).",
+    "description": "Model requires image warning"
+  },
+  "message.promptOrImageRequired": {
+    "message": "Please enter a prompt or upload an image.",
+    "description": "Prompt or image required warning"
+  },
+  "message.startingTask": { "message": "Submitting your video generation task…", "description": "Starting task" },
+  "message.startTaskSuccess": { "message": "Task submitted successfully.", "description": "Task success" },
+  "message.startTaskFailed": { "message": "Failed to submit task: ", "description": "Task failed" },
+  "message.usedUp": { "message": "Your quota has been used up. Please purchase more to continue.", "description": "Used up" }
+}

--- a/src/models/grokvideo.ts
+++ b/src/models/grokvideo.ts
@@ -1,0 +1,61 @@
+export type GrokVideoResolution = '480p' | '720p';
+export type GrokVideoRatio = '1:1' | '16:9' | '9:16' | '4:3' | '3:4' | '3:2' | '2:3';
+
+export interface IGrokVideoConfig {
+  model?: string;
+  prompt?: string;
+  image_url?: string;
+  reference_image_urls?: string[];
+  aspect_ratio?: GrokVideoRatio;
+  resolution?: GrokVideoResolution;
+  duration?: number;
+  callback_url?: string;
+  mirror?: boolean;
+}
+
+export interface IGrokVideoGenerateRequest {
+  model?: string;
+  prompt?: string;
+  image_url?: string;
+  reference_image_urls?: string[];
+  aspect_ratio?: GrokVideoRatio;
+  resolution?: GrokVideoResolution;
+  duration?: number;
+  callback_url?: string;
+  mirror?: boolean;
+}
+
+export interface IGrokVideoVideo {
+  id?: string;
+  task_id?: string;
+  state?: string;
+  status?: string;
+  video_url?: string;
+  duration?: number;
+}
+
+export interface IGrokVideoGenerateResponse {
+  success: boolean;
+  task_id: string;
+  trace_id?: string;
+  data?: IGrokVideoVideo[];
+  error?: {
+    code?: string;
+    message?: string;
+  };
+}
+
+export interface IGrokVideoTask {
+  id: string;
+  created_at?: number;
+  elapsed?: number;
+  request?: IGrokVideoGenerateRequest;
+  response?: IGrokVideoGenerateResponse;
+}
+
+export type IGrokVideoTaskResponse = IGrokVideoTask;
+
+export interface IGrokVideoTasksResponse {
+  count: number;
+  items: IGrokVideoTask[];
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -26,6 +26,7 @@ export * from './nanobanana';
 export * from './openaiimage';
 export * from './seedream';
 export * from './seedance';
+export * from './grokvideo';
 export * from './serp';
 export * from './wan';
 export * from './webextrator';

--- a/src/models/site.ts
+++ b/src/models/site.ts
@@ -20,6 +20,7 @@ export interface ISiteFeatures {
   openaiimage?: any;
   seedream?: any;
   seedance?: any;
+  grokvideo?: any;
   wan?: any;
   producer?: any;
   kimi?: any;

--- a/src/operators/grokvideo.ts
+++ b/src/operators/grokvideo.ts
@@ -1,0 +1,21 @@
+import {
+  IGrokVideoGenerateRequest,
+  IGrokVideoGenerateResponse,
+  IGrokVideoTaskResponse,
+  IGrokVideoTasksResponse
+} from '@/models';
+import { BaseTaskOperator, ITaskListFilter } from './baseTaskOperator';
+
+class GrokVideoOperator extends BaseTaskOperator<
+  IGrokVideoGenerateRequest,
+  IGrokVideoGenerateResponse,
+  IGrokVideoTaskResponse,
+  IGrokVideoTasksResponse,
+  ITaskListFilter & { type?: string }
+> {
+  constructor() {
+    super({ tasksPath: '/grok/tasks', generatePath: '/grok/videos' });
+  }
+}
+
+export const grokvideoOperator = new GrokVideoOperator();

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -30,6 +30,7 @@ export * from './nanobanana';
 export * from './openaiimage';
 export * from './seedream';
 export * from './seedance';
+export * from './grokvideo';
 export * from './serp';
 export * from './wan';
 export * from './webextrator';

--- a/src/pages/grokvideo/Index.vue
+++ b/src/pages/grokvideo/Index.vue
@@ -1,0 +1,195 @@
+<template>
+  <layout>
+    <template #config>
+      <config-panel @generate="onGenerate" />
+    </template>
+    <template #result>
+      <recent-panel ref="recentPanel" :loading="loadingMore" @reach-top="onReachTop" />
+    </template>
+  </layout>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import Layout from '@/layouts/Seedance.vue';
+import ConfigPanel from '@/components/grokvideo/ConfigPanel.vue';
+import RecentPanel from '@/components/grokvideo/RecentPanel.vue';
+import { grokvideoOperator } from '@/operators';
+import { instrumentGeneration } from '@/plugins/telemetry';
+import { IGrokVideoGenerateRequest, IGrokVideoTask, Status } from '@/models';
+import { ElMessage } from 'element-plus';
+import { ERROR_CODE_USED_UP, getWebhookCallbackUrl, isGrokVideoImageOnlyModel } from '@/constants';
+import { loadPreviousPage } from '@/utils/pagination';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
+
+const CALLBACK_URL = getWebhookCallbackUrl('grok');
+
+interface IData {
+  task: IGrokVideoTask | undefined;
+  job: number;
+  loadingMore: boolean;
+  fetchingTasks: boolean;
+}
+
+export default defineComponent({
+  name: 'GrokVideoIndex',
+  components: {
+    ConfigPanel,
+    Layout,
+    RecentPanel
+  },
+  mixins: [uploadTrackerProviderMixin],
+  inject: ['initialized'],
+  data(): IData {
+    return {
+      task: undefined,
+      job: 0,
+      loadingMore: false,
+      fetchingTasks: false
+    };
+  },
+  computed: {
+    applicationsLoading() {
+      return this.$store.state.grokvideo?.status?.getApplications === Status.Request;
+    },
+    tasksLoading() {
+      return this.$store.state.grokvideo?.status?.getTasks === Status.Request || this.fetchingTasks;
+    },
+    credential() {
+      return this.$store.state.grokvideo?.credential;
+    },
+    config() {
+      return this.$store.state.grokvideo?.config;
+    },
+    tasks() {
+      return this.$store.state.grokvideo?.tasks;
+    }
+  },
+  watch: {
+    initialized: {
+      async handler(newValue) {
+        if (newValue) {
+          await this.onGetTasks();
+          await this.onScrollDown();
+          this.job = window.setInterval(() => {
+            this.onGetTasks();
+          }, 5000);
+        }
+      },
+      immediate: true
+    }
+  },
+  async mounted() {
+    await this.onGetService();
+  },
+  async unmounted() {
+    window.clearInterval(this.job);
+  },
+  methods: {
+    async onReachTop() {
+      await loadPreviousPage({
+        tasks: this.tasks,
+        loading: this.loadingMore,
+        setLoading: (v) => (this.loadingMore = v),
+        isBlocked: () => this.tasksLoading || this.applicationsLoading,
+        fetch: (createdAtMax) =>
+          this.onGetTasks({
+            createdAtMax
+          }),
+        getScrollElement: () => this.getTasksScrollElement()
+      });
+    },
+    async onGetService() {
+      await this.$store.dispatch('grokvideo/getService');
+    },
+    async onScrollDown() {
+      await this.$nextTick();
+      const el = this.getTasksScrollElement();
+      if (el) {
+        el.scrollTop = el.scrollHeight;
+      }
+    },
+    async onGetTasks(payload?: { limit?: number; createdAtMin?: number; createdAtMax?: number }) {
+      if (this.applicationsLoading || this.fetchingTasks) {
+        return;
+      }
+      const { limit = 5, createdAtMin, createdAtMax } = payload || {};
+      this.fetchingTasks = true;
+      try {
+        await this.$store.dispatch('grokvideo/getTasks', {
+          limit,
+          createdAtMin,
+          createdAtMax
+        });
+      } finally {
+        this.fetchingTasks = false;
+      }
+    },
+    async onGenerate() {
+      if (
+        !ensureNoPendingUpload(
+          this.uploadTracker,
+          (k) => this.$t(k) as string,
+          (m) => ElMessage.warning(m)
+        )
+      ) {
+        return;
+      }
+      const cfg: any = { ...(this.config || {}) };
+      if (typeof cfg?.prompt === 'string') {
+        cfg.prompt = cfg.prompt.trim();
+        if (!cfg.prompt) delete cfg.prompt;
+      }
+      if (typeof cfg?.image_url === 'string' && !cfg.image_url.trim()) {
+        delete cfg.image_url;
+      }
+
+      const hasImage = !!cfg?.image_url;
+      // grok-imagine-video-1.5-preview is image-to-video only.
+      if (isGrokVideoImageOnlyModel(cfg?.model) && !hasImage) {
+        ElMessage.warning(this.$t('grokvideo.message.modelRequiresImage'));
+        return;
+      }
+      // Text-to-video needs a prompt when no image is provided.
+      if (!hasImage && !cfg?.prompt) {
+        ElMessage.warning(this.$t('grokvideo.message.promptOrImageRequired'));
+        return;
+      }
+
+      const request = {
+        ...cfg,
+        callback_url: CALLBACK_URL
+      } as IGrokVideoGenerateRequest;
+
+      const token = this.credential?.token;
+      if (!token) {
+        console.error('no token specified');
+        return;
+      }
+      ElMessage.info(this.$t('grokvideo.message.startingTask'));
+      instrumentGeneration('grokvideo', grokvideoOperator.generate(request, { token }))
+        .then(() => {
+          ElMessage.success(this.$t('grokvideo.message.startTaskSuccess'));
+        })
+        .catch((error) => {
+          const response = error?.response?.data;
+          if (response?.error?.code === ERROR_CODE_USED_UP) {
+            ElMessage.error(this.$t('grokvideo.message.usedUp'));
+          } else {
+            ElMessage.error(this.$t('grokvideo.message.startTaskFailed') + (response?.error?.message || ''));
+          }
+        })
+        .finally(async () => {
+          setTimeout(async () => {
+            await this.onGetTasks();
+            await this.onScrollDown();
+          }, 1000);
+        });
+    },
+    getTasksScrollElement(): HTMLElement | undefined {
+      const panel = this.$refs.recentPanel as any;
+      return panel?.getScrollElement?.();
+    }
+  }
+});
+</script>

--- a/src/router/constants.ts
+++ b/src/router/constants.ts
@@ -65,6 +65,7 @@ export const ROUTE_OPENAIIMAGE_INDEX = 'openaiimage-index';
 export const ROUTE_SEEDREAM_INDEX = 'seedream-index';
 
 export const ROUTE_SEEDANCE_INDEX = 'seedance-index';
+export const ROUTE_GROKVIDEO_INDEX = 'grokvideo-index';
 
 export const ROUTE_SERP_INDEX = 'serp-index';
 

--- a/src/router/grokvideo.ts
+++ b/src/router/grokvideo.ts
@@ -1,0 +1,17 @@
+import { ROUTE_GROKVIDEO_INDEX } from './constants';
+
+export default {
+  path: '/grok-video',
+  meta: {
+    auth: true,
+    appName: 'grokvideo'
+  },
+  component: () => import('@/layouts/Main.vue'),
+  children: [
+    {
+      path: '',
+      name: ROUTE_GROKVIDEO_INDEX,
+      component: () => import('@/pages/grokvideo/Index.vue')
+    }
+  ]
+};

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -28,6 +28,7 @@ import nanobanana from './nanobanana';
 import openaiimage from './openaiimage';
 import seedream from './seedream';
 import seedance from './seedance';
+import grokvideo from './grokvideo';
 import serp from './serp';
 import wan from './wan';
 import fish from './fish';
@@ -50,6 +51,7 @@ import {
   ROUTE_SUNO_INDEX,
   ROUTE_PRODUCER_INDEX,
   ROUTE_SEEDANCE_INDEX,
+  ROUTE_GROKVIDEO_INDEX,
   ROUTE_LUMA_INDEX,
   ROUTE_HAILUO_INDEX,
   ROUTE_KLING_INDEX,
@@ -199,6 +201,12 @@ const ROUTE_SEO: Record<string, { title: string; description: string; keywords: 
     keywords: ['Seedance', 'AI Video', 'Dance Video', 'ByteDance'],
     category: 'AI Video Generation'
   },
+  grokvideo: {
+    title: 'Grok Imagine Video',
+    description: 'Generate AI videos with Grok Imagine — text-to-video and image-to-video by xAI.',
+    keywords: ['Grok', 'Grok Imagine', 'AI Video', 'Text to Video', 'Image to Video', 'xAI'],
+    category: 'AI Video Generation'
+  },
   wan: {
     title: 'Wan',
     description: 'Generate AI videos with Wan — high-quality video generation by Tongyi Wanxiang.',
@@ -283,6 +291,7 @@ const FEATURE_ROUTE_PRIORITY: Array<[string, string]> = [
   ['luma', ROUTE_LUMA_INDEX],
   ['hailuo', ROUTE_HAILUO_INDEX],
   ['seedance', ROUTE_SEEDANCE_INDEX],
+  ['grokvideo', ROUTE_GROKVIDEO_INDEX],
   ['pixverse', ROUTE_PIXVERSE_INDEX],
   ['wan', ROUTE_WAN_INDEX],
   ['serp', ROUTE_SERP_INDEX],
@@ -334,6 +343,7 @@ const routes = [
   openaiimage,
   seedream,
   seedance,
+  grokvideo,
   serp,
   wan,
   fish,

--- a/src/store/common/models.ts
+++ b/src/store/common/models.ts
@@ -17,6 +17,7 @@ import { INanobananaState } from '../nanobanana/models';
 import { IOpenAIImageState } from '../openaiimage/models';
 import { ISeedreamState } from '../seedream/models';
 import { ISeedanceState } from '../seedance/models';
+import { IGrokVideoState } from '../grokvideo/models';
 import { ISerpState } from '../serp/models';
 import { IWanState } from '../wan/models';
 import { IFishState } from '../fish/models';
@@ -69,6 +70,7 @@ export interface IAppState {
   openaiimage: IOpenAIImageState;
   seedream: ISeedreamState;
   seedance: ISeedanceState;
+  grokvideo: IGrokVideoState;
   serp: ISerpState;
   wan: IWanState;
   fish: IFishState;

--- a/src/store/common/state.ts
+++ b/src/store/common/state.ts
@@ -17,6 +17,7 @@ import nanobananaState from '../nanobanana/state';
 import openaiimageState from '../openaiimage/state';
 import seedreamState from '../seedream/state';
 import seedanceState from '../seedance/state';
+import grokvideoState from '../grokvideo/state';
 import serpState from '../serp/state';
 import wanState from '../wan/state';
 import fishState from '../fish/state';
@@ -65,6 +66,7 @@ export default (): IRootState => {
     openaiimage: openaiimageState(),
     seedream: seedreamState(),
     seedance: seedanceState(),
+    grokvideo: grokvideoState(),
     serp: serpState(),
     wan: wanState(),
     fish: fishState(),

--- a/src/store/grokvideo/actions.ts
+++ b/src/store/grokvideo/actions.ts
@@ -1,0 +1,13 @@
+import { grokvideoOperator } from '@/operators';
+import { IGrokVideoConfig, IGrokVideoTask } from '@/models';
+import { GROKVIDEO_SERVICE_ID } from '@/constants';
+import { createTaskActions } from '@/store/factories/createTaskActions';
+
+const actions = createTaskActions<IGrokVideoConfig, IGrokVideoTask, Record<string, unknown>>({
+  serviceId: GROKVIDEO_SERVICE_ID,
+  operator: grokvideoOperator,
+  paginated: true,
+  type: 'videos'
+});
+
+export default actions;

--- a/src/store/grokvideo/index.ts
+++ b/src/store/grokvideo/index.ts
@@ -1,0 +1,14 @@
+import { Module } from 'vuex';
+import { IGrokVideoState } from './models';
+import actions from './actions';
+import mutations from './mutations';
+import state from './state';
+
+export const grokvideo: Module<IGrokVideoState, any> = {
+  namespaced: true,
+  state,
+  mutations,
+  actions
+};
+
+export default grokvideo;

--- a/src/store/grokvideo/models.ts
+++ b/src/store/grokvideo/models.ts
@@ -1,0 +1,21 @@
+import { IApplication, ICredential, IGrokVideoConfig, IGrokVideoTask, IService, Status } from '@/models';
+
+export interface IGrokVideoState {
+  service: IService | undefined;
+  application: IApplication | undefined;
+  applications: IApplication[] | undefined;
+  tasks:
+    | {
+        items: IGrokVideoTask[] | undefined;
+        total: number | undefined;
+        active: IGrokVideoTask | undefined;
+      }
+    | undefined;
+  credential: ICredential | undefined;
+  config: IGrokVideoConfig | undefined;
+  status: {
+    getService: Status;
+    getApplications: Status;
+    getTasks: Status;
+  };
+}

--- a/src/store/grokvideo/mutations.ts
+++ b/src/store/grokvideo/mutations.ts
@@ -1,0 +1,74 @@
+import { IApplication, ICredential, IGrokVideoConfig, IGrokVideoTask, IService } from '@/models';
+import initialState from './state';
+import { IGrokVideoState } from './models';
+
+const defaultTasks = {
+  items: undefined,
+  total: undefined,
+  active: undefined
+};
+
+export const resetAll = (state: IGrokVideoState): void => {
+  Object.assign(state, initialState());
+};
+
+export const setService = (state: IGrokVideoState, payload: IService): void => {
+  state.service = payload;
+};
+
+export const setCredential = (state: IGrokVideoState, payload: ICredential): void => {
+  state.credential = payload;
+};
+
+export const setApplication = (state: IGrokVideoState, payload: IApplication): void => {
+  state.application = payload;
+};
+
+export const setApplications = (state: IGrokVideoState, payload: IApplication[]): void => {
+  state.applications = payload;
+};
+
+export const setConfig = (state: IGrokVideoState, payload: IGrokVideoConfig): void => {
+  state.config = payload;
+};
+
+export const setTasksItems = (state: IGrokVideoState, payload: IGrokVideoTask[]): void => {
+  const newPayload = {
+    ...(state.tasks || defaultTasks),
+    items: payload
+  } as typeof state.tasks;
+  state.tasks = newPayload;
+};
+
+export const setTasksTotal = (state: IGrokVideoState, payload: number): void => {
+  const newPayload = {
+    ...(state.tasks || defaultTasks),
+    total: payload
+  } as typeof state.tasks;
+  state.tasks = newPayload;
+};
+
+export const setTasksActive = (state: IGrokVideoState, payload: IGrokVideoTask): void => {
+  const newPayload = {
+    ...(state.tasks || defaultTasks),
+    active: payload
+  } as typeof state.tasks;
+  state.tasks = newPayload;
+};
+
+export const setTasks = (state: IGrokVideoState, payload: any): void => {
+  state.tasks = payload;
+};
+
+export default {
+  setTasks,
+  setApplication,
+  setApplications,
+  setConfig,
+  setCredential,
+  setService,
+  setTasksActive,
+  setTasksItems,
+  setTasksTotal,
+  resetAll
+};

--- a/src/store/grokvideo/persist.ts
+++ b/src/store/grokvideo/persist.ts
@@ -1,0 +1,2 @@
+// See flux/persist.ts for why `.tasks` is no longer persisted.
+export default ['grokvideo.credential', 'grokvideo.application', 'grokvideo.applications'];

--- a/src/store/grokvideo/state.ts
+++ b/src/store/grokvideo/state.ts
@@ -1,0 +1,29 @@
+import { IGrokVideoState } from './models';
+import { Status } from '@/models';
+import {
+  GROKVIDEO_DEFAULT_DURATION,
+  GROKVIDEO_DEFAULT_MODEL,
+  GROKVIDEO_DEFAULT_RATIO,
+  GROKVIDEO_DEFAULT_RESOLUTION
+} from '@/constants';
+
+export default (): IGrokVideoState => {
+  return {
+    service: undefined,
+    application: undefined,
+    applications: undefined,
+    tasks: undefined,
+    credential: undefined,
+    config: {
+      model: GROKVIDEO_DEFAULT_MODEL,
+      aspect_ratio: GROKVIDEO_DEFAULT_RATIO,
+      resolution: GROKVIDEO_DEFAULT_RESOLUTION,
+      duration: GROKVIDEO_DEFAULT_DURATION
+    },
+    status: {
+      getService: Status.None,
+      getApplications: Status.None,
+      getTasks: Status.None
+    }
+  };
+};

--- a/src/store/lazy.ts
+++ b/src/store/lazy.ts
@@ -40,6 +40,7 @@ const moduleLoaders: Record<string, () => Promise<{ default: AnyVuexModule }>> =
   openaiimage: () => import('./openaiimage'),
   seedream: () => import('./seedream'),
   seedance: () => import('./seedance'),
+  grokvideo: () => import('./grokvideo'),
   serp: () => import('./serp'),
   wan: () => import('./wan'),
   fish: () => import('./fish'),


### PR DESCRIPTION
## Summary

Adds a consumer **Grok Imagine video** studio to Nexior, mirroring the `seedance` module. Named **`grokvideo`** to avoid colliding with the existing `grok` chat service. This is the last frontend gap for the grok-video service (backend/gateway/MCP/Dify already shipped & merged).

Service: `a270a291-7cbc-44a6-88b9-80334e3e95a0` → `POST /grok/videos` + `/grok/tasks`.

## What's included

- **Store**: `store/grokvideo` (state/mutations/actions/models/persist) via shared `createTaskActions`; operator → `/grok/videos`, `/grok/tasks`
- **UI**: `components/grokvideo` — ConfigPanel (prompt, model, aspect-ratio, resolution, duration, image-to-video upload), RecentPanel, task/Preview; page + `/grok-video` route
- **Models**: `grok-imagine-video` (text+image), `grok-imagine-video-1.5-preview` (image-only, image required — validated client-side)
- **i18n**: `en` + `zh-CN` `grokvideo.json` + `common.nav.grokvideo` (other locales fall back to en per project policy)
- **Registration**: operators/constants/models barrels, store lazy + common state/models, router SEO + priority, i18n scopes, `site.features.grokvideo`, Navigator (video category)

## Validation

- `vue-tsc --noEmit`: **0 errors**
- `eslint`: clean · `prettier --check`: clean

## Notes / follow-ups

- Nav link is gated on `site.features.grokvideo.enabled` — **enable `grokvideo` in the site features config** to surface it.
- Logo uses the Grok icon CDN placeholder (`8nxyy9.jpg`); swap if a dedicated asset exists.
- Recommend a quick visual smoke test (generate text→video + image→video) before/after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)