### PR TITLE
feat(maestro): add scenario selector

### DIFF
--- a/change/@acedatacloud-nexior-maestro-scenario-ui.json
+++ b/change/@acedatacloud-nexior-maestro-scenario-ui.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add Maestro scenario selector to choose video production type.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/maestro/ConfigPanel.vue
+++ b/src/components/maestro/ConfigPanel.vue
@@ -104,6 +104,22 @@
           />
         </el-select>
       </div>
+
+      <!-- Scenario (video type) -->
+      <div class="field-row">
+        <div class="field-head">
+          <h2 class="field-title font-bold">{{ $t('maestro.name.scenario') }}</h2>
+          <info-icon :content="$t('maestro.description.scenario')" class="ml-1" />
+        </div>
+        <el-select v-model="scenario" class="field-control">
+          <el-option
+            v-for="s in MAESTRO_ALLOWED_SCENARIOS"
+            :key="s"
+            :label="$t(`maestro.option.scenario.${s}`)"
+            :value="s"
+          />
+        </el-select>
+      </div>
     </div>
 
     <div class="flex flex-col items-center justify-center px-5 pb-5">
@@ -135,7 +151,9 @@ import {
   MAESTRO_DEFAULT_ASPECT,
   MAESTRO_DEFAULT_DURATION,
   MAESTRO_ALLOWED_QUALITIES,
-  MAESTRO_DEFAULT_QUALITY
+  MAESTRO_DEFAULT_QUALITY,
+  MAESTRO_ALLOWED_SCENARIOS,
+  MAESTRO_DEFAULT_SCENARIO
 } from '@/constants';
 import { IMaestroConfig } from '@/models';
 
@@ -166,7 +184,8 @@ export default defineComponent({
       MAESTRO_ALLOWED_LANGS,
       MAESTRO_MIN_DURATION,
       MAESTRO_MAX_DURATION,
-      MAESTRO_ALLOWED_QUALITIES
+      MAESTRO_ALLOWED_QUALITIES,
+      MAESTRO_ALLOWED_SCENARIOS
     };
   },
   computed: {
@@ -238,6 +257,14 @@ export default defineComponent({
       set(val: string) {
         this.update({ quality: val });
       }
+    },
+    scenario: {
+      get(): string | undefined {
+        return this.config?.scenario;
+      },
+      set(val: string) {
+        this.update({ scenario: val });
+      }
     }
   },
   mounted() {
@@ -246,7 +273,8 @@ export default defineComponent({
       langs: this.config?.langs?.length ? this.config.langs : MAESTRO_DEFAULT_LANGS,
       aspect: this.config?.aspect ?? MAESTRO_DEFAULT_ASPECT,
       duration: this.config?.duration ?? MAESTRO_DEFAULT_DURATION,
-      quality: this.config?.quality ?? MAESTRO_DEFAULT_QUALITY
+      quality: this.config?.quality ?? MAESTRO_DEFAULT_QUALITY,
+      scenario: this.config?.scenario ?? MAESTRO_DEFAULT_SCENARIO
     });
   },
   methods: {

--- a/src/constants/maestro.ts
+++ b/src/constants/maestro.ts
@@ -14,6 +14,19 @@ export const MAESTRO_MIN_DURATION = 1;
 export const MAESTRO_MAX_DURATION = 600;
 // Production tier (effort/price): draft = fast preview, standard = balanced, premium = richer.
 export const MAESTRO_ALLOWED_QUALITIES = ['draft', 'standard', 'premium'];
+// Video type: auto lets the director pick; the rest pin a production style.
+export const MAESTRO_ALLOWED_SCENARIOS = [
+  'auto',
+  'drama',
+  'general',
+  'explainer',
+  'product',
+  'website',
+  'slides',
+  'motion',
+  'changelog',
+  'captions'
+];
 
 // Accepted reference media for file_urls (images / video / audio).
 export const MAESTRO_FILE_ACCEPT = '.png,.jpg,.jpeg,.gif,.bmp,.webp,.mp4,.mov,.webm,.mp3,.wav,.m4a';
@@ -24,3 +37,4 @@ export const MAESTRO_DEFAULT_LANGS = ['zh-cn'];
 export const MAESTRO_DEFAULT_ASPECT = '9:16';
 export const MAESTRO_DEFAULT_DURATION = 30;
 export const MAESTRO_DEFAULT_QUALITY = 'standard';
+export const MAESTRO_DEFAULT_SCENARIO = 'auto';

--- a/src/i18n/ar/maestro.json
+++ b/src/i18n/ar/maestro.json
@@ -222,5 +222,53 @@
   "message.downloadVideo": {
     "message": "تحميل الفيديو الذي تم إنشاؤه",
     "description": "تلميح التحميل"
+  },
+  "name.scenario": {
+    "message": "نوع الفيديو",
+    "description": "Video type field"
+  },
+  "description.scenario": {
+    "message": "اختر نوع الفيديو المراد إنشاؤه. «تلقائي» يترك القرار لـ Maestro؛ أو حدّد نمطًا مثل دراما قصيرة أو لقطات واقعية أو شرح أو ترويج منتج.",
+    "description": "Scenario field help"
+  },
+  "option.scenario.auto": {
+    "message": "تلقائي · دع Maestro يقرر",
+    "description": "Auto scenario option"
+  },
+  "option.scenario.drama": {
+    "message": "دراما قصيرة",
+    "description": "Short drama scenario option"
+  },
+  "option.scenario.general": {
+    "message": "لقطات واقعية",
+    "description": "Footage piece scenario option"
+  },
+  "option.scenario.explainer": {
+    "message": "فيديو توضيحي",
+    "description": "Explainer scenario option"
+  },
+  "option.scenario.product": {
+    "message": "ترويج منتج",
+    "description": "Product promo scenario option"
+  },
+  "option.scenario.website": {
+    "message": "موقع إلى فيديو",
+    "description": "Website-to-video scenario option"
+  },
+  "option.scenario.slides": {
+    "message": "عرض شرائح",
+    "description": "Slideshow scenario option"
+  },
+  "option.scenario.motion": {
+    "message": "رسوم متحركة",
+    "description": "Motion graphics scenario option"
+  },
+  "option.scenario.changelog": {
+    "message": "سجل التغييرات (PR)",
+    "description": "Changelog scenario option"
+  },
+  "option.scenario.captions": {
+    "message": "إضافة ترجمات",
+    "description": "Add-captions scenario option"
   }
 }

--- a/src/i18n/de/maestro.json
+++ b/src/i18n/de/maestro.json
@@ -222,5 +222,53 @@
   "message.downloadVideo": {
     "message": "Herunterladen des generierten Videos",
     "description": "Tooltip für den Download"
+  },
+  "name.scenario": {
+    "message": "Videotyp",
+    "description": "Video type field"
+  },
+  "description.scenario": {
+    "message": "Wähle die Art des Videos. Auto lässt Maestro entscheiden; oder erzwinge einen Stil wie Kurzdrama, Realaufnahmen, Erklärvideo oder Produktwerbung.",
+    "description": "Scenario field help"
+  },
+  "option.scenario.auto": {
+    "message": "Auto · Maestro entscheiden lassen",
+    "description": "Auto scenario option"
+  },
+  "option.scenario.drama": {
+    "message": "Kurzdrama",
+    "description": "Short drama scenario option"
+  },
+  "option.scenario.general": {
+    "message": "Realaufnahmen",
+    "description": "Footage piece scenario option"
+  },
+  "option.scenario.explainer": {
+    "message": "Erklärvideo",
+    "description": "Explainer scenario option"
+  },
+  "option.scenario.product": {
+    "message": "Produktwerbung",
+    "description": "Product promo scenario option"
+  },
+  "option.scenario.website": {
+    "message": "Website zu Video",
+    "description": "Website-to-video scenario option"
+  },
+  "option.scenario.slides": {
+    "message": "Diashow",
+    "description": "Slideshow scenario option"
+  },
+  "option.scenario.motion": {
+    "message": "Motion Graphics",
+    "description": "Motion graphics scenario option"
+  },
+  "option.scenario.changelog": {
+    "message": "Änderungsprotokoll (PR)",
+    "description": "Changelog scenario option"
+  },
+  "option.scenario.captions": {
+    "message": "Untertitel hinzufügen",
+    "description": "Add-captions scenario option"
   }
 }

--- a/src/i18n/el/maestro.json
+++ b/src/i18n/el/maestro.json
@@ -222,5 +222,53 @@
   "message.downloadVideo": {
     "message": "Κατέβασμα του παραγόμενου βίντεο",
     "description": "Tooltip για κατέβασμα"
+  },
+  "name.scenario": {
+    "message": "Τύπος βίντεο",
+    "description": "Video type field"
+  },
+  "description.scenario": {
+    "message": "Επιλέξτε τον τύπο βίντεο. Το «Αυτόματο» αφήνει το Maestro να αποφασίσει· ή επιβάλετε στυλ όπως σύντομο δράμα, πραγματικά πλάνα, επεξήγηση ή προώθηση προϊόντος.",
+    "description": "Scenario field help"
+  },
+  "option.scenario.auto": {
+    "message": "Αυτόματο · ας αποφασίσει το Maestro",
+    "description": "Auto scenario option"
+  },
+  "option.scenario.drama": {
+    "message": "Σύντομο δράμα",
+    "description": "Short drama scenario option"
+  },
+  "option.scenario.general": {
+    "message": "Πραγματικά πλάνα",
+    "description": "Footage piece scenario option"
+  },
+  "option.scenario.explainer": {
+    "message": "Επεξηγηματικό",
+    "description": "Explainer scenario option"
+  },
+  "option.scenario.product": {
+    "message": "Προώθηση προϊόντος",
+    "description": "Product promo scenario option"
+  },
+  "option.scenario.website": {
+    "message": "Ιστότοπος σε βίντεο",
+    "description": "Website-to-video scenario option"
+  },
+  "option.scenario.slides": {
+    "message": "Παρουσίαση διαφανειών",
+    "description": "Slideshow scenario option"
+  },
+  "option.scenario.motion": {
+    "message": "Κινούμενα γραφικά",
+    "description": "Motion graphics scenario option"
+  },
+  "option.scenario.changelog": {
+    "message": "Αρχείο αλλαγών (PR)",
+    "description": "Changelog scenario option"
+  },
+  "option.scenario.captions": {
+    "message": "Προσθήκη υπότιτλων",
+    "description": "Add-captions scenario option"
   }
 }

--- a/src/i18n/en/maestro.json
+++ b/src/i18n/en/maestro.json
@@ -162,5 +162,53 @@
   "message.noTasks": {
     "message": "No videos yet — create your first one on the left.",
     "description": "No tasks"
+  },
+  "name.scenario": {
+    "message": "Video Type",
+    "description": "Video type field"
+  },
+  "description.scenario": {
+    "message": "Pick the kind of video to make. Auto lets Maestro decide; or force a style like short drama, footage piece, explainer or product promo.",
+    "description": "Scenario field help"
+  },
+  "option.scenario.auto": {
+    "message": "Auto · let Maestro decide",
+    "description": "Auto scenario option"
+  },
+  "option.scenario.drama": {
+    "message": "Short Drama",
+    "description": "Short drama scenario option"
+  },
+  "option.scenario.general": {
+    "message": "Footage Piece",
+    "description": "Footage piece scenario option"
+  },
+  "option.scenario.explainer": {
+    "message": "Explainer",
+    "description": "Explainer scenario option"
+  },
+  "option.scenario.product": {
+    "message": "Product Promo",
+    "description": "Product promo scenario option"
+  },
+  "option.scenario.website": {
+    "message": "Website to Video",
+    "description": "Website-to-video scenario option"
+  },
+  "option.scenario.slides": {
+    "message": "Slideshow",
+    "description": "Slideshow scenario option"
+  },
+  "option.scenario.motion": {
+    "message": "Motion Graphics",
+    "description": "Motion graphics scenario option"
+  },
+  "option.scenario.changelog": {
+    "message": "Changelog (PR)",
+    "description": "Changelog scenario option"
+  },
+  "option.scenario.captions": {
+    "message": "Add Captions",
+    "description": "Add-captions scenario option"
   }
 }

--- a/src/i18n/es/maestro.json
+++ b/src/i18n/es/maestro.json
@@ -222,5 +222,53 @@
   "message.downloadVideo": {
     "message": "Descargar el video generado",
     "description": "Tooltip de descarga"
+  },
+  "name.scenario": {
+    "message": "Tipo de vídeo",
+    "description": "Video type field"
+  },
+  "description.scenario": {
+    "message": "Elige el tipo de vídeo a crear. Automático deja que Maestro decida; o fuerza un estilo como drama corto, secuencia real, explicativo o promoción de producto.",
+    "description": "Scenario field help"
+  },
+  "option.scenario.auto": {
+    "message": "Automático · que decida Maestro",
+    "description": "Auto scenario option"
+  },
+  "option.scenario.drama": {
+    "message": "Drama corto",
+    "description": "Short drama scenario option"
+  },
+  "option.scenario.general": {
+    "message": "Secuencia real",
+    "description": "Footage piece scenario option"
+  },
+  "option.scenario.explainer": {
+    "message": "Explicativo",
+    "description": "Explainer scenario option"
+  },
+  "option.scenario.product": {
+    "message": "Promoción de producto",
+    "description": "Product promo scenario option"
+  },
+  "option.scenario.website": {
+    "message": "Web a vídeo",
+    "description": "Website-to-video scenario option"
+  },
+  "option.scenario.slides": {
+    "message": "Presentación",
+    "description": "Slideshow scenario option"
+  },
+  "option.scenario.motion": {
+    "message": "Gráficos animados",
+    "description": "Motion graphics scenario option"
+  },
+  "option.scenario.changelog": {
+    "message": "Registro de cambios (PR)",
+    "description": "Changelog scenario option"
+  },
+  "option.scenario.captions": {
+    "message": "Añadir subtítulos",
+    "description": "Add-captions scenario option"
   }
 }

--- a/src/i18n/fi/maestro.json
+++ b/src/i18n/fi/maestro.json
@@ -222,5 +222,53 @@
   "message.downloadVideo": {
     "message": "Lataa tuotettu video",
     "description": "Lataus työkaluvihje"
+  },
+  "name.scenario": {
+    "message": "Videon tyyppi",
+    "description": "Video type field"
+  },
+  "description.scenario": {
+    "message": "Valitse luotavan videon tyyppi. Automaattinen antaa Maestron päättää; tai pakota tyyli, kuten lyhytdraama, aito kuvamateriaali, selittävä tai tuote-esittely.",
+    "description": "Scenario field help"
+  },
+  "option.scenario.auto": {
+    "message": "Automaattinen · anna Maestron päättää",
+    "description": "Auto scenario option"
+  },
+  "option.scenario.drama": {
+    "message": "Lyhytdraama",
+    "description": "Short drama scenario option"
+  },
+  "option.scenario.general": {
+    "message": "Aito kuvamateriaali",
+    "description": "Footage piece scenario option"
+  },
+  "option.scenario.explainer": {
+    "message": "Selittävä",
+    "description": "Explainer scenario option"
+  },
+  "option.scenario.product": {
+    "message": "Tuote-esittely",
+    "description": "Product promo scenario option"
+  },
+  "option.scenario.website": {
+    "message": "Verkkosivu videoksi",
+    "description": "Website-to-video scenario option"
+  },
+  "option.scenario.slides": {
+    "message": "Diaesitys",
+    "description": "Slideshow scenario option"
+  },
+  "option.scenario.motion": {
+    "message": "Liikegrafiikka",
+    "description": "Motion graphics scenario option"
+  },
+  "option.scenario.changelog": {
+    "message": "Muutosloki (PR)",
+    "description": "Changelog scenario option"
+  },
+  "option.scenario.captions": {
+    "message": "Lisää tekstitykset",
+    "description": "Add-captions scenario option"
   }
 }

--- a/src/i18n/fr/maestro.json
+++ b/src/i18n/fr/maestro.json
@@ -222,5 +222,53 @@
   "message.downloadVideo": {
     "message": "Télécharger la vidéo générée",
     "description": "Infobulle de téléchargement"
+  },
+  "name.scenario": {
+    "message": "Type de vidéo",
+    "description": "Video type field"
+  },
+  "description.scenario": {
+    "message": "Choisissez le type de vidéo à créer. Auto laisse Maestro décider ; ou imposez un style comme drame court, séquence réelle, explicatif ou promo produit.",
+    "description": "Scenario field help"
+  },
+  "option.scenario.auto": {
+    "message": "Auto · laisser Maestro décider",
+    "description": "Auto scenario option"
+  },
+  "option.scenario.drama": {
+    "message": "Drame court",
+    "description": "Short drama scenario option"
+  },
+  "option.scenario.general": {
+    "message": "Séquence réelle",
+    "description": "Footage piece scenario option"
+  },
+  "option.scenario.explainer": {
+    "message": "Explicatif",
+    "description": "Explainer scenario option"
+  },
+  "option.scenario.product": {
+    "message": "Promo produit",
+    "description": "Product promo scenario option"
+  },
+  "option.scenario.website": {
+    "message": "Site web en vidéo",
+    "description": "Website-to-video scenario option"
+  },
+  "option.scenario.slides": {
+    "message": "Diaporama",
+    "description": "Slideshow scenario option"
+  },
+  "option.scenario.motion": {
+    "message": "Motion design",
+    "description": "Motion graphics scenario option"
+  },
+  "option.scenario.changelog": {
+    "message": "Journal des modifs (PR)",
+    "description": "Changelog scenario option"
+  },
+  "option.scenario.captions": {
+    "message": "Ajouter des sous-titres",
+    "description": "Add-captions scenario option"
   }
 }

--- a/src/i18n/it/maestro.json
+++ b/src/i18n/it/maestro.json
@@ -222,5 +222,53 @@
   "message.downloadVideo": {
     "message": "Scarica il video generato",
     "description": "Tooltip per il download"
+  },
+  "name.scenario": {
+    "message": "Tipo di video",
+    "description": "Video type field"
+  },
+  "description.scenario": {
+    "message": "Scegli il tipo di video da creare. Auto lascia decidere a Maestro; oppure imponi uno stile come dramma breve, riprese reali, esplicativo o promo prodotto.",
+    "description": "Scenario field help"
+  },
+  "option.scenario.auto": {
+    "message": "Auto · lascia decidere a Maestro",
+    "description": "Auto scenario option"
+  },
+  "option.scenario.drama": {
+    "message": "Dramma breve",
+    "description": "Short drama scenario option"
+  },
+  "option.scenario.general": {
+    "message": "Riprese reali",
+    "description": "Footage piece scenario option"
+  },
+  "option.scenario.explainer": {
+    "message": "Esplicativo",
+    "description": "Explainer scenario option"
+  },
+  "option.scenario.product": {
+    "message": "Promo prodotto",
+    "description": "Product promo scenario option"
+  },
+  "option.scenario.website": {
+    "message": "Sito web in video",
+    "description": "Website-to-video scenario option"
+  },
+  "option.scenario.slides": {
+    "message": "Presentazione",
+    "description": "Slideshow scenario option"
+  },
+  "option.scenario.motion": {
+    "message": "Grafica animata",
+    "description": "Motion graphics scenario option"
+  },
+  "option.scenario.changelog": {
+    "message": "Changelog (PR)",
+    "description": "Changelog scenario option"
+  },
+  "option.scenario.captions": {
+    "message": "Aggiungi sottotitoli",
+    "description": "Add-captions scenario option"
   }
 }

--- a/src/i18n/ja/maestro.json
+++ b/src/i18n/ja/maestro.json
@@ -222,5 +222,53 @@
   "message.downloadVideo": {
     "message": "生成された動画をダウンロード",
     "description": "ダウンロードツールチップ"
+  },
+  "name.scenario": {
+    "message": "動画タイプ",
+    "description": "Video type field"
+  },
+  "description.scenario": {
+    "message": "作成する動画の種類を選びます。自動では Maestro が判断します。ショートドラマ・実写映像・解説・商品PRなどのスタイルを指定することもできます。",
+    "description": "Scenario field help"
+  },
+  "option.scenario.auto": {
+    "message": "自動 · Maestro に任せる",
+    "description": "Auto scenario option"
+  },
+  "option.scenario.drama": {
+    "message": "ショートドラマ",
+    "description": "Short drama scenario option"
+  },
+  "option.scenario.general": {
+    "message": "実写映像",
+    "description": "Footage piece scenario option"
+  },
+  "option.scenario.explainer": {
+    "message": "解説動画",
+    "description": "Explainer scenario option"
+  },
+  "option.scenario.product": {
+    "message": "商品PR",
+    "description": "Product promo scenario option"
+  },
+  "option.scenario.website": {
+    "message": "ウェブサイト動画化",
+    "description": "Website-to-video scenario option"
+  },
+  "option.scenario.slides": {
+    "message": "スライドショー",
+    "description": "Slideshow scenario option"
+  },
+  "option.scenario.motion": {
+    "message": "モーショングラフィックス",
+    "description": "Motion graphics scenario option"
+  },
+  "option.scenario.changelog": {
+    "message": "変更履歴 (PR)",
+    "description": "Changelog scenario option"
+  },
+  "option.scenario.captions": {
+    "message": "字幕を追加",
+    "description": "Add-captions scenario option"
   }
 }

--- a/src/i18n/ko/maestro.json
+++ b/src/i18n/ko/maestro.json
@@ -222,5 +222,53 @@
   "message.downloadVideo": {
     "message": "생성된 비디오 다운로드",
     "description": "다운로드 툴팁"
+  },
+  "name.scenario": {
+    "message": "동영상 유형",
+    "description": "Video type field"
+  },
+  "description.scenario": {
+    "message": "제작할 동영상 종류를 선택하세요. 자동은 Maestro가 결정하며, 숏드라마·실사 영상·설명·제품 홍보 등 스타일을 지정할 수도 있습니다.",
+    "description": "Scenario field help"
+  },
+  "option.scenario.auto": {
+    "message": "자동 · Maestro가 결정",
+    "description": "Auto scenario option"
+  },
+  "option.scenario.drama": {
+    "message": "숏드라마",
+    "description": "Short drama scenario option"
+  },
+  "option.scenario.general": {
+    "message": "실사 영상",
+    "description": "Footage piece scenario option"
+  },
+  "option.scenario.explainer": {
+    "message": "설명 영상",
+    "description": "Explainer scenario option"
+  },
+  "option.scenario.product": {
+    "message": "제품 홍보",
+    "description": "Product promo scenario option"
+  },
+  "option.scenario.website": {
+    "message": "웹사이트 영상화",
+    "description": "Website-to-video scenario option"
+  },
+  "option.scenario.slides": {
+    "message": "슬라이드쇼",
+    "description": "Slideshow scenario option"
+  },
+  "option.scenario.motion": {
+    "message": "모션 그래픽",
+    "description": "Motion graphics scenario option"
+  },
+  "option.scenario.changelog": {
+    "message": "변경 로그 (PR)",
+    "description": "Changelog scenario option"
+  },
+  "option.scenario.captions": {
+    "message": "자막 추가",
+    "description": "Add-captions scenario option"
   }
 }

--- a/src/i18n/pl/maestro.json
+++ b/src/i18n/pl/maestro.json
@@ -222,5 +222,53 @@
   "message.downloadVideo": {
     "message": "Pobierz wygenerowane wideo",
     "description": "Podpowiedź do pobierania"
+  },
+  "name.scenario": {
+    "message": "Typ wideo",
+    "description": "Video type field"
+  },
+  "description.scenario": {
+    "message": "Wybierz rodzaj tworzonego wideo. Automatyczny pozwala Maestro zdecydować; albo wymuś styl, np. krótki dramat, ujęcia rzeczywiste, objaśnienie lub promocję produktu.",
+    "description": "Scenario field help"
+  },
+  "option.scenario.auto": {
+    "message": "Automatyczny · niech zdecyduje Maestro",
+    "description": "Auto scenario option"
+  },
+  "option.scenario.drama": {
+    "message": "Krótki dramat",
+    "description": "Short drama scenario option"
+  },
+  "option.scenario.general": {
+    "message": "Ujęcia rzeczywiste",
+    "description": "Footage piece scenario option"
+  },
+  "option.scenario.explainer": {
+    "message": "Objaśnienie",
+    "description": "Explainer scenario option"
+  },
+  "option.scenario.product": {
+    "message": "Promocja produktu",
+    "description": "Product promo scenario option"
+  },
+  "option.scenario.website": {
+    "message": "Strona na wideo",
+    "description": "Website-to-video scenario option"
+  },
+  "option.scenario.slides": {
+    "message": "Pokaz slajdów",
+    "description": "Slideshow scenario option"
+  },
+  "option.scenario.motion": {
+    "message": "Grafika ruchoma",
+    "description": "Motion graphics scenario option"
+  },
+  "option.scenario.changelog": {
+    "message": "Lista zmian (PR)",
+    "description": "Changelog scenario option"
+  },
+  "option.scenario.captions": {
+    "message": "Dodaj napisy",
+    "description": "Add-captions scenario option"
   }
 }

--- a/src/i18n/pt/maestro.json
+++ b/src/i18n/pt/maestro.json
@@ -222,5 +222,53 @@
   "message.downloadVideo": {
     "message": "Baixar o vídeo gerado",
     "description": "Dica para download"
+  },
+  "name.scenario": {
+    "message": "Tipo de vídeo",
+    "description": "Video type field"
+  },
+  "description.scenario": {
+    "message": "Escolha o tipo de vídeo a criar. Automático deixa o Maestro decidir; ou force um estilo como drama curto, sequência real, explicativo ou promoção de produto.",
+    "description": "Scenario field help"
+  },
+  "option.scenario.auto": {
+    "message": "Automático · deixar o Maestro decidir",
+    "description": "Auto scenario option"
+  },
+  "option.scenario.drama": {
+    "message": "Drama curto",
+    "description": "Short drama scenario option"
+  },
+  "option.scenario.general": {
+    "message": "Sequência real",
+    "description": "Footage piece scenario option"
+  },
+  "option.scenario.explainer": {
+    "message": "Explicativo",
+    "description": "Explainer scenario option"
+  },
+  "option.scenario.product": {
+    "message": "Promoção de produto",
+    "description": "Product promo scenario option"
+  },
+  "option.scenario.website": {
+    "message": "Site em vídeo",
+    "description": "Website-to-video scenario option"
+  },
+  "option.scenario.slides": {
+    "message": "Apresentação de slides",
+    "description": "Slideshow scenario option"
+  },
+  "option.scenario.motion": {
+    "message": "Motion graphics",
+    "description": "Motion graphics scenario option"
+  },
+  "option.scenario.changelog": {
+    "message": "Registro de alterações (PR)",
+    "description": "Changelog scenario option"
+  },
+  "option.scenario.captions": {
+    "message": "Adicionar legendas",
+    "description": "Add-captions scenario option"
   }
 }

--- a/src/i18n/ru/maestro.json
+++ b/src/i18n/ru/maestro.json
@@ -222,5 +222,53 @@
   "message.downloadVideo": {
     "message": "Скачать сгенерированное видео",
     "description": "Подсказка для скачивания"
+  },
+  "name.scenario": {
+    "message": "Тип видео",
+    "description": "Video type field"
+  },
+  "description.scenario": {
+    "message": "Выберите тип создаваемого видео. «Авто» — Maestro решит сам; либо задайте стиль: короткая драма, реальные кадры, объяснение или промо продукта.",
+    "description": "Scenario field help"
+  },
+  "option.scenario.auto": {
+    "message": "Авто · пусть решает Maestro",
+    "description": "Auto scenario option"
+  },
+  "option.scenario.drama": {
+    "message": "Короткая драма",
+    "description": "Short drama scenario option"
+  },
+  "option.scenario.general": {
+    "message": "Реальные кадры",
+    "description": "Footage piece scenario option"
+  },
+  "option.scenario.explainer": {
+    "message": "Объяснение",
+    "description": "Explainer scenario option"
+  },
+  "option.scenario.product": {
+    "message": "Промо продукта",
+    "description": "Product promo scenario option"
+  },
+  "option.scenario.website": {
+    "message": "Сайт в видео",
+    "description": "Website-to-video scenario option"
+  },
+  "option.scenario.slides": {
+    "message": "Слайд-шоу",
+    "description": "Slideshow scenario option"
+  },
+  "option.scenario.motion": {
+    "message": "Моушн-графика",
+    "description": "Motion graphics scenario option"
+  },
+  "option.scenario.changelog": {
+    "message": "Список изменений (PR)",
+    "description": "Changelog scenario option"
+  },
+  "option.scenario.captions": {
+    "message": "Добавить субтитры",
+    "description": "Add-captions scenario option"
   }
 }

--- a/src/i18n/sr/maestro.json
+++ b/src/i18n/sr/maestro.json
@@ -222,5 +222,53 @@
   "message.downloadVideo": {
     "message": "Preuzmi generisani video",
     "description": "Tooltip za preuzimanje"
+  },
+  "name.scenario": {
+    "message": "Тип видеа",
+    "description": "Video type field"
+  },
+  "description.scenario": {
+    "message": "Изаберите врсту видеа. „Аутоматски“ препушта Maestro-у да одлучи; или наметните стил као што су кратка драма, стварни снимци, објашњење или промоција производа.",
+    "description": "Scenario field help"
+  },
+  "option.scenario.auto": {
+    "message": "Аутоматски · нека одлучи Maestro",
+    "description": "Auto scenario option"
+  },
+  "option.scenario.drama": {
+    "message": "Кратка драма",
+    "description": "Short drama scenario option"
+  },
+  "option.scenario.general": {
+    "message": "Стварни снимци",
+    "description": "Footage piece scenario option"
+  },
+  "option.scenario.explainer": {
+    "message": "Објашњење",
+    "description": "Explainer scenario option"
+  },
+  "option.scenario.product": {
+    "message": "Промоција производа",
+    "description": "Product promo scenario option"
+  },
+  "option.scenario.website": {
+    "message": "Сајт у видео",
+    "description": "Website-to-video scenario option"
+  },
+  "option.scenario.slides": {
+    "message": "Приказ слајдова",
+    "description": "Slideshow scenario option"
+  },
+  "option.scenario.motion": {
+    "message": "Покретна графика",
+    "description": "Motion graphics scenario option"
+  },
+  "option.scenario.changelog": {
+    "message": "Списак измена (PR)",
+    "description": "Changelog scenario option"
+  },
+  "option.scenario.captions": {
+    "message": "Додај титлове",
+    "description": "Add-captions scenario option"
   }
 }

--- a/src/i18n/sv/maestro.json
+++ b/src/i18n/sv/maestro.json
@@ -222,5 +222,53 @@
   "message.downloadVideo": {
     "message": "Ladda ner den genererade videon",
     "description": "Nedladdningstips"
+  },
+  "name.scenario": {
+    "message": "Videotyp",
+    "description": "Video type field"
+  },
+  "description.scenario": {
+    "message": "Välj typ av video att skapa. Auto låter Maestro bestämma; eller tvinga en stil som kortdrama, verkligt filmmaterial, förklarande eller produktreklam.",
+    "description": "Scenario field help"
+  },
+  "option.scenario.auto": {
+    "message": "Auto · låt Maestro bestämma",
+    "description": "Auto scenario option"
+  },
+  "option.scenario.drama": {
+    "message": "Kortdrama",
+    "description": "Short drama scenario option"
+  },
+  "option.scenario.general": {
+    "message": "Verkligt filmmaterial",
+    "description": "Footage piece scenario option"
+  },
+  "option.scenario.explainer": {
+    "message": "Förklarande",
+    "description": "Explainer scenario option"
+  },
+  "option.scenario.product": {
+    "message": "Produktreklam",
+    "description": "Product promo scenario option"
+  },
+  "option.scenario.website": {
+    "message": "Webbplats till video",
+    "description": "Website-to-video scenario option"
+  },
+  "option.scenario.slides": {
+    "message": "Bildspel",
+    "description": "Slideshow scenario option"
+  },
+  "option.scenario.motion": {
+    "message": "Rörlig grafik",
+    "description": "Motion graphics scenario option"
+  },
+  "option.scenario.changelog": {
+    "message": "Ändringslogg (PR)",
+    "description": "Changelog scenario option"
+  },
+  "option.scenario.captions": {
+    "message": "Lägg till undertexter",
+    "description": "Add-captions scenario option"
   }
 }

--- a/src/i18n/uk/maestro.json
+++ b/src/i18n/uk/maestro.json
@@ -222,5 +222,53 @@
   "message.downloadVideo": {
     "message": "Завантажити згенероване відео",
     "description": "Підказка для завантаження"
+  },
+  "name.scenario": {
+    "message": "Тип відео",
+    "description": "Video type field"
+  },
+  "description.scenario": {
+    "message": "Виберіть тип відео. «Авто» дає змогу Maestro вирішити; або задайте стиль: коротка драма, реальні кадри, пояснення чи промо продукту.",
+    "description": "Scenario field help"
+  },
+  "option.scenario.auto": {
+    "message": "Авто · нехай вирішує Maestro",
+    "description": "Auto scenario option"
+  },
+  "option.scenario.drama": {
+    "message": "Коротка драма",
+    "description": "Short drama scenario option"
+  },
+  "option.scenario.general": {
+    "message": "Реальні кадри",
+    "description": "Footage piece scenario option"
+  },
+  "option.scenario.explainer": {
+    "message": "Пояснення",
+    "description": "Explainer scenario option"
+  },
+  "option.scenario.product": {
+    "message": "Промо продукту",
+    "description": "Product promo scenario option"
+  },
+  "option.scenario.website": {
+    "message": "Сайт у відео",
+    "description": "Website-to-video scenario option"
+  },
+  "option.scenario.slides": {
+    "message": "Слайд-шоу",
+    "description": "Slideshow scenario option"
+  },
+  "option.scenario.motion": {
+    "message": "Моушн-графіка",
+    "description": "Motion graphics scenario option"
+  },
+  "option.scenario.changelog": {
+    "message": "Журнал змін (PR)",
+    "description": "Changelog scenario option"
+  },
+  "option.scenario.captions": {
+    "message": "Додати субтитри",
+    "description": "Add-captions scenario option"
   }
 }

--- a/src/i18n/zh-CN/maestro.json
+++ b/src/i18n/zh-CN/maestro.json
@@ -162,5 +162,53 @@
   "message.noTasks": {
     "message": "还没有视频 — 在左侧创建你的第一个吧。",
     "description": "No tasks"
+  },
+  "name.scenario": {
+    "message": "视频类型",
+    "description": "Video type field"
+  },
+  "description.scenario": {
+    "message": "选择要制作的视频类型。自动让 Maestro 决定；也可指定短剧、图文实拍、概念讲解、产品推广等风格。",
+    "description": "Scenario field help"
+  },
+  "option.scenario.auto": {
+    "message": "自动 · 由 Maestro 决定",
+    "description": "Auto scenario option"
+  },
+  "option.scenario.drama": {
+    "message": "短剧",
+    "description": "Short drama scenario option"
+  },
+  "option.scenario.general": {
+    "message": "图文实拍成片",
+    "description": "Footage piece scenario option"
+  },
+  "option.scenario.explainer": {
+    "message": "概念讲解",
+    "description": "Explainer scenario option"
+  },
+  "option.scenario.product": {
+    "message": "产品推广",
+    "description": "Product promo scenario option"
+  },
+  "option.scenario.website": {
+    "message": "网站成片",
+    "description": "Website-to-video scenario option"
+  },
+  "option.scenario.slides": {
+    "message": "演示幻灯",
+    "description": "Slideshow scenario option"
+  },
+  "option.scenario.motion": {
+    "message": "动态图形",
+    "description": "Motion graphics scenario option"
+  },
+  "option.scenario.changelog": {
+    "message": "更新日志 (PR)",
+    "description": "Changelog scenario option"
+  },
+  "option.scenario.captions": {
+    "message": "视频加字幕",
+    "description": "Add-captions scenario option"
   }
 }

--- a/src/i18n/zh-TW/maestro.json
+++ b/src/i18n/zh-TW/maestro.json
@@ -222,5 +222,53 @@
   "message.downloadVideo": {
     "message": "下載生成的視頻",
     "description": "下載提示"
+  },
+  "name.scenario": {
+    "message": "影片類型",
+    "description": "Video type field"
+  },
+  "description.scenario": {
+    "message": "選擇要製作的影片類型。自動讓 Maestro 決定；也可指定短劇、圖文實拍、概念講解、產品推廣等風格。",
+    "description": "Scenario field help"
+  },
+  "option.scenario.auto": {
+    "message": "自動 · 由 Maestro 決定",
+    "description": "Auto scenario option"
+  },
+  "option.scenario.drama": {
+    "message": "短劇",
+    "description": "Short drama scenario option"
+  },
+  "option.scenario.general": {
+    "message": "圖文實拍成片",
+    "description": "Footage piece scenario option"
+  },
+  "option.scenario.explainer": {
+    "message": "概念講解",
+    "description": "Explainer scenario option"
+  },
+  "option.scenario.product": {
+    "message": "產品推廣",
+    "description": "Product promo scenario option"
+  },
+  "option.scenario.website": {
+    "message": "網站成片",
+    "description": "Website-to-video scenario option"
+  },
+  "option.scenario.slides": {
+    "message": "簡報投影片",
+    "description": "Slideshow scenario option"
+  },
+  "option.scenario.motion": {
+    "message": "動態圖形",
+    "description": "Motion graphics scenario option"
+  },
+  "option.scenario.changelog": {
+    "message": "更新日誌 (PR)",
+    "description": "Changelog scenario option"
+  },
+  "option.scenario.captions": {
+    "message": "影片加字幕",
+    "description": "Add-captions scenario option"
   }
 }

--- a/src/models/maestro.ts
+++ b/src/models/maestro.ts
@@ -9,6 +9,7 @@ export interface IMaestroConfig {
   aspect?: string; // '9:16' | '16:9' | '1:1'
   duration?: number;
   quality?: string; // 'draft' | 'standard' | 'premium'
+  scenario?: string; // 'auto' | 'drama' | 'general' | 'explainer' | 'product' | 'website' | 'slides' | 'motion' | 'changelog' | 'captions'
   callback_url?: string;
 }
 


### PR DESCRIPTION
## What

Adds a Maestro **Video Type** selector so callers can choose the production scenario sent as `scenario` in the `/maestro/videos` request.

Supported values match the worker/API contract:

`auto`, `drama`, `general`, `explainer`, `product`, `website`, `slides`, `motion`, `changelog`, `captions`.

`auto` remains the default, so existing behavior is unchanged unless the user chooses a specific scenario.

Companion PRs:
- PlatformService scenario router + video-factory gates: https://github.com/AceDataCloud/PlatformService/pull/1281
- PlatformBackend OpenAPI enum: https://github.com/AceDataCloud/PlatformBackend/pull/827

## Changes

- Adds `MAESTRO_ALLOWED_SCENARIOS` and `MAESTRO_DEFAULT_SCENARIO`.
- Adds `scenario?: string` to `IMaestroConfig` so the value is included in the generate payload.
- Adds a ConfigPanel `<el-select>` for video type, next to quality.
- Adds all new Maestro i18n keys across 18 locale files.
- Adds a Beachball minor change file.

## Validation

- `./node_modules/.bin/vue-tsc -b`
- `./node_modules/.bin/eslint src/components/maestro/ConfigPanel.vue src/constants/maestro.ts src/models/maestro.ts`
- `python3 scripts/check_i18n_coverage.py`
- `npm run verify`

## 🤖 对抗评审

Read-only review checked the UI → config → request path, default handling for old configs, `getConsumption` compatibility, i18n key coverage, and Beachball metadata.

Findings:
- `scenario` is included in `this.config` and passed to `maestroOperator.generate`.
- Missing legacy values default to `auto` in `mounted`, preserving existing behavior.
- `getConsumption(this.config, ...)` tolerates the extra field; scenario is billing-neutral unless future cost rules use it.
- All locale keys match the scenario enum.
- Beachball change file exists and `npm run verify` passes.

**VERDICT: CLEAN**
