### PR TITLE
fix(desktop): brand dock icon on dev runs

### DIFF
--- a/change/@acedatacloud-nexior-dev-dock-icon.json
+++ b/change/@acedatacloud-nexior-dev-dock-icon.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(desktop): set AceData dock icon for dev runs (packaged DMG already branded; `electron .` showed default Electron icon)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -81,6 +81,15 @@ if (!gotLock) {
 
   app.whenReady().then(() => {
     registerAppProtocol.serve();
+    // Dev runs (`electron .`) show the default Electron icon in the Dock; the
+    // packaged DMG uses build/icon.icns. Set the brand icon for dev too.
+    if (!app.isPackaged && process.platform === 'darwin') {
+      try {
+        app.dock?.setIcon(path.join(__dirname, '..', '..', 'build', 'icon.png'));
+      } catch {
+        /* dev-only cosmetic; ignore if asset missing */
+      }
+    }
     createWindow();
     setupAppMenu();
     initUpdater(() => mainWindow);


### PR DESCRIPTION
Dev electron . showed the default Electron atom in the Dock; set app.dock.setIcon(build/icon.png) when !isPackaged on macOS. Packaged DMG already uses build/icon.icns.