### PR TITLE
feat(kling): Talking Photo tab (one-click image+audio → talking video)

### DIFF
--- a/change/@acedatacloud-nexior-97b8fd94-851a-48e4-9f22-3c52b42581c8.json
+++ b/change/@acedatacloud-nexior-97b8fd94-851a-48e4-9f22-3c52b42581c8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(kling): Talking Photo tab (one-click image+audio to talking video)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/kling/TabSwitcher.vue
+++ b/src/components/kling/TabSwitcher.vue
@@ -48,6 +48,10 @@ export default defineComponent({
         {
           value: 'motion',
           label: this.$t('kling.tab.motionControl')
+        },
+        {
+          value: 'talking-photo',
+          label: this.$t('kling.tab.talkingPhoto')
         }
       ];
     }

--- a/src/components/kling/TalkingPhotoPanel.vue
+++ b/src/components/kling/TalkingPhotoPanel.vue
@@ -1,0 +1,212 @@
+<template>
+  <div class="flex flex-col h-full">
+    <div class="flex-1 overflow-y-auto p-5">
+      <!-- Portrait image -->
+      <div class="relative mb-4">
+        <div class="flex justify-start items-center">
+          <span class="text-sm font-bold">{{ $t('kling.name.talkingPhotoImage') }}</span>
+          <info-icon :content="$t('kling.description.talkingPhotoImage')" />
+        </div>
+        <el-upload
+          ref="imageUploader"
+          v-model:file-list="imageFiles"
+          name="file"
+          accept=".png,.jpg,.jpeg,.webp,.bmp"
+          :limit="1"
+          class="upload-wrapper"
+          :multiple="false"
+          :action="uploadUrl"
+          list-type="picture"
+          :headers="headers"
+          :on-exceed="onImageExceed"
+          :on-error="onImageError"
+          :on-success="onImageSuccess"
+        >
+          <template #file="{ file }">
+            <image-preview
+              v-if="file.url && file.percentage !== undefined"
+              :url="file.url"
+              :name="file.name"
+              :percentage="file.percentage"
+              @remove="onImageRemove(file)"
+            />
+          </template>
+          <el-button round type="primary" size="small" class="btn btn-upload">
+            <font-awesome-icon icon="fa-solid fa-upload" class="icon mr-1" />
+            {{ $t('kling.button.uploadReferences') }}
+          </el-button>
+        </el-upload>
+      </div>
+
+      <!-- Driving audio -->
+      <div class="relative mb-4">
+        <div class="flex justify-start items-center">
+          <span class="text-sm font-bold">{{ $t('kling.name.talkingPhotoAudio') }}</span>
+          <info-icon :content="$t('kling.description.talkingPhotoAudio')" />
+        </div>
+        <el-upload
+          ref="audioUploader"
+          v-model:file-list="audioFiles"
+          name="file"
+          accept=".mp3,.wav,.m4a,.aac"
+          :limit="1"
+          class="upload-wrapper"
+          :multiple="false"
+          :action="uploadUrl"
+          :headers="headers"
+          :on-exceed="onAudioExceed"
+          :on-error="onAudioError"
+          :on-success="onAudioSuccess"
+          :on-remove="onAudioRemove"
+        >
+          <el-button round type="primary" size="small" class="btn">
+            <font-awesome-icon icon="fa-solid fa-upload" class="icon mr-1" />
+            {{ $t('kling.button.uploadAudio') }}
+          </el-button>
+        </el-upload>
+        <audio v-if="audioUrl" :src="audioUrl" controls class="w-full mt-2" />
+      </div>
+
+      <!-- Optional prompt -->
+      <div class="mb-4">
+        <div class="flex justify-start items-center">
+          <span class="text-sm font-bold">{{ $t('kling.name.talkingPhotoPrompt') }}</span>
+          <info-icon :content="$t('kling.description.talkingPhotoPrompt')" />
+        </div>
+        <el-input
+          :model-value="config.prompt"
+          type="textarea"
+          :rows="2"
+          :placeholder="$t('kling.placeholder.talkingPhotoPrompt')"
+          class="mt-1"
+          @update:model-value="onPromptChange"
+        />
+      </div>
+    </div>
+
+    <div class="flex flex-col items-center justify-center px-5 pb-5">
+      <consumption :value="consumption" :service="service" />
+      <el-button type="primary" class="btn w-full" round :disabled="!canGenerate" @click="onGenerate">
+        <font-awesome-icon icon="fa-solid fa-magic" class="mr-2" />
+        {{ $t('kling.button.generateTalkingPhoto') }}
+      </el-button>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElUpload, ElButton, ElInput, ElMessage, UploadFiles, UploadFile } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import Consumption from '../common/Consumption.vue';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+import ImagePreview from '@/components/common/ImagePreview.vue';
+import { getBaseUrlPlatform, getConsumption, uploadTrackerMixin } from '@/utils';
+import { IKlingTalkingPhotoConfig } from '@/models';
+
+interface IData {
+  imageFiles: UploadFiles;
+  audioFiles: UploadFiles;
+  uploadUrl: string;
+}
+
+export default defineComponent({
+  name: 'TalkingPhotoPanel',
+  components: {
+    ElUpload,
+    ElButton,
+    ElInput,
+    FontAwesomeIcon,
+    Consumption,
+    InfoIcon,
+    ImagePreview
+  },
+  mixins: [uploadTrackerMixin],
+  emits: ['generate'],
+  data(): IData {
+    return {
+      imageFiles: [],
+      audioFiles: [],
+      uploadUrl: getBaseUrlPlatform() + '/api/v1/files/'
+    };
+  },
+  computed: {
+    config(): IKlingTalkingPhotoConfig {
+      return this.$store.state.kling?.talkingPhotoConfig || {};
+    },
+    audioUrl(): string | undefined {
+      return this.config.audio_url;
+    },
+    headers() {
+      return {
+        Authorization: `Bearer ${this.$store.state.token.access}`
+      };
+    },
+    service() {
+      return this.$store.state.kling?.service;
+    },
+    consumption() {
+      return getConsumption({ ...this.config, action: 'talking-photo' }, this.service?.cost);
+    },
+    canGenerate(): boolean {
+      return Boolean(this.config.image_url && this.config.audio_url);
+    }
+  },
+  methods: {
+    commit(patch: Partial<IKlingTalkingPhotoConfig>) {
+      this.$store.commit('kling/setTalkingPhotoConfig', { ...this.config, ...patch });
+    },
+    onPromptChange(value: string) {
+      this.commit({ prompt: value });
+    },
+    onImageExceed() {
+      ElMessage.warning(this.$t('kling.message.uploadReferencesExceed'));
+    },
+    onImageError() {
+      ElMessage.error(this.$t('kling.message.uploadReferencesError'));
+    },
+    onImageSuccess(response: any) {
+      this.commit({ image_url: response?.file_url });
+    },
+    onImageRemove(file: UploadFile) {
+      this.imageFiles.splice(this.imageFiles.indexOf(file), 1);
+      this.commit({ image_url: undefined });
+    },
+    onAudioExceed() {
+      ElMessage.warning(this.$t('kling.message.uploadAudioExceed'));
+    },
+    onAudioError() {
+      ElMessage.error(this.$t('kling.message.uploadAudioError'));
+    },
+    onAudioSuccess(response: any) {
+      this.commit({ audio_url: response?.file_url });
+    },
+    onAudioRemove() {
+      this.commit({ audio_url: undefined });
+    },
+    onGenerate() {
+      this.$emit('generate');
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.btn.btn-upload {
+  position: absolute;
+  top: 5px;
+  right: 0;
+}
+</style>
+
+<style lang="scss">
+.upload-wrapper {
+  height: auto;
+  display: flex;
+  flex-direction: column;
+  .el-upload-list {
+    margin: 0;
+    width: 100%;
+  }
+}
+</style>

--- a/src/i18n/en/kling.json
+++ b/src/i18n/en/kling.json
@@ -513,7 +513,7 @@
   },
   "placeholder.select": {
     "message": "Select",
-    "description": "Placeholder text in the selection field"
+    "description": "Placeholder text for select fields"
   },
   "placeholder.paddingLevel": {
     "message": "Please select...",
@@ -703,8 +703,17 @@
     "message": "No historical tasks, please click on the left to generate a video",
     "description": "Message when there are no tasks"
   },
-  "placeholder.select": {
-    "message": "Select",
-    "description": "Placeholder text for select fields"
-  }
+  "tab.talkingPhoto": "Talking Photo",
+  "name.talkingPhotoImage": "Portrait Photo",
+  "name.talkingPhotoAudio": "Driving Audio",
+  "name.talkingPhotoPrompt": "Motion Prompt (optional)",
+  "description.talkingPhotoImage": "Upload a clear frontal portrait; it will be animated and made to speak.",
+  "description.talkingPhotoAudio": "Upload an audio clip (mp3/wav, <=5MB); the character lip-syncs to it.",
+  "description.talkingPhotoPrompt": "Optional: describe the desired expression/motion, e.g. \"look gently at the camera\".",
+  "placeholder.talkingPhotoPrompt": "e.g. gentle, calm, natural, subtle head movement",
+  "button.generateTalkingPhoto": "Generate Talking Photo",
+  "button.uploadAudio": "Upload Audio",
+  "message.talkingPhotoMissingInputs": "Please upload a portrait photo and a driving audio first.",
+  "message.uploadAudioExceed": "Only one audio file is allowed.",
+  "message.uploadAudioError": "Audio upload failed, please retry."
 }

--- a/src/i18n/zh-CN/kling.json
+++ b/src/i18n/zh-CN/kling.json
@@ -512,8 +512,8 @@
     "description": "填充噪音输入的占位符"
   },
   "placeholder.select": {
-    "message": "选择",
-    "description": "选择字段中的占位文本"
+    "message": "请选择",
+    "description": "下拉选择字段中的占位文本"
   },
   "placeholder.paddingLevel": {
     "message": "请选择...",
@@ -703,8 +703,17 @@
     "message": "没有历史任务，请点击左方生成视频",
     "description": "没有任务时的消息"
   },
-  "placeholder.select": {
-    "message": "请选择",
-    "description": "下拉选择字段中的占位文本"
-  }
+  "tab.talkingPhoto": "会说话的照片",
+  "name.talkingPhotoImage": "人物照片",
+  "name.talkingPhotoAudio": "驱动音频",
+  "name.talkingPhotoPrompt": "动作提示词（可选）",
+  "description.talkingPhotoImage": "上传一张清晰正脸照片，将自动让它动起来并开口说话。",
+  "description.talkingPhotoAudio": "上传一段音频（mp3/wav，≤5MB），人物会按音频对口型说话。",
+  "description.talkingPhotoPrompt": "可选：描述希望的表情/动作，如「温柔地看向镜头」。",
+  "placeholder.talkingPhotoPrompt": "例如：温柔、平静、自然，轻微头部动作",
+  "button.generateTalkingPhoto": "生成会说话的照片",
+  "button.uploadAudio": "上传音频",
+  "message.talkingPhotoMissingInputs": "请先上传人物照片和驱动音频。",
+  "message.uploadAudioExceed": "只能上传一个音频文件。",
+  "message.uploadAudioError": "音频上传失败，请重试。"
 }

--- a/src/models/kling.ts
+++ b/src/models/kling.ts
@@ -24,7 +24,7 @@ export interface IKlingElementRef {
   element_id?: string;
 }
 
-export type IKlingTaskType = 'videos' | 'motion';
+export type IKlingTaskType = 'videos' | 'motion' | 'talking-photo';
 
 export interface IKlingMotionConfig {
   prompt?: string;
@@ -43,6 +43,26 @@ export interface IKlingMotionRequest {
   character_orientation?: 'image' | 'video';
   mode?: 'std' | 'pro';
   keep_original_sound?: 'yes' | 'no';
+  callback_url?: string;
+}
+
+export interface IKlingTalkingPhotoConfig {
+  image_url?: string;
+  audio_url?: string;
+  prompt?: string;
+  model?: string;
+  duration?: number;
+  mode?: 'std' | 'pro';
+  callback_url?: string;
+}
+
+export interface IKlingTalkingPhotoRequest {
+  image_url: string;
+  audio_url: string;
+  prompt?: string;
+  model?: string;
+  duration?: number;
+  mode?: 'std' | 'pro';
   callback_url?: string;
 }
 

--- a/src/operators/kling.ts
+++ b/src/operators/kling.ts
@@ -3,6 +3,7 @@ import {
   IKlingGenerateRequest,
   IKlingGenerateResponse,
   IKlingMotionRequest,
+  IKlingTalkingPhotoRequest,
   IKlingTaskResponse,
   IKlingTasksResponse
 } from '@/models';
@@ -22,6 +23,20 @@ class KlingOperator extends BaseTaskOperator<
 
   async motion(data: IKlingMotionRequest, options: { token: string }): Promise<AxiosResponse<IKlingGenerateResponse>> {
     return axios.post('/kling/motion', data, {
+      baseURL: BASE_URL_API,
+      headers: {
+        authorization: `Bearer ${options.token}`,
+        'content-type': 'application/json',
+        accept: 'application/x-ndjson'
+      }
+    });
+  }
+
+  async talkingPhoto(
+    data: IKlingTalkingPhotoRequest,
+    options: { token: string }
+  ): Promise<AxiosResponse<IKlingGenerateResponse>> {
+    return axios.post('/kling/talking-photo', data, {
       baseURL: BASE_URL_API,
       headers: {
         authorization: `Bearer ${options.token}`,

--- a/src/pages/kling/Index.vue
+++ b/src/pages/kling/Index.vue
@@ -6,6 +6,7 @@
         <div class="flex-1 min-h-0">
           <config-panel v-if="taskType === 'videos'" @generate="onGenerate" />
           <motion-panel v-else-if="taskType === 'motion'" @generate="onGenerateMotion" />
+          <talking-photo-panel v-else-if="taskType === 'talking-photo'" @generate="onGenerateTalkingPhoto" />
         </div>
       </div>
     </template>
@@ -21,9 +22,10 @@ import Layout from '@/layouts/Kling.vue';
 import ConfigPanel from '@/components/kling/ConfigPanel.vue';
 import MotionPanel from '@/components/kling/MotionPanel.vue';
 import TabSwitcher from '@/components/kling/TabSwitcher.vue';
+import TalkingPhotoPanel from '@/components/kling/TalkingPhotoPanel.vue';
 import { klingOperator } from '@/operators';
 import { instrumentGeneration } from '@/plugins/telemetry';
-import { IKlingGenerateRequest, IKlingMotionRequest, IKlingTaskType, Status } from '@/models';
+import { IKlingGenerateRequest, IKlingMotionRequest, IKlingTalkingPhotoRequest, IKlingTaskType, Status } from '@/models';
 import { ElMessage } from 'element-plus';
 import { ERROR_CODE_USED_UP, getWebhookCallbackUrl } from '@/constants';
 import RecentPanel from '@/components/kling/RecentPanel.vue';
@@ -45,6 +47,7 @@ export default defineComponent({
   components: {
     ConfigPanel,
     MotionPanel,
+    TalkingPhotoPanel,
     TabSwitcher,
     Layout,
     RecentPanel
@@ -74,6 +77,9 @@ export default defineComponent({
     },
     motionConfig() {
       return this.$store.state.kling.motionConfig;
+    },
+    talkingPhotoConfig() {
+      return this.$store.state.kling.talkingPhotoConfig;
     },
     taskType(): IKlingTaskType {
       return this.$store.state.kling.taskType || 'videos';
@@ -281,6 +287,55 @@ export default defineComponent({
       }
       ElMessage.info(this.$t('kling.message.startingTask'));
       instrumentGeneration('kling', klingOperator.motion(request, { token }))
+        .then(() => {
+          ElMessage.success(this.$t('kling.message.startTaskSuccess'));
+        })
+        .catch((error) => {
+          const response = error?.response?.data;
+          if (response?.error?.code === ERROR_CODE_USED_UP) {
+            ElMessage.error(this.$t('kling.message.usedUp'));
+          } else {
+            ElMessage.error(this.$t('kling.message.startTaskFailed'));
+          }
+        })
+        .finally(async () => {
+          setTimeout(async () => {
+            await this.onGetTasks();
+            await this.onScrollDown();
+          }, 1000);
+        });
+    },
+    async onGenerateTalkingPhoto() {
+      if (
+        !ensureNoPendingUpload(
+          this.uploadTracker,
+          (k) => this.$t(k) as string,
+          (m) => ElMessage.warning(m)
+        )
+      ) {
+        return;
+      }
+      const cfg = this.talkingPhotoConfig || {};
+      if (!cfg.image_url || !cfg.audio_url) {
+        ElMessage.warning(this.$t('kling.message.talkingPhotoMissingInputs'));
+        return;
+      }
+      const request: IKlingTalkingPhotoRequest = {
+        image_url: cfg.image_url,
+        audio_url: cfg.audio_url,
+        ...(cfg.prompt ? { prompt: cfg.prompt } : {}),
+        ...(cfg.model ? { model: cfg.model } : {}),
+        ...(cfg.duration ? { duration: cfg.duration } : {}),
+        ...(cfg.mode ? { mode: cfg.mode } : {}),
+        callback_url: CALLBACK_URL
+      };
+      const token = this.credential?.token;
+      if (!token) {
+        console.error('no token specified');
+        return;
+      }
+      ElMessage.info(this.$t('kling.message.startingTask'));
+      instrumentGeneration('kling', klingOperator.talkingPhoto(request, { token }))
         .then(() => {
           ElMessage.success(this.$t('kling.message.startTaskSuccess'));
         })

--- a/src/store/kling/models.ts
+++ b/src/store/kling/models.ts
@@ -1,5 +1,5 @@
 import { IApplication, ICredential, IService, Status } from '@/models';
-import { IKlingConfig, IKlingMotionConfig, IKlingTask, IKlingTaskType } from '@/models';
+import { IKlingConfig, IKlingMotionConfig, IKlingTalkingPhotoConfig, IKlingTask, IKlingTaskType } from '@/models';
 
 export interface IKlingState {
   application: IApplication | undefined;
@@ -8,6 +8,7 @@ export interface IKlingState {
   credential: ICredential | undefined;
   config: IKlingConfig | undefined;
   motionConfig: IKlingMotionConfig | undefined;
+  talkingPhotoConfig: IKlingTalkingPhotoConfig | undefined;
   taskType: IKlingTaskType;
   tasks:
     | {

--- a/src/store/kling/mutations.ts
+++ b/src/store/kling/mutations.ts
@@ -3,6 +3,7 @@ import {
   ICredential,
   IKlingConfig,
   IKlingMotionConfig,
+  IKlingTalkingPhotoConfig,
   IKlingTask,
   IKlingTaskType,
   IService
@@ -36,6 +37,10 @@ export const setConfig = (state: IKlingState, payload: IKlingConfig): void => {
 
 export const setMotionConfig = (state: IKlingState, payload: IKlingMotionConfig): void => {
   state.motionConfig = payload;
+};
+
+export const setTalkingPhotoConfig = (state: IKlingState, payload: IKlingTalkingPhotoConfig): void => {
+  state.talkingPhotoConfig = payload;
 };
 
 export const setTaskType = (state: IKlingState, payload: IKlingTaskType): void => {
@@ -78,6 +83,7 @@ export default {
   setApplications,
   setConfig,
   setMotionConfig,
+  setTalkingPhotoConfig,
   setTaskType,
   setCredential,
   setService,

--- a/src/store/kling/state.ts
+++ b/src/store/kling/state.ts
@@ -10,6 +10,7 @@ export default (): IKlingState => {
     credential: undefined,
     config: undefined,
     motionConfig: undefined,
+    talkingPhotoConfig: undefined,
     taskType: 'videos',
     status: {
       getService: Status.None,


### PR DESCRIPTION
Adds a **Talking Photo** tab to the Kling app: upload a portrait + a driving audio → one click → a talking video. Backed by the single `POST /kling/talking-photo` endpoint (AceDataCloud/PlatformService#1023) which internally chains image2video + lip-sync, so the frontend makes one call.

- `IKlingTaskType` += `talking-photo`; new config/request types + store plumbing
- `talkingPhoto()` operator → /kling/talking-photo
- `TalkingPhotoPanel.vue`: image + audio uploaders + optional prompt + generate
- TabSwitcher tab + Index.vue wiring; i18n zh-CN + en
- vue-tsc clean (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)