### PR TITLE
fix(settings): stop leaking admin-only tabs to non-admins on mobile

### DIFF
--- a/change/@acedatacloud-nexior-1c4c20fe-2d7e-45f7-a41a-f8e884290ac3.json
+++ b/change/@acedatacloud-nexior-1c4c20fe-2d7e-45f7-a41a-f8e884290ac3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(settings): stop leaking admin-only tabs to non-admins on mobile",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/user/Setting.vue
+++ b/src/components/user/Setting.vue
@@ -11,15 +11,17 @@
           :class="['border-r-0 settings-menu', mobile ? 'is-mobile flex flex-row overflow-x-auto' : '']"
           :mode="mobile ? 'horizontal' : 'vertical'"
         >
+          <!-- Render only the visible tabs. CSS-hiding (display:none) leaks
+               admin-only items into the horizontal el-menu ellipsis overflow
+               on mobile, exposing them to non-admins. -->
           <el-menu-item
-            v-for="(item, index) in navItems"
+            v-for="(item, index) in visibleNavItems"
             :key="index"
             :index="item.key"
             :class="[
               'items-center cursor-pointer',
               mobile ? 'flex-shrink-0 px-3 py-2 text-sm' : 'flex w-[180px] px-2 py-2',
-              activeTab === item.key ? 'active' : '',
-              item.visible ? '' : 'hidden'
+              activeTab === item.key ? 'active' : ''
             ]"
             @click="activeTab = item.key"
           >
@@ -35,7 +37,7 @@
         <div v-else-if="activeTab === SETTING_TAB_API_KEY">
           <byok-setting />
         </div>
-        <div v-else-if="activeTab === SETTING_TAB_SITE">
+        <div v-else-if="activeTab === SETTING_TAB_SITE && isSiteAdmin">
           <site-setting />
         </div>
         <div v-else-if="activeTab === SETTING_TAB_SEO && isSiteAdmin">
@@ -214,6 +216,9 @@ export default defineComponent({
         },
         { key: SETTING_TAB_ABOUT, label: this.$t('common.settings.about'), icon: faInfoCircle, visible: true }
       ];
+    },
+    visibleNavItems(): Array<{ key: SettingTabKey; label: string; icon: typeof faCog; visible: boolean }> {
+      return this.navItems.filter((item) => item.visible);
     },
     isSiteAdmin(): boolean {
       return !!this.$store?.state?.site?.admins?.includes(this.$store.getters.user?.id);


### PR DESCRIPTION
## Problem

A regular (non-admin) user logged into **studio.acedata.cloud on a phone** (iOS/Android app or narrow mobile web) could open the settings dialog, tap the **"…"** overflow tab, and see the **Site administration** panel — site origin, who the admins are, branding config, etc. On desktop web the same account correctly sees none of this.

## Root cause

The settings dialog renders **every** tab into the DOM and merely CSS-hides the admin-only ones (`item.visible ? '' : 'hidden'` → `display:none`):

- **Desktop** uses a *vertical* `el-menu` with no overflow → hidden tabs are truly inaccessible. ✅
- **Mobile** (`window.innerWidth < 768`) uses a *horizontal* `el-menu`. Element Plus's default `ellipsis` overflow collapses tabs that don't fit into a clickable **"…"** submenu. `display:none` items have zero width, so the overflow algorithm treats them as "fits" yet still re-renders them inside the overflow popup — where they become **clickable**, leaking the admin tabs. ❌

Compounding it, the `SETTING_TAB_SITE` **content** branch was missing the `&& isSiteAdmin` guard that all its sibling admin tabs (SEO / Distribution / Function / Auth) have, so once the leaked tab was clicked, `<site-setting />` rendered in full.

## Fix (defense-in-depth)

1. Render only `visibleNavItems` (filter `navItems` by `visible`) so non-visible tabs never enter the DOM and can't leak into the mobile overflow menu. This covers **all** admin tabs, not just Site.
2. Add the missing `&& isSiteAdmin` guard to the `SETTING_TAB_SITE` content branch.

## Scope / notes

- Frontend-only. This hides the UI; **server-side write protection on `PATCH/POST/DELETE /api/v1/sites/` remains the real guard** and should be confirmed separately (a non-admin must not be able to read/modify other sites via the API).
- The "My Subsites" (`我的分站`) tab is intentionally gated by host (`isMainOfficialHost`), not admin — it lists the user's *own* subsites and is unaffected.

## Verification

- `npx vue-tsc --noEmit` — clean
- `npx eslint src/components/user/Setting.vue` — clean
- `npx beachball check` — change file present

🤖 Generated with [Claude Code](https://claude.com/claude-code)