### PR TITLE
fix(chat): connector logo 用白底提升对比度

### DIFF
--- a/change/@acedatacloud-nexior-square-connector-logo.json
+++ b/change/@acedatacloud-nexior-square-connector-logo.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Improve chat connector logo contrast on dark backgrounds.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/ConnectorEntryRow.vue
+++ b/src/components/chat/ConnectorEntryRow.vue
@@ -136,16 +136,16 @@ export default defineComponent({
   align-items: center;
   justify-content: center;
   border-radius: 50%;
-  background: var(--el-bg-color);
+  background: #fff;
+  border: 1px solid rgba(17, 24, 39, 0.08);
   font-size: 14px;
   overflow: hidden;
 }
 
 .icon-logo {
-  width: 100%;
-  height: 100%;
+  width: 72%;
+  height: 72%;
   object-fit: contain;
-  border-radius: 50%;
 }
 
 .icon-connected {

--- a/src/components/chat/ConnectorStrip.vue
+++ b/src/components/chat/ConnectorStrip.vue
@@ -115,8 +115,8 @@ export default defineComponent({
     border-radius: 50%;
     overflow: hidden;
     cursor: pointer;
-    background-color: var(--el-fill-color-light);
-    border: 1px solid var(--el-border-color-lighter);
+    background-color: #fff;
+    border: 1px solid rgba(17, 24, 39, 0.08);
     transition:
       transform 0.12s ease,
       box-shadow 0.12s ease;
@@ -125,9 +125,9 @@ export default defineComponent({
       box-shadow: 0 2px 6px rgba(0, 0, 0, 0.14);
     }
     .connector-icon {
-      width: 100%;
-      height: 100%;
-      object-fit: cover;
+      width: 72%;
+      height: 72%;
+      object-fit: contain;
       display: block;
     }
     &.connector-more {


### PR DESCRIPTION
## Summary
- Put chat connector logos on a white tile so transparent/dark brand marks like Square stay legible on dark UI backgrounds.
- Use contained logo sizing in the consent rows and composer connector strip so icons are not cropped.
- Add the required Beachball patch change file.

## Validation
- `npm run build:web` ✅
- `npx eslint src/components/chat/ConnectorEntryRow.vue src/components/chat/ConnectorStrip.vue` ✅
- `npx beachball check --branch origin/main` ✅
- `npm run lint:check` ⚠️ fails on existing unrelated Prettier issues in `src/components/common/Navigator.vue` and `src/components/common/TopHeader.vue`, plus an existing `vue/no-template-shadow` warning in `src/pages/chat/Artifacts.vue`.

## 🤖 对抗评审
VERDICT: CLEAN

- NOTE `src/components/chat/ConnectorEntryRow.vue`: Forcing `.entry-icon` to `#fff` gives the requested white logo tile in both light and dark themes; fallback FontAwesome icons still render with Element Plus semantic colors on the white tile.
- NOTE `src/components/chat/ConnectorStrip.vue`: The chip stays fixed at `20px x 20px`, and the image stays bounded at `72%` with `object-fit: contain`, so dimensions remain stable. This may make some existing full-bleed connector icons visually smaller, but it does not introduce layout instability and matches the white-tile treatment needed for Square.
- NOTE `src/components/chat/ConnectorStrip.vue`: `connector-more` explicitly keeps its own themed background, so the `+N` overflow/fallback text chip is not adversely affected by the white logo tile change.
- NOTE `change/@acedatacloud-nexior-square-connector-logo.json`: Beachball changefile shape looks valid.
