### PR TITLE
feat(attribution): deferred-deep-link referral on iOS/Android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -66,6 +66,8 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     implementation "androidx.coordinatorlayout:coordinatorlayout:$androidxCoordinatorLayoutVersion"
     implementation "androidx.core:core-splashscreen:$coreSplashScreenVersion"
+    // Play Install Referrer — deferred-deep-link referral attribution (InstallReferrerPlugin).
+    implementation "com.android.installreferrer:installreferrer:2.2"
     implementation project(':capacitor-android')
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -28,6 +28,15 @@
                 <data android:scheme="com.acedatacloud.nexior" />
             </intent-filter>
 
+            <!-- App Links: open invite links in the app when installed.
+                 Verified against https://studio.acedata.cloud/.well-known/assetlinks.json. -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="studio.acedata.cloud" android:pathPrefix="/i/" />
+            </intent-filter>
+
         </activity>
 
         <provider

--- a/android/app/src/main/java/com/acedatacloud/nexior/InstallReferrerPlugin.java
+++ b/android/app/src/main/java/com/acedatacloud/nexior/InstallReferrerPlugin.java
@@ -1,0 +1,58 @@
+package com.acedatacloud.nexior;
+
+import android.content.Context;
+import android.os.RemoteException;
+
+import androidx.annotation.NonNull;
+
+import com.android.installreferrer.api.InstallReferrerClient;
+import com.android.installreferrer.api.InstallReferrerStateListener;
+import com.android.installreferrer.api.ReferrerDetails;
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+
+/**
+ * Reads the Google Play Install Referrer once on first launch so a deferred
+ * deep link (invite link) can be attributed to a brand-new install. The
+ * referrer string we set on the store URL ("inviter_id=...&click_id=...")
+ * round-trips back here verbatim.
+ */
+@CapacitorPlugin(name = "InstallReferrer")
+public class InstallReferrerPlugin extends Plugin {
+
+    @PluginMethod
+    public void getReferrer(final PluginCall call) {
+        final Context context = getContext().getApplicationContext();
+        final InstallReferrerClient client = InstallReferrerClient.newBuilder(context).build();
+        client.startConnection(new InstallReferrerStateListener() {
+            @Override
+            public void onInstallReferrerSetupFinished(int responseCode) {
+                try {
+                    if (responseCode == InstallReferrerClient.InstallReferrerResponse.OK) {
+                        ReferrerDetails details = client.getInstallReferrer();
+                        JSObject ret = new JSObject();
+                        ret.put("referrer", details.getInstallReferrer());
+                        call.resolve(ret);
+                    } else {
+                        call.reject("install referrer unavailable: code " + responseCode);
+                    }
+                } catch (RemoteException e) {
+                    call.reject("install referrer remote error", e);
+                } finally {
+                    try {
+                        client.endConnection();
+                    } catch (Exception ignored) {
+                    }
+                }
+            }
+
+            @Override
+            public void onInstallReferrerServiceDisconnected() {
+                // No-op: a one-shot read; we don't retry on disconnect.
+            }
+        });
+    }
+}

--- a/android/app/src/main/java/com/acedatacloud/nexior/MainActivity.java
+++ b/android/app/src/main/java/com/acedatacloud/nexior/MainActivity.java
@@ -11,6 +11,9 @@ import com.getcapacitor.BridgeActivity;
 public class MainActivity extends BridgeActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        // Register the custom Play Install Referrer plugin before the bridge
+        // initializes so it's available to the WebView on first launch.
+        registerPlugin(InstallReferrerPlugin.class);
         EdgeToEdge.enable(this);
         super.onCreate(savedInstanceState);
     }

--- a/change/nexior-deferred-attribution.json
+++ b/change/nexior-deferred-attribution.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(attribution): deferred-deep-link referral attribution for new iOS/Android installs (Play Install Referrer, iOS clipboard/fingerprint, Universal/App Links)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/ios/App/App/App.entitlements
+++ b/ios/App/App/App.entitlements
@@ -8,5 +8,11 @@
 	<array>
 		<string>Default</string>
 	</array>
+	<!-- Universal Links: open invite links in the app when installed.
+	     Verified against https://studio.acedata.cloud/.well-known/apple-app-site-association. -->
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:studio.acedata.cloud</string>
+	</array>
 </dict>
 </plist>

--- a/nginx.conf
+++ b/nginx.conf
@@ -60,6 +60,24 @@ server {
         try_files /llms.txt =404;
     }
 
+    # ---- Deferred-deep-link referral attribution ----
+    # The domain-verification files and the invite landing live in
+    # PlatformBackend, but must be served on THIS host (studio.acedata.cloud)
+    # so iOS Universal Links / Android App Links verify and route correctly.
+    location = /.well-known/apple-app-site-association {
+        proxy_pass https://platform.acedata.cloud;
+    }
+
+    location = /.well-known/assetlinks.json {
+        proxy_pass https://platform.acedata.cloud;
+    }
+
+    # Invite landing: records the click + redirects to the right store
+    # (only hit when the app is NOT installed; otherwise the OS intercepts).
+    location /i/ {
+        proxy_pass https://platform.acedata.cloud;
+    }
+
     location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@capacitor-community/stripe": "^8.1.1",
         "@capacitor/app": "^8.0.1",
         "@capacitor/browser": "^8.0.1",
+        "@capacitor/clipboard": "^8.0.1",
         "@capacitor/local-notifications": "^8.2.0",
         "@capacitor/push-notifications": "^8.1.1",
         "@capgo/capacitor-updater": "^8.49.1",
@@ -415,6 +416,15 @@
       },
       "engines": {
         "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@capacitor/clipboard": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/clipboard/-/clipboard-8.0.1.tgz",
+      "integrity": "sha512-iOlbTi8MojKyLnYE+M27priXid7vHd0PlDwyHohPzkuQ8Rkp6q7ykwZmPEUD+OnU/Ink7Qw/pUOfKgraKmA6Eg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
       }
     },
     "node_modules/@capacitor/core": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@capacitor-community/stripe": "^8.1.1",
     "@capacitor/app": "^8.0.1",
     "@capacitor/browser": "^8.0.1",
+    "@capacitor/clipboard": "^8.0.1",
     "@capacitor/local-notifications": "^8.2.0",
     "@capacitor/push-notifications": "^8.1.1",
     "@capgo/capacitor-updater": "^8.49.1",

--- a/src/App.vue
+++ b/src/App.vue
@@ -17,6 +17,7 @@ import { getLocale } from './i18n';
 import { App as CapApp } from '@capacitor/app';
 import { Browser } from '@capacitor/browser';
 import { isNative } from '@/utils/surface';
+import { parseInviterFromDeepLink, writeInviterCookie } from '@/utils/attribution';
 import { ssoOperator } from '@/operators';
 import { track } from '@/plugins/telemetry';
 
@@ -79,6 +80,15 @@ export default defineComponent({
     if (isNative()) {
       CapApp.addListener('appUrlOpen', async ({ url }) => {
         console.debug('deep link received:', url);
+        // Universal Link / App Link invite (installed-app case): an
+        // https://studio.acedata.cloud/i/<inviter_id> tap opens the app here
+        // instead of hitting the server. Capture the inviter so the login
+        // panel binds the referral. (Deferred/new-install attribution is
+        // handled separately in resolveDeferredInviterId at first launch.)
+        const deepLinkInviter = parseInviterFromDeepLink(url);
+        if (deepLinkInviter) {
+          writeInviterCookie(deepLinkInviter);
+        }
         // Expected format: com.acedatacloud.nexior://auth/callback?code=XXX
         if (url.includes('auth/callback')) {
           const params = new URL(url).searchParams;

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ import './plugins/font-awesome';
 import { MotionPlugin } from '@vueuse/motion';
 import { vLoading } from 'element-plus';
 import { getSurface, isNative } from '@/utils/surface';
+import { resolveDeferredInviterId } from '@/utils/attribution';
 import { syncFeaturesFromUrl } from '@/utils/featureFlag';
 import { runVersionGate } from '@/utils/versionGate';
 import { runLiveUpdate } from '@/utils/liveUpdate';
@@ -70,6 +71,10 @@ const main = async () => {
     return;
   }
   await initializeCookies();
+  // Deferred-deep-link referral: on native first launch, resolve the inviter
+  // (Play Install Referrer / iOS clipboard|fingerprint) into the INVITER_ID
+  // cookie BEFORE the auth panel mounts and reads it. No-op on web.
+  await resolveDeferredInviterId();
   await initializeToken();
   // user/site/config are independent after token is set — run in parallel
   await Promise.all([initializeUser(), initializeSite(), initializeConfig()]);

--- a/src/operators/attribution.ts
+++ b/src/operators/attribution.ts
@@ -1,0 +1,26 @@
+import { AxiosResponse } from 'axios';
+import { httpClient } from './common';
+
+export interface IAttributionResolveRequest {
+  // Token round-tripped via Play Install Referrer (Android) or clipboard (iOS).
+  click_id?: string;
+  platform?: 'ios' | 'android';
+}
+
+export interface IAttributionResolveResponse {
+  inviter_id: string | null;
+  match_type: 'deterministic' | 'probabilistic' | null;
+}
+
+class AttributionOperator {
+  /**
+   * First-launch deferred-deep-link resolution. The shared httpClient already
+   * attaches `x-fingerprint`, so the backend can fall back to a probabilistic
+   * IP/UA match when no `click_id` is available (iOS without clipboard token).
+   */
+  async resolve(payload: IAttributionResolveRequest): Promise<AxiosResponse<IAttributionResolveResponse>> {
+    return httpClient.post('/attribution/resolve/', payload);
+  }
+}
+
+export const attributionOperator = new AttributionOperator();

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -1,4 +1,5 @@
 export * from './common';
+export * from './attribution';
 export * from './application';
 export * from './user';
 export * from './chat';

--- a/src/plugins/installReferrer.ts
+++ b/src/plugins/installReferrer.ts
@@ -1,0 +1,18 @@
+import { registerPlugin } from '@capacitor/core';
+
+export interface InstallReferrerResult {
+  // Raw install referrer string from the Play Store, e.g.
+  // "inviter_id=abc&click_id=def" (urlencoded as set on the store link).
+  referrer: string;
+}
+
+export interface InstallReferrerPlugin {
+  getReferrer(): Promise<InstallReferrerResult>;
+}
+
+/**
+ * Bridges the custom Android `InstallReferrer` plugin (see
+ * android/app/src/main/java/com/acedatacloud/nexior/InstallReferrerPlugin.java).
+ * Android-only — on iOS/web `getReferrer()` rejects, callers must guard.
+ */
+export const InstallReferrer = registerPlugin<InstallReferrerPlugin>('InstallReferrer');

--- a/src/utils/attribution.ts
+++ b/src/utils/attribution.ts
@@ -1,0 +1,98 @@
+import { getCookie, setCookie } from 'typescript-cookie';
+import { Clipboard } from '@capacitor/clipboard';
+import { getDomain } from './domain';
+import { isAndroid, isIOS, isNative } from './surface';
+import { parseInviterFromReferrer } from './attributionParse';
+import { InstallReferrer } from '@/plugins/installReferrer';
+import { attributionOperator } from '@/operators/attribution';
+
+// Re-export so callers (e.g. App.vue) keep importing from '@/utils/attribution'.
+export { parseInviterFromDeepLink } from './attributionParse';
+
+const INVITER_COOKIE = 'INVITER_ID';
+// One-shot guard: a referral attempt must run exactly once per install, so we
+// never re-read the iOS clipboard (re-triggers the paste banner) or clobber an
+// already-bound inviter on later launches.
+const RESOLVED_FLAG = 'ATTRIBUTION_RESOLVED';
+// Backend click_id is a uuid4 hex (32 chars). Only treat clipboard content that
+// matches as our token — otherwise we'd leak arbitrary clipboard data upstream.
+const CLICK_ID_RE = /^[0-9a-f]{32}$/i;
+
+/**
+ * Persist a resolved inviter into the same `INVITER_ID` cookie the existing
+ * login flow (`AuthPanel`, `getInviterId`) already reads. 7-day expiry mirrors
+ * `initializeCookies`.
+ */
+export const writeInviterCookie = (inviterId: string): void => {
+  if (!inviterId) return;
+  const expiration = new Date();
+  expiration.setDate(expiration.getDate() + 7);
+  setCookie(INVITER_COOKIE, inviterId, { expires: expiration, path: '/', domain: getDomain() });
+  console.debug('attribution: wrote INVITER_ID', inviterId);
+};
+
+const resolveAndroid = async (): Promise<void> => {
+  let referrer = '';
+  try {
+    ({ referrer } = await InstallReferrer.getReferrer());
+  } catch (e) {
+    console.debug('attribution: install referrer unavailable', e);
+    return;
+  }
+  const { inviterId } = parseInviterFromReferrer(referrer);
+  // The referrer already carries inviter_id deterministically — no server round
+  // trip needed. (Marking the click resolved server-side is best-effort and
+  // skipped here to keep first launch fast.)
+  if (inviterId) writeInviterCookie(inviterId);
+};
+
+const resolveIOS = async (): Promise<void> => {
+  let clickId: string | undefined;
+  try {
+    const { value } = await Clipboard.read();
+    if (value && CLICK_ID_RE.test(value.trim())) {
+      clickId = value.trim();
+    }
+  } catch (e) {
+    console.debug('attribution: clipboard read unavailable', e);
+  }
+  try {
+    const { data } = await attributionOperator.resolve({ click_id: clickId, platform: 'ios' });
+    if (data?.inviter_id) {
+      console.debug('attribution: resolved inviter via', data.match_type);
+      writeInviterCookie(data.inviter_id);
+    }
+  } catch (e) {
+    console.debug('attribution: resolve failed', e);
+  }
+};
+
+/**
+ * Deferred-deep-link referral resolution, run once on native first launch
+ * BEFORE the auth panel reads the inviter. Android is deterministic (Play
+ * Install Referrer); iOS is best-effort (clipboard token, else a probabilistic
+ * IP/UA match server-side). No-op on web, when already resolved, or when an
+ * inviter cookie is already present.
+ */
+export const resolveDeferredInviterId = async (): Promise<void> => {
+  if (!isNative()) return;
+  if (getCookie(INVITER_COOKIE)) return;
+  try {
+    if (localStorage.getItem(RESOLVED_FLAG)) return;
+  } catch {
+    // localStorage may throw in locked-down WebViews — proceed without the guard
+  }
+  try {
+    if (isAndroid()) {
+      await resolveAndroid();
+    } else if (isIOS()) {
+      await resolveIOS();
+    }
+  } finally {
+    try {
+      localStorage.setItem(RESOLVED_FLAG, '1');
+    } catch {
+      // ignore — worst case we retry next launch
+    }
+  }
+};

--- a/src/utils/attributionParse.test.ts
+++ b/src/utils/attributionParse.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseInviterFromDeepLink, parseInviterFromReferrer } from './attributionParse';
+
+describe('parseInviterFromDeepLink', () => {
+  it('reads inviter_id from the /i/<id> path form (App/Universal Link)', () => {
+    expect(parseInviterFromDeepLink('https://studio.acedata.cloud/i/abc-123')).toBe('abc-123');
+  });
+
+  it('reads inviter_id from a query param', () => {
+    expect(parseInviterFromDeepLink('https://studio.acedata.cloud/?inviter_id=xyz')).toBe('xyz');
+  });
+
+  it('prefers an explicit query param over the path segment', () => {
+    expect(parseInviterFromDeepLink('https://studio.acedata.cloud/i/path-one?inviter_id=query-one')).toBe('query-one');
+  });
+
+  it('url-decodes the path segment', () => {
+    expect(parseInviterFromDeepLink('https://studio.acedata.cloud/i/a%20b')).toBe('a b');
+  });
+
+  it('returns null for URLs without a referral', () => {
+    expect(parseInviterFromDeepLink('https://studio.acedata.cloud/chat')).toBeNull();
+  });
+
+  it('ignores an auth callback custom-scheme URL', () => {
+    expect(parseInviterFromDeepLink('com.acedatacloud.nexior://auth/callback?code=123')).toBeNull();
+  });
+
+  it('returns null for unparseable input', () => {
+    expect(parseInviterFromDeepLink('not a url')).toBeNull();
+  });
+});
+
+describe('parseInviterFromReferrer', () => {
+  it('splits the Play install-referrer blob', () => {
+    expect(parseInviterFromReferrer('inviter_id=abc&click_id=def')).toEqual({
+      inviterId: 'abc',
+      clickId: 'def'
+    });
+  });
+
+  it('handles a missing click_id', () => {
+    expect(parseInviterFromReferrer('inviter_id=abc')).toEqual({ inviterId: 'abc', clickId: null });
+  });
+
+  it('handles an empty / organic referrer', () => {
+    expect(parseInviterFromReferrer('')).toEqual({ inviterId: null, clickId: null });
+    expect(parseInviterFromReferrer('utm_source=google-play&utm_medium=organic')).toEqual({
+      inviterId: null,
+      clickId: null
+    });
+  });
+});

--- a/src/utils/attributionParse.ts
+++ b/src/utils/attributionParse.ts
@@ -1,0 +1,29 @@
+// Dependency-free parsers for deferred-deep-link attribution, split out from
+// utils/attribution.ts (which pulls in Capacitor) so they stay unit-testable.
+
+/**
+ * Pull an inviter_id out of a universal/app-link URL — either the path form
+ * `https://studio.acedata.cloud/i/<inviter_id>` or a `?inviter_id=` query.
+ * Returns null when the URL carries no referral.
+ */
+export const parseInviterFromDeepLink = (rawUrl: string): string | null => {
+  try {
+    const url = new URL(rawUrl);
+    const queryInviter = url.searchParams.get('inviter_id');
+    if (queryInviter) return queryInviter;
+    const match = url.pathname.match(/\/i\/([^/?#]+)/);
+    if (match && match[1]) return decodeURIComponent(match[1]);
+  } catch {
+    // not a parseable URL (e.g. a bare custom-scheme callback) — ignore
+  }
+  return null;
+};
+
+/**
+ * Split a Play Install Referrer blob ("inviter_id=abc&click_id=def") into its
+ * referral parts.
+ */
+export const parseInviterFromReferrer = (referrer: string): { inviterId: string | null; clickId: string | null } => {
+  const params = new URLSearchParams(referrer || '');
+  return { inviterId: params.get('inviter_id'), clickId: params.get('click_id') };
+};


### PR DESCRIPTION
## Why

Invite links (`?inviter_id=xxx`) attach the referrer fine on **web**, but **not** for brand-new **iOS/Android app** installs: the App Store / Play Store drop all web-click context, so a fresh install never sees the `inviter_id`. This is the classic *deferred deep linking / install attribution* problem.

This is the **Nexior app half**; it pairs with PlatformBackend **https://github.com/AceDataCloud/PlatformBackend/pull/644** (landing endpoint, `/attribution/resolve`, and the `.well-known` verification files).

## What

**First launch — `resolveDeferredInviterId()` (native only, run once, before the auth panel reads the inviter):**
- **Android** → reads the Google Play Install Referrer via a custom `InstallReferrerPlugin` (Java). `inviter_id` round-trips **deterministically** through the store link's `&referrer=`.
- **iOS** → reads the clipboard click token (`@capacitor/clipboard`) → `POST /attribution/resolve` (deterministic); if there's no token, the backend falls back to a **probabilistic** IP/UA match.
- The resolved inviter is written to the existing **`INVITER_ID` cookie**, so the current `AuthPanel` / `getInviterId` flow binds the referral **unchanged**.

**Installed-app case** — `App.vue`'s `appUrlOpen` now parses `inviter_id` from Universal Link / App Link taps (`https://studio.acedata.cloud/i/<id>`).

**Wiring:**
- `attributionOperator` (`/attribution/resolve`), `InstallReferrer` plugin shim, `@capacitor/clipboard` dep (lockfile updated).
- Android App Links intent-filter (`autoVerify`, `https://studio.acedata.cloud/i/`) + `installreferrer:2.2` gradle dep.
- iOS `associated-domains` entitlement (`applinks:studio.acedata.cloud`).
- nginx: proxy `/.well-known/apple-app-site-association`, `/.well-known/assetlinks.json`, and `/i/` to PlatformBackend (so they're served on `studio.acedata.cloud`).
- Pure parsers split into `attributionParse.ts` + **10 vitest tests** (pass locally).

## Ops follow-up (required to actually enable, can't be done in code)

1. Set backend env (PR #644): `ATTRIBUTION_APPLE_TEAM_ID`, `ATTRIBUTION_ANDROID_SHA256` (Play App Signing cert), real `ATTRIBUTION_APP_STORE_URL` id.
2. Deploy both PRs so `studio.acedata.cloud/.well-known/...` serves valid files.
3. **Rebuild + resubmit both apps** (entitlement / manifest / native plugin are compile-time) so link verification takes effect.

## Notes

- iOS new-install attribution is **best-effort** (Apple has no install-referrer API): clipboard token, else a probabilistic match flagged `probabilistic` on the backend click row — **don't auto-pay referral rewards on those** without a risk check.
- Full `vue-tsc`/build not run locally (fresh worktree had no `node_modules`; `@capacitor/clipboard` types come from the updated lockfile on `npm ci`). ESLint + the 10 parser tests pass locally via the primary checkout's modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
