### PR TITLE
fix(iap): mobile app-list Top Up entry + global card overflow

### DIFF
--- a/change/@acedatacloud-nexior-4026574b-c85d-49e8-a3b5-8a4095157f0e.json
+++ b/change/@acedatacloud-nexior-4026574b-c85d-49e8-a3b5-8a4095157f0e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: mobile app-list Top Up entry + global card overflow",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/pages/console/application/List.vue
+++ b/src/pages/console/application/List.vue
@@ -27,8 +27,8 @@
         <el-col v-if="showGlobalPayment && globalApplications?.length > 0" :md="12" :xs="24">
           <el-card shadow="hover" class="relative min-h-[180px] mb-2" :body-style="{ padding: '18px 20px' }">
             <el-skeleton v-if="loading" />
-            <div v-else class="flex flex-row justify-between align-center">
-              <div class="summary-card">
+            <div v-else class="flex flex-row justify-between items-center gap-3">
+              <div class="summary-card min-w-0 flex-1">
                 <div class="flex justify-start items-center gap-2 mb-2 w-full">
                   <div class="icon-wrapper !mb-0">
                     <font-awesome-icon icon="fa-solid fa-wallet" />
@@ -51,7 +51,7 @@
                   {{ $t('application.message.globalBalanceDescription') }}
                 </p>
               </div>
-              <div class="flex flex-col items-end gap-2">
+              <div class="flex flex-col items-end gap-2 shrink-0">
                 <el-button class="!m-0 !px-2" size="small" round @click="onGoUsage(globalApplications?.[0])">
                   <font-awesome-icon icon="fa-solid fa-chart-line" class="mr-1 text-[12px]" />
                   {{ $t('application.button.usage') }}
@@ -236,7 +236,7 @@
                     {{ $t('application.button.usage') }}
                   </el-button>
                   <el-button
-                    v-if="showPayment"
+                    v-if="rowCanPay(app)"
                     class="!m-0 !px-3"
                     type="primary"
                     round


### PR DESCRIPTION
The applications list has a separate **mobile** layout (`block sm:hidden`) that phones render. Its Buy More button still referenced `showPayment`, a computed removed in the earlier table refactor → `undefined` → Top Up hidden on iOS. Now uses `rowCanPay(app)` like the desktop table. Also fixed the global-balance card text overflow (the flex text child needed `min-w-0` to wrap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)