### PR TITLE
feat(desktop): app menu, min size, paypal allowlist, OS notifications

### DIFF
--- a/change/@acedatacloud-nexior-desktop-platform-adapt.json
+++ b/change/@acedatacloud-nexior-desktop-platform-adapt.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(desktop): add app menu (clipboard accelerators), min window size, PayPal external-open allowlist, and main-process OS notifications",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, shell } from 'electron';
+import { app, BrowserWindow, ipcMain, shell, Menu, Notification } from 'electron';
 import path from 'node:path';
 import { registerAppProtocol, APP_ORIGIN } from './protocol';
 import { issueState, consumeState } from './auth-state';
@@ -13,7 +13,7 @@ const AUTH_HOSTS = new Set(['auth.acedata.cloud']);
 // Payment redirects through third-party PSP hosts (NOT our domain) — they must
 // be allow-listed or the user can never reach checkout. Verify against the real
 // pay flow before shipping.
-const PSP_HOSTS = ['alipay.com', 'stripe.com', 'wx.tenpay.com'];
+const PSP_HOSTS = ['alipay.com', 'stripe.com', 'wx.tenpay.com', 'paypal.com'];
 const EXTERNAL_HOSTS = new Set(['acedata.cloud', ...PSP_HOSTS]);
 
 // The signed-in site origin, added at runtime via `site:setOrigin` so
@@ -78,6 +78,7 @@ if (!gotLock) {
   app.whenReady().then(() => {
     registerAppProtocol.serve();
     createWindow();
+    setupAppMenu();
     initUpdater(() => mainWindow);
     // Windows cold-start protocol activation: URL is in this instance's argv.
     const coldUrl = process.argv.find((a) => a.startsWith(`${DESKTOP_SCHEME}://`));
@@ -96,6 +97,9 @@ function createWindow(): void {
   mainWindow = new BrowserWindow({
     width: 1200,
     height: 800,
+    minWidth: 940,
+    minHeight: 600,
+    backgroundColor: '#0b0b0f', // avoid white flash before the SPA paints
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,
@@ -196,3 +200,26 @@ ipcMain.handle('auth:openOAuth', (_e, authUrl: string) => {
 ipcMain.handle('shell:openExternal', (_e, url: string) => {
   if (allowedExternal(url)) return shell.openExternal(url);
 });
+
+// Main-process desktop notification (Web Notification is unreliable when the
+// window is hidden/minimized). Clicking it refocuses the app.
+ipcMain.handle('notify:show', (_e, { title, body }: { title: string; body: string }) => {
+  if (!Notification.isSupported()) return;
+  const n = new Notification({ title: String(title || ''), body: String(body || '') });
+  n.on('click', () => focusWindow());
+  n.show();
+});
+
+// Cross-platform menu. The Edit role is REQUIRED for clipboard accelerators
+// (Cmd/Ctrl+C/V/X/A, undo/redo) to work in inputs; without it they are dead.
+function setupAppMenu(): void {
+  const isMac = process.platform === 'darwin';
+  Menu.setApplicationMenu(
+    Menu.buildFromTemplate([
+      ...(isMac ? [{ role: 'appMenu' as const }] : []),
+      { role: 'editMenu' },
+      { role: 'viewMenu' },
+      { role: 'windowMenu' }
+    ])
+  );
+}

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -41,5 +41,9 @@ contextBridge.exposeInMainWorld('desktop', {
 
   // Tell main the signed-in site origin so white-label custom domains are
   // allowed by the external-open / navigation guard (not just acedata.cloud).
-  setSiteOrigin: (origin: string): void => ipcRenderer.send('site:setOrigin', origin)
+  setSiteOrigin: (origin: string): void => ipcRenderer.send('site:setOrigin', origin),
+
+  // Show an OS notification via the main process (reliable when the window is
+  // hidden/minimized, unlike Web Notification). Resolves after dispatch.
+  notify: (title: string, body: string): Promise<void> => ipcRenderer.invoke('notify:show', { title, body })
 });

--- a/src/utils/desktop.ts
+++ b/src/utils/desktop.ts
@@ -22,6 +22,8 @@ export interface DesktopBridge {
   signalReady(): void;
   /** Inform main of the signed-in site origin for the external-open allowlist. */
   setSiteOrigin(origin: string): void;
+  /** Show an OS notification via the main process (reliable when window hidden). */
+  notify(title: string, body: string): Promise<void>;
 }
 
 declare global {


### PR DESCRIPTION
## What
Implements **PLATFORM-ADAPTATION.md P1** for the desktop app (plan: AceDataCloud/Index #152). Electron main-process only — low risk, no renderer layout changes.

- **App menu** (`Menu.buildFromTemplate` → appMenu/editMenu/viewMenu/windowMenu): the **Edit role** restores clipboard accelerators (Cmd/Ctrl+C/V/X/A, undo/redo) — these are dead without an app menu and become a prerequisite once chrome is customized.
- **Min window size + backgroundColor** (`minWidth:940/minHeight:600`, `#0b0b0f`): no white flash, header can't be squished.
- **PayPal allowlist**: `paypal.com` added to `PSP_HOSTS` — PayPal checkout `window.open` was silently denied on desktop.
- **OS notifications**: `notify:show` IPC + `window.desktop.notify()` — reliable when the window is hidden/minimized (Web Notification isn't); click refocuses. Type added to `DesktopBridge`.

Deferred to follow-ups (P2/P3): frameless title bar + traffic-light/WCO drag region, tray, window-state memory.

## Test
`compile:electron` (CI) + E2E smoke. All standard Electron APIs.

## 🤖 对抗评审
Plan itself dual-reviewed (Codex + Claude subagent) in Index #152. This PR is the safe P1 subset; CI `build-and-test` + E2E smoke gate it.
