### PR TITLE
ci: 合并到 main 后自动发布移动端测试版（不发 Production）

### DIFF
--- a/.github/workflows/auto-release-mobile.yaml
+++ b/.github/workflows/auto-release-mobile.yaml
@@ -1,0 +1,67 @@
+name: Auto Release Mobile (Testing)
+
+# Fires automatically after a merge to main bumps the version. Beachball
+# (publish.yaml) commits the bump and pushes the @acedatacloud/nexior_v* tag
+# using BOT_GITHUB_TOKEN (a PAT), which is what lets this tag push trigger
+# further workflows. We trigger on that tag — not raw `push: main` — so the
+# mobile build uses the final, released version and never races the bump.
+#
+# This orchestrator dispatches the existing build-android.yaml / build-ios.yaml
+# with PRODUCTION EXPLICITLY DISABLED:
+#   - Android  -> uploads to the test track below, promote_to_production=false
+#   - iOS      -> uploads to TestFlight (+ external groups), auto_submit_review=false
+# Promotion to the Play Production track and submission for App Store review
+# remain a manual, opt-in action (run build-android.yaml / build-ios.yaml or
+# release-mobile.yaml by hand with the production toggles on).
+#
+# To change the Android test track (alpha = Closed testing, beta = Open
+# testing, internal = Internal testing), edit ANDROID_TRACK below.
+
+on:
+  push:
+    tags:
+      - '@acedatacloud/nexior_v*'
+  # Allow re-running the auto test-publish by hand for the current ref.
+  workflow_dispatch: {}
+
+permissions:
+  actions: write
+  contents: read
+
+env:
+  ANDROID_TRACK: beta
+
+jobs:
+  fanout:
+    name: Auto-publish to test tracks (no Production)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve version
+        id: ver
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "::notice::Auto test-publish Nexior v$VERSION (ref=${{ github.ref_name }}, android track=$ANDROID_TRACK)"
+
+      - name: Trigger Android build → ${{ env.ANDROID_TRACK }} (no production)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run build-android.yaml \
+            --ref "${{ github.ref_name }}" \
+            -f track="$ANDROID_TRACK" \
+            -f promote_to_production=false \
+            -f force=false
+
+      - name: Trigger iOS build → TestFlight (no App Store review)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run build-ios.yaml \
+            --ref "${{ github.ref_name }}" \
+            -f auto_distribute_external=true \
+            -f auto_submit_review=false \
+            -f force=false


### PR DESCRIPTION
## 目的

每次合并到 `main` 产生版本发布后，自动把移动端发到**测试轨道**，Production 仍保持手动。

- **Android** → Open testing（`beta`），`promote_to_production=false`
- **iOS** → TestFlight（含外部测试组），`auto_submit_review=false`（不提交 App Store 审核）

## 工作原理

1. 合并到 `main` → 现有 `publish.yaml` 跑 beachball，bump 版本并推送 `@acedatacloud/nexior_v*` tag（用 `BOT_GITHUB_TOKEN`，PAT，所以能触发后续 workflow）。
2. 新增的 `auto-release-mobile.yaml` 监听该 tag，按 tag 的 ref 去 dispatch 现有的 `build-android.yaml` / `build-ios.yaml`，并**显式关闭 Production**。

## 为什么用 release tag 触发，而不是 `push: main`

- 现有 build workflow 只有在 `workflow_dispatch` 且显式传 `false` 时才会关掉 Production；普通 push/tag 事件下，iOS 审核提交和 Android 晋升 Production 会**无条件执行**。所以必须用 dispatch + 开关，不能直接 push 触发。
- 用 beachball 的 tag（版本 bump 之后）触发，可保证移动端构建的版本号与 npm 发布版本一致，不会和 bump 抢跑、产生重复 versionCode。
- 副作用：没有 beachball change file、不产生版本号的合并，不会触发移动端构建（即"每次 release 发一次"，按当前版本节奏 3.274.x 基本等于每次合并）。

## 调整测试轨道

改文件顶部的 `ANDROID_TRACK`：`alpha`（Closed testing）/ `beta`（Open testing）/ `internal`（Internal testing）。默认 `beta`，与现有 build workflow 默认值一致。

## 备注

- 依赖仓库里已配置的 iOS/Android 签名与商店 secrets（现有 build workflow 已在用）。
- 也支持手动 `workflow_dispatch` 对当前 ref 触发一次。

🤖 Generated with [Claude Code](https://claude.com/claude-code)