### PR TITLE
fix(desktop): separate x64 + arm64 macOS DMGs (drop universal merge)

### DIFF
--- a/change/@acedatacloud-nexior-77213b40-c0e9-4bd0-8624-7f92feaee366.json
+++ b/change/@acedatacloud-nexior-77213b40-c0e9-4bd0-8624-7f92feaee366.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(desktop): universal macOS DMG (Intel + Apple Silicon)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "cqc@cuiqingcai.com",
+  "dependentChangeType": "patch"
+}

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -42,8 +42,12 @@ nsis:
   allowToChangeInstallationDirectory: true
 
 mac:
+  # `universal` = one DMG with both x64 and arm64 slices, so a single download
+  # runs on Intel AND Apple Silicon Macs. electron-builder fetches both Electron
+  # archs and lipo-merges them.
   target:
-    - dmg
+    - target: dmg
+      arch: universal
   category: public.app-category.productivity
   hardenedRuntime: true
   gatekeeperAssess: false

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -42,12 +42,16 @@ nsis:
   allowToChangeInstallationDirectory: true
 
 mac:
-  # `universal` = one DMG with both x64 and arm64 slices, so a single download
-  # runs on Intel AND Apple Silicon Macs. electron-builder fetches both Electron
-  # archs and lipo-merges them.
+  # Two separate DMGs — x64 (Intel) and arm64 (Apple Silicon). Preferred over a
+  # `universal` build, which fails to lipo-merge native prebuilds shipped by the
+  # Solana/walletconnect deps (bufferutil/utf-8-validate). electron-updater's
+  # latest-mac.yml lists both, so auto-update picks the right one per machine;
+  # the download page offers "Intel" vs "Apple Silicon".
   target:
     - target: dmg
-      arch: universal
+      arch:
+        - x64
+        - arm64
   category: public.app-category.productivity
   hardenedRuntime: true
   gatekeeperAssess: false


### PR DESCRIPTION
The universal build failed at the lipo-merge — native prebuilds (bufferutil/utf-8-validate) from the Solana/walletconnect deps are identical across arches and `@electron/universal` can't reconcile them. Build **two separate DMGs** (Intel x64 + Apple Silicon arm64) instead: robust (no merge), covers Intel, and electron-updater's `latest-mac.yml` auto-routes per machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)