### PR TITLE
feat(coding-bridge): restore session settings on reload, keep them editable per turn

### DIFF
--- a/change/@acedatacloud-nexior-cb-reload-restore.json
+++ b/change/@acedatacloud-nexior-cb-reload-restore.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(coding-bridge): restore model/cwd/effort/edit-mode on reload from history and keep them editable per turn",
+  "packageName": "@acedatacloud/nexior",
+  "email": "cqcreer@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/src/components/codingBridge/SessionView.vue
+++ b/src/components/codingBridge/SessionView.vue
@@ -315,83 +315,84 @@
                   </div>
                 </el-popover>
 
-                <!-- Effort, permission and working directory are chosen at start. -->
-                <template v-if="isNewSession">
-                  <el-dropdown v-if="effortOptions.length > 1" trigger="click" @command="effort = $event">
+                <!-- Effort and permission/edit mode stay editable every turn: the
+                     node applies whatever the composer carries on each send, so a
+                     resumed conversation can change them per query. -->
+                <el-dropdown v-if="effortOptions.length > 1" trigger="click" @command="effort = $event">
+                  <button type="button" class="cb-pill">
+                    <font-awesome-icon icon="fa-solid fa-gauge-high" class="cb-pill__icon" />
+                    <span class="truncate">{{ effortLabel(effort) }}</span>
+                    <font-awesome-icon icon="fa-solid fa-chevron-down" class="cb-pill__caret" />
+                  </button>
+                  <template #dropdown>
+                    <el-dropdown-menu>
+                      <el-dropdown-item v-for="opt in effortOptions" :key="opt.value" :command="opt.value">
+                        <font-awesome-icon
+                          icon="fa-solid fa-check"
+                          class="mr-2"
+                          :class="opt.value === effort ? 'opacity-100' : 'opacity-0'"
+                        />
+                        {{ opt.label }}
+                      </el-dropdown-item>
+                    </el-dropdown-menu>
+                  </template>
+                </el-dropdown>
+
+                <el-dropdown trigger="click" @command="permissionMode = $event">
+                  <button type="button" class="cb-pill">
+                    <font-awesome-icon icon="fa-solid fa-shield-halved" class="cb-pill__icon" />
+                    <span class="truncate">{{ permissionModeLabel(permissionMode) }}</span>
+                    <font-awesome-icon icon="fa-solid fa-chevron-down" class="cb-pill__caret" />
+                  </button>
+                  <template #dropdown>
+                    <el-dropdown-menu>
+                      <el-dropdown-item v-for="opt in permissionModeOptions" :key="opt.value" :command="opt.value">
+                        <font-awesome-icon
+                          icon="fa-solid fa-check"
+                          class="mr-2"
+                          :class="opt.value === permissionMode ? 'opacity-100' : 'opacity-0'"
+                        />
+                        {{ opt.label }}
+                      </el-dropdown-item>
+                    </el-dropdown-menu>
+                  </template>
+                </el-dropdown>
+
+                <!-- Working directory: editable for a new or resumed-but-not-yet
+                     -continued session (its first send is a fresh start that
+                     applies the cwd); read-only once a live turn pins it. -->
+                <el-popover v-if="canPickCwd" trigger="click" placement="top-start" :width="320">
+                  <template #reference>
                     <button type="button" class="cb-pill">
-                      <font-awesome-icon icon="fa-solid fa-gauge-high" class="cb-pill__icon" />
-                      <span class="truncate">{{ effortLabel(effort) }}</span>
+                      <font-awesome-icon icon="fa-solid fa-folder-open" class="cb-pill__icon" />
+                      <span class="truncate">{{ cwd || $t('codingBridge.session.cwdDefault') }}</span>
                       <font-awesome-icon icon="fa-solid fa-chevron-down" class="cb-pill__caret" />
                     </button>
-                    <template #dropdown>
-                      <el-dropdown-menu>
-                        <el-dropdown-item v-for="opt in effortOptions" :key="opt.value" :command="opt.value">
-                          <font-awesome-icon
-                            icon="fa-solid fa-check"
-                            class="mr-2"
-                            :class="opt.value === effort ? 'opacity-100' : 'opacity-0'"
-                          />
-                          {{ opt.label }}
-                        </el-dropdown-item>
-                      </el-dropdown-menu>
+                  </template>
+                  <el-input
+                    v-model="cwd"
+                    size="small"
+                    clearable
+                    class="cb-cwd-input"
+                    :placeholder="$t('codingBridge.session.cwdPlaceholder')"
+                  >
+                    <template #suffix>
+                      <span
+                        class="cb-cwd-browse"
+                        role="button"
+                        tabindex="0"
+                        :title="$t('codingBridge.directory.title')"
+                        :aria-label="$t('codingBridge.directory.title')"
+                        @click="openDirectory"
+                        @keydown.enter.prevent="openDirectory"
+                        @keydown.space.prevent="openDirectory"
+                      >
+                        <font-awesome-icon icon="fa-solid fa-folder-open" />
+                      </span>
                     </template>
-                  </el-dropdown>
-
-                  <el-dropdown trigger="click" @command="permissionMode = $event">
-                    <button type="button" class="cb-pill">
-                      <font-awesome-icon icon="fa-solid fa-shield-halved" class="cb-pill__icon" />
-                      <span class="truncate">{{ permissionModeLabel(permissionMode) }}</span>
-                      <font-awesome-icon icon="fa-solid fa-chevron-down" class="cb-pill__caret" />
-                    </button>
-                    <template #dropdown>
-                      <el-dropdown-menu>
-                        <el-dropdown-item v-for="opt in permissionModeOptions" :key="opt.value" :command="opt.value">
-                          <font-awesome-icon
-                            icon="fa-solid fa-check"
-                            class="mr-2"
-                            :class="opt.value === permissionMode ? 'opacity-100' : 'opacity-0'"
-                          />
-                          {{ opt.label }}
-                        </el-dropdown-item>
-                      </el-dropdown-menu>
-                    </template>
-                  </el-dropdown>
-
-                  <el-popover trigger="click" placement="top-start" :width="320">
-                    <template #reference>
-                      <button type="button" class="cb-pill">
-                        <font-awesome-icon icon="fa-solid fa-folder-open" class="cb-pill__icon" />
-                        <span class="truncate">{{ cwd || $t('codingBridge.session.cwdDefault') }}</span>
-                        <font-awesome-icon icon="fa-solid fa-chevron-down" class="cb-pill__caret" />
-                      </button>
-                    </template>
-                    <el-input
-                      v-model="cwd"
-                      size="small"
-                      clearable
-                      class="cb-cwd-input"
-                      :placeholder="$t('codingBridge.session.cwdPlaceholder')"
-                    >
-                      <template #suffix>
-                        <span
-                          class="cb-cwd-browse"
-                          role="button"
-                          tabindex="0"
-                          :title="$t('codingBridge.directory.title')"
-                          :aria-label="$t('codingBridge.directory.title')"
-                          @click="openDirectory"
-                          @keydown.enter.prevent="openDirectory"
-                          @keydown.space.prevent="openDirectory"
-                        >
-                          <font-awesome-icon icon="fa-solid fa-folder-open" />
-                        </span>
-                      </template>
-                    </el-input>
-                  </el-popover>
-                </template>
-
-                <!-- Working directory is fixed once a session is running. -->
-                <span v-if="!isNewSession && currentSession?.cwd" class="cb-pill cb-pill--static">
+                  </el-input>
+                </el-popover>
+                <span v-else-if="currentSession?.cwd" class="cb-pill cb-pill--static">
                   <font-awesome-icon icon="fa-solid fa-folder-open" class="cb-pill__icon" />
                   <span class="truncate">{{ currentSession?.cwd }}</span>
                 </span>
@@ -548,6 +549,14 @@ export default defineComponent({
     },
     isNewSession(): boolean {
       return !this.currentSessionId;
+    },
+    // The working directory can be picked for a brand-new session and for a
+    // resumed conversation that hasn't continued yet (its first send is a fresh
+    // `session.start` that applies the cwd). Once a live turn is running the
+    // agent's directory is fixed, so it's shown read-only — model / effort /
+    // permission stay editable because the node applies those on every turn.
+    canPickCwd(): boolean {
+      return this.isNewSession || !this.currentSession?.started;
     },
     readonly(): boolean {
       return this.currentSession?.readonly === true;
@@ -877,14 +886,21 @@ export default defineComponent({
         this.restoreComposerPrefs();
         return;
       }
+      // Resuming a session (e.g. reopened from history after a reload): seed the
+      // composer from the session, falling back to this device's last setup for
+      // anything the replayed transcript can't carry (effort / permission mode
+      // aren't recorded on disk; cwd may be absent). Without the fallback these
+      // reset to defaults on every reload. Provider already exists → the
+      // `provider` watcher won't wipe model/effort here.
+      const prefs = this.lastComposer;
       if (session.provider) {
         this.provider = session.provider;
       }
       this.model = session.model ?? '';
       this.customModelDraft = '';
-      if (session.cwd) {
-        this.cwd = session.cwd;
-      }
+      this.cwd = session.cwd ?? prefs.cwd ?? '';
+      this.effort = session.effort ?? prefs.effort ?? '';
+      this.permissionMode = session.permission_mode ?? prefs.permissionMode ?? 'default';
     },
     // Pick a listed model (or the empty default) and close the popover.
     selectModel(value: string) {

--- a/src/models/codingBridge.ts
+++ b/src/models/codingBridge.ts
@@ -82,6 +82,12 @@ export interface ICodingBridgeSession {
   status: ICodingBridgeSessionStatus;
   cwd?: string;
   model?: string;
+  // Reasoning-effort tier and permission/edit mode the session is running with.
+  // Transcripts don't record these, so a history replay seeds them from the
+  // node's last composer prefs; a sent turn keeps them current. Both stay
+  // editable per query (the node applies them on each turn).
+  effort?: string;
+  permission_mode?: string;
   cost_usd?: number;
   // Which backend this session targets; defaults to Claude Code.
   provider?: ICodingBridgeHistoryProvider;

--- a/src/store/codingBridge/actions.ts
+++ b/src/store/codingBridge/actions.ts
@@ -160,6 +160,10 @@ const applyNodeEvent = (
         status: 'running',
         cwd: payload.cwd,
         model: payload.model,
+        // The node now echoes effort/permission_mode too; only apply when present
+        // so an older node that omits them doesn't wipe the session's values.
+        ...(payload.effort !== undefined ? { effort: payload.effort } : {}),
+        ...(payload.permission_mode !== undefined ? { permission_mode: payload.permission_mode } : {}),
         trace_id: traceId
       });
       break;
@@ -349,7 +353,7 @@ const applyNodeEvent = (
       }
       break;
     case CB_EVENT_HISTORY_DETAIL:
-      applyHistoryDetail(commit, payload, fromNode);
+      applyHistoryDetail(commit, state, payload, fromNode);
       break;
     case CB_EVENT_FS_LIST:
       // Directory listings are node-scoped (no session_id) and feed the
@@ -379,6 +383,7 @@ const applyNodeEvent = (
 // Materialise a replayed transcript as a (resumable) session.
 const applyHistoryDetail = (
   commit: ActionContext<ICodingBridgeState, IRootState>['commit'],
+  state: ICodingBridgeState,
   payload: Record<string, any>,
   fromNode: string | undefined
 ): void => {
@@ -388,12 +393,21 @@ const applyHistoryDetail = (
     return;
   }
   const resumable = provider === 'claude';
+  // Reasoning effort and permission/edit mode are NOT in the on-disk transcript,
+  // so the node restores them from the per-session sidecar it saved while the
+  // session ran (authoritative, works across devices) and sends them back on the
+  // history detail. Fall back to this device's last composer setup only when the
+  // sidecar is absent (e.g. a session that predates it) so we never reset to
+  // defaults. cwd/model come from the transcript, sidecar-backfilled by the node.
+  const prefs = state.lastComposer?.[fromNode] ?? {};
   commit('upsertSession', {
     session_id: sessionId,
     node_id: fromNode,
     status: 'idle',
-    cwd: payload.cwd,
-    model: payload.model,
+    cwd: payload.cwd ?? prefs.cwd,
+    model: payload.model ?? prefs.model,
+    effort: payload.effort ?? prefs.effort,
+    permission_mode: payload.permission_mode ?? prefs.permissionMode,
     provider,
     started: false,
     readonly: !resumable,
@@ -629,13 +643,25 @@ export const sendPrompt = (
         status: 'starting',
         cwd: payload.cwd,
         model: payload.model,
+        effort: payload.effort,
+        permission_mode: payload.permissionMode,
         provider,
         trace_id: traceId
       });
       commit('setCurrentSession', sessionId);
     } else {
       sessionId = existing.session_id;
-      commit('updateSession', { session_id: sessionId, status: 'starting', trace_id: traceId });
+      // Resuming a replayed conversation: carry the composer's current settings
+      // onto the session so the started turn (and the pills) reflect them.
+      commit('updateSession', {
+        session_id: sessionId,
+        status: 'starting',
+        trace_id: traceId,
+        ...(payload.cwd ? { cwd: payload.cwd } : {}),
+        ...(payload.model !== undefined ? { model: payload.model } : {}),
+        ...(payload.effort !== undefined ? { effort: payload.effort } : {}),
+        ...(payload.permissionMode !== undefined ? { permission_mode: payload.permissionMode } : {})
+      });
     }
     commit(
       'appendEvent',
@@ -665,8 +691,11 @@ export const sendPrompt = (
     commit('updateSession', {
       session_id: sessionId as string,
       status: 'running',
-      // Keep the stored model in sync with a mid-session switch.
-      model: payload.model || undefined
+      // Keep the stored settings in sync with a mid-session switch so the pills
+      // and the next turn reflect the latest choice.
+      model: payload.model || undefined,
+      ...(payload.effort !== undefined ? { effort: payload.effort } : {}),
+      ...(payload.permissionMode !== undefined ? { permission_mode: payload.permissionMode } : {})
     });
     socket.sendToNode(nodeId, {
       action: CB_ACTION_SESSION_SEND,
@@ -676,6 +705,11 @@ export const sendPrompt = (
       // Allow switching the model mid-session; sent verbatim so an empty value
       // resets the node to its default model.
       model: payload.model ?? '',
+      // Reasoning effort and permission/edit mode are also live-changeable per
+      // turn — the node applies them on each `session.send`. Sent only when the
+      // composer offers them so an omitted value keeps the session's current one.
+      ...(payload.effort !== undefined ? { effort: payload.effort } : {}),
+      ...(payload.permissionMode !== undefined ? { permission_mode: payload.permissionMode } : {}),
       images,
       attachments
     });
@@ -730,7 +764,9 @@ export const editPrompt = (
     session_id: sessionId,
     status: 'running',
     trace_id: traceId,
-    model: payload.model || session.model || undefined
+    model: payload.model || session.model || undefined,
+    ...(payload.effort !== undefined ? { effort: payload.effort } : {}),
+    ...(payload.permissionMode !== undefined ? { permission_mode: payload.permissionMode } : {})
   });
   commit('appendEvent', makeEvent(sessionId, 'prompt', { text: prompt, images, attachments, trace_id: traceId }));
   socket.sendToNode(nodeId, {


### PR DESCRIPTION
## Problem
Reloading a Coding Bridge conversation from history reset the **model**, **working directory**, **reasoning effort**, and **edit (permission) mode** — and the directory sometimes came back as `System32`. Effort and permission mode aren't recorded in the on-disk transcript at all, so a replay had nothing to restore them from.

## Fix (frontend half)
- **`actions.ts`** — `applyHistoryDetail` now seeds `effort`/`permission_mode` from the authoritative `HISTORY_DETAIL` payload (the node restores them from its per-session sidecar), falling back to this device's last composer prefs only when the node predates the sidecar. `SESSION_STARTED` absorbs the two fields too. `sendPrompt`/`editPrompt` carry `effort` + `permission_mode` on every start/send/edit, so a resumed conversation reflects the composer and the node applies live changes per turn.
- **`SessionView.vue`** — effort and permission/edit-mode pills stay editable on **every** turn (previously start-only), so each query can change them.
- **`models/codingBridge.ts`** — `ICodingBridgeSession` gains `effort` / `permission_mode`.

Net behaviour: **reload from history restores model + directory + effort + edit mode**, and **every query can still change them**.

## Companion (required)
Server half in **AceDataCloud/CodingBridgeAgent#26** persists & restores these settings and hardens the System32 default-cwd. The two ship together; older nodes simply omit the new fields and the device-local fallback kicks in.

## Note
`vue-tsc` not run here (no Node on the dev host); changes are type-checked by inspection against `ICodingBridgeComposerPrefs` / `ICodingBridgeSession`. Please confirm CI typecheck passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)