### PR TITLE
feat(artifacts): Output -> Artifacts, add Show hidden + Unhide

### DIFF
--- a/change/@acedatacloud-nexior-artifacts-rename.json
+++ b/change/@acedatacloud-nexior-artifacts-rename.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(artifacts): 将 Output/产出 统一改名为 Artifacts；新增 Show hidden 开关与 Unhide 按钮，让被隐藏的 Artifact 可再次找到；reload/loadMore 增加请求 token 防止并发竞态。",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/i18n/ar/chat.json
+++ b/src/i18n/ar/chat.json
@@ -902,5 +902,17 @@
   "model.claudeOpus47Description": {
     "message": "النموذج الأكثر تقدمًا حاليًا",
     "description": "وصف نموذج Claude Opus 4.7"
+  },
+  "artifacts.unhide": {
+    "message": "Unhide",
+    "description": "Restore a hidden artifact"
+  },
+  "artifacts.showHidden": {
+    "message": "Show hidden",
+    "description": "Toggle in the filter bar to include hidden artifacts"
+  },
+  "artifacts.hiddenBadge": {
+    "message": "Hidden",
+    "description": "Badge shown on artifacts that are currently hidden"
   }
 }

--- a/src/i18n/de/chat.json
+++ b/src/i18n/de/chat.json
@@ -902,5 +902,17 @@
   "model.claudeOpus47Description": {
     "message": "Aktuell das fortschrittlichste Modell",
     "description": "Beschreibung des Claude Opus 4.7-Modells"
+  },
+  "artifacts.unhide": {
+    "message": "Unhide",
+    "description": "Restore a hidden artifact"
+  },
+  "artifacts.showHidden": {
+    "message": "Show hidden",
+    "description": "Toggle in the filter bar to include hidden artifacts"
+  },
+  "artifacts.hiddenBadge": {
+    "message": "Hidden",
+    "description": "Badge shown on artifacts that are currently hidden"
   }
 }

--- a/src/i18n/el/chat.json
+++ b/src/i18n/el/chat.json
@@ -902,5 +902,17 @@
   "model.claudeOpus47Description": {
     "message": "Το πιο προηγμένο μοντέλο αυτή τη στιγμή",
     "description": "Περιγραφή του μοντέλου Claude Opus 4.7"
+  },
+  "artifacts.unhide": {
+    "message": "Unhide",
+    "description": "Restore a hidden artifact"
+  },
+  "artifacts.showHidden": {
+    "message": "Show hidden",
+    "description": "Toggle in the filter bar to include hidden artifacts"
+  },
+  "artifacts.hiddenBadge": {
+    "message": "Hidden",
+    "description": "Badge shown on artifacts that are currently hidden"
   }
 }

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -720,15 +720,15 @@
     "message": "Please fill in task name and prompt"
   },
   "artifacts.navTitle": {
-    "message": "Outputs",
-    "description": "Sidebar outputs entry"
+    "message": "Artifacts",
+    "description": "Sidebar artifacts entry"
   },
   "artifacts.title": {
-    "message": "My Outputs",
+    "message": "My Artifacts",
     "description": "Artifacts page title"
   },
   "artifacts.summaryTotal": {
-    "message": "{count} outputs produced",
+    "message": "{count} artifacts",
     "description": "Artifacts summary total"
   },
   "artifacts.filterAll": {
@@ -736,11 +736,11 @@
     "description": "Artifact kind filter - all"
   },
   "artifacts.empty": {
-    "message": "No outputs yet. After the AI publishes articles, generates images or sends emails for you, they will show up here automatically.",
+    "message": "No artifacts yet. After the AI publishes articles, generates images or sends emails for you, they will show up here automatically.",
     "description": "Artifacts empty hint"
   },
   "artifacts.loadError": {
-    "message": "Failed to load outputs",
+    "message": "Failed to load artifacts",
     "description": "Artifacts load error"
   },
   "artifacts.actionError": {
@@ -755,12 +755,24 @@
     "message": "Hide",
     "description": "Hide artifact"
   },
+  "artifacts.unhide": {
+    "message": "Unhide",
+    "description": "Restore a hidden artifact"
+  },
+  "artifacts.showHidden": {
+    "message": "Show hidden",
+    "description": "Toggle in the filter bar to include hidden artifacts"
+  },
+  "artifacts.hiddenBadge": {
+    "message": "Hidden",
+    "description": "Badge shown on artifacts that are currently hidden"
+  },
   "artifacts.delete": {
     "message": "Delete",
     "description": "Delete artifact"
   },
   "artifacts.deleteConfirm": {
-    "message": "Permanently delete this output record?",
+    "message": "Permanently delete this artifact?",
     "description": "Delete artifact confirm"
   },
   "artifacts.loadMore": {

--- a/src/i18n/es/chat.json
+++ b/src/i18n/es/chat.json
@@ -902,5 +902,17 @@
   "model.claudeOpus47Description": {
     "message": "Modelo más avanzado actualmente",
     "description": "Descripción del modelo Claude Opus 4.7"
+  },
+  "artifacts.unhide": {
+    "message": "Unhide",
+    "description": "Restore a hidden artifact"
+  },
+  "artifacts.showHidden": {
+    "message": "Show hidden",
+    "description": "Toggle in the filter bar to include hidden artifacts"
+  },
+  "artifacts.hiddenBadge": {
+    "message": "Hidden",
+    "description": "Badge shown on artifacts that are currently hidden"
   }
 }

--- a/src/i18n/fi/chat.json
+++ b/src/i18n/fi/chat.json
@@ -902,5 +902,17 @@
   "model.claudeOpus47Description": {
     "message": "Tällä hetkellä edistyksellisin malli",
     "description": "Claude Opus 4.7 -mallin kuvaus"
+  },
+  "artifacts.unhide": {
+    "message": "Unhide",
+    "description": "Restore a hidden artifact"
+  },
+  "artifacts.showHidden": {
+    "message": "Show hidden",
+    "description": "Toggle in the filter bar to include hidden artifacts"
+  },
+  "artifacts.hiddenBadge": {
+    "message": "Hidden",
+    "description": "Badge shown on artifacts that are currently hidden"
   }
 }

--- a/src/i18n/fr/chat.json
+++ b/src/i18n/fr/chat.json
@@ -902,5 +902,17 @@
   "model.claudeOpus47Description": {
     "message": "Modèle le plus avancé actuellement",
     "description": "Description du modèle Claude Opus 4.7"
+  },
+  "artifacts.unhide": {
+    "message": "Unhide",
+    "description": "Restore a hidden artifact"
+  },
+  "artifacts.showHidden": {
+    "message": "Show hidden",
+    "description": "Toggle in the filter bar to include hidden artifacts"
+  },
+  "artifacts.hiddenBadge": {
+    "message": "Hidden",
+    "description": "Badge shown on artifacts that are currently hidden"
   }
 }

--- a/src/i18n/it/chat.json
+++ b/src/i18n/it/chat.json
@@ -902,5 +902,17 @@
   "model.claudeOpus47Description": {
     "message": "Modello più avanzato attualmente disponibile",
     "description": "Descrizione del modello Claude Opus 4.7"
+  },
+  "artifacts.unhide": {
+    "message": "Unhide",
+    "description": "Restore a hidden artifact"
+  },
+  "artifacts.showHidden": {
+    "message": "Show hidden",
+    "description": "Toggle in the filter bar to include hidden artifacts"
+  },
+  "artifacts.hiddenBadge": {
+    "message": "Hidden",
+    "description": "Badge shown on artifacts that are currently hidden"
   }
 }

--- a/src/i18n/ja/chat.json
+++ b/src/i18n/ja/chat.json
@@ -902,5 +902,17 @@
   "model.claudeOpus47Description": {
     "message": "現在最も先進的なモデル",
     "description": "Claude Opus 4.7モデルの説明"
+  },
+  "artifacts.unhide": {
+    "message": "Unhide",
+    "description": "Restore a hidden artifact"
+  },
+  "artifacts.showHidden": {
+    "message": "Show hidden",
+    "description": "Toggle in the filter bar to include hidden artifacts"
+  },
+  "artifacts.hiddenBadge": {
+    "message": "Hidden",
+    "description": "Badge shown on artifacts that are currently hidden"
   }
 }

--- a/src/i18n/ko/chat.json
+++ b/src/i18n/ko/chat.json
@@ -902,5 +902,17 @@
   "model.claudeOpus47Description": {
     "message": "현재 가장 진보된 모델",
     "description": "Claude Opus 4.7 모델의 설명"
+  },
+  "artifacts.unhide": {
+    "message": "Unhide",
+    "description": "Restore a hidden artifact"
+  },
+  "artifacts.showHidden": {
+    "message": "Show hidden",
+    "description": "Toggle in the filter bar to include hidden artifacts"
+  },
+  "artifacts.hiddenBadge": {
+    "message": "Hidden",
+    "description": "Badge shown on artifacts that are currently hidden"
   }
 }

--- a/src/i18n/pl/chat.json
+++ b/src/i18n/pl/chat.json
@@ -902,5 +902,17 @@
   "model.claudeOpus47Description": {
     "message": "Obecnie najnowocześniejszy model",
     "description": "Opis modelu Claude Opus 4.7"
+  },
+  "artifacts.unhide": {
+    "message": "Unhide",
+    "description": "Restore a hidden artifact"
+  },
+  "artifacts.showHidden": {
+    "message": "Show hidden",
+    "description": "Toggle in the filter bar to include hidden artifacts"
+  },
+  "artifacts.hiddenBadge": {
+    "message": "Hidden",
+    "description": "Badge shown on artifacts that are currently hidden"
   }
 }

--- a/src/i18n/pt/chat.json
+++ b/src/i18n/pt/chat.json
@@ -902,5 +902,17 @@
   "model.claudeOpus47Description": {
     "message": "Modelo mais avançado atualmente",
     "description": "Descrição do modelo Claude Opus 4.7"
+  },
+  "artifacts.unhide": {
+    "message": "Unhide",
+    "description": "Restore a hidden artifact"
+  },
+  "artifacts.showHidden": {
+    "message": "Show hidden",
+    "description": "Toggle in the filter bar to include hidden artifacts"
+  },
+  "artifacts.hiddenBadge": {
+    "message": "Hidden",
+    "description": "Badge shown on artifacts that are currently hidden"
   }
 }

--- a/src/i18n/ru/chat.json
+++ b/src/i18n/ru/chat.json
@@ -902,5 +902,17 @@
   "model.claudeOpus47Description": {
     "message": "На данный момент самая продвинутая модель",
     "description": "Описание модели Claude Opus 4.7"
+  },
+  "artifacts.unhide": {
+    "message": "Unhide",
+    "description": "Restore a hidden artifact"
+  },
+  "artifacts.showHidden": {
+    "message": "Show hidden",
+    "description": "Toggle in the filter bar to include hidden artifacts"
+  },
+  "artifacts.hiddenBadge": {
+    "message": "Hidden",
+    "description": "Badge shown on artifacts that are currently hidden"
   }
 }

--- a/src/i18n/sr/chat.json
+++ b/src/i18n/sr/chat.json
@@ -902,5 +902,17 @@
   "model.claudeOpus47Description": {
     "message": "Trenutno najnapredniji model",
     "description": "Opis Claude Opus 4.7 modela"
+  },
+  "artifacts.unhide": {
+    "message": "Unhide",
+    "description": "Restore a hidden artifact"
+  },
+  "artifacts.showHidden": {
+    "message": "Show hidden",
+    "description": "Toggle in the filter bar to include hidden artifacts"
+  },
+  "artifacts.hiddenBadge": {
+    "message": "Hidden",
+    "description": "Badge shown on artifacts that are currently hidden"
   }
 }

--- a/src/i18n/sv/chat.json
+++ b/src/i18n/sv/chat.json
@@ -902,5 +902,17 @@
   "model.claudeOpus47Description": {
     "message": "Den mest avancerade modellen hittills",
     "description": "Beskrivning av Claude Opus 4.7-modellen"
+  },
+  "artifacts.unhide": {
+    "message": "Unhide",
+    "description": "Restore a hidden artifact"
+  },
+  "artifacts.showHidden": {
+    "message": "Show hidden",
+    "description": "Toggle in the filter bar to include hidden artifacts"
+  },
+  "artifacts.hiddenBadge": {
+    "message": "Hidden",
+    "description": "Badge shown on artifacts that are currently hidden"
   }
 }

--- a/src/i18n/uk/chat.json
+++ b/src/i18n/uk/chat.json
@@ -902,5 +902,17 @@
   "model.claudeOpus47Description": {
     "message": "Найсучасніша модель на сьогодні",
     "description": "Опис моделі Claude Opus 4.7"
+  },
+  "artifacts.unhide": {
+    "message": "Unhide",
+    "description": "Restore a hidden artifact"
+  },
+  "artifacts.showHidden": {
+    "message": "Show hidden",
+    "description": "Toggle in the filter bar to include hidden artifacts"
+  },
+  "artifacts.hiddenBadge": {
+    "message": "Hidden",
+    "description": "Badge shown on artifacts that are currently hidden"
   }
 }

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -768,52 +768,64 @@
     "description": "必填项验证"
   },
   "artifacts.navTitle": {
-    "message": "产出",
-    "description": "侧边栏产出入口"
+    "message": "Artifacts",
+    "description": "侧边栏 Artifacts 入口"
   },
   "artifacts.title": {
-    "message": "我的产出",
-    "description": "产出页面标题"
+    "message": "我的 Artifacts",
+    "description": "Artifacts 页面标题"
   },
   "artifacts.summaryTotal": {
-    "message": "本期共产出 {count} 项",
-    "description": "产出汇总总数"
+    "message": "共 {count} 个 Artifact",
+    "description": "Artifacts 汇总总数"
   },
   "artifacts.filterAll": {
     "message": "全部",
-    "description": "产出类型筛选-全部"
+    "description": "Artifacts 类型筛选-全部"
   },
   "artifacts.empty": {
-    "message": "还没有任何产出。让 AI 帮你发文章、生成图片或发送邮件后，产出会自动出现在这里。",
-    "description": "产出为空提示"
+    "message": "还没有任何 Artifact。让 AI 帮你发文章、生成图片或发送邮件后，产出会自动出现在这里。",
+    "description": "Artifacts 为空提示"
   },
   "artifacts.loadError": {
-    "message": "加载产出失败",
-    "description": "加载产出错误提示"
+    "message": "加载 Artifacts 失败",
+    "description": "加载 Artifacts 错误提示"
   },
   "artifacts.actionError": {
     "message": "操作失败，请重试",
-    "description": "产出操作错误提示"
+    "description": "Artifacts 操作错误提示"
   },
   "artifacts.open": {
     "message": "打开",
-    "description": "打开产出原链接按钮"
+    "description": "打开 Artifact 原链接按钮"
   },
   "artifacts.hide": {
     "message": "隐藏",
-    "description": "隐藏产出按钮"
+    "description": "隐藏 Artifact 按钮"
+  },
+  "artifacts.unhide": {
+    "message": "取消隐藏",
+    "description": "恢复被隐藏 Artifact 的按钮"
+  },
+  "artifacts.showHidden": {
+    "message": "显示已隐藏",
+    "description": "筛选栏中显示已隐藏 Artifacts 的开关"
+  },
+  "artifacts.hiddenBadge": {
+    "message": "已隐藏",
+    "description": "标记 Artifact 已被隐藏的徽章"
   },
   "artifacts.delete": {
     "message": "删除",
-    "description": "删除产出按钮"
+    "description": "删除 Artifact 按钮"
   },
   "artifacts.deleteConfirm": {
-    "message": "确定要永久删除这条产出记录吗？",
-    "description": "删除产出确认提示"
+    "message": "确定要永久删除这条 Artifact 吗？",
+    "description": "删除 Artifact 确认提示"
   },
   "artifacts.loadMore": {
     "message": "加载更多",
-    "description": "加载更多产出按钮"
+    "description": "加载更多 Artifacts 按钮"
   },
   "artifacts.sourceAuto": {
     "message": "自动捕获",

--- a/src/i18n/zh-TW/chat.json
+++ b/src/i18n/zh-TW/chat.json
@@ -902,5 +902,17 @@
   "model.claudeOpus47Description": {
     "message": "目前最先進的模型",
     "description": "Claude Opus 4.7 模型的描述"
+  },
+  "artifacts.unhide": {
+    "message": "Unhide",
+    "description": "Restore a hidden artifact"
+  },
+  "artifacts.showHidden": {
+    "message": "Show hidden",
+    "description": "Toggle in the filter bar to include hidden artifacts"
+  },
+  "artifacts.hiddenBadge": {
+    "message": "Hidden",
+    "description": "Badge shown on artifacts that are currently hidden"
   }
 }

--- a/src/pages/chat/Artifacts.vue
+++ b/src/pages/chat/Artifacts.vue
@@ -3,6 +3,12 @@
     <div class="inner">
       <div class="header">
         <h2 class="title">{{ $t('chat.artifacts.title') }}</h2>
+        <el-switch
+          v-model="showHidden"
+          class="show-hidden"
+          :active-text="$t('chat.artifacts.showHidden')"
+          @change="reload"
+        />
       </div>
 
       <!-- Summary card -->
@@ -52,6 +58,9 @@
                   <el-tag v-if="item.source === 'auto'" size="small" type="info" round class="source-tag">
                     {{ $t('chat.artifacts.sourceAuto') }}
                   </el-tag>
+                  <el-tag v-if="item.hidden" size="small" type="warning" round class="hidden-tag">
+                    {{ $t('chat.artifacts.hiddenBadge') }}
+                  </el-tag>
                   <span v-if="item.channel" class="channel">{{ item.channel }}</span>
                   <span class="time">{{ formatTime(item.created_at) }}</span>
                 </div>
@@ -71,9 +80,9 @@
                     <font-awesome-icon icon="fa-solid fa-up-right-from-square" class="icon" />
                     {{ $t('chat.artifacts.open') }}
                   </el-button>
-                  <el-button size="small" text @click="onHide(item)">
-                    <font-awesome-icon icon="fa-solid fa-eye-slash" class="icon" />
-                    {{ $t('chat.artifacts.hide') }}
+                  <el-button size="small" text @click="onToggleHide(item)">
+                    <font-awesome-icon :icon="item.hidden ? 'fa-solid fa-eye' : 'fa-solid fa-eye-slash'" class="icon" />
+                    {{ item.hidden ? $t('chat.artifacts.unhide') : $t('chat.artifacts.hide') }}
                   </el-button>
                   <el-button size="small" text type="danger" @click="onDelete(item)">
                     <font-awesome-icon icon="fa-solid fa-trash" class="icon" />
@@ -95,7 +104,7 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { ElButton, ElCard, ElSkeleton, ElEmpty, ElTag, ElMessage, ElMessageBox } from 'element-plus';
+import { ElButton, ElCard, ElSkeleton, ElEmpty, ElTag, ElSwitch, ElMessage, ElMessageBox } from 'element-plus';
 import { artifactsOperator, IArtifact, IArtifactKind } from '@/operators/artifacts';
 
 const PAGE_SIZE = 30;
@@ -103,7 +112,7 @@ const KIND_FILTERS: (IArtifactKind | 'all')[] = ['all', 'article', 'image', 'vid
 
 export default defineComponent({
   name: 'Artifacts',
-  components: { FontAwesomeIcon, ElButton, ElCard, ElSkeleton, ElEmpty, ElTag },
+  components: { FontAwesomeIcon, ElButton, ElCard, ElSkeleton, ElEmpty, ElTag, ElSwitch },
   data() {
     return {
       loading: true,
@@ -112,8 +121,10 @@ export default defineComponent({
       count: 0,
       offset: 0,
       activeKind: 'all' as IArtifactKind | 'all',
+      showHidden: false,
       summary: null as { total: number; by_kind: Record<string, number> } | null,
-      kindFilters: KIND_FILTERS
+      kindFilters: KIND_FILTERS,
+      reloadToken: 0
     };
   },
   computed: {
@@ -146,31 +157,40 @@ export default defineComponent({
       }
       this.loading = true;
       this.offset = 0;
+      const token = ++this.reloadToken;
       try {
         const { items, count } = await artifactsOperator.list(this.token, {
           ...(this.activeKind !== 'all' ? { kind: this.activeKind } : {}),
+          ...(this.showHidden ? { include_hidden: true } : {}),
           offset: 0,
           limit: PAGE_SIZE
         });
+        // Drop stale responses when the user toggled filters/switch mid-flight.
+        if (token !== this.reloadToken) return;
         this.items = items;
         this.count = count;
         this.offset = items.length;
       } catch (e) {
+        if (token !== this.reloadToken) return;
         console.error('load artifacts failed', e);
         ElMessage.error(this.$t('chat.artifacts.loadError'));
       } finally {
-        this.loading = false;
+        if (token === this.reloadToken) this.loading = false;
       }
     },
     async loadMore() {
       if (!this.token || this.loadingMore) return;
       this.loadingMore = true;
+      const token = this.reloadToken;
       try {
         const { items } = await artifactsOperator.list(this.token, {
           ...(this.activeKind !== 'all' ? { kind: this.activeKind } : {}),
+          ...(this.showHidden ? { include_hidden: true } : {}),
           offset: this.offset,
           limit: PAGE_SIZE
         });
+        // Drop the page if the user changed filters (or hit reload) mid-flight.
+        if (token !== this.reloadToken) return;
         this.items.push(...items);
         this.offset += items.length;
       } catch (e) {
@@ -184,16 +204,22 @@ export default defineComponent({
       this.activeKind = kind;
       this.reload();
     },
-    async onHide(item: IArtifact) {
+    async onToggleHide(item: IArtifact) {
       if (!this.token) return;
+      const nextHidden = !item.hidden;
       try {
-        await artifactsOperator.hide(this.token, item.id, true);
-        this.items = this.items.filter((i) => i.id !== item.id);
-        this.count = Math.max(0, this.count - 1);
-        this.offset = Math.max(0, this.offset - 1);
+        await artifactsOperator.hide(this.token, item.id, nextHidden);
+        if (this.showHidden) {
+          // Keep the item in place so the user can toggle it again.
+          item.hidden = nextHidden;
+        } else {
+          this.items = this.items.filter((i) => i.id !== item.id);
+          this.count = Math.max(0, this.count - 1);
+          this.offset = Math.max(0, this.offset - 1);
+        }
         this.loadSummary();
       } catch (e) {
-        console.error('hide artifact failed', e);
+        console.error('toggle hide artifact failed', e);
         ElMessage.error(this.$t('chat.artifacts.actionError'));
       }
     },


### PR DESCRIPTION
## 背景

用户反馈 https://studio.acedata.cloud/chatgpt/artifacts ：

1. 页面 URL 是 `/artifacts`，但标题却叫 **Output / 产出**，命名不统一，用户很懵。
2. 卡片上有 **Hide（隐藏）** 按钮，但整个 UI 里没有任何地方能看到已隐藏的条目，也没有 unhide 入口 —— 点了就等于永久消失。

## 修改

### 1. 术语统一：`Output/产出` → `Artifacts`

- `src/i18n/en/chat.json`：`Outputs` → `Artifacts`，`My Outputs` → `My Artifacts`，empty / load error 文案同步更新。
- `src/i18n/zh-CN/chat.json`：侧边栏「产出」→「Artifacts」，页面标题「我的产出」→「我的 Artifacts」，其余提示文案统一沿用 `Artifacts` 英文原词以匹配 URL 与 en 站点。
- 只维护 `zh-CN` 与 `en`，其余 17 种语言等 `translate.py` CronJob 处理（遵循 monorepo 约定）。

### 2. 隐藏可见 & 可恢复

- Artifacts 页顶栏新增 `Show hidden / 显示已隐藏` 开关（`el-switch`）。
- 开启后：`list` / `loadMore` 均传 `include_hidden: true`；已隐藏条目在卡片顶部显示 `Hidden / 已隐藏` 徽章；操作按钮从 `Hide` 变为 `Unhide`（图标：`fa-eye-slash` ↔ `fa-eye`）。
- `onHide` 重构为 `onToggleHide`：调用现有 `artifactsOperator.hide(token, id, nextHidden)`（operator 早就支持 unhide，只是没有 UI），在 `showHidden=true` 时保留条目并翻转徽章 / 按钮，`showHidden=false` 时按原有行为从列表移除。
- 新增 i18n keys：`artifacts.unhide` / `artifacts.showHidden` / `artifacts.hiddenBadge`（zh-CN + en）。

### 3. 并发保护

顺手加了个 `reloadToken` 单调计数器：`reload()` 与 `loadMore()` 在开始时快照 token，返回后如果 token 已变（说明用户中途切了筛选或开关）就丢弃这次响应，避免旧数据覆盖新数据 / offset 错位。

## 涉及文件

- `src/pages/chat/Artifacts.vue`
- `src/i18n/en/chat.json`
- `src/i18n/zh-CN/chat.json`

## 验证

- `vue-tsc --noEmit` ✅ 无错误
- `eslint src/pages/chat/Artifacts.vue` ✅ 无错误（仅 1 条与本次修改无关的 pre-existing warning：模板 `v-for="(count, kind)"` 与 `data()` 里的 `count` 变量重名）
- `src/plugins/font-awesome.ts` 已确认 `fa-eye` / `fa-eye-slash` 均已注册，无需新增。
- `src/operators/artifacts.ts` 未改动，其 `IArtifactFilter.include_hidden` 与 `hide(token, id, hidden)` API 早已存在，只是从没暴露到 UI。

## 🤖 对抗评审

### Round 1（Explore 子代理，read-only）

- **RISK #1：`reload()` 缺少并发保护** —— 用户快速切换开关会导致晚到的响应覆盖早到的。**已修**：`reload()` 用 `++this.reloadToken` 打快照，所有分支 mutate state 前都校验 token；`loading` 也只有在 token 匹配时才复位。
- **RISK #2：`item.hidden = nextHidden` 反应性是否可靠？** —— **鉴驳**：Vue 3 基于 `Proxy` 的响应式系统完整支持在响应式对象上新增属性（正是相对 Vue 2 `Object.defineProperty` 的主要改进）。`this.items = items` 经 Options API `data()` 变为响应式数组，其成员均为响应式代理，直接赋值可选属性即可触发重渲，无需 `this.$set` / `Object.assign`。
- **RISK #3：`showHidden=true` 时 hide 不改 count 会不会与 `hasMore` / `loadSummary` 冲突？** —— **鉴驳**：后端 `retrieve_batch` 在 `include_hidden=true` 时返回的 `count` 本就包含隐藏项，隐藏项留在列表中 & `count` 不变正好一致，`hasMore = items.length < count` 依旧正确。`loadSummary()` 写的是 `this.summary.total`，与 `this.count` 是两个字段，不影响 `hasMore`。

### Round 2

- **NEW RISK：`loadMore()` 没加同款守卫，会与 `reload()` 竞态**（用户翻页途中切开关会把旧 offset 的旧数据 push 进新列表并把 offset 加乱）—— **已修**：`loadMore()` 同样快照 `this.reloadToken`，返回后 token 变了就丢弃，不再 push 也不再累加 offset。
- 复检结论：无新增风险。

VERDICT: CLEAN（收敛）
