### PR TITLE
feat(desktop): local-tools settings page

### DIFF
--- a/change/@acedatacloud-nexior-localtools-settings.json
+++ b/change/@acedatacloud-nexior-localtools-settings.json
@@ -1,0 +1,7 @@
+{
+  "type":"patch",
+  "comment":"feat(desktop): settings/local-tools page — authorize root folders for local tools",
+  "packageName":"@acedatacloud/nexior",
+  "email":"dev@acedata.cloud",
+  "dependentChangeType":"patch"
+}

--- a/src/pages/settings/LocalTools.vue
+++ b/src/pages/settings/LocalTools.vue
@@ -1,0 +1,77 @@
+<template>
+  <div class="local-tools">
+    <h2>Local Tools</h2>
+    <p v-if="!desktop" class="muted">Desktop app only.</p>
+    <template v-else>
+      <p class="muted">Authorize folders the AI may read/write locally. Tools execute on this machine.</p>
+      <el-button size="small" type="primary" @click="addFolder">Add folder</el-button>
+      <ul class="roots">
+        <li v-for="(r, i) in roots" :key="r">
+          <span>{{ r }}</span>
+          <el-button size="small" text @click="removeRoot(i)">remove</el-button>
+        </li>
+        <li v-if="!roots.length" class="muted">No folders yet.</li>
+      </ul>
+      <el-button size="small" :loading="saving" @click="save">Save</el-button>
+      <p v-if="tools.length" class="muted">Tools: {{ tools.join(', ') }}</p>
+    </template>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElButton } from 'element-plus';
+import { localExec } from '@/utils/desktop';
+
+export default defineComponent({
+  name: 'SettingsLocalTools',
+  components: { ElButton },
+  data() {
+    return { roots: [] as string[], tools: [] as string[], saving: false };
+  },
+  computed: {
+    desktop(): boolean {
+      return !!localExec();
+    }
+  },
+  async mounted() {
+    const ex = localExec();
+    if (!ex) return;
+    this.roots = (await ex.getConfig()).roots;
+    this.tools = (await ex.listTools()).map((t) => t.name);
+  },
+  methods: {
+    async addFolder() {
+      const p = await localExec()?.pickFolder();
+      if (p && !this.roots.includes(p)) this.roots.push(p);
+    },
+    removeRoot(i: number) {
+      this.roots.splice(i, 1);
+    },
+    async save() {
+      this.saving = true;
+      await localExec()?.saveConfig({ roots: this.roots, mcp: [] });
+      this.saving = false;
+    }
+  }
+});
+</script>
+
+<style scoped>
+.local-tools {
+  padding: 24px;
+}
+.muted {
+  color: #888;
+  font-size: 13px;
+}
+.roots {
+  list-style: none;
+  padding: 0;
+}
+.roots li {
+  display: flex;
+  justify-content: space-between;
+  padding: 4px 0;
+}
+</style>

--- a/src/router/constants.ts
+++ b/src/router/constants.ts
@@ -5,6 +5,7 @@ export const ROUTE_AUTH_LOGIN = 'auth-login';
 export const ROUTE_AUTH_CALLBACK = 'auth-callback';
 
 export const ROUTE_SETTINGS_INDEX = 'settings-index';
+export const ROUTE_SETTINGS_LOCAL_TOOLS = 'settings-local-tools';
 
 export const ROUTE_CHATGPT_CONVERSATION = 'chatgpt-conversation';
 export const ROUTE_CHATGPT_CONVERSATION_NEW = 'chatgpt-conversation-new';

--- a/src/router/settings.ts
+++ b/src/router/settings.ts
@@ -1,4 +1,4 @@
-import { ROUTE_SETTINGS_INDEX } from './constants';
+import { ROUTE_SETTINGS_INDEX, ROUTE_SETTINGS_LOCAL_TOOLS } from './constants';
 
 export default {
   path: '/settings',
@@ -8,6 +8,11 @@ export default {
       path: '',
       name: ROUTE_SETTINGS_INDEX,
       component: () => import('@/pages/settings/Index.vue')
+    },
+    {
+      path: 'local-tools',
+      name: ROUTE_SETTINGS_LOCAL_TOOLS,
+      component: () => import('@/pages/settings/LocalTools.vue')
     }
   ]
 };


### PR DESCRIPTION
/settings/local-tools to authorize root folders for desktop local tools. Completes local-execution UX.