### PR TITLE
fix(coding-bridge): mention GitHub Copilot in history drawer intro

### DIFF
--- a/change/@acedatacloud-nexior-a2c3ef8e-54f5-4ed4-950e-89985807dd00.json
+++ b/change/@acedatacloud-nexior-a2c3ef8e-54f5-4ed4-950e-89985807dd00.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "mention GitHub Copilot in the coding bridge history drawer intro",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/i18n/ar/codingBridge.json
+++ b/src/i18n/ar/codingBridge.json
@@ -208,7 +208,7 @@
     "description": "History drawer title"
   },
   "history.intro": {
-    "message": "جلسات Claude Code وCodex السابقة على هذا الجهاز.",
+    "message": "جلسات Claude Code وCodex وGitHub Copilot السابقة على هذا الجهاز.",
     "description": "History drawer intro"
   },
   "history.refresh": {

--- a/src/i18n/de/codingBridge.json
+++ b/src/i18n/de/codingBridge.json
@@ -208,7 +208,7 @@
     "description": "History drawer title"
   },
   "history.intro": {
-    "message": "Frühere Claude-Code- und Codex-Sitzungen auf diesem Gerät.",
+    "message": "Frühere Claude-Code-, Codex- und GitHub-Copilot-Sitzungen auf diesem Gerät.",
     "description": "History drawer intro"
   },
   "history.refresh": {

--- a/src/i18n/el/codingBridge.json
+++ b/src/i18n/el/codingBridge.json
@@ -208,7 +208,7 @@
     "description": "History drawer title"
   },
   "history.intro": {
-    "message": "Προηγούμενες συνεδρίες Claude Code και Codex σε αυτή τη συσκευή.",
+    "message": "Προηγούμενες συνεδρίες Claude Code, Codex και GitHub Copilot σε αυτή τη συσκευή.",
     "description": "History drawer intro"
   },
   "history.refresh": {

--- a/src/i18n/en/codingBridge.json
+++ b/src/i18n/en/codingBridge.json
@@ -208,7 +208,7 @@
     "description": "History drawer title"
   },
   "history.intro": {
-    "message": "Past Claude Code & Codex sessions on this device.",
+    "message": "Past Claude Code, Codex & GitHub Copilot sessions on this device.",
     "description": "History drawer intro"
   },
   "history.refresh": {

--- a/src/i18n/es/codingBridge.json
+++ b/src/i18n/es/codingBridge.json
@@ -208,7 +208,7 @@
     "description": "History drawer title"
   },
   "history.intro": {
-    "message": "Sesiones anteriores de Claude Code y Codex en este dispositivo.",
+    "message": "Sesiones anteriores de Claude Code, Codex y GitHub Copilot en este dispositivo.",
     "description": "History drawer intro"
   },
   "history.refresh": {

--- a/src/i18n/fi/codingBridge.json
+++ b/src/i18n/fi/codingBridge.json
@@ -208,7 +208,7 @@
     "description": "History drawer title"
   },
   "history.intro": {
-    "message": "Aiemmat Claude Code- ja Codex-istunnot tällä laitteella.",
+    "message": "Aiemmat Claude Code-, Codex- ja GitHub Copilot -istunnot tällä laitteella.",
     "description": "History drawer intro"
   },
   "history.refresh": {

--- a/src/i18n/fr/codingBridge.json
+++ b/src/i18n/fr/codingBridge.json
@@ -208,7 +208,7 @@
     "description": "History drawer title"
   },
   "history.intro": {
-    "message": "Sessions Claude Code et Codex précédentes sur cet appareil.",
+    "message": "Sessions Claude Code, Codex et GitHub Copilot précédentes sur cet appareil.",
     "description": "History drawer intro"
   },
   "history.refresh": {

--- a/src/i18n/it/codingBridge.json
+++ b/src/i18n/it/codingBridge.json
@@ -208,7 +208,7 @@
     "description": "History drawer title"
   },
   "history.intro": {
-    "message": "Sessioni Claude Code e Codex precedenti su questo dispositivo.",
+    "message": "Sessioni Claude Code, Codex e GitHub Copilot precedenti su questo dispositivo.",
     "description": "History drawer intro"
   },
   "history.refresh": {

--- a/src/i18n/ja/codingBridge.json
+++ b/src/i18n/ja/codingBridge.json
@@ -208,7 +208,7 @@
     "description": "History drawer title"
   },
   "history.intro": {
-    "message": "このデバイス上の過去の Claude Code および Codex セッション。",
+    "message": "このデバイス上の過去の Claude Code、Codex、GitHub Copilot セッション。",
     "description": "History drawer intro"
   },
   "history.refresh": {

--- a/src/i18n/ko/codingBridge.json
+++ b/src/i18n/ko/codingBridge.json
@@ -208,7 +208,7 @@
     "description": "History drawer title"
   },
   "history.intro": {
-    "message": "이 기기의 이전 Claude Code 및 Codex 세션입니다.",
+    "message": "이 기기의 이전 Claude Code, Codex 및 GitHub Copilot 세션입니다.",
     "description": "History drawer intro"
   },
   "history.refresh": {

--- a/src/i18n/pl/codingBridge.json
+++ b/src/i18n/pl/codingBridge.json
@@ -208,7 +208,7 @@
     "description": "History drawer title"
   },
   "history.intro": {
-    "message": "Poprzednie sesje Claude Code i Codex na tym urządzeniu.",
+    "message": "Poprzednie sesje Claude Code, Codex i GitHub Copilot na tym urządzeniu.",
     "description": "History drawer intro"
   },
   "history.refresh": {

--- a/src/i18n/pt/codingBridge.json
+++ b/src/i18n/pt/codingBridge.json
@@ -208,7 +208,7 @@
     "description": "History drawer title"
   },
   "history.intro": {
-    "message": "Sessões anteriores do Claude Code e do Codex neste dispositivo.",
+    "message": "Sessões anteriores do Claude Code, do Codex e do GitHub Copilot neste dispositivo.",
     "description": "History drawer intro"
   },
   "history.refresh": {

--- a/src/i18n/ru/codingBridge.json
+++ b/src/i18n/ru/codingBridge.json
@@ -208,7 +208,7 @@
     "description": "History drawer title"
   },
   "history.intro": {
-    "message": "Прошлые сессии Claude Code и Codex на этом устройстве.",
+    "message": "Прошлые сессии Claude Code, Codex и GitHub Copilot на этом устройстве.",
     "description": "History drawer intro"
   },
   "history.refresh": {

--- a/src/i18n/sr/codingBridge.json
+++ b/src/i18n/sr/codingBridge.json
@@ -208,7 +208,7 @@
     "description": "History drawer title"
   },
   "history.intro": {
-    "message": "Претходне Claude Code и Codex сесије на овом уређају.",
+    "message": "Претходне Claude Code, Codex и GitHub Copilot сесије на овом уређају.",
     "description": "History drawer intro"
   },
   "history.refresh": {

--- a/src/i18n/sv/codingBridge.json
+++ b/src/i18n/sv/codingBridge.json
@@ -208,7 +208,7 @@
     "description": "History drawer title"
   },
   "history.intro": {
-    "message": "Tidigare Claude Code- och Codex-sessioner på den här enheten.",
+    "message": "Tidigare Claude Code-, Codex- och GitHub Copilot-sessioner på den här enheten.",
     "description": "History drawer intro"
   },
   "history.refresh": {

--- a/src/i18n/uk/codingBridge.json
+++ b/src/i18n/uk/codingBridge.json
@@ -208,7 +208,7 @@
     "description": "History drawer title"
   },
   "history.intro": {
-    "message": "Попередні сесії Claude Code та Codex на цьому пристрої.",
+    "message": "Попередні сесії Claude Code, Codex та GitHub Copilot на цьому пристрої.",
     "description": "History drawer intro"
   },
   "history.refresh": {

--- a/src/i18n/zh-CN/codingBridge.json
+++ b/src/i18n/zh-CN/codingBridge.json
@@ -208,7 +208,7 @@
     "description": "历史会话抽屉标题"
   },
   "history.intro": {
-    "message": "此设备上的 Claude Code 与 Codex 历史会话。",
+    "message": "此设备上的 Claude Code、Codex 与 GitHub Copilot 历史会话。",
     "description": "历史会话抽屉说明"
   },
   "history.refresh": {

--- a/src/i18n/zh-TW/codingBridge.json
+++ b/src/i18n/zh-TW/codingBridge.json
@@ -208,7 +208,7 @@
     "description": "History drawer title"
   },
   "history.intro": {
-    "message": "此裝置上的 Claude Code 與 Codex 歷史會話。",
+    "message": "此裝置上的 Claude Code、Codex 與 GitHub Copilot 歷史工作階段。",
     "description": "History drawer intro"
   },
   "history.refresh": {


### PR DESCRIPTION
## What & why

The Coding Bridge history drawer intro read "此设备上的 Claude Code 与 Codex
历史会话。" / "Past Claude Code & Codex sessions on this device." — but the drawer
also lists **GitHub Copilot** sessions (the Copilot provider + its brand icon are
already wired). The intro copy just never mentioned Copilot.

This updates `history.intro` in all 18 locales to include GitHub Copilot.

Pairs with CodingBridgeAgent#34 (teaches the agent to actually read Copilot
transcripts). No component/logic changes — `github-copilot.svg` and the picker
already handle Copilot.

## Verification

`python3 scripts/check_i18n_coverage.py` → OK (17 locales × 44 namespaces).
