### PR TITLE
fix(flux): send required size param from studio config

### DIFF
--- a/change/@acedatacloud-nexior-flux-size-required.json
+++ b/change/@acedatacloud-nexior-flux-size-required.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(flux): send required size (aspect ratio) param from studio config so generation no longer fails with 'size is required'",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/flux/ConfigPanel.vue
+++ b/src/components/flux/ConfigPanel.vue
@@ -5,6 +5,7 @@
       <prompt-input class="mb-4" />
       <image-url-input v-if="config?.action === 'edits'" class="mb-4" />
       <model-selector class="mb-4" />
+      <size-selector class="mb-4" />
       <count-selector class="mb-4" />
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
@@ -26,6 +27,7 @@ import CountSelector from './config/CountSelector.vue';
 import ActionSelector from './config/ActionSelector.vue';
 import ImageUrlInput from './config/ImageUrlInput.vue';
 import PromptInput from './config/PromptInput.vue';
+import SizeSelector from './config/SizeSelector.vue';
 import Consumption from '../common/Consumption.vue';
 import { getConsumption } from '@/utils';
 
@@ -39,7 +41,8 @@ export default defineComponent({
     CountSelector,
     Consumption,
     ActionSelector,
-    ImageUrlInput
+    ImageUrlInput,
+    SizeSelector
   },
   emits: ['generate'],
   computed: {

--- a/src/components/flux/config/SizeSelector.vue
+++ b/src/components/flux/config/SizeSelector.vue
@@ -1,0 +1,64 @@
+<template>
+  <div class="field">
+    <h2 class="title font-bold">{{ $t('flux.name.ratio') }}</h2>
+    <el-select v-model="value" class="value" :placeholder="$t('flux.placeholder.select')">
+      <el-option v-for="item in options" :key="item" :label="item" :value="item" />
+    </el-select>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElSelect, ElOption } from 'element-plus';
+import { FLUX_ASPECT_RATIOS, FLUX_DEFAULT_SIZE } from '@/constants';
+
+export default defineComponent({
+  name: 'SizeSelector',
+  components: {
+    ElSelect,
+    ElOption
+  },
+  data() {
+    return {
+      options: FLUX_ASPECT_RATIOS
+    };
+  },
+  computed: {
+    value: {
+      get() {
+        return this.$store.state.flux?.config?.size;
+      },
+      set(val: string) {
+        this.$store.commit('flux/setConfig', {
+          ...this.$store.state.flux?.config,
+          size: val
+        });
+      }
+    }
+  },
+  mounted() {
+    if (!this.value) {
+      this.value = FLUX_DEFAULT_SIZE;
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.field {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+
+  .title {
+    font-size: 14px;
+    margin: 0;
+    width: 30%;
+  }
+
+  .value {
+    width: 160px;
+  }
+}
+</style>

--- a/src/constants/flux.ts
+++ b/src/constants/flux.ts
@@ -7,3 +7,8 @@ export const FLUX_DEFAULT_ACTION = 'generate';
 export const FLUX_DEFAULT_ASPECT_RATIO = '1:1';
 export const FLUX_DEFAULT_COUNT = 1;
 export const FLUX_DEFAULT_QUALITY = 80;
+
+// Aspect ratios accepted by every Flux model (ratio-only models like
+// flux-2-pro require one; pixel-size models also accept them). Sent as `size`.
+export const FLUX_ASPECT_RATIOS = ['21:9', '16:9', '4:3', '3:2', '1:1', '2:3', '3:4', '9:16', '9:21'];
+export const FLUX_DEFAULT_SIZE = '1:1';

--- a/src/models/flux.ts
+++ b/src/models/flux.ts
@@ -3,6 +3,7 @@ export interface IFluxConfig {
   count?: number;
   prompt?: string;
   aspect_ratio?: string;
+  size?: string;
   model?: string;
   image_url?: string;
   quality?: number;
@@ -13,6 +14,7 @@ export interface IFluxConfig {
 export interface IFluxGenerateRequest {
   action?: string;
   prompt?: string;
+  size?: string;
   model?: string;
   image_url?: string;
   callback_url?: string;


### PR DESCRIPTION
## Problem

`studio.acedata.cloud/flux` failed to start generation with **`发起任务失败，请联系管理员size is required`** for `flux-2-pro` (and other models). The Flux config panel had no size/aspect-ratio control and `onGenerate` never sent a `size`, but the ttapi worker's `validateSize()` requires `size` for **every** model — and flux-2 models (`flux-2-flex/pro/max`, kontext) only accept an aspect ratio.

## Fix

- New `SizeSelector.vue` (aspect ratio) wired into `ConfigPanel.vue`, mirroring the existing `ModelSelector` pattern.
- Add `size?: string` to `IFluxConfig` and `IFluxGenerateRequest` so the value flows through `onGenerate` (which spreads `config`).
- Add `FLUX_ASPECT_RATIOS` + `FLUX_DEFAULT_SIZE = '1:1'` constants. Aspect ratios (`1:1`, `16:9`, …) are valid for **all** Flux models per the worker, so a single ratio list works everywhere and defaults to `1:1`.

Reuses existing i18n keys `flux.name.ratio` and `flux.placeholder.select` (present in zh-CN + en), so no new translations required.

## 🤖 对抗评审

Reviewer: **Codex** (`codex exec --sandbox read-only`), 1 round.

- **RISK:** `ConfigPanel.vue` imports `./config/SizeSelector.vue`, but the file was absent from `git diff origin/main` — a pushed checkout would fail to build.
  - **Resolution:** False positive — the file exists as a *new untracked* file (hence not in `git diff`). Confirmed `git add` stages it (`A  src/components/flux/config/SizeSelector.vue`) so it ships in the commit.

**VERDICT: CLEAN** after staging the new file.