### PR TITLE
fix(kling): repair Talking Photo i18n + require model so generation works

### DIFF
--- a/change/@acedatacloud-nexior-b0716412-5d89-470f-bde8-94cfdf615071.json
+++ b/change/@acedatacloud-nexior-b0716412-5d89-470f-bde8-94cfdf615071.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(kling): repair Talking Photo i18n and require model so generation works",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/kling/TalkingPhotoPanel.vue
+++ b/src/components/kling/TalkingPhotoPanel.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="flex flex-col h-full">
     <div class="flex-1 overflow-y-auto p-5">
+      <model-selector class="mb-4" />
+      <mode-selector class="mb-4" />
+
       <!-- Portrait image -->
       <div class="relative mb-4">
         <div class="flex justify-start items-center">
@@ -101,6 +104,8 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import Consumption from '../common/Consumption.vue';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
+import ModelSelector from './talking-photo/ModelSelector.vue';
+import ModeSelector from './talking-photo/ModeSelector.vue';
 import { getBaseUrlPlatform, getConsumption, uploadTrackerMixin } from '@/utils';
 import { IKlingTalkingPhotoConfig } from '@/models';
 
@@ -119,7 +124,9 @@ export default defineComponent({
     FontAwesomeIcon,
     Consumption,
     InfoIcon,
-    ImagePreview
+    ImagePreview,
+    ModelSelector,
+    ModeSelector
   },
   mixins: [uploadTrackerMixin],
   emits: ['generate'],

--- a/src/components/kling/talking-photo/ModeSelector.vue
+++ b/src/components/kling/talking-photo/ModeSelector.vue
@@ -1,0 +1,64 @@
+<template>
+  <div class="field">
+    <h2 class="title font-bold">{{ $t('kling.name.mode') }}</h2>
+    <el-select v-model="value" class="value" :placeholder="$t('kling.placeholder.select')">
+      <el-option v-for="item in options" :key="item.value" :label="item.label" :value="item.value" />
+    </el-select>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElSelect, ElOption } from 'element-plus';
+import { KLING_TALKING_PHOTO_DEFAULT_MODE } from '@/constants';
+
+export default defineComponent({
+  name: 'TalkingPhotoModeSelector',
+  components: {
+    ElSelect,
+    ElOption
+  },
+  computed: {
+    options() {
+      return [
+        { value: 'std', label: this.$t('kling.name.modeStd') },
+        { value: 'pro', label: this.$t('kling.name.modePro') }
+      ];
+    },
+    value: {
+      get(): 'std' | 'pro' {
+        return this.$store.state.kling?.talkingPhotoConfig?.mode || KLING_TALKING_PHOTO_DEFAULT_MODE;
+      },
+      set(val: 'std' | 'pro') {
+        this.$store.commit('kling/setTalkingPhotoConfig', {
+          ...this.$store.state.kling?.talkingPhotoConfig,
+          mode: val
+        });
+      }
+    }
+  },
+  mounted() {
+    if (!this.$store.state.kling?.talkingPhotoConfig?.mode) {
+      this.value = KLING_TALKING_PHOTO_DEFAULT_MODE;
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.field {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+
+  .title {
+    font-size: 14px;
+    margin: 0;
+    width: 30%;
+  }
+  .value {
+    width: 160px;
+  }
+}
+</style>

--- a/src/components/kling/talking-photo/ModelSelector.vue
+++ b/src/components/kling/talking-photo/ModelSelector.vue
@@ -1,0 +1,72 @@
+<template>
+  <div class="field">
+    <h2 class="title font-bold">{{ $t('kling.name.model') }}</h2>
+    <el-select v-model="value" class="value" :placeholder="$t('kling.placeholder.select')">
+      <el-option v-for="item in options" :key="item.value" :label="item.label" :value="item.value" />
+    </el-select>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElSelect, ElOption } from 'element-plus';
+import { KLING_TALKING_PHOTO_MODELS, KLING_TALKING_PHOTO_DEFAULT_MODEL } from '@/constants';
+
+const LABELS: Record<string, string> = {
+  'kling-v2-6': 'v2.6',
+  'kling-v2-5-turbo': 'v2.5-Turbo',
+  'kling-v2-1-master': 'v2.1-Master',
+  'kling-v2-master': 'v2-Master',
+  'kling-v1-6': 'v1.6',
+  'kling-v1': 'v1'
+};
+
+export default defineComponent({
+  name: 'TalkingPhotoModelSelector',
+  components: {
+    ElSelect,
+    ElOption
+  },
+  data() {
+    return {
+      options: KLING_TALKING_PHOTO_MODELS.map((value) => ({ value, label: LABELS[value] || value }))
+    };
+  },
+  computed: {
+    value: {
+      get(): string {
+        return this.$store.state.kling?.talkingPhotoConfig?.model || KLING_TALKING_PHOTO_DEFAULT_MODEL;
+      },
+      set(val: string) {
+        this.$store.commit('kling/setTalkingPhotoConfig', {
+          ...this.$store.state.kling?.talkingPhotoConfig,
+          model: val
+        });
+      }
+    }
+  },
+  mounted() {
+    if (!this.$store.state.kling?.talkingPhotoConfig?.model) {
+      this.value = KLING_TALKING_PHOTO_DEFAULT_MODEL;
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.field {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+
+  .title {
+    font-size: 14px;
+    margin: 0;
+    width: 30%;
+  }
+  .value {
+    width: 160px;
+  }
+}
+</style>

--- a/src/constants/kling.ts
+++ b/src/constants/kling.ts
@@ -11,3 +11,15 @@ export const KLING_DEFAULT_CFG_SCALE = 0;
 export const KLING_DEFAULT_GENERATE_AUDIO = false;
 
 export const KLING_V3_MODELS = ['kling-v3', 'kling-v3-omni'];
+
+// Talking Photo supports a narrower model set than video (no v3/omni/o1).
+export const KLING_TALKING_PHOTO_MODELS = [
+  'kling-v2-6',
+  'kling-v2-5-turbo',
+  'kling-v2-1-master',
+  'kling-v2-master',
+  'kling-v1-6',
+  'kling-v1'
+];
+export const KLING_TALKING_PHOTO_DEFAULT_MODEL = 'kling-v2-1-master';
+export const KLING_TALKING_PHOTO_DEFAULT_MODE: 'std' | 'pro' = 'pro';

--- a/src/i18n/ar/kling.json
+++ b/src/i18n/ar/kling.json
@@ -702,5 +702,57 @@
   "message.noTasks": {
     "message": "لا توجد مهام تاريخية، يرجى النقر على الجهة اليسرى لتوليد الفيديو",
     "description": "رسالة عند عدم وجود مهام"
+  },
+  "tab.talkingPhoto": {
+    "message": "صورة ناطقة",
+    "description": "Tab label: Talking Photo"
+  },
+  "name.talkingPhotoImage": {
+    "message": "صورة شخصية",
+    "description": "Talking Photo portrait image input"
+  },
+  "name.talkingPhotoAudio": {
+    "message": "الصوت المُحرّك",
+    "description": "Talking Photo driving audio input"
+  },
+  "name.talkingPhotoPrompt": {
+    "message": "وصف الحركة (اختياري)",
+    "description": "Talking Photo optional motion prompt"
+  },
+  "description.talkingPhotoImage": {
+    "message": "ارفع صورة أمامية واضحة للوجه؛ سيتم تحريكها وجعلها تتكلم.",
+    "description": "Talking Photo portrait image help text"
+  },
+  "description.talkingPhotoAudio": {
+    "message": "ارفع مقطعًا صوتيًا (mp3/wav، ≤5 ميجابايت)؛ ستتزامن شفاه الشخصية معه.",
+    "description": "Talking Photo driving audio help text"
+  },
+  "description.talkingPhotoPrompt": {
+    "message": "اختياري: صِف التعبير/الحركة المطلوبة، مثل «انظر بلطف إلى الكاميرا».",
+    "description": "Talking Photo motion prompt help text"
+  },
+  "placeholder.talkingPhotoPrompt": {
+    "message": "مثال: لطيف، هادئ، طبيعي، حركة رأس خفيفة",
+    "description": "Talking Photo prompt input placeholder"
+  },
+  "button.generateTalkingPhoto": {
+    "message": "إنشاء صورة ناطقة",
+    "description": "Talking Photo generate button"
+  },
+  "button.uploadAudio": {
+    "message": "رفع الصوت",
+    "description": "Talking Photo upload audio button"
+  },
+  "message.talkingPhotoMissingInputs": {
+    "message": "يرجى رفع صورة شخصية وملف صوتي مُحرّك أولاً.",
+    "description": "Talking Photo missing inputs warning"
+  },
+  "message.uploadAudioExceed": {
+    "message": "يُسمح بملف صوتي واحد فقط.",
+    "description": "Talking Photo audio count limit warning"
+  },
+  "message.uploadAudioError": {
+    "message": "فشل رفع الصوت، يرجى المحاولة مرة أخرى.",
+    "description": "Talking Photo audio upload error"
   }
 }

--- a/src/i18n/de/kling.json
+++ b/src/i18n/de/kling.json
@@ -702,5 +702,57 @@
   "message.noTasks": {
     "message": "Keine historischen Aufgaben, bitte klicken Sie links, um ein Video zu generieren",
     "description": "Nachricht, wenn keine Aufgaben vorhanden sind"
+  },
+  "tab.talkingPhoto": {
+    "message": "Sprechendes Foto",
+    "description": "Tab label: Talking Photo"
+  },
+  "name.talkingPhotoImage": {
+    "message": "Porträtfoto",
+    "description": "Talking Photo portrait image input"
+  },
+  "name.talkingPhotoAudio": {
+    "message": "Steuer-Audio",
+    "description": "Talking Photo driving audio input"
+  },
+  "name.talkingPhotoPrompt": {
+    "message": "Bewegungs-Prompt (optional)",
+    "description": "Talking Photo optional motion prompt"
+  },
+  "description.talkingPhotoImage": {
+    "message": "Laden Sie ein klares frontales Porträt hoch; es wird animiert und zum Sprechen gebracht.",
+    "description": "Talking Photo portrait image help text"
+  },
+  "description.talkingPhotoAudio": {
+    "message": "Laden Sie einen Audioclip hoch (mp3/wav, ≤5 MB); die Figur synchronisiert die Lippen dazu.",
+    "description": "Talking Photo driving audio help text"
+  },
+  "description.talkingPhotoPrompt": {
+    "message": "Optional: Beschreiben Sie den gewünschten Ausdruck/die Bewegung, z. B. „sanft in die Kamera blicken“.",
+    "description": "Talking Photo motion prompt help text"
+  },
+  "placeholder.talkingPhotoPrompt": {
+    "message": "z. B. sanft, ruhig, natürlich, leichte Kopfbewegung",
+    "description": "Talking Photo prompt input placeholder"
+  },
+  "button.generateTalkingPhoto": {
+    "message": "Sprechendes Foto erstellen",
+    "description": "Talking Photo generate button"
+  },
+  "button.uploadAudio": {
+    "message": "Audio hochladen",
+    "description": "Talking Photo upload audio button"
+  },
+  "message.talkingPhotoMissingInputs": {
+    "message": "Bitte laden Sie zuerst ein Porträtfoto und ein Steuer-Audio hoch.",
+    "description": "Talking Photo missing inputs warning"
+  },
+  "message.uploadAudioExceed": {
+    "message": "Es ist nur eine Audiodatei erlaubt.",
+    "description": "Talking Photo audio count limit warning"
+  },
+  "message.uploadAudioError": {
+    "message": "Audio-Upload fehlgeschlagen, bitte erneut versuchen.",
+    "description": "Talking Photo audio upload error"
   }
 }

--- a/src/i18n/el/kling.json
+++ b/src/i18n/el/kling.json
@@ -702,5 +702,57 @@
   "message.noTasks": {
     "message": "Δεν υπάρχουν ιστορικές εργασίες, παρακαλώ κάντε κλικ για να δημιουργήσετε βίντεο αριστερά",
     "description": "Μήνυμα όταν δεν υπάρχουν εργασίες"
+  },
+  "tab.talkingPhoto": {
+    "message": "Ομιλούσα Φωτογραφία",
+    "description": "Tab label: Talking Photo"
+  },
+  "name.talkingPhotoImage": {
+    "message": "Φωτογραφία πορτρέτου",
+    "description": "Talking Photo portrait image input"
+  },
+  "name.talkingPhotoAudio": {
+    "message": "Ήχος καθοδήγησης",
+    "description": "Talking Photo driving audio input"
+  },
+  "name.talkingPhotoPrompt": {
+    "message": "Προτροπή κίνησης (προαιρετικό)",
+    "description": "Talking Photo optional motion prompt"
+  },
+  "description.talkingPhotoImage": {
+    "message": "Ανεβάστε ένα καθαρό μετωπικό πορτρέτο· θα κινηθεί και θα μιλήσει.",
+    "description": "Talking Photo portrait image help text"
+  },
+  "description.talkingPhotoAudio": {
+    "message": "Ανεβάστε ένα ηχητικό κλιπ (mp3/wav, ≤5MB)· ο χαρακτήρας συγχρονίζει τα χείλη του.",
+    "description": "Talking Photo driving audio help text"
+  },
+  "description.talkingPhotoPrompt": {
+    "message": "Προαιρετικό: περιγράψτε την επιθυμητή έκφραση/κίνηση, π.χ. «κοιτάξτε απαλά την κάμερα».",
+    "description": "Talking Photo motion prompt help text"
+  },
+  "placeholder.talkingPhotoPrompt": {
+    "message": "π.χ. απαλό, ήρεμο, φυσικό, ελαφριά κίνηση κεφαλιού",
+    "description": "Talking Photo prompt input placeholder"
+  },
+  "button.generateTalkingPhoto": {
+    "message": "Δημιουργία ομιλούσας φωτογραφίας",
+    "description": "Talking Photo generate button"
+  },
+  "button.uploadAudio": {
+    "message": "Μεταφόρτωση ήχου",
+    "description": "Talking Photo upload audio button"
+  },
+  "message.talkingPhotoMissingInputs": {
+    "message": "Ανεβάστε πρώτα μια φωτογραφία πορτρέτου και έναν ήχο καθοδήγησης.",
+    "description": "Talking Photo missing inputs warning"
+  },
+  "message.uploadAudioExceed": {
+    "message": "Επιτρέπεται μόνο ένα αρχείο ήχου.",
+    "description": "Talking Photo audio count limit warning"
+  },
+  "message.uploadAudioError": {
+    "message": "Η μεταφόρτωση ήχου απέτυχε, δοκιμάστε ξανά.",
+    "description": "Talking Photo audio upload error"
   }
 }

--- a/src/i18n/en/kling.json
+++ b/src/i18n/en/kling.json
@@ -703,17 +703,56 @@
     "message": "No historical tasks, please click on the left to generate a video",
     "description": "Message when there are no tasks"
   },
-  "tab.talkingPhoto": "Talking Photo",
-  "name.talkingPhotoImage": "Portrait Photo",
-  "name.talkingPhotoAudio": "Driving Audio",
-  "name.talkingPhotoPrompt": "Motion Prompt (optional)",
-  "description.talkingPhotoImage": "Upload a clear frontal portrait; it will be animated and made to speak.",
-  "description.talkingPhotoAudio": "Upload an audio clip (mp3/wav, <=5MB); the character lip-syncs to it.",
-  "description.talkingPhotoPrompt": "Optional: describe the desired expression/motion, e.g. \"look gently at the camera\".",
-  "placeholder.talkingPhotoPrompt": "e.g. gentle, calm, natural, subtle head movement",
-  "button.generateTalkingPhoto": "Generate Talking Photo",
-  "button.uploadAudio": "Upload Audio",
-  "message.talkingPhotoMissingInputs": "Please upload a portrait photo and a driving audio first.",
-  "message.uploadAudioExceed": "Only one audio file is allowed.",
-  "message.uploadAudioError": "Audio upload failed, please retry."
+  "tab.talkingPhoto": {
+    "message": "Talking Photo",
+    "description": "Tab label: Talking Photo"
+  },
+  "name.talkingPhotoImage": {
+    "message": "Portrait Photo",
+    "description": "Talking Photo portrait image input"
+  },
+  "name.talkingPhotoAudio": {
+    "message": "Driving Audio",
+    "description": "Talking Photo driving audio input"
+  },
+  "name.talkingPhotoPrompt": {
+    "message": "Motion Prompt (optional)",
+    "description": "Talking Photo optional motion prompt"
+  },
+  "description.talkingPhotoImage": {
+    "message": "Upload a clear frontal portrait; it will be animated and made to speak.",
+    "description": "Talking Photo portrait image help text"
+  },
+  "description.talkingPhotoAudio": {
+    "message": "Upload an audio clip (mp3/wav, <=5MB); the character lip-syncs to it.",
+    "description": "Talking Photo driving audio help text"
+  },
+  "description.talkingPhotoPrompt": {
+    "message": "Optional: describe the desired expression/motion, e.g. \"look gently at the camera\".",
+    "description": "Talking Photo motion prompt help text"
+  },
+  "placeholder.talkingPhotoPrompt": {
+    "message": "e.g. gentle, calm, natural, subtle head movement",
+    "description": "Talking Photo prompt input placeholder"
+  },
+  "button.generateTalkingPhoto": {
+    "message": "Generate Talking Photo",
+    "description": "Talking Photo generate button"
+  },
+  "button.uploadAudio": {
+    "message": "Upload Audio",
+    "description": "Talking Photo upload audio button"
+  },
+  "message.talkingPhotoMissingInputs": {
+    "message": "Please upload a portrait photo and a driving audio first.",
+    "description": "Talking Photo missing inputs warning"
+  },
+  "message.uploadAudioExceed": {
+    "message": "Only one audio file is allowed.",
+    "description": "Talking Photo audio count limit warning"
+  },
+  "message.uploadAudioError": {
+    "message": "Audio upload failed, please retry.",
+    "description": "Talking Photo audio upload error"
+  }
 }

--- a/src/i18n/es/kling.json
+++ b/src/i18n/es/kling.json
@@ -702,5 +702,57 @@
   "message.noTasks": {
     "message": "No hay tareas históricas, por favor haga clic en generar video a la izquierda",
     "description": "Mensaje cuando no hay tareas"
+  },
+  "tab.talkingPhoto": {
+    "message": "Foto que habla",
+    "description": "Tab label: Talking Photo"
+  },
+  "name.talkingPhotoImage": {
+    "message": "Foto de retrato",
+    "description": "Talking Photo portrait image input"
+  },
+  "name.talkingPhotoAudio": {
+    "message": "Audio de control",
+    "description": "Talking Photo driving audio input"
+  },
+  "name.talkingPhotoPrompt": {
+    "message": "Indicación de movimiento (opcional)",
+    "description": "Talking Photo optional motion prompt"
+  },
+  "description.talkingPhotoImage": {
+    "message": "Sube un retrato frontal nítido; se animará y se hará hablar.",
+    "description": "Talking Photo portrait image help text"
+  },
+  "description.talkingPhotoAudio": {
+    "message": "Sube un clip de audio (mp3/wav, ≤5 MB); el personaje sincronizará los labios.",
+    "description": "Talking Photo driving audio help text"
+  },
+  "description.talkingPhotoPrompt": {
+    "message": "Opcional: describe la expresión/movimiento deseado, p. ej. «mirar suavemente a la cámara».",
+    "description": "Talking Photo motion prompt help text"
+  },
+  "placeholder.talkingPhotoPrompt": {
+    "message": "p. ej. suave, tranquilo, natural, ligero movimiento de cabeza",
+    "description": "Talking Photo prompt input placeholder"
+  },
+  "button.generateTalkingPhoto": {
+    "message": "Generar foto que habla",
+    "description": "Talking Photo generate button"
+  },
+  "button.uploadAudio": {
+    "message": "Subir audio",
+    "description": "Talking Photo upload audio button"
+  },
+  "message.talkingPhotoMissingInputs": {
+    "message": "Sube primero una foto de retrato y un audio de control.",
+    "description": "Talking Photo missing inputs warning"
+  },
+  "message.uploadAudioExceed": {
+    "message": "Solo se permite un archivo de audio.",
+    "description": "Talking Photo audio count limit warning"
+  },
+  "message.uploadAudioError": {
+    "message": "Error al subir el audio, inténtalo de nuevo.",
+    "description": "Talking Photo audio upload error"
   }
 }

--- a/src/i18n/fi/kling.json
+++ b/src/i18n/fi/kling.json
@@ -702,5 +702,57 @@
   "message.noTasks": {
     "message": "Ei historiallisia tehtäviä, napsauta vasemmalla luodaksesi videon",
     "description": "Viesti, kun tehtäviä ei ole"
+  },
+  "tab.talkingPhoto": {
+    "message": "Puhuva kuva",
+    "description": "Tab label: Talking Photo"
+  },
+  "name.talkingPhotoImage": {
+    "message": "Muotokuva",
+    "description": "Talking Photo portrait image input"
+  },
+  "name.talkingPhotoAudio": {
+    "message": "Ohjaava ääni",
+    "description": "Talking Photo driving audio input"
+  },
+  "name.talkingPhotoPrompt": {
+    "message": "Liikekehote (valinnainen)",
+    "description": "Talking Photo optional motion prompt"
+  },
+  "description.talkingPhotoImage": {
+    "message": "Lataa selkeä kasvokuva edestä; se animoidaan ja saadaan puhumaan.",
+    "description": "Talking Photo portrait image help text"
+  },
+  "description.talkingPhotoAudio": {
+    "message": "Lataa äänileike (mp3/wav, ≤5 Mt); hahmo huulisynkronoi siihen.",
+    "description": "Talking Photo driving audio help text"
+  },
+  "description.talkingPhotoPrompt": {
+    "message": "Valinnainen: kuvaile haluttu ilme/liike, esim. ”katso lempeästi kameraan”.",
+    "description": "Talking Photo motion prompt help text"
+  },
+  "placeholder.talkingPhotoPrompt": {
+    "message": "esim. lempeä, rauhallinen, luonnollinen, kevyt pään liike",
+    "description": "Talking Photo prompt input placeholder"
+  },
+  "button.generateTalkingPhoto": {
+    "message": "Luo puhuva kuva",
+    "description": "Talking Photo generate button"
+  },
+  "button.uploadAudio": {
+    "message": "Lataa ääni",
+    "description": "Talking Photo upload audio button"
+  },
+  "message.talkingPhotoMissingInputs": {
+    "message": "Lataa ensin muotokuva ja ohjaava ääni.",
+    "description": "Talking Photo missing inputs warning"
+  },
+  "message.uploadAudioExceed": {
+    "message": "Vain yksi äänitiedosto on sallittu.",
+    "description": "Talking Photo audio count limit warning"
+  },
+  "message.uploadAudioError": {
+    "message": "Äänen lataus epäonnistui, yritä uudelleen.",
+    "description": "Talking Photo audio upload error"
   }
 }

--- a/src/i18n/fr/kling.json
+++ b/src/i18n/fr/kling.json
@@ -702,5 +702,57 @@
   "message.noTasks": {
     "message": "Aucune tâche historique, veuillez cliquer sur 'Générer une vidéo' à gauche",
     "description": "Message lorsqu'il n'y a pas de tâches"
+  },
+  "tab.talkingPhoto": {
+    "message": "Photo parlante",
+    "description": "Tab label: Talking Photo"
+  },
+  "name.talkingPhotoImage": {
+    "message": "Photo de portrait",
+    "description": "Talking Photo portrait image input"
+  },
+  "name.talkingPhotoAudio": {
+    "message": "Audio pilote",
+    "description": "Talking Photo driving audio input"
+  },
+  "name.talkingPhotoPrompt": {
+    "message": "Invite de mouvement (facultatif)",
+    "description": "Talking Photo optional motion prompt"
+  },
+  "description.talkingPhotoImage": {
+    "message": "Téléversez un portrait de face net ; il sera animé et se mettra à parler.",
+    "description": "Talking Photo portrait image help text"
+  },
+  "description.talkingPhotoAudio": {
+    "message": "Téléversez un clip audio (mp3/wav, ≤5 Mo) ; le personnage synchronise les lèvres dessus.",
+    "description": "Talking Photo driving audio help text"
+  },
+  "description.talkingPhotoPrompt": {
+    "message": "Facultatif : décrivez l’expression/le mouvement souhaité, p. ex. « regarder doucement la caméra ».",
+    "description": "Talking Photo motion prompt help text"
+  },
+  "placeholder.talkingPhotoPrompt": {
+    "message": "p. ex. doux, calme, naturel, léger mouvement de tête",
+    "description": "Talking Photo prompt input placeholder"
+  },
+  "button.generateTalkingPhoto": {
+    "message": "Générer une photo parlante",
+    "description": "Talking Photo generate button"
+  },
+  "button.uploadAudio": {
+    "message": "Téléverser l’audio",
+    "description": "Talking Photo upload audio button"
+  },
+  "message.talkingPhotoMissingInputs": {
+    "message": "Veuillez d’abord téléverser une photo de portrait et un audio pilote.",
+    "description": "Talking Photo missing inputs warning"
+  },
+  "message.uploadAudioExceed": {
+    "message": "Un seul fichier audio est autorisé.",
+    "description": "Talking Photo audio count limit warning"
+  },
+  "message.uploadAudioError": {
+    "message": "Échec du téléversement de l’audio, veuillez réessayer.",
+    "description": "Talking Photo audio upload error"
   }
 }

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -56,7 +56,8 @@ export const loadLocaleMessages = async (locale: string) => {
     for (const key in resource) {
       if (resource.hasOwnProperty(key)) {
         const element = resource[key];
-        messages[`${name}.${key}`] = element.message;
+        // Tolerate both the `{ message, description }` wrapper and a plain string value.
+        messages[`${name}.${key}`] = typeof element === 'string' ? element : element?.message;
       }
     }
   });

--- a/src/i18n/it/kling.json
+++ b/src/i18n/it/kling.json
@@ -702,5 +702,57 @@
   "message.noTasks": {
     "message": "Nessun compito storico, fai clic a sinistra per generare un video",
     "description": "Messaggio quando non ci sono compiti"
+  },
+  "tab.talkingPhoto": {
+    "message": "Foto parlante",
+    "description": "Tab label: Talking Photo"
+  },
+  "name.talkingPhotoImage": {
+    "message": "Foto ritratto",
+    "description": "Talking Photo portrait image input"
+  },
+  "name.talkingPhotoAudio": {
+    "message": "Audio guida",
+    "description": "Talking Photo driving audio input"
+  },
+  "name.talkingPhotoPrompt": {
+    "message": "Prompt di movimento (opzionale)",
+    "description": "Talking Photo optional motion prompt"
+  },
+  "description.talkingPhotoImage": {
+    "message": "Carica un ritratto frontale nitido; verrà animato e fatto parlare.",
+    "description": "Talking Photo portrait image help text"
+  },
+  "description.talkingPhotoAudio": {
+    "message": "Carica un clip audio (mp3/wav, ≤5 MB); il personaggio sincronizza le labbra.",
+    "description": "Talking Photo driving audio help text"
+  },
+  "description.talkingPhotoPrompt": {
+    "message": "Opzionale: descrivi l’espressione/il movimento desiderato, es. «guarda dolcemente la telecamera».",
+    "description": "Talking Photo motion prompt help text"
+  },
+  "placeholder.talkingPhotoPrompt": {
+    "message": "es. delicato, calmo, naturale, leggero movimento della testa",
+    "description": "Talking Photo prompt input placeholder"
+  },
+  "button.generateTalkingPhoto": {
+    "message": "Genera foto parlante",
+    "description": "Talking Photo generate button"
+  },
+  "button.uploadAudio": {
+    "message": "Carica audio",
+    "description": "Talking Photo upload audio button"
+  },
+  "message.talkingPhotoMissingInputs": {
+    "message": "Carica prima una foto ritratto e un audio guida.",
+    "description": "Talking Photo missing inputs warning"
+  },
+  "message.uploadAudioExceed": {
+    "message": "È consentito un solo file audio.",
+    "description": "Talking Photo audio count limit warning"
+  },
+  "message.uploadAudioError": {
+    "message": "Caricamento audio non riuscito, riprova.",
+    "description": "Talking Photo audio upload error"
   }
 }

--- a/src/i18n/ja/kling.json
+++ b/src/i18n/ja/kling.json
@@ -702,5 +702,57 @@
   "message.noTasks": {
     "message": "履歴タスクはありません。左側のボタンをクリックして動画を生成してください",
     "description": "タスクがないときのメッセージ"
+  },
+  "tab.talkingPhoto": {
+    "message": "トーキングフォト",
+    "description": "Tab label: Talking Photo"
+  },
+  "name.talkingPhotoImage": {
+    "message": "人物写真",
+    "description": "Talking Photo portrait image input"
+  },
+  "name.talkingPhotoAudio": {
+    "message": "駆動オーディオ",
+    "description": "Talking Photo driving audio input"
+  },
+  "name.talkingPhotoPrompt": {
+    "message": "モーションプロンプト（任意）",
+    "description": "Talking Photo optional motion prompt"
+  },
+  "description.talkingPhotoImage": {
+    "message": "鮮明な正面の人物写真をアップロードしてください。自動で動き出し、話し始めます。",
+    "description": "Talking Photo portrait image help text"
+  },
+  "description.talkingPhotoAudio": {
+    "message": "音声クリップ（mp3/wav、5MB以下）をアップロードしてください。人物が音声に合わせて口を動かします。",
+    "description": "Talking Photo driving audio help text"
+  },
+  "description.talkingPhotoPrompt": {
+    "message": "任意：希望する表情・動作を記述します。例「カメラを優しく見つめる」。",
+    "description": "Talking Photo motion prompt help text"
+  },
+  "placeholder.talkingPhotoPrompt": {
+    "message": "例：穏やか、落ち着いた、自然、わずかな頭の動き",
+    "description": "Talking Photo prompt input placeholder"
+  },
+  "button.generateTalkingPhoto": {
+    "message": "トーキングフォトを生成",
+    "description": "Talking Photo generate button"
+  },
+  "button.uploadAudio": {
+    "message": "音声をアップロード",
+    "description": "Talking Photo upload audio button"
+  },
+  "message.talkingPhotoMissingInputs": {
+    "message": "先に人物写真と駆動オーディオをアップロードしてください。",
+    "description": "Talking Photo missing inputs warning"
+  },
+  "message.uploadAudioExceed": {
+    "message": "音声ファイルは1つだけアップロードできます。",
+    "description": "Talking Photo audio count limit warning"
+  },
+  "message.uploadAudioError": {
+    "message": "音声のアップロードに失敗しました。もう一度お試しください。",
+    "description": "Talking Photo audio upload error"
   }
 }

--- a/src/i18n/ko/kling.json
+++ b/src/i18n/ko/kling.json
@@ -702,5 +702,57 @@
   "message.noTasks": {
     "message": "역사적 작업이 없습니다. 왼쪽에서 비디오 생성 버튼을 클릭하세요",
     "description": "작업이 없을 때의 메시지"
+  },
+  "tab.talkingPhoto": {
+    "message": "말하는 사진",
+    "description": "Tab label: Talking Photo"
+  },
+  "name.talkingPhotoImage": {
+    "message": "인물 사진",
+    "description": "Talking Photo portrait image input"
+  },
+  "name.talkingPhotoAudio": {
+    "message": "구동 오디오",
+    "description": "Talking Photo driving audio input"
+  },
+  "name.talkingPhotoPrompt": {
+    "message": "모션 프롬프트(선택)",
+    "description": "Talking Photo optional motion prompt"
+  },
+  "description.talkingPhotoImage": {
+    "message": "선명한 정면 인물 사진을 업로드하세요. 자동으로 움직이며 말하게 됩니다.",
+    "description": "Talking Photo portrait image help text"
+  },
+  "description.talkingPhotoAudio": {
+    "message": "오디오 클립(mp3/wav, 5MB 이하)을 업로드하세요. 인물이 오디오에 맞춰 입을 맞춥니다.",
+    "description": "Talking Photo driving audio help text"
+  },
+  "description.talkingPhotoPrompt": {
+    "message": "선택: 원하는 표정/동작을 설명하세요. 예: «카메라를 부드럽게 바라보기».",
+    "description": "Talking Photo motion prompt help text"
+  },
+  "placeholder.talkingPhotoPrompt": {
+    "message": "예: 부드럽고, 차분하고, 자연스럽고, 미세한 머리 움직임",
+    "description": "Talking Photo prompt input placeholder"
+  },
+  "button.generateTalkingPhoto": {
+    "message": "말하는 사진 생성",
+    "description": "Talking Photo generate button"
+  },
+  "button.uploadAudio": {
+    "message": "오디오 업로드",
+    "description": "Talking Photo upload audio button"
+  },
+  "message.talkingPhotoMissingInputs": {
+    "message": "먼저 인물 사진과 구동 오디오를 업로드하세요.",
+    "description": "Talking Photo missing inputs warning"
+  },
+  "message.uploadAudioExceed": {
+    "message": "오디오 파일은 하나만 업로드할 수 있습니다.",
+    "description": "Talking Photo audio count limit warning"
+  },
+  "message.uploadAudioError": {
+    "message": "오디오 업로드에 실패했습니다. 다시 시도하세요.",
+    "description": "Talking Photo audio upload error"
   }
 }

--- a/src/i18n/pl/kling.json
+++ b/src/i18n/pl/kling.json
@@ -702,5 +702,57 @@
   "message.noTasks": {
     "message": "Brak historii zadań, kliknij po lewej, aby wygenerować wideo",
     "description": "Komunikat, gdy nie ma zadań"
+  },
+  "tab.talkingPhoto": {
+    "message": "Mówiące zdjęcie",
+    "description": "Tab label: Talking Photo"
+  },
+  "name.talkingPhotoImage": {
+    "message": "Zdjęcie portretowe",
+    "description": "Talking Photo portrait image input"
+  },
+  "name.talkingPhotoAudio": {
+    "message": "Audio sterujące",
+    "description": "Talking Photo driving audio input"
+  },
+  "name.talkingPhotoPrompt": {
+    "message": "Podpowiedź ruchu (opcjonalnie)",
+    "description": "Talking Photo optional motion prompt"
+  },
+  "description.talkingPhotoImage": {
+    "message": "Prześlij wyraźny portret en face; zostanie animowany i zacznie mówić.",
+    "description": "Talking Photo portrait image help text"
+  },
+  "description.talkingPhotoAudio": {
+    "message": "Prześlij klip audio (mp3/wav, ≤5MB); postać zsynchronizuje ruch ust.",
+    "description": "Talking Photo driving audio help text"
+  },
+  "description.talkingPhotoPrompt": {
+    "message": "Opcjonalnie: opisz pożądany wyraz twarzy/ruch, np. „spójrz łagodnie w kamerę”.",
+    "description": "Talking Photo motion prompt help text"
+  },
+  "placeholder.talkingPhotoPrompt": {
+    "message": "np. delikatny, spokojny, naturalny, lekki ruch głowy",
+    "description": "Talking Photo prompt input placeholder"
+  },
+  "button.generateTalkingPhoto": {
+    "message": "Wygeneruj mówiące zdjęcie",
+    "description": "Talking Photo generate button"
+  },
+  "button.uploadAudio": {
+    "message": "Prześlij audio",
+    "description": "Talking Photo upload audio button"
+  },
+  "message.talkingPhotoMissingInputs": {
+    "message": "Najpierw prześlij zdjęcie portretowe i audio sterujące.",
+    "description": "Talking Photo missing inputs warning"
+  },
+  "message.uploadAudioExceed": {
+    "message": "Dozwolony jest tylko jeden plik audio.",
+    "description": "Talking Photo audio count limit warning"
+  },
+  "message.uploadAudioError": {
+    "message": "Przesłanie audio nie powiodło się, spróbuj ponownie.",
+    "description": "Talking Photo audio upload error"
   }
 }

--- a/src/i18n/pt/kling.json
+++ b/src/i18n/pt/kling.json
@@ -702,5 +702,57 @@
   "message.noTasks": {
     "message": "Nenhuma tarefa histórica, por favor clique à esquerda para gerar vídeo",
     "description": "Mensagem quando não há tarefas"
+  },
+  "tab.talkingPhoto": {
+    "message": "Foto falante",
+    "description": "Tab label: Talking Photo"
+  },
+  "name.talkingPhotoImage": {
+    "message": "Foto de retrato",
+    "description": "Talking Photo portrait image input"
+  },
+  "name.talkingPhotoAudio": {
+    "message": "Áudio de controle",
+    "description": "Talking Photo driving audio input"
+  },
+  "name.talkingPhotoPrompt": {
+    "message": "Prompt de movimento (opcional)",
+    "description": "Talking Photo optional motion prompt"
+  },
+  "description.talkingPhotoImage": {
+    "message": "Envie um retrato frontal nítido; ele será animado e fará falar.",
+    "description": "Talking Photo portrait image help text"
+  },
+  "description.talkingPhotoAudio": {
+    "message": "Envie um clipe de áudio (mp3/wav, ≤5 MB); o personagem sincroniza os lábios.",
+    "description": "Talking Photo driving audio help text"
+  },
+  "description.talkingPhotoPrompt": {
+    "message": "Opcional: descreva a expressão/movimento desejado, ex.: «olhar suavemente para a câmera».",
+    "description": "Talking Photo motion prompt help text"
+  },
+  "placeholder.talkingPhotoPrompt": {
+    "message": "ex.: suave, calmo, natural, leve movimento de cabeça",
+    "description": "Talking Photo prompt input placeholder"
+  },
+  "button.generateTalkingPhoto": {
+    "message": "Gerar foto falante",
+    "description": "Talking Photo generate button"
+  },
+  "button.uploadAudio": {
+    "message": "Enviar áudio",
+    "description": "Talking Photo upload audio button"
+  },
+  "message.talkingPhotoMissingInputs": {
+    "message": "Envie primeiro uma foto de retrato e um áudio de controle.",
+    "description": "Talking Photo missing inputs warning"
+  },
+  "message.uploadAudioExceed": {
+    "message": "Apenas um arquivo de áudio é permitido.",
+    "description": "Talking Photo audio count limit warning"
+  },
+  "message.uploadAudioError": {
+    "message": "Falha no envio do áudio, tente novamente.",
+    "description": "Talking Photo audio upload error"
   }
 }

--- a/src/i18n/ru/kling.json
+++ b/src/i18n/ru/kling.json
@@ -702,5 +702,57 @@
   "message.noTasks": {
     "message": "Нет историй задач, пожалуйста, нажмите слева для генерации видео",
     "description": "Сообщение, когда нет задач"
+  },
+  "tab.talkingPhoto": {
+    "message": "Говорящее фото",
+    "description": "Tab label: Talking Photo"
+  },
+  "name.talkingPhotoImage": {
+    "message": "Портретное фото",
+    "description": "Talking Photo portrait image input"
+  },
+  "name.talkingPhotoAudio": {
+    "message": "Управляющее аудио",
+    "description": "Talking Photo driving audio input"
+  },
+  "name.talkingPhotoPrompt": {
+    "message": "Подсказка движения (необязательно)",
+    "description": "Talking Photo optional motion prompt"
+  },
+  "description.talkingPhotoImage": {
+    "message": "Загрузите чёткий фронтальный портрет; он будет анимирован и заговорит.",
+    "description": "Talking Photo portrait image help text"
+  },
+  "description.talkingPhotoAudio": {
+    "message": "Загрузите аудиоклип (mp3/wav, ≤5 МБ); персонаж синхронизирует губы под него.",
+    "description": "Talking Photo driving audio help text"
+  },
+  "description.talkingPhotoPrompt": {
+    "message": "Необязательно: опишите желаемое выражение/движение, напр. «мягко смотреть в камеру».",
+    "description": "Talking Photo motion prompt help text"
+  },
+  "placeholder.talkingPhotoPrompt": {
+    "message": "напр. мягкое, спокойное, естественное, лёгкое движение головы",
+    "description": "Talking Photo prompt input placeholder"
+  },
+  "button.generateTalkingPhoto": {
+    "message": "Создать говорящее фото",
+    "description": "Talking Photo generate button"
+  },
+  "button.uploadAudio": {
+    "message": "Загрузить аудио",
+    "description": "Talking Photo upload audio button"
+  },
+  "message.talkingPhotoMissingInputs": {
+    "message": "Сначала загрузите портретное фото и управляющее аудио.",
+    "description": "Talking Photo missing inputs warning"
+  },
+  "message.uploadAudioExceed": {
+    "message": "Можно загрузить только один аудиофайл.",
+    "description": "Talking Photo audio count limit warning"
+  },
+  "message.uploadAudioError": {
+    "message": "Не удалось загрузить аудио, повторите попытку.",
+    "description": "Talking Photo audio upload error"
   }
 }

--- a/src/i18n/sr/kling.json
+++ b/src/i18n/sr/kling.json
@@ -702,5 +702,57 @@
   "message.noTasks": {
     "message": "Nema istorijskih zadataka, molimo kliknite levo za generisanje videa",
     "description": "Poruka kada nema zadataka"
+  },
+  "tab.talkingPhoto": {
+    "message": "Говорећа фотографија",
+    "description": "Tab label: Talking Photo"
+  },
+  "name.talkingPhotoImage": {
+    "message": "Портретна фотографија",
+    "description": "Talking Photo portrait image input"
+  },
+  "name.talkingPhotoAudio": {
+    "message": "Покретачки звук",
+    "description": "Talking Photo driving audio input"
+  },
+  "name.talkingPhotoPrompt": {
+    "message": "Упит за покрет (опционо)",
+    "description": "Talking Photo optional motion prompt"
+  },
+  "description.talkingPhotoImage": {
+    "message": "Отпремите јасан портрет анфас; биће анимиран и проговориће.",
+    "description": "Talking Photo portrait image help text"
+  },
+  "description.talkingPhotoAudio": {
+    "message": "Отпремите аудио клип (mp3/wav, ≤5MB); лик ће синхронизовати усне.",
+    "description": "Talking Photo driving audio help text"
+  },
+  "description.talkingPhotoPrompt": {
+    "message": "Опционо: опишите жељени израз/покрет, нпр. „нежно гледати у камеру“.",
+    "description": "Talking Photo motion prompt help text"
+  },
+  "placeholder.talkingPhotoPrompt": {
+    "message": "нпр. нежно, мирно, природно, благи покрет главе",
+    "description": "Talking Photo prompt input placeholder"
+  },
+  "button.generateTalkingPhoto": {
+    "message": "Генериши говорећу фотографију",
+    "description": "Talking Photo generate button"
+  },
+  "button.uploadAudio": {
+    "message": "Отпреми звук",
+    "description": "Talking Photo upload audio button"
+  },
+  "message.talkingPhotoMissingInputs": {
+    "message": "Прво отпремите портретну фотографију и покретачки звук.",
+    "description": "Talking Photo missing inputs warning"
+  },
+  "message.uploadAudioExceed": {
+    "message": "Дозвољена је само једна аудио датотека.",
+    "description": "Talking Photo audio count limit warning"
+  },
+  "message.uploadAudioError": {
+    "message": "Отпремање звука није успело, покушајте поново.",
+    "description": "Talking Photo audio upload error"
   }
 }

--- a/src/i18n/sv/kling.json
+++ b/src/i18n/sv/kling.json
@@ -702,5 +702,57 @@
   "message.noTasks": {
     "message": "Inga historiska uppgifter, vänligen klicka på vänster sida för att generera video",
     "description": "Meddelande när inga uppgifter finns"
+  },
+  "tab.talkingPhoto": {
+    "message": "Talande foto",
+    "description": "Tab label: Talking Photo"
+  },
+  "name.talkingPhotoImage": {
+    "message": "Porträttfoto",
+    "description": "Talking Photo portrait image input"
+  },
+  "name.talkingPhotoAudio": {
+    "message": "Styrljud",
+    "description": "Talking Photo driving audio input"
+  },
+  "name.talkingPhotoPrompt": {
+    "message": "Rörelseprompt (valfritt)",
+    "description": "Talking Photo optional motion prompt"
+  },
+  "description.talkingPhotoImage": {
+    "message": "Ladda upp ett tydligt porträtt framifrån; det animeras och får tala.",
+    "description": "Talking Photo portrait image help text"
+  },
+  "description.talkingPhotoAudio": {
+    "message": "Ladda upp ett ljudklipp (mp3/wav, ≤5MB); karaktären läppsynkar till det.",
+    "description": "Talking Photo driving audio help text"
+  },
+  "description.talkingPhotoPrompt": {
+    "message": "Valfritt: beskriv önskat uttryck/rörelse, t.ex. ”titta mjukt in i kameran”.",
+    "description": "Talking Photo motion prompt help text"
+  },
+  "placeholder.talkingPhotoPrompt": {
+    "message": "t.ex. mjuk, lugn, naturlig, lätt huvudrörelse",
+    "description": "Talking Photo prompt input placeholder"
+  },
+  "button.generateTalkingPhoto": {
+    "message": "Skapa talande foto",
+    "description": "Talking Photo generate button"
+  },
+  "button.uploadAudio": {
+    "message": "Ladda upp ljud",
+    "description": "Talking Photo upload audio button"
+  },
+  "message.talkingPhotoMissingInputs": {
+    "message": "Ladda först upp ett porträttfoto och ett styrljud.",
+    "description": "Talking Photo missing inputs warning"
+  },
+  "message.uploadAudioExceed": {
+    "message": "Endast en ljudfil tillåts.",
+    "description": "Talking Photo audio count limit warning"
+  },
+  "message.uploadAudioError": {
+    "message": "Ljuduppladdningen misslyckades, försök igen.",
+    "description": "Talking Photo audio upload error"
   }
 }

--- a/src/i18n/uk/kling.json
+++ b/src/i18n/uk/kling.json
@@ -702,5 +702,57 @@
   "message.noTasks": {
     "message": "Немає історичних завдань, будь ласка, натисніть ліворуч для генерації відео",
     "description": "Повідомлення, коли немає завдань"
+  },
+  "tab.talkingPhoto": {
+    "message": "Фото, що говорить",
+    "description": "Tab label: Talking Photo"
+  },
+  "name.talkingPhotoImage": {
+    "message": "Портретне фото",
+    "description": "Talking Photo portrait image input"
+  },
+  "name.talkingPhotoAudio": {
+    "message": "Керуюче аудіо",
+    "description": "Talking Photo driving audio input"
+  },
+  "name.talkingPhotoPrompt": {
+    "message": "Підказка руху (необов’язково)",
+    "description": "Talking Photo optional motion prompt"
+  },
+  "description.talkingPhotoImage": {
+    "message": "Завантажте чіткий фронтальний портрет; його буде анімовано, і він заговорить.",
+    "description": "Talking Photo portrait image help text"
+  },
+  "description.talkingPhotoAudio": {
+    "message": "Завантажте аудіокліп (mp3/wav, ≤5 МБ); персонаж синхронізує губи під нього.",
+    "description": "Talking Photo driving audio help text"
+  },
+  "description.talkingPhotoPrompt": {
+    "message": "Необов’язково: опишіть бажаний вираз/рух, напр. «лагідно дивитися в камеру».",
+    "description": "Talking Photo motion prompt help text"
+  },
+  "placeholder.talkingPhotoPrompt": {
+    "message": "напр. м’яко, спокійно, природно, легкий рух голови",
+    "description": "Talking Photo prompt input placeholder"
+  },
+  "button.generateTalkingPhoto": {
+    "message": "Створити фото, що говорить",
+    "description": "Talking Photo generate button"
+  },
+  "button.uploadAudio": {
+    "message": "Завантажити аудіо",
+    "description": "Talking Photo upload audio button"
+  },
+  "message.talkingPhotoMissingInputs": {
+    "message": "Спочатку завантажте портретне фото та керуюче аудіо.",
+    "description": "Talking Photo missing inputs warning"
+  },
+  "message.uploadAudioExceed": {
+    "message": "Дозволено лише один аудіофайл.",
+    "description": "Talking Photo audio count limit warning"
+  },
+  "message.uploadAudioError": {
+    "message": "Не вдалося завантажити аудіо, повторіть спробу.",
+    "description": "Talking Photo audio upload error"
   }
 }

--- a/src/i18n/zh-CN/kling.json
+++ b/src/i18n/zh-CN/kling.json
@@ -703,17 +703,56 @@
     "message": "没有历史任务，请点击左方生成视频",
     "description": "没有任务时的消息"
   },
-  "tab.talkingPhoto": "会说话的照片",
-  "name.talkingPhotoImage": "人物照片",
-  "name.talkingPhotoAudio": "驱动音频",
-  "name.talkingPhotoPrompt": "动作提示词（可选）",
-  "description.talkingPhotoImage": "上传一张清晰正脸照片，将自动让它动起来并开口说话。",
-  "description.talkingPhotoAudio": "上传一段音频（mp3/wav，≤5MB），人物会按音频对口型说话。",
-  "description.talkingPhotoPrompt": "可选：描述希望的表情/动作，如「温柔地看向镜头」。",
-  "placeholder.talkingPhotoPrompt": "例如：温柔、平静、自然，轻微头部动作",
-  "button.generateTalkingPhoto": "生成会说话的照片",
-  "button.uploadAudio": "上传音频",
-  "message.talkingPhotoMissingInputs": "请先上传人物照片和驱动音频。",
-  "message.uploadAudioExceed": "只能上传一个音频文件。",
-  "message.uploadAudioError": "音频上传失败，请重试。"
+  "tab.talkingPhoto": {
+    "message": "会说话的照片",
+    "description": "Tab 标签：Talking Photo"
+  },
+  "name.talkingPhotoImage": {
+    "message": "人物照片",
+    "description": "Talking Photo 的人物照片输入"
+  },
+  "name.talkingPhotoAudio": {
+    "message": "驱动音频",
+    "description": "Talking Photo 的驱动音频输入"
+  },
+  "name.talkingPhotoPrompt": {
+    "message": "动作提示词（可选）",
+    "description": "Talking Photo 的可选动作提示词"
+  },
+  "description.talkingPhotoImage": {
+    "message": "上传一张清晰正脸照片，将自动让它动起来并开口说话。",
+    "description": "Talking Photo 人物照片说明"
+  },
+  "description.talkingPhotoAudio": {
+    "message": "上传一段音频（mp3/wav，≤5MB），人物会按音频对口型说话。",
+    "description": "Talking Photo 驱动音频说明"
+  },
+  "description.talkingPhotoPrompt": {
+    "message": "可选：描述希望的表情/动作，如「温柔地看向镜头」。",
+    "description": "Talking Photo 动作提示词说明"
+  },
+  "placeholder.talkingPhotoPrompt": {
+    "message": "例如：温柔、平静、自然，轻微头部动作",
+    "description": "Talking Photo 提示词输入占位符"
+  },
+  "button.generateTalkingPhoto": {
+    "message": "生成会说话的照片",
+    "description": "Talking Photo 生成按钮"
+  },
+  "button.uploadAudio": {
+    "message": "上传音频",
+    "description": "Talking Photo 上传音频按钮"
+  },
+  "message.talkingPhotoMissingInputs": {
+    "message": "请先上传人物照片和驱动音频。",
+    "description": "Talking Photo 缺少输入时的提示"
+  },
+  "message.uploadAudioExceed": {
+    "message": "只能上传一个音频文件。",
+    "description": "Talking Photo 音频超出数量限制提示"
+  },
+  "message.uploadAudioError": {
+    "message": "音频上传失败，请重试。",
+    "description": "Talking Photo 音频上传失败提示"
+  }
 }

--- a/src/i18n/zh-TW/kling.json
+++ b/src/i18n/zh-TW/kling.json
@@ -702,5 +702,57 @@
   "message.noTasks": {
     "message": "沒有歷史任務，請點擊左方生成視頻",
     "description": "沒有任務時的消息"
+  },
+  "tab.talkingPhoto": {
+    "message": "會說話的照片",
+    "description": "Tab label: Talking Photo"
+  },
+  "name.talkingPhotoImage": {
+    "message": "人物照片",
+    "description": "Talking Photo portrait image input"
+  },
+  "name.talkingPhotoAudio": {
+    "message": "驅動音訊",
+    "description": "Talking Photo driving audio input"
+  },
+  "name.talkingPhotoPrompt": {
+    "message": "動作提示詞（可選）",
+    "description": "Talking Photo optional motion prompt"
+  },
+  "description.talkingPhotoImage": {
+    "message": "上傳一張清晰正臉照片，將自動讓它動起來並開口說話。",
+    "description": "Talking Photo portrait image help text"
+  },
+  "description.talkingPhotoAudio": {
+    "message": "上傳一段音訊（mp3/wav，≤5MB），人物會按音訊對口型說話。",
+    "description": "Talking Photo driving audio help text"
+  },
+  "description.talkingPhotoPrompt": {
+    "message": "可選：描述希望的表情/動作，如「溫柔地看向鏡頭」。",
+    "description": "Talking Photo motion prompt help text"
+  },
+  "placeholder.talkingPhotoPrompt": {
+    "message": "例如：溫柔、平靜、自然，輕微頭部動作",
+    "description": "Talking Photo prompt input placeholder"
+  },
+  "button.generateTalkingPhoto": {
+    "message": "生成會說話的照片",
+    "description": "Talking Photo generate button"
+  },
+  "button.uploadAudio": {
+    "message": "上傳音訊",
+    "description": "Talking Photo upload audio button"
+  },
+  "message.talkingPhotoMissingInputs": {
+    "message": "請先上傳人物照片和驅動音訊。",
+    "description": "Talking Photo missing inputs warning"
+  },
+  "message.uploadAudioExceed": {
+    "message": "只能上傳一個音訊檔案。",
+    "description": "Talking Photo audio count limit warning"
+  },
+  "message.uploadAudioError": {
+    "message": "音訊上傳失敗，請重試。",
+    "description": "Talking Photo audio upload error"
   }
 }

--- a/src/pages/kling/Index.vue
+++ b/src/pages/kling/Index.vue
@@ -25,9 +25,20 @@ import TabSwitcher from '@/components/kling/TabSwitcher.vue';
 import TalkingPhotoPanel from '@/components/kling/TalkingPhotoPanel.vue';
 import { klingOperator } from '@/operators';
 import { instrumentGeneration } from '@/plugins/telemetry';
-import { IKlingGenerateRequest, IKlingMotionRequest, IKlingTalkingPhotoRequest, IKlingTaskType, Status } from '@/models';
+import {
+  IKlingGenerateRequest,
+  IKlingMotionRequest,
+  IKlingTalkingPhotoRequest,
+  IKlingTaskType,
+  Status
+} from '@/models';
 import { ElMessage } from 'element-plus';
-import { ERROR_CODE_USED_UP, getWebhookCallbackUrl } from '@/constants';
+import {
+  ERROR_CODE_USED_UP,
+  getWebhookCallbackUrl,
+  KLING_TALKING_PHOTO_DEFAULT_MODEL,
+  KLING_TALKING_PHOTO_DEFAULT_MODE
+} from '@/constants';
 import RecentPanel from '@/components/kling/RecentPanel.vue';
 import { IKlingTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
@@ -323,10 +334,11 @@ export default defineComponent({
       const request: IKlingTalkingPhotoRequest = {
         image_url: cfg.image_url,
         audio_url: cfg.audio_url,
+        // Upstream requires `model`; always send a supported default if unset.
+        model: cfg.model || KLING_TALKING_PHOTO_DEFAULT_MODEL,
+        mode: cfg.mode || KLING_TALKING_PHOTO_DEFAULT_MODE,
         ...(cfg.prompt ? { prompt: cfg.prompt } : {}),
-        ...(cfg.model ? { model: cfg.model } : {}),
         ...(cfg.duration ? { duration: cfg.duration } : {}),
-        ...(cfg.mode ? { mode: cfg.mode } : {}),
         callback_url: CALLBACK_URL
       };
       const token = this.credential?.token;


### PR DESCRIPTION
## Problem

The **Talking Photo** tab (`studio.acedata.cloud/kling`, shipped in #942) was broken on three fronts — visible in production:

1. **Translations** — every label rendered as its raw key (`kling.tab.talkingPhoto`, `kling.name.talkingPhotoImage`, `kling.button.uploadAudio`, …).
2. **Generation failed** — upstream rejected requests with `model is required`.
3. **Layout** — the panel had no model/mode controls, unlike the Video tab.

## Root cause

1. **i18n format mismatch.** The loader at `src/i18n/index.ts` builds messages from `element.message` (every other key uses the `{ message, description }` wrapper). The new `talkingPhoto` keys were added as **plain strings**, so `element.message` was `undefined` → vue-i18n fell back to showing the raw key. They were also missing from the wrapper entirely.
2. **`model` never sent.** The panel had no model selector and `onGenerateTalkingPhoto` only included `model` when `cfg.model` was set (it never was). The `/kling/talking-photo` endpoint requires `model` (OpenAPI default `kling-v2-1-master` is documentation only, not auto-injected).

## Fix

- **i18n** — converted the zh-CN/en `talkingPhoto` keys to the `{ message, description }` wrapper, and **hardened the loader** to tolerate plain-string values too, so this class of bug can't silently break a label again.
- **Generation** — the request now **always** sends a supported `model` + `mode` (defaults `kling-v2-1-master` / `pro`).
- **Layout** — added **Model** and **Mode** selectors (`talking-photo/ModelSelector.vue`, `ModeSelector.vue`) bound to `talkingPhotoConfig`, for parity with the Video tab. They seed a default on mount, so generation works even with zero interaction.

## Notes

- Per repo convention only zh-CN/en locale files are hand-maintained; the other 16 locales are left to the translation pipeline (and now fall back gracefully via the hardened loader).
- `npx vue-tsc --noEmit` and `eslint` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)