### PR TITLE
fix(desktop): make local tools run on the user's machine (Proxy clone + ~ expansion)

### DIFF
--- a/change/@acedatacloud-nexior-local-tools-clone.json
+++ b/change/@acedatacloud-nexior-local-tools-clone.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(desktop): deep-copy local tool input before IPC so it isn't a Vue reactive Proxy ('An object could not be cloned')",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/electron/local/fs.ts
+++ b/electron/local/fs.ts
@@ -1,5 +1,6 @@
 import fsp from 'node:fs/promises';
 import { realpathSync } from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import type { ToolResult } from './types';
 
@@ -23,22 +24,32 @@ function inRootDir(full: string): boolean {
   return ROOTS.some((r) => full === r || full.startsWith(r + path.sep));
 }
 
+// Models commonly pass `~/Desktop`; Node never expands `~`, so realpathSync
+// would walk a literal `/~` and ENOENT. Expand a leading `~`/`~/` to the home
+// dir (which is typically what an authorized root sits under).
+function expandHome(p: string): string {
+  if (p === '~') return os.homedir();
+  if (p.startsWith('~/') || p.startsWith('~\\')) return path.join(os.homedir(), p.slice(2));
+  return p;
+}
+
 // For reads/lists: resolve the real file and assert it stays in a root (blocks
 // an in-root symlink pointing outside). For writes: parent must realpath into a
 // root; the new file inherits that boundary.
 function resolveExisting(p: string): string {
-  const real = realpathSync(p);
+  const real = realpathSync(expandHome(p));
   if (!inRootDir(real)) throw new Error('path outside allowed roots');
   return real;
 }
 function resolveForWrite(p: string): string {
+  const expanded = expandHome(p);
   let dir: string;
   try {
-    dir = realpathSync(path.dirname(p));
+    dir = realpathSync(path.dirname(expanded));
   } catch {
     throw new Error('parent dir missing');
   }
-  const full = path.join(dir, path.basename(p));
+  const full = path.join(dir, path.basename(expanded));
   if (!inRootDir(full)) throw new Error('path outside allowed roots');
   return full;
 }

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -823,9 +823,19 @@ export default defineComponent({
       // dotted tool name localExec expects (else `unknown tool`).
       const realName = this._wiredTools().find((w) => w.wire === name)?.spec.name ?? name;
       const sessionId = (conversationId ?? this.conversationId) || '';
+      // `input` came from reactive component state (pendingClientTool / message
+      // content), so it's a Vue reactive Proxy. Electron's IPC structured-clone
+      // can't clone a Proxy → "An object could not be cloned". Pass a plain deep
+      // copy (tool inputs are JSON-serializable).
+      let safeInput: Record<string, unknown>;
+      try {
+        safeInput = JSON.parse(JSON.stringify(input ?? {}));
+      } catch {
+        safeInput = {};
+      }
       let r: { output: string; is_error?: boolean };
       try {
-        r = (await localExec()?.invoke({ name: realName, input, sessionId })) ?? {
+        r = (await localExec()?.invoke({ name: realName, input: safeInput, sessionId })) ?? {
           output: 'local execution unavailable',
           is_error: true
         };


### PR DESCRIPTION
## What

Follow-up to #1079. Two bugs blocked the desktop "Local Tools" from running on the user's machine even though the model now correctly calls them:

1. **`An object could not be cloned`** — the model's tool `input` is stored in **reactive** component state (`pendingClientTool` / message content), so it's a **Vue reactive `Proxy`**. `ipcRenderer.invoke({ input })` structured-clone can't clone a `Proxy` → every local tool call failed and the model fell back to the server-side `Bash` sandbox.
2. **`ENOENT: ... lstat '/~'`** — the model passes `~/Desktop`, but Node never expands `~`, so `realpathSync` walked a literal `/~` → ENOENT, and `fs.list_dir` failed even though `/Users/qicu/Desktop` is an authorized root.

## Fix

- **Clone:** `_runClientTool` passes a plain deep copy `JSON.parse(JSON.stringify(input ?? {}))` to `localExec().invoke` (LLM tool args are JSON-serializable → lossless, fully strips the Proxy).
- **`~` expansion:** `electron/local/fs.ts` expands a leading `~`/`~/` to `os.homedir()` before `realpathSync`. **Root confinement is unchanged** — the expanded path still must `realpath` into an authorized root, so `~/Documents` is still rejected unless authorized.

`vue-tsc -b`, `tsc -p electron/tsconfig.json`, and eslint all clean. Verified end-to-end in a locally-built app: consent dialog appears, `fs.list_dir {path:"~/Desktop"}` resolves to the real Desktop and lists files (no more sandbox / clone / ENOENT).

## 🤖 对抗评审 (reviewer: codex — VERDICT: CLEAN on the clone fix)

- Clone fix reviewed CLEAN (JSON round-trip strips proxies more reliably than `toRaw`; only strings + `safeInput` cross IPC). NIT (rebutted): the `catch {}` fallback is unreachable for JSON tool args.
- `~` expansion is a self-contained, security-preserving path normalization (post-expansion root check unchanged).
