### PR TITLE
feat(grokvideo): dedicated layout, multi reference images, pending elapsed timer

### DIFF
--- a/change/@acedatacloud-nexior-grokvideo-polish.json
+++ b/change/@acedatacloud-nexior-grokvideo-polish.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(grokvideo): dedicated layout, multi reference images, pending elapsed timer",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/grokvideo/ConfigPanel.vue
+++ b/src/components/grokvideo/ConfigPanel.vue
@@ -7,6 +7,7 @@
       <resolution-selector class="mb-4" />
       <duration-selector class="mb-4" />
       <image-input class="mb-2" />
+      <reference-images-input v-if="supportsReferenceImages" class="mb-2" />
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
       <consumption :value="consumption" :service="service" />
@@ -28,8 +29,10 @@ import DurationSelector from './config/DurationSelector.vue';
 import ResolutionSelector from './config/ResolutionSelector.vue';
 import RatioSelector from './config/RatioSelector.vue';
 import ImageInput from './config/ImageInput.vue';
+import ReferenceImagesInput from './config/ReferenceImagesInput.vue';
 import Consumption from '../common/Consumption.vue';
 import { getConsumption } from '@/utils';
+import { isGrokVideoImageOnlyModel } from '@/constants';
 
 export default defineComponent({
   name: 'GrokVideoConfigPanel',
@@ -42,12 +45,18 @@ export default defineComponent({
     ResolutionSelector,
     RatioSelector,
     ImageInput,
+    ReferenceImagesInput,
     Consumption
   },
   emits: ['generate'],
   computed: {
     config() {
       return this.$store.state.grokvideo?.config;
+    },
+    // grok-imagine-video (1.0) accepts multiple reference images;
+    // grok-imagine-video-1.5-preview is single-image only.
+    supportsReferenceImages(): boolean {
+      return !isGrokVideoImageOnlyModel(this.$store.state.grokvideo?.config?.model);
     },
     consumption() {
       return getConsumption(this.config, this.service?.cost);

--- a/src/components/grokvideo/config/ReferenceImagesInput.vue
+++ b/src/components/grokvideo/config/ReferenceImagesInput.vue
@@ -85,7 +85,10 @@ export default defineComponent({
       };
     },
     urls(): string[] {
-      return (this.fileList.map((file: UploadFile) => file?.response?.file_url).filter((u) => !!u) as string[]) || [];
+      return (
+        (this.fileList.map((file: UploadFile) => (file?.response as any)?.file_url).filter((u) => !!u) as string[]) ||
+        []
+      );
     },
     value(): string[] | undefined {
       return this.$store.state.grokvideo?.config?.reference_image_urls;

--- a/src/components/grokvideo/config/ReferenceImagesInput.vue
+++ b/src/components/grokvideo/config/ReferenceImagesInput.vue
@@ -1,0 +1,189 @@
+<template>
+  <div class="field flex items-center justify-between">
+    <h2 class="title font-bold text-[14px] mb-[10px]">{{ $t('grokvideo.name.referenceImages') }}</h2>
+    <div class="upload-wrapper flex flex-col items-start gap-[8px]">
+      <div class="controls flex items-center">
+        <el-upload
+          ref="uploader"
+          v-model:file-list="fileList"
+          accept=".png,.jpg,.jpeg,.gif,.bmp,.webp"
+          name="file"
+          class="value"
+          :limit="limit"
+          :multiple="true"
+          :show-file-list="false"
+          :action="uploadUrl"
+          :on-exceed="onExceed"
+          :on-error="onError"
+          :on-success="onSuccess"
+          :on-change="onChange"
+          :on-remove="onRemove"
+          :headers="headers"
+        >
+          <el-button size="small" type="primary" round>
+            <font-awesome-icon icon="fa-solid fa-upload" class="mr-1" />
+            {{ $t('grokvideo.button.upload') }}
+          </el-button>
+        </el-upload>
+        <info-icon :content="$t('grokvideo.description.referenceImages')" class="ml-2" />
+      </div>
+    </div>
+  </div>
+  <div class="file-list flex flex-wrap gap-[10px]">
+    <image-preview
+      v-for="(file, idx) in fileList"
+      :key="(file as any).uid || (file as any)?.response?.file_url || (file as any).url || idx"
+      :url="(file as any).url || (file as any)?.response?.file_url"
+      :name="(file as any).name"
+      :percentage="(file as any).percentage"
+      @remove="onRemovePreview(idx, file)"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElButton, ElUpload, ElMessage, UploadFiles, UploadFile } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { getBaseUrlPlatform } from '@/utils';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+import ImagePreview from '@/components/common/ImagePreview.vue';
+import { pasteUploadMixin, uploadTrackerMixin } from '@/utils';
+
+const MAX_REFERENCE_IMAGES = 4;
+
+interface IData {
+  fileList: UploadFiles;
+  uploadUrl: string;
+  limit: number;
+  suppressWatch: boolean;
+}
+
+export default defineComponent({
+  name: 'GrokVideoReferenceImagesInput',
+  components: {
+    ElUpload,
+    ElButton,
+    InfoIcon,
+    ImagePreview,
+    FontAwesomeIcon
+  },
+  mixins: [pasteUploadMixin, uploadTrackerMixin],
+  data(): IData {
+    return {
+      fileList: [],
+      uploadUrl: getBaseUrlPlatform() + '/api/v1/files/',
+      limit: MAX_REFERENCE_IMAGES,
+      // prevent feedback loops when syncing store -> fileList
+      suppressWatch: false
+    };
+  },
+  computed: {
+    headers() {
+      return {
+        Authorization: `Bearer ${this.$store.state.token.access}`
+      };
+    },
+    urls(): string[] {
+      return (this.fileList.map((file: UploadFile) => file?.response?.file_url).filter((u) => !!u) as string[]) || [];
+    },
+    value(): string[] | undefined {
+      return this.$store.state.grokvideo?.config?.reference_image_urls;
+    }
+  },
+  watch: {
+    value: {
+      immediate: true,
+      handler(newVal?: string[]) {
+        if (this.suppressWatch) return;
+        if (!newVal || newVal.length === 0) {
+          const uploading = (this.fileList || []).filter((f: any) => !f?.response?.file_url);
+          this.fileList = uploading.length ? uploading : [];
+          return;
+        }
+        const newFiles: UploadFiles = [];
+        newVal.forEach((url: string) => {
+          const existing = this.fileList.find(
+            (file) => (file as any)?.response?.file_url === url || (file as any)?.url === url
+          );
+          if (existing) {
+            newFiles.push(existing);
+          } else {
+            newFiles.push({
+              name: url.split('/').pop() || url,
+              url,
+              status: 'success',
+              percentage: 100,
+              response: { file_url: url }
+            } as UploadFile);
+          }
+        });
+        const uploading = (this.fileList || []).filter((f: any) => !f?.response?.file_url);
+        uploading.forEach((f: any) => {
+          const exists = newFiles.some(
+            (nf: any) => nf === f || nf?.url === f?.url || nf?.response?.file_url === f?.response?.file_url
+          );
+          if (!exists) newFiles.push(f);
+        });
+        this.fileList = newFiles;
+      }
+    }
+  },
+  methods: {
+    onChange(file: any) {
+      if (!file?.url && file?.raw) {
+        try {
+          file.url = URL.createObjectURL(file.raw);
+        } catch (e) {
+          // ignore
+        }
+      }
+    },
+    onRemove(file: any) {
+      if (file?.url && typeof file.url === 'string' && file.url.startsWith('blob:')) {
+        try {
+          URL.revokeObjectURL(file.url);
+        } catch (e) {
+          // ignore
+        }
+      }
+      this.onSetReferenceImages();
+    },
+    onExceed() {
+      ElMessage.warning(this.$t('grokvideo.message.uploadReferenceExceed'));
+    },
+    onError() {
+      ElMessage.error(this.$t('grokvideo.message.uploadError'));
+    },
+    onSetReferenceImages() {
+      const urls = this.urls;
+      this.suppressWatch = true;
+      this.$store.commit('grokvideo/setConfig', {
+        ...this.$store.state.grokvideo?.config,
+        reference_image_urls: urls.length ? urls : undefined
+      });
+      this.$nextTick(() => {
+        this.suppressWatch = false;
+      });
+    },
+    async onSuccess(response: any, file: any) {
+      if (response?.file_url) {
+        file.url = response.file_url;
+        file.response = response;
+      }
+      this.onSetReferenceImages();
+    },
+    onRemovePreview(idx: number, file: any) {
+      this.fileList.splice(idx, 1);
+      if (file?.url && typeof file.url === 'string' && file.url.startsWith('blob:')) {
+        try {
+          URL.revokeObjectURL(file.url);
+        } catch (e) {
+          // ignore
+        }
+      }
+      this.onSetReferenceImages();
+    }
+  }
+});
+</script>

--- a/src/components/grokvideo/task/Preview.vue
+++ b/src/components/grokvideo/task/Preview.vue
@@ -28,11 +28,15 @@
             <font-awesome-icon icon="fa-regular fa-clock" class="mr-1" />
             {{ $t('grokvideo.status.pending') }}
           </template>
-          <p class="text-[var(--el-text-color-regular)] text-xs mb-0">
+          <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
             <font-awesome-icon icon="fa-solid fa-magic" class="mr-1" />
             {{ $t('grokvideo.name.taskId') }}:
             {{ modelValue?.id }}
             <copy-to-clipboard :content="modelValue?.id!" class="btn-copy inline-block" />
+          </p>
+          <p v-if="pendingElapsed !== undefined" class="text-[var(--el-text-color-regular)] text-xs mb-0">
+            <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
+            {{ $t('grokvideo.name.elapsed') }}: {{ pendingElapsed }}s
           </p>
         </el-alert>
       </div>
@@ -163,7 +167,9 @@ export default defineComponent({
   },
   data() {
     return {
-      grokVideoLogo: GROKVIDEO_LOGO
+      grokVideoLogo: GROKVIDEO_LOGO,
+      nowTs: Date.now(),
+      timer: 0
     };
   },
   computed: {
@@ -172,9 +178,43 @@ export default defineComponent({
     },
     inputImage(): string | undefined {
       return this.modelValue?.request?.image_url;
+    },
+    // Live elapsed seconds shown while a task is still pending (no upstream
+    // progress %, so elapsed time is the honest signal during the 1-2 min wait).
+    pendingElapsed(): number | undefined {
+      const created = parseFloat((this.modelValue?.created_at || '').toString());
+      if (!created) {
+        return undefined;
+      }
+      return Math.max(0, Math.floor(this.nowTs / 1000 - created));
     }
   },
+  watch: {
+    'modelValue.response': {
+      handler(response) {
+        if (response) {
+          this.stopTimer();
+        }
+      }
+    }
+  },
+  mounted() {
+    if (!this.modelValue?.response) {
+      this.timer = window.setInterval(() => {
+        this.nowTs = Date.now();
+      }, 1000);
+    }
+  },
+  beforeUnmount() {
+    this.stopTimer();
+  },
   methods: {
+    stopTimer() {
+      if (this.timer) {
+        window.clearInterval(this.timer);
+        this.timer = 0;
+      }
+    },
     onDownload(videoUrl: string) {
       window.open(videoUrl, '_blank');
     }

--- a/src/i18n/ar/grokvideo.json
+++ b/src/i18n/ar/grokvideo.json
@@ -27,6 +27,10 @@
     "message": "صورة",
     "description": "تسمية لإدخال الصورة"
   },
+  "name.referenceImages": {
+    "message": "Reference Images",
+    "description": "Label for reference images"
+  },
   "name.required": {
     "message": "مطلوب",
     "description": "شارة مطلوبة"
@@ -79,6 +83,10 @@
     "message": "صورة إدخال اختيارية، تستخدم لإنشاء الفيديو. grok-imagine-video-1.5-preview إلزامية.",
     "description": "تعليمات حول إدخال الصورة"
   },
+  "description.referenceImages": {
+    "message": "Optional reference images to guide the style or content of the generated video (grok-imagine-video only).",
+    "description": "Instructions for reference images"
+  },
   "placeholder.prompt": {
     "message": "وصف الفيديو الخاص بك…",
     "description": "نص بديل لنص التوجيه"
@@ -118,6 +126,10 @@
   "message.uploadExceed": {
     "message": "يمكنك رفع صورة واحدة فقط.",
     "description": "تحذير تجاوز الرفع"
+  },
+  "message.uploadReferenceExceed": {
+    "message": "You can upload up to 4 reference images.",
+    "description": "Reference images upload exceed warning"
   },
   "message.uploadError": {
     "message": "فشل رفع الصورة، يرجى المحاولة مرة أخرى.",

--- a/src/i18n/de/grokvideo.json
+++ b/src/i18n/de/grokvideo.json
@@ -27,6 +27,10 @@
     "message": "Bild",
     "description": "Label für das Eingabebild"
   },
+  "name.referenceImages": {
+    "message": "Reference Images",
+    "description": "Label for reference images"
+  },
   "name.required": {
     "message": "Pflichtfeld",
     "description": "Pflichtfeld-Label"
@@ -79,6 +83,10 @@
     "message": "Optionales Eingabebild für die Videoerstellung. grok-imagine-video-1.5-preview ist erforderlich.",
     "description": "Anweisungen für die Bild-Eingabe"
   },
+  "description.referenceImages": {
+    "message": "Optional reference images to guide the style or content of the generated video (grok-imagine-video only).",
+    "description": "Instructions for reference images"
+  },
   "placeholder.prompt": {
     "message": "Beschreibe dein Video…",
     "description": "Platzhalter für die Eingabeaufforderung"
@@ -118,6 +126,10 @@
   "message.uploadExceed": {
     "message": "Es kann nur ein Bild hochgeladen werden.",
     "description": "Warnung, dass das Upload-Limit überschritten wurde"
+  },
+  "message.uploadReferenceExceed": {
+    "message": "You can upload up to 4 reference images.",
+    "description": "Reference images upload exceed warning"
   },
   "message.uploadError": {
     "message": "Bild-Upload fehlgeschlagen, bitte erneut versuchen.",

--- a/src/i18n/el/grokvideo.json
+++ b/src/i18n/el/grokvideo.json
@@ -27,6 +27,10 @@
     "message": "Εικόνα",
     "description": "Ετικέτα για την είσοδο εικόνας"
   },
+  "name.referenceImages": {
+    "message": "Reference Images",
+    "description": "Label for reference images"
+  },
   "name.required": {
     "message": "Υποχρεωτικό",
     "description": "Σήμα υποχρεωτικού πεδίου"
@@ -79,6 +83,10 @@
     "message": "Προαιρετική είσοδος εικόνας, για βίντεο που δημιουργούνται από εικόνες. Το grok-imagine-video-1.5-preview είναι υποχρεωτικό.",
     "description": "Οδηγίες για την είσοδο εικόνας"
   },
+  "description.referenceImages": {
+    "message": "Optional reference images to guide the style or content of the generated video (grok-imagine-video only).",
+    "description": "Instructions for reference images"
+  },
   "placeholder.prompt": {
     "message": "Περιγράψτε το βίντεό σας…",
     "description": "Placeholder για την προτροπή"
@@ -118,6 +126,10 @@
   "message.uploadExceed": {
     "message": "Μπορείτε να ανεβάσετε μόνο μία εικόνα.",
     "description": "Προειδοποίηση υπέρβασης ανέβασματος"
+  },
+  "message.uploadReferenceExceed": {
+    "message": "You can upload up to 4 reference images.",
+    "description": "Reference images upload exceed warning"
   },
   "message.uploadError": {
     "message": "Η ανέβασμα εικόνας απέτυχε, παρακαλώ δοκιμάστε ξανά.",

--- a/src/i18n/en/grokvideo.json
+++ b/src/i18n/en/grokvideo.json
@@ -6,6 +6,7 @@
   "name.resolution": { "message": "Resolution", "description": "Label for resolution" },
   "name.duration": { "message": "Duration", "description": "Label for duration" },
   "name.image": { "message": "Image", "description": "Label for input image" },
+  "name.referenceImages": { "message": "Reference Images", "description": "Label for reference images" },
   "name.required": { "message": "Required", "description": "Required badge" },
   "name.taskId": { "message": "Task ID", "description": "Task id label" },
   "name.elapsed": { "message": "Elapsed", "description": "Elapsed time label" },
@@ -34,6 +35,10 @@
     "message": "Optional input image to animate (image-to-video). Required for grok-imagine-video-1.5-preview.",
     "description": "Instructions for image input"
   },
+  "description.referenceImages": {
+    "message": "Optional reference images to guide the style or content of the generated video (grok-imagine-video only).",
+    "description": "Instructions for reference images"
+  },
   "placeholder.prompt": { "message": "Describe your video…", "description": "Placeholder for prompt" },
   "placeholder.select": { "message": "Please select", "description": "Placeholder for selects" },
   "model.default": { "message": "Grok Imagine Video", "description": "Default model label" },
@@ -44,6 +49,7 @@
   "status.pending": { "message": "Pending", "description": "Pending status" },
   "status.processing": { "message": "Processing", "description": "Processing status" },
   "message.uploadExceed": { "message": "You can upload only one image.", "description": "Upload exceed warning" },
+  "message.uploadReferenceExceed": { "message": "You can upload up to 4 reference images.", "description": "Reference images upload exceed warning" },
   "message.uploadError": { "message": "Image upload failed, please try again.", "description": "Upload error" },
   "message.downloadVideo": { "message": "Download video", "description": "Download tooltip" },
   "message.modelRequiresImage": {

--- a/src/i18n/es/grokvideo.json
+++ b/src/i18n/es/grokvideo.json
@@ -27,6 +27,10 @@
     "message": "Imagen",
     "description": "Etiqueta para la entrada de imagen"
   },
+  "name.referenceImages": {
+    "message": "Reference Images",
+    "description": "Label for reference images"
+  },
   "name.required": {
     "message": "Requerido",
     "description": "Insignia de requerido"
@@ -79,6 +83,10 @@
     "message": "Imagen de entrada opcional, utilizada para generar video. grok-imagine-video-1.5-preview es obligatorio.",
     "description": "Instrucciones para la entrada de imagen"
   },
+  "description.referenceImages": {
+    "message": "Optional reference images to guide the style or content of the generated video (grok-imagine-video only).",
+    "description": "Instructions for reference images"
+  },
   "placeholder.prompt": {
     "message": "Describe tu video…",
     "description": "Placeholder para la palabra clave"
@@ -118,6 +126,10 @@
   "message.uploadExceed": {
     "message": "Solo se puede subir una imagen.",
     "description": "Advertencia de exceso de subida"
+  },
+  "message.uploadReferenceExceed": {
+    "message": "You can upload up to 4 reference images.",
+    "description": "Reference images upload exceed warning"
   },
   "message.uploadError": {
     "message": "Error al subir la imagen, por favor intenta de nuevo.",

--- a/src/i18n/fi/grokvideo.json
+++ b/src/i18n/fi/grokvideo.json
@@ -27,6 +27,10 @@
     "message": "Kuva",
     "description": "Syöttokuvan etiketti"
   },
+  "name.referenceImages": {
+    "message": "Reference Images",
+    "description": "Label for reference images"
+  },
   "name.required": {
     "message": "Pakollinen",
     "description": "Pakollinen merkki"
@@ -79,6 +83,10 @@
     "message": "Valinnainen syötekuva videon tuottamiseen. grok-imagine-video-1.5-preview on pakollinen.",
     "description": "Ohjeet kuva syötteelle"
   },
+  "description.referenceImages": {
+    "message": "Optional reference images to guide the style or content of the generated video (grok-imagine-video only).",
+    "description": "Instructions for reference images"
+  },
   "placeholder.prompt": {
     "message": "Kuvaile videota…",
     "description": "Kehotteen paikkamerkki"
@@ -118,6 +126,10 @@
   "message.uploadExceed": {
     "message": "Vain yksi kuva voidaan ladata.",
     "description": "Latausylitysvaroitus"
+  },
+  "message.uploadReferenceExceed": {
+    "message": "You can upload up to 4 reference images.",
+    "description": "Reference images upload exceed warning"
   },
   "message.uploadError": {
     "message": "Kuvan lataaminen epäonnistui, yritä uudelleen.",

--- a/src/i18n/fr/grokvideo.json
+++ b/src/i18n/fr/grokvideo.json
@@ -27,6 +27,10 @@
     "message": "Image",
     "description": "Étiquette pour l'image d'entrée"
   },
+  "name.referenceImages": {
+    "message": "Reference Images",
+    "description": "Label for reference images"
+  },
   "name.required": {
     "message": "Champ requis",
     "description": "Badge indiquant que le champ est obligatoire"
@@ -79,6 +83,10 @@
     "message": "Image d'entrée optionnelle pour générer une vidéo. grok-imagine-video-1.5-preview est requis.",
     "description": "Instructions pour l'entrée d'image"
   },
+  "description.referenceImages": {
+    "message": "Optional reference images to guide the style or content of the generated video (grok-imagine-video only).",
+    "description": "Instructions for reference images"
+  },
   "placeholder.prompt": {
     "message": "Décrivez votre vidéo…",
     "description": "Espace réservé pour l'invite"
@@ -118,6 +126,10 @@
   "message.uploadExceed": {
     "message": "Vous ne pouvez téléverser qu'une seule image.",
     "description": "Avertissement sur le dépassement de téléversement"
+  },
+  "message.uploadReferenceExceed": {
+    "message": "You can upload up to 4 reference images.",
+    "description": "Reference images upload exceed warning"
   },
   "message.uploadError": {
     "message": "Échec du téléversement de l'image, veuillez réessayer.",

--- a/src/i18n/it/grokvideo.json
+++ b/src/i18n/it/grokvideo.json
@@ -27,6 +27,10 @@
     "message": "Immagine",
     "description": "Etichetta per l'immagine di input"
   },
+  "name.referenceImages": {
+    "message": "Reference Images",
+    "description": "Label for reference images"
+  },
   "name.required": {
     "message": "Obbligatorio",
     "description": "Badge per campo obbligatorio"
@@ -79,6 +83,10 @@
     "message": "Immagine di input opzionale, utilizzata per generare video. grok-imagine-video-1.5-preview è obbligatorio.",
     "description": "Istruzioni per l'input dell'immagine"
   },
+  "description.referenceImages": {
+    "message": "Optional reference images to guide the style or content of the generated video (grok-imagine-video only).",
+    "description": "Instructions for reference images"
+  },
   "placeholder.prompt": {
     "message": "Descrivi il tuo video…",
     "description": "Placeholder per la parola chiave"
@@ -118,6 +126,10 @@
   "message.uploadExceed": {
     "message": "Puoi caricare solo un'immagine.",
     "description": "Avviso di superamento dell'upload"
+  },
+  "message.uploadReferenceExceed": {
+    "message": "You can upload up to 4 reference images.",
+    "description": "Reference images upload exceed warning"
   },
   "message.uploadError": {
     "message": "Caricamento dell'immagine fallito, riprova.",

--- a/src/i18n/ja/grokvideo.json
+++ b/src/i18n/ja/grokvideo.json
@@ -27,6 +27,10 @@
     "message": "画像",
     "description": "画像入力のラベル"
   },
+  "name.referenceImages": {
+    "message": "Reference Images",
+    "description": "Label for reference images"
+  },
   "name.required": {
     "message": "必須",
     "description": "必須バッジ"
@@ -79,6 +83,10 @@
     "message": "オプションの入力画像、動画生成に使用します。grok-imagine-video-1.5-previewは必須です。",
     "description": "画像入力に関する指示"
   },
+  "description.referenceImages": {
+    "message": "Optional reference images to guide the style or content of the generated video (grok-imagine-video only).",
+    "description": "Instructions for reference images"
+  },
   "placeholder.prompt": {
     "message": "あなたのビデオを説明してください…",
     "description": "プロンプトのプレースホルダー"
@@ -118,6 +126,10 @@
   "message.uploadExceed": {
     "message": "画像は1枚のみアップロードできます。",
     "description": "アップロード超過警告"
+  },
+  "message.uploadReferenceExceed": {
+    "message": "You can upload up to 4 reference images.",
+    "description": "Reference images upload exceed warning"
   },
   "message.uploadError": {
     "message": "画像のアップロードに失敗しました。再試行してください。",

--- a/src/i18n/ko/grokvideo.json
+++ b/src/i18n/ko/grokvideo.json
@@ -27,6 +27,10 @@
     "message": "이미지",
     "description": "입력 이미지의 레이블"
   },
+  "name.referenceImages": {
+    "message": "Reference Images",
+    "description": "Label for reference images"
+  },
   "name.required": {
     "message": "필수",
     "description": "필수 배지"
@@ -79,6 +83,10 @@
     "message": "비디오 생성을 위한 선택적 입력 이미지. grok-imagine-video-1.5-preview는 필수입니다.",
     "description": "이미지 입력에 대한 설명"
   },
+  "description.referenceImages": {
+    "message": "Optional reference images to guide the style or content of the generated video (grok-imagine-video only).",
+    "description": "Instructions for reference images"
+  },
   "placeholder.prompt": {
     "message": "비디오를 설명하세요…",
     "description": "프롬프트를 위한 플레이스홀더"
@@ -118,6 +126,10 @@
   "message.uploadExceed": {
     "message": "이미지는 한 장만 업로드할 수 있습니다.",
     "description": "업로드 초과 경고"
+  },
+  "message.uploadReferenceExceed": {
+    "message": "You can upload up to 4 reference images.",
+    "description": "Reference images upload exceed warning"
   },
   "message.uploadError": {
     "message": "이미지 업로드 실패, 다시 시도하세요.",

--- a/src/i18n/pl/grokvideo.json
+++ b/src/i18n/pl/grokvideo.json
@@ -27,6 +27,10 @@
     "message": "Obraz",
     "description": "Etykieta dla wprowadzenia obrazu"
   },
+  "name.referenceImages": {
+    "message": "Reference Images",
+    "description": "Label for reference images"
+  },
   "name.required": {
     "message": "Wymagane",
     "description": "Odznaka wymagania"
@@ -79,6 +83,10 @@
     "message": "Opcjonalny obraz wejściowy do generowania wideo. grok-imagine-video-1.5-preview jest wymagany.",
     "description": "Instrukcje dotyczące obrazu wejściowego"
   },
+  "description.referenceImages": {
+    "message": "Optional reference images to guide the style or content of the generated video (grok-imagine-video only).",
+    "description": "Instructions for reference images"
+  },
   "placeholder.prompt": {
     "message": "Opisz swoje wideo…",
     "description": "Miejsce na podpowiedź"
@@ -118,6 +126,10 @@
   "message.uploadExceed": {
     "message": "Można przesłać tylko jeden obraz.",
     "description": "Ostrzeżenie o przekroczeniu limitu przesyłania"
+  },
+  "message.uploadReferenceExceed": {
+    "message": "You can upload up to 4 reference images.",
+    "description": "Reference images upload exceed warning"
   },
   "message.uploadError": {
     "message": "Nie udało się przesłać obrazu, spróbuj ponownie.",

--- a/src/i18n/pt/grokvideo.json
+++ b/src/i18n/pt/grokvideo.json
@@ -27,6 +27,10 @@
     "message": "Imagem",
     "description": "Rótulo para entrada de imagem"
   },
+  "name.referenceImages": {
+    "message": "Reference Images",
+    "description": "Label for reference images"
+  },
   "name.required": {
     "message": "Obrigatório",
     "description": "Sinalizador de campo obrigatório"
@@ -79,6 +83,10 @@
     "message": "Imagem de entrada opcional, usada para gerar vídeo. grok-imagine-video-1.5-preview é obrigatório.",
     "description": "Instruções para a entrada de imagem"
   },
+  "description.referenceImages": {
+    "message": "Optional reference images to guide the style or content of the generated video (grok-imagine-video only).",
+    "description": "Instructions for reference images"
+  },
   "placeholder.prompt": {
     "message": "Descreva seu vídeo…",
     "description": "Texto de espaço reservado para prompt"
@@ -118,6 +126,10 @@
   "message.uploadExceed": {
     "message": "Somente uma imagem pode ser enviada.",
     "description": "Aviso de excesso de upload"
+  },
+  "message.uploadReferenceExceed": {
+    "message": "You can upload up to 4 reference images.",
+    "description": "Reference images upload exceed warning"
   },
   "message.uploadError": {
     "message": "Falha ao enviar a imagem, por favor tente novamente.",

--- a/src/i18n/ru/grokvideo.json
+++ b/src/i18n/ru/grokvideo.json
@@ -27,6 +27,10 @@
     "message": "Изображение",
     "description": "Метка для ввода изображения"
   },
+  "name.referenceImages": {
+    "message": "Reference Images",
+    "description": "Label for reference images"
+  },
   "name.required": {
     "message": "Обязательно",
     "description": "Значок обязательного поля"
@@ -79,6 +83,10 @@
     "message": "Необязательное входное изображение для генерации видео. grok-imagine-video-1.5-preview обязательно.",
     "description": "Инструкции по входному изображению"
   },
+  "description.referenceImages": {
+    "message": "Optional reference images to guide the style or content of the generated video (grok-imagine-video only).",
+    "description": "Instructions for reference images"
+  },
   "placeholder.prompt": {
     "message": "Опишите ваше видео…",
     "description": "Заполнитель для подсказки"
@@ -118,6 +126,10 @@
   "message.uploadExceed": {
     "message": "Можно загрузить только одно изображение.",
     "description": "Предупреждение о превышении загрузки"
+  },
+  "message.uploadReferenceExceed": {
+    "message": "You can upload up to 4 reference images.",
+    "description": "Reference images upload exceed warning"
   },
   "message.uploadError": {
     "message": "Ошибка загрузки изображения, пожалуйста, попробуйте снова.",

--- a/src/i18n/sr/grokvideo.json
+++ b/src/i18n/sr/grokvideo.json
@@ -27,6 +27,10 @@
     "message": "Слика",
     "description": "Ознака за унос слике"
   },
+  "name.referenceImages": {
+    "message": "Reference Images",
+    "description": "Label for reference images"
+  },
   "name.required": {
     "message": "Обавезно",
     "description": "Ознака за обавезна поља"
@@ -79,6 +83,10 @@
     "message": "Opcionalna ulazna slika, koristi se za generisanje videa. grok-imagine-video-1.5-preview je obavezno.",
     "description": "Uputstvo za ulaznu sliku"
   },
+  "description.referenceImages": {
+    "message": "Optional reference images to guide the style or content of the generated video (grok-imagine-video only).",
+    "description": "Instructions for reference images"
+  },
   "placeholder.prompt": {
     "message": "Опишите ваш видео…",
     "description": "Плацехолдер за упитник"
@@ -118,6 +126,10 @@
   "message.uploadExceed": {
     "message": "Možete otpremiti samo jednu sliku.",
     "description": "Upozorenje o prekoračenju otpremanja"
+  },
+  "message.uploadReferenceExceed": {
+    "message": "You can upload up to 4 reference images.",
+    "description": "Reference images upload exceed warning"
   },
   "message.uploadError": {
     "message": "Otpremanje slike nije uspelo, molimo pokušajte ponovo.",

--- a/src/i18n/sv/grokvideo.json
+++ b/src/i18n/sv/grokvideo.json
@@ -27,6 +27,10 @@
     "message": "Bild",
     "description": "Etikett för inmatningsbild"
   },
+  "name.referenceImages": {
+    "message": "Reference Images",
+    "description": "Label for reference images"
+  },
   "name.required": {
     "message": "Obligatorisk",
     "description": "Obligatorisk märkning"
@@ -79,6 +83,10 @@
     "message": "Valfri inmatningsbild för att generera video. grok-imagine-video-1.5-preview är obligatorisk.",
     "description": "Instruktioner för bildinmatning"
   },
+  "description.referenceImages": {
+    "message": "Optional reference images to guide the style or content of the generated video (grok-imagine-video only).",
+    "description": "Instructions for reference images"
+  },
   "placeholder.prompt": {
     "message": "Beskriv din video…",
     "description": "Platsinnehåll för prompt"
@@ -118,6 +126,10 @@
   "message.uploadExceed": {
     "message": "Endast en bild kan laddas upp.",
     "description": "Varning för överskridning av uppladdning"
+  },
+  "message.uploadReferenceExceed": {
+    "message": "You can upload up to 4 reference images.",
+    "description": "Reference images upload exceed warning"
   },
   "message.uploadError": {
     "message": "Bilduppladdning misslyckades, försök igen.",

--- a/src/i18n/uk/grokvideo.json
+++ b/src/i18n/uk/grokvideo.json
@@ -27,6 +27,10 @@
     "message": "Зображення",
     "description": "Мітка для введення зображення"
   },
+  "name.referenceImages": {
+    "message": "Reference Images",
+    "description": "Label for reference images"
+  },
   "name.required": {
     "message": "Обов'язково",
     "description": "Знак обов'язковості"
@@ -79,6 +83,10 @@
     "message": "Додаткове зображення для генерації відео. grok-imagine-video-1.5-preview є обов'язковим.",
     "description": "Інструкції щодо введення зображення"
   },
+  "description.referenceImages": {
+    "message": "Optional reference images to guide the style or content of the generated video (grok-imagine-video only).",
+    "description": "Instructions for reference images"
+  },
   "placeholder.prompt": {
     "message": "Опишіть ваше відео…",
     "description": "Заповнювач для запиту"
@@ -118,6 +126,10 @@
   "message.uploadExceed": {
     "message": "Можна завантажити лише одне зображення.",
     "description": "Попередження про перевищення завантаження"
+  },
+  "message.uploadReferenceExceed": {
+    "message": "You can upload up to 4 reference images.",
+    "description": "Reference images upload exceed warning"
   },
   "message.uploadError": {
     "message": "Не вдалося завантажити зображення, будь ласка, спробуйте ще раз.",

--- a/src/i18n/zh-CN/grokvideo.json
+++ b/src/i18n/zh-CN/grokvideo.json
@@ -6,6 +6,7 @@
   "name.resolution": { "message": "分辨率", "description": "Label for resolution" },
   "name.duration": { "message": "时长", "description": "Label for duration" },
   "name.image": { "message": "图片", "description": "Label for input image" },
+  "name.referenceImages": { "message": "参考图", "description": "Label for reference images" },
   "name.required": { "message": "必填", "description": "Required badge" },
   "name.taskId": { "message": "任务 ID", "description": "Task id label" },
   "name.elapsed": { "message": "耗时", "description": "Elapsed time label" },
@@ -34,6 +35,10 @@
     "message": "可选的输入图片，用于图生视频。grok-imagine-video-1.5-preview 为必填。",
     "description": "Instructions for image input"
   },
+  "description.referenceImages": {
+    "message": "可选的参考图，用于引导生成视频的风格或内容（仅 grok-imagine-video 支持）。",
+    "description": "Instructions for reference images"
+  },
   "placeholder.prompt": { "message": "描述你的视频…", "description": "Placeholder for prompt" },
   "placeholder.select": { "message": "请选择", "description": "Placeholder for selects" },
   "model.default": { "message": "Grok Imagine 视频", "description": "Default model label" },
@@ -44,6 +49,7 @@
   "status.pending": { "message": "排队中", "description": "Pending status" },
   "status.processing": { "message": "生成中", "description": "Processing status" },
   "message.uploadExceed": { "message": "只能上传一张图片。", "description": "Upload exceed warning" },
+  "message.uploadReferenceExceed": { "message": "最多可上传 4 张参考图。", "description": "Reference images upload exceed warning" },
   "message.uploadError": { "message": "图片上传失败，请重试。", "description": "Upload error" },
   "message.downloadVideo": { "message": "下载视频", "description": "Download tooltip" },
   "message.modelRequiresImage": {

--- a/src/i18n/zh-TW/grokvideo.json
+++ b/src/i18n/zh-TW/grokvideo.json
@@ -27,6 +27,10 @@
     "message": "圖片",
     "description": "輸入圖片的標籤"
   },
+  "name.referenceImages": {
+    "message": "Reference Images",
+    "description": "Label for reference images"
+  },
   "name.required": {
     "message": "必填",
     "description": "必填標籤"
@@ -79,6 +83,10 @@
     "message": "可選的輸入圖片，用於圖生視頻。grok-imagine-video-1.5-preview 為必填。",
     "description": "有關圖片輸入的說明"
   },
+  "description.referenceImages": {
+    "message": "Optional reference images to guide the style or content of the generated video (grok-imagine-video only).",
+    "description": "Instructions for reference images"
+  },
   "placeholder.prompt": {
     "message": "描述你的视频…",
     "description": "提示的佔位符"
@@ -118,6 +126,10 @@
   "message.uploadExceed": {
     "message": "只能上傳一張圖片。",
     "description": "上傳超過限制的警告"
+  },
+  "message.uploadReferenceExceed": {
+    "message": "You can upload up to 4 reference images.",
+    "description": "Reference images upload exceed warning"
   },
   "message.uploadError": {
     "message": "圖片上傳失敗，請重試。",

--- a/src/layouts/GrokVideo.vue
+++ b/src/layouts/GrokVideo.vue
@@ -1,0 +1,57 @@
+<template>
+  <div class="main flex flex-row flex-1">
+    <div
+      class="config w-[320px] flex-none h-full overflow-y-auto bg-[var(--app-sidebar-bg)] border-r border-[var(--app-border-subtle)]"
+    >
+      <slot name="config" />
+    </div>
+    <div class="result h-full p-6 flex-1 flex flex-col min-w-0 overflow-x-hidden bg-[var(--app-content-bg)]">
+      <slot name="result" />
+    </div>
+    <el-button v-show="!tasksEmpty" circle class="menu" @click="drawer = true">
+      <font-awesome-icon icon="fa-solid fa-magic" />
+    </el-button>
+    <el-drawer v-model="drawer" direction="ltr" :with-header="false" size="350px">
+      <slot name="config" />
+    </el-drawer>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElDrawer, ElButton } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import taskDrawerMixin from '@/utils/taskDrawerMixin';
+
+export default defineComponent({
+  name: 'LayoutGrokVideo',
+  components: {
+    ElDrawer,
+    ElButton,
+    FontAwesomeIcon
+  },
+  mixins: [taskDrawerMixin]
+});
+</script>
+
+<style lang="scss" scoped>
+.menu {
+  display: none;
+}
+
+@media (max-width: 767px) {
+  .config {
+    display: none;
+  }
+  .result {
+    width: 100%;
+  }
+  .menu {
+    display: block;
+    position: absolute;
+    right: 8px;
+    top: calc(45px + var(--app-safe-area-top));
+    z-index: 1000;
+  }
+}
+</style>

--- a/src/pages/grokvideo/Index.vue
+++ b/src/pages/grokvideo/Index.vue
@@ -11,7 +11,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import Layout from '@/layouts/Seedance.vue';
+import Layout from '@/layouts/GrokVideo.vue';
 import ConfigPanel from '@/components/grokvideo/ConfigPanel.vue';
 import RecentPanel from '@/components/grokvideo/RecentPanel.vue';
 import { grokvideoOperator } from '@/operators';
@@ -140,6 +140,14 @@ export default defineComponent({
       }
       if (typeof cfg?.image_url === 'string' && !cfg.image_url.trim()) {
         delete cfg.image_url;
+      }
+      // Reference images are only supported by grok-imagine-video (1.0). Drop
+      // stale refs (e.g. uploaded on 1.0 then switched to 1.5-preview) and empties.
+      if (
+        isGrokVideoImageOnlyModel(cfg?.model) ||
+        !(Array.isArray(cfg?.reference_image_urls) && cfg.reference_image_urls.length)
+      ) {
+        delete cfg.reference_image_urls;
       }
 
       const hasImage = !!cfg?.image_url;


### PR DESCRIPTION
## What

Polish the Grok Video page per review feedback.

1. **Dedicated layout** — Grok Video was the only service page borrowing another service's
   layout (`Seedance.vue`). Added its own `src/layouts/GrokVideo.vue` and repointed the page.
   Audited every other service page: all already have their own layout, so no other changes needed.
2. **Multi reference images** — new `ReferenceImagesInput.vue` (up to 4 → `reference_image_urls`),
   shown only for `grok-imagine-video` (1.0). Mirrors nano-banana's multi-image UX and uses an
   API capability we already support. `grok-imagine-video-1.5-preview` stays single-image.
3. **Pending elapsed timer** — the non-official upstream returns no progress %, so the pending
   task card now shows a live elapsed-seconds counter (honest signal during the 1–2 min wait).
   `setInterval` is cleared in `beforeUnmount` and when the response arrives.

## Correctness

- At generate time, `reference_image_urls` is stripped for image-only models (1.5-preview) and
  when empty — so refs uploaded on 1.0 can't leak into a 1.5-preview request.
- i18n: 3 new keys backfilled across all 18 locales; `check_i18n_coverage.py` passes.

## Verification

- `vue-tsc --noEmit` clean, eslint clean, prettier clean, i18n coverage guard OK.

## 🤖 对抗评审 (codex, read-only)

- **RISK (High, fixed):** stale `reference_image_urls` (uploaded on 1.0) would be sent for
  1.5-preview after a model switch → fixed by stripping it for image-only models at generate time.
- Re-review verdict: **CLEAN**.