### PR TITLE
feat(grokvideo): expose 1080p and model-aware duration caps

### DIFF
--- a/change/@acedatacloud-nexior-grok-video-caps.json
+++ b/change/@acedatacloud-nexior-grok-video-caps.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(grokvideo): expose 1080p and model-aware duration caps",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/grokvideo/config/DurationSelector.vue
+++ b/src/components/grokvideo/config/DurationSelector.vue
@@ -16,7 +16,7 @@
 import { defineComponent } from 'vue';
 import { ElSelect, ElOption } from 'element-plus';
 import InfoIcon from '@/components/common/InfoIcon.vue';
-import { GROKVIDEO_DEFAULT_DURATION } from '@/constants';
+import { GROKVIDEO_DEFAULT_DURATION, GROKVIDEO_DURATION_OPTIONS, getGrokVideoMaxDuration } from '@/constants';
 
 export default defineComponent({
   name: 'GrokVideoDurationSelector',
@@ -25,20 +25,17 @@ export default defineComponent({
     ElOption,
     InfoIcon
   },
-  data() {
-    return {
-      options: [
-        { value: 3, label: '3s' },
-        { value: 5, label: '5s' },
-        { value: 6, label: '6s' },
-        { value: 8, label: '8s' },
-        { value: 10, label: '10s' },
-        { value: 12, label: '12s' },
-        { value: 15, label: '15s' }
-      ]
-    };
-  },
   computed: {
+    model(): string | undefined {
+      return this.$store.state.grokvideo?.config?.model;
+    },
+    // grok-imagine-video supports up to 30s; grok-imagine-video-1.5-preview up to 15s.
+    maxDuration(): number {
+      return getGrokVideoMaxDuration(this.model);
+    },
+    options(): { value: number; label: string }[] {
+      return GROKVIDEO_DURATION_OPTIONS.filter((d) => d <= this.maxDuration).map((d) => ({ value: d, label: `${d}s` }));
+    },
     value: {
       get(): number | undefined {
         return this.$store.state.grokvideo?.config?.duration;
@@ -48,6 +45,14 @@ export default defineComponent({
           ...this.$store.state.grokvideo?.config,
           duration: val
         });
+      }
+    }
+  },
+  watch: {
+    // Switching to a model with a lower cap (e.g. 1.5-preview) clamps the value.
+    maxDuration(max: number) {
+      if (this.value && this.value > max) {
+        this.value = max;
       }
     }
   },

--- a/src/components/grokvideo/config/ResolutionSelector.vue
+++ b/src/components/grokvideo/config/ResolutionSelector.vue
@@ -21,7 +21,12 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import InfoIcon from '@/components/common/InfoIcon.vue';
-import { GROKVIDEO_DEFAULT_RESOLUTION, GROKVIDEO_RESOLUTION_480P, GROKVIDEO_RESOLUTION_720P } from '@/constants';
+import {
+  GROKVIDEO_DEFAULT_RESOLUTION,
+  GROKVIDEO_RESOLUTION_480P,
+  GROKVIDEO_RESOLUTION_720P,
+  GROKVIDEO_RESOLUTION_1080P
+} from '@/constants';
 
 export default defineComponent({
   name: 'GrokVideoResolutionSelector',
@@ -32,7 +37,8 @@ export default defineComponent({
     return {
       options: [
         { value: GROKVIDEO_RESOLUTION_480P, label: '480p' },
-        { value: GROKVIDEO_RESOLUTION_720P, label: '720p' }
+        { value: GROKVIDEO_RESOLUTION_720P, label: '720p' },
+        { value: GROKVIDEO_RESOLUTION_1080P, label: '1080p' }
       ]
     };
   },

--- a/src/constants/grokvideo.ts
+++ b/src/constants/grokvideo.ts
@@ -18,12 +18,24 @@ export const GROKVIDEO_DEFAULT_RATIO = GROKVIDEO_RATIO_16_9;
 
 export const GROKVIDEO_RESOLUTION_480P = '480p';
 export const GROKVIDEO_RESOLUTION_720P = '720p';
+export const GROKVIDEO_RESOLUTION_1080P = '1080p';
 export const GROKVIDEO_DEFAULT_RESOLUTION = GROKVIDEO_RESOLUTION_480P;
 
 export const GROKVIDEO_DEFAULT_DURATION = 8;
+
+// grok-imagine-video (1.0) supports up to 30s; grok-imagine-video-1.5-preview up to 15s.
+export const GROKVIDEO_MAX_DURATION_DEFAULT = 30;
+export const GROKVIDEO_MAX_DURATION_1_5_PREVIEW = 15;
+
+/** All selectable clip durations (seconds); filtered per-model by max duration. */
+export const GROKVIDEO_DURATION_OPTIONS = [3, 5, 6, 8, 10, 12, 15, 20, 25, 30];
 
 /** Models that only support image-to-video (require an input image). */
 export const GROKVIDEO_IMAGE_ONLY_MODELS = [GROKVIDEO_MODEL_1_5_PREVIEW];
 
 export const isGrokVideoImageOnlyModel = (model?: string): boolean =>
   !!model && GROKVIDEO_IMAGE_ONLY_MODELS.includes(model);
+
+/** Max clip duration (seconds) for the given model. */
+export const getGrokVideoMaxDuration = (model?: string): number =>
+  model === GROKVIDEO_MODEL_1_5_PREVIEW ? GROKVIDEO_MAX_DURATION_1_5_PREVIEW : GROKVIDEO_MAX_DURATION_DEFAULT;

--- a/src/i18n/en/grokvideo.json
+++ b/src/i18n/en/grokvideo.json
@@ -18,16 +18,16 @@
     "description": "Instructions for prompt input"
   },
   "description.model": {
-    "message": "Choose the Grok Imagine model. grok-imagine-video supports text and image; 1.5-preview is image-to-video only.",
+    "message": "Choose the Grok Imagine model. grok-imagine-video supports text and image up to 30s; 1.5-preview is image-to-video only up to 15s.",
     "description": "Instructions for model selection"
   },
   "description.ratio": { "message": "Select the output aspect ratio.", "description": "Instructions for aspect ratio" },
   "description.resolution": {
-    "message": "Select the output resolution. Higher resolution costs more credits per second.",
+    "message": "Select the output resolution. 480p / 720p / 1080p are supported; higher resolution costs more.",
     "description": "Instructions for resolution"
   },
   "description.duration": {
-    "message": "Video duration in seconds. Billed per output second.",
+    "message": "Video duration in seconds. grok-imagine-video supports 1-30s with banded pricing; 1.5-preview supports 1-15s and is billed per output second.",
     "description": "Instructions for duration"
   },
   "description.image": {

--- a/src/i18n/zh-CN/grokvideo.json
+++ b/src/i18n/zh-CN/grokvideo.json
@@ -18,16 +18,16 @@
     "description": "Instructions for prompt input"
   },
   "description.model": {
-    "message": "选择 Grok Imagine 模型。grok-imagine-video 支持文生与图生视频；1.5-preview 仅支持图生视频。",
+    "message": "选择 Grok Imagine 模型。grok-imagine-video 支持文生与图生视频，时长最长 30 秒；1.5-preview 仅支持图生视频，时长最长 15 秒。",
     "description": "Instructions for model selection"
   },
   "description.ratio": { "message": "选择输出画面比例。", "description": "Instructions for aspect ratio" },
   "description.resolution": {
-    "message": "选择输出分辨率。分辨率越高，每秒消耗的额度越多。",
+    "message": "选择输出分辨率，支持 480p / 720p / 1080p。分辨率越高，消耗的额度越多。",
     "description": "Instructions for resolution"
   },
   "description.duration": {
-    "message": "视频时长（秒），按输出秒数计费。",
+    "message": "视频时长（秒）。grok-imagine-video 支持 1-30 秒，按时长分档计费；1.5-preview 支持 1-15 秒，按输出秒数计费。",
     "description": "Instructions for duration"
   },
   "description.image": {

--- a/src/models/grokvideo.ts
+++ b/src/models/grokvideo.ts
@@ -1,4 +1,4 @@
-export type GrokVideoResolution = '480p' | '720p';
+export type GrokVideoResolution = '480p' | '720p' | '1080p';
 export type GrokVideoRatio = '1:1' | '16:9' | '9:16' | '4:3' | '3:4' | '3:2' | '2:3';
 
 export interface IGrokVideoConfig {


### PR DESCRIPTION
## What

Align Nexior's Grok Video UI with the backend switch to TTAPI's cheaper non-official path.

Companion to:
- https://github.com/AceDataCloud/PlatformService/pull/1158
- https://github.com/AceDataCloud/PlatformBackend/pull/750
- https://github.com/AceDataCloud/MCPs/pull/400

## Changes

- add `1080p` to the Grok Video resolution selector
- allow `grok-imagine-video` durations up to `30s`
- keep `grok-imagine-video-1.5-preview` capped at `15s`
- when switching to `1.5-preview`, clamp any previously-selected longer duration down to 15s
- refresh `en` / `zh-CN` copy to mention 1080p and the model-aware duration / billing rules

## Why

Without this, the public backend supports new caps/pricing but the Nexior UI still blocks them client-side and shows stale text.

## Verification

- prettier clean
- eslint clean (0 errors)
- `vue-tsc --noEmit` clean

## 🤖 Adversarial review

Codex read-only review verdict: `VERDICT: CLEAN`.