### PR TITLE
fix(nexior): drop macOS chat-rail logo inset in fullscreen

### DIFF
--- a/change/@acedatacloud-nexior-mac-traffic-light-logo.json
+++ b/change/@acedatacloud-nexior-mac-traffic-light-logo.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(nexior): drop macOS chat-rail logo inset in fullscreen (traffic lights hidden)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -159,6 +159,12 @@ function createWindow(): void {
   };
   mainWindow.webContents.on('will-navigate', (event, url) => guard(event, url));
   mainWindow.webContents.on('will-frame-navigate', (event) => guard(event, event.url));
+
+  // Tell the renderer about native fullscreen (macOS green button / setFullScreen):
+  // in fullscreen the traffic lights are hidden, so the web header/rail drop
+  // their inset. macOS-only events, but harmless to wire everywhere.
+  mainWindow.on('enter-full-screen', () => mainWindow?.webContents.send('window:fullscreen', true));
+  mainWindow.on('leave-full-screen', () => mainWindow?.webContents.send('window:fullscreen', false));
 }
 
 function handleDeepLink(rawUrl: string): void {
@@ -225,6 +231,10 @@ ipcMain.handle('auth:openOAuth', (_e, authUrl: string) => {
 ipcMain.handle('shell:openExternal', (_e, url: string) => {
   if (allowedExternal(url)) return shell.openExternal(url);
 });
+
+// Current native fullscreen state, so a renderer that subscribes after the
+// window already entered fullscreen still gets the right initial value.
+ipcMain.handle('window:isFullscreen', () => mainWindow?.isFullScreen() ?? false);
 
 // Main-process desktop notification (Web Notification is unreliable when the
 // window is hidden/minimized). Clicking it refocuses the app.

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -35,6 +35,16 @@ contextBridge.exposeInMainWorld('desktop', {
   // Open an external https link (payment Page, docs) in the system browser.
   openExternal: (url: string): Promise<void> => ipcRenderer.invoke('shell:openExternal', url),
 
+  // Subscribe to native window fullscreen changes (macOS green button /
+  // setFullScreen). Emits the current state immediately, then on every change.
+  // In fullscreen the traffic lights are hidden, so the UI drops its inset.
+  onFullscreenChange: (cb: (isFullscreen: boolean) => void): (() => void) => {
+    const handler = (_e: unknown, isFullscreen: boolean) => cb(isFullscreen);
+    ipcRenderer.on('window:fullscreen', handler);
+    void ipcRenderer.invoke('window:isFullscreen').then((v: boolean) => cb(!!v));
+    return () => ipcRenderer.removeListener('window:fullscreen', handler);
+  },
+
   // Handshake: called from App.vue mounted() AFTER onAuthCallback is subscribed
   // so main only flushes a queued deep link once a listener exists.
   signalReady: (): void => ipcRenderer.send('renderer:ready'),

--- a/src/components/common/Navigator.vue
+++ b/src/components/common/Navigator.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :direction="direction" :class="['navigator', { collapsed: direction === 'column', 'is-mac': isMacOS() }]">
+  <div :direction="direction" :class="['navigator', { collapsed: direction === 'column', 'is-mac': isMacOS() && !isFullscreen }]">
     <div v-if="direction === 'column'" class="brand">
       <logo collapsed @click.stop="onHome" />
     </div>
@@ -138,6 +138,7 @@ import {
 import Logo from './Logo.vue';
 import UserCenter from '@/components/user/Center.vue';
 import { isMacOS } from '@/utils/surface';
+import { desktopBridge } from '@/utils/desktop';
 
 interface NavLink {
   route: { name: string };
@@ -172,7 +173,11 @@ export default defineComponent({
       activeIndex: this.$route.name as string,
       containerHeight: 0,
       showOverflow: false,
-      resizeObserver: null as ResizeObserver | null
+      resizeObserver: null as ResizeObserver | null,
+      // macOS native fullscreen hides the traffic lights, so the brand inset
+      // must be dropped there. Fed by the Electron main fullscreen events.
+      isFullscreen: false,
+      offFullscreen: null as (() => void) | null
     };
   },
   computed: {
@@ -478,11 +483,20 @@ export default defineComponent({
       });
       this.resizeObserver.observe(el);
     }
+    // Native fullscreen state from the Electron main process (canonical signal
+    // for the macOS green button / setFullScreen; undefined off desktop).
+    this.offFullscreen = desktopBridge()?.onFullscreenChange((v) => {
+      this.isFullscreen = v;
+    }) ?? null;
   },
   beforeUnmount() {
     if (this.resizeObserver) {
       this.resizeObserver.disconnect();
       this.resizeObserver = null;
+    }
+    if (this.offFullscreen) {
+      this.offFullscreen();
+      this.offFullscreen = null;
     }
   },
   methods: {

--- a/src/utils/desktop.ts
+++ b/src/utils/desktop.ts
@@ -18,6 +18,9 @@ export interface DesktopBridge {
   onAuthExpired(cb: () => void): () => void;
   /** Open an external https link (payment Page, docs) in the system browser. */
   openExternal(url: string): Promise<void>;
+  /** Subscribe to native window fullscreen changes (macOS). Fires immediately
+   * with the current state, then on every enter/leave. Returns an unsubscribe. */
+  onFullscreenChange(cb: (isFullscreen: boolean) => void): () => void;
   /** Handshake: call AFTER auth listeners are attached so main flushes queued deep links. */
   signalReady(): void;
   /** Inform main of the signed-in site origin for the external-open allowlist. */


### PR DESCRIPTION
## Problem
PR #1078 added a 38px inset to the chat-page left rail (`Navigator`, column mode) so the brand logo clears the macOS window traffic lights. But in **native fullscreen** (green button / `setFullScreen`) the traffic lights are hidden, so the inset just wastes space and pushes the logo down for no reason.

## Fix
Track the window's native fullscreen state and only apply the `is-mac` inset when **not** fullscreen, using the canonical Electron signal (not the unreliable `display-mode` media query):

- `electron/main.ts`: forward `enter-full-screen` / `leave-full-screen` → `webContents.send('window:fullscreen', bool)`, plus `ipcMain.handle('window:isFullscreen')` for the initial value.
- `electron/preload.ts`: expose `onFullscreenChange(cb)` on the audited `window.desktop` bridge — subscribes, immediately invokes the current state (covers late-subscribe race), returns an unsubscribe.
- `src/utils/desktop.ts`: type the new bridge method.
- `Navigator.vue`: subscribe in `mounted`, store `isFullscreen`, unsubscribe in `beforeUnmount`; bind `is-mac` only when `isMacOS() && !isFullscreen`.

Off-desktop the bridge is `undefined` (null-safe no-op); web/iOS/Android unaffected.

> Note: ships with the next desktop build (touches the Electron main/preload).

## 🤖 对抗评审
codex (read-only) — **VERDICT: CLEAN**. IPC channels match, listener cleanup wired, bridge access null-safe off desktop, `mainWindow` null falls back to `false`, types line up, and subscribe-before-invoke covers the initial-state race.