### PR TITLE
fix(attribution): static App/Universal Link files + /i/ via /api/v1

### DIFF
--- a/change/nexior-attribution-nginx-routing.json
+++ b/change/nexior-attribution-nginx-routing.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(attribution): serve App/Universal Link verification files statically and route /i/ landing via /api/v1 (fixes EdgeOne 423 loop + path allowlist)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -61,21 +61,29 @@ server {
     }
 
     # ---- Deferred-deep-link referral attribution ----
-    # The domain-verification files and the invite landing live in
-    # PlatformBackend, but must be served on THIS host (studio.acedata.cloud)
-    # so iOS Universal Links / Android App Links verify and route correctly.
+    # iOS Universal Links / Android App Links verification files. Served as
+    # static files (constants) from public/well-known/ — NOT proxied, so they
+    # don't hit the platform host's path allowlist or loop through EdgeOne.
     location = /.well-known/apple-app-site-association {
-        proxy_pass https://platform.acedata.cloud;
+        alias /usr/share/nginx/html/well-known/apple-app-site-association;
+        default_type application/json;
+        add_header Cache-Control "public, max-age=3600" always;
     }
 
     location = /.well-known/assetlinks.json {
-        proxy_pass https://platform.acedata.cloud;
+        alias /usr/share/nginx/html/well-known/assetlinks.json;
+        default_type application/json;
+        add_header Cache-Control "public, max-age=3600" always;
     }
 
-    # Invite landing: records the click + redirects to the right store
-    # (only hit when the app is NOT installed; otherwise the OS intercepts).
+    # Invite landing (only hit when the app is NOT installed; otherwise the OS
+    # intercepts the App/Universal Link). Rewrite /i/<id> to the backend's
+    # /api/v1 landing — the platform host routes /api/v1/* to Django, and the
+    # explicit Host stops EdgeOne from bouncing the request back here (loop).
     location /i/ {
+        rewrite ^/i/(.+)$ /api/v1/attribution/landing/$1 break;
         proxy_pass https://platform.acedata.cloud;
+        proxy_set_header Host platform.acedata.cloud;
     }
 
     location / {

--- a/public/well-known/apple-app-site-association
+++ b/public/well-known/apple-app-site-association
@@ -1,0 +1,12 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "3HRQL4667P.com.acedatacloud.nexior",
+        "paths": ["/i/*"],
+        "components": [{ "/": "/i/*", "comment": "invite landing" }]
+      }
+    ]
+  }
+}

--- a/public/well-known/assetlinks.json
+++ b/public/well-known/assetlinks.json
@@ -1,0 +1,13 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.acedatacloud.nexior",
+      "sha256_cert_fingerprints": [
+        "DA:65:7E:17:64:50:19:3F:24:16:B6:56:40:D3:C2:E9:42:4A:B5:28:A2:BB:B0:91:AC:03:62:C5:8B:01:94:13",
+        "0C:59:45:AD:6D:4E:E6:04:87:1F:D9:0E:E4:44:F9:5E:B1:2B:0D:1C:DF:9F:9B:AB:F8:54:9E:69:F0:B1:D1:E3"
+      ]
+    }
+  }
+]


### PR DESCRIPTION
Follow-up after E2E found the prod endpoints broken. Pairs with PlatformBackend #647.

**E2E found:**
1. Proxying `/.well-known/*` + `/i/` to platform.acedata.cloud forwarded `Host: studio`, so EdgeOne bounced it back to studio → 16-hop loop → **HTTP 423**.
2. platform.acedata.cloud's edge only routes an allowlist (`/api/v1`, `/.well-known/x402`…) to Django; the new root paths fell through to the SPA (index.html).

**Fix:**
- Serve `apple-app-site-association` + `assetlinks.json` as **static files** from `public/well-known/` (Team ID `3HRQL4667P` + both Play signing SHA-256). No proxy → no loop, no allowlist dependency.
- Rewrite `/i/<id>` → `/api/v1/attribution/landing/<id>` with explicit `Host: platform.acedata.cloud` (reaches Django via the proven API path; needs #647).

After both merge + deploy I'll re-run the full E2E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)