### PR TITLE
feat(maestro): migrate consumer module to v4 agent-native contract

### DIFF
--- a/change/@acedatacloud-nexior-cfbaaf89-2421-413d-bedb-4465a1b7e86f.json
+++ b/change/@acedatacloud-nexior-cfbaaf89-2421-413d-bedb-4465a1b7e86f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(maestro): migrate consumer module to v4 agent-native contract (prompt/file_urls/action/langs/remix)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/maestro/ConfigPanel.vue
+++ b/src/components/maestro/ConfigPanel.vue
@@ -1,43 +1,41 @@
 <template>
   <div class="flex flex-col h-full">
     <div class="flex-1 overflow-y-auto p-5">
-      <!-- Source type -->
+      <!-- Remix banner: iterating on a previous video -->
+      <el-alert v-if="isRemixing" :closable="false" type="info" class="mb-4">
+        <p class="text-xs mb-1">
+          <font-awesome-icon icon="fa-solid fa-wand-magic-sparkles" class="mr-1" />
+          {{ $t('maestro.name.remixing') }}: {{ refTaskId }}
+        </p>
+        <el-button size="small" text @click="onClearRemix">{{ $t('maestro.button.cancelRemix') }}</el-button>
+      </el-alert>
+
+      <!-- Prompt -->
       <div class="mb-4">
-        <span class="text-sm font-bold mb-2 block">{{ $t('maestro.name.sourceType') }}</span>
-        <el-radio-group v-model="sourceType" class="w-full">
-          <el-radio-button :value="MAESTRO_SOURCE_TYPE_TOPIC">{{ $t('maestro.option.topic') }}</el-radio-button>
-          <el-radio-button :value="MAESTRO_SOURCE_TYPE_ARTICLE">{{ $t('maestro.option.article') }}</el-radio-button>
-        </el-radio-group>
+        <span class="text-sm font-bold mb-2 block">{{ $t('maestro.name.prompt') }}</span>
+        <el-input v-model="prompt" type="textarea" :rows="6" :placeholder="$t('maestro.placeholder.prompt')" />
+        <p class="text-xs text-[var(--el-text-color-secondary)] mt-1">{{ $t('maestro.description.prompt') }}</p>
       </div>
 
-      <!-- Source content -->
+      <!-- Reference files -->
       <div class="mb-4">
-        <span class="text-sm font-bold mb-2 block">{{ $t('maestro.name.sourceRef') }}</span>
-        <el-input v-model="sourceRef" type="textarea" :rows="5" :placeholder="$t('maestro.placeholder.sourceRef')" />
-        <p class="text-xs text-[var(--el-text-color-secondary)] mt-1">{{ $t('maestro.description.sourceRef') }}</p>
+        <span class="text-sm font-bold mb-2 block">{{ $t('maestro.name.files') }}</span>
+        <file-urls-input />
       </div>
 
-      <!-- Main language -->
+      <!-- Languages -->
       <div class="mb-4">
-        <span class="text-sm font-bold mb-2 block">{{ $t('maestro.name.lang') }}</span>
-        <el-select v-model="lang" :placeholder="$t('maestro.placeholder.select')" class="w-full">
-          <el-option v-for="l in MAESTRO_ALLOWED_LANGS" :key="l" :label="l" :value="l" />
-        </el-select>
-      </div>
-
-      <!-- Extra languages -->
-      <div class="mb-4">
-        <span class="text-sm font-bold mb-2 block">{{ $t('maestro.name.extraLangs') }}</span>
+        <span class="text-sm font-bold mb-2 block">{{ $t('maestro.name.langs') }}</span>
         <el-select
-          v-model="extraLangs"
+          v-model="langs"
           multiple
           collapse-tags
           :placeholder="$t('maestro.placeholder.select')"
           class="w-full"
         >
-          <el-option v-for="l in extraLangOptions" :key="l" :label="l" :value="l" />
+          <el-option v-for="l in MAESTRO_ALLOWED_LANGS" :key="l" :label="l" :value="l" />
         </el-select>
-        <p class="text-xs text-[var(--el-text-color-secondary)] mt-1">{{ $t('maestro.description.extraLangs') }}</p>
+        <p class="text-xs text-[var(--el-text-color-secondary)] mt-1">{{ $t('maestro.description.langs') }}</p>
       </div>
 
       <!-- Aspect ratio -->
@@ -55,17 +53,11 @@
           <el-option v-for="d in MAESTRO_ALLOWED_DURATIONS" :key="d" :label="`${d}s`" :value="d" />
         </el-select>
       </div>
-
-      <!-- Music -->
-      <div class="mb-2 flex items-center justify-between">
-        <span class="text-sm font-bold">{{ $t('maestro.name.music') }}</span>
-        <el-switch v-model="music" />
-      </div>
     </div>
 
     <div class="flex flex-col items-center justify-center px-5 pb-5">
       <consumption :value="consumption" :service="service" />
-      <el-button type="primary" class="btn w-full" round :disabled="!sourceRef" @click="onGenerate">
+      <el-button type="primary" class="btn w-full" round :disabled="!canGenerate" @click="onGenerate">
         <font-awesome-icon icon="fa-solid fa-magic" class="mr-2" />
         {{ $t('maestro.button.generate') }}
       </el-button>
@@ -75,21 +67,19 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElButton, ElInput, ElSelect, ElOption, ElRadioGroup, ElRadioButton, ElSwitch } from 'element-plus';
+import { ElButton, ElInput, ElSelect, ElOption, ElRadioGroup, ElRadioButton, ElAlert } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import Consumption from '../common/Consumption.vue';
+import FileUrlsInput from './config/FileUrlsInput.vue';
 import { getConsumption } from '@/utils';
 import {
-  MAESTRO_SOURCE_TYPE_TOPIC,
-  MAESTRO_SOURCE_TYPE_ARTICLE,
   MAESTRO_ALLOWED_LANGS,
   MAESTRO_ALLOWED_ASPECTS,
   MAESTRO_ALLOWED_DURATIONS,
-  MAESTRO_DEFAULT_SOURCE_TYPE,
-  MAESTRO_DEFAULT_LANG,
+  MAESTRO_DEFAULT_ACTION,
+  MAESTRO_DEFAULT_LANGS,
   MAESTRO_DEFAULT_ASPECT,
-  MAESTRO_DEFAULT_DURATION,
-  MAESTRO_DEFAULT_MUSIC
+  MAESTRO_DEFAULT_DURATION
 } from '@/constants';
 import { IMaestroConfig } from '@/models';
 
@@ -102,15 +92,14 @@ export default defineComponent({
     ElOption,
     ElRadioGroup,
     ElRadioButton,
-    ElSwitch,
+    ElAlert,
     Consumption,
+    FileUrlsInput,
     FontAwesomeIcon
   },
   emits: ['generate'],
   data() {
     return {
-      MAESTRO_SOURCE_TYPE_TOPIC,
-      MAESTRO_SOURCE_TYPE_ARTICLE,
       MAESTRO_ALLOWED_LANGS,
       MAESTRO_ALLOWED_ASPECTS,
       MAESTRO_ALLOWED_DURATIONS
@@ -126,41 +115,31 @@ export default defineComponent({
     consumption() {
       return getConsumption(this.config, this.service?.cost);
     },
-    extraLangOptions(): string[] {
-      return MAESTRO_ALLOWED_LANGS.filter((l) => l !== this.lang);
+    isRemixing(): boolean {
+      const action = this.config?.action;
+      return !!action && action !== MAESTRO_DEFAULT_ACTION && !!this.config?.ref_task_id;
     },
-    sourceType: {
+    refTaskId(): string | undefined {
+      return this.config?.ref_task_id;
+    },
+    canGenerate(): boolean {
+      return !!this.prompt?.trim();
+    },
+    prompt: {
       get(): string | undefined {
-        return this.config?.source_type;
+        return this.config?.prompt;
       },
       set(val: string) {
-        this.update({ source_type: val });
+        this.update({ prompt: val });
       }
     },
-    sourceRef: {
-      get(): string | undefined {
-        return this.config?.source_ref;
-      },
-      set(val: string) {
-        this.update({ source_ref: val });
-      }
-    },
-    lang: {
-      get(): string | undefined {
-        return this.config?.lang;
-      },
-      set(val: string) {
-        // drop the new main language from extra_langs to avoid duplicate renders
-        const extra = (this.config?.extra_langs || []).filter((l) => l !== val);
-        this.update({ lang: val, extra_langs: extra });
-      }
-    },
-    extraLangs: {
+    langs: {
       get(): string[] {
-        return this.config?.extra_langs || [];
+        return this.config?.langs || [];
       },
       set(val: string[]) {
-        this.update({ extra_langs: val });
+        // keep at least the primary language so billing/render always has one
+        this.update({ langs: val.length ? val : MAESTRO_DEFAULT_LANGS });
       }
     },
     aspect: {
@@ -178,23 +157,14 @@ export default defineComponent({
       set(val: number) {
         this.update({ duration: val });
       }
-    },
-    music: {
-      get(): boolean {
-        return this.config?.music ?? true;
-      },
-      set(val: boolean) {
-        this.update({ music: val });
-      }
     }
   },
   mounted() {
     this.update({
-      source_type: this.config?.source_type ?? MAESTRO_DEFAULT_SOURCE_TYPE,
-      lang: this.config?.lang ?? MAESTRO_DEFAULT_LANG,
+      action: this.config?.action ?? MAESTRO_DEFAULT_ACTION,
+      langs: this.config?.langs?.length ? this.config.langs : MAESTRO_DEFAULT_LANGS,
       aspect: this.config?.aspect ?? MAESTRO_DEFAULT_ASPECT,
-      duration: this.config?.duration ?? MAESTRO_DEFAULT_DURATION,
-      music: this.config?.music ?? MAESTRO_DEFAULT_MUSIC
+      duration: this.config?.duration ?? MAESTRO_DEFAULT_DURATION
     });
   },
   methods: {
@@ -203,6 +173,9 @@ export default defineComponent({
         ...this.config,
         ...patch
       });
+    },
+    onClearRemix() {
+      this.update({ action: MAESTRO_DEFAULT_ACTION, ref_task_id: undefined });
     },
     onGenerate() {
       this.$emit('generate');

--- a/src/components/maestro/config/FileUrlsInput.vue
+++ b/src/components/maestro/config/FileUrlsInput.vue
@@ -1,0 +1,82 @@
+<template>
+  <div>
+    <el-upload
+      ref="uploader"
+      v-model:file-list="fileList"
+      :accept="MAESTRO_FILE_ACCEPT"
+      name="file"
+      class="w-full"
+      :limit="MAESTRO_FILE_LIMIT"
+      :multiple="true"
+      :action="uploadUrl"
+      :headers="headers"
+      :on-exceed="onExceed"
+      :on-error="onError"
+      :on-success="onChange"
+      :on-remove="onChange"
+    >
+      <el-button size="small" round>
+        <font-awesome-icon icon="fa-solid fa-paperclip" class="mr-1" />
+        {{ $t('maestro.button.uploadFiles') }}
+      </el-button>
+    </el-upload>
+    <p class="text-xs text-[var(--el-text-color-secondary)] mt-1">{{ $t('maestro.description.files') }}</p>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElButton, ElUpload, ElMessage, UploadFiles, UploadFile } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { getBaseUrlPlatform } from '@/utils';
+import { MAESTRO_FILE_ACCEPT, MAESTRO_FILE_LIMIT } from '@/constants';
+
+interface IData {
+  fileList: UploadFiles;
+  uploadUrl: string;
+  MAESTRO_FILE_ACCEPT: string;
+  MAESTRO_FILE_LIMIT: number;
+}
+
+export default defineComponent({
+  name: 'MaestroFileUrlsInput',
+  components: {
+    ElUpload,
+    ElButton,
+    FontAwesomeIcon
+  },
+  data(): IData {
+    return {
+      fileList: [],
+      uploadUrl: getBaseUrlPlatform() + '/api/v1/files/',
+      MAESTRO_FILE_ACCEPT,
+      MAESTRO_FILE_LIMIT
+    };
+  },
+  computed: {
+    headers() {
+      return {
+        Authorization: `Bearer ${this.$store.state.token.access}`
+      };
+    }
+  },
+  methods: {
+    onExceed() {
+      ElMessage.warning(this.$t('maestro.message.uploadExceed'));
+    },
+    onError() {
+      ElMessage.error(this.$t('maestro.message.uploadError'));
+    },
+    onChange() {
+      // Only files that finished uploading have a response.file_url.
+      const urls = this.fileList
+        .map((file: UploadFile) => (file?.response as any)?.file_url)
+        .filter((url: string | undefined): url is string => !!url);
+      this.$store.commit('maestro/setConfig', {
+        ...this.$store.state.maestro?.config,
+        file_urls: urls
+      });
+    }
+  }
+});
+</script>

--- a/src/components/maestro/task/Preview.vue
+++ b/src/components/maestro/task/Preview.vue
@@ -11,17 +11,27 @@
         </span>
       </div>
       <div class="info">
-        <p v-if="modelValue?.request?.source_ref" class="prompt mt-2">
-          {{ modelValue?.request?.source_ref }}
+        <p v-if="modelValue?.request?.prompt" class="prompt mt-2">
+          {{ modelValue?.request?.prompt }}
           <span v-if="!isTerminal"> - ({{ statusLabel }}) </span>
         </p>
+        <p v-if="fileCount" class="text-xs text-[var(--el-text-color-secondary)] mb-1">
+          <font-awesome-icon icon="fa-solid fa-paperclip" class="mr-1" />{{ fileCount }}
+        </p>
+      </div>
+
+      <!-- in-progress: live stage + percentage -->
+      <div v-if="!isTerminal && progressMessage" class="content">
+        <p class="text-xs text-[var(--el-text-color-secondary)] mb-1">{{ progressMessage }}</p>
+        <el-progress v-if="progressPct !== undefined" :percentage="progressPct" :stroke-width="6" />
       </div>
 
       <!-- success: one player per language variant -->
       <div v-if="modelValue?.response?.success === true && variants.length" class="content">
         <div v-for="(variant, vi) in variants" :key="vi" class="mb-4">
           <p class="text-xs text-[var(--el-text-color-secondary)] mb-1">
-            <font-awesome-icon icon="fa-solid fa-language" class="mr-1" />{{ variant.lang }}
+            <font-awesome-icon icon="fa-solid fa-language" class="mr-1" />{{ variant.lang
+            }}<span v-if="variant.title"> · {{ variant.title }}</span>
           </p>
           <video-player v-if="variant.output_url" :src="variant.output_url" />
           <div class="operations mt-2">
@@ -34,17 +44,13 @@
             >
               {{ $t('maestro.button.download') }}
             </el-button>
-            <el-button
-              v-if="variant.captions_url"
-              size="small"
-              class="btn-action"
-              @click="onDownload($event, variant.captions_url)"
-            >
-              {{ $t('maestro.button.downloadCaptions') }}
-            </el-button>
           </div>
         </div>
         <div class="operations">
+          <el-button size="small" type="primary" class="btn-action" @click="onRemix">
+            <font-awesome-icon icon="fa-solid fa-wand-magic-sparkles" class="mr-1" />
+            {{ $t('maestro.button.remix') }}
+          </el-button>
           <api-code-button path="/maestro/videos" :body="modelValue?.request" />
         </div>
         <el-alert :closable="false" class="mt-2 success">
@@ -84,9 +90,9 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElImage, ElAlert, ElButton } from 'element-plus';
-import { IMaestroTask, IMaestroVariant } from '@/models';
-import { MAESTRO_LOGO } from '@/constants';
+import { ElImage, ElAlert, ElButton, ElProgress, ElMessage } from 'element-plus';
+import { IMaestroTask, IMaestroVariant, IMaestroConfig } from '@/models';
+import { MAESTRO_LOGO, MAESTRO_ACTION_REMIX } from '@/constants';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import VideoPlayer from '@/components/common/VideoPlayer.vue';
@@ -101,6 +107,7 @@ export default defineComponent({
     CopyToClipboard,
     FontAwesomeIcon,
     ElAlert,
+    ElProgress,
     VideoPlayer,
     ElButton,
     ApiCodeButton
@@ -120,8 +127,21 @@ export default defineComponent({
     variants(): IMaestroVariant[] {
       return this.modelValue?.response?.data?.variants || [];
     },
+    fileCount(): number {
+      return this.modelValue?.request?.file_urls?.length || 0;
+    },
     isTerminal(): boolean {
       return TERMINAL.includes(this.modelValue?.status || '');
+    },
+    progressMessage(): string | undefined {
+      const progress = this.modelValue?.response?.data?.progress;
+      const last = progress?.length ? progress[progress.length - 1] : undefined;
+      return last?.message || last?.stage || this.modelValue?.response?.data?.stage;
+    },
+    progressPct(): number | undefined {
+      const progress = this.modelValue?.response?.data?.progress;
+      const last = progress?.length ? progress[progress.length - 1] : undefined;
+      return typeof last?.pct === 'number' ? last.pct : undefined;
     },
     statusLabel(): string {
       const s = this.modelValue?.status || 'pending';
@@ -139,6 +159,21 @@ export default defineComponent({
     onDownload(event: MouseEvent, url: string) {
       event?.stopPropagation();
       window.open(url, '_blank');
+    },
+    onRemix() {
+      const req = this.modelValue?.request;
+      const patch: IMaestroConfig = {
+        ...(this.$store.state.maestro?.config || {}),
+        action: MAESTRO_ACTION_REMIX,
+        ref_task_id: this.modelValue?.id,
+        prompt: '',
+        langs: req?.langs?.length ? req.langs : this.$store.state.maestro?.config?.langs,
+        aspect: req?.aspect ?? this.$store.state.maestro?.config?.aspect,
+        duration: req?.duration ?? this.$store.state.maestro?.config?.duration,
+        file_urls: []
+      };
+      this.$store.commit('maestro/setConfig', patch);
+      ElMessage.info(this.$t('maestro.message.remixLoaded'));
     }
   }
 });

--- a/src/constants/maestro.ts
+++ b/src/constants/maestro.ts
@@ -2,16 +2,20 @@ export const MAESTRO_SERVICE_ID = '0d7031bf-610a-419e-a5a0-db8f240286d5';
 
 export const MAESTRO_LOGO = 'https://cdn.acedata.cloud/ae064d6b6c.svg';
 
-export const MAESTRO_SOURCE_TYPE_TOPIC = 'Topic';
-export const MAESTRO_SOURCE_TYPE_ARTICLE = 'Article';
-export const MAESTRO_ALLOWED_SOURCE_TYPES = [MAESTRO_SOURCE_TYPE_TOPIC, MAESTRO_SOURCE_TYPE_ARTICLE];
+export const MAESTRO_ACTION_GENERATE = 'generate';
+export const MAESTRO_ACTION_REMIX = 'remix';
+export const MAESTRO_ACTION_EDIT = 'edit';
+export const MAESTRO_ACTION_EXTEND = 'extend';
 
 export const MAESTRO_ALLOWED_ASPECTS = ['9:16', '16:9', '1:1'];
 export const MAESTRO_ALLOWED_LANGS = ['zh-cn', 'en', 'ja', 'ko', 'es', 'fr', 'de'];
 export const MAESTRO_ALLOWED_DURATIONS = [20, 30, 45, 60];
 
-export const MAESTRO_DEFAULT_SOURCE_TYPE = MAESTRO_SOURCE_TYPE_TOPIC;
-export const MAESTRO_DEFAULT_LANG = 'zh-cn';
+// Accepted reference media for file_urls (images / video / audio).
+export const MAESTRO_FILE_ACCEPT = '.png,.jpg,.jpeg,.gif,.bmp,.webp,.mp4,.mov,.webm,.mp3,.wav,.m4a';
+export const MAESTRO_FILE_LIMIT = 6;
+
+export const MAESTRO_DEFAULT_ACTION = MAESTRO_ACTION_GENERATE;
+export const MAESTRO_DEFAULT_LANGS = ['zh-cn'];
 export const MAESTRO_DEFAULT_ASPECT = '9:16';
 export const MAESTRO_DEFAULT_DURATION = 30;
-export const MAESTRO_DEFAULT_MUSIC = true;

--- a/src/i18n/ar/maestro.json
+++ b/src/i18n/ar/maestro.json
@@ -27,21 +27,17 @@
     "message": "سبب الفشل",
     "description": "سبب الفشل"
   },
-  "name.sourceType": {
-    "message": "نوع المصدر",
-    "description": "حقل نوع المصدر"
+  "name.prompt": {
+    "message": "كلمة الطلب",
+    "description": "حقل الطلب"
   },
-  "name.sourceRef": {
-    "message": "المحتوى",
-    "description": "حقل محتوى المصدر"
+  "name.files": {
+    "message": "المواد المرجعية",
+    "description": "حقل الوسائط المرجعية"
   },
-  "name.lang": {
-    "message": "اللغة الرئيسية",
-    "description": "حقل اللغة الأساسية"
-  },
-  "name.extraLangs": {
-    "message": "لغات إضافية",
-    "description": "حقل النسخ اللغوية الإضافية"
+  "name.langs": {
+    "message": "اللغات",
+    "description": "حقل لغات الإخراج"
   },
   "name.aspect": {
     "message": "نسبة العرض إلى الارتفاع",
@@ -51,49 +47,41 @@
     "message": "المدة",
     "description": "حقل المدة المستهدفة"
   },
-  "name.music": {
-    "message": "الموسيقى الخلفية",
-    "description": "حقل تبديل الموسيقى"
+  "name.remixing": {
+    "message": "إعادة التعديل",
+    "description": "علامة شريط إعادة التعديل"
   },
-  "option.topic": {
-    "message": "موضوع",
-    "description": "نوع المصدر: موضوع/عنوان"
-  },
-  "option.article": {
-    "message": "مقالة",
-    "description": "نوع المصدر: نص المقال الكامل"
-  },
-  "placeholder.sourceRef": {
-    "message": "أدخل موضوعًا (مثل “ما هو قاعدة بيانات المتجهات”) أو الصق المقالة الكاملة...",
-    "description": "مكان حجز نص المصدر"
+  "placeholder.prompt": {
+    "message": "صف الفيديو الذي تريده - الموضوع، ما الذي تريد عرضه، الأسلوب، الجمهور...",
+    "description": "نص توضيحي لحقل الطلب"
   },
   "placeholder.select": {
     "message": "يرجى الاختيار",
     "description": "نموذج عام لمكان حجز الاختيار"
   },
-  "description.sourceRef": {
-    "message": "موضوع/عنوان، أو نص المقالة بالكامل الذي سيتم تحويله إلى فيديو.",
-    "description": "مساعدة حقل المصدر"
+  "description.prompt": {
+    "message": "استخدم لغة بسيطة لشرح ما تريده، النص، المشاهد، الصوت، والتحرير كلها تعود إلى Maestro.",
+    "description": "مساعدة حقل الطلب"
   },
-  "description.extraLangs": {
-    "message": "إعادة استخدام المشهد، وإنتاج هذه النسخ اللغوية الإضافية (+6 نقاط لكل لغة).",
-    "description": "مساعدة اللغات الإضافية"
+  "description.langs": {
+    "message": "يمكن إخراج لغة واحدة أو أكثر، مع إعادة استخدام المشاهد، فقط إضافة صوت (كل لغة إضافية +6 نقاط).",
+    "description": "مساعدة اللغات"
+  },
+  "description.files": {
+    "message": "اختياري. قم بتحميل الصور أو الفيديوهات أو الصوتيات لاستخدامها في Maestro (مثل صور المنتج، الشعار).",
+    "description": "مساعدة الملفات"
   },
   "status.pending": {
     "message": "قيد الانتظار",
     "description": "قيد الانتظار"
   },
-  "status.scripting": {
-    "message": "يتم إنشاء السكربت",
-    "description": "يتم إنشاء السكربت"
+  "status.planning": {
+    "message": "قيد التخطيط",
+    "description": "التخطيط"
   },
-  "status.generating": {
-    "message": "يتم إنشاء الشاشة",
-    "description": "يتم إنشاء المحتوى"
-  },
-  "status.rendering": {
-    "message": "يتم العرض",
-    "description": "يتم عرض المحتوى"
+  "status.producing": {
+    "message": "قيد الإنتاج",
+    "description": "الإنتاج"
   },
   "status.processing": {
     "message": "يتم المعالجة",
@@ -107,9 +95,17 @@
     "message": "تحميل الفيديو",
     "description": "زر تحميل الفيديو"
   },
-  "button.downloadCaptions": {
-    "message": "تحميل الترجمة",
-    "description": "زر تحميل ملف srt"
+  "button.uploadFiles": {
+    "message": "رفع الملفات",
+    "description": "زر رفع الملفات المرجعية"
+  },
+  "button.remix": {
+    "message": "إعادة التعديل",
+    "description": "زر إعادة تعديل هذا الفيديو"
+  },
+  "button.cancelRemix": {
+    "message": "إلغاء إعادة التعديل",
+    "description": "زر إلغاء إعادة التعديل"
   },
   "message.startingTask": {
     "message": "جارٍ تقديم مهمة الفيديو…",
@@ -127,12 +123,80 @@
     "message": "تم استنفاد الرصيد، يرجى إعادة الشحن للمتابعة.",
     "description": "تم الاستنفاد"
   },
-  "message.downloadVideo": {
-    "message": "تحميل الفيديو الذي تم إنشاؤه",
-    "description": "تلميح التحميل"
+  "message.remixLoaded": {
+    "message": "تم تحميل إعادة التعديل - في الجهة اليسرى، صف التعديلات التي تريدها، ثم قم بالتوليد.",
+    "description": "إشعار تحميل إعادة التعديل"
+  },
+  "message.uploadExceed": {
+    "message": "عدد الملفات كبير جدًا، يرجى حذف بعضها ثم المحاولة مرة أخرى.",
+    "description": "تجاوز حد الرفع"
+  },
+  "message.uploadError": {
+    "message": "فشل الرفع، يرجى المحاولة مرة أخرى.",
+    "description": "خطأ في الرفع"
   },
   "message.noTasks": {
     "message": "لا توجد فيديوهات بعد — قم بإنشاء أول فيديو لك على اليسار.",
     "description": "لا توجد مهام"
+  },
+  "name.sourceType": {
+    "message": "نوع المصدر",
+    "description": "حقل نوع المصدر"
+  },
+  "name.sourceRef": {
+    "message": "المحتوى",
+    "description": "حقل محتوى المصدر"
+  },
+  "name.lang": {
+    "message": "اللغة الرئيسية",
+    "description": "حقل اللغة الأساسية"
+  },
+  "name.extraLangs": {
+    "message": "لغات إضافية",
+    "description": "حقل النسخ اللغوية الإضافية"
+  },
+  "name.music": {
+    "message": "الموسيقى الخلفية",
+    "description": "حقل تبديل الموسيقى"
+  },
+  "option.topic": {
+    "message": "موضوع",
+    "description": "نوع المصدر: موضوع/عنوان"
+  },
+  "option.article": {
+    "message": "مقالة",
+    "description": "نوع المصدر: نص المقال الكامل"
+  },
+  "placeholder.sourceRef": {
+    "message": "أدخل موضوعًا (مثل “ما هو قاعدة بيانات المتجهات”) أو الصق المقالة الكاملة...",
+    "description": "مكان حجز نص المصدر"
+  },
+  "description.sourceRef": {
+    "message": "موضوع/عنوان، أو نص المقالة بالكامل الذي سيتم تحويله إلى فيديو.",
+    "description": "مساعدة حقل المصدر"
+  },
+  "description.extraLangs": {
+    "message": "إعادة استخدام المشهد، وإنتاج هذه النسخ اللغوية الإضافية (+6 نقاط لكل لغة).",
+    "description": "مساعدة اللغات الإضافية"
+  },
+  "status.scripting": {
+    "message": "يتم إنشاء السكربت",
+    "description": "يتم إنشاء السكربت"
+  },
+  "status.generating": {
+    "message": "يتم إنشاء الشاشة",
+    "description": "يتم إنشاء المحتوى"
+  },
+  "status.rendering": {
+    "message": "يتم العرض",
+    "description": "يتم عرض المحتوى"
+  },
+  "button.downloadCaptions": {
+    "message": "تحميل الترجمة",
+    "description": "زر تحميل ملف srt"
+  },
+  "message.downloadVideo": {
+    "message": "تحميل الفيديو الذي تم إنشاؤه",
+    "description": "تلميح التحميل"
   }
 }

--- a/src/i18n/de/maestro.json
+++ b/src/i18n/de/maestro.json
@@ -27,21 +27,17 @@
     "message": "Fehlerursache",
     "description": "Grund für den Fehler"
   },
-  "name.sourceType": {
-    "message": "Quelltyp",
-    "description": "Feld für den Quelltyp"
+  "name.prompt": {
+    "message": "Eingabeaufforderung",
+    "description": "Eingabefeld"
   },
-  "name.sourceRef": {
-    "message": "Inhalt",
-    "description": "Feld für den Quellinhalt"
+  "name.files": {
+    "message": "Referenzmaterial",
+    "description": "Feld für Referenzmedien"
   },
-  "name.lang": {
-    "message": "Hauptsprache",
-    "description": "Feld für die primäre Sprache"
-  },
-  "name.extraLangs": {
-    "message": "Zusätzliche Sprachen",
-    "description": "Feld für zusätzliche Sprachversionen"
+  "name.langs": {
+    "message": "Sprachen",
+    "description": "Feld für Ausgabesprachen"
   },
   "name.aspect": {
     "message": "Seitenverhältnis",
@@ -51,49 +47,41 @@
     "message": "Dauer",
     "description": "Ziel-Dauerfeld"
   },
-  "name.music": {
-    "message": "Hintergrundmusik",
-    "description": "Feld für den Musikumschalter"
+  "name.remixing": {
+    "message": "Remix",
+    "description": "Label für das Remix-Banner"
   },
-  "option.topic": {
-    "message": "Thema",
-    "description": "Quelltyp: ein Thema/Überschrift"
-  },
-  "option.article": {
-    "message": "Artikel",
-    "description": "Quelltyp: vollständiger Artikeltext"
-  },
-  "placeholder.sourceRef": {
-    "message": "Geben Sie ein Thema ein (z.B. „Was ist eine Vektordatenbank“) oder fügen Sie einen gesamten Artikel ein…",
-    "description": "Platzhalter für den Quelltextbereich"
+  "placeholder.prompt": {
+    "message": "Beschreiben Sie das Video, das Sie möchten – Thema, was gezeigt werden soll, Stil, Zielgruppe…",
+    "description": "Platzhalter für das Eingabefeld"
   },
   "placeholder.select": {
     "message": "Bitte auswählen",
     "description": "Allgemeiner Platzhalter für Auswahl"
   },
-  "description.sourceRef": {
-    "message": "Ein Thema/Titel oder der gesamte Text eines Artikels, der in ein Video umgewandelt werden soll.",
-    "description": "Hilfestellung für das Quellfeld"
+  "description.prompt": {
+    "message": "Formulieren Sie klar, was Sie möchten. Skript, Bilder, Sprachübertragung und Schnitt übernimmt Maestro.",
+    "description": "Hilfe zum Eingabefeld"
   },
-  "description.extraLangs": {
-    "message": "Wiederverwendung des Bildes, zusätzliche Ausgaben in diesen Sprachversionen (jeweils +6 Punkte).",
-    "description": "Hilfestellung für zusätzliche Sprachen"
+  "description.langs": {
+    "message": "Kann in einer oder mehreren Sprachen ausgegeben werden, jede zusätzliche Sprache verwendet dasselbe Bild, nur zusätzliche Sprachübertragung (jede zusätzliche +6 Punkte).",
+    "description": "Hilfe zu Sprachen"
+  },
+  "description.files": {
+    "message": "Optional. Laden Sie Bilder, Videos oder Audios für Maestro hoch (z. B. Produktbilder, Logos).",
+    "description": "Hilfe zu Dateien"
   },
   "status.pending": {
     "message": "In der Warteschlange",
     "description": "Ausstehend"
   },
-  "status.scripting": {
-    "message": "Skripterstellung läuft",
-    "description": "Skripting"
+  "status.planning": {
+    "message": "In Planung",
+    "description": "Planung"
   },
-  "status.generating": {
-    "message": "Generierung läuft",
-    "description": "Wird generiert"
-  },
-  "status.rendering": {
-    "message": "Wird gerendert",
-    "description": "Wird gerendert"
+  "status.producing": {
+    "message": "In Produktion",
+    "description": "Produktion"
   },
   "status.processing": {
     "message": "Wird verarbeitet",
@@ -107,9 +95,17 @@
     "message": "Video herunterladen",
     "description": "Download-Button für Videos"
   },
-  "button.downloadCaptions": {
-    "message": "Untertitel herunterladen",
-    "description": "Download-Button für srt-Dateien"
+  "button.uploadFiles": {
+    "message": "Dateien hochladen",
+    "description": "Schaltfläche zum Hochladen von Referenzdateien"
+  },
+  "button.remix": {
+    "message": "Remix",
+    "description": "Schaltfläche zum Remixen dieses Videos"
+  },
+  "button.cancelRemix": {
+    "message": "Remix abbrechen",
+    "description": "Schaltfläche zum Abbrechen des Remixes"
   },
   "message.startingTask": {
     "message": "Videoaufgabe wird eingereicht…",
@@ -127,12 +123,80 @@
     "message": "Kontingent erschöpft, bitte aufladen, um fortzufahren.",
     "description": "Kontingent aufgebraucht"
   },
-  "message.downloadVideo": {
-    "message": "Herunterladen des generierten Videos",
-    "description": "Tooltip für den Download"
+  "message.remixLoaded": {
+    "message": "Remix geladen – beschreiben Sie links die gewünschten Änderungen und generieren Sie dann.",
+    "description": "Toast-Nachricht für geladenen Remix"
+  },
+  "message.uploadExceed": {
+    "message": "Zu viele Dateien, bitte löschen Sie einige und versuchen Sie es erneut.",
+    "description": "Überschreitung der Upload-Grenze"
+  },
+  "message.uploadError": {
+    "message": "Hochladen fehlgeschlagen, bitte erneut versuchen.",
+    "description": "Fehler beim Hochladen"
   },
   "message.noTasks": {
     "message": "Noch keine Videos — erstelle dein erstes auf der linken Seite.",
     "description": "Keine Aufgaben vorhanden"
+  },
+  "name.sourceType": {
+    "message": "Quelltyp",
+    "description": "Feld für den Quelltyp"
+  },
+  "name.sourceRef": {
+    "message": "Inhalt",
+    "description": "Feld für den Quellinhalt"
+  },
+  "name.lang": {
+    "message": "Hauptsprache",
+    "description": "Feld für die primäre Sprache"
+  },
+  "name.extraLangs": {
+    "message": "Zusätzliche Sprachen",
+    "description": "Feld für zusätzliche Sprachversionen"
+  },
+  "name.music": {
+    "message": "Hintergrundmusik",
+    "description": "Feld für den Musikumschalter"
+  },
+  "option.topic": {
+    "message": "Thema",
+    "description": "Quelltyp: ein Thema/Überschrift"
+  },
+  "option.article": {
+    "message": "Artikel",
+    "description": "Quelltyp: vollständiger Artikeltext"
+  },
+  "placeholder.sourceRef": {
+    "message": "Geben Sie ein Thema ein (z.B. „Was ist eine Vektordatenbank“) oder fügen Sie einen gesamten Artikel ein…",
+    "description": "Platzhalter für den Quelltextbereich"
+  },
+  "description.sourceRef": {
+    "message": "Ein Thema/Titel oder der gesamte Text eines Artikels, der in ein Video umgewandelt werden soll.",
+    "description": "Hilfestellung für das Quellfeld"
+  },
+  "description.extraLangs": {
+    "message": "Wiederverwendung des Bildes, zusätzliche Ausgaben in diesen Sprachversionen (jeweils +6 Punkte).",
+    "description": "Hilfestellung für zusätzliche Sprachen"
+  },
+  "status.scripting": {
+    "message": "Skripterstellung läuft",
+    "description": "Skripting"
+  },
+  "status.generating": {
+    "message": "Generierung läuft",
+    "description": "Wird generiert"
+  },
+  "status.rendering": {
+    "message": "Wird gerendert",
+    "description": "Wird gerendert"
+  },
+  "button.downloadCaptions": {
+    "message": "Untertitel herunterladen",
+    "description": "Download-Button für srt-Dateien"
+  },
+  "message.downloadVideo": {
+    "message": "Herunterladen des generierten Videos",
+    "description": "Tooltip für den Download"
   }
 }

--- a/src/i18n/el/maestro.json
+++ b/src/i18n/el/maestro.json
@@ -27,21 +27,17 @@
     "message": "Λόγος αποτυχίας",
     "description": "Λόγος αποτυχίας"
   },
-  "name.sourceType": {
-    "message": "Τύπος πηγής",
-    "description": "Πεδίο τύπου πηγής"
+  "name.prompt": {
+    "message": "Προτροπή",
+    "description": "Πεδίο προτροπής"
   },
-  "name.sourceRef": {
-    "message": "Περιεχόμενο",
-    "description": "Πεδίο περιεχομένου πηγής"
+  "name.files": {
+    "message": "Υλικά αναφοράς",
+    "description": "Πεδίο αναφοράς μέσων"
   },
-  "name.lang": {
-    "message": "Κύρια γλώσσα",
-    "description": "Πεδίο κύριας γλώσσας"
-  },
-  "name.extraLangs": {
-    "message": "Επιπλέον γλώσσες",
-    "description": "Πεδίο επιπλέον γλωσσικών εκδόσεων"
+  "name.langs": {
+    "message": "Γλώσσες",
+    "description": "Πεδίο εξαγωγής γλωσσών"
   },
   "name.aspect": {
     "message": "Αναλογία εικόνας",
@@ -51,49 +47,41 @@
     "message": "Διάρκεια",
     "description": "Πεδίο στοχευόμενης διάρκειας"
   },
-  "name.music": {
-    "message": "Μουσική υπόκρουση",
-    "description": "Πεδίο εναλλαγής μουσικής"
+  "name.remixing": {
+    "message": "Επαναδημιουργία",
+    "description": "Ετικέτα banner επαναδημιουργίας"
   },
-  "option.topic": {
-    "message": "Θέμα",
-    "description": "Τύπος πηγής: ένα θέμα/τίτλος"
-  },
-  "option.article": {
-    "message": "Άρθρο",
-    "description": "Τύπος πηγής: πλήρες κείμενο άρθρου"
-  },
-  "placeholder.sourceRef": {
-    "message": "Εισάγετε ένα θέμα (π.χ. “Τι είναι η βάση δεδομένων διανυσμάτων”) ή επικολλήστε ολόκληρο το άρθρο…",
-    "description": "Placeholder για textarea πηγής"
+  "placeholder.prompt": {
+    "message": "Περιγράψτε το βίντεο που θέλετε — θέμα, τι να δείξει, στυλ, κοινό…",
+    "description": "Placeholder για το textarea προτροπής"
   },
   "placeholder.select": {
     "message": "Επιλέξτε",
     "description": "Γενικό placeholder επιλογής"
   },
-  "description.sourceRef": {
-    "message": "Ένα θέμα/τίτλος ή το πλήρες κείμενο του άρθρου που θέλετε να κάνετε βίντεο.",
-    "description": "Βοήθεια για το πεδίο πηγής"
+  "description.prompt": {
+    "message": "Πες με απλά λόγια τι θέλεις, το σενάριο, τις εικόνες, τη φωνητική, το μοντάζ τα αναλαμβάνει ο Maestro.",
+    "description": "Βοήθεια για το πεδίο προτροπής"
   },
-  "description.extraLangs": {
-    "message": "Επαναχρησιμοποίηση εικόνας, επιπλέον παραγωγή αυτών των γλωσσών (κάθε μία +6 πόντους).",
-    "description": "Βοήθεια για επιπλέον γλώσσες"
+  "description.langs": {
+    "message": "Μπορεί να εξάγει μία ή περισσότερες γλώσσες, για κάθε επιπλέον γλώσσα επαναχρησιμοποιεί την εικόνα και προσθέτει μόνο φωνητική (κάθε επιπλέον +6 πόντοι).",
+    "description": "Βοήθεια για γλώσσες"
+  },
+  "description.files": {
+    "message": "Προαιρετικό. Ανέβασε εικόνες, βίντεο ή ήχο για χρήση από τον Maestro (όπως εικόνες προϊόντων, λογότυπα).",
+    "description": "Βοήθεια για αρχεία"
   },
   "status.pending": {
     "message": "Σε αναμονή",
     "description": "Σε αναμονή"
   },
-  "status.scripting": {
-    "message": "Δημιουργία σεναρίου σε εξέλιξη",
-    "description": "Δημιουργία σεναρίου"
+  "status.planning": {
+    "message": "Σε σχεδίαση",
+    "description": "Σχεδίαση"
   },
-  "status.generating": {
-    "message": "Δημιουργία σε εξέλιξη",
-    "description": "Δημιουργία"
-  },
-  "status.rendering": {
-    "message": "Απεικόνιση σε εξέλιξη",
-    "description": "Απεικόνιση"
+  "status.producing": {
+    "message": "Σε παραγωγή",
+    "description": "Παραγωγή"
   },
   "status.processing": {
     "message": "Επεξεργασία σε εξέλιξη",
@@ -107,9 +95,17 @@
     "message": "Κατέβασμα βίντεο",
     "description": "Κουμπί για κατέβασμα βίντεο"
   },
-  "button.downloadCaptions": {
-    "message": "Κατέβασμα υποτίτλων",
-    "description": "Κουμπί για κατέβασμα srt"
+  "button.uploadFiles": {
+    "message": "Ανέβασμα αρχείων",
+    "description": "Κουμπί ανέβασμα αναφοράς αρχείων"
+  },
+  "button.remix": {
+    "message": "Επαναδημιουργία",
+    "description": "Κουμπί επαναδημιουργίας αυτού του βίντεο"
+  },
+  "button.cancelRemix": {
+    "message": "Ακύρωση επαναδημιουργίας",
+    "description": "Κουμπί ακύρωσης επαναδημιουργίας"
   },
   "message.startingTask": {
     "message": "Υποβάλλεται η εργασία βίντεο…",
@@ -127,12 +123,80 @@
     "message": "Η πιστωτική σας ποσότητα έχει εξαντληθεί, παρακαλώ ανανεώστε για να συνεχίσετε.",
     "description": "Εξαντλημένο"
   },
-  "message.downloadVideo": {
-    "message": "Κατέβασμα του παραγόμενου βίντεο",
-    "description": "Tooltip για κατέβασμα"
+  "message.remixLoaded": {
+    "message": "Η επαναδημιουργία έχει φορτωθεί — περιγράψτε τις επιθυμητές αλλαγές στα αριστερά και στη συνέχεια δημιουργήστε.",
+    "description": "Toast που δείχνει ότι η επαναδημιουργία έχει φορτωθεί"
+  },
+  "message.uploadExceed": {
+    "message": "Πάρα πολλά αρχεία, παρακαλώ διαγράψτε μερικά και δοκιμάστε ξανά.",
+    "description": "Υπέρβαση ανέβασμα"
+  },
+  "message.uploadError": {
+    "message": "Η ανέβασμα απέτυχε, παρακαλώ δοκιμάστε ξανά.",
+    "description": "Σφάλμα ανέβασμα"
   },
   "message.noTasks": {
     "message": "Δεν υπάρχουν βίντεο — Δημιουργήστε το πρώτο σας αριστερά.",
     "description": "Χωρίς εργασίες"
+  },
+  "name.sourceType": {
+    "message": "Τύπος πηγής",
+    "description": "Πεδίο τύπου πηγής"
+  },
+  "name.sourceRef": {
+    "message": "Περιεχόμενο",
+    "description": "Πεδίο περιεχομένου πηγής"
+  },
+  "name.lang": {
+    "message": "Κύρια γλώσσα",
+    "description": "Πεδίο κύριας γλώσσας"
+  },
+  "name.extraLangs": {
+    "message": "Επιπλέον γλώσσες",
+    "description": "Πεδίο επιπλέον γλωσσικών εκδόσεων"
+  },
+  "name.music": {
+    "message": "Μουσική υπόκρουση",
+    "description": "Πεδίο εναλλαγής μουσικής"
+  },
+  "option.topic": {
+    "message": "Θέμα",
+    "description": "Τύπος πηγής: ένα θέμα/τίτλος"
+  },
+  "option.article": {
+    "message": "Άρθρο",
+    "description": "Τύπος πηγής: πλήρες κείμενο άρθρου"
+  },
+  "placeholder.sourceRef": {
+    "message": "Εισάγετε ένα θέμα (π.χ. “Τι είναι η βάση δεδομένων διανυσμάτων”) ή επικολλήστε ολόκληρο το άρθρο…",
+    "description": "Placeholder για textarea πηγής"
+  },
+  "description.sourceRef": {
+    "message": "Ένα θέμα/τίτλος ή το πλήρες κείμενο του άρθρου που θέλετε να κάνετε βίντεο.",
+    "description": "Βοήθεια για το πεδίο πηγής"
+  },
+  "description.extraLangs": {
+    "message": "Επαναχρησιμοποίηση εικόνας, επιπλέον παραγωγή αυτών των γλωσσών (κάθε μία +6 πόντους).",
+    "description": "Βοήθεια για επιπλέον γλώσσες"
+  },
+  "status.scripting": {
+    "message": "Δημιουργία σεναρίου σε εξέλιξη",
+    "description": "Δημιουργία σεναρίου"
+  },
+  "status.generating": {
+    "message": "Δημιουργία σε εξέλιξη",
+    "description": "Δημιουργία"
+  },
+  "status.rendering": {
+    "message": "Απεικόνιση σε εξέλιξη",
+    "description": "Απεικόνιση"
+  },
+  "button.downloadCaptions": {
+    "message": "Κατέβασμα υποτίτλων",
+    "description": "Κουμπί για κατέβασμα srt"
+  },
+  "message.downloadVideo": {
+    "message": "Κατέβασμα του παραγόμενου βίντεο",
+    "description": "Tooltip για κατέβασμα"
   }
 }

--- a/src/i18n/en/maestro.json
+++ b/src/i18n/en/maestro.json
@@ -27,21 +27,17 @@
     "message": "Failure Reason",
     "description": "Failure reason"
   },
-  "name.sourceType": {
-    "message": "Source",
-    "description": "Source type field"
+  "name.prompt": {
+    "message": "Prompt",
+    "description": "Prompt field"
   },
-  "name.sourceRef": {
-    "message": "Content",
-    "description": "Source content field"
+  "name.files": {
+    "message": "Reference Files",
+    "description": "Reference media field"
   },
-  "name.lang": {
-    "message": "Main Language",
-    "description": "Primary language field"
-  },
-  "name.extraLangs": {
-    "message": "Extra Languages",
-    "description": "Extra language versions field"
+  "name.langs": {
+    "message": "Languages",
+    "description": "Output languages field"
   },
   "name.aspect": {
     "message": "Aspect Ratio",
@@ -51,49 +47,41 @@
     "message": "Duration",
     "description": "Target duration field"
   },
-  "name.music": {
-    "message": "Background Music",
-    "description": "Music toggle field"
+  "name.remixing": {
+    "message": "Remixing",
+    "description": "Remix banner label"
   },
-  "option.topic": {
-    "message": "Topic",
-    "description": "Source type: a topic/headline"
-  },
-  "option.article": {
-    "message": "Article",
-    "description": "Source type: full article text"
-  },
-  "placeholder.sourceRef": {
-    "message": "Paste a topic (e.g. “What is a vector database”) or a full article…",
-    "description": "Source textarea placeholder"
+  "placeholder.prompt": {
+    "message": "Describe the video you want — topic, what to show, tone, audience…",
+    "description": "Prompt textarea placeholder"
   },
   "placeholder.select": {
     "message": "Please select",
     "description": "Generic select placeholder"
   },
-  "description.sourceRef": {
-    "message": "A topic/headline, or the full article text to turn into a video.",
-    "description": "Source field help"
+  "description.prompt": {
+    "message": "Say what you want in plain language — Maestro plans the script, visuals, voiceover and edit.",
+    "description": "Prompt field help"
   },
-  "description.extraLangs": {
-    "message": "Reuse the visuals to also produce these languages (+6 credits each).",
-    "description": "Extra langs help"
+  "description.langs": {
+    "message": "Output one or more languages. Each extra language reuses the visuals with a localized voiceover (+6 credits each).",
+    "description": "Languages help"
+  },
+  "description.files": {
+    "message": "Optional. Attach images, video or audio for Maestro to use (e.g. a product shot or logo).",
+    "description": "Files help"
   },
   "status.pending": {
     "message": "Pending",
     "description": "Pending"
   },
-  "status.scripting": {
-    "message": "Scripting",
-    "description": "Scripting"
+  "status.planning": {
+    "message": "Planning",
+    "description": "Planning"
   },
-  "status.generating": {
-    "message": "Generating",
-    "description": "Generating"
-  },
-  "status.rendering": {
-    "message": "Rendering",
-    "description": "Rendering"
+  "status.producing": {
+    "message": "Producing",
+    "description": "Producing"
   },
   "status.processing": {
     "message": "Processing",
@@ -107,9 +95,17 @@
     "message": "Download Video",
     "description": "Download video button"
   },
-  "button.downloadCaptions": {
-    "message": "Download Captions",
-    "description": "Download srt button"
+  "button.uploadFiles": {
+    "message": "Upload Files",
+    "description": "Upload reference files button"
+  },
+  "button.remix": {
+    "message": "Remix",
+    "description": "Remix this video button"
+  },
+  "button.cancelRemix": {
+    "message": "Cancel remix",
+    "description": "Cancel remix button"
   },
   "message.startingTask": {
     "message": "Submitting your video task…",
@@ -127,9 +123,17 @@
     "message": "Your quota is used up. Please top up to continue.",
     "description": "Used up"
   },
-  "message.downloadVideo": {
-    "message": "Download the generated video",
-    "description": "Download tooltip"
+  "message.remixLoaded": {
+    "message": "Loaded for remix — describe your change on the left, then generate.",
+    "description": "Remix loaded toast"
+  },
+  "message.uploadExceed": {
+    "message": "Too many files. Please remove some and try again.",
+    "description": "Upload exceed"
+  },
+  "message.uploadError": {
+    "message": "Upload failed. Please try again.",
+    "description": "Upload error"
   },
   "message.noTasks": {
     "message": "No videos yet — create your first one on the left.",

--- a/src/i18n/es/maestro.json
+++ b/src/i18n/es/maestro.json
@@ -27,21 +27,17 @@
     "message": "Razón del fallo",
     "description": "Razón del fallo"
   },
-  "name.sourceType": {
-    "message": "Tipo de origen",
-    "description": "Campo de tipo de origen"
+  "name.prompt": {
+    "message": "Palabra clave",
+    "description": "Campo de solicitud"
   },
-  "name.sourceRef": {
-    "message": "Contenido",
-    "description": "Campo de contenido de origen"
+  "name.files": {
+    "message": "Material de referencia",
+    "description": "Campo para medios de referencia"
   },
-  "name.lang": {
-    "message": "Idioma principal",
-    "description": "Campo de idioma principal"
-  },
-  "name.extraLangs": {
-    "message": "Idiomas adicionales",
-    "description": "Campo de versiones en idiomas adicionales"
+  "name.langs": {
+    "message": "Idiomas",
+    "description": "Campo para idiomas de salida"
   },
   "name.aspect": {
     "message": "Relación de aspecto",
@@ -51,49 +47,41 @@
     "message": "Duración",
     "description": "Campo de duración objetivo"
   },
-  "name.music": {
-    "message": "Música de fondo",
-    "description": "Campo de alternar música"
+  "name.remixing": {
+    "message": "Rehacer",
+    "description": "Etiqueta del banner de remezcla"
   },
-  "option.topic": {
-    "message": "Tema",
-    "description": "Tipo de fuente: un tema/título"
-  },
-  "option.article": {
-    "message": "Artículo",
-    "description": "Tipo de fuente: texto completo del artículo"
-  },
-  "placeholder.sourceRef": {
-    "message": "Ingrese un tema (como “¿Qué es una base de datos vectorial?”) o pegue un artículo completo...",
-    "description": "Marcador de posición para el área de texto de la fuente"
+  "placeholder.prompt": {
+    "message": "Describe el video que deseas — tema, qué mostrar, estilo, audiencia…",
+    "description": "Placeholder para el área de texto de solicitud"
   },
   "placeholder.select": {
     "message": "Seleccione",
     "description": "Marcador de posición genérico para selección"
   },
-  "description.sourceRef": {
-    "message": "Un tema/título, o el texto completo de un artículo que se va a convertir en video.",
-    "description": "Ayuda sobre el campo de origen"
+  "description.prompt": {
+    "message": "Explica claramente lo que deseas en términos simples; deja el guion, las imágenes, la voz en off y la edición a Maestro.",
+    "description": "Ayuda sobre el campo de solicitud"
   },
-  "description.extraLangs": {
-    "message": "Reutilizar la imagen, generar estas versiones en idiomas adicionales (cada una +6 puntos).",
-    "description": "Ayuda sobre idiomas adicionales"
+  "description.langs": {
+    "message": "Puedes exportar en uno o más idiomas, reutilizando la misma imagen y solo agregando voz en off (cada idioma adicional +6 puntos).",
+    "description": "Ayuda sobre idiomas"
+  },
+  "description.files": {
+    "message": "Opcional. Sube imágenes, videos o audios para que los use Maestro (como imágenes de productos, logotipos).",
+    "description": "Ayuda sobre archivos"
   },
   "status.pending": {
     "message": "En cola",
     "description": "Pendiente"
   },
-  "status.scripting": {
-    "message": "Generando script",
-    "description": "Generando script"
+  "status.planning": {
+    "message": "En planificación",
+    "description": "Planificación"
   },
-  "status.generating": {
-    "message": "Generando",
-    "description": "Generando"
-  },
-  "status.rendering": {
-    "message": "Renderizando",
-    "description": "Renderizando"
+  "status.producing": {
+    "message": "En producción",
+    "description": "Producción"
   },
   "status.processing": {
     "message": "Procesando",
@@ -107,9 +95,17 @@
     "message": "Descargar video",
     "description": "Botón para descargar video"
   },
-  "button.downloadCaptions": {
-    "message": "Descargar subtítulos",
-    "description": "Botón para descargar srt"
+  "button.uploadFiles": {
+    "message": "Subir archivos",
+    "description": "Botón para subir archivos de referencia"
+  },
+  "button.remix": {
+    "message": "Rehacer",
+    "description": "Botón para rehacer este video"
+  },
+  "button.cancelRemix": {
+    "message": "Cancelar remix",
+    "description": "Botón para cancelar la remezcla"
   },
   "message.startingTask": {
     "message": "Enviando tarea de video…",
@@ -127,12 +123,80 @@
     "message": "Límite alcanzado, por favor recarga para continuar.",
     "description": "Agotado"
   },
-  "message.downloadVideo": {
-    "message": "Descargar el video generado",
-    "description": "Tooltip de descarga"
+  "message.remixLoaded": {
+    "message": "Rehacer cargado — describe los cambios deseados a la izquierda y luego genera.",
+    "description": "Notificación de remezcla cargada"
+  },
+  "message.uploadExceed": {
+    "message": "Demasiados archivos, por favor elimina algunos e intenta de nuevo.",
+    "description": "Exceso de carga"
+  },
+  "message.uploadError": {
+    "message": "Error al subir, por favor intenta de nuevo.",
+    "description": "Error de carga"
   },
   "message.noTasks": {
     "message": "No hay videos aún — crea el tuyo primero a la izquierda.",
     "description": "Sin tareas"
+  },
+  "name.sourceType": {
+    "message": "Tipo de origen",
+    "description": "Campo de tipo de origen"
+  },
+  "name.sourceRef": {
+    "message": "Contenido",
+    "description": "Campo de contenido de origen"
+  },
+  "name.lang": {
+    "message": "Idioma principal",
+    "description": "Campo de idioma principal"
+  },
+  "name.extraLangs": {
+    "message": "Idiomas adicionales",
+    "description": "Campo de versiones en idiomas adicionales"
+  },
+  "name.music": {
+    "message": "Música de fondo",
+    "description": "Campo de alternar música"
+  },
+  "option.topic": {
+    "message": "Tema",
+    "description": "Tipo de fuente: un tema/título"
+  },
+  "option.article": {
+    "message": "Artículo",
+    "description": "Tipo de fuente: texto completo del artículo"
+  },
+  "placeholder.sourceRef": {
+    "message": "Ingrese un tema (como “¿Qué es una base de datos vectorial?”) o pegue un artículo completo...",
+    "description": "Marcador de posición para el área de texto de la fuente"
+  },
+  "description.sourceRef": {
+    "message": "Un tema/título, o el texto completo de un artículo que se va a convertir en video.",
+    "description": "Ayuda sobre el campo de origen"
+  },
+  "description.extraLangs": {
+    "message": "Reutilizar la imagen, generar estas versiones en idiomas adicionales (cada una +6 puntos).",
+    "description": "Ayuda sobre idiomas adicionales"
+  },
+  "status.scripting": {
+    "message": "Generando script",
+    "description": "Generando script"
+  },
+  "status.generating": {
+    "message": "Generando",
+    "description": "Generando"
+  },
+  "status.rendering": {
+    "message": "Renderizando",
+    "description": "Renderizando"
+  },
+  "button.downloadCaptions": {
+    "message": "Descargar subtítulos",
+    "description": "Botón para descargar srt"
+  },
+  "message.downloadVideo": {
+    "message": "Descargar el video generado",
+    "description": "Tooltip de descarga"
   }
 }

--- a/src/i18n/fi/maestro.json
+++ b/src/i18n/fi/maestro.json
@@ -27,21 +27,17 @@
     "message": "Epäonnistumisen syy",
     "description": "Epäonnistumisen syy"
   },
-  "name.sourceType": {
-    "message": "Lähteen tyyppi",
-    "description": "Lähteen tyyppi kenttä"
+  "name.prompt": {
+    "message": "Vihje",
+    "description": "Prompt-kenttä"
   },
-  "name.sourceRef": {
-    "message": "Sisältö",
-    "description": "Lähdesisältö kenttä"
+  "name.files": {
+    "message": "Viitemateriaali",
+    "description": "Viitemedia-kenttä"
   },
-  "name.lang": {
-    "message": "Pääkieli",
-    "description": "Pääkieli kenttä"
-  },
-  "name.extraLangs": {
-    "message": "Lisäkielet",
-    "description": "Lisäkieliversiot kenttä"
+  "name.langs": {
+    "message": "Kielet",
+    "description": "Tuotettavat kielet -kenttä"
   },
   "name.aspect": {
     "message": "Kuvan suhde",
@@ -51,49 +47,41 @@
     "message": "Kesto",
     "description": "Tavoitekesto kenttä"
   },
-  "name.music": {
-    "message": "Taustamusiikki",
-    "description": "Musiikin kytkentäkenttä"
+  "name.remixing": {
+    "message": "Remix",
+    "description": "Remix-bannerin etiketti"
   },
-  "option.topic": {
-    "message": "Aihe",
-    "description": "Lähdetyyppi: aihe/otsikko"
-  },
-  "option.article": {
-    "message": "Artikkeli",
-    "description": "Lähdetyyppi: koko artikkelin teksti"
-  },
-  "placeholder.sourceRef": {
-    "message": "Syötä aihe (esim. “Mikä on vektoritietokanta”) tai liitä koko artikkeli…",
-    "description": "Lähdetekstin tekstikentän paikkamerkki"
+  "placeholder.prompt": {
+    "message": "Kuvaile haluamaasi videota - teema, mitä esitellään, tyyli, kohdeyleisö...",
+    "description": "Prompt-tekstialueen paikkamerkki"
   },
   "placeholder.select": {
     "message": "Valitse",
     "description": "Yleinen valintapaikka"
   },
-  "description.sourceRef": {
-    "message": "Yksi aihe/otsikko tai koko artikkelin sisältö, joka tehdään videoksi.",
-    "description": "Lähde kenttä apu"
+  "description.prompt": {
+    "message": "Kerro selkeästi, mitä haluat, käsikirjoitus, kuvat, äänitys ja leikkaus ovat Maestroa varten.",
+    "description": "Prompt-kenttä help"
   },
-  "description.extraLangs": {
-    "message": "Uudelleenkäytä kuvaa, tuota nämä kieliversiot (jokaisesta +6 pistettä).",
-    "description": "Lisäkieliversiot apu"
+  "description.langs": {
+    "message": "Voit tuottaa yhden tai useamman kielen, jokaisesta lisäkielestä käytetään samaa kuvaa, vain lisää äänitys (jokaisesta lisäkielestä +6 pistettä).",
+    "description": "Kielet help"
+  },
+  "description.files": {
+    "message": "Valinnainen. Lataa kuvia, videoita tai ääntä Maestroa varten (esim. tuotekuvat, logo).",
+    "description": "Tiedostot help"
   },
   "status.pending": {
     "message": "Jonossa",
     "description": "Odottaa"
   },
-  "status.scripting": {
-    "message": "Skriptiä luodaan",
-    "description": "Skriptiä luodaan"
+  "status.planning": {
+    "message": "Suunnittelussa",
+    "description": "Suunnittelu"
   },
-  "status.generating": {
-    "message": "Kuvaa luodaan",
-    "description": "Luodaan"
-  },
-  "status.rendering": {
-    "message": "Renderöidään",
-    "description": "Renderöidään"
+  "status.producing": {
+    "message": "Tuotannossa",
+    "description": "Tuotanto"
   },
   "status.processing": {
     "message": "Käsitellään",
@@ -107,9 +95,17 @@
     "message": "Lataa video",
     "description": "Lataa video -painike"
   },
-  "button.downloadCaptions": {
-    "message": "Lataa tekstitykset",
-    "description": "Lataa srt -painike"
+  "button.uploadFiles": {
+    "message": "Lataa tiedostot",
+    "description": "Lataa viitetiedostot -painike"
+  },
+  "button.remix": {
+    "message": "Remix",
+    "description": "Remixaa tämä video -painike"
+  },
+  "button.cancelRemix": {
+    "message": "Peru remix",
+    "description": "Peru remix -painike"
   },
   "message.startingTask": {
     "message": "Videotehtävää lähetetään…",
@@ -127,12 +123,80 @@
     "message": "Käyttöoikeus on käytetty loppuun, lataa lisää jatkaaksesi.",
     "description": "Käyttö loppu"
   },
-  "message.downloadVideo": {
-    "message": "Lataa tuotettu video",
-    "description": "Lataus työkaluvihje"
+  "message.remixLoaded": {
+    "message": "Remix ladattu - kuvaile vasemmalla haluamasi muutokset ja luo.",
+    "description": "Remix ladattu toast"
+  },
+  "message.uploadExceed": {
+    "message": "Liian monta tiedostoa, poista joitakin ja yritä uudelleen.",
+    "description": "Lataus ylittää rajan"
+  },
+  "message.uploadError": {
+    "message": "Lataus epäonnistui, yritä uudelleen.",
+    "description": "Latausvirhe"
   },
   "message.noTasks": {
     "message": "Ei vielä videoita — luo ensimmäinen vasemmalla.",
     "description": "Ei tehtäviä"
+  },
+  "name.sourceType": {
+    "message": "Lähteen tyyppi",
+    "description": "Lähteen tyyppi kenttä"
+  },
+  "name.sourceRef": {
+    "message": "Sisältö",
+    "description": "Lähdesisältö kenttä"
+  },
+  "name.lang": {
+    "message": "Pääkieli",
+    "description": "Pääkieli kenttä"
+  },
+  "name.extraLangs": {
+    "message": "Lisäkielet",
+    "description": "Lisäkieliversiot kenttä"
+  },
+  "name.music": {
+    "message": "Taustamusiikki",
+    "description": "Musiikin kytkentäkenttä"
+  },
+  "option.topic": {
+    "message": "Aihe",
+    "description": "Lähdetyyppi: aihe/otsikko"
+  },
+  "option.article": {
+    "message": "Artikkeli",
+    "description": "Lähdetyyppi: koko artikkelin teksti"
+  },
+  "placeholder.sourceRef": {
+    "message": "Syötä aihe (esim. “Mikä on vektoritietokanta”) tai liitä koko artikkeli…",
+    "description": "Lähdetekstin tekstikentän paikkamerkki"
+  },
+  "description.sourceRef": {
+    "message": "Yksi aihe/otsikko tai koko artikkelin sisältö, joka tehdään videoksi.",
+    "description": "Lähde kenttä apu"
+  },
+  "description.extraLangs": {
+    "message": "Uudelleenkäytä kuvaa, tuota nämä kieliversiot (jokaisesta +6 pistettä).",
+    "description": "Lisäkieliversiot apu"
+  },
+  "status.scripting": {
+    "message": "Skriptiä luodaan",
+    "description": "Skriptiä luodaan"
+  },
+  "status.generating": {
+    "message": "Kuvaa luodaan",
+    "description": "Luodaan"
+  },
+  "status.rendering": {
+    "message": "Renderöidään",
+    "description": "Renderöidään"
+  },
+  "button.downloadCaptions": {
+    "message": "Lataa tekstitykset",
+    "description": "Lataa srt -painike"
+  },
+  "message.downloadVideo": {
+    "message": "Lataa tuotettu video",
+    "description": "Lataus työkaluvihje"
   }
 }

--- a/src/i18n/fr/maestro.json
+++ b/src/i18n/fr/maestro.json
@@ -27,21 +27,17 @@
     "message": "Raison de l'échec",
     "description": "Raison de l'échec"
   },
-  "name.sourceType": {
-    "message": "Type de source",
-    "description": "Champ de type de source"
+  "name.prompt": {
+    "message": "Mot-clé",
+    "description": "Champ de prompt"
   },
-  "name.sourceRef": {
-    "message": "Contenu",
-    "description": "Champ de contenu source"
+  "name.files": {
+    "message": "Matériel de référence",
+    "description": "Champ pour les médias de référence"
   },
-  "name.lang": {
-    "message": "Langue principale",
-    "description": "Champ de langue principale"
-  },
-  "name.extraLangs": {
-    "message": "Langues supplémentaires",
-    "description": "Champ des versions linguistiques supplémentaires"
+  "name.langs": {
+    "message": "Langues",
+    "description": "Champ pour les langues de sortie"
   },
   "name.aspect": {
     "message": "Ratio d'aspect",
@@ -51,49 +47,41 @@
     "message": "Durée",
     "description": "Champ de durée cible"
   },
-  "name.music": {
-    "message": "Musique de fond",
-    "description": "Champ de bascule de musique"
+  "name.remixing": {
+    "message": "Remixage",
+    "description": "Étiquette de la bannière de remix"
   },
-  "option.topic": {
-    "message": "Sujet",
-    "description": "Type de source : un sujet/titre"
-  },
-  "option.article": {
-    "message": "Article",
-    "description": "Type de source : texte complet de l'article"
-  },
-  "placeholder.sourceRef": {
-    "message": "Entrez un sujet (comme « Qu'est-ce qu'une base de données vectorielle ») ou collez l'article complet…",
-    "description": "Espace réservé pour la zone de texte source"
+  "placeholder.prompt": {
+    "message": "Décrivez la vidéo que vous souhaitez - sujet, ce que vous voulez montrer, style, public...",
+    "description": "Espace réservé pour le champ de prompt"
   },
   "placeholder.select": {
     "message": "Veuillez sélectionner",
     "description": "Espace réservé générique pour la sélection"
   },
-  "description.sourceRef": {
-    "message": "Un sujet/titre ou le texte complet d'un article à transformer en vidéo.",
-    "description": "Aide pour le champ source"
+  "description.prompt": {
+    "message": "Exprimez clairement ce que vous voulez en termes simples, le script, les images, le doublage et le montage sont gérés par Maestro.",
+    "description": "Aide sur le champ de prompt"
   },
-  "description.extraLangs": {
-    "message": "Réutiliser l'image, produire ces versions linguistiques supplémentaires (chaque +6 points).",
-    "description": "Aide pour les langues supplémentaires"
+  "description.langs": {
+    "message": "Peut sortir une ou plusieurs langues, chaque langue supplémentaire réutilise l'image, uniquement le doublage supplémentaire (chaque langue supplémentaire +6 points).",
+    "description": "Aide sur les langues"
+  },
+  "description.files": {
+    "message": "Optionnel. Téléchargez des images, vidéos ou audio pour l'utilisation de Maestro (comme des images de produit, logo).",
+    "description": "Aide sur les fichiers"
   },
   "status.pending": {
     "message": "En attente",
     "description": "En attente"
   },
-  "status.scripting": {
-    "message": "Génération de script en cours",
-    "description": "Génération de script"
+  "status.planning": {
+    "message": "En planification",
+    "description": "Planification"
   },
-  "status.generating": {
-    "message": "Génération en cours",
-    "description": "Génération"
-  },
-  "status.rendering": {
-    "message": "Rendu en cours",
-    "description": "Rendu"
+  "status.producing": {
+    "message": "En production",
+    "description": "Production"
   },
   "status.processing": {
     "message": "Traitement en cours",
@@ -107,9 +95,17 @@
     "message": "Télécharger la vidéo",
     "description": "Bouton de téléchargement de vidéo"
   },
-  "button.downloadCaptions": {
-    "message": "Télécharger les sous-titres",
-    "description": "Bouton de téléchargement de srt"
+  "button.uploadFiles": {
+    "message": "Télécharger des fichiers",
+    "description": "Bouton pour télécharger des fichiers de référence"
+  },
+  "button.remix": {
+    "message": "Remixer",
+    "description": "Bouton pour remixer cette vidéo"
+  },
+  "button.cancelRemix": {
+    "message": "Annuler le remix",
+    "description": "Bouton pour annuler le remix"
   },
   "message.startingTask": {
     "message": "Soumission de la tâche vidéo en cours…",
@@ -127,12 +123,80 @@
     "message": "Crédit épuisé, veuillez recharger pour continuer.",
     "description": "Crédit épuisé"
   },
-  "message.downloadVideo": {
-    "message": "Télécharger la vidéo générée",
-    "description": "Infobulle de téléchargement"
+  "message.remixLoaded": {
+    "message": "Remix chargé - décrivez les modifications souhaitées à gauche, puis générez.",
+    "description": "Toast de remix chargé"
+  },
+  "message.uploadExceed": {
+    "message": "Trop de fichiers, veuillez en supprimer quelques-uns puis réessayer.",
+    "description": "Dépassement de téléchargement"
+  },
+  "message.uploadError": {
+    "message": "Échec du téléchargement, veuillez réessayer.",
+    "description": "Erreur de téléchargement"
   },
   "message.noTasks": {
     "message": "Aucune vidéo encore — créez votre première à gauche.",
     "description": "Aucune tâche"
+  },
+  "name.sourceType": {
+    "message": "Type de source",
+    "description": "Champ de type de source"
+  },
+  "name.sourceRef": {
+    "message": "Contenu",
+    "description": "Champ de contenu source"
+  },
+  "name.lang": {
+    "message": "Langue principale",
+    "description": "Champ de langue principale"
+  },
+  "name.extraLangs": {
+    "message": "Langues supplémentaires",
+    "description": "Champ des versions linguistiques supplémentaires"
+  },
+  "name.music": {
+    "message": "Musique de fond",
+    "description": "Champ de bascule de musique"
+  },
+  "option.topic": {
+    "message": "Sujet",
+    "description": "Type de source : un sujet/titre"
+  },
+  "option.article": {
+    "message": "Article",
+    "description": "Type de source : texte complet de l'article"
+  },
+  "placeholder.sourceRef": {
+    "message": "Entrez un sujet (comme « Qu'est-ce qu'une base de données vectorielle ») ou collez l'article complet…",
+    "description": "Espace réservé pour la zone de texte source"
+  },
+  "description.sourceRef": {
+    "message": "Un sujet/titre ou le texte complet d'un article à transformer en vidéo.",
+    "description": "Aide pour le champ source"
+  },
+  "description.extraLangs": {
+    "message": "Réutiliser l'image, produire ces versions linguistiques supplémentaires (chaque +6 points).",
+    "description": "Aide pour les langues supplémentaires"
+  },
+  "status.scripting": {
+    "message": "Génération de script en cours",
+    "description": "Génération de script"
+  },
+  "status.generating": {
+    "message": "Génération en cours",
+    "description": "Génération"
+  },
+  "status.rendering": {
+    "message": "Rendu en cours",
+    "description": "Rendu"
+  },
+  "button.downloadCaptions": {
+    "message": "Télécharger les sous-titres",
+    "description": "Bouton de téléchargement de srt"
+  },
+  "message.downloadVideo": {
+    "message": "Télécharger la vidéo générée",
+    "description": "Infobulle de téléchargement"
   }
 }

--- a/src/i18n/it/maestro.json
+++ b/src/i18n/it/maestro.json
@@ -27,21 +27,17 @@
     "message": "Motivo del fallimento",
     "description": "Motivo del fallimento"
   },
-  "name.sourceType": {
-    "message": "Tipo di sorgente",
-    "description": "Campo per il tipo di sorgente"
+  "name.prompt": {
+    "message": "Parola chiave",
+    "description": "Campo per il prompt"
   },
-  "name.sourceRef": {
-    "message": "Contenuto",
-    "description": "Campo per il contenuto sorgente"
+  "name.files": {
+    "message": "Materiale di riferimento",
+    "description": "Campo per i media di riferimento"
   },
-  "name.lang": {
-    "message": "Lingua principale",
-    "description": "Campo per la lingua primaria"
-  },
-  "name.extraLangs": {
-    "message": "Lingue extra",
-    "description": "Campo per le versioni linguistiche extra"
+  "name.langs": {
+    "message": "Lingue",
+    "description": "Campo per le lingue di output"
   },
   "name.aspect": {
     "message": "Rapporto d'aspetto",
@@ -51,49 +47,41 @@
     "message": "Durata",
     "description": "Campo per la durata target"
   },
-  "name.music": {
-    "message": "Musica di sottofondo",
-    "description": "Campo per attivare/disattivare la musica"
+  "name.remixing": {
+    "message": "Remix",
+    "description": "Etichetta del banner remix"
   },
-  "option.topic": {
-    "message": "Argomento",
-    "description": "Tipo di sorgente: un argomento/titolo"
-  },
-  "option.article": {
-    "message": "Articolo",
-    "description": "Tipo di sorgente: testo completo dell'articolo"
-  },
-  "placeholder.sourceRef": {
-    "message": "Inserisci un argomento (es. “che cos'è un database vettoriale”) o incolla l'intero articolo…",
-    "description": "Segnaposto per il textarea della sorgente"
+  "placeholder.prompt": {
+    "message": "Descrivi il video che desideri — tema, cosa mostrare, stile, pubblico...",
+    "description": "Placeholder per il textarea del prompt"
   },
   "placeholder.select": {
     "message": "Seleziona",
     "description": "Segnaposto generico per la selezione"
   },
-  "description.sourceRef": {
-    "message": "Un argomento/titolo, o il testo completo di un articolo da trasformare in video.",
-    "description": "Aiuto per il campo sorgente"
+  "description.prompt": {
+    "message": "Spiega chiaramente cosa desideri, lascia a Maestro la sceneggiatura, le immagini, il doppiaggio e il montaggio.",
+    "description": "Aiuto sul campo prompt"
   },
-  "description.extraLangs": {
-    "message": "Riutilizza il video, produci queste versioni linguistiche aggiuntive (ogni +6 punti).",
-    "description": "Aiuto per le lingue extra"
+  "description.langs": {
+    "message": "Puoi esportare una o più lingue, ogni lingua aggiuntiva riutilizza le immagini e aggiunge solo il doppiaggio (ogni lingua aggiuntiva +6 punti).",
+    "description": "Aiuto sulle lingue"
+  },
+  "description.files": {
+    "message": "Facoltativo. Carica immagini, video o audio per l'uso di Maestro (come immagini di prodotto, logo).",
+    "description": "Aiuto sui file"
   },
   "status.pending": {
     "message": "In attesa",
     "description": "In attesa"
   },
-  "status.scripting": {
-    "message": "Generazione dello script in corso",
-    "description": "Generazione dello script"
+  "status.planning": {
+    "message": "In pianificazione",
+    "description": "Pianificazione"
   },
-  "status.generating": {
-    "message": "Generazione in corso",
-    "description": "Generazione"
-  },
-  "status.rendering": {
-    "message": "Rendering in corso",
-    "description": "Rendering"
+  "status.producing": {
+    "message": "In produzione",
+    "description": "Produzione"
   },
   "status.processing": {
     "message": "Elaborazione in corso",
@@ -107,9 +95,17 @@
     "message": "Scarica video",
     "description": "Pulsante per scaricare il video"
   },
-  "button.downloadCaptions": {
-    "message": "Scarica sottotitoli",
-    "description": "Pulsante per scaricare i sottotitoli srt"
+  "button.uploadFiles": {
+    "message": "Carica file",
+    "description": "Pulsante per caricare file di riferimento"
+  },
+  "button.remix": {
+    "message": "Remix",
+    "description": "Pulsante per remixare questo video"
+  },
+  "button.cancelRemix": {
+    "message": "Annulla remix",
+    "description": "Pulsante per annullare il remix"
   },
   "message.startingTask": {
     "message": "Inviando il compito video…",
@@ -127,12 +123,80 @@
     "message": "Credito esaurito, ricarica per continuare.",
     "description": "Esaurito"
   },
-  "message.downloadVideo": {
-    "message": "Scarica il video generato",
-    "description": "Tooltip per il download"
+  "message.remixLoaded": {
+    "message": "Remix caricato — descrivi a sinistra le modifiche desiderate e poi genera.",
+    "description": "Toast di remix caricato"
+  },
+  "message.uploadExceed": {
+    "message": "Troppi file, elimina alcuni e riprova.",
+    "description": "Superamento del limite di caricamento"
+  },
+  "message.uploadError": {
+    "message": "Caricamento fallito, riprova.",
+    "description": "Errore di caricamento"
   },
   "message.noTasks": {
     "message": "Non ci sono video — crea il tuo primo a sinistra.",
     "description": "Nessun compito"
+  },
+  "name.sourceType": {
+    "message": "Tipo di sorgente",
+    "description": "Campo per il tipo di sorgente"
+  },
+  "name.sourceRef": {
+    "message": "Contenuto",
+    "description": "Campo per il contenuto sorgente"
+  },
+  "name.lang": {
+    "message": "Lingua principale",
+    "description": "Campo per la lingua primaria"
+  },
+  "name.extraLangs": {
+    "message": "Lingue extra",
+    "description": "Campo per le versioni linguistiche extra"
+  },
+  "name.music": {
+    "message": "Musica di sottofondo",
+    "description": "Campo per attivare/disattivare la musica"
+  },
+  "option.topic": {
+    "message": "Argomento",
+    "description": "Tipo di sorgente: un argomento/titolo"
+  },
+  "option.article": {
+    "message": "Articolo",
+    "description": "Tipo di sorgente: testo completo dell'articolo"
+  },
+  "placeholder.sourceRef": {
+    "message": "Inserisci un argomento (es. “che cos'è un database vettoriale”) o incolla l'intero articolo…",
+    "description": "Segnaposto per il textarea della sorgente"
+  },
+  "description.sourceRef": {
+    "message": "Un argomento/titolo, o il testo completo di un articolo da trasformare in video.",
+    "description": "Aiuto per il campo sorgente"
+  },
+  "description.extraLangs": {
+    "message": "Riutilizza il video, produci queste versioni linguistiche aggiuntive (ogni +6 punti).",
+    "description": "Aiuto per le lingue extra"
+  },
+  "status.scripting": {
+    "message": "Generazione dello script in corso",
+    "description": "Generazione dello script"
+  },
+  "status.generating": {
+    "message": "Generazione in corso",
+    "description": "Generazione"
+  },
+  "status.rendering": {
+    "message": "Rendering in corso",
+    "description": "Rendering"
+  },
+  "button.downloadCaptions": {
+    "message": "Scarica sottotitoli",
+    "description": "Pulsante per scaricare i sottotitoli srt"
+  },
+  "message.downloadVideo": {
+    "message": "Scarica il video generato",
+    "description": "Tooltip per il download"
   }
 }

--- a/src/i18n/ja/maestro.json
+++ b/src/i18n/ja/maestro.json
@@ -27,21 +27,17 @@
     "message": "失敗理由",
     "description": "失敗の理由"
   },
-  "name.sourceType": {
-    "message": "ソースタイプ",
-    "description": "ソースタイプフィールド"
+  "name.prompt": {
+    "message": "プロンプト",
+    "description": "プロンプトフィールド"
   },
-  "name.sourceRef": {
-    "message": "コンテンツ",
-    "description": "ソースコンテンツフィールド"
+  "name.files": {
+    "message": "参考素材",
+    "description": "参照メディアフィールド"
   },
-  "name.lang": {
-    "message": "主言語",
-    "description": "主要言語フィールド"
-  },
-  "name.extraLangs": {
-    "message": "追加言語",
-    "description": "追加言語バージョンフィールド"
+  "name.langs": {
+    "message": "言語",
+    "description": "出力言語フィールド"
   },
   "name.aspect": {
     "message": "アスペクト比",
@@ -51,49 +47,41 @@
     "message": "長さ",
     "description": "ターゲットの長さフィールド"
   },
-  "name.music": {
-    "message": "バックグラウンドミュージック",
-    "description": "音楽トグルフィールド"
+  "name.remixing": {
+    "message": "リミックス",
+    "description": "リミックスバナーラベル"
   },
-  "option.topic": {
-    "message": "トピック",
-    "description": "ソースタイプ：トピック/見出し"
-  },
-  "option.article": {
-    "message": "記事",
-    "description": "ソースタイプ：全文記事テキスト"
-  },
-  "placeholder.sourceRef": {
-    "message": "トピックを入力してください（例：「ベクトルデータベースとは」）または全文を貼り付けてください…",
-    "description": "ソーステキストエリアのプレースホルダー"
+  "placeholder.prompt": {
+    "message": "あなたが望むビデオを説明してください——テーマ、表示したい内容、スタイル、対象……",
+    "description": "プロンプトテキストエリアのプレースホルダー"
   },
   "placeholder.select": {
     "message": "選択してください",
     "description": "一般的な選択プレースホルダー"
   },
-  "description.sourceRef": {
-    "message": "トピック/タイトル、または動画にする全体の記事本文。",
-    "description": "ソースフィールドのヘルプ"
+  "description.prompt": {
+    "message": "あなたが望むことを明確に説明してください。スクリプト、映像、音声、編集はすべてMaestroにお任せください。",
+    "description": "プロンプトフィールドのヘルプ"
   },
-  "description.extraLangs": {
-    "message": "画面を再利用し、これらの言語バージョンを追加出力します（各言語 +6 ポイント）。",
-    "description": "追加言語のヘルプ"
+  "description.langs": {
+    "message": "1つ以上の言語を出力可能で、言語ごとに映像を再利用し、音声のみを追加します（言語ごとに+6ポイント）。",
+    "description": "言語のヘルプ"
+  },
+  "description.files": {
+    "message": "任意。Maestroで使用する画像、動画、音声をアップロードします（製品画像、ロゴなど）。",
+    "description": "ファイルのヘルプ"
   },
   "status.pending": {
     "message": "待機中",
     "description": "保留中"
   },
-  "status.scripting": {
-    "message": "スクリプト生成中",
-    "description": "スクリプト生成中"
+  "status.planning": {
+    "message": "計画中",
+    "description": "計画中"
   },
-  "status.generating": {
-    "message": "生成中",
-    "description": "生成中"
-  },
-  "status.rendering": {
-    "message": "レンダリング中",
-    "description": "レンダリング中"
+  "status.producing": {
+    "message": "制作中",
+    "description": "制作中"
   },
   "status.processing": {
     "message": "処理中",
@@ -107,9 +95,17 @@
     "message": "動画をダウンロード",
     "description": "動画をダウンロードするボタン"
   },
-  "button.downloadCaptions": {
-    "message": "字幕をダウンロード",
-    "description": "srtをダウンロードするボタン"
+  "button.uploadFiles": {
+    "message": "ファイルをアップロード",
+    "description": "参照ファイルをアップロードするボタン"
+  },
+  "button.remix": {
+    "message": "リミックス",
+    "description": "このビデオをリミックスするボタン"
+  },
+  "button.cancelRemix": {
+    "message": "リミックスをキャンセル",
+    "description": "リミックスをキャンセルするボタン"
   },
   "message.startingTask": {
     "message": "動画タスクを提出中…",
@@ -127,12 +123,80 @@
     "message": "クレジットが使い切れました。続行するにはチャージしてください。",
     "description": "使い切ったことを示すメッセージ"
   },
-  "message.downloadVideo": {
-    "message": "生成された動画をダウンロード",
-    "description": "ダウンロードツールチップ"
+  "message.remixLoaded": {
+    "message": "リミックスが読み込まれました——左側に希望する変更を記述し、生成してください。",
+    "description": "リミックス読み込みトースト"
+  },
+  "message.uploadExceed": {
+    "message": "ファイルが多すぎます。いくつか削除して再試行してください。",
+    "description": "アップロード超過"
+  },
+  "message.uploadError": {
+    "message": "アップロードに失敗しました。再試行してください。",
+    "description": "アップロードエラー"
   },
   "message.noTasks": {
     "message": "まだ動画がありません — 左側で最初の動画を作成しましょう。",
     "description": "タスクがないことを示すメッセージ"
+  },
+  "name.sourceType": {
+    "message": "ソースタイプ",
+    "description": "ソースタイプフィールド"
+  },
+  "name.sourceRef": {
+    "message": "コンテンツ",
+    "description": "ソースコンテンツフィールド"
+  },
+  "name.lang": {
+    "message": "主言語",
+    "description": "主要言語フィールド"
+  },
+  "name.extraLangs": {
+    "message": "追加言語",
+    "description": "追加言語バージョンフィールド"
+  },
+  "name.music": {
+    "message": "バックグラウンドミュージック",
+    "description": "音楽トグルフィールド"
+  },
+  "option.topic": {
+    "message": "トピック",
+    "description": "ソースタイプ：トピック/見出し"
+  },
+  "option.article": {
+    "message": "記事",
+    "description": "ソースタイプ：全文記事テキスト"
+  },
+  "placeholder.sourceRef": {
+    "message": "トピックを入力してください（例：「ベクトルデータベースとは」）または全文を貼り付けてください…",
+    "description": "ソーステキストエリアのプレースホルダー"
+  },
+  "description.sourceRef": {
+    "message": "トピック/タイトル、または動画にする全体の記事本文。",
+    "description": "ソースフィールドのヘルプ"
+  },
+  "description.extraLangs": {
+    "message": "画面を再利用し、これらの言語バージョンを追加出力します（各言語 +6 ポイント）。",
+    "description": "追加言語のヘルプ"
+  },
+  "status.scripting": {
+    "message": "スクリプト生成中",
+    "description": "スクリプト生成中"
+  },
+  "status.generating": {
+    "message": "生成中",
+    "description": "生成中"
+  },
+  "status.rendering": {
+    "message": "レンダリング中",
+    "description": "レンダリング中"
+  },
+  "button.downloadCaptions": {
+    "message": "字幕をダウンロード",
+    "description": "srtをダウンロードするボタン"
+  },
+  "message.downloadVideo": {
+    "message": "生成された動画をダウンロード",
+    "description": "ダウンロードツールチップ"
   }
 }

--- a/src/i18n/ko/maestro.json
+++ b/src/i18n/ko/maestro.json
@@ -27,21 +27,17 @@
     "message": "실패 원인",
     "description": "실패 이유"
   },
-  "name.sourceType": {
-    "message": "출처 유형",
-    "description": "출처 유형 필드"
+  "name.prompt": {
+    "message": "프롬프트",
+    "description": "프롬프트 필드"
   },
-  "name.sourceRef": {
-    "message": "내용",
-    "description": "소스 콘텐츠 필드"
+  "name.files": {
+    "message": "참조 자료",
+    "description": "참조 미디어 필드"
   },
-  "name.lang": {
-    "message": "주 언어",
-    "description": "주 언어 필드"
-  },
-  "name.extraLangs": {
-    "message": "추가 언어",
-    "description": "추가 언어 버전 필드"
+  "name.langs": {
+    "message": "언어",
+    "description": "출력 언어 필드"
   },
   "name.aspect": {
     "message": "화면 비율",
@@ -51,49 +47,41 @@
     "message": "지속 시간",
     "description": "목표 지속 시간 필드"
   },
-  "name.music": {
-    "message": "배경 음악",
-    "description": "음악 토글 필드"
+  "name.remixing": {
+    "message": "리믹스",
+    "description": "리믹스 배너 레이블"
   },
-  "option.topic": {
-    "message": "주제",
-    "description": "소스 유형: 주제/헤드라인"
-  },
-  "option.article": {
-    "message": "기사",
-    "description": "소스 유형: 전체 기사 텍스트"
-  },
-  "placeholder.sourceRef": {
-    "message": "주제 입력(예: “벡터 데이터베이스란?”) 또는 전체 기사 붙여넣기…",
-    "description": "소스 텍스트 영역 자리 표시자"
+  "placeholder.prompt": {
+    "message": "원하는 비디오를 설명하세요 — 주제, 보여줄 내용, 스타일, 대상……",
+    "description": "프롬프트 텍스트 영역 플레이스홀더"
   },
   "placeholder.select": {
     "message": "선택하세요",
     "description": "일반적인 선택 자리 표시자"
   },
-  "description.sourceRef": {
-    "message": "주제/제목 또는 비디오로 만들고자 하는 전체 기사 본문.",
-    "description": "소스 필드 도움"
+  "description.prompt": {
+    "message": "원하는 내용을 간단히 설명하세요. 스크립트, 화면, 더빙, 편집은 Maestro에게 맡기세요.",
+    "description": "프롬프트 필드 도움말"
   },
-  "description.extraLangs": {
-    "message": "화면을 재사용하고, 이러한 언어 버전을 추가로 생성합니다(각 언어당 +6 포인트).",
-    "description": "추가 언어 도움"
+  "description.langs": {
+    "message": "하나 이상의 언어로 출력할 수 있으며, 언어를 추가할 때마다 화면을 재사용하고 더 많은 더빙이 필요합니다(언어당 +6 포인트).",
+    "description": "언어 도움말"
+  },
+  "description.files": {
+    "message": "선택 사항입니다. Maestro에서 사용할 이미지, 비디오 또는 오디오를 업로드하세요(예: 제품 이미지, 로고).",
+    "description": "파일 도움말"
   },
   "status.pending": {
     "message": "대기 중",
     "description": "대기 중"
   },
-  "status.scripting": {
-    "message": "스크립트 생성 중",
-    "description": "스크립트 생성 중"
+  "status.planning": {
+    "message": "계획 중",
+    "description": "계획 중 상태"
   },
-  "status.generating": {
-    "message": "생성 중",
-    "description": "생성 중"
-  },
-  "status.rendering": {
-    "message": "렌더링 중",
-    "description": "렌더링 중"
+  "status.producing": {
+    "message": "제작 중",
+    "description": "제작 중 상태"
   },
   "status.processing": {
     "message": "처리 중",
@@ -107,9 +95,17 @@
     "message": "비디오 다운로드",
     "description": "비디오 다운로드 버튼"
   },
-  "button.downloadCaptions": {
-    "message": "자막 다운로드",
-    "description": "srt 다운로드 버튼"
+  "button.uploadFiles": {
+    "message": "파일 업로드",
+    "description": "참조 파일을 업로드하는 버튼"
+  },
+  "button.remix": {
+    "message": "리믹스",
+    "description": "이 비디오를 리믹스하는 버튼"
+  },
+  "button.cancelRemix": {
+    "message": "리믹스 취소",
+    "description": "리믹스를 취소하는 버튼"
   },
   "message.startingTask": {
     "message": "비디오 작업을 제출하는 중…",
@@ -127,12 +123,80 @@
     "message": "할당량이 소진되었습니다, 충전 후 계속 진행하세요.",
     "description": "소진됨"
   },
-  "message.downloadVideo": {
-    "message": "생성된 비디오 다운로드",
-    "description": "다운로드 툴팁"
+  "message.remixLoaded": {
+    "message": "리믹스가 로드되었습니다 — 왼쪽에서 원하는 수정 사항을 설명한 후 생성하세요.",
+    "description": "리믹스 로드 완료 토스트"
+  },
+  "message.uploadExceed": {
+    "message": "파일이 너무 많습니다. 일부를 삭제한 후 다시 시도하세요.",
+    "description": "업로드 초과"
+  },
+  "message.uploadError": {
+    "message": "업로드 실패, 다시 시도하세요.",
+    "description": "업로드 오류"
   },
   "message.noTasks": {
     "message": "아직 비디오가 없습니다 — 왼쪽에서 첫 번째 비디오를 생성하세요.",
     "description": "작업 없음"
+  },
+  "name.sourceType": {
+    "message": "출처 유형",
+    "description": "출처 유형 필드"
+  },
+  "name.sourceRef": {
+    "message": "내용",
+    "description": "소스 콘텐츠 필드"
+  },
+  "name.lang": {
+    "message": "주 언어",
+    "description": "주 언어 필드"
+  },
+  "name.extraLangs": {
+    "message": "추가 언어",
+    "description": "추가 언어 버전 필드"
+  },
+  "name.music": {
+    "message": "배경 음악",
+    "description": "음악 토글 필드"
+  },
+  "option.topic": {
+    "message": "주제",
+    "description": "소스 유형: 주제/헤드라인"
+  },
+  "option.article": {
+    "message": "기사",
+    "description": "소스 유형: 전체 기사 텍스트"
+  },
+  "placeholder.sourceRef": {
+    "message": "주제 입력(예: “벡터 데이터베이스란?”) 또는 전체 기사 붙여넣기…",
+    "description": "소스 텍스트 영역 자리 표시자"
+  },
+  "description.sourceRef": {
+    "message": "주제/제목 또는 비디오로 만들고자 하는 전체 기사 본문.",
+    "description": "소스 필드 도움"
+  },
+  "description.extraLangs": {
+    "message": "화면을 재사용하고, 이러한 언어 버전을 추가로 생성합니다(각 언어당 +6 포인트).",
+    "description": "추가 언어 도움"
+  },
+  "status.scripting": {
+    "message": "스크립트 생성 중",
+    "description": "스크립트 생성 중"
+  },
+  "status.generating": {
+    "message": "생성 중",
+    "description": "생성 중"
+  },
+  "status.rendering": {
+    "message": "렌더링 중",
+    "description": "렌더링 중"
+  },
+  "button.downloadCaptions": {
+    "message": "자막 다운로드",
+    "description": "srt 다운로드 버튼"
+  },
+  "message.downloadVideo": {
+    "message": "생성된 비디오 다운로드",
+    "description": "다운로드 툴팁"
   }
 }

--- a/src/i18n/pl/maestro.json
+++ b/src/i18n/pl/maestro.json
@@ -27,21 +27,17 @@
     "message": "Powód niepowodzenia",
     "description": "Powód niepowodzenia"
   },
-  "name.sourceType": {
-    "message": "Typ źródła",
-    "description": "Pole typu źródła"
+  "name.prompt": {
+    "message": "Słowo kluczowe",
+    "description": "Pole prompt"
   },
-  "name.sourceRef": {
-    "message": "Treść",
-    "description": "Pole treści źródłowej"
+  "name.files": {
+    "message": "Materiały referencyjne",
+    "description": "Pole mediów referencyjnych"
   },
-  "name.lang": {
-    "message": "Język główny",
-    "description": "Pole głównego języka"
-  },
-  "name.extraLangs": {
-    "message": "Dodatkowe języki",
-    "description": "Pole wersji językowych"
+  "name.langs": {
+    "message": "Języki",
+    "description": "Pole języków wyjściowych"
   },
   "name.aspect": {
     "message": "Proporcje obrazu",
@@ -51,49 +47,41 @@
     "message": "Czas trwania",
     "description": "Pole docelowego czasu trwania"
   },
-  "name.music": {
-    "message": "Muzyka w tle",
-    "description": "Pole przełączania muzyki"
+  "name.remixing": {
+    "message": "Remixowanie",
+    "description": "Etykieta banera remixu"
   },
-  "option.topic": {
-    "message": "Temat",
-    "description": "Typ źródła: temat/tytuł"
-  },
-  "option.article": {
-    "message": "Artykuł",
-    "description": "Typ źródła: pełny tekst artykułu"
-  },
-  "placeholder.sourceRef": {
-    "message": "Wprowadź temat (np. „Czym jest baza danych wektorowa”) lub wklej cały artykuł…",
-    "description": "Placeholder dla pola tekstowego źródła"
+  "placeholder.prompt": {
+    "message": "Opisz, jakie wideo chcesz — temat, co pokazać, styl, odbiorcy…",
+    "description": "Placeholder w polu prompt"
   },
   "placeholder.select": {
     "message": "Wybierz",
     "description": "Ogólny placeholder dla wyboru"
   },
-  "description.sourceRef": {
-    "message": "Temat/tytuł lub pełny tekst artykułu, który ma być przekształcony w wideo.",
-    "description": "Pomoc dotycząca pola źródłowego"
+  "description.prompt": {
+    "message": "Wyraź jasno, czego chcesz, skrypt, obraz, dubbing, montaż zostaw Maestro.",
+    "description": "Pomoc dotycząca pola prompt"
   },
-  "description.extraLangs": {
-    "message": "Wykorzystaj obraz, dodatkowo wygeneruj te wersje językowe (każda +6 punktów).",
-    "description": "Pomoc dotycząca dodatkowych języków"
+  "description.langs": {
+    "message": "Możesz wybrać jeden lub więcej języków, każdy dodatkowy język wykorzystuje ten sam obraz, tylko dodaje dubbing (każdy dodatkowy +6 punktów).",
+    "description": "Pomoc dotycząca języków"
+  },
+  "description.files": {
+    "message": "Opcjonalne. Prześlij obrazy, wideo lub audio do wykorzystania przez Maestro (np. zdjęcia produktów, logo).",
+    "description": "Pomoc dotycząca plików"
   },
   "status.pending": {
     "message": "W kolejce",
     "description": "Oczekiwanie"
   },
-  "status.scripting": {
-    "message": "Generowanie skryptu",
-    "description": "Generowanie skryptu"
+  "status.planning": {
+    "message": "W planowaniu",
+    "description": "Planowanie"
   },
-  "status.generating": {
-    "message": "Generowanie",
-    "description": "Generowanie"
-  },
-  "status.rendering": {
-    "message": "Renderowanie",
-    "description": "Renderowanie"
+  "status.producing": {
+    "message": "W produkcji",
+    "description": "Produkcja"
   },
   "status.processing": {
     "message": "Przetwarzanie",
@@ -107,9 +95,17 @@
     "message": "Pobierz wideo",
     "description": "Przycisk do pobierania wideo"
   },
-  "button.downloadCaptions": {
-    "message": "Pobierz napisy",
-    "description": "Przycisk do pobierania pliku srt"
+  "button.uploadFiles": {
+    "message": "Prześlij pliki",
+    "description": "Przycisk przesyłania plików referencyjnych"
+  },
+  "button.remix": {
+    "message": "Remixuj",
+    "description": "Przycisk remixowania tego wideo"
+  },
+  "button.cancelRemix": {
+    "message": "Anuluj remix",
+    "description": "Przycisk anulowania remixu"
   },
   "message.startingTask": {
     "message": "Wysyłanie zadania wideo…",
@@ -127,12 +123,80 @@
     "message": "Limit został wyczerpany, proszę doładować, aby kontynuować.",
     "description": "Limit wyczerpany"
   },
-  "message.downloadVideo": {
-    "message": "Pobierz wygenerowane wideo",
-    "description": "Podpowiedź do pobierania"
+  "message.remixLoaded": {
+    "message": "Załadowano remix — opisz po lewej stronie, jakie chcesz wprowadzić zmiany, a następnie wygeneruj.",
+    "description": "Toast załadowania remixu"
+  },
+  "message.uploadExceed": {
+    "message": "Zbyt wiele plików, usuń kilka i spróbuj ponownie.",
+    "description": "Przekroczenie limitu przesyłania"
+  },
+  "message.uploadError": {
+    "message": "Przesyłanie nie powiodło się, spróbuj ponownie.",
+    "description": "Błąd przesyłania"
   },
   "message.noTasks": {
     "message": "Brak wideo — stwórz swoje pierwsze po lewej stronie.",
     "description": "Brak zadań"
+  },
+  "name.sourceType": {
+    "message": "Typ źródła",
+    "description": "Pole typu źródła"
+  },
+  "name.sourceRef": {
+    "message": "Treść",
+    "description": "Pole treści źródłowej"
+  },
+  "name.lang": {
+    "message": "Język główny",
+    "description": "Pole głównego języka"
+  },
+  "name.extraLangs": {
+    "message": "Dodatkowe języki",
+    "description": "Pole wersji językowych"
+  },
+  "name.music": {
+    "message": "Muzyka w tle",
+    "description": "Pole przełączania muzyki"
+  },
+  "option.topic": {
+    "message": "Temat",
+    "description": "Typ źródła: temat/tytuł"
+  },
+  "option.article": {
+    "message": "Artykuł",
+    "description": "Typ źródła: pełny tekst artykułu"
+  },
+  "placeholder.sourceRef": {
+    "message": "Wprowadź temat (np. „Czym jest baza danych wektorowa”) lub wklej cały artykuł…",
+    "description": "Placeholder dla pola tekstowego źródła"
+  },
+  "description.sourceRef": {
+    "message": "Temat/tytuł lub pełny tekst artykułu, który ma być przekształcony w wideo.",
+    "description": "Pomoc dotycząca pola źródłowego"
+  },
+  "description.extraLangs": {
+    "message": "Wykorzystaj obraz, dodatkowo wygeneruj te wersje językowe (każda +6 punktów).",
+    "description": "Pomoc dotycząca dodatkowych języków"
+  },
+  "status.scripting": {
+    "message": "Generowanie skryptu",
+    "description": "Generowanie skryptu"
+  },
+  "status.generating": {
+    "message": "Generowanie",
+    "description": "Generowanie"
+  },
+  "status.rendering": {
+    "message": "Renderowanie",
+    "description": "Renderowanie"
+  },
+  "button.downloadCaptions": {
+    "message": "Pobierz napisy",
+    "description": "Przycisk do pobierania pliku srt"
+  },
+  "message.downloadVideo": {
+    "message": "Pobierz wygenerowane wideo",
+    "description": "Podpowiedź do pobierania"
   }
 }

--- a/src/i18n/pt/maestro.json
+++ b/src/i18n/pt/maestro.json
@@ -27,21 +27,17 @@
     "message": "Razão da falha",
     "description": "Razão da falha"
   },
-  "name.sourceType": {
-    "message": "Tipo de origem",
-    "description": "Campo de tipo de origem"
+  "name.prompt": {
+    "message": "Prompt",
+    "description": "Campo de prompt"
   },
-  "name.sourceRef": {
-    "message": "Conteúdo",
-    "description": "Campo de conteúdo de origem"
+  "name.files": {
+    "message": "Materiais de referência",
+    "description": "Campo para mídia de referência"
   },
-  "name.lang": {
-    "message": "Idioma principal",
-    "description": "Campo de idioma principal"
-  },
-  "name.extraLangs": {
-    "message": "Idiomas adicionais",
-    "description": "Campo para versões de idiomas extras"
+  "name.langs": {
+    "message": "Idiomas",
+    "description": "Campo para idiomas de saída"
   },
   "name.aspect": {
     "message": "Proporção",
@@ -51,49 +47,41 @@
     "message": "Duração",
     "description": "Campo de duração alvo"
   },
-  "name.music": {
-    "message": "Música de fundo",
-    "description": "Campo para alternar música"
+  "name.remixing": {
+    "message": "Remixando",
+    "description": "Rótulo do banner de remix"
   },
-  "option.topic": {
-    "message": "Tópico",
-    "description": "Tipo de fonte: um tópico/título"
-  },
-  "option.article": {
-    "message": "Artigo",
-    "description": "Tipo de fonte: texto completo do artigo"
-  },
-  "placeholder.sourceRef": {
-    "message": "Digite um tópico (como “o que é um banco de dados vetorial”) ou cole um artigo completo…",
-    "description": "Placeholder para área de texto de fonte"
+  "placeholder.prompt": {
+    "message": "Descreva o vídeo que você deseja — tema, o que mostrar, estilo, público-alvo…",
+    "description": "Placeholder do textarea de prompt"
   },
   "placeholder.select": {
     "message": "Selecione",
     "description": "Placeholder genérico para seleção"
   },
-  "description.sourceRef": {
-    "message": "Um tópico/título ou o texto completo do artigo a ser transformado em vídeo.",
-    "description": "Ajuda para o campo de origem"
+  "description.prompt": {
+    "message": "Explique claramente o que você deseja em linguagem simples; deixe o roteiro, as cenas, a dublagem e a edição para o Maestro.",
+    "description": "Ajuda sobre o campo de prompt"
   },
-  "description.extraLangs": {
-    "message": "Reutilizar a imagem, produzir versões adicionais nesses idiomas (cada uma +6 pontos).",
-    "description": "Ajuda sobre idiomas extras"
+  "description.langs": {
+    "message": "Você pode exportar em uma ou mais línguas, reutilizando a mesma cena e apenas adicionando a dublagem (cada língua adicional +6 pontos).",
+    "description": "Ajuda sobre idiomas"
+  },
+  "description.files": {
+    "message": "Opcional. Envie imagens, vídeos ou áudios para uso do Maestro (como imagens de produtos, logotipos).",
+    "description": "Ajuda sobre arquivos"
   },
   "status.pending": {
     "message": "Aguardando",
     "description": "Aguardando"
   },
-  "status.scripting": {
-    "message": "Gerando script",
-    "description": "Gerando script"
+  "status.planning": {
+    "message": "Planejando",
+    "description": "Planejamento"
   },
-  "status.generating": {
-    "message": "Gerando",
-    "description": "Gerando"
-  },
-  "status.rendering": {
-    "message": "Renderizando",
-    "description": "Renderizando"
+  "status.producing": {
+    "message": "Produzindo",
+    "description": "Produção"
   },
   "status.processing": {
     "message": "Processando",
@@ -107,9 +95,17 @@
     "message": "Baixar vídeo",
     "description": "Botão para baixar vídeo"
   },
-  "button.downloadCaptions": {
-    "message": "Baixar legendas",
-    "description": "Botão para baixar srt"
+  "button.uploadFiles": {
+    "message": "Enviar arquivos",
+    "description": "Botão para enviar arquivos de referência"
+  },
+  "button.remix": {
+    "message": "Remixar",
+    "description": "Botão para remixar este vídeo"
+  },
+  "button.cancelRemix": {
+    "message": "Cancelar remix",
+    "description": "Botão para cancelar a remixagem"
   },
   "message.startingTask": {
     "message": "Enviando tarefa de vídeo…",
@@ -127,12 +123,80 @@
     "message": "Créditos esgotados, por favor, recarregue para continuar.",
     "description": "Esgotado"
   },
-  "message.downloadVideo": {
-    "message": "Baixar o vídeo gerado",
-    "description": "Dica para download"
+  "message.remixLoaded": {
+    "message": "Remix carregado — descreva à esquerda as modificações desejadas e, em seguida, gere.",
+    "description": "Toast de remix carregado"
+  },
+  "message.uploadExceed": {
+    "message": "Muitos arquivos, por favor, exclua alguns e tente novamente.",
+    "description": "Excedeu o limite de upload"
+  },
+  "message.uploadError": {
+    "message": "Falha no envio, por favor, tente novamente.",
+    "description": "Erro de upload"
   },
   "message.noTasks": {
     "message": "Ainda não há vídeos — crie o seu primeiro à esquerda.",
     "description": "Sem tarefas"
+  },
+  "name.sourceType": {
+    "message": "Tipo de origem",
+    "description": "Campo de tipo de origem"
+  },
+  "name.sourceRef": {
+    "message": "Conteúdo",
+    "description": "Campo de conteúdo de origem"
+  },
+  "name.lang": {
+    "message": "Idioma principal",
+    "description": "Campo de idioma principal"
+  },
+  "name.extraLangs": {
+    "message": "Idiomas adicionais",
+    "description": "Campo para versões de idiomas extras"
+  },
+  "name.music": {
+    "message": "Música de fundo",
+    "description": "Campo para alternar música"
+  },
+  "option.topic": {
+    "message": "Tópico",
+    "description": "Tipo de fonte: um tópico/título"
+  },
+  "option.article": {
+    "message": "Artigo",
+    "description": "Tipo de fonte: texto completo do artigo"
+  },
+  "placeholder.sourceRef": {
+    "message": "Digite um tópico (como “o que é um banco de dados vetorial”) ou cole um artigo completo…",
+    "description": "Placeholder para área de texto de fonte"
+  },
+  "description.sourceRef": {
+    "message": "Um tópico/título ou o texto completo do artigo a ser transformado em vídeo.",
+    "description": "Ajuda para o campo de origem"
+  },
+  "description.extraLangs": {
+    "message": "Reutilizar a imagem, produzir versões adicionais nesses idiomas (cada uma +6 pontos).",
+    "description": "Ajuda sobre idiomas extras"
+  },
+  "status.scripting": {
+    "message": "Gerando script",
+    "description": "Gerando script"
+  },
+  "status.generating": {
+    "message": "Gerando",
+    "description": "Gerando"
+  },
+  "status.rendering": {
+    "message": "Renderizando",
+    "description": "Renderizando"
+  },
+  "button.downloadCaptions": {
+    "message": "Baixar legendas",
+    "description": "Botão para baixar srt"
+  },
+  "message.downloadVideo": {
+    "message": "Baixar o vídeo gerado",
+    "description": "Dica para download"
   }
 }

--- a/src/i18n/ru/maestro.json
+++ b/src/i18n/ru/maestro.json
@@ -27,21 +27,17 @@
     "message": "Причина ошибки",
     "description": "Причина ошибки"
   },
-  "name.sourceType": {
-    "message": "Тип источника",
-    "description": "Поле типа источника"
+  "name.prompt": {
+    "message": "Подсказка",
+    "description": "Поле подсказки"
   },
-  "name.sourceRef": {
-    "message": "Содержимое",
-    "description": "Поле исходного контента"
+  "name.files": {
+    "message": "Референсные материалы",
+    "description": "Поле для медиа-материалов"
   },
-  "name.lang": {
-    "message": "Основной язык",
-    "description": "Поле основного языка"
-  },
-  "name.extraLangs": {
-    "message": "Дополнительные языки",
-    "description": "Поле для дополнительных языковых версий"
+  "name.langs": {
+    "message": "Языки",
+    "description": "Поле для языков вывода"
   },
   "name.aspect": {
     "message": "Соотношение сторон",
@@ -51,49 +47,41 @@
     "message": "Длительность",
     "description": "Поле целевой длительности"
   },
-  "name.music": {
-    "message": "Фоновая музыка",
-    "description": "Поле переключения музыки"
+  "name.remixing": {
+    "message": "Ремикс",
+    "description": "Метка баннера ремикса"
   },
-  "option.topic": {
-    "message": "Тема",
-    "description": "Тип источника: тема/заголовок"
-  },
-  "option.article": {
-    "message": "Статья",
-    "description": "Тип источника: полный текст статьи"
-  },
-  "placeholder.sourceRef": {
-    "message": "Введите тему (например, “Что такое векторная база данных”) или вставьте полную статью…",
-    "description": "Плейсхолдер для текстовой области источника"
+  "placeholder.prompt": {
+    "message": "Опишите, какое видео вы хотите — тему, что показать, стиль, аудиторию…",
+    "description": "Заполнитель текстовой области подсказки"
   },
   "placeholder.select": {
     "message": "Пожалуйста, выберите",
     "description": "Общий плейсхолдер для выбора"
   },
-  "description.sourceRef": {
-    "message": "Тема/заголовок или полный текст статьи, которую нужно сделать видео.",
-    "description": "Помощь по полю источника"
+  "description.prompt": {
+    "message": "Четко сформулируйте, что вы хотите, сценарий, изображения, озвучка и монтаж — все это сделает Maestro.",
+    "description": "Помощь по полю подсказки"
   },
-  "description.extraLangs": {
-    "message": "Повторное использование изображения, дополнительный выпуск этих языковых версий (каждая +6 баллов).",
-    "description": "Помощь по дополнительным языкам"
+  "description.langs": {
+    "message": "Можно вывести на одном или нескольких языках, каждый дополнительный язык использует те же изображения и добавляет только озвучку (каждый дополнительный +6 баллов).",
+    "description": "Помощь по языкам"
+  },
+  "description.files": {
+    "message": "Необязательно. Загрузите изображения, видео или аудио для использования Maestro (например, изображения продукта, логотипы).",
+    "description": "Помощь по файлам"
   },
   "status.pending": {
     "message": "В очереди",
     "description": "Ожидание"
   },
-  "status.scripting": {
-    "message": "Генерация скрипта",
-    "description": "Генерация скрипта"
+  "status.planning": {
+    "message": "В планировании",
+    "description": "Планирование"
   },
-  "status.generating": {
-    "message": "Генерация изображения",
-    "description": "Генерация"
-  },
-  "status.rendering": {
-    "message": "Рендеринг",
-    "description": "Рендеринг"
+  "status.producing": {
+    "message": "В производстве",
+    "description": "Производство"
   },
   "status.processing": {
     "message": "Обработка",
@@ -107,9 +95,17 @@
     "message": "Скачать видео",
     "description": "Кнопка для скачивания видео"
   },
-  "button.downloadCaptions": {
-    "message": "Скачать субтитры",
-    "description": "Кнопка для скачивания srt"
+  "button.uploadFiles": {
+    "message": "Загрузить файлы",
+    "description": "Кнопка загрузки файлов-образцов"
+  },
+  "button.remix": {
+    "message": "Создать ремикс",
+    "description": "Кнопка создания ремикса этого видео"
+  },
+  "button.cancelRemix": {
+    "message": "Отменить ремикс",
+    "description": "Кнопка отмены ремикса"
   },
   "message.startingTask": {
     "message": "Отправка видео задачи…",
@@ -127,12 +123,80 @@
     "message": "Лимит исчерпан, пожалуйста, пополните счет для продолжения.",
     "description": "Лимит исчерпан"
   },
-  "message.downloadVideo": {
-    "message": "Скачать сгенерированное видео",
-    "description": "Подсказка для скачивания"
+  "message.remixLoaded": {
+    "message": "Ремикс загружен — опишите слева желаемые изменения, затем создайте.",
+    "description": "Уведомление о загруженном ремиксе"
+  },
+  "message.uploadExceed": {
+    "message": "Слишком много файлов, пожалуйста, удалите некоторые и попробуйте снова.",
+    "description": "Превышение лимита загрузки"
+  },
+  "message.uploadError": {
+    "message": "Ошибка загрузки, пожалуйста, попробуйте снова.",
+    "description": "Ошибка загрузки"
   },
   "message.noTasks": {
     "message": "Пока нет видео — создайте ваше первое слева.",
     "description": "Нет задач"
+  },
+  "name.sourceType": {
+    "message": "Тип источника",
+    "description": "Поле типа источника"
+  },
+  "name.sourceRef": {
+    "message": "Содержимое",
+    "description": "Поле исходного контента"
+  },
+  "name.lang": {
+    "message": "Основной язык",
+    "description": "Поле основного языка"
+  },
+  "name.extraLangs": {
+    "message": "Дополнительные языки",
+    "description": "Поле для дополнительных языковых версий"
+  },
+  "name.music": {
+    "message": "Фоновая музыка",
+    "description": "Поле переключения музыки"
+  },
+  "option.topic": {
+    "message": "Тема",
+    "description": "Тип источника: тема/заголовок"
+  },
+  "option.article": {
+    "message": "Статья",
+    "description": "Тип источника: полный текст статьи"
+  },
+  "placeholder.sourceRef": {
+    "message": "Введите тему (например, “Что такое векторная база данных”) или вставьте полную статью…",
+    "description": "Плейсхолдер для текстовой области источника"
+  },
+  "description.sourceRef": {
+    "message": "Тема/заголовок или полный текст статьи, которую нужно сделать видео.",
+    "description": "Помощь по полю источника"
+  },
+  "description.extraLangs": {
+    "message": "Повторное использование изображения, дополнительный выпуск этих языковых версий (каждая +6 баллов).",
+    "description": "Помощь по дополнительным языкам"
+  },
+  "status.scripting": {
+    "message": "Генерация скрипта",
+    "description": "Генерация скрипта"
+  },
+  "status.generating": {
+    "message": "Генерация изображения",
+    "description": "Генерация"
+  },
+  "status.rendering": {
+    "message": "Рендеринг",
+    "description": "Рендеринг"
+  },
+  "button.downloadCaptions": {
+    "message": "Скачать субтитры",
+    "description": "Кнопка для скачивания srt"
+  },
+  "message.downloadVideo": {
+    "message": "Скачать сгенерированное видео",
+    "description": "Подсказка для скачивания"
   }
 }

--- a/src/i18n/sr/maestro.json
+++ b/src/i18n/sr/maestro.json
@@ -27,21 +27,17 @@
     "message": "Razlog neuspeha",
     "description": "Razlog neuspeha"
   },
-  "name.sourceType": {
-    "message": "Tip izvora",
-    "description": "Polje za tip izvora"
+  "name.prompt": {
+    "message": "Упит",
+    "description": "Поље за упит"
   },
-  "name.sourceRef": {
-    "message": "Sadržaj",
-    "description": "Polje za izvorni sadržaj"
+  "name.files": {
+    "message": "Референцијални материјал",
+    "description": "Поље за референтне медије"
   },
-  "name.lang": {
-    "message": "Glavni jezik",
-    "description": "Polje za primarni jezik"
-  },
-  "name.extraLangs": {
-    "message": "Dodatni jezici",
-    "description": "Polje za dodatne jezičke verzije"
+  "name.langs": {
+    "message": "Језици",
+    "description": "Поље за излазне језике"
   },
   "name.aspect": {
     "message": "Odnos stranica",
@@ -51,49 +47,41 @@
     "message": "Trajanje",
     "description": "Polje za ciljano trajanje"
   },
-  "name.music": {
-    "message": "Pozadinska muzika",
-    "description": "Polje za prebacivanje muzike"
+  "name.remixing": {
+    "message": "Ремиксовање",
+    "description": "Ознака банера за ремиксовање"
   },
-  "option.topic": {
-    "message": "Tema",
-    "description": "Tip izvora: tema/naslov"
-  },
-  "option.article": {
-    "message": "Članak",
-    "description": "Tip izvora: puni tekst članka"
-  },
-  "placeholder.sourceRef": {
-    "message": "Unesite temu (npr. \"Šta je vektorska baza podataka\") ili nalepite ceo članak…",
-    "description": "Placeholder za tekstualno polje izvora"
+  "placeholder.prompt": {
+    "message": "Описујте видео који желите — тему, шта да се прикаже, стил, публику…",
+    "description": "Плацехолдер за текстуално поље упита"
   },
   "placeholder.select": {
     "message": "Izaberite",
     "description": "Generički placeholder za izbor"
   },
-  "description.sourceRef": {
-    "message": "Tema/titula ili ceo tekst članka koji treba pretvoriti u video.",
-    "description": "Pomoć za polje izvora"
+  "description.prompt": {
+    "message": "Јасно изразите шта желите, сценарио, слике, глас, монтажу оставите Maestro-у.",
+    "description": "Помоћ о пољу за упит"
   },
-  "description.extraLangs": {
-    "message": "Ponovno koristi slike, dodatno proizvedi ove jezičke verzije (svaka +6 poena).",
-    "description": "Pomoć za dodatne jezike"
+  "description.langs": {
+    "message": "Можете изабрати један или више језика, за сваки додатни језик користите исту сцену, само додајте глас (за сваки додатни +6 поена).",
+    "description": "Помоћ о језицима"
+  },
+  "description.files": {
+    "message": "Опционално. Отпремите слике, видео или аудио за Maestro (као што су слике производа, логотипи).",
+    "description": "Помоћ о фајловима"
   },
   "status.pending": {
     "message": "Na čekanju",
     "description": "Na čekanju"
   },
-  "status.scripting": {
-    "message": "Generiše se skripta",
-    "description": "Generisanje skripte"
+  "status.planning": {
+    "message": "У планирању",
+    "description": "Планирање"
   },
-  "status.generating": {
-    "message": "Generiše se",
-    "description": "Generisanje"
-  },
-  "status.rendering": {
-    "message": "Renderuje se",
-    "description": "Renderovanje"
+  "status.producing": {
+    "message": "У производњи",
+    "description": "Производња"
   },
   "status.processing": {
     "message": "Obrada",
@@ -107,9 +95,17 @@
     "message": "Preuzmi video",
     "description": "Dugme za preuzimanje videa"
   },
-  "button.downloadCaptions": {
-    "message": "Preuzmi titlove",
-    "description": "Dugme za preuzimanje srt"
+  "button.uploadFiles": {
+    "message": "Отпреми фајлове",
+    "description": " dugme za otpremu referentnih fajlova"
+  },
+  "button.remix": {
+    "message": "Ремикс",
+    "description": " dugme za remiksovanje ovog videa"
+  },
+  "button.cancelRemix": {
+    "message": "Откажи ремикс",
+    "description": " dugme za otkazivanje remiksa"
   },
   "message.startingTask": {
     "message": "Podnošenje video zadatka…",
@@ -127,12 +123,80 @@
     "message": "Kredit je iskorišćen, molimo dopunite da biste nastavili.",
     "description": "Iskorišćeno"
   },
-  "message.downloadVideo": {
-    "message": "Preuzmi generisani video",
-    "description": "Tooltip za preuzimanje"
+  "message.remixLoaded": {
+    "message": "Ремикс је учитан — опишите жељене измене с леве стране, а затим генеришите.",
+    "description": "Обавештење о учитаном ремиксу"
+  },
+  "message.uploadExceed": {
+    "message": "Превише фајлова, молимо вас да избришете неке и покушате поново.",
+    "description": "Превазилажење лимита отпремања"
+  },
+  "message.uploadError": {
+    "message": "Отпремање није успело, покушајте поново.",
+    "description": "Грешка при отпремању"
   },
   "message.noTasks": {
     "message": "Još nema videa — kreiraj svoj prvi sa leve strane.",
     "description": "Nema zadataka"
+  },
+  "name.sourceType": {
+    "message": "Tip izvora",
+    "description": "Polje za tip izvora"
+  },
+  "name.sourceRef": {
+    "message": "Sadržaj",
+    "description": "Polje za izvorni sadržaj"
+  },
+  "name.lang": {
+    "message": "Glavni jezik",
+    "description": "Polje za primarni jezik"
+  },
+  "name.extraLangs": {
+    "message": "Dodatni jezici",
+    "description": "Polje za dodatne jezičke verzije"
+  },
+  "name.music": {
+    "message": "Pozadinska muzika",
+    "description": "Polje za prebacivanje muzike"
+  },
+  "option.topic": {
+    "message": "Tema",
+    "description": "Tip izvora: tema/naslov"
+  },
+  "option.article": {
+    "message": "Članak",
+    "description": "Tip izvora: puni tekst članka"
+  },
+  "placeholder.sourceRef": {
+    "message": "Unesite temu (npr. \"Šta je vektorska baza podataka\") ili nalepite ceo članak…",
+    "description": "Placeholder za tekstualno polje izvora"
+  },
+  "description.sourceRef": {
+    "message": "Tema/titula ili ceo tekst članka koji treba pretvoriti u video.",
+    "description": "Pomoć za polje izvora"
+  },
+  "description.extraLangs": {
+    "message": "Ponovno koristi slike, dodatno proizvedi ove jezičke verzije (svaka +6 poena).",
+    "description": "Pomoć za dodatne jezike"
+  },
+  "status.scripting": {
+    "message": "Generiše se skripta",
+    "description": "Generisanje skripte"
+  },
+  "status.generating": {
+    "message": "Generiše se",
+    "description": "Generisanje"
+  },
+  "status.rendering": {
+    "message": "Renderuje se",
+    "description": "Renderovanje"
+  },
+  "button.downloadCaptions": {
+    "message": "Preuzmi titlove",
+    "description": "Dugme za preuzimanje srt"
+  },
+  "message.downloadVideo": {
+    "message": "Preuzmi generisani video",
+    "description": "Tooltip za preuzimanje"
   }
 }

--- a/src/i18n/sv/maestro.json
+++ b/src/i18n/sv/maestro.json
@@ -27,21 +27,17 @@
     "message": "Orsak till misslyckande",
     "description": "Orsak till misslyckande"
   },
-  "name.sourceType": {
-    "message": "Källtyp",
-    "description": "Fält för källtyp"
+  "name.prompt": {
+    "message": "Prompt",
+    "description": "Prompt fält"
   },
-  "name.sourceRef": {
-    "message": "Innehåll",
-    "description": "Fält för källinnehåll"
+  "name.files": {
+    "message": "Referensmaterial",
+    "description": "Referensmedia fält"
   },
-  "name.lang": {
-    "message": "Huvudspråk",
-    "description": "Fält för primärt språk"
-  },
-  "name.extraLangs": {
-    "message": "Extra språk",
-    "description": "Fält för extra språkversioner"
+  "name.langs": {
+    "message": "Språk",
+    "description": "Utgångsspråk fält"
   },
   "name.aspect": {
     "message": "Bildförhållande",
@@ -51,49 +47,41 @@
     "message": "Längd",
     "description": "Mållängdsfält"
   },
-  "name.music": {
-    "message": "Bakgrundsmusik",
-    "description": "Fält för musikväxling"
+  "name.remixing": {
+    "message": "Remix",
+    "description": "Remix banner etikett"
   },
-  "option.topic": {
-    "message": "Ämne",
-    "description": "Källtyp: ett ämne/rubrik"
-  },
-  "option.article": {
-    "message": "Artikel",
-    "description": "Källtyp: fullständig artikeltext"
-  },
-  "placeholder.sourceRef": {
-    "message": "Skriv ett ämne (t.ex. \"Vad är en vektordatabas?\") eller klistra in hela artikeln…",
-    "description": "Platshållare för källtextområde"
+  "placeholder.prompt": {
+    "message": "Beskriv videon du vill ha - tema, vad som ska visas, stil, publik…",
+    "description": "Prompt textarea platshållare"
   },
   "placeholder.select": {
     "message": "Vänligen välj",
     "description": "Allmänt val av platshållare"
   },
-  "description.sourceRef": {
-    "message": "Ett ämne/titel, eller hela texten av artikeln som ska göras till video.",
-    "description": "Hjälp för källfält"
+  "description.prompt": {
+    "message": "Säg tydligt vad du vill ha, manus, bilder, röstöverlagring, klippning lämnar du till Maestro.",
+    "description": "Prompt fält hjälp"
   },
-  "description.extraLangs": {
-    "message": "Återanvända bild, extra utgåvor av dessa språkversioner (varje +6 poäng).",
-    "description": "Extra språk hjälper"
+  "description.langs": {
+    "message": "Kan exportera ett eller flera språk, varje extra språk återanvänder bilden, bara mer röstöverlagring (varje extra +6 poäng).",
+    "description": "Språk hjälp"
+  },
+  "description.files": {
+    "message": "Valfritt. Ladda upp bilder, videor eller ljud för Maestro att använda (som produktbilder, logotyper).",
+    "description": "Filer hjälp"
   },
   "status.pending": {
     "message": "I kö",
     "description": "Väntar"
   },
-  "status.scripting": {
-    "message": "Skripterar",
-    "description": "Skripterar"
+  "status.planning": {
+    "message": "Planering",
+    "description": "Planering"
   },
-  "status.generating": {
-    "message": "Genererar",
-    "description": "Genererar"
-  },
-  "status.rendering": {
-    "message": "Renderar",
-    "description": "Renderar"
+  "status.producing": {
+    "message": "Produktion",
+    "description": "Produktion"
   },
   "status.processing": {
     "message": "Bearbetar",
@@ -107,9 +95,17 @@
     "message": "Ladda ner video",
     "description": "Ladda ner video-knapp"
   },
-  "button.downloadCaptions": {
-    "message": "Ladda ner undertexter",
-    "description": "Ladda ner srt-knapp"
+  "button.uploadFiles": {
+    "message": "Ladda upp filer",
+    "description": "Ladda upp referensfiler-knappen"
+  },
+  "button.remix": {
+    "message": "Remixa",
+    "description": "Remixa denna video-knappen"
+  },
+  "button.cancelRemix": {
+    "message": "Avbryt remix",
+    "description": "Avbryt remix-knappen"
   },
   "message.startingTask": {
     "message": "Skickar videouppgift…",
@@ -127,12 +123,80 @@
     "message": "Krediten är slut, vänligen ladda på för att fortsätta.",
     "description": "Användd upp"
   },
-  "message.downloadVideo": {
-    "message": "Ladda ner den genererade videon",
-    "description": "Nedladdningstips"
+  "message.remixLoaded": {
+    "message": "Remix inläst - beskriv ändringarna du vill ha till vänster och generera.",
+    "description": "Remix inläst toast"
+  },
+  "message.uploadExceed": {
+    "message": "För många filer, vänligen ta bort några och försök igen.",
+    "description": "Överskridande av uppladdning"
+  },
+  "message.uploadError": {
+    "message": "Uppladdning misslyckades, försök igen.",
+    "description": "Uppladdningsfel"
   },
   "message.noTasks": {
     "message": "Inga videor än — skapa din första till vänster.",
     "description": "Inga uppgifter"
+  },
+  "name.sourceType": {
+    "message": "Källtyp",
+    "description": "Fält för källtyp"
+  },
+  "name.sourceRef": {
+    "message": "Innehåll",
+    "description": "Fält för källinnehåll"
+  },
+  "name.lang": {
+    "message": "Huvudspråk",
+    "description": "Fält för primärt språk"
+  },
+  "name.extraLangs": {
+    "message": "Extra språk",
+    "description": "Fält för extra språkversioner"
+  },
+  "name.music": {
+    "message": "Bakgrundsmusik",
+    "description": "Fält för musikväxling"
+  },
+  "option.topic": {
+    "message": "Ämne",
+    "description": "Källtyp: ett ämne/rubrik"
+  },
+  "option.article": {
+    "message": "Artikel",
+    "description": "Källtyp: fullständig artikeltext"
+  },
+  "placeholder.sourceRef": {
+    "message": "Skriv ett ämne (t.ex. \"Vad är en vektordatabas?\") eller klistra in hela artikeln…",
+    "description": "Platshållare för källtextområde"
+  },
+  "description.sourceRef": {
+    "message": "Ett ämne/titel, eller hela texten av artikeln som ska göras till video.",
+    "description": "Hjälp för källfält"
+  },
+  "description.extraLangs": {
+    "message": "Återanvända bild, extra utgåvor av dessa språkversioner (varje +6 poäng).",
+    "description": "Extra språk hjälper"
+  },
+  "status.scripting": {
+    "message": "Skripterar",
+    "description": "Skripterar"
+  },
+  "status.generating": {
+    "message": "Genererar",
+    "description": "Genererar"
+  },
+  "status.rendering": {
+    "message": "Renderar",
+    "description": "Renderar"
+  },
+  "button.downloadCaptions": {
+    "message": "Ladda ner undertexter",
+    "description": "Ladda ner srt-knapp"
+  },
+  "message.downloadVideo": {
+    "message": "Ladda ner den genererade videon",
+    "description": "Nedladdningstips"
   }
 }

--- a/src/i18n/uk/maestro.json
+++ b/src/i18n/uk/maestro.json
@@ -27,21 +27,17 @@
     "message": "Причина невдачі",
     "description": "Причина невдачі"
   },
-  "name.sourceType": {
-    "message": "Тип джерела",
-    "description": "Поле типу джерела"
+  "name.prompt": {
+    "message": "Підказка",
+    "description": "Поле підказки"
   },
-  "name.sourceRef": {
-    "message": "Контент",
-    "description": "Поле джерела контенту"
+  "name.files": {
+    "message": "Матеріали для посилання",
+    "description": "Поле для медіа посилань"
   },
-  "name.lang": {
-    "message": "Основна мова",
-    "description": "Поле основної мови"
-  },
-  "name.extraLangs": {
-    "message": "Додаткові мови",
-    "description": "Поле для додаткових мовних версій"
+  "name.langs": {
+    "message": "Мови",
+    "description": "Поле для мов виводу"
   },
   "name.aspect": {
     "message": "Співвідношення сторін",
@@ -51,49 +47,41 @@
     "message": "Тривалість",
     "description": "Поле цільової тривалості"
   },
-  "name.music": {
-    "message": "Фоновий музика",
-    "description": "Поле перемикання музики"
+  "name.remixing": {
+    "message": "Ремікс",
+    "description": "Мітка банера реміксу"
   },
-  "option.topic": {
-    "message": "Тема",
-    "description": "Тип джерела: тема/заголовок"
-  },
-  "option.article": {
-    "message": "Стаття",
-    "description": "Тип джерела: повний текст статті"
-  },
-  "placeholder.sourceRef": {
-    "message": "Введіть тему (наприклад, “Що таке векторна база даних”) або вставте повну статтю…",
-    "description": "Заповнювач текстової області джерела"
+  "placeholder.prompt": {
+    "message": "Опишіть, яке відео ви хочете — тему, що показати, стиль, аудиторію…",
+    "description": "Плейсхолдер текстового поля підказки"
   },
   "placeholder.select": {
     "message": "Будь ласка, виберіть",
     "description": "Загальний заповнювач для вибору"
   },
-  "description.sourceRef": {
-    "message": "Тема/заголовок або повний текст статті, яку потрібно перетворити на відео.",
-    "description": "Допомога для поля джерела"
+  "description.prompt": {
+    "message": "Чітко сформулюйте, що ви хочете, сценарій, кадри, озвучення, монтаж - все це Maestro.",
+    "description": "Допомога для поля підказки"
   },
-  "description.extraLangs": {
-    "message": "Використовуйте зображення, додатково створіть ці мовні версії (кожна +6 балів).",
-    "description": "Допомога з додатковими мовами"
+  "description.langs": {
+    "message": "Можна вивести одну або кілька мов, кожна додаткова мова використовує той же кадр, лише додається озвучення (кожна додаткова +6 балів).",
+    "description": "Допомога щодо мов"
+  },
+  "description.files": {
+    "message": "Необов'язково. Завантажте зображення, відео або аудіо для використання Maestro (наприклад, зображення продукту, логотип).",
+    "description": "Допомога щодо файлів"
   },
   "status.pending": {
     "message": "В черзі",
     "description": "Очікування"
   },
-  "status.scripting": {
-    "message": "Генерація скрипту",
-    "description": "Генерація скрипту"
+  "status.planning": {
+    "message": "В процесі планування",
+    "description": "Планування"
   },
-  "status.generating": {
-    "message": "Генерація",
-    "description": "Генерація"
-  },
-  "status.rendering": {
-    "message": "Рендеринг",
-    "description": "Рендеринг"
+  "status.producing": {
+    "message": "В процесі виробництва",
+    "description": "Виробництво"
   },
   "status.processing": {
     "message": "Обробка",
@@ -107,9 +95,17 @@
     "message": "Завантажити відео",
     "description": "Кнопка для завантаження відео"
   },
-  "button.downloadCaptions": {
-    "message": "Завантажити субтитри",
-    "description": "Кнопка для завантаження srt"
+  "button.uploadFiles": {
+    "message": "Завантажити файли",
+    "description": "Кнопка для завантаження файлів посилань"
+  },
+  "button.remix": {
+    "message": "Ремікс",
+    "description": "Кнопка для реміксу цього відео"
+  },
+  "button.cancelRemix": {
+    "message": "Скасувати ремікс",
+    "description": "Кнопка скасування реміксу"
   },
   "message.startingTask": {
     "message": "Надсилаємо відеозавдання…",
@@ -127,12 +123,80 @@
     "message": "Ліміт вичерпано, будь ласка, поповніть рахунок для продовження.",
     "description": "Вичерпано"
   },
-  "message.downloadVideo": {
-    "message": "Завантажити згенероване відео",
-    "description": "Підказка для завантаження"
+  "message.remixLoaded": {
+    "message": "Завантажено ремікс — опишіть бажані зміни зліва, а потім згенеруйте.",
+    "description": "Тост про завантажений ремікс"
+  },
+  "message.uploadExceed": {
+    "message": "Занадто багато файлів, будь ласка, видаліть деякі та спробуйте ще раз.",
+    "description": "Перевищення кількості завантажень"
+  },
+  "message.uploadError": {
+    "message": "Завантаження не вдалося, будь ласка, спробуйте ще раз.",
+    "description": "Помилка завантаження"
   },
   "message.noTasks": {
     "message": "Ще немає відео — створіть своє перше зліва.",
     "description": "Відсутність завдань"
+  },
+  "name.sourceType": {
+    "message": "Тип джерела",
+    "description": "Поле типу джерела"
+  },
+  "name.sourceRef": {
+    "message": "Контент",
+    "description": "Поле джерела контенту"
+  },
+  "name.lang": {
+    "message": "Основна мова",
+    "description": "Поле основної мови"
+  },
+  "name.extraLangs": {
+    "message": "Додаткові мови",
+    "description": "Поле для додаткових мовних версій"
+  },
+  "name.music": {
+    "message": "Фоновий музика",
+    "description": "Поле перемикання музики"
+  },
+  "option.topic": {
+    "message": "Тема",
+    "description": "Тип джерела: тема/заголовок"
+  },
+  "option.article": {
+    "message": "Стаття",
+    "description": "Тип джерела: повний текст статті"
+  },
+  "placeholder.sourceRef": {
+    "message": "Введіть тему (наприклад, “Що таке векторна база даних”) або вставте повну статтю…",
+    "description": "Заповнювач текстової області джерела"
+  },
+  "description.sourceRef": {
+    "message": "Тема/заголовок або повний текст статті, яку потрібно перетворити на відео.",
+    "description": "Допомога для поля джерела"
+  },
+  "description.extraLangs": {
+    "message": "Використовуйте зображення, додатково створіть ці мовні версії (кожна +6 балів).",
+    "description": "Допомога з додатковими мовами"
+  },
+  "status.scripting": {
+    "message": "Генерація скрипту",
+    "description": "Генерація скрипту"
+  },
+  "status.generating": {
+    "message": "Генерація",
+    "description": "Генерація"
+  },
+  "status.rendering": {
+    "message": "Рендеринг",
+    "description": "Рендеринг"
+  },
+  "button.downloadCaptions": {
+    "message": "Завантажити субтитри",
+    "description": "Кнопка для завантаження srt"
+  },
+  "message.downloadVideo": {
+    "message": "Завантажити згенероване відео",
+    "description": "Підказка для завантаження"
   }
 }

--- a/src/i18n/zh-CN/maestro.json
+++ b/src/i18n/zh-CN/maestro.json
@@ -27,21 +27,17 @@
     "message": "失败原因",
     "description": "Failure reason"
   },
-  "name.sourceType": {
-    "message": "来源类型",
-    "description": "Source type field"
+  "name.prompt": {
+    "message": "提示词",
+    "description": "Prompt field"
   },
-  "name.sourceRef": {
-    "message": "内容",
-    "description": "Source content field"
+  "name.files": {
+    "message": "参考素材",
+    "description": "Reference media field"
   },
-  "name.lang": {
-    "message": "主语言",
-    "description": "Primary language field"
-  },
-  "name.extraLangs": {
-    "message": "额外语言",
-    "description": "Extra language versions field"
+  "name.langs": {
+    "message": "语言",
+    "description": "Output languages field"
   },
   "name.aspect": {
     "message": "画面比例",
@@ -51,49 +47,41 @@
     "message": "时长",
     "description": "Target duration field"
   },
-  "name.music": {
-    "message": "背景音乐",
-    "description": "Music toggle field"
+  "name.remixing": {
+    "message": "二次创作",
+    "description": "Remix banner label"
   },
-  "option.topic": {
-    "message": "话题",
-    "description": "Source type: a topic/headline"
-  },
-  "option.article": {
-    "message": "文章",
-    "description": "Source type: full article text"
-  },
-  "placeholder.sourceRef": {
-    "message": "输入一个话题(如“什么是向量数据库”)或粘贴整篇文章…",
-    "description": "Source textarea placeholder"
+  "placeholder.prompt": {
+    "message": "描述你想要的视频——主题、要展示什么、风格、受众……",
+    "description": "Prompt textarea placeholder"
   },
   "placeholder.select": {
     "message": "请选择",
     "description": "Generic select placeholder"
   },
-  "description.sourceRef": {
-    "message": "一个话题/标题,或要做成视频的整篇文章正文。",
-    "description": "Source field help"
+  "description.prompt": {
+    "message": "用大白话说清楚你想要什么,脚本、画面、配音、剪辑都交给 Maestro。",
+    "description": "Prompt field help"
   },
-  "description.extraLangs": {
-    "message": "复用画面,额外产出这些语言版本(每种 +6 积分)。",
-    "description": "Extra langs help"
+  "description.langs": {
+    "message": "可输出一种或多种语言,每多一种语言复用画面、只多配音(每多一种 +6 积分)。",
+    "description": "Languages help"
+  },
+  "description.files": {
+    "message": "可选。上传图片、视频或音频供 Maestro 使用(如产品图、logo)。",
+    "description": "Files help"
   },
   "status.pending": {
     "message": "排队中",
     "description": "Pending"
   },
-  "status.scripting": {
-    "message": "脚本生成中",
-    "description": "Scripting"
+  "status.planning": {
+    "message": "策划中",
+    "description": "Planning"
   },
-  "status.generating": {
-    "message": "画面生成中",
-    "description": "Generating"
-  },
-  "status.rendering": {
-    "message": "渲染中",
-    "description": "Rendering"
+  "status.producing": {
+    "message": "制作中",
+    "description": "Producing"
   },
   "status.processing": {
     "message": "处理中",
@@ -107,9 +95,17 @@
     "message": "下载视频",
     "description": "Download video button"
   },
-  "button.downloadCaptions": {
-    "message": "下载字幕",
-    "description": "Download srt button"
+  "button.uploadFiles": {
+    "message": "上传文件",
+    "description": "Upload reference files button"
+  },
+  "button.remix": {
+    "message": "二次创作",
+    "description": "Remix this video button"
+  },
+  "button.cancelRemix": {
+    "message": "取消二次创作",
+    "description": "Cancel remix button"
   },
   "message.startingTask": {
     "message": "正在提交视频任务…",
@@ -127,9 +123,17 @@
     "message": "额度已用完,请充值后继续。",
     "description": "Used up"
   },
-  "message.downloadVideo": {
-    "message": "下载生成的视频",
-    "description": "Download tooltip"
+  "message.remixLoaded": {
+    "message": "已载入二次创作——在左侧描述想要的修改,然后生成。",
+    "description": "Remix loaded toast"
+  },
+  "message.uploadExceed": {
+    "message": "文件过多,请删除一些后重试。",
+    "description": "Upload exceed"
+  },
+  "message.uploadError": {
+    "message": "上传失败,请重试。",
+    "description": "Upload error"
   },
   "message.noTasks": {
     "message": "还没有视频 — 在左侧创建你的第一个吧。",

--- a/src/i18n/zh-TW/maestro.json
+++ b/src/i18n/zh-TW/maestro.json
@@ -27,21 +27,17 @@
     "message": "失敗原因",
     "description": "失敗原因"
   },
-  "name.sourceType": {
-    "message": "來源類型",
-    "description": "來源類型字段"
+  "name.prompt": {
+    "message": "提示詞",
+    "description": "提示詞欄位"
   },
-  "name.sourceRef": {
-    "message": "內容",
-    "description": "來源內容字段"
+  "name.files": {
+    "message": "參考素材",
+    "description": "參考媒體欄位"
   },
-  "name.lang": {
-    "message": "主語言",
-    "description": "主要語言字段"
-  },
-  "name.extraLangs": {
-    "message": "額外語言",
-    "description": "額外語言版本字段"
+  "name.langs": {
+    "message": "語言",
+    "description": "輸出語言欄位"
   },
   "name.aspect": {
     "message": "畫面比例",
@@ -51,49 +47,41 @@
     "message": "時長",
     "description": "目標時長字段"
   },
-  "name.music": {
-    "message": "背景音樂",
-    "description": "音樂切換字段"
+  "name.remixing": {
+    "message": "二次創作",
+    "description": "二次創作橫幅標籤"
   },
-  "option.topic": {
-    "message": "話題",
-    "description": "來源類型：一個話題/標題"
-  },
-  "option.article": {
-    "message": "文章",
-    "description": "來源類型：完整文章文本"
-  },
-  "placeholder.sourceRef": {
-    "message": "輸入一個話題(如“什麼是向量資料庫”)或粘貼整篇文章…",
-    "description": "來源文本區域佔位符"
+  "placeholder.prompt": {
+    "message": "描述你想要的視頻——主題、要展示什麼、風格、受眾……",
+    "description": "提示詞文本區佔位符"
   },
   "placeholder.select": {
     "message": "請選擇",
     "description": "通用選擇佔位符"
   },
-  "description.sourceRef": {
-    "message": "一個話題/標題，或要做成視頻的整篇文章正文。",
-    "description": "來源字段幫助"
+  "description.prompt": {
+    "message": "用大白話說清楚你想要什麼,腳本、畫面、配音、剪輯都交給 Maestro。",
+    "description": "提示詞欄位幫助"
   },
-  "description.extraLangs": {
-    "message": "重用畫面，額外產出這些語言版本（每種 +6 積分）。",
-    "description": "額外語言幫助"
+  "description.langs": {
+    "message": "可輸出一種或多種語言,每多一種語言復用畫面、只多配音(每多一種 +6 積分)。",
+    "description": "語言幫助"
+  },
+  "description.files": {
+    "message": "可選。上傳圖片、視頻或音頻供 Maestro 使用(如產品圖、logo)。",
+    "description": "文件幫助"
   },
   "status.pending": {
     "message": "排隊中",
     "description": "等待中"
   },
-  "status.scripting": {
-    "message": "腳本生成中",
-    "description": "正在生成腳本"
+  "status.planning": {
+    "message": "策劃中",
+    "description": "策劃階段"
   },
-  "status.generating": {
-    "message": "畫面生成中",
-    "description": "正在生成"
-  },
-  "status.rendering": {
-    "message": "渲染中",
-    "description": "正在渲染"
+  "status.producing": {
+    "message": "製作中",
+    "description": "製作階段"
   },
   "status.processing": {
     "message": "處理中",
@@ -107,9 +95,17 @@
     "message": "下載視頻",
     "description": "下載視頻按鈕"
   },
-  "button.downloadCaptions": {
-    "message": "下載字幕",
-    "description": "下載 srt 按鈕"
+  "button.uploadFiles": {
+    "message": "上傳文件",
+    "description": "上傳參考文件的按鈕"
+  },
+  "button.remix": {
+    "message": "二次創作",
+    "description": "對此視頻進行二次創作的按鈕"
+  },
+  "button.cancelRemix": {
+    "message": "取消二次創作",
+    "description": "取消二次創作的按鈕"
   },
   "message.startingTask": {
     "message": "正在提交視頻任務…",
@@ -127,12 +123,80 @@
     "message": "額度已用完，請充值後繼續。",
     "description": "已用完"
   },
-  "message.downloadVideo": {
-    "message": "下載生成的視頻",
-    "description": "下載提示"
+  "message.remixLoaded": {
+    "message": "已載入二次創作——在左側描述想要的修改,然後生成。",
+    "description": "二次創作載入的提示"
+  },
+  "message.uploadExceed": {
+    "message": "文件過多,請刪除一些後重試。",
+    "description": "上傳超過限制"
+  },
+  "message.uploadError": {
+    "message": "上傳失敗,請重試。",
+    "description": "上傳錯誤"
   },
   "message.noTasks": {
     "message": "還沒有視頻 — 在左側創建你的第一個吧。",
     "description": "沒有任務"
+  },
+  "name.sourceType": {
+    "message": "來源類型",
+    "description": "來源類型字段"
+  },
+  "name.sourceRef": {
+    "message": "內容",
+    "description": "來源內容字段"
+  },
+  "name.lang": {
+    "message": "主語言",
+    "description": "主要語言字段"
+  },
+  "name.extraLangs": {
+    "message": "額外語言",
+    "description": "額外語言版本字段"
+  },
+  "name.music": {
+    "message": "背景音樂",
+    "description": "音樂切換字段"
+  },
+  "option.topic": {
+    "message": "話題",
+    "description": "來源類型：一個話題/標題"
+  },
+  "option.article": {
+    "message": "文章",
+    "description": "來源類型：完整文章文本"
+  },
+  "placeholder.sourceRef": {
+    "message": "輸入一個話題(如“什麼是向量資料庫”)或粘貼整篇文章…",
+    "description": "來源文本區域佔位符"
+  },
+  "description.sourceRef": {
+    "message": "一個話題/標題，或要做成視頻的整篇文章正文。",
+    "description": "來源字段幫助"
+  },
+  "description.extraLangs": {
+    "message": "重用畫面，額外產出這些語言版本（每種 +6 積分）。",
+    "description": "額外語言幫助"
+  },
+  "status.scripting": {
+    "message": "腳本生成中",
+    "description": "正在生成腳本"
+  },
+  "status.generating": {
+    "message": "畫面生成中",
+    "description": "正在生成"
+  },
+  "status.rendering": {
+    "message": "渲染中",
+    "description": "正在渲染"
+  },
+  "button.downloadCaptions": {
+    "message": "下載字幕",
+    "description": "下載 srt 按鈕"
+  },
+  "message.downloadVideo": {
+    "message": "下載生成的視頻",
+    "description": "下載提示"
   }
 }

--- a/src/models/maestro.ts
+++ b/src/models/maestro.ts
@@ -1,38 +1,44 @@
+export type IMaestroAction = 'generate' | 'remix' | 'edit' | 'extend';
+
 export interface IMaestroConfig {
-  source_type?: string; // 'Topic' | 'Article'
-  source_ref?: string;
-  lang?: string;
-  extra_langs?: string[];
+  prompt?: string;
+  action?: IMaestroAction;
+  ref_task_id?: string;
+  file_urls?: string[];
+  langs?: string[];
   aspect?: string; // '9:16' | '16:9' | '1:1'
   duration?: number;
-  music?: boolean;
   callback_url?: string;
 }
 
-export interface IMaestroGenerateRequest extends IMaestroConfig {
-  async?: boolean;
-}
+export type IMaestroGenerateRequest = IMaestroConfig;
 
 export interface IMaestroVariant {
-  variant?: string;
   lang?: string;
   aspect?: string;
+  kind?: string; // 'video'
+  title?: string;
   output_url?: string;
-  captions_url?: string;
-  duration?: number;
-  qc_score?: number | null;
-  state?: string;
 }
 
-export interface IMaestroStoryboard {
-  title?: string;
-  hook?: string;
-  scenes?: unknown[];
+export interface IMaestroProgress {
+  stage?: string;
+  message?: string;
+  pct?: number | null;
+  t?: number;
+}
+
+export interface IMaestroProject {
+  cos_prefix?: string;
+  tarball_url?: string;
+  outputs?: string[];
 }
 
 export interface IMaestroData {
   variants?: IMaestroVariant[];
-  storyboard?: IMaestroStoryboard;
+  project?: IMaestroProject;
+  progress?: IMaestroProgress[];
+  stage?: string;
 }
 
 export interface IMaestroGenerateResponse {
@@ -40,10 +46,15 @@ export interface IMaestroGenerateResponse {
   task_id: string;
   trace_id?: string;
   data?: IMaestroData;
-  error?: {
-    code?: string;
-    message?: string;
-  };
+  // The worker sets a plain string on failure; objects are also tolerated.
+  error?: string | { code?: string; message?: string };
+}
+
+export interface IMaestroAgentStats {
+  model?: string;
+  cost_usd?: number;
+  turns?: number;
+  tool_calls?: number;
 }
 
 export interface IMaestroTask {
@@ -53,6 +64,7 @@ export interface IMaestroTask {
   elapsed?: number;
   request?: IMaestroGenerateRequest;
   response?: IMaestroGenerateResponse;
+  agent?: IMaestroAgentStats;
 }
 
 export type IMaestroTaskResponse = IMaestroTask;

--- a/src/pages/maestro/Index.vue
+++ b/src/pages/maestro/Index.vue
@@ -115,8 +115,7 @@ export default defineComponent({
     },
     async onGenerate() {
       const request = {
-        ...this.config,
-        async: true
+        ...this.config
       } as IMaestroGenerateRequest;
       const token = this.credential?.token;
       if (!token) {


### PR DESCRIPTION
## Why

The Nexior **Maestro** consumer module (added in #987, still **gated off** via `site.features.maestro.enabled`) was built for the **dead v3 contract** — every generate would `400 missing field: prompt` against the live **v4 agent-native API**. This rewrites the module to v4 so the page actually works.

Paired with PlatformBackend #724 (billing/OpenAPI/docs → v4).

## What

- **models / constants** → v4 request (`prompt` / `action` / `ref_task_id` / `file_urls[]` / `langs[]` / `aspect` / `duration`) + v4 response shapes (`variants` / `progress` / `project` / `stage`). Dropped `source_type` / `source_ref` / `lang` / `extra_langs` / `music`.
- **ConfigPanel**: prompt textarea (required), reference-media upload, **langs** multi-select (replaces lang + extra_langs), aspect, duration, and a **remix banner** when iterating on a past video.
- **FileUrlsInput** (new): uploads images / video / audio → `file_urls[]` (reuses `/api/v1/files/`).
- **Preview**: shows the `prompt`, **live progress** (stage + pct) while producing, one player per language `variant` (with title), a **Remix** button (loads `action:remix` + `ref_task_id`), input-file count. Dropped the captions button (v4 burns captions in).
- **Index**: dropped the obsolete `async:true`.
- **i18n**: v4 keys for `en` + `zh-CN`; 16 other locales backfilled via `translate_i18n.py`. All 18 locales cover every key; 0 missing `$t()` references.

## Capabilities

Supports the full v4 surface you asked for: **prompt + file upload + multi-language + aspect + duration + remix/edit/extend**.

## Verification

- `npm run build` (vue-tsc) **passes**.
- i18n coverage check: every `zh-CN` maestro key present in all 18 locales; no component `$t()` references a missing key.
- Live contract confirmed against prod (`POST /maestro/videos` accepts the v4 body; v3 body returns `400 missing field: prompt`).

## Activation (after merge)

Flip the prod `Site.features.maestro.enabled` flag to surface the nav entry + `/maestro` route. (Best done after PlatformBackend #724 is synced so the displayed price matches the charge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
