### PR TITLE
feat(openaiimage): add gpt-image-2 official model to studio

### DIFF
--- a/change/@acedatacloud-nexior-gpt-image-2-official.json
+++ b/change/@acedatacloud-nexior-gpt-image-2-official.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(openaiimage): 在 studio 图像模型下拉中新增 gpt-image-2 官方直连（gpt-image-2:official）选项，复用 gpt-image-2 的尺寸预设与自定义尺寸支持，并补全 17 种语言的 i18n 文案。",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/openaiimage/config/ModelSelector.vue
+++ b/src/components/openaiimage/config/ModelSelector.vue
@@ -19,7 +19,8 @@ import {
   OPENAIIMAGE_DEFAULT_MODEL,
   OPENAIIMAGE_MODEL_GPT_IMAGE_1,
   OPENAIIMAGE_MODEL_GPT_IMAGE_15,
-  OPENAIIMAGE_MODEL_GPT_IMAGE_2
+  OPENAIIMAGE_MODEL_GPT_IMAGE_2,
+  OPENAIIMAGE_MODEL_GPT_IMAGE_2_OFFICIAL
 } from '@/constants';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 
@@ -44,6 +45,10 @@ export default defineComponent({
         {
           value: OPENAIIMAGE_MODEL_GPT_IMAGE_2,
           label: this.$t('openaiimage.model.gptImage2')
+        },
+        {
+          value: OPENAIIMAGE_MODEL_GPT_IMAGE_2_OFFICIAL,
+          label: this.$t('openaiimage.model.gptImage2Official')
         }
       ]
     };

--- a/src/components/openaiimage/config/ResolutionSelector.vue
+++ b/src/components/openaiimage/config/ResolutionSelector.vue
@@ -73,6 +73,7 @@ import {
   OPENAIIMAGE_DEFAULT_MODEL,
   OPENAIIMAGE_DEFAULT_SIZE,
   OPENAIIMAGE_MODEL_GPT_IMAGE_2,
+  OPENAIIMAGE_MODEL_GPT_IMAGE_2_OFFICIAL,
   OPENAIIMAGE_MODEL_SIZES,
   OPENAIIMAGE_SIZES_GPT_IMAGE_2_1K,
   OPENAIIMAGE_SIZES_GPT_IMAGE_2_2K,
@@ -131,7 +132,7 @@ export default defineComponent({
       return OPENAIIMAGE_MODEL_SIZES[this.model] ?? OPENAIIMAGE_MODEL_SIZES[OPENAIIMAGE_DEFAULT_MODEL] ?? [];
     },
     presetGroups(): IGroup[] {
-      if (this.model === OPENAIIMAGE_MODEL_GPT_IMAGE_2) {
+      if (this.model === OPENAIIMAGE_MODEL_GPT_IMAGE_2 || this.model === OPENAIIMAGE_MODEL_GPT_IMAGE_2_OFFICIAL) {
         return [
           { label: this.$t('openaiimage.sizeGroup.standard1k'), options: OPENAIIMAGE_SIZES_GPT_IMAGE_2_1K },
           { label: this.$t('openaiimage.sizeGroup.preset2k'), options: OPENAIIMAGE_SIZES_GPT_IMAGE_2_2K },

--- a/src/constants/openaiimage.ts
+++ b/src/constants/openaiimage.ts
@@ -6,6 +6,9 @@ export const OPENAIIMAGE_LOGO = CHAT_MODEL_ICON_CHATGPT;
 export const OPENAIIMAGE_MODEL_GPT_IMAGE_1 = 'gpt-image-1';
 export const OPENAIIMAGE_MODEL_GPT_IMAGE_15 = 'gpt-image-1.5';
 export const OPENAIIMAGE_MODEL_GPT_IMAGE_2 = 'gpt-image-2';
+// Official-relay variant (openai-hk gpt-image-2-vip upstream). Same feature set
+// as gpt-image-2, billed at a higher tier.
+export const OPENAIIMAGE_MODEL_GPT_IMAGE_2_OFFICIAL = 'gpt-image-2:official';
 
 export const OPENAIIMAGE_DEFAULT_MODEL = OPENAIIMAGE_MODEL_GPT_IMAGE_2;
 
@@ -84,11 +87,15 @@ export const OPENAIIMAGE_SIZES_GPT_IMAGE_2: string[] = [
 export const OPENAIIMAGE_MODEL_SIZES: Record<string, string[]> = {
   [OPENAIIMAGE_MODEL_GPT_IMAGE_1]: OPENAIIMAGE_SIZES_GPT_IMAGE_1,
   [OPENAIIMAGE_MODEL_GPT_IMAGE_15]: OPENAIIMAGE_SIZES_GPT_IMAGE_15,
-  [OPENAIIMAGE_MODEL_GPT_IMAGE_2]: OPENAIIMAGE_SIZES_GPT_IMAGE_2
+  [OPENAIIMAGE_MODEL_GPT_IMAGE_2]: OPENAIIMAGE_SIZES_GPT_IMAGE_2,
+  [OPENAIIMAGE_MODEL_GPT_IMAGE_2_OFFICIAL]: OPENAIIMAGE_SIZES_GPT_IMAGE_2
 };
 
 // Models that allow arbitrary WIDTHxHEIGHT (subject to validation).
-export const OPENAIIMAGE_CUSTOM_SIZE_MODELS: string[] = [OPENAIIMAGE_MODEL_GPT_IMAGE_2];
+export const OPENAIIMAGE_CUSTOM_SIZE_MODELS: string[] = [
+  OPENAIIMAGE_MODEL_GPT_IMAGE_2,
+  OPENAIIMAGE_MODEL_GPT_IMAGE_2_OFFICIAL
+];
 
 // Custom-size validation constants for gpt-image-2. Mirrors upstream constraints
 // documented in the OpenAPI `size` description: multiples of 16, longer side

--- a/src/i18n/ar/openaiimage.json
+++ b/src/i18n/ar/openaiimage.json
@@ -178,5 +178,9 @@
   "model.gptImage2": {
     "message": "gpt-image-2",
     "description": "خيار نموذج gpt-image-2"
+  },
+  "model.gptImage2Official": {
+    "message": "gpt-image-2 (رسمي)",
+    "description": "خيار نموذج gpt-image-2 عبر التوصيل الرسمي"
   }
 }

--- a/src/i18n/de/openaiimage.json
+++ b/src/i18n/de/openaiimage.json
@@ -178,5 +178,9 @@
   "model.gptImage2": {
     "message": "gpt-image-2",
     "description": "Option für das Modell gpt-image-2"
+  },
+  "model.gptImage2Official": {
+    "message": "gpt-image-2 (Offiziell)",
+    "description": "gpt-image-2 Modelloption (offizielles Relay)"
   }
 }

--- a/src/i18n/el/openaiimage.json
+++ b/src/i18n/el/openaiimage.json
@@ -178,5 +178,9 @@
   "model.gptImage2": {
     "message": "gpt-image-2",
     "description": "Επιλογή μοντέλου gpt-image-2"
+  },
+  "model.gptImage2Official": {
+    "message": "gpt-image-2 (Επίσημο)",
+    "description": "Επιλογή μοντέλου gpt-image-2 (επίσημη αναμετάδοση)"
   }
 }

--- a/src/i18n/en/openaiimage.json
+++ b/src/i18n/en/openaiimage.json
@@ -178,5 +178,9 @@
   "model.gptImage2": {
     "message": "gpt-image-2",
     "description": "gpt-image-2 model option"
+  },
+  "model.gptImage2Official": {
+    "message": "gpt-image-2 (Official)",
+    "description": "gpt-image-2 official-relay model option"
   }
 }

--- a/src/i18n/es/openaiimage.json
+++ b/src/i18n/es/openaiimage.json
@@ -178,5 +178,9 @@
   "model.gptImage2": {
     "message": "gpt-image-2",
     "description": "Opción de modelo gpt-image-2"
+  },
+  "model.gptImage2Official": {
+    "message": "gpt-image-2 (Oficial)",
+    "description": "Opción de modelo gpt-image-2 (relé oficial)"
   }
 }

--- a/src/i18n/fi/openaiimage.json
+++ b/src/i18n/fi/openaiimage.json
@@ -178,5 +178,9 @@
   "model.gptImage2": {
     "message": "gpt-image-2",
     "description": "gpt-image-2 mallivaihtoehto"
+  },
+  "model.gptImage2Official": {
+    "message": "gpt-image-2 (Virallinen)",
+    "description": "gpt-image-2-mallivaihtoehto (virallinen välitys)"
   }
 }

--- a/src/i18n/fr/openaiimage.json
+++ b/src/i18n/fr/openaiimage.json
@@ -178,5 +178,9 @@
   "model.gptImage2": {
     "message": "gpt-image-2",
     "description": "Option pour le modèle gpt-image-2"
+  },
+  "model.gptImage2Official": {
+    "message": "gpt-image-2 (Officiel)",
+    "description": "Option de modèle gpt-image-2 (relais officiel)"
   }
 }

--- a/src/i18n/it/openaiimage.json
+++ b/src/i18n/it/openaiimage.json
@@ -178,5 +178,9 @@
   "model.gptImage2": {
     "message": "gpt-image-2",
     "description": "Opzione modello gpt-image-2"
+  },
+  "model.gptImage2Official": {
+    "message": "gpt-image-2 (Ufficiale)",
+    "description": "Opzione modello gpt-image-2 (relay ufficiale)"
   }
 }

--- a/src/i18n/ja/openaiimage.json
+++ b/src/i18n/ja/openaiimage.json
@@ -178,5 +178,9 @@
   "model.gptImage2": {
     "message": "gpt-image-2",
     "description": "gpt-image-2 モデルオプション"
+  },
+  "model.gptImage2Official": {
+    "message": "gpt-image-2（公式）",
+    "description": "gpt-image-2（公式リレー）モデルオプション"
   }
 }

--- a/src/i18n/ko/openaiimage.json
+++ b/src/i18n/ko/openaiimage.json
@@ -178,5 +178,9 @@
   "model.gptImage2": {
     "message": "gpt-image-2",
     "description": "gpt-image-2 모델 옵션"
+  },
+  "model.gptImage2Official": {
+    "message": "gpt-image-2 (공식)",
+    "description": "gpt-image-2(공식 릴레이) 모델 옵션"
   }
 }

--- a/src/i18n/pl/openaiimage.json
+++ b/src/i18n/pl/openaiimage.json
@@ -178,5 +178,9 @@
   "model.gptImage2": {
     "message": "gpt-image-2",
     "description": "Opcja modelu gpt-image-2"
+  },
+  "model.gptImage2Official": {
+    "message": "gpt-image-2 (Oficjalny)",
+    "description": "Opcja modelu gpt-image-2 (oficjalny przekaźnik)"
   }
 }

--- a/src/i18n/pt/openaiimage.json
+++ b/src/i18n/pt/openaiimage.json
@@ -178,5 +178,9 @@
   "model.gptImage2": {
     "message": "gpt-image-2",
     "description": "Opção de modelo gpt-image-2"
+  },
+  "model.gptImage2Official": {
+    "message": "gpt-image-2 (Oficial)",
+    "description": "Opção de modelo gpt-image-2 (relé oficial)"
   }
 }

--- a/src/i18n/ru/openaiimage.json
+++ b/src/i18n/ru/openaiimage.json
@@ -178,5 +178,9 @@
   "model.gptImage2": {
     "message": "gpt-image-2",
     "description": "Опция модели gpt-image-2"
+  },
+  "model.gptImage2Official": {
+    "message": "gpt-image-2 (Официальный)",
+    "description": "Вариант модели gpt-image-2 (официальный релей)"
   }
 }

--- a/src/i18n/sr/openaiimage.json
+++ b/src/i18n/sr/openaiimage.json
@@ -178,5 +178,9 @@
   "model.gptImage2": {
     "message": "gpt-image-2",
     "description": "Opcija modela gpt-image-2"
+  },
+  "model.gptImage2Official": {
+    "message": "gpt-image-2 (Zvanično)",
+    "description": "Opcija modela gpt-image-2 (zvanični relej)"
   }
 }

--- a/src/i18n/sv/openaiimage.json
+++ b/src/i18n/sv/openaiimage.json
@@ -178,5 +178,9 @@
   "model.gptImage2": {
     "message": "gpt-image-2",
     "description": "Alternativ för gpt-image-2 modellen"
+  },
+  "model.gptImage2Official": {
+    "message": "gpt-image-2 (Officiell)",
+    "description": "gpt-image-2-modellalternativ (officiell relä)"
   }
 }

--- a/src/i18n/uk/openaiimage.json
+++ b/src/i18n/uk/openaiimage.json
@@ -178,5 +178,9 @@
   "model.gptImage2": {
     "message": "gpt-image-2",
     "description": "Опція моделі gpt-image-2"
+  },
+  "model.gptImage2Official": {
+    "message": "gpt-image-2 (Офіційний)",
+    "description": "Варіант моделі gpt-image-2 (офіційний релей)"
   }
 }

--- a/src/i18n/zh-CN/openaiimage.json
+++ b/src/i18n/zh-CN/openaiimage.json
@@ -178,5 +178,9 @@
   "model.gptImage2": {
     "message": "gpt-image-2",
     "description": "gpt-image-2 模型选项"
+  },
+  "model.gptImage2Official": {
+    "message": "gpt-image-2（官方直连）",
+    "description": "gpt-image-2 官方直连模型选项"
   }
 }

--- a/src/i18n/zh-TW/openaiimage.json
+++ b/src/i18n/zh-TW/openaiimage.json
@@ -178,5 +178,9 @@
   "model.gptImage2": {
     "message": "gpt-image-2",
     "description": "gpt-image-2 模型選項"
+  },
+  "model.gptImage2Official": {
+    "message": "gpt-image-2（官方直連）",
+    "description": "gpt-image-2 官方直連模型選項"
   }
 }


### PR DESCRIPTION
## What

Adds the **gpt-image-2 official** variant (`gpt-image-2:official`) to the studio (Nexior) OpenAI Image model dropdown, alongside the existing `gpt-image-1`, `gpt-image-1.5`, and default `gpt-image-2`.

- Default `gpt-image-2` → reverse pool (0.11×/img).
- New `gpt-image-2:official` → openai-hk `gpt-image-2-vip` upstream (0.22×/img), for users who want the official relay channel.

## Changes

- `src/constants/openaiimage.ts` — new `OPENAIIMAGE_MODEL_GPT_IMAGE_2_OFFICIAL` constant; wired into `OPENAIIMAGE_MODEL_SIZES` and `OPENAIIMAGE_CUSTOM_SIZE_MODELS` (identical size/custom-size support as `gpt-image-2`).
- `src/components/openaiimage/config/ModelSelector.vue` — adds the dropdown option.
- `src/components/openaiimage/config/ResolutionSelector.vue` — official variant shares the gpt-image-2 1K/2K/4K preset groups.
- `src/i18n/*/openaiimage.json` — adds `model.gptImage2Official` label to all 17 locales (i18n coverage guard passes).

The selected model flows to the API via `config.model`; the backend already accepts `gpt-image-2:official` in its OpenAPI `model` enum (PRs #758/#765), so no backend change is needed.

## Validation

- `python3 scripts/check_i18n_coverage.py` → OK (17 locales × 44 namespaces).
- No TypeScript errors on the edited files.

## 🤖 对抗评审

Independent reviewer (subagent) traced all `OPENAIIMAGE_MODEL_GPT_IMAGE_2` usages, size maps, custom-size validation, i18n coverage, barrel export, and API wiring. **No RISK-level defects.** One NIT: the backfilled locales had English `description` metadata (non-user-visible) while zh-CN localized it — **fixed** by localizing the `description` field per locale.