### PR TITLE
fix(desktop): build:electron applies VITE_SURFACE=desktop to vite build

### DIFF
--- a/change/@acedatacloud-nexior-23376bf1-42cb-4ff3-b754-1d281ea7b34f.json
+++ b/change/@acedatacloud-nexior-23376bf1-42cb-4ff3-b754-1d281ea7b34f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(desktop): build:electron applies VITE_SURFACE=desktop to vite build",
+  "packageName": "@acedatacloud/nexior",
+  "email": "cqc@cuiqingcai.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:ios": "cross-env VITE_SURFACE=ios vite build",
     "pack:android": "npm run build:android && npx cap copy android",
     "pack:ios": "npm run build:ios && npx cap copy ios",
-    "build:electron": "cross-env VITE_SURFACE=desktop vue-tsc -b && vite build",
+    "build:electron": "cross-env VITE_SURFACE=desktop vue-tsc -b && cross-env VITE_SURFACE=desktop vite build",
     "compile:electron": "tsc -p electron/tsconfig.json",
     "pack:electron": "npm run build:electron && npm run compile:electron && node scripts/copy-renderer.js && electron-builder",
     "start:electron": "npm run compile:electron && node scripts/copy-renderer.js && electron electron/dist/main.js",


### PR DESCRIPTION
**Bug caught by the first CI beta dry-run.** `build:electron` was
`cross-env VITE_SURFACE=desktop vue-tsc -b && vite build` — `cross-env` only scopes the env to `vue-tsc`; the `&&` ends its command, so **`vite build` ran without `VITE_SURFACE`**. Consequences: output went to `dist/` instead of `dist-electron/` (so `copy-renderer` failed), and worse, the bundle was built in **web mode** (`import.meta.env.VITE_SURFACE` undefined → `getSurface()==='web'`) — the entire desktop surface would have been inert.

Fix: apply `cross-env VITE_SURFACE=desktop` to **both** commands.

Verified locally: `vite build` now emits `dist-electron/` and the bundle contains the desktop surface markers (`acedata-desktop`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)