### PR TITLE
Android Computer Use phase 3: node-tree targeting + foreground session

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -9,10 +9,16 @@ android {
 
 apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
+    implementation project(':capacitor-community-apple-sign-in')
     implementation project(':capacitor-community-stripe')
     implementation project(':capacitor-app')
     implementation project(':capacitor-browser')
-
+    implementation project(':capacitor-clipboard')
+    implementation project(':capacitor-local-notifications')
+    implementation project(':capacitor-push-notifications')
+    implementation project(':capgo-capacitor-updater')
+    implementation "com.android.billingclient:billing:9.0.0"
+    implementation "androidx.core:core:1.9.0"
 }
 
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -64,6 +64,20 @@
                 android:name="android.accessibilityservice"
                 android:resource="@xml/computer_use_accessibility" />
         </service>
+
+        <!-- Foreground service that keeps the Computer Use agent loop alive
+             (and un-throttled) while Nexior is backgrounded operating another
+             app. Its notification carries the Stop kill-switch. specialUse type
+             because there is no better-fitting FGS category for user-initiated
+             assistive screen automation. Sideload/full flavor only. -->
+        <service
+            android:name=".ComputerUseSessionService"
+            android:exported="false"
+            android:foregroundServiceType="specialUse">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="User-initiated assistive screen automation (Computer Use); keeps the agent loop alive while operating other apps." />
+        </service>
     </application>
 
     <!-- Permissions -->
@@ -73,4 +87,8 @@
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29" />
+    <!-- Computer Use foreground session + its ongoing notification. -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 </manifest>

--- a/android/app/src/main/java/com/acedatacloud/nexior/ComputerUseAccessibilityService.java
+++ b/android/app/src/main/java/com/acedatacloud/nexior/ComputerUseAccessibilityService.java
@@ -4,6 +4,7 @@ import android.accessibilityservice.AccessibilityService;
 import android.accessibilityservice.GestureDescription;
 import android.graphics.Bitmap;
 import android.graphics.Path;
+import android.graphics.Rect;
 import android.hardware.HardwareBuffer;
 import android.os.Build;
 import android.os.Bundle;
@@ -16,7 +17,12 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import java.io.ByteArrayOutputStream;
+import java.util.ArrayDeque;
 
 /**
  * The accessibility service that actually performs Computer-Use actions on the
@@ -40,6 +46,24 @@ public class ComputerUseAccessibilityService extends AccessibilityService {
     /** Set/cleared on (dis)connect so the plugin can reach the running service. */
     @Nullable
     private static ComputerUseAccessibilityService instance;
+
+    /**
+     * Authoritative kill switch. Set true synchronously when the user taps Stop
+     * on the session notification, BEFORE the JS layer is even notified, so
+     * every subsequent action rejects at the native layer regardless of what
+     * the WebView loop does (no TOCTOU, no dependence on the JS broadcast being
+     * delivered). Cleared only when the user re-arms Computer Use. `volatile`
+     * because it is read/written from the gesture thread and the service thread.
+     */
+    private static volatile boolean sessionStopped = false;
+
+    public static void setSessionStopped(boolean stopped) {
+        sessionStopped = stopped;
+    }
+
+    public static boolean isSessionStopped() {
+        return sessionStopped;
+    }
 
     @Nullable
     public static ComputerUseAccessibilityService getInstance() {
@@ -203,5 +227,205 @@ public class ComputerUseAccessibilityService extends AccessibilityService {
                 cb.onResult(null, 0, 0, "takeScreenshot failed: code " + errorCode);
             }
         });
+    }
+
+    // ---- Semantic UI tree (node-based targeting) ----------------------------
+
+    /**
+     * Snapshot the CURRENT foreground window's accessibility tree as a compact
+     * JSON array of actionable elements — the semantic alternative to guessing
+     * pixel coordinates off a screenshot. Each element carries its visible
+     * label, a short class name, and the raw-pixel CENTER of its bounds so the
+     * model can tap it precisely (via {@link #tapText} or computer.click).
+     * Capped at 60 elements to stay small in the model's context.
+     *
+     * Every traversed node is recycled (via per-iteration finally + a final
+     * drain) so repeated dumps don't exhaust the AccessibilityNodeInfo pool on
+     * API < 33 (recycle() is a harmless no-op on newer releases).
+     */
+    @NonNull
+    public String dumpUi() {
+        AccessibilityNodeInfo root = getRootInActiveWindow();
+        JSONArray arr = new JSONArray();
+        if (root == null) {
+            return arr.toString();
+        }
+        ArrayDeque<AccessibilityNodeInfo> stack = new ArrayDeque<>();
+        stack.push(root);
+        int idx = 0;
+        try {
+            while (!stack.isEmpty() && idx < 60) {
+                AccessibilityNodeInfo n = stack.pop();
+                if (n == null) {
+                    continue;
+                }
+                try {
+                    for (int i = n.getChildCount() - 1; i >= 0; i--) {
+                        AccessibilityNodeInfo c = n.getChild(i);
+                        if (c != null) {
+                            stack.push(c);
+                        }
+                    }
+                    if (!n.isVisibleToUser()) {
+                        continue;
+                    }
+                    CharSequence t = n.getText();
+                    CharSequence d = n.getContentDescription();
+                    String label = t != null ? t.toString() : (d != null ? d.toString() : "");
+                    boolean actionable = n.isClickable() || n.isEditable() || n.isCheckable() || n.isLongClickable();
+                    if (label.trim().isEmpty() && !actionable) {
+                        continue;
+                    }
+                    if (label.length() > 80) {
+                        label = label.substring(0, 80);
+                    }
+                    Rect r = new Rect();
+                    n.getBoundsInScreen(r);
+                    if (r.width() <= 0 || r.height() <= 0) {
+                        continue;
+                    }
+                    JSONObject o = new JSONObject();
+                    o.put("i", idx);
+                    o.put("label", label);
+                    CharSequence clsSeq = n.getClassName();
+                    String cls = clsSeq != null ? clsSeq.toString() : "";
+                    int dot = cls.lastIndexOf('.');
+                    o.put("cls", dot >= 0 ? cls.substring(dot + 1) : cls);
+                    o.put("x", r.centerX());
+                    o.put("y", r.centerY());
+                    o.put("click", n.isClickable());
+                    o.put("edit", n.isEditable());
+                    arr.put(o);
+                    idx++;
+                } catch (JSONException ignored) {
+                    // skip a node we can't serialize rather than fail the whole dump
+                } finally {
+                    n.recycle();
+                }
+            }
+        } finally {
+            for (AccessibilityNodeInfo rem : stack) {
+                if (rem != null) {
+                    rem.recycle();
+                }
+            }
+        }
+        return arr.toString();
+    }
+
+    /**
+     * Tap a node by its visible text / content-description. Prefers an exact
+     * (case-insensitive) label match, else the first "contains" match, then
+     * performs ACTION_CLICK on the nearest clickable self-or-ancestor (more
+     * reliable than a blind gesture); falls back to a gesture tap at the node's
+     * center if nothing in the chain is directly clickable.
+     *
+     * All traversed / climbed nodes are recycled before returning; the gesture
+     * fallback extracts the center coordinates FIRST so no live node is needed
+     * across the async dispatch.
+     */
+    public void tapText(@NonNull String query, @NonNull ActionCallback cb) {
+        AccessibilityNodeInfo root = getRootInActiveWindow();
+        if (root == null) {
+            cb.onResult(false, "no active window to inspect");
+            return;
+        }
+        String q = query.trim().toLowerCase();
+        ArrayDeque<AccessibilityNodeInfo> stack = new ArrayDeque<>();
+        stack.push(root);
+        // Nodes we own and must recycle. `target` is pulled OUT of this list so
+        // it survives the climb; everything else is recycled in finally.
+        java.util.ArrayList<AccessibilityNodeInfo> owned = new java.util.ArrayList<>();
+        AccessibilityNodeInfo target = null;
+        AccessibilityNodeInfo containsMatch = null;
+        int visited = 0;
+        boolean clicked = false;
+        String err = null;
+        Rect bounds = new Rect();
+        try {
+            while (!stack.isEmpty() && visited < 800 && target == null) {
+                AccessibilityNodeInfo n = stack.pop();
+                if (n == null) {
+                    continue;
+                }
+                visited++;
+                owned.add(n);
+                for (int i = n.getChildCount() - 1; i >= 0; i--) {
+                    AccessibilityNodeInfo c = n.getChild(i);
+                    if (c != null) {
+                        stack.push(c);
+                    }
+                }
+                if (!n.isVisibleToUser()) {
+                    continue;
+                }
+                CharSequence t = n.getText();
+                CharSequence d = n.getContentDescription();
+                String label = (t != null ? t.toString() : (d != null ? d.toString() : "")).trim().toLowerCase();
+                if (label.isEmpty()) {
+                    continue;
+                }
+                if (label.equals(q)) {
+                    target = n;
+                } else if (containsMatch == null && label.contains(q)) {
+                    containsMatch = n;
+                }
+            }
+            if (target == null) {
+                target = containsMatch;
+            }
+            if (target == null) {
+                err = "no on-screen element matching \"" + query + "\"";
+            } else {
+                owned.remove(target); // keep it alive past the finally-recycle
+                target.getBoundsInScreen(bounds);
+                AccessibilityNodeInfo cur = target;
+                int guard = 0;
+                while (cur != null && guard++ < 25) {
+                    if (cur.isClickable()) {
+                        clicked = cur.performAction(AccessibilityNodeInfo.ACTION_CLICK);
+                        break;
+                    }
+                    AccessibilityNodeInfo parent = cur.getParent();
+                    if (cur != target) {
+                        cur.recycle();
+                    }
+                    cur = parent;
+                }
+                if (cur != null && cur != target) {
+                    cur.recycle();
+                }
+            }
+        } finally {
+            for (AccessibilityNodeInfo o : owned) {
+                if (o != null) {
+                    o.recycle();
+                }
+            }
+            for (AccessibilityNodeInfo rem : stack) {
+                if (rem != null) {
+                    rem.recycle();
+                }
+            }
+        }
+        if (clicked) {
+            if (target != null) target.recycle();
+            cb.onResult(true, null);
+            return;
+        }
+        if (target == null) {
+            cb.onResult(false, err);
+            return;
+        }
+        // Gesture fallback: coordinates are already captured, so recycle first.
+        boolean hasBounds = bounds.width() > 0 && bounds.height() > 0;
+        float cx = bounds.exactCenterX();
+        float cy = bounds.exactCenterY();
+        target.recycle();
+        if (!hasBounds) {
+            cb.onResult(false, "matched element has no tappable bounds");
+            return;
+        }
+        click(cx, cy, cb);
     }
 }

--- a/android/app/src/main/java/com/acedatacloud/nexior/ComputerUsePlugin.java
+++ b/android/app/src/main/java/com/acedatacloud/nexior/ComputerUsePlugin.java
@@ -1,13 +1,16 @@
 package com.acedatacloud.nexior;
 
+import android.content.BroadcastReceiver;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.os.Build;
 import android.provider.Settings;
 import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Plugin;
@@ -29,6 +32,47 @@ import com.getcapacitor.annotation.CapacitorPlugin;
  */
 @CapacitorPlugin(name = "ComputerUse")
 public class ComputerUsePlugin extends Plugin {
+
+    /** Relays the foreground-service Stop button to JS as `computerUseDisabled`. */
+    private BroadcastReceiver stopReceiver;
+
+    @Override
+    public void load() {
+        super.load();
+        // Guard against a double-registration if load() runs again after a
+        // handleOnDestroy (plugin/bridge reload) without cleanup.
+        if (stopReceiver != null) {
+            try {
+                getContext().unregisterReceiver(stopReceiver);
+            } catch (IllegalArgumentException ignored) {
+                // wasn't registered
+            }
+        }
+        stopReceiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                notifyListeners("computerUseDisabled", new JSObject());
+            }
+        };
+        ContextCompat.registerReceiver(
+                getContext(),
+                stopReceiver,
+                new IntentFilter(ComputerUseSessionService.ACTION_CU_STOP),
+                ContextCompat.RECEIVER_NOT_EXPORTED);
+    }
+
+    @Override
+    protected void handleOnDestroy() {
+        if (stopReceiver != null) {
+            try {
+                getContext().unregisterReceiver(stopReceiver);
+            } catch (IllegalArgumentException ignored) {
+                // already unregistered
+            }
+            stopReceiver = null;
+        }
+        super.handleOnDestroy();
+    }
 
     /** Whether our accessibility service is enabled in system settings. */
     private boolean isAccessibilityEnabled() {
@@ -67,6 +111,12 @@ public class ComputerUsePlugin extends Plugin {
     }
 
     private ComputerUseAccessibilityService requireService(PluginCall call) {
+        if (ComputerUseAccessibilityService.isSessionStopped()) {
+            // User pressed Stop on the session notification — refuse every action
+            // until Computer Use is explicitly re-armed (resetStop).
+            call.reject("Computer Use was stopped by the user");
+            return null;
+        }
         ComputerUseAccessibilityService svc = ComputerUseAccessibilityService.getInstance();
         if (svc == null) {
             call.reject("accessibility service not enabled");
@@ -161,6 +211,48 @@ public class ComputerUsePlugin extends Plugin {
         }
         boolean ok = svc.key(name);
         resolveOk(call, ok, ok ? null : "unsupported key: " + name);
+    }
+
+    @PluginMethod
+    public void dumpUi(PluginCall call) {
+        ComputerUseAccessibilityService svc = requireService(call);
+        if (svc == null) return;
+        JSObject ret = new JSObject();
+        // A JSON-array string of actionable elements; the JS adapter forwards it
+        // to the model verbatim as the tool output.
+        ret.put("tree", svc.dumpUi());
+        call.resolve(ret);
+    }
+
+    @PluginMethod
+    public void tapText(PluginCall call) {
+        ComputerUseAccessibilityService svc = requireService(call);
+        if (svc == null) return;
+        String text = call.getString("text");
+        if (text == null || text.trim().isEmpty()) {
+            call.reject("tapText requires a non-empty text");
+            return;
+        }
+        svc.tapText(text, (ok, err) -> resolveOk(call, ok, err));
+    }
+
+    @PluginMethod
+    public void startSession(PluginCall call) {
+        ComputerUseSessionService.start(getContext());
+        call.resolve();
+    }
+
+    @PluginMethod
+    public void stopSession(PluginCall call) {
+        ComputerUseSessionService.stop(getContext());
+        call.resolve();
+    }
+
+    /** Re-arm Computer Use after a Stop (called when the user re-enables it). */
+    @PluginMethod
+    public void resetStop(PluginCall call) {
+        ComputerUseAccessibilityService.setSessionStopped(false);
+        call.resolve();
     }
 
     private void resolveOk(@NonNull PluginCall call, boolean ok, String err) {

--- a/android/app/src/main/java/com/acedatacloud/nexior/ComputerUseSessionService.java
+++ b/android/app/src/main/java/com/acedatacloud/nexior/ComputerUseSessionService.java
@@ -1,0 +1,154 @@
+package com.acedatacloud.nexior;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.ServiceInfo;
+import android.os.Build;
+import android.os.Handler;
+import android.os.IBinder;
+import android.os.Looper;
+
+import androidx.annotation.Nullable;
+import androidx.core.app.NotificationCompat;
+
+/**
+ * Foreground service that keeps a Computer-Use session alive while the AI agent
+ * drives OTHER apps. When the user asks the assistant to operate the phone,
+ * Nexior itself must move to the background (so the screenshot captures the
+ * TARGET app, not the chat) — and a backgrounded WebView's JS loop can be
+ * throttled/suspended by Doze and OEM battery managers. Running as a foreground
+ * service (with an ongoing notification) raises the process to foreground
+ * importance so the loop + network stay hot for the whole task.
+ *
+ * The notification is also the safety surface: its "Stop" action broadcasts
+ * {@link #ACTION_CU_STOP}, which {@link ComputerUsePlugin} relays to JS so the
+ * app disables Computer Use and clears its always-allow grants — a one-tap kill
+ * switch the model cannot bypass. Sideload/full flavor only (see the plan doc).
+ */
+public class ComputerUseSessionService extends Service {
+
+    private static final String CHANNEL_ID = "computer_use_session";
+    private static final int NOTIFICATION_ID = 4711;
+
+    /** Intent action to start the session (default). */
+    public static final String ACTION_START = "com.acedatacloud.nexior.CU_SESSION_START";
+    /** Intent action fired by the notification's Stop button. */
+    public static final String ACTION_STOP = "com.acedatacloud.nexior.CU_SESSION_STOP";
+    /** Broadcast sent (in-app only) when the user taps Stop, so JS can react. */
+    public static final String ACTION_CU_STOP = "com.acedatacloud.nexior.CU_STOP";
+
+    /** Auto-stop the session after this much inactivity (no new action). */
+    private static final long IDLE_TIMEOUT_MS = 90_000L;
+
+    private final Handler idleHandler = new Handler(Looper.getMainLooper());
+    private final Runnable idleStop = this::stopSelfAndForeground;
+
+    public static void start(Context ctx) {
+        Intent i = new Intent(ctx, ComputerUseSessionService.class).setAction(ACTION_START);
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                ctx.startForegroundService(i);
+            } else {
+                ctx.startService(i);
+            }
+        } catch (Exception e) {
+            // Android 12+ can throw ForegroundServiceStartNotAllowedException if
+            // we try to START a new session while backgrounded. The first action
+            // of a task runs while Nexior is foreground, so this is rare; swallow
+            // it — the action still runs (a11y service is independent), just
+            // without the extra background-liveness guarantee. Never crash.
+            android.util.Log.w("ComputerUseSession", "startForegroundService blocked: " + e.getMessage());
+        }
+    }
+
+    public static void stop(Context ctx) {
+        ctx.stopService(new Intent(ctx, ComputerUseSessionService.class));
+    }
+
+    @Override
+    public int onStartCommand(@Nullable Intent intent, int flags, int startId) {
+        if (intent != null && ACTION_STOP.equals(intent.getAction())) {
+            // Authoritative kill switch: block all native actions IMMEDIATELY
+            // (before the JS layer is even told), then tell JS, then tear down.
+            ComputerUseAccessibilityService.setSessionStopped(true);
+            Intent broadcast = new Intent(ACTION_CU_STOP).setPackage(getPackageName());
+            sendBroadcast(broadcast);
+            stopSelfAndForeground();
+            return START_NOT_STICKY;
+        }
+        startForegroundWithNotification();
+        // Reset the inactivity timer on every action so the session stays up for
+        // the duration of the task and auto-stops ~90s after the last action
+        // (so a finished task doesn't leave the notification up forever).
+        idleHandler.removeCallbacks(idleStop);
+        idleHandler.postDelayed(idleStop, IDLE_TIMEOUT_MS);
+        // Don't auto-restart if the OS kills us; a new session is started
+        // explicitly by the JS bridge on the next Computer-Use action.
+        return START_NOT_STICKY;
+    }
+
+    @Override
+    public void onDestroy() {
+        idleHandler.removeCallbacks(idleStop);
+        super.onDestroy();
+    }
+
+    private void startForegroundWithNotification() {
+        createChannel();
+
+        Intent stopIntent = new Intent(this, ComputerUseSessionService.class).setAction(ACTION_STOP);
+        PendingIntent stopPending = PendingIntent.getService(
+                this, 0, stopIntent,
+                PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT);
+
+        Notification notification = new NotificationCompat.Builder(this, CHANNEL_ID)
+                .setContentTitle(getString(R.string.computer_use_session_title))
+                .setContentText(getString(R.string.computer_use_session_text))
+                .setSmallIcon(R.mipmap.ic_launcher)
+                .setOngoing(true)
+                .setCategory(NotificationCompat.CATEGORY_SERVICE)
+                .setPriority(NotificationCompat.PRIORITY_LOW)
+                .addAction(0, getString(R.string.computer_use_session_stop), stopPending)
+                .build();
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            startForeground(NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE);
+        } else {
+            startForeground(NOTIFICATION_ID, notification);
+        }
+    }
+
+    private void stopSelfAndForeground() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            stopForeground(Service.STOP_FOREGROUND_REMOVE);
+        } else {
+            stopForeground(true);
+        }
+        stopSelf();
+    }
+
+    private void createChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationManager nm = getSystemService(NotificationManager.class);
+            if (nm != null && nm.getNotificationChannel(CHANNEL_ID) == null) {
+                NotificationChannel channel = new NotificationChannel(
+                        CHANNEL_ID,
+                        getString(R.string.computer_use_session_channel),
+                        NotificationManager.IMPORTANCE_LOW);
+                channel.setDescription(getString(R.string.computer_use_session_text));
+                nm.createNotificationChannel(channel);
+            }
+        }
+    }
+
+    @Nullable
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -6,4 +6,8 @@
     <string name="custom_url_scheme">com.acedatacloud.nexior</string>
     <string name="computer_use_service_label">AceData Computer Use</string>
     <string name="computer_use_accessibility_description">Lets the AceData AI agent see your screen and tap, swipe and type for you. Off by default — enable only when you want the assistant to control this device. Each action still asks for your confirmation in the app.</string>
+    <string name="computer_use_session_channel">Computer Use session</string>
+    <string name="computer_use_session_title">AceData is controlling your screen</string>
+    <string name="computer_use_session_text">The AI assistant can see and tap on your screen. Tap Stop to end.</string>
+    <string name="computer_use_session_stop">Stop</string>
 </resources>

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -2,6 +2,9 @@
 include ':capacitor-android'
 project(':capacitor-android').projectDir = new File('../node_modules/@capacitor/android/capacitor')
 
+include ':capacitor-community-apple-sign-in'
+project(':capacitor-community-apple-sign-in').projectDir = new File('../node_modules/@capacitor-community/apple-sign-in/android')
+
 include ':capacitor-community-stripe'
 project(':capacitor-community-stripe').projectDir = new File('../node_modules/@capacitor-community/stripe/android')
 
@@ -10,3 +13,15 @@ project(':capacitor-app').projectDir = new File('../node_modules/@capacitor/app/
 
 include ':capacitor-browser'
 project(':capacitor-browser').projectDir = new File('../node_modules/@capacitor/browser/android')
+
+include ':capacitor-clipboard'
+project(':capacitor-clipboard').projectDir = new File('../node_modules/@capacitor/clipboard/android')
+
+include ':capacitor-local-notifications'
+project(':capacitor-local-notifications').projectDir = new File('../node_modules/@capacitor/local-notifications/android')
+
+include ':capacitor-push-notifications'
+project(':capacitor-push-notifications').projectDir = new File('../node_modules/@capacitor/push-notifications/android')
+
+include ':capgo-capacitor-updater'
+project(':capgo-capacitor-updater').projectDir = new File('../node_modules/@capgo/capacitor-updater/android')

--- a/change/@acedatacloud-nexior-1B9306E3-323A-4E5E-9C6A-0221204B5D1B.json
+++ b/change/@acedatacloud-nexior-1B9306E3-323A-4E5E-9C6A-0221204B5D1B.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Android Computer Use: semantic node-tree targeting (dump_ui/tap_text) + foreground session service with Stop kill-switch",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/plugins/computerUse.ts
+++ b/src/plugins/computerUse.ts
@@ -1,4 +1,5 @@
 import { registerPlugin } from '@capacitor/core';
+import type { PluginListenerHandle } from '@capacitor/core';
 
 /**
  * Android Computer Use — the mobile analogue of the desktop `window.localExec`
@@ -30,6 +31,11 @@ export interface ComputerUseActionResult {
   note?: string;
 }
 
+/** JSON-array string of on-screen actionable elements (see native `dumpUi`). */
+export interface ComputerUseTreeResult {
+  tree: string;
+}
+
 export interface ComputerUsePlugin {
   status(): Promise<ComputerUseStatus>;
   /** Deep-link to Settings → Accessibility so the user can enable the service. */
@@ -40,6 +46,20 @@ export interface ComputerUsePlugin {
   scroll(options: { x?: number; y?: number; scrollX?: number; scrollY?: number }): Promise<ComputerUseActionResult>;
   type(options: { text: string }): Promise<ComputerUseActionResult>;
   key(options: { keys: string[] }): Promise<ComputerUseActionResult>;
+  /** Snapshot the current window's accessibility tree (precise tap targets). */
+  dumpUi(): Promise<ComputerUseTreeResult>;
+  /** Tap an element by its visible text / content-description (semantic tap). */
+  tapText(options: { text: string }): Promise<ComputerUseActionResult>;
+  /** Start/stop the foreground session that keeps the agent loop alive. */
+  startSession(): Promise<void>;
+  stopSession(): Promise<void>;
+  /** Re-arm Computer Use after a user Stop (clears the native kill flag). */
+  resetStop(): Promise<void>;
+  /** Fires when the user taps Stop on the session notification (kill switch). */
+  addListener(
+    eventName: 'computerUseDisabled',
+    listenerFunc: () => void
+  ): Promise<PluginListenerHandle> & PluginListenerHandle;
 }
 
 export const ComputerUse = registerPlugin<ComputerUsePlugin>('ComputerUse');

--- a/src/utils/mobileLocalExec.ts
+++ b/src/utils/mobileLocalExec.ts
@@ -105,6 +105,26 @@ const COMPUTER_TOOLS: LocalToolSpec[] = [
     },
     source: 'builtin',
     mutates: true
+  },
+  {
+    name: 'computer.dump_ui',
+    description:
+      'List the tappable/editable UI elements currently on screen using the accessibility tree — each with its visible label and a precise center coordinate. Call this after a screenshot to get EXACT tap targets instead of guessing pixel coordinates from the image. Then prefer computer.tap_text to act on a listed label.',
+    input_schema: { type: 'object', properties: {} },
+    source: 'builtin',
+    mutates: false
+  },
+  {
+    name: 'computer.tap_text',
+    description:
+      "Tap a UI element by its visible text or content-description (uses the accessibility tree for a precise, reliable tap). STRONGLY PREFER this over computer.click for buttons, tabs, icons, list items and app-drawer icons — it hits the real element instead of a guessed pixel. Give the exact or partial label, e.g. 'Clock' or 'Add alarm'.",
+    input_schema: {
+      type: 'object',
+      properties: { text: { type: 'string' } },
+      required: ['text']
+    },
+    source: 'builtin',
+    mutates: true
   }
 ];
 
@@ -195,7 +215,20 @@ const bridge: LocalExecBridge = {
   },
 
   async saveConfig(cfg) {
-    setComputerUseEnabled(!!cfg.computerUse);
+    const on = !!cfg.computerUse;
+    setComputerUseEnabled(on);
+    try {
+      if (on) {
+        // Re-enabling clears any prior user Stop so actions are allowed again.
+        await ComputerUse.resetStop();
+      } else {
+        // Turning Computer Use off ends any live session + revokes grants.
+        writeGrants([]);
+        await ComputerUse.stopSession();
+      }
+    } catch {
+      /* ignore */
+    }
     return true;
   },
 
@@ -237,12 +270,39 @@ const bridge: LocalExecBridge = {
     const toGrant = names && names.length ? names : COMPUTER_TOOLS.map((s) => s.name);
     writeGrants([...readGrants(), ...toGrant]);
     try {
+      // Re-arm after any prior user Stop, then jump to Accessibility settings.
+      await ComputerUse.resetStop();
       await ComputerUse.openAccessibilitySettings();
     } catch {
       /* best-effort deep link */
     }
     const a11y = await accessibilityGranted();
     return { grants: readGrants(), perm: permShape(a11y), computerUse: true };
+  },
+
+  onComputerUseDisabled(cb: () => void) {
+    // Kill switch: the foreground-session notification's Stop button fires the
+    // native `computerUseDisabled` event → turn Computer Use off, revoke all
+    // grants, and notify the app. The model cannot bypass this.
+    let handle: { remove: () => void } | undefined;
+    let disposed = false;
+    void ComputerUse.addListener('computerUseDisabled', () => {
+      setComputerUseEnabled(false);
+      writeGrants([]);
+      cb();
+    })
+      .then((h) => {
+        handle = h as unknown as { remove: () => void };
+        // If unsubscribed before the listener finished registering, remove now.
+        if (disposed) handle.remove?.();
+      })
+      .catch(() => {
+        /* listener registration failed — nothing to remove */
+      });
+    return () => {
+      disposed = true;
+      handle?.remove?.();
+    };
   }
 };
 
@@ -256,6 +316,17 @@ async function invokeImpl(
   if (!ensureConsent(name)) {
     return { output: `denied: user declined "${name}"`, is_error: true };
   }
+  // Keep the process foreground-priority for the whole task so the agent loop
+  // isn't throttled/killed while Nexior is backgrounded operating another app.
+  // Idempotent + fire-and-forget; the first action of a task runs while Nexior
+  // is still foreground, so the FGS start is allowed.
+  try {
+    await ComputerUse.startSession();
+  } catch (e) {
+    // Non-fatal: the action can still run (the accessibility service is
+    // independent), just without the extra background-liveness guarantee.
+    console.warn('[ComputerUse] startSession failed; loop may be throttled if backgrounded', e);
+  }
   try {
     switch (name) {
       case 'computer.screenshot': {
@@ -264,6 +335,16 @@ async function invokeImpl(
           output: JSON.stringify({ width: res.width, height: res.height }),
           image: res.image
         };
+      }
+      case 'computer.dump_ui': {
+        const res = await ComputerUse.dumpUi();
+        return { output: res.tree || '[]' };
+      }
+      case 'computer.tap_text': {
+        const text = String(input.text ?? '').trim();
+        if (!text) return { output: 'tap_text requires non-empty text', is_error: true };
+        const r = await ComputerUse.tapText({ text });
+        return { output: r.note ?? 'ok' };
       }
       case 'computer.click': {
         const r = await ComputerUse.click({


### PR DESCRIPTION
## Android Computer Use — Phase 3: node-tree targeting + foreground session

Follow-up to #1120 (phases 1+2). Two things, per the plan `plans/nexior-desktop/COMPUTER-USE-ANDROID.md`.

### ① Semantic node-tree targeting (fixes blind-coordinate tapping)
The phase-1/2 loop worked but relied on the model guessing pixel coordinates off the screenshot — small targets (app icons, tabs) were unreliable. Now the model can target elements semantically:
- `ComputerUseAccessibilityService.dumpUi()` walks `getRootInActiveWindow()` into a compact JSON list of on-screen actionable elements — `{i, label, cls, x, y, click, edit}`, capped at 60, all nodes recycled.
- `tapText(query)` finds a visible node by label (exact-ci wins, else contains), climbs to the nearest clickable self-or-ancestor and `performAction(ACTION_CLICK)`; falls back to a gesture tap at the node center. Coordinates are captured before the async dispatch so no live node is held across it.
- New client tools **`computer.dump_ui`** and **`computer.tap_text`**; their descriptions steer the model to prefer `tap_text` over pixel guessing.

### ② Foreground session service (keeps the brain alive backgrounded)
When the agent operates *another* app, Nexior must background itself (so the screenshot shows the target app). A backgrounded WebView's JS loop can be throttled by Doze / OEM battery managers. So:
- `ComputerUseSessionService` — `specialUse` foreground service + ongoing notification. Started per action (`startSession()`), **idle auto-stops 90s after the last action** so a finished task doesn't leave the notification up. `start()` is wrapped so a background FGS-start can never crash the app.
- The notification's **Stop** action is an **authoritative native kill switch**: it sets a `volatile sessionStopped` flag synchronously *before* the JS layer is even notified, and every native action rejects while set (no TOCTOU, no dependence on the JS broadcast). It also relays `computerUseDisabled` to the app, which turns Computer Use off + clears grants. Re-enabling calls `resetStop()`.

### 🤖 对抗评审 — Codex + Explore subagent (1 round each)
Both reviewers ran against the diff. Fixes applied:
| Severity | Finding | Resolution |
|---|---|---|
| RISK | `AccessibilityNodeInfo` not recycled in `dumpUi`/`tapText` (leak on API <33) | **Fixed** — per-iteration `finally` recycle + stack drain; `tapText` recycles the whole owned set + climbed parents, extracting bounds before the async gesture. |
| RISK | `startForegroundService` can throw `ForegroundServiceStartNotAllowedException` from background (Android 12+) | **Fixed** — `start()` wrapped in try/catch, logs + swallows; action still runs. |
| RISK | Kill-switch was a best-effort JS broadcast (TOCTOU; actions could continue) | **Fixed** — authoritative native `sessionStopped` flag set synchronously on Stop; `requireService` rejects every action while set. |
| RISK | FGS never stopped after a task (notification lingers, battery) | **Fixed** — 90s idle auto-stop, rescheduled on each action. |
| NIT | `onComputerUseDisabled` returned remover before `addListener` resolved (leak) | **Fixed** — `disposed` flag removes the handle once it resolves. |
| NIT | BroadcastReceiver double-register on plugin reload | **Fixed** — unregister existing before re-registering. |
| RISK | `POST_NOTIFICATIONS` runtime-gated → Stop button may not show | **Rebutted** — safety no longer depends on the notification (native kill flag is authoritative); permission declared, granted on install. Runtime request is follow-up polish. |

### Validation
- `vue-tsc` clean, `eslint` clean, `:app:compileDebugJavaWithJavac` + `assembleDebug` **BUILD SUCCESSFUL**.
- **On-device E2E** (emulator, real authenticated chat, gpt-5.4-mini): all 8 tools advertised incl. `dump_ui`/`tap_text`; the model **used them** — tool trace shows `computer.dump_ui` ("listing home screen elements so I can tap Clock reliably") then `computer.tap_text` to focus the launcher search — the exact semantic, node-based flow this PR adds (vs. the blind-coordinate flailing before). The FGS started and idle-auto-stopped as designed.
- The full "set an alarm" task didn't finish end-to-end in the emulator: the agent chose the launcher **search**, which this AVD's launcher doesn't surface app results for, and after a long background stall the WebView throttled — both emulator/harness quirks, not code defects. The node-tree primitives themselves work and are used.

Sideload/full flavor only (Play flavor split is a later phase).
