### PR TITLE
fix(coding-bridge): reattach live session, pending prompts & provider state on restore

### DIFF
--- a/change/@acedatacloud-nexior-coding-bridge-restore.json
+++ b/change/@acedatacloud-nexior-coding-bridge-restore.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(coding-bridge): restore live streaming, pending AskUserQuestion prompts and provider availability after a reload/session restore",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/codingBridge/HistoryDrawer.vue
+++ b/src/components/codingBridge/HistoryDrawer.vue
@@ -122,7 +122,10 @@ export default defineComponent({
       if (!this.currentNodeId) {
         return;
       }
-      this.$store.dispatch('codingBridge/getHistoryDetail', {
+      // Reattach (not just fetch the transcript): if this conversation is still
+      // running on the node, this re-pulls its live stream, running state and any
+      // blocked permission/AskUserQuestion prompt instead of showing it idle.
+      this.$store.dispatch('codingBridge/reattachSession', {
         node_id: this.currentNodeId,
         provider: item.provider,
         session_id: item.session_id

--- a/src/components/codingBridge/SessionView.vue
+++ b/src/components/codingBridge/SessionView.vue
@@ -621,12 +621,16 @@ export default defineComponent({
       return (this.attachmentFileList || []).some((file: UploadFile) => this.isAttachmentUploading(file));
     },
     canSend(): boolean {
+      // Intentionally NOT gated on `currentProviderAvailable`: that flag comes
+      // from the node's CLI probe, which false-negatives when the daemon's PATH
+      // can't see an installed CLI (nvm/launchd). Blocking send there locked the
+      // user out of a working node. We surface a warning in `composerHint`
+      // instead and let the node return a clear error if the CLI is truly absent.
       return (
         (!!this.prompt.trim() || this.attachments.length > 0) &&
         !this.uploadingAttachments &&
         this.connected &&
-        this.nodeOnline &&
-        this.currentProviderAvailable
+        this.nodeOnline
       );
     },
     composerHint(): string {

--- a/src/store/codingBridge/actions.identity.test.ts
+++ b/src/store/codingBridge/actions.identity.test.ts
@@ -126,4 +126,34 @@ describe('coding bridge session identity (integration)', () => {
     h.feed({ event: 'history.detail', session_id: 'cx', provider: 'codex', events: [] });
     expect(h.state.sessions['cx'].readonly).toBe(true);
   });
+
+  it('reattaches (not just views) the open conversation when history snapshot lands after a reload', () => {
+    const h = harness();
+    // historyRef survives a reload (it is persisted); currentSessionId does not.
+    h.state.historyRef = { node_id: NODE, provider: 'claude', session_id: 'real-1' };
+    h.feed({
+      event: 'history.snapshot',
+      sessions: [{ session_id: 'real-1', provider: 'claude', running: true }]
+    });
+    // Must fully reattach the open conversation, not just fetch its transcript —
+    // this is what re-pulls a running session's live stream + pending prompt.
+    const reattach = h.dispatched.find((d) => d.type === 'reattachSession');
+    expect(reattach).toBeDefined();
+    expect(reattach?.payload).toMatchObject({ node_id: NODE, session_id: 'real-1' });
+    expect(h.dispatched.some((d) => d.type === 'getHistoryDetail')).toBe(false);
+  });
+
+  it('advances and dedupes the per-session seq cursor (the persisted resume point)', () => {
+    const h = harness();
+    h.feed({ event: 'session.started', session_id: 'real-1' });
+    h.feed({ event: 'session.text_delta', session_id: 'real-1', id: 's', text: 'a', seq: 5 });
+    expect(h.state.lastSeq['real-1']).toBe(5);
+    // A replayed/overlapping event at or below the cursor is dropped (no dup text).
+    h.feed({ event: 'session.text_delta', session_id: 'real-1', id: 's', text: 'DUP', seq: 5 });
+    expect(h.state.events['real-1'][0].text).toBe('a');
+    // A higher seq advances the cursor and is applied.
+    h.feed({ event: 'session.text_delta', session_id: 'real-1', id: 's', text: 'b', seq: 6 });
+    expect(h.state.lastSeq['real-1']).toBe(6);
+    expect(h.state.events['real-1'][0].text).toBe('ab');
+  });
 });

--- a/src/store/codingBridge/actions.ts
+++ b/src/store/codingBridge/actions.ts
@@ -364,10 +364,12 @@ export const applyNodeEvent = (
       if (fromNode) {
         commit('setHistory', { node_id: fromNode, sessions: payload.sessions ?? [] });
         commit('updateStatus', { key: 'getHistory', value: Status.Success });
-        // Restore the conversation that was open before a reload.
+        // Restore the conversation that was open before a reload — and fully
+        // reattach it (transcript + running state + pending permission + live
+        // stream replay), not just lay down a static transcript.
         const ref = state.historyRef;
         if (ref && ref.node_id === fromNode && !state.currentSessionId) {
-          dispatch('getHistoryDetail', ref);
+          dispatch('reattachSession', ref);
         }
       }
       break;
@@ -698,6 +700,10 @@ export const sendPrompt = (
         trace_id: traceId
       });
       commit('setCurrentSession', sessionId);
+      // Point historyRef at this fresh session so a reload can restore AND focus
+      // it (so its live stream / pending prompt re-surface). renameSession
+      // migrates this to the provider's real id once `session.identified` lands.
+      commit('setHistoryRef', { node_id: nodeId, provider, session_id: sessionId });
     } else {
       sessionId = existing.session_id;
       // Resuming a replayed conversation: carry the composer's current settings
@@ -953,6 +959,31 @@ export const getHistoryDetail = (
   });
 };
 
+// Re-establish a conversation as fully LIVE — used when restoring after a reload
+// or opening a session from the history drawer. A static `getHistoryDetail`
+// alone left three gaps: a still-running session showed no live output until the
+// user sent something; a blocked AskUserQuestion / permission prompt never
+// re-surfaced; and the running status could be lost. This pulls all four pieces:
+//  1. the transcript (getHistoryDetail),
+//  2. which sessions are running right now (requestSessions → reattach + Stop),
+//  3. any outstanding permission/question prompt (requestPendingPermissions),
+//  4. the in-flight event stream replayed from our last cursor (socket.resume),
+//     so live deltas (higher seq) append onto the restored transcript.
+export const reattachSession = (
+  { state, dispatch }: ActionContext<ICodingBridgeState, IRootState>,
+  ref: ICodingBridgeHistoryRef
+): void => {
+  if (!ref?.node_id || !ref?.session_id) {
+    return;
+  }
+  dispatch('getHistoryDetail', ref);
+  dispatch('requestSessions', ref.node_id);
+  dispatch('requestPendingPermissions', ref.node_id);
+  // Replay the live stream from the last event we applied (0 = from the start of
+  // the relay's buffer). The relay and the browser both dedupe by seq.
+  socket?.resume({ [ref.session_id]: state.lastSeq[ref.session_id] ?? 0 });
+};
+
 // Resync a live session from the device transcript after the live stream lost
 // events it could not replay (stream_truncated). Pulls the full history detail,
 // which replaces the session's events; later live events (higher seq) still
@@ -1096,6 +1127,7 @@ export default {
   answerQuestion,
   getHistory,
   getHistoryDetail,
+  reattachSession,
   resyncSession,
   browseDir,
   clearDirectory,

--- a/src/store/codingBridge/persist.ts
+++ b/src/store/codingBridge/persist.ts
@@ -1,5 +1,18 @@
-// Only the selected node and the last-opened history pointer survive a reload.
-// Live nodes, sessions, events and permission prompts are rebuilt from the
-// relay on reconnect, and the open conversation is re-read from the device, so
-// persisting their contents would only show stale data.
-export default ['codingBridge.currentNodeId', 'codingBridge.historyRef', 'codingBridge.lastComposer'];
+// Only the selected node, the last-opened history pointer, the composer prefs
+// and the per-session event cursors survive a reload. Live nodes, sessions,
+// events and permission prompts are rebuilt from the relay on reconnect, and the
+// open conversation is re-read from the device, so persisting their contents
+// would only show stale data.
+//
+// `lastSeq` is persisted so that after a full page reload the reconnect can ask
+// the relay to `resume` each session's stream from the last event we applied —
+// otherwise the cursor is empty, no replay is requested, and an actively
+// streaming session looks frozen until the user sends something. A stale cursor
+// (relay buffer trimmed) is self-healing: the relay replies `stream_truncated`
+// and the session resyncs from the device transcript.
+export default [
+  'codingBridge.currentNodeId',
+  'codingBridge.historyRef',
+  'codingBridge.lastComposer',
+  'codingBridge.lastSeq'
+];


### PR DESCRIPTION
Fixes three reported Coding Bridge restore bugs. Root causes confirmed by reading the node daemon, relay protocol and browser store end-to-end (the user's node runs agent `2026.6.14.4`, which already has #23/#27/#28 — so these are genuine browser-side residual gaps, plus a node PATH issue handled in a companion PR).

## Bug 1 — "Claude Code is not installed on this device", send blocked
The node computes provider availability via `shutil.which`, which **false-negatives** when its daemon PATH can't see an installed CLI (the user's `claude` lives under an nvm dir not on the agent's PATH). The frontend turned that flag into a **hard send-block** (`canSend`). 
**Fix:** drop the availability gate from `canSend` — keep the warning in `composerHint`, and let the node return a clear error if the CLI is truly absent. The real detection fix is node-side in [CodingBridgeAgent#29](https://github.com/AceDataCloud/CodingBridgeAgent/pull/29).

## Bug 2 — background-running session doesn't sync until you send a message
After a full page reload `state.lastSeq` was empty (it wasn't persisted), so the reconnect's `socket.resume(cursors)` was skipped and the relay never replayed the in-flight stream — the session looked frozen until a send nudged delivery. 
**Fix:** persist `lastSeq` ([persist.ts](https://github.com/AceDataCloud/Nexior/blob/main/src/store/codingBridge/persist.ts)); add `reattachSession`, which replays the live stream from the last applied cursor. A stale cursor self-heals via the existing `stream_truncated` → `resyncSession` path.

## Bug 3 — pending AskUserQuestion / permission dialog gone after restore
Opening a conversation from the history drawer only dispatched `getHistoryDetail`; it never re-requested that session's pending permissions, and a fresh session never set `historyRef` so a reload restored the wrong (or no) focused session — so the question card (filtered by `currentSessionId`) never showed.
**Fix:** `reattachSession` pulls transcript + running state (`requestSessions`) + pending permissions (`requestPendingPermissions`) + live stream (`resume`) together. Both the history-drawer open and the reload restore now go through it. `sendPrompt` sets `historyRef` for fresh sessions (migrated to the real id on `session.identified`) so a reload restores **and focuses** them.

## Tests
`src/store/codingBridge/actions.identity.test.ts` (drives the real reducer): history.snapshot now reattaches the open conversation rather than doing a bare transcript fetch; the seq cursor advances and dedupes (the persisted resume point). `vitest` (22 pass) + `vue-tsc --noEmit` + `eslint` all green. Beachball change file included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)