### PR TITLE
feat(coding-bridge): notify the user when a session needs approval

### DIFF
--- a/change/@acedatacloud-nexior-0e432b5e-0f22-45e1-8e5e-24d9165397c8.json
+++ b/change/@acedatacloud-nexior-0e432b5e-0f22-45e1-8e5e-24d9165397c8.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(coding-bridge): notify the user when a session needs approval (in-page, Web Push, mobile push)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "@capacitor-community/stripe": "^8.1.1",
         "@capacitor/app": "^8.0.1",
         "@capacitor/browser": "^8.0.1",
+        "@capacitor/local-notifications": "^8.2.0",
+        "@capacitor/push-notifications": "^8.1.1",
         "@capgo/capacitor-updater": "^8.49.1",
         "@codemirror/lang-java": "^6.0.1",
         "@codemirror/lang-javascript": "^6.1.2",
@@ -433,6 +435,24 @@
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": "^8.4.0"
+      }
+    },
+    "node_modules/@capacitor/local-notifications": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/local-notifications/-/local-notifications-8.2.0.tgz",
+      "integrity": "sha512-fvLY0w2w4MiX+DD4+Wv4DOwOLdzKZsMDwAcRv/Juudd+QbKbn69s6cM3xVqPwAiDqfnqsY4/S8xtQD6M73wY2A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor/push-notifications": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/push-notifications/-/push-notifications-8.1.1.tgz",
+      "integrity": "sha512-WqzjPKIbYbARMN+GC0XMAJcxJpUUzqgzS/Ny8RODLrro38pQhm3GXYwX2Mwd+LZlLY39rGImkCkrKyQSNfuikA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
       }
     },
     "node_modules/@capgo/capacitor-updater": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "@capacitor-community/stripe": "^8.1.1",
     "@capacitor/app": "^8.0.1",
     "@capacitor/browser": "^8.0.1",
+    "@capacitor/local-notifications": "^8.2.0",
+    "@capacitor/push-notifications": "^8.1.1",
     "@capgo/capacitor-updater": "^8.49.1",
     "@codemirror/lang-java": "^6.0.1",
     "@codemirror/lang-javascript": "^6.1.2",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,51 @@
+/* Coding Bridge service worker — Web Push receiver.
+ *
+ * Shows a consent-prompt notification pushed by the coding-bridge relay when no
+ * tab is open, and opens (or focuses) the deep-linked page when it is tapped.
+ * Deliberately minimal: this SW does NOT cache or intercept fetches — Nexior is
+ * not a PWA shell, it only needs push delivery.
+ */
+
+self.addEventListener('push', (event) => {
+  let payload = {};
+  try {
+    payload = event.data ? event.data.json() : {};
+  } catch (e) {
+    payload = { title: 'Approval needed', body: 'Open Coding Bridge to review.' };
+  }
+  const title = payload.title || 'Approval needed';
+  const data = payload.data || {};
+  const options = {
+    body: payload.body || 'A coding session needs your approval.',
+    tag: payload.tag || data.request_id || 'coding-bridge-permission',
+    renotify: true,
+    requireInteraction: true,
+    data
+  };
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const data = event.notification.data || {};
+  const target = data.deep_link || '/coding-bridge';
+  event.waitUntil(
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clients) => {
+      // Focus an existing tab if one is already open, else open a new one.
+      for (const client of clients) {
+        if ('focus' in client) {
+          client.focus();
+          if ('navigate' in client && target) {
+            try {
+              client.navigate(target);
+            } catch (e) {
+              /* cross-origin or unsupported — ignore */
+            }
+          }
+          return undefined;
+        }
+      }
+      return self.clients.openWindow ? self.clients.openWindow(target) : undefined;
+    })
+  );
+});

--- a/src/components/codingBridge/NodeList.vue
+++ b/src/components/codingBridge/NodeList.vue
@@ -6,6 +6,7 @@
         <span>{{ $t('codingBridge.nodeList.title') }}</span>
       </div>
       <div class="flex items-center gap-1">
+        <notification-toggle />
         <el-button circle size="small" :title="$t('codingBridge.nodeList.refresh')" @click="onRefresh">
           <font-awesome-icon icon="fa-solid fa-rotate-right" />
         </el-button>
@@ -71,12 +72,14 @@ import { defineComponent } from 'vue';
 import { ElButton, ElMessage, ElMessageBox } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { ICodingBridgeConnectionStatus, ICodingBridgeNode } from '@/models';
+import NotificationToggle from './NotificationToggle.vue';
 
 export default defineComponent({
   name: 'CodingBridgeNodeList',
   components: {
     ElButton,
-    FontAwesomeIcon
+    FontAwesomeIcon,
+    NotificationToggle
   },
   emits: ['pair'],
   computed: {

--- a/src/components/codingBridge/NotificationToggle.vue
+++ b/src/components/codingBridge/NotificationToggle.vue
@@ -1,0 +1,71 @@
+<template>
+  <el-button
+    v-if="supported"
+    circle
+    size="small"
+    :type="enabled ? 'primary' : 'default'"
+    :title="enabled ? $t('codingBridge.notify.disable') : $t('codingBridge.notify.enable')"
+    :loading="busy"
+    @click="onToggle"
+  >
+    <font-awesome-icon :icon="enabled ? 'fa-solid fa-bell' : 'fa-regular fa-bell'" />
+  </el-button>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElButton, ElMessage } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { notifyPermission, webNotificationsSupported } from '@/utils/codingBridgeNotify';
+import { isNative } from '@/utils/surface';
+
+export default defineComponent({
+  name: 'CodingBridgeNotificationToggle',
+  components: {
+    ElButton,
+    FontAwesomeIcon
+  },
+  data() {
+    return {
+      enabled: false,
+      busy: false
+    };
+  },
+  computed: {
+    supported(): boolean {
+      // Native always supports notifications; web needs the Notification API.
+      return isNative() || webNotificationsSupported();
+    }
+  },
+  mounted() {
+    // Reflect a prior grant so the bell shows the right state on load.
+    this.enabled = !isNative() && notifyPermission() === 'granted';
+  },
+  methods: {
+    async onToggle() {
+      this.busy = true;
+      try {
+        if (this.enabled) {
+          await this.$store.dispatch('codingBridge/disableNotifications');
+          this.enabled = false;
+          ElMessage.success(this.$t('codingBridge.notify.disabled') as string);
+          return;
+        }
+        const result = await this.$store.dispatch('codingBridge/enableNotifications');
+        if (result === 'enabled') {
+          this.enabled = true;
+          ElMessage.success(this.$t('codingBridge.notify.enabled') as string);
+        } else if (result === 'denied') {
+          ElMessage.warning(this.$t('codingBridge.notify.denied') as string);
+        } else {
+          ElMessage.warning(this.$t('codingBridge.notify.unsupported') as string);
+        }
+      } catch {
+        ElMessage.error(this.$t('codingBridge.notify.failed') as string);
+      } finally {
+        this.busy = false;
+      }
+    }
+  }
+});
+</script>

--- a/src/constants/codingBridge.ts
+++ b/src/constants/codingBridge.ts
@@ -25,6 +25,8 @@ export const CB_ACTION_SESSION_EDIT = 'session.edit';
 export const CB_ACTION_SESSION_INTERRUPT = 'session.interrupt';
 export const CB_ACTION_SESSION_CLOSE = 'session.close';
 export const CB_ACTION_PERMISSION_RESOLVE = 'permission.resolve';
+// Reconnect / followed a notification: re-fetch every pending permission prompt.
+export const CB_ACTION_PERMISSIONS_LIST = 'permissions.list';
 export const CB_ACTION_SESSIONS_LIST = 'sessions.list';
 export const CB_ACTION_HISTORY_LIST = 'history.list';
 export const CB_ACTION_HISTORY_GET = 'history.get';
@@ -41,6 +43,8 @@ export const CB_EVENT_SESSION_TOOL_USE = 'session.tool_use';
 export const CB_EVENT_SESSION_TOOL_RESULT = 'session.tool_result';
 export const CB_EVENT_PERMISSION_REQUEST = 'permission.request';
 export const CB_EVENT_PERMISSION_RESOLVED = 'permission.resolved';
+// Reply to permissions.list: every still-pending request across all sessions.
+export const CB_EVENT_PERMISSIONS_SNAPSHOT = 'permissions.snapshot';
 export const CB_EVENT_SESSION_RESULT = 'session.result';
 export const CB_EVENT_SESSION_NOTICE = 'session.notice';
 export const CB_EVENT_SESSION_ERROR = 'session.error';

--- a/src/i18n/ar/codingBridge.json
+++ b/src/i18n/ar/codingBridge.json
@@ -406,5 +406,33 @@
   "notice.slashCodexUnsupported": {
     "message": "‏/{command} غير متاح لـ Codex في جلسة عن بُعد.",
     "description": "Notice shown when a Codex slash command isn't supported remotely"
+  },
+  "notify.enable": {
+    "message": "تفعيل الإشعارات",
+    "description": "Tooltip on the notification bell when notifications are off"
+  },
+  "notify.disable": {
+    "message": "إيقاف الإشعارات",
+    "description": "Tooltip on the notification bell when notifications are on"
+  },
+  "notify.enabled": {
+    "message": "تم تفعيل الإشعارات. سننبّهك عندما تحتاج الجلسة إلى موافقة.",
+    "description": "Toast after enabling notifications"
+  },
+  "notify.disabled": {
+    "message": "تم إيقاف الإشعارات.",
+    "description": "Toast after disabling notifications"
+  },
+  "notify.denied": {
+    "message": "الإشعارات محظورة. اسمح بها في إعدادات المتصفح لتلقّي تنبيهات الموافقة.",
+    "description": "Toast when notification permission is denied"
+  },
+  "notify.unsupported": {
+    "message": "الإشعارات غير مدعومة على هذا الجهاز.",
+    "description": "Toast when notifications are unsupported"
+  },
+  "notify.failed": {
+    "message": "تعذّر تحديث إعدادات الإشعارات.",
+    "description": "Toast when enabling or disabling notifications errors"
   }
 }

--- a/src/i18n/de/codingBridge.json
+++ b/src/i18n/de/codingBridge.json
@@ -406,5 +406,33 @@
   "notice.slashCodexUnsupported": {
     "message": "/{command} ist für Codex in einer Remote-Sitzung nicht verfügbar.",
     "description": "Notice shown when a Codex slash command isn't supported remotely"
+  },
+  "notify.enable": {
+    "message": "Benachrichtigungen aktivieren",
+    "description": "Tooltip on the notification bell when notifications are off"
+  },
+  "notify.disable": {
+    "message": "Benachrichtigungen deaktivieren",
+    "description": "Tooltip on the notification bell when notifications are on"
+  },
+  "notify.enabled": {
+    "message": "Benachrichtigungen aktiviert. Wir melden uns, wenn eine Sitzung eine Freigabe benötigt.",
+    "description": "Toast after enabling notifications"
+  },
+  "notify.disabled": {
+    "message": "Benachrichtigungen deaktiviert.",
+    "description": "Toast after disabling notifications"
+  },
+  "notify.denied": {
+    "message": "Benachrichtigungen sind blockiert. Erlaube sie in deinen Browser-Einstellungen, um Freigabe-Hinweise zu erhalten.",
+    "description": "Toast when notification permission is denied"
+  },
+  "notify.unsupported": {
+    "message": "Benachrichtigungen werden auf diesem Gerät nicht unterstützt.",
+    "description": "Toast when notifications are unsupported"
+  },
+  "notify.failed": {
+    "message": "Benachrichtigungseinstellungen konnten nicht aktualisiert werden.",
+    "description": "Toast when enabling or disabling notifications errors"
   }
 }

--- a/src/i18n/el/codingBridge.json
+++ b/src/i18n/el/codingBridge.json
@@ -406,5 +406,33 @@
   "notice.slashCodexUnsupported": {
     "message": "Η /{command} δεν είναι διαθέσιμη για το Codex σε απομακρυσμένη συνεδρία.",
     "description": "Notice shown when a Codex slash command isn't supported remotely"
+  },
+  "notify.enable": {
+    "message": "Ενεργοποίηση ειδοποιήσεων",
+    "description": "Tooltip on the notification bell when notifications are off"
+  },
+  "notify.disable": {
+    "message": "Απενεργοποίηση ειδοποιήσεων",
+    "description": "Tooltip on the notification bell when notifications are on"
+  },
+  "notify.enabled": {
+    "message": "Οι ειδοποιήσεις ενεργοποιήθηκαν. Θα σας ειδοποιήσουμε όταν μια συνεδρία χρειάζεται έγκριση.",
+    "description": "Toast after enabling notifications"
+  },
+  "notify.disabled": {
+    "message": "Οι ειδοποιήσεις απενεργοποιήθηκαν.",
+    "description": "Toast after disabling notifications"
+  },
+  "notify.denied": {
+    "message": "Οι ειδοποιήσεις είναι αποκλεισμένες. Επιτρέψτε τις στις ρυθμίσεις του προγράμματος περιήγησης για να λαμβάνετε ειδοποιήσεις έγκρισης.",
+    "description": "Toast when notification permission is denied"
+  },
+  "notify.unsupported": {
+    "message": "Οι ειδοποιήσεις δεν υποστηρίζονται σε αυτή τη συσκευή.",
+    "description": "Toast when notifications are unsupported"
+  },
+  "notify.failed": {
+    "message": "Δεν ήταν δυνατή η ενημέρωση των ρυθμίσεων ειδοποιήσεων.",
+    "description": "Toast when enabling or disabling notifications errors"
   }
 }

--- a/src/i18n/en/codingBridge.json
+++ b/src/i18n/en/codingBridge.json
@@ -406,5 +406,33 @@
   "notice.slashCodexUnsupported": {
     "message": "/{command} isn't available for Codex in a remote session.",
     "description": "Notice shown when a Codex slash command isn't supported remotely"
+  },
+  "notify.enable": {
+    "message": "Enable notifications",
+    "description": "Tooltip on the notification bell when notifications are off"
+  },
+  "notify.disable": {
+    "message": "Disable notifications",
+    "description": "Tooltip on the notification bell when notifications are on"
+  },
+  "notify.enabled": {
+    "message": "Notifications enabled. We'll alert you when a session needs approval.",
+    "description": "Toast after enabling notifications"
+  },
+  "notify.disabled": {
+    "message": "Notifications disabled.",
+    "description": "Toast after disabling notifications"
+  },
+  "notify.denied": {
+    "message": "Notifications are blocked. Allow them in your browser settings to get approval alerts.",
+    "description": "Toast when notification permission is denied"
+  },
+  "notify.unsupported": {
+    "message": "Notifications aren't supported on this device.",
+    "description": "Toast when notifications are unsupported"
+  },
+  "notify.failed": {
+    "message": "Couldn't update notification settings.",
+    "description": "Toast when enabling or disabling notifications errors"
   }
 }

--- a/src/i18n/es/codingBridge.json
+++ b/src/i18n/es/codingBridge.json
@@ -406,5 +406,33 @@
   "notice.slashCodexUnsupported": {
     "message": "/{command} no está disponible para Codex en una sesión remota.",
     "description": "Notice shown when a Codex slash command isn't supported remotely"
+  },
+  "notify.enable": {
+    "message": "Activar notificaciones",
+    "description": "Tooltip on the notification bell when notifications are off"
+  },
+  "notify.disable": {
+    "message": "Desactivar notificaciones",
+    "description": "Tooltip on the notification bell when notifications are on"
+  },
+  "notify.enabled": {
+    "message": "Notificaciones activadas. Te avisaremos cuando una sesión necesite aprobación.",
+    "description": "Toast after enabling notifications"
+  },
+  "notify.disabled": {
+    "message": "Notificaciones desactivadas.",
+    "description": "Toast after disabling notifications"
+  },
+  "notify.denied": {
+    "message": "Las notificaciones están bloqueadas. Permítelas en la configuración del navegador para recibir avisos de aprobación.",
+    "description": "Toast when notification permission is denied"
+  },
+  "notify.unsupported": {
+    "message": "Las notificaciones no son compatibles con este dispositivo.",
+    "description": "Toast when notifications are unsupported"
+  },
+  "notify.failed": {
+    "message": "No se pudo actualizar la configuración de notificaciones.",
+    "description": "Toast when enabling or disabling notifications errors"
   }
 }

--- a/src/i18n/fi/codingBridge.json
+++ b/src/i18n/fi/codingBridge.json
@@ -406,5 +406,33 @@
   "notice.slashCodexUnsupported": {
     "message": "/{command} ei ole käytettävissä Codexille etäistunnossa.",
     "description": "Notice shown when a Codex slash command isn't supported remotely"
+  },
+  "notify.enable": {
+    "message": "Ota ilmoitukset käyttöön",
+    "description": "Tooltip on the notification bell when notifications are off"
+  },
+  "notify.disable": {
+    "message": "Poista ilmoitukset käytöstä",
+    "description": "Tooltip on the notification bell when notifications are on"
+  },
+  "notify.enabled": {
+    "message": "Ilmoitukset otettu käyttöön. Ilmoitamme, kun istunto tarvitsee hyväksynnän.",
+    "description": "Toast after enabling notifications"
+  },
+  "notify.disabled": {
+    "message": "Ilmoitukset poistettu käytöstä.",
+    "description": "Toast after disabling notifications"
+  },
+  "notify.denied": {
+    "message": "Ilmoitukset on estetty. Salli ne selaimen asetuksissa saadaksesi hyväksyntäilmoituksia.",
+    "description": "Toast when notification permission is denied"
+  },
+  "notify.unsupported": {
+    "message": "Ilmoituksia ei tueta tällä laitteella.",
+    "description": "Toast when notifications are unsupported"
+  },
+  "notify.failed": {
+    "message": "Ilmoitusasetusten päivittäminen epäonnistui.",
+    "description": "Toast when enabling or disabling notifications errors"
   }
 }

--- a/src/i18n/fr/codingBridge.json
+++ b/src/i18n/fr/codingBridge.json
@@ -406,5 +406,33 @@
   "notice.slashCodexUnsupported": {
     "message": "/{command} n'est pas disponible pour Codex dans une session distante.",
     "description": "Notice shown when a Codex slash command isn't supported remotely"
+  },
+  "notify.enable": {
+    "message": "Activer les notifications",
+    "description": "Tooltip on the notification bell when notifications are off"
+  },
+  "notify.disable": {
+    "message": "Désactiver les notifications",
+    "description": "Tooltip on the notification bell when notifications are on"
+  },
+  "notify.enabled": {
+    "message": "Notifications activées. Nous vous préviendrons lorsqu'une session nécessite une approbation.",
+    "description": "Toast after enabling notifications"
+  },
+  "notify.disabled": {
+    "message": "Notifications désactivées.",
+    "description": "Toast after disabling notifications"
+  },
+  "notify.denied": {
+    "message": "Les notifications sont bloquées. Autorisez-les dans les paramètres de votre navigateur pour recevoir les alertes d'approbation.",
+    "description": "Toast when notification permission is denied"
+  },
+  "notify.unsupported": {
+    "message": "Les notifications ne sont pas prises en charge sur cet appareil.",
+    "description": "Toast when notifications are unsupported"
+  },
+  "notify.failed": {
+    "message": "Impossible de mettre à jour les paramètres de notification.",
+    "description": "Toast when enabling or disabling notifications errors"
   }
 }

--- a/src/i18n/it/codingBridge.json
+++ b/src/i18n/it/codingBridge.json
@@ -406,5 +406,33 @@
   "notice.slashCodexUnsupported": {
     "message": "/{command} non è disponibile per Codex in una sessione remota.",
     "description": "Notice shown when a Codex slash command isn't supported remotely"
+  },
+  "notify.enable": {
+    "message": "Attiva le notifiche",
+    "description": "Tooltip on the notification bell when notifications are off"
+  },
+  "notify.disable": {
+    "message": "Disattiva le notifiche",
+    "description": "Tooltip on the notification bell when notifications are on"
+  },
+  "notify.enabled": {
+    "message": "Notifiche attivate. Ti avviseremo quando una sessione richiede un'approvazione.",
+    "description": "Toast after enabling notifications"
+  },
+  "notify.disabled": {
+    "message": "Notifiche disattivate.",
+    "description": "Toast after disabling notifications"
+  },
+  "notify.denied": {
+    "message": "Le notifiche sono bloccate. Consentile nelle impostazioni del browser per ricevere gli avvisi di approvazione.",
+    "description": "Toast when notification permission is denied"
+  },
+  "notify.unsupported": {
+    "message": "Le notifiche non sono supportate su questo dispositivo.",
+    "description": "Toast when notifications are unsupported"
+  },
+  "notify.failed": {
+    "message": "Impossibile aggiornare le impostazioni delle notifiche.",
+    "description": "Toast when enabling or disabling notifications errors"
   }
 }

--- a/src/i18n/ja/codingBridge.json
+++ b/src/i18n/ja/codingBridge.json
@@ -406,5 +406,33 @@
   "notice.slashCodexUnsupported": {
     "message": "/{command} はリモートセッションの Codex では利用できません。",
     "description": "Notice shown when a Codex slash command isn't supported remotely"
+  },
+  "notify.enable": {
+    "message": "通知を有効にする",
+    "description": "Tooltip on the notification bell when notifications are off"
+  },
+  "notify.disable": {
+    "message": "通知を無効にする",
+    "description": "Tooltip on the notification bell when notifications are on"
+  },
+  "notify.enabled": {
+    "message": "通知を有効にしました。セッションで承認が必要なときにお知らせします。",
+    "description": "Toast after enabling notifications"
+  },
+  "notify.disabled": {
+    "message": "通知を無効にしました。",
+    "description": "Toast after disabling notifications"
+  },
+  "notify.denied": {
+    "message": "通知がブロックされています。承認通知を受け取るにはブラウザの設定で許可してください。",
+    "description": "Toast when notification permission is denied"
+  },
+  "notify.unsupported": {
+    "message": "このデバイスでは通知がサポートされていません。",
+    "description": "Toast when notifications are unsupported"
+  },
+  "notify.failed": {
+    "message": "通知設定を更新できませんでした。",
+    "description": "Toast when enabling or disabling notifications errors"
   }
 }

--- a/src/i18n/ko/codingBridge.json
+++ b/src/i18n/ko/codingBridge.json
@@ -406,5 +406,33 @@
   "notice.slashCodexUnsupported": {
     "message": "/{command} 은(는) 원격 세션의 Codex에서 사용할 수 없습니다.",
     "description": "Notice shown when a Codex slash command isn't supported remotely"
+  },
+  "notify.enable": {
+    "message": "알림 켜기",
+    "description": "Tooltip on the notification bell when notifications are off"
+  },
+  "notify.disable": {
+    "message": "알림 끄기",
+    "description": "Tooltip on the notification bell when notifications are on"
+  },
+  "notify.enabled": {
+    "message": "알림이 켜졌습니다. 세션에 승인이 필요하면 알려드립니다.",
+    "description": "Toast after enabling notifications"
+  },
+  "notify.disabled": {
+    "message": "알림이 꺼졌습니다.",
+    "description": "Toast after disabling notifications"
+  },
+  "notify.denied": {
+    "message": "알림이 차단되어 있습니다. 승인 알림을 받으려면 브라우저 설정에서 허용하세요.",
+    "description": "Toast when notification permission is denied"
+  },
+  "notify.unsupported": {
+    "message": "이 기기에서는 알림이 지원되지 않습니다.",
+    "description": "Toast when notifications are unsupported"
+  },
+  "notify.failed": {
+    "message": "알림 설정을 업데이트하지 못했습니다.",
+    "description": "Toast when enabling or disabling notifications errors"
   }
 }

--- a/src/i18n/pl/codingBridge.json
+++ b/src/i18n/pl/codingBridge.json
@@ -406,5 +406,33 @@
   "notice.slashCodexUnsupported": {
     "message": "/{command} nie jest dostępne dla Codex w sesji zdalnej.",
     "description": "Notice shown when a Codex slash command isn't supported remotely"
+  },
+  "notify.enable": {
+    "message": "Włącz powiadomienia",
+    "description": "Tooltip on the notification bell when notifications are off"
+  },
+  "notify.disable": {
+    "message": "Wyłącz powiadomienia",
+    "description": "Tooltip on the notification bell when notifications are on"
+  },
+  "notify.enabled": {
+    "message": "Powiadomienia włączone. Powiadomimy Cię, gdy sesja będzie wymagać zatwierdzenia.",
+    "description": "Toast after enabling notifications"
+  },
+  "notify.disabled": {
+    "message": "Powiadomienia wyłączone.",
+    "description": "Toast after disabling notifications"
+  },
+  "notify.denied": {
+    "message": "Powiadomienia są zablokowane. Zezwól na nie w ustawieniach przeglądarki, aby otrzymywać alerty o zatwierdzeniu.",
+    "description": "Toast when notification permission is denied"
+  },
+  "notify.unsupported": {
+    "message": "Powiadomienia nie są obsługiwane na tym urządzeniu.",
+    "description": "Toast when notifications are unsupported"
+  },
+  "notify.failed": {
+    "message": "Nie udało się zaktualizować ustawień powiadomień.",
+    "description": "Toast when enabling or disabling notifications errors"
   }
 }

--- a/src/i18n/pt/codingBridge.json
+++ b/src/i18n/pt/codingBridge.json
@@ -406,5 +406,33 @@
   "notice.slashCodexUnsupported": {
     "message": "/{command} não está disponível para o Codex numa sessão remota.",
     "description": "Notice shown when a Codex slash command isn't supported remotely"
+  },
+  "notify.enable": {
+    "message": "Ativar notificações",
+    "description": "Tooltip on the notification bell when notifications are off"
+  },
+  "notify.disable": {
+    "message": "Desativar notificações",
+    "description": "Tooltip on the notification bell when notifications are on"
+  },
+  "notify.enabled": {
+    "message": "Notificações ativadas. Avisaremos quando uma sessão precisar de aprovação.",
+    "description": "Toast after enabling notifications"
+  },
+  "notify.disabled": {
+    "message": "Notificações desativadas.",
+    "description": "Toast after disabling notifications"
+  },
+  "notify.denied": {
+    "message": "As notificações estão bloqueadas. Permita-as nas configurações do navegador para receber alertas de aprovação.",
+    "description": "Toast when notification permission is denied"
+  },
+  "notify.unsupported": {
+    "message": "As notificações não são compatíveis com este dispositivo.",
+    "description": "Toast when notifications are unsupported"
+  },
+  "notify.failed": {
+    "message": "Não foi possível atualizar as configurações de notificação.",
+    "description": "Toast when enabling or disabling notifications errors"
   }
 }

--- a/src/i18n/ru/codingBridge.json
+++ b/src/i18n/ru/codingBridge.json
@@ -406,5 +406,33 @@
   "notice.slashCodexUnsupported": {
     "message": "/{command} недоступна для Codex в удалённом сеансе.",
     "description": "Notice shown when a Codex slash command isn't supported remotely"
+  },
+  "notify.enable": {
+    "message": "Включить уведомления",
+    "description": "Tooltip on the notification bell when notifications are off"
+  },
+  "notify.disable": {
+    "message": "Отключить уведомления",
+    "description": "Tooltip on the notification bell when notifications are on"
+  },
+  "notify.enabled": {
+    "message": "Уведомления включены. Мы сообщим, когда сессии потребуется подтверждение.",
+    "description": "Toast after enabling notifications"
+  },
+  "notify.disabled": {
+    "message": "Уведомления отключены.",
+    "description": "Toast after disabling notifications"
+  },
+  "notify.denied": {
+    "message": "Уведомления заблокированы. Разрешите их в настройках браузера, чтобы получать оповещения о подтверждении.",
+    "description": "Toast when notification permission is denied"
+  },
+  "notify.unsupported": {
+    "message": "Уведомления не поддерживаются на этом устройстве.",
+    "description": "Toast when notifications are unsupported"
+  },
+  "notify.failed": {
+    "message": "Не удалось обновить настройки уведомлений.",
+    "description": "Toast when enabling or disabling notifications errors"
   }
 }

--- a/src/i18n/sr/codingBridge.json
+++ b/src/i18n/sr/codingBridge.json
@@ -406,5 +406,33 @@
   "notice.slashCodexUnsupported": {
     "message": "/{command} није доступна за Codex у удаљеној сесији.",
     "description": "Notice shown when a Codex slash command isn't supported remotely"
+  },
+  "notify.enable": {
+    "message": "Омогући обавештења",
+    "description": "Tooltip on the notification bell when notifications are off"
+  },
+  "notify.disable": {
+    "message": "Онемогући обавештења",
+    "description": "Tooltip on the notification bell when notifications are on"
+  },
+  "notify.enabled": {
+    "message": "Обавештења су омогућена. Обавестићемо вас када сесија захтева одобрење.",
+    "description": "Toast after enabling notifications"
+  },
+  "notify.disabled": {
+    "message": "Обавештења су онемогућена.",
+    "description": "Toast after disabling notifications"
+  },
+  "notify.denied": {
+    "message": "Обавештења су блокирана. Дозволите их у подешавањима прегледача да бисте примали обавештења о одобрењу.",
+    "description": "Toast when notification permission is denied"
+  },
+  "notify.unsupported": {
+    "message": "Обавештења нису подржана на овом уређају.",
+    "description": "Toast when notifications are unsupported"
+  },
+  "notify.failed": {
+    "message": "Ажурирање подешавања обавештења није успело.",
+    "description": "Toast when enabling or disabling notifications errors"
   }
 }

--- a/src/i18n/sv/codingBridge.json
+++ b/src/i18n/sv/codingBridge.json
@@ -406,5 +406,33 @@
   "notice.slashCodexUnsupported": {
     "message": "/{command} är inte tillgängligt för Codex i en fjärrsession.",
     "description": "Notice shown when a Codex slash command isn't supported remotely"
+  },
+  "notify.enable": {
+    "message": "Aktivera aviseringar",
+    "description": "Tooltip on the notification bell when notifications are off"
+  },
+  "notify.disable": {
+    "message": "Inaktivera aviseringar",
+    "description": "Tooltip on the notification bell when notifications are on"
+  },
+  "notify.enabled": {
+    "message": "Aviseringar aktiverade. Vi meddelar dig när en session behöver godkännande.",
+    "description": "Toast after enabling notifications"
+  },
+  "notify.disabled": {
+    "message": "Aviseringar inaktiverade.",
+    "description": "Toast after disabling notifications"
+  },
+  "notify.denied": {
+    "message": "Aviseringar är blockerade. Tillåt dem i webbläsarinställningarna för att få godkännandeaviseringar.",
+    "description": "Toast when notification permission is denied"
+  },
+  "notify.unsupported": {
+    "message": "Aviseringar stöds inte på den här enheten.",
+    "description": "Toast when notifications are unsupported"
+  },
+  "notify.failed": {
+    "message": "Det gick inte att uppdatera aviseringsinställningarna.",
+    "description": "Toast when enabling or disabling notifications errors"
   }
 }

--- a/src/i18n/uk/codingBridge.json
+++ b/src/i18n/uk/codingBridge.json
@@ -406,5 +406,33 @@
   "notice.slashCodexUnsupported": {
     "message": "/{command} недоступна для Codex у віддаленому сеансі.",
     "description": "Notice shown when a Codex slash command isn't supported remotely"
+  },
+  "notify.enable": {
+    "message": "Увімкнути сповіщення",
+    "description": "Tooltip on the notification bell when notifications are off"
+  },
+  "notify.disable": {
+    "message": "Вимкнути сповіщення",
+    "description": "Tooltip on the notification bell when notifications are on"
+  },
+  "notify.enabled": {
+    "message": "Сповіщення ввімкнено. Ми повідомимо, коли сесія потребуватиме підтвердження.",
+    "description": "Toast after enabling notifications"
+  },
+  "notify.disabled": {
+    "message": "Сповіщення вимкнено.",
+    "description": "Toast after disabling notifications"
+  },
+  "notify.denied": {
+    "message": "Сповіщення заблоковано. Дозвольте їх у налаштуваннях браузера, щоб отримувати сповіщення про підтвердження.",
+    "description": "Toast when notification permission is denied"
+  },
+  "notify.unsupported": {
+    "message": "Сповіщення не підтримуються на цьому пристрої.",
+    "description": "Toast when notifications are unsupported"
+  },
+  "notify.failed": {
+    "message": "Не вдалося оновити налаштування сповіщень.",
+    "description": "Toast when enabling or disabling notifications errors"
   }
 }

--- a/src/i18n/zh-CN/codingBridge.json
+++ b/src/i18n/zh-CN/codingBridge.json
@@ -406,5 +406,33 @@
   "notice.slashCodexUnsupported": {
     "message": "/{command} 在远程会话中暂不支持 Codex。",
     "description": "Notice shown when a Codex slash command isn't supported remotely"
+  },
+  "notify.enable": {
+    "message": "开启通知",
+    "description": "Tooltip on the notification bell when notifications are off"
+  },
+  "notify.disable": {
+    "message": "关闭通知",
+    "description": "Tooltip on the notification bell when notifications are on"
+  },
+  "notify.enabled": {
+    "message": "通知已开启，会话需要授权时会提醒你。",
+    "description": "Toast after enabling notifications"
+  },
+  "notify.disabled": {
+    "message": "通知已关闭。",
+    "description": "Toast after disabling notifications"
+  },
+  "notify.denied": {
+    "message": "通知已被阻止，请在浏览器设置中允许通知以接收授权提醒。",
+    "description": "Toast when notification permission is denied"
+  },
+  "notify.unsupported": {
+    "message": "当前设备不支持通知。",
+    "description": "Toast when notifications are unsupported"
+  },
+  "notify.failed": {
+    "message": "无法更新通知设置。",
+    "description": "Toast when enabling or disabling notifications errors"
   }
 }

--- a/src/i18n/zh-TW/codingBridge.json
+++ b/src/i18n/zh-TW/codingBridge.json
@@ -406,5 +406,33 @@
   "notice.slashCodexUnsupported": {
     "message": "/{command} 在遠端工作階段中暫不支援 Codex。",
     "description": "Notice shown when a Codex slash command isn't supported remotely"
+  },
+  "notify.enable": {
+    "message": "開啟通知",
+    "description": "Tooltip on the notification bell when notifications are off"
+  },
+  "notify.disable": {
+    "message": "關閉通知",
+    "description": "Tooltip on the notification bell when notifications are on"
+  },
+  "notify.enabled": {
+    "message": "通知已開啟，工作階段需要授權時會通知你。",
+    "description": "Toast after enabling notifications"
+  },
+  "notify.disabled": {
+    "message": "通知已關閉。",
+    "description": "Toast after disabling notifications"
+  },
+  "notify.denied": {
+    "message": "通知已被封鎖，請在瀏覽器設定中允許通知以接收授權提醒。",
+    "description": "Toast when notification permission is denied"
+  },
+  "notify.unsupported": {
+    "message": "此裝置不支援通知。",
+    "description": "Toast when notifications are unsupported"
+  },
+  "notify.failed": {
+    "message": "無法更新通知設定。",
+    "description": "Toast when enabling or disabling notifications errors"
   }
 }

--- a/src/models/codingBridge.ts
+++ b/src/models/codingBridge.ts
@@ -213,3 +213,11 @@ export interface ICodingBridgeClaimResponse {
   ok: boolean;
   node_name: string;
 }
+
+/** Push capability advertised by the relay (`GET /api/push/config`). */
+export interface ICodingBridgePushConfig {
+  enabled: boolean;
+  web_push_enabled: boolean;
+  fcm_enabled: boolean;
+  vapid_public_key: string;
+}

--- a/src/operators/codingBridge.ts
+++ b/src/operators/codingBridge.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosResponse } from 'axios';
-import { ICodingBridgeClaimResponse, ICodingBridgeNode } from '@/models';
+import { ICodingBridgeClaimResponse, ICodingBridgeNode, ICodingBridgePushConfig } from '@/models';
 import { BASE_URL_CODING_BRIDGE } from '@/constants';
 
 /**
@@ -37,6 +37,36 @@ class CodingBridgeOperator {
   /** Revoke a node and drop any live connection it holds. */
   async deleteNode(nodeId: string, options: { token: string }): Promise<AxiosResponse<{ ok: boolean }>> {
     return await axios.delete(`/api/nodes/${encodeURIComponent(nodeId)}`, {
+      headers: this.headers(options.token),
+      baseURL: BASE_URL_CODING_BRIDGE
+    });
+  }
+
+  /** Push capability + VAPID public key (no auth needed). */
+  async getPushConfig(): Promise<AxiosResponse<ICodingBridgePushConfig>> {
+    return await axios.get('/api/push/config', { baseURL: BASE_URL_CODING_BRIDGE });
+  }
+
+  /** Register a web-push subscription or an FCM device token for the user. */
+  async savePushSubscription(
+    body:
+      | { kind: 'webpush'; subscription: PushSubscriptionJSON; ua?: string }
+      | { kind: 'fcm'; token: string; ua?: string },
+    options: { token: string }
+  ): Promise<AxiosResponse<{ ok: boolean }>> {
+    return await axios.post('/api/push/subscriptions', body, {
+      headers: this.headers(options.token),
+      baseURL: BASE_URL_CODING_BRIDGE
+    });
+  }
+
+  /** Unregister a subscription by its web-push endpoint or FCM token. */
+  async deletePushSubscription(
+    body: { endpoint?: string; token?: string },
+    options: { token: string }
+  ): Promise<AxiosResponse<{ ok: boolean }>> {
+    return await axios.delete('/api/push/subscriptions', {
+      data: body,
       headers: this.headers(options.token),
       baseURL: BASE_URL_CODING_BRIDGE
     });

--- a/src/pages/codingBridge/Index.vue
+++ b/src/pages/codingBridge/Index.vue
@@ -54,6 +54,7 @@ export default defineComponent({
       this.initialCode = code;
       this.pairVisible = true;
     }
+    this.handleNotificationDeepLink();
   },
   beforeUnmount() {
     this.$store.dispatch('codingBridge/disconnect');
@@ -66,6 +67,17 @@ export default defineComponent({
     openPairFromDrawer() {
       this.drawer = false;
       this.openPair();
+    },
+    // A tapped notification opens `/coding-bridge?node=&session=&request=`.
+    // Select that node and re-fetch its pending prompts so the consent dialog
+    // surfaces immediately. The relay/socket may still be connecting, so we
+    // select eagerly — selectNode + the socket onOpen both request the prompts.
+    handleNotificationDeepLink() {
+      const nodeId = this.$route.query.node;
+      if (typeof nodeId === 'string' && nodeId) {
+        this.$store.dispatch('codingBridge/selectNode', nodeId);
+        this.$store.dispatch('codingBridge/requestPendingPermissions', nodeId);
+      }
     }
   }
 });

--- a/src/plugins/font-awesome.ts
+++ b/src/plugins/font-awesome.ts
@@ -10,7 +10,8 @@ import {
   faFileAlt as faRegularFileAlt,
   faClock as faRegularClock,
   faFile as faRegularFile,
-  faStar as faRegularStar
+  faStar as faRegularStar,
+  faBell as faRegularBell
 } from '@fortawesome/free-regular-svg-icons';
 import {
   faDiscord as faBrandsDiscord,
@@ -34,6 +35,7 @@ import {
   faSeedling as faSolidSeedling,
   faDiamond as faSolidDiamond,
   faLaptopCode as faSolidLaptopCode,
+  faBell as faSolidBell,
   faOutdent as faSolidOutdent,
   faImage as faSolidImage,
   faChevronRight as faSolidChevronRight,
@@ -180,6 +182,8 @@ library.add(faSolidImage);
 library.add(faSolidXmark);
 library.add(faSolidFire);
 library.add(faSolidLaptopCode);
+library.add(faSolidBell);
+library.add(faRegularBell);
 library.add(faSolidRotateRight);
 library.add(faSolidSeedling);
 library.add(faSolidPenToSquare);

--- a/src/store/codingBridge/actions.ts
+++ b/src/store/codingBridge/actions.ts
@@ -11,12 +11,22 @@ import {
 } from '@/models';
 import { CodingBridgeSocket } from '@/utils/codingBridgeSocket';
 import {
+  notifyPermissionLocally,
+  subscribeWebPush,
+  unsubscribeWebPush,
+  registerNativePush,
+  requestWebPermission,
+  type ICodingBridgeNotifyData
+} from '@/utils/codingBridgeNotify';
+import { isNative } from '@/utils/surface';
+import {
   CB_ACTION_SESSION_START,
   CB_ACTION_SESSION_SEND,
   CB_ACTION_SESSION_EDIT,
   CB_ACTION_SESSION_INTERRUPT,
   CB_ACTION_SESSION_CLOSE,
   CB_ACTION_PERMISSION_RESOLVE,
+  CB_ACTION_PERMISSIONS_LIST,
   CB_ACTION_HISTORY_LIST,
   CB_ACTION_HISTORY_GET,
   CB_ACTION_FS_LIST,
@@ -29,6 +39,7 @@ import {
   CB_EVENT_SESSION_TOOL_RESULT,
   CB_EVENT_PERMISSION_REQUEST,
   CB_EVENT_PERMISSION_RESOLVED,
+  CB_EVENT_PERMISSIONS_SNAPSHOT,
   CB_EVENT_SESSION_RESULT,
   CB_EVENT_SESSION_NOTICE,
   CB_EVENT_SESSION_ERROR,
@@ -86,6 +97,28 @@ const formatAnswerText = (output: string): string => {
   return Object.entries(answers)
     .map(([question, value]) => `${question} → ${Array.isArray(value) ? value.join(', ') : value}`)
     .join('\n');
+};
+
+// Raise a Tier-1 local notification for a consent prompt (no-op when the tab is
+// visible). Tapping it focuses the page and opens the originating node so the
+// pending dialog is shown.
+const notifyForPermission = (
+  dispatch: ActionContext<ICodingBridgeState, IRootState>['dispatch'],
+  data: ICodingBridgeNotifyData
+): void => {
+  const tool = data.tool || 'a tool';
+  notifyPermissionLocally(
+    {
+      title: 'Approval needed',
+      body: `Claude wants to use ${tool}. Tap to review.`,
+      data
+    },
+    (clicked) => {
+      if (clicked.node_id) {
+        dispatch('selectNode', clicked.node_id);
+      }
+    }
+  );
 };
 
 // Translate one inner node event into the matching mutation(s).
@@ -200,6 +233,31 @@ const applyNodeEvent = (
         display_name: payload.display_name,
         description: payload.description
       });
+      // Tier 1: if the tab is hidden, surface the prompt as an OS notification.
+      // A visible tab shows the inline dialog instead, so this stays silent.
+      notifyForPermission(dispatch, {
+        node_id: fromNode,
+        session_id: sessionId,
+        request_id: payload.request_id,
+        tool: payload.display_name || payload.title || payload.tool
+      });
+      break;
+    case CB_EVENT_PERMISSIONS_SNAPSHOT:
+      // Reply to permissions.list after a (re)connect or a followed notification:
+      // re-add every prompt that was raised while we were away. addPermission
+      // dedups, so this is safe to apply alongside live events.
+      for (const item of payload.requests ?? []) {
+        commit('addPermission', {
+          request_id: item.request_id,
+          session_id: item.session_id,
+          node_id: fromNode,
+          tool: item.tool,
+          input: item.input,
+          title: item.title,
+          display_name: item.display_name,
+          description: item.description
+        });
+      }
       break;
     case CB_EVENT_PERMISSION_RESOLVED:
       commit('removePermission', payload.request_id);
@@ -464,6 +522,8 @@ export const connect = ({
       if (state.currentNodeId) {
         dispatch('getHistory', state.currentNodeId);
         dispatch('getCapabilities', state.currentNodeId);
+        // Re-fetch any consent prompt raised while we were disconnected.
+        dispatch('requestPendingPermissions', state.currentNodeId);
       }
     },
     onClose: () => commit('setConnection', 'disconnected'),
@@ -478,6 +538,7 @@ export const connect = ({
       if (status === 'online' && nodeId === state.currentNodeId) {
         dispatch('getHistory', nodeId);
         dispatch('getCapabilities', nodeId);
+        dispatch('requestPendingPermissions', nodeId);
       }
     },
     onRelayError: (code, message) => console.warn('[codingBridge] relay error', code, message)
@@ -506,6 +567,21 @@ export const selectNode = (
   commit('setCurrentSession', ids.length ? ids[ids.length - 1] : undefined);
   dispatch('getHistory', nodeId);
   dispatch('getCapabilities', nodeId);
+  dispatch('requestPendingPermissions', nodeId);
+};
+
+// Ask a node to re-emit every outstanding permission prompt (permissions.list).
+// Used after a (re)connect, a node coming online, or following a notification —
+// so a prompt raised while we were away still surfaces instead of blocking.
+export const requestPendingPermissions = (
+  { state }: ActionContext<ICodingBridgeState, IRootState>,
+  nodeId?: string
+): void => {
+  const target = nodeId ?? state.currentNodeId;
+  if (!target || !socket) {
+    return;
+  }
+  socket.sendToNode(target, { action: CB_ACTION_PERMISSIONS_LIST });
 };
 
 export const newSession = ({ commit }: ActionContext<ICodingBridgeState, IRootState>): void => {
@@ -832,6 +908,80 @@ export const getCapabilities = ({ state }: ActionContext<ICodingBridgeState, IRo
   socket.sendToNode(target, { action: CB_ACTION_CAPABILITIES_GET });
 };
 
+// Turn on out-of-band notifications for the signed-in user:
+//  - web: subscribe to Web Push (so a closed tab still gets the prompt),
+//  - native: register for FCM and route taps back to the originating node.
+// Returns the granted/ungranted outcome so the UI can reflect it. Local (Tier 1)
+// notifications need only the browser permission, requested here too.
+export const enableNotifications = async ({
+  dispatch,
+  rootState
+}: ActionContext<ICodingBridgeState, IRootState>): Promise<'enabled' | 'denied' | 'unsupported'> => {
+  const token = rootState.token?.access;
+  if (!token) {
+    return 'unsupported';
+  }
+  if (isNative()) {
+    const deviceToken = await registerNativePush((data) => {
+      if (data?.node_id) {
+        dispatch('selectNode', data.node_id);
+        dispatch('requestPendingPermissions', data.node_id);
+      }
+    });
+    if (!deviceToken) {
+      return 'denied';
+    }
+    await codingBridgeOperator.savePushSubscription(
+      { kind: 'fcm', token: deviceToken, ua: navigator.userAgent },
+      { token }
+    );
+    return 'enabled';
+  }
+  // Web: a local-only grant (no relay VAPID) still powers Tier-1 notifications.
+  const permission = await requestWebPermission();
+  if (permission === 'unsupported') {
+    return 'unsupported';
+  }
+  if (permission !== 'granted') {
+    return 'denied';
+  }
+  try {
+    const { data: config } = await codingBridgeOperator.getPushConfig();
+    if (config.web_push_enabled && config.vapid_public_key) {
+      const subscription = await subscribeWebPush(config.vapid_public_key);
+      if (subscription) {
+        await codingBridgeOperator.savePushSubscription(
+          { kind: 'webpush', subscription, ua: navigator.userAgent },
+          { token }
+        );
+      }
+    }
+  } catch (error) {
+    // Web Push setup failed (relay not configured / network) — Tier-1 still works.
+    console.warn('[codingBridge] web push setup skipped', error);
+  }
+  return 'enabled';
+};
+
+// Tear down Web Push for this browser (Tier-1 needs no teardown; native tokens
+// expire on uninstall). Best-effort: unsubscribe locally, deregister on relay.
+export const disableNotifications = async ({
+  rootState
+}: ActionContext<ICodingBridgeState, IRootState>): Promise<void> => {
+  const token = rootState.token?.access;
+  if (isNative() || !token) {
+    return;
+  }
+  const endpoint = await unsubscribeWebPush();
+  if (endpoint) {
+    try {
+      await codingBridgeOperator.deletePushSubscription({ endpoint }, { token });
+    } catch (error) {
+      console.warn('[codingBridge] failed to deregister web push', error);
+    }
+  }
+};
+
 export default {
   resetAll,
   getApplications,
@@ -842,6 +992,9 @@ export default {
   connect,
   disconnect,
   selectNode,
+  requestPendingPermissions,
+  enableNotifications,
+  disableNotifications,
   newSession,
   sendPrompt,
   editPrompt,

--- a/src/utils/codingBridgeNotify.ts
+++ b/src/utils/codingBridgeNotify.ts
@@ -1,0 +1,262 @@
+/**
+ * Coding Bridge notifications — getting a consent prompt in front of the user
+ * when they are not looking at the page.
+ *
+ * Three tiers, by how far away the user is:
+ *
+ *  1. **In-page / background tab** (this module, web): the live socket is still
+ *     open, so when a `permission.request` arrives while the tab is hidden we
+ *     raise an OS `Notification` directly. Instant, no server round-trip, no
+ *     VAPID needed. A focused tab shows the inline dialog instead — no notice.
+ *  2. **Tab closed** (Web Push): the relay pushes to a VAPID subscription and
+ *     `public/sw.js` shows it. Subscription is managed here.
+ *  3. **Native app backgrounded/killed** (FCM): the relay pushes to the device
+ *     token registered here via `@capacitor/push-notifications`.
+ *
+ * Everything degrades quietly: missing API, denied permission or an unconfigured
+ * relay simply means no notification, never a thrown error to the caller.
+ */
+import { isNative } from '@/utils/surface';
+
+export interface ICodingBridgeNotifyData {
+  deep_link?: string;
+  session_id?: string;
+  request_id?: string;
+  node_id?: string;
+  tool?: string;
+}
+
+const SW_URL = '/sw.js';
+
+/** Browser push permission, normalised. 'unsupported' when the API is absent. */
+export type NotifyPermission = 'granted' | 'denied' | 'default' | 'unsupported';
+
+export const webNotificationsSupported = (): boolean => typeof window !== 'undefined' && 'Notification' in window;
+
+export const serviceWorkerSupported = (): boolean => typeof navigator !== 'undefined' && 'serviceWorker' in navigator;
+
+export const webPushSupported = (): boolean => serviceWorkerSupported() && 'PushManager' in window;
+
+export const notifyPermission = (): NotifyPermission =>
+  webNotificationsSupported() ? (Notification.permission as NotifyPermission) : 'unsupported';
+
+/** VAPID public keys are base64url; the Push API wants a Uint8Array. */
+const urlBase64ToUint8Array = (base64: string): Uint8Array => {
+  const padding = '='.repeat((4 - (base64.length % 4)) % 4);
+  const normalised = (base64 + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const raw = atob(normalised);
+  const output = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i++) {
+    output[i] = raw.charCodeAt(i);
+  }
+  return output;
+};
+
+/** Register the service worker once; returns its registration or null. */
+export const ensureServiceWorker = async (): Promise<ServiceWorkerRegistration | null> => {
+  if (!serviceWorkerSupported()) {
+    return null;
+  }
+  try {
+    return (await navigator.serviceWorker.getRegistration(SW_URL)) ?? (await navigator.serviceWorker.register(SW_URL));
+  } catch (error) {
+    console.warn('[codingBridge] service worker registration failed', error);
+    return null;
+  }
+};
+
+/** Ask the browser for notification permission (no-op if already decided). */
+export const requestWebPermission = async (): Promise<NotifyPermission> => {
+  if (!webNotificationsSupported()) {
+    return 'unsupported';
+  }
+  if (Notification.permission !== 'default') {
+    return Notification.permission as NotifyPermission;
+  }
+  try {
+    return (await Notification.requestPermission()) as NotifyPermission;
+  } catch {
+    return 'denied';
+  }
+};
+
+/**
+ * Tier 1 — raise a local OS notification for a consent prompt when the tab is
+ * hidden. A visible tab shows the inline dialog, so we stay silent there.
+ * `onClick` re-focuses and routes to the pending prompt.
+ */
+export const notifyPermissionLocally = (
+  opts: { title: string; body: string; data: ICodingBridgeNotifyData },
+  onClick?: (data: ICodingBridgeNotifyData) => void
+): void => {
+  // Only when the user isn't already looking at the page.
+  if (typeof document !== 'undefined' && document.visibilityState === 'visible') {
+    return;
+  }
+  if (isNative()) {
+    void notifyNativeLocal(opts);
+    return;
+  }
+  if (!webNotificationsSupported() || Notification.permission !== 'granted') {
+    return;
+  }
+  try {
+    const notification = new Notification(opts.title, {
+      body: opts.body,
+      tag: opts.data.request_id || 'coding-bridge-permission',
+      data: opts.data
+    });
+    notification.onclick = () => {
+      try {
+        window.focus();
+      } catch {
+        // ignore — some browsers disallow focus() from a notification
+      }
+      onClick?.(opts.data);
+      notification.close();
+    };
+  } catch (error) {
+    console.warn('[codingBridge] failed to raise local notification', error);
+  }
+};
+
+/** Native (Capacitor) local notification, used when the app is backgrounded. */
+const notifyNativeLocal = async (opts: {
+  title: string;
+  body: string;
+  data: ICodingBridgeNotifyData;
+}): Promise<void> => {
+  try {
+    const { LocalNotifications } = await import('@capacitor/local-notifications');
+    const perm = await LocalNotifications.checkPermissions();
+    if (perm.display !== 'granted') {
+      const req = await LocalNotifications.requestPermissions();
+      if (req.display !== 'granted') {
+        return;
+      }
+    }
+    await LocalNotifications.schedule({
+      notifications: [
+        {
+          // A stable small int derived from the request id keeps re-issues from stacking.
+          id: hashToInt(opts.data.request_id || 'permission'),
+          title: opts.title,
+          body: opts.body,
+          extra: opts.data
+        }
+      ]
+    });
+  } catch (error) {
+    console.warn('[codingBridge] native local notification failed', error);
+  }
+};
+
+const hashToInt = (value: string): number => {
+  let hash = 0;
+  for (let i = 0; i < value.length; i++) {
+    hash = (hash * 31 + value.charCodeAt(i)) | 0;
+  }
+  return Math.abs(hash) % 2147483000;
+};
+
+/**
+ * Tier 2 — subscribe this browser to Web Push with the relay's VAPID key.
+ * Returns the subscription JSON to register with the relay, or null on failure.
+ */
+export const subscribeWebPush = async (vapidPublicKey: string): Promise<PushSubscriptionJSON | null> => {
+  if (!webPushSupported() || !vapidPublicKey) {
+    return null;
+  }
+  const permission = await requestWebPermission();
+  if (permission !== 'granted') {
+    return null;
+  }
+  const registration = await ensureServiceWorker();
+  if (!registration) {
+    return null;
+  }
+  try {
+    const existing = await registration.pushManager.getSubscription();
+    const subscription =
+      existing ??
+      (await registration.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: urlBase64ToUint8Array(vapidPublicKey)
+      }));
+    return subscription.toJSON();
+  } catch (error) {
+    console.warn('[codingBridge] web push subscribe failed', error);
+    return null;
+  }
+};
+
+/** Current web-push endpoint (the relay's subscription key), or null. */
+export const currentWebPushEndpoint = async (): Promise<string | null> => {
+  if (!webPushSupported()) {
+    return null;
+  }
+  const registration = await ensureServiceWorker();
+  const subscription = await registration?.pushManager.getSubscription();
+  return subscription?.endpoint ?? null;
+};
+
+/** Tier 2 teardown — unsubscribe locally and return the endpoint to deregister. */
+export const unsubscribeWebPush = async (): Promise<string | null> => {
+  if (!webPushSupported()) {
+    return null;
+  }
+  const registration = await ensureServiceWorker();
+  const subscription = await registration?.pushManager.getSubscription();
+  if (!subscription) {
+    return null;
+  }
+  const endpoint = subscription.endpoint;
+  try {
+    await subscription.unsubscribe();
+  } catch {
+    // Still return the endpoint so the caller can deregister it server-side.
+  }
+  return endpoint;
+};
+
+/**
+ * Tier 3 — register the native device for FCM. Resolves to the device token
+ * (to register with the relay) or null. Wires a tap handler that routes via
+ * `onOpen` with the notification's `extra` data.
+ */
+export const registerNativePush = async (onOpen?: (data: ICodingBridgeNotifyData) => void): Promise<string | null> => {
+  if (!isNative()) {
+    return null;
+  }
+  try {
+    const { PushNotifications } = await import('@capacitor/push-notifications');
+    const perm = await PushNotifications.requestPermissions();
+    if (perm.receive !== 'granted') {
+      return null;
+    }
+    const token = await new Promise<string | null>((resolve) => {
+      const timer = setTimeout(() => resolve(null), 10000);
+      void PushNotifications.addListener('registration', (t: { value: string }) => {
+        clearTimeout(timer);
+        resolve(t.value);
+      });
+      void PushNotifications.addListener('registrationError', () => {
+        clearTimeout(timer);
+        resolve(null);
+      });
+      void PushNotifications.register();
+    });
+    if (onOpen) {
+      void PushNotifications.addListener(
+        'pushNotificationActionPerformed',
+        (action: { notification: { data?: Record<string, string> } }) => {
+          onOpen((action.notification?.data ?? {}) as ICodingBridgeNotifyData);
+        }
+      );
+    }
+    return token;
+  } catch (error) {
+    console.warn('[codingBridge] native push registration failed', error);
+    return null;
+  }
+};


### PR DESCRIPTION
## Why

Part 3/3 of remote **consent notifications** for Coding Bridge (studio.acedata.cloud/coding-bridge). The agent blocks on a tool-permission prompt; until now you only saw it if you were already looking at the page. This surfaces it wherever you are — background tab, closed tab, or phone — with a **bell toggle** in the device list to opt in.

## What — three tiers, by how far away you are
`src/utils/codingBridgeNotify.ts`:
1. **Background tab (web)** — on `permission.request` while the tab is hidden, raise an OS `Notification` directly over the live socket. Instant, no server round-trip, no VAPID. A focused tab still shows the inline dialog, so never a double-notify.
2. **Tab closed (Web Push)** — a service worker (`public/sw.js`) shows a prompt the relay pushes to a VAPID subscription; the tap deep-links back to the exact prompt.
3. **Native app backgrounded/killed (FCM)** — `@capacitor/push-notifications` registers a device token; taps route to the originating node. (FCM relays to APNs, so iOS works through the same path.)

## Plumbing
- **Pending-prompt replay** — on (re)connect / node-online / node-select / a followed notification we send `permissions.list` and fold the `permissions.snapshot` reply back in (`addPermission` dedups), so a prompt raised while away still appears instead of blocking.
- **Deep link** `/coding-bridge?node=&session=&request=` selects the node and re-fetches its pending prompts.
- Operator + relay REST for push config & subscription save/delete; bell registered in the central `font-awesome` plugin; `en` + `zh-CN` strings.

## Manual config left to you
- **VAPID public key** → set in the relay (companion PR) and exposed via `GET /api/push/config`; the frontend reads it at subscribe time, so **no frontend env change needed**.
- **Native push** needs the Firebase config files added to the iOS/Android projects + APNs key in Firebase (Apple Developer account). Web Push and Tier-1 work without any native step.

## Companion PRs
- CodingBridgeAgent #23 — durable pending requests + `permissions.list`/`permissions.snapshot`
- PlatformService #1013 — relay push dispatch (Web Push + FCM) + subscription REST

## Testing
- `vue-tsc -b` clean · `eslint` clean · `vite build` (web) succeeds and emits `dist/sw.js` · `vitest` codingBridge suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)