### PR TITLE
polish(desktop): align Local Tools MCP server fields into a form grid

### DIFF
--- a/change/@acedatacloud-nexior-localtools-mcp-grid.json
+++ b/change/@acedatacloud-nexior-localtools-mcp-grid.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "polish(desktop): align Local Tools MCP server fields into a form grid",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/setting/LocalTools.vue
+++ b/src/components/setting/LocalTools.vue
@@ -88,30 +88,26 @@
                   {{ $t('common.settings.localToolsRemove') }}
                 </el-button>
               </div>
-              <el-input v-model="m.id" size="small" :placeholder="$t('common.settings.localToolsMcpNamePlaceholder')">
-                <template #prepend>{{ $t('common.settings.localToolsMcpName') }}</template>
-              </el-input>
-              <el-input
-                v-model="m.command"
-                size="small"
-                :placeholder="$t('common.settings.localToolsMcpCommandPlaceholder')"
-              >
-                <template #prepend>{{ $t('common.settings.localToolsMcpCommand') }}</template>
-              </el-input>
-              <label class="mcp-label">{{ $t('common.settings.localToolsMcpArgs') }}</label>
-              <el-input
-                v-model="m.argsText"
-                type="textarea"
-                :rows="2"
-                :placeholder="$t('common.settings.localToolsMcpArgsHint')"
-              />
-              <label class="mcp-label">{{ $t('common.settings.localToolsMcpEnv') }}</label>
-              <el-input
-                v-model="m.envText"
-                type="textarea"
-                :rows="2"
-                :placeholder="$t('common.settings.localToolsMcpEnvHint')"
-              />
+              <div class="mcp-grid">
+                <label class="mcp-flabel">{{ $t('common.settings.localToolsMcpName') }}</label>
+                <el-input v-model="m.id" :placeholder="$t('common.settings.localToolsMcpNamePlaceholder')" />
+                <label class="mcp-flabel">{{ $t('common.settings.localToolsMcpCommand') }}</label>
+                <el-input v-model="m.command" :placeholder="$t('common.settings.localToolsMcpCommandPlaceholder')" />
+                <label class="mcp-flabel top">{{ $t('common.settings.localToolsMcpArgs') }}</label>
+                <el-input
+                  v-model="m.argsText"
+                  type="textarea"
+                  :rows="2"
+                  :placeholder="$t('common.settings.localToolsMcpArgsHint')"
+                />
+                <label class="mcp-flabel top">{{ $t('common.settings.localToolsMcpEnv') }}</label>
+                <el-input
+                  v-model="m.envText"
+                  type="textarea"
+                  :rows="2"
+                  :placeholder="$t('common.settings.localToolsMcpEnvHint')"
+                />
+              </div>
               <p v-if="mcpErrorFor(m.id)" class="mcp-row-error">{{ mcpErrorFor(m.id) }}</p>
             </div>
           </li>
@@ -717,13 +713,32 @@ export default defineComponent({
 }
 .mcp-row {
   align-items: flex-start;
+  padding: 16px;
+  background: var(--el-fill-color-lighter, #fafafa);
 }
 .mcp-fields {
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 14px;
   min-width: 0;
+}
+.mcp-grid {
+  display: grid;
+  grid-template-columns: 100px minmax(0, 1fr);
+  gap: 10px 12px;
+  align-items: center;
+}
+.mcp-flabel {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--el-text-color-secondary, #909399);
+  text-align: right;
+  overflow-wrap: anywhere;
+}
+.mcp-flabel.top {
+  align-self: start;
+  padding-top: 8px;
 }
 .mcp-head {
   display: flex;
@@ -740,12 +755,8 @@ export default defineComponent({
   word-break: break-word;
 }
 .mcp-platform-hint {
-  margin-top: 8px;
-}
-.mcp-label {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--el-text-color-secondary, #909399);
+  margin-top: 4px;
+  line-height: 1.5;
 }
 .mcp-error {
   color: var(--el-color-danger, #f56c6c);


### PR DESCRIPTION
## What

Polish the desktop **Local Tools → MCP servers** editor. The per-server fields were cramped (`size="small"` inputs, misaligned prepend labels, "衔接不上"). This aligns them into a proper two-column form grid.

### Changes (`src/components/setting/LocalTools.vue` only)
- Replace the four stacked `size="small"` inputs + `#prepend` labels with a `.mcp-grid` (`grid-template-columns: 100px minmax(0,1fr)`): right-aligned `.mcp-flabel` labels paired with **default-size** inputs for Name / Command / Args / Env.
- Textarea rows use `.mcp-flabel.top` (top-aligned label).
- Give each server card a subtle background + padding (`.mcp-row { padding:16px; background: var(--el-fill-color-lighter) }`) so rows read as distinct cards.
- Remove the now-dead `.mcp-label` CSS rule.

No behavior/logic change — pure template + scoped CSS. Same i18n keys (`common.settings.localToolsMcp*`).

## Verification (live, in-app)

Built the renderer and launched the Electron app against an isolated profile seeded with a real `@playwright/mcp` server. A runtime probe hooked `app.config.errorHandler`, opened the panel, and read `window.localExec.mcp.status()`:

```
panel? true   grids 1   flabels 4   badge "Connected · 23 tools"
status [{"id":"playwright","status":"connected","toolCount":23, ...23 browser_* tools}]
```

- ✅ Panel renders (no blank), new grid + 4 labels present.
- ✅ No `REAL_ERR` (Vue errorHandler stayed silent).
- ✅ The Playwright MCP server connects end-to-end and the badge shows **Connected · 23 tools**.
- ✅ `npx eslint` clean, `vue-tsc` clean (via `build:electron`).

## 🤖 对抗评审

Read-only reviewer (Claude `Explore` subagent — no Codex on host) audited the diff for dead selectors, style scope leakage, i18n key drift, grid pairing, template correctness, and label overflow.

| # | Severity | Finding | Resolution |
|---|----------|---------|------------|
| 1 | **RISK** | `.mcp-flabel` had `white-space: nowrap` in a fixed 96px column → a long translated label (e.g. German "Umgebungsvariablen") could silently overflow into the input column. | **Fixed** — column widened to `100px`, `nowrap` replaced with `overflow-wrap: anywhere` so long labels **wrap** (never clip; ellipsis was rejected because it would hide the label text). |
| 2 | nit | Inputs are now default-size while the header row controls stay `size="small"`, a slight height mismatch. | **Rebutted** — default-size inputs are the explicit ask ("有的输入框太小了"); the header controls are compact action buttons/switch/tag by design, which is a standard Element Plus pattern. |

Verified CLEAN: no `.mcp-label` references remain, `<style scoped>` (no leakage), all four `localToolsMcp*` keys exist across all 18 locales, grid label↔input pairing order correct, template well-formed (`mcpErrorFor` `<p>` sits outside the grid but inside the row).
