### PR TITLE
feat(chat): pre-authorize skills for scheduled tasks

### DIFF
--- a/change/@acedatacloud-nexior-2408d222-a9c4-41f9-812c-2932cd79b535.json
+++ b/change/@acedatacloud-nexior-2408d222-a9c4-41f9-812c-2932cd79b535.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Pre-authorize selected Skills for scheduled tasks",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/i18n/ar/chat.json
+++ b/src/i18n/ar/chat.json
@@ -681,6 +681,30 @@
   "scheduledTasks.form.cron": {
     "message": "Cron expression"
   },
+  "scheduledTasks.form.skills": {
+    "message": "تفويض المهارات",
+    "description": "اختيار متعدد لتفويض المهارات في المهام المجدولة بدون تدخل بشري"
+  },
+  "scheduledTasks.form.skillsPlaceholder": {
+    "message": "اختر المهارات التي تسمح بتنفيذ هذه المهمة تلقائيًا",
+    "description": "نص العنصر النائب لتفويض المهارات"
+  },
+  "scheduledTasks.form.skillsHint": {
+    "message": "يمكن للمهارات المحددة تخطي التأكيد البشري عند تنفيذ المهام المجدولة في الخلفية؛ بينما المهارات غير المحددة لا تزال قادرة على المعاينة أو الانتظار للتأكيد.",
+    "description": "وصف تفويض المهارات"
+  },
+  "scheduledTasks.form.skillMissing": {
+    "message": "غير متصل",
+    "description": "تفتقر المهارة إلى الاتصال"
+  },
+  "scheduledTasks.form.skillsConfirmTitle": {
+    "message": "تأكيد التفويض بدون تدخل بشري",
+    "description": "عنوان تأكيد التفويض"
+  },
+  "scheduledTasks.form.skillsConfirm": {
+    "message": "ستسمح هذه المهمة لـ {count} مهارة بالتنفيذ في الخلفية دون تأكيد بشري: {skills}. قد ترسل هذه المهارات رسائل، أو تنشر محتوى، أو تكتب إلى خدمات خارجية، يرجى التأكيد.",
+    "description": "نص تأكيد التفويض"
+  },
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
   },

--- a/src/i18n/de/chat.json
+++ b/src/i18n/de/chat.json
@@ -681,6 +681,30 @@
   "scheduledTasks.form.cron": {
     "message": "Cron expression"
   },
+  "scheduledTasks.form.skills": {
+    "message": "Erlaubte Skills",
+    "description": "Mehrfachauswahl für unbeaufsichtigte Autorisierung von Skills bei geplanten Aufgaben"
+  },
+  "scheduledTasks.form.skillsPlaceholder": {
+    "message": "Wählen Sie die Skills aus, die dieser Aufgabe die automatische Ausführung erlauben",
+    "description": "Platzhalter für die Autorisierung von Skills"
+  },
+  "scheduledTasks.form.skillsHint": {
+    "message": "Die ausgewählten Skills können im Hintergrund der geplanten Aufgabe ohne manuelle Bestätigung ausgeführt werden; nicht ausgewählte Skills können weiterhin nur in der Vorschau angezeigt oder auf Bestätigung warten.",
+    "description": "Erläuterung zur Autorisierung von Skills"
+  },
+  "scheduledTasks.form.skillMissing": {
+    "message": "Nicht verbunden",
+    "description": "Skill fehlt die Verbindung"
+  },
+  "scheduledTasks.form.skillsConfirmTitle": {
+    "message": "Bestätigung der unbeaufsichtigten Autorisierung",
+    "description": "Titel der Bestätigung der Autorisierung"
+  },
+  "scheduledTasks.form.skillsConfirm": {
+    "message": "Diese Aufgabe erlaubt {count} Skills, im Hintergrund ohne manuelle Bestätigung auszuführen: {skills}. Diese Skills können Nachrichten senden, Inhalte veröffentlichen oder in externe Dienste schreiben, bitte bestätigen Sie.",
+    "description": "Text zur Bestätigung der Autorisierung"
+  },
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
   },

--- a/src/i18n/el/chat.json
+++ b/src/i18n/el/chat.json
@@ -681,6 +681,30 @@
   "scheduledTasks.form.cron": {
     "message": "Cron expression"
   },
+  "scheduledTasks.form.skills": {
+    "message": "Εξουσιοδοτημένες Δεξιότητες",
+    "description": "Πολλαπλή επιλογή εξουσιοδοτημένων δεξιοτήτων για αυτόματες εργασίες"
+  },
+  "scheduledTasks.form.skillsPlaceholder": {
+    "message": "Επιλέξτε τις Δεξιότητες που επιτρέπουν σε αυτή την εργασία να εκτελείται αυτόματα",
+    "description": "Placeholder εξουσιοδότησης δεξιοτήτων"
+  },
+  "scheduledTasks.form.skillsHint": {
+    "message": "Οι επιλεγμένες Δεξιότητες μπορούν να παρακάμψουν την ανθρώπινη επιβεβαίωση κατά την εκτέλεση στο παρασκήνιο. Οι μη επιλεγμένες Δεξιότητες μπορούν μόνο να προβάλλονται ή να περιμένουν επιβεβαίωση.",
+    "description": "Περιγραφή εξουσιοδότησης δεξιοτήτων"
+  },
+  "scheduledTasks.form.skillMissing": {
+    "message": "Μη συνδεδεμένο",
+    "description": "Η δεξιότητα λείπει σύνδεση"
+  },
+  "scheduledTasks.form.skillsConfirmTitle": {
+    "message": "Επιβεβαίωση Αυτόματης Εξουσιοδότησης",
+    "description": "Τίτλος επιβεβαίωσης εξουσιοδότησης"
+  },
+  "scheduledTasks.form.skillsConfirm": {
+    "message": "Αυτή η εργασία θα επιτρέψει σε {count} Δεξιότητες να παρακάμψουν την ανθρώπινη επιβεβαίωση στο παρασκήνιο: {skills}. Αυτές οι Δεξιότητες μπορεί να στείλουν μηνύματα, να δημοσιεύσουν περιεχόμενο ή να γράψουν σε εξωτερικές υπηρεσίες, παρακαλώ επιβεβαιώστε.",
+    "description": "Κείμενο επιβεβαίωσης εξουσιοδότησης"
+  },
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
   },

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -680,6 +680,24 @@
   "scheduledTasks.form.cron": {
     "message": "Cron expression"
   },
+  "scheduledTasks.form.skills": {
+    "message": "Authorized Skills"
+  },
+  "scheduledTasks.form.skillsPlaceholder": {
+    "message": "Select Skills this task may run automatically"
+  },
+  "scheduledTasks.form.skillsHint": {
+    "message": "Selected Skills may skip interactive confirmation during scheduled background runs. Unselected Skills can still preview or wait for confirmation."
+  },
+  "scheduledTasks.form.skillMissing": {
+    "message": "Not connected"
+  },
+  "scheduledTasks.form.skillsConfirmTitle": {
+    "message": "Confirm unattended authorization"
+  },
+  "scheduledTasks.form.skillsConfirm": {
+    "message": "This task will allow {count} Skill(s) to skip interactive confirmation in background runs: {skills}. These Skills may send messages, publish content, or write to external services. Please confirm."
+  },
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
   }

--- a/src/i18n/es/chat.json
+++ b/src/i18n/es/chat.json
@@ -681,6 +681,30 @@
   "scheduledTasks.form.cron": {
     "message": "Cron expression"
   },
+  "scheduledTasks.form.skills": {
+    "message": "Autorizar Skills",
+    "description": "Selección múltiple de skills para la autorización de tareas programadas sin supervisión"
+  },
+  "scheduledTasks.form.skillsPlaceholder": {
+    "message": "Seleccionar Skills que permitan la ejecución automática de esta tarea",
+    "description": "Placeholder para la autorización de skills"
+  },
+  "scheduledTasks.form.skillsHint": {
+    "message": "Las Skills seleccionadas pueden omitir la confirmación manual al ejecutarse en segundo plano; las Skills no seleccionadas solo pueden previsualizar o esperar confirmación.",
+    "description": "Descripción de la autorización de skills"
+  },
+  "scheduledTasks.form.skillMissing": {
+    "message": "No conectado",
+    "description": "Falta la conexión de skill"
+  },
+  "scheduledTasks.form.skillsConfirmTitle": {
+    "message": "Confirmar autorización sin supervisión",
+    "description": "Título de la confirmación de autorización"
+  },
+  "scheduledTasks.form.skillsConfirm": {
+    "message": "Esta tarea permitirá que {count} Skills se ejecuten en segundo plano omitiendo la confirmación manual: {skills}. Estas Skills pueden enviar mensajes, publicar contenido o escribir en servicios externos, por favor confirme.",
+    "description": "Texto de confirmación de autorización"
+  },
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
   },

--- a/src/i18n/fi/chat.json
+++ b/src/i18n/fi/chat.json
@@ -681,6 +681,30 @@
   "scheduledTasks.form.cron": {
     "message": "Cron expression"
   },
+  "scheduledTasks.form.skills": {
+    "message": "Valtuuta taidot",
+    "description": "Aikataulutetut tehtävät, joissa on valtuutettuja taitoja, usean valinnan vaihtoehto"
+  },
+  "scheduledTasks.form.skillsPlaceholder": {
+    "message": "Valitse taidot, jotka sallivat tämän tehtävän suorittaa automaattisesti",
+    "description": "Valtuutettujen taitojen paikkamerkki"
+  },
+  "scheduledTasks.form.skillsHint": {
+    "message": "Valitut taidot voivat suorittaa taustalla ilman manuaalista vahvistusta; valitsemattomat taidot voivat vain esikatsella tai odottaa vahvistusta.",
+    "description": "Valtuutettujen taitojen selitys"
+  },
+  "scheduledTasks.form.skillMissing": {
+    "message": "Ei yhdistetty",
+    "description": "skill puuttuu yhteydestä"
+  },
+  "scheduledTasks.form.skillsConfirmTitle": {
+    "message": "Vahvista automaattinen valtuutus",
+    "description": "Valtuutuksen vahvistuksen otsikko"
+  },
+  "scheduledTasks.form.skillsConfirm": {
+    "message": "Tämä tehtävä sallii {count} taidon suorittaa taustalla ilman manuaalista vahvistusta: {skills}. Nämä taidot voivat lähettää viestejä, julkaista sisältöä tai kirjoittaa ulkoisiin palveluihin, vahvista tämä.",
+    "description": "Valtuutuksen vahvistusteksti"
+  },
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
   },

--- a/src/i18n/fr/chat.json
+++ b/src/i18n/fr/chat.json
@@ -681,6 +681,30 @@
   "scheduledTasks.form.cron": {
     "message": "Cron expression"
   },
+  "scheduledTasks.form.skills": {
+    "message": "Autoriser les Skills",
+    "description": "Sélection multiple pour l'autorisation des skills dans les tâches planifiées sans supervision"
+  },
+  "scheduledTasks.form.skillsPlaceholder": {
+    "message": "Sélectionnez les Skills autorisés à s'exécuter automatiquement pour cette tâche",
+    "description": "Espace réservé pour l'autorisation des skills"
+  },
+  "scheduledTasks.form.skillsHint": {
+    "message": "Les Skills sélectionnés peuvent s'exécuter en arrière-plan lors des tâches planifiées sans confirmation manuelle ; les Skills non sélectionnés ne peuvent que prévisualiser ou attendre une confirmation.",
+    "description": "Explication de l'autorisation des skills"
+  },
+  "scheduledTasks.form.skillMissing": {
+    "message": "Non connecté",
+    "description": "skill manque de connexion"
+  },
+  "scheduledTasks.form.skillsConfirmTitle": {
+    "message": "Confirmer l'autorisation sans supervision",
+    "description": "Titre de la confirmation d'autorisation"
+  },
+  "scheduledTasks.form.skillsConfirm": {
+    "message": "Cette tâche permettra à {count} Skills de s'exécuter en arrière-plan sans confirmation manuelle : {skills}. Ces Skills peuvent envoyer des messages, publier du contenu ou écrire dans des services externes, veuillez confirmer.",
+    "description": "Texte de confirmation d'autorisation"
+  },
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
   },

--- a/src/i18n/it/chat.json
+++ b/src/i18n/it/chat.json
@@ -681,6 +681,30 @@
   "scheduledTasks.form.cron": {
     "message": "Cron expression"
   },
+  "scheduledTasks.form.skills": {
+    "message": "Autorizza Skills",
+    "description": "Autorizzazione multi-selezione per task programmati senza supervisione"
+  },
+  "scheduledTasks.form.skillsPlaceholder": {
+    "message": "Seleziona le Skills che possono essere eseguite automaticamente da questo compito",
+    "description": "Segnaposto autorizzazione skill"
+  },
+  "scheduledTasks.form.skillsHint": {
+    "message": "Le Skills selezionate possono eseguire in background senza conferma manuale; le Skills non selezionate possono solo essere visualizzate o attendere conferma.",
+    "description": "Descrizione autorizzazione skill"
+  },
+  "scheduledTasks.form.skillMissing": {
+    "message": "Non connesso",
+    "description": "skill manca la connessione"
+  },
+  "scheduledTasks.form.skillsConfirmTitle": {
+    "message": "Conferma autorizzazione senza supervisione",
+    "description": "Titolo di conferma autorizzazione"
+  },
+  "scheduledTasks.form.skillsConfirm": {
+    "message": "Questo compito permetterà a {count} Skills di eseguire in background senza conferma manuale: {skills}. Queste Skills potrebbero inviare messaggi, pubblicare contenuti o scrivere su servizi esterni, si prega di confermare.",
+    "description": "Testo di conferma autorizzazione"
+  },
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
   },

--- a/src/i18n/ja/chat.json
+++ b/src/i18n/ja/chat.json
@@ -681,6 +681,30 @@
   "scheduledTasks.form.cron": {
     "message": "Cron expression"
   },
+  "scheduledTasks.form.skills": {
+    "message": "権限を付与する Skills",
+    "description": "定期タスクの無人権限付与のための Skills の複数選択"
+  },
+  "scheduledTasks.form.skillsPlaceholder": {
+    "message": "このタスクの自動実行を許可する Skills を選択",
+    "description": "権限付与の skill プレースホルダー"
+  },
+  "scheduledTasks.form.skillsHint": {
+    "message": "選択した Skills は定期タスクのバックグラウンド実行時に人工確認をスキップできます；未選択の Skills はプレビューまたは確認待ちのままとなります。",
+    "description": "権限付与の skill 説明"
+  },
+  "scheduledTasks.form.skillMissing": {
+    "message": "未接続",
+    "description": "skill が接続されていません"
+  },
+  "scheduledTasks.form.skillsConfirmTitle": {
+    "message": "無人権限付与の確認",
+    "description": "権限付与確認のタイトル"
+  },
+  "scheduledTasks.form.skillsConfirm": {
+    "message": "このタスクは {count} 個の Skill がバックグラウンドで実行される際に人工確認をスキップすることを許可します：{skills}。これらの Skill はメッセージを送信したり、コンテンツを公開したり、外部サービスに書き込んだりする可能性がありますので、ご確認ください。",
+    "description": "権限付与確認の本文"
+  },
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
   },

--- a/src/i18n/ko/chat.json
+++ b/src/i18n/ko/chat.json
@@ -681,6 +681,30 @@
   "scheduledTasks.form.cron": {
     "message": "Cron expression"
   },
+  "scheduledTasks.form.skills": {
+    "message": "권한 부여 Skills",
+    "description": "정기 작업의 무인 권한 부여를 위한 skill 다중 선택"
+  },
+  "scheduledTasks.form.skillsPlaceholder": {
+    "message": "이 작업이 자동으로 실행되도록 허용할 Skills 선택",
+    "description": "권한 부여 skill 자리 표시자"
+  },
+  "scheduledTasks.form.skillsHint": {
+    "message": "선택된 Skills는 정기 작업 백그라운드에서 실행될 때 인적 확인을 건너뛸 수 있습니다; 선택되지 않은 Skills는 여전히 미리보기 또는 확인 대기만 가능합니다.",
+    "description": "권한 부여 skill 설명"
+  },
+  "scheduledTasks.form.skillMissing": {
+    "message": "연결되지 않음",
+    "description": "skill이 연결되지 않았음을 나타냅니다."
+  },
+  "scheduledTasks.form.skillsConfirmTitle": {
+    "message": "무인 권한 부여 확인",
+    "description": "권한 부여 확인 제목"
+  },
+  "scheduledTasks.form.skillsConfirm": {
+    "message": "이 작업은 {count}개의 Skill이 백그라운드에서 실행될 때 인적 확인을 건너뛰도록 허용합니다: {skills}입니다. 이 Skill은 메시지를 보내거나 콘텐츠를 게시하거나 외부 서비스에 기록할 수 있으니 확인해 주세요.",
+    "description": "권한 부여 확인 본문"
+  },
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
   },

--- a/src/i18n/pl/chat.json
+++ b/src/i18n/pl/chat.json
@@ -681,6 +681,30 @@
   "scheduledTasks.form.cron": {
     "message": "Cron expression"
   },
+  "scheduledTasks.form.skills": {
+    "message": "Autoryzuj umiejętności",
+    "description": "Wielokrotny wybór umiejętności do zadań zaplanowanych w trybie bezobsługowym"
+  },
+  "scheduledTasks.form.skillsPlaceholder": {
+    "message": "Wybierz umiejętności, które mogą być automatycznie wykonywane w tym zadaniu",
+    "description": "Placeholder dla autoryzacji umiejętności"
+  },
+  "scheduledTasks.form.skillsHint": {
+    "message": "Wybrane umiejętności mogą być wykonywane w tle bez potwierdzenia ręcznego; nie wybrane umiejętności mogą być jedynie podglądane lub czekać na potwierdzenie.",
+    "description": "Opis autoryzacji umiejętności"
+  },
+  "scheduledTasks.form.skillMissing": {
+    "message": "Niepołączone",
+    "description": "Brak połączenia z umiejętnością"
+  },
+  "scheduledTasks.form.skillsConfirmTitle": {
+    "message": "Potwierdzenie autoryzacji bezobsługowej",
+    "description": "Tytuł potwierdzenia autoryzacji"
+  },
+  "scheduledTasks.form.skillsConfirm": {
+    "message": "To zadanie pozwoli na pominięcie potwierdzenia ręcznego dla {count} umiejętności w tle: {skills}. Te umiejętności mogą wysyłać wiadomości, publikować treści lub zapisywać w zewnętrznych usługach, proszę potwierdzić.",
+    "description": "Treść potwierdzenia autoryzacji"
+  },
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
   },

--- a/src/i18n/pt/chat.json
+++ b/src/i18n/pt/chat.json
@@ -681,6 +681,30 @@
   "scheduledTasks.form.cron": {
     "message": "Cron expression"
   },
+  "scheduledTasks.form.skills": {
+    "message": "Autorizar Skills",
+    "description": "Seleção múltipla de skills para autorização de tarefas agendadas sem supervisão"
+  },
+  "scheduledTasks.form.skillsPlaceholder": {
+    "message": "Selecione as Skills que permitirão a execução automática desta tarefa",
+    "description": "Placeholder para autorização de skills"
+  },
+  "scheduledTasks.form.skillsHint": {
+    "message": "As Skills selecionadas podem ser executadas em segundo plano durante a tarefa agendada sem confirmação manual; as Skills não selecionadas ainda precisam ser visualizadas ou aguardam confirmação.",
+    "description": "Descrição da autorização de skills"
+  },
+  "scheduledTasks.form.skillMissing": {
+    "message": "Desconectado",
+    "description": "skill está faltando conexão"
+  },
+  "scheduledTasks.form.skillsConfirmTitle": {
+    "message": "Confirmar Autorização Sem Supervisão",
+    "description": "Título da confirmação de autorização"
+  },
+  "scheduledTasks.form.skillsConfirm": {
+    "message": "Esta tarefa permitirá que {count} Skills sejam executadas em segundo plano sem confirmação manual: {skills}. Essas Skills podem enviar mensagens, publicar conteúdo ou escrever em serviços externos, por favor, confirme.",
+    "description": "Corpo da confirmação de autorização"
+  },
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
   },

--- a/src/i18n/ru/chat.json
+++ b/src/i18n/ru/chat.json
@@ -681,6 +681,30 @@
   "scheduledTasks.form.cron": {
     "message": "Cron expression"
   },
+  "scheduledTasks.form.skills": {
+    "message": "Разрешить Skills",
+    "description": "Множественный выбор skill для автоматического выполнения запланированных задач"
+  },
+  "scheduledTasks.form.skillsPlaceholder": {
+    "message": "Выберите Skills, разрешенные для автоматического выполнения этой задачи",
+    "description": "Заполнитель для разрешения skill"
+  },
+  "scheduledTasks.form.skillsHint": {
+    "message": "Выбранные Skills могут выполнять действия в фоновом режиме без подтверждения; невыбранные Skills все еще требуют предварительного просмотра или ожидания подтверждения.",
+    "description": "Описание разрешения skill"
+  },
+  "scheduledTasks.form.skillMissing": {
+    "message": "Не подключено",
+    "description": "Отсутствует подключение к skill"
+  },
+  "scheduledTasks.form.skillsConfirmTitle": {
+    "message": "Подтверждение автоматического разрешения",
+    "description": "Заголовок подтверждения разрешения"
+  },
+  "scheduledTasks.form.skillsConfirm": {
+    "message": "Эта задача позволит {count} Skill выполнять действия в фоновом режиме без подтверждения: {skills}. Эти Skill могут отправлять сообщения, публиковать контент или записывать в внешние сервисы, пожалуйста, подтвердите.",
+    "description": "Текст подтверждения разрешения"
+  },
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
   },

--- a/src/i18n/sr/chat.json
+++ b/src/i18n/sr/chat.json
@@ -681,6 +681,30 @@
   "scheduledTasks.form.cron": {
     "message": "Cron expression"
   },
+  "scheduledTasks.form.skills": {
+    "message": "Овласти Skills",
+    "description": "Поставке за заказане задатке без надзора, вишеструки избор skill"
+  },
+  "scheduledTasks.form.skillsPlaceholder": {
+    "message": "Изаберите Skills које ће овлаштити аутоматско извршавање овог задатка",
+    "description": "Позиција за овлашћење skill"
+  },
+  "scheduledTasks.form.skillsHint": {
+    "message": "Изабрани Skills могу се извршавати у позадини без људске потврде; неизабрани Skills и даље могу само да се прегледају или чекају потврду.",
+    "description": "Објашњење за овлашћење skill"
+  },
+  "scheduledTasks.form.skillMissing": {
+    "message": "Није повезано",
+    "description": "skill недостаје веза"
+  },
+  "scheduledTasks.form.skillsConfirmTitle": {
+    "message": "Потврда овлашћења без надзора",
+    "description": "Наслов за потврду овлашћења"
+  },
+  "scheduledTasks.form.skillsConfirm": {
+    "message": "Овај задатак ће дозволити {count} Skill да се извршавају у позадини без људске потврде: {skills}. Ови Skill могу слати поруке, објављивати садржај или писати у спољне услуге, молимо потврдите.",
+    "description": "Текст за потврду овлашћења"
+  },
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
   },

--- a/src/i18n/sv/chat.json
+++ b/src/i18n/sv/chat.json
@@ -681,6 +681,30 @@
   "scheduledTasks.form.cron": {
     "message": "Cron expression"
   },
+  "scheduledTasks.form.skills": {
+    "message": "Auktorisera Skills",
+    "description": "Schemalagda uppgifter för obevakad auktorisering av flera skills"
+  },
+  "scheduledTasks.form.skillsPlaceholder": {
+    "message": "Välj Skills som får denna uppgift att köras automatiskt",
+    "description": "Platshållare för auktorisering av skills"
+  },
+  "scheduledTasks.form.skillsHint": {
+    "message": "Valda Skills kan köras i bakgrunden utan manuell bekräftelse; icke-valda Skills kan fortfarande endast förhandsgranskas eller vänta på bekräftelse.",
+    "description": "Beskrivning av auktorisering av skills"
+  },
+  "scheduledTasks.form.skillMissing": {
+    "message": "Ej ansluten",
+    "description": "skill saknar anslutning"
+  },
+  "scheduledTasks.form.skillsConfirmTitle": {
+    "message": "Bekräfta obevakad auktorisering",
+    "description": "Titel för auktoriseringsbekräftelse"
+  },
+  "scheduledTasks.form.skillsConfirm": {
+    "message": "Denna uppgift kommer att tillåta {count} Skills att köras i bakgrunden utan manuell bekräftelse: {skills}. Dessa Skills kan skicka meddelanden, publicera innehåll eller skriva till externa tjänster, vänligen bekräfta.",
+    "description": "Text för auktoriseringsbekräftelse"
+  },
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
   },

--- a/src/i18n/uk/chat.json
+++ b/src/i18n/uk/chat.json
@@ -681,6 +681,30 @@
   "scheduledTasks.form.cron": {
     "message": "Cron expression"
   },
+  "scheduledTasks.form.skills": {
+    "message": "Авторизувати навички",
+    "description": "Дозволити вибір кількох навичок для автоматизованих завдань"
+  },
+  "scheduledTasks.form.skillsPlaceholder": {
+    "message": "Виберіть навички, які дозволите автоматично виконувати в цьому завданні",
+    "description": "Плейсхолдер для авторизації навичок"
+  },
+  "scheduledTasks.form.skillsHint": {
+    "message": "Вибрані навички можуть виконуватись у фоновому режимі без підтвердження; невибрані навички все ще можуть лише переглядатися або чекати підтвердження.",
+    "description": "Опис авторизації навичок"
+  },
+  "scheduledTasks.form.skillMissing": {
+    "message": "Не підключено",
+    "description": "Відсутнє з'єднання з навичкою"
+  },
+  "scheduledTasks.form.skillsConfirmTitle": {
+    "message": "Підтвердження авторизації без нагляду",
+    "description": "Заголовок підтвердження авторизації"
+  },
+  "scheduledTasks.form.skillsConfirm": {
+    "message": "Це завдання дозволить {count} навичкам виконуватись у фоновому режимі без підтвердження: {skills}. Ці навички можуть надсилати повідомлення, публікувати контент або записувати в зовнішні сервіси, будь ласка, підтверджте.",
+    "description": "Текст підтвердження авторизації"
+  },
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
   },

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -610,5 +610,11 @@
   "scheduledTasks.form.time": { "message": "执行时间", "description": "时间字段" },
   "scheduledTasks.form.weekday": { "message": "星期", "description": "星期字段" },
   "scheduledTasks.form.cron": { "message": "Cron 表达式", "description": "cron 表达式字段" },
+  "scheduledTasks.form.skills": { "message": "授权 Skills", "description": "定时任务无人值守授权 skill 多选" },
+  "scheduledTasks.form.skillsPlaceholder": { "message": "选择允许此任务自动执行的 Skills", "description": "授权 skill 占位符" },
+  "scheduledTasks.form.skillsHint": { "message": "选中的 Skills 可在定时任务后台执行时跳过人工确认；未选中的 Skills 仍只能预览或等待确认。", "description": "授权 skill 说明" },
+  "scheduledTasks.form.skillMissing": { "message": "未连接", "description": "skill 缺少连接" },
+  "scheduledTasks.form.skillsConfirmTitle": { "message": "确认无人值守授权", "description": "授权确认标题" },
+  "scheduledTasks.form.skillsConfirm": { "message": "此任务将允许 {count} 个 Skill 在后台执行时跳过人工确认：{skills}。这些 Skill 可能会发送消息、发布内容或写入外部服务，请确认。", "description": "授权确认正文" },
   "scheduledTasks.form.required": { "message": "请填写任务名称和提示词", "description": "必填项验证" }
 }

--- a/src/i18n/zh-TW/chat.json
+++ b/src/i18n/zh-TW/chat.json
@@ -681,6 +681,30 @@
   "scheduledTasks.form.cron": {
     "message": "Cron expression"
   },
+  "scheduledTasks.form.skills": {
+    "message": "授權 Skills",
+    "description": "定時任務無人值守授權 skill 多選"
+  },
+  "scheduledTasks.form.skillsPlaceholder": {
+    "message": "選擇允許此任務自動執行的 Skills",
+    "description": "授權 skill 占位符"
+  },
+  "scheduledTasks.form.skillsHint": {
+    "message": "選中的 Skills 可在定時任務後台執行時跳過人工確認；未選中的 Skills 仍只能預覽或等待確認。",
+    "description": "授權 skill 說明"
+  },
+  "scheduledTasks.form.skillMissing": {
+    "message": "未連接",
+    "description": "skill 缺少連接"
+  },
+  "scheduledTasks.form.skillsConfirmTitle": {
+    "message": "確認無人值守授權",
+    "description": "授權確認標題"
+  },
+  "scheduledTasks.form.skillsConfirm": {
+    "message": "此任務將允許 {count} 個 Skill 在後台執行時跳過人工確認：{skills}。這些 Skill 可能會發送消息、發布內容或寫入外部服務，請確認。",
+    "description": "授權確認正文"
+  },
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
   },

--- a/src/operators/scheduledTasks.ts
+++ b/src/operators/scheduledTasks.ts
@@ -26,6 +26,7 @@ export interface IScheduledTask {
     mcp_servers?: string[];
     max_turns?: number;
   };
+  unattended_policy?: IScheduledTaskUnattendedPolicy;
   run_count: number;
   last_output_snippet?: string;
   last_error?: string;
@@ -53,6 +54,32 @@ export type IScheduleSpec =
   | { type: 'interval'; interval_seconds: number; tz: string; ends_at?: number }
   | { type: 'once'; at: number; tz: string };
 
+export interface IScheduledTaskUnattendedPolicy {
+  mode: 'deny_all' | 'allow_selected_skills';
+  allowed_skills: string[];
+  expires_at?: number;
+}
+
+export interface IAuthorizableSkill {
+  slug: string;
+  name: string;
+  description: string;
+  when_to_use?: string;
+  required_connections: string[];
+  allowed_tools: string[];
+  source: string;
+  connected: boolean;
+  missing_connections: string[];
+}
+
+type ScheduledTaskPayload = {
+  name: string;
+  description?: string;
+  schedule: IScheduleSpec;
+  template: IScheduledTask['template'];
+  unattended_policy?: IScheduledTaskUnattendedPolicy;
+};
+
 class ScheduledTasksOperator {
   async listTasks(token: string): Promise<IScheduledTask[]> {
     const { data } = await axios.post(BASE, { action: 'retrieve_batch' }, { headers: headers(token) });
@@ -61,7 +88,7 @@ class ScheduledTasksOperator {
 
   async createTask(
     token: string,
-    payload: { name: string; description?: string; schedule: IScheduleSpec; template: IScheduledTask['template'] }
+    payload: ScheduledTaskPayload
   ): Promise<IScheduledTask> {
     const { data } = await axios.post(BASE, { action: 'create', ...payload }, { headers: headers(token) });
     return data;
@@ -70,7 +97,7 @@ class ScheduledTasksOperator {
   async updateTask(
     token: string,
     id: string,
-    patch: Partial<Pick<IScheduledTask, 'name' | 'description' | 'state' | 'template' | 'schedule'>>
+    patch: Partial<Pick<IScheduledTask, 'name' | 'description' | 'state' | 'template' | 'schedule' | 'unattended_policy'>>
   ): Promise<IScheduledTask> {
     const { data } = await axios.post(BASE, { action: 'update', id, ...patch }, { headers: headers(token) });
     return data;
@@ -82,6 +109,11 @@ class ScheduledTasksOperator {
 
   async listRuns(token: string, id: string): Promise<IScheduledRun[]> {
     const { data } = await axios.post(BASE, { action: 'retrieve_runs', id }, { headers: headers(token) });
+    return data?.items ?? [];
+  }
+
+  async listAuthorizableSkills(token: string): Promise<IAuthorizableSkill[]> {
+    const { data } = await axios.post(BASE, { action: 'retrieve_authorizable_skills' }, { headers: headers(token) });
     return data?.items ?? [];
   }
 }

--- a/src/pages/chat/ScheduledTasks.vue
+++ b/src/pages/chat/ScheduledTasks.vue
@@ -160,6 +160,36 @@
         <el-form-item v-if="form.scheduleType === 'cron'" :label="$t('chat.scheduledTasks.form.cron')">
           <el-input v-model="form.cronExpr" placeholder="0 9 * * *" />
         </el-form-item>
+
+        <el-form-item :label="$t('chat.scheduledTasks.form.skills')">
+          <el-select
+            v-model="form.authorizedSkills"
+            style="width: 100%"
+            multiple
+            filterable
+            collapse-tags
+            collapse-tags-tooltip
+            :loading="skillsLoading"
+            :placeholder="$t('chat.scheduledTasks.form.skillsPlaceholder')"
+            @visible-change="onSkillSelectVisible"
+          >
+            <el-option
+              v-for="skill in authorizableSkills"
+              :key="skill.slug"
+              :label="skillLabel(skill)"
+              :value="skill.slug"
+              :disabled="!skill.connected"
+            >
+              <div class="skill-option">
+                <span class="skill-option-name">{{ skillLabel(skill) }}</span>
+                <span v-if="!skill.connected" class="skill-option-missing">
+                  {{ $t('chat.scheduledTasks.form.skillMissing') }}
+                </span>
+              </div>
+            </el-option>
+          </el-select>
+          <div class="hint">{{ $t('chat.scheduledTasks.form.skillsHint') }}</div>
+        </el-form-item>
       </el-form>
 
       <template #footer>
@@ -195,7 +225,7 @@ import {
   ElMessage,
   ElMessageBox
 } from 'element-plus';
-import { scheduledTasksOperator, IScheduledTask, IScheduledRun, IScheduleSpec } from '@/operators/scheduledTasks';
+import { scheduledTasksOperator, IScheduledTask, IScheduledRun, IScheduleSpec, IAuthorizableSkill } from '@/operators/scheduledTasks';
 import { CHAT_MODEL_GROUPS, CHAT_MODEL_NAME_GPT_5_4_MINI } from '@/constants';
 import { IChatModelGroup } from '@/models';
 
@@ -208,6 +238,7 @@ interface TaskForm {
   dailyTime: string;
   weekday: number;
   cronExpr: string;
+  authorizedSkills: string[];
 }
 
 export default defineComponent({
@@ -237,11 +268,13 @@ export default defineComponent({
       runs: [] as IScheduledRun[],
       loading: false,
       runsLoading: false,
+      skillsLoading: false,
       saving: false,
       showCreateDialog: false,
       showRunHistory: false,
       selectedTask: null as IScheduledTask | null,
       editingTask: null as IScheduledTask | null,
+      authorizableSkills: [] as IAuthorizableSkill[],
       weekdays: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
       form: this.emptyForm() as TaskForm
     };
@@ -269,7 +302,8 @@ export default defineComponent({
         scheduleType: 'daily',
         dailyTime: '09:00',
         weekday: 1,
-        cronExpr: '0 9 * * *'
+        cronExpr: '0 9 * * *',
+        authorizedSkills: []
       };
     },
     // The task name is no longer a separate field — derive a short label from the prompt.
@@ -330,9 +364,11 @@ export default defineComponent({
         scheduleType,
         dailyTime,
         weekday,
-        cronExpr
+        cronExpr,
+        authorizedSkills: task.unattended_policy?.mode === 'allow_selected_skills' ? task.unattended_policy.allowed_skills || [] : []
       };
       this.showCreateDialog = true;
+      void this.loadAuthorizableSkills();
     },
     buildSchedule(): IScheduleSpec {
       const { scheduleType, dailyTime, weekday, cronExpr } = this.form;
@@ -359,10 +395,21 @@ export default defineComponent({
       }
       this.saving = true;
       try {
+        if (this.form.authorizedSkills.length > 0) {
+          await ElMessageBox.confirm(this.authorizationConfirmText(), this.$t('chat.scheduledTasks.form.skillsConfirmTitle') as string, {
+            type: 'warning',
+            confirmButtonText: this.$t('common.button.confirm') as string,
+            cancelButtonText: this.$t('common.button.cancel') as string
+          });
+        }
+        const authorizedSkills = [...this.form.authorizedSkills];
         const payload = {
           name: this.deriveName(this.form.question),
           schedule: this.buildSchedule(),
-          template: { model: this.form.model, question: this.form.question }
+          template: { model: this.form.model, question: this.form.question, skills: authorizedSkills },
+          unattended_policy: authorizedSkills.length
+            ? { mode: 'allow_selected_skills' as const, allowed_skills: authorizedSkills }
+            : { mode: 'deny_all' as const, allowed_skills: [] }
         };
         if (this.editingTask) {
           await scheduledTasksOperator.updateTask(this.token!, this.editingTask.id, payload);
@@ -379,6 +426,33 @@ export default defineComponent({
       } finally {
         this.saving = false;
       }
+    },
+    async loadAuthorizableSkills(force = false) {
+      if (!this.token || this.skillsLoading || (!force && this.authorizableSkills.length)) return;
+      this.skillsLoading = true;
+      try {
+        this.authorizableSkills = await scheduledTasksOperator.listAuthorizableSkills(this.token);
+      } catch {
+        ElMessage.error(this.$t('chat.scheduledTasks.loadError') as string);
+      } finally {
+        this.skillsLoading = false;
+      }
+    },
+    onSkillSelectVisible(visible: boolean) {
+      if (visible) void this.loadAuthorizableSkills(true);
+    },
+    skillLabel(skill: IAuthorizableSkill) {
+      return skill.name || skill.slug;
+    },
+    authorizationConfirmText() {
+      const selected = new Set(this.form.authorizedSkills);
+      const names = this.authorizableSkills
+        .filter((skill) => selected.has(skill.slug))
+        .map((skill) => this.skillLabel(skill));
+      return this.$t('chat.scheduledTasks.form.skillsConfirm', {
+        count: selected.size,
+        skills: names.length ? names.join(', ') : Array.from(selected).join(', ')
+      }) as string;
     },
     async toggleState(task: IScheduledTask, enabled: boolean) {
       await scheduledTasksOperator.updateTask(this.token!, task.id, {
@@ -488,4 +562,7 @@ export default defineComponent({
 .run-noconv { font-size: 11px; color: var(--el-text-color-secondary); flex-shrink: 0; }
 .hint { font-size: 11px; color: var(--el-text-color-secondary); margin-top: 4px; }
 .jitter-hint { font-size: 11px; color: var(--el-text-color-secondary); margin-left: 8px; }
+.skill-option { display: flex; align-items: center; justify-content: space-between; gap: 8px; min-width: 0; }
+.skill-option-name { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.skill-option-missing { flex-shrink: 0; font-size: 11px; color: var(--el-text-color-secondary); }
 </style>


### PR DESCRIPTION
## What

Adds a generic scheduled-task UI for pre-authorizing selected Skills in unattended background runs.

## Changes

- Adds `unattended_policy` and `retrieve_authorizable_skills` types to the scheduled task operator.
- Adds a generic multi-select in the scheduled task create/edit dialog for authorized Skills.
- Saves selected Skills both as task `template.skills` and `unattended_policy.allowed_skills`.
- Shows a generic warning confirmation before saving any unattended Skill authorization.
- Adds i18n coverage for all locales.

## Validation

- `npx vue-tsc -b --force`
- `python3 scripts/check_i18n_coverage.py`

## 🤖 对抗评审

Review found the skill list cache could become stale if connections changed in another tab. Fixed by refreshing authorizable Skills every time the select is opened.
