### PR TITLE
fix(chat): show voice call button only for ChatGPT model group

### DIFF
--- a/change/@acedatacloud-nexior-voice-call-chatgpt-only.json
+++ b/change/@acedatacloud-nexior-voice-call-chatgpt-only.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "show the realtime voice call button only for the ChatGPT model group",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/Composer.vue
+++ b/src/components/chat/Composer.vue
@@ -88,7 +88,13 @@
           </el-dropdown-menu>
         </template>
       </el-dropdown>
-      <el-tooltip class="box-item" effect="dark" :content="$t('realtime.callTooltip')" placement="top">
+      <el-tooltip
+        v-if="isVoiceCallSupported"
+        class="box-item"
+        effect="dark"
+        :content="$t('realtime.callTooltip')"
+        placement="top"
+      >
         <span :class="{ btn: true, 'btn-voice': true }" role="button" @click="onStartCall">
           <font-awesome-icon icon="fa-solid fa-microphone" class="icon icon-voice" />
         </span>
@@ -196,6 +202,11 @@ export default defineComponent({
     },
     modelGroup() {
       return this.$store.state.chat.modelGroup;
+    },
+    isVoiceCallSupported(): boolean {
+      // The realtime voice call route + store only exist for ChatGPT, so the
+      // mic button stays hidden for other model groups (Grok, Gemini, …).
+      return this.modelGroup?.isVoiceCallSupported ?? false;
     },
     isFileSupported() {
       return this.model?.isFileSupported;

--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -278,7 +278,8 @@ export const CHAT_MODEL_GROUP_CHATGPT: IChatModelGroup = {
   name: 'chatgpt',
   getDisplayName: () => i18n.global.t('chat.modelGroup.chatgpt'),
   getDescription: () => i18n.global.t('chat.modelGroup.chatgptDescription'),
-  models: [CHAT_MODEL_GPT_5_4_MINI, CHAT_MODEL_GPT_5_5, CHAT_MODEL_GPT_5_4]
+  models: [CHAT_MODEL_GPT_5_4_MINI, CHAT_MODEL_GPT_5_5, CHAT_MODEL_GPT_5_4],
+  isVoiceCallSupported: true
 };
 
 export const CHAT_MODEL_GROUP_DEEPSEEK: IChatModelGroup = {

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -71,6 +71,8 @@ export interface IChatModelGroup {
   getDisplayName: () => string;
   getDescription: () => string;
   models: IChatModel[];
+  // Realtime voice call is only wired up for the OpenAI (ChatGPT) service.
+  isVoiceCallSupported?: boolean;
 }
 
 interface IError {


### PR DESCRIPTION
## Problem

The realtime **voice call** feature (the mic button in the chat composer) is only
wired up for the OpenAI / ChatGPT service — the `/chatgpt/call` route + the
`realtime` Vuex store module exist only for ChatGPT. But the chat `Composer` is a
**shared** component rendered for every chat model group, so the mic button was
showing on non-ChatGPT pages too (e.g. `studio.acedata.cloud/grok/conversations`),
where clicking it would push the user into the ChatGPT-only call route.

## Fix (model-group capability flag)

Gate the button behind a new declarative capability flag on the model group,
matching the existing `isReasoningSupported` flag pattern:

- `IChatModelGroup` gains optional `isVoiceCallSupported?: boolean`.
- Only `CHAT_MODEL_GROUP_CHATGPT` sets `isVoiceCallSupported: true`.
- `Composer.vue` renders the voice `<el-tooltip>` with
  `v-if="isVoiceCallSupported"`, where the computed reads
  `this.modelGroup?.isVoiceCallSupported ?? false`.

Result: the mic button shows for ChatGPT only; Grok / Gemini / Claude / DeepSeek /
Kimi / GLM no longer show it. Adding voice to another group later is a one-line
flag flip.

## Validation

- `vue-tsc -b --force` (CI build-mode type-check) — passes.
- `eslint` on the 3 changed files — passes.
- Beachball change file added (`patch`).

## 🤖 对抗评审

Independent read-only reviewer (Codex was rate-limited; fell back to a
`general-purpose` subagent). One round, converged.

**VERDICT: CLEAN.** Checks performed:

- Composer.vue is the **only** UI entry point to the voice/realtime feature
  (`ROUTE_CHATGPT_CALL` / `onStartCall` / `btn-voice` grep is exhaustive);
  no sidebar/menu/header link remains ungated.
- `chat.modelGroup` is reliably populated — store default is the ChatGPT group
  and `ModelSelector` syncs the route's `meta.modelGroup` on mount and on route
  change, so non-ChatGPT pages resolve to their own group (button hidden) and
  the ChatGPT page keeps the flag (button shown). `modelGroup` is intentionally
  **not** persisted, so no stale cross-group leakage on reload.
- The optional-chaining + `?? false` default means an undefined group hides the
  button (safe fail-closed) rather than erroring.
- Interface field is optional → backward compatible; no other group object needs
  changes. No existing Composer/constants tests are affected.
