### PR TITLE
feat(realtime): voice call UI inside ChatGPT (OpenAI Realtime)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -52,6 +52,7 @@
 
     <!-- Permissions -->
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />

--- a/change/@acedatacloud-nexior-c73f4bf3-00d5-4119-8498-3753d5e04917.json
+++ b/change/@acedatacloud-nexior-c73f4bf3-00d5-4119-8498-3753d5e04917.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Real-time voice call inside ChatGPT (OpenAI Realtime): mic button -> call screen, 24kHz PCM16 AudioWorklet, streamed playback, server-VAD barge-in",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -24,6 +24,8 @@
 	<false/>
 	<key>NSCameraUsageDescription</key>
 	<string>This app needs camera access so you can take a photo to attach to your chat messages.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>This app needs microphone access to enable real-time voice calls.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>This app needs photo library access so you can attach images to your chat messages.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>

--- a/public/recorder-worklet.js
+++ b/public/recorder-worklet.js
@@ -1,0 +1,31 @@
+// AudioWorklet running inside a 24 kHz AudioContext.
+// Receives mono float32 mic frames, batches them, converts to PCM16,
+// and posts ArrayBuffers to the main thread. Used by the realtime voice call.
+class RecorderProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this._buf = new Int16Array(2048);
+    this._n = 0;
+  }
+
+  process(inputs) {
+    const input = inputs[0];
+    if (!input || input.length === 0) return true;
+    const ch = input[0];
+    if (!ch) return true;
+
+    for (let i = 0; i < ch.length; i++) {
+      let s = ch[i];
+      s = s < -1 ? -1 : s > 1 ? 1 : s;
+      this._buf[this._n++] = s < 0 ? s * 0x8000 : s * 0x7fff;
+      if (this._n === this._buf.length) {
+        const out = this._buf.slice(0, this._n);
+        this.port.postMessage(out.buffer, [out.buffer]);
+        this._n = 0;
+      }
+    }
+    return true;
+  }
+}
+
+registerProcessor('recorder-processor', RecorderProcessor);

--- a/src/constants/endpoint.ts
+++ b/src/constants/endpoint.ts
@@ -15,6 +15,10 @@ export const BASE_URL_CODING_BRIDGE = isTest
 // Browser WebSocket endpoint: same host, https -> wss / http -> ws, path `/ws`.
 export const WS_URL_CODING_BRIDGE = `${BASE_URL_CODING_BRIDGE.replace(/^http/, 'ws')}/ws`;
 
+// OpenAI-compatible Realtime voice endpoint (WebSocket), drop-in with the
+// official API. Token is passed via the Sec-WebSocket-Protocol subprotocol.
+export const WS_URL_REALTIME = `${BASE_URL_API.replace(/^http/, 'ws')}/v1/realtime`;
+
 export const BASE_HOST_PLATFORM = new URL(BASE_URL_PLATFORM).host;
 export const BASE_HOST_HUB = new URL(BASE_URL_HUB).host;
 export const BASE_HOST_AUTH = new URL(BASE_URL_AUTH).host;

--- a/src/constants/i18n.ts
+++ b/src/constants/i18n.ts
@@ -63,5 +63,6 @@ export const I18N_SCOPES = [
   'byok',
   'subsite',
   'webextrator',
-  'codingBridge'
+  'codingBridge',
+  'realtime'
 ];

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -3,6 +3,7 @@ export * from './errorStatus';
 export * from './endpoint';
 export * from './action';
 export * from './chat';
+export * from './realtime';
 export * from './midjourney';
 export * from './qrart';
 export * from './luma';

--- a/src/constants/realtime.ts
+++ b/src/constants/realtime.ts
@@ -1,0 +1,5 @@
+// The Realtime API is exposed under the `openai` service; a user's openai
+// Application + Credential funds realtime voice calls.
+export const REALTIME_SERVICE_ID = '06f2acb7-e4d4-43de-9909-76e27b4e2355';
+export const REALTIME_DEFAULT_MODEL = 'gpt-realtime';
+export const REALTIME_SAMPLE_RATE = 24000;

--- a/src/i18n/ar/realtime.json
+++ b/src/i18n/ar/realtime.json
@@ -1,0 +1,17 @@
+{
+  "title": "Voice Call",
+  "you": "You: ",
+  "assistant": "Assistant: ",
+  "listening": "Listening… start speaking",
+  "start": "Start call",
+  "end": "End call",
+  "needService": "Enable the OpenAI service in the console to use voice calls.",
+  "startFailed": "Failed to start the call",
+  "callTooltip": "Voice call",
+  "status": {
+    "connecting": "connecting…",
+    "connected": "connected",
+    "disconnected": "disconnected",
+    "error": "error"
+  }
+}

--- a/src/i18n/ar/realtime.json
+++ b/src/i18n/ar/realtime.json
@@ -8,10 +8,8 @@
   "needService": "Enable the OpenAI service in the console to use voice calls.",
   "startFailed": "Failed to start the call",
   "callTooltip": "Voice call",
-  "status": {
-    "connecting": "connecting…",
-    "connected": "connected",
-    "disconnected": "disconnected",
-    "error": "error"
-  }
+  "status.connecting": "connecting…",
+  "status.connected": "connected",
+  "status.disconnected": "disconnected",
+  "status.error": "error"
 }

--- a/src/i18n/de/realtime.json
+++ b/src/i18n/de/realtime.json
@@ -1,0 +1,17 @@
+{
+  "title": "Voice Call",
+  "you": "You: ",
+  "assistant": "Assistant: ",
+  "listening": "Listening… start speaking",
+  "start": "Start call",
+  "end": "End call",
+  "needService": "Enable the OpenAI service in the console to use voice calls.",
+  "startFailed": "Failed to start the call",
+  "callTooltip": "Voice call",
+  "status": {
+    "connecting": "connecting…",
+    "connected": "connected",
+    "disconnected": "disconnected",
+    "error": "error"
+  }
+}

--- a/src/i18n/de/realtime.json
+++ b/src/i18n/de/realtime.json
@@ -8,10 +8,8 @@
   "needService": "Enable the OpenAI service in the console to use voice calls.",
   "startFailed": "Failed to start the call",
   "callTooltip": "Voice call",
-  "status": {
-    "connecting": "connecting…",
-    "connected": "connected",
-    "disconnected": "disconnected",
-    "error": "error"
-  }
+  "status.connecting": "connecting…",
+  "status.connected": "connected",
+  "status.disconnected": "disconnected",
+  "status.error": "error"
 }

--- a/src/i18n/el/realtime.json
+++ b/src/i18n/el/realtime.json
@@ -1,0 +1,17 @@
+{
+  "title": "Voice Call",
+  "you": "You: ",
+  "assistant": "Assistant: ",
+  "listening": "Listening… start speaking",
+  "start": "Start call",
+  "end": "End call",
+  "needService": "Enable the OpenAI service in the console to use voice calls.",
+  "startFailed": "Failed to start the call",
+  "callTooltip": "Voice call",
+  "status": {
+    "connecting": "connecting…",
+    "connected": "connected",
+    "disconnected": "disconnected",
+    "error": "error"
+  }
+}

--- a/src/i18n/el/realtime.json
+++ b/src/i18n/el/realtime.json
@@ -8,10 +8,8 @@
   "needService": "Enable the OpenAI service in the console to use voice calls.",
   "startFailed": "Failed to start the call",
   "callTooltip": "Voice call",
-  "status": {
-    "connecting": "connecting…",
-    "connected": "connected",
-    "disconnected": "disconnected",
-    "error": "error"
-  }
+  "status.connecting": "connecting…",
+  "status.connected": "connected",
+  "status.disconnected": "disconnected",
+  "status.error": "error"
 }

--- a/src/i18n/en/realtime.json
+++ b/src/i18n/en/realtime.json
@@ -1,0 +1,17 @@
+{
+  "title": "Voice Call",
+  "you": "You: ",
+  "assistant": "Assistant: ",
+  "listening": "Listening… start speaking",
+  "start": "Start call",
+  "end": "End call",
+  "needService": "Enable the OpenAI service in the console to use voice calls.",
+  "startFailed": "Failed to start the call",
+  "callTooltip": "Voice call",
+  "status": {
+    "connecting": "connecting…",
+    "connected": "connected",
+    "disconnected": "disconnected",
+    "error": "error"
+  }
+}

--- a/src/i18n/en/realtime.json
+++ b/src/i18n/en/realtime.json
@@ -8,10 +8,8 @@
   "needService": "Enable the OpenAI service in the console to use voice calls.",
   "startFailed": "Failed to start the call",
   "callTooltip": "Voice call",
-  "status": {
-    "connecting": "connecting…",
-    "connected": "connected",
-    "disconnected": "disconnected",
-    "error": "error"
-  }
+  "status.connecting": "connecting…",
+  "status.connected": "connected",
+  "status.disconnected": "disconnected",
+  "status.error": "error"
 }

--- a/src/i18n/es/realtime.json
+++ b/src/i18n/es/realtime.json
@@ -1,0 +1,17 @@
+{
+  "title": "Voice Call",
+  "you": "You: ",
+  "assistant": "Assistant: ",
+  "listening": "Listening… start speaking",
+  "start": "Start call",
+  "end": "End call",
+  "needService": "Enable the OpenAI service in the console to use voice calls.",
+  "startFailed": "Failed to start the call",
+  "callTooltip": "Voice call",
+  "status": {
+    "connecting": "connecting…",
+    "connected": "connected",
+    "disconnected": "disconnected",
+    "error": "error"
+  }
+}

--- a/src/i18n/es/realtime.json
+++ b/src/i18n/es/realtime.json
@@ -8,10 +8,8 @@
   "needService": "Enable the OpenAI service in the console to use voice calls.",
   "startFailed": "Failed to start the call",
   "callTooltip": "Voice call",
-  "status": {
-    "connecting": "connecting…",
-    "connected": "connected",
-    "disconnected": "disconnected",
-    "error": "error"
-  }
+  "status.connecting": "connecting…",
+  "status.connected": "connected",
+  "status.disconnected": "disconnected",
+  "status.error": "error"
 }

--- a/src/i18n/fi/realtime.json
+++ b/src/i18n/fi/realtime.json
@@ -1,0 +1,17 @@
+{
+  "title": "Voice Call",
+  "you": "You: ",
+  "assistant": "Assistant: ",
+  "listening": "Listening… start speaking",
+  "start": "Start call",
+  "end": "End call",
+  "needService": "Enable the OpenAI service in the console to use voice calls.",
+  "startFailed": "Failed to start the call",
+  "callTooltip": "Voice call",
+  "status": {
+    "connecting": "connecting…",
+    "connected": "connected",
+    "disconnected": "disconnected",
+    "error": "error"
+  }
+}

--- a/src/i18n/fi/realtime.json
+++ b/src/i18n/fi/realtime.json
@@ -8,10 +8,8 @@
   "needService": "Enable the OpenAI service in the console to use voice calls.",
   "startFailed": "Failed to start the call",
   "callTooltip": "Voice call",
-  "status": {
-    "connecting": "connecting…",
-    "connected": "connected",
-    "disconnected": "disconnected",
-    "error": "error"
-  }
+  "status.connecting": "connecting…",
+  "status.connected": "connected",
+  "status.disconnected": "disconnected",
+  "status.error": "error"
 }

--- a/src/i18n/fr/realtime.json
+++ b/src/i18n/fr/realtime.json
@@ -1,0 +1,17 @@
+{
+  "title": "Voice Call",
+  "you": "You: ",
+  "assistant": "Assistant: ",
+  "listening": "Listening… start speaking",
+  "start": "Start call",
+  "end": "End call",
+  "needService": "Enable the OpenAI service in the console to use voice calls.",
+  "startFailed": "Failed to start the call",
+  "callTooltip": "Voice call",
+  "status": {
+    "connecting": "connecting…",
+    "connected": "connected",
+    "disconnected": "disconnected",
+    "error": "error"
+  }
+}

--- a/src/i18n/fr/realtime.json
+++ b/src/i18n/fr/realtime.json
@@ -8,10 +8,8 @@
   "needService": "Enable the OpenAI service in the console to use voice calls.",
   "startFailed": "Failed to start the call",
   "callTooltip": "Voice call",
-  "status": {
-    "connecting": "connecting…",
-    "connected": "connected",
-    "disconnected": "disconnected",
-    "error": "error"
-  }
+  "status.connecting": "connecting…",
+  "status.connected": "connected",
+  "status.disconnected": "disconnected",
+  "status.error": "error"
 }

--- a/src/i18n/it/realtime.json
+++ b/src/i18n/it/realtime.json
@@ -1,0 +1,17 @@
+{
+  "title": "Voice Call",
+  "you": "You: ",
+  "assistant": "Assistant: ",
+  "listening": "Listening… start speaking",
+  "start": "Start call",
+  "end": "End call",
+  "needService": "Enable the OpenAI service in the console to use voice calls.",
+  "startFailed": "Failed to start the call",
+  "callTooltip": "Voice call",
+  "status": {
+    "connecting": "connecting…",
+    "connected": "connected",
+    "disconnected": "disconnected",
+    "error": "error"
+  }
+}

--- a/src/i18n/it/realtime.json
+++ b/src/i18n/it/realtime.json
@@ -8,10 +8,8 @@
   "needService": "Enable the OpenAI service in the console to use voice calls.",
   "startFailed": "Failed to start the call",
   "callTooltip": "Voice call",
-  "status": {
-    "connecting": "connecting…",
-    "connected": "connected",
-    "disconnected": "disconnected",
-    "error": "error"
-  }
+  "status.connecting": "connecting…",
+  "status.connected": "connected",
+  "status.disconnected": "disconnected",
+  "status.error": "error"
 }

--- a/src/i18n/ja/realtime.json
+++ b/src/i18n/ja/realtime.json
@@ -1,0 +1,17 @@
+{
+  "title": "Voice Call",
+  "you": "You: ",
+  "assistant": "Assistant: ",
+  "listening": "Listening… start speaking",
+  "start": "Start call",
+  "end": "End call",
+  "needService": "Enable the OpenAI service in the console to use voice calls.",
+  "startFailed": "Failed to start the call",
+  "callTooltip": "Voice call",
+  "status": {
+    "connecting": "connecting…",
+    "connected": "connected",
+    "disconnected": "disconnected",
+    "error": "error"
+  }
+}

--- a/src/i18n/ja/realtime.json
+++ b/src/i18n/ja/realtime.json
@@ -8,10 +8,8 @@
   "needService": "Enable the OpenAI service in the console to use voice calls.",
   "startFailed": "Failed to start the call",
   "callTooltip": "Voice call",
-  "status": {
-    "connecting": "connecting…",
-    "connected": "connected",
-    "disconnected": "disconnected",
-    "error": "error"
-  }
+  "status.connecting": "connecting…",
+  "status.connected": "connected",
+  "status.disconnected": "disconnected",
+  "status.error": "error"
 }

--- a/src/i18n/ko/realtime.json
+++ b/src/i18n/ko/realtime.json
@@ -1,0 +1,17 @@
+{
+  "title": "Voice Call",
+  "you": "You: ",
+  "assistant": "Assistant: ",
+  "listening": "Listening… start speaking",
+  "start": "Start call",
+  "end": "End call",
+  "needService": "Enable the OpenAI service in the console to use voice calls.",
+  "startFailed": "Failed to start the call",
+  "callTooltip": "Voice call",
+  "status": {
+    "connecting": "connecting…",
+    "connected": "connected",
+    "disconnected": "disconnected",
+    "error": "error"
+  }
+}

--- a/src/i18n/ko/realtime.json
+++ b/src/i18n/ko/realtime.json
@@ -8,10 +8,8 @@
   "needService": "Enable the OpenAI service in the console to use voice calls.",
   "startFailed": "Failed to start the call",
   "callTooltip": "Voice call",
-  "status": {
-    "connecting": "connecting…",
-    "connected": "connected",
-    "disconnected": "disconnected",
-    "error": "error"
-  }
+  "status.connecting": "connecting…",
+  "status.connected": "connected",
+  "status.disconnected": "disconnected",
+  "status.error": "error"
 }

--- a/src/i18n/pl/realtime.json
+++ b/src/i18n/pl/realtime.json
@@ -1,0 +1,17 @@
+{
+  "title": "Voice Call",
+  "you": "You: ",
+  "assistant": "Assistant: ",
+  "listening": "Listening… start speaking",
+  "start": "Start call",
+  "end": "End call",
+  "needService": "Enable the OpenAI service in the console to use voice calls.",
+  "startFailed": "Failed to start the call",
+  "callTooltip": "Voice call",
+  "status": {
+    "connecting": "connecting…",
+    "connected": "connected",
+    "disconnected": "disconnected",
+    "error": "error"
+  }
+}

--- a/src/i18n/pl/realtime.json
+++ b/src/i18n/pl/realtime.json
@@ -8,10 +8,8 @@
   "needService": "Enable the OpenAI service in the console to use voice calls.",
   "startFailed": "Failed to start the call",
   "callTooltip": "Voice call",
-  "status": {
-    "connecting": "connecting…",
-    "connected": "connected",
-    "disconnected": "disconnected",
-    "error": "error"
-  }
+  "status.connecting": "connecting…",
+  "status.connected": "connected",
+  "status.disconnected": "disconnected",
+  "status.error": "error"
 }

--- a/src/i18n/pt/realtime.json
+++ b/src/i18n/pt/realtime.json
@@ -1,0 +1,17 @@
+{
+  "title": "Voice Call",
+  "you": "You: ",
+  "assistant": "Assistant: ",
+  "listening": "Listening… start speaking",
+  "start": "Start call",
+  "end": "End call",
+  "needService": "Enable the OpenAI service in the console to use voice calls.",
+  "startFailed": "Failed to start the call",
+  "callTooltip": "Voice call",
+  "status": {
+    "connecting": "connecting…",
+    "connected": "connected",
+    "disconnected": "disconnected",
+    "error": "error"
+  }
+}

--- a/src/i18n/pt/realtime.json
+++ b/src/i18n/pt/realtime.json
@@ -8,10 +8,8 @@
   "needService": "Enable the OpenAI service in the console to use voice calls.",
   "startFailed": "Failed to start the call",
   "callTooltip": "Voice call",
-  "status": {
-    "connecting": "connecting…",
-    "connected": "connected",
-    "disconnected": "disconnected",
-    "error": "error"
-  }
+  "status.connecting": "connecting…",
+  "status.connected": "connected",
+  "status.disconnected": "disconnected",
+  "status.error": "error"
 }

--- a/src/i18n/ru/realtime.json
+++ b/src/i18n/ru/realtime.json
@@ -1,0 +1,17 @@
+{
+  "title": "Voice Call",
+  "you": "You: ",
+  "assistant": "Assistant: ",
+  "listening": "Listening… start speaking",
+  "start": "Start call",
+  "end": "End call",
+  "needService": "Enable the OpenAI service in the console to use voice calls.",
+  "startFailed": "Failed to start the call",
+  "callTooltip": "Voice call",
+  "status": {
+    "connecting": "connecting…",
+    "connected": "connected",
+    "disconnected": "disconnected",
+    "error": "error"
+  }
+}

--- a/src/i18n/ru/realtime.json
+++ b/src/i18n/ru/realtime.json
@@ -8,10 +8,8 @@
   "needService": "Enable the OpenAI service in the console to use voice calls.",
   "startFailed": "Failed to start the call",
   "callTooltip": "Voice call",
-  "status": {
-    "connecting": "connecting…",
-    "connected": "connected",
-    "disconnected": "disconnected",
-    "error": "error"
-  }
+  "status.connecting": "connecting…",
+  "status.connected": "connected",
+  "status.disconnected": "disconnected",
+  "status.error": "error"
 }

--- a/src/i18n/sr/realtime.json
+++ b/src/i18n/sr/realtime.json
@@ -1,0 +1,17 @@
+{
+  "title": "Voice Call",
+  "you": "You: ",
+  "assistant": "Assistant: ",
+  "listening": "Listening… start speaking",
+  "start": "Start call",
+  "end": "End call",
+  "needService": "Enable the OpenAI service in the console to use voice calls.",
+  "startFailed": "Failed to start the call",
+  "callTooltip": "Voice call",
+  "status": {
+    "connecting": "connecting…",
+    "connected": "connected",
+    "disconnected": "disconnected",
+    "error": "error"
+  }
+}

--- a/src/i18n/sr/realtime.json
+++ b/src/i18n/sr/realtime.json
@@ -8,10 +8,8 @@
   "needService": "Enable the OpenAI service in the console to use voice calls.",
   "startFailed": "Failed to start the call",
   "callTooltip": "Voice call",
-  "status": {
-    "connecting": "connecting…",
-    "connected": "connected",
-    "disconnected": "disconnected",
-    "error": "error"
-  }
+  "status.connecting": "connecting…",
+  "status.connected": "connected",
+  "status.disconnected": "disconnected",
+  "status.error": "error"
 }

--- a/src/i18n/sv/realtime.json
+++ b/src/i18n/sv/realtime.json
@@ -1,0 +1,17 @@
+{
+  "title": "Voice Call",
+  "you": "You: ",
+  "assistant": "Assistant: ",
+  "listening": "Listening… start speaking",
+  "start": "Start call",
+  "end": "End call",
+  "needService": "Enable the OpenAI service in the console to use voice calls.",
+  "startFailed": "Failed to start the call",
+  "callTooltip": "Voice call",
+  "status": {
+    "connecting": "connecting…",
+    "connected": "connected",
+    "disconnected": "disconnected",
+    "error": "error"
+  }
+}

--- a/src/i18n/sv/realtime.json
+++ b/src/i18n/sv/realtime.json
@@ -8,10 +8,8 @@
   "needService": "Enable the OpenAI service in the console to use voice calls.",
   "startFailed": "Failed to start the call",
   "callTooltip": "Voice call",
-  "status": {
-    "connecting": "connecting…",
-    "connected": "connected",
-    "disconnected": "disconnected",
-    "error": "error"
-  }
+  "status.connecting": "connecting…",
+  "status.connected": "connected",
+  "status.disconnected": "disconnected",
+  "status.error": "error"
 }

--- a/src/i18n/uk/realtime.json
+++ b/src/i18n/uk/realtime.json
@@ -1,0 +1,17 @@
+{
+  "title": "Voice Call",
+  "you": "You: ",
+  "assistant": "Assistant: ",
+  "listening": "Listening… start speaking",
+  "start": "Start call",
+  "end": "End call",
+  "needService": "Enable the OpenAI service in the console to use voice calls.",
+  "startFailed": "Failed to start the call",
+  "callTooltip": "Voice call",
+  "status": {
+    "connecting": "connecting…",
+    "connected": "connected",
+    "disconnected": "disconnected",
+    "error": "error"
+  }
+}

--- a/src/i18n/uk/realtime.json
+++ b/src/i18n/uk/realtime.json
@@ -8,10 +8,8 @@
   "needService": "Enable the OpenAI service in the console to use voice calls.",
   "startFailed": "Failed to start the call",
   "callTooltip": "Voice call",
-  "status": {
-    "connecting": "connecting…",
-    "connected": "connected",
-    "disconnected": "disconnected",
-    "error": "error"
-  }
+  "status.connecting": "connecting…",
+  "status.connected": "connected",
+  "status.disconnected": "disconnected",
+  "status.error": "error"
 }

--- a/src/i18n/zh-CN/realtime.json
+++ b/src/i18n/zh-CN/realtime.json
@@ -1,0 +1,17 @@
+{
+  "title": "语音通话",
+  "you": "你：",
+  "assistant": "助手：",
+  "listening": "正在聆听…请开始说话",
+  "start": "开始通话",
+  "end": "结束通话",
+  "needService": "请先在控制台开通 OpenAI 服务以使用语音通话。",
+  "startFailed": "通话启动失败",
+  "callTooltip": "语音通话",
+  "status": {
+    "connecting": "连接中…",
+    "connected": "已连接",
+    "disconnected": "已断开",
+    "error": "出错"
+  }
+}

--- a/src/i18n/zh-CN/realtime.json
+++ b/src/i18n/zh-CN/realtime.json
@@ -8,10 +8,8 @@
   "needService": "请先在控制台开通 OpenAI 服务以使用语音通话。",
   "startFailed": "通话启动失败",
   "callTooltip": "语音通话",
-  "status": {
-    "connecting": "连接中…",
-    "connected": "已连接",
-    "disconnected": "已断开",
-    "error": "出错"
-  }
+  "status.connecting": "连接中…",
+  "status.connected": "已连接",
+  "status.disconnected": "已断开",
+  "status.error": "出错"
 }

--- a/src/i18n/zh-TW/realtime.json
+++ b/src/i18n/zh-TW/realtime.json
@@ -1,0 +1,17 @@
+{
+  "title": "語音通話",
+  "you": "你：",
+  "assistant": "助手：",
+  "listening": "正在聆聽…請開始說話",
+  "start": "開始通話",
+  "end": "結束通話",
+  "needService": "請先在控制台開通 OpenAI 服務以使用語音通話。",
+  "startFailed": "通話啟動失敗",
+  "callTooltip": "語音通話",
+  "status": {
+    "connecting": "連接中…",
+    "connected": "已連接",
+    "disconnected": "已斷開",
+    "error": "出錯"
+  }
+}

--- a/src/i18n/zh-TW/realtime.json
+++ b/src/i18n/zh-TW/realtime.json
@@ -8,10 +8,8 @@
   "needService": "請先在控制台開通 OpenAI 服務以使用語音通話。",
   "startFailed": "通話啟動失敗",
   "callTooltip": "語音通話",
-  "status": {
-    "connecting": "連接中…",
-    "connected": "已連接",
-    "disconnected": "已斷開",
-    "error": "出錯"
-  }
+  "status.connecting": "連接中…",
+  "status.connected": "已連接",
+  "status.disconnected": "已斷開",
+  "status.error": "出錯"
 }

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -7,6 +7,11 @@
           <byok-badge class="byok-badge" />
         </div>
         <div class="toolbar-actions">
+          <el-tooltip :content="$t('realtime.callTooltip')" placement="bottom">
+            <el-button class="toolbar-btn" text @click="onStartCall">
+              <font-awesome-icon icon="fa-solid fa-microphone" />
+            </el-button>
+          </el-tooltip>
           <el-tooltip v-if="false" :content="$t('chat.agent.tooltip')" placement="bottom">
             <el-button class="toolbar-btn" text @click="agentManagerVisible = true">
               <font-awesome-icon icon="fa-solid fa-desktop" />
@@ -64,6 +69,7 @@ import axios from 'axios';
 import { defineComponent } from 'vue';
 import Message from '@/components/chat/Message.vue';
 import { CHAT_MODEL_GROUPS, CHAT_MODELS, ROLE_ASSISTANT, ROLE_USER } from '@/constants';
+import { ROUTE_CHATGPT_CALL } from '@/router/constants';
 import {
   IChatMessageState,
   IChatConversationResponse,
@@ -281,6 +287,9 @@ export default defineComponent({
     this.onApplyQueryFromUrl();
   },
   methods: {
+    onStartCall() {
+      this.$router.push({ name: ROUTE_CHATGPT_CALL });
+    },
     resetConversation() {
       this.messages = [];
       this.question = '';

--- a/src/pages/chat/RealtimeCall.vue
+++ b/src/pages/chat/RealtimeCall.vue
@@ -1,0 +1,235 @@
+<template>
+  <div class="realtime-call">
+    <div class="call-card">
+      <div class="call-header">
+        <el-button text class="back-btn" @click="goBack">
+          <font-awesome-icon icon="fa-solid fa-arrow-left" />
+        </el-button>
+        <span class="title">{{ $t('realtime.title') }}</span>
+        <span class="status" :class="status">{{ statusText }}</span>
+      </div>
+
+      <div class="orb" :class="{ active: running, speaking: aiSpeaking }">
+        <font-awesome-icon icon="fa-solid fa-microphone" />
+      </div>
+
+      <div class="transcript">
+        <p v-if="userText" class="line user">
+          <span class="who">{{ $t('realtime.you') }}</span
+          >{{ userText }}
+        </p>
+        <p v-if="aiText" class="line ai">
+          <span class="who">{{ $t('realtime.assistant') }}</span
+          >{{ aiText }}
+        </p>
+        <p v-if="!userText && !aiText && running" class="hint">{{ $t('realtime.listening') }}</p>
+      </div>
+
+      <p v-if="errorMsg" class="error">{{ errorMsg }}</p>
+
+      <div class="actions">
+        <el-button
+          v-if="!running"
+          type="primary"
+          round
+          size="large"
+          :loading="connecting"
+          :disabled="!canCall"
+          @click="startCall"
+        >
+          <font-awesome-icon icon="fa-solid fa-phone" class="btn-icon" />
+          {{ $t('realtime.start') }}
+        </el-button>
+        <el-button v-else type="danger" round size="large" @click="endCall">
+          <font-awesome-icon icon="fa-solid fa-phone-slash" class="btn-icon" />
+          {{ $t('realtime.end') }}
+        </el-button>
+      </div>
+
+      <p v-if="!canCall && !provisioning" class="hint small">{{ $t('realtime.needService') }}</p>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { RealtimeClient, RealtimeStatus } from '@/utils/realtimeClient';
+import { REALTIME_DEFAULT_MODEL } from '@/constants';
+import { ROUTE_CHATGPT_CONVERSATION_NEW } from '@/router/constants';
+
+export default defineComponent({
+  name: 'RealtimeCall',
+  data() {
+    return {
+      client: undefined as RealtimeClient | undefined,
+      status: 'disconnected' as RealtimeStatus,
+      connecting: false,
+      provisioning: true,
+      running: false,
+      aiSpeaking: false,
+      userText: '',
+      aiText: '',
+      errorMsg: ''
+    };
+  },
+  computed: {
+    token(): string | undefined {
+      return this.$store.state.realtime?.credential?.token;
+    },
+    canCall(): boolean {
+      return !!this.token;
+    },
+    statusText(): string {
+      return this.$t(`realtime.status.${this.status}`);
+    }
+  },
+  async mounted() {
+    this.provisioning = true;
+    try {
+      await this.$store.dispatch('realtime/init');
+    } finally {
+      this.provisioning = false;
+    }
+  },
+  beforeUnmount() {
+    this.client?.stop();
+  },
+  methods: {
+    async startCall() {
+      if (!this.token) return;
+      this.errorMsg = '';
+      this.userText = '';
+      this.aiText = '';
+      this.connecting = true;
+      this.client = new RealtimeClient(this.token, REALTIME_DEFAULT_MODEL, {
+        onStatus: (s: RealtimeStatus) => {
+          this.status = s;
+          this.running = s === 'connecting' || s === 'connected';
+          if (s === 'connected' || s === 'disconnected' || s === 'error') this.connecting = false;
+        },
+        onUserSpeechStarted: () => {
+          this.aiSpeaking = false;
+        },
+        onUserTranscript: (t: string) => {
+          this.userText = t;
+        },
+        onAiResponseStart: () => {
+          this.aiText = '';
+          this.aiSpeaking = true;
+        },
+        onAiTranscriptDelta: (d: string) => {
+          this.aiText += d;
+        },
+        onError: (m: string) => {
+          this.errorMsg = m;
+        }
+      });
+      try {
+        await this.client.start();
+      } catch (e: any) {
+        this.connecting = false;
+        this.running = false;
+        this.errorMsg = e?.message || this.$t('realtime.startFailed');
+        this.client?.stop();
+      }
+    },
+    endCall() {
+      this.client?.stop();
+      this.running = false;
+      this.aiSpeaking = false;
+    },
+    goBack() {
+      this.client?.stop();
+      this.$router.push({ name: ROUTE_CHATGPT_CONVERSATION_NEW });
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.realtime-call {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+  padding: 20px;
+}
+.call-card {
+  width: 100%;
+  max-width: 480px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+}
+.call-header {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  gap: 10px;
+  .title {
+    flex: 1;
+    font-weight: 600;
+  }
+  .status {
+    font-size: 12px;
+    color: #999;
+    &.connected {
+      color: #34c759;
+    }
+    &.error {
+      color: #ff3b30;
+    }
+  }
+}
+.orb {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 40px;
+  color: #fff;
+  background: #c8c9cc;
+  transition: all 0.3s ease;
+  &.active {
+    background: #409eff;
+  }
+  &.speaking {
+    background: #34c759;
+    box-shadow: 0 0 0 12px rgba(52, 199, 89, 0.18);
+  }
+}
+.transcript {
+  min-height: 80px;
+  width: 100%;
+  .line {
+    margin: 6px 0;
+    text-align: left;
+    .who {
+      font-weight: 600;
+      margin-right: 6px;
+      opacity: 0.7;
+    }
+  }
+  .hint {
+    color: #999;
+  }
+  .hint.small {
+    font-size: 12px;
+  }
+}
+.error {
+  color: #ff3b30;
+  font-size: 13px;
+}
+.btn-icon {
+  margin-right: 6px;
+}
+.hint.small {
+  font-size: 12px;
+  color: #999;
+}
+</style>

--- a/src/plugins/font-awesome.ts
+++ b/src/plugins/font-awesome.ts
@@ -54,6 +54,8 @@ import {
   faHashtag as faSolidHashtag,
   faCircleInfo as faSolidCircleInfo,
   faMicrophone as faSolidMicrophone,
+  faPhone as faSolidPhone,
+  faPhoneSlash as faSolidPhoneSlash,
   faArrowLeft as faSolidArrowLeft,
   faArrowUp as faSolidArrowUp,
   faUpload as faSolidUpload,
@@ -203,6 +205,8 @@ library.add(faSolidBook);
 library.add(faSolidGear);
 library.add(faSolidSitemap);
 library.add(faSolidMicrophone);
+library.add(faSolidPhone);
+library.add(faSolidPhoneSlash);
 library.add(faSolidBars);
 library.add(faSolidPlus);
 library.add(faSolidUpload);

--- a/src/router/chatgpt.ts
+++ b/src/router/chatgpt.ts
@@ -1,5 +1,5 @@
 import { CHAT_MODEL_GROUP_CHATGPT } from '@/constants';
-import { ROUTE_CHATGPT_CONVERSATION, ROUTE_CHATGPT_CONVERSATION_NEW } from './constants';
+import { ROUTE_CHATGPT_CALL, ROUTE_CHATGPT_CONVERSATION, ROUTE_CHATGPT_CONVERSATION_NEW } from './constants';
 
 export default {
   path: '/chatgpt',
@@ -24,6 +24,13 @@ export default {
       path: 'conversations/:id',
       name: ROUTE_CHATGPT_CONVERSATION,
       component: () => import('@/pages/chat/Conversation.vue')
+    },
+    {
+      path: 'call',
+      name: ROUTE_CHATGPT_CALL,
+      // Voice call uses the realtime store module (openai service), not chat.
+      meta: { appName: 'realtime' },
+      component: () => import('@/pages/chat/RealtimeCall.vue')
     }
   ]
 };

--- a/src/router/constants.ts
+++ b/src/router/constants.ts
@@ -8,6 +8,7 @@ export const ROUTE_SETTINGS_INDEX = 'settings-index';
 
 export const ROUTE_CHATGPT_CONVERSATION = 'chatgpt-conversation';
 export const ROUTE_CHATGPT_CONVERSATION_NEW = 'chatgpt-conversation-new';
+export const ROUTE_CHATGPT_CALL = 'chatgpt-call';
 
 export const ROUTE_DEEPSEEK_CONVERSATION = 'deepseek-conversation';
 export const ROUTE_DEEPSEEK_CONVERSATION_NEW = 'deepseek-conversation-new';

--- a/src/store/common/models.ts
+++ b/src/store/common/models.ts
@@ -1,6 +1,7 @@
 import { IApplication, IConfigResponse, ISite, IToken, IUser, Status } from '@/models';
 import { IMidjourneyState } from '../midjourney/models';
 import { IChatState } from '../chat/models';
+import { IRealtimeState } from '../realtime/models';
 import { IQrartState } from '../qrart/models';
 import { ILumaState } from '../luma/models';
 import { IPikaState } from '../pika/models';
@@ -55,6 +56,7 @@ export interface ICommonState {
 export interface IAppState {
   midjourney: IMidjourneyState;
   chat: IChatState;
+  realtime: IRealtimeState;
   qrart: IQrartState;
   luma: ILumaState;
   pika: IPikaState;

--- a/src/store/common/models.ts
+++ b/src/store/common/models.ts
@@ -56,7 +56,9 @@ export interface ICommonState {
 export interface IAppState {
   midjourney: IMidjourneyState;
   chat: IChatState;
-  realtime: IRealtimeState;
+  // Lazily registered only when the user opens the voice-call screen, so it's
+  // absent from the initial root state — optional, accessed with `?.`.
+  realtime?: IRealtimeState;
   qrart: IQrartState;
   luma: ILumaState;
   pika: IPikaState;

--- a/src/store/lazy.ts
+++ b/src/store/lazy.ts
@@ -23,6 +23,7 @@ type AnyVuexModule = Module<any, any>;
  */
 const moduleLoaders: Record<string, () => Promise<{ default: AnyVuexModule }>> = {
   chat: () => import('./chat'),
+  realtime: () => import('./realtime'),
   midjourney: () => import('./midjourney'),
   qrart: () => import('./qrart'),
   luma: () => import('./luma'),

--- a/src/store/realtime/actions.ts
+++ b/src/store/realtime/actions.ts
@@ -1,0 +1,84 @@
+import { applicationOperator, credentialOperator, serviceOperator } from '@/operators';
+import { ActionContext } from 'vuex';
+import { IRootState } from '../common/models';
+import { IRealtimeState } from './models';
+import { IApplication, ICredential } from '@/models';
+import { Status } from '@/models';
+import { REALTIME_SERVICE_ID } from '@/constants';
+
+export const getService = async ({ commit, state }: ActionContext<IRealtimeState, IRootState>) => {
+  state.status.getService = Status.Request;
+  try {
+    const { data: service } = await serviceOperator.get(REALTIME_SERVICE_ID);
+    state.status.getService = Status.Success;
+    commit('setService', service);
+    return service;
+  } catch (error) {
+    state.status.getService = Status.Error;
+    commit('setService', undefined);
+  }
+};
+
+export const getApplications = async ({ commit, state }: ActionContext<IRealtimeState, IRootState>) => {
+  state.status.getApplications = Status.Request;
+  try {
+    const { data: applications } = await applicationOperator.getAll({
+      user_id: 'me',
+      service_id: REALTIME_SERVICE_ID,
+      affiliation: ['owner', 'granted']
+    });
+    state.status.getApplications = Status.Success;
+    commit('setApplications', applications.items);
+    return applications.items;
+  } catch (error) {
+    state.status.getApplications = Status.Error;
+    commit('setApplications', undefined);
+  }
+};
+
+export const createCredential = async ({ commit, state }: any): Promise<ICredential | undefined> => {
+  const application = state.application;
+  if (!application) return undefined;
+  state.status.getCredential = Status.Request;
+  try {
+    const { data: credential } = await credentialOperator.create({
+      application_id: application?.id,
+      host: window.location.origin
+    });
+    state.status.getCredential = Status.Success;
+    commit('setCredential', credential);
+    return credential;
+  } catch (error) {
+    state.status.getCredential = Status.Error;
+    return undefined;
+  }
+};
+
+export const setApplication = async ({ commit, dispatch, rootState }: any, payload: IApplication): Promise<void> => {
+  commit('setApplication', payload);
+  if (!payload) return;
+  const me = rootState?.user?.id;
+  const isGranted = payload?.role === 'grantee';
+  let credential = payload?.credentials?.find((c: ICredential) => c?.host === window.location.origin);
+  if (!credential && isGranted) {
+    credential = payload?.credentials?.find((c: ICredential) => c?.user_id === me);
+  }
+  if (credential) {
+    commit('setCredential', credential);
+  } else if (!isGranted) {
+    await dispatch('createCredential');
+  } else {
+    commit('setCredential', undefined);
+  }
+};
+
+// Orchestrate provisioning: service -> applications -> first usable app -> credential.
+export const init = async ({ dispatch, state }: any): Promise<ICredential | undefined> => {
+  await dispatch('getService');
+  const applications = await dispatch('getApplications');
+  const application = (applications || [])[0];
+  if (application) {
+    await dispatch('setApplication', application);
+  }
+  return state.credential;
+};

--- a/src/store/realtime/actions.ts
+++ b/src/store/realtime/actions.ts
@@ -82,3 +82,11 @@ export const init = async ({ dispatch, state }: any): Promise<ICredential | unde
   }
   return state.credential;
 };
+
+export default {
+  getService,
+  getApplications,
+  createCredential,
+  setApplication,
+  init
+};

--- a/src/store/realtime/index.ts
+++ b/src/store/realtime/index.ts
@@ -1,0 +1,14 @@
+import { Module } from 'vuex';
+import { IRealtimeState } from './models';
+import state from './state';
+import actions from './actions';
+import mutations from './mutations';
+
+export const realtime: Module<IRealtimeState, any> = {
+  namespaced: true,
+  state,
+  mutations,
+  actions
+};
+
+export default realtime;

--- a/src/store/realtime/models.ts
+++ b/src/store/realtime/models.ts
@@ -1,0 +1,13 @@
+import { IApplication, ICredential, IService, Status } from '@/models';
+
+export interface IRealtimeState {
+  service: IService | undefined;
+  applications: IApplication[] | undefined;
+  application: IApplication | undefined;
+  credential: ICredential | undefined;
+  status: {
+    getService: Status;
+    getApplications: Status;
+    getCredential: Status;
+  };
+}

--- a/src/store/realtime/mutations.ts
+++ b/src/store/realtime/mutations.ts
@@ -1,0 +1,20 @@
+import { MutationTree } from 'vuex';
+import { IRealtimeState } from './models';
+import { IApplication, ICredential, IService } from '@/models';
+
+const mutations: MutationTree<IRealtimeState> = {
+  setService(state, service: IService | undefined) {
+    state.service = service;
+  },
+  setApplications(state, applications: IApplication[] | undefined) {
+    state.applications = applications;
+  },
+  setApplication(state, application: IApplication | undefined) {
+    state.application = application;
+  },
+  setCredential(state, credential: ICredential | undefined) {
+    state.credential = credential;
+  }
+};
+
+export default mutations;

--- a/src/store/realtime/state.ts
+++ b/src/store/realtime/state.ts
@@ -1,0 +1,16 @@
+import { IRealtimeState } from './models';
+import { Status } from '@/models';
+
+export default (): IRealtimeState => {
+  return {
+    service: undefined,
+    applications: undefined,
+    application: undefined,
+    credential: undefined,
+    status: {
+      getService: Status.None,
+      getApplications: Status.None,
+      getCredential: Status.None
+    }
+  };
+};

--- a/src/utils/realtimeClient.ts
+++ b/src/utils/realtimeClient.ts
@@ -1,0 +1,224 @@
+import { REALTIME_SAMPLE_RATE, WS_URL_REALTIME } from '@/constants';
+
+export type RealtimeStatus = 'connecting' | 'connected' | 'disconnected' | 'error';
+
+export interface IRealtimeHandlers {
+  onStatus?: (status: RealtimeStatus, detail?: string) => void;
+  onUserTranscript?: (text: string) => void;
+  onAiTranscriptDelta?: (delta: string) => void;
+  onAiResponseStart?: () => void;
+  onUserSpeechStarted?: () => void;
+  onError?: (message: string) => void;
+}
+
+/**
+ * Browser realtime voice client: captures the mic as 24kHz PCM16 via an
+ * AudioWorklet, streams it to wss://…/v1/realtime, plays the assistant audio
+ * back with a scheduled queue, and barges-in (stops playback) when the server
+ * VAD reports the user started speaking. Speaks the OpenAI Realtime GA event
+ * format directly; the relay injects the session config + upstream key.
+ */
+export class RealtimeClient {
+  private readonly token: string;
+  private readonly model: string;
+  private readonly handlers: IRealtimeHandlers;
+
+  private ws: WebSocket | undefined;
+  private audioCtx: AudioContext | undefined;
+  private micStream: MediaStream | undefined;
+  private micNode: MediaStreamAudioSourceNode | undefined;
+  private workletNode: AudioWorkletNode | undefined;
+  private running = false;
+
+  private playHead = 0;
+  private activeSources: AudioBufferSourceNode[] = [];
+  private disposed = false; // set by stop(); aborts an in-flight start()
+  private suppressAudio = false; // drop in-flight deltas after a barge-in
+  private aiResponding = false; // a response is streaming (so barge-in can cancel it)
+
+  constructor(token: string, model: string, handlers: IRealtimeHandlers) {
+    this.token = token;
+    this.model = model;
+    this.handlers = handlers;
+  }
+
+  get isRunning(): boolean {
+    return this.running;
+  }
+
+  async start(): Promise<void> {
+    this.handlers.onStatus?.('connecting');
+    const Ctx = window.AudioContext || (window as any).webkitAudioContext;
+    this.audioCtx = new Ctx({ sampleRate: REALTIME_SAMPLE_RATE });
+    await this.audioCtx.audioWorklet.addModule('/recorder-worklet.js');
+    if (this.disposed) return this.teardownAudio(); // user hit End/Back mid-startup
+
+    this.micStream = await navigator.mediaDevices.getUserMedia({
+      audio: { channelCount: 1, echoCancellation: true, noiseSuppression: true, autoGainControl: true }
+    });
+    if (this.disposed) return this.teardownAudio();
+    this.micNode = this.audioCtx.createMediaStreamSource(this.micStream);
+    this.workletNode = new AudioWorkletNode(this.audioCtx, 'recorder-processor');
+    this.micNode.connect(this.workletNode);
+    // The worklet must be in the graph to pull; route it to a muted gain so the
+    // mic isn't echoed to the speaker.
+    const sink = this.audioCtx.createGain();
+    sink.gain.value = 0;
+    this.workletNode.connect(sink).connect(this.audioCtx.destination);
+
+    const url = `${WS_URL_REALTIME}?model=${encodeURIComponent(this.model)}`;
+    this.ws = new WebSocket(url, ['realtime', `acedata-token.${this.token}`]);
+
+    this.ws.onopen = () => {
+      if (this.disposed) {
+        this.ws?.close();
+        return;
+      }
+      this.running = true;
+      this.handlers.onStatus?.('connected');
+    };
+    this.ws.onclose = () => {
+      this.handlers.onStatus?.('disconnected');
+      this.teardownAudio();
+      this.running = false;
+    };
+    this.ws.onerror = () => this.handlers.onStatus?.('error');
+    this.ws.onmessage = (e) => this.onServerEvent(e);
+
+    this.workletNode.port.onmessage = (e) => {
+      if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+      this.ws.send(JSON.stringify({ type: 'input_audio_buffer.append', audio: b64FromArrayBuffer(e.data) }));
+    };
+  }
+
+  stop(): void {
+    this.disposed = true;
+    // Close whether the socket is still CONNECTING or already OPEN.
+    if (this.ws && (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING)) {
+      this.ws.close();
+    }
+    this.teardownAudio();
+    this.running = false;
+    this.handlers.onStatus?.('disconnected');
+  }
+
+  private send(event: Record<string, unknown>): void {
+    if (this.ws && this.ws.readyState === WebSocket.OPEN) this.ws.send(JSON.stringify(event));
+  }
+
+  private onServerEvent(e: MessageEvent): void {
+    let evt: any;
+    try {
+      evt = JSON.parse(e.data);
+    } catch {
+      return;
+    }
+    switch (evt.type) {
+      case 'session.created':
+      case 'session.updated':
+        break;
+      case 'input_audio_buffer.speech_started':
+        // Barge-in: stop local playback, cancel the upstream response so it
+        // stops generating, and drop any deltas still in flight until the next
+        // response starts.
+        this.stopPlayback();
+        if (this.aiResponding) this.send({ type: 'response.cancel' });
+        this.suppressAudio = true;
+        this.handlers.onUserSpeechStarted?.();
+        break;
+      case 'conversation.item.input_audio_transcription.completed':
+        this.handlers.onUserTranscript?.(evt.transcript || '');
+        break;
+      case 'response.created':
+        this.aiResponding = true;
+        this.suppressAudio = false;
+        this.handlers.onAiResponseStart?.();
+        break;
+      case 'response.done':
+        this.aiResponding = false;
+        break;
+      // Handle GA names plus legacy aliases so audio always plays.
+      case 'response.output_audio.delta':
+      case 'response.audio.delta':
+        if (evt.delta && !this.suppressAudio) this.enqueuePcm16(evt.delta);
+        break;
+      case 'response.output_audio_transcript.delta':
+      case 'response.audio_transcript.delta':
+        if (evt.delta) this.handlers.onAiTranscriptDelta?.(evt.delta);
+        break;
+      case 'error': {
+        const err = evt.error || {};
+        this.handlers.onError?.(err.message || 'realtime error');
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  private enqueuePcm16(b64: string): void {
+    if (!this.audioCtx) return;
+    const buf = arrayBufferFromB64(b64);
+    const i16 = new Int16Array(buf);
+    if (i16.length === 0) return;
+    const f32 = new Float32Array(i16.length);
+    for (let i = 0; i < i16.length; i++) f32[i] = i16[i] / 0x8000;
+
+    const audioBuffer = this.audioCtx.createBuffer(1, f32.length, REALTIME_SAMPLE_RATE);
+    audioBuffer.getChannelData(0).set(f32);
+    const src = this.audioCtx.createBufferSource();
+    src.buffer = audioBuffer;
+    src.connect(this.audioCtx.destination);
+
+    const now = this.audioCtx.currentTime;
+    if (this.playHead < now) this.playHead = now + 0.02;
+    src.start(this.playHead);
+    this.playHead += audioBuffer.duration;
+    this.activeSources.push(src);
+    src.onended = () => {
+      this.activeSources = this.activeSources.filter((s) => s !== src);
+    };
+  }
+
+  private stopPlayback(): void {
+    for (const s of this.activeSources) {
+      try {
+        s.onended = null;
+        s.stop();
+      } catch {
+        // ignore
+      }
+    }
+    this.activeSources = [];
+    this.playHead = 0;
+  }
+
+  private teardownAudio(): void {
+    try {
+      if (this.workletNode) this.workletNode.port.onmessage = null;
+      if (this.micStream) this.micStream.getTracks().forEach((t) => t.stop());
+      this.stopPlayback();
+      if (this.audioCtx) this.audioCtx.close();
+    } catch {
+      // ignore
+    }
+    this.micStream = this.micNode = this.workletNode = this.audioCtx = undefined;
+  }
+}
+
+function b64FromArrayBuffer(buf: ArrayBuffer): string {
+  const bytes = new Uint8Array(buf);
+  let bin = '';
+  const chunk = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunk) {
+    bin += String.fromCharCode.apply(null, Array.from(bytes.subarray(i, i + chunk)));
+  }
+  return btoa(bin);
+}
+
+function arrayBufferFromB64(b64: string): ArrayBuffer {
+  const bin = atob(b64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return bytes.buffer;
+}


### PR DESCRIPTION
## What

A **real-time voice call** inside the ChatGPT page (M3 of the realtime-voice rollout — design Index #114, relay PS #1069, cost PB #719, gateway PG #167).

A mic button in the ChatGPT toolbar opens `/chatgpt/call` → connects to `wss://api.acedata.cloud/v1/realtime` (the relay), captures the mic as **24kHz PCM16 via AudioWorklet**, streams it, plays the assistant audio back with a scheduled queue, and **barges-in** when the server VAD reports the user started speaking.

## Notes
- **Token via `Sec-WebSocket-Protocol` subprotocol** (`['realtime','acedata-token.<token>']`), never a `?token=` query — browsers can't set `Authorization` on a WebSocket, and this keeps the credential out of access logs.
- **GA event names** (`response.output_audio.delta` etc.) plus legacy aliases handled.
- Provisions an Application+Credential against the **openai service** (`06f2acb7…`) — realtime bills the openai balance, **separate from text chat (aichat2)**; the call screen shows guidance if the user has no openai app.
- iOS `NSMicrophoneUsageDescription` + Android `RECORD_AUDIO` added.
- i18n: zh-CN/zh-TW + en written; other 15 locales seeded (English) for the coverage gate — `npm run translate` backfills.
- `vue-tsc` clean, eslint clean.

## ⚠️ Gates (before this is usable end-to-end)
1. The **Kong ws route** for `/v1/realtime` must exist (final go-live step, after PB #719 / PG #167 merge + sync).
2. Auto-provisioning the openai service for Nexior consumers is a follow-up (today it requires an existing openai app); live mic test on web + a real device still pending.

## 🤖 对抗评审 (reviewer: codex, 1 round, 3 RISK — all fixed)
- RISK: only GA `output_audio` handled → **fixed** (handle GA + legacy `response.audio.delta` aliases).
- RISK: `stop()` can't cancel an in-flight `start()` (leaks mic/WS; only closed OPEN sockets) → **fixed** (disposed guard after each await; close CONNECTING + OPEN).
- RISK: barge-in didn't cancel the upstream response (deltas refill playback) → **fixed** (send `response.cancel` + suppress in-flight audio until the next response).

🤖 Generated with [Claude Code](https://claude.com/claude-code)