### PR TITLE
fix(download): add a back button to the chrome-less /download page

### DIFF
--- a/change/@acedatacloud-nexior-5e499468-e13f-44e2-aa14-05282e8a29cb.json
+++ b/change/@acedatacloud-nexior-5e499468-e13f-44e2-aa14-05282e8a29cb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(download): add a back button to the chrome-less /download page",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/pages/download/Index.vue
+++ b/src/pages/download/Index.vue
@@ -2,6 +2,12 @@
   <div class="download-page">
     <div class="download-page__glow" aria-hidden="true"></div>
     <div class="download-page__inner">
+      <!-- Bare layout has no app chrome (native/desktop have no browser back) — always offer a way back. -->
+      <button type="button" class="download-back" @click="goBack">
+        <font-awesome-icon :icon="faArrowLeft" class="download-back__icon" />
+        <span>{{ $t('common.button.goBack') }}</span>
+      </button>
+
       <!-- Hero -->
       <header class="hero">
         <span class="hero__brand">
@@ -274,7 +280,7 @@ import { ElButton } from 'element-plus';
 import QrCode from 'vue-qrcode';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { faAndroid, faApple, faGooglePlay, faWindows } from '@fortawesome/free-brands-svg-icons';
-import { faDownload, faCircleInfo } from '@fortawesome/free-solid-svg-icons';
+import { faDownload, faCircleInfo, faArrowLeft } from '@fortawesome/free-solid-svg-icons';
 import defaultLogo from '@/assets/images/logo.png';
 import {
   DESKTOP_APP_VERSION,
@@ -303,7 +309,8 @@ export default defineComponent({
       faGooglePlay,
       faWindows,
       faDownload,
-      faCircleInfo
+      faCircleInfo,
+      faArrowLeft
     };
   },
   computed: {
@@ -360,6 +367,13 @@ export default defineComponent({
     }
   },
   methods: {
+    goBack() {
+      if (window.history.length > 1) {
+        this.$router.back();
+      } else {
+        this.$router.push('/');
+      }
+    },
     openSupport() {
       window.open('https://platform.acedata.cloud/support', '_blank');
     }
@@ -395,6 +409,35 @@ export default defineComponent({
   max-width: 1080px;
   margin: 0 auto;
   padding: 72px 24px 96px;
+}
+
+.download-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 28px;
+  padding: 9px 16px 9px 13px;
+  border-radius: 999px;
+  background: var(--app-bg-section);
+  border: 1px solid var(--app-border-subtle);
+  color: var(--el-text-color-regular);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    color 0.2s ease,
+    border-color 0.2s ease,
+    transform 0.2s ease;
+
+  &:hover {
+    color: var(--app-brand-hex);
+    border-color: rgba(var(--app-brand-rgb), 0.4);
+    transform: translateX(-2px);
+  }
+}
+
+.download-back__icon {
+  font-size: 13px;
 }
 
 /* Hero */


### PR DESCRIPTION
## Problem

In the native app (iOS/Android via Capacitor) and the Electron desktop app, once a user opens `/download` (`https://studio.acedata.cloud/download`) they get **stuck** — there is no way back.

Root cause: `/download` renders through the chrome-less `Bare.vue` layout (only `<router-view/>` + footer — **no `TopHeader`, no back button**), and the app registers no Android hardware-back handler. iOS has no hardware back at all, so the page becomes a dead end.

## Fix

Add a visible back button to the top of the download page, mirroring the pattern already shipped on the 404 page (`NotFound.vue`):

- `goBack()` → `window.history.length > 1 ? $router.back() : $router.push('/')` — falls back to home on cold-start / deep-link so it never dead-ends.
- Works on every surface (web, iOS, Android, desktop). Reuses the existing i18n key `common.button.goBack` and CSS tokens already present in the file.

Scope is intentionally kept to the reported symptom. A broader follow-up (a global Capacitor `backButton` handler for the Android hardware back button) is possible but out of scope here.

## Test

- ESLint on the changed file: **pass**
- Vue/TS language server: **no errors**

## 🤖 对抗评审

Reviewer: Claude general-purpose subagent (Codex not installed on this host). Read-only pass over the diff + reference files (`NotFound.vue`, `Bare.vue`, i18n locales).

Findings: **none material.**

- i18n key `common.button.goBack` present in all locales ✓
- CSS tokens (`--app-bg-section`, `--app-border-subtle`, `--el-text-color-regular`, `--app-brand-hex`, `--app-brand-rgb`) all defined/used in-file ✓
- `faArrowLeft` imported + registered in `data()`, matches the file's object-icon pattern ✓
- `goBack()` identical to the proven `NotFound.vue` pattern; correct on web / native / desktop incl. deep-link fallback ✓
- Accessible button (`type="button"` + visible text label) ✓

**VERDICT: CLEAN** (1 round)
