### PR TITLE
fix(desktop): deep-copy local tool input before IPC (Proxy clone) + expand ~ in fs paths

### DIFF
--- a/change/@acedatacloud-nexior-7f721334-c82a-489b-878d-21253b394421.json
+++ b/change/@acedatacloud-nexior-7f721334-c82a-489b-878d-21253b394421.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(desktop): deep-copy local tool input before IPC (Proxy clone) + expand ~ in fs paths",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/electron/local/fs.ts
+++ b/electron/local/fs.ts
@@ -1,5 +1,6 @@
 import fsp from 'node:fs/promises';
 import { realpathSync } from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import type { ToolResult } from './types';
 
@@ -23,22 +24,32 @@ function inRootDir(full: string): boolean {
   return ROOTS.some((r) => full === r || full.startsWith(r + path.sep));
 }
 
+// Models commonly pass `~/Desktop`; Node never expands `~`, so realpathSync
+// would walk a literal `/~` and ENOENT. Expand a leading `~`/`~/` to the home
+// dir (which is typically what an authorized root sits under).
+function expandHome(p: string): string {
+  if (p === '~') return os.homedir();
+  if (p.startsWith('~/') || p.startsWith('~\\')) return path.join(os.homedir(), p.slice(2));
+  return p;
+}
+
 // For reads/lists: resolve the real file and assert it stays in a root (blocks
 // an in-root symlink pointing outside). For writes: parent must realpath into a
 // root; the new file inherits that boundary.
 function resolveExisting(p: string): string {
-  const real = realpathSync(p);
+  const real = realpathSync(expandHome(p));
   if (!inRootDir(real)) throw new Error('path outside allowed roots');
   return real;
 }
 function resolveForWrite(p: string): string {
+  const expanded = expandHome(p);
   let dir: string;
   try {
-    dir = realpathSync(path.dirname(p));
+    dir = realpathSync(path.dirname(expanded));
   } catch {
     throw new Error('parent dir missing');
   }
-  const full = path.join(dir, path.basename(p));
+  const full = path.join(dir, path.basename(expanded));
   if (!inRootDir(full)) throw new Error('path outside allowed roots');
   return full;
 }

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -857,9 +857,19 @@ export default defineComponent({
         // The worker echoes the sanitized wire name; map it back to the real
         // dotted tool name localExec expects (else `unknown tool`).
         const realName = this._wiredTools().find((w) => w.wire === p.name)?.spec.name ?? p.name;
+        // `p.input` came from reactive component state (pendingClientTools /
+        // message content), so it's a Vue reactive Proxy. Electron's IPC
+        // structured-clone can't clone a Proxy → "An object could not be
+        // cloned". Pass a plain deep copy (tool inputs are JSON-serializable).
+        let safeInput: Record<string, unknown>;
+        try {
+          safeInput = JSON.parse(JSON.stringify(p.input ?? {}));
+        } catch {
+          safeInput = {};
+        }
         let r: { output: string; is_error?: boolean };
         try {
-          r = (await localExec()?.invoke({ name: realName, input: p.input, sessionId })) ?? {
+          r = (await localExec()?.invoke({ name: realName, input: safeInput, sessionId })) ?? {
             output: 'local execution unavailable',
             is_error: true
           };


### PR DESCRIPTION
## 问题

桌面 App 里**每个本地工具调用都失败**(见用户截图:`fs.list_dir` → OUTPUT `An object could not be cloned.`)。根因是 PR #1080 的两个修复**从未被合并**(它早于 #1079/#1081 的重构,已 stale),所以 main 里一直缺这两块:

1. **Vue Proxy → IPC clone 错误**:`p.input` 来自响应式组件状态(`pendingClientTools` / 消息内容),是 Vue reactive Proxy。Electron contextBridge 的 structured-clone 无法克隆 Proxy → `localExec().invoke({input})` 抛 `An object could not be cloned`,工具把它当错误输出返回。
2. **`~` 未展开**:模型常传 `~/Desktop`,但 Node 不展开 `~`,`realpathSync` 会去走字面量 `/~` → ENOENT。

## 修复

- `src/pages/chat/Conversation.vue` `_runClientTools`:invoke 前对 `p.input` 做 `JSON.parse(JSON.stringify(...))` 深拷贝(工具入参都是 JSON 可序列化的),剥掉 Vue Proxy。
- `electron/local/fs.ts`:新增 `expandHome()`,在 `resolveExisting`/`resolveForWrite` 里把开头的 `~`/`~/` 展开到 `os.homedir()`。**根目录限制不变**——展开后仍走 realpath + in-root 校验。

## 验证

- `vue-tsc -b` / `tsc`(electron)编译通过。
- **本地从本分支重新构建 macOS App(v3.291.20,arm64)并安装**,实测能真实列出 `~/Desktop`,不再报 clone 错误。

## 备注

本 PR 取代未合并的 #1080(#1080 改的是被 #1081 重命名掉的旧 `_runClientTool`,已无法干净合并)。合并本 PR 后可关闭 #1080。
