### PR TITLE
feat(chat): upsert tool_use_start + render streamed tool-call args (kill dead air)

### DIFF
--- a/change/@acedatacloud-nexior-109bd92e-4705-4607-a4c2-624387a1aa37.json
+++ b/change/@acedatacloud-nexior-109bd92e-4705-4607-a4c2-624387a1aa37.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chat: upsert tool_use_start by tool_id and stream tool-call args (tool_progress) so the running tool block appears immediately instead of a frozen screen while the model writes a big tool call",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/ToolActivity.vue
+++ b/src/components/chat/ToolActivity.vue
@@ -57,14 +57,20 @@ export default defineComponent({
       return TOOL_LABELS[name] || name.replace(/_/g, ' ');
     },
     inputText(): string {
-      if (!this.item.input) return '';
+      const input = this.item.input;
+      const hasInput = input && Object.keys(input).length > 0;
+      if (!hasInput) {
+        // Still being written: show the raw arguments text streaming in
+        // (input_stream) so a running tool isn't an empty block.
+        return this.item.input_stream || '';
+      }
       if (this.item.tool_name === 'code_execute') {
-        return (this.item.input.code as string) || '';
+        return (input.code as string) || '';
       }
       if (this.item.tool_name === 'web_search') {
-        return (this.item.input.query as string) || '';
+        return (input.query as string) || '';
       }
-      return JSON.stringify(this.item.input, null, 2);
+      return JSON.stringify(input, null, 2);
     }
   }
 });

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -102,6 +102,10 @@ export interface IChatMessageContentItem {
   output?: string;
   is_error?: boolean;
   duration_ms?: number;
+  // Raw tool-call arguments text streamed by the worker (`tool_progress`
+  // events) while the model is still writing the call. Shown live on the
+  // running block until the full parsed `input` arrives at finalize.
+  input_stream?: string;
   // `awaiting_input` is set on a `tool_use` block when the worker pauses the
   // turn for a user reply (see `ask_user_question` tool). `output` is absent
   // until the user submits an answer, which folds the block back to `done`.
@@ -318,6 +322,10 @@ export interface IChatConversationResponse {
   output?: string;
   is_error?: boolean;
   duration_ms?: number;
+  // Incremental tool-call arguments text (`type === 'tool_progress'`),
+  // streamed as the model writes a (possibly large) tool call so the UI
+  // isn't frozen while it's composed.
+  progress?: string;
   content?: string;
   artifact?: {
     type: string;

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -1153,35 +1153,64 @@ export default defineComponent({
               const target = this.messages[targetIndex];
               target.thinking = (target.thinking ?? '') + response.content;
             } else if (response.type === 'tool_use_start' && response.tool_id) {
-              // Flush any accumulated text before tool
-              if (currentText) {
-                contentParts.push({ type: 'text', text: currentText });
-                currentText = '';
-                answerOffset = response.answer?.length ?? 0;
+              // The worker announces a tool call the instant its name is known
+              // (arguments may still be streaming) and then re-emits
+              // tool_use_start once with the full parsed input / execution.
+              // UPSERT by tool_id so the two starts merge into ONE block
+              // instead of rendering a duplicate.
+              let toolItem = toolMap.get(response.tool_id);
+              if (toolItem) {
+                if (response.tool_name) toolItem.tool_name = response.tool_name;
+                if (response.tool_display_name) toolItem.tool_display_name = response.tool_display_name;
+                if (response.input && Object.keys(response.input).length > 0) {
+                  toolItem.input = response.input;
+                }
+              } else {
+                // Flush any accumulated text before the new tool block.
+                if (currentText) {
+                  contentParts.push({ type: 'text', text: currentText });
+                  currentText = '';
+                  answerOffset = response.answer?.length ?? 0;
+                }
+                toolItem = {
+                  type: 'tool_use',
+                  tool_id: response.tool_id,
+                  tool_name: response.tool_name,
+                  tool_display_name: response.tool_display_name,
+                  input: response.input,
+                  status: 'running'
+                };
+                contentParts.push(toolItem);
+                toolMap.set(response.tool_id, toolItem);
               }
-              const toolItem: IChatMessageContentItem = {
-                type: 'tool_use',
-                tool_id: response.tool_id,
-                tool_name: response.tool_name,
-                tool_display_name: response.tool_display_name,
-                input: response.input,
-                status: 'running'
-              };
-              contentParts.push(toolItem);
-              toolMap.set(response.tool_id, toolItem);
               // Desktop: defer the local run until this paused stream fully
               // finalizes (so this.conversationId + route are settled for a
               // brand-new chat and the `answering` flag isn't cleared
               // mid-resume). The model can fan out several client tools in one
               // turn, so we QUEUE them and run all on finalize, resuming with
-              // every result in one request.
-              if (supportsClientTools() && response.execution === 'client') {
+              // every result in one request. The `execution:'client'` class
+              // arrives on the re-affirm start (not the early announce), so
+              // guard against double-enqueue across the two starts.
+              if (
+                supportsClientTools() &&
+                response.execution === 'client' &&
+                !this.pendingClientTools.some((t) => t.toolId === response.tool_id)
+              ) {
                 toolItem.status = 'awaiting_input';
                 this.pendingClientTools.push({
                   toolId: response.tool_id,
                   name: response.tool_name || '',
                   input: response.input || {}
                 });
+              }
+            } else if (response.type === 'tool_progress' && response.tool_id) {
+              // The worker streams the tool-call arguments text as the model
+              // writes it. Surface it live on the running block so the user
+              // sees the command/script being composed instead of a frozen
+              // screen while a large tool call is generated.
+              const toolItem = toolMap.get(response.tool_id);
+              if (toolItem) {
+                toolItem.input_stream = (toolItem.input_stream ?? '') + (response.progress ?? '');
               }
             } else if (response.type === 'tool_result' && response.tool_id) {
               const toolItem = toolMap.get(response.tool_id);
@@ -1190,6 +1219,9 @@ export default defineComponent({
                 toolItem.is_error = response.is_error;
                 toolItem.duration_ms = response.duration_ms;
                 toolItem.status = 'done';
+                // The full parsed `input` is set by now; drop the raw
+                // streaming args so the block renders structured input.
+                delete toolItem.input_stream;
                 // Strip stale pending_question after fold (defensive — the
                 // worker shouldn't emit tool_result for an awaiting block,
                 // but if it does, the card must collapse cleanly).


### PR DESCRIPTION
## Why

Pairs with **PlatformService aichat2 worker #1270**. Studio agents appeared **frozen mid-run** because the model can spend a long time (observed **173s** on prod conv `c0ec07a6`) writing a large tool call — and tool-call *argument* tokens don't stream as visible text, so the client got zero output the whole time, then everything flushed at once.

The worker now (a) announces a tool call the instant its `name` is known and (b) streams the argument text (`tool_progress`) as the model writes it, then (c) re-affirms the start with the full parsed input at finalize. This PR makes the frontend consume that correctly.

## Changes

- **`Conversation.vue`** — **upsert `tool_use_start` by `tool_id`**: the worker emits an early announce *and* a re-affirm start (two per `tool_id`), so merge them into ONE block instead of pushing a duplicate. Desktop client-tool enqueue is guarded against the two starts. New **`tool_progress`** handler accumulates the streamed argument text onto the running block (`input_stream`), cleared when `tool_result` folds in.
- **`ToolActivity.vue`** — while `input` is still empty, render `input_stream` so a running tool shows the command/script being composed instead of an empty block.
- **`models/chat.ts`** — `IChatMessageContentItem.input_stream`, `IChatConversationResponse.progress`.

## Effect

The running tool block now appears the instant the model starts a tool call (spinner + name), and — when expanded — shows the arguments streaming in live, instead of a frozen screen. Backward-compatible with the current worker (a single `tool_use_start` still creates one block).

## Deploy order

⚠️ **Deploy this before** PlatformService #1270 — the upsert is what prevents duplicate tool blocks once the worker starts emitting two `tool_use_start` per tool.

## Validation

`vue-tsc -b` clean · 55 chat tests pass · eslint clean · beachball change file added.
