### PR TITLE
feat(digitalhuman): Digital Human talking-head scenario

### DIFF
--- a/change/@acedatacloud-nexior-7cce043a-f139-4277-9d1f-93f255a67e8d.json
+++ b/change/@acedatacloud-nexior-7cce043a-f139-4277-9d1f-93f255a67e8d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add Digital Human talking-head scenario (face + voice -> lip-synced video)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/Navigator.vue
+++ b/src/components/common/Navigator.vue
@@ -88,6 +88,7 @@ import {
   ROUTE_VEO_HISTORY,
   ROUTE_SORA_INDEX,
   ROUTE_MAESTRO_INDEX,
+  ROUTE_DIGITALHUMAN_INDEX,
   ROUTE_SORA_HISTORY,
   ROUTE_NANOBANANA_INDEX,
   ROUTE_OPENAIIMAGE_INDEX,
@@ -127,6 +128,7 @@ import {
   VEO_LOGO,
   SORA_LOGO,
   MAESTRO_LOGO,
+  DIGITALHUMAN_LOGO,
   PIXVERSE_LOGO,
   WAN_LOGO,
   PRODUCER_LOGO,
@@ -365,6 +367,15 @@ export default defineComponent({
           displayName: this.$t('common.nav.maestro'),
           logo: MAESTRO_LOGO,
           routes: [ROUTE_MAESTRO_INDEX],
+          category: 'video'
+        });
+      }
+      if (this.$store?.state?.site?.features?.digitalhuman?.enabled) {
+        result.push({
+          route: { name: ROUTE_DIGITALHUMAN_INDEX },
+          displayName: this.$t('common.nav.digitalhuman'),
+          logo: DIGITALHUMAN_LOGO,
+          routes: [ROUTE_DIGITALHUMAN_INDEX],
           category: 'video'
         });
       }

--- a/src/components/digitalhuman/ConfigPanel.vue
+++ b/src/components/digitalhuman/ConfigPanel.vue
@@ -1,0 +1,235 @@
+<template>
+  <div class="flex flex-col h-full">
+    <div class="flex-1 overflow-y-auto p-5">
+      <!-- Face source -->
+      <div class="mb-4">
+        <span class="text-sm font-bold mb-2 block">{{ $t('digitalhuman.name.face') }}</span>
+        <el-radio-group v-model="faceMode" class="w-full mb-2" @change="onFaceModeChange">
+          <el-radio-button value="video">{{ $t('digitalhuman.name.faceVideo') }}</el-radio-button>
+          <el-radio-button value="photo">{{ $t('digitalhuman.name.facePhoto') }}</el-radio-button>
+        </el-radio-group>
+        <file-input
+          v-if="faceMode === 'video'"
+          :accept="DIGITALHUMAN_VIDEO_ACCEPT"
+          :button-text="$t('digitalhuman.button.uploadVideo')"
+          icon="fa-solid fa-film"
+          @change="onFaceVideoChange"
+        />
+        <file-input
+          v-else
+          :accept="DIGITALHUMAN_IMAGE_ACCEPT"
+          :button-text="$t('digitalhuman.button.uploadPhoto')"
+          icon="fa-solid fa-image"
+          @change="onFacePhotoChange"
+        />
+        <p class="text-xs text-[var(--el-text-color-secondary)] mt-1">{{ $t('digitalhuman.description.face') }}</p>
+      </div>
+
+      <!-- Voice source -->
+      <div class="mb-4">
+        <span class="text-sm font-bold mb-2 block">{{ $t('digitalhuman.name.voice') }}</span>
+        <el-radio-group v-model="voiceMode" class="w-full mb-2" @change="onVoiceModeChange">
+          <el-radio-button value="audio">{{ $t('digitalhuman.name.voiceAudio') }}</el-radio-button>
+          <el-radio-button value="text">{{ $t('digitalhuman.name.voiceText') }}</el-radio-button>
+        </el-radio-group>
+
+        <file-input
+          v-if="voiceMode === 'audio'"
+          :accept="DIGITALHUMAN_AUDIO_ACCEPT"
+          :button-text="$t('digitalhuman.button.uploadAudio')"
+          icon="fa-solid fa-music"
+          @change="onAudioChange"
+        />
+        <template v-else>
+          <el-input
+            v-model="text"
+            type="textarea"
+            :rows="4"
+            :placeholder="$t('digitalhuman.placeholder.text')"
+            class="mb-2"
+          />
+          <voice-clone />
+        </template>
+      </div>
+
+      <!-- Engine -->
+      <div class="mb-4">
+        <span class="text-sm font-bold mb-2 block">{{ $t('digitalhuman.name.engine') }}</span>
+        <el-radio-group v-model="engine" class="w-full">
+          <el-radio-button v-for="e in DIGITALHUMAN_ALLOWED_ENGINES" :key="e" :value="e">{{ e }}</el-radio-button>
+        </el-radio-group>
+      </div>
+
+      <!-- Resolution -->
+      <div class="mb-4">
+        <span class="text-sm font-bold mb-2 block">{{ $t('digitalhuman.name.resolution') }}</span>
+        <el-radio-group v-model="resolution" class="w-full">
+          <el-radio-button v-for="r in DIGITALHUMAN_ALLOWED_RESOLUTIONS" :key="r" :value="r">{{ r }}</el-radio-button>
+        </el-radio-group>
+      </div>
+    </div>
+
+    <div class="flex flex-col items-center justify-center px-5 pb-5">
+      <consumption :value="consumption" :service="service" />
+      <el-button type="primary" class="btn w-full" round :disabled="!canGenerate" @click="onGenerate">
+        <font-awesome-icon icon="fa-solid fa-user" class="mr-2" />
+        {{ $t('digitalhuman.button.generate') }}
+      </el-button>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElButton, ElInput, ElRadioGroup, ElRadioButton } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import Consumption from '../common/Consumption.vue';
+import FileInput from './config/FileInput.vue';
+import VoiceClone from './config/VoiceClone.vue';
+import { getConsumption } from '@/utils';
+import {
+  DIGITALHUMAN_ALLOWED_ENGINES,
+  DIGITALHUMAN_ALLOWED_RESOLUTIONS,
+  DIGITALHUMAN_VIDEO_ACCEPT,
+  DIGITALHUMAN_IMAGE_ACCEPT,
+  DIGITALHUMAN_AUDIO_ACCEPT,
+  DIGITALHUMAN_DEFAULT_ENGINE,
+  DIGITALHUMAN_DEFAULT_RESOLUTION
+} from '@/constants';
+import { IDigitalHumanConfig, IDigitalHumanGenerateRequest } from '@/models';
+
+interface IData {
+  faceMode: 'video' | 'photo';
+  voiceMode: 'audio' | 'text';
+  DIGITALHUMAN_ALLOWED_ENGINES: string[];
+  DIGITALHUMAN_ALLOWED_RESOLUTIONS: string[];
+  DIGITALHUMAN_VIDEO_ACCEPT: string;
+  DIGITALHUMAN_IMAGE_ACCEPT: string;
+  DIGITALHUMAN_AUDIO_ACCEPT: string;
+}
+
+export default defineComponent({
+  name: 'ConfigPanel',
+  components: {
+    ElButton,
+    ElInput,
+    ElRadioGroup,
+    ElRadioButton,
+    Consumption,
+    FileInput,
+    VoiceClone,
+    FontAwesomeIcon
+  },
+  emits: ['generate'],
+  data(): IData {
+    return {
+      faceMode: 'video',
+      voiceMode: 'audio',
+      DIGITALHUMAN_ALLOWED_ENGINES,
+      DIGITALHUMAN_ALLOWED_RESOLUTIONS,
+      DIGITALHUMAN_VIDEO_ACCEPT,
+      DIGITALHUMAN_IMAGE_ACCEPT,
+      DIGITALHUMAN_AUDIO_ACCEPT
+    };
+  },
+  computed: {
+    config(): IDigitalHumanConfig | undefined {
+      return this.$store.state.digitalhuman?.config;
+    },
+    service() {
+      return this.$store.state.digitalhuman?.service;
+    },
+    consumption() {
+      return getConsumption(this.config, this.service?.cost);
+    },
+    canGenerate(): boolean {
+      const faceOk = this.faceMode === 'video' ? !!this.config?.video_url : !!this.config?.image_url;
+      const voiceOk =
+        this.voiceMode === 'audio' ? !!this.config?.audio_url : !!this.config?.text?.trim() && !!this.config?.voice_id;
+      return faceOk && voiceOk;
+    },
+    text: {
+      get(): string | undefined {
+        return this.config?.text;
+      },
+      set(val: string) {
+        this.update({ text: val });
+      }
+    },
+    engine: {
+      get(): string | undefined {
+        return this.config?.engine;
+      },
+      set(val: string) {
+        this.update({ engine: val as IDigitalHumanConfig['engine'] });
+      }
+    },
+    resolution: {
+      get(): string | undefined {
+        return this.config?.resolution;
+      },
+      set(val: string) {
+        this.update({ resolution: val as IDigitalHumanConfig['resolution'] });
+      }
+    }
+  },
+  mounted() {
+    // restore the UI mode from any persisted config, then seed option defaults
+    if (this.config?.image_url && !this.config?.video_url) {
+      this.faceMode = 'photo';
+    }
+    if (this.config?.text || this.config?.voice_id) {
+      this.voiceMode = 'text';
+    }
+    this.update({
+      engine: this.config?.engine ?? (DIGITALHUMAN_DEFAULT_ENGINE as IDigitalHumanConfig['engine']),
+      resolution: this.config?.resolution ?? (DIGITALHUMAN_DEFAULT_RESOLUTION as IDigitalHumanConfig['resolution'])
+    });
+  },
+  methods: {
+    update(patch: Partial<IDigitalHumanConfig>) {
+      this.$store.commit('digitalhuman/setConfig', {
+        ...this.config,
+        ...patch
+      });
+    },
+    onFaceModeChange(mode: string | number | boolean | undefined) {
+      // keep only the active face field so the request never carries both
+      this.update(mode === 'video' ? { image_url: undefined } : { video_url: undefined });
+    },
+    onVoiceModeChange(mode: string | number | boolean | undefined) {
+      this.update(mode === 'audio' ? { text: undefined, voice_id: undefined } : { audio_url: undefined });
+    },
+    onFaceVideoChange(url: string | undefined) {
+      this.update({ video_url: url });
+    },
+    onFacePhotoChange(url: string | undefined) {
+      this.update({ image_url: url });
+    },
+    onAudioChange(url: string | undefined) {
+      this.update({ audio_url: url });
+    },
+    onGenerate() {
+      // build a clean request from the active modes only — never leak the
+      // inactive face/voice fields into the payload
+      const c = this.config || {};
+      const request: IDigitalHumanGenerateRequest = {
+        engine: c.engine,
+        resolution: c.resolution
+      };
+      if (this.faceMode === 'video') {
+        request.video_url = c.video_url;
+      } else {
+        request.image_url = c.image_url;
+      }
+      if (this.voiceMode === 'audio') {
+        request.audio_url = c.audio_url;
+      } else {
+        request.text = c.text;
+        request.voice_id = c.voice_id;
+      }
+      this.$emit('generate', request);
+    }
+  }
+});
+</script>

--- a/src/components/digitalhuman/RecentPanel.vue
+++ b/src/components/digitalhuman/RecentPanel.vue
@@ -1,0 +1,56 @@
+<template>
+  <div v-if="tasks?.items === undefined">
+    <bot-placeholder />
+  </div>
+  <scroll-list
+    v-else-if="tasks?.items?.length && tasks?.items?.length > 0"
+    ref="scrollList"
+    class="tasks h-full w-full overflow-y-auto"
+    :loading="loading"
+    @reach-top="$emit('reach-top')"
+  >
+    <task-preview v-for="(task, taskIndex) in tasks?.items" :key="taskIndex" :model-value="task" />
+  </scroll-list>
+  <div v-if="tasks?.items?.length === 0" class="w-full h-full flex items-center justify-center">
+    <no-tasks />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import TaskPreview from './task/Preview.vue';
+import BotPlaceholder from '@/components/common/BotPlaceholder.vue';
+import NoTasks from '@/components/common/NoTasks.vue';
+import ScrollList from '@/components/common/ScrollList.vue';
+
+export default defineComponent({
+  name: 'RecentPanel',
+  components: {
+    TaskPreview,
+    NoTasks,
+    BotPlaceholder,
+    ScrollList
+  },
+  props: {
+    loading: {
+      type: Boolean,
+      default: false
+    }
+  },
+  emits: ['reach-top'],
+  computed: {
+    tasks() {
+      return {
+        ...this.$store.state.digitalhuman?.tasks,
+        items: this.$store.state.digitalhuman?.tasks?.items?.slice()
+      };
+    }
+  },
+  methods: {
+    getScrollElement(): HTMLElement | undefined {
+      const list = this.$refs.scrollList as any;
+      return list?.getScrollElement?.();
+    }
+  }
+});
+</script>

--- a/src/components/digitalhuman/config/FileInput.vue
+++ b/src/components/digitalhuman/config/FileInput.vue
@@ -1,0 +1,92 @@
+<template>
+  <div>
+    <el-upload
+      ref="uploader"
+      v-model:file-list="fileList"
+      :accept="accept"
+      name="file"
+      class="w-full"
+      :limit="1"
+      :action="uploadUrl"
+      :headers="headers"
+      :on-exceed="onExceed"
+      :on-error="onError"
+      :on-success="onChange"
+      :on-remove="onChange"
+    >
+      <el-button size="small" round>
+        <font-awesome-icon :icon="icon" class="mr-1" />
+        {{ buttonText }}
+      </el-button>
+    </el-upload>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElButton, ElUpload, ElMessage, UploadFiles, UploadFile, UploadInstance } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { getBaseUrlPlatform } from '@/utils';
+
+interface IData {
+  fileList: UploadFiles;
+  uploadUrl: string;
+}
+
+export default defineComponent({
+  name: 'DigitalHumanFileInput',
+  components: {
+    ElUpload,
+    ElButton,
+    FontAwesomeIcon
+  },
+  props: {
+    accept: {
+      type: String,
+      default: ''
+    },
+    buttonText: {
+      type: String,
+      default: ''
+    },
+    icon: {
+      type: String,
+      default: 'fa-solid fa-upload'
+    }
+  },
+  emits: ['change'],
+  data(): IData {
+    return {
+      fileList: [],
+      uploadUrl: getBaseUrlPlatform() + '/api/v1/files/'
+    };
+  },
+  computed: {
+    headers() {
+      return {
+        Authorization: `Bearer ${this.$store.state.token.access}`
+      };
+    }
+  },
+  methods: {
+    onExceed(files: File[]) {
+      // single-file slot: replace whatever is there with the newly picked file
+      const uploader = this.$refs.uploader as UploadInstance | undefined;
+      uploader?.clearFiles();
+      const file = files[0];
+      if (file) {
+        (uploader as any)?.handleStart?.(file);
+        (uploader as any)?.submit?.();
+      }
+    },
+    onError() {
+      ElMessage.error(this.$t('digitalhuman.message.uploadError'));
+    },
+    onChange() {
+      const file = this.fileList?.[0] as UploadFile | undefined;
+      const url = (file?.response as any)?.file_url as string | undefined;
+      this.$emit('change', url);
+    }
+  }
+});
+</script>

--- a/src/components/digitalhuman/config/VoiceClone.vue
+++ b/src/components/digitalhuman/config/VoiceClone.vue
@@ -1,0 +1,179 @@
+<template>
+  <div class="voice-clone">
+    <p class="text-xs text-[var(--el-text-color-secondary)] mb-2">{{ $t('digitalhuman.description.voiceClone') }}</p>
+    <div class="flex flex-row items-center gap-2 mb-2">
+      <file-input
+        :accept="DIGITALHUMAN_AUDIO_ACCEPT"
+        :button-text="$t('digitalhuman.button.uploadSample')"
+        icon="fa-solid fa-microphone"
+        @change="onSampleChange"
+      />
+      <el-select v-model="lang" size="small" class="!w-[90px]">
+        <el-option v-for="l in DIGITALHUMAN_ALLOWED_LANGS" :key="l" :label="l" :value="l" />
+      </el-select>
+    </div>
+    <el-button size="small" type="primary" round :loading="cloning" :disabled="!sampleUrl || cloning" @click="onClone">
+      <font-awesome-icon icon="fa-solid fa-wand-magic-sparkles" class="mr-1" />
+      {{ cloning ? $t('digitalhuman.button.cloning') : $t('digitalhuman.button.clone') }}
+    </el-button>
+
+    <el-alert v-if="voiceId" :closable="false" type="success" class="mt-2">
+      <p class="text-xs mb-0">
+        <font-awesome-icon icon="fa-solid fa-check" class="mr-1" />
+        {{ $t('digitalhuman.name.voiceReady') }}: {{ voiceId }}
+      </p>
+    </el-alert>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElButton, ElSelect, ElOption, ElAlert, ElMessage } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import FileInput from './FileInput.vue';
+import { digitalHumanOperator } from '@/operators';
+import { DIGITALHUMAN_ALLOWED_LANGS, DIGITALHUMAN_AUDIO_ACCEPT, DIGITALHUMAN_DEFAULT_LANG } from '@/constants';
+import { IDigitalHumanLang } from '@/models';
+
+const POLL_INTERVAL = 3000;
+const POLL_MAX = 60;
+
+interface IData {
+  sampleUrl: string | undefined;
+  lang: IDigitalHumanLang;
+  cloning: boolean;
+  destroyed: boolean;
+  runId: number;
+  DIGITALHUMAN_ALLOWED_LANGS: string[];
+  DIGITALHUMAN_AUDIO_ACCEPT: string;
+}
+
+export default defineComponent({
+  name: 'VoiceClone',
+  components: {
+    ElButton,
+    ElSelect,
+    ElOption,
+    ElAlert,
+    FileInput,
+    FontAwesomeIcon
+  },
+  data(): IData {
+    return {
+      sampleUrl: undefined,
+      lang: DIGITALHUMAN_DEFAULT_LANG as IDigitalHumanLang,
+      cloning: false,
+      destroyed: false,
+      runId: 0,
+      DIGITALHUMAN_ALLOWED_LANGS,
+      DIGITALHUMAN_AUDIO_ACCEPT
+    };
+  },
+  computed: {
+    credentialToken(): string | undefined {
+      return this.$store.state.digitalhuman?.credential?.token;
+    },
+    voiceId(): string | undefined {
+      return this.$store.state.digitalhuman?.config?.voice_id;
+    }
+  },
+  watch: {
+    // a different language invalidates a voice cloned from the previous setting
+    lang() {
+      this.invalidate();
+    }
+  },
+  beforeUnmount() {
+    this.destroyed = true;
+    this.runId++;
+  },
+  methods: {
+    onSampleChange(url: string | undefined) {
+      this.sampleUrl = url;
+      // a new sample invalidates any prior / in-flight clone so we never submit a stale voice
+      this.invalidate();
+    },
+    invalidate() {
+      this.runId++;
+      this.cloning = false;
+      if (this.voiceId) {
+        this.setVoiceId(undefined);
+      }
+    },
+    isStale(runId: number): boolean {
+      return this.destroyed || runId !== this.runId;
+    },
+    setVoiceId(voiceId: string | undefined) {
+      this.$store.commit('digitalhuman/setConfig', {
+        ...this.$store.state.digitalhuman?.config,
+        voice_id: voiceId
+      });
+    },
+    sleep(ms: number): Promise<void> {
+      return new Promise((resolve) => setTimeout(resolve, ms));
+    },
+    async onClone() {
+      const token = this.credentialToken;
+      if (!this.sampleUrl || !token) {
+        return;
+      }
+      const runId = ++this.runId;
+      this.cloning = true;
+      this.setVoiceId(undefined);
+      try {
+        const { data } = await digitalHumanOperator.cloneVoice(
+          { audio_url: this.sampleUrl, lang: this.lang },
+          { token }
+        );
+        if (this.isStale(runId)) {
+          return;
+        }
+        if (data?.voice_id) {
+          this.onCloned(data.voice_id);
+          return;
+        }
+        if (data?.task_id) {
+          await this.pollVoice(data.task_id, token, runId);
+        } else {
+          throw new Error('no task');
+        }
+      } catch (_e) {
+        if (!this.isStale(runId)) {
+          ElMessage.error(this.$t('digitalhuman.message.voiceCloneFailed'));
+        }
+      } finally {
+        if (!this.isStale(runId)) {
+          this.cloning = false;
+        }
+      }
+    },
+    async pollVoice(taskId: string, token: string, runId: number) {
+      for (let i = 0; i < POLL_MAX; i++) {
+        if (this.isStale(runId)) {
+          return;
+        }
+        await this.sleep(POLL_INTERVAL);
+        if (this.isStale(runId)) {
+          return;
+        }
+        const { data } = await digitalHumanOperator.pollTask(taskId, { token });
+        if (this.isStale(runId)) {
+          return;
+        }
+        if (data?.voice_id) {
+          this.onCloned(data.voice_id);
+          return;
+        }
+        if (data?.state === 'failed') {
+          throw new Error('clone failed');
+        }
+      }
+      throw new Error('timeout');
+    },
+    onCloned(voiceId: string) {
+      this.setVoiceId(voiceId);
+      ElMessage.success(this.$t('digitalhuman.message.voiceCloneSuccess'));
+    }
+  }
+});
+</script>

--- a/src/components/digitalhuman/task/Preview.vue
+++ b/src/components/digitalhuman/task/Preview.vue
@@ -1,0 +1,243 @@
+<template>
+  <div class="preview">
+    <div class="left">
+      <el-image :src="DIGITALHUMAN_LOGO" class="avatar" />
+    </div>
+    <div class="main">
+      <div class="bot">
+        {{ $t('digitalhuman.name.bot') }}
+        <span class="datetime">
+          {{ $dayjs.format('' + new Date(parseFloat((modelValue?.created_at || '').toString()) * 1000)) }}
+        </span>
+      </div>
+      <div class="info">
+        <p v-if="modelValue?.request?.text" class="prompt mt-2">
+          {{ modelValue?.request?.text }}
+          <span v-if="!isTerminal"> - ({{ statusLabel }}) </span>
+        </p>
+        <p v-else class="prompt mt-2">
+          {{ voiceLabel }}
+          <span v-if="!isTerminal"> - ({{ statusLabel }}) </span>
+        </p>
+        <p class="text-xs text-[var(--el-text-color-secondary)] mb-1">
+          <font-awesome-icon :icon="faceIcon" class="mr-1" />{{ faceLabel }}
+          <span class="ml-2"><font-awesome-icon icon="fa-solid fa-sliders" class="mr-1" />{{ engineLabel }}</span>
+        </p>
+      </div>
+
+      <!-- in-progress: status + percentage -->
+      <div v-if="!isTerminal" class="content">
+        <p class="text-xs text-[var(--el-text-color-secondary)] mb-1">{{ statusLabel }}</p>
+        <el-progress :percentage="progressPct" :stroke-width="6" />
+      </div>
+
+      <!-- success: the talking-head video -->
+      <div v-if="isSuccess" class="content">
+        <video-player v-if="videoUrl" :src="videoUrl" />
+        <div class="operations mt-2">
+          <el-button v-if="videoUrl" type="info" size="small" class="btn-action" @click="onDownload($event, videoUrl)">
+            {{ $t('digitalhuman.button.download') }}
+          </el-button>
+          <api-code-button path="/digital-human/videos" :body="modelValue?.request" />
+        </div>
+        <el-alert :closable="false" class="mt-2 success">
+          <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-user" class="mr-1" />
+            {{ $t('digitalhuman.name.taskId') }}: {{ modelValue?.id }}
+            <copy-to-clipboard :content="modelValue?.id!" />
+          </p>
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-0">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('digitalhuman.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
+          </p>
+        </el-alert>
+      </div>
+
+      <!-- failure -->
+      <div v-if="isFailure" class="content">
+        <el-alert :closable="false" class="failure">
+          <template #template>
+            <font-awesome-icon icon="fa-solid fa-exclamation-triangle" class="mr-1" />
+            {{ $t('digitalhuman.name.failure') }}
+          </template>
+          <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
+            <font-awesome-icon icon="fa-solid fa-user" class="mr-1" />
+            {{ $t('digitalhuman.name.taskId') }}: {{ modelValue?.id }}
+            <copy-to-clipboard :content="modelValue?.id!" />
+          </p>
+          <p v-if="failureReason" class="text-[var(--el-text-color-regular)] text-xs mb-0">
+            <font-awesome-icon icon="fa-solid fa-circle-info" class="mr-1" />
+            {{ $t('digitalhuman.name.failureReason') }}: {{ failureReason }}
+          </p>
+        </el-alert>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElImage, ElAlert, ElButton, ElProgress } from 'element-plus';
+import { IDigitalHumanTask } from '@/models';
+import { DIGITALHUMAN_LOGO } from '@/constants';
+import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import VideoPlayer from '@/components/common/VideoPlayer.vue';
+import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
+
+export default defineComponent({
+  name: 'TaskPreview',
+  components: {
+    ElImage,
+    CopyToClipboard,
+    FontAwesomeIcon,
+    ElAlert,
+    ElProgress,
+    VideoPlayer,
+    ElButton,
+    ApiCodeButton
+  },
+  props: {
+    modelValue: {
+      type: Object as () => IDigitalHumanTask | undefined,
+      required: true
+    }
+  },
+  data() {
+    return {
+      DIGITALHUMAN_LOGO
+    };
+  },
+  computed: {
+    status(): string {
+      return this.modelValue?.status || this.modelValue?.response?.state || 'pending';
+    },
+    isSuccess(): boolean {
+      return ['succeed', 'succeeded'].includes(this.status) || !!this.modelValue?.response?.video_url;
+    },
+    isFailure(): boolean {
+      return ['failed', 'dead'].includes(this.status) || this.modelValue?.response?.success === false;
+    },
+    isTerminal(): boolean {
+      // drive terminal state off the actual outcome so a finished row never
+      // also shows the in-progress bar (robust to succeed/succeeded wording)
+      return this.isSuccess || this.isFailure;
+    },
+    videoUrl(): string | undefined {
+      return this.modelValue?.response?.video_url;
+    },
+    progressPct(): number {
+      const p = this.modelValue?.response?.progress;
+      return typeof p === 'number' ? p : 0;
+    },
+    voiceLabel(): string {
+      return this.modelValue?.request?.audio_url
+        ? (this.$t('digitalhuman.name.audioDriven') as string)
+        : (this.$t('digitalhuman.name.textDriven') as string);
+    },
+    faceLabel(): string {
+      return this.modelValue?.request?.image_url
+        ? (this.$t('digitalhuman.name.facePhoto') as string)
+        : (this.$t('digitalhuman.name.faceVideo') as string);
+    },
+    faceIcon(): string {
+      return this.modelValue?.request?.image_url ? 'fa-solid fa-image' : 'fa-solid fa-film';
+    },
+    engineLabel(): string {
+      return this.modelValue?.request?.engine || this.modelValue?.response?.engine || 'latentsync';
+    },
+    statusLabel(): string {
+      const s = this.status;
+      const key = `digitalhuman.status.${s}`;
+      const label = this.$t(key);
+      return label === key ? (this.$t('digitalhuman.status.processing') as string) : (label as string);
+    },
+    failureReason(): string | undefined {
+      const err = this.modelValue?.response?.error;
+      if (!err) return undefined;
+      return typeof err === 'string' ? err : err?.message;
+    }
+  },
+  methods: {
+    onDownload(event: MouseEvent, url: string) {
+      event?.stopPropagation();
+      window.open(url, '_blank');
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+$left-width: 70px;
+.preview {
+  width: 100%;
+  height: fit-content;
+  text-align: left;
+  display: flex;
+  flex-direction: row;
+  margin-bottom: 15px;
+  .left {
+    width: $left-width;
+    .avatar {
+      width: 50px;
+      height: 50px;
+      margin: 10px;
+      border-radius: 50%;
+    }
+  }
+
+  .main {
+    flex: 1;
+    width: calc(100% - $left-width);
+    min-width: 0;
+    padding: 10px 10px 0 10px;
+
+    .bot {
+      font-size: 16px;
+      font-weight: bold;
+      color: var(--el-color-primary);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      .datetime {
+        font-size: 12px;
+        font-weight: normal;
+        color: var(--el-text-color-secondary);
+        margin-left: 10px;
+      }
+    }
+
+    .info {
+      overflow: hidden;
+      .prompt {
+        font-size: 16px;
+        font-weight: bold;
+        color: var(--el-text-color-regular);
+        margin-bottom: 10px;
+        white-space: normal;
+        word-break: break-word;
+        overflow-wrap: anywhere;
+      }
+    }
+
+    .content {
+      word-break: break-word;
+      overflow-wrap: anywhere;
+
+      .el-alert {
+        border-left-width: 2px;
+        border-left-style: solid;
+        &.failure {
+          border-color: var(--el-color-danger);
+        }
+        &.success {
+          border-color: var(--el-color-success);
+        }
+        :deep(p:last-child) {
+          margin-bottom: 0;
+        }
+      }
+    }
+  }
+}
+</style>

--- a/src/components/setting/Function.vue
+++ b/src/components/setting/Function.vue
@@ -113,6 +113,7 @@ const FEATURE_KEYS = [
   'seedance',
   'grokvideo',
   'maestro',
+  'digitalhuman',
   'wan',
   'producer',
   'kimi',

--- a/src/constants/digitalhuman.ts
+++ b/src/constants/digitalhuman.ts
@@ -1,0 +1,16 @@
+export const DIGITALHUMAN_SERVICE_ID = '5b132265-40e8-4a79-9582-589f8eea4733';
+
+export const DIGITALHUMAN_LOGO = 'https://cdn.acedata.cloud/6f9197d1a9.svg';
+
+export const DIGITALHUMAN_DEFAULT_ENGINE = 'latentsync';
+export const DIGITALHUMAN_DEFAULT_RESOLUTION = '720p';
+export const DIGITALHUMAN_DEFAULT_LANG = 'zh';
+
+export const DIGITALHUMAN_ALLOWED_ENGINES = ['latentsync', 'heygem'];
+export const DIGITALHUMAN_ALLOWED_RESOLUTIONS = ['720p', '540p'];
+export const DIGITALHUMAN_ALLOWED_LANGS = ['zh', 'en'];
+
+// Upload accept filters (face video/photo + voice audio sample).
+export const DIGITALHUMAN_VIDEO_ACCEPT = 'video/mp4,video/quicktime,video/webm';
+export const DIGITALHUMAN_IMAGE_ACCEPT = 'image/png,image/jpeg,image/webp';
+export const DIGITALHUMAN_AUDIO_ACCEPT = 'audio/wav,audio/mpeg,audio/mp4,audio/x-m4a';

--- a/src/constants/i18n.ts
+++ b/src/constants/i18n.ts
@@ -32,6 +32,7 @@ export const I18N_SCOPES = [
   'veo',
   'sora',
   'maestro',
+  'digitalhuman',
   'pixverse',
   'flux',
   'nanobanana',

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -12,6 +12,7 @@ export * from './kling';
 export * from './veo';
 export * from './sora';
 export * from './maestro';
+export * from './digitalhuman';
 export * from './pixverse';
 export * from './flux';
 export * from './hailuo';

--- a/src/i18n/ar/common.json
+++ b/src/i18n/ar/common.json
@@ -1066,5 +1066,9 @@
   "nav.maestro": {
     "message": "مايسترو",
     "description": "نص صفحة تحويل مقالات مايسترو إلى فيديو في شريط التنقل، يجب أن يبقى 'مايسترو'"
+  },
+  "nav.digitalhuman": {
+    "message": "Digital Human",
+    "description": "Text in the website navigation bar for the Digital Human talking-head page"
   }
 }

--- a/src/i18n/ar/digitalhuman.json
+++ b/src/i18n/ar/digitalhuman.json
@@ -1,0 +1,154 @@
+{
+  "name.bot": {
+    "message": "Digital Human",
+    "description": "Bot display name"
+  },
+  "name.taskId": {
+    "message": "Task ID",
+    "description": "Task id"
+  },
+  "name.elapsed": {
+    "message": "Elapsed Time",
+    "description": "Elapsed seconds"
+  },
+  "name.failure": {
+    "message": "Failed",
+    "description": "Failure status"
+  },
+  "name.failureReason": {
+    "message": "Failure Reason",
+    "description": "Failure reason"
+  },
+  "name.face": {
+    "message": "Face Source",
+    "description": "Face source field"
+  },
+  "name.faceVideo": {
+    "message": "Video",
+    "description": "Face video option"
+  },
+  "name.facePhoto": {
+    "message": "Photo",
+    "description": "Face photo option"
+  },
+  "name.voice": {
+    "message": "Voice",
+    "description": "Voice source field"
+  },
+  "name.voiceAudio": {
+    "message": "Audio",
+    "description": "Audio-driven voice option"
+  },
+  "name.voiceText": {
+    "message": "Text",
+    "description": "Text-driven voice option"
+  },
+  "name.audioDriven": {
+    "message": "Audio-driven",
+    "description": "Audio-driven label"
+  },
+  "name.textDriven": {
+    "message": "Text-driven",
+    "description": "Text-driven label"
+  },
+  "name.engine": {
+    "message": "Engine",
+    "description": "Lip-sync engine field"
+  },
+  "name.resolution": {
+    "message": "Resolution",
+    "description": "Output resolution field"
+  },
+  "name.voiceReady": {
+    "message": "Voice ready",
+    "description": "Cloned voice ready label"
+  },
+  "placeholder.text": {
+    "message": "Type what the avatar should say…",
+    "description": "Spoken text placeholder"
+  },
+  "description.face": {
+    "message": "Upload a clear, front-facing face video (preferred) or a single photo to drive the talking head.",
+    "description": "Face field help"
+  },
+  "description.voiceClone": {
+    "message": "Upload a clean 10–20s voice sample to clone a voice, then reuse it to speak your text.",
+    "description": "Voice clone help"
+  },
+  "status.pending": {
+    "message": "Pending",
+    "description": "Pending"
+  },
+  "status.processing": {
+    "message": "Processing",
+    "description": "Processing"
+  },
+  "status.succeed": {
+    "message": "Succeeded",
+    "description": "Succeeded"
+  },
+  "status.failed": {
+    "message": "Failed",
+    "description": "Failed"
+  },
+  "button.generate": {
+    "message": "Generate Video",
+    "description": "Generate button"
+  },
+  "button.download": {
+    "message": "Download Video",
+    "description": "Download video button"
+  },
+  "button.uploadVideo": {
+    "message": "Upload Face Video",
+    "description": "Upload face video button"
+  },
+  "button.uploadPhoto": {
+    "message": "Upload Face Photo",
+    "description": "Upload face photo button"
+  },
+  "button.uploadAudio": {
+    "message": "Upload Audio",
+    "description": "Upload driving audio button"
+  },
+  "button.uploadSample": {
+    "message": "Upload Sample",
+    "description": "Upload voice sample button"
+  },
+  "button.clone": {
+    "message": "Clone Voice",
+    "description": "Clone voice button"
+  },
+  "button.cloning": {
+    "message": "Cloning…",
+    "description": "Cloning in progress button"
+  },
+  "message.startingTask": {
+    "message": "Submitting your video task…",
+    "description": "Submit toast"
+  },
+  "message.startTaskSuccess": {
+    "message": "Task submitted! It will appear below as it renders.",
+    "description": "Submit success"
+  },
+  "message.startTaskFailed": {
+    "message": "Failed to submit the task. Please try again.",
+    "description": "Submit fail"
+  },
+  "message.usedUp": {
+    "message": "Your balance is not sufficient for this request.",
+    "description": "Used-up toast"
+  },
+  "message.uploadError": {
+    "message": "Upload failed. Please try again.",
+    "description": "Upload error toast"
+  },
+  "message.voiceCloneSuccess": {
+    "message": "Voice cloned! You can now generate with your text.",
+    "description": "Voice clone success"
+  },
+  "message.voiceCloneFailed": {
+    "message": "Voice clone failed. Please try a cleaner sample.",
+    "description": "Voice clone fail"
+  }
+}

--- a/src/i18n/ar/site.json
+++ b/src/i18n/ar/site.json
@@ -103,6 +103,10 @@
     "message": "مايسترو",
     "description": "يظهر كعنوان في صندوق التحرير"
   },
+  "field.featuresDigitalhuman": {
+    "message": "Digital Human",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresDeepseek": {
     "message": "ديب سيك",
     "description": "عرض في مربع التحرير"
@@ -450,6 +454,10 @@
   "message.featuresMaestro": {
     "message": "قم بتمكين أو تعطيل وحدة ميزات مايسترو.",
     "description": "وصف ميزة مايسترو"
+  },
+  "message.featuresDigitalhuman": {
+    "message": "Enable or disable the Digital Human feature module.",
+    "description": "Description of the Digital Human feature"
   },
   "message.featuresDeepseek": {
     "message": "تفعيل أو تعطيل وحدة وظيفة ديبسيك.",

--- a/src/i18n/de/common.json
+++ b/src/i18n/de/common.json
@@ -1066,5 +1066,9 @@
   "nav.maestro": {
     "message": "Maestro",
     "description": "Text auf der Navigationsleiste für die Seite, die Artikel in Videos umwandelt, bleibt 'Maestro'"
+  },
+  "nav.digitalhuman": {
+    "message": "Digital Human",
+    "description": "Text in the website navigation bar for the Digital Human talking-head page"
   }
 }

--- a/src/i18n/de/digitalhuman.json
+++ b/src/i18n/de/digitalhuman.json
@@ -1,0 +1,154 @@
+{
+  "name.bot": {
+    "message": "Digital Human",
+    "description": "Bot display name"
+  },
+  "name.taskId": {
+    "message": "Task ID",
+    "description": "Task id"
+  },
+  "name.elapsed": {
+    "message": "Elapsed Time",
+    "description": "Elapsed seconds"
+  },
+  "name.failure": {
+    "message": "Failed",
+    "description": "Failure status"
+  },
+  "name.failureReason": {
+    "message": "Failure Reason",
+    "description": "Failure reason"
+  },
+  "name.face": {
+    "message": "Face Source",
+    "description": "Face source field"
+  },
+  "name.faceVideo": {
+    "message": "Video",
+    "description": "Face video option"
+  },
+  "name.facePhoto": {
+    "message": "Photo",
+    "description": "Face photo option"
+  },
+  "name.voice": {
+    "message": "Voice",
+    "description": "Voice source field"
+  },
+  "name.voiceAudio": {
+    "message": "Audio",
+    "description": "Audio-driven voice option"
+  },
+  "name.voiceText": {
+    "message": "Text",
+    "description": "Text-driven voice option"
+  },
+  "name.audioDriven": {
+    "message": "Audio-driven",
+    "description": "Audio-driven label"
+  },
+  "name.textDriven": {
+    "message": "Text-driven",
+    "description": "Text-driven label"
+  },
+  "name.engine": {
+    "message": "Engine",
+    "description": "Lip-sync engine field"
+  },
+  "name.resolution": {
+    "message": "Resolution",
+    "description": "Output resolution field"
+  },
+  "name.voiceReady": {
+    "message": "Voice ready",
+    "description": "Cloned voice ready label"
+  },
+  "placeholder.text": {
+    "message": "Type what the avatar should say…",
+    "description": "Spoken text placeholder"
+  },
+  "description.face": {
+    "message": "Upload a clear, front-facing face video (preferred) or a single photo to drive the talking head.",
+    "description": "Face field help"
+  },
+  "description.voiceClone": {
+    "message": "Upload a clean 10–20s voice sample to clone a voice, then reuse it to speak your text.",
+    "description": "Voice clone help"
+  },
+  "status.pending": {
+    "message": "Pending",
+    "description": "Pending"
+  },
+  "status.processing": {
+    "message": "Processing",
+    "description": "Processing"
+  },
+  "status.succeed": {
+    "message": "Succeeded",
+    "description": "Succeeded"
+  },
+  "status.failed": {
+    "message": "Failed",
+    "description": "Failed"
+  },
+  "button.generate": {
+    "message": "Generate Video",
+    "description": "Generate button"
+  },
+  "button.download": {
+    "message": "Download Video",
+    "description": "Download video button"
+  },
+  "button.uploadVideo": {
+    "message": "Upload Face Video",
+    "description": "Upload face video button"
+  },
+  "button.uploadPhoto": {
+    "message": "Upload Face Photo",
+    "description": "Upload face photo button"
+  },
+  "button.uploadAudio": {
+    "message": "Upload Audio",
+    "description": "Upload driving audio button"
+  },
+  "button.uploadSample": {
+    "message": "Upload Sample",
+    "description": "Upload voice sample button"
+  },
+  "button.clone": {
+    "message": "Clone Voice",
+    "description": "Clone voice button"
+  },
+  "button.cloning": {
+    "message": "Cloning…",
+    "description": "Cloning in progress button"
+  },
+  "message.startingTask": {
+    "message": "Submitting your video task…",
+    "description": "Submit toast"
+  },
+  "message.startTaskSuccess": {
+    "message": "Task submitted! It will appear below as it renders.",
+    "description": "Submit success"
+  },
+  "message.startTaskFailed": {
+    "message": "Failed to submit the task. Please try again.",
+    "description": "Submit fail"
+  },
+  "message.usedUp": {
+    "message": "Your balance is not sufficient for this request.",
+    "description": "Used-up toast"
+  },
+  "message.uploadError": {
+    "message": "Upload failed. Please try again.",
+    "description": "Upload error toast"
+  },
+  "message.voiceCloneSuccess": {
+    "message": "Voice cloned! You can now generate with your text.",
+    "description": "Voice clone success"
+  },
+  "message.voiceCloneFailed": {
+    "message": "Voice clone failed. Please try a cleaner sample.",
+    "description": "Voice clone fail"
+  }
+}

--- a/src/i18n/de/site.json
+++ b/src/i18n/de/site.json
@@ -103,6 +103,10 @@
     "message": "Maestro",
     "description": "Wird als Titel im Bearbeitungsfeld angezeigt"
   },
+  "field.featuresDigitalhuman": {
+    "message": "Digital Human",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresDeepseek": {
     "message": "Deepseek",
     "description": "Anzeige im Bearbeitungsfeld"
@@ -450,6 +454,10 @@
   "message.featuresMaestro": {
     "message": "Aktivieren oder Deaktivieren des Maestro Funktionsmoduls.",
     "description": "Beschreibung der Maestro Funktion"
+  },
+  "message.featuresDigitalhuman": {
+    "message": "Enable or disable the Digital Human feature module.",
+    "description": "Description of the Digital Human feature"
   },
   "message.featuresDeepseek": {
     "message": "Deepseek-Funktion aktivieren oder deaktivieren.",

--- a/src/i18n/el/common.json
+++ b/src/i18n/el/common.json
@@ -1066,5 +1066,9 @@
   "nav.maestro": {
     "message": "Maestro",
     "description": "Το κείμενο της σελίδας μετατροπής άρθρων σε βίντεο Maestro στη γραμμή πλοήγησης, παραμένει 'Maestro'"
+  },
+  "nav.digitalhuman": {
+    "message": "Digital Human",
+    "description": "Text in the website navigation bar for the Digital Human talking-head page"
   }
 }

--- a/src/i18n/el/digitalhuman.json
+++ b/src/i18n/el/digitalhuman.json
@@ -1,0 +1,154 @@
+{
+  "name.bot": {
+    "message": "Digital Human",
+    "description": "Bot display name"
+  },
+  "name.taskId": {
+    "message": "Task ID",
+    "description": "Task id"
+  },
+  "name.elapsed": {
+    "message": "Elapsed Time",
+    "description": "Elapsed seconds"
+  },
+  "name.failure": {
+    "message": "Failed",
+    "description": "Failure status"
+  },
+  "name.failureReason": {
+    "message": "Failure Reason",
+    "description": "Failure reason"
+  },
+  "name.face": {
+    "message": "Face Source",
+    "description": "Face source field"
+  },
+  "name.faceVideo": {
+    "message": "Video",
+    "description": "Face video option"
+  },
+  "name.facePhoto": {
+    "message": "Photo",
+    "description": "Face photo option"
+  },
+  "name.voice": {
+    "message": "Voice",
+    "description": "Voice source field"
+  },
+  "name.voiceAudio": {
+    "message": "Audio",
+    "description": "Audio-driven voice option"
+  },
+  "name.voiceText": {
+    "message": "Text",
+    "description": "Text-driven voice option"
+  },
+  "name.audioDriven": {
+    "message": "Audio-driven",
+    "description": "Audio-driven label"
+  },
+  "name.textDriven": {
+    "message": "Text-driven",
+    "description": "Text-driven label"
+  },
+  "name.engine": {
+    "message": "Engine",
+    "description": "Lip-sync engine field"
+  },
+  "name.resolution": {
+    "message": "Resolution",
+    "description": "Output resolution field"
+  },
+  "name.voiceReady": {
+    "message": "Voice ready",
+    "description": "Cloned voice ready label"
+  },
+  "placeholder.text": {
+    "message": "Type what the avatar should say…",
+    "description": "Spoken text placeholder"
+  },
+  "description.face": {
+    "message": "Upload a clear, front-facing face video (preferred) or a single photo to drive the talking head.",
+    "description": "Face field help"
+  },
+  "description.voiceClone": {
+    "message": "Upload a clean 10–20s voice sample to clone a voice, then reuse it to speak your text.",
+    "description": "Voice clone help"
+  },
+  "status.pending": {
+    "message": "Pending",
+    "description": "Pending"
+  },
+  "status.processing": {
+    "message": "Processing",
+    "description": "Processing"
+  },
+  "status.succeed": {
+    "message": "Succeeded",
+    "description": "Succeeded"
+  },
+  "status.failed": {
+    "message": "Failed",
+    "description": "Failed"
+  },
+  "button.generate": {
+    "message": "Generate Video",
+    "description": "Generate button"
+  },
+  "button.download": {
+    "message": "Download Video",
+    "description": "Download video button"
+  },
+  "button.uploadVideo": {
+    "message": "Upload Face Video",
+    "description": "Upload face video button"
+  },
+  "button.uploadPhoto": {
+    "message": "Upload Face Photo",
+    "description": "Upload face photo button"
+  },
+  "button.uploadAudio": {
+    "message": "Upload Audio",
+    "description": "Upload driving audio button"
+  },
+  "button.uploadSample": {
+    "message": "Upload Sample",
+    "description": "Upload voice sample button"
+  },
+  "button.clone": {
+    "message": "Clone Voice",
+    "description": "Clone voice button"
+  },
+  "button.cloning": {
+    "message": "Cloning…",
+    "description": "Cloning in progress button"
+  },
+  "message.startingTask": {
+    "message": "Submitting your video task…",
+    "description": "Submit toast"
+  },
+  "message.startTaskSuccess": {
+    "message": "Task submitted! It will appear below as it renders.",
+    "description": "Submit success"
+  },
+  "message.startTaskFailed": {
+    "message": "Failed to submit the task. Please try again.",
+    "description": "Submit fail"
+  },
+  "message.usedUp": {
+    "message": "Your balance is not sufficient for this request.",
+    "description": "Used-up toast"
+  },
+  "message.uploadError": {
+    "message": "Upload failed. Please try again.",
+    "description": "Upload error toast"
+  },
+  "message.voiceCloneSuccess": {
+    "message": "Voice cloned! You can now generate with your text.",
+    "description": "Voice clone success"
+  },
+  "message.voiceCloneFailed": {
+    "message": "Voice clone failed. Please try a cleaner sample.",
+    "description": "Voice clone fail"
+  }
+}

--- a/src/i18n/el/site.json
+++ b/src/i18n/el/site.json
@@ -103,6 +103,10 @@
     "message": "Maestro",
     "description": "Εμφανίζεται ως ο τίτλος στο πλαίσιο επεξεργασίας"
   },
+  "field.featuresDigitalhuman": {
+    "message": "Digital Human",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresDeepseek": {
     "message": "Deepseek",
     "description": "展示在编辑框的标题"
@@ -450,6 +454,10 @@
   "message.featuresMaestro": {
     "message": "Ενεργοποιήστε ή απενεργοποιήστε το module λειτουργίας Maestro.",
     "description": "Περιγραφή της λειτουργίας Maestro"
+  },
+  "message.featuresDigitalhuman": {
+    "message": "Enable or disable the Digital Human feature module.",
+    "description": "Description of the Digital Human feature"
   },
   "message.featuresDeepseek": {
     "message": "Ενεργοποιήστε ή απενεργοποιήστε τη λειτουργία Deepseek.",

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -1066,5 +1066,9 @@
   "nav.maestro": {
     "message": "Maestro",
     "description": "Text in the website navigation bar for the Maestro article-to-video page, keep it as 'Maestro'"
+  },
+  "nav.digitalhuman": {
+    "message": "Digital Human",
+    "description": "Text in the website navigation bar for the Digital Human talking-head page"
   }
 }

--- a/src/i18n/en/digitalhuman.json
+++ b/src/i18n/en/digitalhuman.json
@@ -1,0 +1,154 @@
+{
+  "name.bot": {
+    "message": "Digital Human",
+    "description": "Bot display name"
+  },
+  "name.taskId": {
+    "message": "Task ID",
+    "description": "Task id"
+  },
+  "name.elapsed": {
+    "message": "Elapsed Time",
+    "description": "Elapsed seconds"
+  },
+  "name.failure": {
+    "message": "Failed",
+    "description": "Failure status"
+  },
+  "name.failureReason": {
+    "message": "Failure Reason",
+    "description": "Failure reason"
+  },
+  "name.face": {
+    "message": "Face Source",
+    "description": "Face source field"
+  },
+  "name.faceVideo": {
+    "message": "Video",
+    "description": "Face video option"
+  },
+  "name.facePhoto": {
+    "message": "Photo",
+    "description": "Face photo option"
+  },
+  "name.voice": {
+    "message": "Voice",
+    "description": "Voice source field"
+  },
+  "name.voiceAudio": {
+    "message": "Audio",
+    "description": "Audio-driven voice option"
+  },
+  "name.voiceText": {
+    "message": "Text",
+    "description": "Text-driven voice option"
+  },
+  "name.audioDriven": {
+    "message": "Audio-driven",
+    "description": "Audio-driven label"
+  },
+  "name.textDriven": {
+    "message": "Text-driven",
+    "description": "Text-driven label"
+  },
+  "name.engine": {
+    "message": "Engine",
+    "description": "Lip-sync engine field"
+  },
+  "name.resolution": {
+    "message": "Resolution",
+    "description": "Output resolution field"
+  },
+  "name.voiceReady": {
+    "message": "Voice ready",
+    "description": "Cloned voice ready label"
+  },
+  "placeholder.text": {
+    "message": "Type what the avatar should say…",
+    "description": "Spoken text placeholder"
+  },
+  "description.face": {
+    "message": "Upload a clear, front-facing face video (preferred) or a single photo to drive the talking head.",
+    "description": "Face field help"
+  },
+  "description.voiceClone": {
+    "message": "Upload a clean 10–20s voice sample to clone a voice, then reuse it to speak your text.",
+    "description": "Voice clone help"
+  },
+  "status.pending": {
+    "message": "Pending",
+    "description": "Pending"
+  },
+  "status.processing": {
+    "message": "Processing",
+    "description": "Processing"
+  },
+  "status.succeed": {
+    "message": "Succeeded",
+    "description": "Succeeded"
+  },
+  "status.failed": {
+    "message": "Failed",
+    "description": "Failed"
+  },
+  "button.generate": {
+    "message": "Generate Video",
+    "description": "Generate button"
+  },
+  "button.download": {
+    "message": "Download Video",
+    "description": "Download video button"
+  },
+  "button.uploadVideo": {
+    "message": "Upload Face Video",
+    "description": "Upload face video button"
+  },
+  "button.uploadPhoto": {
+    "message": "Upload Face Photo",
+    "description": "Upload face photo button"
+  },
+  "button.uploadAudio": {
+    "message": "Upload Audio",
+    "description": "Upload driving audio button"
+  },
+  "button.uploadSample": {
+    "message": "Upload Sample",
+    "description": "Upload voice sample button"
+  },
+  "button.clone": {
+    "message": "Clone Voice",
+    "description": "Clone voice button"
+  },
+  "button.cloning": {
+    "message": "Cloning…",
+    "description": "Cloning in progress button"
+  },
+  "message.startingTask": {
+    "message": "Submitting your video task…",
+    "description": "Submit toast"
+  },
+  "message.startTaskSuccess": {
+    "message": "Task submitted! It will appear below as it renders.",
+    "description": "Submit success"
+  },
+  "message.startTaskFailed": {
+    "message": "Failed to submit the task. Please try again.",
+    "description": "Submit fail"
+  },
+  "message.usedUp": {
+    "message": "Your balance is not sufficient for this request.",
+    "description": "Used-up toast"
+  },
+  "message.uploadError": {
+    "message": "Upload failed. Please try again.",
+    "description": "Upload error toast"
+  },
+  "message.voiceCloneSuccess": {
+    "message": "Voice cloned! You can now generate with your text.",
+    "description": "Voice clone success"
+  },
+  "message.voiceCloneFailed": {
+    "message": "Voice clone failed. Please try a cleaner sample.",
+    "description": "Voice clone fail"
+  }
+}

--- a/src/i18n/en/site.json
+++ b/src/i18n/en/site.json
@@ -103,6 +103,10 @@
     "message": "Maestro",
     "description": "Displayed as the title in the editing box"
   },
+  "field.featuresDigitalhuman": {
+    "message": "Digital Human",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresDeepseek": {
     "message": "Deepseek",
     "description": "Displayed as the title in the editing box"
@@ -450,6 +454,10 @@
   "message.featuresMaestro": {
     "message": "Enable or disable the Maestro feature module.",
     "description": "Description of the Maestro feature"
+  },
+  "message.featuresDigitalhuman": {
+    "message": "Enable or disable the Digital Human feature module.",
+    "description": "Description of the Digital Human feature"
   },
   "message.featuresDeepseek": {
     "message": "Enable or disable the Deepseek feature module.",

--- a/src/i18n/es/common.json
+++ b/src/i18n/es/common.json
@@ -1066,5 +1066,9 @@
   "nav.maestro": {
     "message": "Maestro",
     "description": "Texto en la barra de navegación que lleva a la página de conversión de artículos a videos de Maestro, manteniendo 'Maestro'"
+  },
+  "nav.digitalhuman": {
+    "message": "Digital Human",
+    "description": "Text in the website navigation bar for the Digital Human talking-head page"
   }
 }

--- a/src/i18n/es/digitalhuman.json
+++ b/src/i18n/es/digitalhuman.json
@@ -1,0 +1,154 @@
+{
+  "name.bot": {
+    "message": "Digital Human",
+    "description": "Bot display name"
+  },
+  "name.taskId": {
+    "message": "Task ID",
+    "description": "Task id"
+  },
+  "name.elapsed": {
+    "message": "Elapsed Time",
+    "description": "Elapsed seconds"
+  },
+  "name.failure": {
+    "message": "Failed",
+    "description": "Failure status"
+  },
+  "name.failureReason": {
+    "message": "Failure Reason",
+    "description": "Failure reason"
+  },
+  "name.face": {
+    "message": "Face Source",
+    "description": "Face source field"
+  },
+  "name.faceVideo": {
+    "message": "Video",
+    "description": "Face video option"
+  },
+  "name.facePhoto": {
+    "message": "Photo",
+    "description": "Face photo option"
+  },
+  "name.voice": {
+    "message": "Voice",
+    "description": "Voice source field"
+  },
+  "name.voiceAudio": {
+    "message": "Audio",
+    "description": "Audio-driven voice option"
+  },
+  "name.voiceText": {
+    "message": "Text",
+    "description": "Text-driven voice option"
+  },
+  "name.audioDriven": {
+    "message": "Audio-driven",
+    "description": "Audio-driven label"
+  },
+  "name.textDriven": {
+    "message": "Text-driven",
+    "description": "Text-driven label"
+  },
+  "name.engine": {
+    "message": "Engine",
+    "description": "Lip-sync engine field"
+  },
+  "name.resolution": {
+    "message": "Resolution",
+    "description": "Output resolution field"
+  },
+  "name.voiceReady": {
+    "message": "Voice ready",
+    "description": "Cloned voice ready label"
+  },
+  "placeholder.text": {
+    "message": "Type what the avatar should say…",
+    "description": "Spoken text placeholder"
+  },
+  "description.face": {
+    "message": "Upload a clear, front-facing face video (preferred) or a single photo to drive the talking head.",
+    "description": "Face field help"
+  },
+  "description.voiceClone": {
+    "message": "Upload a clean 10–20s voice sample to clone a voice, then reuse it to speak your text.",
+    "description": "Voice clone help"
+  },
+  "status.pending": {
+    "message": "Pending",
+    "description": "Pending"
+  },
+  "status.processing": {
+    "message": "Processing",
+    "description": "Processing"
+  },
+  "status.succeed": {
+    "message": "Succeeded",
+    "description": "Succeeded"
+  },
+  "status.failed": {
+    "message": "Failed",
+    "description": "Failed"
+  },
+  "button.generate": {
+    "message": "Generate Video",
+    "description": "Generate button"
+  },
+  "button.download": {
+    "message": "Download Video",
+    "description": "Download video button"
+  },
+  "button.uploadVideo": {
+    "message": "Upload Face Video",
+    "description": "Upload face video button"
+  },
+  "button.uploadPhoto": {
+    "message": "Upload Face Photo",
+    "description": "Upload face photo button"
+  },
+  "button.uploadAudio": {
+    "message": "Upload Audio",
+    "description": "Upload driving audio button"
+  },
+  "button.uploadSample": {
+    "message": "Upload Sample",
+    "description": "Upload voice sample button"
+  },
+  "button.clone": {
+    "message": "Clone Voice",
+    "description": "Clone voice button"
+  },
+  "button.cloning": {
+    "message": "Cloning…",
+    "description": "Cloning in progress button"
+  },
+  "message.startingTask": {
+    "message": "Submitting your video task…",
+    "description": "Submit toast"
+  },
+  "message.startTaskSuccess": {
+    "message": "Task submitted! It will appear below as it renders.",
+    "description": "Submit success"
+  },
+  "message.startTaskFailed": {
+    "message": "Failed to submit the task. Please try again.",
+    "description": "Submit fail"
+  },
+  "message.usedUp": {
+    "message": "Your balance is not sufficient for this request.",
+    "description": "Used-up toast"
+  },
+  "message.uploadError": {
+    "message": "Upload failed. Please try again.",
+    "description": "Upload error toast"
+  },
+  "message.voiceCloneSuccess": {
+    "message": "Voice cloned! You can now generate with your text.",
+    "description": "Voice clone success"
+  },
+  "message.voiceCloneFailed": {
+    "message": "Voice clone failed. Please try a cleaner sample.",
+    "description": "Voice clone fail"
+  }
+}

--- a/src/i18n/es/site.json
+++ b/src/i18n/es/site.json
@@ -103,6 +103,10 @@
     "message": "Maestro",
     "description": "Se muestra como el título en el cuadro de edición"
   },
+  "field.featuresDigitalhuman": {
+    "message": "Digital Human",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresDeepseek": {
     "message": "Deepseek",
     "description": "Texto que se muestra en el cuadro de edición"
@@ -450,6 +454,10 @@
   "message.featuresMaestro": {
     "message": "Habilitar o deshabilitar el módulo de funciones de Maestro.",
     "description": "Descripción de la función Maestro"
+  },
+  "message.featuresDigitalhuman": {
+    "message": "Enable or disable the Digital Human feature module.",
+    "description": "Description of the Digital Human feature"
   },
   "message.featuresDeepseek": {
     "message": "Activar o desactivar el módulo de función de Deepseek.",

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -1066,5 +1066,9 @@
   "nav.maestro": {
     "message": "Maestro",
     "description": "Navigointipalkissa Maestro-artikkeleiden muuntaminen videoiksi -sivun teksti, säilytä 'Maestro'"
+  },
+  "nav.digitalhuman": {
+    "message": "Digital Human",
+    "description": "Text in the website navigation bar for the Digital Human talking-head page"
   }
 }

--- a/src/i18n/fi/digitalhuman.json
+++ b/src/i18n/fi/digitalhuman.json
@@ -1,0 +1,154 @@
+{
+  "name.bot": {
+    "message": "Digital Human",
+    "description": "Bot display name"
+  },
+  "name.taskId": {
+    "message": "Task ID",
+    "description": "Task id"
+  },
+  "name.elapsed": {
+    "message": "Elapsed Time",
+    "description": "Elapsed seconds"
+  },
+  "name.failure": {
+    "message": "Failed",
+    "description": "Failure status"
+  },
+  "name.failureReason": {
+    "message": "Failure Reason",
+    "description": "Failure reason"
+  },
+  "name.face": {
+    "message": "Face Source",
+    "description": "Face source field"
+  },
+  "name.faceVideo": {
+    "message": "Video",
+    "description": "Face video option"
+  },
+  "name.facePhoto": {
+    "message": "Photo",
+    "description": "Face photo option"
+  },
+  "name.voice": {
+    "message": "Voice",
+    "description": "Voice source field"
+  },
+  "name.voiceAudio": {
+    "message": "Audio",
+    "description": "Audio-driven voice option"
+  },
+  "name.voiceText": {
+    "message": "Text",
+    "description": "Text-driven voice option"
+  },
+  "name.audioDriven": {
+    "message": "Audio-driven",
+    "description": "Audio-driven label"
+  },
+  "name.textDriven": {
+    "message": "Text-driven",
+    "description": "Text-driven label"
+  },
+  "name.engine": {
+    "message": "Engine",
+    "description": "Lip-sync engine field"
+  },
+  "name.resolution": {
+    "message": "Resolution",
+    "description": "Output resolution field"
+  },
+  "name.voiceReady": {
+    "message": "Voice ready",
+    "description": "Cloned voice ready label"
+  },
+  "placeholder.text": {
+    "message": "Type what the avatar should say…",
+    "description": "Spoken text placeholder"
+  },
+  "description.face": {
+    "message": "Upload a clear, front-facing face video (preferred) or a single photo to drive the talking head.",
+    "description": "Face field help"
+  },
+  "description.voiceClone": {
+    "message": "Upload a clean 10–20s voice sample to clone a voice, then reuse it to speak your text.",
+    "description": "Voice clone help"
+  },
+  "status.pending": {
+    "message": "Pending",
+    "description": "Pending"
+  },
+  "status.processing": {
+    "message": "Processing",
+    "description": "Processing"
+  },
+  "status.succeed": {
+    "message": "Succeeded",
+    "description": "Succeeded"
+  },
+  "status.failed": {
+    "message": "Failed",
+    "description": "Failed"
+  },
+  "button.generate": {
+    "message": "Generate Video",
+    "description": "Generate button"
+  },
+  "button.download": {
+    "message": "Download Video",
+    "description": "Download video button"
+  },
+  "button.uploadVideo": {
+    "message": "Upload Face Video",
+    "description": "Upload face video button"
+  },
+  "button.uploadPhoto": {
+    "message": "Upload Face Photo",
+    "description": "Upload face photo button"
+  },
+  "button.uploadAudio": {
+    "message": "Upload Audio",
+    "description": "Upload driving audio button"
+  },
+  "button.uploadSample": {
+    "message": "Upload Sample",
+    "description": "Upload voice sample button"
+  },
+  "button.clone": {
+    "message": "Clone Voice",
+    "description": "Clone voice button"
+  },
+  "button.cloning": {
+    "message": "Cloning…",
+    "description": "Cloning in progress button"
+  },
+  "message.startingTask": {
+    "message": "Submitting your video task…",
+    "description": "Submit toast"
+  },
+  "message.startTaskSuccess": {
+    "message": "Task submitted! It will appear below as it renders.",
+    "description": "Submit success"
+  },
+  "message.startTaskFailed": {
+    "message": "Failed to submit the task. Please try again.",
+    "description": "Submit fail"
+  },
+  "message.usedUp": {
+    "message": "Your balance is not sufficient for this request.",
+    "description": "Used-up toast"
+  },
+  "message.uploadError": {
+    "message": "Upload failed. Please try again.",
+    "description": "Upload error toast"
+  },
+  "message.voiceCloneSuccess": {
+    "message": "Voice cloned! You can now generate with your text.",
+    "description": "Voice clone success"
+  },
+  "message.voiceCloneFailed": {
+    "message": "Voice clone failed. Please try a cleaner sample.",
+    "description": "Voice clone fail"
+  }
+}

--- a/src/i18n/fi/site.json
+++ b/src/i18n/fi/site.json
@@ -103,6 +103,10 @@
     "message": "Maestro",
     "description": "Näytetään otsikkona muokkausruudussa"
   },
+  "field.featuresDigitalhuman": {
+    "message": "Digital Human",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresDeepseek": {
     "message": "Deepseek",
     "description": "Näytetään muokkausruudun otsikkona"
@@ -450,6 +454,10 @@
   "message.featuresMaestro": {
     "message": "Ota käyttöön tai poista käytöstä Maestro-toimintomoduuli.",
     "description": "Maestro-toiminnon kuvaus"
+  },
+  "message.featuresDigitalhuman": {
+    "message": "Enable or disable the Digital Human feature module.",
+    "description": "Description of the Digital Human feature"
   },
   "message.featuresDeepseek": {
     "message": "Avaa tai sulje Deepseek-toimintomoduuli.",

--- a/src/i18n/fr/common.json
+++ b/src/i18n/fr/common.json
@@ -1066,5 +1066,9 @@
   "nav.maestro": {
     "message": "Maestro",
     "description": "Texte sur la page de conversion d'articles en vidéos Maestro dans la barre de navigation, restez comme 'Maestro'"
+  },
+  "nav.digitalhuman": {
+    "message": "Digital Human",
+    "description": "Text in the website navigation bar for the Digital Human talking-head page"
   }
 }

--- a/src/i18n/fr/digitalhuman.json
+++ b/src/i18n/fr/digitalhuman.json
@@ -1,0 +1,154 @@
+{
+  "name.bot": {
+    "message": "Digital Human",
+    "description": "Bot display name"
+  },
+  "name.taskId": {
+    "message": "Task ID",
+    "description": "Task id"
+  },
+  "name.elapsed": {
+    "message": "Elapsed Time",
+    "description": "Elapsed seconds"
+  },
+  "name.failure": {
+    "message": "Failed",
+    "description": "Failure status"
+  },
+  "name.failureReason": {
+    "message": "Failure Reason",
+    "description": "Failure reason"
+  },
+  "name.face": {
+    "message": "Face Source",
+    "description": "Face source field"
+  },
+  "name.faceVideo": {
+    "message": "Video",
+    "description": "Face video option"
+  },
+  "name.facePhoto": {
+    "message": "Photo",
+    "description": "Face photo option"
+  },
+  "name.voice": {
+    "message": "Voice",
+    "description": "Voice source field"
+  },
+  "name.voiceAudio": {
+    "message": "Audio",
+    "description": "Audio-driven voice option"
+  },
+  "name.voiceText": {
+    "message": "Text",
+    "description": "Text-driven voice option"
+  },
+  "name.audioDriven": {
+    "message": "Audio-driven",
+    "description": "Audio-driven label"
+  },
+  "name.textDriven": {
+    "message": "Text-driven",
+    "description": "Text-driven label"
+  },
+  "name.engine": {
+    "message": "Engine",
+    "description": "Lip-sync engine field"
+  },
+  "name.resolution": {
+    "message": "Resolution",
+    "description": "Output resolution field"
+  },
+  "name.voiceReady": {
+    "message": "Voice ready",
+    "description": "Cloned voice ready label"
+  },
+  "placeholder.text": {
+    "message": "Type what the avatar should say…",
+    "description": "Spoken text placeholder"
+  },
+  "description.face": {
+    "message": "Upload a clear, front-facing face video (preferred) or a single photo to drive the talking head.",
+    "description": "Face field help"
+  },
+  "description.voiceClone": {
+    "message": "Upload a clean 10–20s voice sample to clone a voice, then reuse it to speak your text.",
+    "description": "Voice clone help"
+  },
+  "status.pending": {
+    "message": "Pending",
+    "description": "Pending"
+  },
+  "status.processing": {
+    "message": "Processing",
+    "description": "Processing"
+  },
+  "status.succeed": {
+    "message": "Succeeded",
+    "description": "Succeeded"
+  },
+  "status.failed": {
+    "message": "Failed",
+    "description": "Failed"
+  },
+  "button.generate": {
+    "message": "Generate Video",
+    "description": "Generate button"
+  },
+  "button.download": {
+    "message": "Download Video",
+    "description": "Download video button"
+  },
+  "button.uploadVideo": {
+    "message": "Upload Face Video",
+    "description": "Upload face video button"
+  },
+  "button.uploadPhoto": {
+    "message": "Upload Face Photo",
+    "description": "Upload face photo button"
+  },
+  "button.uploadAudio": {
+    "message": "Upload Audio",
+    "description": "Upload driving audio button"
+  },
+  "button.uploadSample": {
+    "message": "Upload Sample",
+    "description": "Upload voice sample button"
+  },
+  "button.clone": {
+    "message": "Clone Voice",
+    "description": "Clone voice button"
+  },
+  "button.cloning": {
+    "message": "Cloning…",
+    "description": "Cloning in progress button"
+  },
+  "message.startingTask": {
+    "message": "Submitting your video task…",
+    "description": "Submit toast"
+  },
+  "message.startTaskSuccess": {
+    "message": "Task submitted! It will appear below as it renders.",
+    "description": "Submit success"
+  },
+  "message.startTaskFailed": {
+    "message": "Failed to submit the task. Please try again.",
+    "description": "Submit fail"
+  },
+  "message.usedUp": {
+    "message": "Your balance is not sufficient for this request.",
+    "description": "Used-up toast"
+  },
+  "message.uploadError": {
+    "message": "Upload failed. Please try again.",
+    "description": "Upload error toast"
+  },
+  "message.voiceCloneSuccess": {
+    "message": "Voice cloned! You can now generate with your text.",
+    "description": "Voice clone success"
+  },
+  "message.voiceCloneFailed": {
+    "message": "Voice clone failed. Please try a cleaner sample.",
+    "description": "Voice clone fail"
+  }
+}

--- a/src/i18n/fr/site.json
+++ b/src/i18n/fr/site.json
@@ -103,6 +103,10 @@
     "message": "Maestro",
     "description": "Affiché comme le titre dans la boîte d'édition"
   },
+  "field.featuresDigitalhuman": {
+    "message": "Digital Human",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresDeepseek": {
     "message": "Deepseek",
     "description": "Affiché comme titre dans la zone d'édition"
@@ -450,6 +454,10 @@
   "message.featuresMaestro": {
     "message": "Activer ou désactiver le module de fonctionnalité Maestro.",
     "description": "Description de la fonctionnalité Maestro"
+  },
+  "message.featuresDigitalhuman": {
+    "message": "Enable or disable the Digital Human feature module.",
+    "description": "Description of the Digital Human feature"
   },
   "message.featuresDeepseek": {
     "message": "Activer ou désactiver le module de fonction Deepseek.",

--- a/src/i18n/it/common.json
+++ b/src/i18n/it/common.json
@@ -1066,5 +1066,9 @@
   "nav.maestro": {
     "message": "Maestro",
     "description": "Testo della pagina di conversione di articoli in video di Maestro nella barra di navigazione, mantenere come 'Maestro'"
+  },
+  "nav.digitalhuman": {
+    "message": "Digital Human",
+    "description": "Text in the website navigation bar for the Digital Human talking-head page"
   }
 }

--- a/src/i18n/it/digitalhuman.json
+++ b/src/i18n/it/digitalhuman.json
@@ -1,0 +1,154 @@
+{
+  "name.bot": {
+    "message": "Digital Human",
+    "description": "Bot display name"
+  },
+  "name.taskId": {
+    "message": "Task ID",
+    "description": "Task id"
+  },
+  "name.elapsed": {
+    "message": "Elapsed Time",
+    "description": "Elapsed seconds"
+  },
+  "name.failure": {
+    "message": "Failed",
+    "description": "Failure status"
+  },
+  "name.failureReason": {
+    "message": "Failure Reason",
+    "description": "Failure reason"
+  },
+  "name.face": {
+    "message": "Face Source",
+    "description": "Face source field"
+  },
+  "name.faceVideo": {
+    "message": "Video",
+    "description": "Face video option"
+  },
+  "name.facePhoto": {
+    "message": "Photo",
+    "description": "Face photo option"
+  },
+  "name.voice": {
+    "message": "Voice",
+    "description": "Voice source field"
+  },
+  "name.voiceAudio": {
+    "message": "Audio",
+    "description": "Audio-driven voice option"
+  },
+  "name.voiceText": {
+    "message": "Text",
+    "description": "Text-driven voice option"
+  },
+  "name.audioDriven": {
+    "message": "Audio-driven",
+    "description": "Audio-driven label"
+  },
+  "name.textDriven": {
+    "message": "Text-driven",
+    "description": "Text-driven label"
+  },
+  "name.engine": {
+    "message": "Engine",
+    "description": "Lip-sync engine field"
+  },
+  "name.resolution": {
+    "message": "Resolution",
+    "description": "Output resolution field"
+  },
+  "name.voiceReady": {
+    "message": "Voice ready",
+    "description": "Cloned voice ready label"
+  },
+  "placeholder.text": {
+    "message": "Type what the avatar should say…",
+    "description": "Spoken text placeholder"
+  },
+  "description.face": {
+    "message": "Upload a clear, front-facing face video (preferred) or a single photo to drive the talking head.",
+    "description": "Face field help"
+  },
+  "description.voiceClone": {
+    "message": "Upload a clean 10–20s voice sample to clone a voice, then reuse it to speak your text.",
+    "description": "Voice clone help"
+  },
+  "status.pending": {
+    "message": "Pending",
+    "description": "Pending"
+  },
+  "status.processing": {
+    "message": "Processing",
+    "description": "Processing"
+  },
+  "status.succeed": {
+    "message": "Succeeded",
+    "description": "Succeeded"
+  },
+  "status.failed": {
+    "message": "Failed",
+    "description": "Failed"
+  },
+  "button.generate": {
+    "message": "Generate Video",
+    "description": "Generate button"
+  },
+  "button.download": {
+    "message": "Download Video",
+    "description": "Download video button"
+  },
+  "button.uploadVideo": {
+    "message": "Upload Face Video",
+    "description": "Upload face video button"
+  },
+  "button.uploadPhoto": {
+    "message": "Upload Face Photo",
+    "description": "Upload face photo button"
+  },
+  "button.uploadAudio": {
+    "message": "Upload Audio",
+    "description": "Upload driving audio button"
+  },
+  "button.uploadSample": {
+    "message": "Upload Sample",
+    "description": "Upload voice sample button"
+  },
+  "button.clone": {
+    "message": "Clone Voice",
+    "description": "Clone voice button"
+  },
+  "button.cloning": {
+    "message": "Cloning…",
+    "description": "Cloning in progress button"
+  },
+  "message.startingTask": {
+    "message": "Submitting your video task…",
+    "description": "Submit toast"
+  },
+  "message.startTaskSuccess": {
+    "message": "Task submitted! It will appear below as it renders.",
+    "description": "Submit success"
+  },
+  "message.startTaskFailed": {
+    "message": "Failed to submit the task. Please try again.",
+    "description": "Submit fail"
+  },
+  "message.usedUp": {
+    "message": "Your balance is not sufficient for this request.",
+    "description": "Used-up toast"
+  },
+  "message.uploadError": {
+    "message": "Upload failed. Please try again.",
+    "description": "Upload error toast"
+  },
+  "message.voiceCloneSuccess": {
+    "message": "Voice cloned! You can now generate with your text.",
+    "description": "Voice clone success"
+  },
+  "message.voiceCloneFailed": {
+    "message": "Voice clone failed. Please try a cleaner sample.",
+    "description": "Voice clone fail"
+  }
+}

--- a/src/i18n/it/site.json
+++ b/src/i18n/it/site.json
@@ -103,6 +103,10 @@
     "message": "Maestro",
     "description": "Visualizzato come titolo nella casella di modifica"
   },
+  "field.featuresDigitalhuman": {
+    "message": "Digital Human",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresDeepseek": {
     "message": "Deepseek",
     "description": "Mostrato nel campo di modifica del titolo"
@@ -450,6 +454,10 @@
   "message.featuresMaestro": {
     "message": "Abilita o disabilita il modulo funzionale Maestro.",
     "description": "Descrizione della funzionalità Maestro"
+  },
+  "message.featuresDigitalhuman": {
+    "message": "Enable or disable the Digital Human feature module.",
+    "description": "Description of the Digital Human feature"
   },
   "message.featuresDeepseek": {
     "message": "Attiva o disattiva il modulo funzionalità Deepseek.",

--- a/src/i18n/ja/common.json
+++ b/src/i18n/ja/common.json
@@ -1066,5 +1066,9 @@
   "nav.maestro": {
     "message": "マエストロ",
     "description": "ナビゲーションバーのマエストロ記事を動画に変換するページの文字で、'マエストロ'のままにします。"
+  },
+  "nav.digitalhuman": {
+    "message": "Digital Human",
+    "description": "Text in the website navigation bar for the Digital Human talking-head page"
   }
 }

--- a/src/i18n/ja/digitalhuman.json
+++ b/src/i18n/ja/digitalhuman.json
@@ -1,0 +1,154 @@
+{
+  "name.bot": {
+    "message": "Digital Human",
+    "description": "Bot display name"
+  },
+  "name.taskId": {
+    "message": "Task ID",
+    "description": "Task id"
+  },
+  "name.elapsed": {
+    "message": "Elapsed Time",
+    "description": "Elapsed seconds"
+  },
+  "name.failure": {
+    "message": "Failed",
+    "description": "Failure status"
+  },
+  "name.failureReason": {
+    "message": "Failure Reason",
+    "description": "Failure reason"
+  },
+  "name.face": {
+    "message": "Face Source",
+    "description": "Face source field"
+  },
+  "name.faceVideo": {
+    "message": "Video",
+    "description": "Face video option"
+  },
+  "name.facePhoto": {
+    "message": "Photo",
+    "description": "Face photo option"
+  },
+  "name.voice": {
+    "message": "Voice",
+    "description": "Voice source field"
+  },
+  "name.voiceAudio": {
+    "message": "Audio",
+    "description": "Audio-driven voice option"
+  },
+  "name.voiceText": {
+    "message": "Text",
+    "description": "Text-driven voice option"
+  },
+  "name.audioDriven": {
+    "message": "Audio-driven",
+    "description": "Audio-driven label"
+  },
+  "name.textDriven": {
+    "message": "Text-driven",
+    "description": "Text-driven label"
+  },
+  "name.engine": {
+    "message": "Engine",
+    "description": "Lip-sync engine field"
+  },
+  "name.resolution": {
+    "message": "Resolution",
+    "description": "Output resolution field"
+  },
+  "name.voiceReady": {
+    "message": "Voice ready",
+    "description": "Cloned voice ready label"
+  },
+  "placeholder.text": {
+    "message": "Type what the avatar should say…",
+    "description": "Spoken text placeholder"
+  },
+  "description.face": {
+    "message": "Upload a clear, front-facing face video (preferred) or a single photo to drive the talking head.",
+    "description": "Face field help"
+  },
+  "description.voiceClone": {
+    "message": "Upload a clean 10–20s voice sample to clone a voice, then reuse it to speak your text.",
+    "description": "Voice clone help"
+  },
+  "status.pending": {
+    "message": "Pending",
+    "description": "Pending"
+  },
+  "status.processing": {
+    "message": "Processing",
+    "description": "Processing"
+  },
+  "status.succeed": {
+    "message": "Succeeded",
+    "description": "Succeeded"
+  },
+  "status.failed": {
+    "message": "Failed",
+    "description": "Failed"
+  },
+  "button.generate": {
+    "message": "Generate Video",
+    "description": "Generate button"
+  },
+  "button.download": {
+    "message": "Download Video",
+    "description": "Download video button"
+  },
+  "button.uploadVideo": {
+    "message": "Upload Face Video",
+    "description": "Upload face video button"
+  },
+  "button.uploadPhoto": {
+    "message": "Upload Face Photo",
+    "description": "Upload face photo button"
+  },
+  "button.uploadAudio": {
+    "message": "Upload Audio",
+    "description": "Upload driving audio button"
+  },
+  "button.uploadSample": {
+    "message": "Upload Sample",
+    "description": "Upload voice sample button"
+  },
+  "button.clone": {
+    "message": "Clone Voice",
+    "description": "Clone voice button"
+  },
+  "button.cloning": {
+    "message": "Cloning…",
+    "description": "Cloning in progress button"
+  },
+  "message.startingTask": {
+    "message": "Submitting your video task…",
+    "description": "Submit toast"
+  },
+  "message.startTaskSuccess": {
+    "message": "Task submitted! It will appear below as it renders.",
+    "description": "Submit success"
+  },
+  "message.startTaskFailed": {
+    "message": "Failed to submit the task. Please try again.",
+    "description": "Submit fail"
+  },
+  "message.usedUp": {
+    "message": "Your balance is not sufficient for this request.",
+    "description": "Used-up toast"
+  },
+  "message.uploadError": {
+    "message": "Upload failed. Please try again.",
+    "description": "Upload error toast"
+  },
+  "message.voiceCloneSuccess": {
+    "message": "Voice cloned! You can now generate with your text.",
+    "description": "Voice clone success"
+  },
+  "message.voiceCloneFailed": {
+    "message": "Voice clone failed. Please try a cleaner sample.",
+    "description": "Voice clone fail"
+  }
+}

--- a/src/i18n/ja/site.json
+++ b/src/i18n/ja/site.json
@@ -103,6 +103,10 @@
     "message": "マエストロ",
     "description": "編集ボックスのタイトルとして表示されます"
   },
+  "field.featuresDigitalhuman": {
+    "message": "Digital Human",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresDeepseek": {
     "message": "Deepseek",
     "description": "編集ボックスに表示されるタイトル"
@@ -450,6 +454,10 @@
   "message.featuresMaestro": {
     "message": "Maestro機能モジュールを有効または無効にします。",
     "description": "Maestro機能の説明"
+  },
+  "message.featuresDigitalhuman": {
+    "message": "Enable or disable the Digital Human feature module.",
+    "description": "Description of the Digital Human feature"
   },
   "message.featuresDeepseek": {
     "message": "Deepseek機能モジュールをオンまたはオフにします。",

--- a/src/i18n/ko/common.json
+++ b/src/i18n/ko/common.json
@@ -1066,5 +1066,9 @@
   "nav.maestro": {
     "message": "Maestro",
     "description": "탐색 막대에서 Maestro 기사에서 비디오 페이지로의 텍스트로, 'Maestro'로 유지합니다."
+  },
+  "nav.digitalhuman": {
+    "message": "Digital Human",
+    "description": "Text in the website navigation bar for the Digital Human talking-head page"
   }
 }

--- a/src/i18n/ko/digitalhuman.json
+++ b/src/i18n/ko/digitalhuman.json
@@ -1,0 +1,154 @@
+{
+  "name.bot": {
+    "message": "Digital Human",
+    "description": "Bot display name"
+  },
+  "name.taskId": {
+    "message": "Task ID",
+    "description": "Task id"
+  },
+  "name.elapsed": {
+    "message": "Elapsed Time",
+    "description": "Elapsed seconds"
+  },
+  "name.failure": {
+    "message": "Failed",
+    "description": "Failure status"
+  },
+  "name.failureReason": {
+    "message": "Failure Reason",
+    "description": "Failure reason"
+  },
+  "name.face": {
+    "message": "Face Source",
+    "description": "Face source field"
+  },
+  "name.faceVideo": {
+    "message": "Video",
+    "description": "Face video option"
+  },
+  "name.facePhoto": {
+    "message": "Photo",
+    "description": "Face photo option"
+  },
+  "name.voice": {
+    "message": "Voice",
+    "description": "Voice source field"
+  },
+  "name.voiceAudio": {
+    "message": "Audio",
+    "description": "Audio-driven voice option"
+  },
+  "name.voiceText": {
+    "message": "Text",
+    "description": "Text-driven voice option"
+  },
+  "name.audioDriven": {
+    "message": "Audio-driven",
+    "description": "Audio-driven label"
+  },
+  "name.textDriven": {
+    "message": "Text-driven",
+    "description": "Text-driven label"
+  },
+  "name.engine": {
+    "message": "Engine",
+    "description": "Lip-sync engine field"
+  },
+  "name.resolution": {
+    "message": "Resolution",
+    "description": "Output resolution field"
+  },
+  "name.voiceReady": {
+    "message": "Voice ready",
+    "description": "Cloned voice ready label"
+  },
+  "placeholder.text": {
+    "message": "Type what the avatar should say…",
+    "description": "Spoken text placeholder"
+  },
+  "description.face": {
+    "message": "Upload a clear, front-facing face video (preferred) or a single photo to drive the talking head.",
+    "description": "Face field help"
+  },
+  "description.voiceClone": {
+    "message": "Upload a clean 10–20s voice sample to clone a voice, then reuse it to speak your text.",
+    "description": "Voice clone help"
+  },
+  "status.pending": {
+    "message": "Pending",
+    "description": "Pending"
+  },
+  "status.processing": {
+    "message": "Processing",
+    "description": "Processing"
+  },
+  "status.succeed": {
+    "message": "Succeeded",
+    "description": "Succeeded"
+  },
+  "status.failed": {
+    "message": "Failed",
+    "description": "Failed"
+  },
+  "button.generate": {
+    "message": "Generate Video",
+    "description": "Generate button"
+  },
+  "button.download": {
+    "message": "Download Video",
+    "description": "Download video button"
+  },
+  "button.uploadVideo": {
+    "message": "Upload Face Video",
+    "description": "Upload face video button"
+  },
+  "button.uploadPhoto": {
+    "message": "Upload Face Photo",
+    "description": "Upload face photo button"
+  },
+  "button.uploadAudio": {
+    "message": "Upload Audio",
+    "description": "Upload driving audio button"
+  },
+  "button.uploadSample": {
+    "message": "Upload Sample",
+    "description": "Upload voice sample button"
+  },
+  "button.clone": {
+    "message": "Clone Voice",
+    "description": "Clone voice button"
+  },
+  "button.cloning": {
+    "message": "Cloning…",
+    "description": "Cloning in progress button"
+  },
+  "message.startingTask": {
+    "message": "Submitting your video task…",
+    "description": "Submit toast"
+  },
+  "message.startTaskSuccess": {
+    "message": "Task submitted! It will appear below as it renders.",
+    "description": "Submit success"
+  },
+  "message.startTaskFailed": {
+    "message": "Failed to submit the task. Please try again.",
+    "description": "Submit fail"
+  },
+  "message.usedUp": {
+    "message": "Your balance is not sufficient for this request.",
+    "description": "Used-up toast"
+  },
+  "message.uploadError": {
+    "message": "Upload failed. Please try again.",
+    "description": "Upload error toast"
+  },
+  "message.voiceCloneSuccess": {
+    "message": "Voice cloned! You can now generate with your text.",
+    "description": "Voice clone success"
+  },
+  "message.voiceCloneFailed": {
+    "message": "Voice clone failed. Please try a cleaner sample.",
+    "description": "Voice clone fail"
+  }
+}

--- a/src/i18n/ko/site.json
+++ b/src/i18n/ko/site.json
@@ -103,6 +103,10 @@
     "message": "Maestro",
     "description": "편집 상자에서 제목으로 표시됩니다."
   },
+  "field.featuresDigitalhuman": {
+    "message": "Digital Human",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresDeepseek": {
     "message": "Deepseek",
     "description": "편집 상자에 표시되는 제목"
@@ -450,6 +454,10 @@
   "message.featuresMaestro": {
     "message": "Maestro 기능 모듈을 활성화하거나 비활성화합니다.",
     "description": "Maestro 기능에 대한 설명입니다."
+  },
+  "message.featuresDigitalhuman": {
+    "message": "Enable or disable the Digital Human feature module.",
+    "description": "Description of the Digital Human feature"
   },
   "message.featuresDeepseek": {
     "message": "Deepseek 기능 모듈을 켜거나 끕니다.",

--- a/src/i18n/pl/common.json
+++ b/src/i18n/pl/common.json
@@ -1066,5 +1066,9 @@
   "nav.maestro": {
     "message": "Maestro",
     "description": "Tekst na stronie przejścia z artykułu na wideo w nawigacji, pozostaje jako 'Maestro'"
+  },
+  "nav.digitalhuman": {
+    "message": "Digital Human",
+    "description": "Text in the website navigation bar for the Digital Human talking-head page"
   }
 }

--- a/src/i18n/pl/digitalhuman.json
+++ b/src/i18n/pl/digitalhuman.json
@@ -1,0 +1,154 @@
+{
+  "name.bot": {
+    "message": "Digital Human",
+    "description": "Bot display name"
+  },
+  "name.taskId": {
+    "message": "Task ID",
+    "description": "Task id"
+  },
+  "name.elapsed": {
+    "message": "Elapsed Time",
+    "description": "Elapsed seconds"
+  },
+  "name.failure": {
+    "message": "Failed",
+    "description": "Failure status"
+  },
+  "name.failureReason": {
+    "message": "Failure Reason",
+    "description": "Failure reason"
+  },
+  "name.face": {
+    "message": "Face Source",
+    "description": "Face source field"
+  },
+  "name.faceVideo": {
+    "message": "Video",
+    "description": "Face video option"
+  },
+  "name.facePhoto": {
+    "message": "Photo",
+    "description": "Face photo option"
+  },
+  "name.voice": {
+    "message": "Voice",
+    "description": "Voice source field"
+  },
+  "name.voiceAudio": {
+    "message": "Audio",
+    "description": "Audio-driven voice option"
+  },
+  "name.voiceText": {
+    "message": "Text",
+    "description": "Text-driven voice option"
+  },
+  "name.audioDriven": {
+    "message": "Audio-driven",
+    "description": "Audio-driven label"
+  },
+  "name.textDriven": {
+    "message": "Text-driven",
+    "description": "Text-driven label"
+  },
+  "name.engine": {
+    "message": "Engine",
+    "description": "Lip-sync engine field"
+  },
+  "name.resolution": {
+    "message": "Resolution",
+    "description": "Output resolution field"
+  },
+  "name.voiceReady": {
+    "message": "Voice ready",
+    "description": "Cloned voice ready label"
+  },
+  "placeholder.text": {
+    "message": "Type what the avatar should say…",
+    "description": "Spoken text placeholder"
+  },
+  "description.face": {
+    "message": "Upload a clear, front-facing face video (preferred) or a single photo to drive the talking head.",
+    "description": "Face field help"
+  },
+  "description.voiceClone": {
+    "message": "Upload a clean 10–20s voice sample to clone a voice, then reuse it to speak your text.",
+    "description": "Voice clone help"
+  },
+  "status.pending": {
+    "message": "Pending",
+    "description": "Pending"
+  },
+  "status.processing": {
+    "message": "Processing",
+    "description": "Processing"
+  },
+  "status.succeed": {
+    "message": "Succeeded",
+    "description": "Succeeded"
+  },
+  "status.failed": {
+    "message": "Failed",
+    "description": "Failed"
+  },
+  "button.generate": {
+    "message": "Generate Video",
+    "description": "Generate button"
+  },
+  "button.download": {
+    "message": "Download Video",
+    "description": "Download video button"
+  },
+  "button.uploadVideo": {
+    "message": "Upload Face Video",
+    "description": "Upload face video button"
+  },
+  "button.uploadPhoto": {
+    "message": "Upload Face Photo",
+    "description": "Upload face photo button"
+  },
+  "button.uploadAudio": {
+    "message": "Upload Audio",
+    "description": "Upload driving audio button"
+  },
+  "button.uploadSample": {
+    "message": "Upload Sample",
+    "description": "Upload voice sample button"
+  },
+  "button.clone": {
+    "message": "Clone Voice",
+    "description": "Clone voice button"
+  },
+  "button.cloning": {
+    "message": "Cloning…",
+    "description": "Cloning in progress button"
+  },
+  "message.startingTask": {
+    "message": "Submitting your video task…",
+    "description": "Submit toast"
+  },
+  "message.startTaskSuccess": {
+    "message": "Task submitted! It will appear below as it renders.",
+    "description": "Submit success"
+  },
+  "message.startTaskFailed": {
+    "message": "Failed to submit the task. Please try again.",
+    "description": "Submit fail"
+  },
+  "message.usedUp": {
+    "message": "Your balance is not sufficient for this request.",
+    "description": "Used-up toast"
+  },
+  "message.uploadError": {
+    "message": "Upload failed. Please try again.",
+    "description": "Upload error toast"
+  },
+  "message.voiceCloneSuccess": {
+    "message": "Voice cloned! You can now generate with your text.",
+    "description": "Voice clone success"
+  },
+  "message.voiceCloneFailed": {
+    "message": "Voice clone failed. Please try a cleaner sample.",
+    "description": "Voice clone fail"
+  }
+}

--- a/src/i18n/pl/site.json
+++ b/src/i18n/pl/site.json
@@ -103,6 +103,10 @@
     "message": "Maestro",
     "description": "Wyświetlane jako tytuł w oknie edycji"
   },
+  "field.featuresDigitalhuman": {
+    "message": "Digital Human",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresDeepseek": {
     "message": "Deepseek",
     "description": "Wyświetlane w tytule edytora"
@@ -450,6 +454,10 @@
   "message.featuresMaestro": {
     "message": "Włącz lub wyłącz moduł funkcji Maestro.",
     "description": "Opis funkcji Maestro"
+  },
+  "message.featuresDigitalhuman": {
+    "message": "Enable or disable the Digital Human feature module.",
+    "description": "Description of the Digital Human feature"
   },
   "message.featuresDeepseek": {
     "message": "Włącz lub wyłącz moduł funkcji Deepseek.",

--- a/src/i18n/pt/common.json
+++ b/src/i18n/pt/common.json
@@ -1066,5 +1066,9 @@
   "nav.maestro": {
     "message": "Maestro",
     "description": "Texto da página de conversão de artigos em vídeos do Maestro na barra de navegação, mantenha como 'Maestro'"
+  },
+  "nav.digitalhuman": {
+    "message": "Digital Human",
+    "description": "Text in the website navigation bar for the Digital Human talking-head page"
   }
 }

--- a/src/i18n/pt/digitalhuman.json
+++ b/src/i18n/pt/digitalhuman.json
@@ -1,0 +1,154 @@
+{
+  "name.bot": {
+    "message": "Digital Human",
+    "description": "Bot display name"
+  },
+  "name.taskId": {
+    "message": "Task ID",
+    "description": "Task id"
+  },
+  "name.elapsed": {
+    "message": "Elapsed Time",
+    "description": "Elapsed seconds"
+  },
+  "name.failure": {
+    "message": "Failed",
+    "description": "Failure status"
+  },
+  "name.failureReason": {
+    "message": "Failure Reason",
+    "description": "Failure reason"
+  },
+  "name.face": {
+    "message": "Face Source",
+    "description": "Face source field"
+  },
+  "name.faceVideo": {
+    "message": "Video",
+    "description": "Face video option"
+  },
+  "name.facePhoto": {
+    "message": "Photo",
+    "description": "Face photo option"
+  },
+  "name.voice": {
+    "message": "Voice",
+    "description": "Voice source field"
+  },
+  "name.voiceAudio": {
+    "message": "Audio",
+    "description": "Audio-driven voice option"
+  },
+  "name.voiceText": {
+    "message": "Text",
+    "description": "Text-driven voice option"
+  },
+  "name.audioDriven": {
+    "message": "Audio-driven",
+    "description": "Audio-driven label"
+  },
+  "name.textDriven": {
+    "message": "Text-driven",
+    "description": "Text-driven label"
+  },
+  "name.engine": {
+    "message": "Engine",
+    "description": "Lip-sync engine field"
+  },
+  "name.resolution": {
+    "message": "Resolution",
+    "description": "Output resolution field"
+  },
+  "name.voiceReady": {
+    "message": "Voice ready",
+    "description": "Cloned voice ready label"
+  },
+  "placeholder.text": {
+    "message": "Type what the avatar should say…",
+    "description": "Spoken text placeholder"
+  },
+  "description.face": {
+    "message": "Upload a clear, front-facing face video (preferred) or a single photo to drive the talking head.",
+    "description": "Face field help"
+  },
+  "description.voiceClone": {
+    "message": "Upload a clean 10–20s voice sample to clone a voice, then reuse it to speak your text.",
+    "description": "Voice clone help"
+  },
+  "status.pending": {
+    "message": "Pending",
+    "description": "Pending"
+  },
+  "status.processing": {
+    "message": "Processing",
+    "description": "Processing"
+  },
+  "status.succeed": {
+    "message": "Succeeded",
+    "description": "Succeeded"
+  },
+  "status.failed": {
+    "message": "Failed",
+    "description": "Failed"
+  },
+  "button.generate": {
+    "message": "Generate Video",
+    "description": "Generate button"
+  },
+  "button.download": {
+    "message": "Download Video",
+    "description": "Download video button"
+  },
+  "button.uploadVideo": {
+    "message": "Upload Face Video",
+    "description": "Upload face video button"
+  },
+  "button.uploadPhoto": {
+    "message": "Upload Face Photo",
+    "description": "Upload face photo button"
+  },
+  "button.uploadAudio": {
+    "message": "Upload Audio",
+    "description": "Upload driving audio button"
+  },
+  "button.uploadSample": {
+    "message": "Upload Sample",
+    "description": "Upload voice sample button"
+  },
+  "button.clone": {
+    "message": "Clone Voice",
+    "description": "Clone voice button"
+  },
+  "button.cloning": {
+    "message": "Cloning…",
+    "description": "Cloning in progress button"
+  },
+  "message.startingTask": {
+    "message": "Submitting your video task…",
+    "description": "Submit toast"
+  },
+  "message.startTaskSuccess": {
+    "message": "Task submitted! It will appear below as it renders.",
+    "description": "Submit success"
+  },
+  "message.startTaskFailed": {
+    "message": "Failed to submit the task. Please try again.",
+    "description": "Submit fail"
+  },
+  "message.usedUp": {
+    "message": "Your balance is not sufficient for this request.",
+    "description": "Used-up toast"
+  },
+  "message.uploadError": {
+    "message": "Upload failed. Please try again.",
+    "description": "Upload error toast"
+  },
+  "message.voiceCloneSuccess": {
+    "message": "Voice cloned! You can now generate with your text.",
+    "description": "Voice clone success"
+  },
+  "message.voiceCloneFailed": {
+    "message": "Voice clone failed. Please try a cleaner sample.",
+    "description": "Voice clone fail"
+  }
+}

--- a/src/i18n/pt/site.json
+++ b/src/i18n/pt/site.json
@@ -103,6 +103,10 @@
     "message": "Maestro",
     "description": "Exibido como o título na caixa de edição"
   },
+  "field.featuresDigitalhuman": {
+    "message": "Digital Human",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresDeepseek": {
     "message": "Deepseek",
     "description": "Exibido como o título na caixa de edição"
@@ -450,6 +454,10 @@
   "message.featuresMaestro": {
     "message": "Ativar ou desativar o módulo de funcionalidades do Maestro.",
     "description": "Descrição da funcionalidade do Maestro"
+  },
+  "message.featuresDigitalhuman": {
+    "message": "Enable or disable the Digital Human feature module.",
+    "description": "Description of the Digital Human feature"
   },
   "message.featuresDeepseek": {
     "message": "Ativar ou desativar o módulo de Deepseek.",

--- a/src/i18n/ru/common.json
+++ b/src/i18n/ru/common.json
@@ -1066,5 +1066,9 @@
   "nav.maestro": {
     "message": "Маэстро",
     "description": "Текст на странице преобразования статей Maestro в видео в навигационной панели, остается как 'Маэстро'"
+  },
+  "nav.digitalhuman": {
+    "message": "Digital Human",
+    "description": "Text in the website navigation bar for the Digital Human talking-head page"
   }
 }

--- a/src/i18n/ru/digitalhuman.json
+++ b/src/i18n/ru/digitalhuman.json
@@ -1,0 +1,154 @@
+{
+  "name.bot": {
+    "message": "Digital Human",
+    "description": "Bot display name"
+  },
+  "name.taskId": {
+    "message": "Task ID",
+    "description": "Task id"
+  },
+  "name.elapsed": {
+    "message": "Elapsed Time",
+    "description": "Elapsed seconds"
+  },
+  "name.failure": {
+    "message": "Failed",
+    "description": "Failure status"
+  },
+  "name.failureReason": {
+    "message": "Failure Reason",
+    "description": "Failure reason"
+  },
+  "name.face": {
+    "message": "Face Source",
+    "description": "Face source field"
+  },
+  "name.faceVideo": {
+    "message": "Video",
+    "description": "Face video option"
+  },
+  "name.facePhoto": {
+    "message": "Photo",
+    "description": "Face photo option"
+  },
+  "name.voice": {
+    "message": "Voice",
+    "description": "Voice source field"
+  },
+  "name.voiceAudio": {
+    "message": "Audio",
+    "description": "Audio-driven voice option"
+  },
+  "name.voiceText": {
+    "message": "Text",
+    "description": "Text-driven voice option"
+  },
+  "name.audioDriven": {
+    "message": "Audio-driven",
+    "description": "Audio-driven label"
+  },
+  "name.textDriven": {
+    "message": "Text-driven",
+    "description": "Text-driven label"
+  },
+  "name.engine": {
+    "message": "Engine",
+    "description": "Lip-sync engine field"
+  },
+  "name.resolution": {
+    "message": "Resolution",
+    "description": "Output resolution field"
+  },
+  "name.voiceReady": {
+    "message": "Voice ready",
+    "description": "Cloned voice ready label"
+  },
+  "placeholder.text": {
+    "message": "Type what the avatar should say…",
+    "description": "Spoken text placeholder"
+  },
+  "description.face": {
+    "message": "Upload a clear, front-facing face video (preferred) or a single photo to drive the talking head.",
+    "description": "Face field help"
+  },
+  "description.voiceClone": {
+    "message": "Upload a clean 10–20s voice sample to clone a voice, then reuse it to speak your text.",
+    "description": "Voice clone help"
+  },
+  "status.pending": {
+    "message": "Pending",
+    "description": "Pending"
+  },
+  "status.processing": {
+    "message": "Processing",
+    "description": "Processing"
+  },
+  "status.succeed": {
+    "message": "Succeeded",
+    "description": "Succeeded"
+  },
+  "status.failed": {
+    "message": "Failed",
+    "description": "Failed"
+  },
+  "button.generate": {
+    "message": "Generate Video",
+    "description": "Generate button"
+  },
+  "button.download": {
+    "message": "Download Video",
+    "description": "Download video button"
+  },
+  "button.uploadVideo": {
+    "message": "Upload Face Video",
+    "description": "Upload face video button"
+  },
+  "button.uploadPhoto": {
+    "message": "Upload Face Photo",
+    "description": "Upload face photo button"
+  },
+  "button.uploadAudio": {
+    "message": "Upload Audio",
+    "description": "Upload driving audio button"
+  },
+  "button.uploadSample": {
+    "message": "Upload Sample",
+    "description": "Upload voice sample button"
+  },
+  "button.clone": {
+    "message": "Clone Voice",
+    "description": "Clone voice button"
+  },
+  "button.cloning": {
+    "message": "Cloning…",
+    "description": "Cloning in progress button"
+  },
+  "message.startingTask": {
+    "message": "Submitting your video task…",
+    "description": "Submit toast"
+  },
+  "message.startTaskSuccess": {
+    "message": "Task submitted! It will appear below as it renders.",
+    "description": "Submit success"
+  },
+  "message.startTaskFailed": {
+    "message": "Failed to submit the task. Please try again.",
+    "description": "Submit fail"
+  },
+  "message.usedUp": {
+    "message": "Your balance is not sufficient for this request.",
+    "description": "Used-up toast"
+  },
+  "message.uploadError": {
+    "message": "Upload failed. Please try again.",
+    "description": "Upload error toast"
+  },
+  "message.voiceCloneSuccess": {
+    "message": "Voice cloned! You can now generate with your text.",
+    "description": "Voice clone success"
+  },
+  "message.voiceCloneFailed": {
+    "message": "Voice clone failed. Please try a cleaner sample.",
+    "description": "Voice clone fail"
+  }
+}

--- a/src/i18n/ru/site.json
+++ b/src/i18n/ru/site.json
@@ -103,6 +103,10 @@
     "message": "Maestro",
     "description": "Отображается как заголовок в окне редактирования"
   },
+  "field.featuresDigitalhuman": {
+    "message": "Digital Human",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresDeepseek": {
     "message": "Deepseek",
     "description": "展示在编辑框的标题"
@@ -450,6 +454,10 @@
   "message.featuresMaestro": {
     "message": "Включите или отключите модуль функции Maestro.",
     "description": "Описание функции Maestro"
+  },
+  "message.featuresDigitalhuman": {
+    "message": "Enable or disable the Digital Human feature module.",
+    "description": "Description of the Digital Human feature"
   },
   "message.featuresDeepseek": {
     "message": "Включить или отключить модуль функции Deepseek.",

--- a/src/i18n/sr/common.json
+++ b/src/i18n/sr/common.json
@@ -1066,5 +1066,9 @@
   "nav.maestro": {
     "message": "Maestro",
     "description": "Текст на страници за претварање Maestro чланака у видео у навигационом менију, остаје 'Maestro'"
+  },
+  "nav.digitalhuman": {
+    "message": "Digital Human",
+    "description": "Text in the website navigation bar for the Digital Human talking-head page"
   }
 }

--- a/src/i18n/sr/digitalhuman.json
+++ b/src/i18n/sr/digitalhuman.json
@@ -1,0 +1,154 @@
+{
+  "name.bot": {
+    "message": "Digital Human",
+    "description": "Bot display name"
+  },
+  "name.taskId": {
+    "message": "Task ID",
+    "description": "Task id"
+  },
+  "name.elapsed": {
+    "message": "Elapsed Time",
+    "description": "Elapsed seconds"
+  },
+  "name.failure": {
+    "message": "Failed",
+    "description": "Failure status"
+  },
+  "name.failureReason": {
+    "message": "Failure Reason",
+    "description": "Failure reason"
+  },
+  "name.face": {
+    "message": "Face Source",
+    "description": "Face source field"
+  },
+  "name.faceVideo": {
+    "message": "Video",
+    "description": "Face video option"
+  },
+  "name.facePhoto": {
+    "message": "Photo",
+    "description": "Face photo option"
+  },
+  "name.voice": {
+    "message": "Voice",
+    "description": "Voice source field"
+  },
+  "name.voiceAudio": {
+    "message": "Audio",
+    "description": "Audio-driven voice option"
+  },
+  "name.voiceText": {
+    "message": "Text",
+    "description": "Text-driven voice option"
+  },
+  "name.audioDriven": {
+    "message": "Audio-driven",
+    "description": "Audio-driven label"
+  },
+  "name.textDriven": {
+    "message": "Text-driven",
+    "description": "Text-driven label"
+  },
+  "name.engine": {
+    "message": "Engine",
+    "description": "Lip-sync engine field"
+  },
+  "name.resolution": {
+    "message": "Resolution",
+    "description": "Output resolution field"
+  },
+  "name.voiceReady": {
+    "message": "Voice ready",
+    "description": "Cloned voice ready label"
+  },
+  "placeholder.text": {
+    "message": "Type what the avatar should say…",
+    "description": "Spoken text placeholder"
+  },
+  "description.face": {
+    "message": "Upload a clear, front-facing face video (preferred) or a single photo to drive the talking head.",
+    "description": "Face field help"
+  },
+  "description.voiceClone": {
+    "message": "Upload a clean 10–20s voice sample to clone a voice, then reuse it to speak your text.",
+    "description": "Voice clone help"
+  },
+  "status.pending": {
+    "message": "Pending",
+    "description": "Pending"
+  },
+  "status.processing": {
+    "message": "Processing",
+    "description": "Processing"
+  },
+  "status.succeed": {
+    "message": "Succeeded",
+    "description": "Succeeded"
+  },
+  "status.failed": {
+    "message": "Failed",
+    "description": "Failed"
+  },
+  "button.generate": {
+    "message": "Generate Video",
+    "description": "Generate button"
+  },
+  "button.download": {
+    "message": "Download Video",
+    "description": "Download video button"
+  },
+  "button.uploadVideo": {
+    "message": "Upload Face Video",
+    "description": "Upload face video button"
+  },
+  "button.uploadPhoto": {
+    "message": "Upload Face Photo",
+    "description": "Upload face photo button"
+  },
+  "button.uploadAudio": {
+    "message": "Upload Audio",
+    "description": "Upload driving audio button"
+  },
+  "button.uploadSample": {
+    "message": "Upload Sample",
+    "description": "Upload voice sample button"
+  },
+  "button.clone": {
+    "message": "Clone Voice",
+    "description": "Clone voice button"
+  },
+  "button.cloning": {
+    "message": "Cloning…",
+    "description": "Cloning in progress button"
+  },
+  "message.startingTask": {
+    "message": "Submitting your video task…",
+    "description": "Submit toast"
+  },
+  "message.startTaskSuccess": {
+    "message": "Task submitted! It will appear below as it renders.",
+    "description": "Submit success"
+  },
+  "message.startTaskFailed": {
+    "message": "Failed to submit the task. Please try again.",
+    "description": "Submit fail"
+  },
+  "message.usedUp": {
+    "message": "Your balance is not sufficient for this request.",
+    "description": "Used-up toast"
+  },
+  "message.uploadError": {
+    "message": "Upload failed. Please try again.",
+    "description": "Upload error toast"
+  },
+  "message.voiceCloneSuccess": {
+    "message": "Voice cloned! You can now generate with your text.",
+    "description": "Voice clone success"
+  },
+  "message.voiceCloneFailed": {
+    "message": "Voice clone failed. Please try a cleaner sample.",
+    "description": "Voice clone fail"
+  }
+}

--- a/src/i18n/sr/site.json
+++ b/src/i18n/sr/site.json
@@ -103,6 +103,10 @@
     "message": "Maestro",
     "description": "Prikazuje se kao naslov u okviru za uređivanje"
   },
+  "field.featuresDigitalhuman": {
+    "message": "Digital Human",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresDeepseek": {
     "message": "Deepseek",
     "description": "Prikazuje se kao naslov u okviru za uređivanje"
@@ -450,6 +454,10 @@
   "message.featuresMaestro": {
     "message": "Omogućite ili onemogućite Maestro funkcionalnost.",
     "description": "Opis Maestro funkcionalnosti"
+  },
+  "message.featuresDigitalhuman": {
+    "message": "Enable or disable the Digital Human feature module.",
+    "description": "Description of the Digital Human feature"
   },
   "message.featuresDeepseek": {
     "message": "Укључи или искључи Deepseek модул.",

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -1066,5 +1066,9 @@
   "nav.maestro": {
     "message": "Maestro",
     "description": "Texten för Maestro-artikeln på videoproduktionssidan i navigeringsfältet, hålls som 'Maestro'"
+  },
+  "nav.digitalhuman": {
+    "message": "Digital Human",
+    "description": "Text in the website navigation bar for the Digital Human talking-head page"
   }
 }

--- a/src/i18n/sv/digitalhuman.json
+++ b/src/i18n/sv/digitalhuman.json
@@ -1,0 +1,154 @@
+{
+  "name.bot": {
+    "message": "Digital Human",
+    "description": "Bot display name"
+  },
+  "name.taskId": {
+    "message": "Task ID",
+    "description": "Task id"
+  },
+  "name.elapsed": {
+    "message": "Elapsed Time",
+    "description": "Elapsed seconds"
+  },
+  "name.failure": {
+    "message": "Failed",
+    "description": "Failure status"
+  },
+  "name.failureReason": {
+    "message": "Failure Reason",
+    "description": "Failure reason"
+  },
+  "name.face": {
+    "message": "Face Source",
+    "description": "Face source field"
+  },
+  "name.faceVideo": {
+    "message": "Video",
+    "description": "Face video option"
+  },
+  "name.facePhoto": {
+    "message": "Photo",
+    "description": "Face photo option"
+  },
+  "name.voice": {
+    "message": "Voice",
+    "description": "Voice source field"
+  },
+  "name.voiceAudio": {
+    "message": "Audio",
+    "description": "Audio-driven voice option"
+  },
+  "name.voiceText": {
+    "message": "Text",
+    "description": "Text-driven voice option"
+  },
+  "name.audioDriven": {
+    "message": "Audio-driven",
+    "description": "Audio-driven label"
+  },
+  "name.textDriven": {
+    "message": "Text-driven",
+    "description": "Text-driven label"
+  },
+  "name.engine": {
+    "message": "Engine",
+    "description": "Lip-sync engine field"
+  },
+  "name.resolution": {
+    "message": "Resolution",
+    "description": "Output resolution field"
+  },
+  "name.voiceReady": {
+    "message": "Voice ready",
+    "description": "Cloned voice ready label"
+  },
+  "placeholder.text": {
+    "message": "Type what the avatar should say…",
+    "description": "Spoken text placeholder"
+  },
+  "description.face": {
+    "message": "Upload a clear, front-facing face video (preferred) or a single photo to drive the talking head.",
+    "description": "Face field help"
+  },
+  "description.voiceClone": {
+    "message": "Upload a clean 10–20s voice sample to clone a voice, then reuse it to speak your text.",
+    "description": "Voice clone help"
+  },
+  "status.pending": {
+    "message": "Pending",
+    "description": "Pending"
+  },
+  "status.processing": {
+    "message": "Processing",
+    "description": "Processing"
+  },
+  "status.succeed": {
+    "message": "Succeeded",
+    "description": "Succeeded"
+  },
+  "status.failed": {
+    "message": "Failed",
+    "description": "Failed"
+  },
+  "button.generate": {
+    "message": "Generate Video",
+    "description": "Generate button"
+  },
+  "button.download": {
+    "message": "Download Video",
+    "description": "Download video button"
+  },
+  "button.uploadVideo": {
+    "message": "Upload Face Video",
+    "description": "Upload face video button"
+  },
+  "button.uploadPhoto": {
+    "message": "Upload Face Photo",
+    "description": "Upload face photo button"
+  },
+  "button.uploadAudio": {
+    "message": "Upload Audio",
+    "description": "Upload driving audio button"
+  },
+  "button.uploadSample": {
+    "message": "Upload Sample",
+    "description": "Upload voice sample button"
+  },
+  "button.clone": {
+    "message": "Clone Voice",
+    "description": "Clone voice button"
+  },
+  "button.cloning": {
+    "message": "Cloning…",
+    "description": "Cloning in progress button"
+  },
+  "message.startingTask": {
+    "message": "Submitting your video task…",
+    "description": "Submit toast"
+  },
+  "message.startTaskSuccess": {
+    "message": "Task submitted! It will appear below as it renders.",
+    "description": "Submit success"
+  },
+  "message.startTaskFailed": {
+    "message": "Failed to submit the task. Please try again.",
+    "description": "Submit fail"
+  },
+  "message.usedUp": {
+    "message": "Your balance is not sufficient for this request.",
+    "description": "Used-up toast"
+  },
+  "message.uploadError": {
+    "message": "Upload failed. Please try again.",
+    "description": "Upload error toast"
+  },
+  "message.voiceCloneSuccess": {
+    "message": "Voice cloned! You can now generate with your text.",
+    "description": "Voice clone success"
+  },
+  "message.voiceCloneFailed": {
+    "message": "Voice clone failed. Please try a cleaner sample.",
+    "description": "Voice clone fail"
+  }
+}

--- a/src/i18n/sv/site.json
+++ b/src/i18n/sv/site.json
@@ -103,6 +103,10 @@
     "message": "Maestro",
     "description": "Visas som titeln i redigeringsrutan"
   },
+  "field.featuresDigitalhuman": {
+    "message": "Digital Human",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresDeepseek": {
     "message": "Deepseek",
     "description": "Visas som titeln i redigeringsrutan"
@@ -450,6 +454,10 @@
   "message.featuresMaestro": {
     "message": "Aktivera eller inaktivera Maestro-funktionmodulen.",
     "description": "Beskrivning av Maestro-funktionen"
+  },
+  "message.featuresDigitalhuman": {
+    "message": "Enable or disable the Digital Human feature module.",
+    "description": "Description of the Digital Human feature"
   },
   "message.featuresDeepseek": {
     "message": "Aktivera eller inaktivera Deepseek-funktion.",

--- a/src/i18n/uk/common.json
+++ b/src/i18n/uk/common.json
@@ -1066,5 +1066,9 @@
   "nav.maestro": {
     "message": "Maestro",
     "description": "Текст на сторінці перетворення статей Maestro на відео в навігаційній панелі, залишити як 'Maestro'"
+  },
+  "nav.digitalhuman": {
+    "message": "Digital Human",
+    "description": "Text in the website navigation bar for the Digital Human talking-head page"
   }
 }

--- a/src/i18n/uk/digitalhuman.json
+++ b/src/i18n/uk/digitalhuman.json
@@ -1,0 +1,154 @@
+{
+  "name.bot": {
+    "message": "Digital Human",
+    "description": "Bot display name"
+  },
+  "name.taskId": {
+    "message": "Task ID",
+    "description": "Task id"
+  },
+  "name.elapsed": {
+    "message": "Elapsed Time",
+    "description": "Elapsed seconds"
+  },
+  "name.failure": {
+    "message": "Failed",
+    "description": "Failure status"
+  },
+  "name.failureReason": {
+    "message": "Failure Reason",
+    "description": "Failure reason"
+  },
+  "name.face": {
+    "message": "Face Source",
+    "description": "Face source field"
+  },
+  "name.faceVideo": {
+    "message": "Video",
+    "description": "Face video option"
+  },
+  "name.facePhoto": {
+    "message": "Photo",
+    "description": "Face photo option"
+  },
+  "name.voice": {
+    "message": "Voice",
+    "description": "Voice source field"
+  },
+  "name.voiceAudio": {
+    "message": "Audio",
+    "description": "Audio-driven voice option"
+  },
+  "name.voiceText": {
+    "message": "Text",
+    "description": "Text-driven voice option"
+  },
+  "name.audioDriven": {
+    "message": "Audio-driven",
+    "description": "Audio-driven label"
+  },
+  "name.textDriven": {
+    "message": "Text-driven",
+    "description": "Text-driven label"
+  },
+  "name.engine": {
+    "message": "Engine",
+    "description": "Lip-sync engine field"
+  },
+  "name.resolution": {
+    "message": "Resolution",
+    "description": "Output resolution field"
+  },
+  "name.voiceReady": {
+    "message": "Voice ready",
+    "description": "Cloned voice ready label"
+  },
+  "placeholder.text": {
+    "message": "Type what the avatar should say…",
+    "description": "Spoken text placeholder"
+  },
+  "description.face": {
+    "message": "Upload a clear, front-facing face video (preferred) or a single photo to drive the talking head.",
+    "description": "Face field help"
+  },
+  "description.voiceClone": {
+    "message": "Upload a clean 10–20s voice sample to clone a voice, then reuse it to speak your text.",
+    "description": "Voice clone help"
+  },
+  "status.pending": {
+    "message": "Pending",
+    "description": "Pending"
+  },
+  "status.processing": {
+    "message": "Processing",
+    "description": "Processing"
+  },
+  "status.succeed": {
+    "message": "Succeeded",
+    "description": "Succeeded"
+  },
+  "status.failed": {
+    "message": "Failed",
+    "description": "Failed"
+  },
+  "button.generate": {
+    "message": "Generate Video",
+    "description": "Generate button"
+  },
+  "button.download": {
+    "message": "Download Video",
+    "description": "Download video button"
+  },
+  "button.uploadVideo": {
+    "message": "Upload Face Video",
+    "description": "Upload face video button"
+  },
+  "button.uploadPhoto": {
+    "message": "Upload Face Photo",
+    "description": "Upload face photo button"
+  },
+  "button.uploadAudio": {
+    "message": "Upload Audio",
+    "description": "Upload driving audio button"
+  },
+  "button.uploadSample": {
+    "message": "Upload Sample",
+    "description": "Upload voice sample button"
+  },
+  "button.clone": {
+    "message": "Clone Voice",
+    "description": "Clone voice button"
+  },
+  "button.cloning": {
+    "message": "Cloning…",
+    "description": "Cloning in progress button"
+  },
+  "message.startingTask": {
+    "message": "Submitting your video task…",
+    "description": "Submit toast"
+  },
+  "message.startTaskSuccess": {
+    "message": "Task submitted! It will appear below as it renders.",
+    "description": "Submit success"
+  },
+  "message.startTaskFailed": {
+    "message": "Failed to submit the task. Please try again.",
+    "description": "Submit fail"
+  },
+  "message.usedUp": {
+    "message": "Your balance is not sufficient for this request.",
+    "description": "Used-up toast"
+  },
+  "message.uploadError": {
+    "message": "Upload failed. Please try again.",
+    "description": "Upload error toast"
+  },
+  "message.voiceCloneSuccess": {
+    "message": "Voice cloned! You can now generate with your text.",
+    "description": "Voice clone success"
+  },
+  "message.voiceCloneFailed": {
+    "message": "Voice clone failed. Please try a cleaner sample.",
+    "description": "Voice clone fail"
+  }
+}

--- a/src/i18n/uk/site.json
+++ b/src/i18n/uk/site.json
@@ -103,6 +103,10 @@
     "message": "Maestro",
     "description": "Відображається як заголовок у полі редагування"
   },
+  "field.featuresDigitalhuman": {
+    "message": "Digital Human",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresDeepseek": {
     "message": "Deepseek",
     "description": "展示在编辑框的标题"
@@ -450,6 +454,10 @@
   "message.featuresMaestro": {
     "message": "Увімкнути або вимкнути модуль функцій Maestro.",
     "description": "Опис функції Maestro"
+  },
+  "message.featuresDigitalhuman": {
+    "message": "Enable or disable the Digital Human feature module.",
+    "description": "Description of the Digital Human feature"
   },
   "message.featuresDeepseek": {
     "message": "Увімкнути або вимкнути модуль функції Deepseek.",

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -1066,5 +1066,9 @@
   "nav.maestro": {
     "message": "Maestro",
     "description": "导航栏中 Maestro 文章转视频页面的文字,保持为 'Maestro'"
+  },
+  "nav.digitalhuman": {
+    "message": "数字人",
+    "description": "导航栏中数字人口播页面的文字"
   }
 }

--- a/src/i18n/zh-CN/digitalhuman.json
+++ b/src/i18n/zh-CN/digitalhuman.json
@@ -1,0 +1,154 @@
+{
+  "name.bot": {
+    "message": "数字人",
+    "description": "Bot display name"
+  },
+  "name.taskId": {
+    "message": "任务 ID",
+    "description": "Task id"
+  },
+  "name.elapsed": {
+    "message": "耗时",
+    "description": "Elapsed seconds"
+  },
+  "name.failure": {
+    "message": "失败",
+    "description": "Failure status"
+  },
+  "name.failureReason": {
+    "message": "失败原因",
+    "description": "Failure reason"
+  },
+  "name.face": {
+    "message": "面部来源",
+    "description": "Face source field"
+  },
+  "name.faceVideo": {
+    "message": "视频",
+    "description": "Face video option"
+  },
+  "name.facePhoto": {
+    "message": "照片",
+    "description": "Face photo option"
+  },
+  "name.voice": {
+    "message": "声音",
+    "description": "Voice source field"
+  },
+  "name.voiceAudio": {
+    "message": "音频",
+    "description": "Audio-driven voice option"
+  },
+  "name.voiceText": {
+    "message": "文本",
+    "description": "Text-driven voice option"
+  },
+  "name.audioDriven": {
+    "message": "音频驱动",
+    "description": "Audio-driven label"
+  },
+  "name.textDriven": {
+    "message": "文本驱动",
+    "description": "Text-driven label"
+  },
+  "name.engine": {
+    "message": "引擎",
+    "description": "Lip-sync engine field"
+  },
+  "name.resolution": {
+    "message": "分辨率",
+    "description": "Output resolution field"
+  },
+  "name.voiceReady": {
+    "message": "音色已就绪",
+    "description": "Cloned voice ready label"
+  },
+  "placeholder.text": {
+    "message": "输入数字人要说的内容……",
+    "description": "Spoken text placeholder"
+  },
+  "description.face": {
+    "message": "上传清晰的正脸视频（推荐）或一张照片来驱动口播数字人。",
+    "description": "Face field help"
+  },
+  "description.voiceClone": {
+    "message": "上传一段干净的 10–20 秒人声样本克隆音色，再用它朗读你的文本。",
+    "description": "Voice clone help"
+  },
+  "status.pending": {
+    "message": "排队中",
+    "description": "Pending"
+  },
+  "status.processing": {
+    "message": "处理中",
+    "description": "Processing"
+  },
+  "status.succeed": {
+    "message": "已完成",
+    "description": "Succeeded"
+  },
+  "status.failed": {
+    "message": "失败",
+    "description": "Failed"
+  },
+  "button.generate": {
+    "message": "生成视频",
+    "description": "Generate button"
+  },
+  "button.download": {
+    "message": "下载视频",
+    "description": "Download video button"
+  },
+  "button.uploadVideo": {
+    "message": "上传面部视频",
+    "description": "Upload face video button"
+  },
+  "button.uploadPhoto": {
+    "message": "上传面部照片",
+    "description": "Upload face photo button"
+  },
+  "button.uploadAudio": {
+    "message": "上传音频",
+    "description": "Upload driving audio button"
+  },
+  "button.uploadSample": {
+    "message": "上传样本",
+    "description": "Upload voice sample button"
+  },
+  "button.clone": {
+    "message": "克隆音色",
+    "description": "Clone voice button"
+  },
+  "button.cloning": {
+    "message": "克隆中……",
+    "description": "Cloning in progress button"
+  },
+  "message.startingTask": {
+    "message": "正在提交视频任务……",
+    "description": "Submit toast"
+  },
+  "message.startTaskSuccess": {
+    "message": "任务已提交！生成后会显示在下方。",
+    "description": "Submit success"
+  },
+  "message.startTaskFailed": {
+    "message": "任务提交失败，请重试。",
+    "description": "Submit fail"
+  },
+  "message.usedUp": {
+    "message": "余额不足，无法完成本次请求。",
+    "description": "Used-up toast"
+  },
+  "message.uploadError": {
+    "message": "上传失败，请重试。",
+    "description": "Upload error toast"
+  },
+  "message.voiceCloneSuccess": {
+    "message": "音色克隆成功！现在可以用文本生成了。",
+    "description": "Voice clone success"
+  },
+  "message.voiceCloneFailed": {
+    "message": "音色克隆失败，请换一段更干净的样本。",
+    "description": "Voice clone fail"
+  }
+}

--- a/src/i18n/zh-CN/site.json
+++ b/src/i18n/zh-CN/site.json
@@ -103,6 +103,10 @@
     "message": "Maestro",
     "description": "Displayed as the title in the editing box"
   },
+  "field.featuresDigitalhuman": {
+    "message": "数字人",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresDeepseek": {
     "message": "Deepseek",
     "description": "展示在编辑框的标题"
@@ -450,6 +454,10 @@
   "message.featuresMaestro": {
     "message": "启用或禁用 Maestro 功能模块。",
     "description": "Maestro功能的描述"
+  },
+  "message.featuresDigitalhuman": {
+    "message": "启用或禁用数字人功能模块。",
+    "description": "数字人功能的描述"
   },
   "message.featuresDeepseek": {
     "message": "打开或关闭 Deepseek 功能模块。",

--- a/src/i18n/zh-TW/common.json
+++ b/src/i18n/zh-TW/common.json
@@ -1066,5 +1066,9 @@
   "nav.maestro": {
     "message": "Maestro",
     "description": "導航欄中 Maestro 文章轉視頻頁面的文字,保持為 'Maestro'"
+  },
+  "nav.digitalhuman": {
+    "message": "數字人",
+    "description": "Text in the website navigation bar for the Digital Human talking-head page"
   }
 }

--- a/src/i18n/zh-TW/digitalhuman.json
+++ b/src/i18n/zh-TW/digitalhuman.json
@@ -1,0 +1,154 @@
+{
+  "name.bot": {
+    "message": "数字人",
+    "description": "Bot display name"
+  },
+  "name.taskId": {
+    "message": "任务 ID",
+    "description": "Task id"
+  },
+  "name.elapsed": {
+    "message": "耗时",
+    "description": "Elapsed seconds"
+  },
+  "name.failure": {
+    "message": "失败",
+    "description": "Failure status"
+  },
+  "name.failureReason": {
+    "message": "失败原因",
+    "description": "Failure reason"
+  },
+  "name.face": {
+    "message": "面部来源",
+    "description": "Face source field"
+  },
+  "name.faceVideo": {
+    "message": "视频",
+    "description": "Face video option"
+  },
+  "name.facePhoto": {
+    "message": "照片",
+    "description": "Face photo option"
+  },
+  "name.voice": {
+    "message": "声音",
+    "description": "Voice source field"
+  },
+  "name.voiceAudio": {
+    "message": "音频",
+    "description": "Audio-driven voice option"
+  },
+  "name.voiceText": {
+    "message": "文本",
+    "description": "Text-driven voice option"
+  },
+  "name.audioDriven": {
+    "message": "音频驱动",
+    "description": "Audio-driven label"
+  },
+  "name.textDriven": {
+    "message": "文本驱动",
+    "description": "Text-driven label"
+  },
+  "name.engine": {
+    "message": "引擎",
+    "description": "Lip-sync engine field"
+  },
+  "name.resolution": {
+    "message": "分辨率",
+    "description": "Output resolution field"
+  },
+  "name.voiceReady": {
+    "message": "音色已就绪",
+    "description": "Cloned voice ready label"
+  },
+  "placeholder.text": {
+    "message": "输入数字人要说的内容……",
+    "description": "Spoken text placeholder"
+  },
+  "description.face": {
+    "message": "上传清晰的正脸视频（推荐）或一张照片来驱动口播数字人。",
+    "description": "Face field help"
+  },
+  "description.voiceClone": {
+    "message": "上传一段干净的 10–20 秒人声样本克隆音色，再用它朗读你的文本。",
+    "description": "Voice clone help"
+  },
+  "status.pending": {
+    "message": "排队中",
+    "description": "Pending"
+  },
+  "status.processing": {
+    "message": "处理中",
+    "description": "Processing"
+  },
+  "status.succeed": {
+    "message": "已完成",
+    "description": "Succeeded"
+  },
+  "status.failed": {
+    "message": "失败",
+    "description": "Failed"
+  },
+  "button.generate": {
+    "message": "生成视频",
+    "description": "Generate button"
+  },
+  "button.download": {
+    "message": "下载视频",
+    "description": "Download video button"
+  },
+  "button.uploadVideo": {
+    "message": "上传面部视频",
+    "description": "Upload face video button"
+  },
+  "button.uploadPhoto": {
+    "message": "上传面部照片",
+    "description": "Upload face photo button"
+  },
+  "button.uploadAudio": {
+    "message": "上传音频",
+    "description": "Upload driving audio button"
+  },
+  "button.uploadSample": {
+    "message": "上传样本",
+    "description": "Upload voice sample button"
+  },
+  "button.clone": {
+    "message": "克隆音色",
+    "description": "Clone voice button"
+  },
+  "button.cloning": {
+    "message": "克隆中……",
+    "description": "Cloning in progress button"
+  },
+  "message.startingTask": {
+    "message": "正在提交视频任务……",
+    "description": "Submit toast"
+  },
+  "message.startTaskSuccess": {
+    "message": "任务已提交！生成后会显示在下方。",
+    "description": "Submit success"
+  },
+  "message.startTaskFailed": {
+    "message": "任务提交失败，请重试。",
+    "description": "Submit fail"
+  },
+  "message.usedUp": {
+    "message": "余额不足，无法完成本次请求。",
+    "description": "Used-up toast"
+  },
+  "message.uploadError": {
+    "message": "上传失败，请重试。",
+    "description": "Upload error toast"
+  },
+  "message.voiceCloneSuccess": {
+    "message": "音色克隆成功！现在可以用文本生成了。",
+    "description": "Voice clone success"
+  },
+  "message.voiceCloneFailed": {
+    "message": "音色克隆失败，请换一段更干净的样本。",
+    "description": "Voice clone fail"
+  }
+}

--- a/src/i18n/zh-TW/site.json
+++ b/src/i18n/zh-TW/site.json
@@ -103,6 +103,10 @@
     "message": "Maestro",
     "description": "顯示為編輯框中的標題"
   },
+  "field.featuresDigitalhuman": {
+    "message": "數字人",
+    "description": "Displayed as the title in the editing box"
+  },
   "field.featuresDeepseek": {
     "message": "Deepseek",
     "description": "展示在編輯框的標題"
@@ -450,6 +454,10 @@
   "message.featuresMaestro": {
     "message": "啟用或禁用 Maestro 功能模組。",
     "description": "Maestro 功能的描述"
+  },
+  "message.featuresDigitalhuman": {
+    "message": "啟用或停用數字人功能模組。",
+    "description": "Description of the Digital Human feature"
   },
   "message.featuresDeepseek": {
     "message": "開啟或關閉 Deepseek 功能模塊。",

--- a/src/layouts/DigitalHuman.vue
+++ b/src/layouts/DigitalHuman.vue
@@ -1,0 +1,57 @@
+<template>
+  <div class="main flex flex-row flex-1">
+    <div
+      class="config w-[320px] flex-none h-full overflow-y-auto bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+    >
+      <slot name="config" />
+    </div>
+    <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
+      <slot name="result" />
+    </div>
+    <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
+      <font-awesome-icon icon="fa-solid fa-user" />
+    </el-button>
+    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="350px">
+      <slot name="config" />
+    </el-drawer>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElDrawer, ElButton } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import taskDrawerMixin from '@/utils/taskDrawerMixin';
+
+export default defineComponent({
+  name: 'LayoutDigitalHuman',
+  components: {
+    ElDrawer,
+    ElButton,
+    FontAwesomeIcon
+  },
+  mixins: [taskDrawerMixin]
+});
+</script>
+
+<style lang="scss" scoped>
+.menu {
+  display: none;
+}
+
+@media (max-width: 767px) {
+  .config {
+    display: none;
+  }
+  .result {
+    width: 100%;
+  }
+  .menu {
+    display: block;
+    position: absolute;
+    right: 8px;
+    top: calc(45px + var(--app-safe-area-top));
+    z-index: 1000;
+  }
+}
+</style>

--- a/src/models/digitalhuman.ts
+++ b/src/models/digitalhuman.ts
@@ -1,0 +1,91 @@
+export type IDigitalHumanEngine = 'latentsync' | 'heygem';
+export type IDigitalHumanResolution = '720p' | '540p';
+export type IDigitalHumanLang = 'zh' | 'en';
+
+export interface IDigitalHumanConfig {
+  // face source — one of video_url (preferred) / image_url
+  video_url?: string;
+  image_url?: string;
+  // voice source — audio_url, or text + voice_id (cloned)
+  audio_url?: string;
+  text?: string;
+  voice_id?: string;
+  // options
+  engine?: IDigitalHumanEngine;
+  resolution?: IDigitalHumanResolution;
+  speed?: number;
+  callback_url?: string;
+  async?: boolean;
+}
+
+export type IDigitalHumanGenerateRequest = {
+  video_url?: string;
+  image_url?: string;
+  audio_url?: string;
+  text?: string;
+  voice_id?: string;
+  engine?: IDigitalHumanEngine;
+  resolution?: IDigitalHumanResolution;
+  speed?: number;
+  callback_url?: string;
+  async?: boolean;
+};
+
+// Flat single-poll / history `response` shape (matches the worker `public()` view).
+export interface IDigitalHumanGenerateResponse {
+  success: boolean;
+  task_id: string;
+  trace_id?: string;
+  state?: string;
+  progress?: number;
+  video_url?: string;
+  duration?: number;
+  width?: number;
+  height?: number;
+  engine?: string;
+  voice_id?: string;
+  error?:
+    | string
+    | {
+        code?: string;
+        message?: string;
+      };
+}
+
+export interface IDigitalHumanVoiceRequest {
+  audio_url: string;
+  lang?: IDigitalHumanLang;
+  name?: string;
+  async?: boolean;
+}
+
+export interface IDigitalHumanVoiceResponse {
+  success: boolean;
+  task_id: string;
+  trace_id?: string;
+  state?: string;
+  voice_id?: string;
+  error?:
+    | string
+    | {
+        code?: string;
+        message?: string;
+      };
+}
+
+export interface IDigitalHumanTask {
+  id: string;
+  status?: string;
+  kind?: string;
+  created_at?: number;
+  elapsed?: number;
+  request?: IDigitalHumanGenerateRequest;
+  response?: IDigitalHumanGenerateResponse;
+}
+
+export type IDigitalHumanTaskResponse = IDigitalHumanTask;
+
+export interface IDigitalHumanTasksResponse {
+  count: number;
+  items: IDigitalHumanTask[];
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -17,6 +17,7 @@ export * from './kling';
 export * from './veo';
 export * from './sora';
 export * from './maestro';
+export * from './digitalhuman';
 export * from './pixverse';
 export * from './flux';
 export * from './hailuo';

--- a/src/models/site.ts
+++ b/src/models/site.ts
@@ -13,6 +13,7 @@ export interface ISiteFeatures {
   veo?: any;
   sora?: any;
   maestro?: any;
+  digitalhuman?: any;
   pixverse?: any;
   hailuo?: any;
   headshots?: any;

--- a/src/operators/digitalhuman.ts
+++ b/src/operators/digitalhuman.ts
@@ -1,0 +1,57 @@
+import axios, { AxiosResponse } from 'axios';
+import { BASE_URL_API } from '@/constants';
+import {
+  IDigitalHumanGenerateRequest,
+  IDigitalHumanGenerateResponse,
+  IDigitalHumanTaskResponse,
+  IDigitalHumanTasksResponse,
+  IDigitalHumanVoiceRequest,
+  IDigitalHumanVoiceResponse
+} from '@/models';
+import { BaseTaskOperator, ITaskListFilter } from './baseTaskOperator';
+
+class DigitalHumanOperator extends BaseTaskOperator<
+  IDigitalHumanGenerateRequest,
+  IDigitalHumanGenerateResponse,
+  IDigitalHumanTaskResponse,
+  IDigitalHumanTasksResponse,
+  ITaskListFilter & { type?: string }
+> {
+  constructor() {
+    super({ tasksPath: '/digital-human/tasks', generatePath: '/digital-human/videos' });
+  }
+
+  /** Clone a voice sample into a reusable voice_id (async — poll with `pollTask`). */
+  async cloneVoice(
+    data: IDigitalHumanVoiceRequest,
+    options: { token: string }
+  ): Promise<AxiosResponse<IDigitalHumanVoiceResponse>> {
+    return axios.post('/digital-human/voices', data, {
+      baseURL: BASE_URL_API,
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json',
+        authorization: `Bearer ${options.token}`
+      }
+    });
+  }
+
+  /** Poll a single task (voice clone or video) by task_id — the flat external shape. */
+  async pollTask(taskId: string, options: { token: string }): Promise<AxiosResponse<IDigitalHumanGenerateResponse>> {
+    return axios.post(
+      '/digital-human/tasks',
+      { task_id: taskId },
+      {
+        baseURL: BASE_URL_API,
+        headers: {
+          'content-type': 'application/json',
+          accept: 'application/json',
+          'x-record-exempt': 'true',
+          authorization: `Bearer ${options.token}`
+        }
+      }
+    );
+  }
+}
+
+export const digitalHumanOperator = new DigitalHumanOperator();

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -18,6 +18,7 @@ export * from './kling';
 export * from './veo';
 export * from './sora';
 export * from './maestro';
+export * from './digitalhuman';
 export * from './pixverse';
 export * from './flux';
 export * from './hailuo';

--- a/src/pages/digitalhuman/Index.vue
+++ b/src/pages/digitalhuman/Index.vue
@@ -1,0 +1,149 @@
+<template>
+  <layout>
+    <template #config>
+      <config-panel @generate="onGenerate" />
+    </template>
+    <template #result>
+      <recent-panel ref="recentPanel" :loading="loadingMore" @reach-top="onReachTop" />
+    </template>
+  </layout>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import Layout from '@/layouts/DigitalHuman.vue';
+import ConfigPanel from '@/components/digitalhuman/ConfigPanel.vue';
+import RecentPanel from '@/components/digitalhuman/RecentPanel.vue';
+import { digitalHumanOperator } from '@/operators';
+import { instrumentGeneration } from '@/plugins/telemetry';
+import { IDigitalHumanGenerateRequest, Status } from '@/models';
+import { ElMessage } from 'element-plus';
+import { ERROR_CODE_USED_UP } from '@/constants';
+import { loadPreviousPage } from '@/utils/pagination';
+
+interface IData {
+  job: number;
+  loadingMore: boolean;
+  fetchingTasks: boolean;
+}
+
+export default defineComponent({
+  name: 'DigitalHumanIndex',
+  components: {
+    ConfigPanel,
+    Layout,
+    RecentPanel
+  },
+  inject: ['initialized'],
+  data(): IData {
+    return {
+      job: 0,
+      loadingMore: false,
+      fetchingTasks: false
+    };
+  },
+  computed: {
+    applicationsLoading() {
+      return this.$store.state.digitalhuman?.status?.getApplications === Status.Request;
+    },
+    tasksLoading() {
+      return this.$store.state.digitalhuman?.status?.getTasks === Status.Request || this.fetchingTasks;
+    },
+    credential() {
+      return this.$store.state.digitalhuman.credential;
+    },
+    config() {
+      return this.$store.state.digitalhuman.config;
+    },
+    tasks() {
+      return this.$store.state.digitalhuman.tasks;
+    }
+  },
+  watch: {
+    initialized: {
+      async handler(newValue) {
+        window.clearInterval(this.job);
+        if (newValue) {
+          await this.onGetTasks();
+          await this.onScrollDown();
+          this.job = window.setInterval(() => {
+            this.onGetTasks();
+          }, 5000);
+        }
+      },
+      immediate: true
+    }
+  },
+  async mounted() {
+    await this.onGetService();
+  },
+  async unmounted() {
+    window.clearInterval(this.job);
+  },
+  methods: {
+    async onReachTop() {
+      await loadPreviousPage({
+        tasks: this.tasks,
+        getTasks: () => this.tasks,
+        loading: this.loadingMore,
+        setLoading: (v) => (this.loadingMore = v),
+        isBlocked: () => this.tasksLoading || this.applicationsLoading,
+        fetch: (createdAtMax) => this.onGetTasks({ createdAtMax }),
+        getScrollElement: () => this.getTasksScrollElement()
+      });
+    },
+    async onGetService() {
+      await this.$store.dispatch('digitalhuman/getService');
+    },
+    async onScrollDown() {
+      await this.$nextTick();
+      const el = this.getTasksScrollElement();
+      if (el) {
+        el.scrollTop = el.scrollHeight;
+      }
+    },
+    async onGetTasks(payload?: { limit?: number; createdAtMin?: number; createdAtMax?: number }) {
+      if (this.applicationsLoading || this.fetchingTasks) {
+        return;
+      }
+      const { limit = 5, createdAtMin, createdAtMax } = payload || {};
+      this.fetchingTasks = true;
+      try {
+        await this.$store.dispatch('digitalhuman/getTasks', { limit, createdAtMin, createdAtMax });
+      } finally {
+        this.fetchingTasks = false;
+      }
+    },
+    async onGenerate(request: IDigitalHumanGenerateRequest) {
+      const token = this.credential?.token;
+      if (!token) {
+        console.error('no token specified');
+        return;
+      }
+      ElMessage.info(this.$t('digitalhuman.message.startingTask'));
+      instrumentGeneration('digitalhuman', digitalHumanOperator.generate(request, { token }))
+        .then(() => {
+          ElMessage.success(this.$t('digitalhuman.message.startTaskSuccess'));
+        })
+        .catch((error) => {
+          const response = error?.response?.data;
+          if (response?.error?.code === ERROR_CODE_USED_UP) {
+            ElMessage.error(this.$t('digitalhuman.message.usedUp'));
+          } else {
+            ElMessage.error(this.$t('digitalhuman.message.startTaskFailed'));
+          }
+        })
+        .finally(async () => {
+          setTimeout(async () => {
+            await this.onGetTasks();
+            await this.onScrollDown();
+          }, 1000);
+        });
+    },
+    getTasksScrollElement(): HTMLElement | undefined {
+      const panel = this.$refs.recentPanel as any;
+      return panel?.getScrollElement?.();
+    }
+  }
+});
+</script>

--- a/src/router/constants.ts
+++ b/src/router/constants.ts
@@ -43,6 +43,7 @@ export const ROUTE_VEO_HISTORY = 'veo-history';
 export const ROUTE_SORA_INDEX = 'sora-index';
 export const ROUTE_SORA_HISTORY = 'sora-history';
 export const ROUTE_MAESTRO_INDEX = 'maestro-index';
+export const ROUTE_DIGITALHUMAN_INDEX = 'digitalhuman-index';
 
 export const ROUTE_PIXVERSE_INDEX = 'pixverse-index';
 export const ROUTE_PIXVERSE_HISTORY = 'pixverse-history';

--- a/src/router/digitalhuman.ts
+++ b/src/router/digitalhuman.ts
@@ -1,0 +1,17 @@
+import { ROUTE_DIGITALHUMAN_INDEX } from './constants';
+
+export default {
+  path: '/digital-human',
+  meta: {
+    auth: true,
+    appName: 'digitalhuman'
+  },
+  component: () => import('@/layouts/Main.vue'),
+  children: [
+    {
+      path: '',
+      name: ROUTE_DIGITALHUMAN_INDEX,
+      component: () => import('@/pages/digitalhuman/Index.vue')
+    }
+  ]
+};

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -19,6 +19,7 @@ import kling from './kling';
 import veo from './veo';
 import sora from './sora';
 import maestro from './maestro';
+import digitalhuman from './digitalhuman';
 import pixverse from './pixverse';
 import flux from './flux';
 import hailuo from './hailuo';
@@ -59,6 +60,7 @@ import {
   ROUTE_VEO_INDEX,
   ROUTE_SORA_INDEX,
   ROUTE_MAESTRO_INDEX,
+  ROUTE_DIGITALHUMAN_INDEX,
   ROUTE_PIXVERSE_INDEX,
   ROUTE_WAN_INDEX,
   ROUTE_SERP_INDEX,
@@ -172,6 +174,13 @@ const ROUTE_SEO: Record<string, { title: string; description: string; keywords: 
     description:
       'Turn any article or topic into a captioned short video — script, visuals, voiceover and music, fully automated.',
     keywords: ['Maestro', 'AI Video', 'Article to Video', 'Faceless Video', 'Short Video Generator'],
+    category: 'AI Video Generation'
+  },
+  'digital-human': {
+    title: 'Digital Human',
+    description:
+      'Generate a talking-head video from a face video or photo and a voice — clone a voice, drive it with text or audio, and lip-sync it.',
+    keywords: ['Digital Human', 'Talking Head', 'Lip Sync', 'AI Avatar', 'Voice Clone', 'Text to Video'],
     category: 'AI Video Generation'
   },
   veo: {
@@ -297,6 +306,7 @@ const FEATURE_ROUTE_PRIORITY: Array<[string, string]> = [
   ['veo', ROUTE_VEO_INDEX],
   ['sora', ROUTE_SORA_INDEX],
   ['maestro', ROUTE_MAESTRO_INDEX],
+  ['digitalhuman', ROUTE_DIGITALHUMAN_INDEX],
   ['kling', ROUTE_KLING_INDEX],
   ['luma', ROUTE_LUMA_INDEX],
   ['hailuo', ROUTE_HAILUO_INDEX],
@@ -344,6 +354,7 @@ export const routes = [
   veo,
   sora,
   maestro,
+  digitalhuman,
   pixverse,
   flux,
   hailuo,

--- a/src/store/common/models.ts
+++ b/src/store/common/models.ts
@@ -9,6 +9,7 @@ import { IKlingState } from '../kling/models';
 import { IVeoState } from '../veo/models';
 import { ISoraState } from '../sora/models';
 import { IMaestroState } from '../maestro/models';
+import { IDigitalHumanState } from '../digitalhuman/models';
 import { IPixverseState } from '../pixverse/models';
 import { IFluxState } from '../flux/models';
 import { IHailuoState } from '../hailuo/models';
@@ -66,6 +67,7 @@ export interface IAppState {
   veo: IVeoState;
   sora: ISoraState;
   maestro: IMaestroState;
+  digitalhuman: IDigitalHumanState;
   pixverse: IPixverseState;
   flux: IFluxState;
   hailuo: IHailuoState;

--- a/src/store/common/state.ts
+++ b/src/store/common/state.ts
@@ -8,6 +8,7 @@ import klingState from '../kling/state';
 import veoState from '../veo/state';
 import soraState from '../sora/state';
 import maestroState from '../maestro/state';
+import digitalhumanState from '../digitalhuman/state';
 import pixverseState from '../pixverse/state';
 import fluxState from '../flux/state';
 import hailuoState from '../hailuo/state';
@@ -57,6 +58,7 @@ export default (): IRootState => {
     kling: klingState(),
     sora: soraState(),
     maestro: maestroState(),
+    digitalhuman: digitalhumanState(),
     veo: veoState(),
     pixverse: pixverseState(),
     flux: fluxState(),

--- a/src/store/digitalhuman/actions.ts
+++ b/src/store/digitalhuman/actions.ts
@@ -1,0 +1,12 @@
+import { digitalHumanOperator } from '@/operators';
+import { IDigitalHumanConfig, IDigitalHumanTask } from '@/models';
+import { DIGITALHUMAN_SERVICE_ID } from '@/constants';
+import { createTaskActions } from '@/store/factories/createTaskActions';
+
+const actions = createTaskActions<IDigitalHumanConfig, IDigitalHumanTask, Record<string, unknown>>({
+  serviceId: DIGITALHUMAN_SERVICE_ID,
+  operator: digitalHumanOperator,
+  type: 'videos'
+});
+
+export default actions;

--- a/src/store/digitalhuman/index.ts
+++ b/src/store/digitalhuman/index.ts
@@ -1,0 +1,14 @@
+import { Module } from 'vuex';
+import { IDigitalHumanState } from './models';
+import actions from './actions';
+import mutations from './mutations';
+import state from './state';
+
+export const digitalhuman: Module<IDigitalHumanState, any> = {
+  namespaced: true,
+  state,
+  mutations,
+  actions
+};
+
+export default digitalhuman;

--- a/src/store/digitalhuman/models.ts
+++ b/src/store/digitalhuman/models.ts
@@ -1,0 +1,22 @@
+import { IApplication, ICredential, IService, Status } from '@/models';
+import { IDigitalHumanConfig, IDigitalHumanTask } from '@/models';
+
+export interface IDigitalHumanState {
+  application: IApplication | undefined;
+  applications: IApplication[] | undefined;
+  service: IService | undefined;
+  credential: ICredential | undefined;
+  config: IDigitalHumanConfig | undefined;
+  tasks:
+    | {
+        items: IDigitalHumanTask[] | undefined;
+        total: number | undefined;
+        active: IDigitalHumanTask | undefined;
+      }
+    | undefined;
+  status: {
+    getService: Status;
+    getApplications: Status;
+    getTasks: Status;
+  };
+}

--- a/src/store/digitalhuman/mutations.ts
+++ b/src/store/digitalhuman/mutations.ts
@@ -1,0 +1,68 @@
+import { IApplication, ICredential, IDigitalHumanConfig, IDigitalHumanTask, IService } from '@/models';
+import initialState from './state';
+import { IDigitalHumanState } from './models';
+
+export const resetAll = (state: IDigitalHumanState): void => {
+  Object.assign(state, initialState());
+};
+
+export const setService = (state: IDigitalHumanState, payload: IService): void => {
+  state.service = payload;
+};
+
+export const setCredential = (state: IDigitalHumanState, payload: ICredential): void => {
+  state.credential = payload;
+};
+
+export const setApplication = (state: IDigitalHumanState, payload: IApplication): void => {
+  state.application = payload;
+};
+
+export const setApplications = (state: IDigitalHumanState, payload: IApplication[]): void => {
+  state.applications = payload;
+};
+
+export const setConfig = (state: IDigitalHumanState, payload: IDigitalHumanConfig): void => {
+  state.config = payload;
+};
+
+export const setTasksItems = (state: IDigitalHumanState, payload: IDigitalHumanTask[]): void => {
+  const newPayload = {
+    ...state.tasks,
+    items: payload
+  } as typeof state.tasks;
+  state.tasks = newPayload;
+};
+
+export const setTasksTotal = (state: IDigitalHumanState, payload: number): void => {
+  const newPayload = {
+    ...state.tasks,
+    total: payload
+  } as typeof state.tasks;
+  state.tasks = newPayload;
+};
+
+export const setTasksActive = (state: IDigitalHumanState, payload: IDigitalHumanTask): void => {
+  const newPayload = {
+    ...state.tasks,
+    active: payload
+  } as typeof state.tasks;
+  state.tasks = newPayload;
+};
+
+export const setTasks = (state: IDigitalHumanState, payload: any): void => {
+  state.tasks = payload;
+};
+
+export default {
+  setTasks,
+  setApplication,
+  setApplications,
+  setService,
+  setCredential,
+  setConfig,
+  setTasksItems,
+  setTasksTotal,
+  setTasksActive,
+  resetAll
+};

--- a/src/store/digitalhuman/persist.ts
+++ b/src/store/digitalhuman/persist.ts
@@ -1,0 +1,2 @@
+// See flux/persist.ts for why `.tasks` is no longer persisted.
+export default ['digitalhuman.credential', 'digitalhuman.application', 'digitalhuman.applications'];

--- a/src/store/digitalhuman/state.ts
+++ b/src/store/digitalhuman/state.ts
@@ -1,0 +1,18 @@
+import { IDigitalHumanState } from './models';
+import { Status } from '@/models';
+
+export default (): IDigitalHumanState => {
+  return {
+    service: undefined,
+    application: undefined,
+    applications: undefined,
+    tasks: undefined,
+    credential: undefined,
+    config: undefined,
+    status: {
+      getService: Status.None,
+      getApplications: Status.None,
+      getTasks: Status.None
+    }
+  };
+};

--- a/src/store/lazy.ts
+++ b/src/store/lazy.ts
@@ -32,6 +32,7 @@ const moduleLoaders: Record<string, () => Promise<{ default: AnyVuexModule }>> =
   veo: () => import('./veo'),
   sora: () => import('./sora'),
   maestro: () => import('./maestro'),
+  digitalhuman: () => import('./digitalhuman'),
   pixverse: () => import('./pixverse'),
   flux: () => import('./flux'),
   hailuo: () => import('./hailuo'),


### PR DESCRIPTION
## What

A new consumer scenario for the **Digital Human** service (`5b132265-…`, AI Video), modeled on the existing **maestro** scenario. Users turn a **face** (video or photo) + a **voice** (uploaded audio, or text spoken by an inline-cloned voice) into a lip-synced talking-head video, with a recent/history panel like every other scenario.

### UI (standard parity)
- **ConfigPanel** — face source (`Video | Photo`), voice source (`Audio upload | Text`), engine (`latentsync | heygem`) + resolution (`720p | 540p`). It emits a **sanitized request built from the active modes**, so the payload never carries the inactive face/voice fields.
- **VoiceClone** (text path) — upload a 10–20s sample → clone → poll → `voice_id`, then speak your text. A `runId` + unmount guard makes a stale/in-flight clone never write the wrong `voice_id`, and changing the sample/lang clears a previously cloned voice.
- **task/Preview** — one talking-head player; terminal state driven by success/`video_url` (robust to `succeed`/`succeeded`).

### Wiring (mirrors maestro)
`models` / `operators` / `constants` / `store(digitalhuman)` + `BaseTaskOperator` on `/digital-human/{videos,tasks}` (operator adds `cloneVoice` → `/digital-human/voices` and `pollTask`). Registered in the router (`/digital-human`, SEO, landing priority), lazy store, common state/models, the `Navigator` menu, and the settings feature toggle.

### i18n
`zh-CN` + `en` authored by hand; the new namespace + `nav.digitalhuman` + `featuresDigitalhuman` keys are backfilled to the other 16 locales so the coverage guard passes (the translation CronJob refines non-base values later).

## Dependency

History (the recent panel) needs **AceDataCloud/PlatformService#1128** — https://github.com/AceDataCloud/PlatformService/pull/1128 — which adds `retrieve` / `retrieve_batch` to `/digital-human/tasks`. Generation + single-task polling work without it; the list stays empty until it merges & deploys.

## Validation
- `vue-tsc -b --force`: clean
- `eslint`: clean
- `python3 scripts/check_i18n_coverage.py`: `17 locale(s) × 44 namespace(s) all match zh-CN`

## 🤖 对抗评审

Reviewer: **Codex** (`codex exec --sandbox read-only`), 2 rounds → converged `VERDICT: CLEAN`. Round 1 found 5 RISKs (logic/wiring), all **fixed**:

1. **Stale `voice_id` on sample/lang change** → `VoiceClone.invalidate()` clears it; a `lang` watcher + `onSampleChange` invalidate.
2. **Async clone/poll could write after unmount or mode-switch** → `runId` + `destroyed` guard (`isStale`) checked after **every** await before mutating store / toasting.
3. **Generate spread the whole config (stale inactive fields)** → `ConfigPanel.onGenerate` emits a request built only from the active face/voice modes; the page submits that.
4. **Terminal logic only matched `succeed`** → `isTerminal = isSuccess || isFailure`, normalizing `succeed`/`succeeded` and falling back to `video_url` / `response.success`.
5. **Poll interval leaked on repeated `initialized` transitions** → clear `this.job` before re-arming (and on `initialized=false`).

Round 2 re-reviewed the 5 fixes: no remaining defects, no new defects → `VERDICT: CLEAN`.