### PR TITLE
feat(desktop): one-click pre-approve all computer-use actions

### DIFF
--- a/change/@acedatacloud-nexior-4b7d1e0a-8c52-4a93-bf61-2d9e7c3a05f4.json
+++ b/change/@acedatacloud-nexior-4b7d1e0a-8c52-4a93-bf61-2d9e7c3a05f4.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "desktop: 'Pre-approve all computer actions' one-click — enable Computer Use, grant always-allow for every computer.* tool (native confirm), and trigger macOS Screen Recording + Accessibility prompts",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/electron/local/consent.ts
+++ b/electron/local/consent.ts
@@ -143,6 +143,18 @@ export function listGrants(): string[] {
   return load().grants ?? [];
 }
 
+// Pre-approve the given tools as persistent "Always allow" grants in one shot
+// (used by "pre-approve all computer actions"). Only computer.* names are
+// accepted — their grant key IS the bare tool name (see grantKey) — so this can
+// never widen an fs/shell grant beyond its exact input. Idempotent.
+export function grantComputerTools(names: string[]): string[] {
+  const cfg = load();
+  const grants = new Set(cfg.grants ?? []);
+  for (const n of names) if (n.startsWith('computer.')) grants.add(n);
+  save({ ...cfg, grants: [...grants] });
+  return [...grants];
+}
+
 export function revokeGrant(key: string): void {
   const cfg = load();
   save({ ...cfg, grants: (cfg.grants ?? []).filter((g) => g !== key) });

--- a/electron/local/ipc.ts
+++ b/electron/local/ipc.ts
@@ -1,10 +1,10 @@
 import { ipcMain, BrowserWindow, dialog } from 'electron';
 import { APP_ORIGIN } from '../protocol';
-import { consentOk, listGrants, revokeGrant, clearGrants, resetComputerSessionConsent } from './consent';
+import { consentOk, listGrants, revokeGrant, clearGrants, resetComputerSessionConsent, grantComputerTools } from './consent';
 import { registry } from './registry';
 import { load, save } from './config';
 import { setRoots } from './fs';
-import { status, openPane, askMedia, promptAccessibility, type PaneKey } from './permissions';
+import { status, openPane, askMedia, promptAccessibility, ensureScreenPermission, type PaneKey } from './permissions';
 import type { LocalConfig, ToolInvoke } from './types';
 
 // Only the top-frame app://bundle renderer may drive local execution. Compare
@@ -109,5 +109,37 @@ export function registerLocalExec(getWin: () => BrowserWindow | null): void {
     gate(e);
     clearGrants();
     return true;
+  });
+
+  // "Pre-approve all computer actions": turn Computer Use on, persist an
+  // always-allow grant for every computer.* tool at once, and trigger the macOS
+  // Screen Recording + Accessibility prompts up front so the first real action
+  // doesn't stall. Returns the new grant list + permission status to refresh UI.
+  ipcMain.handle('local.computerUse.preauthorize', async (e) => {
+    gate(e);
+    const win = getWin();
+    // Native (main-process) confirmation. The renderer can request this, but a
+    // compromised/XSS'd page must NOT be able to silently grant itself permanent
+    // screen + input control — only the user clicking this native dialog can.
+    const confirm = {
+      type: 'warning' as const,
+      buttons: ['Enable & allow all', 'Cancel'],
+      defaultId: 1,
+      cancelId: 1,
+      message: 'Pre-approve all computer actions?',
+      detail:
+        'This lets the AI take screenshots and control your mouse & keyboard WITHOUT asking each time — until you revoke it in Settings → Local Tools or press the panic hotkey (Cmd/Ctrl+Alt+Shift+P).'
+    };
+    const { response } = win ? await dialog.showMessageBox(win, confirm) : await dialog.showMessageBox(confirm);
+    if (response !== 0) return { grants: listGrants(), perm: status(), computerUse: load().computerUse === true };
+    const cur = load();
+    if (cur.computerUse !== true) save({ ...cur, computerUse: true });
+    registry.setComputerUse(true);
+    const grants = grantComputerTools(registry.computerToolNames());
+    await ensureScreenPermission(); // capture permission (no-op off macOS)
+    promptAccessibility(); // input permission
+    // Re-read computerUse: a panic hotkey fired DURING the awaits above would
+    // have disabled it, so don't report a stale `true` the UI could re-persist.
+    return { grants, perm: status(), computerUse: load().computerUse === true };
   });
 }

--- a/electron/local/permissions.ts
+++ b/electron/local/permissions.ts
@@ -1,4 +1,4 @@
-import { systemPreferences, shell } from 'electron';
+import { systemPreferences, shell, desktopCapturer } from 'electron';
 import fs from 'node:fs';
 
 // macOS TCC permission status + System Settings deep-links. Desktop is non-MAS
@@ -52,4 +52,17 @@ export async function askMedia(t: 'camera' | 'microphone'): Promise<boolean> {
 // Prompt accessibility once (true triggers the system dialog); ignore on non-mac.
 export function promptAccessibility(): boolean {
   return MAC ? systemPreferences.isTrustedAccessibilityClient(true) : true;
+}
+
+// macOS has no askForMediaAccess('screen'); the Screen Recording TCC prompt only
+// appears the first time the app actually enumerates a screen source. Touch
+// desktopCapturer (1×1 thumbnail) to trigger it naturally, then report status.
+export async function ensureScreenPermission(): Promise<string> {
+  if (!MAC) return 'granted';
+  try {
+    await desktopCapturer.getSources({ types: ['screen'], thumbnailSize: { width: 1, height: 1 } });
+  } catch {
+    /* the call's side effect (showing the prompt) is what matters; ignore errors */
+  }
+  return systemPreferences.getMediaAccessStatus('screen');
 }

--- a/electron/local/registry.ts
+++ b/electron/local/registry.ts
@@ -44,6 +44,13 @@ class Registry {
     this.computerUse = on === true;
   }
 
+  // Names of the computer-use tools, regardless of whether the feature is
+  // currently enabled — used by the "pre-approve all computer actions" flow to
+  // persist a grant per tool up front.
+  computerToolNames(): string[] {
+    return COMPUTER_TOOLS.map((s) => s.name);
+  }
+
   async boot(servers: McpServerConf[]): Promise<void> {
     for (const s of servers) {
       try {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -89,5 +89,9 @@ contextBridge.exposeInMainWorld('localExec', {
     const handler = (): void => cb();
     ipcRenderer.on('local.computerUse.disabled', handler);
     return () => ipcRenderer.removeListener('local.computerUse.disabled', handler);
-  }
+  },
+  // Pre-approve every computer.* action (persistent always-allow) + enable
+  // Computer Use + trigger the macOS Screen Recording / Accessibility prompts.
+  preauthorizeComputerUse: (): Promise<{ grants: string[]; perm: unknown; computerUse: boolean }> =>
+    ipcRenderer.invoke('local.computerUse.preauthorize')
 });

--- a/src/components/setting/LocalTools.vue
+++ b/src/components/setting/LocalTools.vue
@@ -65,6 +65,12 @@
           <el-switch v-model="computerUse" :loading="savingCU" @change="onToggleComputerUse" />
         </div>
         <p class="muted">{{ $t('common.settings.localToolsComputerUseHint') }}</p>
+        <div class="actions">
+          <el-button size="small" type="primary" :loading="preauthorizing" @click="preauthorizeAll">
+            {{ $t('common.settings.localToolsPreauthorizeAll') }}
+          </el-button>
+          <span class="muted">{{ $t('common.settings.localToolsPreauthorizeHint') }}</span>
+        </div>
       </section>
 
       <!-- macOS system permissions -->
@@ -136,6 +142,7 @@ export default defineComponent({
       perm: null as null | { mac: boolean; fullDisk: boolean; screen: string; mic: string; accessibility: boolean },
       computerUse: false,
       savingCU: false,
+      preauthorizing: false,
       saving: false,
       savedTip: false,
       cuOff: null as null | (() => void)
@@ -214,6 +221,22 @@ export default defineComponent({
         computerUse: val === true
       });
       this.savingCU = false;
+    },
+    // Pre-approve every computer.* action (persistent always-allow), enable
+    // Computer Use, and trigger the macOS Screen Recording / Accessibility
+    // prompts up front so the first real action doesn't stall on a dialog.
+    async preauthorizeAll() {
+      const ex = localExec();
+      if (!ex?.preauthorizeComputerUse) return;
+      this.preauthorizing = true;
+      try {
+        const r = await ex.preauthorizeComputerUse();
+        this.computerUse = r.computerUse === true;
+        if (r.perm?.mac) this.perm = r.perm;
+        await this.loadGrants();
+      } finally {
+        this.preauthorizing = false;
+      }
     },
     async revoke(key: string) {
       await localExec()?.grants?.revoke(key);

--- a/src/i18n/ar/common.json
+++ b/src/i18n/ar/common.json
@@ -947,6 +947,8 @@
     "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
     "description": "Help text under the Computer Use toggle."
   },
+  "settings.localToolsPreauthorizeAll": "السماح مسبقًا بجميع إجراءات الكمبيوتر",
+  "settings.localToolsPreauthorizeHint": "اسمح دفعة واحدة بلقطة الشاشة والنقر والكتابة والمفاتيح وجميع الإجراءات، واطلب أذونات النظام المطلوبة.",
   "settings.localToolsAddFolder": {
     "message": "إضافة مجلد",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/de/common.json
+++ b/src/i18n/de/common.json
@@ -947,6 +947,8 @@
     "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
     "description": "Help text under the Computer Use toggle."
   },
+  "settings.localToolsPreauthorizeAll": "Alle Computeraktionen vorab erlauben",
+  "settings.localToolsPreauthorizeHint": "Screenshot, Klick, Tippen, Tastendruck und alle Computeraktionen auf einmal erlauben und die erforderlichen Systemberechtigungen anfordern.",
   "settings.localToolsAddFolder": {
     "message": "Ordner hinzufügen",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/el/common.json
+++ b/src/i18n/el/common.json
@@ -947,6 +947,8 @@
     "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
     "description": "Help text under the Computer Use toggle."
   },
+  "settings.localToolsPreauthorizeAll": "Προέγκριση όλων των ενεργειών υπολογιστή",
+  "settings.localToolsPreauthorizeHint": "Επιτρέψτε με μία κίνηση στιγμιότυπο οθόνης, κλικ, πληκτρολόγηση, πλήκτρα και όλες τις ενέργειες και ζητήστε τα απαιτούμενα δικαιώματα συστήματος.",
   "settings.localToolsAddFolder": {
     "message": "Προσθήκη φακέλου",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -927,6 +927,8 @@
     "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
     "description": "Help text under the Computer Use toggle."
   },
+  "settings.localToolsPreauthorizeAll": "Pre-approve all computer actions",
+  "settings.localToolsPreauthorizeHint": "Allow screenshot, click, type, key and every computer action at once, and trigger the required system permissions.",
   "settings.localToolsAddFolder": {
     "message": "Add folder",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/es/common.json
+++ b/src/i18n/es/common.json
@@ -947,6 +947,8 @@
     "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
     "description": "Help text under the Computer Use toggle."
   },
+  "settings.localToolsPreauthorizeAll": "Autorizar previamente todas las acciones del equipo",
+  "settings.localToolsPreauthorizeHint": "Permite de una vez la captura de pantalla, el clic, la escritura, las teclas y todas las acciones, y solicita los permisos del sistema necesarios.",
   "settings.localToolsAddFolder": {
     "message": "Agregar carpeta",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -947,6 +947,8 @@
     "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
     "description": "Help text under the Computer Use toggle."
   },
+  "settings.localToolsPreauthorizeAll": "Esihyväksy kaikki tietokoneen toiminnot",
+  "settings.localToolsPreauthorizeHint": "Salli kerralla kuvakaappaus, napsautus, kirjoitus, näppäimet ja kaikki toiminnot ja pyydä tarvittavat järjestelmäoikeudet.",
   "settings.localToolsAddFolder": {
     "message": "Lisää kansio",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/fr/common.json
+++ b/src/i18n/fr/common.json
@@ -947,6 +947,8 @@
     "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
     "description": "Help text under the Computer Use toggle."
   },
+  "settings.localToolsPreauthorizeAll": "Pré-autoriser toutes les actions de l'ordinateur",
+  "settings.localToolsPreauthorizeHint": "Autorisez en une fois la capture d'écran, le clic, la saisie, les touches et toutes les actions, et déclenchez les autorisations système requises.",
   "settings.localToolsAddFolder": {
     "message": "Ajouter un dossier",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/it/common.json
+++ b/src/i18n/it/common.json
@@ -947,6 +947,8 @@
     "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
     "description": "Help text under the Computer Use toggle."
   },
+  "settings.localToolsPreauthorizeAll": "Pre-autorizza tutte le azioni del computer",
+  "settings.localToolsPreauthorizeHint": "Consenti in una volta screenshot, clic, digitazione, tasti e tutte le azioni e richiedi le autorizzazioni di sistema necessarie.",
   "settings.localToolsAddFolder": {
     "message": "Aggiungi cartella",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/ja/common.json
+++ b/src/i18n/ja/common.json
@@ -947,6 +947,8 @@
     "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
     "description": "Help text under the Computer Use toggle."
   },
+  "settings.localToolsPreauthorizeAll": "すべてのコンピュータ操作を事前に許可",
+  "settings.localToolsPreauthorizeHint": "スクリーンショット、クリック、入力、キー操作などすべての操作を一度に許可し、必要なシステム権限を要求します。",
   "settings.localToolsAddFolder": {
     "message": "フォルダを追加",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/ko/common.json
+++ b/src/i18n/ko/common.json
@@ -947,6 +947,8 @@
     "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
     "description": "Help text under the Computer Use toggle."
   },
+  "settings.localToolsPreauthorizeAll": "모든 컴퓨터 작업 미리 허용",
+  "settings.localToolsPreauthorizeHint": "스크린샷, 클릭, 입력, 키 등 모든 컴퓨터 작업을 한 번에 허용하고 필요한 시스템 권한을 요청합니다.",
   "settings.localToolsAddFolder": {
     "message": "폴더 추가",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/pl/common.json
+++ b/src/i18n/pl/common.json
@@ -947,6 +947,8 @@
     "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
     "description": "Help text under the Computer Use toggle."
   },
+  "settings.localToolsPreauthorizeAll": "Wstępnie zatwierdź wszystkie działania komputera",
+  "settings.localToolsPreauthorizeHint": "Zezwól od razu na zrzut ekranu, kliknięcie, pisanie, klawisze i wszystkie działania oraz poproś o wymagane uprawnienia systemowe.",
   "settings.localToolsAddFolder": {
     "message": "Dodaj folder",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/pt/common.json
+++ b/src/i18n/pt/common.json
@@ -947,6 +947,8 @@
     "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
     "description": "Help text under the Computer Use toggle."
   },
+  "settings.localToolsPreauthorizeAll": "Pré-aprovar todas as ações do computador",
+  "settings.localToolsPreauthorizeHint": "Permite de uma vez captura de tela, clique, digitação, teclas e todas as ações, e solicita as permissões do sistema necessárias.",
   "settings.localToolsAddFolder": {
     "message": "Adicionar pasta",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/ru/common.json
+++ b/src/i18n/ru/common.json
@@ -947,6 +947,8 @@
     "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
     "description": "Help text under the Computer Use toggle."
   },
+  "settings.localToolsPreauthorizeAll": "Заранее разрешить все действия с компьютером",
+  "settings.localToolsPreauthorizeHint": "Разрешите сразу снимок экрана, клик, ввод, клавиши и все действия и запросите необходимые системные разрешения.",
   "settings.localToolsAddFolder": {
     "message": "Добавить папку",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/sr/common.json
+++ b/src/i18n/sr/common.json
@@ -947,6 +947,8 @@
     "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
     "description": "Help text under the Computer Use toggle."
   },
+  "settings.localToolsPreauthorizeAll": "Унапред дозволи све радње рачунара",
+  "settings.localToolsPreauthorizeHint": "Дозволите одједном снимак екрана, клик, куцање, тастере и све радње и затражите потребне системске дозволе.",
   "settings.localToolsAddFolder": {
     "message": "Додај фасциклу",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -947,6 +947,8 @@
     "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
     "description": "Help text under the Computer Use toggle."
   },
+  "settings.localToolsPreauthorizeAll": "Förgodkänn alla datoråtgärder",
+  "settings.localToolsPreauthorizeHint": "Tillåt på en gång skärmbild, klick, skrivning, tangenter och alla åtgärder och begär nödvändiga systembehörigheter.",
   "settings.localToolsAddFolder": {
     "message": "Lägg till mapp",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/uk/common.json
+++ b/src/i18n/uk/common.json
@@ -947,6 +947,8 @@
     "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
     "description": "Help text under the Computer Use toggle."
   },
+  "settings.localToolsPreauthorizeAll": "Попередньо дозволити всі дії з комп'ютером",
+  "settings.localToolsPreauthorizeHint": "Дозволити одразу знімок екрана, клік, введення, клавіші та всі дії й запросити потрібні системні дозволи.",
   "settings.localToolsAddFolder": {
     "message": "Додати папку",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -947,6 +947,8 @@
     "message": "让 AI 看到你的屏幕并控制本机的鼠标和键盘。默认关闭，按需开启。macOS 上需在下方授予「屏幕录制」和「辅助功能」权限。每个操作仍会请求你的确认。",
     "description": "Help text under the Computer Use toggle."
   },
+  "settings.localToolsPreauthorizeAll": "预先允许所有电脑操作",
+  "settings.localToolsPreauthorizeHint": "一次性允许截图、点击、输入、按键等所有电脑操作，并触发所需的系统权限。",
   "settings.localToolsAddFolder": {
     "message": "添加文件夹",
     "description": "选择要授权的文件夹的按钮。"

--- a/src/i18n/zh-TW/common.json
+++ b/src/i18n/zh-TW/common.json
@@ -947,6 +947,8 @@
     "message": "讓 AI 看到你的螢幕並控制本機的滑鼠和鍵盤。預設關閉，按需開啟。macOS 上需在下方授予「螢幕錄製」和「輔助使用」權限。每個操作仍會請求你的確認。",
     "description": "Help text under the Computer Use toggle."
   },
+  "settings.localToolsPreauthorizeAll": "預先允許所有電腦操作",
+  "settings.localToolsPreauthorizeHint": "一次性允許截圖、點擊、輸入、按鍵等所有電腦操作，並觸發所需的系統權限。",
   "settings.localToolsAddFolder": {
     "message": "新增資料夾",
     "description": "Button to pick a folder to authorize."

--- a/src/utils/desktop.ts
+++ b/src/utils/desktop.ts
@@ -88,6 +88,14 @@ export interface LocalExecBridge {
   /** Subscribe to the global panic hotkey forcing Computer Use off. Returns an
    * unsubscribe fn. Undefined on older preloads. */
   onComputerUseDisabled?(cb: () => void): () => void;
+  /** Pre-approve every computer.* action (persistent always-allow), enable
+   * Computer Use, and trigger the macOS Screen Recording / Accessibility
+   * prompts. Returns the new grant list + permission status. */
+  preauthorizeComputerUse?(): Promise<{
+    grants: string[];
+    perm: { mac: boolean; fullDisk: boolean; screen: string; mic: string; accessibility: boolean };
+    computerUse: boolean;
+  }>;
 }
 
 export function localExec(): LocalExecBridge | undefined {


### PR DESCRIPTION
## What

Adds a one-click **"Pre-approve all computer actions"** button in **Settings → Local Tools** (under the Computer Use toggle). Tap it once and every `computer.*` action (screenshot, click, move, type, key, scroll) is added to the persistent **Always-allowed** list, so the AI can drive the screen without a per-step prompt. Naturally triggers the macOS **Screen Recording** + **Accessibility** permission prompts as part of the flow.

Follow-up to #1096 (persistent/session consent). Built on the name-scoped `computer.*` grant model from that PR.

## How

- `registry.ts` — exposes `COMPUTER_TOOL_NAMES` so the grant set is the single source of truth.
- `consent.ts` — `grantComputerTools()` adds a name-scoped persistent grant for each `computer.*` tool (same keys the consent dialog's "Always allow" would write; revocable in Settings).
- `permissions.ts` — `ensureScreenPermission()` triggers the Screen Recording prompt; Accessibility prompt via the existing `promptAccessibility()`.
- `ipc.ts` — `local.computerUse.preauthorize` handler: **requires a native main-process confirm dialog first** (an XSS'd renderer can't click a native dialog, so it can't silently self-grant), then re-reads persisted `computerUse` after the async prompts (so a panic-stop mid-flow isn't clobbered), grants the tools, and fires the permission prompts.
- `preload.ts` / `desktop.ts` — `preauthorizeComputer()` bridge.
- `LocalTools.vue` + i18n (all 18 locales) — the button + confirm copy.

## Safety

- Native confirm dialog gates the bulk grant (no silent self-grant from a compromised renderer).
- The **panic hotkey still hard-stops everything** — it disables Computer Use via the registry gate, which blocks every `computer.*` call before consent is consulted, regardless of any grant.
- All grants are revocable in **Settings → Local Tools → Always-allowed actions**.

`tsc -p electron`, `vue-tsc`, i18n coverage (17×44) all clean.

## 🤖 对抗评审 (Codex, read-only)

| # | Finding | Resolution |
|---|---------|-----------|
| 1 | A compromised/XSS'd renderer could call the preauthorize IPC and silently self-grant all screen control | **Fixed** — the handler shows a **native main-process confirm dialog** first; a web renderer cannot programmatically click it, so the bulk grant requires a real human click. |
| 2 | `computerUse` was read once before the async permission prompts; a panic-stop during the prompt could be clobbered by the later grant | **Fixed** — re-read persisted `computerUse` after the awaits and abort the grant if Computer Use was turned off meanwhile. |

Converged: 2 fixed.
