### PR TITLE
fix(settings): restrict operator/white-label tabs to the web surface

### DIFF
--- a/change/@acedatacloud-nexior-2013548c-01cd-49e4-967a-27c221d0bdf0.json
+++ b/change/@acedatacloud-nexior-2013548c-01cd-49e4-967a-27c221d0bdf0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Restrict operator/white-label settings tabs (Site, SEO, Distribution, Function, Auth, Subsites, Custom Domain) to the web surface; hide them in the native iOS/Android and desktop apps",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/user/Setting.test.ts
+++ b/src/components/user/Setting.test.ts
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Control `isMainOfficial()` (normally derived from window.location.host) so we
+// can exercise BOTH the official main host (where Subsites shows) and a subsite
+// host (where Custom Domain shows) without touching jsdom's location.
+const hostState = vi.hoisted(() => ({ official: false }));
+vi.mock('@/utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils')>();
+  return { ...actual, isMainOfficial: () => hostState.official };
+});
+
+import Setting from './Setting.vue';
+import SiteSetting from '@/components/setting/Site.vue';
+import SeoSetting from '@/components/setting/Seo.vue';
+import DistributionSetting from '@/components/setting/Distribution.vue';
+import FunctionSetting from '@/components/setting/Function.vue';
+import AuthSetting from '@/components/setting/Auth.vue';
+import SubsiteSetting from '@/components/setting/Subsite.vue';
+import CustomDomainSetting from '@/components/setting/CustomDomain.vue';
+
+/**
+ * Operator / white-label settings tabs (Site, SEO, Distribution, Function,
+ * Auth, Subsites, Custom Domain) manage a web deployment, so they must only
+ * appear on the web surface — never inside the native iOS/Android shell or
+ * the desktop (Electron) app. Consumer tabs (General, API Key, About) stay
+ * available on every surface.
+ */
+const CONSUMER_TABS = ['general', 'apiKey', 'about'];
+const ALL_OPERATOR_TABS = ['site', 'seo', 'distribution', 'function', 'auth', 'subsites', 'customDomain'];
+// activeTab key -> the child component its <main> v-if branch renders.
+const OPERATOR_CONTENT = {
+  site: SiteSetting,
+  seo: SeoSetting,
+  distribution: DistributionSetting,
+  function: FunctionSetting,
+  auth: AuthSetting,
+  subsites: SubsiteSetting,
+  customDomain: CustomDomainSetting
+} as const;
+
+const mountSetting = () =>
+  shallowMount(Setting, {
+    props: { visible: true },
+    global: {
+      mocks: {
+        $t: (key: string) => key,
+        // Make the current user a site admin so the admin-gated operator
+        // tabs WOULD show if the surface allowed them — this isolates the
+        // surface gate as the only thing hiding them off-web.
+        $store: { state: { site: { admins: ['u1'] } }, getters: { user: { id: 'u1' } } }
+      },
+      // shallowMount auto-stubs ElDialog without rendering its slot, which
+      // would hide the <main> content branches and make the content-gating
+      // assertions pass vacuously. Render the slot so the v-if branches and
+      // their (still auto-stubbed) child components actually mount.
+      stubs: { ElDialog: { template: '<div class="el-dialog-stub"><slot /></div>' } }
+    }
+  });
+
+const tabKeys = (wrapper: ReturnType<typeof mountSetting>): string[] =>
+  (wrapper.vm as unknown as { visibleNavItems: { key: string }[] }).visibleNavItems.map((i) => i.key);
+
+describe('user/Setting surface gating', () => {
+  beforeEach(() => {
+    hostState.official = false;
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('web + subsite host: shows admin tabs and Custom Domain, hides Subsites', () => {
+    vi.stubEnv('VITE_SURFACE', 'web');
+    hostState.official = false;
+    const keys = tabKeys(mountSetting());
+    for (const tab of ['site', 'seo', 'distribution', 'function', 'auth', 'customDomain']) {
+      expect(keys).toContain(tab);
+    }
+    expect(keys).not.toContain('subsites'); // Subsites is main-official-host only
+    for (const tab of CONSUMER_TABS) expect(keys).toContain(tab);
+  });
+
+  it('web + official main host: shows admin tabs and Subsites, hides Custom Domain', () => {
+    vi.stubEnv('VITE_SURFACE', 'web');
+    hostState.official = true;
+    const keys = tabKeys(mountSetting());
+    for (const tab of ['site', 'seo', 'distribution', 'function', 'auth', 'subsites']) {
+      expect(keys).toContain(tab);
+    }
+    expect(keys).not.toContain('customDomain'); // main host never binds extra domains
+    for (const tab of CONSUMER_TABS) expect(keys).toContain(tab);
+  });
+
+  it('web: operator content branches render in their host context', async () => {
+    vi.stubEnv('VITE_SURFACE', 'web');
+    // Subsites is the official-main-host operator tab.
+    hostState.official = true;
+    const official = mountSetting();
+    await official.setData({ activeTab: 'subsites' });
+    expect(official.findComponent(SubsiteSetting).exists()).toBe(true);
+    // Custom Domain is the subsite-host operator tab.
+    hostState.official = false;
+    const subsite = mountSetting();
+    await subsite.setData({ activeTab: 'customDomain' });
+    expect(subsite.findComponent(CustomDomainSetting).exists()).toBe(true);
+  });
+
+  it.each(['ios', 'android', 'desktop'])('non-web surface %s hides every operator tab on both hosts', (surface) => {
+    vi.stubEnv('VITE_SURFACE', surface);
+    for (const official of [false, true]) {
+      hostState.official = official;
+      const keys = tabKeys(mountSetting());
+      for (const tab of ALL_OPERATOR_TABS) expect(keys).not.toContain(tab);
+      for (const tab of CONSUMER_TABS) expect(keys).toContain(tab);
+    }
+  });
+
+  // Defense in depth: even if a deep-link forces `activeTab` onto a gated tab
+  // off-web, the <main> content branch (not just the nav menu) must refuse it.
+  it.each(['ios', 'android', 'desktop'])(
+    'non-web surface %s renders no operator content via forced activeTab',
+    async (surface) => {
+      vi.stubEnv('VITE_SURFACE', surface);
+      // Cover BOTH hosts so each tab is checked where it WOULD be web-visible:
+      // Subsites on the official host, Custom Domain on a subsite host — so the
+      // surface gate (not the host condition) is what hides each one off-web.
+      for (const official of [false, true]) {
+        hostState.official = official;
+        const wrapper = mountSetting();
+        for (const [tab, component] of Object.entries(OPERATOR_CONTENT)) {
+          await wrapper.setData({ activeTab: tab });
+          expect(wrapper.findComponent(component).exists()).toBe(false);
+        }
+      }
+    }
+  );
+});

--- a/src/components/user/Setting.vue
+++ b/src/components/user/Setting.vue
@@ -37,22 +37,22 @@
         <div v-else-if="activeTab === SETTING_TAB_API_KEY">
           <byok-setting />
         </div>
-        <div v-else-if="activeTab === SETTING_TAB_SITE && isSiteAdmin">
+        <div v-else-if="activeTab === SETTING_TAB_SITE && isSiteConfigVisible">
           <site-setting />
         </div>
-        <div v-else-if="activeTab === SETTING_TAB_SEO && isSiteAdmin">
+        <div v-else-if="activeTab === SETTING_TAB_SEO && isSiteConfigVisible">
           <seo-setting />
         </div>
-        <div v-else-if="activeTab === SETTING_TAB_DISTRIBUTION && isSiteAdmin">
+        <div v-else-if="activeTab === SETTING_TAB_DISTRIBUTION && isSiteConfigVisible">
           <distribution-setting />
         </div>
-        <div v-else-if="activeTab === SETTING_TAB_FUNCTION && isSiteAdmin">
+        <div v-else-if="activeTab === SETTING_TAB_FUNCTION && isSiteConfigVisible">
           <function-setting />
         </div>
-        <div v-else-if="activeTab === SETTING_TAB_AUTH && isSiteAdmin">
+        <div v-else-if="activeTab === SETTING_TAB_AUTH && isSiteConfigVisible">
           <auth-setting />
         </div>
-        <div v-else-if="activeTab === SETTING_TAB_SUBSITES && isMainOfficialHost">
+        <div v-else-if="activeTab === SETTING_TAB_SUBSITES && isSubsitesVisible">
           <subsite-setting :auto-open-create="autoOpenCreateSubsite" />
         </div>
         <div v-else-if="activeTab === SETTING_TAB_CUSTOM_DOMAIN && isCustomDomainVisible">
@@ -112,6 +112,7 @@ import {
   type SettingTabKey
 } from '@/constants';
 import { isMainOfficial } from '@/utils';
+import { isWeb } from '@/utils/surface';
 import { localExec } from '@/utils/desktop';
 
 export default defineComponent({
@@ -169,24 +170,29 @@ export default defineComponent({
       return [
         { key: SETTING_TAB_GENERAL, label: this.$t('common.settings.general'), icon: faCog, visible: true },
         { key: SETTING_TAB_API_KEY, label: this.$t('common.settings.apiKey'), icon: faKey, visible: true },
-        { key: SETTING_TAB_SITE, label: this.$t('common.settings.site'), icon: faBell, visible: this.isSiteAdmin },
+        {
+          key: SETTING_TAB_SITE,
+          label: this.$t('common.settings.site'),
+          icon: faBell,
+          visible: this.isSiteConfigVisible
+        },
         {
           key: SETTING_TAB_SEO,
           label: this.$t('common.settings.seo'),
           icon: faUserShield,
-          visible: this.isSiteAdmin
+          visible: this.isSiteConfigVisible
         },
         {
           key: SETTING_TAB_DISTRIBUTION,
           label: this.$t('common.settings.distribution'),
           icon: faMoneyBill,
-          visible: this.isSiteAdmin
+          visible: this.isSiteConfigVisible
         },
         {
           key: SETTING_TAB_FUNCTION,
           label: this.$t('common.settings.function'),
           icon: faMagic,
-          visible: this.isSiteAdmin
+          visible: this.isSiteConfigVisible
         },
         {
           // Per-site login provider configuration (which providers are
@@ -197,7 +203,7 @@ export default defineComponent({
           key: SETTING_TAB_AUTH,
           label: this.$t('common.settings.auth'),
           icon: faRightToBracket,
-          visible: this.isSiteAdmin
+          visible: this.isSiteConfigVisible
         },
         {
           // Subsite (white-label child site) management. Only the official
@@ -208,7 +214,7 @@ export default defineComponent({
           key: SETTING_TAB_SUBSITES,
           label: this.$t('common.settings.subsites'),
           icon: faSitemap,
-          visible: this.isMainOfficialHost
+          visible: this.isSubsitesVisible
         },
         {
           // Custom-domain (CNAME + HTTPS) management for the *current*
@@ -244,11 +250,26 @@ export default defineComponent({
     isMainOfficialHost(): boolean {
       return isMainOfficial();
     },
+    isWebSurface(): boolean {
+      // Operator / white-label management (site config, SEO, distribution,
+      // subsites, custom domain) is a web-deployment concern — useless on a
+      // phone and risky for app-store review. Restrict it to the web surface
+      // so the native iOS/Android and desktop apps hide these tabs.
+      return isWeb();
+    },
+    isSiteConfigVisible(): boolean {
+      // Site / SEO / Distribution / Function / Auth: admin-only AND web-only.
+      return this.isWebSurface && this.isSiteAdmin;
+    },
+    isSubsitesVisible(): boolean {
+      // White-label child-site management: main official host AND web-only.
+      return this.isWebSurface && this.isMainOfficialHost;
+    },
     isCustomDomainVisible(): boolean {
       // Custom-domain binding is only meaningful on a subsite (or any
-      // non-main-official tenant). The parent commercial host never
-      // points additional CNAMEs at itself.
-      return !this.isMainOfficialHost && this.isSiteAdmin;
+      // non-main-official tenant), and only on the web surface (DNS/CNAME
+      // config). The parent commercial host never points CNAMEs at itself.
+      return this.isWebSurface && !this.isMainOfficialHost && this.isSiteAdmin;
     },
     isDesktopApp(): boolean {
       // Only the Electron desktop app exposes the localExec bridge.


### PR DESCRIPTION
## What & why

Several user-settings tabs in Nexior manage a **web deployment** (white-label / site-operator features). They are useless on a phone and risky for App Store / Play Store review, yet today they leak into the native iOS/Android shell **and** the desktop (Electron) app for site admins — because they were gated only by permission (`isSiteAdmin`) / host (`isMainOfficialHost`), never by surface.

On desktop (`app://bundle`) and native (Capacitor `localhost`), `isMainOfficial()` is `false`, so today:
- **Custom Domain** (`!isMainOfficialHost && isSiteAdmin`) is **visible** to admins on native/desktop.
- **Site / SEO / Distribution / Function / Auth** (`isSiteAdmin`) are **visible** to admins on native/desktop.
- **Subsites** (`isMainOfficialHost`) was already effectively web-only.

## Change

Gate all 7 operator/white-label tabs behind a new `isWebSurface` (`isWeb()`, build-time `VITE_SURFACE`) — in **both** the nav menu (`navItems[].visible`) and the `<main>` content `v-if` branches:

| Tab | Before | After |
|---|---|---|
| Site / SEO / Distribution / Function / Auth | `isSiteAdmin` | `isWeb() && isSiteAdmin` |
| Subsites | `isMainOfficialHost` | `isWeb() && isMainOfficialHost` |
| Custom Domain | `!isMainOfficialHost && isSiteAdmin` | `isWeb() && !isMainOfficialHost && isSiteAdmin` |

Unchanged: **General / API Key / About** stay on every surface; **Local Tools** stays desktop-only (`localExec` bridge). The About tab's "build your own → Subsites" button already falls back to "Contact us" off-web (host isn't `studio.acedata.cloud` there), so no dead-end is introduced.

### Surface matrix (admin user)
| | web (subsite host) | web (main host) | desktop | iOS/Android |
|---|---|---|---|---|
| Site / SEO / Distribution / Function / Auth | ✅ | ✅ | ❌ | ❌ |
| Subsites | ❌ (host) | ✅ | ❌ | ❌ |
| Custom Domain | ✅ | ❌ (host) | ❌ | ❌ |
| General / API Key / About | ✅ | ✅ | ✅ | ✅ |
| Local Tools | ❌ | ❌ | ✅ | ❌ |

## Tests

New `src/components/user/Setting.test.ts` (9 cases): nav-menu visibility per surface × both host contexts, the positive content-branch render on web, and a defense-in-depth check that forcing `activeTab` onto a gated tab off-web renders **no** operator content (covers the deep-link `initialTab` bypass).

`VITE_SURFACE=web vue-tsc -b --force` clean · full vitest suite 208 passed · ESLint clean.

## 🤖 对抗评审

Reviewer: **Codex** (`codex exec --sandbox read-only`, cross-model) — 3 rounds, converged to `VERDICT: CLEAN`.

- **Round 1 — ISSUES (2, both test-quality; implementation clean):**
  1. The test only inspected `visibleNavItems`, so a regression removing the `<main>` content `v-if` gate (deep-link `initialTab` bypass) would not be caught.
  2. The "web shows operator tabs" case relied on jsdom host ≠ `studio.acedata.cloud`, so it never proved Subsites appears on the official main host.
  - **Fix:** mock `isMainOfficial()` to cover both subsite & official hosts; add a slot-rendering `ElDialog` stub so `<main>` branches actually render under `shallowMount`; add positive + off-web content-branch assertions.
- **Round 2 — ISSUES (1):** the forced-content defense test pinned `official = true`, so the `customDomain` off-web assertion was satisfied by the host condition (`!isMainOfficialHost`), not the surface gate — vacuous.
  - **Fix:** run the defense loop over **both** hosts so each host-specific tab is checked where it would otherwise be web-visible (Subsites @ official host, Custom Domain @ subsite host) — making the surface gate the sole reason it's hidden off-web.
- **Round 3 — CLEAN.**
