### PR TITLE
feat(chat): 产出物汇总页 /chatgpt/artifacts（我的产出）

### DIFF
--- a/change/@acedatacloud-nexior-518b3c1f-af8d-42ec-9250-654f10bc3004.json
+++ b/change/@acedatacloud-nexior-518b3c1f-af8d-42ec-9250-654f10bc3004.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(chat): artifacts 产出物汇总页 + operator",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/SidePanel.vue
+++ b/src/components/chat/SidePanel.vue
@@ -18,6 +18,14 @@
           {{ $t('chat.scheduledTasks.navTitle') }}
         </div>
       </div>
+      <div class="conversation" @click="onArtifacts">
+        <div class="icons">
+          <font-awesome-icon icon="fa-solid fa-box-archive" class="icon" />
+        </div>
+        <div class="title">
+          {{ $t('chat.artifacts.navTitle') }}
+        </div>
+      </div>
       <div v-for="(group, groupKey) in conversationGroups" :key="groupKey" class="group">
         <div class="key">
           {{ $t(`chat.group.${groupKey}`) }}
@@ -102,7 +110,7 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { chatOperator } from '@/operators';
 import { IChatConversation } from '@/models';
 import { Status } from '@/models';
-import { ROUTE_CHAT_SCHEDULED_TASKS } from '@/router/constants';
+import { ROUTE_CHAT_SCHEDULED_TASKS, ROUTE_CHAT_ARTIFACTS } from '@/router/constants';
 
 type ConversationCommand = 'rename' | 'delete';
 
@@ -198,6 +206,9 @@ export default defineComponent({
     },
     onScheduledTasks() {
       this.$router.push({ name: ROUTE_CHAT_SCHEDULED_TASKS });
+    },
+    onArtifacts() {
+      this.$router.push({ name: ROUTE_CHAT_ARTIFACTS });
     },
     onClickConversation(id?: string) {
       console.debug('onClickConversation in side panel', id);

--- a/src/i18n/ar/chat.json
+++ b/src/i18n/ar/chat.json
@@ -731,6 +731,98 @@
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
   },
+  "artifacts.navTitle": {
+    "message": "الإنتاج",
+    "description": "مدخل الإنتاج في الشريط الجانبي"
+  },
+  "artifacts.title": {
+    "message": "إنتاجي",
+    "description": "عنوان صفحة الإنتاج"
+  },
+  "artifacts.summaryTotal": {
+    "message": "إجمالي الإنتاج لهذا الشهر هو {count} عنصر",
+    "description": "إجمالي عدد الإنتاج"
+  },
+  "artifacts.filterAll": {
+    "message": "الكل",
+    "description": "تصفية نوع الإنتاج - الكل"
+  },
+  "artifacts.empty": {
+    "message": "لا يوجد أي إنتاج حتى الآن. ستظهر الإنتاج هنا تلقائيًا بعد أن تساعدك الذكاء الاصطناعي في كتابة مقالات، أو إنشاء صور، أو إرسال رسائل بريد إلكتروني.",
+    "description": "إشعار عندما يكون الإنتاج فارغًا"
+  },
+  "artifacts.loadError": {
+    "message": "فشل تحميل الإنتاج",
+    "description": "إشعار خطأ في تحميل الإنتاج"
+  },
+  "artifacts.actionError": {
+    "message": "فشل العملية، يرجى المحاولة مرة أخرى",
+    "description": "إشعار خطأ في عملية الإنتاج"
+  },
+  "artifacts.open": {
+    "message": "فتح",
+    "description": "زر فتح الرابط الأصلي للإنتاج"
+  },
+  "artifacts.hide": {
+    "message": "إخفاء",
+    "description": "زر إخفاء الإنتاج"
+  },
+  "artifacts.delete": {
+    "message": "حذف",
+    "description": "زر حذف الإنتاج"
+  },
+  "artifacts.deleteConfirm": {
+    "message": "هل تريد بالتأكيد حذف سجل الإنتاج هذا بشكل دائم؟",
+    "description": "إشعار تأكيد حذف الإنتاج"
+  },
+  "artifacts.loadMore": {
+    "message": "تحميل المزيد",
+    "description": "زر تحميل المزيد من الإنتاج"
+  },
+  "artifacts.sourceAuto": {
+    "message": "التقاط تلقائي",
+    "description": "علامة مصدر الالتقاط التلقائي"
+  },
+  "artifacts.kind.article": {
+    "message": "مقال",
+    "description": "نوع الإنتاج - مقال"
+  },
+  "artifacts.kind.image": {
+    "message": "صورة",
+    "description": "نوع الإنتاج - صورة"
+  },
+  "artifacts.kind.video": {
+    "message": "فيديو",
+    "description": "نوع الإنتاج - فيديو"
+  },
+  "artifacts.kind.audio": {
+    "message": "صوتي",
+    "description": "نوع الإنتاج - صوتي"
+  },
+  "artifacts.kind.document": {
+    "message": "وثيقة",
+    "description": "نوع الإنتاج - وثيقة"
+  },
+  "artifacts.kind.email": {
+    "message": "بريد إلكتروني",
+    "description": "نوع الإنتاج - بريد إلكتروني"
+  },
+  "artifacts.kind.message": {
+    "message": "رسالة",
+    "description": "نوع الإنتاج - رسالة"
+  },
+  "artifacts.kind.dataset": {
+    "message": "بيانات",
+    "description": "نوع الإنتاج - بيانات"
+  },
+  "artifacts.kind.link": {
+    "message": "رابط",
+    "description": "نوع الإنتاج - رابط"
+  },
+  "artifacts.kind.other": {
+    "message": "أخرى",
+    "description": "نوع الإنتاج - أخرى"
+  },
   "model.claudeOpus47": {
     "message": "claude-opus-4.7",
     "description": "اسم النموذج للخدمة، أي Claude Opus 4.7"

--- a/src/i18n/de/chat.json
+++ b/src/i18n/de/chat.json
@@ -731,6 +731,98 @@
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
   },
+  "artifacts.navTitle": {
+    "message": "Ausgaben",
+    "description": "Navigationsüberschrift für Ausgaben im Seitenmenü"
+  },
+  "artifacts.title": {
+    "message": "Meine Ausgaben",
+    "description": "Titel der Ausgabenseite"
+  },
+  "artifacts.summaryTotal": {
+    "message": "In dieser Ausgabe wurden insgesamt {count} erstellt",
+    "description": "Zusammenfassung der Gesamtanzahl der Ausgaben"
+  },
+  "artifacts.filterAll": {
+    "message": "Alle",
+    "description": "Filter für alle Ausgabetypen"
+  },
+  "artifacts.empty": {
+    "message": "Es gibt noch keine Ausgaben. Lassen Sie die KI Artikel verfassen, Bilder generieren oder E-Mails senden, dann erscheinen die Ausgaben hier automatisch.",
+    "description": "Hinweis, dass keine Ausgaben vorhanden sind"
+  },
+  "artifacts.loadError": {
+    "message": "Laden der Ausgaben fehlgeschlagen",
+    "description": "Hinweis auf einen Fehler beim Laden der Ausgaben"
+  },
+  "artifacts.actionError": {
+    "message": "Aktion fehlgeschlagen, bitte erneut versuchen",
+    "description": "Hinweis auf einen Fehler bei der Ausführung der Aktion"
+  },
+  "artifacts.open": {
+    "message": "Öffnen",
+    "description": "Button zum Öffnen des Originallinks der Ausgabe"
+  },
+  "artifacts.hide": {
+    "message": "Ausblenden",
+    "description": "Button zum Ausblenden von Ausgaben"
+  },
+  "artifacts.delete": {
+    "message": "Löschen",
+    "description": "Button zum Löschen von Ausgaben"
+  },
+  "artifacts.deleteConfirm": {
+    "message": "Möchten Sie diesen Ausgabepost wirklich dauerhaft löschen?",
+    "description": "Bestätigungsaufforderung zum Löschen einer Ausgabe"
+  },
+  "artifacts.loadMore": {
+    "message": "Mehr laden",
+    "description": "Button zum Laden weiterer Ausgaben"
+  },
+  "artifacts.sourceAuto": {
+    "message": "Automatische Erfassung",
+    "description": "Kennzeichnung der Quelle für die automatische Erfassung"
+  },
+  "artifacts.kind.article": {
+    "message": "Artikel",
+    "description": "Ausgabetyp - Artikel"
+  },
+  "artifacts.kind.image": {
+    "message": "Bild",
+    "description": "Ausgabetyp - Bild"
+  },
+  "artifacts.kind.video": {
+    "message": "Video",
+    "description": "Ausgabetyp - Video"
+  },
+  "artifacts.kind.audio": {
+    "message": "Audio",
+    "description": "Ausgabetyp - Audio"
+  },
+  "artifacts.kind.document": {
+    "message": "Dokument",
+    "description": "Ausgabetyp - Dokument"
+  },
+  "artifacts.kind.email": {
+    "message": "E-Mail",
+    "description": "Ausgabetyp - E-Mail"
+  },
+  "artifacts.kind.message": {
+    "message": "Nachricht",
+    "description": "Ausgabetyp - Nachricht"
+  },
+  "artifacts.kind.dataset": {
+    "message": "Daten",
+    "description": "Ausgabetyp - Daten"
+  },
+  "artifacts.kind.link": {
+    "message": "Link",
+    "description": "Ausgabetyp - Link"
+  },
+  "artifacts.kind.other": {
+    "message": "Sonstiges",
+    "description": "Ausgabetyp - Sonstiges"
+  },
   "model.claudeOpus47": {
     "message": "claude-opus-4.7",
     "description": "Name des Modells des Dienstes, d.h. Claude Opus 4.7"

--- a/src/i18n/el/chat.json
+++ b/src/i18n/el/chat.json
@@ -731,6 +731,98 @@
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
   },
+  "artifacts.navTitle": {
+    "message": "Παραγωγές",
+    "description": "Είσοδος παραγωγής στην πλαϊνή μπάρα"
+  },
+  "artifacts.title": {
+    "message": "Οι παραγωγές μου",
+    "description": "Τίτλος σελίδας παραγωγής"
+  },
+  "artifacts.summaryTotal": {
+    "message": "Συνολικά {count} παραγωγές αυτή την περίοδο",
+    "description": "Συνολικός αριθμός παραγωγών"
+  },
+  "artifacts.filterAll": {
+    "message": "Όλα",
+    "description": "Φίλτρο τύπου παραγωγής - όλα"
+  },
+  "artifacts.empty": {
+    "message": "Δεν υπάρχει καμία παραγωγή ακόμα. Αφήστε την AI να σας βοηθήσει να δημοσιεύσετε άρθρα, να δημιουργήσετε εικόνες ή να στείλετε email και οι παραγωγές θα εμφανιστούν εδώ αυτόματα.",
+    "description": "Μήνυμα όταν δεν υπάρχουν παραγωγές"
+  },
+  "artifacts.loadError": {
+    "message": "Αποτυχία φόρτωσης παραγωγής",
+    "description": "Μήνυμα σφάλματος φόρτωσης παραγωγής"
+  },
+  "artifacts.actionError": {
+    "message": "Η ενέργεια απέτυχε, παρακαλώ δοκιμάστε ξανά",
+    "description": "Μήνυμα σφάλματος για αποτυχία ενέργειας"
+  },
+  "artifacts.open": {
+    "message": "Άνοιγμα",
+    "description": "Κουμπί για άνοιγμα του αρχικού συνδέσμου παραγωγής"
+  },
+  "artifacts.hide": {
+    "message": "Απόκρυψη",
+    "description": "Κουμπί απόκρυψης παραγωγής"
+  },
+  "artifacts.delete": {
+    "message": "Διαγραφή",
+    "description": "Κουμπί διαγραφής"
+  },
+  "artifacts.deleteConfirm": {
+    "message": "Είστε σίγουροι ότι θέλετε να διαγράψετε μόνιμα αυτή την εγγραφή;",
+    "description": "Επιβεβαίωση διαγραφής"
+  },
+  "artifacts.loadMore": {
+    "message": "Φόρτωση περισσότερων",
+    "description": "Κουμπί φόρτωσης περισσότερων παραγωγών"
+  },
+  "artifacts.sourceAuto": {
+    "message": "Αυτόματη καταγραφή",
+    "description": "Ετικέτα αυτόματης καταγραφής πηγής"
+  },
+  "artifacts.kind.article": {
+    "message": "Άρθρο",
+    "description": "Τύπος παραγωγής - άρθρο"
+  },
+  "artifacts.kind.image": {
+    "message": "Εικόνα",
+    "description": "Τύπος παραγωγής - εικόνα"
+  },
+  "artifacts.kind.video": {
+    "message": "Βίντεο",
+    "description": "Τύπος παραγωγής - βίντεο"
+  },
+  "artifacts.kind.audio": {
+    "message": "Ήχος",
+    "description": "Τύπος παραγωγής - ήχος"
+  },
+  "artifacts.kind.document": {
+    "message": "Έγγραφο",
+    "description": "Τύπος παραγωγής - έγγραφο"
+  },
+  "artifacts.kind.email": {
+    "message": "Email",
+    "description": "Τύπος παραγωγής - email"
+  },
+  "artifacts.kind.message": {
+    "message": "Μήνυμα",
+    "description": "Τύπος παραγωγής - μήνυμα"
+  },
+  "artifacts.kind.dataset": {
+    "message": "Δεδομένα",
+    "description": "Τύπος παραγωγής - δεδομένα"
+  },
+  "artifacts.kind.link": {
+    "message": "Σύνδεσμος",
+    "description": "Τύπος παραγωγής - σύνδεσμος"
+  },
+  "artifacts.kind.other": {
+    "message": "Άλλο",
+    "description": "Τύπος παραγωγής - άλλο"
+  },
   "model.claudeOpus47": {
     "message": "claude-opus-4.7",
     "description": "Όνομα του μοντέλου υπηρεσίας, δηλαδή Claude Opus 4.7"

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -718,5 +718,97 @@
   },
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
+  },
+  "artifacts.navTitle": {
+    "message": "Outputs",
+    "description": "Sidebar outputs entry"
+  },
+  "artifacts.title": {
+    "message": "My Outputs",
+    "description": "Artifacts page title"
+  },
+  "artifacts.summaryTotal": {
+    "message": "{count} outputs produced",
+    "description": "Artifacts summary total"
+  },
+  "artifacts.filterAll": {
+    "message": "All",
+    "description": "Artifact kind filter - all"
+  },
+  "artifacts.empty": {
+    "message": "No outputs yet. After the AI publishes articles, generates images or sends emails for you, they will show up here automatically.",
+    "description": "Artifacts empty hint"
+  },
+  "artifacts.loadError": {
+    "message": "Failed to load outputs",
+    "description": "Artifacts load error"
+  },
+  "artifacts.actionError": {
+    "message": "Action failed, please retry",
+    "description": "Artifact action error"
+  },
+  "artifacts.open": {
+    "message": "Open",
+    "description": "Open artifact source link"
+  },
+  "artifacts.hide": {
+    "message": "Hide",
+    "description": "Hide artifact"
+  },
+  "artifacts.delete": {
+    "message": "Delete",
+    "description": "Delete artifact"
+  },
+  "artifacts.deleteConfirm": {
+    "message": "Permanently delete this output record?",
+    "description": "Delete artifact confirm"
+  },
+  "artifacts.loadMore": {
+    "message": "Load more",
+    "description": "Load more artifacts"
+  },
+  "artifacts.sourceAuto": {
+    "message": "Auto-captured",
+    "description": "Auto-capture source badge"
+  },
+  "artifacts.kind.article": {
+    "message": "Article",
+    "description": "Artifact kind - Article"
+  },
+  "artifacts.kind.image": {
+    "message": "Image",
+    "description": "Artifact kind - Image"
+  },
+  "artifacts.kind.video": {
+    "message": "Video",
+    "description": "Artifact kind - Video"
+  },
+  "artifacts.kind.audio": {
+    "message": "Audio",
+    "description": "Artifact kind - Audio"
+  },
+  "artifacts.kind.document": {
+    "message": "Document",
+    "description": "Artifact kind - Document"
+  },
+  "artifacts.kind.email": {
+    "message": "Email",
+    "description": "Artifact kind - Email"
+  },
+  "artifacts.kind.message": {
+    "message": "Message",
+    "description": "Artifact kind - Message"
+  },
+  "artifacts.kind.dataset": {
+    "message": "Dataset",
+    "description": "Artifact kind - Dataset"
+  },
+  "artifacts.kind.link": {
+    "message": "Link",
+    "description": "Artifact kind - Link"
+  },
+  "artifacts.kind.other": {
+    "message": "Other",
+    "description": "Artifact kind - Other"
   }
 }

--- a/src/i18n/es/chat.json
+++ b/src/i18n/es/chat.json
@@ -731,6 +731,98 @@
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
   },
+  "artifacts.navTitle": {
+    "message": "Producción",
+    "description": "Entrada de producción en la barra lateral"
+  },
+  "artifacts.title": {
+    "message": "Mis producciones",
+    "description": "Título de la página de producción"
+  },
+  "artifacts.summaryTotal": {
+    "message": "Se han producido un total de {count} elementos en esta sesión",
+    "description": "Total de producción resumida"
+  },
+  "artifacts.filterAll": {
+    "message": "Todo",
+    "description": "Filtro de tipo de producción - Todo"
+  },
+  "artifacts.empty": {
+    "message": "Aún no hay ninguna producción. Una vez que AI te ayude a publicar artículos, generar imágenes o enviar correos, la producción aparecerá aquí automáticamente.",
+    "description": "Mensaje cuando no hay producción"
+  },
+  "artifacts.loadError": {
+    "message": "Error al cargar la producción",
+    "description": "Mensaje de error al cargar la producción"
+  },
+  "artifacts.actionError": {
+    "message": "Error de operación, por favor intenta de nuevo",
+    "description": "Mensaje de error de operación de producción"
+  },
+  "artifacts.open": {
+    "message": "Abrir",
+    "description": "Botón para abrir el enlace original de la producción"
+  },
+  "artifacts.hide": {
+    "message": "Ocultar",
+    "description": "Botón para ocultar la producción"
+  },
+  "artifacts.delete": {
+    "message": "Eliminar",
+    "description": "Botón para eliminar la producción"
+  },
+  "artifacts.deleteConfirm": {
+    "message": "¿Estás seguro de que deseas eliminar permanentemente este registro de producción?",
+    "description": "Mensaje de confirmación para eliminar la producción"
+  },
+  "artifacts.loadMore": {
+    "message": "Cargar más",
+    "description": "Botón para cargar más producciones"
+  },
+  "artifacts.sourceAuto": {
+    "message": "Captura automática",
+    "description": "Etiqueta de origen de captura automática"
+  },
+  "artifacts.kind.article": {
+    "message": "Artículo",
+    "description": "Tipo de producción - Artículo"
+  },
+  "artifacts.kind.image": {
+    "message": "Imagen",
+    "description": "Tipo de producción - Imagen"
+  },
+  "artifacts.kind.video": {
+    "message": "Video",
+    "description": "Tipo de producción - Video"
+  },
+  "artifacts.kind.audio": {
+    "message": "Audio",
+    "description": "Tipo de producción - Audio"
+  },
+  "artifacts.kind.document": {
+    "message": "Documento",
+    "description": "Tipo de producción - Documento"
+  },
+  "artifacts.kind.email": {
+    "message": "Correo",
+    "description": "Tipo de producción - Correo"
+  },
+  "artifacts.kind.message": {
+    "message": "Mensaje",
+    "description": "Tipo de producción - Mensaje"
+  },
+  "artifacts.kind.dataset": {
+    "message": "Datos",
+    "description": "Tipo de producción - Datos"
+  },
+  "artifacts.kind.link": {
+    "message": "Enlace",
+    "description": "Tipo de producción - Enlace"
+  },
+  "artifacts.kind.other": {
+    "message": "Otro",
+    "description": "Tipo de producción - Otro"
+  },
   "model.claudeOpus47": {
     "message": "claude-opus-4.7",
     "description": "Nombre del modelo del servicio, es decir, Claude Opus 4.7"

--- a/src/i18n/fi/chat.json
+++ b/src/i18n/fi/chat.json
@@ -731,6 +731,98 @@
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
   },
+  "artifacts.navTitle": {
+    "message": "Tuotokset",
+    "description": "Sivupalkin tuotosten sisäänkäynti"
+  },
+  "artifacts.title": {
+    "message": "Omat tuotokset",
+    "description": "Tuotossivun otsikko"
+  },
+  "artifacts.summaryTotal": {
+    "message": "Tällä kertaa tuotoksia yhteensä {count} kappaletta",
+    "description": "Tuotosten yhteenvedon kokonaismäärä"
+  },
+  "artifacts.filterAll": {
+    "message": "Kaikki",
+    "description": "Tuotostyyppien suodatus - kaikki"
+  },
+  "artifacts.empty": {
+    "message": "Ei vielä mitään tuotoksia. Anna AI:n auttaa sinua kirjoittamaan artikkeleita, luomaan kuvia tai lähettämään sähköposteja, niin tuotokset ilmestyvät tänne automaattisesti.",
+    "description": "Tuotokset ovat tyhjät ilmoitus"
+  },
+  "artifacts.loadError": {
+    "message": "Tuotosten lataaminen epäonnistui",
+    "description": "Tuotosten latausvirheen ilmoitus"
+  },
+  "artifacts.actionError": {
+    "message": "Toiminto epäonnistui, yritä uudelleen",
+    "description": "Tuotteen toimintavirheen ilmoitus"
+  },
+  "artifacts.open": {
+    "message": "Avaa",
+    "description": "Avaa tuotteen alkuperäinen linkkipainike"
+  },
+  "artifacts.hide": {
+    "message": "Piilota",
+    "description": "Tuotteen piilottamispainike"
+  },
+  "artifacts.delete": {
+    "message": "Poista",
+    "description": "Tuotteen poistopainike"
+  },
+  "artifacts.deleteConfirm": {
+    "message": "Haluatko varmasti poistaa tämän tuotteen pysyvästi?",
+    "description": "Tuotteen poistamisen vahvistusilmoitus"
+  },
+  "artifacts.loadMore": {
+    "message": "Lataa lisää",
+    "description": "Lisää tuotoksia lataava painike"
+  },
+  "artifacts.sourceAuto": {
+    "message": "Automaattinen tallennus",
+    "description": "Automaattisen tallennuksen lähteen merkintä"
+  },
+  "artifacts.kind.article": {
+    "message": "Artikkeli",
+    "description": "Tuotostyyppi - artikkeli"
+  },
+  "artifacts.kind.image": {
+    "message": "Kuva",
+    "description": "Tuotostyyppi - kuva"
+  },
+  "artifacts.kind.video": {
+    "message": "Video",
+    "description": "Tuotostyyppi - video"
+  },
+  "artifacts.kind.audio": {
+    "message": "Ääni",
+    "description": "Tuotostyyppi - ääni"
+  },
+  "artifacts.kind.document": {
+    "message": "Dokumentti",
+    "description": "Tuotostyyppi - dokumentti"
+  },
+  "artifacts.kind.email": {
+    "message": "Sähköposti",
+    "description": "Tuotostyyppi - sähköposti"
+  },
+  "artifacts.kind.message": {
+    "message": "Viesti",
+    "description": "Tuotostyyppi - viesti"
+  },
+  "artifacts.kind.dataset": {
+    "message": "Tietoaineisto",
+    "description": "Tuotostyyppi - tietoaineisto"
+  },
+  "artifacts.kind.link": {
+    "message": "Linkki",
+    "description": "Tuotostyyppi - linkki"
+  },
+  "artifacts.kind.other": {
+    "message": "Muu",
+    "description": "Tuotostyyppi - muu"
+  },
   "model.claudeOpus47": {
     "message": "claude-opus-4.7",
     "description": "Palvelun mallin nimi, eli Claude Opus 4.7"

--- a/src/i18n/fr/chat.json
+++ b/src/i18n/fr/chat.json
@@ -731,6 +731,98 @@
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
   },
+  "artifacts.navTitle": {
+    "message": "Productions",
+    "description": "Entrée de la barre latérale pour les productions"
+  },
+  "artifacts.title": {
+    "message": "Mes productions",
+    "description": "Titre de la page de production"
+  },
+  "artifacts.summaryTotal": {
+    "message": "Un total de {count} productions cette période",
+    "description": "Résumé du nombre total de productions"
+  },
+  "artifacts.filterAll": {
+    "message": "Tout",
+    "description": "Filtre de type de production - Tout"
+  },
+  "artifacts.empty": {
+    "message": "Aucune production pour le moment. Laissez l'IA vous aider à rédiger des articles, générer des images ou envoyer des e-mails, et la production apparaîtra ici automatiquement.",
+    "description": "Alerte lorsque la production est vide"
+  },
+  "artifacts.loadError": {
+    "message": "Échec du chargement de la production",
+    "description": "Alerte d'erreur lors du chargement de la production"
+  },
+  "artifacts.actionError": {
+    "message": "Échec de l'opération, veuillez réessayer",
+    "description": "Alerte d'erreur lors de l'opération de production"
+  },
+  "artifacts.open": {
+    "message": "Ouvrir",
+    "description": "Bouton pour ouvrir le lien original de la production"
+  },
+  "artifacts.hide": {
+    "message": "Masquer",
+    "description": "Bouton pour masquer la production"
+  },
+  "artifacts.delete": {
+    "message": "Supprimer",
+    "description": "Bouton de suppression de la production"
+  },
+  "artifacts.deleteConfirm": {
+    "message": "Êtes-vous sûr de vouloir supprimer définitivement cet enregistrement de production ?",
+    "description": "Alerte de confirmation pour la suppression de la production"
+  },
+  "artifacts.loadMore": {
+    "message": "Charger plus",
+    "description": "Bouton pour charger plus de productions"
+  },
+  "artifacts.sourceAuto": {
+    "message": "Capture automatique",
+    "description": "Étiquette de source pour la capture automatique"
+  },
+  "artifacts.kind.article": {
+    "message": "Article",
+    "description": "Type de production - Article"
+  },
+  "artifacts.kind.image": {
+    "message": "Image",
+    "description": "Type de production - Image"
+  },
+  "artifacts.kind.video": {
+    "message": "Vidéo",
+    "description": "Type de production - Vidéo"
+  },
+  "artifacts.kind.audio": {
+    "message": "Audio",
+    "description": "Type de production - Audio"
+  },
+  "artifacts.kind.document": {
+    "message": "Document",
+    "description": "Type de production - Document"
+  },
+  "artifacts.kind.email": {
+    "message": "E-mail",
+    "description": "Type de production - E-mail"
+  },
+  "artifacts.kind.message": {
+    "message": "Message",
+    "description": "Type de production - Message"
+  },
+  "artifacts.kind.dataset": {
+    "message": "Données",
+    "description": "Type de production - Données"
+  },
+  "artifacts.kind.link": {
+    "message": "Lien",
+    "description": "Type de production - Lien"
+  },
+  "artifacts.kind.other": {
+    "message": "Autre",
+    "description": "Type de production - Autre"
+  },
   "model.claudeOpus47": {
     "message": "claude-opus-4.7",
     "description": "Nom du modèle du service, c'est-à-dire Claude Opus 4.7"

--- a/src/i18n/it/chat.json
+++ b/src/i18n/it/chat.json
@@ -731,6 +731,98 @@
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
   },
+  "artifacts.navTitle": {
+    "message": "Produzioni",
+    "description": "Voce di accesso alle produzioni nella barra laterale"
+  },
+  "artifacts.title": {
+    "message": "Le mie produzioni",
+    "description": "Titolo della pagina delle produzioni"
+  },
+  "artifacts.summaryTotal": {
+    "message": "In questa edizione ci sono state {count} produzioni",
+    "description": "Totale delle produzioni riassunte"
+  },
+  "artifacts.filterAll": {
+    "message": "Tutti",
+    "description": "Filtro per tipo di produzione - tutti"
+  },
+  "artifacts.empty": {
+    "message": "Non ci sono ancora produzioni. Lascia che l'AI ti aiuti a scrivere articoli, generare immagini o inviare email e le produzioni appariranno automaticamente qui.",
+    "description": "Messaggio che indica che non ci sono produzioni"
+  },
+  "artifacts.loadError": {
+    "message": "Caricamento della produzione fallito",
+    "description": "Messaggio di errore per il caricamento della produzione"
+  },
+  "artifacts.actionError": {
+    "message": "Operazione fallita, riprova",
+    "description": "Messaggio di errore per operazione di produzione"
+  },
+  "artifacts.open": {
+    "message": "Apri",
+    "description": "Pulsante per aprire il link originale della produzione"
+  },
+  "artifacts.hide": {
+    "message": "Nascondi",
+    "description": "Pulsante per nascondere la produzione"
+  },
+  "artifacts.delete": {
+    "message": "Elimina",
+    "description": "Pulsante per eliminare la produzione"
+  },
+  "artifacts.deleteConfirm": {
+    "message": "Sei sicuro di voler eliminare permanentemente questo record di produzione?",
+    "description": "Messaggio di conferma per l'eliminazione della produzione"
+  },
+  "artifacts.loadMore": {
+    "message": "Carica di più",
+    "description": "Pulsante per caricare più produzioni"
+  },
+  "artifacts.sourceAuto": {
+    "message": "Cattura automatica",
+    "description": "Etichetta per la fonte di cattura automatica"
+  },
+  "artifacts.kind.article": {
+    "message": "Articolo",
+    "description": "Tipo di produzione - articolo"
+  },
+  "artifacts.kind.image": {
+    "message": "Immagine",
+    "description": "Tipo di produzione - immagine"
+  },
+  "artifacts.kind.video": {
+    "message": "Video",
+    "description": "Tipo di produzione - video"
+  },
+  "artifacts.kind.audio": {
+    "message": "Audio",
+    "description": "Tipo di produzione - audio"
+  },
+  "artifacts.kind.document": {
+    "message": "Documento",
+    "description": "Tipo di produzione - documento"
+  },
+  "artifacts.kind.email": {
+    "message": "Email",
+    "description": "Tipo di produzione - email"
+  },
+  "artifacts.kind.message": {
+    "message": "Messaggio",
+    "description": "Tipo di produzione - messaggio"
+  },
+  "artifacts.kind.dataset": {
+    "message": "Dati",
+    "description": "Tipo di produzione - dati"
+  },
+  "artifacts.kind.link": {
+    "message": "Link",
+    "description": "Tipo di produzione - link"
+  },
+  "artifacts.kind.other": {
+    "message": "Altro",
+    "description": "Tipo di produzione - altro"
+  },
   "model.claudeOpus47": {
     "message": "claude-opus-4.7",
     "description": "Nome del modello del servizio, ovvero Claude Opus 4.7"

--- a/src/i18n/ja/chat.json
+++ b/src/i18n/ja/chat.json
@@ -731,6 +731,98 @@
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
   },
+  "artifacts.navTitle": {
+    "message": "出力",
+    "description": "サイドバーの出力入口"
+  },
+  "artifacts.title": {
+    "message": "私の出力",
+    "description": "出力ページのタイトル"
+  },
+  "artifacts.summaryTotal": {
+    "message": "今期の出力は {count} 件です。",
+    "description": "出力の合計数を示すメッセージ"
+  },
+  "artifacts.filterAll": {
+    "message": "すべて",
+    "description": "出力タイプフィルター - すべて"
+  },
+  "artifacts.empty": {
+    "message": "まだ出力はありません。AIに記事を作成させたり、画像を生成したり、メールを送信したりすると、出力がここに自動的に表示されます。",
+    "description": "出力が空であることを示すメッセージ"
+  },
+  "artifacts.loadError": {
+    "message": "出力の読み込みに失敗しました。",
+    "description": "出力読み込みエラーの通知"
+  },
+  "artifacts.actionError": {
+    "message": "操作に失敗しました。再試行してください。",
+    "description": "出力操作エラーの通知"
+  },
+  "artifacts.open": {
+    "message": "開く",
+    "description": "出力の元リンクを開くボタン"
+  },
+  "artifacts.hide": {
+    "message": "非表示",
+    "description": "出力を非表示にするボタン"
+  },
+  "artifacts.delete": {
+    "message": "削除",
+    "description": "出力を削除するボタン"
+  },
+  "artifacts.deleteConfirm": {
+    "message": "この出力記録を永久に削除してもよろしいですか？",
+    "description": "出力削除の確認メッセージ"
+  },
+  "artifacts.loadMore": {
+    "message": "もっと読み込む",
+    "description": "さらに出力を読み込むボタン"
+  },
+  "artifacts.sourceAuto": {
+    "message": "自動キャプチャ",
+    "description": "自動キャプチャのソースマーク"
+  },
+  "artifacts.kind.article": {
+    "message": "記事",
+    "description": "出力タイプ - 記事"
+  },
+  "artifacts.kind.image": {
+    "message": "画像",
+    "description": "出力タイプ - 画像"
+  },
+  "artifacts.kind.video": {
+    "message": "動画",
+    "description": "出力タイプ - 動画"
+  },
+  "artifacts.kind.audio": {
+    "message": "音声",
+    "description": "出力タイプ - 音声"
+  },
+  "artifacts.kind.document": {
+    "message": "文書",
+    "description": "出力タイプ - 文書"
+  },
+  "artifacts.kind.email": {
+    "message": "メール",
+    "description": "出力タイプ - メール"
+  },
+  "artifacts.kind.message": {
+    "message": "メッセージ",
+    "description": "出力タイプ - メッセージ"
+  },
+  "artifacts.kind.dataset": {
+    "message": "データ",
+    "description": "出力タイプ - データ"
+  },
+  "artifacts.kind.link": {
+    "message": "リンク",
+    "description": "出力タイプ - リンク"
+  },
+  "artifacts.kind.other": {
+    "message": "その他",
+    "description": "出力タイプ - その他"
+  },
   "model.claudeOpus47": {
     "message": "claude-opus-4.7",
     "description": "サービスのモデル名、すなわち Claude Opus 4.7"

--- a/src/i18n/ko/chat.json
+++ b/src/i18n/ko/chat.json
@@ -731,6 +731,98 @@
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
   },
+  "artifacts.navTitle": {
+    "message": "출력",
+    "description": "사이드바 출력 항목"
+  },
+  "artifacts.title": {
+    "message": "내 출력",
+    "description": "출력 페이지 제목"
+  },
+  "artifacts.summaryTotal": {
+    "message": "이번 기간에 생성된 출력 {count} 항목",
+    "description": "출력 요약 총 수"
+  },
+  "artifacts.filterAll": {
+    "message": "전체",
+    "description": "출력 유형 필터 - 전체"
+  },
+  "artifacts.empty": {
+    "message": "아직 출력이 없습니다. AI에게 글을 작성하거나 이미지를 생성하거나 이메일을 보내면 출력이 자동으로 여기에 나타납니다.",
+    "description": "출력이 비어있음을 알리는 메시지"
+  },
+  "artifacts.loadError": {
+    "message": "출력 로드 실패",
+    "description": "출력 로드 오류 알림"
+  },
+  "artifacts.actionError": {
+    "message": "작업 실패, 다시 시도해 주세요",
+    "description": "작업 오류 알림"
+  },
+  "artifacts.open": {
+    "message": "열기",
+    "description": "출력 원본 링크를 여는 버튼"
+  },
+  "artifacts.hide": {
+    "message": "숨기기",
+    "description": "출력을 숨기는 버튼"
+  },
+  "artifacts.delete": {
+    "message": "삭제",
+    "description": "출력을 삭제하는 버튼"
+  },
+  "artifacts.deleteConfirm": {
+    "message": "이 출력을 영구적으로 삭제하시겠습니까?",
+    "description": "출력 삭제 확인 알림"
+  },
+  "artifacts.loadMore": {
+    "message": "더 보기",
+    "description": "더 많은 출력을 로드하는 버튼"
+  },
+  "artifacts.sourceAuto": {
+    "message": "자동 캡처",
+    "description": "자동 캡처 출처 표시"
+  },
+  "artifacts.kind.article": {
+    "message": "기사",
+    "description": "출력 유형 - 기사"
+  },
+  "artifacts.kind.image": {
+    "message": "이미지",
+    "description": "출력 유형 - 이미지"
+  },
+  "artifacts.kind.video": {
+    "message": "비디오",
+    "description": "출력 유형 - 비디오"
+  },
+  "artifacts.kind.audio": {
+    "message": "오디오",
+    "description": "출력 유형 - 오디오"
+  },
+  "artifacts.kind.document": {
+    "message": "문서",
+    "description": "출력 유형 - 문서"
+  },
+  "artifacts.kind.email": {
+    "message": "이메일",
+    "description": "출력 유형 - 이메일"
+  },
+  "artifacts.kind.message": {
+    "message": "메시지",
+    "description": "출력 유형 - 메시지"
+  },
+  "artifacts.kind.dataset": {
+    "message": "데이터",
+    "description": "출력 유형 - 데이터"
+  },
+  "artifacts.kind.link": {
+    "message": "링크",
+    "description": "출력 유형 - 링크"
+  },
+  "artifacts.kind.other": {
+    "message": "기타",
+    "description": "출력 유형 - 기타"
+  },
   "model.claudeOpus47": {
     "message": "claude-opus-4.7",
     "description": "서비스의 모델 이름, 즉 Claude Opus 4.7"

--- a/src/i18n/pl/chat.json
+++ b/src/i18n/pl/chat.json
@@ -731,6 +731,98 @@
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
   },
+  "artifacts.navTitle": {
+    "message": "Elementy",
+    "description": "Tytuł sekcji elementów w pasku bocznym"
+  },
+  "artifacts.title": {
+    "message": "Moje elementy",
+    "description": "Tytuł strony z elementami"
+  },
+  "artifacts.summaryTotal": {
+    "message": "W tej edycji stworzono {count} elementów",
+    "description": "Podsumowanie łącznej liczby elementów"
+  },
+  "artifacts.filterAll": {
+    "message": "Wszystko",
+    "description": "Filtruj typy elementów - wszystko"
+  },
+  "artifacts.empty": {
+    "message": "Nie ma jeszcze żadnych elementów. Po tym, jak AI pomoże Ci napisać artykuł, wygenerować obraz lub wysłać e-mail, elementy automatycznie pojawią się tutaj.",
+    "description": "Wskazówka, gdy nie ma żadnych elementów"
+  },
+  "artifacts.loadError": {
+    "message": "Nie udało się załadować elementów",
+    "description": "Wskazówka o błędzie ładowania elementów"
+  },
+  "artifacts.actionError": {
+    "message": "Operacja nie powiodła się, spróbuj ponownie",
+    "description": "Wskazówka o błędzie operacji"
+  },
+  "artifacts.open": {
+    "message": "Otwórz",
+    "description": "Przycisk do otwierania oryginalnego linku elementu"
+  },
+  "artifacts.hide": {
+    "message": "Ukryj",
+    "description": "Przycisk do ukrywania elementu"
+  },
+  "artifacts.delete": {
+    "message": "Usuń",
+    "description": "Przycisk do usuwania elementu"
+  },
+  "artifacts.deleteConfirm": {
+    "message": "Czy na pewno chcesz na stałe usunąć ten rekord?",
+    "description": "Potwierdzenie usunięcia elementu"
+  },
+  "artifacts.loadMore": {
+    "message": "Załaduj więcej",
+    "description": "Przycisk do ładowania większej ilości elementów"
+  },
+  "artifacts.sourceAuto": {
+    "message": "Automatyczne przechwytywanie",
+    "description": "Oznaczenie źródła automatycznego przechwytywania"
+  },
+  "artifacts.kind.article": {
+    "message": "Artykuł",
+    "description": "Typ elementu - artykuł"
+  },
+  "artifacts.kind.image": {
+    "message": "Obraz",
+    "description": "Typ elementu - obraz"
+  },
+  "artifacts.kind.video": {
+    "message": "Wideo",
+    "description": "Typ elementu - wideo"
+  },
+  "artifacts.kind.audio": {
+    "message": "Audio",
+    "description": "Typ elementu - audio"
+  },
+  "artifacts.kind.document": {
+    "message": "Dokument",
+    "description": "Typ elementu - dokument"
+  },
+  "artifacts.kind.email": {
+    "message": "E-mail",
+    "description": "Typ elementu - e-mail"
+  },
+  "artifacts.kind.message": {
+    "message": "Wiadomość",
+    "description": "Typ elementu - wiadomość"
+  },
+  "artifacts.kind.dataset": {
+    "message": "Dane",
+    "description": "Typ elementu - dane"
+  },
+  "artifacts.kind.link": {
+    "message": "Link",
+    "description": "Typ elementu - link"
+  },
+  "artifacts.kind.other": {
+    "message": "Inne",
+    "description": "Typ elementu - inne"
+  },
   "model.claudeOpus47": {
     "message": "claude-opus-4.7",
     "description": "Nazwa modelu usługi, czyli Claude Opus 4.7"

--- a/src/i18n/pt/chat.json
+++ b/src/i18n/pt/chat.json
@@ -731,6 +731,98 @@
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
   },
+  "artifacts.navTitle": {
+    "message": "Saídas",
+    "description": "Entrada do menu lateral para saídas"
+  },
+  "artifacts.title": {
+    "message": "Minhas saídas",
+    "description": "Título da página de saídas"
+  },
+  "artifacts.summaryTotal": {
+    "message": "Total de saídas nesta edição: {count}",
+    "description": "Total de saídas resumidas"
+  },
+  "artifacts.filterAll": {
+    "message": "Todos",
+    "description": "Filtro de tipo de saída - Todos"
+  },
+  "artifacts.empty": {
+    "message": "Ainda não há nenhuma saída. Deixe a IA ajudá-lo a publicar artigos, gerar imagens ou enviar e-mails, e as saídas aparecerão automaticamente aqui.",
+    "description": "Mensagem indicando que não há saídas"
+  },
+  "artifacts.loadError": {
+    "message": "Falha ao carregar a saída",
+    "description": "Mensagem de erro ao carregar a saída"
+  },
+  "artifacts.actionError": {
+    "message": "A operação falhou, por favor tente novamente",
+    "description": "Mensagem de erro para operações de saída"
+  },
+  "artifacts.open": {
+    "message": "Abrir",
+    "description": "Botão para abrir o link original da saída"
+  },
+  "artifacts.hide": {
+    "message": "Ocultar",
+    "description": "Botão para ocultar saída"
+  },
+  "artifacts.delete": {
+    "message": "Excluir",
+    "description": "Botão para excluir saída"
+  },
+  "artifacts.deleteConfirm": {
+    "message": "Você tem certeza de que deseja excluir permanentemente este registro de saída?",
+    "description": "Mensagem de confirmação para exclusão de saída"
+  },
+  "artifacts.loadMore": {
+    "message": "Carregar mais",
+    "description": "Botão para carregar mais saídas"
+  },
+  "artifacts.sourceAuto": {
+    "message": "Captura automática",
+    "description": "Marcador de origem de captura automática"
+  },
+  "artifacts.kind.article": {
+    "message": "Artigo",
+    "description": "Tipo de saída - Artigo"
+  },
+  "artifacts.kind.image": {
+    "message": "Imagem",
+    "description": "Tipo de saída - Imagem"
+  },
+  "artifacts.kind.video": {
+    "message": "Vídeo",
+    "description": "Tipo de saída - Vídeo"
+  },
+  "artifacts.kind.audio": {
+    "message": "Áudio",
+    "description": "Tipo de saída - Áudio"
+  },
+  "artifacts.kind.document": {
+    "message": "Documento",
+    "description": "Tipo de saída - Documento"
+  },
+  "artifacts.kind.email": {
+    "message": "E-mail",
+    "description": "Tipo de saída - E-mail"
+  },
+  "artifacts.kind.message": {
+    "message": "Mensagem",
+    "description": "Tipo de saída - Mensagem"
+  },
+  "artifacts.kind.dataset": {
+    "message": "Dados",
+    "description": "Tipo de saída - Dados"
+  },
+  "artifacts.kind.link": {
+    "message": "Link",
+    "description": "Tipo de saída - Link"
+  },
+  "artifacts.kind.other": {
+    "message": "Outro",
+    "description": "Tipo de saída - Outro"
+  },
   "model.claudeOpus47": {
     "message": "claude-opus-4.7",
     "description": "Nome do modelo do serviço, ou seja, Claude Opus 4.7"

--- a/src/i18n/ru/chat.json
+++ b/src/i18n/ru/chat.json
@@ -731,6 +731,98 @@
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
   },
+  "artifacts.navTitle": {
+    "message": "Результаты",
+    "description": "Вход в боковую панель результатов"
+  },
+  "artifacts.title": {
+    "message": "Мои результаты",
+    "description": "Заголовок страницы результатов"
+  },
+  "artifacts.summaryTotal": {
+    "message": "Всего создано {count} результатов в этом периоде",
+    "description": "Общее количество результатов"
+  },
+  "artifacts.filterAll": {
+    "message": "Все",
+    "description": "Фильтр по типу результата - все"
+  },
+  "artifacts.empty": {
+    "message": "Пока нет никаких результатов. После того, как AI поможет вам написать статью, создать изображение или отправить электронное письмо, результаты автоматически появятся здесь.",
+    "description": "Сообщение о пустом результате"
+  },
+  "artifacts.loadError": {
+    "message": "Не удалось загрузить результаты",
+    "description": "Сообщение об ошибке загрузки результата"
+  },
+  "artifacts.actionError": {
+    "message": "Операция не удалась, пожалуйста, попробуйте еще раз",
+    "description": "Сообщение об ошибке операции"
+  },
+  "artifacts.open": {
+    "message": "Открыть",
+    "description": "Кнопка открытия оригинальной ссылки результата"
+  },
+  "artifacts.hide": {
+    "message": "Скрыть",
+    "description": "Кнопка скрытия результата"
+  },
+  "artifacts.delete": {
+    "message": "Удалить",
+    "description": "Кнопка удаления результата"
+  },
+  "artifacts.deleteConfirm": {
+    "message": "Вы уверены, что хотите навсегда удалить эту запись результата?",
+    "description": "Подтверждение удаления результата"
+  },
+  "artifacts.loadMore": {
+    "message": "Загрузить больше",
+    "description": "Кнопка загрузки дополнительных результатов"
+  },
+  "artifacts.sourceAuto": {
+    "message": "Автоматический захват",
+    "description": "Метка источника автоматического захвата"
+  },
+  "artifacts.kind.article": {
+    "message": "Статья",
+    "description": "Тип результата - статья"
+  },
+  "artifacts.kind.image": {
+    "message": "Изображение",
+    "description": "Тип результата - изображение"
+  },
+  "artifacts.kind.video": {
+    "message": "Видео",
+    "description": "Тип результата - видео"
+  },
+  "artifacts.kind.audio": {
+    "message": "Аудио",
+    "description": "Тип результата - аудио"
+  },
+  "artifacts.kind.document": {
+    "message": "Документ",
+    "description": "Тип результата - документ"
+  },
+  "artifacts.kind.email": {
+    "message": "Электронная почта",
+    "description": "Тип результата - электронная почта"
+  },
+  "artifacts.kind.message": {
+    "message": "Сообщение",
+    "description": "Тип результата - сообщение"
+  },
+  "artifacts.kind.dataset": {
+    "message": "Данные",
+    "description": "Тип результата - данные"
+  },
+  "artifacts.kind.link": {
+    "message": "Ссылка",
+    "description": "Тип результата - ссылка"
+  },
+  "artifacts.kind.other": {
+    "message": "Другие",
+    "description": "Тип результата - другие"
+  },
   "model.claudeOpus47": {
     "message": "claude-opus-4.7",
     "description": "Название модели сервиса, то есть Claude Opus 4.7"

--- a/src/i18n/sr/chat.json
+++ b/src/i18n/sr/chat.json
@@ -731,6 +731,98 @@
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
   },
+  "artifacts.navTitle": {
+    "message": "Производи",
+    "description": "Наслов у бочној траци за производе"
+  },
+  "artifacts.title": {
+    "message": "Моји производи",
+    "description": "Наслов странице производа"
+  },
+  "artifacts.summaryTotal": {
+    "message": "У овом периоду је створено {count} производа",
+    "description": "Укупни број производа"
+  },
+  "artifacts.filterAll": {
+    "message": "Све",
+    "description": "Филтер типова производа - све"
+  },
+  "artifacts.empty": {
+    "message": "Нема ниједног производа. Када AI помогне да напишете чланак, генеришете слике или пошаљете е-пошту, производи ће се аутоматски појавити овде.",
+    "description": "Порука када нема производа"
+  },
+  "artifacts.loadError": {
+    "message": "Неуспешно учитавање производа",
+    "description": "Порука о грешци при учитавању производа"
+  },
+  "artifacts.actionError": {
+    "message": "Операција је失败，请重试",
+    "description": "Порука о грешци у операцији"
+  },
+  "artifacts.open": {
+    "message": "Отвори",
+    "description": "Дугме за отварање оригиналне везе производа"
+  },
+  "artifacts.hide": {
+    "message": "Сакриј",
+    "description": "Дугме за сакривање производа"
+  },
+  "artifacts.delete": {
+    "message": "Избриши",
+    "description": "Дугме за брисање"
+  },
+  "artifacts.deleteConfirm": {
+    "message": "Да ли сте сигурни да желите трајно да избришете овај запис?",
+    "description": "Потврда за брисање"
+  },
+  "artifacts.loadMore": {
+    "message": "Учитај више",
+    "description": "Дугме за учитавање више производа"
+  },
+  "artifacts.sourceAuto": {
+    "message": "Аутоматско хватање",
+    "description": "Ознака за аутоматско хватање извора"
+  },
+  "artifacts.kind.article": {
+    "message": "Чланак",
+    "description": "Тип производа - чланак"
+  },
+  "artifacts.kind.image": {
+    "message": "Слика",
+    "description": "Тип производа - слика"
+  },
+  "artifacts.kind.video": {
+    "message": "Видео",
+    "description": "Тип производа - видео"
+  },
+  "artifacts.kind.audio": {
+    "message": "Аудио",
+    "description": "Тип производа - аудио"
+  },
+  "artifacts.kind.document": {
+    "message": "Документ",
+    "description": "Тип производа - документ"
+  },
+  "artifacts.kind.email": {
+    "message": "Е-пошта",
+    "description": "Тип производа - е-пошта"
+  },
+  "artifacts.kind.message": {
+    "message": "Порука",
+    "description": "Тип производа - порука"
+  },
+  "artifacts.kind.dataset": {
+    "message": "Податак",
+    "description": "Тип производа - податак"
+  },
+  "artifacts.kind.link": {
+    "message": "Линк",
+    "description": "Тип производа - линк"
+  },
+  "artifacts.kind.other": {
+    "message": "Друго",
+    "description": "Тип производа - друго"
+  },
   "model.claudeOpus47": {
     "message": "claude-opus-4.7",
     "description": "Naziv modela usluge, tj. Claude Opus 4.7"

--- a/src/i18n/sv/chat.json
+++ b/src/i18n/sv/chat.json
@@ -731,6 +731,98 @@
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
   },
+  "artifacts.navTitle": {
+    "message": "Utdata",
+    "description": "Sidofältets ingång för utdata"
+  },
+  "artifacts.title": {
+    "message": "Mina utdata",
+    "description": "Titel på utdata sidan"
+  },
+  "artifacts.summaryTotal": {
+    "message": "Totalt har {count} utdata producerats",
+    "description": "Sammanfattning av det totala antalet utdata"
+  },
+  "artifacts.filterAll": {
+    "message": "Alla",
+    "description": "Filtrering av utdata typ - alla"
+  },
+  "artifacts.empty": {
+    "message": "Det finns inga utdata ännu. Låt AI hjälpa dig att publicera artiklar, generera bilder eller skicka e-post, så kommer utdata automatiskt att visas här.",
+    "description": "Meddelande när det inte finns några utdata"
+  },
+  "artifacts.loadError": {
+    "message": "Misslyckades med att ladda utdata",
+    "description": "Felmeddelande för att ladda utdata"
+  },
+  "artifacts.actionError": {
+    "message": "Åtgärden misslyckades, vänligen försök igen",
+    "description": "Felmeddelande för utdataåtgärd"
+  },
+  "artifacts.open": {
+    "message": "Öppna",
+    "description": "Knapp för att öppna den ursprungliga länken till utdata"
+  },
+  "artifacts.hide": {
+    "message": "Dölj",
+    "description": "Knapp för att dölja utdata"
+  },
+  "artifacts.delete": {
+    "message": "Ta bort",
+    "description": "Knapp för att ta bort utdata"
+  },
+  "artifacts.deleteConfirm": {
+    "message": "Vill du verkligen permanent ta bort denna utdata post?",
+    "description": "Bekräftelsemeddelande för att ta bort utdata"
+  },
+  "artifacts.loadMore": {
+    "message": "Ladda mer",
+    "description": "Knapp för att ladda fler utdata"
+  },
+  "artifacts.sourceAuto": {
+    "message": "Automatisk fångst",
+    "description": "Markering för automatisk fångst av källa"
+  },
+  "artifacts.kind.article": {
+    "message": "Artikel",
+    "description": "Utdata typ - artikel"
+  },
+  "artifacts.kind.image": {
+    "message": "Bild",
+    "description": "Utdata typ - bild"
+  },
+  "artifacts.kind.video": {
+    "message": "Video",
+    "description": "Utdata typ - video"
+  },
+  "artifacts.kind.audio": {
+    "message": "Ljud",
+    "description": "Utdata typ - ljud"
+  },
+  "artifacts.kind.document": {
+    "message": "Dokument",
+    "description": "Utdata typ - dokument"
+  },
+  "artifacts.kind.email": {
+    "message": "E-post",
+    "description": "Utdata typ - e-post"
+  },
+  "artifacts.kind.message": {
+    "message": "Meddelande",
+    "description": "Utdata typ - meddelande"
+  },
+  "artifacts.kind.dataset": {
+    "message": "Data",
+    "description": "Utdata typ - data"
+  },
+  "artifacts.kind.link": {
+    "message": "Länk",
+    "description": "Utdata typ - länk"
+  },
+  "artifacts.kind.other": {
+    "message": "Annat",
+    "description": "Utdata typ - annat"
+  },
   "model.claudeOpus47": {
     "message": "claude-opus-4.7",
     "description": "Modellnamnet för tjänsten, det vill säga Claude Opus 4.7"

--- a/src/i18n/uk/chat.json
+++ b/src/i18n/uk/chat.json
@@ -731,6 +731,98 @@
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
   },
+  "artifacts.navTitle": {
+    "message": "Артефакти",
+    "description": "Вхід до артефактів в бічній панелі"
+  },
+  "artifacts.title": {
+    "message": "Мої артефакти",
+    "description": "Заголовок сторінки артефактів"
+  },
+  "artifacts.summaryTotal": {
+    "message": "Цього разу створено {count} артефактів",
+    "description": "Загальна кількість артефактів"
+  },
+  "artifacts.filterAll": {
+    "message": "Усе",
+    "description": "Фільтр типів артефактів - усе"
+  },
+  "artifacts.empty": {
+    "message": "Ще немає жодного артефакту. Дайте AI допомогти вам написати статтю, згенерувати зображення або надіслати електронну пошту, після чого артефакти автоматично з'являться тут.",
+    "description": "Повідомлення про те, що артефакти відсутні"
+  },
+  "artifacts.loadError": {
+    "message": "Не вдалося завантажити артефакти",
+    "description": "Повідомлення про помилку завантаження артефактів"
+  },
+  "artifacts.actionError": {
+    "message": "Операція не вдалася, будь ласка, спробуйте ще раз",
+    "description": "Повідомлення про помилку операції"
+  },
+  "artifacts.open": {
+    "message": "Відкрити",
+    "description": "Кнопка для відкриття оригінального посилання артефакту"
+  },
+  "artifacts.hide": {
+    "message": "Сховати",
+    "description": "Кнопка для приховування артефакту"
+  },
+  "artifacts.delete": {
+    "message": "Видалити",
+    "description": "Кнопка для видалення артефакту"
+  },
+  "artifacts.deleteConfirm": {
+    "message": "Ви впевнені, що хочете назавжди видалити цей запис артефакту?",
+    "description": "Підтвердження видалення артефакту"
+  },
+  "artifacts.loadMore": {
+    "message": "Завантажити більше",
+    "description": "Кнопка для завантаження додаткових артефактів"
+  },
+  "artifacts.sourceAuto": {
+    "message": "Автоматичне захоплення",
+    "description": "Позначка для автоматичного захоплення джерела"
+  },
+  "artifacts.kind.article": {
+    "message": "Стаття",
+    "description": "Тип артефакту - стаття"
+  },
+  "artifacts.kind.image": {
+    "message": "Зображення",
+    "description": "Тип артефакту - зображення"
+  },
+  "artifacts.kind.video": {
+    "message": "Відео",
+    "description": "Тип артефакту - відео"
+  },
+  "artifacts.kind.audio": {
+    "message": "Аудіо",
+    "description": "Тип артефакту - аудіо"
+  },
+  "artifacts.kind.document": {
+    "message": "Документ",
+    "description": "Тип артефакту - документ"
+  },
+  "artifacts.kind.email": {
+    "message": "Електронна пошта",
+    "description": "Тип артефакту - електронна пошта"
+  },
+  "artifacts.kind.message": {
+    "message": "Повідомлення",
+    "description": "Тип артефакту - повідомлення"
+  },
+  "artifacts.kind.dataset": {
+    "message": "Дані",
+    "description": "Тип артефакту - дані"
+  },
+  "artifacts.kind.link": {
+    "message": "Посилання",
+    "description": "Тип артефакту - посилання"
+  },
+  "artifacts.kind.other": {
+    "message": "Інше",
+    "description": "Тип артефакту - інше"
+  },
   "model.claudeOpus47": {
     "message": "claude-opus-4.7",
     "description": "Назва моделі сервісу, тобто Claude Opus 4.7"

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -575,55 +575,288 @@
     "message": "已跳过连接器授权",
     "description": "用户跳过授权后的卡片底部说明"
   },
-  "scheduledTasks.navTitle": { "message": "定时任务", "description": "侧边栏定时任务入口" },
-  "scheduledTasks.title": { "message": "定时任务", "description": "页面标题" },
-  "scheduledTasks.create": { "message": "新建", "description": "创建定时任务按钮" },
-  "scheduledTasks.edit": { "message": "编辑任务", "description": "编辑对话框标题" },
-  "scheduledTasks.empty": { "message": "还没有定时任务，点击「新建」创建一个", "description": "空状态提示" },
-  "scheduledTasks.noRuns": { "message": "尚未运行", "description": "没有运行历史" },
-  "scheduledTasks.loadError": { "message": "加载失败", "description": "加载错误提示" },
-  "scheduledTasks.deleteConfirm": { "message": "确认删除「{name}」？删除后任务将停止运行。", "description": "删除确认" },
-  "scheduledTasks.viewResult": { "message": "查看结果", "description": "跳转到对话" },
-  "scheduledTasks.viewRuns": { "message": "运行记录", "description": "卡片底部查看运行历史" },
-  "scheduledTasks.noConversation": { "message": "无对话记录", "description": "运行未关联对话（旧版本运行）" },
-  "scheduledTasks.jitterHint": { "message": "±60s 抖动", "description": "运行时间抖动说明" },
-  "scheduledTasks.runCount": { "message": "已运行 {count} 次", "description": "运行次数" },
-  "scheduledTasks.state.enabled": { "message": "运行中", "description": "启用状态" },
-  "scheduledTasks.state.disabled": { "message": "已暂停", "description": "禁用状态" },
-  "scheduledTasks.state.error": { "message": "出错", "description": "错误状态" },
-  "scheduledTasks.run.queued": { "message": "排队", "description": "排队状态" },
-  "scheduledTasks.run.running": { "message": "运行中", "description": "运行中状态" },
-  "scheduledTasks.run.success": { "message": "成功", "description": "成功状态" },
-  "scheduledTasks.run.failed": { "message": "失败", "description": "失败状态" },
-  "scheduledTasks.run.needs_user_input": { "message": "需要操作", "description": "需要用户操作状态" },
-  "scheduledTasks.scheduleType.daily": { "message": "每天", "description": "每天执行" },
-  "scheduledTasks.scheduleType.minutely": { "message": "每分钟", "description": "每分钟执行" },
-  "scheduledTasks.scheduleType.hourly": { "message": "每小时", "description": "每小时执行" },
-  "scheduledTasks.scheduleType.weekly": { "message": "每周", "description": "每周执行" },
-  "scheduledTasks.scheduleType.cron": { "message": "Cron 表达式", "description": "自定义 cron" },
-  "scheduledTasks.form.name": { "message": "任务名称", "description": "名称字段" },
-  "scheduledTasks.form.namePlaceholder": { "message": "例：每日资讯汇总", "description": "名称占位符" },
-  "scheduledTasks.form.model": { "message": "模型", "description": "模型选择" },
-  "scheduledTasks.form.prompt": { "message": "提示词", "description": "提示词字段" },
-  "scheduledTasks.form.promptPlaceholder": { "message": "输入要定时执行的问题或指令，支持 {'{{date}}'}、{'{{run_count}}'}、{'{{last_output}}'} 变量", "description": "提示词占位符" },
-  "scheduledTasks.form.promptHint": { "message": "支持模板变量：{'{{date}}'} 今日日期，{'{{run_count}}'} 第几次运行，{'{{last_output}}'} 上次结果摘要", "description": "提示词说明" },
-  "scheduledTasks.form.schedule": { "message": "执行频率", "description": "频率选择" },
-  "scheduledTasks.form.time": { "message": "执行时间", "description": "时间字段" },
-  "scheduledTasks.form.weekday": { "message": "星期", "description": "星期字段" },
-  "scheduledTasks.form.cron": { "message": "Cron 表达式", "description": "cron 表达式字段" },
-  "scheduledTasks.form.skills": { "message": "授权 Skills", "description": "定时任务无人值守授权 skill 多选" },
-  "scheduledTasks.form.skillsPlaceholder": { "message": "选择允许此任务自动执行的 Skills", "description": "授权 skill 占位符" },
-  "scheduledTasks.form.skillsHint": { "message": "选中的 Skills 可在定时任务后台执行时跳过人工确认；未选中的 Skills 仍只能预览或等待确认。", "description": "授权 skill 说明" },
-  "scheduledTasks.form.skillMissing": { "message": "未连接", "description": "skill 缺少连接" },
-  "scheduledTasks.form.mcpServers": { "message": "授权 MCP", "description": "定时任务无人值守授权 MCP server 多选" },
-  "scheduledTasks.form.mcpServersPlaceholder": { "message": "选择允许此任务自动加载的 MCP Servers", "description": "授权 MCP server 占位符" },
-  "scheduledTasks.form.mcpServersHint": { "message": "选中的 MCP Servers 可在定时任务后台加载并执行；未选中的 MCP Servers 不会在无人值守模式下加载。", "description": "授权 MCP server 说明" },
-  "scheduledTasks.form.maxTurns": { "message": "最大轮次", "description": "定时任务单次运行的最大 agent 轮次上限" },
-  "scheduledTasks.form.maxTurnsHint": { "message": "任务单次运行允许的最大对话轮次（1–50）。上限太低会让多步骤任务（如需多次执行 Bash、查文档的技能）在完成前被强制停止、没有最终结果。默认 50。", "description": "最大轮次说明" },
-  "scheduledTasks.form.skillsConfirmTitle": { "message": "确认无人值守授权", "description": "授权确认标题" },
+  "scheduledTasks.navTitle": {
+    "message": "定时任务",
+    "description": "侧边栏定时任务入口"
+  },
+  "scheduledTasks.title": {
+    "message": "定时任务",
+    "description": "页面标题"
+  },
+  "scheduledTasks.create": {
+    "message": "新建",
+    "description": "创建定时任务按钮"
+  },
+  "scheduledTasks.edit": {
+    "message": "编辑任务",
+    "description": "编辑对话框标题"
+  },
+  "scheduledTasks.empty": {
+    "message": "还没有定时任务，点击「新建」创建一个",
+    "description": "空状态提示"
+  },
+  "scheduledTasks.noRuns": {
+    "message": "尚未运行",
+    "description": "没有运行历史"
+  },
+  "scheduledTasks.loadError": {
+    "message": "加载失败",
+    "description": "加载错误提示"
+  },
+  "scheduledTasks.deleteConfirm": {
+    "message": "确认删除「{name}」？删除后任务将停止运行。",
+    "description": "删除确认"
+  },
+  "scheduledTasks.viewResult": {
+    "message": "查看结果",
+    "description": "跳转到对话"
+  },
+  "scheduledTasks.viewRuns": {
+    "message": "运行记录",
+    "description": "卡片底部查看运行历史"
+  },
+  "scheduledTasks.noConversation": {
+    "message": "无对话记录",
+    "description": "运行未关联对话（旧版本运行）"
+  },
+  "scheduledTasks.jitterHint": {
+    "message": "±60s 抖动",
+    "description": "运行时间抖动说明"
+  },
+  "scheduledTasks.runCount": {
+    "message": "已运行 {count} 次",
+    "description": "运行次数"
+  },
+  "scheduledTasks.state.enabled": {
+    "message": "运行中",
+    "description": "启用状态"
+  },
+  "scheduledTasks.state.disabled": {
+    "message": "已暂停",
+    "description": "禁用状态"
+  },
+  "scheduledTasks.state.error": {
+    "message": "出错",
+    "description": "错误状态"
+  },
+  "scheduledTasks.run.queued": {
+    "message": "排队",
+    "description": "排队状态"
+  },
+  "scheduledTasks.run.running": {
+    "message": "运行中",
+    "description": "运行中状态"
+  },
+  "scheduledTasks.run.success": {
+    "message": "成功",
+    "description": "成功状态"
+  },
+  "scheduledTasks.run.failed": {
+    "message": "失败",
+    "description": "失败状态"
+  },
+  "scheduledTasks.run.needs_user_input": {
+    "message": "需要操作",
+    "description": "需要用户操作状态"
+  },
+  "scheduledTasks.scheduleType.daily": {
+    "message": "每天",
+    "description": "每天执行"
+  },
+  "scheduledTasks.scheduleType.minutely": {
+    "message": "每分钟",
+    "description": "每分钟执行"
+  },
+  "scheduledTasks.scheduleType.hourly": {
+    "message": "每小时",
+    "description": "每小时执行"
+  },
+  "scheduledTasks.scheduleType.weekly": {
+    "message": "每周",
+    "description": "每周执行"
+  },
+  "scheduledTasks.scheduleType.cron": {
+    "message": "Cron 表达式",
+    "description": "自定义 cron"
+  },
+  "scheduledTasks.form.name": {
+    "message": "任务名称",
+    "description": "名称字段"
+  },
+  "scheduledTasks.form.namePlaceholder": {
+    "message": "例：每日资讯汇总",
+    "description": "名称占位符"
+  },
+  "scheduledTasks.form.model": {
+    "message": "模型",
+    "description": "模型选择"
+  },
+  "scheduledTasks.form.prompt": {
+    "message": "提示词",
+    "description": "提示词字段"
+  },
+  "scheduledTasks.form.promptPlaceholder": {
+    "message": "输入要定时执行的问题或指令，支持 {'{{date}}'}、{'{{run_count}}'}、{'{{last_output}}'} 变量",
+    "description": "提示词占位符"
+  },
+  "scheduledTasks.form.promptHint": {
+    "message": "支持模板变量：{'{{date}}'} 今日日期，{'{{run_count}}'} 第几次运行，{'{{last_output}}'} 上次结果摘要",
+    "description": "提示词说明"
+  },
+  "scheduledTasks.form.schedule": {
+    "message": "执行频率",
+    "description": "频率选择"
+  },
+  "scheduledTasks.form.time": {
+    "message": "执行时间",
+    "description": "时间字段"
+  },
+  "scheduledTasks.form.weekday": {
+    "message": "星期",
+    "description": "星期字段"
+  },
+  "scheduledTasks.form.cron": {
+    "message": "Cron 表达式",
+    "description": "cron 表达式字段"
+  },
+  "scheduledTasks.form.skills": {
+    "message": "授权 Skills",
+    "description": "定时任务无人值守授权 skill 多选"
+  },
+  "scheduledTasks.form.skillsPlaceholder": {
+    "message": "选择允许此任务自动执行的 Skills",
+    "description": "授权 skill 占位符"
+  },
+  "scheduledTasks.form.skillsHint": {
+    "message": "选中的 Skills 可在定时任务后台执行时跳过人工确认；未选中的 Skills 仍只能预览或等待确认。",
+    "description": "授权 skill 说明"
+  },
+  "scheduledTasks.form.skillMissing": {
+    "message": "未连接",
+    "description": "skill 缺少连接"
+  },
+  "scheduledTasks.form.mcpServers": {
+    "message": "授权 MCP",
+    "description": "定时任务无人值守授权 MCP server 多选"
+  },
+  "scheduledTasks.form.mcpServersPlaceholder": {
+    "message": "选择允许此任务自动加载的 MCP Servers",
+    "description": "授权 MCP server 占位符"
+  },
+  "scheduledTasks.form.mcpServersHint": {
+    "message": "选中的 MCP Servers 可在定时任务后台加载并执行；未选中的 MCP Servers 不会在无人值守模式下加载。",
+    "description": "授权 MCP server 说明"
+  },
+  "scheduledTasks.form.maxTurns": {
+    "message": "最大轮次",
+    "description": "定时任务单次运行的最大 agent 轮次上限"
+  },
+  "scheduledTasks.form.maxTurnsHint": {
+    "message": "任务单次运行允许的最大对话轮次（1–50）。上限太低会让多步骤任务（如需多次执行 Bash、查文档的技能）在完成前被强制停止、没有最终结果。默认 50。",
+    "description": "最大轮次说明"
+  },
+  "scheduledTasks.form.skillsConfirmTitle": {
+    "message": "确认无人值守授权",
+    "description": "授权确认标题"
+  },
   "scheduledTasks.form.skillsConfirm": {
     "message": "此任务将允许 {count} 个 Skill/MCP 在后台执行时跳过人工确认或加载限制：{skills}。它们可能会发送消息、发布内容或写入外部服务，请确认。",
     "description": "授权确认正文"
   },
-  "scheduledTasks.form.required": { "message": "请填写任务名称和提示词", "description": "必填项验证" }
+  "scheduledTasks.form.required": {
+    "message": "请填写任务名称和提示词",
+    "description": "必填项验证"
+  },
+  "artifacts.navTitle": {
+    "message": "产出",
+    "description": "侧边栏产出入口"
+  },
+  "artifacts.title": {
+    "message": "我的产出",
+    "description": "产出页面标题"
+  },
+  "artifacts.summaryTotal": {
+    "message": "本期共产出 {count} 项",
+    "description": "产出汇总总数"
+  },
+  "artifacts.filterAll": {
+    "message": "全部",
+    "description": "产出类型筛选-全部"
+  },
+  "artifacts.empty": {
+    "message": "还没有任何产出。让 AI 帮你发文章、生成图片或发送邮件后，产出会自动出现在这里。",
+    "description": "产出为空提示"
+  },
+  "artifacts.loadError": {
+    "message": "加载产出失败",
+    "description": "加载产出错误提示"
+  },
+  "artifacts.actionError": {
+    "message": "操作失败，请重试",
+    "description": "产出操作错误提示"
+  },
+  "artifacts.open": {
+    "message": "打开",
+    "description": "打开产出原链接按钮"
+  },
+  "artifacts.hide": {
+    "message": "隐藏",
+    "description": "隐藏产出按钮"
+  },
+  "artifacts.delete": {
+    "message": "删除",
+    "description": "删除产出按钮"
+  },
+  "artifacts.deleteConfirm": {
+    "message": "确定要永久删除这条产出记录吗？",
+    "description": "删除产出确认提示"
+  },
+  "artifacts.loadMore": {
+    "message": "加载更多",
+    "description": "加载更多产出按钮"
+  },
+  "artifacts.sourceAuto": {
+    "message": "自动捕获",
+    "description": "自动捕获来源标记"
+  },
+  "artifacts.kind.article": {
+    "message": "文章",
+    "description": "产出类型-文章"
+  },
+  "artifacts.kind.image": {
+    "message": "图片",
+    "description": "产出类型-图片"
+  },
+  "artifacts.kind.video": {
+    "message": "视频",
+    "description": "产出类型-视频"
+  },
+  "artifacts.kind.audio": {
+    "message": "音频",
+    "description": "产出类型-音频"
+  },
+  "artifacts.kind.document": {
+    "message": "文件",
+    "description": "产出类型-文件"
+  },
+  "artifacts.kind.email": {
+    "message": "邮件",
+    "description": "产出类型-邮件"
+  },
+  "artifacts.kind.message": {
+    "message": "消息",
+    "description": "产出类型-消息"
+  },
+  "artifacts.kind.dataset": {
+    "message": "数据",
+    "description": "产出类型-数据"
+  },
+  "artifacts.kind.link": {
+    "message": "链接",
+    "description": "产出类型-链接"
+  },
+  "artifacts.kind.other": {
+    "message": "其他",
+    "description": "产出类型-其他"
+  }
 }

--- a/src/i18n/zh-TW/chat.json
+++ b/src/i18n/zh-TW/chat.json
@@ -731,6 +731,98 @@
   "scheduledTasks.form.required": {
     "message": "Please fill in task name and prompt"
   },
+  "artifacts.navTitle": {
+    "message": "產出",
+    "description": "側邊欄產出入口"
+  },
+  "artifacts.title": {
+    "message": "我的產出",
+    "description": "產出頁面標題"
+  },
+  "artifacts.summaryTotal": {
+    "message": "本期共产出 {count} 项",
+    "description": "產出彙總總數"
+  },
+  "artifacts.filterAll": {
+    "message": "全部",
+    "description": "產出類型篩選-全部"
+  },
+  "artifacts.empty": {
+    "message": "還沒有任何產出。讓 AI 幫你發文章、生成圖片或發送郵件後，產出會自動出現在這裡。",
+    "description": "產出為空提示"
+  },
+  "artifacts.loadError": {
+    "message": "加載產出失敗",
+    "description": "加載產出錯誤提示"
+  },
+  "artifacts.actionError": {
+    "message": "操作失敗，請重試",
+    "description": "產出操作錯誤提示"
+  },
+  "artifacts.open": {
+    "message": "打開",
+    "description": "打開產出原鏈接按鈕"
+  },
+  "artifacts.hide": {
+    "message": "隱藏",
+    "description": "隱藏產出按鈕"
+  },
+  "artifacts.delete": {
+    "message": "刪除",
+    "description": "刪除產出按鈕"
+  },
+  "artifacts.deleteConfirm": {
+    "message": "確定要永久刪除這條產出記錄嗎？",
+    "description": "刪除產出確認提示"
+  },
+  "artifacts.loadMore": {
+    "message": "加載更多",
+    "description": "加載更多產出按鈕"
+  },
+  "artifacts.sourceAuto": {
+    "message": "自動捕獲",
+    "description": "自動捕獲來源標記"
+  },
+  "artifacts.kind.article": {
+    "message": "文章",
+    "description": "產出類型-文章"
+  },
+  "artifacts.kind.image": {
+    "message": "圖片",
+    "description": "產出類型-圖片"
+  },
+  "artifacts.kind.video": {
+    "message": "視頻",
+    "description": "產出類型-視頻"
+  },
+  "artifacts.kind.audio": {
+    "message": "音頻",
+    "description": "產出類型-音頻"
+  },
+  "artifacts.kind.document": {
+    "message": "文件",
+    "description": "產出類型-文件"
+  },
+  "artifacts.kind.email": {
+    "message": "郵件",
+    "description": "產出類型-郵件"
+  },
+  "artifacts.kind.message": {
+    "message": "消息",
+    "description": "產出類型-消息"
+  },
+  "artifacts.kind.dataset": {
+    "message": "數據",
+    "description": "產出類型-數據"
+  },
+  "artifacts.kind.link": {
+    "message": "鏈接",
+    "description": "產出類型-鏈接"
+  },
+  "artifacts.kind.other": {
+    "message": "其他",
+    "description": "產出類型-其他"
+  },
   "model.claudeOpus47": {
     "message": "claude-opus-4.7",
     "description": "服务的模型名称，即 Claude Opus 4.7"

--- a/src/operators/artifacts.ts
+++ b/src/operators/artifacts.ts
@@ -1,0 +1,97 @@
+import axios from 'axios';
+import { BASE_URL_API } from '@/constants';
+import { currentSiteOrigin } from '@/utils';
+
+function headers(token: string) {
+  const origin = currentSiteOrigin();
+  return {
+    Authorization: `Bearer ${token}`,
+    'Content-Type': 'application/json',
+    ...(origin ? { 'x-site-origin': origin } : {})
+  };
+}
+
+const BASE = `${BASE_URL_API}/aichat2/artifacts`;
+
+export type IArtifactKind =
+  | 'article'
+  | 'image'
+  | 'video'
+  | 'audio'
+  | 'document'
+  | 'email'
+  | 'message'
+  | 'dataset'
+  | 'link'
+  | 'other';
+
+export type IArtifactStatus = 'delivered' | 'draft' | 'failed';
+export type IArtifactSource = 'tool' | 'auto';
+
+export interface IArtifact {
+  id: string;
+  user_id: string;
+  application_id?: string;
+  conversation_id?: string;
+  scheduled_task_id?: string;
+  run_id?: string;
+  site_origin?: string;
+  kind: IArtifactKind;
+  status: IArtifactStatus;
+  title: string;
+  summary?: string;
+  url?: string;
+  preview_url?: string;
+  mime_type?: string;
+  size?: number;
+  channel?: string;
+  target?: string;
+  source: IArtifactSource;
+  tool_name?: string;
+  hidden?: boolean;
+  tags?: string[];
+  created_at: number;
+}
+
+export interface IArtifactFilter {
+  scheduled_task_id?: string;
+  run_id?: string;
+  conversation_id?: string;
+  kind?: IArtifactKind;
+  status?: IArtifactStatus;
+  include_hidden?: boolean;
+  offset?: number;
+  limit?: number;
+}
+
+export interface IArtifactSummary {
+  total: number;
+  by_kind: Record<string, number>;
+}
+
+class ArtifactsOperator {
+  async list(token: string, filter: IArtifactFilter = {}): Promise<{ items: IArtifact[]; count: number }> {
+    const { data } = await axios.post(BASE, { action: 'retrieve_batch', ...filter }, { headers: headers(token) });
+    return { items: data?.items ?? [], count: data?.count ?? 0 };
+  }
+
+  async retrieve(token: string, id: string): Promise<IArtifact> {
+    const { data } = await axios.post(BASE, { action: 'retrieve', id }, { headers: headers(token) });
+    return data;
+  }
+
+  async summary(token: string, filter: IArtifactFilter = {}): Promise<IArtifactSummary> {
+    const { data } = await axios.post(BASE, { action: 'retrieve_summary', ...filter }, { headers: headers(token) });
+    return { total: data?.total ?? 0, by_kind: data?.by_kind ?? {} };
+  }
+
+  async hide(token: string, id: string, hidden = true): Promise<void> {
+    await axios.post(BASE, { action: 'hide', id, hidden }, { headers: headers(token) });
+  }
+
+  async remove(token: string, id: string): Promise<void> {
+    await axios.post(BASE, { action: 'delete', id }, { headers: headers(token) });
+  }
+}
+
+export const artifactsOperator = new ArtifactsOperator();

--- a/src/pages/chat/Artifacts.vue
+++ b/src/pages/chat/Artifacts.vue
@@ -1,0 +1,332 @@
+<template>
+  <div class="artifacts">
+    <div class="inner">
+      <div class="header">
+        <h2 class="title">{{ $t('chat.artifacts.title') }}</h2>
+      </div>
+
+      <!-- Summary card -->
+      <el-card v-if="summary && summary.total > 0" class="summary-card" shadow="never">
+        <div class="summary-total">{{ $t('chat.artifacts.summaryTotal', { count: summary.total }) }}</div>
+        <div class="summary-kinds">
+          <el-tag v-for="(count, kind) in summary.by_kind" :key="kind" round class="summary-tag">
+            {{ $t('chat.artifacts.kind.' + kind) }} · {{ count }}
+          </el-tag>
+        </div>
+      </el-card>
+
+      <!-- Kind filter tabs -->
+      <div class="filters">
+        <el-tag
+          v-for="opt in kindFilters"
+          :key="opt"
+          :effect="activeKind === opt ? 'dark' : 'plain'"
+          round
+          class="filter-tag"
+          @click="onFilter(opt)"
+        >
+          {{ opt === 'all' ? $t('chat.artifacts.filterAll') : $t('chat.artifacts.kind.' + opt) }}
+        </el-tag>
+      </div>
+
+      <el-skeleton v-if="loading" :rows="4" animated class="loading-block" />
+
+      <el-empty v-else-if="!items.length" :description="$t('chat.artifacts.empty')" class="empty" />
+
+      <template v-else>
+        <div class="artifact-list">
+          <el-card v-for="item in items" :key="item.id" class="artifact-card" shadow="hover">
+            <div class="artifact-body">
+              <a
+                v-if="item.preview_url"
+                :href="item.url || item.preview_url"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="thumb"
+              >
+                <img :src="item.preview_url" :alt="item.title" />
+              </a>
+              <div class="artifact-main">
+                <div class="artifact-top">
+                  <el-tag size="small" round class="kind-tag">{{ $t('chat.artifacts.kind.' + item.kind) }}</el-tag>
+                  <el-tag v-if="item.source === 'auto'" size="small" type="info" round class="source-tag">
+                    {{ $t('chat.artifacts.sourceAuto') }}
+                  </el-tag>
+                  <span v-if="item.channel" class="channel">{{ item.channel }}</span>
+                  <span class="time">{{ formatTime(item.created_at) }}</span>
+                </div>
+                <div class="artifact-title">{{ item.title }}</div>
+                <div v-if="item.summary" class="artifact-summary">{{ item.summary }}</div>
+                <div class="artifact-actions">
+                  <el-button
+                    v-if="item.url"
+                    size="small"
+                    text
+                    type="primary"
+                    tag="a"
+                    :href="item.url"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <font-awesome-icon icon="fa-solid fa-up-right-from-square" class="icon" />
+                    {{ $t('chat.artifacts.open') }}
+                  </el-button>
+                  <el-button size="small" text @click="onHide(item)">
+                    <font-awesome-icon icon="fa-solid fa-eye-slash" class="icon" />
+                    {{ $t('chat.artifacts.hide') }}
+                  </el-button>
+                  <el-button size="small" text type="danger" @click="onDelete(item)">
+                    <font-awesome-icon icon="fa-solid fa-trash" class="icon" />
+                    {{ $t('chat.artifacts.delete') }}
+                  </el-button>
+                </div>
+              </div>
+            </div>
+          </el-card>
+        </div>
+        <div v-if="hasMore" class="load-more">
+          <el-button round :loading="loadingMore" @click="loadMore">{{ $t('chat.artifacts.loadMore') }}</el-button>
+        </div>
+      </template>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { ElButton, ElCard, ElSkeleton, ElEmpty, ElTag, ElMessage, ElMessageBox } from 'element-plus';
+import { artifactsOperator, IArtifact, IArtifactKind } from '@/operators/artifacts';
+
+const PAGE_SIZE = 30;
+const KIND_FILTERS: (IArtifactKind | 'all')[] = ['all', 'article', 'image', 'video', 'audio', 'email', 'document'];
+
+export default defineComponent({
+  name: 'Artifacts',
+  components: { FontAwesomeIcon, ElButton, ElCard, ElSkeleton, ElEmpty, ElTag },
+  data() {
+    return {
+      loading: true,
+      loadingMore: false,
+      items: [] as IArtifact[],
+      count: 0,
+      offset: 0,
+      activeKind: 'all' as IArtifactKind | 'all',
+      summary: null as { total: number; by_kind: Record<string, number> } | null,
+      kindFilters: KIND_FILTERS
+    };
+  },
+  computed: {
+    token(): string | undefined {
+      return this.$store.state.chat?.credential?.token;
+    },
+    hasMore(): boolean {
+      return this.items.length < this.count;
+    }
+  },
+  async mounted() {
+    await Promise.all([this.loadSummary(), this.reload()]);
+  },
+  methods: {
+    formatTime(ts: number): string {
+      return new Date(ts * 1000).toLocaleString();
+    },
+    async loadSummary() {
+      if (!this.token) return;
+      try {
+        this.summary = await artifactsOperator.summary(this.token);
+      } catch (e) {
+        console.error('load artifact summary failed', e);
+      }
+    },
+    async reload() {
+      if (!this.token) {
+        this.loading = false;
+        return;
+      }
+      this.loading = true;
+      this.offset = 0;
+      try {
+        const { items, count } = await artifactsOperator.list(this.token, {
+          ...(this.activeKind !== 'all' ? { kind: this.activeKind } : {}),
+          offset: 0,
+          limit: PAGE_SIZE
+        });
+        this.items = items;
+        this.count = count;
+        this.offset = items.length;
+      } catch (e) {
+        console.error('load artifacts failed', e);
+        ElMessage.error(this.$t('chat.artifacts.loadError'));
+      } finally {
+        this.loading = false;
+      }
+    },
+    async loadMore() {
+      if (!this.token || this.loadingMore) return;
+      this.loadingMore = true;
+      try {
+        const { items } = await artifactsOperator.list(this.token, {
+          ...(this.activeKind !== 'all' ? { kind: this.activeKind } : {}),
+          offset: this.offset,
+          limit: PAGE_SIZE
+        });
+        this.items.push(...items);
+        this.offset += items.length;
+      } catch (e) {
+        console.error('load more artifacts failed', e);
+      } finally {
+        this.loadingMore = false;
+      }
+    },
+    onFilter(kind: IArtifactKind | 'all') {
+      if (this.activeKind === kind) return;
+      this.activeKind = kind;
+      this.reload();
+    },
+    async onHide(item: IArtifact) {
+      if (!this.token) return;
+      try {
+        await artifactsOperator.hide(this.token, item.id, true);
+        this.items = this.items.filter((i) => i.id !== item.id);
+        this.count = Math.max(0, this.count - 1);
+        this.offset = Math.max(0, this.offset - 1);
+        this.loadSummary();
+      } catch (e) {
+        console.error('hide artifact failed', e);
+        ElMessage.error(this.$t('chat.artifacts.actionError'));
+      }
+    },
+    async onDelete(item: IArtifact) {
+      if (!this.token) return;
+      try {
+        await ElMessageBox.confirm(this.$t('chat.artifacts.deleteConfirm'), '', {
+          type: 'warning'
+        });
+      } catch {
+        return; // user cancelled
+      }
+      try {
+        await artifactsOperator.remove(this.token, item.id);
+        this.items = this.items.filter((i) => i.id !== item.id);
+        this.count = Math.max(0, this.count - 1);
+        this.offset = Math.max(0, this.offset - 1);
+        this.loadSummary();
+      } catch (e) {
+        console.error('delete artifact failed', e);
+        ElMessage.error(this.$t('chat.artifacts.actionError'));
+      }
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.artifacts {
+  height: 100%;
+  overflow-y: auto;
+  .inner {
+    max-width: 860px;
+    margin: 0 auto;
+    padding: 24px 16px 64px;
+    .header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 16px;
+      .title {
+        margin: 0;
+        font-size: 20px;
+      }
+    }
+    .summary-card {
+      margin-bottom: 16px;
+      .summary-total {
+        font-size: 15px;
+        font-weight: 600;
+        margin-bottom: 8px;
+      }
+      .summary-kinds {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+      }
+    }
+    .filters {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      margin-bottom: 16px;
+      .filter-tag {
+        cursor: pointer;
+      }
+    }
+    .artifact-list {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+    .artifact-card {
+      .artifact-body {
+        display: flex;
+        gap: 12px;
+        .thumb {
+          flex-shrink: 0;
+          width: 96px;
+          height: 96px;
+          border-radius: 8px;
+          overflow: hidden;
+          img {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+          }
+        }
+        .artifact-main {
+          flex: 1;
+          min-width: 0;
+          .artifact-top {
+            display: flex;
+            align-items: center;
+            flex-wrap: wrap;
+            gap: 6px;
+            margin-bottom: 4px;
+            .channel {
+              font-size: 12px;
+              color: var(--el-text-color-secondary);
+            }
+            .time {
+              font-size: 12px;
+              color: var(--el-text-color-placeholder);
+              margin-left: auto;
+            }
+          }
+          .artifact-title {
+            font-weight: 600;
+            word-break: break-word;
+          }
+          .artifact-summary {
+            font-size: 13px;
+            color: var(--el-text-color-secondary);
+            margin-top: 2px;
+            word-break: break-word;
+          }
+          .artifact-actions {
+            margin-top: 6px;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 4px;
+            .icon {
+              margin-right: 4px;
+            }
+          }
+        }
+      }
+    }
+    .load-more {
+      text-align: center;
+      margin-top: 16px;
+    }
+  }
+}
+</style>

--- a/src/plugins/font-awesome.ts
+++ b/src/plugins/font-awesome.ts
@@ -85,6 +85,8 @@ import {
   faChevronDown as faSolidChevronDown,
   faArrowsRotate as faSolidArrowsRotate,
   faUpRightFromSquare as faSolidUpRightFromSquare,
+  faBoxArchive as faSolidBoxArchive,
+  faEyeSlash as faSolidEyeSlash,
   faArrowRightFromBracket as faSolidArrowRightFromBracket,
   faTriangleExclamation as faSolidTriangleExclamation,
   faPenToSquare as faSolidPenToSquare,
@@ -225,6 +227,8 @@ library.add(faSolidQuestion);
 library.add(faSolidStop);
 library.add(faSolidTriangleExclamation);
 library.add(faSolidUpRightFromSquare);
+library.add(faSolidBoxArchive);
+library.add(faSolidEyeSlash);
 library.add(faRegularClock);
 library.add(faSolidArrowsRotate);
 library.add(faSolidPenNib);

--- a/src/router/chatgpt.ts
+++ b/src/router/chatgpt.ts
@@ -1,5 +1,11 @@
 import { CHAT_MODEL_GROUP_CHATGPT } from '@/constants';
-import { ROUTE_CHATGPT_CALL, ROUTE_CHATGPT_CONVERSATION, ROUTE_CHATGPT_CONVERSATION_NEW, ROUTE_CHAT_SCHEDULED_TASKS } from './constants';
+import {
+  ROUTE_CHATGPT_CALL,
+  ROUTE_CHATGPT_CONVERSATION,
+  ROUTE_CHATGPT_CONVERSATION_NEW,
+  ROUTE_CHAT_SCHEDULED_TASKS,
+  ROUTE_CHAT_ARTIFACTS
+} from './constants';
 
 export default {
   path: '/chatgpt',
@@ -36,6 +42,11 @@ export default {
       path: 'scheduled',
       name: ROUTE_CHAT_SCHEDULED_TASKS,
       component: () => import('@/pages/chat/ScheduledTasks.vue')
+    },
+    {
+      path: 'artifacts',
+      name: ROUTE_CHAT_ARTIFACTS,
+      component: () => import('@/pages/chat/Artifacts.vue')
     }
   ]
 };

--- a/src/router/constants.ts
+++ b/src/router/constants.ts
@@ -11,6 +11,7 @@ export const ROUTE_CHATGPT_CONVERSATION = 'chatgpt-conversation';
 export const ROUTE_CHATGPT_CONVERSATION_NEW = 'chatgpt-conversation-new';
 export const ROUTE_CHATGPT_CALL = 'chatgpt-call';
 export const ROUTE_CHAT_SCHEDULED_TASKS = 'chat-scheduled-tasks';
+export const ROUTE_CHAT_ARTIFACTS = 'chat-artifacts';
 
 export const ROUTE_DEEPSEEK_CONVERSATION = 'deepseek-conversation';
 export const ROUTE_DEEPSEEK_CONVERSATION_NEW = 'deepseek-conversation-new';


### PR DESCRIPTION
## 背景

实现 [AICHAT2-ARTIFACTS 计划](https://github.com/AceDataCloud/Index/blob/main/plans/aichat-and-nexior/AICHAT2-ARTIFACTS.md) 的 Nexior 前端（PR5+6 的核心：全局产出 Feed）。用户建了很多定时任务/对话，产出（发文章、生成图、发邮件…）此前无从汇总——本 PR 给出「我的产出」独立页。

## 改动

- **`operators/artifacts.ts`（新）** — 调 `POST /aichat2/artifacts`（`retrieve_batch/retrieve/retrieve_summary/hide/delete`），照 `scheduledTasks.ts` 的 headers/BASE 模式；导出 `IArtifact` 等类型。
- **`pages/chat/Artifacts.vue`（新）** — 独立页 `/chatgpt/artifacts`（决策①）：顶部汇总卡（"本期共产出 N 项" + 各 kind 计数）+ kind 过滤 tab + 产出列表（缩略图/标题/摘要/来源 badge/渠道/时间/打开原链）+ 分页「加载更多」+ 每条 hide/delete（决策③，delete 二次确认）。`source=auto` 默认展示并带来源 badge（决策②）。
- **`router/chatgpt.ts` + `router/constants.ts`** — 注册 `chat-artifacts` 路由。
- **`components/chat/SidePanel.vue`** — 侧栏加「产出」入口（fa-box-archive）。
- **`plugins/font-awesome.ts`** — 注册 `faBoxArchive` + `faEyeSlash`。
- **i18n** — `chat.artifacts.*` 共 23 键：手工写 zh-CN + en，其余 15 locale 由 `translate_i18n.py` 增量补全（coverage guard 通过：17 locale × 44 namespace 全对齐）。

> 说明：zh-CN/chat.json 里既有的 `scheduledTasks.*` 块被规范化为标准 2 空格 JSON（**纯空白改动，键值未变**）。

## 校验

- `vue-tsc -b` 干净；`check_i18n_coverage.py` OK。
- 依赖后端 PlatformService#1320（`/aichat2/artifacts`）+ PlatformBackend#848（Api row）+ PlatformGateway#177（skip billing）+ Kong route 上线后生效；未上线时前端优雅降级为空 feed（防御式 `data?.items ?? []`）。

## 🤖 对抗评审

subagent READ-ONLY 逐条核验 8 个风险面（图标注册 / El 组件注册 / `el-button tag=a` 链接 / token 未定义优雅降级 / operator 形状 / 分页 off-by-one / SSG 安全 / v-for 类型）——**全部 CLEAN**。仅提示：后端端点须先上线（外部依赖，已降级处理）；已顺手修 hide/delete 后 offset 未递减导致的翻页边界漂移（review item 3）。

VERDICT: CLEAN。
