### PR TITLE
style: apply elegant thin scrollbar globally (desktop/mouse only)

### DIFF
--- a/change/@acedatacloud-nexior-3d18d0af-a2cd-4bc8-a871-2bd32a12ead8.json
+++ b/change/@acedatacloud-nexior-3d18d0af-a2cd-4bc8-a871-2bd32a12ead8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "style: apply the elegant thin scrollbar globally (desktop/mouse only)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/assets/scss/_scrollbar.scss
+++ b/src/assets/scss/_scrollbar.scss
@@ -1,0 +1,49 @@
+// Global elegant scrollbar — mouse / fine-pointer devices only.
+//
+// Thin, rounded, faintly visible at rest and a touch stronger on hover — the
+// same look as the chat sidebar, applied to every native scrollbar (vertical
+// and horizontal). Uses Element Plus border tokens so it adapts to dark mode.
+//
+// Gated behind `(hover: hover) and (pointer: fine)` on purpose: touch builds
+// (Capacitor iOS/Android, tablets) keep their native overlay scrollbars, which
+// is the expected mobile behaviour — we don't want a permanently reserved
+// gutter there.
+//
+// Not affected by design:
+//   - `el-scrollbar` / `mac-scrollbar` draw their own overlay and hide the
+//     native scrollbar, so these rules don't touch them.
+//   - Components with a bespoke scoped scrollbar out-specify `*` and keep it.
+
+@media (hover: hover) and (pointer: fine) {
+  * {
+    scrollbar-width: thin; // Firefox
+    scrollbar-color: var(--el-border-color) transparent;
+  }
+
+  *::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  *::-webkit-scrollbar-thumb {
+    // A 2px transparent border + padding-box clip slims the visible thumb to
+    // ~4px and floats it off the container edge.
+    border: 2px solid transparent;
+    background-clip: padding-box;
+    border-radius: 999px;
+    background-color: var(--el-border-color);
+    transition: background-color 0.2s ease;
+  }
+
+  *::-webkit-scrollbar-thumb:hover {
+    background-color: var(--el-border-color-darker, var(--el-text-color-secondary));
+  }
+
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/src/assets/scss/style.scss
+++ b/src/assets/scss/style.scss
@@ -1,3 +1,4 @@
 @use './element';
 @use './common';
+@use './scrollbar';
 @use './markdown';

--- a/src/layouts/Chat.vue
+++ b/src/layouts/Chat.vue
@@ -61,37 +61,6 @@ export default defineComponent({
   flex-shrink: 0;
   background-color: var(--app-sidebar-bg);
   border-right: 1px solid var(--app-border-subtle);
-
-  // Elegant, thin, hover-revealed scrollbar (ChatGPT/Linear-style).
-  scrollbar-width: thin;
-  scrollbar-color: transparent transparent;
-  transition: scrollbar-color 0.25s ease;
-
-  &::-webkit-scrollbar {
-    width: 8px;
-  }
-  &::-webkit-scrollbar-track {
-    background: transparent;
-  }
-  &::-webkit-scrollbar-thumb {
-    // Transparent border + padding-box clip slims the thumb to ~4px and
-    // floats it away from the panel edge.
-    border: 2px solid transparent;
-    background-clip: padding-box;
-    border-radius: 999px;
-    background-color: transparent;
-    transition: background-color 0.25s ease;
-  }
-
-  &:hover {
-    scrollbar-color: var(--el-border-color) transparent;
-    &::-webkit-scrollbar-thumb {
-      background-color: var(--el-border-color);
-    }
-  }
-  &::-webkit-scrollbar-thumb:hover {
-    background-color: var(--el-border-color-darker);
-  }
 }
 
 .chat {


### PR DESCRIPTION
## What & why

Follow-up to #1153 (merged), which added the elegant thin scrollbar to the **chat sidebar only**. This promotes that look to a **global** rule so every native scrollbar in the app matches.

## Changes

- **New `src/assets/scss/_scrollbar.scss`** — one global rule: thin (8px gutter, ~4px inset rounded thumb via a 2px transparent border + `background-clip: padding-box`), transparent track, thumb `--el-border-color` at rest → `--el-border-color-darker` on hover (Element Plus tokens → adapts to dark mode). Applies to both vertical **and** horizontal scrollbars (`width` + `height`).
- **`src/assets/scss/style.scss`** — `@use './scrollbar';` (the entry imported once by `main.ts`).
- **`src/layouts/Chat.vue`** — removed the now-redundant bespoke `.side` scrollbar block; the sidebar inherits the global rule (kept `overscroll-behavior: contain` and the layout props).

### Design decisions
- **Gated to `@media (hover: hover) and (pointer: fine)`** — desktop/mouse only. Touch builds (Capacitor iOS/Android, tablets) keep their **native overlay** scrollbars, so we don't force a permanently-reserved gutter on mobile.
- **Always-faint (not hidden-until-hover)** — a global default should be discoverable everywhere (GitHub/Linear/Notion pattern), so the thumb is subtly visible at rest and darkens on hover, rather than the chat-only "reveal on container hover".
- **Non-invasive** — `el-scrollbar` / `mac-scrollbar` draw their own overlay and hide the native bar (and `MacScrollbar` has 0 usages in `src` anyway); components with a scoped bespoke scrollbar (`Navigator`, `AskUserQuestionCard`) out-specify `*` and keep their own look.

## Validation
- SCSS compiles (dart-sass). Prettier-clean against Nexior's `.prettierrc.mjs` (printWidth 120, etc.). `.vue` change is a deletion only (no script/template touched). Beachball change file included.

> Note: Nexior's local `node_modules` was mid-reinstall by a parallel process, so lint/compile were validated with a borrowed toolchain against Nexior's own config; CI is the authoritative gate.

## 🤖 对抗评审

Reviewer: read-only subagent (Codex not installed here). One round, converged.

| Finding | Severity | Resolution |
|---|---|---|
| macOS/iOS/Electron: forcing `::-webkit-scrollbar { width }` makes scrollbars always-on (reserved gutter) instead of native overlay — a touch/mobile UX regression | **RISK** | **Fixed.** Wrapped the whole rule in `@media (hover: hover) and (pointer: fine)` → touch devices keep native overlay; only mouse/desktop get the custom bar. |
| `--el-border-color-darker` may be undefined → hover state no-ops | **RISK** | **Fixed.** Added fallback: `var(--el-border-color-darker, var(--el-text-color-secondary))`. Robust whether or not the token exists. |
| `mac-scrollbar` global conflict / double scrollbars | RISK→moot | `MacScrollbar` component has **0 usages** in `src` (only its CSS is imported); nothing to conflict with. |
| Hidden-until-hover elegance lost going global | NIT | Intentional — always-faint is the more discoverable global default; documented. |
| 8px global vs 4/6px in `Navigator`/`AskUserQuestionCard` | NIT | Scoped `[data-v-*]::-webkit-scrollbar` out-specifies `*`; those keep their bespoke look. |
| `AskUserQuestionCard` `padding-right:2px` scrollbar workaround | NIT | That component keeps its own scoped scrollbar (wins over global); unaffected. |

**VERDICT: CLEAN** after fixes.
