### PR TITLE
fix(preview): guard event.stopPropagation() against undefined

### DIFF
--- a/change/@acedatacloud-nexior-bd2909c5-47f5-4cc3-aa5f-ae8dc35fc8d8.json
+++ b/change/@acedatacloud-nexior-bd2909c5-47f5-4cc3-aa5f-ae8dc35fc8d8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(preview): guard event.stopPropagation() against undefined in task previews",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/flux/task/Preview.vue
+++ b/src/components/flux/task/Preview.vue
@@ -151,7 +151,7 @@ export default defineComponent({
   },
   methods: {
     onDownload(event: MouseEvent, image_url: string) {
-      event.stopPropagation();
+      event?.stopPropagation();
       console.log('on download');
       // download url here
       window.open(image_url, '_blank');

--- a/src/components/headshots/task/Preview.vue
+++ b/src/components/headshots/task/Preview.vue
@@ -139,7 +139,7 @@ export default defineComponent({
   },
   methods: {
     onDownload(event: MouseEvent, video_url: string) {
-      event.stopPropagation();
+      event?.stopPropagation();
       console.log('on download');
       // download url here
       window.open(video_url, '_blank');

--- a/src/components/kling/task/Preview.vue
+++ b/src/components/kling/task/Preview.vue
@@ -185,7 +185,7 @@ export default defineComponent({
   },
   methods: {
     onDownload(event: MouseEvent, video_url: string) {
-      event.stopPropagation();
+      event?.stopPropagation();
       console.log('on download');
       // download url here
       window.open(video_url, '_blank');

--- a/src/components/pixverse/task/Preview.vue
+++ b/src/components/pixverse/task/Preview.vue
@@ -145,7 +145,7 @@ export default defineComponent({
   },
   methods: {
     onDownload(event: MouseEvent, video_url: string) {
-      event.stopPropagation();
+      event?.stopPropagation();
       console.log('on download');
       // download url here
       window.open(video_url, '_blank');

--- a/src/components/producer/task/Preview.vue
+++ b/src/components/producer/task/Preview.vue
@@ -236,7 +236,7 @@ export default defineComponent({
       }
     },
     onExtend(event: MouseEvent, audio: IProducerAudio) {
-      event.stopPropagation();
+      event?.stopPropagation();
       console.debug('set config', audio);
       this.$store.commit('producer/setConfig', {
         ...this.$store.state.producer?.config,
@@ -252,7 +252,7 @@ export default defineComponent({
     },
     onDownload(event: MouseEvent | null, audioUrl: string) {
       if (event) {
-        event.stopPropagation();
+        event?.stopPropagation();
       }
       const parsedUrl = new URL(audioUrl);
       const pathname = parsedUrl.pathname;
@@ -312,7 +312,7 @@ export default defineComponent({
       });
     },
     onPreview(event: MouseEvent, videoUrl: string) {
-      event.stopPropagation();
+      event?.stopPropagation();
       window.open(videoUrl, '_blank');
     },
     async onGetStems(audioId: string) {

--- a/src/components/sora/task/Preview.vue
+++ b/src/components/sora/task/Preview.vue
@@ -155,7 +155,7 @@ export default defineComponent({
   },
   methods: {
     onDownload(event: MouseEvent, video_url: string) {
-      event.stopPropagation();
+      event?.stopPropagation();
       console.log('on download');
       // download url here
       window.open(video_url, '_blank');

--- a/src/components/suno/task/Preview.vue
+++ b/src/components/suno/task/Preview.vue
@@ -368,7 +368,7 @@ export default defineComponent({
       }
     },
     onExtend(event: MouseEvent, audio: ISunoAudio) {
-      event.stopPropagation();
+      event?.stopPropagation();
       console.log('on extend');
       // download url here
       console.debug('set config', audio);
@@ -386,7 +386,7 @@ export default defineComponent({
     },
     onDownload(event: MouseEvent | null, audioUrl: string) {
       if (event) {
-        event.stopPropagation();
+        event?.stopPropagation();
       }
       console.log('on download', audioUrl);
       const parsedUrl = new URL(audioUrl);
@@ -450,7 +450,7 @@ export default defineComponent({
       });
     },
     onPreview(event: MouseEvent, videoUrl: string) {
-      event.stopPropagation();
+      event?.stopPropagation();
       console.log('on preview', videoUrl);
       // preview url here
       window.open(videoUrl, '_blank');

--- a/src/components/veo/task/Preview.vue
+++ b/src/components/veo/task/Preview.vue
@@ -235,7 +235,7 @@ export default defineComponent({
       });
     },
     onDownload(event: MouseEvent, video_url: string) {
-      event.stopPropagation();
+      event?.stopPropagation();
       console.log('on download');
       // download url here
       window.open(video_url, '_blank');


### PR DESCRIPTION
## Problem

RUM (Aegis) surfaced ~14/day `Cannot read properties of undefined (reading 'stopPropagation')` on studio.acedata.cloud — across `/veo`, `/chatgpt/conversations` and other pages.

## Cause

The `*/task/Preview.vue` download/extend/preview handlers call `event.stopPropagation()` directly, while their signatures already permit a missing event (several are typed `MouseEvent | null`). When invoked without a real event, dereferencing `event` throws.

## Fix

Optional-chain the calls — `event?.stopPropagation()` — so a missing event is a harmless no-op instead of an uncaught error. Covers veo / producer / sora / flux / headshots / kling / pixverse / suno (12 call sites).

Found via the new `/manage-rum` tooling (Index #82). Verified `eslint` + `vue-tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)