### PR TITLE
fix(desktop): separate x64 + arm64 macOS DMGs (drop universal merge)

### DIFF
--- a/change/@acedatacloud-nexior-f5fb23ee-cecc-45a4-94a8-891e8150bb6f.json
+++ b/change/@acedatacloud-nexior-f5fb23ee-cecc-45a4-94a8-891e8150bb6f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(desktop): separate x64 + arm64 macOS DMGs",
+  "packageName": "@acedatacloud/nexior",
+  "email": "cqc@cuiqingcai.com",
+  "dependentChangeType": "patch"
+}

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -42,12 +42,16 @@ nsis:
   allowToChangeInstallationDirectory: true
 
 mac:
-  # `universal` = one DMG with both x64 and arm64 slices, so a single download
-  # runs on Intel AND Apple Silicon Macs. electron-builder fetches both Electron
-  # archs and lipo-merges them.
+  # Two separate DMGs — x64 (Intel) and arm64 (Apple Silicon). Preferred over a
+  # `universal` build, which fails to lipo-merge native prebuilds shipped by the
+  # Solana/walletconnect deps (bufferutil/utf-8-validate). electron-updater's
+  # latest-mac.yml lists both, so auto-update picks the right one per machine;
+  # the download page offers "Intel" vs "Apple Silicon".
   target:
     - target: dmg
-      arch: universal
+      arch:
+        - x64
+        - arm64
   category: public.app-category.productivity
   hardenedRuntime: true
   gatekeeperAssess: false


### PR DESCRIPTION
The universal build failed at lipo-merge (native prebuilds bufferutil/utf-8-validate from Solana/walletconnect deps can't be reconciled). Build **two separate DMGs** — Intel x64 + Apple Silicon arm64. Robust (no merge), covers Intel, electron-updater auto-routes via latest-mac.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)