### PR TITLE
fix(desktop): host computer.screenshot images as URLs, not inline base64

### DIFF
--- a/change/@acedatacloud-nexior-f9319f93-1902-47d1-b1fc-5e5247f6d1de.json
+++ b/change/@acedatacloud-nexior-f9319f93-1902-47d1-b1fc-5e5247f6d1de.json
@@ -1,0 +1,1 @@
+{"type":"minor","comment":"Computer Use: upload screenshot tool-result images to the file store and send a short hosted URL (like normal image attachments) instead of an inline multi-MB base64 data-uri","packageName":"@acedatacloud/nexior","email":"dev@acedata.cloud","dependentChangeType":"patch"}

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -86,6 +86,7 @@ import { isImageUrl } from '@/utils/is';
 import { isDesktop } from '@/utils/surface';
 import { ensureLoggedIn } from '@/utils/login';
 import { localExec, type LocalToolSpec } from '@/utils/desktop';
+import { getBaseUrlPlatform } from '@/utils';
 import { IAskUserQuestionPayload, IChatMessageContentItem, IConsentRequestPayload } from '@/models';
 import {
   buildAuthorizedConsentOutput,
@@ -907,17 +908,53 @@ export default defineComponent({
         // denied, path outside allowed roots) resume as a tool ERROR, not a
         // successful output the model would trust. `image` (e.g. a
         // computer.screenshot) is forwarded so the worker can show the model
-        // the screen as a vision input.
+        // the screen as a vision input — hosted as a short URL (like a normal
+        // user-attached image) rather than an inline multi-MB base64 data-uri.
+        const image = r.image ? (await this._hostToolResultImage(r.image)) || r.image : undefined;
         results.push({
           tool_use_id: p.toolId,
           output: r.output,
           ...(r.is_error ? { is_error: true } : {}),
-          ...(r.image ? { image: r.image } : {})
+          ...(image ? { image } : {})
         });
       }
       // Stop pressed while the last tool was running → don't resume the turn.
       if (runId !== undefined && runId !== this.clientToolRunId) return;
       this._resumeWithToolResults(results, conversationId);
+    },
+    /**
+     * Host a tool-result image (e.g. a computer.screenshot) on the platform
+     * file store and return its short public URL — exactly how a normal
+     * user-attached image is sent. A screenshot returned inline as a multi-MB
+     * base64 `data:` URI otherwise bloats every stored message + upstream
+     * request (and a single one can dwarf the model's context budget). No-op
+     * for a value that is already an https URL. Returns null on any failure so
+     * the caller keeps the inline image as a fallback.
+     */
+    async _hostToolResultImage(image: string): Promise<string | null> {
+      if (!image || !image.startsWith('data:')) return image || null;
+      const accessToken = this.$store.getters.token?.access;
+      if (!accessToken) return null;
+      try {
+        const blob = await (await fetch(image)).blob();
+        const ext = (blob.type.split('/')[1] || 'png').split(';')[0];
+        const fd = new FormData();
+        fd.append('file', blob, `screenshot.${ext}`);
+        // Raw fetch (not the shared axios client, which forces a JSON
+        // content-type): the browser sets the multipart boundary itself.
+        const resp = await fetch(`${getBaseUrlPlatform()}/api/v1/files/`, {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${accessToken}` },
+          body: fd
+        });
+        if (!resp.ok) return null;
+        const data = await resp.json();
+        const url = data?.file_url || data?.data?.file_url;
+        return typeof url === 'string' && url ? url : null;
+      } catch (e) {
+        console.warn('[computer-use] screenshot upload failed; sending inline', e);
+        return null;
+      }
     },
     /**
      * Visual-only "skip" of an ask_user_question card. Marks the pending


### PR DESCRIPTION
## What

`computer.screenshot` returned its image to the worker as a **multi-MB base64 `data:` URI**. Every other image in the product — normal user attachments — is uploaded to the platform file store and sent as a short hosted URL (`https://cdn.acedata.cloud/xxxx.png`). Screenshots were the **only** image sent inline.

Evidence (aichat2 conversations): user attachments are all `URL: https://cdn.acedata.cloud/...`, while the screenshot tool result is `DATA_URI(200191ch)`.

That inline base64:
- bloats every stored message + upstream request, and
- was the true trigger of the **"Hi! How can I help?"** regression: one ~200KB screenshot tokenizes to ~126k tokens ≈ the whole context window, so the worker's context-trim evicted the entire conversation and the model got only the system prompt. (COS request archive confirmed the resume request was `system`-only.)

## Fix

Make a screenshot behave **exactly like a normal image attachment**. In `_runClientTools`, when a client tool returns an image as a `data:` URI, upload it to `POST /api/v1/files/` and send the returned `file_url` as `tool_results[].image`:

```ts
const image = r.image ? (await this._hostToolResultImage(r.image)) || r.image : undefined;
```

`_hostToolResultImage` uses a **raw `fetch`** (not the shared axios client, which forces a JSON content-type) with the user bearer token, so the browser sets the multipart boundary — the same path the audio/image uploaders already use. It **falls back to the inline image** on any upload failure (degrades gracefully) and is a **no-op** for a value that's already an `https` URL.

## Relationship to PlatformService#1259

Complementary. #1259 fixes the worker's token accounting so an inline image can never again evict the conversation (defense-in-depth). This PR removes the multi-MB base64 at the source so screenshots ride as short URLs like every other image (smaller storage/bandwidth, consistent path). Either one fixes the symptom; both together are the right end state.

## Verification

- `vue-tsc -b` + `vite build` (desktop) clean; `tsc -p electron/tsconfig.json` clean; eslint clean on `src/*`.
- Built local arm64 `.app` (codesign OK), installed to /Applications, launched.

## 🤖 对抗评审

Self-review: raw `fetch` avoids the axios JSON-content-type trap (verified `createHttpClient` sets a default JSON content-type); upload uses the user access token (`$store.getters.token.access`), same as normal uploads; graceful fallback keeps the feature working if `/files/` fails (and #1259 still prevents eviction in that case); no-op on non-`data:` URLs so re-sent history isn't re-uploaded. **VERDICT: CLEAN** (1 round).