### PR TITLE
fix(ios): complete native push integration so Coding-Bridge notifications work

### DIFF
--- a/.github/workflows/build-ios.yaml
+++ b/.github/workflows/build-ios.yaml
@@ -160,8 +160,10 @@ jobs:
       - name: Build web assets (iOS surface)
         run: npm run build:ios
 
-      - name: Copy web assets to iOS project
-        run: npx cap copy ios
+      - name: Sync web assets and native plugins to iOS project
+        # `cap sync` (not `cap copy`) regenerates the Podfile from the installed
+        # Capacitor plugins so native pods like CapacitorPushNotifications are present.
+        run: npx cap sync ios
 
       - name: Install CocoaPods
         working-directory: ios/App

--- a/ios/App/App/AppDelegate.swift
+++ b/ios/App/App/AppDelegate.swift
@@ -33,6 +33,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 
+    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        // Forward the APNs device token to the Capacitor PushNotifications plugin,
+        // which resolves the JS `registration` listener with the token.
+        NotificationCenter.default.post(name: .capacitorDidRegisterForRemoteNotifications, object: deviceToken)
+    }
+
+    func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+        // Forward registration failures so the JS `registrationError` listener fires.
+        NotificationCenter.default.post(name: .capacitorDidFailToRegisterForRemoteNotifications, object: error)
+    }
+
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
         // Called when the app was launched with a url. Feel free to add additional processing here,
         // but if you want the App API to support tracking app url opens, make sure to keep this call

--- a/src/utils/codingBridgeNotify.ts
+++ b/src/utils/codingBridgeNotify.ts
@@ -235,16 +235,23 @@ export const registerNativePush = async (onOpen?: (data: ICodingBridgeNotifyData
     const { PushNotifications } = await import('@capacitor/push-notifications');
     const perm = await PushNotifications.requestPermissions();
     if (perm.receive !== 'granted') {
+      console.warn(`[codingBridge] push permission not granted (receive=${perm.receive})`);
       return null;
     }
     const token = await new Promise<string | null>((resolve) => {
-      const timer = setTimeout(() => resolve(null), 10000);
+      const timer = setTimeout(() => {
+        // No `registration` event within the window. On iOS this usually means the
+        // native APNs callbacks aren't being forwarded from AppDelegate to Capacitor.
+        console.warn('[codingBridge] push registration timed out — no device token');
+        resolve(null);
+      }, 10000);
       void PushNotifications.addListener('registration', (t: { value: string }) => {
         clearTimeout(timer);
         resolve(t.value);
       });
-      void PushNotifications.addListener('registrationError', () => {
+      void PushNotifications.addListener('registrationError', (err: unknown) => {
         clearTimeout(timer);
+        console.warn('[codingBridge] push registrationError', err);
         resolve(null);
       });
       void PushNotifications.register();
@@ -259,7 +266,14 @@ export const registerNativePush = async (onOpen?: (data: ICodingBridgeNotifyData
     }
     return token;
   } catch (error) {
-    console.warn('[codingBridge] native push registration failed', error);
+    // `UNIMPLEMENTED` here means the native PushNotifications plugin isn't compiled
+    // into the build (e.g. the Pod was never synced into the iOS project).
+    const code = (error as { code?: string })?.code;
+    if (code === 'UNIMPLEMENTED') {
+      console.warn('[codingBridge] PushNotifications plugin not available in this build', error);
+    } else {
+      console.warn('[codingBridge] native push registration failed', error);
+    }
     return null;
   }
 };


### PR DESCRIPTION
## Problem
On iOS the app never prompts for notification permission and the device never registers in the backend device list, so Coding-Bridge "session needs approval" pushes never arrive.

The JS/TS layer, backend (`POST /api/push/subscriptions`), and `aps-environment` entitlement all shipped in #921 / #926 / #928 — but the **native iOS integration was never completed**. (Android works because its CI already runs `cap sync`.)

### Failure chain
`requestPermissions()` → native `PushNotifications` plugin not compiled in → throws `UNIMPLEMENTED` → swallowed in `registerNativePush()` → no dialog → no `register()` → no token → `savePushSubscription()` never called → not in device list.

## Changes
1. **`build-ios.yaml`: `npx cap copy ios` → `npx cap sync ios`.** `sync` regenerates the Podfile from installed plugins so `CapacitorPushNotifications` is installed; the existing `pod install` step compiles it in. (Android CI already uses `cap sync`.)
2. **`AppDelegate.swift`: add the APNs forwarding handlers** (`didRegisterForRemoteNotificationsWithDeviceToken` / `didFailToRegisterForRemoteNotificationsWithError`). Capacitor requires these to deliver the token to JS — `cap sync` does not add them. Without them the `registration` listener never fires (10s timeout → null token).
3. **`codingBridgeNotify.ts`: replace the silent catch-all** with distinct logs (permission-denied / timeout / `registrationError` / `UNIMPLEMENTED`). This is what masked the bug.

Deliberately **not** adding `UIBackgroundModes: remote-notification` — these are alert/tap pushes (`pushNotificationActionPerformed`), not silent `content-available` pushes, so it isn't needed and would invite extra App Store review.

## Verification
- [ ] Build from this branch → install on a **physical iPhone** (push doesn't work in the simulator)
- [ ] Tap the notification bell → native iOS permission dialog appears
- [ ] coding-bridge Mongo `push` collection gets a `kind:"apns"` doc under the user's `owner_user_id` (or CLS shows `POST /api/push/subscriptions` → `{ok:true}`)
- [ ] Trigger a "session needs approval" event → push lands on device

> Note: delivery also requires the APNs auth key (.p8) on the coding-bridge sender, and the sender's APNs environment must match the build. `aps-environment` is `production`, so test via TestFlight (production gateway), not a raw Xcode debug build (sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
