### PR TITLE
fix(desktop): open store links externally + add Back/Forward nav so /download isn't a dead end

### DIFF
--- a/change/@acedatacloud-nexior-602d14d7-c853-43c1-90c5-b1580c8ff32a.json
+++ b/change/@acedatacloud-nexior-602d14d7-c853-43c1-90c5-b1580c8ff32a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(desktop): open store links externally + Back/Forward nav so /download isn't a dead end",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -18,7 +18,11 @@ const AUTH_HOSTS = new Set(['auth.acedata.cloud']);
 // be allow-listed or the user can never reach checkout. Verify against the real
 // pay flow before shipping.
 const PSP_HOSTS = ['alipay.com', 'stripe.com', 'wx.tenpay.com', 'paypal.com'];
-const EXTERNAL_HOSTS = new Set(['acedata.cloud', ...PSP_HOSTS]);
+// Public app-store / desktop-build download destinations linked from the
+// /download page. Without these the store buttons are dead on desktop —
+// setWindowOpenHandler denies any host not on the allowlist.
+const STORE_HOSTS = ['play.google.com', 'apps.apple.com', 'github.com'];
+const EXTERNAL_HOSTS = new Set(['acedata.cloud', ...PSP_HOSTS, ...STORE_HOSTS]);
 
 // The signed-in site origin, added at runtime via `site:setOrigin` so
 // white-label custom-domain tenants aren't denied. Auth host stays fixed.
@@ -166,6 +170,15 @@ function createWindow(): void {
   // their inset. macOS-only events, but harmless to wire everywhere.
   mainWindow.on('enter-full-screen', () => mainWindow?.webContents.send('window:fullscreen', true));
   mainWindow.on('leave-full-screen', () => mainWindow?.webContents.send('window:fullscreen', false));
+
+  // macOS trackpad two-finger swipe ↔ history (matches Safari/browser muscle
+  // memory). Cmd+[ / Cmd+] and the Go menu cover keyboard users.
+  mainWindow.on('swipe', (_e, direction) => {
+    const h = mainWindow?.webContents.navigationHistory;
+    if (!h) return;
+    if (direction === 'left' && h.canGoBack()) h.goBack();
+    else if (direction === 'right' && h.canGoForward()) h.goForward();
+  });
 }
 
 function handleDeepLink(rawUrl: string): void {
@@ -250,11 +263,26 @@ ipcMain.handle('notify:show', (_e, { title, body }: { title: string; body: strin
 // (Cmd/Ctrl+C/V/X/A, undo/redo) to work in inputs; without it they are dead.
 function setupAppMenu(): void {
   const isMac = process.platform === 'darwin';
+  const nav = (dir: 'back' | 'forward') => {
+    const h = BrowserWindow.getFocusedWindow()?.webContents.navigationHistory;
+    if (!h) return;
+    if (dir === 'back' && h.canGoBack()) h.goBack();
+    else if (dir === 'forward' && h.canGoForward()) h.goForward();
+  };
   Menu.setApplicationMenu(
     Menu.buildFromTemplate([
       ...(isMac ? [{ role: 'appMenu' as const }] : []),
       { role: 'editMenu' },
       { role: 'viewMenu' },
+      // Escape hatch from chrome-less pages (e.g. /download): without this the
+      // user can land on a Bare-layout route with no in-app way back.
+      {
+        label: 'Go',
+        submenu: [
+          { label: 'Back', accelerator: isMac ? 'Cmd+[' : 'Alt+Left', click: () => nav('back') },
+          { label: 'Forward', accelerator: isMac ? 'Cmd+]' : 'Alt+Right', click: () => nav('forward') }
+        ]
+      },
       { role: 'windowMenu' }
     ])
   );

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -260,8 +260,8 @@
     "description": "Used to display the amount of service that has been used"
   },
   "message.mobileAppDescription": {
-    "message": "Take the full AceData studio with you. The Android app is now on Google Play — install in one tap, or scan the QR code. The iOS build is on the way.",
-    "description": "Description text for the mobile app download page"
+    "message": "Take the full AceData studio everywhere — on Android, iPhone & iPad, Windows, and macOS. Install in one tap, or scan a QR code to get started.",
+    "description": "Description text for the app download page"
   },
   "message.mobileAndroidHint": {
     "message": "For Android phones and tablets. Install from Google Play for automatic updates, or grab the APK directly.",
@@ -344,8 +344,8 @@
     "description": "Mobile app installation prompt"
   },
   "title.mobileApp": {
-    "message": "Download the AceData App",
-    "description": "Title for the mobile app download page"
+    "message": "Get the AceData Apps",
+    "description": "Title for the app download page"
   },
   "title.mobileFastAccess": {
     "message": "Faster Access, No App Store Detours",
@@ -360,8 +360,8 @@
     "description": "Title for the download page advantage card, emphasizing unified experience"
   },
   "nav.mobileApp": {
-    "message": "Mobile",
-    "description": "Navigation entry for mobile app download"
+    "message": "Apps",
+    "description": "Navigation entry for the app download page (mobile + desktop)"
   },
   "message.mobileFastAccess": {
     "message": "Users can scan the code on their phone for direct installation, or download the APK on the desktop and distribute it to team members, suitable for quick trials and internal testing.",

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -264,8 +264,8 @@
     "description": "用于显示服务已使用的金额"
   },
   "message.mobileAppDescription": {
-    "message": "把完整的 AceData 创作工具装进口袋。Android 版现已上架 Google Play —— 一键安装，或扫码前往；iOS 版正在路上。",
-    "description": "移动应用下载页的说明文案"
+    "message": "随时随地使用完整的 AceData 创作工具 —— 支持 Android、iPhone、iPad、Windows 与 macOS。一键安装，或扫码前往。",
+    "description": "应用下载页的说明文案"
   },
   "message.mobileAndroidHint": {
     "message": "适用于 Android 手机和平板。可从 Google Play 安装以获得自动更新，也可直接下载 APK。",
@@ -348,8 +348,8 @@
     "description": "移动应用安装提示"
   },
   "title.mobileApp": {
-    "message": "下载 AceData 移动端",
-    "description": "移动应用下载页标题"
+    "message": "获取 AceData 客户端",
+    "description": "应用下载页标题"
   },
   "title.mobileFastAccess": {
     "message": "更快触达，不绕应用商店",
@@ -364,8 +364,8 @@
     "description": "下载页优势卡片标题，强调统一体验"
   },
   "nav.mobileApp": {
-    "message": "移动端",
-    "description": "导航中的移动应用下载入口"
+    "message": "客户端",
+    "description": "导航中的应用下载入口（移动端 + 桌面端）"
   },
   "message.mobileFastAccess": {
     "message": "用户可以在手机扫码直接安装，也可以在桌面端先下载 APK 再分发给团队成员，适合需要快速试用和内测的场景。",


### PR DESCRIPTION
## Problem (macOS desktop)

On the desktop app, the `/download` page was broken in two ways:

1. **Store buttons were dead** — "Get it on Google Play", "Get it on the App Store" and the GitHub footer link point to `play.google.com` / `apps.apple.com` / `github.com`, none of which were in the Electron `EXTERNAL_HOSTS` allowlist. `setWindowOpenHandler` denies any non-allowlisted host, so `shell.openExternal` was never called and the links did nothing.
2. **No way back** — `/download` uses the chrome-less `Bare` layout and the app menu had no Back/Forward, so once a user landed there (via the footer link, which is a full-document navigation) they were stuck with no in-app way to return.

## Fix

`electron/main.ts`:

- Add `play.google.com`, `apps.apple.com`, `github.com` to the external-open allowlist (`STORE_HOSTS`). These are reputable public download destinations linked from the `/download` page; the matcher is still https-only with exact/dot-suffix matching, and the links open in the system browser, not in-app.
- Add a **Go** menu with **Back** (`Cmd+[` / `Alt+Left`) and **Forward** (`Cmd+]` / `Alt+Right`) so users are never trapped on a chrome-less route.
- Add macOS trackpad two-finger **swipe ↔ history** navigation to match browser muscle memory.

## Verification

- `tsc -p electron/tsconfig.json --noEmit` passes.
- Codex adversarial review: **VERDICT: CLEAN** (allowlist matcher safe, Electron 42 `navigationHistory` API correct, accelerators valid).
