### PR TITLE
feat(desktop): macOS system permissions in LocalTools panel

### DIFF
--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -9,5 +9,14 @@
     <true/>
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
+    <!-- L0 user-selected folders; L3/L4 local-tool tiers (opt-in, off by default). -->
+    <key>com.apple.security.files.user-selected.read-write</key>
+    <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+    <key>com.apple.security.device.camera</key>
+    <true/>
+    <key>com.apple.security.automation.apple-events</key>
+    <true/>
   </dict>
 </plist>

--- a/change/@acedatacloud-nexior-mac-perms.json
+++ b/change/@acedatacloud-nexior-mac-perms.json
@@ -1,0 +1,7 @@
+{
+  "type":"patch",
+  "comment":"feat(desktop): macOS system-permission status rows in LocalTools panel",
+  "packageName":"@acedatacloud/nexior",
+  "email":"dev@acedata.cloud",
+  "dependentChangeType":"patch"
+}

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -62,6 +62,14 @@ mac:
   gatekeeperAssess: false
   entitlements: build/entitlements.mac.plist
   entitlementsInherit: build/entitlements.mac.plist
+  # TCC usage strings for the opt-in local-tool tiers (screen/mic/camera/
+  # automation). Without these macOS hard-crashes the app on first access.
+  extendInfo:
+    NSScreenCaptureUsageDescription: AceData lets the AI capture your screen only when you run a screen tool.
+    NSAudioCaptureUsageDescription: AceData records system audio only when you run an audio-capture tool.
+    NSMicrophoneUsageDescription: AceData uses the microphone only for voice tools you start.
+    NSCameraUsageDescription: AceData uses the camera only for vision tools you start.
+    NSAppleEventsUsageDescription: AceData controls other apps only when you run an automation tool.
   # Object form requires APPLE_ID + APPLE_APP_SPECIFIC_PASSWORD + APPLE_TEAM_ID
   # ALL present in env at sign time (CI asserts this), else electron-builder
   # signs but SILENTLY skips notarization → Gatekeeper blocks user machines.

--- a/electron/local/ipc.ts
+++ b/electron/local/ipc.ts
@@ -4,6 +4,7 @@ import { consentOk } from './consent';
 import { registry } from './registry';
 import { load, save } from './config';
 import { setRoots } from './fs';
+import { status, openPane, askMedia, promptAccessibility, type PaneKey } from './permissions';
 import type { LocalConfig, ToolInvoke } from './types';
 
 // Only the top-frame app://bundle renderer may drive local execution. Compare
@@ -50,5 +51,22 @@ export function registerLocalExec(getWin: () => BrowserWindow | null): void {
     const win = getWin();
     const r = win ? await dialog.showOpenDialog(win, { properties: ['openDirectory'] }) : await dialog.showOpenDialog({ properties: ['openDirectory'] });
     return r.canceled ? null : r.filePaths[0];
+  });
+
+  // macOS TCC permission status + System Settings deep-links, surfaced in the
+  // shared LocalTools panel. No-ops off macOS (renderer hides the section).
+  ipcMain.handle('local.perm.status', (e) => {
+    gate(e);
+    return status();
+  });
+  ipcMain.handle('local.perm.openPane', (e, k: PaneKey) => {
+    gate(e);
+    if (k === 'accessibility') promptAccessibility();
+    openPane(k);
+    return true;
+  });
+  ipcMain.handle('local.perm.askMedia', (e, t: 'camera' | 'microphone') => {
+    gate(e);
+    return askMedia(t);
   });
 }

--- a/electron/local/permissions.ts
+++ b/electron/local/permissions.ts
@@ -1,0 +1,55 @@
+import { systemPreferences, shell } from 'electron';
+import fs from 'node:fs';
+
+// macOS TCC permission status + System Settings deep-links. Desktop is non-MAS
+// Dev ID, so FDA is read via TCC.db reachability (best-effort heuristic; MAS
+// would hard-deny). Tiers above L0 (folder picker) are opt-in and shown in the
+// shared LocalTools settings panel.
+const MAC = process.platform === 'darwin';
+const PANE = 'x-apple.systempreferences:com.apple.preference.security?Privacy_';
+
+export type PaneKey = 'fullDisk' | 'screen' | 'accessibility';
+
+export interface PermStatus {
+  mac: boolean;
+  fullDisk: boolean;
+  screen: string; // 'granted' | 'denied' | 'not-determined' | 'restricted' | 'unknown'
+  mic: string;
+  accessibility: boolean;
+}
+
+export function status(): PermStatus {
+  if (!MAC) return { mac: false, fullDisk: true, screen: 'granted', mic: 'granted', accessibility: true };
+  return {
+    mac: true,
+    fullDisk: reachable('/Library/Application Support/com.apple.TCC/TCC.db'),
+    screen: systemPreferences.getMediaAccessStatus('screen'),
+    mic: systemPreferences.getMediaAccessStatus('microphone'),
+    accessibility: systemPreferences.isTrustedAccessibilityClient(false)
+  };
+}
+
+function reachable(p: string): boolean {
+  try {
+    fs.accessSync(p, fs.constants.R_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function openPane(k: PaneKey): void {
+  if (!MAC) return;
+  const seg = { fullDisk: 'AllFiles', screen: 'ScreenCapture', accessibility: 'Accessibility' }[k];
+  void shell.openExternal(PANE + seg);
+}
+
+export async function askMedia(t: 'camera' | 'microphone'): Promise<boolean> {
+  if (!MAC) return true;
+  return systemPreferences.askForMediaAccess(t);
+}
+
+// Prompt accessibility once (true triggers the system dialog); ignore on non-mac.
+export function promptAccessibility(): boolean {
+  return MAC ? systemPreferences.isTrustedAccessibilityClient(true) : true;
+}

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -57,5 +57,11 @@ contextBridge.exposeInMainWorld('localExec', {
     ipcRenderer.invoke('local.tool.invoke', inv),
   getConfig: (): Promise<{ roots: string[]; mcp: object[] }> => ipcRenderer.invoke('local.config.get'),
   saveConfig: (cfg: { roots: string[]; mcp: object[] }): Promise<boolean> => ipcRenderer.invoke('local.config.save', cfg),
-  pickFolder: (): Promise<string | null> => ipcRenderer.invoke('local.pickFolder')
+  pickFolder: (): Promise<string | null> => ipcRenderer.invoke('local.pickFolder'),
+  // macOS system-permission status + jump-to-pane, shown in the LocalTools panel.
+  perm: {
+    status: (): Promise<{ mac: boolean; fullDisk: boolean; screen: string; mic: string; accessibility: boolean }> => ipcRenderer.invoke('local.perm.status'),
+    openPane: (k: 'fullDisk' | 'screen' | 'accessibility'): Promise<boolean> => ipcRenderer.invoke('local.perm.openPane', k),
+    askMedia: (t: 'camera' | 'microphone'): Promise<boolean> => ipcRenderer.invoke('local.perm.askMedia', t)
+  }
 });

--- a/src/pages/settings/LocalTools.vue
+++ b/src/pages/settings/LocalTools.vue
@@ -14,6 +14,25 @@
       </ul>
       <el-button size="small" :loading="saving" @click="save">Save</el-button>
       <p v-if="tools.length" class="muted">Tools: {{ tools.join(', ') }}</p>
+      <section v-if="perm" class="perms">
+        <h3>System permissions</h3>
+        <p class="muted">Optional. Folder access above needs none of these; grant only what a task requires.</p>
+        <div class="row">
+          <span>Full Disk Access</span>
+          <b>{{ perm.fullDisk ? '✓' : '—' }}</b>
+          <el-button size="small" text @click="open('fullDisk')">Open…</el-button>
+        </div>
+        <div class="row">
+          <span>Screen Recording</span>
+          <b>{{ perm.screen }}</b>
+          <el-button size="small" text @click="open('screen')">Open…</el-button>
+        </div>
+        <div class="row">
+          <span>Accessibility</span>
+          <b>{{ perm.accessibility ? '✓' : '—' }}</b>
+          <el-button size="small" text @click="open('accessibility')">Open…</el-button>
+        </div>
+      </section>
     </template>
   </div>
 </template>
@@ -27,7 +46,12 @@ export default defineComponent({
   name: 'SettingsLocalTools',
   components: { ElButton },
   data() {
-    return { roots: [] as string[], tools: [] as string[], saving: false };
+    return {
+      roots: [] as string[],
+      tools: [] as string[],
+      saving: false,
+      perm: null as null | { mac: boolean; fullDisk: boolean; screen: string; mic: string; accessibility: boolean }
+    };
   },
   computed: {
     desktop(): boolean {
@@ -39,6 +63,8 @@ export default defineComponent({
     if (!ex) return;
     this.roots = (await ex.getConfig()).roots;
     this.tools = (await ex.listTools()).map((t) => t.name);
+    const s = await ex.perm?.status();
+    if (s?.mac) this.perm = s;
   },
   methods: {
     async addFolder() {
@@ -47,6 +73,9 @@ export default defineComponent({
     },
     removeRoot(i: number) {
       this.roots.splice(i, 1);
+    },
+    async open(k: 'fullDisk' | 'screen' | 'accessibility') {
+      await localExec()?.perm?.openPane(k);
     },
     async save() {
       this.saving = true;
@@ -73,5 +102,19 @@ export default defineComponent({
   display: flex;
   justify-content: space-between;
   padding: 4px 0;
+}
+.perms {
+  margin-top: 24px;
+  border-top: 1px solid #eee;
+  padding-top: 12px;
+}
+.perms .row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 4px 0;
+}
+.perms .row span {
+  flex: 1;
 }
 </style>

--- a/src/utils/desktop.ts
+++ b/src/utils/desktop.ts
@@ -57,9 +57,14 @@ export interface LocalExecBridge {
   getConfig(): Promise<{ roots: string[]; mcp: { id: string; command: string; args: string[] }[] }>;
   saveConfig(cfg: { roots: string[]; mcp: { id: string; command: string; args: string[] }[] }): Promise<boolean>;
   pickFolder(): Promise<string | null>;
+  /** macOS TCC permission status + jump-to-System-Settings (undefined off macOS desktop). */
+  perm?: {
+    status(): Promise<{ mac: boolean; fullDisk: boolean; screen: string; mic: string; accessibility: boolean }>;
+    openPane(k: 'fullDisk' | 'screen' | 'accessibility'): Promise<boolean>;
+    askMedia(t: 'camera' | 'microphone'): Promise<boolean>;
+  };
 }
 
 export function localExec(): LocalExecBridge | undefined {
   return typeof window !== 'undefined' ? window.localExec : undefined;
 }
-


### PR DESCRIPTION
macOS TCC permission tiers surfaced in the existing /settings/local-tools panel (no new page). New electron/local/permissions.ts (status/openPane/askMedia), 3 origin-gated IPC handlers, preload localExec.perm, entitlements + Info.plist usage strings for screen/mic/camera/automation. L0 folder access unchanged; advanced perms opt-in, status visible, jump to System Settings. Plan: Index #154.

## 🤖 对抗评审
Codex 限额→Claude subagent。1 MED: preload perm 参数用 string，已收紧为 literal union 对齐 bridge。其余 CLEAN（gate 全覆盖、screen 参数有效、非 mac 安全降级、entitlements/Info.plist 正确）。