### PR TITLE
fix(coding-bridge): keep the thinking indicator up through the first turn

### DIFF
--- a/src/store/codingBridge/actions.ts
+++ b/src/store/codingBridge/actions.ts
@@ -116,10 +116,15 @@ const applyNodeEvent = (
   }
   switch (event) {
     case CB_EVENT_SESSION_STARTED:
+      // The session was created and its first turn is now running — keep it
+      // 'running' (so the thinking indicator stays and the turn stays
+      // interruptible) until session.result/error flips it to idle. Marking it
+      // 'idle' here hid the indicator the instant the turn began, before any
+      // output had streamed back.
       commit('upsertSession', {
         session_id: sessionId,
         node_id: fromNode,
-        status: 'idle',
+        status: 'running',
         cwd: payload.cwd,
         model: payload.model,
         trace_id: traceId


### PR DESCRIPTION
## Symptom
The "thinking" animation (Brewing… spinner) flashes for a split second on the **first** turn of a session and then disappears — before any real response has streamed back. The session looks frozen until text suddenly appears.

## Cause
`thinking = running && !pendingQuestion`, and `running = status === 'running' || 'starting'`.

- Sending sets status `'starting'` → indicator shows. ✅
- The node's **`session.started`** event (the first thing back, `seq:1`) means "session created, first turn starting" — but the handler set **`status: 'idle'`**, so `running` went false and the indicator hid **the instant the turn began**, before any output. The exact envelope the user saw:
  ```json
  {"type":"node.to_browser","payload":{"event":"session.started","status…","seq":1}}
  ```
- Only `session.result` should mark the turn done/idle.

Follow-up turns were unaffected (they set `'running'` in `sendPrompt` and get no `session.started`), so this only hit the first turn of each session.

## Fix
Mark the session **`running`** on `session.started`; `session.result`/`session.error` still flip it to `idle` when the turn actually ends. This keeps the indicator up for the whole first turn and, as a bonus, restores the interrupt (stop) button mid-first-turn.

## Checks
`vue-tsc` build clean, eslint clean. No test asserted the old `idle` behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)