### PR TITLE
fix(ci): override publish.channel for electron-builder (not root channel)

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -194,9 +194,10 @@ jobs:
           npm run build:electron
           npm run compile:electron
           node scripts/copy-renderer.js
-          # ${EXTRA[@]+...} guards against unbound-variable on an empty array
-          # under `set -u` in bash 3.2 (the macOS runner's default bash).
-          npx electron-builder --config.channel="$ELECTRON_BUILDER_CHANNEL" ${EXTRA[@]+"${EXTRA[@]}"} --publish never
+          # `channel` lives under `publish`, not at the config root — override
+          # the nested key. ${EXTRA[@]+...} guards against unbound-variable on an
+          # empty array under `set -u` in bash 3.2 (the macOS runner's bash).
+          npx electron-builder --config.publish.channel="$ELECTRON_BUILDER_CHANNEL" ${EXTRA[@]+"${EXTRA[@]}"} --publish never
           echo "DESKTOP_SIGNED=$SIGN" >> "$GITHUB_ENV"
 
       - name: Verify macOS notarization (stapled)

--- a/change/@acedatacloud-nexior-f1a7793d-d813-4a31-aca1-105dfd6de0b8.json
+++ b/change/@acedatacloud-nexior-f1a7793d-d813-4a31-aca1-105dfd6de0b8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(ci): override publish.channel for electron-builder",
+  "packageName": "@acedatacloud/nexior",
+  "email": "cqc@cuiqingcai.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
Auto-build matrix caught it: electron-builder 26 rejects `channel` at config root — it lives under `publish`. Build steps all succeeded; only the CLI override was misplaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)