### PR TITLE
feat(desktop): local MCP server config UI + hot-apply without restart

### DIFF
--- a/change/@acedatacloud-nexior-mcp-config-ui.json
+++ b/change/@acedatacloud-nexior-mcp-config-ui.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Desktop: add MCP server config UI in Settings → Local Tools (name/command/args/env) and hot-apply MCP changes without an app restart.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/electron/local/ipc.ts
+++ b/electron/local/ipc.ts
@@ -32,6 +32,33 @@ export function disableComputerUse(): boolean {
   return wasOn;
 }
 
+// Serialize config writes. `local.config.save` is called from three UI paths
+// (folders, MCP servers, Computer Use), each doing a read-modify-write on the
+// single local-tools.json. Chaining guarantees each handler's `load()` sees the
+// previous write, so a rapid folder+MCP save can't drop one field's changes.
+let configSaveChain: Promise<boolean> = Promise.resolve(true);
+
+async function applyConfigSave(cfg: LocalConfig): Promise<boolean> {
+  // Preserve persistent consent grants — the renderer's save payload only
+  // carries roots + mcp (+ optional computerUse), so merge to avoid wiping
+  // the "always allow" list. `computerUse` falls back to the current value
+  // when the renderer omits it.
+  const cur = load();
+  const computerUse = cfg.computerUse ?? cur.computerUse ?? false;
+  // Only re-spawn MCP servers when their config actually changed — a folder /
+  // Computer-Use save shouldn't tear down healthy MCP connections.
+  const mcpChanged = JSON.stringify(cur.mcp ?? []) !== JSON.stringify(cfg.mcp ?? []);
+  save({ ...cur, roots: cfg.roots, mcp: cfg.mcp, computerUse });
+  setRoots(cfg.roots); // hot-apply roots
+  registry.setComputerUse(computerUse); // hot-apply the Computer Use toggle
+  if (!computerUse) resetComputerSessionConsent(); // turning it off clears session grants
+  // Hot-apply MCP servers: stop the old ones and boot the new set so their
+  // tools appear/disappear from the next `client_tools` payload without a
+  // restart. `reboot` swallows per-server failures, so save never rejects.
+  if (mcpChanged) await registry.reboot(cfg.mcp ?? []);
+  return true;
+}
+
 export function registerLocalExec(getWin: () => BrowserWindow | null): void {
   const gate = (e: Electron.IpcMainInvokeEvent) => {
     if (!sameOrigin(e.senderFrame?.url)) throw new Error('local-exec: bad sender origin');
@@ -56,17 +83,12 @@ export function registerLocalExec(getWin: () => BrowserWindow | null): void {
   });
   ipcMain.handle('local.config.save', (e, cfg: LocalConfig) => {
     gate(e);
-    // Preserve persistent consent grants — the renderer's save payload only
-    // carries roots + mcp (+ optional computerUse), so merge to avoid wiping
-    // the "always allow" list. `computerUse` falls back to the current value
-    // when the renderer omits it.
-    const cur = load();
-    const computerUse = cfg.computerUse ?? cur.computerUse ?? false;
-    save({ ...cur, roots: cfg.roots, mcp: cfg.mcp, computerUse });
-    setRoots(cfg.roots); // hot-apply roots; MCP server changes apply next launch
-    registry.setComputerUse(computerUse); // hot-apply the Computer Use toggle
-    if (!computerUse) resetComputerSessionConsent(); // turning it off clears session grants
-    return true;
+    // Run behind the shared chain so overlapping saves apply sequentially.
+    configSaveChain = configSaveChain.then(
+      () => applyConfigSave(cfg),
+      () => applyConfigSave(cfg)
+    );
+    return configSaveChain;
   });
   ipcMain.handle('local.pickFolder', async (e) => {
     gate(e);

--- a/electron/local/mcp.ts
+++ b/electron/local/mcp.ts
@@ -40,7 +40,12 @@ export class McpHost {
         }
       }
     });
-    p.on('exit', () => this.procs.delete(c.id));
+    p.on('exit', () => {
+      // Only forget this proc if it's still the one we tracked. On reboot()
+      // stopAll() kills the old proc, then boot() spawns a new one under the
+      // same id; the old proc's async exit must NOT delete the new entry.
+      if (this.procs.get(c.id) === p) this.procs.delete(c.id);
+    });
     this.procs.set(c.id, p);
     await this.rpc(c.id, 'initialize', { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'nexior', version: '1' } });
   }

--- a/electron/local/registry.ts
+++ b/electron/local/registry.ts
@@ -82,6 +82,17 @@ class Registry {
     }
   }
 
+  // Hot-reapply the MCP server set: stop the running servers, drop their tool
+  // specs + names (keeping builtin + computer), then re-boot from the new
+  // config. Called by `local.config.save` so editing MCP servers in Settings
+  // takes effect immediately, without restarting the app.
+  async reboot(servers: McpServerConf[]): Promise<void> {
+    this.host.stopAll();
+    this.mcpSpecs = [];
+    this.names = new Set([...BUILTIN, ...COMPUTER_TOOLS].map((s) => s.name));
+    await this.boot(servers);
+  }
+
   specs(): ToolSpec[] {
     return [...BUILTIN, ...(this.computerUse ? COMPUTER_TOOLS : []), ...this.mcpSpecs];
   }
@@ -97,8 +108,13 @@ class Registry {
     // the feature is disabled, refuse it here too.
     if (isComputerTool(inv.name) && !this.computerUse) return { output: 'computer use is disabled', is_error: true };
     if (inv.name.startsWith('mcp.')) {
-      const [, server, tool] = inv.name.split('.');
-      return this.host.call(server, tool, inv.input);
+      // Split at the FIRST dot after the `mcp.` prefix: the server id is
+      // constrained to [A-Za-z0-9_-] (no dots) by the config UI, so everything
+      // after it is the tool name — which MAY itself contain dots.
+      const rest = inv.name.slice('mcp.'.length);
+      const dot = rest.indexOf('.');
+      if (dot < 0) return { output: `bad mcp tool name ${inv.name}`, is_error: true };
+      return this.host.call(rest.slice(0, dot), rest.slice(dot + 1), inv.input);
     }
     if (inv.name === 'fs.read_file') return fsTool.read_file(inv.input as { path: string });
     if (inv.name === 'fs.list_dir') return fsTool.list_dir(inv.input as { path: string });

--- a/src/components/setting/LocalTools.vue
+++ b/src/components/setting/LocalTools.vue
@@ -34,6 +34,58 @@
         </p>
       </section>
 
+      <!-- MCP servers (local stdio, Claude-Desktop style) -->
+      <section>
+        <div class="section-head">
+          <h3>{{ $t('common.settings.localToolsMcpTitle') }}</h3>
+          <el-button size="small" type="primary" :icon="Plus" @click="addMcp">
+            {{ $t('common.settings.localToolsMcpAdd') }}
+          </el-button>
+        </div>
+        <p class="muted">{{ $t('common.settings.localToolsMcpHint') }}</p>
+        <ul v-if="mcpServers.length" class="rows">
+          <li v-for="(m, i) in mcpServers" :key="m._uid" class="row mcp-row">
+            <div class="mcp-fields">
+              <el-input v-model="m.id" size="small" :placeholder="$t('common.settings.localToolsMcpNamePlaceholder')">
+                <template #prepend>{{ $t('common.settings.localToolsMcpName') }}</template>
+              </el-input>
+              <el-input
+                v-model="m.command"
+                size="small"
+                :placeholder="$t('common.settings.localToolsMcpCommandPlaceholder')"
+              >
+                <template #prepend>{{ $t('common.settings.localToolsMcpCommand') }}</template>
+              </el-input>
+              <label class="mcp-label">{{ $t('common.settings.localToolsMcpArgs') }}</label>
+              <el-input
+                v-model="m.argsText"
+                type="textarea"
+                :rows="2"
+                :placeholder="$t('common.settings.localToolsMcpArgsHint')"
+              />
+              <label class="mcp-label">{{ $t('common.settings.localToolsMcpEnv') }}</label>
+              <el-input
+                v-model="m.envText"
+                type="textarea"
+                :rows="2"
+                :placeholder="$t('common.settings.localToolsMcpEnvHint')"
+              />
+            </div>
+            <el-button size="small" text type="danger" @click="removeMcp(i)">
+              {{ $t('common.settings.localToolsRemove') }}
+            </el-button>
+          </li>
+        </ul>
+        <p v-else class="muted">{{ $t('common.settings.localToolsMcpNoServers') }}</p>
+        <div class="actions">
+          <el-button size="small" type="primary" :loading="savingMcp" @click="saveMcp">
+            {{ $t('common.settings.localToolsSave') }}
+          </el-button>
+          <span v-if="mcpSavedTip" class="muted saved-tip">{{ $t('common.settings.localToolsSaved') }}</span>
+          <span v-if="mcpError" class="mcp-error">{{ mcpError }}</span>
+        </div>
+      </section>
+
       <!-- Always-allowed (persistent consent grants) -->
       <section v-if="grants !== null">
         <div class="section-head">
@@ -165,7 +217,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElButton, ElTag, ElSwitch } from 'element-plus';
+import { ElButton, ElTag, ElSwitch, ElInput } from 'element-plus';
 import { Plus } from '@element-plus/icons-vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { localExec } from '@/utils/desktop';
@@ -176,14 +228,31 @@ interface GrantRow {
   input: string;
 }
 
+// Editable draft of one MCP server row. `args` / `env` are edited as free text
+// (one-per-line) and parsed into the array / record shape on save. `_uid` is a
+// stable render key so removing a middle row doesn't rebind inputs by index.
+interface McpDraft {
+  _uid: number;
+  id: string;
+  command: string;
+  argsText: string;
+  envText: string;
+}
+
 export default defineComponent({
   name: 'LocalToolsSetting',
-  components: { ElButton, ElTag, ElSwitch, FontAwesomeIcon },
+  components: { ElButton, ElTag, ElSwitch, ElInput, FontAwesomeIcon },
   data() {
     return {
       Plus,
       roots: [] as string[],
       tools: [] as string[],
+      // Editable MCP server drafts (loaded from config, parsed back on save).
+      mcpServers: [] as McpDraft[],
+      mcpUid: 0,
+      savingMcp: false,
+      mcpSavedTip: false,
+      mcpError: '',
       grants: null as null | GrantRow[],
       perm: null as null | { mac: boolean; fullDisk: boolean; screen: string; mic: string; accessibility: boolean },
       computerUse: false,
@@ -214,6 +283,15 @@ export default defineComponent({
     const cfg = await ex.getConfig();
     this.roots = cfg.roots;
     this.computerUse = cfg.computerUse === true;
+    this.mcpServers = (cfg.mcp ?? []).map((m) => ({
+      _uid: this.mcpUid++,
+      id: m.id,
+      command: m.command,
+      argsText: (m.args ?? []).join('\n'),
+      envText: Object.entries(m.env ?? {})
+        .map(([k, v]) => `${k}=${v}`)
+        .join('\n')
+    }));
     this.tools = (await ex.listTools()).map((t) => t.name);
     this.computerTools = (await ex.computerTools?.()) ?? [];
     this.builtinTools = (await ex.builtinTools?.()) ?? [];
@@ -273,6 +351,68 @@ export default defineComponent({
     },
     removeRoot(i: number) {
       this.roots.splice(i, 1);
+    },
+    addMcp() {
+      this.mcpServers.push({ _uid: this.mcpUid++, id: '', command: '', argsText: '', envText: '' });
+    },
+    removeMcp(i: number) {
+      this.mcpServers.splice(i, 1);
+    },
+    // Validate + parse the drafts into `McpServerConf[]` and persist. The main
+    // process hot-reboots the MCP host, so the new tools appear without a
+    // restart. `id` is constrained to `[A-Za-z0-9_-]` because it becomes the
+    // `mcp.<id>.<tool>` route key (a dot would break the split at invoke time).
+    async saveMcp() {
+      this.mcpError = '';
+      const mcp: { id: string; command: string; args: string[]; env?: Record<string, string> }[] = [];
+      const seen = new Set<string>();
+      for (const m of this.mcpServers) {
+        const id = m.id.trim();
+        const command = m.command.trim();
+        if (!id || !command) {
+          this.mcpError = this.$t('common.settings.localToolsMcpNameRequired');
+          return;
+        }
+        if (!/^[A-Za-z0-9_-]+$/.test(id)) {
+          this.mcpError = this.$t('common.settings.localToolsMcpNameInvalid');
+          return;
+        }
+        if (seen.has(id)) {
+          this.mcpError = this.$t('common.settings.localToolsMcpDuplicateName');
+          return;
+        }
+        seen.add(id);
+        const args = m.argsText
+          .split('\n')
+          .map((s) => s.trim())
+          .filter(Boolean);
+        const env: Record<string, string> = {};
+        for (const line of m.envText.split('\n')) {
+          const t = line.trim();
+          if (!t) continue;
+          const eq = t.indexOf('=');
+          if (eq <= 0) continue;
+          env[t.slice(0, eq).trim()] = t.slice(eq + 1).trim();
+        }
+        const row: { id: string; command: string; args: string[]; env?: Record<string, string> } = {
+          id,
+          command,
+          args
+        };
+        if (Object.keys(env).length) row.env = env;
+        mcp.push(row);
+      }
+      this.savingMcp = true;
+      try {
+        const cur = await localExec()?.getConfig();
+        await localExec()?.saveConfig({ roots: cur?.roots ?? this.roots, mcp, computerUse: this.computerUse });
+        // Re-fetch the active tools so newly-connected MCP tools show up.
+        this.tools = (await localExec()?.listTools())?.map((t) => t.name) ?? this.tools;
+        this.mcpSavedTip = true;
+        setTimeout(() => (this.mcpSavedTip = false), 2000);
+      } finally {
+        this.savingMcp = false;
+      }
     },
     async open(k: 'fullDisk' | 'screen' | 'accessibility') {
       await localExec()?.perm?.openPane(k);
@@ -438,6 +578,25 @@ export default defineComponent({
 .cu-action-desc {
   color: var(--el-text-color-secondary, #909399);
   font-size: 12px;
+}
+.mcp-row {
+  align-items: flex-start;
+}
+.mcp-fields {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+.mcp-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--el-text-color-secondary, #909399);
+}
+.mcp-error {
+  color: var(--el-color-danger, #f56c6c);
+  font-size: 13px;
 }
 .muted {
   color: var(--el-text-color-secondary, #909399);

--- a/src/i18n/ar/common.json
+++ b/src/i18n/ar/common.json
@@ -980,6 +980,66 @@
     "message": "حفظ",
     "description": "Save the authorized folders."
   },
+  "settings.localToolsMcpTitle": {
+    "message": "MCP servers",
+    "description": "Section title for local MCP server configuration in Local Tools settings."
+  },
+  "settings.localToolsMcpHint": {
+    "message": "Connect local MCP servers over stdio. Their tools become available to the AI, gated by the same per-call confirmation. Changes take effect immediately.",
+    "description": "Explains what local MCP servers do and that changes apply without a restart."
+  },
+  "settings.localToolsMcpAdd": {
+    "message": "Add server",
+    "description": "Button to add a new local MCP server row."
+  },
+  "settings.localToolsMcpName": {
+    "message": "Name",
+    "description": "Label for the MCP server name/id field."
+  },
+  "settings.localToolsMcpCommand": {
+    "message": "Command",
+    "description": "Label for the MCP server launch command field."
+  },
+  "settings.localToolsMcpArgs": {
+    "message": "Arguments",
+    "description": "Label for the MCP server command arguments field."
+  },
+  "settings.localToolsMcpArgsHint": {
+    "message": "One argument per line.",
+    "description": "Placeholder/hint for the MCP arguments textarea."
+  },
+  "settings.localToolsMcpEnv": {
+    "message": "Environment",
+    "description": "Label for the MCP server environment variables field."
+  },
+  "settings.localToolsMcpEnvHint": {
+    "message": "One KEY=VALUE per line.",
+    "description": "Placeholder/hint for the MCP environment variables textarea."
+  },
+  "settings.localToolsMcpNoServers": {
+    "message": "No MCP servers configured.",
+    "description": "Empty state shown when no MCP servers are configured."
+  },
+  "settings.localToolsMcpNamePlaceholder": {
+    "message": "e.g. filesystem",
+    "description": "Placeholder for the MCP server name input."
+  },
+  "settings.localToolsMcpCommandPlaceholder": {
+    "message": "e.g. npx",
+    "description": "Placeholder for the MCP server command input."
+  },
+  "settings.localToolsMcpNameRequired": {
+    "message": "Each server needs a name and a command.",
+    "description": "Validation error when a server row is missing a name or command."
+  },
+  "settings.localToolsMcpDuplicateName": {
+    "message": "Server names must be unique.",
+    "description": "Validation error when two servers share the same name."
+  },
+  "settings.localToolsMcpNameInvalid": {
+    "message": "Name may only contain letters, numbers, hyphens and underscores.",
+    "description": "Validation error when a server name contains invalid characters."
+  },
   "settings.localToolsSaved": {
     "message": "تم الحفظ",
     "description": "Transient confirmation after saving local-tool folders."

--- a/src/i18n/de/common.json
+++ b/src/i18n/de/common.json
@@ -980,6 +980,66 @@
     "message": "Speichern",
     "description": "Save the authorized folders."
   },
+  "settings.localToolsMcpTitle": {
+    "message": "MCP servers",
+    "description": "Section title for local MCP server configuration in Local Tools settings."
+  },
+  "settings.localToolsMcpHint": {
+    "message": "Connect local MCP servers over stdio. Their tools become available to the AI, gated by the same per-call confirmation. Changes take effect immediately.",
+    "description": "Explains what local MCP servers do and that changes apply without a restart."
+  },
+  "settings.localToolsMcpAdd": {
+    "message": "Add server",
+    "description": "Button to add a new local MCP server row."
+  },
+  "settings.localToolsMcpName": {
+    "message": "Name",
+    "description": "Label for the MCP server name/id field."
+  },
+  "settings.localToolsMcpCommand": {
+    "message": "Command",
+    "description": "Label for the MCP server launch command field."
+  },
+  "settings.localToolsMcpArgs": {
+    "message": "Arguments",
+    "description": "Label for the MCP server command arguments field."
+  },
+  "settings.localToolsMcpArgsHint": {
+    "message": "One argument per line.",
+    "description": "Placeholder/hint for the MCP arguments textarea."
+  },
+  "settings.localToolsMcpEnv": {
+    "message": "Environment",
+    "description": "Label for the MCP server environment variables field."
+  },
+  "settings.localToolsMcpEnvHint": {
+    "message": "One KEY=VALUE per line.",
+    "description": "Placeholder/hint for the MCP environment variables textarea."
+  },
+  "settings.localToolsMcpNoServers": {
+    "message": "No MCP servers configured.",
+    "description": "Empty state shown when no MCP servers are configured."
+  },
+  "settings.localToolsMcpNamePlaceholder": {
+    "message": "e.g. filesystem",
+    "description": "Placeholder for the MCP server name input."
+  },
+  "settings.localToolsMcpCommandPlaceholder": {
+    "message": "e.g. npx",
+    "description": "Placeholder for the MCP server command input."
+  },
+  "settings.localToolsMcpNameRequired": {
+    "message": "Each server needs a name and a command.",
+    "description": "Validation error when a server row is missing a name or command."
+  },
+  "settings.localToolsMcpDuplicateName": {
+    "message": "Server names must be unique.",
+    "description": "Validation error when two servers share the same name."
+  },
+  "settings.localToolsMcpNameInvalid": {
+    "message": "Name may only contain letters, numbers, hyphens and underscores.",
+    "description": "Validation error when a server name contains invalid characters."
+  },
   "settings.localToolsSaved": {
     "message": "Gespeichert",
     "description": "Transient confirmation after saving local-tool folders."

--- a/src/i18n/el/common.json
+++ b/src/i18n/el/common.json
@@ -980,6 +980,66 @@
     "message": "Αποθήκευση",
     "description": "Save the authorized folders."
   },
+  "settings.localToolsMcpTitle": {
+    "message": "MCP servers",
+    "description": "Section title for local MCP server configuration in Local Tools settings."
+  },
+  "settings.localToolsMcpHint": {
+    "message": "Connect local MCP servers over stdio. Their tools become available to the AI, gated by the same per-call confirmation. Changes take effect immediately.",
+    "description": "Explains what local MCP servers do and that changes apply without a restart."
+  },
+  "settings.localToolsMcpAdd": {
+    "message": "Add server",
+    "description": "Button to add a new local MCP server row."
+  },
+  "settings.localToolsMcpName": {
+    "message": "Name",
+    "description": "Label for the MCP server name/id field."
+  },
+  "settings.localToolsMcpCommand": {
+    "message": "Command",
+    "description": "Label for the MCP server launch command field."
+  },
+  "settings.localToolsMcpArgs": {
+    "message": "Arguments",
+    "description": "Label for the MCP server command arguments field."
+  },
+  "settings.localToolsMcpArgsHint": {
+    "message": "One argument per line.",
+    "description": "Placeholder/hint for the MCP arguments textarea."
+  },
+  "settings.localToolsMcpEnv": {
+    "message": "Environment",
+    "description": "Label for the MCP server environment variables field."
+  },
+  "settings.localToolsMcpEnvHint": {
+    "message": "One KEY=VALUE per line.",
+    "description": "Placeholder/hint for the MCP environment variables textarea."
+  },
+  "settings.localToolsMcpNoServers": {
+    "message": "No MCP servers configured.",
+    "description": "Empty state shown when no MCP servers are configured."
+  },
+  "settings.localToolsMcpNamePlaceholder": {
+    "message": "e.g. filesystem",
+    "description": "Placeholder for the MCP server name input."
+  },
+  "settings.localToolsMcpCommandPlaceholder": {
+    "message": "e.g. npx",
+    "description": "Placeholder for the MCP server command input."
+  },
+  "settings.localToolsMcpNameRequired": {
+    "message": "Each server needs a name and a command.",
+    "description": "Validation error when a server row is missing a name or command."
+  },
+  "settings.localToolsMcpDuplicateName": {
+    "message": "Server names must be unique.",
+    "description": "Validation error when two servers share the same name."
+  },
+  "settings.localToolsMcpNameInvalid": {
+    "message": "Name may only contain letters, numbers, hyphens and underscores.",
+    "description": "Validation error when a server name contains invalid characters."
+  },
   "settings.localToolsSaved": {
     "message": "Αποθηκεύτηκε",
     "description": "Transient confirmation after saving local-tool folders."

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -960,6 +960,66 @@
     "message": "Save",
     "description": "Save the authorized folders."
   },
+  "settings.localToolsMcpTitle": {
+    "message": "MCP servers",
+    "description": "Section title for local MCP server configuration in Local Tools settings."
+  },
+  "settings.localToolsMcpHint": {
+    "message": "Connect local MCP servers over stdio. Their tools become available to the AI, gated by the same per-call confirmation. Changes take effect immediately.",
+    "description": "Explains what local MCP servers do and that changes apply without a restart."
+  },
+  "settings.localToolsMcpAdd": {
+    "message": "Add server",
+    "description": "Button to add a new local MCP server row."
+  },
+  "settings.localToolsMcpName": {
+    "message": "Name",
+    "description": "Label for the MCP server name/id field."
+  },
+  "settings.localToolsMcpCommand": {
+    "message": "Command",
+    "description": "Label for the MCP server launch command field."
+  },
+  "settings.localToolsMcpArgs": {
+    "message": "Arguments",
+    "description": "Label for the MCP server command arguments field."
+  },
+  "settings.localToolsMcpArgsHint": {
+    "message": "One argument per line.",
+    "description": "Placeholder/hint for the MCP arguments textarea."
+  },
+  "settings.localToolsMcpEnv": {
+    "message": "Environment",
+    "description": "Label for the MCP server environment variables field."
+  },
+  "settings.localToolsMcpEnvHint": {
+    "message": "One KEY=VALUE per line.",
+    "description": "Placeholder/hint for the MCP environment variables textarea."
+  },
+  "settings.localToolsMcpNoServers": {
+    "message": "No MCP servers configured.",
+    "description": "Empty state shown when no MCP servers are configured."
+  },
+  "settings.localToolsMcpNamePlaceholder": {
+    "message": "e.g. filesystem",
+    "description": "Placeholder for the MCP server name input."
+  },
+  "settings.localToolsMcpCommandPlaceholder": {
+    "message": "e.g. npx",
+    "description": "Placeholder for the MCP server command input."
+  },
+  "settings.localToolsMcpNameRequired": {
+    "message": "Each server needs a name and a command.",
+    "description": "Validation error when a server row is missing a name or command."
+  },
+  "settings.localToolsMcpDuplicateName": {
+    "message": "Server names must be unique.",
+    "description": "Validation error when two servers share the same name."
+  },
+  "settings.localToolsMcpNameInvalid": {
+    "message": "Name may only contain letters, numbers, hyphens and underscores.",
+    "description": "Validation error when a server name contains invalid characters."
+  },
   "settings.localToolsSaved": {
     "message": "Saved",
     "description": "Transient confirmation after saving local-tool folders."

--- a/src/i18n/es/common.json
+++ b/src/i18n/es/common.json
@@ -980,6 +980,66 @@
     "message": "Guardar",
     "description": "Save the authorized folders."
   },
+  "settings.localToolsMcpTitle": {
+    "message": "MCP servers",
+    "description": "Section title for local MCP server configuration in Local Tools settings."
+  },
+  "settings.localToolsMcpHint": {
+    "message": "Connect local MCP servers over stdio. Their tools become available to the AI, gated by the same per-call confirmation. Changes take effect immediately.",
+    "description": "Explains what local MCP servers do and that changes apply without a restart."
+  },
+  "settings.localToolsMcpAdd": {
+    "message": "Add server",
+    "description": "Button to add a new local MCP server row."
+  },
+  "settings.localToolsMcpName": {
+    "message": "Name",
+    "description": "Label for the MCP server name/id field."
+  },
+  "settings.localToolsMcpCommand": {
+    "message": "Command",
+    "description": "Label for the MCP server launch command field."
+  },
+  "settings.localToolsMcpArgs": {
+    "message": "Arguments",
+    "description": "Label for the MCP server command arguments field."
+  },
+  "settings.localToolsMcpArgsHint": {
+    "message": "One argument per line.",
+    "description": "Placeholder/hint for the MCP arguments textarea."
+  },
+  "settings.localToolsMcpEnv": {
+    "message": "Environment",
+    "description": "Label for the MCP server environment variables field."
+  },
+  "settings.localToolsMcpEnvHint": {
+    "message": "One KEY=VALUE per line.",
+    "description": "Placeholder/hint for the MCP environment variables textarea."
+  },
+  "settings.localToolsMcpNoServers": {
+    "message": "No MCP servers configured.",
+    "description": "Empty state shown when no MCP servers are configured."
+  },
+  "settings.localToolsMcpNamePlaceholder": {
+    "message": "e.g. filesystem",
+    "description": "Placeholder for the MCP server name input."
+  },
+  "settings.localToolsMcpCommandPlaceholder": {
+    "message": "e.g. npx",
+    "description": "Placeholder for the MCP server command input."
+  },
+  "settings.localToolsMcpNameRequired": {
+    "message": "Each server needs a name and a command.",
+    "description": "Validation error when a server row is missing a name or command."
+  },
+  "settings.localToolsMcpDuplicateName": {
+    "message": "Server names must be unique.",
+    "description": "Validation error when two servers share the same name."
+  },
+  "settings.localToolsMcpNameInvalid": {
+    "message": "Name may only contain letters, numbers, hyphens and underscores.",
+    "description": "Validation error when a server name contains invalid characters."
+  },
   "settings.localToolsSaved": {
     "message": "Guardado",
     "description": "Transient confirmation after saving local-tool folders."

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -980,6 +980,66 @@
     "message": "Tallenna",
     "description": "Save the authorized folders."
   },
+  "settings.localToolsMcpTitle": {
+    "message": "MCP servers",
+    "description": "Section title for local MCP server configuration in Local Tools settings."
+  },
+  "settings.localToolsMcpHint": {
+    "message": "Connect local MCP servers over stdio. Their tools become available to the AI, gated by the same per-call confirmation. Changes take effect immediately.",
+    "description": "Explains what local MCP servers do and that changes apply without a restart."
+  },
+  "settings.localToolsMcpAdd": {
+    "message": "Add server",
+    "description": "Button to add a new local MCP server row."
+  },
+  "settings.localToolsMcpName": {
+    "message": "Name",
+    "description": "Label for the MCP server name/id field."
+  },
+  "settings.localToolsMcpCommand": {
+    "message": "Command",
+    "description": "Label for the MCP server launch command field."
+  },
+  "settings.localToolsMcpArgs": {
+    "message": "Arguments",
+    "description": "Label for the MCP server command arguments field."
+  },
+  "settings.localToolsMcpArgsHint": {
+    "message": "One argument per line.",
+    "description": "Placeholder/hint for the MCP arguments textarea."
+  },
+  "settings.localToolsMcpEnv": {
+    "message": "Environment",
+    "description": "Label for the MCP server environment variables field."
+  },
+  "settings.localToolsMcpEnvHint": {
+    "message": "One KEY=VALUE per line.",
+    "description": "Placeholder/hint for the MCP environment variables textarea."
+  },
+  "settings.localToolsMcpNoServers": {
+    "message": "No MCP servers configured.",
+    "description": "Empty state shown when no MCP servers are configured."
+  },
+  "settings.localToolsMcpNamePlaceholder": {
+    "message": "e.g. filesystem",
+    "description": "Placeholder for the MCP server name input."
+  },
+  "settings.localToolsMcpCommandPlaceholder": {
+    "message": "e.g. npx",
+    "description": "Placeholder for the MCP server command input."
+  },
+  "settings.localToolsMcpNameRequired": {
+    "message": "Each server needs a name and a command.",
+    "description": "Validation error when a server row is missing a name or command."
+  },
+  "settings.localToolsMcpDuplicateName": {
+    "message": "Server names must be unique.",
+    "description": "Validation error when two servers share the same name."
+  },
+  "settings.localToolsMcpNameInvalid": {
+    "message": "Name may only contain letters, numbers, hyphens and underscores.",
+    "description": "Validation error when a server name contains invalid characters."
+  },
   "settings.localToolsSaved": {
     "message": "Tallennettu",
     "description": "Transient confirmation after saving local-tool folders."

--- a/src/i18n/fr/common.json
+++ b/src/i18n/fr/common.json
@@ -980,6 +980,66 @@
     "message": "Enregistrer",
     "description": "Save the authorized folders."
   },
+  "settings.localToolsMcpTitle": {
+    "message": "MCP servers",
+    "description": "Section title for local MCP server configuration in Local Tools settings."
+  },
+  "settings.localToolsMcpHint": {
+    "message": "Connect local MCP servers over stdio. Their tools become available to the AI, gated by the same per-call confirmation. Changes take effect immediately.",
+    "description": "Explains what local MCP servers do and that changes apply without a restart."
+  },
+  "settings.localToolsMcpAdd": {
+    "message": "Add server",
+    "description": "Button to add a new local MCP server row."
+  },
+  "settings.localToolsMcpName": {
+    "message": "Name",
+    "description": "Label for the MCP server name/id field."
+  },
+  "settings.localToolsMcpCommand": {
+    "message": "Command",
+    "description": "Label for the MCP server launch command field."
+  },
+  "settings.localToolsMcpArgs": {
+    "message": "Arguments",
+    "description": "Label for the MCP server command arguments field."
+  },
+  "settings.localToolsMcpArgsHint": {
+    "message": "One argument per line.",
+    "description": "Placeholder/hint for the MCP arguments textarea."
+  },
+  "settings.localToolsMcpEnv": {
+    "message": "Environment",
+    "description": "Label for the MCP server environment variables field."
+  },
+  "settings.localToolsMcpEnvHint": {
+    "message": "One KEY=VALUE per line.",
+    "description": "Placeholder/hint for the MCP environment variables textarea."
+  },
+  "settings.localToolsMcpNoServers": {
+    "message": "No MCP servers configured.",
+    "description": "Empty state shown when no MCP servers are configured."
+  },
+  "settings.localToolsMcpNamePlaceholder": {
+    "message": "e.g. filesystem",
+    "description": "Placeholder for the MCP server name input."
+  },
+  "settings.localToolsMcpCommandPlaceholder": {
+    "message": "e.g. npx",
+    "description": "Placeholder for the MCP server command input."
+  },
+  "settings.localToolsMcpNameRequired": {
+    "message": "Each server needs a name and a command.",
+    "description": "Validation error when a server row is missing a name or command."
+  },
+  "settings.localToolsMcpDuplicateName": {
+    "message": "Server names must be unique.",
+    "description": "Validation error when two servers share the same name."
+  },
+  "settings.localToolsMcpNameInvalid": {
+    "message": "Name may only contain letters, numbers, hyphens and underscores.",
+    "description": "Validation error when a server name contains invalid characters."
+  },
   "settings.localToolsSaved": {
     "message": "Enregistré",
     "description": "Transient confirmation after saving local-tool folders."

--- a/src/i18n/it/common.json
+++ b/src/i18n/it/common.json
@@ -980,6 +980,66 @@
     "message": "Salva",
     "description": "Save the authorized folders."
   },
+  "settings.localToolsMcpTitle": {
+    "message": "MCP servers",
+    "description": "Section title for local MCP server configuration in Local Tools settings."
+  },
+  "settings.localToolsMcpHint": {
+    "message": "Connect local MCP servers over stdio. Their tools become available to the AI, gated by the same per-call confirmation. Changes take effect immediately.",
+    "description": "Explains what local MCP servers do and that changes apply without a restart."
+  },
+  "settings.localToolsMcpAdd": {
+    "message": "Add server",
+    "description": "Button to add a new local MCP server row."
+  },
+  "settings.localToolsMcpName": {
+    "message": "Name",
+    "description": "Label for the MCP server name/id field."
+  },
+  "settings.localToolsMcpCommand": {
+    "message": "Command",
+    "description": "Label for the MCP server launch command field."
+  },
+  "settings.localToolsMcpArgs": {
+    "message": "Arguments",
+    "description": "Label for the MCP server command arguments field."
+  },
+  "settings.localToolsMcpArgsHint": {
+    "message": "One argument per line.",
+    "description": "Placeholder/hint for the MCP arguments textarea."
+  },
+  "settings.localToolsMcpEnv": {
+    "message": "Environment",
+    "description": "Label for the MCP server environment variables field."
+  },
+  "settings.localToolsMcpEnvHint": {
+    "message": "One KEY=VALUE per line.",
+    "description": "Placeholder/hint for the MCP environment variables textarea."
+  },
+  "settings.localToolsMcpNoServers": {
+    "message": "No MCP servers configured.",
+    "description": "Empty state shown when no MCP servers are configured."
+  },
+  "settings.localToolsMcpNamePlaceholder": {
+    "message": "e.g. filesystem",
+    "description": "Placeholder for the MCP server name input."
+  },
+  "settings.localToolsMcpCommandPlaceholder": {
+    "message": "e.g. npx",
+    "description": "Placeholder for the MCP server command input."
+  },
+  "settings.localToolsMcpNameRequired": {
+    "message": "Each server needs a name and a command.",
+    "description": "Validation error when a server row is missing a name or command."
+  },
+  "settings.localToolsMcpDuplicateName": {
+    "message": "Server names must be unique.",
+    "description": "Validation error when two servers share the same name."
+  },
+  "settings.localToolsMcpNameInvalid": {
+    "message": "Name may only contain letters, numbers, hyphens and underscores.",
+    "description": "Validation error when a server name contains invalid characters."
+  },
   "settings.localToolsSaved": {
     "message": "Salvato",
     "description": "Transient confirmation after saving local-tool folders."

--- a/src/i18n/ja/common.json
+++ b/src/i18n/ja/common.json
@@ -980,6 +980,66 @@
     "message": "保存",
     "description": "Save the authorized folders."
   },
+  "settings.localToolsMcpTitle": {
+    "message": "MCP servers",
+    "description": "Section title for local MCP server configuration in Local Tools settings."
+  },
+  "settings.localToolsMcpHint": {
+    "message": "Connect local MCP servers over stdio. Their tools become available to the AI, gated by the same per-call confirmation. Changes take effect immediately.",
+    "description": "Explains what local MCP servers do and that changes apply without a restart."
+  },
+  "settings.localToolsMcpAdd": {
+    "message": "Add server",
+    "description": "Button to add a new local MCP server row."
+  },
+  "settings.localToolsMcpName": {
+    "message": "Name",
+    "description": "Label for the MCP server name/id field."
+  },
+  "settings.localToolsMcpCommand": {
+    "message": "Command",
+    "description": "Label for the MCP server launch command field."
+  },
+  "settings.localToolsMcpArgs": {
+    "message": "Arguments",
+    "description": "Label for the MCP server command arguments field."
+  },
+  "settings.localToolsMcpArgsHint": {
+    "message": "One argument per line.",
+    "description": "Placeholder/hint for the MCP arguments textarea."
+  },
+  "settings.localToolsMcpEnv": {
+    "message": "Environment",
+    "description": "Label for the MCP server environment variables field."
+  },
+  "settings.localToolsMcpEnvHint": {
+    "message": "One KEY=VALUE per line.",
+    "description": "Placeholder/hint for the MCP environment variables textarea."
+  },
+  "settings.localToolsMcpNoServers": {
+    "message": "No MCP servers configured.",
+    "description": "Empty state shown when no MCP servers are configured."
+  },
+  "settings.localToolsMcpNamePlaceholder": {
+    "message": "e.g. filesystem",
+    "description": "Placeholder for the MCP server name input."
+  },
+  "settings.localToolsMcpCommandPlaceholder": {
+    "message": "e.g. npx",
+    "description": "Placeholder for the MCP server command input."
+  },
+  "settings.localToolsMcpNameRequired": {
+    "message": "Each server needs a name and a command.",
+    "description": "Validation error when a server row is missing a name or command."
+  },
+  "settings.localToolsMcpDuplicateName": {
+    "message": "Server names must be unique.",
+    "description": "Validation error when two servers share the same name."
+  },
+  "settings.localToolsMcpNameInvalid": {
+    "message": "Name may only contain letters, numbers, hyphens and underscores.",
+    "description": "Validation error when a server name contains invalid characters."
+  },
   "settings.localToolsSaved": {
     "message": "保存しました",
     "description": "Transient confirmation after saving local-tool folders."

--- a/src/i18n/ko/common.json
+++ b/src/i18n/ko/common.json
@@ -980,6 +980,66 @@
     "message": "저장",
     "description": "Save the authorized folders."
   },
+  "settings.localToolsMcpTitle": {
+    "message": "MCP servers",
+    "description": "Section title for local MCP server configuration in Local Tools settings."
+  },
+  "settings.localToolsMcpHint": {
+    "message": "Connect local MCP servers over stdio. Their tools become available to the AI, gated by the same per-call confirmation. Changes take effect immediately.",
+    "description": "Explains what local MCP servers do and that changes apply without a restart."
+  },
+  "settings.localToolsMcpAdd": {
+    "message": "Add server",
+    "description": "Button to add a new local MCP server row."
+  },
+  "settings.localToolsMcpName": {
+    "message": "Name",
+    "description": "Label for the MCP server name/id field."
+  },
+  "settings.localToolsMcpCommand": {
+    "message": "Command",
+    "description": "Label for the MCP server launch command field."
+  },
+  "settings.localToolsMcpArgs": {
+    "message": "Arguments",
+    "description": "Label for the MCP server command arguments field."
+  },
+  "settings.localToolsMcpArgsHint": {
+    "message": "One argument per line.",
+    "description": "Placeholder/hint for the MCP arguments textarea."
+  },
+  "settings.localToolsMcpEnv": {
+    "message": "Environment",
+    "description": "Label for the MCP server environment variables field."
+  },
+  "settings.localToolsMcpEnvHint": {
+    "message": "One KEY=VALUE per line.",
+    "description": "Placeholder/hint for the MCP environment variables textarea."
+  },
+  "settings.localToolsMcpNoServers": {
+    "message": "No MCP servers configured.",
+    "description": "Empty state shown when no MCP servers are configured."
+  },
+  "settings.localToolsMcpNamePlaceholder": {
+    "message": "e.g. filesystem",
+    "description": "Placeholder for the MCP server name input."
+  },
+  "settings.localToolsMcpCommandPlaceholder": {
+    "message": "e.g. npx",
+    "description": "Placeholder for the MCP server command input."
+  },
+  "settings.localToolsMcpNameRequired": {
+    "message": "Each server needs a name and a command.",
+    "description": "Validation error when a server row is missing a name or command."
+  },
+  "settings.localToolsMcpDuplicateName": {
+    "message": "Server names must be unique.",
+    "description": "Validation error when two servers share the same name."
+  },
+  "settings.localToolsMcpNameInvalid": {
+    "message": "Name may only contain letters, numbers, hyphens and underscores.",
+    "description": "Validation error when a server name contains invalid characters."
+  },
   "settings.localToolsSaved": {
     "message": "저장됨",
     "description": "Transient confirmation after saving local-tool folders."

--- a/src/i18n/pl/common.json
+++ b/src/i18n/pl/common.json
@@ -980,6 +980,66 @@
     "message": "Zapisz",
     "description": "Save the authorized folders."
   },
+  "settings.localToolsMcpTitle": {
+    "message": "MCP servers",
+    "description": "Section title for local MCP server configuration in Local Tools settings."
+  },
+  "settings.localToolsMcpHint": {
+    "message": "Connect local MCP servers over stdio. Their tools become available to the AI, gated by the same per-call confirmation. Changes take effect immediately.",
+    "description": "Explains what local MCP servers do and that changes apply without a restart."
+  },
+  "settings.localToolsMcpAdd": {
+    "message": "Add server",
+    "description": "Button to add a new local MCP server row."
+  },
+  "settings.localToolsMcpName": {
+    "message": "Name",
+    "description": "Label for the MCP server name/id field."
+  },
+  "settings.localToolsMcpCommand": {
+    "message": "Command",
+    "description": "Label for the MCP server launch command field."
+  },
+  "settings.localToolsMcpArgs": {
+    "message": "Arguments",
+    "description": "Label for the MCP server command arguments field."
+  },
+  "settings.localToolsMcpArgsHint": {
+    "message": "One argument per line.",
+    "description": "Placeholder/hint for the MCP arguments textarea."
+  },
+  "settings.localToolsMcpEnv": {
+    "message": "Environment",
+    "description": "Label for the MCP server environment variables field."
+  },
+  "settings.localToolsMcpEnvHint": {
+    "message": "One KEY=VALUE per line.",
+    "description": "Placeholder/hint for the MCP environment variables textarea."
+  },
+  "settings.localToolsMcpNoServers": {
+    "message": "No MCP servers configured.",
+    "description": "Empty state shown when no MCP servers are configured."
+  },
+  "settings.localToolsMcpNamePlaceholder": {
+    "message": "e.g. filesystem",
+    "description": "Placeholder for the MCP server name input."
+  },
+  "settings.localToolsMcpCommandPlaceholder": {
+    "message": "e.g. npx",
+    "description": "Placeholder for the MCP server command input."
+  },
+  "settings.localToolsMcpNameRequired": {
+    "message": "Each server needs a name and a command.",
+    "description": "Validation error when a server row is missing a name or command."
+  },
+  "settings.localToolsMcpDuplicateName": {
+    "message": "Server names must be unique.",
+    "description": "Validation error when two servers share the same name."
+  },
+  "settings.localToolsMcpNameInvalid": {
+    "message": "Name may only contain letters, numbers, hyphens and underscores.",
+    "description": "Validation error when a server name contains invalid characters."
+  },
   "settings.localToolsSaved": {
     "message": "Zapisano",
     "description": "Transient confirmation after saving local-tool folders."

--- a/src/i18n/pt/common.json
+++ b/src/i18n/pt/common.json
@@ -980,6 +980,66 @@
     "message": "Salvar",
     "description": "Save the authorized folders."
   },
+  "settings.localToolsMcpTitle": {
+    "message": "MCP servers",
+    "description": "Section title for local MCP server configuration in Local Tools settings."
+  },
+  "settings.localToolsMcpHint": {
+    "message": "Connect local MCP servers over stdio. Their tools become available to the AI, gated by the same per-call confirmation. Changes take effect immediately.",
+    "description": "Explains what local MCP servers do and that changes apply without a restart."
+  },
+  "settings.localToolsMcpAdd": {
+    "message": "Add server",
+    "description": "Button to add a new local MCP server row."
+  },
+  "settings.localToolsMcpName": {
+    "message": "Name",
+    "description": "Label for the MCP server name/id field."
+  },
+  "settings.localToolsMcpCommand": {
+    "message": "Command",
+    "description": "Label for the MCP server launch command field."
+  },
+  "settings.localToolsMcpArgs": {
+    "message": "Arguments",
+    "description": "Label for the MCP server command arguments field."
+  },
+  "settings.localToolsMcpArgsHint": {
+    "message": "One argument per line.",
+    "description": "Placeholder/hint for the MCP arguments textarea."
+  },
+  "settings.localToolsMcpEnv": {
+    "message": "Environment",
+    "description": "Label for the MCP server environment variables field."
+  },
+  "settings.localToolsMcpEnvHint": {
+    "message": "One KEY=VALUE per line.",
+    "description": "Placeholder/hint for the MCP environment variables textarea."
+  },
+  "settings.localToolsMcpNoServers": {
+    "message": "No MCP servers configured.",
+    "description": "Empty state shown when no MCP servers are configured."
+  },
+  "settings.localToolsMcpNamePlaceholder": {
+    "message": "e.g. filesystem",
+    "description": "Placeholder for the MCP server name input."
+  },
+  "settings.localToolsMcpCommandPlaceholder": {
+    "message": "e.g. npx",
+    "description": "Placeholder for the MCP server command input."
+  },
+  "settings.localToolsMcpNameRequired": {
+    "message": "Each server needs a name and a command.",
+    "description": "Validation error when a server row is missing a name or command."
+  },
+  "settings.localToolsMcpDuplicateName": {
+    "message": "Server names must be unique.",
+    "description": "Validation error when two servers share the same name."
+  },
+  "settings.localToolsMcpNameInvalid": {
+    "message": "Name may only contain letters, numbers, hyphens and underscores.",
+    "description": "Validation error when a server name contains invalid characters."
+  },
   "settings.localToolsSaved": {
     "message": "Salvo",
     "description": "Transient confirmation after saving local-tool folders."

--- a/src/i18n/ru/common.json
+++ b/src/i18n/ru/common.json
@@ -980,6 +980,66 @@
     "message": "Сохранить",
     "description": "Save the authorized folders."
   },
+  "settings.localToolsMcpTitle": {
+    "message": "MCP servers",
+    "description": "Section title for local MCP server configuration in Local Tools settings."
+  },
+  "settings.localToolsMcpHint": {
+    "message": "Connect local MCP servers over stdio. Their tools become available to the AI, gated by the same per-call confirmation. Changes take effect immediately.",
+    "description": "Explains what local MCP servers do and that changes apply without a restart."
+  },
+  "settings.localToolsMcpAdd": {
+    "message": "Add server",
+    "description": "Button to add a new local MCP server row."
+  },
+  "settings.localToolsMcpName": {
+    "message": "Name",
+    "description": "Label for the MCP server name/id field."
+  },
+  "settings.localToolsMcpCommand": {
+    "message": "Command",
+    "description": "Label for the MCP server launch command field."
+  },
+  "settings.localToolsMcpArgs": {
+    "message": "Arguments",
+    "description": "Label for the MCP server command arguments field."
+  },
+  "settings.localToolsMcpArgsHint": {
+    "message": "One argument per line.",
+    "description": "Placeholder/hint for the MCP arguments textarea."
+  },
+  "settings.localToolsMcpEnv": {
+    "message": "Environment",
+    "description": "Label for the MCP server environment variables field."
+  },
+  "settings.localToolsMcpEnvHint": {
+    "message": "One KEY=VALUE per line.",
+    "description": "Placeholder/hint for the MCP environment variables textarea."
+  },
+  "settings.localToolsMcpNoServers": {
+    "message": "No MCP servers configured.",
+    "description": "Empty state shown when no MCP servers are configured."
+  },
+  "settings.localToolsMcpNamePlaceholder": {
+    "message": "e.g. filesystem",
+    "description": "Placeholder for the MCP server name input."
+  },
+  "settings.localToolsMcpCommandPlaceholder": {
+    "message": "e.g. npx",
+    "description": "Placeholder for the MCP server command input."
+  },
+  "settings.localToolsMcpNameRequired": {
+    "message": "Each server needs a name and a command.",
+    "description": "Validation error when a server row is missing a name or command."
+  },
+  "settings.localToolsMcpDuplicateName": {
+    "message": "Server names must be unique.",
+    "description": "Validation error when two servers share the same name."
+  },
+  "settings.localToolsMcpNameInvalid": {
+    "message": "Name may only contain letters, numbers, hyphens and underscores.",
+    "description": "Validation error when a server name contains invalid characters."
+  },
   "settings.localToolsSaved": {
     "message": "Сохранено",
     "description": "Transient confirmation after saving local-tool folders."

--- a/src/i18n/sr/common.json
+++ b/src/i18n/sr/common.json
@@ -980,6 +980,66 @@
     "message": "Сачувај",
     "description": "Save the authorized folders."
   },
+  "settings.localToolsMcpTitle": {
+    "message": "MCP servers",
+    "description": "Section title for local MCP server configuration in Local Tools settings."
+  },
+  "settings.localToolsMcpHint": {
+    "message": "Connect local MCP servers over stdio. Their tools become available to the AI, gated by the same per-call confirmation. Changes take effect immediately.",
+    "description": "Explains what local MCP servers do and that changes apply without a restart."
+  },
+  "settings.localToolsMcpAdd": {
+    "message": "Add server",
+    "description": "Button to add a new local MCP server row."
+  },
+  "settings.localToolsMcpName": {
+    "message": "Name",
+    "description": "Label for the MCP server name/id field."
+  },
+  "settings.localToolsMcpCommand": {
+    "message": "Command",
+    "description": "Label for the MCP server launch command field."
+  },
+  "settings.localToolsMcpArgs": {
+    "message": "Arguments",
+    "description": "Label for the MCP server command arguments field."
+  },
+  "settings.localToolsMcpArgsHint": {
+    "message": "One argument per line.",
+    "description": "Placeholder/hint for the MCP arguments textarea."
+  },
+  "settings.localToolsMcpEnv": {
+    "message": "Environment",
+    "description": "Label for the MCP server environment variables field."
+  },
+  "settings.localToolsMcpEnvHint": {
+    "message": "One KEY=VALUE per line.",
+    "description": "Placeholder/hint for the MCP environment variables textarea."
+  },
+  "settings.localToolsMcpNoServers": {
+    "message": "No MCP servers configured.",
+    "description": "Empty state shown when no MCP servers are configured."
+  },
+  "settings.localToolsMcpNamePlaceholder": {
+    "message": "e.g. filesystem",
+    "description": "Placeholder for the MCP server name input."
+  },
+  "settings.localToolsMcpCommandPlaceholder": {
+    "message": "e.g. npx",
+    "description": "Placeholder for the MCP server command input."
+  },
+  "settings.localToolsMcpNameRequired": {
+    "message": "Each server needs a name and a command.",
+    "description": "Validation error when a server row is missing a name or command."
+  },
+  "settings.localToolsMcpDuplicateName": {
+    "message": "Server names must be unique.",
+    "description": "Validation error when two servers share the same name."
+  },
+  "settings.localToolsMcpNameInvalid": {
+    "message": "Name may only contain letters, numbers, hyphens and underscores.",
+    "description": "Validation error when a server name contains invalid characters."
+  },
   "settings.localToolsSaved": {
     "message": "Сачувано",
     "description": "Transient confirmation after saving local-tool folders."

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -980,6 +980,66 @@
     "message": "Spara",
     "description": "Save the authorized folders."
   },
+  "settings.localToolsMcpTitle": {
+    "message": "MCP servers",
+    "description": "Section title for local MCP server configuration in Local Tools settings."
+  },
+  "settings.localToolsMcpHint": {
+    "message": "Connect local MCP servers over stdio. Their tools become available to the AI, gated by the same per-call confirmation. Changes take effect immediately.",
+    "description": "Explains what local MCP servers do and that changes apply without a restart."
+  },
+  "settings.localToolsMcpAdd": {
+    "message": "Add server",
+    "description": "Button to add a new local MCP server row."
+  },
+  "settings.localToolsMcpName": {
+    "message": "Name",
+    "description": "Label for the MCP server name/id field."
+  },
+  "settings.localToolsMcpCommand": {
+    "message": "Command",
+    "description": "Label for the MCP server launch command field."
+  },
+  "settings.localToolsMcpArgs": {
+    "message": "Arguments",
+    "description": "Label for the MCP server command arguments field."
+  },
+  "settings.localToolsMcpArgsHint": {
+    "message": "One argument per line.",
+    "description": "Placeholder/hint for the MCP arguments textarea."
+  },
+  "settings.localToolsMcpEnv": {
+    "message": "Environment",
+    "description": "Label for the MCP server environment variables field."
+  },
+  "settings.localToolsMcpEnvHint": {
+    "message": "One KEY=VALUE per line.",
+    "description": "Placeholder/hint for the MCP environment variables textarea."
+  },
+  "settings.localToolsMcpNoServers": {
+    "message": "No MCP servers configured.",
+    "description": "Empty state shown when no MCP servers are configured."
+  },
+  "settings.localToolsMcpNamePlaceholder": {
+    "message": "e.g. filesystem",
+    "description": "Placeholder for the MCP server name input."
+  },
+  "settings.localToolsMcpCommandPlaceholder": {
+    "message": "e.g. npx",
+    "description": "Placeholder for the MCP server command input."
+  },
+  "settings.localToolsMcpNameRequired": {
+    "message": "Each server needs a name and a command.",
+    "description": "Validation error when a server row is missing a name or command."
+  },
+  "settings.localToolsMcpDuplicateName": {
+    "message": "Server names must be unique.",
+    "description": "Validation error when two servers share the same name."
+  },
+  "settings.localToolsMcpNameInvalid": {
+    "message": "Name may only contain letters, numbers, hyphens and underscores.",
+    "description": "Validation error when a server name contains invalid characters."
+  },
   "settings.localToolsSaved": {
     "message": "Sparat",
     "description": "Transient confirmation after saving local-tool folders."

--- a/src/i18n/uk/common.json
+++ b/src/i18n/uk/common.json
@@ -980,6 +980,66 @@
     "message": "Зберегти",
     "description": "Save the authorized folders."
   },
+  "settings.localToolsMcpTitle": {
+    "message": "MCP servers",
+    "description": "Section title for local MCP server configuration in Local Tools settings."
+  },
+  "settings.localToolsMcpHint": {
+    "message": "Connect local MCP servers over stdio. Their tools become available to the AI, gated by the same per-call confirmation. Changes take effect immediately.",
+    "description": "Explains what local MCP servers do and that changes apply without a restart."
+  },
+  "settings.localToolsMcpAdd": {
+    "message": "Add server",
+    "description": "Button to add a new local MCP server row."
+  },
+  "settings.localToolsMcpName": {
+    "message": "Name",
+    "description": "Label for the MCP server name/id field."
+  },
+  "settings.localToolsMcpCommand": {
+    "message": "Command",
+    "description": "Label for the MCP server launch command field."
+  },
+  "settings.localToolsMcpArgs": {
+    "message": "Arguments",
+    "description": "Label for the MCP server command arguments field."
+  },
+  "settings.localToolsMcpArgsHint": {
+    "message": "One argument per line.",
+    "description": "Placeholder/hint for the MCP arguments textarea."
+  },
+  "settings.localToolsMcpEnv": {
+    "message": "Environment",
+    "description": "Label for the MCP server environment variables field."
+  },
+  "settings.localToolsMcpEnvHint": {
+    "message": "One KEY=VALUE per line.",
+    "description": "Placeholder/hint for the MCP environment variables textarea."
+  },
+  "settings.localToolsMcpNoServers": {
+    "message": "No MCP servers configured.",
+    "description": "Empty state shown when no MCP servers are configured."
+  },
+  "settings.localToolsMcpNamePlaceholder": {
+    "message": "e.g. filesystem",
+    "description": "Placeholder for the MCP server name input."
+  },
+  "settings.localToolsMcpCommandPlaceholder": {
+    "message": "e.g. npx",
+    "description": "Placeholder for the MCP server command input."
+  },
+  "settings.localToolsMcpNameRequired": {
+    "message": "Each server needs a name and a command.",
+    "description": "Validation error when a server row is missing a name or command."
+  },
+  "settings.localToolsMcpDuplicateName": {
+    "message": "Server names must be unique.",
+    "description": "Validation error when two servers share the same name."
+  },
+  "settings.localToolsMcpNameInvalid": {
+    "message": "Name may only contain letters, numbers, hyphens and underscores.",
+    "description": "Validation error when a server name contains invalid characters."
+  },
   "settings.localToolsSaved": {
     "message": "Збережено",
     "description": "Transient confirmation after saving local-tool folders."

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -980,6 +980,66 @@
     "message": "保存",
     "description": "保存已授权文件夹。"
   },
+  "settings.localToolsMcpTitle": {
+    "message": "MCP 服务器",
+    "description": "本地工具设置中本地 MCP 服务器配置的分区标题。"
+  },
+  "settings.localToolsMcpHint": {
+    "message": "通过 stdio 连接本地 MCP 服务器。它们的工具会提供给 AI 使用，并受同样的逐次调用确认保护。修改后立即生效。",
+    "description": "说明本地 MCP 服务器的作用，以及修改无需重启即可生效。"
+  },
+  "settings.localToolsMcpAdd": {
+    "message": "添加服务器",
+    "description": "添加一个新的本地 MCP 服务器行的按钮。"
+  },
+  "settings.localToolsMcpName": {
+    "message": "名称",
+    "description": "MCP 服务器名称/标识字段的标签。"
+  },
+  "settings.localToolsMcpCommand": {
+    "message": "命令",
+    "description": "MCP 服务器启动命令字段的标签。"
+  },
+  "settings.localToolsMcpArgs": {
+    "message": "参数",
+    "description": "MCP 服务器命令参数字段的标签。"
+  },
+  "settings.localToolsMcpArgsHint": {
+    "message": "每行一个参数。",
+    "description": "MCP 参数文本框的占位提示。"
+  },
+  "settings.localToolsMcpEnv": {
+    "message": "环境变量",
+    "description": "MCP 服务器环境变量字段的标签。"
+  },
+  "settings.localToolsMcpEnvHint": {
+    "message": "每行一个 KEY=VALUE。",
+    "description": "MCP 环境变量文本框的占位提示。"
+  },
+  "settings.localToolsMcpNoServers": {
+    "message": "尚未配置 MCP 服务器。",
+    "description": "未配置任何 MCP 服务器时显示的空状态。"
+  },
+  "settings.localToolsMcpNamePlaceholder": {
+    "message": "例如 filesystem",
+    "description": "MCP 服务器名称输入框的占位符。"
+  },
+  "settings.localToolsMcpCommandPlaceholder": {
+    "message": "例如 npx",
+    "description": "MCP 服务器命令输入框的占位符。"
+  },
+  "settings.localToolsMcpNameRequired": {
+    "message": "每个服务器都需要名称和命令。",
+    "description": "服务器行缺少名称或命令时的校验错误。"
+  },
+  "settings.localToolsMcpDuplicateName": {
+    "message": "服务器名称必须唯一。",
+    "description": "两个服务器名称重复时的校验错误。"
+  },
+  "settings.localToolsMcpNameInvalid": {
+    "message": "名称只能包含字母、数字、连字符和下划线。",
+    "description": "服务器名称含非法字符时的校验错误。"
+  },
   "settings.localToolsSaved": {
     "message": "已保存",
     "description": "保存本地工具文件夹后的短暂确认。"

--- a/src/i18n/zh-TW/common.json
+++ b/src/i18n/zh-TW/common.json
@@ -980,6 +980,66 @@
     "message": "儲存",
     "description": "Save the authorized folders."
   },
+  "settings.localToolsMcpTitle": {
+    "message": "MCP servers",
+    "description": "Section title for local MCP server configuration in Local Tools settings."
+  },
+  "settings.localToolsMcpHint": {
+    "message": "Connect local MCP servers over stdio. Their tools become available to the AI, gated by the same per-call confirmation. Changes take effect immediately.",
+    "description": "Explains what local MCP servers do and that changes apply without a restart."
+  },
+  "settings.localToolsMcpAdd": {
+    "message": "Add server",
+    "description": "Button to add a new local MCP server row."
+  },
+  "settings.localToolsMcpName": {
+    "message": "Name",
+    "description": "Label for the MCP server name/id field."
+  },
+  "settings.localToolsMcpCommand": {
+    "message": "Command",
+    "description": "Label for the MCP server launch command field."
+  },
+  "settings.localToolsMcpArgs": {
+    "message": "Arguments",
+    "description": "Label for the MCP server command arguments field."
+  },
+  "settings.localToolsMcpArgsHint": {
+    "message": "One argument per line.",
+    "description": "Placeholder/hint for the MCP arguments textarea."
+  },
+  "settings.localToolsMcpEnv": {
+    "message": "Environment",
+    "description": "Label for the MCP server environment variables field."
+  },
+  "settings.localToolsMcpEnvHint": {
+    "message": "One KEY=VALUE per line.",
+    "description": "Placeholder/hint for the MCP environment variables textarea."
+  },
+  "settings.localToolsMcpNoServers": {
+    "message": "No MCP servers configured.",
+    "description": "Empty state shown when no MCP servers are configured."
+  },
+  "settings.localToolsMcpNamePlaceholder": {
+    "message": "e.g. filesystem",
+    "description": "Placeholder for the MCP server name input."
+  },
+  "settings.localToolsMcpCommandPlaceholder": {
+    "message": "e.g. npx",
+    "description": "Placeholder for the MCP server command input."
+  },
+  "settings.localToolsMcpNameRequired": {
+    "message": "Each server needs a name and a command.",
+    "description": "Validation error when a server row is missing a name or command."
+  },
+  "settings.localToolsMcpDuplicateName": {
+    "message": "Server names must be unique.",
+    "description": "Validation error when two servers share the same name."
+  },
+  "settings.localToolsMcpNameInvalid": {
+    "message": "Name may only contain letters, numbers, hyphens and underscores.",
+    "description": "Validation error when a server name contains invalid characters."
+  },
   "settings.localToolsSaved": {
     "message": "已儲存",
     "description": "Transient confirmation after saving local-tool folders."

--- a/src/utils/desktop.ts
+++ b/src/utils/desktop.ts
@@ -63,12 +63,12 @@ export interface LocalExecBridge {
   }): Promise<{ output: string; is_error?: boolean; image?: string }>;
   getConfig(): Promise<{
     roots: string[];
-    mcp: { id: string; command: string; args: string[] }[];
+    mcp: { id: string; command: string; args: string[]; cwd?: string; env?: Record<string, string> }[];
     computerUse?: boolean;
   }>;
   saveConfig(cfg: {
     roots: string[];
-    mcp: { id: string; command: string; args: string[] }[];
+    mcp: { id: string; command: string; args: string[]; cwd?: string; env?: Record<string, string> }[];
     computerUse?: boolean;
   }): Promise<boolean>;
   pickFolder(): Promise<string | null>;


### PR DESCRIPTION
## What & why

Answers "can Nexior desktop connect to **local MCP servers**, like Claude Desktop?" — yes, and the engine already shipped. This PR closes the two remaining UX gaps.

Already in place (no change here):
- **Engine** — `electron/local/mcp.ts` `McpHost` spawns local **stdio** MCP servers, does `initialize` + `tools/list` + `tools/call` (newline-framed JSON-RPC, 30s timeouts). Merged in Nexior #1069.
- **Backend** — aichat2 worker accepts `client_tools`, registers them, pauses the turn with `execution:'client'`, and resumes via `tool_results`. Merged in PlatformService #1215.

The gaps this PR fills:
1. **No UI** to configure MCP servers — you had to hand-edit `userData/local-tools.json`.
2. Changes **only applied on next app launch**.

## Changes
- **`src/components/setting/LocalTools.vue`** — new **MCP servers** section: add / edit / remove rows (name, command, args one-per-line, env `KEY=VALUE` per line). Validates the server id against `^[A-Za-z0-9_-]+$` (so it can never break the `mcp.<id>.<tool>` route key), uniqueness, and required fields.
- **`electron/local/registry.ts`** — `reboot(servers)`: stop the running MCP host, drop its tool specs/names (keep builtin + computer), re-boot the new set.
- **`electron/local/ipc.ts`** — `local.config.save` now **hot-applies** MCP changes by awaiting `registry.reboot()` when the mcp config changed; saves are **serialized** through a shared chain so overlapping folder / MCP / Computer-Use saves can't drop a field.
- **`src/utils/desktop.ts`** — widen the mcp config type with optional `cwd` / `env`.
- **i18n** — 15 new keys across all 18 locales (zh-CN + en authored; rest English pending the translate CronJob).

## Validation
- `tsc -p electron/tsconfig.json` ✅ · `vue-tsc -b` ✅ · `eslint` ✅
- `npm run test:run` → **214 passed** ✅
- `scripts/check_i18n_coverage.py` → all locales cover zh-CN ✅

## 🤖 对抗评审
Reviewer: Claude `general-purpose` subagent (Codex was rate-limited). 4 RISKs raised, all fixed:
1. **RISK (exit-handler race, `mcp.ts`)** — on reboot, an old proc's async `exit` deleted the freshly re-booted proc of the same id → untracked, `call()` fails. **Fixed**: guard `procs.get(id) === p` before delete.
2. **RISK (dotted tool names, `registry.invoke`)** — `mcp.<id>.<tool>` split on every `.` truncated tool names containing dots. **Fixed**: split at the first dot after the `mcp.` prefix (id is dot-free by validation).
3. **RISK (index v-for key)** — removing a middle MCP row rebinds inputs by index. **Fixed**: stable `_uid` render key.
4. **RISK (concurrent save data loss)** — read-modify-write on one JSON from 3 UI paths. **Fixed**: serialized `local.config.save` via a shared promise chain.
