### PR TITLE
feat(download): enable iOS App Store entry on studio download page

### DIFF
--- a/change/@acedatacloud-nexior-ios-appstore-entry.json
+++ b/change/@acedatacloud-nexior-ios-appstore-entry.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "enable the iOS App Store download entry on the studio download page",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/constants/mobile.ts
+++ b/src/constants/mobile.ts
@@ -4,6 +4,8 @@ export const MOBILE_ANDROID_DOWNLOAD_URL = 'https://cdn.acedata.cloud/2f29543715
 
 export const MOBILE_ANDROID_PLAY_STORE_URL = 'https://play.google.com/store/apps/details?id=com.acedatacloud.nexior';
 
+export const MOBILE_IOS_APP_STORE_URL = 'https://apps.apple.com/app/id6772432921';
+
 export const MOBILE_IOS_DOWNLOAD_URL = '';
 
 export const MOBILE_IOS_FALLBACK_URL = '';

--- a/src/i18n/ar/common.json
+++ b/src/i18n/ar/common.json
@@ -299,9 +299,17 @@
     "message": "قريبًا",
     "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
   },
+  "message.mobileNowOnAppStore": {
+    "message": "Now on the App Store",
+    "description": "Status label shown on the iOS card when the app is live on the App Store"
+  },
   "button.getOnGooglePlay": {
     "message": "تنزيل من Google Play",
     "description": "Button label that opens the app's Google Play Store listing"
+  },
+  "button.getOnAppStore": {
+    "message": "Get it on the App Store",
+    "description": "Button label that opens the app's Apple App Store listing"
   },
   "message.mobileApkFallback": {
     "message": "لا يمكنك الوصول إلى Google Play؟ نزّل حزمة APK مباشرةً.",
@@ -310,6 +318,10 @@
   "message.mobilePlayStoreHint": {
     "message": "امسح الرمز لفتح Google Play",
     "description": "Hint under the QR code explaining that scanning it opens the Google Play listing"
+  },
+  "message.mobileAppStoreHint": {
+    "message": "Scan to open the App Store",
+    "description": "Hint under the QR code explaining that scanning it opens the App Store listing"
   },
   "message.mobileInstallNote": {
     "message": "عند تثبيت حزمة مؤسسية أو Ad Hoc على iOS لأول مرة، قد يطلب النظام أولاً الوثوق بالشهادة في \"الإعدادات > عام > VPN وإدارة الأجهزة\".",

--- a/src/i18n/de/common.json
+++ b/src/i18n/de/common.json
@@ -299,9 +299,17 @@
     "message": "Demnächst verfügbar",
     "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
   },
+  "message.mobileNowOnAppStore": {
+    "message": "Now on the App Store",
+    "description": "Status label shown on the iOS card when the app is live on the App Store"
+  },
   "button.getOnGooglePlay": {
     "message": "Jetzt bei Google Play",
     "description": "Button label that opens the app's Google Play Store listing"
+  },
+  "button.getOnAppStore": {
+    "message": "Get it on the App Store",
+    "description": "Button label that opens the app's Apple App Store listing"
   },
   "message.mobileApkFallback": {
     "message": "Kein Zugriff auf Google Play? Lade die APK direkt herunter.",
@@ -310,6 +318,10 @@
   "message.mobilePlayStoreHint": {
     "message": "Scannen, um Google Play zu öffnen",
     "description": "Hint under the QR code explaining that scanning it opens the Google Play listing"
+  },
+  "message.mobileAppStoreHint": {
+    "message": "Scan to open the App Store",
+    "description": "Hint under the QR code explaining that scanning it opens the App Store listing"
   },
   "message.mobileInstallNote": {
     "message": "Bei der ersten Installation eines Unternehmens- oder Ad-Hoc-Pakets auf iOS kann das System verlangen, dass das Zertifikat zuerst unter 'Einstellungen > Allgemein > VPN & Geräteverwaltung' vertraut wird.",

--- a/src/i18n/el/common.json
+++ b/src/i18n/el/common.json
@@ -299,9 +299,17 @@
     "message": "Σύντομα",
     "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
   },
+  "message.mobileNowOnAppStore": {
+    "message": "Now on the App Store",
+    "description": "Status label shown on the iOS card when the app is live on the App Store"
+  },
   "button.getOnGooglePlay": {
     "message": "Λήψη από το Google Play",
     "description": "Button label that opens the app's Google Play Store listing"
+  },
+  "button.getOnAppStore": {
+    "message": "Get it on the App Store",
+    "description": "Button label that opens the app's Apple App Store listing"
   },
   "message.mobileApkFallback": {
     "message": "Δεν έχετε πρόσβαση στο Google Play; Κατεβάστε απευθείας το APK.",
@@ -310,6 +318,10 @@
   "message.mobilePlayStoreHint": {
     "message": "Σαρώστε για άνοιγμα στο Google Play",
     "description": "Hint under the QR code explaining that scanning it opens the Google Play listing"
+  },
+  "message.mobileAppStoreHint": {
+    "message": "Scan to open the App Store",
+    "description": "Hint under the QR code explaining that scanning it opens the App Store listing"
   },
   "message.mobileInstallNote": {
     "message": "Κατά την πρώτη εγκατάσταση του πακέτου επιχείρησης ή Ad Hoc για iOS, το σύστημα μπορεί να ζητήσει πρώτα να εμπιστευτείτε το πιστοποιητικό στις 'Ρυθμίσεις > Γενικά > VPN και Διαχείριση Συσκευών'.",

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -284,7 +284,7 @@
     "description": "Used to explain that the mobile version shares the account with the web version"
   },
   "message.mobileIosHint": {
-    "message": "For iPhone and iPad, can be installed directly online; if the system intercepts, you can also download the IPA first and then distribute it.",
+    "message": "For iPhone and iPad — install directly from the App Store, sharing your account and quota with the web app.",
     "description": "iOS download card description"
   },
   "message.mobileIosPending": {
@@ -295,9 +295,17 @@
     "message": "Coming soon",
     "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
   },
+  "message.mobileNowOnAppStore": {
+    "message": "Now on the App Store",
+    "description": "Status label shown on the iOS card when the app is live on the App Store"
+  },
   "button.getOnGooglePlay": {
     "message": "Get it on Google Play",
     "description": "Button label that opens the app's Google Play Store listing"
+  },
+  "button.getOnAppStore": {
+    "message": "Get it on the App Store",
+    "description": "Button label that opens the app's Apple App Store listing"
   },
   "message.mobileApkFallback": {
     "message": "No access to Google Play? Download the APK directly.",
@@ -306,6 +314,10 @@
   "message.mobilePlayStoreHint": {
     "message": "Scan to open Google Play",
     "description": "Hint under the QR code explaining that scanning it opens the Google Play listing"
+  },
+  "message.mobileAppStoreHint": {
+    "message": "Scan to open the App Store",
+    "description": "Hint under the QR code explaining that scanning it opens the App Store listing"
   },
   "message.mobileInstallNote": {
     "message": "When installing the enterprise or Ad Hoc package for the first time on iOS, the system may require you to trust the certificate in 'Settings > General > VPN & Device Management'.",

--- a/src/i18n/es/common.json
+++ b/src/i18n/es/common.json
@@ -299,9 +299,17 @@
     "message": "Próximamente",
     "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
   },
+  "message.mobileNowOnAppStore": {
+    "message": "Now on the App Store",
+    "description": "Status label shown on the iOS card when the app is live on the App Store"
+  },
   "button.getOnGooglePlay": {
     "message": "Disponible en Google Play",
     "description": "Button label that opens the app's Google Play Store listing"
+  },
+  "button.getOnAppStore": {
+    "message": "Get it on the App Store",
+    "description": "Button label that opens the app's Apple App Store listing"
   },
   "message.mobileApkFallback": {
     "message": "¿Sin acceso a Google Play? Descarga el APK directamente.",
@@ -310,6 +318,10 @@
   "message.mobilePlayStoreHint": {
     "message": "Escanea para abrir Google Play",
     "description": "Hint under the QR code explaining that scanning it opens the Google Play listing"
+  },
+  "message.mobileAppStoreHint": {
+    "message": "Scan to open the App Store",
+    "description": "Hint under the QR code explaining that scanning it opens the App Store listing"
   },
   "message.mobileInstallNote": {
     "message": "Al instalar por primera vez un paquete empresarial o Ad Hoc en iOS, el sistema puede requerir que confíes en el certificado en 'Configuración > General > VPN y gestión de dispositivos'.",

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -299,9 +299,17 @@
     "message": "Tulossa pian",
     "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
   },
+  "message.mobileNowOnAppStore": {
+    "message": "Now on the App Store",
+    "description": "Status label shown on the iOS card when the app is live on the App Store"
+  },
   "button.getOnGooglePlay": {
     "message": "Lataa Google Playsta",
     "description": "Button label that opens the app's Google Play Store listing"
+  },
+  "button.getOnAppStore": {
+    "message": "Get it on the App Store",
+    "description": "Button label that opens the app's Apple App Store listing"
   },
   "message.mobileApkFallback": {
     "message": "Eikö Google Play ole käytettävissä? Lataa APK suoraan.",
@@ -310,6 +318,10 @@
   "message.mobilePlayStoreHint": {
     "message": "Skannaa avataksesi Google Playn",
     "description": "Hint under the QR code explaining that scanning it opens the Google Play listing"
+  },
+  "message.mobileAppStoreHint": {
+    "message": "Scan to open the App Store",
+    "description": "Hint under the QR code explaining that scanning it opens the App Store listing"
   },
   "message.mobileInstallNote": {
     "message": "Kun asennat iOS:lle ensimmäistä kertaa yritys- tai Ad Hoc-pakettia, järjestelmä saattaa vaatia ensin luottamusta sertifikaattiin 'Asetukset > Yleiset > VPN ja laitehallinta' -valikossa.",

--- a/src/i18n/fr/common.json
+++ b/src/i18n/fr/common.json
@@ -299,9 +299,17 @@
     "message": "Bientôt disponible",
     "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
   },
+  "message.mobileNowOnAppStore": {
+    "message": "Now on the App Store",
+    "description": "Status label shown on the iOS card when the app is live on the App Store"
+  },
   "button.getOnGooglePlay": {
     "message": "Disponible sur Google Play",
     "description": "Button label that opens the app's Google Play Store listing"
+  },
+  "button.getOnAppStore": {
+    "message": "Get it on the App Store",
+    "description": "Button label that opens the app's Apple App Store listing"
   },
   "message.mobileApkFallback": {
     "message": "Pas d'accès à Google Play ? Téléchargez directement l'APK.",
@@ -310,6 +318,10 @@
   "message.mobilePlayStoreHint": {
     "message": "Scannez pour ouvrir Google Play",
     "description": "Hint under the QR code explaining that scanning it opens the Google Play listing"
+  },
+  "message.mobileAppStoreHint": {
+    "message": "Scan to open the App Store",
+    "description": "Hint under the QR code explaining that scanning it opens the App Store listing"
   },
   "message.mobileInstallNote": {
     "message": "Lors de la première installation d'un package d'entreprise ou Ad Hoc sur iOS, le système peut demander de faire confiance au certificat dans 'Réglages > Général > VPN et gestion des appareils'.",

--- a/src/i18n/it/common.json
+++ b/src/i18n/it/common.json
@@ -299,9 +299,17 @@
     "message": "Disponibile a breve",
     "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
   },
+  "message.mobileNowOnAppStore": {
+    "message": "Now on the App Store",
+    "description": "Status label shown on the iOS card when the app is live on the App Store"
+  },
   "button.getOnGooglePlay": {
     "message": "Disponibile su Google Play",
     "description": "Button label that opens the app's Google Play Store listing"
+  },
+  "button.getOnAppStore": {
+    "message": "Get it on the App Store",
+    "description": "Button label that opens the app's Apple App Store listing"
   },
   "message.mobileApkFallback": {
     "message": "Nessun accesso a Google Play? Scarica direttamente l'APK.",
@@ -310,6 +318,10 @@
   "message.mobilePlayStoreHint": {
     "message": "Scansiona per aprire Google Play",
     "description": "Hint under the QR code explaining that scanning it opens the Google Play listing"
+  },
+  "message.mobileAppStoreHint": {
+    "message": "Scan to open the App Store",
+    "description": "Hint under the QR code explaining that scanning it opens the App Store listing"
   },
   "message.mobileInstallNote": {
     "message": "Durante la prima installazione di un pacchetto aziendale o Ad Hoc su iOS, il sistema potrebbe richiedere di fidarsi del certificato in 'Impostazioni > Generali > VPN e gestione dispositivo'.",

--- a/src/i18n/ja/common.json
+++ b/src/i18n/ja/common.json
@@ -299,9 +299,17 @@
     "message": "近日公開",
     "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
   },
+  "message.mobileNowOnAppStore": {
+    "message": "Now on the App Store",
+    "description": "Status label shown on the iOS card when the app is live on the App Store"
+  },
   "button.getOnGooglePlay": {
     "message": "Google Play で手に入れよう",
     "description": "Button label that opens the app's Google Play Store listing"
+  },
+  "button.getOnAppStore": {
+    "message": "Get it on the App Store",
+    "description": "Button label that opens the app's Apple App Store listing"
   },
   "message.mobileApkFallback": {
     "message": "Google Play を利用できない場合は、APK を直接ダウンロードできます。",
@@ -310,6 +318,10 @@
   "message.mobilePlayStoreHint": {
     "message": "スキャンして Google Play を開く",
     "description": "Hint under the QR code explaining that scanning it opens the Google Play listing"
+  },
+  "message.mobileAppStoreHint": {
+    "message": "Scan to open the App Store",
+    "description": "Hint under the QR code explaining that scanning it opens the App Store listing"
   },
   "message.mobileInstallNote": {
     "message": "iOSで企業またはAd Hocパッケージを初めてインストールする際、システムが「設定 > 一般 > VPNとデバイス管理」で証明書を信頼するよう求める場合があります。",

--- a/src/i18n/ko/common.json
+++ b/src/i18n/ko/common.json
@@ -299,9 +299,17 @@
     "message": "출시 예정",
     "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
   },
+  "message.mobileNowOnAppStore": {
+    "message": "Now on the App Store",
+    "description": "Status label shown on the iOS card when the app is live on the App Store"
+  },
   "button.getOnGooglePlay": {
     "message": "Google Play에서 다운로드",
     "description": "Button label that opens the app's Google Play Store listing"
+  },
+  "button.getOnAppStore": {
+    "message": "Get it on the App Store",
+    "description": "Button label that opens the app's Apple App Store listing"
   },
   "message.mobileApkFallback": {
     "message": "Google Play를 사용할 수 없나요? APK를 직접 다운로드하세요.",
@@ -310,6 +318,10 @@
   "message.mobilePlayStoreHint": {
     "message": "스캔하여 Google Play 열기",
     "description": "Hint under the QR code explaining that scanning it opens the Google Play listing"
+  },
+  "message.mobileAppStoreHint": {
+    "message": "Scan to open the App Store",
+    "description": "Hint under the QR code explaining that scanning it opens the App Store listing"
   },
   "message.mobileInstallNote": {
     "message": "iOS에서 기업 또는 Ad Hoc 패키지를 처음 설치할 때, 시스템이 '설정 > 일반 > VPN 및 기기 관리'에서 인증서를 신뢰하도록 요구할 수 있습니다.",

--- a/src/i18n/pl/common.json
+++ b/src/i18n/pl/common.json
@@ -299,9 +299,17 @@
     "message": "Wkrótce",
     "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
   },
+  "message.mobileNowOnAppStore": {
+    "message": "Now on the App Store",
+    "description": "Status label shown on the iOS card when the app is live on the App Store"
+  },
   "button.getOnGooglePlay": {
     "message": "Pobierz z Google Play",
     "description": "Button label that opens the app's Google Play Store listing"
+  },
+  "button.getOnAppStore": {
+    "message": "Get it on the App Store",
+    "description": "Button label that opens the app's Apple App Store listing"
   },
   "message.mobileApkFallback": {
     "message": "Brak dostępu do Google Play? Pobierz plik APK bezpośrednio.",
@@ -310,6 +318,10 @@
   "message.mobilePlayStoreHint": {
     "message": "Zeskanuj, aby otworzyć Google Play",
     "description": "Hint under the QR code explaining that scanning it opens the Google Play listing"
+  },
+  "message.mobileAppStoreHint": {
+    "message": "Scan to open the App Store",
+    "description": "Hint under the QR code explaining that scanning it opens the App Store listing"
   },
   "message.mobileInstallNote": {
     "message": "Podczas pierwszej instalacji pakietu korporacyjnego lub Ad Hoc na iOS, system może poprosić o zaufanie certyfikatowi w 'Ustawienia > Ogólne > VPN i zarządzanie urządzeniem'.",

--- a/src/i18n/pt/common.json
+++ b/src/i18n/pt/common.json
@@ -299,9 +299,17 @@
     "message": "Em breve",
     "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
   },
+  "message.mobileNowOnAppStore": {
+    "message": "Now on the App Store",
+    "description": "Status label shown on the iOS card when the app is live on the App Store"
+  },
   "button.getOnGooglePlay": {
     "message": "Disponível no Google Play",
     "description": "Button label that opens the app's Google Play Store listing"
+  },
+  "button.getOnAppStore": {
+    "message": "Get it on the App Store",
+    "description": "Button label that opens the app's Apple App Store listing"
   },
   "message.mobileApkFallback": {
     "message": "Sem acesso ao Google Play? Baixe o APK diretamente.",
@@ -310,6 +318,10 @@
   "message.mobilePlayStoreHint": {
     "message": "Escaneie para abrir o Google Play",
     "description": "Hint under the QR code explaining that scanning it opens the Google Play listing"
+  },
+  "message.mobileAppStoreHint": {
+    "message": "Scan to open the App Store",
+    "description": "Hint under the QR code explaining that scanning it opens the App Store listing"
   },
   "message.mobileInstallNote": {
     "message": "Ao instalar pela primeira vez um pacote corporativo ou Ad Hoc no iOS, o sistema pode solicitar que você confie no certificado em 'Ajustes > Geral > VPN e Gerenciamento de Dispositivos'.",

--- a/src/i18n/ru/common.json
+++ b/src/i18n/ru/common.json
@@ -299,9 +299,17 @@
     "message": "Скоро",
     "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
   },
+  "message.mobileNowOnAppStore": {
+    "message": "Now on the App Store",
+    "description": "Status label shown on the iOS card when the app is live on the App Store"
+  },
   "button.getOnGooglePlay": {
     "message": "Доступно в Google Play",
     "description": "Button label that opens the app's Google Play Store listing"
+  },
+  "button.getOnAppStore": {
+    "message": "Get it on the App Store",
+    "description": "Button label that opens the app's Apple App Store listing"
   },
   "message.mobileApkFallback": {
     "message": "Нет доступа к Google Play? Скачайте APK напрямую.",
@@ -310,6 +318,10 @@
   "message.mobilePlayStoreHint": {
     "message": "Отсканируйте, чтобы открыть Google Play",
     "description": "Hint under the QR code explaining that scanning it opens the Google Play listing"
+  },
+  "message.mobileAppStoreHint": {
+    "message": "Scan to open the App Store",
+    "description": "Hint under the QR code explaining that scanning it opens the App Store listing"
   },
   "message.mobileInstallNote": {
     "message": "При первой установке корпоративного или Ad Hoc пакета на iOS система может потребовать сначала доверить сертификат в 'Настройки > Основные > VPN и управление устройствами'.",

--- a/src/i18n/sr/common.json
+++ b/src/i18n/sr/common.json
@@ -299,9 +299,17 @@
     "message": "Ускоро",
     "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
   },
+  "message.mobileNowOnAppStore": {
+    "message": "Now on the App Store",
+    "description": "Status label shown on the iOS card when the app is live on the App Store"
+  },
   "button.getOnGooglePlay": {
     "message": "Преузмите са Google Play-а",
     "description": "Button label that opens the app's Google Play Store listing"
+  },
+  "button.getOnAppStore": {
+    "message": "Get it on the App Store",
+    "description": "Button label that opens the app's Apple App Store listing"
   },
   "message.mobileApkFallback": {
     "message": "Немате приступ Google Play-у? Преузмите APK директно.",
@@ -310,6 +318,10 @@
   "message.mobilePlayStoreHint": {
     "message": "Скенирајте да отворите Google Play",
     "description": "Hint under the QR code explaining that scanning it opens the Google Play listing"
+  },
+  "message.mobileAppStoreHint": {
+    "message": "Scan to open the App Store",
+    "description": "Hint under the QR code explaining that scanning it opens the App Store listing"
   },
   "message.mobileInstallNote": {
     "message": "Prilikom prve instalacije preduzeća ili Ad Hoc paketa na iOS-u, sistem može zatražiti da prvo verifikujete sertifikat u 'Podešavanja > Opšte > VPN i upravljanje uređajem'.",

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -299,9 +299,17 @@
     "message": "Kommer snart",
     "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
   },
+  "message.mobileNowOnAppStore": {
+    "message": "Now on the App Store",
+    "description": "Status label shown on the iOS card when the app is live on the App Store"
+  },
   "button.getOnGooglePlay": {
     "message": "Hämta på Google Play",
     "description": "Button label that opens the app's Google Play Store listing"
+  },
+  "button.getOnAppStore": {
+    "message": "Get it on the App Store",
+    "description": "Button label that opens the app's Apple App Store listing"
   },
   "message.mobileApkFallback": {
     "message": "Ingen åtkomst till Google Play? Ladda ner APK-filen direkt.",
@@ -310,6 +318,10 @@
   "message.mobilePlayStoreHint": {
     "message": "Skanna för att öppna Google Play",
     "description": "Hint under the QR code explaining that scanning it opens the Google Play listing"
+  },
+  "message.mobileAppStoreHint": {
+    "message": "Scan to open the App Store",
+    "description": "Hint under the QR code explaining that scanning it opens the App Store listing"
   },
   "message.mobileInstallNote": {
     "message": "Vid första installationen av företags- eller Ad Hoc-paket på iOS kan systemet kräva att du först litar på certifikatet i 'Inställningar > Allmänt > VPN och enhetsadministration'.",

--- a/src/i18n/uk/common.json
+++ b/src/i18n/uk/common.json
@@ -299,9 +299,17 @@
     "message": "Незабаром",
     "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
   },
+  "message.mobileNowOnAppStore": {
+    "message": "Now on the App Store",
+    "description": "Status label shown on the iOS card when the app is live on the App Store"
+  },
   "button.getOnGooglePlay": {
     "message": "Завантажити в Google Play",
     "description": "Button label that opens the app's Google Play Store listing"
+  },
+  "button.getOnAppStore": {
+    "message": "Get it on the App Store",
+    "description": "Button label that opens the app's Apple App Store listing"
   },
   "message.mobileApkFallback": {
     "message": "Немає доступу до Google Play? Завантажте APK напряму.",
@@ -310,6 +318,10 @@
   "message.mobilePlayStoreHint": {
     "message": "Скануйте, щоб відкрити Google Play",
     "description": "Hint under the QR code explaining that scanning it opens the Google Play listing"
+  },
+  "message.mobileAppStoreHint": {
+    "message": "Scan to open the App Store",
+    "description": "Hint under the QR code explaining that scanning it opens the App Store listing"
   },
   "message.mobileInstallNote": {
     "message": "При першому встановленні корпоративного або Ad Hoc пакету на iOS, система може вимагати спочатку довірити сертифікат у 'Налаштування > Загальні > VPN та управління пристроями'.",

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -288,7 +288,7 @@
     "description": "用于说明移动端与网页端共用账号"
   },
   "message.mobileIosHint": {
-    "message": "适用于 iPhone 和 iPad，可直接在线安装；如果系统拦截，也可以先下载 IPA 再分发。",
+    "message": "适用于 iPhone 和 iPad，可直接从 App Store 安装，与网页端共用账号和额度。",
     "description": "iOS 下载卡片说明"
   },
   "message.mobileIosPending": {
@@ -299,9 +299,17 @@
     "message": "即将推出",
     "description": "用于标记某个平台（如 iOS）即将开放下载的短状态标签"
   },
+  "message.mobileNowOnAppStore": {
+    "message": "已上架 App Store",
+    "description": "Status label shown on the iOS card when the app is live on the App Store"
+  },
   "button.getOnGooglePlay": {
     "message": "在 Google Play 上获取",
     "description": "Button label that opens the app's Google Play Store listing"
+  },
+  "button.getOnAppStore": {
+    "message": "在 App Store 下载",
+    "description": "Button label that opens the app's Apple App Store listing"
   },
   "message.mobileApkFallback": {
     "message": "无法访问 Google Play？可直接下载 APK 安装包。",
@@ -310,6 +318,10 @@
   "message.mobilePlayStoreHint": {
     "message": "扫码前往 Google Play",
     "description": "Hint under the QR code explaining that scanning it opens the Google Play listing"
+  },
+  "message.mobileAppStoreHint": {
+    "message": "扫码前往 App Store",
+    "description": "Hint under the QR code explaining that scanning it opens the App Store listing"
   },
   "message.mobileInstallNote": {
     "message": "iOS 首次安装企业或 Ad Hoc 包时，系统可能要求先在“设置 > 通用 > VPN 与设备管理”中信任证书。",

--- a/src/i18n/zh-TW/common.json
+++ b/src/i18n/zh-TW/common.json
@@ -299,9 +299,17 @@
     "message": "即將推出",
     "description": "Short status label shown on a platform card (e.g. iOS) while its build is being prepared"
   },
+  "message.mobileNowOnAppStore": {
+    "message": "已上架 App Store",
+    "description": "Status label shown on the iOS card when the app is live on the App Store"
+  },
   "button.getOnGooglePlay": {
     "message": "在 Google Play 取得",
     "description": "Button label that opens the app's Google Play Store listing"
+  },
+  "button.getOnAppStore": {
+    "message": "在 App Store 下載",
+    "description": "Button label that opens the app's Apple App Store listing"
   },
   "message.mobileApkFallback": {
     "message": "無法存取 Google Play？可直接下載 APK 安裝檔。",
@@ -310,6 +318,10 @@
   "message.mobilePlayStoreHint": {
     "message": "掃碼前往 Google Play",
     "description": "Hint under the QR code explaining that scanning it opens the Google Play listing"
+  },
+  "message.mobileAppStoreHint": {
+    "message": "掃碼前往 App Store",
+    "description": "Hint under the QR code explaining that scanning it opens the App Store listing"
   },
   "message.mobileInstallNote": {
     "message": "iOS 首次安裝企業或 Ad Hoc 包時，系統可能要求先在“設定 > 通用 > VPN 與設備管理”中信任證書。",

--- a/src/pages/download/Index.vue
+++ b/src/pages/download/Index.vue
@@ -36,6 +36,10 @@
             <font-awesome-icon :icon="faAndroid" class="btn-icon" />
             {{ $t('common.button.downloadAndroid') }}
           </el-button>
+          <el-button v-if="hasAppStore" round size="large" tag="a" :href="appStoreUrl" target="_blank">
+            <font-awesome-icon :icon="faApple" class="btn-icon" />
+            {{ $t('common.button.getOnAppStore') }}
+          </el-button>
           <el-button round size="large" class="btn-ghost" @click="openSupport">
             {{ $t('common.nav.support') }}
           </el-button>
@@ -110,27 +114,63 @@
               <font-awesome-icon :icon="faApple" class="platform__os-icon" />
               iOS
             </span>
-            <span class="chip chip--pending">
-              <span class="chip__dot"></span>{{ $t('common.message.mobileComingSoon') }}
+            <span :class="['chip', hasIos ? 'chip--live' : 'chip--pending']">
+              <span class="chip__dot"></span>
+              {{ hasIos ? $t('common.message.mobileNowOnAppStore') : $t('common.message.mobileComingSoon') }}
             </span>
           </div>
           <h2 class="platform__title">{{ $t('common.button.downloadIos') }}</h2>
           <p class="platform__text">
-            {{ hasIosDownload ? $t('common.message.mobileIosHint') : $t('common.message.mobileIosPending') }}
+            {{ hasIos ? $t('common.message.mobileIosHint') : $t('common.message.mobileIosPending') }}
           </p>
 
-          <template v-if="hasIosDownload">
+          <div v-if="hasAppStore" class="qr">
+            <qr-code
+              :value="appStoreUrl"
+              :width="184"
+              :height="184"
+              class="qr__img"
+              type="image/png"
+              :color="{ dark: '#0e2a33ff', light: '#ffffffff' }"
+            />
+            <p class="qr__hint">{{ $t('common.message.mobileAppStoreHint') }}</p>
+          </div>
+
+          <template v-if="hasIos">
             <div class="platform__foot platform__foot--stack">
-              <div class="btn-row">
-                <el-button type="primary" round size="large" tag="a" :href="iosDownloadUrl" target="_blank">
-                  <font-awesome-icon :icon="faApple" class="btn-icon" />
-                  {{ $t('common.button.installIos') }}
-                </el-button>
-                <el-button round size="large" class="btn-ghost" tag="a" :href="iosFallbackUrl" target="_blank">
-                  {{ $t('common.button.downloadIos') }}
-                </el-button>
-              </div>
-              <span class="platform__meta">{{ $t('common.message.mobileInstallNote') }}</span>
+              <el-button
+                v-if="hasAppStore"
+                type="primary"
+                round
+                size="large"
+                tag="a"
+                :href="appStoreUrl"
+                target="_blank"
+              >
+                <font-awesome-icon :icon="faApple" class="btn-icon" />
+                {{ $t('common.button.getOnAppStore') }}
+              </el-button>
+
+              <template v-if="hasIosDownload">
+                <div class="btn-row">
+                  <el-button
+                    :type="hasAppStore ? 'default' : 'primary'"
+                    round
+                    :size="hasAppStore ? 'default' : 'large'"
+                    :class="{ 'btn-ghost': hasAppStore }"
+                    tag="a"
+                    :href="iosDownloadUrl"
+                    target="_blank"
+                  >
+                    <font-awesome-icon :icon="faApple" class="btn-icon" />
+                    {{ $t('common.button.installIos') }}
+                  </el-button>
+                  <el-button round size="large" class="btn-ghost" tag="a" :href="iosFallbackUrl" target="_blank">
+                    {{ $t('common.button.downloadIos') }}
+                  </el-button>
+                </div>
+                <span class="platform__meta">{{ $t('common.message.mobileInstallNote') }}</span>
+              </template>
             </div>
           </template>
 
@@ -168,7 +208,7 @@
       </section>
 
       <!-- Install note -->
-      <aside class="note">
+      <aside v-if="hasIosDownload" class="note">
         <font-awesome-icon :icon="faCircleInfo" class="note__icon" />
         <p class="note__text">{{ $t('common.message.mobileInstallNote') }}</p>
       </aside>
@@ -188,6 +228,7 @@ import {
   MOBILE_ANDROID_DOWNLOAD_URL,
   MOBILE_ANDROID_PLAY_STORE_URL,
   MOBILE_APP_VERSION,
+  MOBILE_IOS_APP_STORE_URL,
   MOBILE_IOS_DOWNLOAD_URL,
   MOBILE_IOS_FALLBACK_URL
 } from '@/constants';
@@ -230,6 +271,12 @@ export default defineComponent({
     hasPlayStore() {
       return !!MOBILE_ANDROID_PLAY_STORE_URL;
     },
+    appStoreUrl() {
+      return MOBILE_IOS_APP_STORE_URL;
+    },
+    hasAppStore() {
+      return !!MOBILE_IOS_APP_STORE_URL;
+    },
     iosDownloadUrl() {
       return MOBILE_IOS_DOWNLOAD_URL;
     },
@@ -238,6 +285,9 @@ export default defineComponent({
     },
     hasIosDownload() {
       return !!MOBILE_IOS_DOWNLOAD_URL && !!MOBILE_IOS_FALLBACK_URL;
+    },
+    hasIos() {
+      return this.hasAppStore || this.hasIosDownload;
     }
   },
   methods: {


### PR DESCRIPTION
## What

Enables the **iOS App Store** download entry on the Nexior (studio.acedata.cloud) mobile download page now that the app passed Apple review (Apple ID `6772432921`).

Previously the iOS card was hard-coded to a "Coming Soon" badge because the iOS URL constant was empty.

## Changes

- `src/constants/mobile.ts`: add `MOBILE_IOS_APP_STORE_URL = https://apps.apple.com/app/id6772432921` (region-neutral, matches `ATTRIBUTION_APP_STORE_URL` in PlatformBackend).
- `src/pages/download/Index.vue`:
  - New `appStoreUrl` / `hasAppStore` computed; `hasIos = hasAppStore || hasIosDownload`.
  - iOS card now shows a **live** badge, a **QR code**, and a **"Get it on the App Store"** CTA when the App Store URL is set — mirroring the existing Google Play card. The legacy IPA / enterprise install buttons remain but only render if a direct IPA download (`MOBILE_IOS_DOWNLOAD_URL` + fallback) is configured.
  - Added an App Store button to the hero actions for symmetry with Google Play.
  - The bottom enterprise/Ad Hoc "trust certificate" install note now only renders when an IPA path exists (`hasIosDownload`) — it's irrelevant for App Store installs.
- i18n: 3 new keys (`button.getOnAppStore`, `message.mobileAppStoreHint`, `message.mobileNowOnAppStore`) added to all 18 locales; `message.mobileIosHint` text updated (en + zh-CN) to reflect App Store distribution.

## Verification

- `python3 scripts/check_i18n_coverage.py` → OK (17 locales × 44 namespaces match zh-CN).
- `eslint` + `vue-tsc --noEmit` clean on changed files.
- The page reads URLs from constants, so the iOS entry self-activates on deploy.

## 🤖 对抗评审

Reviewer: **Codex** (`codex exec --sandbox read-only`). Display-only frontend change; verified Vue v-if gating, i18n key coverage, `vue-qrcode` import/usage, and URL correctness. `VERDICT: CLEAN`.
