### PR TITLE
fix(maestro/grokvideo): add maestro to site feature toggles + missing i18n

### DIFF
--- a/change/@acedatacloud-nexior-acb4a4e5-3c40-4f9a-bde5-0b4c67b7793d.json
+++ b/change/@acedatacloud-nexior-acb4a4e5-3c40-4f9a-bde5-0b4c67b7793d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(maestro/grokvideo): site feature toggle + missing i18n keys",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/setting/Function.vue
+++ b/src/components/setting/Function.vue
@@ -112,6 +112,7 @@ const FEATURE_KEYS = [
   'seedream',
   'seedance',
   'grokvideo',
+  'maestro',
   'wan',
   'producer',
   'kimi',

--- a/src/i18n/ar/site.json
+++ b/src/i18n/ar/site.json
@@ -95,6 +95,14 @@
     "message": "غروك",
     "description": "عرض في مربع التحرير"
   },
+  "field.featuresGrokvideo": {
+    "message": "فيديو غروك",
+    "description": "يظهر كعنوان في صندوق التحرير"
+  },
+  "field.featuresMaestro": {
+    "message": "مايسترو",
+    "description": "يظهر كعنوان في صندوق التحرير"
+  },
   "field.featuresDeepseek": {
     "message": "ديب سيك",
     "description": "عرض في مربع التحرير"
@@ -434,6 +442,14 @@
   "message.featuresGrok": {
     "message": "تفعيل أو تعطيل وحدة وظيفة جروك.",
     "description": "وصف وظيفة جروك"
+  },
+  "message.featuresGrokvideo": {
+    "message": "قم بتمكين أو تعطيل وحدة ميزات فيديو غروك.",
+    "description": "وصف ميزة فيديو غروك"
+  },
+  "message.featuresMaestro": {
+    "message": "قم بتمكين أو تعطيل وحدة ميزات مايسترو.",
+    "description": "وصف ميزة مايسترو"
   },
   "message.featuresDeepseek": {
     "message": "تفعيل أو تعطيل وحدة وظيفة ديبسيك.",

--- a/src/i18n/de/site.json
+++ b/src/i18n/de/site.json
@@ -95,6 +95,14 @@
     "message": "Grok",
     "description": "Anzeige im Bearbeitungsfeld"
   },
+  "field.featuresGrokvideo": {
+    "message": "Grok Video",
+    "description": "Wird als Titel im Bearbeitungsfeld angezeigt"
+  },
+  "field.featuresMaestro": {
+    "message": "Maestro",
+    "description": "Wird als Titel im Bearbeitungsfeld angezeigt"
+  },
   "field.featuresDeepseek": {
     "message": "Deepseek",
     "description": "Anzeige im Bearbeitungsfeld"
@@ -434,6 +442,14 @@
   "message.featuresGrok": {
     "message": "Grok-Funktion aktivieren oder deaktivieren.",
     "description": "Beschreibung der Grok-Funktion"
+  },
+  "message.featuresGrokvideo": {
+    "message": "Aktivieren oder Deaktivieren des Grok Video Funktionsmoduls.",
+    "description": "Beschreibung der Grok Video Funktion"
+  },
+  "message.featuresMaestro": {
+    "message": "Aktivieren oder Deaktivieren des Maestro Funktionsmoduls.",
+    "description": "Beschreibung der Maestro Funktion"
   },
   "message.featuresDeepseek": {
     "message": "Deepseek-Funktion aktivieren oder deaktivieren.",

--- a/src/i18n/el/site.json
+++ b/src/i18n/el/site.json
@@ -95,6 +95,14 @@
     "message": "Grok",
     "description": "展示在编辑框的标题"
   },
+  "field.featuresGrokvideo": {
+    "message": "Grok Video",
+    "description": "Εμφανίζεται ως ο τίτλος στο πλαίσιο επεξεργασίας"
+  },
+  "field.featuresMaestro": {
+    "message": "Maestro",
+    "description": "Εμφανίζεται ως ο τίτλος στο πλαίσιο επεξεργασίας"
+  },
   "field.featuresDeepseek": {
     "message": "Deepseek",
     "description": "展示在编辑框的标题"
@@ -434,6 +442,14 @@
   "message.featuresGrok": {
     "message": "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Grok.",
     "description": "Περιγραφή της λειτουργίας Grok"
+  },
+  "message.featuresGrokvideo": {
+    "message": "Ενεργοποιήστε ή απενεργοποιήστε το module λειτουργίας Grok Video.",
+    "description": "Περιγραφή της λειτουργίας Grok Video"
+  },
+  "message.featuresMaestro": {
+    "message": "Ενεργοποιήστε ή απενεργοποιήστε το module λειτουργίας Maestro.",
+    "description": "Περιγραφή της λειτουργίας Maestro"
   },
   "message.featuresDeepseek": {
     "message": "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Deepseek.",

--- a/src/i18n/en/site.json
+++ b/src/i18n/en/site.json
@@ -95,6 +95,14 @@
     "message": "Grok",
     "description": "Displayed as the title in the editing box"
   },
+  "field.featuresGrokvideo": {
+    "message": "Grok Video",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresMaestro": {
+    "message": "Maestro",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresDeepseek": {
     "message": "Deepseek",
     "description": "Displayed as the title in the editing box"
@@ -434,6 +442,14 @@
   "message.featuresGrok": {
     "message": "Enable or disable the Grok feature module.",
     "description": "Description of the Grok feature"
+  },
+  "message.featuresGrokvideo": {
+    "message": "Enable or disable the Grok Video feature module.",
+    "description": "Description of the Grok Video feature"
+  },
+  "message.featuresMaestro": {
+    "message": "Enable or disable the Maestro feature module.",
+    "description": "Description of the Maestro feature"
   },
   "message.featuresDeepseek": {
     "message": "Enable or disable the Deepseek feature module.",

--- a/src/i18n/es/site.json
+++ b/src/i18n/es/site.json
@@ -95,6 +95,14 @@
     "message": "Grok",
     "description": "Texto que se muestra en el cuadro de edición"
   },
+  "field.featuresGrokvideo": {
+    "message": "Grok Video",
+    "description": "Se muestra como el título en el cuadro de edición"
+  },
+  "field.featuresMaestro": {
+    "message": "Maestro",
+    "description": "Se muestra como el título en el cuadro de edición"
+  },
   "field.featuresDeepseek": {
     "message": "Deepseek",
     "description": "Texto que se muestra en el cuadro de edición"
@@ -434,6 +442,14 @@
   "message.featuresGrok": {
     "message": "Activar o desactivar el módulo de función de Grok.",
     "description": "Descripción de la función de Grok"
+  },
+  "message.featuresGrokvideo": {
+    "message": "Habilitar o deshabilitar el módulo de funciones de Grok Video.",
+    "description": "Descripción de la función Grok Video"
+  },
+  "message.featuresMaestro": {
+    "message": "Habilitar o deshabilitar el módulo de funciones de Maestro.",
+    "description": "Descripción de la función Maestro"
   },
   "message.featuresDeepseek": {
     "message": "Activar o desactivar el módulo de función de Deepseek.",

--- a/src/i18n/fi/site.json
+++ b/src/i18n/fi/site.json
@@ -95,6 +95,14 @@
     "message": "Grok",
     "description": "Näytetään muokkausruudun otsikkona"
   },
+  "field.featuresGrokvideo": {
+    "message": "Grok Video",
+    "description": "Näytetään otsikkona muokkausruudussa"
+  },
+  "field.featuresMaestro": {
+    "message": "Maestro",
+    "description": "Näytetään otsikkona muokkausruudussa"
+  },
   "field.featuresDeepseek": {
     "message": "Deepseek",
     "description": "Näytetään muokkausruudun otsikkona"
@@ -434,6 +442,14 @@
   "message.featuresGrok": {
     "message": "Avaa tai sulje Grok-toimintomoduuli.",
     "description": "Grok-toiminnon kuvaus"
+  },
+  "message.featuresGrokvideo": {
+    "message": "Ota käyttöön tai poista käytöstä Grok Video -toimintomoduuli.",
+    "description": "Grok Video -toiminnon kuvaus"
+  },
+  "message.featuresMaestro": {
+    "message": "Ota käyttöön tai poista käytöstä Maestro-toimintomoduuli.",
+    "description": "Maestro-toiminnon kuvaus"
   },
   "message.featuresDeepseek": {
     "message": "Avaa tai sulje Deepseek-toimintomoduuli.",

--- a/src/i18n/fr/site.json
+++ b/src/i18n/fr/site.json
@@ -95,6 +95,14 @@
     "message": "Grok",
     "description": "Affiché comme titre dans la zone d'édition"
   },
+  "field.featuresGrokvideo": {
+    "message": "Grok Video",
+    "description": "Affiché comme le titre dans la boîte d'édition"
+  },
+  "field.featuresMaestro": {
+    "message": "Maestro",
+    "description": "Affiché comme le titre dans la boîte d'édition"
+  },
   "field.featuresDeepseek": {
     "message": "Deepseek",
     "description": "Affiché comme titre dans la zone d'édition"
@@ -434,6 +442,14 @@
   "message.featuresGrok": {
     "message": "Activer ou désactiver le module de fonction Grok.",
     "description": "Description de la fonction Grok"
+  },
+  "message.featuresGrokvideo": {
+    "message": "Activer ou désactiver le module de fonctionnalité Grok Video.",
+    "description": "Description de la fonctionnalité Grok Video"
+  },
+  "message.featuresMaestro": {
+    "message": "Activer ou désactiver le module de fonctionnalité Maestro.",
+    "description": "Description de la fonctionnalité Maestro"
   },
   "message.featuresDeepseek": {
     "message": "Activer ou désactiver le module de fonction Deepseek.",

--- a/src/i18n/it/site.json
+++ b/src/i18n/it/site.json
@@ -95,6 +95,14 @@
     "message": "Grok",
     "description": "Mostrato nel campo di modifica del titolo"
   },
+  "field.featuresGrokvideo": {
+    "message": "Grok Video",
+    "description": "Visualizzato come titolo nella casella di modifica"
+  },
+  "field.featuresMaestro": {
+    "message": "Maestro",
+    "description": "Visualizzato come titolo nella casella di modifica"
+  },
   "field.featuresDeepseek": {
     "message": "Deepseek",
     "description": "Mostrato nel campo di modifica del titolo"
@@ -434,6 +442,14 @@
   "message.featuresGrok": {
     "message": "Attiva o disattiva il modulo funzionalità Grok.",
     "description": "Descrizione della funzionalità Grok"
+  },
+  "message.featuresGrokvideo": {
+    "message": "Abilita o disabilita il modulo funzionale Grok Video.",
+    "description": "Descrizione della funzionalità Grok Video"
+  },
+  "message.featuresMaestro": {
+    "message": "Abilita o disabilita il modulo funzionale Maestro.",
+    "description": "Descrizione della funzionalità Maestro"
   },
   "message.featuresDeepseek": {
     "message": "Attiva o disattiva il modulo funzionalità Deepseek.",

--- a/src/i18n/ja/site.json
+++ b/src/i18n/ja/site.json
@@ -95,6 +95,14 @@
     "message": "Grok",
     "description": "編集ボックスに表示されるタイトル"
   },
+  "field.featuresGrokvideo": {
+    "message": "グロックビデオ",
+    "description": "編集ボックスのタイトルとして表示されます"
+  },
+  "field.featuresMaestro": {
+    "message": "マエストロ",
+    "description": "編集ボックスのタイトルとして表示されます"
+  },
   "field.featuresDeepseek": {
     "message": "Deepseek",
     "description": "編集ボックスに表示されるタイトル"
@@ -434,6 +442,14 @@
   "message.featuresGrok": {
     "message": "Grok機能モジュールをオンまたはオフにします。",
     "description": "Grok機能の説明"
+  },
+  "message.featuresGrokvideo": {
+    "message": "Grok Video機能モジュールを有効または無効にします。",
+    "description": "Grok Video機能の説明"
+  },
+  "message.featuresMaestro": {
+    "message": "Maestro機能モジュールを有効または無効にします。",
+    "description": "Maestro機能の説明"
   },
   "message.featuresDeepseek": {
     "message": "Deepseek機能モジュールをオンまたはオフにします。",

--- a/src/i18n/ko/site.json
+++ b/src/i18n/ko/site.json
@@ -95,6 +95,14 @@
     "message": "Grok",
     "description": "편집 상자에 표시되는 제목"
   },
+  "field.featuresGrokvideo": {
+    "message": "Grok 비디오",
+    "description": "편집 상자에서 제목으로 표시됩니다."
+  },
+  "field.featuresMaestro": {
+    "message": "Maestro",
+    "description": "편집 상자에서 제목으로 표시됩니다."
+  },
   "field.featuresDeepseek": {
     "message": "Deepseek",
     "description": "편집 상자에 표시되는 제목"
@@ -434,6 +442,14 @@
   "message.featuresGrok": {
     "message": "Grok 기능 모듈을 켜거나 끕니다.",
     "description": "Grok 기능에 대한 설명"
+  },
+  "message.featuresGrokvideo": {
+    "message": "Grok 비디오 기능 모듈을 활성화하거나 비활성화합니다.",
+    "description": "Grok 비디오 기능에 대한 설명입니다."
+  },
+  "message.featuresMaestro": {
+    "message": "Maestro 기능 모듈을 활성화하거나 비활성화합니다.",
+    "description": "Maestro 기능에 대한 설명입니다."
   },
   "message.featuresDeepseek": {
     "message": "Deepseek 기능 모듈을 켜거나 끕니다.",

--- a/src/i18n/pl/site.json
+++ b/src/i18n/pl/site.json
@@ -95,6 +95,14 @@
     "message": "Grok",
     "description": "Wyświetlane w tytule edytora"
   },
+  "field.featuresGrokvideo": {
+    "message": "Grok Video",
+    "description": "Wyświetlane jako tytuł w oknie edycji"
+  },
+  "field.featuresMaestro": {
+    "message": "Maestro",
+    "description": "Wyświetlane jako tytuł w oknie edycji"
+  },
   "field.featuresDeepseek": {
     "message": "Deepseek",
     "description": "Wyświetlane w tytule edytora"
@@ -434,6 +442,14 @@
   "message.featuresGrok": {
     "message": "Włącz lub wyłącz moduł funkcji Grok.",
     "description": "Opis funkcji Grok"
+  },
+  "message.featuresGrokvideo": {
+    "message": "Włącz lub wyłącz moduł funkcji Grok Video.",
+    "description": "Opis funkcji Grok Video"
+  },
+  "message.featuresMaestro": {
+    "message": "Włącz lub wyłącz moduł funkcji Maestro.",
+    "description": "Opis funkcji Maestro"
   },
   "message.featuresDeepseek": {
     "message": "Włącz lub wyłącz moduł funkcji Deepseek.",

--- a/src/i18n/pt/site.json
+++ b/src/i18n/pt/site.json
@@ -95,6 +95,14 @@
     "message": "Grok",
     "description": "Exibido como o título na caixa de edição"
   },
+  "field.featuresGrokvideo": {
+    "message": "Grok Video",
+    "description": "Exibido como o título na caixa de edição"
+  },
+  "field.featuresMaestro": {
+    "message": "Maestro",
+    "description": "Exibido como o título na caixa de edição"
+  },
   "field.featuresDeepseek": {
     "message": "Deepseek",
     "description": "Exibido como o título na caixa de edição"
@@ -434,6 +442,14 @@
   "message.featuresGrok": {
     "message": "Ativar ou desativar o módulo de Grok.",
     "description": "Descrição da funcionalidade de Grok"
+  },
+  "message.featuresGrokvideo": {
+    "message": "Ativar ou desativar o módulo de funcionalidades do Grok Video.",
+    "description": "Descrição da funcionalidade do Grok Video"
+  },
+  "message.featuresMaestro": {
+    "message": "Ativar ou desativar o módulo de funcionalidades do Maestro.",
+    "description": "Descrição da funcionalidade do Maestro"
   },
   "message.featuresDeepseek": {
     "message": "Ativar ou desativar o módulo de Deepseek.",

--- a/src/i18n/ru/site.json
+++ b/src/i18n/ru/site.json
@@ -95,6 +95,14 @@
     "message": "Grok",
     "description": "展示在编辑框的标题"
   },
+  "field.featuresGrokvideo": {
+    "message": "Grok Video",
+    "description": "Отображается как заголовок в окне редактирования"
+  },
+  "field.featuresMaestro": {
+    "message": "Maestro",
+    "description": "Отображается как заголовок в окне редактирования"
+  },
   "field.featuresDeepseek": {
     "message": "Deepseek",
     "description": "展示在编辑框的标题"
@@ -434,6 +442,14 @@
   "message.featuresGrok": {
     "message": "Включить или отключить модуль функции Grok.",
     "description": "Grok 功能的描述"
+  },
+  "message.featuresGrokvideo": {
+    "message": "Включите или отключите модуль функции Grok Video.",
+    "description": "Описание функции Grok Video"
+  },
+  "message.featuresMaestro": {
+    "message": "Включите или отключите модуль функции Maestro.",
+    "description": "Описание функции Maestro"
   },
   "message.featuresDeepseek": {
     "message": "Включить или отключить модуль функции Deepseek.",

--- a/src/i18n/sr/site.json
+++ b/src/i18n/sr/site.json
@@ -95,6 +95,14 @@
     "message": "Grok",
     "description": "Prikazuje se kao naslov u okviru za uređivanje"
   },
+  "field.featuresGrokvideo": {
+    "message": "Grok Video",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
+  "field.featuresMaestro": {
+    "message": "Maestro",
+    "description": "Prikazuje se kao naslov u okviru za uređivanje"
+  },
   "field.featuresDeepseek": {
     "message": "Deepseek",
     "description": "Prikazuje se kao naslov u okviru za uređivanje"
@@ -434,6 +442,14 @@
   "message.featuresGrok": {
     "message": "Укључи или искључи Grok модул.",
     "description": "Опис Grok функције"
+  },
+  "message.featuresGrokvideo": {
+    "message": "Omogućite ili onemogućite Grok Video funkcionalnost.",
+    "description": "Opis Grok Video funkcionalnosti"
+  },
+  "message.featuresMaestro": {
+    "message": "Omogućite ili onemogućite Maestro funkcionalnost.",
+    "description": "Opis Maestro funkcionalnosti"
   },
   "message.featuresDeepseek": {
     "message": "Укључи или искључи Deepseek модул.",

--- a/src/i18n/sv/site.json
+++ b/src/i18n/sv/site.json
@@ -95,6 +95,14 @@
     "message": "Grok",
     "description": "Visas som titeln i redigeringsrutan"
   },
+  "field.featuresGrokvideo": {
+    "message": "Grok Video",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
+  "field.featuresMaestro": {
+    "message": "Maestro",
+    "description": "Visas som titeln i redigeringsrutan"
+  },
   "field.featuresDeepseek": {
     "message": "Deepseek",
     "description": "Visas som titeln i redigeringsrutan"
@@ -434,6 +442,14 @@
   "message.featuresGrok": {
     "message": "Aktivera eller inaktivera Grok-funktion.",
     "description": "Beskrivning av Grok-funktionen"
+  },
+  "message.featuresGrokvideo": {
+    "message": "Aktivera eller inaktivera Grok Video-funktionmodulen.",
+    "description": "Beskrivning av Grok Video-funktionen"
+  },
+  "message.featuresMaestro": {
+    "message": "Aktivera eller inaktivera Maestro-funktionmodulen.",
+    "description": "Beskrivning av Maestro-funktionen"
   },
   "message.featuresDeepseek": {
     "message": "Aktivera eller inaktivera Deepseek-funktion.",

--- a/src/i18n/uk/site.json
+++ b/src/i18n/uk/site.json
@@ -95,6 +95,14 @@
     "message": "Grok",
     "description": "展示在编辑框的标题"
   },
+  "field.featuresGrokvideo": {
+    "message": "Grok Video",
+    "description": "Відображається як заголовок у полі редагування"
+  },
+  "field.featuresMaestro": {
+    "message": "Maestro",
+    "description": "Відображається як заголовок у полі редагування"
+  },
   "field.featuresDeepseek": {
     "message": "Deepseek",
     "description": "展示在编辑框的标题"
@@ -434,6 +442,14 @@
   "message.featuresGrok": {
     "message": "Увімкнути або вимкнути модуль функції Grok.",
     "description": "Опис функції Grok"
+  },
+  "message.featuresGrokvideo": {
+    "message": "Увімкнути або вимкнути модуль функцій Grok Video.",
+    "description": "Опис функції Grok Video"
+  },
+  "message.featuresMaestro": {
+    "message": "Увімкнути або вимкнути модуль функцій Maestro.",
+    "description": "Опис функції Maestro"
   },
   "message.featuresDeepseek": {
     "message": "Увімкнути або вимкнути модуль функції Deepseek.",

--- a/src/i18n/zh-CN/site.json
+++ b/src/i18n/zh-CN/site.json
@@ -95,6 +95,14 @@
     "message": "Grok",
     "description": "展示在编辑框的标题"
   },
+  "field.featuresGrokvideo": {
+    "message": "Grok Video",
+    "description": "Displayed as the title in the editing box"
+  },
+  "field.featuresMaestro": {
+    "message": "Maestro",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresDeepseek": {
     "message": "Deepseek",
     "description": "展示在编辑框的标题"
@@ -434,6 +442,14 @@
   "message.featuresGrok": {
     "message": "打开或关闭 Grok 功能模块。",
     "description": "Grok 功能的描述"
+  },
+  "message.featuresGrokvideo": {
+    "message": "启用或禁用 Grok Video 功能模块。",
+    "description": "Grok Video功能的描述"
+  },
+  "message.featuresMaestro": {
+    "message": "启用或禁用 Maestro 功能模块。",
+    "description": "Maestro功能的描述"
   },
   "message.featuresDeepseek": {
     "message": "打开或关闭 Deepseek 功能模块。",

--- a/src/i18n/zh-TW/site.json
+++ b/src/i18n/zh-TW/site.json
@@ -95,6 +95,14 @@
     "message": "Grok",
     "description": "展示在編輯框的標題"
   },
+  "field.featuresGrokvideo": {
+    "message": "Grok 視頻",
+    "description": "顯示為編輯框中的標題"
+  },
+  "field.featuresMaestro": {
+    "message": "Maestro",
+    "description": "顯示為編輯框中的標題"
+  },
   "field.featuresDeepseek": {
     "message": "Deepseek",
     "description": "展示在編輯框的標題"
@@ -434,6 +442,14 @@
   "message.featuresGrok": {
     "message": "開啟或關閉 Grok 功能模塊。",
     "description": "Grok 功能的描述"
+  },
+  "message.featuresGrokvideo": {
+    "message": "啟用或禁用 Grok 視頻功能模組。",
+    "description": "Grok 視頻功能的描述"
+  },
+  "message.featuresMaestro": {
+    "message": "啟用或禁用 Maestro 功能模組。",
+    "description": "Maestro 功能的描述"
   },
   "message.featuresDeepseek": {
     "message": "開啟或關閉 Deepseek 功能模塊。",


### PR DESCRIPTION
## Why

Follow-up to the merged Maestro v4 module (#1007). Two gaps surfaced in the admin **功能设置 / Function settings** dialog:

1. **Maestro had no toggle** — `setting/Function.vue`'s `FEATURE_KEYS` list didn't include `maestro`, so it never appeared in the dialog and couldn't be enabled. That's why no Maestro entry showed in Nexior (the nav entry is gated on `site.features.maestro.enabled`, which the admin had no way to turn on).
2. **Grok Video showed raw i18n keys** — the toggle rendered `site.field.featuresGrokvideo` / `site.message.featuresGrokvideo` because those keys didn't exist (only `featuresGrok` for the chat model did).

## What

- Add `'maestro'` to `FEATURE_KEYS` in `src/components/setting/Function.vue`.
- Add missing `site.json` keys, backfilled across all 18 locales:
  - `field.featuresGrokvideo` / `message.featuresGrokvideo`
  - `field.featuresMaestro` / `message.featuresMaestro`

After this, the admin can toggle Maestro on (→ nav entry + `/maestro` route appear), and Grok Video shows a proper label/description.

## Verify

- `npm run build` passes.
- All 18 locales now contain the 4 new `site.json` keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
