### PR TITLE
feat(coding-bridge): render markdown links & syntax highlighting

### DIFF
--- a/src/components/codingBridge/TranscriptItem.vue
+++ b/src/components/codingBridge/TranscriptItem.vue
@@ -352,11 +352,23 @@ export default defineComponent({
     list-style: disc;
   }
 
+  /* Let the night-owl `.hljs` dark background fill the block cleanly instead
+     of framing it with github-markdown's light `pre` padding/background. */
   pre {
+    margin: 0;
+    padding: 0;
+    background: transparent;
     border-radius: 6px;
+    overflow: hidden;
   }
   pre code {
     color: #fff;
+  }
+
+  /* Inline code keeps a subtle chip; block code is themed by night-owl. */
+  a {
+    color: var(--el-color-primary);
+    text-decoration: underline;
   }
 }
 

--- a/src/components/common/VueMarkdown.vue
+++ b/src/components/common/VueMarkdown.vue
@@ -2,6 +2,7 @@
 import type { PropType } from 'vue';
 import { defineComponent, computed, h } from 'vue';
 import MarkdownIt, { Options as MarkdownItOptions } from 'markdown-it';
+import hljs from 'highlight.js/lib/common';
 import 'katex/dist/katex.min.css';
 import { katex } from '@mdit/plugin-katex';
 
@@ -19,12 +20,45 @@ export default defineComponent({
     }
   },
   setup(props, { attrs }) {
-    const md = new MarkdownIt({ ...props.options, html: true }).use(katex as any, {
+    const md = new MarkdownIt({
+      ...props.options,
+      html: true,
+      // Auto-link bare URLs (agent output is full of raw PR/doc links).
+      linkify: true,
+      // Bake syntax highlighting into the rendered HTML so it survives the
+      // streaming re-render churn instead of relying on a post-render pass.
+      highlight: (str: string, lang: string): string => {
+        if (lang && hljs.getLanguage(lang)) {
+          try {
+            const out = hljs.highlight(str, { language: lang, ignoreIllegals: true }).value;
+            return `<pre><code class="hljs language-${lang}">${out}</code></pre>`;
+          } catch {
+            /* fall through to auto-detect */
+          }
+        }
+        try {
+          return `<pre><code class="hljs">${hljs.highlightAuto(str).value}</code></pre>`;
+        } catch {
+          return `<pre><code class="hljs">${md.utils.escapeHtml(str)}</code></pre>`;
+        }
+      }
+    }).use(katex as any, {
       delimiters: 'all',
       throwOnError: false,
       errorColor: '#cc0000',
       mathFence: true
     });
+
+    // Open every link in a new tab — this app is often embedded, and an
+    // in-place navigation would blow away the user's session.
+    const defaultLinkOpen =
+      md.renderer.rules.link_open || ((tokens, idx, options, _env, self) => self.renderToken(tokens, idx, options));
+    md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
+      const token = tokens[idx];
+      token.attrSet('target', '_blank');
+      token.attrSet('rel', 'noopener noreferrer');
+      return defaultLinkOpen(tokens, idx, options, env, self);
+    };
 
     const content = computed(() => {
       const src = props.source;

--- a/src/utils/highlight.ts
+++ b/src/utils/highlight.ts
@@ -9,11 +9,17 @@ export const highlight = async (el: HTMLElement) => {
     const pre = code.parentElement as HTMLElement;
     if (!pre) return;
 
+    // VueMarkdown already bakes highlighting into the HTML (`hljs` class +
+    // token spans). Re-running highlight.js on that would nest spans, so here
+    // we only need to add the copy button. CodeSnippet renders plain code
+    // without the `hljs` class — those we still highlight ourselves below.
+    const prehighlighted = code.classList.contains('hljs');
+
     // highlight.js v11 refuses to re-highlight a node once `data-highlighted`
     // is set, even if the inner text has changed (e.g. user switches a
     // language tab in the API-code dialog). Reset the marker + previously
     // applied hljs classes so each render is highlighted fresh.
-    if (code.dataset.highlighted) {
+    if (!prehighlighted && code.dataset.highlighted) {
       delete code.dataset.highlighted;
       code.className = code.className
         .split(/\s+/)
@@ -21,9 +27,14 @@ export const highlight = async (el: HTMLElement) => {
         .join(' ');
     }
 
-    if (pre.dataset.hasCopy === '1') {
+    const applyHighlight = () => {
+      if (prehighlighted) return;
       if ('highlightElement' in hl) hl.highlightElement(code);
       else (hl as any).highlightBlock(code);
+    };
+
+    if (pre.dataset.hasCopy === '1') {
+      applyHighlight();
       return;
     }
 
@@ -53,7 +64,6 @@ export const highlight = async (el: HTMLElement) => {
 
     pre.dataset.hasCopy = '1';
 
-    if ('highlightElement' in hl) hl.highlightElement(code);
-    else (hl as any).highlightBlock(code);
+    applyHighlight();
   });
 };


### PR DESCRIPTION
## Problem

In Nexior's **coding-bridge** transcript, assistant messages rendered:

- **bare URLs as plain text** (not clickable) — coding agents emit raw PR/doc links constantly
- **code blocks without syntax highlighting**

## Root cause

`VueMarkdown` initialized `markdown-it` with only `{ html: true }`:

- no `linkify`, so bare URLs were never converted to `<a>` (only explicit `[text](url)` worked)
- highlighting relied solely on a post-render `v-highlight` directive that mutates the DOM. During streaming, every token re-render replaces the component's `innerHTML`, wiping those mutations — so highlighting was racy/unreliable.

## Fix

- **`VueMarkdown.vue`** — enable `linkify`, and bake syntax highlighting directly into the rendered HTML with highlight.js (deterministic, immune to streaming re-render churn). Links now open in a new tab (`target=_blank rel=noopener`) since the app is often embedded.
- **`utils/highlight.ts`** — the `v-highlight` directive now skips blocks already highlighted by VueMarkdown (prevents nested token spans) while still highlighting `CodeSnippet`'s plain blocks and adding the copy button everywhere.
- **`TranscriptItem.vue`** — let night-owl's dark `.hljs` background fill code blocks cleanly (no light github-markdown frame) and style links.

## Scope / blast radius

`VueMarkdown` is consumed by chat (`MarkdownRenderer`) and coding-bridge (`TranscriptItem`). Chat already applied the same night-owl highlighting via the directive, so its output is visually unchanged — just more reliable. `CodeSnippet` (API-docs code samples) is unaffected: it has no `hljs` class, so the directive still highlights it.

## Verification

- `npx eslint` ✅
- `npx vue-tsc --noEmit` ✅
- markdown-it config verified to linkify bare URLs and emit `hljs`-classed, token-highlighted code blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)