### PR TITLE
fix(maestro): redesign logo to a professional conducting-waves icon

### DIFF
--- a/change/@acedatacloud-nexior-maestro-logo-redesign.json
+++ b/change/@acedatacloud-nexior-maestro-logo-redesign.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "redesign Maestro logo — professional conducting-waves icon (play triangle + radiating arcs) replacing the old flat SVG",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/constants/maestro.ts
+++ b/src/constants/maestro.ts
@@ -1,6 +1,6 @@
 export const MAESTRO_SERVICE_ID = '0d7031bf-610a-419e-a5a0-db8f240286d5';
 
-export const MAESTRO_LOGO = 'https://cdn.acedata.cloud/ae064d6b6c.svg';
+export const MAESTRO_LOGO = 'https://cdn.acedata.cloud/ee49012887.svg';
 
 export const MAESTRO_ACTION_GENERATE = 'generate';
 export const MAESTRO_ACTION_REMIX = 'remix';


### PR DESCRIPTION
## What

Replace the Maestro logo with a polished, professional redesign.

- **Old:** `https://cdn.acedata.cloud/ae064d6b6c.svg` — a flat icon with an unbalanced composition (play triangle + a loose curve + a corner sparkle).
- **New:** `https://cdn.acedata.cloud/ee49012887.svg` — a rounded-square app icon: a white play triangle with radiating **conducting arcs** on a premium indigo→violet→magenta gradient. The arcs evoke the *Maestro* (conductor / orchestrator) metaphor — "conduct a finished video" — and the icon now matches the house style of the other video scenarios (seedance / sora / veo).

Only the `MAESTRO_LOGO` constant changes (single source of truth; the backend `Service.logo` is `null`, so no backend change is needed). Includes a beachball `patch` change file.

## Preview

| Before | After |
|---|---|
| flat play + stray curve + sparkle | rounded-square gradient, play triangle + conducting waves |

(New asset is a hand-authored SVG: `<rect>` + `<path>` + `<linearGradient>` only — no script/foreignObject/external refs.)

## Test
- `grep -rn ae064d6b6c src/` → 0 stale references (the constant was the only usage).
- New CDN asset returns `HTTP 200` / `image/svg+xml` and renders correctly.
- Consumers unchanged: `Navigator.vue` (nav logo) and `components/maestro/task/Preview.vue` (`:src="MAESTRO_LOGO"`).

## 🤖 对抗评审 (reviewer: claude-subagent, 1 round)
- VERDICT: CLEAN — no stale `ae064d6b6c` refs; valid TS + beachball change file (`packageName` matches `package.json`); SVG is inert (served via `el-image :src`, not `innerHTML`; contains no `<script>`/`<foreignObject>`/external `href`); diff is a single string swap + one JSON file, so vue-tsc/eslint/beachball CI unaffected.
