### PR TITLE
style(nexior): make empty-state magic-wand button smaller (48px → 40px)

### DIFF
--- a/change/@acedatacloud-nexior-2aefe63f-fb21-48e8-b520-e3fdbe175a64.json
+++ b/change/@acedatacloud-nexior-2aefe63f-fb21-48e8-b520-e3fdbe175a64.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "style(nexior): make the empty-state magic-wand button a bit smaller (48px -> 40px)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/NoTasks.vue
+++ b/src/components/common/NoTasks.vue
@@ -2,11 +2,11 @@
   <div class="text-center text-[var(--el-text-color-secondary)] py-10">
     <button
       type="button"
-      class="no-tasks-btn inline-flex items-center justify-center w-12 h-12 rounded-full border border-[var(--el-color-primary-light-5)] bg-[var(--el-color-primary-light-9)] text-[var(--el-color-primary)] cursor-pointer transition duration-200 hover:bg-[var(--el-color-primary-light-7)] hover:scale-105 active:scale-95"
+      class="no-tasks-btn inline-flex items-center justify-center w-10 h-10 rounded-full border border-[var(--el-color-primary-light-5)] bg-[var(--el-color-primary-light-9)] text-[var(--el-color-primary)] cursor-pointer transition duration-200 hover:bg-[var(--el-color-primary-light-7)] hover:scale-105 active:scale-95"
       :aria-label="$t('common.message.noTasks')"
       @click="onClick"
     >
-      <font-awesome-icon icon="fa-solid fa-magic" class="text-xl" />
+      <font-awesome-icon icon="fa-solid fa-magic" class="text-base" />
     </button>
     <p class="mt-4 text-sm">{{ $t('common.message.noTasks') }}</p>
   </div>


### PR DESCRIPTION
Follow-up to #922 / #935. Shrinks the centered empty-state magic-wand button a bit more per request:

- Button: `w-12 h-12` (48px) → `w-10 h-10` (40px)
- Icon: `text-xl` → `text-base`

Behavior unchanged (tap still opens the config drawer on mobile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)