### PR TITLE
fix(realtime): orb clipping, stale cancel error, voice picker, wallet app selection

### DIFF
--- a/change/@acedatacloud-nexior-8455d52d-f1e4-42fa-aba3-9f6029e7c73c.json
+++ b/change/@acedatacloud-nexior-8455d52d-f1e4-42fa-aba3-9f6029e7c73c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(realtime): orb clipping, stale cancel error, voice picker, wallet app selection",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/constants/realtime.ts
+++ b/src/constants/realtime.ts
@@ -4,3 +4,21 @@
 export const REALTIME_SERVICE_ID = 'b1fbcc32-e218-4253-9dc3-4fe600a1bfb9';
 export const REALTIME_DEFAULT_MODEL = 'gpt-realtime';
 export const REALTIME_SAMPLE_RATE = 24000;
+
+// Selectable voices for gpt-realtime. The relay whitelists `voice` in its
+// client session.update sanitizer, so the browser can pick any of these; the
+// default mirrors the relay's own default (DEFAULT_REALTIME_VOICE = "alloy").
+export const REALTIME_VOICES = [
+  'alloy',
+  'ash',
+  'ballad',
+  'coral',
+  'echo',
+  'sage',
+  'shimmer',
+  'verse',
+  'marin',
+  'cedar'
+] as const;
+export type RealtimeVoice = (typeof REALTIME_VOICES)[number];
+export const REALTIME_DEFAULT_VOICE: RealtimeVoice = 'alloy';

--- a/src/pages/chat/RealtimeCall.vue
+++ b/src/pages/chat/RealtimeCall.vue
@@ -6,6 +6,17 @@
         <font-awesome-icon icon="fa-solid fa-chevron-down" />
       </button>
       <div class="rtc-top-right">
+        <div class="voice-pick">
+          <button class="voice-chip" :class="{ on: voiceMenuOpen }" @click.stop="voiceMenuOpen = !voiceMenuOpen">
+            <span class="voice-name">{{ voiceLabel }}</span>
+            <font-awesome-icon icon="fa-solid fa-chevron-down" class="voice-caret" />
+          </button>
+          <ul v-if="voiceMenuOpen" class="voice-menu">
+            <li v-for="v in voices" :key="v" :class="{ sel: v === voice }" @click="selectVoice(v)">
+              {{ labelOf(v) }}
+            </li>
+          </ul>
+        </div>
         <button class="ic" :class="{ on: showInfo }" :title="$t('realtime.title')" @click="showInfo = !showInfo">
           <font-awesome-icon icon="fa-solid fa-circle-info" />
         </button>
@@ -14,6 +25,9 @@
         </button>
       </div>
     </header>
+
+    <!-- tap-away closer for the voice menu -->
+    <div v-if="voiceMenuOpen" class="voice-backdrop" @click="voiceMenuOpen = false"></div>
 
     <!-- stage: the audio-reactive orb -->
     <main class="rtc-stage">
@@ -65,8 +79,10 @@
 import { defineComponent } from 'vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { RealtimeClient, RealtimeStatus } from '@/utils/realtimeClient';
-import { REALTIME_DEFAULT_MODEL } from '@/constants';
+import { REALTIME_DEFAULT_MODEL, REALTIME_DEFAULT_VOICE, REALTIME_VOICES } from '@/constants';
 import { ROUTE_CHATGPT_CONVERSATION_NEW } from '@/router/constants';
+
+const VOICE_STORAGE_KEY = 'nexior.realtime.voice';
 
 export default defineComponent({
   name: 'RealtimeCall',
@@ -87,7 +103,10 @@ export default defineComponent({
       level: 0,
       muted: false,
       captionsOn: false,
-      showInfo: false
+      showInfo: false,
+      voice: REALTIME_DEFAULT_VOICE as string,
+      voices: [...REALTIME_VOICES] as string[],
+      voiceMenuOpen: false
     };
   },
   computed: {
@@ -124,9 +143,18 @@ export default defineComponent({
       if (this.provisioning || this.connecting) return this.$t('realtime.status.connecting');
       if (this.running) return this.aiSpeaking ? this.$t('realtime.speaking') : this.$t('realtime.listening');
       return this.$t('realtime.start');
+    },
+    voiceLabel(): string {
+      return this.labelOf(this.voice);
     }
   },
   async mounted() {
+    try {
+      const saved = localStorage.getItem(VOICE_STORAGE_KEY);
+      if (saved && this.voices.includes(saved)) this.voice = saved;
+    } catch {
+      // localStorage may be unavailable; fall back to the default voice
+    }
     this.provisioning = true;
     try {
       await this.$store.dispatch('realtime/init');
@@ -146,33 +174,41 @@ export default defineComponent({
       this.userText = '';
       this.aiText = '';
       this.connecting = true;
-      this.client = new RealtimeClient(this.token, REALTIME_DEFAULT_MODEL, {
-        onStatus: (s: RealtimeStatus) => {
-          this.status = s;
-          this.running = s === 'connecting' || s === 'connected';
-          if (s === 'connected' || s === 'disconnected' || s === 'error') this.connecting = false;
-          if (!this.running) this.level = 0;
+      this.client = new RealtimeClient(
+        this.token,
+        REALTIME_DEFAULT_MODEL,
+        {
+          onStatus: (s: RealtimeStatus) => {
+            this.status = s;
+            this.running = s === 'connecting' || s === 'connected';
+            if (s === 'connected' || s === 'disconnected' || s === 'error') this.connecting = false;
+            if (!this.running) this.level = 0;
+          },
+          onUserSpeechStarted: () => {
+            this.aiSpeaking = false;
+            // Any prior transient error is stale once a new turn begins.
+            this.errorMsg = '';
+          },
+          onUserTranscript: (t: string) => {
+            this.userText = t;
+          },
+          onAiResponseStart: () => {
+            this.aiText = '';
+            this.aiSpeaking = true;
+            this.errorMsg = '';
+          },
+          onAiTranscriptDelta: (d: string) => {
+            this.aiText += d;
+          },
+          onAudioLevel: (lvl: number) => {
+            this.level = lvl;
+          },
+          onError: (m: string) => {
+            this.errorMsg = m;
+          }
         },
-        onUserSpeechStarted: () => {
-          this.aiSpeaking = false;
-        },
-        onUserTranscript: (t: string) => {
-          this.userText = t;
-        },
-        onAiResponseStart: () => {
-          this.aiText = '';
-          this.aiSpeaking = true;
-        },
-        onAiTranscriptDelta: (d: string) => {
-          this.aiText += d;
-        },
-        onAudioLevel: (lvl: number) => {
-          this.level = lvl;
-        },
-        onError: (m: string) => {
-          this.errorMsg = m;
-        }
-      });
+        this.voice
+      );
       // a fresh call should honour the current mute state
       try {
         await this.client.start();
@@ -190,6 +226,21 @@ export default defineComponent({
     },
     toggleCaptions() {
       this.captionsOn = !this.captionsOn;
+    },
+    labelOf(v: string): string {
+      return v.charAt(0).toUpperCase() + v.slice(1);
+    },
+    selectVoice(v: string) {
+      this.voiceMenuOpen = false;
+      if (v === this.voice) return;
+      this.voice = v;
+      try {
+        localStorage.setItem(VOICE_STORAGE_KEY, v);
+      } catch {
+        // ignore persistence failure
+      }
+      // Apply live if a call is running; otherwise it's used on the next start.
+      this.client?.setVoice(v);
     },
     onOrbTap() {
       if (!this.running && !this.connecting) this.startCall();
@@ -273,6 +324,74 @@ export default defineComponent({
   }
 }
 
+/* ---------- voice picker ---------- */
+.voice-pick {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+.voice-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 36px;
+  padding: 0 12px;
+  border: none;
+  border-radius: 18px;
+  background: var(--chip);
+  color: var(--chip-fg);
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    background 0.2s ease,
+    color 0.2s ease;
+  .voice-caret {
+    font-size: 11px;
+    opacity: 0.7;
+  }
+  &.on,
+  &:hover {
+    color: #2f86f6;
+  }
+}
+.voice-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 10;
+  min-width: 132px;
+  max-height: 240px;
+  overflow-y: auto;
+  margin: 0;
+  padding: 6px;
+  list-style: none;
+  background: var(--bg);
+  border: 1px solid var(--chip);
+  border-radius: 12px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.18);
+  li {
+    padding: 8px 12px;
+    border-radius: 8px;
+    font-size: 14px;
+    color: var(--fg);
+    cursor: pointer;
+    transition: background 0.15s ease;
+    &:hover {
+      background: var(--chip);
+    }
+    &.sel {
+      color: #2f86f6;
+      font-weight: 600;
+    }
+  }
+}
+.voice-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1;
+}
+
 /* ---------- stage / orb ---------- */
 .rtc-stage {
   flex: 1;
@@ -317,6 +436,9 @@ export default defineComponent({
   width: 100%;
   height: 100%;
   animation: breathe 6.5s ease-in-out infinite;
+  // The orb's circular clip below drops its own outer glow; re-add it here on
+  // the (unclipped) wrapper as a drop-shadow that follows the round shape.
+  filter: drop-shadow(0 18px 34px rgba(47, 134, 246, 0.4));
   &.paused {
     animation-duration: 9s;
   }
@@ -336,6 +458,12 @@ export default defineComponent({
   height: 100%;
   border-radius: 50%;
   overflow: hidden;
+  // Safari/WebKit drops `overflow:hidden`+`border-radius` clipping for
+  // `mix-blend-mode` children on a composited (transform/will-change) layer —
+  // the corner clouds (c1/c2) then leak past the circle as square corners.
+  // `clip-path` clips every descendant reliably; `isolation` keeps the blend.
+  clip-path: circle(50%);
+  isolation: isolate;
   background: radial-gradient(120% 120% at 34% 24%, #ffffff 0%, #eaf4ff 16%, #c2deff 40%, #79b3ff 70%, #2f86f6 100%);
   box-shadow:
     0 20px 55px rgba(47, 134, 246, 0.4),

--- a/src/store/realtime/actions.ts
+++ b/src/store/realtime/actions.ts
@@ -5,6 +5,7 @@ import { IRealtimeState } from './models';
 import { IApplication, ICredential } from '@/models';
 import { Status } from '@/models';
 import { REALTIME_SERVICE_ID } from '@/constants';
+import { getFinalApplication } from '@/utils';
 
 export const getService = async ({ commit, state }: ActionContext<IRealtimeState, IRootState>) => {
   state.status.getService = Status.Request;
@@ -72,11 +73,20 @@ export const setApplication = async ({ commit, dispatch, rootState }: any, paylo
   }
 };
 
-// Orchestrate provisioning: service -> applications -> first usable app -> credential.
-export const init = async ({ dispatch, state }: any): Promise<ICredential | undefined> => {
+// Orchestrate provisioning: service -> applications -> selected app -> credential.
+export const init = async ({ dispatch, state, rootState }: any): Promise<ICredential | undefined> => {
   await dispatch('getService');
-  const applications = await dispatch('getApplications');
-  const application = (applications || [])[0];
+  // Load this service's individual apps AND the universal (global / 通用余额)
+  // balance, then pick the SAME way the wallet does: respect the current
+  // selection, else prefer a usable global app over an exhausted individual one.
+  // Blind-picking `applications[0]` used to yank the wallet onto a 0-balance
+  // individual app and fight the layout's global-preferred selection on mount.
+  const [individual] = await Promise.all([
+    dispatch('getApplications'),
+    dispatch('getApplications', null, { root: true })
+  ]);
+  const combined = [...(rootState?.applications ?? []), ...((individual as IApplication[]) ?? [])];
+  const application = getFinalApplication(combined, state.application);
   if (application) {
     await dispatch('setApplication', application);
   }

--- a/src/utils/realtimeClient.ts
+++ b/src/utils/realtimeClient.ts
@@ -1,4 +1,4 @@
-import { REALTIME_SAMPLE_RATE, WS_URL_REALTIME } from '@/constants';
+import { REALTIME_DEFAULT_VOICE, REALTIME_SAMPLE_RATE, WS_URL_REALTIME } from '@/constants';
 
 export type RealtimeStatus = 'connecting' | 'connected' | 'disconnected' | 'error';
 
@@ -24,6 +24,7 @@ export class RealtimeClient {
   private readonly token: string;
   private readonly model: string;
   private readonly handlers: IRealtimeHandlers;
+  private voice: string;
 
   private ws: WebSocket | undefined;
   private audioCtx: AudioContext | undefined;
@@ -39,11 +40,13 @@ export class RealtimeClient {
   private disposed = false; // set by stop(); aborts an in-flight start()
   private suppressAudio = false; // drop in-flight deltas after a barge-in
   private aiResponding = false; // a response is streaming (so barge-in can cancel it)
+  private audioEmitted = false; // upstream has played audio this session — voice can no longer change
 
-  constructor(token: string, model: string, handlers: IRealtimeHandlers) {
+  constructor(token: string, model: string, handlers: IRealtimeHandlers, voice: string = REALTIME_DEFAULT_VOICE) {
     this.token = token;
     this.model = model;
     this.handlers = handlers;
+    this.voice = voice;
   }
 
   get isRunning(): boolean {
@@ -86,6 +89,9 @@ export class RealtimeClient {
         return;
       }
       this.running = true;
+      // Apply the chosen voice before the first response. The relay forwards a
+      // whitelisted `voice` from a client session.update straight to upstream.
+      this.send({ type: 'session.update', session: { voice: this.voice } });
       this.handlers.onStatus?.('connected');
     };
     this.ws.onclose = () => {
@@ -105,6 +111,16 @@ export class RealtimeClient {
   /** Mute/unmute the microphone without tearing down the call. */
   setMuted(muted: boolean): void {
     this.micStream?.getAudioTracks().forEach((t) => (t.enabled = !muted));
+  }
+
+  /**
+   * Switch the assistant voice. Takes effect on the next response; upstream
+   * rejects a change once it has already emitted audio this session — that
+   * error is swallowed (the next fresh call still uses the new voice).
+   */
+  setVoice(voice: string): void {
+    this.voice = voice;
+    this.send({ type: 'session.update', session: { voice } });
   }
 
   private startLevelLoop(): void {
@@ -184,7 +200,26 @@ export class RealtimeClient {
         break;
       case 'error': {
         const err = evt.error || {};
-        this.handlers.onError?.(err.message || 'realtime error');
+        // Barge-in race: we fire `response.cancel` on speech-start, but the
+        // response may have just finished — upstream then replies "Cancellation
+        // failed: no active response found". It's harmless; never surface it.
+        const code = String(err.code || '');
+        const message = String(err.message || '');
+        // Don't touch `aiResponding` here: `response.done` owns that flag, and a
+        // late cancel-error can arrive after the NEXT response.created — clearing
+        // it then would silently disable barge-in for that new turn. Match the
+        // specific benign message, not any "cancellation failed", so genuine
+        // cancel/protocol failures still surface.
+        if (code === 'response_cancel_not_active' || /no active response/i.test(message)) {
+          break;
+        }
+        // Mid-call voice switch: upstream rejects a voice change ONLY after it
+        // has already emitted audio this session — swallow that. Before any
+        // audio (e.g. an invalid initial voice) the error must still surface.
+        if (this.audioEmitted && /voice/i.test(message)) {
+          break;
+        }
+        this.handlers.onError?.(message || 'realtime error');
         break;
       }
       default:
@@ -197,6 +232,7 @@ export class RealtimeClient {
     const buf = arrayBufferFromB64(b64);
     const i16 = new Int16Array(buf);
     if (i16.length === 0) return;
+    this.audioEmitted = true;
     const f32 = new Float32Array(i16.length);
     for (let i = 0; i < i16.length; i++) f32[i] = i16[i] / 0x8000;
 


### PR DESCRIPTION
Four bugs reported on the Realtime voice-call screen (studio.acedata.cloud in mobile Safari).

## 1. Orb rendered with square corners (Safari)
The audio-reactive orb showed sharp top-left / bottom-right corners. Cause: the `c1`/`c2` glow clouds use `mix-blend-mode: screen`, and WebKit drops `overflow:hidden`+`border-radius` clipping for blended children on a composited (`transform`/`will-change`) layer, so they leaked past the circle. Fixed with `clip-path: circle(50%)` + `isolation: isolate` on `.orb`, and moved the outer glow to a `drop-shadow` on the unclipped `.orb-breathe` wrapper so the halo isn't lost.

## 2. "Cancellation failed: no active response found" stuck on screen
Barge-in fires `response.cancel` on speech-start; if the response *just* finished, upstream replies with that benign error, which was forwarded to the UI and never cleared. Now the client swallows that specific error (matched on `no active response`, not any cancel failure), and the component clears `errorMsg` at the start of each new turn. (`response.done` still owns the `aiResponding` flag — the handler no longer touches it, so a late cancel-error can't disable barge-in for the next turn.)

## 3. Wallet kept auto-switching to a 0-balance application
The realtime route's wallet shows `realtime.application`. `realtime/init` blind-picked `applications[0]` (a service-scoped individual app, ignoring the global 通用余额), racing the layout's global-preferred selection — so it flipped to a 0-credit app, then reverted to 通用余额 when a dialog closed. Now `init` loads global + individual apps and selects via `getFinalApplication(combined, current)` — the exact global-preferred logic `Main.vue` (and chat) already use.

## 4. Could not select a voice (音色)
Added a voice picker (top bar). It sends `session.update { voice }`; the relay already whitelists `voice` in its client session.update sanitizer, so no backend change is needed. Choice is persisted in `localStorage`; default mirrors the relay default (`alloy`).

## 🤖 对抗评审
Reviewer: **Codex** (`codex exec --sandbox read-only`) on the diff. 3 RISKs raised:

- **RISK — cancel-error swallow too broad** (`realtimeClient.ts`). `/cancellation failed/i` would hide other cancel/protocol failures. **Fixed:** match `response_cancel_not_active` / `no active response` only.
- **RISK — voice-error swallow too broad** (`realtimeClient.ts`). Could hide an *initial* invalid-voice error. **Fixed:** gated on a new `audioEmitted` flag — only the legit mid-call "can't change after audio" case is swallowed; initial voice errors surface.
- **RISK — `init` preserves the current app even if exhausted** (`store/realtime/actions.ts`). **Rebutted:** that's the deliberate, app-wide `getFinalApplication` contract (respect an explicit prior selection so the wallet choice sticks — its docstring cites the "selection doesn't stick after refresh" fix). On a fresh load realtime state is empty, so `init` auto-picks the usable global; forcing `undefined` would re-break stickiness and diverge from `Main.vue`.

Also caught in review: an earlier version set `aiResponding = false` in the cancel-error handler, which could disable barge-in if the error landed after the next `response.created` — removed.

## Verification
- `eslint` clean, `vue-tsc --noEmit` clean, `vite build` clean.
- Orb appearance and the voice picker should be eyeballed once deployed to studio.acedata.cloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)