### PR TITLE
fix(desktop): use boolean form for mac.notarize (electron-builder 26.x)

### DIFF
--- a/change/@acedatacloud-nexior-4e766983-3c6b-488a-8f6c-c88a5f6f4bbb.json
+++ b/change/@acedatacloud-nexior-4e766983-3c6b-488a-8f6c-c88a5f6f4bbb.json
@@ -1,0 +1,7 @@
+{
+  "email": "dev@acedata.cloud",
+  "packageName": "@acedatacloud/nexior",
+  "dependentChangeType": "patch",
+  "type": "patch",
+  "comment": "fix(desktop): use boolean form for mac.notarize (electron-builder 26.x)"
+}

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -70,11 +70,16 @@ mac:
     NSMicrophoneUsageDescription: AceData uses the microphone only for voice tools you start.
     NSCameraUsageDescription: AceData uses the camera only for vision tools you start.
     NSAppleEventsUsageDescription: AceData controls other apps only when you run an automation tool.
-  # Object form requires APPLE_ID + APPLE_APP_SPECIFIC_PASSWORD + APPLE_TEAM_ID
-  # ALL present in env at sign time (CI asserts this), else electron-builder
-  # signs but SILENTLY skips notarization → Gatekeeper blocks user machines.
-  notarize:
-    teamId: ${env.APPLE_TEAM_ID}
+  # electron-builder 26.x requires `notarize` to be a boolean. Credentials come
+  # from env at sign time (any ONE of these sets):
+  #   1) APPLE_API_KEY + APPLE_API_KEY_ID + APPLE_API_ISSUER   (App Store Connect API key — CI's choice)
+  #   2) APPLE_ID + APPLE_APP_SPECIFIC_PASSWORD + APPLE_TEAM_ID
+  #   3) APPLE_KEYCHAIN + APPLE_KEYCHAIN_PROFILE
+  # If none are set electron-builder signs but SILENTLY skips notarization →
+  # Gatekeeper blocks user machines, so CI must provide them (see
+  # .github/workflows/desktop.yml). The unsigned path overrides this to `false`
+  # via `--config.mac.notarize=false`.
+  notarize: true
 
 publish:
   provider: generic


### PR DESCRIPTION
## Problem

`npm run pack:electron` (and the CI `desktop.yml` workflow) fails on electron-builder 26.15.3 with:

```
Invalid configuration object. electron-builder ... has been initialized using a configuration object that does not match the API schema.
 - configuration.mac.notarize should be a boolean
```

electron-builder 26.x removed the object form of `mac.notarize` — the schema now only accepts a boolean (see [`scheme.json`](https://github.com/electron-userland/electron-builder/blob/master/packages/app-builder-lib/scheme.json)).

The current config still uses the removed form:

```yaml
notarize:
  teamId: ${env.APPLE_TEAM_ID}
```

## Fix

Switch `mac.notarize` to the boolean form and document where credentials come from:

```yaml
notarize: true
```

Notarization credentials are already supplied by CI env vars on the mac sign path — no CI change needed:

- `.github/workflows/desktop.yml` sign path exports `APPLE_API_KEY` (file) + `APPLE_API_KEY_ID` + `APPLE_API_ISSUER` + `APPLE_TEAM_ID`.
- The unsigned CI path continues to override with `--config.mac.notarize=false`, which is still valid under the boolean schema.

## Verification

Locally in a fresh worktree with the fix applied:

```
> npx electron-builder --win --dir
  • electron-builder  version=26.15.3 os=10.0.22631
  • loaded configuration  file=…\electron-builder.yml
  • executing @electron/rebuild
  • packaging  platform=win32 arch=x64 electron=42.4.1
  • downloaded electron zip extracted successfully
```

Configuration validates cleanly (schema error is gone). Packaging then proceeds through native rebuild, electron download, and unpacking.

## 🤖 对抗评审

Reviewer: Claude `general-purpose` subagent (Codex CLI not available on this box).
Loop: review → rebut → converge (1 round, both findings out of PR scope).

| # | Finding | Verdict |
|---|---------|---------|
| 1 | `electron-builder.win.yml` has a stale comment about schema failure | **REBUT** — that file is an untracked local-only workaround that only exists in one developer's working copy; it is not tracked in git and not part of this PR. It will be removed locally once this lands. |
| 2 | Local macOS build without signing certs has no doc guidance | **REBUT** — behavior is unchanged by this PR. electron-builder auto-skips signing (and thus notarization becomes a no-op) when no `CSC_LINK`/keychain identity is present. A documentation improvement is legitimate but out of scope for this schema-conformance fix. |

**VERDICT: CLEAN** for the change in this PR.
