### PR TITLE
feat(seo): add slack-app-id meta tag for Slack App Suggestions

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,8 @@
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
     <title>Ace Data Cloud - AI Hub</title>
+    <!-- Slack App Directory: suggest our Slack app when acedata links are shared -->
+    <meta name="slack-app-id" content="A0B0VU3KBQX" />
     <meta
       name="description"
       content="AI-powered creative hub — generate images with Midjourney & Flux, create music with Suno, produce videos with Luma & Sora, chat with GPT, Claude, Gemini & DeepSeek."


### PR DESCRIPTION
Adds `<meta name="slack-app-id" content="A0B0VU3KBQX" />` to the site `<head>`.

Part of the Slack Marketplace distribution setup: with this tag, Slack can surface our Slack app as a suggestion when links from this domain are shared in a workspace. One additive meta tag, no behavior change. App ID is public (not a secret).

🤖 Generated with [Claude Code](https://claude.com/claude-code)