### PR TITLE
feat(scheduled-tasks): add editable task title field

### DIFF
--- a/change/@acedatacloud-nexior-e33da95a-922d-440c-b6c3-fb1654044f16.json
+++ b/change/@acedatacloud-nexior-e33da95a-922d-440c-b6c3-fb1654044f16.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(scheduled-tasks): add editable task title field",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/pages/chat/ScheduledTasks.vue
+++ b/src/pages/chat/ScheduledTasks.vue
@@ -133,6 +133,10 @@
       class="scheduled-task-dialog"
     >
       <el-form :model="form" label-width="92px">
+        <el-form-item :label="$t('chat.scheduledTasks.form.name')">
+          <el-input v-model="form.name" :placeholder="$t('chat.scheduledTasks.form.namePlaceholder')" maxlength="80" />
+        </el-form-item>
+
         <el-form-item :label="$t('chat.scheduledTasks.form.prompt')" required>
           <el-input
             v-model="form.question"
@@ -289,6 +293,7 @@ const USER_TZ = Intl.DateTimeFormat().resolvedOptions().timeZone || 'Asia/Shangh
 const DEFAULT_SCHEDULED_MAX_TURNS = 50;
 
 interface TaskForm {
+  name: string;
   question: string;
   model: string;
   scheduleType: 'minutely' | 'daily' | 'hourly' | 'weekly' | 'cron';
@@ -372,6 +377,7 @@ export default defineComponent({
   methods: {
     emptyForm(): TaskForm {
       return {
+        name: '',
         question: '',
         model: CHAT_MODEL_NAME_GPT_5_4_MINI,
         scheduleType: 'daily',
@@ -383,7 +389,7 @@ export default defineComponent({
         maxTurns: DEFAULT_SCHEDULED_MAX_TURNS
       };
     },
-    // The task name is no longer a separate field — derive a short label from the prompt.
+    // Fallback label when the user leaves the name field blank — derive from the prompt.
     deriveName(question: string): string {
       const firstLine = (question || '').trim().split('\n')[0].trim();
       return firstLine.length > 40 ? `${firstLine.slice(0, 40)}…` : firstLine || 'Scheduled Task';
@@ -446,6 +452,7 @@ export default defineComponent({
         else scheduleType = 'cron';
       }
       this.form = {
+        name: task.name,
         question: task.template.question,
         model: task.template.model,
         scheduleType,
@@ -500,7 +507,7 @@ export default defineComponent({
         const authorizedSkills = [...this.form.authorizedSkills];
         const authorizedMcpServers = [...this.form.authorizedMcpServers];
         const payload = {
-          name: this.deriveName(this.form.question),
+          name: this.form.name.trim() || this.deriveName(this.form.question),
           schedule: this.buildSchedule(),
           template: {
             model: this.form.model,


### PR DESCRIPTION
## 背景

定时任务（Scheduled Tasks）弹窗此前移除了独立的「任务名称」输入框，名称只能由提示词自动推导（`deriveName`），用户无法自定义或修改标题。卡片列表因此显示的都是截断的提示词首行。

## 改动

在创建/编辑弹窗中重新加入「任务名称」输入框（位于提示词上方）：

- `TaskForm` 新增 `name` 字段，`emptyForm()` 初始化为空串。
- `openEdit()` 用 `task.name` 回填输入框，可修改。
- `saveTask()` 提交时 `name = form.name.trim() || deriveName(question)`——留空时仍回退到从提示词推导，保持向后兼容。
- 复用已存在于全部 18 个语言包的 `chat.scheduledTasks.form.name` / `namePlaceholder` 文案，无需新增 i18n。

后端 `IScheduledTask.name` 与 operator 的 create/update payload 早已支持 `name`，无需后端改动。

## 🤖 对抗评审

- Reviewer: Codex 触发用量上限（`usage limit`），回退到 general-purpose 子代理评审。
- 检查项：编辑回填、空名称回退、`TaskForm`/`emptyForm` 一致性、保存后表单重置、i18n key 匹配、类型安全。
- 结论：**VERDICT: CLEAN**，无 RISK。