### PR TITLE
refactor: consume @acedatacloud/core for telemetry + fingerprint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.277.6",
       "license": "MIT",
       "dependencies": {
-        "@acedatacloud/core": "^0.1.0",
+        "@acedatacloud/core": "^0.2.0",
         "@capacitor-community/apple-sign-in": "^7.1.0",
         "@capacitor-community/stripe": "^8.1.1",
         "@capacitor/app": "^8.0.1",
@@ -116,9 +116,9 @@
       }
     },
     "node_modules/@acedatacloud/core": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@acedatacloud/core/-/core-0.1.0.tgz",
-      "integrity": "sha512-fKTo0A8NVqcby6PHo50xD3Ce0Es6nUJBWiFQLy5p1uwHof/39J+M0qSJhbHYlz/tiEcLHGNfHyDAL6PIhwloaQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@acedatacloud/core/-/core-0.2.0.tgz",
+      "integrity": "sha512-TiG0rm3xcWd5PsGL0iosnOpxU6gYi+J5+2YJXXWseAo8ZOFeMGhedOQYiAEmetyZOsfyqVMvNJO/KKk+qtVuAA==",
       "license": "UNLICENSED",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "analyze": "vite-bundle-visualizer"
   },
   "dependencies": {
-    "@acedatacloud/core": "^0.1.0",
+    "@acedatacloud/core": "^0.2.0",
     "@capacitor-community/apple-sign-in": "^7.1.0",
     "@capacitor-community/stripe": "^8.1.1",
     "@capacitor/app": "^8.0.1",

--- a/src/plugins/telemetry.ts
+++ b/src/plugins/telemetry.ts
@@ -1,165 +1,33 @@
 /**
- * Frontend telemetry powered by Tencent Cloud RUM (Aegis).
+ * Frontend telemetry powered by Tencent Cloud RUM (Aegis). The Aegis glue now
+ * lives in @acedatacloud/core (createTelemetry); this module wires it with
+ * Nexior's RUM project id and keeps the existing exported function names plus
+ * the Nexior-only `instrumentGeneration` helper.
  *
- * Captures:
- *   - JS errors / unhandled rejections / Vue render errors
- *   - API request speed + 4xx/5xx (Aegis built-in `reportApiSpeed`)
- *   - SPA page views (Aegis built-in `spa: true`)
- *   - Custom business events via `track(event, props)`
- *   - Manual error reporting via `captureError(err, ctx)`
- *
- * Project ID is hardcoded — Tencent RUM project IDs are not secret (they're
- * shipped to every visitor's browser anyway), and pinning the ID keeps local
- * dev / Capacitor / preview builds all reporting to the same dashboard so
- * pre-production issues are visible too.
- *
- * Console: https://console.cloud.tencent.com/rum
+ * Project ID is hardcoded — Tencent RUM project ids are not secret (shipped to
+ * every visitor anyway), and pinning it keeps local dev / Capacitor / preview
+ * builds all reporting to the same dashboard.
+ *   Console: https://console.cloud.tencent.com/rum
+ *   App:     Ace Data Cloud (应用ID 154475, business system rum-vK9sZMBo)
  */
+import { createTelemetry } from '@acedatacloud/core/telemetry';
 
-import type Aegis from 'aegis-web-sdk';
-
-type AegisInstance = InstanceType<typeof Aegis>;
-
-interface InitOptions {
-  uin?: string;
-  fingerprint?: string;
-  release?: string;
-}
-
-let aegis: AegisInstance | null = null;
-let initialized = false;
-
-// Aegis "report id" — the alphanumeric token shown on each Web app's "应用接入"
-// row in the RUM console (NOT the numeric "应用ID" / "业务系统 ID").
-// Pinned here intentionally: this value is shipped to every visitor anyway,
-// so there's nothing to gain from sourcing it from env vars, and pinning
-// keeps local dev / Capacitor / preview builds reporting to the same
-// dashboard as production.
-//   Console:  https://console.cloud.tencent.com/rum
-//   App:      Ace Data Cloud (numeric 应用ID 154475, business system rum-vK9sZMBo)
 const PROJECT_ID = 'LlKeKIj1mDzkYrY6na';
 const HOST_URL = 'https://rumt-zh.com';
 
-/**
- * Initialize Aegis. Safe to call multiple times — subsequent calls update
- * config (uin, aid) instead of reinstantiating.
- */
-export async function initTelemetry(opts: InitOptions = {}): Promise<void> {
-  if (initialized && aegis) {
-    setUser(opts.uin, opts.fingerprint);
-    return;
-  }
+const telemetry = createTelemetry({ projectId: PROJECT_ID, hostUrl: HOST_URL });
 
-  try {
-    const { default: AegisCtor } = await import('aegis-web-sdk');
-    aegis = new AegisCtor({
-      id: PROJECT_ID,
-      uin: opts.uin,
-      aid: opts.fingerprint,
-      reportApiSpeed: true,
-      reportAssetSpeed: true,
-      spa: true,
-      hostUrl: HOST_URL,
-      version: opts.release
-    });
-    initialized = true;
-  } catch (err) {
-    // SDK load failure must never break the app.
-    console.warn('[telemetry] failed to init Aegis:', err);
-  }
-}
+export const initTelemetry = telemetry.initTelemetry;
+export const setUser = telemetry.setUser;
+export const track = telemetry.track;
+export const captureError = telemetry.captureError;
+export const trackApiFailure = telemetry.trackApiFailure;
+export const isInitialized = telemetry.isInitialized;
 
 /**
- * Update the visitor identity (after login, after fingerprint resolves).
- */
-export function setUser(uin?: string, aid?: string): void {
-  if (!aegis) return;
-  try {
-    if (uin) aegis.setConfig({ uin });
-    if (aid) aegis.setConfig({ aid });
-  } catch (err) {
-    console.warn('[telemetry] setUser failed:', err);
-  }
-}
-
-/**
- * Fire a custom business event. Property values are coerced to strings and
- * placed into Aegis's `ext1..ext3` slots so they're filterable in the RUM
- * dashboard.
- *
- *   track('payment_success', { order_id, pay_way, amount })
- */
-export function track(event: string, props: Record<string, unknown> = {}): void {
-  if (!aegis) return;
-  try {
-    const ext1 = props.service ?? props.pay_way ?? props.action;
-    const ext2 = props.order_id ?? props.task_id ?? props.id;
-    const ext3 = props.trace_id ?? props.error;
-    aegis.info({
-      msg: event,
-      ext1: ext1 != null ? String(ext1) : undefined,
-      ext2: ext2 != null ? String(ext2) : undefined,
-      ext3: ext3 != null ? String(ext3) : undefined
-    });
-  } catch (err) {
-    console.warn('[telemetry] track failed:', err);
-  }
-}
-
-/**
- * Capture an exception (Vue errorHandler, unhandled rejection, manual catch).
- */
-export function captureError(error: unknown, ctx: Record<string, unknown> = {}): void {
-  if (!aegis) return;
-  try {
-    const err = error instanceof Error ? error : new Error(String(error));
-    aegis.error({
-      msg: err.message,
-      stack: err.stack,
-      ext1: ctx.source != null ? String(ctx.source) : undefined,
-      ext2: ctx.route != null ? String(ctx.route) : undefined,
-      ext3: ctx.trace_id != null ? String(ctx.trace_id) : undefined
-    });
-  } catch (e) {
-    console.warn('[telemetry] captureError failed:', e);
-  }
-}
-
-/**
- * Mark an API failure (called from axios response interceptor). Goes through
- * `info` rather than `error` so it doesn't double-count with Aegis's built-in
- * `reportApiSpeed` 4xx/5xx capture; the value of this hook is attaching the
- * server-side `trace_id` so the entry can be cross-referenced with CLS.
- */
-export function trackApiFailure(args: { url: string; method?: string; status?: number; trace_id?: string }): void {
-  if (!aegis) return;
-  try {
-    aegis.info({
-      msg: 'api_failure',
-      ext1: `${args.method ?? 'GET'} ${args.url}`,
-      ext2: args.status != null ? String(args.status) : undefined,
-      ext3: args.trace_id
-    });
-  } catch (err) {
-    console.warn('[telemetry] trackApiFailure failed:', err);
-  }
-}
-
-/** Returns true when the SDK is up and running. Useful for tests. */
-export function isInitialized(): boolean {
-  return initialized;
-}
-
-/**
- * Wrap a generation request with `generation_submit` / `generation_success`
- * / `generation_failed` events.
- *
- *   instrumentGeneration('flux', fluxOperator.generate(req, { token }))
- *     .then(...)
- *     .catch(...)
- *
- * The wrapper preserves the underlying promise's resolved value and rejection,
- * so the surrounding `.then` / `.catch` keep working unchanged.
+ * Wrap a generation request with `generation_submit` / `generation_success` /
+ * `generation_failed` events. Preserves the underlying promise's value and
+ * rejection so surrounding `.then` / `.catch` keep working unchanged.
  */
 export function instrumentGeneration<T>(service: string, promise: Promise<T>): Promise<T> {
   track('generation_submit', { service });

--- a/src/store/common/actions.ts
+++ b/src/store/common/actions.ts
@@ -1,4 +1,5 @@
 import { ActionContext } from 'vuex';
+import { createFingerprintResolver } from '@acedatacloud/core/fingerprint';
 import { IRootState } from './models';
 import {
   userOperator,
@@ -65,15 +66,15 @@ export const getUser = async ({ commit }: ActionContext<IRootState, IRootState>)
   }
 };
 
+// `@fingerprintjs/fingerprintjs` is ~30 KB minified and only needed once,
+// typically well after first paint. Load it lazily (inside the injected loader)
+// so it stays out of the entry chunk and off the critical path.
+const resolveFingerprint = createFingerprintResolver({
+  load: () => import('@fingerprintjs/fingerprintjs').then((m) => m.default.load())
+});
+
 export const getFingerprint = async ({ commit }: ActionContext<IRootState, IRootState>) => {
-  // `@fingerprintjs/fingerprintjs` is ~30 KB minified and only needed once,
-  // typically well after first paint. Load it lazily so it stays out of the
-  // entry chunk and out of the critical-path execution time.
-  const { default: FingerprintJS } = await import('@fingerprintjs/fingerprintjs');
-  const fp = await FingerprintJS.load();
-  const result = await fp.get();
-  const visitorId = result.visitorId;
-  console.debug('visitorId', visitorId);
+  const visitorId = await resolveFingerprint();
   commit('setFingerprint', visitorId);
   return visitorId;
 };


### PR DESCRIPTION
**Stacked on #947** (base is the chunkLoadError+getLocale branch). Will retarget to main once #947 merges.

Adopts two more core modules in Nexior:
- **telemetry** → `createTelemetry` from `@acedatacloud/core/telemetry` (Aegis RUM glue; project id wired here). All exported names + the Nexior-only `instrumentGeneration` preserved. ~120 → ~30 LOC.
- **fingerprint** → `createFingerprintResolver` from `@acedatacloud/core/fingerprint`; lazy FingerprintJS import preserved (stays out of the entry chunk).

Bumps `@acedatacloud/core` to `^0.2.0` (subpath imports rely on the new typesVersions map).

Verified: `vue-tsc -b` ✅ · `eslint`/`prettier` ✅ · `npm run build:web` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)