### PR TITLE
fix(coding-bridge): keep the real id's first events after session re-key (codex first reply was dropped)

### DIFF
--- a/change/@acedatacloud-nexior-42343d31-de4c-4f25-b242-908e4dbd19cc.json
+++ b/change/@acedatacloud-nexior-42343d31-de4c-4f25-b242-908e4dbd19cc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(coding-bridge): don't drop the real id's first events after session re-key",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/store/codingBridge/actions.identity.test.ts
+++ b/src/store/codingBridge/actions.identity.test.ts
@@ -64,6 +64,22 @@ describe('coding bridge session identity (integration)', () => {
     expect(h.state.events['real-1'][0].streaming).toBe(true);
   });
 
+  it("keeps the real id's first events after re-key (relay seq is per-session)", () => {
+    // The relay numbers `seq` PER session_id. The provisional id accrues some seq
+    // before the real id is known; the real id then starts its OWN seq at 1. The
+    // dedup must not drop those low-seq events as "already seen" — that silently
+    // dropped a codex turn's first reply (only later turns showed).
+    const h = harness();
+    h.feed({ event: 'session.started', session_id: 'prov', seq: 1 });
+    h.feed({ event: 'session.identified', session_id: 'prov', sdk_session_id: 'real-x', seq: 2 });
+    // Node re-tags subsequent events to real-x; relay numbers real-x from 1.
+    h.feed({ event: 'session.text', session_id: 'real-x', id: 'r1', text: 'first reply', seq: 1 });
+    h.feed({ event: 'session.result', session_id: 'real-x', subtype: 'turn_complete', seq: 2 });
+    const ev = h.state.events['real-x'] || [];
+    expect(ev.some((e) => e.kind === 'text' && e.text === 'first reply')).toBe(true);
+    expect(ev.some((e) => e.kind === 'result')).toBe(true);
+  });
+
   it('reattaches to a live session on restore after a reload (Stop + typewriter kept)', () => {
     const h = harness();
     // After a reload the store is empty; requestSessions → sessions.snapshot tells

--- a/src/store/codingBridge/mutations.test.ts
+++ b/src/store/codingBridge/mutations.test.ts
@@ -146,7 +146,9 @@ describe('coding bridge session identity (renameSession)', () => {
     expect(state.sessions['real'].status).toBe('running');
     expect(state.events['prov']).toBeUndefined();
     expect(state.events['real'].map((e) => e.id)).toEqual(['a']);
-    expect(state.lastSeq['real']).toBe(7);
+    // The real id starts a FRESH relay seq space, so its cursor resets to 0 (not
+    // the provisional id's 7) — otherwise the real id's first events get dropped.
+    expect(state.lastSeq['real']).toBe(0);
     expect(state.lastSeq['prov']).toBeUndefined();
     expect(state.currentSessionId).toBe('real');
     expect(state.historyRef?.session_id).toBe('real');

--- a/src/store/codingBridge/mutations.ts
+++ b/src/store/codingBridge/mutations.ts
@@ -97,10 +97,15 @@ export const renameSession = (state: ICodingBridgeState, payload: { from: string
     state.events[to] = moving;
   }
   delete state.events[from];
-  if (state.lastSeq[from] !== undefined) {
-    state.lastSeq[to] = Math.max(state.lastSeq[to] ?? 0, state.lastSeq[from]);
-    delete state.lastSeq[from];
-  }
+  // Do NOT carry the provisional id's seq cursor onto the real id. The relay
+  // numbers `seq` PER session_id, so once the node re-tags events to the real id
+  // that id begins a FRESH seq space (1, 2, 3…). Inheriting the provisional
+  // cursor made the dedup in `applyNodeEvent` drop the real id's first events as
+  // "already seen" — e.g. a codex turn's first reply (low seq) silently vanished
+  // while a later turn (higher seq) showed. The real id is brand-new to this tab
+  // at re-key time, so reset its cursor to accept its whole stream.
+  delete state.lastSeq[from];
+  state.lastSeq[to] = 0;
   for (const request of state.permissions) {
     if (request.session_id === from) {
       request.session_id = to;


### PR DESCRIPTION
## What & why

Re-testing the merged codex-resume work (Nexior#996 / CodingBridgeAgent#30) on the live node surfaced a residual bug: **a fresh codex session's FIRST reply never appears in the UI** (only the 2nd+ turn shows). Verified live on `studio.acedata.cloud` against an upgraded node — the prompt is there, the reply is generated by codex (the node returns it, and a follow-up `codex exec resume` succeeds), but the first reply is dropped browser-side.

**Root cause:** the relay numbers `seq` **per `session_id`**. When the node learns the provider's real id mid-turn it emits `session.identified` and re-tags subsequent events to that real id — which begins a **fresh seq space** (1, 2, 3…). `renameSession` was carrying the provisional id's seq cursor onto the real id:

```ts
state.lastSeq[to] = Math.max(state.lastSeq[to] ?? 0, state.lastSeq[from]); // ← wrong
```

so the dedup in `applyNodeEvent` (`if (seq <= lastSeq[sid]) return`) dropped the real id's first events (low seq) as "already seen". The first reply vanished; a later turn (higher seq) survived.

This was **surfaced** by the codex identity unification: once the node started emitting codex `session.identified` (which the node's older installed build didn't), codex began re-keying and hit this. Claude rides the same re-key path and benefits too.

## Fix
`renameSession`: the real id is brand-new to the tab at re-key time, so **reset its cursor** (`lastSeq[to] = 0`) instead of inheriting the provisional id's — its whole fresh-seq stream then applies.

## Verification
- `vitest` `src/store/codingBridge` green (25 passed), incl. a new regression test: after re-key, the real id's low-seq (`seq:1`) first reply + result are kept; and the renameSession unit test now asserts the cursor resets to 0.
- `eslint` clean, `vue-tsc --noEmit` exit 0.
- Will re-confirm live on the node after merge+deploy (fresh codex session → first reply shows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
