### PR TITLE
Android Computer Use: Set-of-Mark visual grounding (observe + tap_mark)

### DIFF
--- a/android/app/src/main/java/com/acedatacloud/nexior/ComputerUseAccessibilityService.java
+++ b/android/app/src/main/java/com/acedatacloud/nexior/ComputerUseAccessibilityService.java
@@ -3,6 +3,9 @@ package com.acedatacloud.nexior;
 import android.accessibilityservice.AccessibilityService;
 import android.accessibilityservice.GestureDescription;
 import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.Rect;
 import android.hardware.HardwareBuffer;
@@ -23,6 +26,7 @@ import org.json.JSONObject;
 
 import java.io.ByteArrayOutputStream;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 
 /**
  * The accessibility service that actually performs Computer-Use actions on the
@@ -57,8 +61,19 @@ public class ComputerUseAccessibilityService extends AccessibilityService {
      */
     private static volatile boolean sessionStopped = false;
 
+    /** Center coords of the marks from the last {@link #observe} call, indexed
+     *  by mark number (1-based). Lets tapMark() hit a mark by its number without
+     *  the JS side round-tripping coordinates. Single active session, so a plain
+     *  volatile reference is enough. */
+    private static volatile int[][] lastMarks = new int[0][];
+
     public static void setSessionStopped(boolean stopped) {
         sessionStopped = stopped;
+        if (stopped) {
+            // Drop cached Set-of-Mark centers so a post-Stop tapMark can't reuse
+            // stale coordinates from before the kill switch.
+            lastMarks = new int[0][];
+        }
     }
 
     public static boolean isSessionStopped() {
@@ -427,5 +442,177 @@ public class ComputerUseAccessibilityService extends AccessibilityService {
             return;
         }
         click(cx, cy, cb);
+    }
+
+    // ---- Set-of-Mark visual grounding --------------------------------------
+
+    public interface ObserveCallback {
+        void onResult(@Nullable String base64Jpeg, @Nullable String marksJson, int width, int height, @Nullable String error);
+    }
+
+    /**
+     * "Set-of-Mark" observe: capture the screen AND overlay a numbered box on
+     * every actionable element (from the accessibility tree), returning the
+     * annotated JPEG plus a legend `[{n,label,x,y}]`. The model can then act by
+     * NUMBER (computer.tap_mark) instead of guessing pixels or labels — the
+     * grounding technique used by state-of-the-art GUI agents. Each mark's
+     * center is cached in {@link #lastMarks} so tapMark() needs only the index.
+     */
+    @RequiresApi(api = Build.VERSION_CODES.R)
+    public void observe(@NonNull ObserveCallback cb) {
+        takeScreenshot(Display.DEFAULT_DISPLAY, getMainExecutor(), new TakeScreenshotCallback() {
+            @Override
+            public void onSuccess(@NonNull ScreenshotResult result) {
+                if (isSessionStopped()) {
+                    cb.onResult(null, null, 0, 0, "Computer Use was stopped by the user");
+                    return;
+                }
+                HardwareBuffer buffer = null;
+                Bitmap hw = null;
+                Bitmap mutable = null;
+                try {
+                    buffer = result.getHardwareBuffer();
+                    hw = Bitmap.wrapHardwareBuffer(buffer, result.getColorSpace());
+                    if (hw == null) {
+                        cb.onResult(null, null, 0, 0, "failed to wrap screenshot buffer");
+                        return;
+                    }
+                    mutable = hw.copy(Bitmap.Config.ARGB_8888, true);
+                    JSONArray marks = new JSONArray();
+                    ArrayList<int[]> centers = new ArrayList<>();
+                    centers.add(new int[] {0, 0}); // index 0 unused (marks are 1-based)
+                    drawMarks(mutable, marks, centers);
+                    lastMarks = centers.toArray(new int[0][]);
+
+                    ByteArrayOutputStream out = new ByteArrayOutputStream();
+                    mutable.compress(Bitmap.CompressFormat.JPEG, 70, out);
+                    String b64 = Base64.encodeToString(out.toByteArray(), Base64.NO_WRAP);
+                    cb.onResult("data:image/jpeg;base64," + b64, marks.toString(),
+                            mutable.getWidth(), mutable.getHeight(), null);
+                } catch (Throwable e) {
+                    // Throwable (not just Exception) so an OutOfMemoryError from the
+                    // full-res bitmap copy/encode fails the call instead of killing
+                    // the service. Drop stale marks on failure.
+                    lastMarks = new int[0][];
+                    cb.onResult(null, null, 0, 0, "observe failed: " + e.getMessage());
+                } finally {
+                    if (mutable != null) mutable.recycle();
+                    if (hw != null) hw.recycle();
+                    if (buffer != null) buffer.close();
+                }
+            }
+
+            @Override
+            public void onFailure(int errorCode) {
+                cb.onResult(null, null, 0, 0, "takeScreenshot failed: code " + errorCode);
+            }
+        });
+    }
+
+    /** Walk the active window, draw a numbered box on each actionable node, and
+     *  fill {@code marks}/{@code centers}. Nodes recycled as we go. */
+    private void drawMarks(@NonNull Bitmap bitmap, @NonNull JSONArray marks, @NonNull ArrayList<int[]> centers) {
+        AccessibilityNodeInfo root = getRootInActiveWindow();
+        if (root == null) {
+            return;
+        }
+        Canvas canvas = new Canvas(bitmap);
+        Paint box = new Paint();
+        box.setColor(Color.rgb(255, 0, 90));
+        box.setStyle(Paint.Style.STROKE);
+        box.setStrokeWidth(4f);
+        box.setAntiAlias(true);
+        Paint tagBg = new Paint();
+        tagBg.setColor(Color.rgb(255, 0, 90));
+        tagBg.setStyle(Paint.Style.FILL);
+        Paint tagTxt = new Paint();
+        tagTxt.setColor(Color.WHITE);
+        tagTxt.setTextSize(34f);
+        tagTxt.setFakeBoldText(true);
+        tagTxt.setAntiAlias(true);
+
+        ArrayDeque<AccessibilityNodeInfo> stack = new ArrayDeque<>();
+        stack.push(root);
+        int n = 1;
+        try {
+            while (!stack.isEmpty() && n <= 40) {
+                AccessibilityNodeInfo node = stack.pop();
+                if (node == null) {
+                    continue;
+                }
+                try {
+                    for (int i = node.getChildCount() - 1; i >= 0; i--) {
+                        AccessibilityNodeInfo c = node.getChild(i);
+                        if (c != null) {
+                            stack.push(c);
+                        }
+                    }
+                    boolean actionable = node.isClickable() || node.isEditable()
+                            || node.isCheckable() || node.isLongClickable();
+                    if (!actionable || !node.isVisibleToUser()) {
+                        continue;
+                    }
+                    Rect r = new Rect();
+                    node.getBoundsInScreen(r);
+                    // Clip to the screenshot bounds so a mark's center is always
+                    // on-screen (and skip fully-offscreen nodes).
+                    if (!r.intersect(0, 0, bitmap.getWidth(), bitmap.getHeight())) {
+                        continue;
+                    }
+                    if (r.width() <= 0 || r.height() <= 0) {
+                        continue;
+                    }
+                    CharSequence t = node.getText();
+                    CharSequence d = node.getContentDescription();
+                    String label = t != null ? t.toString() : (d != null ? d.toString() : "");
+                    if (label.length() > 60) {
+                        label = label.substring(0, 60);
+                    }
+                    // Box + a numbered tag at the top-left corner.
+                    canvas.drawRect(r, box);
+                    String tag = String.valueOf(n);
+                    float tagW = tagTxt.measureText(tag) + 16f;
+                    float tagH = 44f;
+                    float left = r.left;
+                    float top = Math.max(0f, r.top);
+                    canvas.drawRect(left, top, left + tagW, top + tagH, tagBg);
+                    canvas.drawText(tag, left + 8f, top + 34f, tagTxt);
+
+                    JSONObject o = new JSONObject();
+                    o.put("n", n);
+                    o.put("label", label);
+                    o.put("x", r.centerX());
+                    o.put("y", r.centerY());
+                    marks.put(o);
+                    centers.add(new int[] {r.centerX(), r.centerY()});
+                    n++;
+                } catch (JSONException ignored) {
+                    // skip unserializable node
+                } finally {
+                    node.recycle();
+                }
+            }
+        } finally {
+            for (AccessibilityNodeInfo rem : stack) {
+                if (rem != null) {
+                    rem.recycle();
+                }
+            }
+        }
+    }
+
+    /** Tap the center of the numbered mark from the last observe(). */
+    public void tapMark(int mark, @NonNull ActionCallback cb) {
+        int[][] marks = lastMarks;
+        if (mark < 1 || mark >= marks.length) {
+            cb.onResult(false, "mark " + mark + " is out of range; call observe first");
+            return;
+        }
+        int[] c = marks[mark];
+        if (c == null) {
+            cb.onResult(false, "mark " + mark + " is unavailable; call observe again");
+            return;
+        }
+        click(c[0], c[1], cb);
     }
 }

--- a/android/app/src/main/java/com/acedatacloud/nexior/ComputerUsePlugin.java
+++ b/android/app/src/main/java/com/acedatacloud/nexior/ComputerUsePlugin.java
@@ -237,6 +237,40 @@ public class ComputerUsePlugin extends Plugin {
     }
 
     @PluginMethod
+    public void observe(PluginCall call) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            call.reject("observe requires Android 11+");
+            return;
+        }
+        ComputerUseAccessibilityService svc = requireService(call);
+        if (svc == null) return;
+        svc.observe((base64Jpeg, marksJson, width, height, error) -> {
+            if (error != null || base64Jpeg == null) {
+                call.reject(error != null ? error : "observe failed");
+                return;
+            }
+            JSObject ret = new JSObject();
+            ret.put("image", base64Jpeg);
+            ret.put("marks", marksJson);
+            ret.put("width", width);
+            ret.put("height", height);
+            call.resolve(ret);
+        });
+    }
+
+    @PluginMethod
+    public void tapMark(PluginCall call) {
+        ComputerUseAccessibilityService svc = requireService(call);
+        if (svc == null) return;
+        Integer mark = call.getInt("mark");
+        if (mark == null) {
+            call.reject("tapMark requires a mark number");
+            return;
+        }
+        svc.tapMark(mark, (ok, err) -> resolveOk(call, ok, err));
+    }
+
+    @PluginMethod
     public void startSession(PluginCall call) {
         ComputerUseSessionService.start(getContext());
         call.resolve();

--- a/change/@acedatacloud-nexior-5DDB4744-FB9C-4482-9A64-09F401D8C3DB.json
+++ b/change/@acedatacloud-nexior-5DDB4744-FB9C-4482-9A64-09F401D8C3DB.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Android Computer Use: Set-of-Mark visual grounding (computer.observe draws numbered boxes on tappable elements + computer.tap_mark taps by number)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/plugins/computerUse.ts
+++ b/src/plugins/computerUse.ts
@@ -36,6 +36,16 @@ export interface ComputerUseTreeResult {
   tree: string;
 }
 
+/** Set-of-Mark observe result: an annotated screenshot + numbered legend. */
+export interface ComputerUseObserveResult {
+  /** `data:image/jpeg;base64,…` with numbered boxes drawn on each element. */
+  image: string;
+  /** JSON-array string: `[{n, label, x, y}]`. */
+  marks: string;
+  width: number;
+  height: number;
+}
+
 export interface ComputerUsePlugin {
   status(): Promise<ComputerUseStatus>;
   /** Deep-link to Settings → Accessibility so the user can enable the service. */
@@ -50,6 +60,10 @@ export interface ComputerUsePlugin {
   dumpUi(): Promise<ComputerUseTreeResult>;
   /** Tap an element by its visible text / content-description (semantic tap). */
   tapText(options: { text: string }): Promise<ComputerUseActionResult>;
+  /** Set-of-Mark: annotated screenshot + numbered legend of actionable elements. */
+  observe(): Promise<ComputerUseObserveResult>;
+  /** Tap the numbered mark from the last observe(). */
+  tapMark(options: { mark: number }): Promise<ComputerUseActionResult>;
   /** Start/stop the foreground session that keeps the agent loop alive. */
   startSession(): Promise<void>;
   stopSession(): Promise<void>;

--- a/src/utils/mobileLocalExec.ts
+++ b/src/utils/mobileLocalExec.ts
@@ -125,6 +125,26 @@ const COMPUTER_TOOLS: LocalToolSpec[] = [
     },
     source: 'builtin',
     mutates: true
+  },
+  {
+    name: 'computer.observe',
+    description:
+      'BEST way to see and act: returns a screenshot with a numbered box drawn on every tappable element, plus a legend mapping each number to its label. Prefer this over computer.screenshot when you intend to tap something — then call computer.tap_mark with the number of the element you want. Removes all coordinate guessing.',
+    input_schema: { type: 'object', properties: {} },
+    source: 'builtin',
+    mutates: true
+  },
+  {
+    name: 'computer.tap_mark',
+    description:
+      'Tap the numbered element from the most recent computer.observe (Set-of-Mark). Pass the mark number shown on the annotated screenshot. This is the most reliable way to tap.',
+    input_schema: {
+      type: 'object',
+      properties: { mark: { type: 'integer' } },
+      required: ['mark']
+    },
+    source: 'builtin',
+    mutates: true
   }
 ];
 
@@ -339,6 +359,29 @@ async function invokeImpl(
       case 'computer.dump_ui': {
         const res = await ComputerUse.dumpUi();
         return { output: res.tree || '[]' };
+      }
+      case 'computer.observe': {
+        const res = await ComputerUse.observe();
+        // The legend goes in `output` (text the model reads), the annotated
+        // screenshot in `image` (uploaded to a URL by #1107 for the vision model).
+        let marks: unknown = [];
+        try {
+          marks = JSON.parse(res.marks || '[]');
+        } catch {
+          marks = [];
+        }
+        return {
+          output: JSON.stringify({ width: res.width, height: res.height, marks }),
+          image: res.image
+        };
+      }
+      case 'computer.tap_mark': {
+        const mark = Number(input.mark);
+        if (!Number.isInteger(mark) || mark < 1) {
+          return { output: 'tap_mark requires a positive integer mark from the last observe', is_error: true };
+        }
+        const r = await ComputerUse.tapMark({ mark });
+        return { output: r.note ?? 'ok' };
       }
       case 'computer.tap_text': {
         const text = String(input.text ?? '').trim();


### PR DESCRIPTION
## Android Computer Use — Set-of-Mark visual grounding

> **Stacked on #1122** (node-tree + foreground session). Review/merge #1122 first; the diff here will slim to just the SoM commit once #1122 lands.

Adds the grounding technique used by state-of-the-art GUI agents (SoM / "Set-of-Mark" prompting). Instead of the model guessing pixel coordinates from a screenshot, or guessing element labels, it now gets a screenshot **with a numbered box drawn on every tappable element** plus a legend, and acts by **number**.

### What it adds
- **`ComputerUseAccessibilityService.observe()`** (`@RequiresApi R`): captures the screen, copies to a mutable bitmap, walks `getRootInActiveWindow()` and draws a numbered box on each actionable node (cap 40) via `Canvas`, returns the annotated JPEG + a legend `[{n,label,x,y}]`, and caches each mark's center.
- **`tapMark(n)`**: taps the center of mark `n` from the last `observe`.
- Plugin `observe()` / `tapMark({mark})`; adapter tools **`computer.observe`** (output = legend, image = annotated screenshot, reused by the #1107 hosted-URL upload) and **`computer.tap_mark({mark})`**. Tool descriptions steer the model: observe → pick a number → tap_mark.

### Why
In the phase-1/2 E2E the model flailed on blind coordinates; node-tree (#1122) fixed navigation but still needs the model to name a label. SoM is the tightest loop: one `observe` shows the model exactly what's tappable and how to tap it. It's how leading computer-use agents ground actions.

### 🤖 对抗评审 — Codex + Explore subagent
Both ran against the SoM diff. Fixes applied:
| Severity | Finding | Resolution |
|---|---|---|
| RISK | `catch (Exception)` misses `OutOfMemoryError` from the full-res bitmap copy/encode → could crash the service | **Fixed** — `catch (Throwable)`, drop cached marks, fail the call gracefully. |
| RISK | `lastMarks` not cleared on the Stop kill switch → post-Stop `tapMark` could reuse stale coords | **Fixed** — `setSessionStopped(true)` clears `lastMarks`. |
| RISK | Node bounds not clipped to the screenshot → a mark center could be off-screen | **Fixed** — `r.intersect(0,0,w,h)`; skip fully-offscreen nodes; tag drawn within bounds. |
| RISK | `JSON.parse(res.marks)` unguarded | **Fixed** — try/catch → `[]`. |
| RISK | `observe` screenshot callback could run after Stop | **Fixed** — re-checks `isSessionStopped()` in `onSuccess`. |
| NIT | `tap_mark` accepted fractional numbers | **Fixed** — `Number.isInteger(mark) && mark>=1`; schema `integer`; native null-guards the lookup. |
| NIT | ByteArrayOutputStream memory spike | **Rebutted** — matches the existing `screenshot()` path; OOM now caught (Throwable); downscaling is a future optimization. |

### Validation
- `vue-tsc` clean, `eslint` clean, `:app:assembleDebug` **BUILD SUCCESSFUL**.
- **On-device E2E (emulator, real tools, FGS-backed, zero adb):** `observe` returned a 1080×2400 annotated screenshot with **30 numbered boxes** + legend (Clock = mark #10); **`tap_mark 10` opened the Clock app** (`com.google.android.deskclock` in focus). Node recycling + Throwable guard exercised across repeated observes with no crash/leak.

Annotated screenshot (app drawer) — every app boxed & numbered, so the model taps by number:

- `6:AceData 7:Calendar 8:Camera 9:Chrome 10:Clock 11:Contacts … 20:Play Store 22:Settings …`

Sideload/full flavor only (Play flavor split is a later phase).
