### PR TITLE
fix(coding-bridge): stop iOS auto-zoom on the mobile composer

### DIFF
--- a/change/@acedatacloud-nexior-fix-coding-bridge-composer-ios-zoom.json
+++ b/change/@acedatacloud-nexior-fix-coding-bridge-composer-ios-zoom.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(coding-bridge): use 16px font-size for the mobile composer textarea so iOS Safari no longer auto-zooms the page in on focus/send",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/codingBridge/SessionView.vue
+++ b/src/components/codingBridge/SessionView.vue
@@ -1217,6 +1217,17 @@ export default defineComponent({
       font-size: 14px;
       line-height: 1.5;
     }
+
+    // iOS Safari auto-zooms a focused field whose font-size is below 16px and
+    // ignores `maximum-scale` / `user-scalable=0`, so tapping into the composer
+    // (or hitting Send, which keeps it focused) would zoom the whole page in.
+    // Keep the mobile text at >=16px to suppress that — same fix as the chat
+    // composer (#732).
+    @media (max-width: 767px) {
+      :deep(.el-textarea__inner) {
+        font-size: 16px;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Problem

On mobile, tapping into the coding-bridge composer — or hitting **Send**, which keeps the textarea focused — auto-zooms the whole page in on iOS. Same class of bug fixed for the chat composer in #732, now reappearing in the separate coding-bridge composer.

## Cause

iOS Safari (and the Capacitor WKWebView) auto-zoom any focused form field whose `font-size` is below **16px**, and deliberately ignore `maximum-scale=1.0 / user-scalable=0` in our viewport meta. The coding-bridge composer textarea (`.cb-composer__input`) sets `font-size: 14px`, so focusing it triggers the zoom.

## Fix

Bump the composer textarea to `font-size: 16px` on mobile (`max-width: 767px`), mirroring the chat composer fix in #732. Desktop styling is unchanged (stays 14px).

## Test

- Open `/coding-bridge` on an iPhone, select a device, tap the composer → page no longer zooms.
- Desktop composer text size unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)