### PR TITLE
fix(desktop): draggable chrome + credits pill placement (Windows/macOS)

### DIFF
--- a/change/@acedatacloud-nexior-4b371c6f-8845-427c-8509-f10f0ba36003.json
+++ b/change/@acedatacloud-nexior-4b371c6f-8845-427c-8509-f10f0ba36003.json
@@ -1,0 +1,7 @@
+{
+  "email": "dev@acedata.cloud",
+  "packageName": "@acedatacloud/nexior",
+  "dependentChangeType": "patch",
+  "type": "patch",
+  "comment": "feat(desktop): draggable top chrome + reposition credits pill below title bar"
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -156,8 +156,12 @@ function createWindow(): void {
     backgroundColor: '#0b0b0f', // avoid white flash before the SPA paints
     // Frameless: macOS keeps inset traffic lights; Win/Linux use Window Controls
     // Overlay so min/max/close stay native. The web header draws into the bar.
+    // titleBarOverlay height 40 (was 64): the app now renders a dedicated 32px
+    // drag bar via <DesktopDragBar>, so we no longer need to reserve the full
+    // 64px TopHeader height for chrome — 40px is just enough to display the
+    // native min/max/close buttons at their default size.
     titleBarStyle: isMac ? 'hiddenInset' : 'hidden',
-    ...(isMac ? { trafficLightPosition: { x: 16, y: 20 } } : { titleBarOverlay: { color: '#00000000', symbolColor: '#888888', height: 64 } }),
+    ...(isMac ? { trafficLightPosition: { x: 16, y: 20 } } : { titleBarOverlay: { color: '#00000000', symbolColor: '#888888', height: 40 } }),
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,7 @@
 <template>
   <el-config-provider :locale="epLocale">
     <auth-panel v-if="authPopup" />
+    <desktop-drag-bar />
     <router-view />
     <el-tag v-if="isTest" size="large" class="fixed bottom-4 right-4 z-50" type="warning">
       {{ $t('index.button.testEnv') }}
@@ -12,6 +13,7 @@
 import { defineComponent } from 'vue';
 import { ElConfigProvider, ElTag } from 'element-plus';
 import AuthPanel from './components/common/AuthPanel.vue';
+import DesktopDragBar from './components/common/DesktopDragBar.vue';
 import { isTest } from '@/constants/endpoint';
 import { getLocale } from './i18n';
 import { App as CapApp } from '@capacitor/app';
@@ -48,7 +50,8 @@ export default defineComponent({
   components: {
     ElConfigProvider,
     ElTag,
-    AuthPanel
+    AuthPanel,
+    DesktopDragBar
   },
   data() {
     return {

--- a/src/components/application/Status.vue
+++ b/src/components/application/Status.vue
@@ -139,6 +139,8 @@ export default defineComponent({
   font-size: 13px;
   line-height: 1;
   cursor: pointer;
+  // Ensure clicks work when this pill sits inside the desktop drag region.
+  -webkit-app-region: no-drag;
   transition:
     border-color 0.18s ease,
     box-shadow 0.18s ease,

--- a/src/components/common/DesktopDragBar.vue
+++ b/src/components/common/DesktopDragBar.vue
@@ -33,9 +33,11 @@ export default defineComponent({
   },
   mounted() {
     if (!isDesktop()) return;
+    // `desktopBridge` is a factory: () => DesktopBridge | undefined.
     // Preload emits current fullscreen state immediately, then on every change.
+    const bridge = desktopBridge();
     this.offFullscreen =
-      desktopBridge?.onFullscreenChange?.((isFullscreen: boolean) => {
+      bridge?.onFullscreenChange?.((isFullscreen: boolean) => {
         this.fullscreen = !!isFullscreen;
       }) ?? null;
   },

--- a/src/components/common/DesktopDragBar.vue
+++ b/src/components/common/DesktopDragBar.vue
@@ -1,0 +1,76 @@
+<template>
+  <div v-if="visible" class="desktop-drag-bar" :class="{ 'is-mac': isMac, 'is-win': !isMac }" aria-hidden="true" />
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { isDesktop, isMacOS } from '@/utils/surface';
+import { desktopBridge } from '@/utils/desktop';
+
+// Frameless desktop windows have no built-in drag handle: renderer must declare
+// one via `-webkit-app-region: drag`. `Index.vue` gets it from `TopHeader`, but
+// every service page (`Main.vue`, `Chat.vue`, `Console.vue`, `Bare.vue`, …)
+// has no header — so the window can't be dragged at all there. Mount this once
+// in `App.vue` and it covers every layout. `pointer-events: none` keeps the
+// underlying UI (nav, buttons, credits pill) fully clickable — the drag hit-
+// test is done by Chromium before pointer-events.
+export default defineComponent({
+  name: 'DesktopDragBar',
+  data() {
+    return {
+      fullscreen: false,
+      offFullscreen: null as null | (() => void)
+    };
+  },
+  computed: {
+    visible(): boolean {
+      // Only on desktop, and hide in native fullscreen (no title-bar chrome).
+      return isDesktop() && !this.fullscreen;
+    },
+    isMac(): boolean {
+      return isMacOS();
+    }
+  },
+  mounted() {
+    if (!isDesktop()) return;
+    // Preload emits current fullscreen state immediately, then on every change.
+    this.offFullscreen =
+      desktopBridge?.onFullscreenChange?.((isFullscreen: boolean) => {
+        this.fullscreen = !!isFullscreen;
+      }) ?? null;
+  },
+  beforeUnmount() {
+    this.offFullscreen?.();
+    this.offFullscreen = null;
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.desktop-drag-bar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 32px;
+  z-index: 100; // below status-floating(200), above router-view content
+  -webkit-app-region: drag;
+  // Do NOT eat clicks — underlying UI (credits pill, nav rail, close/max/min)
+  // still gets pointer events. Only the window-drag hit-test uses this element.
+  pointer-events: none;
+}
+
+// macOS hiddenInset traffic lights sit at x:16..76 y:20..34. Leave that alone
+// so the native buttons stay clickable; drag bar starts to the right of them.
+.desktop-drag-bar.is-mac {
+  left: 84px;
+  right: 0;
+}
+
+// Windows titleBarOverlay draws min/max/close in the top-right ~138px.
+// Drag bar stops before them so buttons stay hittable.
+.desktop-drag-bar.is-win {
+  left: 0;
+  right: 138px;
+}
+</style>

--- a/src/layouts/Main.vue
+++ b/src/layouts/Main.vue
@@ -243,6 +243,24 @@ export default defineComponent({
   top: calc(0.5rem + var(--app-safe-area-top));
 }
 
+// Desktop: the pill sits inside the frameless title bar area. Push it below
+// the 32px drag-bar + 40px titleBarOverlay so it doesn't overlap the drag
+// region visually. On Windows shift left of the native min/max/close buttons
+// (~138px wide, top-right). On macOS traffic-lights are top-left, so pull the
+// pill a little further from the right edge for breathing room. Ancestor
+// selectors compile cleanly under Vue <style scoped>: only the last simple
+// selector receives the [data-v-*] attribute, and `.status-floating` is in
+// this component.
+html.surface-desktop .status-floating {
+  top: 44px;
+}
+html.surface-desktop.is-win .status-floating {
+  right: 148px;
+}
+html.surface-desktop.is-mac .status-floating {
+  right: 12px;
+}
+
 @media (max-width: 767px) {
   .wrapper {
     width: 100%;

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@ import dayjs from './plugins/dayjs';
 import './plugins/font-awesome';
 import { MotionPlugin } from '@vueuse/motion';
 import { vLoading } from 'element-plus';
-import { getSurface, isNative, isDesktop } from '@/utils/surface';
+import { getSurface, isNative, isDesktop, isMacOS, isWindows } from '@/utils/surface';
 import { resolveDeferredInviterId } from '@/utils/attribution';
 import { syncFeaturesFromUrl } from '@/utils/featureFlag';
 import { runVersionGate } from '@/utils/versionGate';
@@ -70,6 +70,13 @@ export const createApp = ViteSSG(App, { routes, base: import.meta.env.BASE_URL }
   document.documentElement.classList.add(`surface-${surface}`);
   if (isNative()) {
     document.documentElement.classList.add('surface-native');
+  }
+  // Desktop OS marker for CSS. Traffic-light vs Windows-controls layout differs
+  // enough (left-side inset vs right-side overlay) that per-OS rules are simpler
+  // than a runtime CSS var. Safe: isMacOS/isWindows return false off-desktop.
+  if (isDesktop()) {
+    if (isMacOS()) document.documentElement.classList.add('is-mac');
+    if (isWindows()) document.documentElement.classList.add('is-win');
   }
   // Drop the iOS zoom-lock on web/Android (WCAG 1.4.4); native shells keep it.
   if (!Capacitor.isNativePlatform()) {


### PR DESCRIPTION
Resolves issues #1 and #3 from [`plans/nexior-desktop/DESKTOP-POLISH-WINDOWS.md`](https://github.com/AceDataCloud/Index/blob/main/plans/nexior-desktop/DESKTOP-POLISH-WINDOWS.md).

## What

On the Nexior desktop build (Electron, frameless window):

1. **Every service page is undraggable.** `layouts/Main.vue` (chat / console / …) renders no `TopHeader`, so there is no element with `-webkit-app-region: drag` and the window has zero drag surface. Users can only move the window from the tiny native title bar on Windows / trackpad drag on macOS.
2. **Wallet / credits pill overlaps the native window controls on Windows.** `ApplicationStatus` is fixed to the top-right at y≈8 px, colliding with `titleBarOverlay`'s min / max / close buttons (~138 px wide).

## Fix

- New `src/components/common/DesktopDragBar.vue` — 32 px fixed-top band with `-webkit-app-region: drag` + `pointer-events: none`. Mounted **once** in `App.vue` so every layout inherits it. Auto-hides in macOS native fullscreen via `desktopBridge.onFullscreenChange`. Leaves gaps for the traffic-light cluster (left 84 px on mac) and Windows Controls Overlay (right 138 px on win).
- `electron/main.ts`: shrink Windows `titleBarOverlay.height` from 64 → 40 (still inside Chromium's 30–48 range) — we no longer reserve full header height there.
- `src/main.ts` bootstrap: add `html.is-mac` / `html.is-win` marker classes on desktop so per-OS CSS is one-liners.
- `src/layouts/Main.vue`: on `html.surface-desktop` push `.status-floating` down to `top: 44 px` (clears drag-bar + overlay). On Windows shift `right: 148 px` (past the min/max/close). On macOS `right: 12 px` breathing room.
- `src/components/application/Status.vue`: give `.entry` button `-webkit-app-region: no-drag` so clicks work when the pill sits inside the desktop drag region.

Bundle cost on web / mobile: `DesktopDragBar` renders nothing (`v-if` off) — just the component import.

## Verification

- `npx vue-tsc --noEmit` → 0 errors.
- `npx eslint --fix` on all changed files → clean.
- Manual (needs local Windows / mac build, tracked as manual pre-merge check):
  - Windows: drag anywhere in the top 32 px band except the min/max/close area moves the window; credits pill sits at y:44 px, clickable, no collision with native buttons.
  - macOS: drag anywhere in the top 32 px band except the traffic lights moves the window; pill sits at y:44 px right:12 px, still clickable.
  - Both: enter/exit macOS fullscreen (green button) → drag bar hides / reappears with no leak.

## 🤖 对抗评审

Independent adversarial review (Explore subagent, cross-model) called out **2 RISKs**, both addressed in this branch before push:

- **RISK 1** `src/layouts/Main.vue:251` — pill at `top: 6 px` sat inside the drag-bar's Y range, creating a fragmented drag zone. **Fixed**: moved to `top: 44 px` per plan.
- **RISK 2** `src/layouts/Main.vue:254` — macOS was missing a `right` override, leaving the pill on Tailwind's `right-2` (8 px). **Fixed**: added `html.surface-desktop.is-mac .status-floating { right: 12 px }` per plan.

Non-fixed premises the reviewer verified clean:
1. `-webkit-app-region` layering — `no-drag` on the pill correctly wins over parent `drag` region despite `pointer-events: none`.
2. Vue `<style scoped>` ancestor selectors (`html.surface-desktop .status-floating`) compile to `.status-floating[data-v-*]` and do not bleed into other components (only Main.vue uses this class).
3. `desktopBridge?.onFullscreenChange?.(…) ?? null` short-circuits cleanly off-desktop, `beforeUnmount` cleans up.
4. Chromium `titleBarOverlay.height: 40` is within the 30–48 safe range.
5. Preload injects `window.desktop.platform` synchronously before renderer JS runs, so `isMacOS()` / `isWindows()` in `main.ts` bootstrap are race-free.
6. `TopHeader`'s existing drag region (Index.vue layout only) OR-combines with the new DragBar — redundant but harmless.