### PR TITLE
feat(desktop): computer-use POC — opt-in screenshot + mouse/keyboard local tools

### DIFF
--- a/change/@acedatacloud-nexior-b4160020-c970-416e-b2c9-b01d8f50efd6.json
+++ b/change/@acedatacloud-nexior-b4160020-c970-416e-b2c9-b01d8f50efd6.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(desktop): computer-use POC — opt-in screenshot + mouse/keyboard local tools",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/electron/local/computer.ts
+++ b/electron/local/computer.ts
@@ -1,0 +1,258 @@
+import { desktopCapturer, screen as eScreen, app } from 'electron';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import type { ToolResult } from './types';
+import { status } from './permissions';
+
+// Computer-use POC: lets the model SEE the screen (screenshot) and ACT on the
+// user's machine (mouse / keyboard) — the GUI-control flavor (cf. Codex/Claude
+// "computer use"). Screenshot uses Electron's built-in desktopCapturer (no
+// native dep). Input injection (click/move/type/key/scroll) uses nut.js, which
+// is loaded lazily and optionally: if the native module isn't installed the
+// action returns a clear, structured error instead of crashing — so the build
+// and non-desktop paths stay green. All actions are gated upstream by the
+// per-tool consent prompt (registered as `mutates`) and macOS TCC permissions
+// (Screen Recording for capture, Accessibility for input).
+
+// ---- nut.js: lazy, optional load (no static module resolution) -------------
+
+interface NutPoint {
+  x: number;
+  y: number;
+}
+interface NutButton {
+  LEFT: unknown;
+  RIGHT: unknown;
+  MIDDLE: unknown;
+}
+interface NutModule {
+  mouse: {
+    setPosition: (p: NutPoint) => Promise<unknown>;
+    click: (button: unknown) => Promise<unknown>;
+    scrollDown: (amount: number) => Promise<unknown>;
+    scrollUp: (amount: number) => Promise<unknown>;
+    scrollLeft: (amount: number) => Promise<unknown>;
+    scrollRight: (amount: number) => Promise<unknown>;
+  };
+  keyboard: {
+    type: (text: string) => Promise<unknown>;
+    pressKey: (...keys: unknown[]) => Promise<unknown>;
+    releaseKey: (...keys: unknown[]) => Promise<unknown>;
+    config: { autoDelayMs: number };
+  };
+  Point: new (x: number, y: number) => NutPoint;
+  Button: NutButton;
+  Key: Record<string, unknown>;
+}
+
+let nutCache: NutModule | null | undefined;
+
+function loadNut(): NutModule | null {
+  if (nutCache !== undefined) return nutCache;
+  try {
+    // Variable specifier ⇒ tsc does not statically resolve it, so the build
+    // succeeds even when the optional native dep is absent.
+    const moduleName = '@nut-tree-fork/nut-js';
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+    nutCache = require(moduleName) as NutModule;
+    nutCache.keyboard.config.autoDelayMs = 0;
+  } catch {
+    nutCache = null;
+  }
+  return nutCache;
+}
+
+const INPUT_BACKEND_HINT =
+  'input backend unavailable: install the optional dependency ' +
+  '`@nut-tree-fork/nut-js` and run `electron-rebuild` to enable mouse/keyboard ' +
+  'control (see plans/desktop-computer-use). Screenshot still works without it.';
+
+function err(message: string): ToolResult {
+  return { output: message, is_error: true };
+}
+
+// Cap retained screenshots so the capture dir can't grow without bound and
+// stale screen captures (sensitive) don't linger. shot-<ms>.png names sort
+// chronologically, so keep the newest MAX_SHOTS and unlink the rest.
+const MAX_SHOTS = 10;
+async function pruneShots(dir: string): Promise<void> {
+  try {
+    const files = (await fsp.readdir(dir)).filter((f) => f.startsWith('shot-') && f.endsWith('.png')).sort();
+    for (const f of files.slice(0, Math.max(0, files.length - MAX_SHOTS))) {
+      await fsp.unlink(path.join(dir, f)).catch(() => undefined);
+    }
+  } catch {
+    /* best-effort cleanup */
+  }
+}
+
+// macOS gate: capture needs Screen Recording, input needs Accessibility. On
+// non-macOS `status()` reports everything granted, so these are no-ops there.
+function captureBlocked(): string | null {
+  const p = status();
+  if (p.mac && p.screen !== 'granted') {
+    return 'Screen Recording permission is not granted. Open System Settings → Privacy & Security → Screen Recording, enable AceData, then retry.';
+  }
+  return null;
+}
+function inputBlocked(): string | null {
+  const p = status();
+  if (p.mac && !p.accessibility) {
+    return 'Accessibility permission is not granted. Open System Settings → Privacy & Security → Accessibility, enable AceData, then retry.';
+  }
+  return null;
+}
+
+// ---- screenshot (real, via desktopCapturer) --------------------------------
+
+export async function screenshot(): Promise<ToolResult> {
+  const blocked = captureBlocked();
+  if (blocked) return err(blocked);
+
+  const display = eScreen.getPrimaryDisplay();
+  const { width, height } = display.size;
+  const scaleFactor = display.scaleFactor || 1;
+  const sources = await desktopCapturer.getSources({
+    types: ['screen'],
+    thumbnailSize: { width: Math.round(width * scaleFactor), height: Math.round(height * scaleFactor) }
+  });
+  const source = sources[0];
+  if (!source || source.thumbnail.isEmpty()) return err('no screen source available (capture returned empty)');
+
+  const png = source.thumbnail.toPNG();
+  const dir = path.join(app.getPath('userData'), 'computer-use');
+  await fsp.mkdir(dir, { recursive: true });
+  const file = path.join(dir, `shot-${Date.now()}.png`);
+  await fsp.writeFile(file, png, { mode: 0o600 });
+  await pruneShots(dir);
+
+  // The PNG is saved to disk (not inlined) to keep the tool result small —
+  // a full-screen base64 would blow the client-tool result cap and the model
+  // context. Returning the image to the model as an image content block is a
+  // follow-up (see plan: "image tool-results"). Only the basename is returned
+  // so the absolute userData/home path isn't leaked to the model.
+  return {
+    output: JSON.stringify({
+      saved: path.basename(file),
+      width,
+      height,
+      scaleFactor,
+      bytes: png.length,
+      note: 'screenshot saved; coordinates below are in logical pixels (the click tool expects the same)'
+    })
+  };
+}
+
+// ---- input injection (nut.js, lazy) ----------------------------------------
+
+export async function click(i: { x: number; y: number; button?: 'left' | 'right' | 'middle' }): Promise<ToolResult> {
+  const blocked = inputBlocked();
+  if (blocked) return err(blocked);
+  const nut = loadNut();
+  if (!nut) return err(INPUT_BACKEND_HINT);
+  try {
+    await nut.mouse.setPosition(new nut.Point(i.x, i.y));
+    const button = i.button === 'right' ? nut.Button.RIGHT : i.button === 'middle' ? nut.Button.MIDDLE : nut.Button.LEFT;
+    await nut.mouse.click(button);
+    return { output: `clicked ${i.button ?? 'left'} at (${i.x}, ${i.y})` };
+  } catch (e) {
+    return err(`click failed: ${(e as Error).message}`);
+  }
+}
+
+export async function move(i: { x: number; y: number }): Promise<ToolResult> {
+  const blocked = inputBlocked();
+  if (blocked) return err(blocked);
+  const nut = loadNut();
+  if (!nut) return err(INPUT_BACKEND_HINT);
+  try {
+    await nut.mouse.setPosition(new nut.Point(i.x, i.y));
+    return { output: `moved to (${i.x}, ${i.y})` };
+  } catch (e) {
+    return err(`move failed: ${(e as Error).message}`);
+  }
+}
+
+export async function type_text(i: { text: string }): Promise<ToolResult> {
+  const blocked = inputBlocked();
+  if (blocked) return err(blocked);
+  const nut = loadNut();
+  if (!nut) return err(INPUT_BACKEND_HINT);
+  try {
+    await nut.keyboard.type(i.text);
+    return { output: `typed ${i.text.length} characters` };
+  } catch (e) {
+    return err(`type failed: ${(e as Error).message}`);
+  }
+}
+
+export async function key_press(i: { keys: string[] }): Promise<ToolResult> {
+  const blocked = inputBlocked();
+  if (blocked) return err(blocked);
+  const nut = loadNut();
+  if (!nut) return err(INPUT_BACKEND_HINT);
+  const mapped = i.keys.map((k) => nut.Key[normalizeKeyName(k)]);
+  if (mapped.some((k) => k === undefined)) return err(`unknown key in [${i.keys.join(', ')}] (use names like cmd, ctrl, shift, enter, a, ArrowLeft)`);
+  try {
+    for (const k of mapped) await nut.keyboard.pressKey(k);
+    for (const k of [...mapped].reverse()) await nut.keyboard.releaseKey(k);
+    return { output: `pressed ${i.keys.join('+')}` };
+  } catch (e) {
+    return err(`key press failed: ${(e as Error).message}`);
+  }
+}
+
+export async function scroll(i: { x?: number; y?: number; scrollX?: number; scrollY?: number }): Promise<ToolResult> {
+  const blocked = inputBlocked();
+  if (blocked) return err(blocked);
+  const nut = loadNut();
+  if (!nut) return err(INPUT_BACKEND_HINT);
+  try {
+    if (typeof i.x === 'number' && typeof i.y === 'number') await nut.mouse.setPosition(new nut.Point(i.x, i.y));
+    const dy = i.scrollY ?? 0;
+    const dx = i.scrollX ?? 0;
+    if (dy > 0) await nut.mouse.scrollDown(dy);
+    else if (dy < 0) await nut.mouse.scrollUp(-dy);
+    if (dx > 0) await nut.mouse.scrollRight(dx);
+    else if (dx < 0) await nut.mouse.scrollLeft(-dx);
+    return { output: `scrolled (dx=${dx}, dy=${dy})` };
+  } catch (e) {
+    return err(`scroll failed: ${(e as Error).message}`);
+  }
+}
+
+// Map friendly / OpenAI-style key names to nut.js Key enum member names.
+function normalizeKeyName(k: string): string {
+  const table: Record<string, string> = {
+    cmd: 'LeftCmd',
+    command: 'LeftCmd',
+    meta: 'LeftCmd',
+    super: 'LeftSuper',
+    ctrl: 'LeftControl',
+    control: 'LeftControl',
+    alt: 'LeftAlt',
+    option: 'LeftAlt',
+    shift: 'LeftShift',
+    enter: 'Enter',
+    return: 'Enter',
+    esc: 'Escape',
+    escape: 'Escape',
+    tab: 'Tab',
+    space: 'Space',
+    backspace: 'Backspace',
+    delete: 'Delete',
+    up: 'Up',
+    down: 'Down',
+    left: 'Left',
+    right: 'Right',
+    arrowup: 'Up',
+    arrowdown: 'Down',
+    arrowleft: 'Left',
+    arrowright: 'Right'
+  };
+  const lower = k.toLowerCase();
+  if (table[lower]) return table[lower];
+  if (/^[a-z]$/.test(lower)) return lower.toUpperCase(); // single letters: nut.js Key.A..Z
+  if (/^[0-9]$/.test(lower)) return `Num${lower}`;
+  return k; // pass through (e.g. already-correct nut.js name); undefined-checked by caller
+}

--- a/electron/local/config.ts
+++ b/electron/local/config.ts
@@ -10,9 +10,9 @@ const file = (): string => path.join(app.getPath('userData'), 'local-tools.json'
 export function load(): LocalConfig {
   try {
     const c = JSON.parse(fs.readFileSync(file(), 'utf8')) as Partial<LocalConfig>;
-    return { roots: c.roots ?? [], mcp: c.mcp ?? [], grants: c.grants ?? [] };
+    return { roots: c.roots ?? [], mcp: c.mcp ?? [], grants: c.grants ?? [], computerUse: c.computerUse ?? false };
   } catch {
-    return { roots: [], mcp: [], grants: [] };
+    return { roots: [], mcp: [], grants: [], computerUse: false };
   }
 }
 

--- a/electron/local/consent.ts
+++ b/electron/local/consent.ts
@@ -49,26 +49,37 @@ export function grantKey(inv: ToolInvoke): string {
 }
 
 export async function consentOk(inv: ToolInvoke, win: BrowserWindow | null, mutates: boolean): Promise<boolean> {
+  // Computer-use tools (screen capture + mouse/keyboard injection) are too
+  // sensitive to ever auto-run silently: their grant key is often constant
+  // (e.g. `computer.screenshot:{}`), so a single persistent "Always allow"
+  // would hand the AI permanent promptless control of the screen. Until a
+  // dedicated session-scoped computer-use consent lands (see plan Phase 3),
+  // they are NOT persistable — no permanent grant, no "Always allow" button.
+  const persistable = !inv.name.startsWith('computer.');
   const gk = grantKey(inv);
-  if ((load().grants ?? []).includes(gk)) return true; // persistent always-allow
+  if (persistable && (load().grants ?? []).includes(gk)) return true; // persistent always-allow
   if (sessionGranted.has(sessionKey(inv)) && !mutates) return true;
+  const buttons = persistable
+    ? ['Allow once', 'Allow for session', 'Always allow', 'Deny']
+    : ['Allow once', 'Allow for session', 'Deny'];
+  const denyId = buttons.length - 1;
   const opts = {
     type: 'warning' as const,
-    buttons: ['Allow once', 'Allow for session', 'Always allow', 'Deny'],
+    buttons,
     defaultId: 0,
-    cancelId: 3,
+    cancelId: denyId,
     message: `Run local tool: ${inv.name}?`,
     detail: JSON.stringify(inv.input)
   };
   const { response } = win ? await dialog.showMessageBox(win, opts) : await dialog.showMessageBox(opts);
   if (response === 1) sessionGranted.add(sessionKey(inv));
-  if (response === 2) {
+  if (persistable && response === 2) {
     const cfg = load();
     const grants = new Set(cfg.grants ?? []);
     grants.add(gk);
     save({ ...cfg, grants: [...grants] });
   }
-  return response !== 3;
+  return response !== denyId;
 }
 
 export function resetConsent(): void {

--- a/electron/local/ipc.ts
+++ b/electron/local/ipc.ts
@@ -43,10 +43,14 @@ export function registerLocalExec(getWin: () => BrowserWindow | null): void {
   ipcMain.handle('local.config.save', (e, cfg: LocalConfig) => {
     gate(e);
     // Preserve persistent consent grants — the renderer's save payload only
-    // carries roots + mcp, so merge to avoid wiping the "always allow" list.
+    // carries roots + mcp (+ optional computerUse), so merge to avoid wiping
+    // the "always allow" list. `computerUse` falls back to the current value
+    // when the renderer omits it.
     const cur = load();
-    save({ ...cur, roots: cfg.roots, mcp: cfg.mcp });
+    const computerUse = cfg.computerUse ?? cur.computerUse ?? false;
+    save({ ...cur, roots: cfg.roots, mcp: cfg.mcp, computerUse });
     setRoots(cfg.roots); // hot-apply roots; MCP server changes apply next launch
+    registry.setComputerUse(computerUse); // hot-apply the Computer Use toggle
     return true;
   });
   ipcMain.handle('local.pickFolder', async (e) => {

--- a/electron/local/registry.ts
+++ b/electron/local/registry.ts
@@ -1,6 +1,7 @@
 import { McpHost } from './mcp';
 import * as fsTool from './fs';
 import { run_command } from './shell';
+import * as computer from './computer';
 import type { McpServerConf, ToolInvoke, ToolResult, ToolSpec } from './types';
 
 const BUILTIN: ToolSpec[] = [
@@ -10,10 +11,38 @@ const BUILTIN: ToolSpec[] = [
   { name: 'shell.run_command', description: 'Run a local command (argv form)', input_schema: { type: 'object', properties: { cmd: { type: 'string' }, args: { type: 'array', items: { type: 'string' } }, cwd: { type: 'string' } }, required: ['cmd'] }, source: 'builtin', mutates: true }
 ];
 
+// Computer-use POC: see + control the GUI on the user's own machine. Kept in a
+// SEPARATE, opt-in group: these specs are only advertised (and only invokable)
+// when the user enables Computer Use in Settings. Disabled by default, so on web
+// these never exist (no localExec bridge) and on desktop they aren't sent as
+// `client_tools` until opted in — no wasted prompt tokens on any surface. macOS
+// needs Screen Recording (capture) + Accessibility (input); all gated by
+// per-call consent (mutates: true).
+const COMPUTER_TOOLS: ToolSpec[] = [
+  { name: 'computer.screenshot', description: "Capture the user's screen (primary display) on their local machine. Returns saved PNG path + dimensions in logical pixels. Use to see the current UI before acting.", input_schema: { type: 'object', properties: {} }, source: 'builtin', mutates: true },
+  { name: 'computer.click', description: "Click the mouse at logical-pixel (x, y) on the user's local screen.", input_schema: { type: 'object', properties: { x: { type: 'number' }, y: { type: 'number' }, button: { type: 'string', enum: ['left', 'right', 'middle'] } }, required: ['x', 'y'] }, source: 'builtin', mutates: true },
+  { name: 'computer.move', description: "Move the mouse pointer to logical-pixel (x, y) on the user's local screen.", input_schema: { type: 'object', properties: { x: { type: 'number' }, y: { type: 'number' } }, required: ['x', 'y'] }, source: 'builtin', mutates: true },
+  { name: 'computer.type', description: "Type text via the keyboard on the user's local machine.", input_schema: { type: 'object', properties: { text: { type: 'string' } }, required: ['text'] }, source: 'builtin', mutates: true },
+  { name: 'computer.key', description: "Press a key combo on the user's local machine, e.g. ['cmd','t'] or ['enter'].", input_schema: { type: 'object', properties: { keys: { type: 'array', items: { type: 'string' } } }, required: ['keys'] }, source: 'builtin', mutates: true },
+  { name: 'computer.scroll', description: "Scroll the user's local screen (optionally move to x,y first). Positive scrollY = down, positive scrollX = right.", input_schema: { type: 'object', properties: { x: { type: 'number' }, y: { type: 'number' }, scrollX: { type: 'number' }, scrollY: { type: 'number' } }, required: [] }, source: 'builtin', mutates: true }
+];
+
+function isComputerTool(name: string): boolean {
+  return name.startsWith('computer.');
+}
+
 class Registry {
   private host = new McpHost();
   private mcpSpecs: ToolSpec[] = [];
-  private names = new Set(BUILTIN.map((s) => s.name));
+  private names = new Set([...BUILTIN, ...COMPUTER_TOOLS].map((s) => s.name));
+  // Opt-in Computer Use (screen capture + mouse/keyboard). Default OFF; toggled
+  // from Settings → Local Tools. While off, the tools are neither advertised nor
+  // invokable.
+  private computerUse = false;
+
+  setComputerUse(on: boolean): void {
+    this.computerUse = on === true;
+  }
 
   async boot(servers: McpServerConf[]): Promise<void> {
     for (const s of servers) {
@@ -29,15 +58,19 @@ class Registry {
   }
 
   specs(): ToolSpec[] {
-    return [...BUILTIN, ...this.mcpSpecs];
+    return [...BUILTIN, ...(this.computerUse ? COMPUTER_TOOLS : []), ...this.mcpSpecs];
   }
 
   isKnown(name: string): boolean {
+    if (isComputerTool(name)) return this.computerUse && this.names.has(name);
     return this.names.has(name);
   }
 
   async invoke(inv: ToolInvoke): Promise<ToolResult> {
     if (!this.isKnown(inv.name)) return { output: `unknown tool ${inv.name}`, is_error: true };
+    // Defense in depth: even if a stale renderer calls a computer.* tool while
+    // the feature is disabled, refuse it here too.
+    if (isComputerTool(inv.name) && !this.computerUse) return { output: 'computer use is disabled', is_error: true };
     if (inv.name.startsWith('mcp.')) {
       const [, server, tool] = inv.name.split('.');
       return this.host.call(server, tool, inv.input);
@@ -46,6 +79,12 @@ class Registry {
     if (inv.name === 'fs.list_dir') return fsTool.list_dir(inv.input as { path: string });
     if (inv.name === 'fs.write_file') return fsTool.write_file(inv.input as { path: string; content: string });
     if (inv.name === 'shell.run_command') return run_command(inv.input as { cmd: string; args?: string[]; cwd?: string });
+    if (inv.name === 'computer.screenshot') return computer.screenshot();
+    if (inv.name === 'computer.click') return computer.click(inv.input as { x: number; y: number; button?: 'left' | 'right' | 'middle' });
+    if (inv.name === 'computer.move') return computer.move(inv.input as { x: number; y: number });
+    if (inv.name === 'computer.type') return computer.type_text(inv.input as { text: string });
+    if (inv.name === 'computer.key') return computer.key_press(inv.input as { keys: string[] });
+    if (inv.name === 'computer.scroll') return computer.scroll(inv.input as { x?: number; y?: number; scrollX?: number; scrollY?: number });
     return { output: `unhandled tool ${inv.name}`, is_error: true };
   }
 

--- a/electron/local/types.ts
+++ b/electron/local/types.ts
@@ -36,4 +36,7 @@ export interface LocalConfig {
   // session-independent key `<tool.name>:<stable json input>` the user
   // explicitly chose to always allow; matching invocations skip the prompt.
   grants?: string[];
+  // Opt-in Computer Use (screen capture + mouse/keyboard control). Default
+  // false; while false the `computer.*` tools are not advertised or invokable.
+  computerUse?: boolean;
 }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -96,6 +96,7 @@ if (!gotLock) {
     // Local tool execution: load authorized roots, boot MCP servers, wire IPC.
     const localCfg = loadLocalConfig();
     setRoots(localCfg.roots);
+    registry.setComputerUse(localCfg.computerUse === true); // opt-in, default off
     void registry.boot(localCfg.mcp);
     registerLocalExec(() => mainWindow);
     // Windows cold-start protocol activation: URL is in this instance's argv.

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -55,8 +55,8 @@ contextBridge.exposeInMainWorld('localExec', {
   listTools: (): Promise<unknown[]> => ipcRenderer.invoke('local.tools.list'),
   invoke: (inv: { name: string; input: object; sessionId: string }): Promise<{ output: string; is_error?: boolean }> =>
     ipcRenderer.invoke('local.tool.invoke', inv),
-  getConfig: (): Promise<{ roots: string[]; mcp: object[] }> => ipcRenderer.invoke('local.config.get'),
-  saveConfig: (cfg: { roots: string[]; mcp: object[] }): Promise<boolean> =>
+  getConfig: (): Promise<{ roots: string[]; mcp: object[]; computerUse?: boolean }> => ipcRenderer.invoke('local.config.get'),
+  saveConfig: (cfg: { roots: string[]; mcp: object[]; computerUse?: boolean }): Promise<boolean> =>
     ipcRenderer.invoke('local.config.save', cfg),
   pickFolder: (): Promise<string | null> => ipcRenderer.invoke('local.pickFolder'),
   // macOS system-permission status + jump-to-pane, shown in the LocalTools panel.

--- a/src/components/setting/LocalTools.vue
+++ b/src/components/setting/LocalTools.vue
@@ -58,6 +58,15 @@
         </ul>
       </section>
 
+      <!-- Computer Use (opt-in: screen capture + mouse/keyboard control) -->
+      <section>
+        <div class="section-head">
+          <h3>{{ $t('common.settings.localToolsComputerUseTitle') }}</h3>
+          <el-switch v-model="computerUse" :loading="savingCU" @change="onToggleComputerUse" />
+        </div>
+        <p class="muted">{{ $t('common.settings.localToolsComputerUseHint') }}</p>
+      </section>
+
       <!-- macOS system permissions -->
       <section v-if="perm">
         <div class="section-head">
@@ -96,7 +105,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElButton, ElTag } from 'element-plus';
+import { ElButton, ElTag, ElSwitch } from 'element-plus';
 import { Plus } from '@element-plus/icons-vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { localExec } from '@/utils/desktop';
@@ -109,7 +118,7 @@ interface GrantRow {
 
 export default defineComponent({
   name: 'LocalToolsSetting',
-  components: { ElButton, ElTag, FontAwesomeIcon },
+  components: { ElButton, ElTag, ElSwitch, FontAwesomeIcon },
   data() {
     return {
       Plus,
@@ -117,6 +126,8 @@ export default defineComponent({
       tools: [] as string[],
       grants: null as null | GrantRow[],
       perm: null as null | { mac: boolean; fullDisk: boolean; screen: string; mic: string; accessibility: boolean },
+      computerUse: false,
+      savingCU: false,
       saving: false,
       savedTip: false
     };
@@ -129,7 +140,9 @@ export default defineComponent({
   async mounted() {
     const ex = localExec();
     if (!ex) return;
-    this.roots = (await ex.getConfig()).roots;
+    const cfg = await ex.getConfig();
+    this.roots = cfg.roots;
+    this.computerUse = cfg.computerUse === true;
     this.tools = (await ex.listTools()).map((t) => t.name);
     const s = await ex.perm?.status();
     if (s?.mac) this.perm = s;
@@ -166,10 +179,23 @@ export default defineComponent({
       this.saving = true;
       // Preserve mcp; the worker registers MCP servers from this same config.
       const cur = await localExec()?.getConfig();
-      await localExec()?.saveConfig({ roots: this.roots, mcp: cur?.mcp ?? [] });
+      await localExec()?.saveConfig({ roots: this.roots, mcp: cur?.mcp ?? [], computerUse: this.computerUse });
       this.saving = false;
       this.savedTip = true;
       setTimeout(() => (this.savedTip = false), 2000);
+    },
+    // Toggle persists ONLY the Computer Use flag (preserving last-saved roots +
+    // mcp), and hot-applies it in the main process so the tools appear/disappear
+    // from the next `client_tools` payload without a restart.
+    async onToggleComputerUse(val: string | number | boolean) {
+      this.savingCU = true;
+      const cur = await localExec()?.getConfig();
+      await localExec()?.saveConfig({
+        roots: cur?.roots ?? this.roots,
+        mcp: cur?.mcp ?? [],
+        computerUse: val === true
+      });
+      this.savingCU = false;
     },
     async revoke(key: string) {
       await localExec()?.grants?.revoke(key);

--- a/src/i18n/ar/common.json
+++ b/src/i18n/ar/common.json
@@ -919,6 +919,14 @@
     "message": "المجلدات التي يُسمح للذكاء الاصطناعي بالقراءة والكتابة فيها على هذا الجهاز. تعمل الأدوات محليًا؛ ولا يغادر أي شيء جهازك دون موافقتك.",
     "description": "Help text under the authorized-folders heading."
   },
+  "settings.localToolsComputerUseTitle": {
+    "message": "Computer Use (experimental)",
+    "description": "Heading for the opt-in Computer Use (screen + mouse/keyboard control) toggle."
+  },
+  "settings.localToolsComputerUseHint": {
+    "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
+    "description": "Help text under the Computer Use toggle."
+  },
   "settings.localToolsAddFolder": {
     "message": "إضافة مجلد",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/de/common.json
+++ b/src/i18n/de/common.json
@@ -919,6 +919,14 @@
     "message": "Ordner, die die KI auf diesem Gerät lesen und schreiben darf. Tools laufen lokal; ohne deine Zustimmung verlässt nichts dein Gerät.",
     "description": "Help text under the authorized-folders heading."
   },
+  "settings.localToolsComputerUseTitle": {
+    "message": "Computer Use (experimental)",
+    "description": "Heading for the opt-in Computer Use (screen + mouse/keyboard control) toggle."
+  },
+  "settings.localToolsComputerUseHint": {
+    "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
+    "description": "Help text under the Computer Use toggle."
+  },
   "settings.localToolsAddFolder": {
     "message": "Ordner hinzufügen",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/el/common.json
+++ b/src/i18n/el/common.json
@@ -919,6 +919,14 @@
     "message": "Φάκελοι που το AI μπορεί να διαβάζει και να γράφει σε αυτό το μηχάνημα. Τα εργαλεία εκτελούνται τοπικά· τίποτα δεν φεύγει από τη συσκευή σας χωρίς τη συγκατάθεσή σας.",
     "description": "Help text under the authorized-folders heading."
   },
+  "settings.localToolsComputerUseTitle": {
+    "message": "Computer Use (experimental)",
+    "description": "Heading for the opt-in Computer Use (screen + mouse/keyboard control) toggle."
+  },
+  "settings.localToolsComputerUseHint": {
+    "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
+    "description": "Help text under the Computer Use toggle."
+  },
   "settings.localToolsAddFolder": {
     "message": "Προσθήκη φακέλου",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -899,6 +899,14 @@
     "message": "Folders the AI may read and write on this machine. Tools run locally; nothing leaves your device without your consent.",
     "description": "Help text under the authorized-folders heading."
   },
+  "settings.localToolsComputerUseTitle": {
+    "message": "Computer Use (experimental)",
+    "description": "Heading for the opt-in Computer Use (screen + mouse/keyboard control) toggle."
+  },
+  "settings.localToolsComputerUseHint": {
+    "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
+    "description": "Help text under the Computer Use toggle."
+  },
   "settings.localToolsAddFolder": {
     "message": "Add folder",
     "description": "Button to pick a folder to authorize."
@@ -972,7 +980,7 @@
     "description": "Status tag when a system permission is not granted."
   },
   "settings.localToolsOpen": {
-    "message": "Open\u2026",
+    "message": "Open…",
     "description": "Button to open the relevant macOS System Settings pane."
   },
   "settings.subsites": {

--- a/src/i18n/es/common.json
+++ b/src/i18n/es/common.json
@@ -919,6 +919,14 @@
     "message": "Carpetas que la IA puede leer y escribir en este equipo. Las herramientas se ejecutan localmente; nada sale de tu dispositivo sin tu consentimiento.",
     "description": "Help text under the authorized-folders heading."
   },
+  "settings.localToolsComputerUseTitle": {
+    "message": "Computer Use (experimental)",
+    "description": "Heading for the opt-in Computer Use (screen + mouse/keyboard control) toggle."
+  },
+  "settings.localToolsComputerUseHint": {
+    "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
+    "description": "Help text under the Computer Use toggle."
+  },
   "settings.localToolsAddFolder": {
     "message": "Agregar carpeta",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -919,6 +919,14 @@
     "message": "Kansiot, joita tekoäly saa lukea ja kirjoittaa tällä laitteella. Työkalut suoritetaan paikallisesti; mikään ei poistu laitteeltasi ilman suostumustasi.",
     "description": "Help text under the authorized-folders heading."
   },
+  "settings.localToolsComputerUseTitle": {
+    "message": "Computer Use (experimental)",
+    "description": "Heading for the opt-in Computer Use (screen + mouse/keyboard control) toggle."
+  },
+  "settings.localToolsComputerUseHint": {
+    "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
+    "description": "Help text under the Computer Use toggle."
+  },
   "settings.localToolsAddFolder": {
     "message": "Lisää kansio",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/fr/common.json
+++ b/src/i18n/fr/common.json
@@ -919,6 +919,14 @@
     "message": "Dossiers que l’IA peut lire et écrire sur cette machine. Les outils s’exécutent localement ; rien ne quitte votre appareil sans votre consentement.",
     "description": "Help text under the authorized-folders heading."
   },
+  "settings.localToolsComputerUseTitle": {
+    "message": "Computer Use (experimental)",
+    "description": "Heading for the opt-in Computer Use (screen + mouse/keyboard control) toggle."
+  },
+  "settings.localToolsComputerUseHint": {
+    "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
+    "description": "Help text under the Computer Use toggle."
+  },
   "settings.localToolsAddFolder": {
     "message": "Ajouter un dossier",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/it/common.json
+++ b/src/i18n/it/common.json
@@ -919,6 +919,14 @@
     "message": "Cartelle che l’IA può leggere e scrivere su questo dispositivo. Gli strumenti vengono eseguiti localmente; nulla lascia il tuo dispositivo senza il tuo consenso.",
     "description": "Help text under the authorized-folders heading."
   },
+  "settings.localToolsComputerUseTitle": {
+    "message": "Computer Use (experimental)",
+    "description": "Heading for the opt-in Computer Use (screen + mouse/keyboard control) toggle."
+  },
+  "settings.localToolsComputerUseHint": {
+    "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
+    "description": "Help text under the Computer Use toggle."
+  },
   "settings.localToolsAddFolder": {
     "message": "Aggiungi cartella",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/ja/common.json
+++ b/src/i18n/ja/common.json
@@ -919,6 +919,14 @@
     "message": "AI がこの端末で読み書きできるフォルダです。ツールはローカルで実行され、あなたの同意なしに何も端末の外へ出ません。",
     "description": "Help text under the authorized-folders heading."
   },
+  "settings.localToolsComputerUseTitle": {
+    "message": "Computer Use (experimental)",
+    "description": "Heading for the opt-in Computer Use (screen + mouse/keyboard control) toggle."
+  },
+  "settings.localToolsComputerUseHint": {
+    "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
+    "description": "Help text under the Computer Use toggle."
+  },
   "settings.localToolsAddFolder": {
     "message": "フォルダを追加",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/ko/common.json
+++ b/src/i18n/ko/common.json
@@ -919,6 +919,14 @@
     "message": "AI가 이 기기에서 읽고 쓸 수 있는 폴더입니다. 도구는 로컬에서 실행되며, 동의 없이는 아무것도 기기를 벗어나지 않습니다.",
     "description": "Help text under the authorized-folders heading."
   },
+  "settings.localToolsComputerUseTitle": {
+    "message": "Computer Use (experimental)",
+    "description": "Heading for the opt-in Computer Use (screen + mouse/keyboard control) toggle."
+  },
+  "settings.localToolsComputerUseHint": {
+    "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
+    "description": "Help text under the Computer Use toggle."
+  },
   "settings.localToolsAddFolder": {
     "message": "폴더 추가",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/pl/common.json
+++ b/src/i18n/pl/common.json
@@ -919,6 +919,14 @@
     "message": "Foldery, które AI może odczytywać i zapisywać na tym urządzeniu. Narzędzia działają lokalnie; nic nie opuszcza urządzenia bez Twojej zgody.",
     "description": "Help text under the authorized-folders heading."
   },
+  "settings.localToolsComputerUseTitle": {
+    "message": "Computer Use (experimental)",
+    "description": "Heading for the opt-in Computer Use (screen + mouse/keyboard control) toggle."
+  },
+  "settings.localToolsComputerUseHint": {
+    "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
+    "description": "Help text under the Computer Use toggle."
+  },
   "settings.localToolsAddFolder": {
     "message": "Dodaj folder",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/pt/common.json
+++ b/src/i18n/pt/common.json
@@ -919,6 +919,14 @@
     "message": "Pastas que a IA pode ler e gravar nesta máquina. As ferramentas são executadas localmente; nada sai do seu dispositivo sem o seu consentimento.",
     "description": "Help text under the authorized-folders heading."
   },
+  "settings.localToolsComputerUseTitle": {
+    "message": "Computer Use (experimental)",
+    "description": "Heading for the opt-in Computer Use (screen + mouse/keyboard control) toggle."
+  },
+  "settings.localToolsComputerUseHint": {
+    "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
+    "description": "Help text under the Computer Use toggle."
+  },
   "settings.localToolsAddFolder": {
     "message": "Adicionar pasta",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/ru/common.json
+++ b/src/i18n/ru/common.json
@@ -919,6 +919,14 @@
     "message": "Папки, которые ИИ может читать и записывать на этом устройстве. Инструменты выполняются локально; ничто не покидает ваше устройство без вашего согласия.",
     "description": "Help text under the authorized-folders heading."
   },
+  "settings.localToolsComputerUseTitle": {
+    "message": "Computer Use (experimental)",
+    "description": "Heading for the opt-in Computer Use (screen + mouse/keyboard control) toggle."
+  },
+  "settings.localToolsComputerUseHint": {
+    "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
+    "description": "Help text under the Computer Use toggle."
+  },
   "settings.localToolsAddFolder": {
     "message": "Добавить папку",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/sr/common.json
+++ b/src/i18n/sr/common.json
@@ -919,6 +919,14 @@
     "message": "Фасцикле које вештачка интелигенција сме да чита и уписује на овом уређају. Алати се извршавају локално; ништа не напушта ваш уређај без ваше сагласности.",
     "description": "Help text under the authorized-folders heading."
   },
+  "settings.localToolsComputerUseTitle": {
+    "message": "Computer Use (experimental)",
+    "description": "Heading for the opt-in Computer Use (screen + mouse/keyboard control) toggle."
+  },
+  "settings.localToolsComputerUseHint": {
+    "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
+    "description": "Help text under the Computer Use toggle."
+  },
   "settings.localToolsAddFolder": {
     "message": "Додај фасциклу",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -919,6 +919,14 @@
     "message": "Mappar som AI:n får läsa och skriva på den här datorn. Verktygen körs lokalt; ingenting lämnar din enhet utan ditt samtycke.",
     "description": "Help text under the authorized-folders heading."
   },
+  "settings.localToolsComputerUseTitle": {
+    "message": "Computer Use (experimental)",
+    "description": "Heading for the opt-in Computer Use (screen + mouse/keyboard control) toggle."
+  },
+  "settings.localToolsComputerUseHint": {
+    "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
+    "description": "Help text under the Computer Use toggle."
+  },
   "settings.localToolsAddFolder": {
     "message": "Lägg till mapp",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/uk/common.json
+++ b/src/i18n/uk/common.json
@@ -919,6 +919,14 @@
     "message": "Папки, які ШІ може читати та записувати на цьому пристрої. Інструменти виконуються локально; ніщо не залишає ваш пристрій без вашої згоди.",
     "description": "Help text under the authorized-folders heading."
   },
+  "settings.localToolsComputerUseTitle": {
+    "message": "Computer Use (experimental)",
+    "description": "Heading for the opt-in Computer Use (screen + mouse/keyboard control) toggle."
+  },
+  "settings.localToolsComputerUseHint": {
+    "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
+    "description": "Help text under the Computer Use toggle."
+  },
   "settings.localToolsAddFolder": {
     "message": "Додати папку",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -919,6 +919,14 @@
     "message": "AI 可在本机读写的文件夹。工具在本地执行；未经你同意，任何内容都不会离开你的设备。",
     "description": "已授权文件夹标题下的说明。"
   },
+  "settings.localToolsComputerUseTitle": {
+    "message": "电脑操作（实验性）",
+    "description": "Heading for the opt-in Computer Use (screen + mouse/keyboard control) toggle."
+  },
+  "settings.localToolsComputerUseHint": {
+    "message": "让 AI 看到你的屏幕并控制本机的鼠标和键盘。默认关闭，按需开启。macOS 上需在下方授予「屏幕录制」和「辅助功能」权限。每个操作仍会请求你的确认。",
+    "description": "Help text under the Computer Use toggle."
+  },
   "settings.localToolsAddFolder": {
     "message": "添加文件夹",
     "description": "选择要授权的文件夹的按钮。"
@@ -992,7 +1000,7 @@
     "description": "系统权限未授权时的状态标签。"
   },
   "settings.localToolsOpen": {
-    "message": "打开\u2026",
+    "message": "打开…",
     "description": "打开对应 macOS 系统设置面板的按钮。"
   },
   "settings.subsites": {

--- a/src/i18n/zh-TW/common.json
+++ b/src/i18n/zh-TW/common.json
@@ -919,6 +919,14 @@
     "message": "AI 可在本機讀寫的資料夾。工具於本機執行；未經你同意，任何內容都不會離開你的裝置。",
     "description": "Help text under the authorized-folders heading."
   },
+  "settings.localToolsComputerUseTitle": {
+    "message": "電腦操作（實驗性）",
+    "description": "Heading for the opt-in Computer Use (screen + mouse/keyboard control) toggle."
+  },
+  "settings.localToolsComputerUseHint": {
+    "message": "讓 AI 看到你的螢幕並控制本機的滑鼠和鍵盤。預設關閉，按需開啟。macOS 上需在下方授予「螢幕錄製」和「輔助使用」權限。每個操作仍會請求你的確認。",
+    "description": "Help text under the Computer Use toggle."
+  },
   "settings.localToolsAddFolder": {
     "message": "新增資料夾",
     "description": "Button to pick a folder to authorize."

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -654,6 +654,14 @@ export default defineComponent({
     },
     // Get answers to questions
     async onRequest() {
+      // Refresh the desktop local-tool list at the start of each user turn so a
+      // Settings change (e.g. toggling Computer Use on/off) takes effect on the
+      // very next message. Without this, `localTools` is cached from mount and a
+      // disabled tool would keep being advertised as `client_tools` — wasting
+      // prompt tokens — until the chat remounts.
+      if (isDesktop()) {
+        this.localTools = (await localExec()?.listTools()) ?? [];
+      }
       console.debug('start to get answer', this.messages);
       const token = this.credential?.token;
       const question = this.question.trim();

--- a/src/utils/desktop.ts
+++ b/src/utils/desktop.ts
@@ -54,8 +54,16 @@ export interface LocalExecBridge {
   available: true;
   listTools(): Promise<LocalToolSpec[]>;
   invoke(inv: { name: string; input: object; sessionId: string }): Promise<{ output: string; is_error?: boolean }>;
-  getConfig(): Promise<{ roots: string[]; mcp: { id: string; command: string; args: string[] }[] }>;
-  saveConfig(cfg: { roots: string[]; mcp: { id: string; command: string; args: string[] }[] }): Promise<boolean>;
+  getConfig(): Promise<{
+    roots: string[];
+    mcp: { id: string; command: string; args: string[] }[];
+    computerUse?: boolean;
+  }>;
+  saveConfig(cfg: {
+    roots: string[];
+    mcp: { id: string; command: string; args: string[] }[];
+    computerUse?: boolean;
+  }): Promise<boolean>;
   pickFolder(): Promise<string | null>;
   /** macOS TCC permission status + jump-to-System-Settings (undefined off macOS desktop). */
   perm?: {


### PR DESCRIPTION
## What

A working **proof-of-concept for desktop "computer use"** (GUI control — the Codex/Claude Computer Use flavor): let the model **see the screen** and **operate the mouse/keyboard** on the user's own machine. Six new builtin local tools, wired into the existing `electron/local` stack, **opt-in and default OFF**, with a Settings toggle.

| Tool | Backend | State |
|---|---|---|
| `computer.screenshot` | Electron `desktopCapturer` (no native dep) | **fully working** — captures the primary display, saves PNG to `userData/computer-use/`, returns dimensions. Gated by Screen Recording. |
| `computer.click` / `move` | `nut.js` mouse | wired; lights up when the optional native module is installed |
| `computer.type` / `key` | `nut.js` keyboard | wired |
| `computer.scroll` | `nut.js` wheel | wired |

Design doc + full rollout plan: `plans/nexior-desktop/COMPUTER-USE.md` (Index PR #163).

## Opt-in + surface gating (no wasted prompt tokens)

The computer-use tools live in a **separate, flag-gated group** (`COMPUTER_TOOLS` in `registry.ts`), default **OFF**:

- **Web / mobile pay nothing, ever** — those surfaces have no `localExec` bridge, so they never list or send local tools at all.
- **Desktop pays nothing until you turn it on** — while disabled, the registry neither advertises (`specs()`/`listTools()`) nor invokes (`isKnown()` + an `invoke()` guard) the `computer.*` tools, so they're never sent as `client_tools` → zero extra tokens.
- **A Settings → Local Tools toggle** (`el-switch`, default off) flips it; the change **hot-applies in the main process** and `Conversation.vue` re-fetches the tool list at the start of each turn, so toggling takes effect on the **very next message** (no remount, no stale specs).
- The toggle is only shown on **desktop** (web shows the existing "desktop only" hint). Persisted in `local-tools.json` (`computerUse`), preserving the existing roots/mcp/grants.

## Build-safety

`nut.js` (`@nut-tree-fork/nut-js`) is **lazy-required via a variable specifier** — not a hard dependency. With it absent the input tools return a clear structured error instead of crashing, and `tsc` / vitest / web build stay green. `computer.screenshot` needs no native dep and works today.

All `computer.*` tools are `mutates: true`, so `ipc.ts` forces the consent dialog on every call, and each is preflighted against the macOS permission status (Screen Recording for capture, Accessibility for input).

## Adversarial review (Codex, read-only) — two rounds, all addressed

**Round 1 (capture/injection):**
- **HIGH** — `consentOk()` checked the persistent "Always allow" grant *before* the `mutates` logic, and `computer.screenshot`'s grant key is constant (`{}`), so one "Always allow" = **permanent promptless screen capture**. → **Fixed**: `computer.*` are non-persistable — no permanent grant honored, no "Always allow" button (always require an interactive decision). Session-scoped consent is Phase 3 in the plan.
- **MED** — unbounded growth + sensitive-data retention in `userData/computer-use/`. → **Fixed**: `pruneShots()` keeps only the newest 10.
- **LOW** — screenshot result leaked the absolute `userData` path. → **Fixed**: returns `path.basename()` only.

**Round 2 (opt-in gating):**
- **HIGH** — `Conversation.vue` cached `localTools` once on mount, so toggling Computer Use off didn't refresh an open chat — it kept sending stale `computer.*` specs (wasted tokens) until remount, and enabling didn't take effect either. → **Fixed**: `onRequest()` re-fetches `listTools()` at the start of every user turn, so the toggle takes effect on the next message.

## i18n

Two new keys (`settings.localToolsComputerUseTitle/Hint`) added to **all 18 locales** (real en + zh-CN + zh-TW; English placeholder elsewhere). `check_i18n_coverage.py` passes.

## Not in this PR (tracked in the plan)

- Returning the screenshot to the model as an **image content block** (worker `tool_results` image support) — the highest-value follow-up that closes the perceive→act loop.
- `nut.js` as an optionalDependency + `electron-rebuild` + hardened-runtime entitlements.
- Session-scoped consent + "AI is controlling your screen" overlay + panic-stop hotkey + risk-point confirmation (**required before any user-facing enablement**).
- Vision-model routing.

## Validation

- `tsc -p electron/tsconfig.json`: clean. `vue-tsc -b`: clean.
- `npm run test:run`: **199 passed**. `check_i18n_coverage.py`: OK.
- `eslint` clean on all touched `src/` files (electron/ is not linted, same as existing main-process files).
- No tool-count assertions broken.
