### PR TITLE
fix(iap): show global 积分 top-up entry on iOS

### DIFF
--- a/change/@acedatacloud-nexior-880a9dd0-3a86-4133-9884-a2c447ed9cc9.json
+++ b/change/@acedatacloud-nexior-880a9dd0-3a86-4133-9884-a2c447ed9cc9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: show global credits top-up entry on iOS",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/application/Info.vue
+++ b/src/components/application/Info.vue
@@ -91,9 +91,14 @@ export default defineComponent({
   },
   emits: ['buy', 'usage'],
   computed: {
-    // Hide the "Top Up" action inside the iOS bundle (payments are web-only).
+    // On iOS, only show "Top Up" when this application has Apple-buyable
+    // packages (apple_product_id mapped) — i.e. the global 积分 wallet.
+    // Per-service apps have no Apple products, so the action stays hidden.
     showPayment(): boolean {
-      return !isIOS();
+      if (!isIOS()) {
+        return true;
+      }
+      return (this.application?.packages || []).some((p) => p?.metadata?.apple_product_id);
     },
     remainingAmountText(): string {
       const amount = Number(this.application?.remaining_amount ?? 0);

--- a/src/components/console/SidePanel.vue
+++ b/src/components/console/SidePanel.vue
@@ -33,7 +33,7 @@ import {
   ROUTE_INDEX
 } from '@/router';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { isOfficial, isIOS } from '@/utils';
+import { isOfficial } from '@/utils';
 
 interface ILink {
   key: string;
@@ -81,13 +81,8 @@ export default defineComponent({
         }
       ];
 
-      // App Store Review Guideline 3.1.1: hide all order/payment entry
-      // points when running inside the iOS native bundle. Users can still
-      // reach order routes via deep link, but they will see no actionable
-      // payment UI (see the v-if guards in order/Detail.vue etc.).
-      if (isIOS()) {
-        links = links.filter((link) => link.key !== 'order-list');
-      }
+      // Order history stays visible on iOS — purchases now happen in-app via
+      // Apple IAP, so users should see their orders.
 
       return links;
     }

--- a/src/pages/console/application/List.vue
+++ b/src/pages/console/application/List.vue
@@ -24,7 +24,7 @@
             </div>
           </el-card>
         </el-col>
-        <el-col v-if="showPayment && globalApplications?.length > 0" :md="12" :xs="24">
+        <el-col v-if="showGlobalPayment && globalApplications?.length > 0" :md="12" :xs="24">
           <el-card shadow="hover" class="relative min-h-[180px] mb-2" :body-style="{ padding: '18px 20px' }">
             <el-skeleton v-if="loading" />
             <div v-else class="flex flex-row justify-between align-center">
@@ -57,7 +57,7 @@
                   {{ $t('application.button.usage') }}
                 </el-button>
                 <el-button
-                  v-if="showPayment"
+                  v-if="showGlobalPayment"
                   class="!m-0 !px-2"
                   type="primary"
                   round
@@ -296,13 +296,19 @@ export default defineComponent({
     page() {
       return parseInt(this.$route.query.page?.toString() || '1');
     },
-    // App Store Review Guideline 3.1.1 forbids exposing non-IAP purchase
-    // flows inside the iOS bundle. Hide every "Buy More" / order entry
-    // on the iOS surface; the page remains reachable via deep link but
-    // shows no payment UI (see also order/Detail.vue, Subscribe.vue,
-    // Extra.vue, components/console/SidePanel.vue).
+    // Per-service apps have no Apple products, so their "Buy More" stays
+    // hidden on iOS (web-only). Non-iOS shows everything.
     showPayment(): boolean {
       return !isIOS();
+    },
+    // The global 积分 wallet IS buyable on iOS via Apple IAP. Show its
+    // top-up entry when its packages have an apple_product_id mapped.
+    showGlobalPayment(): boolean {
+      if (!isIOS()) {
+        return true;
+      }
+      const pkgs = (this.globalApplications?.[0] as any)?.packages || [];
+      return pkgs.some((p: any) => p?.metadata?.apple_product_id);
     }
   },
   watch: {


### PR DESCRIPTION
Follow-up to #970. The IAP buy **page** was unhidden on iOS, but the **entry points that navigate to it** were still iOS-gated in 3 spots, so users couldn't reach it:
- `components/console/SidePanel.vue` — hid the order-history menu on iOS
- `components/application/Info.vue` — hid the per-app top-up button on iOS
- `pages/console/application/List.vue` — hid the global-balance card + buy buttons on iOS

Now on iOS the **global 积分 wallet** top-up shows (gated on packages having an `apple_product_id` — the 4 Apple consumables), while per-service apps stay hidden (no Apple products). Order history is visible again on iOS.

vue-tsc + eslint clean; vite build + cap sync ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)