### PR TITLE
refactor(i18n): consume @acedatacloud/core/i18n loaders + setI18nLanguage

### DIFF
--- a/change/@acedatacloud-nexior-44809810-f5f7-4415-b63a-df9dc5118318.json
+++ b/change/@acedatacloud-nexior-44809810-f5f7-4415-b63a-df9dc5118318.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "consume @acedatacloud/core/i18n for locale loaders + setI18nLanguage",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.278.0",
       "license": "MIT",
       "dependencies": {
-        "@acedatacloud/core": "^0.2.0",
+        "@acedatacloud/core": "^0.4.0",
         "@capacitor-community/apple-sign-in": "^7.1.0",
         "@capacitor-community/stripe": "^8.1.1",
         "@capacitor/app": "^8.0.1",
@@ -118,22 +118,30 @@
       }
     },
     "node_modules/@acedatacloud/core": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@acedatacloud/core/-/core-0.2.0.tgz",
-      "integrity": "sha512-TiG0rm3xcWd5PsGL0iosnOpxU6gYi+J5+2YJXXWseAo8ZOFeMGhedOQYiAEmetyZOsfyqVMvNJO/KKk+qtVuAA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@acedatacloud/core/-/core-0.4.0.tgz",
+      "integrity": "sha512-xzsCXxuU715llcsESH6jHj6H2gJTN4eyQJXtc7ZeC55vOUMxn88kBUfFt+K3OSvmLmjQvxdom15CD6iRYmB/6Q==",
       "license": "UNLICENSED",
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
         "aegis-web-sdk": "*",
-        "axios": ">=1.0.0 <2"
+        "axios": ">=1.0.0 <2",
+        "vue": ">=3.2.0 <4",
+        "vue-i18n": ">=9.1.0 <12"
       },
       "peerDependenciesMeta": {
         "aegis-web-sdk": {
           "optional": true
         },
         "axios": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-i18n": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "build:ssg": "cross-env VITE_SURFACE=web vite-ssg build"
   },
   "dependencies": {
-    "@acedatacloud/core": "^0.2.0",
+    "@acedatacloud/core": "^0.4.0",
     "@capacitor-community/apple-sign-in": "^7.1.0",
     "@capacitor-community/stripe": "^8.1.1",
     "@capacitor/app": "^8.0.1",

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,8 +1,8 @@
 import { createI18n } from 'vue-i18n';
 import { makeGetLocale } from '@acedatacloud/core';
+import { makeFlatLoader, createSetI18nLanguage } from '@acedatacloud/core/i18n';
 import { I18N_DEFAULT_LOCALE, I18N_SCOPES, I18N_SUPPORTED_LOCALES } from '@/constants/i18n';
 import axios from 'axios';
-import { nextTick } from 'vue';
 
 export const i18n = createI18n({
   legacy: true
@@ -35,53 +35,21 @@ export const loadLocaleResource = async (name: string, locale: string) => {
   return module.default;
 };
 
-export const loadLocaleMessages = async (locale: string) => {
-  const promises = I18N_SCOPES.map((name) => loadLocaleResource(name, locale));
-  const resources = await Promise.all(promises);
+// Flat dotted-key loader + setI18nLanguage now come from @acedatacloud/core/i18n;
+// the glob loader above + the scope list stay owned here.
+const loadLocaleMessagesInternal = makeFlatLoader({ scopes: I18N_SCOPES, loadResource: loadLocaleResource });
 
-  const messages: any = {};
-  I18N_SCOPES.forEach((name, index) => {
-    const resource = resources[index];
-    for (const key in resource) {
-      if (resource.hasOwnProperty(key)) {
-        const element = resource[key];
-        // Tolerate both the `{ message, description }` wrapper and a plain string value.
-        messages[`${name}.${key}`] = typeof element === 'string' ? element : element?.message;
-      }
+export const loadLocaleMessages = (locale: string) => loadLocaleMessagesInternal(i18n, locale);
+
+export const setI18nLanguage = createSetI18nLanguage({
+  i18n,
+  loadLocaleMessages: loadLocaleMessagesInternal,
+  setAxiosLanguageHeader: (locale) => {
+    if (axios.defaults.headers) {
+      axios.defaults.headers['Accept-Language'] = locale;
     }
-  });
-
-  // set locale and locale message
-  i18n.global.setLocaleMessage(locale, messages);
-
-  return nextTick();
-};
-
-export const setI18nLanguage = async (locale: string) => {
-  // load locale messages
-  if (!i18n.global.availableLocales.includes(locale)) {
-    await loadLocaleMessages(locale);
   }
-
-  // set global locale
-  if (i18n.mode === 'legacy') {
-    i18n.global.locale = locale;
-  } else {
-    // @ts-ignore
-    i18n.global.locale.value = locale;
-  }
-
-  // set global axios headers
-  if (axios.defaults.headers) {
-    axios.defaults.headers['Accept-Language'] = locale;
-  }
-
-  // set global dom html lang attribute (client only — no document during SSG)
-  const htmlDom = typeof document !== 'undefined' ? document.querySelector('html') : null;
-  if (htmlDom) {
-    htmlDom.setAttribute('lang', locale);
-  }
-};
+});
 
 export const t = i18n.global.t;
 


### PR DESCRIPTION
Adopts core 0.4.0's i18n factories. Replaces Nexior's inline flat-key loader + `setI18nLanguage` with `makeFlatLoader` + `createSetI18nLanguage`. The glob `loadLocaleResource`, scope list, `i18n`, `getLocale`, `t` stay; exported `loadLocaleMessages(locale)` + `setI18nLanguage(locale)` signatures preserved (axios Accept-Language + html lang behavior kept via injected setter). −24 LOC. vue-tsc + vite build + lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)