### PR TITLE
fix(desktop): keep settings nav highlight in sync with the shown tab

### DIFF
--- a/change/@acedatacloud-nexior-settings-tab-desync.json
+++ b/change/@acedatacloud-nexior-settings-tab-desync.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix settings dialog: keep the left-nav highlight in sync with the shown tab and never render a blank content pane.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/user/Setting.vue
+++ b/src/components/user/Setting.vue
@@ -10,18 +10,19 @@
         <el-menu
           :class="['border-r-0 settings-menu', mobile ? 'is-mobile flex flex-row overflow-x-auto' : '']"
           :mode="mobile ? 'horizontal' : 'vertical'"
+          :default-active="currentTab"
         >
-          <!-- Render only the visible tabs. CSS-hiding (display:none) leaks
-               admin-only items into the horizontal el-menu ellipsis overflow
-               on mobile, exposing them to non-admins. -->
+          <!-- Render only the visible tabs; CSS-hiding leaks admin-only items
+               into the mobile el-menu overflow. Key by stable tab key (not the
+               array index) so el-menu can't reuse a stale item on set change. -->
           <el-menu-item
-            v-for="(item, index) in visibleNavItems"
-            :key="index"
+            v-for="item in visibleNavItems"
+            :key="item.key"
             :index="item.key"
             :class="[
               'items-center cursor-pointer',
               mobile ? 'flex-shrink-0 px-3 py-2 text-sm' : 'flex w-[180px] px-2 py-2',
-              activeTab === item.key ? 'active' : ''
+              currentTab === item.key ? 'active' : ''
             ]"
             @click="activeTab = item.key"
           >
@@ -31,37 +32,37 @@
         </el-menu>
       </aside>
       <main :class="['flex-1 overflow-y-auto', mobile ? 'p-4' : 'p-6']">
-        <div v-if="activeTab === SETTING_TAB_GENERAL">
+        <div v-if="currentTab === SETTING_TAB_GENERAL">
           <general-setting />
         </div>
-        <div v-else-if="activeTab === SETTING_TAB_API_KEY">
+        <div v-else-if="currentTab === SETTING_TAB_API_KEY">
           <byok-setting />
         </div>
-        <div v-else-if="activeTab === SETTING_TAB_SITE && isSiteConfigVisible">
+        <div v-else-if="currentTab === SETTING_TAB_SITE && isSiteConfigVisible">
           <site-setting />
         </div>
-        <div v-else-if="activeTab === SETTING_TAB_SEO && isSiteConfigVisible">
+        <div v-else-if="currentTab === SETTING_TAB_SEO && isSiteConfigVisible">
           <seo-setting />
         </div>
-        <div v-else-if="activeTab === SETTING_TAB_DISTRIBUTION && isSiteConfigVisible">
+        <div v-else-if="currentTab === SETTING_TAB_DISTRIBUTION && isSiteConfigVisible">
           <distribution-setting />
         </div>
-        <div v-else-if="activeTab === SETTING_TAB_FUNCTION && isSiteConfigVisible">
+        <div v-else-if="currentTab === SETTING_TAB_FUNCTION && isSiteConfigVisible">
           <function-setting />
         </div>
-        <div v-else-if="activeTab === SETTING_TAB_AUTH && isSiteConfigVisible">
+        <div v-else-if="currentTab === SETTING_TAB_AUTH && isSiteConfigVisible">
           <auth-setting />
         </div>
-        <div v-else-if="activeTab === SETTING_TAB_SUBSITES && isSubsitesVisible">
+        <div v-else-if="currentTab === SETTING_TAB_SUBSITES && isSubsitesVisible">
           <subsite-setting :auto-open-create="autoOpenCreateSubsite" />
         </div>
-        <div v-else-if="activeTab === SETTING_TAB_CUSTOM_DOMAIN && isCustomDomainVisible">
+        <div v-else-if="currentTab === SETTING_TAB_CUSTOM_DOMAIN && isCustomDomainVisible">
           <custom-domain-setting />
         </div>
-        <div v-else-if="activeTab === SETTING_TAB_LOCAL_TOOLS && isDesktopApp">
+        <div v-else-if="currentTab === SETTING_TAB_LOCAL_TOOLS && isDesktopApp">
           <local-tools-setting />
         </div>
-        <div v-else-if="activeTab === SETTING_TAB_ABOUT">
+        <div v-else-if="currentTab === SETTING_TAB_ABOUT">
           <about-setting @switch-tab="onSwitchTab" />
         </div>
       </main>
@@ -244,6 +245,12 @@ export default defineComponent({
     visibleNavItems(): Array<{ key: SettingTabKey; label: string; icon: typeof faCog; visible: boolean }> {
       return this.navItems.filter((item) => item.visible);
     },
+    // The tab actually rendered. Falls back to General when `activeTab` points
+    // at a tab that isn't currently visible (stale `initialTab`, or hidden by
+    // surface/permission) — otherwise the content pane would render BLANK.
+    currentTab(): SettingTabKey {
+      return this.visibleNavItems.some((item) => item.key === this.activeTab) ? this.activeTab : SETTING_TAB_GENERAL;
+    },
     isSiteAdmin(): boolean {
       return !!this.$store?.state?.site?.admins?.includes(this.$store.getters.user?.id);
     },
@@ -281,7 +288,7 @@ export default defineComponent({
       if (this.mobile) return '94vw';
       // BYOK and Subsites both render multi-column tables that don't fit
       // the default 50% dialog width on most laptops.
-      return this.activeTab === SETTING_TAB_API_KEY || this.activeTab === SETTING_TAB_SUBSITES ? '900px' : '50%';
+      return this.currentTab === SETTING_TAB_API_KEY || this.currentTab === SETTING_TAB_SUBSITES ? '900px' : '50%';
     }
   },
   watch: {


### PR DESCRIPTION
## What & why

The desktop Settings dialog had two user-reported bugs:

1. **Nav highlight desynced from content.** On reopen, the left nav highlighted one tab (e.g. **Local Tools**) while the content pane showed a different one (**General Settings** — theme/language/source). The content pane rendered from `activeTab`, but `el-menu` kept its **own** internal highlight on the last-clicked item; the `visible` watcher reset `activeTab` to General on open without touching el-menu's state, so the highlight lied.
2. **Blank content pane.** The content `v-if / v-else-if` chain had no fallback branch. When `activeTab` pointed at a tab that isn't currently visible (a stale `initial-tab`, or a tab hidden by surface/permission), **every** branch was false and the pane rendered empty.

## The fix

- Add a guarded `currentTab` computed that returns `activeTab` only when it's in the currently visible tab set, else falls back to `SETTING_TAB_GENERAL`.
- Drive **everything** from `currentTab`: the `el-menu` `:default-active`, the active-item CSS class, the content `v-if` chain, and the dialog width. One source of truth → highlight, content, and width can never disagree, and the pane is never blank.
- Element Plus `el-menu` `watch(() => props.defaultActive, …)` → `updateActiveIndex`, so binding `:default-active="currentTab"` keeps el-menu's **internal** active index (highlight + keyboard nav) in sync too — not just CSS.
- Key the nav `v-for` by the stable `item.key` instead of the array index, so el-menu can't reuse a stale item when the visible set changes.

Behavior after the fix: reopening Settings shows **General highlighted + General content** (honest), and clicking **Local Tools** shows **Local Tools highlighted + the Local Tools panel**. No persistence behavior was changed.

## Test plan

- `npx eslint src/components/user/Setting.vue` → clean
- `npx vue-tsc --noEmit -p tsconfig.app.json` → clean
- Manual (desktop build): open Settings → General shown & highlighted; click Local Tools → panel renders; close & reopen → resets to General, highlight matches; no blank pane.

## 🤖 对抗评审

Reviewer: independent read-only subagent (no `codex` on this host). One round, converged.

- **RISK [high]: does `el-menu` actually react to a changing `:default-active`? If it only reads it once, the highlight fix is a CSS band-aid and bug #1 still reproduces.**
  → **Verified & rebutted.** Read the installed source `node_modules/element-plus/es/components/menu/src/menu.mjs:215`:
  ```js
  watch(() => props.defaultActive, (currentActive) => {
    if (!items.value[currentActive]) { activeIndex.value = ""; }
    updateActiveIndex(currentActive);
  });
  ```
  el-menu watches `defaultActive` and updates its internal `activeIndex` (used for both the highlight and keyboard nav/focus). Binding `:default-active="currentTab"` fully syncs el-menu's internal state — not just CSS. Fix is complete.
- **RISK [med]: the per-branch `&& isSiteConfigVisible` checks are now technically unreachable, since `currentTab` already falls back when a tab isn't visible.**
  → **Rebutted (kept intentionally).** They're harmless defense-in-depth and removing them would expand the diff for no behavior change. `currentTab` is the primary guard; the secondary checks are a cheap second layer.
- **RISK [low]: CSS `active` class could mask a broken el-menu internal state.**
  → **Moot** given the high-risk rebuttal — el-menu's internal `activeIndex` follows `currentTab`, so there is no hidden broken state.

**VERDICT: CLEAN** after evidence-based rebuttal.
