### PR TITLE
fix(coding-bridge): surface GitHub Copilot provider in UI

### DIFF
--- a/change/@acedatacloud-nexior-coding-bridge-copilot-ui.json
+++ b/change/@acedatacloud-nexior-coding-bridge-copilot-ui.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Support GitHub Copilot in Coding Bridge provider labels, history restore, and deep links.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/codingBridge/HistoryDrawer.vue
+++ b/src/components/codingBridge/HistoryDrawer.vue
@@ -36,10 +36,17 @@
         >
           <div class="flex items-center gap-2 mb-1">
             <img
-              :src="providerIcon(item.provider).src"
+              v-if="providerIcon(item.provider)"
+              :src="providerIcon(item.provider)!.src"
               class="provider-icon"
-              :class="{ 'provider-icon--invert': providerIcon(item.provider).invertOnDark }"
-              :alt="item.provider === 'codex' ? 'Codex' : 'Claude'"
+              :class="{ 'provider-icon--invert': providerIcon(item.provider)!.invertOnDark }"
+              :alt="providerLabel(item.provider)"
+            />
+            <font-awesome-icon
+              v-else
+              icon="fa-solid fa-code"
+              class="provider-icon"
+              :title="providerLabel(item.provider)"
             />
             <span class="text-sm font-medium truncate flex-1">{{ item.title }}</span>
             <!-- Live on the node right now: opening it reattaches to the running
@@ -110,8 +117,16 @@ export default defineComponent({
     }
   },
   methods: {
-    providerIcon(provider: string): { src: string; invertOnDark: boolean } {
-      return PROVIDER_ICONS[provider] ?? PROVIDER_ICONS.claude;
+    providerLabel(provider: string): string {
+      const labels: Record<string, string> = {
+        claude: 'Claude Code',
+        codex: 'Codex',
+        copilot: 'GitHub Copilot'
+      };
+      return labels[provider] ?? provider;
+    },
+    providerIcon(provider: string): { src: string; invertOnDark: boolean } | null {
+      return PROVIDER_ICONS[provider] ?? null;
     },
     refresh() {
       if (this.currentNodeId) {

--- a/src/components/codingBridge/SessionView.vue
+++ b/src/components/codingBridge/SessionView.vue
@@ -656,9 +656,13 @@ export default defineComponent({
       if (!this.currentSession?.provider || this.currentSession?.started) {
         return '';
       }
-      return this.currentSession.provider === 'codex'
-        ? (this.$t('codingBridge.history.codexLabel') as string)
-        : (this.$t('codingBridge.history.claudeLabel') as string);
+      if (this.currentSession.provider === 'codex') {
+        return this.$t('codingBridge.history.codexLabel') as string;
+      }
+      if (this.currentSession.provider === 'claude') {
+        return this.$t('codingBridge.history.claudeLabel') as string;
+      }
+      return this.providerName(this.currentSession.provider);
     },
     running(): boolean {
       const status = this.currentSession?.status;
@@ -781,7 +785,8 @@ export default defineComponent({
       }
       return [
         { label: this.$t('codingBridge.session.providerClaude') as string, value: 'claude', available: true },
-        { label: this.$t('codingBridge.session.providerCodex') as string, value: 'codex', available: true }
+        { label: this.$t('codingBridge.session.providerCodex') as string, value: 'codex', available: true },
+        { label: 'GitHub Copilot', value: 'copilot', available: true }
       ];
     },
     modelOptions(): { label: string; value: string }[] {
@@ -961,9 +966,12 @@ export default defineComponent({
       if (cap) {
         return cap.label;
       }
-      return provider === 'codex'
-        ? (this.$t('codingBridge.session.providerCodex') as string)
-        : (this.$t('codingBridge.session.providerClaude') as string);
+      const fallback: Record<string, string> = {
+        claude: this.$t('codingBridge.session.providerClaude') as string,
+        codex: this.$t('codingBridge.session.providerCodex') as string,
+        copilot: 'GitHub Copilot'
+      };
+      return fallback[provider] ?? provider;
     },
     // Brand mark for a backend, or null to fall back to a generic icon.
     providerIcon(provider: string): { src: string; invertOnDark: boolean } | null {

--- a/src/models/codingBridge.ts
+++ b/src/models/codingBridge.ts
@@ -1,6 +1,6 @@
 /**
- * Coding Bridge lets a signed-in user drive a Claude Code / Codex agent that
- * runs on their own machine (a "node" daemon) from the web UI. The browser
+ * Coding Bridge lets a signed-in user drive a Claude Code / Codex / Copilot
+ * agent that runs on their own machine (a "node" daemon) from the web UI. The browser
  * never executes anything: it only relays JSON envelopes to the node through
  * the stateful `coding-bridge` relay over a single authenticated WebSocket.
  */
@@ -16,7 +16,7 @@ export interface ICodingBridgeNode {
 
 export type ICodingBridgeSessionStatus = 'starting' | 'running' | 'idle' | 'closed' | 'error';
 
-export type ICodingBridgeHistoryProvider = 'claude' | 'codex';
+export type ICodingBridgeHistoryProvider = 'claude' | 'codex' | 'copilot';
 
 /** One selectable model offered by a provider, as reported by the node. */
 export interface ICodingBridgeModelOption {

--- a/src/pages/codingBridge/Index.vue
+++ b/src/pages/codingBridge/Index.vue
@@ -79,7 +79,7 @@ export default defineComponent({
       if (!sessionId || !nodeId) {
         return;
       }
-      const provider = q.provider === 'codex' ? 'codex' : 'claude';
+      const provider = q.provider === 'codex' || q.provider === 'copilot' ? q.provider : 'claude';
       this.$store.commit('codingBridge/setCurrentNode', nodeId);
       this.$store.commit('codingBridge/setHistoryRef', { node_id: nodeId, provider, session_id: sessionId });
       this.$store.dispatch('codingBridge/getHistory', nodeId);

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -272,8 +272,8 @@ const ROUTE_SEO: Record<string, { title: string; description: string; keywords: 
   'coding-bridge': {
     title: 'Coding Bridge',
     description:
-      'Drive Claude Code and Codex on your own machine from the web — pair a local node and run coding agents remotely with per-tool approval.',
-    keywords: ['Coding Bridge', 'Claude Code', 'Codex', 'Remote Agent', 'AI Coding'],
+      'Drive Claude Code, Codex, and GitHub Copilot on your own machine from the web — pair a local node and run coding agents remotely with per-tool approval.',
+    keywords: ['Coding Bridge', 'Claude Code', 'Codex', 'GitHub Copilot', 'Remote Agent', 'AI Coding'],
     category: 'AI Coding'
   }
 };

--- a/src/store/codingBridge/actions.ts
+++ b/src/store/codingBridge/actions.ts
@@ -7,6 +7,7 @@ import {
   ICodingBridgeAttachment,
   ICodingBridgeEvent,
   ICodingBridgeEventKind,
+  ICodingBridgeHistoryProvider,
   ICodingBridgeNode
 } from '@/models';
 import { CodingBridgeSocket } from '@/utils/codingBridgeSocket';
@@ -408,10 +409,7 @@ export const applyNodeEvent = (
 // same id. The node now keys live sessions by their real (SDK) id — exactly the
 // id history lists them under — so a transcript that is still running on the
 // node is reattached (its running status, seq cursor and in-flight stream kept
-// intact) instead of being overwritten by a static, idle copy. A dead transcript
-// materialises as a resumable idle session — for BOTH providers: Claude
-// (`claude --resume`) and Codex (`codex exec resume`) can each continue an
-// on-disk transcript, so neither is forced read-only.
+// intact) instead of being overwritten by a static, idle copy.
 const applyHistoryDetail = (
   commit: ActionContext<ICodingBridgeState, IRootState>['commit'],
   state: ICodingBridgeState,
@@ -419,13 +417,11 @@ const applyHistoryDetail = (
   fromNode: string | undefined
 ): void => {
   const sessionId = payload?.session_id;
-  const provider = payload?.provider === 'codex' ? 'codex' : 'claude';
+  const provider = normalizeHistoryProvider(payload?.provider);
   if (!sessionId || !fromNode) {
     return;
   }
-  // Codex resume now works end-to-end (node sends `codex exec resume` with the
-  // sandbox as a -c override), so codex history is resumable too — not read-only.
-  const resumable = provider === 'claude' || provider === 'codex';
+  const resumable = provider === 'claude' || provider === 'codex' || provider === 'copilot';
   const live = state.sessions[sessionId];
   // "Live" = a session the node is currently running (surfaced via the sessions
   // snapshot) or one already mid-turn in this tab. Such a session keeps the Stop
@@ -479,6 +475,10 @@ const applyHistoryDetail = (
   commit('setCurrentNode', fromNode);
   commit('setCurrentSession', sessionId);
   commit('setHistoryRef', { node_id: fromNode, provider, session_id: sessionId });
+};
+
+const normalizeHistoryProvider = (provider: unknown): ICodingBridgeHistoryProvider => {
+  return provider === 'codex' || provider === 'copilot' ? provider : 'claude';
 };
 
 export const resetAll = ({ commit }: ActionContext<ICodingBridgeState, IRootState>): void => {

--- a/src/store/codingBridge/models.ts
+++ b/src/store/codingBridge/models.ts
@@ -6,6 +6,7 @@ import {
   ICodingBridgeDirListing,
   ICodingBridgeEvent,
   ICodingBridgeHistorySummary,
+  ICodingBridgeHistoryProvider,
   ICodingBridgeNode,
   ICodingBridgePermissionRequest,
   ICodingBridgeSession
@@ -14,7 +15,7 @@ import {
 /** Pointer to the last-opened history conversation, restored after a reload. */
 export interface ICodingBridgeHistoryRef {
   node_id: string;
-  provider: 'claude' | 'codex';
+  provider: ICodingBridgeHistoryProvider;
   session_id: string;
 }
 


### PR DESCRIPTION
## Summary
- surface the new `copilot` Coding Bridge provider in Nexior’s provider types and fallback UI labels
- preserve Copilot in history replay/deep-link restore instead of collapsing non-Codex providers to Claude
- avoid showing Claude branding for Copilot history rows; use the dynamic capability label when available and a generic code icon fallback otherwise
- update Coding Bridge SEO copy to mention GitHub Copilot

## Context
Backend/node support is in AceDataCloud/CodingBridge#33.
The relay remains unchanged because `coding-bridge` forwards inner payloads opaquely; it only peeks at event names for logging/permission push notifications.

## Validation
- `npx eslint src/models/codingBridge.ts src/store/codingBridge/models.ts src/store/codingBridge/actions.ts src/components/codingBridge/SessionView.vue src/components/codingBridge/HistoryDrawer.vue src/pages/codingBridge/Index.vue src/router/index.ts`
- `npx vue-tsc -b`
- `python3 scripts/check_i18n_coverage.py`
- `./node_modules/.bin/beachball check`

## Review
Read-only adversarial review found and fixed:
- history detail hydrate collapsed `provider=copilot` to Claude
- history drawer rows labeled non-Codex providers as Claude
- `/coding-bridge?...&provider=copilot` deep links collapsed to Claude

Final re-review: VERDICT: CLEAN
