### PR TITLE
docs(readme): 给 Free-key CTA 加增长归因(inviter + utm)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <p>
   <a href="https://hub.acedata.cloud">🚀 Live Demo</a> ·
   <a href="#-quick-start">⚡ Deploy in minutes</a> ·
-  <a href="https://platform.acedata.cloud">🔑 Free API key</a> ·
+  <a href="https://platform.acedata.cloud/?inviter_id=4c37bac7-d460-4d5e-8a72-8d5312050f2c&utm_source=github&utm_campaign=nexior">🔑 Free API key</a> ·
   <a href="https://discord.gg/f9GRuKCmRc">💬 Discord</a> ·
   <a href="#-star-us">⭐ Star us</a>
 </p>
@@ -78,7 +78,7 @@ cp .env.example .env.local
 npm run dev
 ```
 
-Get a key (free quota) at **[platform.acedata.cloud](https://platform.acedata.cloud)**. Full guides → [`docs/deploy/`](docs/deploy/).
+Get a key (free quota) at **[platform.acedata.cloud](https://platform.acedata.cloud/?inviter_id=4c37bac7-d460-4d5e-8a72-8d5312050f2c&utm_source=github&utm_campaign=nexior)**. Full guides → [`docs/deploy/`](docs/deploy/).
 
 ---
 
@@ -136,7 +136,7 @@ Stars don't pay rent — but they tell the next builder, the next agent, and the
 
 ## 🤝 Community & support
 
-- 🔑 Free API key & docs: <https://platform.acedata.cloud>
+- 🔑 Free API key & docs: <https://platform.acedata.cloud/?inviter_id=4c37bac7-d460-4d5e-8a72-8d5312050f2c&utm_source=github&utm_campaign=nexior>
 - 💬 Discord: <https://discord.gg/f9GRuKCmRc>
 - 🐦 Follow on X: [@acedatacloud](https://x.com/acedatacloud)
 - 📧 Email: office@acedata.cloud


### PR DESCRIPTION
Workstream A.2 — 把注册 CTA 打上增长归因,让内容驱动的注册可追踪。

- 三处「Free API key」CTA → `?inviter_id=4c37bac7-…&utm_source=github&utm_campaign=nexior`
- 不动品牌/部署/support/license 链接。

纯 README。