### PR TITLE
feat(suno): P1 — create-loop & player polish

### DIFF
--- a/change/@acedatacloud-nexior-56b754a7-1ba4-41d5-bf15-ed875fa2c3a4.json
+++ b/change/@acedatacloud-nexior-56b754a7-1ba4-41d5-bf15-ed875fa2c3a4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(suno): P1 create-loop & player — prev/next (visible-order queue) + grabbable seek bar, quick Extend, generating pulse",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/player/Player.vue
+++ b/src/components/common/player/Player.vue
@@ -16,14 +16,20 @@
 </template>
 
 <script setup lang="ts">
-import { provide } from 'vue';
+import { computed, provide } from 'vue';
 import PlayerSlider from './PlayerSlider.vue';
 import PlayerSong from './PlayerSong.vue';
 import PlayerAction from './PlayerAction.vue';
 import PlayerController from './PlayerController.vue';
-import { AudioNamespaceKey, type AudioNamespace } from './useAudioState';
+import { AudioNamespaceKey, AudioQueueKey, type AudioNamespace } from './useAudioState';
 
-const props = defineProps<{ namespace: AudioNamespace }>();
+// `tracks` is the visible, ordered playback queue from the host list (optional;
+// when omitted, prev/next falls back to the namespace's task history).
+const props = defineProps<{ namespace: AudioNamespace; tracks?: Record<string, any>[] }>();
 
 provide(AudioNamespaceKey, props.namespace);
+provide(
+  AudioQueueKey,
+  computed(() => props.tracks ?? [])
+);
 </script>

--- a/src/components/common/player/PlayerController.vue
+++ b/src/components/common/player/PlayerController.vue
@@ -1,11 +1,29 @@
 <template>
   <div class="flex items-center justify-center gap-x-3">
     <icon-park
+      v-if="hasTracks"
+      :icon="GoStart"
+      size="22"
+      theme="filled"
+      class="cursor-pointer transition-opacity"
+      :class="hasPrev ? 'text-[var(--el-text-color-regular)]' : 'opacity-30 cursor-not-allowed'"
+      @click="hasPrev && playAdjacent(-1)"
+    />
+    <icon-park
       :icon="audio?.state === 'playing' ? PauseOne : Play"
       size="45"
       theme="filled"
       class="text-[var(--el-color-primary)] cursor-pointer"
       @click="togglePlay"
+    />
+    <icon-park
+      v-if="hasTracks"
+      :icon="GoEnd"
+      size="22"
+      theme="filled"
+      class="cursor-pointer transition-opacity"
+      :class="hasNext ? 'text-[var(--el-text-color-regular)]' : 'opacity-30 cursor-not-allowed'"
+      @click="hasNext && playAdjacent(1)"
     />
     <el-popover placement="top" width="50px" trigger="click">
       <template #reference>
@@ -17,13 +35,18 @@
 </template>
 
 <script setup lang="ts">
-import { Play, PauseOne, VolumeSmall } from '@icon-park/vue-next';
+import { computed } from 'vue';
+import { Play, PauseOne, VolumeSmall, GoStart, GoEnd } from '@icon-park/vue-next';
 import IconPark from '@/components/common/IconPark.vue';
 import PlayerVolumeSlider from './PlayerVolumeSlider.vue';
 import { ElPopover } from 'element-plus';
 import { useAudioState } from './useAudioState';
 
-const { audio, dispatchAudio } = useAudioState();
+const { audio, dispatchAudio, tracks, currentIndex, playAdjacent } = useAudioState();
+
+const hasTracks = computed(() => tracks.value.length > 1);
+const hasPrev = computed(() => currentIndex.value > 0);
+const hasNext = computed(() => currentIndex.value !== -1 && currentIndex.value < tracks.value.length - 1);
 
 const togglePlay = () =>
   dispatchAudio({

--- a/src/components/common/player/PlayerSlider.vue
+++ b/src/components/common/player/PlayerSlider.vue
@@ -27,23 +27,32 @@ const onSliderChange = (val: number | number[]) => dispatchAudio({ progress: Arr
 <style lang="scss">
 .player-slider {
   .el-slider {
-    height: 10px;
+    height: 12px;
 
     .el-slider__runway,
     .el-slider__bar {
-      height: 2px;
-      border-radius: 0;
+      height: 4px;
+      border-radius: 2px;
     }
 
     .el-slider__button-wrapper {
-      width: 10px;
-      height: 10px;
-      top: -10.5px;
+      width: 16px;
+      height: 16px;
+      top: -12px;
     }
 
+    // Handle stays small until hover/drag, so the bar reads clean but is grabbable
     .el-slider__button {
-      width: 8px;
-      height: 8px;
+      width: 10px;
+      height: 10px;
+      border-width: 2px;
+      transition:
+        transform 0.15s,
+        box-shadow 0.15s;
+    }
+
+    &:hover .el-slider__button {
+      transform: scale(1.3);
     }
   }
 }

--- a/src/components/common/player/useAudioState.ts
+++ b/src/components/common/player/useAudioState.ts
@@ -1,9 +1,17 @@
-import { computed, inject, type InjectionKey, type WritableComputedRef } from 'vue';
+import { computed, inject, type ComputedRef, type InjectionKey, type WritableComputedRef } from 'vue';
 import { useStore } from 'vuex';
 
 export type AudioNamespace = 'suno' | 'producer';
 
 export const AudioNamespaceKey: InjectionKey<AudioNamespace> = Symbol('AudioNamespace');
+
+/**
+ * Optional ordered playback queue, provided by the host list so prev/next
+ * follow the *visible* order (respecting the list's search/filter/sort)
+ * rather than the raw store order. When absent, the queue is derived from
+ * the namespace's task history.
+ */
+export const AudioQueueKey: InjectionKey<ComputedRef<Record<string, any>[]>> = Symbol('AudioQueue');
 
 export const useAudioNamespace = (): AudioNamespace => {
   const ns = inject(AudioNamespaceKey);
@@ -50,12 +58,56 @@ export const useAudioState = (namespace?: AudioNamespace) => {
       set: (value: T) => patchAudio({ [name]: value })
     });
 
+  // Ordered, visible queue provided by the host list (RecentPanel), if any.
+  const injectedQueue = inject(AudioQueueKey, undefined);
+
+  /**
+   * Flat, ordered list of playable tracks for prev/next navigation. Prefers
+   * the host-provided visible queue (so it respects search/filter/sort);
+   * falls back to the namespace's raw task history. Both `suno` and
+   * `producer` stores share the `tasks.items[].response.data[]` shape; if a
+   * namespace lacks it the list is simply empty (prev/next hide).
+   */
+  const tracks = computed<Record<string, any>[]>(() => {
+    const external = injectedQueue?.value;
+    if (external && external.length) return external;
+    const items = (store.state[ns]?.tasks?.items ?? []) as Record<string, any>[];
+    const list: Record<string, any>[] = [];
+    for (const t of items) {
+      for (const a of (t?.response?.data ?? []) as Record<string, any>[]) {
+        if (a?.audio_url) list.push(a);
+      }
+    }
+    return list;
+  });
+
+  const currentIndex = computed(() => {
+    const id = store.state[ns].audio?.id;
+    return tracks.value.findIndex((a) => a.id === id);
+  });
+
+  const playAdjacent = (dir: 1 | -1) => {
+    const idx = currentIndex.value;
+    if (idx === -1) return;
+    const next = tracks.value[idx + dir];
+    if (!next) return;
+    store.dispatch(`${ns}/setAudio`, {
+      ...store.state[ns].audio,
+      ...next,
+      progress: 0,
+      state: 'playing'
+    });
+  };
+
   return {
     namespace: ns,
     store,
     audio,
     field,
     patchAudio,
-    dispatchAudio
+    dispatchAudio,
+    tracks,
+    currentIndex,
+    playAdjacent
   };
 };

--- a/src/components/suno/RecentPanel.vue
+++ b/src/components/suno/RecentPanel.vue
@@ -121,7 +121,7 @@
     </div>
   </template>
   <div v-show="!!$store?.state?.suno?.audio?.object" class="h-20">
-    <player namespace="suno" />
+    <player namespace="suno" :tracks="visibleTracks" />
   </div>
 </template>
 
@@ -269,6 +269,18 @@ export default defineComponent({
         items = [...items].reverse();
       }
       return items;
+    },
+    // Flat, ordered playable tracks in the *visible* order — feeds the player's
+    // prev/next so it follows the list the user sees (search/filter/sort), not
+    // the raw store order.
+    visibleTracks(): ISunoAudio[] {
+      const out: ISunoAudio[] = [];
+      for (const task of this.filteredTasks) {
+        for (const a of (task?.response?.data ?? []) as ISunoAudio[]) {
+          if (a?.audio_url) out.push(a);
+        }
+      }
+      return out;
     }
   },
   methods: {

--- a/src/components/suno/task/Preview.vue
+++ b/src/components/suno/task/Preview.vue
@@ -4,7 +4,11 @@
       v-for="(audio, index) in audios"
       :key="audio.id"
       class="audio"
-      :class="{ 'mashup-selected': isMashupSelected(audio), active: $store.state?.suno?.audio?.id === audio.id }"
+      :class="{
+        'mashup-selected': isMashupSelected(audio),
+        active: $store.state?.suno?.audio?.id === audio.id,
+        generating: !audio?.audio_url
+      }"
       @click.stop="onClick(audio)"
     >
       <!-- Mashup selection checkbox -->
@@ -70,6 +74,14 @@
         </div>
       </div>
       <div class="right">
+        <!-- Quick Extend — the most common re-use action, surfaced out of the "…" menu -->
+        <el-tooltip v-if="audio?.audio_url" effect="dark" :content="$t('suno.button.extend')" placement="top">
+          <font-awesome-icon
+            icon="fa-solid fa-forward"
+            class="icon icon-extend"
+            @click.stop="onExtend($event, audio)"
+          />
+        </el-tooltip>
         <el-dropdown>
           <span class="el-dropdown-link">
             <el-tooltip effect="dark" :content="$t('suno.button.download')" placement="top">
@@ -994,7 +1006,7 @@ export default defineComponent({
       border-radius: 8px;
     }
     .right {
-      width: 120px;
+      width: 140px;
       display: flex;
       align-items: center;
       justify-content: flex-end;
@@ -1004,11 +1016,31 @@ export default defineComponent({
         z-index: 100;
         cursor: pointer;
         margin-right: 15px;
+        color: var(--el-text-color-secondary);
+        transition: color 0.2s;
+        &:hover {
+          color: var(--el-color-primary);
+        }
       }
       .el-button {
         margin-right: 15px; /* Add margin to the right of the button */
       }
     }
+
+    // Pulse the cover while a generation is still in flight (~2 min wait)
+    &.generating .left .cover {
+      animation: suno-pulse 1.4s ease-in-out infinite;
+    }
+  }
+}
+
+@keyframes suno-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.55;
   }
 }
 


### PR DESCRIPTION
## What & why
Phase-2 step 2 (plan: AceDataCloud/Index#122), **stacked on #995** (P0). Targets the player and the ~2-min generation wait — the "反应不对" part of the feedback. **Zero new i18n keys.**

> Base is `feat/suno-ux-p0`; review P0 (#995) first. GitHub will retarget this to `main` once #995 merges.

## Changes
- **Player prev/next** — track navigation reading an ordered playback queue; **follows the visible list order** (the player gets RecentPanel's filtered/sorted queue via a `tracks` prop, with a store-derived fallback for the `producer` namespace). Track swap is handled by the existing `PlayerSong` `<audio>` watcher.
- **Visible, grabbable seek bar** — was a 2px hairline; now 4px with a handle that grows on hover. (The slider was already functional, just invisible.)
- **Quick Extend icon** per row — surfaces the most common re-use action out of the 20-item `…` menu; consistent icon hover colors.
- **Generating pulse** — songs pulse their cover during the wait for clearer in-flight feedback.

Verified locally: `eslint` clean, `vue-tsc --noEmit` clean.

## 🤖 对抗评审 (Codex, read-only)
One round, one **RISK**, fixed:
- **RISK** `useAudioState.ts` — prev/next used the raw store order, so Suno search/filter/sort could make it play hidden or wrong-order songs. **Fixed** per the reviewer's own suggestion: the player now navigates the *visible* queue passed down from `RecentPanel.filteredTasks` (search + filter + sort applied), falling back to store order only when no queue is provided (e.g. `producer`). When the playing track isn't in the visible list, prev/next simply disable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)