### PR TITLE
fix(coding-bridge): resumable codex history, switch loading, full transcript, session URL

### DIFF
--- a/change/@acedatacloud-nexior-d9ff34d7-ecf5-47fa-b3c4-b63424365bdd.json
+++ b/change/@acedatacloud-nexior-d9ff34d7-ecf5-47fa-b3c4-b63424365bdd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(coding-bridge): resumable codex history, switch loading, full transcript, session URL",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/pages/codingBridge/Index.vue
+++ b/src/pages/codingBridge/Index.vue
@@ -39,8 +39,33 @@ export default defineComponent({
       drawer: false,
       pairVisible: false,
       historyVisible: false,
-      initialCode: ''
+      initialCode: '',
+      // A `?session=` is in the URL but its transcript hasn't been reattached
+      // yet; while true the URL writer must not strip the param it's restoring.
+      restorePending: false
     };
+  },
+  computed: {
+    currentSessionId(): string | undefined {
+      return this.$store.state.codingBridge?.currentSessionId;
+    },
+    currentNodeId(): string | undefined {
+      return this.$store.state.codingBridge?.currentNodeId;
+    },
+    currentProvider(): string | undefined {
+      const id = this.currentSessionId;
+      const fromSession = id ? this.$store.state.codingBridge?.sessions?.[id]?.provider : undefined;
+      return fromSession || this.$store.state.codingBridge?.historyRef?.provider;
+    },
+    // One key so a single watcher reacts to any part of the open conversation.
+    sessionUrlKey(): string {
+      return `${this.currentNodeId || ''}|${this.currentSessionId || ''}|${this.currentProvider || ''}`;
+    }
+  },
+  watch: {
+    sessionUrlKey() {
+      this.syncUrl();
+    }
   },
   mounted() {
     this.$store.dispatch('codingBridge/connect');
@@ -50,6 +75,7 @@ export default defineComponent({
       this.initialCode = code;
       this.pairVisible = true;
     }
+    this.restoreFromUrl();
     this.handleNotificationDeepLink();
   },
   beforeUnmount() {
@@ -64,14 +90,64 @@ export default defineComponent({
       this.drawer = false;
       this.openPair();
     },
-    // A tapped notification opens `/coding-bridge?node=&session=&request=`.
-    // Select that node and re-fetch its pending prompts so the consent dialog
-    // surfaces immediately. The relay/socket may still be connecting, so we
-    // select eagerly — selectNode + the socket onOpen both request the prompts.
+    // Open the exact conversation named in `/coding-bridge?session=&node=&provider=`.
+    // We set the node + history pointer (not currentSession) and let the socket's
+    // onOpen → getHistory → history.snapshot handler reattach it (its guard needs
+    // currentSessionId empty). reattach then sets currentSession → syncUrl runs.
+    restoreFromUrl() {
+      const q = this.$route.query;
+      const sessionId = typeof q.session === 'string' ? q.session : '';
+      const nodeId = typeof q.node === 'string' ? q.node : '';
+      if (!sessionId || !nodeId) {
+        return;
+      }
+      const provider = q.provider === 'codex' ? 'codex' : 'claude';
+      this.restorePending = true;
+      this.$store.commit('codingBridge/setCurrentNode', nodeId);
+      this.$store.commit('codingBridge/setHistoryRef', { node_id: nodeId, provider, session_id: sessionId });
+      this.$store.dispatch('codingBridge/getHistory', nodeId);
+      this.$store.dispatch('codingBridge/requestSessions', nodeId);
+      // Don't pin the param forever if the session can't be restored (deleted/offline).
+      setTimeout(() => (this.restorePending = false), 15000);
+    },
+    // Mirror the open conversation into the URL so it's shareable and survives a
+    // reload / back button. `replace` (not push) avoids cluttering history.
+    syncUrl() {
+      const sessionId = this.currentSessionId;
+      const nodeId = this.currentNodeId;
+      if (sessionId) {
+        this.restorePending = false;
+      }
+      const query: Record<string, any> = { ...this.$route.query };
+      if (sessionId) {
+        query.session = sessionId;
+        if (nodeId) {
+          query.node = nodeId;
+        }
+        if (this.currentProvider) {
+          query.provider = this.currentProvider;
+        }
+      } else if (this.restorePending) {
+        return; // a cold restore is still resolving; keep the URL it's restoring
+      } else {
+        delete query.session;
+        delete query.provider;
+      }
+      const r = this.$route.query;
+      if (query.session === r.session && query.node === r.node && query.provider === r.provider) {
+        return;
+      }
+      this.$router.replace({ query }).catch(() => {});
+    },
+    // A tapped notification opens `/coding-bridge?node=&session=&request=`. When a
+    // session is present `restoreFromUrl` already selected the node (selecting
+    // again would jump to the node's last session); just re-fetch its prompts.
     handleNotificationDeepLink() {
       const nodeId = this.$route.query.node;
       if (typeof nodeId === 'string' && nodeId) {
-        this.$store.dispatch('codingBridge/selectNode', nodeId);
+        if (!this.$route.query.session) {
+          this.$store.dispatch('codingBridge/selectNode', nodeId);
+        }
         this.$store.dispatch('codingBridge/requestPendingPermissions', nodeId);
       }
     }

--- a/src/store/codingBridge/actions.identity.test.ts
+++ b/src/store/codingBridge/actions.identity.test.ts
@@ -121,10 +121,59 @@ describe('coding bridge session identity (integration)', () => {
     expect(h.state.events['old-session']).toHaveLength(1);
   });
 
-  it('marks a Codex history replay read-only', () => {
+  it('restores a Codex history session as resumable (not read-only)', () => {
+    // Codex resume works end-to-end now (`codex exec resume` with the sandbox as a
+    // -c override), so a Codex transcript opens as a continuable idle session.
     const h = harness();
     h.feed({ event: 'history.detail', session_id: 'cx', provider: 'codex', events: [] });
-    expect(h.state.sessions['cx'].readonly).toBe(true);
+    expect(h.state.sessions['cx'].readonly).toBe(false);
+    expect(h.state.sessions['cx'].status).toBe('idle');
+  });
+
+  it('replaces a partial relay buffer with the full transcript on idle reattach (bug 3)', () => {
+    const h = harness();
+    // A session the node still tracks (started) but NOT currently streaming, with
+    // only a short partial replay held in memory.
+    h.state.sessions['s1'] = {
+      session_id: 's1',
+      node_id: NODE,
+      provider: 'claude',
+      started: true,
+      status: 'idle'
+    } as never;
+    h.state.events['s1'] = [{ id: 'a', session_id: 's1', kind: 'text', ts: 1, text: 'partial tail' }] as never;
+    h.feed({
+      event: 'history.detail',
+      session_id: 's1',
+      provider: 'claude',
+      events: [
+        { kind: 'prompt', text: 'q1' },
+        { kind: 'text', text: 'a1' },
+        { kind: 'prompt', text: 'q2' }
+      ]
+    });
+    // The full on-disk transcript wins over the shorter partial buffer.
+    expect(h.state.events['s1'].map((e) => e.kind)).toEqual(['prompt', 'text', 'prompt']);
+  });
+
+  it('does NOT clobber an actively streaming turn with a longer history detail', () => {
+    const h = harness();
+    h.feed({ event: 'session.started', session_id: 's2' }); // status: running
+    h.feed({ event: 'session.text_delta', session_id: 's2', id: 'd', text: 'streaming…' });
+    // A late, longer history.detail must keep the in-flight stream (replacing it
+    // would drop the open bubble and the replay would duplicate the tail).
+    h.feed({
+      event: 'history.detail',
+      session_id: 's2',
+      provider: 'claude',
+      events: [
+        { kind: 'prompt', text: 'old1' },
+        { kind: 'text', text: 'old2' },
+        { kind: 'text', text: 'old3' }
+      ]
+    });
+    expect(h.state.events['s2'].length).toBe(1);
+    expect(h.state.events['s2'][0].text).toBe('streaming…');
   });
 
   it('reattaches (not just views) the open conversation when history snapshot lands after a reload', () => {

--- a/src/store/codingBridge/actions.ts
+++ b/src/store/codingBridge/actions.ts
@@ -409,7 +409,9 @@ export const applyNodeEvent = (
 // id history lists them under — so a transcript that is still running on the
 // node is reattached (its running status, seq cursor and in-flight stream kept
 // intact) instead of being overwritten by a static, idle copy. A dead transcript
-// materialises as a resumable idle session as before.
+// materialises as a resumable idle session — for BOTH providers: Claude
+// (`claude --resume`) and Codex (`codex exec resume`) can each continue an
+// on-disk transcript, so neither is forced read-only.
 const applyHistoryDetail = (
   commit: ActionContext<ICodingBridgeState, IRootState>['commit'],
   state: ICodingBridgeState,
@@ -421,7 +423,9 @@ const applyHistoryDetail = (
   if (!sessionId || !fromNode) {
     return;
   }
-  const resumable = provider === 'claude';
+  // Codex resume now works end-to-end (node sends `codex exec resume` with the
+  // sandbox as a -c override), so codex history is resumable too — not read-only.
+  const resumable = provider === 'claude' || provider === 'codex';
   const live = state.sessions[sessionId];
   // "Live" = a session the node is currently running (surfaced via the sessions
   // snapshot) or one already mid-turn in this tab. Such a session keeps the Stop
@@ -443,11 +447,18 @@ const applyHistoryDetail = (
     started: isLive ? true : false,
     readonly: !resumable && !isLive
   });
-  // Only lay down the static transcript when we don't already hold a richer live
-  // one: a session we're actively watching keeps its streamed events; a live
-  // session we only just learned about (e.g. after a reload) gets the transcript
-  // as its base, with later live deltas (higher seq) appending on top.
-  const haveLiveEvents = isLive && (state.events[sessionId]?.length ?? 0) > 0;
+  // Decide whether to keep our in-memory events or lay down the on-disk
+  // transcript. Keep them while a turn is ACTIVELY streaming (replacing would
+  // drop the in-flight bubble, and the seq-deduped replay would duplicate the
+  // transcript's tail), or when we already hold at least as many events as the
+  // transcript. Otherwise — an idle session opened with only a partial relay
+  // replay — the transcript is the source of truth and must win, or the user
+  // sees a truncated conversation that can't be scrolled back. Later live deltas
+  // (higher seq) still append on top.
+  const currentCount = state.events[sessionId]?.length ?? 0;
+  const transcriptCount = (payload.events ?? []).length;
+  const streaming = live?.status === 'running' || live?.status === 'starting';
+  const haveLiveEvents = isLive && currentCount > 0 && (streaming || currentCount >= transcriptCount);
   if (!haveLiveEvents) {
     const events: ICodingBridgeEvent[] = (payload.events ?? []).map((item: any, index: number) => ({
       id: uid(),
@@ -979,12 +990,19 @@ export const getHistoryDetail = (
 //  4. the in-flight event stream replayed from our last cursor (socket.resume),
 //     so live deltas (higher seq) append onto the restored transcript.
 export const reattachSession = (
-  { state, dispatch }: ActionContext<ICodingBridgeState, IRootState>,
+  { state, commit, dispatch }: ActionContext<ICodingBridgeState, IRootState>,
   ref: ICodingBridgeHistoryRef
 ): void => {
   if (!ref?.node_id || !ref?.session_id) {
     return;
   }
+  // Switch the view to the target session NOW, before the transcript lands.
+  // Otherwise currentSessionId stays on the previous conversation (whose events
+  // are non-empty), so the loading skeleton — gated on `!events.length` — never
+  // shows when switching between history sessions; only the very first open
+  // (from an empty view) ever animated. The detail reply re-affirms the same id.
+  commit('setCurrentNode', ref.node_id);
+  commit('setCurrentSession', ref.session_id);
   dispatch('getHistoryDetail', ref);
   dispatch('requestSessions', ref.node_id);
   dispatch('requestPendingPermissions', ref.node_id);


### PR DESCRIPTION
## What & why

Four Coding Bridge UI bugs (paired with AceDataCloud/CodingBridgeAgent#30 on the node side).

### Bug 4 — restored Codex history couldn't be continued
`applyHistoryDetail` hard-coded `resumable = provider === 'claude'`, so a Codex transcript was forced read-only and the composer was hidden ("This Codex conversation is read-only and cannot be continued"). Codex resume works end-to-end now (node fix #30), so `resumable = claude || codex`.

### Bug 1 — no loading skeleton when switching between history sessions
The skeleton is gated on `!events.length` of `currentSessionId`, but `currentSessionId` only flipped once the detail reply landed — so when switching from session A to B, the view stayed on A (non-empty events) and never showed loading. Only the very first open (from an empty view) ever animated. `reattachSession` now selects the target session **immediately**, before the detail arrives.

### Bug 3 — transcript loaded incompletely / can't scroll back
The `haveLiveEvents` guard skipped the full transcript whenever **any** in-memory events existed (e.g. a partial relay replay after opening a running session), leaving a truncated conversation. Now we keep in-memory events only while a turn is **actively streaming** (replacing would drop the in-flight bubble and the replay would duplicate the tail) or when we already hold at least as many events as the transcript; otherwise the on-disk transcript wins. (Node side also returns the recent tail of huge transcripts — #30.)

### Bug 6 — session id in the URL
The open conversation is now mirrored to `?session=&node=&provider=` and restored on load (shareable / back button), via the existing history-snapshot reattach path, guarded so the URL writer can't strip the param mid-restore.

## Verification
- `vitest` — `src/store/codingBridge` green (24 passed), incl. new tests: codex history resumable; idle reattach replaces a partial buffer with the full transcript; an actively-streaming turn is never clobbered.
- `eslint` clean, `vue-tsc --noEmit` exit 0.

> **Needs node E2E after merge:** Bug 3's reattach reconciliation (transcript vs seq-deduped live replay) is best confirmed on a live node.

## 🤖 对抗评审

Reviewer: **Codex** (`codex exec --sandbox read-only`, cross-model) + self-review.

- **Bug 4 confirmed** by Codex, down to the i18n string.
- **Codex round-2 RISK on the diff:** the first `haveLiveEvents` rewrite could still clobber an **actively-streaming** transcript when `currentCount < transcriptCount`, duplicating/reordering the tail vs the seq-deduped replay. **Fixed** — added the `streaming` guard so a live turn is never replaced; covered by a new test.
- **Rebutted (intended, not changed):** Codex flagged `reattachSession` selecting the target before detail lands — that's the Bug 1 fix; it shows the correct target with a loading skeleton, and a failed/missing detail already clears the skeleton (`session.error` path) within the 12s safety timeout.
- **NIT (intended):** `syncUrl` leaves `node` in the URL when no session is open — a node-only deep link is a valid state (node selected, composing a new session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
