### PR TITLE
fix(chat): 分享菜单项补齐图标注册

### DIFF
--- a/change/@acedatacloud-nexior-91587d58-6c4c-4ee3-af8b-5997583943f1.json
+++ b/change/@acedatacloud-nexior-91587d58-6c4c-4ee3-af8b-5997583943f1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(chat): register fa-share-nodes so the share menu item shows its icon",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/plugins/font-awesome.ts
+++ b/src/plugins/font-awesome.ts
@@ -82,6 +82,7 @@ import {
   faWind as faSolidWind,
   faStore as faSolidStore,
   faTrash as faSolidTrash,
+  faShareNodes as faSolidShareNodes,
   faChevronDown as faSolidChevronDown,
   faArrowsRotate as faSolidArrowsRotate,
   faUpRightFromSquare as faSolidUpRightFromSquare,
@@ -239,6 +240,7 @@ library.add(faRegularComment);
 library.add(faSolidArrowRightFromBracket);
 library.add(faSolidUserXmark);
 library.add(faSolidTrash);
+library.add(faSolidShareNodes);
 library.add(faSolidChevronDown);
 library.add(faSolidPalette);
 library.add(faSolidWandMagicSparkles);


### PR DESCRIPTION
## 问题

会话侧栏的"分享"菜单项引用了 `fa-solid fa-share-nodes` 图标，但该图标从未在中心化的 Font Awesome 插件（`src/plugins/font-awesome.ts`）里注册，导致菜单里"重命名/删除"有图标、唯独"分享"没有图标。

## 修改

在 `src/plugins/font-awesome.ts` 补两行，按现有模式注册该 solid 图标：

- 导入：`faShareNodes as faSolidShareNodes`
- 注册：`library.add(faSolidShareNodes)`

Bug 来自已合并的分享功能 PR #1162，本 PR 补齐其遗漏的图标注册。

## 🤖 对抗评审

- 评审方式：Codex 不可用 → Claude `general-purpose` 只读子代理。
- 结论：**VERDICT: CLEAN**（1 轮收敛，无 RISK）。
- 核对项：`faShareNodes` 是 `@fortawesome/free-solid-svg-icons` v6.2.1 的有效导出；导入位于 solid 图标块；`fa-solid fa-share-nodes` ↔ `faShareNodes` 映射正确；无重复注册 / 拼写错误 / 未使用导入。