### PR TITLE
ci(release): show real iOS App Store link on the release download page

### DIFF
--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -33,6 +33,9 @@ jobs:
       - name: Prepare metadata
         id: meta
         shell: bash
+        env:
+          # Optional override; falls back to the canonical URL shipped in the app.
+          IOS_APP_STORE_URL_OVERRIDE: ${{ vars.IOS_APP_STORE_URL }}
         run: |
           TAG="${GITHUB_REF_NAME}"
           SAFE_TAG="${TAG//\//-}"
@@ -41,9 +44,16 @@ jobs:
           else
             VERSION="${TAG#v}"
           fi
+          # iOS store link: prefer the repo-variable override, else the canonical
+          # URL the app already ships with (single source of truth in mobile.ts).
+          IOS_URL="${IOS_APP_STORE_URL_OVERRIDE:-}"
+          if [ -z "$IOS_URL" ]; then
+            IOS_URL=$(sed -nE "s/.*MOBILE_IOS_APP_STORE_URL *= *'([^']+)'.*/\1/p" src/constants/mobile.ts | head -n1)
+          fi
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "safe_tag=${SAFE_TAG}" >> "$GITHUB_OUTPUT"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "ios_url=${IOS_URL}" >> "$GITHUB_OUTPUT"
 
       - name: Package dist
         shell: bash
@@ -73,7 +83,7 @@ jobs:
             | 🍎 **macOS** | The `.dmg` in Assets below (`x64` for Intel, `arm64` for Apple Silicon) |
             | 🪟 **Windows** | The `.exe` installer in Assets below |
             | 🤖 **Android** | The `.apk` in Assets below (sideload), or [Google Play](https://play.google.com/store/apps/details?id=com.acedatacloud.nexior) |
-            | 📱 **iOS** | ${{ vars.IOS_APP_STORE_URL != '' && format('[App Store / TestFlight]({0})', vars.IOS_APP_STORE_URL) || 'TestFlight beta (public link pending — set repo variable `IOS_APP_STORE_URL`)' }} |
+            | 📱 **iOS** | ${{ steps.meta.outputs.ios_url != '' && format('[App Store]({0})', steps.meta.outputs.ios_url) || 'TestFlight beta (coming soon)' }} |
             | 🌐 **Web** | The `nexior-dist-*.tar.gz` below (self-host) |
 
             > ⚠️ The desktop apps are currently an **unsigned beta**: on macOS, right-click → Open to bypass Gatekeeper; on Windows, click "Run anyway" on the SmartScreen prompt. They switch to signed builds automatically once the signing certificates are configured.

--- a/change/@acedatacloud-nexior-061e0db8-fd33-44f1-8d19-1a6446e9a040.json
+++ b/change/@acedatacloud-nexior-061e0db8-fd33-44f1-8d19-1a6446e9a040.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "ci(release): render real iOS App Store link on the release download page",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "none"
+}


### PR DESCRIPTION
## What & why

The GitHub Release **Downloads** table (e.g. [v3.290.2](https://github.com/AceDataCloud/Nexior/releases/tag/%40acedatacloud%2Fnexior_v3.290.2)) rendered the **iOS** row as placeholder text:

> 📱 **iOS** | TestFlight beta (public link pending — set repo variable `IOS_APP_STORE_URL`)

That happened because the template fell back to placeholder text whenever the repo **variable** `IOS_APP_STORE_URL` was empty — and it was **never set** (`gh variable list` is empty). Meanwhile the app has been **live on the App Store** all along; the canonical URL `https://apps.apple.com/app/id6772432921` is already hardcoded in the app at `src/constants/mobile.ts` (`MOBILE_IOS_APP_STORE_URL`).

So every release page has been showing "public link pending" needlessly.

## Change

`Prepare metadata` now derives an `ios_url` output:
1. the `IOS_APP_STORE_URL` repo variable, if an admin sets one (override, passed via `env` to avoid shell injection); else
2. the canonical `MOBILE_IOS_APP_STORE_URL` already shipped in `src/constants/mobile.ts` — **single source of truth**, no duplicated constant.

The iOS table row then renders `[App Store](<ios_url>)`. No repo variable needs to be set anymore; the page is correct by default. (Installer assets — `.dmg`/`.exe`/`.apk`/web `.tar.gz` — were already attached correctly by the per-platform workflows; this only fixes the iOS link cell.)

## Note

This does **not** touch desktop code signing — the "unsigned beta" warning is intentional and stays until `WIN_CSC_LINK`/`MAC_CSC_LINK` signing secrets are configured.

## 🤖 对抗评审

Reviewer: Codex hit its usage limit → fell back to an independent subagent reviewer (read-only).

- Checked: GitHub Actions `A && B || C` expression + `format()` + `steps.meta.outputs` reference; shell-injection (override passed via `env`, quoted `"${IOS_APP_STORE_URL_OVERRIDE:-}"`); `sed` extraction against the real `mobile.ts` line; no `set -euo pipefail` so an empty grep degrades gracefully to the "coming soon" fallback; YAML quoting; rendered markdown table + link; `actions/checkout@v4` includes `src/constants/mobile.ts` at the sed path.
- **VERDICT: CLEAN** — no real defects. Locally confirmed: sed extracts `https://apps.apple.com/app/id6772432921`, and the workflow YAML still parses.