### PR TITLE
chore(ci): default build-android promote_to_production to false

### DIFF
--- a/.github/workflows/build-android.yaml
+++ b/.github/workflows/build-android.yaml
@@ -19,7 +19,7 @@ on:
       promote_to_production:
         description: 'Auto-promote the same versionCode to Production after the initial upload succeeds.'
         required: false
-        default: true
+        default: false
         type: boolean
       rollout_percent:
         description: 'Production staged rollout fraction (0.0–1.0). 1.0 = full release.'

--- a/change/build-android-no-auto-prod.json
+++ b/change/build-android-no-auto-prod.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore(ci): default build-android promote_to_production to false",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "none"
+}


### PR DESCRIPTION
Mirror of #939 for Android: a manual `build-android` dispatch defaults to the **test track only** (beta/Open testing) and no longer auto-promotes to **Production** unless you set `promote_to_production=true`.

- `workflow_dispatch` input `promote_to_production`: default `true` → `false`.
- Tag-push releases unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)