### PR TITLE
feat(desktop): Local Tools settings tab + persistent Always-allow consent

### DIFF
--- a/change/@acedatacloud-nexior-7fead046-e1fb-46d5-8a7a-d19a979ed8f2.json
+++ b/change/@acedatacloud-nexior-7fead046-e1fb-46d5-8a7a-d19a979ed8f2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(desktop): Local Tools settings tab + persistent Always-allow consent",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/electron/local/config.ts
+++ b/electron/local/config.ts
@@ -10,9 +10,9 @@ const file = (): string => path.join(app.getPath('userData'), 'local-tools.json'
 export function load(): LocalConfig {
   try {
     const c = JSON.parse(fs.readFileSync(file(), 'utf8')) as Partial<LocalConfig>;
-    return { roots: c.roots ?? [], mcp: c.mcp ?? [] };
+    return { roots: c.roots ?? [], mcp: c.mcp ?? [], grants: c.grants ?? [] };
   } catch {
-    return { roots: [], mcp: [] };
+    return { roots: [], mcp: [], grants: [] };
   }
 }
 

--- a/electron/local/consent.ts
+++ b/electron/local/consent.ts
@@ -1,30 +1,91 @@
 import { dialog, BrowserWindow } from 'electron';
 import type { ToolInvoke } from './types';
+import { load, save } from './config';
 
-// No OS sandbox by design — consent is the control. Reads can be cached per
-// (session,tool,path); mutating tools (write/exec) always re-confirm. The full
-// argv/path is shown untruncated so the dangerous part can't hide.
-const granted = new Set<string>();
+// No OS sandbox by design — consent is the control. Three tiers:
+//   • Allow once     — run this one time.
+//   • Allow for session — cache in-memory for this app run (reads only;
+//                      mutating tools still re-confirm).
+//   • Always allow   — persist a session-independent grant to disk so the
+//                      exact (tool, input) never prompts again — even for
+//                      mutating tools, because the user explicitly opted in
+//                      for that precise call. Revocable from Settings.
+// The full argv/path is shown untruncated so the dangerous part can't hide.
+const sessionGranted = new Set<string>();
 
-function key(inv: ToolInvoke): string {
-  return `${inv.sessionId}:${inv.name}:${JSON.stringify(inv.input)}`;
+// Deep-stable stringify: recursively sorts object keys at EVERY level so
+// equivalent inputs map to the same grant key regardless of property order.
+// Must NOT use the `JSON.stringify(v, keysArray)` replacer form — that filters
+// keys at all depths and silently DROPS nested fields, which would collapse
+// `{cfg:{path:'/safe'}}` and `{cfg:{path:'/danger'}}` to the same key and let an
+// Always-allow grant leak to a different, dangerous call.
+function stableStringify(v: unknown): string {
+  if (v === null || typeof v !== 'object') return JSON.stringify(v ?? null);
+  if (Array.isArray(v)) return '[' + v.map(stableStringify).join(',') + ']';
+  const obj = v as Record<string, unknown>;
+  return (
+    '{' +
+    Object.keys(obj)
+      .sort()
+      .map((k) => JSON.stringify(k) + ':' + stableStringify(obj[k]))
+      .join(',') +
+    '}'
+  );
+}
+
+function stable(input: Record<string, unknown>): string {
+  return stableStringify(input ?? {});
+}
+
+// Per-run key (includes sessionId) for the "Allow for session" cache.
+function sessionKey(inv: ToolInvoke): string {
+  return `${inv.sessionId}:${inv.name}:${stable(inv.input)}`;
+}
+
+// Session-independent key for persistent "Always allow" grants. Scoped to the
+// EXACT tool + input, so always-allowing `ls /Desktop` never auto-runs `rm`.
+export function grantKey(inv: ToolInvoke): string {
+  return `${inv.name}:${stable(inv.input)}`;
 }
 
 export async function consentOk(inv: ToolInvoke, win: BrowserWindow | null, mutates: boolean): Promise<boolean> {
-  if (granted.has(key(inv)) && !mutates) return true;
+  const gk = grantKey(inv);
+  if ((load().grants ?? []).includes(gk)) return true; // persistent always-allow
+  if (sessionGranted.has(sessionKey(inv)) && !mutates) return true;
   const opts = {
     type: 'warning' as const,
-    buttons: ['Allow once', 'Allow for session', 'Deny'],
+    buttons: ['Allow once', 'Allow for session', 'Always allow', 'Deny'],
     defaultId: 0,
-    cancelId: 2,
+    cancelId: 3,
     message: `Run local tool: ${inv.name}?`,
     detail: JSON.stringify(inv.input)
   };
   const { response } = win ? await dialog.showMessageBox(win, opts) : await dialog.showMessageBox(opts);
-  if (response === 1) granted.add(key(inv));
-  return response !== 2;
+  if (response === 1) sessionGranted.add(sessionKey(inv));
+  if (response === 2) {
+    const cfg = load();
+    const grants = new Set(cfg.grants ?? []);
+    grants.add(gk);
+    save({ ...cfg, grants: [...grants] });
+  }
+  return response !== 3;
 }
 
 export function resetConsent(): void {
-  granted.clear();
+  sessionGranted.clear();
+}
+
+// Persistent-grant management, surfaced in Settings → Local Tools.
+export function listGrants(): string[] {
+  return load().grants ?? [];
+}
+
+export function revokeGrant(key: string): void {
+  const cfg = load();
+  save({ ...cfg, grants: (cfg.grants ?? []).filter((g) => g !== key) });
+}
+
+export function clearGrants(): void {
+  const cfg = load();
+  save({ ...cfg, grants: [] });
 }

--- a/electron/local/ipc.ts
+++ b/electron/local/ipc.ts
@@ -1,6 +1,6 @@
 import { ipcMain, BrowserWindow, dialog } from 'electron';
 import { APP_ORIGIN } from '../protocol';
-import { consentOk } from './consent';
+import { consentOk, listGrants, revokeGrant, clearGrants } from './consent';
 import { registry } from './registry';
 import { load, save } from './config';
 import { setRoots } from './fs';
@@ -42,14 +42,19 @@ export function registerLocalExec(getWin: () => BrowserWindow | null): void {
   });
   ipcMain.handle('local.config.save', (e, cfg: LocalConfig) => {
     gate(e);
-    save(cfg);
+    // Preserve persistent consent grants — the renderer's save payload only
+    // carries roots + mcp, so merge to avoid wiping the "always allow" list.
+    const cur = load();
+    save({ ...cur, roots: cfg.roots, mcp: cfg.mcp });
     setRoots(cfg.roots); // hot-apply roots; MCP server changes apply next launch
     return true;
   });
   ipcMain.handle('local.pickFolder', async (e) => {
     gate(e);
     const win = getWin();
-    const r = win ? await dialog.showOpenDialog(win, { properties: ['openDirectory'] }) : await dialog.showOpenDialog({ properties: ['openDirectory'] });
+    const r = win
+      ? await dialog.showOpenDialog(win, { properties: ['openDirectory'] })
+      : await dialog.showOpenDialog({ properties: ['openDirectory'] });
     return r.canceled ? null : r.filePaths[0];
   });
 
@@ -68,5 +73,22 @@ export function registerLocalExec(getWin: () => BrowserWindow | null): void {
   ipcMain.handle('local.perm.askMedia', (e, t: 'camera' | 'microphone') => {
     gate(e);
     return askMedia(t);
+  });
+
+  // Persistent "always allow" consent grants — list / revoke / clear from
+  // Settings → Local Tools. Revoking re-arms the per-call confirmation.
+  ipcMain.handle('local.grants.list', (e) => {
+    gate(e);
+    return listGrants();
+  });
+  ipcMain.handle('local.grants.revoke', (e, key: string) => {
+    gate(e);
+    revokeGrant(key);
+    return true;
+  });
+  ipcMain.handle('local.grants.clear', (e) => {
+    gate(e);
+    clearGrants();
+    return true;
   });
 }

--- a/electron/local/types.ts
+++ b/electron/local/types.ts
@@ -32,4 +32,8 @@ export interface McpServerConf {
 export interface LocalConfig {
   roots: string[];
   mcp: McpServerConf[];
+  // Persistent "always allow" consent grants. Each entry is a
+  // session-independent key `<tool.name>:<stable json input>` the user
+  // explicitly chose to always allow; matching invocations skip the prompt.
+  grants?: string[];
 }

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -56,12 +56,21 @@ contextBridge.exposeInMainWorld('localExec', {
   invoke: (inv: { name: string; input: object; sessionId: string }): Promise<{ output: string; is_error?: boolean }> =>
     ipcRenderer.invoke('local.tool.invoke', inv),
   getConfig: (): Promise<{ roots: string[]; mcp: object[] }> => ipcRenderer.invoke('local.config.get'),
-  saveConfig: (cfg: { roots: string[]; mcp: object[] }): Promise<boolean> => ipcRenderer.invoke('local.config.save', cfg),
+  saveConfig: (cfg: { roots: string[]; mcp: object[] }): Promise<boolean> =>
+    ipcRenderer.invoke('local.config.save', cfg),
   pickFolder: (): Promise<string | null> => ipcRenderer.invoke('local.pickFolder'),
   // macOS system-permission status + jump-to-pane, shown in the LocalTools panel.
   perm: {
-    status: (): Promise<{ mac: boolean; fullDisk: boolean; screen: string; mic: string; accessibility: boolean }> => ipcRenderer.invoke('local.perm.status'),
-    openPane: (k: 'fullDisk' | 'screen' | 'accessibility'): Promise<boolean> => ipcRenderer.invoke('local.perm.openPane', k),
+    status: (): Promise<{ mac: boolean; fullDisk: boolean; screen: string; mic: string; accessibility: boolean }> =>
+      ipcRenderer.invoke('local.perm.status'),
+    openPane: (k: 'fullDisk' | 'screen' | 'accessibility'): Promise<boolean> =>
+      ipcRenderer.invoke('local.perm.openPane', k),
     askMedia: (t: 'camera' | 'microphone'): Promise<boolean> => ipcRenderer.invoke('local.perm.askMedia', t)
+  },
+  // Persistent "always allow" consent grants, managed from the LocalTools panel.
+  grants: {
+    list: (): Promise<string[]> => ipcRenderer.invoke('local.grants.list'),
+    revoke: (key: string): Promise<boolean> => ipcRenderer.invoke('local.grants.revoke', key),
+    clear: (): Promise<boolean> => ipcRenderer.invoke('local.grants.clear')
   }
 });

--- a/src/components/setting/LocalTools.vue
+++ b/src/components/setting/LocalTools.vue
@@ -1,0 +1,275 @@
+<template>
+  <div class="settings-list local-tools-setting">
+    <p v-if="!desktop" class="hint muted">
+      {{ $t('common.settings.localToolsDesktopOnly') }}
+    </p>
+    <template v-else>
+      <!-- Authorized folders -->
+      <section>
+        <div class="section-head">
+          <h3>{{ $t('common.settings.localToolsFoldersTitle') }}</h3>
+          <el-button size="small" type="primary" :icon="Plus" @click="addFolder">
+            {{ $t('common.settings.localToolsAddFolder') }}
+          </el-button>
+        </div>
+        <p class="muted">{{ $t('common.settings.localToolsFoldersHint') }}</p>
+        <ul class="rows">
+          <li v-for="(r, i) in roots" :key="r" class="row">
+            <font-awesome-icon icon="fa-solid fa-folder" class="row-icon" />
+            <span class="path">{{ r }}</span>
+            <el-button size="small" text type="danger" @click="removeRoot(i)">
+              {{ $t('common.settings.localToolsRemove') }}
+            </el-button>
+          </li>
+          <li v-if="!roots.length" class="row muted empty">{{ $t('common.settings.localToolsNoFolders') }}</li>
+        </ul>
+        <div class="actions">
+          <el-button size="small" type="primary" :loading="saving" @click="save">
+            {{ $t('common.settings.localToolsSave') }}
+          </el-button>
+          <span v-if="savedTip" class="muted saved-tip">{{ $t('common.settings.localToolsSaved') }}</span>
+        </div>
+        <p v-if="tools.length" class="muted tools">
+          {{ $t('common.settings.localToolsActiveTools') }}: {{ tools.join(', ') }}
+        </p>
+      </section>
+
+      <!-- Always-allowed (persistent consent grants) -->
+      <section v-if="grants !== null">
+        <div class="section-head">
+          <h3>{{ $t('common.settings.localToolsGrantsTitle') }}</h3>
+          <el-button v-if="grants.length" size="small" text type="danger" @click="revokeAll">
+            {{ $t('common.settings.localToolsRevokeAll') }}
+          </el-button>
+        </div>
+        <p class="muted">{{ $t('common.settings.localToolsGrantsHint') }}</p>
+        <ul class="rows">
+          <li v-for="g in grants" :key="g.key" class="row">
+            <font-awesome-icon icon="fa-solid fa-shield-halved" class="row-icon" />
+            <span class="grant">
+              <code class="grant-name">{{ g.name }}</code>
+              <span class="grant-input">{{ g.input }}</span>
+            </span>
+            <el-button size="small" text type="danger" @click="revoke(g.key)">
+              {{ $t('common.settings.localToolsRevoke') }}
+            </el-button>
+          </li>
+          <li v-if="!grants.length" class="row muted empty">{{ $t('common.settings.localToolsNoGrants') }}</li>
+        </ul>
+      </section>
+
+      <!-- macOS system permissions -->
+      <section v-if="perm">
+        <div class="section-head">
+          <h3>{{ $t('common.settings.localToolsPermsTitle') }}</h3>
+        </div>
+        <p class="muted">{{ $t('common.settings.localToolsPermsHint') }}</p>
+        <div class="perm-row">
+          <span class="perm-name">{{ $t('common.settings.localToolsPermFullDisk') }}</span>
+          <el-tag size="small" :type="perm.fullDisk ? 'success' : 'info'" effect="plain">
+            {{ perm.fullDisk ? $t('common.settings.localToolsGranted') : $t('common.settings.localToolsNotGranted') }}
+          </el-tag>
+          <el-button size="small" text @click="open('fullDisk')">{{ $t('common.settings.localToolsOpen') }}</el-button>
+        </div>
+        <div class="perm-row">
+          <span class="perm-name">{{ $t('common.settings.localToolsPermScreen') }}</span>
+          <el-tag size="small" :type="perm.screen === 'granted' ? 'success' : 'info'" effect="plain">{{
+            perm.screen
+          }}</el-tag>
+          <el-button size="small" text @click="open('screen')">{{ $t('common.settings.localToolsOpen') }}</el-button>
+        </div>
+        <div class="perm-row">
+          <span class="perm-name">{{ $t('common.settings.localToolsPermAccessibility') }}</span>
+          <el-tag size="small" :type="perm.accessibility ? 'success' : 'info'" effect="plain">
+            {{
+              perm.accessibility ? $t('common.settings.localToolsGranted') : $t('common.settings.localToolsNotGranted')
+            }}
+          </el-tag>
+          <el-button size="small" text @click="open('accessibility')">{{
+            $t('common.settings.localToolsOpen')
+          }}</el-button>
+        </div>
+      </section>
+    </template>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElButton, ElTag } from 'element-plus';
+import { Plus } from '@element-plus/icons-vue';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { localExec } from '@/utils/desktop';
+
+interface GrantRow {
+  key: string;
+  name: string;
+  input: string;
+}
+
+export default defineComponent({
+  name: 'LocalToolsSetting',
+  components: { ElButton, ElTag, FontAwesomeIcon },
+  data() {
+    return {
+      Plus,
+      roots: [] as string[],
+      tools: [] as string[],
+      grants: null as null | GrantRow[],
+      perm: null as null | { mac: boolean; fullDisk: boolean; screen: string; mic: string; accessibility: boolean },
+      saving: false,
+      savedTip: false
+    };
+  },
+  computed: {
+    desktop(): boolean {
+      return !!localExec();
+    }
+  },
+  async mounted() {
+    const ex = localExec();
+    if (!ex) return;
+    this.roots = (await ex.getConfig()).roots;
+    this.tools = (await ex.listTools()).map((t) => t.name);
+    const s = await ex.perm?.status();
+    if (s?.mac) this.perm = s;
+    await this.loadGrants();
+  },
+  methods: {
+    async loadGrants() {
+      const ex = localExec();
+      if (!ex?.grants) {
+        this.grants = null;
+        return;
+      }
+      const keys = await ex.grants.list();
+      this.grants = keys.map((k) => {
+        // key shape: `<tool.name>:<json input>`. The input is always JSON, so
+        // split at the first `:{` (object) — robust even if a tool name ever
+        // contained a colon. Fall back to the first `:` for non-object inputs.
+        const sep = k.indexOf(':{');
+        const idx = sep >= 0 ? sep : k.indexOf(':');
+        return { key: k, name: idx >= 0 ? k.slice(0, idx) : k, input: idx >= 0 ? k.slice(idx + 1) : '' };
+      });
+    },
+    async addFolder() {
+      const p = await localExec()?.pickFolder();
+      if (p && !this.roots.includes(p)) this.roots.push(p);
+    },
+    removeRoot(i: number) {
+      this.roots.splice(i, 1);
+    },
+    async open(k: 'fullDisk' | 'screen' | 'accessibility') {
+      await localExec()?.perm?.openPane(k);
+    },
+    async save() {
+      this.saving = true;
+      // Preserve mcp; the worker registers MCP servers from this same config.
+      const cur = await localExec()?.getConfig();
+      await localExec()?.saveConfig({ roots: this.roots, mcp: cur?.mcp ?? [] });
+      this.saving = false;
+      this.savedTip = true;
+      setTimeout(() => (this.savedTip = false), 2000);
+    },
+    async revoke(key: string) {
+      await localExec()?.grants?.revoke(key);
+      await this.loadGrants();
+    },
+    async revokeAll() {
+      await localExec()?.grants?.clear();
+      await this.loadGrants();
+    }
+  }
+});
+</script>
+
+<style scoped>
+.local-tools-setting {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+.section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.section-head h3 {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+}
+.muted {
+  color: var(--el-text-color-secondary, #909399);
+  font-size: 13px;
+  margin: 6px 0 10px;
+}
+.rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border: 1px solid var(--el-border-color-lighter, #ebeef5);
+  border-radius: 8px;
+  overflow: hidden;
+}
+.row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--el-border-color-lighter, #ebeef5);
+}
+.rows .row:last-child {
+  border-bottom: none;
+}
+.row.empty {
+  justify-content: center;
+  padding: 16px;
+}
+.row-icon {
+  color: var(--el-text-color-secondary, #909399);
+  flex-shrink: 0;
+}
+.path,
+.grant {
+  flex: 1;
+  word-break: break-all;
+  font-size: 13px;
+}
+.grant {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.grant-name {
+  font-weight: 600;
+}
+.grant-input {
+  color: var(--el-text-color-secondary, #909399);
+  font-size: 12px;
+  word-break: break-all;
+}
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 12px;
+}
+.saved-tip {
+  margin: 0;
+}
+.tools {
+  margin-top: 12px;
+}
+.perm-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 0;
+}
+.perm-name {
+  flex: 1;
+  font-size: 14px;
+}
+</style>

--- a/src/components/user/Setting.vue
+++ b/src/components/user/Setting.vue
@@ -58,6 +58,9 @@
         <div v-else-if="activeTab === SETTING_TAB_CUSTOM_DOMAIN && isCustomDomainVisible">
           <custom-domain-setting />
         </div>
+        <div v-else-if="activeTab === SETTING_TAB_LOCAL_TOOLS && isDesktopApp">
+          <local-tools-setting />
+        </div>
         <div v-else-if="activeTab === SETTING_TAB_ABOUT">
           <about-setting @switch-tab="onSwitchTab" />
         </div>
@@ -80,7 +83,8 @@ import {
   faInfoCircle,
   faSitemap,
   faGlobe,
-  faRightToBracket
+  faRightToBracket,
+  faLaptopCode
 } from '@fortawesome/free-solid-svg-icons';
 import GeneralSetting from '@/components/setting/General.vue';
 import ByokSetting from '@/components/setting/Byok.vue';
@@ -92,6 +96,7 @@ import SubsiteSetting from '@/components/setting/Subsite.vue';
 import CustomDomainSetting from '@/components/setting/CustomDomain.vue';
 import AuthSetting from '@/components/setting/Auth.vue';
 import AboutSetting from '@/components/setting/About.vue';
+import LocalToolsSetting from '@/components/setting/LocalTools.vue';
 import {
   SETTING_TAB_ABOUT,
   SETTING_TAB_API_KEY,
@@ -103,9 +108,11 @@ import {
   SETTING_TAB_SITE,
   SETTING_TAB_SUBSITES,
   SETTING_TAB_CUSTOM_DOMAIN,
+  SETTING_TAB_LOCAL_TOOLS,
   type SettingTabKey
 } from '@/constants';
 import { isMainOfficial } from '@/utils';
+import { localExec } from '@/utils/desktop';
 
 export default defineComponent({
   name: 'UserSetting',
@@ -123,7 +130,8 @@ export default defineComponent({
     SubsiteSetting,
     CustomDomainSetting,
     AuthSetting,
-    AboutSetting
+    AboutSetting,
+    LocalToolsSetting
   },
   props: {
     visible: {
@@ -150,6 +158,7 @@ export default defineComponent({
       SETTING_TAB_SUBSITES,
       SETTING_TAB_CUSTOM_DOMAIN,
       SETTING_TAB_ABOUT,
+      SETTING_TAB_LOCAL_TOOLS,
       activeTab: SETTING_TAB_GENERAL as SettingTabKey,
       autoOpenCreateSubsite: false,
       mobile: typeof window !== 'undefined' && window.innerWidth < 768
@@ -214,6 +223,15 @@ export default defineComponent({
           icon: faGlobe,
           visible: this.isCustomDomainVisible
         },
+        {
+          // Desktop-only: manage the folders / system permissions / persistent
+          // "always allow" grants for local tools that run on the user's
+          // machine. Hidden on web & mobile (no localExec bridge there).
+          key: SETTING_TAB_LOCAL_TOOLS,
+          label: this.$t('common.settings.localTools'),
+          icon: faLaptopCode,
+          visible: this.isDesktopApp
+        },
         { key: SETTING_TAB_ABOUT, label: this.$t('common.settings.about'), icon: faInfoCircle, visible: true }
       ];
     },
@@ -231,6 +249,10 @@ export default defineComponent({
       // non-main-official tenant). The parent commercial host never
       // points additional CNAMEs at itself.
       return !this.isMainOfficialHost && this.isSiteAdmin;
+    },
+    isDesktopApp(): boolean {
+      // Only the Electron desktop app exposes the localExec bridge.
+      return !!localExec();
     },
     dialogWidth(): string {
       // Phone-sized viewports: take almost full width so the 450px-min

--- a/src/constants/setting.ts
+++ b/src/constants/setting.ts
@@ -14,6 +14,7 @@ export const SETTING_TAB_FUNCTION = 'function';
 export const SETTING_TAB_AUTH = 'auth';
 export const SETTING_TAB_SUBSITES = 'subsites';
 export const SETTING_TAB_CUSTOM_DOMAIN = 'customDomain';
+export const SETTING_TAB_LOCAL_TOOLS = 'localTools';
 export const SETTING_TAB_ABOUT = 'about';
 
 export type SettingTabKey =
@@ -26,4 +27,5 @@ export type SettingTabKey =
   | typeof SETTING_TAB_AUTH
   | typeof SETTING_TAB_SUBSITES
   | typeof SETTING_TAB_CUSTOM_DOMAIN
+  | typeof SETTING_TAB_LOCAL_TOOLS
   | typeof SETTING_TAB_ABOUT;

--- a/src/i18n/ar/common.json
+++ b/src/i18n/ar/common.json
@@ -903,6 +903,98 @@
     "message": "حول",
     "description": "عنوان قسم حول في صفحة الإعدادات"
   },
+  "settings.localTools": {
+    "message": "الأدوات المحلية",
+    "description": "Desktop-only settings tab for managing local tool folders, permissions and grants."
+  },
+  "settings.localToolsDesktopOnly": {
+    "message": "متاح في تطبيق سطح المكتب فقط.",
+    "description": "Shown when the Local Tools tab is opened on web/mobile."
+  },
+  "settings.localToolsFoldersTitle": {
+    "message": "المجلدات المصرّح بها",
+    "description": "Heading for the list of folders the AI may read/write locally."
+  },
+  "settings.localToolsFoldersHint": {
+    "message": "المجلدات التي يُسمح للذكاء الاصطناعي بالقراءة والكتابة فيها على هذا الجهاز. تعمل الأدوات محليًا؛ ولا يغادر أي شيء جهازك دون موافقتك.",
+    "description": "Help text under the authorized-folders heading."
+  },
+  "settings.localToolsAddFolder": {
+    "message": "إضافة مجلد",
+    "description": "Button to pick a folder to authorize."
+  },
+  "settings.localToolsRemove": {
+    "message": "إزالة",
+    "description": "Button to remove an authorized folder."
+  },
+  "settings.localToolsNoFolders": {
+    "message": "لا توجد مجلدات مصرّح بها بعد.",
+    "description": "Empty state for the authorized-folders list."
+  },
+  "settings.localToolsSave": {
+    "message": "حفظ",
+    "description": "Save the authorized folders."
+  },
+  "settings.localToolsSaved": {
+    "message": "تم الحفظ",
+    "description": "Transient confirmation after saving local-tool folders."
+  },
+  "settings.localToolsActiveTools": {
+    "message": "الأدوات النشطة",
+    "description": "Label before the list of currently available local tools."
+  },
+  "settings.localToolsGrantsTitle": {
+    "message": "الإجراءات المسموح بها دائمًا",
+    "description": "Heading for the persistent consent grants list."
+  },
+  "settings.localToolsGrantsHint": {
+    "message": "استدعاءات الأدوات التي اخترت السماح بها دائمًا. تُنفَّذ دون السؤال مجددًا. ألغِ أيًّا منها لإعادة تفعيل مطالبة التأكيد.",
+    "description": "Help text under the always-allowed actions heading."
+  },
+  "settings.localToolsRevoke": {
+    "message": "إلغاء",
+    "description": "Button to revoke a single always-allow grant."
+  },
+  "settings.localToolsRevokeAll": {
+    "message": "إلغاء الكل",
+    "description": "Button to revoke every always-allow grant."
+  },
+  "settings.localToolsNoGrants": {
+    "message": "لا توجد إجراءات مسموح بها دائمًا. ستُطلب موافقتك قبل تشغيل كل أداة محلية.",
+    "description": "Empty state for the always-allowed actions list."
+  },
+  "settings.localToolsPermsTitle": {
+    "message": "أذونات النظام",
+    "description": "Heading for the macOS system-permission section."
+  },
+  "settings.localToolsPermsHint": {
+    "message": "اختياري. الوصول إلى المجلدات أعلاه لا يحتاج إلى أيٍّ منها — امنح فقط ما تتطلبه مهمة محددة.",
+    "description": "Help text under the system-permissions heading."
+  },
+  "settings.localToolsPermFullDisk": {
+    "message": "الوصول الكامل إلى القرص",
+    "description": "macOS Full Disk Access permission row."
+  },
+  "settings.localToolsPermScreen": {
+    "message": "تسجيل الشاشة",
+    "description": "macOS Screen Recording permission row."
+  },
+  "settings.localToolsPermAccessibility": {
+    "message": "إمكانية الوصول",
+    "description": "macOS Accessibility permission row."
+  },
+  "settings.localToolsGranted": {
+    "message": "مَمنوح",
+    "description": "Status tag when a system permission is granted."
+  },
+  "settings.localToolsNotGranted": {
+    "message": "غير ممنوح",
+    "description": "Status tag when a system permission is not granted."
+  },
+  "settings.localToolsOpen": {
+    "message": "فتح…",
+    "description": "Button to open the relevant macOS System Settings pane."
+  },
   "settings.subsites": {
     "message": "مواقعي الفرعية",
     "description": "عنوان علامة تبويب إدارة المواقع الفرعية في نافذة الإعدادات. يظهر فقط في الموقع الرسمي، المواقع الفرعية لا تظهر."

--- a/src/i18n/de/common.json
+++ b/src/i18n/de/common.json
@@ -903,6 +903,98 @@
     "message": "Über",
     "description": "Titel des Abschnitts 'Über' auf der Einstellungsseite"
   },
+  "settings.localTools": {
+    "message": "Lokale Tools",
+    "description": "Desktop-only settings tab for managing local tool folders, permissions and grants."
+  },
+  "settings.localToolsDesktopOnly": {
+    "message": "Nur in der Desktop-App verfügbar.",
+    "description": "Shown when the Local Tools tab is opened on web/mobile."
+  },
+  "settings.localToolsFoldersTitle": {
+    "message": "Autorisierte Ordner",
+    "description": "Heading for the list of folders the AI may read/write locally."
+  },
+  "settings.localToolsFoldersHint": {
+    "message": "Ordner, die die KI auf diesem Gerät lesen und schreiben darf. Tools laufen lokal; ohne deine Zustimmung verlässt nichts dein Gerät.",
+    "description": "Help text under the authorized-folders heading."
+  },
+  "settings.localToolsAddFolder": {
+    "message": "Ordner hinzufügen",
+    "description": "Button to pick a folder to authorize."
+  },
+  "settings.localToolsRemove": {
+    "message": "Entfernen",
+    "description": "Button to remove an authorized folder."
+  },
+  "settings.localToolsNoFolders": {
+    "message": "Noch keine Ordner autorisiert.",
+    "description": "Empty state for the authorized-folders list."
+  },
+  "settings.localToolsSave": {
+    "message": "Speichern",
+    "description": "Save the authorized folders."
+  },
+  "settings.localToolsSaved": {
+    "message": "Gespeichert",
+    "description": "Transient confirmation after saving local-tool folders."
+  },
+  "settings.localToolsActiveTools": {
+    "message": "Aktive Tools",
+    "description": "Label before the list of currently available local tools."
+  },
+  "settings.localToolsGrantsTitle": {
+    "message": "Immer erlaubte Aktionen",
+    "description": "Heading for the persistent consent grants list."
+  },
+  "settings.localToolsGrantsHint": {
+    "message": "Tool-Aufrufe, die du immer erlauben möchtest. Sie laufen ohne erneute Nachfrage. Widerrufe einen, um die Bestätigung wieder zu aktivieren.",
+    "description": "Help text under the always-allowed actions heading."
+  },
+  "settings.localToolsRevoke": {
+    "message": "Widerrufen",
+    "description": "Button to revoke a single always-allow grant."
+  },
+  "settings.localToolsRevokeAll": {
+    "message": "Alle widerrufen",
+    "description": "Button to revoke every always-allow grant."
+  },
+  "settings.localToolsNoGrants": {
+    "message": "Keine immer erlaubten Aktionen. Vor jeder Ausführung eines lokalen Tools wirst du gefragt.",
+    "description": "Empty state for the always-allowed actions list."
+  },
+  "settings.localToolsPermsTitle": {
+    "message": "Systemberechtigungen",
+    "description": "Heading for the macOS system-permission section."
+  },
+  "settings.localToolsPermsHint": {
+    "message": "Optional. Der Ordnerzugriff oben benötigt keine davon – gewähre nur, was eine bestimmte Aufgabe erfordert.",
+    "description": "Help text under the system-permissions heading."
+  },
+  "settings.localToolsPermFullDisk": {
+    "message": "Vollständiger Festplattenzugriff",
+    "description": "macOS Full Disk Access permission row."
+  },
+  "settings.localToolsPermScreen": {
+    "message": "Bildschirmaufnahme",
+    "description": "macOS Screen Recording permission row."
+  },
+  "settings.localToolsPermAccessibility": {
+    "message": "Bedienungshilfen",
+    "description": "macOS Accessibility permission row."
+  },
+  "settings.localToolsGranted": {
+    "message": "Gewährt",
+    "description": "Status tag when a system permission is granted."
+  },
+  "settings.localToolsNotGranted": {
+    "message": "Nicht gewährt",
+    "description": "Status tag when a system permission is not granted."
+  },
+  "settings.localToolsOpen": {
+    "message": "Öffnen…",
+    "description": "Button to open the relevant macOS System Settings pane."
+  },
   "settings.subsites": {
     "message": "Meine Subsites",
     "description": "Titel des Tabs zur Verwaltung von Subsites im Einstellungs-Popup. Nur auf der offiziellen Hauptseite sichtbar, Subsites werden nicht angezeigt."

--- a/src/i18n/el/common.json
+++ b/src/i18n/el/common.json
@@ -903,6 +903,98 @@
     "message": "Σχετικά",
     "description": "Τίτλος της ενότητας σχετικά στην σελίδα ρυθμίσεων"
   },
+  "settings.localTools": {
+    "message": "Τοπικά εργαλεία",
+    "description": "Desktop-only settings tab for managing local tool folders, permissions and grants."
+  },
+  "settings.localToolsDesktopOnly": {
+    "message": "Διαθέσιμο μόνο στην εφαρμογή υπολογιστή.",
+    "description": "Shown when the Local Tools tab is opened on web/mobile."
+  },
+  "settings.localToolsFoldersTitle": {
+    "message": "Εξουσιοδοτημένοι φάκελοι",
+    "description": "Heading for the list of folders the AI may read/write locally."
+  },
+  "settings.localToolsFoldersHint": {
+    "message": "Φάκελοι που το AI μπορεί να διαβάζει και να γράφει σε αυτό το μηχάνημα. Τα εργαλεία εκτελούνται τοπικά· τίποτα δεν φεύγει από τη συσκευή σας χωρίς τη συγκατάθεσή σας.",
+    "description": "Help text under the authorized-folders heading."
+  },
+  "settings.localToolsAddFolder": {
+    "message": "Προσθήκη φακέλου",
+    "description": "Button to pick a folder to authorize."
+  },
+  "settings.localToolsRemove": {
+    "message": "Αφαίρεση",
+    "description": "Button to remove an authorized folder."
+  },
+  "settings.localToolsNoFolders": {
+    "message": "Δεν υπάρχουν ακόμη εξουσιοδοτημένοι φάκελοι.",
+    "description": "Empty state for the authorized-folders list."
+  },
+  "settings.localToolsSave": {
+    "message": "Αποθήκευση",
+    "description": "Save the authorized folders."
+  },
+  "settings.localToolsSaved": {
+    "message": "Αποθηκεύτηκε",
+    "description": "Transient confirmation after saving local-tool folders."
+  },
+  "settings.localToolsActiveTools": {
+    "message": "Ενεργά εργαλεία",
+    "description": "Label before the list of currently available local tools."
+  },
+  "settings.localToolsGrantsTitle": {
+    "message": "Πάντα επιτρεπόμενες ενέργειες",
+    "description": "Heading for the persistent consent grants list."
+  },
+  "settings.localToolsGrantsHint": {
+    "message": "Κλήσεις εργαλείων που επιλέξατε να επιτρέπετε πάντα. Εκτελούνται χωρίς νέα ερώτηση. Ανακαλέστε οποιαδήποτε για να ενεργοποιήσετε ξανά την επιβεβαίωση.",
+    "description": "Help text under the always-allowed actions heading."
+  },
+  "settings.localToolsRevoke": {
+    "message": "Ανάκληση",
+    "description": "Button to revoke a single always-allow grant."
+  },
+  "settings.localToolsRevokeAll": {
+    "message": "Ανάκληση όλων",
+    "description": "Button to revoke every always-allow grant."
+  },
+  "settings.localToolsNoGrants": {
+    "message": "Καμία πάντα επιτρεπόμενη ενέργεια. Θα ερωτάστε πριν από κάθε τοπικό εργαλείο.",
+    "description": "Empty state for the always-allowed actions list."
+  },
+  "settings.localToolsPermsTitle": {
+    "message": "Δικαιώματα συστήματος",
+    "description": "Heading for the macOS system-permission section."
+  },
+  "settings.localToolsPermsHint": {
+    "message": "Προαιρετικό. Η πρόσβαση στους φακέλους παραπάνω δεν χρειάζεται κανένα — παραχωρήστε μόνο ό,τι απαιτεί μια συγκεκριμένη εργασία.",
+    "description": "Help text under the system-permissions heading."
+  },
+  "settings.localToolsPermFullDisk": {
+    "message": "Πλήρης πρόσβαση στον δίσκο",
+    "description": "macOS Full Disk Access permission row."
+  },
+  "settings.localToolsPermScreen": {
+    "message": "Εγγραφή οθόνης",
+    "description": "macOS Screen Recording permission row."
+  },
+  "settings.localToolsPermAccessibility": {
+    "message": "Προσβασιμότητα",
+    "description": "macOS Accessibility permission row."
+  },
+  "settings.localToolsGranted": {
+    "message": "Παραχωρήθηκε",
+    "description": "Status tag when a system permission is granted."
+  },
+  "settings.localToolsNotGranted": {
+    "message": "Δεν παραχωρήθηκε",
+    "description": "Status tag when a system permission is not granted."
+  },
+  "settings.localToolsOpen": {
+    "message": "Άνοιγμα…",
+    "description": "Button to open the relevant macOS System Settings pane."
+  },
   "settings.subsites": {
     "message": "Οι υποσελίδες μου",
     "description": "Τίτλος της καρτέλας διαχείρισης υποσελίδων στο παράθυρο ρυθμίσεων. Ορατό μόνο στην επίσημη κύρια σελίδα, οι υποσελίδες δεν εμφανίζονται."

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -883,6 +883,98 @@
     "message": "About",
     "description": "Title for the about section in the settings page"
   },
+  "settings.localTools": {
+    "message": "Local Tools",
+    "description": "Desktop-only settings tab for managing local tool folders, permissions and grants."
+  },
+  "settings.localToolsDesktopOnly": {
+    "message": "Available in the desktop app only.",
+    "description": "Shown when the Local Tools tab is opened on web/mobile."
+  },
+  "settings.localToolsFoldersTitle": {
+    "message": "Authorized folders",
+    "description": "Heading for the list of folders the AI may read/write locally."
+  },
+  "settings.localToolsFoldersHint": {
+    "message": "Folders the AI may read and write on this machine. Tools run locally; nothing leaves your device without your consent.",
+    "description": "Help text under the authorized-folders heading."
+  },
+  "settings.localToolsAddFolder": {
+    "message": "Add folder",
+    "description": "Button to pick a folder to authorize."
+  },
+  "settings.localToolsRemove": {
+    "message": "Remove",
+    "description": "Button to remove an authorized folder."
+  },
+  "settings.localToolsNoFolders": {
+    "message": "No folders authorized yet.",
+    "description": "Empty state for the authorized-folders list."
+  },
+  "settings.localToolsSave": {
+    "message": "Save",
+    "description": "Save the authorized folders."
+  },
+  "settings.localToolsSaved": {
+    "message": "Saved",
+    "description": "Transient confirmation after saving local-tool folders."
+  },
+  "settings.localToolsActiveTools": {
+    "message": "Active tools",
+    "description": "Label before the list of currently available local tools."
+  },
+  "settings.localToolsGrantsTitle": {
+    "message": "Always-allowed actions",
+    "description": "Heading for the persistent consent grants list."
+  },
+  "settings.localToolsGrantsHint": {
+    "message": "Tool calls you chose to always allow. They run without asking again. Revoke any to re-arm the confirmation prompt.",
+    "description": "Help text under the always-allowed actions heading."
+  },
+  "settings.localToolsRevoke": {
+    "message": "Revoke",
+    "description": "Button to revoke a single always-allow grant."
+  },
+  "settings.localToolsRevokeAll": {
+    "message": "Revoke all",
+    "description": "Button to revoke every always-allow grant."
+  },
+  "settings.localToolsNoGrants": {
+    "message": "No always-allowed actions. You'll be asked before each local tool runs.",
+    "description": "Empty state for the always-allowed actions list."
+  },
+  "settings.localToolsPermsTitle": {
+    "message": "System permissions",
+    "description": "Heading for the macOS system-permission section."
+  },
+  "settings.localToolsPermsHint": {
+    "message": "Optional. Folder access above needs none of these — grant only what a specific task requires.",
+    "description": "Help text under the system-permissions heading."
+  },
+  "settings.localToolsPermFullDisk": {
+    "message": "Full Disk Access",
+    "description": "macOS Full Disk Access permission row."
+  },
+  "settings.localToolsPermScreen": {
+    "message": "Screen Recording",
+    "description": "macOS Screen Recording permission row."
+  },
+  "settings.localToolsPermAccessibility": {
+    "message": "Accessibility",
+    "description": "macOS Accessibility permission row."
+  },
+  "settings.localToolsGranted": {
+    "message": "Granted",
+    "description": "Status tag when a system permission is granted."
+  },
+  "settings.localToolsNotGranted": {
+    "message": "Not granted",
+    "description": "Status tag when a system permission is not granted."
+  },
+  "settings.localToolsOpen": {
+    "message": "Open\u2026",
+    "description": "Button to open the relevant macOS System Settings pane."
+  },
   "settings.subsites": {
     "message": "My Subsites",
     "description": "Title for the subsites management tab in the settings popup. Visible only on the official main site; subsites are not displayed."

--- a/src/i18n/es/common.json
+++ b/src/i18n/es/common.json
@@ -903,6 +903,98 @@
     "message": "Acerca de",
     "description": "Título de la sección 'Acerca de' en la página de configuración"
   },
+  "settings.localTools": {
+    "message": "Herramientas locales",
+    "description": "Desktop-only settings tab for managing local tool folders, permissions and grants."
+  },
+  "settings.localToolsDesktopOnly": {
+    "message": "Disponible solo en la aplicación de escritorio.",
+    "description": "Shown when the Local Tools tab is opened on web/mobile."
+  },
+  "settings.localToolsFoldersTitle": {
+    "message": "Carpetas autorizadas",
+    "description": "Heading for the list of folders the AI may read/write locally."
+  },
+  "settings.localToolsFoldersHint": {
+    "message": "Carpetas que la IA puede leer y escribir en este equipo. Las herramientas se ejecutan localmente; nada sale de tu dispositivo sin tu consentimiento.",
+    "description": "Help text under the authorized-folders heading."
+  },
+  "settings.localToolsAddFolder": {
+    "message": "Agregar carpeta",
+    "description": "Button to pick a folder to authorize."
+  },
+  "settings.localToolsRemove": {
+    "message": "Quitar",
+    "description": "Button to remove an authorized folder."
+  },
+  "settings.localToolsNoFolders": {
+    "message": "Aún no hay carpetas autorizadas.",
+    "description": "Empty state for the authorized-folders list."
+  },
+  "settings.localToolsSave": {
+    "message": "Guardar",
+    "description": "Save the authorized folders."
+  },
+  "settings.localToolsSaved": {
+    "message": "Guardado",
+    "description": "Transient confirmation after saving local-tool folders."
+  },
+  "settings.localToolsActiveTools": {
+    "message": "Herramientas activas",
+    "description": "Label before the list of currently available local tools."
+  },
+  "settings.localToolsGrantsTitle": {
+    "message": "Acciones siempre permitidas",
+    "description": "Heading for the persistent consent grants list."
+  },
+  "settings.localToolsGrantsHint": {
+    "message": "Llamadas de herramientas que elegiste permitir siempre. Se ejecutan sin volver a preguntar. Revoca cualquiera para reactivar la confirmación.",
+    "description": "Help text under the always-allowed actions heading."
+  },
+  "settings.localToolsRevoke": {
+    "message": "Revocar",
+    "description": "Button to revoke a single always-allow grant."
+  },
+  "settings.localToolsRevokeAll": {
+    "message": "Revocar todo",
+    "description": "Button to revoke every always-allow grant."
+  },
+  "settings.localToolsNoGrants": {
+    "message": "No hay acciones siempre permitidas. Se te preguntará antes de ejecutar cada herramienta local.",
+    "description": "Empty state for the always-allowed actions list."
+  },
+  "settings.localToolsPermsTitle": {
+    "message": "Permisos del sistema",
+    "description": "Heading for the macOS system-permission section."
+  },
+  "settings.localToolsPermsHint": {
+    "message": "Opcional. El acceso a carpetas de arriba no necesita ninguno; concede solo lo que requiera una tarea concreta.",
+    "description": "Help text under the system-permissions heading."
+  },
+  "settings.localToolsPermFullDisk": {
+    "message": "Acceso a todo el disco",
+    "description": "macOS Full Disk Access permission row."
+  },
+  "settings.localToolsPermScreen": {
+    "message": "Grabación de pantalla",
+    "description": "macOS Screen Recording permission row."
+  },
+  "settings.localToolsPermAccessibility": {
+    "message": "Accesibilidad",
+    "description": "macOS Accessibility permission row."
+  },
+  "settings.localToolsGranted": {
+    "message": "Concedido",
+    "description": "Status tag when a system permission is granted."
+  },
+  "settings.localToolsNotGranted": {
+    "message": "No concedido",
+    "description": "Status tag when a system permission is not granted."
+  },
+  "settings.localToolsOpen": {
+    "message": "Abrir…",
+    "description": "Button to open the relevant macOS System Settings pane."
+  },
   "settings.subsites": {
     "message": "Mis subsitios",
     "description": "Título de la pestaña de gestión de subsitios en el cuadro de configuración. Solo visible en el sitio principal oficial, los subsitios no se muestran."

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -903,6 +903,98 @@
     "message": "Tietoja",
     "description": "Asetussivun tietoja-osan otsikko"
   },
+  "settings.localTools": {
+    "message": "Paikalliset työkalut",
+    "description": "Desktop-only settings tab for managing local tool folders, permissions and grants."
+  },
+  "settings.localToolsDesktopOnly": {
+    "message": "Käytettävissä vain työpöytäsovelluksessa.",
+    "description": "Shown when the Local Tools tab is opened on web/mobile."
+  },
+  "settings.localToolsFoldersTitle": {
+    "message": "Valtuutetut kansiot",
+    "description": "Heading for the list of folders the AI may read/write locally."
+  },
+  "settings.localToolsFoldersHint": {
+    "message": "Kansiot, joita tekoäly saa lukea ja kirjoittaa tällä laitteella. Työkalut suoritetaan paikallisesti; mikään ei poistu laitteeltasi ilman suostumustasi.",
+    "description": "Help text under the authorized-folders heading."
+  },
+  "settings.localToolsAddFolder": {
+    "message": "Lisää kansio",
+    "description": "Button to pick a folder to authorize."
+  },
+  "settings.localToolsRemove": {
+    "message": "Poista",
+    "description": "Button to remove an authorized folder."
+  },
+  "settings.localToolsNoFolders": {
+    "message": "Ei vielä valtuutettuja kansioita.",
+    "description": "Empty state for the authorized-folders list."
+  },
+  "settings.localToolsSave": {
+    "message": "Tallenna",
+    "description": "Save the authorized folders."
+  },
+  "settings.localToolsSaved": {
+    "message": "Tallennettu",
+    "description": "Transient confirmation after saving local-tool folders."
+  },
+  "settings.localToolsActiveTools": {
+    "message": "Aktiiviset työkalut",
+    "description": "Label before the list of currently available local tools."
+  },
+  "settings.localToolsGrantsTitle": {
+    "message": "Aina sallitut toiminnot",
+    "description": "Heading for the persistent consent grants list."
+  },
+  "settings.localToolsGrantsHint": {
+    "message": "Työkalukutsut, jotka valitsit sallittavaksi aina. Ne suoritetaan kysymättä uudelleen. Peru mikä tahansa ottaaksesi vahvistuksen taas käyttöön.",
+    "description": "Help text under the always-allowed actions heading."
+  },
+  "settings.localToolsRevoke": {
+    "message": "Peru",
+    "description": "Button to revoke a single always-allow grant."
+  },
+  "settings.localToolsRevokeAll": {
+    "message": "Peru kaikki",
+    "description": "Button to revoke every always-allow grant."
+  },
+  "settings.localToolsNoGrants": {
+    "message": "Ei aina sallittuja toimintoja. Sinulta kysytään ennen jokaista paikallista työkalua.",
+    "description": "Empty state for the always-allowed actions list."
+  },
+  "settings.localToolsPermsTitle": {
+    "message": "Järjestelmän käyttöoikeudet",
+    "description": "Heading for the macOS system-permission section."
+  },
+  "settings.localToolsPermsHint": {
+    "message": "Valinnainen. Yllä oleva kansiokäyttö ei tarvitse näitä – myönnä vain se, mitä tietty tehtävä vaatii.",
+    "description": "Help text under the system-permissions heading."
+  },
+  "settings.localToolsPermFullDisk": {
+    "message": "Täysi levyn käyttöoikeus",
+    "description": "macOS Full Disk Access permission row."
+  },
+  "settings.localToolsPermScreen": {
+    "message": "Näytön tallennus",
+    "description": "macOS Screen Recording permission row."
+  },
+  "settings.localToolsPermAccessibility": {
+    "message": "Käyttöapu",
+    "description": "macOS Accessibility permission row."
+  },
+  "settings.localToolsGranted": {
+    "message": "Myönnetty",
+    "description": "Status tag when a system permission is granted."
+  },
+  "settings.localToolsNotGranted": {
+    "message": "Ei myönnetty",
+    "description": "Status tag when a system permission is not granted."
+  },
+  "settings.localToolsOpen": {
+    "message": "Avaa…",
+    "description": "Button to open the relevant macOS System Settings pane."
+  },
   "settings.subsites": {
     "message": "Omat alisivustot",
     "description": "Asetusikkunassa alisivustojen hallinta-välilehden otsikko. Näkyy vain virallisella pääsivustolla, alisivustot eivät näy."

--- a/src/i18n/fr/common.json
+++ b/src/i18n/fr/common.json
@@ -903,6 +903,98 @@
     "message": "À propos",
     "description": "Titre de la section à propos dans la page des paramètres"
   },
+  "settings.localTools": {
+    "message": "Outils locaux",
+    "description": "Desktop-only settings tab for managing local tool folders, permissions and grants."
+  },
+  "settings.localToolsDesktopOnly": {
+    "message": "Disponible uniquement dans l’application de bureau.",
+    "description": "Shown when the Local Tools tab is opened on web/mobile."
+  },
+  "settings.localToolsFoldersTitle": {
+    "message": "Dossiers autorisés",
+    "description": "Heading for the list of folders the AI may read/write locally."
+  },
+  "settings.localToolsFoldersHint": {
+    "message": "Dossiers que l’IA peut lire et écrire sur cette machine. Les outils s’exécutent localement ; rien ne quitte votre appareil sans votre consentement.",
+    "description": "Help text under the authorized-folders heading."
+  },
+  "settings.localToolsAddFolder": {
+    "message": "Ajouter un dossier",
+    "description": "Button to pick a folder to authorize."
+  },
+  "settings.localToolsRemove": {
+    "message": "Retirer",
+    "description": "Button to remove an authorized folder."
+  },
+  "settings.localToolsNoFolders": {
+    "message": "Aucun dossier autorisé pour l’instant.",
+    "description": "Empty state for the authorized-folders list."
+  },
+  "settings.localToolsSave": {
+    "message": "Enregistrer",
+    "description": "Save the authorized folders."
+  },
+  "settings.localToolsSaved": {
+    "message": "Enregistré",
+    "description": "Transient confirmation after saving local-tool folders."
+  },
+  "settings.localToolsActiveTools": {
+    "message": "Outils actifs",
+    "description": "Label before the list of currently available local tools."
+  },
+  "settings.localToolsGrantsTitle": {
+    "message": "Actions toujours autorisées",
+    "description": "Heading for the persistent consent grants list."
+  },
+  "settings.localToolsGrantsHint": {
+    "message": "Appels d’outils que vous avez choisi de toujours autoriser. Ils s’exécutent sans nouvelle demande. Révoquez-en un pour réactiver la confirmation.",
+    "description": "Help text under the always-allowed actions heading."
+  },
+  "settings.localToolsRevoke": {
+    "message": "Révoquer",
+    "description": "Button to revoke a single always-allow grant."
+  },
+  "settings.localToolsRevokeAll": {
+    "message": "Tout révoquer",
+    "description": "Button to revoke every always-allow grant."
+  },
+  "settings.localToolsNoGrants": {
+    "message": "Aucune action toujours autorisée. Une confirmation vous sera demandée avant chaque outil local.",
+    "description": "Empty state for the always-allowed actions list."
+  },
+  "settings.localToolsPermsTitle": {
+    "message": "Autorisations système",
+    "description": "Heading for the macOS system-permission section."
+  },
+  "settings.localToolsPermsHint": {
+    "message": "Facultatif. L’accès aux dossiers ci-dessus n’en a pas besoin — n’accordez que ce qu’une tâche précise exige.",
+    "description": "Help text under the system-permissions heading."
+  },
+  "settings.localToolsPermFullDisk": {
+    "message": "Accès complet au disque",
+    "description": "macOS Full Disk Access permission row."
+  },
+  "settings.localToolsPermScreen": {
+    "message": "Enregistrement de l’écran",
+    "description": "macOS Screen Recording permission row."
+  },
+  "settings.localToolsPermAccessibility": {
+    "message": "Accessibilité",
+    "description": "macOS Accessibility permission row."
+  },
+  "settings.localToolsGranted": {
+    "message": "Accordé",
+    "description": "Status tag when a system permission is granted."
+  },
+  "settings.localToolsNotGranted": {
+    "message": "Non accordé",
+    "description": "Status tag when a system permission is not granted."
+  },
+  "settings.localToolsOpen": {
+    "message": "Ouvrir…",
+    "description": "Button to open the relevant macOS System Settings pane."
+  },
   "settings.subsites": {
     "message": "Mes sous-sites",
     "description": "Titre de l'onglet de gestion des sous-sites dans la fenêtre des paramètres. Visible uniquement sur le site principal officiel, les sous-sites ne s'affichent pas."

--- a/src/i18n/it/common.json
+++ b/src/i18n/it/common.json
@@ -903,6 +903,98 @@
     "message": "Informazioni",
     "description": "Titolo della sezione 'Informazioni' nella pagina delle impostazioni"
   },
+  "settings.localTools": {
+    "message": "Strumenti locali",
+    "description": "Desktop-only settings tab for managing local tool folders, permissions and grants."
+  },
+  "settings.localToolsDesktopOnly": {
+    "message": "Disponibile solo nell’app desktop.",
+    "description": "Shown when the Local Tools tab is opened on web/mobile."
+  },
+  "settings.localToolsFoldersTitle": {
+    "message": "Cartelle autorizzate",
+    "description": "Heading for the list of folders the AI may read/write locally."
+  },
+  "settings.localToolsFoldersHint": {
+    "message": "Cartelle che l’IA può leggere e scrivere su questo dispositivo. Gli strumenti vengono eseguiti localmente; nulla lascia il tuo dispositivo senza il tuo consenso.",
+    "description": "Help text under the authorized-folders heading."
+  },
+  "settings.localToolsAddFolder": {
+    "message": "Aggiungi cartella",
+    "description": "Button to pick a folder to authorize."
+  },
+  "settings.localToolsRemove": {
+    "message": "Rimuovi",
+    "description": "Button to remove an authorized folder."
+  },
+  "settings.localToolsNoFolders": {
+    "message": "Nessuna cartella autorizzata.",
+    "description": "Empty state for the authorized-folders list."
+  },
+  "settings.localToolsSave": {
+    "message": "Salva",
+    "description": "Save the authorized folders."
+  },
+  "settings.localToolsSaved": {
+    "message": "Salvato",
+    "description": "Transient confirmation after saving local-tool folders."
+  },
+  "settings.localToolsActiveTools": {
+    "message": "Strumenti attivi",
+    "description": "Label before the list of currently available local tools."
+  },
+  "settings.localToolsGrantsTitle": {
+    "message": "Azioni sempre consentite",
+    "description": "Heading for the persistent consent grants list."
+  },
+  "settings.localToolsGrantsHint": {
+    "message": "Chiamate di strumenti che hai scelto di consentire sempre. Vengono eseguite senza chiedere di nuovo. Revocane una per riattivare la conferma.",
+    "description": "Help text under the always-allowed actions heading."
+  },
+  "settings.localToolsRevoke": {
+    "message": "Revoca",
+    "description": "Button to revoke a single always-allow grant."
+  },
+  "settings.localToolsRevokeAll": {
+    "message": "Revoca tutto",
+    "description": "Button to revoke every always-allow grant."
+  },
+  "settings.localToolsNoGrants": {
+    "message": "Nessuna azione sempre consentita. Ti verrà chiesto prima di ogni strumento locale.",
+    "description": "Empty state for the always-allowed actions list."
+  },
+  "settings.localToolsPermsTitle": {
+    "message": "Autorizzazioni di sistema",
+    "description": "Heading for the macOS system-permission section."
+  },
+  "settings.localToolsPermsHint": {
+    "message": "Facoltativo. L’accesso alle cartelle qui sopra non ne richiede nessuna: concedi solo ciò che una specifica attività richiede.",
+    "description": "Help text under the system-permissions heading."
+  },
+  "settings.localToolsPermFullDisk": {
+    "message": "Accesso completo al disco",
+    "description": "macOS Full Disk Access permission row."
+  },
+  "settings.localToolsPermScreen": {
+    "message": "Registrazione schermo",
+    "description": "macOS Screen Recording permission row."
+  },
+  "settings.localToolsPermAccessibility": {
+    "message": "Accessibilità",
+    "description": "macOS Accessibility permission row."
+  },
+  "settings.localToolsGranted": {
+    "message": "Concesso",
+    "description": "Status tag when a system permission is granted."
+  },
+  "settings.localToolsNotGranted": {
+    "message": "Non concesso",
+    "description": "Status tag when a system permission is not granted."
+  },
+  "settings.localToolsOpen": {
+    "message": "Apri…",
+    "description": "Button to open the relevant macOS System Settings pane."
+  },
   "settings.subsites": {
     "message": "I miei sottositi",
     "description": "Titolo della scheda di gestione dei sottositi nella finestra delle impostazioni. Visibile solo nel sito principale ufficiale, i sottositi non vengono visualizzati."

--- a/src/i18n/ja/common.json
+++ b/src/i18n/ja/common.json
@@ -903,6 +903,98 @@
     "message": "概要",
     "description": "設定ページの概要セクションのタイトル"
   },
+  "settings.localTools": {
+    "message": "ローカルツール",
+    "description": "Desktop-only settings tab for managing local tool folders, permissions and grants."
+  },
+  "settings.localToolsDesktopOnly": {
+    "message": "デスクトップアプリでのみ利用できます。",
+    "description": "Shown when the Local Tools tab is opened on web/mobile."
+  },
+  "settings.localToolsFoldersTitle": {
+    "message": "許可済みフォルダ",
+    "description": "Heading for the list of folders the AI may read/write locally."
+  },
+  "settings.localToolsFoldersHint": {
+    "message": "AI がこの端末で読み書きできるフォルダです。ツールはローカルで実行され、あなたの同意なしに何も端末の外へ出ません。",
+    "description": "Help text under the authorized-folders heading."
+  },
+  "settings.localToolsAddFolder": {
+    "message": "フォルダを追加",
+    "description": "Button to pick a folder to authorize."
+  },
+  "settings.localToolsRemove": {
+    "message": "削除",
+    "description": "Button to remove an authorized folder."
+  },
+  "settings.localToolsNoFolders": {
+    "message": "まだフォルダが許可されていません。",
+    "description": "Empty state for the authorized-folders list."
+  },
+  "settings.localToolsSave": {
+    "message": "保存",
+    "description": "Save the authorized folders."
+  },
+  "settings.localToolsSaved": {
+    "message": "保存しました",
+    "description": "Transient confirmation after saving local-tool folders."
+  },
+  "settings.localToolsActiveTools": {
+    "message": "利用可能なツール",
+    "description": "Label before the list of currently available local tools."
+  },
+  "settings.localToolsGrantsTitle": {
+    "message": "常に許可する操作",
+    "description": "Heading for the persistent consent grants list."
+  },
+  "settings.localToolsGrantsHint": {
+    "message": "「常に許可」を選んだツール呼び出しです。再確認なしで実行されます。いずれかを取り消すと確認ダイアログが再び表示されます。",
+    "description": "Help text under the always-allowed actions heading."
+  },
+  "settings.localToolsRevoke": {
+    "message": "取り消す",
+    "description": "Button to revoke a single always-allow grant."
+  },
+  "settings.localToolsRevokeAll": {
+    "message": "すべて取り消す",
+    "description": "Button to revoke every always-allow grant."
+  },
+  "settings.localToolsNoGrants": {
+    "message": "常に許可する操作はありません。ローカルツールの実行前に毎回確認されます。",
+    "description": "Empty state for the always-allowed actions list."
+  },
+  "settings.localToolsPermsTitle": {
+    "message": "システム権限",
+    "description": "Heading for the macOS system-permission section."
+  },
+  "settings.localToolsPermsHint": {
+    "message": "任意です。上のフォルダアクセスにこれらは不要です。特定の作業に必要なものだけ許可してください。",
+    "description": "Help text under the system-permissions heading."
+  },
+  "settings.localToolsPermFullDisk": {
+    "message": "フルディスクアクセス",
+    "description": "macOS Full Disk Access permission row."
+  },
+  "settings.localToolsPermScreen": {
+    "message": "画面収録",
+    "description": "macOS Screen Recording permission row."
+  },
+  "settings.localToolsPermAccessibility": {
+    "message": "アクセシビリティ",
+    "description": "macOS Accessibility permission row."
+  },
+  "settings.localToolsGranted": {
+    "message": "許可済み",
+    "description": "Status tag when a system permission is granted."
+  },
+  "settings.localToolsNotGranted": {
+    "message": "未許可",
+    "description": "Status tag when a system permission is not granted."
+  },
+  "settings.localToolsOpen": {
+    "message": "開く…",
+    "description": "Button to open the relevant macOS System Settings pane."
+  },
   "settings.subsites": {
     "message": "私のサブサイト",
     "description": "設定ポップアップのサブサイト管理タブのタイトル。officialメインサイトでのみ表示され、サブサイトは表示されません。"

--- a/src/i18n/ko/common.json
+++ b/src/i18n/ko/common.json
@@ -903,6 +903,98 @@
     "message": "정보",
     "description": "설정 페이지의 정보 섹션 제목"
   },
+  "settings.localTools": {
+    "message": "로컬 도구",
+    "description": "Desktop-only settings tab for managing local tool folders, permissions and grants."
+  },
+  "settings.localToolsDesktopOnly": {
+    "message": "데스크톱 앱에서만 사용할 수 있습니다.",
+    "description": "Shown when the Local Tools tab is opened on web/mobile."
+  },
+  "settings.localToolsFoldersTitle": {
+    "message": "허용된 폴더",
+    "description": "Heading for the list of folders the AI may read/write locally."
+  },
+  "settings.localToolsFoldersHint": {
+    "message": "AI가 이 기기에서 읽고 쓸 수 있는 폴더입니다. 도구는 로컬에서 실행되며, 동의 없이는 아무것도 기기를 벗어나지 않습니다.",
+    "description": "Help text under the authorized-folders heading."
+  },
+  "settings.localToolsAddFolder": {
+    "message": "폴더 추가",
+    "description": "Button to pick a folder to authorize."
+  },
+  "settings.localToolsRemove": {
+    "message": "제거",
+    "description": "Button to remove an authorized folder."
+  },
+  "settings.localToolsNoFolders": {
+    "message": "아직 허용된 폴더가 없습니다.",
+    "description": "Empty state for the authorized-folders list."
+  },
+  "settings.localToolsSave": {
+    "message": "저장",
+    "description": "Save the authorized folders."
+  },
+  "settings.localToolsSaved": {
+    "message": "저장됨",
+    "description": "Transient confirmation after saving local-tool folders."
+  },
+  "settings.localToolsActiveTools": {
+    "message": "사용 가능한 도구",
+    "description": "Label before the list of currently available local tools."
+  },
+  "settings.localToolsGrantsTitle": {
+    "message": "항상 허용된 작업",
+    "description": "Heading for the persistent consent grants list."
+  },
+  "settings.localToolsGrantsHint": {
+    "message": "항상 허용하기로 선택한 도구 호출입니다. 다시 묻지 않고 실행됩니다. 항목을 취소하면 확인 창이 다시 표시됩니다.",
+    "description": "Help text under the always-allowed actions heading."
+  },
+  "settings.localToolsRevoke": {
+    "message": "취소",
+    "description": "Button to revoke a single always-allow grant."
+  },
+  "settings.localToolsRevokeAll": {
+    "message": "모두 취소",
+    "description": "Button to revoke every always-allow grant."
+  },
+  "settings.localToolsNoGrants": {
+    "message": "항상 허용된 작업이 없습니다. 각 로컬 도구 실행 전에 확인을 요청합니다.",
+    "description": "Empty state for the always-allowed actions list."
+  },
+  "settings.localToolsPermsTitle": {
+    "message": "시스템 권한",
+    "description": "Heading for the macOS system-permission section."
+  },
+  "settings.localToolsPermsHint": {
+    "message": "선택 사항입니다. 위의 폴더 접근에는 이 권한들이 필요하지 않습니다. 특정 작업에 필요한 것만 허용하세요.",
+    "description": "Help text under the system-permissions heading."
+  },
+  "settings.localToolsPermFullDisk": {
+    "message": "전체 디스크 접근 권한",
+    "description": "macOS Full Disk Access permission row."
+  },
+  "settings.localToolsPermScreen": {
+    "message": "화면 기록",
+    "description": "macOS Screen Recording permission row."
+  },
+  "settings.localToolsPermAccessibility": {
+    "message": "손쉬운 사용",
+    "description": "macOS Accessibility permission row."
+  },
+  "settings.localToolsGranted": {
+    "message": "허용됨",
+    "description": "Status tag when a system permission is granted."
+  },
+  "settings.localToolsNotGranted": {
+    "message": "허용 안 됨",
+    "description": "Status tag when a system permission is not granted."
+  },
+  "settings.localToolsOpen": {
+    "message": "열기…",
+    "description": "Button to open the relevant macOS System Settings pane."
+  },
   "settings.subsites": {
     "message": "내 서브사이트",
     "description": "설정 팝업의 서브사이트 관리 탭 제목. 공식 메인 사이트에서만 표시되며, 서브사이트는 표시되지 않음."

--- a/src/i18n/pl/common.json
+++ b/src/i18n/pl/common.json
@@ -903,6 +903,98 @@
     "message": "O aplikacji",
     "description": "Tytuł sekcji o aplikacji na stronie ustawień"
   },
+  "settings.localTools": {
+    "message": "Narzędzia lokalne",
+    "description": "Desktop-only settings tab for managing local tool folders, permissions and grants."
+  },
+  "settings.localToolsDesktopOnly": {
+    "message": "Dostępne tylko w aplikacji desktopowej.",
+    "description": "Shown when the Local Tools tab is opened on web/mobile."
+  },
+  "settings.localToolsFoldersTitle": {
+    "message": "Autoryzowane foldery",
+    "description": "Heading for the list of folders the AI may read/write locally."
+  },
+  "settings.localToolsFoldersHint": {
+    "message": "Foldery, które AI może odczytywać i zapisywać na tym urządzeniu. Narzędzia działają lokalnie; nic nie opuszcza urządzenia bez Twojej zgody.",
+    "description": "Help text under the authorized-folders heading."
+  },
+  "settings.localToolsAddFolder": {
+    "message": "Dodaj folder",
+    "description": "Button to pick a folder to authorize."
+  },
+  "settings.localToolsRemove": {
+    "message": "Usuń",
+    "description": "Button to remove an authorized folder."
+  },
+  "settings.localToolsNoFolders": {
+    "message": "Brak autoryzowanych folderów.",
+    "description": "Empty state for the authorized-folders list."
+  },
+  "settings.localToolsSave": {
+    "message": "Zapisz",
+    "description": "Save the authorized folders."
+  },
+  "settings.localToolsSaved": {
+    "message": "Zapisano",
+    "description": "Transient confirmation after saving local-tool folders."
+  },
+  "settings.localToolsActiveTools": {
+    "message": "Aktywne narzędzia",
+    "description": "Label before the list of currently available local tools."
+  },
+  "settings.localToolsGrantsTitle": {
+    "message": "Zawsze dozwolone działania",
+    "description": "Heading for the persistent consent grants list."
+  },
+  "settings.localToolsGrantsHint": {
+    "message": "Wywołania narzędzi, które wybrałeś, aby zawsze zezwalać. Działają bez ponownego pytania. Cofnij dowolne, aby ponownie włączyć potwierdzenie.",
+    "description": "Help text under the always-allowed actions heading."
+  },
+  "settings.localToolsRevoke": {
+    "message": "Cofnij",
+    "description": "Button to revoke a single always-allow grant."
+  },
+  "settings.localToolsRevokeAll": {
+    "message": "Cofnij wszystkie",
+    "description": "Button to revoke every always-allow grant."
+  },
+  "settings.localToolsNoGrants": {
+    "message": "Brak zawsze dozwolonych działań. Przed każdym lokalnym narzędziem pojawi się pytanie.",
+    "description": "Empty state for the always-allowed actions list."
+  },
+  "settings.localToolsPermsTitle": {
+    "message": "Uprawnienia systemowe",
+    "description": "Heading for the macOS system-permission section."
+  },
+  "settings.localToolsPermsHint": {
+    "message": "Opcjonalne. Dostęp do folderów powyżej ich nie wymaga — przyznawaj tylko to, czego wymaga konkretne zadanie.",
+    "description": "Help text under the system-permissions heading."
+  },
+  "settings.localToolsPermFullDisk": {
+    "message": "Pełny dostęp do dysku",
+    "description": "macOS Full Disk Access permission row."
+  },
+  "settings.localToolsPermScreen": {
+    "message": "Nagrywanie ekranu",
+    "description": "macOS Screen Recording permission row."
+  },
+  "settings.localToolsPermAccessibility": {
+    "message": "Dostępność",
+    "description": "macOS Accessibility permission row."
+  },
+  "settings.localToolsGranted": {
+    "message": "Przyznano",
+    "description": "Status tag when a system permission is granted."
+  },
+  "settings.localToolsNotGranted": {
+    "message": "Nie przyznano",
+    "description": "Status tag when a system permission is not granted."
+  },
+  "settings.localToolsOpen": {
+    "message": "Otwórz…",
+    "description": "Button to open the relevant macOS System Settings pane."
+  },
   "settings.subsites": {
     "message": "Moje podstrony",
     "description": "Tytuł zakładki zarządzania podstronami w oknie ustawień. Widoczne tylko na oficjalnej stronie głównej, podstrony nie są wyświetlane."

--- a/src/i18n/pt/common.json
+++ b/src/i18n/pt/common.json
@@ -903,6 +903,98 @@
     "message": "Sobre",
     "description": "Título da seção sobre na página de configurações"
   },
+  "settings.localTools": {
+    "message": "Ferramentas locais",
+    "description": "Desktop-only settings tab for managing local tool folders, permissions and grants."
+  },
+  "settings.localToolsDesktopOnly": {
+    "message": "Disponível apenas no aplicativo de desktop.",
+    "description": "Shown when the Local Tools tab is opened on web/mobile."
+  },
+  "settings.localToolsFoldersTitle": {
+    "message": "Pastas autorizadas",
+    "description": "Heading for the list of folders the AI may read/write locally."
+  },
+  "settings.localToolsFoldersHint": {
+    "message": "Pastas que a IA pode ler e gravar nesta máquina. As ferramentas são executadas localmente; nada sai do seu dispositivo sem o seu consentimento.",
+    "description": "Help text under the authorized-folders heading."
+  },
+  "settings.localToolsAddFolder": {
+    "message": "Adicionar pasta",
+    "description": "Button to pick a folder to authorize."
+  },
+  "settings.localToolsRemove": {
+    "message": "Remover",
+    "description": "Button to remove an authorized folder."
+  },
+  "settings.localToolsNoFolders": {
+    "message": "Nenhuma pasta autorizada ainda.",
+    "description": "Empty state for the authorized-folders list."
+  },
+  "settings.localToolsSave": {
+    "message": "Salvar",
+    "description": "Save the authorized folders."
+  },
+  "settings.localToolsSaved": {
+    "message": "Salvo",
+    "description": "Transient confirmation after saving local-tool folders."
+  },
+  "settings.localToolsActiveTools": {
+    "message": "Ferramentas ativas",
+    "description": "Label before the list of currently available local tools."
+  },
+  "settings.localToolsGrantsTitle": {
+    "message": "Ações sempre permitidas",
+    "description": "Heading for the persistent consent grants list."
+  },
+  "settings.localToolsGrantsHint": {
+    "message": "Chamadas de ferramentas que você optou por sempre permitir. Elas são executadas sem perguntar novamente. Revogue qualquer uma para reativar a confirmação.",
+    "description": "Help text under the always-allowed actions heading."
+  },
+  "settings.localToolsRevoke": {
+    "message": "Revogar",
+    "description": "Button to revoke a single always-allow grant."
+  },
+  "settings.localToolsRevokeAll": {
+    "message": "Revogar tudo",
+    "description": "Button to revoke every always-allow grant."
+  },
+  "settings.localToolsNoGrants": {
+    "message": "Nenhuma ação sempre permitida. Você será perguntado antes de cada ferramenta local.",
+    "description": "Empty state for the always-allowed actions list."
+  },
+  "settings.localToolsPermsTitle": {
+    "message": "Permissões do sistema",
+    "description": "Heading for the macOS system-permission section."
+  },
+  "settings.localToolsPermsHint": {
+    "message": "Opcional. O acesso às pastas acima não precisa de nenhuma — conceda apenas o que uma tarefa específica exigir.",
+    "description": "Help text under the system-permissions heading."
+  },
+  "settings.localToolsPermFullDisk": {
+    "message": "Acesso total ao disco",
+    "description": "macOS Full Disk Access permission row."
+  },
+  "settings.localToolsPermScreen": {
+    "message": "Gravação de tela",
+    "description": "macOS Screen Recording permission row."
+  },
+  "settings.localToolsPermAccessibility": {
+    "message": "Acessibilidade",
+    "description": "macOS Accessibility permission row."
+  },
+  "settings.localToolsGranted": {
+    "message": "Concedido",
+    "description": "Status tag when a system permission is granted."
+  },
+  "settings.localToolsNotGranted": {
+    "message": "Não concedido",
+    "description": "Status tag when a system permission is not granted."
+  },
+  "settings.localToolsOpen": {
+    "message": "Abrir…",
+    "description": "Button to open the relevant macOS System Settings pane."
+  },
   "settings.subsites": {
     "message": "Meus Subsites",
     "description": "Título da aba de gerenciamento de subsites na janela de configurações. Visível apenas no site oficial, subsites não são exibidos."

--- a/src/i18n/ru/common.json
+++ b/src/i18n/ru/common.json
@@ -903,6 +903,98 @@
     "message": "О нас",
     "description": "Заголовок раздела 'О нас' на странице настроек"
   },
+  "settings.localTools": {
+    "message": "Локальные инструменты",
+    "description": "Desktop-only settings tab for managing local tool folders, permissions and grants."
+  },
+  "settings.localToolsDesktopOnly": {
+    "message": "Доступно только в настольном приложении.",
+    "description": "Shown when the Local Tools tab is opened on web/mobile."
+  },
+  "settings.localToolsFoldersTitle": {
+    "message": "Разрешённые папки",
+    "description": "Heading for the list of folders the AI may read/write locally."
+  },
+  "settings.localToolsFoldersHint": {
+    "message": "Папки, которые ИИ может читать и записывать на этом устройстве. Инструменты выполняются локально; ничто не покидает ваше устройство без вашего согласия.",
+    "description": "Help text under the authorized-folders heading."
+  },
+  "settings.localToolsAddFolder": {
+    "message": "Добавить папку",
+    "description": "Button to pick a folder to authorize."
+  },
+  "settings.localToolsRemove": {
+    "message": "Удалить",
+    "description": "Button to remove an authorized folder."
+  },
+  "settings.localToolsNoFolders": {
+    "message": "Пока нет разрешённых папок.",
+    "description": "Empty state for the authorized-folders list."
+  },
+  "settings.localToolsSave": {
+    "message": "Сохранить",
+    "description": "Save the authorized folders."
+  },
+  "settings.localToolsSaved": {
+    "message": "Сохранено",
+    "description": "Transient confirmation after saving local-tool folders."
+  },
+  "settings.localToolsActiveTools": {
+    "message": "Активные инструменты",
+    "description": "Label before the list of currently available local tools."
+  },
+  "settings.localToolsGrantsTitle": {
+    "message": "Всегда разрешённые действия",
+    "description": "Heading for the persistent consent grants list."
+  },
+  "settings.localToolsGrantsHint": {
+    "message": "Вызовы инструментов, которые вы решили всегда разрешать. Они выполняются без повторного запроса. Отзовите любой, чтобы снова включить подтверждение.",
+    "description": "Help text under the always-allowed actions heading."
+  },
+  "settings.localToolsRevoke": {
+    "message": "Отозвать",
+    "description": "Button to revoke a single always-allow grant."
+  },
+  "settings.localToolsRevokeAll": {
+    "message": "Отозвать все",
+    "description": "Button to revoke every always-allow grant."
+  },
+  "settings.localToolsNoGrants": {
+    "message": "Нет всегда разрешённых действий. Перед каждым локальным инструментом будет запрашиваться подтверждение.",
+    "description": "Empty state for the always-allowed actions list."
+  },
+  "settings.localToolsPermsTitle": {
+    "message": "Системные разрешения",
+    "description": "Heading for the macOS system-permission section."
+  },
+  "settings.localToolsPermsHint": {
+    "message": "Необязательно. Для доступа к папкам выше они не нужны — предоставляйте только то, что требует конкретная задача.",
+    "description": "Help text under the system-permissions heading."
+  },
+  "settings.localToolsPermFullDisk": {
+    "message": "Полный доступ к диску",
+    "description": "macOS Full Disk Access permission row."
+  },
+  "settings.localToolsPermScreen": {
+    "message": "Запись экрана",
+    "description": "macOS Screen Recording permission row."
+  },
+  "settings.localToolsPermAccessibility": {
+    "message": "Универсальный доступ",
+    "description": "macOS Accessibility permission row."
+  },
+  "settings.localToolsGranted": {
+    "message": "Предоставлено",
+    "description": "Status tag when a system permission is granted."
+  },
+  "settings.localToolsNotGranted": {
+    "message": "Не предоставлено",
+    "description": "Status tag when a system permission is not granted."
+  },
+  "settings.localToolsOpen": {
+    "message": "Открыть…",
+    "description": "Button to open the relevant macOS System Settings pane."
+  },
   "settings.subsites": {
     "message": "Мои подсайты",
     "description": "Заголовок вкладки управления подсайтами в окне настроек. Видно только на официальном основном сайте, подсайты не отображаются."

--- a/src/i18n/sr/common.json
+++ b/src/i18n/sr/common.json
@@ -903,6 +903,98 @@
     "message": "O aplikaciji",
     "description": "Naslov sekcije o aplikaciji na stranici sa podešavanjima"
   },
+  "settings.localTools": {
+    "message": "Локални алати",
+    "description": "Desktop-only settings tab for managing local tool folders, permissions and grants."
+  },
+  "settings.localToolsDesktopOnly": {
+    "message": "Доступно само у десктоп апликацији.",
+    "description": "Shown when the Local Tools tab is opened on web/mobile."
+  },
+  "settings.localToolsFoldersTitle": {
+    "message": "Овлашћене фасцикле",
+    "description": "Heading for the list of folders the AI may read/write locally."
+  },
+  "settings.localToolsFoldersHint": {
+    "message": "Фасцикле које вештачка интелигенција сме да чита и уписује на овом уређају. Алати се извршавају локално; ништа не напушта ваш уређај без ваше сагласности.",
+    "description": "Help text under the authorized-folders heading."
+  },
+  "settings.localToolsAddFolder": {
+    "message": "Додај фасциклу",
+    "description": "Button to pick a folder to authorize."
+  },
+  "settings.localToolsRemove": {
+    "message": "Уклони",
+    "description": "Button to remove an authorized folder."
+  },
+  "settings.localToolsNoFolders": {
+    "message": "Још нема овлашћених фасцикли.",
+    "description": "Empty state for the authorized-folders list."
+  },
+  "settings.localToolsSave": {
+    "message": "Сачувај",
+    "description": "Save the authorized folders."
+  },
+  "settings.localToolsSaved": {
+    "message": "Сачувано",
+    "description": "Transient confirmation after saving local-tool folders."
+  },
+  "settings.localToolsActiveTools": {
+    "message": "Активни алати",
+    "description": "Label before the list of currently available local tools."
+  },
+  "settings.localToolsGrantsTitle": {
+    "message": "Увек дозвољене радње",
+    "description": "Heading for the persistent consent grants list."
+  },
+  "settings.localToolsGrantsHint": {
+    "message": "Позиви алата које сте изабрали да увек дозволите. Извршавају се без поновног питања. Опозовите било који да поново укључите потврду.",
+    "description": "Help text under the always-allowed actions heading."
+  },
+  "settings.localToolsRevoke": {
+    "message": "Опозови",
+    "description": "Button to revoke a single always-allow grant."
+  },
+  "settings.localToolsRevokeAll": {
+    "message": "Опозови све",
+    "description": "Button to revoke every always-allow grant."
+  },
+  "settings.localToolsNoGrants": {
+    "message": "Нема увек дозвољених радњи. Бићете упитани пре сваког локалног алата.",
+    "description": "Empty state for the always-allowed actions list."
+  },
+  "settings.localToolsPermsTitle": {
+    "message": "Системске дозволе",
+    "description": "Heading for the macOS system-permission section."
+  },
+  "settings.localToolsPermsHint": {
+    "message": "Опционо. Приступ фасциклама изнад не захтева ниједну — доделите само оно што одређени задатак захтева.",
+    "description": "Help text under the system-permissions heading."
+  },
+  "settings.localToolsPermFullDisk": {
+    "message": "Пун приступ диску",
+    "description": "macOS Full Disk Access permission row."
+  },
+  "settings.localToolsPermScreen": {
+    "message": "Снимање екрана",
+    "description": "macOS Screen Recording permission row."
+  },
+  "settings.localToolsPermAccessibility": {
+    "message": "Приступачност",
+    "description": "macOS Accessibility permission row."
+  },
+  "settings.localToolsGranted": {
+    "message": "Додељено",
+    "description": "Status tag when a system permission is granted."
+  },
+  "settings.localToolsNotGranted": {
+    "message": "Није додељено",
+    "description": "Status tag when a system permission is not granted."
+  },
+  "settings.localToolsOpen": {
+    "message": "Отвори…",
+    "description": "Button to open the relevant macOS System Settings pane."
+  },
   "settings.subsites": {
     "message": "Moje podstranice",
     "description": "Naslov taba za upravljanje podstranicama u prozoru sa podešavanjima. Vidljivo samo na zvaničnoj glavnoj stranici, podstranice se ne prikazuju."

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -903,6 +903,98 @@
     "message": "Om",
     "description": "Inställningssidans om-sektionens rubrik"
   },
+  "settings.localTools": {
+    "message": "Lokala verktyg",
+    "description": "Desktop-only settings tab for managing local tool folders, permissions and grants."
+  },
+  "settings.localToolsDesktopOnly": {
+    "message": "Endast tillgängligt i skrivbordsappen.",
+    "description": "Shown when the Local Tools tab is opened on web/mobile."
+  },
+  "settings.localToolsFoldersTitle": {
+    "message": "Auktoriserade mappar",
+    "description": "Heading for the list of folders the AI may read/write locally."
+  },
+  "settings.localToolsFoldersHint": {
+    "message": "Mappar som AI:n får läsa och skriva på den här datorn. Verktygen körs lokalt; ingenting lämnar din enhet utan ditt samtycke.",
+    "description": "Help text under the authorized-folders heading."
+  },
+  "settings.localToolsAddFolder": {
+    "message": "Lägg till mapp",
+    "description": "Button to pick a folder to authorize."
+  },
+  "settings.localToolsRemove": {
+    "message": "Ta bort",
+    "description": "Button to remove an authorized folder."
+  },
+  "settings.localToolsNoFolders": {
+    "message": "Inga auktoriserade mappar ännu.",
+    "description": "Empty state for the authorized-folders list."
+  },
+  "settings.localToolsSave": {
+    "message": "Spara",
+    "description": "Save the authorized folders."
+  },
+  "settings.localToolsSaved": {
+    "message": "Sparat",
+    "description": "Transient confirmation after saving local-tool folders."
+  },
+  "settings.localToolsActiveTools": {
+    "message": "Aktiva verktyg",
+    "description": "Label before the list of currently available local tools."
+  },
+  "settings.localToolsGrantsTitle": {
+    "message": "Alltid tillåtna åtgärder",
+    "description": "Heading for the persistent consent grants list."
+  },
+  "settings.localToolsGrantsHint": {
+    "message": "Verktygsanrop som du valt att alltid tillåta. De körs utan att fråga igen. Återkalla något för att aktivera bekräftelsen igen.",
+    "description": "Help text under the always-allowed actions heading."
+  },
+  "settings.localToolsRevoke": {
+    "message": "Återkalla",
+    "description": "Button to revoke a single always-allow grant."
+  },
+  "settings.localToolsRevokeAll": {
+    "message": "Återkalla alla",
+    "description": "Button to revoke every always-allow grant."
+  },
+  "settings.localToolsNoGrants": {
+    "message": "Inga alltid tillåtna åtgärder. Du tillfrågas före varje lokalt verktyg.",
+    "description": "Empty state for the always-allowed actions list."
+  },
+  "settings.localToolsPermsTitle": {
+    "message": "Systembehörigheter",
+    "description": "Heading for the macOS system-permission section."
+  },
+  "settings.localToolsPermsHint": {
+    "message": "Valfritt. Mappåtkomsten ovan behöver inga av dessa – bevilja bara det som en viss uppgift kräver.",
+    "description": "Help text under the system-permissions heading."
+  },
+  "settings.localToolsPermFullDisk": {
+    "message": "Fullständig diskåtkomst",
+    "description": "macOS Full Disk Access permission row."
+  },
+  "settings.localToolsPermScreen": {
+    "message": "Skärminspelning",
+    "description": "macOS Screen Recording permission row."
+  },
+  "settings.localToolsPermAccessibility": {
+    "message": "Hjälpmedel",
+    "description": "macOS Accessibility permission row."
+  },
+  "settings.localToolsGranted": {
+    "message": "Beviljad",
+    "description": "Status tag when a system permission is granted."
+  },
+  "settings.localToolsNotGranted": {
+    "message": "Inte beviljad",
+    "description": "Status tag when a system permission is not granted."
+  },
+  "settings.localToolsOpen": {
+    "message": "Öppna…",
+    "description": "Button to open the relevant macOS System Settings pane."
+  },
   "settings.subsites": {
     "message": "Mina underwebbplatser",
     "description": "Rubriken för fliken för underwebbplatsadministration i inställningsfönstret. Syns endast på officiella huvudwebbplatsen, underwebbplatser visas inte."

--- a/src/i18n/uk/common.json
+++ b/src/i18n/uk/common.json
@@ -903,6 +903,98 @@
     "message": "Про нас",
     "description": "Заголовок розділу 'Про нас' на сторінці налаштувань"
   },
+  "settings.localTools": {
+    "message": "Локальні інструменти",
+    "description": "Desktop-only settings tab for managing local tool folders, permissions and grants."
+  },
+  "settings.localToolsDesktopOnly": {
+    "message": "Доступно лише в застосунку для комп’ютера.",
+    "description": "Shown when the Local Tools tab is opened on web/mobile."
+  },
+  "settings.localToolsFoldersTitle": {
+    "message": "Дозволені папки",
+    "description": "Heading for the list of folders the AI may read/write locally."
+  },
+  "settings.localToolsFoldersHint": {
+    "message": "Папки, які ШІ може читати та записувати на цьому пристрої. Інструменти виконуються локально; ніщо не залишає ваш пристрій без вашої згоди.",
+    "description": "Help text under the authorized-folders heading."
+  },
+  "settings.localToolsAddFolder": {
+    "message": "Додати папку",
+    "description": "Button to pick a folder to authorize."
+  },
+  "settings.localToolsRemove": {
+    "message": "Вилучити",
+    "description": "Button to remove an authorized folder."
+  },
+  "settings.localToolsNoFolders": {
+    "message": "Ще немає дозволених папок.",
+    "description": "Empty state for the authorized-folders list."
+  },
+  "settings.localToolsSave": {
+    "message": "Зберегти",
+    "description": "Save the authorized folders."
+  },
+  "settings.localToolsSaved": {
+    "message": "Збережено",
+    "description": "Transient confirmation after saving local-tool folders."
+  },
+  "settings.localToolsActiveTools": {
+    "message": "Активні інструменти",
+    "description": "Label before the list of currently available local tools."
+  },
+  "settings.localToolsGrantsTitle": {
+    "message": "Завжди дозволені дії",
+    "description": "Heading for the persistent consent grants list."
+  },
+  "settings.localToolsGrantsHint": {
+    "message": "Виклики інструментів, які ви вирішили завжди дозволяти. Вони виконуються без повторного запиту. Відкличте будь-який, щоб знову ввімкнути підтвердження.",
+    "description": "Help text under the always-allowed actions heading."
+  },
+  "settings.localToolsRevoke": {
+    "message": "Відкликати",
+    "description": "Button to revoke a single always-allow grant."
+  },
+  "settings.localToolsRevokeAll": {
+    "message": "Відкликати все",
+    "description": "Button to revoke every always-allow grant."
+  },
+  "settings.localToolsNoGrants": {
+    "message": "Немає завжди дозволених дій. Перед кожним локальним інструментом запитуватиметься підтвердження.",
+    "description": "Empty state for the always-allowed actions list."
+  },
+  "settings.localToolsPermsTitle": {
+    "message": "Системні дозволи",
+    "description": "Heading for the macOS system-permission section."
+  },
+  "settings.localToolsPermsHint": {
+    "message": "Необов’язково. Для доступу до папок вище вони не потрібні — надавайте лише те, що потребує конкретне завдання.",
+    "description": "Help text under the system-permissions heading."
+  },
+  "settings.localToolsPermFullDisk": {
+    "message": "Повний доступ до диска",
+    "description": "macOS Full Disk Access permission row."
+  },
+  "settings.localToolsPermScreen": {
+    "message": "Запис екрана",
+    "description": "macOS Screen Recording permission row."
+  },
+  "settings.localToolsPermAccessibility": {
+    "message": "Доступність",
+    "description": "macOS Accessibility permission row."
+  },
+  "settings.localToolsGranted": {
+    "message": "Надано",
+    "description": "Status tag when a system permission is granted."
+  },
+  "settings.localToolsNotGranted": {
+    "message": "Не надано",
+    "description": "Status tag when a system permission is not granted."
+  },
+  "settings.localToolsOpen": {
+    "message": "Відкрити…",
+    "description": "Button to open the relevant macOS System Settings pane."
+  },
   "settings.subsites": {
     "message": "Мої підсайти",
     "description": "Заголовок вкладки управління підсайтами в спливаючому вікні налаштувань. Видно лише на офіційному головному сайті, підсайти не відображаються."

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -903,6 +903,98 @@
     "message": "关于",
     "description": "设置页面中的关于部分的标题"
   },
+  "settings.localTools": {
+    "message": "本地工具",
+    "description": "桌面专属设置 tab：管理本地工具的授权文件夹、系统权限与永久授权。"
+  },
+  "settings.localToolsDesktopOnly": {
+    "message": "仅在桌面应用中可用。",
+    "description": "在 web/移动端打开本地工具 tab 时的提示。"
+  },
+  "settings.localToolsFoldersTitle": {
+    "message": "已授权文件夹",
+    "description": "AI 可在本地读写的文件夹列表标题。"
+  },
+  "settings.localToolsFoldersHint": {
+    "message": "AI 可在本机读写的文件夹。工具在本地执行；未经你同意，任何内容都不会离开你的设备。",
+    "description": "已授权文件夹标题下的说明。"
+  },
+  "settings.localToolsAddFolder": {
+    "message": "添加文件夹",
+    "description": "选择要授权的文件夹的按钮。"
+  },
+  "settings.localToolsRemove": {
+    "message": "移除",
+    "description": "移除已授权文件夹的按钮。"
+  },
+  "settings.localToolsNoFolders": {
+    "message": "还没有授权任何文件夹。",
+    "description": "已授权文件夹列表的空状态。"
+  },
+  "settings.localToolsSave": {
+    "message": "保存",
+    "description": "保存已授权文件夹。"
+  },
+  "settings.localToolsSaved": {
+    "message": "已保存",
+    "description": "保存本地工具文件夹后的短暂确认。"
+  },
+  "settings.localToolsActiveTools": {
+    "message": "可用工具",
+    "description": "当前可用本地工具列表前的标签。"
+  },
+  "settings.localToolsGrantsTitle": {
+    "message": "永久允许的操作",
+    "description": "永久授权列表的标题。"
+  },
+  "settings.localToolsGrantsHint": {
+    "message": "你选择「永久允许」的工具调用，将不再询问直接执行。撤销任意一项可重新开启确认弹窗。",
+    "description": "永久允许操作标题下的说明。"
+  },
+  "settings.localToolsRevoke": {
+    "message": "撤销",
+    "description": "撤销单条永久授权的按钮。"
+  },
+  "settings.localToolsRevokeAll": {
+    "message": "全部撤销",
+    "description": "撤销所有永久授权的按钮。"
+  },
+  "settings.localToolsNoGrants": {
+    "message": "暂无永久允许的操作。每次执行本地工具前都会先征求你的同意。",
+    "description": "永久允许操作列表的空状态。"
+  },
+  "settings.localToolsPermsTitle": {
+    "message": "系统权限",
+    "description": "macOS 系统权限区块的标题。"
+  },
+  "settings.localToolsPermsHint": {
+    "message": "可选。上面的文件夹访问无需这些权限——只授予某个任务真正需要的。",
+    "description": "系统权限标题下的说明。"
+  },
+  "settings.localToolsPermFullDisk": {
+    "message": "完全磁盘访问权限",
+    "description": "macOS 完全磁盘访问权限行。"
+  },
+  "settings.localToolsPermScreen": {
+    "message": "屏幕录制",
+    "description": "macOS 屏幕录制权限行。"
+  },
+  "settings.localToolsPermAccessibility": {
+    "message": "辅助功能",
+    "description": "macOS 辅助功能权限行。"
+  },
+  "settings.localToolsGranted": {
+    "message": "已授权",
+    "description": "系统权限已授权时的状态标签。"
+  },
+  "settings.localToolsNotGranted": {
+    "message": "未授权",
+    "description": "系统权限未授权时的状态标签。"
+  },
+  "settings.localToolsOpen": {
+    "message": "打开\u2026",
+    "description": "打开对应 macOS 系统设置面板的按钮。"
+  },
   "settings.subsites": {
     "message": "我的分站",
     "description": "设置弹窗中分站管理 tab 的标题。仅在 official 主站可见，分站不显示。"

--- a/src/i18n/zh-TW/common.json
+++ b/src/i18n/zh-TW/common.json
@@ -903,6 +903,98 @@
     "message": "關於",
     "description": "設定頁面中的關於部分的標題"
   },
+  "settings.localTools": {
+    "message": "本機工具",
+    "description": "Desktop-only settings tab for managing local tool folders, permissions and grants."
+  },
+  "settings.localToolsDesktopOnly": {
+    "message": "僅在桌面應用程式中可用。",
+    "description": "Shown when the Local Tools tab is opened on web/mobile."
+  },
+  "settings.localToolsFoldersTitle": {
+    "message": "已授權資料夾",
+    "description": "Heading for the list of folders the AI may read/write locally."
+  },
+  "settings.localToolsFoldersHint": {
+    "message": "AI 可在本機讀寫的資料夾。工具於本機執行；未經你同意，任何內容都不會離開你的裝置。",
+    "description": "Help text under the authorized-folders heading."
+  },
+  "settings.localToolsAddFolder": {
+    "message": "新增資料夾",
+    "description": "Button to pick a folder to authorize."
+  },
+  "settings.localToolsRemove": {
+    "message": "移除",
+    "description": "Button to remove an authorized folder."
+  },
+  "settings.localToolsNoFolders": {
+    "message": "尚未授權任何資料夾。",
+    "description": "Empty state for the authorized-folders list."
+  },
+  "settings.localToolsSave": {
+    "message": "儲存",
+    "description": "Save the authorized folders."
+  },
+  "settings.localToolsSaved": {
+    "message": "已儲存",
+    "description": "Transient confirmation after saving local-tool folders."
+  },
+  "settings.localToolsActiveTools": {
+    "message": "可用工具",
+    "description": "Label before the list of currently available local tools."
+  },
+  "settings.localToolsGrantsTitle": {
+    "message": "永久允許的操作",
+    "description": "Heading for the persistent consent grants list."
+  },
+  "settings.localToolsGrantsHint": {
+    "message": "你選擇「永久允許」的工具呼叫，將不再詢問直接執行。撤銷任一項可重新開啟確認提示。",
+    "description": "Help text under the always-allowed actions heading."
+  },
+  "settings.localToolsRevoke": {
+    "message": "撤銷",
+    "description": "Button to revoke a single always-allow grant."
+  },
+  "settings.localToolsRevokeAll": {
+    "message": "全部撤銷",
+    "description": "Button to revoke every always-allow grant."
+  },
+  "settings.localToolsNoGrants": {
+    "message": "尚無永久允許的操作。每次執行本機工具前都會先徵求你的同意。",
+    "description": "Empty state for the always-allowed actions list."
+  },
+  "settings.localToolsPermsTitle": {
+    "message": "系統權限",
+    "description": "Heading for the macOS system-permission section."
+  },
+  "settings.localToolsPermsHint": {
+    "message": "選用。上方的資料夾存取不需要這些權限——只授予特定工作真正需要的。",
+    "description": "Help text under the system-permissions heading."
+  },
+  "settings.localToolsPermFullDisk": {
+    "message": "完整磁碟存取權",
+    "description": "macOS Full Disk Access permission row."
+  },
+  "settings.localToolsPermScreen": {
+    "message": "螢幕錄製",
+    "description": "macOS Screen Recording permission row."
+  },
+  "settings.localToolsPermAccessibility": {
+    "message": "輔助使用",
+    "description": "macOS Accessibility permission row."
+  },
+  "settings.localToolsGranted": {
+    "message": "已授權",
+    "description": "Status tag when a system permission is granted."
+  },
+  "settings.localToolsNotGranted": {
+    "message": "未授權",
+    "description": "Status tag when a system permission is not granted."
+  },
+  "settings.localToolsOpen": {
+    "message": "開啟…",
+    "description": "Button to open the relevant macOS System Settings pane."
+  },
   "settings.subsites": {
     "message": "我的分站",
     "description": "設定彈窗中分站管理 tab 的標題。僅在 official 主站可見，分站不顯示。"

--- a/src/pages/settings/LocalTools.vue
+++ b/src/pages/settings/LocalTools.vue
@@ -1,120 +1,29 @@
 <template>
-  <div class="local-tools">
-    <h2>Local Tools</h2>
-    <p v-if="!desktop" class="muted">Desktop app only.</p>
-    <template v-else>
-      <p class="muted">Authorize folders the AI may read/write locally. Tools execute on this machine.</p>
-      <el-button size="small" type="primary" @click="addFolder">Add folder</el-button>
-      <ul class="roots">
-        <li v-for="(r, i) in roots" :key="r">
-          <span>{{ r }}</span>
-          <el-button size="small" text @click="removeRoot(i)">remove</el-button>
-        </li>
-        <li v-if="!roots.length" class="muted">No folders yet.</li>
-      </ul>
-      <el-button size="small" :loading="saving" @click="save">Save</el-button>
-      <p v-if="tools.length" class="muted">Tools: {{ tools.join(', ') }}</p>
-      <section v-if="perm" class="perms">
-        <h3>System permissions</h3>
-        <p class="muted">Optional. Folder access above needs none of these; grant only what a task requires.</p>
-        <div class="row">
-          <span>Full Disk Access</span>
-          <b>{{ perm.fullDisk ? '✓' : '—' }}</b>
-          <el-button size="small" text @click="open('fullDisk')">Open…</el-button>
-        </div>
-        <div class="row">
-          <span>Screen Recording</span>
-          <b>{{ perm.screen }}</b>
-          <el-button size="small" text @click="open('screen')">Open…</el-button>
-        </div>
-        <div class="row">
-          <span>Accessibility</span>
-          <b>{{ perm.accessibility ? '✓' : '—' }}</b>
-          <el-button size="small" text @click="open('accessibility')">Open…</el-button>
-        </div>
-      </section>
-    </template>
+  <div class="local-tools-page">
+    <h2>{{ $t('common.settings.localTools') }}</h2>
+    <local-tools-setting />
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElButton } from 'element-plus';
-import { localExec } from '@/utils/desktop';
+import LocalToolsSetting from '@/components/setting/LocalTools.vue';
 
+// Standalone route (/settings/local-tools) kept as a thin wrapper over the
+// shared panel so there's a single source of truth — the same component also
+// renders as the "Local Tools" tab inside the user-settings dialog.
 export default defineComponent({
   name: 'SettingsLocalTools',
-  components: { ElButton },
-  data() {
-    return {
-      roots: [] as string[],
-      tools: [] as string[],
-      saving: false,
-      perm: null as null | { mac: boolean; fullDisk: boolean; screen: string; mic: string; accessibility: boolean }
-    };
-  },
-  computed: {
-    desktop(): boolean {
-      return !!localExec();
-    }
-  },
-  async mounted() {
-    const ex = localExec();
-    if (!ex) return;
-    this.roots = (await ex.getConfig()).roots;
-    this.tools = (await ex.listTools()).map((t) => t.name);
-    const s = await ex.perm?.status();
-    if (s?.mac) this.perm = s;
-  },
-  methods: {
-    async addFolder() {
-      const p = await localExec()?.pickFolder();
-      if (p && !this.roots.includes(p)) this.roots.push(p);
-    },
-    removeRoot(i: number) {
-      this.roots.splice(i, 1);
-    },
-    async open(k: 'fullDisk' | 'screen' | 'accessibility') {
-      await localExec()?.perm?.openPane(k);
-    },
-    async save() {
-      this.saving = true;
-      await localExec()?.saveConfig({ roots: this.roots, mcp: [] });
-      this.saving = false;
-    }
-  }
+  components: { LocalToolsSetting }
 });
 </script>
 
 <style scoped>
-.local-tools {
+.local-tools-page {
   padding: 24px;
+  max-width: 760px;
 }
-.muted {
-  color: #888;
-  font-size: 13px;
-}
-.roots {
-  list-style: none;
-  padding: 0;
-}
-.roots li {
-  display: flex;
-  justify-content: space-between;
-  padding: 4px 0;
-}
-.perms {
-  margin-top: 24px;
-  border-top: 1px solid #eee;
-  padding-top: 12px;
-}
-.perms .row {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 4px 0;
-}
-.perms .row span {
-  flex: 1;
+.local-tools-page h2 {
+  margin: 0 0 16px;
 }
 </style>

--- a/src/utils/desktop.ts
+++ b/src/utils/desktop.ts
@@ -63,6 +63,13 @@ export interface LocalExecBridge {
     openPane(k: 'fullDisk' | 'screen' | 'accessibility'): Promise<boolean>;
     askMedia(t: 'camera' | 'microphone'): Promise<boolean>;
   };
+  /** Persistent "always allow" consent grants (undefined off desktop). Each key
+   * is `<tool.name>:<json input>`; revoking re-arms the per-call prompt. */
+  grants?: {
+    list(): Promise<string[]>;
+    revoke(key: string): Promise<boolean>;
+    clear(): Promise<boolean>;
+  };
 }
 
 export function localExec(): LocalExecBridge | undefined {


### PR DESCRIPTION
## 背景

两个桌面本地工具的 UX 诉求(用户在 Settings 弹窗里找不到本地工具设置 + consent 想要「永久允许」):

## 改动

### 1. 把「本地工具」搬进 Settings 弹窗
之前本地工具设置只在独立路由 `/settings/local-tools`,**不在弹窗导航里**,所以用户在 Settings 弹窗里找不到。现在给用户设置弹窗 [`Setting.vue`](https://github.com/AceDataCloud/Nexior/blob/main/src/components/user/Setting.vue) 加了一个**桌面专属的「本地工具」tab**(web/移动端隐藏,以 `localExec` 桥是否存在判定)。把面板抽成 [`components/setting/LocalTools.vue`](https://github.com/AceDataCloud/Nexior/blob/main/src/components/setting/LocalTools.vue),旧路由页改成它的薄包装(单一实现来源)。面板做了打磨,和其它 tab 一致:授权文件夹、可用工具、macOS 系统权限(完全磁盘 / 屏幕录制 / 辅助功能,带状态标签 + 跳系统设置)。

### 2. consent 加「永久允许」
本地工具确认弹窗按钮现为 **Allow once / Allow for session / Always allow / Deny**。「Always allow」把一个**与会话无关**的授权键 `<tool.name>:<深度稳定 json input>` 持久化到 `local-tools.json`,之后该**精确 tool+input** 不再询问(可撤销)。按精确 input 限定,所以「永久允许 `ls /Desktop`」绝不会自动放行别的命令。新 tab 列出所有「永久允许」并提供逐条 Revoke + 全部撤销。

接线:`LocalConfig.grants`;`config.load/save` 往返保存;ipc `config.save` 合并以保留 grants;新增 origin-gated 的 `local.grants.list/revoke/clear`;preload + `desktop.ts` 桥类型。

## 🤖 对抗评审(Codex,4 条 RISK 全修)

1. **`config.load` 丢了 grants**(读时被剥离 → Always-allow 根本没持久化、还会在 save 时被擦掉)→ load 现在返回 `grants`。
2. **稳定序列化用了 `JSON.stringify(input, keysArray)` replacer-array 形式,会静默丢弃嵌套字段** → `{cfg:{path:"/safe"}}` 与 `{cfg:{path:"/danger"}}` 会塌成同一个键 → 授权泄漏到危险调用。改为**深度递归**稳定序列化;node 实测:无碰撞、键序无关。
3. **授权键 UI 解析**改为在第一个 `:{` 处切分(即使 tool 名含冒号也稳)。
4. RISK1(共享 `sameOrigin` gate)是既有边界(更危险的 invoke handler 早已在用;Electron 把 `app://` 注册为 standard scheme,`.origin` 是真值),不在本 UX PR 范围。

## 校验

`vue-tsc -b` ✅ · electron `tsc --noEmit` ✅ · eslint ✅ · prettier ✅ · beachball change 已附。仅桌面 UX + 本地 consent;不碰 web/计费/后端。
