### PR TITLE
feat(realtime): redesign voice call UI to match ChatGPT Voice

### DIFF
--- a/change/@acedatacloud-nexior-b1fe15c7-d976-4cc7-8e7f-24bb158b8e49.json
+++ b/change/@acedatacloud-nexior-b1fe15c7-d976-4cc7-8e7f-24bb158b8e49.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Redesign realtime voice call UI to match ChatGPT Voice (reactive orb, captions mode, mute, minimal controls)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/i18n/ar/realtime.json
+++ b/src/i18n/ar/realtime.json
@@ -11,5 +11,9 @@
   "status.connecting": "connecting…",
   "status.connected": "connected",
   "status.disconnected": "disconnected",
-  "status.error": "error"
+  "status.error": "error",
+  "speaking": "يتحدث…",
+  "mute": "كتم الصوت",
+  "unmute": "إلغاء كتم الصوت",
+  "captions": "التسميات التوضيحية"
 }

--- a/src/i18n/de/realtime.json
+++ b/src/i18n/de/realtime.json
@@ -11,5 +11,9 @@
   "status.connecting": "connecting…",
   "status.connected": "connected",
   "status.disconnected": "disconnected",
-  "status.error": "error"
+  "status.error": "error",
+  "speaking": "Spricht…",
+  "mute": "Stummschalten",
+  "unmute": "Stummschaltung aufheben",
+  "captions": "Untertitel"
 }

--- a/src/i18n/el/realtime.json
+++ b/src/i18n/el/realtime.json
@@ -11,5 +11,9 @@
   "status.connecting": "connecting…",
   "status.connected": "connected",
   "status.disconnected": "disconnected",
-  "status.error": "error"
+  "status.error": "error",
+  "speaking": "Μιλάει…",
+  "mute": "Σίγαση",
+  "unmute": "Κατάργηση σίγασης",
+  "captions": "Υπότιτλοι"
 }

--- a/src/i18n/en/realtime.json
+++ b/src/i18n/en/realtime.json
@@ -11,5 +11,9 @@
   "status.connecting": "connecting…",
   "status.connected": "connected",
   "status.disconnected": "disconnected",
-  "status.error": "error"
+  "status.error": "error",
+  "speaking": "Speaking…",
+  "mute": "Mute",
+  "unmute": "Unmute",
+  "captions": "Captions"
 }

--- a/src/i18n/es/realtime.json
+++ b/src/i18n/es/realtime.json
@@ -11,5 +11,9 @@
   "status.connecting": "connecting…",
   "status.connected": "connected",
   "status.disconnected": "disconnected",
-  "status.error": "error"
+  "status.error": "error",
+  "speaking": "Hablando…",
+  "mute": "Silenciar",
+  "unmute": "Activar micrófono",
+  "captions": "Subtítulos"
 }

--- a/src/i18n/fi/realtime.json
+++ b/src/i18n/fi/realtime.json
@@ -11,5 +11,9 @@
   "status.connecting": "connecting…",
   "status.connected": "connected",
   "status.disconnected": "disconnected",
-  "status.error": "error"
+  "status.error": "error",
+  "speaking": "Puhuu…",
+  "mute": "Mykistä",
+  "unmute": "Poista mykistys",
+  "captions": "Tekstitys"
 }

--- a/src/i18n/fr/realtime.json
+++ b/src/i18n/fr/realtime.json
@@ -11,5 +11,9 @@
   "status.connecting": "connecting…",
   "status.connected": "connected",
   "status.disconnected": "disconnected",
-  "status.error": "error"
+  "status.error": "error",
+  "speaking": "Parle…",
+  "mute": "Couper le micro",
+  "unmute": "Réactiver le micro",
+  "captions": "Sous-titres"
 }

--- a/src/i18n/it/realtime.json
+++ b/src/i18n/it/realtime.json
@@ -11,5 +11,9 @@
   "status.connecting": "connecting…",
   "status.connected": "connected",
   "status.disconnected": "disconnected",
-  "status.error": "error"
+  "status.error": "error",
+  "speaking": "Sta parlando…",
+  "mute": "Disattiva audio",
+  "unmute": "Riattiva audio",
+  "captions": "Sottotitoli"
 }

--- a/src/i18n/ja/realtime.json
+++ b/src/i18n/ja/realtime.json
@@ -11,5 +11,9 @@
   "status.connecting": "connecting…",
   "status.connected": "connected",
   "status.disconnected": "disconnected",
-  "status.error": "error"
+  "status.error": "error",
+  "speaking": "話しています…",
+  "mute": "ミュート",
+  "unmute": "ミュート解除",
+  "captions": "字幕"
 }

--- a/src/i18n/ko/realtime.json
+++ b/src/i18n/ko/realtime.json
@@ -11,5 +11,9 @@
   "status.connecting": "connecting…",
   "status.connected": "connected",
   "status.disconnected": "disconnected",
-  "status.error": "error"
+  "status.error": "error",
+  "speaking": "말하는 중…",
+  "mute": "음소거",
+  "unmute": "음소거 해제",
+  "captions": "자막"
 }

--- a/src/i18n/pl/realtime.json
+++ b/src/i18n/pl/realtime.json
@@ -11,5 +11,9 @@
   "status.connecting": "connecting…",
   "status.connected": "connected",
   "status.disconnected": "disconnected",
-  "status.error": "error"
+  "status.error": "error",
+  "speaking": "Mówi…",
+  "mute": "Wycisz",
+  "unmute": "Wyłącz wyciszenie",
+  "captions": "Napisy"
 }

--- a/src/i18n/pt/realtime.json
+++ b/src/i18n/pt/realtime.json
@@ -11,5 +11,9 @@
   "status.connecting": "connecting…",
   "status.connected": "connected",
   "status.disconnected": "disconnected",
-  "status.error": "error"
+  "status.error": "error",
+  "speaking": "Falando…",
+  "mute": "Silenciar",
+  "unmute": "Ativar som",
+  "captions": "Legendas"
 }

--- a/src/i18n/ru/realtime.json
+++ b/src/i18n/ru/realtime.json
@@ -11,5 +11,9 @@
   "status.connecting": "connecting…",
   "status.connected": "connected",
   "status.disconnected": "disconnected",
-  "status.error": "error"
+  "status.error": "error",
+  "speaking": "Говорит…",
+  "mute": "Выключить микрофон",
+  "unmute": "Включить микрофон",
+  "captions": "Субтитры"
 }

--- a/src/i18n/sr/realtime.json
+++ b/src/i18n/sr/realtime.json
@@ -11,5 +11,9 @@
   "status.connecting": "connecting…",
   "status.connected": "connected",
   "status.disconnected": "disconnected",
-  "status.error": "error"
+  "status.error": "error",
+  "speaking": "Говори…",
+  "mute": "Искључи звук",
+  "unmute": "Укључи звук",
+  "captions": "Титлови"
 }

--- a/src/i18n/sv/realtime.json
+++ b/src/i18n/sv/realtime.json
@@ -11,5 +11,9 @@
   "status.connecting": "connecting…",
   "status.connected": "connected",
   "status.disconnected": "disconnected",
-  "status.error": "error"
+  "status.error": "error",
+  "speaking": "Talar…",
+  "mute": "Tysta",
+  "unmute": "Slå på ljud",
+  "captions": "Undertexter"
 }

--- a/src/i18n/uk/realtime.json
+++ b/src/i18n/uk/realtime.json
@@ -11,5 +11,9 @@
   "status.connecting": "connecting…",
   "status.connected": "connected",
   "status.disconnected": "disconnected",
-  "status.error": "error"
+  "status.error": "error",
+  "speaking": "Говорить…",
+  "mute": "Вимкнути мікрофон",
+  "unmute": "Увімкнути мікрофон",
+  "captions": "Субтитри"
 }

--- a/src/i18n/zh-CN/realtime.json
+++ b/src/i18n/zh-CN/realtime.json
@@ -11,5 +11,9 @@
   "status.connecting": "连接中…",
   "status.connected": "已连接",
   "status.disconnected": "已断开",
-  "status.error": "出错"
+  "status.error": "出错",
+  "speaking": "正在回答…",
+  "mute": "静音",
+  "unmute": "取消静音",
+  "captions": "字幕"
 }

--- a/src/i18n/zh-TW/realtime.json
+++ b/src/i18n/zh-TW/realtime.json
@@ -11,5 +11,9 @@
   "status.connecting": "連接中…",
   "status.connected": "已連接",
   "status.disconnected": "已斷開",
-  "status.error": "出錯"
+  "status.error": "出錯",
+  "speaking": "正在回答…",
+  "mute": "靜音",
+  "unmute": "取消靜音",
+  "captions": "字幕"
 }

--- a/src/pages/chat/RealtimeCall.vue
+++ b/src/pages/chat/RealtimeCall.vue
@@ -1,53 +1,63 @@
 <template>
-  <div class="realtime-call">
-    <div class="call-card">
-      <div class="call-header">
-        <el-button text class="back-btn" @click="goBack">
-          <font-awesome-icon icon="fa-solid fa-arrow-left" />
-        </el-button>
-        <span class="title">{{ $t('realtime.title') }}</span>
-        <span class="status" :class="status">{{ statusText }}</span>
+  <div class="rtc" :class="{ 'is-captions': captionsOn, 'is-live': running }">
+    <!-- top bar: minimal utility icons (mirrors the ChatGPT voice screen) -->
+    <header class="rtc-top">
+      <button class="ic" :title="$t('realtime.title')" @click="goBack">
+        <font-awesome-icon icon="fa-solid fa-chevron-down" />
+      </button>
+      <div class="rtc-top-right">
+        <button class="ic" :class="{ on: showInfo }" :title="$t('realtime.title')" @click="showInfo = !showInfo">
+          <font-awesome-icon icon="fa-solid fa-circle-info" />
+        </button>
+        <button class="ic" :class="{ on: captionsOn }" :title="$t('realtime.captions')" @click="toggleCaptions">
+          <font-awesome-icon icon="fa-solid fa-closed-captioning" />
+        </button>
+      </div>
+    </header>
+
+    <!-- stage: the audio-reactive orb -->
+    <main class="rtc-stage">
+      <div class="orb-stage" @click="onOrbTap">
+        <div class="orb-halo" :style="haloStyle"></div>
+        <div class="orb-breathe" :class="{ paused: !running }">
+          <div class="orb" :class="orbClass" :style="{ transform: `scale(${orbScale})` }">
+            <span class="cloud c1"></span>
+            <span class="cloud c2"></span>
+            <span class="cloud c3"></span>
+            <span class="sheen"></span>
+          </div>
+        </div>
       </div>
 
-      <div class="orb" :class="{ active: running, speaking: aiSpeaking }">
-        <font-awesome-icon icon="fa-solid fa-microphone" />
+      <transition name="fade">
+        <p v-if="showInfo && !captionsOn" class="rtc-info">{{ modelName }}</p>
+      </transition>
+
+      <!-- captions: large transcript, dark theme (ChatGPT CC mode) -->
+      <div v-if="captionsOn" class="rtc-captions">
+        <p v-if="userText" class="cap user">{{ userText }}</p>
+        <p class="cap ai">{{ captionText }}</p>
       </div>
+      <p v-else class="rtc-status" :class="{ err: !!errorMsg }">{{ stageText }}</p>
+    </main>
 
-      <div class="transcript">
-        <p v-if="userText" class="line user">
-          <span class="who">{{ $t('realtime.you') }}</span
-          >{{ userText }}
-        </p>
-        <p v-if="aiText" class="line ai">
-          <span class="who">{{ $t('realtime.assistant') }}</span
-          >{{ aiText }}
-        </p>
-        <p v-if="!userText && !aiText && running" class="hint">{{ $t('realtime.listening') }}</p>
-      </div>
-
-      <p v-if="errorMsg" class="error">{{ errorMsg }}</p>
-
-      <div class="actions">
-        <el-button
-          v-if="!running"
-          type="primary"
-          round
-          size="large"
-          :loading="connecting"
-          :disabled="!canCall"
-          @click="startCall"
-        >
-          <font-awesome-icon icon="fa-solid fa-phone" class="btn-icon" />
-          {{ $t('realtime.start') }}
-        </el-button>
-        <el-button v-else type="danger" round size="large" @click="endCall">
-          <font-awesome-icon icon="fa-solid fa-phone-slash" class="btn-icon" />
-          {{ $t('realtime.end') }}
-        </el-button>
-      </div>
-
-      <p v-if="!canCall && !provisioning" class="hint small">{{ $t('realtime.needService') }}</p>
-    </div>
+    <!-- bottom control bar: circular buttons -->
+    <footer class="rtc-controls">
+      <button
+        class="ctl"
+        :class="{ active: muted }"
+        :title="muted ? $t('realtime.unmute') : $t('realtime.mute')"
+        @click="toggleMute"
+      >
+        <font-awesome-icon :icon="muted ? 'fa-solid fa-microphone-slash' : 'fa-solid fa-microphone'" />
+      </button>
+      <button class="ctl" :class="{ active: captionsOn }" :title="$t('realtime.captions')" @click="toggleCaptions">
+        <font-awesome-icon icon="fa-solid fa-closed-captioning" />
+      </button>
+      <button class="ctl end" :title="$t('realtime.end')" @click="endCall">
+        <font-awesome-icon icon="fa-solid fa-xmark" />
+      </button>
+    </footer>
   </div>
 </template>
 
@@ -69,7 +79,11 @@ export default defineComponent({
       aiSpeaking: false,
       userText: '',
       aiText: '',
-      errorMsg: ''
+      errorMsg: '',
+      level: 0,
+      muted: false,
+      captionsOn: false,
+      showInfo: false
     };
   },
   computed: {
@@ -79,8 +93,33 @@ export default defineComponent({
     canCall(): boolean {
       return !!this.token;
     },
-    statusText(): string {
-      return this.$t(`realtime.status.${this.status}`);
+    modelName(): string {
+      return REALTIME_DEFAULT_MODEL;
+    },
+    orbScale(): number {
+      // gentle audio-reactive swell; idle orb just breathes (handled in CSS)
+      return 1 + this.level * 0.16;
+    },
+    haloStyle(): Record<string, string> {
+      const lvl = this.running ? this.level : 0;
+      return {
+        transform: `scale(${1 + lvl * 0.7})`,
+        opacity: `${0.16 + lvl * 0.5}`
+      };
+    },
+    orbClass(): Record<string, boolean> {
+      return { speaking: this.aiSpeaking, live: this.running, idle: !this.running };
+    },
+    captionText(): string {
+      if (this.aiText) return this.aiText;
+      if (this.running && !this.userText) return this.$t('realtime.listening');
+      return '';
+    },
+    stageText(): string {
+      if (this.errorMsg) return this.errorMsg;
+      if (this.provisioning || this.connecting) return this.$t('realtime.status.connecting');
+      if (this.running) return this.aiSpeaking ? this.$t('realtime.speaking') : this.$t('realtime.listening');
+      return this.$t('realtime.start');
     }
   },
   async mounted() {
@@ -90,13 +129,15 @@ export default defineComponent({
     } finally {
       this.provisioning = false;
     }
+    // Enter the call like ChatGPT voice: connect immediately once provisioned.
+    if (this.canCall) this.startCall();
   },
   beforeUnmount() {
     this.client?.stop();
   },
   methods: {
     async startCall() {
-      if (!this.token) return;
+      if (!this.token || this.connecting || this.running) return;
       this.errorMsg = '';
       this.userText = '';
       this.aiText = '';
@@ -106,6 +147,7 @@ export default defineComponent({
           this.status = s;
           this.running = s === 'connecting' || s === 'connected';
           if (s === 'connected' || s === 'disconnected' || s === 'error') this.connecting = false;
+          if (!this.running) this.level = 0;
         },
         onUserSpeechStarted: () => {
           this.aiSpeaking = false;
@@ -120,12 +162,17 @@ export default defineComponent({
         onAiTranscriptDelta: (d: string) => {
           this.aiText += d;
         },
+        onAudioLevel: (lvl: number) => {
+          this.level = lvl;
+        },
         onError: (m: string) => {
           this.errorMsg = m;
         }
       });
+      // a fresh call should honour the current mute state
       try {
         await this.client.start();
+        this.client.setMuted(this.muted);
       } catch (e: any) {
         this.connecting = false;
         this.running = false;
@@ -133,10 +180,22 @@ export default defineComponent({
         this.client?.stop();
       }
     },
+    toggleMute() {
+      this.muted = !this.muted;
+      this.client?.setMuted(this.muted);
+    },
+    toggleCaptions() {
+      this.captionsOn = !this.captionsOn;
+    },
+    onOrbTap() {
+      if (!this.running && !this.connecting) this.startCall();
+    },
     endCall() {
       this.client?.stop();
       this.running = false;
       this.aiSpeaking = false;
+      this.level = 0;
+      this.goBack();
     },
     goBack() {
       this.client?.stop();
@@ -147,89 +206,309 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-.realtime-call {
+.rtc {
+  --bg: #ffffff;
+  --fg: #1c1c1e;
+  --muted: #9aa0a6;
+  --chip: #f1f2f4;
+  --chip-fg: #3c4043;
+  position: relative;
   display: flex;
-  justify-content: center;
-  align-items: center;
+  flex-direction: column;
   height: 100%;
-  padding: 20px;
-}
-.call-card {
   width: 100%;
-  max-width: 480px;
-  text-align: center;
+  background: var(--bg);
+  color: var(--fg);
+  overflow: hidden;
+  transition:
+    background 0.45s ease,
+    color 0.45s ease;
+}
+// CC mode flips to the dark “captions” look from ChatGPT voice.
+.rtc.is-captions {
+  --bg: #0a0a0b;
+  --fg: #ffffff;
+  --muted: #8e8e93;
+  --chip: rgba(255, 255, 255, 0.12);
+  --chip-fg: #ffffff;
+}
+
+/* ---------- top bar ---------- */
+.rtc-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  z-index: 2;
+}
+.rtc-top-right {
+  display: flex;
+  gap: 6px;
+}
+.ic {
+  width: 36px;
+  height: 36px;
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--muted);
+  font-size: 17px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    background 0.2s ease,
+    color 0.2s ease;
+  &:hover {
+    background: var(--chip);
+    color: var(--chip-fg);
+  }
+  &.on {
+    color: #2f86f6;
+  }
+}
+
+/* ---------- stage / orb ---------- */
+.rtc-stage {
+  flex: 1;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 20px;
+  justify-content: center;
+  gap: 26px;
+  padding: 0 24px;
+  transition: justify-content 0.4s ease;
 }
-.call-header {
-  display: flex;
-  align-items: center;
-  width: 100%;
-  gap: 10px;
-  .title {
-    flex: 1;
-    font-weight: 600;
-  }
-  .status {
-    font-size: 12px;
-    color: #999;
-    &.connected {
-      color: #34c759;
-    }
-    &.error {
-      color: #ff3b30;
-    }
-  }
+.rtc.is-captions .rtc-stage {
+  justify-content: flex-start;
+  padding-top: 8px;
 }
-.orb {
-  width: 120px;
-  height: 120px;
-  border-radius: 50%;
+.orb-stage {
+  position: relative;
+  width: 200px;
+  height: 200px;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 40px;
-  color: #fff;
-  background: #c8c9cc;
-  transition: all 0.3s ease;
-  &.active {
-    background: #409eff;
-  }
-  &.speaking {
-    background: #34c759;
-    box-shadow: 0 0 0 12px rgba(52, 199, 89, 0.18);
-  }
+  cursor: pointer;
+  transition: transform 0.4s ease;
 }
-.transcript {
-  min-height: 80px;
+.rtc.is-captions .orb-stage {
+  width: 96px;
+  height: 96px;
+}
+.orb-halo {
+  position: absolute;
+  inset: -16%;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(79, 150, 255, 0.55), rgba(79, 150, 255, 0) 62%);
+  filter: blur(14px);
+  transition:
+    transform 0.12s ease-out,
+    opacity 0.2s ease;
+  pointer-events: none;
+}
+.orb-breathe {
   width: 100%;
-  .line {
-    margin: 6px 0;
-    text-align: left;
-    .who {
-      font-weight: 600;
-      margin-right: 6px;
-      opacity: 0.7;
-    }
-  }
-  .hint {
-    color: #999;
-  }
-  .hint.small {
-    font-size: 12px;
+  height: 100%;
+  animation: breathe 6.5s ease-in-out infinite;
+  &.paused {
+    animation-duration: 9s;
   }
 }
-.error {
-  color: #ff3b30;
+@keyframes breathe {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.04);
+  }
+}
+.orb {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  overflow: hidden;
+  background: radial-gradient(120% 120% at 34% 24%, #ffffff 0%, #eaf4ff 16%, #c2deff 40%, #79b3ff 70%, #2f86f6 100%);
+  box-shadow:
+    0 20px 55px rgba(47, 134, 246, 0.4),
+    inset 0 -16px 36px rgba(18, 86, 188, 0.5),
+    inset 0 14px 30px rgba(255, 255, 255, 0.6);
+  transition:
+    transform 0.1s ease-out,
+    filter 0.3s ease;
+  will-change: transform;
+}
+.orb.idle {
+  filter: saturate(0.9) brightness(1.02);
+}
+.orb.speaking {
+  box-shadow:
+    0 22px 60px rgba(47, 134, 246, 0.55),
+    inset 0 -16px 36px rgba(18, 86, 188, 0.5),
+    inset 0 14px 30px rgba(255, 255, 255, 0.65);
+}
+.cloud {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(13px);
+  mix-blend-mode: screen;
+  pointer-events: none;
+}
+.cloud.c1 {
+  top: -28%;
+  left: -22%;
+  width: 92%;
+  height: 82%;
+  background: radial-gradient(circle at 50% 50%, #ffffff, rgba(255, 255, 255, 0) 70%);
+  animation: drift-a 13s ease-in-out infinite;
+}
+.cloud.c2 {
+  bottom: -26%;
+  right: -18%;
+  width: 84%;
+  height: 74%;
+  background: radial-gradient(circle at 50% 50%, #dcefff, rgba(220, 239, 255, 0) 70%);
+  animation: drift-b 17s ease-in-out infinite;
+}
+.cloud.c3 {
+  top: 30%;
+  left: 28%;
+  width: 60%;
+  height: 52%;
+  background: radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0) 68%);
+  animation: drift-a 21s ease-in-out infinite reverse;
+}
+.sheen {
+  position: absolute;
+  top: 10%;
+  left: 18%;
+  width: 42%;
+  height: 30%;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0) 70%);
+  filter: blur(4px);
+  pointer-events: none;
+}
+@keyframes drift-a {
+  0%,
+  100% {
+    transform: translate(0, 0) scale(1);
+  }
+  50% {
+    transform: translate(10%, 8%) scale(1.12);
+  }
+}
+@keyframes drift-b {
+  0%,
+  100% {
+    transform: translate(0, 0) scale(1.05);
+  }
+  50% {
+    transform: translate(-12%, -8%) scale(0.92);
+  }
+}
+
+/* ---------- status / info / captions ---------- */
+.rtc-status {
+  font-size: 17px;
+  color: var(--muted);
+  margin: 0;
+  min-height: 24px;
+  text-align: center;
+  &.err {
+    color: #ff3b30;
+  }
+}
+.rtc-info {
   font-size: 13px;
+  color: var(--muted);
+  margin: -10px 0 0;
 }
-.btn-icon {
-  margin-right: 6px;
+.rtc-captions {
+  width: 100%;
+  max-width: 560px;
+  margin-top: 22px;
+  text-align: left;
+  .cap {
+    margin: 0 0 14px;
+  }
+  .cap.user {
+    font-size: 15px;
+    color: var(--muted);
+  }
+  .cap.ai {
+    font-size: 30px;
+    line-height: 1.35;
+    font-weight: 500;
+    color: var(--fg);
+  }
 }
-.hint.small {
-  font-size: 12px;
-  color: #999;
+
+/* ---------- bottom controls ---------- */
+.rtc-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 26px;
+  padding: 22px 16px calc(26px + env(safe-area-inset-bottom, 0px));
+  z-index: 2;
+}
+.ctl {
+  width: 60px;
+  height: 60px;
+  border: none;
+  border-radius: 50%;
+  background: var(--chip);
+  color: var(--chip-fg);
+  font-size: 21px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    transform 0.15s ease,
+    background 0.2s ease,
+    color 0.2s ease;
+  &:hover {
+    transform: translateY(-2px);
+  }
+  &:active {
+    transform: scale(0.94);
+  }
+  &.active {
+    background: #2f86f6;
+    color: #fff;
+  }
+  &.end {
+    background: #2b2b2e;
+    color: #fff;
+  }
+}
+.rtc.is-captions .ctl.end {
+  background: rgba(255, 255, 255, 0.16);
+}
+
+/* ---------- transitions ---------- */
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.25s ease;
+}
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+
+@media (max-width: 520px) {
+  .orb-stage {
+    width: 168px;
+    height: 168px;
+  }
+  .rtc-captions .cap.ai {
+    font-size: 26px;
+  }
 }
 </style>

--- a/src/plugins/font-awesome.ts
+++ b/src/plugins/font-awesome.ts
@@ -54,6 +54,8 @@ import {
   faHashtag as faSolidHashtag,
   faCircleInfo as faSolidCircleInfo,
   faMicrophone as faSolidMicrophone,
+  faMicrophoneSlash as faSolidMicrophoneSlash,
+  faClosedCaptioning as faSolidClosedCaptioning,
   faPhone as faSolidPhone,
   faPhoneSlash as faSolidPhoneSlash,
   faArrowLeft as faSolidArrowLeft,
@@ -205,6 +207,8 @@ library.add(faSolidBook);
 library.add(faSolidGear);
 library.add(faSolidSitemap);
 library.add(faSolidMicrophone);
+library.add(faSolidMicrophoneSlash);
+library.add(faSolidClosedCaptioning);
 library.add(faSolidPhone);
 library.add(faSolidPhoneSlash);
 library.add(faSolidBars);

--- a/src/utils/realtimeClient.ts
+++ b/src/utils/realtimeClient.ts
@@ -9,6 +9,8 @@ export interface IRealtimeHandlers {
   onAiResponseStart?: () => void;
   onUserSpeechStarted?: () => void;
   onError?: (message: string) => void;
+  /** Smoothed combined mic+assistant loudness (0–1) for UI animation. */
+  onAudioLevel?: (level: number) => void;
 }
 
 /**
@@ -28,6 +30,8 @@ export class RealtimeClient {
   private micStream: MediaStream | undefined;
   private micNode: MediaStreamAudioSourceNode | undefined;
   private workletNode: AudioWorkletNode | undefined;
+  private analyser: AnalyserNode | undefined; // taps mic + assistant audio for the level meter
+  private levelRaf = 0;
   private running = false;
 
   private playHead = 0;
@@ -60,6 +64,13 @@ export class RealtimeClient {
     this.micNode = this.audioCtx.createMediaStreamSource(this.micStream);
     this.workletNode = new AudioWorkletNode(this.audioCtx, 'recorder-processor');
     this.micNode.connect(this.workletNode);
+    // Level meter: an analyser sees the mic and (later) the assistant playback so
+    // the UI orb pulses for whoever is talking. It's a sink — never wired onward
+    // to the destination, so it adds no audible echo.
+    this.analyser = this.audioCtx.createAnalyser();
+    this.analyser.fftSize = 256;
+    this.micNode.connect(this.analyser);
+    this.startLevelLoop();
     // The worklet must be in the graph to pull; route it to a muted gain so the
     // mic isn't echoed to the speaker.
     const sink = this.audioCtx.createGain();
@@ -89,6 +100,31 @@ export class RealtimeClient {
       if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
       this.ws.send(JSON.stringify({ type: 'input_audio_buffer.append', audio: b64FromArrayBuffer(e.data) }));
     };
+  }
+
+  /** Mute/unmute the microphone without tearing down the call. */
+  setMuted(muted: boolean): void {
+    this.micStream?.getAudioTracks().forEach((t) => (t.enabled = !muted));
+  }
+
+  private startLevelLoop(): void {
+    const data = new Uint8Array(this.analyser ? this.analyser.fftSize : 0);
+    let smooth = 0;
+    const tick = () => {
+      if (this.disposed || !this.analyser) return;
+      this.analyser.getByteTimeDomainData(data);
+      let sum = 0;
+      for (let i = 0; i < data.length; i++) {
+        const v = (data[i] - 128) / 128;
+        sum += v * v;
+      }
+      const rms = Math.sqrt(sum / data.length);
+      const level = Math.min(1, rms * 3.4); // amplify quiet speech into a visible range
+      smooth = smooth * 0.82 + level * 0.18; // ease for a fluid orb, no jitter
+      this.handlers.onAudioLevel?.(smooth);
+      this.levelRaf = requestAnimationFrame(tick);
+    };
+    this.levelRaf = requestAnimationFrame(tick);
   }
 
   stop(): void {
@@ -169,6 +205,7 @@ export class RealtimeClient {
     const src = this.audioCtx.createBufferSource();
     src.buffer = audioBuffer;
     src.connect(this.audioCtx.destination);
+    if (this.analyser) src.connect(this.analyser); // feed the level meter so the orb reacts while the assistant speaks
 
     const now = this.audioCtx.currentTime;
     if (this.playHead < now) this.playHead = now + 0.02;
@@ -195,6 +232,7 @@ export class RealtimeClient {
 
   private teardownAudio(): void {
     try {
+      if (this.levelRaf) cancelAnimationFrame(this.levelRaf);
       if (this.workletNode) this.workletNode.port.onmessage = null;
       if (this.micStream) this.micStream.getTracks().forEach((t) => t.stop());
       this.stopPlayback();
@@ -202,7 +240,9 @@ export class RealtimeClient {
     } catch {
       // ignore
     }
-    this.micStream = this.micNode = this.workletNode = this.audioCtx = undefined;
+    this.levelRaf = 0;
+    this.handlers.onAudioLevel?.(0);
+    this.micStream = this.micNode = this.workletNode = this.audioCtx = this.analyser = undefined;
   }
 }
 


### PR DESCRIPTION
## What

Polishes the realtime voice call screen (`/chatgpt/call`) to mirror the [ChatGPT Voice](https://chatgpt.com/features/voice/) experience.

| Before | After |
|---|---|
| Flat grey/blue circle with a mic glyph, transcript text block, and Start/End buttons in a card | Audio-reactive **blue gradient orb** (sky/cloud look + soft halo), minimal top icons, circular bottom control bar, and a dark **CC captions** mode with large transcript |

### Highlights
- **Reactive orb** — an `AnalyserNode` taps both the mic and the assistant playback; a smoothed RMS level (0–1) drives the orb's scale + halo glow, so it pulses for whoever is talking. Idle orb gently breathes.
- **Captions (CC) mode** — toggles the screen to the dark, big-transcript look from ChatGPT voice (assistant text large, user line small above).
- **Mute** — toggles the mic track without dropping the call.
- **Minimal chrome** — chevron-down (minimize), info, CC up top; mic / CC / end (✕) as circular buttons at the bottom.
- **Auto-connect** on open (like entering a call); tap the orb to retry after an error.

### Scope
- `src/pages/chat/RealtimeCall.vue` — full redesign (template + scoped SCSS).
- `src/utils/realtimeClient.ts` — added `onAudioLevel` (analyser + rAF level loop) and `setMuted()`. The analyser is a sink (never wired to `destination`), so it adds no audible echo; cleaned up on teardown.
- `src/plugins/font-awesome.ts` — registered `microphone-slash` + `closed-captioning`.
- `src/i18n/*/realtime.json` — added `speaking`, `mute`, `unmute`, `captions` across all 18 locales (real translations).

No API/billing/auth changes — purely the consumer call UI. Backend path (`/aichat2/realtime` → aichat billing) is unchanged and already live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)