### PR TITLE
fix(chat): restore cached conversations with empty summaries

### DIFF
--- a/change/@acedatacloud-nexior-a967b4eb-b479-468f-9f43-5d4b82efeab4.json
+++ b/change/@acedatacloud-nexior-a967b4eb-b479-468f-9f43-5d4b82efeab4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix chat conversation restore when cached summaries contain empty messages.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/conversationRestore.test.ts
+++ b/src/components/chat/conversationRestore.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { ROLE_USER } from '@/constants/chat';
+import { hasLoadedConversationMessages } from './conversationRestore';
+
+describe('hasLoadedConversationMessages', () => {
+  it('requires a non-empty messages array', () => {
+    expect(hasLoadedConversationMessages(undefined)).toBe(false);
+    expect(hasLoadedConversationMessages({ id: 'conv_1' })).toBe(false);
+    expect(hasLoadedConversationMessages({ id: 'conv_1', messages: [] })).toBe(false);
+    expect(
+      hasLoadedConversationMessages({
+        id: 'conv_1',
+        messages: [{ role: ROLE_USER, content: 'hello' }]
+      })
+    ).toBe(true);
+  });
+});

--- a/src/components/chat/conversationRestore.ts
+++ b/src/components/chat/conversationRestore.ts
@@ -1,0 +1,5 @@
+import type { IChatConversation } from '@/models';
+
+export function hasLoadedConversationMessages(conversation: IChatConversation | undefined): boolean {
+  return Array.isArray(conversation?.messages) && conversation.messages.length > 0;
+}

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -95,6 +95,7 @@ import {
   repairInstallReturnToUrl,
   type IConsentReturn
 } from '@/components/chat/consentReturn';
+import { hasLoadedConversationMessages } from '@/components/chat/conversationRestore';
 import { chatOperator, agentOperator } from '@/operators';
 import { ElTooltip, ElButton } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
@@ -599,7 +600,7 @@ export default defineComponent({
       //    Side-panel summaries do NOT include `messages`, so we always
       //    need a `retrieve` call the first time a conversation is opened.
       let conversation: IChatConversation | undefined = this.conversations?.find((c: IChatConversation) => c.id === id);
-      if (!conversation || !conversation.messages) {
+      if (!hasLoadedConversationMessages(conversation)) {
         const fetched = await this.$store.dispatch('chat/getConversation', id);
         if (fetched) conversation = fetched;
       }


### PR DESCRIPTION
## Summary
- Fix chat conversation restore when a cached side-panel summary contains `messages: []`.
- Add a focused regression helper/test so empty message arrays are treated as unloaded summaries and trigger the full `RETRIEVE` call.
- Add the required Beachball patch change file.

## Validation
- `npm run test:run -- src/components/chat/conversationRestore.test.ts src/operators/chat.test.ts`
- `npx eslint src/components/chat/conversationRestore.ts src/components/chat/conversationRestore.test.ts src/pages/chat/Conversation.vue`
- `npx vue-tsc -b`
- `npx beachball check`

## 🤖 对抗评审 (reviewer: claude-subagent, 1 round)
- NIT: Loaded empty histories are indistinguishable from unloaded summaries → 未采纳，理由: persisted chat conversations that users can open should contain at least one message; treating `messages: []` as unloaded is the intended conservative behavior to restore histories when batch summaries include empty arrays. A truly empty retrieved conversation would only incur an extra retrieve on reopen, not data loss.
