### PR TITLE
i18n(service): add missing Count unit translations

### DIFF
--- a/change/@acedatacloud-nexior-001aae42-fd66-4a07-a789-9a3dd9b11d4b.json
+++ b/change/@acedatacloud-nexior-001aae42-fd66-4a07-a789-9a3dd9b11d4b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "i18n: add missing Count unit translations",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/i18n/ar/service.json
+++ b/src/i18n/ar/service.json
@@ -123,6 +123,22 @@
     "message": "استدعاءات",
     "description": "الاستدعاءات هي عدد مرات استدعاء خدمة API، هذه هي الصيغة الكبيرة والجمع."
   },
+  "unit.count": {
+    "message": "مرة",
+    "description": "Count unit (number of API calls), singular."
+  },
+  "unit.Count": {
+    "message": "مرة",
+    "description": "Count unit (number of API calls), singular."
+  },
+  "unit.counts": {
+    "message": "مرات",
+    "description": "Count unit (number of API calls), plural."
+  },
+  "unit.Counts": {
+    "message": "مرات",
+    "description": "Count unit (number of API calls), plural."
+  },
   "unit.MB": {
     "message": "ميغابايت",
     "description": "ميغابايت تعني وحدة تخزين المعلومات الرقمية."

--- a/src/i18n/de/service.json
+++ b/src/i18n/de/service.json
@@ -123,6 +123,22 @@
     "message": "Aufrufe",
     "description": "Aufrufe sind die Anzahl der Aufrufe des API-Dienstes, dies ist die Großschreibung und Pluralform."
   },
+  "unit.count": {
+    "message": "Mal",
+    "description": "Count unit (number of API calls), singular."
+  },
+  "unit.Count": {
+    "message": "Mal",
+    "description": "Count unit (number of API calls), singular."
+  },
+  "unit.counts": {
+    "message": "Mal",
+    "description": "Count unit (number of API calls), plural."
+  },
+  "unit.Counts": {
+    "message": "Mal",
+    "description": "Count unit (number of API calls), plural."
+  },
   "unit.MB": {
     "message": "MB",
     "description": "MB steht für Megabyte, eine Einheit zur Speicherung digitaler Informationen."

--- a/src/i18n/el/service.json
+++ b/src/i18n/el/service.json
@@ -123,6 +123,22 @@
     "message": "Κλήσεις",
     "description": "Οι κλήσεις είναι ο αριθμός των φορών που καλείται η υπηρεσία API, αυτή είναι η κεφαλαία και πληθυντική μορφή."
   },
+  "unit.count": {
+    "message": "φορά",
+    "description": "Count unit (number of API calls), singular."
+  },
+  "unit.Count": {
+    "message": "φορά",
+    "description": "Count unit (number of API calls), singular."
+  },
+  "unit.counts": {
+    "message": "φορές",
+    "description": "Count unit (number of API calls), plural."
+  },
+  "unit.Counts": {
+    "message": "φορές",
+    "description": "Count unit (number of API calls), plural."
+  },
   "unit.MB": {
     "message": "MB",
     "description": "Το MB σημαίνει megabyte, μονάδα αποθήκευσης ψηφιακών πληροφοριών."

--- a/src/i18n/en/service.json
+++ b/src/i18n/en/service.json
@@ -123,6 +123,22 @@
     "message": "Calls",
     "description": "Calls are the number of times the API service is invoked, in uppercase and plural form."
   },
+  "unit.count": {
+    "message": "Count",
+    "description": "Count unit (number of API calls), singular."
+  },
+  "unit.Count": {
+    "message": "Count",
+    "description": "Count unit (number of API calls), singular."
+  },
+  "unit.counts": {
+    "message": "Counts",
+    "description": "Count unit (number of API calls), plural."
+  },
+  "unit.Counts": {
+    "message": "Counts",
+    "description": "Count unit (number of API calls), plural."
+  },
   "unit.MB": {
     "message": "MB",
     "description": "MB stands for megabyte, a unit of digital information storage."

--- a/src/i18n/es/service.json
+++ b/src/i18n/es/service.json
@@ -123,6 +123,22 @@
     "message": "Llamadas",
     "description": "Las llamadas son el número de veces que se invoca el servicio de API, esta es la forma en mayúscula y plural."
   },
+  "unit.count": {
+    "message": "vez",
+    "description": "Count unit (number of API calls), singular."
+  },
+  "unit.Count": {
+    "message": "vez",
+    "description": "Count unit (number of API calls), singular."
+  },
+  "unit.counts": {
+    "message": "veces",
+    "description": "Count unit (number of API calls), plural."
+  },
+  "unit.Counts": {
+    "message": "veces",
+    "description": "Count unit (number of API calls), plural."
+  },
   "unit.MB": {
     "message": "MB",
     "description": "MB significa megabyte, una unidad de almacenamiento de información digital."

--- a/src/i18n/fi/service.json
+++ b/src/i18n/fi/service.json
@@ -123,6 +123,22 @@
     "message": "Kutsut",
     "description": "Kutsu on API-palvelun kutsumiskertojen määrä, tämä on iso ja monikkomuoto."
   },
+  "unit.count": {
+    "message": "kerta",
+    "description": "Count unit (number of API calls), singular."
+  },
+  "unit.Count": {
+    "message": "kerta",
+    "description": "Count unit (number of API calls), singular."
+  },
+  "unit.counts": {
+    "message": "kertaa",
+    "description": "Count unit (number of API calls), plural."
+  },
+  "unit.Counts": {
+    "message": "kertaa",
+    "description": "Count unit (number of API calls), plural."
+  },
   "unit.MB": {
     "message": "MB",
     "description": "MB tarkoittaa megatavua, digitaalisen tiedon tallennusyksikkö."

--- a/src/i18n/fr/service.json
+++ b/src/i18n/fr/service.json
@@ -123,6 +123,22 @@
     "message": "Appels",
     "description": "Les appels sont le nombre de fois qu'un service API est appelé, c'est la forme majuscule et plurielle."
   },
+  "unit.count": {
+    "message": "fois",
+    "description": "Count unit (number of API calls), singular."
+  },
+  "unit.Count": {
+    "message": "fois",
+    "description": "Count unit (number of API calls), singular."
+  },
+  "unit.counts": {
+    "message": "fois",
+    "description": "Count unit (number of API calls), plural."
+  },
+  "unit.Counts": {
+    "message": "fois",
+    "description": "Count unit (number of API calls), plural."
+  },
   "unit.MB": {
     "message": "Mo",
     "description": "Mo signifie mégaoctet, une unité de stockage d'informations numériques."

--- a/src/i18n/it/service.json
+++ b/src/i18n/it/service.json
@@ -123,6 +123,22 @@
     "message": "Chiamate",
     "description": "Le chiamate sono il numero di volte in cui il servizio API viene chiamato, questa è la forma maiuscola e plurale."
   },
+  "unit.count": {
+    "message": "volta",
+    "description": "Count unit (number of API calls), singular."
+  },
+  "unit.Count": {
+    "message": "volta",
+    "description": "Count unit (number of API calls), singular."
+  },
+  "unit.counts": {
+    "message": "volte",
+    "description": "Count unit (number of API calls), plural."
+  },
+  "unit.Counts": {
+    "message": "volte",
+    "description": "Count unit (number of API calls), plural."
+  },
   "unit.MB": {
     "message": "MB",
     "description": "MB significa megabyte, un'unità di misura per la memorizzazione di informazioni digitali."

--- a/src/i18n/ja/service.json
+++ b/src/i18n/ja/service.json
@@ -123,6 +123,22 @@
     "message": "呼び出し",
     "description": "呼び出しはAPIサービスが呼び出される回数、これは大文字と複数形。"
   },
+  "unit.count": {
+    "message": "回",
+    "description": "Count unit (number of API calls), singular."
+  },
+  "unit.Count": {
+    "message": "回",
+    "description": "Count unit (number of API calls), singular."
+  },
+  "unit.counts": {
+    "message": "回",
+    "description": "Count unit (number of API calls), plural."
+  },
+  "unit.Counts": {
+    "message": "回",
+    "description": "Count unit (number of API calls), plural."
+  },
   "unit.MB": {
     "message": "MB",
     "description": "MBはメガバイトを意味し、デジタル情報の保存単位。"

--- a/src/i18n/ko/service.json
+++ b/src/i18n/ko/service.json
@@ -123,6 +123,22 @@
     "message": "호출",
     "description": "호출은 API 서비스가 호출된 횟수로, 대문자와 복수형입니다."
   },
+  "unit.count": {
+    "message": "회",
+    "description": "Count unit (number of API calls), singular."
+  },
+  "unit.Count": {
+    "message": "회",
+    "description": "Count unit (number of API calls), singular."
+  },
+  "unit.counts": {
+    "message": "회",
+    "description": "Count unit (number of API calls), plural."
+  },
+  "unit.Counts": {
+    "message": "회",
+    "description": "Count unit (number of API calls), plural."
+  },
   "unit.MB": {
     "message": "MB",
     "description": "MB는 메가바이트를 의미하며, 디지털 정보 저장 단위입니다."

--- a/src/i18n/pl/service.json
+++ b/src/i18n/pl/service.json
@@ -123,6 +123,22 @@
     "message": "Wywołania",
     "description": "Wywołania to liczba razy, kiedy usługa API została wywołana, w formie wielkiej litery i liczby mnogiej."
   },
+  "unit.count": {
+    "message": "raz",
+    "description": "Count unit (number of API calls), singular."
+  },
+  "unit.Count": {
+    "message": "raz",
+    "description": "Count unit (number of API calls), singular."
+  },
+  "unit.counts": {
+    "message": "razy",
+    "description": "Count unit (number of API calls), plural."
+  },
+  "unit.Counts": {
+    "message": "razy",
+    "description": "Count unit (number of API calls), plural."
+  },
   "unit.MB": {
     "message": "MB",
     "description": "MB oznacza megabajt, jednostka przechowywania informacji cyfrowych."

--- a/src/i18n/pt/service.json
+++ b/src/i18n/pt/service.json
@@ -123,6 +123,22 @@
     "message": "Chamadas",
     "description": "Chamadas é o número de vezes que o serviço de API é chamado, esta é a forma maiúscula e plural."
   },
+  "unit.count": {
+    "message": "vez",
+    "description": "Count unit (number of API calls), singular."
+  },
+  "unit.Count": {
+    "message": "vez",
+    "description": "Count unit (number of API calls), singular."
+  },
+  "unit.counts": {
+    "message": "vezes",
+    "description": "Count unit (number of API calls), plural."
+  },
+  "unit.Counts": {
+    "message": "vezes",
+    "description": "Count unit (number of API calls), plural."
+  },
   "unit.MB": {
     "message": "MB",
     "description": "MB significa megabyte, uma unidade de armazenamento de informações digitais."

--- a/src/i18n/ru/service.json
+++ b/src/i18n/ru/service.json
@@ -123,6 +123,22 @@
     "message": "Вызовы",
     "description": "Вызовы - это количество обращений к API сервису, это заглавная и множественная форма."
   },
+  "unit.count": {
+    "message": "раз",
+    "description": "Count unit (number of API calls), singular."
+  },
+  "unit.Count": {
+    "message": "раз",
+    "description": "Count unit (number of API calls), singular."
+  },
+  "unit.counts": {
+    "message": "раза",
+    "description": "Count unit (number of API calls), plural."
+  },
+  "unit.Counts": {
+    "message": "раза",
+    "description": "Count unit (number of API calls), plural."
+  },
   "unit.MB": {
     "message": "МБ",
     "description": "МБ означает мегабайт, единица хранения цифровой информации."

--- a/src/i18n/sr/service.json
+++ b/src/i18n/sr/service.json
@@ -123,6 +123,22 @@
     "message": "Pozivi",
     "description": "Pozivi su broj puta kada je API usluga pozvana, ovo je velika i množina forma."
   },
+  "unit.count": {
+    "message": "пут",
+    "description": "Count unit (number of API calls), singular."
+  },
+  "unit.Count": {
+    "message": "пут",
+    "description": "Count unit (number of API calls), singular."
+  },
+  "unit.counts": {
+    "message": "пута",
+    "description": "Count unit (number of API calls), plural."
+  },
+  "unit.Counts": {
+    "message": "пута",
+    "description": "Count unit (number of API calls), plural."
+  },
   "unit.MB": {
     "message": "MB",
     "description": "MB označava megabajt, jedinicu za skladištenje digitalnih informacija."

--- a/src/i18n/sv/service.json
+++ b/src/i18n/sv/service.json
@@ -123,6 +123,22 @@
     "message": "Anrop",
     "description": "Anrop är antalet gånger API-tjänsten har anropats, detta är den stora bokstaven och pluralformen."
   },
+  "unit.count": {
+    "message": "gång",
+    "description": "Count unit (number of API calls), singular."
+  },
+  "unit.Count": {
+    "message": "gång",
+    "description": "Count unit (number of API calls), singular."
+  },
+  "unit.counts": {
+    "message": "gånger",
+    "description": "Count unit (number of API calls), plural."
+  },
+  "unit.Counts": {
+    "message": "gånger",
+    "description": "Count unit (number of API calls), plural."
+  },
   "unit.MB": {
     "message": "MB",
     "description": "MB står för megabyte, en enhet för lagring av digital information."

--- a/src/i18n/uk/service.json
+++ b/src/i18n/uk/service.json
@@ -123,6 +123,22 @@
     "message": "Виклики",
     "description": "Виклики - це кількість разів, коли API-сервіс був викликаний, це велика і множинна форма."
   },
+  "unit.count": {
+    "message": "раз",
+    "description": "Count unit (number of API calls), singular."
+  },
+  "unit.Count": {
+    "message": "раз",
+    "description": "Count unit (number of API calls), singular."
+  },
+  "unit.counts": {
+    "message": "рази",
+    "description": "Count unit (number of API calls), plural."
+  },
+  "unit.Counts": {
+    "message": "рази",
+    "description": "Count unit (number of API calls), plural."
+  },
   "unit.MB": {
     "message": "МБ",
     "description": "МБ означає мегабайт, одиниця зберігання цифрової інформації."

--- a/src/i18n/zh-CN/service.json
+++ b/src/i18n/zh-CN/service.json
@@ -123,6 +123,22 @@
     "message": "调用",
     "description": "调用是 API 服务被调用的次数，这是大写和复数形式。"
   },
+  "unit.count": {
+    "message": "次",
+    "description": "Count unit (number of API calls), singular."
+  },
+  "unit.Count": {
+    "message": "次",
+    "description": "Count unit (number of API calls), singular."
+  },
+  "unit.counts": {
+    "message": "次",
+    "description": "Count unit (number of API calls), plural."
+  },
+  "unit.Counts": {
+    "message": "次",
+    "description": "Count unit (number of API calls), plural."
+  },
   "unit.MB": {
     "message": "MB",
     "description": "MB 意味着兆字节，数字信息存储的单位。"

--- a/src/i18n/zh-TW/service.json
+++ b/src/i18n/zh-TW/service.json
@@ -123,6 +123,22 @@
     "message": "调用",
     "description": "调用是 API 服务被调用的次数，这是大写和复数形式。"
   },
+  "unit.count": {
+    "message": "次",
+    "description": "Count unit (number of API calls), singular."
+  },
+  "unit.Count": {
+    "message": "次",
+    "description": "Count unit (number of API calls), singular."
+  },
+  "unit.counts": {
+    "message": "次",
+    "description": "Count unit (number of API calls), plural."
+  },
+  "unit.Counts": {
+    "message": "次",
+    "description": "Count unit (number of API calls), plural."
+  },
   "unit.MB": {
     "message": "MB",
     "description": "MB 意味着兆字节，数字信息存储的单位。"


### PR DESCRIPTION
The `Count` service unit (33 services, e.g. WeChat Bot) had no `unit.Count`/`unit.Counts` key, so balances rendered the raw key `service.unit.Counts`. Added `count/Count/counts/Counts` across all 18 locales (Chinese 次, English Count/Counts, etc.). Coverage check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)