### PR TITLE
Android Computer Use: Settings accessibility permission entry + on-demand consent

### DIFF
--- a/change/@acedatacloud-nexior-C143D6C1-2FA7-474A-AA6D-BEC60151012C.json
+++ b/change/@acedatacloud-nexior-C143D6C1-2FA7-474A-AA6D-BEC60151012C.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Android Computer Use: Settings accessibility permission entry (pre-authorize) + on-demand consent dialog (replaces window.confirm)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/setting/LocalTools.vue
+++ b/src/components/setting/LocalTools.vue
@@ -4,8 +4,27 @@
       {{ $t('common.settings.localToolsDesktopOnly') }}
     </p>
     <template v-else>
+      <!-- Android: Computer Use system permission entry (Accessibility). This
+           is where the user pre-authorizes the service that lets the assistant
+           see + control the screen. -->
+      <section v-if="android">
+        <div class="section-head">
+          <h3>{{ $t('common.settings.localToolsPermsTitle') }}</h3>
+        </div>
+        <p class="muted">{{ $t('common.settings.localToolsAndroidPermHint') }}</p>
+        <div class="perm-row">
+          <span class="perm-name">{{ $t('common.settings.localToolsPermAccessibility') }}</span>
+          <el-tag size="small" :type="a11yEnabled ? 'success' : 'info'" effect="plain">
+            {{ a11yEnabled ? $t('common.settings.localToolsGranted') : $t('common.settings.localToolsNotGranted') }}
+          </el-tag>
+          <el-button size="small" type="primary" @click="openAndroidAccessibility">{{
+            $t('common.settings.localToolsOpen')
+          }}</el-button>
+        </div>
+      </section>
+
       <!-- Authorized folders -->
-      <section>
+      <section v-if="!android">
         <div class="section-head">
           <h3>{{ $t('common.settings.localToolsFoldersTitle') }}</h3>
           <el-button size="small" type="primary" :icon="Plus" @click="addFolder">
@@ -35,7 +54,7 @@
       </section>
 
       <!-- Always-allowed (persistent consent grants) -->
-      <section v-if="grants !== null">
+      <section v-if="grants !== null && !android">
         <div class="section-head">
           <h3>{{ $t('common.settings.localToolsGrantsTitle') }}</h3>
           <el-button v-if="grants.length" size="small" text type="danger" @click="revokeAll">
@@ -59,7 +78,7 @@
       </section>
 
       <!-- Built-in tools: per-tool "always allow (any input)" toggles -->
-      <section v-if="builtinTools.length">
+      <section v-if="builtinTools.length && !android">
         <div class="section-head">
           <h3>{{ $t('common.settings.localToolsBuiltinTitle') }}</h3>
         </div>
@@ -169,6 +188,7 @@ import { ElButton, ElTag, ElSwitch } from 'element-plus';
 import { Plus } from '@element-plus/icons-vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { localExec } from '@/utils/desktop';
+import { isAndroid } from '@/utils/surface';
 
 interface GrantRow {
   key: string;
@@ -200,12 +220,18 @@ export default defineComponent({
       preauthorizing: false,
       saving: false,
       savedTip: false,
+      // Android: whether the Computer Use accessibility service is enabled.
+      a11yEnabled: false,
+      onFocus: null as null | (() => void),
       cuOff: null as null | (() => void)
     };
   },
   computed: {
     desktop(): boolean {
       return !!localExec();
+    },
+    android(): boolean {
+      return isAndroid();
     }
   },
   async mounted() {
@@ -220,6 +246,15 @@ export default defineComponent({
     const s = await ex.perm?.status();
     if (s?.mac) this.perm = s;
     await this.loadGrants();
+    if (this.android) {
+      await this.refreshA11y();
+      // Re-check the accessibility status when the user returns from system
+      // settings so the badge/toggles reflect it without a manual reload.
+      this.onFocus = () => {
+        if (document.visibilityState === 'visible') void this.refreshA11y();
+      };
+      document.addEventListener('visibilitychange', this.onFocus);
+    }
     // Reflect the global panic hotkey: keep the toggle in sync so a later Save
     // can't silently re-enable Computer Use after it was force-disabled.
     this.cuOff =
@@ -229,8 +264,16 @@ export default defineComponent({
   },
   beforeUnmount() {
     this.cuOff?.();
+    if (this.onFocus) document.removeEventListener('visibilitychange', this.onFocus);
   },
   methods: {
+    async refreshA11y() {
+      const s = await localExec()?.perm?.status();
+      this.a11yEnabled = s?.accessibility === true;
+    },
+    async openAndroidAccessibility() {
+      await localExec()?.perm?.openPane('accessibility');
+    },
     async loadGrants() {
       const ex = localExec();
       if (!ex?.grants) {

--- a/src/i18n/ar/common.json
+++ b/src/i18n/ar/common.json
@@ -1219,5 +1219,25 @@
   "nav.digitalhuman": {
     "message": "Digital Human",
     "description": "Text in the website navigation bar for the Digital Human talking-head page"
+  },
+  "settings.localToolsAndroidPermHint": {
+    "message": "Enable the accessibility service so the assistant can see and control your screen. You can pre-authorize individual actions below.",
+    "description": "Hint for the Android Computer Use accessibility permission section in Settings."
+  },
+  "settings.cuConsentTitle": {
+    "message": "Allow action?",
+    "description": "Title of the on-demand consent dialog shown when the assistant requests a screen action."
+  },
+  "settings.cuConsentMessage": {
+    "message": "The assistant wants to run \"{action}\" on your phone. Allow it?",
+    "description": "Body of the on-demand consent dialog; {action} is the computer.* action name."
+  },
+  "settings.cuConsentAllow": {
+    "message": "Allow once",
+    "description": "Allow button of the on-demand consent dialog."
+  },
+  "settings.cuConsentDeny": {
+    "message": "Deny",
+    "description": "Deny button of the on-demand consent dialog."
   }
 }

--- a/src/i18n/de/common.json
+++ b/src/i18n/de/common.json
@@ -1219,5 +1219,25 @@
   "nav.digitalhuman": {
     "message": "Digital Human",
     "description": "Text in the website navigation bar for the Digital Human talking-head page"
+  },
+  "settings.localToolsAndroidPermHint": {
+    "message": "Enable the accessibility service so the assistant can see and control your screen. You can pre-authorize individual actions below.",
+    "description": "Hint for the Android Computer Use accessibility permission section in Settings."
+  },
+  "settings.cuConsentTitle": {
+    "message": "Allow action?",
+    "description": "Title of the on-demand consent dialog shown when the assistant requests a screen action."
+  },
+  "settings.cuConsentMessage": {
+    "message": "The assistant wants to run \"{action}\" on your phone. Allow it?",
+    "description": "Body of the on-demand consent dialog; {action} is the computer.* action name."
+  },
+  "settings.cuConsentAllow": {
+    "message": "Allow once",
+    "description": "Allow button of the on-demand consent dialog."
+  },
+  "settings.cuConsentDeny": {
+    "message": "Deny",
+    "description": "Deny button of the on-demand consent dialog."
   }
 }

--- a/src/i18n/el/common.json
+++ b/src/i18n/el/common.json
@@ -1219,5 +1219,25 @@
   "nav.digitalhuman": {
     "message": "Digital Human",
     "description": "Text in the website navigation bar for the Digital Human talking-head page"
+  },
+  "settings.localToolsAndroidPermHint": {
+    "message": "Enable the accessibility service so the assistant can see and control your screen. You can pre-authorize individual actions below.",
+    "description": "Hint for the Android Computer Use accessibility permission section in Settings."
+  },
+  "settings.cuConsentTitle": {
+    "message": "Allow action?",
+    "description": "Title of the on-demand consent dialog shown when the assistant requests a screen action."
+  },
+  "settings.cuConsentMessage": {
+    "message": "The assistant wants to run \"{action}\" on your phone. Allow it?",
+    "description": "Body of the on-demand consent dialog; {action} is the computer.* action name."
+  },
+  "settings.cuConsentAllow": {
+    "message": "Allow once",
+    "description": "Allow button of the on-demand consent dialog."
+  },
+  "settings.cuConsentDeny": {
+    "message": "Deny",
+    "description": "Deny button of the on-demand consent dialog."
   }
 }

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -1219,5 +1219,25 @@
   "nav.digitalhuman": {
     "message": "Digital Human",
     "description": "Text in the website navigation bar for the Digital Human talking-head page"
+  },
+  "settings.localToolsAndroidPermHint": {
+    "message": "Enable the accessibility service so the assistant can see and control your screen. You can pre-authorize individual actions below.",
+    "description": "Hint for the Android Computer Use accessibility permission section in Settings."
+  },
+  "settings.cuConsentTitle": {
+    "message": "Allow action?",
+    "description": "Title of the on-demand consent dialog shown when the assistant requests a screen action."
+  },
+  "settings.cuConsentMessage": {
+    "message": "The assistant wants to run \"{action}\" on your phone. Allow it?",
+    "description": "Body of the on-demand consent dialog; {action} is the computer.* action name."
+  },
+  "settings.cuConsentAllow": {
+    "message": "Allow once",
+    "description": "Allow button of the on-demand consent dialog."
+  },
+  "settings.cuConsentDeny": {
+    "message": "Deny",
+    "description": "Deny button of the on-demand consent dialog."
   }
 }

--- a/src/i18n/es/common.json
+++ b/src/i18n/es/common.json
@@ -1219,5 +1219,25 @@
   "nav.digitalhuman": {
     "message": "Digital Human",
     "description": "Text in the website navigation bar for the Digital Human talking-head page"
+  },
+  "settings.localToolsAndroidPermHint": {
+    "message": "Enable the accessibility service so the assistant can see and control your screen. You can pre-authorize individual actions below.",
+    "description": "Hint for the Android Computer Use accessibility permission section in Settings."
+  },
+  "settings.cuConsentTitle": {
+    "message": "Allow action?",
+    "description": "Title of the on-demand consent dialog shown when the assistant requests a screen action."
+  },
+  "settings.cuConsentMessage": {
+    "message": "The assistant wants to run \"{action}\" on your phone. Allow it?",
+    "description": "Body of the on-demand consent dialog; {action} is the computer.* action name."
+  },
+  "settings.cuConsentAllow": {
+    "message": "Allow once",
+    "description": "Allow button of the on-demand consent dialog."
+  },
+  "settings.cuConsentDeny": {
+    "message": "Deny",
+    "description": "Deny button of the on-demand consent dialog."
   }
 }

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -1219,5 +1219,25 @@
   "nav.digitalhuman": {
     "message": "Digital Human",
     "description": "Text in the website navigation bar for the Digital Human talking-head page"
+  },
+  "settings.localToolsAndroidPermHint": {
+    "message": "Enable the accessibility service so the assistant can see and control your screen. You can pre-authorize individual actions below.",
+    "description": "Hint for the Android Computer Use accessibility permission section in Settings."
+  },
+  "settings.cuConsentTitle": {
+    "message": "Allow action?",
+    "description": "Title of the on-demand consent dialog shown when the assistant requests a screen action."
+  },
+  "settings.cuConsentMessage": {
+    "message": "The assistant wants to run \"{action}\" on your phone. Allow it?",
+    "description": "Body of the on-demand consent dialog; {action} is the computer.* action name."
+  },
+  "settings.cuConsentAllow": {
+    "message": "Allow once",
+    "description": "Allow button of the on-demand consent dialog."
+  },
+  "settings.cuConsentDeny": {
+    "message": "Deny",
+    "description": "Deny button of the on-demand consent dialog."
   }
 }

--- a/src/i18n/fr/common.json
+++ b/src/i18n/fr/common.json
@@ -1219,5 +1219,25 @@
   "nav.digitalhuman": {
     "message": "Digital Human",
     "description": "Text in the website navigation bar for the Digital Human talking-head page"
+  },
+  "settings.localToolsAndroidPermHint": {
+    "message": "Enable the accessibility service so the assistant can see and control your screen. You can pre-authorize individual actions below.",
+    "description": "Hint for the Android Computer Use accessibility permission section in Settings."
+  },
+  "settings.cuConsentTitle": {
+    "message": "Allow action?",
+    "description": "Title of the on-demand consent dialog shown when the assistant requests a screen action."
+  },
+  "settings.cuConsentMessage": {
+    "message": "The assistant wants to run \"{action}\" on your phone. Allow it?",
+    "description": "Body of the on-demand consent dialog; {action} is the computer.* action name."
+  },
+  "settings.cuConsentAllow": {
+    "message": "Allow once",
+    "description": "Allow button of the on-demand consent dialog."
+  },
+  "settings.cuConsentDeny": {
+    "message": "Deny",
+    "description": "Deny button of the on-demand consent dialog."
   }
 }

--- a/src/i18n/it/common.json
+++ b/src/i18n/it/common.json
@@ -1219,5 +1219,25 @@
   "nav.digitalhuman": {
     "message": "Digital Human",
     "description": "Text in the website navigation bar for the Digital Human talking-head page"
+  },
+  "settings.localToolsAndroidPermHint": {
+    "message": "Enable the accessibility service so the assistant can see and control your screen. You can pre-authorize individual actions below.",
+    "description": "Hint for the Android Computer Use accessibility permission section in Settings."
+  },
+  "settings.cuConsentTitle": {
+    "message": "Allow action?",
+    "description": "Title of the on-demand consent dialog shown when the assistant requests a screen action."
+  },
+  "settings.cuConsentMessage": {
+    "message": "The assistant wants to run \"{action}\" on your phone. Allow it?",
+    "description": "Body of the on-demand consent dialog; {action} is the computer.* action name."
+  },
+  "settings.cuConsentAllow": {
+    "message": "Allow once",
+    "description": "Allow button of the on-demand consent dialog."
+  },
+  "settings.cuConsentDeny": {
+    "message": "Deny",
+    "description": "Deny button of the on-demand consent dialog."
   }
 }

--- a/src/i18n/ja/common.json
+++ b/src/i18n/ja/common.json
@@ -1219,5 +1219,25 @@
   "nav.digitalhuman": {
     "message": "Digital Human",
     "description": "Text in the website navigation bar for the Digital Human talking-head page"
+  },
+  "settings.localToolsAndroidPermHint": {
+    "message": "Enable the accessibility service so the assistant can see and control your screen. You can pre-authorize individual actions below.",
+    "description": "Hint for the Android Computer Use accessibility permission section in Settings."
+  },
+  "settings.cuConsentTitle": {
+    "message": "Allow action?",
+    "description": "Title of the on-demand consent dialog shown when the assistant requests a screen action."
+  },
+  "settings.cuConsentMessage": {
+    "message": "The assistant wants to run \"{action}\" on your phone. Allow it?",
+    "description": "Body of the on-demand consent dialog; {action} is the computer.* action name."
+  },
+  "settings.cuConsentAllow": {
+    "message": "Allow once",
+    "description": "Allow button of the on-demand consent dialog."
+  },
+  "settings.cuConsentDeny": {
+    "message": "Deny",
+    "description": "Deny button of the on-demand consent dialog."
   }
 }

--- a/src/i18n/ko/common.json
+++ b/src/i18n/ko/common.json
@@ -1219,5 +1219,25 @@
   "nav.digitalhuman": {
     "message": "Digital Human",
     "description": "Text in the website navigation bar for the Digital Human talking-head page"
+  },
+  "settings.localToolsAndroidPermHint": {
+    "message": "Enable the accessibility service so the assistant can see and control your screen. You can pre-authorize individual actions below.",
+    "description": "Hint for the Android Computer Use accessibility permission section in Settings."
+  },
+  "settings.cuConsentTitle": {
+    "message": "Allow action?",
+    "description": "Title of the on-demand consent dialog shown when the assistant requests a screen action."
+  },
+  "settings.cuConsentMessage": {
+    "message": "The assistant wants to run \"{action}\" on your phone. Allow it?",
+    "description": "Body of the on-demand consent dialog; {action} is the computer.* action name."
+  },
+  "settings.cuConsentAllow": {
+    "message": "Allow once",
+    "description": "Allow button of the on-demand consent dialog."
+  },
+  "settings.cuConsentDeny": {
+    "message": "Deny",
+    "description": "Deny button of the on-demand consent dialog."
   }
 }

--- a/src/i18n/pl/common.json
+++ b/src/i18n/pl/common.json
@@ -1219,5 +1219,25 @@
   "nav.digitalhuman": {
     "message": "Digital Human",
     "description": "Text in the website navigation bar for the Digital Human talking-head page"
+  },
+  "settings.localToolsAndroidPermHint": {
+    "message": "Enable the accessibility service so the assistant can see and control your screen. You can pre-authorize individual actions below.",
+    "description": "Hint for the Android Computer Use accessibility permission section in Settings."
+  },
+  "settings.cuConsentTitle": {
+    "message": "Allow action?",
+    "description": "Title of the on-demand consent dialog shown when the assistant requests a screen action."
+  },
+  "settings.cuConsentMessage": {
+    "message": "The assistant wants to run \"{action}\" on your phone. Allow it?",
+    "description": "Body of the on-demand consent dialog; {action} is the computer.* action name."
+  },
+  "settings.cuConsentAllow": {
+    "message": "Allow once",
+    "description": "Allow button of the on-demand consent dialog."
+  },
+  "settings.cuConsentDeny": {
+    "message": "Deny",
+    "description": "Deny button of the on-demand consent dialog."
   }
 }

--- a/src/i18n/pt/common.json
+++ b/src/i18n/pt/common.json
@@ -1219,5 +1219,25 @@
   "nav.digitalhuman": {
     "message": "Digital Human",
     "description": "Text in the website navigation bar for the Digital Human talking-head page"
+  },
+  "settings.localToolsAndroidPermHint": {
+    "message": "Enable the accessibility service so the assistant can see and control your screen. You can pre-authorize individual actions below.",
+    "description": "Hint for the Android Computer Use accessibility permission section in Settings."
+  },
+  "settings.cuConsentTitle": {
+    "message": "Allow action?",
+    "description": "Title of the on-demand consent dialog shown when the assistant requests a screen action."
+  },
+  "settings.cuConsentMessage": {
+    "message": "The assistant wants to run \"{action}\" on your phone. Allow it?",
+    "description": "Body of the on-demand consent dialog; {action} is the computer.* action name."
+  },
+  "settings.cuConsentAllow": {
+    "message": "Allow once",
+    "description": "Allow button of the on-demand consent dialog."
+  },
+  "settings.cuConsentDeny": {
+    "message": "Deny",
+    "description": "Deny button of the on-demand consent dialog."
   }
 }

--- a/src/i18n/ru/common.json
+++ b/src/i18n/ru/common.json
@@ -1219,5 +1219,25 @@
   "nav.digitalhuman": {
     "message": "Digital Human",
     "description": "Text in the website navigation bar for the Digital Human talking-head page"
+  },
+  "settings.localToolsAndroidPermHint": {
+    "message": "Enable the accessibility service so the assistant can see and control your screen. You can pre-authorize individual actions below.",
+    "description": "Hint for the Android Computer Use accessibility permission section in Settings."
+  },
+  "settings.cuConsentTitle": {
+    "message": "Allow action?",
+    "description": "Title of the on-demand consent dialog shown when the assistant requests a screen action."
+  },
+  "settings.cuConsentMessage": {
+    "message": "The assistant wants to run \"{action}\" on your phone. Allow it?",
+    "description": "Body of the on-demand consent dialog; {action} is the computer.* action name."
+  },
+  "settings.cuConsentAllow": {
+    "message": "Allow once",
+    "description": "Allow button of the on-demand consent dialog."
+  },
+  "settings.cuConsentDeny": {
+    "message": "Deny",
+    "description": "Deny button of the on-demand consent dialog."
   }
 }

--- a/src/i18n/sr/common.json
+++ b/src/i18n/sr/common.json
@@ -1219,5 +1219,25 @@
   "nav.digitalhuman": {
     "message": "Digital Human",
     "description": "Text in the website navigation bar for the Digital Human talking-head page"
+  },
+  "settings.localToolsAndroidPermHint": {
+    "message": "Enable the accessibility service so the assistant can see and control your screen. You can pre-authorize individual actions below.",
+    "description": "Hint for the Android Computer Use accessibility permission section in Settings."
+  },
+  "settings.cuConsentTitle": {
+    "message": "Allow action?",
+    "description": "Title of the on-demand consent dialog shown when the assistant requests a screen action."
+  },
+  "settings.cuConsentMessage": {
+    "message": "The assistant wants to run \"{action}\" on your phone. Allow it?",
+    "description": "Body of the on-demand consent dialog; {action} is the computer.* action name."
+  },
+  "settings.cuConsentAllow": {
+    "message": "Allow once",
+    "description": "Allow button of the on-demand consent dialog."
+  },
+  "settings.cuConsentDeny": {
+    "message": "Deny",
+    "description": "Deny button of the on-demand consent dialog."
   }
 }

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -1219,5 +1219,25 @@
   "nav.digitalhuman": {
     "message": "Digital Human",
     "description": "Text in the website navigation bar for the Digital Human talking-head page"
+  },
+  "settings.localToolsAndroidPermHint": {
+    "message": "Enable the accessibility service so the assistant can see and control your screen. You can pre-authorize individual actions below.",
+    "description": "Hint for the Android Computer Use accessibility permission section in Settings."
+  },
+  "settings.cuConsentTitle": {
+    "message": "Allow action?",
+    "description": "Title of the on-demand consent dialog shown when the assistant requests a screen action."
+  },
+  "settings.cuConsentMessage": {
+    "message": "The assistant wants to run \"{action}\" on your phone. Allow it?",
+    "description": "Body of the on-demand consent dialog; {action} is the computer.* action name."
+  },
+  "settings.cuConsentAllow": {
+    "message": "Allow once",
+    "description": "Allow button of the on-demand consent dialog."
+  },
+  "settings.cuConsentDeny": {
+    "message": "Deny",
+    "description": "Deny button of the on-demand consent dialog."
   }
 }

--- a/src/i18n/uk/common.json
+++ b/src/i18n/uk/common.json
@@ -1219,5 +1219,25 @@
   "nav.digitalhuman": {
     "message": "Digital Human",
     "description": "Text in the website navigation bar for the Digital Human talking-head page"
+  },
+  "settings.localToolsAndroidPermHint": {
+    "message": "Enable the accessibility service so the assistant can see and control your screen. You can pre-authorize individual actions below.",
+    "description": "Hint for the Android Computer Use accessibility permission section in Settings."
+  },
+  "settings.cuConsentTitle": {
+    "message": "Allow action?",
+    "description": "Title of the on-demand consent dialog shown when the assistant requests a screen action."
+  },
+  "settings.cuConsentMessage": {
+    "message": "The assistant wants to run \"{action}\" on your phone. Allow it?",
+    "description": "Body of the on-demand consent dialog; {action} is the computer.* action name."
+  },
+  "settings.cuConsentAllow": {
+    "message": "Allow once",
+    "description": "Allow button of the on-demand consent dialog."
+  },
+  "settings.cuConsentDeny": {
+    "message": "Deny",
+    "description": "Deny button of the on-demand consent dialog."
   }
 }

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -1219,5 +1219,25 @@
   "nav.digitalhuman": {
     "message": "数字人",
     "description": "导航栏中数字人口播页面的文字"
+  },
+  "settings.localToolsAndroidPermHint": {
+    "message": "启用无障碍服务后，AI 助手才能查看并操作你的屏幕。你可以在下方逐项提前授权具体操作。",
+    "description": "Android 设置里 Computer Use 无障碍权限区块的说明。"
+  },
+  "settings.cuConsentTitle": {
+    "message": "允许操作？",
+    "description": "按需授权对话框的标题（模型请求执行某个屏幕操作时弹出）。"
+  },
+  "settings.cuConsentMessage": {
+    "message": "AI 助手想在你的手机上执行「{action}」操作，是否允许？",
+    "description": "按需授权对话框正文；{action} 为具体的 computer.* 操作名。"
+  },
+  "settings.cuConsentAllow": {
+    "message": "允许一次",
+    "description": "按需授权对话框的允许按钮。"
+  },
+  "settings.cuConsentDeny": {
+    "message": "拒绝",
+    "description": "按需授权对话框的拒绝按钮。"
   }
 }

--- a/src/i18n/zh-TW/common.json
+++ b/src/i18n/zh-TW/common.json
@@ -1219,5 +1219,25 @@
   "nav.digitalhuman": {
     "message": "數字人",
     "description": "Text in the website navigation bar for the Digital Human talking-head page"
+  },
+  "settings.localToolsAndroidPermHint": {
+    "message": "Enable the accessibility service so the assistant can see and control your screen. You can pre-authorize individual actions below.",
+    "description": "Hint for the Android Computer Use accessibility permission section in Settings."
+  },
+  "settings.cuConsentTitle": {
+    "message": "Allow action?",
+    "description": "Title of the on-demand consent dialog shown when the assistant requests a screen action."
+  },
+  "settings.cuConsentMessage": {
+    "message": "The assistant wants to run \"{action}\" on your phone. Allow it?",
+    "description": "Body of the on-demand consent dialog; {action} is the computer.* action name."
+  },
+  "settings.cuConsentAllow": {
+    "message": "Allow once",
+    "description": "Allow button of the on-demand consent dialog."
+  },
+  "settings.cuConsentDeny": {
+    "message": "Deny",
+    "description": "Deny button of the on-demand consent dialog."
   }
 }

--- a/src/utils/mobileLocalExec.ts
+++ b/src/utils/mobileLocalExec.ts
@@ -23,7 +23,9 @@
  * tool error the model can react to.
  */
 import { Capacitor } from '@capacitor/core';
+import { ElMessageBox } from 'element-plus';
 import { ComputerUse } from '@/plugins/computerUse';
+import i18n from '@/i18n';
 import type { LocalExecBridge, LocalToolSpec } from '@/utils/desktop';
 
 const ENABLED_KEY = 'nexior.android.cu.enabled';
@@ -164,16 +166,37 @@ function writeGrants(names: string[]): void {
   }
 }
 
-/** Per-call consent: honor a persisted always-allow grant, else fall back to a
- *  native confirm. Returns false → the action is denied and reported as a tool
- *  error (never silently). */
-function ensureConsent(name: string): boolean {
+/** Per-call consent: honor a persisted always-allow grant, else show an
+ *  ON-DEMAND consent dialog (Allow once / Deny). Users who want an action to
+ *  run without prompting can pre-authorize it in Settings → Local Tools. Falls
+ *  back to a native confirm if the dialog service can't render (SSR/no DOM).
+ *  Returns false → denied (never silent). */
+async function ensureConsent(name: string): Promise<boolean> {
   if (readGrants().includes(name)) return true;
-  const ok =
-    typeof window !== 'undefined' && typeof window.confirm === 'function'
-      ? window.confirm(`Allow this chat to run "${name}" on your phone?`)
-      : false;
-  return ok;
+  // On-demand consent needs a VISIBLE dialog. If Nexior is backgrounded (the
+  // model is mid-task operating another app), we can't prompt — deny
+  // (fail-closed) rather than hang on an invisible modal. Autonomous background
+  // tasks must pre-authorize the action in Settings → Local Tools.
+  if (typeof document !== 'undefined' && document.visibilityState === 'hidden') {
+    return false;
+  }
+  const t = i18n.global.t;
+  const action = name.replace(/^computer\./, '');
+  const message = t('common.settings.cuConsentMessage', { action });
+  try {
+    await ElMessageBox.confirm(message, t('common.settings.cuConsentTitle'), {
+      confirmButtonText: t('common.settings.cuConsentAllow'),
+      cancelButtonText: t('common.settings.cuConsentDeny'),
+      type: 'warning',
+      distinguishCancelAndClose: true
+    });
+    return true;
+  } catch (e) {
+    // Element Plus (v2) rejects with the string 'cancel'/'close' on user denial.
+    if (typeof e === 'string') return false;
+    // Anything else = the dialog couldn't render → fall back to a native confirm.
+    return typeof window !== 'undefined' && typeof window.confirm === 'function' ? window.confirm(message) : false;
+  }
 }
 
 async function accessibilityGranted(): Promise<boolean> {
@@ -182,6 +205,22 @@ async function accessibilityGranted(): Promise<boolean> {
     return !!s.accessibility;
   } catch {
     return false;
+  }
+}
+
+/** Best-effort request for POST_NOTIFICATIONS (Android 13+) so the foreground
+ *  Computer-Use session's Stop notification is actually visible. Reuses the
+ *  local-notifications plugin the app already ships. Requested at most once per
+ *  app session. Never throws. */
+let notifPermRequested = false;
+async function requestNotificationPermission(): Promise<void> {
+  if (notifPermRequested) return;
+  notifPermRequested = true;
+  try {
+    const { LocalNotifications } = await import('@capacitor/local-notifications');
+    await LocalNotifications.requestPermissions();
+  } catch {
+    /* best-effort */
   }
 }
 
@@ -236,6 +275,29 @@ const bridge: LocalExecBridge = {
     return null; // no authorized-roots concept on a phone
   },
 
+  perm: {
+    // Android's one relevant "permission" for Computer Use is the accessibility
+    // service. Map it onto the desktop-shaped struct (only `accessibility` is
+    // meaningful) so Settings can show status + a jump-to-settings button.
+    async status() {
+      return permShape(await accessibilityGranted());
+    },
+    async openPane(k: 'fullDisk' | 'screen' | 'accessibility') {
+      if (k === 'accessibility') {
+        try {
+          await ComputerUse.openAccessibilitySettings();
+        } catch {
+          /* ignore */
+        }
+        return true;
+      }
+      return false;
+    },
+    async askMedia() {
+      return false;
+    }
+  },
+
   grants: {
     async list() {
       return readGrants();
@@ -270,8 +332,11 @@ const bridge: LocalExecBridge = {
     const toGrant = names && names.length ? names : COMPUTER_TOOLS.map((s) => s.name);
     writeGrants([...readGrants(), ...toGrant]);
     try {
-      // Re-arm after any prior user Stop, then jump to Accessibility settings.
+      // Re-arm after any prior user Stop, request the notification permission so
+      // the foreground-session Stop notification is visible (Android 13+ gates
+      // it), then jump to Accessibility settings.
       await ComputerUse.resetStop();
+      await requestNotificationPermission();
       await ComputerUse.openAccessibilitySettings();
     } catch {
       /* best-effort deep link */
@@ -313,8 +378,11 @@ async function invokeImpl(
   if (!name.startsWith('computer.')) {
     return { output: `unknown tool: ${name}`, is_error: true };
   }
-  if (!ensureConsent(name)) {
-    return { output: `denied: user declined "${name}"`, is_error: true };
+  if (!(await ensureConsent(name))) {
+    return {
+      output: `denied: "${name}" is not pre-authorized. Ask the user to allow it when prompted (foreground), or pre-authorize it in Settings → Local Tools.`,
+      is_error: true
+    };
   }
   // Keep the process foreground-priority for the whole task so the agent loop
   // isn't throttled/killed while Nexior is backgrounded operating another app.


### PR DESCRIPTION
## Android Computer Use — permission entry in Settings + on-demand consent

Two user-requested additions to the Android Computer Use feature (builds on the merged node-tree + foreground-session work).

### 1. Permission entry in Settings (pre-authorize)
`Settings → Local Tools` on Android now surfaces the one system permission Computer Use needs — the **Accessibility service**:
- A permission section with a live **status badge** (Granted / Not granted) and an **Open** button that jumps to the system Accessibility settings, so the user can turn it on ahead of time. Status **refreshes on `visibilitychange`** when they return from settings.
- Desktop-only sections (authorized folders, generic grants, builtin fs/shell tools) are **hidden on Android**; the existing **Computer Use per-action pre-authorize toggles** (screenshot/click/type/…) remain, so the user can pre-grant exactly the actions they want.
- Adapter now implements `perm.status()` / `perm.openPane('accessibility')` for this, and `preauthorizeComputerUse` also requests **POST_NOTIFICATIONS** (once per session, via the already-shipped local-notifications plugin) so the foreground-session **Stop kill-switch notification** is actually visible on Android 13+.

### 2. On-demand consent
When the model calls a `computer.*` action that **isn't** pre-authorized, the adapter now shows a proper **Element Plus consent dialog** (*Allow once / Deny*) instead of the raw `window.confirm`. **Fail-closed**:
- If the user denies → action refused.
- If Nexior is **backgrounded** (mid-task operating another app, so no visible dialog is possible) → refused immediately (no hang), and the tool result tells the model to have the user pre-authorize in Settings.
- If the dialog can't render at all → falls back to a native confirm.

Pre-authorize (Settings) and allow-once (on-demand) together give the user full control: grant ahead of time for autonomous background tasks, or approve per-action in the foreground.

### i18n
Consent + permission strings added to **all 18 locales** (`check_i18n_coverage.py` green: 17 × 44 namespaces match zh-CN). zh-CN + en authored; other locales seeded (per repo convention).

### 🤖 对抗评审
Codex was rate-limited this run → reviewed by an Explore subagent. Findings + resolution:
| Severity | Finding | Resolution |
|---|---|---|
| RISK | Backgrounded app → `ElMessageBox` renders invisibly → `await ensureConsent` hangs the agent loop | **Fixed** — `document.visibilityState === 'hidden'` → deny (fail-closed) before prompting. |
| MED | Fragile `ElMessageBox` rejection contract (`e === 'cancel'`) | **Fixed** — treat any string rejection as denial; non-string → native-confirm fallback. |
| NIT | Notification permission re-requested on every `preauthorize` | **Fixed** — once-per-session flag. |
| RISK×2 | "Missing i18n keys" | **False positive** — keys exist in all 18 locales (coverage guard green); they were outside the code-only diff the reviewer saw. |

### Validation
`vue-tsc` clean, `eslint` clean, `build:android` OK, `check_i18n_coverage.py` green. UI + consent plumbing on top of the already on-device-E2E-proven `computer.*` tools.
