### PR TITLE
fix(nexior): align chat mobile menu button + relocate composer connector strip above input

### DIFF
--- a/change/@acedatacloud-nexior-7869d1de-4c43-44f3-a323-86192064c33a.json
+++ b/change/@acedatacloud-nexior-7869d1de-4c43-44f3-a323-86192064c33a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(chat): align mobile menu button + move connector icons above the input (left-aligned) with a centered disclaimer below",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/layouts/Chat.vue
+++ b/src/layouts/Chat.vue
@@ -91,7 +91,9 @@ export default defineComponent({
     display: block;
     position: fixed;
     left: 12px;
-    top: calc(48px + var(--app-safe-area-top));
+    // Vertically center the button within the 45px toolbar band so it lines up
+    // with the model selector (left) and the credits pill (right) on one row.
+    top: calc(var(--app-safe-area-top) + 6px);
     z-index: 2000;
     box-shadow: var(--app-shadow-md);
   }

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -43,6 +43,7 @@
           />
         </div>
         <div class="starter">
+          <div class="composer-connectors"><connector-strip /></div>
           <composer
             v-model:question="question"
             :answering="answering"
@@ -52,11 +53,7 @@
             @submit="onSubmit"
             @stop="onStop"
           />
-          <div class="composer-footer">
-            <div class="footer-connectors"><connector-strip /></div>
-            <disclaimer class="disclaimer" />
-            <span class="footer-spacer" aria-hidden="true"></span>
-          </div>
+          <disclaimer class="composer-disclaimer" />
         </div>
       </div>
     </template>
@@ -1171,33 +1168,28 @@ export default defineComponent({
   height: 100%;
   overflow-y: auto;
   position: relative;
-  // Footer row below the composer: enabled-connector icons hug the left while
-  // the disclaimer stays centered in the column. Equal flex:1 side columns
-  // (icons left + an empty mirror spacer right) keep the disclaimer balanced
-  // regardless of how many icons render (or none).
-  .composer-footer {
+  // Enabled-connector icons sit left-aligned directly above the composer input;
+  // :empty drops the row when there are no connectors. The disclaimer is a
+  // single centered line below. Both share the composer's own box
+  // (max-width:800px; margin:auto) so they line up with the input edges rather
+  // than the wider .starter content box.
+  .composer-connectors {
     width: 100%;
     max-width: 800px;
-    margin: 8px auto;
+    margin: 0 auto 8px;
     display: flex;
-    align-items: center;
-    gap: 8px;
-    .footer-connectors,
-    .footer-spacer {
-      flex: 1 1 0;
-      min-width: 0;
+    justify-content: flex-start;
+    &:empty {
+      display: none;
     }
-    .footer-connectors {
-      display: flex;
-      justify-content: flex-start;
-    }
-    .disclaimer {
-      flex: 0 1 auto;
-      text-align: center;
-      font-size: 12px;
-      margin: 0;
-      color: var(--el-text-color-secondary);
-    }
+  }
+  .composer-disclaimer {
+    width: 100%;
+    max-width: 800px;
+    margin: 8px auto 0;
+    text-align: center;
+    font-size: 12px;
+    color: var(--el-text-color-secondary);
   }
   &.empty {
     position: relative;


### PR DESCRIPTION
## What & why

Two fixes for the chat page (`studio.acedata.cloud`).

### 1. Hamburger menu button alignment (mobile)
The top-left hamburger (`☰`) was at `top: calc(48px + safe-area-top)`, leaving it ~40px **below** the model selector. It now centers within the 45px toolbar band (`top: calc(safe-area-top + 6px)`), so the hamburger, model selector (left) and credits pill (right) all sit on one row.

### 2. Composer connector strip relocation (all widths)
The footer previously rendered the enabled-connector icons + the disclaimer together in a row; on phones this overflowed (icons spilling onto the text), and a first attempt to stack them below the input looked cramped.

New layout: the connector icon strip now sits **left-aligned directly above the input** (aligned to the input's left edge), and the disclaimer is a single **centered line below** the input. The connector row collapses entirely (`:empty`) when the user has no active connectors. The old 3-column `.composer-footer` (and its mobile override) is removed.

```
[ icons +28 ]              <- connector icons, left-aligned, above the input
+-----------------------+
| Please enter question |
| [+] [mic]        [up] |
+-----------------------+
   AI may make mistakes    <- disclaimer, centered, below the input
```

## Files
- `src/layouts/Chat.vue` — hamburger `top` offset (mobile media query)
- `src/pages/chat/Conversation.vue` — connector strip moved above the composer; disclaimer moved below; old footer CSS removed

## Testing
- `npx eslint` on changed files — clean.
- Verified `:empty` drops the connector row when there are no connectors; left edge aligns with the input in both empty and conversation states.

## 🤖 对抗评审

Codex (`codex exec`) hung with no output (~5 min) again this session, so per the auto-review protocol the reviewer fell back to a Claude `general-purpose` subagent.

Reviewer checked: the `:empty` trick with comment-only children, scoped-CSS styling of the `<disclaimer>` child root + specificity vs the UA `<p>` margin, left-edge alignment in empty & non-empty states, dangling references to removed classes, empty-state transform-centering, and inline-flex-inside-flex behavior.

Findings:
- **`:empty` + comments** — comment/PI nodes don't prevent `:empty` from matching in Chrome & iOS Safari; the no-connector row is correctly hidden, no phantom gap. ✓
- **Disclaimer styling** — `.dialogue .composer-disclaimer` (0,2,0) beats the child's `.disclaimer` (0,1,0) and the UA margin; applies to Disclaimer's root `<p>` via Vue scope fallthrough. ✓
- **Left-edge alignment** — connector row and composer share `.starter`'s padding → icons align with the input's left edge in both states. ✓
- **No dangling refs** — `composer-footer` / `footer-connectors` / `footer-spacer` removed everywhere. ✓
- **Empty state** — absolute + transform-centered `.starter` re-centers on new height; `overflow:hidden` doesn't clip chips or one-line disclaimer. ✓
- **inline-flex in flex** — strip shrinks to content, pinned left, no odd stretch. ✓

**VERDICT: CLEAN**