### PR TITLE
fix(realtime): voice via WS connect param; move picker off wallet; safe reconnect

### DIFF
--- a/change/@acedatacloud-nexior-e864d007-6872-4884-a2b6-029ac0dfdcd2.json
+++ b/change/@acedatacloud-nexior-e864d007-6872-4884-a2b6-029ac0dfdcd2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(realtime): voice via WS connect param; move picker off wallet; safe reconnect",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/pages/chat/RealtimeCall.vue
+++ b/src/pages/chat/RealtimeCall.vue
@@ -2,10 +2,12 @@
   <div class="rtc" :class="{ 'is-captions': captionsOn, 'is-live': running }">
     <!-- top bar: minimal utility icons (mirrors the ChatGPT voice screen) -->
     <header class="rtc-top">
-      <button class="ic" :title="$t('realtime.title')" @click="goBack">
-        <font-awesome-icon icon="fa-solid fa-chevron-down" />
-      </button>
-      <div class="rtc-top-right">
+      <!-- left group: back + voice picker (kept LEFT so it never sits under the
+           right-pinned floating wallet pill, which would otherwise block taps) -->
+      <div class="rtc-top-left">
+        <button class="ic" :title="$t('realtime.title')" @click="goBack">
+          <font-awesome-icon icon="fa-solid fa-chevron-down" />
+        </button>
         <div class="voice-pick">
           <button class="voice-chip" :class="{ on: voiceMenuOpen }" @click.stop="voiceMenuOpen = !voiceMenuOpen">
             <span class="voice-name">{{ voiceLabel }}</span>
@@ -17,6 +19,8 @@
             </li>
           </ul>
         </div>
+      </div>
+      <div class="rtc-top-right">
         <button class="ic" :class="{ on: showInfo }" :title="$t('realtime.title')" @click="showInfo = !showInfo">
           <font-awesome-icon icon="fa-solid fa-circle-info" />
         </button>
@@ -106,7 +110,10 @@ export default defineComponent({
       showInfo: false,
       voice: REALTIME_DEFAULT_VOICE as string,
       voices: [...REALTIME_VOICES] as string[],
-      voiceMenuOpen: false
+      voiceMenuOpen: false,
+      // Bumped on every (re)connect; handlers of a superseded client compare
+      // against it and no-op, so a stale teardown can't clobber the new call.
+      callSeq: 0
     };
   },
   computed: {
@@ -170,54 +177,65 @@ export default defineComponent({
   methods: {
     async startCall() {
       if (!this.token || this.connecting || this.running) return;
+      const seq = ++this.callSeq;
+      const live = () => seq === this.callSeq; // false once superseded by a reconnect
       this.errorMsg = '';
       this.userText = '';
       this.aiText = '';
       this.connecting = true;
-      this.client = new RealtimeClient(
+      // Hold a LOCAL ref: after the `await` below, `this.client` may already be a
+      // newer client (reconnect during async startup), so the continuation must
+      // act on `client`, never `this.client`.
+      const client = new RealtimeClient(
         this.token,
         REALTIME_DEFAULT_MODEL,
         {
           onStatus: (s: RealtimeStatus) => {
+            if (!live()) return;
             this.status = s;
             this.running = s === 'connecting' || s === 'connected';
             if (s === 'connected' || s === 'disconnected' || s === 'error') this.connecting = false;
             if (!this.running) this.level = 0;
           },
           onUserSpeechStarted: () => {
+            if (!live()) return;
             this.aiSpeaking = false;
             // Any prior transient error is stale once a new turn begins.
             this.errorMsg = '';
           },
           onUserTranscript: (t: string) => {
-            this.userText = t;
+            if (live()) this.userText = t;
           },
           onAiResponseStart: () => {
+            if (!live()) return;
             this.aiText = '';
             this.aiSpeaking = true;
             this.errorMsg = '';
           },
           onAiTranscriptDelta: (d: string) => {
-            this.aiText += d;
+            if (live()) this.aiText += d;
           },
           onAudioLevel: (lvl: number) => {
-            this.level = lvl;
+            if (live()) this.level = lvl;
           },
           onError: (m: string) => {
-            this.errorMsg = m;
+            if (live()) this.errorMsg = m;
           }
         },
         this.voice
       );
+      this.client = client;
       // a fresh call should honour the current mute state
       try {
-        await this.client.start();
-        this.client.setMuted(this.muted);
+        await client.start();
+        if (!live() || this.client !== client) return; // superseded mid-startup
+        client.setMuted(this.muted);
       } catch (e: any) {
+        client.stop();
+        if (!live() || this.client !== client) return; // don't clobber a newer call
         this.connecting = false;
         this.running = false;
         this.errorMsg = e?.message || this.$t('realtime.startFailed');
-        this.client?.stop();
       }
     },
     toggleMute() {
@@ -239,8 +257,24 @@ export default defineComponent({
       } catch {
         // ignore persistence failure
       }
-      // Apply live if a call is running; otherwise it's used on the next start.
-      this.client?.setVoice(v);
+      // Voice is fixed at connect (relay injects it). Reconnect to switch it live;
+      // otherwise it just applies the next time a call starts.
+      if (this.running || this.connecting) this.reconnect();
+    },
+    reconnect() {
+      const old = this.client;
+      this.client = undefined;
+      // Invalidate the old client's handlers before its teardown fires.
+      this.callSeq++;
+      this.running = false;
+      this.connecting = false;
+      this.aiSpeaking = false;
+      this.level = 0;
+      this.userText = '';
+      this.aiText = '';
+      this.errorMsg = '';
+      old?.stop();
+      this.$nextTick(() => this.startCall());
     },
     onOrbTap() {
       if (!this.running && !this.connecting) this.startCall();
@@ -295,6 +329,11 @@ export default defineComponent({
   justify-content: space-between;
   padding: 14px 16px;
   z-index: 2;
+}
+.rtc-top-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 .rtc-top-right {
   display: flex;
@@ -358,7 +397,7 @@ export default defineComponent({
 .voice-menu {
   position: absolute;
   top: calc(100% + 6px);
-  right: 0;
+  left: 0;
   z-index: 10;
   min-width: 132px;
   max-height: 240px;

--- a/src/utils/realtimeClient.ts
+++ b/src/utils/realtimeClient.ts
@@ -40,7 +40,6 @@ export class RealtimeClient {
   private disposed = false; // set by stop(); aborts an in-flight start()
   private suppressAudio = false; // drop in-flight deltas after a barge-in
   private aiResponding = false; // a response is streaming (so barge-in can cancel it)
-  private audioEmitted = false; // upstream has played audio this session — voice can no longer change
 
   constructor(token: string, model: string, handlers: IRealtimeHandlers, voice: string = REALTIME_DEFAULT_VOICE) {
     this.token = token;
@@ -80,7 +79,11 @@ export class RealtimeClient {
     sink.gain.value = 0;
     this.workletNode.connect(sink).connect(this.audioCtx.destination);
 
-    const url = `${WS_URL_REALTIME}?model=${encodeURIComponent(this.model)}`;
+    // Voice is a connect-time param: the relay injects it into its initial
+    // (GA-valid) session.update. A client session.update can't set it — the relay
+    // sanitizer drops the required session.type and GA nests voice under audio.output.
+    const url =
+      `${WS_URL_REALTIME}?model=${encodeURIComponent(this.model)}` + `&voice=${encodeURIComponent(this.voice)}`;
     this.ws = new WebSocket(url, ['realtime', `acedata-token.${this.token}`]);
 
     this.ws.onopen = () => {
@@ -89,9 +92,6 @@ export class RealtimeClient {
         return;
       }
       this.running = true;
-      // Apply the chosen voice before the first response. The relay forwards a
-      // whitelisted `voice` from a client session.update straight to upstream.
-      this.send({ type: 'session.update', session: { voice: this.voice } });
       this.handlers.onStatus?.('connected');
     };
     this.ws.onclose = () => {
@@ -111,16 +111,6 @@ export class RealtimeClient {
   /** Mute/unmute the microphone without tearing down the call. */
   setMuted(muted: boolean): void {
     this.micStream?.getAudioTracks().forEach((t) => (t.enabled = !muted));
-  }
-
-  /**
-   * Switch the assistant voice. Takes effect on the next response; upstream
-   * rejects a change once it has already emitted audio this session — that
-   * error is swallowed (the next fresh call still uses the new voice).
-   */
-  setVoice(voice: string): void {
-    this.voice = voice;
-    this.send({ type: 'session.update', session: { voice } });
   }
 
   private startLevelLoop(): void {
@@ -213,12 +203,6 @@ export class RealtimeClient {
         if (code === 'response_cancel_not_active' || /no active response/i.test(message)) {
           break;
         }
-        // Mid-call voice switch: upstream rejects a voice change ONLY after it
-        // has already emitted audio this session — swallow that. Before any
-        // audio (e.g. an invalid initial voice) the error must still surface.
-        if (this.audioEmitted && /voice/i.test(message)) {
-          break;
-        }
         this.handlers.onError?.(message || 'realtime error');
         break;
       }
@@ -232,7 +216,6 @@ export class RealtimeClient {
     const buf = arrayBufferFromB64(b64);
     const i16 = new Int16Array(buf);
     if (i16.length === 0) return;
-    this.audioEmitted = true;
     const f32 = new Float32Array(i16.length);
     for (let i = 0; i < i16.length; i++) f32[i] = i16[i] / 0x8000;
 


### PR DESCRIPTION
Follow-up to #1014. A **live E2E** of the merged build (on `studio.acedata.cloud/chatgpt/call`) surfaced two real problems the unit/build checks couldn't:

1. **Every call errored "Missing required parameter: 'session.type'."** The voice picker sent a client `session.update { session: { voice } }`, but the relay sanitizer strips `session.type` and GA nests voice under `audio.output` — so the override is invalid and breaks the call.
2. **The voice chip was unclickable** — it sat under the right-pinned floating wallet pill (`3,495 Credits`), which intercepted taps.

(The orb renders fine in Chromium; its square-corner bug is Safari-only.)

## Fix
- **`realtimeClient.ts`** — pass the voice as a `&voice=` **WS query param** (paired relay PR has the relay inject it into its initial, GA-valid `session.update`). Stop sending any client `session.update`. Removed the now-dead `setVoice` / `audioEmitted` / voice-error-swallow.
- **`RealtimeCall.vue`** — moved the voice picker to the **left** of the top bar (next to the back button), clear of the wallet. Menu now opens left-aligned.
- **Mid-call voice change** → `reconnect()` with a `callSeq` guard: it invalidates the old client's late teardown callbacks **and** its awaited `start()` continuation (operates on a local `client` ref, never `this.client`) so a stale teardown can't `stop()` the new call.

## Pairs with
PlatformService **#1094** (relay reads `?voice=`, validates an allowlist, injects `session.type`). Deploy the relay first — its `session.type` injection alone clears the live regression even before this lands.

## 🤖 对抗评审
Codex reviewed the cross-repo diff. Fixed: (1) **the `startCall()` promise continuation wasn't guarded** — a superseded call could `stop()` the new client → now uses a local `client` ref + post-`await` `live()`/identity guard; (2) `turn_detection` whitelist shape [fixed in the relay PR]. No outstanding RISKs.

## Verification
`eslint` / `vue-tsc` / `vite build` clean. Will re-verify on the live site (voice switch applies, no error banner, picker clickable) once both deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)