### PR TITLE
refactor(digitalhuman): polish config panel to match maestro/Kling scenarios

### DIFF
--- a/change/@acedatacloud-nexior-5e7a9272-2115-4b58-9ad8-21962255d067.json
+++ b/change/@acedatacloud-nexior-5e7a9272-2115-4b58-9ad8-21962255d067.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "polish digitalhuman config panel to match maestro/Kling scenarios",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/digitalhuman/ConfigPanel.vue
+++ b/src/components/digitalhuman/ConfigPanel.vue
@@ -2,8 +2,11 @@
   <div class="flex flex-col h-full">
     <div class="flex-1 overflow-y-auto p-5">
       <!-- Face source -->
-      <div class="mb-4">
-        <span class="text-sm font-bold mb-2 block">{{ $t('digitalhuman.name.face') }}</span>
+      <div class="field-block mb-5">
+        <div class="field-head">
+          <h2 class="field-title font-bold">{{ $t('digitalhuman.name.face') }}</h2>
+          <info-icon :content="$t('digitalhuman.description.face')" class="ml-1" />
+        </div>
         <el-radio-group v-model="faceMode" class="w-full mb-2" @change="onFaceModeChange">
           <el-radio-button value="video">{{ $t('digitalhuman.name.faceVideo') }}</el-radio-button>
           <el-radio-button value="photo">{{ $t('digitalhuman.name.facePhoto') }}</el-radio-button>
@@ -22,12 +25,13 @@
           icon="fa-solid fa-image"
           @change="onFacePhotoChange"
         />
-        <p class="text-xs text-[var(--el-text-color-secondary)] mt-1">{{ $t('digitalhuman.description.face') }}</p>
       </div>
 
       <!-- Voice source -->
-      <div class="mb-4">
-        <span class="text-sm font-bold mb-2 block">{{ $t('digitalhuman.name.voice') }}</span>
+      <div class="field-block mb-5">
+        <div class="field-head">
+          <h2 class="field-title font-bold">{{ $t('digitalhuman.name.voice') }}</h2>
+        </div>
         <el-radio-group v-model="voiceMode" class="w-full mb-2" @change="onVoiceModeChange">
           <el-radio-button value="audio">{{ $t('digitalhuman.name.voiceAudio') }}</el-radio-button>
           <el-radio-button value="text">{{ $t('digitalhuman.name.voiceText') }}</el-radio-button>
@@ -53,16 +57,20 @@
       </div>
 
       <!-- Engine -->
-      <div class="mb-4">
-        <span class="text-sm font-bold mb-2 block">{{ $t('digitalhuman.name.engine') }}</span>
+      <div class="field-block mb-5">
+        <div class="field-head">
+          <h2 class="field-title font-bold">{{ $t('digitalhuman.name.engine') }}</h2>
+        </div>
         <el-radio-group v-model="engine" class="w-full">
           <el-radio-button v-for="e in DIGITALHUMAN_ALLOWED_ENGINES" :key="e" :value="e">{{ e }}</el-radio-button>
         </el-radio-group>
       </div>
 
       <!-- Resolution -->
-      <div class="mb-4">
-        <span class="text-sm font-bold mb-2 block">{{ $t('digitalhuman.name.resolution') }}</span>
+      <div class="field-block">
+        <div class="field-head">
+          <h2 class="field-title font-bold">{{ $t('digitalhuman.name.resolution') }}</h2>
+        </div>
         <el-radio-group v-model="resolution" class="w-full">
           <el-radio-button v-for="r in DIGITALHUMAN_ALLOWED_RESOLUTIONS" :key="r" :value="r">{{ r }}</el-radio-button>
         </el-radio-group>
@@ -84,6 +92,7 @@ import { defineComponent } from 'vue';
 import { ElButton, ElInput, ElRadioGroup, ElRadioButton } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import Consumption from '../common/Consumption.vue';
+import InfoIcon from '@/components/common/InfoIcon.vue';
 import FileInput from './config/FileInput.vue';
 import VoiceClone from './config/VoiceClone.vue';
 import { getConsumption } from '@/utils';
@@ -116,6 +125,7 @@ export default defineComponent({
     ElRadioGroup,
     ElRadioButton,
     Consumption,
+    InfoIcon,
     FileInput,
     VoiceClone,
     FontAwesomeIcon
@@ -233,3 +243,16 @@ export default defineComponent({
   }
 });
 </script>
+
+<style lang="scss" scoped>
+.field-head {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  margin-bottom: 8px;
+}
+.field-title {
+  font-size: 14px;
+  margin: 0;
+}
+</style>


### PR DESCRIPTION
## What

Extends the Maestro config-panel polish (#1058) to the **digitalhuman** scenario — the only other scenario that still used the same ad-hoc pattern.

## Why — analysis

I audited all 23 scenario config panels for Maestro's anti-patterns (monolithic panel, ad-hoc `<span>` labels, always-on gray help paragraphs, no info icons). Result:

- **22 are already clean** — composed of dedicated sub-components and the shared `field` / `h2.title` / `InfoIcon` patterns. The remaining `font-bold mb-2 block` labels all live inside dedicated `RatioSelector` / `OrientationSelector` sub-components (the same accepted pattern Kling/MJ use). Gray secondary text elsewhere is legitimate (slider value readouts, char counters, selected-style chips).
- **digitalhuman was the sole offender**: a monolithic `ConfigPanel.vue` with four `<span class="text-sm font-bold mb-2 block">` labels, an always-on gray help paragraph, and no `InfoIcon`.

(Verified via grep: only `fish` [1 tidy slider], `maestro` [already fixed], and `digitalhuman` embed inline form controls in their top-level panel.)

## Changes (digitalhuman/ConfigPanel.vue only)

- Section labels → consistent `field-head` + `h2.field-title` (matches the merged maestro panel).
- Face section's gray help `<p>` → an `InfoIcon` "i" tooltip next to the title.
- Spacing `mb-4` → `mb-5` for even section rhythm; added scoped `.field-head` / `.field-title`.
- Kept the face/voice/engine/resolution `el-radio-button` groups as-is — they're small enum toggles and already keyboard-accessible.
- Left `VoiceClone.vue`'s instruction paragraph untouched — it's actionable how-to for the clone workflow, not a redundant field label.

No new i18n keys (reuses `description.face`), so no coverage-guard backfill. No behavior/billing changes.

## Validation

- `eslint src` ✅
- `vue-tsc -b --force` ✅
- `python3 scripts/check_i18n_coverage.py` → `17 locale(s) × 44 namespace(s) all match zh-CN` ✅

## 🤖 对抗评审

Codex hit its usage limit mid-run, so the review fell back to an independent Claude `general-purpose` subagent (the documented fallback). It verified: `InfoIcon` imported + registered, all referenced i18n keys defined, no removed imports still used, all `v-model`/computed bindings intact, scoped styles match the maestro reference, and no leftover ad-hoc labels. Verdict: **CLEAN** (round 1).
