### PR TITLE
fix(grokvideo): point service id at merged grok service

### DIFF
--- a/change/@acedatacloud-nexior-grok-video-merge.json
+++ b/change/@acedatacloud-nexior-grok-video-merge.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(grokvideo): point service id at the merged grok service (PlatformBackend#702)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/constants/grokvideo.ts
+++ b/src/constants/grokvideo.ts
@@ -1,4 +1,5 @@
-export const GROKVIDEO_SERVICE_ID = 'a270a291-7cbc-44a6-88b9-80334e3e95a0';
+// Video lives under the merged `grok` service (PlatformBackend migration 0176).
+export const GROKVIDEO_SERVICE_ID = 'cbfe0ade-0b4e-4c42-83f4-3e2d5b429545';
 
 export const GROKVIDEO_LOGO = 'https://cdn.acedata.cloud/p1ge98.png';
 


### PR DESCRIPTION
## What

Repoints `GROKVIDEO_SERVICE_ID` from the standalone `grok-video` service (`a270a291…`) to the merged **`grok`** service (`cbfe0ade…`).

## Why

PlatformBackend [#702](https://github.com/AceDataCloud/PlatformBackend/pull/702) folds the `grok-video` service into `grok` — the video APIs (`/grok/videos`, `/grok/tasks`) now belong to the `grok` service, and the `grok-video` service is deleted. Studio's video page fetches its application/credential **by service id**, so it must point at `grok` or it breaks once the backend service is gone.

The API paths are unchanged; only the service the credential is scoped to changes.

## Deploy order

Merge/deploy **PlatformBackend#702 first**, then this. Usage is tiny (3 empty apps, 24 total calls), so the transient window is negligible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)