### PR TITLE
feat(auth): guest browsing with deferred login-on-operation

### DIFF
--- a/change/@acedatacloud-nexior-8738e6e1-6caa-4c09-8110-2dc07c58e153.json
+++ b/change/@acedatacloud-nexior-8738e6e1-6caa-4c09-8110-2dc07c58e153.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Support guest browsing with deferred login: unauthenticated visitors can view service pages, models and pricing, and are only prompted to log in when they start an operation (chat send, generate, search).",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -141,16 +141,13 @@ export default defineComponent({
         this.$store.dispatch('resetAll');
         this.$store.dispatch('login');
       } else {
-        // Don't dispatch 'logout' here — there's nothing to log out from when
-        // the user isn't authenticated, and 'logout' races with 'login' for
-        // window.location.href. Because 'logout' has many awaits, it would win
-        // the race and overwrite 'login's properly-encoded URL with a raw
-        // string-concatenated one, causing inviter_id to end up nested inside
-        // the redirect= value where AuthFrontend can't find it. This silently
-        // breaks the referral binding for users who arrive via share links on
-        // custom-domain (white-label) deployments.
+        // Web: deferred auth. Guests may browse service pages, models and
+        // pricing without logging in — the login flow is triggered lazily the
+        // moment they start a real operation (see `ensureLoggedIn`). So we
+        // only clear any stale (logged-out) state here and DON'T bounce to
+        // login. `resetAll` also drops any leftover credential so a guest can
+        // never reuse a previous session's token.
         this.$store.dispatch('resetAll');
-        this.$store.dispatch('login');
       }
     }
   },

--- a/src/layouts/Main.vue
+++ b/src/layouts/Main.vue
@@ -141,6 +141,14 @@ export default defineComponent({
     async initialize() {
       const runId = ++this.initializeRunId;
       this.initialized = false;
+      // Guests browse without an application/credential — defer all of that
+      // (and login itself) until they actually start an operation. Skip the
+      // whole bootstrap so we neither fire doomed authenticated requests nor
+      // pop the auto-apply error toast. `initialized` stays false, so the
+      // per-page `initialized` watchers that fetch tasks never run for guests.
+      if (!this.$store.state.token?.access) {
+        return;
+      }
       console.debug('Fetching all individual and global applications for', this.appName);
       await Promise.allSettled([
         this.$store.dispatch('getApplications'),

--- a/src/operators/common.ts
+++ b/src/operators/common.ts
@@ -25,7 +25,12 @@ const httpClient = createHttpClient({
   // Fire-and-forget (not awaited) to preserve the original timing: the caller's
   // rejection runs without waiting for logout to complete.
   onUnauthorized: () => {
-    store.dispatch('logout');
+    // Guests (no token) may browse freely — a 401 on a guest request is
+    // expected (passive catalog/bootstrap calls) and must NOT bounce them to
+    // the login page. Only a logged-in user whose token expired gets logged out.
+    if (store.getters.authenticated) {
+      store.dispatch('logout');
+    }
   },
   onApiFailure: trackApiFailure
 });

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -84,6 +84,7 @@ import ConnectorStrip from '@/components/chat/ConnectorStrip.vue';
 import Layout from '@/layouts/Chat.vue';
 import { isImageUrl } from '@/utils/is';
 import { isDesktop } from '@/utils/surface';
+import { ensureLoggedIn } from '@/utils/login';
 import { localExec, type LocalToolSpec } from '@/utils/desktop';
 import { IAskUserQuestionPayload, IChatMessageContentItem, IConsentRequestPayload } from '@/models';
 import {
@@ -218,6 +219,11 @@ export default defineComponent({
       return this.$store.state.chat.status.getApplications === Status.Request;
     },
     ready(): boolean {
+      // Guests may compose & "send" — the submit handler triggers login
+      // (deferred auth), so the composer must not be disabled for them.
+      if (!this.$store.getters.authenticated) {
+        return true;
+      }
       // Disable sending until token/application/credential are all initialized,
       // otherwise the first submit races init and hits `You have not applied for this service...`.
       return !this.initializing && !!this.credential?.token && !!this.application;
@@ -622,6 +628,11 @@ export default defineComponent({
       await this.$router.push(this.conversationsPath(target));
     },
     async onSubmit() {
+      // Deferred auth: a guest hitting send is sent to login here, before we
+      // mutate `messages`, so they return to a clean composer post-login.
+      if (!ensureLoggedIn()) {
+        return;
+      }
       if (this.references.length > 0) {
         const content: IChatMessageContentItem[] = [
           {
@@ -654,6 +665,11 @@ export default defineComponent({
     },
     // Get answers to questions
     async onRequest() {
+      // Safety net for every send path (onSubmit / onEdit / onRestart funnel
+      // here): a guest is sent to login before any request is attempted.
+      if (!ensureLoggedIn()) {
+        return;
+      }
       // Refresh the desktop local-tool list at the start of each user turn so a
       // Settings change (e.g. toggling Computer Use on/off) takes effect on the
       // very next message. Without this, `localTools` is cached from mount and a

--- a/src/pages/digitalhuman/Index.vue
+++ b/src/pages/digitalhuman/Index.vue
@@ -15,6 +15,7 @@ import Layout from '@/layouts/DigitalHuman.vue';
 import ConfigPanel from '@/components/digitalhuman/ConfigPanel.vue';
 import RecentPanel from '@/components/digitalhuman/RecentPanel.vue';
 import { digitalHumanOperator } from '@/operators';
+import { ensureLoggedIn } from '@/utils';
 import { instrumentGeneration } from '@/plugins/telemetry';
 import { IDigitalHumanGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
@@ -115,6 +116,9 @@ export default defineComponent({
       }
     },
     async onGenerate(request: IDigitalHumanGenerateRequest) {
+      if (!ensureLoggedIn()) {
+        return;
+      }
       const token = this.credential?.token;
       if (!token) {
         console.error('no token specified');

--- a/src/pages/fish/Model.vue
+++ b/src/pages/fish/Model.vue
@@ -21,6 +21,7 @@ import ModelConfigPanel from '@/components/fish/ModelConfigPanel.vue';
 import ModelListPanel from '@/components/fish/ModelListPanel.vue';
 import TabSwitcher from '@/components/fish/TabSwitcher.vue';
 import { fishOperator } from '@/operators';
+import { ensureLoggedIn } from '@/utils';
 import { ElMessage } from 'element-plus';
 import { ERROR_CODE_USED_UP } from '@/constants';
 
@@ -77,6 +78,9 @@ export default defineComponent({
       enhance_audio_quality?: boolean;
       generate_sample?: boolean;
     }) {
+      if (!ensureLoggedIn()) {
+        return;
+      }
       const token = this.credential?.token;
       if (!token) {
         console.error('no token specified');

--- a/src/pages/fish/Tts.vue
+++ b/src/pages/fish/Tts.vue
@@ -26,7 +26,7 @@ import { IFishTask, IFishTtsRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
 import { ERROR_CODE_USED_UP, FISH_DEFAULT_TTS_MODEL } from '@/constants';
 import { loadPreviousPage } from '@/utils/pagination';
-import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 
 interface IData {
   task: IFishTask | undefined;
@@ -154,6 +154,9 @@ export default defineComponent({
       const text = cfg.text?.trim();
       if (!text) {
         ElMessage.warning(this.$t('fish.message.textRequired'));
+        return;
+      }
+      if (!ensureLoggedIn()) {
         return;
       }
       const token = this.credential?.token;

--- a/src/pages/flux/Index.vue
+++ b/src/pages/flux/Index.vue
@@ -21,7 +21,7 @@ import { ERROR_CODE_USED_UP } from '@/constants';
 import RecentPanel from '@/components/flux/RecentPanel.vue';
 import { IFluxTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
-import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 
 interface IData {
   task: IFluxTask | undefined;
@@ -164,6 +164,9 @@ export default defineComponent({
         ...this.config,
         async: true
       } as IFluxGenerateRequest;
+      if (!ensureLoggedIn()) {
+        return;
+      }
       const token = this.credential?.token;
       if (!token) {
         console.error('no token specified');

--- a/src/pages/grokvideo/Index.vue
+++ b/src/pages/grokvideo/Index.vue
@@ -20,7 +20,7 @@ import { IGrokVideoGenerateRequest, IGrokVideoTask, Status } from '@/models';
 import { ElMessage } from 'element-plus';
 import { ERROR_CODE_USED_UP, isGrokVideoImageOnlyModel } from '@/constants';
 import { loadPreviousPage } from '@/utils/pagination';
-import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 
 interface IData {
   task: IGrokVideoTask | undefined;
@@ -167,6 +167,9 @@ export default defineComponent({
         async: true
       } as IGrokVideoGenerateRequest;
 
+      if (!ensureLoggedIn()) {
+        return;
+      }
       const token = this.credential?.token;
       if (!token) {
         console.error('no token specified');

--- a/src/pages/hailuo/Index.vue
+++ b/src/pages/hailuo/Index.vue
@@ -21,7 +21,7 @@ import { ERROR_CODE_USED_UP } from '@/constants';
 import RecentPanel from '@/components/hailuo/RecentPanel.vue';
 import { IHailuoTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
-import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 
 interface IData {
   task: IHailuoTask | undefined;
@@ -166,6 +166,9 @@ export default defineComponent({
         ...this.config,
         async: true
       } as IHailuoGenerateRequest;
+      if (!ensureLoggedIn()) {
+        return;
+      }
       const token = this.credential?.token;
       if (!token) {
         console.error('no token specified');

--- a/src/pages/headshots/Index.vue
+++ b/src/pages/headshots/Index.vue
@@ -33,7 +33,7 @@ import ApplicationStatus from '@/components/application/Status.vue';
 import RecentPanel from '@/components/headshots/RecentPanel.vue';
 import { IHeadshotsTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
-import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 
 interface IData {
   task: IHeadshotsTask | undefined;
@@ -205,6 +205,9 @@ export default defineComponent({
         ...this.config,
         async: true
       } as IHeadshotsGenerateRequest;
+      if (!ensureLoggedIn()) {
+        return;
+      }
       const token = this.credential?.token;
       if (!token) {
         console.error('no token specified');

--- a/src/pages/kling/Index.vue
+++ b/src/pages/kling/Index.vue
@@ -37,7 +37,7 @@ import { ERROR_CODE_USED_UP, KLING_TALKING_PHOTO_DEFAULT_MODEL, KLING_TALKING_PH
 import RecentPanel from '@/components/kling/RecentPanel.vue';
 import { IKlingTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
-import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 
 interface IData {
   task: IKlingTask | undefined;
@@ -224,6 +224,9 @@ export default defineComponent({
             : {})
         };
       }
+      if (!ensureLoggedIn()) {
+        return;
+      }
       const token = this.credential?.token;
       if (!token) {
         console.error('no token specified');
@@ -284,6 +287,9 @@ export default defineComponent({
         ...(cfg.prompt ? { prompt: cfg.prompt } : {}),
         async: true
       };
+      if (!ensureLoggedIn()) {
+        return;
+      }
       const token = this.credential?.token;
       if (!token) {
         console.error('no token specified');
@@ -334,6 +340,9 @@ export default defineComponent({
         ...(cfg.duration ? { duration: cfg.duration } : {}),
         async: true
       };
+      if (!ensureLoggedIn()) {
+        return;
+      }
       const token = this.credential?.token;
       if (!token) {
         console.error('no token specified');

--- a/src/pages/luma/Index.vue
+++ b/src/pages/luma/Index.vue
@@ -21,7 +21,7 @@ import { ERROR_CODE_USED_UP } from '@/constants';
 import RecentPanel from '@/components/luma/RecentPanel.vue';
 import { ILumaTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
-import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 
 interface IData {
   task: ILumaTask | undefined;
@@ -171,6 +171,9 @@ export default defineComponent({
         return;
       }
       request.prompt = request.prompt?.trim();
+      if (!ensureLoggedIn()) {
+        return;
+      }
       const token = this.credential?.token;
       if (!token) {
         console.error('no token specified');

--- a/src/pages/maestro/Index.vue
+++ b/src/pages/maestro/Index.vue
@@ -15,6 +15,7 @@ import Layout from '@/layouts/Maestro.vue';
 import ConfigPanel from '@/components/maestro/ConfigPanel.vue';
 import RecentPanel from '@/components/maestro/RecentPanel.vue';
 import { maestroOperator } from '@/operators';
+import { ensureLoggedIn } from '@/utils';
 import { instrumentGeneration } from '@/plugins/telemetry';
 import { IMaestroGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
@@ -117,6 +118,9 @@ export default defineComponent({
       const request = {
         ...this.config
       } as IMaestroGenerateRequest;
+      if (!ensureLoggedIn()) {
+        return;
+      }
       const token = this.credential?.token;
       if (!token) {
         console.error('no token specified');

--- a/src/pages/midjourney/Index.vue
+++ b/src/pages/midjourney/Index.vue
@@ -34,7 +34,7 @@ import {
   MIDJOURNEY_DEFAULT_QUALITY
 } from '@/constants';
 import { loadPreviousPage } from '@/utils/pagination';
-import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 
 interface IData {
   operating: boolean;
@@ -216,6 +216,10 @@ export default defineComponent({
       await this.onGetTasks();
     },
     async onStartImagineTask(request: IMidjourneyImagineRequest) {
+      // Deferred auth: guests compose freely; hitting generate sends them to login.
+      if (!ensureLoggedIn()) {
+        return;
+      }
       const token = this.credential?.token;
       if (!token) {
         console.error('no token specified');
@@ -246,6 +250,10 @@ export default defineComponent({
         });
     },
     async onStartVideosTask(request: IMidjourneyVideosRequest) {
+      // Deferred auth: guests compose freely; hitting generate sends them to login.
+      if (!ensureLoggedIn()) {
+        return;
+      }
       const token = this.credential?.token;
       if (!token) {
         console.error('no token specified');
@@ -282,6 +290,10 @@ export default defineComponent({
         });
     },
     async onStartDescribeTask(request: IMidjourneyDescribeRequest) {
+      // Deferred auth: guests compose freely; hitting describe sends them to login.
+      if (!ensureLoggedIn()) {
+        return;
+      }
       const token = this.credential?.token;
       if (!token) {
         console.error('no token specified');

--- a/src/pages/nanobanana/Index.vue
+++ b/src/pages/nanobanana/Index.vue
@@ -21,7 +21,7 @@ import { ERROR_CODE_USED_UP, NANOBANANA_DEFAULT_RESOLUTION, NANOBANANA_MODEL_NAN
 import RecentPanel from '@/components/nanobanana/RecentPanel.vue';
 import { INanobananaTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
-import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 
 interface IData {
   task: INanobananaTask | undefined;
@@ -170,6 +170,9 @@ export default defineComponent({
         action: hasReferenceImages ? 'edit' : 'generate',
         async: true
       } as INanobananaGenerateRequest;
+      if (!ensureLoggedIn()) {
+        return;
+      }
       const token = this.credential?.token;
       if (!token) {
         console.error('no token specified');

--- a/src/pages/openaiimage/Index.vue
+++ b/src/pages/openaiimage/Index.vue
@@ -20,7 +20,7 @@ import { ElMessage } from 'element-plus';
 import { ERROR_CODE_USED_UP } from '@/constants';
 import RecentPanel from '@/components/openaiimage/RecentPanel.vue';
 import { loadPreviousPage } from '@/utils/pagination';
-import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 import { IOpenAIImageTask } from '@/models';
 
 interface IData {
@@ -179,6 +179,9 @@ export default defineComponent({
         async: true
       } as IOpenAIImageEditRequest;
 
+      if (!ensureLoggedIn()) {
+        return;
+      }
       const token = this.credential?.token;
       if (!token) {
         console.error('no token specified');

--- a/src/pages/pika/Index.vue
+++ b/src/pages/pika/Index.vue
@@ -21,7 +21,7 @@ import { ERROR_CODE_DUPLICATION, ERROR_CODE_USED_UP } from '@/constants';
 import RecentPanel from '@/components/pika/RecentPanel.vue';
 import { IPikaTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
-import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 
 interface IData {
   task: IPikaTask | undefined;
@@ -192,6 +192,9 @@ export default defineComponent({
         ...this.config,
         async: true
       } as IPikaGenerateRequest;
+      if (!ensureLoggedIn()) {
+        return;
+      }
       const token = this.credential?.token;
       if (!token) {
         console.error('no token specified');

--- a/src/pages/pixverse/Index.vue
+++ b/src/pages/pixverse/Index.vue
@@ -21,7 +21,7 @@ import { ERROR_CODE_USED_UP } from '@/constants';
 import RecentPanel from '@/components/pixverse/RecentPanel.vue';
 import { IPixverseTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
-import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 
 interface IData {
   task: IPixverseTask | undefined;
@@ -161,6 +161,9 @@ export default defineComponent({
         ...this.config,
         async: true
       } as IPixverseGenerateRequest;
+      if (!ensureLoggedIn()) {
+        return;
+      }
       const token = this.credential?.token;
       if (!token) {
         console.error('no token specified');

--- a/src/pages/producer/Index.vue
+++ b/src/pages/producer/Index.vue
@@ -25,7 +25,7 @@ import ConfigPanel from '@/components/producer/ConfigPanel.vue';
 import RecentPanel from '@/components/producer/RecentPanel.vue';
 import PreviewPanel from '@/components/producer/PreviewPanel.vue';
 import { loadPreviousPage } from '@/utils/pagination';
-import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 
 interface IData {
   task: IProducerTask | undefined;
@@ -195,6 +195,9 @@ export default defineComponent({
         ...this.config,
         async: true
       } as IProducerAudioRequest;
+      if (!ensureLoggedIn()) {
+        return;
+      }
       const token = this.credential?.token;
       if (!token) {
         console.error('no token specified');

--- a/src/pages/qrart/Index.vue
+++ b/src/pages/qrart/Index.vue
@@ -32,7 +32,7 @@ import ApplicationStatus from '@/components/application/Status.vue';
 import RecentPanel from '@/components/qrart/RecentPanel.vue';
 import { IQrartTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
-import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 
 interface IData {
   task: IQrartTask | undefined;
@@ -224,6 +224,9 @@ export default defineComponent({
             }
           : {})
       } as IQrartGenerateRequest;
+      if (!ensureLoggedIn()) {
+        return;
+      }
       const token = this.credential?.token;
       if (!token) {
         console.error('no token specified');

--- a/src/pages/seedance/Index.vue
+++ b/src/pages/seedance/Index.vue
@@ -21,7 +21,7 @@ import { ElMessage } from 'element-plus';
 import { ERROR_CODE_USED_UP, getSeedanceCapability, SEEDANCE_MODEL_CAPABILITIES } from '@/constants';
 import { ISeedanceTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
-import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 
 interface IData {
   task: ISeedanceTask | undefined;
@@ -218,6 +218,9 @@ export default defineComponent({
         async: true
       } as ISeedanceGenerateRequest;
 
+      if (!ensureLoggedIn()) {
+        return;
+      }
       const token = this.credential?.token;
       if (!token) {
         console.error('no token specified');

--- a/src/pages/seedream/Index.vue
+++ b/src/pages/seedream/Index.vue
@@ -20,7 +20,7 @@ import { ElMessage } from 'element-plus';
 import { ERROR_CODE_USED_UP } from '@/constants';
 import RecentPanel from '@/components/seedream/RecentPanel.vue';
 import { loadPreviousPage } from '@/utils/pagination';
-import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 import { ISeedreamTask } from '@/models';
 
 interface IData {
@@ -160,6 +160,9 @@ export default defineComponent({
         ...cfg,
         async: true
       } as ISeedreamGenerateRequest;
+      if (!ensureLoggedIn()) {
+        return;
+      }
       const token = this.credential?.token;
       if (!token) {
         console.error('no token specified');

--- a/src/pages/serp/Index.vue
+++ b/src/pages/serp/Index.vue
@@ -16,6 +16,7 @@ import SearchPanel from '@/components/serp/SearchPanel.vue';
 import ResultPanel from '@/components/serp/ResultPanel.vue';
 import { ElMessage } from 'element-plus';
 import { ERROR_CODE_USED_UP } from '@/constants';
+import { ensureLoggedIn } from '@/utils';
 
 export default defineComponent({
   name: 'SerpIndex',
@@ -35,6 +36,10 @@ export default defineComponent({
       console.debug('end onGetService');
     },
     async onSearch() {
+      // Deferred auth: guests compose a query freely; running it triggers login.
+      if (!ensureLoggedIn()) {
+        return;
+      }
       const config = this.$store.state.serp?.config;
       if (!config?.query) {
         return;

--- a/src/pages/sora/Index.vue
+++ b/src/pages/sora/Index.vue
@@ -21,7 +21,7 @@ import { ERROR_CODE_USED_UP } from '@/constants';
 import RecentPanel from '@/components/sora/RecentPanel.vue';
 import { ISoraTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
-import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 
 interface IData {
   task: ISoraTask | undefined;
@@ -161,6 +161,9 @@ export default defineComponent({
         ...this.config,
         async: true
       } as ISoraGenerateRequest;
+      if (!ensureLoggedIn()) {
+        return;
+      }
       const token = this.credential?.token;
       if (!token) {
         console.error('no token specified');

--- a/src/pages/suno/Index.vue
+++ b/src/pages/suno/Index.vue
@@ -31,7 +31,7 @@ import ConfigPanel from '@/components/suno/ConfigPanel.vue';
 import RecentPanel from '@/components/suno/RecentPanel.vue';
 import PreviewPanel from '@/components/suno/PreviewPanel.vue';
 import { loadPreviousPage } from '@/utils/pagination';
-import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 
 interface IData {
   task: ISunoTask | undefined;
@@ -239,6 +239,9 @@ export default defineComponent({
       }
       if (this.hasText(request.prompt)) {
         request.prompt = request.prompt.trim();
+      }
+      if (!ensureLoggedIn()) {
+        return;
       }
       const token = this.credential?.token;
       if (!token) {

--- a/src/pages/veo/Index.vue
+++ b/src/pages/veo/Index.vue
@@ -21,7 +21,7 @@ import { ERROR_CODE_USED_UP } from '@/constants';
 import RecentPanel from '@/components/veo/RecentPanel.vue';
 import { IVeoTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
-import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 
 interface IData {
   task: IVeoTask | undefined;
@@ -161,6 +161,9 @@ export default defineComponent({
         ...this.config,
         async: true
       } as IVeoGenerateRequest;
+      if (!ensureLoggedIn()) {
+        return;
+      }
       const token = this.credential?.token;
       if (!token) {
         console.error('no token specified');

--- a/src/pages/wan/Index.vue
+++ b/src/pages/wan/Index.vue
@@ -21,7 +21,7 @@ import { ERROR_CODE_USED_UP } from '@/constants';
 import RecentPanel from '@/components/wan/RecentPanel.vue';
 import { IWanTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
-import { uploadTrackerProviderMixin, ensureNoPendingUpload } from '@/utils';
+import { uploadTrackerProviderMixin, ensureNoPendingUpload, ensureLoggedIn } from '@/utils';
 
 interface IData {
   task: IWanTask | undefined;
@@ -165,6 +165,9 @@ export default defineComponent({
         ...this.config,
         async: true
       } as IWanGenerateRequest;
+      if (!ensureLoggedIn()) {
+        return;
+      }
       const token = this.credential?.token;
       if (!token) {
         console.error('no token specified');

--- a/src/pages/webextrator/Index.vue
+++ b/src/pages/webextrator/Index.vue
@@ -16,6 +16,7 @@ import ConfigPanel from '@/components/webextrator/ConfigPanel.vue';
 import ResultPanel from '@/components/webextrator/ResultPanel.vue';
 import { ElMessage } from 'element-plus';
 import { ERROR_CODE_USED_UP } from '@/constants';
+import { ensureLoggedIn } from '@/utils';
 
 export default defineComponent({
   name: 'WebextratorIndex',
@@ -30,6 +31,10 @@ export default defineComponent({
   },
   methods: {
     async onRun() {
+      // Deferred auth: guests compose freely; running the extraction triggers login.
+      if (!ensureLoggedIn()) {
+        return;
+      }
       const config = this.$store.state.webextrator?.config;
       if (!config?.url) return;
       const isExtract = (config.mode || 'extract') === 'extract';

--- a/src/store/chat/actions.ts
+++ b/src/store/chat/actions.ts
@@ -88,9 +88,21 @@ export const getService = async ({
 
 export const getApplications = async ({
   commit,
-  state
+  state,
+  rootState
 }: ActionContext<IChatState, IRootState>): Promise<IApplication[] | undefined> => {
   console.debug('start to get applications for chat');
+  // Guests browse the chat composer without an application — login is deferred
+  // to send-time (see `onSubmit`/`onRequest`). Skip the authed fetch so it
+  // neither 401s nor leaves the page stuck in a "Request" state, and drop any
+  // stale credential so a guest can never reuse a previous session's token.
+  if (!rootState?.token?.access) {
+    state.status.getApplications = Status.Success;
+    commit('setApplications', []);
+    commit('setApplication', undefined);
+    commit('setCredential', undefined);
+    return [];
+  }
   state.status.getApplications = Status.Request;
   try {
     const { data: applications } = await applicationOperator.getAll({

--- a/src/store/factories/createTaskActions.ts
+++ b/src/store/factories/createTaskActions.ts
@@ -147,6 +147,17 @@ export function createTaskActions<TConfig, TTask, TFilter>(opts: {
     state,
     rootState
   }: ActionContext<S, IRootState>): Promise<IApplication[] | undefined> => {
+    // Guests browse the config panel without an application — login is deferred
+    // to the operation handlers on each page. Skip the authed fetch so it
+    // neither 401s nor leaves the page pinned in a "Request" state, and drop any
+    // stale credential so a guest can never reuse a previous session's token.
+    if (!rootState?.token?.access) {
+      state.status.getApplications = Status.Success;
+      commit('setApplications', []);
+      commit('setApplication', undefined);
+      commit('setCredential', undefined);
+      return [];
+    }
     state.status.getApplications = Status.Request;
     try {
       const { data: applications } = await applicationOperator.getAll({

--- a/src/utils/login.ts
+++ b/src/utils/login.ts
@@ -40,3 +40,20 @@ export const loginRedirect = ({
   const targetUrl = `${targetBaseUrl}?${new URLSearchParams(targetQuery).toString()}`;
   window.location.href = targetUrl;
 };
+
+/**
+ * Gate a user-initiated operation behind login. Returns `true` when the user is
+ * already authenticated; otherwise kicks off the login flow (in-app popup on
+ * native/desktop, redirect on web — preserving the current URL) and returns
+ * `false` so the caller can abort the just-attempted operation.
+ *
+ * This is the "deferred auth" primitive: guests can browse and compose, and are
+ * only sent to login the moment they actually try to run something.
+ */
+export const ensureLoggedIn = (): boolean => {
+  if (store.getters.authenticated) {
+    return true;
+  }
+  store.dispatch('login');
+  return false;
+};


### PR DESCRIPTION
## What & why

Today **every** unauthenticated visitor to studio.acedata.cloud is immediately bounced to the auth page — they can't see anything before logging in. This PR lets guests **browse** service pages (models, options, pricing) and only prompts for login the moment they **actually start an operation** (send a chat, click generate, run a search).

## How it works

- **`App.vue`** — the real global gate: it dispatched `login` on every unauthenticated **web** mount. Now web guests just get a state reset and stay; native/desktop keep the in-app login popup (unchanged).
- **`operators/common.ts`** — the 401 interceptor now only logs out when `store.getters.authenticated` (a logged-in user whose token expired). A 401 on a guest's passive bootstrap call no longer forces a redirect.
- **`layouts/Main.vue`** — `initialize()` skips the application/credential bootstrap (and the `onAutoApply()` error toast) for guests; `initialized` stays false so per-page task-polling watchers don't fire.
- **`store/chat/actions.ts` + `store/factories/createTaskActions.ts`** — `getApplications` short-circuits to a clean empty `Success` state for guests **and clears any stale credential**, so a guest can never reuse a previous session's token.
- **`utils/login.ts`** — new `ensureLoggedIn()`: returns `true` if authenticated, else kicks off login (web redirect / native popup) and returns `false` so the caller aborts.
- **~24 operation handlers** across every AI service (chat send + the generate/run handlers for midjourney, flux, sora, luma, veo, hailuo, kling, wan, seedance, seedream, openaiimage, nanobanana, pixverse, pika, qrart, grokvideo, headshots, suno, producer, digitalhuman, maestro, fish, serp, webextrator) now call `ensureLoggedIn()` first. The chat composer & generate buttons stay **enabled** for guests; clicking triggers login.

## Verification

- `GET /api/v1/services/<id>` returns **200 anonymously** (full config) — confirmed live, so config panels render for guests without a token.
- `vue-tsc -b` ✅, `eslint` on changed files ✅, `vite build` ✅.

## Scope boundary

Account/management routes (console, distribution, settings, codingBridge) are now reachable by guests and show empty states (their APIs 401, no bounce). No private data is rendered (server returns nothing without auth). A follow-up can add a `meta.auth` router guard to redirect those specific routes.

## 🤖 对抗评审

Reviewer: **Codex** (`codex exec --sandbox read-only`, gpt-5.5). One substantive round, converged — all findings fixed.

| # | Finding | Resolution |
|---|---------|------------|
| RISK 1 | `App.vue` still dispatched `login()` on every unauthenticated web mount — the **real** global guest bounce, upstream of the router/interceptor changes. | **Fixed** — web branch no longer dispatches `login` (keeps `resetAll`); native/desktop unchanged. |
| RISK 2 | Chat guest branch cleared `application` but left a persisted `credential`/token, so the `credential.token` watcher could fetch private data as a guest. | **Fixed** — both guest branches now `setCredential(undefined)`; `App.vue` `resetAll` also drops it. |
| RISK 3 | Factory enabled guest mode for all services, but most operation handlers only checked `credential?.token` so guest generate clicks silently no-op'd. | **Fixed** — wired `ensureLoggedIn()` into all ~24 operation handlers. |

A second confirmation round was attempted but the reviewer hung on tooling; the substantive round above converged with every finding addressed, and the fan-out follows the exact pattern RISK 3 requested (type-check + lint + build all green).