### PR TITLE
feat(chat): authorize MCP servers for scheduled tasks

### DIFF
--- a/change/@acedatacloud-nexior-scheduled-mcp-auth.json
+++ b/change/@acedatacloud-nexior-scheduled-mcp-auth.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Allow scheduled tasks to pre-authorize selected MCP servers alongside Skills for unattended runs",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/i18n/ar/chat.json
+++ b/src/i18n/ar/chat.json
@@ -700,6 +700,18 @@
     "message": "غير متصل",
     "description": "تفتقر المهارة إلى الاتصال"
   },
+  "scheduledTasks.form.mcpServers": {
+    "message": "تفويض MCP",
+    "description": "تفويض خادم MCP لمهام مجدولة بدون تدخل بشري، يمكن اختيار عدة خوادم."
+  },
+  "scheduledTasks.form.mcpServersPlaceholder": {
+    "message": "اختر خوادم MCP المسموح لها بتحميل هذه المهمة تلقائيًا",
+    "description": "نص توضيحي لتفويض خادم MCP."
+  },
+  "scheduledTasks.form.mcpServersHint": {
+    "message": "يمكن تحميل وتنفيذ خوادم MCP المختارة في خلفية المهام المجدولة؛ لن يتم تحميل خوادم MCP غير المختارة في وضع بدون تدخل بشري.",
+    "description": "شرح تفويض خادم MCP."
+  },
   "scheduledTasks.form.skillsConfirmTitle": {
     "message": "تأكيد التفويض بدون تدخل بشري",
     "description": "عنوان تأكيد التفويض"

--- a/src/i18n/de/chat.json
+++ b/src/i18n/de/chat.json
@@ -700,6 +700,18 @@
     "message": "Nicht verbunden",
     "description": "Skill fehlt die Verbindung"
   },
+  "scheduledTasks.form.mcpServers": {
+    "message": "MCP autorisieren",
+    "description": "Unbeaufsichtigte Autorisierung von MCP-Servern für geplante Aufgaben, Mehrfachauswahl möglich."
+  },
+  "scheduledTasks.form.mcpServersPlaceholder": {
+    "message": "Wählen Sie die MCP-Server aus, die diese Aufgabe automatisch laden dürfen",
+    "description": "Platzhalter für die Autorisierung von MCP-Servern."
+  },
+  "scheduledTasks.form.mcpServersHint": {
+    "message": "Die ausgewählten MCP-Server können im Hintergrund der geplanten Aufgaben geladen und ausgeführt werden; nicht ausgewählte MCP-Server werden im unbeaufsichtigten Modus nicht geladen.",
+    "description": "Erläuterung zur Autorisierung von MCP-Servern."
+  },
   "scheduledTasks.form.skillsConfirmTitle": {
     "message": "Bestätigung der unbeaufsichtigten Autorisierung",
     "description": "Titel der Bestätigung der Autorisierung"

--- a/src/i18n/el/chat.json
+++ b/src/i18n/el/chat.json
@@ -700,6 +700,18 @@
     "message": "Μη συνδεδεμένο",
     "description": "Η δεξιότητα λείπει σύνδεση"
   },
+  "scheduledTasks.form.mcpServers": {
+    "message": "Εξουσιοδότηση MCP",
+    "description": "Προγραμματισμένο καθήκον χωρίς επίβλεψη εξουσιοδότησης πολλαπλών MCP servers"
+  },
+  "scheduledTasks.form.mcpServersPlaceholder": {
+    "message": "Επιλέξτε τους MCP Servers που επιτρέπεται να φορτωθούν αυτόματα σε αυτήν την εργασία",
+    "description": "Placeholder για την εξουσιοδότηση MCP server"
+  },
+  "scheduledTasks.form.mcpServersHint": {
+    "message": "Οι επιλεγμένοι MCP Servers μπορούν να φορτωθούν και να εκτελούνται στο παρασκήνιο του προγραμματισμένου καθήκοντος. Οι μη επιλεγμένοι MCP Servers δεν θα φορτωθούν σε λειτουργία χωρίς επίβλεψη.",
+    "description": "Επεξήγηση για την εξουσιοδότηση MCP server"
+  },
   "scheduledTasks.form.skillsConfirmTitle": {
     "message": "Επιβεβαίωση Αυτόματης Εξουσιοδότησης",
     "description": "Τίτλος επιβεβαίωσης εξουσιοδότησης"

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -695,11 +695,20 @@
   "scheduledTasks.form.skillMissing": {
     "message": "Not connected"
   },
+  "scheduledTasks.form.mcpServers": {
+    "message": "Authorized MCP"
+  },
+  "scheduledTasks.form.mcpServersPlaceholder": {
+    "message": "Select MCP servers this task may load automatically"
+  },
+  "scheduledTasks.form.mcpServersHint": {
+    "message": "Selected MCP servers may be loaded and used during scheduled background runs. Unselected MCP servers will not load in unattended mode."
+  },
   "scheduledTasks.form.skillsConfirmTitle": {
     "message": "Confirm unattended authorization"
   },
   "scheduledTasks.form.skillsConfirm": {
-    "message": "This task will allow {count} Skill(s) to skip interactive confirmation in background runs: {skills}. These Skills may send messages, publish content, or write to external services. Please confirm."
+    "message": "This task will allow {count} Skill/MCP item(s) to skip interactive confirmation or load restrictions in background runs: {skills}. They may send messages, publish content, or write to external services. Please confirm."
   },
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"

--- a/src/i18n/es/chat.json
+++ b/src/i18n/es/chat.json
@@ -700,6 +700,18 @@
     "message": "No conectado",
     "description": "Falta la conexión de skill"
   },
+  "scheduledTasks.form.mcpServers": {
+    "message": "Autorizar MCP",
+    "description": "Tarea programada para autorizar múltiples servidores MCP sin intervención."
+  },
+  "scheduledTasks.form.mcpServersPlaceholder": {
+    "message": "Selecciona los servidores MCP que permitirán la carga automática de esta tarea",
+    "description": "Placeholder para la autorización de servidores MCP."
+  },
+  "scheduledTasks.form.mcpServersHint": {
+    "message": "Los servidores MCP seleccionados se cargarán y ejecutarán en la tarea programada; los servidores MCP no seleccionados no se cargarán en modo desatendido.",
+    "description": "Explicación sobre la autorización de servidores MCP."
+  },
   "scheduledTasks.form.skillsConfirmTitle": {
     "message": "Confirmar autorización sin supervisión",
     "description": "Título de la confirmación de autorización"

--- a/src/i18n/fi/chat.json
+++ b/src/i18n/fi/chat.json
@@ -700,6 +700,18 @@
     "message": "Ei yhdistetty",
     "description": "skill puuttuu yhteydestä"
   },
+  "scheduledTasks.form.mcpServers": {
+    "message": "Valtuuta MCP",
+    "description": "Aikataulutetut tehtävät valvonnasta vapaa valtuutus MCP-palvelimille usealla valinnalla"
+  },
+  "scheduledTasks.form.mcpServersPlaceholder": {
+    "message": "Valitse MCP-palvelimet, jotka saavat automaattisesti ladata tämän tehtävän",
+    "description": "Valtuutuksen MCP-palvelimien paikka"
+  },
+  "scheduledTasks.form.mcpServersHint": {
+    "message": "Valitut MCP-palvelimet voidaan ladata ja suorittaa aikataulutettujen tehtävien taustalla; valitsemattomia MCP-palvelimia ei ladata valvonnasta vapaassa tilassa.",
+    "description": "Valtuutuksen MCP-palvelimista selitys"
+  },
   "scheduledTasks.form.skillsConfirmTitle": {
     "message": "Vahvista automaattinen valtuutus",
     "description": "Valtuutuksen vahvistuksen otsikko"

--- a/src/i18n/fr/chat.json
+++ b/src/i18n/fr/chat.json
@@ -700,6 +700,18 @@
     "message": "Non connecté",
     "description": "skill manque de connexion"
   },
+  "scheduledTasks.form.mcpServers": {
+    "message": "Autoriser MCP",
+    "description": "Sélection multiple des serveurs MCP pour les tâches planifiées sans supervision."
+  },
+  "scheduledTasks.form.mcpServersPlaceholder": {
+    "message": "Sélectionnez les serveurs MCP autorisés à charger automatiquement cette tâche",
+    "description": "Espace réservé pour l'autorisation des serveurs MCP."
+  },
+  "scheduledTasks.form.mcpServersHint": {
+    "message": "Les serveurs MCP sélectionnés peuvent être chargés et exécutés en arrière-plan des tâches planifiées ; les serveurs MCP non sélectionnés ne seront pas chargés en mode sans supervision.",
+    "description": "Explication sur l'autorisation des serveurs MCP."
+  },
   "scheduledTasks.form.skillsConfirmTitle": {
     "message": "Confirmer l'autorisation sans supervision",
     "description": "Titre de la confirmation d'autorisation"

--- a/src/i18n/it/chat.json
+++ b/src/i18n/it/chat.json
@@ -700,6 +700,18 @@
     "message": "Non connesso",
     "description": "skill manca la connessione"
   },
+  "scheduledTasks.form.mcpServers": {
+    "message": "Autorizza MCP",
+    "description": "Autorizzazione multipla per i server MCP in un'attività pianificata senza supervisione."
+  },
+  "scheduledTasks.form.mcpServersPlaceholder": {
+    "message": "Seleziona i server MCP autorizzati a caricare automaticamente questa attività",
+    "description": "Segnaposto per l'autorizzazione dei server MCP."
+  },
+  "scheduledTasks.form.mcpServersHint": {
+    "message": "I server MCP selezionati possono essere caricati ed eseguiti in background per l'attività pianificata; i server MCP non selezionati non verranno caricati in modalità senza supervisione.",
+    "description": "Spiegazione sull'autorizzazione dei server MCP."
+  },
   "scheduledTasks.form.skillsConfirmTitle": {
     "message": "Conferma autorizzazione senza supervisione",
     "description": "Titolo di conferma autorizzazione"

--- a/src/i18n/ja/chat.json
+++ b/src/i18n/ja/chat.json
@@ -700,6 +700,18 @@
     "message": "未接続",
     "description": "skill が接続されていません"
   },
+  "scheduledTasks.form.mcpServers": {
+    "message": "MCPを承認",
+    "description": "定期タスクの無人運転用にMCPサーバーを複数選択する"
+  },
+  "scheduledTasks.form.mcpServersPlaceholder": {
+    "message": "このタスクが自動的に読み込むことを許可するMCPサーバーを選択",
+    "description": "MCPサーバーの承認用プレースホルダー"
+  },
+  "scheduledTasks.form.mcpServersHint": {
+    "message": "選択したMCPサーバーは定期タスクのバックエンドで読み込まれ、実行されます；未選択のMCPサーバーは無人運転モードでは読み込まれません。",
+    "description": "MCPサーバーの承認に関する説明"
+  },
   "scheduledTasks.form.skillsConfirmTitle": {
     "message": "無人権限付与の確認",
     "description": "権限付与確認のタイトル"

--- a/src/i18n/ko/chat.json
+++ b/src/i18n/ko/chat.json
@@ -700,6 +700,18 @@
     "message": "연결되지 않음",
     "description": "skill이 연결되지 않았음을 나타냅니다."
   },
+  "scheduledTasks.form.mcpServers": {
+    "message": "MCP 권한 부여",
+    "description": "정기 작업의 무인 권한 부여를 위한 MCP 서버 다중 선택"
+  },
+  "scheduledTasks.form.mcpServersPlaceholder": {
+    "message": "이 작업이 자동으로 로드할 수 있는 MCP 서버 선택",
+    "description": "MCP 서버 권한 부여 자리 표시자"
+  },
+  "scheduledTasks.form.mcpServersHint": {
+    "message": "선택한 MCP 서버는 정기 작업 백그라운드에서 로드 및 실행됩니다; 선택하지 않은 MCP 서버는 무인 모드에서 로드되지 않습니다.",
+    "description": "MCP 서버 권한 부여 설명"
+  },
   "scheduledTasks.form.skillsConfirmTitle": {
     "message": "무인 권한 부여 확인",
     "description": "권한 부여 확인 제목"

--- a/src/i18n/pl/chat.json
+++ b/src/i18n/pl/chat.json
@@ -700,6 +700,18 @@
     "message": "Niepołączone",
     "description": "Brak połączenia z umiejętnością"
   },
+  "scheduledTasks.form.mcpServers": {
+    "message": "Autoryzuj MCP",
+    "description": "Autoryzacja serwera MCP dla zadań zaplanowanych w trybie bezobsługowym"
+  },
+  "scheduledTasks.form.mcpServersPlaceholder": {
+    "message": "Wybierz serwery MCP, które mogą być automatycznie ładowane przez to zadanie",
+    "description": "Placeholder dla autoryzacji serwera MCP"
+  },
+  "scheduledTasks.form.mcpServersHint": {
+    "message": "Wybrane serwery MCP mogą być ładowane i wykonywane w tle zadań zaplanowanych; nie wybrane serwery MCP nie będą ładowane w trybie bezobsługowym.",
+    "description": "Opis autoryzacji serwera MCP"
+  },
   "scheduledTasks.form.skillsConfirmTitle": {
     "message": "Potwierdzenie autoryzacji bezobsługowej",
     "description": "Tytuł potwierdzenia autoryzacji"

--- a/src/i18n/pt/chat.json
+++ b/src/i18n/pt/chat.json
@@ -700,6 +700,18 @@
     "message": "Desconectado",
     "description": "skill está faltando conexão"
   },
+  "scheduledTasks.form.mcpServers": {
+    "message": "Autorizar MCP",
+    "description": "Autorização de servidores MCP para tarefas agendadas sem supervisão, múltipla seleção."
+  },
+  "scheduledTasks.form.mcpServersPlaceholder": {
+    "message": "Selecione os MCP Servers que podem carregar automaticamente esta tarefa",
+    "description": "Placeholder para autorização do servidor MCP."
+  },
+  "scheduledTasks.form.mcpServersHint": {
+    "message": "Os MCP Servers selecionados podem ser carregados e executados nas tarefas agendadas; os MCP Servers não selecionados não serão carregados no modo sem supervisão.",
+    "description": "Explicação sobre a autorização do servidor MCP."
+  },
   "scheduledTasks.form.skillsConfirmTitle": {
     "message": "Confirmar Autorização Sem Supervisão",
     "description": "Título da confirmação de autorização"

--- a/src/i18n/ru/chat.json
+++ b/src/i18n/ru/chat.json
@@ -700,6 +700,18 @@
     "message": "Не подключено",
     "description": "Отсутствует подключение к skill"
   },
+  "scheduledTasks.form.mcpServers": {
+    "message": "Авторизация MCP",
+    "description": "Запланированные задачи для безнадзорной авторизации нескольких серверов MCP"
+  },
+  "scheduledTasks.form.mcpServersPlaceholder": {
+    "message": "Выберите разрешенные для автоматической загрузки серверы MCP",
+    "description": "Заполнитель для авторизации серверов MCP"
+  },
+  "scheduledTasks.form.mcpServersHint": {
+    "message": "Выбранные серверы MCP могут загружаться и выполняться в фоновом режиме запланированных задач; невыбранные серверы MCP не будут загружаться в безнадзорном режиме.",
+    "description": "Объяснение авторизации серверов MCP"
+  },
   "scheduledTasks.form.skillsConfirmTitle": {
     "message": "Подтверждение автоматического разрешения",
     "description": "Заголовок подтверждения разрешения"

--- a/src/i18n/sr/chat.json
+++ b/src/i18n/sr/chat.json
@@ -700,6 +700,18 @@
     "message": "Није повезано",
     "description": "skill недостаје веза"
   },
+  "scheduledTasks.form.mcpServers": {
+    "message": "Ovlašćenje MCP",
+    "description": "Ovlašćenje za MCP servere za automatske zadatke."
+  },
+  "scheduledTasks.form.mcpServersPlaceholder": {
+    "message": "Izaberite MCP servere kojima dozvoljavate automatsko učitavanje za ovaj zadatak",
+    "description": "Placeholder za ovlašćenje MCP servera."
+  },
+  "scheduledTasks.form.mcpServersHint": {
+    "message": "Izabrani MCP serveri će se učitati i izvršiti u pozadini zadatka; neizabrani MCP serveri neće se učitati u režimu bez nadzora.",
+    "description": "Objašnjenje ovlašćenja za MCP servere."
+  },
   "scheduledTasks.form.skillsConfirmTitle": {
     "message": "Потврда овлашћења без надзора",
     "description": "Наслов за потврду овлашћења"

--- a/src/i18n/sv/chat.json
+++ b/src/i18n/sv/chat.json
@@ -700,6 +700,18 @@
     "message": "Ej ansluten",
     "description": "skill saknar anslutning"
   },
+  "scheduledTasks.form.mcpServers": {
+    "message": "Auktorisera MCP",
+    "description": "Schemalagda uppgifter för obevakad auktorisering av flera MCP-servrar"
+  },
+  "scheduledTasks.form.mcpServersPlaceholder": {
+    "message": "Välj MCP-servrar som får laddas automatiskt för denna uppgift",
+    "description": "Platshållare för auktorisering av MCP-servrar"
+  },
+  "scheduledTasks.form.mcpServersHint": {
+    "message": "Valda MCP-servrar kan laddas och utföras i den schemalagda uppgiften; icke-valda MCP-servrar kommer inte att laddas i obevakad läge.",
+    "description": "Förklaring av auktorisering av MCP-servrar"
+  },
   "scheduledTasks.form.skillsConfirmTitle": {
     "message": "Bekräfta obevakad auktorisering",
     "description": "Titel för auktoriseringsbekräftelse"

--- a/src/i18n/uk/chat.json
+++ b/src/i18n/uk/chat.json
@@ -700,6 +700,18 @@
     "message": "Не підключено",
     "description": "Відсутнє з'єднання з навичкою"
   },
+  "scheduledTasks.form.mcpServers": {
+    "message": "Авторизувати MCP",
+    "description": "Регулярне завдання для безлюдної авторизації мультивибору серверів MCP"
+  },
+  "scheduledTasks.form.mcpServersPlaceholder": {
+    "message": "Виберіть дозволені для автоматичного завантаження сервери MCP",
+    "description": "Плейсхолдер для авторизації серверів MCP"
+  },
+  "scheduledTasks.form.mcpServersHint": {
+    "message": "Вибрані сервери MCP можуть бути завантажені та виконані в фоновому режимі завдання; невибрані сервери MCP не будуть завантажені в безлюдному режимі.",
+    "description": "Пояснення авторизації серверів MCP"
+  },
   "scheduledTasks.form.skillsConfirmTitle": {
     "message": "Підтвердження авторизації без нагляду",
     "description": "Заголовок підтвердження авторизації"

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -615,7 +615,13 @@
   "scheduledTasks.form.skillsPlaceholder": { "message": "选择允许此任务自动执行的 Skills", "description": "授权 skill 占位符" },
   "scheduledTasks.form.skillsHint": { "message": "选中的 Skills 可在定时任务后台执行时跳过人工确认；未选中的 Skills 仍只能预览或等待确认。", "description": "授权 skill 说明" },
   "scheduledTasks.form.skillMissing": { "message": "未连接", "description": "skill 缺少连接" },
+  "scheduledTasks.form.mcpServers": { "message": "授权 MCP", "description": "定时任务无人值守授权 MCP server 多选" },
+  "scheduledTasks.form.mcpServersPlaceholder": { "message": "选择允许此任务自动加载的 MCP Servers", "description": "授权 MCP server 占位符" },
+  "scheduledTasks.form.mcpServersHint": { "message": "选中的 MCP Servers 可在定时任务后台加载并执行；未选中的 MCP Servers 不会在无人值守模式下加载。", "description": "授权 MCP server 说明" },
   "scheduledTasks.form.skillsConfirmTitle": { "message": "确认无人值守授权", "description": "授权确认标题" },
-  "scheduledTasks.form.skillsConfirm": { "message": "此任务将允许 {count} 个 Skill 在后台执行时跳过人工确认：{skills}。这些 Skill 可能会发送消息、发布内容或写入外部服务，请确认。", "description": "授权确认正文" },
+  "scheduledTasks.form.skillsConfirm": {
+    "message": "此任务将允许 {count} 个 Skill/MCP 在后台执行时跳过人工确认或加载限制：{skills}。它们可能会发送消息、发布内容或写入外部服务，请确认。",
+    "description": "授权确认正文"
+  },
   "scheduledTasks.form.required": { "message": "请填写任务名称和提示词", "description": "必填项验证" }
 }

--- a/src/i18n/zh-TW/chat.json
+++ b/src/i18n/zh-TW/chat.json
@@ -700,6 +700,18 @@
     "message": "未連接",
     "description": "skill 缺少連接"
   },
+  "scheduledTasks.form.mcpServers": {
+    "message": "授權 MCP",
+    "description": "定時任務無人值守授權 MCP server 多選"
+  },
+  "scheduledTasks.form.mcpServersPlaceholder": {
+    "message": "選擇允許此任務自動加載的 MCP Servers",
+    "description": "授權 MCP server 占位符"
+  },
+  "scheduledTasks.form.mcpServersHint": {
+    "message": "選中的 MCP Servers 可在定時任務後台加載並執行；未選中的 MCP Servers 不會在無人值守模式下加載。",
+    "description": "授權 MCP server 說明"
+  },
   "scheduledTasks.form.skillsConfirmTitle": {
     "message": "確認無人值守授權",
     "description": "授權確認標題"

--- a/src/operators/scheduledTasks.ts
+++ b/src/operators/scheduledTasks.ts
@@ -55,8 +55,9 @@ export type IScheduleSpec =
   | { type: 'once'; at: number; tz: string };
 
 export interface IScheduledTaskUnattendedPolicy {
-  mode: 'deny_all' | 'allow_selected_skills';
+  mode: 'deny_all' | 'allow_selected' | 'allow_selected_skills';
   allowed_skills: string[];
+  allowed_mcp_servers?: string[];
   expires_at?: number;
 }
 
@@ -70,6 +71,17 @@ export interface IAuthorizableSkill {
   source: string;
   connected: boolean;
   missing_connections: string[];
+}
+
+export interface IAuthorizableMcpServer {
+  slug: string;
+  name: string;
+  server_url: string;
+}
+
+export interface IAuthorizableCapabilities {
+  skills: IAuthorizableSkill[];
+  mcp_servers: IAuthorizableMcpServer[];
 }
 
 type ScheduledTaskPayload = {
@@ -86,10 +98,7 @@ class ScheduledTasksOperator {
     return data?.items ?? [];
   }
 
-  async createTask(
-    token: string,
-    payload: ScheduledTaskPayload
-  ): Promise<IScheduledTask> {
+  async createTask(token: string, payload: ScheduledTaskPayload): Promise<IScheduledTask> {
     const { data } = await axios.post(BASE, { action: 'create', ...payload }, { headers: headers(token) });
     return data;
   }
@@ -97,7 +106,9 @@ class ScheduledTasksOperator {
   async updateTask(
     token: string,
     id: string,
-    patch: Partial<Pick<IScheduledTask, 'name' | 'description' | 'state' | 'template' | 'schedule' | 'unattended_policy'>>
+    patch: Partial<
+      Pick<IScheduledTask, 'name' | 'description' | 'state' | 'template' | 'schedule' | 'unattended_policy'>
+    >
   ): Promise<IScheduledTask> {
     const { data } = await axios.post(BASE, { action: 'update', id, ...patch }, { headers: headers(token) });
     return data;
@@ -115,6 +126,14 @@ class ScheduledTasksOperator {
   async listAuthorizableSkills(token: string): Promise<IAuthorizableSkill[]> {
     const { data } = await axios.post(BASE, { action: 'retrieve_authorizable_skills' }, { headers: headers(token) });
     return data?.items ?? [];
+  }
+
+  async listAuthorizableCapabilities(token: string): Promise<IAuthorizableCapabilities> {
+    const { data } = await axios.post(BASE, { action: 'retrieve_authorizable_skills' }, { headers: headers(token) });
+    return {
+      skills: data?.skills ?? data?.items ?? [],
+      mcp_servers: data?.mcp_servers ?? []
+    };
   }
 }
 

--- a/src/pages/chat/ScheduledTasks.vue
+++ b/src/pages/chat/ScheduledTasks.vue
@@ -206,6 +206,28 @@
           </el-select>
           <div class="hint">{{ $t('chat.scheduledTasks.form.skillsHint') }}</div>
         </el-form-item>
+
+        <el-form-item :label="$t('chat.scheduledTasks.form.mcpServers')">
+          <el-select
+            v-model="form.authorizedMcpServers"
+            style="width: 100%"
+            multiple
+            filterable
+            collapse-tags
+            collapse-tags-tooltip
+            :loading="skillsLoading"
+            :placeholder="$t('chat.scheduledTasks.form.mcpServersPlaceholder')"
+            @visible-change="onSkillSelectVisible"
+          >
+            <el-option
+              v-for="server in authorizableMcpServers"
+              :key="server.slug"
+              :label="mcpServerLabel(server)"
+              :value="server.slug"
+            />
+          </el-select>
+          <div class="hint">{{ $t('chat.scheduledTasks.form.mcpServersHint') }}</div>
+        </el-form-item>
       </el-form>
 
       <template #footer>
@@ -248,7 +270,8 @@ import {
   IScheduledTask,
   IScheduledRun,
   IScheduleSpec,
-  IAuthorizableSkill
+  IAuthorizableSkill,
+  IAuthorizableMcpServer
 } from '@/operators/scheduledTasks';
 import { CHAT_MODEL_GROUPS, CHAT_MODEL_NAME_GPT_5_4_MINI } from '@/constants';
 import { IChatModelGroup } from '@/models';
@@ -263,6 +286,7 @@ interface TaskForm {
   weekday: number;
   cronExpr: string;
   authorizedSkills: string[];
+  authorizedMcpServers: string[];
 }
 
 export default defineComponent({
@@ -301,6 +325,7 @@ export default defineComponent({
       selectedTask: null as IScheduledTask | null,
       editingTask: null as IScheduledTask | null,
       authorizableSkills: [] as IAuthorizableSkill[],
+      authorizableMcpServers: [] as IAuthorizableMcpServer[],
       weekdays: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
       page: 1,
       pageSize: 6,
@@ -341,7 +366,8 @@ export default defineComponent({
         dailyTime: '09:00',
         weekday: 1,
         cronExpr: '0 9 * * *',
-        authorizedSkills: []
+        authorizedSkills: [],
+        authorizedMcpServers: []
       };
     },
     // The task name is no longer a separate field — derive a short label from the prompt.
@@ -413,7 +439,14 @@ export default defineComponent({
         dailyTime,
         weekday,
         cronExpr,
-        authorizedSkills: task.unattended_policy?.mode === 'allow_selected_skills' ? task.unattended_policy.allowed_skills || [] : []
+        authorizedSkills:
+          task.unattended_policy?.mode === 'allow_selected' || task.unattended_policy?.mode === 'allow_selected_skills'
+            ? task.unattended_policy.allowed_skills || []
+            : [],
+        authorizedMcpServers:
+          task.unattended_policy?.mode === 'allow_selected' || task.unattended_policy?.mode === 'allow_selected_skills'
+            ? task.unattended_policy.allowed_mcp_servers || []
+            : []
       };
       this.showCreateDialog = true;
       void this.loadAuthorizableSkills();
@@ -443,7 +476,7 @@ export default defineComponent({
       }
       this.saving = true;
       try {
-        if (this.form.authorizedSkills.length > 0) {
+        if (this.form.authorizedSkills.length > 0 || this.form.authorizedMcpServers.length > 0) {
           await ElMessageBox.confirm(this.authorizationConfirmText(), this.$t('chat.scheduledTasks.form.skillsConfirmTitle') as string, {
             type: 'warning',
             confirmButtonText: this.$t('common.button.confirm') as string,
@@ -451,13 +484,23 @@ export default defineComponent({
           });
         }
         const authorizedSkills = [...this.form.authorizedSkills];
+        const authorizedMcpServers = [...this.form.authorizedMcpServers];
         const payload = {
           name: this.deriveName(this.form.question),
           schedule: this.buildSchedule(),
-          template: { model: this.form.model, question: this.form.question, skills: authorizedSkills },
-          unattended_policy: authorizedSkills.length
-            ? { mode: 'allow_selected_skills' as const, allowed_skills: authorizedSkills }
-            : { mode: 'deny_all' as const, allowed_skills: [] }
+          template: {
+            model: this.form.model,
+            question: this.form.question,
+            skills: authorizedSkills,
+            mcp_servers: authorizedMcpServers
+          },
+          unattended_policy: authorizedSkills.length || authorizedMcpServers.length
+            ? {
+                mode: 'allow_selected' as const,
+                allowed_skills: authorizedSkills,
+                allowed_mcp_servers: authorizedMcpServers
+              }
+            : { mode: 'deny_all' as const, allowed_skills: [], allowed_mcp_servers: [] }
         };
         if (this.editingTask) {
           await scheduledTasksOperator.updateTask(this.token!, this.editingTask.id, payload);
@@ -476,10 +519,12 @@ export default defineComponent({
       }
     },
     async loadAuthorizableSkills(force = false) {
-      if (!this.token || this.skillsLoading || (!force && this.authorizableSkills.length)) return;
+      if (!this.token || this.skillsLoading || (!force && (this.authorizableSkills.length || this.authorizableMcpServers.length))) return;
       this.skillsLoading = true;
       try {
-        this.authorizableSkills = await scheduledTasksOperator.listAuthorizableSkills(this.token);
+        const capabilities = await scheduledTasksOperator.listAuthorizableCapabilities(this.token);
+        this.authorizableSkills = capabilities.skills;
+        this.authorizableMcpServers = capabilities.mcp_servers;
       } catch {
         ElMessage.error(this.$t('chat.scheduledTasks.loadError') as string);
       } finally {
@@ -492,14 +537,23 @@ export default defineComponent({
     skillLabel(skill: IAuthorizableSkill) {
       return skill.name || skill.slug;
     },
+    mcpServerLabel(server: IAuthorizableMcpServer) {
+      return server.name || server.slug;
+    },
     authorizationConfirmText() {
       const selected = new Set(this.form.authorizedSkills);
+      const selectedMcp = new Set(this.form.authorizedMcpServers);
       const names = this.authorizableSkills
         .filter((skill) => selected.has(skill.slug))
         .map((skill) => this.skillLabel(skill));
+      const mcpNames = this.authorizableMcpServers
+        .filter((server) => selectedMcp.has(server.slug))
+        .map((server) => this.mcpServerLabel(server));
       return this.$t('chat.scheduledTasks.form.skillsConfirm', {
-        count: selected.size,
-        skills: names.length ? names.join(', ') : Array.from(selected).join(', ')
+        count: selected.size + selectedMcp.size,
+        skills: [...names, ...mcpNames].length
+          ? [...names, ...mcpNames].join(', ')
+          : [...Array.from(selected), ...Array.from(selectedMcp)].join(', ')
       }) as string;
     },
     async toggleState(task: IScheduledTask, enabled: boolean) {


### PR DESCRIPTION
## What

Follow-up to #1060: adds MCP server selection to scheduled-task unattended authorization UI.

## Changes

- Extends scheduled task types with `allowed_mcp_servers` and authorizable MCP server rows.
- Adds an "Authorized MCP" multi-select next to the existing Skill selector.
- Saves selected MCP servers to both `template.mcp_servers` and `unattended_policy.allowed_mcp_servers`.
- Updates confirmation copy and i18n for all locales.

## Validation

- `python3 scripts/check_i18n_coverage.py`
- `npx vue-tsc -b --force --pretty false`
- `git diff --check`

## 🤖 对抗评审

Reviewed PlatformService/Nexior/Skills follow-up diffs together after fail-closed fixes. Final re-review: `VERDICT: CLEAN`.
