### PR TITLE
fix(chat): media preview failures fall back to file links

### DIFF
--- a/change/@acedatacloud-nexior-fix-google-drive-media-citation.json
+++ b/change/@acedatacloud-nexior-fix-google-drive-media-citation.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fallback failed chat media previews to file links.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/ArtifactBlock.vue
+++ b/src/components/chat/ArtifactBlock.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="artifact-block">
     <!-- Image -->
-    <div v-if="artifact.type === 'image'" class="artifact-image">
+    <div v-if="artifactType === 'image'" class="artifact-image">
       <el-image
         :src="artifact.url"
         :alt="artifact.name"
@@ -9,19 +9,20 @@
         style="max-width: 400px; max-height: 400px; border-radius: 8px"
         :preview-src-list="[artifact.url]"
         :preview-teleported="true"
+        @error="onMediaError"
       />
       <div class="artifact-name">{{ artifact.name }}</div>
     </div>
 
     <!-- Audio -->
-    <div v-else-if="artifact.type === 'audio'" class="artifact-audio">
-      <audio controls :src="artifact.url" style="width: 100%; max-width: 400px" />
+    <div v-else-if="artifactType === 'audio'" class="artifact-audio">
+      <audio controls :src="artifact.url" style="width: 100%; max-width: 400px" @error="onMediaError" />
       <div class="artifact-name">{{ artifact.name }}</div>
     </div>
 
     <!-- Video -->
-    <div v-else-if="artifact.type === 'video'" class="artifact-video">
-      <video controls :src="artifact.url" style="max-width: 500px; border-radius: 8px" />
+    <div v-else-if="artifactType === 'video'" class="artifact-video">
+      <video controls :src="artifact.url" style="max-width: 500px; border-radius: 8px" @error="onMediaError" />
       <div class="artifact-name">{{ artifact.name }}</div>
     </div>
 
@@ -40,6 +41,10 @@ import { defineComponent, type PropType } from 'vue';
 import { Document } from '@element-plus/icons-vue';
 import type { IChatArtifact } from '@/models';
 
+interface IData {
+  mediaFailed: boolean;
+}
+
 export default defineComponent({
   name: 'ArtifactBlock',
   components: { Document },
@@ -47,6 +52,29 @@ export default defineComponent({
     artifact: {
       type: Object as PropType<IChatArtifact>,
       required: true
+    }
+  },
+  data(): IData {
+    return {
+      mediaFailed: false
+    };
+  },
+  computed: {
+    artifactType(): IChatArtifact['type'] {
+      return this.mediaFailed ? 'file' : this.artifact.type;
+    },
+    artifactKey(): string {
+      return [this.artifact.url, this.artifact.type, this.artifact.mimeType || ''].join('\u0000');
+    }
+  },
+  watch: {
+    artifactKey(): void {
+      this.mediaFailed = false;
+    }
+  },
+  methods: {
+    onMediaError(): void {
+      this.mediaFailed = true;
     }
   }
 });

--- a/src/components/chat/EntityCard.vue
+++ b/src/components/chat/EntityCard.vue
@@ -8,7 +8,7 @@
       <div class="meta">
         <div v-if="card.title" class="title" :title="card.title">{{ card.title }}</div>
         <div v-if="card.duration" class="sub">{{ formattedDuration }}</div>
-        <audio class="player" controls preload="metadata" :src="card.url" />
+        <audio class="player" controls preload="metadata" :src="card.url" @error="onMediaError" />
         <div class="actions">
           <a class="download" :href="card.url" target="_blank" rel="noopener noreferrer">
             <font-awesome-icon icon="fa-solid fa-arrow-down" />
@@ -18,13 +18,11 @@
       </div>
     </div>
 
-    <!-- Video — rendered as an iframe by default. The aichat2 worker
-         normalizes YouTube watch URLs to the canonical embed form, and
-         iframes also play direct media URLs (browser shows its native
-         video viewer) so a single renderer covers both. -->
+    <!-- Video -->
     <div v-else-if="cardType === 'video'" class="video-card">
       <div class="frame">
         <iframe
+          v-if="videoUsesIframe"
           class="player"
           :src="card.url"
           :title="card.title || ''"
@@ -33,7 +31,9 @@
           referrerpolicy="strict-origin-when-cross-origin"
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
           allowfullscreen
+          @error="onMediaError"
         />
+        <video v-else class="player" controls preload="metadata" :src="card.url" @error="onMediaError" />
       </div>
       <div v-if="card.title || card.duration" class="meta">
         <span v-if="card.title" class="title" :title="card.title">{{ card.title }}</span>
@@ -52,6 +52,7 @@
         :initial-index="0"
         :hide-on-click-modal="true"
         :preview-teleported="true"
+        @error="onMediaError"
       >
         <template #placeholder>
           <div class="image-placeholder" />
@@ -88,6 +89,10 @@ import { ElImage } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import type { IChatCard } from '@/models';
 
+interface IData {
+  mediaFailed: boolean;
+}
+
 export default defineComponent({
   name: 'EntityCard',
   components: { ElImage, FontAwesomeIcon },
@@ -97,12 +102,18 @@ export default defineComponent({
       required: true
     }
   },
+  data(): IData {
+    return {
+      mediaFailed: false
+    };
+  },
   computed: {
     /** Normalize the card type into one of the primary renderers. The
      * legacy `embed` type (briefly emitted by PlatformService #826) is
      * folded back into `video` so historical cards still render — the
      * worker no longer flips type, see PlatformService #827. */
     cardType(): 'audio' | 'video' | 'image' | 'file' {
+      if (this.mediaFailed) return 'file';
       const t = (this.card.type || '').toLowerCase();
       if (t === 'audio' || t === 'image') return t;
       if (t === 'video' || t === 'embed') return 'video';
@@ -110,6 +121,18 @@ export default defineComponent({
       if (this.card.mimeType?.startsWith('video/')) return 'video';
       if (this.card.mimeType?.startsWith('image/')) return 'image';
       return 'file';
+    },
+    mediaKey(): string {
+      return [this.card.url, this.card.type, this.card.mimeType || ''].join('\u0000');
+    },
+    videoUsesIframe(): boolean {
+      if ((this.card.type || '').toLowerCase() === 'embed') return true;
+      try {
+        const url = new URL(this.card.url);
+        return url.pathname.split('/').includes('embed');
+      } catch {
+        return false;
+      }
     },
     formattedDuration(): string {
       const total = this.card.duration ?? 0;
@@ -144,6 +167,16 @@ export default defineComponent({
       if (mime.includes('zip') || mime.includes('compressed')) return 'fa-solid fa-file-zipper';
       if (mime.startsWith('text/')) return 'fa-solid fa-file-lines';
       return 'fa-solid fa-file';
+    }
+  },
+  watch: {
+    mediaKey(): void {
+      this.mediaFailed = false;
+    }
+  },
+  methods: {
+    onMediaError(): void {
+      this.mediaFailed = true;
     }
   }
 });


### PR DESCRIPTION
## Summary
- Fall back failed chat rich media cards to file links instead of leaving blank previews or broken players.
- Apply the same fallback behavior to tool artifact image/audio/video previews.
- Use native `<video>` for non-embed video URLs so load failures can trigger the fallback, while preserving iframe rendering for explicit embeds.

## Validation
- `npx eslint src/components/chat/EntityCard.vue src/components/chat/ArtifactBlock.vue`
- `npx beachball check`
- VS Code diagnostics: no errors in touched Vue files

## 🤖 对抗评审
- Initial review found `iframe` `error` is unreliable for ordinary video URLs and that failure state only reset on URL changes.
- Fixed by rendering non-embed videos with native `<video>` and resetting failure state from URL/type/mime identity in both renderers.
- Re-review verdict: `VERDICT: CLEAN`.
