### PR TITLE
feat(chat): add 每分钟 (minutely) frequency to scheduled tasks

### DIFF
--- a/change/@acedatacloud-nexior-2f8a3129-6429-4df9-8ca7-2427a5e2d1b5.json
+++ b/change/@acedatacloud-nexior-2f8a3129-6429-4df9-8ca7-2427a5e2d1b5.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add a 每分钟 (every-minute) frequency option to scheduled tasks",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/i18n/ar/chat.json
+++ b/src/i18n/ar/chat.json
@@ -639,6 +639,9 @@
   "scheduledTasks.scheduleType.daily": {
     "message": "Daily"
   },
+  "scheduledTasks.scheduleType.minutely": {
+    "message": "كل دقيقة"
+  },
   "scheduledTasks.scheduleType.hourly": {
     "message": "Hourly"
   },

--- a/src/i18n/de/chat.json
+++ b/src/i18n/de/chat.json
@@ -639,6 +639,9 @@
   "scheduledTasks.scheduleType.daily": {
     "message": "Daily"
   },
+  "scheduledTasks.scheduleType.minutely": {
+    "message": "Jede Minute"
+  },
   "scheduledTasks.scheduleType.hourly": {
     "message": "Hourly"
   },

--- a/src/i18n/el/chat.json
+++ b/src/i18n/el/chat.json
@@ -639,6 +639,9 @@
   "scheduledTasks.scheduleType.daily": {
     "message": "Daily"
   },
+  "scheduledTasks.scheduleType.minutely": {
+    "message": "Κάθε λεπτό"
+  },
   "scheduledTasks.scheduleType.hourly": {
     "message": "Hourly"
   },

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -638,6 +638,9 @@
   "scheduledTasks.scheduleType.daily": {
     "message": "Daily"
   },
+  "scheduledTasks.scheduleType.minutely": {
+    "message": "Every minute"
+  },
   "scheduledTasks.scheduleType.hourly": {
     "message": "Hourly"
   },

--- a/src/i18n/es/chat.json
+++ b/src/i18n/es/chat.json
@@ -639,6 +639,9 @@
   "scheduledTasks.scheduleType.daily": {
     "message": "Daily"
   },
+  "scheduledTasks.scheduleType.minutely": {
+    "message": "Cada minuto"
+  },
   "scheduledTasks.scheduleType.hourly": {
     "message": "Hourly"
   },

--- a/src/i18n/fi/chat.json
+++ b/src/i18n/fi/chat.json
@@ -639,6 +639,9 @@
   "scheduledTasks.scheduleType.daily": {
     "message": "Daily"
   },
+  "scheduledTasks.scheduleType.minutely": {
+    "message": "Joka minuutti"
+  },
   "scheduledTasks.scheduleType.hourly": {
     "message": "Hourly"
   },

--- a/src/i18n/fr/chat.json
+++ b/src/i18n/fr/chat.json
@@ -639,6 +639,9 @@
   "scheduledTasks.scheduleType.daily": {
     "message": "Daily"
   },
+  "scheduledTasks.scheduleType.minutely": {
+    "message": "Chaque minute"
+  },
   "scheduledTasks.scheduleType.hourly": {
     "message": "Hourly"
   },

--- a/src/i18n/it/chat.json
+++ b/src/i18n/it/chat.json
@@ -639,6 +639,9 @@
   "scheduledTasks.scheduleType.daily": {
     "message": "Daily"
   },
+  "scheduledTasks.scheduleType.minutely": {
+    "message": "Ogni minuto"
+  },
   "scheduledTasks.scheduleType.hourly": {
     "message": "Hourly"
   },

--- a/src/i18n/ja/chat.json
+++ b/src/i18n/ja/chat.json
@@ -639,6 +639,9 @@
   "scheduledTasks.scheduleType.daily": {
     "message": "Daily"
   },
+  "scheduledTasks.scheduleType.minutely": {
+    "message": "毎分"
+  },
   "scheduledTasks.scheduleType.hourly": {
     "message": "Hourly"
   },

--- a/src/i18n/ko/chat.json
+++ b/src/i18n/ko/chat.json
@@ -639,6 +639,9 @@
   "scheduledTasks.scheduleType.daily": {
     "message": "Daily"
   },
+  "scheduledTasks.scheduleType.minutely": {
+    "message": "매분"
+  },
   "scheduledTasks.scheduleType.hourly": {
     "message": "Hourly"
   },

--- a/src/i18n/pl/chat.json
+++ b/src/i18n/pl/chat.json
@@ -639,6 +639,9 @@
   "scheduledTasks.scheduleType.daily": {
     "message": "Daily"
   },
+  "scheduledTasks.scheduleType.minutely": {
+    "message": "Co minutę"
+  },
   "scheduledTasks.scheduleType.hourly": {
     "message": "Hourly"
   },

--- a/src/i18n/pt/chat.json
+++ b/src/i18n/pt/chat.json
@@ -639,6 +639,9 @@
   "scheduledTasks.scheduleType.daily": {
     "message": "Daily"
   },
+  "scheduledTasks.scheduleType.minutely": {
+    "message": "A cada minuto"
+  },
   "scheduledTasks.scheduleType.hourly": {
     "message": "Hourly"
   },

--- a/src/i18n/ru/chat.json
+++ b/src/i18n/ru/chat.json
@@ -639,6 +639,9 @@
   "scheduledTasks.scheduleType.daily": {
     "message": "Daily"
   },
+  "scheduledTasks.scheduleType.minutely": {
+    "message": "Каждую минуту"
+  },
   "scheduledTasks.scheduleType.hourly": {
     "message": "Hourly"
   },

--- a/src/i18n/sr/chat.json
+++ b/src/i18n/sr/chat.json
@@ -639,6 +639,9 @@
   "scheduledTasks.scheduleType.daily": {
     "message": "Daily"
   },
+  "scheduledTasks.scheduleType.minutely": {
+    "message": "Сваког минута"
+  },
   "scheduledTasks.scheduleType.hourly": {
     "message": "Hourly"
   },

--- a/src/i18n/sv/chat.json
+++ b/src/i18n/sv/chat.json
@@ -639,6 +639,9 @@
   "scheduledTasks.scheduleType.daily": {
     "message": "Daily"
   },
+  "scheduledTasks.scheduleType.minutely": {
+    "message": "Varje minut"
+  },
   "scheduledTasks.scheduleType.hourly": {
     "message": "Hourly"
   },

--- a/src/i18n/uk/chat.json
+++ b/src/i18n/uk/chat.json
@@ -639,6 +639,9 @@
   "scheduledTasks.scheduleType.daily": {
     "message": "Daily"
   },
+  "scheduledTasks.scheduleType.minutely": {
+    "message": "Щохвилини"
+  },
   "scheduledTasks.scheduleType.hourly": {
     "message": "Hourly"
   },

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -596,6 +596,7 @@
   "scheduledTasks.run.failed": { "message": "失败", "description": "失败状态" },
   "scheduledTasks.run.needs_user_input": { "message": "需要操作", "description": "需要用户操作状态" },
   "scheduledTasks.scheduleType.daily": { "message": "每天", "description": "每天执行" },
+  "scheduledTasks.scheduleType.minutely": { "message": "每分钟", "description": "每分钟执行" },
   "scheduledTasks.scheduleType.hourly": { "message": "每小时", "description": "每小时执行" },
   "scheduledTasks.scheduleType.weekly": { "message": "每周", "description": "每周执行" },
   "scheduledTasks.scheduleType.cron": { "message": "Cron 表达式", "description": "自定义 cron" },

--- a/src/i18n/zh-TW/chat.json
+++ b/src/i18n/zh-TW/chat.json
@@ -639,6 +639,9 @@
   "scheduledTasks.scheduleType.daily": {
     "message": "Daily"
   },
+  "scheduledTasks.scheduleType.minutely": {
+    "message": "每分鐘"
+  },
   "scheduledTasks.scheduleType.hourly": {
     "message": "Hourly"
   },

--- a/src/pages/chat/ScheduledTasks.vue
+++ b/src/pages/chat/ScheduledTasks.vue
@@ -137,6 +137,7 @@
 
         <el-form-item :label="$t('chat.scheduledTasks.form.schedule')">
           <el-radio-group v-model="form.scheduleType">
+            <el-radio value="minutely">{{ $t('chat.scheduledTasks.scheduleType.minutely') }}</el-radio>
             <el-radio value="daily">{{ $t('chat.scheduledTasks.scheduleType.daily') }}</el-radio>
             <el-radio value="hourly">{{ $t('chat.scheduledTasks.scheduleType.hourly') }}</el-radio>
             <el-radio value="weekly">{{ $t('chat.scheduledTasks.scheduleType.weekly') }}</el-radio>
@@ -203,7 +204,7 @@ const USER_TZ = Intl.DateTimeFormat().resolvedOptions().timeZone || 'Asia/Shangh
 interface TaskForm {
   question: string;
   model: string;
-  scheduleType: 'daily' | 'hourly' | 'weekly' | 'cron';
+  scheduleType: 'minutely' | 'daily' | 'hourly' | 'weekly' | 'cron';
   dailyTime: string;
   weekday: number;
   cronExpr: string;
@@ -319,7 +320,9 @@ export default defineComponent({
           }
         }
       } else if (s.type === 'interval') {
-        scheduleType = s.interval_seconds === 3600 ? 'hourly' : 'cron';
+        if (s.interval_seconds === 60) scheduleType = 'minutely';
+        else if (s.interval_seconds === 3600) scheduleType = 'hourly';
+        else scheduleType = 'cron';
       }
       this.form = {
         question: task.template.question,
@@ -333,6 +336,9 @@ export default defineComponent({
     },
     buildSchedule(): IScheduleSpec {
       const { scheduleType, dailyTime, weekday, cronExpr } = this.form;
+      if (scheduleType === 'minutely') {
+        return { type: 'interval', interval_seconds: 60, tz: USER_TZ };
+      }
       if (scheduleType === 'hourly') {
         return { type: 'interval', interval_seconds: 3600, tz: USER_TZ };
       }


### PR DESCRIPTION
## What

Adds an **每分钟 (every-minute)** option to the Nexior scheduled-task create form (`/chatgpt/scheduled`), next to the existing 每天 / 每小时 / 每周 / Cron radios.

## How

- New first radio `minutely` → maps to `{ type: 'interval', interval_seconds: 60 }`.
- `openEdit` round-trips a 60s interval back to the `minutely` radio.
- `scheduleType.minutely` i18n key added to **all 18 locales** (CI coverage guard).

`platform-scheduler` already supports this — the worker polls every 5s and `handleCreate` has no minimum-interval guard. (A 60s cadence was technically already reachable via the `Cron` field with `* * * * *`; this just adds a one-click shortcut.)

**Companion PR:** AceDataCloud/PlatformService#1185 caps interval jitter so a 60s cadence fires cleanly (~30–90s spacing) instead of bursting.

## Cost note

Each run is a billed chat completion; an every-minute task is up to ~1440 runs/day, deducted from the user's balance.

## Validation

- `vue-tsc -b --force` → 0 errors
- `eslint` (changed files) → 0 non-prettier problems
- `python3 scripts/check_i18n_coverage.py` → OK (17 locales × 44 namespaces)
- `beachball check` → pass

## 🤖 对抗评审 (reviewer: claude-subagent, 2 rounds)

- RISK: frontend `jitter_seconds:10` hack only applied on create (not edit), asymmetric & aichat2 `handleUpdate` ignores jitter → **已修**：彻底移除该 hack；jitter 改在正确的层处理（见 companion PluginService#1185，对所有 interval 任务统一封顶）。
- RISK: frontend-hardcoded jitter could diverge from backend default / no range validation → **已修**：移除后前端不再发送 jitter。
- RISK: `scheduleLabel` 对非中文 UI 显示硬编码中文 → **未采纳（pre-existing）**：不在本 diff 内；对 hourly/cron/once 同样存在，早于本 PR。TODO：单独做一次 `scheduleLabel` 的 i18n。
- RISK: `openEdit` 把未知 `interval_seconds` 落到 `cron` + 默认表达式 → **未采纳（pre-existing）**：原代码本就是 `=== 3600 ? 'hourly' : 'cron'`；本 PR 只新增了正确的 `60 → minutely` 分支，严格改善；该表单只会创建 60/3600。
- RISK: 没有每用户 minutely 任务数上限 → **未采纳（out of scope）**：每次运行都按余额计费（经济上限）；任务数限额是单独的产品/后端决策。
