### PR TITLE
fix(chat): 让用户发送与历史消息也显示复制按钮

### DIFF
--- a/change/@acedatacloud-nexior-copy-user-message.json
+++ b/change/@acedatacloud-nexior-copy-user-message.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(chat): 让用户发送与历史消息也显示复制按钮",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/Message.vue
+++ b/src/components/chat/Message.vue
@@ -158,7 +158,7 @@
           @click="startEditing"
         />
         <copy-to-clipboard
-          v-if="copyableText && (message.state === messageState.FINISHED || message.state === messageState.FAILED)"
+          v-if="copyableText && message.state !== messageState.PENDING && message.state !== messageState.ANSWERING"
           :content="copyableText"
           class="btn-copy"
         />


### PR DESCRIPTION
## 问题

在 `https://studio.acedata.cloud/chatgpt/conversations`（以及新会话中）用户**发出去的消息**和从历史记录**加载出来的消息**都没有复制按钮，只有正在生成的助手回复完成后才有。

## 原因

`Message.vue` 里复制按钮的显示条件是 `message.state === FINISHED || FAILED`：

- 用户发送的消息只带 `{ content, role: 'user' }`，**没有 `state` 字段**（`Conversation.vue` ~654-662）。
- 从会话历史恢复的消息直接来自服务端数据，同样没有 `state`（`Conversation.vue` ~611）。

因此这两类消息 `state === undefined`，永远匹配不上原条件，复制按钮不显示。

## 修复

把条件改为"只要有可复制文本且不在流式生成中（PENDING/ANSWERING）就显示复制按钮"：

```diff
- v-if="copyableText && (message.state === messageState.FINISHED || message.state === messageState.FAILED)"
+ v-if="copyableText && message.state !== messageState.PENDING && message.state !== messageState.ANSWERING"
```

行为差异只有一处：`state === undefined` 的消息（即用户发送 + 历史加载）现在也会显示复制按钮；四个枚举状态的行为与之前完全一致，流式生成中（ANSWERING/PENDING）仍然隐藏。`copyableText` 计算属性已处理字符串与内容数组两种情况，空内容返回 `''` 被前置的 `copyableText &&` 拦住，不会出现空复制按钮。

## 🤖 对抗评审

- Reviewer：Codex 触发用量上限，回退到 Claude `general-purpose` 子代理（read-only）。
- 结论：**VERDICT: CLEAN**。
- 已核验：
  - 流式中助手消息为 `ANSWERING`，新条件显式排除，复制不会在生成中出现；初始 `PENDING` 同样排除。
  - `FINISHED`/`FAILED` 助手消息行为与旧条件一致，无回归。
  - 错误消息走 `v-if="!errorText"` 的 error-card 分支，复制按钮从不渲染，不受影响。
  - 空内容 / 纯图片消息 `copyableText === ''`，前置 guard 保证不显示空按钮。
  - 持久化的助手消息以 `FINISHED` 保存，历史恢复后仍正常显示复制。
