### PR TITLE
feat(settings): install Xiaohongshu DM skill from Android Local Tools

### DIFF
--- a/change/@acedatacloud-nexior-ae7172e6-f7f7-4aee-bf18-a5f55714f398.json
+++ b/change/@acedatacloud-nexior-ae7172e6-f7f7-4aee-bf18-a5f55714f398.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(settings): install Xiaohongshu DM skill from Android Local Tools",
+  "packageName": "@acedatacloud/nexior",
+  "email": "cqc@cuiqingcai.com",
+  "dependentChangeType": "patch"
+}

--- a/src/components/setting/LocalTools.vue
+++ b/src/components/setting/LocalTools.vue
@@ -208,6 +208,49 @@
         </template>
       </section>
 
+      <!-- Android: install curated phone-automation skills (computer.* based) -->
+      <section v-if="android">
+        <div class="section-head">
+          <h3>{{ $t('common.settings.localToolsAndroidSkillsTitle') }}</h3>
+        </div>
+        <p class="muted">{{ $t('common.settings.localToolsAndroidSkillsHint') }}</p>
+        <ul class="rows">
+          <li v-if="xhsSkill" class="row">
+            <font-awesome-icon icon="fa-solid fa-wand-magic-sparkles" class="row-icon" />
+            <span class="cu-action">
+              <span class="cu-action-name">{{ $t('common.settings.localToolsAndroidSkillsXhsName') }}</span>
+              <span class="cu-action-desc">{{ $t('common.settings.localToolsAndroidSkillsXhsDesc') }}</span>
+            </span>
+            <el-tag v-if="xhsSkill.installed" size="small" type="success" effect="plain">
+              {{ $t('common.settings.localToolsAndroidSkillsInstalled') }}
+            </el-tag>
+            <el-button
+              v-else
+              size="small"
+              type="primary"
+              :loading="xhsInstalling"
+              :disabled="!canInstallXhs"
+              @click="installXhs"
+            >
+              {{ $t('common.settings.localToolsAndroidSkillsInstall') }}
+            </el-button>
+          </li>
+          <li v-else-if="xhsLoading" class="row muted empty">
+            {{ $t('common.settings.localToolsAndroidSkillsLoading') }}
+          </li>
+          <li v-else-if="!xhsError" class="row muted empty">
+            {{ $t('common.settings.localToolsAndroidSkillsUnavailable') }}
+          </li>
+        </ul>
+        <p v-if="xhsSkill && !xhsSkill.installed && !canInstallXhs" class="muted">
+          {{ $t('common.settings.localToolsAndroidSkillsNeedComputerUse') }}
+        </p>
+        <p v-if="xhsSkill && xhsSkill.installed" class="muted saved-tip">
+          {{ $t('common.settings.localToolsAndroidSkillsNextTurn') }}
+        </p>
+        <p v-if="xhsError" class="mcp-error">{{ xhsError }}</p>
+      </section>
+
       <!-- macOS system permissions -->
       <section v-if="perm">
         <div class="section-head">
@@ -259,11 +302,23 @@ import { Plus } from '@element-plus/icons-vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { localExec, type IMcpServerStatus } from '@/utils/desktop';
 import { isAndroid } from '@/utils/surface';
+import { httpClient } from '@/operators/common';
+import { getBaseUrlAuth } from '@/utils';
+import type { AxiosResponse } from 'axios';
 
 interface GrantRow {
   key: string;
   name: string;
   input: string;
+}
+
+// One row from AuthBackend's public skill directory (subset of SkillSerializer).
+interface AndroidSkillRow {
+  id: string;
+  identifier: string;
+  name: string;
+  installed: boolean;
+  installable: boolean;
 }
 
 // Editable draft of one MCP server row. `args` / `env` are edited as free text
@@ -313,6 +368,11 @@ export default defineComponent({
       savedTip: false,
       // Android: whether the Computer Use accessibility service is enabled.
       a11yEnabled: false,
+      // Android: curated phone-automation skill (Xiaohongshu DM) + install state.
+      xhsSkill: null as null | AndroidSkillRow,
+      xhsLoading: false,
+      xhsInstalling: false,
+      xhsError: '',
       onFocus: null as null | (() => void),
       cuOff: null as null | (() => void)
     };
@@ -323,6 +383,11 @@ export default defineComponent({
     },
     android(): boolean {
       return isAndroid();
+    },
+    // Install only makes sense once the skill can run: accessibility granted AND
+    // Computer Use on. Gate the button on both.
+    canInstallXhs(): boolean {
+      return this.a11yEnabled && this.computerUse;
     }
   },
   async mounted() {
@@ -350,6 +415,7 @@ export default defineComponent({
     await this.loadGrants();
     if (this.android) {
       await this.refreshA11y();
+      void this.fetchXhsSkill();
       // Re-check the accessibility status when the user returns from system
       // settings so the badge/toggles reflect it without a manual reload.
       this.onFocus = () => {
@@ -375,6 +441,49 @@ export default defineComponent({
     },
     async openAndroidAccessibility() {
       await localExec()?.perm?.openPane('accessibility');
+    },
+    // Fetch the curated Android skill (Xiaohongshu DM auto-reply) from
+    // AuthBackend's public skill directory to show its install state. Same auth +
+    // baseURL override the connector catalog cache uses.
+    async fetchXhsSkill() {
+      this.xhsLoading = true;
+      this.xhsError = '';
+      try {
+        const resp: AxiosResponse<{ items?: AndroidSkillRow[] }> = await httpClient.get('/skills/', {
+          baseURL: `${getBaseUrlAuth()}/api/v1`,
+          params: { q: 'xhs-dm', limit: 10 }
+        });
+        const items = Array.isArray(resp.data?.items) ? resp.data.items : [];
+        this.xhsSkill = items.find((s) => s.identifier?.endsWith('/xhs-dm')) ?? null;
+      } catch (e) {
+        console.warn('[LocalTools] fetch xhs skill failed', e);
+        this.xhsSkill = null;
+        this.xhsError = this.$t('common.settings.localToolsAndroidSkillsLoadFailed');
+      } finally {
+        this.xhsLoading = false;
+      }
+    },
+    // Install the curated skill into the user's account. Takes effect next chat
+    // turn (the worker reads /internal/v1/skills/active per turn). 409 = already
+    // installed, treated as success.
+    async installXhs() {
+      const skill = this.xhsSkill;
+      if (!skill || skill.installed) return;
+      this.xhsInstalling = true;
+      this.xhsError = '';
+      try {
+        await httpClient.post(`/skills/${skill.id}/install/`, {}, { baseURL: `${getBaseUrlAuth()}/api/v1` });
+        skill.installed = true;
+      } catch (e) {
+        const httpStatus = (e as { response?: { status?: number } })?.response?.status;
+        if (httpStatus === 409) {
+          skill.installed = true;
+        } else {
+          this.xhsError = this.$t('common.settings.localToolsAndroidSkillsInstallFailed');
+        }
+      } finally {
+        this.xhsInstalling = false;
+      }
     },
     async loadGrants() {
       const ex = localExec();

--- a/src/i18n/ar/common.json
+++ b/src/i18n/ar/common.json
@@ -987,6 +987,54 @@
     "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
     "description": "Help text under the Computer Use toggle."
   },
+  "settings.localToolsAndroidSkillsTitle": {
+    "message": "مهارات أتمتة الهاتف",
+    "description": "عنوان للقسم المخصص لنظام أندرويد الذي يثبت المهارات التي تتحكم في التطبيقات على الهاتف عبر التحكم بالكمبيوتر."
+  },
+  "settings.localToolsAndroidSkillsHint": {
+    "message": "قم بتثبيت المهارات التي تمكن المساعد من التحكم في تطبيقات الهاتف. يتم تشغيلها عبر \"التحكم بالكمبيوتر\"، يرجى منح إذن الوصول لذوي الاحتياجات الخاصة أعلاه وتفعيل التحكم بالكمبيوتر أولاً. لا تزال كل خطوة تتبع إعدادات تأكيد التحكم بالكمبيوتر الخاصة بك.",
+    "description": "نص مساعد تحت عنوان مهارات أتمتة الهاتف."
+  },
+  "settings.localToolsAndroidSkillsXhsName": {
+    "message": "الرد التلقائي على الرسائل المباشرة في 小红书",
+    "description": "اسم العرض لمهارة الرد التلقائي على الرسائل المباشرة في 小红书 (RED)."
+  },
+  "settings.localToolsAndroidSkillsXhsDesc": {
+    "message": "قراءة الرسائل الجديدة في تطبيق 小红书 وصياغة الردود، سيتم طلب تأكيدك قبل الإرسال.",
+    "description": "وصف مختصر لمهارة الرد التلقائي على الرسائل المباشرة في 小红书."
+  },
+  "settings.localToolsAndroidSkillsInstall": {
+    "message": "تثبيت",
+    "description": "زر يقوم بتثبيت المهارة في حساب المستخدم."
+  },
+  "settings.localToolsAndroidSkillsInstalled": {
+    "message": "تم التثبيت",
+    "description": "علامة تظهر عندما تكون المهارة مثبتة بالفعل."
+  },
+  "settings.localToolsAndroidSkillsLoading": {
+    "message": "جارٍ تحميل المهارات المتاحة...",
+    "description": "نص مؤقت أثناء جلب دليل المهارات."
+  },
+  "settings.localToolsAndroidSkillsUnavailable": {
+    "message": "لا توجد مهارات هاتفية قابلة للتثبيت حالياً.",
+    "description": "حالة فارغة عندما لا يتم العثور على مهارة هاتفية قابلة للتثبيت."
+  },
+  "settings.localToolsAndroidSkillsNeedComputerUse": {
+    "message": "يرجى منح إذن الوصول لذوي الاحتياجات الخاصة وتفعيل التحكم بالكمبيوتر أعلاه قبل التثبيت.",
+    "description": "تلميح يظهر عندما يكون زر التثبيت معطلاً بسبب عدم توفر المتطلبات."
+  },
+  "settings.localToolsAndroidSkillsNextTurn": {
+    "message": "تم التثبيت، وسيتم تفعيله في محادثتك القادمة.",
+    "description": "تأكيد يظهر بعد تثبيت ناجح."
+  },
+  "settings.localToolsAndroidSkillsInstallFailed": {
+    "message": "فشل التثبيت، يرجى المحاولة مرة أخرى.",
+    "description": "خطأ يظهر عندما يفشل طلب التثبيت."
+  },
+  "settings.localToolsAndroidSkillsLoadFailed": {
+    "message": "فشل تحميل المهارات المتاحة، يرجى المحاولة مرة أخرى.",
+    "description": "خطأ يظهر عند فشل جلب دليل المهارات."
+  },
   "settings.localToolsPreauthorizeAll": "السماح مسبقًا بجميع إجراءات الكمبيوتر",
   "settings.localToolsPreauthorizeHint": "اسمح دفعة واحدة بلقطة الشاشة والنقر والكتابة والمفاتيح وجميع الإجراءات، واطلب أذونات النظام المطلوبة.",
   "settings.localToolsCuActionsTitle": "السماح بالإجراءات فرديًا",

--- a/src/i18n/de/common.json
+++ b/src/i18n/de/common.json
@@ -987,6 +987,54 @@
     "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
     "description": "Help text under the Computer Use toggle."
   },
+  "settings.localToolsAndroidSkillsTitle": {
+    "message": "Telefonautomatisierungsfähigkeiten",
+    "description": "Überschrift für den Android-exklusiven Abschnitt, der Fähigkeiten installiert, die Apps auf dem Telefon über die Computersteuerung steuern."
+  },
+  "settings.localToolsAndroidSkillsHint": {
+    "message": "Installieren Sie Fähigkeiten, die es dem Assistenten ermöglichen, native Apps zu steuern. Diese laufen über „Computersteuerung“. Bitte gewähren Sie zuerst oben die Barrierefreiheit und aktivieren Sie die Computersteuerung. Jede Aktion folgt weiterhin Ihren Bestätigungs-Einstellungen für die Computersteuerung.",
+    "description": "Hilfetext unter der Überschrift für die Telefonautomatisierungsfähigkeiten."
+  },
+  "settings.localToolsAndroidSkillsXhsName": {
+    "message": "Xiaohongshu private Nachrichten automatische Antwort",
+    "description": "Anzeigename der automatischen Antwortfähigkeit für direkte Nachrichten von Xiaohongshu (RED)."
+  },
+  "settings.localToolsAndroidSkillsXhsDesc": {
+    "message": "Lesen Sie neue private Nachrichten in der Xiaohongshu-App und entwerfen Sie Antworten, die vor dem Senden von Ihnen bestätigt werden.",
+    "description": "Einzeilige Beschreibung der Xiaohongshu DM-Fähigkeit."
+  },
+  "settings.localToolsAndroidSkillsInstall": {
+    "message": "Installieren",
+    "description": "Schaltfläche, die die Fähigkeit im Benutzerkonto installiert."
+  },
+  "settings.localToolsAndroidSkillsInstalled": {
+    "message": "Installiert",
+    "description": "Tag, der angezeigt wird, wenn die Fähigkeit bereits installiert ist."
+  },
+  "settings.localToolsAndroidSkillsLoading": {
+    "message": "Lade verfügbare Fähigkeiten…",
+    "description": "Platzhalter, während das Fähigkeitsverzeichnis abgerufen wird."
+  },
+  "settings.localToolsAndroidSkillsUnavailable": {
+    "message": "Derzeit sind keine installierbaren Telefonfähigkeiten verfügbar.",
+    "description": "Leerer Zustand, wenn keine installierbare Telefonfähigkeit gefunden wird."
+  },
+  "settings.localToolsAndroidSkillsNeedComputerUse": {
+    "message": "Bitte gewähren Sie zuerst die Barrierefreiheit und aktivieren Sie oben die Computersteuerung, bevor Sie installieren.",
+    "description": "Hinweis, der angezeigt wird, wenn die Installationsschaltfläche deaktiviert ist, weil Voraussetzungen fehlen."
+  },
+  "settings.localToolsAndroidSkillsNextTurn": {
+    "message": "Installiert, wird bei Ihrem nächsten Gespräch wirksam.",
+    "description": "Bestätigung, die nach einer erfolgreichen Installation angezeigt wird."
+  },
+  "settings.localToolsAndroidSkillsInstallFailed": {
+    "message": "Installation fehlgeschlagen, bitte erneut versuchen.",
+    "description": "Fehlermeldung, wenn die Installationsanfrage fehlschlägt."
+  },
+  "settings.localToolsAndroidSkillsLoadFailed": {
+    "message": "Laden der verfügbaren Fähigkeiten fehlgeschlagen, bitte erneut versuchen.",
+    "description": "Fehlermeldung, wenn das Abrufen des Fähigkeitsverzeichnisses fehlschlägt."
+  },
   "settings.localToolsPreauthorizeAll": "Alle Computeraktionen vorab erlauben",
   "settings.localToolsPreauthorizeHint": "Screenshot, Klick, Tippen, Tastendruck und alle Computeraktionen auf einmal erlauben und die erforderlichen Systemberechtigungen anfordern.",
   "settings.localToolsCuActionsTitle": "Einzelne Aktionen erlauben",

--- a/src/i18n/el/common.json
+++ b/src/i18n/el/common.json
@@ -987,6 +987,54 @@
     "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
     "description": "Help text under the Computer Use toggle."
   },
+  "settings.localToolsAndroidSkillsTitle": {
+    "message": "Δεξιότητες αυτοματοποίησης κινητού",
+    "description": "Επικεφαλίδα για την ενότητα μόνο για Android που εγκαθιστά δεξιότητες που οδηγούν εφαρμογές στο κινητό μέσω Χειρισμού Υπολογιστή."
+  },
+  "settings.localToolsAndroidSkillsHint": {
+    "message": "Εγκαταστήστε δεξιότητες που επιτρέπουν στον βοηθό να χειρίζεται τις εφαρμογές του κινητού. Λειτουργούν μέσω «Χειρισμού Υπολογιστή», παρακαλώ δώστε πρώτα άδεια προσβασιμότητας παραπάνω και ενεργοποιήστε τον χειρισμό υπολογιστή. Κάθε βήμα ακολουθεί τις ρυθμίσεις επιβεβαίωσης του χειρισμού υπολογιστή σας.",
+    "description": "Βοηθητικό κείμενο κάτω από την επικεφαλίδα δεξιοτήτων αυτοματοποίησης κινητού."
+  },
+  "settings.localToolsAndroidSkillsXhsName": {
+    "message": "Αυτόματη απάντηση μηνυμάτων Xiaohongshu",
+    "description": "Όνομα εμφάνισης της αυτόματης απάντησης άμεσων μηνυμάτων Xiaohongshu (RED)."
+  },
+  "settings.localToolsAndroidSkillsXhsDesc": {
+    "message": "Διαβάστε τα νέα μηνύματα στο App Xiaohongshu και συντάξτε απαντήσεις, θα σας ζητηθεί επιβεβαίωση πριν την αποστολή.",
+    "description": "Μονογραμμή περιγραφή της δεξιότητας DM του Xiaohongshu."
+  },
+  "settings.localToolsAndroidSkillsInstall": {
+    "message": "Εγκατάσταση",
+    "description": "Κουμπί που εγκαθιστά τη δεξιότητα στον λογαριασμό του χρήστη."
+  },
+  "settings.localToolsAndroidSkillsInstalled": {
+    "message": "Εγκατεστημένο",
+    "description": "Ετικέτα που εμφανίζεται όταν η δεξιότητα είναι ήδη εγκατεστημένη."
+  },
+  "settings.localToolsAndroidSkillsLoading": {
+    "message": "Φόρτωση διαθέσιμων δεξιοτήτων…",
+    "description": "Placeholder ενώ ανακτάται ο κατάλογος δεξιοτήτων."
+  },
+  "settings.localToolsAndroidSkillsUnavailable": {
+    "message": "Δεν υπάρχουν διαθέσιμες δεξιότητες κινητού προς εγκατάσταση.",
+    "description": "Κατάσταση κενής όταν δεν βρεθεί καμία εγκατάσιμη δεξιότητα κινητού."
+  },
+  "settings.localToolsAndroidSkillsNeedComputerUse": {
+    "message": "Πριν την εγκατάσταση, παρακαλώ δώστε άδεια προσβασιμότητας και ενεργοποιήστε τον χειρισμό υπολογιστή παραπάνω.",
+    "description": "Υπόδειξη που εμφανίζεται όταν το κουμπί εγκατάστασης είναι απενεργοποιημένο λόγω έλλειψης προϋποθέσεων."
+  },
+  "settings.localToolsAndroidSkillsNextTurn": {
+    "message": "Εγκατεστημένο, θα ισχύσει στην επόμενη συνομιλία σας.",
+    "description": "Επιβεβαίωση που εμφανίζεται μετά από μια επιτυχημένη εγκατάσταση."
+  },
+  "settings.localToolsAndroidSkillsInstallFailed": {
+    "message": "Η εγκατάσταση απέτυχε, παρακαλώ δοκιμάστε ξανά.",
+    "description": "Σφάλμα που εμφανίζεται όταν η αίτηση εγκατάστασης αποτυγχάνει."
+  },
+  "settings.localToolsAndroidSkillsLoadFailed": {
+    "message": "Αποτυχία φόρτωσης διαθέσιμων δεξιοτήτων, παρακαλώ δοκιμάστε ξανά.",
+    "description": "Σφάλμα που εμφανίζεται όταν η ανάκτηση του καταλόγου δεξιοτήτων αποτυγχάνει."
+  },
   "settings.localToolsPreauthorizeAll": "Προέγκριση όλων των ενεργειών υπολογιστή",
   "settings.localToolsPreauthorizeHint": "Επιτρέψτε με μία κίνηση στιγμιότυπο οθόνης, κλικ, πληκτρολόγηση, πλήκτρα και όλες τις ενέργειες και ζητήστε τα απαιτούμενα δικαιώματα συστήματος.",
   "settings.localToolsCuActionsTitle": "Άδεια μεμονωμένων ενεργειών",

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -967,6 +967,54 @@
     "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
     "description": "Help text under the Computer Use toggle."
   },
+  "settings.localToolsAndroidSkillsTitle": {
+    "message": "Phone automation skills",
+    "description": "Heading for the Android-only section that installs skills which drive apps on the phone via Computer Use."
+  },
+  "settings.localToolsAndroidSkillsHint": {
+    "message": "Install skills that let the assistant operate apps on this phone. They run through Computer Use, so enable the accessibility permission and Computer Use above first. Each action still follows your Computer Use confirmations.",
+    "description": "Help text under the phone-automation skills heading."
+  },
+  "settings.localToolsAndroidSkillsXhsName": {
+    "message": "Xiaohongshu DM auto-reply",
+    "description": "Display name of the Xiaohongshu (RED) direct-message auto-reply skill."
+  },
+  "settings.localToolsAndroidSkillsXhsDesc": {
+    "message": "Reads new private messages in the Xiaohongshu app and drafts replies. Asks you to confirm before sending.",
+    "description": "One-line description of the Xiaohongshu DM skill."
+  },
+  "settings.localToolsAndroidSkillsInstall": {
+    "message": "Install",
+    "description": "Button that installs the skill into the user's account."
+  },
+  "settings.localToolsAndroidSkillsInstalled": {
+    "message": "Installed",
+    "description": "Tag shown when the skill is already installed."
+  },
+  "settings.localToolsAndroidSkillsLoading": {
+    "message": "Loading available skills…",
+    "description": "Placeholder while the skill directory is being fetched."
+  },
+  "settings.localToolsAndroidSkillsUnavailable": {
+    "message": "No phone skills available yet.",
+    "description": "Empty state when no installable phone skill is found."
+  },
+  "settings.localToolsAndroidSkillsNeedComputerUse": {
+    "message": "Enable the accessibility permission and turn on Computer Use above before installing.",
+    "description": "Hint shown when the install button is disabled because prerequisites are missing."
+  },
+  "settings.localToolsAndroidSkillsNextTurn": {
+    "message": "Installed. It takes effect on your next chat.",
+    "description": "Confirmation shown after a successful install."
+  },
+  "settings.localToolsAndroidSkillsInstallFailed": {
+    "message": "Install failed. Please try again.",
+    "description": "Error shown when the install request fails."
+  },
+  "settings.localToolsAndroidSkillsLoadFailed": {
+    "message": "Couldn't load available skills. Please try again.",
+    "description": "Error shown when fetching the skill directory fails."
+  },
   "settings.localToolsPreauthorizeAll": "Pre-approve all computer actions",
   "settings.localToolsPreauthorizeHint": "Allow screenshot, click, type, key and every computer action at once, and trigger the required system permissions.",
   "settings.localToolsCuActionsTitle": "Allow individual actions",

--- a/src/i18n/es/common.json
+++ b/src/i18n/es/common.json
@@ -987,6 +987,54 @@
     "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
     "description": "Help text under the Computer Use toggle."
   },
+  "settings.localToolsAndroidSkillsTitle": {
+    "message": "Habilidades de automatización del teléfono",
+    "description": "Encabezado para la sección exclusiva de Android que instala habilidades que controlan aplicaciones en el teléfono a través del Control de computadora."
+  },
+  "settings.localToolsAndroidSkillsHint": {
+    "message": "Instala habilidades que permiten al asistente operar aplicaciones nativas. Se ejecutan a través de 'Control de computadora', primero otorga permisos de accesibilidad arriba y activa el control de computadora. Cada acción sigue la configuración de confirmación de control de computadora.",
+    "description": "Texto de ayuda bajo el encabezado de habilidades de automatización del teléfono."
+  },
+  "settings.localToolsAndroidSkillsXhsName": {
+    "message": "Respuesta automática de mensajes directos de Xiaohongshu",
+    "description": "Nombre mostrado de la habilidad de respuesta automática de mensajes directos de Xiaohongshu (RED)."
+  },
+  "settings.localToolsAndroidSkillsXhsDesc": {
+    "message": "Lee nuevos mensajes directos en la App de Xiaohongshu y redacta respuestas, te pedirá confirmación antes de enviar.",
+    "description": "Descripción breve de la habilidad de DM de Xiaohongshu."
+  },
+  "settings.localToolsAndroidSkillsInstall": {
+    "message": "Instalar",
+    "description": "Botón que instala la habilidad en la cuenta del usuario."
+  },
+  "settings.localToolsAndroidSkillsInstalled": {
+    "message": "Instalado",
+    "description": "Etiqueta mostrada cuando la habilidad ya está instalada."
+  },
+  "settings.localToolsAndroidSkillsLoading": {
+    "message": "Cargando habilidades disponibles...",
+    "description": "Marcador de posición mientras se obtiene el directorio de habilidades."
+  },
+  "settings.localToolsAndroidSkillsUnavailable": {
+    "message": "No hay habilidades de teléfono disponibles para instalar.",
+    "description": "Estado vacío cuando no se encuentra ninguna habilidad de teléfono instalable."
+  },
+  "settings.localToolsAndroidSkillsNeedComputerUse": {
+    "message": "Por favor otorga permisos de accesibilidad y activa el control de computadora arriba antes de instalar.",
+    "description": "Sugerencia mostrada cuando el botón de instalación está deshabilitado debido a requisitos previos faltantes."
+  },
+  "settings.localToolsAndroidSkillsNextTurn": {
+    "message": "Instalado, se aplicará en tu próxima conversación.",
+    "description": "Confirmación mostrada después de una instalación exitosa."
+  },
+  "settings.localToolsAndroidSkillsInstallFailed": {
+    "message": "Instalación fallida, por favor intenta de nuevo.",
+    "description": "Error mostrado cuando la solicitud de instalación falla."
+  },
+  "settings.localToolsAndroidSkillsLoadFailed": {
+    "message": "Error al cargar habilidades disponibles, por favor intenta de nuevo.",
+    "description": "Error mostrado cuando falla la obtención del directorio de habilidades."
+  },
   "settings.localToolsPreauthorizeAll": "Autorizar previamente todas las acciones del equipo",
   "settings.localToolsPreauthorizeHint": "Permite de una vez la captura de pantalla, el clic, la escritura, las teclas y todas las acciones, y solicita los permisos del sistema necesarios.",
   "settings.localToolsCuActionsTitle": "Permitir acciones individuales",

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -987,6 +987,54 @@
     "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
     "description": "Help text under the Computer Use toggle."
   },
+  "settings.localToolsAndroidSkillsTitle": {
+    "message": "Puhelinautomaatio taidot",
+    "description": "Otsikko Android-yksinomaiselle osastolle, joka asentaa taitoja, jotka ohjaavat sovelluksia puhelimessa tietokoneen käytön kautta."
+  },
+  "settings.localToolsAndroidSkillsHint": {
+    "message": "Asenna taitoja, jotka antavat avustajalle mahdollisuuden käyttää paikallisia sovelluksia. Ne toimivat 'tietokoneen käytön' kautta, joten myönnä ensin esteettömyyslupa ja aktivoi tietokoneen käyttö yllä. Jokainen toiminto noudattaa edelleen tietokoneen käytön vahvistusasetuksia.",
+    "description": "Ohjeteksti puhelinautomaatio taitojen otsikon alla."
+  },
+  "settings.localToolsAndroidSkillsXhsName": {
+    "message": "Xiaohongshu yksityisviestin automaattinen vastaus",
+    "description": "Näyttönimi Xiaohongshu (RED) suoran viestin automaattiselle vastaukselle."
+  },
+  "settings.localToolsAndroidSkillsXhsDesc": {
+    "message": "Lue Xiaohongshu-sovelluksesta uudet yksityisviestit ja luonnostele vastaus, ennen lähettämistä kysytään vahvistusta.",
+    "description": "Yhden rivin kuvaus Xiaohongshu DM -taidosta."
+  },
+  "settings.localToolsAndroidSkillsInstall": {
+    "message": "Asenna",
+    "description": "Nappi, joka asentaa taidon käyttäjän tiliin."
+  },
+  "settings.localToolsAndroidSkillsInstalled": {
+    "message": "Asennettu",
+    "description": "Tunniste, joka näytetään, kun taito on jo asennettu."
+  },
+  "settings.localToolsAndroidSkillsLoading": {
+    "message": "Ladataan saatavilla olevia taitoja…",
+    "description": "Paikkamerkki, kun taitohakemistoa haetaan."
+  },
+  "settings.localToolsAndroidSkillsUnavailable": {
+    "message": "Ei saatavilla asennettavia puhelintaitoja.",
+    "description": "Tyhjät tilat, kun asennettavia puhelintaitoja ei löydy."
+  },
+  "settings.localToolsAndroidSkillsNeedComputerUse": {
+    "message": "Asenna ensin myöntämällä esteettömyyslupa ja aktivoi tietokoneen käyttö yllä.",
+    "description": "Vihje, joka näytetään, kun asennusnappi on poistettu käytöstä, koska edellytyksiä puuttuu."
+  },
+  "settings.localToolsAndroidSkillsNextTurn": {
+    "message": "Asennettu, se tulee voimaan seuraavassa keskustelussasi.",
+    "description": "Vahvistus, joka näytetään onnistuneen asennuksen jälkeen."
+  },
+  "settings.localToolsAndroidSkillsInstallFailed": {
+    "message": "Asennus epäonnistui, yritä uudelleen.",
+    "description": "Virhe, joka näytetään, kun asennuspyyntö epäonnistuu."
+  },
+  "settings.localToolsAndroidSkillsLoadFailed": {
+    "message": "Saatavilla olevien taitojen lataaminen epäonnistui, yritä uudelleen.",
+    "description": "Virhe, joka näytetään, kun taitohakemiston hakeminen epäonnistuu."
+  },
   "settings.localToolsPreauthorizeAll": "Esihyväksy kaikki tietokoneen toiminnot",
   "settings.localToolsPreauthorizeHint": "Salli kerralla kuvakaappaus, napsautus, kirjoitus, näppäimet ja kaikki toiminnot ja pyydä tarvittavat järjestelmäoikeudet.",
   "settings.localToolsCuActionsTitle": "Salli toiminnot erikseen",

--- a/src/i18n/fr/common.json
+++ b/src/i18n/fr/common.json
@@ -987,6 +987,54 @@
     "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
     "description": "Help text under the Computer Use toggle."
   },
+  "settings.localToolsAndroidSkillsTitle": {
+    "message": "Compétences d'automatisation du téléphone",
+    "description": "Titre de la section réservée aux Android qui installe des compétences permettant de contrôler des applications sur le téléphone via le Contrôle d'ordinateur."
+  },
+  "settings.localToolsAndroidSkillsHint": {
+    "message": "Installez des compétences qui permettent à l'assistant d'opérer des applications locales. Elles fonctionnent via « Contrôle d'ordinateur », veuillez d'abord accorder les autorisations d'accessibilité ci-dessus et activer le contrôle d'ordinateur. Chaque action suit toujours vos paramètres de confirmation de contrôle d'ordinateur.",
+    "description": "Texte d'aide sous le titre des compétences d'automatisation du téléphone."
+  },
+  "settings.localToolsAndroidSkillsXhsName": {
+    "message": "Réponse automatique aux messages privés Xiaohongshu",
+    "description": "Nom affiché de la compétence de réponse automatique aux messages directs de Xiaohongshu (RED)."
+  },
+  "settings.localToolsAndroidSkillsXhsDesc": {
+    "message": "Lire les nouveaux messages privés dans l'application Xiaohongshu et rédiger des réponses, une confirmation vous sera demandée avant l'envoi.",
+    "description": "Description en une ligne de la compétence de DM de Xiaohongshu."
+  },
+  "settings.localToolsAndroidSkillsInstall": {
+    "message": "Installer",
+    "description": "Bouton qui installe la compétence dans le compte de l'utilisateur."
+  },
+  "settings.localToolsAndroidSkillsInstalled": {
+    "message": "Installé",
+    "description": "Étiquette affichée lorsque la compétence est déjà installée."
+  },
+  "settings.localToolsAndroidSkillsLoading": {
+    "message": "Chargement des compétences disponibles…",
+    "description": "Espace réservé pendant que le répertoire de compétences est en cours de récupération."
+  },
+  "settings.localToolsAndroidSkillsUnavailable": {
+    "message": "Aucune compétence de téléphone à installer pour le moment.",
+    "description": "État vide lorsque aucune compétence de téléphone installable n'est trouvée."
+  },
+  "settings.localToolsAndroidSkillsNeedComputerUse": {
+    "message": "Veuillez d'abord accorder les autorisations d'accessibilité et activer le contrôle d'ordinateur ci-dessus avant d'installer.",
+    "description": "Indication affichée lorsque le bouton d'installation est désactivé en raison de prérequis manquants."
+  },
+  "settings.localToolsAndroidSkillsNextTurn": {
+    "message": "Installé, cela prendra effet lors de votre prochaine conversation.",
+    "description": "Confirmation affichée après une installation réussie."
+  },
+  "settings.localToolsAndroidSkillsInstallFailed": {
+    "message": "Échec de l'installation, veuillez réessayer.",
+    "description": "Erreur affichée lorsque la demande d'installation échoue."
+  },
+  "settings.localToolsAndroidSkillsLoadFailed": {
+    "message": "Échec du chargement des compétences disponibles, veuillez réessayer.",
+    "description": "Erreur affichée lorsque la récupération du répertoire de compétences échoue."
+  },
   "settings.localToolsPreauthorizeAll": "Pré-autoriser toutes les actions de l'ordinateur",
   "settings.localToolsPreauthorizeHint": "Autorisez en une fois la capture d'écran, le clic, la saisie, les touches et toutes les actions, et déclenchez les autorisations système requises.",
   "settings.localToolsCuActionsTitle": "Autoriser chaque action",

--- a/src/i18n/it/common.json
+++ b/src/i18n/it/common.json
@@ -987,6 +987,54 @@
     "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
     "description": "Help text under the Computer Use toggle."
   },
+  "settings.localToolsAndroidSkillsTitle": {
+    "message": "Abilità di automazione del telefono",
+    "description": "Titolo per la sezione solo Android che installa abilità che controllano le app sul telefono tramite Controllo Computer."
+  },
+  "settings.localToolsAndroidSkillsHint": {
+    "message": "Installa le abilità che consentono all'assistente di controllare le app locali. Funzionano tramite \"Controllo computer\"; assicurati di concedere i permessi di accessibilità sopra e attivare il controllo computer. Ogni azione seguirà comunque le impostazioni di conferma del controllo computer.",
+    "description": "Testo di aiuto sotto il titolo delle abilità di automazione del telefono."
+  },
+  "settings.localToolsAndroidSkillsXhsName": {
+    "message": "Risposta automatica ai messaggi privati di Xiaohongshu",
+    "description": "Nome visualizzato dell'abilità di risposta automatica ai messaggi diretti di Xiaohongshu (RED)."
+  },
+  "settings.localToolsAndroidSkillsXhsDesc": {
+    "message": "Leggi i nuovi messaggi privati nell'app Xiaohongshu e redigi una risposta, ti verrà chiesto di confermare prima di inviare.",
+    "description": "Descrizione in una riga dell'abilità DM di Xiaohongshu."
+  },
+  "settings.localToolsAndroidSkillsInstall": {
+    "message": "Installa",
+    "description": "Pulsante che installa l'abilità nell'account dell'utente."
+  },
+  "settings.localToolsAndroidSkillsInstalled": {
+    "message": "Installato",
+    "description": "Etichetta mostrata quando l'abilità è già installata."
+  },
+  "settings.localToolsAndroidSkillsLoading": {
+    "message": "Caricamento delle abilità disponibili in corso…",
+    "description": "Segnaposto mentre la directory delle abilità viene recuperata."
+  },
+  "settings.localToolsAndroidSkillsUnavailable": {
+    "message": "Nessuna abilità telefonica installabile disponibile.",
+    "description": "Stato vuoto quando non viene trovata alcuna abilità telefonica installabile."
+  },
+  "settings.localToolsAndroidSkillsNeedComputerUse": {
+    "message": "Prima di installare, concedi i permessi di accessibilità e attiva il controllo computer sopra.",
+    "description": "Suggerimento mostrato quando il pulsante di installazione è disabilitato perché mancano i requisiti."
+  },
+  "settings.localToolsAndroidSkillsNextTurn": {
+    "message": "Installato, sarà attivo al tuo prossimo dialogo.",
+    "description": "Conferma mostrata dopo un'installazione riuscita."
+  },
+  "settings.localToolsAndroidSkillsInstallFailed": {
+    "message": "Installazione fallita, riprova.",
+    "description": "Errore mostrato quando la richiesta di installazione fallisce."
+  },
+  "settings.localToolsAndroidSkillsLoadFailed": {
+    "message": "Caricamento delle abilità disponibili fallito, riprova.",
+    "description": "Errore mostrato quando il recupero della directory delle abilità fallisce."
+  },
   "settings.localToolsPreauthorizeAll": "Pre-autorizza tutte le azioni del computer",
   "settings.localToolsPreauthorizeHint": "Consenti in una volta screenshot, clic, digitazione, tasti e tutte le azioni e richiedi le autorizzazioni di sistema necessarie.",
   "settings.localToolsCuActionsTitle": "Consenti singole azioni",

--- a/src/i18n/ja/common.json
+++ b/src/i18n/ja/common.json
@@ -987,6 +987,54 @@
     "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
     "description": "Help text under the Computer Use toggle."
   },
+  "settings.localToolsAndroidSkillsTitle": {
+    "message": "電話自動化スキル",
+    "description": "コンピュータ操作を介して電話のアプリを操作するスキルをインストールするAndroid専用セクションの見出し。"
+  },
+  "settings.localToolsAndroidSkillsHint": {
+    "message": "アシスタントがローカルアプリを操作するためのスキルをインストールします。これらは「コンピュータ操作」で実行されるため、上部でアクセシビリティ権限を付与し、コンピュータ操作を有効にしてください。各アクションは、あなたのコンピュータ操作確認設定に従います。",
+    "description": "電話自動化スキルの見出しの下にあるヘルプテキスト。"
+  },
+  "settings.localToolsAndroidSkillsXhsName": {
+    "message": "小紅書ダイレクトメッセージ自動返信",
+    "description": "小紅書（RED）のダイレクトメッセージ自動返信スキルの表示名。"
+  },
+  "settings.localToolsAndroidSkillsXhsDesc": {
+    "message": "小紅書アプリ内の新しいダイレクトメッセージを読み取り、返信を下書きします。送信前に確認を求めます。",
+    "description": "小紅書のDMスキルの一行説明。"
+  },
+  "settings.localToolsAndroidSkillsInstall": {
+    "message": "インストール",
+    "description": "ユーザーのアカウントにスキルをインストールするボタン。"
+  },
+  "settings.localToolsAndroidSkillsInstalled": {
+    "message": "インストール済み",
+    "description": "スキルがすでにインストールされているときに表示されるタグ。"
+  },
+  "settings.localToolsAndroidSkillsLoading": {
+    "message": "利用可能なスキルを読み込んでいます……",
+    "description": "スキルディレクトリが取得されている間のプレースホルダー。"
+  },
+  "settings.localToolsAndroidSkillsUnavailable": {
+    "message": "インストール可能な電話スキルはありません。",
+    "description": "インストール可能な電話スキルが見つからないときの空の状態。"
+  },
+  "settings.localToolsAndroidSkillsNeedComputerUse": {
+    "message": "インストールする前に、アクセシビリティ権限を付与し、上部でコンピュータ操作を有効にしてください。",
+    "description": "前提条件が不足しているためインストールボタンが無効になっているときに表示されるヒント。"
+  },
+  "settings.localToolsAndroidSkillsNextTurn": {
+    "message": "インストール済みです。次回の会話で有効になります。",
+    "description": "インストールが成功した後に表示される確認メッセージ。"
+  },
+  "settings.localToolsAndroidSkillsInstallFailed": {
+    "message": "インストールに失敗しました。再試行してください。",
+    "description": "インストールリクエストが失敗したときに表示されるエラー。"
+  },
+  "settings.localToolsAndroidSkillsLoadFailed": {
+    "message": "利用可能なスキルの読み込みに失敗しました。再試行してください。",
+    "description": "スキルディレクトリの取得に失敗したときに表示されるエラー。"
+  },
   "settings.localToolsPreauthorizeAll": "すべてのコンピュータ操作を事前に許可",
   "settings.localToolsPreauthorizeHint": "スクリーンショット、クリック、入力、キー操作などすべての操作を一度に許可し、必要なシステム権限を要求します。",
   "settings.localToolsCuActionsTitle": "操作を個別に許可",

--- a/src/i18n/ko/common.json
+++ b/src/i18n/ko/common.json
@@ -987,6 +987,54 @@
     "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
     "description": "Help text under the Computer Use toggle."
   },
+  "settings.localToolsAndroidSkillsTitle": {
+    "message": "전화 자동화 기술",
+    "description": "전화에서 앱을 조작하는 기술을 설치하는 Android 전용 섹션의 제목입니다."
+  },
+  "settings.localToolsAndroidSkillsHint": {
+    "message": "도우미가 본 기기 앱을 조작할 수 있는 기술을 설치하세요. 이들은 '컴퓨터 조작'을 통해 실행되며, 위에서 접근성 권한을 부여하고 컴퓨터 조작을 활성화해야 합니다. 모든 동작은 여전히 귀하의 컴퓨터 조작 확인 설정을 따릅니다.",
+    "description": "전화 자동화 기술 제목 아래의 도움말 텍스트입니다."
+  },
+  "settings.localToolsAndroidSkillsXhsName": {
+    "message": "샤오홍슈 개인 메시지 자동 응답",
+    "description": "샤오홍슈(RED) 직접 메시지 자동 응답 기술의 표시 이름입니다."
+  },
+  "settings.localToolsAndroidSkillsXhsDesc": {
+    "message": "샤오홍슈 앱에서 새로운 개인 메시지를 읽고 답장을 작성하며, 전송 전에 확인을 요청합니다.",
+    "description": "샤오홍슈 DM 기술에 대한 한 줄 설명입니다."
+  },
+  "settings.localToolsAndroidSkillsInstall": {
+    "message": "설치",
+    "description": "사용자의 계정에 기술을 설치하는 버튼입니다."
+  },
+  "settings.localToolsAndroidSkillsInstalled": {
+    "message": "설치됨",
+    "description": "기술이 이미 설치되어 있을 때 표시되는 태그입니다."
+  },
+  "settings.localToolsAndroidSkillsLoading": {
+    "message": "사용 가능한 기술을 로드하는 중……",
+    "description": "기술 디렉토리를 가져오는 동안의 자리 표시자입니다."
+  },
+  "settings.localToolsAndroidSkillsUnavailable": {
+    "message": "설치할 수 있는 전화 기술이 없습니다.",
+    "description": "설치 가능한 전화 기술이 발견되지 않았을 때의 빈 상태입니다."
+  },
+  "settings.localToolsAndroidSkillsNeedComputerUse": {
+    "message": "설치 전에 접근성 권한을 부여하고 위에서 컴퓨터 조작을 활성화하세요.",
+    "description": "필수 조건이 충족되지 않아 설치 버튼이 비활성화되었을 때 표시되는 힌트입니다."
+  },
+  "settings.localToolsAndroidSkillsNextTurn": {
+    "message": "설치됨, 다음 대화 시에 적용됩니다.",
+    "description": "설치가 성공적으로 완료된 후 표시되는 확인 메시지입니다."
+  },
+  "settings.localToolsAndroidSkillsInstallFailed": {
+    "message": "설치 실패, 다시 시도하세요.",
+    "description": "설치 요청이 실패했을 때 표시되는 오류입니다."
+  },
+  "settings.localToolsAndroidSkillsLoadFailed": {
+    "message": "사용 가능한 기술 로드 실패, 다시 시도하세요.",
+    "description": "기술 디렉토리 가져오기가 실패했을 때 표시되는 오류입니다."
+  },
   "settings.localToolsPreauthorizeAll": "모든 컴퓨터 작업 미리 허용",
   "settings.localToolsPreauthorizeHint": "스크린샷, 클릭, 입력, 키 등 모든 컴퓨터 작업을 한 번에 허용하고 필요한 시스템 권한을 요청합니다.",
   "settings.localToolsCuActionsTitle": "개별 작업 허용",

--- a/src/i18n/pl/common.json
+++ b/src/i18n/pl/common.json
@@ -987,6 +987,54 @@
     "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
     "description": "Help text under the Computer Use toggle."
   },
+  "settings.localToolsAndroidSkillsTitle": {
+    "message": "Umiejętności automatyzacji telefonu",
+    "description": "Nagłówek sekcji tylko dla Androida, która instaluje umiejętności sterujące aplikacjami na telefonie za pomocą operacji komputerowych."
+  },
+  "settings.localToolsAndroidSkillsHint": {
+    "message": "Zainstaluj umiejętności, które pozwalają asystentowi na obsługę lokalnych aplikacji. Działają one poprzez „komputerowe operacje”, proszę najpierw przyznać dostęp do funkcji ułatwień dostępu powyżej i włączyć komputerowe operacje. Każdy krok będzie nadal zgodny z ustawieniami potwierdzenia operacji komputerowych.",
+    "description": "Tekst pomocy pod nagłówkiem umiejętności automatyzacji telefonu."
+  },
+  "settings.localToolsAndroidSkillsXhsName": {
+    "message": "Automatyczna odpowiedź na wiadomości prywatne Xiaohongshu",
+    "description": "Nazwa wyświetlana umiejętności automatycznej odpowiedzi na wiadomości bezpośrednie Xiaohongshu (RED)."
+  },
+  "settings.localToolsAndroidSkillsXhsDesc": {
+    "message": "Odczytaj nowe wiadomości prywatne w aplikacji Xiaohongshu i napisz odpowiedź, przed wysłaniem poprosi cię o potwierdzenie.",
+    "description": "Jednolinijkowy opis umiejętności DM Xiaohongshu."
+  },
+  "settings.localToolsAndroidSkillsInstall": {
+    "message": "Zainstaluj",
+    "description": "Przycisk, który instaluje umiejętność na koncie użytkownika."
+  },
+  "settings.localToolsAndroidSkillsInstalled": {
+    "message": "Zainstalowane",
+    "description": "Etykieta wyświetlana, gdy umiejętność jest już zainstalowana."
+  },
+  "settings.localToolsAndroidSkillsLoading": {
+    "message": "Ładowanie dostępnych umiejętności…",
+    "description": "Zastępczy tekst podczas pobierania katalogu umiejętności."
+  },
+  "settings.localToolsAndroidSkillsUnavailable": {
+    "message": "Brak dostępnych umiejętności do zainstalowania.",
+    "description": "Stan pusty, gdy nie znaleziono żadnej umiejętności do zainstalowania."
+  },
+  "settings.localToolsAndroidSkillsNeedComputerUse": {
+    "message": "Przed instalacją proszę najpierw przyznać dostęp do funkcji ułatwień dostępu i włączyć komputerowe operacje powyżej.",
+    "description": "Wskazówka wyświetlana, gdy przycisk instalacji jest wyłączony z powodu brakujących wymagań wstępnych."
+  },
+  "settings.localToolsAndroidSkillsNextTurn": {
+    "message": "Zainstalowane, wejdzie w życie przy następnej rozmowie.",
+    "description": "Potwierdzenie wyświetlane po pomyślnej instalacji."
+  },
+  "settings.localToolsAndroidSkillsInstallFailed": {
+    "message": "Instalacja nie powiodła się, spróbuj ponownie.",
+    "description": "Błąd wyświetlany, gdy żądanie instalacji nie powiodło się."
+  },
+  "settings.localToolsAndroidSkillsLoadFailed": {
+    "message": "Nie udało się załadować dostępnych umiejętności, spróbuj ponownie.",
+    "description": "Błąd wyświetlany, gdy pobieranie katalogu umiejętności nie powiodło się."
+  },
   "settings.localToolsPreauthorizeAll": "Wstępnie zatwierdź wszystkie działania komputera",
   "settings.localToolsPreauthorizeHint": "Zezwól od razu na zrzut ekranu, kliknięcie, pisanie, klawisze i wszystkie działania oraz poproś o wymagane uprawnienia systemowe.",
   "settings.localToolsCuActionsTitle": "Zezwól na pojedyncze akcje",

--- a/src/i18n/pt/common.json
+++ b/src/i18n/pt/common.json
@@ -987,6 +987,54 @@
     "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
     "description": "Help text under the Computer Use toggle."
   },
+  "settings.localToolsAndroidSkillsTitle": {
+    "message": "Habilidades de Automação do Telefone",
+    "description": "Título para a seção exclusiva do Android que instala habilidades que controlam aplicativos no telefone via Operação do Computador."
+  },
+  "settings.localToolsAndroidSkillsHint": {
+    "message": "Instale habilidades que permitem ao assistente operar aplicativos nativos. Elas funcionam através da 'Operação do Computador', então, primeiro, conceda permissões de acessibilidade acima e ative a operação do computador. Cada ação ainda seguirá suas configurações de confirmação de operação do computador.",
+    "description": "Texto de ajuda sob o título de habilidades de automação do telefone."
+  },
+  "settings.localToolsAndroidSkillsXhsName": {
+    "message": "Resposta Automática de Mensagens Diretas do Xiaohongshu",
+    "description": "Nome exibido da habilidade de resposta automática de mensagens diretas do Xiaohongshu (RED)."
+  },
+  "settings.localToolsAndroidSkillsXhsDesc": {
+    "message": "Leia novas mensagens diretas no App Xiaohongshu e redija respostas, que serão confirmadas antes do envio.",
+    "description": "Descrição em uma linha da habilidade de DM do Xiaohongshu."
+  },
+  "settings.localToolsAndroidSkillsInstall": {
+    "message": "Instalar",
+    "description": "Botão que instala a habilidade na conta do usuário."
+  },
+  "settings.localToolsAndroidSkillsInstalled": {
+    "message": "Instalado",
+    "description": "Etiqueta exibida quando a habilidade já está instalada."
+  },
+  "settings.localToolsAndroidSkillsLoading": {
+    "message": "Carregando habilidades disponíveis...",
+    "description": "Placeholder enquanto o diretório de habilidades está sendo buscado."
+  },
+  "settings.localToolsAndroidSkillsUnavailable": {
+    "message": "Nenhuma habilidade de telefone disponível para instalação.",
+    "description": "Estado vazio quando nenhuma habilidade de telefone instalável é encontrada."
+  },
+  "settings.localToolsAndroidSkillsNeedComputerUse": {
+    "message": "Antes de instalar, conceda permissões de acessibilidade e ative a operação do computador acima.",
+    "description": "Dica exibida quando o botão de instalação está desativado devido à falta de pré-requisitos."
+  },
+  "settings.localToolsAndroidSkillsNextTurn": {
+    "message": "Instalado, estará ativo na sua próxima conversa.",
+    "description": "Confirmação exibida após uma instalação bem-sucedida."
+  },
+  "settings.localToolsAndroidSkillsInstallFailed": {
+    "message": "Instalação falhou, por favor, tente novamente.",
+    "description": "Erro exibido quando a solicitação de instalação falha."
+  },
+  "settings.localToolsAndroidSkillsLoadFailed": {
+    "message": "Falha ao carregar habilidades disponíveis, por favor, tente novamente.",
+    "description": "Erro exibido quando a busca pelo diretório de habilidades falha."
+  },
   "settings.localToolsPreauthorizeAll": "Pré-aprovar todas as ações do computador",
   "settings.localToolsPreauthorizeHint": "Permite de uma vez captura de tela, clique, digitação, teclas e todas as ações, e solicita as permissões do sistema necessárias.",
   "settings.localToolsCuActionsTitle": "Permitir ações individuais",

--- a/src/i18n/ru/common.json
+++ b/src/i18n/ru/common.json
@@ -987,6 +987,54 @@
     "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
     "description": "Help text under the Computer Use toggle."
   },
+  "settings.localToolsAndroidSkillsTitle": {
+    "message": "Навыки автоматизации телефона",
+    "description": "Заголовок для раздела только для Android, который устанавливает навыки, управляющие приложениями на телефоне через управление компьютером."
+  },
+  "settings.localToolsAndroidSkillsHint": {
+    "message": "Установите навыки, которые позволяют помощнику управлять локальными приложениями. Они работают через «Управление компьютером», пожалуйста, сначала предоставьте разрешение на доступ и включите управление компьютером выше. Каждое действие будет следовать вашим настройкам подтверждения управления компьютером.",
+    "description": "Текст помощи под заголовком навыков автоматизации телефона."
+  },
+  "settings.localToolsAndroidSkillsXhsName": {
+    "message": "Автоответчик личных сообщений Xiaohongshu",
+    "description": "Отображаемое имя навыка автоответчика личных сообщений Xiaohongshu (RED)."
+  },
+  "settings.localToolsAndroidSkillsXhsDesc": {
+    "message": "Читать новые личные сообщения в приложении Xiaohongshu и составлять ответы, перед отправкой вас попросят подтвердить.",
+    "description": "Однострочное описание навыка DM Xiaohongshu."
+  },
+  "settings.localToolsAndroidSkillsInstall": {
+    "message": "Установить",
+    "description": "Кнопка, которая устанавливает навык в учетную запись пользователя."
+  },
+  "settings.localToolsAndroidSkillsInstalled": {
+    "message": "Установлено",
+    "description": "Метка, отображаемая, когда навык уже установлен."
+  },
+  "settings.localToolsAndroidSkillsLoading": {
+    "message": "Загрузка доступных навыков…",
+    "description": "Заполнитель, пока каталог навыков загружается."
+  },
+  "settings.localToolsAndroidSkillsUnavailable": {
+    "message": "Нет доступных для установки мобильных навыков.",
+    "description": "Пустое состояние, когда не найдено навыков для установки."
+  },
+  "settings.localToolsAndroidSkillsNeedComputerUse": {
+    "message": "Пожалуйста, сначала предоставьте разрешение на доступ и включите управление компьютером выше перед установкой.",
+    "description": "Подсказка, отображаемая, когда кнопка установки отключена из-за отсутствия предварительных условий."
+  },
+  "settings.localToolsAndroidSkillsNextTurn": {
+    "message": "Установлено, вступит в силу при вашем следующем разговоре.",
+    "description": "Подтверждение, отображаемое после успешной установки."
+  },
+  "settings.localToolsAndroidSkillsInstallFailed": {
+    "message": "Ошибка установки, пожалуйста, попробуйте еще раз.",
+    "description": "Ошибка, отображаемая, когда запрос на установку не удался."
+  },
+  "settings.localToolsAndroidSkillsLoadFailed": {
+    "message": "Ошибка загрузки доступных навыков, пожалуйста, попробуйте еще раз.",
+    "description": "Ошибка, отображаемая, когда не удалось получить каталог навыков."
+  },
   "settings.localToolsPreauthorizeAll": "Заранее разрешить все действия с компьютером",
   "settings.localToolsPreauthorizeHint": "Разрешите сразу снимок экрана, клик, ввод, клавиши и все действия и запросите необходимые системные разрешения.",
   "settings.localToolsCuActionsTitle": "Разрешить отдельные действия",

--- a/src/i18n/sr/common.json
+++ b/src/i18n/sr/common.json
@@ -987,6 +987,54 @@
     "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
     "description": "Help text under the Computer Use toggle."
   },
+  "settings.localToolsAndroidSkillsTitle": {
+    "message": "Veštine automatizacije telefona",
+    "description": "Naslov za sekciju isključivo za Android koja instalira veštine koje upravljaju aplikacijama na telefonu putem računarskog upravljanja."
+  },
+  "settings.localToolsAndroidSkillsHint": {
+    "message": "Instalirajte veštine koje omogućavaju asistentu da upravlja lokalnim aplikacijama. One se pokreću putem „računarskog upravljanja“, prvo dodelite dozvole za pristup u gornjem delu i omogućite računarsko upravljanje. Svaki korak će i dalje pratiti vaša podešavanja za potvrdu računarskog upravljanja.",
+    "description": "Pomoćni tekst ispod naslova za veštine automatizacije telefona."
+  },
+  "settings.localToolsAndroidSkillsXhsName": {
+    "message": "Automatski odgovor na poruke u Xiaohongshu",
+    "description": "Prikazno ime veštine automatskog odgovaranja na direktne poruke u Xiaohongshu (RED)."
+  },
+  "settings.localToolsAndroidSkillsXhsDesc": {
+    "message": "Čita nove poruke u aplikaciji Xiaohongshu i priprema odgovore, pre slanja će vas prvo pitati za potvrdu.",
+    "description": "Jednolinijski opis veštine automatskog odgovaranja za DM u Xiaohongshu."
+  },
+  "settings.localToolsAndroidSkillsInstall": {
+    "message": "Instaliraj",
+    "description": "Dugme koje instalira veštinu u korisnički nalog."
+  },
+  "settings.localToolsAndroidSkillsInstalled": {
+    "message": "Instalirano",
+    "description": "Oznaka koja se prikazuje kada je veština već instalirana."
+  },
+  "settings.localToolsAndroidSkillsLoading": {
+    "message": "Učitavanje dostupnih veština…",
+    "description": "Placeholder dok se preuzima direktorijum veština."
+  },
+  "settings.localToolsAndroidSkillsUnavailable": {
+    "message": "Nema dostupnih veština za instalaciju.",
+    "description": "Prazno stanje kada nije pronađena nijedna veština za instalaciju."
+  },
+  "settings.localToolsAndroidSkillsNeedComputerUse": {
+    "message": "Pre instalacije, prvo dodelite dozvole za pristup i omogućite računarsko upravljanje u gornjem delu.",
+    "description": "Saveta koji se prikazuje kada je dugme za instalaciju onemogućeno zbog nedostajućih preduslova."
+  },
+  "settings.localToolsAndroidSkillsNextTurn": {
+    "message": "Instalirano, biće aktivno pri vašem sledećem razgovoru.",
+    "description": "Potvrda koja se prikazuje nakon uspešne instalacije."
+  },
+  "settings.localToolsAndroidSkillsInstallFailed": {
+    "message": "Instalacija nije uspela, molimo pokušajte ponovo.",
+    "description": "Greška koja se prikazuje kada zahtev za instalaciju ne uspe."
+  },
+  "settings.localToolsAndroidSkillsLoadFailed": {
+    "message": "Učitavanje dostupnih veština nije uspelo, molimo pokušajte ponovo.",
+    "description": "Greška koja se prikazuje kada preuzimanje direktorijuma veština ne uspe."
+  },
   "settings.localToolsPreauthorizeAll": "Унапред дозволи све радње рачунара",
   "settings.localToolsPreauthorizeHint": "Дозволите одједном снимак екрана, клик, куцање, тастере и све радње и затражите потребне системске дозволе.",
   "settings.localToolsCuActionsTitle": "Дозволи појединачне радње",

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -987,6 +987,54 @@
     "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
     "description": "Help text under the Computer Use toggle."
   },
+  "settings.localToolsAndroidSkillsTitle": {
+    "message": "Telefonautomationsfärdigheter",
+    "description": "Rubrik för Android-endast sektionen som installerar färdigheter som styr appar på telefonen via datoranvändning."
+  },
+  "settings.localToolsAndroidSkillsHint": {
+    "message": "Installera färdigheter som gör att assistenten kan styra inhemska appar. De körs via \"datoranvändning\", vänligen ge tillgång till tillgänglighetsbehörigheter ovan och aktivera datoranvändning. Varje åtgärd följer fortfarande dina inställningar för bekräftelse av datoranvändning.",
+    "description": "Hjälptext under rubriken för telefonautomationsfärdigheter."
+  },
+  "settings.localToolsAndroidSkillsXhsName": {
+    "message": "Xiaohongshu meddelande automatisk svar",
+    "description": "Visningsnamn för Xiaohongshu (RED) direktmeddelande automatisk svar färdigheten."
+  },
+  "settings.localToolsAndroidSkillsXhsDesc": {
+    "message": "Läsa nya meddelanden i Xiaohongshu-appen och utarbeta svar, du kommer att bekräfta innan det skickas.",
+    "description": "En rad beskrivning av Xiaohongshu DM-färdigheten."
+  },
+  "settings.localToolsAndroidSkillsInstall": {
+    "message": "Installera",
+    "description": "Knapp som installerar färdigheten i användarens konto."
+  },
+  "settings.localToolsAndroidSkillsInstalled": {
+    "message": "Installerad",
+    "description": "Tagg som visas när färdigheten redan är installerad."
+  },
+  "settings.localToolsAndroidSkillsLoading": {
+    "message": "Laddar tillgängliga färdigheter…",
+    "description": "Platshållare medan färdighetskatalogen hämtas."
+  },
+  "settings.localToolsAndroidSkillsUnavailable": {
+    "message": "Inga telefonfärdigheter tillgängliga för installation.",
+    "description": "Tomt tillstånd när ingen installabel telefonfärdighet hittas."
+  },
+  "settings.localToolsAndroidSkillsNeedComputerUse": {
+    "message": "Vänligen ge tillgång till tillgänglighetsbehörigheter och aktivera datoranvändning ovan innan installation.",
+    "description": "Hint som visas när installationsknappen är inaktiverad på grund av saknade förutsättningar."
+  },
+  "settings.localToolsAndroidSkillsNextTurn": {
+    "message": "Installerad, kommer att träda i kraft vid ditt nästa samtal.",
+    "description": "Bekräftelse som visas efter en lyckad installation."
+  },
+  "settings.localToolsAndroidSkillsInstallFailed": {
+    "message": "Installationen misslyckades, vänligen försök igen.",
+    "description": "Felmeddelande som visas när installationsförfrågan misslyckas."
+  },
+  "settings.localToolsAndroidSkillsLoadFailed": {
+    "message": "Misslyckades med att ladda tillgängliga färdigheter, vänligen försök igen.",
+    "description": "Felmeddelande som visas när hämtningen av färdighetskatalogen misslyckas."
+  },
   "settings.localToolsPreauthorizeAll": "Förgodkänn alla datoråtgärder",
   "settings.localToolsPreauthorizeHint": "Tillåt på en gång skärmbild, klick, skrivning, tangenter och alla åtgärder och begär nödvändiga systembehörigheter.",
   "settings.localToolsCuActionsTitle": "Tillåt enskilda åtgärder",

--- a/src/i18n/uk/common.json
+++ b/src/i18n/uk/common.json
@@ -987,6 +987,54 @@
     "message": "Let the AI see your screen and control the mouse and keyboard on this computer. Off by default — turn it on only when you need it. On macOS, grant Screen Recording and Accessibility permissions below. Each action still asks for your confirmation.",
     "description": "Help text under the Computer Use toggle."
   },
+  "settings.localToolsAndroidSkillsTitle": {
+    "message": "Навички автоматизації телефону",
+    "description": "Заголовок для розділу, що стосується лише Android, який встановлює навички, що керують додатками на телефоні через Керування комп'ютером."
+  },
+  "settings.localToolsAndroidSkillsHint": {
+    "message": "Встановіть навички, які дозволяють асистенту керувати додатками на пристрої. Вони працюють через «Керування комп'ютером», спочатку надайте доступ до функцій допомоги та увімкніть керування комп'ютером. Кожен крок дій все ще дотримується ваших налаштувань підтвердження керування комп'ютером.",
+    "description": "Допоміжний текст під заголовком навичок автоматизації телефону."
+  },
+  "settings.localToolsAndroidSkillsXhsName": {
+    "message": "Автоматична відповідь на особисті повідомлення Xiaohongshu",
+    "description": "Відображувана назва навички автоматичної відповіді на особисті повідомлення Xiaohongshu (RED)."
+  },
+  "settings.localToolsAndroidSkillsXhsDesc": {
+    "message": "Читати нові особисті повідомлення в додатку Xiaohongshu та складати відповіді, перед відправленням буде запит на підтвердження.",
+    "description": "Однорядний опис навички DM Xiaohongshu."
+  },
+  "settings.localToolsAndroidSkillsInstall": {
+    "message": "Встановити",
+    "description": "Кнопка, яка встановлює навичку в обліковий запис користувача."
+  },
+  "settings.localToolsAndroidSkillsInstalled": {
+    "message": "Встановлено",
+    "description": "Мітка, що відображається, коли навичка вже встановлена."
+  },
+  "settings.localToolsAndroidSkillsLoading": {
+    "message": "Завантаження доступних навичок…",
+    "description": "Заповнювач під час отримання каталогу навичок."
+  },
+  "settings.localToolsAndroidSkillsUnavailable": {
+    "message": "Немає доступних навичок для встановлення.",
+    "description": "Порожній стан, коли не знайдено навичок для встановлення."
+  },
+  "settings.localToolsAndroidSkillsNeedComputerUse": {
+    "message": "Перед встановленням надайте доступ до функцій допомоги та увімкніть керування комп'ютером вище.",
+    "description": "Підказка, що відображається, коли кнопка встановлення вимкнена через відсутність попередніх умов."
+  },
+  "settings.localToolsAndroidSkillsNextTurn": {
+    "message": "Встановлено, буде активовано під час вашої наступної розмови.",
+    "description": "Підтвердження, що відображається після успішного встановлення."
+  },
+  "settings.localToolsAndroidSkillsInstallFailed": {
+    "message": "Встановлення не вдалося, будь ласка, спробуйте ще раз.",
+    "description": "Помилка, що відображається, коли запит на встановлення не вдається."
+  },
+  "settings.localToolsAndroidSkillsLoadFailed": {
+    "message": "Не вдалося завантажити доступні навички, будь ласка, спробуйте ще раз.",
+    "description": "Помилка, що відображається, коли не вдається отримати каталог навичок."
+  },
   "settings.localToolsPreauthorizeAll": "Попередньо дозволити всі дії з комп'ютером",
   "settings.localToolsPreauthorizeHint": "Дозволити одразу знімок екрана, клік, введення, клавіші та всі дії й запросити потрібні системні дозволи.",
   "settings.localToolsCuActionsTitle": "Дозволити окремі дії",

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -987,6 +987,54 @@
     "message": "让 AI 看到你的屏幕并控制本机的鼠标和键盘。默认关闭，按需开启。macOS 上需在下方授予「屏幕录制」和「辅助功能」权限。每个操作仍会请求你的确认。",
     "description": "Help text under the Computer Use toggle."
   },
+  "settings.localToolsAndroidSkillsTitle": {
+    "message": "手机自动化技能",
+    "description": "Heading for the Android-only section that installs skills which drive apps on the phone via Computer Use."
+  },
+  "settings.localToolsAndroidSkillsHint": {
+    "message": "安装能让助手操作本机 App 的技能。它们通过「电脑操作」运行，请先在上方授予无障碍权限并开启电脑操作。每步动作仍遵循你的电脑操作确认设置。",
+    "description": "Help text under the phone-automation skills heading."
+  },
+  "settings.localToolsAndroidSkillsXhsName": {
+    "message": "小红书私信自动回复",
+    "description": "Display name of the Xiaohongshu (RED) direct-message auto-reply skill."
+  },
+  "settings.localToolsAndroidSkillsXhsDesc": {
+    "message": "读取小红书 App 里的新私信并起草回复，发送前会先请你确认。",
+    "description": "One-line description of the Xiaohongshu DM skill."
+  },
+  "settings.localToolsAndroidSkillsInstall": {
+    "message": "安装",
+    "description": "Button that installs the skill into the user's account."
+  },
+  "settings.localToolsAndroidSkillsInstalled": {
+    "message": "已安装",
+    "description": "Tag shown when the skill is already installed."
+  },
+  "settings.localToolsAndroidSkillsLoading": {
+    "message": "正在加载可用技能……",
+    "description": "Placeholder while the skill directory is being fetched."
+  },
+  "settings.localToolsAndroidSkillsUnavailable": {
+    "message": "暂无可安装的手机技能。",
+    "description": "Empty state when no installable phone skill is found."
+  },
+  "settings.localToolsAndroidSkillsNeedComputerUse": {
+    "message": "安装前请先授予无障碍权限并在上方开启电脑操作。",
+    "description": "Hint shown when the install button is disabled because prerequisites are missing."
+  },
+  "settings.localToolsAndroidSkillsNextTurn": {
+    "message": "已安装，将在你下次对话时生效。",
+    "description": "Confirmation shown after a successful install."
+  },
+  "settings.localToolsAndroidSkillsInstallFailed": {
+    "message": "安装失败，请重试。",
+    "description": "Error shown when the install request fails."
+  },
+  "settings.localToolsAndroidSkillsLoadFailed": {
+    "message": "加载可用技能失败，请重试。",
+    "description": "Error shown when fetching the skill directory fails."
+  },
   "settings.localToolsPreauthorizeAll": "预先允许所有电脑操作",
   "settings.localToolsPreauthorizeHint": "一次性允许截图、点击、输入、按键等所有电脑操作，并触发所需的系统权限。",
   "settings.localToolsCuActionsTitle": "逐项允许操作",

--- a/src/i18n/zh-TW/common.json
+++ b/src/i18n/zh-TW/common.json
@@ -987,6 +987,54 @@
     "message": "讓 AI 看到你的螢幕並控制本機的滑鼠和鍵盤。預設關閉，按需開啟。macOS 上需在下方授予「螢幕錄製」和「輔助使用」權限。每個操作仍會請求你的確認。",
     "description": "Help text under the Computer Use toggle."
   },
+  "settings.localToolsAndroidSkillsTitle": {
+    "message": "手機自動化技能",
+    "description": "安裝通過電腦操作驅動手機應用的技能的 Android 專用部分的標題。"
+  },
+  "settings.localToolsAndroidSkillsHint": {
+    "message": "安裝能讓助手操作本機 App 的技能。它們透過「電腦操作」運行，請先在上方授予無障礙權限並開啟電腦操作。每步動作仍遵循你的電腦操作確認設定。",
+    "description": "在手機自動化技能標題下的幫助文字。"
+  },
+  "settings.localToolsAndroidSkillsXhsName": {
+    "message": "小紅書私信自動回覆",
+    "description": "小紅書（RED）私信自動回覆技能的顯示名稱。"
+  },
+  "settings.localToolsAndroidSkillsXhsDesc": {
+    "message": "讀取小紅書 App 裡的新私信並起草回覆，發送前會先請你確認。",
+    "description": "小紅書私信技能的一行描述。"
+  },
+  "settings.localToolsAndroidSkillsInstall": {
+    "message": "安裝",
+    "description": "安裝技能到用戶帳戶的按鈕。"
+  },
+  "settings.localToolsAndroidSkillsInstalled": {
+    "message": "已安裝",
+    "description": "當技能已經安裝時顯示的標籤。"
+  },
+  "settings.localToolsAndroidSkillsLoading": {
+    "message": "正在加載可用技能……",
+    "description": "在獲取技能目錄時的佔位符。"
+  },
+  "settings.localToolsAndroidSkillsUnavailable": {
+    "message": "暫無可安裝的手機技能。",
+    "description": "當未找到可安裝的手機技能時的空狀態。"
+  },
+  "settings.localToolsAndroidSkillsNeedComputerUse": {
+    "message": "安裝前請先授予無障礙權限並在上方開啟電腦操作。",
+    "description": "當安裝按鈕因缺少前置條件而被禁用時顯示的提示。"
+  },
+  "settings.localToolsAndroidSkillsNextTurn": {
+    "message": "已安裝，將在你下次對話時生效。",
+    "description": "成功安裝後顯示的確認信息。"
+  },
+  "settings.localToolsAndroidSkillsInstallFailed": {
+    "message": "安裝失敗，請重試。",
+    "description": "當安裝請求失敗時顯示的錯誤信息。"
+  },
+  "settings.localToolsAndroidSkillsLoadFailed": {
+    "message": "加載可用技能失敗，請重試。",
+    "description": "當獲取技能目錄失敗時顯示的錯誤信息。"
+  },
   "settings.localToolsPreauthorizeAll": "預先允許所有電腦操作",
   "settings.localToolsPreauthorizeHint": "一次性允許截圖、點擊、輸入、按鍵等所有電腦操作，並觸發所需的系統權限。",
   "settings.localToolsCuActionsTitle": "逐項允許操作",


### PR DESCRIPTION
## What

Adds an **Android-only "Phone automation skills"** section to Nexior's Local Tools settings (`LocalTools.vue`) that lets a user install the curated **`xhs-dm`** skill (小红书私信自动回复) into their account with one tap.

## Why

Phone-automation skills like `xhs-dm` only work on the Android build via Computer Use (accessibility). Skills — like connectors — must be **installed** before the aichat2 worker surfaces them: `/internal/v1/skills/active` returns only a user's own uploaded / installed / global `UserSkill` rows, not the public `Skill` catalog. Previously the only install path was the external `auth.acedata.cloud/user/skills` page. This surfaces the install right where its prerequisite (Computer Use) is configured, and only on Android where the skill can actually run.

## How

- New `<section v-if="android">` placed under the Computer Use section (the funnel: enable accessibility → turn on Computer Use → install skill).
- `fetchXhsSkill()` → `GET {getBaseUrlAuth()}/api/v1/skills/?q=xhs-dm` (finds the `…/xhs-dm` row, reads its `installed` flag).
- `installXhs()` → `POST {getBaseUrlAuth()}/api/v1/skills/{id}/install/` (201 → installed; 409 already-installed → treated as installed).
- Reuses the `httpClient` + `getBaseUrlAuth()` baseURL-override pattern from `connectorCatalogCache.ts` (auto-injects the AuthBackend Bearer token / fingerprint / locale).
- Install button gated on `a11yEnabled && computerUse`; the skill takes effect on the **next chat turn** (the worker reads `/internal/v1/skills/active` per turn).
- i18n: `zh-CN` + `en` only, per project convention.

## Testing

- `npm run lint` → 0 errors
- `npx vue-tsc --noEmit` → 0 errors
- `npx vitest run src/components/setting/LocalTools.i18n.test.ts` → 36 passed (new keys compile in every locale)
- Full device E2E (build APK → install on Android → tap install → run the skill) in progress.

## 🤖 对抗评审

Reviewer: Explore subagent (read-only), 1 round.

- **RISK — `fetchXhsSkill()` swallowed fetch errors** (it only set `xhsSkill=null` + `console.warn`, so a network/API failure looked identical to "no skills available"). **Fixed**: the catch now sets `xhsError` via a new `localToolsAndroidSkillsLoadFailed` string, and the "unavailable" empty-state is suppressed while an error is shown.
- **NIT — type assertion vs `instanceof AxiosError`** in `installXhs()`'s catch. **Rebutted**: optional-chaining on the asserted `{ response?: { status?: number } }` shape is safe and matches house style — `connectorCatalogCache.ts` doesn't import `AxiosError` either.

Verdict after fix: **CLEAN**.
