### PR TITLE
fix(desktop): resolve node/npx on Windows despite a stale GUI PATH

### DIFF
--- a/change/@acedatacloud-nexior-mcp-windows-path.json
+++ b/change/@acedatacloud-nexior-mcp-windows-path.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(desktop): resolve node/npx for local MCP servers on Windows even when a GUI-launched app inherited a stale PATH (augment PATH with the standard Node install dirs)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/electron/local/mcp.test.ts
+++ b/electron/local/mcp.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { windowsNodeDirs } from './mcp';
+
+// A GUI-launched Windows app can inherit a stale PATH without the Node dir;
+// resolveEnhancedPath() appends these standard install dirs so a bare `node` /
+// `npx` MCP command still resolves. Keep the derivation pure + covered.
+describe('windowsNodeDirs', () => {
+  it('derives the standard Node + global-npm dirs from env vars', () => {
+    const dirs = windowsNodeDirs({
+      ProgramFiles: 'C:\\Program Files',
+      'ProgramFiles(x86)': 'C:\\Program Files (x86)',
+      APPDATA: 'C:\\Users\\x\\AppData\\Roaming',
+      LOCALAPPDATA: 'C:\\Users\\x\\AppData\\Local'
+    } as NodeJS.ProcessEnv);
+    expect(dirs).toEqual([
+      'C:\\Program Files\\nodejs',
+      'C:\\Program Files (x86)\\nodejs',
+      'C:\\Users\\x\\AppData\\Roaming\\npm',
+      'C:\\Users\\x\\AppData\\Local\\Programs\\nodejs'
+    ]);
+  });
+
+  it('skips any env var that is unset', () => {
+    expect(windowsNodeDirs({ ProgramFiles: 'C:\\Program Files' } as NodeJS.ProcessEnv)).toEqual(['C:\\Program Files\\nodejs']);
+    expect(windowsNodeDirs({} as NodeJS.ProcessEnv)).toEqual([]);
+  });
+});

--- a/electron/local/mcp.ts
+++ b/electron/local/mcp.ts
@@ -18,6 +18,17 @@ interface Pending { resolve: (v: unknown) => void; reject: (e: Error) => void; t
 // and every MCP server silently fails to connect. Rebuild a usable PATH once,
 // cached (as a Promise) for the process lifetime. ASYNC so the login-shell
 // probe never blocks the main thread / UI.
+// Standard Node + global-npm install dirs on Windows, derived from STABLE env
+// vars (never the possibly-stale inherited PATH). Exported for tests.
+export function windowsNodeDirs(env: NodeJS.ProcessEnv = process.env): string[] {
+  return [
+    env.ProgramFiles && `${env.ProgramFiles}\\nodejs`,
+    env['ProgramFiles(x86)'] && `${env['ProgramFiles(x86)']}\\nodejs`,
+    env.APPDATA && `${env.APPDATA}\\npm`,
+    env.LOCALAPPDATA && `${env.LOCALAPPDATA}\\Programs\\nodejs`
+  ].filter((d): d is string => !!d);
+}
+
 let cachedPath: Promise<string> | null = null;
 function resolveEnhancedPath(): Promise<string> {
   if (cachedPath) return cachedPath;
@@ -38,6 +49,15 @@ function resolveEnhancedPath(): Promise<string> {
       }
       const home = process.env.HOME || '';
       parts = parts.concat(['/opt/homebrew/bin', '/usr/local/bin', '/usr/bin', '/bin', `${home}/.local/bin`, `${home}/.bun/bin`]);
+    } else {
+      // A GUI-launched Windows app can inherit a STALE PATH — e.g. an
+      // explorer.exe started before Node was installed (or before its installer
+      // updated the registry PATH) — so a bare `node` / `npx` resolves to
+      // `spawn ENOENT` even though Node IS installed and on the machine PATH.
+      // Append the standard Node + global-npm install dirs so the common install
+      // still resolves. Bare-command resolution tolerates the space in
+      // "Program Files".
+      parts = parts.concat(windowsNodeDirs());
     }
     const seen = new Set<string>();
     return parts.filter((d) => d && !seen.has(d) && seen.add(d)).join(sep);


### PR DESCRIPTION
## Problem

On Windows, a local **Local Tools → MCP server** configured with a bare `command: "node"` (or `npx`) can fail with **`mcp rpc timeout — 'node' 不是内部或外部命令`** (`spawn ENOENT`) — even though Node **is** installed and on the machine PATH.

Cause: a GUI-launched app (double-click / Start menu) inherits its PATH from the `explorer.exe` that launched it. If Node was installed (or its installer updated the registry PATH) **after** that `explorer.exe` started, the inherited PATH is **stale** and lacks `C:\Program Files\nodejs`. `resolveEnhancedPath()` already rebuilds a usable PATH on macOS/Linux (login-shell probe + brew/bun dirs) but on **Windows it used the raw, possibly-stale `process.env.PATH`** — a latent gap. The MCP host spawns with `shell: true` + `PATH: enhancedPath`, so the bare command never resolves.

## Fix

`electron/local/mcp.ts` — `resolveEnhancedPath()` now has a Windows `else` branch that appends the standard Node + global-npm install dirs, derived from **stable env vars** (not the stale PATH):

```
%ProgramFiles%\nodejs, %ProgramFiles(x86)%\nodejs, %APPDATA%\npm, %LOCALAPPDATA%\Programs\nodejs
```

Extracted into a pure, exported `windowsNodeDirs(env = process.env)` (skips unset vars). Dirs are **appended** (lowest precedence, so an intentional earlier `node` still wins) and pass through the existing dedup. A bare `node` command resolves via cmd against the `C:\Program Files\nodejs` entry (the space is fine for bare-command resolution).

`electron/local/mcp.test.ts` (new): asserts the derivation (all vars set → exact ordered list) and the skip-unset-var branch.

### Verified live
With node **stripped from PATH** and a bare `command: "node"` MCP config, the Playwright MCP now **connects (23 tools)** on launch — previously it timed out as `failed`. (Before the fix, only an absolute `C:\PROGRA~1\nodejs\node.exe` command worked.)

- ✅ `compile:electron` (tsc) clean · `vitest` (mcp + registry) green.

## 🤖 对抗评审

Read-only reviewer (Claude `Explore` subagent — no Codex on host) audited correctness, precedence, dedup, security (PATH-hijack), non-Windows parity, cache interaction, and test soundness. Confirmed: the four dirs cover the default MSI + global-npm install; bare-command resolution tolerates the space in "Program Files"; **append** (not prepend) is the correct precedence; dedup filters empties; env vars are system-controlled so no new hijack surface (`%APPDATA%\npm` was already trusted as the install target); macOS/Linux path is byte-for-byte unchanged; the exported helper is pure with no import side effects; tests are exact + deterministic and cover both branches. **VERDICT: CLEAN** (no findings).
