### PR TITLE
fix(grokvideo): correct logo icon and regenerate locale translations

### DIFF
--- a/change/@acedatacloud-nexior-9c4e7ed3-276b-45ce-9424-0418e082e281.json
+++ b/change/@acedatacloud-nexior-9c4e7ed3-276b-45ce-9424-0418e082e281.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(grokvideo): correct logo icon and regenerate locale translations",
+  "packageName": "@acedatacloud/nexior",
+  "email": "cqc@cuiqingcai.com",
+  "dependentChangeType": "patch"
+}

--- a/src/constants/grokvideo.ts
+++ b/src/constants/grokvideo.ts
@@ -1,6 +1,6 @@
 export const GROKVIDEO_SERVICE_ID = 'a270a291-7cbc-44a6-88b9-80334e3e95a0';
 
-export const GROKVIDEO_LOGO = 'https://cdn.acedata.cloud/8nxyy9.jpg';
+export const GROKVIDEO_LOGO = 'https://cdn.acedata.cloud/p1ge98.png';
 
 export const GROKVIDEO_MODEL_DEFAULT = 'grok-imagine-video';
 export const GROKVIDEO_MODEL_1_5_PREVIEW = 'grok-imagine-video-1.5-preview';

--- a/src/i18n/ar/grokvideo.json
+++ b/src/i18n/ar/grokvideo.json
@@ -1,61 +1,154 @@
 {
-  "name.bot": { "message": "Grok Video Bot", "description": "Name of the Grok video generator" },
-  "name.prompt": { "message": "Prompt", "description": "Prompt for generating the video" },
-  "name.model": { "message": "Model", "description": "Label for model selection" },
-  "name.ratio": { "message": "Aspect Ratio", "description": "Label for aspect ratio" },
-  "name.resolution": { "message": "Resolution", "description": "Label for resolution" },
-  "name.duration": { "message": "Duration", "description": "Label for duration" },
-  "name.image": { "message": "Image", "description": "Label for input image" },
-  "name.required": { "message": "Required", "description": "Required badge" },
-  "name.taskId": { "message": "Task ID", "description": "Task id label" },
-  "name.elapsed": { "message": "Elapsed", "description": "Elapsed time label" },
-  "name.traceId": { "message": "Trace ID", "description": "Trace id label" },
-  "name.failure": { "message": "Generation Failed", "description": "Failure title" },
-  "name.failureReason": { "message": "Reason", "description": "Failure reason label" },
-  "name.status": { "message": "Status", "description": "Status title" },
+  "name.bot": {
+    "message": "روبوت فيديو Grok",
+    "description": "اسم مولد فيديو Grok"
+  },
+  "name.prompt": {
+    "message": "نص التوجيه",
+    "description": "نص لتوليد الفيديو"
+  },
+  "name.model": {
+    "message": "نموذج",
+    "description": "تسمية لاختيار النموذج"
+  },
+  "name.ratio": {
+    "message": "نسبة العرض إلى الارتفاع",
+    "description": "تسمية لنسبة العرض إلى الارتفاع"
+  },
+  "name.resolution": {
+    "message": "الدقة",
+    "description": "تسمية للدقة"
+  },
+  "name.duration": {
+    "message": "المدة",
+    "description": "تسمية للمدة"
+  },
+  "name.image": {
+    "message": "صورة",
+    "description": "تسمية لإدخال الصورة"
+  },
+  "name.required": {
+    "message": "مطلوب",
+    "description": "شارة مطلوبة"
+  },
+  "name.taskId": {
+    "message": "معرف المهمة",
+    "description": "تسمية معرف المهمة"
+  },
+  "name.elapsed": {
+    "message": "الوقت المستغرق",
+    "description": "تسمية الوقت المستغرق"
+  },
+  "name.traceId": {
+    "message": "معرف التتبع",
+    "description": "تسمية معرف التتبع"
+  },
+  "name.failure": {
+    "message": "فشل الإنشاء",
+    "description": "عنوان الفشل"
+  },
+  "name.failureReason": {
+    "message": "سبب الفشل",
+    "description": "تسمية سبب الفشل"
+  },
+  "name.status": {
+    "message": "الحالة",
+    "description": "عنوان الحالة"
+  },
   "description.prompt": {
-    "message": "Describe the video you want to generate (scene, subject, motion, camera, lighting, style).",
-    "description": "Instructions for prompt input"
+    "message": "صف الفيديو الذي ترغب في إنشائه (المشهد، الموضوع، الحركة، اللقطة، الإضاءة، الأسلوب).",
+    "description": "تعليمات حول إدخال النص"
   },
   "description.model": {
-    "message": "Choose the Grok Imagine model. grok-imagine-video supports text and image; 1.5-preview is image-to-video only.",
-    "description": "Instructions for model selection"
+    "message": "اختر نموذج Grok Imagine. يدعم grok-imagine-video الفيديو الناتج عن النص والصورة؛ بينما 1.5-preview يدعم فقط الفيديو الناتج عن الصورة.",
+    "description": "تعليمات حول اختيار النموذج"
   },
-  "description.ratio": { "message": "Select the output aspect ratio.", "description": "Instructions for aspect ratio" },
+  "description.ratio": {
+    "message": "اختر نسبة عرض إلى ارتفاع الإخراج.",
+    "description": "تعليمات حول نسبة العرض إلى الارتفاع"
+  },
   "description.resolution": {
-    "message": "Select the output resolution. Higher resolution costs more credits per second.",
-    "description": "Instructions for resolution"
+    "message": "اختر دقة الإخراج. كلما كانت الدقة أعلى، زادت التكلفة لكل ثانية.",
+    "description": "تعليمات حول الدقة"
   },
   "description.duration": {
-    "message": "Video duration in seconds. Billed per output second.",
-    "description": "Instructions for duration"
+    "message": "مدة الفيديو (بالثواني)، يتم احتساب الرسوم حسب عدد الثواني.",
+    "description": "تعليمات حول المدة"
   },
   "description.image": {
-    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5-preview.",
-    "description": "Instructions for image input"
+    "message": "صورة إدخال اختيارية، تستخدم لإنشاء الفيديو. grok-imagine-video-1.5-preview إلزامية.",
+    "description": "تعليمات حول إدخال الصورة"
   },
-  "placeholder.prompt": { "message": "Describe your video…", "description": "Placeholder for prompt" },
-  "placeholder.select": { "message": "Please select", "description": "Placeholder for selects" },
-  "model.default": { "message": "Grok Imagine Video", "description": "Default model label" },
-  "model.preview15": { "message": "Grok Imagine Video 1.5 (Preview, image-to-video)", "description": "1.5 preview model label" },
-  "button.upload": { "message": "Upload", "description": "Upload button" },
-  "button.generate": { "message": "Generate", "description": "Generate button" },
-  "button.download": { "message": "Download", "description": "Download button" },
-  "status.pending": { "message": "Pending", "description": "Pending status" },
-  "status.processing": { "message": "Processing", "description": "Processing status" },
-  "message.uploadExceed": { "message": "You can upload only one image.", "description": "Upload exceed warning" },
-  "message.uploadError": { "message": "Image upload failed, please try again.", "description": "Upload error" },
-  "message.downloadVideo": { "message": "Download video", "description": "Download tooltip" },
+  "placeholder.prompt": {
+    "message": "وصف الفيديو الخاص بك…",
+    "description": "نص بديل لنص التوجيه"
+  },
+  "placeholder.select": {
+    "message": "يرجى الاختيار",
+    "description": "نص بديل للاختيارات"
+  },
+  "model.default": {
+    "message": "فيديو Grok Imagine",
+    "description": "تسمية النموذج الافتراضي"
+  },
+  "model.preview15": {
+    "message": "فيديو Grok Imagine 1.5 (معاينة، فيديو ناتج عن الصورة)",
+    "description": "تسمية نموذج المعاينة 1.5"
+  },
+  "button.upload": {
+    "message": "رفع",
+    "description": "زر الرفع"
+  },
+  "button.generate": {
+    "message": "إنشاء",
+    "description": "زر الإنشاء"
+  },
+  "button.download": {
+    "message": "تنزيل",
+    "description": "زر التنزيل"
+  },
+  "status.pending": {
+    "message": "قيد الانتظار",
+    "description": "حالة الانتظار"
+  },
+  "status.processing": {
+    "message": "جاري المعالجة",
+    "description": "حالة المعالجة"
+  },
+  "message.uploadExceed": {
+    "message": "يمكنك رفع صورة واحدة فقط.",
+    "description": "تحذير تجاوز الرفع"
+  },
+  "message.uploadError": {
+    "message": "فشل رفع الصورة، يرجى المحاولة مرة أخرى.",
+    "description": "خطأ في الرفع"
+  },
+  "message.downloadVideo": {
+    "message": "تنزيل الفيديو",
+    "description": "تلميح التنزيل"
+  },
   "message.modelRequiresImage": {
-    "message": "This model requires an input image (image-to-video).",
-    "description": "Model requires image warning"
+    "message": "هذا النموذج يتطلب صورة إدخال (فيديو ناتج عن الصورة).",
+    "description": "تحذير يتطلب صورة للنموذج"
   },
   "message.promptOrImageRequired": {
-    "message": "Please enter a prompt or upload an image.",
-    "description": "Prompt or image required warning"
+    "message": "يرجى إدخال نص أو رفع صورة.",
+    "description": "تحذير يتطلب نص أو صورة"
   },
-  "message.startingTask": { "message": "Submitting your video generation task…", "description": "Starting task" },
-  "message.startTaskSuccess": { "message": "Task submitted successfully.", "description": "Task success" },
-  "message.startTaskFailed": { "message": "Failed to submit task: ", "description": "Task failed" },
-  "message.usedUp": { "message": "Your quota has been used up. Please purchase more to continue.", "description": "Used up" }
+  "message.startingTask": {
+    "message": "جارٍ تقديم مهمة إنشاء الفيديو...",
+    "description": "بدء المهمة"
+  },
+  "message.startTaskSuccess": {
+    "message": "تم تقديم المهمة بنجاح.",
+    "description": "نجاح المهمة"
+  },
+  "message.startTaskFailed": {
+    "message": "فشل تقديم المهمة:",
+    "description": "فشل المهمة"
+  },
+  "message.usedUp": {
+    "message": "تم استهلاك الرصيد، يرجى الشراء للاستمرار في الاستخدام.",
+    "description": "استهلاك الرصيد"
+  }
 }

--- a/src/i18n/de/grokvideo.json
+++ b/src/i18n/de/grokvideo.json
@@ -1,61 +1,154 @@
 {
-  "name.bot": { "message": "Grok Video Bot", "description": "Name of the Grok video generator" },
-  "name.prompt": { "message": "Prompt", "description": "Prompt for generating the video" },
-  "name.model": { "message": "Model", "description": "Label for model selection" },
-  "name.ratio": { "message": "Aspect Ratio", "description": "Label for aspect ratio" },
-  "name.resolution": { "message": "Resolution", "description": "Label for resolution" },
-  "name.duration": { "message": "Duration", "description": "Label for duration" },
-  "name.image": { "message": "Image", "description": "Label for input image" },
-  "name.required": { "message": "Required", "description": "Required badge" },
-  "name.taskId": { "message": "Task ID", "description": "Task id label" },
-  "name.elapsed": { "message": "Elapsed", "description": "Elapsed time label" },
-  "name.traceId": { "message": "Trace ID", "description": "Trace id label" },
-  "name.failure": { "message": "Generation Failed", "description": "Failure title" },
-  "name.failureReason": { "message": "Reason", "description": "Failure reason label" },
-  "name.status": { "message": "Status", "description": "Status title" },
+  "name.bot": {
+    "message": "Grok Video Bot",
+    "description": "Name des Grok Video Generators"
+  },
+  "name.prompt": {
+    "message": "Eingabeaufforderung",
+    "description": "Eingabeaufforderung zur Videoerstellung"
+  },
+  "name.model": {
+    "message": "Modell",
+    "description": "Label für die Modellauswahl"
+  },
+  "name.ratio": {
+    "message": "Seitenverhältnis",
+    "description": "Label für das Seitenverhältnis"
+  },
+  "name.resolution": {
+    "message": "Auflösung",
+    "description": "Label für die Auflösung"
+  },
+  "name.duration": {
+    "message": "Dauer",
+    "description": "Bezeichnung für die Dauer"
+  },
+  "name.image": {
+    "message": "Bild",
+    "description": "Label für das Eingabebild"
+  },
+  "name.required": {
+    "message": "Pflichtfeld",
+    "description": "Pflichtfeld-Label"
+  },
+  "name.taskId": {
+    "message": "Aufgaben-ID",
+    "description": "Label für die Aufgaben-ID"
+  },
+  "name.elapsed": {
+    "message": "Verstrichene Zeit",
+    "description": "Bezeichnung für die verstrichene Zeit"
+  },
+  "name.traceId": {
+    "message": "Verfolgungs-ID",
+    "description": "Label für die Verfolgungs-ID"
+  },
+  "name.failure": {
+    "message": "Generierung fehlgeschlagen",
+    "description": "Titel für Fehler"
+  },
+  "name.failureReason": {
+    "message": "Fehlerursache",
+    "description": "Bezeichnung für die Fehlerursache"
+  },
+  "name.status": {
+    "message": "Status",
+    "description": "Statusüberschrift"
+  },
   "description.prompt": {
-    "message": "Describe the video you want to generate (scene, subject, motion, camera, lighting, style).",
-    "description": "Instructions for prompt input"
+    "message": "Beschreiben Sie das Video, das Sie generieren möchten (Szene, Subjekt, Aktion, Kamera, Licht, Stil).",
+    "description": "Anweisungen zur Eingabe des Prompts"
   },
   "description.model": {
-    "message": "Choose the Grok Imagine model. grok-imagine-video supports text and image; 1.5-preview is image-to-video only.",
-    "description": "Instructions for model selection"
+    "message": "Wählen Sie das Grok Imagine Modell. grok-imagine-video unterstützt Text-zu-Video und Bild-zu-Video; 1.5-preview unterstützt nur Bild-zu-Video.",
+    "description": "Anweisungen zur Modellauswahl"
   },
-  "description.ratio": { "message": "Select the output aspect ratio.", "description": "Instructions for aspect ratio" },
+  "description.ratio": {
+    "message": "Wählen Sie das Ausgabe-Seitenverhältnis.",
+    "description": "Anweisungen zum Seitenverhältnis"
+  },
   "description.resolution": {
-    "message": "Select the output resolution. Higher resolution costs more credits per second.",
-    "description": "Instructions for resolution"
+    "message": "Wählen Sie die Ausgabeauflösung. Höhere Auflösungen verbrauchen mehr Kontingent pro Sekunde.",
+    "description": "Anweisungen zur Auflösung"
   },
   "description.duration": {
-    "message": "Video duration in seconds. Billed per output second.",
-    "description": "Instructions for duration"
+    "message": "Videodauer (Sekunden), Abrechnung nach ausgegebenen Sekunden.",
+    "description": "Anweisungen zur Dauer"
   },
   "description.image": {
-    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5-preview.",
-    "description": "Instructions for image input"
+    "message": "Optionales Eingabebild für die Videoerstellung. grok-imagine-video-1.5-preview ist erforderlich.",
+    "description": "Anweisungen für die Bild-Eingabe"
   },
-  "placeholder.prompt": { "message": "Describe your video…", "description": "Placeholder for prompt" },
-  "placeholder.select": { "message": "Please select", "description": "Placeholder for selects" },
-  "model.default": { "message": "Grok Imagine Video", "description": "Default model label" },
-  "model.preview15": { "message": "Grok Imagine Video 1.5 (Preview, image-to-video)", "description": "1.5 preview model label" },
-  "button.upload": { "message": "Upload", "description": "Upload button" },
-  "button.generate": { "message": "Generate", "description": "Generate button" },
-  "button.download": { "message": "Download", "description": "Download button" },
-  "status.pending": { "message": "Pending", "description": "Pending status" },
-  "status.processing": { "message": "Processing", "description": "Processing status" },
-  "message.uploadExceed": { "message": "You can upload only one image.", "description": "Upload exceed warning" },
-  "message.uploadError": { "message": "Image upload failed, please try again.", "description": "Upload error" },
-  "message.downloadVideo": { "message": "Download video", "description": "Download tooltip" },
+  "placeholder.prompt": {
+    "message": "Beschreibe dein Video…",
+    "description": "Platzhalter für die Eingabeaufforderung"
+  },
+  "placeholder.select": {
+    "message": "Bitte auswählen",
+    "description": "Platzhalter für Auswahlfelder"
+  },
+  "model.default": {
+    "message": "Grok Imagine Video",
+    "description": "Standardmodellbezeichnung"
+  },
+  "model.preview15": {
+    "message": "Grok Imagine Video 1.5 (Vorschau, Bild-zu-Video)",
+    "description": "1.5 Vorschau Modellbezeichnung"
+  },
+  "button.upload": {
+    "message": "Hochladen",
+    "description": "Upload-Button"
+  },
+  "button.generate": {
+    "message": "Generieren",
+    "description": "Generieren-Button"
+  },
+  "button.download": {
+    "message": "Herunterladen",
+    "description": "Download-Button"
+  },
+  "status.pending": {
+    "message": "Wartend",
+    "description": "Status für ausstehende Vorgänge"
+  },
+  "status.processing": {
+    "message": "Wird erstellt",
+    "description": "Status für die Verarbeitung"
+  },
+  "message.uploadExceed": {
+    "message": "Es kann nur ein Bild hochgeladen werden.",
+    "description": "Warnung, dass das Upload-Limit überschritten wurde"
+  },
+  "message.uploadError": {
+    "message": "Bild-Upload fehlgeschlagen, bitte erneut versuchen.",
+    "description": "Upload-Fehler"
+  },
+  "message.downloadVideo": {
+    "message": "Video herunterladen",
+    "description": "Download-Hinweis"
+  },
   "message.modelRequiresImage": {
-    "message": "This model requires an input image (image-to-video).",
-    "description": "Model requires image warning"
+    "message": "Dieses Modell benötigt ein Eingabebild (Bild-zu-Video).",
+    "description": "Warnung, dass das Modell ein Bild benötigt"
   },
   "message.promptOrImageRequired": {
-    "message": "Please enter a prompt or upload an image.",
-    "description": "Prompt or image required warning"
+    "message": "Bitte geben Sie einen Prompt ein oder laden Sie ein Bild hoch.",
+    "description": "Warnung, dass ein Prompt oder Bild erforderlich ist"
   },
-  "message.startingTask": { "message": "Submitting your video generation task…", "description": "Starting task" },
-  "message.startTaskSuccess": { "message": "Task submitted successfully.", "description": "Task success" },
-  "message.startTaskFailed": { "message": "Failed to submit task: ", "description": "Task failed" },
-  "message.usedUp": { "message": "Your quota has been used up. Please purchase more to continue.", "description": "Used up" }
+  "message.startingTask": {
+    "message": "Videoerstellungsaufgabe wird übermittelt…",
+    "description": "Aufgabe wird gestartet"
+  },
+  "message.startTaskSuccess": {
+    "message": "Aufgabenübermittlung erfolgreich.",
+    "description": "Aufgabe erfolgreich"
+  },
+  "message.startTaskFailed": {
+    "message": "Aufgabenübermittlung fehlgeschlagen:",
+    "description": "Aufgabe fehlgeschlagen"
+  },
+  "message.usedUp": {
+    "message": "Kontingent erschöpft, bitte kaufen Sie, um fortzufahren.",
+    "description": "Erschöpft"
+  }
 }

--- a/src/i18n/el/grokvideo.json
+++ b/src/i18n/el/grokvideo.json
@@ -1,61 +1,154 @@
 {
-  "name.bot": { "message": "Grok Video Bot", "description": "Name of the Grok video generator" },
-  "name.prompt": { "message": "Prompt", "description": "Prompt for generating the video" },
-  "name.model": { "message": "Model", "description": "Label for model selection" },
-  "name.ratio": { "message": "Aspect Ratio", "description": "Label for aspect ratio" },
-  "name.resolution": { "message": "Resolution", "description": "Label for resolution" },
-  "name.duration": { "message": "Duration", "description": "Label for duration" },
-  "name.image": { "message": "Image", "description": "Label for input image" },
-  "name.required": { "message": "Required", "description": "Required badge" },
-  "name.taskId": { "message": "Task ID", "description": "Task id label" },
-  "name.elapsed": { "message": "Elapsed", "description": "Elapsed time label" },
-  "name.traceId": { "message": "Trace ID", "description": "Trace id label" },
-  "name.failure": { "message": "Generation Failed", "description": "Failure title" },
-  "name.failureReason": { "message": "Reason", "description": "Failure reason label" },
-  "name.status": { "message": "Status", "description": "Status title" },
+  "name.bot": {
+    "message": "Grok βίντεο ρομπότ",
+    "description": "Όνομα του γεννήτριας βίντεο Grok"
+  },
+  "name.prompt": {
+    "message": "Προτροπή",
+    "description": "Προτροπή για τη δημιουργία του βίντεο"
+  },
+  "name.model": {
+    "message": "Μοντέλο",
+    "description": "Ετικέτα για την επιλογή μοντέλου"
+  },
+  "name.ratio": {
+    "message": "Αναλογία διαστάσεων",
+    "description": "Ετικέτα για την αναλογία διαστάσεων"
+  },
+  "name.resolution": {
+    "message": "Ανάλυση",
+    "description": "Ετικέτα για την ανάλυση"
+  },
+  "name.duration": {
+    "message": "Διάρκεια",
+    "description": "Ετικέτα για τη διάρκεια"
+  },
+  "name.image": {
+    "message": "Εικόνα",
+    "description": "Ετικέτα για την είσοδο εικόνας"
+  },
+  "name.required": {
+    "message": "Υποχρεωτικό",
+    "description": "Σήμα υποχρεωτικού πεδίου"
+  },
+  "name.taskId": {
+    "message": "ID Εργασίας",
+    "description": "Ετικέτα για το ID της εργασίας"
+  },
+  "name.elapsed": {
+    "message": "Χρόνος που πέρασε",
+    "description": "Ετικέτα για τον χρόνο που πέρασε"
+  },
+  "name.traceId": {
+    "message": "ID Ιχνηλάτη",
+    "description": "Ετικέτα για το ID ιχνηλάτη"
+  },
+  "name.failure": {
+    "message": "Αποτυχία δημιουργίας",
+    "description": "Τίτλος αποτυχίας"
+  },
+  "name.failureReason": {
+    "message": "Λόγος αποτυχίας",
+    "description": "Ετικέτα λόγου αποτυχίας"
+  },
+  "name.status": {
+    "message": "Κατάσταση",
+    "description": "Τίτλος κατάστασης"
+  },
   "description.prompt": {
-    "message": "Describe the video you want to generate (scene, subject, motion, camera, lighting, style).",
-    "description": "Instructions for prompt input"
+    "message": "Περιγράψτε το βίντεο που θέλετε να δημιουργήσετε (σκηνές, υποκείμενα, δράσεις, λήψεις, φωτισμός, στυλ).",
+    "description": "Οδηγίες για την είσοδο προτροπής"
   },
   "description.model": {
-    "message": "Choose the Grok Imagine model. grok-imagine-video supports text and image; 1.5-preview is image-to-video only.",
-    "description": "Instructions for model selection"
+    "message": "Επιλέξτε το μοντέλο Grok Imagine. Το grok-imagine-video υποστηρίζει βίντεο που δημιουργούνται από κείμενο και εικόνες; το 1.5-preview υποστηρίζει μόνο βίντεο που δημιουργούνται από εικόνες.",
+    "description": "Οδηγίες για την επιλογή μοντέλου"
   },
-  "description.ratio": { "message": "Select the output aspect ratio.", "description": "Instructions for aspect ratio" },
+  "description.ratio": {
+    "message": "Επιλέξτε την αναλογία εξόδου.",
+    "description": "Οδηγίες για την αναλογία διαστάσεων"
+  },
   "description.resolution": {
-    "message": "Select the output resolution. Higher resolution costs more credits per second.",
-    "description": "Instructions for resolution"
+    "message": "Επιλέξτε την ανάλυση εξόδου. Όσο υψηλότερη είναι η ανάλυση, τόσο περισσότερη είναι η κατανάλωση ανά δευτερόλεπτο.",
+    "description": "Οδηγίες για την ανάλυση"
   },
   "description.duration": {
-    "message": "Video duration in seconds. Billed per output second.",
-    "description": "Instructions for duration"
+    "message": "Διάρκεια βίντεο (δευτερόλεπτα), χρεώνεται ανά δευτερόλεπτο εξόδου.",
+    "description": "Οδηγίες για τη διάρκεια"
   },
   "description.image": {
-    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5-preview.",
-    "description": "Instructions for image input"
+    "message": "Προαιρετική είσοδος εικόνας, για βίντεο που δημιουργούνται από εικόνες. Το grok-imagine-video-1.5-preview είναι υποχρεωτικό.",
+    "description": "Οδηγίες για την είσοδο εικόνας"
   },
-  "placeholder.prompt": { "message": "Describe your video…", "description": "Placeholder for prompt" },
-  "placeholder.select": { "message": "Please select", "description": "Placeholder for selects" },
-  "model.default": { "message": "Grok Imagine Video", "description": "Default model label" },
-  "model.preview15": { "message": "Grok Imagine Video 1.5 (Preview, image-to-video)", "description": "1.5 preview model label" },
-  "button.upload": { "message": "Upload", "description": "Upload button" },
-  "button.generate": { "message": "Generate", "description": "Generate button" },
-  "button.download": { "message": "Download", "description": "Download button" },
-  "status.pending": { "message": "Pending", "description": "Pending status" },
-  "status.processing": { "message": "Processing", "description": "Processing status" },
-  "message.uploadExceed": { "message": "You can upload only one image.", "description": "Upload exceed warning" },
-  "message.uploadError": { "message": "Image upload failed, please try again.", "description": "Upload error" },
-  "message.downloadVideo": { "message": "Download video", "description": "Download tooltip" },
+  "placeholder.prompt": {
+    "message": "Περιγράψτε το βίντεό σας…",
+    "description": "Placeholder για την προτροπή"
+  },
+  "placeholder.select": {
+    "message": "Επιλέξτε",
+    "description": "Placeholder για επιλογές"
+  },
+  "model.default": {
+    "message": "Grok Imagine βίντεο",
+    "description": "Ετικέτα προεπιλεγμένου μοντέλου"
+  },
+  "model.preview15": {
+    "message": "Grok Imagine βίντεο 1.5 (προεπισκόπηση, βίντεο που δημιουργούνται από εικόνες)",
+    "description": "Ετικέτα μοντέλου προεπισκόπησης 1.5"
+  },
+  "button.upload": {
+    "message": "Ανέβασμα",
+    "description": "Κουμπί ανεβάσματος"
+  },
+  "button.generate": {
+    "message": "Δημιουργία",
+    "description": "Κουμπί δημιουργίας"
+  },
+  "button.download": {
+    "message": "Λήψη",
+    "description": "Κουμπί λήψης"
+  },
+  "status.pending": {
+    "message": "Σε αναμονή",
+    "description": "Κατάσταση αναμονής"
+  },
+  "status.processing": {
+    "message": "Δημιουργείται",
+    "description": "Κατάσταση επεξεργασίας"
+  },
+  "message.uploadExceed": {
+    "message": "Μπορείτε να ανεβάσετε μόνο μία εικόνα.",
+    "description": "Προειδοποίηση υπέρβασης ανέβασματος"
+  },
+  "message.uploadError": {
+    "message": "Η ανέβασμα εικόνας απέτυχε, παρακαλώ δοκιμάστε ξανά.",
+    "description": "Σφάλμα ανέβασματος"
+  },
+  "message.downloadVideo": {
+    "message": "Λήψη βίντεο",
+    "description": "Σημείωση λήψης"
+  },
   "message.modelRequiresImage": {
-    "message": "This model requires an input image (image-to-video).",
-    "description": "Model requires image warning"
+    "message": "Αυτό το μοντέλο απαιτεί είσοδο εικόνας (βίντεο που δημιουργούνται από εικόνες).",
+    "description": "Προειδοποίηση ότι το μοντέλο απαιτεί εικόνα"
   },
   "message.promptOrImageRequired": {
-    "message": "Please enter a prompt or upload an image.",
-    "description": "Prompt or image required warning"
+    "message": "Παρακαλώ εισάγετε προτροπή ή ανεβάστε εικόνα.",
+    "description": "Προειδοποίηση ότι απαιτείται προτροπή ή εικόνα"
   },
-  "message.startingTask": { "message": "Submitting your video generation task…", "description": "Starting task" },
-  "message.startTaskSuccess": { "message": "Task submitted successfully.", "description": "Task success" },
-  "message.startTaskFailed": { "message": "Failed to submit task: ", "description": "Task failed" },
-  "message.usedUp": { "message": "Your quota has been used up. Please purchase more to continue.", "description": "Used up" }
+  "message.startingTask": {
+    "message": "Υποβάλλεται η εργασία δημιουργίας βίντεο…",
+    "description": "Ξεκινώντας εργασία"
+  },
+  "message.startTaskSuccess": {
+    "message": "Η υποβολή της εργασίας ήταν επιτυχής.",
+    "description": "Επιτυχία εργασίας"
+  },
+  "message.startTaskFailed": {
+    "message": "Η υποβολή της εργασίας απέτυχε:",
+    "description": "Αποτυχία εργασίας"
+  },
+  "message.usedUp": {
+    "message": "Η ποσόστωση έχει εξαντληθεί, παρακαλώ αγοράστε για να συνεχίσετε τη χρήση.",
+    "description": "Εξαντλημένο"
+  }
 }

--- a/src/i18n/es/grokvideo.json
+++ b/src/i18n/es/grokvideo.json
@@ -1,61 +1,154 @@
 {
-  "name.bot": { "message": "Grok Video Bot", "description": "Name of the Grok video generator" },
-  "name.prompt": { "message": "Prompt", "description": "Prompt for generating the video" },
-  "name.model": { "message": "Model", "description": "Label for model selection" },
-  "name.ratio": { "message": "Aspect Ratio", "description": "Label for aspect ratio" },
-  "name.resolution": { "message": "Resolution", "description": "Label for resolution" },
-  "name.duration": { "message": "Duration", "description": "Label for duration" },
-  "name.image": { "message": "Image", "description": "Label for input image" },
-  "name.required": { "message": "Required", "description": "Required badge" },
-  "name.taskId": { "message": "Task ID", "description": "Task id label" },
-  "name.elapsed": { "message": "Elapsed", "description": "Elapsed time label" },
-  "name.traceId": { "message": "Trace ID", "description": "Trace id label" },
-  "name.failure": { "message": "Generation Failed", "description": "Failure title" },
-  "name.failureReason": { "message": "Reason", "description": "Failure reason label" },
-  "name.status": { "message": "Status", "description": "Status title" },
+  "name.bot": {
+    "message": "Grok Video Bot",
+    "description": "Nombre del generador de video Grok"
+  },
+  "name.prompt": {
+    "message": "Palabra clave",
+    "description": "Palabra clave para generar el video"
+  },
+  "name.model": {
+    "message": "Modelo",
+    "description": "Etiqueta para la selección de modelo"
+  },
+  "name.ratio": {
+    "message": "Relación de aspecto",
+    "description": "Etiqueta para la relación de aspecto"
+  },
+  "name.resolution": {
+    "message": "Resolución",
+    "description": "Etiqueta para la resolución"
+  },
+  "name.duration": {
+    "message": "Duración",
+    "description": "Etiqueta para la duración"
+  },
+  "name.image": {
+    "message": "Imagen",
+    "description": "Etiqueta para la entrada de imagen"
+  },
+  "name.required": {
+    "message": "Requerido",
+    "description": "Insignia de requerido"
+  },
+  "name.taskId": {
+    "message": "ID de tarea",
+    "description": "Etiqueta para el ID de tarea"
+  },
+  "name.elapsed": {
+    "message": "Tiempo transcurrido",
+    "description": "Etiqueta de tiempo transcurrido"
+  },
+  "name.traceId": {
+    "message": "ID de seguimiento",
+    "description": "Etiqueta para el ID de seguimiento"
+  },
+  "name.failure": {
+    "message": "Error en la generación",
+    "description": "Título de error"
+  },
+  "name.failureReason": {
+    "message": "Razón del fallo",
+    "description": "Etiqueta de razón del fallo"
+  },
+  "name.status": {
+    "message": "Estado",
+    "description": "Título del estado"
+  },
   "description.prompt": {
-    "message": "Describe the video you want to generate (scene, subject, motion, camera, lighting, style).",
-    "description": "Instructions for prompt input"
+    "message": "Describe el video que deseas generar (escena, sujeto, acción, toma, luz, estilo).",
+    "description": "Instrucciones para la entrada de prompt"
   },
   "description.model": {
-    "message": "Choose the Grok Imagine model. grok-imagine-video supports text and image; 1.5-preview is image-to-video only.",
-    "description": "Instructions for model selection"
+    "message": "Selecciona el modelo Grok Imagine. grok-imagine-video admite video generado por texto e imagen; 1.5-preview solo admite video generado por imagen.",
+    "description": "Instrucciones para la selección de modelo"
   },
-  "description.ratio": { "message": "Select the output aspect ratio.", "description": "Instructions for aspect ratio" },
+  "description.ratio": {
+    "message": "Selecciona la relación de aspecto de salida.",
+    "description": "Instrucciones para la relación de aspecto"
+  },
   "description.resolution": {
-    "message": "Select the output resolution. Higher resolution costs more credits per second.",
-    "description": "Instructions for resolution"
+    "message": "Selecciona la resolución de salida. Cuanto mayor sea la resolución, más crédito se consumirá por segundo.",
+    "description": "Instrucciones para la resolución"
   },
   "description.duration": {
-    "message": "Video duration in seconds. Billed per output second.",
-    "description": "Instructions for duration"
+    "message": "Duración del video (segundos), facturado por el número de segundos de salida.",
+    "description": "Instrucciones para la duración"
   },
   "description.image": {
-    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5-preview.",
-    "description": "Instructions for image input"
+    "message": "Imagen de entrada opcional, utilizada para generar video. grok-imagine-video-1.5-preview es obligatorio.",
+    "description": "Instrucciones para la entrada de imagen"
   },
-  "placeholder.prompt": { "message": "Describe your video…", "description": "Placeholder for prompt" },
-  "placeholder.select": { "message": "Please select", "description": "Placeholder for selects" },
-  "model.default": { "message": "Grok Imagine Video", "description": "Default model label" },
-  "model.preview15": { "message": "Grok Imagine Video 1.5 (Preview, image-to-video)", "description": "1.5 preview model label" },
-  "button.upload": { "message": "Upload", "description": "Upload button" },
-  "button.generate": { "message": "Generate", "description": "Generate button" },
-  "button.download": { "message": "Download", "description": "Download button" },
-  "status.pending": { "message": "Pending", "description": "Pending status" },
-  "status.processing": { "message": "Processing", "description": "Processing status" },
-  "message.uploadExceed": { "message": "You can upload only one image.", "description": "Upload exceed warning" },
-  "message.uploadError": { "message": "Image upload failed, please try again.", "description": "Upload error" },
-  "message.downloadVideo": { "message": "Download video", "description": "Download tooltip" },
+  "placeholder.prompt": {
+    "message": "Describe tu video…",
+    "description": "Placeholder para la palabra clave"
+  },
+  "placeholder.select": {
+    "message": "Por favor selecciona",
+    "description": "Placeholder para selecciones"
+  },
+  "model.default": {
+    "message": "Grok Imagine Video",
+    "description": "Etiqueta del modelo por defecto"
+  },
+  "model.preview15": {
+    "message": "Grok Imagine Video 1.5 (vista previa, video generado por imagen)",
+    "description": "Etiqueta del modelo de vista previa 1.5"
+  },
+  "button.upload": {
+    "message": "Subir",
+    "description": "Botón de subida"
+  },
+  "button.generate": {
+    "message": "Generar",
+    "description": "Botón de generación"
+  },
+  "button.download": {
+    "message": "Descargar",
+    "description": "Botón de descarga"
+  },
+  "status.pending": {
+    "message": "En cola",
+    "description": "Estado pendiente"
+  },
+  "status.processing": {
+    "message": "Procesando",
+    "description": "Estado de procesamiento"
+  },
+  "message.uploadExceed": {
+    "message": "Solo se puede subir una imagen.",
+    "description": "Advertencia de exceso de subida"
+  },
+  "message.uploadError": {
+    "message": "Error al subir la imagen, por favor intenta de nuevo.",
+    "description": "Error de subida"
+  },
+  "message.downloadVideo": {
+    "message": "Descargar video",
+    "description": "Tooltip de descarga"
+  },
   "message.modelRequiresImage": {
-    "message": "This model requires an input image (image-to-video).",
-    "description": "Model requires image warning"
+    "message": "Este modelo requiere una imagen de entrada (video generado por imagen).",
+    "description": "Advertencia de que el modelo requiere imagen"
   },
   "message.promptOrImageRequired": {
-    "message": "Please enter a prompt or upload an image.",
-    "description": "Prompt or image required warning"
+    "message": "Por favor, ingresa un prompt o sube una imagen.",
+    "description": "Advertencia de que se requiere un prompt o imagen"
   },
-  "message.startingTask": { "message": "Submitting your video generation task…", "description": "Starting task" },
-  "message.startTaskSuccess": { "message": "Task submitted successfully.", "description": "Task success" },
-  "message.startTaskFailed": { "message": "Failed to submit task: ", "description": "Task failed" },
-  "message.usedUp": { "message": "Your quota has been used up. Please purchase more to continue.", "description": "Used up" }
+  "message.startingTask": {
+    "message": "Enviando tarea de generación de video…",
+    "description": "Iniciando tarea"
+  },
+  "message.startTaskSuccess": {
+    "message": "Tarea enviada con éxito.",
+    "description": "Éxito de tarea"
+  },
+  "message.startTaskFailed": {
+    "message": "Error al enviar la tarea:",
+    "description": "Error de tarea"
+  },
+  "message.usedUp": {
+    "message": "Crédito agotado, por favor compra más para continuar usando.",
+    "description": "Agotado"
+  }
 }

--- a/src/i18n/fi/grokvideo.json
+++ b/src/i18n/fi/grokvideo.json
@@ -1,61 +1,154 @@
 {
-  "name.bot": { "message": "Grok Video Bot", "description": "Name of the Grok video generator" },
-  "name.prompt": { "message": "Prompt", "description": "Prompt for generating the video" },
-  "name.model": { "message": "Model", "description": "Label for model selection" },
-  "name.ratio": { "message": "Aspect Ratio", "description": "Label for aspect ratio" },
-  "name.resolution": { "message": "Resolution", "description": "Label for resolution" },
-  "name.duration": { "message": "Duration", "description": "Label for duration" },
-  "name.image": { "message": "Image", "description": "Label for input image" },
-  "name.required": { "message": "Required", "description": "Required badge" },
-  "name.taskId": { "message": "Task ID", "description": "Task id label" },
-  "name.elapsed": { "message": "Elapsed", "description": "Elapsed time label" },
-  "name.traceId": { "message": "Trace ID", "description": "Trace id label" },
-  "name.failure": { "message": "Generation Failed", "description": "Failure title" },
-  "name.failureReason": { "message": "Reason", "description": "Failure reason label" },
-  "name.status": { "message": "Status", "description": "Status title" },
+  "name.bot": {
+    "message": "Grok Video -robotti",
+    "description": "Grok-video generoijan nimi"
+  },
+  "name.prompt": {
+    "message": "Kehotus",
+    "description": "Videoiden luontikehotus"
+  },
+  "name.model": {
+    "message": "Malli",
+    "description": "Mallin valinnan etiketti"
+  },
+  "name.ratio": {
+    "message": "Kuvasuhde",
+    "description": "Kuvasuhteen etiketti"
+  },
+  "name.resolution": {
+    "message": "Resoluutio",
+    "description": "Resoluutio-etiketti"
+  },
+  "name.duration": {
+    "message": "Kesto",
+    "description": "Keston etiketti"
+  },
+  "name.image": {
+    "message": "Kuva",
+    "description": "Syöttokuvan etiketti"
+  },
+  "name.required": {
+    "message": "Pakollinen",
+    "description": "Pakollinen merkki"
+  },
+  "name.taskId": {
+    "message": "Tehtävän ID",
+    "description": "Tehtävän ID-etiketti"
+  },
+  "name.elapsed": {
+    "message": "Kulunut aika",
+    "description": "Kuluneen ajan etiketti"
+  },
+  "name.traceId": {
+    "message": "Seuranta ID",
+    "description": "Seuranta ID-etiketti"
+  },
+  "name.failure": {
+    "message": "Tuotanto epäonnistui",
+    "description": "Epäonnistumisen otsikko"
+  },
+  "name.failureReason": {
+    "message": "Epäonnistumisen syy",
+    "description": "Epäonnistumisen syyn etiketti"
+  },
+  "name.status": {
+    "message": "Tila",
+    "description": "Tilamerkintä"
+  },
   "description.prompt": {
-    "message": "Describe the video you want to generate (scene, subject, motion, camera, lighting, style).",
-    "description": "Instructions for prompt input"
+    "message": "Kuvaile haluamaasi videota (kohtaus, aihe, toiminta, kuvakulma, valaistus, tyyli).",
+    "description": "Ohjeet kehotteen syöttämiseen"
   },
   "description.model": {
-    "message": "Choose the Grok Imagine model. grok-imagine-video supports text and image; 1.5-preview is image-to-video only.",
-    "description": "Instructions for model selection"
+    "message": "Valitse Grok Imagine -malli. grok-imagine-video tukee tekstistä kuvaan -videoita; 1.5-preview tukee vain kuvaan perustuvia videoita.",
+    "description": "Ohjeet mallin valintaan"
   },
-  "description.ratio": { "message": "Select the output aspect ratio.", "description": "Instructions for aspect ratio" },
+  "description.ratio": {
+    "message": "Valitse ulostulojen kuvasuhde.",
+    "description": "Ohjeet kuvasuhteen valintaan"
+  },
   "description.resolution": {
-    "message": "Select the output resolution. Higher resolution costs more credits per second.",
-    "description": "Instructions for resolution"
+    "message": "Valitse ulostulojen resoluutio. Korkeampi resoluutio kuluttaa enemmän varoja sekunnissa.",
+    "description": "Ohjeet resoluution valintaan"
   },
   "description.duration": {
-    "message": "Video duration in seconds. Billed per output second.",
-    "description": "Instructions for duration"
+    "message": "Videon kesto (sekunteina), laskutetaan ulostulojen sekuntien mukaan.",
+    "description": "Ohjeet keston syöttämiseen"
   },
   "description.image": {
-    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5-preview.",
-    "description": "Instructions for image input"
+    "message": "Valinnainen syötekuva videon tuottamiseen. grok-imagine-video-1.5-preview on pakollinen.",
+    "description": "Ohjeet kuva syötteelle"
   },
-  "placeholder.prompt": { "message": "Describe your video…", "description": "Placeholder for prompt" },
-  "placeholder.select": { "message": "Please select", "description": "Placeholder for selects" },
-  "model.default": { "message": "Grok Imagine Video", "description": "Default model label" },
-  "model.preview15": { "message": "Grok Imagine Video 1.5 (Preview, image-to-video)", "description": "1.5 preview model label" },
-  "button.upload": { "message": "Upload", "description": "Upload button" },
-  "button.generate": { "message": "Generate", "description": "Generate button" },
-  "button.download": { "message": "Download", "description": "Download button" },
-  "status.pending": { "message": "Pending", "description": "Pending status" },
-  "status.processing": { "message": "Processing", "description": "Processing status" },
-  "message.uploadExceed": { "message": "You can upload only one image.", "description": "Upload exceed warning" },
-  "message.uploadError": { "message": "Image upload failed, please try again.", "description": "Upload error" },
-  "message.downloadVideo": { "message": "Download video", "description": "Download tooltip" },
+  "placeholder.prompt": {
+    "message": "Kuvaile videota…",
+    "description": "Kehotteen paikkamerkki"
+  },
+  "placeholder.select": {
+    "message": "Valitse",
+    "description": "Valintojen paikkamerkki"
+  },
+  "model.default": {
+    "message": "Grok Imagine -video",
+    "description": "Oletusmallin etiketti"
+  },
+  "model.preview15": {
+    "message": "Grok Imagine -video 1.5 (esikatselu, kuvaan perustuva video)",
+    "description": "1.5 esikatselumallin etiketti"
+  },
+  "button.upload": {
+    "message": "Lataa",
+    "description": "Latauspainike"
+  },
+  "button.generate": {
+    "message": "Tuota",
+    "description": "Tuotantopainike"
+  },
+  "button.download": {
+    "message": "Lataa",
+    "description": "Latauspainike"
+  },
+  "status.pending": {
+    "message": "Jonossa",
+    "description": "Odotustila"
+  },
+  "status.processing": {
+    "message": "Luodaan",
+    "description": "Käsittelytila"
+  },
+  "message.uploadExceed": {
+    "message": "Vain yksi kuva voidaan ladata.",
+    "description": "Latausylitysvaroitus"
+  },
+  "message.uploadError": {
+    "message": "Kuvan lataaminen epäonnistui, yritä uudelleen.",
+    "description": "Latausvirhe"
+  },
+  "message.downloadVideo": {
+    "message": "Lataa video",
+    "description": "Lataustyökalu"
+  },
   "message.modelRequiresImage": {
-    "message": "This model requires an input image (image-to-video).",
-    "description": "Model requires image warning"
+    "message": "Tämä malli vaatii syötekuvan (kuvaan perustuva video).",
+    "description": "Malli vaatii kuvan varoitus"
   },
   "message.promptOrImageRequired": {
-    "message": "Please enter a prompt or upload an image.",
-    "description": "Prompt or image required warning"
+    "message": "Syötä kehotteet tai lataa kuva.",
+    "description": "Kehote tai kuva vaaditaan varoitus"
   },
-  "message.startingTask": { "message": "Submitting your video generation task…", "description": "Starting task" },
-  "message.startTaskSuccess": { "message": "Task submitted successfully.", "description": "Task success" },
-  "message.startTaskFailed": { "message": "Failed to submit task: ", "description": "Task failed" },
-  "message.usedUp": { "message": "Your quota has been used up. Please purchase more to continue.", "description": "Used up" }
+  "message.startingTask": {
+    "message": "Videon tuotantotehtävää lähetetään…",
+    "description": "Tehtävän aloitus"
+  },
+  "message.startTaskSuccess": {
+    "message": "Tehtävän lähettäminen onnistui.",
+    "description": "Tehtävä onnistui"
+  },
+  "message.startTaskFailed": {
+    "message": "Tehtävän lähettäminen epäonnistui:",
+    "description": "Tehtävä epäonnistui"
+  },
+  "message.usedUp": {
+    "message": "Varat on käytetty loppuun, osta lisää jatkaaksesi käyttöä.",
+    "description": "Loppu"
+  }
 }

--- a/src/i18n/fr/grokvideo.json
+++ b/src/i18n/fr/grokvideo.json
@@ -1,61 +1,154 @@
 {
-  "name.bot": { "message": "Grok Video Bot", "description": "Name of the Grok video generator" },
-  "name.prompt": { "message": "Prompt", "description": "Prompt for generating the video" },
-  "name.model": { "message": "Model", "description": "Label for model selection" },
-  "name.ratio": { "message": "Aspect Ratio", "description": "Label for aspect ratio" },
-  "name.resolution": { "message": "Resolution", "description": "Label for resolution" },
-  "name.duration": { "message": "Duration", "description": "Label for duration" },
-  "name.image": { "message": "Image", "description": "Label for input image" },
-  "name.required": { "message": "Required", "description": "Required badge" },
-  "name.taskId": { "message": "Task ID", "description": "Task id label" },
-  "name.elapsed": { "message": "Elapsed", "description": "Elapsed time label" },
-  "name.traceId": { "message": "Trace ID", "description": "Trace id label" },
-  "name.failure": { "message": "Generation Failed", "description": "Failure title" },
-  "name.failureReason": { "message": "Reason", "description": "Failure reason label" },
-  "name.status": { "message": "Status", "description": "Status title" },
+  "name.bot": {
+    "message": "Robot Vidéo Grok",
+    "description": "Nom du générateur de vidéo Grok"
+  },
+  "name.prompt": {
+    "message": "Invite",
+    "description": "Invite pour générer la vidéo"
+  },
+  "name.model": {
+    "message": "Modèle",
+    "description": "Étiquette pour la sélection du modèle"
+  },
+  "name.ratio": {
+    "message": "Ratio d'image",
+    "description": "Étiquette pour le rapport d'aspect"
+  },
+  "name.resolution": {
+    "message": "Résolution",
+    "description": "Étiquette pour la résolution"
+  },
+  "name.duration": {
+    "message": "Durée",
+    "description": "Étiquette pour la durée"
+  },
+  "name.image": {
+    "message": "Image",
+    "description": "Étiquette pour l'image d'entrée"
+  },
+  "name.required": {
+    "message": "Champ requis",
+    "description": "Badge indiquant que le champ est obligatoire"
+  },
+  "name.taskId": {
+    "message": "ID de tâche",
+    "description": "Étiquette pour l'identifiant de la tâche"
+  },
+  "name.elapsed": {
+    "message": "Temps écoulé",
+    "description": "Étiquette du temps écoulé"
+  },
+  "name.traceId": {
+    "message": "ID de suivi",
+    "description": "Étiquette pour l'identifiant de suivi"
+  },
+  "name.failure": {
+    "message": "Échec de la génération",
+    "description": "Titre de l'échec"
+  },
+  "name.failureReason": {
+    "message": "Raison de l'échec",
+    "description": "Étiquette de la raison de l'échec"
+  },
+  "name.status": {
+    "message": "Statut",
+    "description": "Titre du statut"
+  },
   "description.prompt": {
-    "message": "Describe the video you want to generate (scene, subject, motion, camera, lighting, style).",
-    "description": "Instructions for prompt input"
+    "message": "Décrivez la vidéo que vous souhaitez générer (scène, sujet, action, plan, lumière, style).",
+    "description": "Instructions pour l'entrée de prompt"
   },
   "description.model": {
-    "message": "Choose the Grok Imagine model. grok-imagine-video supports text and image; 1.5-preview is image-to-video only.",
-    "description": "Instructions for model selection"
+    "message": "Sélectionnez le modèle Grok Imagine. grok-imagine-video prend en charge les vidéos générées par texte et par image ; 1.5-preview prend uniquement en charge les vidéos générées par image.",
+    "description": "Instructions pour la sélection du modèle"
   },
-  "description.ratio": { "message": "Select the output aspect ratio.", "description": "Instructions for aspect ratio" },
+  "description.ratio": {
+    "message": "Sélectionnez le rapport d'aspect de sortie.",
+    "description": "Instructions pour le rapport d'aspect"
+  },
   "description.resolution": {
-    "message": "Select the output resolution. Higher resolution costs more credits per second.",
-    "description": "Instructions for resolution"
+    "message": "Sélectionnez la résolution de sortie. Plus la résolution est élevée, plus le quota consommé par seconde est important.",
+    "description": "Instructions pour la résolution"
   },
   "description.duration": {
-    "message": "Video duration in seconds. Billed per output second.",
-    "description": "Instructions for duration"
+    "message": "Durée de la vidéo (secondes), facturée par seconde de sortie.",
+    "description": "Instructions pour la durée"
   },
   "description.image": {
-    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5-preview.",
-    "description": "Instructions for image input"
+    "message": "Image d'entrée optionnelle pour générer une vidéo. grok-imagine-video-1.5-preview est requis.",
+    "description": "Instructions pour l'entrée d'image"
   },
-  "placeholder.prompt": { "message": "Describe your video…", "description": "Placeholder for prompt" },
-  "placeholder.select": { "message": "Please select", "description": "Placeholder for selects" },
-  "model.default": { "message": "Grok Imagine Video", "description": "Default model label" },
-  "model.preview15": { "message": "Grok Imagine Video 1.5 (Preview, image-to-video)", "description": "1.5 preview model label" },
-  "button.upload": { "message": "Upload", "description": "Upload button" },
-  "button.generate": { "message": "Generate", "description": "Generate button" },
-  "button.download": { "message": "Download", "description": "Download button" },
-  "status.pending": { "message": "Pending", "description": "Pending status" },
-  "status.processing": { "message": "Processing", "description": "Processing status" },
-  "message.uploadExceed": { "message": "You can upload only one image.", "description": "Upload exceed warning" },
-  "message.uploadError": { "message": "Image upload failed, please try again.", "description": "Upload error" },
-  "message.downloadVideo": { "message": "Download video", "description": "Download tooltip" },
+  "placeholder.prompt": {
+    "message": "Décrivez votre vidéo…",
+    "description": "Espace réservé pour l'invite"
+  },
+  "placeholder.select": {
+    "message": "Veuillez sélectionner",
+    "description": "Espace réservé pour les sélections"
+  },
+  "model.default": {
+    "message": "Grok Imagine Vidéo",
+    "description": "Étiquette du modèle par défaut"
+  },
+  "model.preview15": {
+    "message": "Grok Imagine Vidéo 1.5 (aperçu, vidéo générée par image)",
+    "description": "Étiquette du modèle 1.5 aperçu"
+  },
+  "button.upload": {
+    "message": "Téléverser",
+    "description": "Bouton de téléversement"
+  },
+  "button.generate": {
+    "message": "Générer",
+    "description": "Bouton de génération"
+  },
+  "button.download": {
+    "message": "Télécharger",
+    "description": "Bouton de téléchargement"
+  },
+  "status.pending": {
+    "message": "En attente",
+    "description": "Statut en attente"
+  },
+  "status.processing": {
+    "message": "En cours de génération",
+    "description": "Statut de traitement"
+  },
+  "message.uploadExceed": {
+    "message": "Vous ne pouvez téléverser qu'une seule image.",
+    "description": "Avertissement sur le dépassement de téléversement"
+  },
+  "message.uploadError": {
+    "message": "Échec du téléversement de l'image, veuillez réessayer.",
+    "description": "Erreur de téléversement"
+  },
+  "message.downloadVideo": {
+    "message": "Télécharger la vidéo",
+    "description": "Infobulle de téléchargement"
+  },
   "message.modelRequiresImage": {
-    "message": "This model requires an input image (image-to-video).",
-    "description": "Model requires image warning"
+    "message": "Ce modèle nécessite une image d'entrée (vidéo générée par image).",
+    "description": "Avertissement sur le modèle nécessitant une image"
   },
   "message.promptOrImageRequired": {
-    "message": "Please enter a prompt or upload an image.",
-    "description": "Prompt or image required warning"
+    "message": "Veuillez entrer un prompt ou téléverser une image.",
+    "description": "Avertissement sur le prompt ou l'image requis"
   },
-  "message.startingTask": { "message": "Submitting your video generation task…", "description": "Starting task" },
-  "message.startTaskSuccess": { "message": "Task submitted successfully.", "description": "Task success" },
-  "message.startTaskFailed": { "message": "Failed to submit task: ", "description": "Task failed" },
-  "message.usedUp": { "message": "Your quota has been used up. Please purchase more to continue.", "description": "Used up" }
+  "message.startingTask": {
+    "message": "Soumission de la tâche de génération de vidéo…",
+    "description": "Démarrage de la tâche"
+  },
+  "message.startTaskSuccess": {
+    "message": "Soumission de la tâche réussie.",
+    "description": "Succès de la tâche"
+  },
+  "message.startTaskFailed": {
+    "message": "Échec de la soumission de la tâche :",
+    "description": "Échec de la tâche"
+  },
+  "message.usedUp": {
+    "message": "Quota épuisé, veuillez acheter pour continuer à utiliser.",
+    "description": "Épuisé"
+  }
 }

--- a/src/i18n/it/grokvideo.json
+++ b/src/i18n/it/grokvideo.json
@@ -1,61 +1,154 @@
 {
-  "name.bot": { "message": "Grok Video Bot", "description": "Name of the Grok video generator" },
-  "name.prompt": { "message": "Prompt", "description": "Prompt for generating the video" },
-  "name.model": { "message": "Model", "description": "Label for model selection" },
-  "name.ratio": { "message": "Aspect Ratio", "description": "Label for aspect ratio" },
-  "name.resolution": { "message": "Resolution", "description": "Label for resolution" },
-  "name.duration": { "message": "Duration", "description": "Label for duration" },
-  "name.image": { "message": "Image", "description": "Label for input image" },
-  "name.required": { "message": "Required", "description": "Required badge" },
-  "name.taskId": { "message": "Task ID", "description": "Task id label" },
-  "name.elapsed": { "message": "Elapsed", "description": "Elapsed time label" },
-  "name.traceId": { "message": "Trace ID", "description": "Trace id label" },
-  "name.failure": { "message": "Generation Failed", "description": "Failure title" },
-  "name.failureReason": { "message": "Reason", "description": "Failure reason label" },
-  "name.status": { "message": "Status", "description": "Status title" },
+  "name.bot": {
+    "message": "Grok Video Bot",
+    "description": "Nome del generatore di video Grok"
+  },
+  "name.prompt": {
+    "message": "Parola chiave",
+    "description": "Parola chiave per generare il video"
+  },
+  "name.model": {
+    "message": "Modello",
+    "description": "Etichetta per la selezione del modello"
+  },
+  "name.ratio": {
+    "message": "Rapporto d'aspetto",
+    "description": "Etichetta per il rapporto d'aspetto"
+  },
+  "name.resolution": {
+    "message": "Risoluzione",
+    "description": "Etichetta per la risoluzione"
+  },
+  "name.duration": {
+    "message": "Durata",
+    "description": "Etichetta per la durata"
+  },
+  "name.image": {
+    "message": "Immagine",
+    "description": "Etichetta per l'immagine di input"
+  },
+  "name.required": {
+    "message": "Obbligatorio",
+    "description": "Badge per campo obbligatorio"
+  },
+  "name.taskId": {
+    "message": "ID attività",
+    "description": "Etichetta per l'ID dell'attività"
+  },
+  "name.elapsed": {
+    "message": "Tempo trascorso",
+    "description": "Etichetta per il tempo trascorso"
+  },
+  "name.traceId": {
+    "message": "ID tracciamento",
+    "description": "Etichetta per l'ID di tracciamento"
+  },
+  "name.failure": {
+    "message": "Generazione fallita",
+    "description": "Titolo di fallimento"
+  },
+  "name.failureReason": {
+    "message": "Motivo del fallimento",
+    "description": "Etichetta per il motivo del fallimento"
+  },
+  "name.status": {
+    "message": "Stato",
+    "description": "Titolo dello stato"
+  },
   "description.prompt": {
-    "message": "Describe the video you want to generate (scene, subject, motion, camera, lighting, style).",
-    "description": "Instructions for prompt input"
+    "message": "Descrivi il video che desideri generare (scena, soggetto, azione, inquadratura, luce, stile).",
+    "description": "Istruzioni per l'input del prompt"
   },
   "description.model": {
-    "message": "Choose the Grok Imagine model. grok-imagine-video supports text and image; 1.5-preview is image-to-video only.",
-    "description": "Instructions for model selection"
+    "message": "Seleziona il modello Grok Imagine. grok-imagine-video supporta video generati da testo e da immagini; 1.5-preview supporta solo video generati da immagini.",
+    "description": "Istruzioni per la selezione del modello"
   },
-  "description.ratio": { "message": "Select the output aspect ratio.", "description": "Instructions for aspect ratio" },
+  "description.ratio": {
+    "message": "Seleziona il rapporto d'aspetto dell'output.",
+    "description": "Istruzioni per il rapporto d'aspetto"
+  },
   "description.resolution": {
-    "message": "Select the output resolution. Higher resolution costs more credits per second.",
-    "description": "Instructions for resolution"
+    "message": "Seleziona la risoluzione di output. Maggiore è la risoluzione, maggiore è il consumo per secondo.",
+    "description": "Istruzioni per la risoluzione"
   },
   "description.duration": {
-    "message": "Video duration in seconds. Billed per output second.",
-    "description": "Instructions for duration"
+    "message": "Durata del video (secondi), addebitato in base ai secondi di output.",
+    "description": "Istruzioni per la durata"
   },
   "description.image": {
-    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5-preview.",
-    "description": "Instructions for image input"
+    "message": "Immagine di input opzionale, utilizzata per generare video. grok-imagine-video-1.5-preview è obbligatorio.",
+    "description": "Istruzioni per l'input dell'immagine"
   },
-  "placeholder.prompt": { "message": "Describe your video…", "description": "Placeholder for prompt" },
-  "placeholder.select": { "message": "Please select", "description": "Placeholder for selects" },
-  "model.default": { "message": "Grok Imagine Video", "description": "Default model label" },
-  "model.preview15": { "message": "Grok Imagine Video 1.5 (Preview, image-to-video)", "description": "1.5 preview model label" },
-  "button.upload": { "message": "Upload", "description": "Upload button" },
-  "button.generate": { "message": "Generate", "description": "Generate button" },
-  "button.download": { "message": "Download", "description": "Download button" },
-  "status.pending": { "message": "Pending", "description": "Pending status" },
-  "status.processing": { "message": "Processing", "description": "Processing status" },
-  "message.uploadExceed": { "message": "You can upload only one image.", "description": "Upload exceed warning" },
-  "message.uploadError": { "message": "Image upload failed, please try again.", "description": "Upload error" },
-  "message.downloadVideo": { "message": "Download video", "description": "Download tooltip" },
+  "placeholder.prompt": {
+    "message": "Descrivi il tuo video…",
+    "description": "Placeholder per la parola chiave"
+  },
+  "placeholder.select": {
+    "message": "Seleziona",
+    "description": "Placeholder per le selezioni"
+  },
+  "model.default": {
+    "message": "Grok Imagine Video",
+    "description": "Etichetta del modello predefinito"
+  },
+  "model.preview15": {
+    "message": "Grok Imagine Video 1.5 (anteprima, video generato da immagini)",
+    "description": "Etichetta del modello anteprima 1.5"
+  },
+  "button.upload": {
+    "message": "Carica",
+    "description": "Pulsante di upload"
+  },
+  "button.generate": {
+    "message": "Genera",
+    "description": "Pulsante di generazione"
+  },
+  "button.download": {
+    "message": "Scarica",
+    "description": "Pulsante di download"
+  },
+  "status.pending": {
+    "message": "In coda",
+    "description": "Stato in attesa"
+  },
+  "status.processing": {
+    "message": "In elaborazione",
+    "description": "Stato di elaborazione"
+  },
+  "message.uploadExceed": {
+    "message": "Puoi caricare solo un'immagine.",
+    "description": "Avviso di superamento dell'upload"
+  },
+  "message.uploadError": {
+    "message": "Caricamento dell'immagine fallito, riprova.",
+    "description": "Errore di upload"
+  },
+  "message.downloadVideo": {
+    "message": "Scarica video",
+    "description": "Tooltip di download"
+  },
   "message.modelRequiresImage": {
-    "message": "This model requires an input image (image-to-video).",
-    "description": "Model requires image warning"
+    "message": "Questo modello richiede un'immagine di input (video generato da immagini).",
+    "description": "Avviso che il modello richiede un'immagine"
   },
   "message.promptOrImageRequired": {
-    "message": "Please enter a prompt or upload an image.",
-    "description": "Prompt or image required warning"
+    "message": "Inserisci un prompt o carica un'immagine.",
+    "description": "Avviso che richiede un prompt o un'immagine"
   },
-  "message.startingTask": { "message": "Submitting your video generation task…", "description": "Starting task" },
-  "message.startTaskSuccess": { "message": "Task submitted successfully.", "description": "Task success" },
-  "message.startTaskFailed": { "message": "Failed to submit task: ", "description": "Task failed" },
-  "message.usedUp": { "message": "Your quota has been used up. Please purchase more to continue.", "description": "Used up" }
+  "message.startingTask": {
+    "message": "Invio del compito di generazione video in corso…",
+    "description": "Avvio del compito"
+  },
+  "message.startTaskSuccess": {
+    "message": "Invio del compito riuscito.",
+    "description": "Successo del compito"
+  },
+  "message.startTaskFailed": {
+    "message": "Invio del compito fallito:",
+    "description": "Compito fallito"
+  },
+  "message.usedUp": {
+    "message": "Credito esaurito, acquista per continuare a utilizzare.",
+    "description": "Esaurito"
+  }
 }

--- a/src/i18n/ja/grokvideo.json
+++ b/src/i18n/ja/grokvideo.json
@@ -1,61 +1,154 @@
 {
-  "name.bot": { "message": "Grok Video Bot", "description": "Name of the Grok video generator" },
-  "name.prompt": { "message": "Prompt", "description": "Prompt for generating the video" },
-  "name.model": { "message": "Model", "description": "Label for model selection" },
-  "name.ratio": { "message": "Aspect Ratio", "description": "Label for aspect ratio" },
-  "name.resolution": { "message": "Resolution", "description": "Label for resolution" },
-  "name.duration": { "message": "Duration", "description": "Label for duration" },
-  "name.image": { "message": "Image", "description": "Label for input image" },
-  "name.required": { "message": "Required", "description": "Required badge" },
-  "name.taskId": { "message": "Task ID", "description": "Task id label" },
-  "name.elapsed": { "message": "Elapsed", "description": "Elapsed time label" },
-  "name.traceId": { "message": "Trace ID", "description": "Trace id label" },
-  "name.failure": { "message": "Generation Failed", "description": "Failure title" },
-  "name.failureReason": { "message": "Reason", "description": "Failure reason label" },
-  "name.status": { "message": "Status", "description": "Status title" },
+  "name.bot": {
+    "message": "Grok 動画ロボット",
+    "description": "Grok動画生成器の名前"
+  },
+  "name.prompt": {
+    "message": "プロンプト",
+    "description": "ビデオ生成のためのプロンプト"
+  },
+  "name.model": {
+    "message": "モデル",
+    "description": "モデル選択のラベル"
+  },
+  "name.ratio": {
+    "message": "アスペクト比",
+    "description": "アスペクト比のラベル"
+  },
+  "name.resolution": {
+    "message": "解像度",
+    "description": "解像度のラベル"
+  },
+  "name.duration": {
+    "message": "長さ",
+    "description": "長さのラベル"
+  },
+  "name.image": {
+    "message": "画像",
+    "description": "画像入力のラベル"
+  },
+  "name.required": {
+    "message": "必須",
+    "description": "必須バッジ"
+  },
+  "name.taskId": {
+    "message": "タスク ID",
+    "description": "タスク ID のラベル"
+  },
+  "name.elapsed": {
+    "message": "経過時間",
+    "description": "経過時間のラベル"
+  },
+  "name.traceId": {
+    "message": "トレース ID",
+    "description": "トレース ID のラベル"
+  },
+  "name.failure": {
+    "message": "生成失敗",
+    "description": "失敗タイトル"
+  },
+  "name.failureReason": {
+    "message": "失敗理由",
+    "description": "失敗理由のラベル"
+  },
+  "name.status": {
+    "message": "ステータス",
+    "description": "ステータスタイトル"
+  },
   "description.prompt": {
-    "message": "Describe the video you want to generate (scene, subject, motion, camera, lighting, style).",
-    "description": "Instructions for prompt input"
+    "message": "生成したい動画を説明してください（シーン、主体、アクション、ショット、光、スタイル）。",
+    "description": "プロンプト入力に関する指示"
   },
   "description.model": {
-    "message": "Choose the Grok Imagine model. grok-imagine-video supports text and image; 1.5-preview is image-to-video only.",
-    "description": "Instructions for model selection"
+    "message": "Grok Imagineモデルを選択します。grok-imagine-videoはテキストから画像生成と画像から動画生成をサポートします；1.5-previewは画像から動画生成のみサポートします。",
+    "description": "モデル選択に関する指示"
   },
-  "description.ratio": { "message": "Select the output aspect ratio.", "description": "Instructions for aspect ratio" },
+  "description.ratio": {
+    "message": "出力画面のアスペクト比を選択します。",
+    "description": "アスペクト比に関する指示"
+  },
   "description.resolution": {
-    "message": "Select the output resolution. Higher resolution costs more credits per second.",
-    "description": "Instructions for resolution"
+    "message": "出力解像度を選択します。解像度が高いほど、毎秒消費する額が増えます。",
+    "description": "解像度に関する指示"
   },
   "description.duration": {
-    "message": "Video duration in seconds. Billed per output second.",
-    "description": "Instructions for duration"
+    "message": "動画の長さ（秒）、出力秒数に基づいて課金されます。",
+    "description": "長さに関する指示"
   },
   "description.image": {
-    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5-preview.",
-    "description": "Instructions for image input"
+    "message": "オプションの入力画像、動画生成に使用します。grok-imagine-video-1.5-previewは必須です。",
+    "description": "画像入力に関する指示"
   },
-  "placeholder.prompt": { "message": "Describe your video…", "description": "Placeholder for prompt" },
-  "placeholder.select": { "message": "Please select", "description": "Placeholder for selects" },
-  "model.default": { "message": "Grok Imagine Video", "description": "Default model label" },
-  "model.preview15": { "message": "Grok Imagine Video 1.5 (Preview, image-to-video)", "description": "1.5 preview model label" },
-  "button.upload": { "message": "Upload", "description": "Upload button" },
-  "button.generate": { "message": "Generate", "description": "Generate button" },
-  "button.download": { "message": "Download", "description": "Download button" },
-  "status.pending": { "message": "Pending", "description": "Pending status" },
-  "status.processing": { "message": "Processing", "description": "Processing status" },
-  "message.uploadExceed": { "message": "You can upload only one image.", "description": "Upload exceed warning" },
-  "message.uploadError": { "message": "Image upload failed, please try again.", "description": "Upload error" },
-  "message.downloadVideo": { "message": "Download video", "description": "Download tooltip" },
+  "placeholder.prompt": {
+    "message": "あなたのビデオを説明してください…",
+    "description": "プロンプトのプレースホルダー"
+  },
+  "placeholder.select": {
+    "message": "選択してください",
+    "description": "選択のプレースホルダー"
+  },
+  "model.default": {
+    "message": "Grok Imagine 動画",
+    "description": "デフォルトモデルラベル"
+  },
+  "model.preview15": {
+    "message": "Grok Imagine 動画 1.5（プレビュー、画像から動画生成）",
+    "description": "1.5プレビューモデルラベル"
+  },
+  "button.upload": {
+    "message": "アップロード",
+    "description": "アップロードボタン"
+  },
+  "button.generate": {
+    "message": "生成",
+    "description": "生成ボタン"
+  },
+  "button.download": {
+    "message": "ダウンロード",
+    "description": "ダウンロードボタン"
+  },
+  "status.pending": {
+    "message": "保留中",
+    "description": "保留中のステータス"
+  },
+  "status.processing": {
+    "message": "処理中",
+    "description": "処理中のステータス"
+  },
+  "message.uploadExceed": {
+    "message": "画像は1枚のみアップロードできます。",
+    "description": "アップロード超過警告"
+  },
+  "message.uploadError": {
+    "message": "画像のアップロードに失敗しました。再試行してください。",
+    "description": "アップロードエラー"
+  },
+  "message.downloadVideo": {
+    "message": "動画をダウンロード",
+    "description": "ダウンロードツールチップ"
+  },
   "message.modelRequiresImage": {
-    "message": "This model requires an input image (image-to-video).",
-    "description": "Model requires image warning"
+    "message": "このモデルは画像入力が必要です（画像から動画生成）。",
+    "description": "モデルが画像を必要とする警告"
   },
   "message.promptOrImageRequired": {
-    "message": "Please enter a prompt or upload an image.",
-    "description": "Prompt or image required warning"
+    "message": "プロンプトまたは画像をアップロードしてください。",
+    "description": "プロンプトまたは画像が必要な警告"
   },
-  "message.startingTask": { "message": "Submitting your video generation task…", "description": "Starting task" },
-  "message.startTaskSuccess": { "message": "Task submitted successfully.", "description": "Task success" },
-  "message.startTaskFailed": { "message": "Failed to submit task: ", "description": "Task failed" },
-  "message.usedUp": { "message": "Your quota has been used up. Please purchase more to continue.", "description": "Used up" }
+  "message.startingTask": {
+    "message": "動画生成タスクを提出中…",
+    "description": "タスク開始"
+  },
+  "message.startTaskSuccess": {
+    "message": "タスクが正常に提出されました。",
+    "description": "タスク成功"
+  },
+  "message.startTaskFailed": {
+    "message": "タスクの提出に失敗しました：",
+    "description": "タスク失敗"
+  },
+  "message.usedUp": {
+    "message": "利用可能な額が使い切られました。購入後に続行してください。",
+    "description": "使い切り"
+  }
 }

--- a/src/i18n/ko/grokvideo.json
+++ b/src/i18n/ko/grokvideo.json
@@ -1,61 +1,154 @@
 {
-  "name.bot": { "message": "Grok Video Bot", "description": "Name of the Grok video generator" },
-  "name.prompt": { "message": "Prompt", "description": "Prompt for generating the video" },
-  "name.model": { "message": "Model", "description": "Label for model selection" },
-  "name.ratio": { "message": "Aspect Ratio", "description": "Label for aspect ratio" },
-  "name.resolution": { "message": "Resolution", "description": "Label for resolution" },
-  "name.duration": { "message": "Duration", "description": "Label for duration" },
-  "name.image": { "message": "Image", "description": "Label for input image" },
-  "name.required": { "message": "Required", "description": "Required badge" },
-  "name.taskId": { "message": "Task ID", "description": "Task id label" },
-  "name.elapsed": { "message": "Elapsed", "description": "Elapsed time label" },
-  "name.traceId": { "message": "Trace ID", "description": "Trace id label" },
-  "name.failure": { "message": "Generation Failed", "description": "Failure title" },
-  "name.failureReason": { "message": "Reason", "description": "Failure reason label" },
-  "name.status": { "message": "Status", "description": "Status title" },
+  "name.bot": {
+    "message": "Grok 비디오 봇",
+    "description": "Grok 비디오 생성기의 이름"
+  },
+  "name.prompt": {
+    "message": "프롬프트",
+    "description": "비디오 생성을 위한 프롬프트"
+  },
+  "name.model": {
+    "message": "모델",
+    "description": "모델 선택을 위한 레이블"
+  },
+  "name.ratio": {
+    "message": "화면 비율",
+    "description": "종횡비를 위한 레이블"
+  },
+  "name.resolution": {
+    "message": "해상도",
+    "description": "해상도를 위한 레이블"
+  },
+  "name.duration": {
+    "message": "길이",
+    "description": "길이에 대한 레이블"
+  },
+  "name.image": {
+    "message": "이미지",
+    "description": "입력 이미지의 레이블"
+  },
+  "name.required": {
+    "message": "필수",
+    "description": "필수 배지"
+  },
+  "name.taskId": {
+    "message": "작업 ID",
+    "description": "작업 ID 레이블"
+  },
+  "name.elapsed": {
+    "message": "소요 시간",
+    "description": "소요 시간 레이블"
+  },
+  "name.traceId": {
+    "message": "추적 ID",
+    "description": "추적 ID 레이블"
+  },
+  "name.failure": {
+    "message": "생성 실패",
+    "description": "실패 제목"
+  },
+  "name.failureReason": {
+    "message": "실패 원인",
+    "description": "실패 원인 레이블"
+  },
+  "name.status": {
+    "message": "상태",
+    "description": "상태 제목"
+  },
   "description.prompt": {
-    "message": "Describe the video you want to generate (scene, subject, motion, camera, lighting, style).",
-    "description": "Instructions for prompt input"
+    "message": "생성하고 싶은 비디오를 설명하세요(장면, 주제, 동작, 샷, 조명, 스타일).",
+    "description": "프롬프트 입력에 대한 설명"
   },
   "description.model": {
-    "message": "Choose the Grok Imagine model. grok-imagine-video supports text and image; 1.5-preview is image-to-video only.",
-    "description": "Instructions for model selection"
+    "message": "Grok Imagine 모델을 선택하세요. grok-imagine-video는 텍스트와 이미지 기반 비디오를 지원하며; 1.5-preview는 이미지 기반 비디오만 지원합니다.",
+    "description": "모델 선택에 대한 설명"
   },
-  "description.ratio": { "message": "Select the output aspect ratio.", "description": "Instructions for aspect ratio" },
+  "description.ratio": {
+    "message": "출력 화면 비율을 선택하세요.",
+    "description": "화면 비율에 대한 설명"
+  },
   "description.resolution": {
-    "message": "Select the output resolution. Higher resolution costs more credits per second.",
-    "description": "Instructions for resolution"
+    "message": "출력 해상도를 선택하세요. 해상도가 높을수록 초당 소모되는 크레딧이 많아집니다.",
+    "description": "해상도에 대한 설명"
   },
   "description.duration": {
-    "message": "Video duration in seconds. Billed per output second.",
-    "description": "Instructions for duration"
+    "message": "비디오 길이(초), 출력 초 수에 따라 요금이 청구됩니다.",
+    "description": "길이에 대한 설명"
   },
   "description.image": {
-    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5-preview.",
-    "description": "Instructions for image input"
+    "message": "비디오 생성을 위한 선택적 입력 이미지. grok-imagine-video-1.5-preview는 필수입니다.",
+    "description": "이미지 입력에 대한 설명"
   },
-  "placeholder.prompt": { "message": "Describe your video…", "description": "Placeholder for prompt" },
-  "placeholder.select": { "message": "Please select", "description": "Placeholder for selects" },
-  "model.default": { "message": "Grok Imagine Video", "description": "Default model label" },
-  "model.preview15": { "message": "Grok Imagine Video 1.5 (Preview, image-to-video)", "description": "1.5 preview model label" },
-  "button.upload": { "message": "Upload", "description": "Upload button" },
-  "button.generate": { "message": "Generate", "description": "Generate button" },
-  "button.download": { "message": "Download", "description": "Download button" },
-  "status.pending": { "message": "Pending", "description": "Pending status" },
-  "status.processing": { "message": "Processing", "description": "Processing status" },
-  "message.uploadExceed": { "message": "You can upload only one image.", "description": "Upload exceed warning" },
-  "message.uploadError": { "message": "Image upload failed, please try again.", "description": "Upload error" },
-  "message.downloadVideo": { "message": "Download video", "description": "Download tooltip" },
+  "placeholder.prompt": {
+    "message": "비디오를 설명하세요…",
+    "description": "프롬프트를 위한 플레이스홀더"
+  },
+  "placeholder.select": {
+    "message": "선택하세요",
+    "description": "선택을 위한 플레이스홀더"
+  },
+  "model.default": {
+    "message": "Grok Imagine 비디오",
+    "description": "기본 모델 레이블"
+  },
+  "model.preview15": {
+    "message": "Grok Imagine 비디오 1.5(미리보기, 이미지 기반 비디오)",
+    "description": "1.5 미리보기 모델 레이블"
+  },
+  "button.upload": {
+    "message": "업로드",
+    "description": "업로드 버튼"
+  },
+  "button.generate": {
+    "message": "생성",
+    "description": "생성 버튼"
+  },
+  "button.download": {
+    "message": "다운로드",
+    "description": "다운로드 버튼"
+  },
+  "status.pending": {
+    "message": "대기 중",
+    "description": "대기 상태"
+  },
+  "status.processing": {
+    "message": "생성 중",
+    "description": "처리 상태"
+  },
+  "message.uploadExceed": {
+    "message": "이미지는 한 장만 업로드할 수 있습니다.",
+    "description": "업로드 초과 경고"
+  },
+  "message.uploadError": {
+    "message": "이미지 업로드 실패, 다시 시도하세요.",
+    "description": "업로드 오류"
+  },
+  "message.downloadVideo": {
+    "message": "비디오 다운로드",
+    "description": "다운로드 툴팁"
+  },
   "message.modelRequiresImage": {
-    "message": "This model requires an input image (image-to-video).",
-    "description": "Model requires image warning"
+    "message": "이 모델은 입력 이미지가 필요합니다(이미지 기반 비디오).",
+    "description": "모델에 이미지가 필요하다는 경고"
   },
   "message.promptOrImageRequired": {
-    "message": "Please enter a prompt or upload an image.",
-    "description": "Prompt or image required warning"
+    "message": "프롬프트를 입력하거나 이미지를 업로드하세요.",
+    "description": "프롬프트 또는 이미지가 필요하다는 경고"
   },
-  "message.startingTask": { "message": "Submitting your video generation task…", "description": "Starting task" },
-  "message.startTaskSuccess": { "message": "Task submitted successfully.", "description": "Task success" },
-  "message.startTaskFailed": { "message": "Failed to submit task: ", "description": "Task failed" },
-  "message.usedUp": { "message": "Your quota has been used up. Please purchase more to continue.", "description": "Used up" }
+  "message.startingTask": {
+    "message": "비디오 생성 작업을 제출하는 중…",
+    "description": "작업 시작"
+  },
+  "message.startTaskSuccess": {
+    "message": "작업 제출 성공.",
+    "description": "작업 성공"
+  },
+  "message.startTaskFailed": {
+    "message": "작업 제출 실패:",
+    "description": "작업 실패"
+  },
+  "message.usedUp": {
+    "message": "크레딧이 소진되었습니다. 구매 후 계속 사용하세요.",
+    "description": "소진됨"
+  }
 }

--- a/src/i18n/pl/grokvideo.json
+++ b/src/i18n/pl/grokvideo.json
@@ -1,61 +1,154 @@
 {
-  "name.bot": { "message": "Grok Video Bot", "description": "Name of the Grok video generator" },
-  "name.prompt": { "message": "Prompt", "description": "Prompt for generating the video" },
-  "name.model": { "message": "Model", "description": "Label for model selection" },
-  "name.ratio": { "message": "Aspect Ratio", "description": "Label for aspect ratio" },
-  "name.resolution": { "message": "Resolution", "description": "Label for resolution" },
-  "name.duration": { "message": "Duration", "description": "Label for duration" },
-  "name.image": { "message": "Image", "description": "Label for input image" },
-  "name.required": { "message": "Required", "description": "Required badge" },
-  "name.taskId": { "message": "Task ID", "description": "Task id label" },
-  "name.elapsed": { "message": "Elapsed", "description": "Elapsed time label" },
-  "name.traceId": { "message": "Trace ID", "description": "Trace id label" },
-  "name.failure": { "message": "Generation Failed", "description": "Failure title" },
-  "name.failureReason": { "message": "Reason", "description": "Failure reason label" },
-  "name.status": { "message": "Status", "description": "Status title" },
+  "name.bot": {
+    "message": "Grok wideo bot",
+    "description": "Nazwa generatora wideo Grok"
+  },
+  "name.prompt": {
+    "message": "Podpowiedź",
+    "description": "Podpowiedź do generowania wideo"
+  },
+  "name.model": {
+    "message": "Model",
+    "description": "Etykieta dla wyboru modelu"
+  },
+  "name.ratio": {
+    "message": "Proporcje",
+    "description": "Etykieta dla proporcji obrazu"
+  },
+  "name.resolution": {
+    "message": "Rozdzielczość",
+    "description": "Etykieta dla rozdzielczości"
+  },
+  "name.duration": {
+    "message": "Czas trwania",
+    "description": "Etykieta dla czasu trwania"
+  },
+  "name.image": {
+    "message": "Obraz",
+    "description": "Etykieta dla wprowadzenia obrazu"
+  },
+  "name.required": {
+    "message": "Wymagane",
+    "description": "Odznaka wymagania"
+  },
+  "name.taskId": {
+    "message": "ID zadania",
+    "description": "Etykieta ID zadania"
+  },
+  "name.elapsed": {
+    "message": "Czas trwania",
+    "description": "Etykieta czasu trwania"
+  },
+  "name.traceId": {
+    "message": "ID śledzenia",
+    "description": "Etykieta ID śledzenia"
+  },
+  "name.failure": {
+    "message": "Generowanie nie powiodło się",
+    "description": "Tytuł niepowodzenia"
+  },
+  "name.failureReason": {
+    "message": "Powód niepowodzenia",
+    "description": "Etykieta powodu niepowodzenia"
+  },
+  "name.status": {
+    "message": "Status",
+    "description": "Tytuł statusu"
+  },
   "description.prompt": {
-    "message": "Describe the video you want to generate (scene, subject, motion, camera, lighting, style).",
-    "description": "Instructions for prompt input"
+    "message": "Opisz wideo, które chcesz wygenerować (scena, obiekt, akcja, ujęcie, światło, styl).",
+    "description": "Instrukcje dotyczące wprowadzenia podpowiedzi"
   },
   "description.model": {
-    "message": "Choose the Grok Imagine model. grok-imagine-video supports text and image; 1.5-preview is image-to-video only.",
-    "description": "Instructions for model selection"
+    "message": "Wybierz model Grok Imagine. grok-imagine-video obsługuje wideo generowane z tekstu i obrazu; 1.5-preview obsługuje tylko wideo generowane z obrazu.",
+    "description": "Instrukcje dotyczące wyboru modelu"
   },
-  "description.ratio": { "message": "Select the output aspect ratio.", "description": "Instructions for aspect ratio" },
+  "description.ratio": {
+    "message": "Wybierz proporcje wyjściowego obrazu.",
+    "description": "Instrukcje dotyczące proporcji"
+  },
   "description.resolution": {
-    "message": "Select the output resolution. Higher resolution costs more credits per second.",
-    "description": "Instructions for resolution"
+    "message": "Wybierz rozdzielczość wyjściową. Wyższa rozdzielczość zużywa więcej zasobów na sekundę.",
+    "description": "Instrukcje dotyczące rozdzielczości"
   },
   "description.duration": {
-    "message": "Video duration in seconds. Billed per output second.",
-    "description": "Instructions for duration"
+    "message": "Czas trwania wideo (sekundy), rozliczany według liczby sekund.",
+    "description": "Instrukcje dotyczące czasu trwania"
   },
   "description.image": {
-    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5-preview.",
-    "description": "Instructions for image input"
+    "message": "Opcjonalny obraz wejściowy do generowania wideo. grok-imagine-video-1.5-preview jest wymagany.",
+    "description": "Instrukcje dotyczące obrazu wejściowego"
   },
-  "placeholder.prompt": { "message": "Describe your video…", "description": "Placeholder for prompt" },
-  "placeholder.select": { "message": "Please select", "description": "Placeholder for selects" },
-  "model.default": { "message": "Grok Imagine Video", "description": "Default model label" },
-  "model.preview15": { "message": "Grok Imagine Video 1.5 (Preview, image-to-video)", "description": "1.5 preview model label" },
-  "button.upload": { "message": "Upload", "description": "Upload button" },
-  "button.generate": { "message": "Generate", "description": "Generate button" },
-  "button.download": { "message": "Download", "description": "Download button" },
-  "status.pending": { "message": "Pending", "description": "Pending status" },
-  "status.processing": { "message": "Processing", "description": "Processing status" },
-  "message.uploadExceed": { "message": "You can upload only one image.", "description": "Upload exceed warning" },
-  "message.uploadError": { "message": "Image upload failed, please try again.", "description": "Upload error" },
-  "message.downloadVideo": { "message": "Download video", "description": "Download tooltip" },
+  "placeholder.prompt": {
+    "message": "Opisz swoje wideo…",
+    "description": "Miejsce na podpowiedź"
+  },
+  "placeholder.select": {
+    "message": "Wybierz",
+    "description": "Miejsce na wybór"
+  },
+  "model.default": {
+    "message": "Grok Imagine wideo",
+    "description": "Etykieta domyślnego modelu"
+  },
+  "model.preview15": {
+    "message": "Grok Imagine wideo 1.5 (podgląd, wideo generowane z obrazu)",
+    "description": "Etykieta modelu podglądu 1.5"
+  },
+  "button.upload": {
+    "message": "Prześlij",
+    "description": "Przycisk przesyłania"
+  },
+  "button.generate": {
+    "message": "Generuj",
+    "description": "Przycisk generowania"
+  },
+  "button.download": {
+    "message": "Pobierz",
+    "description": "Przycisk pobierania"
+  },
+  "status.pending": {
+    "message": "Oczekiwanie",
+    "description": "Status oczekiwania"
+  },
+  "status.processing": {
+    "message": "Przetwarzanie",
+    "description": "Status przetwarzania"
+  },
+  "message.uploadExceed": {
+    "message": "Można przesłać tylko jeden obraz.",
+    "description": "Ostrzeżenie o przekroczeniu limitu przesyłania"
+  },
+  "message.uploadError": {
+    "message": "Nie udało się przesłać obrazu, spróbuj ponownie.",
+    "description": "Błąd przesyłania"
+  },
+  "message.downloadVideo": {
+    "message": "Pobierz wideo",
+    "description": "Podpowiedź do pobrania"
+  },
   "message.modelRequiresImage": {
-    "message": "This model requires an input image (image-to-video).",
-    "description": "Model requires image warning"
+    "message": "Ten model wymaga obrazu wejściowego (wideo generowane z obrazu).",
+    "description": "Ostrzeżenie, że model wymaga obrazu"
   },
   "message.promptOrImageRequired": {
-    "message": "Please enter a prompt or upload an image.",
-    "description": "Prompt or image required warning"
+    "message": "Wprowadź podpowiedź lub prześlij obraz.",
+    "description": "Ostrzeżenie, że wymagana jest podpowiedź lub obraz"
   },
-  "message.startingTask": { "message": "Submitting your video generation task…", "description": "Starting task" },
-  "message.startTaskSuccess": { "message": "Task submitted successfully.", "description": "Task success" },
-  "message.startTaskFailed": { "message": "Failed to submit task: ", "description": "Task failed" },
-  "message.usedUp": { "message": "Your quota has been used up. Please purchase more to continue.", "description": "Used up" }
+  "message.startingTask": {
+    "message": "Zgłaszanie zadania generowania wideo…",
+    "description": "Rozpoczynanie zadania"
+  },
+  "message.startTaskSuccess": {
+    "message": "Zgłoszenie zadania powiodło się.",
+    "description": "Sukces zadania"
+  },
+  "message.startTaskFailed": {
+    "message": "Zgłoszenie zadania nie powiodło się:",
+    "description": "Niepowodzenie zadania"
+  },
+  "message.usedUp": {
+    "message": "Limit został wykorzystany, proszę zakupić więcej, aby kontynuować korzystanie.",
+    "description": "Wykorzystano limit"
+  }
 }

--- a/src/i18n/pt/grokvideo.json
+++ b/src/i18n/pt/grokvideo.json
@@ -1,61 +1,154 @@
 {
-  "name.bot": { "message": "Grok Video Bot", "description": "Name of the Grok video generator" },
-  "name.prompt": { "message": "Prompt", "description": "Prompt for generating the video" },
-  "name.model": { "message": "Model", "description": "Label for model selection" },
-  "name.ratio": { "message": "Aspect Ratio", "description": "Label for aspect ratio" },
-  "name.resolution": { "message": "Resolution", "description": "Label for resolution" },
-  "name.duration": { "message": "Duration", "description": "Label for duration" },
-  "name.image": { "message": "Image", "description": "Label for input image" },
-  "name.required": { "message": "Required", "description": "Required badge" },
-  "name.taskId": { "message": "Task ID", "description": "Task id label" },
-  "name.elapsed": { "message": "Elapsed", "description": "Elapsed time label" },
-  "name.traceId": { "message": "Trace ID", "description": "Trace id label" },
-  "name.failure": { "message": "Generation Failed", "description": "Failure title" },
-  "name.failureReason": { "message": "Reason", "description": "Failure reason label" },
-  "name.status": { "message": "Status", "description": "Status title" },
+  "name.bot": {
+    "message": "Robô de Vídeo Grok",
+    "description": "Nome do gerador de vídeo Grok"
+  },
+  "name.prompt": {
+    "message": "Prompt",
+    "description": "Prompt para gerar o vídeo"
+  },
+  "name.model": {
+    "message": "Modelo",
+    "description": "Rótulo para seleção de modelo"
+  },
+  "name.ratio": {
+    "message": "Proporção",
+    "description": "Rótulo para proporção de aspecto"
+  },
+  "name.resolution": {
+    "message": "Resolução",
+    "description": "Rótulo para resolução"
+  },
+  "name.duration": {
+    "message": "Duração",
+    "description": "Rótulo para duração"
+  },
+  "name.image": {
+    "message": "Imagem",
+    "description": "Rótulo para entrada de imagem"
+  },
+  "name.required": {
+    "message": "Obrigatório",
+    "description": "Sinalizador de campo obrigatório"
+  },
+  "name.taskId": {
+    "message": "ID da Tarefa",
+    "description": "Rótulo para ID da tarefa"
+  },
+  "name.elapsed": {
+    "message": "Tempo decorrido",
+    "description": "Rótulo de tempo decorrido"
+  },
+  "name.traceId": {
+    "message": "ID de Rastreamento",
+    "description": "Rótulo para ID de rastreamento"
+  },
+  "name.failure": {
+    "message": "Falha na geração",
+    "description": "Título de falha"
+  },
+  "name.failureReason": {
+    "message": "Razão da falha",
+    "description": "Rótulo da razão da falha"
+  },
+  "name.status": {
+    "message": "Status",
+    "description": "Título do status"
+  },
   "description.prompt": {
-    "message": "Describe the video you want to generate (scene, subject, motion, camera, lighting, style).",
-    "description": "Instructions for prompt input"
+    "message": "Descreva o vídeo que você deseja gerar (cena, sujeito, ação, ângulo, iluminação, estilo).",
+    "description": "Instruções para entrada de prompt"
   },
   "description.model": {
-    "message": "Choose the Grok Imagine model. grok-imagine-video supports text and image; 1.5-preview is image-to-video only.",
-    "description": "Instructions for model selection"
+    "message": "Escolha o modelo Grok Imagine. grok-imagine-video suporta vídeos gerados por texto e imagem; 1.5-preview suporta apenas vídeos gerados por imagem.",
+    "description": "Instruções para seleção de modelo"
   },
-  "description.ratio": { "message": "Select the output aspect ratio.", "description": "Instructions for aspect ratio" },
+  "description.ratio": {
+    "message": "Escolha a proporção da saída.",
+    "description": "Instruções para a proporção da imagem"
+  },
   "description.resolution": {
-    "message": "Select the output resolution. Higher resolution costs more credits per second.",
-    "description": "Instructions for resolution"
+    "message": "Escolha a resolução de saída. Quanto maior a resolução, mais crédito será consumido por segundo.",
+    "description": "Instruções para resolução"
   },
   "description.duration": {
-    "message": "Video duration in seconds. Billed per output second.",
-    "description": "Instructions for duration"
+    "message": "Duração do vídeo (segundos), cobrado por segundo de saída.",
+    "description": "Instruções para a duração"
   },
   "description.image": {
-    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5-preview.",
-    "description": "Instructions for image input"
+    "message": "Imagem de entrada opcional, usada para gerar vídeo. grok-imagine-video-1.5-preview é obrigatório.",
+    "description": "Instruções para a entrada de imagem"
   },
-  "placeholder.prompt": { "message": "Describe your video…", "description": "Placeholder for prompt" },
-  "placeholder.select": { "message": "Please select", "description": "Placeholder for selects" },
-  "model.default": { "message": "Grok Imagine Video", "description": "Default model label" },
-  "model.preview15": { "message": "Grok Imagine Video 1.5 (Preview, image-to-video)", "description": "1.5 preview model label" },
-  "button.upload": { "message": "Upload", "description": "Upload button" },
-  "button.generate": { "message": "Generate", "description": "Generate button" },
-  "button.download": { "message": "Download", "description": "Download button" },
-  "status.pending": { "message": "Pending", "description": "Pending status" },
-  "status.processing": { "message": "Processing", "description": "Processing status" },
-  "message.uploadExceed": { "message": "You can upload only one image.", "description": "Upload exceed warning" },
-  "message.uploadError": { "message": "Image upload failed, please try again.", "description": "Upload error" },
-  "message.downloadVideo": { "message": "Download video", "description": "Download tooltip" },
+  "placeholder.prompt": {
+    "message": "Descreva seu vídeo…",
+    "description": "Texto de espaço reservado para prompt"
+  },
+  "placeholder.select": {
+    "message": "Selecione",
+    "description": "Texto de espaço reservado para seleções"
+  },
+  "model.default": {
+    "message": "Grok Imagine Vídeo",
+    "description": "Rótulo do modelo padrão"
+  },
+  "model.preview15": {
+    "message": "Grok Imagine Vídeo 1.5 (prévia, vídeo gerado por imagem)",
+    "description": "Rótulo do modelo prévia 1.5"
+  },
+  "button.upload": {
+    "message": "Enviar",
+    "description": "Botão de upload"
+  },
+  "button.generate": {
+    "message": "Gerar",
+    "description": "Botão de gerar"
+  },
+  "button.download": {
+    "message": "Baixar",
+    "description": "Botão de download"
+  },
+  "status.pending": {
+    "message": "Pendente",
+    "description": "Status pendente"
+  },
+  "status.processing": {
+    "message": "Processando",
+    "description": "Status de processamento"
+  },
+  "message.uploadExceed": {
+    "message": "Somente uma imagem pode ser enviada.",
+    "description": "Aviso de excesso de upload"
+  },
+  "message.uploadError": {
+    "message": "Falha ao enviar a imagem, por favor tente novamente.",
+    "description": "Erro de upload"
+  },
+  "message.downloadVideo": {
+    "message": "Baixar vídeo",
+    "description": "Dica de download"
+  },
   "message.modelRequiresImage": {
-    "message": "This model requires an input image (image-to-video).",
-    "description": "Model requires image warning"
+    "message": "Este modelo requer uma imagem de entrada (vídeo gerado por imagem).",
+    "description": "Aviso de que o modelo requer imagem"
   },
   "message.promptOrImageRequired": {
-    "message": "Please enter a prompt or upload an image.",
-    "description": "Prompt or image required warning"
+    "message": "Por favor, insira um prompt ou envie uma imagem.",
+    "description": "Aviso de que prompt ou imagem são necessários"
   },
-  "message.startingTask": { "message": "Submitting your video generation task…", "description": "Starting task" },
-  "message.startTaskSuccess": { "message": "Task submitted successfully.", "description": "Task success" },
-  "message.startTaskFailed": { "message": "Failed to submit task: ", "description": "Task failed" },
-  "message.usedUp": { "message": "Your quota has been used up. Please purchase more to continue.", "description": "Used up" }
+  "message.startingTask": {
+    "message": "Enviando tarefa de geração de vídeo…",
+    "description": "Iniciando tarefa"
+  },
+  "message.startTaskSuccess": {
+    "message": "Tarefa enviada com sucesso.",
+    "description": "Sucesso na tarefa"
+  },
+  "message.startTaskFailed": {
+    "message": "Falha ao enviar a tarefa:",
+    "description": "Falha na tarefa"
+  },
+  "message.usedUp": {
+    "message": "Créditos esgotados, por favor compre mais para continuar usando.",
+    "description": "Esgotado"
+  }
 }

--- a/src/i18n/ru/grokvideo.json
+++ b/src/i18n/ru/grokvideo.json
@@ -1,61 +1,154 @@
 {
-  "name.bot": { "message": "Grok Video Bot", "description": "Name of the Grok video generator" },
-  "name.prompt": { "message": "Prompt", "description": "Prompt for generating the video" },
-  "name.model": { "message": "Model", "description": "Label for model selection" },
-  "name.ratio": { "message": "Aspect Ratio", "description": "Label for aspect ratio" },
-  "name.resolution": { "message": "Resolution", "description": "Label for resolution" },
-  "name.duration": { "message": "Duration", "description": "Label for duration" },
-  "name.image": { "message": "Image", "description": "Label for input image" },
-  "name.required": { "message": "Required", "description": "Required badge" },
-  "name.taskId": { "message": "Task ID", "description": "Task id label" },
-  "name.elapsed": { "message": "Elapsed", "description": "Elapsed time label" },
-  "name.traceId": { "message": "Trace ID", "description": "Trace id label" },
-  "name.failure": { "message": "Generation Failed", "description": "Failure title" },
-  "name.failureReason": { "message": "Reason", "description": "Failure reason label" },
-  "name.status": { "message": "Status", "description": "Status title" },
+  "name.bot": {
+    "message": "Grok Видео Бот",
+    "description": "Название генератора видео Grok"
+  },
+  "name.prompt": {
+    "message": "Подсказка",
+    "description": "Подсказка для генерации видео"
+  },
+  "name.model": {
+    "message": "Модель",
+    "description": "Метка для выбора модели"
+  },
+  "name.ratio": {
+    "message": "Соотношение сторон",
+    "description": "Метка для соотношения сторон"
+  },
+  "name.resolution": {
+    "message": "Разрешение",
+    "description": "Метка для разрешения"
+  },
+  "name.duration": {
+    "message": "Длительность",
+    "description": "Этикетка для длительности"
+  },
+  "name.image": {
+    "message": "Изображение",
+    "description": "Метка для ввода изображения"
+  },
+  "name.required": {
+    "message": "Обязательно",
+    "description": "Значок обязательного поля"
+  },
+  "name.taskId": {
+    "message": "ID задачи",
+    "description": "Метка для ID задачи"
+  },
+  "name.elapsed": {
+    "message": "Затраченное время",
+    "description": "Этикетка затраченного времени"
+  },
+  "name.traceId": {
+    "message": "ID отслеживания",
+    "description": "Метка для ID отслеживания"
+  },
+  "name.failure": {
+    "message": "Ошибка генерации",
+    "description": "Заголовок ошибки"
+  },
+  "name.failureReason": {
+    "message": "Причина ошибки",
+    "description": "Этикетка причины ошибки"
+  },
+  "name.status": {
+    "message": "Статус",
+    "description": "Название статуса"
+  },
   "description.prompt": {
-    "message": "Describe the video you want to generate (scene, subject, motion, camera, lighting, style).",
-    "description": "Instructions for prompt input"
+    "message": "Опишите, какое видео вы хотите сгенерировать (сцена, объект, действие, кадр, освещение, стиль).",
+    "description": "Инструкции по вводу подсказки"
   },
   "description.model": {
-    "message": "Choose the Grok Imagine model. grok-imagine-video supports text and image; 1.5-preview is image-to-video only.",
-    "description": "Instructions for model selection"
+    "message": "Выберите модель Grok Imagine. grok-imagine-video поддерживает генерацию видео по тексту и изображению; 1.5-preview поддерживает только генерацию по изображению.",
+    "description": "Инструкции по выбору модели"
   },
-  "description.ratio": { "message": "Select the output aspect ratio.", "description": "Instructions for aspect ratio" },
+  "description.ratio": {
+    "message": "Выберите соотношение сторон выходного видео.",
+    "description": "Инструкции по соотношению сторон"
+  },
   "description.resolution": {
-    "message": "Select the output resolution. Higher resolution costs more credits per second.",
-    "description": "Instructions for resolution"
+    "message": "Выберите выходное разрешение. Чем выше разрешение, тем больше тратится кредитов в секунду.",
+    "description": "Инструкции по разрешению"
   },
   "description.duration": {
-    "message": "Video duration in seconds. Billed per output second.",
-    "description": "Instructions for duration"
+    "message": "Длительность видео (в секундах), оплата по количеству секунд.",
+    "description": "Инструкции по длительности"
   },
   "description.image": {
-    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5-preview.",
-    "description": "Instructions for image input"
+    "message": "Необязательное входное изображение для генерации видео. grok-imagine-video-1.5-preview обязательно.",
+    "description": "Инструкции по входному изображению"
   },
-  "placeholder.prompt": { "message": "Describe your video…", "description": "Placeholder for prompt" },
-  "placeholder.select": { "message": "Please select", "description": "Placeholder for selects" },
-  "model.default": { "message": "Grok Imagine Video", "description": "Default model label" },
-  "model.preview15": { "message": "Grok Imagine Video 1.5 (Preview, image-to-video)", "description": "1.5 preview model label" },
-  "button.upload": { "message": "Upload", "description": "Upload button" },
-  "button.generate": { "message": "Generate", "description": "Generate button" },
-  "button.download": { "message": "Download", "description": "Download button" },
-  "status.pending": { "message": "Pending", "description": "Pending status" },
-  "status.processing": { "message": "Processing", "description": "Processing status" },
-  "message.uploadExceed": { "message": "You can upload only one image.", "description": "Upload exceed warning" },
-  "message.uploadError": { "message": "Image upload failed, please try again.", "description": "Upload error" },
-  "message.downloadVideo": { "message": "Download video", "description": "Download tooltip" },
+  "placeholder.prompt": {
+    "message": "Опишите ваше видео…",
+    "description": "Заполнитель для подсказки"
+  },
+  "placeholder.select": {
+    "message": "Пожалуйста, выберите",
+    "description": "Заполнитель для выбора"
+  },
+  "model.default": {
+    "message": "Grok Imagine Видео",
+    "description": "Этикетка по умолчанию для модели"
+  },
+  "model.preview15": {
+    "message": "Grok Imagine Видео 1.5 (предварительный просмотр, генерация по изображению)",
+    "description": "Этикетка модели 1.5 предварительного просмотра"
+  },
+  "button.upload": {
+    "message": "Загрузить",
+    "description": "Кнопка загрузки"
+  },
+  "button.generate": {
+    "message": "Сгенерировать",
+    "description": "Кнопка генерации"
+  },
+  "button.download": {
+    "message": "Скачать",
+    "description": "Кнопка загрузки"
+  },
+  "status.pending": {
+    "message": "В очереди",
+    "description": "Статус ожидания"
+  },
+  "status.processing": {
+    "message": "В процессе",
+    "description": "Статус обработки"
+  },
+  "message.uploadExceed": {
+    "message": "Можно загрузить только одно изображение.",
+    "description": "Предупреждение о превышении загрузки"
+  },
+  "message.uploadError": {
+    "message": "Ошибка загрузки изображения, пожалуйста, попробуйте снова.",
+    "description": "Ошибка загрузки"
+  },
+  "message.downloadVideo": {
+    "message": "Скачать видео",
+    "description": "Подсказка для загрузки"
+  },
   "message.modelRequiresImage": {
-    "message": "This model requires an input image (image-to-video).",
-    "description": "Model requires image warning"
+    "message": "Эта модель требует входного изображения (генерация по изображению).",
+    "description": "Предупреждение о необходимости изображения для модели"
   },
   "message.promptOrImageRequired": {
-    "message": "Please enter a prompt or upload an image.",
-    "description": "Prompt or image required warning"
+    "message": "Введите подсказку или загрузите изображение.",
+    "description": "Предупреждение о необходимости подсказки или изображения"
   },
-  "message.startingTask": { "message": "Submitting your video generation task…", "description": "Starting task" },
-  "message.startTaskSuccess": { "message": "Task submitted successfully.", "description": "Task success" },
-  "message.startTaskFailed": { "message": "Failed to submit task: ", "description": "Task failed" },
-  "message.usedUp": { "message": "Your quota has been used up. Please purchase more to continue.", "description": "Used up" }
+  "message.startingTask": {
+    "message": "Отправка задачи на генерацию видео…",
+    "description": "Начало задачи"
+  },
+  "message.startTaskSuccess": {
+    "message": "Задача успешно отправлена.",
+    "description": "Успех выполнения задачи"
+  },
+  "message.startTaskFailed": {
+    "message": "Не удалось отправить задачу:",
+    "description": "Ошибка при выполнении задачи"
+  },
+  "message.usedUp": {
+    "message": "Кредиты исчерпаны, пожалуйста, купите больше для продолжения использования.",
+    "description": "Исчерпано"
+  }
 }

--- a/src/i18n/sr/grokvideo.json
+++ b/src/i18n/sr/grokvideo.json
@@ -1,61 +1,154 @@
 {
-  "name.bot": { "message": "Grok Video Bot", "description": "Name of the Grok video generator" },
-  "name.prompt": { "message": "Prompt", "description": "Prompt for generating the video" },
-  "name.model": { "message": "Model", "description": "Label for model selection" },
-  "name.ratio": { "message": "Aspect Ratio", "description": "Label for aspect ratio" },
-  "name.resolution": { "message": "Resolution", "description": "Label for resolution" },
-  "name.duration": { "message": "Duration", "description": "Label for duration" },
-  "name.image": { "message": "Image", "description": "Label for input image" },
-  "name.required": { "message": "Required", "description": "Required badge" },
-  "name.taskId": { "message": "Task ID", "description": "Task id label" },
-  "name.elapsed": { "message": "Elapsed", "description": "Elapsed time label" },
-  "name.traceId": { "message": "Trace ID", "description": "Trace id label" },
-  "name.failure": { "message": "Generation Failed", "description": "Failure title" },
-  "name.failureReason": { "message": "Reason", "description": "Failure reason label" },
-  "name.status": { "message": "Status", "description": "Status title" },
+  "name.bot": {
+    "message": "Grok video robot",
+    "description": "Ime Grok generatora videa"
+  },
+  "name.prompt": {
+    "message": "Упитник",
+    "description": "Упит за генерисање видеа"
+  },
+  "name.model": {
+    "message": "Модел",
+    "description": "Ознака за избор модела"
+  },
+  "name.ratio": {
+    "message": "Однос страна",
+    "description": "Ознака за однос страна"
+  },
+  "name.resolution": {
+    "message": "Решење",
+    "description": "Ознака за резолуцију"
+  },
+  "name.duration": {
+    "message": "Trajanje",
+    "description": "Oznaka za trajanje"
+  },
+  "name.image": {
+    "message": "Слика",
+    "description": "Ознака за унос слике"
+  },
+  "name.required": {
+    "message": "Обавезно",
+    "description": "Ознака за обавезна поља"
+  },
+  "name.taskId": {
+    "message": "ID задатка",
+    "description": "Ознака за ID задатка"
+  },
+  "name.elapsed": {
+    "message": "Proteklo vreme",
+    "description": "Oznaka za proteklo vreme"
+  },
+  "name.traceId": {
+    "message": "ID трага",
+    "description": "Ознака за ID трага"
+  },
+  "name.failure": {
+    "message": "Generisanje nije uspelo",
+    "description": "Naslov za neuspeh"
+  },
+  "name.failureReason": {
+    "message": "Razlog neuspeha",
+    "description": "Oznaka za razlog neuspeha"
+  },
+  "name.status": {
+    "message": "Статус",
+    "description": "Наслов статуса"
+  },
   "description.prompt": {
-    "message": "Describe the video you want to generate (scene, subject, motion, camera, lighting, style).",
-    "description": "Instructions for prompt input"
+    "message": "Opisujte video koji želite da generišete (scena, subjekat, akcija, kadar, svetlost, stil).",
+    "description": "Uputstvo za unos prompta"
   },
   "description.model": {
-    "message": "Choose the Grok Imagine model. grok-imagine-video supports text and image; 1.5-preview is image-to-video only.",
-    "description": "Instructions for model selection"
+    "message": "Izaberite Grok Imagine model. grok-imagine-video podržava generisanje videa iz teksta i slike; 1.5-preview podržava samo generisanje videa iz slike.",
+    "description": "Uputstvo za izbor modela"
   },
-  "description.ratio": { "message": "Select the output aspect ratio.", "description": "Instructions for aspect ratio" },
+  "description.ratio": {
+    "message": "Izaberite odnos stranica izlaznog videa.",
+    "description": "Uputstvo za odnos stranica"
+  },
   "description.resolution": {
-    "message": "Select the output resolution. Higher resolution costs more credits per second.",
-    "description": "Instructions for resolution"
+    "message": "Izaberite izlaznu rezoluciju. Što je rezolucija viša, to je veća potrošnja po sekundi.",
+    "description": "Uputstvo za rezoluciju"
   },
   "description.duration": {
-    "message": "Video duration in seconds. Billed per output second.",
-    "description": "Instructions for duration"
+    "message": "Trajanje videa (sekunde), naplaćuje se po broju sekundi.",
+    "description": "Uputstvo za trajanje"
   },
   "description.image": {
-    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5-preview.",
-    "description": "Instructions for image input"
+    "message": "Opcionalna ulazna slika, koristi se za generisanje videa. grok-imagine-video-1.5-preview je obavezno.",
+    "description": "Uputstvo za ulaznu sliku"
   },
-  "placeholder.prompt": { "message": "Describe your video…", "description": "Placeholder for prompt" },
-  "placeholder.select": { "message": "Please select", "description": "Placeholder for selects" },
-  "model.default": { "message": "Grok Imagine Video", "description": "Default model label" },
-  "model.preview15": { "message": "Grok Imagine Video 1.5 (Preview, image-to-video)", "description": "1.5 preview model label" },
-  "button.upload": { "message": "Upload", "description": "Upload button" },
-  "button.generate": { "message": "Generate", "description": "Generate button" },
-  "button.download": { "message": "Download", "description": "Download button" },
-  "status.pending": { "message": "Pending", "description": "Pending status" },
-  "status.processing": { "message": "Processing", "description": "Processing status" },
-  "message.uploadExceed": { "message": "You can upload only one image.", "description": "Upload exceed warning" },
-  "message.uploadError": { "message": "Image upload failed, please try again.", "description": "Upload error" },
-  "message.downloadVideo": { "message": "Download video", "description": "Download tooltip" },
+  "placeholder.prompt": {
+    "message": "Опишите ваш видео…",
+    "description": "Плацехолдер за упитник"
+  },
+  "placeholder.select": {
+    "message": "Изаберите",
+    "description": "Плацехолдер за избор"
+  },
+  "model.default": {
+    "message": "Grok Imagine video",
+    "description": "Oznaka za podrazumevani model"
+  },
+  "model.preview15": {
+    "message": "Grok Imagine video 1.5 (preview, generisanje videa iz slike)",
+    "description": "Oznaka za 1.5 preview model"
+  },
+  "button.upload": {
+    "message": "Otpremi",
+    "description": "Dugme za otpremanje"
+  },
+  "button.generate": {
+    "message": "Generiši",
+    "description": "Dugme za generisanje"
+  },
+  "button.download": {
+    "message": "Preuzmi",
+    "description": "Dugme za preuzimanje"
+  },
+  "status.pending": {
+    "message": "На чекању",
+    "description": "Статус на чекању"
+  },
+  "status.processing": {
+    "message": "Генерише се",
+    "description": "Статус обраде"
+  },
+  "message.uploadExceed": {
+    "message": "Možete otpremiti samo jednu sliku.",
+    "description": "Upozorenje o prekoračenju otpremanja"
+  },
+  "message.uploadError": {
+    "message": "Otpremanje slike nije uspelo, molimo pokušajte ponovo.",
+    "description": "Greška prilikom otpremanja"
+  },
+  "message.downloadVideo": {
+    "message": "Preuzmi video",
+    "description": "Tooltip za preuzimanje"
+  },
   "message.modelRequiresImage": {
-    "message": "This model requires an input image (image-to-video).",
-    "description": "Model requires image warning"
+    "message": "Ovaj model zahteva ulaznu sliku (generisanje videa iz slike).",
+    "description": "Upozorenje da model zahteva sliku"
   },
   "message.promptOrImageRequired": {
-    "message": "Please enter a prompt or upload an image.",
-    "description": "Prompt or image required warning"
+    "message": "Unesite prompt ili otpremite sliku.",
+    "description": "Upozorenje da je potreban prompt ili slika"
   },
-  "message.startingTask": { "message": "Submitting your video generation task…", "description": "Starting task" },
-  "message.startTaskSuccess": { "message": "Task submitted successfully.", "description": "Task success" },
-  "message.startTaskFailed": { "message": "Failed to submit task: ", "description": "Task failed" },
-  "message.usedUp": { "message": "Your quota has been used up. Please purchase more to continue.", "description": "Used up" }
+  "message.startingTask": {
+    "message": "Podnošenje zadatka za generisanje videa…",
+    "description": "Pokretanje zadatka"
+  },
+  "message.startTaskSuccess": {
+    "message": "Podnošenje zadatka je uspešno.",
+    "description": "Uspeh zadatka"
+  },
+  "message.startTaskFailed": {
+    "message": "Podnošenje zadatka nije uspelo:",
+    "description": "Zadatak nije uspeo"
+  },
+  "message.usedUp": {
+    "message": "Kredit je iskorišćen, molimo kupite više da biste nastavili sa korišćenjem.",
+    "description": "Iskorišćeno"
+  }
 }

--- a/src/i18n/sv/grokvideo.json
+++ b/src/i18n/sv/grokvideo.json
@@ -1,61 +1,154 @@
 {
-  "name.bot": { "message": "Grok Video Bot", "description": "Name of the Grok video generator" },
-  "name.prompt": { "message": "Prompt", "description": "Prompt for generating the video" },
-  "name.model": { "message": "Model", "description": "Label for model selection" },
-  "name.ratio": { "message": "Aspect Ratio", "description": "Label for aspect ratio" },
-  "name.resolution": { "message": "Resolution", "description": "Label for resolution" },
-  "name.duration": { "message": "Duration", "description": "Label for duration" },
-  "name.image": { "message": "Image", "description": "Label for input image" },
-  "name.required": { "message": "Required", "description": "Required badge" },
-  "name.taskId": { "message": "Task ID", "description": "Task id label" },
-  "name.elapsed": { "message": "Elapsed", "description": "Elapsed time label" },
-  "name.traceId": { "message": "Trace ID", "description": "Trace id label" },
-  "name.failure": { "message": "Generation Failed", "description": "Failure title" },
-  "name.failureReason": { "message": "Reason", "description": "Failure reason label" },
-  "name.status": { "message": "Status", "description": "Status title" },
+  "name.bot": {
+    "message": "Grok Video Bot",
+    "description": "Namn på Grok video-generatorn"
+  },
+  "name.prompt": {
+    "message": "Prompt",
+    "description": "Prompt för att generera videon"
+  },
+  "name.model": {
+    "message": "Modell",
+    "description": "Etikett för modellval"
+  },
+  "name.ratio": {
+    "message": "Bildförhållande",
+    "description": "Etikett för bildförhållande"
+  },
+  "name.resolution": {
+    "message": "Upplösning",
+    "description": "Etikett för upplösning"
+  },
+  "name.duration": {
+    "message": "Längd",
+    "description": "Etikett för längd"
+  },
+  "name.image": {
+    "message": "Bild",
+    "description": "Etikett för inmatningsbild"
+  },
+  "name.required": {
+    "message": "Obligatorisk",
+    "description": "Obligatorisk märkning"
+  },
+  "name.taskId": {
+    "message": "Uppgift ID",
+    "description": "Etikett för uppgifts-ID"
+  },
+  "name.elapsed": {
+    "message": "Tid som förflutit",
+    "description": "Etikett för förfluten tid"
+  },
+  "name.traceId": {
+    "message": "Spårnings ID",
+    "description": "Etikett för spårnings-ID"
+  },
+  "name.failure": {
+    "message": "Generering misslyckades",
+    "description": "Titel för misslyckande"
+  },
+  "name.failureReason": {
+    "message": "Orsak till misslyckande",
+    "description": "Etikett för orsak till misslyckande"
+  },
+  "name.status": {
+    "message": "Status",
+    "description": "Statusrubrik"
+  },
   "description.prompt": {
-    "message": "Describe the video you want to generate (scene, subject, motion, camera, lighting, style).",
-    "description": "Instructions for prompt input"
+    "message": "Beskriv videon du vill generera (scen, ämne, handling, kameravinkel, ljus, stil).",
+    "description": "Instruktioner för promptinmatning"
   },
   "description.model": {
-    "message": "Choose the Grok Imagine model. grok-imagine-video supports text and image; 1.5-preview is image-to-video only.",
-    "description": "Instructions for model selection"
+    "message": "Välj Grok Imagine-modell. grok-imagine-video stöder text-till-video och bild-till-video; 1.5-preview stöder endast bild-till-video.",
+    "description": "Instruktioner för modellval"
   },
-  "description.ratio": { "message": "Select the output aspect ratio.", "description": "Instructions for aspect ratio" },
+  "description.ratio": {
+    "message": "Välj utgångsbildförhållande.",
+    "description": "Instruktioner för bildförhållande"
+  },
   "description.resolution": {
-    "message": "Select the output resolution. Higher resolution costs more credits per second.",
-    "description": "Instructions for resolution"
+    "message": "Välj utgångsupplösning. Ju högre upplösning, desto mer förbrukas per sekund.",
+    "description": "Instruktioner för upplösning"
   },
   "description.duration": {
-    "message": "Video duration in seconds. Billed per output second.",
-    "description": "Instructions for duration"
+    "message": "Videons längd (sekunder), debiteras baserat på utgångssekunder.",
+    "description": "Instruktioner för längd"
   },
   "description.image": {
-    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5-preview.",
-    "description": "Instructions for image input"
+    "message": "Valfri inmatningsbild för att generera video. grok-imagine-video-1.5-preview är obligatorisk.",
+    "description": "Instruktioner för bildinmatning"
   },
-  "placeholder.prompt": { "message": "Describe your video…", "description": "Placeholder for prompt" },
-  "placeholder.select": { "message": "Please select", "description": "Placeholder for selects" },
-  "model.default": { "message": "Grok Imagine Video", "description": "Default model label" },
-  "model.preview15": { "message": "Grok Imagine Video 1.5 (Preview, image-to-video)", "description": "1.5 preview model label" },
-  "button.upload": { "message": "Upload", "description": "Upload button" },
-  "button.generate": { "message": "Generate", "description": "Generate button" },
-  "button.download": { "message": "Download", "description": "Download button" },
-  "status.pending": { "message": "Pending", "description": "Pending status" },
-  "status.processing": { "message": "Processing", "description": "Processing status" },
-  "message.uploadExceed": { "message": "You can upload only one image.", "description": "Upload exceed warning" },
-  "message.uploadError": { "message": "Image upload failed, please try again.", "description": "Upload error" },
-  "message.downloadVideo": { "message": "Download video", "description": "Download tooltip" },
+  "placeholder.prompt": {
+    "message": "Beskriv din video…",
+    "description": "Platsinnehåll för prompt"
+  },
+  "placeholder.select": {
+    "message": "Vänligen välj",
+    "description": "Platsinnehåll för val"
+  },
+  "model.default": {
+    "message": "Grok Imagine Video",
+    "description": "Standardmodellens etikett"
+  },
+  "model.preview15": {
+    "message": "Grok Imagine Video 1.5 (förhandsvisning, bild-till-video)",
+    "description": "1.5 förhandsvisningsmodellens etikett"
+  },
+  "button.upload": {
+    "message": "Ladda upp",
+    "description": "Ladda upp-knapp"
+  },
+  "button.generate": {
+    "message": "Generera",
+    "description": "Generera-knapp"
+  },
+  "button.download": {
+    "message": "Ladda ner",
+    "description": "Ladda ner-knapp"
+  },
+  "status.pending": {
+    "message": "I kö",
+    "description": "Väntande status"
+  },
+  "status.processing": {
+    "message": "Bearbetar",
+    "description": "Bearbetningsstatus"
+  },
+  "message.uploadExceed": {
+    "message": "Endast en bild kan laddas upp.",
+    "description": "Varning för överskridning av uppladdning"
+  },
+  "message.uploadError": {
+    "message": "Bilduppladdning misslyckades, försök igen.",
+    "description": "Uppladdningsfel"
+  },
+  "message.downloadVideo": {
+    "message": "Ladda ner video",
+    "description": "Ladda ner-tooltip"
+  },
   "message.modelRequiresImage": {
-    "message": "This model requires an input image (image-to-video).",
-    "description": "Model requires image warning"
+    "message": "Denna modell kräver en inmatningsbild (bild-till-video).",
+    "description": "Varning för att modellen kräver bild"
   },
   "message.promptOrImageRequired": {
-    "message": "Please enter a prompt or upload an image.",
-    "description": "Prompt or image required warning"
+    "message": "Ange en prompt eller ladda upp en bild.",
+    "description": "Varning för att prompt eller bild krävs"
   },
-  "message.startingTask": { "message": "Submitting your video generation task…", "description": "Starting task" },
-  "message.startTaskSuccess": { "message": "Task submitted successfully.", "description": "Task success" },
-  "message.startTaskFailed": { "message": "Failed to submit task: ", "description": "Task failed" },
-  "message.usedUp": { "message": "Your quota has been used up. Please purchase more to continue.", "description": "Used up" }
+  "message.startingTask": {
+    "message": "Skickar video-genereringsuppgift…",
+    "description": "Startar uppgift"
+  },
+  "message.startTaskSuccess": {
+    "message": "Uppgiften har skickats.",
+    "description": "Uppgift lyckades"
+  },
+  "message.startTaskFailed": {
+    "message": "Uppgiften kunde inte skickas:",
+    "description": "Uppgift misslyckades"
+  },
+  "message.usedUp": {
+    "message": "Krediten är slut, vänligen köp mer för att fortsätta använda.",
+    "description": "Användning slut"
+  }
 }

--- a/src/i18n/uk/grokvideo.json
+++ b/src/i18n/uk/grokvideo.json
@@ -1,61 +1,154 @@
 {
-  "name.bot": { "message": "Grok Video Bot", "description": "Name of the Grok video generator" },
-  "name.prompt": { "message": "Prompt", "description": "Prompt for generating the video" },
-  "name.model": { "message": "Model", "description": "Label for model selection" },
-  "name.ratio": { "message": "Aspect Ratio", "description": "Label for aspect ratio" },
-  "name.resolution": { "message": "Resolution", "description": "Label for resolution" },
-  "name.duration": { "message": "Duration", "description": "Label for duration" },
-  "name.image": { "message": "Image", "description": "Label for input image" },
-  "name.required": { "message": "Required", "description": "Required badge" },
-  "name.taskId": { "message": "Task ID", "description": "Task id label" },
-  "name.elapsed": { "message": "Elapsed", "description": "Elapsed time label" },
-  "name.traceId": { "message": "Trace ID", "description": "Trace id label" },
-  "name.failure": { "message": "Generation Failed", "description": "Failure title" },
-  "name.failureReason": { "message": "Reason", "description": "Failure reason label" },
-  "name.status": { "message": "Status", "description": "Status title" },
+  "name.bot": {
+    "message": "Grok відео робот",
+    "description": "Назва генератора відео Grok"
+  },
+  "name.prompt": {
+    "message": "Запит",
+    "description": "Запит для генерації відео"
+  },
+  "name.model": {
+    "message": "Модель",
+    "description": "Мітка для вибору моделі"
+  },
+  "name.ratio": {
+    "message": "Співвідношення сторін",
+    "description": "Мітка для співвідношення сторін"
+  },
+  "name.resolution": {
+    "message": "Роздільна здатність",
+    "description": "Мітка для роздільної здатності"
+  },
+  "name.duration": {
+    "message": "Тривалість",
+    "description": "Мітка для тривалості"
+  },
+  "name.image": {
+    "message": "Зображення",
+    "description": "Мітка для введення зображення"
+  },
+  "name.required": {
+    "message": "Обов'язково",
+    "description": "Знак обов'язковості"
+  },
+  "name.taskId": {
+    "message": "ID завдання",
+    "description": "Мітка для ID завдання"
+  },
+  "name.elapsed": {
+    "message": "Час виконання",
+    "description": "Мітка для витраченого часу"
+  },
+  "name.traceId": {
+    "message": "ID відстеження",
+    "description": "Мітка для ID відстеження"
+  },
+  "name.failure": {
+    "message": "Генерація не вдалася",
+    "description": "Заголовок для невдачі"
+  },
+  "name.failureReason": {
+    "message": "Причина невдачі",
+    "description": "Мітка для причини невдачі"
+  },
+  "name.status": {
+    "message": "Статус",
+    "description": "Заголовок статусу"
+  },
   "description.prompt": {
-    "message": "Describe the video you want to generate (scene, subject, motion, camera, lighting, style).",
-    "description": "Instructions for prompt input"
+    "message": "Опишіть відео, яке ви хочете згенерувати (сцена, об'єкт, дія, кадри, світло, стиль).",
+    "description": "Інструкції щодо введення підказки"
   },
   "description.model": {
-    "message": "Choose the Grok Imagine model. grok-imagine-video supports text and image; 1.5-preview is image-to-video only.",
-    "description": "Instructions for model selection"
+    "message": "Виберіть модель Grok Imagine. grok-imagine-video підтримує текстове та зображення відео; 1.5-preview підтримує лише зображення відео.",
+    "description": "Інструкції щодо вибору моделі"
   },
-  "description.ratio": { "message": "Select the output aspect ratio.", "description": "Instructions for aspect ratio" },
+  "description.ratio": {
+    "message": "Виберіть співвідношення сторін виходу.",
+    "description": "Інструкції щодо співвідношення сторін"
+  },
   "description.resolution": {
-    "message": "Select the output resolution. Higher resolution costs more credits per second.",
-    "description": "Instructions for resolution"
+    "message": "Виберіть роздільну здатність виходу. Чим вища роздільна здатність, тим більше витрат на секунду.",
+    "description": "Інструкції щодо роздільної здатності"
   },
   "description.duration": {
-    "message": "Video duration in seconds. Billed per output second.",
-    "description": "Instructions for duration"
+    "message": "Тривалість відео (секунди), оплата за вихідну кількість секунд.",
+    "description": "Інструкції щодо тривалості"
   },
   "description.image": {
-    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5-preview.",
-    "description": "Instructions for image input"
+    "message": "Додаткове зображення для генерації відео. grok-imagine-video-1.5-preview є обов'язковим.",
+    "description": "Інструкції щодо введення зображення"
   },
-  "placeholder.prompt": { "message": "Describe your video…", "description": "Placeholder for prompt" },
-  "placeholder.select": { "message": "Please select", "description": "Placeholder for selects" },
-  "model.default": { "message": "Grok Imagine Video", "description": "Default model label" },
-  "model.preview15": { "message": "Grok Imagine Video 1.5 (Preview, image-to-video)", "description": "1.5 preview model label" },
-  "button.upload": { "message": "Upload", "description": "Upload button" },
-  "button.generate": { "message": "Generate", "description": "Generate button" },
-  "button.download": { "message": "Download", "description": "Download button" },
-  "status.pending": { "message": "Pending", "description": "Pending status" },
-  "status.processing": { "message": "Processing", "description": "Processing status" },
-  "message.uploadExceed": { "message": "You can upload only one image.", "description": "Upload exceed warning" },
-  "message.uploadError": { "message": "Image upload failed, please try again.", "description": "Upload error" },
-  "message.downloadVideo": { "message": "Download video", "description": "Download tooltip" },
+  "placeholder.prompt": {
+    "message": "Опишіть ваше відео…",
+    "description": "Заповнювач для запиту"
+  },
+  "placeholder.select": {
+    "message": "Будь ласка, виберіть",
+    "description": "Заповнювач для вибору"
+  },
+  "model.default": {
+    "message": "Grok Imagine відео",
+    "description": "Мітка за замовчуванням для моделі"
+  },
+  "model.preview15": {
+    "message": "Grok Imagine відео 1.5 (попередній перегляд, зображення відео)",
+    "description": "Мітка для моделі попереднього перегляду 1.5"
+  },
+  "button.upload": {
+    "message": "Завантажити",
+    "description": "Кнопка для завантаження"
+  },
+  "button.generate": {
+    "message": "Генерувати",
+    "description": "Кнопка для генерації"
+  },
+  "button.download": {
+    "message": "Завантажити",
+    "description": "Кнопка для завантаження"
+  },
+  "status.pending": {
+    "message": "В черзі",
+    "description": "Статус очікування"
+  },
+  "status.processing": {
+    "message": "В обробці",
+    "description": "Статус обробки"
+  },
+  "message.uploadExceed": {
+    "message": "Можна завантажити лише одне зображення.",
+    "description": "Попередження про перевищення завантаження"
+  },
+  "message.uploadError": {
+    "message": "Не вдалося завантажити зображення, будь ласка, спробуйте ще раз.",
+    "description": "Помилка завантаження"
+  },
+  "message.downloadVideo": {
+    "message": "Завантажити відео",
+    "description": "Підказка для завантаження"
+  },
   "message.modelRequiresImage": {
-    "message": "This model requires an input image (image-to-video).",
-    "description": "Model requires image warning"
+    "message": "Ця модель потребує введення зображення (зображення відео).",
+    "description": "Попередження про необхідність зображення для моделі"
   },
   "message.promptOrImageRequired": {
-    "message": "Please enter a prompt or upload an image.",
-    "description": "Prompt or image required warning"
+    "message": "Будь ласка, введіть підказку або завантажте зображення.",
+    "description": "Попередження про необхідність підказки або зображення"
   },
-  "message.startingTask": { "message": "Submitting your video generation task…", "description": "Starting task" },
-  "message.startTaskSuccess": { "message": "Task submitted successfully.", "description": "Task success" },
-  "message.startTaskFailed": { "message": "Failed to submit task: ", "description": "Task failed" },
-  "message.usedUp": { "message": "Your quota has been used up. Please purchase more to continue.", "description": "Used up" }
+  "message.startingTask": {
+    "message": "Надсилається завдання на генерацію відео…",
+    "description": "Початок завдання"
+  },
+  "message.startTaskSuccess": {
+    "message": "Завдання надіслано успішно.",
+    "description": "Успішне виконання завдання"
+  },
+  "message.startTaskFailed": {
+    "message": "Не вдалося надіслати завдання:",
+    "description": "Не вдалося виконати завдання"
+  },
+  "message.usedUp": {
+    "message": "Ліміт вичерпано, будь ласка, купіть, щоб продовжити використання.",
+    "description": "Вичерпано"
+  }
 }

--- a/src/i18n/zh-TW/grokvideo.json
+++ b/src/i18n/zh-TW/grokvideo.json
@@ -1,61 +1,154 @@
 {
-  "name.bot": { "message": "Grok Video Bot", "description": "Name of the Grok video generator" },
-  "name.prompt": { "message": "Prompt", "description": "Prompt for generating the video" },
-  "name.model": { "message": "Model", "description": "Label for model selection" },
-  "name.ratio": { "message": "Aspect Ratio", "description": "Label for aspect ratio" },
-  "name.resolution": { "message": "Resolution", "description": "Label for resolution" },
-  "name.duration": { "message": "Duration", "description": "Label for duration" },
-  "name.image": { "message": "Image", "description": "Label for input image" },
-  "name.required": { "message": "Required", "description": "Required badge" },
-  "name.taskId": { "message": "Task ID", "description": "Task id label" },
-  "name.elapsed": { "message": "Elapsed", "description": "Elapsed time label" },
-  "name.traceId": { "message": "Trace ID", "description": "Trace id label" },
-  "name.failure": { "message": "Generation Failed", "description": "Failure title" },
-  "name.failureReason": { "message": "Reason", "description": "Failure reason label" },
-  "name.status": { "message": "Status", "description": "Status title" },
+  "name.bot": {
+    "message": "Grok 視頻機器人",
+    "description": "Grok 視頻生成器的名稱"
+  },
+  "name.prompt": {
+    "message": "提示詞",
+    "description": "用於生成視頻的提示"
+  },
+  "name.model": {
+    "message": "模型",
+    "description": "模型選擇的標籤"
+  },
+  "name.ratio": {
+    "message": "畫面比例",
+    "description": "畫面比例的標籤"
+  },
+  "name.resolution": {
+    "message": "分辨率",
+    "description": "分辨率的標籤"
+  },
+  "name.duration": {
+    "message": "時長",
+    "description": "時長標籤"
+  },
+  "name.image": {
+    "message": "圖片",
+    "description": "輸入圖片的標籤"
+  },
+  "name.required": {
+    "message": "必填",
+    "description": "必填標籤"
+  },
+  "name.taskId": {
+    "message": "任務 ID",
+    "description": "任務 ID 的標籤"
+  },
+  "name.elapsed": {
+    "message": "耗時",
+    "description": "耗時標籤"
+  },
+  "name.traceId": {
+    "message": "追蹤 ID",
+    "description": "追蹤 ID 的標籤"
+  },
+  "name.failure": {
+    "message": "生成失敗",
+    "description": "失敗標題"
+  },
+  "name.failureReason": {
+    "message": "失敗原因",
+    "description": "失敗原因標籤"
+  },
+  "name.status": {
+    "message": "狀態",
+    "description": "狀態標題"
+  },
   "description.prompt": {
-    "message": "Describe the video you want to generate (scene, subject, motion, camera, lighting, style).",
-    "description": "Instructions for prompt input"
+    "message": "描述你想生成的視頻（場景、主體、動作、鏡頭、光線、風格）。",
+    "description": "有關提示輸入的說明"
   },
   "description.model": {
-    "message": "Choose the Grok Imagine model. grok-imagine-video supports text and image; 1.5-preview is image-to-video only.",
-    "description": "Instructions for model selection"
+    "message": "選擇 Grok Imagine 模型。grok-imagine-video 支持文生與圖生視頻；1.5-preview 僅支持圖生視頻。",
+    "description": "有關模型選擇的說明"
   },
-  "description.ratio": { "message": "Select the output aspect ratio.", "description": "Instructions for aspect ratio" },
+  "description.ratio": {
+    "message": "選擇輸出畫面比例。",
+    "description": "有關畫面比例的說明"
+  },
   "description.resolution": {
-    "message": "Select the output resolution. Higher resolution costs more credits per second.",
-    "description": "Instructions for resolution"
+    "message": "選擇輸出分辨率。分辨率越高，每秒消耗的額度越多。",
+    "description": "有關分辨率的說明"
   },
   "description.duration": {
-    "message": "Video duration in seconds. Billed per output second.",
-    "description": "Instructions for duration"
+    "message": "視頻時長（秒），按輸出秒數計費。",
+    "description": "有關時長的說明"
   },
   "description.image": {
-    "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5-preview.",
-    "description": "Instructions for image input"
+    "message": "可選的輸入圖片，用於圖生視頻。grok-imagine-video-1.5-preview 為必填。",
+    "description": "有關圖片輸入的說明"
   },
-  "placeholder.prompt": { "message": "Describe your video…", "description": "Placeholder for prompt" },
-  "placeholder.select": { "message": "Please select", "description": "Placeholder for selects" },
-  "model.default": { "message": "Grok Imagine Video", "description": "Default model label" },
-  "model.preview15": { "message": "Grok Imagine Video 1.5 (Preview, image-to-video)", "description": "1.5 preview model label" },
-  "button.upload": { "message": "Upload", "description": "Upload button" },
-  "button.generate": { "message": "Generate", "description": "Generate button" },
-  "button.download": { "message": "Download", "description": "Download button" },
-  "status.pending": { "message": "Pending", "description": "Pending status" },
-  "status.processing": { "message": "Processing", "description": "Processing status" },
-  "message.uploadExceed": { "message": "You can upload only one image.", "description": "Upload exceed warning" },
-  "message.uploadError": { "message": "Image upload failed, please try again.", "description": "Upload error" },
-  "message.downloadVideo": { "message": "Download video", "description": "Download tooltip" },
+  "placeholder.prompt": {
+    "message": "描述你的视频…",
+    "description": "提示的佔位符"
+  },
+  "placeholder.select": {
+    "message": "請選擇",
+    "description": "選擇的佔位符"
+  },
+  "model.default": {
+    "message": "Grok Imagine 視頻",
+    "description": "默認模型標籤"
+  },
+  "model.preview15": {
+    "message": "Grok Imagine 視頻 1.5（預覽，圖生視頻）",
+    "description": "1.5 預覽模型標籤"
+  },
+  "button.upload": {
+    "message": "上傳",
+    "description": "上傳按鈕"
+  },
+  "button.generate": {
+    "message": "生成",
+    "description": "生成按鈕"
+  },
+  "button.download": {
+    "message": "下載",
+    "description": "下載按鈕"
+  },
+  "status.pending": {
+    "message": "排隊中",
+    "description": "待處理狀態"
+  },
+  "status.processing": {
+    "message": "生成中",
+    "description": "處理中狀態"
+  },
+  "message.uploadExceed": {
+    "message": "只能上傳一張圖片。",
+    "description": "上傳超過限制的警告"
+  },
+  "message.uploadError": {
+    "message": "圖片上傳失敗，請重試。",
+    "description": "上傳錯誤"
+  },
+  "message.downloadVideo": {
+    "message": "下載視頻",
+    "description": "下載提示"
+  },
   "message.modelRequiresImage": {
-    "message": "This model requires an input image (image-to-video).",
-    "description": "Model requires image warning"
+    "message": "該模型需要輸入圖片（圖生視頻）。",
+    "description": "模型需要圖片的警告"
   },
   "message.promptOrImageRequired": {
-    "message": "Please enter a prompt or upload an image.",
-    "description": "Prompt or image required warning"
+    "message": "請輸入提示詞或上傳圖片。",
+    "description": "提示詞或圖片必需的警告"
   },
-  "message.startingTask": { "message": "Submitting your video generation task…", "description": "Starting task" },
-  "message.startTaskSuccess": { "message": "Task submitted successfully.", "description": "Task success" },
-  "message.startTaskFailed": { "message": "Failed to submit task: ", "description": "Task failed" },
-  "message.usedUp": { "message": "Your quota has been used up. Please purchase more to continue.", "description": "Used up" }
+  "message.startingTask": {
+    "message": "正在提交視頻生成任務…",
+    "description": "開始任務"
+  },
+  "message.startTaskSuccess": {
+    "message": "任務提交成功。",
+    "description": "任務成功"
+  },
+  "message.startTaskFailed": {
+    "message": "任務提交失敗：",
+    "description": "任務失敗"
+  },
+  "message.usedUp": {
+    "message": "額度已用盡，請購買後繼續使用。",
+    "description": "已用盡"
+  }
 }


### PR DESCRIPTION
## Summary

`studio.acedata.cloud/grok-video` shipped with a wrong icon and broken translations. The Grok Video studio was scaffolded from the Veo module, and two bugs came along for the ride.

### Fixes

1. **Wrong logo icon** — `GROKVIDEO_LOGO` pointed at `https://cdn.acedata.cloud/8nxyy9.jpg`, which is a Google "G" logo (the same placeholder Veo uses). The nav entry and the task-preview avatar therefore showed Google branding on a Grok page. Now points at the official Grok mark (`p1ge98.png`, the same asset the Grok chat models use).

2. **Missing translations** — the 16 non-`en`/`zh-CN` locale files (`de, es, fr, pt, it, ko, ja, ru, pl, fi, sv, el, uk, ar, sr, zh-TW`) were committed as plain English copies, so every non-English / non-Chinese UI rendered English strings. Regenerated them from the `zh-CN` source via `scripts/translate_i18n.py` (the sanctioned Nexior translate tool).

### Verification

- `python scripts/check_i18n_coverage.py` -> `coverage OK: 17 locale(s) x 41 namespace(s) all match zh-CN`
- `npx vue-tsc --noEmit` -> clean
- `npm run lint` -> clean
- Spot-checked ja / ru / ar files now contain the correct target language.

> Note: `src/constants/veo.ts` (`VEO_LOGO`) still uses the same `8nxyy9.jpg` Google logo — left out of scope here since this PR is about grok-video, but it likely deserves a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
