### PR TITLE
fix(chat): cookie/BYOC connector 授权跳回 404（return_to 指向不存在的 /chat/c/ 路由）

### DIFF
--- a/change/@acedatacloud-nexior-c7a40190-1620-4ce8-a529-2d537a53c1f0.json
+++ b/change/@acedatacloud-nexior-c7a40190-1620-4ce8-a529-2d537a53c1f0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(chat): repair connector install return_to so cookie/BYOC auth returns to a real conversation route instead of 404",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/consentReturn.test.ts
+++ b/src/components/chat/consentReturn.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { buildAuthorizedConsentOutput, findPendingConsentBlock, parseConsentReturnFromQuery } from './consentReturn';
+import {
+  buildAuthorizedConsentOutput,
+  findPendingConsentBlock,
+  parseConsentReturnFromQuery,
+  repairInstallReturnToUrl
+} from './consentReturn';
 import { ROLE_ASSISTANT, ROLE_USER } from '@/constants/chat';
 import type { IChatMessage, IConsentRequestPayload } from '@/models';
 
@@ -171,5 +176,46 @@ describe('buildAuthorizedConsentOutput', () => {
       authorized: ['acedatacloud/slack'],
       skipped: []
     });
+  });
+});
+
+describe('repairInstallReturnToUrl', () => {
+  const worker = (returnTo: string) =>
+    `https://auth.acedata.cloud/connections/install/cat_1?return_to=${encodeURIComponent(returnTo)}`;
+
+  it('rewrites the broken /chat/c/<id> path to the current group conversation route', () => {
+    const url = worker('https://studio.acedata.cloud/chat/c/conv-123?consent=consent_abc');
+    const fixed = new URL(repairInstallReturnToUrl(url, '/chatgpt'));
+    const ret = new URL(fixed.searchParams.get('return_to') as string);
+    expect(ret.origin + ret.pathname).toBe('https://studio.acedata.cloud/chatgpt/conversations/conv-123');
+    // The consent beacon (the only carrier of the consent id) is preserved.
+    expect(ret.searchParams.get('consent')).toBe('consent_abc');
+  });
+
+  it('preserves every query param on the worker return_to (e.g. connector)', () => {
+    const url = worker('https://studio.acedata.cloud/chat/c/conv-9?consent=consent_x&connector=medium%2Fmedium');
+    const ret = new URL(new URL(repairInstallReturnToUrl(url, '/claude')).searchParams.get('return_to') as string);
+    expect(ret.pathname).toBe('/claude/conversations/conv-9');
+    expect(ret.searchParams.get('consent')).toBe('consent_x');
+    expect(ret.searchParams.get('connector')).toBe('medium/medium');
+  });
+
+  it('returns the URL unchanged when there is no return_to param', () => {
+    const url = 'https://auth.acedata.cloud/connections/install/cat_1';
+    expect(repairInstallReturnToUrl(url, '/chatgpt')).toBe(url);
+  });
+
+  it('leaves an already-valid (non /chat/c/) return_to untouched', () => {
+    const url = worker('https://studio.acedata.cloud/chatgpt/conversations/conv-1?consent=consent_abc');
+    expect(repairInstallReturnToUrl(url, '/chatgpt')).toBe(url);
+  });
+
+  it('returns the URL unchanged when groupPrefix is empty', () => {
+    const url = worker('https://studio.acedata.cloud/chat/c/conv-123?consent=consent_abc');
+    expect(repairInstallReturnToUrl(url, '')).toBe(url);
+  });
+
+  it('returns the input unchanged when it is not a parseable URL', () => {
+    expect(repairInstallReturnToUrl('not a url', '/chatgpt')).toBe('not a url');
   });
 });

--- a/src/components/chat/consentReturn.ts
+++ b/src/components/chat/consentReturn.ts
@@ -98,3 +98,37 @@ export function findPendingConsentBlock(
 export function buildAuthorizedConsentOutput(payload: IConsentRequestPayload, authorizedConnector: string): string {
   return buildConsentOutput(payload, [authorizedConnector], []);
 }
+
+/**
+ * Repair the `return_to` of the worker-built AuthFrontend install URL so
+ * the post-install redirect lands on a real Nexior route. The aichat2
+ * worker hardcodes `return_to=<origin>/chat/c/<conv>?consent=<rid>`, but
+ * Nexior has no `/chat/c/` route (real routes are
+ * `/<group>/conversations/:id`), so the redirect 404s after a cookie/BYOC
+ * bind. We only rewrite the known-broken `/chat/c/<id>` path shape —
+ * swapping it for `<groupPrefix>/conversations/<id>` — and preserve the
+ * worker's query verbatim (the `consent=<rid>` beacon that drives
+ * auto-resume lives only there). The conversation id is taken from the
+ * worker's own path (authoritative even before the route `:id` is pushed
+ * for a brand-new chat); `groupPrefix` is the prefix of the route the
+ * user is currently viewing (e.g. `/chatgpt`). Any URL that is missing a
+ * `return_to`, is not the broken shape, or fails to parse is returned
+ * unchanged so we never make a working URL worse.
+ */
+export function repairInstallReturnToUrl(installUrl: string, groupPrefix: string): string {
+  try {
+    const url = new URL(installUrl);
+    const rawReturn = url.searchParams.get('return_to');
+    if (!rawReturn || !groupPrefix) return installUrl;
+    const ret = new URL(rawReturn);
+    const match = ret.pathname.match(/^\/chat\/c\/([^/]+)/);
+    if (!match) return installUrl;
+    const convId = match[1];
+    const fixed = new URL(`${ret.origin}${groupPrefix}/conversations/${convId}`);
+    ret.searchParams.forEach((value, key) => fixed.searchParams.set(key, value));
+    url.searchParams.set('return_to', fixed.toString());
+    return url.toString();
+  } catch {
+    return installUrl;
+  }
+}

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -92,6 +92,7 @@ import {
   buildAuthorizedConsentOutput,
   findPendingConsentBlock,
   parseConsentReturnFromQuery,
+  repairInstallReturnToUrl,
   type IConsentReturn
 } from '@/components/chat/consentReturn';
 import { chatOperator, agentOperator } from '@/operators';
@@ -1043,7 +1044,12 @@ export default defineComponent({
         console.warn('authorize click with no install_url', payload);
         return;
       }
-      window.location.href = url;
+      // The worker builds the install `return_to` as `/chat/c/<conv>` —
+      // a path Nexior does not serve — so a cookie/BYOC bind that returns
+      // there 404s. Rewrite it to the current group's real conversation
+      // route before handing off to AuthFrontend.
+      const prefix = this.$route.matched[0]?.path ?? '';
+      window.location.href = repairInstallReturnToUrl(url, prefix);
     },
     /**
      * Stash any ``?consent=<rid>&connector=<id>`` pair on


### PR DESCRIPTION
## 问题

Studio (Nexior) 聊天里对 **cookie / BYOC 类** connector（如 Medium）授权时：完成 cookie 绑定后跳回 **404**，落在 `https://studio.acedata.cloud/chat/c/<conv>?consent=...&connector=...`。普通 MCP（OAuth）connector 没事。

## Root cause

aichat2 worker 把 AuthFrontend 安装页的 `return_to` 硬编码成 `<origin>/chat/c/<conv>?consent=<rid>`，但 Nexior **没有 `/chat/c/` 路由**（真实路由是 `/<group>/conversations/:id`），catch-all `/:pathMatch(.*)*` → NotFound → 404。

- **OAuth connector 正常**：走 `ConnectorConsentCard.performInstall()`，`return_url` 由 `window.location.href`（真实当前路由）构建。
- **cookie/BYOC connector 404**：`auth_mode === 'byoc'` 走 `$emit('authorize')` → `onAuthorizeConnector()` 直接 `window.location.href = entry.install_url`（worker 那个坏 `/chat/c/` URL）。

## 修复

`onAuthorizeConnector` 在跳转前，只针对已知坏形状 `/chat/c/<id>` 重写 `return_to`：换成**当前 group** 的真实会话路由 `<prefix>/conversations/<id>`，并**原样保留 worker 的 query**（`consent=<rid>` 这个自动恢复所需的 beacon 只存在于此处）。会话 id 取自 worker 自己的 `return_to`（即使新会话尚未把 `:id` 推进 URL 也可靠）。任何没有 `return_to`、非坏形状、或解析失败的 URL 一律原样透传——绝不把正常 URL 改坏。

新增纯函数 `repairInstallReturnToUrl()` + 6 个单测（全部通过，19/19）。

## 验证
- `vitest run src/components/chat/consentReturn.test.ts` → 19 passed
- eslint / vue-tsc 对改动文件无报错

配套：AuthFrontend 侧 BYOC 安装页 UI 清理 https://github.com/AceDataCloud/AuthFrontend/pull/174

## 🤖 对抗评审

Codex 已达用量上限，回退到 `general-purpose` 子代理审查了两份实际 diff（读源码全链路追踪）。

**VERDICT: CLEAN** —仅两条低危/装饰性说明，均为预期且无害：

- `RISK (low)`：`installBYOCUnsupported` i18n key 现在无引用，但 18 个 locale 仍保留（覆盖率守卫只查缺失 key → 通过）。无害。
- `RISK (cosmetic, intended)`：`errorMessage=''` 后面板后方为空 `<p>` + Connect 按钮，符合意图，无测试断言旧文案。

确认非问题（已逐一质疑核实）：正则 `/^\/chat\/c\/([^/]+)/` 线性无 ReDoS；`searchParams.forEach+set` 不会双重编码、`consent`/`connector` 均保留；`ret.origin` 保留 → AuthFrontend `isAllowedReturnTo` 白名单仍通过；`matched[0].path` 永远是 `/chatgpt` 等（不会是 `/` 产生 `//conversations`）；OAuth / 已合法 / 缺失 return_to 路径均原样透传，只可能把 404 URL 修好、绝不劣化。
