### PR TITLE
fix(balance): live-refresh Credits pill after generations across all modules

### DIFF
--- a/change/@acedatacloud-nexior-balance-pill-live-refresh.json
+++ b/change/@acedatacloud-nexior-balance-pill-live-refresh.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(balance): live-refresh the Credits pill after generations across all service modules",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/layouts/Main.vue
+++ b/src/layouts/Main.vue
@@ -28,6 +28,11 @@ import { ERROR_CODE_DUPLICATION } from '@/constants';
 import ApplicationConfirm from '@/components/application/Confirm.vue';
 import { getFinalApplication } from '@/utils';
 
+// How often the floating Credits pill re-syncs the selected application's
+// balance. Generations spend credits server-side at task-creation time, so
+// without this the pill stayed stale until a full page reload.
+const BALANCE_REFRESH_INTERVAL_MS = 15000;
+
 export default defineComponent({
   name: 'LayoutMain',
   components: {
@@ -45,7 +50,8 @@ export default defineComponent({
       initialized: false,
       applying: false,
       mobile: typeof window !== 'undefined' && window.innerWidth < 768,
-      initializeRunId: 0
+      initializeRunId: 0,
+      balanceTimer: 0
     };
   },
   computed: {
@@ -92,13 +98,45 @@ export default defineComponent({
     // service-page navigation, so the anonymous-arrow version was leaking
     // one listener per visit, all of which kept the mounted instance alive.
     window.addEventListener('resize', this.onResize);
+    // Keep the floating Credits pill live after generations spend balance:
+    // refresh on an interval and whenever the tab regains focus.
+    this.balanceTimer = window.setInterval(this.refreshBalances, BALANCE_REFRESH_INTERVAL_MS);
+    document.addEventListener('visibilitychange', this.onVisibility);
   },
   beforeUnmount() {
     window.removeEventListener('resize', this.onResize);
+    window.clearInterval(this.balanceTimer);
+    document.removeEventListener('visibilitychange', this.onVisibility);
   },
   methods: {
     onResize() {
       this.mobile = window.innerWidth < 768;
+    },
+    onVisibility() {
+      if (typeof document !== 'undefined' && !document.hidden) {
+        this.refreshBalances();
+      }
+    },
+    // Re-sync the selected application's balance so the floating Credits pill
+    // reflects spend right after a generation, without a full page reload.
+    async refreshBalances() {
+      if (!this.appName) return;
+      if (!this.$store.state.token?.access) return;
+      if (typeof document !== 'undefined' && document.hidden) return;
+      if (this.loading) return;
+      await Promise.allSettled([
+        this.$store.dispatch('getApplications'),
+        this.$store.dispatch(`${this.appName}/getApplications`)
+      ]);
+      // Update via the plain mutation with a fresh copy from the just-fetched
+      // list — NOT the setApplication action, which would re-run credential
+      // creation on every tick.
+      const current = this.$store.state[this.appName]?.application;
+      if (!current) return;
+      const fresh = this.applications?.find((a) => a.id === current.id);
+      if (fresh && fresh !== current) {
+        this.$store.commit(`${this.appName}/setApplication`, fresh);
+      }
     },
     async initialize() {
       const runId = ++this.initializeRunId;


### PR DESCRIPTION
## Problem

The floating **Credits** balance pill (top-right on every AI service page) is rendered by `src/layouts/Main.vue` → `ApplicationStatus`, bound to `store.state[appName].application.remaining_amount`. That application object is fetched **only** in `Main.vue.initialize()`, which runs on mount / `appName` change / `userId` change.

After a generation, the gateway deducts credits **server-side**, but nothing on the client re-fetches the application — so the pill keeps showing the pre-generation balance until a **full page reload**. This is **general across all ~15 service modules** (grok-video, seedance, nanobanana, suno, kling, …), since they all share the same shell + the `createTaskActions` store factory.

## Fix

`Main.vue` is the single shell that renders the pill for every module, so the fix lives in **one file**:

- Adds `refreshBalances()` — re-fetches global + current-module applications, then refreshes the **already-selected** app's mutable balance via the namespaced `setApplication` **mutation** (a fresh copy from the just-fetched list, matched by id).
- Runs it on a **15s interval** and on **tab refocus** (`visibilitychange`).
- Guards: skip when logged out, tab hidden, no active `appName`, or a fetch is already in flight.

### Why the mutation, not the `setApplication` action

`createTaskActions`' `setApplication` **action** dispatches `createCredential` as a side effect when no host credential is found. Calling it on a timer could spawn duplicate credentials. The **mutation** is a plain setter (`state.application = payload`), so committing a fresh app object only updates the balance the pill reads — credential state is untouched.

`getFinalApplication` already returns the fresh server copy (matched by id), so `remaining_amount` reflects server truth.

## Scope / risk

- One file: `src/layouts/Main.vue`. No new UI strings (no i18n impact).
- Extra load: 2 `getApplications` calls per 15s while a service page is open + visible — same ballpark as the existing 5s task polling.
- No behavior change when logged out or on non-service routes (guarded by `appName` + token).

## Test

- `vue-tsc -b` (CI build mode) + `eslint` clean.
- Live verify after deploy: generate on a service page, confirm the pill drops within ~15s without reload.
