### PR TITLE
style(chat): remove sidebar horizontal scroll + elegant thin scrollbar

### DIFF
--- a/change/@acedatacloud-nexior-2781740f-d61f-47fd-a01b-baf7a192e2cd.json
+++ b/change/@acedatacloud-nexior-2781740f-d61f-47fd-a01b-baf7a192e2cd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "style(chat): remove conversation-list horizontal scroll and add elegant thin scrollbar",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/SidePanel.vue
+++ b/src/components/chat/SidePanel.vue
@@ -298,7 +298,7 @@ export default defineComponent({
   flex-direction: column;
   align-items: flex-end;
   padding: 12px;
-  width: 260px;
+  width: 100%;
   height: 100%;
   border-right: none;
 
@@ -363,6 +363,7 @@ export default defineComponent({
       }
       .title {
         flex: 1;
+        min-width: 0;
         font-size: 14px;
         line-height: 40px;
         overflow: hidden;

--- a/src/layouts/Chat.vue
+++ b/src/layouts/Chat.vue
@@ -57,9 +57,41 @@ export default defineComponent({
   width: 260px;
   height: 100%;
   overflow-y: auto;
+  overscroll-behavior: contain;
   flex-shrink: 0;
   background-color: var(--app-sidebar-bg);
   border-right: 1px solid var(--app-border-subtle);
+
+  // Elegant, thin, hover-revealed scrollbar (ChatGPT/Linear-style).
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+  transition: scrollbar-color 0.25s ease;
+
+  &::-webkit-scrollbar {
+    width: 8px;
+  }
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  &::-webkit-scrollbar-thumb {
+    // Transparent border + padding-box clip slims the thumb to ~4px and
+    // floats it away from the panel edge.
+    border: 2px solid transparent;
+    background-clip: padding-box;
+    border-radius: 999px;
+    background-color: transparent;
+    transition: background-color 0.25s ease;
+  }
+
+  &:hover {
+    scrollbar-color: var(--el-border-color) transparent;
+    &::-webkit-scrollbar-thumb {
+      background-color: var(--el-border-color);
+    }
+  }
+  &::-webkit-scrollbar-thumb:hover {
+    background-color: var(--el-border-color-darker);
+  }
 }
 
 .chat {


### PR DESCRIPTION
## What & why

The chat conversation list (left sidebar of `studio.acedata.cloud/*/conversations`) showed **both** a vertical and a horizontal scrollbar, and the vertical bar was a chunky native one.

### Root cause of the horizontal scroll
`.side` (the scroll container in `layouts/Chat.vue`) is `width: 260px; overflow-y: auto`. The inner `.panel` (`components/chat/SidePanel.vue`) was pinned to a **fixed `width: 260px`**. With the global `* { box-sizing: border-box }` reset, once the vertical scrollbar appears it steals ~15px of inner width — but the panel stayed at 260px, so it overflowed sideways → horizontal scrollbar.

## Changes (CSS only)

**`SidePanel.vue`**
- `.panel`: `width: 260px` → `width: 100%` — the panel now fits whatever width the scroll container leaves. This removes the horizontal scroll **by fixing width, not by forcing `overflow-x: hidden`** (as requested).
- `.title`: added `min-width: 0` so a long unbroken conversation title ellipsizes instead of pushing the row wide (classic flexbox min-size fix), including when the `⋯` actions button appears on hover.

**`Chat.vue` (`.side` scroll container)**
- Elegant, thin, **hover-revealed** scrollbar (the pattern ChatGPT / Linear / VS Code use):
  - `scrollbar-width: thin` + `scrollbar-color` for Firefox.
  - WebKit: fixed **8px gutter** (stable — only the thumb *color* animates on hover, so there is no layout jump), `border-radius: 999px`, and a 2px transparent border + `background-clip: padding-box` that slims the visible thumb to ~4px and floats it off the edge.
  - Thumb is transparent at rest, fades to `--el-border-color` when the list is hovered, and `--el-border-color-darker` on direct thumb hover (both are Element Plus tokens, so it adapts to dark mode automatically).
- `overscroll-behavior: contain` to stop scroll-chaining to the page.

No template/script/behavior changes. Prettier-clean, ESLint passes.

## 🤖 对抗评审

Reviewer: read-only subagent (Codex not installed in this environment). One round, converged.

| Finding | Severity | Resolution |
|---|---|---|
| Nested `&::-webkit-scrollbar-thumb` inside `&:hover` allegedly compiles to a descendant selector (`.side:hover ::-webkit-scrollbar-thumb`) and wouldn't apply | RISK | **Rebutted with proof.** SCSS only inserts a descendant space when there is whitespace before `::`. Compiled the exact snippet with dart-sass → output is `.side:hover::-webkit-scrollbar-thumb { … }` (no space) — a valid, working selector. No change needed. |
| Fixed 8px WebKit gutter is stable, only color animates → no hover/unhover width jump | ✅ confirm | Intended. |
| `.panel width:100%` + global `border-box` eliminates the horizontal scroll | ✅ confirm | Intended. |
| `min-width:0` correctly enables `.title` ellipsis under flex | ✅ confirm | Intended. |
| `--el-border-color-darker` is a real Element Plus dark-mode token | ✅ confirm | Intended. |
| Thumb "hidden until hover" could be considered faint; 8px vs 4px elsewhere | NIT | Kept — hover-reveal is exactly the requested elegant/industry-standard behavior; 8px gutter with a ~4px inset thumb reads as thin. |
| Mobile `el-drawer` (290px) renders the panel without `.side`; `width:100%` fills it | NIT | Non-regression (previously the fixed 260px panel hugged the right edge of the 290px drawer). |

**VERDICT: CLEAN** after rebuttal.
