### PR TITLE
feat(suno): P2 — full-history search

### DIFF
--- a/change/@acedatacloud-nexior-6116a2b4-d83a-465f-a4d7-74e1be20629c.json
+++ b/change/@acedatacloud-nexior-6116a2b4-d83a-465f-a4d7-74e1be20629c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(suno): P2 full-history search — load all pages on first search/filter so older songs are not silently missed",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/suno/RecentPanel.vue
+++ b/src/components/suno/RecentPanel.vue
@@ -106,15 +106,21 @@
     >
       <task-preview v-for="(task, taskId) in filteredTasks" :key="taskId" :model-value="task" class="preview" />
     </scroll-list>
-    <div v-else-if="searchQuery && tasks?.items?.length > 0" class="w-full flex-1 flex items-center justify-center">
+    <div
+      v-else-if="!loading && searchQuery && tasks?.items?.length > 0"
+      class="w-full flex-1 flex items-center justify-center"
+    >
       <p class="text-sm text-gray-400">{{ $t('suno.message.noSearchResults') }}</p>
     </div>
     <div
-      v-else-if="activeFilterCount > 0 && tasks?.items?.length > 0"
+      v-else-if="!loading && activeFilterCount > 0 && tasks?.items?.length > 0"
       class="w-full flex-1 flex flex-col items-center justify-center gap-2"
     >
       <p class="text-sm text-gray-400">{{ $t('suno.message.noFilterResults') }}</p>
       <el-button size="small" text @click="onResetFilters">{{ $t('suno.filter.reset') }}</el-button>
+    </div>
+    <div v-else-if="loading" class="w-full flex-1 flex items-center justify-center">
+      <el-icon class="is-loading text-xl text-gray-400"><loading /></el-icon>
     </div>
     <div v-else-if="tasks?.items?.length === 0" class="w-full flex-1 flex items-center justify-center">
       <no-tasks />
@@ -142,8 +148,10 @@ import {
   ElRadioGroup,
   ElRadioButton,
   ElSelect,
-  ElOption
+  ElOption,
+  ElIcon
 } from 'element-plus';
+import { Loading } from '@element-plus/icons-vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import ScrollList from '@/components/common/ScrollList.vue';
 import { ISunoTask, ISunoAudio } from '@/models';
@@ -163,6 +171,8 @@ export default defineComponent({
     ElRadioButton,
     ElSelect,
     ElOption,
+    ElIcon,
+    Loading,
     FontAwesomeIcon,
     TaskPreview,
     Player,
@@ -175,11 +185,12 @@ export default defineComponent({
       default: false
     }
   },
-  emits: ['reach-top'],
+  emits: ['reach-top', 'load-all'],
   data() {
     return {
       job: 0,
       searchQuery: '',
+      historyRequested: false,
       sortBy: 'newest' as 'newest' | 'oldest',
       filterType: 'all' as 'all' | 'vocal' | 'instrumental',
       filterDuration: 'all' as 'all' | 'short' | 'medium' | 'long',
@@ -283,7 +294,23 @@ export default defineComponent({
       return out;
     }
   },
+  watch: {
+    // Search/filter run client-side over loaded pages only. The first time the
+    // user actually searches or filters, pull the full history so they don't
+    // silently miss older songs.
+    searchQuery(val: string) {
+      if (val) this.requestFullHistory();
+    },
+    activeFilterCount(count: number) {
+      if (count > 0) this.requestFullHistory();
+    }
+  },
   methods: {
+    requestFullHistory() {
+      if (this.historyRequested) return;
+      this.historyRequested = true;
+      this.$emit('load-all');
+    },
     onSortChange(command: 'newest' | 'oldest') {
       this.sortBy = command;
     },

--- a/src/pages/suno/Index.vue
+++ b/src/pages/suno/Index.vue
@@ -4,7 +4,13 @@
       <config-panel @generate="onGenerateAudio" />
     </template>
     <template #result>
-      <recent-panel ref="recentPanel" class="panel recent" :loading="loadingMore" @reach-top="onReachTop" />
+      <recent-panel
+        ref="recentPanel"
+        class="panel recent"
+        :loading="loadingMore || loadingAll"
+        @reach-top="onReachTop"
+        @load-all="onLoadAll"
+      />
     </template>
     <template #preview>
       <preview-panel />
@@ -31,6 +37,7 @@ interface IData {
   task: ISunoTask | undefined;
   job: number;
   loadingMore: boolean;
+  loadingAll: boolean;
   fetchingTasks: boolean;
 }
 
@@ -49,6 +56,7 @@ export default defineComponent({
       task: undefined,
       job: 0,
       loadingMore: false,
+      loadingAll: false,
       fetchingTasks: false
     };
   },
@@ -127,6 +135,43 @@ export default defineComponent({
           }),
         getScrollElement: () => this.getTasksScrollElement()
       });
+    },
+    // Pull the user's full task history (older pages) so client-side
+    // search/filter cover everything, not just the loaded pages. Triggered
+    // once when the user first searches/filters.
+    async onLoadAll() {
+      if (this.loadingAll) {
+        return;
+      }
+      this.loadingAll = true;
+      try {
+        // Bounded loop — each pass fetches the page older than the current
+        // oldest item; stop at total, when no progress is made, or at the cap.
+        for (let guard = 0; guard < 100; guard++) {
+          // Wait for any in-flight fetch (the 5s poll or pagination) to settle,
+          // otherwise onGetTasks early-returns on its fetchingTasks guard and we
+          // would mistake the no-op for end-of-history.
+          for (let waits = 0; (this.fetchingTasks || this.applicationsLoading) && waits < 50; waits++) {
+            await new Promise((resolve) => setTimeout(resolve, 100));
+          }
+          const items = this.tasks?.items ?? [];
+          const total = this.tasks?.total;
+          if (total !== undefined && items.length >= total) {
+            break;
+          }
+          const oldest = items[0];
+          if (!oldest?.created_at) {
+            break;
+          }
+          const before = items.length;
+          await this.onGetTasks({ createdAtMax: oldest.created_at });
+          if ((this.tasks?.items?.length ?? 0) <= before) {
+            break;
+          }
+        }
+      } finally {
+        this.loadingAll = false;
+      }
     },
     async onGetService() {
       await this.$store.dispatch('suno/getService');


### PR DESCRIPTION
## What & why
Phase-2 step 3 (plan: AceDataCloud/Index#122). Final PR of the P0→P2 Suno UX series (P0 #995, P1 #997 both merged). Fixes a real correctness gap: search/sort/filter ran client-side over **only the already-loaded pages**, so searching for an older song silently returned nothing. **Zero new i18n keys.**

> Reopened against `main` after the stacked base branch was auto-deleted on P1's merge (supersedes #998, which GitHub auto-closed).

## Changes
- The first time the user searches or filters, the page pulls the **full task history** (older pages via the existing cursor pagination) so client-side search/filter cover everything.
  - `RecentPanel` emits `load-all` once (latched) on first search/filter use.
  - `Index.onLoadAll` loops older pages until total reached / no progress / cap (100).
- A spinner shows while history streams in; the "no results" message is gated behind `!loading` so it can't flash prematurely.

Verified: `eslint`, `vue-tsc`, `beachball check`, `check_i18n_coverage.py`, and `vite build` all clean.

## 🤖 对抗评审 (Codex, read-only)
One round, one **RISK**, fixed: if load-all started while the 5s poll had `fetchingTasks` true, `onGetTasks` early-returns, the no-progress check would break the loop, and the latch would block retry — leaving history partial. **Fixed**: each iteration now waits (bounded 5s) for any in-flight fetch to settle before fetching.

## Deferred
`inspo` (generate-from-reference) — net-new feature needing new params + i18n; its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)