### PR TITLE
feat(desktop): surface-aware auth flow for the desktop client (2/4)

### DIFF
--- a/change/@acedatacloud-nexior-a81056e4-e305-4af6-85d1-4caab11a3246.json
+++ b/change/@acedatacloud-nexior-a81056e4-e305-4af6-85d1-4caab11a3246.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(desktop): surface-aware auth flow (deep-link, login/logout, version gate)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "cqc@cuiqingcai.com",
+  "dependentChangeType": "patch"
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -16,10 +16,11 @@ import { isTest } from '@/constants/endpoint';
 import { getLocale } from './i18n';
 import { App as CapApp } from '@capacitor/app';
 import { Browser } from '@capacitor/browser';
-import { isNative } from '@/utils/surface';
+import { ElMessage } from 'element-plus';
+import { isNative, isDesktop } from '@/utils/surface';
+import { desktopBridge } from '@/utils/desktop';
 import { parseInviterFromDeepLink, writeInviterCookie } from '@/utils/attribution';
-import { ssoOperator } from '@/operators';
-import { track } from '@/plugins/telemetry';
+import { exchangeSsoCode } from '@/utils/auth/exchangeSsoCode';
 
 const elementPlusLocaleMap: Record<string, () => Promise<any>> = {
   en: () => import('element-plus/es/locale/lang/en'),
@@ -53,10 +54,10 @@ export default defineComponent({
     return {
       isTest,
       epLocale: null as any,
-      // Guards against Capacitor delivering the same `appUrlOpen` deep link
-      // more than once — a second exchange of an already-consumed SSO code
-      // fails and would bounce the user back to login.
-      lastHandledCode: ''
+      // Desktop IPC listener detach handles (set in mounted on desktop only).
+      offAuthCb: null as null | (() => void),
+      offAuthExpired: null as null | (() => void),
+      offSiteWatch: null as null | (() => void)
     };
   },
   computed: {
@@ -76,7 +77,7 @@ export default defineComponent({
     }
   },
   mounted() {
-    // Listen for deep link callbacks from native OAuth flow
+    // Listen for deep link callbacks from the native (Capacitor) OAuth flow.
     if (isNative()) {
       CapApp.addListener('appUrlOpen', async ({ url }) => {
         console.debug('deep link received:', url);
@@ -91,53 +92,52 @@ export default defineComponent({
         }
         // Expected format: com.acedatacloud.nexior://auth/callback?code=XXX
         if (url.includes('auth/callback')) {
-          const params = new URL(url).searchParams;
-          const code = params.get('code');
+          const code = new URL(url).searchParams.get('code');
           if (code) {
-            // Dedup: the same code can arrive twice (Capacitor re-delivers the
-            // deep link), and an SSO code is single-use — exchanging it again
-            // 4xxs and would kick the user back to login.
-            if (code === this.lastHandledCode) {
-              console.debug('deep link code already handled, ignoring');
-              return;
-            }
-            this.lastHandledCode = code;
-            track('apple_login_deeplink', { action: 'sso_exchange' });
+            // Browser.close() stays in the native caller — desktop has no
+            // Capacitor in-app browser, so it can't live in the shared util.
             try {
               await Browser.close();
             } catch (e) {
               console.debug('browser close failed (may already be closed)', e);
             }
-            try {
-              const { data } = await ssoOperator.token({ code });
-              const token = {
-                access: data.access_token,
-                refresh: data.refresh_token,
-                expiration: data.expires_in
-              };
-              await this.$store.dispatch('setToken', token);
-              await this.$store.dispatch('getUser');
-              track('apple_login_success', { action: 'sso_exchange' });
-              this.$store.commit('setAuth', { visible: false });
-              await this.$router.push('/');
-            } catch (e) {
-              track('apple_login_failed', { action: 'sso_exchange', error: String(e) });
-              console.error('token exchange failed after deep link', e);
-              this.$store.commit('setAuth', { visible: false });
-              await this.$store.dispatch('login');
-            }
+            await exchangeSsoCode(code, { store: this.$store, router: this.$router, source: 'native' });
           }
         }
       });
     }
 
+    // Desktop (Electron) deep link: the main process has ALREADY validated the
+    // OAuth `state` nonce, so we only receive `code`. Subscribe FIRST, then
+    // signal readiness so main flushes any deep link queued during cold start.
+    if (isDesktop()) {
+      const bridge = desktopBridge();
+      this.offAuthCb =
+        bridge?.onAuthCallback(({ code }) => {
+          void exchangeSsoCode(code, { store: this.$store, router: this.$router, source: 'desktop' });
+        }) ?? null;
+      this.offAuthExpired =
+        bridge?.onAuthExpired(() => {
+          ElMessage.error(this.$t('common.error.loginLinkExpired').toString());
+        }) ?? null;
+      bridge?.signalReady();
+      // Feed the signed-in site origin to main's external-open allowlist.
+      this.offSiteWatch = this.$watch(
+        () => this.$store.state.site?.origin as string | undefined,
+        (origin) => {
+          if (origin) bridge?.setSiteOrigin(origin);
+        },
+        { immediate: true }
+      );
+    }
+
     const authenticated = !!this.$store.state.token.access && !!this.$store.state.user?.id;
     console.debug('App mounted, authenticated:', authenticated);
     if (!authenticated) {
-      if (isNative()) {
-        // On native platforms, just reset state and show login popup.
-        // Don't dispatch 'logout' which would navigate the WebView to an
-        // external auth URL, opening Chrome and landing on localhost.
+      if (isNative() || isDesktop()) {
+        // On native AND desktop, just reset state and show the in-app login
+        // popup. Don't dispatch 'logout' which would navigate the window to an
+        // external auth URL — on desktop the app://bundle window can't return.
         this.$store.dispatch('resetAll');
         this.$store.dispatch('login');
       } else {
@@ -153,6 +153,12 @@ export default defineComponent({
         this.$store.dispatch('login');
       }
     }
+  },
+  beforeUnmount() {
+    // Detach desktop IPC listeners + the site-origin watcher.
+    this.offAuthCb?.();
+    this.offAuthExpired?.();
+    this.offSiteWatch?.();
   },
   methods: {
     async loadElementPlusLocale() {

--- a/src/components/common/AuthPanel.vue
+++ b/src/components/common/AuthPanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="isNative" class="auth-native">
+  <div v-if="isInAppLogin" class="auth-native">
     <div v-if="useBrowser" class="auth-native__loading">
       <p>{{ $t('common.status.loading') }}</p>
     </div>
@@ -40,7 +40,8 @@ import QrCode from 'vue-qrcode';
 import { ROUTE_SETTINGS_INDEX } from '@/router';
 import { Browser } from '@capacitor/browser';
 import { SignInWithApple } from '@capacitor-community/apple-sign-in';
-import { isNative as isNativeSurface, isIOS } from '@/utils/surface';
+import { isNative as isNativeSurface, isIOS, isDesktop } from '@/utils/surface';
+import { desktopBridge } from '@/utils/desktop';
 import { track } from '@/plugins/telemetry';
 
 // Native Sign In with Apple is keyed by the iOS bundle identifier, NOT
@@ -65,12 +66,22 @@ export default defineComponent({
     isNative() {
       return isNativeSurface();
     },
+    // Both native AND desktop use the in-app iframe login UI (never the web
+    // redirect, which can't return to an app://bundle / Capacitor window).
+    isInAppLogin() {
+      return isNativeSurface() || isDesktop();
+    },
+    // Per-surface OAuth redirect scheme. Mobile keeps its existing scheme;
+    // desktop uses a distinct one so the two can't collide on one machine.
+    nativeRedirect() {
+      return isDesktop() ? 'acedata-desktop' : 'com.acedatacloud.nexior';
+    },
     iframeUrl() {
       // Trailing slash matters: `/auth/login` 301s to a cleartext `http://`
       // URL that iOS ATS blocks, leaving this iframe blank (white screen).
       let url = `${getBaseUrlAuth()}/auth/login/?inviter_id=${this.inviterId}`;
-      if (this.isNative) {
-        url += '&native_redirect=com.acedatacloud.nexior';
+      if (this.isInAppLogin) {
+        url += `&native_redirect=${this.nativeRedirect}`;
       }
       // Pass `site` so the embedded AuthFrontend login form renders the
       // calling subsite's white-label logo (no-op on the main official host).
@@ -94,7 +105,10 @@ export default defineComponent({
   },
   mounted() {
     if (this.isNative) {
-      // If user closes the in-app browser manually, fall back to iframe login UI.
+      // Capacitor-only: if the user closes the in-app browser manually, fall
+      // back to the iframe login UI. Desktop OAuth opens the SYSTEM browser
+      // (no browserFinished event), so this listener must stay isNative-only —
+      // never isInAppLogin — or desktop would get stuck on the loading screen.
       Browser.addListener('browserFinished', () => {
         console.debug('browser closed by user');
         this.useBrowser = false;
@@ -108,7 +122,7 @@ export default defineComponent({
         return;
       }
       console.debug('received from child page', event);
-      if (event.data.name === 'nativeOAuth' && this.isNative) {
+      if (event.data.name === 'nativeOAuth' && this.isInAppLogin) {
         const provider = event.data.data?.provider;
         // On iOS, Apple Sign In must use the native ASAuthorization sheet —
         // SFSafariViewController lacks the system bridge that Apple's JS SDK
@@ -180,12 +194,22 @@ export default defineComponent({
           return;
         }
         // AuthFrontend in iframe can't do OAuth popups/redirects (X-Frame-Options).
-        // Open the auth page in an in-app browser with the provider pre-selected.
-        this.useBrowser = true;
+        // Open the auth page with the provider pre-selected, using the
+        // per-surface redirect scheme.
         const authUrl = withCurrentSite(
-          `${getBaseUrlAuth()}/auth/login/?inviter_id=${this.inviterId}&native_redirect=com.acedatacloud.nexior&provider=${provider}`
+          `${getBaseUrlAuth()}/auth/login/?inviter_id=${this.inviterId}&native_redirect=${this.nativeRedirect}&provider=${provider}`
         );
-        Browser.open({ url: authUrl });
+        if (isDesktop()) {
+          // Desktop has no Capacitor in-app browser. Hand off to the Electron
+          // main process, which appends + stores a `state` nonce and opens the
+          // SYSTEM browser. The result returns via the custom-scheme deep link
+          // → window.desktop.onAuthCallback → exchangeSsoCode (in App.vue).
+          // Do NOT set useBrowser here — there's no browserFinished to clear it.
+          await desktopBridge()?.openOAuth(authUrl);
+        } else {
+          this.useBrowser = true;
+          Browser.open({ url: authUrl });
+        }
         return;
       }
       if (event.data.name === 'login') {
@@ -201,18 +225,19 @@ export default defineComponent({
         if (!this.$store.state.site?.origin) {
           await this.$store.dispatch('initializeSite');
           // navigate to settings page (the dialog auto-opens) for
-          // white-label site owners, but skip on native platforms
-          // (Android/iOS) where users are always on the official site
-          if (!isNativeSurface()) {
+          // white-label site owners, but skip on native/desktop where users
+          // are always on the official site
+          if (!isNativeSurface() && !isDesktop()) {
             await this.$router.push({
               name: ROUTE_SETTINGS_INDEX
             });
           }
         }
-        if (isNativeSurface()) {
-          // On native platforms, hide the auth panel and navigate home instead
-          // of reloading — window.location.reload() in Capacitor WKWebView can
-          // fail to re-trigger the auth check, leaving users on a blank screen.
+        if (isNativeSurface() || isDesktop()) {
+          // On native AND desktop, hide the auth panel and navigate home
+          // instead of reloading — window.location.reload() in Capacitor
+          // WKWebView can fail to re-trigger the auth check, and on desktop it
+          // would reload the app://bundle (the navigation we avoid everywhere).
           this.$store.commit('setAuth', { visible: false });
           await this.$router.push('/');
         } else {

--- a/src/i18n/ar/common.json
+++ b/src/i18n/ar/common.json
@@ -223,6 +223,10 @@
     "message": "فشل تسجيل الدخول باستخدام Apple. يرجى المحاولة مرة أخرى أو استخدام طريقة تسجيل دخول أخرى.",
     "description": "Error toast shown when native Apple sign-in fails for a reason other than user cancellation"
   },
+  "error.loginLinkExpired": {
+    "message": "Login link expired. Please sign in again.",
+    "description": "Shown on the desktop client when an OAuth callback is dropped (state mismatch or expired)."
+  },
   "entity.operation": {
     "message": "عملية",
     "description": "عملية الكيان"

--- a/src/i18n/de/common.json
+++ b/src/i18n/de/common.json
@@ -223,6 +223,10 @@
     "message": "Anmeldung mit Apple fehlgeschlagen. Bitte versuchen Sie es erneut oder verwenden Sie eine andere Anmeldemethode.",
     "description": "Error toast shown when native Apple sign-in fails for a reason other than user cancellation"
   },
+  "error.loginLinkExpired": {
+    "message": "Login link expired. Please sign in again.",
+    "description": "Shown on the desktop client when an OAuth callback is dropped (state mismatch or expired)."
+  },
   "entity.operation": {
     "message": "Operation",
     "description": "Operation der Entität"

--- a/src/i18n/el/common.json
+++ b/src/i18n/el/common.json
@@ -223,6 +223,10 @@
     "message": "Η σύνδεση με Apple απέτυχε. Δοκιμάστε ξανά ή χρησιμοποιήστε άλλη μέθοδο σύνδεσης.",
     "description": "Error toast shown when native Apple sign-in fails for a reason other than user cancellation"
   },
+  "error.loginLinkExpired": {
+    "message": "Login link expired. Please sign in again.",
+    "description": "Shown on the desktop client when an OAuth callback is dropped (state mismatch or expired)."
+  },
   "entity.operation": {
     "message": "Ενέργεια",
     "description": "Η ενέργεια της οντότητας"

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -219,6 +219,10 @@
     "message": "Sign in with Apple failed. Please try again or use another sign-in method.",
     "description": "Error toast shown when native Sign in with Apple fails for a reason other than the user cancelling."
   },
+  "error.loginLinkExpired": {
+    "message": "Login link expired. Please sign in again.",
+    "description": "Shown on the desktop client when an OAuth callback is dropped (state mismatch or expired)."
+  },
   "entity.operation": {
     "message": "Operation",
     "description": "The operation of the entity"

--- a/src/i18n/es/common.json
+++ b/src/i18n/es/common.json
@@ -223,6 +223,10 @@
     "message": "No se pudo iniciar sesión con Apple. Inténtalo de nuevo o usa otro método de inicio de sesión.",
     "description": "Error toast shown when native Apple sign-in fails for a reason other than user cancellation"
   },
+  "error.loginLinkExpired": {
+    "message": "Login link expired. Please sign in again.",
+    "description": "Shown on the desktop client when an OAuth callback is dropped (state mismatch or expired)."
+  },
   "entity.operation": {
     "message": "Operación",
     "description": "Operación de la entidad"

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -223,6 +223,10 @@
     "message": "Apple-kirjautuminen epäonnistui. Yritä uudelleen tai käytä toista kirjautumistapaa.",
     "description": "Error toast shown when native Apple sign-in fails for a reason other than user cancellation"
   },
+  "error.loginLinkExpired": {
+    "message": "Login link expired. Please sign in again.",
+    "description": "Shown on the desktop client when an OAuth callback is dropped (state mismatch or expired)."
+  },
   "entity.operation": {
     "message": "Toiminto",
     "description": "Entiteetin toiminto"

--- a/src/i18n/fr/common.json
+++ b/src/i18n/fr/common.json
@@ -223,6 +223,10 @@
     "message": "La connexion avec Apple a échoué. Veuillez réessayer ou utiliser une autre méthode de connexion.",
     "description": "Error toast shown when native Apple sign-in fails for a reason other than user cancellation"
   },
+  "error.loginLinkExpired": {
+    "message": "Login link expired. Please sign in again.",
+    "description": "Shown on the desktop client when an OAuth callback is dropped (state mismatch or expired)."
+  },
   "entity.operation": {
     "message": "Opération",
     "description": "Opération de l'entité"

--- a/src/i18n/it/common.json
+++ b/src/i18n/it/common.json
@@ -223,6 +223,10 @@
     "message": "Accesso con Apple non riuscito. Riprova o usa un altro metodo di accesso.",
     "description": "Error toast shown when native Apple sign-in fails for a reason other than user cancellation"
   },
+  "error.loginLinkExpired": {
+    "message": "Login link expired. Please sign in again.",
+    "description": "Shown on the desktop client when an OAuth callback is dropped (state mismatch or expired)."
+  },
   "entity.operation": {
     "message": "Operazione",
     "description": "Operazione dell'entità"

--- a/src/i18n/ja/common.json
+++ b/src/i18n/ja/common.json
@@ -223,6 +223,10 @@
     "message": "Apple でのサインインに失敗しました。もう一度お試しいただくか、別のサインイン方法をご利用ください。",
     "description": "Error toast shown when native Apple sign-in fails for a reason other than user cancellation"
   },
+  "error.loginLinkExpired": {
+    "message": "Login link expired. Please sign in again.",
+    "description": "Shown on the desktop client when an OAuth callback is dropped (state mismatch or expired)."
+  },
   "entity.operation": {
     "message": "操作",
     "description": "エンティティの操作"

--- a/src/i18n/ko/common.json
+++ b/src/i18n/ko/common.json
@@ -223,6 +223,10 @@
     "message": "Apple로 로그인하지 못했습니다. 다시 시도하거나 다른 로그인 방법을 사용해 주세요.",
     "description": "Error toast shown when native Apple sign-in fails for a reason other than user cancellation"
   },
+  "error.loginLinkExpired": {
+    "message": "Login link expired. Please sign in again.",
+    "description": "Shown on the desktop client when an OAuth callback is dropped (state mismatch or expired)."
+  },
   "entity.operation": {
     "message": "작업",
     "description": "엔티티의 작업"

--- a/src/i18n/pl/common.json
+++ b/src/i18n/pl/common.json
@@ -223,6 +223,10 @@
     "message": "Logowanie przez Apple nie powiodło się. Spróbuj ponownie lub użyj innej metody logowania.",
     "description": "Error toast shown when native Apple sign-in fails for a reason other than user cancellation"
   },
+  "error.loginLinkExpired": {
+    "message": "Login link expired. Please sign in again.",
+    "description": "Shown on the desktop client when an OAuth callback is dropped (state mismatch or expired)."
+  },
   "entity.operation": {
     "message": "Operacja",
     "description": "Operacja encji"

--- a/src/i18n/pt/common.json
+++ b/src/i18n/pt/common.json
@@ -223,6 +223,10 @@
     "message": "Falha ao iniciar sessão com a Apple. Tente novamente ou utilize outro método de início de sessão.",
     "description": "Error toast shown when native Apple sign-in fails for a reason other than user cancellation"
   },
+  "error.loginLinkExpired": {
+    "message": "Login link expired. Please sign in again.",
+    "description": "Shown on the desktop client when an OAuth callback is dropped (state mismatch or expired)."
+  },
   "entity.operation": {
     "message": "Operação",
     "description": "Operação da entidade"

--- a/src/i18n/ru/common.json
+++ b/src/i18n/ru/common.json
@@ -223,6 +223,10 @@
     "message": "Не удалось войти через Apple. Повторите попытку или используйте другой способ входа.",
     "description": "Error toast shown when native Apple sign-in fails for a reason other than user cancellation"
   },
+  "error.loginLinkExpired": {
+    "message": "Login link expired. Please sign in again.",
+    "description": "Shown on the desktop client when an OAuth callback is dropped (state mismatch or expired)."
+  },
   "entity.operation": {
     "message": "Операция",
     "description": "Операция сущности"

--- a/src/i18n/sr/common.json
+++ b/src/i18n/sr/common.json
@@ -223,6 +223,10 @@
     "message": "Пријава помоћу Apple-а није успела. Покушајте поново или користите други начин пријаве.",
     "description": "Error toast shown when native Apple sign-in fails for a reason other than user cancellation"
   },
+  "error.loginLinkExpired": {
+    "message": "Login link expired. Please sign in again.",
+    "description": "Shown on the desktop client when an OAuth callback is dropped (state mismatch or expired)."
+  },
   "entity.operation": {
     "message": "Operacija",
     "description": "Operacija entiteta"

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -223,6 +223,10 @@
     "message": "Det gick inte att logga in med Apple. Försök igen eller använd en annan inloggningsmetod.",
     "description": "Error toast shown when native Apple sign-in fails for a reason other than user cancellation"
   },
+  "error.loginLinkExpired": {
+    "message": "Login link expired. Please sign in again.",
+    "description": "Shown on the desktop client when an OAuth callback is dropped (state mismatch or expired)."
+  },
   "entity.operation": {
     "message": "Åtgärd",
     "description": "Åtgärden för enheten"

--- a/src/i18n/uk/common.json
+++ b/src/i18n/uk/common.json
@@ -223,6 +223,10 @@
     "message": "Не вдалося ввійти через Apple. Спробуйте ще раз або скористайтеся іншим способом входу.",
     "description": "Error toast shown when native Apple sign-in fails for a reason other than user cancellation"
   },
+  "error.loginLinkExpired": {
+    "message": "Login link expired. Please sign in again.",
+    "description": "Shown on the desktop client when an OAuth callback is dropped (state mismatch or expired)."
+  },
   "entity.operation": {
     "message": "Операція",
     "description": "Операція сутності"

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -223,6 +223,10 @@
     "message": "通过 Apple 登录失败，请重试或使用其他登录方式。",
     "description": "当原生“通过 Apple 登录”因用户取消以外的原因失败时显示的错误提示。"
   },
+  "error.loginLinkExpired": {
+    "message": "登录链接已失效，请重新登录。",
+    "description": "桌面客户端 OAuth 回调因 state 校验失败/过期被丢弃时显示的错误提示。"
+  },
   "entity.operation": {
     "message": "操作",
     "description": "实体的操作"

--- a/src/i18n/zh-TW/common.json
+++ b/src/i18n/zh-TW/common.json
@@ -223,6 +223,10 @@
     "message": "透過 Apple 登入失敗，請重試或使用其他登入方式。",
     "description": "Error toast shown when native Apple sign-in fails for a reason other than user cancellation"
   },
+  "error.loginLinkExpired": {
+    "message": "登入連結已失效，請重新登入。",
+    "description": "桌面客戶端 OAuth 回呼因 state 驗證失敗/過期被丟棄時顯示的錯誤提示。"
+  },
   "entity.operation": {
     "message": "操作",
     "description": "实体的操作"

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@ import dayjs from './plugins/dayjs';
 import './plugins/font-awesome';
 import { MotionPlugin } from '@vueuse/motion';
 import { vLoading } from 'element-plus';
-import { getSurface, isNative } from '@/utils/surface';
+import { getSurface, isNative, isDesktop } from '@/utils/surface';
 import { resolveDeferredInviterId } from '@/utils/attribution';
 import { syncFeaturesFromUrl } from '@/utils/featureFlag';
 import { runVersionGate } from '@/utils/versionGate';
@@ -87,7 +87,7 @@ export const createApp = ViteSSG(App, { routes, base: import.meta.env.BASE_URL }
   await initializeToken();
   await Promise.all([initializeUser(), initializeSite(), initializeConfig()]);
 
-  if (isNative()) {
+  if (isNative() || isDesktop()) {
     const blocked = await runVersionGate();
     if (blocked) return;
   }

--- a/src/shims.d.ts
+++ b/src/shims.d.ts
@@ -37,8 +37,12 @@ declare const CdvPurchase: any;
 
 // Injected by vite.config `define` for all surfaces (web/android/ios/desktop).
 // Holds the package.json version; used for the telemetry release tag and the
-// desktop version gate.
-declare const __APP_VERSION__: string;
+// desktop version gate. Must be inside `declare global` — this file has
+// imports, so a bare top-level `declare const` would be module-scoped and not
+// visible from main.ts/versionGate.ts.
+declare global {
+  const __APP_VERSION__: string;
+}
 
 // declare namespace Intl {
 //   function getCanonicalLocales(locales: string | string[] | undefined): string[];

--- a/src/store/common/actions.ts
+++ b/src/store/common/actions.ts
@@ -13,7 +13,7 @@ import {
 import { IApplication, IApplicationScope, IApplicationType, ICredential, IToken, IUser, Status } from '@/models';
 import { getSiteOrigin } from '@/utils/site';
 import { getBaseUrlAuth, getBaseUrlHub, getInviterId, loginRedirect } from '@/utils';
-import { isNative } from '@/utils/surface';
+import { isNative, isDesktop } from '@/utils/surface';
 
 export const resetAll = ({ commit }: ActionContext<IRootState, IRootState>) => {
   commit('resetToken');
@@ -220,7 +220,9 @@ export const createCredential = async ({ commit, state }: any): Promise<ICredent
 
 export const login = async ({ state, commit }: ActionContext<IRootState, IRootState>) => {
   const site = state?.site?.origin;
-  if (isNative()) {
+  if (isNative() || isDesktop()) {
+    // In-app popup (iframe) login. NEVER window.location.href on desktop — an
+    // app://bundle window navigated to the external auth host cannot return.
     commit('setAuth', {
       flow: 'popup',
       visible: true
@@ -250,9 +252,10 @@ export const logout = async ({ dispatch, commit }: ActionContext<IRootState, IRo
   for (const name of getRegisteredLazyModules()) {
     await dispatch(`${name}/resetAll`);
   }
-  if (isNative()) {
-    // On native platforms, show in-app login popup instead of navigating to
-    // external auth URL (which would open Chrome and redirect to localhost)
+  if (isNative() || isDesktop()) {
+    // On native AND desktop, show the in-app login popup instead of navigating
+    // to an external auth URL (which on native opens Chrome → localhost, and on
+    // desktop navigates the app://bundle window somewhere it can't return from).
     commit('setAuth', {
       flow: 'popup',
       visible: true

--- a/src/utils/auth/exchangeSsoCode.test.ts
+++ b/src/utils/auth/exchangeSsoCode.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the SSO operator + telemetry so the util is exercised in isolation.
+const tokenMock = vi.fn();
+vi.mock('@/operators', () => ({
+  ssoOperator: { token: (...args: unknown[]) => tokenMock(...args) }
+}));
+vi.mock('@/plugins/telemetry', () => ({ track: vi.fn() }));
+
+import { exchangeSsoCode } from './exchangeSsoCode';
+
+function makeCtx(source: 'native' | 'desktop' = 'desktop') {
+  const dispatch = vi.fn().mockResolvedValue(undefined);
+  const commit = vi.fn();
+  const push = vi.fn().mockResolvedValue(undefined);
+  const store = { dispatch, commit, state: { site: { origin: 'studio.acedata.cloud' } } };
+  const router = { push };
+  return { store: store as never, router: router as never, source, dispatch, commit, push };
+}
+
+describe('exchangeSsoCode', () => {
+  beforeEach(() => {
+    tokenMock.mockReset();
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('exchanges the code, sets the token, fetches the user, and routes home', async () => {
+    tokenMock.mockResolvedValue({
+      data: { access_token: 'acc', refresh_token: 'ref', expires_in: 3600 }
+    });
+    const ctx = makeCtx();
+    await exchangeSsoCode('code-success-1', ctx);
+
+    expect(tokenMock).toHaveBeenCalledWith({ code: 'code-success-1' });
+    expect(ctx.dispatch).toHaveBeenCalledWith('setToken', {
+      access: 'acc',
+      refresh: 'ref',
+      expiration: 3600
+    });
+    expect(ctx.dispatch).toHaveBeenCalledWith('getUser');
+    expect(ctx.commit).toHaveBeenCalledWith('setAuth', { visible: false });
+    expect(ctx.push).toHaveBeenCalledWith('/');
+  });
+
+  it('dedups: the same code is not exchanged twice', async () => {
+    tokenMock.mockResolvedValue({
+      data: { access_token: 'a', refresh_token: 'r', expires_in: 1 }
+    });
+    const ctx = makeCtx();
+    await exchangeSsoCode('code-dedup', ctx);
+    await exchangeSsoCode('code-dedup', ctx); // second call must be a no-op
+
+    expect(tokenMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('on failure: dispatches login and allows a fresh (different) code to retry', async () => {
+    tokenMock.mockRejectedValueOnce(new Error('boom'));
+    const ctx = makeCtx();
+    await exchangeSsoCode('code-fail', ctx);
+
+    expect(ctx.commit).toHaveBeenCalledWith('setAuth', { visible: false });
+    expect(ctx.dispatch).toHaveBeenCalledWith('login');
+
+    // A NEW code must not be blocked by the failed one (dedup was reset).
+    tokenMock.mockResolvedValue({
+      data: { access_token: 'a2', refresh_token: 'r2', expires_in: 2 }
+    });
+    const ctx2 = makeCtx();
+    await exchangeSsoCode('code-after-fail', ctx2);
+    expect(ctx2.dispatch).toHaveBeenCalledWith('getUser');
+  });
+
+  it('ignores an empty code', async () => {
+    const ctx = makeCtx();
+    await exchangeSsoCode('', ctx);
+    expect(tokenMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/auth/exchangeSsoCode.ts
+++ b/src/utils/auth/exchangeSsoCode.ts
@@ -1,0 +1,58 @@
+import type { Store } from 'vuex';
+import type { Router } from 'vue-router';
+import { ssoOperator } from '@/operators';
+import { track } from '@/plugins/telemetry';
+
+/**
+ * Shared SSO `code → token` exchange used by BOTH the native (Capacitor
+ * `appUrlOpen`) and desktop (Electron custom-scheme) deep-link callbacks.
+ *
+ * Extracted verbatim from the original inline handler in `App.vue` so the two
+ * surfaces share one implementation. On desktop the Electron main process has
+ * ALREADY validated the OAuth `state` nonce before this runs, so `state` never
+ * reaches the renderer — we only ever receive `code`.
+ *
+ * RUM event names are kept identical to the original (`apple_login_deeplink` /
+ * `apple_login_success` / `apple_login_failed`) so existing dashboards/alerts
+ * keep firing; a `source` field distinguishes native vs desktop.
+ */
+let lastHandledCode = '';
+
+interface ExchangeContext {
+  // `Store`/`Router` are passed in (rather than imported) so this stays a pure
+  // util usable from both the component and tests.
+  store: Store<unknown>;
+  router: Router;
+  source: 'native' | 'desktop';
+}
+
+export async function exchangeSsoCode(code: string, { store, router, source }: ExchangeContext): Promise<void> {
+  if (!code) return;
+  // Dedup: an SSO code is single-use; the same code can arrive twice (Capacitor
+  // re-delivers appUrlOpen; a desktop double protocol activation). Replaying a
+  // consumed code 4xxs and would kick the user back to login.
+  if (code === lastHandledCode) return;
+  lastHandledCode = code;
+  track('apple_login_deeplink', { action: 'sso_exchange', source });
+  try {
+    const { data } = await ssoOperator.token({ code });
+    const token = {
+      access: data.access_token,
+      refresh: data.refresh_token,
+      expiration: data.expires_in
+    };
+    await store.dispatch('setToken', token);
+    await store.dispatch('getUser');
+    track('apple_login_success', { action: 'sso_exchange', source });
+    store.commit('setAuth', { visible: false });
+    await router.push('/');
+  } catch (e) {
+    // Reset dedup ONLY if we still own this code, so a concurrent attempt's
+    // newer code (set into lastHandledCode while we awaited) isn't wiped —
+    // that would let its single-use code be re-exchanged and 4xx-bounce.
+    if (lastHandledCode === code) lastHandledCode = '';
+    track('apple_login_failed', { action: 'sso_exchange', source, error: String(e) });
+    store.commit('setAuth', { visible: false });
+    await store.dispatch('login');
+  }
+}

--- a/src/utils/versionGate.ts
+++ b/src/utils/versionGate.ts
@@ -2,8 +2,10 @@ import { App as CapApp } from '@capacitor/app';
 import { Browser } from '@capacitor/browser';
 import { ElMessageBox } from 'element-plus';
 import { appVersionOperator } from '@/operators/appVersion';
-import { isAndroid, isIOS, isNative } from '@/utils/surface';
+import { isAndroid, isIOS, isNative, isDesktop } from '@/utils/surface';
+import { desktopBridge } from '@/utils/desktop';
 import { t, setI18nLanguage, getLocale } from '@/i18n';
+// `__APP_VERSION__` is declared globally in shims.d.ts (vite `define`).
 
 /**
  * Compare two dotted numeric version strings. Returns -1 / 0 / 1 like
@@ -32,6 +34,7 @@ export function compareVersions(a: string, b: string): number {
  *          false otherwise.
  */
 export async function runVersionGate(): Promise<boolean> {
+  if (isDesktop()) return runDesktopVersionGate();
   if (!isNative()) return false;
   const platform = isIOS() ? 'ios' : isAndroid() ? 'android' : null;
   if (!platform) return false;
@@ -122,6 +125,90 @@ async function showSoftUpgrade(storeUrl: string, customMessage: string): Promise
       }
     );
     if (storeUrl) await Browser.open({ url: storeUrl });
+  } catch {
+    // User dismissed — fine.
+  }
+}
+
+/**
+ * Desktop (Electron) version gate. electron-updater has no server-side
+ * hard-block, so this is the out-of-band kill switch — the desktop equivalent
+ * of the mobile gate above. Fails open whenever the version is unknown or the
+ * metadata fetch fails (never brick the app on infra problems).
+ *
+ * Differences from mobile: version comes from the `__APP_VERSION__` build-time
+ * global (not CapApp.getInfo), the store link opens via the desktop bridge in
+ * the system browser, and the blocking modal is a single terminal prompt (not
+ * a re-arming loop) — on desktop the user can always close the OS window.
+ */
+async function runDesktopVersionGate(): Promise<boolean> {
+  const appVersion = typeof __APP_VERSION__ === 'string' ? __APP_VERSION__ : '';
+  if (!appVersion) {
+    console.warn('[versionGate] desktop version unknown, fail-open');
+    return false;
+  }
+
+  let meta;
+  try {
+    const { data } = await appVersionOperator.get('nexior', 'desktop');
+    meta = data;
+  } catch (err) {
+    console.warn('[versionGate] desktop fetch failed, skipping', err);
+    return false;
+  }
+
+  const belowMin = meta.min_supported && compareVersions(appVersion, meta.min_supported) < 0;
+  const belowLatest = meta.latest && compareVersions(appVersion, meta.latest) < 0;
+
+  if (belowMin) {
+    try {
+      await setI18nLanguage(getLocale());
+    } catch (err) {
+      console.warn('[versionGate] locale load failed, continuing with default', err);
+    }
+    await showBlockingUpgradeDesktop(meta.store_url, meta.message);
+    return true;
+  }
+  if (belowLatest) {
+    void showSoftUpgradeDesktop(meta.store_url, meta.message);
+  }
+  return false;
+}
+
+async function showBlockingUpgradeDesktop(storeUrl: string, customMessage: string): Promise<void> {
+  // Single terminal prompt (no while(true) loop — desktop has no "close the
+  // WebView" escape hatch, so a re-arming modal would trap the user behind a
+  // still-interactive window). Open the download page, then the user updates.
+  try {
+    await ElMessageBox.alert(
+      customMessage || (t('common.appUpgrade.blockMessage') as string),
+      t('common.appUpgrade.title') as string,
+      {
+        confirmButtonText: t('common.appUpgrade.openStore') as string,
+        showClose: false,
+        closeOnClickModal: false,
+        closeOnPressEscape: false,
+        type: 'warning'
+      }
+    );
+  } catch {
+    // Dismissed — still open the download page below.
+  }
+  if (storeUrl) await desktopBridge()?.openExternal(storeUrl);
+}
+
+async function showSoftUpgradeDesktop(storeUrl: string, customMessage: string): Promise<void> {
+  try {
+    await ElMessageBox.confirm(
+      customMessage || (t('common.appUpgrade.softMessage') as string),
+      t('common.appUpgrade.title') as string,
+      {
+        confirmButtonText: t('common.appUpgrade.openStore') as string,
+        cancelButtonText: t('common.appUpgrade.later') as string,
+        type: 'info'
+      }
+    );
+    if (storeUrl) await desktopBridge()?.openExternal(storeUrl);
   } catch {
     // User dismissed — fine.
   }


### PR DESCRIPTION
PR 2 of 4 implementing the Nexior desktop client (plan + 3-round adversarial review in `plans/nexior-desktop`). Depends on #1010 (merged).

## What
Makes login work on the `desktop` surface **without changing web/native behavior**.

- **`utils/auth/exchangeSsoCode.ts`** — extract the SSO `code→token` exchange + single-use dedup from `App.vue` so native (Capacitor `appUrlOpen`) and desktop (Electron custom scheme) share one path. Original RUM event names (`apple_login_*`) preserved.
- **`App.vue`** — native delegates to the shared util (`Browser.close` stays native-only); desktop deep-link path via `onAuthCallback`/`onAuthExpired`, the `signalReady` handshake, and a site-origin watcher feeding the Electron external-open allowlist.
- **`store/common/actions.ts`** — `login`/`logout` use the in-app popup on desktop too (never `window.location.href`).
- **`components/common/AuthPanel.vue`** — `isInAppLogin` drives the iframe UI; `native_redirect` per surface (`acedata-desktop`); social login → `window.desktop.openOAuth` (system browser); login-success `router.push` (no reload); `browserFinished` stays native-only.
- **`utils/versionGate.ts` + `main.ts`** — desktop version-gate kill switch, now reachable on desktop.
- **`shims.d.ts`** — `__APP_VERSION__` moved into `declare global` (fixes 2 pre-existing tsc errors).
- **i18n** — `common.error.loginLinkExpired` in all 18 locales.

## Verification
- `vitest run`: **16/16 pass** (exchangeSsoCode dedup/failure-retry + surface + site)
- `eslint --fix`: clean
- `vue-tsc -b`: **65→63** errors vs `main` (zero added). Remaining are pre-existing `@acedatacloud/core/*` / `vite-ssg` local-resolution noise.

## Cross-repo (Phase 0, tracked)
Desktop login end-to-end needs AuthBackend `native_redirect` allow-list for `acedata-desktop`, AuthFrontend `frame-ancestors` for `app://bundle`, and `state` passthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)