### PR TITLE
feat(desktop): surface foundation for Electron desktop client (1/4)

### DIFF
--- a/change/@acedatacloud-nexior-2dc72812-9d7d-4530-8955-feb9db3ecb7f.json
+++ b/change/@acedatacloud-nexior-2dc72812-9d7d-4530-8955-feb9db3ecb7f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(desktop): add desktop surface foundation (constants, surface utils, vite __APP_VERSION__)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "cqc@cuiqingcai.com",
+  "dependentChangeType": "patch"
+}

--- a/src/constants/surface.ts
+++ b/src/constants/surface.ts
@@ -1,3 +1,4 @@
 export const SURFACE_WEB = 'web';
 export const SURFACE_ANDROID = 'android';
 export const SURFACE_IOS = 'ios';
+export const SURFACE_DESKTOP = 'desktop'; // Electron (Windows / macOS)

--- a/src/main.ts
+++ b/src/main.ts
@@ -95,7 +95,10 @@ export const createApp = ViteSSG(App, { routes, base: import.meta.env.BASE_URL }
 
   void initTelemetry({
     uin: store.getters.user?.id,
-    release: import.meta.env.VITE_APP_VERSION as string | undefined
+    // __APP_VERSION__ is injected by vite.config `define` for all surfaces.
+    // (Previously this read import.meta.env.VITE_APP_VERSION, which was never
+    // defined anywhere → the telemetry release tag was always undefined.)
+    release: typeof __APP_VERSION__ === 'string' ? __APP_VERSION__ : undefined
   });
 
   initializeCurrency();

--- a/src/shims.d.ts
+++ b/src/shims.d.ts
@@ -35,6 +35,11 @@ declare module '*.vue' {
 declare module 'cordova-plugin-purchase';
 declare const CdvPurchase: any;
 
+// Injected by vite.config `define` for all surfaces (web/android/ios/desktop).
+// Holds the package.json version; used for the telemetry release tag and the
+// desktop version gate.
+declare const __APP_VERSION__: string;
+
 // declare namespace Intl {
 //   function getCanonicalLocales(locales: string | string[] | undefined): string[];
 // }

--- a/src/utils/baseUrl.ts
+++ b/src/utils/baseUrl.ts
@@ -1,5 +1,5 @@
 import { BASE_URL_AUTH, BASE_URL_PLATFORM, BASE_URL_HUB } from '@/constants';
-import { isNative } from './surface';
+import { isNative, isDesktop } from './surface';
 
 /**
  * Get base url of platform app
@@ -20,9 +20,10 @@ export const getBaseUrlHub = () => {
   if (import.meta.env.VITE_BASE_URL_HUB) {
     return import.meta.env.VITE_BASE_URL_HUB;
   }
-  // On native platforms (Capacitor), window.location.origin is http://localhost
-  // which is not the real hub URL — use the hardcoded constant instead
-  if (isNative()) {
+  // On native platforms (Capacitor) window.location.origin is http://localhost,
+  // and on desktop (Electron) it is app://bundle — neither is the real hub URL,
+  // so use the hardcoded constant instead.
+  if (isNative() || isDesktop()) {
     return BASE_URL_HUB;
   }
   return window.location.origin || BASE_URL_HUB;

--- a/src/utils/desktop.ts
+++ b/src/utils/desktop.ts
@@ -1,0 +1,35 @@
+/**
+ * Typed accessor for the `window.desktop` bridge exposed by the Electron
+ * preload (contextIsolation ON). On web/native this is `undefined`, so every
+ * caller must null-check via {@link desktopBridge}.
+ *
+ * The bridge surface is intentionally minimal and audited — see
+ * `electron/preload.ts`. `state` for the OAuth flow never crosses this bridge;
+ * it lives entirely in the Electron main process.
+ */
+export interface DesktopBridge {
+  isDesktop: true;
+  platform: 'win32' | 'darwin' | string;
+  /** Ask main to append a fresh `state`, store it, and open the system browser. */
+  openOAuth(authUrl: string): Promise<void>;
+  /** Subscribe to the state-validated callback. Payload is `{ code }` only. */
+  onAuthCallback(cb: (payload: { code: string }) => void): () => void;
+  /** Subscribe to a dropped-callback signal (state mismatch/expired). */
+  onAuthExpired(cb: () => void): () => void;
+  /** Open an external https link (payment Page, docs) in the system browser. */
+  openExternal(url: string): Promise<void>;
+  /** Handshake: call AFTER auth listeners are attached so main flushes queued deep links. */
+  signalReady(): void;
+  /** Inform main of the signed-in site origin for the external-open allowlist. */
+  setSiteOrigin(origin: string): void;
+}
+
+declare global {
+  interface Window {
+    desktop?: DesktopBridge;
+  }
+}
+
+export function desktopBridge(): DesktopBridge | undefined {
+  return typeof window !== 'undefined' ? window.desktop : undefined;
+}

--- a/src/utils/site.test.ts
+++ b/src/utils/site.test.ts
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getSiteOrigin } from './site';
+
+/**
+ * getSiteOrigin must treat desktop (Electron, app://bundle authority "bundle")
+ * the same as native (Capacitor, localhost) — both have a useless
+ * window.location.host and must fall back to the canonical first-party host so
+ * the bundle resolves the real Site row instead of looking up "bundle".
+ */
+describe('getSiteOrigin', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('falls back to studio host on desktop', () => {
+    vi.stubEnv('VITE_SURFACE', 'desktop');
+    expect(getSiteOrigin()).toBe('studio.acedata.cloud');
+  });
+
+  it('falls back to studio host on native', () => {
+    vi.stubEnv('VITE_SURFACE', 'ios');
+    expect(getSiteOrigin()).toBe('studio.acedata.cloud');
+  });
+
+  it('trusts an explicit site origin regardless of surface', () => {
+    vi.stubEnv('VITE_SURFACE', 'desktop');
+    expect(getSiteOrigin({ origin: 'tenant.example.com' } as never)).toBe('tenant.example.com');
+  });
+});

--- a/src/utils/site.ts
+++ b/src/utils/site.ts
@@ -1,6 +1,6 @@
 import { ISite } from '@/models';
 import { v4 as uuid } from 'uuid';
-import { BASE_HOST_HUB } from '@/constants';
+import { BASE_HOST_HUB } from '@/constants/endpoint';
 import { isNative, isDesktop } from './surface';
 
 /**

--- a/src/utils/site.ts
+++ b/src/utils/site.ts
@@ -1,7 +1,7 @@
 import { ISite } from '@/models';
 import { v4 as uuid } from 'uuid';
 import { BASE_HOST_HUB } from '@/constants';
-import { isNative } from './surface';
+import { isNative, isDesktop } from './surface';
 
 /**
  * Resolve the origin we send to PlatformBackend's
@@ -34,9 +34,11 @@ export const getSiteOrigin = (site?: ISite) => {
     return site.origin;
   }
   // On native shells (Capacitor on Android / iOS) window.location.host
-  // is "localhost" and useless; fall back to studio's bare host so the
-  // app boots against the canonical first-party Site row.
-  if (isNative()) {
+  // is "localhost" and useless; on desktop (Electron) it is the custom
+  // scheme authority "bundle" (app://bundle) which is equally useless.
+  // Both fall back to studio's bare host so the app boots against the
+  // canonical first-party Site row.
+  if (isNative() || isDesktop()) {
     return STUDIO_HOST;
   }
   if (typeof window === 'undefined' || !window.location?.host) {

--- a/src/utils/surface.test.ts
+++ b/src/utils/surface.test.ts
@@ -1,14 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import {
-  getSurface,
-  isWeb,
-  isIOS,
-  isAndroid,
-  isDesktop,
-  isNative,
-  getPaymentSurface
-} from './surface';
+import { getSurface, isWeb, isIOS, isAndroid, isDesktop, isNative, getPaymentSurface } from './surface';
 
 /**
  * Surface resolution must keep `isNative()` meaning "Capacitor mobile" while

--- a/src/utils/surface.test.ts
+++ b/src/utils/surface.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  getSurface,
+  isWeb,
+  isIOS,
+  isAndroid,
+  isDesktop,
+  isNative,
+  getPaymentSurface
+} from './surface';
+
+/**
+ * Surface resolution must keep `isNative()` meaning "Capacitor mobile" while
+ * `isDesktop()` is an independent predicate — desktop (Electron) must NOT be
+ * treated as native (which gates IAP / push / Capacitor OTA).
+ */
+describe('surface', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  const withSurface = (value?: string) => {
+    if (value === undefined) vi.stubEnv('VITE_SURFACE', '');
+    else vi.stubEnv('VITE_SURFACE', value);
+  };
+
+  describe('getSurface', () => {
+    it('returns desktop when VITE_SURFACE=desktop', () => {
+      withSurface('desktop');
+      expect(getSurface()).toBe('desktop');
+    });
+
+    it('returns ios / android for the mobile surfaces', () => {
+      withSurface('ios');
+      expect(getSurface()).toBe('ios');
+      withSurface('android');
+      expect(getSurface()).toBe('android');
+    });
+
+    it('coerces an unknown surface back to web (but NOT desktop)', () => {
+      withSurface('toaster');
+      expect(getSurface()).toBe('web');
+    });
+
+    it('defaults to web when unset', () => {
+      withSurface('');
+      expect(getSurface()).toBe('web');
+    });
+  });
+
+  describe('predicates', () => {
+    it('isDesktop true only on desktop, and desktop is NOT native', () => {
+      withSurface('desktop');
+      expect(isDesktop()).toBe(true);
+      expect(isNative()).toBe(false); // critical: desktop must not hit IAP/push/OTA
+      expect(isWeb()).toBe(false);
+      expect(isIOS()).toBe(false);
+      expect(isAndroid()).toBe(false);
+    });
+
+    it('isNative true on ios/android, isDesktop false there', () => {
+      withSurface('ios');
+      expect(isNative()).toBe(true);
+      expect(isDesktop()).toBe(false);
+      withSurface('android');
+      expect(isNative()).toBe(true);
+      expect(isDesktop()).toBe(false);
+    });
+
+    it('web is neither native nor desktop', () => {
+      withSurface('web');
+      expect(isWeb()).toBe(true);
+      expect(isNative()).toBe(false);
+      expect(isDesktop()).toBe(false);
+    });
+  });
+
+  describe('getPaymentSurface', () => {
+    it('returns pc on desktop (AliPay Page / Stripe web surface)', () => {
+      withSurface('desktop');
+      expect(getPaymentSurface()).toBe('pc');
+    });
+
+    it('returns ios / android on the mobile surfaces', () => {
+      withSurface('ios');
+      expect(getPaymentSurface()).toBe('ios');
+      withSurface('android');
+      expect(getPaymentSurface()).toBe('android');
+    });
+  });
+});

--- a/src/utils/surface.ts
+++ b/src/utils/surface.ts
@@ -1,10 +1,6 @@
 import { SURFACE_ANDROID, SURFACE_IOS, SURFACE_WEB, SURFACE_DESKTOP } from '@/constants/surface';
 
-type Surface =
-  | typeof SURFACE_WEB
-  | typeof SURFACE_ANDROID
-  | typeof SURFACE_IOS
-  | typeof SURFACE_DESKTOP;
+type Surface = typeof SURFACE_WEB | typeof SURFACE_ANDROID | typeof SURFACE_IOS | typeof SURFACE_DESKTOP;
 
 export function getSurface(): Surface {
   const value = (import.meta.env.VITE_SURFACE as string | undefined) ?? SURFACE_WEB;

--- a/src/utils/surface.ts
+++ b/src/utils/surface.ts
@@ -1,10 +1,19 @@
-import { SURFACE_ANDROID, SURFACE_IOS, SURFACE_WEB } from '@/constants/surface';
+import { SURFACE_ANDROID, SURFACE_IOS, SURFACE_WEB, SURFACE_DESKTOP } from '@/constants/surface';
 
-type Surface = typeof SURFACE_WEB | typeof SURFACE_ANDROID | typeof SURFACE_IOS;
+type Surface =
+  | typeof SURFACE_WEB
+  | typeof SURFACE_ANDROID
+  | typeof SURFACE_IOS
+  | typeof SURFACE_DESKTOP;
 
 export function getSurface(): Surface {
   const value = (import.meta.env.VITE_SURFACE as string | undefined) ?? SURFACE_WEB;
-  return value === SURFACE_IOS || value === SURFACE_ANDROID ? value : SURFACE_WEB;
+  // NOTE: previously any unknown value silently coerced to 'web'. We now
+  // recognize 'desktop' explicitly; everything else still falls back to web.
+  if (value === SURFACE_IOS || value === SURFACE_ANDROID || value === SURFACE_DESKTOP) {
+    return value;
+  }
+  return SURFACE_WEB;
 }
 
 export function isIOS(): boolean {
@@ -15,6 +24,12 @@ export function isAndroid(): boolean {
   return getSurface() === SURFACE_ANDROID;
 }
 
+export function isDesktop(): boolean {
+  return getSurface() === SURFACE_DESKTOP;
+}
+
+// UNCHANGED MEANING: native === "Capacitor mobile shell" (iOS or Android).
+// Desktop is deliberately NOT native — it must not hit IAP/push/Capacitor-OTA.
 export function isNative(): boolean {
   const surface = getSurface();
   return surface === SURFACE_IOS || surface === SURFACE_ANDROID;
@@ -36,5 +51,11 @@ export function isMobile(): boolean {
 export function getPaymentSurface(): 'pc' | 'wap' | 'ios' | 'android' {
   if (isIOS()) return 'ios';
   if (isAndroid()) return 'android';
+  // Desktop: explicit. Electron's UA is desktop-Chromium so without this it
+  // would fall through to 'pc' anyway, but pin it so the intent is clear and
+  // a future UA-sniff change can't accidentally hand desktop a 'wap' Page.
+  // 'pc' is the right backend surface (AliPay Page / Stripe web); the redirect
+  // itself must be opened in the system browser (handled in the Electron shell).
+  if (isDesktop()) return 'pc';
   return isMobile() ? 'wap' : 'pc';
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,9 @@ import { type ConfigEnv, defineConfig, loadEnv } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import replace from '@rollup/plugin-replace';
 import * as path from 'path';
+import { createRequire } from 'module';
+
+const pkg = createRequire(import.meta.url)('./package.json') as { version: string };
 
 const normalizeModuleId = (id: string) => id.replace(/\\/g, '/');
 
@@ -69,6 +72,13 @@ export default defineConfig((config: ConfigEnv) => {
         preventAssignment: true
       })
     ],
+    // Inject the package version as a plain global for ALL surfaces. Read via
+    // `__APP_VERSION__` (telemetry release tag + desktop version gate). Do NOT
+    // define onto import.meta.env.* — Vite manages that namespace and the key
+    // can be clobbered.
+    define: {
+      __APP_VERSION__: JSON.stringify(pkg.version)
+    },
     // vite-ssg: only used by `npm run build:ssg`. Plain `npm run build` ignores
     // this and produces today's SPA. Pre-renders are served behind features=ssr.
     ssgOptions: {
@@ -90,6 +100,9 @@ export default defineConfig((config: ConfigEnv) => {
       }
     },
     build: {
+      // Desktop (Electron) builds go to a dedicated outDir so they never share
+      // or overwrite the web `dist/` (each surface owns its own output).
+      outDir: process.env.VITE_SURFACE === 'desktop' ? 'dist-electron' : 'dist',
       // Computing gzip size for ~10 MB of chunks blows past the 2 GB V8
       // heap on Cloudflare Workers Builds. The report is stdout-only,
       // so disabling it costs nothing functional and shaves ~15 s off


### PR DESCRIPTION
First of 4 PRs implementing the Nexior desktop client (see `plans/nexior-desktop` in the Index repo: design + 3-round adversarial review).

## What
Foundational `desktop` surface so the rest of the desktop work has a home. **Purely additive — no runtime change for web/android/ios.**

- `constants/surface.ts`: add `SURFACE_DESKTOP`
- `utils/surface.ts`: `isDesktop()`; `getSurface()` now recognizes `desktop` (it previously coerced any unknown value, incl. `electron`/`desktop`, back to `web`); `getPaymentSurface()` pins desktop to `pc`. **`isNative()` meaning is unchanged** (Capacitor mobile only) so desktop never hits IAP/push/Capacitor-OTA.
- `utils/desktop.ts`: typed `window.desktop` bridge accessor (undefined off-desktop)
- `utils/site.ts` + `utils/baseUrl.ts`: desktop joins the native fallback — `app://bundle` has no usable `window.location.origin`/`host`
- `vite.config.ts`: inject `__APP_VERSION__` global for **all** surfaces + dedicated `dist-electron` outDir. `main.ts` telemetry `release` now reads it (it previously read the never-defined `VITE_APP_VERSION` → always `undefined`)

## Tests
`src/utils/surface.test.ts` + `src/utils/site.test.ts` — 12 assertions covering surface resolution, the `isNative` vs `isDesktop` split, payment surface, and the desktop site-origin fallback.

## Verification
- `vitest run` on the new tests: **12/12 pass**
- `eslint` on changed files: clean
- `vue-tsc -b`: no new errors from these files (pre-existing `@acedatacloud/core/*` subpath-resolution errors are unrelated and present on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)