### PR TITLE
fix(chat): give connector icon strip vertical breathing room

### DIFF
--- a/change/@acedatacloud-nexior-68713126-2ef3-4b20-a64a-bbe67fb864b9.json
+++ b/change/@acedatacloud-nexior-68713126-2ef3-4b20-a64a-bbe67fb864b9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(chat): inset connector icon strip so it aligns with the composer's + button instead of hugging the card edge",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -1177,6 +1177,10 @@ export default defineComponent({
     width: 100%;
     max-width: 800px;
     margin: 0 auto 8px;
+    // A little vertical breathing room so the icons aren't squished between
+    // the message above and the composer below; 12px inset lines them up with
+    // the composer's + button (left:12px) rather than the card's outer edge.
+    padding: 4px 12px;
     display: flex;
     justify-content: flex-start;
     &:empty {
@@ -1241,6 +1245,11 @@ export default defineComponent({
 
   .dialogue.empty .starter {
     top: 55%;
+  }
+
+  // Match the composer's mobile left control inset (.tools left:10px).
+  .dialogue .composer-connectors {
+    padding: 4px 10px;
   }
 }
 </style>


### PR DESCRIPTION
## What

The enabled-connector icon strip (`.composer-connectors`) that sits directly **above** the chat composer (PR #1028) had no padding, so the icons were squished between the message above and the composer input below.

Add `padding: 4px 12px` (`4px 10px` on mobile):
- **4px top/bottom** — the vertical breathing room this PR is about, so the icons aren't cramped against the surrounding content.
- **12px / 10px left inset** — lines the icons up with the composer's `+` button (`left: 12px` desktop, `10px` mobile) instead of hugging the card's outer edge.

CSS-only change in `src/pages/chat/Conversation.vue`. `* { box-sizing: border-box }` is set globally, so padding stays inside the 800px box (no overflow), and `&:empty { display: none }` is unaffected (the row still disappears when there are no connectors).

## 🤖 对抗评审

**Reviewer:** Codex (`codex exec --sandbox read-only`, cross-model) on the initial revision; this follow-up only changes the padding shorthand from `0 12px` → `4px 12px` (adds the requested vertical value), so the earlier findings still hold.

- `&:empty { display: none }` unaffected by padding.
- Mobile rule `.dialogue .composer-connectors` (later in source, inside `max-width:767px`) correctly wins on mobile.
- `box-sizing: border-box` globally (`src/assets/scss/_common.scss`) → padding contained within the 800px box, no overflow.
- No disclaimer / surrounding layout regression.

**Verdict:** `VERDICT: CLEAN`.