### PR TITLE
ci(mobile): dry-run mode + concurrency guard + correct staged Android rollout

### DIFF
--- a/.github/workflows/auto-production-mobile.yaml
+++ b/.github/workflows/auto-production-mobile.yaml
@@ -48,6 +48,11 @@ on:
         required: false
         default: false
         type: boolean
+      dry_run:
+        description: 'Run the review-state gate only and report its decision — do NOT dispatch any real build/release.'
+        required: false
+        default: false
+        type: boolean
       android_rollout_percent:
         description: 'Android production rollout fraction (0.0–1.0). 1.0 = full release.'
         required: false
@@ -57,6 +62,12 @@ on:
 permissions:
   actions: write
   contents: read
+
+# Never let two store-release runs overlap (a manual dispatch racing the daily
+# cron, etc.). Queue rather than cancel so an in-flight release is never killed.
+concurrency:
+  group: mobile-production-release
+  cancel-in-progress: false
 
 env:
   BUNDLE_ID: com.acedatacloud.nexior
@@ -266,6 +277,7 @@ jobs:
     needs: gate
     if: >-
       needs.gate.outputs.ios-ok == 'true'
+      && (github.event_name != 'workflow_dispatch' || !inputs.dry_run)
       && (github.event_name == 'schedule' || inputs.platforms == 'both' || inputs.platforms == 'ios')
     runs-on: ubuntu-latest
     steps:
@@ -289,6 +301,7 @@ jobs:
     needs: gate
     if: >-
       needs.gate.outputs.android-ok == 'true'
+      && (github.event_name != 'workflow_dispatch' || !inputs.dry_run)
       && (github.event_name == 'schedule' || inputs.platforms == 'both' || inputs.platforms == 'android')
     runs-on: ubuntu-latest
     steps:
@@ -308,12 +321,24 @@ jobs:
             ROLLOUT='1.0'
           fi
           printf '%s\n' "::notice::Android gate clean ($GATE_REASON) — releasing v$VERSION at rollout=$ROLLOUT."
-          gh workflow run build-android.yaml \
-            --ref "${{ github.ref_name }}" \
-            -f track=production \
-            -f promote_to_production=false \
-            -f rollout_percent="$ROLLOUT" \
-            -f force=false
+          # 100% → upload straight to the Production track (status=completed).
+          # Partial → upload to beta then promote to Production at the requested
+          # fraction; build-android only honors rollout_percent on the promote
+          # path, so a <1.0 fraction MUST go through beta+promote to be staged.
+          if [ "$ROLLOUT" = "1.0" ] || [ "$ROLLOUT" = "1" ]; then
+            gh workflow run build-android.yaml \
+              --ref "${{ github.ref_name }}" \
+              -f track=production \
+              -f promote_to_production=false \
+              -f force=false
+          else
+            gh workflow run build-android.yaml \
+              --ref "${{ github.ref_name }}" \
+              -f track=beta \
+              -f promote_to_production=true \
+              -f rollout_percent="$ROLLOUT" \
+              -f force=false
+          fi
 
   summary:
     name: Gate summary
@@ -326,14 +351,23 @@ jobs:
           VERSION: ${{ needs.gate.outputs.version }}
           IOS_REASON: ${{ needs.gate.outputs.ios-reason }}
           ANDROID_REASON: ${{ needs.gate.outputs.android-reason }}
-          IOS_BADGE: ${{ needs.gate.outputs.ios-ok == 'true' && '✅ dispatched' || '⏭️ skipped' }}
-          ANDROID_BADGE: ${{ needs.gate.outputs.android-ok == 'true' && '✅ dispatched' || '⏭️ skipped' }}
+          IOS_OK: ${{ needs.gate.outputs.ios-ok }}
+          ANDROID_OK: ${{ needs.gate.outputs.android-ok }}
+          IOS_RESULT: ${{ needs.ios.result }}
+          ANDROID_RESULT: ${{ needs.android.result }}
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
         run: |
+          badge() {  # $1=gate-ok  $2=job-result
+            if [ "$1" = "true" ] && [ "$2" = "success" ]; then echo "✅ dispatched";
+            elif [ "$1" = "true" ]; then echo "🧪 gate-ok (not dispatched)";
+            else echo "⏭️ skipped"; fi
+          }
           {
             echo "### Auto Production Mobile — v$VERSION"
+            [ "$DRY_RUN" = "true" ] && echo "_dry-run: gate evaluated, nothing dispatched._"
             echo ""
             echo "| Platform | Gate | Reason |"
             echo "|----------|------|--------|"
-            echo "| iOS      | $IOS_BADGE | $IOS_REASON |"
-            echo "| Android  | $ANDROID_BADGE | $ANDROID_REASON |"
+            echo "| iOS      | $(badge "$IOS_OK" "$IOS_RESULT") | $IOS_REASON |"
+            echo "| Android  | $(badge "$ANDROID_OK" "$ANDROID_RESULT") | $ANDROID_REASON |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/change/@acedatacloud-nexior-43bf6f79-aab8-41fe-a182-3fd0868ee73e.json
+++ b/change/@acedatacloud-nexior-43bf6f79-aab8-41fe-a182-3fd0868ee73e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "ci(mobile): auto-production workflow gains dry-run mode, concurrency guard, and correct staged Android rollout routing",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
## 背景

承接 #1098（每日全自动提审 + 生产发布，带商店审核状态闸门）。合并后审视整套 mobile pipeline，做三处优化 —— 既补能力又便于安全验证。

## 改动

### 1. `dry_run` 模式（安全测试）
新增 `dry_run` 输入（默认 false）。手动 `workflow_dispatch` 时设为 true，则 **只跑 gate 闸门并报告判断结果，不调度任何真实构建/发布**。这让我们可以安全地"试一下 gate 怎么判"，而不冒险真发布。

实现：`ios` / `android` 调度 job 的 `if:` 追加 `&& (github.event_name != 'workflow_dispatch' || !inputs.dry_run)`。schedule 触发时 `inputs.dry_run` 为 null → `!null = true` → 照常发布（dry-run 只影响手动触发）。

### 2. `concurrency` 并发护栏
新增顶层 `concurrency: { group: mobile-production-release, cancel-in-progress: false }`。防止手动触发与每日 cron 重叠对同一版本并发发布；`cancel-in-progress: false` → 排队而非杀掉在飞的发布。

### 3. 修正 Android rollout 旋钮（真实灰度）
此前 Android 一律走 `track=production`（`status: completed` 永远 100%，promote job 被跳过），导致 `android_rollout_percent < 1.0` 是**空操作**。现按放量分流：
- `1.0` / `1` → 直发 Production（`track=production`，100%）。
- 其它分数（如 `0.2`）→ `track=beta` + `promote_to_production=true` + `rollout_percent=$ROLLOUT`，走 promote 路径真正灰度（`build-android.yaml` 仅在 promote 路径生效 `rollout_percent`）。

### 4. summary 标注更准确
badge 改为依据 gate-ok + `needs.<job>.result` 计算，dry-run（gate 通过但未调度）显示 `🧪 gate-ok (not dispatched)`，并加 dry-run 提示行。

## 🤖 对抗评审

独立 reviewer（子代理）逐项核对：`if` 表达式在 schedule(null) / dispatch(true/false) 三种情形均正确；rollout 分流与 `build-android.yaml` 契约一致；summary badge 全分支覆盖；concurrency 静态组名 + 不杀在飞发布；无 YAML/shell 引用问题。唯一备注：`1.00` 会走 beta+promote 但 `float("1.00")=1.0` 最终仍 100% 完成发布——结果正确，仅路由略绕，非缺陷。**VERDICT: CLEAN**。

## 验证
- `yaml.safe_load` 解析通过（jobs: gate/ios/android/summary；concurrency；inputs: platforms/bypass_gate/dry_run/android_rollout_percent）。
- 两段内联 Python `py_compile` 通过。
- 合并前已在本分支用 `dry_run=true` 触发验证 gate 判断（见 PR 评论/运行）。
