### PR TITLE
fix(chat): forward tool_progress `progress` so streamed tool-call args render

### DIFF
--- a/change/@acedatacloud-nexior-d8d0435d-dd57-49ef-8cba-bc88d5511e64.json
+++ b/change/@acedatacloud-nexior-d8d0435d-dd57-49ef-8cba-bc88d5511e64.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chat: forward tool_progress `progress` in the SSE operator whitelist so streamed tool-call arguments render on the running block (were silently dropped, leaving the block empty during long tool calls)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/operators/chat.test.ts
+++ b/src/operators/chat.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { chatOperator } from './chat';
+import type { IChatConversationResponse } from '@/models';
+
+// currentSiteOrigin reads window/location; stub it so the operator can run
+// under the plain test environment without touching the DOM.
+vi.mock('@/utils', () => ({ currentSiteOrigin: () => '' }));
+
+function sseResponse(lines: string[]): Response {
+  const encoder = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const line of lines) controller.enqueue(encoder.encode(line));
+      controller.close();
+    }
+  });
+  return { ok: true, body } as unknown as Response;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('chatOperator.chatConversation SSE forwarding', () => {
+  it('forwards tool_progress `progress` fragments to the stream callback', async () => {
+    // The worker streams tool-call argument text as `tool_progress` events
+    // while the model writes a (possibly large) tool call. Regression guard:
+    // the field whitelist here must forward `progress`, or the running tool
+    // block renders empty (the frozen-screen bug this fix addresses).
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(
+          sseResponse([
+            'data: {"type":"tool_use_start","tool_id":"call_1","tool_name":"Bash","input":{}}\n',
+            'data: {"type":"tool_progress","tool_id":"call_1","progress":"{\\"command\\":\\""}\n',
+            'data: {"type":"tool_progress","tool_id":"call_1","progress":"echo hi\\"}"}\n',
+            'data: [DONE]\n'
+          ])
+        )
+    );
+
+    const events: IChatConversationResponse[] = [];
+    await chatOperator.chatConversation({ model: 'gpt-5.5', message: 'run echo hi' } as never, {
+      token: 't',
+      stream: (r) => events.push(r)
+    });
+
+    const progressEvents = events.filter((e) => e.type === 'tool_progress');
+    expect(progressEvents).toHaveLength(2);
+    expect(progressEvents.every((e) => e.tool_id === 'call_1')).toBe(true);
+    const argText = progressEvents.map((e) => e.progress ?? '').join('');
+    expect(argText).toBe('{"command":"echo hi"}');
+  });
+});

--- a/src/operators/chat.ts
+++ b/src/operators/chat.ts
@@ -107,6 +107,10 @@ class ChatOperator {
                     tool_display_name: json.tool_display_name,
                     execution: json.execution,
                     input: json.input,
+                    // Streamed tool-call arguments text (`tool_progress`); without
+                    // this the running tool block renders empty while the model
+                    // writes a large tool call.
+                    progress: json.progress,
                     output: json.output,
                     is_error: json.is_error,
                     duration_ms: json.duration_ms,


### PR DESCRIPTION
## Problem

The aichat2 worker (PlatformService#1270, merged) streams tool-call argument text as `tool_progress` SSE events carrying a `progress` field, so the running tool block can render the command/script **being written live** instead of a frozen-looking empty block during a long tool call (e.g. a model spending 100–170s writing a big Bash script).

But `src/operators/chat.ts` maps upstream SSE JSON to the Vue stream callback via an **explicit field whitelist** in `options.stream({...})`, and `progress` was **not in the list**. Net effect on `origin/main`:

- `response.progress` is always `undefined`
- `Conversation.vue`'s `input_stream += (response.progress ?? '')` only ever appends `''`
- → the live tool-args streaming (the headline of #1270 + Nexior#1121) is a **silent no-op**: the running block appears immediately (good) but stays **empty** the whole time the model writes the tool call.

## Fix

Add `progress: json.progress` to the whitelist. One line, plus a vitest regression test that mocks `fetch` with an SSE `ReadableStream` containing `tool_progress` events and asserts the stream callback receives (and reassembles) the fragments — guarding against the field being silently dropped again.

## Scope

- This is **independent** of the separate `max_turns` truncation issue (that's a backend/agent-loop concern; not touched here).
- No behaviour change for any other event type — purely additive to the forwarded fields.

## Test

```
npx vitest run src/operators/chat.test.ts   # 1 passed
npx eslint src/operators/chat.ts src/operators/chat.test.ts   # clean
```
