### PR TITLE
docs(readme): 服务阵容刷新 — 下架 Sora,新增 Kimi/Wan/Grok Video/Fish/Producer

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,21 +98,11 @@ Deploy once, and `your-domain.com` is a revenue-ready AI product. Zero startup c
 
 ## 🖼️ Preview
 
-| Chat (ChatGPT) | Image (Midjourney) | Music (Suno) | Video (Veo) |
+| 💬 Chat (ChatGPT) | 🖼️ Image (Midjourney) | 🎬 Video (Kling) | 🎵 Music (Suno) |
 |---|---|---|---|
-| ![chat](https://cdn.acedata.cloud/wqzm9r.png) | ![mj](https://cdn.acedata.cloud/0oqva0.png) | ![suno](https://cdn.acedata.cloud/999o20.png) | ![veo](https://cdn.acedata.cloud/rkzqx1.png) |
+| ![chat](https://cdn.acedata.cloud/52dff32e47.png) | ![midjourney](https://cdn.acedata.cloud/5fbabf5c24.png) | ![kling](https://cdn.acedata.cloud/c1ccb5775f.png) | ![suno](https://cdn.acedata.cloud/b64fe23e7c.png) |
 
-<details>
-<summary>More previews (DeepSeek · Grok · Gemini · NanoBanana · Flux · Kling · Hailuo · Luma)</summary>
-
-| | |
-|---|---|
-| DeepSeek ![](https://cdn.acedata.cloud/sqe72j.png) | Grok ![](https://cdn.acedata.cloud/5cl1ea.png) |
-| Gemini ![](https://cdn.acedata.cloud/6l28bw.png) | Nano Banana ![](https://cdn.acedata.cloud/j0h3l3.png) |
-| Flux ![](https://cdn.acedata.cloud/b18s04.png) | Kling ![](https://cdn.acedata.cloud/gt5hv9.png) |
-| Hailuo ![](https://cdn.acedata.cloud/c2jh0d.png) | Luma ![](https://cdn.acedata.cloud/q93b6q.png) |
-
-</details>
+> Try them all live → **[studio.acedata.cloud](https://studio.acedata.cloud)**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### The open-source, self-hostable **all-in-one AI app**
 
-**Every model in one app — ChatGPT · Claude · Gemini · Grok · DeepSeek · Midjourney · Flux · Suno · Sora · Veo · Kling · Seedance — deploy your own in minutes. BYOK or one-key. MIT licensed.**
+**Every model in one app — ChatGPT · Claude · Gemini · Grok · DeepSeek · Kimi · Midjourney · Flux · Suno · Veo · Kling · Hailuo · Wan — deploy your own in minutes. BYOK or one-key. MIT licensed.**
 
 一个开源、可自托管的**全能 AI 应用** —— 聊天 / 图片 / 音乐 / 视频 的所有模型,一处搞定。几分钟部署你自己的,BYOK 或一键直用,MIT 协议。
 
@@ -48,10 +48,10 @@
 
 | Modality | Models |
 |---|---|
-| 💬 **AI Chat** | ChatGPT · Claude · Gemini · Grok · DeepSeek |
+| 💬 **AI Chat** | ChatGPT · Claude · Gemini · Grok · DeepSeek · Kimi |
 | 🖼️ **AI Image** | Midjourney · Flux · OpenAI Image · Seedream · NanoBanana · QR Art · Headshots |
-| 🎵 **AI Music** | Suno |
-| 🎬 **AI Video** | Sora · Veo · Kling · Luma · Hailuo · Pixverse · Seedance · Pika |
+| 🎵 **AI Music & Voice** | Suno · Producer · Fish (TTS) |
+| 🎬 **AI Video** | Veo · Kling · Luma · Hailuo · Pixverse · Seedance · Pika · Wan · Grok Video |
 
 All capabilities ship with a **free trial** — no credit card to try.
 
@@ -98,20 +98,19 @@ Deploy once, and `your-domain.com` is a revenue-ready AI product. Zero startup c
 
 ## 🖼️ Preview
 
-| Chat (ChatGPT) | Image (Midjourney) | Music (Suno) | Video (Sora) |
+| Chat (ChatGPT) | Image (Midjourney) | Music (Suno) | Video (Veo) |
 |---|---|---|---|
-| ![chat](https://cdn.acedata.cloud/wqzm9r.png) | ![mj](https://cdn.acedata.cloud/0oqva0.png) | ![suno](https://cdn.acedata.cloud/999o20.png) | ![sora](https://cdn.acedata.cloud/r1cmvk.png) |
+| ![chat](https://cdn.acedata.cloud/wqzm9r.png) | ![mj](https://cdn.acedata.cloud/0oqva0.png) | ![suno](https://cdn.acedata.cloud/999o20.png) | ![veo](https://cdn.acedata.cloud/rkzqx1.png) |
 
 <details>
-<summary>More previews (DeepSeek · Grok · Gemini · NanoBanana · Flux · Veo · Kling · Hailuo · Luma · Midjourney)</summary>
+<summary>More previews (DeepSeek · Grok · Gemini · NanoBanana · Flux · Kling · Hailuo · Luma)</summary>
 
 | | |
 |---|---|
-| DeepSeek Chat ![](https://cdn.acedata.cloud/sqe72j.png) | Grok Chat ![](https://cdn.acedata.cloud/5cl1ea.png) |
-| Gemini Chat ![](https://cdn.acedata.cloud/6l28bw.png) | Nano Banana ![](https://cdn.acedata.cloud/j0h3l3.png) |
-| Flux ![](https://cdn.acedata.cloud/b18s04.png) | Veo ![](https://cdn.acedata.cloud/rkzqx1.png) |
-| Kling ![](https://cdn.acedata.cloud/gt5hv9.png) | Hailuo ![](https://cdn.acedata.cloud/c2jh0d.png) |
-| Luma ![](https://cdn.acedata.cloud/q93b6q.png) | Midjourney ![](https://cdn.acedata.cloud/5u5tin.png) |
+| DeepSeek ![](https://cdn.acedata.cloud/sqe72j.png) | Grok ![](https://cdn.acedata.cloud/5cl1ea.png) |
+| Gemini ![](https://cdn.acedata.cloud/6l28bw.png) | Nano Banana ![](https://cdn.acedata.cloud/j0h3l3.png) |
+| Flux ![](https://cdn.acedata.cloud/b18s04.png) | Kling ![](https://cdn.acedata.cloud/gt5hv9.png) |
+| Hailuo ![](https://cdn.acedata.cloud/c2jh0d.png) | Luma ![](https://cdn.acedata.cloud/q93b6q.png) |
 
 </details>
 


### PR DESCRIPTION
README 阵容纠错 + 截图刷新(#990 归因合并后的后续)。

## 改了什么
- **下架 Sora**(产品层已下架):首屏文案、模型表、预览图全部移除。
- **新增在售服务**(来源:Nexior `router/index.ts` ROUTE_SEO + `store/lazy.ts` 真实 catalog):Kimi(对话)、Wan + Grok Video(视频)、Producer + Fish/TTS(音乐与语音)。
- **全新截图**:登录 studio.acedata.cloud(.claude/.env 的 admin 测试账号),实拍当前深色 UI 的真实生成结果并传 CDN——ChatGPT、Midjourney(真实出图)、Kling(视频)、Suno(曲目)。
- 去掉旧的浅色混代预览网格,风格统一;新增 live 试用入口。

## 隐私
截图只截主内容,隐藏了含私人标题的会话侧栏(Gmail/IP 等不入公共 README)。

纯 README。