### PR TITLE
style(chat): align scheduled run history with Nexior design patterns

### DIFF
--- a/change/@acedatacloud-nexior-scheduled-run-design-cleanup.json
+++ b/change/@acedatacloud-nexior-scheduled-run-design-cleanup.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "align scheduled run history drawer with Nexior design patterns",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/pages/chat/ScheduledTasks.vue
+++ b/src/pages/chat/ScheduledTasks.vue
@@ -61,7 +61,6 @@
       class="run-history-drawer"
     >
       <div v-if="selectedTask" class="run-context">
-        <div class="run-context-title">{{ selectedTask.name }}</div>
         <div class="run-context-meta">
           <span>{{ scheduleLabel(selectedTask.schedule) }}</span>
           <span>{{ selectedTask.template.model }}</span>
@@ -83,7 +82,6 @@
           @keydown.enter="openRun(run)"
           @keydown.space.prevent="openRun(run)"
         >
-          <div class="run-marker" :class="`status-${run.status}`" />
           <div class="run-body">
             <div class="run-line">
               <span class="run-title">{{ run.conversation_title || formatTime(run.scheduled_at) }}</span>
@@ -94,7 +92,9 @@
             <div v-if="run.conversation_preview" class="run-preview">{{ run.conversation_preview }}</div>
             <div class="run-sub">
               <span class="run-time">{{ formatTime(run.scheduled_at) }}</span>
-              <span v-if="run.error_code" class="run-error">{{ run.error_code }}</span>
+              <span v-if="run.error_code || run.error_message" class="run-error" :title="runErrorText(run)">
+                {{ runErrorText(run) }}
+              </span>
             </div>
           </div>
           <div class="run-action">
@@ -406,6 +406,9 @@ export default defineComponent({
     runTagType(status: string) {
       return status === 'success' ? 'success' : status === 'failed' ? 'danger' : 'warning';
     },
+    runErrorText(run: IScheduledRun) {
+      return run.error_message || run.error_code?.replace(/_/g, ' ') || '';
+    },
     scheduleLabel(s: IScheduleSpec) {
       if (s.type === 'interval') return `每 ${s.interval_seconds / 60} 分钟`;
       if (s.type === 'cron') return `Cron: ${s.cron}`;
@@ -438,12 +441,10 @@ export default defineComponent({
   border-radius: 8px;
   padding: 14px 16px;
   cursor: pointer;
-  box-shadow: var(--app-shadow-sm, 0 1px 2px rgba(15, 23, 42, 0.04));
-  transition: border-color 0.2s, box-shadow 0.2s, transform 0.2s;
+  transition: background 0.16s, border-color 0.16s;
   &:hover {
-    border-color: rgba(var(--app-brand-rgb, 39, 113, 134), 0.28);
-    box-shadow: var(--app-shadow-md, 0 8px 20px rgba(15, 23, 42, 0.08));
-    transform: translateY(-1px);
+    background: var(--el-fill-color-lighter);
+    border-color: var(--el-border-color);
   }
 }
 .task-header {
@@ -456,33 +457,28 @@ export default defineComponent({
 .task-actions { display: flex; gap: 6px; align-items: center; }
 .task-meta { display: flex; gap: 8px; align-items: center; margin-bottom: 6px; font-size: 12px; color: var(--el-text-color-secondary); }
 .task-prompt { font-size: 13px; color: var(--el-text-color-regular); white-space: pre-line; max-height: 48px; overflow: hidden; }
-.task-last-output { font-size: 12px; color: var(--el-text-color-secondary); margin-top: 8px; padding: 8px 10px; border-radius: 6px; background: var(--app-bg-section, var(--el-fill-color-light)); font-style: italic; }
+.task-last-output { font-size: 12px; color: var(--el-text-color-secondary); margin-top: 8px; padding-top: 8px; border-top: 1px solid var(--app-border-subtle, var(--el-border-color-lighter)); }
 .task-footer { display: flex; justify-content: space-between; font-size: 11px; color: var(--el-text-color-secondary); margin-top: 8px; }
 .error-hint { color: var(--el-color-danger); }
 .empty { padding: 60px 0; }
-.run-context { margin-bottom: 16px; padding: 14px 16px; border: 1px solid var(--app-border-subtle, var(--el-border-color-lighter)); border-radius: 8px; background: linear-gradient(135deg, rgba(var(--app-brand-rgb, 39, 113, 134), 0.08), var(--app-bg-surface, var(--el-bg-color))); }
-.run-context-title { font-size: 15px; font-weight: 650; color: var(--el-text-color-primary); }
-.run-context-meta { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 6px; font-size: 12px; color: var(--el-text-color-secondary); }
-.run-context-meta span { padding: 2px 8px; border-radius: 999px; background: rgba(var(--app-brand-rgb, 39, 113, 134), 0.08); }
-.run-context-prompt { margin-top: 10px; font-size: 12px; line-height: 1.55; color: var(--el-text-color-regular); white-space: pre-line; max-height: 64px; overflow: hidden; }
+.run-context { margin-bottom: 14px; padding-bottom: 14px; border-bottom: 1px solid var(--app-border-subtle, var(--el-border-color-lighter)); }
+.run-context-meta { display: flex; flex-wrap: wrap; gap: 8px; font-size: 12px; color: var(--el-text-color-secondary); }
+.run-context-meta span + span::before { content: '·'; margin-right: 8px; color: var(--el-text-color-placeholder); }
+.run-context-prompt { margin-top: 8px; font-size: 12px; line-height: 1.55; color: var(--el-text-color-secondary); white-space: pre-line; max-height: 48px; overflow: hidden; }
 .run-list { display: flex; flex-direction: column; gap: 10px; }
-.run-item { display: flex; gap: 12px; align-items: stretch; padding: 12px 12px 12px 10px; border: 1px solid var(--app-border-subtle, var(--el-border-color-lighter)); border-radius: 8px; background: var(--app-bg-surface, var(--el-bg-color-overlay)); box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04); transition: border-color 0.16s, background 0.16s, box-shadow 0.16s, transform 0.16s; }
+.run-item { display: flex; gap: 12px; align-items: center; padding: 12px 14px; border: 1px solid var(--app-border-subtle, var(--el-border-color-lighter)); border-radius: 8px; background: var(--app-bg-surface, var(--el-bg-color-overlay)); transition: background 0.16s, border-color 0.16s; }
 .run-item.clickable { cursor: pointer; }
-.run-item.clickable:hover, .run-item.clickable:focus-visible { border-color: rgba(var(--app-brand-rgb, 39, 113, 134), 0.34); background: linear-gradient(135deg, rgba(var(--app-brand-rgb, 39, 113, 134), 0.06), var(--app-bg-surface, var(--el-bg-color-overlay))); box-shadow: var(--app-shadow-md, 0 8px 20px rgba(15, 23, 42, 0.08)); transform: translateY(-1px); outline: none; }
-.run-marker { width: 4px; border-radius: 999px; background: var(--el-color-info-light-5); flex-shrink: 0; }
-.run-marker.status-success { background: var(--el-color-success); }
-.run-marker.status-failed { background: var(--el-color-danger); }
-.run-marker.status-running, .run-marker.status-queued, .run-marker.status-needs_user_input { background: var(--el-color-warning); }
+.run-item.clickable:hover, .run-item.clickable:focus-visible { background: var(--el-fill-color-lighter); border-color: var(--el-border-color); outline: none; }
 .run-body { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 6px; }
 .run-line { display: flex; gap: 8px; align-items: center; }
-.run-title { min-width: 0; flex: 1; font-size: 14px; font-weight: 650; color: var(--el-text-color-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.run-title { min-width: 0; flex: 1; font-size: 14px; font-weight: 600; color: var(--el-text-color-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .run-tag { flex-shrink: 0; }
 .run-preview { font-size: 12px; line-height: 1.5; color: var(--el-text-color-secondary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.run-sub { display: flex; gap: 10px; align-items: center; }
+.run-sub { display: flex; gap: 10px; align-items: center; min-width: 0; }
 .run-time { font-size: 12px; color: var(--el-text-color-secondary); }
-.run-error { font-size: 11px; color: var(--el-color-danger); }
+.run-error { min-width: 0; font-size: 11px; color: var(--el-text-color-secondary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .run-action { display: flex; align-items: center; align-self: center; flex-shrink: 0; }
-.run-arrow { color: rgba(var(--app-brand-rgb, 39, 113, 134), 0.76); font-size: 12px; flex-shrink: 0; }
+.run-arrow { color: var(--el-text-color-secondary); font-size: 12px; flex-shrink: 0; }
 .run-noconv { font-size: 11px; color: var(--el-text-color-secondary); flex-shrink: 0; }
 .hint { font-size: 11px; color: var(--el-text-color-secondary); margin-top: 4px; }
 .jitter-hint { font-size: 11px; color: var(--el-text-color-secondary); margin-left: 8px; }


### PR DESCRIPTION
## What & why

上一版运行历史 UI 虽然信息更完整，但视觉 pattern 太多：顶部渐变卡片、运行行左侧竖线、重 hover 阴影、last output 暗底块、失败文案裸红色，和 Nexior 现有的安静卡片风格不够统一。

这个 PR 只做设计清理，让定时任务运行历史回到统一、克制的 Nexior pattern。

## Changes

- 移除运行行左侧状态竖线，状态统一由 `el-tag` 表达。
- 移除顶部渐变 context card，改为轻量分隔区：调度 / 模型 / 运行次数 + prompt 摘要。
- 移除重阴影和位移动效，hover/focus 只用轻微背景和边框变化。
- 任务卡片、运行卡片统一 8px 圆角 + 1px subtle border。
- `last_output_snippet` 从暗底块改成上边框分隔的轻量摘要。
- 失败 run 的错误信息从突兀红块改为 muted 小号文本；长错误会 ellipsis，并通过 `title` 保留全文。
- 保留整行可点击、Enter/Space 键打开 conversation 的交互。

## Validation

- `vue-tsc -b` clean
- `npm run build:web` success
- `npx beachball check --branch origin/main` success (`No change files are needed`)

## 🤖 对抗评审

Subagent read-only review found one real issue: long `run.error_message` could overflow narrow drawers and push the action column. Fixed by adding `min-width: 0`, `white-space: nowrap`, `overflow: hidden`, `text-overflow: ellipsis`, and `title` on the error text.
