### PR TITLE
feat(desktop): frameless window chrome (traffic lights / WCO + drag region)

### DIFF
--- a/change/@acedatacloud-nexior-desktop-chrome.json
+++ b/change/@acedatacloud-nexior-desktop-chrome.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(desktop): frameless window chrome — macOS traffic lights / Windows WCO, draggable header (desktop-gated, P2)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -94,12 +94,17 @@ if (!gotLock) {
 }
 
 function createWindow(): void {
+  const isMac = process.platform === 'darwin';
   mainWindow = new BrowserWindow({
     width: 1200,
     height: 800,
-    minWidth: 940,
+    minWidth: 992,
     minHeight: 600,
     backgroundColor: '#0b0b0f', // avoid white flash before the SPA paints
+    // Frameless: macOS keeps inset traffic lights; Win/Linux use Window Controls
+    // Overlay so min/max/close stay native. The web header draws into the bar.
+    titleBarStyle: isMac ? 'hiddenInset' : 'hidden',
+    ...(isMac ? { trafficLightPosition: { x: 16, y: 20 } } : { titleBarOverlay: { color: '#00000000', symbolColor: '#888888', height: 64 } }),
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,

--- a/src/components/common/TopHeader.vue
+++ b/src/components/common/TopHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <el-row class="header">
+  <el-row class="header" :class="{ 'desktop-chrome': isDesktopChrome, 'is-mac': isMacChrome }">
     <el-col :md="4" :xs="24" class="brand-col">
       <logo @click="onHome" />
     </el-col>
@@ -74,7 +74,7 @@ import { ROUTE_AUTH_LOGIN, ROUTE_CONSOLE_ROOT, ROUTE_DOWNLOAD, ROUTE_INDEX } fro
 import { ElCol, ElRow, ElDropdown, ElMenu, ElSubMenu, ElMenuItem, ElDropdownItem, ElButton } from 'element-plus';
 import Logo from './Logo.vue';
 import { Browser } from '@capacitor/browser';
-import { isNative } from '@/utils/surface';
+import { isNative, isDesktop, isMacOS } from '@/utils/surface';
 
 export default defineComponent({
   name: 'TopHeader',
@@ -110,6 +110,14 @@ export default defineComponent({
     },
     authenticated() {
       return this.$store.getters?.authenticated;
+    },
+    // Frameless desktop: make the header a drag handle; macOS needs left inset
+    // so the logo clears the traffic lights.
+    isDesktopChrome() {
+      return isDesktop();
+    },
+    isMacChrome() {
+      return isDesktop() && isMacOS();
     }
   },
   methods: {
@@ -187,6 +195,19 @@ $height: 64px;
     justify-content: flex-end;
     min-height: $height;
     padding-right: 20px;
+  }
+
+  // Frameless desktop: the bar is the window drag handle; interactive children
+  // opt out. macOS insets the brand col past the traffic lights.
+  &.desktop-chrome {
+    -webkit-app-region: drag;
+    a, button, .el-menu, .el-dropdown, .avatar, .console,
+    .locale, language-selector, dark-selector, .el-switch, [role='button'] {
+      -webkit-app-region: no-drag;
+    }
+  }
+  &.is-mac .brand-col {
+    padding-left: 78px;
   }
 
   .el-menu.menu {


### PR DESCRIPTION
## What (PLATFORM-ADAPTATION.md P2 — Index #152)
Frameless desktop window chrome, **gated to `isDesktop()`** (web/iOS/Android untouched):
- **macOS**: `titleBarStyle: 'hiddenInset'` + `trafficLightPosition {16,20}`; `.is-mac .brand-col` left-inset 78px so the logo clears the traffic lights.
- **Windows/Linux**: `titleBarStyle: 'hidden'` + Window Controls Overlay (64px) so min/max/close stay native.
- Header becomes the drag handle; all interactive children (menu, login, language/dark selectors, switches, avatar/dropdown, console) are `no-drag`.
- `minWidth` 992 (Element Plus `md`) so the header never wraps under the overlay.

## Verify
Renderer `vue-tsc -b` builds clean; CI E2E smoke boots real Electron over `app://bundle`. (Local pixel test blocked: electron binary not installed in this checkout.)

## 🤖 对抗评审
Codex: CHANGES REQUESTED → fixed both — broadened no-drag to language/dark selectors + `.el-switch`/`[role=button]`; minWidth 940→992. Mac inset/transparent overlay/desktop-gating = NONE.
