### PR TITLE
feat(webextrator): friendly message for anti-bot-blocked pages

### DIFF
--- a/change/@acedatacloud-nexior-feat-webextrator-antibot.json
+++ b/change/@acedatacloud-nexior-feat-webextrator-antibot.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(webextrator): friendly message for anti-bot-blocked (422) pages, noting the request was not billed",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/i18n/ar/webextrator.json
+++ b/src/i18n/ar/webextrator.json
@@ -167,6 +167,10 @@
     "message": "The page took too long to load. Try a different URL or increase the timeout.",
     "description": "Error shown on timeout"
   },
+  "message.antibotBlocked": {
+    "message": "تم تفعيل حماية ضد الروبوتات على الموقع المستهدف، ولا يمكن الزحف مؤقتًا (لن يتم احتساب هذه المرة).",
+    "description": "خطأ يظهر عندما تكون الصفحة المستهدفة تحديًا غير واضح ضد الروبوتات (HTTP 422، غير مفوتر)"
+  },
   "message.untitled": {
     "message": "Untitled",
     "description": "Fallback title when the page has no title"

--- a/src/i18n/de/webextrator.json
+++ b/src/i18n/de/webextrator.json
@@ -167,6 +167,10 @@
     "message": "The page took too long to load. Try a different URL or increase the timeout.",
     "description": "Error shown on timeout"
   },
+  "message.antibotBlocked": {
+    "message": "Die Zielwebsite hat einen Anti-Bot-Schutz aktiviert, vorübergehend nicht abrufbar (dies wird nicht berechnet).",
+    "description": "Fehler, der angezeigt wird, wenn die Zielseite eine nicht geklärte Anti-Bot-Herausforderung ist (HTTP 422, nicht berechnet)"
+  },
   "message.untitled": {
     "message": "Untitled",
     "description": "Fallback title when the page has no title"

--- a/src/i18n/el/webextrator.json
+++ b/src/i18n/el/webextrator.json
@@ -167,6 +167,10 @@
     "message": "The page took too long to load. Try a different URL or increase the timeout.",
     "description": "Error shown on timeout"
   },
+  "message.antibotBlocked": {
+    "message": "Ο στόχος ιστοσελίδας έχει ενεργοποιήσει προστασία κατά των ρομπότ, δεν είναι δυνατή η λήψη (δεν χρεώνεται αυτή τη φορά).",
+    "description": "Σφάλμα που εμφανίζεται όταν η στοχευμένη σελίδα έχει μια μη καθαρή πρόκληση κατά των ρομπότ (HTTP 422, δεν χρεώνεται)"
+  },
   "message.untitled": {
     "message": "Untitled",
     "description": "Fallback title when the page has no title"

--- a/src/i18n/en/webextrator.json
+++ b/src/i18n/en/webextrator.json
@@ -167,6 +167,10 @@
     "message": "The page took too long to load. Try a different URL or increase the timeout.",
     "description": "Error shown on timeout"
   },
+  "message.antibotBlocked": {
+    "message": "This site is protected by anti-bot and couldn't be extracted — you were not charged.",
+    "description": "Error shown when the target page is an uncleared anti-bot challenge (HTTP 422, not billed)"
+  },
   "message.untitled": {
     "message": "Untitled",
     "description": "Fallback title when the page has no title"

--- a/src/i18n/es/webextrator.json
+++ b/src/i18n/es/webextrator.json
@@ -167,6 +167,10 @@
     "message": "The page took too long to load. Try a different URL or increase the timeout.",
     "description": "Error shown on timeout"
   },
+  "message.antibotBlocked": {
+    "message": "El sitio web objetivo ha activado protección contra bots, no se puede acceder temporalmente (no se cobrará esta vez).",
+    "description": "Error mostrado cuando la página objetivo tiene un desafío anti-bot no resuelto (HTTP 422, no se cobra)."
+  },
   "message.untitled": {
     "message": "Untitled",
     "description": "Fallback title when the page has no title"

--- a/src/i18n/fi/webextrator.json
+++ b/src/i18n/fi/webextrator.json
@@ -167,6 +167,10 @@
     "message": "The page took too long to load. Try a different URL or increase the timeout.",
     "description": "Error shown on timeout"
   },
+  "message.antibotBlocked": {
+    "message": "Kohdesivustolla on käytössä botinesto, eikä sitä voida toistaiseksi kaapata (tätä kertaa ei veloiteta).",
+    "description": "Virhe, joka näytetään, kun kohdesivulla on selittämätön botinestohaaste (HTTP 422, ei veloiteta)"
+  },
   "message.untitled": {
     "message": "Untitled",
     "description": "Fallback title when the page has no title"

--- a/src/i18n/fr/webextrator.json
+++ b/src/i18n/fr/webextrator.json
@@ -167,6 +167,10 @@
     "message": "The page took too long to load. Try a different URL or increase the timeout.",
     "description": "Error shown on timeout"
   },
+  "message.antibotBlocked": {
+    "message": "Le site cible a activé une protection anti-bot, impossible de le récupérer pour le moment (pas de facturation cette fois).",
+    "description": "Erreur affichée lorsque la page cible présente un défi anti-bot non résolu (HTTP 422, non facturé)"
+  },
   "message.untitled": {
     "message": "Untitled",
     "description": "Fallback title when the page has no title"

--- a/src/i18n/it/webextrator.json
+++ b/src/i18n/it/webextrator.json
@@ -167,6 +167,10 @@
     "message": "The page took too long to load. Try a different URL or increase the timeout.",
     "description": "Error shown on timeout"
   },
+  "message.antibotBlocked": {
+    "message": "Il sito web di destinazione ha attivato la protezione anti-bot, non è possibile effettuare la cattura al momento (questa volta non verrà addebitato alcun costo).",
+    "description": "Errore mostrato quando la pagina di destinazione presenta una sfida anti-bot non superata (HTTP 422, non addebitato)."
+  },
   "message.untitled": {
     "message": "Untitled",
     "description": "Fallback title when the page has no title"

--- a/src/i18n/ja/webextrator.json
+++ b/src/i18n/ja/webextrator.json
@@ -167,6 +167,10 @@
     "message": "The page took too long to load. Try a different URL or increase the timeout.",
     "description": "Error shown on timeout"
   },
+  "message.antibotBlocked": {
+    "message": "対象のウェブサイトはボット対策を有効にしており、一時的に取得できません（今回の料金は発生しません）。",
+    "description": "対象ページが未クリアのボット対策チャレンジの場合に表示されるエラー（HTTP 422、料金は発生しません）"
+  },
   "message.untitled": {
     "message": "Untitled",
     "description": "Fallback title when the page has no title"

--- a/src/i18n/ko/webextrator.json
+++ b/src/i18n/ko/webextrator.json
@@ -167,6 +167,10 @@
     "message": "The page took too long to load. Try a different URL or increase the timeout.",
     "description": "Error shown on timeout"
   },
+  "message.antibotBlocked": {
+    "message": "대상 웹사이트가 반봇 보호를 활성화하여 일시적으로 크롤링할 수 없습니다(이번에는 요금이 청구되지 않습니다).",
+    "description": "대상 페이지가 해결되지 않은 반봇 챌린지를 표시할 때 나타나는 오류입니다 (HTTP 422, 요금 청구되지 않음)"
+  },
   "message.untitled": {
     "message": "Untitled",
     "description": "Fallback title when the page has no title"

--- a/src/i18n/pl/webextrator.json
+++ b/src/i18n/pl/webextrator.json
@@ -167,6 +167,10 @@
     "message": "The page took too long to load. Try a different URL or increase the timeout.",
     "description": "Error shown on timeout"
   },
+  "message.antibotBlocked": {
+    "message": "Docelowa strona włączyła ochronę przed botami, nie można jej tymczasowo zeskrobać (nie będzie naliczana opłata).",
+    "description": "Błąd wyświetlany, gdy strona docelowa ma nieprzezroczyste wyzwanie przeciwko botom (HTTP 422, nie jest naliczana opłata)"
+  },
   "message.untitled": {
     "message": "Untitled",
     "description": "Fallback title when the page has no title"

--- a/src/i18n/pt/webextrator.json
+++ b/src/i18n/pt/webextrator.json
@@ -167,6 +167,10 @@
     "message": "The page took too long to load. Try a different URL or increase the timeout.",
     "description": "Error shown on timeout"
   },
+  "message.antibotBlocked": {
+    "message": "O site de destino ativou a proteção contra bots, não é possível acessar temporariamente (não será cobrado desta vez).",
+    "description": "Erro exibido quando a página de destino apresenta um desafio anti-bot não resolvido (HTTP 422, não será cobrado)."
+  },
   "message.untitled": {
     "message": "Untitled",
     "description": "Fallback title when the page has no title"

--- a/src/i18n/ru/webextrator.json
+++ b/src/i18n/ru/webextrator.json
@@ -167,6 +167,10 @@
     "message": "The page took too long to load. Try a different URL or increase the timeout.",
     "description": "Error shown on timeout"
   },
+  "message.antibotBlocked": {
+    "message": "Целевая страница активировала защиту от ботов, временно невозможно извлечение данных (это не будет тарифицироваться).",
+    "description": "Ошибка, отображаемая, когда целевая страница имеет активный вызов защиты от ботов (HTTP 422, не тарифицируется)"
+  },
   "message.untitled": {
     "message": "Untitled",
     "description": "Fallback title when the page has no title"

--- a/src/i18n/sr/webextrator.json
+++ b/src/i18n/sr/webextrator.json
@@ -167,6 +167,10 @@
     "message": "The page took too long to load. Try a different URL or increase the timeout.",
     "description": "Error shown on timeout"
   },
+  "message.antibotBlocked": {
+    "message": "Ciljna stranica je aktivirala zaštitu od botova, trenutno nije moguće pristupiti (ovaj put se ne naplaćuje).",
+    "description": "Greška koja se prikazuje kada je ciljana stranica nepročišćena anti-bot izazov (HTTP 422, nije naplaćeno)"
+  },
   "message.untitled": {
     "message": "Untitled",
     "description": "Fallback title when the page has no title"

--- a/src/i18n/sv/webextrator.json
+++ b/src/i18n/sv/webextrator.json
@@ -167,6 +167,10 @@
     "message": "The page took too long to load. Try a different URL or increase the timeout.",
     "description": "Error shown on timeout"
   },
+  "message.antibotBlocked": {
+    "message": "Målwebbplatsen har aktiverat skydd mot botar, kan inte nås för tillfället (denna gång debiteras inte).",
+    "description": "Felmeddelande som visas när målsidan har en oavklarad anti-bot-utmaning (HTTP 422, debiteras inte)"
+  },
   "message.untitled": {
     "message": "Untitled",
     "description": "Fallback title when the page has no title"

--- a/src/i18n/uk/webextrator.json
+++ b/src/i18n/uk/webextrator.json
@@ -167,6 +167,10 @@
     "message": "The page took too long to load. Try a different URL or increase the timeout.",
     "description": "Error shown on timeout"
   },
+  "message.antibotBlocked": {
+    "message": "Цільовий сайт увімкнув захист від ботів, тимчасово неможливо отримати дані (цей раз не підлягає оплаті).",
+    "description": "Помилка, яка відображається, коли цільова сторінка має незнятий виклик захисту від ботів (HTTP 422, не підлягає оплаті)"
+  },
   "message.untitled": {
     "message": "Untitled",
     "description": "Fallback title when the page has no title"

--- a/src/i18n/zh-CN/webextrator.json
+++ b/src/i18n/zh-CN/webextrator.json
@@ -167,6 +167,10 @@
     "message": "页面加载超时，请更换网址或调大超时时间。",
     "description": "Error shown on timeout"
   },
+  "message.antibotBlocked": {
+    "message": "目标网站启用了反爬保护，暂时无法抓取（本次不计费）。",
+    "description": "Error shown when the target page is an uncleared anti-bot challenge (HTTP 422, not billed)"
+  },
   "message.untitled": {
     "message": "未命名页面",
     "description": "Fallback title when the page has no title"

--- a/src/i18n/zh-TW/webextrator.json
+++ b/src/i18n/zh-TW/webextrator.json
@@ -167,6 +167,10 @@
     "message": "The page took too long to load. Try a different URL or increase the timeout.",
     "description": "Error shown on timeout"
   },
+  "message.antibotBlocked": {
+    "message": "目標網站啟用了反爬保護，暫時無法抓取（本次不計費）。",
+    "description": "當目標頁面啟用未清除的反爬挑戰時顯示的錯誤（HTTP 422，不計費）"
+  },
   "message.untitled": {
     "message": "Untitled",
     "description": "Fallback title when the page has no title"

--- a/src/pages/webextrator/Index.vue
+++ b/src/pages/webextrator/Index.vue
@@ -45,6 +45,10 @@ export default defineComponent({
           ElMessage.error(this.$t('webextrator.message.busy'));
         } else if (code === 'timeout') {
           ElMessage.error(this.$t('webextrator.message.timeout'));
+        } else if (code === 'antibot_blocked') {
+          // The target served an anti-bot challenge we couldn't clear. The API
+          // returns 422 for these, so the request is NOT billed — say so.
+          ElMessage.error(this.$t('webextrator.message.antibotBlocked'));
         } else {
           ElMessage.error(this.$t('webextrator.message.failed'));
         }


### PR DESCRIPTION
Follow-up to the WebExtrator anti-bot billing change. The service now returns **HTTP 422 `antibot_blocked`** when a target page is an anti-bot interstitial it couldn't clear — and the gateway **doesn't bill** those (status ≥ 400). But the Studio UI fell through to the generic *"请求失败 / request failed"* toast, so the user neither learned the site is bot-protected nor that they weren't charged.

This adds explicit handling for the `antibot_blocked` code:
> 目标网站启用了反爬保护，暂时无法抓取（本次不计费）。
> This site is protected by anti-bot and couldn't be extracted — you were not charged.

i18n backfilled to all 17 locales via the sanctioned `translate_i18n.py`; `check_i18n_coverage.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)