### PR TITLE
feat(suno): P0 — library & visual coherence

### DIFF
--- a/change/@acedatacloud-nexior-9bad4ed4-7b54-41ac-8740-a6221ab3b611.json
+++ b/change/@acedatacloud-nexior-9bad4ed4-7b54-41ac-8740-a6221ab3b611.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(suno): P0 library & visual coherence — coherent search pill, always-visible play, variation badges, model chip, 1-line style, responsive preview, cleanup",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/suno/PreviewPanel.vue
+++ b/src/components/suno/PreviewPanel.vue
@@ -26,18 +26,21 @@
       </div>
     </div>
   </div>
-  <div v-else class="w-full h-full"></div>
+  <div v-else class="flex flex-col items-center justify-center w-full h-full text-[var(--el-text-color-placeholder)]">
+    <el-icon class="text-5xl opacity-40"><headset /></el-icon>
+  </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
 import { ElImage, ElAvatar, ElIcon } from 'element-plus';
-import { Picture as IconPicture } from '@element-plus/icons-vue';
+import { Picture as IconPicture, Headset } from '@element-plus/icons-vue';
 
 export default defineComponent({
   name: 'TaskPreview',
   components: {
     IconPicture,
+    Headset,
     ElImage,
     ElAvatar,
     ElIcon

--- a/src/components/suno/RecentPanel.vue
+++ b/src/components/suno/RecentPanel.vue
@@ -33,7 +33,7 @@
         </template>
       </el-input>
       <el-dropdown trigger="click" @command="onSortChange">
-        <el-button size="small" class="sort-btn">
+        <el-button size="small" round class="sort-btn">
           <font-awesome-icon icon="fa-solid fa-arrow-down-wide-short" class="mr-1" />
           {{ sortLabel }}
         </el-button>
@@ -50,7 +50,7 @@
       </el-dropdown>
       <el-popover trigger="click" placement="bottom-end" :width="260">
         <template #reference>
-          <el-button size="small" class="filter-btn" :class="{ 'has-active-filter': activeFilterCount > 0 }">
+          <el-button size="small" round class="filter-btn" :class="{ 'has-active-filter': activeFilterCount > 0 }">
             <font-awesome-icon icon="fa-solid fa-filter" class="mr-1" />
             {{ $t('suno.filter.title') }}
             <span v-if="activeFilterCount > 0" class="filter-badge">{{ activeFilterCount }}</span>
@@ -293,18 +293,31 @@ export default defineComponent({
 .task-toolbar {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 6px 8px;
+  gap: 8px;
+  padding: 8px 12px;
   border-bottom: 1px solid var(--el-border-color-lighter);
   flex-shrink: 0;
 
   .task-search {
     flex: 1;
+    // Keep the search from dominating the bar; sort/filter sit to its right
+    max-width: 280px;
+
+    :deep(.el-input__wrapper) {
+      border-radius: 999px;
+      background-color: var(--el-fill-color-light);
+      box-shadow: none;
+
+      &.is-focus {
+        box-shadow: 0 0 0 1px var(--el-color-primary) inset;
+      }
+    }
   }
 
   .sort-btn {
     flex-shrink: 0;
     white-space: nowrap;
+    margin-left: auto;
   }
 
   .filter-btn {

--- a/src/components/suno/task/Preview.vue
+++ b/src/components/suno/task/Preview.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="task">
     <div
-      v-for="audio in audios"
+      v-for="(audio, index) in audios"
       :key="audio.id"
       class="audio"
-      :class="{ 'mashup-selected': isMashupSelected(audio) }"
+      :class="{ 'mashup-selected': isMashupSelected(audio), active: $store.state?.suno?.audio?.id === audio.id }"
       @click.stop="onClick(audio)"
     >
       <!-- Mashup selection checkbox -->
@@ -13,26 +13,21 @@
       </div>
       <div v-loading="!audio?.audio_url" class="left">
         <el-image :src="audio?.image_url" class="cover" fit="cover" lazy />
+        <!-- Variation index — one generation returns 2 songs; label them so they don't read as duplicates -->
+        <div v-if="audios.length > 1" class="variation-badge">{{ index + 1 }}</div>
+        <!-- Always-visible play/pause control (hover-only was invisible on touch) -->
         <div
           v-if="
             audio?.audio_url &&
             $store.state?.suno?.audio?.id === audio.id &&
             $store.state?.suno?.audio?.state === 'playing'
           "
-          class="overlay"
+          class="play-btn"
           @click.stop="onPause(audio)"
         >
           <el-icon><video-pause /></el-icon>
         </div>
-        <div
-          v-if="
-            audio?.audio_url &&
-            ($store.state?.suno?.audio?.id !== audio.id ||
-              ($store.state?.suno?.audio?.id === audio.id && $store.state?.suno?.audio?.state === 'paused'))
-          "
-          class="overlay"
-          @click.stop="onPlay(audio)"
-        >
+        <div v-else-if="audio?.audio_url" class="play-btn" @click.stop="onPlay(audio)">
           <el-icon><video-play /></el-icon>
         </div>
         <div v-if="audio?.duration" class="duration">
@@ -53,6 +48,7 @@
         </div>
         <div v-else class="title-row">
           <h2 class="title">{{ audio?.title }}</h2>
+          <span v-if="shortModel(audio)" class="model-chip">{{ shortModel(audio) }}</span>
           <font-awesome-icon
             v-if="audio?.audio_url"
             icon="fa-solid fa-pen"
@@ -74,9 +70,6 @@
         </div>
       </div>
       <div class="right">
-        <!-- <el-button v-if="audio?.audio_url" size="small" round @click.stop="onExtend($event, audio)">{{
-          $t('suno.button.extend')
-        }}</el-button> -->
         <el-dropdown>
           <span class="el-dropdown-link">
             <el-tooltip effect="dark" :content="$t('suno.button.download')" placement="top">
@@ -326,6 +319,15 @@ export default defineComponent({
   },
   methods: {
     useFormatDuring,
+    shortModel(audio: ISunoAudio): string {
+      // "chirp-v5-5" -> "v5.5", "chirp-v3-0" -> "v3" (matches the model selector labels)
+      const m = audio?.model;
+      if (!m) return '';
+      const match = /v(\d+)(?:-(\d+))?(-plus)?/i.exec(m);
+      if (!match) return m;
+      const minor = match[2] && match[2] !== '0' ? '.' + match[2] : '';
+      return `v${match[1]}${minor}${match[3] ? '+' : ''}`;
+    },
     onViewCode() {
       const request = (this.modelValue?.request || {}) as Record<string, unknown>;
       const body: Record<string, unknown> = {};
@@ -346,7 +348,6 @@ export default defineComponent({
         ...audio,
         state: 'playing'
       });
-      console.log('on play');
     },
     onPause(audio: ISunoAudio) {
       this.$store.dispatch('suno/setAudio', {
@@ -354,7 +355,6 @@ export default defineComponent({
         ...audio,
         state: 'paused'
       });
-      console.log('on pause');
     },
     onClick(audio: ISunoAudio) {
       if (this.$store.state?.suno?.audio?.id !== audio.id) {
@@ -366,9 +366,6 @@ export default defineComponent({
     },
     onExtend(event: MouseEvent, audio: ISunoAudio) {
       event?.stopPropagation();
-      console.log('on extend');
-      // download url here
-      console.debug('set config', audio);
       this.$store.commit('suno/setConfig', {
         ...this.$store.state.suno?.config,
         model: audio.model,
@@ -385,11 +382,9 @@ export default defineComponent({
       if (event) {
         event?.stopPropagation();
       }
-      console.log('on download', audioUrl);
       const parsedUrl = new URL(audioUrl);
       const pathname = parsedUrl.pathname;
       const filename = pathname.substring(pathname.lastIndexOf('/') + 1);
-      console.log('on preview', filename);
       fetch(audioUrl)
         .then((response) => response.blob())
         .then((blob) => {
@@ -410,7 +405,6 @@ export default defineComponent({
         this.isFetchingVideoUrl = true;
         // @ts-ignore
         const videoUrl = await this.fetchVideoUrlFromApi(audio?.id);
-        console.log(`get videoUrl: ${videoUrl}`);
         audio.video_url = videoUrl;
         this.onDownload(null, videoUrl);
       } catch (error) {
@@ -448,17 +442,12 @@ export default defineComponent({
     },
     onPreview(event: MouseEvent, videoUrl: string) {
       event?.stopPropagation();
-      console.log('on preview', videoUrl);
-      // preview url here
       window.open(videoUrl, '_blank');
     },
     async onGetStems(audioId: string) {
       await this.onGenerateAudioUrl('stems', audioId);
     },
     onCover(audio: ISunoAudio) {
-      console.log('on cover');
-      // download url here
-      console.debug('set config', audio);
       this.$store.commit('suno/setConfig', {
         ...this.$store.state.suno?.config,
         model: audio.model,
@@ -634,9 +623,8 @@ export default defineComponent({
       ElMessage.info(this.$t('suno.message.fetchingTiming'));
       sunoOperator
         .timing({ audio_id: audioId }, { token })
-        .then((response) => {
+        .then(() => {
           ElMessage.success(this.$t('suno.message.fetchTimingSuccess'));
-          console.debug('timing data', response.data);
         })
         .catch((error) => {
           ElMessage.error(error?.response?.data?.error?.message || this.$t('suno.message.fetchTimingFailed'));
@@ -811,7 +799,6 @@ export default defineComponent({
     },
     async onGetTasks() {
       if (this.loading) {
-        console.debug('loading');
         return;
       }
       await this.$store.dispatch('suno/getTasks', {
@@ -828,13 +815,32 @@ export default defineComponent({
   display: flex;
   flex-direction: column;
   cursor: pointer;
+  // Group the variations of one generation so the pair reads as a unit
+  padding: 4px;
+  margin-bottom: 8px;
+  border-radius: 12px;
+  border: 1px solid transparent;
+  transition: border-color 0.2s;
+  &:hover {
+    border-color: var(--el-border-color-lighter);
+  }
   .audio {
     display: flex;
-    margin-bottom: 10px;
+    padding: 6px;
+    margin-bottom: 2px;
     border-radius: 10px;
+    transition: background-color 0.2s;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
 
     &:hover {
       background-color: var(--el-bg-color-page);
+    }
+
+    &.active {
+      background-color: var(--el-color-primary-light-9);
     }
 
     .left {
@@ -844,14 +850,10 @@ export default defineComponent({
       margin-right: 16px;
       flex-shrink: 0;
 
-      &:hover .overlay {
-        display: block;
-      }
-
       .cover {
         width: 100%;
         height: 100%;
-        border-radius: 4px;
+        border-radius: 6px;
       }
 
       .duration {
@@ -865,26 +867,49 @@ export default defineComponent({
         font-size: 10px;
       }
 
-      .overlay {
+      .variation-badge {
         position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background-color: rgba(0, 0, 0, 0.5);
+        top: 3px;
+        left: 3px;
+        min-width: 16px;
+        height: 16px;
+        padding: 0 4px;
+        border-radius: 8px;
+        background-color: rgba(0, 0, 0, 0.6);
+        color: #fff;
+        font-size: 10px;
+        line-height: 16px;
+        text-align: center;
+        font-weight: 600;
+      }
+
+      // Always-visible play/pause control (works on touch; brightens on hover)
+      .play-btn {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        width: 28px;
+        height: 28px;
+        border-radius: 50%;
+        background-color: rgba(0, 0, 0, 0.55);
         display: flex;
         justify-content: center;
         align-items: center;
-        display: none;
-        transition: opacity 0.3s;
-        border-radius: 4px;
-        text-align: center;
-        line-height: 70px;
         cursor: pointer;
+        opacity: 0.92;
+        transition:
+          background-color 0.2s,
+          opacity 0.2s;
         .el-icon {
-          font-size: 20px;
+          font-size: 16px;
           color: white;
         }
+      }
+
+      &:hover .play-btn {
+        background-color: var(--el-color-primary);
+        opacity: 1;
       }
     }
     .info {
@@ -900,9 +925,22 @@ export default defineComponent({
         font-size: 14px;
         font-weight: bold;
         margin-top: 5px;
-        white-space: normal;
-        word-break: break-word;
-        overflow-wrap: anywhere;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        min-width: 0;
+      }
+      .model-chip {
+        flex-shrink: 0;
+        margin-top: 5px;
+        padding: 0 6px;
+        height: 16px;
+        line-height: 16px;
+        border-radius: 8px;
+        font-size: 10px;
+        font-weight: 600;
+        color: var(--el-color-primary);
+        background: var(--el-color-primary-light-9);
       }
       .edit-icon {
         font-size: 10px;
@@ -919,14 +957,10 @@ export default defineComponent({
       }
       .style {
         font-size: 12px;
+        margin-top: 2px;
         margin-bottom: 0;
         color: var(--el-text-color-secondary);
-        white-space: normal;
-        word-break: break-word;
-        overflow-wrap: anywhere;
-        display: -webkit-box;
-        -webkit-line-clamp: 2;
-        -webkit-box-orient: vertical;
+        white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
       }

--- a/src/layouts/Suno.vue
+++ b/src/layouts/Suno.vue
@@ -33,19 +33,21 @@ export default defineComponent({
     ElButton,
     FontAwesomeIcon
   },
-  mixins: [taskDrawerMixin],
-  data() {
-    return {
-      preview: false
-    };
-  },
-  computed: {}
+  mixins: [taskDrawerMixin]
 });
 </script>
 
 <style lang="scss" scoped>
 .menu {
   display: none;
+}
+
+// On laptops (≤1180px) the 320 + flex + 300 layout crushes the song list —
+// drop the detail preview here so the list keeps a usable width.
+@media (max-width: 1180px) {
+  .main .preview {
+    display: none;
+  }
 }
 
 @media (max-width: 767px) {

--- a/src/pages/suno/Index.vue
+++ b/src/pages/suno/Index.vue
@@ -89,7 +89,6 @@ export default defineComponent({
       handler(value, oldValue) {
         // scroll down if new tasks are added
         if (value?.items?.length > oldValue?.items?.length) {
-          console.debug('new tasks detected');
           // this.onScrollDown();
         }
       },
@@ -98,7 +97,6 @@ export default defineComponent({
     initialized: {
       async handler(newValue) {
         if (newValue) {
-          console.debug('layout initialized');
           await this.onGetTasks();
           await this.onScrollDown();
           this.job = window.setInterval(() => {
@@ -131,14 +129,10 @@ export default defineComponent({
       });
     },
     async onGetService() {
-      console.debug('start onGetService');
       await this.$store.dispatch('suno/getService');
-      console.debug('end onGetService');
     },
     async onGetApplication() {
-      console.debug('start onGetApplications');
       await this.$store.dispatch('suno/getApplications');
-      console.debug('end onGetApplications');
       await this.onGetTasks();
     },
     onApply() {
@@ -166,12 +160,9 @@ export default defineComponent({
     },
     async onGetTasks(payload?: { limit?: number; createdAtMin?: number; createdAtMax?: number }) {
       if (this.applicationsLoading || this.fetchingTasks) {
-        console.debug('loading');
         return;
       }
-      console.debug('start onGetTasks', payload);
       const { limit = 5, createdAtMin, createdAtMax } = payload || {};
-      console.debug('limit', limit, 'createdAtMin', createdAtMin, 'createdAtMax', createdAtMax);
       this.fetchingTasks = true;
       try {
         await this.$store.dispatch('suno/getTasks', {


### PR DESCRIPTION
## What & why

Phase-2 interaction polish on the Suno music page (plan: AceDataCloud/Index#122). The April feature-parity work made the page *have* the features; this makes them *cohere*. Directly targets the user's complaints — search box "格格不入", wrong entry points, wrong reactions. **Zero new i18n keys** (reuses existing strings, numeric badges, icon-only affordances).

## Changes
- **Search toolbar**: rounded pill input capped at 280px + rounded sort/filter buttons, so the bar reads as one coherent control (was a square full-width input wedged beside pills).
- **Always-visible play/pause** per song row (was a hover-only overlay — invisible on touch).
- **Variation badges (1/2) + group container**: one generation returns 2 songs; they no longer read as duplicates. The currently-playing row is highlighted.
- **Trim the wall of text**: 1-line style + a compact model chip (`v5.5`); the full style still shows in the detail preview.
- **Responsive**: drop the 300px detail panel ≤1180px so laptops aren't crushed to a ~300px song list.
- **Preview empty state** placeholder instead of a blank white box.
- **Cleanup**: removed `console.debug`/`console.log` litter, a dead commented Extend button, and dead `preview` layout data.

Verified locally: `eslint` clean, `vue-tsc --noEmit` clean.

## 🤖 对抗评审 (Codex, read-only)
One round. Codex found **no RISKs**, one NIT:
- **NIT** `task/Preview.vue` — `shortModel` rendered `chirp-v3-0` as `v3.0` but the model selector labels it `v3`. **Fixed** — minor `-0` now drops to `v3`.

Play/pause v-if→v-else-if equivalence, responsive breakpoint, always-visible play, and the title/style ellipsis-with-chip layout all passed.

Part of a P0→P2 series. Next: P1 (create-loop & player), P2 (search & capability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)