### PR TITLE
feat(desktop): universal macOS DMG (Intel + Apple Silicon)

### DIFF
--- a/change/@acedatacloud-nexior-77213b40-c0e9-4bd0-8624-7f92feaee366.json
+++ b/change/@acedatacloud-nexior-77213b40-c0e9-4bd0-8624-7f92feaee366.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(desktop): universal macOS DMG (Intel + Apple Silicon)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "cqc@cuiqingcai.com",
+  "dependentChangeType": "patch"
+}

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -42,8 +42,12 @@ nsis:
   allowToChangeInstallationDirectory: true
 
 mac:
+  # `universal` = one DMG with both x64 and arm64 slices, so a single download
+  # runs on Intel AND Apple Silicon Macs. electron-builder fetches both Electron
+  # archs and lipo-merges them.
   target:
-    - dmg
+    - target: dmg
+      arch: universal
   category: public.app-category.productivity
   hardenedRuntime: true
   gatekeeperAssess: false


### PR DESCRIPTION
The macOS runner is arm64, so the DMG was Apple-Silicon-only. Build a `universal` DMG (x64 + arm64) so one download runs on **both Intel and Apple Silicon** Macs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)