### PR TITLE
fix(android): native 3-tier Computer Use consent (Allow once / Always allow / Deny), matching desktop

### DIFF
--- a/android/app/src/main/java/com/acedatacloud/nexior/ComputerUsePlugin.java
+++ b/android/app/src/main/java/com/acedatacloud/nexior/ComputerUsePlugin.java
@@ -1,5 +1,6 @@
 package com.acedatacloud.nexior;
 
+import android.app.Activity;
 import android.content.BroadcastReceiver;
 import android.content.ComponentName;
 import android.content.Context;
@@ -10,6 +11,7 @@ import android.provider.Settings;
 import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
 import androidx.core.content.ContextCompat;
 
 import com.getcapacitor.JSObject;
@@ -108,6 +110,46 @@ public class ComputerUsePlugin extends Plugin {
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         getContext().startActivity(intent);
         call.resolve();
+    }
+
+    /**
+     * Native 3-tier on-demand consent, mirroring the desktop native confirm
+     * (Allow once / Always allow / Deny). Android AlertDialog supports exactly
+     * three buttons (positive/neutral/negative). Back button / tap-outside =
+     * deny (fail-closed), matching desktop's cancelId. Labels are passed from
+     * JS so i18n stays in one place. Resolves { choice: once|always|deny }.
+     */
+    @PluginMethod
+    public void confirmConsent(PluginCall call) {
+        final String title = call.getString("title", "Allow action?");
+        final String message = call.getString("message", "");
+        final String onceLabel = call.getString("onceLabel", "Allow once");
+        final String alwaysLabel = call.getString("alwaysLabel", "Always allow");
+        final String denyLabel = call.getString("denyLabel", "Deny");
+        final Activity activity = getActivity();
+        if (activity == null) {
+            call.reject("no activity to host consent dialog");
+            return;
+        }
+        final boolean[] done = { false };
+        activity.runOnUiThread(() ->
+                new AlertDialog.Builder(activity)
+                        .setTitle(title)
+                        .setMessage(message)
+                        .setCancelable(true)
+                        .setPositiveButton(onceLabel, (d, w) -> resolveChoice(call, done, "once"))
+                        .setNeutralButton(alwaysLabel, (d, w) -> resolveChoice(call, done, "always"))
+                        .setNegativeButton(denyLabel, (d, w) -> resolveChoice(call, done, "deny"))
+                        .setOnCancelListener(d -> resolveChoice(call, done, "deny"))
+                        .show());
+    }
+
+    private void resolveChoice(PluginCall call, boolean[] done, String choice) {
+        if (done[0]) return;
+        done[0] = true;
+        JSObject ret = new JSObject();
+        ret.put("choice", choice);
+        call.resolve(ret);
     }
 
     private ComputerUseAccessibilityService requireService(PluginCall call) {

--- a/change/@acedatacloud-nexior-99c3eacf-bb5c-4922-b07a-d2ce5de2fee4.json
+++ b/change/@acedatacloud-nexior-99c3eacf-bb5c-4922-b07a-d2ce5de2fee4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(android): native 3-tier on-demand Computer Use consent (Allow once / Always allow / Deny), matching desktop",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/i18n/ar/common.json
+++ b/src/i18n/ar/common.json
@@ -1296,6 +1296,10 @@
     "message": "Allow once",
     "description": "Allow button of the on-demand consent dialog."
   },
+  "settings.cuConsentAlways": {
+    "message": "Always allow",
+    "description": "Always-allow button of the on-demand consent dialog; persists a grant so this action never prompts again."
+  },
   "settings.cuConsentDeny": {
     "message": "Deny",
     "description": "Deny button of the on-demand consent dialog."

--- a/src/i18n/de/common.json
+++ b/src/i18n/de/common.json
@@ -1296,6 +1296,10 @@
     "message": "Allow once",
     "description": "Allow button of the on-demand consent dialog."
   },
+  "settings.cuConsentAlways": {
+    "message": "Always allow",
+    "description": "Always-allow button of the on-demand consent dialog; persists a grant so this action never prompts again."
+  },
   "settings.cuConsentDeny": {
     "message": "Deny",
     "description": "Deny button of the on-demand consent dialog."

--- a/src/i18n/el/common.json
+++ b/src/i18n/el/common.json
@@ -1296,6 +1296,10 @@
     "message": "Allow once",
     "description": "Allow button of the on-demand consent dialog."
   },
+  "settings.cuConsentAlways": {
+    "message": "Always allow",
+    "description": "Always-allow button of the on-demand consent dialog; persists a grant so this action never prompts again."
+  },
   "settings.cuConsentDeny": {
     "message": "Deny",
     "description": "Deny button of the on-demand consent dialog."

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -1296,6 +1296,10 @@
     "message": "Allow once",
     "description": "Allow button of the on-demand consent dialog."
   },
+  "settings.cuConsentAlways": {
+    "message": "Always allow",
+    "description": "Always-allow button of the on-demand consent dialog; persists a grant so this action never prompts again."
+  },
   "settings.cuConsentDeny": {
     "message": "Deny",
     "description": "Deny button of the on-demand consent dialog."

--- a/src/i18n/es/common.json
+++ b/src/i18n/es/common.json
@@ -1296,6 +1296,10 @@
     "message": "Allow once",
     "description": "Allow button of the on-demand consent dialog."
   },
+  "settings.cuConsentAlways": {
+    "message": "Always allow",
+    "description": "Always-allow button of the on-demand consent dialog; persists a grant so this action never prompts again."
+  },
   "settings.cuConsentDeny": {
     "message": "Deny",
     "description": "Deny button of the on-demand consent dialog."

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -1296,6 +1296,10 @@
     "message": "Allow once",
     "description": "Allow button of the on-demand consent dialog."
   },
+  "settings.cuConsentAlways": {
+    "message": "Always allow",
+    "description": "Always-allow button of the on-demand consent dialog; persists a grant so this action never prompts again."
+  },
   "settings.cuConsentDeny": {
     "message": "Deny",
     "description": "Deny button of the on-demand consent dialog."

--- a/src/i18n/fr/common.json
+++ b/src/i18n/fr/common.json
@@ -1296,6 +1296,10 @@
     "message": "Allow once",
     "description": "Allow button of the on-demand consent dialog."
   },
+  "settings.cuConsentAlways": {
+    "message": "Always allow",
+    "description": "Always-allow button of the on-demand consent dialog; persists a grant so this action never prompts again."
+  },
   "settings.cuConsentDeny": {
     "message": "Deny",
     "description": "Deny button of the on-demand consent dialog."

--- a/src/i18n/it/common.json
+++ b/src/i18n/it/common.json
@@ -1296,6 +1296,10 @@
     "message": "Allow once",
     "description": "Allow button of the on-demand consent dialog."
   },
+  "settings.cuConsentAlways": {
+    "message": "Always allow",
+    "description": "Always-allow button of the on-demand consent dialog; persists a grant so this action never prompts again."
+  },
   "settings.cuConsentDeny": {
     "message": "Deny",
     "description": "Deny button of the on-demand consent dialog."

--- a/src/i18n/ja/common.json
+++ b/src/i18n/ja/common.json
@@ -1296,6 +1296,10 @@
     "message": "Allow once",
     "description": "Allow button of the on-demand consent dialog."
   },
+  "settings.cuConsentAlways": {
+    "message": "Always allow",
+    "description": "Always-allow button of the on-demand consent dialog; persists a grant so this action never prompts again."
+  },
   "settings.cuConsentDeny": {
     "message": "Deny",
     "description": "Deny button of the on-demand consent dialog."

--- a/src/i18n/ko/common.json
+++ b/src/i18n/ko/common.json
@@ -1296,6 +1296,10 @@
     "message": "Allow once",
     "description": "Allow button of the on-demand consent dialog."
   },
+  "settings.cuConsentAlways": {
+    "message": "Always allow",
+    "description": "Always-allow button of the on-demand consent dialog; persists a grant so this action never prompts again."
+  },
   "settings.cuConsentDeny": {
     "message": "Deny",
     "description": "Deny button of the on-demand consent dialog."

--- a/src/i18n/pl/common.json
+++ b/src/i18n/pl/common.json
@@ -1296,6 +1296,10 @@
     "message": "Allow once",
     "description": "Allow button of the on-demand consent dialog."
   },
+  "settings.cuConsentAlways": {
+    "message": "Always allow",
+    "description": "Always-allow button of the on-demand consent dialog; persists a grant so this action never prompts again."
+  },
   "settings.cuConsentDeny": {
     "message": "Deny",
     "description": "Deny button of the on-demand consent dialog."

--- a/src/i18n/pt/common.json
+++ b/src/i18n/pt/common.json
@@ -1296,6 +1296,10 @@
     "message": "Allow once",
     "description": "Allow button of the on-demand consent dialog."
   },
+  "settings.cuConsentAlways": {
+    "message": "Always allow",
+    "description": "Always-allow button of the on-demand consent dialog; persists a grant so this action never prompts again."
+  },
   "settings.cuConsentDeny": {
     "message": "Deny",
     "description": "Deny button of the on-demand consent dialog."

--- a/src/i18n/ru/common.json
+++ b/src/i18n/ru/common.json
@@ -1296,6 +1296,10 @@
     "message": "Allow once",
     "description": "Allow button of the on-demand consent dialog."
   },
+  "settings.cuConsentAlways": {
+    "message": "Always allow",
+    "description": "Always-allow button of the on-demand consent dialog; persists a grant so this action never prompts again."
+  },
   "settings.cuConsentDeny": {
     "message": "Deny",
     "description": "Deny button of the on-demand consent dialog."

--- a/src/i18n/sr/common.json
+++ b/src/i18n/sr/common.json
@@ -1296,6 +1296,10 @@
     "message": "Allow once",
     "description": "Allow button of the on-demand consent dialog."
   },
+  "settings.cuConsentAlways": {
+    "message": "Always allow",
+    "description": "Always-allow button of the on-demand consent dialog; persists a grant so this action never prompts again."
+  },
   "settings.cuConsentDeny": {
     "message": "Deny",
     "description": "Deny button of the on-demand consent dialog."

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -1296,6 +1296,10 @@
     "message": "Allow once",
     "description": "Allow button of the on-demand consent dialog."
   },
+  "settings.cuConsentAlways": {
+    "message": "Always allow",
+    "description": "Always-allow button of the on-demand consent dialog; persists a grant so this action never prompts again."
+  },
   "settings.cuConsentDeny": {
     "message": "Deny",
     "description": "Deny button of the on-demand consent dialog."

--- a/src/i18n/uk/common.json
+++ b/src/i18n/uk/common.json
@@ -1296,6 +1296,10 @@
     "message": "Allow once",
     "description": "Allow button of the on-demand consent dialog."
   },
+  "settings.cuConsentAlways": {
+    "message": "Always allow",
+    "description": "Always-allow button of the on-demand consent dialog; persists a grant so this action never prompts again."
+  },
   "settings.cuConsentDeny": {
     "message": "Deny",
     "description": "Deny button of the on-demand consent dialog."

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -1296,6 +1296,10 @@
     "message": "允许一次",
     "description": "按需授权对话框的允许按钮。"
   },
+  "settings.cuConsentAlways": {
+    "message": "总是允许",
+    "description": "按需授权对话框的总是允许按钮；持久化授权，此操作以后不再询问。"
+  },
   "settings.cuConsentDeny": {
     "message": "拒绝",
     "description": "按需授权对话框的拒绝按钮。"

--- a/src/i18n/zh-TW/common.json
+++ b/src/i18n/zh-TW/common.json
@@ -1296,6 +1296,10 @@
     "message": "Allow once",
     "description": "Allow button of the on-demand consent dialog."
   },
+  "settings.cuConsentAlways": {
+    "message": "Always allow",
+    "description": "Always-allow button of the on-demand consent dialog; persists a grant so this action never prompts again."
+  },
   "settings.cuConsentDeny": {
     "message": "Deny",
     "description": "Deny button of the on-demand consent dialog."

--- a/src/plugins/computerUse.ts
+++ b/src/plugins/computerUse.ts
@@ -50,6 +50,15 @@ export interface ComputerUsePlugin {
   status(): Promise<ComputerUseStatus>;
   /** Deep-link to Settings → Accessibility so the user can enable the service. */
   openAccessibilitySettings(): Promise<void>;
+  /** Native 3-tier on-demand consent (Allow once / Always allow / Deny),
+   *  mirroring the desktop native confirm. Back / tap-outside = deny. */
+  confirmConsent(options: {
+    title: string;
+    message: string;
+    onceLabel: string;
+    alwaysLabel: string;
+    denyLabel: string;
+  }): Promise<{ choice: 'once' | 'always' | 'deny' }>;
   screenshot(): Promise<ComputerUseScreenshotResult>;
   click(options: { x: number; y: number; button?: string }): Promise<ComputerUseActionResult>;
   move(options: { x: number; y: number }): Promise<ComputerUseActionResult>;

--- a/src/utils/mobileLocalExec.ts
+++ b/src/utils/mobileLocalExec.ts
@@ -23,7 +23,6 @@
  * tool error the model can react to.
  */
 import { Capacitor } from '@capacitor/core';
-import { ElMessageBox } from 'element-plus';
 import { ComputerUse } from '@/plugins/computerUse';
 import i18n from '@/i18n';
 import type { LocalExecBridge, LocalToolSpec } from '@/utils/desktop';
@@ -186,36 +185,40 @@ function writeGrants(names: string[]): void {
   }
 }
 
-/** Per-call consent: honor a persisted always-allow grant, else show an
- *  ON-DEMAND consent dialog (Allow once / Deny). Users who want an action to
- *  run without prompting can pre-authorize it in Settings → Local Tools. Falls
- *  back to a native confirm if the dialog service can't render (SSR/no DOM).
- *  Returns false → denied (never silent). */
+/** Per-call consent: honor a persisted always-allow grant, else show a NATIVE
+ *  3-tier on-demand confirm — Allow once / Always allow / Deny — mirroring the
+ *  desktop native confirm (Electron main-process dialog). "Always allow"
+ *  persists a grant (same store the Settings → Local Tools toggles read/write),
+ *  so the action never prompts again and shows ON in Settings. Returns false →
+ *  denied (never silent). */
 async function ensureConsent(name: string): Promise<boolean> {
   if (readGrants().includes(name)) return true;
-  // On-demand consent needs a VISIBLE dialog. If Nexior is backgrounded (the
+  // On-demand consent needs a VISIBLE prompt. If Nexior is backgrounded (the
   // model is mid-task operating another app), we can't prompt — deny
-  // (fail-closed) rather than hang on an invisible modal. Autonomous background
-  // tasks must pre-authorize the action in Settings → Local Tools.
+  // (fail-closed) rather than surface a dialog the user can't see. Autonomous
+  // background tasks must pre-authorize the action in Settings → Local Tools.
   if (typeof document !== 'undefined' && document.visibilityState === 'hidden') {
     return false;
   }
   const t = i18n.global.t;
   const action = name.replace(/^computer\./, '');
-  const message = t('common.settings.cuConsentMessage', { action });
   try {
-    await ElMessageBox.confirm(message, t('common.settings.cuConsentTitle'), {
-      confirmButtonText: t('common.settings.cuConsentAllow'),
-      cancelButtonText: t('common.settings.cuConsentDeny'),
-      type: 'warning',
-      distinguishCancelAndClose: true
+    const { choice } = await ComputerUse.confirmConsent({
+      title: t('common.settings.cuConsentTitle'),
+      message: t('common.settings.cuConsentMessage', { action }),
+      onceLabel: t('common.settings.cuConsentAllow'),
+      alwaysLabel: t('common.settings.cuConsentAlways'),
+      denyLabel: t('common.settings.cuConsentDeny')
     });
-    return true;
-  } catch (e) {
-    // Element Plus (v2) rejects with the string 'cancel'/'close' on user denial.
-    if (typeof e === 'string') return false;
-    // Anything else = the dialog couldn't render → fall back to a native confirm.
-    return typeof window !== 'undefined' && typeof window.confirm === 'function' ? window.confirm(message) : false;
+    if (choice === 'always') {
+      // Persist so this action never prompts again (and lights up its Settings
+      // → Local Tools toggle). Revocable there or by turning Computer Use off.
+      writeGrants([...readGrants(), name]);
+      return true;
+    }
+    return choice === 'once';
+  } catch {
+    return false;
   }
 }
 


### PR DESCRIPTION
## What & why

The Android **Computer Use** on-demand consent prompt (1) was invisible in this vite-ssg app when built on `ElMessageBox`, and (2) only offered **Allow once / Deny**. Desktop (Mac/Windows) prompts with an **OS-native confirm** that offers a third tier — **Always allow**. Android wasn't at parity.

> 你得对标啊？比如 always allow 呢？—— 对，补齐。

## Fix — native 3-tier dialog, matching desktop

Add a **native Android `AlertDialog`** (the mobile analogue of desktop's Electron main-process confirm), exposed as a new `ComputerUse.confirmConsent` plugin method. Android's `AlertDialog` has exactly three buttons → mapped to the three tiers:

| Button | Tier | Behavior |
|---|---|---|
| **ALLOW ONCE** (positive) | once | run this one time; nothing persisted |
| **ALWAYS ALLOW** (neutral) | always | persist a grant to the **same store** the Settings → Local Tools per-action toggles read/write, so the action never prompts again **and shows ON there** (revocable). Mirrors desktop's "Always allow". |
| **DENY** (negative) | deny | fail-closed. Back button / tap-outside also = deny. |

- `android/…/ComputerUsePlugin.java` — new `confirmConsent()` @PluginMethod (native `AlertDialog`, resolves `{choice}` exactly once via a `done[]` guard, cancel→deny).
- `src/plugins/computerUse.ts` — `confirmConsent(...)` typing → `{choice:'once'|'always'|'deny'}`.
- `src/utils/mobileLocalExec.ts` — `ensureConsent()` calls `confirmConsent`; on `always` → `writeGrants([...readGrants(), name])`. Keeps the fail-closed backgrounded guard. `@capacitor/dialog` (the 2-button interim from the prior revision) removed.
- `src/i18n/*/common.json` — new flat key `settings.cuConsentAlways` in all 18 locales.

Rebased on latest `main`; diff is now just these changes.

## E2E (emulator, Android 16, 1080×2400, native `AlertDialog` via `uiautomator dump`)

Native dialog shows **ALLOW ONCE / ALWAYS ALLOW / DENY** (screencap in thread):

| Case | Result |
|---|---|
| **ALWAYS ALLOW** on `computer.screenshot` | screenshot runs (real JPEG); `grants = ["computer.screenshot"]`; a **second** call runs with **no prompt** |
| **ALLOW ONCE** on `computer.click` | runs; `grants` stays `[]` (not persisted) |
| **DENY** on `computer.type` | `is_error: true`, `denied: "computer.type" is not pre-authorized…` (fail-closed) |

The persisted grant is the same `nexior.android.cu.grants` store the Settings → Local Tools per-action toggles read — so "Always allow" lights up the toggle and is revocable there (or by turning Computer Use off).

## Validation

- `npx vue-tsc --noEmit -p tsconfig.app.json`, `npx eslint --fix` — clean
- `python3 scripts/check_i18n_coverage.py` — `OK: 17 locale(s) × 44 namespace(s)`
- `npm run build:android` + `cap sync` + `gradlew :app:assembleDebug` — APK built, native plugin method linked

## 🤖 对抗评审

Reviewer: Explore subagent (Codex hit its usage limit). One round → converged.

| # | Finding | Resolution |
|---|---|---|
| RISK | Grants keyed by tool **name** (`computer.click`), not `(tool, input)` like desktop — "Always allow click" then permits any coordinate | **Accepted as designed.** Computer-use coordinates are chosen per-call, so input-scoped grants (desktop's model, suited to file/shell tools) would be useless here — every new coord would re-prompt. Name-scoping is the meaningful unit for screen actions; all `computer.*` tools are equally screen-mutating. Reviewer: "By design, not a bug." |
| RISK | `confirmConsent` doesn't `setKeepAlive`; if the activity is destroyed mid-dialog the awaiting JS promise could hang | **Accepted / near-impossible here.** Single-activity, **portrait-locked** app → no rotation/config-change destruction; a genuine activity destroy tears down the WebView/JS context too, which disposes the pending promise. Matches desktop, whose native confirm also blocks indefinitely (no timeout). Flagged as a possible future hardening (JS timeout) but not needed for this PR. |
| ✅ verified | `done[]` resolve-once (UI-thread only, button XOR cancel); `androidx.appcompat.AlertDialog` on classpath; `writeGrants` dedups via `Set`; fail-closed on background; store/key parity with Settings; no leftover `@capacitor/dialog`; i18n key in all 18 locales (guard green) | — |
| NITs | consent-before-startSession ordering; a11y-not-running shows generic error; no window leak on activity finish | All pre-existing / acceptable. |

**VERDICT: CLEAN** (RISKs accepted-by-design with reasoning).
