### PR TITLE
feat(maestro): show Task ID (+ Trace ID) while a video is still producing

### DIFF
--- a/change/@acedatacloud-nexior-maestro-inprogress-taskid.json
+++ b/change/@acedatacloud-nexior-maestro-inprogress-taskid.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(maestro): show Task ID (+ Trace ID) while a video is still producing",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/maestro/task/Preview.vue
+++ b/src/components/maestro/task/Preview.vue
@@ -20,10 +20,20 @@
         </p>
       </div>
 
-      <!-- in-progress: live stage + percentage -->
-      <div v-if="!isTerminal && progressMessage" class="content">
-        <p class="text-xs text-[var(--el-text-color-secondary)] mb-1">{{ progressMessage }}</p>
+      <!-- in-progress: task id (+ trace id) + live stage + percentage -->
+      <div v-if="!isTerminal" class="content">
+        <p v-if="progressMessage" class="text-xs text-[var(--el-text-color-secondary)] mb-1">{{ progressMessage }}</p>
         <el-progress v-if="progressPct !== undefined" :percentage="progressPct" :stroke-width="6" />
+        <p class="text-[var(--el-text-color-regular)] text-xs mb-1 mt-2">
+          <font-awesome-icon icon="fa-solid fa-magic" class="mr-1" />
+          {{ $t('maestro.name.taskId') }}: {{ modelValue?.id }}
+          <copy-to-clipboard :content="modelValue?.id!" />
+        </p>
+        <p v-if="modelValue?.response?.trace_id" class="text-[var(--el-text-color-regular)] text-xs mb-0">
+          <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />
+          {{ $t('maestro.name.traceId') }}: {{ modelValue?.response?.trace_id }}
+          <copy-to-clipboard :content="modelValue?.response?.trace_id" />
+        </p>
       </div>
 
       <!-- success: one player per language variant -->


### PR DESCRIPTION
## What

Show the **Task ID** (and Trace ID when present) on a maestro task **while it's still producing** — not only after it succeeds/fails.

## Why

The success and failure states already render `Task ID: …` (with copy), but the **in-progress** block showed only the stage message + progress bar. So during the (long) production run there was no id to copy for tracing/support — unlike the other scenarios (veo / seedance / wan / openaiimage), which surface the id/trace for pending tasks too.

## Change (`src/components/maestro/task/Preview.vue`, template only)

- The in-progress wrapper is relaxed from `v-if="!isTerminal && progressMessage"` to `v-if="!isTerminal"` (so a freshly-`pending` task with no stage message yet still shows its id); the stage line is now individually `v-if="progressMessage"`.
- Added, styled identically to the success/failure blocks:
  - `Task ID: {{ modelValue?.id }}` + `<copy-to-clipboard>` (always, in-progress).
  - `Trace ID: {{ modelValue?.response?.trace_id }}` + copy, `v-if` the trace id is present (matches the veo/seedance pattern; maestro's response only carries it for gateway-created tasks).

No model/i18n changes needed — `IMaestroTask.response.trace_id` already exists, and `maestro.name.taskId` / `name.traceId` are already defined in every locale.

## Verify

Language server: no errors. Prettier: clean.

## 🤖 对抗评审

Trivial, template-only UI addition reusing existing patterns/i18n. Self-reviewed: no overlap with the success (`success===true`) / failure (`success===false`) blocks (in-progress is `!isTerminal`); bindings copied verbatim from working code (maestro success block for `id`, veo for `trace_id`); relaxed wrapper never renders empty (the id line is unconditional). **VERDICT: CLEAN.**
