### PR TITLE
feat(android): Firebase config so Coding Bridge push works on Android

### DIFF
--- a/android/app/google-services.json
+++ b/android/app/google-services.json
@@ -1,0 +1,29 @@
+{
+  "project_info": {
+    "project_number": "98650688999",
+    "project_id": "acedata-coding-bridge",
+    "storage_bucket": "acedata-coding-bridge.firebasestorage.app"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:98650688999:android:81c19482cdf49cbdc88142",
+        "android_client_info": {
+          "package_name": "com.acedatacloud.nexior"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDwAMTWmz72CLONoCQzn_EuLeKEGzvYnHk"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/change/@acedatacloud-nexior-0ddd2315-3763-4190-87df-b17df8a3967b.json
+++ b/change/@acedatacloud-nexior-0ddd2315-3763-4190-87df-b17df8a3967b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(android): Firebase config for Coding Bridge push (FCM)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
## Why

Enables **real FCM push to the Android app** for Coding Bridge consent prompts. The relay (PlatformService #1013) and the frontend wiring (#921) are already live; this is the last Android-side piece.

## What

- Adds `android/app/google-services.json` for Firebase project **acedata-coding-bridge** (app id `1:98650688999:android:…`, package `com.acedatacloud.nexior`).

That's the only file needed for Android:
- `@capacitor/push-notifications` is already a dependency (#921); the existing `npx cap sync android` step in `build-android.yaml` wires it into the native build.
- `android/app/build.gradle` already applies the `com.google.gms.google-services` plugin **when this file is present** (it no-ops otherwise), and the classpath is already in `android/build.gradle`.
- `google-services.json` is client config — the Firebase API key is **not** a secret (it ships in every Android build) — so it's committed, matching Capacitor's default.

## Server side (already done, live)
- Relay `/api/push/config` now reports `fcm_enabled: true`; the FCM service-account credential was validated against Google's API (a `validate_only` send returned the expected token-validation error, proving auth + API + send path work).

## To actually receive on a device
A **new Android build** from this branch installed on a device → `@capacitor/push-notifications` registers an FCM token → relay pushes consent prompts when the app is backgrounded/closed.

## iOS (follow-up, not in this PR)
iOS needs an APNs auth key uploaded to Firebase (Apple Developer account) + push entitlement + a TestFlight/App Store build — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)