### PR TITLE
feat(ios): aps-environment entitlement for push notifications

### DIFF
--- a/change/@acedatacloud-nexior-867d88e8-ce20-4149-9a5a-3a27b503c31e.json
+++ b/change/@acedatacloud-nexior-867d88e8-ce20-4149-9a5a-3a27b503c31e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(ios): push notifications entitlement",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/ios/App/App/App.entitlements
+++ b/ios/App/App/App.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>aps-environment</key>
+	<string>production</string>
 	<key>com.apple.developer.applesignin</key>
 	<array>
 		<string>Default</string>


### PR DESCRIPTION
## Why
Last app-side piece for **iOS push**. Declares the Push Notifications capability so `@capacitor/push-notifications` can register for remote notifications and receive Coding Bridge consent prompts via APNs.

## What
- `ios/App/App/App.entitlements`: add `aps-environment = production`.

## No signing change needed
- The App ID `com.acedatacloud.nexior` already has **Push Notifications** enabled.
- The live **AceData App Store** distribution profile already grants `aps-environment=production` (decoded + verified) — alongside the `applesignin`/`associated-domains` entitlements current builds already use. So the CI signing secret already supports push; this entitlement just matches what the profile allows. No `IOS_PROVISIONING_PROFILE_*` change.

## Server side (done & validated)
- Relay `apns_enabled: true`; APNs auth (.p8/Key ID/Team ID) validated against `api.push.apple.com` (HTTP/2 → expected `BadDeviceToken` for a dummy token).

## To light up on device
Run `build-ios` → TestFlight → install → open Coding Bridge → tap 🔔 (grants notifications + registers an APNs token) → background the app → consent prompt arrives via APNs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)