### PR TITLE
fix(realtime): render voice-call control icons in RealtimeCall

### DIFF
--- a/change/fix-realtime-fa-icon-1781974941.json
+++ b/change/fix-realtime-fa-icon-1781974941.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(realtime): register FontAwesomeIcon in RealtimeCall so voice-call control icons render",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/pages/chat/RealtimeCall.vue
+++ b/src/pages/chat/RealtimeCall.vue
@@ -63,12 +63,16 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { RealtimeClient, RealtimeStatus } from '@/utils/realtimeClient';
 import { REALTIME_DEFAULT_MODEL } from '@/constants';
 import { ROUTE_CHATGPT_CONVERSATION_NEW } from '@/router/constants';
 
 export default defineComponent({
   name: 'RealtimeCall',
+  components: {
+    FontAwesomeIcon
+  },
   data() {
     return {
       client: undefined as RealtimeClient | undefined,


### PR DESCRIPTION
## Problem
ChatGPT 的语音实时通话页面 (`RealtimeCall.vue`) 中，底部三个控制按钮（静音 / 字幕 / 挂断）以及顶部图标都不显示 icon。

## Root cause
本项目中 `<font-awesome-icon>` **不是全局注册**的组件 —— 172 个用到该标签的 `.vue` 文件里，每个都各自局部 `import { FontAwesomeIcon }` 并在 `components` 中注册。新加入的 `RealtimeCall.vue` 用了 6 次 `<font-awesome-icon>`，却漏掉了这一步，Vue 无法解析该标签，所有图标渲染为空白。

> 注意：`src/plugins/font-awesome.ts` 里的 `library.add(...)` 只加载图标**定义**（microphone / closed-captioning / xmark 等都齐全），并不负责注册组件本身 —— 所以这不是图标缺失的问题。

## Fix
在 `RealtimeCall.vue` 中 import 并注册 `FontAwesomeIcon`，与其余 171 个组件保持一致。

已扫描全部 `.vue` 文件确认这是唯一遗漏；`eslint` 与 `vue-tsc` 均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)