### PR TITLE
refactor(x402): consume @acedatacloud/core/x402 pure primitives

### DIFF
--- a/change/@acedatacloud-nexior-df6a6463-f562-484e-8dd4-acf1dda075bc.json
+++ b/change/@acedatacloud-nexior-df6a6463-f562-484e-8dd4-acf1dda075bc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "refactor(x402): consume @acedatacloud/core/x402 pure primitives",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.278.1",
       "license": "MIT",
       "dependencies": {
-        "@acedatacloud/core": "^0.4.0",
+        "@acedatacloud/core": "^0.8.0",
         "@capacitor-community/apple-sign-in": "^7.1.0",
         "@capacitor-community/stripe": "^8.1.1",
         "@capacitor/app": "^8.0.1",
@@ -118,9 +118,9 @@
       }
     },
     "node_modules/@acedatacloud/core": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@acedatacloud/core/-/core-0.4.0.tgz",
-      "integrity": "sha512-xzsCXxuU715llcsESH6jHj6H2gJTN4eyQJXtc7ZeC55vOUMxn88kBUfFt+K3OSvmLmjQvxdom15CD6iRYmB/6Q==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@acedatacloud/core/-/core-0.8.0.tgz",
+      "integrity": "sha512-9XPjWzC4p2JEQ3X+5DWN/VB677+Msh6pIb5wcGWr3Q9dBOYg1Iq7HUJpI2fVdDOt8IdtKYrw97UCths+Hy1Rpw==",
       "license": "UNLICENSED",
       "engines": {
         "node": ">=18"
@@ -128,6 +128,8 @@
       "peerDependencies": {
         "aegis-web-sdk": "*",
         "axios": ">=1.0.0 <2",
+        "json-logic-js": ">=2.0.0 <3",
+        "mustache": ">=4.0.0 <5",
         "vue": ">=3.2.0 <4",
         "vue-i18n": ">=9.1.0 <12"
       },
@@ -136,6 +138,12 @@
           "optional": true
         },
         "axios": {
+          "optional": true
+        },
+        "json-logic-js": {
+          "optional": true
+        },
+        "mustache": {
           "optional": true
         },
         "vue": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "build:ssg": "cross-env VITE_SURFACE=web vite-ssg build"
   },
   "dependencies": {
-    "@acedatacloud/core": "^0.4.0",
+    "@acedatacloud/core": "^0.8.0",
     "@capacitor-community/apple-sign-in": "^7.1.0",
     "@capacitor-community/stripe": "^8.1.1",
     "@capacitor/app": "^8.0.1",

--- a/src/utils/x402/solana.ts
+++ b/src/utils/x402/solana.ts
@@ -23,6 +23,15 @@ import type {
   TransactionInstruction as TransactionInstructionType
 } from '@solana/web3.js';
 
+import {
+  TOKEN_PROGRAM_ID_ADDRESS,
+  ASSOCIATED_TOKEN_PROGRAM_ID_ADDRESS,
+  uint8ArrayToBase64,
+  resolveRpcUrl,
+  createTransferCheckedData,
+  formatTokenAmount
+} from '@acedatacloud/core/x402';
+
 type SolanaWeb3 = typeof import('@solana/web3.js');
 
 let solanaWeb3Promise: Promise<SolanaWeb3> | null = null;
@@ -33,65 +42,17 @@ const loadSolanaWeb3 = (): Promise<SolanaWeb3> => {
   return solanaWeb3Promise;
 };
 
-// RPC endpoints
-const SOLANA_MAINNET_RPC = 'https://api.mainnet-beta.solana.com';
-const SOLANA_DEVNET_RPC = 'https://api.devnet.solana.com';
-
-// Solana program IDs (raw strings; `PublicKey` instances are constructed lazily
-// after the module is loaded).
-const TOKEN_PROGRAM_ID_STR = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA';
-const ASSOCIATED_TOKEN_PROGRAM_ID_STR = 'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL';
-
-/**
- * Convert Uint8Array to base64 string (browser-compatible, no Node.js Buffer)
- */
-function uint8ArrayToBase64(bytes: Uint8Array): string {
-  let binary = '';
-  for (let i = 0; i < bytes.length; i++) {
-    binary += String.fromCharCode(bytes[i]);
-  }
-  return btoa(binary);
-}
-
-/**
- * Resolve RPC URL based on network
- */
-function resolveRpcUrl(network: string, customRpcUrl?: string): string {
-  if (customRpcUrl) return customRpcUrl;
-  if (network.includes('devnet')) return SOLANA_DEVNET_RPC;
-  return SOLANA_MAINNET_RPC;
-}
-
 /**
  * Find Associated Token Account address
  */
 function findAta(web3: SolanaWeb3, owner: PublicKeyType, mint: PublicKeyType): PublicKeyType {
-  const tokenProgramId = new web3.PublicKey(TOKEN_PROGRAM_ID_STR);
-  const associatedTokenProgramId = new web3.PublicKey(ASSOCIATED_TOKEN_PROGRAM_ID_STR);
+  const tokenProgramId = new web3.PublicKey(TOKEN_PROGRAM_ID_ADDRESS);
+  const associatedTokenProgramId = new web3.PublicKey(ASSOCIATED_TOKEN_PROGRAM_ID_ADDRESS);
   const [ata] = web3.PublicKey.findProgramAddressSync(
     [owner.toBuffer(), tokenProgramId.toBuffer(), mint.toBuffer()],
     associatedTokenProgramId
   );
   return ata;
-}
-
-/**
- * Create TransferChecked instruction data
- */
-function createTransferCheckedData(amount: bigint, decimals: number): Uint8Array {
-  const data = new Uint8Array(10);
-  data[0] = 12; // TransferChecked instruction discriminator
-  new DataView(data.buffer).setBigUint64(1, amount, true);
-  data[9] = decimals;
-  return data;
-}
-
-/**
- * Format a raw token amount with the given decimals into a human string.
- */
-function formatTokenAmount(raw: bigint, decimals: number): string {
-  const dp = Math.min(decimals, 6);
-  return (Number(raw) / 10 ** decimals).toFixed(dp);
 }
 
 /**
@@ -191,7 +152,7 @@ function buildTransferCheckedInstruction(
   decimals: number
 ): TransactionInstructionType {
   const instructionData = createTransferCheckedData(amount, decimals);
-  const tokenProgramId = new web3.PublicKey(TOKEN_PROGRAM_ID_STR);
+  const tokenProgramId = new web3.PublicKey(TOKEN_PROGRAM_ID_ADDRESS);
   return new web3.TransactionInstruction({
     programId: tokenProgramId,
     keys: [


### PR DESCRIPTION
## What

`src/utils/x402/solana.ts` now imports the pure, unit-tested X402 helpers from `@acedatacloud/core/x402` (0.8.0) instead of defining its own copies: `uint8ArrayToBase64`, `resolveRpcUrl`, `createTransferCheckedData`, `formatTokenAmount`, the RPC endpoints, and the SPL Token program-ID addresses.

**Net −39 LOC.** No behavior change — the extracted functions are byte-identical to the originals and covered by 13 exact-output tests in CommonFrontend.

## Money-critical: what is NOT touched

Everything that does the actual signing/submission stays local and untouched:
- `executeSolanaPayment` (wallet `signAndSendTransaction`), `buildSolanaX402Header`
- `findAta` / `buildTransferCheckedInstruction` (use `@solana/web3.js`)
- `ensureSufficientUsdcBalance` / `waitForSignatureConfirmation` (take a `Connection`)
- the lazy `@solana/web3.js` loader (keeps the vendor-web3 chunk dynamic)

Only the deterministic, dependency-free pure helpers moved to core.

## Dependency

Bumps `@acedatacloud/core` `^0.4.0 → ^0.8.0`. `^0.8.0` supersets the pins in #953/#954/#955 — on a `package.json` conflict at merge, **keep `^0.8.0`**.

## Verification

- `vue-tsc --noEmit` clean (exit 0); `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)