### PR TITLE
feat(nexior): redesign scheduled tasks page (cards, page bg, pagination)

### DIFF
--- a/change/@acedatacloud-nexior-3809af6a-d957-40d7-9918-80a43bf1bf34.json
+++ b/change/@acedatacloud-nexior-3809af6a-d957-40d7-9918-80a43bf1bf34.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Redesign scheduled tasks page: el-card layout, page-tone background, filled status tags, larger radii, and client-side pagination for tasks and run history",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/i18n/ar/chat.json
+++ b/src/i18n/ar/chat.json
@@ -602,6 +602,9 @@
   "scheduledTasks.viewResult": {
     "message": "View Result"
   },
+  "scheduledTasks.viewRuns": {
+    "message": "Run history"
+  },
   "scheduledTasks.noConversation": {
     "message": "لا توجد سجلات محادثة",
     "description": "تشير إلى أن التشغيل غير مرتبط بمحادثة (نسخة قديمة من التشغيل)"

--- a/src/i18n/de/chat.json
+++ b/src/i18n/de/chat.json
@@ -602,6 +602,9 @@
   "scheduledTasks.viewResult": {
     "message": "View Result"
   },
+  "scheduledTasks.viewRuns": {
+    "message": "Run history"
+  },
   "scheduledTasks.noConversation": {
     "message": "Keine Gesprächsaufzeichnung",
     "description": "Läuft ohne zugeordnetes Gespräch (ältere Version läuft)"

--- a/src/i18n/el/chat.json
+++ b/src/i18n/el/chat.json
@@ -602,6 +602,9 @@
   "scheduledTasks.viewResult": {
     "message": "View Result"
   },
+  "scheduledTasks.viewRuns": {
+    "message": "Run history"
+  },
   "scheduledTasks.noConversation": {
     "message": "Δεν υπάρχουν καταγεγραμμένες συνομιλίες",
     "description": "Η λειτουργία δεν έχει συσχετιστεί με συνομιλίες (παλαιά έκδοση λειτουργίας)"

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -602,6 +602,9 @@
   "scheduledTasks.viewResult": {
     "message": "View Result"
   },
+  "scheduledTasks.viewRuns": {
+    "message": "Run history"
+  },
   "scheduledTasks.noConversation": {
     "message": "No conversation"
   },

--- a/src/i18n/es/chat.json
+++ b/src/i18n/es/chat.json
@@ -602,6 +602,9 @@
   "scheduledTasks.viewResult": {
     "message": "View Result"
   },
+  "scheduledTasks.viewRuns": {
+    "message": "Run history"
+  },
   "scheduledTasks.noConversation": {
     "message": "Sin registros de conversación",
     "description": "Ejecutar sin conversación asociada (versión anterior de ejecución)"

--- a/src/i18n/fi/chat.json
+++ b/src/i18n/fi/chat.json
@@ -602,6 +602,9 @@
   "scheduledTasks.viewResult": {
     "message": "View Result"
   },
+  "scheduledTasks.viewRuns": {
+    "message": "Run history"
+  },
   "scheduledTasks.noConversation": {
     "message": "Ei keskusteluhistoriaa",
     "description": "Suoritus ei ole liitetty keskusteluun (vanha versio suoritus)"

--- a/src/i18n/fr/chat.json
+++ b/src/i18n/fr/chat.json
@@ -602,6 +602,9 @@
   "scheduledTasks.viewResult": {
     "message": "View Result"
   },
+  "scheduledTasks.viewRuns": {
+    "message": "Run history"
+  },
   "scheduledTasks.noConversation": {
     "message": "Aucun enregistrement de conversation",
     "description": "Exécution sans conversation associée (version ancienne)"

--- a/src/i18n/it/chat.json
+++ b/src/i18n/it/chat.json
@@ -602,6 +602,9 @@
   "scheduledTasks.viewResult": {
     "message": "View Result"
   },
+  "scheduledTasks.viewRuns": {
+    "message": "Run history"
+  },
   "scheduledTasks.noConversation": {
     "message": "Nessuna registrazione di conversazione",
     "description": "Eseguito senza conversazione associata (versione precedente)"

--- a/src/i18n/ja/chat.json
+++ b/src/i18n/ja/chat.json
@@ -602,6 +602,9 @@
   "scheduledTasks.viewResult": {
     "message": "View Result"
   },
+  "scheduledTasks.viewRuns": {
+    "message": "Run history"
+  },
   "scheduledTasks.noConversation": {
     "message": "対話記録がありません",
     "description": "実行中のタスクに関連する対話がないことを示します（旧バージョンの実行）。"

--- a/src/i18n/ko/chat.json
+++ b/src/i18n/ko/chat.json
@@ -602,6 +602,9 @@
   "scheduledTasks.viewResult": {
     "message": "View Result"
   },
+  "scheduledTasks.viewRuns": {
+    "message": "Run history"
+  },
   "scheduledTasks.noConversation": {
     "message": "대화 기록 없음",
     "description": "연결되지 않은 대화가 실행 중입니다(구 버전 실행)"

--- a/src/i18n/pl/chat.json
+++ b/src/i18n/pl/chat.json
@@ -602,6 +602,9 @@
   "scheduledTasks.viewResult": {
     "message": "View Result"
   },
+  "scheduledTasks.viewRuns": {
+    "message": "Run history"
+  },
   "scheduledTasks.noConversation": {
     "message": "Brak historii rozmów",
     "description": "Zadania, które nie są powiązane z żadną rozmową (stara wersja działania)"

--- a/src/i18n/pt/chat.json
+++ b/src/i18n/pt/chat.json
@@ -602,6 +602,9 @@
   "scheduledTasks.viewResult": {
     "message": "View Result"
   },
+  "scheduledTasks.viewRuns": {
+    "message": "Run history"
+  },
   "scheduledTasks.noConversation": {
     "message": "Sem registros de conversa",
     "description": "Executar sem diálogos associados (versão antiga de execução)"

--- a/src/i18n/ru/chat.json
+++ b/src/i18n/ru/chat.json
@@ -602,6 +602,9 @@
   "scheduledTasks.viewResult": {
     "message": "View Result"
   },
+  "scheduledTasks.viewRuns": {
+    "message": "Run history"
+  },
   "scheduledTasks.noConversation": {
     "message": "Нет записей о разговоре",
     "description": "Запуск без связанных разговоров (версия старого типа)"

--- a/src/i18n/sr/chat.json
+++ b/src/i18n/sr/chat.json
@@ -602,6 +602,9 @@
   "scheduledTasks.viewResult": {
     "message": "View Result"
   },
+  "scheduledTasks.viewRuns": {
+    "message": "Run history"
+  },
   "scheduledTasks.noConversation": {
     "message": "Нема записа о разговору",
     "description": "Радња није повезана са разговором (стара верзија рада)"

--- a/src/i18n/sv/chat.json
+++ b/src/i18n/sv/chat.json
@@ -602,6 +602,9 @@
   "scheduledTasks.viewResult": {
     "message": "View Result"
   },
+  "scheduledTasks.viewRuns": {
+    "message": "Run history"
+  },
   "scheduledTasks.noConversation": {
     "message": "Ingen konversationshistorik",
     "description": "Körning utan kopplad konversation (äldre version av körning)"

--- a/src/i18n/uk/chat.json
+++ b/src/i18n/uk/chat.json
@@ -602,6 +602,9 @@
   "scheduledTasks.viewResult": {
     "message": "View Result"
   },
+  "scheduledTasks.viewRuns": {
+    "message": "Run history"
+  },
   "scheduledTasks.noConversation": {
     "message": "Немає записів розмов",
     "description": "Запуск без пов'язаних розмов (версія без оновлень)"

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -584,6 +584,7 @@
   "scheduledTasks.loadError": { "message": "加载失败", "description": "加载错误提示" },
   "scheduledTasks.deleteConfirm": { "message": "确认删除「{name}」？删除后任务将停止运行。", "description": "删除确认" },
   "scheduledTasks.viewResult": { "message": "查看结果", "description": "跳转到对话" },
+  "scheduledTasks.viewRuns": { "message": "运行记录", "description": "卡片底部查看运行历史" },
   "scheduledTasks.noConversation": { "message": "无对话记录", "description": "运行未关联对话（旧版本运行）" },
   "scheduledTasks.jitterHint": { "message": "±60s 抖动", "description": "运行时间抖动说明" },
   "scheduledTasks.runCount": { "message": "已运行 {count} 次", "description": "运行次数" },

--- a/src/i18n/zh-TW/chat.json
+++ b/src/i18n/zh-TW/chat.json
@@ -602,6 +602,9 @@
   "scheduledTasks.viewResult": {
     "message": "View Result"
   },
+  "scheduledTasks.viewRuns": {
+    "message": "Run history"
+  },
   "scheduledTasks.noConversation": {
     "message": "無對話記錄",
     "description": "運行未關聯對話（舊版本運行）"

--- a/src/pages/chat/ScheduledTasks.vue
+++ b/src/pages/chat/ScheduledTasks.vue
@@ -1,55 +1,71 @@
 <template>
   <div class="scheduled-tasks">
-    <div class="header">
-      <h2 class="title">{{ $t('chat.scheduledTasks.title') }}</h2>
-      <el-button type="primary" size="small" @click="showCreateDialog = true">
-        <font-awesome-icon icon="fa-solid fa-plus" class="icon" />
-        {{ $t('chat.scheduledTasks.create') }}
-      </el-button>
-    </div>
-
-    <el-skeleton v-if="loading" :rows="4" animated />
-
-    <el-empty
-      v-else-if="!tasks.length"
-      :description="$t('chat.scheduledTasks.empty')"
-      class="empty"
-    />
-
-    <div v-else class="task-list">
-      <div v-for="task in tasks" :key="task.id" class="task-card" @click="selectTask(task)">
-        <div class="task-header">
-          <div class="task-name">{{ task.name }}</div>
-          <div class="task-actions" @click.stop>
-            <el-switch
-              :model-value="task.state === 'enabled'"
-              size="small"
-              @change="(v: string | number | boolean) => toggleState(task, v === true)"
-            />
-            <el-button size="small" text @click="openEdit(task)">
-              <font-awesome-icon icon="fa-solid fa-pen" />
-            </el-button>
-            <el-button size="small" text type="danger" @click="confirmDelete(task)">
-              <font-awesome-icon icon="fa-solid fa-trash" />
-            </el-button>
-          </div>
-        </div>
-        <div class="task-meta">
-          <el-tag size="small" :type="stateTagType(task.state)">
-            {{ $t(`chat.scheduledTasks.state.${task.state}`) }}
-          </el-tag>
-          <span class="schedule-label">{{ scheduleLabel(task.schedule) }}</span>
-          <span class="model-label">{{ task.template.model }}</span>
-        </div>
-        <div class="task-prompt">{{ task.template.question }}</div>
-        <div v-if="task.last_output_snippet" class="task-last-output">
-          {{ task.last_output_snippet }}
-        </div>
-        <div class="task-footer">
-          <span>{{ $t('chat.scheduledTasks.runCount', { count: task.run_count }) }}</span>
-          <span v-if="task.last_error" class="error-hint">{{ task.last_error }}</span>
-        </div>
+    <div class="inner">
+      <div class="header">
+        <h2 class="title">{{ $t('chat.scheduledTasks.title') }}</h2>
+        <el-button type="primary" round @click="showCreateDialog = true">
+          <font-awesome-icon icon="fa-solid fa-plus" class="icon" />
+          {{ $t('chat.scheduledTasks.create') }}
+        </el-button>
       </div>
+
+      <el-skeleton v-if="loading" :rows="4" animated class="loading-block" />
+
+      <el-empty v-else-if="!tasks.length" :description="$t('chat.scheduledTasks.empty')" class="empty" />
+
+      <template v-else>
+        <div class="task-list">
+          <el-card v-for="task in pagedTasks" :key="task.id" class="task-card" shadow="hover" @click="selectTask(task)">
+            <div class="task-top">
+              <div class="task-name">{{ task.name }}</div>
+              <div class="task-actions" @click.stop>
+                <el-switch
+                  :model-value="task.state === 'enabled'"
+                  @change="(v: string | number | boolean) => toggleState(task, v === true)"
+                />
+                <el-button text class="icon-action" @click="openEdit(task)">
+                  <font-awesome-icon icon="fa-solid fa-pen" />
+                </el-button>
+                <el-button text type="danger" class="icon-action" @click="confirmDelete(task)">
+                  <font-awesome-icon icon="fa-solid fa-trash" />
+                </el-button>
+              </div>
+            </div>
+            <div class="task-meta">
+              <el-tag size="small" :type="stateTagType(task.state)" effect="dark" round>
+                {{ $t(`chat.scheduledTasks.state.${task.state}`) }}
+              </el-tag>
+              <span class="meta-chip">
+                <font-awesome-icon icon="fa-solid fa-clock" class="meta-icon" />
+                {{ scheduleLabel(task.schedule) }}
+              </span>
+              <span class="meta-chip">
+                <font-awesome-icon icon="fa-solid fa-brain" class="meta-icon" />
+                {{ task.template.model }}
+              </span>
+            </div>
+            <div class="task-prompt">{{ task.template.question }}</div>
+            <div v-if="task.last_output_snippet" class="task-last-output">
+              {{ task.last_output_snippet }}
+            </div>
+            <div class="task-footer">
+              <span class="run-count">
+                <font-awesome-icon icon="fa-solid fa-arrows-rotate" class="footer-icon" />
+                {{ $t('chat.scheduledTasks.runCount', { count: task.run_count }) }}
+              </span>
+              <span v-if="task.last_error" class="error-hint">{{ task.last_error }}</span>
+              <span class="open-hint">
+                {{ $t('chat.scheduledTasks.viewRuns') }}
+                <font-awesome-icon icon="fa-solid fa-chevron-right" />
+              </span>
+            </div>
+          </el-card>
+        </div>
+
+        <div v-if="tasks.length > pageSize" class="pager">
+          <pagination :current-page="page" :page-size="pageSize" :total="tasks.length" @change="onPageChange" />
+        </div>
+      </template>
     </div>
 
     <!-- Run history drawer -->
@@ -72,7 +88,7 @@
       <el-empty v-else-if="!runs.length" :description="$t('chat.scheduledTasks.noRuns')" />
       <div v-else class="run-list">
         <div
-          v-for="run in runs"
+          v-for="run in pagedRuns"
           :key="run.id"
           class="run-item"
           :class="{ clickable: !!run.conversation_id }"
@@ -85,7 +101,7 @@
           <div class="run-body">
             <div class="run-line">
               <span class="run-title">{{ run.conversation_title || formatTime(run.scheduled_at) }}</span>
-              <el-tag size="small" :type="runTagType(run.status)" effect="light" class="run-tag">
+              <el-tag size="small" :type="runTagType(run.status)" effect="dark" round class="run-tag">
                 {{ $t(`chat.scheduledTasks.run.${run.status}`) }}
               </el-tag>
             </div>
@@ -98,14 +114,13 @@
             </div>
           </div>
           <div class="run-action">
-            <font-awesome-icon
-              v-if="run.conversation_id"
-              icon="fa-solid fa-chevron-right"
-              class="run-arrow"
-            />
+            <font-awesome-icon v-if="run.conversation_id" icon="fa-solid fa-chevron-right" class="run-arrow" />
             <span v-else class="run-noconv">{{ $t('chat.scheduledTasks.noConversation') }}</span>
           </div>
         </div>
+      </div>
+      <div v-if="!runsLoading && runs.length > runPageSize" class="pager run-pager">
+        <pagination :current-page="runPage" :page-size="runPageSize" :total="runs.length" @change="onRunPageChange" />
       </div>
     </el-drawer>
 
@@ -115,6 +130,7 @@
       :title="editingTask ? $t('chat.scheduledTasks.edit') : $t('chat.scheduledTasks.create')"
       width="540px"
       :close-on-click-modal="false"
+      class="scheduled-task-dialog"
     >
       <el-form :model="form" label-width="92px">
         <el-form-item :label="$t('chat.scheduledTasks.form.prompt')" required>
@@ -207,6 +223,7 @@ import { defineComponent } from 'vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import {
   ElButton,
+  ElCard,
   ElSkeleton,
   ElEmpty,
   ElSwitch,
@@ -225,7 +242,14 @@ import {
   ElMessage,
   ElMessageBox
 } from 'element-plus';
-import { scheduledTasksOperator, IScheduledTask, IScheduledRun, IScheduleSpec, IAuthorizableSkill } from '@/operators/scheduledTasks';
+import Pagination from '@/components/common/Pagination.vue';
+import {
+  scheduledTasksOperator,
+  IScheduledTask,
+  IScheduledRun,
+  IScheduleSpec,
+  IAuthorizableSkill
+} from '@/operators/scheduledTasks';
 import { CHAT_MODEL_GROUPS, CHAT_MODEL_NAME_GPT_5_4_MINI } from '@/constants';
 import { IChatModelGroup } from '@/models';
 
@@ -246,6 +270,7 @@ export default defineComponent({
   components: {
     FontAwesomeIcon,
     ElButton,
+    ElCard,
     ElSkeleton,
     ElEmpty,
     ElSwitch,
@@ -260,7 +285,8 @@ export default defineComponent({
     ElOptionGroup,
     ElRadioGroup,
     ElRadio,
-    ElTimePicker
+    ElTimePicker,
+    Pagination
   },
   data() {
     return {
@@ -276,6 +302,10 @@ export default defineComponent({
       editingTask: null as IScheduledTask | null,
       authorizableSkills: [] as IAuthorizableSkill[],
       weekdays: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+      page: 1,
+      pageSize: 6,
+      runPage: 1,
+      runPageSize: 8,
       form: this.emptyForm() as TaskForm
     };
   },
@@ -289,6 +319,14 @@ export default defineComponent({
       return CHAT_MODEL_GROUPS.filter((g) => features[g.name]?.enabled !== false)
         .map((g) => ({ ...g, models: g.models.filter((m) => m.enabled !== false) }))
         .filter((g) => g.models.length > 0);
+    },
+    pagedTasks(): IScheduledTask[] {
+      const start = (this.page - 1) * this.pageSize;
+      return this.tasks.slice(start, start + this.pageSize);
+    },
+    pagedRuns(): IScheduledRun[] {
+      const start = (this.runPage - 1) * this.runPageSize;
+      return this.runs.slice(start, start + this.runPageSize);
     }
   },
   async mounted() {
@@ -316,6 +354,9 @@ export default defineComponent({
       this.loading = true;
       try {
         this.tasks = await scheduledTasksOperator.listTasks(this.token);
+        // Clamp the page in case deletions shrank the list past the current page.
+        const maxPage = Math.max(1, Math.ceil(this.tasks.length / this.pageSize));
+        if (this.page > maxPage) this.page = maxPage;
       } catch {
         ElMessage.error(this.$t('chat.scheduledTasks.loadError') as string);
       } finally {
@@ -325,12 +366,19 @@ export default defineComponent({
     async selectTask(task: IScheduledTask) {
       this.selectedTask = task;
       this.showRunHistory = true;
+      this.runPage = 1;
       this.runsLoading = true;
       try {
         this.runs = await scheduledTasksOperator.listRuns(this.token!, task.id);
       } finally {
         this.runsLoading = false;
       }
+    },
+    onPageChange(p: number) {
+      this.page = p;
+    },
+    onRunPageChange(p: number) {
+      this.runPage = p;
     },
     openEdit(task: IScheduledTask) {
       this.editingTask = task;
@@ -503,9 +551,14 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .scheduled-tasks {
-  padding: 20px;
-  max-width: 800px;
+  height: 100%;
+  overflow-y: auto;
+  background: var(--app-bg-section);
+}
+.inner {
+  max-width: 880px;
   margin: 0 auto;
+  padding: 24px 20px 48px;
 }
 .header {
   display: flex;
@@ -513,56 +566,296 @@ export default defineComponent({
   align-items: center;
   margin-bottom: 20px;
 }
-.title { font-size: 18px; font-weight: 600; margin: 0; }
-.task-list { display: flex; flex-direction: column; gap: 12px; }
+.title {
+  font-size: 20px;
+  font-weight: 700;
+  margin: 0;
+  color: var(--el-text-color-primary);
+}
+.header .icon {
+  margin-right: 6px;
+}
+.loading-block {
+  padding: 12px 4px;
+}
+.task-list {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
 .task-card {
-  background: var(--app-bg-surface, var(--el-bg-color-overlay));
+  border-radius: 16px;
   border: 1px solid var(--app-border-subtle, var(--el-border-color-light));
-  border-radius: 8px;
-  padding: 14px 16px;
   cursor: pointer;
-  transition: background 0.16s, border-color 0.16s;
+  transition:
+    transform 0.16s ease,
+    box-shadow 0.16s ease,
+    border-color 0.16s ease;
+  :deep(.el-card__body) {
+    padding: 16px 18px;
+  }
   &:hover {
-    background: var(--el-fill-color-lighter);
+    transform: translateY(-2px);
     border-color: var(--el-border-color);
   }
 }
-.task-header {
+.task-top {
   display: flex;
   justify-content: space-between;
-  align-items: center;
-  margin-bottom: 6px;
+  align-items: flex-start;
+  gap: 12px;
+  margin-bottom: 10px;
 }
-.task-name { font-weight: 600; font-size: 14px; }
-.task-actions { display: flex; gap: 6px; align-items: center; }
-.task-meta { display: flex; gap: 8px; align-items: center; margin-bottom: 6px; font-size: 12px; color: var(--el-text-color-secondary); }
-.task-prompt { font-size: 13px; color: var(--el-text-color-regular); white-space: pre-line; max-height: 48px; overflow: hidden; }
-.task-last-output { font-size: 12px; color: var(--el-text-color-secondary); margin-top: 8px; padding-top: 8px; border-top: 1px solid var(--app-border-subtle, var(--el-border-color-lighter)); }
-.task-footer { display: flex; justify-content: space-between; font-size: 11px; color: var(--el-text-color-secondary); margin-top: 8px; }
-.error-hint { color: var(--el-color-danger); }
-.empty { padding: 60px 0; }
-.run-context { margin-bottom: 14px; padding-bottom: 14px; border-bottom: 1px solid var(--app-border-subtle, var(--el-border-color-lighter)); }
-.run-context-meta { display: flex; flex-wrap: wrap; gap: 8px; font-size: 12px; color: var(--el-text-color-secondary); }
-.run-context-meta span + span::before { content: '·'; margin-right: 8px; color: var(--el-text-color-placeholder); }
-.run-context-prompt { margin-top: 8px; font-size: 12px; line-height: 1.55; color: var(--el-text-color-secondary); white-space: pre-line; max-height: 48px; overflow: hidden; }
-.run-list { display: flex; flex-direction: column; gap: 10px; }
-.run-item { display: flex; gap: 12px; align-items: center; padding: 12px 14px; border: 1px solid var(--app-border-subtle, var(--el-border-color-lighter)); border-radius: 8px; background: var(--app-bg-surface, var(--el-bg-color-overlay)); transition: background 0.16s, border-color 0.16s; }
-.run-item.clickable { cursor: pointer; }
-.run-item.clickable:hover, .run-item.clickable:focus-visible { background: var(--el-fill-color-lighter); border-color: var(--el-border-color); outline: none; }
-.run-body { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 6px; }
-.run-line { display: flex; gap: 8px; align-items: center; }
-.run-title { min-width: 0; flex: 1; font-size: 14px; font-weight: 600; color: var(--el-text-color-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.run-tag { flex-shrink: 0; }
-.run-preview { font-size: 12px; line-height: 1.5; color: var(--el-text-color-secondary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.run-sub { display: flex; gap: 10px; align-items: center; min-width: 0; }
-.run-time { font-size: 12px; color: var(--el-text-color-secondary); }
-.run-error { min-width: 0; font-size: 11px; color: var(--el-text-color-secondary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.run-action { display: flex; align-items: center; align-self: center; flex-shrink: 0; }
-.run-arrow { color: var(--el-text-color-secondary); font-size: 12px; flex-shrink: 0; }
-.run-noconv { font-size: 11px; color: var(--el-text-color-secondary); flex-shrink: 0; }
-.hint { font-size: 11px; color: var(--el-text-color-secondary); margin-top: 4px; }
-.jitter-hint { font-size: 11px; color: var(--el-text-color-secondary); margin-left: 8px; }
+.task-name {
+  font-weight: 600;
+  font-size: 15px;
+  line-height: 1.4;
+  color: var(--el-text-color-primary);
+  word-break: break-word;
+}
+.task-actions {
+  display: flex;
+  gap: 2px;
+  align-items: center;
+  flex-shrink: 0;
+}
+.icon-action {
+  padding: 6px 8px;
+}
+.task-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 10px;
+}
+.meta-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+  background: var(--el-fill-color-light);
+  border-radius: 8px;
+  padding: 3px 9px;
+}
+.meta-icon {
+  font-size: 11px;
+  opacity: 0.85;
+}
+.task-prompt {
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--el-text-color-regular);
+  white-space: pre-line;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.task-last-output {
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--el-text-color-secondary);
+  margin-top: 10px;
+  padding: 10px 12px;
+  background: var(--el-fill-color-lighter);
+  border-radius: 10px;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.task-footer {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+  margin-top: 12px;
+}
+.run-count {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+.footer-icon {
+  font-size: 11px;
+  opacity: 0.85;
+}
+.error-hint {
+  color: var(--el-color-danger);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.open-hint {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--el-color-primary);
+  flex-shrink: 0;
+}
+.empty {
+  padding: 60px 0;
+}
+.pager {
+  display: flex;
+  justify-content: center;
+  margin-top: 20px;
+}
+.run-pager {
+  margin-top: 8px;
+}
+.run-context {
+  margin-bottom: 14px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--app-border-subtle, var(--el-border-color-lighter));
+}
+.run-context-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+}
+.run-context-meta span + span::before {
+  content: '·';
+  margin-right: 8px;
+  color: var(--el-text-color-placeholder);
+}
+.run-context-prompt {
+  margin-top: 8px;
+  font-size: 12px;
+  line-height: 1.55;
+  color: var(--el-text-color-secondary);
+  white-space: pre-line;
+  max-height: 48px;
+  overflow: hidden;
+}
+.run-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.run-item {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  padding: 12px 14px;
+  border: 1px solid var(--app-border-subtle, var(--el-border-color-lighter));
+  border-radius: 14px;
+  background: var(--app-bg-surface, var(--el-bg-color-overlay));
+  transition:
+    background 0.16s,
+    border-color 0.16s;
+}
+.run-item.clickable {
+  cursor: pointer;
+}
+.run-item.clickable:hover,
+.run-item.clickable:focus-visible {
+  background: var(--el-fill-color-lighter);
+  border-color: var(--el-border-color);
+  outline: none;
+}
+.run-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.run-line {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+.run-title {
+  min-width: 0;
+  flex: 1;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--el-text-color-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.run-tag {
+  flex-shrink: 0;
+}
+.run-preview {
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--el-text-color-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.run-sub {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  min-width: 0;
+}
+.run-time {
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+}
+.run-error {
+  min-width: 0;
+  font-size: 11px;
+  color: var(--el-text-color-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.run-action {
+  display: flex;
+  align-items: center;
+  align-self: center;
+  flex-shrink: 0;
+}
+.run-arrow {
+  color: var(--el-text-color-secondary);
+  font-size: 12px;
+  flex-shrink: 0;
+}
+.run-noconv {
+  font-size: 11px;
+  color: var(--el-text-color-secondary);
+  flex-shrink: 0;
+}
+.hint {
+  font-size: 11px;
+  color: var(--el-text-color-secondary);
+  margin-top: 4px;
+}
+.jitter-hint {
+  font-size: 11px;
+  color: var(--el-text-color-secondary);
+  margin-left: 8px;
+}
 .skill-option { display: flex; align-items: center; justify-content: space-between; gap: 8px; min-width: 0; }
 .skill-option-name { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .skill-option-missing { flex-shrink: 0; font-size: 11px; color: var(--el-text-color-secondary); }
+</style>
+
+<style lang="scss">
+/* Teleported overlays (drawer / dialog) — larger, softer corners.
+   Non-scoped + uniquely-named classes so the rules reach the panels. */
+.run-history-drawer.el-drawer,
+.run-history-drawer .el-drawer {
+  border-top-left-radius: 18px;
+  border-bottom-left-radius: 18px;
+  overflow: hidden;
+}
+.scheduled-task-dialog.el-dialog,
+.scheduled-task-dialog .el-dialog {
+  border-radius: 16px;
+  overflow: hidden;
+}
 </style>


### PR DESCRIPTION
## What & why

Redesign of the Nexior **定时任务 / Scheduled Tasks** page (`/chatgpt/scheduled`) to address the design feedback:

1. **Page-tone background** — the page now sits on `--app-bg-section` (muted, dark-mode aware) instead of a flat white surface.
2. **`el-card` per task** — each task is an `el-card` (white/`#161b22` surface) on the section background, with hover elevation.
3. **Pagination** — client-side pagination via the shared `Pagination.vue` component (same UX as the API-usage page) for **both** the task list and the run-history drawer. (Backend returns the full task list and ≤20 runs, so paging is done client-side.)
4. **Larger, more standard radii** — task cards `16px`, run items `14px`, drawer panel `18px`, create/edit dialog `16px`.
5. **Filled tags** — task & run status use `effect="dark"` rounded `el-tag` (filled pills) instead of the light/outline variant; schedule & model are shown as icon chips.

### Details
- Task list paginates at 6/page; the run-history drawer paginates at 8/page. Pagers only render when the count exceeds the page size.
- `loadTasks()` clamps the current page after deletions so you never land on an empty page; `selectTask()` resets the run pager to page 1.
- Added i18n key `scheduledTasks.viewRuns` (zh-CN + en only; other locales handled by the translation CronJob).
- Teleported drawer/dialog corners are rounded via a small non-scoped block keyed by unique classes; scoped `:deep(.el-card__body)` tunes card padding.

### Verification
- `vue-tsc --noEmit` — clean.
- `eslint` on changed files — clean for all edited lines (4 remaining prettier warnings are pre-existing in `saveTask`/`confirmDelete`, untouched by this PR; Nexior CI does not gate on lint).
- Both i18n JSON files parse.

## 🤖 对抗评审

Reviewer auto-detect: Codex hit its usage limit, so an independent read-only subagent reviewer was used (per `/auto-review` protocol). One loop.

| # | Finding | Resolution |
|---|---------|------------|
| RISK 1 | "`scheduledTasks.viewRuns` missing from both locale files" | **Rebutted (false positive).** Verified present — `zh-CN/chat.json:587` and `en/chat.json:605` (flat-key format `"scheduledTasks.viewRuns"`, also in `HEAD`). The reviewer missed the flat (non-nested) key layout. |

Confirmed correct by the reviewer (no risk): pagination slice/clamp logic and the `Pagination.vue` 1s guard; `:deep(.el-card__body)`; all 7 Font Awesome icons registered in `src/plugins/font-awesome.ts`; dark-mode contrast (`--app-bg-section` #0d1117 vs card #161b22); `@click.stop` on the action row vs the card click; teleported drawer/dialog selectors reach the panels.

**VERDICT: CLEAN** (the single finding was a verified false positive).
