### PR TITLE
fix(download): align Android & iOS card CTAs

### DIFF
--- a/change/@acedatacloud-nexior-3de297ee-6b06-4610-8f80-23c11173f3be.json
+++ b/change/@acedatacloud-nexior-3de297ee-6b06-4610-8f80-23c11173f3be.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix download card CTA alignment",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/pages/download/Index.vue
+++ b/src/pages/download/Index.vue
@@ -524,6 +524,7 @@ export default defineComponent({
 
 .platform__text {
   margin: 0 0 22px;
+  min-height: 51px;
   font-size: 15px;
   line-height: 1.7;
   color: var(--el-text-color-regular);
@@ -584,7 +585,6 @@ export default defineComponent({
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  margin-top: auto;
 }
 
 .platform__foot--stack {


### PR DESCRIPTION
Cards bottom-pinned their footers, so Android (Play + APK ghost + meta = 3 rows) pushed the Google Play button higher while iOS (single App Store button) sat at the very bottom — primary CTAs were misaligned. Top-align footers + equalize description min-height so QR codes and primary buttons line up. CSS-only.