### PR TITLE
refactor(operators): consume @acedatacloud/core for the http client

### DIFF
--- a/change/@acedatacloud-nexior-59ac751d-f377-46d4-9aac-bda51d1c226c.json
+++ b/change/@acedatacloud-nexior-59ac751d-f377-46d4-9aac-bda51d1c226c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "consume @acedatacloud/core for the http client (interceptor contract)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/operators/common.ts
+++ b/src/operators/common.ts
@@ -1,76 +1,33 @@
 import store from '@/store';
 import { getBaseUrlPlatform } from '@/utils';
 import { trackApiFailure } from '@/plugins/telemetry';
-import axios, { AxiosInstance } from 'axios';
+import { createHttpClient } from '@acedatacloud/core/http';
 import qs from 'qs';
 import { getCookie } from 'typescript-cookie';
 import { v4 as uuidv4 } from 'uuid';
 
-const httpClient: AxiosInstance = axios.create({
+// The axios instance + interceptor contract now lives in @acedatacloud/core;
+// this configures it with Nexior's token/fingerprint/user sources and 401
+// behavior. Header set (x-request-id / Authorization / accept-language /
+// x-fingerprint / x-user-id) and 4xx/5xx-to-RUM are handled inside the factory.
+const httpClient = createHttpClient({
   baseURL: `${getBaseUrlPlatform()}/api/v1`,
   // Without a timeout a stalled mobile connection leaves the promise pending
-  // forever — e.g. the SSO code exchange / getUser after Apple login would
-  // hang with no error, leaving the UI dead. Fail after 20s so the caller's
-  // catch runs (and RUM captures it).
+  // forever (e.g. SSO code exchange / getUser after Apple login). Fail after
+  // 20s so the caller's catch runs and RUM captures it.
   timeout: 20000,
-  headers: {
-    'Content-type': 'application/json',
-    Accept: 'application/json'
+  getToken: () => store.getters.token?.access,
+  getUserId: () => store.getters.user?.id,
+  getFingerprint: () => store.getters.fingerprint,
+  getLocale: () => getCookie('LOCALE'),
+  paramsSerializer: (params) => qs.stringify(params, { arrayFormat: 'repeat' }),
+  generateRequestId: () => uuidv4(),
+  // Fire-and-forget (not awaited) to preserve the original timing: the caller's
+  // rejection runs without waiting for logout to complete.
+  onUnauthorized: () => {
+    store.dispatch('logout');
   },
-  paramsSerializer(params) {
-    return qs.stringify(params, { arrayFormat: 'repeat' });
-  }
+  onApiFailure: trackApiFailure
 });
-
-httpClient.interceptors.request.use((config) => {
-  const accessToken = store.getters.token?.access;
-  const userId = store.getters.user?.id;
-  const fingerprint = store.getters.fingerprint;
-  const locale = getCookie('LOCALE');
-  console.debug('userId', userId);
-  console.debug('fingerprint', fingerprint);
-  config.headers['x-request-id'] = uuidv4();
-  if (accessToken) {
-    config.headers['Authorization'] = `Bearer ${accessToken}`;
-  }
-  if (locale) {
-    config.headers['accept-language'] = locale;
-  }
-  if (fingerprint) {
-    config.headers['x-fingerprint'] = fingerprint;
-  }
-  if (userId) {
-    config.headers['x-user-id'] = userId;
-  }
-  return config;
-});
-
-httpClient.interceptors.response.use(
-  (response) => {
-    return response;
-  },
-  (error) => {
-    if (error?.response?.status === 401) {
-      store.dispatch('logout');
-    }
-    const traceId = error?.response?.data?.trace_id || error?.response?.headers?.['x-request-id'];
-    if (traceId) {
-      console.error(`Request failed [trace_id=${traceId}]`, error?.response?.status, error?.response?.data);
-    }
-    // Forward 4xx/5xx to RUM with the server-side trace_id attached so the
-    // entry can be cross-referenced with PlatformGateway CLS logs. Network
-    // errors (no `response`) are still captured because Aegis's built-in
-    // `reportApiSpeed` covers them.
-    if (error?.response) {
-      trackApiFailure({
-        url: error.config?.url ?? '',
-        method: error.config?.method,
-        status: error.response.status,
-        trace_id: traceId
-      });
-    }
-    return Promise.reject(error);
-  }
-);
 
 export { httpClient };


### PR DESCRIPTION
Final core adoption for Nexior — the **auth/billing-critical** http client.

Replaces the hand-rolled axios instance + interceptors in `operators/common.ts` with core's `createHttpClient`. **Exact parity** (everything app-specific injected via config):
- baseURL `${getBaseUrlPlatform()}/api/v1`, `timeout: 20000`, qs `repeat` serializer
- request headers: `x-request-id` (uuidv4), `Authorization`, `accept-language`, `x-fingerprint`, `x-user-id` — same store getters / `LOCALE` cookie
- 401 → `store.dispatch('logout')` **fire-and-forget** (timing unchanged)
- 4xx/5xx → `trackApiFailure` with the server `trace_id`

Only removed lines are two `console.debug` calls. The interceptor contract is covered by core's 22 unit tests; `vue-tsc` ✅ `eslint`/`prettier` ✅ `build:web` ✅.

⚠️ **Higher-risk than the prior adoptions** (auth path). Suggested post-deploy smoke: login round-trip, a deliberate 401 → logout, and confirm `api_failure` events still land in RUM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)