### PR TITLE
feat(chat): show enabled connector icons above the composer input

### DIFF
--- a/change/@acedatacloud-nexior-bab81b81-ff31-4818-bd11-e9e84a11b84b.json
+++ b/change/@acedatacloud-nexior-bab81b81-ff31-4818-bd11-e9e84a11b84b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "show enabled connector icons above the chat composer input",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/Composer.vue
+++ b/src/components/chat/Composer.vue
@@ -22,6 +22,22 @@
     >
       <span ref="uploadTrigger" class="upload-trigger" aria-hidden="true"></span>
     </el-upload>
+    <!-- Enabled connectors: a compact icon strip at the top of the composer.
+         Display-first — clicking any chip (or the +N overflow) opens the
+         canonical connections manager. Hidden entirely when the user has no
+         active connections. -->
+    <div v-if="visibleConnectors.length > 0" class="connector-strip">
+      <el-tooltip v-for="c in visibleConnectors" :key="c.id" effect="dark" :content="c.name" placement="top">
+        <span class="connector-chip" role="button" @click="onOpenConnections">
+          <img class="connector-icon" :src="c.icon_url" :alt="c.name" loading="lazy" />
+        </span>
+      </el-tooltip>
+      <el-tooltip v-if="overflowCount > 0" effect="dark" :content="$t('chat.composer.connections')" placement="top">
+        <span class="connector-chip connector-more" role="button" @click="onOpenConnections">
+          +{{ overflowCount }}
+        </span>
+      </el-tooltip>
+    </div>
     <div v-if="fileList.length > 0" class="file-previews">
       <template v-for="file in fileList" :key="file.uid">
         <image-preview
@@ -145,6 +161,11 @@ import {
 import FilePreview from '@/components/common/FilePreview.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 import { ROUTE_CHATGPT_CALL } from '@/router/constants';
+import { listEnabledConnectors, type IEnabledConnector } from './connectorCatalogCache';
+
+// Max connector chips shown in the strip. Beyond this, the last slot
+// becomes a "+N" overflow chip so the row never exceeds MAX_CONNECTORS items.
+const MAX_CONNECTORS = 8;
 
 export default defineComponent({
   name: 'Composer',
@@ -187,10 +208,28 @@ export default defineComponent({
       inputHeight: '35px',
       questionValue: this.question || '',
       fileList: [] as UploadFile[],
-      uploadUrl: getBaseUrlPlatform() + '/api/v1/files/'
+      uploadUrl: getBaseUrlPlatform() + '/api/v1/files/',
+      enabledConnectors: [] as IEnabledConnector[]
     };
   },
   computed: {
+    // Connectors actually drawn as icons. When the user has more than
+    // MAX_CONNECTORS, reserve the final slot for the "+N" overflow chip.
+    visibleConnectors(): IEnabledConnector[] {
+      if (this.enabledConnectors.length <= MAX_CONNECTORS) {
+        return this.enabledConnectors;
+      }
+      return this.enabledConnectors.slice(0, MAX_CONNECTORS - 1);
+    },
+    overflowCount(): number {
+      if (this.enabledConnectors.length <= MAX_CONNECTORS) {
+        return 0;
+      }
+      return this.enabledConnectors.length - (MAX_CONNECTORS - 1);
+    },
+    userId(): string | null {
+      return this.$store.getters.user?.id ?? null;
+    },
     model(): IChatModel {
       return this.$store.state.chat.model;
     },
@@ -266,10 +305,43 @@ export default defineComponent({
       if (oldVal && !val) {
         this.fileList = [];
       }
+    },
+    // Login / logout / account switch — clear the previous account's icons
+    // immediately (so they never linger during the new fetch), then reload.
+    userId() {
+      this.enabledConnectors = [];
+      void this.loadConnectors(true);
     }
+  },
+  mounted() {
+    void this.loadConnectors();
+    // The user manages connections in another tab (auth.acedata.cloud);
+    // refetch when they return so connects/disconnects reflect without a
+    // full reload.
+    document.addEventListener('visibilitychange', this.onVisibilityChange);
+  },
+  beforeUnmount() {
+    document.removeEventListener('visibilitychange', this.onVisibilityChange);
   },
   methods: {
     isImageUrl,
+    async loadConnectors(force = false) {
+      // listEnabledConnectors() never throws (returns [] on error / when
+      // logged out) so the strip just stays hidden rather than breaking.
+      const requestedUserId = this.userId;
+      const list = await listEnabledConnectors(requestedUserId, force);
+      // Drop a stale resolution: if the user switched (or logged out) while
+      // this fetch was in flight, its result belongs to the previous account
+      // and must not be written into component state.
+      if (this.userId === requestedUserId) {
+        this.enabledConnectors = list;
+      }
+    },
+    onVisibilityChange() {
+      if (document.visibilityState === 'visible') {
+        void this.loadConnectors(true);
+      }
+    },
     onStartCall() {
       this.$router.push({ name: ROUTE_CHATGPT_CALL });
     },
@@ -434,6 +506,44 @@ textarea.input:focus {
     display: block;
     width: 0;
     height: 0;
+  }
+  .connector-strip {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 8px 0;
+    .connector-chip {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 26px;
+      height: 26px;
+      border-radius: 50%;
+      overflow: hidden;
+      cursor: pointer;
+      background-color: var(--el-fill-color-light);
+      border: 1px solid var(--el-border-color-lighter);
+      transition:
+        transform 0.12s ease,
+        box-shadow 0.12s ease;
+      &:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+      }
+      .connector-icon {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        display: block;
+      }
+      &.connector-more {
+        font-size: 11px;
+        font-weight: 600;
+        color: var(--el-text-color-secondary);
+        background-color: var(--el-fill-color);
+      }
+    }
   }
   .file-previews {
     display: flex;

--- a/src/components/chat/Composer.vue
+++ b/src/components/chat/Composer.vue
@@ -1,4 +1,18 @@
 <template>
+  <!-- Enabled connectors: a compact icon strip ABOVE the composer card
+       (a sibling root, aligned to the same centered column). Display-first —
+       clicking any chip (or the +N overflow) opens the connections manager.
+       Hidden when the user has no active connections. -->
+  <div v-if="visibleConnectors.length > 0" class="connector-strip">
+    <el-tooltip v-for="c in visibleConnectors" :key="c.id" effect="dark" :content="c.name" placement="top">
+      <span class="connector-chip" role="button" @click="onOpenConnections">
+        <img class="connector-icon" :src="c.icon_url" :alt="c.name" loading="lazy" />
+      </span>
+    </el-tooltip>
+    <el-tooltip v-if="overflowCount > 0" effect="dark" :content="$t('chat.composer.connections')" placement="top">
+      <span class="connector-chip connector-more" role="button" @click="onOpenConnections"> +{{ overflowCount }} </span>
+    </el-tooltip>
+  </div>
   <div class="composer">
     <!-- Hidden el-upload: only used for its file-picker + upload pipeline.
          The file list is rendered separately above the textarea (see
@@ -22,22 +36,6 @@
     >
       <span ref="uploadTrigger" class="upload-trigger" aria-hidden="true"></span>
     </el-upload>
-    <!-- Enabled connectors: a compact icon strip at the top of the composer.
-         Display-first — clicking any chip (or the +N overflow) opens the
-         canonical connections manager. Hidden entirely when the user has no
-         active connections. -->
-    <div v-if="visibleConnectors.length > 0" class="connector-strip">
-      <el-tooltip v-for="c in visibleConnectors" :key="c.id" effect="dark" :content="c.name" placement="top">
-        <span class="connector-chip" role="button" @click="onOpenConnections">
-          <img class="connector-icon" :src="c.icon_url" :alt="c.name" loading="lazy" />
-        </span>
-      </el-tooltip>
-      <el-tooltip v-if="overflowCount > 0" effect="dark" :content="$t('chat.composer.connections')" placement="top">
-        <span class="connector-chip connector-more" role="button" @click="onOpenConnections">
-          +{{ overflowCount }}
-        </span>
-      </el-tooltip>
-    </div>
     <div v-if="fileList.length > 0" class="file-previews">
       <template v-for="file in fileList" :key="file.uid">
         <image-preview
@@ -467,6 +465,50 @@ textarea.input:focus {
 </style>
 
 <style lang="scss" scoped>
+// Sits ABOVE the composer card, aligned to the same centered column.
+// Small, refined app-style icons — a quiet "what's connected" affordance.
+.connector-strip {
+  width: 100%;
+  max-width: 800px;
+  margin: 0 auto 8px;
+  padding-left: 6px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 5px;
+  .connector-chip {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    overflow: hidden;
+    cursor: pointer;
+    background-color: var(--el-fill-color-light);
+    border: 1px solid var(--el-border-color-lighter);
+    transition:
+      transform 0.12s ease,
+      box-shadow 0.12s ease;
+    &:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.14);
+    }
+    .connector-icon {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    }
+    &.connector-more {
+      font-size: 9px;
+      font-weight: 600;
+      letter-spacing: -0.3px;
+      color: var(--el-text-color-secondary);
+      background-color: var(--el-fill-color);
+    }
+  }
+}
 .composer {
   width: 100%;
   max-width: 800px;
@@ -506,44 +548,6 @@ textarea.input:focus {
     display: block;
     width: 0;
     height: 0;
-  }
-  .connector-strip {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    gap: 6px;
-    padding: 6px 8px 0;
-    .connector-chip {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      width: 26px;
-      height: 26px;
-      border-radius: 50%;
-      overflow: hidden;
-      cursor: pointer;
-      background-color: var(--el-fill-color-light);
-      border: 1px solid var(--el-border-color-lighter);
-      transition:
-        transform 0.12s ease,
-        box-shadow 0.12s ease;
-      &:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
-      }
-      .connector-icon {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-        display: block;
-      }
-      &.connector-more {
-        font-size: 11px;
-        font-weight: 600;
-        color: var(--el-text-color-secondary);
-        background-color: var(--el-fill-color);
-      }
-    }
   }
   .file-previews {
     display: flex;

--- a/src/components/chat/Composer.vue
+++ b/src/components/chat/Composer.vue
@@ -1,18 +1,4 @@
 <template>
-  <!-- Enabled connectors: a compact icon strip ABOVE the composer card
-       (a sibling root, aligned to the same centered column). Display-first —
-       clicking any chip (or the +N overflow) opens the connections manager.
-       Hidden when the user has no active connections. -->
-  <div v-if="visibleConnectors.length > 0" class="connector-strip">
-    <el-tooltip v-for="c in visibleConnectors" :key="c.id" effect="dark" :content="c.name" placement="top">
-      <span class="connector-chip" role="button" @click="onOpenConnections">
-        <img class="connector-icon" :src="c.icon_url" :alt="c.name" loading="lazy" />
-      </span>
-    </el-tooltip>
-    <el-tooltip v-if="overflowCount > 0" effect="dark" :content="$t('chat.composer.connections')" placement="top">
-      <span class="connector-chip connector-more" role="button" @click="onOpenConnections"> +{{ overflowCount }} </span>
-    </el-tooltip>
-  </div>
   <div class="composer">
     <!-- Hidden el-upload: only used for its file-picker + upload pipeline.
          The file list is rendered separately above the textarea (see
@@ -159,11 +145,6 @@ import {
 import FilePreview from '@/components/common/FilePreview.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 import { ROUTE_CHATGPT_CALL } from '@/router/constants';
-import { listEnabledConnectors, type IEnabledConnector } from './connectorCatalogCache';
-
-// Max connector chips shown in the strip. Beyond this, the last slot
-// becomes a "+N" overflow chip so the row never exceeds MAX_CONNECTORS items.
-const MAX_CONNECTORS = 8;
 
 export default defineComponent({
   name: 'Composer',
@@ -206,28 +187,10 @@ export default defineComponent({
       inputHeight: '35px',
       questionValue: this.question || '',
       fileList: [] as UploadFile[],
-      uploadUrl: getBaseUrlPlatform() + '/api/v1/files/',
-      enabledConnectors: [] as IEnabledConnector[]
+      uploadUrl: getBaseUrlPlatform() + '/api/v1/files/'
     };
   },
   computed: {
-    // Connectors actually drawn as icons. When the user has more than
-    // MAX_CONNECTORS, reserve the final slot for the "+N" overflow chip.
-    visibleConnectors(): IEnabledConnector[] {
-      if (this.enabledConnectors.length <= MAX_CONNECTORS) {
-        return this.enabledConnectors;
-      }
-      return this.enabledConnectors.slice(0, MAX_CONNECTORS - 1);
-    },
-    overflowCount(): number {
-      if (this.enabledConnectors.length <= MAX_CONNECTORS) {
-        return 0;
-      }
-      return this.enabledConnectors.length - (MAX_CONNECTORS - 1);
-    },
-    userId(): string | null {
-      return this.$store.getters.user?.id ?? null;
-    },
     model(): IChatModel {
       return this.$store.state.chat.model;
     },
@@ -303,43 +266,10 @@ export default defineComponent({
       if (oldVal && !val) {
         this.fileList = [];
       }
-    },
-    // Login / logout / account switch — clear the previous account's icons
-    // immediately (so they never linger during the new fetch), then reload.
-    userId() {
-      this.enabledConnectors = [];
-      void this.loadConnectors(true);
     }
-  },
-  mounted() {
-    void this.loadConnectors();
-    // The user manages connections in another tab (auth.acedata.cloud);
-    // refetch when they return so connects/disconnects reflect without a
-    // full reload.
-    document.addEventListener('visibilitychange', this.onVisibilityChange);
-  },
-  beforeUnmount() {
-    document.removeEventListener('visibilitychange', this.onVisibilityChange);
   },
   methods: {
     isImageUrl,
-    async loadConnectors(force = false) {
-      // listEnabledConnectors() never throws (returns [] on error / when
-      // logged out) so the strip just stays hidden rather than breaking.
-      const requestedUserId = this.userId;
-      const list = await listEnabledConnectors(requestedUserId, force);
-      // Drop a stale resolution: if the user switched (or logged out) while
-      // this fetch was in flight, its result belongs to the previous account
-      // and must not be written into component state.
-      if (this.userId === requestedUserId) {
-        this.enabledConnectors = list;
-      }
-    },
-    onVisibilityChange() {
-      if (document.visibilityState === 'visible') {
-        void this.loadConnectors(true);
-      }
-    },
     onStartCall() {
       this.$router.push({ name: ROUTE_CHATGPT_CALL });
     },
@@ -465,50 +395,6 @@ textarea.input:focus {
 </style>
 
 <style lang="scss" scoped>
-// Sits ABOVE the composer card, aligned to the same centered column.
-// Small, refined app-style icons — a quiet "what's connected" affordance.
-.connector-strip {
-  width: 100%;
-  max-width: 800px;
-  margin: 0 auto 8px;
-  padding-left: 6px;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: 5px;
-  .connector-chip {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 20px;
-    height: 20px;
-    border-radius: 50%;
-    overflow: hidden;
-    cursor: pointer;
-    background-color: var(--el-fill-color-light);
-    border: 1px solid var(--el-border-color-lighter);
-    transition:
-      transform 0.12s ease,
-      box-shadow 0.12s ease;
-    &:hover {
-      transform: translateY(-1px);
-      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.14);
-    }
-    .connector-icon {
-      width: 100%;
-      height: 100%;
-      object-fit: cover;
-      display: block;
-    }
-    &.connector-more {
-      font-size: 9px;
-      font-weight: 600;
-      letter-spacing: -0.3px;
-      color: var(--el-text-color-secondary);
-      background-color: var(--el-fill-color);
-    }
-  }
-}
 .composer {
   width: 100%;
   max-width: 800px;

--- a/src/components/chat/ConnectorStrip.vue
+++ b/src/components/chat/ConnectorStrip.vue
@@ -1,0 +1,142 @@
+<template>
+  <!-- Compact strip of the user's enabled (ACTIVE-connection) connector icons.
+       Self-contained + placement-agnostic — the parent decides where it sits.
+       Display-first: clicking any chip (or the +N overflow) opens the
+       connections manager. Renders nothing when there are no active
+       connections or the user is logged out. -->
+  <div v-if="visibleConnectors.length > 0" class="connector-strip">
+    <el-tooltip v-for="c in visibleConnectors" :key="c.id" effect="dark" :content="c.name" placement="top">
+      <span class="connector-chip" role="button" @click="onOpen">
+        <img class="connector-icon" :src="c.icon_url" :alt="c.name" loading="lazy" />
+      </span>
+    </el-tooltip>
+    <el-tooltip v-if="overflowCount > 0" effect="dark" :content="$t('chat.composer.connections')" placement="top">
+      <span class="connector-chip connector-more" role="button" @click="onOpen"> +{{ overflowCount }} </span>
+    </el-tooltip>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElTooltip } from 'element-plus';
+import { listEnabledConnectors, type IEnabledConnector } from './connectorCatalogCache';
+import { openConnectionsManager } from '@/utils';
+
+// Show at most this many connector chips; beyond it the last slot becomes a
+// "+N" overflow chip so the row never exceeds MAX_CONNECTORS items.
+const MAX_CONNECTORS = 5;
+
+export default defineComponent({
+  name: 'ConnectorStrip',
+  components: {
+    ElTooltip
+  },
+  data() {
+    return {
+      enabledConnectors: [] as IEnabledConnector[],
+      // Monotonic load id — only the most recent loadConnectors() may write
+      // state, so an older same-user fetch resolving after a newer force
+      // refresh can't overwrite it with stale icons.
+      loadSeq: 0
+    };
+  },
+  computed: {
+    visibleConnectors(): IEnabledConnector[] {
+      if (this.enabledConnectors.length <= MAX_CONNECTORS) {
+        return this.enabledConnectors;
+      }
+      return this.enabledConnectors.slice(0, MAX_CONNECTORS - 1);
+    },
+    overflowCount(): number {
+      if (this.enabledConnectors.length <= MAX_CONNECTORS) {
+        return 0;
+      }
+      return this.enabledConnectors.length - (MAX_CONNECTORS - 1);
+    },
+    userId(): string | null {
+      return this.$store.getters.user?.id ?? null;
+    }
+  },
+  watch: {
+    // Login / logout / account switch — clear immediately so one account's
+    // icons never linger for the next user, then reload.
+    userId() {
+      this.enabledConnectors = [];
+      void this.loadConnectors(true);
+    }
+  },
+  mounted() {
+    void this.loadConnectors();
+    // The user manages connections in another tab (auth.acedata.cloud);
+    // refetch when they return so connects/disconnects reflect without a
+    // full reload.
+    document.addEventListener('visibilitychange', this.onVisibilityChange);
+  },
+  beforeUnmount() {
+    document.removeEventListener('visibilitychange', this.onVisibilityChange);
+  },
+  methods: {
+    async loadConnectors(force = false) {
+      // listEnabledConnectors() never throws (returns [] on error / when
+      // logged out) so the strip just stays hidden rather than breaking.
+      const requestedUserId = this.userId;
+      const seq = ++this.loadSeq;
+      const list = await listEnabledConnectors(requestedUserId, force);
+      // Drop a stale resolution: a newer load has since started (e.g. a force
+      // refresh) or the user switched / logged out while this was in flight.
+      if (seq === this.loadSeq && this.userId === requestedUserId) {
+        this.enabledConnectors = list;
+      }
+    },
+    onVisibilityChange() {
+      if (document.visibilityState === 'visible') {
+        void this.loadConnectors(true);
+      }
+    },
+    onOpen() {
+      openConnectionsManager();
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.connector-strip {
+  display: inline-flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 5px;
+  .connector-chip {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    overflow: hidden;
+    cursor: pointer;
+    background-color: var(--el-fill-color-light);
+    border: 1px solid var(--el-border-color-lighter);
+    transition:
+      transform 0.12s ease,
+      box-shadow 0.12s ease;
+    &:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.14);
+    }
+    .connector-icon {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    }
+    &.connector-more {
+      font-size: 9px;
+      font-weight: 600;
+      letter-spacing: -0.3px;
+      color: var(--el-text-color-secondary);
+      background-color: var(--el-fill-color);
+    }
+  }
+}
+</style>

--- a/src/components/chat/connectorCatalogCache.ts
+++ b/src/components/chat/connectorCatalogCache.ts
@@ -168,12 +168,17 @@ export interface IEnabledConnector {
 let enabledCache: IEnabledConnector[] | null = null;
 let enabledCacheUserId: string | null = null;
 let enabledInFlight: Promise<IEnabledConnector[]> | null = null;
+// Monotonic fetch id — only the most recently started fetch may write the
+// cache / clear the in-flight marker, so a slow earlier request can't clobber
+// a newer `force` refresh (or a post-account-switch reload).
+let enabledGeneration = 0;
 
 /** Drop any cached enabled-connector state. */
 export function clearEnabledConnectorsCache(): void {
   enabledCache = null;
   enabledCacheUserId = null;
   enabledInFlight = null;
+  enabledGeneration++;
 }
 
 /**
@@ -199,14 +204,20 @@ export async function listEnabledConnectors(
 ): Promise<IEnabledConnector[]> {
   const uid = userId ?? null;
   if (uid !== enabledCacheUserId) {
-    // Login / logout / account switch — discard the previous user's data.
+    // Login / logout / account switch — discard the previous user's data and
+    // invalidate any in-flight fetch so it can't write the new user's cache.
     enabledCacheUserId = uid;
     enabledCache = null;
     enabledInFlight = null;
+    enabledGeneration++;
   }
   if (!uid) return [];
   if (!force && enabledCache) return enabledCache;
-  if (enabledInFlight) return enabledInFlight;
+  // Coalesce concurrent callers — but only when NOT forcing. A `force` caller
+  // (e.g. returning from the connections manager) must start a fresh request
+  // rather than reuse an in-flight fetch that began before the change.
+  if (!force && enabledInFlight) return enabledInFlight;
+  const generation = ++enabledGeneration;
   const task = (async () => {
     try {
       const response = await httpClient.get(`/connectors/`, {
@@ -224,8 +235,9 @@ export async function listEnabledConnectors(
               icon_url: it.icon_url
             }))
         : [];
-      // Only cache if the user hasn't switched while the request was in flight.
-      if (enabledCacheUserId === uid) {
+      // Cache only if this is still the most recent fetch for the same user —
+      // so a slower earlier request can't clobber a newer `force` refresh.
+      if (enabledCacheUserId === uid && enabledGeneration === generation) {
         enabledCache = list;
       }
       return list;
@@ -236,7 +248,7 @@ export async function listEnabledConnectors(
   })();
   enabledInFlight = task;
   void task.finally(() => {
-    if (enabledInFlight === task) {
+    if (enabledGeneration === generation) {
       enabledInFlight = null;
     }
   });

--- a/src/components/chat/connectorCatalogCache.ts
+++ b/src/components/chat/connectorCatalogCache.ts
@@ -147,6 +147,100 @@ export async function getCatalogItem(catalogId: string): Promise<IConnectorCatal
 export function clearConnectorCatalogCache(): void {
   cache.clear();
   inFlight.clear();
+  clearEnabledConnectorsCache();
+}
+
+/** Minimal connector shape the composer strip renders — just enough to
+ *  draw a small icon with a name tooltip. Sourced from the directory list
+ *  (`GET /connectors/`), which carries `icon_url` / `name` inline so the
+ *  strip needs no per-connector join. */
+export interface IEnabledConnector {
+  id: string;
+  identifier: string;
+  name: string;
+  icon_url: string;
+}
+
+// User-scoped: caching the icon list module-level would otherwise leak one
+// account's connectors into the next on a logout / account switch where the
+// SPA stays alive (native/desktop auth popup). The cache is keyed on the
+// user id and dropped the moment it changes.
+let enabledCache: IEnabledConnector[] | null = null;
+let enabledCacheUserId: string | null = null;
+let enabledInFlight: Promise<IEnabledConnector[]> | null = null;
+
+/** Drop any cached enabled-connector state. */
+export function clearEnabledConnectorsCache(): void {
+  enabledCache = null;
+  enabledCacheUserId = null;
+  enabledInFlight = null;
+}
+
+/**
+ * List the connectors the given user currently has an ACTIVE connection to
+ * ("enabled" connectors), for the composer's icon strip.
+ *
+ * AuthBackend's directory list flags each row with `installed` (true iff
+ * the user has an ACTIVE `Connection` whose `connector_identifier` matches
+ * — see `_installed_identifiers`), and the same payload already carries
+ * `icon_url` / `name`, so one round-trip yields everything the strip needs.
+ * `sort=popular` gives a stable order (featured → curated rank → installs).
+ *
+ * Caching is keyed on `userId`; a different (or absent) user invalidates it
+ * so one account's icons never surface for another. Logged-out callers get
+ * an empty list with no network round-trip. Pass `force` to bypass the
+ * cache (e.g. after the user returns from the connections manager). Never
+ * throws — on error it returns the last good value (or an empty list) so
+ * the strip simply stays hidden rather than breaking the composer.
+ */
+export async function listEnabledConnectors(
+  userId: string | null | undefined,
+  force = false
+): Promise<IEnabledConnector[]> {
+  const uid = userId ?? null;
+  if (uid !== enabledCacheUserId) {
+    // Login / logout / account switch — discard the previous user's data.
+    enabledCacheUserId = uid;
+    enabledCache = null;
+    enabledInFlight = null;
+  }
+  if (!uid) return [];
+  if (!force && enabledCache) return enabledCache;
+  if (enabledInFlight) return enabledInFlight;
+  const task = (async () => {
+    try {
+      const response = await httpClient.get(`/connectors/`, {
+        baseURL: `${getBaseUrlAuth()}/api/v1`,
+        params: { sort: 'popular', limit: 200 }
+      });
+      const items = response?.data?.items;
+      const list: IEnabledConnector[] = Array.isArray(items)
+        ? items
+            .filter((it: { installed?: boolean; icon_url?: string }) => it?.installed && it?.icon_url)
+            .map((it: IEnabledConnector) => ({
+              id: it.id,
+              identifier: it.identifier,
+              name: it.name,
+              icon_url: it.icon_url
+            }))
+        : [];
+      // Only cache if the user hasn't switched while the request was in flight.
+      if (enabledCacheUserId === uid) {
+        enabledCache = list;
+      }
+      return list;
+    } catch (error) {
+      console.warn('enabled connectors fetch failed', error);
+      return enabledCache ?? [];
+    }
+  })();
+  enabledInFlight = task;
+  void task.finally(() => {
+    if (enabledInFlight === task) {
+      enabledInFlight = null;
+    }
+  });
+  return task;
 }
 
 /**

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -52,7 +52,11 @@
             @submit="onSubmit"
             @stop="onStop"
           />
-          <disclaimer class="disclaimer" />
+          <div class="composer-footer">
+            <div class="footer-connectors"><connector-strip /></div>
+            <disclaimer class="disclaimer" />
+            <span class="footer-spacer" aria-hidden="true"></span>
+          </div>
         </div>
       </div>
     </template>
@@ -79,6 +83,7 @@ import BYOKBadge from '@/components/chat/BYOKBadge.vue';
 import { ERROR_CODE_CANCELED, ERROR_CODE_NOT_APPLIED, ERROR_CODE_UNKNOWN } from '@/constants/errorCode';
 import { Status } from '@/models';
 import Disclaimer from '@/components/chat/Disclaimer.vue';
+import ConnectorStrip from '@/components/chat/ConnectorStrip.vue';
 import Layout from '@/layouts/Chat.vue';
 import { isImageUrl } from '@/utils/is';
 import { IAskUserQuestionPayload, IChatMessageContentItem, IConsentRequestPayload } from '@/models';
@@ -133,6 +138,7 @@ export default defineComponent({
   components: {
     Composer,
     Disclaimer,
+    ConnectorStrip,
     ModelSelector,
     DesktopAgentManager,
     'byok-badge': BYOKBadge,
@@ -1165,12 +1171,33 @@ export default defineComponent({
   height: 100%;
   overflow-y: auto;
   position: relative;
-  .disclaimer {
+  // Footer row below the composer: enabled-connector icons hug the left while
+  // the disclaimer stays centered in the column. Equal flex:1 side columns
+  // (icons left + an empty mirror spacer right) keep the disclaimer balanced
+  // regardless of how many icons render (or none).
+  .composer-footer {
     width: 100%;
-    text-align: center;
-    font-size: 12px;
-    margin: 10px 0 8px;
-    color: var(--el-text-color-secondary);
+    max-width: 800px;
+    margin: 8px auto;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    .footer-connectors,
+    .footer-spacer {
+      flex: 1 1 0;
+      min-width: 0;
+    }
+    .footer-connectors {
+      display: flex;
+      justify-content: flex-start;
+    }
+    .disclaimer {
+      flex: 0 1 auto;
+      text-align: center;
+      font-size: 12px;
+      margin: 0;
+      color: var(--el-text-color-secondary);
+    }
   }
   &.empty {
     position: relative;


### PR DESCRIPTION
## What

Shows a compact strip of the user's **enabled** connector icons in the chat, as a quiet "what's connected" affordance. Final placement (after iterating with the requester): **below the composer, in the footer row to the left of the disclaimer**, capped at **5** chips with a `+N` overflow.

- Self-contained `ConnectorStrip.vue` — placement-agnostic, drop it anywhere.
- ≤5 small (20px) round icons; >5 → 4 icons + a `+N` overflow chip.
- Name tooltip per icon; clicking any chip (or `+N`) opens the connections manager.
- Renders nothing when the user has no active connections or is logged out.
- The disclaimer stays centered in the column (balanced flex columns), icons hug the left.

## How it integrates with the connector / connections API

A connector is "enabled" when the user has an **ACTIVE `Connection`** for it. AuthBackend's directory list computes exactly this per row:

- `GET https://auth.acedata.cloud/api/v1/connectors/?sort=popular&limit=200` returns every connector with `icon_url` / `name` **and** an `installed` flag — `installed === true` iff the user has an ACTIVE `Connection` whose `connector_identifier` matches (`_installed_identifiers` in `app/views/connectors.py`).
- So **one** authenticated round-trip yields the enabled set *with* icons — no per-connector join against `/connections/` needed.

`listEnabledConnectors(userId, force)` in `connectorCatalogCache.ts` does that call (reusing the existing `httpClient` with the `baseURL` override to AuthBackend, same pattern as the consent card), keeps `installed && icon_url` rows, and caches the result **keyed on the user id** with a monotonic generation guard.

## Files

- **NEW** `src/components/chat/ConnectorStrip.vue` — self-contained strip (fetch + render + refresh).
- `src/components/chat/connectorCatalogCache.ts` — `listEnabledConnectors()` + `IEnabledConnector` + `clearEnabledConnectorsCache()`; user-scoped cache, generation guard, `force` bypasses in-flight.
- `src/pages/chat/Conversation.vue` — renders `<connector-strip>` in the footer next to the disclaimer (balanced flex).
- `Composer.vue` is **unchanged** from main (an earlier iteration that embedded the strip there was reverted).

## Verification

- `eslint` clean, `vue-tsc -b` clean (0 errors), `beachball check` passes (change file included).

## 🤖 对抗评审

Reviewer: **Codex** (`codex exec --sandbox read-only`, cross-model). Multiple rounds across the feature + two placement iterations; every finding **fixed** (none rebutted):

| Round set | RISK | Resolution |
|---|---|---|
| Feature r1 | Module cache not keyed by user → cross-user icon leak on logout / account switch. | Cache keyed on user id; logged-out → `[]` (no call); in-flight only cached if user unchanged. |
| Feature r1 | Strip goes stale after connection changes. | `visibilitychange`→visible force-refetch; `userId` watcher force-reloads on login/logout/switch. |
| Feature r2 | `loadConnectors()` assigned awaited result unconditionally → slow user-A fetch could write A's list after a user-B switch. | Capture `requestedUserId`; assign only if `userId` unchanged afterwards. |
| Feature r3 | Old icons lingered during the new fetch on account switch. | `userId` watcher clears state immediately, then reloads. |
| Refactor r1 | `force` reload reused an in-flight (pre-change) fetch. | `force` skips in-flight reuse; a monotonic `enabledGeneration` makes only the latest fetch write the cache / clear the marker. |
| Refactor r1 | Footer flex shifted the disclaimer off-center. | Balanced flex columns (icons left + mirror spacer right) keep the disclaimer centered regardless of icon count. |
| Refactor r1 | Branch base stale → diff reverted main's release/version bumps. | Rebased onto latest `origin/main`. |
| Refactor r2 | Same-user older fetch could overwrite a newer force refresh in the component. | Per-component `loadSeq` guard — only the most recent `loadConnectors()` writes state. |

Final round: **VERDICT: CLEAN**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
