### PR TITLE
feat(nexior): clickable empty-state magic wand opens new-task drawer

### DIFF
--- a/change/@acedatacloud-nexior-aedf2c90-9f89-4d16-9192-409b229830f3.json
+++ b/change/@acedatacloud-nexior-aedf2c90-9f89-4d16-9192-409b229830f3.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(nexior): make the empty-state magic wand a clickable new-task button and hide the floating magic button while empty",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/NoTasks.vue
+++ b/src/components/common/NoTasks.vue
@@ -1,6 +1,13 @@
 <template>
   <div class="text-center text-[var(--el-text-color-secondary)] py-16">
-    <font-awesome-icon icon="fa-solid fa-magic" class="text-3xl mb-2 text-[var(--el-color-primary-light-5)]" />
+    <button
+      type="button"
+      class="no-tasks-btn inline-flex items-center justify-center w-16 h-16 rounded-full border border-[var(--el-color-primary-light-5)] bg-[var(--el-color-primary-light-9)] text-[var(--el-color-primary)] cursor-pointer transition duration-200 hover:bg-[var(--el-color-primary-light-7)] hover:scale-105 active:scale-95"
+      :aria-label="$t('common.message.noTasks')"
+      @click="onClick"
+    >
+      <font-awesome-icon icon="fa-solid fa-magic" class="text-2xl" />
+    </button>
     <p class="mt-4 text-sm">{{ $t('common.message.noTasks') }}</p>
   </div>
 </template>
@@ -8,11 +15,27 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { taskDrawerState, openTaskDrawer } from '@/utils/taskDrawerMixin';
 
 export default defineComponent({
   name: 'NoTasks',
   components: {
     FontAwesomeIcon
+  },
+  mounted() {
+    taskDrawerState.empty = true;
+  },
+  beforeUnmount() {
+    taskDrawerState.empty = false;
+  },
+  methods: {
+    onClick() {
+      // The drawer is a mobile-only affordance; on desktop the config panel is
+      // already visible, so there is nothing to open.
+      if (window.matchMedia('(max-width: 767px)').matches) {
+        openTaskDrawer();
+      }
+    }
   }
 });
 </script>

--- a/src/layouts/Flux.vue
+++ b/src/layouts/Flux.vue
@@ -8,7 +8,7 @@
     <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
       <slot name="result" />
     </div>
-    <el-button circle class="menu" @click="drawer = true">
+    <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-magic" />
     </el-button>
     <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px" class="drawer">
@@ -21,6 +21,7 @@
 import { defineComponent } from 'vue';
 import { ElDrawer, ElButton } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import taskDrawerMixin from '@/utils/taskDrawerMixin';
 
 export default defineComponent({
   name: 'LayoutFlux',
@@ -29,11 +30,7 @@ export default defineComponent({
     ElButton,
     FontAwesomeIcon
   },
-  data() {
-    return {
-      drawer: false
-    };
-  }
+  mixins: [taskDrawerMixin]
 });
 </script>
 

--- a/src/layouts/Hailuo.vue
+++ b/src/layouts/Hailuo.vue
@@ -8,7 +8,7 @@
     <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
       <slot name="result" />
     </div>
-    <el-button circle class="menu" @click="drawer = true">
+    <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-magic" />
     </el-button>
     <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px">
@@ -21,6 +21,7 @@
 import { defineComponent } from 'vue';
 import { ElDrawer, ElButton } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import taskDrawerMixin from '@/utils/taskDrawerMixin';
 
 export default defineComponent({
   name: 'LayoutHailuo',
@@ -29,11 +30,7 @@ export default defineComponent({
     ElButton,
     FontAwesomeIcon
   },
-  data() {
-    return {
-      drawer: false
-    };
-  }
+  mixins: [taskDrawerMixin]
 });
 </script>
 

--- a/src/layouts/Kling.vue
+++ b/src/layouts/Kling.vue
@@ -8,7 +8,7 @@
     <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
       <slot name="result" />
     </div>
-    <el-button circle class="menu" @click="drawer = true">
+    <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-magic" />
     </el-button>
     <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="350px">
@@ -21,6 +21,7 @@
 import { defineComponent } from 'vue';
 import { ElDrawer, ElButton } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import taskDrawerMixin from '@/utils/taskDrawerMixin';
 
 export default defineComponent({
   name: 'LayoutKling',
@@ -29,11 +30,7 @@ export default defineComponent({
     ElButton,
     FontAwesomeIcon
   },
-  data() {
-    return {
-      drawer: false
-    };
-  }
+  mixins: [taskDrawerMixin]
 });
 </script>
 

--- a/src/layouts/Luma.vue
+++ b/src/layouts/Luma.vue
@@ -8,7 +8,7 @@
     <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
       <slot name="result" />
     </div>
-    <el-button circle class="menu" @click="drawer = true">
+    <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-magic" />
     </el-button>
     <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="350px" class="drawer">
@@ -21,6 +21,7 @@
 import { defineComponent } from 'vue';
 import { ElDrawer, ElButton } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import taskDrawerMixin from '@/utils/taskDrawerMixin';
 
 export default defineComponent({
   name: 'LayoutLuma',
@@ -29,11 +30,7 @@ export default defineComponent({
     ElButton,
     FontAwesomeIcon
   },
-  data() {
-    return {
-      drawer: false
-    };
-  }
+  mixins: [taskDrawerMixin]
 });
 </script>
 

--- a/src/layouts/Midjourney.vue
+++ b/src/layouts/Midjourney.vue
@@ -8,7 +8,7 @@
     <div class="results flex-1 h-full flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
       <slot name="results" />
     </div>
-    <el-button circle class="menu" @click="drawer = true">
+    <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-magic" />
     </el-button>
     <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="350px" class="drawer">
@@ -21,6 +21,7 @@
 import { defineComponent } from 'vue';
 import { ElDrawer, ElButton } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import taskDrawerMixin from '@/utils/taskDrawerMixin';
 
 export default defineComponent({
   name: 'LayoutMidjourney',
@@ -29,11 +30,7 @@ export default defineComponent({
     ElButton,
     FontAwesomeIcon
   },
-  data() {
-    return {
-      drawer: false
-    };
-  }
+  mixins: [taskDrawerMixin]
 });
 </script>
 

--- a/src/layouts/Nanobanana.vue
+++ b/src/layouts/Nanobanana.vue
@@ -8,7 +8,7 @@
     <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
       <slot name="result" />
     </div>
-    <el-button circle class="menu" @click="drawer = true">
+    <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-magic" />
     </el-button>
     <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px" class="drawer">
@@ -21,6 +21,7 @@
 import { defineComponent } from 'vue';
 import { ElDrawer, ElButton } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import taskDrawerMixin from '@/utils/taskDrawerMixin';
 
 export default defineComponent({
   name: 'LayoutNanobanana',
@@ -29,11 +30,7 @@ export default defineComponent({
     ElButton,
     FontAwesomeIcon
   },
-  data() {
-    return {
-      drawer: false
-    };
-  }
+  mixins: [taskDrawerMixin]
 });
 </script>
 

--- a/src/layouts/OpenAIImage.vue
+++ b/src/layouts/OpenAIImage.vue
@@ -8,7 +8,7 @@
     <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
       <slot name="result" />
     </div>
-    <el-button circle class="menu" @click="drawer = true">
+    <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-magic" />
     </el-button>
     <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px" class="drawer">
@@ -21,6 +21,7 @@
 import { defineComponent } from 'vue';
 import { ElDrawer, ElButton } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import taskDrawerMixin from '@/utils/taskDrawerMixin';
 
 export default defineComponent({
   name: 'LayoutNanobanana',
@@ -29,11 +30,7 @@ export default defineComponent({
     ElButton,
     FontAwesomeIcon
   },
-  data() {
-    return {
-      drawer: false
-    };
-  }
+  mixins: [taskDrawerMixin]
 });
 </script>
 

--- a/src/layouts/Pika.vue
+++ b/src/layouts/Pika.vue
@@ -8,7 +8,7 @@
     <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
       <slot name="result" />
     </div>
-    <el-button circle class="menu" @click="drawer = true">
+    <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-magic" />
     </el-button>
     <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="350px">
@@ -21,6 +21,7 @@
 import { defineComponent } from 'vue';
 import { ElDrawer, ElButton } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import taskDrawerMixin from '@/utils/taskDrawerMixin';
 
 export default defineComponent({
   name: 'LayoutPika',
@@ -29,11 +30,7 @@ export default defineComponent({
     ElButton,
     FontAwesomeIcon
   },
-  data() {
-    return {
-      drawer: false
-    };
-  }
+  mixins: [taskDrawerMixin]
 });
 </script>
 

--- a/src/layouts/Pixverse.vue
+++ b/src/layouts/Pixverse.vue
@@ -8,7 +8,7 @@
     <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
       <slot name="result" />
     </div>
-    <el-button circle class="menu" @click="drawer = true">
+    <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-magic" />
     </el-button>
     <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="350px">
@@ -21,6 +21,7 @@
 import { defineComponent } from 'vue';
 import { ElDrawer, ElButton } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import taskDrawerMixin from '@/utils/taskDrawerMixin';
 
 export default defineComponent({
   name: 'LayoutPixverse',
@@ -29,11 +30,7 @@ export default defineComponent({
     ElButton,
     FontAwesomeIcon
   },
-  data() {
-    return {
-      drawer: false
-    };
-  }
+  mixins: [taskDrawerMixin]
 });
 </script>
 

--- a/src/layouts/Producer.vue
+++ b/src/layouts/Producer.vue
@@ -11,7 +11,7 @@
     <div class="preview h-full w-[300px] flex flex-col">
       <slot name="preview" />
     </div>
-    <el-button circle class="menu" @click="drawer = true">
+    <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-magic" />
     </el-button>
     <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px" class="drawer">
@@ -24,6 +24,7 @@
 import { defineComponent } from 'vue';
 import { ElDrawer, ElButton } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import taskDrawerMixin from '@/utils/taskDrawerMixin';
 
 export default defineComponent({
   name: 'LayoutProducer',
@@ -32,9 +33,9 @@ export default defineComponent({
     ElButton,
     FontAwesomeIcon
   },
+  mixins: [taskDrawerMixin],
   data() {
     return {
-      drawer: false,
       preview: false
     };
   },

--- a/src/layouts/Qrart.vue
+++ b/src/layouts/Qrart.vue
@@ -8,7 +8,7 @@
     <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
       <slot name="result" />
     </div>
-    <el-button circle class="menu" @click="drawer = true">
+    <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-magic" />
     </el-button>
     <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="350px">
@@ -21,6 +21,7 @@
 import { defineComponent } from 'vue';
 import { ElDrawer, ElButton } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import taskDrawerMixin from '@/utils/taskDrawerMixin';
 
 export default defineComponent({
   name: 'LayoutQrart',
@@ -29,11 +30,7 @@ export default defineComponent({
     ElButton,
     FontAwesomeIcon
   },
-  data() {
-    return {
-      drawer: false
-    };
-  }
+  mixins: [taskDrawerMixin]
 });
 </script>
 

--- a/src/layouts/Seedance.vue
+++ b/src/layouts/Seedance.vue
@@ -8,7 +8,7 @@
     <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
       <slot name="result" />
     </div>
-    <el-button circle class="menu" @click="drawer = true">
+    <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-magic" />
     </el-button>
     <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="350px">
@@ -21,6 +21,7 @@
 import { defineComponent } from 'vue';
 import { ElDrawer, ElButton } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import taskDrawerMixin from '@/utils/taskDrawerMixin';
 
 export default defineComponent({
   name: 'LayoutSeedance',
@@ -29,11 +30,7 @@ export default defineComponent({
     ElButton,
     FontAwesomeIcon
   },
-  data() {
-    return {
-      drawer: false
-    };
-  }
+  mixins: [taskDrawerMixin]
 });
 </script>
 

--- a/src/layouts/Seedream.vue
+++ b/src/layouts/Seedream.vue
@@ -8,7 +8,7 @@
     <div class="result h-full p-6 flex-1 flex flex-col bg-[var(--app-content-bg)]">
       <slot name="result" />
     </div>
-    <el-button circle class="menu" @click="drawer = true">
+    <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-magic" />
     </el-button>
     <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px" class="drawer">
@@ -21,6 +21,7 @@
 import { defineComponent } from 'vue';
 import { ElDrawer, ElButton } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import taskDrawerMixin from '@/utils/taskDrawerMixin';
 
 export default defineComponent({
   name: 'LayoutSeedream',
@@ -29,11 +30,7 @@ export default defineComponent({
     ElButton,
     FontAwesomeIcon
   },
-  data() {
-    return {
-      drawer: false
-    };
-  }
+  mixins: [taskDrawerMixin]
 });
 </script>
 

--- a/src/layouts/Sora.vue
+++ b/src/layouts/Sora.vue
@@ -8,7 +8,7 @@
     <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
       <slot name="result" />
     </div>
-    <el-button circle class="menu" @click="drawer = true">
+    <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-magic" />
     </el-button>
     <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="350px">
@@ -21,6 +21,7 @@
 import { defineComponent } from 'vue';
 import { ElDrawer, ElButton } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import taskDrawerMixin from '@/utils/taskDrawerMixin';
 
 export default defineComponent({
   name: 'LayoutSora',
@@ -29,11 +30,7 @@ export default defineComponent({
     ElButton,
     FontAwesomeIcon
   },
-  data() {
-    return {
-      drawer: false
-    };
-  }
+  mixins: [taskDrawerMixin]
 });
 </script>
 

--- a/src/layouts/Suno.vue
+++ b/src/layouts/Suno.vue
@@ -11,7 +11,7 @@
     <div class="preview h-full w-[300px] flex flex-col">
       <slot name="preview" />
     </div>
-    <el-button circle class="menu" @click="drawer = true">
+    <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-magic" />
     </el-button>
     <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px" class="drawer">
@@ -24,6 +24,7 @@
 import { defineComponent } from 'vue';
 import { ElDrawer, ElButton } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import taskDrawerMixin from '@/utils/taskDrawerMixin';
 
 export default defineComponent({
   name: 'LayoutSuno',
@@ -32,9 +33,9 @@ export default defineComponent({
     ElButton,
     FontAwesomeIcon
   },
+  mixins: [taskDrawerMixin],
   data() {
     return {
-      drawer: false,
       preview: false
     };
   },

--- a/src/layouts/Veo.vue
+++ b/src/layouts/Veo.vue
@@ -8,7 +8,7 @@
     <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
       <slot name="result" />
     </div>
-    <el-button circle class="menu" @click="drawer = true">
+    <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-magic" />
     </el-button>
     <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="350px">
@@ -21,6 +21,7 @@
 import { defineComponent } from 'vue';
 import { ElDrawer, ElButton } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import taskDrawerMixin from '@/utils/taskDrawerMixin';
 
 export default defineComponent({
   name: 'LayoutVeo',
@@ -29,11 +30,7 @@ export default defineComponent({
     ElButton,
     FontAwesomeIcon
   },
-  data() {
-    return {
-      drawer: false
-    };
-  }
+  mixins: [taskDrawerMixin]
 });
 </script>
 

--- a/src/layouts/Wan.vue
+++ b/src/layouts/Wan.vue
@@ -8,7 +8,7 @@
     <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
       <slot name="result" />
     </div>
-    <el-button circle class="menu" @click="drawer = true">
+    <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
       <font-awesome-icon icon="fa-solid fa-magic" />
     </el-button>
     <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="340px">
@@ -21,6 +21,7 @@
 import { defineComponent } from 'vue';
 import { ElDrawer, ElButton } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import taskDrawerMixin from '@/utils/taskDrawerMixin';
 
 export default defineComponent({
   name: 'LayoutWan',
@@ -29,11 +30,7 @@ export default defineComponent({
     ElButton,
     FontAwesomeIcon
   },
-  data() {
-    return {
-      drawer: false
-    };
-  }
+  mixins: [taskDrawerMixin]
 });
 </script>
 

--- a/src/utils/taskDrawerMixin.ts
+++ b/src/utils/taskDrawerMixin.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared state for a service Layout's mobile config drawer and the centered
+ * `NoTasks` empty state. Only one service Layout is mounted at a time, so a
+ * module-level reactive singleton is safe.
+ *
+ * - `empty` is set by `NoTasks` while it is mounted, so the Layout can hide the
+ *   floating magic button (the centered wand becomes the only "new task" entry).
+ * - `open` mirrors the drawer's open flag; `NoTasks` opens it on tap, exactly
+ *   like the top-right magic button.
+ */
+import { defineComponent, reactive } from 'vue';
+
+export const taskDrawerState = reactive({
+  empty: false,
+  open: false
+});
+
+/** Open the config drawer — same effect as tapping the top-right magic button. */
+export function openTaskDrawer(): void {
+  taskDrawerState.open = true;
+}
+
+/**
+ * Install on a service Layout. Exposes `drawer` (a computed proxy so existing
+ * `v-model="drawer"` / `@click="drawer = true"` keep working) and `tasksEmpty`
+ * (used to hide the floating magic button when the centered wand is shown).
+ */
+export const taskDrawerMixin = defineComponent({
+  computed: {
+    drawer: {
+      get(): boolean {
+        return taskDrawerState.open;
+      },
+      set(value: boolean) {
+        taskDrawerState.open = value;
+      }
+    },
+    tasksEmpty(): boolean {
+      return taskDrawerState.empty;
+    }
+  },
+  beforeUnmount() {
+    // Never inherit a stale open drawer when switching services.
+    taskDrawerState.open = false;
+  }
+});
+
+export default taskDrawerMixin;


### PR DESCRIPTION
## What

When a service task list is empty, the centered magic wand is now a **round clickable button**. Tapping it opens the config drawer to start a new task — the same action as the top-right floating magic button.

The top-right floating magic button is now **hidden while the empty state is shown**, so there is exactly one obvious "new task" affordance instead of two competing ones. Once the user has tasks, the empty state disappears and the floating button returns.

### Problem
On mobile, an empty service screen showed a small greyed-out magic wand in the middle (looks like a failed load, e.g. the Banana/NanoBanana page) plus a separate floating magic button top-right. The center wand wasn't actionable and the two looked disconnected.

### After
- Center wand → circular, themed, clearly tappable button → opens the config drawer (mobile only; on desktop the config panel is already visible).
- Floating top-right magic button hidden while empty.

## How
- New `src/utils/taskDrawerMixin.ts`: a small reactive singleton (`empty`, `open`) + an Options-API mixin exposing `drawer` (computed proxy) and `tasksEmpty`. Existing `v-model=drawer` / `@click=drawer=true` bindings keep working unchanged.
- `NoTasks.vue`: rendered as a round button; flags `empty` while mounted, opens the drawer on tap (guarded to mobile via `matchMedia`).
- All 17 service layouts: `v-show=!tasksEmpty` on the floating button + use the mixin.

## Test
- `npx eslint` ✅
- `npx vue-tsc --noEmit` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)