### PR TITLE
refactor(operators): consume @acedatacloud/core BaseOperator

### DIFF
--- a/change/@acedatacloud-nexior-bcea5c7a-7677-438c-ab31-1d3ae067927e.json
+++ b/change/@acedatacloud-nexior-bcea5c7a-7677-438c-ab31-1d3ae067927e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "refactor(operators): consume @acedatacloud/core BaseOperator CRUD base",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.278.1",
       "license": "MIT",
       "dependencies": {
-        "@acedatacloud/core": "^0.4.0",
+        "@acedatacloud/core": "^0.7.0",
         "@capacitor-community/apple-sign-in": "^7.1.0",
         "@capacitor-community/stripe": "^8.1.1",
         "@capacitor/app": "^8.0.1",
@@ -118,9 +118,9 @@
       }
     },
     "node_modules/@acedatacloud/core": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@acedatacloud/core/-/core-0.4.0.tgz",
-      "integrity": "sha512-xzsCXxuU715llcsESH6jHj6H2gJTN4eyQJXtc7ZeC55vOUMxn88kBUfFt+K3OSvmLmjQvxdom15CD6iRYmB/6Q==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@acedatacloud/core/-/core-0.7.0.tgz",
+      "integrity": "sha512-CTI8OYzbuXBcBA8O8vp3hnYEKSbUyoPYPxq1IDtgtz7vVxHltMLhUJZnyZu5709+xis5O2Hn7qutJt8z1KrDPw==",
       "license": "UNLICENSED",
       "engines": {
         "node": ">=18"
@@ -128,6 +128,8 @@
       "peerDependencies": {
         "aegis-web-sdk": "*",
         "axios": ">=1.0.0 <2",
+        "json-logic-js": ">=2.0.0 <3",
+        "mustache": ">=4.0.0 <5",
         "vue": ">=3.2.0 <4",
         "vue-i18n": ">=9.1.0 <12"
       },
@@ -136,6 +138,12 @@
           "optional": true
         },
         "axios": {
+          "optional": true
+        },
+        "json-logic-js": {
+          "optional": true
+        },
+        "mustache": {
           "optional": true
         },
         "vue": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "build:ssg": "cross-env VITE_SURFACE=web vite-ssg build"
   },
   "dependencies": {
-    "@acedatacloud/core": "^0.4.0",
+    "@acedatacloud/core": "^0.7.0",
     "@capacitor-community/apple-sign-in": "^7.1.0",
     "@capacitor-community/stripe": "^8.1.1",
     "@capacitor/app": "^8.0.1",

--- a/src/operators/api.ts
+++ b/src/operators/api.ts
@@ -1,4 +1,5 @@
 import { AxiosResponse } from 'axios';
+import { BaseOperator } from '@acedatacloud/core/operators';
 import { httpClient } from './common';
 import { IApi, IApiDetailResponse, IApiListResponse } from '@/models';
 
@@ -8,29 +9,9 @@ export interface IApiQuery {
   ordering?: string;
 }
 
-class ApiOperator {
-  key = 'apis';
-
-  async getAll(query: IApiQuery): Promise<AxiosResponse<IApiListResponse>> {
-    return await httpClient.get(`/${this.key}/`, {
-      params: query
-    });
-  }
-
-  async get(id: string): Promise<AxiosResponse<IApiDetailResponse>> {
-    return await httpClient.get(`/${this.key}/${id}`);
-  }
-
-  async create(data: IApi): Promise<AxiosResponse<IApiDetailResponse>> {
-    return await httpClient.post(`/${this.key}/`, data);
-  }
-
-  async update(id: string, data: IApi): Promise<AxiosResponse<IApiDetailResponse>> {
-    return await httpClient.put(`/${this.key}/${id}`, data);
-  }
-
-  async delete(id: string): Promise<AxiosResponse<null>> {
-    return await httpClient.delete(`/${this.key}/${id}`);
+class ApiOperator extends BaseOperator<IApi, IApiListResponse, IApiDetailResponse> {
+  constructor() {
+    super(httpClient, 'apis');
   }
 
   async getAllForService(serviceId: string, query?: IApiQuery): Promise<AxiosResponse<IApiListResponse>> {

--- a/src/operators/application.ts
+++ b/src/operators/application.ts
@@ -1,4 +1,5 @@
 import { AxiosResponse } from 'axios';
+import { BaseOperator } from '@acedatacloud/core/operators';
 import { httpClient } from './common';
 import {
   IApplication,
@@ -28,33 +29,13 @@ export interface IApplicationQuery {
   affiliation?: Array<'owner' | 'granted'> | 'owner' | 'granted';
 }
 
-class ApplicationOperator {
-  key = 'applications';
-
-  async getAll(query: IApplicationQuery): Promise<AxiosResponse<IApplicationListResponse>> {
-    return await httpClient.get(`/${this.key}/`, {
-      params: query
-    });
-  }
-
-  async get(id: string): Promise<AxiosResponse<IApplicationDetailResponse>> {
-    return await httpClient.get(`/${this.key}/${id}`);
-  }
-
-  async create(data: IApplication): Promise<AxiosResponse<IApplicationDetailResponse>> {
-    return await httpClient.post(`/${this.key}/`, data);
-  }
-
-  async update(id: string, data: IApplication): Promise<AxiosResponse<IApplicationDetailResponse>> {
-    return await httpClient.put(`/${this.key}/${id}`, data);
+class ApplicationOperator extends BaseOperator<IApplication, IApplicationListResponse, IApplicationDetailResponse> {
+  constructor() {
+    super(httpClient, 'applications');
   }
 
   async updateAllConsumeGlobal(id: string, data: IApplication): Promise<AxiosResponse<IApplicationDetailResponse>> {
     return await httpClient.post(`/${this.key}/${id}/update-allow-consume-global/`, data);
-  }
-
-  async delete(id: string): Promise<AxiosResponse<null>> {
-    return await httpClient.delete(`/${this.key}/${id}`);
   }
 }
 

--- a/src/operators/service.ts
+++ b/src/operators/service.ts
@@ -1,4 +1,4 @@
-import { AxiosResponse } from 'axios';
+import { BaseOperator } from '@acedatacloud/core/operators';
 import { httpClient } from './common';
 import { IService, IServiceDetailResponse, IServiceListResponse } from '@/models';
 
@@ -9,29 +9,9 @@ export interface IServiceQuery {
   id?: string | string[];
 }
 
-class ServiceOperator {
-  key = 'services';
-
-  async getAll(query: IServiceQuery): Promise<AxiosResponse<IServiceListResponse>> {
-    return await httpClient.get(`/${this.key}/`, {
-      params: query
-    });
-  }
-
-  async get(id: string): Promise<AxiosResponse<IServiceDetailResponse>> {
-    return await httpClient.get(`/${this.key}/${id}`);
-  }
-
-  async create(data: IService): Promise<AxiosResponse<IServiceDetailResponse>> {
-    return await httpClient.post(`/${this.key}/`, data);
-  }
-
-  async update(id: string, data: IService): Promise<AxiosResponse<IServiceDetailResponse>> {
-    return await httpClient.put(`/${this.key}/${id}`, data);
-  }
-
-  async delete(id: string): Promise<AxiosResponse<null>> {
-    return await httpClient.delete(`/${this.key}/${id}`);
+class ServiceOperator extends BaseOperator<IService, IServiceListResponse, IServiceDetailResponse> {
+  constructor() {
+    super(httpClient, 'services');
   }
 }
 


### PR DESCRIPTION
## What

`api` / `application` / `service` operators now extend the shared `BaseOperator` CRUD base class from `@acedatacloud/core/operators` (0.7.0) instead of re-typing `getAll`/`get`/`create`/`update`/`delete` by hand.

- Domain-specific methods stay local: `ApiOperator.getAllForService`, `ApplicationOperator.updateAllConsumeGlobal`.
- These three operators match the default convention exactly (`/${key}/` collection with trailing slash, `/${key}/${id}` item no trailing slash, **PUT** update) — verified against the live URLs, so request behavior is byte-identical.
- **Net −50 LOC** (75 removed / 25 added).

Skipped on purpose (not byte-identical / risk): `order` (money path), `credential` (no update), and any PATCH / trailing-slash deviants.

## Dependency

Bumps `@acedatacloud/core` `^0.4.0 → ^0.7.0`. `^0.7.0` supersets the `^0.5.0`/`^0.6.0` pins in #953 (pricing) and #954 (code-snippet) — on a `package.json` pin conflict at merge, **keep `^0.7.0`**; all three subpaths exist in 0.7.0.

## Verification

- `vue-tsc --noEmit` clean (exit 0).
- `eslint` clean on changed files.
- `BaseOperator` itself has 5 unit tests in CommonFrontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)