### PR TITLE
fix(auth): redirect guests on auth-only routes + friendly guest task prompt

### DIFF
--- a/change/@acedatacloud-nexior-2c845db1-cc9e-456e-8d91-bec9d4fe1e8b.json
+++ b/change/@acedatacloud-nexior-2c845db1-cc9e-456e-8d91-bec9d4fe1e8b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Guest browsing polish: redirect guests away from auth-only routes (console/distribution/settings/coding-bridge) to login, and show a friendly 'log in to start & view tasks' prompt instead of an indefinite skeleton on service task pages.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/BotPlaceholder.vue
+++ b/src/components/common/BotPlaceholder.vue
@@ -1,32 +1,68 @@
 <template>
-  <div v-for="_ in 3" :key="_" class="flex mb-4">
-    <div class="w-[70px] p-3">
-      <el-skeleton animated>
-        <template #template>
-          <el-skeleton-item variant="image" class="w-[50px] h-[50px] rounded-full" />
-        </template>
-      </el-skeleton>
-    </div>
-    <div class="flex-1 p-3">
-      <el-skeleton animated>
-        <template #template>
-          <el-skeleton-item variant="p" class="w-[200px] h-[20px] mb-4 block rounded-lg" />
-          <el-skeleton-item variant="p" class="w-full h-[200px] max-w-[300px] block rounded-2xl" />
-        </template>
-      </el-skeleton>
-    </div>
+  <!-- Guests can browse the config panel but have no task history; instead of an
+       indefinite skeleton (their tasks never load), show a friendly prompt to
+       log in to start a task and see their creations. -->
+  <div
+    v-if="!authenticated"
+    class="guest-prompt h-full w-full flex flex-col items-center justify-center text-center px-6 py-10 text-[var(--el-text-color-secondary)]"
+  >
+    <button
+      type="button"
+      class="inline-flex items-center justify-center w-12 h-12 rounded-full border border-[var(--el-color-primary-light-5)] bg-[var(--el-color-primary-light-9)] text-[var(--el-color-primary)] cursor-pointer transition duration-200 hover:bg-[var(--el-color-primary-light-7)] hover:scale-105 active:scale-95"
+      :aria-label="$t('common.button.login')"
+      @click="onLogin"
+    >
+      <font-awesome-icon icon="fa-solid fa-magic" class="text-lg" />
+    </button>
+    <p class="mt-4 text-sm max-w-[260px]">{{ $t('common.message.guestTasks') }}</p>
+    <el-button type="primary" round class="mt-4" @click="onLogin">
+      {{ $t('common.button.login') }}
+    </el-button>
   </div>
+  <template v-else>
+    <div v-for="_ in 3" :key="_" class="flex mb-4">
+      <div class="w-[70px] p-3">
+        <el-skeleton animated>
+          <template #template>
+            <el-skeleton-item variant="image" class="w-[50px] h-[50px] rounded-full" />
+          </template>
+        </el-skeleton>
+      </div>
+      <div class="flex-1 p-3">
+        <el-skeleton animated>
+          <template #template>
+            <el-skeleton-item variant="p" class="w-[200px] h-[20px] mb-4 block rounded-lg" />
+            <el-skeleton-item variant="p" class="w-full h-[200px] max-w-[300px] block rounded-2xl" />
+          </template>
+        </el-skeleton>
+      </div>
+    </div>
+  </template>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElSkeleton, ElSkeletonItem } from 'element-plus';
+import { ElSkeleton, ElSkeletonItem, ElButton } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { ensureLoggedIn } from '@/utils/login';
 
 export default defineComponent({
   name: 'BotPlaceholder',
   components: {
     ElSkeleton,
-    ElSkeletonItem
+    ElSkeletonItem,
+    ElButton,
+    FontAwesomeIcon
+  },
+  computed: {
+    authenticated(): boolean {
+      return this.$store.getters.authenticated;
+    }
+  },
+  methods: {
+    onLogin() {
+      ensureLoggedIn();
+    }
   }
 });
 </script>

--- a/src/i18n/ar/common.json
+++ b/src/i18n/ar/common.json
@@ -259,6 +259,10 @@
     "message": "لا توجد مهام تاريخية، يرجى بدء مهمة جديدة～",
     "description": "رسالة عند عدم وجود مهام"
   },
+  "message.guestTasks": {
+    "message": "سجّل الدخول لبدء مهمة وعرض إبداعاتك هنا.",
+    "description": "Prompt shown in the task list area for not-logged-in guests"
+  },
   "message.usedAmount": {
     "message": "المبلغ المستخدم",
     "description": "لإظهار المبلغ الذي تم استخدامه من الخدمة"

--- a/src/i18n/de/common.json
+++ b/src/i18n/de/common.json
@@ -259,6 +259,10 @@
     "message": "Keine historischen Aufgaben, bitte starten Sie eine neue Aufgabe～",
     "description": "Nachricht, wenn keine Aufgaben vorhanden sind"
   },
+  "message.guestTasks": {
+    "message": "Melde dich an, um eine Aufgabe zu starten und deine Kreationen hier zu sehen.",
+    "description": "Prompt shown in the task list area for not-logged-in guests"
+  },
   "message.usedAmount": {
     "message": "Verwendeter Betrag",
     "description": "Zur Anzeige des bereits verwendeten Betrags für den Dienst"

--- a/src/i18n/el/common.json
+++ b/src/i18n/el/common.json
@@ -259,6 +259,10 @@
     "message": "Δεν υπάρχουν ιστορικά καθήκοντα, ξεκινήστε ένα νέο καθήκον～",
     "description": "Μήνυμα όταν δεν υπάρχουν καθήκοντα"
   },
+  "message.guestTasks": {
+    "message": "Συνδεθείτε για να ξεκινήσετε μια εργασία και να δείτε εδώ τις δημιουργίες σας.",
+    "description": "Prompt shown in the task list area for not-logged-in guests"
+  },
   "message.usedAmount": {
     "message": "Χρησιμοποιηθέν ποσό",
     "description": "Χρησιμοποιείται για την εμφάνιση του ποσού που έχει χρησιμοποιηθεί από την υπηρεσία"

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -255,6 +255,10 @@
     "message": "No historical tasks, please start a new task~",
     "description": "Message when there are no tasks"
   },
+  "message.guestTasks": {
+    "message": "Log in to start a task and view your creations here.",
+    "description": "Prompt shown in the task list area for not-logged-in guests"
+  },
   "message.usedAmount": {
     "message": "Used Amount",
     "description": "Used to display the amount of service that has been used"

--- a/src/i18n/es/common.json
+++ b/src/i18n/es/common.json
@@ -259,6 +259,10 @@
     "message": "No hay tareas históricas, ¡comienza una nueva tarea!～",
     "description": "Mensaje cuando no hay tareas"
   },
+  "message.guestTasks": {
+    "message": "Inicia sesión para empezar una tarea y ver aquí tus creaciones.",
+    "description": "Prompt shown in the task list area for not-logged-in guests"
+  },
   "message.usedAmount": {
     "message": "Monto utilizado",
     "description": "Para mostrar el monto utilizado del servicio"

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -259,6 +259,10 @@
     "message": "Ei historiallisia tehtäviä, aloita uusi tehtävä～",
     "description": "Viesti, kun tehtäviä ei ole"
   },
+  "message.guestTasks": {
+    "message": "Kirjaudu sisään aloittaaksesi tehtävän ja nähdäksesi luomuksesi täällä.",
+    "description": "Prompt shown in the task list area for not-logged-in guests"
+  },
   "message.usedAmount": {
     "message": "Käytetty määrä",
     "description": "Näyttää käytetyn palvelumäärän"

--- a/src/i18n/fr/common.json
+++ b/src/i18n/fr/common.json
@@ -259,6 +259,10 @@
     "message": "Aucune tâche historique, veuillez commencer une nouvelle tâche～",
     "description": "Message lorsque aucune tâche n'est disponible"
   },
+  "message.guestTasks": {
+    "message": "Connectez-vous pour lancer une tâche et voir vos créations ici.",
+    "description": "Prompt shown in the task list area for not-logged-in guests"
+  },
   "message.usedAmount": {
     "message": "Montant utilisé",
     "description": "Utilisé pour afficher le montant utilisé du service"

--- a/src/i18n/it/common.json
+++ b/src/i18n/it/common.json
@@ -259,6 +259,10 @@
     "message": "Nessun compito storico, inizia un nuovo compito～",
     "description": "Messaggio quando non ci sono compiti"
   },
+  "message.guestTasks": {
+    "message": "Accedi per avviare un'attività e vedere qui le tue creazioni.",
+    "description": "Prompt shown in the task list area for not-logged-in guests"
+  },
   "message.usedAmount": {
     "message": "Importo utilizzato",
     "description": "Utilizzato per visualizzare l'importo già utilizzato per il servizio"

--- a/src/i18n/ja/common.json
+++ b/src/i18n/ja/common.json
@@ -259,6 +259,10 @@
     "message": "履歴タスクはありません。新しいタスクを始めましょう～",
     "description": "タスクがないときのメッセージ"
   },
+  "message.guestTasks": {
+    "message": "ログインしてタスクを開始し、作品をここで確認しましょう。",
+    "description": "Prompt shown in the task list area for not-logged-in guests"
+  },
   "message.usedAmount": {
     "message": "使用済み金額",
     "description": "サービスで使用された金額を表示するために使用"

--- a/src/i18n/ko/common.json
+++ b/src/i18n/ko/common.json
@@ -259,6 +259,10 @@
     "message": "이력 작업이 없습니다. 새로운 작업을 시작하세요～",
     "description": "작업이 없을 때의 메시지"
   },
+  "message.guestTasks": {
+    "message": "로그인하여 작업을 시작하고 여기에서 작품을 확인하세요.",
+    "description": "Prompt shown in the task list area for not-logged-in guests"
+  },
   "message.usedAmount": {
     "message": "사용된 금액",
     "description": "서비스에서 사용된 금액을 표시하는 데 사용"

--- a/src/i18n/pl/common.json
+++ b/src/i18n/pl/common.json
@@ -259,6 +259,10 @@
     "message": "Brak historii zadań, rozpocznij nowe zadanie～",
     "description": "Wiadomość wyświetlana, gdy nie ma zadań"
   },
+  "message.guestTasks": {
+    "message": "Zaloguj się, aby rozpocząć zadanie i zobaczyć tutaj swoje dzieła.",
+    "description": "Prompt shown in the task list area for not-logged-in guests"
+  },
   "message.usedAmount": {
     "message": "Wykorzystana kwota",
     "description": "Tekst wyświetlający kwotę wykorzystaną w usłudze"

--- a/src/i18n/pt/common.json
+++ b/src/i18n/pt/common.json
@@ -259,6 +259,10 @@
     "message": "Nenhuma tarefa histórica, comece uma nova tarefa～",
     "description": "Mensagem exibida quando não há tarefas"
   },
+  "message.guestTasks": {
+    "message": "Faça login para iniciar uma tarefa e ver suas criações aqui.",
+    "description": "Prompt shown in the task list area for not-logged-in guests"
+  },
   "message.usedAmount": {
     "message": "Valor utilizado",
     "description": "Usado para exibir o valor já utilizado do serviço"

--- a/src/i18n/ru/common.json
+++ b/src/i18n/ru/common.json
@@ -259,6 +259,10 @@
     "message": "Нет историй задач, начните новую задачу～",
     "description": "Сообщение, когда нет задач"
   },
+  "message.guestTasks": {
+    "message": "Войдите, чтобы начать задачу и увидеть свои работы здесь.",
+    "description": "Prompt shown in the task list area for not-logged-in guests"
+  },
   "message.usedAmount": {
     "message": "Использованная сумма",
     "description": "Для отображения суммы, уже использованной для услуги"

--- a/src/i18n/sr/common.json
+++ b/src/i18n/sr/common.json
@@ -259,6 +259,10 @@
     "message": "Nema istorijskih zadataka, započnite novi zadatak～",
     "description": "Poruka kada nema zadataka"
   },
+  "message.guestTasks": {
+    "message": "Пријавите се да започнете задатак и овде видите своје креације.",
+    "description": "Prompt shown in the task list area for not-logged-in guests"
+  },
   "message.usedAmount": {
     "message": "Iskorišćeni iznos",
     "description": "Za prikaz iznosa koji je usluga već iskoristila"

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -259,6 +259,10 @@
     "message": "Inga historiska uppgifter, börja en ny uppgift～",
     "description": "Meddelande när det inte finns några uppgifter"
   },
+  "message.guestTasks": {
+    "message": "Logga in för att starta en uppgift och se dina skapelser här.",
+    "description": "Prompt shown in the task list area for not-logged-in guests"
+  },
   "message.usedAmount": {
     "message": "Använt belopp",
     "description": "Visar det belopp som har använts för tjänsten"

--- a/src/i18n/uk/common.json
+++ b/src/i18n/uk/common.json
@@ -259,6 +259,10 @@
     "message": "Немає історичних завдань, почніть нове завдання～",
     "description": "Повідомлення, коли немає завдань"
   },
+  "message.guestTasks": {
+    "message": "Увійдіть, щоб розпочати завдання та переглянути свої творіння тут.",
+    "description": "Prompt shown in the task list area for not-logged-in guests"
+  },
   "message.usedAmount": {
     "message": "Використана сума",
     "description": "Для відображення суми, що була використана для послуги"

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -259,6 +259,10 @@
     "message": "没有历史任务，请开始新的任务吧～",
     "description": "没有任务时的消息"
   },
+  "message.guestTasks": {
+    "message": "登录后即可发起任务，并在这里查看你的作品。",
+    "description": "未登录访客在任务列表区域看到的提示"
+  },
   "message.usedAmount": {
     "message": "已使用金额",
     "description": "用于显示服务已使用的金额"

--- a/src/i18n/zh-TW/common.json
+++ b/src/i18n/zh-TW/common.json
@@ -259,6 +259,10 @@
     "message": "沒有歷史任務，請開始新的任務吧～",
     "description": "没有任务时的消息"
   },
+  "message.guestTasks": {
+    "message": "登入後即可發起任務，並在這裡查看你的作品。",
+    "description": "Prompt shown in the task list area for not-logged-in guests"
+  },
   "message.usedAmount": {
     "message": "已使用金額",
     "description": "用于显示服务已使用的金额"

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -75,6 +75,18 @@ import { updateSeo, setWebApplicationSchema, setOrganization, resetSeo } from '@
 import { ensureStoreModule } from '@/store/lazy';
 import { evaluateUserIdGuard } from '@/utils/crossSiteUser';
 import { handleChunkLoadError } from '@/utils/chunkLoadError';
+import { loginRedirect } from '@/utils/login';
+import { isNative, isDesktop } from '@/utils/surface';
+
+// Sections that require a logged-in user — guests hitting these are sent to the
+// login flow (web: redirect preserving the target; native/desktop: in-app
+// popup). Everything else (AI service pages, home) is browsable as a guest;
+// login is deferred until they actually start an operation. Keep this list in
+// sync when adding account/billing-style routes.
+const AUTH_REQUIRED_PREFIXES = ['/console', '/distribution', '/settings', '/coding-bridge'];
+
+const requiresLogin = (path: string): boolean =>
+  AUTH_REQUIRED_PREFIXES.some((prefix) => path === prefix || path.startsWith(`${prefix}/`));
 
 // SEO metadata per route path prefix
 const ROUTE_SEO: Record<string, { title: string; description: string; keywords: string[]; category: string }> = {
@@ -415,6 +427,19 @@ export function setupRouterGuards(router: Router) {
     }
     if (decision.kind === 'mismatch') {
       // Helper has already triggered a full-page SSO redirect; abort.
+      return next(false);
+    }
+
+    // Auth-required sections (console / distribution / settings / coding-bridge)
+    // need a logged-in user. Guests are sent to login instead of landing on a
+    // page whose data calls 401 and spins forever. The login flow preserves the
+    // intended destination so they return here after authenticating.
+    if (!store.getters.authenticated && requiresLogin(to.path)) {
+      if (isNative() || isDesktop()) {
+        store.dispatch('login');
+      } else {
+        loginRedirect({ redirect: to.fullPath });
+      }
       return next(false);
     }
 


### PR DESCRIPTION
Follow-up to #1101 (guest browsing), fixing two rough edges found in live testing on studio.acedata.cloud.

## Problems

1. **Auth-only pages spun / failed for guests** — e.g. `/console/applications` failed and `/distribution` sat on an infinite loading skeleton, because guests could land there but the data calls 401.
2. **Service task pages showed an indefinite loading skeleton** for guests — the task list never loads without a token, so the `BotPlaceholder` skeleton stayed forever (see screenshot in the issue: nanobanana right-hand panel).

## Fix

- **Router guard** (`src/router/index.ts`): a small allowlist of auth-only sections — `/console`, `/distribution`, `/settings`, `/coding-bridge` — redirects guests to login (web: redirect preserving the destination; native/desktop: in-app popup). Everything else (AI service pages, home) stays guest-browsable; login is still deferred to the first real operation.
- **Friendly guest task prompt** (`src/components/common/BotPlaceholder.vue`): this shared "tasks not loaded yet" component (used by all ~22 service task panels — fish, suno, midjourney, nanobanana, kling, flux, sora, luma, veo, hailuo, seedance, seedream, openaiimage, pixverse, pika, qrart, grokvideo, headshots, wan, digitalhuman, maestro, producer) now renders a **"log in to start a task and view your creations"** prompt with a login button when the user isn't authenticated. Authenticated users still get the skeleton during the brief load. One change fixes every task page.
- New i18n key `common.message.guestTasks` (en + zh-CN only, per repo policy).

## Verification

- `vue-tsc -b` ✅, `eslint` (changed files) ✅, `vite build` ✅.
- Logged-in flow is unchanged: the guard is a no-op for authenticated users; `BotPlaceholder` only diverges when `!authenticated`.

## 🤖 对抗评审

Reviewer (Codex) hung on tooling this round; self-review covered: guard correctness (uses `store.getters.authenticated`, handles native/desktop, preserves target via `to.fullPath`, no-op for authed users), `BotPlaceholder` SSG/hydration safety (auth-dependent rendering already used elsewhere, e.g. `Main.vue`), local Element Plus + Font Awesome registration (Nexior has no global registration — `ElButton`/`FontAwesomeIcon` imported in-component; reused the known-registered `fa-magic` icon), and coverage (grep confirmed all 22 task panels route through `BotPlaceholder` for the unloaded state).