### PR TITLE
ci: 去掉发版时多跑的那条 no-op publish(功能不变)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,6 +15,12 @@ on:
       - '.github/ISSUE_TEMPLATE/**'
 jobs:
   run:
+    # Skip the redundant no-op re-run. beachball's successful publish pushes an
+    # "applying package updates" bump commit back to main, which re-enters this
+    # workflow only to print "Nothing to bump - skipping publish!" after a full
+    # checkout + npm ci + build. The real publish already happened on the
+    # triggering PR-merge run, so short-circuit the self-triggered re-run.
+    if: ${{ !startsWith(github.event.head_commit.message, 'applying package updates') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/change/@acedatacloud-nexior-skip-redundant-publish.json
+++ b/change/@acedatacloud-nexior-skip-redundant-publish.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "ci: skip the redundant no-op publish re-run triggered by beachball's own bump commit",
+  "packageName": "@acedatacloud/nexior",
+  "email": "cqcreer@gmail.com",
+  "dependentChangeType": "none"
+}


### PR DESCRIPTION
## 问题:每次发版 `publish` 跑了两遍

| Run | 触发 | 实际工作 |
|-----|------|---------|
| ① | PR 合并提交 | ✅ 真发版:beachball bump → npm publish → 推 `applying package updates` 提交 + tag |
| ② | ①推回 main 的那个 bump 提交 | ❌ `Nothing to bump - skipping publish!`,但仍跑了 checkout + npm ci + build(约 1m18s) |

这是 beachball "把 bump 提交推回 main → 又触发自己" 的经典自激。第二条对功能零贡献(真正的发版、tag、`github-release`、`auto-release-mobile` 全在第一条完成),纯浪费 CI 分钟。

## 改动

给 `publish.yaml` 的 job 加一个 guard:

```yaml
if: ${{ !startsWith(github.event.head_commit.message, 'applying package updates') }}
```

识别到是 beachball 的 bump 提交就整条 job 跳过。

## 为什么功能不变

- 真正的 publish / npm 发布 / tag 推送 全发生在第一条 run,不受影响。
- tag 照常推出 → `github-release` 和 `auto-release-mobile` 照常触发。
- 只是把第二条 no-op run 短路掉。

按 beachball 默认 bump 提交信息 `applying package updates` 匹配(本仓库历史提交已验证就是这个文案)。本 PR 为纯 CI 改动,附 `none` 类型 change file,不发新版本。

🤖 Generated with [Claude Code](https://claude.com/claude-code)