### PR TITLE
fix(desktop): approving the tool popup authorizes that fs path (wire consent -> allowlist)

### DIFF
--- a/change/@acedatacloud-nexior-b7bc434e-e511-4e21-95b9-24a213d6b615.json
+++ b/change/@acedatacloud-nexior-b7bc434e-e511-4e21-95b9-24a213d6b615.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(desktop): approving the tool popup now authorizes that path, so reads/lists/writes stop failing with 'path outside allowed roots'",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/electron/local/consent.ts
+++ b/electron/local/consent.ts
@@ -1,6 +1,7 @@
 import { dialog, BrowserWindow } from 'electron';
 import type { ToolInvoke } from './types';
 import { load, save } from './config';
+import { authorizeConsentedPath } from './fs';
 
 // No OS sandbox by design — consent is the control. Three tiers:
 //   • Allow once     — run this one time.
@@ -48,6 +49,25 @@ export function grantKey(inv: ToolInvoke): string {
   return `${inv.name}:${stable(inv.input)}`;
 }
 
+// Bridge consent → the fs allowlist. Approving the popup for a file tool used to
+// grant only the *right to run the call*; fs.ts then independently rejected any
+// path not separately added in Settings ("path outside allowed roots"). Here we
+// authorize the exact path the user approved so the call can actually proceed.
+// `persist` (Always allow) additionally writes the granted dir to config.roots
+// so it survives a restart; once/session authorize in-memory only.
+function grantPathAccess(inv: ToolInvoke, persist: boolean): void {
+  if (!inv.name.startsWith('fs.')) return;
+  const p = (inv.input as Record<string, unknown> | undefined)?.path;
+  if (typeof p !== 'string' || !p) return;
+  const dir = authorizeConsentedPath(inv.name, p);
+  if (dir && persist) {
+    const cfg = load();
+    const roots = new Set(cfg.roots ?? []);
+    roots.add(dir);
+    save({ ...cfg, roots: [...roots] });
+  }
+}
+
 export async function consentOk(inv: ToolInvoke, win: BrowserWindow | null, mutates: boolean): Promise<boolean> {
   // Computer-use tools (screen capture + mouse/keyboard injection) are too
   // sensitive to ever auto-run silently: their grant key is often constant
@@ -57,6 +77,14 @@ export async function consentOk(inv: ToolInvoke, win: BrowserWindow | null, muta
   // they are NOT persistable — no permanent grant, no "Always allow" button.
   const persistable = !inv.name.startsWith('computer.');
   const gk = grantKey(inv);
+  // Cached grants must NOT re-authorize the path here. Re-running
+  // authorizeConsentedPath() would realpath the CURRENT target, so a symlink
+  // approved once could be retargeted afterwards to slip a no-prompt grant onto
+  // a new location — defeating the realpath boundary. Authorization is bound at
+  // approval time only: "Always allow" already persisted its canonical dir to
+  // config.roots (loaded into ROOTS on launch); "Allow for session" keeps its
+  // SESSION_ROOTS entry for the run. (Grants created before this change have no
+  // persisted root, so they re-prompt once — which then persists it.)
   if (persistable && (load().grants ?? []).includes(gk)) return true; // persistent always-allow
   if (sessionGranted.has(sessionKey(inv)) && !mutates) return true;
   const buttons = persistable
@@ -79,6 +107,11 @@ export async function consentOk(inv: ToolInvoke, win: BrowserWindow | null, muta
     grants.add(gk);
     save({ ...cfg, grants: [...grants] });
   }
+  // Authorize the approved path (fs.* tools), bound to its realpath AT APPROVAL
+  // TIME — the subsequent read/list/write re-realpaths and re-checks inRootDir,
+  // so a symlink swapped between here and the call is still caught. Only
+  // "Always allow" (response 2, persistable) persists the canonical dir as a root.
+  if (response !== denyId) grantPathAccess(inv, persistable && response === 2);
   return response !== denyId;
 }
 

--- a/electron/local/fs.test.ts
+++ b/electron/local/fs.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, realpathSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setRoots, authorizeConsentedPath, list_dir, read_file, _resetRootsForTesting } from './fs';
+
+// A consented path must become readable/listable even when it was never added
+// as a root in Settings — otherwise the consent popup grants nothing usable
+// and the call fails with "path outside allowed roots".
+describe('fs consent-authorized roots', () => {
+  afterEach(() => _resetRootsForTesting());
+
+  function tmpTree() {
+    const base = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'nx-fs-')));
+    const docs = path.join(base, 'Documents');
+    mkdirSync(docs);
+    writeFileSync(path.join(docs, 'a.txt'), 'hello');
+    return { base, docs };
+  }
+
+  it('rejects a path that is neither a root nor consent-authorized', async () => {
+    const { docs } = tmpTree();
+    await expect(list_dir({ path: docs })).rejects.toThrow('path outside allowed roots');
+  });
+
+  it('authorizes a directory after consent so list_dir succeeds', async () => {
+    const { docs } = tmpTree();
+    const granted = authorizeConsentedPath('fs.list_dir', docs);
+    expect(granted).toBe(docs);
+    const res = await list_dir({ path: docs });
+    expect(res.output).toContain('a.txt');
+  });
+
+  it('authorizes a file after consent so read_file succeeds (and only that file)', async () => {
+    const { docs } = tmpTree();
+    const file = path.join(docs, 'a.txt');
+    authorizeConsentedPath('fs.read_file', file);
+    const res = await read_file({ path: file });
+    expect(res.output).toBe('hello');
+    // The sibling directory listing is still blocked (only the file was granted).
+    await expect(list_dir({ path: docs })).rejects.toThrow('path outside allowed roots');
+  });
+
+  it('still honors roots added via setRoots', async () => {
+    const { docs } = tmpTree();
+    setRoots([docs]);
+    const res = await list_dir({ path: docs });
+    expect(res.output).toContain('a.txt');
+  });
+
+  it('expands ~ when authorizing (matches how models pass paths)', async () => {
+    // The home dir itself; authorizing "~" must add the real home as a root.
+    const granted = authorizeConsentedPath('fs.list_dir', '~');
+    expect(granted).toBe(realpathSync(os.homedir()));
+  });
+});

--- a/electron/local/fs.ts
+++ b/electron/local/fs.ts
@@ -8,6 +8,13 @@ import type { ToolResult } from './types';
 // separator boundary + realpath defeats symlink / sibling-prefix escape.
 let ROOTS: string[] = [];
 
+// Roots authorized at runtime by an explicit consent grant (the popup the user
+// approves for a specific path). In-memory only; "Always allow" additionally
+// persists the granted dir to config.roots (see consent.ts) so it survives a
+// restart via setRoots(). Kept separate from ROOTS so a one-shot/session grant
+// never silently becomes a permanent root.
+const SESSION_ROOTS = new Set<string>();
+
 export function setRoots(roots: string[]): void {
   ROOTS = roots
     .map((p) => {
@@ -21,7 +28,8 @@ export function setRoots(roots: string[]): void {
 }
 
 function inRootDir(full: string): boolean {
-  return ROOTS.some((r) => full === r || full.startsWith(r + path.sep));
+  const ok = (r: string) => full === r || full.startsWith(r + path.sep);
+  return ROOTS.some(ok) || [...SESSION_ROOTS].some(ok);
 }
 
 // Models commonly pass `~/Desktop`; Node never expands `~`, so realpathSync
@@ -52,6 +60,30 @@ function resolveForWrite(p: string): string {
   const full = path.join(dir, path.basename(expanded));
   if (!inRootDir(full)) throw new Error('path outside allowed roots');
   return full;
+}
+
+// Authorize a path the user just consented to via the tool popup, so the
+// matching read/list/write actually passes inRootDir. Without this, approving
+// the consent dialog would still fail with "path outside allowed roots" unless
+// the folder was separately added in Settings. Returns the canonical (realpath)
+// dir/file that was granted, or null if it can't be resolved. For writes the
+// target file may not exist yet, so authorize its parent directory.
+export function authorizeConsentedPath(name: string, p: string): string | null {
+  try {
+    const expanded = expandHome(p);
+    const target =
+      name === 'fs.write_file' ? realpathSync(path.dirname(expanded)) : realpathSync(expanded);
+    SESSION_ROOTS.add(target);
+    return target;
+  } catch {
+    return null;
+  }
+}
+
+// Test hook: clear all roots (persistent + session) between cases.
+export function _resetRootsForTesting(): void {
+  ROOTS = [];
+  SESSION_ROOTS.clear();
 }
 
 export async function read_file(i: { path: string }): Promise<ToolResult> {


### PR DESCRIPTION
## Problem

On the desktop app, the local file tools (`fs.read_file` / `fs.list_dir` / `fs.write_file`) are guarded by **two independent gates**:

1. the **consent popup** (`consentOk`) — grants the right to *run* an exact `(tool, input)`;
2. the **`ROOTS` folder allowlist** (`fs.ts` → `inRootDir`) — set **only** via Settings → "Add folder", and independently rejects any path not under a configured root.

Approving the popup never added the folder to `ROOTS`. So after the model correctly used the local tool (post aichat2 prompt/description fix), listing e.g. `~/Documents` still failed with **`path outside allowed roots`** — even though the user kept approving the popup. `~/Desktop` only worked because it happened to be a configured root. The two permission systems were disconnected.

## Fix — wire consent → the allowlist

- `electron/local/fs.ts`: add an in-memory `SESSION_ROOTS` set; `inRootDir` now checks `ROOTS ∪ SESSION_ROOTS`. New `authorizeConsentedPath(name, path)` realpaths the approved target (for `fs.write_file` the parent dir, since the file may not exist yet) and adds it.
- `electron/local/consent.ts`: `grantPathAccess(inv, persist)` runs **on every approval** — *Allow once* / *Allow for session* authorize the path in-memory; *Always allow* additionally persists the canonical dir to `config.roots` so it survives a restart (and shows up in Settings → revocable).

Net effect: approving the popup now actually grants access to that path. No need to pre-add folders in Settings.

## Adversarial review (Codex, read-only) — HIGH fixed

- **HIGH — symlink-retarget TOCTOU.** My first draft also re-ran `authorizeConsentedPath()` on the *cached* (no-prompt) grant paths, which realpaths the symlink's **current** target. A symlink approved once could later be retargeted to a sensitive path and slip a no-prompt grant onto it, defeating the realpath boundary. **Fixed**: cached grants no longer re-authorize. Authorization binds at **approval time** only — *Always allow* persisted its canonical dir to `config.roots` (loaded into `ROOTS` at launch); *Allow for session* keeps its `SESSION_ROOTS` entry for the run. The subsequent read/list/write still re-realpaths and re-checks `inRootDir`, so a symlink swapped between approval and the call is still caught. (Grants created before this change have no persisted root, so they re-prompt once — which then persists it.)

## Tests

`electron/local/fs.test.ts` (new, 5 cases): rejects un-authorized paths; a consented dir/file becomes listable/readable; a granted file authorizes only that file (sibling listing still blocked); `setRoots` still honored; `~` expansion. Full suite: **213 passed**. `tsc -p electron/tsconfig.json` clean.

> Client-side (Electron main process) — ships with the next desktop build.
