### PR TITLE
feat(desktop): per-tool always-allow toggles for built-in local tools

### DIFF
--- a/change/@acedatacloud-nexior-6d5e552b-f012-4bed-b622-3fcb78004cd7.json
+++ b/change/@acedatacloud-nexior-6d5e552b-f012-4bed-b622-3fcb78004cd7.json
@@ -1,0 +1,1 @@
+{"type":"minor","comment":"Local Tools: per-tool 'always allow (any input)' toggles for builtin tools (shell.run_command, fs.*) with native confirm + risk warning","packageName":"@acedatacloud/nexior","email":"dev@acedata.cloud","dependentChangeType":"patch"}

--- a/electron/local/consent.ts
+++ b/electron/local/consent.ts
@@ -91,6 +91,14 @@ export async function consentOk(inv: ToolInvoke, win: BrowserWindow | null, muta
   // SESSION_ROOTS entry for the run. (Grants created before this change have no
   // persisted root, so they re-prompt once — which then persists it.)
   if ((load().grants ?? []).includes(gk)) return true; // persistent always-allow
+  // Tool-wide always-allow: a grant stored as the BARE tool name (no `:input`)
+  // means "run this tool for ANY input without asking" — opted in per-tool from
+  // Settings → Local Tools. For computer.* the grant key already IS the bare
+  // name (handled above); this line extends the same name-scoping to builtin
+  // tools (shell.run_command, fs.*). fs.* still enforces its ROOTS boundary in
+  // fs.ts, so a tool-wide fs grant can't escape the authorized folders; a
+  // tool-wide shell grant is unrestricted by design (the Settings toggle warns).
+  if (inv.name !== gk && (load().grants ?? []).includes(inv.name)) return true;
   // Non-computer mutating tools still re-confirm; computer.* honors its (name-
   // scoped) session grant even though it mutates — that is the whole point of
   // "Allow for session" for a screen-control loop.
@@ -151,6 +159,18 @@ export function grantComputerTools(names: string[]): string[] {
   const cfg = load();
   const grants = new Set(cfg.grants ?? []);
   for (const n of names) if (n.startsWith('computer.')) grants.add(n);
+  save({ ...cfg, grants: [...grants] });
+  return [...grants];
+}
+
+// Persist a tool-wide "Always allow" grant as the BARE tool name (any input) for
+// the given builtin tools — used by the per-tool always-allow toggles in
+// Settings. The caller (ipc) MUST validate each name is a real registered
+// builtin tool so this can never grant an unknown name by accident.
+export function grantToolsWide(names: string[]): string[] {
+  const cfg = load();
+  const grants = new Set(cfg.grants ?? []);
+  for (const n of names) grants.add(n);
   save({ ...cfg, grants: [...grants] });
   return [...grants];
 }

--- a/electron/local/ipc.ts
+++ b/electron/local/ipc.ts
@@ -1,6 +1,6 @@
 import { ipcMain, BrowserWindow, dialog } from 'electron';
 import { APP_ORIGIN } from '../protocol';
-import { consentOk, listGrants, revokeGrant, clearGrants, resetComputerSessionConsent, grantComputerTools } from './consent';
+import { consentOk, listGrants, revokeGrant, clearGrants, resetComputerSessionConsent, grantComputerTools, grantToolsWide } from './consent';
 import { registry } from './registry';
 import { load, save } from './config';
 import { setRoots } from './fs';
@@ -116,6 +116,41 @@ export function registerLocalExec(getWin: () => BrowserWindow | null): void {
   ipcMain.handle('local.computerUse.tools', (e) => {
     gate(e);
     return registry.computerToolSpecs();
+  });
+
+  // Builtin (fs/shell) tool specs, for the per-tool always-allow toggles.
+  ipcMain.handle('local.tools.builtin', (e) => {
+    gate(e);
+    return registry.builtinToolSpecs();
+  });
+
+  // Tool-wide "Always allow" for a builtin tool (shell.run_command, fs.*): persist
+  // a bare-name grant so the tool runs for ANY input without a per-call prompt.
+  // Native (main-process) confirm — a compromised/XSS'd renderer must NOT be able
+  // to silently give itself prompt-less shell/file access; only the user clicking
+  // this dialog can. Rejects non-builtin names (no computer/MCP/unknown widening).
+  ipcMain.handle('local.grants.grantToolWide', async (e, name: string) => {
+    gate(e);
+    if (typeof name !== 'string' || !registry.isBuiltinTool(name)) return { grants: listGrants(), ok: false };
+    const win = getWin();
+    const dangerous = name === 'shell.run_command' || name === 'fs.write_file';
+    const detail =
+      name === 'shell.run_command'
+        ? 'This lets the AI run ANY shell command on this machine WITHOUT asking each time — full access to your files and system. Only enable if you fully trust this. Revoke anytime in Settings → Local Tools.'
+        : name === 'fs.write_file'
+          ? 'This lets the AI write files WITHOUT asking each time (still limited to your authorized folders). Revoke anytime in Settings → Local Tools.'
+          : `This lets the AI run ${name} WITHOUT asking each time (still limited to your authorized folders). Revoke anytime in Settings → Local Tools.`;
+    const confirm = {
+      type: 'warning' as const,
+      buttons: [dangerous ? 'Allow every time (risky)' : 'Allow every time', 'Cancel'],
+      defaultId: 1,
+      cancelId: 1,
+      message: `Always allow ${name} for any input?`,
+      detail
+    };
+    const { response } = win ? await dialog.showMessageBox(win, confirm) : await dialog.showMessageBox(confirm);
+    if (response !== 0) return { grants: listGrants(), ok: false };
+    return { grants: grantToolsWide([name]), ok: true };
   });
 
   // Pre-approve computer actions: turn Computer Use on, persist an always-allow

--- a/electron/local/registry.ts
+++ b/electron/local/registry.ts
@@ -57,6 +57,18 @@ class Registry {
     return COMPUTER_TOOLS.map((s) => ({ name: s.name, description: s.description }));
   }
 
+  // Builtin (fs/shell) tool specs for the Settings per-tool always-allow toggles.
+  // `mutates` lets the UI flag the dangerous ones (shell/write) distinctly.
+  builtinToolSpecs(): { name: string; description: string; mutates: boolean }[] {
+    return BUILTIN.map((s) => ({ name: s.name, description: s.description, mutates: s.mutates }));
+  }
+
+  // Whether a name is a registered builtin tool — used to validate a tool-wide
+  // grant request so it can never persist an unknown/MCP/computer name.
+  isBuiltinTool(name: string): boolean {
+    return BUILTIN.some((s) => s.name === name);
+  }
+
   async boot(servers: McpServerConf[]): Promise<void> {
     for (const s of servers) {
       try {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -81,8 +81,14 @@ contextBridge.exposeInMainWorld('localExec', {
   grants: {
     list: (): Promise<string[]> => ipcRenderer.invoke('local.grants.list'),
     revoke: (key: string): Promise<boolean> => ipcRenderer.invoke('local.grants.revoke', key),
-    clear: (): Promise<boolean> => ipcRenderer.invoke('local.grants.clear')
+    clear: (): Promise<boolean> => ipcRenderer.invoke('local.grants.clear'),
+    // Tool-wide always-allow for a builtin tool (native confirm in main).
+    grantToolWide: (name: string): Promise<{ grants: string[]; ok: boolean }> =>
+      ipcRenderer.invoke('local.grants.grantToolWide', name)
   },
+  // Builtin (fs/shell) tool specs for the per-tool always-allow toggles.
+  builtinTools: (): Promise<{ name: string; description: string; mutates: boolean }[]> =>
+    ipcRenderer.invoke('local.tools.builtin'),
   // Fired when the global panic hotkey forces Computer Use off, so the Settings
   // toggle reflects reality and a later Save can't silently re-enable it.
   onComputerUseDisabled: (cb: () => void): (() => void) => {

--- a/src/components/setting/LocalTools.vue
+++ b/src/components/setting/LocalTools.vue
@@ -58,6 +58,34 @@
         </ul>
       </section>
 
+      <!-- Built-in tools: per-tool "always allow (any input)" toggles -->
+      <section v-if="builtinTools.length">
+        <div class="section-head">
+          <h3>{{ $t('common.settings.localToolsBuiltinTitle') }}</h3>
+        </div>
+        <p class="muted">{{ $t('common.settings.localToolsBuiltinHint') }}</p>
+        <ul class="rows">
+          <li v-for="t in builtinTools" :key="t.name" class="row">
+            <font-awesome-icon :icon="builtinIcon(t.name)" class="row-icon" />
+            <span class="cu-action">
+              <span class="cu-action-name">
+                <code class="grant-name">{{ t.name }}</code>
+                <el-tag v-if="t.name === 'shell.run_command'" size="small" type="danger" effect="plain">{{
+                  $t('common.settings.localToolsBuiltinRisky')
+                }}</el-tag>
+              </span>
+              <span class="cu-action-desc">{{ t.description }}</span>
+            </span>
+            <el-switch
+              :model-value="toolGrants[t.name] === true"
+              :loading="builtinBusy === t.name"
+              :disabled="!!builtinBusy"
+              @change="(v: string | number | boolean) => onToggleBuiltinTool(t.name, v)"
+            />
+          </li>
+        </ul>
+      </section>
+
       <!-- Computer Use (opt-in: screen capture + mouse/keyboard control) -->
       <section>
         <div class="section-head">
@@ -164,6 +192,10 @@ export default defineComponent({
       computerTools: [] as { name: string; description: string }[],
       computerGrants: {} as Record<string, boolean>,
       cuBusy: null as null | string,
+      // Builtin (fs/shell) tool catalog + per-tool tool-wide always-allow state.
+      builtinTools: [] as { name: string; description: string; mutates: boolean }[],
+      toolGrants: {} as Record<string, boolean>,
+      builtinBusy: null as null | string,
       savingCU: false,
       preauthorizing: false,
       saving: false,
@@ -184,6 +216,7 @@ export default defineComponent({
     this.computerUse = cfg.computerUse === true;
     this.tools = (await ex.listTools()).map((t) => t.name);
     this.computerTools = (await ex.computerTools?.()) ?? [];
+    this.builtinTools = (await ex.builtinTools?.()) ?? [];
     const s = await ex.perm?.status();
     if (s?.mac) this.perm = s;
     await this.loadGrants();
@@ -209,10 +242,18 @@ export default defineComponent({
       // their own per-action toggles, so split them out of the generic
       // "always-allowed" list to avoid showing each one twice.
       const cuGrants: Record<string, boolean> = {};
+      const toolWide: Record<string, boolean> = {};
+      const builtinNames = new Set(this.builtinTools.map((t) => t.name));
       const rows: GrantRow[] = [];
       for (const k of keys) {
         if (k.startsWith('computer.') && !k.includes(':')) {
           cuGrants[k] = true;
+          continue;
+        }
+        // Bare-name (no `:input`) grant for a builtin tool = tool-wide always-allow,
+        // surfaced as its own toggle → hide from the generic list too.
+        if (!k.includes(':') && builtinNames.has(k)) {
+          toolWide[k] = true;
           continue;
         }
         // key shape: `<tool.name>:<json input>`. The input is always JSON, so
@@ -223,6 +264,7 @@ export default defineComponent({
         rows.push({ key: k, name: idx >= 0 ? k.slice(0, idx) : k, input: idx >= 0 ? k.slice(idx + 1) : '' });
       }
       this.computerGrants = cuGrants;
+      this.toolGrants = toolWide;
       this.grants = rows;
     },
     async addFolder() {
@@ -316,6 +358,35 @@ export default defineComponent({
     cuSuffix(name: string): string {
       const s = name.replace(/^computer\./, '');
       return s.charAt(0).toUpperCase() + s.slice(1);
+    },
+    // Per-tool tool-wide always-allow for a builtin tool. ON pre-approves the
+    // tool for ANY input (native confirm in main; the switch reverts if the user
+    // cancels). OFF revokes the bare-name grant, re-arming the per-call prompt.
+    async onToggleBuiltinTool(name: string, val: string | number | boolean) {
+      const ex = localExec();
+      if (!ex?.grants) return;
+      this.builtinBusy = name;
+      try {
+        if (val === true) {
+          const r = await ex.grants.grantToolWide?.(name);
+          // Cancelled native dialog → ok:false → leave the toggle off.
+          if (!r?.ok) {
+            this.toolGrants = { ...this.toolGrants, [name]: false };
+          }
+        } else {
+          await ex.grants.revoke(name);
+        }
+        await this.loadGrants();
+      } finally {
+        this.builtinBusy = null;
+      }
+    },
+    builtinIcon(name: string): string {
+      if (name === 'shell.run_command') return 'fa-solid fa-terminal';
+      if (name === 'fs.write_file') return 'fa-solid fa-pen';
+      if (name === 'fs.read_file') return 'fa-solid fa-file';
+      if (name === 'fs.list_dir') return 'fa-solid fa-folder';
+      return 'fa-solid fa-shield-halved';
     },
     async revoke(key: string) {
       await localExec()?.grants?.revoke(key);

--- a/src/i18n/ar/common.json
+++ b/src/i18n/ar/common.json
@@ -961,6 +961,9 @@
   "settings.localToolsCuType": "كتابة نص",
   "settings.localToolsCuKey": "ضغط المفاتيح",
   "settings.localToolsCuScroll": "تمرير",
+  "settings.localToolsBuiltinTitle": "الأدوات المدمجة",
+  "settings.localToolsBuiltinHint": "فعّل أداة ليشغّلها الذكاء الاصطناعي دون سؤال في كل مرة. يمكن لـ Shell تنفيذ أي أمر على هذا الجهاز — فعّله فقط إذا كنت تثق. تبقى أدوات الملفات محصورة في مجلداتك المصرّح بها.",
+  "settings.localToolsBuiltinRisky": "وصول كامل",
   "settings.localToolsAddFolder": {
     "message": "إضافة مجلد",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/de/common.json
+++ b/src/i18n/de/common.json
@@ -961,6 +961,9 @@
   "settings.localToolsCuType": "Text eingeben",
   "settings.localToolsCuKey": "Tasten",
   "settings.localToolsCuScroll": "Scrollen",
+  "settings.localToolsBuiltinTitle": "Integrierte Tools",
+  "settings.localToolsBuiltinHint": "Aktivieren Sie ein Tool, damit die KI es ohne Nachfrage ausführt. Shell kann jeden Befehl auf diesem Rechner ausführen — nur bei Vertrauen aktivieren. Datei-Tools bleiben auf Ihre freigegebenen Ordner beschränkt.",
+  "settings.localToolsBuiltinRisky": "Vollzugriff",
   "settings.localToolsAddFolder": {
     "message": "Ordner hinzufügen",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/el/common.json
+++ b/src/i18n/el/common.json
@@ -961,6 +961,9 @@
   "settings.localToolsCuType": "Πληκτρολόγηση κειμένου",
   "settings.localToolsCuKey": "Πάτημα πλήκτρων",
   "settings.localToolsCuScroll": "Κύλιση",
+  "settings.localToolsBuiltinTitle": "Ενσωματωμένα εργαλεία",
+  "settings.localToolsBuiltinHint": "Ενεργοποιήστε ένα εργαλείο ώστε η AI να το εκτελεί χωρίς ερώτηση. Το Shell μπορεί να εκτελέσει οποιαδήποτε εντολή σε αυτό το μηχάνημα — ενεργοποιήστε το μόνο αν εμπιστεύεστε. Τα εργαλεία αρχείων παραμένουν εντός των εγκεκριμένων φακέλων.",
+  "settings.localToolsBuiltinRisky": "Πλήρης πρόσβαση",
   "settings.localToolsAddFolder": {
     "message": "Προσθήκη φακέλου",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -941,6 +941,9 @@
   "settings.localToolsCuType": "Type text",
   "settings.localToolsCuKey": "Press keys",
   "settings.localToolsCuScroll": "Scroll",
+  "settings.localToolsBuiltinTitle": "Built-in tools",
+  "settings.localToolsBuiltinHint": "Turn on a tool to let the AI run it without asking each time. Shell can run any command on this machine — enable only if you trust it. File tools stay limited to your authorized folders.",
+  "settings.localToolsBuiltinRisky": "Full access",
   "settings.localToolsAddFolder": {
     "message": "Add folder",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/es/common.json
+++ b/src/i18n/es/common.json
@@ -961,6 +961,9 @@
   "settings.localToolsCuType": "Escribir texto",
   "settings.localToolsCuKey": "Pulsar teclas",
   "settings.localToolsCuScroll": "Desplazamiento",
+  "settings.localToolsBuiltinTitle": "Herramientas integradas",
+  "settings.localToolsBuiltinHint": "Activa una herramienta para que la IA la ejecute sin preguntar. Shell puede ejecutar cualquier comando en este equipo; actívalo solo si confías. Las herramientas de archivos siguen limitadas a tus carpetas autorizadas.",
+  "settings.localToolsBuiltinRisky": "Acceso total",
   "settings.localToolsAddFolder": {
     "message": "Agregar carpeta",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -961,6 +961,9 @@
   "settings.localToolsCuType": "Kirjoita tekstiä",
   "settings.localToolsCuKey": "Näppäinpainallus",
   "settings.localToolsCuScroll": "Vieritys",
+  "settings.localToolsBuiltinTitle": "Sisäänrakennetut työkalut",
+  "settings.localToolsBuiltinHint": "Ota työkalu käyttöön, niin tekoäly suorittaa sen kysymättä joka kerta. Shell voi suorittaa minkä tahansa komennon tällä koneella — ota käyttöön vain jos luotat. Tiedostotyökalut pysyvät sallituissa kansioissasi.",
+  "settings.localToolsBuiltinRisky": "Täysi käyttöoikeus",
   "settings.localToolsAddFolder": {
     "message": "Lisää kansio",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/fr/common.json
+++ b/src/i18n/fr/common.json
@@ -961,6 +961,9 @@
   "settings.localToolsCuType": "Saisir du texte",
   "settings.localToolsCuKey": "Touches",
   "settings.localToolsCuScroll": "Défilement",
+  "settings.localToolsBuiltinTitle": "Outils intégrés",
+  "settings.localToolsBuiltinHint": "Activez un outil pour que l'IA l'exécute sans confirmation. Shell peut exécuter n'importe quelle commande sur cette machine — n'activez que si vous avez confiance. Les outils de fichiers restent limités à vos dossiers autorisés.",
+  "settings.localToolsBuiltinRisky": "Accès total",
   "settings.localToolsAddFolder": {
     "message": "Ajouter un dossier",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/it/common.json
+++ b/src/i18n/it/common.json
@@ -961,6 +961,9 @@
   "settings.localToolsCuType": "Digita testo",
   "settings.localToolsCuKey": "Premi tasti",
   "settings.localToolsCuScroll": "Scorri",
+  "settings.localToolsBuiltinTitle": "Strumenti integrati",
+  "settings.localToolsBuiltinHint": "Attiva uno strumento per farlo eseguire all'IA senza conferma. Shell può eseguire qualsiasi comando su questo computer: attivalo solo se ti fidi. Gli strumenti file restano limitati alle cartelle autorizzate.",
+  "settings.localToolsBuiltinRisky": "Accesso completo",
   "settings.localToolsAddFolder": {
     "message": "Aggiungi cartella",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/ja/common.json
+++ b/src/i18n/ja/common.json
@@ -961,6 +961,9 @@
   "settings.localToolsCuType": "テキスト入力",
   "settings.localToolsCuKey": "キー入力",
   "settings.localToolsCuScroll": "スクロール",
+  "settings.localToolsBuiltinTitle": "組み込みツール",
+  "settings.localToolsBuiltinHint": "ツールをオンにすると、AI は毎回確認せずに実行できます。Shell はこのマシンで任意のコマンドを実行できます。信頼できる場合のみ有効にしてください。ファイルツールは許可済みフォルダーに限定されます。",
+  "settings.localToolsBuiltinRisky": "フルアクセス",
   "settings.localToolsAddFolder": {
     "message": "フォルダを追加",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/ko/common.json
+++ b/src/i18n/ko/common.json
@@ -961,6 +961,9 @@
   "settings.localToolsCuType": "텍스트 입력",
   "settings.localToolsCuKey": "키 입력",
   "settings.localToolsCuScroll": "스크롤",
+  "settings.localToolsBuiltinTitle": "기본 도구",
+  "settings.localToolsBuiltinHint": "도구를 켜면 AI가 매번 확인 없이 실행합니다. Shell은 이 컴퓨터에서 모든 명령을 실행할 수 있으니 신뢰하는 경우에만 켜세요. 파일 도구는 승인된 폴더로 제한됩니다.",
+  "settings.localToolsBuiltinRisky": "전체 액세스",
   "settings.localToolsAddFolder": {
     "message": "폴더 추가",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/pl/common.json
+++ b/src/i18n/pl/common.json
@@ -961,6 +961,9 @@
   "settings.localToolsCuType": "Wpisz tekst",
   "settings.localToolsCuKey": "Naciśnij klawisze",
   "settings.localToolsCuScroll": "Przewijanie",
+  "settings.localToolsBuiltinTitle": "Narzędzia wbudowane",
+  "settings.localToolsBuiltinHint": "Włącz narzędzie, aby AI uruchamiało je bez pytania. Shell może wykonać dowolne polecenie na tym komputerze — włącz tylko jeśli ufasz. Narzędzia plików pozostają ograniczone do autoryzowanych folderów.",
+  "settings.localToolsBuiltinRisky": "Pełny dostęp",
   "settings.localToolsAddFolder": {
     "message": "Dodaj folder",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/pt/common.json
+++ b/src/i18n/pt/common.json
@@ -961,6 +961,9 @@
   "settings.localToolsCuType": "Digitar texto",
   "settings.localToolsCuKey": "Pressionar teclas",
   "settings.localToolsCuScroll": "Rolagem",
+  "settings.localToolsBuiltinTitle": "Ferramentas integradas",
+  "settings.localToolsBuiltinHint": "Ative uma ferramenta para a IA executá-la sem perguntar. O Shell pode executar qualquer comando nesta máquina — ative apenas se confiar. As ferramentas de arquivo continuam limitadas às suas pastas autorizadas.",
+  "settings.localToolsBuiltinRisky": "Acesso total",
   "settings.localToolsAddFolder": {
     "message": "Adicionar pasta",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/ru/common.json
+++ b/src/i18n/ru/common.json
@@ -961,6 +961,9 @@
   "settings.localToolsCuType": "Ввод текста",
   "settings.localToolsCuKey": "Нажатие клавиш",
   "settings.localToolsCuScroll": "Прокрутка",
+  "settings.localToolsBuiltinTitle": "Встроенные инструменты",
+  "settings.localToolsBuiltinHint": "Включите инструмент, чтобы ИИ выполнял его без запроса. Shell может выполнить любую команду на этом компьютере — включайте только при доверии. Файловые инструменты остаются в пределах разрешённых папок.",
+  "settings.localToolsBuiltinRisky": "Полный доступ",
   "settings.localToolsAddFolder": {
     "message": "Добавить папку",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/sr/common.json
+++ b/src/i18n/sr/common.json
@@ -961,6 +961,9 @@
   "settings.localToolsCuType": "Унеси текст",
   "settings.localToolsCuKey": "Притисни тастере",
   "settings.localToolsCuScroll": "Померање",
+  "settings.localToolsBuiltinTitle": "Уграђени алати",
+  "settings.localToolsBuiltinHint": "Укључите алат да га вештачка интелигенција покреће без питања. Shell може извршити било коју команду на овом рачунару — укључите само ако верујете. Алати за датотеке остају ограничени на одобрене фасцикле.",
+  "settings.localToolsBuiltinRisky": "Пун приступ",
   "settings.localToolsAddFolder": {
     "message": "Додај фасциклу",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -961,6 +961,9 @@
   "settings.localToolsCuType": "Skriv text",
   "settings.localToolsCuKey": "Tryck på tangenter",
   "settings.localToolsCuScroll": "Rulla",
+  "settings.localToolsBuiltinTitle": "Inbyggda verktyg",
+  "settings.localToolsBuiltinHint": "Aktivera ett verktyg så att AI:n kör det utan att fråga varje gång. Shell kan köra vilket kommando som helst på den här datorn — aktivera bara om du litar på det. Filverktyg begränsas till dina godkända mappar.",
+  "settings.localToolsBuiltinRisky": "Full åtkomst",
   "settings.localToolsAddFolder": {
     "message": "Lägg till mapp",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/uk/common.json
+++ b/src/i18n/uk/common.json
@@ -961,6 +961,9 @@
   "settings.localToolsCuType": "Ввести текст",
   "settings.localToolsCuKey": "Натискання клавіш",
   "settings.localToolsCuScroll": "Прокручування",
+  "settings.localToolsBuiltinTitle": "Вбудовані інструменти",
+  "settings.localToolsBuiltinHint": "Увімкніть інструмент, щоб ШІ виконував його без запиту. Shell може виконати будь-яку команду на цьому комп'ютері — вмикайте лише за наявності довіри. Файлові інструменти залишаються в межах дозволених папок.",
+  "settings.localToolsBuiltinRisky": "Повний доступ",
   "settings.localToolsAddFolder": {
     "message": "Додати папку",
     "description": "Button to pick a folder to authorize."

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -961,6 +961,9 @@
   "settings.localToolsCuType": "输入文字",
   "settings.localToolsCuKey": "按键",
   "settings.localToolsCuScroll": "滚动",
+  "settings.localToolsBuiltinTitle": "内置工具",
+  "settings.localToolsBuiltinHint": "打开某个工具后，AI 调用它将不再逐次询问。Shell 可执行本机任意命令——请谨慎开启；文件工具仍限制在你已授权的文件夹内。",
+  "settings.localToolsBuiltinRisky": "完全访问",
   "settings.localToolsAddFolder": {
     "message": "添加文件夹",
     "description": "选择要授权的文件夹的按钮。"

--- a/src/i18n/zh-TW/common.json
+++ b/src/i18n/zh-TW/common.json
@@ -961,6 +961,9 @@
   "settings.localToolsCuType": "輸入文字",
   "settings.localToolsCuKey": "按鍵",
   "settings.localToolsCuScroll": "捲動",
+  "settings.localToolsBuiltinTitle": "內建工具",
+  "settings.localToolsBuiltinHint": "開啟某個工具後，AI 呼叫它將不再逐次詢問。Shell 可執行本機任意命令——請謹慎開啟；檔案工具仍限制在你已授權的資料夾內。",
+  "settings.localToolsBuiltinRisky": "完全存取",
   "settings.localToolsAddFolder": {
     "message": "新增資料夾",
     "description": "Button to pick a folder to authorize."

--- a/src/utils/desktop.ts
+++ b/src/utils/desktop.ts
@@ -84,7 +84,12 @@ export interface LocalExecBridge {
     list(): Promise<string[]>;
     revoke(key: string): Promise<boolean>;
     clear(): Promise<boolean>;
+    /** Tool-wide always-allow for a builtin tool (native confirm in main). */
+    grantToolWide?(name: string): Promise<{ grants: string[]; ok: boolean }>;
   };
+  /** Builtin (fs/shell) tool specs for the per-tool always-allow toggles.
+   * Undefined on older preloads. */
+  builtinTools?(): Promise<{ name: string; description: string; mutates: boolean }[]>;
   /** Subscribe to the global panic hotkey forcing Computer Use off. Returns an
    * unsubscribe fn. Undefined on older preloads. */
   onComputerUseDisabled?(cb: () => void): () => void;


### PR DESCRIPTION
## What

Follow-up to #1105 (per-action Computer Use toggles). Settings → Local Tools now also has an **individual \"always allow (any input)\" toggle per built-in local tool**:

| Toggle | Tool | Scope |
|---|---|---|
| shell.run_command | run a local command | ⚠️ **full access** — any command |
| fs.write_file | write a file | limited to authorized folders |
| fs.read_file | read a file | limited to authorized folders |
| fs.list_dir | list a directory | limited to authorized folders |

This answers the request \"shell.run_command 这样的，是不是也可以放到 setting 里面单独打开\" — you can pre-approve e.g. `shell.run_command` once instead of confirming every call.

## How

- **consent.ts**: a grant stored as the **bare tool name** (no `:input`) now means \"run this tool for any input without asking\". `computer.*` already worked this way (its grant key IS the bare name); this extends the same name-scoping to built-in tools:
  ```ts
  if (inv.name !== gk && (load().grants ?? []).includes(inv.name)) return true;
  ```
  `fs.*` still enforces its ROOTS boundary in `fs.ts`, so a tool-wide fs grant **cannot escape the authorized folders**. `shell.run_command` is unrestricted by design — the UI flags it as full access and the confirm dialog warns.
- **registry**: `builtinToolSpecs()` + `isBuiltinTool()` (name validation).
- **ipc**: `local.tools.builtin` lists them; `local.grants.grantToolWide(name)` persists a bare-name grant behind a **native main-process confirm** (a compromised/XSS'd renderer cannot self-grant shell/file access) with a strong warning for shell. Rejects any non-builtin name.
- **preload / LocalExecBridge types**: `builtinTools()` + `grants.grantToolWide(name)`.
- **LocalTools.vue**: \"Built-in tools\" section; ON grants tool-wide (reverts if the native dialog is cancelled), OFF revokes. Bare-name built-in grants are hidden from the generic \"always-allowed\" list so they aren't shown twice.
- **i18n**: 3 keys across all 18 locales — `check_i18n_coverage.py` green.

## Security

The tool-wide grant is opt-in and always goes through the native confirm dialog; `shell.run_command` shows an explicit full-access warning. All grants revocable anytime (toggle off, the generic Revoke, or the panic hotkey path for computer.*). No input-scoped fs/shell grant is widened implicitly — only the exact tool you toggle gets a name-scoped grant.

## Verification

- `vue-tsc -b` + `vite build` (desktop) clean; `tsc -p electron/tsconfig.json` clean; eslint clean on `src/*`.
- `python3 scripts/check_i18n_coverage.py` → `17 locale(s) × 44 namespace(s) all match zh-CN`.
- Built local arm64 `.app` (app.asar 86,587 entries, `codesign -v --deep --strict` OK), installed to /Applications, launched — the \"Built-in tools\" toggles render and gate correctly.

## 🤖 对抗评审

Self-review: bare-name grant check is guarded by `inv.name !== gk` (no double-eval for computer.*); `grantToolWide` validates `isBuiltinTool` so it can never persist a computer/MCP/unknown name; native confirm blocks silent self-grant; fs ROOTS boundary still applies (only shell is unrestricted, clearly warned); grants list de-dups bare-name built-in grants; i18n backfilled to all locales. **VERDICT: CLEAN** (1 round).

> Note: this is a UX/consent convenience. It does NOT change the separate aichat2 client-tool resume issue (screenshot + shell in one turn → degenerate reply) being tracked separately.