### PR TITLE
fix(ios): App Store rejection — Take Photo crash + 3.1.1 paid catalog

### DIFF
--- a/change/nexior-ios-appstore-fix.json
+++ b/change/nexior-ios-appstore-fix.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(ios): add camera/photo usage strings to stop Take Photo crash, and hide non-IAP paid catalog on iOS (App Store 2.1(a) + 3.1.1)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -22,6 +22,12 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>NSCameraUsageDescription</key>
+	<string>This app needs camera access so you can take a photo to attach to your chat messages.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>This app needs photo library access so you can attach images to your chat messages.</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>This app needs permission to save images you generate to your photo library.</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/src/pages/console/application/Extra.vue
+++ b/src/pages/console/application/Extra.vue
@@ -12,6 +12,7 @@
             <el-row>
               <el-col :span="16" :offset="4">
                 <el-skeleton v-if="loading" />
+                <el-empty v-else-if="!showPayment" :description="$t('common.message.noData')" />
                 <el-form v-else-if="application" label-width="100px">
                   <div v-if="!application?.service">
                     <p class="text-[var(--el-text-color-secondary)] text-[12px] mb-3">
@@ -106,6 +107,7 @@ import {
   ElFormItem,
   ElButton,
   ElDivider,
+  ElEmpty,
   ElRadioGroup,
   ElRadioButton
 } from 'element-plus';
@@ -140,6 +142,7 @@ export default defineComponent({
     ElFormItem,
     ElButton,
     ElDivider,
+    ElEmpty,
     ElRadioGroup,
     ElRadioButton,
     Price,

--- a/src/pages/console/application/Subscribe.vue
+++ b/src/pages/console/application/Subscribe.vue
@@ -10,7 +10,10 @@
         <el-col :span="24">
           <el-card shadow="hover" class="card">
             <el-row>
-              <el-col class="max-w-4xl mx-auto">
+              <el-col v-if="!showPayment" class="max-w-4xl mx-auto">
+                <el-empty :description="$t('common.message.noData')" />
+              </el-col>
+              <el-col v-else class="max-w-4xl mx-auto">
                 <p class="introduction">
                   {{ $t('console.subscription.title') }}
                 </p>
@@ -73,7 +76,7 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import { IService, IApplication, IApplicationType, IOrderDetailResponse, IPackageType, IPackage } from '@/models';
-import { ElRow, ElCol, ElCard, ElSkeleton, ElMessage, ElButton, ElTag } from 'element-plus';
+import { ElRow, ElCol, ElCard, ElSkeleton, ElMessage, ElButton, ElTag, ElEmpty } from 'element-plus';
 import { applicationOperator, orderOperator, serviceOperator } from '@/operators';
 import { getPriceString } from '@/utils';
 import { isIOS } from '@/utils';
@@ -109,6 +112,7 @@ export default defineComponent({
     ElTag,
     ElCol,
     ElCard,
+    ElEmpty,
     FontAwesomeIcon,
     ElButton
   },
@@ -131,9 +135,9 @@ export default defineComponent({
     applicationId() {
       return this.$route.params?.id?.toString();
     },
-    // App Store Review Guideline 3.1.1: hide non-IAP purchase actions
-    // inside the iOS bundle. The cards still render so deep-linked users
-    // can see the package info, but the buy buttons are removed.
+    // App Store Review Guideline 3.1.1: on iOS the whole paid catalog
+    // (packages, prices and buy buttons) is hidden — Apple flags merely
+    // displaying non-IAP paid content, not just the purchase action.
     showPayment(): boolean {
       return !isIOS();
     },

--- a/src/pages/order/Pay.vue
+++ b/src/pages/order/Pay.vue
@@ -62,7 +62,7 @@
                 <el-alert :title="$t('order.state.failed')" type="error" show-icon :closable="false" />
               </el-col>
             </el-row>
-            <el-row v-if="order?.state === OrderState.PENDING">
+            <el-row v-if="order?.state === OrderState.PENDING && showPayment">
               <el-col :xs="{ span: 22, offset: 1 }" :sm="{ span: 16, offset: 4 }">
                 <el-divider border-style="dashed" />
                 <div v-if="!order.pay_way && order.price && order.price > 0" class="payways mb-6">
@@ -135,7 +135,7 @@ import PublicWechatPay from '@/components/order/public/WechatPay.vue';
 import PublicStripePay from '@/components/order/public/StripePay.vue';
 import PublicAlipayPay from '@/components/order/public/AliPay.vue';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
-import { getPaymentSurface, getPriceString } from '@/utils';
+import { getPaymentSurface, getPriceString, isIOS } from '@/utils';
 
 // Polls the AllowAny GET /orders/<id> endpoint — POST /orders/<id>/refresh/
 // is IsAuthenticated and would 401 here.
@@ -192,6 +192,10 @@ export default defineComponent({
   computed: {
     id(): string {
       return this.$route.params?.id?.toString() ?? '';
+    },
+    // App Store Review Guideline 3.1.1: no non-IAP payment UI on iOS.
+    showPayment(): boolean {
+      return !isIOS();
     }
   },
   watch: {


### PR DESCRIPTION
## Background

App Store review (submission `cbd63fbd-088a-4b30-aba6-7f328218d9d5`, v3.255.3, iPad Air M3 / iPadOS 26.5) rejected Nexior for two issues. This PR fixes both.

## 1. Guideline 2.1(a) — crash on "Take Photo"

**Root cause:** the chat composer uses `el-upload` with `<input type="file" accept="image/*…">` ([Composer.vue](src/components/chat/Composer.vue#L7-L24)). In iOS WKWebView this presents a native "Take Photo / Photo Library / Choose File" sheet. Tapping **Take Photo** launches the camera, which iOS hard-requires `NSCameraUsageDescription` for. `Info.plist` had **no** camera/photo purpose strings, so iOS terminates the app immediately — exactly the crash the reviewer hit.

**Fix:** add purpose strings to [Info.plist](ios/App/App/Info.plist):
- `NSCameraUsageDescription`
- `NSPhotoLibraryUsageDescription`
- `NSPhotoLibraryAddUsageDescription`

## 2. Guideline 3.1.1 — non-IAP paid content

**Root cause:** prior fixes (#779, #857) hid the *buy buttons* on iOS but still rendered the full **paid catalog** — package names, prices and per-credit cost estimates. Apple flags merely *displaying* non-IAP paid content, not just the purchase action.

**Fix:** on iOS (`isIOS()` / `VITE_SURFACE=ios`) hide the entire paid catalog, not just the button:
- [Subscribe.vue](src/pages/console/application/Subscribe.vue) — the subscription tier cards (incl. prices) are no longer rendered on iOS; shows an empty state instead.
- [Extra.vue](src/pages/console/application/Extra.vue) — the credit top-up pricing form (package amounts, `Price`, `ServiceEstimation`, totals) is gated on iOS.
- [Pay.vue](src/pages/order/Pay.vue) — the public/deep-linkable order pay page now gates its payment-method selector and pay/repay buttons on iOS.

No anti-steering text is shown (no "buy on the web" prompts) — the catalog is simply absent on iOS.

## Verification
- `npx vue-tsc --noEmit` — passes
- `npx eslint` on changed files — clean
- `plutil -lint Info.plist` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)