### PR TITLE
fix(coding-bridge): cleaner loading state on the notification bell

### DIFF
--- a/change/@acedatacloud-nexior-093d025f-0648-4004-8d9c-0789025f8e6c.json
+++ b/change/@acedatacloud-nexior-093d025f-0648-4004-8d9c-0789025f8e6c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(coding-bridge): cleaner loading state on the notification bell",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/codingBridge/NotificationToggle.vue
+++ b/src/components/codingBridge/NotificationToggle.vue
@@ -5,10 +5,14 @@
     size="small"
     :type="enabled ? 'primary' : 'default'"
     :title="enabled ? $t('codingBridge.notify.disable') : $t('codingBridge.notify.enable')"
-    :loading="busy"
+    :disabled="busy"
     @click="onToggle"
   >
-    <font-awesome-icon :icon="enabled ? 'fa-solid fa-bell' : 'fa-regular fa-bell'" />
+    <!-- Swap the bell for a spinner while busy: Element Plus's built-in loading
+         spinner renders cramped inside a small circle icon-button. A same-size
+         font-awesome icon keeps the button visually consistent with its siblings. -->
+    <font-awesome-icon v-if="busy" icon="fa-solid fa-spinner" spin />
+    <font-awesome-icon v-else :icon="enabled ? 'fa-solid fa-bell' : 'fa-regular fa-bell'" />
   </el-button>
 </template>
 

--- a/src/plugins/font-awesome.ts
+++ b/src/plugins/font-awesome.ts
@@ -36,6 +36,7 @@ import {
   faDiamond as faSolidDiamond,
   faLaptopCode as faSolidLaptopCode,
   faBell as faSolidBell,
+  faSpinner as faSolidSpinner,
   faOutdent as faSolidOutdent,
   faImage as faSolidImage,
   faChevronRight as faSolidChevronRight,
@@ -184,6 +185,7 @@ library.add(faSolidFire);
 library.add(faSolidLaptopCode);
 library.add(faSolidBell);
 library.add(faRegularBell);
+library.add(faSolidSpinner);
 library.add(faSolidRotateRight);
 library.add(faSolidSeedling);
 library.add(faSolidPenToSquare);


### PR DESCRIPTION
## Problem
Clicking the notification bell shows Element Plus's built-in `:loading` spinner, which renders **cramped/ugly inside the small circle icon-button** (see report).

## Fix
- Drop `:loading`; while busy, swap the bell for a same-size **font-awesome `fa-spinner` (spin)** icon and `:disabled` the button.
- Keeps the button visually consistent with its sibling refresh/pair circle buttons.
- Registered `faSpinner` in the central `font-awesome` plugin (per the project's icon-registration convention).

vue-tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)