### PR TITLE
feat(suno): P2 — full-history search

### DIFF
--- a/change/@acedatacloud-nexior-6116a2b4-d83a-465f-a4d7-74e1be20629c.json
+++ b/change/@acedatacloud-nexior-6116a2b4-d83a-465f-a4d7-74e1be20629c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(suno): P2 full-history search — load all pages on first search/filter so older songs are not silently missed",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/player/Player.vue
+++ b/src/components/common/player/Player.vue
@@ -16,14 +16,20 @@
 </template>
 
 <script setup lang="ts">
-import { provide } from 'vue';
+import { computed, provide } from 'vue';
 import PlayerSlider from './PlayerSlider.vue';
 import PlayerSong from './PlayerSong.vue';
 import PlayerAction from './PlayerAction.vue';
 import PlayerController from './PlayerController.vue';
-import { AudioNamespaceKey, type AudioNamespace } from './useAudioState';
+import { AudioNamespaceKey, AudioQueueKey, type AudioNamespace } from './useAudioState';
 
-const props = defineProps<{ namespace: AudioNamespace }>();
+// `tracks` is the visible, ordered playback queue from the host list (optional;
+// when omitted, prev/next falls back to the namespace's task history).
+const props = defineProps<{ namespace: AudioNamespace; tracks?: Record<string, any>[] }>();
 
 provide(AudioNamespaceKey, props.namespace);
+provide(
+  AudioQueueKey,
+  computed(() => props.tracks ?? [])
+);
 </script>

--- a/src/components/common/player/PlayerController.vue
+++ b/src/components/common/player/PlayerController.vue
@@ -1,11 +1,29 @@
 <template>
   <div class="flex items-center justify-center gap-x-3">
     <icon-park
+      v-if="hasTracks"
+      :icon="GoStart"
+      size="22"
+      theme="filled"
+      class="cursor-pointer transition-opacity"
+      :class="hasPrev ? 'text-[var(--el-text-color-regular)]' : 'opacity-30 cursor-not-allowed'"
+      @click="hasPrev && playAdjacent(-1)"
+    />
+    <icon-park
       :icon="audio?.state === 'playing' ? PauseOne : Play"
       size="45"
       theme="filled"
       class="text-[var(--el-color-primary)] cursor-pointer"
       @click="togglePlay"
+    />
+    <icon-park
+      v-if="hasTracks"
+      :icon="GoEnd"
+      size="22"
+      theme="filled"
+      class="cursor-pointer transition-opacity"
+      :class="hasNext ? 'text-[var(--el-text-color-regular)]' : 'opacity-30 cursor-not-allowed'"
+      @click="hasNext && playAdjacent(1)"
     />
     <el-popover placement="top" width="50px" trigger="click">
       <template #reference>
@@ -17,13 +35,18 @@
 </template>
 
 <script setup lang="ts">
-import { Play, PauseOne, VolumeSmall } from '@icon-park/vue-next';
+import { computed } from 'vue';
+import { Play, PauseOne, VolumeSmall, GoStart, GoEnd } from '@icon-park/vue-next';
 import IconPark from '@/components/common/IconPark.vue';
 import PlayerVolumeSlider from './PlayerVolumeSlider.vue';
 import { ElPopover } from 'element-plus';
 import { useAudioState } from './useAudioState';
 
-const { audio, dispatchAudio } = useAudioState();
+const { audio, dispatchAudio, tracks, currentIndex, playAdjacent } = useAudioState();
+
+const hasTracks = computed(() => tracks.value.length > 1);
+const hasPrev = computed(() => currentIndex.value > 0);
+const hasNext = computed(() => currentIndex.value !== -1 && currentIndex.value < tracks.value.length - 1);
 
 const togglePlay = () =>
   dispatchAudio({

--- a/src/components/common/player/PlayerSlider.vue
+++ b/src/components/common/player/PlayerSlider.vue
@@ -27,23 +27,32 @@ const onSliderChange = (val: number | number[]) => dispatchAudio({ progress: Arr
 <style lang="scss">
 .player-slider {
   .el-slider {
-    height: 10px;
+    height: 12px;
 
     .el-slider__runway,
     .el-slider__bar {
-      height: 2px;
-      border-radius: 0;
+      height: 4px;
+      border-radius: 2px;
     }
 
     .el-slider__button-wrapper {
-      width: 10px;
-      height: 10px;
-      top: -10.5px;
+      width: 16px;
+      height: 16px;
+      top: -12px;
     }
 
+    // Handle stays small until hover/drag, so the bar reads clean but is grabbable
     .el-slider__button {
-      width: 8px;
-      height: 8px;
+      width: 10px;
+      height: 10px;
+      border-width: 2px;
+      transition:
+        transform 0.15s,
+        box-shadow 0.15s;
+    }
+
+    &:hover .el-slider__button {
+      transform: scale(1.3);
     }
   }
 }

--- a/src/components/common/player/useAudioState.ts
+++ b/src/components/common/player/useAudioState.ts
@@ -1,9 +1,17 @@
-import { computed, inject, type InjectionKey, type WritableComputedRef } from 'vue';
+import { computed, inject, type ComputedRef, type InjectionKey, type WritableComputedRef } from 'vue';
 import { useStore } from 'vuex';
 
 export type AudioNamespace = 'suno' | 'producer';
 
 export const AudioNamespaceKey: InjectionKey<AudioNamespace> = Symbol('AudioNamespace');
+
+/**
+ * Optional ordered playback queue, provided by the host list so prev/next
+ * follow the *visible* order (respecting the list's search/filter/sort)
+ * rather than the raw store order. When absent, the queue is derived from
+ * the namespace's task history.
+ */
+export const AudioQueueKey: InjectionKey<ComputedRef<Record<string, any>[]>> = Symbol('AudioQueue');
 
 export const useAudioNamespace = (): AudioNamespace => {
   const ns = inject(AudioNamespaceKey);
@@ -50,12 +58,56 @@ export const useAudioState = (namespace?: AudioNamespace) => {
       set: (value: T) => patchAudio({ [name]: value })
     });
 
+  // Ordered, visible queue provided by the host list (RecentPanel), if any.
+  const injectedQueue = inject(AudioQueueKey, undefined);
+
+  /**
+   * Flat, ordered list of playable tracks for prev/next navigation. Prefers
+   * the host-provided visible queue (so it respects search/filter/sort);
+   * falls back to the namespace's raw task history. Both `suno` and
+   * `producer` stores share the `tasks.items[].response.data[]` shape; if a
+   * namespace lacks it the list is simply empty (prev/next hide).
+   */
+  const tracks = computed<Record<string, any>[]>(() => {
+    const external = injectedQueue?.value;
+    if (external && external.length) return external;
+    const items = (store.state[ns]?.tasks?.items ?? []) as Record<string, any>[];
+    const list: Record<string, any>[] = [];
+    for (const t of items) {
+      for (const a of (t?.response?.data ?? []) as Record<string, any>[]) {
+        if (a?.audio_url) list.push(a);
+      }
+    }
+    return list;
+  });
+
+  const currentIndex = computed(() => {
+    const id = store.state[ns].audio?.id;
+    return tracks.value.findIndex((a) => a.id === id);
+  });
+
+  const playAdjacent = (dir: 1 | -1) => {
+    const idx = currentIndex.value;
+    if (idx === -1) return;
+    const next = tracks.value[idx + dir];
+    if (!next) return;
+    store.dispatch(`${ns}/setAudio`, {
+      ...store.state[ns].audio,
+      ...next,
+      progress: 0,
+      state: 'playing'
+    });
+  };
+
   return {
     namespace: ns,
     store,
     audio,
     field,
     patchAudio,
-    dispatchAudio
+    dispatchAudio,
+    tracks,
+    currentIndex,
+    playAdjacent
   };
 };

--- a/src/components/suno/PreviewPanel.vue
+++ b/src/components/suno/PreviewPanel.vue
@@ -26,18 +26,21 @@
       </div>
     </div>
   </div>
-  <div v-else class="w-full h-full"></div>
+  <div v-else class="flex flex-col items-center justify-center w-full h-full text-[var(--el-text-color-placeholder)]">
+    <el-icon class="text-5xl opacity-40"><headset /></el-icon>
+  </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
 import { ElImage, ElAvatar, ElIcon } from 'element-plus';
-import { Picture as IconPicture } from '@element-plus/icons-vue';
+import { Picture as IconPicture, Headset } from '@element-plus/icons-vue';
 
 export default defineComponent({
   name: 'TaskPreview',
   components: {
     IconPicture,
+    Headset,
     ElImage,
     ElAvatar,
     ElIcon

--- a/src/components/suno/RecentPanel.vue
+++ b/src/components/suno/RecentPanel.vue
@@ -121,7 +121,7 @@
     </div>
   </template>
   <div v-show="!!$store?.state?.suno?.audio?.object" class="h-20">
-    <player namespace="suno" />
+    <player namespace="suno" :tracks="visibleTracks" />
   </div>
 </template>
 
@@ -269,6 +269,18 @@ export default defineComponent({
         items = [...items].reverse();
       }
       return items;
+    },
+    // Flat, ordered playable tracks in the *visible* order — feeds the player's
+    // prev/next so it follows the list the user sees (search/filter/sort), not
+    // the raw store order.
+    visibleTracks(): ISunoAudio[] {
+      const out: ISunoAudio[] = [];
+      for (const task of this.filteredTasks) {
+        for (const a of (task?.response?.data ?? []) as ISunoAudio[]) {
+          if (a?.audio_url) out.push(a);
+        }
+      }
+      return out;
     }
   },
   methods: {

--- a/src/components/suno/RecentPanel.vue
+++ b/src/components/suno/RecentPanel.vue
@@ -106,15 +106,21 @@
     >
       <task-preview v-for="(task, taskId) in filteredTasks" :key="taskId" :model-value="task" class="preview" />
     </scroll-list>
-    <div v-else-if="searchQuery && tasks?.items?.length > 0" class="w-full flex-1 flex items-center justify-center">
+    <div
+      v-else-if="!loading && searchQuery && tasks?.items?.length > 0"
+      class="w-full flex-1 flex items-center justify-center"
+    >
       <p class="text-sm text-gray-400">{{ $t('suno.message.noSearchResults') }}</p>
     </div>
     <div
-      v-else-if="activeFilterCount > 0 && tasks?.items?.length > 0"
+      v-else-if="!loading && activeFilterCount > 0 && tasks?.items?.length > 0"
       class="w-full flex-1 flex flex-col items-center justify-center gap-2"
     >
       <p class="text-sm text-gray-400">{{ $t('suno.message.noFilterResults') }}</p>
       <el-button size="small" text @click="onResetFilters">{{ $t('suno.filter.reset') }}</el-button>
+    </div>
+    <div v-else-if="loading" class="w-full flex-1 flex items-center justify-center">
+      <el-icon class="is-loading text-xl text-gray-400"><loading /></el-icon>
     </div>
     <div v-else-if="tasks?.items?.length === 0" class="w-full flex-1 flex items-center justify-center">
       <no-tasks />
@@ -142,8 +148,10 @@ import {
   ElRadioGroup,
   ElRadioButton,
   ElSelect,
-  ElOption
+  ElOption,
+  ElIcon
 } from 'element-plus';
+import { Loading } from '@element-plus/icons-vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import ScrollList from '@/components/common/ScrollList.vue';
 import { ISunoTask, ISunoAudio } from '@/models';
@@ -163,6 +171,8 @@ export default defineComponent({
     ElRadioButton,
     ElSelect,
     ElOption,
+    ElIcon,
+    Loading,
     FontAwesomeIcon,
     TaskPreview,
     Player,
@@ -175,11 +185,12 @@ export default defineComponent({
       default: false
     }
   },
-  emits: ['reach-top'],
+  emits: ['reach-top', 'load-all'],
   data() {
     return {
       job: 0,
       searchQuery: '',
+      historyRequested: false,
       sortBy: 'newest' as 'newest' | 'oldest',
       filterType: 'all' as 'all' | 'vocal' | 'instrumental',
       filterDuration: 'all' as 'all' | 'short' | 'medium' | 'long',
@@ -283,7 +294,23 @@ export default defineComponent({
       return out;
     }
   },
+  watch: {
+    // Search/filter run client-side over loaded pages only. The first time the
+    // user actually searches or filters, pull the full history so they don't
+    // silently miss older songs.
+    searchQuery(val: string) {
+      if (val) this.requestFullHistory();
+    },
+    activeFilterCount(count: number) {
+      if (count > 0) this.requestFullHistory();
+    }
+  },
   methods: {
+    requestFullHistory() {
+      if (this.historyRequested) return;
+      this.historyRequested = true;
+      this.$emit('load-all');
+    },
     onSortChange(command: 'newest' | 'oldest') {
       this.sortBy = command;
     },

--- a/src/components/suno/RecentPanel.vue
+++ b/src/components/suno/RecentPanel.vue
@@ -33,7 +33,7 @@
         </template>
       </el-input>
       <el-dropdown trigger="click" @command="onSortChange">
-        <el-button size="small" class="sort-btn">
+        <el-button size="small" round class="sort-btn">
           <font-awesome-icon icon="fa-solid fa-arrow-down-wide-short" class="mr-1" />
           {{ sortLabel }}
         </el-button>
@@ -50,7 +50,7 @@
       </el-dropdown>
       <el-popover trigger="click" placement="bottom-end" :width="260">
         <template #reference>
-          <el-button size="small" class="filter-btn" :class="{ 'has-active-filter': activeFilterCount > 0 }">
+          <el-button size="small" round class="filter-btn" :class="{ 'has-active-filter': activeFilterCount > 0 }">
             <font-awesome-icon icon="fa-solid fa-filter" class="mr-1" />
             {{ $t('suno.filter.title') }}
             <span v-if="activeFilterCount > 0" class="filter-badge">{{ activeFilterCount }}</span>
@@ -293,18 +293,31 @@ export default defineComponent({
 .task-toolbar {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 6px 8px;
+  gap: 8px;
+  padding: 8px 12px;
   border-bottom: 1px solid var(--el-border-color-lighter);
   flex-shrink: 0;
 
   .task-search {
     flex: 1;
+    // Keep the search from dominating the bar; sort/filter sit to its right
+    max-width: 280px;
+
+    :deep(.el-input__wrapper) {
+      border-radius: 999px;
+      background-color: var(--el-fill-color-light);
+      box-shadow: none;
+
+      &.is-focus {
+        box-shadow: 0 0 0 1px var(--el-color-primary) inset;
+      }
+    }
   }
 
   .sort-btn {
     flex-shrink: 0;
     white-space: nowrap;
+    margin-left: auto;
   }
 
   .filter-btn {

--- a/src/components/suno/task/Preview.vue
+++ b/src/components/suno/task/Preview.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="task">
     <div
-      v-for="audio in audios"
+      v-for="(audio, index) in audios"
       :key="audio.id"
       class="audio"
-      :class="{ 'mashup-selected': isMashupSelected(audio) }"
+      :class="{ 'mashup-selected': isMashupSelected(audio), active: $store.state?.suno?.audio?.id === audio.id }"
       @click.stop="onClick(audio)"
     >
       <!-- Mashup selection checkbox -->
@@ -13,26 +13,21 @@
       </div>
       <div v-loading="!audio?.audio_url" class="left">
         <el-image :src="audio?.image_url" class="cover" fit="cover" lazy />
+        <!-- Variation index — one generation returns 2 songs; label them so they don't read as duplicates -->
+        <div v-if="audios.length > 1" class="variation-badge">{{ index + 1 }}</div>
+        <!-- Always-visible play/pause control (hover-only was invisible on touch) -->
         <div
           v-if="
             audio?.audio_url &&
             $store.state?.suno?.audio?.id === audio.id &&
             $store.state?.suno?.audio?.state === 'playing'
           "
-          class="overlay"
+          class="play-btn"
           @click.stop="onPause(audio)"
         >
           <el-icon><video-pause /></el-icon>
         </div>
-        <div
-          v-if="
-            audio?.audio_url &&
-            ($store.state?.suno?.audio?.id !== audio.id ||
-              ($store.state?.suno?.audio?.id === audio.id && $store.state?.suno?.audio?.state === 'paused'))
-          "
-          class="overlay"
-          @click.stop="onPlay(audio)"
-        >
+        <div v-else-if="audio?.audio_url" class="play-btn" @click.stop="onPlay(audio)">
           <el-icon><video-play /></el-icon>
         </div>
         <div v-if="audio?.duration" class="duration">
@@ -53,6 +48,7 @@
         </div>
         <div v-else class="title-row">
           <h2 class="title">{{ audio?.title }}</h2>
+          <span v-if="shortModel(audio)" class="model-chip">{{ shortModel(audio) }}</span>
           <font-awesome-icon
             v-if="audio?.audio_url"
             icon="fa-solid fa-pen"
@@ -74,9 +70,6 @@
         </div>
       </div>
       <div class="right">
-        <!-- <el-button v-if="audio?.audio_url" size="small" round @click.stop="onExtend($event, audio)">{{
-          $t('suno.button.extend')
-        }}</el-button> -->
         <el-dropdown>
           <span class="el-dropdown-link">
             <el-tooltip effect="dark" :content="$t('suno.button.download')" placement="top">
@@ -326,6 +319,15 @@ export default defineComponent({
   },
   methods: {
     useFormatDuring,
+    shortModel(audio: ISunoAudio): string {
+      // "chirp-v5-5" -> "v5.5", "chirp-v3-0" -> "v3" (matches the model selector labels)
+      const m = audio?.model;
+      if (!m) return '';
+      const match = /v(\d+)(?:-(\d+))?(-plus)?/i.exec(m);
+      if (!match) return m;
+      const minor = match[2] && match[2] !== '0' ? '.' + match[2] : '';
+      return `v${match[1]}${minor}${match[3] ? '+' : ''}`;
+    },
     onViewCode() {
       const request = (this.modelValue?.request || {}) as Record<string, unknown>;
       const body: Record<string, unknown> = {};
@@ -346,7 +348,6 @@ export default defineComponent({
         ...audio,
         state: 'playing'
       });
-      console.log('on play');
     },
     onPause(audio: ISunoAudio) {
       this.$store.dispatch('suno/setAudio', {
@@ -354,7 +355,6 @@ export default defineComponent({
         ...audio,
         state: 'paused'
       });
-      console.log('on pause');
     },
     onClick(audio: ISunoAudio) {
       if (this.$store.state?.suno?.audio?.id !== audio.id) {
@@ -366,9 +366,6 @@ export default defineComponent({
     },
     onExtend(event: MouseEvent, audio: ISunoAudio) {
       event?.stopPropagation();
-      console.log('on extend');
-      // download url here
-      console.debug('set config', audio);
       this.$store.commit('suno/setConfig', {
         ...this.$store.state.suno?.config,
         model: audio.model,
@@ -385,11 +382,9 @@ export default defineComponent({
       if (event) {
         event?.stopPropagation();
       }
-      console.log('on download', audioUrl);
       const parsedUrl = new URL(audioUrl);
       const pathname = parsedUrl.pathname;
       const filename = pathname.substring(pathname.lastIndexOf('/') + 1);
-      console.log('on preview', filename);
       fetch(audioUrl)
         .then((response) => response.blob())
         .then((blob) => {
@@ -410,7 +405,6 @@ export default defineComponent({
         this.isFetchingVideoUrl = true;
         // @ts-ignore
         const videoUrl = await this.fetchVideoUrlFromApi(audio?.id);
-        console.log(`get videoUrl: ${videoUrl}`);
         audio.video_url = videoUrl;
         this.onDownload(null, videoUrl);
       } catch (error) {
@@ -448,17 +442,12 @@ export default defineComponent({
     },
     onPreview(event: MouseEvent, videoUrl: string) {
       event?.stopPropagation();
-      console.log('on preview', videoUrl);
-      // preview url here
       window.open(videoUrl, '_blank');
     },
     async onGetStems(audioId: string) {
       await this.onGenerateAudioUrl('stems', audioId);
     },
     onCover(audio: ISunoAudio) {
-      console.log('on cover');
-      // download url here
-      console.debug('set config', audio);
       this.$store.commit('suno/setConfig', {
         ...this.$store.state.suno?.config,
         model: audio.model,
@@ -634,9 +623,8 @@ export default defineComponent({
       ElMessage.info(this.$t('suno.message.fetchingTiming'));
       sunoOperator
         .timing({ audio_id: audioId }, { token })
-        .then((response) => {
+        .then(() => {
           ElMessage.success(this.$t('suno.message.fetchTimingSuccess'));
-          console.debug('timing data', response.data);
         })
         .catch((error) => {
           ElMessage.error(error?.response?.data?.error?.message || this.$t('suno.message.fetchTimingFailed'));
@@ -811,7 +799,6 @@ export default defineComponent({
     },
     async onGetTasks() {
       if (this.loading) {
-        console.debug('loading');
         return;
       }
       await this.$store.dispatch('suno/getTasks', {
@@ -828,13 +815,32 @@ export default defineComponent({
   display: flex;
   flex-direction: column;
   cursor: pointer;
+  // Group the variations of one generation so the pair reads as a unit
+  padding: 4px;
+  margin-bottom: 8px;
+  border-radius: 12px;
+  border: 1px solid transparent;
+  transition: border-color 0.2s;
+  &:hover {
+    border-color: var(--el-border-color-lighter);
+  }
   .audio {
     display: flex;
-    margin-bottom: 10px;
+    padding: 6px;
+    margin-bottom: 2px;
     border-radius: 10px;
+    transition: background-color 0.2s;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
 
     &:hover {
       background-color: var(--el-bg-color-page);
+    }
+
+    &.active {
+      background-color: var(--el-color-primary-light-9);
     }
 
     .left {
@@ -844,14 +850,10 @@ export default defineComponent({
       margin-right: 16px;
       flex-shrink: 0;
 
-      &:hover .overlay {
-        display: block;
-      }
-
       .cover {
         width: 100%;
         height: 100%;
-        border-radius: 4px;
+        border-radius: 6px;
       }
 
       .duration {
@@ -865,26 +867,49 @@ export default defineComponent({
         font-size: 10px;
       }
 
-      .overlay {
+      .variation-badge {
         position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background-color: rgba(0, 0, 0, 0.5);
+        top: 3px;
+        left: 3px;
+        min-width: 16px;
+        height: 16px;
+        padding: 0 4px;
+        border-radius: 8px;
+        background-color: rgba(0, 0, 0, 0.6);
+        color: #fff;
+        font-size: 10px;
+        line-height: 16px;
+        text-align: center;
+        font-weight: 600;
+      }
+
+      // Always-visible play/pause control (works on touch; brightens on hover)
+      .play-btn {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        width: 28px;
+        height: 28px;
+        border-radius: 50%;
+        background-color: rgba(0, 0, 0, 0.55);
         display: flex;
         justify-content: center;
         align-items: center;
-        display: none;
-        transition: opacity 0.3s;
-        border-radius: 4px;
-        text-align: center;
-        line-height: 70px;
         cursor: pointer;
+        opacity: 0.92;
+        transition:
+          background-color 0.2s,
+          opacity 0.2s;
         .el-icon {
-          font-size: 20px;
+          font-size: 16px;
           color: white;
         }
+      }
+
+      &:hover .play-btn {
+        background-color: var(--el-color-primary);
+        opacity: 1;
       }
     }
     .info {
@@ -900,9 +925,22 @@ export default defineComponent({
         font-size: 14px;
         font-weight: bold;
         margin-top: 5px;
-        white-space: normal;
-        word-break: break-word;
-        overflow-wrap: anywhere;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        min-width: 0;
+      }
+      .model-chip {
+        flex-shrink: 0;
+        margin-top: 5px;
+        padding: 0 6px;
+        height: 16px;
+        line-height: 16px;
+        border-radius: 8px;
+        font-size: 10px;
+        font-weight: 600;
+        color: var(--el-color-primary);
+        background: var(--el-color-primary-light-9);
       }
       .edit-icon {
         font-size: 10px;
@@ -919,14 +957,10 @@ export default defineComponent({
       }
       .style {
         font-size: 12px;
+        margin-top: 2px;
         margin-bottom: 0;
         color: var(--el-text-color-secondary);
-        white-space: normal;
-        word-break: break-word;
-        overflow-wrap: anywhere;
-        display: -webkit-box;
-        -webkit-line-clamp: 2;
-        -webkit-box-orient: vertical;
+        white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
       }

--- a/src/components/suno/task/Preview.vue
+++ b/src/components/suno/task/Preview.vue
@@ -4,7 +4,11 @@
       v-for="(audio, index) in audios"
       :key="audio.id"
       class="audio"
-      :class="{ 'mashup-selected': isMashupSelected(audio), active: $store.state?.suno?.audio?.id === audio.id }"
+      :class="{
+        'mashup-selected': isMashupSelected(audio),
+        active: $store.state?.suno?.audio?.id === audio.id,
+        generating: !audio?.audio_url
+      }"
       @click.stop="onClick(audio)"
     >
       <!-- Mashup selection checkbox -->
@@ -70,6 +74,14 @@
         </div>
       </div>
       <div class="right">
+        <!-- Quick Extend — the most common re-use action, surfaced out of the "…" menu -->
+        <el-tooltip v-if="audio?.audio_url" effect="dark" :content="$t('suno.button.extend')" placement="top">
+          <font-awesome-icon
+            icon="fa-solid fa-forward"
+            class="icon icon-extend"
+            @click.stop="onExtend($event, audio)"
+          />
+        </el-tooltip>
         <el-dropdown>
           <span class="el-dropdown-link">
             <el-tooltip effect="dark" :content="$t('suno.button.download')" placement="top">
@@ -994,7 +1006,7 @@ export default defineComponent({
       border-radius: 8px;
     }
     .right {
-      width: 120px;
+      width: 140px;
       display: flex;
       align-items: center;
       justify-content: flex-end;
@@ -1004,11 +1016,31 @@ export default defineComponent({
         z-index: 100;
         cursor: pointer;
         margin-right: 15px;
+        color: var(--el-text-color-secondary);
+        transition: color 0.2s;
+        &:hover {
+          color: var(--el-color-primary);
+        }
       }
       .el-button {
         margin-right: 15px; /* Add margin to the right of the button */
       }
     }
+
+    // Pulse the cover while a generation is still in flight (~2 min wait)
+    &.generating .left .cover {
+      animation: suno-pulse 1.4s ease-in-out infinite;
+    }
+  }
+}
+
+@keyframes suno-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.55;
   }
 }
 

--- a/src/layouts/Suno.vue
+++ b/src/layouts/Suno.vue
@@ -33,19 +33,21 @@ export default defineComponent({
     ElButton,
     FontAwesomeIcon
   },
-  mixins: [taskDrawerMixin],
-  data() {
-    return {
-      preview: false
-    };
-  },
-  computed: {}
+  mixins: [taskDrawerMixin]
 });
 </script>
 
 <style lang="scss" scoped>
 .menu {
   display: none;
+}
+
+// On laptops (≤1180px) the 320 + flex + 300 layout crushes the song list —
+// drop the detail preview here so the list keeps a usable width.
+@media (max-width: 1180px) {
+  .main .preview {
+    display: none;
+  }
 }
 
 @media (max-width: 767px) {

--- a/src/pages/suno/Index.vue
+++ b/src/pages/suno/Index.vue
@@ -89,7 +89,6 @@ export default defineComponent({
       handler(value, oldValue) {
         // scroll down if new tasks are added
         if (value?.items?.length > oldValue?.items?.length) {
-          console.debug('new tasks detected');
           // this.onScrollDown();
         }
       },
@@ -98,7 +97,6 @@ export default defineComponent({
     initialized: {
       async handler(newValue) {
         if (newValue) {
-          console.debug('layout initialized');
           await this.onGetTasks();
           await this.onScrollDown();
           this.job = window.setInterval(() => {
@@ -131,14 +129,10 @@ export default defineComponent({
       });
     },
     async onGetService() {
-      console.debug('start onGetService');
       await this.$store.dispatch('suno/getService');
-      console.debug('end onGetService');
     },
     async onGetApplication() {
-      console.debug('start onGetApplications');
       await this.$store.dispatch('suno/getApplications');
-      console.debug('end onGetApplications');
       await this.onGetTasks();
     },
     onApply() {
@@ -166,12 +160,9 @@ export default defineComponent({
     },
     async onGetTasks(payload?: { limit?: number; createdAtMin?: number; createdAtMax?: number }) {
       if (this.applicationsLoading || this.fetchingTasks) {
-        console.debug('loading');
         return;
       }
-      console.debug('start onGetTasks', payload);
       const { limit = 5, createdAtMin, createdAtMax } = payload || {};
-      console.debug('limit', limit, 'createdAtMin', createdAtMin, 'createdAtMax', createdAtMax);
       this.fetchingTasks = true;
       try {
         await this.$store.dispatch('suno/getTasks', {

--- a/src/pages/suno/Index.vue
+++ b/src/pages/suno/Index.vue
@@ -4,7 +4,13 @@
       <config-panel @generate="onGenerateAudio" />
     </template>
     <template #result>
-      <recent-panel ref="recentPanel" class="panel recent" :loading="loadingMore" @reach-top="onReachTop" />
+      <recent-panel
+        ref="recentPanel"
+        class="panel recent"
+        :loading="loadingMore || loadingAll"
+        @reach-top="onReachTop"
+        @load-all="onLoadAll"
+      />
     </template>
     <template #preview>
       <preview-panel />
@@ -31,6 +37,7 @@ interface IData {
   task: ISunoTask | undefined;
   job: number;
   loadingMore: boolean;
+  loadingAll: boolean;
   fetchingTasks: boolean;
 }
 
@@ -49,6 +56,7 @@ export default defineComponent({
       task: undefined,
       job: 0,
       loadingMore: false,
+      loadingAll: false,
       fetchingTasks: false
     };
   },
@@ -127,6 +135,43 @@ export default defineComponent({
           }),
         getScrollElement: () => this.getTasksScrollElement()
       });
+    },
+    // Pull the user's full task history (older pages) so client-side
+    // search/filter cover everything, not just the loaded pages. Triggered
+    // once when the user first searches/filters.
+    async onLoadAll() {
+      if (this.loadingAll) {
+        return;
+      }
+      this.loadingAll = true;
+      try {
+        // Bounded loop — each pass fetches the page older than the current
+        // oldest item; stop at total, when no progress is made, or at the cap.
+        for (let guard = 0; guard < 100; guard++) {
+          // Wait for any in-flight fetch (the 5s poll or pagination) to settle,
+          // otherwise onGetTasks early-returns on its fetchingTasks guard and we
+          // would mistake the no-op for end-of-history.
+          for (let waits = 0; (this.fetchingTasks || this.applicationsLoading) && waits < 50; waits++) {
+            await new Promise((resolve) => setTimeout(resolve, 100));
+          }
+          const items = this.tasks?.items ?? [];
+          const total = this.tasks?.total;
+          if (total !== undefined && items.length >= total) {
+            break;
+          }
+          const oldest = items[0];
+          if (!oldest?.created_at) {
+            break;
+          }
+          const before = items.length;
+          await this.onGetTasks({ createdAtMax: oldest.created_at });
+          if ((this.tasks?.items?.length ?? 0) <= before) {
+            break;
+          }
+        }
+      } finally {
+        this.loadingAll = false;
+      }
     },
     async onGetService() {
       await this.$store.dispatch('suno/getService');


### PR DESCRIPTION
## What & why
Phase-2 step 3 (plan: AceDataCloud/Index#122), **stacked on #997** (P1). Fixes a real correctness gap: search/sort/filter ran client-side over **only the already-loaded pages**, so searching for an older song silently returned nothing. **Zero new i18n keys.**

> Base is `feat/suno-ux-p1`; review #995 → #997 first. GitHub retargets to `main` as they merge.

## Changes
- The first time the user searches or applies a filter, the page pulls the **full task history** (older pages via the existing cursor pagination) so client-side search/filter cover everything.
  - `RecentPanel` emits `load-all` once (latched) on first search/filter use.
  - `Index.onLoadAll` loops older pages until total reached / no progress / cap (100).
- A spinner shows while history streams in, and the "no results" message is gated behind `!loading` so it can't flash prematurely.

Verified locally: `eslint` clean, `vue-tsc --noEmit` clean.

## 🤖 对抗评审 (Codex, read-only)
One round, one **RISK**, fixed:
- **RISK** `Index.onLoadAll` — if load-all started while the 5s poll had `fetchingTasks` true, `onGetTasks` early-returns on its guard, the no-progress check would break the loop, and the `historyRequested` latch would prevent any retry — leaving history partial. **Fixed**: each iteration now waits (bounded, 5s) for any in-flight fetch to settle before fetching, so a no-op poll is never mistaken for end-of-history.

## Deferred from the plan's P2
`inspo` (generate-from-reference) is a net-new feature needing new request params + UI strings (→ the 19-locale i18n backfill), so it's better as its own feature PR than bundled into this UX-coherence series. Tracked in the plan doc; happy to do it next on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)