### PR TITLE
refactor(nanobanana): visual aspect-ratio chips to match other scenarios

### DIFF
--- a/change/@acedatacloud-nexior-bb2bad5f-74b1-4b10-8a4c-03dfe91dd1fc.json
+++ b/change/@acedatacloud-nexior-bb2bad5f-74b1-4b10-8a4c-03dfe91dd1fc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "visual aspect-ratio chips for nanobanana to match other scenarios",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/nanobanana/config/AspectRatioSelector.vue
+++ b/src/components/nanobanana/config/AspectRatioSelector.vue
@@ -1,59 +1,155 @@
 <template>
-  <div class="field">
-    <h2 class="title font-bold">{{ $t('nanobanana.name.aspectRatio') }}</h2>
-    <el-select v-model="value" class="value" clearable :placeholder="$t('nanobanana.placeholder.select')">
-      <el-option v-for="opt in options" :key="opt" :label="opt" :value="opt" />
-    </el-select>
+  <div class="ratio">
+    <div class="header">
+      <h2 class="title font-bold">{{ $t('nanobanana.name.aspectRatio') }}</h2>
+      <info-icon :content="$t('nanobanana.description.aspectRatio')" class="ml-1" />
+    </div>
+    <div class="items" role="radiogroup" :aria-label="$t('nanobanana.name.aspectRatio')">
+      <div
+        v-for="opt in options"
+        :key="opt.value"
+        class="item"
+        :class="{ active: value === opt.value }"
+        role="radio"
+        :aria-checked="value === opt.value"
+        :aria-label="opt.label"
+        tabindex="0"
+        @click="onSelect(opt.value)"
+        @keydown.enter.prevent="onSelect(opt.value)"
+        @keydown.space.prevent="onSelect(opt.value)"
+      >
+        <div class="preview">
+          <div class="rect" :style="{ width: opt.width + 'px', height: opt.height + 'px' }"></div>
+        </div>
+        <p class="name">{{ opt.label }}</p>
+      </div>
+    </div>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElSelect, ElOption } from 'element-plus';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+
+interface IRatioOption {
+  value: string;
+  label: string;
+  width: number;
+  height: number;
+}
 
 export default defineComponent({
   name: 'AspectRatioSelector',
-  components: { ElSelect, ElOption },
+  components: { InfoIcon },
   data() {
     return {
-      options: ['1:1', '3:2', '2:3', '16:9', '9:16', '4:3', '3:4']
+      options: [
+        { value: '1:1', label: '1:1', width: 20, height: 20 },
+        { value: '3:2', label: '3:2', width: 27, height: 18 },
+        { value: '2:3', label: '2:3', width: 18, height: 27 },
+        { value: '16:9', label: '16:9', width: 25, height: 13 },
+        { value: '9:16', label: '9:16', width: 13, height: 25 },
+        { value: '4:3', label: '4:3', width: 24, height: 18 },
+        { value: '3:4', label: '3:4', width: 18, height: 24 }
+      ] as IRatioOption[]
     };
   },
   computed: {
-    value: {
-      get() {
-        return this.$store.state.nanobanana?.config?.aspect_ratio;
-      },
-      set(val: string | null | undefined) {
-        console.debug('set aspect_ratio', val);
-        const nextConfig = { ...(this.$store.state.nanobanana?.config || {}) };
-        if (!val) {
-          delete (nextConfig as any).aspect_ratio;
-        } else {
-          (nextConfig as any).aspect_ratio = val;
-        }
-        this.$store.commit('nanobanana/setConfig', nextConfig);
+    value(): string | undefined {
+      return this.$store.state.nanobanana?.config?.aspect_ratio;
+    }
+  },
+  methods: {
+    onSelect(val: string) {
+      // Toggle: clicking the active ratio clears it. nano-banana intentionally
+      // allows "no aspect ratio" so edit mode follows the input image's ratio.
+      const next = this.value === val ? undefined : val;
+      const nextConfig = { ...(this.$store.state.nanobanana?.config || {}) };
+      if (!next) {
+        delete (nextConfig as any).aspect_ratio;
+      } else {
+        (nextConfig as any).aspect_ratio = next;
       }
+      this.$store.commit('nanobanana/setConfig', nextConfig);
     }
   }
 });
 </script>
 
 <style lang="scss" scoped>
-.field {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: space-between;
+.ratio {
+  .header {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    margin-bottom: 10px;
 
-  .title {
-    font-size: 14px;
-    margin: 0;
-    width: 30%;
+    .title {
+      font-size: 14px;
+      margin: 0;
+    }
   }
 
-  .value {
-    width: 160px;
+  .items {
+    display: grid;
+    grid-template-columns: repeat(5, 48px);
+    gap: 8px;
+    justify-content: start;
+
+    .item {
+      width: 48px;
+      height: 65px;
+      border: 1px solid var(--el-border-color);
+      background-color: var(--el-fill-color-lighter);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      border-radius: 8px;
+      transition:
+        background-color 0.2s ease,
+        border-color 0.2s ease;
+
+      .preview {
+        width: 30px;
+        height: 30px;
+        margin-bottom: 4px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+
+        .rect {
+          border: 1px solid var(--el-text-color-placeholder);
+          border-radius: 2px;
+        }
+      }
+
+      .name {
+        font-size: 12px;
+        margin: 0;
+        color: var(--el-text-color-primary);
+      }
+
+      &:hover {
+        background-color: var(--el-fill-color);
+      }
+
+      &:focus-visible {
+        outline: none;
+        border-color: var(--el-color-primary);
+        box-shadow: 0 0 0 2px var(--el-color-primary-light-7);
+      }
+
+      &.active {
+        border-color: var(--el-color-primary);
+        background-color: var(--el-color-primary-light-9);
+
+        .rect {
+          border-color: var(--el-color-primary);
+        }
+      }
+    }
   }
 }
 </style>


### PR DESCRIPTION
## What

Converts the **nanobanana** (Gemini image) aspect-ratio control from a plain text dropdown to the same visual preview-chip selector every other scenario already uses (flux, midjourney, kling, veo, qrart, seedance, grokvideo, sora, pixverse).

## Why — continued scenario audit

Following the maestro (#1058) and digitalhuman (#1061) polish, I classified **every** aspect-ratio / orientation selector across all 23 scenarios as visual-chips vs plain. Result: `nanobanana/config/AspectRatioSelector.vue` was the **only** one still rendering a plain `<el-select>` text dropdown — visually inconsistent and lower-fidelity than the rest.

(Resolution / duration selectors that use dropdowns were intentionally left alone — those are numeric and don't benefit from ratio previews. nanobanana's `ResolutionSelector` is already polished with an info icon.)

## Changes (one file)

- Plain dropdown → visual preview-chip grid (7 ratios: 1:1, 3:2, 2:3, 16:9, 9:16, 4:3, 3:4), reusing flux's grid layout (`repeat(5, 48px)`, wraps to 2 rows — fits the 320px sidebar).
- Added the existing `description.aspectRatio` as an `InfoIcon` "i" tooltip next to the title (it was already defined in i18n but never surfaced).
- **Preserved nano-banana's intentional "no aspect ratio" capability**: clicking the active chip toggles it off (deletes `aspect_ratio`), exactly like the old `clearable` dropdown + the `delete cfg.aspect_ratio` logic in `pages/nanobanana/Index.vue`. No forced default on mount — so edit mode still follows the input image's ratio.
- Keyboard-accessible: `role="radiogroup"`/`role="radio"`, `aria-checked`, `tabindex`, Enter/Space, focus ring.

No new i18n keys (reuses existing `name.aspectRatio` + `description.aspectRatio`). No behavior/billing changes.

## Validation

- `eslint src` ✅
- `vue-tsc -b --force` ✅
- `python3 scripts/check_i18n_coverage.py` → `17 locale(s) × 44 namespace(s) all match zh-CN` ✅

## 🤖 对抗评审

Codex was rate-limited, so the review ran via an independent Claude `general-purpose` subagent (the documented fallback). It verified: imports/registration correct, both i18n keys exist, store wiring equivalent to the old getter/setter, **toggle-clear behavior equivalent to the old `clearable` dropdown + Index.vue delete (no regression)**, no forced default (unset preserved), grid fits the sidebar, keyboard a11y present, types fine. Verdict: **CLEAN** (round 1).
