### PR TITLE
docs(readme): 预览图换成 NanoBanana(图)+ Seedance(视频)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ Deploy once, and `your-domain.com` is a revenue-ready AI product. Zero startup c
 
 ## 🖼️ Preview
 
-| 💬 Chat (ChatGPT) | 🖼️ Image (Midjourney) | 🎬 Video (Kling) | 🎵 Music (Suno) |
+| 💬 Chat (ChatGPT) | 🖼️ Image (NanoBanana) | 🎬 Video (Seedance) | 🎵 Music (Suno) |
 |---|---|---|---|
-| ![chat](https://cdn.acedata.cloud/52dff32e47.png) | ![midjourney](https://cdn.acedata.cloud/5fbabf5c24.png) | ![kling](https://cdn.acedata.cloud/c1ccb5775f.png) | ![suno](https://cdn.acedata.cloud/b64fe23e7c.png) |
+| ![chat](https://cdn.acedata.cloud/52dff32e47.png) | ![nanobanana](https://cdn.acedata.cloud/930d011b58.png) | ![seedance](https://cdn.acedata.cloud/f0bf58571a.png) | ![suno](https://cdn.acedata.cloud/b64fe23e7c.png) |
 
 > Try them all live → **[studio.acedata.cloud](https://studio.acedata.cloud)**
 


### PR DESCRIPTION
按要求把预览的图片换成 **NanoBanana**、视频换成 **Seedance**,都是登录 studio.acedata.cloud 后**人工挑的好结果**(没有失败/残缺的生成):
- 图:NanoBanana 的 9:16 高级品牌 3D 渲染(玻璃台座上的发光徽标)
- 视频:Seedance 的数据中心可视化 b-roll(单条、画面干净)

Chat / Suno 保持不变。纯 README。