### PR TITLE
chore(coding-bridge): rename agent CLI to coding-bridge

### DIFF
--- a/change/@acedatacloud-nexior-rename-coding-bridge-cli.json
+++ b/change/@acedatacloud-nexior-rename-coding-bridge-cli.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore(coding-bridge): rename CLI to `coding-bridge` (`pip install coding-bridge`, `coding-bridge up`) in pairing dialog",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/codingBridge/PairDialog.vue
+++ b/src/components/codingBridge/PairDialog.vue
@@ -16,14 +16,14 @@
           <span class="step-index">1</span>
           <div class="flex-1 min-w-0">
             <p class="text-sm mb-1">{{ $t('codingBridge.pair.step1') }}</p>
-            <code class="cmd">pip install coding-bridge-agent</code>
+            <code class="cmd">pip install coding-bridge</code>
           </div>
         </li>
         <li class="flex gap-3 mb-3">
           <span class="step-index">2</span>
           <div class="flex-1 min-w-0">
             <p class="text-sm mb-1">{{ $t('codingBridge.pair.step2') }}</p>
-            <code class="cmd">coding-bridge-agent up</code>
+            <code class="cmd">coding-bridge up</code>
           </div>
         </li>
         <li class="flex gap-3">


### PR DESCRIPTION
## What

The node-daemon PyPI package was renamed `coding-bridge-agent` → `coding-bridge` (the shorter name is free on PyPI, repo renamed to [AceDataCloud/CodingBridge](https://github.com/AceDataCloud/CodingBridge)).

This updates the pairing dialog so the install/run commands shown to users match:

- `pip install coding-bridge-agent` → `pip install coding-bridge`
- `coding-bridge-agent up` → `coding-bridge up`

## Files

- `src/components/codingBridge/PairDialog.vue`

🤖 Generated with [Claude Code](https://claude.com/claude-code)