### PR TITLE
feat(desktop): renderer client-tool routing + local config IPC

### DIFF
--- a/change/@acedatacloud-nexior-desktop-local-exec-ui.json
+++ b/change/@acedatacloud-nexior-desktop-local-exec-ui.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(desktop): renderer client-tool routing + local config IPC — inject local tools into aichat2 chat, run execution:'client' tools locally and resume via tool_results (desktop only)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/electron/local/ipc.ts
+++ b/electron/local/ipc.ts
@@ -1,8 +1,10 @@
-import { ipcMain, BrowserWindow } from 'electron';
+import { ipcMain, BrowserWindow, dialog } from 'electron';
 import { APP_ORIGIN } from '../protocol';
 import { consentOk } from './consent';
 import { registry } from './registry';
-import type { ToolInvoke } from './types';
+import { load, save } from './config';
+import { setRoots } from './fs';
+import type { LocalConfig, ToolInvoke } from './types';
 
 // Only the top-frame app://bundle renderer may drive local execution. Compare
 // parsed origins (not startsWith) so app://bundle.evil can't slip through. A
@@ -31,5 +33,22 @@ export function registerLocalExec(getWin: () => BrowserWindow | null): void {
     const mutates = inv.name !== 'fs.read_file' && inv.name !== 'fs.list_dir';
     if (!(await consentOk(inv, getWin(), mutates))) return { output: 'denied by user', is_error: true };
     return registry.invoke(inv);
+  });
+
+  ipcMain.handle('local.config.get', (e) => {
+    gate(e);
+    return load();
+  });
+  ipcMain.handle('local.config.save', (e, cfg: LocalConfig) => {
+    gate(e);
+    save(cfg);
+    setRoots(cfg.roots); // hot-apply roots; MCP server changes apply next launch
+    return true;
+  });
+  ipcMain.handle('local.pickFolder', async (e) => {
+    gate(e);
+    const win = getWin();
+    const r = win ? await dialog.showOpenDialog(win, { properties: ['openDirectory'] }) : await dialog.showOpenDialog({ properties: ['openDirectory'] });
+    return r.canceled ? null : r.filePaths[0];
   });
 }

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -54,5 +54,8 @@ contextBridge.exposeInMainWorld('localExec', {
   available: true,
   listTools: (): Promise<unknown[]> => ipcRenderer.invoke('local.tools.list'),
   invoke: (inv: { name: string; input: object; sessionId: string }): Promise<{ output: string; is_error?: boolean }> =>
-    ipcRenderer.invoke('local.tool.invoke', inv)
+    ipcRenderer.invoke('local.tool.invoke', inv),
+  getConfig: (): Promise<{ roots: string[]; mcp: object[] }> => ipcRenderer.invoke('local.config.get'),
+  saveConfig: (cfg: { roots: string[]; mcp: object[] }): Promise<boolean> => ipcRenderer.invoke('local.config.save', cfg),
+  pickFolder: (): Promise<string | null> => ipcRenderer.invoke('local.pickFolder')
 });

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -306,6 +306,8 @@ export interface IChatConversationResponse {
   tool_id?: string;
   tool_name?: string;
   tool_display_name?: string;
+  // 'client' ⇒ desktop runs this tool locally; worker pauses awaiting tool_results.
+  execution?: 'client' | 'server';
   input?: Record<string, unknown>;
   output?: string;
   is_error?: boolean;

--- a/src/operators/chat.ts
+++ b/src/operators/chat.ts
@@ -105,6 +105,7 @@ class ChatOperator {
                     tool_id: json.tool_id,
                     tool_name: json.tool_name,
                     tool_display_name: json.tool_display_name,
+                    execution: json.execution,
                     input: json.input,
                     output: json.output,
                     is_error: json.is_error,

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -83,6 +83,8 @@ import Disclaimer from '@/components/chat/Disclaimer.vue';
 import ConnectorStrip from '@/components/chat/ConnectorStrip.vue';
 import Layout from '@/layouts/Chat.vue';
 import { isImageUrl } from '@/utils/is';
+import { isDesktop } from '@/utils/surface';
+import { localExec } from '@/utils/desktop';
 import { IAskUserQuestionPayload, IChatMessageContentItem, IConsentRequestPayload } from '@/models';
 import {
   buildAuthorizedConsentOutput,
@@ -128,6 +130,8 @@ export interface IData {
    * pending return (the common case).
    */
   pendingConsentReturn: IConsentReturn | null;
+  localToolSpecs: string[];
+  localMcpServers: string[];
 }
 
 export default defineComponent({
@@ -150,6 +154,8 @@ export default defineComponent({
       drawer: false,
       question: '',
       references: [],
+      localToolSpecs: [],
+      localMcpServers: [],
       upload: false,
       answering: false,
       canceler: undefined,
@@ -282,6 +288,11 @@ export default defineComponent({
     await this.onGetApplication();
     this.onConsumePendingDraft();
     this.onApplyQueryFromUrl();
+    if (isDesktop()) {
+      const specs = (await localExec()?.listTools()) ?? [];
+      this.localToolSpecs = specs.map((s) => s.name);
+      this.localMcpServers = specs.filter((s) => s.source === 'mcp').map((s) => s.name);
+    }
   },
   methods: {
     resetConversation() {
@@ -662,7 +673,8 @@ export default defineComponent({
           model: this.model.name,
           references,
           id: this.conversationId,
-          stateful: true
+          stateful: true,
+          ...this._localToolInjection()
         },
         token,
         conversationId
@@ -714,6 +726,19 @@ export default defineComponent({
         token,
         this.conversationId
       );
+    },
+    /** Inject desktop local tools into the chat request (no-op on web). */
+    _localToolInjection(): { mcp_servers?: string[]; tools_filter?: string[] } {
+      if (!isDesktop() || !this.localToolSpecs.length) return {};
+      return { mcp_servers: this.localMcpServers, tools_filter: this.localToolSpecs };
+    },
+    /** Run a client-executed tool locally, then resume the turn via tool_results. */
+    async _runClientTool(toolId: string, name: string, input: Record<string, unknown>) {
+      const r = (await localExec()?.invoke({ name, input, sessionId: this.conversationId || '' })) ?? {
+        output: 'local execution unavailable',
+        is_error: true
+      };
+      this.onAnswerAskUserQuestion({ tool_use_id: toolId, output: r.output });
     },
     /**
      * Visual-only "skip" of an ask_user_question card. Marks the pending
@@ -919,6 +944,11 @@ export default defineComponent({
               };
               contentParts.push(toolItem);
               toolMap.set(response.tool_id, toolItem);
+              // Desktop: run client-executed tools locally, then resume the turn.
+              if (isDesktop() && response.execution === 'client') {
+                toolItem.status = 'awaiting_input';
+                void this._runClientTool(response.tool_id, response.tool_name || '', response.input || {});
+              }
             } else if (response.type === 'tool_result' && response.tool_id) {
               const toolItem = toolMap.get(response.tool_id);
               if (toolItem) {

--- a/src/utils/desktop.ts
+++ b/src/utils/desktop.ts
@@ -54,6 +54,9 @@ export interface LocalExecBridge {
   available: true;
   listTools(): Promise<LocalToolSpec[]>;
   invoke(inv: { name: string; input: object; sessionId: string }): Promise<{ output: string; is_error?: boolean }>;
+  getConfig(): Promise<{ roots: string[]; mcp: { id: string; command: string; args: string[] }[] }>;
+  saveConfig(cfg: { roots: string[]; mcp: { id: string; command: string; args: string[] }[] }): Promise<boolean>;
+  pickFolder(): Promise<string | null>;
 }
 
 export function localExec(): LocalExecBridge | undefined {


### PR DESCRIPTION
PR2 of local execution. Desktop injects local tools into aichat2; runs execution:'client' tools via window.localExec, resumes via tool_results. Config IPC (get/save/pickFolder). Inert until aichat2 backend PR3. Stacks on #1069.