### PR TITLE
refactor(price): consume @acedatacloud/core/pricing

### DIFF
--- a/change/@acedatacloud-nexior-a70129c5-645a-4199-8eaa-9d3334ea7d29.json
+++ b/change/@acedatacloud-nexior-a70129c5-645a-4199-8eaa-9d3334ea7d29.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "consume @acedatacloud/core/pricing",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.278.1",
       "license": "MIT",
       "dependencies": {
-        "@acedatacloud/core": "^0.4.0",
+        "@acedatacloud/core": "^0.5.0",
         "@capacitor-community/apple-sign-in": "^7.1.0",
         "@capacitor-community/stripe": "^8.1.1",
         "@capacitor/app": "^8.0.1",
@@ -118,9 +118,9 @@
       }
     },
     "node_modules/@acedatacloud/core": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@acedatacloud/core/-/core-0.4.0.tgz",
-      "integrity": "sha512-xzsCXxuU715llcsESH6jHj6H2gJTN4eyQJXtc7ZeC55vOUMxn88kBUfFt+K3OSvmLmjQvxdom15CD6iRYmB/6Q==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@acedatacloud/core/-/core-0.5.0.tgz",
+      "integrity": "sha512-ELxRw0lAhtuKsyTVDVfTUhax+uy+kRj4Maz64MJ8v33/rLrzLgpe1H363CdWsGSFJemRKcCtzRrhFPGVcEyLCA==",
       "license": "UNLICENSED",
       "engines": {
         "node": ">=18"
@@ -128,6 +128,7 @@
       "peerDependencies": {
         "aegis-web-sdk": "*",
         "axios": ">=1.0.0 <2",
+        "json-logic-js": ">=2.0.0 <3",
         "vue": ">=3.2.0 <4",
         "vue-i18n": ">=9.1.0 <12"
       },
@@ -136,6 +137,9 @@
           "optional": true
         },
         "axios": {
+          "optional": true
+        },
+        "json-logic-js": {
           "optional": true
         },
         "vue": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "build:ssg": "cross-env VITE_SURFACE=web vite-ssg build"
   },
   "dependencies": {
-    "@acedatacloud/core": "^0.4.0",
+    "@acedatacloud/core": "^0.5.0",
     "@capacitor-community/apple-sign-in": "^7.1.0",
     "@capacitor-community/stripe": "^8.1.1",
     "@capacitor/app": "^8.0.1",

--- a/src/utils/price.ts
+++ b/src/utils/price.ts
@@ -1,65 +1,17 @@
+// Pricing helpers now live in @acedatacloud/core/pricing. getConsumption is the
+// pure JsonLogic evaluator; the currency-aware formatters are built from the
+// store's exchange/currency here. Exported names/signatures unchanged.
+import { getConsumption as coreGetConsumption, createPriceFormatter } from '@acedatacloud/core/pricing';
 import { CURRENCY_LABEL_MAPPING } from '@/constants/mapping';
 import store from '@/store';
-import jsonLogic from 'json-logic-js';
 
-/**
- * Input a value and target currency (e.g. cny), return the price which the current locale
- */
-export const getPrice = (payload: { value: number; currency?: string }) => {
-  const exchange = store.state.exchange;
-  let { value, currency = store.state.currency || 'usd' } = payload;
-  const label = CURRENCY_LABEL_MAPPING[currency];
-  if (!exchange) {
-    return {
-      value: value,
-      currency: currency,
-      label: label
-    };
-  }
-  const key = `usd-${currency}`;
-  const rate = exchange[key];
-  if (rate) {
-    value = value * rate;
-  }
-  console.log('new price', { value, currency });
-  return {
-    value,
-    currency,
-    label
-  };
-};
+const formatter = createPriceFormatter({
+  getExchange: () => store.state.exchange,
+  getCurrency: () => store.state.currency,
+  currencyLabels: CURRENCY_LABEL_MAPPING
+});
 
-export const getPriceString = (payload: {
-  value: number | undefined;
-  defaultValue?: number | undefined;
-  fractionDigits?: number | undefined;
-}) => {
-  let { value, defaultValue, fractionDigits = 2 } = payload;
-  if (value === undefined) {
-    value = defaultValue;
-  }
-  if (value === undefined) {
-    return '';
-  }
-  const price = getPrice({
-    value
-  });
-  return `${price.label}${price.value?.toFixed(fractionDigits)}`;
-};
-
-export const getConsumption = (payload: any, rules: any): number | undefined => {
-  console.debug('getConsumption payload', payload, rules);
-  if (!rules || !Array.isArray(rules)) {
-    return undefined;
-  }
-  console.debug('payload', payload);
-  console.debug('rules', rules);
-  for (const rule of rules) {
-    const conditions = rule.conditions;
-    if (jsonLogic.apply(conditions, payload)) {
-      // Evaluate the consumption rule with payload so dynamic expressions can use request fields.
-      return jsonLogic.apply(rule.consumption, payload) as number;
-    }
-  }
-  return 0;
-};
+export const getPrice = formatter.getPrice;
+export const getPriceString = formatter.getPriceString;
+// Keep the historically-loose signature (call sites pass `config | undefined`).
+export const getConsumption = (payload: any, rules: any): number | undefined => coreGetConsumption(payload, rules);


### PR DESCRIPTION
price.ts → thin wrapper over `@acedatacloud/core/pricing` (0.5.0): `getConsumption` from core, `getPrice`/`getPriceString` via `createPriceFormatter` (store exchange/currency injected). Exported names + signatures preserved. vue-tsc + vite build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)