### PR TITLE
feat(iap): Apple In-App Purchase for credits on iOS

### DIFF
--- a/change/@acedatacloud-nexior-5f7c2d12-3dfb-4b01-9350-d4bed8e3d305.json
+++ b/change/@acedatacloud-nexior-5f7c2d12-3dfb-4b01-9350-d4bed8e3d305.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: Apple In-App Purchase for credits on iOS",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "chart.js": "^4.5.1",
         "codemirror": "^6.0.1",
         "copy-to-clipboard": "^4.0.2",
+        "cordova-plugin-purchase": "^13.11.0",
         "dayjs": "^1.11.21",
         "element-plus": "2.10.4",
         "file-saver": "^2.0.5",
@@ -7968,6 +7969,12 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-4.0.2.tgz",
       "integrity": "sha512-gklSft7IuhriZKHKpuoA1fpJSLPNgvUMWMo5BlnzAJm0zNKnznoSv23IjtNqclx8eKi6ZcdvFFzYEER/+U1LoQ==",
+      "license": "MIT"
+    },
+    "node_modules/cordova-plugin-purchase": {
+      "version": "13.17.2",
+      "resolved": "https://registry.npmjs.org/cordova-plugin-purchase/-/cordova-plugin-purchase-13.17.2.tgz",
+      "integrity": "sha512-5PWpF5CGnqdYjH4x2ULVj5fUA304Ftl/UF1wEc4+HOJmAtJeIVb9/UlnckVhAyhQDT7MIk6+YNGSctJeqZGsFQ==",
       "license": "MIT"
     },
     "node_modules/core-js": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "chart.js": "^4.5.1",
     "codemirror": "^6.0.1",
     "copy-to-clipboard": "^4.0.2",
+    "cordova-plugin-purchase": "^13.11.0",
     "dayjs": "^1.11.21",
     "element-plus": "2.10.4",
     "file-saver": "^2.0.5",

--- a/src/components/order/ApplePay.vue
+++ b/src/components/order/ApplePay.vue
@@ -1,0 +1,118 @@
+<template>
+  <el-dialog :model-value="visible" :title="$t('application.title.buyService')" width="500px" center>
+    <p class="text-center">
+      {{ statusText }}
+    </p>
+  </el-dialog>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElDialog, ElMessage } from 'element-plus';
+import { orderOperator } from '@/operators';
+import { IOrder, IOrderDetailResponse, OrderState } from '@/models';
+import { purchaseAndVerify } from '@/utils';
+
+interface IData {
+  refreshTimer: number | undefined;
+  launched: boolean;
+  statusText: string;
+}
+
+export default defineComponent({
+  name: 'ApplePayOrderDialog',
+  components: {
+    ElDialog
+  },
+  props: {
+    modelValue: {
+      type: Object as () => IOrder,
+      required: true
+    },
+    visible: {
+      type: Boolean,
+      required: false,
+      default: false
+    }
+  },
+  emits: ['hide', 'update:modelValue'],
+  data(): IData {
+    return {
+      refreshTimer: undefined,
+      launched: false,
+      statusText: this.$t('order.message.applePayProcessing')
+    };
+  },
+  computed: {
+    // Apple consumable product id mapped to the order's package via
+    // package.metadata.apple_product_id (embedded by the backend).
+    productId(): string | undefined {
+      return (
+        (this.modelValue?.package?.metadata?.apple_product_id as string | undefined) ||
+        (this.modelValue?.packages?.[0]?.metadata?.apple_product_id as string | undefined)
+      );
+    }
+  },
+  watch: {
+    visible: {
+      handler(val) {
+        if (!val) {
+          this.launched = false;
+          return;
+        }
+        this.startPurchase();
+      }
+    }
+  },
+  unmounted() {
+    if (this.refreshTimer) {
+      clearTimeout(this.refreshTimer);
+    }
+  },
+  methods: {
+    async startPurchase() {
+      if (this.launched) return;
+      this.launched = true;
+      if (!this.modelValue.id) {
+        return;
+      }
+      if (!this.productId) {
+        ElMessage.error(this.$t('order.message.applePayUnavailable'));
+        this.$emit('hide');
+        return;
+      }
+      this.statusText = this.$t('order.message.applePayProcessing');
+      const result = await purchaseAndVerify(this.modelValue.id, this.productId);
+      if (result.cancelled) {
+        this.$emit('hide');
+        return;
+      }
+      if (!result.ok) {
+        ElMessage.error(this.$t('order.message.applePayFailed'));
+        this.$emit('hide');
+        return;
+      }
+      // Verified server-side; poll once to pick up the FINISHED state + balance.
+      this.onRefresh();
+    },
+    onRefresh() {
+      if (!this.modelValue.id) {
+        return;
+      }
+      orderOperator
+        .refresh(this.modelValue.id)
+        .then(({ data }: { data: IOrderDetailResponse }) => {
+          this.$emit('update:modelValue', data);
+          if (data.state !== OrderState.PAID && data.state !== OrderState.FINISHED) {
+            this.refreshTimer = window.setTimeout(() => this.onRefresh(), 2000);
+          } else {
+            this.$emit('hide');
+          }
+        })
+        .catch(() => {
+          this.refreshTimer = window.setTimeout(() => this.onRefresh(), 5000);
+        });
+    }
+  }
+});
+</script>

--- a/src/i18n/ar/order.json
+++ b/src/i18n/ar/order.json
@@ -99,6 +99,18 @@
     "message": "يرجى إكمال الدفع في الرابط الخارجي",
     "description": "رسالة للدفع عبر رابط خارجي."
   },
+  "message.applePayProcessing": {
+    "message": "جارٍ إتمام عملية الشراء عبر App Store…",
+    "description": "Message while the Apple in-app purchase is processing."
+  },
+  "message.applePayFailed": {
+    "message": "لم تكتمل عملية الدفع في App Store. حاول مرة أخرى.",
+    "description": "Message when the Apple in-app purchase fails."
+  },
+  "message.applePayUnavailable": {
+    "message": "لا يمكن شراء هذه الباقة داخل التطبيق.",
+    "description": "Message when Apple in-app purchase is unavailable for the package."
+  },
   "message.updateFailed": {
     "message": "فشل التحديث",
     "description": "رسالة تفيد بفشل التحديث."

--- a/src/i18n/de/order.json
+++ b/src/i18n/de/order.json
@@ -99,6 +99,18 @@
     "message": "Bitte schließen Sie die Zahlung über den externen Link ab.",
     "description": "Nachricht über die Zahlung über einen externen Link."
   },
+  "message.applePayProcessing": {
+    "message": "Kauf wird über den App Store abgeschlossen…",
+    "description": "Message while the Apple in-app purchase is processing."
+  },
+  "message.applePayFailed": {
+    "message": "App-Store-Zahlung nicht abgeschlossen. Bitte erneut versuchen.",
+    "description": "Message when the Apple in-app purchase fails."
+  },
+  "message.applePayUnavailable": {
+    "message": "Dieses Paket kann nicht in der App gekauft werden.",
+    "description": "Message when Apple in-app purchase is unavailable for the package."
+  },
   "message.updateFailed": {
     "message": "Aktualisierung fehlgeschlagen",
     "description": "Nachricht über eine fehlgeschlagene Aktualisierung."

--- a/src/i18n/el/order.json
+++ b/src/i18n/el/order.json
@@ -99,6 +99,18 @@
     "message": "Παρακαλώ ολοκληρώστε την πληρωμή μέσω εξωτερικού συνδέσμου.",
     "description": "Μήνυμα για πληρωμή μέσω εξωτερικού συνδέσμου."
   },
+  "message.applePayProcessing": {
+    "message": "Ολοκλήρωση της αγοράς μέσω App Store…",
+    "description": "Message while the Apple in-app purchase is processing."
+  },
+  "message.applePayFailed": {
+    "message": "Η πληρωμή στο App Store δεν ολοκληρώθηκε. Δοκιμάστε ξανά.",
+    "description": "Message when the Apple in-app purchase fails."
+  },
+  "message.applePayUnavailable": {
+    "message": "Αυτό το πακέτο δεν μπορεί να αγοραστεί εντός της εφαρμογής.",
+    "description": "Message when Apple in-app purchase is unavailable for the package."
+  },
   "message.updateFailed": {
     "message": "Αποτυχία Ενημέρωσης",
     "description": "Μήνυμα αποτυχίας ενημέρωσης."

--- a/src/i18n/en/order.json
+++ b/src/i18n/en/order.json
@@ -99,6 +99,18 @@
     "message": "Please complete the payment in the external link.",
     "description": "Message for external link payment."
   },
+  "message.applePayProcessing": {
+    "message": "Completing your purchase through the App Store…",
+    "description": "Message while the Apple in-app purchase is processing."
+  },
+  "message.applePayFailed": {
+    "message": "App Store payment didn't complete. Please try again.",
+    "description": "Message when the Apple in-app purchase fails."
+  },
+  "message.applePayUnavailable": {
+    "message": "This package can't be purchased inside the app.",
+    "description": "Message when Apple in-app purchase is unavailable for the package."
+  },
   "message.updateFailed": {
     "message": "Update Failed",
     "description": "Message indicating update failure."

--- a/src/i18n/es/order.json
+++ b/src/i18n/es/order.json
@@ -99,6 +99,18 @@
     "message": "Por favor, completa el pago en el enlace externo.",
     "description": "Mensaje para pagos a través de enlaces externos."
   },
+  "message.applePayProcessing": {
+    "message": "Completando tu compra a través de la App Store…",
+    "description": "Message while the Apple in-app purchase is processing."
+  },
+  "message.applePayFailed": {
+    "message": "El pago en la App Store no se completó. Inténtalo de nuevo.",
+    "description": "Message when the Apple in-app purchase fails."
+  },
+  "message.applePayUnavailable": {
+    "message": "Este paquete no se puede comprar dentro de la app.",
+    "description": "Message when Apple in-app purchase is unavailable for the package."
+  },
   "message.updateFailed": {
     "message": "Actualización fallida",
     "description": "Mensaje de actualización fallida."

--- a/src/i18n/fi/order.json
+++ b/src/i18n/fi/order.json
@@ -99,6 +99,18 @@
     "message": "Suorita maksu ulkoisessa linkissä",
     "description": "Ulkoisen linkin maksamisen viesti."
   },
+  "message.applePayProcessing": {
+    "message": "Viimeistellään ostoa App Storessa…",
+    "description": "Message while the Apple in-app purchase is processing."
+  },
+  "message.applePayFailed": {
+    "message": "App Store -maksu ei valmistunut. Yritä uudelleen.",
+    "description": "Message when the Apple in-app purchase fails."
+  },
+  "message.applePayUnavailable": {
+    "message": "Tätä pakettia ei voi ostaa sovelluksessa.",
+    "description": "Message when Apple in-app purchase is unavailable for the package."
+  },
   "message.updateFailed": {
     "message": "Päivitys epäonnistui",
     "description": "Päivityksen epäonnistumisen viesti."

--- a/src/i18n/fr/order.json
+++ b/src/i18n/fr/order.json
@@ -99,6 +99,18 @@
     "message": "Veuillez terminer le paiement via le lien externe",
     "description": "Message pour le paiement via un lien externe."
   },
+  "message.applePayProcessing": {
+    "message": "Finalisation de votre achat via l’App Store…",
+    "description": "Message while the Apple in-app purchase is processing."
+  },
+  "message.applePayFailed": {
+    "message": "Le paiement App Store n’a pas abouti. Veuillez réessayer.",
+    "description": "Message when the Apple in-app purchase fails."
+  },
+  "message.applePayUnavailable": {
+    "message": "Ce forfait ne peut pas être acheté dans l’application.",
+    "description": "Message when Apple in-app purchase is unavailable for the package."
+  },
   "message.updateFailed": {
     "message": "Échec de la mise à jour",
     "description": "Message indiquant que la mise à jour a échoué."

--- a/src/i18n/it/order.json
+++ b/src/i18n/it/order.json
@@ -99,6 +99,18 @@
     "message": "Completa il pagamento nel link esterno",
     "description": "Messaggio per pagamento tramite link esterno."
   },
+  "message.applePayProcessing": {
+    "message": "Completamento dell’acquisto tramite l’App Store…",
+    "description": "Message while the Apple in-app purchase is processing."
+  },
+  "message.applePayFailed": {
+    "message": "Pagamento App Store non completato. Riprova.",
+    "description": "Message when the Apple in-app purchase fails."
+  },
+  "message.applePayUnavailable": {
+    "message": "Questo pacchetto non può essere acquistato nell’app.",
+    "description": "Message when Apple in-app purchase is unavailable for the package."
+  },
   "message.updateFailed": {
     "message": "Aggiornamento fallito",
     "description": "Messaggio di aggiornamento fallito."

--- a/src/i18n/ja/order.json
+++ b/src/i18n/ja/order.json
@@ -99,6 +99,18 @@
     "message": "外部リンクで支払いを完了してください。",
     "description": "外部リンクでの支払いに関するメッセージです。"
   },
+  "message.applePayProcessing": {
+    "message": "App Store で購入を完了しています…",
+    "description": "Message while the Apple in-app purchase is processing."
+  },
+  "message.applePayFailed": {
+    "message": "App Store の支払いが完了しませんでした。もう一度お試しください。",
+    "description": "Message when the Apple in-app purchase fails."
+  },
+  "message.applePayUnavailable": {
+    "message": "このパッケージはアプリ内で購入できません。",
+    "description": "Message when Apple in-app purchase is unavailable for the package."
+  },
   "message.updateFailed": {
     "message": "更新失敗",
     "description": "更新失敗のメッセージです。"

--- a/src/i18n/ko/order.json
+++ b/src/i18n/ko/order.json
@@ -99,6 +99,18 @@
     "message": "외부 링크에서 결제를 완료하세요.",
     "description": "외부 링크 결제에 대한 메시지입니다."
   },
+  "message.applePayProcessing": {
+    "message": "App Store에서 결제를 완료하는 중…",
+    "description": "Message while the Apple in-app purchase is processing."
+  },
+  "message.applePayFailed": {
+    "message": "App Store 결제가 완료되지 않았습니다. 다시 시도해 주세요.",
+    "description": "Message when the Apple in-app purchase fails."
+  },
+  "message.applePayUnavailable": {
+    "message": "이 패키지는 앱 내에서 구매할 수 없습니다.",
+    "description": "Message when Apple in-app purchase is unavailable for the package."
+  },
   "message.updateFailed": {
     "message": "업데이트 실패",
     "description": "업데이트 실패에 대한 메시지입니다."

--- a/src/i18n/pl/order.json
+++ b/src/i18n/pl/order.json
@@ -99,6 +99,18 @@
     "message": "Proszę zakończyć płatność w zewnętrznym linku",
     "description": "Wiadomość o płatności w zewnętrznym linku."
   },
+  "message.applePayProcessing": {
+    "message": "Finalizowanie zakupu przez App Store…",
+    "description": "Message while the Apple in-app purchase is processing."
+  },
+  "message.applePayFailed": {
+    "message": "Płatność w App Store nie została ukończona. Spróbuj ponownie.",
+    "description": "Message when the Apple in-app purchase fails."
+  },
+  "message.applePayUnavailable": {
+    "message": "Tego pakietu nie można kupić w aplikacji.",
+    "description": "Message when Apple in-app purchase is unavailable for the package."
+  },
   "message.updateFailed": {
     "message": "Aktualizacja nie powiodła się",
     "description": "Wiadomość o nieudanej aktualizacji."

--- a/src/i18n/pt/order.json
+++ b/src/i18n/pt/order.json
@@ -99,6 +99,18 @@
     "message": "Conclua o pagamento no link externo.",
     "description": "Mensagem para pagamento via link externo."
   },
+  "message.applePayProcessing": {
+    "message": "A concluir a sua compra através da App Store…",
+    "description": "Message while the Apple in-app purchase is processing."
+  },
+  "message.applePayFailed": {
+    "message": "O pagamento na App Store não foi concluído. Tente novamente.",
+    "description": "Message when the Apple in-app purchase fails."
+  },
+  "message.applePayUnavailable": {
+    "message": "Este pacote não pode ser comprado dentro da app.",
+    "description": "Message when Apple in-app purchase is unavailable for the package."
+  },
   "message.updateFailed": {
     "message": "Falha na Atualização",
     "description": "Mensagem de falha na atualização."

--- a/src/i18n/ru/order.json
+++ b/src/i18n/ru/order.json
@@ -99,6 +99,18 @@
     "message": "Пожалуйста, завершите оплату по внешней ссылке",
     "description": "Сообщение о платеже по внешней ссылке."
   },
+  "message.applePayProcessing": {
+    "message": "Завершаем покупку через App Store…",
+    "description": "Message while the Apple in-app purchase is processing."
+  },
+  "message.applePayFailed": {
+    "message": "Платёж в App Store не завершён. Попробуйте ещё раз.",
+    "description": "Message when the Apple in-app purchase fails."
+  },
+  "message.applePayUnavailable": {
+    "message": "Этот пакет нельзя купить внутри приложения.",
+    "description": "Message when Apple in-app purchase is unavailable for the package."
+  },
   "message.updateFailed": {
     "message": "Ошибка обновления",
     "description": "Сообщение об ошибке обновления."

--- a/src/i18n/sr/order.json
+++ b/src/i18n/sr/order.json
@@ -99,6 +99,18 @@
     "message": "Molimo završite plaćanje putem spoljnog linka",
     "description": "Poruka o plaćanju putem spoljnog linka."
   },
+  "message.applePayProcessing": {
+    "message": "Завршавање куповине преко App Store-а…",
+    "description": "Message while the Apple in-app purchase is processing."
+  },
+  "message.applePayFailed": {
+    "message": "Плаћање у App Store-у није завршено. Покушајте поново.",
+    "description": "Message when the Apple in-app purchase fails."
+  },
+  "message.applePayUnavailable": {
+    "message": "Овај пакет не може да се купи унутар апликације.",
+    "description": "Message when Apple in-app purchase is unavailable for the package."
+  },
   "message.updateFailed": {
     "message": "Ažuriranje nije uspelo",
     "description": "Poruka o neuspešnom ažuriranju."

--- a/src/i18n/sv/order.json
+++ b/src/i18n/sv/order.json
@@ -99,6 +99,18 @@
     "message": "Vänligen slutför betalningen via den externa länken",
     "description": "Meddelande om betalning via extern länk."
   },
+  "message.applePayProcessing": {
+    "message": "Slutför ditt köp via App Store…",
+    "description": "Message while the Apple in-app purchase is processing."
+  },
+  "message.applePayFailed": {
+    "message": "App Store-betalningen slutfördes inte. Försök igen.",
+    "description": "Message when the Apple in-app purchase fails."
+  },
+  "message.applePayUnavailable": {
+    "message": "Det här paketet kan inte köpas i appen.",
+    "description": "Message when Apple in-app purchase is unavailable for the package."
+  },
   "message.updateFailed": {
     "message": "Uppdatering misslyckades",
     "description": "Meddelande om att uppdateringen misslyckades."

--- a/src/i18n/uk/order.json
+++ b/src/i18n/uk/order.json
@@ -99,6 +99,18 @@
     "message": "Будь ласка, завершіть оплату за зовнішнім посиланням",
     "description": "Повідомлення про оплату за зовнішнім посиланням."
   },
+  "message.applePayProcessing": {
+    "message": "Завершуємо покупку через App Store…",
+    "description": "Message while the Apple in-app purchase is processing."
+  },
+  "message.applePayFailed": {
+    "message": "Платіж у App Store не завершено. Спробуйте ще раз.",
+    "description": "Message when the Apple in-app purchase fails."
+  },
+  "message.applePayUnavailable": {
+    "message": "Цей пакет не можна придбати в застосунку.",
+    "description": "Message when Apple in-app purchase is unavailable for the package."
+  },
   "message.updateFailed": {
     "message": "Не вдалося оновити",
     "description": "Повідомлення про невдале оновлення."

--- a/src/i18n/zh-CN/order.json
+++ b/src/i18n/zh-CN/order.json
@@ -99,6 +99,18 @@
     "message": "请在外部链接中完成支付",
     "description": "外部链接支付的消息。"
   },
+  "message.applePayProcessing": {
+    "message": "正在通过 App Store 完成支付…",
+    "description": "Apple 内购处理中的消息。"
+  },
+  "message.applePayFailed": {
+    "message": "App Store 支付未完成，请重试",
+    "description": "Apple 内购失败的消息。"
+  },
+  "message.applePayUnavailable": {
+    "message": "该套餐暂不支持在 App 内购买",
+    "description": "Apple 内购不可用的消息。"
+  },
   "message.updateFailed": {
     "message": "更新失败",
     "description": "更新失败的消息。"

--- a/src/i18n/zh-TW/order.json
+++ b/src/i18n/zh-TW/order.json
@@ -99,6 +99,18 @@
     "message": "請在外部鏈接中完成支付",
     "description": "外部鏈接支付的消息。"
   },
+  "message.applePayProcessing": {
+    "message": "正在透過 App Store 完成付款…",
+    "description": "Message while the Apple in-app purchase is processing."
+  },
+  "message.applePayFailed": {
+    "message": "App Store 付款未完成，請重試",
+    "description": "Message when the Apple in-app purchase fails."
+  },
+  "message.applePayUnavailable": {
+    "message": "此方案暫不支援在 App 內購買",
+    "description": "Message when Apple in-app purchase is unavailable for the package."
+  },
   "message.updateFailed": {
     "message": "更新失敗",
     "description": "更新失敗的消息。"

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -57,6 +57,7 @@ export interface IPackage {
   duration?: number;
   type?: IPackageType;
   service?: IService;
+  metadata?: Record<string, any>;
 }
 
 export enum IApiUnit {

--- a/src/models/order.ts
+++ b/src/models/order.ts
@@ -1,4 +1,5 @@
 import { IApplication } from './application';
+import { IPackage } from './api';
 
 export enum OrderState {
   PENDING = 'Pending',
@@ -30,6 +31,8 @@ export interface IOrder {
   application_ids?: string[];
   package_id?: string;
   package_ids?: string[];
+  package?: IPackage;
+  packages?: IPackage[];
   wechatpay_url?: string;
   pay_id?: string;
   pay_url?: string;

--- a/src/operators/order.ts
+++ b/src/operators/order.ts
@@ -63,6 +63,10 @@ class OrderService {
     });
   }
 
+  async appleVerify(id: string, transactionId: string): Promise<AxiosResponse<IOrderDetailResponse>> {
+    return await httpClient.post(`/${this.key}/${id}/apple-verify/`, { transaction_id: transactionId });
+  }
+
   async updatePrice(id: string, data: IOrder): Promise<AxiosResponse<IOrderDetailResponse>> {
     return await httpClient.post(`/${this.key}/${id}/update-price/`, data);
   }

--- a/src/pages/console/application/Extra.vue
+++ b/src/pages/console/application/Extra.vue
@@ -168,11 +168,11 @@ export default defineComponent({
     id() {
       return this.$route.params?.id?.toString();
     },
-    // App Store Review Guideline 3.1.1: hide non-IAP purchase actions on
-    // the iOS surface. The form still renders for deep-linked users but
-    // the "Create Order" submit button is removed.
+    // Credits are buyable on every surface now. On iOS the order is paid via
+    // Apple IAP on the order-detail page; we only offer packages that have an
+    // Apple product id mapped (see `packages`).
     showPayment(): boolean {
-      return !isIOS();
+      return true;
     },
     price() {
       if (this.application?.service?.price && this.form.amount) {
@@ -181,11 +181,15 @@ export default defineComponent({
       return 0;
     },
     packages() {
-      return (
+      const all =
         this.application?.packages
           ?.filter((pkg) => pkg.type === IPackageType.USAGE)
-          .sort((a, b) => a.amount - b.amount) || []
-      );
+          .sort((a, b) => a.amount - b.amount) || [];
+      // On iOS only packages with an Apple product id can be purchased via IAP.
+      if (isIOS()) {
+        return all.filter((pkg) => !!pkg?.metadata?.apple_product_id);
+      }
+      return all;
     },
     package() {
       if (this.packages && this.form.packageId) {

--- a/src/pages/console/order/Detail.vue
+++ b/src/pages/console/order/Detail.vue
@@ -103,7 +103,7 @@
               <el-col :span="16" :offset="4">
                 <el-divider border-style="dashed" />
                 <div
-                  v-if="showPayment && showPayWays && order.price && order.price > 0 && !order.pay_way"
+                  v-if="!isIos && showPayment && showPayWays && order.price && order.price > 0 && !order.pay_way"
                   class="payways mb-6"
                 >
                   <div
@@ -221,6 +221,12 @@
             :visible="paying"
             @hide="paying = false"
           />
+          <apple-pay-order
+            v-if="order && payWay === PayWay.Apple"
+            v-model="order"
+            :visible="paying"
+            @hide="paying = false"
+          />
         </el-col>
       </el-row>
     </el-col>
@@ -247,6 +253,7 @@ import StripePayOrder from '@/components/order/StripePay.vue';
 import AlipayPayOrder from '@/components/order/AliPay.vue';
 import X402PayOrder from '@/components/order/X402Pay.vue';
 import PaypalPayOrder from '@/components/order/PaypalPay.vue';
+import ApplePayOrder from '@/components/order/ApplePay.vue';
 import { IConfigResponse, IOrder, IOrderDetailResponse, OrderState } from '@/models';
 import { getPriceString } from '@/utils';
 import { getPaymentSurface, isAndroid, isIOS } from '@/utils';
@@ -261,7 +268,8 @@ enum PayWay {
   Stripe = 'Stripe',
   AliPay = 'AliPay',
   X402 = 'X402',
-  PayPal = 'PayPal'
+  PayPal = 'PayPal',
+  Apple = 'AppleIAP'
 }
 
 interface IData {
@@ -294,12 +302,14 @@ export default defineComponent({
     StripePayOrder,
     AlipayPayOrder,
     X402PayOrder,
-    PaypalPayOrder
+    PaypalPayOrder,
+    ApplePayOrder
   },
   data(): IData {
     return {
       PayWay: PayWay,
-      payWay: PayWay.WechatPay,
+      // iOS must use Apple IAP (Guideline 3.1.1); everyone else defaults to WeChat.
+      payWay: isIOS() ? PayWay.Apple : PayWay.WechatPay,
       OrderState: OrderState,
       order: undefined,
       x402Session: undefined,
@@ -316,17 +326,20 @@ export default defineComponent({
     enablePaypal(): boolean {
       return !!this.config?.features?.ENABLE_PAYPAL;
     },
+    isIos(): boolean {
+      return isIOS();
+    },
     id() {
       return this.$route.params?.id?.toString();
     },
     redirect() {
       return this.$route.query?.redirect;
     },
-    // App Store Review Guideline 3.1.1: do not expose any non-IAP payment
-    // UI inside the iOS bundle. We keep the order details visible (read
-    // only) but hide every pay-way selector and the Pay / Repay buttons.
+    // Payment is available on all surfaces. On iOS the only method is Apple
+    // IAP (Guideline 3.1.1) — the non-IAP selector grid is hidden separately
+    // (see the grid v-if), so iOS users get the single Apple Pay button.
     showPayment(): boolean {
-      return !isIOS();
+      return true;
     },
     pricingInfo(): {
       original: number;
@@ -619,6 +632,14 @@ export default defineComponent({
     },
     onPay() {
       this.prepaying = true;
+      // Apple IAP: no PSP session / pay_url. The ApplePay dialog drives the
+      // StoreKit purchase and calls apple-verify; just open it and poll.
+      if (this.payWay === PayWay.Apple) {
+        this.prepaying = false;
+        this.paying = true;
+        this.startOrderPolling(POLL_INITIAL_DELAY_MS);
+        return;
+      }
       if (this.payWay === PayWay.X402) {
         this.x402Session = undefined;
       }

--- a/src/shims.d.ts
+++ b/src/shims.d.ts
@@ -29,6 +29,12 @@ declare module '*.vue' {
   export default component;
 }
 
+// Native-only IAP plugin: dynamically imported on iOS, attaches a global
+// `CdvPurchase`. Declared loosely so the web/Android type-check passes
+// without the native package installed.
+declare module 'cordova-plugin-purchase';
+declare const CdvPurchase: any;
+
 // declare namespace Intl {
 //   function getCanonicalLocales(locales: string | string[] | undefined): string[];
 // }

--- a/src/utils/iap.ts
+++ b/src/utils/iap.ts
@@ -1,0 +1,98 @@
+// Apple In-App Purchase (StoreKit) flow via cordova-plugin-purchase.
+// Used only on the iOS surface to satisfy App Store Guideline 3.1.1: the
+// user buys a consumable, we hand the resulting StoreKit transaction id to
+// our backend (/orders/{id}/apple-verify/) which verifies it server-to-server
+// with Apple and credits the order. The plugin is dynamically imported so it
+// never ships in the web / Android bundle.
+import { orderOperator } from '@/operators';
+import { isIOS } from './surface';
+
+export interface IapResult {
+  ok: boolean;
+  transactionId?: string;
+  cancelled?: boolean;
+  error?: string;
+}
+
+let initialized = false;
+
+// cordova-plugin-purchase attaches a global `CdvPurchase` once imported.
+function getCdv(): any | undefined {
+  return (window as any).CdvPurchase;
+}
+
+/**
+ * Purchase `productId` via StoreKit and verify the transaction against our
+ * backend for `orderId`. Resolves once the order is verified (or fails /
+ * is cancelled). Never throws.
+ */
+export async function purchaseAndVerify(orderId: string, productId: string): Promise<IapResult> {
+  if (!isIOS()) {
+    return { ok: false, error: 'iap_only_ios' };
+  }
+  if (!productId) {
+    return { ok: false, error: 'missing_product_id' };
+  }
+  try {
+    // Indirect specifier so the bundler/type-checker doesn't statically
+    // resolve this native-only plugin (absent from the web/Android build).
+    const pluginName = 'cordova-plugin-purchase';
+    await import(/* @vite-ignore */ pluginName);
+  } catch (e) {
+    return { ok: false, error: 'iap_plugin_unavailable' };
+  }
+  const CdvPurchase = getCdv();
+  if (!CdvPurchase?.store) {
+    return { ok: false, error: 'iap_unavailable' };
+  }
+  const { store, ProductType, Platform, ErrorCode } = CdvPurchase;
+
+  return new Promise<IapResult>((resolve) => {
+    let settled = false;
+    const finish = (r: IapResult) => {
+      if (!settled) {
+        settled = true;
+        resolve(r);
+      }
+    };
+
+    store.register([{ id: productId, type: ProductType.CONSUMABLE, platform: Platform.APPLE_APPSTORE }]);
+
+    // Approved → verify with our backend → finish the StoreKit transaction so
+    // the consumable can be bought again later.
+    store.when().approved(async (transaction: any) => {
+      const txId = transaction?.transactionId || transaction?.id;
+      try {
+        await orderOperator.appleVerify(orderId, txId);
+        await transaction.finish();
+        finish({ ok: true, transactionId: txId });
+      } catch (e: any) {
+        finish({ ok: false, transactionId: txId, error: e?.response?.data?.error?.message || 'verify_failed' });
+      }
+    });
+
+    store.error((err: any) => {
+      const cancelled = err?.code === ErrorCode?.PAYMENT_CANCELLED;
+      finish({ ok: false, cancelled, error: err?.message || 'iap_error' });
+    });
+
+    (async () => {
+      try {
+        if (!initialized) {
+          await store.initialize([Platform.APPLE_APPSTORE]);
+          initialized = true;
+        }
+        await store.update();
+        const product = store.get(productId, Platform.APPLE_APPSTORE);
+        const offer = product?.getOffer();
+        if (!offer) {
+          finish({ ok: false, error: 'product_not_found' });
+          return;
+        }
+        await store.order(offer);
+      } catch (e: any) {
+        finish({ ok: false, error: e?.message || 'order_failed' });
+      }
+    })();
+  });
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -16,3 +16,4 @@ export * from './pasteUploadMixin';
 export * from './uploadTrackerMixin';
 export * from './connections';
 export * from './featureFlag';
+export * from './iap';


### PR DESCRIPTION
## Why
iOS app rejected under App Store **Guideline 3.1.1** — credits usable in-app must be buyable via Apple IAP. Previously all payment UI was *hidden* on iOS (not enough). This adds the real StoreKit purchase flow. Pairs with PlatformBackend #694 + PayBackend #42.

## What
- **`utils/iap.ts`** — `purchaseAndVerify(orderId, productId)`: StoreKit purchase via `cordova-plugin-purchase` (dynamic, native-only import), then `orderOperator.appleVerify` → backend verifies the transaction with Apple → `transaction.finish()`.
- **`components/order/ApplePay.vue`** — dialog that drives purchase + verify + order polling (modelled on the Android Stripe PaymentSheet component).
- **order Detail.vue** — `AppleIAP` pay-way is the default & only method on iOS; the non-IAP selector grid is hidden on iOS; `onPay` opens the Apple dialog (no PSP `pay_url`).
- **Extra.vue (credits)** — buyable on iOS, filtered to packages with a mapped `apple_product_id` (the 4 consumables: 100 / 530 / 1110 / 5950). Subscriptions & anonymous pay stay hidden on iOS for now.
- product id read from `order.package.metadata.apple_product_id` (embedded by backend #694).
- `package.json`: `cordova-plugin-purchase`.

## Product mapping (created in App Store Connect)
| credits | product id | iOS price |
|--|--|--|
| 100 | `com.acedatacloud.nexior.credits.100` | $18.99 |
| 530 | `com.acedatacloud.nexior.credits.530` | $89.99 |
| 1110 | `com.acedatacloud.nexior.credits.1110` | $179.99 |
| 5950 | `com.acedatacloud.nexior.credits.5950` | $919.99 |

## ⚠️ Before merge / submit
- iOS native build must run `npx cap sync ios` (wires the CordovaPluginPurchase pod) and have the **In-App Purchase** capability enabled in Xcode.
- **Must be tested on a real device with a Sandbox tester account** — StoreKit can't be verified in CI / simulator here.
- Backend PRs (#694, #42) must be deployed and the `apple-iap` secret present (done) first.

## Checks (local)
- `vue-tsc --noEmit` clean · `eslint` clean · `vite build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)