### PR TITLE
fix(console): card-based application list on mobile

### DIFF
--- a/change/@acedatacloud-nexior-3a392eda-64b8-4ef8-b9bb-b00017b22020.json
+++ b/change/@acedatacloud-nexior-3a392eda-64b8-4ef8-b9bb-b00017b22020.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(console): card-based application list on mobile",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/pages/console/application/List.vue
+++ b/src/pages/console/application/List.vue
@@ -74,7 +74,7 @@
       </el-row>
       <el-row>
         <el-col :span="24">
-          <el-card shadow="hover" class="applications-table-card">
+          <el-card shadow="hover" class="applications-table-card hidden sm:block">
             <el-table
               v-loading="loading"
               :data="individualApplications"
@@ -185,6 +185,71 @@
               </el-table-column>
             </el-table>
           </el-card>
+          <div class="application-cards block sm:hidden">
+            <el-skeleton v-if="loading" :rows="4" animated />
+            <template v-else>
+              <el-empty v-if="!individualApplications?.length" :description="$t('common.message.noData')" />
+              <el-card
+                v-for="app in individualApplications"
+                v-else
+                :key="app.id"
+                shadow="hover"
+                class="application-card mb-2"
+                :body-style="{ padding: '14px 16px' }"
+              >
+                <div class="flex items-center gap-2 flex-wrap">
+                  <span class="application-card__name">{{ app?.service?.title }}</span>
+                  <el-tag v-if="app?.type === 'Period'" type="success" effect="dark" size="small" round>
+                    {{ $t('application.type.period') }}
+                  </el-tag>
+                  <el-tag v-else-if="app?.type === 'Usage'" effect="dark" size="small" round>
+                    {{ $t('application.type.usage') }}
+                  </el-tag>
+                  <el-tag v-if="app?.role === 'grantee'" type="info" size="small" round>
+                    {{ $t('application.badge.shared') }}
+                  </el-tag>
+                </div>
+                <div class="application-card__id">
+                  <span class="truncate">{{ $t('application.field.id') }}: {{ app.id }}</span>
+                  <copy-to-clipboard :content="app.id" class="inline-block shrink-0" />
+                </div>
+                <div class="application-card__row">
+                  <span class="label">{{ $t('application.field.remainingAmount') }}</span>
+                  <span class="value">{{ getRemainingAmount(app) }}</span>
+                </div>
+                <div v-if="app?.expired_at" class="application-card__row">
+                  <span class="label">{{ $t('application.field.expiredAt') }}</span>
+                  <span class="value">{{ $dayjs.format(app.expired_at) }}</span>
+                </div>
+                <div v-if="app.service?.type === serviceType.API" class="application-card__row">
+                  <span class="label">{{ $t('application.field.allowConsumeGlobal') }}</span>
+                  <el-switch
+                    v-model="app.allow_consume_global"
+                    :active-value="true"
+                    :inactive-value="false"
+                    @change="updateAllowConsumeGlobal(app, $event)"
+                  />
+                </div>
+                <div class="flex items-center justify-end gap-2 mt-3">
+                  <el-button class="!m-0 !px-3" size="small" round @click="onGoUsage(app)">
+                    <font-awesome-icon icon="fa-solid fa-chart-line" class="mr-1 text-[12px]" />
+                    {{ $t('application.button.usage') }}
+                  </el-button>
+                  <el-button
+                    v-if="showPayment"
+                    class="!m-0 !px-3"
+                    type="primary"
+                    round
+                    size="small"
+                    @click="onBuyMore(app)"
+                  >
+                    <font-awesome-icon icon="fa-solid fa-coins" class="mr-1 text-[12px]" />
+                    {{ $t('application.button.buyMore') }}
+                  </el-button>
+                </div>
+              </el-card>
+            </template>
+          </div>
         </el-col>
       </el-row>
       <el-row>
@@ -219,6 +284,7 @@ import {
   ElTag,
   ElSkeleton,
   ElSwitch,
+  ElEmpty,
   ElMessage
 } from 'element-plus';
 import { ROUTE_CONSOLE_APPLICATION_EXTRA, ROUTE_CONSOLE_USAGE_LIST } from '@/router/constants';
@@ -265,6 +331,7 @@ export default defineComponent({
     ElTag,
     ElSkeleton,
     ElSwitch,
+    ElEmpty,
     ElTableColumn,
     ElCard,
     FontAwesomeIcon
@@ -478,6 +545,55 @@ export default defineComponent({
   margin: 0;
 }
 
+// Tablet/desktop table can exceed the viewport — let it scroll horizontally
+// instead of squashing columns.
+.applications-table-card {
+  :deep(.el-card__body) {
+    overflow-x: auto;
+  }
+}
+
+.application-card {
+  &__name {
+    font-weight: 600;
+    font-size: 15px;
+    color: var(--el-text-color-primary);
+    word-break: break-word;
+  }
+  &__id {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-top: 6px;
+    color: var(--el-text-color-secondary);
+    font-size: 12px;
+    .truncate {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+  &__row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    margin-top: 8px;
+    .label {
+      color: var(--el-text-color-regular);
+      font-size: 13px;
+      flex-shrink: 0;
+    }
+    .value {
+      color: var(--el-text-color-primary);
+      font-size: 14px;
+      font-weight: 500;
+      text-align: right;
+      word-break: break-all;
+    }
+  }
+}
+
 @media screen and (max-width: 767px) {
   .application-list {
     display: block;
@@ -488,17 +604,6 @@ export default defineComponent({
       font-size: 24px;
       line-height: 30px;
     }
-  }
-
-  .applications-table-card {
-    :deep(.el-card__body) {
-      padding: 0;
-      overflow-x: auto;
-    }
-  }
-
-  .applications-table {
-    min-width: 620px;
   }
 }
 </style>


### PR DESCRIPTION
## Problem

The console **申请列表** (Application list) page looks broken on phones. The page renders a wide desktop `el-table` and, on mobile, just forces it to scroll horizontally (`min-width: 620px` + `overflow-x: auto`). The result (see screenshot the user reported):

- The long UUID `申请ID` column hogs width and wraps onto two lines
- Service names wrap mid-word (`通义万相\n视频生成`)
- Rows get clipped (`ByteDanc…`)
- The **usage / 充值** action buttons sit in a right-fixed column that's off-screen and unreachable

## Fix

On `<sm` viewports the table is hidden and replaced with a stacked **card list**. Each application card shows:

- Service name + type / shared tags
- Copyable application ID (truncated, no wrapping)
- Balance (实例余额)
- Expiry (when set)
- The **allow-global-balance** toggle — previously hidden entirely on mobile, now usable
- The **usage** and **buy more** buttons, properly reachable

The table is kept unchanged for `sm` and up and now scrolls horizontally only when it genuinely overflows (the artificial `min-width` hack is removed).

Reuses existing i18n keys and the existing `getRemainingAmount` / `onGoUsage` / `onBuyMore` / `updateAllowConsumeGlobal` methods — no new strings or logic.

## Verification

- `npm run lint` — clean
- `npx vue-tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)