### PR TITLE
feat(download): add Windows and macOS desktop installers

### DIFF
--- a/change/@acedatacloud-nexior-desktop-download-cards.json
+++ b/change/@acedatacloud-nexior-desktop-download-cards.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(download): add Windows (.exe) and macOS (Intel + Apple Silicon .dmg) desktop installer cards, linking the public GitHub Release assets",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/constants/mobile.ts
+++ b/src/constants/mobile.ts
@@ -9,3 +9,17 @@ export const MOBILE_IOS_APP_STORE_URL = 'https://apps.apple.com/app/id6772432921
 export const MOBILE_IOS_DOWNLOAD_URL = '';
 
 export const MOBILE_IOS_FALLBACK_URL = '';
+
+// Desktop (Electron) installers — attached to every public GitHub Release.
+// UNSIGNED beta: Windows SmartScreen / macOS Gatekeeper warn on first launch.
+// URLs embed the version → bump DESKTOP_APP_VERSION each release (like the APK).
+export const DESKTOP_APP_VERSION = '3.292.0';
+
+const DESKTOP_RELEASE_TAG = `@acedatacloud%2Fnexior_v${DESKTOP_APP_VERSION}`;
+const DESKTOP_RELEASE_BASE = `https://github.com/AceDataCloud/Nexior/releases/download/${DESKTOP_RELEASE_TAG}`;
+
+export const DESKTOP_WINDOWS_DOWNLOAD_URL = `${DESKTOP_RELEASE_BASE}/AceData.Setup.${DESKTOP_APP_VERSION}.exe`;
+
+export const DESKTOP_MAC_ARM_DOWNLOAD_URL = `${DESKTOP_RELEASE_BASE}/AceData-${DESKTOP_APP_VERSION}-arm64.dmg`;
+
+export const DESKTOP_MAC_INTEL_DOWNLOAD_URL = `${DESKTOP_RELEASE_BASE}/AceData-${DESKTOP_APP_VERSION}.dmg`;

--- a/src/i18n/ar/common.json
+++ b/src/i18n/ar/common.json
@@ -127,6 +127,14 @@
     "message": "تنزيل حزمة تثبيت iOS",
     "description": "النص في الزر، المستخدم لتنزيل ملف حزمة تثبيت iOS"
   },
+  "button.downloadWindows": {
+    "message": "تنزيل لنظام Windows",
+    "description": "Text in button for downloading the Windows desktop installer"
+  },
+  "button.downloadMac": {
+    "message": "تنزيل لنظام macOS",
+    "description": "Text in button for downloading the macOS desktop installer"
+  },
   "button.installIos": {
     "message": "تثبيت iOS",
     "description": "النص في الزر، المستخدم لتثبيت تطبيق iOS"
@@ -302,6 +310,18 @@
   "message.mobileNowOnAppStore": {
     "message": "Now on the App Store",
     "description": "Status label shown on the iOS card when the app is live on the App Store"
+  },
+  "message.desktopWindowsHint": {
+    "message": "لنظام Windows 10 والأحدث (64 بت). نزّل المثبّت وانقر نقرًا مزدوجًا للتثبيت.",
+    "description": "Windows desktop download card description"
+  },
+  "message.desktopMacHint": {
+    "message": "لنظام macOS 11 والأحدث. اختر النسخة المناسبة لجهاز Mac لديك — معالج Apple (سلسلة M) أو Intel.",
+    "description": "macOS desktop download card description"
+  },
+  "message.desktopUnsignedNote": {
+    "message": "تطبيقات سطح المكتب هي إصدارات Beta غير موقّعة. على Windows اختر ‹مزيد من المعلومات ← التشغيل على أي حال› عند ظهور SmartScreen؛ وعلى macOS انقر بزر الفأرة الأيمن على التطبيق واختر ‹فتح› لتجاوز Gatekeeper.",
+    "description": "Note explaining the desktop builds are unsigned betas and how to open them"
   },
   "button.getOnGooglePlay": {
     "message": "تنزيل من Google Play",

--- a/src/i18n/de/common.json
+++ b/src/i18n/de/common.json
@@ -127,6 +127,14 @@
     "message": "iOS-Installationspaket herunterladen",
     "description": "Text im Button, der verwendet wird, um die iOS-Installationsdatei herunterzuladen"
   },
+  "button.downloadWindows": {
+    "message": "Für Windows herunterladen",
+    "description": "Text in button for downloading the Windows desktop installer"
+  },
+  "button.downloadMac": {
+    "message": "Für macOS herunterladen",
+    "description": "Text in button for downloading the macOS desktop installer"
+  },
   "button.installIos": {
     "message": "iOS installieren",
     "description": "Text im Button, der verwendet wird, um die iOS-Anwendung zu installieren"
@@ -302,6 +310,18 @@
   "message.mobileNowOnAppStore": {
     "message": "Now on the App Store",
     "description": "Status label shown on the iOS card when the app is live on the App Store"
+  },
+  "message.desktopWindowsHint": {
+    "message": "Für Windows 10 und neuer (64-Bit). Installationsprogramm herunterladen und zum Einrichten doppelklicken.",
+    "description": "Windows desktop download card description"
+  },
+  "message.desktopMacHint": {
+    "message": "Für macOS 11 und neuer. Wähle die passende Version für deinen Mac — Apple Silicon (M-Serie) oder Intel.",
+    "description": "macOS desktop download card description"
+  },
+  "message.desktopUnsignedNote": {
+    "message": "Die Desktop-Apps sind unsignierte Beta-Builds. Wähle unter Windows bei der SmartScreen-Meldung „Weitere Informationen → Trotzdem ausführen“; unter macOS klicke mit der rechten Maustaste auf die App und wähle „Öffnen“, um Gatekeeper zu umgehen.",
+    "description": "Note explaining the desktop builds are unsigned betas and how to open them"
   },
   "button.getOnGooglePlay": {
     "message": "Jetzt bei Google Play",

--- a/src/i18n/el/common.json
+++ b/src/i18n/el/common.json
@@ -127,6 +127,14 @@
     "message": "Λήψη πακέτου εγκατάστασης iOS",
     "description": "Κείμενο στο κουμπί για να κατεβάσετε το πακέτο εγκατάστασης iOS"
   },
+  "button.downloadWindows": {
+    "message": "Λήψη για Windows",
+    "description": "Text in button for downloading the Windows desktop installer"
+  },
+  "button.downloadMac": {
+    "message": "Λήψη για macOS",
+    "description": "Text in button for downloading the macOS desktop installer"
+  },
   "button.installIos": {
     "message": "Εγκατάσταση iOS",
     "description": "Κείμενο στο κουμπί για να εγκαταστήσετε την εφαρμογή iOS"
@@ -302,6 +310,18 @@
   "message.mobileNowOnAppStore": {
     "message": "Now on the App Store",
     "description": "Status label shown on the iOS card when the app is live on the App Store"
+  },
+  "message.desktopWindowsHint": {
+    "message": "Για Windows 10 και νεότερα (64-bit). Κατεβάστε το πρόγραμμα εγκατάστασης και κάντε διπλό κλικ για εγκατάσταση.",
+    "description": "Windows desktop download card description"
+  },
+  "message.desktopMacHint": {
+    "message": "Για macOS 11 και νεότερα. Επιλέξτε την έκδοση που ταιριάζει στο Mac σας — Apple Silicon (σειρά M) ή Intel.",
+    "description": "macOS desktop download card description"
+  },
+  "message.desktopUnsignedNote": {
+    "message": "Οι εφαρμογές για υπολογιστή είναι ανυπόγραφες εκδόσεις beta. Στα Windows επιλέξτε «Περισσότερες πληροφορίες → Εκτέλεση ούτως ή άλλως» στο μήνυμα SmartScreen· στο macOS κάντε δεξί κλικ στην εφαρμογή και επιλέξτε «Άνοιγμα» για να παρακάμψετε το Gatekeeper.",
+    "description": "Note explaining the desktop builds are unsigned betas and how to open them"
   },
   "button.getOnGooglePlay": {
     "message": "Λήψη από το Google Play",

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -123,6 +123,14 @@
     "message": "Download iOS",
     "description": "Text in button for downloading the iOS installation package"
   },
+  "button.downloadWindows": {
+    "message": "Download for Windows",
+    "description": "Text in button for downloading the Windows desktop installer"
+  },
+  "button.downloadMac": {
+    "message": "Download for macOS",
+    "description": "Text in button for downloading the macOS desktop installer"
+  },
   "button.installIos": {
     "message": "Install iOS",
     "description": "Text in button for installing the iOS app"
@@ -298,6 +306,18 @@
   "message.mobileNowOnAppStore": {
     "message": "Now on the App Store",
     "description": "Status label shown on the iOS card when the app is live on the App Store"
+  },
+  "message.desktopWindowsHint": {
+    "message": "For Windows 10 and later (64-bit). Download the installer and double-click to set up.",
+    "description": "Windows desktop download card description"
+  },
+  "message.desktopMacHint": {
+    "message": "For macOS 11 and later. Choose the build that matches your Mac — Apple Silicon (M-series) or Intel.",
+    "description": "macOS desktop download card description"
+  },
+  "message.desktopUnsignedNote": {
+    "message": "The desktop apps are unsigned beta builds. On Windows, choose ‘More info → Run anyway’ at the SmartScreen prompt; on macOS, right-click the app and choose ‘Open’ to bypass Gatekeeper.",
+    "description": "Note explaining the desktop builds are unsigned betas and how to open them"
   },
   "button.getOnGooglePlay": {
     "message": "Get it on Google Play",

--- a/src/i18n/es/common.json
+++ b/src/i18n/es/common.json
@@ -127,6 +127,14 @@
     "message": "Descargar paquete de instalación de iOS",
     "description": "Texto en el botón, utilizado para descargar el archivo del paquete de instalación de iOS"
   },
+  "button.downloadWindows": {
+    "message": "Descargar para Windows",
+    "description": "Text in button for downloading the Windows desktop installer"
+  },
+  "button.downloadMac": {
+    "message": "Descargar para macOS",
+    "description": "Text in button for downloading the macOS desktop installer"
+  },
   "button.installIos": {
     "message": "Instalar iOS",
     "description": "Texto en el botón, utilizado para instalar la aplicación de iOS"
@@ -302,6 +310,18 @@
   "message.mobileNowOnAppStore": {
     "message": "Now on the App Store",
     "description": "Status label shown on the iOS card when the app is live on the App Store"
+  },
+  "message.desktopWindowsHint": {
+    "message": "Para Windows 10 y posterior (64 bits). Descarga el instalador y haz doble clic para instalar.",
+    "description": "Windows desktop download card description"
+  },
+  "message.desktopMacHint": {
+    "message": "Para macOS 11 y posterior. Elige la versión que coincida con tu Mac: Apple Silicon (serie M) o Intel.",
+    "description": "macOS desktop download card description"
+  },
+  "message.desktopUnsignedNote": {
+    "message": "Las apps de escritorio son versiones beta sin firmar. En Windows, elige «Más información → Ejecutar de todas formas» en el aviso de SmartScreen; en macOS, haz clic derecho en la app y elige «Abrir» para omitir Gatekeeper.",
+    "description": "Note explaining the desktop builds are unsigned betas and how to open them"
   },
   "button.getOnGooglePlay": {
     "message": "Disponible en Google Play",

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -127,6 +127,14 @@
     "message": "Lataa iOS-asennustiedosto",
     "description": "Painikkeen teksti, jota käytetään iOS-asennustiedoston lataamiseen"
   },
+  "button.downloadWindows": {
+    "message": "Lataa Windowsille",
+    "description": "Text in button for downloading the Windows desktop installer"
+  },
+  "button.downloadMac": {
+    "message": "Lataa macOS:lle",
+    "description": "Text in button for downloading the macOS desktop installer"
+  },
   "button.installIos": {
     "message": "Asenna iOS",
     "description": "Painikkeen teksti, jota käytetään iOS-sovelluksen asentamiseen"
@@ -302,6 +310,18 @@
   "message.mobileNowOnAppStore": {
     "message": "Now on the App Store",
     "description": "Status label shown on the iOS card when the app is live on the App Store"
+  },
+  "message.desktopWindowsHint": {
+    "message": "Windows 10:lle ja uudemmille (64-bittinen). Lataa asennusohjelma ja asenna kaksoisnapsauttamalla.",
+    "description": "Windows desktop download card description"
+  },
+  "message.desktopMacHint": {
+    "message": "macOS 11:lle ja uudemmille. Valitse Maciisi sopiva versio — Apple Silicon (M-sarja) tai Intel.",
+    "description": "macOS desktop download card description"
+  },
+  "message.desktopUnsignedNote": {
+    "message": "Työpöytäsovellukset ovat allekirjoittamattomia beta-versioita. Valitse Windowsissa SmartScreen-ilmoituksessa »Lisätietoja → Suorita silti«; valitse macOS:ssä sovellusta hiiren oikealla painikkeella »Avaa« ohittaaksesi Gatekeeperin.",
+    "description": "Note explaining the desktop builds are unsigned betas and how to open them"
   },
   "button.getOnGooglePlay": {
     "message": "Lataa Google Playsta",

--- a/src/i18n/fr/common.json
+++ b/src/i18n/fr/common.json
@@ -127,6 +127,14 @@
     "message": "Télécharger le package d'installation iOS",
     "description": "Texte dans le bouton, utilisé pour télécharger le fichier d'installation iOS"
   },
+  "button.downloadWindows": {
+    "message": "Télécharger pour Windows",
+    "description": "Text in button for downloading the Windows desktop installer"
+  },
+  "button.downloadMac": {
+    "message": "Télécharger pour macOS",
+    "description": "Text in button for downloading the macOS desktop installer"
+  },
   "button.installIos": {
     "message": "Installer iOS",
     "description": "Texte dans le bouton, utilisé pour installer l'application iOS"
@@ -302,6 +310,18 @@
   "message.mobileNowOnAppStore": {
     "message": "Now on the App Store",
     "description": "Status label shown on the iOS card when the app is live on the App Store"
+  },
+  "message.desktopWindowsHint": {
+    "message": "Pour Windows 10 et versions ultérieures (64 bits). Téléchargez l’installateur et double-cliquez pour l’installer.",
+    "description": "Windows desktop download card description"
+  },
+  "message.desktopMacHint": {
+    "message": "Pour macOS 11 et versions ultérieures. Choisissez la version adaptée à votre Mac — Apple Silicon (série M) ou Intel.",
+    "description": "macOS desktop download card description"
+  },
+  "message.desktopUnsignedNote": {
+    "message": "Les applications de bureau sont des versions bêta non signées. Sous Windows, choisissez « Informations complémentaires → Exécuter quand même » dans l’invite SmartScreen ; sous macOS, faites un clic droit sur l’application et choisissez « Ouvrir » pour contourner Gatekeeper.",
+    "description": "Note explaining the desktop builds are unsigned betas and how to open them"
   },
   "button.getOnGooglePlay": {
     "message": "Disponible sur Google Play",

--- a/src/i18n/it/common.json
+++ b/src/i18n/it/common.json
@@ -127,6 +127,14 @@
     "message": "Scarica pacchetto iOS",
     "description": "Testo nel pulsante, utilizzato per scaricare il pacchetto di installazione iOS"
   },
+  "button.downloadWindows": {
+    "message": "Scarica per Windows",
+    "description": "Text in button for downloading the Windows desktop installer"
+  },
+  "button.downloadMac": {
+    "message": "Scarica per macOS",
+    "description": "Text in button for downloading the macOS desktop installer"
+  },
   "button.installIos": {
     "message": "Installa iOS",
     "description": "Testo nel pulsante, utilizzato per installare l'app iOS"
@@ -302,6 +310,18 @@
   "message.mobileNowOnAppStore": {
     "message": "Now on the App Store",
     "description": "Status label shown on the iOS card when the app is live on the App Store"
+  },
+  "message.desktopWindowsHint": {
+    "message": "Per Windows 10 e versioni successive (64 bit). Scarica il programma di installazione e fai doppio clic per installare.",
+    "description": "Windows desktop download card description"
+  },
+  "message.desktopMacHint": {
+    "message": "Per macOS 11 e versioni successive. Scegli la versione adatta al tuo Mac — Apple Silicon (serie M) o Intel.",
+    "description": "macOS desktop download card description"
+  },
+  "message.desktopUnsignedNote": {
+    "message": "Le app desktop sono versioni beta non firmate. Su Windows scegli «Maggiori informazioni → Esegui comunque» nell’avviso SmartScreen; su macOS fai clic con il tasto destro sull’app e scegli «Apri» per ignorare Gatekeeper.",
+    "description": "Note explaining the desktop builds are unsigned betas and how to open them"
   },
   "button.getOnGooglePlay": {
     "message": "Disponibile su Google Play",

--- a/src/i18n/ja/common.json
+++ b/src/i18n/ja/common.json
@@ -127,6 +127,14 @@
     "message": "iOSインストーラをダウンロード",
     "description": "ボタンのテキスト、iOSインストーラファイルをダウンロードするため"
   },
+  "button.downloadWindows": {
+    "message": "Windows 版をダウンロード",
+    "description": "Text in button for downloading the Windows desktop installer"
+  },
+  "button.downloadMac": {
+    "message": "macOS 版をダウンロード",
+    "description": "Text in button for downloading the macOS desktop installer"
+  },
   "button.installIos": {
     "message": "iOSをインストール",
     "description": "ボタンのテキスト、iOSアプリをインストールするため"
@@ -302,6 +310,18 @@
   "message.mobileNowOnAppStore": {
     "message": "Now on the App Store",
     "description": "Status label shown on the iOS card when the app is live on the App Store"
+  },
+  "message.desktopWindowsHint": {
+    "message": "Windows 10 以降（64 ビット）向け。インストーラーをダウンロードし、ダブルクリックしてセットアップします。",
+    "description": "Windows desktop download card description"
+  },
+  "message.desktopMacHint": {
+    "message": "macOS 11 以降向け。お使いの Mac に合うビルドを選択してください —— Apple Silicon（M シリーズ）または Intel。",
+    "description": "macOS desktop download card description"
+  },
+  "message.desktopUnsignedNote": {
+    "message": "デスクトップ版は未署名のベータビルドです。Windows では SmartScreen の警告で「詳細情報 → 実行」を選択してください。macOS ではアプリを右クリックして「開く」を選ぶと Gatekeeper を回避できます。",
+    "description": "Note explaining the desktop builds are unsigned betas and how to open them"
   },
   "button.getOnGooglePlay": {
     "message": "Google Play で手に入れよう",

--- a/src/i18n/ko/common.json
+++ b/src/i18n/ko/common.json
@@ -127,6 +127,14 @@
     "message": "iOS 설치 파일 다운로드",
     "description": "버튼의 텍스트, iOS 설치 파일을 다운로드하는 데 사용"
   },
+  "button.downloadWindows": {
+    "message": "Windows용 다운로드",
+    "description": "Text in button for downloading the Windows desktop installer"
+  },
+  "button.downloadMac": {
+    "message": "macOS용 다운로드",
+    "description": "Text in button for downloading the macOS desktop installer"
+  },
   "button.installIos": {
     "message": "iOS 설치",
     "description": "버튼의 텍스트, iOS 애플리케이션을 설치하는 데 사용"
@@ -302,6 +310,18 @@
   "message.mobileNowOnAppStore": {
     "message": "Now on the App Store",
     "description": "Status label shown on the iOS card when the app is live on the App Store"
+  },
+  "message.desktopWindowsHint": {
+    "message": "Windows 10 이상(64비트)용. 설치 프로그램을 내려받아 두 번 클릭하면 설치됩니다.",
+    "description": "Windows desktop download card description"
+  },
+  "message.desktopMacHint": {
+    "message": "macOS 11 이상용. 사용 중인 Mac에 맞는 빌드를 선택하세요 — Apple Silicon(M 시리즈) 또는 Intel.",
+    "description": "macOS desktop download card description"
+  },
+  "message.desktopUnsignedNote": {
+    "message": "데스크톱 앱은 서명되지 않은 베타 빌드입니다. Windows에서는 SmartScreen 알림에서 ‘추가 정보 → 실행’을 선택하고, macOS에서는 앱을 마우스 오른쪽 버튼으로 클릭한 뒤 ‘열기’를 선택하면 Gatekeeper를 우회할 수 있습니다.",
+    "description": "Note explaining the desktop builds are unsigned betas and how to open them"
   },
   "button.getOnGooglePlay": {
     "message": "Google Play에서 다운로드",

--- a/src/i18n/pl/common.json
+++ b/src/i18n/pl/common.json
@@ -127,6 +127,14 @@
     "message": "Pobierz pakiet instalacyjny iOS",
     "description": "Tekst w przycisku, używany do pobierania pliku instalacyjnego iOS"
   },
+  "button.downloadWindows": {
+    "message": "Pobierz dla Windows",
+    "description": "Text in button for downloading the Windows desktop installer"
+  },
+  "button.downloadMac": {
+    "message": "Pobierz dla macOS",
+    "description": "Text in button for downloading the macOS desktop installer"
+  },
   "button.installIos": {
     "message": "Zainstaluj iOS",
     "description": "Tekst w przycisku, używany do instalacji aplikacji iOS"
@@ -302,6 +310,18 @@
   "message.mobileNowOnAppStore": {
     "message": "Now on the App Store",
     "description": "Status label shown on the iOS card when the app is live on the App Store"
+  },
+  "message.desktopWindowsHint": {
+    "message": "Dla Windows 10 i nowszych (64-bit). Pobierz instalator i kliknij dwukrotnie, aby zainstalować.",
+    "description": "Windows desktop download card description"
+  },
+  "message.desktopMacHint": {
+    "message": "Dla macOS 11 i nowszych. Wybierz wersję pasującą do Twojego Maca — Apple Silicon (seria M) lub Intel.",
+    "description": "macOS desktop download card description"
+  },
+  "message.desktopUnsignedNote": {
+    "message": "Aplikacje na komputer to niepodpisane wersje beta. W systemie Windows wybierz „Więcej informacji → Uruchom mimo to” w oknie SmartScreen; w systemie macOS kliknij aplikację prawym przyciskiem myszy i wybierz „Otwórz”, aby pominąć Gatekeeper.",
+    "description": "Note explaining the desktop builds are unsigned betas and how to open them"
   },
   "button.getOnGooglePlay": {
     "message": "Pobierz z Google Play",

--- a/src/i18n/pt/common.json
+++ b/src/i18n/pt/common.json
@@ -127,6 +127,14 @@
     "message": "Baixar iOS",
     "description": "Texto no botão para baixar o arquivo de instalação do iOS"
   },
+  "button.downloadWindows": {
+    "message": "Baixar para Windows",
+    "description": "Text in button for downloading the Windows desktop installer"
+  },
+  "button.downloadMac": {
+    "message": "Baixar para macOS",
+    "description": "Text in button for downloading the macOS desktop installer"
+  },
   "button.installIos": {
     "message": "Instalar iOS",
     "description": "Texto no botão para instalar o aplicativo iOS"
@@ -302,6 +310,18 @@
   "message.mobileNowOnAppStore": {
     "message": "Now on the App Store",
     "description": "Status label shown on the iOS card when the app is live on the App Store"
+  },
+  "message.desktopWindowsHint": {
+    "message": "Para Windows 10 e posterior (64 bits). Baixe o instalador e clique duas vezes para instalar.",
+    "description": "Windows desktop download card description"
+  },
+  "message.desktopMacHint": {
+    "message": "Para macOS 11 e posterior. Escolha a versão que corresponde ao seu Mac — Apple Silicon (série M) ou Intel.",
+    "description": "macOS desktop download card description"
+  },
+  "message.desktopUnsignedNote": {
+    "message": "Os aplicativos de desktop são versões beta não assinadas. No Windows, escolha «Mais informações → Executar assim mesmo» no aviso do SmartScreen; no macOS, clique com o botão direito no app e escolha «Abrir» para ignorar o Gatekeeper.",
+    "description": "Note explaining the desktop builds are unsigned betas and how to open them"
   },
   "button.getOnGooglePlay": {
     "message": "Disponível no Google Play",

--- a/src/i18n/ru/common.json
+++ b/src/i18n/ru/common.json
@@ -127,6 +127,14 @@
     "message": "Скачать для iOS",
     "description": "Текст в кнопке, используемый для скачивания установочного пакета для iOS"
   },
+  "button.downloadWindows": {
+    "message": "Скачать для Windows",
+    "description": "Text in button for downloading the Windows desktop installer"
+  },
+  "button.downloadMac": {
+    "message": "Скачать для macOS",
+    "description": "Text in button for downloading the macOS desktop installer"
+  },
   "button.installIos": {
     "message": "Установить для iOS",
     "description": "Текст в кнопке, используемый для установки приложения для iOS"
@@ -302,6 +310,18 @@
   "message.mobileNowOnAppStore": {
     "message": "Now on the App Store",
     "description": "Status label shown on the iOS card when the app is live on the App Store"
+  },
+  "message.desktopWindowsHint": {
+    "message": "Для Windows 10 и новее (64-бит). Скачайте установщик и дважды щёлкните для установки.",
+    "description": "Windows desktop download card description"
+  },
+  "message.desktopMacHint": {
+    "message": "Для macOS 11 и новее. Выберите сборку для вашего Mac — Apple Silicon (серия M) или Intel.",
+    "description": "macOS desktop download card description"
+  },
+  "message.desktopUnsignedNote": {
+    "message": "Настольные приложения — это неподписанные бета-сборки. В Windows выберите «Подробнее → Выполнить в любом случае» в окне SmartScreen; в macOS щёлкните приложение правой кнопкой мыши и выберите «Открыть», чтобы обойти Gatekeeper.",
+    "description": "Note explaining the desktop builds are unsigned betas and how to open them"
   },
   "button.getOnGooglePlay": {
     "message": "Доступно в Google Play",

--- a/src/i18n/sr/common.json
+++ b/src/i18n/sr/common.json
@@ -127,6 +127,14 @@
     "message": "Preuzmi iOS instalacioni paket",
     "description": "Tekst u dugmetu, koji se koristi za preuzimanje iOS instalacionog paketa"
   },
+  "button.downloadWindows": {
+    "message": "Преузми за Windows",
+    "description": "Text in button for downloading the Windows desktop installer"
+  },
+  "button.downloadMac": {
+    "message": "Преузми за macOS",
+    "description": "Text in button for downloading the macOS desktop installer"
+  },
   "button.installIos": {
     "message": "Instaliraj iOS",
     "description": "Tekst u dugmetu, koji se koristi za instalaciju iOS aplikacije"
@@ -302,6 +310,18 @@
   "message.mobileNowOnAppStore": {
     "message": "Now on the App Store",
     "description": "Status label shown on the iOS card when the app is live on the App Store"
+  },
+  "message.desktopWindowsHint": {
+    "message": "За Windows 10 и новије (64-битни). Преузмите инсталер и двапут кликните да бисте инсталирали.",
+    "description": "Windows desktop download card description"
+  },
+  "message.desktopMacHint": {
+    "message": "За macOS 11 и новије. Изаберите верзију која одговара вашем Mac-у — Apple Silicon (M серија) или Intel.",
+    "description": "macOS desktop download card description"
+  },
+  "message.desktopUnsignedNote": {
+    "message": "Десктоп апликације су непотписане бета верзије. На Windows-у изаберите „Више информација → Свеједно покрени“ у SmartScreen упозорењу; на macOS-у кликните десним тастером на апликацију и изаберите „Отвори“ да бисте заобишли Gatekeeper.",
+    "description": "Note explaining the desktop builds are unsigned betas and how to open them"
   },
   "button.getOnGooglePlay": {
     "message": "Преузмите са Google Play-а",

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -127,6 +127,14 @@
     "message": "Ladda ner iOS-installationspaket",
     "description": "Text i knappen för att ladda ner iOS-installationspaketet"
   },
+  "button.downloadWindows": {
+    "message": "Ladda ner för Windows",
+    "description": "Text in button for downloading the Windows desktop installer"
+  },
+  "button.downloadMac": {
+    "message": "Ladda ner för macOS",
+    "description": "Text in button for downloading the macOS desktop installer"
+  },
   "button.installIos": {
     "message": "Installera iOS",
     "description": "Text i knappen för att installera iOS-appen"
@@ -302,6 +310,18 @@
   "message.mobileNowOnAppStore": {
     "message": "Now on the App Store",
     "description": "Status label shown on the iOS card when the app is live on the App Store"
+  },
+  "message.desktopWindowsHint": {
+    "message": "För Windows 10 och senare (64-bitars). Ladda ner installationsprogrammet och dubbelklicka för att installera.",
+    "description": "Windows desktop download card description"
+  },
+  "message.desktopMacHint": {
+    "message": "För macOS 11 och senare. Välj versionen som passar din Mac — Apple Silicon (M-serien) eller Intel.",
+    "description": "macOS desktop download card description"
+  },
+  "message.desktopUnsignedNote": {
+    "message": "Skrivbordsapparna är osignerade beta-versioner. I Windows väljer du ”Mer information → Kör ändå” vid SmartScreen-meddelandet; i macOS högerklickar du på appen och väljer ”Öppna” för att kringgå Gatekeeper.",
+    "description": "Note explaining the desktop builds are unsigned betas and how to open them"
   },
   "button.getOnGooglePlay": {
     "message": "Hämta på Google Play",

--- a/src/i18n/uk/common.json
+++ b/src/i18n/uk/common.json
@@ -127,6 +127,14 @@
     "message": "Завантажити iOS",
     "description": "Текст у кнопці, що використовується для завантаження iOS інсталяційного файлу"
   },
+  "button.downloadWindows": {
+    "message": "Завантажити для Windows",
+    "description": "Text in button for downloading the Windows desktop installer"
+  },
+  "button.downloadMac": {
+    "message": "Завантажити для macOS",
+    "description": "Text in button for downloading the macOS desktop installer"
+  },
   "button.installIos": {
     "message": "Встановити iOS",
     "description": "Текст у кнопці, що використовується для встановлення iOS додатку"
@@ -302,6 +310,18 @@
   "message.mobileNowOnAppStore": {
     "message": "Now on the App Store",
     "description": "Status label shown on the iOS card when the app is live on the App Store"
+  },
+  "message.desktopWindowsHint": {
+    "message": "Для Windows 10 і новіших (64-біт). Завантажте інсталятор і двічі клацніть, щоб установити.",
+    "description": "Windows desktop download card description"
+  },
+  "message.desktopMacHint": {
+    "message": "Для macOS 11 і новіших. Виберіть збірку для вашого Mac — Apple Silicon (серія M) або Intel.",
+    "description": "macOS desktop download card description"
+  },
+  "message.desktopUnsignedNote": {
+    "message": "Настільні застосунки — це непідписані бета-збірки. У Windows виберіть «Докладніше → Усе одно запустити» у вікні SmartScreen; у macOS клацніть застосунок правою кнопкою миші та виберіть «Відкрити», щоб обійти Gatekeeper.",
+    "description": "Note explaining the desktop builds are unsigned betas and how to open them"
   },
   "button.getOnGooglePlay": {
     "message": "Завантажити в Google Play",

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -127,6 +127,14 @@
     "message": "下载 iOS 安装包",
     "description": "按钮中的文本，用于下载 iOS 安装包文件"
   },
+  "button.downloadWindows": {
+    "message": "下载 Windows 版",
+    "description": "Text in button for downloading the Windows desktop installer"
+  },
+  "button.downloadMac": {
+    "message": "下载 macOS 版",
+    "description": "Text in button for downloading the macOS desktop installer"
+  },
   "button.installIos": {
     "message": "安装 iOS",
     "description": "按钮中的文本，用于安装 iOS 应用"
@@ -302,6 +310,18 @@
   "message.mobileNowOnAppStore": {
     "message": "已上架 App Store",
     "description": "Status label shown on the iOS card when the app is live on the App Store"
+  },
+  "message.desktopWindowsHint": {
+    "message": "适用于 Windows 10 及以上版本（64 位）。下载安装程序后双击即可安装。",
+    "description": "Windows desktop download card description"
+  },
+  "message.desktopMacHint": {
+    "message": "适用于 macOS 11 及以上版本。请按你的机型选择 —— Apple 芯片（M 系列）或 Intel。",
+    "description": "macOS desktop download card description"
+  },
+  "message.desktopUnsignedNote": {
+    "message": "桌面版目前为未签名的 Beta 版本。Windows 在 SmartScreen 提示中选择“更多信息 → 仍要运行”；macOS 请右键点按应用并选择“打开”以绕过 Gatekeeper。",
+    "description": "Note explaining the desktop builds are unsigned betas and how to open them"
   },
   "button.getOnGooglePlay": {
     "message": "在 Google Play 上获取",

--- a/src/i18n/zh-TW/common.json
+++ b/src/i18n/zh-TW/common.json
@@ -127,6 +127,14 @@
     "message": "下載 iOS 安裝包",
     "description": "按鈕中的文本，用於下載 iOS 安裝包文件"
   },
+  "button.downloadWindows": {
+    "message": "下載 Windows 版",
+    "description": "Text in button for downloading the Windows desktop installer"
+  },
+  "button.downloadMac": {
+    "message": "下載 macOS 版",
+    "description": "Text in button for downloading the macOS desktop installer"
+  },
   "button.installIos": {
     "message": "安裝 iOS",
     "description": "按鈕中的文本，用於安裝 iOS 應用"
@@ -302,6 +310,18 @@
   "message.mobileNowOnAppStore": {
     "message": "已上架 App Store",
     "description": "Status label shown on the iOS card when the app is live on the App Store"
+  },
+  "message.desktopWindowsHint": {
+    "message": "適用於 Windows 10 及以上版本（64 位元）。下載安裝程式後按兩下即可安裝。",
+    "description": "Windows desktop download card description"
+  },
+  "message.desktopMacHint": {
+    "message": "適用於 macOS 11 及以上版本。請依你的機型選擇 —— Apple 晶片（M 系列）或 Intel。",
+    "description": "macOS desktop download card description"
+  },
+  "message.desktopUnsignedNote": {
+    "message": "桌面版目前為未簽署的 Beta 版本。Windows 在 SmartScreen 提示中選擇「更多資訊 → 仍要執行」；macOS 請按右鍵點選應用程式並選擇「打開」以略過 Gatekeeper。",
+    "description": "Note explaining the desktop builds are unsigned betas and how to open them"
   },
   "button.getOnGooglePlay": {
     "message": "在 Google Play 取得",

--- a/src/pages/download/Index.vue
+++ b/src/pages/download/Index.vue
@@ -186,6 +186,52 @@
             </div>
           </template>
         </article>
+
+        <article class="platform platform--windows">
+          <div class="platform__head">
+            <span class="platform__os">
+              <font-awesome-icon :icon="faWindows" class="platform__os-icon" />
+              Windows
+            </span>
+            <span class="chip chip--beta"> <span class="chip__dot"></span>Beta </span>
+          </div>
+          <h2 class="platform__title">{{ $t('common.button.downloadWindows') }}</h2>
+          <p class="platform__text">{{ $t('common.message.desktopWindowsHint') }}</p>
+
+          <div class="platform__foot platform__foot--stack">
+            <el-button type="primary" round size="large" tag="a" :href="windowsDownloadUrl" target="_blank">
+              <font-awesome-icon :icon="faWindows" class="btn-icon" />
+              {{ $t('common.button.downloadWindows') }}
+            </el-button>
+            <span class="platform__meta">Beta · v{{ desktopVersion }}</span>
+          </div>
+        </article>
+
+        <article class="platform platform--mac">
+          <div class="platform__head">
+            <span class="platform__os">
+              <font-awesome-icon :icon="faApple" class="platform__os-icon" />
+              macOS
+            </span>
+            <span class="chip chip--beta"> <span class="chip__dot"></span>Beta </span>
+          </div>
+          <h2 class="platform__title">{{ $t('common.button.downloadMac') }}</h2>
+          <p class="platform__text">{{ $t('common.message.desktopMacHint') }}</p>
+
+          <div class="platform__foot platform__foot--stack">
+            <div class="btn-row">
+              <el-button type="primary" round size="large" tag="a" :href="macArmDownloadUrl" target="_blank">
+                <font-awesome-icon :icon="faApple" class="btn-icon" />
+                Apple Silicon
+              </el-button>
+              <el-button round size="large" class="btn-ghost" tag="a" :href="macIntelDownloadUrl" target="_blank">
+                <font-awesome-icon :icon="faApple" class="btn-icon" />
+                Intel
+              </el-button>
+            </div>
+            <span class="platform__meta">Beta · v{{ desktopVersion }}</span>
+          </div>
+        </article>
       </section>
 
       <!-- Advantages -->
@@ -212,6 +258,12 @@
         <font-awesome-icon :icon="faCircleInfo" class="note__icon" />
         <p class="note__text">{{ $t('common.message.mobileInstallNote') }}</p>
       </aside>
+
+      <!-- Desktop unsigned-beta note -->
+      <aside class="note">
+        <font-awesome-icon :icon="faCircleInfo" class="note__icon" />
+        <p class="note__text">{{ $t('common.message.desktopUnsignedNote') }}</p>
+      </aside>
     </div>
   </div>
 </template>
@@ -221,10 +273,14 @@ import { defineComponent } from 'vue';
 import { ElButton } from 'element-plus';
 import QrCode from 'vue-qrcode';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { faAndroid, faApple, faGooglePlay } from '@fortawesome/free-brands-svg-icons';
+import { faAndroid, faApple, faGooglePlay, faWindows } from '@fortawesome/free-brands-svg-icons';
 import { faDownload, faCircleInfo } from '@fortawesome/free-solid-svg-icons';
 import defaultLogo from '@/assets/images/logo.png';
 import {
+  DESKTOP_APP_VERSION,
+  DESKTOP_MAC_ARM_DOWNLOAD_URL,
+  DESKTOP_MAC_INTEL_DOWNLOAD_URL,
+  DESKTOP_WINDOWS_DOWNLOAD_URL,
   MOBILE_ANDROID_DOWNLOAD_URL,
   MOBILE_ANDROID_PLAY_STORE_URL,
   MOBILE_APP_VERSION,
@@ -245,6 +301,7 @@ export default defineComponent({
       faAndroid,
       faApple,
       faGooglePlay,
+      faWindows,
       faDownload,
       faCircleInfo
     };
@@ -288,6 +345,18 @@ export default defineComponent({
     },
     hasIos() {
       return this.hasAppStore || this.hasIosDownload;
+    },
+    desktopVersion() {
+      return DESKTOP_APP_VERSION;
+    },
+    windowsDownloadUrl() {
+      return DESKTOP_WINDOWS_DOWNLOAD_URL;
+    },
+    macArmDownloadUrl() {
+      return DESKTOP_MAC_ARM_DOWNLOAD_URL;
+    },
+    macIntelDownloadUrl() {
+      return DESKTOP_MAC_INTEL_DOWNLOAD_URL;
     }
   },
   methods: {
@@ -475,7 +544,8 @@ export default defineComponent({
   color: var(--app-brand-hex);
 }
 
-.platform--ios .platform__os-icon {
+.platform--ios .platform__os-icon,
+.platform--mac .platform__os-icon {
   color: var(--el-text-color-primary);
 }
 
@@ -512,6 +582,15 @@ export default defineComponent({
 
 .chip--pending .chip__dot {
   background: #f59e0b;
+}
+
+.chip--beta {
+  background: rgba(var(--app-brand-rgb), 0.14);
+  color: var(--app-brand-hex);
+}
+
+.chip--beta .chip__dot {
+  background: var(--app-brand-hex);
 }
 
 .platform__title {


### PR DESCRIPTION
## What

Adds **Windows** and **macOS** desktop installer cards to the public `/download` page (studio.acedata.cloud/download), alongside the existing Android/iOS cards.

| Platform | Button(s) | Links to |
|---|---|---|
| Windows | Download for Windows | `AceData.Setup.<ver>.exe` (NSIS) |
| macOS | Apple Silicon · Intel | `AceData-<ver>-arm64.dmg` · `AceData-<ver>.dmg` |

The desktop client is already built by `.github/workflows/desktop.yml` and attached to **every public GitHub Release**, so the buttons link straight to those release assets (the repo is public → anonymous download works).

## Why this approach

The signed auto-update CDN feed (`cdn.acedata.cloud/nexior/desktop/`) is **not published yet** (no `desktop-v*` tag has ever been pushed → feed is 404). The GitHub-Release installers are the only ones currently available, and they are **unsigned beta** builds. So:

- Each desktop card shows a **`Beta`** chip + `Beta · v<version>` meta.
- A new **unsigned-beta note** explains the Windows SmartScreen / macOS Gatekeeper prompts and how to get past them.
- URLs embed the version (GitHub asset names include it), so `DESKTOP_APP_VERSION` in `src/constants/mobile.ts` must be bumped each release — the same manual pattern as the existing Android APK constant. When the signed CDN channel ships, these can be repointed.

## Changes

- `src/constants/mobile.ts` — `DESKTOP_APP_VERSION` + 3 URL constants derived from it (`%2F`-encoded release tag).
- `src/pages/download/Index.vue` — two new platform cards, the unsigned-beta note, `faWindows` icon registration, computed URL props, and `.chip--beta` / `.platform--mac` styles. Reuses the existing card/grid CSS (4 cards → 2×2, collapses to 1 column ≤860px).
- `src/i18n/<loc>/common.json` — 5 new keys (`button.downloadWindows`, `button.downloadMac`, `message.desktopWindowsHint`, `message.desktopMacHint`, `message.desktopUnsignedNote`) added to **all 18 locales** (CI i18n coverage guard passes).

## Validation

- `eslint src` — clean
- `vue-tsc -b` — clean
- `python3 scripts/check_i18n_coverage.py` — `i18n key coverage OK: 17 locale(s) × 44 namespace(s)`
- `npx beachball check` — OK (change file included)
- Verified all 3 release-asset URLs are byte-exact against `@acedatacloud/nexior_v3.292.0` assets and resolve anonymously (302 → asset).
- Rendered the 4-card grid in a static harness to confirm 2×2 layout + Beta chips.

> Note: live in-app screenshot isn't possible locally (the dev bootstrap's `initializeSite` 401s without a session and redirects to login), but `/download` itself is a public route (`Bare` layout, no auth guard), so anonymous consumers reach it in production.

## 🤖 对抗评审

Reviewer: read-only subagent (Codex not installed on this host). One round, converged.

**VERDICT: CLEAN** — no risks.

Checks performed:
1. **URL correctness** — all three constructed URLs byte-match the real `v3.292.0` asset names (`AceData.Setup.3.292.0.exe`, `AceData-3.292.0-arm64.dmg`, `AceData-3.292.0.dmg`), including `%2F` tag encoding, dots-not-spaces in the `.exe`, and `-arm64` vs no-suffix dmg. ✅
2. **Icon registration** — `faWindows` imported from `free-brands-svg-icons` + added to `data()`; `faApple` already present. ✅
3. **i18n coverage** — all 5 keys present in all 18 locales; valid JSON; coverage script exit 0. ✅
4. **Public route** — `/download` uses `Bare` layout, no auth guard in `beforeEach`. ✅
5. **Computed/template parity** — `windowsDownloadUrl` / `macArmDownloadUrl` / `macIntelDownloadUrl` / `desktopVersion` all defined and correctly bound. ✅
6. **`rel="noopener"`** — absent, but **consistent with the existing** Android/iOS buttons in the same file (pre-existing pattern, not introduced here). Not a regression. ✅
7. **Layout** — 2-col grid → 2×2; all referenced CSS classes exist. ✅
8. **Maintainability** — hardcoded `DESKTOP_APP_VERSION` matches the existing `MOBILE_APP_VERSION` / APK convention; documented in a code comment. Acceptable. ✅
