### PR TITLE
feat(coding-bridge): default the permission mode to bypass

### DIFF
--- a/change/@acedatacloud-nexior-8279282c-e269-473c-af37-654f632b1626.json
+++ b/change/@acedatacloud-nexior-8279282c-e269-473c-af37-654f632b1626.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(coding-bridge): default the permission mode to bypass",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/codingBridge/SessionView.vue
+++ b/src/components/codingBridge/SessionView.vue
@@ -539,7 +539,10 @@ export default defineComponent({
       cwd: '',
       model: '',
       customModelDraft: '',
-      permissionMode: 'default',
+      // Default to bypass: this is the user's own paired machine, so the agent
+      // runs without per-tool approval prompts unless a stricter mode is picked
+      // (which then persists per device via lastComposer).
+      permissionMode: 'bypassPermissions',
       provider: 'claude',
       effort: '',
       directoryVisible: false,
@@ -958,7 +961,7 @@ export default defineComponent({
       this.customModelDraft = '';
       this.cwd = session.cwd ?? prefs.cwd ?? '';
       this.effort = session.effort ?? prefs.effort ?? '';
-      this.permissionMode = session.permission_mode ?? prefs.permissionMode ?? 'default';
+      this.permissionMode = session.permission_mode ?? prefs.permissionMode ?? 'bypassPermissions';
     },
     // Pick a listed model (or the empty default) and close the popover.
     selectModel(value: string) {
@@ -1246,7 +1249,7 @@ export default defineComponent({
       const prefs = this.lastComposer;
       this.cwd = prefs.cwd ?? '';
       this.provider = prefs.provider ?? 'claude';
-      this.permissionMode = prefs.permissionMode ?? 'default';
+      this.permissionMode = prefs.permissionMode ?? 'bypassPermissions';
       this.customModelDraft = '';
       this.$nextTick(() => {
         this.model = prefs.model ?? '';

--- a/src/store/codingBridge/actions.ts
+++ b/src/store/codingBridge/actions.ts
@@ -744,7 +744,7 @@ export const sendPrompt = (
       prompt,
       cwd: payload.cwd || existing?.cwd || undefined,
       model: payload.model || existing?.model || undefined,
-      permission_mode: payload.permissionMode || 'default',
+      permission_mode: payload.permissionMode || 'bypassPermissions',
       provider,
       effort: payload.effort || undefined,
       images,


### PR DESCRIPTION
## What & why

Coding Bridge drives the user's **own paired machine**, so the composer now defaults the permission mode to **`bypassPermissions`** (no per-tool approval prompts) instead of `default`.

- A stricter mode picked in the composer still wins and **persists per device** via `lastComposer`.
- Restored sessions keep the mode they actually ran with.
- Changed: composer initial value, new-session reset, restore fallback, and the `session.start` wire fallback.

## ⚠️ Security note
`bypassPermissions` maps to the agent's **most permissive** sandbox — Claude runs with no approval prompts; **Codex runs `danger-full-access`** (no sandbox). This is the requested default because the node is the user's own machine, but it does mean a freshly paired device runs the agent unsandboxed unless the user picks a stricter mode (which then sticks). Easy to revert by changing the four defaults back to `'default'`.

## Verification
- `vitest` `src/store/codingBridge` — 25 pass.
- `eslint` clean, `vue-tsc --noEmit` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
