### PR TITLE
fix(chat): render /chatgpt/scheduled (register el-* + FontAwesomeIcon)

### DIFF
--- a/change/@acedatacloud-nexior-scheduled-tasks-render-fix.json
+++ b/change/@acedatacloud-nexior-scheduled-tasks-render-fix.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(chat): register Element Plus + FontAwesome components in ScheduledTasks so /chatgpt/scheduled renders instead of a blank page",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/pages/chat/ScheduledTasks.vue
+++ b/src/pages/chat/ScheduledTasks.vue
@@ -145,7 +145,26 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElMessage, ElMessageBox } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import {
+  ElButton,
+  ElSkeleton,
+  ElEmpty,
+  ElSwitch,
+  ElTag,
+  ElDrawer,
+  ElDialog,
+  ElForm,
+  ElFormItem,
+  ElInput,
+  ElSelect,
+  ElOption,
+  ElRadioGroup,
+  ElRadio,
+  ElTimePicker,
+  ElMessage,
+  ElMessageBox
+} from 'element-plus';
 import { scheduledTasksOperator, IScheduledTask, IScheduledRun, IScheduleSpec } from '@/operators/scheduledTasks';
 
 const COMMON_CHAT_MODELS = [
@@ -169,6 +188,24 @@ interface TaskForm {
 
 export default defineComponent({
   name: 'ScheduledTasks',
+  components: {
+    FontAwesomeIcon,
+    ElButton,
+    ElSkeleton,
+    ElEmpty,
+    ElSwitch,
+    ElTag,
+    ElDrawer,
+    ElDialog,
+    ElForm,
+    ElFormItem,
+    ElInput,
+    ElSelect,
+    ElOption,
+    ElRadioGroup,
+    ElRadio,
+    ElTimePicker
+  },
   data() {
     return {
       tasks: [] as IScheduledTask[],


### PR DESCRIPTION
## Problem

Opening **/chatgpt/scheduled** (the Scheduled Tasks page added in #1030) shows a **blank main area**. To the user it also looks like "the menu jumped to the right" — that's just the normal right-side service `Navigator`; the left `SidePanel` (conversation list) correctly disappears because it lives inside `Conversation.vue`, which this route replaces.

## Root cause

Nexior has **no global Element Plus / FontAwesome registration** — `main.ts` never calls `app.use(ElementPlus)`, and `vite.config.ts` documents that *"every consumer in `src` uses selective `import { ElButton } from 'element-plus'`"* and registers it locally.

`ScheduledTasks.vue` imported only the imperative `ElMessage` / `ElMessageBox`, but registered **none** of the 15 `el-*` components nor `FontAwesomeIcon` that its template uses. At runtime those tags resolve to nothing, so the page body renders empty. The build doesn't catch this because unknown template tags compile to silent `resolveComponent()` calls (warn-only in dev, no-op in prod).

## Fix

Import and register `FontAwesomeIcon` + the 15 `el-*` components used in the template (`ElButton, ElSkeleton, ElEmpty, ElSwitch, ElTag, ElDrawer, ElDialog, ElForm, ElFormItem, ElInput, ElSelect, ElOption, ElRadioGroup, ElRadio, ElTimePicker`), matching the convention in sibling pages (`RealtimeCall.vue`, `VoiceCreateDialog.vue`, …). `ElMessage`/`ElMessageBox` stay as imperative imports (not registered).

All required FontAwesome icons (`fa-plus`, `fa-pen`, `fa-trash`, and `fa-clock` for the side-panel entry) were already in the library.

## Verification

- `vue-tsc -b` type-check: **pass**
- Verified every `el-*` / `font-awesome-icon` tag in the template has a matching registration (16/16)
- `beachball check`: pass

## 🤖 对抗评审

Reviewer: **Codex** (`codex exec --sandbox read-only`, cross-model).

Checked: (1) every template `el-*` tag registered; (2) correct PascalCase mapping (`el-time-picker` → `ElTimePicker`); (3) companion components present (`ElForm`+`ElFormItem`, `ElRadioGroup`+`ElRadio`, `ElSelect`+`ElOption`); (4) `ElMessage`/`ElMessageBox` correctly left as imperative (not in `components`); (5) all imports exist in `element-plus@2.10.4`; (6) no regressions.

> **No findings.** All 15 `el-*` tags registered locally, `font-awesome-icon` registered as `FontAwesomeIcon`, companion components present, `ElMessage`/`ElMessageBox` remain imperative imports only. The added Element Plus imports exist in installed `element-plus@2.10.4`.
>
> **VERDICT: CLEAN**

Pre-existing prettier formatting nits in untouched lines were intentionally not changed — CI's `npm run lint` (`eslint src --fix`) handles them.