### PR TITLE
fix(maestro): one-row action buttons + download icon

### DIFF
--- a/change/@acedatacloud-nexior-maestro-buttons-row-2026-06-28.json
+++ b/change/@acedatacloud-nexior-maestro-buttons-row-2026-06-28.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "maestro: put download/remix/view-code in one row + add download icon",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/maestro/task/Preview.vue
+++ b/src/components/maestro/task/Preview.vue
@@ -34,7 +34,10 @@
             }}<span v-if="variant.title"> · {{ variant.title }}</span>
           </p>
           <video-player v-if="variant.output_url" :src="variant.output_url" />
-          <div class="operations mt-2">
+        </div>
+        <!-- all actions in one row: download (per variant) · remix · view code -->
+        <div class="operations">
+          <template v-for="(variant, vi) in variants" :key="vi">
             <el-button
               v-if="variant.output_url"
               type="info"
@@ -42,11 +45,10 @@
               class="btn-action"
               @click="onDownload($event, variant.output_url)"
             >
-              {{ $t('maestro.button.download') }}
+              <font-awesome-icon icon="fa-solid fa-download" class="mr-1" />
+              {{ $t('maestro.button.download') }}<span v-if="variants.length > 1"> · {{ variant.lang }}</span>
             </el-button>
-          </div>
-        </div>
-        <div class="operations">
+          </template>
           <el-button size="small" type="primary" class="btn-action" @click="onRemix">
             <font-awesome-icon icon="fa-solid fa-wand-magic-sparkles" class="mr-1" />
             {{ $t('maestro.button.remix') }}


### PR DESCRIPTION
## What

Maestro task result card actions (download / remix / view code) now render in a **single flex row** instead of the download button sitting in a separate block under each video. Adds a `fa-download` icon to the download button.

## Why

The three action buttons were not aligned in one row — the per-variant download lived in its own `.operations mt-2` block beneath each `<video-player>`, so remix + view-code appeared on a separate line from download. Consolidated them into the one `.operations` flex row that already holds remix + view-code.

## Details

- Download button moved out of the per-variant display loop into the shared `.operations` row, using `<template v-for :key>` + `v-if="variant.output_url"` so multi-variant tasks still get one download button each (and `v-if` narrows `output_url` to `string` for `onDownload`).
- When `variants.length > 1`, the label appends ` · {lang}` so adjacent download buttons stay distinguishable.
- `fa-download` is already registered in `src/plugins/font-awesome.ts`.

## 🤖 对抗评审

Codex (read-only) round 1 → 2 RISKs:
- R1: `v-show` did not narrow `output_url?: string` → vue-tsc strict risk. **Fixed** by switching to `<template v-for>` + `v-if` (narrows type, also avoids the v-for+v-if-same-element lint antipattern).
- R2: multi-variant produced adjacent identical "Download" buttons. **Fixed** by appending the variant lang when >1 variant.

Round 2 → **VERDICT: CLEAN**.