### PR TITLE
feat(maestro): duration as numeric input up to 10 min (per-second billing)

### DIFF
--- a/change/@acedatacloud-nexior-60d59a34-b136-4878-b1e9-bd2ce4b3c1bc.json
+++ b/change/@acedatacloud-nexior-60d59a34-b136-4878-b1e9-bd2ce4b3c1bc.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Maestro: duration is now a numeric input (1-600s, up to 10 min) for per-second billing",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/maestro/ConfigPanel.vue
+++ b/src/components/maestro/ConfigPanel.vue
@@ -79,9 +79,14 @@
           <h2 class="field-title font-bold">{{ $t('maestro.name.duration') }}</h2>
           <info-icon :content="$t('maestro.description.duration')" class="ml-1" />
         </div>
-        <el-select v-model="duration" class="field-control">
-          <el-option v-for="d in MAESTRO_ALLOWED_DURATIONS" :key="d" :label="`${d}s`" :value="d" />
-        </el-select>
+        <el-input-number
+          v-model="duration"
+          class="field-control"
+          :min="MAESTRO_MIN_DURATION"
+          :max="MAESTRO_MAX_DURATION"
+          :step="5"
+          controls-position="right"
+        />
       </div>
 
       <!-- Quality (production tier) -->
@@ -113,7 +118,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElButton, ElSelect, ElOption, ElAlert } from 'element-plus';
+import { ElButton, ElSelect, ElOption, ElInputNumber, ElAlert } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import Consumption from '../common/Consumption.vue';
 import InfoIcon from '@/components/common/InfoIcon.vue';
@@ -123,7 +128,8 @@ import { getConsumption } from '@/utils';
 import {
   MAESTRO_ALLOWED_LANGS,
   MAESTRO_ALLOWED_ASPECTS,
-  MAESTRO_ALLOWED_DURATIONS,
+  MAESTRO_MIN_DURATION,
+  MAESTRO_MAX_DURATION,
   MAESTRO_DEFAULT_ACTION,
   MAESTRO_DEFAULT_LANGS,
   MAESTRO_DEFAULT_ASPECT,
@@ -146,6 +152,7 @@ export default defineComponent({
     ElButton,
     ElSelect,
     ElOption,
+    ElInputNumber,
     ElAlert,
     Consumption,
     InfoIcon,
@@ -157,7 +164,8 @@ export default defineComponent({
   data() {
     return {
       MAESTRO_ALLOWED_LANGS,
-      MAESTRO_ALLOWED_DURATIONS,
+      MAESTRO_MIN_DURATION,
+      MAESTRO_MAX_DURATION,
       MAESTRO_ALLOWED_QUALITIES
     };
   },
@@ -217,7 +225,10 @@ export default defineComponent({
         return this.config?.duration;
       },
       set(val: number) {
-        this.update({ duration: val });
+        // el-input-number can emit null when cleared; clamp into [min, max] with the default as fallback.
+        const n = typeof val === 'number' && !Number.isNaN(val) ? val : MAESTRO_DEFAULT_DURATION;
+        const clamped = Math.min(MAESTRO_MAX_DURATION, Math.max(MAESTRO_MIN_DURATION, Math.round(n)));
+        this.update({ duration: clamped });
       }
     },
     quality: {

--- a/src/constants/maestro.ts
+++ b/src/constants/maestro.ts
@@ -9,7 +9,9 @@ export const MAESTRO_ACTION_EXTEND = 'extend';
 
 export const MAESTRO_ALLOWED_ASPECTS = ['9:16', '16:9', '1:1'];
 export const MAESTRO_ALLOWED_LANGS = ['zh-cn', 'en', 'ja', 'ko', 'es', 'fr', 'de'];
-export const MAESTRO_ALLOWED_DURATIONS = [20, 30, 45, 60];
+// Duration is billed per second (up to 10 min); the user types any value in this range.
+export const MAESTRO_MIN_DURATION = 1;
+export const MAESTRO_MAX_DURATION = 600;
 // Production tier (effort/price): draft = fast preview, standard = balanced, premium = richer.
 export const MAESTRO_ALLOWED_QUALITIES = ['draft', 'standard', 'premium'];
 

--- a/src/i18n/en/maestro.json
+++ b/src/i18n/en/maestro.json
@@ -88,7 +88,7 @@
     "description": "Files help"
   },
   "description.duration": {
-    "message": "Target video length. Longer videos take more time and credits to produce.",
+    "message": "Target video length in seconds (1–600, up to 10 min). Billed by duration — longer videos take more time and credits to produce.",
     "description": "Duration help"
   },
   "description.quality": {

--- a/src/i18n/zh-CN/maestro.json
+++ b/src/i18n/zh-CN/maestro.json
@@ -88,7 +88,7 @@
     "description": "Files help"
   },
   "description.duration": {
-    "message": "目标视频时长,越长则制作耗时与消耗的积分越多。",
+    "message": "目标视频时长（秒，1–600，最长 10 分钟）。按时长计费——越长则制作耗时与消耗的积分越多。",
     "description": "Duration help"
   },
   "description.quality": {


### PR DESCRIPTION
## What

The Maestro config panel exposed `duration` as a fixed dropdown of `[20, 30, 45, 60]`. To match the new **per-duration billing** (PlatformBackend #808) and allow videos **up to 10 minutes**, this swaps it for a numeric input.

- `ConfigPanel.vue` — `el-select` → `el-input-number` (`min=1`, `max=600`, `step=5`, right controls). The `duration` setter now clamps to `[1, 600]`, rounds, and falls back to `MAESTRO_DEFAULT_DURATION` (30) on a null/NaN clear.
- `constants/maestro.ts` — removed `MAESTRO_ALLOWED_DURATIONS` (only used here); added `MAESTRO_MIN_DURATION = 1` / `MAESTRO_MAX_DURATION = 600`.
- i18n (`en` + `zh-CN`) — duration help text now notes the 1–600s (10 min) range and that it's billed by duration.

The credit preview already reads `getConsumption(config, service.cost)`, so it reflects the new per-duration price live once the backend deploys — no extra wiring.

`vue-tsc -b` ✅ · `eslint` ✅.

## 🤖 对抗评审

Reviewer: **Codex** (`codex exec --sandbox read-only`, cross-model) → **VERDICT: CLEAN**.

Verified: no remaining `MAESTRO_ALLOWED_DURATIONS` references; `ElInputNumber` imported + registered; new constants exported via the barrel; `ElInputNumber` emits `number | undefined` matching `IMaestroConfig.duration`; clamp handles clear/undefined/null/NaN + decimals + out-of-range; `maestro.name.duration` / `maestro.description.duration` exist in all locale files.
