### PR TITLE
fix(desktop): resilient local MCP boot (longer init timeout + background retry)

### DIFF
--- a/change/@acedatacloud-nexior-mcp-boot-retry.json
+++ b/change/@acedatacloud-nexior-mcp-boot-retry.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(desktop): make local MCP boot resilient on slow machines — longer initialize timeout + background retry so a cold-start server (e.g. playwright) self-heals instead of stranding as failed",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/electron/local/mcp.ts
+++ b/electron/local/mcp.ts
@@ -4,6 +4,11 @@ import type { McpServerConf, ToolSpec, ToolResult } from './types';
 
 const execFileAsync = promisify(execFile);
 const RPC_TIMEOUT_MS = 30_000;
+// The initial `initialize` handshake gets a longer budget than a mid-turn call:
+// a cold MCP server (e.g. `node …/@playwright/mcp` loading playwright-core) on a
+// slow machine can take far longer than RPC_TIMEOUT_MS just to boot Node + its
+// deps before it answers — a first-boot timeout would strand it as `failed`.
+const STARTUP_TIMEOUT_MS = 60_000;
 
 interface Pending { resolve: (v: unknown) => void; reject: (e: Error) => void; timer: NodeJS.Timeout; }
 
@@ -103,7 +108,7 @@ export class McpHost {
     });
     try {
       await Promise.race([
-        this.rpc(c.id, 'initialize', { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'nexior', version: '1' } }),
+        this.rpc(c.id, 'initialize', { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'nexior', version: '1' } }, STARTUP_TIMEOUT_MS),
         spawnError
       ]);
     } catch (e) {
@@ -114,13 +119,13 @@ export class McpHost {
     }
   }
 
-  private rpc(server: string, method: string, params: unknown): Promise<unknown> {
+  private rpc(server: string, method: string, params: unknown, timeoutMs: number = RPC_TIMEOUT_MS): Promise<unknown> {
     const proc = this.procs.get(server);
     if (!proc?.stdin) return Promise.reject(new Error(`mcp ${server} not running`));
     const id = ++this.seq;
     proc.stdin.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n');
     return new Promise((resolve, reject) => {
-      const timer = setTimeout(() => { this.pending.delete(id); reject(new Error('mcp rpc timeout')); }, RPC_TIMEOUT_MS);
+      const timer = setTimeout(() => { this.pending.delete(id); reject(new Error('mcp rpc timeout')); }, timeoutMs);
       this.pending.set(id, { resolve, reject, timer });
     });
   }

--- a/electron/local/registry.test.ts
+++ b/electron/local/registry.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Registry } from './registry';
+import type { McpHost } from './mcp';
+import type { McpServerConf, ToolSpec } from './types';
+
+// Minimal stand-in for McpHost: `start()` fails the first `failTimes` calls
+// (simulating a slow cold start that blows the initialize budget), then
+// succeeds. Cast to McpHost at the injection site — the concrete class has
+// private fields so it's nominal, but Registry only uses these public methods.
+class FakeHost {
+  startCalls = 0;
+  stopCalls = 0;
+  constructor(private failTimes = 0) {}
+  async start(_c: McpServerConf): Promise<void> {
+    this.startCalls++;
+    if (this.startCalls <= this.failTimes) throw new Error('mcp rpc timeout');
+  }
+  async listTools(server: string): Promise<ToolSpec[]> {
+    return [{ name: `mcp.${server}.tool1`, description: '', input_schema: {}, source: 'mcp', mutates: true }];
+  }
+  stop(): void {
+    this.stopCalls++;
+  }
+  stopAll(): void {}
+  async call(): Promise<{ output: string; is_error: boolean }> {
+    return { output: '', is_error: false };
+  }
+}
+
+const server = (over: Partial<McpServerConf> = {}): McpServerConf => ({ id: 'pw', command: 'x', args: [], enabled: true, ...over });
+const mk = (host: FakeHost, retries = 3, delayMs = 5) => new Registry(host as unknown as McpHost, retries, delayMs);
+
+describe('Registry MCP boot', () => {
+  it('connects on first boot and advertises the server tools', async () => {
+    const reg = mk(new FakeHost(0));
+    await reg.boot([server()]);
+    expect(reg.mcpStatus()).toEqual([{ id: 'pw', status: 'connected', toolCount: 1, tools: ['mcp.pw.tool1'] }]);
+    expect(reg.specs().some((s) => s.name === 'mcp.pw.tool1')).toBe(true);
+  });
+
+  it('marks a disabled server disabled without spawning it', async () => {
+    const host = new FakeHost(0);
+    const reg = mk(host);
+    await reg.boot([server({ enabled: false })]);
+    expect(reg.mcpStatus()).toEqual([{ id: 'pw', status: 'disabled', toolCount: 0, tools: [] }]);
+    expect(host.startCalls).toBe(0);
+  });
+
+  it('dedupes concurrent connects for the same id (no double-spawn)', async () => {
+    const host = new FakeHost(0);
+    const reg = mk(host);
+    // Two overlapping boots (mirrors a background retry racing a user reconnect)
+    // must share one spawn, not orphan a second child process.
+    await Promise.all([reg.boot([server()]), reg.boot([server()])]);
+    expect(host.startCalls).toBe(1);
+    expect(reg.mcpStatus()[0].status).toBe('connected');
+    // Exactly one tool spec, not duplicated.
+    expect(reg.specs().filter((s) => s.name === 'mcp.pw.tool1')).toHaveLength(1);
+  });
+
+  it('retries a failed first connect in the background until it succeeds', async () => {
+    const reg = mk(new FakeHost(2)); // fail twice, connect on the 3rd start
+    await reg.boot([server()]);
+    expect(reg.mcpStatus()[0].status).toBe('failed'); // initial attempt failed
+    await vi.waitFor(
+      () => {
+        expect(reg.mcpStatus().find((s) => s.id === 'pw')?.status).toBe('connected');
+      },
+      { timeout: 1000 }
+    );
+    expect(reg.specs().some((s) => s.name === 'mcp.pw.tool1')).toBe(true);
+  });
+
+  it('gives up after the retry budget and stays failed', async () => {
+    const host = new FakeHost(99); // never connects
+    const reg = mk(host, 2, 5); // initial + 2 retries = 3 start attempts
+    await reg.boot([server()]);
+    await new Promise((r) => setTimeout(r, 80));
+    expect(reg.mcpStatus()[0].status).toBe('failed');
+    expect(host.startCalls).toBe(3);
+  });
+
+  it('drops pending retries once a reboot supersedes the config', async () => {
+    const host = new FakeHost(99); // always fail → would keep scheduling retries
+    const reg = mk(host, 5, 10);
+    await reg.boot([server()]);
+    const afterBoot = host.startCalls; // 1
+    await reg.reboot([]); // new generation, no servers
+    await new Promise((r) => setTimeout(r, 60)); // let any stale retry fire
+    expect(host.startCalls).toBeLessThanOrEqual(afterBoot + 1); // stale retries dropped
+    expect(reg.mcpStatus()).toEqual([]);
+  });
+});

--- a/electron/local/registry.ts
+++ b/electron/local/registry.ts
@@ -31,8 +31,13 @@ function isComputerTool(name: string): boolean {
   return name.startsWith('computer.');
 }
 
-class Registry {
-  private host = new McpHost();
+// A first connect can fail on a slow machine (the MCP server exceeds its
+// `initialize` budget). Rather than strand it as `failed` until the user
+// manually clicks Test/Reconnect, retry a few times in the background.
+const MCP_BOOT_RETRIES = 3;
+const MCP_BOOT_RETRY_DELAY_MS = 5_000;
+
+export class Registry {
   private mcpSpecs: ToolSpec[] = [];
   private names = new Set([...BUILTIN, ...COMPUTER_TOOLS].map((s) => s.name));
   // Per-server connection status (id -> status), surfaced in Settings.
@@ -41,6 +46,20 @@ class Registry {
   // from Settings → Local Tools. While off, the tools are neither advertised nor
   // invokable.
   private computerUse = false;
+  // Bumped on every reboot() so a background retry scheduled against an OLD
+  // config is dropped instead of resurrecting a server the user just changed.
+  private generation = 0;
+  // In-flight connect per id. A second caller (background retry racing a user
+  // reconnect) shares the SAME promise instead of spawning a second child, and
+  // gets the real result — not a stale `false`. Cleared via `.finally`.
+  private connecting = new Map<string, Promise<boolean>>();
+
+  // `host` + retry knobs are injectable for tests; production uses the defaults.
+  constructor(
+    private host: McpHost = new McpHost(),
+    private retries = MCP_BOOT_RETRIES,
+    private retryDelayMs = MCP_BOOT_RETRY_DELAY_MS
+  ) {}
 
   setComputerUse(on: boolean): void {
     this.computerUse = on === true;
@@ -72,23 +91,68 @@ class Registry {
   }
 
   async boot(servers: McpServerConf[]): Promise<void> {
+    const gen = this.generation;
     for (const s of servers) {
       if (s.enabled === false) {
         this.mcpStatuses.set(s.id, { id: s.id, status: 'disabled', toolCount: 0, tools: [] });
         continue;
       }
-      try {
-        await this.host.start(s);
-        const tools = await this.host.listTools(s.id);
-        this.mcpSpecs.push(...tools);
-        tools.forEach((t) => this.names.add(t.name));
-        this.mcpStatuses.set(s.id, { id: s.id, status: 'connected', toolCount: tools.length, tools: tools.map((t) => t.name) });
-      } catch (e) {
-        // Record the reason so Settings can show it instead of failing silently.
-        this.host.stop(s.id);
-        this.mcpStatuses.set(s.id, { id: s.id, status: 'failed', toolCount: 0, tools: [], error: e instanceof Error ? e.message : String(e) });
-      }
+      const ok = await this.connectServer(s);
+      // A failed first connect (e.g. a slow cold start that blew the startup
+      // timeout) retries in the background so it recovers without the user.
+      if (!ok) this.scheduleRetry(s, gen, 1);
     }
+  }
+
+  // Connect (or reconnect) ONE server. Concurrent calls for the same id share
+  // one in-flight attempt (dedup) so a background retry racing a user reconnect
+  // can't double-spawn or orphan a child; the loser awaits the same real result.
+  private connectServer(s: McpServerConf): Promise<boolean> {
+    const inflight = this.connecting.get(s.id);
+    if (inflight) return inflight;
+    const p = this.doConnect(s).finally(() => this.connecting.delete(s.id));
+    this.connecting.set(s.id, p);
+    return p;
+  }
+
+  // Drop any stale specs for this id, spawn + handshake, then record its
+  // tools/status. Idempotent: safe to re-run for a retry or a reconnect.
+  private async doConnect(s: McpServerConf): Promise<boolean> {
+    const prefix = `mcp.${s.id}.`;
+    this.mcpSpecs = this.mcpSpecs.filter((x) => !x.name.startsWith(prefix));
+    this.rebuildNames();
+    this.host.stop(s.id);
+    try {
+      await this.host.start(s);
+      const tools = await this.host.listTools(s.id);
+      this.mcpSpecs.push(...tools);
+      this.rebuildNames();
+      this.mcpStatuses.set(s.id, { id: s.id, status: 'connected', toolCount: tools.length, tools: tools.map((t) => t.name) });
+      return true;
+    } catch (e) {
+      // Record the reason so Settings can show it instead of failing silently.
+      this.host.stop(s.id);
+      this.mcpStatuses.set(s.id, { id: s.id, status: 'failed', toolCount: 0, tools: [], error: e instanceof Error ? e.message : String(e) });
+      return false;
+    }
+  }
+
+  // Background retry for a failed first-connect. Stops once connected, out of
+  // attempts, or once a reboot (new generation) supersedes this config.
+  private scheduleRetry(s: McpServerConf, gen: number, attempt: number): void {
+    if (attempt > this.retries) return;
+    setTimeout(() => {
+      void (async () => {
+        if (gen !== this.generation) return; // rebooted since — config changed
+        if (this.mcpStatuses.get(s.id)?.status === 'connected') return;
+        const ok = await this.connectServer(s);
+        if (!ok && gen === this.generation) this.scheduleRetry(s, gen, attempt + 1);
+      })();
+    }, this.retryDelayMs * attempt);
+  }
+
+  private rebuildNames(): void {
+    this.names = new Set([...BUILTIN, ...COMPUTER_TOOLS].map((s) => s.name).concat(this.mcpSpecs.map((s) => s.name)));
   }
 
   // Hot-reapply the MCP server set: stop the running servers, drop their tool
@@ -96,9 +160,10 @@ class Registry {
   // config. Called by `local.config.save` so editing MCP servers in Settings
   // takes effect immediately, without restarting the app.
   async reboot(servers: McpServerConf[]): Promise<void> {
+    this.generation++; // invalidate any pending background boot retries
     this.host.stopAll();
     this.mcpSpecs = [];
-    this.names = new Set([...BUILTIN, ...COMPUTER_TOOLS].map((s) => s.name));
+    this.rebuildNames();
     this.mcpStatuses.clear();
     await this.boot(servers);
   }
@@ -112,13 +177,27 @@ class Registry {
   // drop its specs/names, then boot only it from the persisted list. Returns
   // its fresh status. Other servers are left untouched.
   async reconnect(id: string, servers: McpServerConf[]): Promise<McpServerStatus | undefined> {
-    this.host.stop(id);
-    const prefix = `mcp.${id}.`;
-    this.mcpSpecs = this.mcpSpecs.filter((s) => !s.name.startsWith(prefix));
-    this.names = new Set([...BUILTIN, ...COMPUTER_TOOLS].map((s) => s.name).concat(this.mcpSpecs.map((s) => s.name)));
-    this.mcpStatuses.delete(id);
     const conf = servers.find((s) => s.id === id);
-    if (conf) await this.boot([conf]);
+    // Server removed from the saved config: stop it and drop its specs/status.
+    if (!conf) {
+      this.host.stop(id);
+      const prefix = `mcp.${id}.`;
+      this.mcpSpecs = this.mcpSpecs.filter((s) => !s.name.startsWith(prefix));
+      this.rebuildNames();
+      this.mcpStatuses.delete(id);
+      return undefined;
+    }
+    if (conf.enabled === false) {
+      this.host.stop(id);
+      const prefix = `mcp.${id}.`;
+      this.mcpSpecs = this.mcpSpecs.filter((s) => !s.name.startsWith(prefix));
+      this.rebuildNames();
+      this.mcpStatuses.set(id, { id, status: 'disabled', toolCount: 0, tools: [] });
+      return this.mcpStatuses.get(id);
+    }
+    // User-initiated: connect once, no background retry (they're watching and
+    // can click Test/Reconnect again).
+    await this.connectServer(conf);
     return this.mcpStatuses.get(id);
   }
 


### PR DESCRIPTION
## Problem

On a slow machine the desktop **Local Tools** MCP servers can fail to appear in chat: the model replies *"no `playwright` MCP tools available in this session."* Root cause chain:

- The chat attaches tools via `_localToolInjection()` → `listTools()`, which only includes `mcp.<server>.*` **when that server is connected**.
- `McpHost.start()`'s `initialize` handshake shared the 30 s `RPC_TIMEOUT_MS`. A cold `node …/@playwright/mcp` (loading `playwright-core`) on a slow machine / slow network can take **longer than 30 s just to answer**, so the boot times out.
- `registry.boot()` is fire-and-forget and, on failure, left the server **`failed` forever** — the user had to manually click *Test / Reconnect*. Send a message before that and the request carries only fs/shell tools → the model correctly says the browser tools aren't there.

(Confirmed live on the affected machine: with a warm start the MCP connects in ~20 s and `listTools()` returns all 23 playwright tools; a borderline cold start hit the 30 s timeout and stranded as `failed`.)

## Fix

**`electron/local/mcp.ts`**
- New `STARTUP_TIMEOUT_MS = 60_000` used **only** for the initial `initialize` RPC (mid-turn `tools/call` keeps the 30 s `RPC_TIMEOUT_MS` so a wedged server still can't hang a turn). `rpc()` gained an optional `timeoutMs`.

**`electron/local/registry.ts`**
- **Background boot-retry**: a failed first connect retries in the background (3×, 5 s·attempt backoff) so a slow cold start self-heals without the user.
- **`generation` guard**: `reboot()` bumps a counter; a retry scheduled against an old config is dropped (never resurrects a server the user removed/changed).
- **Concurrent-connect dedup**: `connectServer()` shares one in-flight `Promise<boolean>` per id (cleared via `.finally`), so a background retry racing a user *Reconnect* can't double-spawn / orphan a child process, and the loser awaits the **real** result instead of a stale `false`.
- `Registry` is now an `export class` with an injectable `(host, retries, retryDelayMs)` constructor (defaults unchanged) for testing.

**`electron/local/registry.test.ts`** (new, 6 vitest cases): first-boot connect, disabled-skip, **retry-until-success**, retry-budget-exhaustion, **reboot drops stale retries**, and **concurrent-connect dedup (single spawn, no duplicate specs)**.

No IPC / renderer changes — `boot()/reboot()/reconnect()/mcpStatus()` signatures are unchanged.

- ✅ `compile:electron` (tsc) clean · `vitest` local suite green (config + fs + registry).

## 🤖 对抗评审

Read-only reviewer (Claude `Explore` subagent — no Codex on host) audited for races, leaks, timer lifecycle, spec/name integrity, and behavior parity.

| # | Severity | Finding | Resolution |
|---|----------|---------|------------|
| 1 | **RISK** | Original `connecting: Set` guard early-returned / did setup work **outside** the `try/finally`; if a colliding call hit the guard (or `host.stop` threw) the id could leak in the set → **permanent deadlock** (server never reconnectable). | **Fixed** — replaced the Set with a `Map<id, Promise<boolean>>` dedup; cleanup is via `.finally` on the shared promise (always runs), eliminating the leak window entirely. Added a concurrent-connect test. |
| 2 | **RISK** | A user *Reconnect* colliding with an in-flight background retry got a stale `false`/status (UX confusion). | **Fixed by the same refactor** — the colliding caller now **awaits the same in-flight promise** and returns the real post-connect status. |
| 3 | nit | (Same as #2.) | Resolved by #1/#2. |

Reviewer verified CLEAN: `generation` guard prevents stale-retry resurrection; `rebuildNames()` keeps `names` consistent with `mcpSpecs` across filter→start→push (no duplicate specs); retry timers self-terminate via attempt-cap / generation / connected guards (no leak); 60 s applies only to `initialize`; `reconnect()` preserves its return contract (+ now handles removed/disabled explicitly); `FakeHost` covers every `McpHost` method `Registry` calls.
