### PR TITLE
feat(maestro): consumer module for the article→video service

### DIFF
--- a/change/@acedatacloud-nexior-24d76d75-b3e3-4f89-8d77-103a9b84560a.json
+++ b/change/@acedatacloud-nexior-24d76d75-b3e3-4f89-8d77-103a9b84560a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(maestro): consumer module for the article-to-video service",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/Navigator.vue
+++ b/src/components/common/Navigator.vue
@@ -87,6 +87,7 @@ import {
   ROUTE_VEO_INDEX,
   ROUTE_VEO_HISTORY,
   ROUTE_SORA_INDEX,
+  ROUTE_MAESTRO_INDEX,
   ROUTE_SORA_HISTORY,
   ROUTE_NANOBANANA_INDEX,
   ROUTE_OPENAIIMAGE_INDEX,
@@ -125,6 +126,7 @@ import {
   KLING_LOGO,
   VEO_LOGO,
   SORA_LOGO,
+  MAESTRO_LOGO,
   PIXVERSE_LOGO,
   WAN_LOGO,
   PRODUCER_LOGO,
@@ -354,6 +356,15 @@ export default defineComponent({
           displayName: this.$t('common.nav.veo'),
           logo: VEO_LOGO,
           routes: [ROUTE_VEO_INDEX, ROUTE_VEO_HISTORY],
+          category: 'video'
+        });
+      }
+      if (this.$store?.state?.site?.features?.maestro?.enabled) {
+        result.push({
+          route: { name: ROUTE_MAESTRO_INDEX },
+          displayName: this.$t('common.nav.maestro'),
+          logo: MAESTRO_LOGO,
+          routes: [ROUTE_MAESTRO_INDEX],
           category: 'video'
         });
       }

--- a/src/components/maestro/ConfigPanel.vue
+++ b/src/components/maestro/ConfigPanel.vue
@@ -1,0 +1,212 @@
+<template>
+  <div class="flex flex-col h-full">
+    <div class="flex-1 overflow-y-auto p-5">
+      <!-- Source type -->
+      <div class="mb-4">
+        <span class="text-sm font-bold mb-2 block">{{ $t('maestro.name.sourceType') }}</span>
+        <el-radio-group v-model="sourceType" class="w-full">
+          <el-radio-button :value="MAESTRO_SOURCE_TYPE_TOPIC">{{ $t('maestro.option.topic') }}</el-radio-button>
+          <el-radio-button :value="MAESTRO_SOURCE_TYPE_ARTICLE">{{ $t('maestro.option.article') }}</el-radio-button>
+        </el-radio-group>
+      </div>
+
+      <!-- Source content -->
+      <div class="mb-4">
+        <span class="text-sm font-bold mb-2 block">{{ $t('maestro.name.sourceRef') }}</span>
+        <el-input v-model="sourceRef" type="textarea" :rows="5" :placeholder="$t('maestro.placeholder.sourceRef')" />
+        <p class="text-xs text-[var(--el-text-color-secondary)] mt-1">{{ $t('maestro.description.sourceRef') }}</p>
+      </div>
+
+      <!-- Main language -->
+      <div class="mb-4">
+        <span class="text-sm font-bold mb-2 block">{{ $t('maestro.name.lang') }}</span>
+        <el-select v-model="lang" :placeholder="$t('maestro.placeholder.select')" class="w-full">
+          <el-option v-for="l in MAESTRO_ALLOWED_LANGS" :key="l" :label="l" :value="l" />
+        </el-select>
+      </div>
+
+      <!-- Extra languages -->
+      <div class="mb-4">
+        <span class="text-sm font-bold mb-2 block">{{ $t('maestro.name.extraLangs') }}</span>
+        <el-select
+          v-model="extraLangs"
+          multiple
+          collapse-tags
+          :placeholder="$t('maestro.placeholder.select')"
+          class="w-full"
+        >
+          <el-option v-for="l in extraLangOptions" :key="l" :label="l" :value="l" />
+        </el-select>
+        <p class="text-xs text-[var(--el-text-color-secondary)] mt-1">{{ $t('maestro.description.extraLangs') }}</p>
+      </div>
+
+      <!-- Aspect ratio -->
+      <div class="mb-4">
+        <span class="text-sm font-bold mb-2 block">{{ $t('maestro.name.aspect') }}</span>
+        <el-radio-group v-model="aspect" class="w-full">
+          <el-radio-button v-for="a in MAESTRO_ALLOWED_ASPECTS" :key="a" :value="a">{{ a }}</el-radio-button>
+        </el-radio-group>
+      </div>
+
+      <!-- Duration -->
+      <div class="mb-4">
+        <span class="text-sm font-bold mb-2 block">{{ $t('maestro.name.duration') }}</span>
+        <el-select v-model="duration" class="w-full">
+          <el-option v-for="d in MAESTRO_ALLOWED_DURATIONS" :key="d" :label="`${d}s`" :value="d" />
+        </el-select>
+      </div>
+
+      <!-- Music -->
+      <div class="mb-2 flex items-center justify-between">
+        <span class="text-sm font-bold">{{ $t('maestro.name.music') }}</span>
+        <el-switch v-model="music" />
+      </div>
+    </div>
+
+    <div class="flex flex-col items-center justify-center px-5 pb-5">
+      <consumption :value="consumption" :service="service" />
+      <el-button type="primary" class="btn w-full" round :disabled="!sourceRef" @click="onGenerate">
+        <font-awesome-icon icon="fa-solid fa-magic" class="mr-2" />
+        {{ $t('maestro.button.generate') }}
+      </el-button>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElButton, ElInput, ElSelect, ElOption, ElRadioGroup, ElRadioButton, ElSwitch } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import Consumption from '../common/Consumption.vue';
+import { getConsumption } from '@/utils';
+import {
+  MAESTRO_SOURCE_TYPE_TOPIC,
+  MAESTRO_SOURCE_TYPE_ARTICLE,
+  MAESTRO_ALLOWED_LANGS,
+  MAESTRO_ALLOWED_ASPECTS,
+  MAESTRO_ALLOWED_DURATIONS,
+  MAESTRO_DEFAULT_SOURCE_TYPE,
+  MAESTRO_DEFAULT_LANG,
+  MAESTRO_DEFAULT_ASPECT,
+  MAESTRO_DEFAULT_DURATION,
+  MAESTRO_DEFAULT_MUSIC
+} from '@/constants';
+import { IMaestroConfig } from '@/models';
+
+export default defineComponent({
+  name: 'ConfigPanel',
+  components: {
+    ElButton,
+    ElInput,
+    ElSelect,
+    ElOption,
+    ElRadioGroup,
+    ElRadioButton,
+    ElSwitch,
+    Consumption,
+    FontAwesomeIcon
+  },
+  emits: ['generate'],
+  data() {
+    return {
+      MAESTRO_SOURCE_TYPE_TOPIC,
+      MAESTRO_SOURCE_TYPE_ARTICLE,
+      MAESTRO_ALLOWED_LANGS,
+      MAESTRO_ALLOWED_ASPECTS,
+      MAESTRO_ALLOWED_DURATIONS
+    };
+  },
+  computed: {
+    config(): IMaestroConfig | undefined {
+      return this.$store.state.maestro?.config;
+    },
+    service() {
+      return this.$store.state.maestro?.service;
+    },
+    consumption() {
+      return getConsumption(this.config, this.service?.cost);
+    },
+    extraLangOptions(): string[] {
+      return MAESTRO_ALLOWED_LANGS.filter((l) => l !== this.lang);
+    },
+    sourceType: {
+      get(): string | undefined {
+        return this.config?.source_type;
+      },
+      set(val: string) {
+        this.update({ source_type: val });
+      }
+    },
+    sourceRef: {
+      get(): string | undefined {
+        return this.config?.source_ref;
+      },
+      set(val: string) {
+        this.update({ source_ref: val });
+      }
+    },
+    lang: {
+      get(): string | undefined {
+        return this.config?.lang;
+      },
+      set(val: string) {
+        // drop the new main language from extra_langs to avoid duplicate renders
+        const extra = (this.config?.extra_langs || []).filter((l) => l !== val);
+        this.update({ lang: val, extra_langs: extra });
+      }
+    },
+    extraLangs: {
+      get(): string[] {
+        return this.config?.extra_langs || [];
+      },
+      set(val: string[]) {
+        this.update({ extra_langs: val });
+      }
+    },
+    aspect: {
+      get(): string | undefined {
+        return this.config?.aspect;
+      },
+      set(val: string) {
+        this.update({ aspect: val });
+      }
+    },
+    duration: {
+      get(): number | undefined {
+        return this.config?.duration;
+      },
+      set(val: number) {
+        this.update({ duration: val });
+      }
+    },
+    music: {
+      get(): boolean {
+        return this.config?.music ?? true;
+      },
+      set(val: boolean) {
+        this.update({ music: val });
+      }
+    }
+  },
+  mounted() {
+    this.update({
+      source_type: this.config?.source_type ?? MAESTRO_DEFAULT_SOURCE_TYPE,
+      lang: this.config?.lang ?? MAESTRO_DEFAULT_LANG,
+      aspect: this.config?.aspect ?? MAESTRO_DEFAULT_ASPECT,
+      duration: this.config?.duration ?? MAESTRO_DEFAULT_DURATION,
+      music: this.config?.music ?? MAESTRO_DEFAULT_MUSIC
+    });
+  },
+  methods: {
+    update(patch: Partial<IMaestroConfig>) {
+      this.$store.commit('maestro/setConfig', {
+        ...this.config,
+        ...patch
+      });
+    },
+    onGenerate() {
+      this.$emit('generate');
+    }
+  }
+});
+</script>

--- a/src/components/maestro/RecentPanel.vue
+++ b/src/components/maestro/RecentPanel.vue
@@ -1,0 +1,56 @@
+<template>
+  <div v-if="tasks?.items === undefined">
+    <bot-placeholder />
+  </div>
+  <scroll-list
+    v-else-if="tasks?.items?.length && tasks?.items?.length > 0"
+    ref="scrollList"
+    class="tasks h-full w-full overflow-y-auto"
+    :loading="loading"
+    @reach-top="$emit('reach-top')"
+  >
+    <task-preview v-for="(task, taskIndex) in tasks?.items" :key="taskIndex" :model-value="task" />
+  </scroll-list>
+  <div v-if="tasks?.items?.length === 0" class="w-full h-full flex items-center justify-center">
+    <no-tasks />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import TaskPreview from './task/Preview.vue';
+import BotPlaceholder from '@/components/common/BotPlaceholder.vue';
+import NoTasks from '@/components/common/NoTasks.vue';
+import ScrollList from '@/components/common/ScrollList.vue';
+
+export default defineComponent({
+  name: 'RecentPanel',
+  components: {
+    TaskPreview,
+    NoTasks,
+    BotPlaceholder,
+    ScrollList
+  },
+  props: {
+    loading: {
+      type: Boolean,
+      default: false
+    }
+  },
+  emits: ['reach-top'],
+  computed: {
+    tasks() {
+      return {
+        ...this.$store.state.maestro?.tasks,
+        items: this.$store.state.maestro?.tasks?.items?.slice()
+      };
+    }
+  },
+  methods: {
+    getScrollElement(): HTMLElement | undefined {
+      const list = this.$refs.scrollList as any;
+      return list?.getScrollElement?.();
+    }
+  }
+});
+</script>

--- a/src/components/maestro/task/Preview.vue
+++ b/src/components/maestro/task/Preview.vue
@@ -1,0 +1,232 @@
+<template>
+  <div class="preview">
+    <div class="left">
+      <el-image :src="MAESTRO_LOGO" class="avatar" />
+    </div>
+    <div class="main">
+      <div class="bot">
+        {{ $t('maestro.name.maestroBot') }}
+        <span class="datetime">
+          {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
+        </span>
+      </div>
+      <div class="info">
+        <p v-if="modelValue?.request?.source_ref" class="prompt mt-2">
+          {{ modelValue?.request?.source_ref }}
+          <span v-if="!isTerminal"> - ({{ statusLabel }}) </span>
+        </p>
+      </div>
+
+      <!-- success: one player per language variant -->
+      <div v-if="modelValue?.response?.success === true && variants.length" class="content">
+        <div v-for="(variant, vi) in variants" :key="vi" class="mb-4">
+          <p class="text-xs text-[var(--el-text-color-secondary)] mb-1">
+            <font-awesome-icon icon="fa-solid fa-language" class="mr-1" />{{ variant.lang }}
+          </p>
+          <video-player v-if="variant.output_url" :src="variant.output_url" />
+          <div class="operations mt-2">
+            <el-button
+              v-if="variant.output_url"
+              type="info"
+              size="small"
+              class="btn-action"
+              @click="onDownload($event, variant.output_url)"
+            >
+              {{ $t('maestro.button.download') }}
+            </el-button>
+            <el-button
+              v-if="variant.captions_url"
+              size="small"
+              class="btn-action"
+              @click="onDownload($event, variant.captions_url)"
+            >
+              {{ $t('maestro.button.downloadCaptions') }}
+            </el-button>
+          </div>
+        </div>
+        <div class="operations">
+          <api-code-button path="/maestro/videos" :body="modelValue?.request" />
+        </div>
+        <el-alert :closable="false" class="mt-2 success">
+          <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-magic" class="mr-1" />
+            {{ $t('maestro.name.taskId') }}: {{ modelValue?.id }}
+            <copy-to-clipboard :content="modelValue?.id!" />
+          </p>
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-0">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('maestro.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
+          </p>
+        </el-alert>
+      </div>
+
+      <!-- failure -->
+      <div v-if="modelValue?.response?.success === false" class="content">
+        <el-alert :closable="false" class="failure">
+          <template #template>
+            <font-awesome-icon icon="fa-solid fa-exclamation-triangle" class="mr-1" />
+            {{ $t('maestro.name.failure') }}
+          </template>
+          <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-magic" class="mr-1" />
+            {{ $t('maestro.name.taskId') }}: {{ modelValue?.id }}
+            <copy-to-clipboard :content="modelValue?.id!" />
+          </p>
+          <p v-if="failureReason" class="text-[var(--el-text-color-regular)] text-xs mb-0">
+            <font-awesome-icon icon="fa-solid fa-circle-info" class="mr-1" />
+            {{ $t('maestro.name.failureReason') }}: {{ failureReason }}
+          </p>
+        </el-alert>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElImage, ElAlert, ElButton } from 'element-plus';
+import { IMaestroTask, IMaestroVariant } from '@/models';
+import { MAESTRO_LOGO } from '@/constants';
+import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import VideoPlayer from '@/components/common/VideoPlayer.vue';
+import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
+
+const TERMINAL = ['succeeded', 'failed'];
+
+export default defineComponent({
+  name: 'TaskPreview',
+  components: {
+    ElImage,
+    CopyToClipboard,
+    FontAwesomeIcon,
+    ElAlert,
+    VideoPlayer,
+    ElButton,
+    ApiCodeButton
+  },
+  props: {
+    modelValue: {
+      type: Object as () => IMaestroTask | undefined,
+      required: true
+    }
+  },
+  data() {
+    return {
+      MAESTRO_LOGO
+    };
+  },
+  computed: {
+    variants(): IMaestroVariant[] {
+      return this.modelValue?.response?.data?.variants || [];
+    },
+    isTerminal(): boolean {
+      return TERMINAL.includes(this.modelValue?.status || '');
+    },
+    statusLabel(): string {
+      const s = this.modelValue?.status || 'pending';
+      const key = `maestro.status.${s}`;
+      const label = this.$t(key);
+      return label === key ? (this.$t('maestro.status.processing') as string) : (label as string);
+    },
+    failureReason(): string | undefined {
+      const err = this.modelValue?.response?.error;
+      if (!err) return undefined;
+      return typeof err === 'string' ? err : err?.message;
+    }
+  },
+  methods: {
+    onDownload(event: MouseEvent, url: string) {
+      event?.stopPropagation();
+      window.open(url, '_blank');
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+$left-width: 70px;
+.preview {
+  width: 100%;
+  height: fit-content;
+  text-align: left;
+  display: flex;
+  flex-direction: row;
+  margin-bottom: 15px;
+  .left {
+    width: $left-width;
+    .avatar {
+      width: 50px;
+      height: 50px;
+      margin: 10px;
+      border-radius: 50%;
+    }
+  }
+
+  .main {
+    flex: 1;
+    width: calc(100% - $left-width);
+    min-width: 0;
+    padding: 10px 10px 0 10px;
+
+    .bot {
+      font-size: 16px;
+      font-weight: bold;
+      color: var(--el-color-primary);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      .datetime {
+        font-size: 12px;
+        font-weight: normal;
+        color: var(--el-text-color-secondary);
+        margin-left: 10px;
+      }
+    }
+
+    .info {
+      overflow: hidden;
+      .prompt {
+        font-size: 16px;
+        font-weight: bold;
+        color: var(--el-text-color-regular);
+        margin-bottom: 10px;
+        white-space: normal;
+        word-break: break-word;
+        overflow-wrap: anywhere;
+      }
+    }
+
+    .content {
+      word-break: break-word;
+      overflow-wrap: anywhere;
+
+      .el-alert {
+        border-left-width: 2px;
+        border-left-style: solid;
+        &.failure {
+          border-color: var(--el-color-danger);
+        }
+        &.success {
+          border-color: var(--el-color-success);
+        }
+        :deep(p:last-child) {
+          margin-bottom: 0;
+        }
+      }
+    }
+
+    .operations {
+      display: flex;
+      justify-content: left;
+      flex-direction: row;
+      width: 100%;
+      align-items: baseline;
+      flex-wrap: wrap;
+      .btn-action {
+        margin-bottom: 10px;
+      }
+    }
+  }
+}
+</style>

--- a/src/constants/i18n.ts
+++ b/src/constants/i18n.ts
@@ -31,6 +31,7 @@ export const I18N_SCOPES = [
   'kling',
   'veo',
   'sora',
+  'maestro',
   'pixverse',
   'flux',
   'nanobanana',

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -10,6 +10,7 @@ export * from './pika';
 export * from './kling';
 export * from './veo';
 export * from './sora';
+export * from './maestro';
 export * from './pixverse';
 export * from './flux';
 export * from './hailuo';

--- a/src/constants/maestro.ts
+++ b/src/constants/maestro.ts
@@ -1,0 +1,17 @@
+export const MAESTRO_SERVICE_ID = '0d7031bf-610a-419e-a5a0-db8f240286d5';
+
+export const MAESTRO_LOGO = 'https://cdn.acedata.cloud/ae064d6b6c.svg';
+
+export const MAESTRO_SOURCE_TYPE_TOPIC = 'Topic';
+export const MAESTRO_SOURCE_TYPE_ARTICLE = 'Article';
+export const MAESTRO_ALLOWED_SOURCE_TYPES = [MAESTRO_SOURCE_TYPE_TOPIC, MAESTRO_SOURCE_TYPE_ARTICLE];
+
+export const MAESTRO_ALLOWED_ASPECTS = ['9:16', '16:9', '1:1'];
+export const MAESTRO_ALLOWED_LANGS = ['zh-cn', 'en', 'ja', 'ko', 'es', 'fr', 'de'];
+export const MAESTRO_ALLOWED_DURATIONS = [20, 30, 45, 60];
+
+export const MAESTRO_DEFAULT_SOURCE_TYPE = MAESTRO_SOURCE_TYPE_TOPIC;
+export const MAESTRO_DEFAULT_LANG = 'zh-cn';
+export const MAESTRO_DEFAULT_ASPECT = '9:16';
+export const MAESTRO_DEFAULT_DURATION = 30;
+export const MAESTRO_DEFAULT_MUSIC = true;

--- a/src/i18n/ar/common.json
+++ b/src/i18n/ar/common.json
@@ -1030,5 +1030,9 @@
   "appUpgrade.later": {
     "message": "Later",
     "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
+  },
+  "nav.maestro": {
+    "message": "مايسترو",
+    "description": "نص صفحة تحويل مقالات مايسترو إلى فيديو في شريط التنقل، يجب أن يبقى 'مايسترو'"
   }
 }

--- a/src/i18n/ar/maestro.json
+++ b/src/i18n/ar/maestro.json
@@ -1,0 +1,138 @@
+{
+  "name.maestroBot": {
+    "message": "مايسترو",
+    "description": "اسم عرض الروبوت"
+  },
+  "name.taskId": {
+    "message": "معرف المهمة",
+    "description": "معرف المهمة"
+  },
+  "name.status": {
+    "message": "الحالة",
+    "description": "حالة المهمة"
+  },
+  "name.elapsed": {
+    "message": "الوقت المستغرق",
+    "description": "الثواني المستغرقة"
+  },
+  "name.traceId": {
+    "message": "معرف التتبع",
+    "description": "معرف التتبع"
+  },
+  "name.failure": {
+    "message": "فشل",
+    "description": "حالة الفشل"
+  },
+  "name.failureReason": {
+    "message": "سبب الفشل",
+    "description": "سبب الفشل"
+  },
+  "name.sourceType": {
+    "message": "نوع المصدر",
+    "description": "حقل نوع المصدر"
+  },
+  "name.sourceRef": {
+    "message": "المحتوى",
+    "description": "حقل محتوى المصدر"
+  },
+  "name.lang": {
+    "message": "اللغة الرئيسية",
+    "description": "حقل اللغة الأساسية"
+  },
+  "name.extraLangs": {
+    "message": "لغات إضافية",
+    "description": "حقل النسخ اللغوية الإضافية"
+  },
+  "name.aspect": {
+    "message": "نسبة العرض إلى الارتفاع",
+    "description": "حقل نسبة العرض إلى الارتفاع"
+  },
+  "name.duration": {
+    "message": "المدة",
+    "description": "حقل المدة المستهدفة"
+  },
+  "name.music": {
+    "message": "الموسيقى الخلفية",
+    "description": "حقل تبديل الموسيقى"
+  },
+  "option.topic": {
+    "message": "موضوع",
+    "description": "نوع المصدر: موضوع/عنوان"
+  },
+  "option.article": {
+    "message": "مقالة",
+    "description": "نوع المصدر: نص المقال الكامل"
+  },
+  "placeholder.sourceRef": {
+    "message": "أدخل موضوعًا (مثل “ما هو قاعدة بيانات المتجهات”) أو الصق المقالة الكاملة...",
+    "description": "مكان حجز نص المصدر"
+  },
+  "placeholder.select": {
+    "message": "يرجى الاختيار",
+    "description": "نموذج عام لمكان حجز الاختيار"
+  },
+  "description.sourceRef": {
+    "message": "موضوع/عنوان، أو نص المقالة بالكامل الذي سيتم تحويله إلى فيديو.",
+    "description": "مساعدة حقل المصدر"
+  },
+  "description.extraLangs": {
+    "message": "إعادة استخدام المشهد، وإنتاج هذه النسخ اللغوية الإضافية (+6 نقاط لكل لغة).",
+    "description": "مساعدة اللغات الإضافية"
+  },
+  "status.pending": {
+    "message": "قيد الانتظار",
+    "description": "قيد الانتظار"
+  },
+  "status.scripting": {
+    "message": "يتم إنشاء السكربت",
+    "description": "يتم إنشاء السكربت"
+  },
+  "status.generating": {
+    "message": "يتم إنشاء الشاشة",
+    "description": "يتم إنشاء المحتوى"
+  },
+  "status.rendering": {
+    "message": "يتم العرض",
+    "description": "يتم عرض المحتوى"
+  },
+  "status.processing": {
+    "message": "يتم المعالجة",
+    "description": "يتم معالجة المحتوى"
+  },
+  "button.generate": {
+    "message": "إنشاء فيديو",
+    "description": "زر الإنشاء"
+  },
+  "button.download": {
+    "message": "تحميل الفيديو",
+    "description": "زر تحميل الفيديو"
+  },
+  "button.downloadCaptions": {
+    "message": "تحميل الترجمة",
+    "description": "زر تحميل ملف srt"
+  },
+  "message.startingTask": {
+    "message": "جارٍ تقديم مهمة الفيديو…",
+    "description": "تلميح التقديم"
+  },
+  "message.startTaskSuccess": {
+    "message": "تم تقديم المهمة! ستظهر تقدم الرندر أدناه.",
+    "description": "نجاح التقديم"
+  },
+  "message.startTaskFailed": {
+    "message": "فشل تقديم المهمة، يرجى المحاولة مرة أخرى.",
+    "description": "فشل التقديم"
+  },
+  "message.usedUp": {
+    "message": "تم استنفاد الرصيد، يرجى إعادة الشحن للمتابعة.",
+    "description": "تم الاستنفاد"
+  },
+  "message.downloadVideo": {
+    "message": "تحميل الفيديو الذي تم إنشاؤه",
+    "description": "تلميح التحميل"
+  },
+  "message.noTasks": {
+    "message": "لا توجد فيديوهات بعد — قم بإنشاء أول فيديو لك على اليسار.",
+    "description": "لا توجد مهام"
+  }
+}

--- a/src/i18n/de/common.json
+++ b/src/i18n/de/common.json
@@ -1030,5 +1030,9 @@
   "appUpgrade.later": {
     "message": "Later",
     "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
+  },
+  "nav.maestro": {
+    "message": "Maestro",
+    "description": "Text auf der Navigationsleiste für die Seite, die Artikel in Videos umwandelt, bleibt 'Maestro'"
   }
 }

--- a/src/i18n/de/maestro.json
+++ b/src/i18n/de/maestro.json
@@ -1,0 +1,138 @@
+{
+  "name.maestroBot": {
+    "message": "Maestro",
+    "description": "Anzeigename des Bots"
+  },
+  "name.taskId": {
+    "message": "Aufgaben-ID",
+    "description": "ID der Aufgabe"
+  },
+  "name.status": {
+    "message": "Status",
+    "description": "Aufgabenstatus"
+  },
+  "name.elapsed": {
+    "message": "Verstrichene Zeit",
+    "description": "Verstrichene Sekunden"
+  },
+  "name.traceId": {
+    "message": "Verfolgungs-ID",
+    "description": "Verfolgungs-ID"
+  },
+  "name.failure": {
+    "message": "Fehler",
+    "description": "Status für Fehler"
+  },
+  "name.failureReason": {
+    "message": "Fehlerursache",
+    "description": "Grund für den Fehler"
+  },
+  "name.sourceType": {
+    "message": "Quelltyp",
+    "description": "Feld für den Quelltyp"
+  },
+  "name.sourceRef": {
+    "message": "Inhalt",
+    "description": "Feld für den Quellinhalt"
+  },
+  "name.lang": {
+    "message": "Hauptsprache",
+    "description": "Feld für die primäre Sprache"
+  },
+  "name.extraLangs": {
+    "message": "Zusätzliche Sprachen",
+    "description": "Feld für zusätzliche Sprachversionen"
+  },
+  "name.aspect": {
+    "message": "Seitenverhältnis",
+    "description": "Feld für das Seitenverhältnis"
+  },
+  "name.duration": {
+    "message": "Dauer",
+    "description": "Ziel-Dauerfeld"
+  },
+  "name.music": {
+    "message": "Hintergrundmusik",
+    "description": "Feld für den Musikumschalter"
+  },
+  "option.topic": {
+    "message": "Thema",
+    "description": "Quelltyp: ein Thema/Überschrift"
+  },
+  "option.article": {
+    "message": "Artikel",
+    "description": "Quelltyp: vollständiger Artikeltext"
+  },
+  "placeholder.sourceRef": {
+    "message": "Geben Sie ein Thema ein (z.B. „Was ist eine Vektordatenbank“) oder fügen Sie einen gesamten Artikel ein…",
+    "description": "Platzhalter für den Quelltextbereich"
+  },
+  "placeholder.select": {
+    "message": "Bitte auswählen",
+    "description": "Allgemeiner Platzhalter für Auswahl"
+  },
+  "description.sourceRef": {
+    "message": "Ein Thema/Titel oder der gesamte Text eines Artikels, der in ein Video umgewandelt werden soll.",
+    "description": "Hilfestellung für das Quellfeld"
+  },
+  "description.extraLangs": {
+    "message": "Wiederverwendung des Bildes, zusätzliche Ausgaben in diesen Sprachversionen (jeweils +6 Punkte).",
+    "description": "Hilfestellung für zusätzliche Sprachen"
+  },
+  "status.pending": {
+    "message": "In der Warteschlange",
+    "description": "Ausstehend"
+  },
+  "status.scripting": {
+    "message": "Skripterstellung läuft",
+    "description": "Skripting"
+  },
+  "status.generating": {
+    "message": "Generierung läuft",
+    "description": "Wird generiert"
+  },
+  "status.rendering": {
+    "message": "Wird gerendert",
+    "description": "Wird gerendert"
+  },
+  "status.processing": {
+    "message": "Wird verarbeitet",
+    "description": "Wird bearbeitet"
+  },
+  "button.generate": {
+    "message": "Video generieren",
+    "description": "Generieren-Button"
+  },
+  "button.download": {
+    "message": "Video herunterladen",
+    "description": "Download-Button für Videos"
+  },
+  "button.downloadCaptions": {
+    "message": "Untertitel herunterladen",
+    "description": "Download-Button für srt-Dateien"
+  },
+  "message.startingTask": {
+    "message": "Videoaufgabe wird eingereicht…",
+    "description": "Toast für die Übermittlung"
+  },
+  "message.startTaskSuccess": {
+    "message": "Aufgabe wurde eingereicht! Der Renderfortschritt wird unten angezeigt.",
+    "description": "Erfolgreiche Übermittlung"
+  },
+  "message.startTaskFailed": {
+    "message": "Aufgabenübermittlung fehlgeschlagen, bitte erneut versuchen.",
+    "description": "Fehler bei der Übermittlung"
+  },
+  "message.usedUp": {
+    "message": "Kontingent erschöpft, bitte aufladen, um fortzufahren.",
+    "description": "Kontingent aufgebraucht"
+  },
+  "message.downloadVideo": {
+    "message": "Herunterladen des generierten Videos",
+    "description": "Tooltip für den Download"
+  },
+  "message.noTasks": {
+    "message": "Noch keine Videos — erstelle dein erstes auf der linken Seite.",
+    "description": "Keine Aufgaben vorhanden"
+  }
+}

--- a/src/i18n/el/common.json
+++ b/src/i18n/el/common.json
@@ -1030,5 +1030,9 @@
   "appUpgrade.later": {
     "message": "Later",
     "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
+  },
+  "nav.maestro": {
+    "message": "Maestro",
+    "description": "Το κείμενο της σελίδας μετατροπής άρθρων σε βίντεο Maestro στη γραμμή πλοήγησης, παραμένει 'Maestro'"
   }
 }

--- a/src/i18n/el/maestro.json
+++ b/src/i18n/el/maestro.json
@@ -1,0 +1,138 @@
+{
+  "name.maestroBot": {
+    "message": "Maestro",
+    "description": "Όνομα εμφάνισης bot"
+  },
+  "name.taskId": {
+    "message": "ID εργασίας",
+    "description": "ID εργασίας"
+  },
+  "name.status": {
+    "message": "Κατάσταση",
+    "description": "Κατάσταση εργασίας"
+  },
+  "name.elapsed": {
+    "message": "Χρόνος που πέρασε",
+    "description": "Περάσαν δευτερόλεπτα"
+  },
+  "name.traceId": {
+    "message": "ID παρακολούθησης",
+    "description": "ID παρακολούθησης"
+  },
+  "name.failure": {
+    "message": "Αποτυχία",
+    "description": "Κατάσταση αποτυχίας"
+  },
+  "name.failureReason": {
+    "message": "Λόγος αποτυχίας",
+    "description": "Λόγος αποτυχίας"
+  },
+  "name.sourceType": {
+    "message": "Τύπος πηγής",
+    "description": "Πεδίο τύπου πηγής"
+  },
+  "name.sourceRef": {
+    "message": "Περιεχόμενο",
+    "description": "Πεδίο περιεχομένου πηγής"
+  },
+  "name.lang": {
+    "message": "Κύρια γλώσσα",
+    "description": "Πεδίο κύριας γλώσσας"
+  },
+  "name.extraLangs": {
+    "message": "Επιπλέον γλώσσες",
+    "description": "Πεδίο επιπλέον γλωσσικών εκδόσεων"
+  },
+  "name.aspect": {
+    "message": "Αναλογία εικόνας",
+    "description": "Πεδίο αναλογίας εικόνας"
+  },
+  "name.duration": {
+    "message": "Διάρκεια",
+    "description": "Πεδίο στοχευόμενης διάρκειας"
+  },
+  "name.music": {
+    "message": "Μουσική υπόκρουση",
+    "description": "Πεδίο εναλλαγής μουσικής"
+  },
+  "option.topic": {
+    "message": "Θέμα",
+    "description": "Τύπος πηγής: ένα θέμα/τίτλος"
+  },
+  "option.article": {
+    "message": "Άρθρο",
+    "description": "Τύπος πηγής: πλήρες κείμενο άρθρου"
+  },
+  "placeholder.sourceRef": {
+    "message": "Εισάγετε ένα θέμα (π.χ. “Τι είναι η βάση δεδομένων διανυσμάτων”) ή επικολλήστε ολόκληρο το άρθρο…",
+    "description": "Placeholder για textarea πηγής"
+  },
+  "placeholder.select": {
+    "message": "Επιλέξτε",
+    "description": "Γενικό placeholder επιλογής"
+  },
+  "description.sourceRef": {
+    "message": "Ένα θέμα/τίτλος ή το πλήρες κείμενο του άρθρου που θέλετε να κάνετε βίντεο.",
+    "description": "Βοήθεια για το πεδίο πηγής"
+  },
+  "description.extraLangs": {
+    "message": "Επαναχρησιμοποίηση εικόνας, επιπλέον παραγωγή αυτών των γλωσσών (κάθε μία +6 πόντους).",
+    "description": "Βοήθεια για επιπλέον γλώσσες"
+  },
+  "status.pending": {
+    "message": "Σε αναμονή",
+    "description": "Σε αναμονή"
+  },
+  "status.scripting": {
+    "message": "Δημιουργία σεναρίου σε εξέλιξη",
+    "description": "Δημιουργία σεναρίου"
+  },
+  "status.generating": {
+    "message": "Δημιουργία σε εξέλιξη",
+    "description": "Δημιουργία"
+  },
+  "status.rendering": {
+    "message": "Απεικόνιση σε εξέλιξη",
+    "description": "Απεικόνιση"
+  },
+  "status.processing": {
+    "message": "Επεξεργασία σε εξέλιξη",
+    "description": "Επεξεργασία"
+  },
+  "button.generate": {
+    "message": "Δημιουργία βίντεο",
+    "description": "Κουμπί δημιουργίας"
+  },
+  "button.download": {
+    "message": "Κατέβασμα βίντεο",
+    "description": "Κουμπί για κατέβασμα βίντεο"
+  },
+  "button.downloadCaptions": {
+    "message": "Κατέβασμα υποτίτλων",
+    "description": "Κουμπί για κατέβασμα srt"
+  },
+  "message.startingTask": {
+    "message": "Υποβάλλεται η εργασία βίντεο…",
+    "description": "Toast υποβολής"
+  },
+  "message.startTaskSuccess": {
+    "message": "Η εργασία υποβλήθηκε! Η πρόοδος απόδοσης θα εμφανιστεί παρακάτω.",
+    "description": "Επιτυχία υποβολής"
+  },
+  "message.startTaskFailed": {
+    "message": "Η υποβολή της εργασίας απέτυχε, παρακαλώ δοκιμάστε ξανά.",
+    "description": "Αποτυχία υποβολής"
+  },
+  "message.usedUp": {
+    "message": "Η πιστωτική σας ποσότητα έχει εξαντληθεί, παρακαλώ ανανεώστε για να συνεχίσετε.",
+    "description": "Εξαντλημένο"
+  },
+  "message.downloadVideo": {
+    "message": "Κατέβασμα του παραγόμενου βίντεο",
+    "description": "Tooltip για κατέβασμα"
+  },
+  "message.noTasks": {
+    "message": "Δεν υπάρχουν βίντεο — Δημιουργήστε το πρώτο σας αριστερά.",
+    "description": "Χωρίς εργασίες"
+  }
+}

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -1030,5 +1030,9 @@
   "message.deleteAccountPlaceholder": {
     "message": "Enter your username here",
     "description": "Placeholder for the username confirmation input"
+  },
+  "nav.maestro": {
+    "message": "Maestro",
+    "description": "Text in the website navigation bar for the Maestro article-to-video page, keep it as 'Maestro'"
   }
 }

--- a/src/i18n/en/maestro.json
+++ b/src/i18n/en/maestro.json
@@ -1,0 +1,138 @@
+{
+  "name.maestroBot": {
+    "message": "Maestro",
+    "description": "Bot display name"
+  },
+  "name.taskId": {
+    "message": "Task ID",
+    "description": "Task id"
+  },
+  "name.status": {
+    "message": "Status",
+    "description": "Task status"
+  },
+  "name.elapsed": {
+    "message": "Elapsed Time",
+    "description": "Elapsed seconds"
+  },
+  "name.traceId": {
+    "message": "Trace ID",
+    "description": "Trace id"
+  },
+  "name.failure": {
+    "message": "Failed",
+    "description": "Failure status"
+  },
+  "name.failureReason": {
+    "message": "Failure Reason",
+    "description": "Failure reason"
+  },
+  "name.sourceType": {
+    "message": "Source",
+    "description": "Source type field"
+  },
+  "name.sourceRef": {
+    "message": "Content",
+    "description": "Source content field"
+  },
+  "name.lang": {
+    "message": "Main Language",
+    "description": "Primary language field"
+  },
+  "name.extraLangs": {
+    "message": "Extra Languages",
+    "description": "Extra language versions field"
+  },
+  "name.aspect": {
+    "message": "Aspect Ratio",
+    "description": "Aspect ratio field"
+  },
+  "name.duration": {
+    "message": "Duration",
+    "description": "Target duration field"
+  },
+  "name.music": {
+    "message": "Background Music",
+    "description": "Music toggle field"
+  },
+  "option.topic": {
+    "message": "Topic",
+    "description": "Source type: a topic/headline"
+  },
+  "option.article": {
+    "message": "Article",
+    "description": "Source type: full article text"
+  },
+  "placeholder.sourceRef": {
+    "message": "Paste a topic (e.g. “What is a vector database”) or a full article…",
+    "description": "Source textarea placeholder"
+  },
+  "placeholder.select": {
+    "message": "Please select",
+    "description": "Generic select placeholder"
+  },
+  "description.sourceRef": {
+    "message": "A topic/headline, or the full article text to turn into a video.",
+    "description": "Source field help"
+  },
+  "description.extraLangs": {
+    "message": "Reuse the visuals to also produce these languages (+6 credits each).",
+    "description": "Extra langs help"
+  },
+  "status.pending": {
+    "message": "Pending",
+    "description": "Pending"
+  },
+  "status.scripting": {
+    "message": "Scripting",
+    "description": "Scripting"
+  },
+  "status.generating": {
+    "message": "Generating",
+    "description": "Generating"
+  },
+  "status.rendering": {
+    "message": "Rendering",
+    "description": "Rendering"
+  },
+  "status.processing": {
+    "message": "Processing",
+    "description": "Processing"
+  },
+  "button.generate": {
+    "message": "Generate Video",
+    "description": "Generate button"
+  },
+  "button.download": {
+    "message": "Download Video",
+    "description": "Download video button"
+  },
+  "button.downloadCaptions": {
+    "message": "Download Captions",
+    "description": "Download srt button"
+  },
+  "message.startingTask": {
+    "message": "Submitting your video task…",
+    "description": "Submit toast"
+  },
+  "message.startTaskSuccess": {
+    "message": "Task submitted! It will appear below as it renders.",
+    "description": "Submit success"
+  },
+  "message.startTaskFailed": {
+    "message": "Failed to submit the task. Please try again.",
+    "description": "Submit fail"
+  },
+  "message.usedUp": {
+    "message": "Your quota is used up. Please top up to continue.",
+    "description": "Used up"
+  },
+  "message.downloadVideo": {
+    "message": "Download the generated video",
+    "description": "Download tooltip"
+  },
+  "message.noTasks": {
+    "message": "No videos yet — create your first one on the left.",
+    "description": "No tasks"
+  }
+}

--- a/src/i18n/es/common.json
+++ b/src/i18n/es/common.json
@@ -1030,5 +1030,9 @@
   "appUpgrade.later": {
     "message": "Later",
     "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
+  },
+  "nav.maestro": {
+    "message": "Maestro",
+    "description": "Texto en la barra de navegación que lleva a la página de conversión de artículos a videos de Maestro, manteniendo 'Maestro'"
   }
 }

--- a/src/i18n/es/maestro.json
+++ b/src/i18n/es/maestro.json
@@ -1,0 +1,138 @@
+{
+  "name.maestroBot": {
+    "message": "Maestro",
+    "description": "Nombre de exhibición del bot"
+  },
+  "name.taskId": {
+    "message": "ID de tarea",
+    "description": "ID de la tarea"
+  },
+  "name.status": {
+    "message": "Estado",
+    "description": "Estado de la tarea"
+  },
+  "name.elapsed": {
+    "message": "Tiempo transcurrido",
+    "description": "Segundos transcurridos"
+  },
+  "name.traceId": {
+    "message": "ID de seguimiento",
+    "description": "ID de seguimiento"
+  },
+  "name.failure": {
+    "message": "Fallo",
+    "description": "Estado de fallo"
+  },
+  "name.failureReason": {
+    "message": "Razón del fallo",
+    "description": "Razón del fallo"
+  },
+  "name.sourceType": {
+    "message": "Tipo de origen",
+    "description": "Campo de tipo de origen"
+  },
+  "name.sourceRef": {
+    "message": "Contenido",
+    "description": "Campo de contenido de origen"
+  },
+  "name.lang": {
+    "message": "Idioma principal",
+    "description": "Campo de idioma principal"
+  },
+  "name.extraLangs": {
+    "message": "Idiomas adicionales",
+    "description": "Campo de versiones en idiomas adicionales"
+  },
+  "name.aspect": {
+    "message": "Relación de aspecto",
+    "description": "Campo de relación de aspecto"
+  },
+  "name.duration": {
+    "message": "Duración",
+    "description": "Campo de duración objetivo"
+  },
+  "name.music": {
+    "message": "Música de fondo",
+    "description": "Campo de alternar música"
+  },
+  "option.topic": {
+    "message": "Tema",
+    "description": "Tipo de fuente: un tema/título"
+  },
+  "option.article": {
+    "message": "Artículo",
+    "description": "Tipo de fuente: texto completo del artículo"
+  },
+  "placeholder.sourceRef": {
+    "message": "Ingrese un tema (como “¿Qué es una base de datos vectorial?”) o pegue un artículo completo...",
+    "description": "Marcador de posición para el área de texto de la fuente"
+  },
+  "placeholder.select": {
+    "message": "Seleccione",
+    "description": "Marcador de posición genérico para selección"
+  },
+  "description.sourceRef": {
+    "message": "Un tema/título, o el texto completo de un artículo que se va a convertir en video.",
+    "description": "Ayuda sobre el campo de origen"
+  },
+  "description.extraLangs": {
+    "message": "Reutilizar la imagen, generar estas versiones en idiomas adicionales (cada una +6 puntos).",
+    "description": "Ayuda sobre idiomas adicionales"
+  },
+  "status.pending": {
+    "message": "En cola",
+    "description": "Pendiente"
+  },
+  "status.scripting": {
+    "message": "Generando script",
+    "description": "Generando script"
+  },
+  "status.generating": {
+    "message": "Generando",
+    "description": "Generando"
+  },
+  "status.rendering": {
+    "message": "Renderizando",
+    "description": "Renderizando"
+  },
+  "status.processing": {
+    "message": "Procesando",
+    "description": "Procesando"
+  },
+  "button.generate": {
+    "message": "Generar video",
+    "description": "Botón para generar"
+  },
+  "button.download": {
+    "message": "Descargar video",
+    "description": "Botón para descargar video"
+  },
+  "button.downloadCaptions": {
+    "message": "Descargar subtítulos",
+    "description": "Botón para descargar srt"
+  },
+  "message.startingTask": {
+    "message": "Enviando tarea de video…",
+    "description": "Toast de envío"
+  },
+  "message.startTaskSuccess": {
+    "message": "¡Tarea enviada! El progreso de renderizado se mostrará abajo.",
+    "description": "Éxito en el envío"
+  },
+  "message.startTaskFailed": {
+    "message": "Error al enviar la tarea, por favor intenta de nuevo.",
+    "description": "Error en el envío"
+  },
+  "message.usedUp": {
+    "message": "Límite alcanzado, por favor recarga para continuar.",
+    "description": "Agotado"
+  },
+  "message.downloadVideo": {
+    "message": "Descargar el video generado",
+    "description": "Tooltip de descarga"
+  },
+  "message.noTasks": {
+    "message": "No hay videos aún — crea el tuyo primero a la izquierda.",
+    "description": "Sin tareas"
+  }
+}

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -1030,5 +1030,9 @@
   "appUpgrade.later": {
     "message": "Later",
     "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
+  },
+  "nav.maestro": {
+    "message": "Maestro",
+    "description": "Navigointipalkissa Maestro-artikkeleiden muuntaminen videoiksi -sivun teksti, säilytä 'Maestro'"
   }
 }

--- a/src/i18n/fi/maestro.json
+++ b/src/i18n/fi/maestro.json
@@ -1,0 +1,138 @@
+{
+  "name.maestroBot": {
+    "message": "Maestro",
+    "description": "Botti näyttönimi"
+  },
+  "name.taskId": {
+    "message": "Tehtävä ID",
+    "description": "Tehtävän id"
+  },
+  "name.status": {
+    "message": "Tila",
+    "description": "Tehtävän tila"
+  },
+  "name.elapsed": {
+    "message": "Kulunut aika",
+    "description": "Kuluneet sekunnit"
+  },
+  "name.traceId": {
+    "message": "Seurantatunnus",
+    "description": "Seuranta id"
+  },
+  "name.failure": {
+    "message": "Epäonnistuminen",
+    "description": "Epäonnistumisen tila"
+  },
+  "name.failureReason": {
+    "message": "Epäonnistumisen syy",
+    "description": "Epäonnistumisen syy"
+  },
+  "name.sourceType": {
+    "message": "Lähteen tyyppi",
+    "description": "Lähteen tyyppi kenttä"
+  },
+  "name.sourceRef": {
+    "message": "Sisältö",
+    "description": "Lähdesisältö kenttä"
+  },
+  "name.lang": {
+    "message": "Pääkieli",
+    "description": "Pääkieli kenttä"
+  },
+  "name.extraLangs": {
+    "message": "Lisäkielet",
+    "description": "Lisäkieliversiot kenttä"
+  },
+  "name.aspect": {
+    "message": "Kuvan suhde",
+    "description": "Kuvan suhde kenttä"
+  },
+  "name.duration": {
+    "message": "Kesto",
+    "description": "Tavoitekesto kenttä"
+  },
+  "name.music": {
+    "message": "Taustamusiikki",
+    "description": "Musiikin kytkentäkenttä"
+  },
+  "option.topic": {
+    "message": "Aihe",
+    "description": "Lähdetyyppi: aihe/otsikko"
+  },
+  "option.article": {
+    "message": "Artikkeli",
+    "description": "Lähdetyyppi: koko artikkelin teksti"
+  },
+  "placeholder.sourceRef": {
+    "message": "Syötä aihe (esim. “Mikä on vektoritietokanta”) tai liitä koko artikkeli…",
+    "description": "Lähdetekstin tekstikentän paikkamerkki"
+  },
+  "placeholder.select": {
+    "message": "Valitse",
+    "description": "Yleinen valintapaikka"
+  },
+  "description.sourceRef": {
+    "message": "Yksi aihe/otsikko tai koko artikkelin sisältö, joka tehdään videoksi.",
+    "description": "Lähde kenttä apu"
+  },
+  "description.extraLangs": {
+    "message": "Uudelleenkäytä kuvaa, tuota nämä kieliversiot (jokaisesta +6 pistettä).",
+    "description": "Lisäkieliversiot apu"
+  },
+  "status.pending": {
+    "message": "Jonossa",
+    "description": "Odottaa"
+  },
+  "status.scripting": {
+    "message": "Skriptiä luodaan",
+    "description": "Skriptiä luodaan"
+  },
+  "status.generating": {
+    "message": "Kuvaa luodaan",
+    "description": "Luodaan"
+  },
+  "status.rendering": {
+    "message": "Renderöidään",
+    "description": "Renderöidään"
+  },
+  "status.processing": {
+    "message": "Käsitellään",
+    "description": "Käsitellään"
+  },
+  "button.generate": {
+    "message": "Tuota video",
+    "description": "Tuota -painike"
+  },
+  "button.download": {
+    "message": "Lataa video",
+    "description": "Lataa video -painike"
+  },
+  "button.downloadCaptions": {
+    "message": "Lataa tekstitykset",
+    "description": "Lataa srt -painike"
+  },
+  "message.startingTask": {
+    "message": "Videotehtävää lähetetään…",
+    "description": "Lähetys ilmoitus"
+  },
+  "message.startTaskSuccess": {
+    "message": "Tehtävä on lähetetty! Renderöintiprosessi näkyy alhaalla.",
+    "description": "Lähetys onnistui"
+  },
+  "message.startTaskFailed": {
+    "message": "Tehtävän lähetys epäonnistui, yritä uudelleen.",
+    "description": "Lähetys epäonnistui"
+  },
+  "message.usedUp": {
+    "message": "Käyttöoikeus on käytetty loppuun, lataa lisää jatkaaksesi.",
+    "description": "Käyttö loppu"
+  },
+  "message.downloadVideo": {
+    "message": "Lataa tuotettu video",
+    "description": "Lataus työkaluvihje"
+  },
+  "message.noTasks": {
+    "message": "Ei vielä videoita — luo ensimmäinen vasemmalla.",
+    "description": "Ei tehtäviä"
+  }
+}

--- a/src/i18n/fr/common.json
+++ b/src/i18n/fr/common.json
@@ -1030,5 +1030,9 @@
   "appUpgrade.later": {
     "message": "Later",
     "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
+  },
+  "nav.maestro": {
+    "message": "Maestro",
+    "description": "Texte sur la page de conversion d'articles en vidéos Maestro dans la barre de navigation, restez comme 'Maestro'"
   }
 }

--- a/src/i18n/fr/maestro.json
+++ b/src/i18n/fr/maestro.json
@@ -1,0 +1,138 @@
+{
+  "name.maestroBot": {
+    "message": "Maestro",
+    "description": "Nom d'affichage du bot"
+  },
+  "name.taskId": {
+    "message": "ID de tâche",
+    "description": "ID de la tâche"
+  },
+  "name.status": {
+    "message": "Statut",
+    "description": "Statut de la tâche"
+  },
+  "name.elapsed": {
+    "message": "Temps écoulé",
+    "description": "Secondes écoulées"
+  },
+  "name.traceId": {
+    "message": "ID de suivi",
+    "description": "ID de suivi"
+  },
+  "name.failure": {
+    "message": "Échec",
+    "description": "Statut d'échec"
+  },
+  "name.failureReason": {
+    "message": "Raison de l'échec",
+    "description": "Raison de l'échec"
+  },
+  "name.sourceType": {
+    "message": "Type de source",
+    "description": "Champ de type de source"
+  },
+  "name.sourceRef": {
+    "message": "Contenu",
+    "description": "Champ de contenu source"
+  },
+  "name.lang": {
+    "message": "Langue principale",
+    "description": "Champ de langue principale"
+  },
+  "name.extraLangs": {
+    "message": "Langues supplémentaires",
+    "description": "Champ des versions linguistiques supplémentaires"
+  },
+  "name.aspect": {
+    "message": "Ratio d'aspect",
+    "description": "Champ de ratio d'aspect"
+  },
+  "name.duration": {
+    "message": "Durée",
+    "description": "Champ de durée cible"
+  },
+  "name.music": {
+    "message": "Musique de fond",
+    "description": "Champ de bascule de musique"
+  },
+  "option.topic": {
+    "message": "Sujet",
+    "description": "Type de source : un sujet/titre"
+  },
+  "option.article": {
+    "message": "Article",
+    "description": "Type de source : texte complet de l'article"
+  },
+  "placeholder.sourceRef": {
+    "message": "Entrez un sujet (comme « Qu'est-ce qu'une base de données vectorielle ») ou collez l'article complet…",
+    "description": "Espace réservé pour la zone de texte source"
+  },
+  "placeholder.select": {
+    "message": "Veuillez sélectionner",
+    "description": "Espace réservé générique pour la sélection"
+  },
+  "description.sourceRef": {
+    "message": "Un sujet/titre ou le texte complet d'un article à transformer en vidéo.",
+    "description": "Aide pour le champ source"
+  },
+  "description.extraLangs": {
+    "message": "Réutiliser l'image, produire ces versions linguistiques supplémentaires (chaque +6 points).",
+    "description": "Aide pour les langues supplémentaires"
+  },
+  "status.pending": {
+    "message": "En attente",
+    "description": "En attente"
+  },
+  "status.scripting": {
+    "message": "Génération de script en cours",
+    "description": "Génération de script"
+  },
+  "status.generating": {
+    "message": "Génération en cours",
+    "description": "Génération"
+  },
+  "status.rendering": {
+    "message": "Rendu en cours",
+    "description": "Rendu"
+  },
+  "status.processing": {
+    "message": "Traitement en cours",
+    "description": "Traitement"
+  },
+  "button.generate": {
+    "message": "Générer la vidéo",
+    "description": "Bouton de génération"
+  },
+  "button.download": {
+    "message": "Télécharger la vidéo",
+    "description": "Bouton de téléchargement de vidéo"
+  },
+  "button.downloadCaptions": {
+    "message": "Télécharger les sous-titres",
+    "description": "Bouton de téléchargement de srt"
+  },
+  "message.startingTask": {
+    "message": "Soumission de la tâche vidéo en cours…",
+    "description": "Toast de soumission"
+  },
+  "message.startTaskSuccess": {
+    "message": "Tâche soumise ! Le progrès du rendu sera affiché ci-dessous.",
+    "description": "Succès de la soumission"
+  },
+  "message.startTaskFailed": {
+    "message": "Échec de la soumission de la tâche, veuillez réessayer.",
+    "description": "Échec de la soumission"
+  },
+  "message.usedUp": {
+    "message": "Crédit épuisé, veuillez recharger pour continuer.",
+    "description": "Crédit épuisé"
+  },
+  "message.downloadVideo": {
+    "message": "Télécharger la vidéo générée",
+    "description": "Infobulle de téléchargement"
+  },
+  "message.noTasks": {
+    "message": "Aucune vidéo encore — créez votre première à gauche.",
+    "description": "Aucune tâche"
+  }
+}

--- a/src/i18n/it/common.json
+++ b/src/i18n/it/common.json
@@ -1030,5 +1030,9 @@
   "appUpgrade.later": {
     "message": "Later",
     "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
+  },
+  "nav.maestro": {
+    "message": "Maestro",
+    "description": "Testo della pagina di conversione di articoli in video di Maestro nella barra di navigazione, mantenere come 'Maestro'"
   }
 }

--- a/src/i18n/it/maestro.json
+++ b/src/i18n/it/maestro.json
@@ -1,0 +1,138 @@
+{
+  "name.maestroBot": {
+    "message": "Maestro",
+    "description": "Nome visualizzato del bot"
+  },
+  "name.taskId": {
+    "message": "ID compito",
+    "description": "ID del compito"
+  },
+  "name.status": {
+    "message": "Stato",
+    "description": "Stato del compito"
+  },
+  "name.elapsed": {
+    "message": "Tempo trascorso",
+    "description": "Secondi trascorsi"
+  },
+  "name.traceId": {
+    "message": "ID tracciamento",
+    "description": "ID di tracciamento"
+  },
+  "name.failure": {
+    "message": "Fallito",
+    "description": "Stato di fallimento"
+  },
+  "name.failureReason": {
+    "message": "Motivo del fallimento",
+    "description": "Motivo del fallimento"
+  },
+  "name.sourceType": {
+    "message": "Tipo di sorgente",
+    "description": "Campo per il tipo di sorgente"
+  },
+  "name.sourceRef": {
+    "message": "Contenuto",
+    "description": "Campo per il contenuto sorgente"
+  },
+  "name.lang": {
+    "message": "Lingua principale",
+    "description": "Campo per la lingua primaria"
+  },
+  "name.extraLangs": {
+    "message": "Lingue extra",
+    "description": "Campo per le versioni linguistiche extra"
+  },
+  "name.aspect": {
+    "message": "Rapporto d'aspetto",
+    "description": "Campo per il rapporto d'aspetto"
+  },
+  "name.duration": {
+    "message": "Durata",
+    "description": "Campo per la durata target"
+  },
+  "name.music": {
+    "message": "Musica di sottofondo",
+    "description": "Campo per attivare/disattivare la musica"
+  },
+  "option.topic": {
+    "message": "Argomento",
+    "description": "Tipo di sorgente: un argomento/titolo"
+  },
+  "option.article": {
+    "message": "Articolo",
+    "description": "Tipo di sorgente: testo completo dell'articolo"
+  },
+  "placeholder.sourceRef": {
+    "message": "Inserisci un argomento (es. “che cos'è un database vettoriale”) o incolla l'intero articolo…",
+    "description": "Segnaposto per il textarea della sorgente"
+  },
+  "placeholder.select": {
+    "message": "Seleziona",
+    "description": "Segnaposto generico per la selezione"
+  },
+  "description.sourceRef": {
+    "message": "Un argomento/titolo, o il testo completo di un articolo da trasformare in video.",
+    "description": "Aiuto per il campo sorgente"
+  },
+  "description.extraLangs": {
+    "message": "Riutilizza il video, produci queste versioni linguistiche aggiuntive (ogni +6 punti).",
+    "description": "Aiuto per le lingue extra"
+  },
+  "status.pending": {
+    "message": "In attesa",
+    "description": "In attesa"
+  },
+  "status.scripting": {
+    "message": "Generazione dello script in corso",
+    "description": "Generazione dello script"
+  },
+  "status.generating": {
+    "message": "Generazione in corso",
+    "description": "Generazione"
+  },
+  "status.rendering": {
+    "message": "Rendering in corso",
+    "description": "Rendering"
+  },
+  "status.processing": {
+    "message": "Elaborazione in corso",
+    "description": "Elaborazione"
+  },
+  "button.generate": {
+    "message": "Genera video",
+    "description": "Pulsante per generare il video"
+  },
+  "button.download": {
+    "message": "Scarica video",
+    "description": "Pulsante per scaricare il video"
+  },
+  "button.downloadCaptions": {
+    "message": "Scarica sottotitoli",
+    "description": "Pulsante per scaricare i sottotitoli srt"
+  },
+  "message.startingTask": {
+    "message": "Inviando il compito video…",
+    "description": "Toast di invio"
+  },
+  "message.startTaskSuccess": {
+    "message": "Compito inviato! Il progresso del rendering sarà mostrato qui sotto.",
+    "description": "Invio riuscito"
+  },
+  "message.startTaskFailed": {
+    "message": "Invio del compito fallito, riprova.",
+    "description": "Invio fallito"
+  },
+  "message.usedUp": {
+    "message": "Credito esaurito, ricarica per continuare.",
+    "description": "Esaurito"
+  },
+  "message.downloadVideo": {
+    "message": "Scarica il video generato",
+    "description": "Tooltip per il download"
+  },
+  "message.noTasks": {
+    "message": "Non ci sono video — crea il tuo primo a sinistra.",
+    "description": "Nessun compito"
+  }
+}

--- a/src/i18n/ja/common.json
+++ b/src/i18n/ja/common.json
@@ -1030,5 +1030,9 @@
   "appUpgrade.later": {
     "message": "Later",
     "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
+  },
+  "nav.maestro": {
+    "message": "マエストロ",
+    "description": "ナビゲーションバーのマエストロ記事を動画に変換するページの文字で、'マエストロ'のままにします。"
   }
 }

--- a/src/i18n/ja/maestro.json
+++ b/src/i18n/ja/maestro.json
@@ -1,0 +1,138 @@
+{
+  "name.maestroBot": {
+    "message": "マエストロ",
+    "description": "ボットの表示名"
+  },
+  "name.taskId": {
+    "message": "タスク ID",
+    "description": "タスク ID"
+  },
+  "name.status": {
+    "message": "ステータス",
+    "description": "タスクのステータス"
+  },
+  "name.elapsed": {
+    "message": "経過時間",
+    "description": "経過した秒数"
+  },
+  "name.traceId": {
+    "message": "トレース ID",
+    "description": "トレース ID"
+  },
+  "name.failure": {
+    "message": "失敗",
+    "description": "失敗ステータス"
+  },
+  "name.failureReason": {
+    "message": "失敗理由",
+    "description": "失敗の理由"
+  },
+  "name.sourceType": {
+    "message": "ソースタイプ",
+    "description": "ソースタイプフィールド"
+  },
+  "name.sourceRef": {
+    "message": "コンテンツ",
+    "description": "ソースコンテンツフィールド"
+  },
+  "name.lang": {
+    "message": "主言語",
+    "description": "主要言語フィールド"
+  },
+  "name.extraLangs": {
+    "message": "追加言語",
+    "description": "追加言語バージョンフィールド"
+  },
+  "name.aspect": {
+    "message": "アスペクト比",
+    "description": "アスペクト比フィールド"
+  },
+  "name.duration": {
+    "message": "長さ",
+    "description": "ターゲットの長さフィールド"
+  },
+  "name.music": {
+    "message": "バックグラウンドミュージック",
+    "description": "音楽トグルフィールド"
+  },
+  "option.topic": {
+    "message": "トピック",
+    "description": "ソースタイプ：トピック/見出し"
+  },
+  "option.article": {
+    "message": "記事",
+    "description": "ソースタイプ：全文記事テキスト"
+  },
+  "placeholder.sourceRef": {
+    "message": "トピックを入力してください（例：「ベクトルデータベースとは」）または全文を貼り付けてください…",
+    "description": "ソーステキストエリアのプレースホルダー"
+  },
+  "placeholder.select": {
+    "message": "選択してください",
+    "description": "一般的な選択プレースホルダー"
+  },
+  "description.sourceRef": {
+    "message": "トピック/タイトル、または動画にする全体の記事本文。",
+    "description": "ソースフィールドのヘルプ"
+  },
+  "description.extraLangs": {
+    "message": "画面を再利用し、これらの言語バージョンを追加出力します（各言語 +6 ポイント）。",
+    "description": "追加言語のヘルプ"
+  },
+  "status.pending": {
+    "message": "待機中",
+    "description": "保留中"
+  },
+  "status.scripting": {
+    "message": "スクリプト生成中",
+    "description": "スクリプト生成中"
+  },
+  "status.generating": {
+    "message": "生成中",
+    "description": "生成中"
+  },
+  "status.rendering": {
+    "message": "レンダリング中",
+    "description": "レンダリング中"
+  },
+  "status.processing": {
+    "message": "処理中",
+    "description": "処理中"
+  },
+  "button.generate": {
+    "message": "動画を生成",
+    "description": "生成ボタン"
+  },
+  "button.download": {
+    "message": "動画をダウンロード",
+    "description": "動画をダウンロードするボタン"
+  },
+  "button.downloadCaptions": {
+    "message": "字幕をダウンロード",
+    "description": "srtをダウンロードするボタン"
+  },
+  "message.startingTask": {
+    "message": "動画タスクを提出中…",
+    "description": "提出トースト"
+  },
+  "message.startTaskSuccess": {
+    "message": "タスクが提出されました！レンダリングの進捗は下に表示されます。",
+    "description": "提出成功"
+  },
+  "message.startTaskFailed": {
+    "message": "タスクの提出に失敗しました。再試行してください。",
+    "description": "提出失敗"
+  },
+  "message.usedUp": {
+    "message": "クレジットが使い切れました。続行するにはチャージしてください。",
+    "description": "使い切ったことを示すメッセージ"
+  },
+  "message.downloadVideo": {
+    "message": "生成された動画をダウンロード",
+    "description": "ダウンロードツールチップ"
+  },
+  "message.noTasks": {
+    "message": "まだ動画がありません — 左側で最初の動画を作成しましょう。",
+    "description": "タスクがないことを示すメッセージ"
+  }
+}

--- a/src/i18n/ko/common.json
+++ b/src/i18n/ko/common.json
@@ -1030,5 +1030,9 @@
   "appUpgrade.later": {
     "message": "Later",
     "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
+  },
+  "nav.maestro": {
+    "message": "Maestro",
+    "description": "탐색 막대에서 Maestro 기사에서 비디오 페이지로의 텍스트로, 'Maestro'로 유지합니다."
   }
 }

--- a/src/i18n/ko/maestro.json
+++ b/src/i18n/ko/maestro.json
@@ -1,0 +1,138 @@
+{
+  "name.maestroBot": {
+    "message": "Maestro",
+    "description": "봇 표시 이름"
+  },
+  "name.taskId": {
+    "message": "작업 ID",
+    "description": "작업 ID"
+  },
+  "name.status": {
+    "message": "상태",
+    "description": "작업 상태"
+  },
+  "name.elapsed": {
+    "message": "소요 시간",
+    "description": "경과된 초"
+  },
+  "name.traceId": {
+    "message": "추적 ID",
+    "description": "추적 ID"
+  },
+  "name.failure": {
+    "message": "실패",
+    "description": "실패 상태"
+  },
+  "name.failureReason": {
+    "message": "실패 원인",
+    "description": "실패 이유"
+  },
+  "name.sourceType": {
+    "message": "출처 유형",
+    "description": "출처 유형 필드"
+  },
+  "name.sourceRef": {
+    "message": "내용",
+    "description": "소스 콘텐츠 필드"
+  },
+  "name.lang": {
+    "message": "주 언어",
+    "description": "주 언어 필드"
+  },
+  "name.extraLangs": {
+    "message": "추가 언어",
+    "description": "추가 언어 버전 필드"
+  },
+  "name.aspect": {
+    "message": "화면 비율",
+    "description": "화면 비율 필드"
+  },
+  "name.duration": {
+    "message": "지속 시간",
+    "description": "목표 지속 시간 필드"
+  },
+  "name.music": {
+    "message": "배경 음악",
+    "description": "음악 토글 필드"
+  },
+  "option.topic": {
+    "message": "주제",
+    "description": "소스 유형: 주제/헤드라인"
+  },
+  "option.article": {
+    "message": "기사",
+    "description": "소스 유형: 전체 기사 텍스트"
+  },
+  "placeholder.sourceRef": {
+    "message": "주제 입력(예: “벡터 데이터베이스란?”) 또는 전체 기사 붙여넣기…",
+    "description": "소스 텍스트 영역 자리 표시자"
+  },
+  "placeholder.select": {
+    "message": "선택하세요",
+    "description": "일반적인 선택 자리 표시자"
+  },
+  "description.sourceRef": {
+    "message": "주제/제목 또는 비디오로 만들고자 하는 전체 기사 본문.",
+    "description": "소스 필드 도움"
+  },
+  "description.extraLangs": {
+    "message": "화면을 재사용하고, 이러한 언어 버전을 추가로 생성합니다(각 언어당 +6 포인트).",
+    "description": "추가 언어 도움"
+  },
+  "status.pending": {
+    "message": "대기 중",
+    "description": "대기 중"
+  },
+  "status.scripting": {
+    "message": "스크립트 생성 중",
+    "description": "스크립트 생성 중"
+  },
+  "status.generating": {
+    "message": "생성 중",
+    "description": "생성 중"
+  },
+  "status.rendering": {
+    "message": "렌더링 중",
+    "description": "렌더링 중"
+  },
+  "status.processing": {
+    "message": "처리 중",
+    "description": "처리 중"
+  },
+  "button.generate": {
+    "message": "비디오 생성",
+    "description": "생성 버튼"
+  },
+  "button.download": {
+    "message": "비디오 다운로드",
+    "description": "비디오 다운로드 버튼"
+  },
+  "button.downloadCaptions": {
+    "message": "자막 다운로드",
+    "description": "srt 다운로드 버튼"
+  },
+  "message.startingTask": {
+    "message": "비디오 작업을 제출하는 중…",
+    "description": "제출 토스트"
+  },
+  "message.startTaskSuccess": {
+    "message": "작업이 제출되었습니다! 렌더링 진행 상황은 아래에 표시됩니다.",
+    "description": "제출 성공"
+  },
+  "message.startTaskFailed": {
+    "message": "작업 제출 실패, 다시 시도하세요.",
+    "description": "제출 실패"
+  },
+  "message.usedUp": {
+    "message": "할당량이 소진되었습니다, 충전 후 계속 진행하세요.",
+    "description": "소진됨"
+  },
+  "message.downloadVideo": {
+    "message": "생성된 비디오 다운로드",
+    "description": "다운로드 툴팁"
+  },
+  "message.noTasks": {
+    "message": "아직 비디오가 없습니다 — 왼쪽에서 첫 번째 비디오를 생성하세요.",
+    "description": "작업 없음"
+  }
+}

--- a/src/i18n/pl/common.json
+++ b/src/i18n/pl/common.json
@@ -1030,5 +1030,9 @@
   "appUpgrade.later": {
     "message": "Later",
     "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
+  },
+  "nav.maestro": {
+    "message": "Maestro",
+    "description": "Tekst na stronie przejścia z artykułu na wideo w nawigacji, pozostaje jako 'Maestro'"
   }
 }

--- a/src/i18n/pl/maestro.json
+++ b/src/i18n/pl/maestro.json
@@ -1,0 +1,138 @@
+{
+  "name.maestroBot": {
+    "message": "Maestro",
+    "description": "Nazwa wyświetlana bota"
+  },
+  "name.taskId": {
+    "message": "ID zadania",
+    "description": "Identyfikator zadania"
+  },
+  "name.status": {
+    "message": "Status",
+    "description": "Status zadania"
+  },
+  "name.elapsed": {
+    "message": "Czas trwania",
+    "description": "Minione sekundy"
+  },
+  "name.traceId": {
+    "message": "ID śledzenia",
+    "description": "Identyfikator śledzenia"
+  },
+  "name.failure": {
+    "message": "Niepowodzenie",
+    "description": "Status niepowodzenia"
+  },
+  "name.failureReason": {
+    "message": "Powód niepowodzenia",
+    "description": "Powód niepowodzenia"
+  },
+  "name.sourceType": {
+    "message": "Typ źródła",
+    "description": "Pole typu źródła"
+  },
+  "name.sourceRef": {
+    "message": "Treść",
+    "description": "Pole treści źródłowej"
+  },
+  "name.lang": {
+    "message": "Język główny",
+    "description": "Pole głównego języka"
+  },
+  "name.extraLangs": {
+    "message": "Dodatkowe języki",
+    "description": "Pole wersji językowych"
+  },
+  "name.aspect": {
+    "message": "Proporcje obrazu",
+    "description": "Pole proporcji obrazu"
+  },
+  "name.duration": {
+    "message": "Czas trwania",
+    "description": "Pole docelowego czasu trwania"
+  },
+  "name.music": {
+    "message": "Muzyka w tle",
+    "description": "Pole przełączania muzyki"
+  },
+  "option.topic": {
+    "message": "Temat",
+    "description": "Typ źródła: temat/tytuł"
+  },
+  "option.article": {
+    "message": "Artykuł",
+    "description": "Typ źródła: pełny tekst artykułu"
+  },
+  "placeholder.sourceRef": {
+    "message": "Wprowadź temat (np. „Czym jest baza danych wektorowa”) lub wklej cały artykuł…",
+    "description": "Placeholder dla pola tekstowego źródła"
+  },
+  "placeholder.select": {
+    "message": "Wybierz",
+    "description": "Ogólny placeholder dla wyboru"
+  },
+  "description.sourceRef": {
+    "message": "Temat/tytuł lub pełny tekst artykułu, który ma być przekształcony w wideo.",
+    "description": "Pomoc dotycząca pola źródłowego"
+  },
+  "description.extraLangs": {
+    "message": "Wykorzystaj obraz, dodatkowo wygeneruj te wersje językowe (każda +6 punktów).",
+    "description": "Pomoc dotycząca dodatkowych języków"
+  },
+  "status.pending": {
+    "message": "W kolejce",
+    "description": "Oczekiwanie"
+  },
+  "status.scripting": {
+    "message": "Generowanie skryptu",
+    "description": "Generowanie skryptu"
+  },
+  "status.generating": {
+    "message": "Generowanie",
+    "description": "Generowanie"
+  },
+  "status.rendering": {
+    "message": "Renderowanie",
+    "description": "Renderowanie"
+  },
+  "status.processing": {
+    "message": "Przetwarzanie",
+    "description": "Przetwarzanie"
+  },
+  "button.generate": {
+    "message": "Generuj wideo",
+    "description": "Przycisk generowania"
+  },
+  "button.download": {
+    "message": "Pobierz wideo",
+    "description": "Przycisk do pobierania wideo"
+  },
+  "button.downloadCaptions": {
+    "message": "Pobierz napisy",
+    "description": "Przycisk do pobierania pliku srt"
+  },
+  "message.startingTask": {
+    "message": "Wysyłanie zadania wideo…",
+    "description": "Toast wysyłania"
+  },
+  "message.startTaskSuccess": {
+    "message": "Zadanie zostało wysłane! Postęp renderowania będzie wyświetlany poniżej.",
+    "description": "Sukces wysyłania"
+  },
+  "message.startTaskFailed": {
+    "message": "Wysłanie zadania nie powiodło się, spróbuj ponownie.",
+    "description": "Niepowodzenie wysyłania"
+  },
+  "message.usedUp": {
+    "message": "Limit został wyczerpany, proszę doładować, aby kontynuować.",
+    "description": "Limit wyczerpany"
+  },
+  "message.downloadVideo": {
+    "message": "Pobierz wygenerowane wideo",
+    "description": "Podpowiedź do pobierania"
+  },
+  "message.noTasks": {
+    "message": "Brak wideo — stwórz swoje pierwsze po lewej stronie.",
+    "description": "Brak zadań"
+  }
+}

--- a/src/i18n/pt/common.json
+++ b/src/i18n/pt/common.json
@@ -1030,5 +1030,9 @@
   "appUpgrade.later": {
     "message": "Later",
     "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
+  },
+  "nav.maestro": {
+    "message": "Maestro",
+    "description": "Texto da página de conversão de artigos em vídeos do Maestro na barra de navegação, mantenha como 'Maestro'"
   }
 }

--- a/src/i18n/pt/maestro.json
+++ b/src/i18n/pt/maestro.json
@@ -1,0 +1,138 @@
+{
+  "name.maestroBot": {
+    "message": "Maestro",
+    "description": "Nome de exibição do bot"
+  },
+  "name.taskId": {
+    "message": "ID da tarefa",
+    "description": "ID da tarefa"
+  },
+  "name.status": {
+    "message": "Status",
+    "description": "Status da tarefa"
+  },
+  "name.elapsed": {
+    "message": "Tempo decorrido",
+    "description": "Segundos decorridos"
+  },
+  "name.traceId": {
+    "message": "ID de rastreamento",
+    "description": "ID de rastreamento"
+  },
+  "name.failure": {
+    "message": "Falha",
+    "description": "Status de falha"
+  },
+  "name.failureReason": {
+    "message": "Razão da falha",
+    "description": "Razão da falha"
+  },
+  "name.sourceType": {
+    "message": "Tipo de origem",
+    "description": "Campo de tipo de origem"
+  },
+  "name.sourceRef": {
+    "message": "Conteúdo",
+    "description": "Campo de conteúdo de origem"
+  },
+  "name.lang": {
+    "message": "Idioma principal",
+    "description": "Campo de idioma principal"
+  },
+  "name.extraLangs": {
+    "message": "Idiomas adicionais",
+    "description": "Campo para versões de idiomas extras"
+  },
+  "name.aspect": {
+    "message": "Proporção",
+    "description": "Campo de proporção de aspecto"
+  },
+  "name.duration": {
+    "message": "Duração",
+    "description": "Campo de duração alvo"
+  },
+  "name.music": {
+    "message": "Música de fundo",
+    "description": "Campo para alternar música"
+  },
+  "option.topic": {
+    "message": "Tópico",
+    "description": "Tipo de fonte: um tópico/título"
+  },
+  "option.article": {
+    "message": "Artigo",
+    "description": "Tipo de fonte: texto completo do artigo"
+  },
+  "placeholder.sourceRef": {
+    "message": "Digite um tópico (como “o que é um banco de dados vetorial”) ou cole um artigo completo…",
+    "description": "Placeholder para área de texto de fonte"
+  },
+  "placeholder.select": {
+    "message": "Selecione",
+    "description": "Placeholder genérico para seleção"
+  },
+  "description.sourceRef": {
+    "message": "Um tópico/título ou o texto completo do artigo a ser transformado em vídeo.",
+    "description": "Ajuda para o campo de origem"
+  },
+  "description.extraLangs": {
+    "message": "Reutilizar a imagem, produzir versões adicionais nesses idiomas (cada uma +6 pontos).",
+    "description": "Ajuda sobre idiomas extras"
+  },
+  "status.pending": {
+    "message": "Aguardando",
+    "description": "Aguardando"
+  },
+  "status.scripting": {
+    "message": "Gerando script",
+    "description": "Gerando script"
+  },
+  "status.generating": {
+    "message": "Gerando",
+    "description": "Gerando"
+  },
+  "status.rendering": {
+    "message": "Renderizando",
+    "description": "Renderizando"
+  },
+  "status.processing": {
+    "message": "Processando",
+    "description": "Processando"
+  },
+  "button.generate": {
+    "message": "Gerar vídeo",
+    "description": "Botão para gerar"
+  },
+  "button.download": {
+    "message": "Baixar vídeo",
+    "description": "Botão para baixar vídeo"
+  },
+  "button.downloadCaptions": {
+    "message": "Baixar legendas",
+    "description": "Botão para baixar srt"
+  },
+  "message.startingTask": {
+    "message": "Enviando tarefa de vídeo…",
+    "description": "Toast de envio"
+  },
+  "message.startTaskSuccess": {
+    "message": "Tarefa enviada! O progresso da renderização será exibido abaixo.",
+    "description": "Sucesso ao enviar"
+  },
+  "message.startTaskFailed": {
+    "message": "Falha ao enviar a tarefa, por favor, tente novamente.",
+    "description": "Falha ao enviar"
+  },
+  "message.usedUp": {
+    "message": "Créditos esgotados, por favor, recarregue para continuar.",
+    "description": "Esgotado"
+  },
+  "message.downloadVideo": {
+    "message": "Baixar o vídeo gerado",
+    "description": "Dica para download"
+  },
+  "message.noTasks": {
+    "message": "Ainda não há vídeos — crie o seu primeiro à esquerda.",
+    "description": "Sem tarefas"
+  }
+}

--- a/src/i18n/ru/common.json
+++ b/src/i18n/ru/common.json
@@ -1030,5 +1030,9 @@
   "appUpgrade.later": {
     "message": "Later",
     "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
+  },
+  "nav.maestro": {
+    "message": "Маэстро",
+    "description": "Текст на странице преобразования статей Maestro в видео в навигационной панели, остается как 'Маэстро'"
   }
 }

--- a/src/i18n/ru/maestro.json
+++ b/src/i18n/ru/maestro.json
@@ -1,0 +1,138 @@
+{
+  "name.maestroBot": {
+    "message": "Maestro",
+    "description": "Отображаемое имя бота"
+  },
+  "name.taskId": {
+    "message": "ID задачи",
+    "description": "ID задачи"
+  },
+  "name.status": {
+    "message": "Статус",
+    "description": "Статус задачи"
+  },
+  "name.elapsed": {
+    "message": "Затраченное время",
+    "description": "Прошедшие секунды"
+  },
+  "name.traceId": {
+    "message": "ID трассировки",
+    "description": "ID трассировки"
+  },
+  "name.failure": {
+    "message": "Ошибка",
+    "description": "Статус ошибки"
+  },
+  "name.failureReason": {
+    "message": "Причина ошибки",
+    "description": "Причина ошибки"
+  },
+  "name.sourceType": {
+    "message": "Тип источника",
+    "description": "Поле типа источника"
+  },
+  "name.sourceRef": {
+    "message": "Содержимое",
+    "description": "Поле исходного контента"
+  },
+  "name.lang": {
+    "message": "Основной язык",
+    "description": "Поле основного языка"
+  },
+  "name.extraLangs": {
+    "message": "Дополнительные языки",
+    "description": "Поле для дополнительных языковых версий"
+  },
+  "name.aspect": {
+    "message": "Соотношение сторон",
+    "description": "Поле соотношения сторон"
+  },
+  "name.duration": {
+    "message": "Длительность",
+    "description": "Поле целевой длительности"
+  },
+  "name.music": {
+    "message": "Фоновая музыка",
+    "description": "Поле переключения музыки"
+  },
+  "option.topic": {
+    "message": "Тема",
+    "description": "Тип источника: тема/заголовок"
+  },
+  "option.article": {
+    "message": "Статья",
+    "description": "Тип источника: полный текст статьи"
+  },
+  "placeholder.sourceRef": {
+    "message": "Введите тему (например, “Что такое векторная база данных”) или вставьте полную статью…",
+    "description": "Плейсхолдер для текстовой области источника"
+  },
+  "placeholder.select": {
+    "message": "Пожалуйста, выберите",
+    "description": "Общий плейсхолдер для выбора"
+  },
+  "description.sourceRef": {
+    "message": "Тема/заголовок или полный текст статьи, которую нужно сделать видео.",
+    "description": "Помощь по полю источника"
+  },
+  "description.extraLangs": {
+    "message": "Повторное использование изображения, дополнительный выпуск этих языковых версий (каждая +6 баллов).",
+    "description": "Помощь по дополнительным языкам"
+  },
+  "status.pending": {
+    "message": "В очереди",
+    "description": "Ожидание"
+  },
+  "status.scripting": {
+    "message": "Генерация скрипта",
+    "description": "Генерация скрипта"
+  },
+  "status.generating": {
+    "message": "Генерация изображения",
+    "description": "Генерация"
+  },
+  "status.rendering": {
+    "message": "Рендеринг",
+    "description": "Рендеринг"
+  },
+  "status.processing": {
+    "message": "Обработка",
+    "description": "Обработка"
+  },
+  "button.generate": {
+    "message": "Сгенерировать видео",
+    "description": "Кнопка генерации"
+  },
+  "button.download": {
+    "message": "Скачать видео",
+    "description": "Кнопка для скачивания видео"
+  },
+  "button.downloadCaptions": {
+    "message": "Скачать субтитры",
+    "description": "Кнопка для скачивания srt"
+  },
+  "message.startingTask": {
+    "message": "Отправка видео задачи…",
+    "description": "Подсказка отправки"
+  },
+  "message.startTaskSuccess": {
+    "message": "Задача отправлена! Прогресс рендеринга будет показан ниже.",
+    "description": "Успешная отправка"
+  },
+  "message.startTaskFailed": {
+    "message": "Не удалось отправить задачу, попробуйте еще раз.",
+    "description": "Ошибка отправки"
+  },
+  "message.usedUp": {
+    "message": "Лимит исчерпан, пожалуйста, пополните счет для продолжения.",
+    "description": "Лимит исчерпан"
+  },
+  "message.downloadVideo": {
+    "message": "Скачать сгенерированное видео",
+    "description": "Подсказка для скачивания"
+  },
+  "message.noTasks": {
+    "message": "Пока нет видео — создайте ваше первое слева.",
+    "description": "Нет задач"
+  }
+}

--- a/src/i18n/sr/common.json
+++ b/src/i18n/sr/common.json
@@ -1030,5 +1030,9 @@
   "appUpgrade.later": {
     "message": "Later",
     "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
+  },
+  "nav.maestro": {
+    "message": "Maestro",
+    "description": "Текст на страници за претварање Maestro чланака у видео у навигационом менију, остаје 'Maestro'"
   }
 }

--- a/src/i18n/sr/maestro.json
+++ b/src/i18n/sr/maestro.json
@@ -1,0 +1,138 @@
+{
+  "name.maestroBot": {
+    "message": "Maestro",
+    "description": "Prikazno ime bota"
+  },
+  "name.taskId": {
+    "message": "ID zadatka",
+    "description": "ID zadatka"
+  },
+  "name.status": {
+    "message": "Status",
+    "description": "Status zadatka"
+  },
+  "name.elapsed": {
+    "message": "Proteklo vreme",
+    "description": "Protekli sekundi"
+  },
+  "name.traceId": {
+    "message": "ID praćenja",
+    "description": "ID praćenja"
+  },
+  "name.failure": {
+    "message": "Neuspeh",
+    "description": "Status neuspeha"
+  },
+  "name.failureReason": {
+    "message": "Razlog neuspeha",
+    "description": "Razlog neuspeha"
+  },
+  "name.sourceType": {
+    "message": "Tip izvora",
+    "description": "Polje za tip izvora"
+  },
+  "name.sourceRef": {
+    "message": "Sadržaj",
+    "description": "Polje za izvorni sadržaj"
+  },
+  "name.lang": {
+    "message": "Glavni jezik",
+    "description": "Polje za primarni jezik"
+  },
+  "name.extraLangs": {
+    "message": "Dodatni jezici",
+    "description": "Polje za dodatne jezičke verzije"
+  },
+  "name.aspect": {
+    "message": "Odnos stranica",
+    "description": "Polje za odnos stranica"
+  },
+  "name.duration": {
+    "message": "Trajanje",
+    "description": "Polje za ciljano trajanje"
+  },
+  "name.music": {
+    "message": "Pozadinska muzika",
+    "description": "Polje za prebacivanje muzike"
+  },
+  "option.topic": {
+    "message": "Tema",
+    "description": "Tip izvora: tema/naslov"
+  },
+  "option.article": {
+    "message": "Članak",
+    "description": "Tip izvora: puni tekst članka"
+  },
+  "placeholder.sourceRef": {
+    "message": "Unesite temu (npr. \"Šta je vektorska baza podataka\") ili nalepite ceo članak…",
+    "description": "Placeholder za tekstualno polje izvora"
+  },
+  "placeholder.select": {
+    "message": "Izaberite",
+    "description": "Generički placeholder za izbor"
+  },
+  "description.sourceRef": {
+    "message": "Tema/titula ili ceo tekst članka koji treba pretvoriti u video.",
+    "description": "Pomoć za polje izvora"
+  },
+  "description.extraLangs": {
+    "message": "Ponovno koristi slike, dodatno proizvedi ove jezičke verzije (svaka +6 poena).",
+    "description": "Pomoć za dodatne jezike"
+  },
+  "status.pending": {
+    "message": "Na čekanju",
+    "description": "Na čekanju"
+  },
+  "status.scripting": {
+    "message": "Generiše se skripta",
+    "description": "Generisanje skripte"
+  },
+  "status.generating": {
+    "message": "Generiše se",
+    "description": "Generisanje"
+  },
+  "status.rendering": {
+    "message": "Renderuje se",
+    "description": "Renderovanje"
+  },
+  "status.processing": {
+    "message": "Obrada",
+    "description": "Obrada"
+  },
+  "button.generate": {
+    "message": "Generiši video",
+    "description": "Dugme za generisanje"
+  },
+  "button.download": {
+    "message": "Preuzmi video",
+    "description": "Dugme za preuzimanje videa"
+  },
+  "button.downloadCaptions": {
+    "message": "Preuzmi titlove",
+    "description": "Dugme za preuzimanje srt"
+  },
+  "message.startingTask": {
+    "message": "Podnošenje video zadatka…",
+    "description": "Toast za podnošenje"
+  },
+  "message.startTaskSuccess": {
+    "message": "Zadatak je podnet! Napredak renderovanja će se prikazati ispod.",
+    "description": "Uspeh pri podnošenju"
+  },
+  "message.startTaskFailed": {
+    "message": "Podnošenje zadatka nije uspelo, molimo pokušajte ponovo.",
+    "description": "Neuspeh pri podnošenju"
+  },
+  "message.usedUp": {
+    "message": "Kredit je iskorišćen, molimo dopunite da biste nastavili.",
+    "description": "Iskorišćeno"
+  },
+  "message.downloadVideo": {
+    "message": "Preuzmi generisani video",
+    "description": "Tooltip za preuzimanje"
+  },
+  "message.noTasks": {
+    "message": "Još nema videa — kreiraj svoj prvi sa leve strane.",
+    "description": "Nema zadataka"
+  }
+}

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -1030,5 +1030,9 @@
   "appUpgrade.later": {
     "message": "Later",
     "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
+  },
+  "nav.maestro": {
+    "message": "Maestro",
+    "description": "Texten för Maestro-artikeln på videoproduktionssidan i navigeringsfältet, hålls som 'Maestro'"
   }
 }

--- a/src/i18n/sv/maestro.json
+++ b/src/i18n/sv/maestro.json
@@ -1,0 +1,138 @@
+{
+  "name.maestroBot": {
+    "message": "Maestro",
+    "description": "Botens visningsnamn"
+  },
+  "name.taskId": {
+    "message": "Uppgift ID",
+    "description": "Uppgifts-ID"
+  },
+  "name.status": {
+    "message": "Status",
+    "description": "Uppgiftsstatus"
+  },
+  "name.elapsed": {
+    "message": "Tid förbrukad",
+    "description": "Förflutna sekunder"
+  },
+  "name.traceId": {
+    "message": "Spårnings ID",
+    "description": "Spårnings-ID"
+  },
+  "name.failure": {
+    "message": "Misslyckande",
+    "description": "Status för misslyckande"
+  },
+  "name.failureReason": {
+    "message": "Orsak till misslyckande",
+    "description": "Orsak till misslyckande"
+  },
+  "name.sourceType": {
+    "message": "Källtyp",
+    "description": "Fält för källtyp"
+  },
+  "name.sourceRef": {
+    "message": "Innehåll",
+    "description": "Fält för källinnehåll"
+  },
+  "name.lang": {
+    "message": "Huvudspråk",
+    "description": "Fält för primärt språk"
+  },
+  "name.extraLangs": {
+    "message": "Extra språk",
+    "description": "Fält för extra språkversioner"
+  },
+  "name.aspect": {
+    "message": "Bildförhållande",
+    "description": "Fält för bildförhållande"
+  },
+  "name.duration": {
+    "message": "Längd",
+    "description": "Mållängdsfält"
+  },
+  "name.music": {
+    "message": "Bakgrundsmusik",
+    "description": "Fält för musikväxling"
+  },
+  "option.topic": {
+    "message": "Ämne",
+    "description": "Källtyp: ett ämne/rubrik"
+  },
+  "option.article": {
+    "message": "Artikel",
+    "description": "Källtyp: fullständig artikeltext"
+  },
+  "placeholder.sourceRef": {
+    "message": "Skriv ett ämne (t.ex. \"Vad är en vektordatabas?\") eller klistra in hela artikeln…",
+    "description": "Platshållare för källtextområde"
+  },
+  "placeholder.select": {
+    "message": "Vänligen välj",
+    "description": "Allmänt val av platshållare"
+  },
+  "description.sourceRef": {
+    "message": "Ett ämne/titel, eller hela texten av artikeln som ska göras till video.",
+    "description": "Hjälp för källfält"
+  },
+  "description.extraLangs": {
+    "message": "Återanvända bild, extra utgåvor av dessa språkversioner (varje +6 poäng).",
+    "description": "Extra språk hjälper"
+  },
+  "status.pending": {
+    "message": "I kö",
+    "description": "Väntar"
+  },
+  "status.scripting": {
+    "message": "Skripterar",
+    "description": "Skripterar"
+  },
+  "status.generating": {
+    "message": "Genererar",
+    "description": "Genererar"
+  },
+  "status.rendering": {
+    "message": "Renderar",
+    "description": "Renderar"
+  },
+  "status.processing": {
+    "message": "Bearbetar",
+    "description": "Bearbetar"
+  },
+  "button.generate": {
+    "message": "Generera video",
+    "description": "Generera-knapp"
+  },
+  "button.download": {
+    "message": "Ladda ner video",
+    "description": "Ladda ner video-knapp"
+  },
+  "button.downloadCaptions": {
+    "message": "Ladda ner undertexter",
+    "description": "Ladda ner srt-knapp"
+  },
+  "message.startingTask": {
+    "message": "Skickar videouppgift…",
+    "description": "Inlämning toast"
+  },
+  "message.startTaskSuccess": {
+    "message": "Uppgiften har skickats! Renderingsstatus kommer att visas nedan.",
+    "description": "Inlämning lyckades"
+  },
+  "message.startTaskFailed": {
+    "message": "Uppgiftsinlämning misslyckades, vänligen försök igen.",
+    "description": "Inlämning misslyckades"
+  },
+  "message.usedUp": {
+    "message": "Krediten är slut, vänligen ladda på för att fortsätta.",
+    "description": "Användd upp"
+  },
+  "message.downloadVideo": {
+    "message": "Ladda ner den genererade videon",
+    "description": "Nedladdningstips"
+  },
+  "message.noTasks": {
+    "message": "Inga videor än — skapa din första till vänster.",
+    "description": "Inga uppgifter"
+  }
+}

--- a/src/i18n/uk/common.json
+++ b/src/i18n/uk/common.json
@@ -1030,5 +1030,9 @@
   "appUpgrade.later": {
     "message": "Later",
     "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
+  },
+  "nav.maestro": {
+    "message": "Maestro",
+    "description": "Текст на сторінці перетворення статей Maestro на відео в навігаційній панелі, залишити як 'Maestro'"
   }
 }

--- a/src/i18n/uk/maestro.json
+++ b/src/i18n/uk/maestro.json
@@ -1,0 +1,138 @@
+{
+  "name.maestroBot": {
+    "message": "Maestro",
+    "description": "Відображуване ім'я бота"
+  },
+  "name.taskId": {
+    "message": "ID завдання",
+    "description": "ID завдання"
+  },
+  "name.status": {
+    "message": "Статус",
+    "description": "Статус завдання"
+  },
+  "name.elapsed": {
+    "message": "Час витрачено",
+    "description": "Витрачені секунди"
+  },
+  "name.traceId": {
+    "message": "ID відстеження",
+    "description": "ID відстеження"
+  },
+  "name.failure": {
+    "message": "Не вдалося",
+    "description": "Статус невдачі"
+  },
+  "name.failureReason": {
+    "message": "Причина невдачі",
+    "description": "Причина невдачі"
+  },
+  "name.sourceType": {
+    "message": "Тип джерела",
+    "description": "Поле типу джерела"
+  },
+  "name.sourceRef": {
+    "message": "Контент",
+    "description": "Поле джерела контенту"
+  },
+  "name.lang": {
+    "message": "Основна мова",
+    "description": "Поле основної мови"
+  },
+  "name.extraLangs": {
+    "message": "Додаткові мови",
+    "description": "Поле для додаткових мовних версій"
+  },
+  "name.aspect": {
+    "message": "Співвідношення сторін",
+    "description": "Поле співвідношення сторін"
+  },
+  "name.duration": {
+    "message": "Тривалість",
+    "description": "Поле цільової тривалості"
+  },
+  "name.music": {
+    "message": "Фоновий музика",
+    "description": "Поле перемикання музики"
+  },
+  "option.topic": {
+    "message": "Тема",
+    "description": "Тип джерела: тема/заголовок"
+  },
+  "option.article": {
+    "message": "Стаття",
+    "description": "Тип джерела: повний текст статті"
+  },
+  "placeholder.sourceRef": {
+    "message": "Введіть тему (наприклад, “Що таке векторна база даних”) або вставте повну статтю…",
+    "description": "Заповнювач текстової області джерела"
+  },
+  "placeholder.select": {
+    "message": "Будь ласка, виберіть",
+    "description": "Загальний заповнювач для вибору"
+  },
+  "description.sourceRef": {
+    "message": "Тема/заголовок або повний текст статті, яку потрібно перетворити на відео.",
+    "description": "Допомога для поля джерела"
+  },
+  "description.extraLangs": {
+    "message": "Використовуйте зображення, додатково створіть ці мовні версії (кожна +6 балів).",
+    "description": "Допомога з додатковими мовами"
+  },
+  "status.pending": {
+    "message": "В черзі",
+    "description": "Очікування"
+  },
+  "status.scripting": {
+    "message": "Генерація скрипту",
+    "description": "Генерація скрипту"
+  },
+  "status.generating": {
+    "message": "Генерація",
+    "description": "Генерація"
+  },
+  "status.rendering": {
+    "message": "Рендеринг",
+    "description": "Рендеринг"
+  },
+  "status.processing": {
+    "message": "Обробка",
+    "description": "Обробка"
+  },
+  "button.generate": {
+    "message": "Згенерувати відео",
+    "description": "Кнопка для генерації"
+  },
+  "button.download": {
+    "message": "Завантажити відео",
+    "description": "Кнопка для завантаження відео"
+  },
+  "button.downloadCaptions": {
+    "message": "Завантажити субтитри",
+    "description": "Кнопка для завантаження srt"
+  },
+  "message.startingTask": {
+    "message": "Надсилаємо відеозавдання…",
+    "description": "Тост для надсилання"
+  },
+  "message.startTaskSuccess": {
+    "message": "Завдання надіслано! Прогрес рендерингу буде показано нижче.",
+    "description": "Успішне надсилання"
+  },
+  "message.startTaskFailed": {
+    "message": "Не вдалося надіслати завдання, будь ласка, спробуйте ще раз.",
+    "description": "Не вдалося надіслати"
+  },
+  "message.usedUp": {
+    "message": "Ліміт вичерпано, будь ласка, поповніть рахунок для продовження.",
+    "description": "Вичерпано"
+  },
+  "message.downloadVideo": {
+    "message": "Завантажити згенероване відео",
+    "description": "Підказка для завантаження"
+  },
+  "message.noTasks": {
+    "message": "Ще немає відео — створіть своє перше зліва.",
+    "description": "Відсутність завдань"
+  }
+}

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -1030,5 +1030,9 @@
   "appUpgrade.later": {
     "message": "稍后再说",
     "description": "软提示升级弹窗的次按钮：忽略本次提示继续使用，仅在非强制升级场景出现。"
+  },
+  "nav.maestro": {
+    "message": "Maestro",
+    "description": "导航栏中 Maestro 文章转视频页面的文字,保持为 'Maestro'"
   }
 }

--- a/src/i18n/zh-CN/maestro.json
+++ b/src/i18n/zh-CN/maestro.json
@@ -1,0 +1,138 @@
+{
+  "name.maestroBot": {
+    "message": "Maestro",
+    "description": "Bot display name"
+  },
+  "name.taskId": {
+    "message": "任务 ID",
+    "description": "Task id"
+  },
+  "name.status": {
+    "message": "状态",
+    "description": "Task status"
+  },
+  "name.elapsed": {
+    "message": "耗时",
+    "description": "Elapsed seconds"
+  },
+  "name.traceId": {
+    "message": "追踪 ID",
+    "description": "Trace id"
+  },
+  "name.failure": {
+    "message": "失败",
+    "description": "Failure status"
+  },
+  "name.failureReason": {
+    "message": "失败原因",
+    "description": "Failure reason"
+  },
+  "name.sourceType": {
+    "message": "来源类型",
+    "description": "Source type field"
+  },
+  "name.sourceRef": {
+    "message": "内容",
+    "description": "Source content field"
+  },
+  "name.lang": {
+    "message": "主语言",
+    "description": "Primary language field"
+  },
+  "name.extraLangs": {
+    "message": "额外语言",
+    "description": "Extra language versions field"
+  },
+  "name.aspect": {
+    "message": "画面比例",
+    "description": "Aspect ratio field"
+  },
+  "name.duration": {
+    "message": "时长",
+    "description": "Target duration field"
+  },
+  "name.music": {
+    "message": "背景音乐",
+    "description": "Music toggle field"
+  },
+  "option.topic": {
+    "message": "话题",
+    "description": "Source type: a topic/headline"
+  },
+  "option.article": {
+    "message": "文章",
+    "description": "Source type: full article text"
+  },
+  "placeholder.sourceRef": {
+    "message": "输入一个话题(如“什么是向量数据库”)或粘贴整篇文章…",
+    "description": "Source textarea placeholder"
+  },
+  "placeholder.select": {
+    "message": "请选择",
+    "description": "Generic select placeholder"
+  },
+  "description.sourceRef": {
+    "message": "一个话题/标题,或要做成视频的整篇文章正文。",
+    "description": "Source field help"
+  },
+  "description.extraLangs": {
+    "message": "复用画面,额外产出这些语言版本(每种 +6 积分)。",
+    "description": "Extra langs help"
+  },
+  "status.pending": {
+    "message": "排队中",
+    "description": "Pending"
+  },
+  "status.scripting": {
+    "message": "脚本生成中",
+    "description": "Scripting"
+  },
+  "status.generating": {
+    "message": "画面生成中",
+    "description": "Generating"
+  },
+  "status.rendering": {
+    "message": "渲染中",
+    "description": "Rendering"
+  },
+  "status.processing": {
+    "message": "处理中",
+    "description": "Processing"
+  },
+  "button.generate": {
+    "message": "生成视频",
+    "description": "Generate button"
+  },
+  "button.download": {
+    "message": "下载视频",
+    "description": "Download video button"
+  },
+  "button.downloadCaptions": {
+    "message": "下载字幕",
+    "description": "Download srt button"
+  },
+  "message.startingTask": {
+    "message": "正在提交视频任务…",
+    "description": "Submit toast"
+  },
+  "message.startTaskSuccess": {
+    "message": "任务已提交!渲染进度会显示在下方。",
+    "description": "Submit success"
+  },
+  "message.startTaskFailed": {
+    "message": "任务提交失败,请重试。",
+    "description": "Submit fail"
+  },
+  "message.usedUp": {
+    "message": "额度已用完,请充值后继续。",
+    "description": "Used up"
+  },
+  "message.downloadVideo": {
+    "message": "下载生成的视频",
+    "description": "Download tooltip"
+  },
+  "message.noTasks": {
+    "message": "还没有视频 — 在左侧创建你的第一个吧。",
+    "description": "No tasks"
+  }
+}

--- a/src/i18n/zh-TW/common.json
+++ b/src/i18n/zh-TW/common.json
@@ -1030,5 +1030,9 @@
   "appUpgrade.later": {
     "message": "Later",
     "description": "Secondary button on the soft upgrade prompt — dismisses the modal and lets the user keep using the current version. Only shown for non-forced upgrades."
+  },
+  "nav.maestro": {
+    "message": "Maestro",
+    "description": "導航欄中 Maestro 文章轉視頻頁面的文字,保持為 'Maestro'"
   }
 }

--- a/src/i18n/zh-TW/maestro.json
+++ b/src/i18n/zh-TW/maestro.json
@@ -1,0 +1,138 @@
+{
+  "name.maestroBot": {
+    "message": "Maestro",
+    "description": "機器人顯示名稱"
+  },
+  "name.taskId": {
+    "message": "任務 ID",
+    "description": "任務 ID"
+  },
+  "name.status": {
+    "message": "狀態",
+    "description": "任務狀態"
+  },
+  "name.elapsed": {
+    "message": "耗時",
+    "description": "已過秒數"
+  },
+  "name.traceId": {
+    "message": "追蹤 ID",
+    "description": "追蹤 ID"
+  },
+  "name.failure": {
+    "message": "失敗",
+    "description": "失敗狀態"
+  },
+  "name.failureReason": {
+    "message": "失敗原因",
+    "description": "失敗原因"
+  },
+  "name.sourceType": {
+    "message": "來源類型",
+    "description": "來源類型字段"
+  },
+  "name.sourceRef": {
+    "message": "內容",
+    "description": "來源內容字段"
+  },
+  "name.lang": {
+    "message": "主語言",
+    "description": "主要語言字段"
+  },
+  "name.extraLangs": {
+    "message": "額外語言",
+    "description": "額外語言版本字段"
+  },
+  "name.aspect": {
+    "message": "畫面比例",
+    "description": "畫面比例字段"
+  },
+  "name.duration": {
+    "message": "時長",
+    "description": "目標時長字段"
+  },
+  "name.music": {
+    "message": "背景音樂",
+    "description": "音樂切換字段"
+  },
+  "option.topic": {
+    "message": "話題",
+    "description": "來源類型：一個話題/標題"
+  },
+  "option.article": {
+    "message": "文章",
+    "description": "來源類型：完整文章文本"
+  },
+  "placeholder.sourceRef": {
+    "message": "輸入一個話題(如“什麼是向量資料庫”)或粘貼整篇文章…",
+    "description": "來源文本區域佔位符"
+  },
+  "placeholder.select": {
+    "message": "請選擇",
+    "description": "通用選擇佔位符"
+  },
+  "description.sourceRef": {
+    "message": "一個話題/標題，或要做成視頻的整篇文章正文。",
+    "description": "來源字段幫助"
+  },
+  "description.extraLangs": {
+    "message": "重用畫面，額外產出這些語言版本（每種 +6 積分）。",
+    "description": "額外語言幫助"
+  },
+  "status.pending": {
+    "message": "排隊中",
+    "description": "等待中"
+  },
+  "status.scripting": {
+    "message": "腳本生成中",
+    "description": "正在生成腳本"
+  },
+  "status.generating": {
+    "message": "畫面生成中",
+    "description": "正在生成"
+  },
+  "status.rendering": {
+    "message": "渲染中",
+    "description": "正在渲染"
+  },
+  "status.processing": {
+    "message": "處理中",
+    "description": "正在處理"
+  },
+  "button.generate": {
+    "message": "生成視頻",
+    "description": "生成按鈕"
+  },
+  "button.download": {
+    "message": "下載視頻",
+    "description": "下載視頻按鈕"
+  },
+  "button.downloadCaptions": {
+    "message": "下載字幕",
+    "description": "下載 srt 按鈕"
+  },
+  "message.startingTask": {
+    "message": "正在提交視頻任務…",
+    "description": "提交提示"
+  },
+  "message.startTaskSuccess": {
+    "message": "任務已提交！渲染進度會顯示在下方。",
+    "description": "提交成功"
+  },
+  "message.startTaskFailed": {
+    "message": "任務提交失敗，請重試。",
+    "description": "提交失敗"
+  },
+  "message.usedUp": {
+    "message": "額度已用完，請充值後繼續。",
+    "description": "已用完"
+  },
+  "message.downloadVideo": {
+    "message": "下載生成的視頻",
+    "description": "下載提示"
+  },
+  "message.noTasks": {
+    "message": "還沒有視頻 — 在左側創建你的第一個吧。",
+    "description": "沒有任務"
+  }
+}

--- a/src/layouts/Maestro.vue
+++ b/src/layouts/Maestro.vue
@@ -1,0 +1,57 @@
+<template>
+  <div class="main flex flex-row flex-1">
+    <div
+      class="config w-[320px] flex-none h-full overflow-y-auto bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+    >
+      <slot name="config" />
+    </div>
+    <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
+      <slot name="result" />
+    </div>
+    <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
+      <font-awesome-icon icon="fa-solid fa-magic" />
+    </el-button>
+    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="350px">
+      <slot name="config" />
+    </el-drawer>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElDrawer, ElButton } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import taskDrawerMixin from '@/utils/taskDrawerMixin';
+
+export default defineComponent({
+  name: 'LayoutMaestro',
+  components: {
+    ElDrawer,
+    ElButton,
+    FontAwesomeIcon
+  },
+  mixins: [taskDrawerMixin]
+});
+</script>
+
+<style lang="scss" scoped>
+.menu {
+  display: none;
+}
+
+@media (max-width: 767px) {
+  .config {
+    display: none;
+  }
+  .result {
+    width: 100%;
+  }
+  .menu {
+    display: block;
+    position: absolute;
+    right: 8px;
+    top: calc(45px + var(--app-safe-area-top));
+    z-index: 1000;
+  }
+}
+</style>

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -16,6 +16,7 @@ export * from './pika';
 export * from './kling';
 export * from './veo';
 export * from './sora';
+export * from './maestro';
 export * from './pixverse';
 export * from './flux';
 export * from './hailuo';

--- a/src/models/maestro.ts
+++ b/src/models/maestro.ts
@@ -1,0 +1,63 @@
+export interface IMaestroConfig {
+  source_type?: string; // 'Topic' | 'Article'
+  source_ref?: string;
+  lang?: string;
+  extra_langs?: string[];
+  aspect?: string; // '9:16' | '16:9' | '1:1'
+  duration?: number;
+  music?: boolean;
+  callback_url?: string;
+}
+
+export interface IMaestroGenerateRequest extends IMaestroConfig {
+  async?: boolean;
+}
+
+export interface IMaestroVariant {
+  variant?: string;
+  lang?: string;
+  aspect?: string;
+  output_url?: string;
+  captions_url?: string;
+  duration?: number;
+  qc_score?: number | null;
+  state?: string;
+}
+
+export interface IMaestroStoryboard {
+  title?: string;
+  hook?: string;
+  scenes?: unknown[];
+}
+
+export interface IMaestroData {
+  variants?: IMaestroVariant[];
+  storyboard?: IMaestroStoryboard;
+}
+
+export interface IMaestroGenerateResponse {
+  success: boolean;
+  task_id: string;
+  trace_id?: string;
+  data?: IMaestroData;
+  error?: {
+    code?: string;
+    message?: string;
+  };
+}
+
+export interface IMaestroTask {
+  id: string;
+  status?: string;
+  created_at?: number;
+  elapsed?: number;
+  request?: IMaestroGenerateRequest;
+  response?: IMaestroGenerateResponse;
+}
+
+export type IMaestroTaskResponse = IMaestroTask;
+
+export interface IMaestroTasksResponse {
+  count: number;
+  items: IMaestroTask[];
+}

--- a/src/models/site.ts
+++ b/src/models/site.ts
@@ -12,6 +12,7 @@ export interface ISiteFeatures {
   kling?: any;
   veo?: any;
   sora?: any;
+  maestro?: any;
   pixverse?: any;
   hailuo?: any;
   headshots?: any;

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -17,6 +17,7 @@ export * from './pika';
 export * from './kling';
 export * from './veo';
 export * from './sora';
+export * from './maestro';
 export * from './pixverse';
 export * from './flux';
 export * from './hailuo';

--- a/src/operators/maestro.ts
+++ b/src/operators/maestro.ts
@@ -1,0 +1,21 @@
+import {
+  IMaestroGenerateRequest,
+  IMaestroGenerateResponse,
+  IMaestroTaskResponse,
+  IMaestroTasksResponse
+} from '@/models';
+import { BaseTaskOperator, ITaskListFilter } from './baseTaskOperator';
+
+class MaestroOperator extends BaseTaskOperator<
+  IMaestroGenerateRequest,
+  IMaestroGenerateResponse,
+  IMaestroTaskResponse,
+  IMaestroTasksResponse,
+  ITaskListFilter & { type?: string }
+> {
+  constructor() {
+    super({ tasksPath: '/maestro/tasks', generatePath: '/maestro/videos' });
+  }
+}
+
+export const maestroOperator = new MaestroOperator();

--- a/src/pages/maestro/Index.vue
+++ b/src/pages/maestro/Index.vue
@@ -16,7 +16,7 @@ import ConfigPanel from '@/components/maestro/ConfigPanel.vue';
 import RecentPanel from '@/components/maestro/RecentPanel.vue';
 import { maestroOperator } from '@/operators';
 import { instrumentGeneration } from '@/plugins/telemetry';
-import { IMaestroGenerateRequest, IMaestroTask, Status } from '@/models';
+import { IMaestroGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
 import { ERROR_CODE_USED_UP } from '@/constants';
 import { loadPreviousPage } from '@/utils/pagination';

--- a/src/pages/maestro/Index.vue
+++ b/src/pages/maestro/Index.vue
@@ -1,0 +1,152 @@
+<template>
+  <layout>
+    <template #config>
+      <config-panel @generate="onGenerate" />
+    </template>
+    <template #result>
+      <recent-panel ref="recentPanel" :loading="loadingMore" @reach-top="onReachTop" />
+    </template>
+  </layout>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import Layout from '@/layouts/Maestro.vue';
+import ConfigPanel from '@/components/maestro/ConfigPanel.vue';
+import RecentPanel from '@/components/maestro/RecentPanel.vue';
+import { maestroOperator } from '@/operators';
+import { instrumentGeneration } from '@/plugins/telemetry';
+import { IMaestroGenerateRequest, IMaestroTask, Status } from '@/models';
+import { ElMessage } from 'element-plus';
+import { ERROR_CODE_USED_UP } from '@/constants';
+import { loadPreviousPage } from '@/utils/pagination';
+
+interface IData {
+  job: number;
+  loadingMore: boolean;
+  fetchingTasks: boolean;
+}
+
+export default defineComponent({
+  name: 'MaestroIndex',
+  components: {
+    ConfigPanel,
+    Layout,
+    RecentPanel
+  },
+  inject: ['initialized'],
+  data(): IData {
+    return {
+      job: 0,
+      loadingMore: false,
+      fetchingTasks: false
+    };
+  },
+  computed: {
+    applicationsLoading() {
+      return this.$store.state.maestro?.status?.getApplications === Status.Request;
+    },
+    tasksLoading() {
+      return this.$store.state.maestro?.status?.getTasks === Status.Request || this.fetchingTasks;
+    },
+    credential() {
+      return this.$store.state.maestro.credential;
+    },
+    config() {
+      return this.$store.state.maestro.config;
+    },
+    tasks() {
+      return this.$store.state.maestro.tasks;
+    }
+  },
+  watch: {
+    initialized: {
+      async handler(newValue) {
+        if (newValue) {
+          await this.onGetTasks();
+          await this.onScrollDown();
+          this.job = window.setInterval(() => {
+            this.onGetTasks();
+          }, 5000);
+        }
+      },
+      immediate: true
+    }
+  },
+  async mounted() {
+    await this.onGetService();
+  },
+  async unmounted() {
+    window.clearInterval(this.job);
+  },
+  methods: {
+    async onReachTop() {
+      await loadPreviousPage({
+        tasks: this.tasks,
+        getTasks: () => this.tasks,
+        loading: this.loadingMore,
+        setLoading: (v) => (this.loadingMore = v),
+        isBlocked: () => this.tasksLoading || this.applicationsLoading,
+        fetch: (createdAtMax) => this.onGetTasks({ createdAtMax }),
+        getScrollElement: () => this.getTasksScrollElement()
+      });
+    },
+    async onGetService() {
+      await this.$store.dispatch('maestro/getService');
+    },
+    async onScrollDown() {
+      await this.$nextTick();
+      const el = this.getTasksScrollElement();
+      if (el) {
+        el.scrollTop = el.scrollHeight;
+      }
+    },
+    async onGetTasks(payload?: { limit?: number; createdAtMin?: number; createdAtMax?: number }) {
+      if (this.applicationsLoading || this.fetchingTasks) {
+        return;
+      }
+      const { limit = 5, createdAtMin, createdAtMax } = payload || {};
+      this.fetchingTasks = true;
+      try {
+        await this.$store.dispatch('maestro/getTasks', { limit, createdAtMin, createdAtMax });
+      } finally {
+        this.fetchingTasks = false;
+      }
+    },
+    async onGenerate() {
+      const request = {
+        ...this.config,
+        async: true
+      } as IMaestroGenerateRequest;
+      const token = this.credential?.token;
+      if (!token) {
+        console.error('no token specified');
+        return;
+      }
+      ElMessage.info(this.$t('maestro.message.startingTask'));
+      instrumentGeneration('maestro', maestroOperator.generate(request, { token }))
+        .then(() => {
+          ElMessage.success(this.$t('maestro.message.startTaskSuccess'));
+        })
+        .catch((error) => {
+          const response = error?.response?.data;
+          if (response?.error?.code === ERROR_CODE_USED_UP) {
+            ElMessage.error(this.$t('maestro.message.usedUp'));
+          } else {
+            ElMessage.error(this.$t('maestro.message.startTaskFailed'));
+          }
+        })
+        .finally(async () => {
+          setTimeout(async () => {
+            await this.onGetTasks();
+            await this.onScrollDown();
+          }, 1000);
+        });
+    },
+    getTasksScrollElement(): HTMLElement | undefined {
+      const panel = this.$refs.recentPanel as any;
+      return panel?.getScrollElement?.();
+    }
+  }
+});
+</script>

--- a/src/router/constants.ts
+++ b/src/router/constants.ts
@@ -40,6 +40,7 @@ export const ROUTE_VEO_HISTORY = 'veo-history';
 
 export const ROUTE_SORA_INDEX = 'sora-index';
 export const ROUTE_SORA_HISTORY = 'sora-history';
+export const ROUTE_MAESTRO_INDEX = 'maestro-index';
 
 export const ROUTE_PIXVERSE_INDEX = 'pixverse-index';
 export const ROUTE_PIXVERSE_HISTORY = 'pixverse-history';

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -18,6 +18,7 @@ import pika from './pika';
 import kling from './kling';
 import veo from './veo';
 import sora from './sora';
+import maestro from './maestro';
 import pixverse from './pixverse';
 import flux from './flux';
 import hailuo from './hailuo';
@@ -57,6 +58,7 @@ import {
   ROUTE_KLING_INDEX,
   ROUTE_VEO_INDEX,
   ROUTE_SORA_INDEX,
+  ROUTE_MAESTRO_INDEX,
   ROUTE_PIXVERSE_INDEX,
   ROUTE_WAN_INDEX,
   ROUTE_SERP_INDEX,
@@ -163,6 +165,13 @@ const ROUTE_SEO: Record<string, { title: string; description: string; keywords: 
     title: 'Sora',
     description: 'Generate AI videos with OpenAI Sora — create realistic videos from text descriptions.',
     keywords: ['Sora', 'OpenAI', 'AI Video', 'Video Generation', 'Text to Video'],
+    category: 'AI Video Generation'
+  },
+  maestro: {
+    title: 'Maestro',
+    description:
+      'Turn any article or topic into a captioned short video — script, visuals, voiceover and music, fully automated.',
+    keywords: ['Maestro', 'AI Video', 'Article to Video', 'Faceless Video', 'Short Video Generator'],
     category: 'AI Video Generation'
   },
   veo: {
@@ -287,6 +296,7 @@ const FEATURE_ROUTE_PRIORITY: Array<[string, string]> = [
   ['fish', ROUTE_FISH_TTS_INDEX],
   ['veo', ROUTE_VEO_INDEX],
   ['sora', ROUTE_SORA_INDEX],
+  ['maestro', ROUTE_MAESTRO_INDEX],
   ['kling', ROUTE_KLING_INDEX],
   ['luma', ROUTE_LUMA_INDEX],
   ['hailuo', ROUTE_HAILUO_INDEX],
@@ -333,6 +343,7 @@ export const routes = [
   kling,
   veo,
   sora,
+  maestro,
   pixverse,
   flux,
   hailuo,

--- a/src/router/maestro.ts
+++ b/src/router/maestro.ts
@@ -1,0 +1,17 @@
+import { ROUTE_MAESTRO_INDEX } from './constants';
+
+export default {
+  path: '/maestro',
+  meta: {
+    auth: true,
+    appName: 'maestro'
+  },
+  component: () => import('@/layouts/Main.vue'),
+  children: [
+    {
+      path: '',
+      name: ROUTE_MAESTRO_INDEX,
+      component: () => import('@/pages/maestro/Index.vue')
+    }
+  ]
+};

--- a/src/store/common/models.ts
+++ b/src/store/common/models.ts
@@ -7,6 +7,7 @@ import { IPikaState } from '../pika/models';
 import { IKlingState } from '../kling/models';
 import { IVeoState } from '../veo/models';
 import { ISoraState } from '../sora/models';
+import { IMaestroState } from '../maestro/models';
 import { IPixverseState } from '../pixverse/models';
 import { IFluxState } from '../flux/models';
 import { IHailuoState } from '../hailuo/models';
@@ -60,6 +61,7 @@ export interface IAppState {
   kling: IKlingState;
   veo: IVeoState;
   sora: ISoraState;
+  maestro: IMaestroState;
   pixverse: IPixverseState;
   flux: IFluxState;
   hailuo: IHailuoState;

--- a/src/store/common/state.ts
+++ b/src/store/common/state.ts
@@ -7,6 +7,7 @@ import pikaState from '../pika/state';
 import klingState from '../kling/state';
 import veoState from '../veo/state';
 import soraState from '../sora/state';
+import maestroState from '../maestro/state';
 import pixverseState from '../pixverse/state';
 import fluxState from '../flux/state';
 import hailuoState from '../hailuo/state';
@@ -55,6 +56,7 @@ export default (): IRootState => {
     pika: pikaState(),
     kling: klingState(),
     sora: soraState(),
+    maestro: maestroState(),
     veo: veoState(),
     pixverse: pixverseState(),
     flux: fluxState(),

--- a/src/store/lazy.ts
+++ b/src/store/lazy.ts
@@ -30,6 +30,7 @@ const moduleLoaders: Record<string, () => Promise<{ default: AnyVuexModule }>> =
   kling: () => import('./kling'),
   veo: () => import('./veo'),
   sora: () => import('./sora'),
+  maestro: () => import('./maestro'),
   pixverse: () => import('./pixverse'),
   flux: () => import('./flux'),
   hailuo: () => import('./hailuo'),

--- a/src/store/maestro/actions.ts
+++ b/src/store/maestro/actions.ts
@@ -1,0 +1,12 @@
+import { maestroOperator } from '@/operators';
+import { IMaestroConfig, IMaestroTask } from '@/models';
+import { MAESTRO_SERVICE_ID } from '@/constants';
+import { createTaskActions } from '@/store/factories/createTaskActions';
+
+const actions = createTaskActions<IMaestroConfig, IMaestroTask, Record<string, unknown>>({
+  serviceId: MAESTRO_SERVICE_ID,
+  operator: maestroOperator,
+  type: 'videos'
+});
+
+export default actions;

--- a/src/store/maestro/index.ts
+++ b/src/store/maestro/index.ts
@@ -1,0 +1,14 @@
+import { Module } from 'vuex';
+import { IMaestroState } from './models';
+import actions from './actions';
+import mutations from './mutations';
+import state from './state';
+
+export const maestro: Module<IMaestroState, any> = {
+  namespaced: true,
+  state,
+  mutations,
+  actions
+};
+
+export default maestro;

--- a/src/store/maestro/models.ts
+++ b/src/store/maestro/models.ts
@@ -1,0 +1,22 @@
+import { IApplication, ICredential, IService, Status } from '@/models';
+import { IMaestroConfig, IMaestroTask } from '@/models';
+
+export interface IMaestroState {
+  application: IApplication | undefined;
+  applications: IApplication[] | undefined;
+  service: IService | undefined;
+  credential: ICredential | undefined;
+  config: IMaestroConfig | undefined;
+  tasks:
+    | {
+        items: IMaestroTask[] | undefined;
+        total: number | undefined;
+        active: IMaestroTask | undefined;
+      }
+    | undefined;
+  status: {
+    getService: Status;
+    getApplications: Status;
+    getTasks: Status;
+  };
+}

--- a/src/store/maestro/mutations.ts
+++ b/src/store/maestro/mutations.ts
@@ -1,0 +1,68 @@
+import { IApplication, ICredential, IMaestroConfig, IMaestroTask, IService } from '@/models';
+import initialState from './state';
+import { IMaestroState } from './models';
+
+export const resetAll = (state: IMaestroState): void => {
+  Object.assign(state, initialState());
+};
+
+export const setService = (state: IMaestroState, payload: IService): void => {
+  state.service = payload;
+};
+
+export const setCredential = (state: IMaestroState, payload: ICredential): void => {
+  state.credential = payload;
+};
+
+export const setApplication = (state: IMaestroState, payload: IApplication): void => {
+  state.application = payload;
+};
+
+export const setApplications = (state: IMaestroState, payload: IApplication[]): void => {
+  state.applications = payload;
+};
+
+export const setConfig = (state: IMaestroState, payload: IMaestroConfig): void => {
+  state.config = payload;
+};
+
+export const setTasksItems = (state: IMaestroState, payload: IMaestroTask[]): void => {
+  const newPayload = {
+    ...state.tasks,
+    items: payload
+  } as typeof state.tasks;
+  state.tasks = newPayload;
+};
+
+export const setTasksTotal = (state: IMaestroState, payload: number): void => {
+  const newPayload = {
+    ...state.tasks,
+    total: payload
+  } as typeof state.tasks;
+  state.tasks = newPayload;
+};
+
+export const setTasksActive = (state: IMaestroState, payload: IMaestroTask): void => {
+  const newPayload = {
+    ...state.tasks,
+    active: payload
+  } as typeof state.tasks;
+  state.tasks = newPayload;
+};
+
+export const setTasks = (state: IMaestroState, payload: any): void => {
+  state.tasks = payload;
+};
+
+export default {
+  setTasks,
+  setApplication,
+  setApplications,
+  setConfig,
+  setCredential,
+  setService,
+  setTasksActive,
+  setTasksItems,
+  setTasksTotal,
+  resetAll
+};

--- a/src/store/maestro/persist.ts
+++ b/src/store/maestro/persist.ts
@@ -1,0 +1,2 @@
+// See flux/persist.ts for why `.tasks` is no longer persisted.
+export default ['maestro.credential', 'maestro.application', 'maestro.applications'];

--- a/src/store/maestro/state.ts
+++ b/src/store/maestro/state.ts
@@ -1,0 +1,18 @@
+import { IMaestroState } from './models';
+import { Status } from '@/models';
+
+export default (): IMaestroState => {
+  return {
+    service: undefined,
+    application: undefined,
+    applications: undefined,
+    tasks: undefined,
+    credential: undefined,
+    config: undefined,
+    status: {
+      getService: Status.None,
+      getApplications: Status.None,
+      getTasks: Status.None
+    }
+  };
+};


### PR DESCRIPTION
## What

Adds the **Nexior consumer surface** for Maestro — the article→video service (`api.acedata.cloud/maestro/videos` + `/maestro/tasks`). Mirrors the existing async-video pattern (sora/luma).

- **Store** `src/store/maestro/` via the `createTaskActions` factory; lazy-registered in `store/lazy.ts`.
- **Operator** `maestroOperator` extends `BaseTaskOperator` (`/maestro/videos`, `/maestro/tasks`).
- **Models + constants** (service `0d7031bf…`; langs / aspects / durations).
- **Route** `/maestro` + nav entry (gated on `site.features.maestro.enabled`) + `ROUTE_SEO`.
- **UI**: `ConfigPanel` (source type/content, main + extra languages, aspect, duration, music) with live consumption; `RecentPanel`; multi-variant `Preview` (one player per language + caption download); `Maestro` layout.
- **i18n** en + zh-CN authored; the other 16 locales backfilled by `translate_i18n.py`.

## Verification

`npm run lint` clean, `vue-tsc --noEmit` clean, `check_i18n_coverage.py` passes (18 locales × 42 namespaces).

Backend support for the consumer history list (`retrieve_batch`) shipped in PlatformService #1063.

> To launch in a site, flip `site.features.maestro.enabled` (the nav entry + route are gated on it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)