### PR TITLE
feat(desktop): per-action always-allow toggles for Computer Use

### DIFF
--- a/change/@acedatacloud-nexior-14e76839-4ea6-46cc-aa39-e384e058c93f.json
+++ b/change/@acedatacloud-nexior-14e76839-4ea6-46cc-aa39-e384e058c93f.json
@@ -1,0 +1,1 @@
+{"type":"minor","comment":"Computer Use: per-action always-allow toggles (screenshot/click/move/type/key/scroll) instead of only a single all-at-once button","packageName":"@acedatacloud/nexior","email":"dev@acedata.cloud","dependentChangeType":"patch"}

--- a/electron/local/ipc.ts
+++ b/electron/local/ipc.ts
@@ -111,31 +111,47 @@ export function registerLocalExec(getWin: () => BrowserWindow | null): void {
     return true;
   });
 
-  // "Pre-approve all computer actions": turn Computer Use on, persist an
-  // always-allow grant for every computer.* tool at once, and trigger the macOS
-  // Screen Recording + Accessibility prompts up front so the first real action
-  // doesn't stall. Returns the new grant list + permission status to refresh UI.
-  ipcMain.handle('local.computerUse.preauthorize', async (e) => {
+  // Names + descriptions of the computer-use tools, so the renderer can render a
+  // per-action always-allow toggle without hardcoding the list.
+  ipcMain.handle('local.computerUse.tools', (e) => {
+    gate(e);
+    return registry.computerToolSpecs();
+  });
+
+  // Pre-approve computer actions: turn Computer Use on, persist an always-allow
+  // grant for the requested computer.* tools (or ALL when `names` is empty), and
+  // trigger the macOS Screen Recording + Accessibility prompts up front so the
+  // first real action doesn't stall. Returns the new grant list + permission
+  // status to refresh UI.
+  ipcMain.handle('local.computerUse.preauthorize', async (e, names?: string[]) => {
     gate(e);
     const win = getWin();
+    // Only ever grant real computer.* tools — never widen an fs/shell grant.
+    const all = registry.computerToolNames();
+    const targets = Array.isArray(names) && names.length ? names.filter((n) => all.includes(n)) : all;
+    if (!targets.length) return { grants: listGrants(), perm: status(), computerUse: load().computerUse === true };
+    const grantingAll = targets.length === all.length;
     // Native (main-process) confirmation. The renderer can request this, but a
     // compromised/XSS'd page must NOT be able to silently grant itself permanent
     // screen + input control — only the user clicking this native dialog can.
     const confirm = {
       type: 'warning' as const,
-      buttons: ['Enable & allow all', 'Cancel'],
+      buttons: [grantingAll ? 'Enable & allow all' : 'Enable & allow', 'Cancel'],
       defaultId: 1,
       cancelId: 1,
-      message: 'Pre-approve all computer actions?',
+      message: grantingAll ? 'Pre-approve all computer actions?' : `Always allow ${targets.join(', ')}?`,
       detail:
-        'This lets the AI take screenshots and control your mouse & keyboard WITHOUT asking each time — until you revoke it in Settings → Local Tools or press the panic hotkey (Cmd/Ctrl+Alt+Shift+P).'
+        (grantingAll
+          ? 'This lets the AI take screenshots and control your mouse & keyboard'
+          : `This lets the AI run ${targets.join(', ')}`) +
+        ' WITHOUT asking each time — until you revoke it in Settings → Local Tools or press the panic hotkey (Cmd/Ctrl+Alt+Shift+P).'
     };
     const { response } = win ? await dialog.showMessageBox(win, confirm) : await dialog.showMessageBox(confirm);
     if (response !== 0) return { grants: listGrants(), perm: status(), computerUse: load().computerUse === true };
     const cur = load();
     if (cur.computerUse !== true) save({ ...cur, computerUse: true });
     registry.setComputerUse(true);
-    const grants = grantComputerTools(registry.computerToolNames());
+    const grants = grantComputerTools(targets);
     await ensureScreenPermission(); // capture permission (no-op off macOS)
     promptAccessibility(); // input permission
     // Re-read computerUse: a panic hotkey fired DURING the awaits above would

--- a/electron/local/registry.ts
+++ b/electron/local/registry.ts
@@ -51,6 +51,12 @@ class Registry {
     return COMPUTER_TOOLS.map((s) => s.name);
   }
 
+  // Full specs (name + description) of the computer-use tools, for the Settings
+  // per-action always-allow toggle list. Independent of whether the feature is on.
+  computerToolSpecs(): { name: string; description: string }[] {
+    return COMPUTER_TOOLS.map((s) => ({ name: s.name, description: s.description }));
+  }
+
   async boot(servers: McpServerConf[]): Promise<void> {
     for (const s of servers) {
       try {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -90,8 +90,12 @@ contextBridge.exposeInMainWorld('localExec', {
     ipcRenderer.on('local.computerUse.disabled', handler);
     return () => ipcRenderer.removeListener('local.computerUse.disabled', handler);
   },
-  // Pre-approve every computer.* action (persistent always-allow) + enable
-  // Computer Use + trigger the macOS Screen Recording / Accessibility prompts.
-  preauthorizeComputerUse: (): Promise<{ grants: string[]; perm: unknown; computerUse: boolean }> =>
-    ipcRenderer.invoke('local.computerUse.preauthorize')
+  // Names + descriptions of the computer.* tools, for the per-action always-allow
+  // toggle list in Settings → Local Tools.
+  computerTools: (): Promise<{ name: string; description: string }[]> => ipcRenderer.invoke('local.computerUse.tools'),
+  // Pre-approve computer.* actions (persistent always-allow) + enable Computer
+  // Use + trigger the macOS Screen Recording / Accessibility prompts. Pass a
+  // subset of tool names to allow only those; omit for every action.
+  preauthorizeComputerUse: (names?: string[]): Promise<{ grants: string[]; perm: unknown; computerUse: boolean }> =>
+    ipcRenderer.invoke('local.computerUse.preauthorize', names)
 });

--- a/src/components/setting/LocalTools.vue
+++ b/src/components/setting/LocalTools.vue
@@ -65,12 +65,30 @@
           <el-switch v-model="computerUse" :loading="savingCU" @change="onToggleComputerUse" />
         </div>
         <p class="muted">{{ $t('common.settings.localToolsComputerUseHint') }}</p>
-        <div class="actions">
-          <el-button size="small" type="primary" :loading="preauthorizing" @click="preauthorizeAll">
-            {{ $t('common.settings.localToolsPreauthorizeAll') }}
-          </el-button>
-          <span class="muted">{{ $t('common.settings.localToolsPreauthorizeHint') }}</span>
-        </div>
+        <template v-if="computerTools.length">
+          <div class="section-head sub">
+            <h4>{{ $t('common.settings.localToolsCuActionsTitle') }}</h4>
+            <el-button size="small" text type="primary" :loading="preauthorizing" @click="preauthorizeAll">
+              {{ $t('common.settings.localToolsPreauthorizeAll') }}
+            </el-button>
+          </div>
+          <p class="muted">{{ $t('common.settings.localToolsCuActionsHint') }}</p>
+          <ul class="rows">
+            <li v-for="t in computerTools" :key="t.name" class="row">
+              <font-awesome-icon :icon="cuIcon(t.name)" class="row-icon" />
+              <span class="cu-action">
+                <span class="cu-action-name">{{ cuLabel(t.name) }}</span>
+                <span class="cu-action-desc">{{ t.description }}</span>
+              </span>
+              <el-switch
+                :model-value="computerGrants[t.name] === true"
+                :loading="cuBusy === t.name"
+                :disabled="!!cuBusy || preauthorizing"
+                @change="(v: string | number | boolean) => onToggleComputerTool(t.name, v)"
+              />
+            </li>
+          </ul>
+        </template>
       </section>
 
       <!-- macOS system permissions -->
@@ -141,6 +159,11 @@ export default defineComponent({
       grants: null as null | GrantRow[],
       perm: null as null | { mac: boolean; fullDisk: boolean; screen: string; mic: string; accessibility: boolean },
       computerUse: false,
+      // Computer-use tool catalog + per-action always-allow state (`computer.<x>`
+      // → granted?). `cuBusy` holds the tool name whose toggle is in flight.
+      computerTools: [] as { name: string; description: string }[],
+      computerGrants: {} as Record<string, boolean>,
+      cuBusy: null as null | string,
       savingCU: false,
       preauthorizing: false,
       saving: false,
@@ -160,6 +183,7 @@ export default defineComponent({
     this.roots = cfg.roots;
     this.computerUse = cfg.computerUse === true;
     this.tools = (await ex.listTools()).map((t) => t.name);
+    this.computerTools = (await ex.computerTools?.()) ?? [];
     const s = await ex.perm?.status();
     if (s?.mac) this.perm = s;
     await this.loadGrants();
@@ -181,14 +205,25 @@ export default defineComponent({
         return;
       }
       const keys = await ex.grants.list();
-      this.grants = keys.map((k) => {
+      // computer.* grants are name-scoped (bare tool name, no `:input`) and get
+      // their own per-action toggles, so split them out of the generic
+      // "always-allowed" list to avoid showing each one twice.
+      const cuGrants: Record<string, boolean> = {};
+      const rows: GrantRow[] = [];
+      for (const k of keys) {
+        if (k.startsWith('computer.') && !k.includes(':')) {
+          cuGrants[k] = true;
+          continue;
+        }
         // key shape: `<tool.name>:<json input>`. The input is always JSON, so
         // split at the first `:{` (object) — robust even if a tool name ever
         // contained a colon. Fall back to the first `:` for non-object inputs.
         const sep = k.indexOf(':{');
         const idx = sep >= 0 ? sep : k.indexOf(':');
-        return { key: k, name: idx >= 0 ? k.slice(0, idx) : k, input: idx >= 0 ? k.slice(idx + 1) : '' };
-      });
+        rows.push({ key: k, name: idx >= 0 ? k.slice(0, idx) : k, input: idx >= 0 ? k.slice(idx + 1) : '' });
+      }
+      this.computerGrants = cuGrants;
+      this.grants = rows;
     },
     async addFolder() {
       const p = await localExec()?.pickFolder();
@@ -238,6 +273,50 @@ export default defineComponent({
         this.preauthorizing = false;
       }
     },
+    // Per-action always-allow. ON pre-approves just this one computer.* tool
+    // (native confirm in main), enables Computer Use, and triggers the system
+    // prompts. OFF revokes the single grant, re-arming its per-call confirmation.
+    async onToggleComputerTool(name: string, val: string | number | boolean) {
+      const ex = localExec();
+      if (!ex) return;
+      this.cuBusy = name;
+      try {
+        if (val === true) {
+          const r = await ex.preauthorizeComputerUse?.([name]);
+          if (r) {
+            this.computerUse = r.computerUse === true;
+            if (r.perm?.mac) this.perm = r.perm;
+          }
+        } else {
+          await ex.grants?.revoke(name);
+        }
+        await this.loadGrants();
+      } finally {
+        this.cuBusy = null;
+      }
+    },
+    // Short i18n label + icon per computer.* action. Falls back to the bare
+    // suffix / a generic icon for any tool the UI doesn't have copy for yet.
+    cuLabel(name: string): string {
+      const key = `common.settings.localToolsCu${this.cuSuffix(name)}`;
+      const label = this.$t(key);
+      return label === key ? name.replace(/^computer\./, '') : label;
+    },
+    cuIcon(name: string): string {
+      const map: Record<string, string> = {
+        screenshot: 'fa-solid fa-camera',
+        click: 'fa-solid fa-arrow-pointer',
+        move: 'fa-solid fa-up-down-left-right',
+        type: 'fa-solid fa-keyboard',
+        key: 'fa-solid fa-keyboard',
+        scroll: 'fa-solid fa-arrows-up-down'
+      };
+      return map[name.replace(/^computer\./, '')] ?? 'fa-solid fa-shield-halved';
+    },
+    cuSuffix(name: string): string {
+      const s = name.replace(/^computer\./, '');
+      return s.charAt(0).toUpperCase() + s.slice(1);
+    },
     async revoke(key: string) {
       await localExec()?.grants?.revoke(key);
       await this.loadGrants();
@@ -266,6 +345,28 @@ export default defineComponent({
   margin: 0;
   font-size: 15px;
   font-weight: 600;
+}
+.section-head.sub {
+  margin-top: 6px;
+}
+.section-head.sub h4 {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+}
+.cu-action {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.cu-action-name {
+  font-weight: 600;
+  font-size: 13px;
+}
+.cu-action-desc {
+  color: var(--el-text-color-secondary, #909399);
+  font-size: 12px;
 }
 .muted {
   color: var(--el-text-color-secondary, #909399);

--- a/src/i18n/ar/common.json
+++ b/src/i18n/ar/common.json
@@ -953,6 +953,14 @@
   },
   "settings.localToolsPreauthorizeAll": "السماح مسبقًا بجميع إجراءات الكمبيوتر",
   "settings.localToolsPreauthorizeHint": "اسمح دفعة واحدة بلقطة الشاشة والنقر والكتابة والمفاتيح وجميع الإجراءات، واطلب أذونات النظام المطلوبة.",
+  "settings.localToolsCuActionsTitle": "السماح بالإجراءات فرديًا",
+  "settings.localToolsCuActionsHint": "فعّل فقط الإجراءات التي تقبل أن ينفّذها الذكاء الاصطناعي دون سؤال في كل مرة. يمكن إلغاء كل منها من هنا.",
+  "settings.localToolsCuScreenshot": "لقطة شاشة",
+  "settings.localToolsCuClick": "نقر",
+  "settings.localToolsCuMove": "تحريك المؤشر",
+  "settings.localToolsCuType": "كتابة نص",
+  "settings.localToolsCuKey": "ضغط المفاتيح",
+  "settings.localToolsCuScroll": "تمرير",
   "settings.localToolsAddFolder": {
     "message": "إضافة مجلد",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/de/common.json
+++ b/src/i18n/de/common.json
@@ -953,6 +953,14 @@
   },
   "settings.localToolsPreauthorizeAll": "Alle Computeraktionen vorab erlauben",
   "settings.localToolsPreauthorizeHint": "Screenshot, Klick, Tippen, Tastendruck und alle Computeraktionen auf einmal erlauben und die erforderlichen Systemberechtigungen anfordern.",
+  "settings.localToolsCuActionsTitle": "Einzelne Aktionen erlauben",
+  "settings.localToolsCuActionsHint": "Aktivieren Sie nur die Aktionen, die die KI ohne Nachfrage ausführen darf. Jede bleibt hier widerrufbar.",
+  "settings.localToolsCuScreenshot": "Screenshot",
+  "settings.localToolsCuClick": "Klicken",
+  "settings.localToolsCuMove": "Zeiger bewegen",
+  "settings.localToolsCuType": "Text eingeben",
+  "settings.localToolsCuKey": "Tasten",
+  "settings.localToolsCuScroll": "Scrollen",
   "settings.localToolsAddFolder": {
     "message": "Ordner hinzufügen",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/el/common.json
+++ b/src/i18n/el/common.json
@@ -953,6 +953,14 @@
   },
   "settings.localToolsPreauthorizeAll": "Προέγκριση όλων των ενεργειών υπολογιστή",
   "settings.localToolsPreauthorizeHint": "Επιτρέψτε με μία κίνηση στιγμιότυπο οθόνης, κλικ, πληκτρολόγηση, πλήκτρα και όλες τις ενέργειες και ζητήστε τα απαιτούμενα δικαιώματα συστήματος.",
+  "settings.localToolsCuActionsTitle": "Άδεια μεμονωμένων ενεργειών",
+  "settings.localToolsCuActionsHint": "Ενεργοποιήστε μόνο τις ενέργειες που δέχεστε να εκτελεί η AI χωρίς ερώτηση κάθε φορά. Κάθε μία μπορεί να ανακληθεί εδώ.",
+  "settings.localToolsCuScreenshot": "Στιγμιότυπο οθόνης",
+  "settings.localToolsCuClick": "Κλικ",
+  "settings.localToolsCuMove": "Μετακίνηση δείκτη",
+  "settings.localToolsCuType": "Πληκτρολόγηση κειμένου",
+  "settings.localToolsCuKey": "Πάτημα πλήκτρων",
+  "settings.localToolsCuScroll": "Κύλιση",
   "settings.localToolsAddFolder": {
     "message": "Προσθήκη φακέλου",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -933,6 +933,14 @@
   },
   "settings.localToolsPreauthorizeAll": "Pre-approve all computer actions",
   "settings.localToolsPreauthorizeHint": "Allow screenshot, click, type, key and every computer action at once, and trigger the required system permissions.",
+  "settings.localToolsCuActionsTitle": "Allow individual actions",
+  "settings.localToolsCuActionsHint": "Turn on only the actions you're comfortable letting the AI run without asking each time. Each stays revocable here.",
+  "settings.localToolsCuScreenshot": "Screenshot",
+  "settings.localToolsCuClick": "Click",
+  "settings.localToolsCuMove": "Move pointer",
+  "settings.localToolsCuType": "Type text",
+  "settings.localToolsCuKey": "Press keys",
+  "settings.localToolsCuScroll": "Scroll",
   "settings.localToolsAddFolder": {
     "message": "Add folder",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/es/common.json
+++ b/src/i18n/es/common.json
@@ -953,6 +953,14 @@
   },
   "settings.localToolsPreauthorizeAll": "Autorizar previamente todas las acciones del equipo",
   "settings.localToolsPreauthorizeHint": "Permite de una vez la captura de pantalla, el clic, la escritura, las teclas y todas las acciones, y solicita los permisos del sistema necesarios.",
+  "settings.localToolsCuActionsTitle": "Permitir acciones individuales",
+  "settings.localToolsCuActionsHint": "Activa solo las acciones que quieras que la IA ejecute sin preguntar cada vez. Cada una se puede revocar aquí.",
+  "settings.localToolsCuScreenshot": "Captura de pantalla",
+  "settings.localToolsCuClick": "Clic",
+  "settings.localToolsCuMove": "Mover el puntero",
+  "settings.localToolsCuType": "Escribir texto",
+  "settings.localToolsCuKey": "Pulsar teclas",
+  "settings.localToolsCuScroll": "Desplazamiento",
   "settings.localToolsAddFolder": {
     "message": "Agregar carpeta",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -953,6 +953,14 @@
   },
   "settings.localToolsPreauthorizeAll": "Esihyväksy kaikki tietokoneen toiminnot",
   "settings.localToolsPreauthorizeHint": "Salli kerralla kuvakaappaus, napsautus, kirjoitus, näppäimet ja kaikki toiminnot ja pyydä tarvittavat järjestelmäoikeudet.",
+  "settings.localToolsCuActionsTitle": "Salli toiminnot erikseen",
+  "settings.localToolsCuActionsHint": "Ota käyttöön vain ne toiminnot, jotka sallit tekoälyn suorittaa kysymättä joka kerta. Kunkin voi peruuttaa täältä.",
+  "settings.localToolsCuScreenshot": "Kuvakaappaus",
+  "settings.localToolsCuClick": "Napsautus",
+  "settings.localToolsCuMove": "Siirrä osoitinta",
+  "settings.localToolsCuType": "Kirjoita tekstiä",
+  "settings.localToolsCuKey": "Näppäinpainallus",
+  "settings.localToolsCuScroll": "Vieritys",
   "settings.localToolsAddFolder": {
     "message": "Lisää kansio",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/fr/common.json
+++ b/src/i18n/fr/common.json
@@ -953,6 +953,14 @@
   },
   "settings.localToolsPreauthorizeAll": "Pré-autoriser toutes les actions de l'ordinateur",
   "settings.localToolsPreauthorizeHint": "Autorisez en une fois la capture d'écran, le clic, la saisie, les touches et toutes les actions, et déclenchez les autorisations système requises.",
+  "settings.localToolsCuActionsTitle": "Autoriser chaque action",
+  "settings.localToolsCuActionsHint": "N'activez que les actions que vous acceptez de laisser l'IA exécuter sans confirmation. Chacune reste révocable ici.",
+  "settings.localToolsCuScreenshot": "Capture d'écran",
+  "settings.localToolsCuClick": "Clic",
+  "settings.localToolsCuMove": "Déplacer le pointeur",
+  "settings.localToolsCuType": "Saisir du texte",
+  "settings.localToolsCuKey": "Touches",
+  "settings.localToolsCuScroll": "Défilement",
   "settings.localToolsAddFolder": {
     "message": "Ajouter un dossier",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/it/common.json
+++ b/src/i18n/it/common.json
@@ -953,6 +953,14 @@
   },
   "settings.localToolsPreauthorizeAll": "Pre-autorizza tutte le azioni del computer",
   "settings.localToolsPreauthorizeHint": "Consenti in una volta screenshot, clic, digitazione, tasti e tutte le azioni e richiedi le autorizzazioni di sistema necessarie.",
+  "settings.localToolsCuActionsTitle": "Consenti singole azioni",
+  "settings.localToolsCuActionsHint": "Attiva solo le azioni che vuoi far eseguire all'IA senza conferma ogni volta. Ognuna resta revocabile qui.",
+  "settings.localToolsCuScreenshot": "Screenshot",
+  "settings.localToolsCuClick": "Clic",
+  "settings.localToolsCuMove": "Sposta il puntatore",
+  "settings.localToolsCuType": "Digita testo",
+  "settings.localToolsCuKey": "Premi tasti",
+  "settings.localToolsCuScroll": "Scorri",
   "settings.localToolsAddFolder": {
     "message": "Aggiungi cartella",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/ja/common.json
+++ b/src/i18n/ja/common.json
@@ -953,6 +953,14 @@
   },
   "settings.localToolsPreauthorizeAll": "すべてのコンピュータ操作を事前に許可",
   "settings.localToolsPreauthorizeHint": "スクリーンショット、クリック、入力、キー操作などすべての操作を一度に許可し、必要なシステム権限を要求します。",
+  "settings.localToolsCuActionsTitle": "操作を個別に許可",
+  "settings.localToolsCuActionsHint": "毎回確認せずに AI に実行させてよい操作だけをオンにします。各項目はここでいつでも取り消せます。",
+  "settings.localToolsCuScreenshot": "スクリーンショット",
+  "settings.localToolsCuClick": "クリック",
+  "settings.localToolsCuMove": "ポインター移動",
+  "settings.localToolsCuType": "テキスト入力",
+  "settings.localToolsCuKey": "キー入力",
+  "settings.localToolsCuScroll": "スクロール",
   "settings.localToolsAddFolder": {
     "message": "フォルダを追加",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/ko/common.json
+++ b/src/i18n/ko/common.json
@@ -953,6 +953,14 @@
   },
   "settings.localToolsPreauthorizeAll": "모든 컴퓨터 작업 미리 허용",
   "settings.localToolsPreauthorizeHint": "스크린샷, 클릭, 입력, 키 등 모든 컴퓨터 작업을 한 번에 허용하고 필요한 시스템 권한을 요청합니다.",
+  "settings.localToolsCuActionsTitle": "개별 작업 허용",
+  "settings.localToolsCuActionsHint": "매번 확인 없이 AI가 실행하도록 허용할 작업만 켜세요. 각 항목은 여기서 취소할 수 있습니다.",
+  "settings.localToolsCuScreenshot": "스크린샷",
+  "settings.localToolsCuClick": "클릭",
+  "settings.localToolsCuMove": "포인터 이동",
+  "settings.localToolsCuType": "텍스트 입력",
+  "settings.localToolsCuKey": "키 입력",
+  "settings.localToolsCuScroll": "스크롤",
   "settings.localToolsAddFolder": {
     "message": "폴더 추가",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/pl/common.json
+++ b/src/i18n/pl/common.json
@@ -953,6 +953,14 @@
   },
   "settings.localToolsPreauthorizeAll": "Wstępnie zatwierdź wszystkie działania komputera",
   "settings.localToolsPreauthorizeHint": "Zezwól od razu na zrzut ekranu, kliknięcie, pisanie, klawisze i wszystkie działania oraz poproś o wymagane uprawnienia systemowe.",
+  "settings.localToolsCuActionsTitle": "Zezwól na pojedyncze akcje",
+  "settings.localToolsCuActionsHint": "Włącz tylko te akcje, które AI może wykonywać bez pytania za każdym razem. Każdą można tu cofnąć.",
+  "settings.localToolsCuScreenshot": "Zrzut ekranu",
+  "settings.localToolsCuClick": "Kliknięcie",
+  "settings.localToolsCuMove": "Przesuń wskaźnik",
+  "settings.localToolsCuType": "Wpisz tekst",
+  "settings.localToolsCuKey": "Naciśnij klawisze",
+  "settings.localToolsCuScroll": "Przewijanie",
   "settings.localToolsAddFolder": {
     "message": "Dodaj folder",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/pt/common.json
+++ b/src/i18n/pt/common.json
@@ -953,6 +953,14 @@
   },
   "settings.localToolsPreauthorizeAll": "Pré-aprovar todas as ações do computador",
   "settings.localToolsPreauthorizeHint": "Permite de uma vez captura de tela, clique, digitação, teclas e todas as ações, e solicita as permissões do sistema necessárias.",
+  "settings.localToolsCuActionsTitle": "Permitir ações individuais",
+  "settings.localToolsCuActionsHint": "Ative apenas as ações que você aceita que a IA execute sem perguntar toda vez. Cada uma continua revogável aqui.",
+  "settings.localToolsCuScreenshot": "Captura de tela",
+  "settings.localToolsCuClick": "Clique",
+  "settings.localToolsCuMove": "Mover o ponteiro",
+  "settings.localToolsCuType": "Digitar texto",
+  "settings.localToolsCuKey": "Pressionar teclas",
+  "settings.localToolsCuScroll": "Rolagem",
   "settings.localToolsAddFolder": {
     "message": "Adicionar pasta",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/ru/common.json
+++ b/src/i18n/ru/common.json
@@ -953,6 +953,14 @@
   },
   "settings.localToolsPreauthorizeAll": "Заранее разрешить все действия с компьютером",
   "settings.localToolsPreauthorizeHint": "Разрешите сразу снимок экрана, клик, ввод, клавиши и все действия и запросите необходимые системные разрешения.",
+  "settings.localToolsCuActionsTitle": "Разрешить отдельные действия",
+  "settings.localToolsCuActionsHint": "Включайте только те действия, которые вы готовы разрешить ИИ выполнять без запроса. Каждое можно отозвать здесь.",
+  "settings.localToolsCuScreenshot": "Снимок экрана",
+  "settings.localToolsCuClick": "Клик",
+  "settings.localToolsCuMove": "Переместить указатель",
+  "settings.localToolsCuType": "Ввод текста",
+  "settings.localToolsCuKey": "Нажатие клавиш",
+  "settings.localToolsCuScroll": "Прокрутка",
   "settings.localToolsAddFolder": {
     "message": "Добавить папку",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/sr/common.json
+++ b/src/i18n/sr/common.json
@@ -953,6 +953,14 @@
   },
   "settings.localToolsPreauthorizeAll": "Унапред дозволи све радње рачунара",
   "settings.localToolsPreauthorizeHint": "Дозволите одједном снимак екрана, клик, куцање, тастере и све радње и затражите потребне системске дозволе.",
+  "settings.localToolsCuActionsTitle": "Дозволи појединачне радње",
+  "settings.localToolsCuActionsHint": "Укључите само радње које дозвољавате да их вештачка интелигенција изврши без питања сваки пут. Свака се може опозвати овде.",
+  "settings.localToolsCuScreenshot": "Снимак екрана",
+  "settings.localToolsCuClick": "Клик",
+  "settings.localToolsCuMove": "Помери показивач",
+  "settings.localToolsCuType": "Унеси текст",
+  "settings.localToolsCuKey": "Притисни тастере",
+  "settings.localToolsCuScroll": "Померање",
   "settings.localToolsAddFolder": {
     "message": "Додај фасциклу",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -953,6 +953,14 @@
   },
   "settings.localToolsPreauthorizeAll": "Förgodkänn alla datoråtgärder",
   "settings.localToolsPreauthorizeHint": "Tillåt på en gång skärmbild, klick, skrivning, tangenter och alla åtgärder och begär nödvändiga systembehörigheter.",
+  "settings.localToolsCuActionsTitle": "Tillåt enskilda åtgärder",
+  "settings.localToolsCuActionsHint": "Aktivera bara de åtgärder du är bekväm med att låta AI:n utföra utan att fråga varje gång. Var och en kan återkallas här.",
+  "settings.localToolsCuScreenshot": "Skärmbild",
+  "settings.localToolsCuClick": "Klick",
+  "settings.localToolsCuMove": "Flytta pekaren",
+  "settings.localToolsCuType": "Skriv text",
+  "settings.localToolsCuKey": "Tryck på tangenter",
+  "settings.localToolsCuScroll": "Rulla",
   "settings.localToolsAddFolder": {
     "message": "Lägg till mapp",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/uk/common.json
+++ b/src/i18n/uk/common.json
@@ -953,6 +953,14 @@
   },
   "settings.localToolsPreauthorizeAll": "Попередньо дозволити всі дії з комп'ютером",
   "settings.localToolsPreauthorizeHint": "Дозволити одразу знімок екрана, клік, введення, клавіші та всі дії й запросити потрібні системні дозволи.",
+  "settings.localToolsCuActionsTitle": "Дозволити окремі дії",
+  "settings.localToolsCuActionsHint": "Вмикайте лише ті дії, які ви готові дозволити ШІ виконувати без запиту щоразу. Кожну можна відкликати тут.",
+  "settings.localToolsCuScreenshot": "Знімок екрана",
+  "settings.localToolsCuClick": "Клік",
+  "settings.localToolsCuMove": "Перемістити вказівник",
+  "settings.localToolsCuType": "Ввести текст",
+  "settings.localToolsCuKey": "Натискання клавіш",
+  "settings.localToolsCuScroll": "Прокручування",
   "settings.localToolsAddFolder": {
     "message": "Додати папку",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -953,6 +953,14 @@
   },
   "settings.localToolsPreauthorizeAll": "预先允许所有电脑操作",
   "settings.localToolsPreauthorizeHint": "一次性允许截图、点击、输入、按键等所有电脑操作，并触发所需的系统权限。",
+  "settings.localToolsCuActionsTitle": "逐项允许操作",
+  "settings.localToolsCuActionsHint": "只打开你愿意让 AI 免确认执行的操作，其余仍会逐次询问。每一项都可在此撤销。",
+  "settings.localToolsCuScreenshot": "截图",
+  "settings.localToolsCuClick": "点击",
+  "settings.localToolsCuMove": "移动指针",
+  "settings.localToolsCuType": "输入文字",
+  "settings.localToolsCuKey": "按键",
+  "settings.localToolsCuScroll": "滚动",
   "settings.localToolsAddFolder": {
     "message": "添加文件夹",
     "description": "选择要授权的文件夹的按钮。"

--- a/src/i18n/zh-TW/common.json
+++ b/src/i18n/zh-TW/common.json
@@ -953,6 +953,14 @@
   },
   "settings.localToolsPreauthorizeAll": "預先允許所有電腦操作",
   "settings.localToolsPreauthorizeHint": "一次性允許截圖、點擊、輸入、按鍵等所有電腦操作，並觸發所需的系統權限。",
+  "settings.localToolsCuActionsTitle": "逐項允許操作",
+  "settings.localToolsCuActionsHint": "只開啟你願意讓 AI 免確認執行的操作，其餘仍會逐次詢問。每一項都可在此撤銷。",
+  "settings.localToolsCuScreenshot": "截圖",
+  "settings.localToolsCuClick": "點擊",
+  "settings.localToolsCuMove": "移動指標",
+  "settings.localToolsCuType": "輸入文字",
+  "settings.localToolsCuKey": "按鍵",
+  "settings.localToolsCuScroll": "捲動",
   "settings.localToolsAddFolder": {
     "message": "新增資料夾",
     "description": "Button to pick a folder to authorize."

--- a/src/plugins/font-awesome.ts
+++ b/src/plugins/font-awesome.ts
@@ -147,7 +147,12 @@ import {
   faTerminal as faSolidTerminal,
   faFolder as faSolidFolder,
   faFolderOpen as faSolidFolderOpen,
-  faFile as faSolidFile
+  faFile as faSolidFile,
+  faCamera as faSolidCamera,
+  faArrowPointer as faSolidArrowPointer,
+  faUpDownLeftRight as faSolidUpDownLeftRight,
+  faKeyboard as faSolidKeyboard,
+  faArrowsUpDown as faSolidArrowsUpDown
 } from '@fortawesome/free-solid-svg-icons';
 // add icons
 library.add(faSolidEllipsis);
@@ -294,3 +299,8 @@ library.add(faSolidFileExport);
 library.add(faSolidFolder);
 library.add(faSolidFolderOpen);
 library.add(faSolidFile);
+library.add(faSolidCamera);
+library.add(faSolidArrowPointer);
+library.add(faSolidUpDownLeftRight);
+library.add(faSolidKeyboard);
+library.add(faSolidArrowsUpDown);

--- a/src/utils/desktop.ts
+++ b/src/utils/desktop.ts
@@ -88,10 +88,14 @@ export interface LocalExecBridge {
   /** Subscribe to the global panic hotkey forcing Computer Use off. Returns an
    * unsubscribe fn. Undefined on older preloads. */
   onComputerUseDisabled?(cb: () => void): () => void;
-  /** Pre-approve every computer.* action (persistent always-allow), enable
-   * Computer Use, and trigger the macOS Screen Recording / Accessibility
-   * prompts. Returns the new grant list + permission status. */
-  preauthorizeComputerUse?(): Promise<{
+  /** Names + descriptions of the computer.* tools, for the per-action toggle
+   * list. Undefined on older preloads. */
+  computerTools?(): Promise<{ name: string; description: string }[]>;
+  /** Pre-approve computer.* actions (persistent always-allow), enable Computer
+   * Use, and trigger the macOS Screen Recording / Accessibility prompts. Pass a
+   * subset of tool names to allow only those; omit for every action. Returns the
+   * new grant list + permission status. */
+  preauthorizeComputerUse?(names?: string[]): Promise<{
     grants: string[];
     perm: { mac: boolean; fullDisk: boolean; screen: string; mic: string; accessibility: boolean };
     computerUse: boolean;


### PR DESCRIPTION
## What

Settings → Local Tools → **Computer Use** had a single **"Pre-approve all computer actions"** button — an all-or-nothing grant with the (frankly absurd) hint *"Allow screenshot, click, type, key and every computer action at once."* You couldn't say *"let the AI screenshot freely but always ask before it types."*

This adds an **individual always-allow toggle per computer action**:

| Toggle | Tool |
|---|---|
| Screenshot | `computer.screenshot` |
| Click | `computer.click` |
| Move pointer | `computer.move` |
| Type text | `computer.type` |
| Press keys | `computer.key` |
| Scroll | `computer.scroll` |

Turning one **ON** pre-approves just that action (persistent always-allow), enables Computer Use, and triggers the macOS Screen Recording / Accessibility prompts. **OFF** revokes that single grant, re-arming its per-call confirmation. The old "allow all" action is kept as a small convenience button beside the list.

## How

- `registry.computerToolSpecs()` — expose name + description for the UI.
- `local.computerUse.tools` IPC lists the actions; `local.computerUse.preauthorize` now takes an **optional name subset** (grants only those; native confirm dialog wording adapts) and still grants ALL when called with no args.
- `preload` + `LocalExecBridge` types: `computerTools()` and `preauthorizeComputerUse(names?)`.
- `LocalTools.vue`: per-action toggle rows (icon + label + tool description + switch). `computer.*` grants are filtered out of the generic "always-allowed" list so they aren't shown twice.
- i18n: 8 new keys added to **all 18 locales** — `check_i18n_coverage.py` green.

## Security

Unchanged threat model. Each per-action grant is name-scoped (`grantKey` returns the bare `computer.<x>` name) and revocable. Enabling a toggle still goes through the **native main-process confirm dialog**, so a compromised/XSS'd renderer cannot silently self-grant screen + input control. The panic hotkey (Cmd/Ctrl+Alt+Shift+P) still hard-disables everything.

## Verification

- `vue-tsc -b` + `vite build` (desktop) clean; `tsc -p electron/tsconfig.json` clean; eslint clean on `src/*`.
- `python3 scripts/check_i18n_coverage.py` → `17 locale(s) × 44 namespace(s) all match zh-CN`.
- Built a local arm64 `.app` (app.asar 86,587 entries, `codesign -v --deep --strict` OK), installed to /Applications, launched — the per-action toggle list renders in Settings → Local Tools.

## 🤖 对抗评审

Self-review: toggle ON→`preauthorizeComputerUse([name])` (native confirm, name-filtered against `registry.computerToolNames()` so no fs/shell widening), OFF→`grants.revoke(name)`; grant-key parse handles the colon-free computer names; grants list de-dups computer.*; i18n keys plain-string but backfilled to all locales per repo convention; FA icons registered. **VERDICT: CLEAN** (1 round).