### PR TITLE
ci(release): attach Android/macOS/Windows installers to every GitHub Release

### DIFF
--- a/.github/workflows/build-android.yaml
+++ b/.github/workflows/build-android.yaml
@@ -157,6 +157,10 @@ jobs:
     needs: preflight
     if: needs.preflight.outputs.should-build == 'true'
     runs-on: ubuntu-latest
+    # Only this job attaches the APK to the GitHub Release; preflight/promote
+    # stay read-only so the write token never reaches other jobs.
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout
@@ -230,6 +234,38 @@ jobs:
         with:
           name: nexior-${{ needs.preflight.outputs.version-name }}.aab
           path: android/app/build/outputs/bundle/release/app-release.aab
+
+      # Attach the sideloadable APK to the matching GitHub Release
+      # (@acedatacloud/nexior_v<version>, created by github-release.yaml). Only
+      # attach when that release ALREADY EXISTS, so a manual `android-v*` /
+      # workflow_dispatch run can never create a spurious release. action-gh-
+      # release is idempotent: it updates the existing release and adds the asset.
+      - name: Check release exists
+        id: rel
+        env:
+          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN || github.token }}
+          REL_TAG: '@acedatacloud/nexior_v${{ needs.preflight.outputs.version-name }}'
+        run: |
+          if gh release view "$REL_TAG" -R "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::release $REL_TAG not found — skipping APK attach."
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Stage versioned APK
+        if: steps.rel.outputs.exists == 'true'
+        run: cp android/app/build/outputs/apk/release/app-release.apk "nexior-${{ needs.preflight.outputs.version-name }}.apk"
+
+      - name: Attach APK to GitHub Release
+        if: steps.rel.outputs.exists == 'true'
+        uses: softprops/action-gh-release@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN || github.token }}
+        with:
+          tag_name: '@acedatacloud/nexior_v${{ needs.preflight.outputs.version-name }}'
+          files: nexior-${{ needs.preflight.outputs.version-name }}.apk
+          fail_on_unmatched_files: true
 
       - name: Upload to Play Store
         uses: r0adkll/upload-google-play@v1

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -5,13 +5,17 @@ name: Desktop
 #
 # Triggers:
 #   - pull_request (desktop paths)        → E2E smoke only
-#   - push to main (desktop paths)        → E2E + build .exe/.dmg as ARTIFACTS
-#                                           (unsigned beta; NO publish, NO gate)
+#   - push tag `@acedatacloud/nexior_v*`  → E2E + build .exe/.dmg (unsigned beta)
+#                                           + ATTACH to that GitHub Release
+#                                           (NO COS publish, NO gate)
 #   - push tag `desktop-v*`               → E2E + build + PUBLISH to `latest`
 #   - workflow_dispatch (channel/dry_run) → E2E + build + (optional) PUBLISH
 #
-# Every merge to main therefore produces downloadable .exe + .dmg in the run's
-# Artifacts. Publishing to the live update feed is a separate, admin-gated job.
+# Nexior releases on (almost) every merge via beachball, so the version tag
+# fires per release — that one build both produces downloadable artifacts AND
+# attaches the installers to the Release page. (Replaces the old per-main-push
+# build, which double-built on every release.) Publishing to the live update
+# feed is a separate, admin-gated job on desktop-v*.
 #
 # Required repo secrets:
 #   TENCENT_CLOUD_SECRET_ID / TENCENT_CLOUD_SECRET_KEY        COS upload
@@ -34,13 +38,13 @@ on:
       - 'scripts/publish_desktop_release.py'
       - '.github/workflows/desktop.yml'
   push:
-    # Every merge to main auto-builds installers (artifacts). A desktop-v* tag
-    # additionally publishes to the live feed. (No path filter: you asked for an
-    # installer on every merge, and tag pushes must always run.)
-    branches:
-      - main
     tags:
       - 'desktop-v*'
+      # The beachball release tag (pushed by publish.yaml on every version bump).
+      # On this tag we build the unsigned beta installers and ATTACH them to the
+      # matching GitHub Release — we do NOT publish to the COS feed (resolve sets
+      # publish=false for it), so the auto-update channel is untouched.
+      - '@acedatacloud/nexior_v*'
   workflow_dispatch:
     inputs:
       channel:
@@ -129,6 +133,10 @@ jobs:
   build:
     name: Build (${{ matrix.os }})
     needs: [e2e, resolve]
+    # Only the build job needs write (to attach installers on the version tag);
+    # e2e (which runs PR-controlled npm scripts) and resolve stay read-only.
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -222,6 +230,39 @@ jobs:
             release/*.yml
           retention-days: 30
           if-no-files-found: error
+
+      # On a beachball release tag, attach this OS's installer to the matching
+      # GitHub Release. github-release.yaml creates that release concurrently;
+      # the desktop build is far slower, so it's normally ready — but we still
+      # WAIT for it and SKIP (never create a bare release) if it never appears,
+      # mirroring the Android guard. Each matrix leg attaches ONLY its own
+      # installer with fail_on_unmatched_files: true, so a missing .exe/.dmg
+      # fails loudly. No COS publish happens for this tag (feed untouched).
+      - name: Wait for GitHub Release
+        id: rel
+        if: startsWith(github.ref, 'refs/tags/@acedatacloud/nexior_v')
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN || github.token }}
+        run: |
+          for i in $(seq 1 18); do
+            if gh release view "$GITHUB_REF_NAME" -R "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+              echo "exists=true" >> "$GITHUB_OUTPUT"; exit 0
+            fi
+            echo "release $GITHUB_REF_NAME not ready (attempt $i) — waiting 10s"; sleep 10
+          done
+          echo "::warning::release $GITHUB_REF_NAME not found after wait — skipping installer attach."
+          echo "exists=false" >> "$GITHUB_OUTPUT"
+
+      - name: Attach installer to GitHub Release
+        if: steps.rel.outputs.exists == 'true'
+        uses: softprops/action-gh-release@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN || github.token }}
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: ${{ runner.os == 'Windows' && 'release/*.exe' || 'release/*.dmg' }}
+          fail_on_unmatched_files: true
 
   # --------------------------------------------------------------------------
   # Publish to the live COS update feed — RELEASES ONLY, behind the admin

--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -66,17 +66,17 @@ jobs:
           # the auto-generated changelog above this table.
           append_body: true
           body: |
-            ## 📦 下载 / Downloads
+            ## 📦 Downloads
 
-            | 平台 | 获取方式 |
-            |------|----------|
-            | 🍎 **macOS** | 下方 Assets 的 `.dmg`（Intel 选 `x64`，Apple Silicon 选 `arm64`）|
-            | 🪟 **Windows** | 下方 Assets 的 `.exe` 安装包 |
-            | 🤖 **Android** | 下方 Assets 的 `.apk`（侧载），或 [Google Play](https://play.google.com/store/apps/details?id=com.acedatacloud.nexior) |
-            | 📱 **iOS** | ${{ vars.IOS_APP_STORE_URL != '' && format('[App Store / TestFlight]({0})', vars.IOS_APP_STORE_URL) || 'TestFlight 内测（公开链接待配置仓库变量 `IOS_APP_STORE_URL`）' }} |
-            | 🌐 **Web** | 下方 `nexior-dist-*.tar.gz`（自托管）|
+            | Platform | How to get it |
+            |----------|---------------|
+            | 🍎 **macOS** | The `.dmg` in Assets below (`x64` for Intel, `arm64` for Apple Silicon) |
+            | 🪟 **Windows** | The `.exe` installer in Assets below |
+            | 🤖 **Android** | The `.apk` in Assets below (sideload), or [Google Play](https://play.google.com/store/apps/details?id=com.acedatacloud.nexior) |
+            | 📱 **iOS** | ${{ vars.IOS_APP_STORE_URL != '' && format('[App Store / TestFlight]({0})', vars.IOS_APP_STORE_URL) || 'TestFlight beta (public link pending — set repo variable `IOS_APP_STORE_URL`)' }} |
+            | 🌐 **Web** | The `nexior-dist-*.tar.gz` below (self-host) |
 
-            > ⚠️ 桌面端当前为 **未签名 beta**：macOS 首次打开需「右键 → 打开」绕过 Gatekeeper；Windows 会弹 SmartScreen 提示点「仍要运行」。签名证书配置完成后将自动转为已签名版本。
+            > ⚠️ The desktop apps are currently an **unsigned beta**: on macOS, right-click → Open to bypass Gatekeeper; on Windows, click "Run anyway" on the SmartScreen prompt. They switch to signed builds automatically once the signing certificates are configured.
           files: |
             nexior-dist-${{ steps.meta.outputs.safe_tag }}.tar.gz
             nexior-dist-${{ steps.meta.outputs.safe_tag }}.tar.gz.sha256

--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -60,6 +60,23 @@ jobs:
           tag_name: ${{ steps.meta.outputs.tag }}
           name: v${{ steps.meta.outputs.version }}
           generate_release_notes: true
+          # The platform installers themselves are attached by the per-platform
+          # workflows (build-android.yaml / desktop.yml) which finish on their own
+          # runners; this block just documents where each lives. append_body keeps
+          # the auto-generated changelog above this table.
+          append_body: true
+          body: |
+            ## 📦 下载 / Downloads
+
+            | 平台 | 获取方式 |
+            |------|----------|
+            | 🍎 **macOS** | 下方 Assets 的 `.dmg`（Intel 选 `x64`，Apple Silicon 选 `arm64`）|
+            | 🪟 **Windows** | 下方 Assets 的 `.exe` 安装包 |
+            | 🤖 **Android** | 下方 Assets 的 `.apk`（侧载），或 [Google Play](https://play.google.com/store/apps/details?id=com.acedatacloud.nexior) |
+            | 📱 **iOS** | ${{ vars.IOS_APP_STORE_URL != '' && format('[App Store / TestFlight]({0})', vars.IOS_APP_STORE_URL) || 'TestFlight 内测（公开链接待配置仓库变量 `IOS_APP_STORE_URL`）' }} |
+            | 🌐 **Web** | 下方 `nexior-dist-*.tar.gz`（自托管）|
+
+            > ⚠️ 桌面端当前为 **未签名 beta**：macOS 首次打开需「右键 → 打开」绕过 Gatekeeper；Windows 会弹 SmartScreen 提示点「仍要运行」。签名证书配置完成后将自动转为已签名版本。
           files: |
             nexior-dist-${{ steps.meta.outputs.safe_tag }}.tar.gz
             nexior-dist-${{ steps.meta.outputs.safe_tag }}.tar.gz.sha256

--- a/change/@acedatacloud-nexior-attach-installers.json
+++ b/change/@acedatacloud-nexior-attach-installers.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "ci(release): attach Android/macOS/Windows installers to every GitHub Release",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "none"
+}


### PR DESCRIPTION
## What

Make **every Nexior release** (the beachball `@acedatacloud/nexior_v*` tag that fires a GitHub Release) carry **per-platform installers**, not just the web `dist` tarball.

| Platform | On the Release page | How |
|---|---|---|
| 🤖 Android | `nexior-<ver>.apk` (sideloadable) + Play link | `build-android.yaml` attaches the signed APK |
| 🍎 macOS | `.dmg` (x64 + arm64) | `desktop.yml` builds on the version tag and attaches |
| 🪟 Windows | `.exe` | same |
| 📱 iOS | TestFlight / App Store **link** in the notes | App Store distribution `.ipa` is not sideloadable, so a file is pointless — link via repo var `IOS_APP_STORE_URL` |
| 🌐 Web | `nexior-dist-*.tar.gz` | unchanged |

## Why

Today the Release for a tag like `@acedatacloud/nexior_v3.289.3` only has the web dist. The desktop installers were built only on plain `main` pushes (artifacts, never attached), Android went to Play + artifacts, iOS to TestFlight — none reached the Release page. This wires all of them onto the one Release users actually see.

## How

- **`github-release.yaml`** — `append_body` a "📦 下载 / Downloads" table after the auto-generated changelog. iOS uses `${{ vars.IOS_APP_STORE_URL }}` (no URL fabricated; set the repo var once). Note that desktop is currently **unsigned beta** (Gatekeeper/SmartScreen bypass instructions included) — auto-upgrades to signed once the certs land.
- **`build-android.yaml`** — after building, stage `nexior-<ver>.apk` and attach to `@acedatacloud/nexior_v<ver>`. Guarded by a `gh release view` existence check so a manual `android-v*`/dispatch run can **never** create a spurious release. `contents: write` scoped to the `build` job only.
- **`desktop.yml`** — trigger on `@acedatacloud/nexior_v*` (channel resolves to `beta`, `publish=false` → unsigned build, **no COS publish**, live auto-update feed untouched). Each matrix leg attaches only its own installer (`.exe` xor `.dmg`, `fail_on_unmatched_files: true`). A bounded "Wait for GitHub Release" poll gates the attach and **skips rather than creates** if the release isn't there. **Removed the redundant `push: main` trigger** — the version tag fires per release and covers both the artifact and the attach, so desktop no longer double-builds on every release.

## Caveats

- **Desktop = unsigned beta** until signing secrets are configured (tracked in `plans/nexior-desktop` remaining work A). Users get OS warnings; the notes explain the bypass.
- **iOS** can only ever be a store link (Apple forbids sideloading App Store `.ipa`s). Set repo variable `IOS_APP_STORE_URL` to surface it; until then the notes show a TestFlight placeholder.
- **Android Play-dedup**: if `should-build=false` (Play already has the versionCode) the build job — and thus the attach — is skipped. This only affects **manual reruns of an already-uploaded version**; the automatic per-release path always has a fresh versionCode, so the first (automatic) run builds and attaches. Accepted.

## 🤖 对抗评审 (reviewer: codex, 3 rounds — 4 RISK+1 NIT → 1 RISK → CLEAN)

Round 1 (`VERDICT: CHANGES`, 4 RISK + 1 NIT) → fixed:
- RISK over-scoped `contents: write` on the whole workflow (reaches PR-controlled e2e job) → moved write to the `build` job only; top-level back to `read`.
- RISK spurious release/tag creation on manual `android-v*`/dispatch → added `gh release view` existence gate; attach only `if exists`.
- RISK desktop cross-OS `fail_on_unmatched_files: false` masks a missing installer → per-OS `files` (`.exe` xor `.dmg`) with `fail_on_unmatched_files: true`.
- NIT comment claimed APK renamed but uploaded `app-release.apk` → added `Stage versioned APK` cp → attaches `nexior-<ver>.apk`.
- RISK (rebutted) Play-dedup could skip the APK attach → see Caveats; only manual reruns of an already-uploaded version, automatic path always builds. Reviewer accepted.

Round 2 (`VERDICT: CHANGES`, 1 RISK) → fixed:
- RISK desktop attach could race `github-release.yaml` and create a bare release → added a bounded `Wait for GitHub Release` poll; attach gated on `exists`, **skips rather than creates** if absent.

Round 3 → `VERDICT: CLEAN` (no RISK, no NIT).
