### PR TITLE
fix(desktop): strip UTF-8 BOM when loading local-tools.json

### DIFF
--- a/change/@acedatacloud-nexior-localtools-config-bom.json
+++ b/change/@acedatacloud-nexior-localtools-config-bom.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(desktop): strip UTF-8 BOM when loading local-tools.json so an externally-edited config no longer silently wipes roots/MCP servers/grants",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/electron/local/config.test.ts
+++ b/electron/local/config.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// config.ts reads `app.getPath('userData')`; point it at a per-test temp dir.
+const state = vi.hoisted(() => ({ userData: '' }));
+vi.mock('electron', () => ({ app: { getPath: () => state.userData } }));
+
+import { load } from './config';
+
+describe('local-tools config load', () => {
+  const dirs: string[] = [];
+  function tmpUserData(): string {
+    const d = mkdtempSync(path.join(os.tmpdir(), 'nx-cfg-'));
+    dirs.push(d);
+    state.userData = d;
+    return d;
+  }
+  afterEach(() => {
+    for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+  });
+
+  const CFG = {
+    roots: ['/tmp/a'],
+    mcp: [{ id: 'playwright', command: 'npx', args: ['-y', '@playwright/mcp@latest'], enabled: true }],
+    grants: ['shell.run_command'],
+    computerUse: true
+  };
+
+  it('parses a normal (BOM-less) config file', () => {
+    const d = tmpUserData();
+    writeFileSync(path.join(d, 'local-tools.json'), JSON.stringify(CFG));
+    const c = load();
+    expect(c.roots).toEqual(['/tmp/a']);
+    expect(c.mcp).toHaveLength(1);
+    expect(c.grants).toEqual(['shell.run_command']);
+    expect(c.computerUse).toBe(true);
+  });
+
+  // Regression: an externally-edited config (e.g. saved by Notepad) can carry a
+  // UTF-8 BOM. Before the fix, JSON.parse threw and load() silently returned
+  // empty defaults — wiping every root, MCP server and grant from the UI.
+  it('parses a config file that begins with a UTF-8 BOM', () => {
+    const d = tmpUserData();
+    writeFileSync(path.join(d, 'local-tools.json'), '\uFEFF' + JSON.stringify(CFG));
+    const c = load();
+    expect(c.mcp).toHaveLength(1);
+    expect(c.mcp[0].id).toBe('playwright');
+    expect(c.roots).toEqual(['/tmp/a']);
+    expect(c.grants).toEqual(['shell.run_command']);
+    expect(c.computerUse).toBe(true);
+  });
+
+  it('returns safe defaults when the file is missing or malformed', () => {
+    const d = tmpUserData();
+    // no file written
+    expect(load()).toEqual({ roots: [], mcp: [], grants: [], computerUse: false });
+    writeFileSync(path.join(d, 'local-tools.json'), '{ not json');
+    expect(load()).toEqual({ roots: [], mcp: [], grants: [], computerUse: false });
+  });
+});

--- a/electron/local/config.ts
+++ b/electron/local/config.ts
@@ -9,7 +9,11 @@ const file = (): string => path.join(app.getPath('userData'), 'local-tools.json'
 
 export function load(): LocalConfig {
   try {
-    const c = JSON.parse(fs.readFileSync(file(), 'utf8')) as Partial<LocalConfig>;
+    // Strip a leading UTF-8 BOM: an externally-edited config (e.g. saved by
+    // Notepad) would otherwise make JSON.parse throw and silently wipe every
+    // authorized root, MCP server and grant.
+    const raw = fs.readFileSync(file(), 'utf8').replace(/^\uFEFF/, '');
+    const c = JSON.parse(raw) as Partial<LocalConfig>;
     return { roots: c.roots ?? [], mcp: c.mcp ?? [], grants: c.grants ?? [], computerUse: c.computerUse ?? false };
   } catch {
     return { roots: [], mcp: [], grants: [], computerUse: false };


### PR DESCRIPTION
## What

Fix a latent config-loss bug in the desktop **Local Tools** feature.

`electron/local/config.ts` `load()` did `JSON.parse(readFileSync(file, 'utf8'))`. If `local-tools.json` ever begins with a **UTF-8 BOM** (e.g. the user opens/saves it in Notepad, or a script writes it with a BOM), `JSON.parse` throws on the leading `\uFEFF`, the `catch` returns empty defaults, and the app **silently wipes every authorized root, MCP server and grant** from the UI (the panel shows "No MCP servers configured" even though the file is intact on disk).

### Change
- `load()` strips a single leading BOM before parsing: `.replace(/^\uFEFF/, '')`. Read encoding stays `utf8`; `save()` already writes BOM-less `JSON.stringify`, so round-trips remain clean. Read-side only — `ipc.ts` is the only other consumer and it goes through `load()`.
- New `electron/local/config.test.ts` (vitest): mocks `electron` (`app.getPath`) to a temp dir and asserts (a) a normal config parses, (b) a **BOM-prefixed** config parses (regression), (c) missing/malformed file still returns safe defaults.

## How this was found + validated

While demonstrating the Playwright MCP server live in the app, the MCP list rendered blank once — traced to the seed file being written with a BOM by Windows PowerShell 5.1. That surfaced the real bug.

**Live E2E through the app's real invoke path** (`window.localExec.invoke` → consent → `registry.invoke` → `McpHost.call` → `tools/call`), consent pre-authorized via a tool-wide grant:

```
status connected tools 23
NAV  is_error=false  →  await page.goto('https://example.com')
      Page URL: https://example.com/   Page Title: Example Domain
SNAP is_error=false  →  heading "Example Domain" [level=1]
      paragraph "This domain is for use in documentation examples…"
      link "Learn more" → https://iana.org/domains/example
```

i.e. the desktop app launched Playwright (headless Chrome), navigated to a real site, and read back its content — proving the local MCP tool-call path works end to end.

- ✅ `vitest` config tests: 3/3 pass (BOM regression + defaults).
- ✅ `compile:electron` (tsc) clean.

## 🤖 对抗评审

Read-only reviewer (Claude `Explore` subagent — no Codex on host) audited the diff for BOM-strip correctness, other unguarded readers, test soundness (`vi.hoisted` + `vi.mock` TDZ / cleanup), and type safety.

| # | Severity | Finding | Resolution |
|---|----------|---------|------------|
| 1 | nit | The BOM regression test asserted `roots`/`mcp`/`grants` but not `computerUse`. | **Fixed** — added `expect(c.computerUse).toBe(true)` to the BOM case. |

Verified CLEAN: `/^\uFEFF/` strips only a single leading BOM at index 0; `save()` emits no BOM (round-trips stay clean); `config.ts` is the sole parser of `local-tools.json` (`ipc.ts` calls `load()`); the `vi.hoisted` mock reads the mutable temp path lazily (no TDZ) and `afterEach` cleans temp dirs; no type regression. **VERDICT: CLEAN.**
