### PR TITLE
feat(chat): clickable scheduled run history with conversation title/preview

### DIFF
--- a/change/@acedatacloud-nexior-3ff48cf4-89d7-446c-9bc6-265c302e779e.json
+++ b/change/@acedatacloud-nexior-3ff48cf4-89d7-446c-9bc6-265c302e779e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "make scheduled run history rows clickable with conversation title/preview",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/i18n/ar/chat.json
+++ b/src/i18n/ar/chat.json
@@ -575,14 +575,6 @@
     "message": "تم تخطي تفويض الموصل",
     "description": "شرح أسفل البطاقة بعد أن يتخطى المستخدم التفويض"
   },
-  "model.claudeOpus47": {
-    "message": "claude-opus-4.7",
-    "description": "اسم النموذج للخدمة، أي Claude Opus 4.7"
-  },
-  "model.claudeOpus47Description": {
-    "message": "النموذج الأكثر تقدمًا حاليًا",
-    "description": "وصف نموذج Claude Opus 4.7"
-  },
   "scheduledTasks.navTitle": {
     "message": "Scheduled Tasks"
   },
@@ -609,6 +601,10 @@
   },
   "scheduledTasks.viewResult": {
     "message": "View Result"
+  },
+  "scheduledTasks.noConversation": {
+    "message": "لا توجد سجلات محادثة",
+    "description": "تشير إلى أن التشغيل غير مرتبط بمحادثة (نسخة قديمة من التشغيل)"
   },
   "scheduledTasks.jitterHint": {
     "message": "±60s jitter"
@@ -684,5 +680,13 @@
   },
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
+  },
+  "model.claudeOpus47": {
+    "message": "claude-opus-4.7",
+    "description": "اسم النموذج للخدمة، أي Claude Opus 4.7"
+  },
+  "model.claudeOpus47Description": {
+    "message": "النموذج الأكثر تقدمًا حاليًا",
+    "description": "وصف نموذج Claude Opus 4.7"
   }
 }

--- a/src/i18n/de/chat.json
+++ b/src/i18n/de/chat.json
@@ -575,14 +575,6 @@
     "message": "Connector-Autorisierung übersprungen",
     "description": "Hinweis am unteren Rand der Karte, nachdem der Benutzer die Autorisierung übersprungen hat"
   },
-  "model.claudeOpus47": {
-    "message": "claude-opus-4.7",
-    "description": "Name des Modells des Dienstes, d.h. Claude Opus 4.7"
-  },
-  "model.claudeOpus47Description": {
-    "message": "Aktuell das fortschrittlichste Modell",
-    "description": "Beschreibung des Claude Opus 4.7-Modells"
-  },
   "scheduledTasks.navTitle": {
     "message": "Scheduled Tasks"
   },
@@ -609,6 +601,10 @@
   },
   "scheduledTasks.viewResult": {
     "message": "View Result"
+  },
+  "scheduledTasks.noConversation": {
+    "message": "Keine Gesprächsaufzeichnung",
+    "description": "Läuft ohne zugeordnetes Gespräch (ältere Version läuft)"
   },
   "scheduledTasks.jitterHint": {
     "message": "±60s jitter"
@@ -684,5 +680,13 @@
   },
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
+  },
+  "model.claudeOpus47": {
+    "message": "claude-opus-4.7",
+    "description": "Name des Modells des Dienstes, d.h. Claude Opus 4.7"
+  },
+  "model.claudeOpus47Description": {
+    "message": "Aktuell das fortschrittlichste Modell",
+    "description": "Beschreibung des Claude Opus 4.7-Modells"
   }
 }

--- a/src/i18n/el/chat.json
+++ b/src/i18n/el/chat.json
@@ -575,14 +575,6 @@
     "message": "Η εξουσιοδότηση συνδέσεων παραλείφθηκε",
     "description": "Σημείωση στο κάτω μέρος της κάρτας όταν ο χρήστης παραλείψει την εξουσιοδότηση"
   },
-  "model.claudeOpus47": {
-    "message": "claude-opus-4.7",
-    "description": "Όνομα του μοντέλου υπηρεσίας, δηλαδή Claude Opus 4.7"
-  },
-  "model.claudeOpus47Description": {
-    "message": "Το πιο προηγμένο μοντέλο αυτή τη στιγμή",
-    "description": "Περιγραφή του μοντέλου Claude Opus 4.7"
-  },
   "scheduledTasks.navTitle": {
     "message": "Scheduled Tasks"
   },
@@ -609,6 +601,10 @@
   },
   "scheduledTasks.viewResult": {
     "message": "View Result"
+  },
+  "scheduledTasks.noConversation": {
+    "message": "Δεν υπάρχουν καταγεγραμμένες συνομιλίες",
+    "description": "Η λειτουργία δεν έχει συσχετιστεί με συνομιλίες (παλαιά έκδοση λειτουργίας)"
   },
   "scheduledTasks.jitterHint": {
     "message": "±60s jitter"
@@ -684,5 +680,13 @@
   },
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
+  },
+  "model.claudeOpus47": {
+    "message": "claude-opus-4.7",
+    "description": "Όνομα του μοντέλου υπηρεσίας, δηλαδή Claude Opus 4.7"
+  },
+  "model.claudeOpus47Description": {
+    "message": "Το πιο προηγμένο μοντέλο αυτή τη στιγμή",
+    "description": "Περιγραφή του μοντέλου Claude Opus 4.7"
   }
 }

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -602,6 +602,9 @@
   "scheduledTasks.viewResult": {
     "message": "View Result"
   },
+  "scheduledTasks.noConversation": {
+    "message": "No conversation"
+  },
   "scheduledTasks.jitterHint": {
     "message": "±60s jitter"
   },

--- a/src/i18n/es/chat.json
+++ b/src/i18n/es/chat.json
@@ -575,14 +575,6 @@
     "message": "Autorización de conectores omitida",
     "description": "Indicador al pie de la tarjeta tras que el usuario omite la autorización"
   },
-  "model.claudeOpus47": {
-    "message": "claude-opus-4.7",
-    "description": "Nombre del modelo del servicio, es decir, Claude Opus 4.7"
-  },
-  "model.claudeOpus47Description": {
-    "message": "Modelo más avanzado actualmente",
-    "description": "Descripción del modelo Claude Opus 4.7"
-  },
   "scheduledTasks.navTitle": {
     "message": "Scheduled Tasks"
   },
@@ -609,6 +601,10 @@
   },
   "scheduledTasks.viewResult": {
     "message": "View Result"
+  },
+  "scheduledTasks.noConversation": {
+    "message": "Sin registros de conversación",
+    "description": "Ejecutar sin conversación asociada (versión anterior de ejecución)"
   },
   "scheduledTasks.jitterHint": {
     "message": "±60s jitter"
@@ -684,5 +680,13 @@
   },
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
+  },
+  "model.claudeOpus47": {
+    "message": "claude-opus-4.7",
+    "description": "Nombre del modelo del servicio, es decir, Claude Opus 4.7"
+  },
+  "model.claudeOpus47Description": {
+    "message": "Modelo más avanzado actualmente",
+    "description": "Descripción del modelo Claude Opus 4.7"
   }
 }

--- a/src/i18n/fi/chat.json
+++ b/src/i18n/fi/chat.json
@@ -575,14 +575,6 @@
     "message": "Liittimen valtuutus ohitettu",
     "description": "Kortin alaosan ilmoitus, kun käyttäjä ohittaa valtuutuksen"
   },
-  "model.claudeOpus47": {
-    "message": "claude-opus-4.7",
-    "description": "Palvelun mallin nimi, eli Claude Opus 4.7"
-  },
-  "model.claudeOpus47Description": {
-    "message": "Tällä hetkellä edistyksellisin malli",
-    "description": "Claude Opus 4.7 -mallin kuvaus"
-  },
   "scheduledTasks.navTitle": {
     "message": "Scheduled Tasks"
   },
@@ -609,6 +601,10 @@
   },
   "scheduledTasks.viewResult": {
     "message": "View Result"
+  },
+  "scheduledTasks.noConversation": {
+    "message": "Ei keskusteluhistoriaa",
+    "description": "Suoritus ei ole liitetty keskusteluun (vanha versio suoritus)"
   },
   "scheduledTasks.jitterHint": {
     "message": "±60s jitter"
@@ -684,5 +680,13 @@
   },
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
+  },
+  "model.claudeOpus47": {
+    "message": "claude-opus-4.7",
+    "description": "Palvelun mallin nimi, eli Claude Opus 4.7"
+  },
+  "model.claudeOpus47Description": {
+    "message": "Tällä hetkellä edistyksellisin malli",
+    "description": "Claude Opus 4.7 -mallin kuvaus"
   }
 }

--- a/src/i18n/fr/chat.json
+++ b/src/i18n/fr/chat.json
@@ -575,14 +575,6 @@
     "message": "Autorisation du connecteur ignorée",
     "description": "Texte au bas de la carte après que l'utilisateur ait sauté l'autorisation"
   },
-  "model.claudeOpus47": {
-    "message": "claude-opus-4.7",
-    "description": "Nom du modèle du service, c'est-à-dire Claude Opus 4.7"
-  },
-  "model.claudeOpus47Description": {
-    "message": "Modèle le plus avancé actuellement",
-    "description": "Description du modèle Claude Opus 4.7"
-  },
   "scheduledTasks.navTitle": {
     "message": "Scheduled Tasks"
   },
@@ -609,6 +601,10 @@
   },
   "scheduledTasks.viewResult": {
     "message": "View Result"
+  },
+  "scheduledTasks.noConversation": {
+    "message": "Aucun enregistrement de conversation",
+    "description": "Exécution sans conversation associée (version ancienne)"
   },
   "scheduledTasks.jitterHint": {
     "message": "±60s jitter"
@@ -684,5 +680,13 @@
   },
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
+  },
+  "model.claudeOpus47": {
+    "message": "claude-opus-4.7",
+    "description": "Nom du modèle du service, c'est-à-dire Claude Opus 4.7"
+  },
+  "model.claudeOpus47Description": {
+    "message": "Modèle le plus avancé actuellement",
+    "description": "Description du modèle Claude Opus 4.7"
   }
 }

--- a/src/i18n/it/chat.json
+++ b/src/i18n/it/chat.json
@@ -575,14 +575,6 @@
     "message": "Autorizzazione dei connettori saltata",
     "description": "Nota in fondo alla scheda dopo che l'utente ha saltato l'autorizzazione"
   },
-  "model.claudeOpus47": {
-    "message": "claude-opus-4.7",
-    "description": "Nome del modello del servizio, ovvero Claude Opus 4.7"
-  },
-  "model.claudeOpus47Description": {
-    "message": "Modello più avanzato attualmente disponibile",
-    "description": "Descrizione del modello Claude Opus 4.7"
-  },
   "scheduledTasks.navTitle": {
     "message": "Scheduled Tasks"
   },
@@ -609,6 +601,10 @@
   },
   "scheduledTasks.viewResult": {
     "message": "View Result"
+  },
+  "scheduledTasks.noConversation": {
+    "message": "Nessuna registrazione di conversazione",
+    "description": "Eseguito senza conversazione associata (versione precedente)"
   },
   "scheduledTasks.jitterHint": {
     "message": "±60s jitter"
@@ -684,5 +680,13 @@
   },
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
+  },
+  "model.claudeOpus47": {
+    "message": "claude-opus-4.7",
+    "description": "Nome del modello del servizio, ovvero Claude Opus 4.7"
+  },
+  "model.claudeOpus47Description": {
+    "message": "Modello più avanzato attualmente disponibile",
+    "description": "Descrizione del modello Claude Opus 4.7"
   }
 }

--- a/src/i18n/ja/chat.json
+++ b/src/i18n/ja/chat.json
@@ -575,14 +575,6 @@
     "message": "コネクタ認可をスキップしました",
     "description": "ユーザーが認可をスキップした後のカード下部の説明"
   },
-  "model.claudeOpus47": {
-    "message": "claude-opus-4.7",
-    "description": "サービスのモデル名、すなわち Claude Opus 4.7"
-  },
-  "model.claudeOpus47Description": {
-    "message": "現在最も先進的なモデル",
-    "description": "Claude Opus 4.7モデルの説明"
-  },
   "scheduledTasks.navTitle": {
     "message": "Scheduled Tasks"
   },
@@ -609,6 +601,10 @@
   },
   "scheduledTasks.viewResult": {
     "message": "View Result"
+  },
+  "scheduledTasks.noConversation": {
+    "message": "対話記録がありません",
+    "description": "実行中のタスクに関連する対話がないことを示します（旧バージョンの実行）。"
   },
   "scheduledTasks.jitterHint": {
     "message": "±60s jitter"
@@ -684,5 +680,13 @@
   },
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
+  },
+  "model.claudeOpus47": {
+    "message": "claude-opus-4.7",
+    "description": "サービスのモデル名、すなわち Claude Opus 4.7"
+  },
+  "model.claudeOpus47Description": {
+    "message": "現在最も先進的なモデル",
+    "description": "Claude Opus 4.7モデルの説明"
   }
 }

--- a/src/i18n/ko/chat.json
+++ b/src/i18n/ko/chat.json
@@ -575,14 +575,6 @@
     "message": "커넥터 권한 부여를 건너뜀",
     "description": "사용자가 권한 부여를 건너뛴 후 카드 하단의 설명입니다."
   },
-  "model.claudeOpus47": {
-    "message": "claude-opus-4.7",
-    "description": "서비스의 모델 이름, 즉 Claude Opus 4.7"
-  },
-  "model.claudeOpus47Description": {
-    "message": "현재 가장 진보된 모델",
-    "description": "Claude Opus 4.7 모델의 설명"
-  },
   "scheduledTasks.navTitle": {
     "message": "Scheduled Tasks"
   },
@@ -609,6 +601,10 @@
   },
   "scheduledTasks.viewResult": {
     "message": "View Result"
+  },
+  "scheduledTasks.noConversation": {
+    "message": "대화 기록 없음",
+    "description": "연결되지 않은 대화가 실행 중입니다(구 버전 실행)"
   },
   "scheduledTasks.jitterHint": {
     "message": "±60s jitter"
@@ -684,5 +680,13 @@
   },
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
+  },
+  "model.claudeOpus47": {
+    "message": "claude-opus-4.7",
+    "description": "서비스의 모델 이름, 즉 Claude Opus 4.7"
+  },
+  "model.claudeOpus47Description": {
+    "message": "현재 가장 진보된 모델",
+    "description": "Claude Opus 4.7 모델의 설명"
   }
 }

--- a/src/i18n/pl/chat.json
+++ b/src/i18n/pl/chat.json
@@ -575,14 +575,6 @@
     "message": "Autoryzacja konektorów pominięta",
     "description": "Informacja na dole karty po pominięciu autoryzacji przez użytkownika"
   },
-  "model.claudeOpus47": {
-    "message": "claude-opus-4.7",
-    "description": "Nazwa modelu usługi, czyli Claude Opus 4.7"
-  },
-  "model.claudeOpus47Description": {
-    "message": "Obecnie najnowocześniejszy model",
-    "description": "Opis modelu Claude Opus 4.7"
-  },
   "scheduledTasks.navTitle": {
     "message": "Scheduled Tasks"
   },
@@ -609,6 +601,10 @@
   },
   "scheduledTasks.viewResult": {
     "message": "View Result"
+  },
+  "scheduledTasks.noConversation": {
+    "message": "Brak historii rozmów",
+    "description": "Zadania, które nie są powiązane z żadną rozmową (stara wersja działania)"
   },
   "scheduledTasks.jitterHint": {
     "message": "±60s jitter"
@@ -684,5 +680,13 @@
   },
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
+  },
+  "model.claudeOpus47": {
+    "message": "claude-opus-4.7",
+    "description": "Nazwa modelu usługi, czyli Claude Opus 4.7"
+  },
+  "model.claudeOpus47Description": {
+    "message": "Obecnie najnowocześniejszy model",
+    "description": "Opis modelu Claude Opus 4.7"
   }
 }

--- a/src/i18n/pt/chat.json
+++ b/src/i18n/pt/chat.json
@@ -575,14 +575,6 @@
     "message": "Autorização de conectores ignorada",
     "description": "Texto no rodapé do cartão após o usuário pular a autorização"
   },
-  "model.claudeOpus47": {
-    "message": "claude-opus-4.7",
-    "description": "Nome do modelo do serviço, ou seja, Claude Opus 4.7"
-  },
-  "model.claudeOpus47Description": {
-    "message": "Modelo mais avançado atualmente",
-    "description": "Descrição do modelo Claude Opus 4.7"
-  },
   "scheduledTasks.navTitle": {
     "message": "Scheduled Tasks"
   },
@@ -609,6 +601,10 @@
   },
   "scheduledTasks.viewResult": {
     "message": "View Result"
+  },
+  "scheduledTasks.noConversation": {
+    "message": "Sem registros de conversa",
+    "description": "Executar sem diálogos associados (versão antiga de execução)"
   },
   "scheduledTasks.jitterHint": {
     "message": "±60s jitter"
@@ -684,5 +680,13 @@
   },
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
+  },
+  "model.claudeOpus47": {
+    "message": "claude-opus-4.7",
+    "description": "Nome do modelo do serviço, ou seja, Claude Opus 4.7"
+  },
+  "model.claudeOpus47Description": {
+    "message": "Modelo mais avançado atualmente",
+    "description": "Descrição do modelo Claude Opus 4.7"
   }
 }

--- a/src/i18n/ru/chat.json
+++ b/src/i18n/ru/chat.json
@@ -575,14 +575,6 @@
     "message": "Авторизация коннектора пропущена",
     "description": "Нижняя подпись карточки после того, как пользователь пропустил авторизацию"
   },
-  "model.claudeOpus47": {
-    "message": "claude-opus-4.7",
-    "description": "Название модели сервиса, то есть Claude Opus 4.7"
-  },
-  "model.claudeOpus47Description": {
-    "message": "На данный момент самая продвинутая модель",
-    "description": "Описание модели Claude Opus 4.7"
-  },
   "scheduledTasks.navTitle": {
     "message": "Scheduled Tasks"
   },
@@ -609,6 +601,10 @@
   },
   "scheduledTasks.viewResult": {
     "message": "View Result"
+  },
+  "scheduledTasks.noConversation": {
+    "message": "Нет записей о разговоре",
+    "description": "Запуск без связанных разговоров (версия старого типа)"
   },
   "scheduledTasks.jitterHint": {
     "message": "±60s jitter"
@@ -684,5 +680,13 @@
   },
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
+  },
+  "model.claudeOpus47": {
+    "message": "claude-opus-4.7",
+    "description": "Название модели сервиса, то есть Claude Opus 4.7"
+  },
+  "model.claudeOpus47Description": {
+    "message": "На данный момент самая продвинутая модель",
+    "description": "Описание модели Claude Opus 4.7"
   }
 }

--- a/src/i18n/sr/chat.json
+++ b/src/i18n/sr/chat.json
@@ -575,14 +575,6 @@
     "message": "Овлашћење конектора је прескочено",
     "description": "Објашњење на дну картице након што је корисник прескочио овлашћење"
   },
-  "model.claudeOpus47": {
-    "message": "claude-opus-4.7",
-    "description": "Naziv modela usluge, tj. Claude Opus 4.7"
-  },
-  "model.claudeOpus47Description": {
-    "message": "Trenutno najnapredniji model",
-    "description": "Opis Claude Opus 4.7 modela"
-  },
   "scheduledTasks.navTitle": {
     "message": "Scheduled Tasks"
   },
@@ -609,6 +601,10 @@
   },
   "scheduledTasks.viewResult": {
     "message": "View Result"
+  },
+  "scheduledTasks.noConversation": {
+    "message": "Нема записа о разговору",
+    "description": "Радња није повезана са разговором (стара верзија рада)"
   },
   "scheduledTasks.jitterHint": {
     "message": "±60s jitter"
@@ -684,5 +680,13 @@
   },
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
+  },
+  "model.claudeOpus47": {
+    "message": "claude-opus-4.7",
+    "description": "Naziv modela usluge, tj. Claude Opus 4.7"
+  },
+  "model.claudeOpus47Description": {
+    "message": "Trenutno najnapredniji model",
+    "description": "Opis Claude Opus 4.7 modela"
   }
 }

--- a/src/i18n/sv/chat.json
+++ b/src/i18n/sv/chat.json
@@ -575,14 +575,6 @@
     "message": "Kopplingsbehörighet hoppad över",
     "description": "Kortets nederdel som visas efter att användaren har hoppat över behörighet"
   },
-  "model.claudeOpus47": {
-    "message": "claude-opus-4.7",
-    "description": "Modellnamnet för tjänsten, det vill säga Claude Opus 4.7"
-  },
-  "model.claudeOpus47Description": {
-    "message": "Den mest avancerade modellen hittills",
-    "description": "Beskrivning av Claude Opus 4.7-modellen"
-  },
   "scheduledTasks.navTitle": {
     "message": "Scheduled Tasks"
   },
@@ -609,6 +601,10 @@
   },
   "scheduledTasks.viewResult": {
     "message": "View Result"
+  },
+  "scheduledTasks.noConversation": {
+    "message": "Ingen konversationshistorik",
+    "description": "Körning utan kopplad konversation (äldre version av körning)"
   },
   "scheduledTasks.jitterHint": {
     "message": "±60s jitter"
@@ -684,5 +680,13 @@
   },
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
+  },
+  "model.claudeOpus47": {
+    "message": "claude-opus-4.7",
+    "description": "Modellnamnet för tjänsten, det vill säga Claude Opus 4.7"
+  },
+  "model.claudeOpus47Description": {
+    "message": "Den mest avancerade modellen hittills",
+    "description": "Beskrivning av Claude Opus 4.7-modellen"
   }
 }

--- a/src/i18n/uk/chat.json
+++ b/src/i18n/uk/chat.json
@@ -575,14 +575,6 @@
     "message": "Авторизацію конектора пропущено",
     "description": "Пояснення внизу картки після того, як користувач пропустив авторизацію"
   },
-  "model.claudeOpus47": {
-    "message": "claude-opus-4.7",
-    "description": "Назва моделі сервісу, тобто Claude Opus 4.7"
-  },
-  "model.claudeOpus47Description": {
-    "message": "Найсучасніша модель на сьогодні",
-    "description": "Опис моделі Claude Opus 4.7"
-  },
   "scheduledTasks.navTitle": {
     "message": "Scheduled Tasks"
   },
@@ -609,6 +601,10 @@
   },
   "scheduledTasks.viewResult": {
     "message": "View Result"
+  },
+  "scheduledTasks.noConversation": {
+    "message": "Немає записів розмов",
+    "description": "Запуск без пов'язаних розмов (версія без оновлень)"
   },
   "scheduledTasks.jitterHint": {
     "message": "±60s jitter"
@@ -684,5 +680,13 @@
   },
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
+  },
+  "model.claudeOpus47": {
+    "message": "claude-opus-4.7",
+    "description": "Назва моделі сервісу, тобто Claude Opus 4.7"
+  },
+  "model.claudeOpus47Description": {
+    "message": "Найсучасніша модель на сьогодні",
+    "description": "Опис моделі Claude Opus 4.7"
   }
 }

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -584,6 +584,7 @@
   "scheduledTasks.loadError": { "message": "加载失败", "description": "加载错误提示" },
   "scheduledTasks.deleteConfirm": { "message": "确认删除「{name}」？删除后任务将停止运行。", "description": "删除确认" },
   "scheduledTasks.viewResult": { "message": "查看结果", "description": "跳转到对话" },
+  "scheduledTasks.noConversation": { "message": "无对话记录", "description": "运行未关联对话（旧版本运行）" },
   "scheduledTasks.jitterHint": { "message": "±60s 抖动", "description": "运行时间抖动说明" },
   "scheduledTasks.runCount": { "message": "已运行 {count} 次", "description": "运行次数" },
   "scheduledTasks.state.enabled": { "message": "运行中", "description": "启用状态" },

--- a/src/i18n/zh-TW/chat.json
+++ b/src/i18n/zh-TW/chat.json
@@ -575,14 +575,6 @@
     "message": "已跳過連接器授權",
     "description": "使用者跳過授權後的卡片底部說明"
   },
-  "model.claudeOpus47": {
-    "message": "claude-opus-4.7",
-    "description": "服务的模型名称，即 Claude Opus 4.7"
-  },
-  "model.claudeOpus47Description": {
-    "message": "目前最先進的模型",
-    "description": "Claude Opus 4.7 模型的描述"
-  },
   "scheduledTasks.navTitle": {
     "message": "Scheduled Tasks"
   },
@@ -609,6 +601,10 @@
   },
   "scheduledTasks.viewResult": {
     "message": "View Result"
+  },
+  "scheduledTasks.noConversation": {
+    "message": "無對話記錄",
+    "description": "運行未關聯對話（舊版本運行）"
   },
   "scheduledTasks.jitterHint": {
     "message": "±60s jitter"
@@ -684,5 +680,13 @@
   },
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
+  },
+  "model.claudeOpus47": {
+    "message": "claude-opus-4.7",
+    "description": "服务的模型名称，即 Claude Opus 4.7"
+  },
+  "model.claudeOpus47Description": {
+    "message": "目前最先進的模型",
+    "description": "Claude Opus 4.7 模型的描述"
   }
 }

--- a/src/operators/scheduledTasks.ts
+++ b/src/operators/scheduledTasks.ts
@@ -41,6 +41,9 @@ export interface IScheduledRun {
   llm_started_at?: number;
   llm_finished_at?: number;
   conversation_id?: string;
+  conversation_title?: string;
+  conversation_preview?: string;
+  conversation_model_group?: string;
   error_code?: string;
   error_message?: string;
 }

--- a/src/pages/chat/ScheduledTasks.vue
+++ b/src/pages/chat/ScheduledTasks.vue
@@ -62,19 +62,32 @@
       <el-skeleton v-if="runsLoading" :rows="3" animated />
       <el-empty v-else-if="!runs.length" :description="$t('chat.scheduledTasks.noRuns')" />
       <div v-else class="run-list">
-        <div v-for="run in runs" :key="run.id" class="run-item">
-          <div class="run-status">
-            <el-tag size="small" :type="runTagType(run.status)">
-              {{ $t(`chat.scheduledTasks.run.${run.status}`) }}
-            </el-tag>
+        <div
+          v-for="run in runs"
+          :key="run.id"
+          class="run-item"
+          :class="{ clickable: !!run.conversation_id }"
+          @click="openRun(run)"
+        >
+          <div class="run-body">
+            <div class="run-line">
+              <el-tag size="small" :type="runTagType(run.status)">
+                {{ $t(`chat.scheduledTasks.run.${run.status}`) }}
+              </el-tag>
+              <span class="run-title">{{ run.conversation_title || formatTime(run.scheduled_at) }}</span>
+            </div>
+            <div v-if="run.conversation_preview" class="run-preview">{{ run.conversation_preview }}</div>
+            <div class="run-sub">
+              <span class="run-time">{{ formatTime(run.scheduled_at) }}</span>
+              <span v-if="run.error_code" class="run-error">{{ run.error_code }}</span>
+            </div>
           </div>
-          <div class="run-time">{{ formatTime(run.scheduled_at) }}</div>
-          <div v-if="run.conversation_id" class="run-link">
-            <el-button text size="small" @click="goToConversation(run.conversation_id)">
-              {{ $t('chat.scheduledTasks.viewResult') }}
-            </el-button>
-          </div>
-          <div v-if="run.error_code" class="run-error">{{ run.error_code }}</div>
+          <font-awesome-icon
+            v-if="run.conversation_id"
+            icon="fa-solid fa-chevron-right"
+            class="run-arrow"
+          />
+          <span v-else class="run-noconv">{{ $t('chat.scheduledTasks.noConversation') }}</span>
         </div>
       </div>
     </el-drawer>
@@ -358,9 +371,17 @@ export default defineComponent({
       await scheduledTasksOperator.deleteTask(this.token!, task.id);
       await this.loadTasks();
     },
-    goToConversation(id: string) {
-      const modelGroup = this.$store.state.chat?.modelGroup ?? 'chatgpt';
-      this.$router.push(`/${modelGroup}/conversations/${id}`);
+    openRun(run: IScheduledRun) {
+      if (!run.conversation_id) return;
+      // The route prefix must be a chat group that actually owns a
+      // /<group>/conversations/:id route. Prefer the run's own conversation
+      // group when it is one we can open; otherwise fall back to the current
+      // chat group (a modelGroup object — use its `.name`), then to chatgpt.
+      const known: string[] = this.modelGroups.map((g) => g.name);
+      const runGroup = run.conversation_model_group;
+      const fallback = this.$store.state.chat?.modelGroup?.name || 'chatgpt';
+      const modelGroup = runGroup && (known.length === 0 || known.includes(runGroup)) ? runGroup : fallback;
+      this.$router.push(`/${modelGroup}/conversations/${run.conversation_id}`);
     },
     stateTagType(state: string) {
       return state === 'enabled' ? 'success' : state === 'error' ? 'danger' : 'info';
@@ -417,10 +438,19 @@ export default defineComponent({
 .task-footer { display: flex; justify-content: space-between; font-size: 11px; color: var(--el-text-color-secondary); margin-top: 8px; }
 .error-hint { color: var(--el-color-danger); }
 .empty { padding: 60px 0; }
-.run-list { display: flex; flex-direction: column; gap: 10px; }
-.run-item { display: flex; gap: 12px; align-items: center; padding: 8px 0; border-bottom: 1px solid var(--el-border-color-lighter); }
+.run-list { display: flex; flex-direction: column; gap: 4px; }
+.run-item { display: flex; gap: 12px; align-items: center; padding: 10px 8px; border-bottom: 1px solid var(--el-border-color-lighter); border-radius: 6px; transition: background 0.15s; }
+.run-item.clickable { cursor: pointer; }
+.run-item.clickable:hover { background: var(--el-fill-color-light); }
+.run-body { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 4px; }
+.run-line { display: flex; gap: 8px; align-items: center; }
+.run-title { font-size: 13px; font-weight: 500; color: var(--el-text-color-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.run-preview { font-size: 12px; color: var(--el-text-color-secondary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.run-sub { display: flex; gap: 10px; align-items: center; }
 .run-time { font-size: 12px; color: var(--el-text-color-secondary); }
 .run-error { font-size: 11px; color: var(--el-color-danger); }
+.run-arrow { color: var(--el-text-color-secondary); font-size: 12px; flex-shrink: 0; }
+.run-noconv { font-size: 11px; color: var(--el-text-color-secondary); flex-shrink: 0; }
 .hint { font-size: 11px; color: var(--el-text-color-secondary); margin-top: 4px; }
 .jitter-hint { font-size: 11px; color: var(--el-text-color-secondary); margin-left: 8px; }
 </style>


### PR DESCRIPTION
## What & why

定时任务「运行历史」抽屉此前每条只显示状态标签 + 时间，外加一个不显眼、且仅在 `conversation_id` 存在时才出现的「查看结果」按钮——旧版运行（无 `conversation_id`）直接是死路。用户反馈「点不开、没标题、看不到详情」。

## Changes

- 运行记录行**整条可点击**：有对话时 `openRun` → 跳转 `/<model_group>/conversations/<id>`，使用该 run 自己的 `conversation_model_group`（而非当前聊天分组），复用既有对话详情页。
- 显示对话**标题 + 末条消息摘要**（来自 worker `retrieve_runs` 新增字段）。
- 旧版无对话的运行显示「无对话记录」提示，不再是空白死路。
- `IScheduledRun` 新增 `conversation_title` / `conversation_preview` / `conversation_model_group`。
- i18n：`scheduledTasks.noConversation` 全语言覆盖。

## Validation

- `vue-tsc -b` 干净；i18n coverage 通过（17 locale × 44 namespace 全匹配 zh-CN）；无 `goToConversation` 残留引用。

## Backend

配套 PlatformService PR（`retrieve_runs` 返回对话标题 / 摘要 / 分组）。前端对缺失字段有降级（无 `model_group` 用当前分组、无 `title` 用时间），可独立合并。

## 🤖 对抗评审（codex，read-only）

| # | RISK | 处置 |
|---|------|------|
| 2 | openRun fallback 用 `store.chat.modelGroup`（对象）→ `/[object Object]/conversations/<id>` | **已修复**：fallback 改用 `.name`。 |
| 3 | `conversation_model_group` 直接作路由前缀，但 `glm` 等组无 `/glm` 路由 → 404 | **已修复**：用已加载的 `modelGroups` 校验，runGroup 不在可路由组内时回退到当前组的 `.name`。 |
| 5 | 引用 `scheduledTasks.noConversation` 但 diff 未见 locale 条目 | **误报**：评审 diff 刻意排除了 i18n 以减噪；实际已加 zh-CN/en 并 translate 补全全 17 locale，coverage 通过。 |
