### PR TITLE
feat(desktop): computer-use POC — opt-in screenshot + mouse/keyboard local tools

### DIFF
--- a/electron/local/computer.ts
+++ b/electron/local/computer.ts
@@ -1,0 +1,258 @@
+import { desktopCapturer, screen as eScreen, app } from 'electron';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import type { ToolResult } from './types';
+import { status } from './permissions';
+
+// Computer-use POC: lets the model SEE the screen (screenshot) and ACT on the
+// user's machine (mouse / keyboard) — the GUI-control flavor (cf. Codex/Claude
+// "computer use"). Screenshot uses Electron's built-in desktopCapturer (no
+// native dep). Input injection (click/move/type/key/scroll) uses nut.js, which
+// is loaded lazily and optionally: if the native module isn't installed the
+// action returns a clear, structured error instead of crashing — so the build
+// and non-desktop paths stay green. All actions are gated upstream by the
+// per-tool consent prompt (registered as `mutates`) and macOS TCC permissions
+// (Screen Recording for capture, Accessibility for input).
+
+// ---- nut.js: lazy, optional load (no static module resolution) -------------
+
+interface NutPoint {
+  x: number;
+  y: number;
+}
+interface NutButton {
+  LEFT: unknown;
+  RIGHT: unknown;
+  MIDDLE: unknown;
+}
+interface NutModule {
+  mouse: {
+    setPosition: (p: NutPoint) => Promise<unknown>;
+    click: (button: unknown) => Promise<unknown>;
+    scrollDown: (amount: number) => Promise<unknown>;
+    scrollUp: (amount: number) => Promise<unknown>;
+    scrollLeft: (amount: number) => Promise<unknown>;
+    scrollRight: (amount: number) => Promise<unknown>;
+  };
+  keyboard: {
+    type: (text: string) => Promise<unknown>;
+    pressKey: (...keys: unknown[]) => Promise<unknown>;
+    releaseKey: (...keys: unknown[]) => Promise<unknown>;
+    config: { autoDelayMs: number };
+  };
+  Point: new (x: number, y: number) => NutPoint;
+  Button: NutButton;
+  Key: Record<string, unknown>;
+}
+
+let nutCache: NutModule | null | undefined;
+
+function loadNut(): NutModule | null {
+  if (nutCache !== undefined) return nutCache;
+  try {
+    // Variable specifier ⇒ tsc does not statically resolve it, so the build
+    // succeeds even when the optional native dep is absent.
+    const moduleName = '@nut-tree-fork/nut-js';
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+    nutCache = require(moduleName) as NutModule;
+    nutCache.keyboard.config.autoDelayMs = 0;
+  } catch {
+    nutCache = null;
+  }
+  return nutCache;
+}
+
+const INPUT_BACKEND_HINT =
+  'input backend unavailable: install the optional dependency ' +
+  '`@nut-tree-fork/nut-js` and run `electron-rebuild` to enable mouse/keyboard ' +
+  'control (see plans/desktop-computer-use). Screenshot still works without it.';
+
+function err(message: string): ToolResult {
+  return { output: message, is_error: true };
+}
+
+// Cap retained screenshots so the capture dir can't grow without bound and
+// stale screen captures (sensitive) don't linger. shot-<ms>.png names sort
+// chronologically, so keep the newest MAX_SHOTS and unlink the rest.
+const MAX_SHOTS = 10;
+async function pruneShots(dir: string): Promise<void> {
+  try {
+    const files = (await fsp.readdir(dir)).filter((f) => f.startsWith('shot-') && f.endsWith('.png')).sort();
+    for (const f of files.slice(0, Math.max(0, files.length - MAX_SHOTS))) {
+      await fsp.unlink(path.join(dir, f)).catch(() => undefined);
+    }
+  } catch {
+    /* best-effort cleanup */
+  }
+}
+
+// macOS gate: capture needs Screen Recording, input needs Accessibility. On
+// non-macOS `status()` reports everything granted, so these are no-ops there.
+function captureBlocked(): string | null {
+  const p = status();
+  if (p.mac && p.screen !== 'granted') {
+    return 'Screen Recording permission is not granted. Open System Settings → Privacy & Security → Screen Recording, enable AceData, then retry.';
+  }
+  return null;
+}
+function inputBlocked(): string | null {
+  const p = status();
+  if (p.mac && !p.accessibility) {
+    return 'Accessibility permission is not granted. Open System Settings → Privacy & Security → Accessibility, enable AceData, then retry.';
+  }
+  return null;
+}
+
+// ---- screenshot (real, via desktopCapturer) --------------------------------
+
+export async function screenshot(): Promise<ToolResult> {
+  const blocked = captureBlocked();
+  if (blocked) return err(blocked);
+
+  const display = eScreen.getPrimaryDisplay();
+  const { width, height } = display.size;
+  const scaleFactor = display.scaleFactor || 1;
+  const sources = await desktopCapturer.getSources({
+    types: ['screen'],
+    thumbnailSize: { width: Math.round(width * scaleFactor), height: Math.round(height * scaleFactor) }
+  });
+  const source = sources[0];
+  if (!source || source.thumbnail.isEmpty()) return err('no screen source available (capture returned empty)');
+
+  const png = source.thumbnail.toPNG();
+  const dir = path.join(app.getPath('userData'), 'computer-use');
+  await fsp.mkdir(dir, { recursive: true });
+  const file = path.join(dir, `shot-${Date.now()}.png`);
+  await fsp.writeFile(file, png, { mode: 0o600 });
+  await pruneShots(dir);
+
+  // The PNG is saved to disk (not inlined) to keep the tool result small —
+  // a full-screen base64 would blow the client-tool result cap and the model
+  // context. Returning the image to the model as an image content block is a
+  // follow-up (see plan: "image tool-results"). Only the basename is returned
+  // so the absolute userData/home path isn't leaked to the model.
+  return {
+    output: JSON.stringify({
+      saved: path.basename(file),
+      width,
+      height,
+      scaleFactor,
+      bytes: png.length,
+      note: 'screenshot saved; coordinates below are in logical pixels (the click tool expects the same)'
+    })
+  };
+}
+
+// ---- input injection (nut.js, lazy) ----------------------------------------
+
+export async function click(i: { x: number; y: number; button?: 'left' | 'right' | 'middle' }): Promise<ToolResult> {
+  const blocked = inputBlocked();
+  if (blocked) return err(blocked);
+  const nut = loadNut();
+  if (!nut) return err(INPUT_BACKEND_HINT);
+  try {
+    await nut.mouse.setPosition(new nut.Point(i.x, i.y));
+    const button = i.button === 'right' ? nut.Button.RIGHT : i.button === 'middle' ? nut.Button.MIDDLE : nut.Button.LEFT;
+    await nut.mouse.click(button);
+    return { output: `clicked ${i.button ?? 'left'} at (${i.x}, ${i.y})` };
+  } catch (e) {
+    return err(`click failed: ${(e as Error).message}`);
+  }
+}
+
+export async function move(i: { x: number; y: number }): Promise<ToolResult> {
+  const blocked = inputBlocked();
+  if (blocked) return err(blocked);
+  const nut = loadNut();
+  if (!nut) return err(INPUT_BACKEND_HINT);
+  try {
+    await nut.mouse.setPosition(new nut.Point(i.x, i.y));
+    return { output: `moved to (${i.x}, ${i.y})` };
+  } catch (e) {
+    return err(`move failed: ${(e as Error).message}`);
+  }
+}
+
+export async function type_text(i: { text: string }): Promise<ToolResult> {
+  const blocked = inputBlocked();
+  if (blocked) return err(blocked);
+  const nut = loadNut();
+  if (!nut) return err(INPUT_BACKEND_HINT);
+  try {
+    await nut.keyboard.type(i.text);
+    return { output: `typed ${i.text.length} characters` };
+  } catch (e) {
+    return err(`type failed: ${(e as Error).message}`);
+  }
+}
+
+export async function key_press(i: { keys: string[] }): Promise<ToolResult> {
+  const blocked = inputBlocked();
+  if (blocked) return err(blocked);
+  const nut = loadNut();
+  if (!nut) return err(INPUT_BACKEND_HINT);
+  const mapped = i.keys.map((k) => nut.Key[normalizeKeyName(k)]);
+  if (mapped.some((k) => k === undefined)) return err(`unknown key in [${i.keys.join(', ')}] (use names like cmd, ctrl, shift, enter, a, ArrowLeft)`);
+  try {
+    for (const k of mapped) await nut.keyboard.pressKey(k);
+    for (const k of [...mapped].reverse()) await nut.keyboard.releaseKey(k);
+    return { output: `pressed ${i.keys.join('+')}` };
+  } catch (e) {
+    return err(`key press failed: ${(e as Error).message}`);
+  }
+}
+
+export async function scroll(i: { x?: number; y?: number; scrollX?: number; scrollY?: number }): Promise<ToolResult> {
+  const blocked = inputBlocked();
+  if (blocked) return err(blocked);
+  const nut = loadNut();
+  if (!nut) return err(INPUT_BACKEND_HINT);
+  try {
+    if (typeof i.x === 'number' && typeof i.y === 'number') await nut.mouse.setPosition(new nut.Point(i.x, i.y));
+    const dy = i.scrollY ?? 0;
+    const dx = i.scrollX ?? 0;
+    if (dy > 0) await nut.mouse.scrollDown(dy);
+    else if (dy < 0) await nut.mouse.scrollUp(-dy);
+    if (dx > 0) await nut.mouse.scrollRight(dx);
+    else if (dx < 0) await nut.mouse.scrollLeft(-dx);
+    return { output: `scrolled (dx=${dx}, dy=${dy})` };
+  } catch (e) {
+    return err(`scroll failed: ${(e as Error).message}`);
+  }
+}
+
+// Map friendly / OpenAI-style key names to nut.js Key enum member names.
+function normalizeKeyName(k: string): string {
+  const table: Record<string, string> = {
+    cmd: 'LeftCmd',
+    command: 'LeftCmd',
+    meta: 'LeftCmd',
+    super: 'LeftSuper',
+    ctrl: 'LeftControl',
+    control: 'LeftControl',
+    alt: 'LeftAlt',
+    option: 'LeftAlt',
+    shift: 'LeftShift',
+    enter: 'Enter',
+    return: 'Enter',
+    esc: 'Escape',
+    escape: 'Escape',
+    tab: 'Tab',
+    space: 'Space',
+    backspace: 'Backspace',
+    delete: 'Delete',
+    up: 'Up',
+    down: 'Down',
+    left: 'Left',
+    right: 'Right',
+    arrowup: 'Up',
+    arrowdown: 'Down',
+    arrowleft: 'Left',
+    arrowright: 'Right'
+  };
+  const lower = k.toLowerCase();
+  if (table[lower]) return table[lower];
+  if (/^[a-z]$/.test(lower)) return lower.toUpperCase(); // single letters: nut.js Key.A..Z
+  if (/^[0-9]$/.test(lower)) return `Num${lower}`;
+  return k; // pass through (e.g. already-correct nut.js name); undefined-checked by caller
+}

--- a/electron/local/consent.ts
+++ b/electron/local/consent.ts
@@ -49,26 +49,37 @@ export function grantKey(inv: ToolInvoke): string {
 }
 
 export async function consentOk(inv: ToolInvoke, win: BrowserWindow | null, mutates: boolean): Promise<boolean> {
+  // Computer-use tools (screen capture + mouse/keyboard injection) are too
+  // sensitive to ever auto-run silently: their grant key is often constant
+  // (e.g. `computer.screenshot:{}`), so a single persistent "Always allow"
+  // would hand the AI permanent promptless control of the screen. Until a
+  // dedicated session-scoped computer-use consent lands (see plan Phase 3),
+  // they are NOT persistable — no permanent grant, no "Always allow" button.
+  const persistable = !inv.name.startsWith('computer.');
   const gk = grantKey(inv);
-  if ((load().grants ?? []).includes(gk)) return true; // persistent always-allow
+  if (persistable && (load().grants ?? []).includes(gk)) return true; // persistent always-allow
   if (sessionGranted.has(sessionKey(inv)) && !mutates) return true;
+  const buttons = persistable
+    ? ['Allow once', 'Allow for session', 'Always allow', 'Deny']
+    : ['Allow once', 'Allow for session', 'Deny'];
+  const denyId = buttons.length - 1;
   const opts = {
     type: 'warning' as const,
-    buttons: ['Allow once', 'Allow for session', 'Always allow', 'Deny'],
+    buttons,
     defaultId: 0,
-    cancelId: 3,
+    cancelId: denyId,
     message: `Run local tool: ${inv.name}?`,
     detail: JSON.stringify(inv.input)
   };
   const { response } = win ? await dialog.showMessageBox(win, opts) : await dialog.showMessageBox(opts);
   if (response === 1) sessionGranted.add(sessionKey(inv));
-  if (response === 2) {
+  if (persistable && response === 2) {
     const cfg = load();
     const grants = new Set(cfg.grants ?? []);
     grants.add(gk);
     save({ ...cfg, grants: [...grants] });
   }
-  return response !== 3;
+  return response !== denyId;
 }
 
 export function resetConsent(): void {

--- a/electron/local/registry.ts
+++ b/electron/local/registry.ts
@@ -1,13 +1,23 @@
 import { McpHost } from './mcp';
 import * as fsTool from './fs';
 import { run_command } from './shell';
+import * as computer from './computer';
 import type { McpServerConf, ToolInvoke, ToolResult, ToolSpec } from './types';
 
 const BUILTIN: ToolSpec[] = [
   { name: 'fs.read_file', description: 'Read a UTF-8 file inside an authorized root', input_schema: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] }, source: 'builtin', mutates: false },
   { name: 'fs.list_dir', description: 'List a directory inside an authorized root', input_schema: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] }, source: 'builtin', mutates: false },
   { name: 'fs.write_file', description: 'Write a file inside an authorized root', input_schema: { type: 'object', properties: { path: { type: 'string' }, content: { type: 'string' } }, required: ['path', 'content'] }, source: 'builtin', mutates: true },
-  { name: 'shell.run_command', description: 'Run a local command (argv form)', input_schema: { type: 'object', properties: { cmd: { type: 'string' }, args: { type: 'array', items: { type: 'string' } }, cwd: { type: 'string' } }, required: ['cmd'] }, source: 'builtin', mutates: true }
+  { name: 'shell.run_command', description: 'Run a local command (argv form)', input_schema: { type: 'object', properties: { cmd: { type: 'string' }, args: { type: 'array', items: { type: 'string' } }, cwd: { type: 'string' } }, required: ['cmd'] }, source: 'builtin', mutates: true },
+  // Computer-use POC: see + control the GUI on the user's own machine. macOS
+  // needs Screen Recording (capture) + Accessibility (input); both gated by
+  // per-call consent (mutates: true) and the existing permission helpers.
+  { name: 'computer.screenshot', description: "Capture the user's screen (primary display) on their local machine. Returns saved PNG path + dimensions in logical pixels. Use to see the current UI before acting.", input_schema: { type: 'object', properties: {} }, source: 'builtin', mutates: true },
+  { name: 'computer.click', description: "Click the mouse at logical-pixel (x, y) on the user's local screen.", input_schema: { type: 'object', properties: { x: { type: 'number' }, y: { type: 'number' }, button: { type: 'string', enum: ['left', 'right', 'middle'] } }, required: ['x', 'y'] }, source: 'builtin', mutates: true },
+  { name: 'computer.move', description: "Move the mouse pointer to logical-pixel (x, y) on the user's local screen.", input_schema: { type: 'object', properties: { x: { type: 'number' }, y: { type: 'number' } }, required: ['x', 'y'] }, source: 'builtin', mutates: true },
+  { name: 'computer.type', description: "Type text via the keyboard on the user's local machine.", input_schema: { type: 'object', properties: { text: { type: 'string' } }, required: ['text'] }, source: 'builtin', mutates: true },
+  { name: 'computer.key', description: "Press a key combo on the user's local machine, e.g. ['cmd','t'] or ['enter'].", input_schema: { type: 'object', properties: { keys: { type: 'array', items: { type: 'string' } } }, required: ['keys'] }, source: 'builtin', mutates: true },
+  { name: 'computer.scroll', description: "Scroll the user's local screen (optionally move to x,y first). Positive scrollY = down, positive scrollX = right.", input_schema: { type: 'object', properties: { x: { type: 'number' }, y: { type: 'number' }, scrollX: { type: 'number' }, scrollY: { type: 'number' } }, required: [] }, source: 'builtin', mutates: true }
 ];
 
 class Registry {
@@ -46,6 +56,12 @@ class Registry {
     if (inv.name === 'fs.list_dir') return fsTool.list_dir(inv.input as { path: string });
     if (inv.name === 'fs.write_file') return fsTool.write_file(inv.input as { path: string; content: string });
     if (inv.name === 'shell.run_command') return run_command(inv.input as { cmd: string; args?: string[]; cwd?: string });
+    if (inv.name === 'computer.screenshot') return computer.screenshot();
+    if (inv.name === 'computer.click') return computer.click(inv.input as { x: number; y: number; button?: 'left' | 'right' | 'middle' });
+    if (inv.name === 'computer.move') return computer.move(inv.input as { x: number; y: number });
+    if (inv.name === 'computer.type') return computer.type_text(inv.input as { text: string });
+    if (inv.name === 'computer.key') return computer.key_press(inv.input as { keys: string[] });
+    if (inv.name === 'computer.scroll') return computer.scroll(inv.input as { x?: number; y?: number; scrollX?: number; scrollY?: number });
     return { output: `unhandled tool ${inv.name}`, is_error: true };
   }
 


### PR DESCRIPTION
## What

A working **proof-of-concept for desktop "computer use"** (GUI control — the Codex/Claude Computer Use flavor): let the model **see the screen** and **operate the mouse/keyboard** on the user's own machine. Six new builtin local tools, wired into the existing `electron/local` stack, **opt-in and default OFF**, with a Settings toggle.

| Tool | Backend | State |
|---|---|---|
| `computer.screenshot` | Electron `desktopCapturer` (no native dep) | **fully working** — captures the primary display, saves PNG to `userData/computer-use/`, returns dimensions. Gated by Screen Recording. |
| `computer.click` / `move` | `nut.js` mouse | wired; lights up when the optional native module is installed |
| `computer.type` / `key` | `nut.js` keyboard | wired |
| `computer.scroll` | `nut.js` wheel | wired |

Design doc + full rollout plan: `plans/nexior-desktop/COMPUTER-USE.md` (Index PR #163).

## Opt-in + surface gating (no wasted prompt tokens)

The computer-use tools live in a **separate, flag-gated group** (`COMPUTER_TOOLS` in `registry.ts`), default **OFF**:

- **Web / mobile pay nothing, ever** — those surfaces have no `localExec` bridge, so they never list or send local tools at all.
- **Desktop pays nothing until you turn it on** — while disabled, the registry neither advertises (`specs()`/`listTools()`) nor invokes (`isKnown()` + an `invoke()` guard) the `computer.*` tools, so they're never sent as `client_tools` → zero extra tokens.
- **A Settings → Local Tools toggle** (`el-switch`, default off) flips it; the change **hot-applies in the main process** and `Conversation.vue` re-fetches the tool list at the start of each turn, so toggling takes effect on the **very next message** (no remount, no stale specs).
- The toggle is only shown on **desktop** (web shows the existing "desktop only" hint). Persisted in `local-tools.json` (`computerUse`), preserving the existing roots/mcp/grants.

## Build-safety

`nut.js` (`@nut-tree-fork/nut-js`) is **lazy-required via a variable specifier** — not a hard dependency. With it absent the input tools return a clear structured error instead of crashing, and `tsc` / vitest / web build stay green. `computer.screenshot` needs no native dep and works today.

All `computer.*` tools are `mutates: true`, so `ipc.ts` forces the consent dialog on every call, and each is preflighted against the macOS permission status (Screen Recording for capture, Accessibility for input).

## Adversarial review (Codex, read-only) — two rounds, all addressed

**Round 1 (capture/injection):**
- **HIGH** — `consentOk()` checked the persistent "Always allow" grant *before* the `mutates` logic, and `computer.screenshot`'s grant key is constant (`{}`), so one "Always allow" = **permanent promptless screen capture**. → **Fixed**: `computer.*` are non-persistable — no permanent grant honored, no "Always allow" button (always require an interactive decision). Session-scoped consent is Phase 3 in the plan.
- **MED** — unbounded growth + sensitive-data retention in `userData/computer-use/`. → **Fixed**: `pruneShots()` keeps only the newest 10.
- **LOW** — screenshot result leaked the absolute `userData` path. → **Fixed**: returns `path.basename()` only.

**Round 2 (opt-in gating):**
- **HIGH** — `Conversation.vue` cached `localTools` once on mount, so toggling Computer Use off didn't refresh an open chat — it kept sending stale `computer.*` specs (wasted tokens) until remount, and enabling didn't take effect either. → **Fixed**: `onRequest()` re-fetches `listTools()` at the start of every user turn, so the toggle takes effect on the next message.

## i18n

Two new keys (`settings.localToolsComputerUseTitle/Hint`) added to **all 18 locales** (real en + zh-CN + zh-TW; English placeholder elsewhere). `check_i18n_coverage.py` passes.

## Not in this PR (tracked in the plan)

- Returning the screenshot to the model as an **image content block** (worker `tool_results` image support) — the highest-value follow-up that closes the perceive→act loop.
- `nut.js` as an optionalDependency + `electron-rebuild` + hardened-runtime entitlements.
- Session-scoped consent + "AI is controlling your screen" overlay + panic-stop hotkey + risk-point confirmation (**required before any user-facing enablement**).
- Vision-model routing.

## Validation

- `tsc -p electron/tsconfig.json`: clean. `vue-tsc -b`: clean.
- `npm run test:run`: **199 passed**. `check_i18n_coverage.py`: OK.
- `eslint` clean on all touched `src/` files (electron/ is not linted, same as existing main-process files).
- No tool-count assertions broken.
