### PR TITLE
fix(android): raise Gradle heap to fix lintVitalRelease OOM (push build regression)

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -9,7 +9,10 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx1536m
+# Bumped from 1536m: after adding the Firebase/push native deps, the
+# lintVitalRelease task (PrivateApiDetector loads the full hidden-API DB) OOMs
+# at 1536m on CI. 4g comfortably fits the hosted runner (~16 GB).
+org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/change/@acedatacloud-nexior-e1dc5c29-4323-472c-a172-2270423eb36a.json
+++ b/change/@acedatacloud-nexior-e1dc5c29-4323-472c-a172-2270423eb36a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(android): raise Gradle heap to fix lint OOM on release builds",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
## Why
The release **Build Android** has failed on every run since #921 merged (14:13). Cause: adding `@capacitor/push-notifications` (+ firebase-messaging via google-services in #925) gives Android Lint's `PrivateApiDetector` more classes to scan, and it **OOMs loading the hidden-API DB** at the old `-Xmx1536m` during `lintVitalRelease`.

Last green Android build: 09:38 (pre-#921). All builds since: failure with `OutOfMemoryError` in lint.

## Fix
- `android/gradle.properties`: `org.gradle.jvmargs` 1536m → **4096m** (+ MaxMetaspace 1g). The hosted runner has ~16 GB.

## Verify
Merges to main auto-trigger `build-android` (beta/Open-Testing track, no production) via Auto Release Mobile — I'll watch that build go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)