### PR TITLE
fix(nexior/download): drop hardcoded version labels; Windows/macOS to Releases page

### DIFF
--- a/change/@acedatacloud-nexior-95cdab83-adce-4ece-932e-110f93a0ddd6.json
+++ b/change/@acedatacloud-nexior-95cdab83-adce-4ece-932e-110f93a0ddd6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(download): drop hardcoded version labels; Windows/macOS link to the GitHub Releases page",
+  "packageName": "@acedatacloud/nexior",
+  "email": "cqc@cuiqingcai.com",
+  "dependentChangeType": "patch"
+}

--- a/src/constants/mobile.ts
+++ b/src/constants/mobile.ts
@@ -10,16 +10,7 @@ export const MOBILE_IOS_DOWNLOAD_URL = '';
 
 export const MOBILE_IOS_FALLBACK_URL = '';
 
-// Desktop (Electron) installers — attached to every public GitHub Release.
-// UNSIGNED beta: Windows SmartScreen / macOS Gatekeeper warn on first launch.
-// URLs embed the version → bump DESKTOP_APP_VERSION each release (like the APK).
-export const DESKTOP_APP_VERSION = '3.292.0';
-
-const DESKTOP_RELEASE_TAG = `@acedatacloud%2Fnexior_v${DESKTOP_APP_VERSION}`;
-const DESKTOP_RELEASE_BASE = `https://github.com/AceDataCloud/Nexior/releases/download/${DESKTOP_RELEASE_TAG}`;
-
-export const DESKTOP_WINDOWS_DOWNLOAD_URL = `${DESKTOP_RELEASE_BASE}/AceData.Setup.${DESKTOP_APP_VERSION}.exe`;
-
-export const DESKTOP_MAC_ARM_DOWNLOAD_URL = `${DESKTOP_RELEASE_BASE}/AceData-${DESKTOP_APP_VERSION}-arm64.dmg`;
-
-export const DESKTOP_MAC_INTEL_DOWNLOAD_URL = `${DESKTOP_RELEASE_BASE}/AceData-${DESKTOP_APP_VERSION}.dmg`;
+// Desktop (Electron) installers: link to the GitHub Releases listing (newest
+// release on top, .exe + arm64/Intel .dmg in Assets) so it stays evergreen —
+// no version-pinned URL to bump each release. Unsigned beta; OS warns on launch.
+export const DESKTOP_RELEASES_URL = 'https://github.com/AceDataCloud/Nexior/releases';

--- a/src/pages/download/Index.vue
+++ b/src/pages/download/Index.vue
@@ -21,7 +21,6 @@
           <span class="badge badge--live">
             <span class="badge__dot"></span>{{ $t('common.message.mobileAvailableNow') }}
           </span>
-          <span class="badge">v{{ version }}</span>
           <span class="badge">{{ $t('common.message.mobileSharedAccount') }}</span>
         </div>
 
@@ -101,14 +100,14 @@
                   <font-awesome-icon :icon="faDownload" class="btn-icon" />
                   {{ $t('common.button.downloadAndroid') }}
                 </el-button>
-                <span class="platform__meta">{{ $t('common.message.mobileApkFallback') }} · v{{ version }}</span>
+                <span class="platform__meta">{{ $t('common.message.mobileApkFallback') }}</span>
               </div>
               <template v-else>
                 <el-button type="primary" round size="large" tag="a" :href="androidDownloadUrl" target="_blank">
                   <font-awesome-icon :icon="faDownload" class="btn-icon" />
                   {{ $t('common.button.downloadAndroid') }}
                 </el-button>
-                <span class="platform__meta">{{ $t('common.message.mobileDirectInstall') }} · v{{ version }}</span>
+                <span class="platform__meta">{{ $t('common.message.mobileDirectInstall') }}</span>
               </template>
             </template>
           </div>
@@ -205,11 +204,11 @@
           <p class="platform__text">{{ $t('common.message.desktopWindowsHint') }}</p>
 
           <div class="platform__foot platform__foot--stack">
-            <el-button type="primary" round size="large" tag="a" :href="windowsDownloadUrl" target="_blank">
+            <el-button type="primary" round size="large" tag="a" :href="desktopReleasesUrl" target="_blank">
               <font-awesome-icon :icon="faWindows" class="btn-icon" />
               {{ $t('common.button.downloadWindows') }}
             </el-button>
-            <span class="platform__meta">Beta · v{{ desktopVersion }}</span>
+            <span class="platform__meta">Beta</span>
           </div>
         </article>
 
@@ -225,17 +224,11 @@
           <p class="platform__text">{{ $t('common.message.desktopMacHint') }}</p>
 
           <div class="platform__foot platform__foot--stack">
-            <div class="btn-row">
-              <el-button type="primary" round size="large" tag="a" :href="macArmDownloadUrl" target="_blank">
-                <font-awesome-icon :icon="faApple" class="btn-icon" />
-                Apple Silicon
-              </el-button>
-              <el-button round size="large" class="btn-ghost" tag="a" :href="macIntelDownloadUrl" target="_blank">
-                <font-awesome-icon :icon="faApple" class="btn-icon" />
-                Intel
-              </el-button>
-            </div>
-            <span class="platform__meta">Beta · v{{ desktopVersion }}</span>
+            <el-button type="primary" round size="large" tag="a" :href="desktopReleasesUrl" target="_blank">
+              <font-awesome-icon :icon="faApple" class="btn-icon" />
+              {{ $t('common.button.downloadMac') }}
+            </el-button>
+            <span class="platform__meta">Beta · Apple Silicon &amp; Intel</span>
           </div>
         </article>
       </section>
@@ -283,13 +276,9 @@ import { faAndroid, faApple, faGooglePlay, faWindows } from '@fortawesome/free-b
 import { faDownload, faCircleInfo, faArrowLeft } from '@fortawesome/free-solid-svg-icons';
 import defaultLogo from '@/assets/images/logo.png';
 import {
-  DESKTOP_APP_VERSION,
-  DESKTOP_MAC_ARM_DOWNLOAD_URL,
-  DESKTOP_MAC_INTEL_DOWNLOAD_URL,
-  DESKTOP_WINDOWS_DOWNLOAD_URL,
+  DESKTOP_RELEASES_URL,
   MOBILE_ANDROID_DOWNLOAD_URL,
   MOBILE_ANDROID_PLAY_STORE_URL,
-  MOBILE_APP_VERSION,
   MOBILE_IOS_APP_STORE_URL,
   MOBILE_IOS_DOWNLOAD_URL,
   MOBILE_IOS_FALLBACK_URL
@@ -314,9 +303,6 @@ export default defineComponent({
     };
   },
   computed: {
-    version() {
-      return MOBILE_APP_VERSION;
-    },
     brandTitle(): string {
       return this.$store.state.site?.title || 'AceData';
     },
@@ -353,17 +339,8 @@ export default defineComponent({
     hasIos() {
       return this.hasAppStore || this.hasIosDownload;
     },
-    desktopVersion() {
-      return DESKTOP_APP_VERSION;
-    },
-    windowsDownloadUrl() {
-      return DESKTOP_WINDOWS_DOWNLOAD_URL;
-    },
-    macArmDownloadUrl() {
-      return DESKTOP_MAC_ARM_DOWNLOAD_URL;
-    },
-    macIntelDownloadUrl() {
-      return DESKTOP_MAC_INTEL_DOWNLOAD_URL;
+    desktopReleasesUrl() {
+      return DESKTOP_RELEASES_URL;
     }
   },
   methods: {


### PR DESCRIPTION
## What & why

The download page (`studio.acedata.cloud/download`) printed **hard-coded version numbers** that drifted stale:

- `MOBILE_APP_VERSION` = `3.252.1` and `DESKTOP_APP_VERSION` = `3.292.0`, while `package.json` is `3.313.6`.
- The Windows/macOS buttons linked to **version-pinned** GitHub asset URLs baked from `DESKTOP_APP_VERSION`, so they served an old (`3.292.0`) build until someone manually bumped the constant.

This removes every displayed version number and points the Windows/macOS buttons at the **evergreen GitHub Releases listing** (newest release on top), so nothing needs a manual per-release bump and users always land on the latest build.

## Changes

**`src/pages/download/Index.vue`**
- Remove the hero `v{{ version }}` badge and the `· v{{ version }}` suffix on both Android meta lines.
- Windows button → `desktopReleasesUrl`; meta `Beta`.
- macOS: collapse the two version-pinned arch buttons (Apple Silicon / Intel) into one "Download for macOS" button → `desktopReleasesUrl`; meta `Beta · Apple Silicon & Intel` (both archs live on the Releases page).
- Drop the `version` / `desktopVersion` / `windowsDownloadUrl` / `macArmDownloadUrl` / `macIntelDownloadUrl` computeds; add `desktopReleasesUrl`.

**`src/constants/mobile.ts`**
- Remove `DESKTOP_APP_VERSION` + the three version-pinned desktop URL constants.
- Add `DESKTOP_RELEASES_URL = 'https://github.com/AceDataCloud/Nexior/releases'`.
- Keep `MOBILE_APP_VERSION` (still written by CI `scripts/sync-native-version.js`).

## Notes / scope

- Store QR codes (Android → Play Store, iOS → App Store) already always resolve to the latest store listing — **unchanged**.
- The Android APK fallback URL (`MOBILE_ANDROID_DOWNLOAD_URL`) is out of scope and untouched.

## Verification

- `eslint` on both files: clean
- `vue-tsc --noEmit` (full project): clean
- Grep: no remaining source references to the removed symbols (only the pre-built `electron/renderer/` bundle, regenerated at desktop-build time).

## 🤖 对抗评审

Reviewer: Claude `general-purpose` subagent (Codex not installed on this host). One loop; converged.

**RISK (rebutted): the GitHub Releases page can briefly show a top release whose desktop `.exe`/`.dmg` have not attached yet.**
`github-release.yaml` creates the release (with the web dist) immediately, while `desktop.yml` builds + attaches the installers ~10–15 min later. So for a short window after each release the newest release's Assets lack the desktop installers.

Resolution — kept as-is, because:
1. `/releases` is the destination explicitly chosen by the product owner.
2. We link to the `/releases` **listing** (not `/releases/latest`), which shows all releases newest-first — during the race window the immediately-preceding release (minutes older) still has complete desktop assets as a fallback. Strictly more robust than `/releases/latest`.
3. Strictly better than the status quo it replaces: the old buttons pinned `v3.292.0` assets (21 releases stale), so users **always** got an old build; the new links serve the latest in the overwhelmingly common case.
4. The race is a pre-existing property of the release pipeline (it equally affects the Android row and anyone arriving from the GitHub UI). A real fix — publishing the release as a draft until all installers attach, or serializing the desktop build ahead of release creation — belongs in the release workflow and is out of scope for this UI change.

All other checks returned CLEAN: no stale symbol refs, i18n keys `common.button.downloadMac` / `downloadWindows` present in all locales, `.btn-row` SCSS still used by the iOS card, `&amp;` renders as `&`, and the unused `MOBILE_APP_VERSION` export is not lint-flagged.
