### PR TITLE
feat(desktop): distinguish Windows vs macOS at runtime

### DIFF
--- a/change/@acedatacloud-nexior-5573817d-87f9-4479-b286-1ab0be71e8e2.json
+++ b/change/@acedatacloud-nexior-5573817d-87f9-4479-b286-1ab0be71e8e2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(desktop): distinguish Windows vs macOS at runtime (isWindows/isMacOS, per-OS version gate)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "cqc@cuiqingcai.com",
+  "dependentChangeType": "patch"
+}

--- a/src/utils/surface.test.ts
+++ b/src/utils/surface.test.ts
@@ -1,6 +1,17 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { getSurface, isWeb, isIOS, isAndroid, isDesktop, isNative, getPaymentSurface } from './surface';
+import {
+  getSurface,
+  isWeb,
+  isIOS,
+  isAndroid,
+  isDesktop,
+  isNative,
+  getPaymentSurface,
+  getDesktopOS,
+  isWindows,
+  isMacOS
+} from './surface';
 
 /**
  * Surface resolution must keep `isNative()` meaning "Capacitor mobile" while
@@ -65,6 +76,33 @@ describe('surface', () => {
       expect(isWeb()).toBe(true);
       expect(isNative()).toBe(false);
       expect(isDesktop()).toBe(false);
+    });
+  });
+
+  describe('getDesktopOS (runtime, via window.desktop bridge)', () => {
+    afterEach(() => {
+      delete (window as unknown as { desktop?: unknown }).desktop;
+    });
+    const setPlatform = (platform?: string) => {
+      (window as unknown as { desktop?: { platform?: string } }).desktop = platform ? { platform } : undefined;
+    };
+
+    it('maps win32 → windows and darwin → mac', () => {
+      setPlatform('win32');
+      expect(getDesktopOS()).toBe('windows');
+      expect(isWindows()).toBe(true);
+      expect(isMacOS()).toBe(false);
+      setPlatform('darwin');
+      expect(getDesktopOS()).toBe('mac');
+      expect(isMacOS()).toBe(true);
+      expect(isWindows()).toBe(false);
+    });
+
+    it('is undefined off-desktop (no bridge)', () => {
+      setPlatform(undefined);
+      expect(getDesktopOS()).toBeUndefined();
+      expect(isWindows()).toBe(false);
+      expect(isMacOS()).toBe(false);
     });
   });
 

--- a/src/utils/surface.ts
+++ b/src/utils/surface.ts
@@ -24,6 +24,29 @@ export function isDesktop(): boolean {
   return getSurface() === SURFACE_DESKTOP;
 }
 
+/**
+ * The desktop OS, distinguished at RUNTIME via the Electron preload bridge
+ * (`window.desktop.platform` = process.platform). The renderer bundle is
+ * identical for Windows and macOS — they share one `VITE_SURFACE=desktop`
+ * build — so the OS is a runtime property, not a build surface. Used for the
+ * per-OS version gate, download links, and update feed selection.
+ * Returns undefined off-desktop (web/native).
+ */
+export function getDesktopOS(): 'windows' | 'mac' | undefined {
+  const platform = typeof window !== 'undefined' ? window.desktop?.platform : undefined;
+  if (platform === 'win32') return 'windows';
+  if (platform === 'darwin') return 'mac';
+  return undefined;
+}
+
+export function isWindows(): boolean {
+  return getDesktopOS() === 'windows';
+}
+
+export function isMacOS(): boolean {
+  return getDesktopOS() === 'mac';
+}
+
 // UNCHANGED MEANING: native === "Capacitor mobile shell" (iOS or Android).
 // Desktop is deliberately NOT native — it must not hit IAP/push/Capacitor-OTA.
 export function isNative(): boolean {

--- a/src/utils/versionGate.ts
+++ b/src/utils/versionGate.ts
@@ -2,7 +2,7 @@ import { App as CapApp } from '@capacitor/app';
 import { Browser } from '@capacitor/browser';
 import { ElMessageBox } from 'element-plus';
 import { appVersionOperator } from '@/operators/appVersion';
-import { isAndroid, isIOS, isNative, isDesktop } from '@/utils/surface';
+import { isAndroid, isIOS, isNative, isDesktop, getDesktopOS } from '@/utils/surface';
 import { desktopBridge } from '@/utils/desktop';
 import { t, setI18nLanguage, getLocale } from '@/i18n';
 // `__APP_VERSION__` is declared globally in shims.d.ts (vite `define`).
@@ -148,9 +148,13 @@ async function runDesktopVersionGate(): Promise<boolean> {
     return false;
   }
 
+  // Gate per OS so Windows and macOS can be force-upgraded independently
+  // (their installers + update feeds are separate). Falls back to 'desktop'
+  // if the OS can't be resolved (bridge missing).
+  const platform = getDesktopOS() ?? 'desktop';
   let meta;
   try {
-    const { data } = await appVersionOperator.get('nexior', 'desktop');
+    const { data } = await appVersionOperator.get('nexior', platform);
     meta = data;
   } catch (err) {
     console.warn('[versionGate] desktop fetch failed, skipping', err);


### PR DESCRIPTION
Per your note that the desktop surface should distinguish Windows vs macOS.

The renderer bundle is **identical** for both OSes (one `VITE_SURFACE=desktop` build — building it twice would be pure waste), so the OS is a **runtime** property, exposed via the Electron preload bridge (`window.desktop.platform`):

- `surface.ts`: `getDesktopOS()` → `'windows' | 'mac' | undefined`, plus `isWindows()` / `isMacOS()`.
- `versionGate.ts`: queries the per-OS platform (`windows`/`mac`) so Windows and macOS can be force-upgraded independently — their installers and auto-update feeds (`latest.yml` vs `latest-mac.yml`) are already separate. Falls back to `desktop`.
- Backend support: AceDataCloud/PlatformBackend#732 (per-OS `APP_VERSIONS`).
- Tests for the `win32→windows` / `darwin→mac` mapping. **vitest 11/11.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)