### PR TITLE
chore(ci): default build-ios auto_submit_review to false

### DIFF
--- a/.github/workflows/build-ios.yaml
+++ b/.github/workflows/build-ios.yaml
@@ -19,7 +19,7 @@ on:
       auto_submit_review:
         description: 'After upload, attach the build to an App Store version and submit it for App Review.'
         required: false
-        default: true
+        default: false
         type: boolean
 
 permissions:

--- a/change/build-ios-no-auto-submit.json
+++ b/change/build-ios-no-auto-submit.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(ci): default build-ios auto_submit_review to false",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "none"
+}


### PR DESCRIPTION
Make a manual `build-ios` dispatch default to **TestFlight-only** — no longer auto-submits to Apple App Review unless you explicitly set `auto_submit_review=true`.

- `workflow_dispatch` input `auto_submit_review`: default `true` → `false`.
- Tag-push releases unchanged (that path doesn't read the dispatch input).
- Note: `auto_distribute_external` (TestFlight Open-testing) and Android `promote_to_production` defaults are still `true` — say the word to flip those too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)