### PR TITLE
ci: 在 PR 流水线强制 beachball change file（修复移动端自动发布断链）

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,11 @@ jobs:
         node-version: [22.x]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          # beachball check diffs the PR against the base branch, so it needs
+          # full history (not the default shallow fetch).
+          fetch-depth: 0
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6
@@ -30,6 +34,20 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Verify change file present (beachball)
+        # Fail any PR that touches publishable files but carries no change file.
+        # Without a change file beachball never bumps the version on merge to
+        # main, so publish.yaml prints "Nothing to bump", no
+        # @acedatacloud/nexior_v* tag is pushed, and the mobile auto-release
+        # (auto-release-mobile.yaml) never fires. Run `npm run change` to add
+        # one — use type "none" for changes that should not ship a new version
+        # (e.g. CI-only or tooling edits). This is the same `beachball check`
+        # the local .husky/pre-push hook runs, enforced in CI so it can't be
+        # bypassed with --no-verify or a web/squash merge.
+        run: |
+          git fetch origin "${{ github.base_ref }}"
+          npx beachball check --branch "origin/${{ github.base_ref }}"
 
       - name: Run lint
         run: npm run lint

--- a/change/@acedatacloud-nexior-ci-enforce-changefile.json
+++ b/change/@acedatacloud-nexior-ci-enforce-changefile.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "ci: enforce beachball change-file check in PR pipeline so every merge bumps, tags, and auto-publishes mobile test builds",
+  "packageName": "@acedatacloud/nexior",
+  "email": "cqcreer@gmail.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
## 背景：为什么"合并了却没自动发移动端"

排查 #916/#917/#918 合并后,`auto-release-mobile` 一次都没触发。根因不在那个 workflow,而在**版本根本没 bump**:

- `publish.yaml` 跑 beachball 时输出 **`Nothing to bump - skipping publish!`**
- 这些 PR 没带 beachball change file → 不 bump → 不打 `@acedatacloud/nexior_v*` tag → 移动端自动发布(靠该 tag 触发)永远不会跑。
- 最新版本 tag 停在 `v3.274.2`(06-10),package.json 也还是 3.274.2。

## 闸门为什么没拦住

- `npm run verify`(= `beachball check`)**只挂在本地 `.husky/pre-push`**,流水线里没有。
- 本地钩子可被绕过:`git push --no-verify`、网页端 squash merge、自动化 agent 推送都不跑 husky。
- 且 main **没开分支保护**(`Branch not protected`),CI 红了也能合。

## 本 PR 的修复

在 PR 的 `check` workflow 里加上 `beachball check`(对 base 分支做全量 diff),没带 change file 的 PR 直接 CI 失败。这就是本地 pre-push 跑的同一条命令,挪到 CI 里、绕不过去。

- 不该发版的 PR(纯 CI/工具改动)用 `npm run change` 选 **type `none`** 即可过闸、不 bump。
- 本 PR 自带一个 `patch` change file,所以**合并它就会真正跑通一次全链路**:bump → 推 tag → `auto-release-mobile` 触发 → iOS TestFlight + Android beta(Production 仍手动)。

## 还差一步(需要你拍板)

要让这道闸**真正阻断合并**,main 必须开分支保护并把 `check` 设为 required status check。但要注意:beachball 在 `publish.yaml` 里用 `BOT_GITHUB_TOKEN` 直接 push bump commit 回 main,分支保护配置不当会**挡住这个 bot 推送、反而搞坏发版**。所以这步我没擅自开,建议用 ruleset 给发版 bot 加 bypass。要的话我帮你配。

🤖 Generated with [Claude Code](https://claude.com/claude-code)