### PR TITLE
feat(maestro): add quality tier selector (draft/standard/premium)

### DIFF
--- a/change/@acedatacloud-nexior-91703dbf-38a9-441a-b893-195027d79ae7.json
+++ b/change/@acedatacloud-nexior-91703dbf-38a9-441a-b893-195027d79ae7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(maestro): quality tier selector (draft/standard/premium)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/maestro/ConfigPanel.vue
+++ b/src/components/maestro/ConfigPanel.vue
@@ -53,6 +53,19 @@
           <el-option v-for="d in MAESTRO_ALLOWED_DURATIONS" :key="d" :label="`${d}s`" :value="d" />
         </el-select>
       </div>
+
+      <!-- Quality (production tier) -->
+      <div class="mb-4">
+        <span class="text-sm font-bold mb-2 block">{{ $t('maestro.name.quality') }}</span>
+        <el-select v-model="quality" class="w-full">
+          <el-option
+            v-for="q in MAESTRO_ALLOWED_QUALITIES"
+            :key="q"
+            :label="$t(`maestro.option.quality.${q}`)"
+            :value="q"
+          />
+        </el-select>
+      </div>
     </div>
 
     <div class="flex flex-col items-center justify-center px-5 pb-5">
@@ -79,7 +92,9 @@ import {
   MAESTRO_DEFAULT_ACTION,
   MAESTRO_DEFAULT_LANGS,
   MAESTRO_DEFAULT_ASPECT,
-  MAESTRO_DEFAULT_DURATION
+  MAESTRO_DEFAULT_DURATION,
+  MAESTRO_ALLOWED_QUALITIES,
+  MAESTRO_DEFAULT_QUALITY
 } from '@/constants';
 import { IMaestroConfig } from '@/models';
 
@@ -102,7 +117,8 @@ export default defineComponent({
     return {
       MAESTRO_ALLOWED_LANGS,
       MAESTRO_ALLOWED_ASPECTS,
-      MAESTRO_ALLOWED_DURATIONS
+      MAESTRO_ALLOWED_DURATIONS,
+      MAESTRO_ALLOWED_QUALITIES
     };
   },
   computed: {
@@ -157,6 +173,14 @@ export default defineComponent({
       set(val: number) {
         this.update({ duration: val });
       }
+    },
+    quality: {
+      get(): string | undefined {
+        return this.config?.quality;
+      },
+      set(val: string) {
+        this.update({ quality: val });
+      }
     }
   },
   mounted() {
@@ -164,7 +188,8 @@ export default defineComponent({
       action: this.config?.action ?? MAESTRO_DEFAULT_ACTION,
       langs: this.config?.langs?.length ? this.config.langs : MAESTRO_DEFAULT_LANGS,
       aspect: this.config?.aspect ?? MAESTRO_DEFAULT_ASPECT,
-      duration: this.config?.duration ?? MAESTRO_DEFAULT_DURATION
+      duration: this.config?.duration ?? MAESTRO_DEFAULT_DURATION,
+      quality: this.config?.quality ?? MAESTRO_DEFAULT_QUALITY
     });
   },
   methods: {

--- a/src/constants/maestro.ts
+++ b/src/constants/maestro.ts
@@ -10,6 +10,8 @@ export const MAESTRO_ACTION_EXTEND = 'extend';
 export const MAESTRO_ALLOWED_ASPECTS = ['9:16', '16:9', '1:1'];
 export const MAESTRO_ALLOWED_LANGS = ['zh-cn', 'en', 'ja', 'ko', 'es', 'fr', 'de'];
 export const MAESTRO_ALLOWED_DURATIONS = [20, 30, 45, 60];
+// Production tier (effort/price): draft = fast preview, standard = balanced, premium = richer.
+export const MAESTRO_ALLOWED_QUALITIES = ['draft', 'standard', 'premium'];
 
 // Accepted reference media for file_urls (images / video / audio).
 export const MAESTRO_FILE_ACCEPT = '.png,.jpg,.jpeg,.gif,.bmp,.webp,.mp4,.mov,.webm,.mp3,.wav,.m4a';
@@ -19,3 +21,4 @@ export const MAESTRO_DEFAULT_ACTION = MAESTRO_ACTION_GENERATE;
 export const MAESTRO_DEFAULT_LANGS = ['zh-cn'];
 export const MAESTRO_DEFAULT_ASPECT = '9:16';
 export const MAESTRO_DEFAULT_DURATION = 30;
+export const MAESTRO_DEFAULT_QUALITY = 'standard';

--- a/src/i18n/ar/maestro.json
+++ b/src/i18n/ar/maestro.json
@@ -47,6 +47,22 @@
     "message": "المدة",
     "description": "حقل المدة المستهدفة"
   },
+  "name.quality": {
+    "message": "الجودة",
+    "description": "Production quality tier field"
+  },
+  "option.quality.draft": {
+    "message": "مسودة · معاينة سريعة",
+    "description": "Draft quality option"
+  },
+  "option.quality.standard": {
+    "message": "قياسي · متوازن",
+    "description": "Standard quality option"
+  },
+  "option.quality.premium": {
+    "message": "متميز · تفاصيل أكثر",
+    "description": "Premium quality option"
+  },
   "name.remixing": {
     "message": "إعادة التعديل",
     "description": "علامة شريط إعادة التعديل"

--- a/src/i18n/de/maestro.json
+++ b/src/i18n/de/maestro.json
@@ -47,6 +47,22 @@
     "message": "Dauer",
     "description": "Ziel-Dauerfeld"
   },
+  "name.quality": {
+    "message": "Qualität",
+    "description": "Production quality tier field"
+  },
+  "option.quality.draft": {
+    "message": "Entwurf · schnelle Vorschau",
+    "description": "Draft quality option"
+  },
+  "option.quality.standard": {
+    "message": "Standard · ausgewogen",
+    "description": "Standard quality option"
+  },
+  "option.quality.premium": {
+    "message": "Premium · mehr Details",
+    "description": "Premium quality option"
+  },
   "name.remixing": {
     "message": "Remix",
     "description": "Label für das Remix-Banner"

--- a/src/i18n/el/maestro.json
+++ b/src/i18n/el/maestro.json
@@ -47,6 +47,22 @@
     "message": "Διάρκεια",
     "description": "Πεδίο στοχευόμενης διάρκειας"
   },
+  "name.quality": {
+    "message": "Ποιότητα",
+    "description": "Production quality tier field"
+  },
+  "option.quality.draft": {
+    "message": "Πρόχειρο · γρήγορη προεπισκόπηση",
+    "description": "Draft quality option"
+  },
+  "option.quality.standard": {
+    "message": "Τυπικό · ισορροπημένο",
+    "description": "Standard quality option"
+  },
+  "option.quality.premium": {
+    "message": "Premium · περισσότερες λεπτομέρειες",
+    "description": "Premium quality option"
+  },
   "name.remixing": {
     "message": "Επαναδημιουργία",
     "description": "Ετικέτα banner επαναδημιουργίας"

--- a/src/i18n/en/maestro.json
+++ b/src/i18n/en/maestro.json
@@ -47,6 +47,22 @@
     "message": "Duration",
     "description": "Target duration field"
   },
+  "name.quality": {
+    "message": "Quality",
+    "description": "Production quality tier field"
+  },
+  "option.quality.draft": {
+    "message": "Draft · fast preview",
+    "description": "Draft quality option"
+  },
+  "option.quality.standard": {
+    "message": "Standard · balanced",
+    "description": "Standard quality option"
+  },
+  "option.quality.premium": {
+    "message": "Premium · more detail",
+    "description": "Premium quality option"
+  },
   "name.remixing": {
     "message": "Remixing",
     "description": "Remix banner label"

--- a/src/i18n/es/maestro.json
+++ b/src/i18n/es/maestro.json
@@ -47,6 +47,22 @@
     "message": "Duración",
     "description": "Campo de duración objetivo"
   },
+  "name.quality": {
+    "message": "Calidad",
+    "description": "Production quality tier field"
+  },
+  "option.quality.draft": {
+    "message": "Borrador · vista previa rápida",
+    "description": "Draft quality option"
+  },
+  "option.quality.standard": {
+    "message": "Estándar · equilibrado",
+    "description": "Standard quality option"
+  },
+  "option.quality.premium": {
+    "message": "Premium · más detalle",
+    "description": "Premium quality option"
+  },
   "name.remixing": {
     "message": "Rehacer",
     "description": "Etiqueta del banner de remezcla"

--- a/src/i18n/fi/maestro.json
+++ b/src/i18n/fi/maestro.json
@@ -47,6 +47,22 @@
     "message": "Kesto",
     "description": "Tavoitekesto kenttä"
   },
+  "name.quality": {
+    "message": "Laatu",
+    "description": "Production quality tier field"
+  },
+  "option.quality.draft": {
+    "message": "Luonnos · nopea esikatselu",
+    "description": "Draft quality option"
+  },
+  "option.quality.standard": {
+    "message": "Vakio · tasapainoinen",
+    "description": "Standard quality option"
+  },
+  "option.quality.premium": {
+    "message": "Premium · enemmän yksityiskohtia",
+    "description": "Premium quality option"
+  },
   "name.remixing": {
     "message": "Remix",
     "description": "Remix-bannerin etiketti"

--- a/src/i18n/fr/maestro.json
+++ b/src/i18n/fr/maestro.json
@@ -47,6 +47,22 @@
     "message": "Durée",
     "description": "Champ de durée cible"
   },
+  "name.quality": {
+    "message": "Qualité",
+    "description": "Production quality tier field"
+  },
+  "option.quality.draft": {
+    "message": "Brouillon · aperçu rapide",
+    "description": "Draft quality option"
+  },
+  "option.quality.standard": {
+    "message": "Standard · équilibré",
+    "description": "Standard quality option"
+  },
+  "option.quality.premium": {
+    "message": "Premium · plus de détails",
+    "description": "Premium quality option"
+  },
   "name.remixing": {
     "message": "Remixage",
     "description": "Étiquette de la bannière de remix"

--- a/src/i18n/it/maestro.json
+++ b/src/i18n/it/maestro.json
@@ -47,6 +47,22 @@
     "message": "Durata",
     "description": "Campo per la durata target"
   },
+  "name.quality": {
+    "message": "Qualità",
+    "description": "Production quality tier field"
+  },
+  "option.quality.draft": {
+    "message": "Bozza · anteprima rapida",
+    "description": "Draft quality option"
+  },
+  "option.quality.standard": {
+    "message": "Standard · bilanciato",
+    "description": "Standard quality option"
+  },
+  "option.quality.premium": {
+    "message": "Premium · più dettagli",
+    "description": "Premium quality option"
+  },
   "name.remixing": {
     "message": "Remix",
     "description": "Etichetta del banner remix"

--- a/src/i18n/ja/maestro.json
+++ b/src/i18n/ja/maestro.json
@@ -47,6 +47,22 @@
     "message": "長さ",
     "description": "ターゲットの長さフィールド"
   },
+  "name.quality": {
+    "message": "品質",
+    "description": "Production quality tier field"
+  },
+  "option.quality.draft": {
+    "message": "ドラフト · 高速プレビュー",
+    "description": "Draft quality option"
+  },
+  "option.quality.standard": {
+    "message": "標準 · バランス",
+    "description": "Standard quality option"
+  },
+  "option.quality.premium": {
+    "message": "プレミアム · より詳細",
+    "description": "Premium quality option"
+  },
   "name.remixing": {
     "message": "リミックス",
     "description": "リミックスバナーラベル"

--- a/src/i18n/ko/maestro.json
+++ b/src/i18n/ko/maestro.json
@@ -47,6 +47,22 @@
     "message": "지속 시간",
     "description": "목표 지속 시간 필드"
   },
+  "name.quality": {
+    "message": "품질",
+    "description": "Production quality tier field"
+  },
+  "option.quality.draft": {
+    "message": "초안 · 빠른 미리보기",
+    "description": "Draft quality option"
+  },
+  "option.quality.standard": {
+    "message": "표준 · 균형",
+    "description": "Standard quality option"
+  },
+  "option.quality.premium": {
+    "message": "프리미엄 · 더 세밀함",
+    "description": "Premium quality option"
+  },
   "name.remixing": {
     "message": "리믹스",
     "description": "리믹스 배너 레이블"

--- a/src/i18n/pl/maestro.json
+++ b/src/i18n/pl/maestro.json
@@ -47,6 +47,22 @@
     "message": "Czas trwania",
     "description": "Pole docelowego czasu trwania"
   },
+  "name.quality": {
+    "message": "Jakość",
+    "description": "Production quality tier field"
+  },
+  "option.quality.draft": {
+    "message": "Szkic · szybki podgląd",
+    "description": "Draft quality option"
+  },
+  "option.quality.standard": {
+    "message": "Standard · zrównoważony",
+    "description": "Standard quality option"
+  },
+  "option.quality.premium": {
+    "message": "Premium · więcej szczegółów",
+    "description": "Premium quality option"
+  },
   "name.remixing": {
     "message": "Remixowanie",
     "description": "Etykieta banera remixu"

--- a/src/i18n/pt/maestro.json
+++ b/src/i18n/pt/maestro.json
@@ -47,6 +47,22 @@
     "message": "Duração",
     "description": "Campo de duração alvo"
   },
+  "name.quality": {
+    "message": "Qualidade",
+    "description": "Production quality tier field"
+  },
+  "option.quality.draft": {
+    "message": "Rascunho · pré-visualização rápida",
+    "description": "Draft quality option"
+  },
+  "option.quality.standard": {
+    "message": "Padrão · equilibrado",
+    "description": "Standard quality option"
+  },
+  "option.quality.premium": {
+    "message": "Premium · mais detalhes",
+    "description": "Premium quality option"
+  },
   "name.remixing": {
     "message": "Remixando",
     "description": "Rótulo do banner de remix"

--- a/src/i18n/ru/maestro.json
+++ b/src/i18n/ru/maestro.json
@@ -47,6 +47,22 @@
     "message": "Длительность",
     "description": "Поле целевой длительности"
   },
+  "name.quality": {
+    "message": "Качество",
+    "description": "Production quality tier field"
+  },
+  "option.quality.draft": {
+    "message": "Черновик · быстрый предпросмотр",
+    "description": "Draft quality option"
+  },
+  "option.quality.standard": {
+    "message": "Стандарт · сбалансированно",
+    "description": "Standard quality option"
+  },
+  "option.quality.premium": {
+    "message": "Премиум · больше деталей",
+    "description": "Premium quality option"
+  },
   "name.remixing": {
     "message": "Ремикс",
     "description": "Метка баннера ремикса"

--- a/src/i18n/sr/maestro.json
+++ b/src/i18n/sr/maestro.json
@@ -47,6 +47,22 @@
     "message": "Trajanje",
     "description": "Polje za ciljano trajanje"
   },
+  "name.quality": {
+    "message": "Квалитет",
+    "description": "Production quality tier field"
+  },
+  "option.quality.draft": {
+    "message": "Нацрт · брзи преглед",
+    "description": "Draft quality option"
+  },
+  "option.quality.standard": {
+    "message": "Стандард · уравнотежено",
+    "description": "Standard quality option"
+  },
+  "option.quality.premium": {
+    "message": "Премијум · више детаља",
+    "description": "Premium quality option"
+  },
   "name.remixing": {
     "message": "Ремиксовање",
     "description": "Ознака банера за ремиксовање"

--- a/src/i18n/sv/maestro.json
+++ b/src/i18n/sv/maestro.json
@@ -47,6 +47,22 @@
     "message": "Längd",
     "description": "Mållängdsfält"
   },
+  "name.quality": {
+    "message": "Kvalitet",
+    "description": "Production quality tier field"
+  },
+  "option.quality.draft": {
+    "message": "Utkast · snabb förhandsvisning",
+    "description": "Draft quality option"
+  },
+  "option.quality.standard": {
+    "message": "Standard · balanserad",
+    "description": "Standard quality option"
+  },
+  "option.quality.premium": {
+    "message": "Premium · mer detaljer",
+    "description": "Premium quality option"
+  },
   "name.remixing": {
     "message": "Remix",
     "description": "Remix banner etikett"

--- a/src/i18n/uk/maestro.json
+++ b/src/i18n/uk/maestro.json
@@ -47,6 +47,22 @@
     "message": "Тривалість",
     "description": "Поле цільової тривалості"
   },
+  "name.quality": {
+    "message": "Якість",
+    "description": "Production quality tier field"
+  },
+  "option.quality.draft": {
+    "message": "Чернетка · швидкий перегляд",
+    "description": "Draft quality option"
+  },
+  "option.quality.standard": {
+    "message": "Стандарт · збалансовано",
+    "description": "Standard quality option"
+  },
+  "option.quality.premium": {
+    "message": "Преміум · більше деталей",
+    "description": "Premium quality option"
+  },
   "name.remixing": {
     "message": "Ремікс",
     "description": "Мітка банера реміксу"

--- a/src/i18n/zh-CN/maestro.json
+++ b/src/i18n/zh-CN/maestro.json
@@ -47,6 +47,22 @@
     "message": "时长",
     "description": "Target duration field"
   },
+  "name.quality": {
+    "message": "制作档位",
+    "description": "Production quality tier field"
+  },
+  "option.quality.draft": {
+    "message": "草稿 · 快速预览",
+    "description": "Draft quality option"
+  },
+  "option.quality.standard": {
+    "message": "标准 · 均衡",
+    "description": "Standard quality option"
+  },
+  "option.quality.premium": {
+    "message": "高级 · 更精细",
+    "description": "Premium quality option"
+  },
   "name.remixing": {
     "message": "二次创作",
     "description": "Remix banner label"

--- a/src/i18n/zh-TW/maestro.json
+++ b/src/i18n/zh-TW/maestro.json
@@ -47,6 +47,22 @@
     "message": "時長",
     "description": "目標時長字段"
   },
+  "name.quality": {
+    "message": "製作檔位",
+    "description": "Production quality tier field"
+  },
+  "option.quality.draft": {
+    "message": "草稿 · 快速預覽",
+    "description": "Draft quality option"
+  },
+  "option.quality.standard": {
+    "message": "標準 · 均衡",
+    "description": "Standard quality option"
+  },
+  "option.quality.premium": {
+    "message": "高級 · 更精細",
+    "description": "Premium quality option"
+  },
   "name.remixing": {
     "message": "二次創作",
     "description": "二次創作橫幅標籤"

--- a/src/models/maestro.ts
+++ b/src/models/maestro.ts
@@ -8,6 +8,7 @@ export interface IMaestroConfig {
   langs?: string[];
   aspect?: string; // '9:16' | '16:9' | '1:1'
   duration?: number;
+  quality?: string; // 'draft' | 'standard' | 'premium'
   callback_url?: string;
 }
 


### PR DESCRIPTION
## What

Adds a **Quality** (production tier) selector to the Maestro video config panel — the UI half of the `quality` = `draft | standard | premium` feature (worker = PlatformService #1170, pricing/docs = PlatformBackend #753).

- `models/maestro.ts` — `IMaestroConfig.quality?: string` (the interface is the POST body, so it ships automatically).
- `constants/maestro.ts` — `MAESTRO_ALLOWED_QUALITIES` + `MAESTRO_DEFAULT_QUALITY = 'standard'`.
- `components/maestro/ConfigPanel.vue` — an `el-select` mirroring the existing `duration` field (import + `data()` + computed getter/setter + `mounted()` default).
- `i18n/<17 locales>/maestro.json` — `name.quality` + `option.quality.{draft,standard,premium}` (en + zh-CN hand-written; the other 16 backfilled so the CI i18n coverage guard passes).

The price shown by `<consumption>` updates by tier automatically, because `getConsumption(config, service.cost)` evaluates the cost JsonLogic (PlatformBackend #753) and `config` now carries `quality`.

## UX (hides the LLM)

Users see a simple dropdown: **Draft · fast preview / Standard · balanced / Premium · more detail**. No mention of models, turns or agents — it reads as a video production setting.

## Depends on

- **PlatformService #1170** (worker honours the tier) — deploy first.
- **PlatformBackend #753** (tiered pricing + OpenAPI) — sync after #1170 so the displayed/charged price matches the rendered effort.

Default is `standard` (= today's behaviour), so shipping the selector before the others just sends `quality: "standard"` → unchanged.

## Test

- `vue-tsc -b` (CI build mode): exit 0. `eslint src`: clean.
- `python3 scripts/check_i18n_coverage.py`: `OK: 17 locale(s) × 44 namespace(s) all match zh-CN`.
- Beachball change file included.

## 🤖 对抗评审

Reviewer: Codex rate-limited → Claude `general-purpose` subagent. One round → **CLEAN**.

Verified: model field optional + spread into the POST body (`{ ...this.config }` in `pages/maestro/Index.vue`); constants re-exported via `constants/index.ts`'s `export *`; ConfigPanel wire-up complete (import + data + computed + mounted, no dangling import); all 17 locales carry the 4 keys (coverage guard green); beachball change file present; eslint/vue-tsc clean; consumption reactively re-prices by tier; the pre-`mounted()` `undefined` tick is identical to the existing `duration`/`aspect` selects (not a new defect). No risks.
