### PR TITLE
fix(console): align tab icons & fix general-balance card on mobile

### DIFF
--- a/change/@acedatacloud-nexior-3a392eda-64b8-4ef8-b9bb-b00017b22020.json
+++ b/change/@acedatacloud-nexior-3a392eda-64b8-4ef8-b9bb-b00017b22020.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(console): card-based application list on mobile",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/console/SidePanel.vue
+++ b/src/components/console/SidePanel.vue
@@ -150,10 +150,15 @@ $padding-left: 12px;
     .icon {
       width: 16px;
       height: 16px;
-      display: inline-block;
-      position: relative;
+      // Center the SVG in its own box and drop the inherited 40px line-height,
+      // otherwise the icon renders against the link's tall line box and sits
+      // visibly above/below the label.
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      line-height: 1;
+      vertical-align: middle;
       margin-right: 10px;
-      transform: translateY(-2%);
     }
     .text {
       font-size: 14px;

--- a/src/pages/console/application/List.vue
+++ b/src/pages/console/application/List.vue
@@ -74,7 +74,7 @@
       </el-row>
       <el-row>
         <el-col :span="24">
-          <el-card shadow="hover" class="applications-table-card">
+          <el-card shadow="hover" class="applications-table-card hidden sm:block">
             <el-table
               v-loading="loading"
               :data="individualApplications"
@@ -185,6 +185,71 @@
               </el-table-column>
             </el-table>
           </el-card>
+          <div class="application-cards block sm:hidden">
+            <el-skeleton v-if="loading" :rows="4" animated />
+            <template v-else>
+              <el-empty v-if="!individualApplications?.length" :description="$t('common.message.noData')" />
+              <el-card
+                v-for="app in individualApplications"
+                v-else
+                :key="app.id"
+                shadow="hover"
+                class="application-card mb-2"
+                :body-style="{ padding: '14px 16px' }"
+              >
+                <div class="flex items-center gap-2 flex-wrap">
+                  <span class="application-card__name">{{ app?.service?.title }}</span>
+                  <el-tag v-if="app?.type === 'Period'" type="success" effect="dark" size="small" round>
+                    {{ $t('application.type.period') }}
+                  </el-tag>
+                  <el-tag v-else-if="app?.type === 'Usage'" effect="dark" size="small" round>
+                    {{ $t('application.type.usage') }}
+                  </el-tag>
+                  <el-tag v-if="app?.role === 'grantee'" type="info" size="small" round>
+                    {{ $t('application.badge.shared') }}
+                  </el-tag>
+                </div>
+                <div class="application-card__id">
+                  <span class="truncate">{{ $t('application.field.id') }}: {{ app.id }}</span>
+                  <copy-to-clipboard :content="app.id" class="inline-block shrink-0" />
+                </div>
+                <div class="application-card__row">
+                  <span class="label">{{ $t('application.field.remainingAmount') }}</span>
+                  <span class="value">{{ getRemainingAmount(app) }}</span>
+                </div>
+                <div v-if="app?.expired_at" class="application-card__row">
+                  <span class="label">{{ $t('application.field.expiredAt') }}</span>
+                  <span class="value">{{ $dayjs.format(app.expired_at) }}</span>
+                </div>
+                <div v-if="app.service?.type === serviceType.API" class="application-card__row">
+                  <span class="label">{{ $t('application.field.allowConsumeGlobal') }}</span>
+                  <el-switch
+                    v-model="app.allow_consume_global"
+                    :active-value="true"
+                    :inactive-value="false"
+                    @change="updateAllowConsumeGlobal(app, $event)"
+                  />
+                </div>
+                <div class="flex items-center justify-end gap-2 mt-3">
+                  <el-button class="!m-0 !px-3" size="small" round @click="onGoUsage(app)">
+                    <font-awesome-icon icon="fa-solid fa-chart-line" class="mr-1 text-[12px]" />
+                    {{ $t('application.button.usage') }}
+                  </el-button>
+                  <el-button
+                    v-if="showPayment"
+                    class="!m-0 !px-3"
+                    type="primary"
+                    round
+                    size="small"
+                    @click="onBuyMore(app)"
+                  >
+                    <font-awesome-icon icon="fa-solid fa-coins" class="mr-1 text-[12px]" />
+                    {{ $t('application.button.buyMore') }}
+                  </el-button>
+                </div>
+              </el-card>
+            </template>
+          </div>
         </el-col>
       </el-row>
       <el-row>
@@ -219,6 +284,7 @@ import {
   ElTag,
   ElSkeleton,
   ElSwitch,
+  ElEmpty,
   ElMessage
 } from 'element-plus';
 import { ROUTE_CONSOLE_APPLICATION_EXTRA, ROUTE_CONSOLE_USAGE_LIST } from '@/router/constants';
@@ -265,6 +331,7 @@ export default defineComponent({
     ElTag,
     ElSkeleton,
     ElSwitch,
+    ElEmpty,
     ElTableColumn,
     ElCard,
     FontAwesomeIcon
@@ -478,6 +545,55 @@ export default defineComponent({
   margin: 0;
 }
 
+// Tablet/desktop table can exceed the viewport — let it scroll horizontally
+// instead of squashing columns.
+.applications-table-card {
+  :deep(.el-card__body) {
+    overflow-x: auto;
+  }
+}
+
+.application-card {
+  &__name {
+    font-weight: 600;
+    font-size: 15px;
+    color: var(--el-text-color-primary);
+    word-break: break-word;
+  }
+  &__id {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-top: 6px;
+    color: var(--el-text-color-secondary);
+    font-size: 12px;
+    .truncate {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+  &__row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    margin-top: 8px;
+    .label {
+      color: var(--el-text-color-regular);
+      font-size: 13px;
+      flex-shrink: 0;
+    }
+    .value {
+      color: var(--el-text-color-primary);
+      font-size: 14px;
+      font-weight: 500;
+      text-align: right;
+      word-break: break-all;
+    }
+  }
+}
+
 @media screen and (max-width: 767px) {
   .application-list {
     display: block;
@@ -488,17 +604,6 @@ export default defineComponent({
       font-size: 24px;
       line-height: 30px;
     }
-  }
-
-  .applications-table-card {
-    :deep(.el-card__body) {
-      padding: 0;
-      overflow-x: auto;
-    }
-  }
-
-  .applications-table {
-    min-width: 620px;
   }
 }
 </style>

--- a/src/pages/console/application/List.vue
+++ b/src/pages/console/application/List.vue
@@ -27,18 +27,18 @@
         <el-col v-if="showGlobalPayment && globalApplications?.length > 0" :md="12" :xs="24">
           <el-card shadow="hover" class="relative min-h-[180px] mb-2" :body-style="{ padding: '18px 20px' }">
             <el-skeleton v-if="loading" />
-            <div v-else class="flex flex-row justify-between align-center">
-              <div class="summary-card">
-                <div class="flex justify-start items-center gap-2 mb-2 w-full">
+            <div v-else class="flex flex-col sm:flex-row sm:justify-between gap-3">
+              <div class="summary-card min-w-0">
+                <div class="flex justify-start items-center gap-2 mb-2 w-full min-w-0">
                   <div class="icon-wrapper !mb-0">
                     <font-awesome-icon icon="fa-solid fa-wallet" />
                   </div>
-                  <span class="text-[var(--el-text-color-regular)] text-[14px] truncate">
-                    {{ $t('application.field.id') }}: {{ globalApplications?.[0]?.id }}
+                  <span class="flex items-center gap-1 min-w-0 text-[var(--el-text-color-regular)] text-[14px]">
+                    <span class="truncate">{{ $t('application.field.id') }}: {{ globalApplications?.[0]?.id }}</span>
                     <copy-to-clipboard
                       v-if="globalApplications?.[0]?.id"
                       :content="globalApplications?.[0]?.id"
-                      class="inline-block"
+                      class="inline-block shrink-0"
                     />
                   </span>
                 </div>
@@ -51,7 +51,7 @@
                   {{ $t('application.message.globalBalanceDescription') }}
                 </p>
               </div>
-              <div class="flex flex-col items-end gap-2">
+              <div class="flex flex-row sm:flex-col justify-end items-center sm:items-end gap-2 shrink-0">
                 <el-button class="!m-0 !px-2" size="small" round @click="onGoUsage(globalApplications?.[0])">
                   <font-awesome-icon icon="fa-solid fa-chart-line" class="mr-1 text-[12px]" />
                   {{ $t('application.button.usage') }}


### PR DESCRIPTION
Follow-up mobile polish on the console. **Builds on #973** (includes its card-list commits); merging this brings both. Once #973 merges first, this reduces to just the two new commits.

## Issues (from device screenshot)

1. **Tab icons misaligned** — the *Application List / Order List / Usage History* tab icons rendered visibly above/below their text labels.
2. **General Balance card cramped** — its *Usage* / *Top Up* buttons were jammed into the top-right corner and clipped off the card edge (`Usag…`, `Top U…`), so the top-up entry was effectively unreachable.

## Fixes

**`SidePanel.vue`** — `.icon` was `inline-block` and inherited the link's 40px line-height (plus a `translateY(-2%)` nudge), so the SVG sat off-center. Changed it to an `inline-flex` centered box with `line-height: 1` / `vertical-align: middle` and removed the hack. Icons now align with the label in both the desktop sidebar and the mobile tab bar.

**`List.vue` (General Balance card)** — the card laid the buttons in a right column with `flex-row justify-between`; the left summary never shrank, so the buttons overflowed. It now stacks below the `sm` breakpoint (summary on top, buttons in a right-aligned row beneath) and the App ID truncates instead of pushing the buttons out. Desktop layout is unchanged.

## Verification
- `npm run lint` — clean
- `npx vue-tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)