### PR TITLE
fix(desktop): consistent perm status casing + solid Open/Revoke buttons in Local Tools

### DIFF
--- a/change/@acedatacloud-nexior-localtools-buttons.json
+++ b/change/@acedatacloud-nexior-localtools-buttons.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(desktop): consistent permission status casing + solid Open/Revoke buttons in Local Tools settings",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/setting/LocalTools.vue
+++ b/src/components/setting/LocalTools.vue
@@ -50,7 +50,7 @@
               <code class="grant-name">{{ g.name }}</code>
               <span class="grant-input">{{ g.input }}</span>
             </span>
-            <el-button size="small" text type="danger" @click="revoke(g.key)">
+            <el-button size="small" type="danger" @click="revoke(g.key)">
               {{ $t('common.settings.localToolsRevoke') }}
             </el-button>
           </li>
@@ -78,14 +78,22 @@
           <el-tag size="small" :type="perm.fullDisk ? 'success' : 'info'" effect="plain">
             {{ perm.fullDisk ? $t('common.settings.localToolsGranted') : $t('common.settings.localToolsNotGranted') }}
           </el-tag>
-          <el-button size="small" text @click="open('fullDisk')">{{ $t('common.settings.localToolsOpen') }}</el-button>
+          <el-button size="small" type="primary" @click="open('fullDisk')">{{
+            $t('common.settings.localToolsOpen')
+          }}</el-button>
         </div>
         <div class="perm-row">
           <span class="perm-name">{{ $t('common.settings.localToolsPermScreen') }}</span>
-          <el-tag size="small" :type="perm.screen === 'granted' ? 'success' : 'info'" effect="plain">{{
-            perm.screen
-          }}</el-tag>
-          <el-button size="small" text @click="open('screen')">{{ $t('common.settings.localToolsOpen') }}</el-button>
+          <el-tag size="small" :type="perm.screen === 'granted' ? 'success' : 'info'" effect="plain">
+            {{
+              perm.screen === 'granted'
+                ? $t('common.settings.localToolsGranted')
+                : $t('common.settings.localToolsNotGranted')
+            }}
+          </el-tag>
+          <el-button size="small" type="primary" @click="open('screen')">{{
+            $t('common.settings.localToolsOpen')
+          }}</el-button>
         </div>
         <div class="perm-row">
           <span class="perm-name">{{ $t('common.settings.localToolsPermAccessibility') }}</span>
@@ -94,7 +102,7 @@
               perm.accessibility ? $t('common.settings.localToolsGranted') : $t('common.settings.localToolsNotGranted')
             }}
           </el-tag>
-          <el-button size="small" text @click="open('accessibility')">{{
+          <el-button size="small" type="primary" @click="open('accessibility')">{{
             $t('common.settings.localToolsOpen')
           }}</el-button>
         </div>

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -1000,7 +1000,7 @@
     "description": "Status tag when a system permission is not granted."
   },
   "settings.localToolsOpen": {
-    "message": "Open…",
+    "message": "Open",
     "description": "Button to open the relevant macOS System Settings pane."
   },
   "settings.subsites": {

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -1020,7 +1020,7 @@
     "description": "系统权限未授权时的状态标签。"
   },
   "settings.localToolsOpen": {
-    "message": "打开…",
+    "message": "打开",
     "description": "打开对应 macOS 系统设置面板的按钮。"
   },
   "settings.subsites": {


### PR DESCRIPTION
## What

Polish the **Local Tools → System permissions** rows in the Nexior user-settings dialog (desktop):

- **Consistent status casing** — the Screen Recording tag previously rendered the raw OS string (`granted`, lowercase) while Full Disk Access / Accessibility showed the localized `Granted`. All three rows now use the same `Granted` / `Not granted` labels.
- **Solid action buttons** — the borderless `text` "Open…" links and the per-row "Revoke" button now render as solid Element Plus buttons (`type="primary"` / `type="danger"`), matching the rest of the dialog.
- **Cleaner label** — dropped the ellipsis from the "Open" button label (`zh-CN` + `en`).

## Files

- `src/components/setting/LocalTools.vue`
- `src/i18n/en/common.json`, `src/i18n/zh-CN/common.json` (`settings.localToolsOpen` label only)

Other locales are intentionally left to the translate CronJob per project convention (only `zh-CN` + `en` are hand-maintained).

## 🤖 对抗评审

Reviewer: **Codex** (`codex exec --sandbox read-only`). Verdict after one round: 3 RISK items, all rebutted (no code change required).

| # | RISK | Resolution |
|---|------|-----------|
| 1 | `localToolsOpen` ellipsis dropped only in en/zh-CN | **Rebut** — Nexior convention: only zh-CN + en are hand-maintained; remaining 16 locales are regenerated by the translate CronJob. Editing them manually is disallowed. |
| 2 | "Revoke all" still uses text | **Rebut** — that's the header-level bulk action; a subtle text button avoids a heavy red header button. The user's request targeted the per-row Revoke, now solid. |
| 3 | Screen status collapses denied/not-determined/restricted into "Not granted" | **Rebut** — intentional binary Granted/Not granted UI matching the other two (boolean) rows; the solid "Open" button surfaces the real OS state in System Settings. |

No el-tag/el-button prop misuse; i18n keys valid; JSON parses.
