### PR TITLE
fix(maestro): refine step-checklist UI (no connector line, smaller icons)

### DIFF
--- a/change/@acedatacloud-nexior-maestro-steps-refine.json
+++ b/change/@acedatacloud-nexior-maestro-steps-refine.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Refine the maestro step-checklist: drop the connector line, smaller consistent icons, round native loading",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/maestro/task/Preview.vue
+++ b/src/components/maestro/task/Preview.vue
@@ -13,7 +13,7 @@
       <div class="info">
         <p v-if="modelValue?.request?.prompt" class="prompt mt-2">
           {{ modelValue?.request?.prompt }}
-          <span v-if="!isTerminal"> - ({{ statusLabel }}) </span>
+          <span v-if="!isTerminal" class="progress-pct"> · {{ progressText }}</span>
         </p>
         <p v-if="fileCount" class="text-xs text-[var(--el-text-color-secondary)] mb-1">
           <font-awesome-icon icon="fa-solid fa-paperclip" class="mr-1" />{{ fileCount }}
@@ -24,7 +24,6 @@
       <div v-if="!isTerminal" class="content">
         <el-alert :closable="false" class="mt-2 processing">
           <progress-steps :model-value="modelValue" />
-          <el-progress v-if="progressPct !== undefined" :percentage="progressPct" :stroke-width="6" class="mt-1" />
           <p class="text-[var(--el-text-color-regular)] text-xs mb-1 mt-3">
             <font-awesome-icon icon="fa-solid fa-magic" class="mr-1" />
             {{ $t('maestro.name.taskId') }}: {{ modelValue?.id }}
@@ -104,7 +103,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElImage, ElAlert, ElButton, ElProgress, ElMessage } from 'element-plus';
+import { ElImage, ElAlert, ElButton, ElMessage } from 'element-plus';
 import { IMaestroTask, IMaestroVariant, IMaestroConfig } from '@/models';
 import { MAESTRO_LOGO, MAESTRO_ACTION_REMIX } from '@/constants';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
@@ -122,7 +121,6 @@ export default defineComponent({
     CopyToClipboard,
     FontAwesomeIcon,
     ElAlert,
-    ElProgress,
     VideoPlayer,
     ElButton,
     ApiCodeButton,
@@ -153,6 +151,9 @@ export default defineComponent({
       const progress = this.modelValue?.response?.data?.progress;
       const last = progress?.length ? progress[progress.length - 1] : undefined;
       return typeof last?.pct === 'number' ? last.pct : undefined;
+    },
+    progressText(): string {
+      return this.progressPct !== undefined ? `${this.progressPct}%` : this.statusLabel;
     },
     statusLabel(): string {
       const s = this.modelValue?.status || 'pending';
@@ -240,6 +241,11 @@ $left-width: 70px;
         white-space: normal;
         word-break: break-word;
         overflow-wrap: anywhere;
+        .progress-pct {
+          font-weight: 600;
+          color: var(--el-color-primary);
+          white-space: nowrap;
+        }
       }
     }
 

--- a/src/components/maestro/task/ProgressSteps.vue
+++ b/src/components/maestro/task/ProgressSteps.vue
@@ -1,20 +1,28 @@
 <template>
   <div class="progress-steps" aria-live="polite">
-    <el-steps direction="vertical" :active="currentIndex" finish-status="finish" :space="34">
-      <el-step v-for="(step, i) in steps" :key="step.key" :title="$t(`maestro.step.${step.key}`)">
-        <template v-if="i === currentIndex" #icon>
-          <el-icon class="is-loading" :aria-label="$t(`maestro.step.${step.key}`)"><loading /></el-icon>
-        </template>
-      </el-step>
-    </el-steps>
+    <div
+      v-for="(step, i) in steps"
+      :key="step.key"
+      class="step"
+      :class="stateOf(i)"
+      :aria-current="i === currentIndex ? 'step' : undefined"
+    >
+      <span class="ico">
+        <el-icon v-if="i === currentIndex" class="is-loading" :aria-label="$t(`maestro.step.${step.key}`)">
+          <loading />
+        </el-icon>
+        <el-icon v-else-if="i < currentIndex"><check /></el-icon>
+      </span>
+      <span class="txt">{{ $t(`maestro.step.${step.key}`) }}</span>
+    </div>
     <p v-if="detail" class="detail">{{ detail }}</p>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElSteps, ElStep, ElIcon } from 'element-plus';
-import { Loading } from '@element-plus/icons-vue';
+import { ElIcon } from 'element-plus';
+import { Loading, Check } from '@element-plus/icons-vue';
 import { IMaestroTask } from '@/models';
 
 // Canonical, ordered pipeline stages the backend emits (runner.py). The checklist mirrors them.
@@ -37,7 +45,7 @@ function canonIndex(stage?: string): number {
 
 export default defineComponent({
   name: 'ProgressSteps',
-  components: { ElSteps, ElStep, ElIcon, Loading },
+  components: { ElIcon, Loading, Check },
   props: {
     modelValue: {
       type: Object as () => IMaestroTask | undefined,
@@ -66,48 +74,66 @@ export default defineComponent({
     steps(): { key: string }[] {
       return CANON.map((key) => ({ key }));
     }
+  },
+  methods: {
+    stateOf(i: number): 'done' | 'active' | 'pending' {
+      const cur = this.currentIndex;
+      return i < cur ? 'done' : i === cur ? 'active' : 'pending';
+    }
   }
 });
 </script>
 
 <style lang="scss" scoped>
 .progress-steps {
-  margin: 4px 0 10px;
+  margin: 4px 0 8px;
 
-  // compact, on-brand overrides for the native vertical stepper
-  :deep(.el-step__icon) {
-    width: 22px;
-    height: 22px;
-    font-size: 12px;
-  }
-  // thinner ring on the numbered / check circles
-  :deep(.el-step__icon.is-text) {
-    border-width: 1px;
-  }
-  // the active step is a clean spinning ring (no boxy border), brand-colored
-  :deep(.el-step__icon.is-icon) {
-    border: none;
-    color: var(--el-color-primary);
-    font-size: 16px;
-  }
-  :deep(.el-step__title) {
+  // refined, connector-line-free checklist with small consistent indicators
+  .step {
+    display: flex;
+    align-items: center;
+    gap: 8px;
     font-size: 13px;
-    line-height: 22px;
-    padding-bottom: 4px;
-    &.is-finish {
-      color: var(--el-color-primary);
+    line-height: 1.75;
+
+    .ico {
+      width: 14px;
+      height: 14px;
+      flex-shrink: 0;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 13px;
     }
-    &.is-process {
+
+    &.done {
+      color: var(--el-color-primary);
+      .ico {
+        color: var(--el-color-primary);
+      }
+    }
+    &.active {
+      color: var(--el-color-primary);
       font-weight: 600;
-      color: var(--el-color-primary);
+      .ico {
+        color: var(--el-color-primary);
+      }
     }
-    &.is-wait {
+    &.pending {
       color: var(--el-text-color-disabled);
+      .ico::before {
+        content: '';
+        display: inline-block;
+        width: 7px;
+        height: 7px;
+        border-radius: 50%;
+        border: 1px solid var(--el-text-color-disabled);
+      }
     }
   }
 
   .detail {
-    margin: 2px 0 0 30px;
+    margin: 3px 0 0 22px;
     font-size: 12px;
     line-height: 1.5;
     color: var(--el-text-color-placeholder);


### PR DESCRIPTION
## Why

Follow-up UI feedback on the maestro step-checklist: the `el-steps` vertical stepper's **thick connector line** and big number circles read as heavy / unrefined, and the active-step icon looked boxy.

## What

Replace `el-steps`/`el-step` with a lightweight, **connector-line-free** custom checklist:
- **No vertical line** — just a clean list of rows.
- **Small, consistent 14px indicators**: a primary-color check (`el-icon` `Check`) for done steps, a native **round** spinning ring (`<el-icon class="is-loading"><loading/></el-icon>`, the same pattern suno/voice already use) for the active step, and a subtle 7px hollow dot for pending steps.
- Primary color theme throughout (matches the card's primary left-border).
- `stateOf(i)` derives done/active/pending from the unchanged `currentIndex`. No logic/behavior change (`canonIndex`/`currentIndex`/`detail`/`steps` untouched); no new i18n keys (reuses `maestro.step.*`).

## Checks

`prettier --check` clean · `eslint` exit 0 · `vue-tsc --noEmit` exit 0 · beachball change file added.

## 🤖 对抗评审

Reviewer: Claude `general-purpose` subagent. One round → 1 real defect fixed, 1 false positive rebutted.

- **RISK — the pending `.ico::before` hollow dot lacked `display`, so as a default-`inline` pseudo-element it would ignore width/height and render 0×0 (invisible).** → **Fixed** (`display: inline-block`).
- **RISK — claimed the `maestro.step.*` i18n keys don't exist.** → **Rebutted / false positive.** Verified all 18 locale `maestro.json` files each contain the 6 `step.*` keys (added in the earlier #1166, already merged). Confirmed programmatically.
- Verified: `Loading`/`Check` are valid `@element-plus/icons-vue` exports; `stateOf` reading the `currentIndex` computed is valid Options API; no leftover `el-steps`/`is-finish`/`is-text` refs; `<check>`/`<loading>` resolve from the PascalCase registration; accessibility (`aria-current` + spinner `aria-label`) intact.

**VERDICT: CLEAN** after the display fix.
