### PR TITLE
fix(openaiimage): remove step-strictly from custom size inputs

### DIFF
--- a/src/components/openaiimage/config/ResolutionSelector.vue
+++ b/src/components/openaiimage/config/ResolutionSelector.vue
@@ -38,7 +38,6 @@
             :min="minSide"
             :max="maxSide"
             :step="multiple"
-            :step-strictly="true"
             controls-position="right"
           />
         </div>
@@ -50,7 +49,6 @@
             :min="minSide"
             :max="maxSide"
             :step="multiple"
-            :step-strictly="true"
             controls-position="right"
           />
         </div>


### PR DESCRIPTION
## Problem

用户反馈自定义尺寸输入框输入值后会自动变化（输入之后他会变）。

## Root Cause

`el-input-number` 设置了 `:step-strictly="true"`，当用户输入的值不是 16 的精确倍数时，组件在失焦时会自动修正（四舍五入）到最近的 16 倍数值，导致用户看到输入值被篡改。

## Fix

移除 `step-strictly` 属性。用户可以自由输入任意值：
- 如果值不是 16 的倍数，已有的 `customError` 验证逻辑会显示错误提示
- 点击上下箭头按钮仍然按 16 递增/递减
- 不再自动修改用户的输入值