### PR TITLE
fix(iap): iOS top-up entry visibility + wallet-widget navigation

### DIFF
--- a/change/@acedatacloud-nexior-80bea653-8058-4b53-bfc9-7d266319a1eb.json
+++ b/change/@acedatacloud-nexior-80bea653-8058-4b53-bfc9-7d266319a1eb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: iOS top-up entry visibility + wallet-widget in-app navigation",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/application/Info.vue
+++ b/src/components/application/Info.vue
@@ -91,11 +91,15 @@ export default defineComponent({
   },
   emits: ['buy', 'usage'],
   computed: {
-    // On iOS, only show "Top Up" when this application has Apple-buyable
-    // packages (apple_product_id mapped) — i.e. the global 积分 wallet.
-    // Per-service apps have no Apple products, so the action stays hidden.
+    // On iOS the only Apple-buyable entity is the global 积分 wallet, so show
+    // "Top Up" for the global application (per-service apps have no Apple
+    // products). Keyed on scope (always present) rather than packages, which
+    // isn't serialized in every view.
     showPayment(): boolean {
       if (!isIOS()) {
+        return true;
+      }
+      if (this.application?.scope === 'Global') {
         return true;
       }
       return (this.application?.packages || []).some((p) => p?.metadata?.apple_product_id);

--- a/src/components/application/Status.vue
+++ b/src/components/application/Status.vue
@@ -36,6 +36,7 @@ import { ElDialog } from 'element-plus';
 import { IApplicationType, IApplication, IService } from '@/models';
 import { ROUTE_CONSOLE_APPLICATION_EXTRA, ROUTE_CONSOLE_USAGE_LIST } from '@/router';
 import ApplicationInfo from './Info.vue';
+import { isNative } from '@/utils';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 export interface IData {
   visible: boolean;
@@ -98,23 +99,24 @@ export default defineComponent({
   },
   methods: {
     onGoUsage(application: IApplication) {
-      const url = this.$router.resolve({
-        name: ROUTE_CONSOLE_USAGE_LIST,
-        query: {
-          application_id: application.id
-        }
-      });
-      window.open(url.href, '_blank');
+      const target = { name: ROUTE_CONSOLE_USAGE_LIST, query: { application_id: application.id } };
+      // window.open('_blank') is a no-op inside the iOS/Android webview; navigate in-app.
+      if (isNative()) {
+        this.visible = false;
+        this.$router.push(target);
+        return;
+      }
+      window.open(this.$router.resolve(target).href, '_blank');
     },
     onBuyMore(application: IApplication) {
-      // open in new tab for this url
-      const url = this.$router.resolve({
-        name: ROUTE_CONSOLE_APPLICATION_EXTRA,
-        params: {
-          id: application.id
-        }
-      }).href;
-      window.open(url, '_blank');
+      const target = { name: ROUTE_CONSOLE_APPLICATION_EXTRA, params: { id: application.id } };
+      // window.open('_blank') is a no-op inside the iOS/Android webview; navigate in-app.
+      if (isNative()) {
+        this.visible = false;
+        this.$router.push(target);
+        return;
+      }
+      window.open(this.$router.resolve(target).href, '_blank');
     },
     onSelectApplication(application: IApplication) {
       this.$emit('select', application);

--- a/src/pages/console/application/List.vue
+++ b/src/pages/console/application/List.vue
@@ -301,14 +301,11 @@ export default defineComponent({
     showPayment(): boolean {
       return !isIOS();
     },
-    // The global 积分 wallet IS buyable on iOS via Apple IAP. Show its
-    // top-up entry when its packages have an apple_product_id mapped.
+    // The global 积分 wallet IS buyable on iOS via Apple IAP (it always has
+    // the mapped consumable packages), so its top-up entry is shown on every
+    // surface. The card itself is still gated on having a global application.
     showGlobalPayment(): boolean {
-      if (!isIOS()) {
-        return true;
-      }
-      const pkgs = (this.globalApplications?.[0] as any)?.packages || [];
-      return pkgs.some((p: any) => p?.metadata?.apple_product_id);
+      return true;
     }
   },
   watch: {


### PR DESCRIPTION
Follow-up to #970/#972. Two iOS bugs that made top-up unusable:

1. **`Status.vue` (wallet widget):** `window.open(url, '_blank')` is a no-op inside the iOS/Android webview, so tapping top-up/usage did nothing → now navigates in-app via `router.push` on native.
2. **`Info.vue` + `List.vue`:** the iOS top-up entry was gated on `packages[].metadata.apple_product_id`, which isn't serialized in every view (e.g. the wallet widget) → the entry disappeared. Now gated on the **global 积分 wallet** (`scope === 'Global'`), which is reliably present.

Backend side (done out-of-band): the 4 IAP consumables are now `READY_TO_SUBMIT` (added availability) so StoreKit can fetch them in sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)