### PR TITLE
feat(desktop): computer.screenshot returns the screen image for the model (computer-use Phase 1)

### DIFF
--- a/change/@acedatacloud-nexior-7c3e1f90-4a2b-4d6e-9f81-2b5c6e0a1d34.json
+++ b/change/@acedatacloud-nexior-7c3e1f90-4a2b-4d6e-9f81-2b5c6e0a1d34.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(desktop): computer.screenshot returns the screen image so the model can see it (computer-use Phase 1)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/electron/local/computer.ts
+++ b/electron/local/computer.ts
@@ -75,6 +75,10 @@ function err(message: string): ToolResult {
 // stale screen captures (sensitive) don't linger. shot-<ms>.png names sort
 // chronologically, so keep the newest MAX_SHOTS and unlink the rest.
 const MAX_SHOTS = 10;
+
+// Stay safely under the aichat2 worker's tool-result image budget (~6 MB of
+// base64); JPEG quality is stepped down until the encoded screenshot fits.
+const MAX_IMAGE_B64_CHARS = 5_400_000;
 async function pruneShots(dir: string): Promise<void> {
   try {
     const files = (await fsp.readdir(dir)).filter((f) => f.startsWith('shot-') && f.endsWith('.png')).sort();
@@ -116,7 +120,10 @@ export async function screenshot(): Promise<ToolResult> {
     types: ['screen'],
     thumbnailSize: { width: Math.round(width * scaleFactor), height: Math.round(height * scaleFactor) }
   });
-  const source = sources[0];
+  // Pick the source for the PRIMARY display — on multi-monitor setups the array
+  // order isn't guaranteed, and the dimensions/coordinate space below are the
+  // primary's, so capturing a different screen would mis-map the model's clicks.
+  const source = sources.find((s) => s.display_id && s.display_id === String(display.id)) ?? sources[0];
   if (!source || source.thumbnail.isEmpty()) return err('no screen source available (capture returned empty)');
 
   const png = source.thumbnail.toPNG();
@@ -126,11 +133,21 @@ export async function screenshot(): Promise<ToolResult> {
   await fsp.writeFile(file, png, { mode: 0o600 });
   await pruneShots(dir);
 
-  // The PNG is saved to disk (not inlined) to keep the tool result small —
-  // a full-screen base64 would blow the client-tool result cap and the model
-  // context. Returning the image to the model as an image content block is a
-  // follow-up (see plan: "image tool-results"). Only the basename is returned
-  // so the absolute userData/home path isn't leaked to the model.
+  // The model SEES the screen via `image` (a JPEG data URL resized to LOGICAL
+  // resolution): logical-pixel image ⇒ the model's click coordinates map 1:1 to
+  // what `computer.click` expects (so quality drops, not dimensions, when we
+  // need to shrink). JPEG keeps the base64 small; we step quality down until it
+  // fits the worker's data-URL budget. The full-res PNG is still saved to disk
+  // for debugging. Only the basename is returned in `output` (no absolute path).
+  const resized = source.thumbnail.resize({ width, height });
+  let image: string | undefined;
+  for (const quality of [80, 60, 45]) {
+    const b64 = resized.toJPEG(quality).toString('base64');
+    if (b64.length <= MAX_IMAGE_B64_CHARS) {
+      image = `data:image/jpeg;base64,${b64}`;
+      break;
+    }
+  }
   return {
     output: JSON.stringify({
       saved: path.basename(file),
@@ -138,8 +155,11 @@ export async function screenshot(): Promise<ToolResult> {
       height,
       scaleFactor,
       bytes: png.length,
-      note: 'screenshot saved; coordinates below are in logical pixels (the click tool expects the same)'
-    })
+      note: image
+        ? 'screenshot attached as an image; coordinates are in logical pixels (the click tool expects the same)'
+        : 'screenshot captured but too large to attach as an image this turn; coordinates are in logical pixels'
+    }),
+    ...(image ? { image } : {})
   };
 }
 

--- a/electron/local/types.ts
+++ b/electron/local/types.ts
@@ -19,6 +19,9 @@ export interface ToolInvoke {
 export interface ToolResult {
   output: string;
   is_error?: boolean;
+  // Optional image result (e.g. computer.screenshot): a `data:image/...` URL the
+  // worker surfaces to the vision model so it can SEE the screen.
+  image?: string;
 }
 
 export interface McpServerConf {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -63,7 +63,7 @@ contextBridge.exposeInMainWorld('desktop', {
 contextBridge.exposeInMainWorld('localExec', {
   available: true,
   listTools: (): Promise<unknown[]> => ipcRenderer.invoke('local.tools.list'),
-  invoke: (inv: { name: string; input: object; sessionId: string }): Promise<{ output: string; is_error?: boolean }> =>
+  invoke: (inv: { name: string; input: object; sessionId: string }): Promise<{ output: string; is_error?: boolean; image?: string }> =>
     ipcRenderer.invoke('local.tool.invoke', inv),
   getConfig: (): Promise<{ roots: string[]; mcp: object[]; computerUse?: boolean }> => ipcRenderer.invoke('local.config.get'),
   saveConfig: (cfg: { roots: string[]; mcp: object[]; computerUse?: boolean }): Promise<boolean> =>

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -299,7 +299,7 @@ export interface IChatConversationRequest {
   // MUST be in `awaiting_user_input` state and `tool_results` MUST contain
   // exactly one entry whose `tool_use_id` matches the pending `tool_use`
   // block. `question` / `message` / `references` are ignored when this is set.
-  tool_results?: { tool_use_id: string; output: string; is_error?: boolean }[];
+  tool_results?: { tool_use_id: string; output: string; is_error?: boolean; image?: string }[];
 }
 
 export interface IChatConversationResponse {

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -720,7 +720,7 @@ export default defineComponent({
      * first.
      */
     _resumeWithToolResults(
-      toolResults: { tool_use_id: string; output: string; is_error?: boolean }[],
+      toolResults: { tool_use_id: string; output: string; is_error?: boolean; image?: string }[],
       conversationId?: string
     ) {
       const token = this.credential?.token;
@@ -856,7 +856,7 @@ export default defineComponent({
       runId?: number
     ) {
       const sessionId = (conversationId ?? this.conversationId) || '';
-      const results: { tool_use_id: string; output: string; is_error?: boolean }[] = [];
+      const results: { tool_use_id: string; output: string; is_error?: boolean; image?: string }[] = [];
       for (const p of pending) {
         // Stop pressed mid-batch → onStop() bumped the token; abort BEFORE
         // running any further local tool (each invoke may be a shell command,
@@ -875,7 +875,7 @@ export default defineComponent({
         } catch {
           safeInput = {};
         }
-        let r: { output: string; is_error?: boolean };
+        let r: { output: string; is_error?: boolean; image?: string };
         try {
           r = (await localExec()?.invoke({ name: realName, input: safeInput, sessionId })) ?? {
             output: 'local execution unavailable',
@@ -889,8 +889,15 @@ export default defineComponent({
         }
         // Propagate is_error so denied/failed local executions (e.g. consent
         // denied, path outside allowed roots) resume as a tool ERROR, not a
-        // successful output the model would trust.
-        results.push({ tool_use_id: p.toolId, output: r.output, ...(r.is_error ? { is_error: true } : {}) });
+        // successful output the model would trust. `image` (e.g. a
+        // computer.screenshot) is forwarded so the worker can show the model
+        // the screen as a vision input.
+        results.push({
+          tool_use_id: p.toolId,
+          output: r.output,
+          ...(r.is_error ? { is_error: true } : {}),
+          ...(r.image ? { image: r.image } : {})
+        });
       }
       // Stop pressed while the last tool was running → don't resume the turn.
       if (runId !== undefined && runId !== this.clientToolRunId) return;

--- a/src/utils/desktop.ts
+++ b/src/utils/desktop.ts
@@ -56,7 +56,11 @@ export interface LocalToolSpec {
 export interface LocalExecBridge {
   available: true;
   listTools(): Promise<LocalToolSpec[]>;
-  invoke(inv: { name: string; input: object; sessionId: string }): Promise<{ output: string; is_error?: boolean }>;
+  invoke(inv: {
+    name: string;
+    input: object;
+    sessionId: string;
+  }): Promise<{ output: string; is_error?: boolean; image?: string }>;
   getConfig(): Promise<{
     roots: string[];
     mcp: { id: string; command: string; args: string[] }[];


### PR DESCRIPTION
## What

Phase 1 (desktop half) of **computer use** — paired with PlatformService #1241 (worker accepts `tool_results[].image`). The desktop `computer.screenshot` tool now returns the screen **as an image** so a vision model can actually SEE it and decide the next action, closing the perceive→act loop.

## Changes

- `electron/local/computer.ts` — `screenshot()` returns `image`: the captured screen **resized to LOGICAL resolution**, JPEG-encoded. Logical-pixel image ⇒ the model's click coordinates map 1:1 to what `computer.click` expects (we drop *quality*, not dimensions, to fit the budget). The full-res PNG is still saved to disk for debugging.
- `electron/local/types.ts`, `electron/preload.ts`, `src/utils/desktop.ts` — `ToolResult` / the `localExec.invoke` bridge gain an optional `image?: string`.
- `src/models/chat.ts`, `src/pages/chat/Conversation.vue` — the resume `tool_results` entry gains `image?`, and `Conversation.vue` forwards `r.image` from `localExec.invoke()` into the `tool_results` it sends on resume.

Only `computer.screenshot` sets `image`; fs/shell/MCP tools are unaffected.

## Adversarial review (Codex, read-only) — addressed

- **MED** — `sources[0]` may not be the primary display on multi-monitor, while the dimensions/coords are the primary's → the model would see the wrong screen and mis-click. → **Fixed**: pick the source whose `display_id` matches the primary `display.id` (fallback to `sources[0]`).
- **MED** — q80 JPEG could exceed the worker's ~6 MB data-URL budget on a large/noisy display → silently dropped while the note claimed "attached". → **Fixed**: step JPEG quality down (80→60→45) until it fits `MAX_IMAGE_B64_CHARS`; if it still can't, omit `image` and the `output.note` says so (the model knows it has no visual this turn). Dimensions are never reduced, so coordinate mapping stays correct.

## Validation

- `tsc -p electron/tsconfig.json`: clean. `vue-tsc -b`: clean. `npm run test:run`: **213 passed**. eslint + prettier clean on changed `src` files (`electron/` is not linted, same as existing main-process files).

## Note

Requires the worker side (#1241) to be deployed to take effect end-to-end. Computer Use is opt-in (default off) in Settings → Local Tools.
