### PR TITLE
fix(theme): stop Settings theme switcher from flipping theme on open

### DIFF
--- a/change/@acedatacloud-nexior-ce55abaa-3da2-4c22-ae1d-09b98d9ae467.json
+++ b/change/@acedatacloud-nexior-ce55abaa-3da2-4c22-ae1d-09b98d9ae467.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(theme): stop Settings theme switcher from flipping the theme on open",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/user/Theme.vue
+++ b/src/components/user/Theme.vue
@@ -17,7 +17,7 @@
 import { defineComponent } from 'vue';
 import { ElDropdown, ElDropdownMenu, ElDropdownItem, ElIcon } from 'element-plus';
 import { getDomain } from '@/utils';
-import { getCookie, setCookie } from 'typescript-cookie';
+import { setCookie } from 'typescript-cookie';
 import { ArrowDown } from '@element-plus/icons-vue';
 
 export default defineComponent({
@@ -42,8 +42,11 @@ export default defineComponent({
     }
   },
   mounted() {
-    this.theme = this.loadFromCookie();
-    this.applyTheme();
+    // Mirror the theme already applied at startup by `initializeTheme`
+    // (cookie-or-dark) via the live <html> class. Re-deriving from the
+    // cookie here used a different default ('light') and stricter parse,
+    // so a missing/non-canonical cookie flipped the theme on Settings open.
+    this.theme = document.documentElement.classList.contains('dark') ? 'dark' : 'light';
   },
   methods: {
     onSelect(command: 'light' | 'dark') {
@@ -60,10 +63,6 @@ export default defineComponent({
       } else {
         document.documentElement.classList.remove('dark');
       }
-    },
-    loadFromCookie(): 'light' | 'dark' {
-      const saved = getCookie('THEME');
-      return saved === 'dark' ? 'dark' : 'light';
     }
   }
 });


### PR DESCRIPTION
## What

Fixes the intermittent **theme flip when opening the Settings dialog** (usually dark → light).

## Root cause

`src/components/user/Theme.vue` (the theme switcher) is **only** mounted inside Settings → General. Its `mounted()` re-derived **and re-applied** the theme from the `THEME` cookie, using a **different default and parse** than the app-startup `initializeTheme()`:

| Path | Missing/empty cookie resolves to |
|---|---|
| startup `initializeTheme()` (`utils/initializer.ts`) — `getCookie('THEME') \|\| 'dark'` | **dark** |
| `Theme.vue.loadFromCookie()` — `getCookie('THEME') === 'dark' ? 'dark' : 'light'` | **light** |

So when the `THEME` cookie is absent or non-canonical, the app boots **dark** but mounting the switcher (opening Settings) flips it to **light** and rewrites the cookie.

`initializeCookies()` eagerly writes `THEME='dark'` when missing, which masks the bug on the web — but origins that reject a **domain-scoped** cookie write (Capacitor `capacitor://`, Electron `file://`, IP hosts, blocked cookies) keep the cookie absent, so the flip returns. That matches "can't reproduce recently, but it used to happen."

## Fix

In `Theme.vue mounted()`, **mirror** the already-applied theme by reading the live `<html>` `dark` class (the authoritative state `initializeTheme` set) and **stop re-applying on mount**. Only an explicit user choice (`onSelect` → `applyTheme`) writes the cookie + toggles the class. Removed the now-unused `loadFromCookie()` and `getCookie` import.

A switcher should *reflect* global state, never re-impose its own re-derivation on mount.

## 🤖 对抗评审

- Reviewer: **Codex** (`codex exec --sandbox read-only`, file-based diff).
- Scope: state correctness, SSR/hydration (`document` in `mounted`), stale label, user-switch regressions, unused imports.
- Result: **VERDICT: CLEAN** (1 round, no `RISK` findings). `mounted` is client-only (Element Plus dialog never renders during the SSG build), user-initiated switching is unchanged, and the dropped import/method are fully unused.

## Test

- `get_errors` on the file: no type errors.
- Manual reasoning: cookie `dark` → dark class → switcher shows dark; cookie `light` → no dark class → switcher shows light; cookie **absent** → `initializeTheme` applied dark → switcher now also shows **dark** (previously wrongly forced light). No mount-time DOM mutation in any case.
