### PR TITLE
docs(readme): 缩短邀请链接的显示文字

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Stars don't pay rent — but they tell the next builder, the next agent, and the
 
 ## 🤝 Community & support
 
-- 🔑 Free API key & docs: <https://platform.acedata.cloud/?inviter_id=4c37bac7-d460-4d5e-8a72-8d5312050f2c&utm_source=github&utm_campaign=nexior>
+- 🔑 Free API key & docs: [platform.acedata.cloud](https://platform.acedata.cloud/?inviter_id=4c37bac7-d460-4d5e-8a72-8d5312050f2c&utm_source=github&utm_campaign=nexior)
 - 💬 Discord: <https://discord.gg/f9GRuKCmRc>
 - 🐦 Follow on X: [@acedatacloud](https://x.com/acedatacloud)
 - 📧 Email: office@acedata.cloud


### PR DESCRIPTION
社区区块的「Free API key & docs」之前是裸 autolink `<https://…长链接…>`,会把完整邀请 URL 当文字显示出来,太长。改成 markdown 链接:**显示文字只剩 `platform.acedata.cloud`,完整归因 URL 仍在 href 里**(链接照常带 inviter_id + utm)。其余 CTA(顶部 HTML、quick-start markdown)本来就是短文字。纯 README 一行。