### PR TITLE
fix(auth): extend guest browsing to native + desktop startup

### DIFF
--- a/change/@acedatacloud-nexior-9ac65759-511a-454c-bb5e-3e0e0d687475.json
+++ b/change/@acedatacloud-nexior-9ac65759-511a-454c-bb5e-3e0e0d687475.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(auth): defer login to operation on native + desktop startup",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -134,21 +134,14 @@ export default defineComponent({
     const authenticated = !!this.$store.state.token.access && !!this.$store.state.user?.id;
     console.debug('App mounted, authenticated:', authenticated);
     if (!authenticated) {
-      if (isNative() || isDesktop()) {
-        // On native AND desktop, just reset state and show the in-app login
-        // popup. Don't dispatch 'logout' which would navigate the window to an
-        // external auth URL — on desktop the app://bundle window can't return.
-        this.$store.dispatch('resetAll');
-        this.$store.dispatch('login');
-      } else {
-        // Web: deferred auth. Guests may browse service pages, models and
-        // pricing without logging in — the login flow is triggered lazily the
-        // moment they start a real operation (see `ensureLoggedIn`). So we
-        // only clear any stale (logged-out) state here and DON'T bounce to
-        // login. `resetAll` also drops any leftover credential so a guest can
-        // never reuse a previous session's token.
-        this.$store.dispatch('resetAll');
-      }
+      // Deferred auth on ALL surfaces (web, native, desktop). Guests may browse
+      // service pages, models and pricing without logging in — login is
+      // triggered lazily the moment they start a real operation (see
+      // `ensureLoggedIn`, which shows the in-app popup on native/desktop and a
+      // redirect on web). So we only clear any stale (logged-out) state here
+      // and DON'T bounce to login. `resetAll` also drops any leftover
+      // credential so a guest can never reuse a previous session's token.
+      this.$store.dispatch('resetAll');
     }
   },
   beforeUnmount() {


### PR DESCRIPTION
## 问题

游客浏览 / 延迟登录（#1101、#1102）上线后，**web 已生效**，但 Mac、Windows 桌面端和 iOS/Android 移动端**一进 app 仍然强制弹登录**。

## 根因

`src/App.vue` 的 `mounted()` 在未登录时按平台分了两支：

- **web**（`else` 分支）：只 `dispatch('resetAll')`，不弹登录 → 游客可浏览 ✅
- **`isNative() || isDesktop()`**：`dispatch('resetAll')` + **`dispatch('login')`** → 启动即弹登录 ❌

也就是说 #1101 的延迟登录**只覆盖了 web 分支**，客户端从没接入过——不是回归，是遗漏。

## 修复

移除 native/desktop 分支的 `dispatch('login')`，合并为所有端启动时只 `resetAll`。登录改为懒触发：游客真正发起操作时由 `ensureLoggedIn()` 唤起（native/desktop 走 in-app popup `flow:'popup'`，web 走 redirect）。

## 为什么安全

- `ensureLoggedIn()` 已接入全部 **28 个服务页面共 58 处**操作 handler（suno/midjourney/flux/chat/veo/...），且它本身跨平台通用——延迟登录契约在所有端本就成立，本改动只是让客户端走上这条已受保护的路径。
- `resetAll` 仍清空 token/credential，游客无法复用旧会话。
- 桌面/移动端 deep-link OAuth 回调（`exchangeSsoCode`）独立处理，不依赖启动登录。
- 权限页（console/distribution/settings/coding-bridge）由 router `beforeEach` 守卫，游客访问仍会被要求登录。

## 🤖 对抗评审

- Reviewer：Codex 额度用尽，回退 Claude `general-purpose` 子代理（read-only）。
- **RISK：`isNative`/`isDesktop` 是否变成未使用导入？** → 已核实，仍用于 deep-link 处理块（App.vue L81/L113），导入有效。`vue-tsc -b` 与 `eslint src/App.vue` 均通过。
- **RISK：`ensureLoggedIn` 是否覆盖所有操作入口？** → 已核实：58 处调用横跨 28 个服务页面；函数跨平台通用。契约成立，驳回。
- **RISK：安全回归 / deep-link 回调 / 权限页** → 逐条核实均安全（见上）。
- **设计取舍**：native 端从"进门即登录"改为"先逛后登"——正是本 issue 诉求。
- **VERDICT: CLEAN**