### PR TITLE
fix(console): vertically center sidebar tab icons

### DIFF
--- a/change/@acedatacloud-nexior-d43781c5-c980-4ad7-b871-68f4cc6db4c0.json
+++ b/change/@acedatacloud-nexior-d43781c5-c980-4ad7-b871-68f4cc6db4c0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(console): vertically center sidebar tab icons",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/console/SidePanel.vue
+++ b/src/components/console/SidePanel.vue
@@ -150,10 +150,15 @@ $padding-left: 12px;
     .icon {
       width: 16px;
       height: 16px;
-      display: inline-block;
-      position: relative;
+      // Center the SVG in its own box and reset the inherited tall line-height,
+      // otherwise the icon renders against the link's 36/40px line box and drops
+      // well below the label.
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      line-height: 1;
+      vertical-align: middle;
       margin-right: 10px;
-      transform: translateY(-2%);
     }
     .text {
       font-size: 14px;


### PR DESCRIPTION
## Problem

On the console pages (申请列表 / 订单列表 / 使用历史), the tab icons render **dropped down and to the left, below their text labels** — most obvious on mobile. Reported as "icon 都错位了".

## Root cause

In `src/components/console/SidePanel.vue`, the `.icon` span is a fixed `16×16` `inline-block` but **inherits the parent `.link`'s `line-height`** (36px on mobile, 40px on desktop). The Font Awesome SVG inside is therefore laid out against that tall line box instead of the 16px box, pushing it well below center. The old `transform: translateY(-2%)` (≈ −0.3px) did nothing to compensate.

## Fix

Make the icon box center its own SVG and stop inheriting the tall line-height:

```scss
.icon {
  width: 16px;
  height: 16px;
  display: inline-flex;
  align-items: center;
  justify-content: center;
  line-height: 1;
  vertical-align: middle;
  margin-right: 10px;
}
```

This corrects both the mobile (flex `.link`) and desktop (block `.link`) layouts.

## Verification

Reproduced the exact mobile flex `.link` + icon-span CSS in an isolated page and screenshotted before/after: BEFORE the icons hang low below the text; AFTER all three are vertically centered with their labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)