### PR TITLE
fix(coding-bridge): dock AskUserQuestion above composer + Enter to advance

### DIFF
--- a/src/components/chat/AskUserQuestionCard.vue
+++ b/src/components/chat/AskUserQuestionCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="ask-user-question-card" :class="{ 'is-collapsed': collapsed, 'is-bounded': bounded && !collapsed }">
+  <div class="ask-user-question-card" :class="{ 'is-collapsed': collapsed }">
     <!-- Collapsed view: one-line summary per question after submit / restore -->
     <div v-if="collapsed" class="collapsed">
       <div v-for="(q, idx) in questions" :key="idx" class="collapsed-row">
@@ -10,8 +10,9 @@
       </div>
     </div>
 
-    <!-- Wizard view: one question at a time -->
-    <div v-else class="wizard">
+    <!-- Wizard view: one question at a time. Enter advances / submits (a
+         radio or the freeform textarea bubbles its keydown up to here). -->
+    <div v-else class="wizard" @keydown.enter="onEnter">
       <!-- Progress header -->
       <div class="progress">
         <div class="progress-meta">
@@ -43,7 +44,6 @@
               :rows="3"
               :placeholder="$t('chat.askUserQuestion.placeholder')"
               resize="none"
-              @keydown.enter.exact.prevent="onNext"
             />
           </div>
 
@@ -104,7 +104,6 @@
                 :rows="2"
                 :placeholder="$t('chat.askUserQuestion.placeholder')"
                 resize="none"
-                @keydown.enter.exact.prevent="onNext"
               />
             </div>
           </Transition>
@@ -173,18 +172,6 @@ export default defineComponent({
     collapsed: {
       type: Boolean,
       default: false
-    },
-    /**
-     * Bound the card to the viewport and scroll the option list internally so
-     * the action row stays pinned. Right for a host that does NOT auto-scroll
-     * the card into view (chat). Set `false` when the card lives inside a host
-     * scroll container that already scrolls it into view (coding bridge): the
-     * card then flows at natural height and the host handles overflow, avoiding
-     * a nested-scroll conflict that clips the buttons on mobile.
-     */
-    bounded: {
-      type: Boolean,
-      default: true
     },
     previousOutput: {
       type: String,
@@ -268,6 +255,16 @@ export default defineComponent({
       this.transitionName = 'slide-next';
       this.currentIndex += 1;
     },
+    // Enter (without modifiers) advances or submits. Shift/Ctrl/Cmd+Enter keeps
+    // the default so the freeform textarea can still insert a newline, and IME
+    // composition Enter (confirming candidates) never triggers navigation.
+    onEnter(event: KeyboardEvent) {
+      if (event.isComposing || event.shiftKey || event.metaKey || event.ctrlKey || event.altKey) {
+        return;
+      }
+      event.preventDefault();
+      this.onNext();
+    },
     onBack() {
       if (this.currentIndex === 0) return;
       this.transitionName = 'slide-back';
@@ -330,13 +327,12 @@ export default defineComponent({
 // list scrolls internally (see `.options`) while the progress header and the
 // action row (Back / Next / Submit) stay pinned and always reachable — on a
 // phone they previously fell below the fold, leaving no clickable button.
-// Only applied in `bounded` mode; an unbounded card (e.g. inside the coding
-// bridge transcript, which already scrolls the card into view) flows at its
-// natural height so the host's own scroll reaches every option and button.
-.ask-user-question-card.is-bounded {
+// A host can shrink the bound via `--auq-max-height` (the coding bridge docks
+// the card above its composer and caps it so the action bar is always on screen).
+.ask-user-question-card:not(.is-collapsed) {
   display: flex;
   flex-direction: column;
-  max-height: min(80vh, 620px);
+  max-height: var(--auq-max-height, min(80vh, 620px));
 }
 
 .ask-user-question-card.is-collapsed {
@@ -472,12 +468,16 @@ export default defineComponent({
 
 // ----- Options -----
 
-// On short viewports (mobile webview) a long option list would push the action
-// row — and the Submit button with it — below the fold. In `bounded` mode the
-// list takes the card's free space and scrolls internally so the progress
-// header and actions stay pinned; short lists keep their natural height. An
-// unbounded card skips this and flows naturally (the host container scrolls).
-.is-bounded .options {
+.options {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: stretch;
+
+  // On short viewports (mobile webview) a long option list would push the
+  // action row — and the Submit button with it — below the fold. Let the list
+  // take the card's free space and scroll internally so the progress header
+  // and actions stay pinned; short lists keep their natural height.
   flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
@@ -493,13 +493,6 @@ export default defineComponent({
     border-radius: 999px;
     background: var(--el-border-color);
   }
-}
-
-.options {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  align-items: stretch;
 
   // Element Plus radios/checkboxes default to inline; stack and theme.
   :deep(.el-radio),

--- a/src/components/codingBridge/SessionView.vue
+++ b/src/components/codingBridge/SessionView.vue
@@ -58,7 +58,7 @@
       </div>
 
       <!-- Transcript -->
-      <div ref="transcript" class="flex-1 overflow-y-auto px-5 py-4 flex flex-col gap-3">
+      <div ref="transcript" class="flex-1 min-h-0 overflow-y-auto px-5 py-4 flex flex-col gap-3">
         <div v-if="!events.length" class="m-auto text-center text-sm text-[var(--app-text-subtle)]">
           {{ $t('codingBridge.session.startHint') }}
         </div>
@@ -78,15 +78,18 @@
             {{ $t('codingBridge.session.retry') }}
           </el-button>
         </div>
-        <!-- Unbounded: the transcript already scrolls the card into view, so it
-             flows at natural height instead of nesting its own scroll (which
-             clipped the options/buttons on mobile). -->
+      </div>
+
+      <!-- Pending question: docked between the transcript and the composer
+           (NOT inside the scrolling transcript) so its options scroll inside
+           the card and the Back / Next / Submit bar is always on screen and
+           tappable on mobile. Capped via `--auq-max-height` so the dock +
+           composer + header always fit the viewport. -->
+      <div v-if="pendingQuestion" class="cb-question-dock flex-none px-5">
         <ask-user-question-card
-          v-if="pendingQuestion"
           :key="pendingQuestion.request_id"
           :tool-use-id="pendingQuestion.request_id"
           :payload="pendingQuestion.payload"
-          :bounded="false"
           @submit="onAnswerQuestion"
           @skip="onSkipQuestion"
         />
@@ -1189,6 +1192,18 @@ export default defineComponent({
 </script>
 
 <style scoped lang="scss">
+// Docked pending-question panel. It shares the column with the transcript
+// (which is `flex-1` and shrinks first); the card caps its own height via
+// `--auq-max-height` and scrolls its options internally, so the action bar
+// stays visible above the composer even on a short phone screen. `dvh` tracks
+// the mobile browser's dynamic chrome.
+.cb-question-dock {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  --auq-max-height: min(52dvh, 560px);
+}
+
 .cb-composer {
   position: relative;
 


### PR DESCRIPTION
Follow-up to #915 — that fix wasn't enough on mobile.

## Problem (still broken after #915)

On a phone, the interactive **AskUserQuestion** card in the coding bridge (`/coding-bridge`):
- **Can't reach Next/Submit** — the options + Back/Next/Submit bar are clipped / below the fold.
- **Enter does nothing** — a selected radio option can't be confirmed with the keyboard.

Reported with session `a2bf9a4f56f845db860f66216cd9610b`.

## Root cause

1. The card sits **inside the transcript's own `overflow-y-auto` scroll container**. #915 gave the card its own `max-height: 80vh` + internally-scrolling option list — correct for chat, but it nests a second scroll inside the transcript. On a phone the transcript viewport is shorter than `80vh` (header + diagnostics + composer eat the height), so the action bar ends up outside the visible/scrollable area.
2. Enter-to-advance was only wired on the freeform textarea, not radio/checkbox selection.

## Fix

- **Dock the pending question between the transcript and the composer** (no longer inside the scrolling transcript). It shares the column with the transcript (`flex-1`, which shrinks first); the card caps its height and scrolls its options **internally**, so the Back/Next/Submit bar is always on screen and tappable.
- Make the card's bound **host-overridable** via a new `--auq-max-height` CSS var (default unchanged `min(80vh, 620px)` → **chat is byte-for-byte the same**; the dock sets `min(52dvh, 560px)`, `dvh` tracking mobile browser chrome).
- **Enter-to-advance/submit** on the wizard: plain Enter advances or submits; Shift/Ctrl/Cmd+Enter and IME-composition Enter keep their default.

## Result (the three asks)

1. ✅ Enter responds (advance / submit).
2. ✅ Next→Submit switch and the whole action bar stay visible.
3. ✅ Options scroll inside the card; the action bar is always tappable on mobile.

## Testing

- `npx eslint` + `npx vue-tsc --noEmit` — clean.
- chat path unchanged (default `--auq-max-height`).
- Verify on the per-branch preview Worker at `/coding-bridge`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)