### PR TITLE
fix(coding-bridge): bound transcript render memory to stop mobile Safari OOM (follow-up to #1026)

### DIFF
--- a/change/@acedatacloud-nexior-5231fe07-1e7d-42eb-a930-f84cde69ccb3.json
+++ b/change/@acedatacloud-nexior-5231fe07-1e7d-42eb-a930-f84cde69ccb3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(coding-bridge): window transcript + cap per-item content to stop mobile Safari OOM on large conversations",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/codingBridge/SessionView.vue
+++ b/src/components/codingBridge/SessionView.vue
@@ -106,8 +106,18 @@
         <div v-else-if="!events.length" class="m-auto text-center text-sm text-[var(--app-text-subtle)]">
           {{ $t('codingBridge.session.startHint') }}
         </div>
+        <button
+          v-if="hiddenEventCount > 0"
+          type="button"
+          class="cb-load-earlier mx-auto mb-1 flex items-center gap-1.5 rounded-full border border-[var(--app-border-subtle)] bg-[var(--app-content-bg)] px-3 py-1 text-xs text-[var(--app-text-subtle)] hover:text-[var(--el-color-primary)]"
+          :title="`+${hiddenEventCount}`"
+          @click="loadEarlier"
+        >
+          <font-awesome-icon icon="fa-solid fa-arrow-up" />
+          {{ hiddenEventCount }}
+        </button>
         <transcript-item
-          v-for="event in events"
+          v-for="event in visibleEvents"
           :key="event.id"
           :event="event"
           :editable="canEdit"
@@ -504,6 +514,14 @@ import openaiIcon from '@/assets/images/logos/openai.svg';
 const MAX_ATTACHMENT_BYTES = 50 * 1024 * 1024;
 const MAX_ATTACHMENTS = 10;
 
+// Render only a window of the most recent events so a long coding-agent
+// transcript can't put thousands of markdown/highlight DOM subtrees on the page
+// at once (mobile Safari OOM-kills the tab past its ~2GB limit). Older turns
+// load in pages via the "earlier" control. Paired with per-item content caps in
+// TranscriptItem, this bounds rendered memory regardless of conversation size.
+const RENDER_WINDOW = 60;
+const RENDER_PAGE = 60;
+
 // Brand marks for each coding backend. `invertOnDark` flips the black OpenAI
 // glyph to white in dark mode; Claude's orange already reads on both themes.
 const PROVIDER_BRANDS: Record<string, { src: string; invertOnDark: boolean }> = {
@@ -554,7 +572,10 @@ export default defineComponent({
       restoreCode: false,
       attachmentFileList: [] as UploadFiles,
       uploadUrl: getBaseUrlPlatform() + '/api/v1/files/',
-      maxAttachments: MAX_ATTACHMENTS
+      maxAttachments: MAX_ATTACHMENTS,
+      // How many of the most recent events to render; grows by RENDER_PAGE when
+      // the user loads earlier turns. Reset on session switch.
+      visibleCount: RENDER_WINDOW
     };
   },
   computed: {
@@ -587,6 +608,15 @@ export default defineComponent({
     events(): ICodingBridgeEvent[] {
       const id = this.currentSessionId;
       return id ? (this.$store.state.codingBridge?.events?.[id] ?? []) : [];
+    },
+    // Only the most recent `visibleCount` events are rendered; the rest stay
+    // behind the "load earlier" control so a huge transcript never mounts at once.
+    visibleEvents(): ICodingBridgeEvent[] {
+      const all = this.events;
+      return all.length > this.visibleCount ? all.slice(-this.visibleCount) : all;
+    },
+    hiddenEventCount(): number {
+      return Math.max(0, this.events.length - this.visibleCount);
     },
     // A history transcript is being fetched (restore / drawer open). Drives the
     // transcript skeleton; the `!events.length` guard keeps a live resync silent.
@@ -843,6 +873,8 @@ export default defineComponent({
     },
     currentSessionId() {
       this.scrollToBottom();
+      // A different conversation starts capped to the most recent window again.
+      this.visibleCount = RENDER_WINDOW;
       // Switching conversations cancels any in-progress edit.
       this.editingEventId = '';
       this.restoreCode = false;
@@ -1261,6 +1293,17 @@ export default defineComponent({
         const el = this.$refs.transcript as HTMLElement | undefined;
         if (el) {
           el.scrollTop = el.scrollHeight;
+        }
+      });
+    },
+    // Reveal an older page of the transcript, keeping the current scroll anchor.
+    loadEarlier() {
+      const el = this.$refs.transcript as HTMLElement | undefined;
+      const prevHeight = el?.scrollHeight ?? 0;
+      this.visibleCount += RENDER_PAGE;
+      this.$nextTick(() => {
+        if (el) {
+          el.scrollTop = el.scrollHeight - prevHeight + el.scrollTop;
         }
       });
     }

--- a/src/components/codingBridge/TranscriptItem.vue
+++ b/src/components/codingBridge/TranscriptItem.vue
@@ -60,7 +60,7 @@
       v-else-if="event.kind === 'thinking'"
       class="whitespace-pre-wrap break-words italic text-[var(--app-text-subtle)] border-l-2 border-[var(--app-border-subtle)] pl-3"
     >
-      {{ event.text }}
+      {{ thinkingText }}
     </div>
 
     <!-- Tool use -->
@@ -217,7 +217,9 @@ export default defineComponent({
       for (const key of ['command', 'cmd', 'script']) {
         const value = input[key];
         if (typeof value === 'string' && value.trim()) {
-          return value;
+          // Shell commands / heredocs can be huge; cap like other tool content so
+          // a big script can't recreate the OOM the window+caps are guarding.
+          return capForRender(value, MAX_INPUT_CHARS);
         }
       }
       return '';
@@ -291,6 +293,11 @@ export default defineComponent({
       } catch {
         return capForRender(String(input), MAX_INPUT_CHARS);
       }
+    },
+    // Extended-thinking blocks are agent-generated and can be very long; cap them
+    // too (plain text, but unbounded otherwise).
+    thinkingText(): string {
+      return capForRender(this.event.text || '', MAX_TEXT_CHARS);
     },
     resultText(): string {
       const content = this.event.content;

--- a/src/components/codingBridge/TranscriptItem.vue
+++ b/src/components/codingBridge/TranscriptItem.vue
@@ -116,7 +116,7 @@
       <pre
         class="m-0 max-h-72 overflow-auto whitespace-pre-wrap break-words px-2.5 py-2 font-mono text-xs"
         :class="event.is_error ? 'text-[var(--el-color-danger)]' : 'text-[var(--app-text-subtle)]'"
-        >{{ resultText }}</pre
+        >{{ resultDisplay }}</pre
       >
     </div>
 
@@ -163,6 +163,21 @@ import 'highlight.js/styles/night-owl.css';
 // (non-streaming) text renders immediately so it never looks behind.
 const STREAM_RENDER_MS = 100;
 
+// A coding-agent transcript can carry multi-MB tool output, file writes, or
+// messages. Rendering them in full (markdown + highlight + DOM) blows past
+// mobile Safari's ~2GB per-tab memory limit and the renderer is OOM-killed.
+// Cap what we render; the copy buttons still expose the full value.
+const MAX_TEXT_CHARS = 40000;
+const MAX_RESULT_CHARS = 12000;
+const MAX_INPUT_CHARS = 6000;
+const capForRender = (value: string, max: number): string => {
+  if (value.length <= max) {
+    return value;
+  }
+  const droppedKb = ((value.length - max) / 1024).toFixed(1);
+  return `${value.slice(0, max)}\n\n··· +${droppedKb} KB ···`;
+};
+
 export default defineComponent({
   name: 'CodingBridgeTranscriptItem',
   directives: {
@@ -188,8 +203,8 @@ export default defineComponent({
   emits: ['edit'],
   data() {
     return {
-      // Throttled mirror of `event.text` actually fed to the markdown renderer.
-      renderedText: this.event.text || '',
+      // Throttled, size-capped mirror of `event.text` fed to the markdown renderer.
+      renderedText: capForRender(this.event.text || '', MAX_TEXT_CHARS),
       streamTimer: 0
     };
   },
@@ -272,14 +287,18 @@ export default defineComponent({
         return '';
       }
       try {
-        return JSON.stringify(filtered, null, 2);
+        return capForRender(JSON.stringify(filtered, null, 2), MAX_INPUT_CHARS);
       } catch {
-        return String(input);
+        return capForRender(String(input), MAX_INPUT_CHARS);
       }
     },
     resultText(): string {
       const content = this.event.content;
       return typeof content === 'string' && content.length > 0 ? content : '—';
+    },
+    // Capped for display; the copy button copies the full `resultText`.
+    resultDisplay(): string {
+      return capForRender(this.resultText, MAX_RESULT_CHARS);
     },
     resultLabel(): string {
       const parts: string[] = [];
@@ -341,7 +360,7 @@ export default defineComponent({
       }
       this.streamTimer = window.setTimeout(() => {
         this.streamTimer = 0;
-        this.renderedText = this.event.text || '';
+        this.renderedText = capForRender(this.event.text || '', MAX_TEXT_CHARS);
       }, STREAM_RENDER_MS);
     },
     flushRender() {
@@ -349,7 +368,7 @@ export default defineComponent({
         window.clearTimeout(this.streamTimer);
         this.streamTimer = 0;
       }
-      this.renderedText = this.event.text || '';
+      this.renderedText = capForRender(this.event.text || '', MAX_TEXT_CHARS);
     }
   }
 });


### PR DESCRIPTION
## 这是 #1026 的关键续作 —— 真正的根因修复

#1026(已合并)做了**流式渲染节流** + **URL 不再 pin session id**。但用户的手机 Safari **依然崩溃**。连真机重新排查后,发现 #1026 是「必要但不充分」——崩溃是**内存 OOM**,不是流式/CPU 路径。

## 根因(连真机抓到铁证)

打开一个**大的 coding-agent 会话**时,整段 transcript **全量、无虚拟化**地渲染进 DOM:每条消息 markdown+highlight、每个 tool_use 的 `input`(`JSON.stringify`,含整文件 `Write` 内容)、每个 tool_result 的 `<pre>` 全量、外加**每条文本一个 MarkdownIt+KaTeX 实例**——全部同时在 DOM 里。iOS Safari 的 WebContent 进程冲破 **~2GB 单标签页内存上限**被 jetsam 杀掉,Safari 自动重载又渲染同一会话 → 再崩。

证据:
- 今天的 JetsamEvent:`com.apple.WebKit.WebContent` 占用 **1123.6 MB** 被杀。
- 用户复现瞬间(21:18:57)设备日志:`WebContent: Memory usage info dump` + `Memory Limits: active 2048`(2GB 上限)+ jetsam 优先级 40→100→0(杀进程+重启)。
- CLS relay 日志:同一会话 `history.get` 每 **~8 秒**被重新加载一次,4 分钟内 15 次 = 崩→重载→再崩的循环。

## 改动(上限 + 截断,用户选定的低风险路线)

- **`SessionView.vue`**:只渲染最近 `RENDER_WINDOW`(60)条 event(`visibleEvents`);顶部「加载更早」控件(箭头 + 隐藏条数,**纯数字/图标、无需新增 i18n**)按 `RENDER_PAGE`(60)翻页并保持滚动锚点;切换会话时重置。既限住渲染条数,也限住 MarkdownIt/KaTeX 实例数。
- **`TranscriptItem.vue`**:`capForRender()` 对超大内容截断并标 `··· +X KB ···`:markdown 源(40000)、tool_use input JSON(6000)、tool_result `<pre>`(12000,经 `resultDisplay`)。**复制按钮仍复制完整内容**(`resultText` 保持全量)。

两者叠加把渲染内存按 `条数 × 每条上限` 双重封顶,**与会话大小无关**;单条巨型 event 也不会再撑爆。

## 验证

- `npm run build` ✅ / `vue-tsc` ✅ / `eslint` ✅ / `vitest`(coding-bridge)**25/25** ✅ / i18n 覆盖率门禁 ✅(无新增 key)
- 真机抓到 OOM 铁证(1.1GB jetsam + 2048 上限 + ~8s 崩溃循环)。
- 待部署后我会连真机用这个会话复测确认不再崩。

> ⚠️ 已知取舍:超过 60 条的更早消息默认折叠在「加载更早」后;编辑/重试很老的 prompt 需先展开。超大输出默认截断,完整内容用复制按钮拿。

## 🤖 对抗评审(本轮 = 上限+截断)

- **评审者:** Claude `general-purpose` 子代理(本机 `codex` 进程挂死,按 `auto-review.md` 回退)。
- **范围:** 窗口化是否漏掉最新流式 event / 破坏 scrollToBottom;`loadEarlier` 滚动锚点数学;编辑/重试窗口外的 prompt 是否引用到未渲染的 DOM;`resultDisplay` vs `resultText`(复制是否仍拿全量);截断切断 markdown code fence / KaTeX 是否抛错或产生坏 HTML;截断与流式节流的交互;`visibleCount` 重置时机;符号一致性/未用变量。
- **结论:`VERDICT: CLEAN`** —— 逐条核验真实代码,无真实缺陷。关键确认:① `slice(-visibleCount)` 始终保留最新尾部,`events()` watcher 不变,滚动正常;② `loadEarlier` 锚点公式正确、`el` 不会 undefined;③ 编辑/重试走完整 `state.events`(非 DOM),窗口外只是没渲染、非悬空引用;④ 复制仍绑 `resultText` 全量;⑤ markdown-it 自动闭合截断的 fence、KaTeX best-effort 不抛;⑥ cap 在 init/throttle/flush 三处一致;⑦ 无符号错配/未用变量。

(承上一轮 #1026 的对抗评审同样 `VERDICT: CLEAN`。)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
