### PR TITLE
feat(desktop): local tool execution foundation (electron/local)

### DIFF
--- a/change/@acedatacloud-nexior-desktop-local-exec.json
+++ b/change/@acedatacloud-nexior-desktop-local-exec.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(desktop): local tool execution foundation (electron/local) — fs/shell/MCP host + consent + registry + IPC, gated to desktop, inert until aichat2 client tools land",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/electron/local/config.ts
+++ b/electron/local/config.ts
@@ -1,0 +1,21 @@
+import { app } from 'electron';
+import fs from 'node:fs';
+import path from 'node:path';
+import type { LocalConfig } from './types';
+
+// Persisted at userData/local-tools.json (0600). Holds the user-authorized
+// root folders for file tools and the local MCP server list.
+const file = (): string => path.join(app.getPath('userData'), 'local-tools.json');
+
+export function load(): LocalConfig {
+  try {
+    const c = JSON.parse(fs.readFileSync(file(), 'utf8')) as Partial<LocalConfig>;
+    return { roots: c.roots ?? [], mcp: c.mcp ?? [] };
+  } catch {
+    return { roots: [], mcp: [] };
+  }
+}
+
+export function save(c: LocalConfig): void {
+  fs.writeFileSync(file(), JSON.stringify(c, null, 2), { mode: 0o600 });
+}

--- a/electron/local/consent.ts
+++ b/electron/local/consent.ts
@@ -1,0 +1,30 @@
+import { dialog, BrowserWindow } from 'electron';
+import type { ToolInvoke } from './types';
+
+// No OS sandbox by design — consent is the control. Reads can be cached per
+// (session,tool,path); mutating tools (write/exec) always re-confirm. The full
+// argv/path is shown untruncated so the dangerous part can't hide.
+const granted = new Set<string>();
+
+function key(inv: ToolInvoke): string {
+  return `${inv.sessionId}:${inv.name}:${JSON.stringify(inv.input)}`;
+}
+
+export async function consentOk(inv: ToolInvoke, win: BrowserWindow | null, mutates: boolean): Promise<boolean> {
+  if (granted.has(key(inv)) && !mutates) return true;
+  const opts = {
+    type: 'warning' as const,
+    buttons: ['Allow once', 'Allow for session', 'Deny'],
+    defaultId: 0,
+    cancelId: 2,
+    message: `Run local tool: ${inv.name}?`,
+    detail: JSON.stringify(inv.input)
+  };
+  const { response } = win ? await dialog.showMessageBox(win, opts) : await dialog.showMessageBox(opts);
+  if (response === 1) granted.add(key(inv));
+  return response !== 2;
+}
+
+export function resetConsent(): void {
+  granted.clear();
+}

--- a/electron/local/fs.ts
+++ b/electron/local/fs.ts
@@ -1,0 +1,61 @@
+import fsp from 'node:fs/promises';
+import { realpathSync } from 'node:fs';
+import path from 'node:path';
+import type { ToolResult } from './types';
+
+// File tools confined to user-authorized roots. Mirrors protocol.ts resolveSafe:
+// separator boundary + realpath defeats symlink / sibling-prefix escape.
+let ROOTS: string[] = [];
+
+export function setRoots(roots: string[]): void {
+  ROOTS = roots
+    .map((p) => {
+      try {
+        return realpathSync(p);
+      } catch {
+        return '';
+      }
+    })
+    .filter(Boolean);
+}
+
+function inRootDir(full: string): boolean {
+  return ROOTS.some((r) => full === r || full.startsWith(r + path.sep));
+}
+
+// For reads/lists: resolve the real file and assert it stays in a root (blocks
+// an in-root symlink pointing outside). For writes: parent must realpath into a
+// root; the new file inherits that boundary.
+function resolveExisting(p: string): string {
+  const real = realpathSync(p);
+  if (!inRootDir(real)) throw new Error('path outside allowed roots');
+  return real;
+}
+function resolveForWrite(p: string): string {
+  let dir: string;
+  try {
+    dir = realpathSync(path.dirname(p));
+  } catch {
+    throw new Error('parent dir missing');
+  }
+  const full = path.join(dir, path.basename(p));
+  if (!inRootDir(full)) throw new Error('path outside allowed roots');
+  return full;
+}
+
+export async function read_file(i: { path: string }): Promise<ToolResult> {
+  return { output: await fsp.readFile(resolveExisting(i.path), 'utf8') };
+}
+
+export async function list_dir(i: { path: string }): Promise<ToolResult> {
+  const entries = await fsp.readdir(resolveExisting(i.path), { withFileTypes: true });
+  return { output: entries.map((d) => (d.isDirectory() ? d.name + '/' : d.name)).join('\n') };
+}
+
+export async function write_file(i: { path: string; content: string }): Promise<ToolResult> {
+  const f = resolveForWrite(i.path);
+  const tmp = f + '.tmp';
+  await fsp.writeFile(tmp, i.content, { flag: 'wx', mode: 0o600 }); // no symlink follow, not world-readable
+  await fsp.rename(tmp, f); // atomic
+  return { output: `wrote ${i.content.length} bytes` };
+}

--- a/electron/local/ipc.ts
+++ b/electron/local/ipc.ts
@@ -1,0 +1,35 @@
+import { ipcMain, BrowserWindow } from 'electron';
+import { APP_ORIGIN } from '../protocol';
+import { consentOk } from './consent';
+import { registry } from './registry';
+import type { ToolInvoke } from './types';
+
+// Only the top-frame app://bundle renderer may drive local execution. Compare
+// parsed origins (not startsWith) so app://bundle.evil can't slip through. A
+// compromised/XSS'd renderer still hits per-tool consent before anything runs.
+function sameOrigin(url: string | undefined): boolean {
+  try {
+    return !!url && new URL(url).origin === new URL(APP_ORIGIN).origin;
+  } catch {
+    return false;
+  }
+}
+
+export function registerLocalExec(getWin: () => BrowserWindow | null): void {
+  const gate = (e: Electron.IpcMainInvokeEvent) => {
+    if (!sameOrigin(e.senderFrame?.url)) throw new Error('local-exec: bad sender origin');
+  };
+
+  ipcMain.handle('local.tools.list', (e) => {
+    gate(e);
+    return registry.specs();
+  });
+
+  ipcMain.handle('local.tool.invoke', async (e, inv: ToolInvoke) => {
+    gate(e);
+    if (!registry.isKnown(inv.name)) return { output: `unknown tool ${inv.name}`, is_error: true };
+    const mutates = inv.name !== 'fs.read_file' && inv.name !== 'fs.list_dir';
+    if (!(await consentOk(inv, getWin(), mutates))) return { output: 'denied by user', is_error: true };
+    return registry.invoke(inv);
+  });
+}

--- a/electron/local/mcp.ts
+++ b/electron/local/mcp.ts
@@ -1,0 +1,79 @@
+import { spawn, ChildProcess } from 'node:child_process';
+import type { McpServerConf, ToolSpec, ToolResult } from './types';
+
+const RPC_TIMEOUT_MS = 30_000;
+
+interface Pending { resolve: (v: unknown) => void; reject: (e: Error) => void; timer: NodeJS.Timeout; }
+
+// Spawns local stdio MCP servers and bridges tools/list + tools/call.
+// Newline-delimited JSON-RPC with partial-line buffering; notifications (no id)
+// are ignored; outstanding calls time out so a wedged server can't hang a turn.
+export class McpHost {
+  private procs = new Map<string, ChildProcess>();
+  private seq = 0;
+  private pending = new Map<number, Pending>();
+
+  async start(c: McpServerConf): Promise<void> {
+    const p = spawn(c.command, c.args, {
+      cwd: c.cwd,
+      env: { ...c.env, PATH: process.env.PATH },
+      stdio: ['pipe', 'pipe', 'inherit']
+    });
+    let buf = '';
+    p.stdout.on('data', (chunk: Buffer) => {
+      buf += chunk.toString();
+      let nl: number;
+      while ((nl = buf.indexOf('\n')) >= 0) {
+        const line = buf.slice(0, nl).trim();
+        buf = buf.slice(nl + 1);
+        if (!line) continue;
+        try {
+          const m = JSON.parse(line) as { id?: number; result?: unknown; error?: unknown };
+          if (m.id == null) continue; // notification
+          const w = this.pending.get(m.id);
+          if (!w) continue;
+          this.pending.delete(m.id);
+          clearTimeout(w.timer);
+          m.error ? w.reject(new Error(JSON.stringify(m.error))) : w.resolve(m.result);
+        } catch {
+          /* skip malformed line */
+        }
+      }
+    });
+    p.on('exit', () => this.procs.delete(c.id));
+    this.procs.set(c.id, p);
+    await this.rpc(c.id, 'initialize', { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'nexior', version: '1' } });
+  }
+
+  private rpc(server: string, method: string, params: unknown): Promise<unknown> {
+    const proc = this.procs.get(server);
+    if (!proc?.stdin) return Promise.reject(new Error(`mcp ${server} not running`));
+    const id = ++this.seq;
+    proc.stdin.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n');
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => { this.pending.delete(id); reject(new Error('mcp rpc timeout')); }, RPC_TIMEOUT_MS);
+      this.pending.set(id, { resolve, reject, timer });
+    });
+  }
+
+  async listTools(server: string): Promise<ToolSpec[]> {
+    const r = (await this.rpc(server, 'tools/list', {})) as { tools?: { name: string; description?: string; inputSchema?: Record<string, unknown> }[] };
+    return (r.tools ?? []).map((t) => ({
+      name: `mcp.${server}.${t.name}`,
+      description: t.description ?? '',
+      input_schema: t.inputSchema ?? {},
+      source: 'mcp' as const,
+      mutates: true
+    }));
+  }
+
+  async call(server: string, tool: string, input: Record<string, unknown>): Promise<ToolResult> {
+    const r = (await this.rpc(server, 'tools/call', { name: tool, arguments: input })) as { content?: unknown; isError?: boolean };
+    return { output: JSON.stringify(r.content ?? ''), is_error: !!r.isError };
+  }
+
+  stopAll(): void {
+    this.procs.forEach((p) => p.kill());
+    this.procs.clear();
+  }
+}

--- a/electron/local/registry.ts
+++ b/electron/local/registry.ts
@@ -1,0 +1,57 @@
+import { McpHost } from './mcp';
+import * as fsTool from './fs';
+import { run_command } from './shell';
+import type { McpServerConf, ToolInvoke, ToolResult, ToolSpec } from './types';
+
+const BUILTIN: ToolSpec[] = [
+  { name: 'fs.read_file', description: 'Read a UTF-8 file inside an authorized root', input_schema: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] }, source: 'builtin', mutates: false },
+  { name: 'fs.list_dir', description: 'List a directory inside an authorized root', input_schema: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] }, source: 'builtin', mutates: false },
+  { name: 'fs.write_file', description: 'Write a file inside an authorized root', input_schema: { type: 'object', properties: { path: { type: 'string' }, content: { type: 'string' } }, required: ['path', 'content'] }, source: 'builtin', mutates: true },
+  { name: 'shell.run_command', description: 'Run a local command (argv form)', input_schema: { type: 'object', properties: { cmd: { type: 'string' }, args: { type: 'array', items: { type: 'string' } }, cwd: { type: 'string' } }, required: ['cmd'] }, source: 'builtin', mutates: true }
+];
+
+class Registry {
+  private host = new McpHost();
+  private mcpSpecs: ToolSpec[] = [];
+  private names = new Set(BUILTIN.map((s) => s.name));
+
+  async boot(servers: McpServerConf[]): Promise<void> {
+    for (const s of servers) {
+      try {
+        await this.host.start(s);
+        const tools = await this.host.listTools(s.id);
+        this.mcpSpecs.push(...tools);
+        tools.forEach((t) => this.names.add(t.name));
+      } catch {
+        /* server failed to start — skip; UI surfaces config errors separately */
+      }
+    }
+  }
+
+  specs(): ToolSpec[] {
+    return [...BUILTIN, ...this.mcpSpecs];
+  }
+
+  isKnown(name: string): boolean {
+    return this.names.has(name);
+  }
+
+  async invoke(inv: ToolInvoke): Promise<ToolResult> {
+    if (!this.isKnown(inv.name)) return { output: `unknown tool ${inv.name}`, is_error: true };
+    if (inv.name.startsWith('mcp.')) {
+      const [, server, tool] = inv.name.split('.');
+      return this.host.call(server, tool, inv.input);
+    }
+    if (inv.name === 'fs.read_file') return fsTool.read_file(inv.input as { path: string });
+    if (inv.name === 'fs.list_dir') return fsTool.list_dir(inv.input as { path: string });
+    if (inv.name === 'fs.write_file') return fsTool.write_file(inv.input as { path: string; content: string });
+    if (inv.name === 'shell.run_command') return run_command(inv.input as { cmd: string; args?: string[]; cwd?: string });
+    return { output: `unhandled tool ${inv.name}`, is_error: true };
+  }
+
+  stop(): void {
+    this.host.stopAll();
+  }
+}
+
+export const registry = new Registry();

--- a/electron/local/shell.ts
+++ b/electron/local/shell.ts
@@ -1,0 +1,21 @@
+import { execFile } from 'node:child_process';
+import type { ToolResult } from './types';
+
+// NO sandbox by design (user's own machine; gated by consent + visibility).
+// execFile with argv (never a shell string) avoids injection; env is an
+// explicit allowlist so local tokens/API keys never leak to AI-run commands.
+export function run_command(i: { cmd: string; args?: string[]; cwd?: string }, timeoutMs = 120_000): Promise<ToolResult> {
+  return new Promise((resolve) => {
+    execFile(
+      i.cmd,
+      i.args ?? [],
+      {
+        cwd: i.cwd,
+        timeout: timeoutMs,
+        maxBuffer: 8_000_000,
+        env: { PATH: process.env.PATH, HOME: process.env.HOME, LANG: process.env.LANG, SystemRoot: process.env.SystemRoot }
+      },
+      (err, stdout, stderr) => resolve({ output: (stdout || '') + (stderr || ''), is_error: !!err })
+    );
+  });
+}

--- a/electron/local/types.ts
+++ b/electron/local/types.ts
@@ -1,0 +1,35 @@
+// Local tool execution types — shared by main-process modules and preload.
+// Desktop-only: lets aichat2 client-side tools run on the user's machine
+// (read/write files, run commands, local MCP), Claude-Desktop style.
+
+export interface ToolSpec {
+  name: string; // 'fs.read_file' | 'shell.run_command' | 'mcp.<server>.<tool>'
+  description: string;
+  input_schema: Record<string, unknown>;
+  source: 'builtin' | 'mcp';
+  mutates: boolean; // write/exec ⇒ always re-confirm
+}
+
+export interface ToolInvoke {
+  name: string;
+  input: Record<string, unknown>;
+  sessionId: string;
+}
+
+export interface ToolResult {
+  output: string;
+  is_error?: boolean;
+}
+
+export interface McpServerConf {
+  id: string;
+  command: string;
+  args: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+}
+
+export interface LocalConfig {
+  roots: string[];
+  mcp: McpServerConf[];
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -3,6 +3,10 @@ import path from 'node:path';
 import { registerAppProtocol, APP_ORIGIN } from './protocol';
 import { issueState, consumeState } from './auth-state';
 import { initUpdater } from './updater';
+import { registerLocalExec } from './local/ipc';
+import { registry } from './local/registry';
+import { setRoots } from './local/fs';
+import { load as loadLocalConfig } from './local/config';
 
 const DESKTOP_SCHEME = 'acedata-desktop';
 
@@ -79,6 +83,11 @@ if (!gotLock) {
     registerAppProtocol.serve();
     createWindow();
     initUpdater(() => mainWindow);
+    // Local tool execution: load authorized roots, boot MCP servers, wire IPC.
+    const localCfg = loadLocalConfig();
+    setRoots(localCfg.roots);
+    void registry.boot(localCfg.mcp);
+    registerLocalExec(() => mainWindow);
     // Windows cold-start protocol activation: URL is in this instance's argv.
     const coldUrl = process.argv.find((a) => a.startsWith(`${DESKTOP_SCHEME}://`));
     if (coldUrl) handleDeepLink(coldUrl);

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -43,3 +43,12 @@ contextBridge.exposeInMainWorld('desktop', {
   // allowed by the external-open / navigation guard (not just acedata.cloud).
   setSiteOrigin: (origin: string): void => ipcRenderer.send('site:setOrigin', origin)
 });
+
+// Local tool execution (desktop only): list authorized local tools and invoke
+// one. Each invoke is gated by main (sender-origin check + per-tool consent).
+contextBridge.exposeInMainWorld('localExec', {
+  available: true,
+  listTools: (): Promise<unknown[]> => ipcRenderer.invoke('local.tools.list'),
+  invoke: (inv: { name: string; input: object; sessionId: string }): Promise<{ output: string; is_error?: boolean }> =>
+    ipcRenderer.invoke('local.tool.invoke', inv)
+});

--- a/src/utils/desktop.ts
+++ b/src/utils/desktop.ts
@@ -27,9 +27,34 @@ export interface DesktopBridge {
 declare global {
   interface Window {
     desktop?: DesktopBridge;
+    localExec?: LocalExecBridge;
   }
 }
 
 export function desktopBridge(): DesktopBridge | undefined {
   return typeof window !== 'undefined' ? window.desktop : undefined;
 }
+
+/**
+ * Local tool execution bridge (desktop only). Lets aichat2 client-side tools
+ * run on the user's machine: list authorized local tools and invoke one. Each
+ * invoke is gated in the main process (sender-origin check + per-tool consent).
+ * `undefined` on web/native — callers must null-check.
+ */
+export interface LocalToolSpec {
+  name: string;
+  description: string;
+  input_schema: Record<string, unknown>;
+  source: 'builtin' | 'mcp';
+  mutates: boolean;
+}
+export interface LocalExecBridge {
+  available: true;
+  listTools(): Promise<LocalToolSpec[]>;
+  invoke(inv: { name: string; input: object; sessionId: string }): Promise<{ output: string; is_error?: boolean }>;
+}
+
+export function localExec(): LocalExecBridge | undefined {
+  return typeof window !== 'undefined' ? window.localExec : undefined;
+}
+


### PR DESCRIPTION
## What

PR 1 of the **desktop local tool execution** feature (plan: `Index plans/nexior-desktop/LOCAL-EXECUTION.md`, merged). Foundation only — the Electron main-process modules that let aichat2 client-side tools run locally (Claude-Desktop style): read/write files, run commands, connect local MCP servers. **No CodingBridge, no sandbox** (user's own machine; gated by consent + visibility).

New `electron/local/`:
- `fs.ts` — read/list/write confined to user-authorized roots (full `realpath`, atomic 0600 write, symlink/parent-ENOENT safe)
- `shell.ts` — `run_command` via `execFile` argv, 120s timeout, scrubbed env (PATH/HOME/LANG/SystemRoot only)
- `mcp.ts` — stdio JSON-RPC MCP host (partial-line buffering, notification skip, per-call timeouts)
- `consent.ts` — per-(session,tool,path) allow; mutating tools always re-confirm; untruncated argv
- `registry.ts` — builtin + MCP tools, **tool-name validation** (trust boundary)
- `ipc.ts` — origin-equality sender gate (blocks `app://bundle.evil`)
- preload `window.localExec` + `main.ts` boot + `src/utils/desktop.ts` types

**Inert today**: nothing fires until aichat2 emits `execution:'client'` (PR 3) and the renderer routes it (PR 2). All gated `isDesktop()`.

## Review
2 rounds Codex + 1 Claude subagent on the design; their code-level findings (full realpath, origin gate, MCP buffering/timeouts, 0600, env scrub, name validation) are applied here. CI `compile:electron` type-checks.
