### PR TITLE
fix(nanobanana): honor resolution for nano-banana-2

### DIFF
--- a/change/@acedatacloud-nexior-nanobanana-resolution-nb2.json
+++ b/change/@acedatacloud-nexior-nanobanana-resolution-nb2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(nanobanana): honor resolution for nano-banana-2",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/i18n/en/nanobanana.json
+++ b/src/i18n/en/nanobanana.json
@@ -56,8 +56,8 @@
     "description": "Resolution of the generated image"
   },
   "description.resolutionProOnly": {
-    "message": "Resolution settings are only supported for nano-banana-pro.",
-    "description": "Resolution options are effective only for pro models"
+    "message": "Resolution settings are supported by nano-banana-2 and nano-banana-pro.",
+    "description": "Resolution options are effective only for nano-banana-2 and pro models"
   },
   "description.prompt": {
     "message": "Prompt for generating or editing images",

--- a/src/i18n/zh-CN/nanobanana.json
+++ b/src/i18n/zh-CN/nanobanana.json
@@ -56,8 +56,8 @@
     "description": "生成图像的分辨率"
   },
   "description.resolutionProOnly": {
-    "message": "仅 nano-banana-pro 支持分辨率设置。",
-    "description": "分辨率选项仅对 pro 模型生效"
+    "message": "nano-banana-2 和 nano-banana-pro 支持分辨率设置。",
+    "description": "分辨率选项仅对 nano-banana-2 和 pro 模型生效"
   },
   "description.prompt": {
     "message": "生成或编辑图像的提示词",

--- a/src/pages/nanobanana/Index.vue
+++ b/src/pages/nanobanana/Index.vue
@@ -17,7 +17,7 @@ import { nanobananaOperator } from '@/operators';
 import { instrumentGeneration } from '@/plugins/telemetry';
 import { INanobananaGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
-import { ERROR_CODE_USED_UP, NANOBANANA_DEFAULT_RESOLUTION, NANOBANANA_MODEL_NANO_BANANA_PRO } from '@/constants';
+import { ERROR_CODE_USED_UP, NANOBANANA_DEFAULT_RESOLUTION, NANOBANANA_MODEL_NANO_BANANA } from '@/constants';
 import RecentPanel from '@/components/nanobanana/RecentPanel.vue';
 import { INanobananaTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
@@ -158,10 +158,11 @@ export default defineComponent({
       if (!cfg?.aspect_ratio) {
         delete cfg.aspect_ratio;
       }
-      if (cfg?.model !== NANOBANANA_MODEL_NANO_BANANA_PRO && 'resolution' in cfg) {
+      // Resolution (1K/2K/4K) is supported by nano-banana-2 and nano-banana-pro; base nano-banana is 1K only.
+      if (cfg?.model === NANOBANANA_MODEL_NANO_BANANA && 'resolution' in cfg) {
         delete cfg.resolution;
       }
-      if (cfg?.model === NANOBANANA_MODEL_NANO_BANANA_PRO && !cfg?.resolution) {
+      if (cfg?.model !== NANOBANANA_MODEL_NANO_BANANA && !cfg?.resolution) {
         cfg.resolution = NANOBANANA_DEFAULT_RESOLUTION;
       }
       const request = {


### PR DESCRIPTION
## Summary
The resolution selector was enabled for both `nano-banana-2` and `nano-banana-pro` (`isProModel = model !== 'nano-banana'`) and the upstream worker honors 1K/2K/4K for both — but `onGenerate` stripped `resolution` for every model except `nano-banana-pro`, so nano-banana-2 silently dropped the selected resolution. Tooltip also wrongly said pro-only.

## Fix
- Index.vue: drop `resolution` only for base `nano-banana`; default it for any non-base model (nb2 + pro).
- en/zh-CN copy: resolution is supported by nano-banana-2 and nano-banana-pro.

## 🤖 对抗评审
Codex: found resolution stripped for nb2 (RISK) + stale non-en/zh-CN locales (RISK, rebutted per Nexior i18n policy). Fix applied → re-review VERDICT: CLEAN.