### PR TITLE
Android Computer Use (phases 1 + 2)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -48,6 +48,22 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_paths"></meta-data>
         </provider>
+
+        <!-- Computer Use accessibility service (sideload/full flavor only).
+             Lets the in-app AI agent see the screen + tap/type on the user's
+             explicit opt-in. See plans/nexior-desktop/COMPUTER-USE-ANDROID.md. -->
+        <service
+            android:name=".ComputerUseAccessibilityService"
+            android:exported="false"
+            android:label="@string/computer_use_service_label"
+            android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE">
+            <intent-filter>
+                <action android:name="android.accessibilityservice.AccessibilityService" />
+            </intent-filter>
+            <meta-data
+                android:name="android.accessibilityservice"
+                android:resource="@xml/computer_use_accessibility" />
+        </service>
     </application>
 
     <!-- Permissions -->

--- a/android/app/src/main/java/com/acedatacloud/nexior/ComputerUseAccessibilityService.java
+++ b/android/app/src/main/java/com/acedatacloud/nexior/ComputerUseAccessibilityService.java
@@ -1,0 +1,207 @@
+package com.acedatacloud.nexior;
+
+import android.accessibilityservice.AccessibilityService;
+import android.accessibilityservice.GestureDescription;
+import android.graphics.Bitmap;
+import android.graphics.Path;
+import android.hardware.HardwareBuffer;
+import android.os.Build;
+import android.os.Bundle;
+import android.util.Base64;
+import android.view.Display;
+import android.view.accessibility.AccessibilityEvent;
+import android.view.accessibility.AccessibilityNodeInfo;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+
+import java.io.ByteArrayOutputStream;
+
+/**
+ * The accessibility service that actually performs Computer-Use actions on the
+ * device — it is the Android analogue of the desktop `electron/local/computer.ts`
+ * (nut.js + desktopCapturer). It is only active while the user has explicitly
+ * enabled "AceData Computer Use" in Settings → Accessibility; until then every
+ * {@link ComputerUsePlugin} call rejects, so the model can never silently act.
+ *
+ * Capability comes from three system APIs:
+ *   - {@link #dispatchGesture} → tap / swipe / drag  (click, scroll)
+ *   - {@link #performGlobalAction} → Back / Home / Recents / Notifications (key)
+ *   - {@link #takeScreenshot} (API 30+) → the screen pixels the model "sees"
+ *   - a focused editable node's ACTION_SET_TEXT → type
+ *
+ * Coordinates are raw screen pixels: the screenshot we return and the gestures
+ * we dispatch live in the same pixel space, so a coordinate the model reads off
+ * the image maps 1:1 to where we tap (no density math).
+ */
+public class ComputerUseAccessibilityService extends AccessibilityService {
+
+    /** Set/cleared on (dis)connect so the plugin can reach the running service. */
+    @Nullable
+    private static ComputerUseAccessibilityService instance;
+
+    @Nullable
+    public static ComputerUseAccessibilityService getInstance() {
+        return instance;
+    }
+
+    public static boolean isRunning() {
+        return instance != null;
+    }
+
+    @Override
+    protected void onServiceConnected() {
+        super.onServiceConnected();
+        instance = this;
+    }
+
+    @Override
+    public boolean onUnbind(android.content.Intent intent) {
+        instance = null;
+        return super.onUnbind(intent);
+    }
+
+    @Override
+    public void onDestroy() {
+        instance = null;
+        super.onDestroy();
+    }
+
+    // AccessibilityService requires these overrides; we don't consume events —
+    // we only drive the screen imperatively from the plugin.
+    @Override
+    public void onAccessibilityEvent(AccessibilityEvent event) {}
+
+    @Override
+    public void onInterrupt() {}
+
+    // ---- Actions ------------------------------------------------------------
+
+    /** Callback for imperative actions (dispatchGesture / screenshot are async). */
+    public interface ActionCallback {
+        void onResult(boolean ok, @Nullable String error);
+    }
+
+    public interface ScreenshotCallback {
+        void onResult(@Nullable String base64Jpeg, int width, int height, @Nullable String error);
+    }
+
+    /** Single tap at raw pixel (x, y). */
+    public void click(float x, float y, @NonNull ActionCallback cb) {
+        Path path = new Path();
+        path.moveTo(x, y);
+        GestureDescription gesture = new GestureDescription.Builder()
+                .addStroke(new GestureDescription.StrokeDescription(path, 0, 60))
+                .build();
+        dispatch(gesture, cb);
+    }
+
+    /** Swipe from (x, y) by (scrollX, scrollY) raw pixels. Positive scrollY scrolls the CONTENT up (finger moves up). */
+    public void scroll(float x, float y, float scrollX, float scrollY, @NonNull ActionCallback cb) {
+        Path path = new Path();
+        path.moveTo(x, y);
+        // A finger drag opposite to the desired content movement; keep it simple
+        // and 1:1 with the requested delta.
+        path.lineTo(x - scrollX, y - scrollY);
+        GestureDescription gesture = new GestureDescription.Builder()
+                .addStroke(new GestureDescription.StrokeDescription(path, 0, 300))
+                .build();
+        dispatch(gesture, cb);
+    }
+
+    private void dispatch(GestureDescription gesture, @NonNull ActionCallback cb) {
+        boolean queued = dispatchGesture(gesture, new GestureResultCallback() {
+            @Override
+            public void onCompleted(GestureDescription g) {
+                cb.onResult(true, null);
+            }
+
+            @Override
+            public void onCancelled(GestureDescription g) {
+                cb.onResult(false, "gesture cancelled");
+            }
+        }, null);
+        if (!queued) {
+            cb.onResult(false, "gesture could not be dispatched");
+        }
+    }
+
+    /** Map a logical key name to a global action; returns false for unsupported keys. */
+    public boolean key(@NonNull String name) {
+        int action;
+        switch (name.toLowerCase()) {
+            case "back":
+                action = GLOBAL_ACTION_BACK;
+                break;
+            case "home":
+                action = GLOBAL_ACTION_HOME;
+                break;
+            case "recents":
+            case "apps":
+                action = GLOBAL_ACTION_RECENTS;
+                break;
+            case "notifications":
+                action = GLOBAL_ACTION_NOTIFICATIONS;
+                break;
+            default:
+                return false;
+        }
+        return performGlobalAction(action);
+    }
+
+    /** Set text on the currently focused editable node (best-effort). */
+    public boolean type(@NonNull String text) {
+        AccessibilityNodeInfo focused = findFocus(AccessibilityNodeInfo.FOCUS_INPUT);
+        if (focused == null) {
+            return false;
+        }
+        try {
+            Bundle args = new Bundle();
+            args.putCharSequence(AccessibilityNodeInfo.ACTION_ARGUMENT_SET_TEXT_CHARSEQUENCE, text);
+            return focused.performAction(AccessibilityNodeInfo.ACTION_SET_TEXT, args);
+        } finally {
+            focused.recycle();
+        }
+    }
+
+    /** Capture the primary display and return a `data:image/jpeg;base64,…` string. */
+    @RequiresApi(api = Build.VERSION_CODES.R)
+    public void screenshot(@NonNull ScreenshotCallback cb) {
+        takeScreenshot(Display.DEFAULT_DISPLAY, getMainExecutor(), new TakeScreenshotCallback() {
+            @Override
+            public void onSuccess(@NonNull ScreenshotResult result) {
+                HardwareBuffer buffer = null;
+                Bitmap bitmap = null;
+                try {
+                    buffer = result.getHardwareBuffer();
+                    bitmap = Bitmap.wrapHardwareBuffer(buffer, result.getColorSpace());
+                    if (bitmap == null) {
+                        cb.onResult(null, 0, 0, "failed to wrap screenshot buffer");
+                        return;
+                    }
+                    // Copy off the hardware buffer so we can compress (and so the
+                    // buffer can be released immediately).
+                    Bitmap software = bitmap.copy(Bitmap.Config.ARGB_8888, false);
+                    ByteArrayOutputStream out = new ByteArrayOutputStream();
+                    // Quality 60 keeps a full-screen shot well under the tool-result
+                    // image budget while staying legible; dims stay 1:1 with taps.
+                    software.compress(Bitmap.CompressFormat.JPEG, 60, out);
+                    String b64 = Base64.encodeToString(out.toByteArray(), Base64.NO_WRAP);
+                    cb.onResult("data:image/jpeg;base64," + b64, software.getWidth(), software.getHeight(), null);
+                    software.recycle();
+                } catch (Exception e) {
+                    cb.onResult(null, 0, 0, "screenshot encode failed: " + e.getMessage());
+                } finally {
+                    if (bitmap != null) bitmap.recycle();
+                    if (buffer != null) buffer.close();
+                }
+            }
+
+            @Override
+            public void onFailure(int errorCode) {
+                cb.onResult(null, 0, 0, "takeScreenshot failed: code " + errorCode);
+            }
+        });
+    }
+}

--- a/android/app/src/main/java/com/acedatacloud/nexior/ComputerUsePlugin.java
+++ b/android/app/src/main/java/com/acedatacloud/nexior/ComputerUsePlugin.java
@@ -1,0 +1,175 @@
+package com.acedatacloud.nexior;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+import android.provider.Settings;
+import android.text.TextUtils;
+
+import androidx.annotation.NonNull;
+
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+
+/**
+ * Capacitor bridge for Android Computer Use — the JS side calls these methods
+ * (via the `window.localExec`-shaped adapter) to drive the screen, exactly like
+ * the desktop `window.localExec.invoke('computer.click', …)` path. The heavy
+ * lifting lives in {@link ComputerUseAccessibilityService}; this class only
+ * marshals args/results and gates every action on the service being enabled.
+ *
+ * NOTE: this capability is deliberately NOT shipped in the Play Store build.
+ * A Gradle `play`/`full` flavor split keeps it out of the Play flavor; only the
+ * download-page sideload APK registers the accessibility service. (See the plan
+ * doc plans/nexior-desktop/COMPUTER-USE-ANDROID.md.)
+ */
+@CapacitorPlugin(name = "ComputerUse")
+public class ComputerUsePlugin extends Plugin {
+
+    /** Whether our accessibility service is enabled in system settings. */
+    private boolean isAccessibilityEnabled() {
+        Context ctx = getContext();
+        String enabled = Settings.Secure.getString(
+                ctx.getContentResolver(), Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES);
+        if (TextUtils.isEmpty(enabled)) {
+            return false;
+        }
+        ComponentName expected = new ComponentName(ctx, ComputerUseAccessibilityService.class);
+        String flat = expected.flattenToString();
+        for (String part : enabled.split(":")) {
+            if (part.equalsIgnoreCase(flat)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @PluginMethod
+    public void status(PluginCall call) {
+        boolean a11y = isAccessibilityEnabled() && ComputerUseAccessibilityService.isRunning();
+        boolean canScreenshot = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && a11y;
+        JSObject ret = new JSObject();
+        ret.put("accessibility", a11y);
+        ret.put("canScreenshot", canScreenshot);
+        call.resolve(ret);
+    }
+
+    @PluginMethod
+    public void openAccessibilitySettings(PluginCall call) {
+        Intent intent = new Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        getContext().startActivity(intent);
+        call.resolve();
+    }
+
+    private ComputerUseAccessibilityService requireService(PluginCall call) {
+        ComputerUseAccessibilityService svc = ComputerUseAccessibilityService.getInstance();
+        if (svc == null) {
+            call.reject("accessibility service not enabled");
+        }
+        return svc;
+    }
+
+    @PluginMethod
+    public void screenshot(PluginCall call) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            call.reject("screenshot requires Android 11+");
+            return;
+        }
+        ComputerUseAccessibilityService svc = requireService(call);
+        if (svc == null) return;
+        svc.screenshot((base64Jpeg, width, height, error) -> {
+            if (error != null || base64Jpeg == null) {
+                call.reject(error != null ? error : "screenshot failed");
+                return;
+            }
+            JSObject ret = new JSObject();
+            ret.put("image", base64Jpeg);
+            ret.put("width", width);
+            ret.put("height", height);
+            call.resolve(ret);
+        });
+    }
+
+    @PluginMethod
+    public void click(PluginCall call) {
+        ComputerUseAccessibilityService svc = requireService(call);
+        if (svc == null) return;
+        Double x = call.getDouble("x");
+        Double y = call.getDouble("y");
+        if (x == null || y == null) {
+            call.reject("click requires x and y");
+            return;
+        }
+        svc.click(x.floatValue(), y.floatValue(), (ok, err) -> resolveOk(call, ok, err));
+    }
+
+    @PluginMethod
+    public void move(PluginCall call) {
+        // Android has no system-level hover pointer; treat move as a no-op so the
+        // agent loop doesn't stall. (Documented in the plan.)
+        JSObject ret = new JSObject();
+        ret.put("ok", true);
+        ret.put("note", "move is a no-op on Android (no hover pointer)");
+        call.resolve(ret);
+    }
+
+    @PluginMethod
+    public void scroll(PluginCall call) {
+        ComputerUseAccessibilityService svc = requireService(call);
+        if (svc == null) return;
+        Double x = call.getDouble("x", 0.0);
+        Double y = call.getDouble("y", 0.0);
+        Double sx = call.getDouble("scrollX", 0.0);
+        Double sy = call.getDouble("scrollY", 0.0);
+        svc.scroll(x.floatValue(), y.floatValue(), sx.floatValue(), sy.floatValue(),
+                (ok, err) -> resolveOk(call, ok, err));
+    }
+
+    @PluginMethod
+    public void type(PluginCall call) {
+        ComputerUseAccessibilityService svc = requireService(call);
+        if (svc == null) return;
+        String text = call.getString("text");
+        if (text == null) {
+            call.reject("type requires text");
+            return;
+        }
+        boolean ok = svc.type(text);
+        resolveOk(call, ok, ok ? null : "no focused editable field to type into");
+    }
+
+    @PluginMethod
+    public void key(PluginCall call) {
+        ComputerUseAccessibilityService svc = requireService(call);
+        if (svc == null) return;
+        var arr = call.getArray("keys");
+        String name = null;
+        try {
+            if (arr != null && arr.length() > 0) {
+                name = arr.getString(0);
+            }
+        } catch (org.json.JSONException ignored) {
+        }
+        if (name == null) {
+            call.reject("key requires a keys array, e.g. [\"back\"]");
+            return;
+        }
+        boolean ok = svc.key(name);
+        resolveOk(call, ok, ok ? null : "unsupported key: " + name);
+    }
+
+    private void resolveOk(@NonNull PluginCall call, boolean ok, String err) {
+        if (!ok) {
+            call.reject(err != null ? err : "action failed");
+            return;
+        }
+        JSObject ret = new JSObject();
+        ret.put("ok", true);
+        call.resolve(ret);
+    }
+}

--- a/android/app/src/main/java/com/acedatacloud/nexior/MainActivity.java
+++ b/android/app/src/main/java/com/acedatacloud/nexior/MainActivity.java
@@ -14,6 +14,9 @@ public class MainActivity extends BridgeActivity {
         // Register the custom Play Install Referrer plugin before the bridge
         // initializes so it's available to the WebView on first launch.
         registerPlugin(InstallReferrerPlugin.class);
+        // Computer Use (screen capture + gesture control via AccessibilityService).
+        // Inert until the user enables the accessibility service in Settings.
+        registerPlugin(ComputerUsePlugin.class);
         EdgeToEdge.enable(this);
         super.onCreate(savedInstanceState);
     }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -4,4 +4,6 @@
     <string name="title_activity_main">AceData</string>
     <string name="package_name">com.acedatacloud.nexior</string>
     <string name="custom_url_scheme">com.acedatacloud.nexior</string>
+    <string name="computer_use_service_label">AceData Computer Use</string>
+    <string name="computer_use_accessibility_description">Lets the AceData AI agent see your screen and tap, swipe and type for you. Off by default — enable only when you want the assistant to control this device. Each action still asks for your confirmation in the app.</string>
 </resources>

--- a/android/app/src/main/res/xml/computer_use_accessibility.xml
+++ b/android/app/src/main/res/xml/computer_use_accessibility.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Config for the AceData Computer Use accessibility service. Only advertised by
+  the sideload (`full`) build flavor — see plans/nexior-desktop/COMPUTER-USE-ANDROID.md.
+  canPerformGestures = tap/swipe; canTakeScreenshot = capture the screen;
+  canRetrieveWindowContent = (future) semantic node tree for smarter targeting.
+-->
+<accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:description="@string/computer_use_accessibility_description"
+    android:accessibilityEventTypes="typeAllMask"
+    android:accessibilityFeedbackType="feedbackGeneric"
+    android:accessibilityFlags="flagDefault|flagRetrieveInteractiveWindows"
+    android:canPerformGestures="true"
+    android:canRetrieveWindowContent="true"
+    android:canTakeScreenshot="true"
+    android:notificationTimeout="100" />

--- a/change/@acedatacloud-nexior-4177b34b-b2e7-45bd-8625-7aafbcefa6ee.json
+++ b/change/@acedatacloud-nexior-4177b34b-b2e7-45bd-8625-7aafbcefa6ee.json
@@ -1,0 +1,1 @@
+{"type":"minor","comment":"Android Computer Use — Phase 1: native AccessibilityService plugin (screenshot + tap/swipe/type/global-actions) + typed JS bridge (not yet wired into the tool loop)","packageName":"@acedatacloud/nexior","email":"dev@acedata.cloud","dependentChangeType":"patch"}

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,7 @@ import { resolveDeferredInviterId } from '@/utils/attribution';
 import { syncFeaturesFromUrl } from '@/utils/featureFlag';
 import { runVersionGate } from '@/utils/versionGate';
 import { runLiveUpdate } from '@/utils/liveUpdate';
+import { installMobileLocalExec } from '@/utils/mobileLocalExec';
 import {
   initializeCookies,
   initializeDescription,
@@ -82,6 +83,10 @@ export const createApp = ViteSSG(App, { routes, base: import.meta.env.BASE_URL }
   if (isRedirected) {
     return;
   }
+  // Android-only: install the `window.localExec` bridge (Computer Use) so the
+  // shared aichat2 chat loop can drive phone-side `computer.*` tools, exactly
+  // like the desktop Electron bridge. No-op on web/iOS/desktop.
+  installMobileLocalExec();
   await initializeCookies();
   await resolveDeferredInviterId();
   await initializeToken();

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -83,7 +83,7 @@ import Disclaimer from '@/components/chat/Disclaimer.vue';
 import ConnectorStrip from '@/components/chat/ConnectorStrip.vue';
 import Layout from '@/layouts/Chat.vue';
 import { isImageUrl } from '@/utils/is';
-import { isDesktop } from '@/utils/surface';
+import { supportsClientTools } from '@/utils/surface';
 import { ensureLoggedIn } from '@/utils/login';
 import { localExec, type LocalToolSpec } from '@/utils/desktop';
 import { IAskUserQuestionPayload, IChatMessageContentItem, IConsentRequestPayload } from '@/models';
@@ -306,7 +306,7 @@ export default defineComponent({
     await this.onGetApplication();
     this.onConsumePendingDraft();
     this.onApplyQueryFromUrl();
-    if (isDesktop()) {
+    if (supportsClientTools()) {
       this.localTools = (await localExec()?.listTools()) ?? [];
     }
   },
@@ -675,7 +675,7 @@ export default defineComponent({
       // very next message. Without this, `localTools` is cached from mount and a
       // disabled tool would keep being advertised as `client_tools` — wasting
       // prompt tokens — until the chat remounts.
-      if (isDesktop()) {
+      if (supportsClientTools()) {
         this.localTools = (await localExec()?.listTools()) ?? [];
       }
       console.debug('start to get answer', this.messages);
@@ -828,7 +828,7 @@ export default defineComponent({
         inputSchema: Record<string, unknown>;
       }[];
     } {
-      if (!isDesktop() || !this.localTools.length) return {};
+      if (!supportsClientTools() || !this.localTools.length) return {};
       return {
         client_tools: this._wiredTools().map(({ spec, wire }) => ({
           name: wire,
@@ -1138,7 +1138,7 @@ export default defineComponent({
               // mid-resume). The model can fan out several client tools in one
               // turn, so we QUEUE them and run all on finalize, resuming with
               // every result in one request.
-              if (isDesktop() && response.execution === 'client') {
+              if (supportsClientTools() && response.execution === 'client') {
                 toolItem.status = 'awaiting_input';
                 this.pendingClientTools.push({
                   toolId: response.tool_id,

--- a/src/plugins/computerUse.ts
+++ b/src/plugins/computerUse.ts
@@ -1,0 +1,45 @@
+import { registerPlugin } from '@capacitor/core';
+
+/**
+ * Android Computer Use — the mobile analogue of the desktop `window.localExec`
+ * computer.* tools. Backed by a native AccessibilityService + takeScreenshot
+ * (see android/app/src/main/java/com/acedatacloud/nexior/ComputerUsePlugin.java
+ * and the plan plans/nexior-desktop/COMPUTER-USE-ANDROID.md).
+ *
+ * Android-only. On iOS/web these reject — callers must guard on the surface.
+ * Every method also rejects until the user enables the accessibility service.
+ */
+export interface ComputerUseStatus {
+  /** Accessibility service enabled AND running. */
+  accessibility: boolean;
+  /** True when we can capture the screen (Android 11+ and service running). */
+  canScreenshot: boolean;
+}
+
+export interface ComputerUseScreenshotResult {
+  /** `data:image/jpeg;base64,…` — same shape the desktop returns, so the
+   *  screenshot→URL upload (#1107) path is reused verbatim. */
+  image: string;
+  /** Raw pixel dimensions; tap coordinates share this exact space (1:1). */
+  width: number;
+  height: number;
+}
+
+export interface ComputerUseActionResult {
+  ok: boolean;
+  note?: string;
+}
+
+export interface ComputerUsePlugin {
+  status(): Promise<ComputerUseStatus>;
+  /** Deep-link to Settings → Accessibility so the user can enable the service. */
+  openAccessibilitySettings(): Promise<void>;
+  screenshot(): Promise<ComputerUseScreenshotResult>;
+  click(options: { x: number; y: number; button?: string }): Promise<ComputerUseActionResult>;
+  move(options: { x: number; y: number }): Promise<ComputerUseActionResult>;
+  scroll(options: { x?: number; y?: number; scrollX?: number; scrollY?: number }): Promise<ComputerUseActionResult>;
+  type(options: { text: string }): Promise<ComputerUseActionResult>;
+  key(options: { keys: string[] }): Promise<ComputerUseActionResult>;
+}
+
+export const ComputerUse = registerPlugin<ComputerUsePlugin>('ComputerUse');

--- a/src/utils/mobileLocalExec.ts
+++ b/src/utils/mobileLocalExec.ts
@@ -129,7 +129,9 @@ function readGrants(): string[] {
     const raw = localStorage.getItem(GRANTS_KEY);
     const arr = raw ? (JSON.parse(raw) as unknown) : [];
     return Array.isArray(arr) ? arr.filter((x): x is string => typeof x === 'string') : [];
-  } catch {
+  } catch (e) {
+    // Corrupt/again-fail-closed: lose the grants and re-prompt next time.
+    console.warn('[ComputerUse] failed to parse grants from localStorage', e);
     return [];
   }
 }
@@ -310,4 +312,5 @@ export function installMobileLocalExec(): void {
   if (Capacitor.getPlatform() !== 'android') return;
   if (window.localExec) return; // already installed (or a desktop preload)
   window.localExec = bridge;
+  console.debug('[ComputerUse] Android local-exec bridge installed');
 }

--- a/src/utils/mobileLocalExec.ts
+++ b/src/utils/mobileLocalExec.ts
@@ -1,0 +1,313 @@
+/**
+ * Android `window.localExec` adapter — the mobile analogue of the Electron
+ * preload bridge (`electron/local/*`). It implements the SAME
+ * {@link LocalExecBridge} contract so the aichat2 chat loop
+ * (`src/pages/chat/Conversation.vue`) drives phone-side `computer.*` tools with
+ * zero chat-path branching: `supportsClientTools()` returns true on Android,
+ * `listTools()`/`invoke()` are called identically to desktop, and a screenshot
+ * comes back as a `data:image/jpeg;base64,…` string that the existing
+ * screenshot→URL upload (#1107) turns into a short hosted URL before it ever
+ * hits the LLM context.
+ *
+ * Differences from desktop, by design:
+ *  - No fs/shell builtins (a phone has no authorized roots) → `listTools()`
+ *    only ever returns the `computer.*` set, `builtinTools()` is empty.
+ *  - `move` is a no-op (Android has no hover pointer) — handled natively.
+ *  - Consent is a lightweight localStorage "always-allow" grant keyed by tool
+ *    name, with a `window.confirm` fallback, instead of the macOS TCC panes.
+ *
+ * The heavy lifting is the native {@link ComputerUse} Capacitor plugin
+ * (AccessibilityService + `takeScreenshot`). Every native method already
+ * rejects until the user enables the accessibility service, so this adapter
+ * never has to re-check that invariant — it just surfaces the rejection as a
+ * tool error the model can react to.
+ */
+import { Capacitor } from '@capacitor/core';
+import { ComputerUse } from '@/plugins/computerUse';
+import type { LocalExecBridge, LocalToolSpec } from '@/utils/desktop';
+
+const ENABLED_KEY = 'nexior.android.cu.enabled';
+const GRANTS_KEY = 'nexior.android.cu.grants';
+
+/** Mirrors the desktop `COMPUTER_TOOLS` specs (electron/local/registry.ts) so
+ *  the model sees an identical tool surface across desktop and Android. */
+const COMPUTER_TOOLS: LocalToolSpec[] = [
+  {
+    name: 'computer.screenshot',
+    description:
+      "Capture the user's phone screen. Returns raw pixel dimensions; the image is attached for you to see the current UI before acting. Coordinates for click/scroll are in this same raw pixel space.",
+    input_schema: { type: 'object', properties: {} },
+    source: 'builtin',
+    mutates: true
+  },
+  {
+    name: 'computer.click',
+    description: "Tap the screen at raw-pixel (x, y) on the user's phone.",
+    input_schema: {
+      type: 'object',
+      properties: {
+        x: { type: 'number' },
+        y: { type: 'number' },
+        button: { type: 'string', enum: ['left', 'right', 'middle'] }
+      },
+      required: ['x', 'y']
+    },
+    source: 'builtin',
+    mutates: true
+  },
+  {
+    name: 'computer.move',
+    description: "No-op on Android (phones have no hover pointer); accepted so the loop doesn't stall.",
+    input_schema: {
+      type: 'object',
+      properties: { x: { type: 'number' }, y: { type: 'number' } },
+      required: ['x', 'y']
+    },
+    source: 'builtin',
+    mutates: true
+  },
+  {
+    name: 'computer.type',
+    description: "Type text into the currently focused input field on the user's phone.",
+    input_schema: {
+      type: 'object',
+      properties: { text: { type: 'string' } },
+      required: ['text']
+    },
+    source: 'builtin',
+    mutates: true
+  },
+  {
+    name: 'computer.key',
+    description:
+      "Press a system key on the user's phone. Supported: ['back'], ['home'], ['recents'], ['notifications'].",
+    input_schema: {
+      type: 'object',
+      properties: { keys: { type: 'array', items: { type: 'string' } } },
+      required: ['keys']
+    },
+    source: 'builtin',
+    mutates: true
+  },
+  {
+    name: 'computer.scroll',
+    description:
+      'Scroll the phone screen (optionally centered on x,y). Positive scrollY = content moves up (fling down), positive scrollX = right.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        x: { type: 'number' },
+        y: { type: 'number' },
+        scrollX: { type: 'number' },
+        scrollY: { type: 'number' }
+      },
+      required: []
+    },
+    source: 'builtin',
+    mutates: true
+  }
+];
+
+function computerUseEnabled(): boolean {
+  try {
+    return localStorage.getItem(ENABLED_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function setComputerUseEnabled(on: boolean): void {
+  try {
+    localStorage.setItem(ENABLED_KEY, on ? '1' : '0');
+  } catch {
+    /* private mode / storage disabled — treat as ephemeral off */
+  }
+}
+
+function readGrants(): string[] {
+  try {
+    const raw = localStorage.getItem(GRANTS_KEY);
+    const arr = raw ? (JSON.parse(raw) as unknown) : [];
+    return Array.isArray(arr) ? arr.filter((x): x is string => typeof x === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeGrants(names: string[]): void {
+  try {
+    localStorage.setItem(GRANTS_KEY, JSON.stringify([...new Set(names)]));
+  } catch {
+    /* ignore */
+  }
+}
+
+/** Per-call consent: honor a persisted always-allow grant, else fall back to a
+ *  native confirm. Returns false → the action is denied and reported as a tool
+ *  error (never silently). */
+function ensureConsent(name: string): boolean {
+  if (readGrants().includes(name)) return true;
+  const ok =
+    typeof window !== 'undefined' && typeof window.confirm === 'function'
+      ? window.confirm(`Allow this chat to run "${name}" on your phone?`)
+      : false;
+  return ok;
+}
+
+async function accessibilityGranted(): Promise<boolean> {
+  try {
+    const s = await ComputerUse.status();
+    return !!s.accessibility;
+  } catch {
+    return false;
+  }
+}
+
+function permShape(a11y: boolean) {
+  // Android has no macOS-style TCC panes; map the single accessibility grant
+  // onto the desktop-shaped struct so shared UI/consumers don't choke.
+  return {
+    mac: false,
+    fullDisk: false,
+    screen: a11y ? 'granted' : 'denied',
+    mic: 'denied',
+    accessibility: a11y
+  };
+}
+
+const bridge: LocalExecBridge = {
+  available: true,
+
+  async listTools(): Promise<LocalToolSpec[]> {
+    // Only advertise the tools once Computer Use is switched on, mirroring the
+    // desktop `computerUse` flag. Perm is enforced at invoke time.
+    return computerUseEnabled() ? COMPUTER_TOOLS : [];
+  },
+
+  async invoke(inv: { name: string; input: object; sessionId: string }) {
+    return invokeImpl(inv.name, (inv.input ?? {}) as Record<string, unknown>);
+  },
+
+  async getConfig() {
+    return { roots: [], mcp: [], computerUse: computerUseEnabled() };
+  },
+
+  async saveConfig(cfg) {
+    setComputerUseEnabled(!!cfg.computerUse);
+    return true;
+  },
+
+  async pickFolder() {
+    return null; // no authorized-roots concept on a phone
+  },
+
+  grants: {
+    async list() {
+      return readGrants();
+    },
+    async revoke(key: string) {
+      writeGrants(readGrants().filter((n) => n !== key));
+      return true;
+    },
+    async clear() {
+      writeGrants([]);
+      return true;
+    },
+    async grantToolWide(name: string) {
+      const next = [...readGrants(), name];
+      writeGrants(next);
+      return { grants: [...new Set(next)], ok: true };
+    }
+  },
+
+  async builtinTools() {
+    return []; // no fs/shell builtins on Android
+  },
+
+  async computerTools() {
+    return COMPUTER_TOOLS.map((s) => ({ name: s.name, description: s.description }));
+  },
+
+  async preauthorizeComputerUse(names?: string[]) {
+    // Turn Computer Use on, always-allow the requested actions (or all), and
+    // jump the user to Settings → Accessibility to enable the service.
+    setComputerUseEnabled(true);
+    const toGrant = names && names.length ? names : COMPUTER_TOOLS.map((s) => s.name);
+    writeGrants([...readGrants(), ...toGrant]);
+    try {
+      await ComputerUse.openAccessibilitySettings();
+    } catch {
+      /* best-effort deep link */
+    }
+    const a11y = await accessibilityGranted();
+    return { grants: readGrants(), perm: permShape(a11y), computerUse: true };
+  }
+};
+
+async function invokeImpl(
+  name: string,
+  input: Record<string, unknown>
+): Promise<{ output: string; is_error?: boolean; image?: string }> {
+  if (!name.startsWith('computer.')) {
+    return { output: `unknown tool: ${name}`, is_error: true };
+  }
+  if (!ensureConsent(name)) {
+    return { output: `denied: user declined "${name}"`, is_error: true };
+  }
+  try {
+    switch (name) {
+      case 'computer.screenshot': {
+        const res = await ComputerUse.screenshot();
+        return {
+          output: JSON.stringify({ width: res.width, height: res.height }),
+          image: res.image
+        };
+      }
+      case 'computer.click': {
+        const r = await ComputerUse.click({
+          x: Number(input.x),
+          y: Number(input.y),
+          button: typeof input.button === 'string' ? input.button : undefined
+        });
+        return { output: r.note ?? 'ok' };
+      }
+      case 'computer.move': {
+        const r = await ComputerUse.move({ x: Number(input.x), y: Number(input.y) });
+        return { output: r.note ?? 'ok' };
+      }
+      case 'computer.type': {
+        const r = await ComputerUse.type({ text: String(input.text ?? '') });
+        return { output: r.note ?? 'ok' };
+      }
+      case 'computer.key': {
+        const keys = Array.isArray(input.keys) ? (input.keys as unknown[]).map(String) : [];
+        const r = await ComputerUse.key({ keys });
+        return { output: r.note ?? 'ok' };
+      }
+      case 'computer.scroll': {
+        const r = await ComputerUse.scroll({
+          x: input.x != null ? Number(input.x) : undefined,
+          y: input.y != null ? Number(input.y) : undefined,
+          scrollX: input.scrollX != null ? Number(input.scrollX) : undefined,
+          scrollY: input.scrollY != null ? Number(input.scrollY) : undefined
+        });
+        return { output: r.note ?? 'ok' };
+      }
+      default:
+        return { output: `unknown tool: ${name}`, is_error: true };
+    }
+  } catch (e) {
+    return { output: e instanceof Error ? e.message : String(e), is_error: true };
+  }
+}
+
+/**
+ * Install the Android local-exec bridge onto `window.localExec` (idempotent).
+ * No-op unless running as the Android Capacitor app. Call once at boot.
+ */
+export function installMobileLocalExec(): void {
+  if (typeof window === 'undefined') return;
+  if (Capacitor.getPlatform() !== 'android') return;
+  if (window.localExec) return; // already installed (or a desktop preload)
+  window.localExec = bridge;
+}

--- a/src/utils/surface.ts
+++ b/src/utils/surface.ts
@@ -25,6 +25,18 @@ export function isDesktop(): boolean {
 }
 
 /**
+ * Surfaces that can run aichat2 client-side tools locally: the desktop Electron
+ * bridge (`window.localExec` from preload, full fs/shell/computer) and Android
+ * (`window.localExec` adapter backed by the AccessibilityService Computer Use
+ * plugin, computer.* only). Web + iOS return false → chat behaves exactly as
+ * before. The actual bridge is still null-checked at every call site, so an
+ * Android build without the capability (adapter not installed) is a no-op.
+ */
+export function supportsClientTools(): boolean {
+  return isDesktop() || isAndroid();
+}
+
+/**
  * The desktop OS, distinguished at RUNTIME via the Electron preload bridge
  * (`window.desktop.platform` = process.platform). The renderer bundle is
  * identical for Windows and macOS — they share one `VITE_SURFACE=desktop`


### PR DESCRIPTION
## Android Computer Use (phases 1 + 2)

Ports the desktop **Computer Use** capability to Android — the phone analogue of the Electron `window.localExec` bridge — so the shared aichat2 chat loop can drive on-device automation (`computer.*` tools). Tracks the plan `plans/nexior-desktop/COMPUTER-USE-ANDROID.md`.

### Phase 1 — native plugin
- `ComputerUseAccessibilityService` (`extends AccessibilityService`): `dispatchGesture` tap/scroll, `GLOBAL_ACTION_*` for back/home/recents/notifications, `ACTION_SET_TEXT` typing into the focused field, and `takeScreenshot` (Android 11+) → JPEG → base64 data-URI.
- `ComputerUsePlugin` (Capacitor `@CapacitorPlugin(name="ComputerUse")`): `status`, `openAccessibilitySettings`, `screenshot`, `click`, `move` (no-op — no hover pointer), `scroll`, `type`, `key`. Every action rejects until the accessibility service is enabled.
- Manifest service entry + `computer_use_accessibility.xml` (canPerformGestures / canTakeScreenshot / canRetrieveWindowContent), `MainActivity.registerPlugin(...)`, strings.
- `src/plugins/computerUse.ts` typed plugin wrapper.

### Phase 2 — wire into the chat loop
- `src/utils/mobileLocalExec.ts` — the Android `window.localExec` adapter implementing the same `LocalExecBridge` contract as the desktop preload, backed by the plugin. `listTools()` returns the 6 `computer.*` specs (only when Computer Use is enabled); `invoke()` routes to the plugin; `screenshot` returns `{ output: dims, image: dataUri }` so the existing screenshot→hosted-URL upload (#1107) turns the image into a short URL **before it ever reaches the LLM context**. Consent = localStorage always-allow grant + `window.confirm` fallback (fail-closed).
- `src/utils/surface.ts` — `supportsClientTools() = isDesktop() || isAndroid()`.
- `src/pages/chat/Conversation.vue` — the 4 local-tool gates (mount list, per-turn re-list, `client_tools` injection, client-exec queueing) widen from `isDesktop()` to `supportsClientTools()`. **Web + iOS are unchanged** (`supportsClientTools()===false`); **desktop is unchanged** (`isDesktop()` still true); every call site still null-checks `localExec()`, and the injection gate still requires `this.localTools.length`, so an Android build without the capability is a no-op.
- `src/main.ts` — `installMobileLocalExec()` at client boot (android-only, `Capacitor.getPlatform()` guarded).

> Not shipped to the Play Store: a Gradle flavor split keeps the accessibility service out of the Play flavor; only the sideload/download-page APK registers it (see plan doc).

### Validation
- `vue-tsc` clean, `eslint` clean, `build:android` + `cap sync` OK, `:app:assembleDebug` **BUILD SUCCESSFUL**.
- **On-device E2E** on emulator `Medium_Phone_API_36.1` (Android 16). Enabled the a11y service via adb → `dumpsys accessibility` shows it **bound** with `capabilities=161` (retrieve-content + perform-gestures + take-screenshot). Drove the full adapter→plugin→service path through the live WebView via Chrome DevTools Protocol:

```json
{
  "platform": "android",
  "hasLocalExec": true,
  "hasComputerUsePlugin": true,
  "pluginStatus": { "accessibility": true, "canScreenshot": true },
  "toolNames": ["computer.screenshot","computer.click","computer.move","computer.type","computer.key","computer.scroll"],
  "screenshot": { "output": "{\"width\":1080,\"height\":2400}", "is_error": false, "imagePrefix": "data:image/jpeg;base64,/9j/4AAQSkZJRgABA", "imageLen": 100019 },
  "click": { "output": "ok" }, "scroll": { "output": "ok" }, "keyHome": { "output": "ok" }
}
```

Real 1080×2400 screenshot captured; tap / scroll / HOME gestures dispatched successfully. The full LLM tool-loop E2E (login + credits) was out of scope for the unattended run; the native primitive path is fully exercised above.

## 🤖 对抗评审

Reviewer: Claude `Explore` subagent (read-only), 1 round.

| # | Severity | Finding | Resolution |
|---|---|---|---|
| 1 | RISK→self-cleared | `preauthorizeComputerUse` perm computed once, not a live accessor | **Rebut** — it re-checks via `await accessibilityGranted()` at call time; reviewer concluded "This is safe". |
| 2 | RISK | Tools advertised on Android before bridge installed → model could call a tool that never runs / false success | **Rebut** — `installMobileLocalExec()` runs synchronously in the client bootstrap **before** any component mounts; the injection gate also requires `this.localTools.length`, and `listTools()` yields `[]` when the bridge is absent, so nothing is advertised without a live bridge; the invoke fallback returns `is_error: true` (a failure, not a false success). |
| 3 | RISK/NIT | grants `JSON.parse` failure silently drops grants; no bridge-install signal | **Fixed** — added `console.warn` on grants-parse failure and a `console.debug` confirming bridge install (commit `eb1a93e`). Consent stays fail-closed. |

Verdict after round 1: converged.
