### PR TITLE
feat(maestro): friendly step-checklist for in-progress video tasks

### DIFF
--- a/change/@acedatacloud-nexior-e69a9ead-0d7e-48e8-b4a4-4de7e1ebaf65.json
+++ b/change/@acedatacloud-nexior-e69a9ead-0d7e-48e8-b4a4-4de7e1ebaf65.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add a friendly step-checklist for in-progress maestro video tasks",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/maestro/task/Preview.vue
+++ b/src/components/maestro/task/Preview.vue
@@ -20,9 +20,9 @@
         </p>
       </div>
 
-      <!-- in-progress: task id (+ trace id) + live stage + percentage -->
+      <!-- in-progress: step checklist + task id (+ trace id) + overall percentage -->
       <div v-if="!isTerminal" class="content">
-        <p v-if="progressMessage" class="text-xs text-[var(--el-text-color-secondary)] mb-1">{{ progressMessage }}</p>
+        <progress-steps :model-value="modelValue" />
         <el-progress v-if="progressPct !== undefined" :percentage="progressPct" :stroke-width="6" />
         <p class="text-[var(--el-text-color-regular)] text-xs mb-1 mt-2">
           <font-awesome-icon icon="fa-solid fa-magic" class="mr-1" />
@@ -109,6 +109,7 @@ import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import VideoPlayer from '@/components/common/VideoPlayer.vue';
 import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
+import ProgressSteps from './ProgressSteps.vue';
 
 const TERMINAL = ['succeeded', 'failed'];
 
@@ -122,7 +123,8 @@ export default defineComponent({
     ElProgress,
     VideoPlayer,
     ElButton,
-    ApiCodeButton
+    ApiCodeButton,
+    ProgressSteps
   },
   props: {
     modelValue: {
@@ -144,11 +146,6 @@ export default defineComponent({
     },
     isTerminal(): boolean {
       return TERMINAL.includes(this.modelValue?.status || '');
-    },
-    progressMessage(): string | undefined {
-      const progress = this.modelValue?.response?.data?.progress;
-      const last = progress?.length ? progress[progress.length - 1] : undefined;
-      return last?.message || last?.stage || this.modelValue?.response?.data?.stage;
     },
     progressPct(): number | undefined {
       const progress = this.modelValue?.response?.data?.progress;

--- a/src/components/maestro/task/ProgressSteps.vue
+++ b/src/components/maestro/task/ProgressSteps.vue
@@ -1,0 +1,132 @@
+<template>
+  <div class="progress-steps" aria-live="polite">
+    <div
+      v-for="step in steps"
+      :key="step.key"
+      class="step"
+      :class="step.state"
+      :role="step.state === 'active' ? 'status' : undefined"
+      :aria-current="step.state === 'active' ? 'step' : undefined"
+    >
+      <span class="marker">
+        <font-awesome-icon v-if="step.state === 'done'" icon="fa-solid fa-circle-check" />
+        <font-awesome-icon v-else-if="step.state === 'active'" icon="fa-solid fa-spinner" spin />
+        <span v-else class="dot" />
+      </span>
+      <span class="label">{{ $t(`maestro.step.${step.key}`) }}</span>
+      <span v-if="step.state === 'active' && detail" class="detail">{{ detail }}</span>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { IMaestroTask } from '@/models';
+
+// Canonical, ordered pipeline stages the backend emits (runner.py). The checklist mirrors them.
+const CANON = ['plan', 'source', 'voice', 'compose', 'render', 'deliver'];
+
+// Map a (possibly legacy/free-form) stage string to its canonical index; -1 = unrecognized.
+function canonIndex(stage?: string): number {
+  if (!stage) return -1;
+  const s = stage.toLowerCase();
+  const direct = CANON.indexOf(s);
+  if (direct >= 0) return direct;
+  if (/plan|storyboard|script|brief/.test(s)) return 0;
+  if (/source|search|image|photo|asset|media/.test(s)) return 1;
+  if (/voice|tts|audio|narrat/.test(s)) return 2;
+  if (/compose|composit|build|layout|scene/.test(s)) return 3;
+  if (/render|encode/.test(s)) return 4;
+  if (/deliver|upload|cdn|complete|done|finish/.test(s)) return 5;
+  return -1;
+}
+
+type StepState = 'done' | 'active' | 'pending';
+
+export default defineComponent({
+  name: 'ProgressSteps',
+  components: { FontAwesomeIcon },
+  props: {
+    modelValue: {
+      type: Object as () => IMaestroTask | undefined,
+      required: true
+    }
+  },
+  computed: {
+    // The highest canonical stage reached so far. A running task is at least "planning" (index 0)
+    // even before any progress event lands, so the checklist never renders fully empty.
+    currentIndex(): number {
+      const events = this.modelValue?.response?.data?.progress || [];
+      let max = -1;
+      for (const e of events) max = Math.max(max, canonIndex(e?.stage));
+      max = Math.max(max, canonIndex(this.modelValue?.response?.data?.stage));
+      return Math.max(max, 0);
+    },
+    // Latest progress message (may be from a previous step if the current step hasn't logged one
+    // yet) — shown as the live "currently doing" detail under the active step.
+    detail(): string | undefined {
+      const events = this.modelValue?.response?.data?.progress || [];
+      for (let i = events.length - 1; i >= 0; i--) {
+        if (events[i]?.message) return events[i]?.message;
+      }
+      return undefined;
+    },
+    steps(): { key: string; state: StepState }[] {
+      const cur = this.currentIndex;
+      return CANON.map((key, i) => ({
+        key,
+        state: (i < cur ? 'done' : i === cur ? 'active' : 'pending') as StepState
+      }));
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.progress-steps {
+  margin: 6px 0 10px;
+  .step {
+    display: flex;
+    align-items: center;
+    font-size: 13px;
+    line-height: 1.9;
+    color: var(--el-text-color-secondary);
+    min-width: 0;
+    .marker {
+      width: 18px;
+      flex-shrink: 0;
+      display: inline-flex;
+      justify-content: center;
+      margin-right: 8px;
+      .dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        border: 1.5px solid var(--el-text-color-disabled);
+      }
+    }
+    .label {
+      flex-shrink: 0;
+    }
+    .detail {
+      margin-left: 8px;
+      font-size: 12px;
+      color: var(--el-text-color-placeholder);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    &.done {
+      color: var(--el-color-success);
+    }
+    &.active {
+      color: var(--el-color-primary);
+      font-weight: 600;
+    }
+    &.pending {
+      color: var(--el-text-color-disabled);
+    }
+  }
+}
+</style>

--- a/src/i18n/ar/maestro.json
+++ b/src/i18n/ar/maestro.json
@@ -27,6 +27,30 @@
     "message": "سبب الفشل",
     "description": "سبب الفشل"
   },
+  "step.plan": {
+    "message": "التخطيط والقصة المصورة",
+    "description": "Pipeline step: plan"
+  },
+  "step.source": {
+    "message": "جمع الوسائط",
+    "description": "Pipeline step: source media"
+  },
+  "step.voice": {
+    "message": "التعليق الصوتي",
+    "description": "Pipeline step: voiceover"
+  },
+  "step.compose": {
+    "message": "تركيب المشاهد",
+    "description": "Pipeline step: compose"
+  },
+  "step.render": {
+    "message": "معالجة الفيديو",
+    "description": "Pipeline step: render"
+  },
+  "step.deliver": {
+    "message": "التسليم",
+    "description": "Pipeline step: deliver"
+  },
   "name.prompt": {
     "message": "كلمة الطلب",
     "description": "حقل الطلب"

--- a/src/i18n/de/maestro.json
+++ b/src/i18n/de/maestro.json
@@ -27,6 +27,30 @@
     "message": "Fehlerursache",
     "description": "Grund für den Fehler"
   },
+  "step.plan": {
+    "message": "Planung & Storyboard",
+    "description": "Pipeline step: plan"
+  },
+  "step.source": {
+    "message": "Medien sammeln",
+    "description": "Pipeline step: source media"
+  },
+  "step.voice": {
+    "message": "Voiceover",
+    "description": "Pipeline step: voiceover"
+  },
+  "step.compose": {
+    "message": "Szenen komponieren",
+    "description": "Pipeline step: compose"
+  },
+  "step.render": {
+    "message": "Video rendern",
+    "description": "Pipeline step: render"
+  },
+  "step.deliver": {
+    "message": "Bereitstellen",
+    "description": "Pipeline step: deliver"
+  },
   "name.prompt": {
     "message": "Eingabeaufforderung",
     "description": "Eingabefeld"

--- a/src/i18n/el/maestro.json
+++ b/src/i18n/el/maestro.json
@@ -27,6 +27,30 @@
     "message": "Λόγος αποτυχίας",
     "description": "Λόγος αποτυχίας"
   },
+  "step.plan": {
+    "message": "Σχεδιασμός & στορίμπορντ",
+    "description": "Pipeline step: plan"
+  },
+  "step.source": {
+    "message": "Συλλογή πολυμέσων",
+    "description": "Pipeline step: source media"
+  },
+  "step.voice": {
+    "message": "Αφήγηση",
+    "description": "Pipeline step: voiceover"
+  },
+  "step.compose": {
+    "message": "Σύνθεση σκηνών",
+    "description": "Pipeline step: compose"
+  },
+  "step.render": {
+    "message": "Απόδοση βίντεο",
+    "description": "Pipeline step: render"
+  },
+  "step.deliver": {
+    "message": "Παράδοση",
+    "description": "Pipeline step: deliver"
+  },
   "name.prompt": {
     "message": "Προτροπή",
     "description": "Πεδίο προτροπής"

--- a/src/i18n/en/maestro.json
+++ b/src/i18n/en/maestro.json
@@ -27,6 +27,30 @@
     "message": "Failure Reason",
     "description": "Failure reason"
   },
+  "step.plan": {
+    "message": "Plan & storyboard",
+    "description": "Pipeline step: plan"
+  },
+  "step.source": {
+    "message": "Gather media",
+    "description": "Pipeline step: source media"
+  },
+  "step.voice": {
+    "message": "Voiceover",
+    "description": "Pipeline step: voiceover"
+  },
+  "step.compose": {
+    "message": "Compose scenes",
+    "description": "Pipeline step: compose"
+  },
+  "step.render": {
+    "message": "Render video",
+    "description": "Pipeline step: render"
+  },
+  "step.deliver": {
+    "message": "Deliver",
+    "description": "Pipeline step: deliver"
+  },
   "name.prompt": {
     "message": "Prompt",
     "description": "Prompt field"

--- a/src/i18n/es/maestro.json
+++ b/src/i18n/es/maestro.json
@@ -27,6 +27,30 @@
     "message": "Razón del fallo",
     "description": "Razón del fallo"
   },
+  "step.plan": {
+    "message": "Plan y guion gráfico",
+    "description": "Pipeline step: plan"
+  },
+  "step.source": {
+    "message": "Reunir material",
+    "description": "Pipeline step: source media"
+  },
+  "step.voice": {
+    "message": "Voz en off",
+    "description": "Pipeline step: voiceover"
+  },
+  "step.compose": {
+    "message": "Componer escenas",
+    "description": "Pipeline step: compose"
+  },
+  "step.render": {
+    "message": "Renderizar vídeo",
+    "description": "Pipeline step: render"
+  },
+  "step.deliver": {
+    "message": "Entregar",
+    "description": "Pipeline step: deliver"
+  },
   "name.prompt": {
     "message": "Palabra clave",
     "description": "Campo de solicitud"

--- a/src/i18n/fi/maestro.json
+++ b/src/i18n/fi/maestro.json
@@ -27,6 +27,30 @@
     "message": "Epäonnistumisen syy",
     "description": "Epäonnistumisen syy"
   },
+  "step.plan": {
+    "message": "Suunnittelu & kuvakäsikirjoitus",
+    "description": "Pipeline step: plan"
+  },
+  "step.source": {
+    "message": "Kerää media",
+    "description": "Pipeline step: source media"
+  },
+  "step.voice": {
+    "message": "Selostus",
+    "description": "Pipeline step: voiceover"
+  },
+  "step.compose": {
+    "message": "Kokoa kohtaukset",
+    "description": "Pipeline step: compose"
+  },
+  "step.render": {
+    "message": "Renderöi video",
+    "description": "Pipeline step: render"
+  },
+  "step.deliver": {
+    "message": "Toimitus",
+    "description": "Pipeline step: deliver"
+  },
   "name.prompt": {
     "message": "Vihje",
     "description": "Prompt-kenttä"

--- a/src/i18n/fr/maestro.json
+++ b/src/i18n/fr/maestro.json
@@ -27,6 +27,30 @@
     "message": "Raison de l'échec",
     "description": "Raison de l'échec"
   },
+  "step.plan": {
+    "message": "Plan et storyboard",
+    "description": "Pipeline step: plan"
+  },
+  "step.source": {
+    "message": "Rassembler les médias",
+    "description": "Pipeline step: source media"
+  },
+  "step.voice": {
+    "message": "Voix off",
+    "description": "Pipeline step: voiceover"
+  },
+  "step.compose": {
+    "message": "Composer les scènes",
+    "description": "Pipeline step: compose"
+  },
+  "step.render": {
+    "message": "Rendu de la vidéo",
+    "description": "Pipeline step: render"
+  },
+  "step.deliver": {
+    "message": "Livraison",
+    "description": "Pipeline step: deliver"
+  },
   "name.prompt": {
     "message": "Mot-clé",
     "description": "Champ de prompt"

--- a/src/i18n/it/maestro.json
+++ b/src/i18n/it/maestro.json
@@ -27,6 +27,30 @@
     "message": "Motivo del fallimento",
     "description": "Motivo del fallimento"
   },
+  "step.plan": {
+    "message": "Piano e storyboard",
+    "description": "Pipeline step: plan"
+  },
+  "step.source": {
+    "message": "Raccolta media",
+    "description": "Pipeline step: source media"
+  },
+  "step.voice": {
+    "message": "Voce fuori campo",
+    "description": "Pipeline step: voiceover"
+  },
+  "step.compose": {
+    "message": "Comporre le scene",
+    "description": "Pipeline step: compose"
+  },
+  "step.render": {
+    "message": "Rendering del video",
+    "description": "Pipeline step: render"
+  },
+  "step.deliver": {
+    "message": "Consegna",
+    "description": "Pipeline step: deliver"
+  },
   "name.prompt": {
     "message": "Parola chiave",
     "description": "Campo per il prompt"

--- a/src/i18n/ja/maestro.json
+++ b/src/i18n/ja/maestro.json
@@ -27,6 +27,30 @@
     "message": "失敗理由",
     "description": "失敗の理由"
   },
+  "step.plan": {
+    "message": "企画・絵コンテ",
+    "description": "Pipeline step: plan"
+  },
+  "step.source": {
+    "message": "素材の収集",
+    "description": "Pipeline step: source media"
+  },
+  "step.voice": {
+    "message": "ナレーション生成",
+    "description": "Pipeline step: voiceover"
+  },
+  "step.compose": {
+    "message": "シーン編集",
+    "description": "Pipeline step: compose"
+  },
+  "step.render": {
+    "message": "動画レンダリング",
+    "description": "Pipeline step: render"
+  },
+  "step.deliver": {
+    "message": "配信",
+    "description": "Pipeline step: deliver"
+  },
   "name.prompt": {
     "message": "プロンプト",
     "description": "プロンプトフィールド"

--- a/src/i18n/ko/maestro.json
+++ b/src/i18n/ko/maestro.json
@@ -27,6 +27,30 @@
     "message": "실패 원인",
     "description": "실패 이유"
   },
+  "step.plan": {
+    "message": "기획 및 스토리보드",
+    "description": "Pipeline step: plan"
+  },
+  "step.source": {
+    "message": "소재 수집",
+    "description": "Pipeline step: source media"
+  },
+  "step.voice": {
+    "message": "내레이션 생성",
+    "description": "Pipeline step: voiceover"
+  },
+  "step.compose": {
+    "message": "장면 구성",
+    "description": "Pipeline step: compose"
+  },
+  "step.render": {
+    "message": "영상 렌더링",
+    "description": "Pipeline step: render"
+  },
+  "step.deliver": {
+    "message": "전달",
+    "description": "Pipeline step: deliver"
+  },
   "name.prompt": {
     "message": "프롬프트",
     "description": "프롬프트 필드"

--- a/src/i18n/pl/maestro.json
+++ b/src/i18n/pl/maestro.json
@@ -27,6 +27,30 @@
     "message": "Powód niepowodzenia",
     "description": "Powód niepowodzenia"
   },
+  "step.plan": {
+    "message": "Plan i storyboard",
+    "description": "Pipeline step: plan"
+  },
+  "step.source": {
+    "message": "Zbieranie materiałów",
+    "description": "Pipeline step: source media"
+  },
+  "step.voice": {
+    "message": "Narracja",
+    "description": "Pipeline step: voiceover"
+  },
+  "step.compose": {
+    "message": "Komponowanie scen",
+    "description": "Pipeline step: compose"
+  },
+  "step.render": {
+    "message": "Renderowanie wideo",
+    "description": "Pipeline step: render"
+  },
+  "step.deliver": {
+    "message": "Dostarczenie",
+    "description": "Pipeline step: deliver"
+  },
   "name.prompt": {
     "message": "Słowo kluczowe",
     "description": "Pole prompt"

--- a/src/i18n/pt/maestro.json
+++ b/src/i18n/pt/maestro.json
@@ -27,6 +27,30 @@
     "message": "Razão da falha",
     "description": "Razão da falha"
   },
+  "step.plan": {
+    "message": "Plano e storyboard",
+    "description": "Pipeline step: plan"
+  },
+  "step.source": {
+    "message": "Reunir mídia",
+    "description": "Pipeline step: source media"
+  },
+  "step.voice": {
+    "message": "Narração",
+    "description": "Pipeline step: voiceover"
+  },
+  "step.compose": {
+    "message": "Compor cenas",
+    "description": "Pipeline step: compose"
+  },
+  "step.render": {
+    "message": "Renderizar vídeo",
+    "description": "Pipeline step: render"
+  },
+  "step.deliver": {
+    "message": "Entregar",
+    "description": "Pipeline step: deliver"
+  },
   "name.prompt": {
     "message": "Prompt",
     "description": "Campo de prompt"

--- a/src/i18n/ru/maestro.json
+++ b/src/i18n/ru/maestro.json
@@ -27,6 +27,30 @@
     "message": "Причина ошибки",
     "description": "Причина ошибки"
   },
+  "step.plan": {
+    "message": "План и раскадровка",
+    "description": "Pipeline step: plan"
+  },
+  "step.source": {
+    "message": "Сбор материалов",
+    "description": "Pipeline step: source media"
+  },
+  "step.voice": {
+    "message": "Озвучивание",
+    "description": "Pipeline step: voiceover"
+  },
+  "step.compose": {
+    "message": "Сборка сцен",
+    "description": "Pipeline step: compose"
+  },
+  "step.render": {
+    "message": "Рендеринг видео",
+    "description": "Pipeline step: render"
+  },
+  "step.deliver": {
+    "message": "Публикация",
+    "description": "Pipeline step: deliver"
+  },
   "name.prompt": {
     "message": "Подсказка",
     "description": "Поле подсказки"

--- a/src/i18n/sr/maestro.json
+++ b/src/i18n/sr/maestro.json
@@ -27,6 +27,30 @@
     "message": "Razlog neuspeha",
     "description": "Razlog neuspeha"
   },
+  "step.plan": {
+    "message": "План и сториборд",
+    "description": "Pipeline step: plan"
+  },
+  "step.source": {
+    "message": "Прикупљање материјала",
+    "description": "Pipeline step: source media"
+  },
+  "step.voice": {
+    "message": "Нарација",
+    "description": "Pipeline step: voiceover"
+  },
+  "step.compose": {
+    "message": "Компоновање сцена",
+    "description": "Pipeline step: compose"
+  },
+  "step.render": {
+    "message": "Рендеровање видеа",
+    "description": "Pipeline step: render"
+  },
+  "step.deliver": {
+    "message": "Испорука",
+    "description": "Pipeline step: deliver"
+  },
   "name.prompt": {
     "message": "Упит",
     "description": "Поље за упит"

--- a/src/i18n/sv/maestro.json
+++ b/src/i18n/sv/maestro.json
@@ -27,6 +27,30 @@
     "message": "Orsak till misslyckande",
     "description": "Orsak till misslyckande"
   },
+  "step.plan": {
+    "message": "Plan & storyboard",
+    "description": "Pipeline step: plan"
+  },
+  "step.source": {
+    "message": "Samla media",
+    "description": "Pipeline step: source media"
+  },
+  "step.voice": {
+    "message": "Voiceover",
+    "description": "Pipeline step: voiceover"
+  },
+  "step.compose": {
+    "message": "Komponera scener",
+    "description": "Pipeline step: compose"
+  },
+  "step.render": {
+    "message": "Rendera video",
+    "description": "Pipeline step: render"
+  },
+  "step.deliver": {
+    "message": "Leverera",
+    "description": "Pipeline step: deliver"
+  },
   "name.prompt": {
     "message": "Prompt",
     "description": "Prompt fält"

--- a/src/i18n/uk/maestro.json
+++ b/src/i18n/uk/maestro.json
@@ -27,6 +27,30 @@
     "message": "Причина невдачі",
     "description": "Причина невдачі"
   },
+  "step.plan": {
+    "message": "План і розкадровка",
+    "description": "Pipeline step: plan"
+  },
+  "step.source": {
+    "message": "Збір матеріалів",
+    "description": "Pipeline step: source media"
+  },
+  "step.voice": {
+    "message": "Озвучення",
+    "description": "Pipeline step: voiceover"
+  },
+  "step.compose": {
+    "message": "Компонування сцен",
+    "description": "Pipeline step: compose"
+  },
+  "step.render": {
+    "message": "Рендеринг відео",
+    "description": "Pipeline step: render"
+  },
+  "step.deliver": {
+    "message": "Доставка",
+    "description": "Pipeline step: deliver"
+  },
   "name.prompt": {
     "message": "Підказка",
     "description": "Поле підказки"

--- a/src/i18n/zh-CN/maestro.json
+++ b/src/i18n/zh-CN/maestro.json
@@ -27,6 +27,30 @@
     "message": "失败原因",
     "description": "Failure reason"
   },
+  "step.plan": {
+    "message": "理解需求 · 分镜脚本",
+    "description": "Pipeline step: plan"
+  },
+  "step.source": {
+    "message": "准备素材（搜图 / 生成）",
+    "description": "Pipeline step: source media"
+  },
+  "step.voice": {
+    "message": "生成配音",
+    "description": "Pipeline step: voiceover"
+  },
+  "step.compose": {
+    "message": "编排合成",
+    "description": "Pipeline step: compose"
+  },
+  "step.render": {
+    "message": "渲染出片",
+    "description": "Pipeline step: render"
+  },
+  "step.deliver": {
+    "message": "上传交付",
+    "description": "Pipeline step: deliver"
+  },
   "name.prompt": {
     "message": "提示词",
     "description": "Prompt field"

--- a/src/i18n/zh-TW/maestro.json
+++ b/src/i18n/zh-TW/maestro.json
@@ -27,6 +27,30 @@
     "message": "失敗原因",
     "description": "失敗原因"
   },
+  "step.plan": {
+    "message": "理解需求 · 分鏡腳本",
+    "description": "Pipeline step: plan"
+  },
+  "step.source": {
+    "message": "準備素材（搜圖 / 生成）",
+    "description": "Pipeline step: source media"
+  },
+  "step.voice": {
+    "message": "生成配音",
+    "description": "Pipeline step: voiceover"
+  },
+  "step.compose": {
+    "message": "編排合成",
+    "description": "Pipeline step: compose"
+  },
+  "step.render": {
+    "message": "渲染出片",
+    "description": "Pipeline step: render"
+  },
+  "step.deliver": {
+    "message": "上傳交付",
+    "description": "Pipeline step: deliver"
+  },
   "name.prompt": {
     "message": "提示詞",
     "description": "提示詞欄位"


### PR DESCRIPTION
## Why

An in-progress maestro video task currently shows just one opaque line + a percent bar, and the backend's self-reported progress is often empty for a long time — so users stare at "制作中 · 8%" with no idea what's happening. Companion backend PR (PlatformService #1351) now emits **6 canonical, ordered pipeline stages**; this renders them as a friendly **step-checklist** that checks off as the video is made.

## What

New `src/components/maestro/task/ProgressSteps.vue`, shown in [Preview.vue](src/components/maestro/task/Preview.vue)'s in-progress block:

```
✅ 理解需求 · 分镜脚本
🔄 准备素材（搜图 / 生成）   正在用 gpt-image-2 提升实拍图清晰度…
○ 生成配音
○ 编排合成
○ 渲染出片
○ 上传交付
──────────────  ▓▓▓▓▓░░░░░ 42%
```

- Derives step state from the task's `response.data.progress[]` canonical `stage` + `response.data.stage`. `canonIndex()` matches the canonical set exactly, with a regex **alias fallback** for legacy/free-form stages so old tasks still render.
- `currentIndex` = highest stage reached, **floored at 0** — a running task shows `plan` active immediately, even before the first progress event lands (no more empty state).
- Each step: done (`fa-circle-check`) / active (`fa-spinner` spin + the live message) / pending (CSS hollow dot). The overall percent bar is kept.
- Updates live via the existing 5s task poll (props → computed). Only rendered for non-terminal tasks; success shows the player, failure shows the error.
- Removed the now-redundant single `progressMessage` line + computed.
- i18n: `maestro.step.*` added to **zh-CN + en** only (per repo rule — no `yarn translate`).

Backwards-compatible: if the backend hasn't deployed the canonical stages yet, the alias fallback + floor still drive a sensible checklist.

## Checks

VS Code diagnostics clean · `prettier --check` clean · `eslint` exit 0 · `vue-tsc --noEmit` exit 0.

## 🤖 对抗评审

Reviewer: Claude `general-purpose` subagent (Codex not installed). One round → nits applied, converged.

- **NIT — `detail()` comment overstated "currently doing" (message may be from a previous step if the active step hasn't logged one).** → **Fixed** (comment clarified).
- **NIT — active spinner lacked screen-reader semantics.** → **Fixed** (`aria-live="polite"` on the list, `role="status"` + `aria-current="step"` on the active step).
- Reviewer verified: only shown when `!isTerminal`; reactive on the 5s poll; no regex collisions across the 6 stages (direct match precedes alias); `progressMessage` removed with zero dangling refs; i18n keys present in both locales; optional-chained message access; overall `progressPct` bar intact.

**VERDICT: CLEAN** after the two nits.
