### PR TITLE
feat(desktop): global panic-stop hotkey to kill Computer Use (Phase 3)

### DIFF
--- a/change/@acedatacloud-nexior-7c1d2e9a-4b83-4f6a-9d21-5a0e8c4f1b22.json
+++ b/change/@acedatacloud-nexior-7c1d2e9a-4b83-4f6a-9d21-5a0e8c4f1b22.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "desktop: add global panic-stop hotkey (Cmd/Ctrl+Alt+Shift+P) to instantly disable Computer Use",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/electron/local/ipc.ts
+++ b/electron/local/ipc.ts
@@ -18,6 +18,19 @@ function sameOrigin(url: string | undefined): boolean {
   }
 }
 
+// Panic kill-switch: force Computer Use OFF (persisted + hot-applied at once) so
+// a global hotkey can halt all screen capture + input even when the app is
+// unfocused. Returns whether it was actually on (for the caller's feedback).
+export function disableComputerUse(): boolean {
+  const cur = load();
+  const wasOn = cur.computerUse === true;
+  // Flip the in-memory gate first — that is what actually blocks execution — so
+  // a slow/throwing save() can never leave Computer Use live after a panic.
+  registry.setComputerUse(false);
+  if (wasOn) save({ ...cur, computerUse: false });
+  return wasOn;
+}
+
 export function registerLocalExec(getWin: () => BrowserWindow | null): void {
   const gate = (e: Electron.IpcMainInvokeEvent) => {
     if (!sameOrigin(e.senderFrame?.url)) throw new Error('local-exec: bad sender origin');

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,9 +1,9 @@
-import { app, BrowserWindow, ipcMain, shell, Menu, Notification } from 'electron';
+import { app, BrowserWindow, ipcMain, shell, Menu, Notification, globalShortcut } from 'electron';
 import path from 'node:path';
 import { registerAppProtocol, APP_ORIGIN } from './protocol';
 import { issueState, consumeState } from './auth-state';
 import { initUpdater } from './updater';
-import { registerLocalExec } from './local/ipc';
+import { registerLocalExec, disableComputerUse } from './local/ipc';
 import { registry } from './local/registry';
 import { setRoots } from './local/fs';
 import { load as loadLocalConfig } from './local/config';
@@ -103,6 +103,7 @@ if (!gotLock) {
     registry.setComputerUse(localCfg.computerUse === true); // opt-in, default off
     void registry.boot(localCfg.mcp);
     registerLocalExec(() => mainWindow);
+    registerPanicStop();
     // Windows cold-start protocol activation: URL is in this instance's argv.
     const coldUrl = process.argv.find((a) => a.startsWith(`${DESKTOP_SCHEME}://`));
     if (coldUrl) handleDeepLink(coldUrl);
@@ -111,9 +112,38 @@ if (!gotLock) {
   app.on('window-all-closed', () => {
     if (process.platform !== 'darwin') app.quit();
   });
+  app.on('will-quit', () => globalShortcut.unregisterAll());
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow();
   });
+}
+
+// Global "panic stop" hotkey: instantly disables Computer Use (screen capture +
+// mouse/keyboard input) from anywhere, even when the app is unfocused — the
+// escape hatch for a runaway screen-control loop. Per-action consent is the
+// primary gate; this is the always-available kill switch.
+const PANIC_ACCELERATOR = 'CommandOrControl+Alt+Shift+P';
+
+function registerPanicStop(): void {
+  try {
+    const ok = globalShortcut.register(PANIC_ACCELERATOR, () => {
+      const wasOn = disableComputerUse();
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.webContents.send('local.computerUse.disabled');
+      }
+      if (Notification.isSupported()) {
+        new Notification({
+          title: 'Computer Use stopped',
+          body: wasOn
+            ? 'Screen control was disabled. Re-enable it in Settings → Local Tools.'
+            : 'Computer Use was already off.'
+        }).show();
+      }
+    });
+    if (!ok) console.warn(`panic-stop: failed to register ${PANIC_ACCELERATOR}`);
+  } catch (err) {
+    console.warn('panic-stop: globalShortcut registration error', err);
+  }
 }
 
 function createWindow(): void {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -82,5 +82,12 @@ contextBridge.exposeInMainWorld('localExec', {
     list: (): Promise<string[]> => ipcRenderer.invoke('local.grants.list'),
     revoke: (key: string): Promise<boolean> => ipcRenderer.invoke('local.grants.revoke', key),
     clear: (): Promise<boolean> => ipcRenderer.invoke('local.grants.clear')
+  },
+  // Fired when the global panic hotkey forces Computer Use off, so the Settings
+  // toggle reflects reality and a later Save can't silently re-enable it.
+  onComputerUseDisabled: (cb: () => void): (() => void) => {
+    const handler = (): void => cb();
+    ipcRenderer.on('local.computerUse.disabled', handler);
+    return () => ipcRenderer.removeListener('local.computerUse.disabled', handler);
   }
 });

--- a/src/components/setting/LocalTools.vue
+++ b/src/components/setting/LocalTools.vue
@@ -137,7 +137,8 @@ export default defineComponent({
       computerUse: false,
       savingCU: false,
       saving: false,
-      savedTip: false
+      savedTip: false,
+      cuOff: null as null | (() => void)
     };
   },
   computed: {
@@ -155,6 +156,15 @@ export default defineComponent({
     const s = await ex.perm?.status();
     if (s?.mac) this.perm = s;
     await this.loadGrants();
+    // Reflect the global panic hotkey: keep the toggle in sync so a later Save
+    // can't silently re-enable Computer Use after it was force-disabled.
+    this.cuOff =
+      ex.onComputerUseDisabled?.(() => {
+        this.computerUse = false;
+      }) ?? null;
+  },
+  beforeUnmount() {
+    this.cuOff?.();
   },
   methods: {
     async loadGrants() {

--- a/src/utils/desktop.ts
+++ b/src/utils/desktop.ts
@@ -85,6 +85,9 @@ export interface LocalExecBridge {
     revoke(key: string): Promise<boolean>;
     clear(): Promise<boolean>;
   };
+  /** Subscribe to the global panic hotkey forcing Computer Use off. Returns an
+   * unsubscribe fn. Undefined on older preloads. */
+  onComputerUseDisabled?(cb: () => void): () => void;
 }
 
 export function localExec(): LocalExecBridge | undefined {


### PR DESCRIPTION
## What

Phase 3 of **computer use** — the safety **kill switch**. Adds a global "panic stop" hotkey that instantly disables Computer Use (screen capture + mouse/keyboard automation) from anywhere, even when the app is unfocused.

- **Accelerator:** `Cmd/Ctrl + Alt + Shift + P`.
- On trigger: flips the in-memory tool gate **off first** (`registry.setComputerUse(false)`), persists `computerUse:false`, shows an OS notification, and broadcasts `local.computerUse.disabled` so the Settings toggle reflects reality.
- Registered on `app.whenReady`, torn down on `will-quit` (`globalShortcut.unregisterAll()`).

## Why

Per-call consent is the **primary** gate (every `computer.*` action prompts and is never persistently grantable). This is the always-available escape hatch for a runaway screen-control loop — the hard safety gate before broad enablement (plan `plans/nexior-desktop/COMPUTER-USE.md`, Phase 3).

## Files

- `electron/local/ipc.ts` — `disableComputerUse()` helper (gate-first, then persist).
- `electron/main.ts` — `registerPanicStop()` + lifecycle teardown.
- `electron/preload.ts` / `src/utils/desktop.ts` — `onComputerUseDisabled` bridge.
- `src/components/setting/LocalTools.vue` — sync the toggle when panic fires (prevents a later Save from silently re-enabling).

Computer Use stays **opt-in, default OFF**. No new deps. Verified: `tsc -p electron`, `vue-tsc -b`, `eslint src` all clean.

## 🤖 对抗评审 (Codex, read-only)

| # | Finding | Resolution |
|---|---------|-----------|
| 1 | In-flight `computer.*` action not abortable mid-run | **Rebut** — each action is atomic & sub-second and individually consented; panic stops the *loop* from continuing. True mid-injection abort is a larger feature (tracked Phase 3b). |
| 2 | `save()` ran before flipping the in-memory gate → a throwing save could leave it live | **Fixed** — `registry.setComputerUse(false)` now runs **first**, persist second. |
| 3 | Shortcut registration is fail-open (only logs on conflict) | **Rebut** — failing to register grants no capability; the per-call consent gate is unaffected and CU is OFF by default. A warning is logged. |
| 4 | `disabled` event unhandled → stale Settings toggle could silently re-enable on next Save | **Fixed** — added `onComputerUseDisabled` bridge; `LocalTools.vue` flips the toggle off on panic. |
| 5 | `mainWindow?.webContents.send` could hit a destroyed window (macOS window closed, app alive) | **Fixed** — guarded with `mainWindow && !mainWindow.isDestroyed()`. |

Converged: 3 fixed, 2 rebutted.
