### PR TITLE
feat(desktop): MCP per-server status + enable/reconnect + cross-platform spawn fix

### DIFF
--- a/change/@acedatacloud-nexior-mcp-status.json
+++ b/change/@acedatacloud-nexior-mcp-status.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Desktop MCP: per-server connection status (connected/failed-with-reason/disabled) + enable toggle + Test/Reconnect in Settings, and a cross-platform spawn fix (rebuild PATH from the login shell on macOS/Linux, shell:true on Windows) so GUI-launched apps can actually find npx/node/uvx.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/electron/local/ipc.ts
+++ b/electron/local/ipc.ts
@@ -90,6 +90,25 @@ export function registerLocalExec(getWin: () => BrowserWindow | null): void {
     );
     return configSaveChain;
   });
+
+  // Per-server MCP connection status, so Settings can show connected / failed
+  // (with reason) / disabled per server instead of a silent merged tool list.
+  ipcMain.handle('local.mcp.status', (e) => {
+    gate(e);
+    return registry.mcpStatus();
+  });
+
+  // "Test / Reconnect" one MCP server: re-spawn it from the persisted config
+  // and return its fresh status. Chained behind saves so it can't race one; the
+  // chain is kept always-resolving so a failed reconnect can't poison later saves.
+  ipcMain.handle('local.mcp.reconnect', (e, id: string) => {
+    gate(e);
+    const run = (): Promise<unknown> => registry.reconnect(id, load().mcp);
+    const p = configSaveChain.then(run, run);
+    configSaveChain = p.then(() => true, () => true);
+    return p.then(() => registry.mcpStatus().find((s) => s.id === id) ?? null);
+  });
+
   ipcMain.handle('local.pickFolder', async (e) => {
     gate(e);
     const win = getWin();

--- a/electron/local/mcp.ts
+++ b/electron/local/mcp.ts
@@ -1,9 +1,44 @@
-import { spawn, ChildProcess } from 'node:child_process';
+import { spawn, execFile, ChildProcess } from 'node:child_process';
+import { promisify } from 'node:util';
 import type { McpServerConf, ToolSpec, ToolResult } from './types';
 
+const execFileAsync = promisify(execFile);
 const RPC_TIMEOUT_MS = 30_000;
 
 interface Pending { resolve: (v: unknown) => void; reject: (e: Error) => void; timer: NodeJS.Timeout; }
+
+// A GUI-launched Electron app (Finder / Dock / Start menu) inherits a stripped
+// PATH — it does NOT source the user's shell profile — so `npx` / `node` /
+// `uvx` / `bunx` (in Homebrew, nvm, ~/.local, bun) resolve to `spawn ENOENT`
+// and every MCP server silently fails to connect. Rebuild a usable PATH once,
+// cached (as a Promise) for the process lifetime. ASYNC so the login-shell
+// probe never blocks the main thread / UI.
+let cachedPath: Promise<string> | null = null;
+function resolveEnhancedPath(): Promise<string> {
+  if (cachedPath) return cachedPath;
+  cachedPath = (async (): Promise<string> => {
+    const sep = process.platform === 'win32' ? ';' : ':';
+    let parts = (process.env.PATH || '').split(sep);
+    if (process.platform !== 'win32') {
+      // Ask the user's login shell for its real PATH (covers nvm / asdf / brew /
+      // bun). Bounded by a short timeout + static fallback so a slow or noisy
+      // shell can't wedge startup; take the last non-empty line.
+      try {
+        const shell = process.env.SHELL || '/bin/zsh';
+        const { stdout } = await execFileAsync(shell, ['-lic', 'printf "%s" "$PATH"'], { timeout: 3000, encoding: 'utf8' });
+        const line = stdout.trim().split('\n').filter(Boolean).pop() || '';
+        if (line.includes('/')) parts = line.split(sep).concat(parts);
+      } catch {
+        /* login shell unavailable — fall back to the static dirs below */
+      }
+      const home = process.env.HOME || '';
+      parts = parts.concat(['/opt/homebrew/bin', '/usr/local/bin', '/usr/bin', '/bin', `${home}/.local/bin`, `${home}/.bun/bin`]);
+    }
+    const seen = new Set<string>();
+    return parts.filter((d) => d && !seen.has(d) && seen.add(d)).join(sep);
+  })();
+  return cachedPath;
+}
 
 // Spawns local stdio MCP servers and bridges tools/list + tools/call.
 // Newline-delimited JSON-RPC with partial-line buffering; notifications (no id)
@@ -12,12 +47,32 @@ export class McpHost {
   private procs = new Map<string, ChildProcess>();
   private seq = 0;
   private pending = new Map<number, Pending>();
+  // Last ~2KB of stderr per server id, so a failed start can report WHY.
+  private stderrTail = new Map<string, string>();
 
   async start(c: McpServerConf): Promise<void> {
+    const isWin = process.platform === 'win32';
+    const enhancedPath = await resolveEnhancedPath();
     const p = spawn(c.command, c.args, {
       cwd: c.cwd,
-      env: { ...c.env, PATH: process.env.PATH },
-      stdio: ['pipe', 'pipe', 'inherit']
+      // Spread the full env (MCP servers expect HOME/USER/etc.), let the server
+      // conf override, then force our resolved PATH last.
+      env: { ...process.env, ...c.env, PATH: enhancedPath },
+      stdio: ['pipe', 'pipe', 'pipe'],
+      // Windows: `npx`/`node` are `.cmd` shims that only resolve via a shell.
+      shell: isWin,
+      windowsHide: true
+    });
+    this.procs.set(c.id, p);
+    this.stderrTail.set(c.id, '');
+    p.stderr?.on('data', (chunk: Buffer) => {
+      this.stderrTail.set(c.id, ((this.stderrTail.get(c.id) ?? '') + chunk.toString()).slice(-2000));
+    });
+    // spawn failures (ENOENT for a missing command, EACCES, …) arrive as an
+    // 'error' event, NOT a throw — race it against initialize so a bad command
+    // rejects start() promptly instead of hanging until the rpc timeout.
+    const spawnError = new Promise<never>((_, reject) => {
+      p.once('error', (e: Error) => reject(new Error(`spawn ${c.command}: ${e.message}`)));
     });
     let buf = '';
     p.stdout.on('data', (chunk: Buffer) => {
@@ -46,8 +101,17 @@ export class McpHost {
       // same id; the old proc's async exit must NOT delete the new entry.
       if (this.procs.get(c.id) === p) this.procs.delete(c.id);
     });
-    this.procs.set(c.id, p);
-    await this.rpc(c.id, 'initialize', { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'nexior', version: '1' } });
+    try {
+      await Promise.race([
+        this.rpc(c.id, 'initialize', { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'nexior', version: '1' } }),
+        spawnError
+      ]);
+    } catch (e) {
+      // Fold the stderr tail into the error so the Settings row can show a real
+      // reason (npm 404, python traceback, "command not found", …).
+      const tail = (this.stderrTail.get(c.id) ?? '').trim().split('\n').slice(-3).join(' ');
+      throw new Error((e instanceof Error ? e.message : String(e)) + (tail ? ` — ${tail}` : ''));
+    }
   }
 
   private rpc(server: string, method: string, params: unknown): Promise<unknown> {
@@ -80,5 +144,14 @@ export class McpHost {
   stopAll(): void {
     this.procs.forEach((p) => p.kill());
     this.procs.clear();
+  }
+
+  // Kill one server's process (used by targeted reconnect).
+  stop(id: string): void {
+    const p = this.procs.get(id);
+    if (p) {
+      p.kill();
+      this.procs.delete(id);
+    }
   }
 }

--- a/electron/local/registry.ts
+++ b/electron/local/registry.ts
@@ -2,7 +2,7 @@ import { McpHost } from './mcp';
 import * as fsTool from './fs';
 import { run_command } from './shell';
 import * as computer from './computer';
-import type { McpServerConf, ToolInvoke, ToolResult, ToolSpec } from './types';
+import type { McpServerConf, McpServerStatus, ToolInvoke, ToolResult, ToolSpec } from './types';
 
 const BUILTIN: ToolSpec[] = [
   { name: 'fs.read_file', description: 'Read a UTF-8 file inside an authorized root', input_schema: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] }, source: 'builtin', mutates: false },
@@ -35,6 +35,8 @@ class Registry {
   private host = new McpHost();
   private mcpSpecs: ToolSpec[] = [];
   private names = new Set([...BUILTIN, ...COMPUTER_TOOLS].map((s) => s.name));
+  // Per-server connection status (id -> status), surfaced in Settings.
+  private mcpStatuses = new Map<string, McpServerStatus>();
   // Opt-in Computer Use (screen capture + mouse/keyboard). Default OFF; toggled
   // from Settings → Local Tools. While off, the tools are neither advertised nor
   // invokable.
@@ -71,13 +73,20 @@ class Registry {
 
   async boot(servers: McpServerConf[]): Promise<void> {
     for (const s of servers) {
+      if (s.enabled === false) {
+        this.mcpStatuses.set(s.id, { id: s.id, status: 'disabled', toolCount: 0, tools: [] });
+        continue;
+      }
       try {
         await this.host.start(s);
         const tools = await this.host.listTools(s.id);
         this.mcpSpecs.push(...tools);
         tools.forEach((t) => this.names.add(t.name));
-      } catch {
-        /* server failed to start — skip; UI surfaces config errors separately */
+        this.mcpStatuses.set(s.id, { id: s.id, status: 'connected', toolCount: tools.length, tools: tools.map((t) => t.name) });
+      } catch (e) {
+        // Record the reason so Settings can show it instead of failing silently.
+        this.host.stop(s.id);
+        this.mcpStatuses.set(s.id, { id: s.id, status: 'failed', toolCount: 0, tools: [], error: e instanceof Error ? e.message : String(e) });
       }
     }
   }
@@ -90,7 +99,27 @@ class Registry {
     this.host.stopAll();
     this.mcpSpecs = [];
     this.names = new Set([...BUILTIN, ...COMPUTER_TOOLS].map((s) => s.name));
+    this.mcpStatuses.clear();
     await this.boot(servers);
+  }
+
+  // Current connection status of every configured MCP server.
+  mcpStatus(): McpServerStatus[] {
+    return [...this.mcpStatuses.values()];
+  }
+
+  // Re-spawn just ONE server ("Test / Reconnect" in Settings): kill its proc,
+  // drop its specs/names, then boot only it from the persisted list. Returns
+  // its fresh status. Other servers are left untouched.
+  async reconnect(id: string, servers: McpServerConf[]): Promise<McpServerStatus | undefined> {
+    this.host.stop(id);
+    const prefix = `mcp.${id}.`;
+    this.mcpSpecs = this.mcpSpecs.filter((s) => !s.name.startsWith(prefix));
+    this.names = new Set([...BUILTIN, ...COMPUTER_TOOLS].map((s) => s.name).concat(this.mcpSpecs.map((s) => s.name)));
+    this.mcpStatuses.delete(id);
+    const conf = servers.find((s) => s.id === id);
+    if (conf) await this.boot([conf]);
+    return this.mcpStatuses.get(id);
   }
 
   specs(): ToolSpec[] {

--- a/electron/local/types.ts
+++ b/electron/local/types.ts
@@ -30,6 +30,19 @@ export interface McpServerConf {
   args: string[];
   cwd?: string;
   env?: Record<string, string>;
+  // Opt-out toggle (default true = enabled). Disabled servers are not spawned
+  // and their tools are hidden from the AI.
+  enabled?: boolean;
+}
+
+// Live connection status of one configured MCP server, surfaced in Settings so
+// the user can tell whether a server actually connected (and why not).
+export interface McpServerStatus {
+  id: string;
+  status: 'connected' | 'failed' | 'disabled';
+  toolCount: number;
+  tools: string[];
+  error?: string;
 }
 
 export interface LocalConfig {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -68,6 +68,13 @@ contextBridge.exposeInMainWorld('localExec', {
   getConfig: (): Promise<{ roots: string[]; mcp: object[]; computerUse?: boolean }> => ipcRenderer.invoke('local.config.get'),
   saveConfig: (cfg: { roots: string[]; mcp: object[]; computerUse?: boolean }): Promise<boolean> =>
     ipcRenderer.invoke('local.config.save', cfg),
+  // Per-server MCP connection status + targeted reconnect, for Settings.
+  mcp: {
+    status: (): Promise<{ id: string; status: string; toolCount: number; tools: string[]; error?: string }[]> =>
+      ipcRenderer.invoke('local.mcp.status'),
+    reconnect: (id: string): Promise<{ id: string; status: string; toolCount: number; tools: string[]; error?: string } | null> =>
+      ipcRenderer.invoke('local.mcp.reconnect', id)
+  },
   pickFolder: (): Promise<string | null> => ipcRenderer.invoke('local.pickFolder'),
   // macOS system-permission status + jump-to-pane, shown in the LocalTools panel.
   perm: {

--- a/src/components/setting/LocalTools.vue
+++ b/src/components/setting/LocalTools.vue
@@ -65,6 +65,29 @@
         <ul v-if="mcpServers.length" class="rows">
           <li v-for="(m, i) in mcpServers" :key="m._uid" class="row mcp-row">
             <div class="mcp-fields">
+              <div class="mcp-head">
+                <el-tag size="small" effect="plain" :type="mcpBadgeType(m.id)">{{ mcpBadgeText(m.id) }}</el-tag>
+                <span class="mcp-spacer" />
+                <el-switch
+                  v-model="m.enabled"
+                  size="small"
+                  :active-text="$t('common.settings.localToolsMcpEnabled')"
+                  inline-prompt
+                  @change="onToggleMcpEnabled(m)"
+                />
+                <el-button
+                  size="small"
+                  text
+                  :loading="mcpBusy === m.id"
+                  :disabled="!m.id || !m.command"
+                  @click="reconnectMcp(m)"
+                >
+                  {{ $t('common.settings.localToolsMcpReconnect') }}
+                </el-button>
+                <el-button size="small" text type="danger" @click="removeMcp(i)">
+                  {{ $t('common.settings.localToolsRemove') }}
+                </el-button>
+              </div>
               <el-input v-model="m.id" size="small" :placeholder="$t('common.settings.localToolsMcpNamePlaceholder')">
                 <template #prepend>{{ $t('common.settings.localToolsMcpName') }}</template>
               </el-input>
@@ -89,13 +112,12 @@
                 :rows="2"
                 :placeholder="$t('common.settings.localToolsMcpEnvHint')"
               />
+              <p v-if="mcpErrorFor(m.id)" class="mcp-row-error">{{ mcpErrorFor(m.id) }}</p>
             </div>
-            <el-button size="small" text type="danger" @click="removeMcp(i)">
-              {{ $t('common.settings.localToolsRemove') }}
-            </el-button>
           </li>
         </ul>
         <p v-else class="muted">{{ $t('common.settings.localToolsMcpNoServers') }}</p>
+        <p class="muted mcp-platform-hint">{{ $t('common.settings.localToolsMcpPlatformHint') }}</p>
         <div class="actions">
           <el-button size="small" type="primary" :loading="savingMcp" @click="saveMcp">
             {{ $t('common.settings.localToolsSave') }}
@@ -239,7 +261,7 @@ import { defineComponent } from 'vue';
 import { ElButton, ElTag, ElSwitch, ElInput } from 'element-plus';
 import { Plus } from '@element-plus/icons-vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { localExec } from '@/utils/desktop';
+import { localExec, type IMcpServerStatus } from '@/utils/desktop';
 import { isAndroid } from '@/utils/surface';
 
 interface GrantRow {
@@ -257,6 +279,7 @@ interface McpDraft {
   command: string;
   argsText: string;
   envText: string;
+  enabled: boolean;
 }
 
 export default defineComponent({
@@ -270,6 +293,9 @@ export default defineComponent({
       // Editable MCP server drafts (loaded from config, parsed back on save).
       mcpServers: [] as McpDraft[],
       mcpUid: 0,
+      // Live per-server connection status (id -> status), refreshed after save.
+      mcpStatuses: [] as IMcpServerStatus[],
+      mcpBusy: null as null | string,
       savingMcp: false,
       mcpSavedTip: false,
       mcpError: '',
@@ -316,8 +342,10 @@ export default defineComponent({
       argsText: (m.args ?? []).join('\n'),
       envText: Object.entries(m.env ?? {})
         .map(([k, v]) => `${k}=${v}`)
-        .join('\n')
+        .join('\n'),
+      enabled: m.enabled !== false
     }));
+    this.mcpStatuses = (await ex.mcp?.status()) ?? [];
     this.tools = (await ex.listTools()).map((t) => t.name);
     this.computerTools = (await ex.computerTools?.()) ?? [];
     this.builtinTools = (await ex.builtinTools?.()) ?? [];
@@ -396,33 +424,58 @@ export default defineComponent({
       this.roots.splice(i, 1);
     },
     addMcp() {
-      this.mcpServers.push({ _uid: this.mcpUid++, id: '', command: '', argsText: '', envText: '' });
+      this.mcpServers.push({ _uid: this.mcpUid++, id: '', command: '', argsText: '', envText: '', enabled: true });
     },
     removeMcp(i: number) {
       this.mcpServers.splice(i, 1);
     },
-    // Validate + parse the drafts into `McpServerConf[]` and persist. The main
-    // process hot-reboots the MCP host, so the new tools appear without a
-    // restart. `id` is constrained to `[A-Za-z0-9_-]` because it becomes the
-    // `mcp.<id>.<tool>` route key (a dot would break the split at invoke time).
-    async saveMcp() {
+    // Look up the live status of a draft by its (trimmed) id.
+    mcpStatusFor(id: string): IMcpServerStatus | undefined {
+      const key = id.trim();
+      return this.mcpStatuses.find((s) => s.id === key);
+    },
+    mcpBadgeType(id: string): 'success' | 'danger' | 'info' {
+      const s = this.mcpStatusFor(id)?.status;
+      if (s === 'connected') return 'success';
+      if (s === 'failed') return 'danger';
+      return 'info'; // disabled / unknown (not yet saved)
+    },
+    mcpBadgeText(id: string): string {
+      const st = this.mcpStatusFor(id);
+      if (this.mcpBusy === id.trim()) return this.$t('common.settings.localToolsMcpConnecting');
+      if (!st) return this.$t('common.settings.localToolsMcpNotSaved');
+      if (st.status === 'connected') return this.$t('common.settings.localToolsMcpConnected', { n: st.toolCount });
+      if (st.status === 'disabled') return this.$t('common.settings.localToolsMcpDisabled');
+      return this.$t('common.settings.localToolsMcpFailed');
+    },
+    mcpErrorFor(id: string): string {
+      const st = this.mcpStatusFor(id);
+      return st?.status === 'failed' && st.error ? st.error : '';
+    },
+    // Build + validate the McpServerConf[] payload from the drafts. Sets
+    // `mcpError` and returns null on the first invalid row.
+    buildMcpPayload():
+      | { id: string; command: string; args: string[]; env?: Record<string, string>; enabled?: boolean }[]
+      | null {
       this.mcpError = '';
-      const mcp: { id: string; command: string; args: string[]; env?: Record<string, string> }[] = [];
+      const mcp: { id: string; command: string; args: string[]; env?: Record<string, string>; enabled?: boolean }[] =
+        [];
       const seen = new Set<string>();
       for (const m of this.mcpServers) {
         const id = m.id.trim();
         const command = m.command.trim();
         if (!id || !command) {
           this.mcpError = this.$t('common.settings.localToolsMcpNameRequired');
-          return;
+          return null;
         }
+        // `id` becomes the `mcp.<id>.<tool>` route key — a dot would break the split.
         if (!/^[A-Za-z0-9_-]+$/.test(id)) {
           this.mcpError = this.$t('common.settings.localToolsMcpNameInvalid');
-          return;
+          return null;
         }
         if (seen.has(id)) {
           this.mcpError = this.$t('common.settings.localToolsMcpDuplicateName');
-          return;
+          return null;
         }
         seen.add(id);
         const args = m.argsText
@@ -437,24 +490,64 @@ export default defineComponent({
           if (eq <= 0) continue;
           env[t.slice(0, eq).trim()] = t.slice(eq + 1).trim();
         }
-        const row: { id: string; command: string; args: string[]; env?: Record<string, string> } = {
+        const row: { id: string; command: string; args: string[]; env?: Record<string, string>; enabled?: boolean } = {
           id,
           command,
-          args
+          args,
+          enabled: m.enabled !== false
         };
         if (Object.keys(env).length) row.env = env;
         mcp.push(row);
       }
+      return mcp;
+    },
+    // Persist the MCP servers. The main process hot-reboots the MCP host, so the
+    // tools + per-server status update without a restart. Returns false when a
+    // row failed validation (nothing was saved) so callers can react.
+    async saveMcp(): Promise<boolean> {
+      const mcp = this.buildMcpPayload();
+      if (!mcp) return false;
       this.savingMcp = true;
       try {
         const cur = await localExec()?.getConfig();
         await localExec()?.saveConfig({ roots: cur?.roots ?? this.roots, mcp, computerUse: this.computerUse });
-        // Re-fetch the active tools so newly-connected MCP tools show up.
-        this.tools = (await localExec()?.listTools())?.map((t) => t.name) ?? this.tools;
+        await this.refreshMcpStatus();
         this.mcpSavedTip = true;
         setTimeout(() => (this.mcpSavedTip = false), 2000);
+        return true;
       } finally {
         this.savingMcp = false;
+      }
+    },
+    // Re-fetch per-server status + the merged active-tools line.
+    async refreshMcpStatus() {
+      const ex = localExec();
+      if (!ex) return;
+      this.mcpStatuses = (await ex.mcp?.status()) ?? [];
+      this.tools = (await ex.listTools())?.map((t) => t.name) ?? this.tools;
+    },
+    // Toggling enable/disable persists immediately (needs a save+reboot to take
+    // effect). If another row is invalid the save is blocked, so revert the
+    // optimistic switch flip to keep the UI in sync with what's persisted.
+    async onToggleMcpEnabled(m: McpDraft) {
+      const ok = await this.saveMcp();
+      if (!ok) m.enabled = !m.enabled;
+    },
+    // "Test / Reconnect" one server: save first (so its latest edits apply),
+    // then re-spawn just it and show the fresh status/error.
+    async reconnectMcp(m: McpDraft) {
+      const id = m.id.trim();
+      if (!id || !m.command.trim()) return;
+      const mcp = this.buildMcpPayload();
+      if (!mcp) return;
+      this.mcpBusy = id;
+      try {
+        const cur = await localExec()?.getConfig();
+        await localExec()?.saveConfig({ roots: cur?.roots ?? this.roots, mcp, computerUse: this.computerUse });
+        await localExec()?.mcp?.reconnect(id);
+        await this.refreshMcpStatus();
+      } finally {
+        this.mcpBusy = null;
       }
     },
     async open(k: 'fullDisk' | 'screen' | 'accessibility') {
@@ -631,6 +724,23 @@ export default defineComponent({
   flex-direction: column;
   gap: 8px;
   min-width: 0;
+}
+.mcp-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.mcp-spacer {
+  flex: 1;
+}
+.mcp-row-error {
+  margin: 0;
+  color: var(--el-color-danger, #f56c6c);
+  font-size: 12px;
+  word-break: break-word;
+}
+.mcp-platform-hint {
+  margin-top: 8px;
 }
 .mcp-label {
   font-size: 12px;

--- a/src/i18n/ar/common.json
+++ b/src/i18n/ar/common.json
@@ -1040,6 +1040,38 @@
     "message": "Name may only contain letters, numbers, hyphens and underscores.",
     "description": "Validation error when a server name contains invalid characters."
   },
+  "settings.localToolsMcpEnabled": {
+    "message": "On",
+    "description": "Toggle label to enable/disable a local MCP server."
+  },
+  "settings.localToolsMcpReconnect": {
+    "message": "Test / Reconnect",
+    "description": "Button to re-spawn one MCP server and refresh its status."
+  },
+  "settings.localToolsMcpConnecting": {
+    "message": "Connecting…",
+    "description": "Badge while an MCP server is being (re)connected."
+  },
+  "settings.localToolsMcpNotSaved": {
+    "message": "Not saved yet",
+    "description": "Badge for an MCP server row that hasn't been saved/connected yet."
+  },
+  "settings.localToolsMcpConnected": {
+    "message": "Connected · {n} tools",
+    "description": "Badge when an MCP server connected; {n} is the tool count."
+  },
+  "settings.localToolsMcpDisabled": {
+    "message": "Disabled",
+    "description": "Badge when an MCP server is turned off."
+  },
+  "settings.localToolsMcpFailed": {
+    "message": "Failed to connect",
+    "description": "Badge when an MCP server failed to start; the reason is shown below."
+  },
+  "settings.localToolsMcpPlatformHint": {
+    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y @modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
+    "description": "Cross-platform hint for configuring the MCP launch command."
+  },
   "settings.localToolsSaved": {
     "message": "تم الحفظ",
     "description": "Transient confirmation after saving local-tool folders."

--- a/src/i18n/de/common.json
+++ b/src/i18n/de/common.json
@@ -1040,6 +1040,38 @@
     "message": "Name may only contain letters, numbers, hyphens and underscores.",
     "description": "Validation error when a server name contains invalid characters."
   },
+  "settings.localToolsMcpEnabled": {
+    "message": "On",
+    "description": "Toggle label to enable/disable a local MCP server."
+  },
+  "settings.localToolsMcpReconnect": {
+    "message": "Test / Reconnect",
+    "description": "Button to re-spawn one MCP server and refresh its status."
+  },
+  "settings.localToolsMcpConnecting": {
+    "message": "Connecting…",
+    "description": "Badge while an MCP server is being (re)connected."
+  },
+  "settings.localToolsMcpNotSaved": {
+    "message": "Not saved yet",
+    "description": "Badge for an MCP server row that hasn't been saved/connected yet."
+  },
+  "settings.localToolsMcpConnected": {
+    "message": "Connected · {n} tools",
+    "description": "Badge when an MCP server connected; {n} is the tool count."
+  },
+  "settings.localToolsMcpDisabled": {
+    "message": "Disabled",
+    "description": "Badge when an MCP server is turned off."
+  },
+  "settings.localToolsMcpFailed": {
+    "message": "Failed to connect",
+    "description": "Badge when an MCP server failed to start; the reason is shown below."
+  },
+  "settings.localToolsMcpPlatformHint": {
+    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y @modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
+    "description": "Cross-platform hint for configuring the MCP launch command."
+  },
   "settings.localToolsSaved": {
     "message": "Gespeichert",
     "description": "Transient confirmation after saving local-tool folders."

--- a/src/i18n/el/common.json
+++ b/src/i18n/el/common.json
@@ -1040,6 +1040,38 @@
     "message": "Name may only contain letters, numbers, hyphens and underscores.",
     "description": "Validation error when a server name contains invalid characters."
   },
+  "settings.localToolsMcpEnabled": {
+    "message": "On",
+    "description": "Toggle label to enable/disable a local MCP server."
+  },
+  "settings.localToolsMcpReconnect": {
+    "message": "Test / Reconnect",
+    "description": "Button to re-spawn one MCP server and refresh its status."
+  },
+  "settings.localToolsMcpConnecting": {
+    "message": "Connecting…",
+    "description": "Badge while an MCP server is being (re)connected."
+  },
+  "settings.localToolsMcpNotSaved": {
+    "message": "Not saved yet",
+    "description": "Badge for an MCP server row that hasn't been saved/connected yet."
+  },
+  "settings.localToolsMcpConnected": {
+    "message": "Connected · {n} tools",
+    "description": "Badge when an MCP server connected; {n} is the tool count."
+  },
+  "settings.localToolsMcpDisabled": {
+    "message": "Disabled",
+    "description": "Badge when an MCP server is turned off."
+  },
+  "settings.localToolsMcpFailed": {
+    "message": "Failed to connect",
+    "description": "Badge when an MCP server failed to start; the reason is shown below."
+  },
+  "settings.localToolsMcpPlatformHint": {
+    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y @modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
+    "description": "Cross-platform hint for configuring the MCP launch command."
+  },
   "settings.localToolsSaved": {
     "message": "Αποθηκεύτηκε",
     "description": "Transient confirmation after saving local-tool folders."

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -1020,6 +1020,38 @@
     "message": "Name may only contain letters, numbers, hyphens and underscores.",
     "description": "Validation error when a server name contains invalid characters."
   },
+  "settings.localToolsMcpEnabled": {
+    "message": "On",
+    "description": "Toggle label to enable/disable a local MCP server."
+  },
+  "settings.localToolsMcpReconnect": {
+    "message": "Test / Reconnect",
+    "description": "Button to re-spawn one MCP server and refresh its status."
+  },
+  "settings.localToolsMcpConnecting": {
+    "message": "Connecting…",
+    "description": "Badge while an MCP server is being (re)connected."
+  },
+  "settings.localToolsMcpNotSaved": {
+    "message": "Not saved yet",
+    "description": "Badge for an MCP server row that hasn't been saved/connected yet."
+  },
+  "settings.localToolsMcpConnected": {
+    "message": "Connected · {n} tools",
+    "description": "Badge when an MCP server connected; {n} is the tool count."
+  },
+  "settings.localToolsMcpDisabled": {
+    "message": "Disabled",
+    "description": "Badge when an MCP server is turned off."
+  },
+  "settings.localToolsMcpFailed": {
+    "message": "Failed to connect",
+    "description": "Badge when an MCP server failed to start; the reason is shown below."
+  },
+  "settings.localToolsMcpPlatformHint": {
+    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y @modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
+    "description": "Cross-platform hint for configuring the MCP launch command."
+  },
   "settings.localToolsSaved": {
     "message": "Saved",
     "description": "Transient confirmation after saving local-tool folders."

--- a/src/i18n/es/common.json
+++ b/src/i18n/es/common.json
@@ -1040,6 +1040,38 @@
     "message": "Name may only contain letters, numbers, hyphens and underscores.",
     "description": "Validation error when a server name contains invalid characters."
   },
+  "settings.localToolsMcpEnabled": {
+    "message": "On",
+    "description": "Toggle label to enable/disable a local MCP server."
+  },
+  "settings.localToolsMcpReconnect": {
+    "message": "Test / Reconnect",
+    "description": "Button to re-spawn one MCP server and refresh its status."
+  },
+  "settings.localToolsMcpConnecting": {
+    "message": "Connecting…",
+    "description": "Badge while an MCP server is being (re)connected."
+  },
+  "settings.localToolsMcpNotSaved": {
+    "message": "Not saved yet",
+    "description": "Badge for an MCP server row that hasn't been saved/connected yet."
+  },
+  "settings.localToolsMcpConnected": {
+    "message": "Connected · {n} tools",
+    "description": "Badge when an MCP server connected; {n} is the tool count."
+  },
+  "settings.localToolsMcpDisabled": {
+    "message": "Disabled",
+    "description": "Badge when an MCP server is turned off."
+  },
+  "settings.localToolsMcpFailed": {
+    "message": "Failed to connect",
+    "description": "Badge when an MCP server failed to start; the reason is shown below."
+  },
+  "settings.localToolsMcpPlatformHint": {
+    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y @modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
+    "description": "Cross-platform hint for configuring the MCP launch command."
+  },
   "settings.localToolsSaved": {
     "message": "Guardado",
     "description": "Transient confirmation after saving local-tool folders."

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -1040,6 +1040,38 @@
     "message": "Name may only contain letters, numbers, hyphens and underscores.",
     "description": "Validation error when a server name contains invalid characters."
   },
+  "settings.localToolsMcpEnabled": {
+    "message": "On",
+    "description": "Toggle label to enable/disable a local MCP server."
+  },
+  "settings.localToolsMcpReconnect": {
+    "message": "Test / Reconnect",
+    "description": "Button to re-spawn one MCP server and refresh its status."
+  },
+  "settings.localToolsMcpConnecting": {
+    "message": "Connecting…",
+    "description": "Badge while an MCP server is being (re)connected."
+  },
+  "settings.localToolsMcpNotSaved": {
+    "message": "Not saved yet",
+    "description": "Badge for an MCP server row that hasn't been saved/connected yet."
+  },
+  "settings.localToolsMcpConnected": {
+    "message": "Connected · {n} tools",
+    "description": "Badge when an MCP server connected; {n} is the tool count."
+  },
+  "settings.localToolsMcpDisabled": {
+    "message": "Disabled",
+    "description": "Badge when an MCP server is turned off."
+  },
+  "settings.localToolsMcpFailed": {
+    "message": "Failed to connect",
+    "description": "Badge when an MCP server failed to start; the reason is shown below."
+  },
+  "settings.localToolsMcpPlatformHint": {
+    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y @modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
+    "description": "Cross-platform hint for configuring the MCP launch command."
+  },
   "settings.localToolsSaved": {
     "message": "Tallennettu",
     "description": "Transient confirmation after saving local-tool folders."

--- a/src/i18n/fr/common.json
+++ b/src/i18n/fr/common.json
@@ -1040,6 +1040,38 @@
     "message": "Name may only contain letters, numbers, hyphens and underscores.",
     "description": "Validation error when a server name contains invalid characters."
   },
+  "settings.localToolsMcpEnabled": {
+    "message": "On",
+    "description": "Toggle label to enable/disable a local MCP server."
+  },
+  "settings.localToolsMcpReconnect": {
+    "message": "Test / Reconnect",
+    "description": "Button to re-spawn one MCP server and refresh its status."
+  },
+  "settings.localToolsMcpConnecting": {
+    "message": "Connecting…",
+    "description": "Badge while an MCP server is being (re)connected."
+  },
+  "settings.localToolsMcpNotSaved": {
+    "message": "Not saved yet",
+    "description": "Badge for an MCP server row that hasn't been saved/connected yet."
+  },
+  "settings.localToolsMcpConnected": {
+    "message": "Connected · {n} tools",
+    "description": "Badge when an MCP server connected; {n} is the tool count."
+  },
+  "settings.localToolsMcpDisabled": {
+    "message": "Disabled",
+    "description": "Badge when an MCP server is turned off."
+  },
+  "settings.localToolsMcpFailed": {
+    "message": "Failed to connect",
+    "description": "Badge when an MCP server failed to start; the reason is shown below."
+  },
+  "settings.localToolsMcpPlatformHint": {
+    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y @modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
+    "description": "Cross-platform hint for configuring the MCP launch command."
+  },
   "settings.localToolsSaved": {
     "message": "Enregistré",
     "description": "Transient confirmation after saving local-tool folders."

--- a/src/i18n/it/common.json
+++ b/src/i18n/it/common.json
@@ -1040,6 +1040,38 @@
     "message": "Name may only contain letters, numbers, hyphens and underscores.",
     "description": "Validation error when a server name contains invalid characters."
   },
+  "settings.localToolsMcpEnabled": {
+    "message": "On",
+    "description": "Toggle label to enable/disable a local MCP server."
+  },
+  "settings.localToolsMcpReconnect": {
+    "message": "Test / Reconnect",
+    "description": "Button to re-spawn one MCP server and refresh its status."
+  },
+  "settings.localToolsMcpConnecting": {
+    "message": "Connecting…",
+    "description": "Badge while an MCP server is being (re)connected."
+  },
+  "settings.localToolsMcpNotSaved": {
+    "message": "Not saved yet",
+    "description": "Badge for an MCP server row that hasn't been saved/connected yet."
+  },
+  "settings.localToolsMcpConnected": {
+    "message": "Connected · {n} tools",
+    "description": "Badge when an MCP server connected; {n} is the tool count."
+  },
+  "settings.localToolsMcpDisabled": {
+    "message": "Disabled",
+    "description": "Badge when an MCP server is turned off."
+  },
+  "settings.localToolsMcpFailed": {
+    "message": "Failed to connect",
+    "description": "Badge when an MCP server failed to start; the reason is shown below."
+  },
+  "settings.localToolsMcpPlatformHint": {
+    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y @modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
+    "description": "Cross-platform hint for configuring the MCP launch command."
+  },
   "settings.localToolsSaved": {
     "message": "Salvato",
     "description": "Transient confirmation after saving local-tool folders."

--- a/src/i18n/ja/common.json
+++ b/src/i18n/ja/common.json
@@ -1040,6 +1040,38 @@
     "message": "Name may only contain letters, numbers, hyphens and underscores.",
     "description": "Validation error when a server name contains invalid characters."
   },
+  "settings.localToolsMcpEnabled": {
+    "message": "On",
+    "description": "Toggle label to enable/disable a local MCP server."
+  },
+  "settings.localToolsMcpReconnect": {
+    "message": "Test / Reconnect",
+    "description": "Button to re-spawn one MCP server and refresh its status."
+  },
+  "settings.localToolsMcpConnecting": {
+    "message": "Connecting…",
+    "description": "Badge while an MCP server is being (re)connected."
+  },
+  "settings.localToolsMcpNotSaved": {
+    "message": "Not saved yet",
+    "description": "Badge for an MCP server row that hasn't been saved/connected yet."
+  },
+  "settings.localToolsMcpConnected": {
+    "message": "Connected · {n} tools",
+    "description": "Badge when an MCP server connected; {n} is the tool count."
+  },
+  "settings.localToolsMcpDisabled": {
+    "message": "Disabled",
+    "description": "Badge when an MCP server is turned off."
+  },
+  "settings.localToolsMcpFailed": {
+    "message": "Failed to connect",
+    "description": "Badge when an MCP server failed to start; the reason is shown below."
+  },
+  "settings.localToolsMcpPlatformHint": {
+    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y @modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
+    "description": "Cross-platform hint for configuring the MCP launch command."
+  },
   "settings.localToolsSaved": {
     "message": "保存しました",
     "description": "Transient confirmation after saving local-tool folders."

--- a/src/i18n/ko/common.json
+++ b/src/i18n/ko/common.json
@@ -1040,6 +1040,38 @@
     "message": "Name may only contain letters, numbers, hyphens and underscores.",
     "description": "Validation error when a server name contains invalid characters."
   },
+  "settings.localToolsMcpEnabled": {
+    "message": "On",
+    "description": "Toggle label to enable/disable a local MCP server."
+  },
+  "settings.localToolsMcpReconnect": {
+    "message": "Test / Reconnect",
+    "description": "Button to re-spawn one MCP server and refresh its status."
+  },
+  "settings.localToolsMcpConnecting": {
+    "message": "Connecting…",
+    "description": "Badge while an MCP server is being (re)connected."
+  },
+  "settings.localToolsMcpNotSaved": {
+    "message": "Not saved yet",
+    "description": "Badge for an MCP server row that hasn't been saved/connected yet."
+  },
+  "settings.localToolsMcpConnected": {
+    "message": "Connected · {n} tools",
+    "description": "Badge when an MCP server connected; {n} is the tool count."
+  },
+  "settings.localToolsMcpDisabled": {
+    "message": "Disabled",
+    "description": "Badge when an MCP server is turned off."
+  },
+  "settings.localToolsMcpFailed": {
+    "message": "Failed to connect",
+    "description": "Badge when an MCP server failed to start; the reason is shown below."
+  },
+  "settings.localToolsMcpPlatformHint": {
+    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y @modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
+    "description": "Cross-platform hint for configuring the MCP launch command."
+  },
   "settings.localToolsSaved": {
     "message": "저장됨",
     "description": "Transient confirmation after saving local-tool folders."

--- a/src/i18n/pl/common.json
+++ b/src/i18n/pl/common.json
@@ -1040,6 +1040,38 @@
     "message": "Name may only contain letters, numbers, hyphens and underscores.",
     "description": "Validation error when a server name contains invalid characters."
   },
+  "settings.localToolsMcpEnabled": {
+    "message": "On",
+    "description": "Toggle label to enable/disable a local MCP server."
+  },
+  "settings.localToolsMcpReconnect": {
+    "message": "Test / Reconnect",
+    "description": "Button to re-spawn one MCP server and refresh its status."
+  },
+  "settings.localToolsMcpConnecting": {
+    "message": "Connecting…",
+    "description": "Badge while an MCP server is being (re)connected."
+  },
+  "settings.localToolsMcpNotSaved": {
+    "message": "Not saved yet",
+    "description": "Badge for an MCP server row that hasn't been saved/connected yet."
+  },
+  "settings.localToolsMcpConnected": {
+    "message": "Connected · {n} tools",
+    "description": "Badge when an MCP server connected; {n} is the tool count."
+  },
+  "settings.localToolsMcpDisabled": {
+    "message": "Disabled",
+    "description": "Badge when an MCP server is turned off."
+  },
+  "settings.localToolsMcpFailed": {
+    "message": "Failed to connect",
+    "description": "Badge when an MCP server failed to start; the reason is shown below."
+  },
+  "settings.localToolsMcpPlatformHint": {
+    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y @modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
+    "description": "Cross-platform hint for configuring the MCP launch command."
+  },
   "settings.localToolsSaved": {
     "message": "Zapisano",
     "description": "Transient confirmation after saving local-tool folders."

--- a/src/i18n/pt/common.json
+++ b/src/i18n/pt/common.json
@@ -1040,6 +1040,38 @@
     "message": "Name may only contain letters, numbers, hyphens and underscores.",
     "description": "Validation error when a server name contains invalid characters."
   },
+  "settings.localToolsMcpEnabled": {
+    "message": "On",
+    "description": "Toggle label to enable/disable a local MCP server."
+  },
+  "settings.localToolsMcpReconnect": {
+    "message": "Test / Reconnect",
+    "description": "Button to re-spawn one MCP server and refresh its status."
+  },
+  "settings.localToolsMcpConnecting": {
+    "message": "Connecting…",
+    "description": "Badge while an MCP server is being (re)connected."
+  },
+  "settings.localToolsMcpNotSaved": {
+    "message": "Not saved yet",
+    "description": "Badge for an MCP server row that hasn't been saved/connected yet."
+  },
+  "settings.localToolsMcpConnected": {
+    "message": "Connected · {n} tools",
+    "description": "Badge when an MCP server connected; {n} is the tool count."
+  },
+  "settings.localToolsMcpDisabled": {
+    "message": "Disabled",
+    "description": "Badge when an MCP server is turned off."
+  },
+  "settings.localToolsMcpFailed": {
+    "message": "Failed to connect",
+    "description": "Badge when an MCP server failed to start; the reason is shown below."
+  },
+  "settings.localToolsMcpPlatformHint": {
+    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y @modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
+    "description": "Cross-platform hint for configuring the MCP launch command."
+  },
   "settings.localToolsSaved": {
     "message": "Salvo",
     "description": "Transient confirmation after saving local-tool folders."

--- a/src/i18n/ru/common.json
+++ b/src/i18n/ru/common.json
@@ -1040,6 +1040,38 @@
     "message": "Name may only contain letters, numbers, hyphens and underscores.",
     "description": "Validation error when a server name contains invalid characters."
   },
+  "settings.localToolsMcpEnabled": {
+    "message": "On",
+    "description": "Toggle label to enable/disable a local MCP server."
+  },
+  "settings.localToolsMcpReconnect": {
+    "message": "Test / Reconnect",
+    "description": "Button to re-spawn one MCP server and refresh its status."
+  },
+  "settings.localToolsMcpConnecting": {
+    "message": "Connecting…",
+    "description": "Badge while an MCP server is being (re)connected."
+  },
+  "settings.localToolsMcpNotSaved": {
+    "message": "Not saved yet",
+    "description": "Badge for an MCP server row that hasn't been saved/connected yet."
+  },
+  "settings.localToolsMcpConnected": {
+    "message": "Connected · {n} tools",
+    "description": "Badge when an MCP server connected; {n} is the tool count."
+  },
+  "settings.localToolsMcpDisabled": {
+    "message": "Disabled",
+    "description": "Badge when an MCP server is turned off."
+  },
+  "settings.localToolsMcpFailed": {
+    "message": "Failed to connect",
+    "description": "Badge when an MCP server failed to start; the reason is shown below."
+  },
+  "settings.localToolsMcpPlatformHint": {
+    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y @modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
+    "description": "Cross-platform hint for configuring the MCP launch command."
+  },
   "settings.localToolsSaved": {
     "message": "Сохранено",
     "description": "Transient confirmation after saving local-tool folders."

--- a/src/i18n/sr/common.json
+++ b/src/i18n/sr/common.json
@@ -1040,6 +1040,38 @@
     "message": "Name may only contain letters, numbers, hyphens and underscores.",
     "description": "Validation error when a server name contains invalid characters."
   },
+  "settings.localToolsMcpEnabled": {
+    "message": "On",
+    "description": "Toggle label to enable/disable a local MCP server."
+  },
+  "settings.localToolsMcpReconnect": {
+    "message": "Test / Reconnect",
+    "description": "Button to re-spawn one MCP server and refresh its status."
+  },
+  "settings.localToolsMcpConnecting": {
+    "message": "Connecting…",
+    "description": "Badge while an MCP server is being (re)connected."
+  },
+  "settings.localToolsMcpNotSaved": {
+    "message": "Not saved yet",
+    "description": "Badge for an MCP server row that hasn't been saved/connected yet."
+  },
+  "settings.localToolsMcpConnected": {
+    "message": "Connected · {n} tools",
+    "description": "Badge when an MCP server connected; {n} is the tool count."
+  },
+  "settings.localToolsMcpDisabled": {
+    "message": "Disabled",
+    "description": "Badge when an MCP server is turned off."
+  },
+  "settings.localToolsMcpFailed": {
+    "message": "Failed to connect",
+    "description": "Badge when an MCP server failed to start; the reason is shown below."
+  },
+  "settings.localToolsMcpPlatformHint": {
+    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y @modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
+    "description": "Cross-platform hint for configuring the MCP launch command."
+  },
   "settings.localToolsSaved": {
     "message": "Сачувано",
     "description": "Transient confirmation after saving local-tool folders."

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -1040,6 +1040,38 @@
     "message": "Name may only contain letters, numbers, hyphens and underscores.",
     "description": "Validation error when a server name contains invalid characters."
   },
+  "settings.localToolsMcpEnabled": {
+    "message": "On",
+    "description": "Toggle label to enable/disable a local MCP server."
+  },
+  "settings.localToolsMcpReconnect": {
+    "message": "Test / Reconnect",
+    "description": "Button to re-spawn one MCP server and refresh its status."
+  },
+  "settings.localToolsMcpConnecting": {
+    "message": "Connecting…",
+    "description": "Badge while an MCP server is being (re)connected."
+  },
+  "settings.localToolsMcpNotSaved": {
+    "message": "Not saved yet",
+    "description": "Badge for an MCP server row that hasn't been saved/connected yet."
+  },
+  "settings.localToolsMcpConnected": {
+    "message": "Connected · {n} tools",
+    "description": "Badge when an MCP server connected; {n} is the tool count."
+  },
+  "settings.localToolsMcpDisabled": {
+    "message": "Disabled",
+    "description": "Badge when an MCP server is turned off."
+  },
+  "settings.localToolsMcpFailed": {
+    "message": "Failed to connect",
+    "description": "Badge when an MCP server failed to start; the reason is shown below."
+  },
+  "settings.localToolsMcpPlatformHint": {
+    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y @modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
+    "description": "Cross-platform hint for configuring the MCP launch command."
+  },
   "settings.localToolsSaved": {
     "message": "Sparat",
     "description": "Transient confirmation after saving local-tool folders."

--- a/src/i18n/uk/common.json
+++ b/src/i18n/uk/common.json
@@ -1040,6 +1040,38 @@
     "message": "Name may only contain letters, numbers, hyphens and underscores.",
     "description": "Validation error when a server name contains invalid characters."
   },
+  "settings.localToolsMcpEnabled": {
+    "message": "On",
+    "description": "Toggle label to enable/disable a local MCP server."
+  },
+  "settings.localToolsMcpReconnect": {
+    "message": "Test / Reconnect",
+    "description": "Button to re-spawn one MCP server and refresh its status."
+  },
+  "settings.localToolsMcpConnecting": {
+    "message": "Connecting…",
+    "description": "Badge while an MCP server is being (re)connected."
+  },
+  "settings.localToolsMcpNotSaved": {
+    "message": "Not saved yet",
+    "description": "Badge for an MCP server row that hasn't been saved/connected yet."
+  },
+  "settings.localToolsMcpConnected": {
+    "message": "Connected · {n} tools",
+    "description": "Badge when an MCP server connected; {n} is the tool count."
+  },
+  "settings.localToolsMcpDisabled": {
+    "message": "Disabled",
+    "description": "Badge when an MCP server is turned off."
+  },
+  "settings.localToolsMcpFailed": {
+    "message": "Failed to connect",
+    "description": "Badge when an MCP server failed to start; the reason is shown below."
+  },
+  "settings.localToolsMcpPlatformHint": {
+    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y @modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
+    "description": "Cross-platform hint for configuring the MCP launch command."
+  },
   "settings.localToolsSaved": {
     "message": "Збережено",
     "description": "Transient confirmation after saving local-tool folders."

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -1040,6 +1040,38 @@
     "message": "名称只能包含字母、数字、连字符和下划线。",
     "description": "服务器名称含非法字符时的校验错误。"
   },
+  "settings.localToolsMcpEnabled": {
+    "message": "启用",
+    "description": "启用/停用某个本地 MCP 服务器的开关标签。"
+  },
+  "settings.localToolsMcpReconnect": {
+    "message": "测试 / 重连",
+    "description": "重新启动某个 MCP 服务器并刷新其状态的按钮。"
+  },
+  "settings.localToolsMcpConnecting": {
+    "message": "连接中…",
+    "description": "MCP 服务器正在（重新）连接时的状态标签。"
+  },
+  "settings.localToolsMcpNotSaved": {
+    "message": "尚未保存",
+    "description": "尚未保存/连接的 MCP 服务器行的状态标签。"
+  },
+  "settings.localToolsMcpConnected": {
+    "message": "已连接 · {n} 个工具",
+    "description": "MCP 服务器连接成功时的标签；{n} 为工具数量。"
+  },
+  "settings.localToolsMcpDisabled": {
+    "message": "已停用",
+    "description": "MCP 服务器被关闭时的标签。"
+  },
+  "settings.localToolsMcpFailed": {
+    "message": "连接失败",
+    "description": "MCP 服务器启动失败时的标签；原因显示在下方。"
+  },
+  "settings.localToolsMcpPlatformHint": {
+    "message": "提示：使用 PATH 中的命令，如 npx 或 uvx（例如 npx -y @modelcontextprotocol/server-filesystem ~/Documents）。Windows 上 npx/node 会自动解析。若某服务器显示 “spawn … ENOENT”，请把命令改为完整路径。",
+    "description": "配置 MCP 启动命令的跨平台提示。"
+  },
   "settings.localToolsSaved": {
     "message": "已保存",
     "description": "保存本地工具文件夹后的短暂确认。"

--- a/src/i18n/zh-TW/common.json
+++ b/src/i18n/zh-TW/common.json
@@ -1040,6 +1040,38 @@
     "message": "Name may only contain letters, numbers, hyphens and underscores.",
     "description": "Validation error when a server name contains invalid characters."
   },
+  "settings.localToolsMcpEnabled": {
+    "message": "On",
+    "description": "Toggle label to enable/disable a local MCP server."
+  },
+  "settings.localToolsMcpReconnect": {
+    "message": "Test / Reconnect",
+    "description": "Button to re-spawn one MCP server and refresh its status."
+  },
+  "settings.localToolsMcpConnecting": {
+    "message": "Connecting…",
+    "description": "Badge while an MCP server is being (re)connected."
+  },
+  "settings.localToolsMcpNotSaved": {
+    "message": "Not saved yet",
+    "description": "Badge for an MCP server row that hasn't been saved/connected yet."
+  },
+  "settings.localToolsMcpConnected": {
+    "message": "Connected · {n} tools",
+    "description": "Badge when an MCP server connected; {n} is the tool count."
+  },
+  "settings.localToolsMcpDisabled": {
+    "message": "Disabled",
+    "description": "Badge when an MCP server is turned off."
+  },
+  "settings.localToolsMcpFailed": {
+    "message": "Failed to connect",
+    "description": "Badge when an MCP server failed to start; the reason is shown below."
+  },
+  "settings.localToolsMcpPlatformHint": {
+    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y @modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
+    "description": "Cross-platform hint for configuring the MCP launch command."
+  },
   "settings.localToolsSaved": {
     "message": "已儲存",
     "description": "Transient confirmation after saving local-tool folders."

--- a/src/utils/desktop.ts
+++ b/src/utils/desktop.ts
@@ -53,6 +53,14 @@ export interface LocalToolSpec {
   source: 'builtin' | 'mcp';
   mutates: boolean;
 }
+/** Live connection status of one configured local MCP server. */
+export interface IMcpServerStatus {
+  id: string;
+  status: 'connected' | 'failed' | 'disabled' | string;
+  toolCount: number;
+  tools: string[];
+  error?: string;
+}
 export interface LocalExecBridge {
   available: true;
   listTools(): Promise<LocalToolSpec[]>;
@@ -63,14 +71,33 @@ export interface LocalExecBridge {
   }): Promise<{ output: string; is_error?: boolean; image?: string }>;
   getConfig(): Promise<{
     roots: string[];
-    mcp: { id: string; command: string; args: string[]; cwd?: string; env?: Record<string, string> }[];
+    mcp: {
+      id: string;
+      command: string;
+      args: string[];
+      cwd?: string;
+      env?: Record<string, string>;
+      enabled?: boolean;
+    }[];
     computerUse?: boolean;
   }>;
   saveConfig(cfg: {
     roots: string[];
-    mcp: { id: string; command: string; args: string[]; cwd?: string; env?: Record<string, string> }[];
+    mcp: {
+      id: string;
+      command: string;
+      args: string[];
+      cwd?: string;
+      env?: Record<string, string>;
+      enabled?: boolean;
+    }[];
     computerUse?: boolean;
   }): Promise<boolean>;
+  /** Per-server MCP connection status + targeted reconnect (desktop only). */
+  mcp?: {
+    status(): Promise<IMcpServerStatus[]>;
+    reconnect(id: string): Promise<IMcpServerStatus | null>;
+  };
   pickFolder(): Promise<string | null>;
   /** macOS TCC permission status + jump-to-System-Settings (undefined off macOS desktop). */
   perm?: {


### PR DESCRIPTION
## What & why

Follow-up to #1129. That PR added the MCP config UI, but it only showed a merged **Active tools** line — so if a server failed to spawn you got **zero feedback** ("我咋知道能不能连上啊"). This makes local MCP actually testable, and fixes the #1 silent-failure cause.

## Per-server status / enable / test (Settings → Local Tools → MCP servers)
Each server row now shows:
- **Status badge**: 🟢 `Connected · N tools` / 🔴 `Failed to connect` (+ the real reason below, e.g. `spawn npx ENOENT`) / ⚪ `Disabled` / 🟡 `Connecting…` / `Not saved yet`
- **Enable switch** (`enabled` in config) — disabled servers aren't spawned and their tools are hidden from the AI
- **Test / Reconnect** button — re-spawns just that server and refreshes its status live

## Cross-platform spawn fix (the actual "why won't it connect")
- **macOS/Linux:** GUI-launched apps inherit a stripped `PATH` (Finder/Dock don't source your shell profile) → `npx`/`node`/`uvx`/`bunx` = `spawn ENOENT`. `mcp.ts` now rebuilds `PATH` from the login shell (`$SHELL -lic`, **async** + 3s timeout + static fallback: homebrew / /usr/local / ~/.local / ~/.bun) and spreads the full env so servers get `HOME` etc.
- **Windows:** spawn with `shell:true` + `windowsHide` so `npx`/`node` resolve their `.cmd` shims.
- stderr captured → folded into the failure reason; spawn `error` (ENOENT) rejects `start()` promptly instead of hanging to the RPC timeout.

## How you E2E test it
1. Settings → Local Tools → MCP servers → **Add**: name `fs`, command `npx`, args (one per line) `-y` / `@modelcontextprotocol/server-filesystem` / `~/Documents` → **Save**.
2. Row turns 🟢 `Connected · 11 tools` — or 🔴 with the exact error.
3. Toggle **off** → row `Disabled`, tools removed from the AI.
4. In chat: "list my Documents" → `mcp.fs.list_directory` runs (with a consent prompt).

## Validation
- `tsc -p electron/tsconfig.json` ✅ · `vue-tsc -b` ✅ · `eslint` ✅ · `npm run test:run` → **214 passed** ✅ · i18n coverage ✅
- **Real-code E2E** via `ELECTRON_RUN_AS_NODE` harness against the compiled `registry` + a mock stdio MCP server: connected / disabled / **failed-with-ENOENT-reason**, targeted reconnect (others untouched), invoke — all PASS.

## 🤖 对抗评审
Reviewer: Claude `general-purpose` subagent (Codex rate-limited). 3 accepted + 1 rebutted:
1. **RISK (sync PATH probe blocks main thread ≤3s)** → **fixed**: made `resolveEnhancedPath` async (`execFile`), awaited in the already-async `start()`.
2. **RISK (enable toggle flips but save blocked by another invalid row → UI/state drift)** → **fixed**: `saveMcp()` returns success; the switch reverts on failure.
3. **RISK (`as Promise<boolean>` cast + a failed reconnect poisoning the save chain)** → **fixed**: restructured the handler; the chain is kept always-resolving.
4. **RISK (frozen reconnect button)** → **rebutted**: `mcpBusy` is set *after* the validation early-return, and `buildMcpPayload` sets the visible `mcpError`; no stuck spinner.
