### PR TITLE
feat(ios): register native push as APNs on iOS (FCM on Android)

### DIFF
--- a/change/@acedatacloud-nexior-aeb837ce-86ec-4769-8857-5e92d0f6fe48.json
+++ b/change/@acedatacloud-nexior-aeb837ce-86ec-4769-8857-5e92d0f6fe48.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(ios): register iOS native push as APNs",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/operators/codingBridge.ts
+++ b/src/operators/codingBridge.ts
@@ -47,11 +47,11 @@ class CodingBridgeOperator {
     return await axios.get('/api/push/config', { baseURL: BASE_URL_CODING_BRIDGE });
   }
 
-  /** Register a web-push subscription or an FCM device token for the user. */
+  /** Register a web-push subscription, an FCM (Android) or APNs (iOS) device token. */
   async savePushSubscription(
     body:
       | { kind: 'webpush'; subscription: PushSubscriptionJSON; ua?: string }
-      | { kind: 'fcm'; token: string; ua?: string },
+      | { kind: 'fcm' | 'apns'; token: string; ua?: string },
     options: { token: string }
   ): Promise<AxiosResponse<{ ok: boolean }>> {
     return await axios.post('/api/push/subscriptions', body, {

--- a/src/store/codingBridge/actions.ts
+++ b/src/store/codingBridge/actions.ts
@@ -18,7 +18,7 @@ import {
   requestWebPermission,
   type ICodingBridgeNotifyData
 } from '@/utils/codingBridgeNotify';
-import { isNative } from '@/utils/surface';
+import { isNative, isIOS } from '@/utils/surface';
 import {
   CB_ACTION_SESSION_START,
   CB_ACTION_SESSION_SEND,
@@ -931,8 +931,10 @@ export const enableNotifications = async ({
     if (!deviceToken) {
       return 'denied';
     }
+    // iOS hands back a raw APNs token (the relay delivers it via APNs); Android
+    // hands back an FCM token (delivered via FCM). The relay routes by `kind`.
     await codingBridgeOperator.savePushSubscription(
-      { kind: 'fcm', token: deviceToken, ua: navigator.userAgent },
+      { kind: isIOS() ? 'apns' : 'fcm', token: deviceToken, ua: navigator.userAgent },
       { token }
     );
     return 'enabled';

--- a/src/utils/codingBridgeNotify.ts
+++ b/src/utils/codingBridgeNotify.ts
@@ -10,8 +10,11 @@
  *     VAPID needed. A focused tab shows the inline dialog instead — no notice.
  *  2. **Tab closed** (Web Push): the relay pushes to a VAPID subscription and
  *     `public/sw.js` shows it. Subscription is managed here.
- *  3. **Native app backgrounded/killed** (FCM): the relay pushes to the device
- *     token registered here via `@capacitor/push-notifications`.
+ *  3. **Native app backgrounded/killed**: the relay pushes to the device token
+ *     registered here via `@capacitor/push-notifications` — an FCM token on
+ *     Android (delivered via FCM) or a raw APNs token on iOS (delivered via
+ *     APNs). The store tags the subscription `kind` by platform so the relay
+ *     picks the right transport.
  *
  * Everything degrades quietly: missing API, denied permission or an unconfigured
  * relay simply means no notification, never a thrown error to the caller.


### PR DESCRIPTION
## Why
iOS's `@capacitor/push-notifications` returns a **raw APNs token**, not an FCM token. The relay now has a direct APNs transport (PlatformService #1014); this tells it which transport to use by tagging the subscription `kind` per platform.

## What
- `enableNotifications`: send `kind: isIOS() ? 'apns' : 'fcm'` with the native device token.
- Operator + types accept `kind: 'apns'`.
- Fixed the stale code comment that said iOS used FCM.

Safe no-op until iOS push is actually enabled (entitlement + APNs key + build).

## Remaining for iOS to light up (separate, your Apple account)
1. APNs Auth Key (.p8) → `coding-bridge-push` secret (`APNS_KEY_P8/ID/TEAM_ID`).
2. Enable Push on App ID `com.acedatacloud.nexior` + **regenerate the Distribution provisioning profile** (with push) and update the CI signing secret.
3. Add the `aps-environment` entitlement (I'll do this once the profile is ready, so signing doesn't break) + a TestFlight build.

## Companion
- PlatformService #1014 — direct APNs transport in the relay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)