### PR TITLE
fix(ios): stop login white screen — ATS blocks /auth/login http-downgrade 301

### DIFF
--- a/change/@acedatacloud-nexior-ios-auth-login-ats.json
+++ b/change/@acedatacloud-nexior-ios-auth-login-ats.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(ios): request canonical /auth/login/ so the native login iframe stops white-screening (ATS blocks the http downgrade 301)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/AuthPanel.vue
+++ b/src/components/common/AuthPanel.vue
@@ -66,7 +66,9 @@ export default defineComponent({
       return isNativeSurface();
     },
     iframeUrl() {
-      let url = `${getBaseUrlAuth()}/auth/login?inviter_id=${this.inviterId}`;
+      // Trailing slash matters: `/auth/login` 301s to a cleartext `http://`
+      // URL that iOS ATS blocks, leaving this iframe blank (white screen).
+      let url = `${getBaseUrlAuth()}/auth/login/?inviter_id=${this.inviterId}`;
       if (this.isNative) {
         url += '&native_redirect=com.acedatacloud.nexior';
       }
@@ -181,7 +183,7 @@ export default defineComponent({
         // Open the auth page in an in-app browser with the provider pre-selected.
         this.useBrowser = true;
         const authUrl = withCurrentSite(
-          `${getBaseUrlAuth()}/auth/login?inviter_id=${this.inviterId}&native_redirect=com.acedatacloud.nexior&provider=${provider}`
+          `${getBaseUrlAuth()}/auth/login/?inviter_id=${this.inviterId}&native_redirect=com.acedatacloud.nexior&provider=${provider}`
         );
         Browser.open({ url: authUrl });
         return;

--- a/src/store/common/actions.ts
+++ b/src/store/common/actions.ts
@@ -277,7 +277,7 @@ export const logout = async ({ dispatch, commit }: ActionContext<IRootState, IRo
       ...(inviterId ? { inviter_id: inviterId } : {}),
       redirect: callbackUrl
     };
-    const loginUrl = `${baseUrlAuth}/auth/login?${new URLSearchParams(loginQuery).toString()}`;
+    const loginUrl = `${baseUrlAuth}/auth/login/?${new URLSearchParams(loginQuery).toString()}`;
     const redirectUrl = `${baseUrlAuth}/auth/logout?${new URLSearchParams({ redirect: loginUrl }).toString()}`;
     window.location.href = redirectUrl;
   }

--- a/src/utils/login.ts
+++ b/src/utils/login.ts
@@ -28,7 +28,10 @@ export const loginRedirect = ({
   // callback url used to init access token and then redirect back of `redirect`
   const callbackUrl = `${hubBaseUrl}/auth/callback?redirect=${redirect}`;
   // redirect to auth service to get access token then redirect back
-  const targetBaseUrl = `${authBaseUrl}/auth/login`;
+  // Trailing slash is required: `/auth/login` 301-redirects to a cleartext
+  // `http://.../auth/login/`, which iOS ATS blocks (white screen in the native
+  // login iframe). The canonical `/auth/login/` returns 200 directly.
+  const targetBaseUrl = `${authBaseUrl}/auth/login/`;
   const targetQuery = {
     site,
     ...(inviterId ? { inviter_id: inviterId } : {}),


### PR DESCRIPTION
## Problem

The Nexior iOS app **white-screens on launch** for any logged-out user.

## Root cause

On native, `AuthPanel` gates the whole app behind a full-screen login `<iframe>` whose `src` was `\${authBase}/auth/login` (no trailing slash). The auth server responds:

```
GET https://auth.acedata.cloud/auth/login   → 301
     Location: http://auth.acedata.cloud/auth/login/      ← scheme downgraded to cleartext http
                                              → 200
```

iOS **App Transport Security** blocks the cleartext `http://` subframe load (`NSURLError -1022`), so the login iframe never loads and the white `.auth-native` container (z-index 9999, `inset:0`) covers the screen. Desktop/mobile web hide this because the browser silently upgrades the `http` hop via HSTS — **WKWebView does not**.

Confirmed live in the iOS Simulator: WebKit logged `didFailProvisionalLoadForFrame … code=-1022` on the auth subframe, and `curl` reproduces the downgrade. The canonical `/auth/login/` (with trailing slash) returns **200 directly** — no redirect.

## Fix

Request `/auth/login/` at every call site so no scheme-downgrading 301 occurs:

- `src/components/common/AuthPanel.vue` — native login iframe + native OAuth in-app-browser URL (the actual white-screen path)
- `src/utils/login.ts` — web `loginRedirect`
- `src/store/common/actions.ts` — web re-login redirect

`/auth/logout` is unaffected (already returns 200 without a slash) and is left as-is.

## Verification

Built `VITE_SURFACE=ios`, ran in the iOS 26.1 Simulator. **Before:** blank white screen. **After:** the email/password + OAuth login form renders, and the `-1022` failure is gone from the WebKit log.

> Note: the underlying auth-server 301 that downgrades https→http is itself a server-side misconfig (redirect not honoring `X-Forwarded-Proto`). Worth fixing in AuthFrontend/ingress separately, but this client-side canonical-URL change fixes the user-facing crash now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)