### PR TITLE
fix(auth): timeout + telemetry for Apple login to surface silent hangs

### DIFF
--- a/change/@acedatacloud-nexior-4031a243-6cfd-40b0-8258-db15a0ce74ef.json
+++ b/change/@acedatacloud-nexior-4031a243-6cfd-40b0-8258-db15a0ce74ef.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(auth): timeout + telemetry for Apple login to surface silent hangs",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -18,6 +18,7 @@ import { App as CapApp } from '@capacitor/app';
 import { Browser } from '@capacitor/browser';
 import { isNative } from '@/utils/surface';
 import { ssoOperator } from '@/operators';
+import { track } from '@/plugins/telemetry';
 
 const elementPlusLocaleMap: Record<string, () => Promise<any>> = {
   en: () => import('element-plus/es/locale/lang/en'),
@@ -50,7 +51,11 @@ export default defineComponent({
   data() {
     return {
       isTest,
-      epLocale: null as any
+      epLocale: null as any,
+      // Guards against Capacitor delivering the same `appUrlOpen` deep link
+      // more than once — a second exchange of an already-consumed SSO code
+      // fails and would bounce the user back to login.
+      lastHandledCode: ''
     };
   },
   computed: {
@@ -79,6 +84,15 @@ export default defineComponent({
           const params = new URL(url).searchParams;
           const code = params.get('code');
           if (code) {
+            // Dedup: the same code can arrive twice (Capacitor re-delivers the
+            // deep link), and an SSO code is single-use — exchanging it again
+            // 4xxs and would kick the user back to login.
+            if (code === this.lastHandledCode) {
+              console.debug('deep link code already handled, ignoring');
+              return;
+            }
+            this.lastHandledCode = code;
+            track('apple_login_deeplink', { action: 'sso_exchange' });
             try {
               await Browser.close();
             } catch (e) {
@@ -93,9 +107,11 @@ export default defineComponent({
               };
               await this.$store.dispatch('setToken', token);
               await this.$store.dispatch('getUser');
+              track('apple_login_success', { action: 'sso_exchange' });
               this.$store.commit('setAuth', { visible: false });
               await this.$router.push('/');
             } catch (e) {
+              track('apple_login_failed', { action: 'sso_exchange', error: String(e) });
               console.error('token exchange failed after deep link', e);
               this.$store.commit('setAuth', { visible: false });
               await this.$store.dispatch('login');

--- a/src/components/common/AuthPanel.vue
+++ b/src/components/common/AuthPanel.vue
@@ -41,6 +41,7 @@ import { ROUTE_SETTINGS_INDEX } from '@/router';
 import { Browser } from '@capacitor/browser';
 import { SignInWithApple } from '@capacitor-community/apple-sign-in';
 import { isNative as isNativeSurface, isIOS } from '@/utils/surface';
+import { track } from '@/plugins/telemetry';
 
 // Native Sign In with Apple is keyed by the iOS bundle identifier, NOT
 // the web Services ID. The same Apple `sub` is returned for both, so
@@ -112,6 +113,7 @@ export default defineComponent({
         // needs, so it falls back to a webpage that asks for the iCloud
         // password instead of using Face ID.
         if (provider === 'apple' && isIOS()) {
+          track('apple_login_submit', { action: 'native_ios' });
           try {
             const { response } = await SignInWithApple.authorize({
               clientId: APPLE_NATIVE_CLIENT_ID,
@@ -123,18 +125,24 @@ export default defineComponent({
             }
             // POST the identity_token directly to AuthBackend. Same endpoint
             // as the web Apple JS flow — apple_get_user_data verifies the JWT
-            // against Apple's JWKS, no client_secret needed.
-            const loginResp = await axios.post(`${getBaseUrlAuth()}/api/v1/auth/login/`, {
-              platform: 'apple',
-              identity_token: response.identityToken,
-              inviter_id: this.inviterId,
-              user: {
-                name: {
-                  firstName: response.givenName ?? '',
-                  lastName: response.familyName ?? ''
+            // against Apple's JWKS, no client_secret needed. Raw axios here
+            // bypasses the platform httpClient, so set an explicit timeout —
+            // otherwise a stalled connection hangs the sheet with no error.
+            const loginResp = await axios.post(
+              `${getBaseUrlAuth()}/api/v1/auth/login/`,
+              {
+                platform: 'apple',
+                identity_token: response.identityToken,
+                inviter_id: this.inviterId,
+                user: {
+                  name: {
+                    firstName: response.givenName ?? '',
+                    lastName: response.familyName ?? ''
+                  }
                 }
-              }
-            });
+              },
+              { timeout: 20000 }
+            );
             const data = loginResp.data;
             const token = {
               access: data.access_token,
@@ -146,6 +154,7 @@ export default defineComponent({
             if (!this.$store.state.site?.origin) {
               await this.$store.dispatch('initializeSite');
             }
+            track('apple_login_success', { action: 'native_ios' });
             this.$store.commit('setAuth', { visible: false });
             await this.$router.push('/');
           } catch (error: unknown) {
@@ -158,8 +167,10 @@ export default defineComponent({
             const detail = error instanceof Error ? error.message : String(error);
             const canceled = /\b100[01]\b/.test(detail) || /cancel/i.test(detail);
             if (canceled) {
+              track('apple_login_canceled', { action: 'native_ios' });
               console.debug('native apple sign in canceled by user', error);
             } else {
+              track('apple_login_failed', { action: 'native_ios', error: detail });
               console.warn('native apple sign in failed', error);
               ElMessage.error(this.$t('common.error.appleSignInFailed').toString());
             }

--- a/src/operators/common.ts
+++ b/src/operators/common.ts
@@ -8,6 +8,11 @@ import { v4 as uuidv4 } from 'uuid';
 
 const httpClient: AxiosInstance = axios.create({
   baseURL: `${getBaseUrlPlatform()}/api/v1`,
+  // Without a timeout a stalled mobile connection leaves the promise pending
+  // forever — e.g. the SSO code exchange / getUser after Apple login would
+  // hang with no error, leaving the UI dead. Fail after 20s so the caller's
+  // catch runs (and RUM captures it).
+  timeout: 20000,
   headers: {
     'Content-type': 'application/json',
     Accept: 'application/json'


### PR DESCRIPTION
## Problem

Apple Sign-In intermittently left the UI dead after the user authorized ("授权完了没反应"). Investigation (code + AuthBackend pod logs over 24h) showed:

- **AuthBackend is healthy** — every Apple login that *reaches* it succeeds in ~0.5–0.9s; zero JWKS/signing-key/timeout errors. The failing attempts never reach the backend, so the break is client-side, *after* Apple returns the identity token.
- The request that completes login had **no timeout**, so a stalled mobile connection left the promise pending forever — no error, no toast, no telemetry.
- The existing Tencent RUM (Aegis) couldn't see it: a never-resolving request produces no `unhandledrejection` and no `reportApiSpeed` entry.

## Changes

- **`operators/common.ts`** — add `timeout: 20000` to the platform `httpClient` (covers the post-deep-link SSO code exchange + `getUser`).
- **`components/common/AuthPanel.vue`** — native iOS Apple POST uses raw `axios` (bypasses the instrumented client); add an explicit `timeout: 20000` so it fails loudly, plus `apple_login_submit / success / failed / canceled` RUM events.
- **`App.vue` `appUrlOpen`** — dedup guard so a re-delivered deep link can't re-exchange an already-consumed (single-use) SSO code, which previously 4xx'd and bounced the user back to login; plus `apple_login_deeplink / success / failed` RUM events.

Net effect: stalled logins now fail within 20s with a visible error **and** become observable in RUM, instead of hanging silently.

## Test

- `npx eslint` on changed files — clean
- `npx vue-tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)