### PR TITLE
feat(coding-bridge): adopt the provider's real session id as one identity

### DIFF
--- a/change/@acedatacloud-nexior-cb-session-identity.json
+++ b/change/@acedatacloud-nexior-cb-session-identity.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(coding-bridge): adopt the provider's real session id as one identity so resuming a conversation reattaches to its live session (Stop button, typewriter, no cross-talk) instead of forking a parallel one",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/codingBridge/HistoryDrawer.vue
+++ b/src/components/codingBridge/HistoryDrawer.vue
@@ -42,6 +42,9 @@
               :alt="item.provider === 'codex' ? 'Codex' : 'Claude'"
             />
             <span class="text-sm font-medium truncate flex-1">{{ item.title }}</span>
+            <!-- Live on the node right now: opening it reattaches to the running
+                 session (Stop button + streaming) rather than replaying a copy. -->
+            <span v-if="item.running" class="running-dot" :title="$t('codingBridge.history.running')"></span>
           </div>
           <div class="text-[11px] text-[var(--app-text-subtle)] truncate">
             <span v-if="item.cwd">{{ item.cwd }}</span>
@@ -150,6 +153,15 @@ export default defineComponent({
   width: 16px;
   height: 16px;
   object-fit: contain;
+}
+
+.running-dot {
+  flex: none;
+  width: 8px;
+  height: 8px;
+  border-radius: 9999px;
+  background: var(--el-color-success);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--el-color-success) 25%, transparent);
 }
 
 // The OpenAI glyph ships black; flip it to white on dark backgrounds.

--- a/src/constants/codingBridge.ts
+++ b/src/constants/codingBridge.ts
@@ -36,6 +36,9 @@ export const CB_ACTION_PING = 'ping';
 
 // --- Inner events: node -> browser -----------------------------------------
 export const CB_EVENT_SESSION_STARTED = 'session.started';
+// The provider's real (SDK) session id is known: re-key the session from the
+// provisional id (`session_id`) to the canonical one (`sdk_session_id`).
+export const CB_EVENT_SESSION_IDENTIFIED = 'session.identified';
 export const CB_EVENT_SESSION_TEXT = 'session.text';
 export const CB_EVENT_SESSION_TEXT_DELTA = 'session.text_delta';
 export const CB_EVENT_SESSION_THINKING = 'session.thinking';

--- a/src/i18n/ar/codingBridge.json
+++ b/src/i18n/ar/codingBridge.json
@@ -231,6 +231,10 @@
     "message": "محادثة Codex هذه للقراءة فقط ولا يمكن متابعتها. ابدأ جلسة جديدة لمواصلة البرمجة.",
     "description": "Read-only replay notice"
   },
+  "history.running": {
+    "message": "قيد التشغيل",
+    "description": "Marks a history conversation that is currently live on the device"
+  },
   "history.resumeHint": {
     "message": "سيؤدي إرسال رسالة إلى استئناف هذه المحادثة على الجهاز.",
     "description": "Resume composer hint"

--- a/src/i18n/de/codingBridge.json
+++ b/src/i18n/de/codingBridge.json
@@ -231,6 +231,10 @@
     "message": "Diese Codex-Konversation ist schreibgeschützt und kann nicht fortgesetzt werden. Starte eine neue Sitzung, um weiterzuarbeiten.",
     "description": "Read-only replay notice"
   },
+  "history.running": {
+    "message": "Läuft",
+    "description": "Marks a history conversation that is currently live on the device"
+  },
   "history.resumeHint": {
     "message": "Eine Nachricht setzt diese Konversation auf dem Gerät fort.",
     "description": "Resume composer hint"

--- a/src/i18n/el/codingBridge.json
+++ b/src/i18n/el/codingBridge.json
@@ -231,6 +231,10 @@
     "message": "Αυτή η συνομιλία Codex είναι μόνο για ανάγνωση και δεν μπορεί να συνεχιστεί. Ξεκινήστε νέα συνεδρία για να συνεχίσετε.",
     "description": "Read-only replay notice"
   },
+  "history.running": {
+    "message": "Σε εκτέλεση",
+    "description": "Marks a history conversation that is currently live on the device"
+  },
   "history.resumeHint": {
     "message": "Η αποστολή μηνύματος θα συνεχίσει αυτή τη συνομιλία στη συσκευή.",
     "description": "Resume composer hint"

--- a/src/i18n/en/codingBridge.json
+++ b/src/i18n/en/codingBridge.json
@@ -231,6 +231,10 @@
     "message": "This Codex conversation is read-only and cannot be continued. Start a new session to keep coding.",
     "description": "Read-only replay notice"
   },
+  "history.running": {
+    "message": "Running",
+    "description": "Marks a history conversation that is currently live on the device"
+  },
   "history.resumeHint": {
     "message": "Sending a message will resume this conversation on the device.",
     "description": "Resume composer hint"

--- a/src/i18n/es/codingBridge.json
+++ b/src/i18n/es/codingBridge.json
@@ -231,6 +231,10 @@
     "message": "Esta conversación de Codex es de solo lectura y no se puede continuar. Inicia una nueva sesión para seguir programando.",
     "description": "Read-only replay notice"
   },
+  "history.running": {
+    "message": "En ejecución",
+    "description": "Marks a history conversation that is currently live on the device"
+  },
   "history.resumeHint": {
     "message": "Enviar un mensaje reanudará esta conversación en el dispositivo.",
     "description": "Resume composer hint"

--- a/src/i18n/fi/codingBridge.json
+++ b/src/i18n/fi/codingBridge.json
@@ -231,6 +231,10 @@
     "message": "Tämä Codex-keskustelu on vain luettavissa, eikä sitä voi jatkaa. Aloita uusi istunto jatkaaksesi koodausta.",
     "description": "Read-only replay notice"
   },
+  "history.running": {
+    "message": "Käynnissä",
+    "description": "Marks a history conversation that is currently live on the device"
+  },
   "history.resumeHint": {
     "message": "Viestin lähettäminen jatkaa tätä keskustelua laitteella.",
     "description": "Resume composer hint"

--- a/src/i18n/fr/codingBridge.json
+++ b/src/i18n/fr/codingBridge.json
@@ -231,6 +231,10 @@
     "message": "Cette conversation Codex est en lecture seule et ne peut pas être poursuivie. Démarrez une nouvelle session pour continuer à coder.",
     "description": "Read-only replay notice"
   },
+  "history.running": {
+    "message": "En cours",
+    "description": "Marks a history conversation that is currently live on the device"
+  },
   "history.resumeHint": {
     "message": "Envoyer un message reprendra cette conversation sur l’appareil.",
     "description": "Resume composer hint"

--- a/src/i18n/it/codingBridge.json
+++ b/src/i18n/it/codingBridge.json
@@ -231,6 +231,10 @@
     "message": "Questa conversazione Codex è di sola lettura e non può essere continuata. Avvia una nuova sessione per continuare a programmare.",
     "description": "Read-only replay notice"
   },
+  "history.running": {
+    "message": "In esecuzione",
+    "description": "Marks a history conversation that is currently live on the device"
+  },
   "history.resumeHint": {
     "message": "L’invio di un messaggio riprenderà questa conversazione sul dispositivo.",
     "description": "Resume composer hint"

--- a/src/i18n/ja/codingBridge.json
+++ b/src/i18n/ja/codingBridge.json
@@ -231,6 +231,10 @@
     "message": "この Codex の会話は読み取り専用で続行できません。コーディングを続けるには新しいセッションを開始してください。",
     "description": "Read-only replay notice"
   },
+  "history.running": {
+    "message": "実行中",
+    "description": "Marks a history conversation that is currently live on the device"
+  },
   "history.resumeHint": {
     "message": "メッセージを送信すると、デバイス上でこの会話が再開されます。",
     "description": "Resume composer hint"

--- a/src/i18n/ko/codingBridge.json
+++ b/src/i18n/ko/codingBridge.json
@@ -231,6 +231,10 @@
     "message": "이 Codex 대화는 읽기 전용이라 이어갈 수 없습니다. 계속 코딩하려면 새 세션을 시작하세요.",
     "description": "Read-only replay notice"
   },
+  "history.running": {
+    "message": "실행 중",
+    "description": "Marks a history conversation that is currently live on the device"
+  },
   "history.resumeHint": {
     "message": "메시지를 보내면 기기에서 이 대화가 다시 시작됩니다.",
     "description": "Resume composer hint"

--- a/src/i18n/pl/codingBridge.json
+++ b/src/i18n/pl/codingBridge.json
@@ -231,6 +231,10 @@
     "message": "Ta rozmowa Codex jest tylko do odczytu i nie można jej kontynuować. Rozpocznij nową sesję, aby kontynuować kodowanie.",
     "description": "Read-only replay notice"
   },
+  "history.running": {
+    "message": "Działa",
+    "description": "Marks a history conversation that is currently live on the device"
+  },
   "history.resumeHint": {
     "message": "Wysłanie wiadomości wznowi tę rozmowę na urządzeniu.",
     "description": "Resume composer hint"

--- a/src/i18n/pt/codingBridge.json
+++ b/src/i18n/pt/codingBridge.json
@@ -231,6 +231,10 @@
     "message": "Esta conversa do Codex é somente leitura e não pode ser continuada. Inicie uma nova sessão para continuar programando.",
     "description": "Read-only replay notice"
   },
+  "history.running": {
+    "message": "Em execução",
+    "description": "Marks a history conversation that is currently live on the device"
+  },
   "history.resumeHint": {
     "message": "Enviar uma mensagem retomará esta conversa no dispositivo.",
     "description": "Resume composer hint"

--- a/src/i18n/ru/codingBridge.json
+++ b/src/i18n/ru/codingBridge.json
@@ -231,6 +231,10 @@
     "message": "Этот разговор Codex доступен только для чтения и не может быть продолжен. Начните новую сессию, чтобы продолжить программировать.",
     "description": "Read-only replay notice"
   },
+  "history.running": {
+    "message": "Выполняется",
+    "description": "Marks a history conversation that is currently live on the device"
+  },
   "history.resumeHint": {
     "message": "Отправка сообщения возобновит этот разговор на устройстве.",
     "description": "Resume composer hint"

--- a/src/i18n/sr/codingBridge.json
+++ b/src/i18n/sr/codingBridge.json
@@ -231,6 +231,10 @@
     "message": "Овај Codex разговор је само за читање и не може се наставити. Покрените нову сесију да наставите са кодирањем.",
     "description": "Read-only replay notice"
   },
+  "history.running": {
+    "message": "У току",
+    "description": "Marks a history conversation that is currently live on the device"
+  },
   "history.resumeHint": {
     "message": "Слање поруке ће наставити овај разговор на уређају.",
     "description": "Resume composer hint"

--- a/src/i18n/sv/codingBridge.json
+++ b/src/i18n/sv/codingBridge.json
@@ -231,6 +231,10 @@
     "message": "Den här Codex-konversationen är skrivskyddad och kan inte fortsättas. Starta en ny session för att fortsätta koda.",
     "description": "Read-only replay notice"
   },
+  "history.running": {
+    "message": "Körs",
+    "description": "Marks a history conversation that is currently live on the device"
+  },
   "history.resumeHint": {
     "message": "Att skicka ett meddelande återupptar konversationen på enheten.",
     "description": "Resume composer hint"

--- a/src/i18n/uk/codingBridge.json
+++ b/src/i18n/uk/codingBridge.json
@@ -231,6 +231,10 @@
     "message": "Ця розмова Codex доступна лише для читання й не може бути продовжена. Почніть нову сесію, щоб продовжити програмувати.",
     "description": "Read-only replay notice"
   },
+  "history.running": {
+    "message": "Виконується",
+    "description": "Marks a history conversation that is currently live on the device"
+  },
   "history.resumeHint": {
     "message": "Надсилання повідомлення відновить цю розмову на пристрої.",
     "description": "Resume composer hint"

--- a/src/i18n/zh-CN/codingBridge.json
+++ b/src/i18n/zh-CN/codingBridge.json
@@ -231,6 +231,10 @@
     "message": "此 Codex 会话为只读，无法继续。开始新会话以继续编码。",
     "description": "只读回放提示"
   },
+  "history.running": {
+    "message": "运行中",
+    "description": "历史会话当前正在设备上运行的标记"
+  },
   "history.resumeHint": {
     "message": "发送消息将在设备上续接此会话。",
     "description": "续接输入框提示"

--- a/src/i18n/zh-TW/codingBridge.json
+++ b/src/i18n/zh-TW/codingBridge.json
@@ -231,6 +231,10 @@
     "message": "此 Codex 會話為唯讀，無法繼續。開始新會話以繼續編碼。",
     "description": "Read-only replay notice"
   },
+  "history.running": {
+    "message": "執行中",
+    "description": "Marks a history conversation that is currently live on the device"
+  },
   "history.resumeHint": {
     "message": "傳送訊息將在裝置上接續此會話。",
     "description": "Resume composer hint"

--- a/src/models/codingBridge.ts
+++ b/src/models/codingBridge.ts
@@ -91,11 +91,9 @@ export interface ICodingBridgeSession {
   cost_usd?: number;
   // Which backend this session targets; defaults to Claude Code.
   provider?: ICodingBridgeHistoryProvider;
-  // Provider session id to resume when the first prompt is sent (Claude only).
-  resume_session_id?: string;
-  // The SDK/CLI's own session id for a live session, reported by the node on
-  // each turn's result. The fork target when editing a past prompt.
-  sdk_session_id?: string;
+  // `session_id` IS the canonical identity. A new session opens under a
+  // provisional id and is re-keyed to the provider's real (SDK/transcript) id on
+  // `session.identified`, so the same id resumes it and matches its history entry.
   // A live turn has been started on the node for this session.
   started?: boolean;
   // Replay of past history that cannot be continued (e.g. Codex).
@@ -114,6 +112,9 @@ export interface ICodingBridgeHistorySummary {
   git_branch?: string;
   updated_at?: number;
   message_count?: number;
+  // True when this transcript is a session live on the node right now, so the
+  // drawer can flag it and opening it reattaches instead of replaying a copy.
+  running?: boolean;
 }
 
 /** A normalised transcript returned by `history.get`. */

--- a/src/store/codingBridge/actions.identity.test.ts
+++ b/src/store/codingBridge/actions.identity.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+//
+// Integration tests for the session-identity flow: they drive the REAL reducer
+// (`applyNodeEvent` + the actual mutations) with the exact node→browser event
+// streams the daemon emits, asserting the store ends in the right state for each
+// of the four restore bugs this change fixes.
+import { describe, expect, it, vi } from 'vitest';
+import createState from './state';
+import mutations from './mutations';
+import type { ICodingBridgeState } from './models';
+
+// `actions.ts` pulls in the notification helper, which dynamically imports a
+// Capacitor native module that isn't resolvable in the test env. None of these
+// tests exercise the permission/notification path, so stub it out.
+vi.mock('@/utils/codingBridgeNotify', () => ({
+  notifyPermissionLocally: () => {},
+  subscribeWebPush: async () => null,
+  unsubscribeWebPush: async () => null,
+  registerNativePush: async () => null,
+  requestWebPermission: async () => 'granted'
+}));
+
+const { applyNodeEvent } = await import('./actions');
+
+const NODE = 'node-1';
+
+// A harness whose `commit` applies the real named mutation to real state, so the
+// test exercises production reducer logic end to end. `dispatch` is recorded.
+const harness = () => {
+  const state: ICodingBridgeState = createState();
+  const dispatched: Array<{ type: string; payload: unknown }> = [];
+  const commit = (type: string, payload?: unknown): void => {
+    const fn = (mutations as Record<string, (s: ICodingBridgeState, p: unknown) => void>)[type];
+    if (!fn) {
+      throw new Error(`unknown mutation: ${type}`);
+    }
+    fn(state, payload);
+  };
+  const dispatch = (type: string, payload?: unknown): void => {
+    dispatched.push({ type, payload });
+  };
+  const feed = (payload: Record<string, unknown>): void =>
+    applyNodeEvent(commit as never, dispatch as never, state, payload, NODE);
+  return { state, dispatched, feed };
+};
+
+describe('coding bridge session identity (integration)', () => {
+  it('re-keys to the real id mid-turn while keeping running status and live stream', () => {
+    const h = harness();
+    // A brand-new session opens under a provisional id and starts streaming...
+    h.feed({ event: 'session.started', session_id: 'prov', cwd: '/repo', model: 'opus' });
+    h.feed({ event: 'session.text_delta', session_id: 'prov', id: 'st1', text: 'Hel' });
+    // ...then the node announces the provider's real id.
+    h.feed({ event: 'session.identified', session_id: 'prov', sdk_session_id: 'real-1' });
+
+    // Bug #1/#4: one identity. The provisional entry is gone; everything moved.
+    expect(h.state.sessions['prov']).toBeUndefined();
+    expect(h.state.sessions['real-1'].session_id).toBe('real-1');
+    expect(h.state.currentSessionId).toBeUndefined(); // started() doesn't select; sendPrompt does
+    // Bug #2: still running → the Stop button stays.
+    expect(h.state.sessions['real-1'].status).toBe('running');
+    // Bug #3: the streaming bubble survived the rename and is still open.
+    expect(h.state.events['real-1'][0].text).toBe('Hel');
+    expect(h.state.events['real-1'][0].streaming).toBe(true);
+  });
+
+  it('reattaches to a live session on restore after a reload (Stop + typewriter kept)', () => {
+    const h = harness();
+    // After a reload the store is empty; requestSessions → sessions.snapshot tells
+    // us this session is running on the node right now.
+    h.feed({ event: 'sessions.snapshot', sessions: [{ session_id: 'real-1', status: 'running' }] });
+    expect(h.state.sessions['real-1'].started).toBe(true);
+    expect(h.state.sessions['real-1'].status).toBe('running');
+
+    // Opening it from history must reattach, NOT overwrite to idle.
+    h.feed({
+      event: 'history.detail',
+      session_id: 'real-1',
+      provider: 'claude',
+      events: [
+        { kind: 'prompt', text: 'do the thing' },
+        { kind: 'text', text: 'working...' }
+      ]
+    });
+    // Bug #2/#3: running preserved → Stop button + thinking indicator stay.
+    expect(h.state.sessions['real-1'].status).toBe('running');
+    expect(h.state.sessions['real-1'].started).toBe(true);
+    expect(h.state.sessions['real-1'].readonly).not.toBe(true);
+    // The transcript fills the past; later live deltas (higher seq) append on top.
+    expect(h.state.events['real-1'].map((e) => e.kind)).toEqual(['prompt', 'text']);
+    expect(h.state.currentSessionId).toBe('real-1');
+  });
+
+  it('does not clobber a live transcript we are already watching', () => {
+    const h = harness();
+    h.feed({ event: 'session.started', session_id: 'real-2' });
+    h.feed({ event: 'session.text_delta', session_id: 'real-2', id: 's', text: 'live output' });
+    // A late history.detail for the same id must keep the in-flight transcript.
+    h.feed({
+      event: 'history.detail',
+      session_id: 'real-2',
+      provider: 'claude',
+      events: [{ kind: 'prompt', text: 'stale' }]
+    });
+    expect(h.state.events['real-2'][0].text).toBe('live output');
+  });
+
+  it('restores a dead transcript as a resumable idle session', () => {
+    const h = harness();
+    h.feed({
+      event: 'history.detail',
+      session_id: 'old-session',
+      provider: 'claude',
+      events: [{ kind: 'prompt', text: 'past chat' }]
+    });
+    // No live session → idle, resumable (claude), selected for viewing.
+    expect(h.state.sessions['old-session'].status).toBe('idle');
+    expect(h.state.sessions['old-session'].started).toBe(false);
+    expect(h.state.sessions['old-session'].readonly).toBe(false);
+    expect(h.state.currentSessionId).toBe('old-session');
+    expect(h.state.events['old-session']).toHaveLength(1);
+  });
+
+  it('marks a Codex history replay read-only', () => {
+    const h = harness();
+    h.feed({ event: 'history.detail', session_id: 'cx', provider: 'codex', events: [] });
+    expect(h.state.sessions['cx'].readonly).toBe(true);
+  });
+});

--- a/src/store/codingBridge/actions.ts
+++ b/src/store/codingBridge/actions.ts
@@ -123,8 +123,9 @@ const notifyForPermission = (
   );
 };
 
-// Translate one inner node event into the matching mutation(s).
-const applyNodeEvent = (
+// Translate one inner node event into the matching mutation(s). Exported for
+// integration tests that drive the real reducer with node-shaped event streams.
+export const applyNodeEvent = (
   commit: ActionContext<ICodingBridgeState, IRootState>['commit'],
   dispatch: ActionContext<ICodingBridgeState, IRootState>['dispatch'],
   state: ICodingBridgeState,

--- a/src/store/codingBridge/actions.ts
+++ b/src/store/codingBridge/actions.ts
@@ -27,11 +27,13 @@ import {
   CB_ACTION_SESSION_CLOSE,
   CB_ACTION_PERMISSION_RESOLVE,
   CB_ACTION_PERMISSIONS_LIST,
+  CB_ACTION_SESSIONS_LIST,
   CB_ACTION_HISTORY_LIST,
   CB_ACTION_HISTORY_GET,
   CB_ACTION_FS_LIST,
   CB_ACTION_CAPABILITIES_GET,
   CB_EVENT_SESSION_STARTED,
+  CB_EVENT_SESSION_IDENTIFIED,
   CB_EVENT_SESSION_TEXT,
   CB_EVENT_SESSION_TEXT_DELTA,
   CB_EVENT_SESSION_THINKING,
@@ -167,6 +169,17 @@ const applyNodeEvent = (
         trace_id: traceId
       });
       break;
+    case CB_EVENT_SESSION_IDENTIFIED: {
+      // The node learned the provider's real session id: re-key this session
+      // from the provisional id it opened with to the canonical one, so the live
+      // session and its history entry share one identity (and a later resume
+      // reattaches instead of forking a parallel session).
+      const realId = payload.sdk_session_id;
+      if (sessionId && realId && realId !== sessionId) {
+        commit('renameSession', { from: sessionId, to: realId });
+      }
+      break;
+    }
     case CB_EVENT_SESSION_TEXT_DELTA: {
       // Streaming chunk: grow the open bubble for this stream id, or open a
       // new streaming bubble if this is the first delta seen for it.
@@ -285,9 +298,7 @@ const applyNodeEvent = (
       commit('updateSession', {
         session_id: sessionId,
         status: 'idle',
-        cost_usd: payload.cost_usd,
-        // Keep the live SDK session id current so an edit can fork from it.
-        ...(payload.sdk_session_id ? { sdk_session_id: payload.sdk_session_id } : {})
+        cost_usd: payload.cost_usd
       });
       break;
     case CB_EVENT_SESSION_NOTICE:
@@ -331,13 +342,20 @@ const applyNodeEvent = (
       dispatch('resyncSession', sessionId);
       break;
     case CB_EVENT_SESSIONS_SNAPSHOT:
+      // Live sessions the node is running right now (keyed by their real id).
+      // Mark them started so a follow-up sends rather than re-starts, and so
+      // opening their history entry reattaches with the running state intact —
+      // this is how a reload recovers the Stop button and the typewriter.
       for (const item of payload.sessions ?? []) {
         commit('upsertSession', {
           session_id: item.session_id,
           node_id: fromNode,
-          status: item.status ?? 'idle',
+          status: item.status ?? 'running',
+          started: true,
           cwd: item.cwd,
-          model: item.model
+          model: item.model,
+          ...(item.effort !== undefined ? { effort: item.effort } : {}),
+          ...(item.permission_mode !== undefined ? { permission_mode: item.permission_mode } : {})
         });
       }
       break;
@@ -380,7 +398,12 @@ const applyNodeEvent = (
   }
 };
 
-// Materialise a replayed transcript as a (resumable) session.
+// Open a history transcript, reconciling it against any live session of the
+// same id. The node now keys live sessions by their real (SDK) id — exactly the
+// id history lists them under — so a transcript that is still running on the
+// node is reattached (its running status, seq cursor and in-flight stream kept
+// intact) instead of being overwritten by a static, idle copy. A dead transcript
+// materialises as a resumable idle session as before.
 const applyHistoryDetail = (
   commit: ActionContext<ICodingBridgeState, IRootState>['commit'],
   state: ICodingBridgeState,
@@ -393,41 +416,49 @@ const applyHistoryDetail = (
     return;
   }
   const resumable = provider === 'claude';
-  // Reasoning effort and permission/edit mode are NOT in the on-disk transcript,
-  // so the node restores them from the per-session sidecar it saved while the
-  // session ran (authoritative, works across devices) and sends them back on the
-  // history detail. Fall back to this device's last composer setup only when the
-  // sidecar is absent (e.g. a session that predates it) so we never reset to
-  // defaults. cwd/model come from the transcript, sidecar-backfilled by the node.
+  const live = state.sessions[sessionId];
+  // "Live" = a session the node is currently running (surfaced via the sessions
+  // snapshot) or one already mid-turn in this tab. Such a session keeps the Stop
+  // button and the typewriter; clobbering it to idle is the restore bug.
+  const isLive = !!live && (live.started === true || live.status === 'running' || live.status === 'starting');
+  // Effort/permission-mode aren't in the transcript; the node backfills them from
+  // its per-session sidecar. Fall back to a live value, then this device's last
+  // composer setup, so a restore never silently resets to defaults.
   const prefs = state.lastComposer?.[fromNode] ?? {};
   commit('upsertSession', {
     session_id: sessionId,
     node_id: fromNode,
-    status: 'idle',
-    cwd: payload.cwd ?? prefs.cwd,
-    model: payload.model ?? prefs.model,
-    effort: payload.effort ?? prefs.effort,
-    permission_mode: payload.permission_mode ?? prefs.permissionMode,
+    status: isLive ? live!.status : 'idle',
+    cwd: payload.cwd ?? live?.cwd ?? prefs.cwd,
+    model: payload.model ?? live?.model ?? prefs.model,
+    effort: payload.effort ?? live?.effort ?? prefs.effort,
+    permission_mode: payload.permission_mode ?? live?.permission_mode ?? prefs.permissionMode,
     provider,
-    started: false,
-    readonly: !resumable,
-    resume_session_id: resumable ? sessionId : undefined
+    started: isLive ? true : false,
+    readonly: !resumable && !isLive
   });
-  const events: ICodingBridgeEvent[] = (payload.events ?? []).map((item: any, index: number) => ({
-    id: uid(),
-    session_id: sessionId,
-    kind: item.kind as ICodingBridgeEventKind,
-    ts: typeof item.ts === 'number' ? item.ts : Date.now() + index,
-    text: item.text,
-    tool: item.tool,
-    tool_use_id: item.tool_use_id,
-    input: item.input,
-    content: item.content,
-    is_error: item.is_error,
-    subtype: item.subtype,
-    cost_usd: item.cost_usd
-  }));
-  commit('setEvents', { session_id: sessionId, events });
+  // Only lay down the static transcript when we don't already hold a richer live
+  // one: a session we're actively watching keeps its streamed events; a live
+  // session we only just learned about (e.g. after a reload) gets the transcript
+  // as its base, with later live deltas (higher seq) appending on top.
+  const haveLiveEvents = isLive && (state.events[sessionId]?.length ?? 0) > 0;
+  if (!haveLiveEvents) {
+    const events: ICodingBridgeEvent[] = (payload.events ?? []).map((item: any, index: number) => ({
+      id: uid(),
+      session_id: sessionId,
+      kind: item.kind as ICodingBridgeEventKind,
+      ts: typeof item.ts === 'number' ? item.ts : Date.now() + index,
+      text: item.text,
+      tool: item.tool,
+      tool_use_id: item.tool_use_id,
+      input: item.input,
+      content: item.content,
+      is_error: item.is_error,
+      subtype: item.subtype,
+      cost_usd: item.cost_usd
+    }));
+    commit('setEvents', { session_id: sessionId, events });
+  }
   commit('setCurrentNode', fromNode);
   commit('setCurrentSession', sessionId);
   commit('setHistoryRef', { node_id: fromNode, provider, session_id: sessionId });
@@ -536,6 +567,10 @@ export const connect = ({
       if (state.currentNodeId) {
         dispatch('getHistory', state.currentNodeId);
         dispatch('getCapabilities', state.currentNodeId);
+        // Re-learn which sessions are running right now, so a reload recovers a
+        // live session's status (Stop button, typewriter) instead of treating
+        // every conversation as idle history.
+        dispatch('requestSessions', state.currentNodeId);
         // Re-fetch any consent prompt raised while we were disconnected.
         dispatch('requestPendingPermissions', state.currentNodeId);
       }
@@ -552,6 +587,7 @@ export const connect = ({
       if (status === 'online' && nodeId === state.currentNodeId) {
         dispatch('getHistory', nodeId);
         dispatch('getCapabilities', nodeId);
+        dispatch('requestSessions', nodeId);
         dispatch('requestPendingPermissions', nodeId);
       }
     },
@@ -581,7 +617,19 @@ export const selectNode = (
   commit('setCurrentSession', ids.length ? ids[ids.length - 1] : undefined);
   dispatch('getHistory', nodeId);
   dispatch('getCapabilities', nodeId);
+  dispatch('requestSessions', nodeId);
   dispatch('requestPendingPermissions', nodeId);
+};
+
+// Ask a node which sessions it is running right now (sessions.list). The reply
+// (sessions.snapshot) re-establishes live sessions — with their running status —
+// after a reload or reconnect, so the UI reattaches rather than showing history.
+export const requestSessions = ({ state }: ActionContext<ICodingBridgeState, IRootState>, nodeId?: string): void => {
+  const target = nodeId ?? state.currentNodeId;
+  if (!target || !socket) {
+    return;
+  }
+  socket.sendToNode(target, { action: CB_ACTION_SESSIONS_LIST });
 };
 
 // Ask a node to re-emit every outstanding permission prompt (permissions.list).
@@ -680,7 +728,10 @@ export const sendPrompt = (
       effort: payload.effort || undefined,
       images,
       attachments,
-      resume_session_id: existing?.resume_session_id || undefined
+      // Resuming a restored conversation: its id IS the provider's real session
+      // id, so the node resumes that transcript (or reattaches if it's still
+      // live). A brand-new session has no existing entry and so no resume target.
+      resume_session_id: existing?.session_id || undefined
     });
   } else {
     commit('updateSession', { session_id: sessionId as string, trace_id: traceId });
@@ -1030,6 +1081,7 @@ export default {
   connect,
   disconnect,
   selectNode,
+  requestSessions,
   requestPendingPermissions,
   enableNotifications,
   disableNotifications,

--- a/src/store/codingBridge/mutations.test.ts
+++ b/src/store/codingBridge/mutations.test.ts
@@ -6,11 +6,20 @@ import {
   appendEvent,
   finalizeAllStreams,
   finalizeStream,
+  renameSession,
   rewindToCut,
   setLastSeq,
-  truncateEventsBefore
+  truncateEventsBefore,
+  upsertSession
 } from './mutations';
-import type { ICodingBridgeEvent } from '@/models';
+import type { ICodingBridgeEvent, ICodingBridgeSession } from '@/models';
+
+const session = (overrides: Partial<ICodingBridgeSession> = {}): ICodingBridgeSession => ({
+  session_id: 's1',
+  node_id: 'n1',
+  status: 'running',
+  ...overrides
+});
 
 const textEvent = (overrides: Partial<ICodingBridgeEvent> = {}): ICodingBridgeEvent => ({
   id: 'e1',
@@ -118,5 +127,50 @@ describe('coding bridge reliable-delivery mutations', () => {
     expect(state.lastSeq['s1']).toBe(5);
     setLastSeq(state, { session_id: 's1', seq: 9 });
     expect(state.lastSeq['s1']).toBe(9);
+  });
+});
+
+describe('coding bridge session identity (renameSession)', () => {
+  it('migrates session, transcript, cursor, selection and history pointer', () => {
+    const state = createState();
+    upsertSession(state, session({ session_id: 'prov', status: 'running', started: true }));
+    appendEvent(state, textEvent({ id: 'a', session_id: 'prov', text: 'hi' }));
+    setLastSeq(state, { session_id: 'prov', seq: 7 });
+    state.currentSessionId = 'prov';
+    state.historyRef = { node_id: 'n1', provider: 'claude', session_id: 'prov' };
+
+    renameSession(state, { from: 'prov', to: 'real' });
+
+    expect(state.sessions['prov']).toBeUndefined();
+    expect(state.sessions['real'].session_id).toBe('real');
+    expect(state.sessions['real'].status).toBe('running');
+    expect(state.events['prov']).toBeUndefined();
+    expect(state.events['real'].map((e) => e.id)).toEqual(['a']);
+    expect(state.lastSeq['real']).toBe(7);
+    expect(state.lastSeq['prov']).toBeUndefined();
+    expect(state.currentSessionId).toBe('real');
+    expect(state.historyRef?.session_id).toBe('real');
+  });
+
+  it('keeps the live transcript when merging into a pre-existing snapshot stub', () => {
+    const state = createState();
+    // A snapshot stub already exists under the real id (no events yet)...
+    upsertSession(state, session({ session_id: 'real', status: 'running', started: true }));
+    // ...and the live, provisionally-keyed session holds the streamed transcript.
+    upsertSession(state, session({ session_id: 'prov', model: 'opus' }));
+    appendEvent(state, textEvent({ id: 'live', session_id: 'prov', text: 'streamed' }));
+
+    renameSession(state, { from: 'prov', to: 'real' });
+
+    expect(state.sessions['real'].model).toBe('opus');
+    expect(state.events['real'].map((e) => e.id)).toEqual(['live']);
+  });
+
+  it('is a no-op when ids match or the source is missing', () => {
+    const state = createState();
+    upsertSession(state, session({ session_id: 's1' }));
+    renameSession(state, { from: 's1', to: 's1' });
+    renameSession(state, { from: 'ghost', to: 'x' });
+    expect(Object.keys(state.sessions)).toEqual(['s1']);
   });
 });

--- a/src/store/codingBridge/mutations.ts
+++ b/src/store/codingBridge/mutations.ts
@@ -79,6 +79,41 @@ export const updateSession = (
   }
 };
 
+// Re-key a session from its provisional id to the provider's real (SDK) id once
+// the node reports it (`session.identified`). Migrates everything indexed by
+// session id so the live session and its history entry share one identity. The
+// live session's fields win when merging into a pre-existing entry under `to`
+// (e.g. a snapshot stub); its transcript is only carried over when non-empty so
+// a reattach never blows away events already loaded under the real id.
+export const renameSession = (state: ICodingBridgeState, payload: { from: string; to: string }): void => {
+  const { from, to } = payload;
+  if (from === to || !state.sessions[from]) {
+    return;
+  }
+  state.sessions[to] = { ...state.sessions[to], ...state.sessions[from], session_id: to };
+  delete state.sessions[from];
+  const moving = state.events[from];
+  if (moving && (moving.length || !state.events[to]?.length)) {
+    state.events[to] = moving;
+  }
+  delete state.events[from];
+  if (state.lastSeq[from] !== undefined) {
+    state.lastSeq[to] = Math.max(state.lastSeq[to] ?? 0, state.lastSeq[from]);
+    delete state.lastSeq[from];
+  }
+  for (const request of state.permissions) {
+    if (request.session_id === from) {
+      request.session_id = to;
+    }
+  }
+  if (state.currentSessionId === from) {
+    state.currentSessionId = to;
+  }
+  if (state.historyRef?.session_id === from) {
+    state.historyRef = { ...state.historyRef, session_id: to };
+  }
+};
+
 export const appendEvent = (state: ICodingBridgeState, payload: ICodingBridgeEvent): void => {
   if (!state.events[payload.session_id]) {
     state.events[payload.session_id] = [];
@@ -264,6 +299,7 @@ export default {
   setCurrentSession,
   upsertSession,
   updateSession,
+  renameSession,
   appendEvent,
   truncateEventsBefore,
   rewindToCut,


### PR DESCRIPTION
Browser half of the Coding Bridge **session-identity unification**. Node half: AceDataCloud/CodingBridgeAgent#27 (merged).

## Problem

A coding session had **two ids that never reconciled** — the provisional id the browser minted for the live session, and the provider's real on-disk transcript id used in 历史会话. Restoring a conversation therefore:
1. **leaked follow-ups into another session** (resume spawned a parallel client over the same transcript),
2. **lost the Stop button** (restore hard-coded `status: 'idle'`),
3. **lost the typewriter/loading effect** (same idle override + no live re-subscribe),
4. **dropped state** generally.

## Fix — one canonical identity

`session_id` IS the provider's real id end-to-end:

- **`renameSession` mutation** — on `session.identified` the store re-keys the session from its provisional id to the real (SDK) id, migrating session + transcript + seq cursor + permissions + current selection + history pointer together.
- **Restore reconciliation** (`applyHistoryDetail`) — opening a history conversation that is **live on the node reattaches** to it (running status, Stop button, seq cursor, in-flight stream all kept) instead of overwriting it with a static idle copy. Dead transcripts replay as resumable idle, as before.
- **`requestSessions`** — `connect` / node-online / `selectNode` now ask for `sessions.list`, so a reload re-learns which sessions are running and recovers their live state (snapshot sessions are marked `started`).
- **Resume targets the canonical id** — a follow-up on a restored conversation continues the same transcript instead of forking a new one.
- History drawer shows a **"running" dot** for sessions live on the node.

Collapses the redundant `resume_session_id` / `sdk_session_id` session fields into the single `session_id`. No backward-compat — the feature isn't live yet.

## Tests

- `vue-tsc --noEmit` clean, `eslint` clean, `vitest` green (15 passed).
- New `renameSession` tests: full migration, live-transcript-wins-on-merge, no-op guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)