### PR TITLE
fix(desktop): escape @ in Local Tools MCP hint so vue-i18n stops blanking the panel

### DIFF
--- a/change/@acedatacloud-nexior-localtools-i18n-blank.json
+++ b/change/@acedatacloud-nexior-localtools-i18n-blank.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(desktop): escape @ in Local Tools MCP hint so vue-i18n stops blanking the panel",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/e2e/local-tools.spec.ts
+++ b/e2e/local-tools.spec.ts
@@ -1,0 +1,140 @@
+import { test, expect, _electron as electron, type ElectronApplication, type Page } from '@playwright/test';
+import path from 'node:path';
+import os from 'node:os';
+import fs from 'node:fs';
+
+/**
+ * Local Tools settings panel E2E. Reproduces the "Local Tools tab is blank"
+ * report against the REAL Electron app (real preload bridge, real main-process
+ * config load, real Element Plus / i18n / font-awesome renderer).
+ *
+ * Each test launches the app with an ISOLATED `--user-data-dir` seeded with a
+ * realistic local-tools config (authorized root + full computer-use / builtin
+ * grants + `computerUse: true`) — matching the shape a real user accumulates.
+ * Isolating userData (a) avoids colliding with the single-instance lock of a
+ * running dev/installed app, and (b) makes the render deterministic.
+ *
+ * The panel is opened via the `open-user-settings` event (owned by the
+ * always-mounted UserCenter, so it works for guests — no login). Any renderer
+ * `pageerror` / `console.error` fails the test: a render-time crash (the
+ * classic Vue "blank subtree" failure) surfaces here.
+ *
+ * Run after `compile:electron` + `copy-renderer` so electron/dist/main.js and
+ * electron/renderer/ exist.
+ */
+const MAIN = path.join(__dirname, '..', 'electron', 'dist', 'main.js');
+
+// A config in the shape a real desktop user ends up with: one authorized root,
+// no MCP servers, computer-use enabled, and a full set of persistent grants
+// (per-action computer.* grants + tool-wide builtin grants + one input-scoped
+// fs grant). This is the data that must render without blanking.
+const SEED_CONFIG = {
+  roots: [path.join(os.tmpdir(), 'acedata-e2e-root')],
+  mcp: [],
+  grants: [
+    'fs.list_dir:{"path":"~/Desktop"}',
+    'computer.screenshot',
+    'computer.click',
+    'computer.move',
+    'computer.type',
+    'computer.key',
+    'computer.scroll',
+    'shell.run_command',
+    'fs.write_file',
+    'fs.list_dir',
+    'fs.read_file'
+  ],
+  computerUse: true
+};
+
+let app: ElectronApplication;
+let win: Page;
+let userDataDir: string;
+const errors: string[] = [];
+
+test.beforeEach(async () => {
+  errors.length = 0;
+  userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'acedata-e2e-'));
+  fs.writeFileSync(path.join(userDataDir, 'local-tools.json'), JSON.stringify(SEED_CONFIG, null, 2));
+
+  app = await electron.launch({ args: [MAIN, `--user-data-dir=${userDataDir}`] });
+  win = await app.firstWindow();
+  win.on('pageerror', (e) => errors.push(`pageerror: ${e.message}\n${e.stack ?? ''}`));
+  win.on('console', (m) => {
+    if (m.type() === 'error') errors.push(`console.error: ${m.text()}`);
+  });
+  await win.waitForLoadState('domcontentloaded');
+  await expect(win.locator('#app')).toBeAttached();
+});
+
+test.afterEach(async () => {
+  await app?.close();
+  try {
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+  } catch {
+    /* best-effort temp cleanup */
+  }
+});
+
+test('localExec.getConfig() returns a well-formed config (roots is an array)', async () => {
+  const cfg = await win.evaluate(async () => {
+    const bridge = (window as unknown as { localExec?: { getConfig: () => Promise<unknown> } }).localExec;
+    if (!bridge) return { __missing: true } as const;
+    return bridge.getConfig();
+  });
+
+  expect(cfg, 'localExec bridge should be exposed by preload').not.toHaveProperty('__missing');
+  // The renderer reads cfg.roots unguarded (`roots.length` in the template),
+  // so the main process MUST always hand back roots as an array — otherwise the
+  // panel crashes to blank.
+  expect(Array.isArray((cfg as { roots?: unknown }).roots), `roots must be an array, got: ${JSON.stringify(cfg)}`).toBe(
+    true
+  );
+});
+
+test('Local Tools settings tab renders content (not a blank pane)', async () => {
+  // The UserCenter (always mounted in the Main layout, guests included) owns the
+  // only <user-setting> dialog and opens it on this event. Dispatch repeatedly
+  // until the panel mounts, to absorb boot/listener-registration timing.
+  await expect
+    .poll(
+      async () => {
+        await win.evaluate(() =>
+          window.dispatchEvent(new CustomEvent('open-user-settings', { detail: { tab: 'localTools' } }))
+        );
+        return win.locator('.local-tools-setting').count();
+      },
+      { timeout: 20_000, intervals: [300, 500, 1000, 2000, 3000] }
+    )
+    .toBeGreaterThan(0);
+
+  const panel = win.locator('.local-tools-setting');
+  await expect(panel).toBeVisible();
+
+  // Give the async mounted() (getConfig + tool catalogs + grants) time to run,
+  // so a render crash triggered by the loaded data has a chance to fire.
+  await win.waitForTimeout(1500);
+
+  // Diagnostics: dump what actually rendered + any captured errors. Printed
+  // regardless so a blank pane is debuggable from CI logs.
+  const html = await panel.evaluate((el) => el.innerHTML).catch(() => '<panel detached>');
+  const sectionCount = await panel.locator('section').count();
+  const text = ((await panel.innerText().catch(() => '')) || '').trim();
+  // eslint-disable-next-line no-console
+  console.log(
+    `\n[local-tools] sections=${sectionCount} textLen=${text.length}\n` +
+      `[local-tools] errors:\n${errors.join('\n') || '(none)'}\n` +
+      `[local-tools] innerHTML (first 1200):\n${html.slice(0, 1200)}\n`
+  );
+
+  // "Not blank" = the desktop branch rendered its sections. On desktop at least
+  // the MCP + Computer Use sections always render (no v-if gate), each with an
+  // <h3> heading. A render crash (e.g. `roots` undefined) would blank the whole
+  // subtree, dropping these to zero.
+  await expect(panel.locator('section h3').first()).toBeVisible();
+  expect(sectionCount, 'panel should render at least one section').toBeGreaterThan(0);
+  expect(text.length, 'panel should not be visually empty').toBeGreaterThan(0);
+
+  // No render-time errors should have fired while opening the panel.
+  expect(errors, `renderer errors during Local Tools render:\n${errors.join('\n')}`).toEqual([]);
+});

--- a/src/components/setting/LocalTools.i18n.test.ts
+++ b/src/components/setting/LocalTools.i18n.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { createI18n } from 'vue-i18n';
+
+// Load every locale's `common` bundle exactly as it ships in the repo.
+const bundles = import.meta.glob('../../i18n/*/common.json', { eager: true }) as Record<
+  string,
+  { default: Record<string, { message?: string } | string> }
+>;
+
+const localeOf = (path: string) => path.replace(/.*\/i18n\/([^/]+)\/common\.json$/, '$1');
+
+const messageOf = (entry: { message?: string } | string): string =>
+  typeof entry === 'string' ? entry : (entry?.message ?? '');
+
+// The app runs vue-i18n in legacy mode; assert both modes so the test can't be a
+// false-negative relative to production.
+const LEGACY_MODES = [true, false] as const;
+
+// Regression guard for the "Local Tools panel is blank" bug: a bare `@` inside a
+// rendered translation makes vue-i18n's message compiler throw INVALID_LINKED_FORMAT
+// at render time, which the app's errorHandler swallows -> the whole panel renders
+// as an empty comment node. Every Local Tools string must compile without throwing.
+describe('Local Tools i18n messages compile (no blank-panel regression)', () => {
+  for (const [path, mod] of Object.entries(bundles)) {
+    const locale = localeOf(path);
+    const source = mod.default;
+    const localToolsKeys = Object.keys(source).filter((k) => k.startsWith('settings.localTools'));
+
+    it(`[${locale}] all settings.localTools* messages compile via vue-i18n`, () => {
+      expect(localToolsKeys.length).toBeGreaterThan(0);
+      const messages: Record<string, string> = {};
+      localToolsKeys.forEach((k, i) => (messages[`k${i}`] = messageOf(source[k])));
+      for (const legacy of LEGACY_MODES) {
+        const i18n: any = createI18n({ legacy, locale, messages: { [locale]: messages } });
+        localToolsKeys.forEach((k, i) => {
+          // Compilation happens on first `t()`; an unescaped control char throws here.
+          expect(() => i18n.global.t(`k${i}`), `message for "${k}" must compile (legacy=${legacy})`).not.toThrow();
+        });
+      }
+    });
+
+    it(`[${locale}] MCP platform hint renders a literal @modelcontextprotocol`, () => {
+      const raw = messageOf(source['settings.localToolsMcpPlatformHint']);
+      expect(raw, 'localToolsMcpPlatformHint must exist').toBeTruthy();
+      for (const legacy of LEGACY_MODES) {
+        const i18n: any = createI18n({ legacy, locale, messages: { [locale]: { hint: raw } } });
+        const rendered = i18n.global.t('hint');
+        // The escaped `{'@'}` must resolve back to a plain `@` in the example command.
+        expect(rendered).toContain('@modelcontextprotocol/server-filesystem');
+        expect(rendered).not.toContain("{'@'}");
+      }
+    });
+  }
+});

--- a/src/i18n/ar/common.json
+++ b/src/i18n/ar/common.json
@@ -1069,7 +1069,7 @@
     "description": "Badge when an MCP server failed to start; the reason is shown below."
   },
   "settings.localToolsMcpPlatformHint": {
-    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y @modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
+    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y {'@'}modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
     "description": "Cross-platform hint for configuring the MCP launch command."
   },
   "settings.localToolsSaved": {

--- a/src/i18n/de/common.json
+++ b/src/i18n/de/common.json
@@ -1069,7 +1069,7 @@
     "description": "Badge when an MCP server failed to start; the reason is shown below."
   },
   "settings.localToolsMcpPlatformHint": {
-    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y @modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
+    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y {'@'}modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
     "description": "Cross-platform hint for configuring the MCP launch command."
   },
   "settings.localToolsSaved": {

--- a/src/i18n/el/common.json
+++ b/src/i18n/el/common.json
@@ -1069,7 +1069,7 @@
     "description": "Badge when an MCP server failed to start; the reason is shown below."
   },
   "settings.localToolsMcpPlatformHint": {
-    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y @modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
+    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y {'@'}modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
     "description": "Cross-platform hint for configuring the MCP launch command."
   },
   "settings.localToolsSaved": {

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -1049,7 +1049,7 @@
     "description": "Badge when an MCP server failed to start; the reason is shown below."
   },
   "settings.localToolsMcpPlatformHint": {
-    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y @modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
+    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y {'@'}modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
     "description": "Cross-platform hint for configuring the MCP launch command."
   },
   "settings.localToolsSaved": {

--- a/src/i18n/es/common.json
+++ b/src/i18n/es/common.json
@@ -1069,7 +1069,7 @@
     "description": "Badge when an MCP server failed to start; the reason is shown below."
   },
   "settings.localToolsMcpPlatformHint": {
-    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y @modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
+    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y {'@'}modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
     "description": "Cross-platform hint for configuring the MCP launch command."
   },
   "settings.localToolsSaved": {

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -1069,7 +1069,7 @@
     "description": "Badge when an MCP server failed to start; the reason is shown below."
   },
   "settings.localToolsMcpPlatformHint": {
-    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y @modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
+    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y {'@'}modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
     "description": "Cross-platform hint for configuring the MCP launch command."
   },
   "settings.localToolsSaved": {

--- a/src/i18n/fr/common.json
+++ b/src/i18n/fr/common.json
@@ -1069,7 +1069,7 @@
     "description": "Badge when an MCP server failed to start; the reason is shown below."
   },
   "settings.localToolsMcpPlatformHint": {
-    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y @modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
+    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y {'@'}modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
     "description": "Cross-platform hint for configuring the MCP launch command."
   },
   "settings.localToolsSaved": {

--- a/src/i18n/it/common.json
+++ b/src/i18n/it/common.json
@@ -1069,7 +1069,7 @@
     "description": "Badge when an MCP server failed to start; the reason is shown below."
   },
   "settings.localToolsMcpPlatformHint": {
-    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y @modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
+    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y {'@'}modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
     "description": "Cross-platform hint for configuring the MCP launch command."
   },
   "settings.localToolsSaved": {

--- a/src/i18n/ja/common.json
+++ b/src/i18n/ja/common.json
@@ -1069,7 +1069,7 @@
     "description": "Badge when an MCP server failed to start; the reason is shown below."
   },
   "settings.localToolsMcpPlatformHint": {
-    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y @modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
+    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y {'@'}modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
     "description": "Cross-platform hint for configuring the MCP launch command."
   },
   "settings.localToolsSaved": {

--- a/src/i18n/ko/common.json
+++ b/src/i18n/ko/common.json
@@ -1069,7 +1069,7 @@
     "description": "Badge when an MCP server failed to start; the reason is shown below."
   },
   "settings.localToolsMcpPlatformHint": {
-    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y @modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
+    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y {'@'}modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
     "description": "Cross-platform hint for configuring the MCP launch command."
   },
   "settings.localToolsSaved": {

--- a/src/i18n/pl/common.json
+++ b/src/i18n/pl/common.json
@@ -1069,7 +1069,7 @@
     "description": "Badge when an MCP server failed to start; the reason is shown below."
   },
   "settings.localToolsMcpPlatformHint": {
-    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y @modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
+    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y {'@'}modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
     "description": "Cross-platform hint for configuring the MCP launch command."
   },
   "settings.localToolsSaved": {

--- a/src/i18n/pt/common.json
+++ b/src/i18n/pt/common.json
@@ -1069,7 +1069,7 @@
     "description": "Badge when an MCP server failed to start; the reason is shown below."
   },
   "settings.localToolsMcpPlatformHint": {
-    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y @modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
+    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y {'@'}modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
     "description": "Cross-platform hint for configuring the MCP launch command."
   },
   "settings.localToolsSaved": {

--- a/src/i18n/ru/common.json
+++ b/src/i18n/ru/common.json
@@ -1069,7 +1069,7 @@
     "description": "Badge when an MCP server failed to start; the reason is shown below."
   },
   "settings.localToolsMcpPlatformHint": {
-    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y @modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
+    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y {'@'}modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
     "description": "Cross-platform hint for configuring the MCP launch command."
   },
   "settings.localToolsSaved": {

--- a/src/i18n/sr/common.json
+++ b/src/i18n/sr/common.json
@@ -1069,7 +1069,7 @@
     "description": "Badge when an MCP server failed to start; the reason is shown below."
   },
   "settings.localToolsMcpPlatformHint": {
-    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y @modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
+    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y {'@'}modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
     "description": "Cross-platform hint for configuring the MCP launch command."
   },
   "settings.localToolsSaved": {

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -1069,7 +1069,7 @@
     "description": "Badge when an MCP server failed to start; the reason is shown below."
   },
   "settings.localToolsMcpPlatformHint": {
-    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y @modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
+    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y {'@'}modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
     "description": "Cross-platform hint for configuring the MCP launch command."
   },
   "settings.localToolsSaved": {

--- a/src/i18n/uk/common.json
+++ b/src/i18n/uk/common.json
@@ -1069,7 +1069,7 @@
     "description": "Badge when an MCP server failed to start; the reason is shown below."
   },
   "settings.localToolsMcpPlatformHint": {
-    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y @modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
+    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y {'@'}modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
     "description": "Cross-platform hint for configuring the MCP launch command."
   },
   "settings.localToolsSaved": {

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -1069,7 +1069,7 @@
     "description": "MCP 服务器启动失败时的标签；原因显示在下方。"
   },
   "settings.localToolsMcpPlatformHint": {
-    "message": "提示：使用 PATH 中的命令，如 npx 或 uvx（例如 npx -y @modelcontextprotocol/server-filesystem ~/Documents）。Windows 上 npx/node 会自动解析。若某服务器显示 “spawn … ENOENT”，请把命令改为完整路径。",
+    "message": "提示：使用 PATH 中的命令，如 npx 或 uvx（例如 npx -y {'@'}modelcontextprotocol/server-filesystem ~/Documents）。Windows 上 npx/node 会自动解析。若某服务器显示 “spawn … ENOENT”，请把命令改为完整路径。",
     "description": "配置 MCP 启动命令的跨平台提示。"
   },
   "settings.localToolsSaved": {

--- a/src/i18n/zh-TW/common.json
+++ b/src/i18n/zh-TW/common.json
@@ -1069,7 +1069,7 @@
     "description": "Badge when an MCP server failed to start; the reason is shown below."
   },
   "settings.localToolsMcpPlatformHint": {
-    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y @modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
+    "message": "Tip: use a command on your PATH such as npx or uvx (e.g. npx -y {'@'}modelcontextprotocol/server-filesystem ~/Documents). On Windows, npx/node resolve automatically. If a server shows \"spawn … ENOENT\", set the command to a full path.",
     "description": "Cross-platform hint for configuring the MCP launch command."
   },
   "settings.localToolsSaved": {


### PR DESCRIPTION
## What & why

The desktop **Local Tools** settings panel rendered **completely blank in every language**.

### Root cause (proven by runtime stderr logging)

The translation `settings.localToolsMcpPlatformHint` contained a **bare `@`** in its example command:

```
npx -y @modelcontextprotocol/server-filesystem ~/Documents
```

vue-i18n's `@intlify` message compiler parses a bare `@` as a **linked-message directive** (`@:key`) and throws `INVALID_LINKED_FORMAT` (runtime `SyntaxError` code `"10"`) **at render time**. The app's global `app.config.errorHandler` swallows the throw, so `<local-tools-setting/>` renders as an empty comment node → the whole panel is blank. The hint renders **unconditionally** on desktop, so the panel blanked in **all 18 locales**.

This is why the earlier highlight-sync fix (#1141) did not help — the bug was purely in the translated string, not the tab wiring.

### Fix

Escape the `@` using vue-i18n **literal interpolation** `{'@'}` in `settings.localToolsMcpPlatformHint` across **all 18 locale files**. The rendered output is still a literal `@modelcontextprotocol/server-filesystem`, so the useful example command is unchanged.

### Verification

- Rebuilt the desktop renderer and launched Electron with `ELECTRON_ENABLE_LOGGING=1`, hooking `app.config.errorHandler` to surface swallowed render errors. Result after the fix: **`panel? true, sections 5, h3count 5`** on every probe and **zero render errors** (before: `panel` present but `sections 0` / `SyntaxError: 10`).
- New regression test `src/components/setting/LocalTools.i18n.test.ts` loads all 18 locales' `common.json`, compiles every `settings.localTools*` message through a real `createI18n` in **both `legacy: true` (the app's mode) and `legacy: false`**, and asserts no throw + the hint renders a literal `@modelcontextprotocol/server-filesystem`. **36 tests pass.** (Reverting the escape makes this test fail.)
- Kept `e2e/local-tools.spec.ts` (Playwright Electron) as the CI end-to-end guard.
- Removed a stale red-herring test (`LocalTools.repro.test.ts`) that mocked `$t` and never compiled real strings — it could never have caught this bug.

`eslint` + `vue-tsc --noEmit` clean. Full `vitest` suite: **231 assertions pass**; the only 2 failing files are pre-existing jsdom-`localStorage` env failures in `src/store/codingBridge/` (fail in isolation on `main`, unrelated to this change).

> Note: `common.about.email` (`office@acedata.cloud`) also contains a bare `@`, but it is **not** referenced by any `$t()` in Nexior, so it is never compiled and never throws — left out of scope.

## 🤖 对抗评审

Reviewer: read-only subagent (Codex not installed on this host). One round.

- **RISK (raised): test used `legacy: false` while the app runs `legacy: true` → potential false-negative.**
  **Fixed**, not rebutted: the regression test now runs every assertion under **both** legacy modes (`LEGACY_MODES = [true, false]`), so it faithfully matches production. Re-verified: 36/36 pass.
- Verified clean: escape syntax is valid JSON and the officially-documented vue-i18n literal-interpolation form; applied uniformly to all 18 locales (18/18); no other unescaped `@`/`|`/`{`/`}` in any `settings.localTools*` message; component renders the hint via a plain `{{ $t(...) }}`; deleting the mocked repro test loses no real coverage.

**VERDICT: CLEAN**
