### PR TITLE
fix(iap): poll for StoreKit product before failing

### DIFF
--- a/change/@acedatacloud-nexior-0a650ca2-030d-4fae-a374-36d1eeb4f097.json
+++ b/change/@acedatacloud-nexior-0a650ca2-030d-4fae-a374-36d1eeb4f097.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: poll for StoreKit product before failing",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/utils/iap.ts
+++ b/src/utils/iap.ts
@@ -90,9 +90,17 @@ export async function purchaseAndVerify(orderId: string, productId: string): Pro
           await store.initialize([Platform.APPLE_APPSTORE]);
           initialized = true;
         }
-        await store.update();
-        const product = store.get(productId, Platform.APPLE_APPSTORE);
-        const offer = product?.getOffer();
+        // Products load asynchronously from Apple after initialize/update —
+        // poll until the offer is available (race + sandbox propagation),
+        // up to ~15s, before giving up.
+        let offer = store.get(productId, Platform.APPLE_APPSTORE)?.getOffer();
+        let waited = 0;
+        while (!offer && waited < 15000) {
+          await store.update().catch(() => {});
+          await new Promise((r) => setTimeout(r, 1500));
+          waited += 1500;
+          offer = store.get(productId, Platform.APPLE_APPSTORE)?.getOffer();
+        }
         if (!offer) {
           finish({ ok: false, error: 'product_not_found' });
           return;


### PR DESCRIPTION
Products load asynchronously after `store.initialize/update`; the code checked `getOffer()` once and failed immediately with `product_not_found`. Now polls up to ~15s for the offer (handles the load race + fresh sandbox propagation).

Follow-up to #976.

🤖 Generated with [Claude Code](https://claude.com/claude-code)