### PR TITLE
fix(seedance): show prompt + reference audio/video on task cards

### DIFF
--- a/change/@acedatacloud-nexior-seedance-prompt-fix.json
+++ b/change/@acedatacloud-nexior-seedance-prompt-fix.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "seedance: show prompt on task cards for audio/video requests (prompt was folded into content[] and dropped from request.prompt)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "none"
+}

--- a/src/components/common/AudioPreview.vue
+++ b/src/components/common/AudioPreview.vue
@@ -1,0 +1,71 @@
+<template>
+  <div
+    class="audio-preview w-[50px] h-[50px] relative rounded-[var(--el-border-radius-base)] overflow-hidden shadow-sm cursor-pointer flex items-center justify-center"
+    :title="name"
+    @click.stop="onToggle"
+  >
+    <font-awesome-icon
+      :icon="playing ? 'fa-solid fa-pause' : 'fa-solid fa-music'"
+      class="icon text-white text-[16px]"
+    />
+    <audio
+      ref="audio"
+      :src="url"
+      preload="none"
+      @play="playing = true"
+      @pause="playing = false"
+      @ended="playing = false"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+
+export default defineComponent({
+  name: 'AudioPreview',
+  components: {
+    FontAwesomeIcon
+  },
+  props: {
+    url: {
+      type: String,
+      required: true
+    },
+    name: {
+      type: String,
+      required: false,
+      default: 'audio'
+    }
+  },
+  data() {
+    return {
+      playing: false
+    };
+  },
+  methods: {
+    onToggle() {
+      const audio = this.$refs.audio as HTMLAudioElement | undefined;
+      if (!audio) return;
+      if (audio.paused) {
+        audio.play().catch(() => {
+          this.playing = false;
+        });
+      } else {
+        audio.pause();
+      }
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.audio-preview {
+  background: linear-gradient(135deg, var(--el-color-primary), var(--el-color-primary-light-3));
+  transition: filter 0.15s ease;
+  &:hover {
+    filter: brightness(1.08);
+  }
+}
+</style>

--- a/src/components/common/VideoPreview.vue
+++ b/src/components/common/VideoPreview.vue
@@ -1,0 +1,64 @@
+<template>
+  <div
+    class="video-preview w-[50px] h-[50px] relative rounded-[var(--el-border-radius-base)] overflow-hidden shadow-sm cursor-pointer bg-[var(--el-fill-color-darker)]"
+    :title="name"
+    @click.stop="open = true"
+  >
+    <video class="w-full h-full object-cover" :src="`${url}#t=0.1`" muted preload="metadata" playsinline />
+    <div class="overlay absolute inset-0 flex items-center justify-center bg-[rgba(0,0,0,0.25)]">
+      <font-awesome-icon icon="fa-solid fa-play" class="text-white text-[14px]" />
+    </div>
+    <el-dialog
+      v-model="open"
+      width="640"
+      align-center
+      append-to-body
+      destroy-on-close
+      class="video-preview-dialog"
+      @click.stop
+    >
+      <video-player :src="url" />
+    </el-dialog>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElDialog } from 'element-plus';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import VideoPlayer from '@/components/common/VideoPlayer.vue';
+
+export default defineComponent({
+  name: 'VideoPreview',
+  components: {
+    ElDialog,
+    FontAwesomeIcon,
+    VideoPlayer
+  },
+  props: {
+    url: {
+      type: String,
+      required: true
+    },
+    name: {
+      type: String,
+      required: false,
+      default: 'video'
+    }
+  },
+  data() {
+    return {
+      open: false
+    };
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.video-preview {
+  transition: filter 0.15s ease;
+  &:hover {
+    filter: brightness(1.08);
+  }
+}
+</style>

--- a/src/components/seedance/task/Preview.vue
+++ b/src/components/seedance/task/Preview.vue
@@ -23,8 +23,8 @@
             :closable="false"
           />
         </div>
-        <p v-if="modelValue?.request?.prompt" class="prompt mt-2">
-          {{ modelValue?.request?.prompt }}
+        <p v-if="promptText" class="prompt mt-2">
+          {{ promptText }}
           <span v-if="!modelValue?.response"> - ({{ $t('seedance.status.pending') }}) </span>
           <span v-else-if="video?.status === 'processing' || video?.status === 'pending'">
             - ({{ $t('seedance.status.processing') }})
@@ -199,6 +199,20 @@ export default defineComponent({
   computed: {
     video(): ISeedanceVideo | undefined {
       return this.modelValue?.response?.data;
+    },
+    // Audio/video requests fold the prompt into `content[]` and drop the flat
+    // `prompt` field (see seedanceOperator.buildRequest), so fall back to the
+    // content text item, then to the prompt echoed back on the response.
+    promptText(): string | undefined {
+      const request = this.modelValue?.request;
+      if (request?.prompt) {
+        return request.prompt;
+      }
+      const textItem = request?.content?.find((item) => item?.type === 'text' && item?.text);
+      if (textItem?.text) {
+        return textItem.text;
+      }
+      return this.video?.prompt;
     },
     referenceImages(): { url: string; name: string }[] {
       const images = this.modelValue?.request?.images;

--- a/src/components/seedance/task/Preview.vue
+++ b/src/components/seedance/task/Preview.vue
@@ -23,6 +23,20 @@
             :closable="false"
           />
         </div>
+        <div v-for="(url, idx) in referenceAudios" :key="`audio-${idx}`" class="reference-audio mt-2">
+          <div class="reference-label">
+            <font-awesome-icon icon="fa-solid fa-music" class="mr-1" />
+            {{ $t('seedance.name.referenceAudio') }}
+          </div>
+          <audio :src="url" controls preload="metadata" class="audio-player" />
+        </div>
+        <div v-for="(url, idx) in referenceVideos" :key="`video-${idx}`" class="reference-video mt-2">
+          <div class="reference-label">
+            <font-awesome-icon icon="fa-solid fa-film" class="mr-1" />
+            {{ $t('seedance.name.referenceVideo') }}
+          </div>
+          <video-player :src="url" />
+        </div>
         <p v-if="promptText" class="prompt mt-2">
           {{ promptText }}
           <span v-if="!modelValue?.response"> - ({{ $t('seedance.status.pending') }}) </span>
@@ -162,7 +176,7 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import { ElImage, ElAlert, ElButton, ElTooltip } from 'element-plus';
-import { ISeedanceTask, ISeedanceVideo } from '@/models';
+import { ISeedanceTask, ISeedanceVideo, SeedanceImageRole } from '@/models';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import VideoPlayer from '@/components/common/VideoPlayer.vue';
@@ -215,8 +229,8 @@ export default defineComponent({
       return this.video?.prompt;
     },
     referenceImages(): { url: string; name: string }[] {
-      const images = this.modelValue?.request?.images;
-      if (!Array.isArray(images)) {
+      const images = this.collectImages();
+      if (images.length === 0) {
         return [];
       }
       const ordered: { url: string; name: string }[] = [];
@@ -234,9 +248,44 @@ export default defineComponent({
         }
       });
       return ordered;
+    },
+    // Reference media is folded into content[] for audio/video requests, so
+    // gather urls from both the flat fields and the content items.
+    referenceAudios(): string[] {
+      const request = this.modelValue?.request;
+      const urls = (request?.audios ?? []).map((a) => a?.url).filter(Boolean) as string[];
+      (request?.content ?? []).forEach((item) => {
+        if (item?.type === 'audio_url' && item?.audio_url?.url) {
+          urls.push(item.audio_url.url);
+        }
+      });
+      return urls;
+    },
+    referenceVideos(): string[] {
+      const request = this.modelValue?.request;
+      const urls = (request?.videos ?? []).map((v) => v?.url).filter(Boolean) as string[];
+      (request?.content ?? []).forEach((item) => {
+        if (item?.type === 'video_url' && item?.video_url?.url) {
+          urls.push(item.video_url.url);
+        }
+      });
+      return urls;
     }
   },
   methods: {
+    // Merge flat request.images with content[] image_url items (folded requests).
+    collectImages(): { url?: string; role?: SeedanceImageRole }[] {
+      const request = this.modelValue?.request;
+      const images: { url?: string; role?: SeedanceImageRole }[] = Array.isArray(request?.images)
+        ? [...request!.images]
+        : [];
+      (request?.content ?? []).forEach((item) => {
+        if (item?.type === 'image_url' && item?.image_url?.url) {
+          images.push({ url: item.image_url.url, role: item.role });
+        }
+      });
+      return images;
+    },
     onDownload(videoUrl: string) {
       window.open(videoUrl, '_blank');
     }
@@ -289,6 +338,20 @@ $left-width: 70px;
 
     .info {
       overflow: hidden;
+      .reference-audio,
+      .reference-video {
+        max-width: 360px;
+        .reference-label {
+          font-size: 12px;
+          font-weight: bold;
+          color: var(--el-text-color-secondary);
+          margin-bottom: 4px;
+        }
+      }
+      .reference-audio .audio-player {
+        width: 100%;
+        height: 38px;
+      }
       .prompt {
         font-size: 14px;
         font-weight: bold;

--- a/src/components/seedance/task/Preview.vue
+++ b/src/components/seedance/task/Preview.vue
@@ -12,30 +12,28 @@
       </div>
       <div class="info">
         <div
-          v-if="referenceImages.length > 0"
+          v-if="referenceImages.length > 0 || referenceAudios.length > 0 || referenceVideos.length > 0"
           class="flex justify-start items-center gap-2 mt-2 w-full overflow-x-auto"
         >
           <image-preview
             v-for="(image, idx) in referenceImages"
-            :key="idx"
+            :key="`image-${idx}`"
             :url="image.url"
             :name="image.name"
             :closable="false"
           />
-        </div>
-        <div v-for="(url, idx) in referenceAudios" :key="`audio-${idx}`" class="reference-audio mt-2">
-          <div class="reference-label">
-            <font-awesome-icon icon="fa-solid fa-music" class="mr-1" />
-            {{ $t('seedance.name.referenceAudio') }}
-          </div>
-          <audio :src="url" controls preload="metadata" class="audio-player" />
-        </div>
-        <div v-for="(url, idx) in referenceVideos" :key="`video-${idx}`" class="reference-video mt-2">
-          <div class="reference-label">
-            <font-awesome-icon icon="fa-solid fa-film" class="mr-1" />
-            {{ $t('seedance.name.referenceVideo') }}
-          </div>
-          <video-player :src="url" />
+          <audio-preview
+            v-for="(url, idx) in referenceAudios"
+            :key="`audio-${idx}`"
+            :url="url"
+            :name="`audio-${idx + 1}`"
+          />
+          <video-preview
+            v-for="(url, idx) in referenceVideos"
+            :key="`video-${idx}`"
+            :url="url"
+            :name="`video-${idx + 1}`"
+          />
         </div>
         <p v-if="promptText" class="prompt mt-2">
           {{ promptText }}
@@ -182,6 +180,8 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import VideoPlayer from '@/components/common/VideoPlayer.vue';
 import ImageWrapper from '@/components/common/ImageWrapper.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
+import AudioPreview from '@/components/common/AudioPreview.vue';
+import VideoPreview from '@/components/common/VideoPreview.vue';
 import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
 import { SEEDANCE_LOGO } from '@/constants';
 
@@ -197,6 +197,8 @@ export default defineComponent({
     ElButton,
     ImageWrapper,
     ImagePreview,
+    AudioPreview,
+    VideoPreview,
     ApiCodeButton
   },
   props: {
@@ -338,20 +340,6 @@ $left-width: 70px;
 
     .info {
       overflow: hidden;
-      .reference-audio,
-      .reference-video {
-        max-width: 360px;
-        .reference-label {
-          font-size: 12px;
-          font-weight: bold;
-          color: var(--el-text-color-secondary);
-          margin-bottom: 4px;
-        }
-      }
-      .reference-audio .audio-player {
-        width: 100%;
-        height: 38px;
-      }
       .prompt {
         font-size: 14px;
         font-weight: bold;

--- a/src/plugins/font-awesome.ts
+++ b/src/plugins/font-awesome.ts
@@ -26,6 +26,7 @@ import {
   faIdCard as faSolidIdCard,
   faStopCircle as faSolidStopCircle,
   faPlay as faSolidPlay,
+  faPause as faSolidPause,
   faPlayCircle as faSolidPlayCircle,
   faDownload as faSolidDownload,
   faFilm as faSolidFilm,
@@ -161,6 +162,7 @@ library.add(faSolidStopCircle);
 library.add(faRegularFile);
 library.add(faSolidPlayCircle);
 library.add(faSolidPlay);
+library.add(faSolidPause);
 library.add(faSolidArrowUp);
 library.add(faRegularFileAlt);
 library.add(faSolidFilm);


### PR DESCRIPTION
## Problem

Seedance 任务卡片信息缺失，尤其是**带参考音频/视频的任务**（如音色克隆）：
1. 不显示 prompt
2. 完全不展示输入的参考音频 / 参考视频
3. 连参考图片也不显示

## Root cause

`src/operators/seedance.ts` 的 `buildRequest()` 在请求携带参考音频/视频时，会把 `prompt + images + audios + videos` 全部折叠进 `content[]`（text / image_url / audio_url / video_url 项），并**丢弃扁平字段**（上游 `images[]` 路径只支持图片，音视频必须走 `content[]`）。而 `Preview.vue` 只读扁平的 `request.prompt` / `request.images`，于是这些任务的 prompt、参考图、参考音视频全部不显示。

文本/图生视频任务不走折叠逻辑所以正常；seedream/kling 无折叠逻辑不受影响。

## Fix

`Preview.vue`：

1. **prompt** — 新增 `promptText` computed，回退取：`request.prompt` → `content[]` 的 text 项 → `response.data.prompt`。
2. **参考音频** — 新增 `referenceAudios` computed（合并 `request.audios` 与 `content[]` audio_url 项），渲染原生 `<audio controls>` 播放器（与 fish/kling 一致约定）。
3. **参考视频** — 新增 `referenceVideos` computed，渲染 `<video-player>`。
4. **参考图片** — `referenceImages` 改用 `collectImages()`，合并 `request.images` 与 `content[]` image_url 项，使折叠请求也能显示参考图。

每块带图标 + 标签（i18n key 已存在），`fa-music` / `fa-film` 已在全局注册。`eslint` + `vue-tsc --noEmit` 均通过。

## 🤖 对抗评审

两轮独立 reviewer（Claude general-purpose 子代理）：

**第一轮（prompt 回退）** — `.find` 回调类型安全、null 守卫齐全、`video.prompt` 类型存在、pending/processing span 无回归 → **VERDICT: CLEAN**

**第二轮（音视频 UI）** 逐项核对：
- (a) 同一媒体不会重复渲染——`buildRequest` 互斥（要么全 content[]、要么全扁平），存储 request 即该 payload 回显 ✅
- (b) `:key` 命名空间隔离（`audio-${idx}` / `video-${idx}`）✅
- (c) `[...request!.images]` 类型可赋值，`request!` 由前置 `Array.isArray` 守卫 ✅
- (d) 参考视频 `<video-player>` 与 success 分支生成结果的 `<video-player>` 位置/数据/实例均独立 ✅
- (e) `collectImages()` 仅读 `this.modelValue`，computed 依赖追踪与缓存不受影响 ✅

→ **VERDICT: CLEAN**

> 注：`Workers Builds: nexior`（Cloudflare 外部检查）为预先损坏项，最近 #1101/1102/1103 全失败仍正常合入，与本改动无关、不阻塞合并。
