### PR TITLE
fix(mobile): inset teleported drawers below status bar / home indicator

### DIFF
--- a/change/@acedatacloud-nexior-9040e608-0eb3-4839-9602-24e98ab1b639.json
+++ b/change/@acedatacloud-nexior-9040e608-0eb3-4839-9602-24e98ab1b639.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(codingBridge): let the directory picker jump to any drive via an editable path input",
+  "packageName": "@acedatacloud/nexior",
+  "email": "cqc@cuiqingcai.com",
+  "dependentChangeType": "patch"
+}

--- a/src/assets/scss/_common.scss
+++ b/src/assets/scss/_common.scss
@@ -404,6 +404,37 @@ html.dark .el-dialog {
   border: 1px solid var(--app-glass-border);
 }
 
+// Mobile: drawers (service config panels, the chat side panel, inspiration /
+// history sheets, voice manager …) are teleported to <body>, so unlike routed
+// pages they do NOT inherit the layout's `padding-top: var(--app-safe-area-top)`
+// (see Main.vue / Console.vue). Their content therefore drew under the iOS
+// Dynamic Island / Android status bar — e.g. the Kling "Video Generation /
+// Motion Control / Talking Photo" tabs hugging the clock & battery — and under
+// the home indicator at the bottom.
+//
+// Inset the drawer panel itself (covers both headerless config drawers and
+// drawers that render an `.el-drawer__header`) by the safe area on small
+// screens. `--app-safe-area-*` resolves to 0px on non-notched devices, so this
+// is a no-op there. The `+ 8px` top gives the same comfortable gap the floating
+// balance pill already uses (`0.5rem + safe-area`, see Main.vue .status-floating).
+@media (max-width: 767px) {
+  // Full-height side drawers (direction ltr / rtl) span the whole viewport
+  // height, so they must clear both the top status bar and the bottom home bar.
+  .el-drawer.ltr,
+  .el-drawer.rtl {
+    padding-top: calc(var(--app-safe-area-top) + 8px);
+    padding-bottom: var(--app-safe-area-bottom);
+  }
+
+  // Top / bottom sheets only touch one edge.
+  .el-drawer.ttb {
+    padding-top: calc(var(--app-safe-area-top) + 8px);
+  }
+  .el-drawer.btt {
+    padding-bottom: var(--app-safe-area-bottom);
+  }
+}
+
 .el-message-box {
   --el-messagebox-border-radius: 1.25rem;
 }

--- a/src/components/codingBridge/DirectoryDialog.vue
+++ b/src/components/codingBridge/DirectoryDialog.vue
@@ -8,7 +8,9 @@
     @open="onOpen"
   >
     <div class="flex flex-col gap-2">
-      <!-- Current path + parent navigation -->
+      <!-- Editable path + parent navigation. The input lets the user jump to
+           any absolute path (e.g. another drive like D:\), which is otherwise
+           unreachable because a drive root has no parent to navigate up to. -->
       <div class="flex items-center gap-2 min-w-0">
         <el-button
           size="small"
@@ -19,9 +21,22 @@
         >
           <font-awesome-icon icon="fa-solid fa-arrow-up" />
         </el-button>
-        <span class="text-xs text-[var(--app-text-subtle)] truncate flex-1" dir="ltr">
-          {{ listing ? listing.path : '…' }}
-        </span>
+        <el-input
+          v-model="pathInput"
+          size="small"
+          class="flex-1 min-w-0"
+          dir="ltr"
+          :placeholder="$t('codingBridge.directory.pathPlaceholder')"
+          :disabled="loading"
+          @keyup.enter="goPath"
+          @blur="syncPathInput"
+        >
+          <template #append>
+            <el-button :title="$t('codingBridge.directory.go')" :disabled="loading || !pathInput.trim()" @click="goPath">
+              <font-awesome-icon icon="fa-solid fa-arrow-right" />
+            </el-button>
+          </template>
+        </el-input>
         <el-button
           size="small"
           circle
@@ -94,7 +109,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElDialog, ElButton } from 'element-plus';
+import { ElDialog, ElButton, ElInput } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { ICodingBridgeDirEntry, ICodingBridgeDirListing } from '@/models';
 
@@ -103,6 +118,7 @@ export default defineComponent({
   components: {
     ElDialog,
     ElButton,
+    ElInput,
     FontAwesomeIcon
   },
   props: {
@@ -117,6 +133,19 @@ export default defineComponent({
     }
   },
   emits: ['update:visible', 'select'],
+  data() {
+    return {
+      // Mirror of the current listing path, kept editable so the user can type
+      // or paste an absolute path (including a different drive) and jump there.
+      pathInput: ''
+    };
+  },
+  watch: {
+    // Keep the input in step with wherever the node actually navigated to.
+    'listing.path'(value: string | undefined) {
+      this.pathInput = value ?? '';
+    }
+  },
   computed: {
     listing(): ICodingBridgeDirListing | undefined {
       return this.$store.state.codingBridge?.directory;
@@ -136,7 +165,20 @@ export default defineComponent({
   },
   methods: {
     onOpen() {
+      this.pathInput = this.initialPath || '';
       this.$store.dispatch('codingBridge/browseDir', this.initialPath || undefined);
+    },
+    // Navigate to whatever absolute path the user typed (e.g. `D:\`), letting
+    // them cross to a drive/root that the parent-directory button can't reach.
+    goPath() {
+      const target = this.pathInput.trim();
+      if (target) {
+        this.$store.dispatch('codingBridge/browseDir', target);
+      }
+    },
+    // Reset a half-edited path back to where we actually are when focus leaves.
+    syncPathInput() {
+      this.pathInput = this.listing?.path ?? '';
     },
     onVisibleChange(value: boolean) {
       this.$emit('update:visible', value);

--- a/src/components/codingBridge/DirectoryDialog.vue
+++ b/src/components/codingBridge/DirectoryDialog.vue
@@ -32,7 +32,11 @@
           @blur="syncPathInput"
         >
           <template #append>
-            <el-button :title="$t('codingBridge.directory.go')" :disabled="loading || !pathInput.trim()" @click="goPath">
+            <el-button
+              :title="$t('codingBridge.directory.go')"
+              :disabled="loading || !pathInput.trim()"
+              @click="goPath"
+            >
               <font-awesome-icon icon="fa-solid fa-arrow-right" />
             </el-button>
           </template>
@@ -140,12 +144,6 @@ export default defineComponent({
       pathInput: ''
     };
   },
-  watch: {
-    // Keep the input in step with wherever the node actually navigated to.
-    'listing.path'(value: string | undefined) {
-      this.pathInput = value ?? '';
-    }
-  },
   computed: {
     listing(): ICodingBridgeDirListing | undefined {
       return this.$store.state.codingBridge?.directory;
@@ -161,6 +159,12 @@ export default defineComponent({
     },
     isEmpty(): boolean {
       return !!this.listing && !this.listing.error && (this.listing.entries ?? []).length === 0;
+    }
+  },
+  watch: {
+    // Keep the input in step with wherever the node actually navigated to.
+    'listing.path'(value: string | undefined) {
+      this.pathInput = value ?? '';
     }
   },
   methods: {

--- a/src/i18n/ar/codingBridge.json
+++ b/src/i18n/ar/codingBridge.json
@@ -327,14 +327,6 @@
     "message": "تحديث",
     "description": "Button: reload the current directory"
   },
-  "directory.pathPlaceholder": {
-    "message": "Type a path (e.g. D:\\) and press Enter",
-    "description": "Placeholder for the editable directory path input"
-  },
-  "directory.go": {
-    "message": "Go",
-    "description": "Button: navigate to the typed directory path"
-  },
   "directory.loading": {
     "message": "جارٍ التحميل…",
     "description": "Directory listing loading hint"

--- a/src/i18n/ar/codingBridge.json
+++ b/src/i18n/ar/codingBridge.json
@@ -327,6 +327,14 @@
     "message": "تحديث",
     "description": "Button: reload the current directory"
   },
+  "directory.pathPlaceholder": {
+    "message": "أدخل المسار (مثل D:\\) ثم اضغط إدخال",
+    "description": "نص توضيحي لحقل إدخال مسار الدليل القابل للتعديل"
+  },
+  "directory.go": {
+    "message": "انتقل",
+    "description": "زر: الانتقال إلى مسار الدليل المدخل"
+  },
   "directory.loading": {
     "message": "جارٍ التحميل…",
     "description": "Directory listing loading hint"

--- a/src/i18n/ar/codingBridge.json
+++ b/src/i18n/ar/codingBridge.json
@@ -327,6 +327,14 @@
     "message": "تحديث",
     "description": "Button: reload the current directory"
   },
+  "directory.pathPlaceholder": {
+    "message": "Type a path (e.g. D:\\) and press Enter",
+    "description": "Placeholder for the editable directory path input"
+  },
+  "directory.go": {
+    "message": "Go",
+    "description": "Button: navigate to the typed directory path"
+  },
   "directory.loading": {
     "message": "جارٍ التحميل…",
     "description": "Directory listing loading hint"

--- a/src/i18n/de/codingBridge.json
+++ b/src/i18n/de/codingBridge.json
@@ -327,14 +327,6 @@
     "message": "Aktualisieren",
     "description": "Button: reload the current directory"
   },
-  "directory.pathPlaceholder": {
-    "message": "Type a path (e.g. D:\\) and press Enter",
-    "description": "Placeholder for the editable directory path input"
-  },
-  "directory.go": {
-    "message": "Go",
-    "description": "Button: navigate to the typed directory path"
-  },
   "directory.loading": {
     "message": "Wird geladen…",
     "description": "Directory listing loading hint"

--- a/src/i18n/de/codingBridge.json
+++ b/src/i18n/de/codingBridge.json
@@ -327,6 +327,14 @@
     "message": "Aktualisieren",
     "description": "Button: reload the current directory"
   },
+  "directory.pathPlaceholder": {
+    "message": "Geben Sie den Pfad ein (z. B. D:\\) und drücken Sie die Eingabetaste",
+    "description": "Platzhalter für das bearbeitbare Eingabefeld des Verzeichnis-Pfads"
+  },
+  "directory.go": {
+    "message": "Gehe zu",
+    "description": "Schaltfläche: navigiere zum eingegebenen Verzeichnis-Pfad"
+  },
   "directory.loading": {
     "message": "Wird geladen…",
     "description": "Directory listing loading hint"

--- a/src/i18n/de/codingBridge.json
+++ b/src/i18n/de/codingBridge.json
@@ -327,6 +327,14 @@
     "message": "Aktualisieren",
     "description": "Button: reload the current directory"
   },
+  "directory.pathPlaceholder": {
+    "message": "Type a path (e.g. D:\\) and press Enter",
+    "description": "Placeholder for the editable directory path input"
+  },
+  "directory.go": {
+    "message": "Go",
+    "description": "Button: navigate to the typed directory path"
+  },
   "directory.loading": {
     "message": "Wird geladen…",
     "description": "Directory listing loading hint"

--- a/src/i18n/el/codingBridge.json
+++ b/src/i18n/el/codingBridge.json
@@ -327,6 +327,14 @@
     "message": "Ανανέωση",
     "description": "Button: reload the current directory"
   },
+  "directory.pathPlaceholder": {
+    "message": "Εισάγετε τη διαδρομή (π.χ. D:\\) και πατήστε Enter",
+    "description": "Placeholder για την επεξεργάσιμη είσοδο διαδρομής φακέλου"
+  },
+  "directory.go": {
+    "message": "Μετάβαση",
+    "description": "Κουμπί: πλοήγηση στη διαδρομή φακέλου που πληκτρολογήθηκε"
+  },
   "directory.loading": {
     "message": "Φόρτωση…",
     "description": "Directory listing loading hint"

--- a/src/i18n/el/codingBridge.json
+++ b/src/i18n/el/codingBridge.json
@@ -327,6 +327,14 @@
     "message": "Ανανέωση",
     "description": "Button: reload the current directory"
   },
+  "directory.pathPlaceholder": {
+    "message": "Type a path (e.g. D:\\) and press Enter",
+    "description": "Placeholder for the editable directory path input"
+  },
+  "directory.go": {
+    "message": "Go",
+    "description": "Button: navigate to the typed directory path"
+  },
   "directory.loading": {
     "message": "Φόρτωση…",
     "description": "Directory listing loading hint"

--- a/src/i18n/el/codingBridge.json
+++ b/src/i18n/el/codingBridge.json
@@ -327,14 +327,6 @@
     "message": "Ανανέωση",
     "description": "Button: reload the current directory"
   },
-  "directory.pathPlaceholder": {
-    "message": "Type a path (e.g. D:\\) and press Enter",
-    "description": "Placeholder for the editable directory path input"
-  },
-  "directory.go": {
-    "message": "Go",
-    "description": "Button: navigate to the typed directory path"
-  },
   "directory.loading": {
     "message": "Φόρτωση…",
     "description": "Directory listing loading hint"

--- a/src/i18n/en/codingBridge.json
+++ b/src/i18n/en/codingBridge.json
@@ -327,6 +327,14 @@
     "message": "Refresh",
     "description": "Button: reload the current directory"
   },
+  "directory.pathPlaceholder": {
+    "message": "Type a path (e.g. D:\\) and press Enter",
+    "description": "Placeholder for the editable directory path input"
+  },
+  "directory.go": {
+    "message": "Go",
+    "description": "Button: navigate to the typed directory path"
+  },
   "directory.loading": {
     "message": "Loading…",
     "description": "Directory listing loading hint"

--- a/src/i18n/es/codingBridge.json
+++ b/src/i18n/es/codingBridge.json
@@ -327,14 +327,6 @@
     "message": "Actualizar",
     "description": "Button: reload the current directory"
   },
-  "directory.pathPlaceholder": {
-    "message": "Type a path (e.g. D:\\) and press Enter",
-    "description": "Placeholder for the editable directory path input"
-  },
-  "directory.go": {
-    "message": "Go",
-    "description": "Button: navigate to the typed directory path"
-  },
   "directory.loading": {
     "message": "Cargando…",
     "description": "Directory listing loading hint"

--- a/src/i18n/es/codingBridge.json
+++ b/src/i18n/es/codingBridge.json
@@ -327,6 +327,14 @@
     "message": "Actualizar",
     "description": "Button: reload the current directory"
   },
+  "directory.pathPlaceholder": {
+    "message": "Type a path (e.g. D:\\) and press Enter",
+    "description": "Placeholder for the editable directory path input"
+  },
+  "directory.go": {
+    "message": "Go",
+    "description": "Button: navigate to the typed directory path"
+  },
   "directory.loading": {
     "message": "Cargando…",
     "description": "Directory listing loading hint"

--- a/src/i18n/es/codingBridge.json
+++ b/src/i18n/es/codingBridge.json
@@ -327,6 +327,14 @@
     "message": "Actualizar",
     "description": "Button: reload the current directory"
   },
+  "directory.pathPlaceholder": {
+    "message": "Introduce la ruta (por ejemplo, D:\\) y presiona Enter",
+    "description": "Marcador de posición para la entrada editable de la ruta del directorio"
+  },
+  "directory.go": {
+    "message": "Ir",
+    "description": "Botón: navegar a la ruta de directorio escrita"
+  },
   "directory.loading": {
     "message": "Cargando…",
     "description": "Directory listing loading hint"

--- a/src/i18n/fi/codingBridge.json
+++ b/src/i18n/fi/codingBridge.json
@@ -327,6 +327,14 @@
     "message": "Päivitä",
     "description": "Button: reload the current directory"
   },
+  "directory.pathPlaceholder": {
+    "message": "Syötä polku (esim. D:\\) ja paina Enter",
+    "description": "Paikkamerkki muokattavalle hakemistopolun syötteelle"
+  },
+  "directory.go": {
+    "message": "Siirry",
+    "description": "Painike: siirry kirjoitettuun hakemistopolkuun"
+  },
   "directory.loading": {
     "message": "Ladataan…",
     "description": "Directory listing loading hint"

--- a/src/i18n/fi/codingBridge.json
+++ b/src/i18n/fi/codingBridge.json
@@ -327,14 +327,6 @@
     "message": "Päivitä",
     "description": "Button: reload the current directory"
   },
-  "directory.pathPlaceholder": {
-    "message": "Type a path (e.g. D:\\) and press Enter",
-    "description": "Placeholder for the editable directory path input"
-  },
-  "directory.go": {
-    "message": "Go",
-    "description": "Button: navigate to the typed directory path"
-  },
   "directory.loading": {
     "message": "Ladataan…",
     "description": "Directory listing loading hint"

--- a/src/i18n/fi/codingBridge.json
+++ b/src/i18n/fi/codingBridge.json
@@ -327,6 +327,14 @@
     "message": "Päivitä",
     "description": "Button: reload the current directory"
   },
+  "directory.pathPlaceholder": {
+    "message": "Type a path (e.g. D:\\) and press Enter",
+    "description": "Placeholder for the editable directory path input"
+  },
+  "directory.go": {
+    "message": "Go",
+    "description": "Button: navigate to the typed directory path"
+  },
   "directory.loading": {
     "message": "Ladataan…",
     "description": "Directory listing loading hint"

--- a/src/i18n/fr/codingBridge.json
+++ b/src/i18n/fr/codingBridge.json
@@ -327,6 +327,14 @@
     "message": "Actualiser",
     "description": "Button: reload the current directory"
   },
+  "directory.pathPlaceholder": {
+    "message": "Entrez le chemin (par exemple D:\\) puis appuyez sur Entrée",
+    "description": "Espace réservé pour le champ de saisie du chemin de répertoire modifiable"
+  },
+  "directory.go": {
+    "message": "Aller",
+    "description": "Bouton : naviguer vers le chemin de répertoire saisi"
+  },
   "directory.loading": {
     "message": "Chargement…",
     "description": "Directory listing loading hint"

--- a/src/i18n/fr/codingBridge.json
+++ b/src/i18n/fr/codingBridge.json
@@ -327,14 +327,6 @@
     "message": "Actualiser",
     "description": "Button: reload the current directory"
   },
-  "directory.pathPlaceholder": {
-    "message": "Type a path (e.g. D:\\) and press Enter",
-    "description": "Placeholder for the editable directory path input"
-  },
-  "directory.go": {
-    "message": "Go",
-    "description": "Button: navigate to the typed directory path"
-  },
   "directory.loading": {
     "message": "Chargement…",
     "description": "Directory listing loading hint"

--- a/src/i18n/fr/codingBridge.json
+++ b/src/i18n/fr/codingBridge.json
@@ -327,6 +327,14 @@
     "message": "Actualiser",
     "description": "Button: reload the current directory"
   },
+  "directory.pathPlaceholder": {
+    "message": "Type a path (e.g. D:\\) and press Enter",
+    "description": "Placeholder for the editable directory path input"
+  },
+  "directory.go": {
+    "message": "Go",
+    "description": "Button: navigate to the typed directory path"
+  },
   "directory.loading": {
     "message": "Chargement…",
     "description": "Directory listing loading hint"

--- a/src/i18n/it/codingBridge.json
+++ b/src/i18n/it/codingBridge.json
@@ -327,6 +327,14 @@
     "message": "Aggiorna",
     "description": "Button: reload the current directory"
   },
+  "directory.pathPlaceholder": {
+    "message": "Type a path (e.g. D:\\) and press Enter",
+    "description": "Placeholder for the editable directory path input"
+  },
+  "directory.go": {
+    "message": "Go",
+    "description": "Button: navigate to the typed directory path"
+  },
   "directory.loading": {
     "message": "Caricamento…",
     "description": "Directory listing loading hint"

--- a/src/i18n/it/codingBridge.json
+++ b/src/i18n/it/codingBridge.json
@@ -327,14 +327,6 @@
     "message": "Aggiorna",
     "description": "Button: reload the current directory"
   },
-  "directory.pathPlaceholder": {
-    "message": "Type a path (e.g. D:\\) and press Enter",
-    "description": "Placeholder for the editable directory path input"
-  },
-  "directory.go": {
-    "message": "Go",
-    "description": "Button: navigate to the typed directory path"
-  },
   "directory.loading": {
     "message": "Caricamento…",
     "description": "Directory listing loading hint"

--- a/src/i18n/it/codingBridge.json
+++ b/src/i18n/it/codingBridge.json
@@ -327,6 +327,14 @@
     "message": "Aggiorna",
     "description": "Button: reload the current directory"
   },
+  "directory.pathPlaceholder": {
+    "message": "Inserisci il percorso (es. D:\\) e premi invio",
+    "description": "Segnaposto per l'input del percorso della directory modificabile"
+  },
+  "directory.go": {
+    "message": "Vai",
+    "description": "Pulsante: naviga al percorso della directory digitato"
+  },
   "directory.loading": {
     "message": "Caricamento…",
     "description": "Directory listing loading hint"

--- a/src/i18n/ja/codingBridge.json
+++ b/src/i18n/ja/codingBridge.json
@@ -327,6 +327,14 @@
     "message": "更新",
     "description": "Button: reload the current directory"
   },
+  "directory.pathPlaceholder": {
+    "message": "Type a path (e.g. D:\\) and press Enter",
+    "description": "Placeholder for the editable directory path input"
+  },
+  "directory.go": {
+    "message": "Go",
+    "description": "Button: navigate to the typed directory path"
+  },
   "directory.loading": {
     "message": "読み込み中…",
     "description": "Directory listing loading hint"

--- a/src/i18n/ja/codingBridge.json
+++ b/src/i18n/ja/codingBridge.json
@@ -327,6 +327,14 @@
     "message": "更新",
     "description": "Button: reload the current directory"
   },
+  "directory.pathPlaceholder": {
+    "message": "パスを入力（例: D:\\）してエンター",
+    "description": "編集可能なディレクトリパス入力のプレースホルダー"
+  },
+  "directory.go": {
+    "message": "移動",
+    "description": "ボタン: 入力したディレクトリパスに移動する"
+  },
   "directory.loading": {
     "message": "読み込み中…",
     "description": "Directory listing loading hint"

--- a/src/i18n/ja/codingBridge.json
+++ b/src/i18n/ja/codingBridge.json
@@ -327,14 +327,6 @@
     "message": "更新",
     "description": "Button: reload the current directory"
   },
-  "directory.pathPlaceholder": {
-    "message": "Type a path (e.g. D:\\) and press Enter",
-    "description": "Placeholder for the editable directory path input"
-  },
-  "directory.go": {
-    "message": "Go",
-    "description": "Button: navigate to the typed directory path"
-  },
   "directory.loading": {
     "message": "読み込み中…",
     "description": "Directory listing loading hint"

--- a/src/i18n/ko/codingBridge.json
+++ b/src/i18n/ko/codingBridge.json
@@ -327,6 +327,14 @@
     "message": "새로 고침",
     "description": "Button: reload the current directory"
   },
+  "directory.pathPlaceholder": {
+    "message": "Type a path (e.g. D:\\) and press Enter",
+    "description": "Placeholder for the editable directory path input"
+  },
+  "directory.go": {
+    "message": "Go",
+    "description": "Button: navigate to the typed directory path"
+  },
   "directory.loading": {
     "message": "불러오는 중…",
     "description": "Directory listing loading hint"

--- a/src/i18n/ko/codingBridge.json
+++ b/src/i18n/ko/codingBridge.json
@@ -327,14 +327,6 @@
     "message": "새로 고침",
     "description": "Button: reload the current directory"
   },
-  "directory.pathPlaceholder": {
-    "message": "Type a path (e.g. D:\\) and press Enter",
-    "description": "Placeholder for the editable directory path input"
-  },
-  "directory.go": {
-    "message": "Go",
-    "description": "Button: navigate to the typed directory path"
-  },
   "directory.loading": {
     "message": "불러오는 중…",
     "description": "Directory listing loading hint"

--- a/src/i18n/ko/codingBridge.json
+++ b/src/i18n/ko/codingBridge.json
@@ -327,6 +327,14 @@
     "message": "새로 고침",
     "description": "Button: reload the current directory"
   },
+  "directory.pathPlaceholder": {
+    "message": "경로 입력 (예: D:\\) 후 엔터",
+    "description": "편집 가능한 디렉토리 경로 입력란의 플레이스홀더입니다."
+  },
+  "directory.go": {
+    "message": "이동",
+    "description": "버튼: 입력한 디렉토리 경로로 이동합니다."
+  },
   "directory.loading": {
     "message": "불러오는 중…",
     "description": "Directory listing loading hint"

--- a/src/i18n/pl/codingBridge.json
+++ b/src/i18n/pl/codingBridge.json
@@ -327,14 +327,6 @@
     "message": "Odśwież",
     "description": "Button: reload the current directory"
   },
-  "directory.pathPlaceholder": {
-    "message": "Type a path (e.g. D:\\) and press Enter",
-    "description": "Placeholder for the editable directory path input"
-  },
-  "directory.go": {
-    "message": "Go",
-    "description": "Button: navigate to the typed directory path"
-  },
   "directory.loading": {
     "message": "Ładowanie…",
     "description": "Directory listing loading hint"

--- a/src/i18n/pl/codingBridge.json
+++ b/src/i18n/pl/codingBridge.json
@@ -327,6 +327,14 @@
     "message": "Odśwież",
     "description": "Button: reload the current directory"
   },
+  "directory.pathPlaceholder": {
+    "message": "Wprowadź ścieżkę (np. D:\\) i naciśnij Enter",
+    "description": "Placeholder dla edytowalnego pola wprowadzania ścieżki katalogu"
+  },
+  "directory.go": {
+    "message": "Przejdź",
+    "description": "Przycisk: przejdź do wpisanej ścieżki katalogu"
+  },
   "directory.loading": {
     "message": "Ładowanie…",
     "description": "Directory listing loading hint"

--- a/src/i18n/pl/codingBridge.json
+++ b/src/i18n/pl/codingBridge.json
@@ -327,6 +327,14 @@
     "message": "Odśwież",
     "description": "Button: reload the current directory"
   },
+  "directory.pathPlaceholder": {
+    "message": "Type a path (e.g. D:\\) and press Enter",
+    "description": "Placeholder for the editable directory path input"
+  },
+  "directory.go": {
+    "message": "Go",
+    "description": "Button: navigate to the typed directory path"
+  },
   "directory.loading": {
     "message": "Ładowanie…",
     "description": "Directory listing loading hint"

--- a/src/i18n/pt/codingBridge.json
+++ b/src/i18n/pt/codingBridge.json
@@ -327,6 +327,14 @@
     "message": "Atualizar",
     "description": "Button: reload the current directory"
   },
+  "directory.pathPlaceholder": {
+    "message": "Digite o caminho (como D:\\) e pressione Enter",
+    "description": "Texto de espaço reservado para o campo de entrada do caminho do diretório editável"
+  },
+  "directory.go": {
+    "message": "Ir",
+    "description": "Botão: navegar para o caminho do diretório digitado"
+  },
   "directory.loading": {
     "message": "A carregar…",
     "description": "Directory listing loading hint"

--- a/src/i18n/pt/codingBridge.json
+++ b/src/i18n/pt/codingBridge.json
@@ -327,6 +327,14 @@
     "message": "Atualizar",
     "description": "Button: reload the current directory"
   },
+  "directory.pathPlaceholder": {
+    "message": "Type a path (e.g. D:\\) and press Enter",
+    "description": "Placeholder for the editable directory path input"
+  },
+  "directory.go": {
+    "message": "Go",
+    "description": "Button: navigate to the typed directory path"
+  },
   "directory.loading": {
     "message": "A carregar…",
     "description": "Directory listing loading hint"

--- a/src/i18n/pt/codingBridge.json
+++ b/src/i18n/pt/codingBridge.json
@@ -327,14 +327,6 @@
     "message": "Atualizar",
     "description": "Button: reload the current directory"
   },
-  "directory.pathPlaceholder": {
-    "message": "Type a path (e.g. D:\\) and press Enter",
-    "description": "Placeholder for the editable directory path input"
-  },
-  "directory.go": {
-    "message": "Go",
-    "description": "Button: navigate to the typed directory path"
-  },
   "directory.loading": {
     "message": "A carregar…",
     "description": "Directory listing loading hint"

--- a/src/i18n/ru/codingBridge.json
+++ b/src/i18n/ru/codingBridge.json
@@ -327,6 +327,14 @@
     "message": "Обновить",
     "description": "Button: reload the current directory"
   },
+  "directory.pathPlaceholder": {
+    "message": "Введите путь (например, D:\\) и нажмите Enter",
+    "description": "Заполнитель для редактируемого ввода пути директории"
+  },
+  "directory.go": {
+    "message": "Перейти",
+    "description": "Кнопка: перейти к введенному пути директории"
+  },
   "directory.loading": {
     "message": "Загрузка…",
     "description": "Directory listing loading hint"

--- a/src/i18n/ru/codingBridge.json
+++ b/src/i18n/ru/codingBridge.json
@@ -327,14 +327,6 @@
     "message": "Обновить",
     "description": "Button: reload the current directory"
   },
-  "directory.pathPlaceholder": {
-    "message": "Type a path (e.g. D:\\) and press Enter",
-    "description": "Placeholder for the editable directory path input"
-  },
-  "directory.go": {
-    "message": "Go",
-    "description": "Button: navigate to the typed directory path"
-  },
   "directory.loading": {
     "message": "Загрузка…",
     "description": "Directory listing loading hint"

--- a/src/i18n/ru/codingBridge.json
+++ b/src/i18n/ru/codingBridge.json
@@ -327,6 +327,14 @@
     "message": "Обновить",
     "description": "Button: reload the current directory"
   },
+  "directory.pathPlaceholder": {
+    "message": "Type a path (e.g. D:\\) and press Enter",
+    "description": "Placeholder for the editable directory path input"
+  },
+  "directory.go": {
+    "message": "Go",
+    "description": "Button: navigate to the typed directory path"
+  },
   "directory.loading": {
     "message": "Загрузка…",
     "description": "Directory listing loading hint"

--- a/src/i18n/sr/codingBridge.json
+++ b/src/i18n/sr/codingBridge.json
@@ -327,6 +327,14 @@
     "message": "Освежи",
     "description": "Button: reload the current directory"
   },
+  "directory.pathPlaceholder": {
+    "message": "Унесите путању (нпр. D:\\) и притисните Enter",
+    "description": "placeholder за unos putanje direktorijuma"
+  },
+  "directory.go": {
+    "message": "Иди",
+    "description": " dugme: navigiraj do unete putanje direktorijuma"
+  },
   "directory.loading": {
     "message": "Учитавање…",
     "description": "Directory listing loading hint"

--- a/src/i18n/sr/codingBridge.json
+++ b/src/i18n/sr/codingBridge.json
@@ -327,6 +327,14 @@
     "message": "Освежи",
     "description": "Button: reload the current directory"
   },
+  "directory.pathPlaceholder": {
+    "message": "Type a path (e.g. D:\\) and press Enter",
+    "description": "Placeholder for the editable directory path input"
+  },
+  "directory.go": {
+    "message": "Go",
+    "description": "Button: navigate to the typed directory path"
+  },
   "directory.loading": {
     "message": "Учитавање…",
     "description": "Directory listing loading hint"

--- a/src/i18n/sr/codingBridge.json
+++ b/src/i18n/sr/codingBridge.json
@@ -327,14 +327,6 @@
     "message": "Освежи",
     "description": "Button: reload the current directory"
   },
-  "directory.pathPlaceholder": {
-    "message": "Type a path (e.g. D:\\) and press Enter",
-    "description": "Placeholder for the editable directory path input"
-  },
-  "directory.go": {
-    "message": "Go",
-    "description": "Button: navigate to the typed directory path"
-  },
   "directory.loading": {
     "message": "Учитавање…",
     "description": "Directory listing loading hint"

--- a/src/i18n/sv/codingBridge.json
+++ b/src/i18n/sv/codingBridge.json
@@ -327,6 +327,14 @@
     "message": "Uppdatera",
     "description": "Button: reload the current directory"
   },
+  "directory.pathPlaceholder": {
+    "message": "Type a path (e.g. D:\\) and press Enter",
+    "description": "Placeholder for the editable directory path input"
+  },
+  "directory.go": {
+    "message": "Go",
+    "description": "Button: navigate to the typed directory path"
+  },
   "directory.loading": {
     "message": "Läser in…",
     "description": "Directory listing loading hint"

--- a/src/i18n/sv/codingBridge.json
+++ b/src/i18n/sv/codingBridge.json
@@ -327,6 +327,14 @@
     "message": "Uppdatera",
     "description": "Button: reload the current directory"
   },
+  "directory.pathPlaceholder": {
+    "message": "Skriv in sökväg (t.ex. D:\\) och tryck på Enter",
+    "description": "Platshållare för den redigerbara katalogvägsinmatningen"
+  },
+  "directory.go": {
+    "message": "Gå",
+    "description": "Knapp: navigera till den angivna katalogvägen"
+  },
   "directory.loading": {
     "message": "Läser in…",
     "description": "Directory listing loading hint"

--- a/src/i18n/sv/codingBridge.json
+++ b/src/i18n/sv/codingBridge.json
@@ -327,14 +327,6 @@
     "message": "Uppdatera",
     "description": "Button: reload the current directory"
   },
-  "directory.pathPlaceholder": {
-    "message": "Type a path (e.g. D:\\) and press Enter",
-    "description": "Placeholder for the editable directory path input"
-  },
-  "directory.go": {
-    "message": "Go",
-    "description": "Button: navigate to the typed directory path"
-  },
   "directory.loading": {
     "message": "Läser in…",
     "description": "Directory listing loading hint"

--- a/src/i18n/uk/codingBridge.json
+++ b/src/i18n/uk/codingBridge.json
@@ -327,6 +327,14 @@
     "message": "Оновити",
     "description": "Button: reload the current directory"
   },
+  "directory.pathPlaceholder": {
+    "message": "Type a path (e.g. D:\\) and press Enter",
+    "description": "Placeholder for the editable directory path input"
+  },
+  "directory.go": {
+    "message": "Go",
+    "description": "Button: navigate to the typed directory path"
+  },
   "directory.loading": {
     "message": "Завантаження…",
     "description": "Directory listing loading hint"

--- a/src/i18n/uk/codingBridge.json
+++ b/src/i18n/uk/codingBridge.json
@@ -327,14 +327,6 @@
     "message": "Оновити",
     "description": "Button: reload the current directory"
   },
-  "directory.pathPlaceholder": {
-    "message": "Type a path (e.g. D:\\) and press Enter",
-    "description": "Placeholder for the editable directory path input"
-  },
-  "directory.go": {
-    "message": "Go",
-    "description": "Button: navigate to the typed directory path"
-  },
   "directory.loading": {
     "message": "Завантаження…",
     "description": "Directory listing loading hint"

--- a/src/i18n/uk/codingBridge.json
+++ b/src/i18n/uk/codingBridge.json
@@ -327,6 +327,14 @@
     "message": "Оновити",
     "description": "Button: reload the current directory"
   },
+  "directory.pathPlaceholder": {
+    "message": "Введіть шлях (наприклад, D:\\) і натисніть Enter",
+    "description": "Заповнювач для поля введення редагованого шляху каталогу"
+  },
+  "directory.go": {
+    "message": "Перейти",
+    "description": "Кнопка: перейти до введеного шляху каталогу"
+  },
   "directory.loading": {
     "message": "Завантаження…",
     "description": "Directory listing loading hint"

--- a/src/i18n/zh-CN/codingBridge.json
+++ b/src/i18n/zh-CN/codingBridge.json
@@ -327,6 +327,14 @@
     "message": "刷新",
     "description": "Button: reload the current directory"
   },
+  "directory.pathPlaceholder": {
+    "message": "输入路径（如 D:\\）后回车",
+    "description": "Placeholder for the editable directory path input"
+  },
+  "directory.go": {
+    "message": "跳转",
+    "description": "Button: navigate to the typed directory path"
+  },
   "directory.loading": {
     "message": "正在加载…",
     "description": "Directory listing loading hint"

--- a/src/i18n/zh-TW/codingBridge.json
+++ b/src/i18n/zh-TW/codingBridge.json
@@ -327,6 +327,14 @@
     "message": "重新整理",
     "description": "Button: reload the current directory"
   },
+  "directory.pathPlaceholder": {
+    "message": "輸入路徑（如 D:\\）後按 Enter",
+    "description": "Placeholder for the editable directory path input"
+  },
+  "directory.go": {
+    "message": "跳轉",
+    "description": "Button: navigate to the typed directory path"
+  },
   "directory.loading": {
     "message": "正在載入…",
     "description": "Directory listing loading hint"

--- a/src/i18n/zh-TW/codingBridge.json
+++ b/src/i18n/zh-TW/codingBridge.json
@@ -327,6 +327,14 @@
     "message": "重新整理",
     "description": "Button: reload the current directory"
   },
+  "directory.pathPlaceholder": {
+    "message": "輸入路徑（如 D:\\）後回車",
+    "description": "可編輯目錄路徑輸入框的佔位符"
+  },
+  "directory.go": {
+    "message": "跳轉",
+    "description": "按鈕：導航到輸入的目錄路徑"
+  },
   "directory.loading": {
     "message": "正在載入…",
     "description": "Directory listing loading hint"

--- a/src/i18n/zh-TW/codingBridge.json
+++ b/src/i18n/zh-TW/codingBridge.json
@@ -327,14 +327,6 @@
     "message": "重新整理",
     "description": "Button: reload the current directory"
   },
-  "directory.pathPlaceholder": {
-    "message": "輸入路徑（如 D:\\）後按 Enter",
-    "description": "Placeholder for the editable directory path input"
-  },
-  "directory.go": {
-    "message": "跳轉",
-    "description": "Button: navigate to the typed directory path"
-  },
   "directory.loading": {
     "message": "正在載入…",
     "description": "Directory listing loading hint"

--- a/src/layouts/Webextrator.vue
+++ b/src/layouts/Webextrator.vue
@@ -53,7 +53,7 @@ export default defineComponent({
     display: block;
     position: absolute;
     right: 8px;
-    top: 45px;
+    top: calc(45px + var(--app-safe-area-top));
     z-index: 1000;
   }
 }


### PR DESCRIPTION
## Problem

On phones, content in the service **config drawers** drew *under* the iOS Dynamic Island / Android status bar. In the reported screenshot the Kling **Video Generation / Motion Control / Talking Photo** tabs sit right behind the clock & battery, with no breathing room.

This isn't a one-off — it affects **every** service config drawer (Kling, Seedance, Luma, Hailuo, Flux, Pika, Pixverse, Midjourney, Nanobanana, OpenAIImage, Seedream, Producer, Qrart, Veo, Wan, Sora, Suno, Headshots, Serp, Webextrator, codingBridge), the **chat side panel**, and the inspiration / history / voice-manager sheets — matching the "很多地方都这样" report.

## Root cause

These panels are all `el-drawer`s teleported to `<body>`. Routed pages clear the status bar because `Main.vue` / `Console.vue` put `padding-top: var(--app-safe-area-top)` on their layout wrapper — but a teleported drawer is `position: fixed` and lives outside that wrapper, so it never gets the inset. The floating balance pill (`Main.vue .status-floating`) already accounts for the safe area, which is why it sits correctly below the status bar while the drawer tabs do not.

## Fix

- **`_common.scss`** — one global rule: on mobile (`max-width: 767px`), pad every drawer panel by the safe area.
  - Full-height side drawers (`ltr` / `rtl`) clear both the top status bar (`safe-area-top + 8px`, the same comfortable gap the balance pill uses) and the bottom home indicator (`safe-area-bottom`).
  - Top/bottom sheets (`ttb` / `btt`) clear the edge they touch.
  - `--app-safe-area-*` resolves to `0px` on non-notched devices, so this is a no-op there and on desktop. Padding the *panel* (not the body) covers both headerless config drawers and drawers that render an `.el-drawer__header`.
- **`Webextrator.vue`** — its floating menu button used a bare `top: 45px`; aligned it with every other layout's `top: calc(45px + var(--app-safe-area-top))`.

## Verification

- `vite build` passes (SCSS compiles; only pre-existing third-party annotation warnings).
- Lint-staged (eslint + prettier) ran clean on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)