### PR TITLE
fix(iap): use global CdvPurchase (the actual purchase-failure bug)

### DIFF
--- a/change/@acedatacloud-nexior-448f8bd1-fd8d-4c3b-846c-043269cbff2b.json
+++ b/change/@acedatacloud-nexior-448f8bd1-fd8d-4c3b-846c-043269cbff2b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: iOS IAP uses global CdvPurchase + per-service top-up visibility",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/order/ApplePay.vue
+++ b/src/components/order/ApplePay.vue
@@ -88,7 +88,10 @@ export default defineComponent({
         return;
       }
       if (!result.ok) {
-        ElMessage.error(this.$t('order.message.applePayFailed'));
+        // Surface the specific reason (product_not_found / iap_unavailable /
+        // verify_failed …) to aid diagnosis during rollout.
+        const reason = result.error ? ` (${result.error})` : '';
+        ElMessage.error(this.$t('order.message.applePayFailed') + reason);
         this.$emit('hide');
         return;
       }

--- a/src/pages/console/application/List.vue
+++ b/src/pages/console/application/List.vue
@@ -170,7 +170,7 @@
                       {{ $t('application.button.usage') }}
                     </el-button>
                     <el-button
-                      v-if="showPayment"
+                      v-if="rowCanPay(scope?.row)"
                       class="!m-0 !px-2"
                       type="primary"
                       round
@@ -296,11 +296,6 @@ export default defineComponent({
     page() {
       return parseInt(this.$route.query.page?.toString() || '1');
     },
-    // Per-service apps have no Apple products, so their "Buy More" stays
-    // hidden on iOS (web-only). Non-iOS shows everything.
-    showPayment(): boolean {
-      return !isIOS();
-    },
     // The global 积分 wallet IS buyable on iOS via Apple IAP (it always has
     // the mapped consumable packages), so its top-up entry is shown on every
     // surface. The card itself is still gated on having a global application.
@@ -320,6 +315,14 @@ export default defineComponent({
     this.onFetchData();
   },
   methods: {
+    // A per-service app row shows "Buy More" on every surface, but on iOS
+    // only when it has an Apple-buyable package (apple_product_id mapped).
+    rowCanPay(application: IApplication): boolean {
+      if (!isIOS()) {
+        return true;
+      }
+      return ((application as any)?.packages || []).some((p: any) => p?.metadata?.apple_product_id);
+    },
     updateAllowConsumeGlobal(application: IApplication, value: any) {
       if (!application || !application.id) {
         return;

--- a/src/utils/iap.ts
+++ b/src/utils/iap.ts
@@ -2,8 +2,11 @@
 // Used only on the iOS surface to satisfy App Store Guideline 3.1.1: the
 // user buys a consumable, we hand the resulting StoreKit transaction id to
 // our backend (/orders/{id}/apple-verify/) which verifies it server-to-server
-// with Apple and credits the order. The plugin is dynamically imported so it
-// never ships in the web / Android bundle.
+// with Apple and credits the order.
+//
+// NOTE: cordova-plugin-purchase is a Cordova plugin — Capacitor auto-loads it
+// and exposes a GLOBAL `window.CdvPurchase`. We must NOT `import` it (that
+// throws in the webview); we wait for the global to appear instead.
 import { orderOperator } from '@/operators';
 import { isIOS } from './surface';
 
@@ -16,9 +19,22 @@ export interface IapResult {
 
 let initialized = false;
 
-// cordova-plugin-purchase attaches a global `CdvPurchase` once imported.
 function getCdv(): any | undefined {
   return (window as any).CdvPurchase;
+}
+
+// The cordova bridge attaches `CdvPurchase` shortly after deviceready, which
+// can be after our Vue code runs — poll briefly for it.
+async function waitForCdv(timeoutMs = 8000): Promise<any | undefined> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const cdv = getCdv();
+    if (cdv?.store) {
+      return cdv;
+    }
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  return getCdv();
 }
 
 /**
@@ -33,15 +49,7 @@ export async function purchaseAndVerify(orderId: string, productId: string): Pro
   if (!productId) {
     return { ok: false, error: 'missing_product_id' };
   }
-  try {
-    // Indirect specifier so the bundler/type-checker doesn't statically
-    // resolve this native-only plugin (absent from the web/Android build).
-    const pluginName = 'cordova-plugin-purchase';
-    await import(/* @vite-ignore */ pluginName);
-  } catch (e) {
-    return { ok: false, error: 'iap_plugin_unavailable' };
-  }
-  const CdvPurchase = getCdv();
+  const CdvPurchase = await waitForCdv();
   if (!CdvPurchase?.store) {
     return { ok: false, error: 'iap_unavailable' };
   }


### PR DESCRIPTION
## Root cause of "App Store payment didn't complete"
`iap.ts` did `await import('cordova-plugin-purchase')`. But Capacitor auto-loads Cordova plugins as a **global** (`window.CdvPurchase`) — that ES import **throws in the webview**, so every purchase failed instantly *before* StoreKit ran (confirmed via CLS: `/apple-verify/` was never called).

## Fix
- **iap.ts**: stop importing; wait for the global `window.CdvPurchase` (poll up to 8s for the cordova bridge), then run the StoreKit flow.
- **ApplePay.vue**: show the specific failure reason in the toast (`product_not_found` / `iap_unavailable` / `verify_failed`) for diagnosis.
- **List.vue**: show per-service "Buy More" on iOS when the app has an Apple-buyable package (pairs with PlatformBackend #696 which maps per-service packages).

Also done out-of-band: the 4 IAP products are now `READY_TO_SUBMIT` (availability added) so StoreKit can fetch them in sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)