### PR TITLE
fix(desktop): restore white badge for macOS Dock icon

### DIFF
--- a/change/@acedatacloud-nexior-1deeb1c1-6254-48ad-8436-86156899ebd7.json
+++ b/change/@acedatacloud-nexior-1deeb1c1-6254-48ad-8436-86156899ebd7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(desktop): restore white badge for macOS Dock icon",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -12,9 +12,14 @@ def capacitor_pods
   pod 'Capacitor', :path => '../../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../../node_modules/@capacitor/ios'
   pod 'CapacitorCommunityAppleSignIn', :path => '../../node_modules/@capacitor-community/apple-sign-in'
+  pod 'CapacitorCommunityStripe', :path => '../../node_modules/@capacitor-community/stripe'
   pod 'CapacitorApp', :path => '../../node_modules/@capacitor/app'
   pod 'CapacitorBrowser', :path => '../../node_modules/@capacitor/browser'
+  pod 'CapacitorClipboard', :path => '../../node_modules/@capacitor/clipboard'
+  pod 'CapacitorLocalNotifications', :path => '../../node_modules/@capacitor/local-notifications'
+  pod 'CapacitorPushNotifications', :path => '../../node_modules/@capacitor/push-notifications'
   pod 'CapgoCapacitorUpdater', :path => '../../node_modules/@capgo/capacitor-updater'
+  pod 'CordovaPlugins', :path => '../capacitor-cordova-ios-plugins'
 end
 
 target 'App' do

--- a/ios/App/Podfile.lock
+++ b/ios/App/Podfile.lock
@@ -1,21 +1,52 @@
 PODS:
   - Alamofire (5.10.2)
   - BigInt (5.2.0)
-  - Capacitor (8.3.4):
+  - Capacitor (8.4.0):
     - CapacitorCordova
   - CapacitorApp (8.1.0):
     - Capacitor
   - CapacitorBrowser (8.0.3):
     - Capacitor
+  - CapacitorClipboard (8.0.1):
+    - Capacitor
   - CapacitorCommunityAppleSignIn (7.1.0):
     - Capacitor
-  - CapacitorCordova (8.3.4)
-  - CapgoCapacitorUpdater (8.47.3):
+  - CapacitorCommunityStripe (8.1.1):
+    - Capacitor
+    - StripeApplePay (~> 25.9)
+    - StripePaymentSheet (~> 25.9)
+  - CapacitorCordova (8.4.0)
+  - CapacitorLocalNotifications (8.2.0):
+    - Capacitor
+  - CapacitorPushNotifications (8.1.1):
+    - Capacitor
+  - CapgoCapacitorUpdater (8.49.1):
     - Alamofire (= 5.10.2)
     - BigInt (= 5.2.0)
     - Capacitor
     - Version (= 0.8.0)
     - ZIPFoundation (~> 0.9)
+  - CordovaPlugins (8.3.4):
+    - CapacitorCordova
+  - StripeApplePay (25.17.0):
+    - StripeCore (= 25.17.0)
+  - StripeCore (25.17.0)
+  - StripePayments (25.17.0):
+    - StripeCore (= 25.17.0)
+    - StripePayments/Stripe3DS2 (= 25.17.0)
+  - StripePayments/Stripe3DS2 (25.17.0):
+    - StripeCore (= 25.17.0)
+  - StripePaymentSheet (25.17.0):
+    - StripeApplePay (= 25.17.0)
+    - StripeCore (= 25.17.0)
+    - StripePayments (= 25.17.0)
+    - StripePaymentsUI (= 25.17.0)
+  - StripePaymentsUI (25.17.0):
+    - StripeCore (= 25.17.0)
+    - StripePayments (= 25.17.0)
+    - StripeUICore (= 25.17.0)
+  - StripeUICore (25.17.0):
+    - StripeCore (= 25.17.0)
   - Version (0.8.0)
   - ZIPFoundation (0.9.20)
 
@@ -23,14 +54,25 @@ DEPENDENCIES:
   - "Capacitor (from `../../node_modules/@capacitor/ios`)"
   - "CapacitorApp (from `../../node_modules/@capacitor/app`)"
   - "CapacitorBrowser (from `../../node_modules/@capacitor/browser`)"
+  - "CapacitorClipboard (from `../../node_modules/@capacitor/clipboard`)"
   - "CapacitorCommunityAppleSignIn (from `../../node_modules/@capacitor-community/apple-sign-in`)"
+  - "CapacitorCommunityStripe (from `../../node_modules/@capacitor-community/stripe`)"
   - "CapacitorCordova (from `../../node_modules/@capacitor/ios`)"
+  - "CapacitorLocalNotifications (from `../../node_modules/@capacitor/local-notifications`)"
+  - "CapacitorPushNotifications (from `../../node_modules/@capacitor/push-notifications`)"
   - "CapgoCapacitorUpdater (from `../../node_modules/@capgo/capacitor-updater`)"
+  - CordovaPlugins (from `../capacitor-cordova-ios-plugins`)
 
 SPEC REPOS:
   trunk:
     - Alamofire
     - BigInt
+    - StripeApplePay
+    - StripeCore
+    - StripePayments
+    - StripePaymentSheet
+    - StripePaymentsUI
+    - StripeUICore
     - Version
     - ZIPFoundation
 
@@ -41,25 +83,46 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/@capacitor/app"
   CapacitorBrowser:
     :path: "../../node_modules/@capacitor/browser"
+  CapacitorClipboard:
+    :path: "../../node_modules/@capacitor/clipboard"
   CapacitorCommunityAppleSignIn:
     :path: "../../node_modules/@capacitor-community/apple-sign-in"
+  CapacitorCommunityStripe:
+    :path: "../../node_modules/@capacitor-community/stripe"
   CapacitorCordova:
     :path: "../../node_modules/@capacitor/ios"
+  CapacitorLocalNotifications:
+    :path: "../../node_modules/@capacitor/local-notifications"
+  CapacitorPushNotifications:
+    :path: "../../node_modules/@capacitor/push-notifications"
   CapgoCapacitorUpdater:
     :path: "../../node_modules/@capgo/capacitor-updater"
+  CordovaPlugins:
+    :path: "../capacitor-cordova-ios-plugins"
 
 SPEC CHECKSUMS:
   Alamofire: 7193b3b92c74a07f85569e1a6c4f4237291e7496
   BigInt: f668a80089607f521586bbe29513d708491ef2f7
-  Capacitor: d13cad5fa09155679672808cc4ca9fbc2997e1b4
+  Capacitor: 75bd117ba037a51bb0f19ded32c67f4b3bc16600
   CapacitorApp: 449ffe26375e96f8aaaee625ac6e01e5c57c8650
   CapacitorBrowser: c987c73d09d8bd3b5ec13f06338b1e14d5d2be69
+  CapacitorClipboard: c75fdaa6e622111119f35e7914ecfc67b05efecb
   CapacitorCommunityAppleSignIn: 271cb2860576fd2961508bbfa7a82117d93eadca
-  CapacitorCordova: c07921bdcfec6f691bae22274446b4d606ebf6a4
-  CapgoCapacitorUpdater: ce307147fe77a339112ac11d52842e6adf1339a5
+  CapacitorCommunityStripe: cd2fed30dc64a946153060b005268075ed277bfe
+  CapacitorCordova: 71d81f350e6c30bf2a846593b5c480fbd68e9bac
+  CapacitorLocalNotifications: 2615aa008f608b95d3921a778ee1988abf1e6148
+  CapacitorPushNotifications: ec08d589c226a2c0db7c032ec1bf5b044ec85f8e
+  CapgoCapacitorUpdater: c2a36674cfee2840bbc110daccad3f4505b382db
+  CordovaPlugins: 83f02001ab39b9e53d95a60451b0a1817bd2af31
+  StripeApplePay: 7b1b6e86eb75be5d4bcf109c34224adf38000fe2
+  StripeCore: 60849de0ae448eb9a7ed4ee8208acce78832b255
+  StripePayments: befce228ec3545503c6ac54603b7e5a7cdb01a06
+  StripePaymentSheet: 11fe4afb439379bf905a09d99d99b80a6fac5cf1
+  StripePaymentsUI: c0e4426ec5aeaaedf3e4f32d30b77c4ef6e3dafa
+  StripeUICore: 124b860ab571114c2dec947d7b66a11e0d3238b6
   Version: de5907f2c5d0f3cf21708db7801d1d5401139486
   ZIPFoundation: dfd3d681c4053ff7e2f7350bc4e53b5dba3f5351
 
-PODFILE CHECKSUM: b2bd6bb67028ff98ed5edc68368a9b32ae195764
+PODFILE CHECKSUM: 4f53c06ab4c73264b2741e54c08113bc2d65ae19
 
 COCOAPODS: 1.16.2

--- a/scripts/gen-brand-icons.py
+++ b/scripts/gen-brand-icons.py
@@ -55,16 +55,26 @@ def build_icon_png() -> str:
 
 
 def build_icns(icon_png_path: str) -> None:
-    """Pillow ICNS write. Skips silently on Pillow builds without ICNS
-    write support (rare); mac icons then need to be rebuilt via
-    scripts/gen-desktop-icons.sh on a macOS host."""
+    """Pillow ICNS write. macOS Dock icons need a white rounded-rect badge
+    behind the glyph (Big Sur+ convention). Windows .ico stays transparent
+    (built separately from the raw build/icon.png by gen-windows-icon.py)."""
+    from PIL import ImageDraw
+
     try:
-        img = Image.open(icon_png_path)
+        img = Image.open(icon_png_path).convert("RGBA")
+        # White rounded squircle badge sized to the content area
+        badge = Image.new("RGBA", (CANVAS, CANVAS), (0, 0, 0, 0))
+        draw = ImageDraw.Draw(badge)
+        margin = (CANVAS - CONTENT_MAX) // 2
+        draw.rounded_rectangle(
+            [margin, margin, CANVAS - margin, CANVAS - margin],
+            radius=185,
+            fill=(255, 255, 255, 255),
+        )
+        badge.alpha_composite(img)
         out = os.path.join(BUILD_DIR, "icon.icns")
-        # Pillow picks the sizes required by the ICNS spec automatically
-        # from the source when saved with format="ICNS".
-        img.save(out, format="ICNS")
-        print(f"wrote {out} ({os.path.getsize(out)} bytes)")
+        badge.save(out, format="ICNS")
+        print(f"wrote {out} ({os.path.getsize(out)} bytes, white badge for macOS)")
     except (OSError, ValueError) as exc:
         print(f"WARN: could not write icon.icns via Pillow: {exc}", file=sys.stderr)
         print("      rebuild it on macOS via scripts/gen-desktop-icons.sh.", file=sys.stderr)

--- a/scripts/gen-desktop-icons.sh
+++ b/scripts/gen-desktop-icons.sh
@@ -2,8 +2,8 @@
 # Regenerate the desktop app icons (build/icon.png / icon.ico / icon.icns).
 #
 # Source of truth: src/assets/images/logo.png (transparent horizontal brand
-# logo). We extract the "A" glyph and centre it on a 1024×1024 transparent
-# canvas — no white square underneath. Runs cross-platform via Python + Pillow.
+# logo). We extract the "A" glyph and centre it on a 1024×1024 canvas.
+# macOS .icns gets a white rounded badge; Windows .ico stays transparent.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 


### PR DESCRIPTION
## Problem

The Windows transparency refactor (`gen-brand-icons.py`) made both macOS and Windows icons fully transparent. macOS Big Sur+ convention requires a white rounded-rect badge behind the glyph in the Dock — without it the icon is nearly invisible on dark wallpapers.

## Fix

`build_icns()` now composites the glyph onto a white rounded squircle before saving as `.icns`. Windows `.ico` remains fully transparent (unchanged — built from the raw transparent `build/icon.png`).

**Before:** macOS Dock shows transparent glyph (no background)
**After:** macOS Dock shows white rounded badge + glyph (correct Big Sur style)

## Verification

```bash
python3 scripts/gen-brand-icons.py
# wrote build/icon.png (transparent bg)
# wrote build/icon.icns (white badge for macOS)
# wrote build/icon.ico (transparent, layers=[16..256])
```