### PR TITLE
fix(coding-bridge): stop streaming render from crashing mobile Safari; drop session id from URL

### DIFF
--- a/change/@acedatacloud-nexior-4bc54b7c-297d-4526-b3e6-2617600cea3a.json
+++ b/change/@acedatacloud-nexior-4bc54b7c-297d-4526-b3e6-2617600cea3a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(coding-bridge): throttle streaming markdown render (mobile Safari crash) + stop pinning session id in URL",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/codingBridge/TranscriptItem.vue
+++ b/src/components/codingBridge/TranscriptItem.vue
@@ -52,11 +52,7 @@
 
     <!-- Assistant text (markdown); a blinking caret trails while streaming. -->
     <div v-else-if="event.kind === 'text'" class="cb-stream-text" :class="{ 'is-streaming': event.streaming }">
-      <vue-markdown
-        v-highlight
-        :source="event.text || ''"
-        class="markdown-body bg-transparent text-[var(--app-text)]"
-      />
+      <vue-markdown v-highlight :source="renderedText" class="markdown-body bg-transparent text-[var(--app-text)]" />
     </div>
 
     <!-- Thinking -->
@@ -160,6 +156,13 @@ import { ICodingBridgeEvent } from '@/models';
 import { ASK_USER_QUESTION_TOOL } from './askUserQuestion';
 import 'highlight.js/styles/night-owl.css';
 
+// A streaming assistant message grows by many chunks per second. Re-rendering
+// the full markdown (parse + highlight.js over every code block) on each chunk
+// is O(n²) in message length and can peg mobile Safari's renderer until iOS
+// CPU-resource-kills the tab. Coalesce streaming updates to ~10fps; finalized
+// (non-streaming) text renders immediately so it never looks behind.
+const STREAM_RENDER_MS = 100;
+
 export default defineComponent({
   name: 'CodingBridgeTranscriptItem',
   directives: {
@@ -183,6 +186,13 @@ export default defineComponent({
     }
   },
   emits: ['edit'],
+  data() {
+    return {
+      // Throttled mirror of `event.text` actually fed to the markdown renderer.
+      renderedText: this.event.text || '',
+      streamTimer: 0
+    };
+  },
   computed: {
     commandText(): string {
       const input = this.event.input;
@@ -300,6 +310,46 @@ export default defineComponent({
         }
       }
       return this.event.text || '';
+    }
+  },
+  watch: {
+    'event.text'() {
+      this.scheduleRender();
+    },
+    'event.streaming'(streaming: boolean) {
+      // Stream ended — make sure the final, complete text is rendered.
+      if (!streaming) {
+        this.flushRender();
+      }
+    }
+  },
+  beforeUnmount() {
+    if (this.streamTimer) {
+      window.clearTimeout(this.streamTimer);
+    }
+  },
+  methods: {
+    // Coalesce rapid streaming chunks into ~10fps markdown renders; finalized
+    // (non-streaming) text renders immediately.
+    scheduleRender() {
+      if (!this.event.streaming) {
+        this.flushRender();
+        return;
+      }
+      if (this.streamTimer) {
+        return;
+      }
+      this.streamTimer = window.setTimeout(() => {
+        this.streamTimer = 0;
+        this.renderedText = this.event.text || '';
+      }, STREAM_RENDER_MS);
+    },
+    flushRender() {
+      if (this.streamTimer) {
+        window.clearTimeout(this.streamTimer);
+        this.streamTimer = 0;
+      }
+      this.renderedText = this.event.text || '';
     }
   }
 });

--- a/src/pages/codingBridge/Index.vue
+++ b/src/pages/codingBridge/Index.vue
@@ -39,33 +39,8 @@ export default defineComponent({
       drawer: false,
       pairVisible: false,
       historyVisible: false,
-      initialCode: '',
-      // A `?session=` is in the URL but its transcript hasn't been reattached
-      // yet; while true the URL writer must not strip the param it's restoring.
-      restorePending: false
+      initialCode: ''
     };
-  },
-  computed: {
-    currentSessionId(): string | undefined {
-      return this.$store.state.codingBridge?.currentSessionId;
-    },
-    currentNodeId(): string | undefined {
-      return this.$store.state.codingBridge?.currentNodeId;
-    },
-    currentProvider(): string | undefined {
-      const id = this.currentSessionId;
-      const fromSession = id ? this.$store.state.codingBridge?.sessions?.[id]?.provider : undefined;
-      return fromSession || this.$store.state.codingBridge?.historyRef?.provider;
-    },
-    // One key so a single watcher reacts to any part of the open conversation.
-    sessionUrlKey(): string {
-      return `${this.currentNodeId || ''}|${this.currentSessionId || ''}|${this.currentProvider || ''}`;
-    }
-  },
-  watch: {
-    sessionUrlKey() {
-      this.syncUrl();
-    }
   },
   mounted() {
     this.$store.dispatch('codingBridge/connect');
@@ -77,6 +52,7 @@ export default defineComponent({
     }
     this.restoreFromUrl();
     this.handleNotificationDeepLink();
+    this.cleanUrl();
   },
   beforeUnmount() {
     this.$store.dispatch('codingBridge/disconnect');
@@ -90,10 +66,12 @@ export default defineComponent({
       this.drawer = false;
       this.openPair();
     },
-    // Open the exact conversation named in `/coding-bridge?session=&node=&provider=`.
-    // We set the node + history pointer (not currentSession) and let the socket's
-    // onOpen → getHistory → history.snapshot handler reattach it (its guard needs
-    // currentSessionId empty). reattach then sets currentSession → syncUrl runs.
+    // Entry deep link (shared link / tapped notification) may name a conversation
+    // in `/coding-bridge?session=&node=&provider=`. Seed the node + history pointer
+    // from it; the socket's onOpen → getHistory → history.snapshot handler then
+    // reattaches it. The open conversation is NOT pinned back into the URL — it
+    // lives in the (persisted) store, so a plain refresh restores it without the
+    // param (see `cleanUrl`).
     restoreFromUrl() {
       const q = this.$route.query;
       const sessionId = typeof q.session === 'string' ? q.session : '';
@@ -102,41 +80,22 @@ export default defineComponent({
         return;
       }
       const provider = q.provider === 'codex' ? 'codex' : 'claude';
-      this.restorePending = true;
       this.$store.commit('codingBridge/setCurrentNode', nodeId);
       this.$store.commit('codingBridge/setHistoryRef', { node_id: nodeId, provider, session_id: sessionId });
       this.$store.dispatch('codingBridge/getHistory', nodeId);
       this.$store.dispatch('codingBridge/requestSessions', nodeId);
-      // Don't pin the param forever if the session can't be restored (deleted/offline).
-      setTimeout(() => (this.restorePending = false), 15000);
     },
-    // Mirror the open conversation into the URL so it's shareable and survives a
-    // reload / back button. `replace` (not push) avoids cluttering history.
-    syncUrl() {
-      const sessionId = this.currentSessionId;
-      const nodeId = this.currentNodeId;
-      if (sessionId) {
-        this.restorePending = false;
-      }
-      const query: Record<string, any> = { ...this.$route.query };
-      if (sessionId) {
-        query.session = sessionId;
-        if (nodeId) {
-          query.node = nodeId;
-        }
-        if (this.currentProvider) {
-          query.provider = this.currentProvider;
-        }
-      } else if (this.restorePending) {
-        return; // a cold restore is still resolving; keep the URL it's restoring
-      } else {
-        delete query.session;
-        delete query.provider;
-      }
-      const r = this.$route.query;
-      if (query.session === r.session && query.node === r.node && query.provider === r.provider) {
+    // Keep the address bar a clean `/coding-bridge`: once any entry deep-link
+    // params have been consumed above, strip them so the open conversation is
+    // never pinned to the URL. `replace` (not push) avoids a history entry.
+    cleanUrl() {
+      const q = this.$route.query;
+      const keys = ['session', 'node', 'provider', 'request', 'code'];
+      if (!keys.some((k) => k in q)) {
         return;
       }
+      const query: Record<string, any> = { ...q };
+      keys.forEach((k) => delete query[k]);
       this.$router.replace({ query }).catch(() => {});
     },
     // A tapped notification opens `/coding-bridge?node=&session=&request=`. When a


### PR DESCRIPTION
## 问题

coding-bridge 页面在手机 Safari 上反复「加载 → 自动重新加载 → 白屏」,无法使用。

## 现场诊断(通过数据线连真机抓到)

- 崩溃的 tab 停在 `/coding-bridge?session=…&provider=claude&__nexior_reload=…`,Safari 显示「网页已崩溃」——即 WebContent 渲染进程被系统杀掉(不是 JS 报错;JS 报错页面还活着)。
- 设备崩溃报告 `com.apple.WebKit.WebContent.cpu_resource`:该 tab **66% CPU 持续 136 秒**,JS 堆 **100MB → 506MB**,最热栈是 `CFRunLoop timer → WebCore → JavaScriptCore → 应用 JS`。典型的定时器驱动的 JS 失控 + 内存膨胀。

## 根因

流式输出时,每个 chunk 都 `event.text += delta`(`mutations.ts`),绑定的 `<vue-markdown :source>` 会把**整段越来越长的消息**重新 `md.render()`(完整 markdown 解析 + highlight.js 高亮所有代码块)并用 `innerHTML` 整块替换,外加 `v-highlight` 指令又把代码块重包一遍。每秒几十个 chunk × 每次重做整条消息 = 对消息长度的 **O(n²)**。coding agent 的回复又长又多代码,一个回合下来就把渲染进程压垮,iOS 触发 CPU 资源限制把它杀掉 → 网页已崩溃 → chunk-load 恢复逻辑重载 → 白屏死循环。桌面 CPU/内存够顶得住,手机扛不住。

## 改动

1. **`TranscriptItem.vue`** — 流式期间把喂给 `<vue-markdown>` 的源文本**节流到 ~10fps**(`renderedText` + `scheduleRender`/`flushRender`),流式结束立即渲染最终文本;`beforeUnmount` 清定时器。彻底把「渲染频率」和「chunk 到达频率」解耦,快速流也压不垮渲染进程。保留实时 markdown 格式化 / 高亮 / 复制按钮。
2. **`Index.vue`** — 选会话 / 点击时**不再把 session id 写进 URL**(移除 `syncUrl` 及其 watcher、`restorePending`)。`restoreFromUrl` 仍会从入口深链(分享链接 / 通知)读取 node+historyRef 来打开指定会话;新增 `cleanUrl` 在挂载消费完参数后把 `session/node/provider/request/code` 从 URL 抹掉。刷新恢复改为依赖**持久化的 store `historyRef`**(`actions.ts` 的 `history.snapshot` 在 `historyRef` 匹配且无 `currentSessionId` 时 reattach)——所以刷新不丢会话,地址栏保持干净的 `/coding-bridge`。

## 验证

- `npm run build` ✅ / `vue-tsc --noEmit` ✅ / `eslint` ✅
- 真机抓证据确认根因(cpu_resource 报告 + 崩溃栈 + 堆增长)。
- 节流逻辑 trace:流结束的 mutation 同时把 `streaming=false`,`event.streaming` watcher 与 `scheduleRender` 都会 `flushRender` 写入最终全文,不丢最后一帧;断线 `finalizeAllStreams` 也置 `streaming=false`。
- 刷新恢复路径:`historyRef`/`currentNodeId` 在 `persist.ts` 白名单内,且在每次打开/新建/reattach 会话时写入,新建会话时清空 → 不依赖 URL 也能恢复。

> 上线后我会在连着的真机 Safari 上跑一个真实长回合复测。

## 🤖 对抗评审

- **评审者:** Claude `general-purpose` 子代理(本机 `codex` 进程挂死/无输出,按 `auto-review.md` 回退到子代理)。
- **范围:** 节流的最后一帧是否丢失 / 渲染滞后、定时器泄漏或卸载后触发、`event.text`/`event.streaming` 字符串路径 watcher 是否触发、`cleanUrl` 是否过早抹参数破坏深链/配对、刷新恢复是否真靠持久化 `historyRef`、`router.replace` 循环、移除 `syncUrl` 后的悬空引用、其他读取 URL session 的消费者。
- **结论:`VERDICT: CLEAN`** — 逐条对照真实代码核验,未发现真实缺陷。要点:① 流结束两条路径都会 `flushRender` 最终全文,且 100ms 定时器保证最多滞后一帧即收敛;② `:key="event.id"` 稳定,组件实例不跨 event 复用,定时器回调读 `this.event.text` 无陈旧闭包;③ `code` 在 `cleanUrl` 之前读取,深链/配对不受影响;④ `historyRef` 在 `actions.ts` 的打开/新建/reattach 处写入、新建时清空,持久化恢复确实替代了 URL 机制;⑤ 全仓 grep 确认无 `syncUrl/sessionUrlKey/restorePending` 残留引用、无其他读 `query.session` 的消费者。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
