### PR TITLE
ci(desktop): graceful unsigned beta + notarize via App Store Connect API key

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -124,39 +124,64 @@ jobs:
         env:
           ELECTRON_BUILDER_CHANNEL: ${{ needs.setup.outputs.channel }}
           VITE_STRIPE_PUBLISHABLE_KEY: ${{ secrets.VITE_STRIPE_PUBLISHABLE_KEY }}
-          # Windows signing
+          # Windows signing (optional — unsigned build if absent)
           WIN_CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
           WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
-          # macOS signing + notarization
+          # macOS signing (Developer ID Application .p12 — optional)
           MAC_CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
           MAC_CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          # macOS notarization via the App Store Connect API key (reuses the
+          # secrets the iOS pipeline already has — no Apple-ID password needed).
+          APP_STORE_CONNECT_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_KEY_BASE64 }}
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          APPLE_TEAM_ID: ${{ secrets.IOS_TEAM_ID }}
         run: |
           set -euo pipefail
-          # Map per-OS signing secrets onto the env vars electron-builder reads.
+          EXTRA=()
+          SIGN=false
+
           if [ "${{ runner.os }}" = "Windows" ]; then
-            export CSC_LINK="$WIN_CSC_LINK"
-            export CSC_KEY_PASSWORD="$WIN_CSC_KEY_PASSWORD"
+            if [ -n "$WIN_CSC_LINK" ]; then
+              export CSC_LINK="$WIN_CSC_LINK" CSC_KEY_PASSWORD="$WIN_CSC_KEY_PASSWORD"
+              SIGN=true
+            fi
           else
-            export CSC_LINK="$MAC_CSC_LINK"
-            export CSC_KEY_PASSWORD="$MAC_CSC_KEY_PASSWORD"
-            # Fail loudly if notarization creds are incomplete — otherwise
-            # electron-builder signs but SILENTLY skips notarization and
-            # Gatekeeper blocks the app on user machines.
-            if [ -z "$APPLE_ID" ] || [ -z "$APPLE_APP_SPECIFIC_PASSWORD" ] || [ -z "$APPLE_TEAM_ID" ]; then
-              echo "::error::macOS notarization secrets incomplete (APPLE_ID / APPLE_APP_SPECIFIC_PASSWORD / APPLE_TEAM_ID)"
-              exit 1
+            if [ -n "$MAC_CSC_LINK" ]; then
+              export CSC_LINK="$MAC_CSC_LINK" CSC_KEY_PASSWORD="$MAC_CSC_KEY_PASSWORD"
+              SIGN=true
+              # Notarization needs a signed app. Wire notarytool to the API key.
+              echo "$APP_STORE_CONNECT_KEY_BASE64" | base64 -d > "$RUNNER_TEMP/AuthKey.p8"
+              export APPLE_API_KEY="$RUNNER_TEMP/AuthKey.p8"
+              export APPLE_API_KEY_ID="$APP_STORE_CONNECT_KEY_ID"
+              export APPLE_API_ISSUER="$APP_STORE_CONNECT_ISSUER_ID"
             fi
           fi
+
+          if [ "$SIGN" = false ]; then
+            # No cert: a stable release must NEVER ship unsigned (Windows
+            # SmartScreen / macOS Gatekeeper would block it, and electron-updater
+            # can't apply an unsigned update). Beta builds unsigned so the whole
+            # build → publish → COS path can be exercised before certs land.
+            if [ "$ELECTRON_BUILDER_CHANNEL" = "latest" ]; then
+              echo "::error::refusing to build the 'latest' (stable) channel unsigned — provide signing secrets"
+              exit 1
+            fi
+            echo "::warning::no signing cert for ${{ runner.os }} — building UNSIGNED (beta only; auto-update apply will not be testable)"
+            export CSC_IDENTITY_AUTO_DISCOVERY=false
+            EXTRA+=(--config.mac.notarize=false)
+          fi
+
           npm run build:electron
           npm run compile:electron
           node scripts/copy-renderer.js
-          npx electron-builder --config.channel="$ELECTRON_BUILDER_CHANNEL" --publish never
+          # ${EXTRA[@]+...} guards against "unbound variable" on an empty array
+          # under `set -u` in bash 3.2 (the macOS runner's default bash).
+          npx electron-builder --config.channel="$ELECTRON_BUILDER_CHANNEL" ${EXTRA[@]+"${EXTRA[@]}"} --publish never
+          echo "DESKTOP_SIGNED=$SIGN" >> "$GITHUB_ENV"
 
       - name: Verify macOS notarization (stapled)
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && env.DESKTOP_SIGNED == 'true'
         run: |
           set -euo pipefail
           APP=$(find release/mac* -maxdepth 1 -name '*.app' | head -n1 || true)

--- a/change/@acedatacloud-nexior-5530245f-9815-4640-90ac-0cdcc9233a14.json
+++ b/change/@acedatacloud-nexior-5530245f-9815-4640-90ac-0cdcc9233a14.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "ci(desktop): graceful unsigned beta + notarize via App Store Connect API key",
+  "packageName": "@acedatacloud/nexior",
+  "email": "cqc@cuiqingcai.com",
+  "dependentChangeType": "patch"
+}

--- a/docs/DESKTOP_RELEASE.md
+++ b/docs/DESKTOP_RELEASE.md
@@ -27,22 +27,33 @@ manifest** (artifacts are immutable, never deleted).
    job references this environment, so every publish pauses for a human
    approval before any signed artifact reaches the live feed.
 2. **Secrets** (repo or environment):
-   - `TENCENT_CLOUD_SECRET_ID` / `TENCENT_CLOUD_SECRET_KEY` — COS upload
-   - `VITE_STRIPE_PUBLISHABLE_KEY` — renderer build
-   - `WIN_CSC_LINK` / `WIN_CSC_KEY_PASSWORD` — Windows OV/EV `.pfx` (base64) + password
-   - `MAC_CSC_LINK` / `MAC_CSC_KEY_PASSWORD` — macOS Developer ID `.p12` (base64) + password
-   - `APPLE_ID` / `APPLE_APP_SPECIFIC_PASSWORD` / `APPLE_TEAM_ID` — notarization
+   - `TENCENT_CLOUD_SECRET_ID` / `TENCENT_CLOUD_SECRET_KEY` — COS upload (already set org-wide for the OTA pipeline)
+   - `VITE_STRIPE_PUBLISHABLE_KEY` — renderer build (already set) ✅
+   - **Notarization (macOS)** reuses the iOS pipeline's existing App Store Connect
+     API-key secrets — **nothing new to add**: `APP_STORE_CONNECT_KEY_BASE64`,
+     `APP_STORE_CONNECT_KEY_ID`, `APP_STORE_CONNECT_ISSUER_ID`, `IOS_TEAM_ID`. ✅
+   - **Code-signing certs — the only NEW secrets you must add** (and the only
+     blocker for a *stable* release):
+     - `WIN_CSC_LINK` / `WIN_CSC_KEY_PASSWORD` — Windows OV/EV `.pfx` (base64) + password
+     - `MAC_CSC_LINK` / `MAC_CSC_KEY_PASSWORD` — macOS **Developer ID Application** `.p12` (base64) + password
+       (the existing `IOS_P12` is an iOS *distribution* cert and will **not** work for a Developer ID DMG)
+
+   > **Beta runs without any signing cert.** When `WIN_CSC_LINK` / `MAC_CSC_LINK`
+   > are absent the `beta` channel builds **unsigned** so you can exercise the
+   > whole build → COS-publish path today. The `latest` (stable) channel
+   > **refuses** to build unsigned. Auto-update *apply* can only be validated on
+   > a signed build.
 
 ## Cutting a release
 
-- **Beta:** Actions → **Desktop** → _Run workflow_ → channel `beta`.
-- **Stable:** push a `desktop-v*` tag (e.g. `desktop-v3.282.4`) **or** run the
-  workflow with channel `latest`.
+- **Beta (works today, signed or not):** Actions → **Desktop** → _Run workflow_ → channel `beta`.
+- **Stable (requires the signing certs above):** push a `desktop-v*` tag
+  (e.g. `desktop-v3.282.4`) **or** run the workflow with channel `latest`.
 
 Flow: `e2e` smoke (Linux/xvfb) → wait for **admin approval** → `build` matrix
 (Windows + macOS): `build:electron` → `compile:electron` → `copy-renderer` →
-`electron-builder` (signs; macOS also notarizes + staples, verified by
-`stapler validate`) → upload artifacts → publish to COS.
+`electron-builder` (signs when a cert is present; macOS notarizes via the API
+key + staples, verified by `stapler validate`) → upload artifacts → publish to COS.
 
 `workflow_dispatch` has a `dry_run` toggle (build + sign, skip the COS upload).
 


### PR DESCRIPTION
Makes the desktop pipeline runnable **today** and removes the Apple-ID dependency.

## What
- **Unsigned beta**: when `WIN_CSC_LINK`/`MAC_CSC_LINK` are absent, the `beta` channel builds **unsigned** so the whole `build → COS publish` path can be exercised now, before any cert exists. The `latest` (stable) channel still **refuses** to build unsigned.
- **Notarize via API key**: macOS notarization now uses the App Store Connect API key — the `APP_STORE_CONNECT_KEY_BASE64` / `APP_STORE_CONNECT_KEY_ID` / `APP_STORE_CONNECT_ISSUER_ID` / `IOS_TEAM_ID` secrets the iOS pipeline **already has** — instead of `APPLE_ID` + app-specific password. No new Apple secret to add.
- The **only new secrets** for a stable release are the two signing certs (`WIN_CSC_LINK`, `MAC_CSC_LINK` = a Developer ID Application `.p12`; the existing iOS `.p12` won't work for a Developer ID DMG).
- bash 3.2-safe empty-array expansion (macOS runner default bash) + doc update.

## Verification
- YAML validated. Logic is shell-level; the signed path runs in CI once certs are added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)