### PR TITLE
feat(maestro): align config UI with refactored scenario set + add style

### DIFF
--- a/change/@acedatacloud-nexior-5b4c4afe-38a0-4a11-94c8-0d92ec46fc81.json
+++ b/change/@acedatacloud-nexior-5b4c4afe-38a0-4a11-94c8-0d92ec46fc81.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(maestro): align video config UI with refactored scenario set (auto/narrated/drama/avatar/motion/slideshow) + add style control",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/maestro/ConfigPanel.vue
+++ b/src/components/maestro/ConfigPanel.vue
@@ -120,6 +120,24 @@
           />
         </el-select>
       </div>
+
+      <!-- Style (visual direction) -->
+      <div class="field-row">
+        <div class="field-head">
+          <h2 class="field-title font-bold">{{ $t('maestro.name.style') }}</h2>
+          <info-icon :content="$t('maestro.description.style')" class="ml-1" />
+        </div>
+        <el-select
+          v-model="style"
+          class="field-control"
+          filterable
+          allow-create
+          default-first-option
+          :placeholder="$t('maestro.placeholder.select')"
+        >
+          <el-option v-for="s in MAESTRO_ALLOWED_STYLES" :key="s" :label="$t(`maestro.option.style.${s}`)" :value="s" />
+        </el-select>
+      </div>
     </div>
 
     <div class="flex flex-col items-center justify-center px-5 pb-5">
@@ -153,7 +171,9 @@ import {
   MAESTRO_ALLOWED_QUALITIES,
   MAESTRO_DEFAULT_QUALITY,
   MAESTRO_ALLOWED_SCENARIOS,
-  MAESTRO_DEFAULT_SCENARIO
+  MAESTRO_DEFAULT_SCENARIO,
+  MAESTRO_ALLOWED_STYLES,
+  MAESTRO_DEFAULT_STYLE
 } from '@/constants';
 import { IMaestroConfig } from '@/models';
 
@@ -185,7 +205,8 @@ export default defineComponent({
       MAESTRO_MIN_DURATION,
       MAESTRO_MAX_DURATION,
       MAESTRO_ALLOWED_QUALITIES,
-      MAESTRO_ALLOWED_SCENARIOS
+      MAESTRO_ALLOWED_SCENARIOS,
+      MAESTRO_ALLOWED_STYLES
     };
   },
   computed: {
@@ -265,6 +286,14 @@ export default defineComponent({
       set(val: string) {
         this.update({ scenario: val });
       }
+    },
+    style: {
+      get(): string | undefined {
+        return this.config?.style;
+      },
+      set(val: string) {
+        this.update({ style: val || MAESTRO_DEFAULT_STYLE });
+      }
     }
   },
   mounted() {
@@ -274,7 +303,8 @@ export default defineComponent({
       aspect: this.config?.aspect ?? MAESTRO_DEFAULT_ASPECT,
       duration: this.config?.duration ?? MAESTRO_DEFAULT_DURATION,
       quality: this.config?.quality ?? MAESTRO_DEFAULT_QUALITY,
-      scenario: this.config?.scenario ?? MAESTRO_DEFAULT_SCENARIO
+      scenario: this.config?.scenario ?? MAESTRO_DEFAULT_SCENARIO,
+      style: this.config?.style ?? MAESTRO_DEFAULT_STYLE
     });
   },
   methods: {

--- a/src/constants/maestro.ts
+++ b/src/constants/maestro.ts
@@ -14,19 +14,12 @@ export const MAESTRO_MIN_DURATION = 1;
 export const MAESTRO_MAX_DURATION = 600;
 // Production tier (effort/price): draft = fast preview, standard = balanced, premium = richer.
 export const MAESTRO_ALLOWED_QUALITIES = ['draft', 'standard', 'premium'];
-// Video type: auto lets the director pick; the rest pin a production style.
-export const MAESTRO_ALLOWED_SCENARIOS = [
-  'auto',
-  'drama',
-  'general',
-  'explainer',
-  'product',
-  'website',
-  'slides',
-  'motion',
-  'changelog',
-  'captions'
-];
+// Video type: a routing hint. `auto` lets the director pick; the rest bias the route.
+// Legacy values (general/explainer/product/website/changelog/captions -> auto, slides -> slideshow)
+// are still accepted by the API but no longer offered here.
+export const MAESTRO_ALLOWED_SCENARIOS = ['auto', 'narrated', 'drama', 'avatar', 'motion', 'slideshow'];
+// Visual style hint (freeform on the API; these are quick presets). Orthogonal to scenario routing.
+export const MAESTRO_ALLOWED_STYLES = ['auto', 'cinematic', 'minimal', 'neon', 'corporate', 'hand-drawn'];
 
 // Accepted reference media for file_urls (images / video / audio).
 export const MAESTRO_FILE_ACCEPT = '.png,.jpg,.jpeg,.gif,.bmp,.webp,.mp4,.mov,.webm,.mp3,.wav,.m4a';
@@ -38,3 +31,4 @@ export const MAESTRO_DEFAULT_ASPECT = '9:16';
 export const MAESTRO_DEFAULT_DURATION = 30;
 export const MAESTRO_DEFAULT_QUALITY = 'standard';
 export const MAESTRO_DEFAULT_SCENARIO = 'auto';
+export const MAESTRO_DEFAULT_STYLE = 'auto';

--- a/src/i18n/ar/maestro.json
+++ b/src/i18n/ar/maestro.json
@@ -187,6 +187,70 @@
     "message": "لا توجد فيديوهات بعد — قم بإنشاء أول فيديو لك على اليسار.",
     "description": "لا توجد مهام"
   },
+  "name.scenario": {
+    "message": "نوع الفيديو",
+    "description": "Video type field"
+  },
+  "description.scenario": {
+    "message": "اختر نوع الفيديو المراد إنشاؤه. «تلقائي» يترك القرار لـ Maestro؛ أو حدّد نمطًا مثل دراما قصيرة أو لقطات واقعية أو شرح أو ترويج منتج.",
+    "description": "Scenario field help"
+  },
+  "option.scenario.auto": {
+    "message": "تلقائي · دع Maestro يقرر",
+    "description": "Auto scenario option"
+  },
+  "option.scenario.narrated": {
+    "message": "فيديو مصور مع تعليق",
+    "description": "خيار فيديو متعدد المشاهد مع تعليق"
+  },
+  "option.scenario.drama": {
+    "message": "دراما قصيرة",
+    "description": "Short drama scenario option"
+  },
+  "option.scenario.avatar": {
+    "message": "شخصية رقمية · حديث مباشر",
+    "description": "خيار سيناريو شخصية / حديث مباشر"
+  },
+  "option.scenario.motion": {
+    "message": "رسوم متحركة",
+    "description": "Motion graphics scenario option"
+  },
+  "option.scenario.slideshow": {
+    "message": "عرض شرائح",
+    "description": "خيار سيناريو عرض شرائح"
+  },
+  "name.style": {
+    "message": "الأسلوب البصري",
+    "description": "حقل الأسلوب البصري"
+  },
+  "description.style": {
+    "message": "نصائح أسلوب بصري اختيارية (تؤثر على الطباعة، الألوان، الحركات، الإيقاع)، مستقلة عن نوع الفيديو. يمكن اختيار إعدادات مسبقة أو إدخالها يدويًا.",
+    "description": "مساعدة حقل الأسلوب"
+  },
+  "option.style.auto": {
+    "message": "تلقائي · بدون تحديد إضافي",
+    "description": "خيار أسلوب تلقائي"
+  },
+  "option.style.cinematic": {
+    "message": "إحساس سينمائي",
+    "description": "خيار أسلوب سينمائي"
+  },
+  "option.style.minimal": {
+    "message": "بسيط جداً",
+    "description": "خيار أسلوب بسيط جداً"
+  },
+  "option.style.neon": {
+    "message": "نيون",
+    "description": "خيار أسلوب نيون"
+  },
+  "option.style.corporate": {
+    "message": "أعمال",
+    "description": "خيار أسلوب أعمال"
+  },
+  "option.style.hand-drawn": {
+    "message": "مرسوم باليد",
+    "description": "خيار أسلوب مرسوم باليد"
+  },
   "name.sourceType": {
     "message": "نوع المصدر",
     "description": "حقل نوع المصدر"
@@ -247,22 +311,6 @@
     "message": "تحميل الفيديو الذي تم إنشاؤه",
     "description": "تلميح التحميل"
   },
-  "name.scenario": {
-    "message": "نوع الفيديو",
-    "description": "Video type field"
-  },
-  "description.scenario": {
-    "message": "اختر نوع الفيديو المراد إنشاؤه. «تلقائي» يترك القرار لـ Maestro؛ أو حدّد نمطًا مثل دراما قصيرة أو لقطات واقعية أو شرح أو ترويج منتج.",
-    "description": "Scenario field help"
-  },
-  "option.scenario.auto": {
-    "message": "تلقائي · دع Maestro يقرر",
-    "description": "Auto scenario option"
-  },
-  "option.scenario.drama": {
-    "message": "دراما قصيرة",
-    "description": "Short drama scenario option"
-  },
   "option.scenario.general": {
     "message": "لقطات واقعية",
     "description": "Footage piece scenario option"
@@ -282,10 +330,6 @@
   "option.scenario.slides": {
     "message": "عرض شرائح",
     "description": "Slideshow scenario option"
-  },
-  "option.scenario.motion": {
-    "message": "رسوم متحركة",
-    "description": "Motion graphics scenario option"
   },
   "option.scenario.changelog": {
     "message": "سجل التغييرات (PR)",

--- a/src/i18n/de/maestro.json
+++ b/src/i18n/de/maestro.json
@@ -187,6 +187,70 @@
     "message": "Noch keine Videos — erstelle dein erstes auf der linken Seite.",
     "description": "Keine Aufgaben vorhanden"
   },
+  "name.scenario": {
+    "message": "Videotyp",
+    "description": "Video type field"
+  },
+  "description.scenario": {
+    "message": "Wähle die Art des Videos. Auto lässt Maestro entscheiden; oder erzwinge einen Stil wie Kurzdrama, Realaufnahmen, Erklärvideo oder Produktwerbung.",
+    "description": "Scenario field help"
+  },
+  "option.scenario.auto": {
+    "message": "Auto · Maestro entscheiden lassen",
+    "description": "Auto scenario option"
+  },
+  "option.scenario.narrated": {
+    "message": "Erzähltes Multi-Szenen-Video",
+    "description": "Option für erzähltes Video mit mehreren Szenen"
+  },
+  "option.scenario.drama": {
+    "message": "Kurzdrama",
+    "description": "Short drama scenario option"
+  },
+  "option.scenario.avatar": {
+    "message": "Digitale Person · Sprachübertragung",
+    "description": "Avatar / Talking-Head-Szenario-Option"
+  },
+  "option.scenario.motion": {
+    "message": "Motion Graphics",
+    "description": "Motion graphics scenario option"
+  },
+  "option.scenario.slideshow": {
+    "message": "Präsentationsdiashow",
+    "description": "Option für Diashow-Szenario"
+  },
+  "name.style": {
+    "message": "Visueller Stil",
+    "description": "Feld für visuellen Stil"
+  },
+  "description.style": {
+    "message": "Optionale visuelle Stilhinweise (wirken sich auf Typografie, Farbgebung, Animationen, Rhythmus aus), unabhängig vom Video-Typ. Wählen Sie eine vordefinierte Einstellung oder geben Sie Ihre eigene ein.",
+    "description": "Hilfe zum Stilfeld"
+  },
+  "option.style.auto": {
+    "message": "Automatisch · Keine zusätzliche Angabe",
+    "description": "Option für automatischen Stil"
+  },
+  "option.style.cinematic": {
+    "message": "Filmisch",
+    "description": "Option für filmischen Stil"
+  },
+  "option.style.minimal": {
+    "message": "Minimalistisch",
+    "description": "Option für minimalistischen Stil"
+  },
+  "option.style.neon": {
+    "message": "Neon",
+    "description": "Option für Neon-Stil"
+  },
+  "option.style.corporate": {
+    "message": "Geschäftlich",
+    "description": "Option für geschäftlichen Stil"
+  },
+  "option.style.hand-drawn": {
+    "message": "Handgezeichnet",
+    "description": "Option für handgezeichneten Stil"
+  },
   "name.sourceType": {
     "message": "Quelltyp",
     "description": "Feld für den Quelltyp"
@@ -247,22 +311,6 @@
     "message": "Herunterladen des generierten Videos",
     "description": "Tooltip für den Download"
   },
-  "name.scenario": {
-    "message": "Videotyp",
-    "description": "Video type field"
-  },
-  "description.scenario": {
-    "message": "Wähle die Art des Videos. Auto lässt Maestro entscheiden; oder erzwinge einen Stil wie Kurzdrama, Realaufnahmen, Erklärvideo oder Produktwerbung.",
-    "description": "Scenario field help"
-  },
-  "option.scenario.auto": {
-    "message": "Auto · Maestro entscheiden lassen",
-    "description": "Auto scenario option"
-  },
-  "option.scenario.drama": {
-    "message": "Kurzdrama",
-    "description": "Short drama scenario option"
-  },
   "option.scenario.general": {
     "message": "Realaufnahmen",
     "description": "Footage piece scenario option"
@@ -282,10 +330,6 @@
   "option.scenario.slides": {
     "message": "Diashow",
     "description": "Slideshow scenario option"
-  },
-  "option.scenario.motion": {
-    "message": "Motion Graphics",
-    "description": "Motion graphics scenario option"
   },
   "option.scenario.changelog": {
     "message": "Änderungsprotokoll (PR)",

--- a/src/i18n/el/maestro.json
+++ b/src/i18n/el/maestro.json
@@ -187,6 +187,70 @@
     "message": "Δεν υπάρχουν βίντεο — Δημιουργήστε το πρώτο σας αριστερά.",
     "description": "Χωρίς εργασίες"
   },
+  "name.scenario": {
+    "message": "Τύπος βίντεο",
+    "description": "Video type field"
+  },
+  "description.scenario": {
+    "message": "Επιλέξτε τον τύπο βίντεο. Το «Αυτόματο» αφήνει το Maestro να αποφασίσει· ή επιβάλετε στυλ όπως σύντομο δράμα, πραγματικά πλάνα, επεξήγηση ή προώθηση προϊόντος.",
+    "description": "Scenario field help"
+  },
+  "option.scenario.auto": {
+    "message": "Αυτόματο · ας αποφασίσει το Maestro",
+    "description": "Auto scenario option"
+  },
+  "option.scenario.narrated": {
+    "message": "Βίντεο με αφήγηση",
+    "description": "Επιλογή βίντεο με αφήγηση πολλαπλών σκηνών"
+  },
+  "option.scenario.drama": {
+    "message": "Σύντομο δράμα",
+    "description": "Short drama scenario option"
+  },
+  "option.scenario.avatar": {
+    "message": "Ψηφιακός άνθρωπος · Ομιλία",
+    "description": "Επιλογή σεναρίου με avatar / ομιλητή"
+  },
+  "option.scenario.motion": {
+    "message": "Κινούμενα γραφικά",
+    "description": "Motion graphics scenario option"
+  },
+  "option.scenario.slideshow": {
+    "message": "Παρουσίαση διαφανειών",
+    "description": "Επιλογή σεναρίου παρουσίασης διαφανειών"
+  },
+  "name.style": {
+    "message": "Οπτικός στυλ",
+    "description": "Πεδίο οπτικού στυλ"
+  },
+  "description.style": {
+    "message": "Επιλογές οπτικού στυλ (που επηρεάζουν την τυπογραφία, τα χρώματα, τις κινήσεις, τον ρυθμό), ανεξάρτητες από τον τύπο βίντεο. Επιλογές προεπιλογής ή εισαγωγή από τον χρήστη.",
+    "description": "Βοήθεια πεδίου στυλ"
+  },
+  "option.style.auto": {
+    "message": "Αυτόματο · Χωρίς επιπλέον καθορισμό",
+    "description": "Επιλογή αυτόματου στυλ"
+  },
+  "option.style.cinematic": {
+    "message": "Κινηματογραφικό",
+    "description": "Επιλογή κινηματογραφικού στυλ"
+  },
+  "option.style.minimal": {
+    "message": "Εξαιρετικά απλό",
+    "description": "Επιλογή ελάχιστου στυλ"
+  },
+  "option.style.neon": {
+    "message": "Νεον",
+    "description": "Επιλογή στυλ νεον"
+  },
+  "option.style.corporate": {
+    "message": "Επιχειρηματικό",
+    "description": "Επιλογή επιχειρηματικού στυλ"
+  },
+  "option.style.hand-drawn": {
+    "message": "Χειροποίητο",
+    "description": "Επιλογή χειροποίητου στυλ"
+  },
   "name.sourceType": {
     "message": "Τύπος πηγής",
     "description": "Πεδίο τύπου πηγής"
@@ -247,22 +311,6 @@
     "message": "Κατέβασμα του παραγόμενου βίντεο",
     "description": "Tooltip για κατέβασμα"
   },
-  "name.scenario": {
-    "message": "Τύπος βίντεο",
-    "description": "Video type field"
-  },
-  "description.scenario": {
-    "message": "Επιλέξτε τον τύπο βίντεο. Το «Αυτόματο» αφήνει το Maestro να αποφασίσει· ή επιβάλετε στυλ όπως σύντομο δράμα, πραγματικά πλάνα, επεξήγηση ή προώθηση προϊόντος.",
-    "description": "Scenario field help"
-  },
-  "option.scenario.auto": {
-    "message": "Αυτόματο · ας αποφασίσει το Maestro",
-    "description": "Auto scenario option"
-  },
-  "option.scenario.drama": {
-    "message": "Σύντομο δράμα",
-    "description": "Short drama scenario option"
-  },
   "option.scenario.general": {
     "message": "Πραγματικά πλάνα",
     "description": "Footage piece scenario option"
@@ -282,10 +330,6 @@
   "option.scenario.slides": {
     "message": "Παρουσίαση διαφανειών",
     "description": "Slideshow scenario option"
-  },
-  "option.scenario.motion": {
-    "message": "Κινούμενα γραφικά",
-    "description": "Motion graphics scenario option"
   },
   "option.scenario.changelog": {
     "message": "Αρχείο αλλαγών (PR)",

--- a/src/i18n/en/maestro.json
+++ b/src/i18n/en/maestro.json
@@ -192,47 +192,63 @@
     "description": "Video type field"
   },
   "description.scenario": {
-    "message": "Pick the kind of video to make. Auto lets Maestro decide; or force a style like short drama, footage piece, explainer or product promo.",
+    "message": "Pick the kind of video to make. Auto lets Maestro decide; or force narrated footage, short drama, a talking-head avatar, motion graphics or a slideshow.",
     "description": "Scenario field help"
   },
   "option.scenario.auto": {
     "message": "Auto · let Maestro decide",
     "description": "Auto scenario option"
   },
+  "option.scenario.narrated": {
+    "message": "Narrated Footage",
+    "description": "Narrated multi-scene video option"
+  },
   "option.scenario.drama": {
     "message": "Short Drama",
     "description": "Short drama scenario option"
   },
-  "option.scenario.general": {
-    "message": "Footage Piece",
-    "description": "Footage piece scenario option"
-  },
-  "option.scenario.explainer": {
-    "message": "Explainer",
-    "description": "Explainer scenario option"
-  },
-  "option.scenario.product": {
-    "message": "Product Promo",
-    "description": "Product promo scenario option"
-  },
-  "option.scenario.website": {
-    "message": "Website to Video",
-    "description": "Website-to-video scenario option"
-  },
-  "option.scenario.slides": {
-    "message": "Slideshow",
-    "description": "Slideshow scenario option"
+  "option.scenario.avatar": {
+    "message": "Avatar · Talking Head",
+    "description": "Avatar / talking-head scenario option"
   },
   "option.scenario.motion": {
     "message": "Motion Graphics",
     "description": "Motion graphics scenario option"
   },
-  "option.scenario.changelog": {
-    "message": "Changelog (PR)",
-    "description": "Changelog scenario option"
+  "option.scenario.slideshow": {
+    "message": "Slideshow",
+    "description": "Slideshow scenario option"
   },
-  "option.scenario.captions": {
-    "message": "Add Captions",
-    "description": "Add-captions scenario option"
+  "name.style": {
+    "message": "Visual Style",
+    "description": "Visual style field"
+  },
+  "description.style": {
+    "message": "Optional visual-style hint (typography, palette, motion, pacing), independent of the video type. Pick a preset or type your own.",
+    "description": "Style field help"
+  },
+  "option.style.auto": {
+    "message": "Auto · no extra styling",
+    "description": "Auto style option"
+  },
+  "option.style.cinematic": {
+    "message": "Cinematic",
+    "description": "Cinematic style option"
+  },
+  "option.style.minimal": {
+    "message": "Minimal",
+    "description": "Minimal style option"
+  },
+  "option.style.neon": {
+    "message": "Neon",
+    "description": "Neon style option"
+  },
+  "option.style.corporate": {
+    "message": "Corporate",
+    "description": "Corporate style option"
+  },
+  "option.style.hand-drawn": {
+    "message": "Hand-drawn",
+    "description": "Hand-drawn style option"
   }
 }

--- a/src/i18n/es/maestro.json
+++ b/src/i18n/es/maestro.json
@@ -187,6 +187,70 @@
     "message": "No hay videos aún — crea el tuyo primero a la izquierda.",
     "description": "Sin tareas"
   },
+  "name.scenario": {
+    "message": "Tipo de vídeo",
+    "description": "Video type field"
+  },
+  "description.scenario": {
+    "message": "Elige el tipo de vídeo a crear. Automático deja que Maestro decida; o fuerza un estilo como drama corto, secuencia real, explicativo o promoción de producto.",
+    "description": "Scenario field help"
+  },
+  "option.scenario.auto": {
+    "message": "Automático · que decida Maestro",
+    "description": "Auto scenario option"
+  },
+  "option.scenario.narrated": {
+    "message": "Video narrado con imágenes",
+    "description": "Opción de video narrado de múltiples escenas"
+  },
+  "option.scenario.drama": {
+    "message": "Drama corto",
+    "description": "Short drama scenario option"
+  },
+  "option.scenario.avatar": {
+    "message": "Avatar · Locución",
+    "description": "Opción de escenario de avatar / cabeza hablante"
+  },
+  "option.scenario.motion": {
+    "message": "Gráficos animados",
+    "description": "Motion graphics scenario option"
+  },
+  "option.scenario.slideshow": {
+    "message": "Presentación de diapositivas",
+    "description": "Opción de escenario de presentación de diapositivas"
+  },
+  "name.style": {
+    "message": "Estilo visual",
+    "description": "Campo de estilo visual"
+  },
+  "description.style": {
+    "message": "Consejos de estilo visual opcionales (aplicables a tipografía, paleta de colores, efectos y ritmo), independientes del tipo de video. Preajustes opcionales o entrada manual.",
+    "description": "Ayuda para el campo de estilo"
+  },
+  "option.style.auto": {
+    "message": "Automático · Sin especificar adicionalmente",
+    "description": "Opción de estilo automático"
+  },
+  "option.style.cinematic": {
+    "message": "Estilo cinematográfico",
+    "description": "Opción de estilo cinematográfico"
+  },
+  "option.style.minimal": {
+    "message": "Estilo minimalista",
+    "description": "Opción de estilo minimalista"
+  },
+  "option.style.neon": {
+    "message": "Estilo neón",
+    "description": "Opción de estilo neón"
+  },
+  "option.style.corporate": {
+    "message": "Estilo corporativo",
+    "description": "Opción de estilo corporativo"
+  },
+  "option.style.hand-drawn": {
+    "message": "Dibujo a mano",
+    "description": "Opción de estilo dibujado a mano"
+  },
   "name.sourceType": {
     "message": "Tipo de origen",
     "description": "Campo de tipo de origen"
@@ -247,22 +311,6 @@
     "message": "Descargar el video generado",
     "description": "Tooltip de descarga"
   },
-  "name.scenario": {
-    "message": "Tipo de vídeo",
-    "description": "Video type field"
-  },
-  "description.scenario": {
-    "message": "Elige el tipo de vídeo a crear. Automático deja que Maestro decida; o fuerza un estilo como drama corto, secuencia real, explicativo o promoción de producto.",
-    "description": "Scenario field help"
-  },
-  "option.scenario.auto": {
-    "message": "Automático · que decida Maestro",
-    "description": "Auto scenario option"
-  },
-  "option.scenario.drama": {
-    "message": "Drama corto",
-    "description": "Short drama scenario option"
-  },
   "option.scenario.general": {
     "message": "Secuencia real",
     "description": "Footage piece scenario option"
@@ -282,10 +330,6 @@
   "option.scenario.slides": {
     "message": "Presentación",
     "description": "Slideshow scenario option"
-  },
-  "option.scenario.motion": {
-    "message": "Gráficos animados",
-    "description": "Motion graphics scenario option"
   },
   "option.scenario.changelog": {
     "message": "Registro de cambios (PR)",

--- a/src/i18n/fi/maestro.json
+++ b/src/i18n/fi/maestro.json
@@ -187,6 +187,70 @@
     "message": "Ei vielä videoita — luo ensimmäinen vasemmalla.",
     "description": "Ei tehtäviä"
   },
+  "name.scenario": {
+    "message": "Videon tyyppi",
+    "description": "Video type field"
+  },
+  "description.scenario": {
+    "message": "Valitse luotavan videon tyyppi. Automaattinen antaa Maestron päättää; tai pakota tyyli, kuten lyhytdraama, aito kuvamateriaali, selittävä tai tuote-esittely.",
+    "description": "Scenario field help"
+  },
+  "option.scenario.auto": {
+    "message": "Automaattinen · anna Maestron päättää",
+    "description": "Auto scenario option"
+  },
+  "option.scenario.narrated": {
+    "message": "Kuvateksteillä varustettu video",
+    "description": "Kuvateksteillä varustettu monikohtainen videovaihtoehto"
+  },
+  "option.scenario.drama": {
+    "message": "Lyhytdraama",
+    "description": "Short drama scenario option"
+  },
+  "option.scenario.avatar": {
+    "message": "Digitaalinen henkilö · Puhe",
+    "description": "Avatar / puhuva pää -skenaario vaihtoehto"
+  },
+  "option.scenario.motion": {
+    "message": "Liikegrafiikka",
+    "description": "Motion graphics scenario option"
+  },
+  "option.scenario.slideshow": {
+    "message": "Esitysdia",
+    "description": "Diaesityksen skenaario vaihtoehto"
+  },
+  "name.style": {
+    "message": "Visuaalinen tyyli",
+    "description": "Visuaalisen tyylin kenttä"
+  },
+  "description.style": {
+    "message": "Valinnainen visuaalinen tyyli (vaikuttaa typografiaan, väreihin, animaatioihin, rytmiin), riippumaton videotyypistä. Valinnaiset esiasetukset tai oma syöttö.",
+    "description": "Tyylikentän ohje"
+  },
+  "option.style.auto": {
+    "message": "Automaattinen · Ei lisäyksityiskohtia",
+    "description": "Automaattinen tyylivaihtoehto"
+  },
+  "option.style.cinematic": {
+    "message": "Elokuvamainen",
+    "description": "Elokuvamainen tyylivaihtoehto"
+  },
+  "option.style.minimal": {
+    "message": "Minimalistinen",
+    "description": "Minimalistinen tyylivaihtoehto"
+  },
+  "option.style.neon": {
+    "message": "Neon",
+    "description": "Neon-tyylivaihtoehto"
+  },
+  "option.style.corporate": {
+    "message": "Liiketoiminta",
+    "description": "Liiketoimintatyylivaihtoehto"
+  },
+  "option.style.hand-drawn": {
+    "message": "Käsin piirretty",
+    "description": "Käsin piirretty tyylivaihtoehto"
+  },
   "name.sourceType": {
     "message": "Lähteen tyyppi",
     "description": "Lähteen tyyppi kenttä"
@@ -247,22 +311,6 @@
     "message": "Lataa tuotettu video",
     "description": "Lataus työkaluvihje"
   },
-  "name.scenario": {
-    "message": "Videon tyyppi",
-    "description": "Video type field"
-  },
-  "description.scenario": {
-    "message": "Valitse luotavan videon tyyppi. Automaattinen antaa Maestron päättää; tai pakota tyyli, kuten lyhytdraama, aito kuvamateriaali, selittävä tai tuote-esittely.",
-    "description": "Scenario field help"
-  },
-  "option.scenario.auto": {
-    "message": "Automaattinen · anna Maestron päättää",
-    "description": "Auto scenario option"
-  },
-  "option.scenario.drama": {
-    "message": "Lyhytdraama",
-    "description": "Short drama scenario option"
-  },
   "option.scenario.general": {
     "message": "Aito kuvamateriaali",
     "description": "Footage piece scenario option"
@@ -282,10 +330,6 @@
   "option.scenario.slides": {
     "message": "Diaesitys",
     "description": "Slideshow scenario option"
-  },
-  "option.scenario.motion": {
-    "message": "Liikegrafiikka",
-    "description": "Motion graphics scenario option"
   },
   "option.scenario.changelog": {
     "message": "Muutosloki (PR)",

--- a/src/i18n/fr/maestro.json
+++ b/src/i18n/fr/maestro.json
@@ -187,6 +187,70 @@
     "message": "Aucune vidéo encore — créez votre première à gauche.",
     "description": "Aucune tâche"
   },
+  "name.scenario": {
+    "message": "Type de vidéo",
+    "description": "Video type field"
+  },
+  "description.scenario": {
+    "message": "Choisissez le type de vidéo à créer. Auto laisse Maestro décider ; ou imposez un style comme drame court, séquence réelle, explicatif ou promo produit.",
+    "description": "Scenario field help"
+  },
+  "option.scenario.auto": {
+    "message": "Auto · laisser Maestro décider",
+    "description": "Auto scenario option"
+  },
+  "option.scenario.narrated": {
+    "message": "Vidéo narrée avec images",
+    "description": "Option de vidéo multi-scènes narrée"
+  },
+  "option.scenario.drama": {
+    "message": "Drame court",
+    "description": "Short drama scenario option"
+  },
+  "option.scenario.avatar": {
+    "message": "Avatar · Présentation orale",
+    "description": "Option de scénario avatar / tête parlante"
+  },
+  "option.scenario.motion": {
+    "message": "Motion design",
+    "description": "Motion graphics scenario option"
+  },
+  "option.scenario.slideshow": {
+    "message": "Diaporama",
+    "description": "Option de scénario diaporama"
+  },
+  "name.style": {
+    "message": "Style visuel",
+    "description": "Champ de style visuel"
+  },
+  "description.style": {
+    "message": "Options de style visuel facultatives (affectant la typographie, les couleurs, les animations, le rythme), indépendantes du type de vidéo. Préréglages optionnels ou saisie manuelle.",
+    "description": "Aide au champ de style"
+  },
+  "option.style.auto": {
+    "message": "Automatique · Pas de spécification supplémentaire",
+    "description": "Option de style automatique"
+  },
+  "option.style.cinematic": {
+    "message": "Style cinématographique",
+    "description": "Option de style cinématographique"
+  },
+  "option.style.minimal": {
+    "message": "Style minimaliste",
+    "description": "Option de style minimal"
+  },
+  "option.style.neon": {
+    "message": "Style néon",
+    "description": "Option de style néon"
+  },
+  "option.style.corporate": {
+    "message": "Style professionnel",
+    "description": "Option de style d'entreprise"
+  },
+  "option.style.hand-drawn": {
+    "message": "Dessin à la main",
+    "description": "Option de style dessin à la main"
+  },
   "name.sourceType": {
     "message": "Type de source",
     "description": "Champ de type de source"
@@ -247,22 +311,6 @@
     "message": "Télécharger la vidéo générée",
     "description": "Infobulle de téléchargement"
   },
-  "name.scenario": {
-    "message": "Type de vidéo",
-    "description": "Video type field"
-  },
-  "description.scenario": {
-    "message": "Choisissez le type de vidéo à créer. Auto laisse Maestro décider ; ou imposez un style comme drame court, séquence réelle, explicatif ou promo produit.",
-    "description": "Scenario field help"
-  },
-  "option.scenario.auto": {
-    "message": "Auto · laisser Maestro décider",
-    "description": "Auto scenario option"
-  },
-  "option.scenario.drama": {
-    "message": "Drame court",
-    "description": "Short drama scenario option"
-  },
   "option.scenario.general": {
     "message": "Séquence réelle",
     "description": "Footage piece scenario option"
@@ -282,10 +330,6 @@
   "option.scenario.slides": {
     "message": "Diaporama",
     "description": "Slideshow scenario option"
-  },
-  "option.scenario.motion": {
-    "message": "Motion design",
-    "description": "Motion graphics scenario option"
   },
   "option.scenario.changelog": {
     "message": "Journal des modifs (PR)",

--- a/src/i18n/it/maestro.json
+++ b/src/i18n/it/maestro.json
@@ -187,6 +187,70 @@
     "message": "Non ci sono video — crea il tuo primo a sinistra.",
     "description": "Nessun compito"
   },
+  "name.scenario": {
+    "message": "Tipo di video",
+    "description": "Video type field"
+  },
+  "description.scenario": {
+    "message": "Scegli il tipo di video da creare. Auto lascia decidere a Maestro; oppure imponi uno stile come dramma breve, riprese reali, esplicativo o promo prodotto.",
+    "description": "Scenario field help"
+  },
+  "option.scenario.auto": {
+    "message": "Auto · lascia decidere a Maestro",
+    "description": "Auto scenario option"
+  },
+  "option.scenario.narrated": {
+    "message": "Video con narrazione",
+    "description": "Opzione video narrato multi-scena"
+  },
+  "option.scenario.drama": {
+    "message": "Dramma breve",
+    "description": "Short drama scenario option"
+  },
+  "option.scenario.avatar": {
+    "message": "Persona digitale · Voce narrante",
+    "description": "Opzione scenario avatar / testa parlante"
+  },
+  "option.scenario.motion": {
+    "message": "Grafica animata",
+    "description": "Motion graphics scenario option"
+  },
+  "option.scenario.slideshow": {
+    "message": "Presentazione",
+    "description": "Opzione scenario slideshow"
+  },
+  "name.style": {
+    "message": "Stile visivo",
+    "description": "Campo per lo stile visivo"
+  },
+  "description.style": {
+    "message": "Suggerimenti di stile visivo opzionali (applicabili a tipografia, colori, animazioni, ritmo), indipendenti dal tipo di video. Preset opzionali o input manuale.",
+    "description": "Aiuto per il campo stile"
+  },
+  "option.style.auto": {
+    "message": "Automatico · Nessuna specifica aggiuntiva",
+    "description": "Opzione stile automatico"
+  },
+  "option.style.cinematic": {
+    "message": "Stile cinematografico",
+    "description": "Opzione stile cinematografico"
+  },
+  "option.style.minimal": {
+    "message": "Stile minimalista",
+    "description": "Opzione stile minimalista"
+  },
+  "option.style.neon": {
+    "message": "Stile neon",
+    "description": "Opzione stile neon"
+  },
+  "option.style.corporate": {
+    "message": "Stile aziendale",
+    "description": "Opzione stile aziendale"
+  },
+  "option.style.hand-drawn": {
+    "message": "Disegno a mano",
+    "description": "Opzione stile disegnato a mano"
+  },
   "name.sourceType": {
     "message": "Tipo di sorgente",
     "description": "Campo per il tipo di sorgente"
@@ -247,22 +311,6 @@
     "message": "Scarica il video generato",
     "description": "Tooltip per il download"
   },
-  "name.scenario": {
-    "message": "Tipo di video",
-    "description": "Video type field"
-  },
-  "description.scenario": {
-    "message": "Scegli il tipo di video da creare. Auto lascia decidere a Maestro; oppure imponi uno stile come dramma breve, riprese reali, esplicativo o promo prodotto.",
-    "description": "Scenario field help"
-  },
-  "option.scenario.auto": {
-    "message": "Auto · lascia decidere a Maestro",
-    "description": "Auto scenario option"
-  },
-  "option.scenario.drama": {
-    "message": "Dramma breve",
-    "description": "Short drama scenario option"
-  },
   "option.scenario.general": {
     "message": "Riprese reali",
     "description": "Footage piece scenario option"
@@ -282,10 +330,6 @@
   "option.scenario.slides": {
     "message": "Presentazione",
     "description": "Slideshow scenario option"
-  },
-  "option.scenario.motion": {
-    "message": "Grafica animata",
-    "description": "Motion graphics scenario option"
   },
   "option.scenario.changelog": {
     "message": "Changelog (PR)",

--- a/src/i18n/ja/maestro.json
+++ b/src/i18n/ja/maestro.json
@@ -187,6 +187,70 @@
     "message": "まだ動画がありません — 左側で最初の動画を作成しましょう。",
     "description": "タスクがないことを示すメッセージ"
   },
+  "name.scenario": {
+    "message": "動画タイプ",
+    "description": "Video type field"
+  },
+  "description.scenario": {
+    "message": "作成する動画の種類を選びます。自動では Maestro が判断します。ショートドラマ・実写映像・解説・商品PRなどのスタイルを指定することもできます。",
+    "description": "Scenario field help"
+  },
+  "option.scenario.auto": {
+    "message": "自動 · Maestro に任せる",
+    "description": "Auto scenario option"
+  },
+  "option.scenario.narrated": {
+    "message": "図文ナレーションの完成品",
+    "description": "ナレーション付きマルチシーンビデオオプション"
+  },
+  "option.scenario.drama": {
+    "message": "ショートドラマ",
+    "description": "Short drama scenario option"
+  },
+  "option.scenario.avatar": {
+    "message": "デジタル人 · ナレーション",
+    "description": "アバター / トーキングヘッドシナリオオプション"
+  },
+  "option.scenario.motion": {
+    "message": "モーショングラフィックス",
+    "description": "Motion graphics scenario option"
+  },
+  "option.scenario.slideshow": {
+    "message": "スライドショー",
+    "description": "スライドショーシナリオオプション"
+  },
+  "name.style": {
+    "message": "ビジュアルスタイル",
+    "description": "ビジュアルスタイルフィールド"
+  },
+  "description.style": {
+    "message": "選択可能なビジュアルスタイルのヒント（タイポグラフィ、カラースキーム、アニメーション、リズムに影響し、ビデオタイプとは独立しています）。プリセットを選択するか、自分で入力します。",
+    "description": "スタイルフィールドのヘルプ"
+  },
+  "option.style.auto": {
+    "message": "自動 · 追加指定なし",
+    "description": "自動スタイルオプション"
+  },
+  "option.style.cinematic": {
+    "message": "映画的",
+    "description": "シネマティックスタイルオプション"
+  },
+  "option.style.minimal": {
+    "message": "ミニマル",
+    "description": "ミニマルスタイルオプション"
+  },
+  "option.style.neon": {
+    "message": "ネオン",
+    "description": "ネオンスタイルオプション"
+  },
+  "option.style.corporate": {
+    "message": "ビジネス",
+    "description": "コーポレートスタイルオプション"
+  },
+  "option.style.hand-drawn": {
+    "message": "手描き",
+    "description": "手描きスタイルオプション"
+  },
   "name.sourceType": {
     "message": "ソースタイプ",
     "description": "ソースタイプフィールド"
@@ -247,22 +311,6 @@
     "message": "生成された動画をダウンロード",
     "description": "ダウンロードツールチップ"
   },
-  "name.scenario": {
-    "message": "動画タイプ",
-    "description": "Video type field"
-  },
-  "description.scenario": {
-    "message": "作成する動画の種類を選びます。自動では Maestro が判断します。ショートドラマ・実写映像・解説・商品PRなどのスタイルを指定することもできます。",
-    "description": "Scenario field help"
-  },
-  "option.scenario.auto": {
-    "message": "自動 · Maestro に任せる",
-    "description": "Auto scenario option"
-  },
-  "option.scenario.drama": {
-    "message": "ショートドラマ",
-    "description": "Short drama scenario option"
-  },
   "option.scenario.general": {
     "message": "実写映像",
     "description": "Footage piece scenario option"
@@ -282,10 +330,6 @@
   "option.scenario.slides": {
     "message": "スライドショー",
     "description": "Slideshow scenario option"
-  },
-  "option.scenario.motion": {
-    "message": "モーショングラフィックス",
-    "description": "Motion graphics scenario option"
   },
   "option.scenario.changelog": {
     "message": "変更履歴 (PR)",

--- a/src/i18n/ko/maestro.json
+++ b/src/i18n/ko/maestro.json
@@ -187,6 +187,70 @@
     "message": "아직 비디오가 없습니다 — 왼쪽에서 첫 번째 비디오를 생성하세요.",
     "description": "작업 없음"
   },
+  "name.scenario": {
+    "message": "동영상 유형",
+    "description": "Video type field"
+  },
+  "description.scenario": {
+    "message": "제작할 동영상 종류를 선택하세요. 자동은 Maestro가 결정하며, 숏드라마·실사 영상·설명·제품 홍보 등 스타일을 지정할 수도 있습니다.",
+    "description": "Scenario field help"
+  },
+  "option.scenario.auto": {
+    "message": "자동 · Maestro가 결정",
+    "description": "Auto scenario option"
+  },
+  "option.scenario.narrated": {
+    "message": "이미지와 텍스트 내레이션 영상",
+    "description": "내레이션이 포함된 다중 장면 비디오 옵션"
+  },
+  "option.scenario.drama": {
+    "message": "숏드라마",
+    "description": "Short drama scenario option"
+  },
+  "option.scenario.avatar": {
+    "message": "디지털 사람 · 구술",
+    "description": "아바타 / 토킹 헤드 시나리오 옵션"
+  },
+  "option.scenario.motion": {
+    "message": "모션 그래픽",
+    "description": "Motion graphics scenario option"
+  },
+  "option.scenario.slideshow": {
+    "message": "슬라이드 쇼",
+    "description": "슬라이드 쇼 시나리오 옵션"
+  },
+  "name.style": {
+    "message": "시각적 스타일",
+    "description": "시각적 스타일 필드"
+  },
+  "description.style": {
+    "message": "선택 가능한 시각적 스타일 힌트(타이포그래피, 색상, 애니메이션, 리듬에 적용되며 비디오 유형과 독립적입니다). 선택된 프리셋 또는 직접 입력 가능합니다.",
+    "description": "스타일 필드 도움말"
+  },
+  "option.style.auto": {
+    "message": "자동 · 추가 지정 없음",
+    "description": "자동 스타일 옵션"
+  },
+  "option.style.cinematic": {
+    "message": "영화 느낌",
+    "description": "영화적 스타일 옵션"
+  },
+  "option.style.minimal": {
+    "message": "미니멀",
+    "description": "미니멀 스타일 옵션"
+  },
+  "option.style.neon": {
+    "message": "네온",
+    "description": "네온 스타일 옵션"
+  },
+  "option.style.corporate": {
+    "message": "비즈니스",
+    "description": "기업 스타일 옵션"
+  },
+  "option.style.hand-drawn": {
+    "message": "손으로 그린",
+    "description": "손그림 스타일 옵션"
+  },
   "name.sourceType": {
     "message": "출처 유형",
     "description": "출처 유형 필드"
@@ -247,22 +311,6 @@
     "message": "생성된 비디오 다운로드",
     "description": "다운로드 툴팁"
   },
-  "name.scenario": {
-    "message": "동영상 유형",
-    "description": "Video type field"
-  },
-  "description.scenario": {
-    "message": "제작할 동영상 종류를 선택하세요. 자동은 Maestro가 결정하며, 숏드라마·실사 영상·설명·제품 홍보 등 스타일을 지정할 수도 있습니다.",
-    "description": "Scenario field help"
-  },
-  "option.scenario.auto": {
-    "message": "자동 · Maestro가 결정",
-    "description": "Auto scenario option"
-  },
-  "option.scenario.drama": {
-    "message": "숏드라마",
-    "description": "Short drama scenario option"
-  },
   "option.scenario.general": {
     "message": "실사 영상",
     "description": "Footage piece scenario option"
@@ -282,10 +330,6 @@
   "option.scenario.slides": {
     "message": "슬라이드쇼",
     "description": "Slideshow scenario option"
-  },
-  "option.scenario.motion": {
-    "message": "모션 그래픽",
-    "description": "Motion graphics scenario option"
   },
   "option.scenario.changelog": {
     "message": "변경 로그 (PR)",

--- a/src/i18n/pl/maestro.json
+++ b/src/i18n/pl/maestro.json
@@ -187,6 +187,70 @@
     "message": "Brak wideo — stwórz swoje pierwsze po lewej stronie.",
     "description": "Brak zadań"
   },
+  "name.scenario": {
+    "message": "Typ wideo",
+    "description": "Video type field"
+  },
+  "description.scenario": {
+    "message": "Wybierz rodzaj tworzonego wideo. Automatyczny pozwala Maestro zdecydować; albo wymuś styl, np. krótki dramat, ujęcia rzeczywiste, objaśnienie lub promocję produktu.",
+    "description": "Scenario field help"
+  },
+  "option.scenario.auto": {
+    "message": "Automatyczny · niech zdecyduje Maestro",
+    "description": "Auto scenario option"
+  },
+  "option.scenario.narrated": {
+    "message": "Narracja z ilustracjami",
+    "description": "Opcja wideo z narracją w wielu scenach"
+  },
+  "option.scenario.drama": {
+    "message": "Krótki dramat",
+    "description": "Short drama scenario option"
+  },
+  "option.scenario.avatar": {
+    "message": "Cyfrowa postać · Mówca",
+    "description": "Opcja scenariusza z awatarem / mówiącą głową"
+  },
+  "option.scenario.motion": {
+    "message": "Grafika ruchoma",
+    "description": "Motion graphics scenario option"
+  },
+  "option.scenario.slideshow": {
+    "message": "Pokaz slajdów",
+    "description": "Opcja scenariusza pokazu slajdów"
+  },
+  "name.style": {
+    "message": "Styl wizualny",
+    "description": "Pole stylu wizualnego"
+  },
+  "description.style": {
+    "message": "Opcjonalne wskazówki dotyczące stylu wizualnego (dotyczące typografii, kolorystyki, animacji, rytmu), niezależne od typu wideo. Opcjonalne ustawienia wstępne lub własny wpis.",
+    "description": "Pomoc dotycząca pola stylu"
+  },
+  "option.style.auto": {
+    "message": "Automatycznie · Bez dodatkowego określenia",
+    "description": "Opcja stylu automatycznego"
+  },
+  "option.style.cinematic": {
+    "message": "Filmowy",
+    "description": "Opcja stylu filmowego"
+  },
+  "option.style.minimal": {
+    "message": "Minimalistyczny",
+    "description": "Opcja stylu minimalistycznego"
+  },
+  "option.style.neon": {
+    "message": "Neonowy",
+    "description": "Opcja stylu neonowego"
+  },
+  "option.style.corporate": {
+    "message": "Biznesowy",
+    "description": "Opcja stylu korporacyjnego"
+  },
+  "option.style.hand-drawn": {
+    "message": "Ręcznie rysowany",
+    "description": "Opcja stylu ręcznie rysowanego"
+  },
   "name.sourceType": {
     "message": "Typ źródła",
     "description": "Pole typu źródła"
@@ -247,22 +311,6 @@
     "message": "Pobierz wygenerowane wideo",
     "description": "Podpowiedź do pobierania"
   },
-  "name.scenario": {
-    "message": "Typ wideo",
-    "description": "Video type field"
-  },
-  "description.scenario": {
-    "message": "Wybierz rodzaj tworzonego wideo. Automatyczny pozwala Maestro zdecydować; albo wymuś styl, np. krótki dramat, ujęcia rzeczywiste, objaśnienie lub promocję produktu.",
-    "description": "Scenario field help"
-  },
-  "option.scenario.auto": {
-    "message": "Automatyczny · niech zdecyduje Maestro",
-    "description": "Auto scenario option"
-  },
-  "option.scenario.drama": {
-    "message": "Krótki dramat",
-    "description": "Short drama scenario option"
-  },
   "option.scenario.general": {
     "message": "Ujęcia rzeczywiste",
     "description": "Footage piece scenario option"
@@ -282,10 +330,6 @@
   "option.scenario.slides": {
     "message": "Pokaz slajdów",
     "description": "Slideshow scenario option"
-  },
-  "option.scenario.motion": {
-    "message": "Grafika ruchoma",
-    "description": "Motion graphics scenario option"
   },
   "option.scenario.changelog": {
     "message": "Lista zmian (PR)",

--- a/src/i18n/pt/maestro.json
+++ b/src/i18n/pt/maestro.json
@@ -187,6 +187,70 @@
     "message": "Ainda não há vídeos — crie o seu primeiro à esquerda.",
     "description": "Sem tarefas"
   },
+  "name.scenario": {
+    "message": "Tipo de vídeo",
+    "description": "Video type field"
+  },
+  "description.scenario": {
+    "message": "Escolha o tipo de vídeo a criar. Automático deixa o Maestro decidir; ou force um estilo como drama curto, sequência real, explicativo ou promoção de produto.",
+    "description": "Scenario field help"
+  },
+  "option.scenario.auto": {
+    "message": "Automático · deixar o Maestro decidir",
+    "description": "Auto scenario option"
+  },
+  "option.scenario.narrated": {
+    "message": "Vídeo narrado com imagens",
+    "description": "Opção de vídeo narrado com múltiplas cenas"
+  },
+  "option.scenario.drama": {
+    "message": "Drama curto",
+    "description": "Short drama scenario option"
+  },
+  "option.scenario.avatar": {
+    "message": "Avatar · Apresentação",
+    "description": "Opção de cenário de avatar / apresentador"
+  },
+  "option.scenario.motion": {
+    "message": "Motion graphics",
+    "description": "Motion graphics scenario option"
+  },
+  "option.scenario.slideshow": {
+    "message": "Apresentação de slides",
+    "description": "Opção de cenário de apresentação de slides"
+  },
+  "name.style": {
+    "message": "Estilo visual",
+    "description": "Campo de estilo visual"
+  },
+  "description.style": {
+    "message": "Dicas de estilo visual opcionais (aplicáveis à tipografia, paleta de cores, animações, ritmo), independentes do tipo de vídeo. Presets opcionais ou entrada manual.",
+    "description": "Ajuda para o campo de estilo"
+  },
+  "option.style.auto": {
+    "message": "Automático · Sem especificação adicional",
+    "description": "Opção de estilo automático"
+  },
+  "option.style.cinematic": {
+    "message": "Estilo cinematográfico",
+    "description": "Opção de estilo cinematográfico"
+  },
+  "option.style.minimal": {
+    "message": "Estilo minimalista",
+    "description": "Opção de estilo minimalista"
+  },
+  "option.style.neon": {
+    "message": "Estilo neon",
+    "description": "Opção de estilo neon"
+  },
+  "option.style.corporate": {
+    "message": "Estilo corporativo",
+    "description": "Opção de estilo corporativo"
+  },
+  "option.style.hand-drawn": {
+    "message": "Estilo desenhado à mão",
+    "description": "Opção de estilo desenhado à mão"
+  },
   "name.sourceType": {
     "message": "Tipo de origem",
     "description": "Campo de tipo de origem"
@@ -247,22 +311,6 @@
     "message": "Baixar o vídeo gerado",
     "description": "Dica para download"
   },
-  "name.scenario": {
-    "message": "Tipo de vídeo",
-    "description": "Video type field"
-  },
-  "description.scenario": {
-    "message": "Escolha o tipo de vídeo a criar. Automático deixa o Maestro decidir; ou force um estilo como drama curto, sequência real, explicativo ou promoção de produto.",
-    "description": "Scenario field help"
-  },
-  "option.scenario.auto": {
-    "message": "Automático · deixar o Maestro decidir",
-    "description": "Auto scenario option"
-  },
-  "option.scenario.drama": {
-    "message": "Drama curto",
-    "description": "Short drama scenario option"
-  },
   "option.scenario.general": {
     "message": "Sequência real",
     "description": "Footage piece scenario option"
@@ -282,10 +330,6 @@
   "option.scenario.slides": {
     "message": "Apresentação de slides",
     "description": "Slideshow scenario option"
-  },
-  "option.scenario.motion": {
-    "message": "Motion graphics",
-    "description": "Motion graphics scenario option"
   },
   "option.scenario.changelog": {
     "message": "Registro de alterações (PR)",

--- a/src/i18n/ru/maestro.json
+++ b/src/i18n/ru/maestro.json
@@ -187,6 +187,70 @@
     "message": "Пока нет видео — создайте ваше первое слева.",
     "description": "Нет задач"
   },
+  "name.scenario": {
+    "message": "Тип видео",
+    "description": "Video type field"
+  },
+  "description.scenario": {
+    "message": "Выберите тип создаваемого видео. «Авто» — Maestro решит сам; либо задайте стиль: короткая драма, реальные кадры, объяснение или промо продукта.",
+    "description": "Scenario field help"
+  },
+  "option.scenario.auto": {
+    "message": "Авто · пусть решает Maestro",
+    "description": "Auto scenario option"
+  },
+  "option.scenario.narrated": {
+    "message": "Озвученный многосценный видео",
+    "description": "Опция озвученного видео с несколькими сценами"
+  },
+  "option.scenario.drama": {
+    "message": "Короткая драма",
+    "description": "Short drama scenario option"
+  },
+  "option.scenario.avatar": {
+    "message": "Цифровой человек · Озвучка",
+    "description": "Опция сценария с аватаром / говорящей головой"
+  },
+  "option.scenario.motion": {
+    "message": "Моушн-графика",
+    "description": "Motion graphics scenario option"
+  },
+  "option.scenario.slideshow": {
+    "message": "Слайд-шоу",
+    "description": "Опция сценария слайд-шоу"
+  },
+  "name.style": {
+    "message": "Визуальный стиль",
+    "description": "Поле визуального стиля"
+  },
+  "description.style": {
+    "message": "Дополнительные визуальные стили (для типографики, цветовой схемы, анимации, ритма), независимые от типа видео. Можно выбрать предустановленный вариант или ввести свой.",
+    "description": "Помощь по полю стиля"
+  },
+  "option.style.auto": {
+    "message": "Авто · Без дополнительных указаний",
+    "description": "Опция автоматического стиля"
+  },
+  "option.style.cinematic": {
+    "message": "Кинематографический",
+    "description": "Опция кинематографического стиля"
+  },
+  "option.style.minimal": {
+    "message": "Минимализм",
+    "description": "Опция минималистского стиля"
+  },
+  "option.style.neon": {
+    "message": "Неон",
+    "description": "Опция неонового стиля"
+  },
+  "option.style.corporate": {
+    "message": "Корпоративный",
+    "description": "Опция корпоративного стиля"
+  },
+  "option.style.hand-drawn": {
+    "message": "Ручная работа",
+    "description": "Опция стиля ручной работы"
+  },
   "name.sourceType": {
     "message": "Тип источника",
     "description": "Поле типа источника"
@@ -247,22 +311,6 @@
     "message": "Скачать сгенерированное видео",
     "description": "Подсказка для скачивания"
   },
-  "name.scenario": {
-    "message": "Тип видео",
-    "description": "Video type field"
-  },
-  "description.scenario": {
-    "message": "Выберите тип создаваемого видео. «Авто» — Maestro решит сам; либо задайте стиль: короткая драма, реальные кадры, объяснение или промо продукта.",
-    "description": "Scenario field help"
-  },
-  "option.scenario.auto": {
-    "message": "Авто · пусть решает Maestro",
-    "description": "Auto scenario option"
-  },
-  "option.scenario.drama": {
-    "message": "Короткая драма",
-    "description": "Short drama scenario option"
-  },
   "option.scenario.general": {
     "message": "Реальные кадры",
     "description": "Footage piece scenario option"
@@ -282,10 +330,6 @@
   "option.scenario.slides": {
     "message": "Слайд-шоу",
     "description": "Slideshow scenario option"
-  },
-  "option.scenario.motion": {
-    "message": "Моушн-графика",
-    "description": "Motion graphics scenario option"
   },
   "option.scenario.changelog": {
     "message": "Список изменений (PR)",

--- a/src/i18n/sr/maestro.json
+++ b/src/i18n/sr/maestro.json
@@ -187,6 +187,70 @@
     "message": "Još nema videa — kreiraj svoj prvi sa leve strane.",
     "description": "Nema zadataka"
   },
+  "name.scenario": {
+    "message": "Тип видеа",
+    "description": "Video type field"
+  },
+  "description.scenario": {
+    "message": "Изаберите врсту видеа. „Аутоматски“ препушта Maestro-у да одлучи; или наметните стил као што су кратка драма, стварни снимци, објашњење или промоција производа.",
+    "description": "Scenario field help"
+  },
+  "option.scenario.auto": {
+    "message": "Аутоматски · нека одлучи Maestro",
+    "description": "Auto scenario option"
+  },
+  "option.scenario.narrated": {
+    "message": "Нарација уз слике",
+    "description": "Опција за видео са нарацијом у више сцена"
+  },
+  "option.scenario.drama": {
+    "message": "Кратка драма",
+    "description": "Short drama scenario option"
+  },
+  "option.scenario.avatar": {
+    "message": "Дигитална особа · Говорна глава",
+    "description": "Опција за аватар / сценарио говорне главе"
+  },
+  "option.scenario.motion": {
+    "message": "Покретна графика",
+    "description": "Motion graphics scenario option"
+  },
+  "option.scenario.slideshow": {
+    "message": "Презентација слајдова",
+    "description": "Опција за сценарио слајд шоу"
+  },
+  "name.style": {
+    "message": "Визуелни стил",
+    "description": "Поље за визуелни стил"
+  },
+  "description.style": {
+    "message": "Опционални визуелни стилски савети (који се односе на типографију, боје, анимације, ритам), независно од типа видеа. Опционални предлози или ручно унети.",
+    "description": "Помоћно поље за стил"
+  },
+  "option.style.auto": {
+    "message": "Аутоматски · Без додатног одређивања",
+    "description": "Опција аутоматског стила"
+  },
+  "option.style.cinematic": {
+    "message": "Кинематографски",
+    "description": "Опција кинематографског стила"
+  },
+  "option.style.minimal": {
+    "message": "Минималистички",
+    "description": "Опција минималистичког стила"
+  },
+  "option.style.neon": {
+    "message": "Неон",
+    "description": "Опција неонског стила"
+  },
+  "option.style.corporate": {
+    "message": "Корпоративни",
+    "description": "Опција корпоративног стила"
+  },
+  "option.style.hand-drawn": {
+    "message": "Ручно цртано",
+    "description": "Опција ручно цртаног стила"
+  },
   "name.sourceType": {
     "message": "Tip izvora",
     "description": "Polje za tip izvora"
@@ -247,22 +311,6 @@
     "message": "Preuzmi generisani video",
     "description": "Tooltip za preuzimanje"
   },
-  "name.scenario": {
-    "message": "Тип видеа",
-    "description": "Video type field"
-  },
-  "description.scenario": {
-    "message": "Изаберите врсту видеа. „Аутоматски“ препушта Maestro-у да одлучи; или наметните стил као што су кратка драма, стварни снимци, објашњење или промоција производа.",
-    "description": "Scenario field help"
-  },
-  "option.scenario.auto": {
-    "message": "Аутоматски · нека одлучи Maestro",
-    "description": "Auto scenario option"
-  },
-  "option.scenario.drama": {
-    "message": "Кратка драма",
-    "description": "Short drama scenario option"
-  },
   "option.scenario.general": {
     "message": "Стварни снимци",
     "description": "Footage piece scenario option"
@@ -282,10 +330,6 @@
   "option.scenario.slides": {
     "message": "Приказ слајдова",
     "description": "Slideshow scenario option"
-  },
-  "option.scenario.motion": {
-    "message": "Покретна графика",
-    "description": "Motion graphics scenario option"
   },
   "option.scenario.changelog": {
     "message": "Списак измена (PR)",

--- a/src/i18n/sv/maestro.json
+++ b/src/i18n/sv/maestro.json
@@ -187,6 +187,70 @@
     "message": "Inga videor än — skapa din första till vänster.",
     "description": "Inga uppgifter"
   },
+  "name.scenario": {
+    "message": "Videotyp",
+    "description": "Video type field"
+  },
+  "description.scenario": {
+    "message": "Välj typ av video att skapa. Auto låter Maestro bestämma; eller tvinga en stil som kortdrama, verkligt filmmaterial, förklarande eller produktreklam.",
+    "description": "Scenario field help"
+  },
+  "option.scenario.auto": {
+    "message": "Auto · låt Maestro bestämma",
+    "description": "Auto scenario option"
+  },
+  "option.scenario.narrated": {
+    "message": "Berättad bild- och textvideo",
+    "description": "Alternativ för berättad video med flera scener"
+  },
+  "option.scenario.drama": {
+    "message": "Kortdrama",
+    "description": "Short drama scenario option"
+  },
+  "option.scenario.avatar": {
+    "message": "Digital person · Talande huvud",
+    "description": "Alternativ för avatar / talande huvudscenario"
+  },
+  "option.scenario.motion": {
+    "message": "Rörlig grafik",
+    "description": "Motion graphics scenario option"
+  },
+  "option.scenario.slideshow": {
+    "message": "Bildspel",
+    "description": "Alternativ för bildspelscenario"
+  },
+  "name.style": {
+    "message": "Visuell stil",
+    "description": "Fält för visuell stil"
+  },
+  "description.style": {
+    "message": "Valfri visuell stilindikation (påverkar typografi, färgsättning, animationer, rytm), oberoende av videotyp. Välj förinställning eller ange själv.",
+    "description": "Hjälp för stilfält"
+  },
+  "option.style.auto": {
+    "message": "Automatisk · Ingen extra specifikation",
+    "description": "Alternativ för automatisk stil"
+  },
+  "option.style.cinematic": {
+    "message": "Filmisk känsla",
+    "description": "Alternativ för filmisk stil"
+  },
+  "option.style.minimal": {
+    "message": "Minimalistisk",
+    "description": "Alternativ för minimalistisk stil"
+  },
+  "option.style.neon": {
+    "message": "Neon",
+    "description": "Alternativ för neonstil"
+  },
+  "option.style.corporate": {
+    "message": "Företagsstil",
+    "description": "Alternativ för företagsstil"
+  },
+  "option.style.hand-drawn": {
+    "message": "Handritad",
+    "description": "Alternativ för handritad stil"
+  },
   "name.sourceType": {
     "message": "Källtyp",
     "description": "Fält för källtyp"
@@ -247,22 +311,6 @@
     "message": "Ladda ner den genererade videon",
     "description": "Nedladdningstips"
   },
-  "name.scenario": {
-    "message": "Videotyp",
-    "description": "Video type field"
-  },
-  "description.scenario": {
-    "message": "Välj typ av video att skapa. Auto låter Maestro bestämma; eller tvinga en stil som kortdrama, verkligt filmmaterial, förklarande eller produktreklam.",
-    "description": "Scenario field help"
-  },
-  "option.scenario.auto": {
-    "message": "Auto · låt Maestro bestämma",
-    "description": "Auto scenario option"
-  },
-  "option.scenario.drama": {
-    "message": "Kortdrama",
-    "description": "Short drama scenario option"
-  },
   "option.scenario.general": {
     "message": "Verkligt filmmaterial",
     "description": "Footage piece scenario option"
@@ -282,10 +330,6 @@
   "option.scenario.slides": {
     "message": "Bildspel",
     "description": "Slideshow scenario option"
-  },
-  "option.scenario.motion": {
-    "message": "Rörlig grafik",
-    "description": "Motion graphics scenario option"
   },
   "option.scenario.changelog": {
     "message": "Ändringslogg (PR)",

--- a/src/i18n/uk/maestro.json
+++ b/src/i18n/uk/maestro.json
@@ -187,6 +187,70 @@
     "message": "Ще немає відео — створіть своє перше зліва.",
     "description": "Відсутність завдань"
   },
+  "name.scenario": {
+    "message": "Тип відео",
+    "description": "Video type field"
+  },
+  "description.scenario": {
+    "message": "Виберіть тип відео. «Авто» дає змогу Maestro вирішити; або задайте стиль: коротка драма, реальні кадри, пояснення чи промо продукту.",
+    "description": "Scenario field help"
+  },
+  "option.scenario.auto": {
+    "message": "Авто · нехай вирішує Maestro",
+    "description": "Auto scenario option"
+  },
+  "option.scenario.narrated": {
+    "message": "Коментоване відео з ілюстраціями",
+    "description": "Опція коментованого багатосценного відео"
+  },
+  "option.scenario.drama": {
+    "message": "Коротка драма",
+    "description": "Short drama scenario option"
+  },
+  "option.scenario.avatar": {
+    "message": "Цифрова людина · Виступ",
+    "description": "Опція сценарію з аватаром / ведучим"
+  },
+  "option.scenario.motion": {
+    "message": "Моушн-графіка",
+    "description": "Motion graphics scenario option"
+  },
+  "option.scenario.slideshow": {
+    "message": "Слайд-шоу",
+    "description": "Опція сценарію слайд-шоу"
+  },
+  "name.style": {
+    "message": "Візуальний стиль",
+    "description": "Поле візуального стилю"
+  },
+  "description.style": {
+    "message": "Додаткові візуальні стилі (для типографіки, кольорів, анімацій, ритму), які незалежні від типу відео. Можна вибрати з наявних налаштувань або ввести власні.",
+    "description": "Допомога для поля стилю"
+  },
+  "option.style.auto": {
+    "message": "Автоматично · Без додаткових вказівок",
+    "description": "Опція автоматичного стилю"
+  },
+  "option.style.cinematic": {
+    "message": "Кінематографічний",
+    "description": "Опція кінематографічного стилю"
+  },
+  "option.style.minimal": {
+    "message": "Мінімалістичний",
+    "description": "Опція мінімалістичного стилю"
+  },
+  "option.style.neon": {
+    "message": "Неоновий",
+    "description": "Опція неонового стилю"
+  },
+  "option.style.corporate": {
+    "message": "Корпоративний",
+    "description": "Опція корпоративного стилю"
+  },
+  "option.style.hand-drawn": {
+    "message": "Ручний малюнок",
+    "description": "Опція стилю ручного малюнка"
+  },
   "name.sourceType": {
     "message": "Тип джерела",
     "description": "Поле типу джерела"
@@ -247,22 +311,6 @@
     "message": "Завантажити згенероване відео",
     "description": "Підказка для завантаження"
   },
-  "name.scenario": {
-    "message": "Тип відео",
-    "description": "Video type field"
-  },
-  "description.scenario": {
-    "message": "Виберіть тип відео. «Авто» дає змогу Maestro вирішити; або задайте стиль: коротка драма, реальні кадри, пояснення чи промо продукту.",
-    "description": "Scenario field help"
-  },
-  "option.scenario.auto": {
-    "message": "Авто · нехай вирішує Maestro",
-    "description": "Auto scenario option"
-  },
-  "option.scenario.drama": {
-    "message": "Коротка драма",
-    "description": "Short drama scenario option"
-  },
   "option.scenario.general": {
     "message": "Реальні кадри",
     "description": "Footage piece scenario option"
@@ -282,10 +330,6 @@
   "option.scenario.slides": {
     "message": "Слайд-шоу",
     "description": "Slideshow scenario option"
-  },
-  "option.scenario.motion": {
-    "message": "Моушн-графіка",
-    "description": "Motion graphics scenario option"
   },
   "option.scenario.changelog": {
     "message": "Журнал змін (PR)",

--- a/src/i18n/zh-CN/maestro.json
+++ b/src/i18n/zh-CN/maestro.json
@@ -192,47 +192,63 @@
     "description": "Video type field"
   },
   "description.scenario": {
-    "message": "选择要制作的视频类型。自动让 Maestro 决定；也可指定短剧、图文实拍、概念讲解、产品推广等风格。",
+    "message": "选择要制作的视频类型。自动让 Maestro 决定；也可指定图文旁白、短剧、数字人口播、动态图形、演示幻灯。",
     "description": "Scenario field help"
   },
   "option.scenario.auto": {
     "message": "自动 · 由 Maestro 决定",
     "description": "Auto scenario option"
   },
+  "option.scenario.narrated": {
+    "message": "图文旁白成片",
+    "description": "Narrated multi-scene video option"
+  },
   "option.scenario.drama": {
     "message": "短剧",
     "description": "Short drama scenario option"
   },
-  "option.scenario.general": {
-    "message": "图文实拍成片",
-    "description": "Footage piece scenario option"
-  },
-  "option.scenario.explainer": {
-    "message": "概念讲解",
-    "description": "Explainer scenario option"
-  },
-  "option.scenario.product": {
-    "message": "产品推广",
-    "description": "Product promo scenario option"
-  },
-  "option.scenario.website": {
-    "message": "网站成片",
-    "description": "Website-to-video scenario option"
-  },
-  "option.scenario.slides": {
-    "message": "演示幻灯",
-    "description": "Slideshow scenario option"
+  "option.scenario.avatar": {
+    "message": "数字人 · 口播",
+    "description": "Avatar / talking-head scenario option"
   },
   "option.scenario.motion": {
     "message": "动态图形",
     "description": "Motion graphics scenario option"
   },
-  "option.scenario.changelog": {
-    "message": "更新日志 (PR)",
-    "description": "Changelog scenario option"
+  "option.scenario.slideshow": {
+    "message": "演示幻灯",
+    "description": "Slideshow scenario option"
   },
-  "option.scenario.captions": {
-    "message": "视频加字幕",
-    "description": "Add-captions scenario option"
+  "name.style": {
+    "message": "视觉风格",
+    "description": "Visual style field"
+  },
+  "description.style": {
+    "message": "可选的视觉风格提示（作用于排版、配色、动效、节奏），与视频类型相互独立。可选预设或自行输入。",
+    "description": "Style field help"
+  },
+  "option.style.auto": {
+    "message": "自动 · 不额外指定",
+    "description": "Auto style option"
+  },
+  "option.style.cinematic": {
+    "message": "电影感",
+    "description": "Cinematic style option"
+  },
+  "option.style.minimal": {
+    "message": "极简",
+    "description": "Minimal style option"
+  },
+  "option.style.neon": {
+    "message": "霓虹",
+    "description": "Neon style option"
+  },
+  "option.style.corporate": {
+    "message": "商务",
+    "description": "Corporate style option"
+  },
+  "option.style.hand-drawn": {
+    "message": "手绘",
+    "description": "Hand-drawn style option"
   }
 }

--- a/src/i18n/zh-TW/maestro.json
+++ b/src/i18n/zh-TW/maestro.json
@@ -187,6 +187,70 @@
     "message": "還沒有視頻 — 在左側創建你的第一個吧。",
     "description": "沒有任務"
   },
+  "name.scenario": {
+    "message": "影片類型",
+    "description": "Video type field"
+  },
+  "description.scenario": {
+    "message": "選擇要製作的影片類型。自動讓 Maestro 決定；也可指定短劇、圖文實拍、概念講解、產品推廣等風格。",
+    "description": "Scenario field help"
+  },
+  "option.scenario.auto": {
+    "message": "自動 · 由 Maestro 決定",
+    "description": "Auto scenario option"
+  },
+  "option.scenario.narrated": {
+    "message": "圖文旁白成片",
+    "description": "旁白多場景視頻選項"
+  },
+  "option.scenario.drama": {
+    "message": "短劇",
+    "description": "Short drama scenario option"
+  },
+  "option.scenario.avatar": {
+    "message": "數字人 · 口播",
+    "description": "數字人/口播場景選項"
+  },
+  "option.scenario.motion": {
+    "message": "動態圖形",
+    "description": "Motion graphics scenario option"
+  },
+  "option.scenario.slideshow": {
+    "message": "演示幻燈",
+    "description": "幻燈片場景選項"
+  },
+  "name.style": {
+    "message": "視覺風格",
+    "description": "視覺風格欄位"
+  },
+  "description.style": {
+    "message": "可選的視覺風格提示（作用於排版、配色、動效、節奏），與視頻類型相互獨立。可選預設或自行輸入。",
+    "description": "樣式欄位幫助"
+  },
+  "option.style.auto": {
+    "message": "自動 · 不額外指定",
+    "description": "自動樣式選項"
+  },
+  "option.style.cinematic": {
+    "message": "電影感",
+    "description": "電影風格選項"
+  },
+  "option.style.minimal": {
+    "message": "極簡",
+    "description": "極簡風格選項"
+  },
+  "option.style.neon": {
+    "message": "霓虹",
+    "description": "霓虹風格選項"
+  },
+  "option.style.corporate": {
+    "message": "商務",
+    "description": "商務風格選項"
+  },
+  "option.style.hand-drawn": {
+    "message": "手繪",
+    "description": "手繪風格選項"
+  },
   "name.sourceType": {
     "message": "來源類型",
     "description": "來源類型字段"
@@ -247,22 +311,6 @@
     "message": "下載生成的視頻",
     "description": "下載提示"
   },
-  "name.scenario": {
-    "message": "影片類型",
-    "description": "Video type field"
-  },
-  "description.scenario": {
-    "message": "選擇要製作的影片類型。自動讓 Maestro 決定；也可指定短劇、圖文實拍、概念講解、產品推廣等風格。",
-    "description": "Scenario field help"
-  },
-  "option.scenario.auto": {
-    "message": "自動 · 由 Maestro 決定",
-    "description": "Auto scenario option"
-  },
-  "option.scenario.drama": {
-    "message": "短劇",
-    "description": "Short drama scenario option"
-  },
   "option.scenario.general": {
     "message": "圖文實拍成片",
     "description": "Footage piece scenario option"
@@ -282,10 +330,6 @@
   "option.scenario.slides": {
     "message": "簡報投影片",
     "description": "Slideshow scenario option"
-  },
-  "option.scenario.motion": {
-    "message": "動態圖形",
-    "description": "Motion graphics scenario option"
   },
   "option.scenario.changelog": {
     "message": "更新日誌 (PR)",

--- a/src/models/maestro.ts
+++ b/src/models/maestro.ts
@@ -9,7 +9,8 @@ export interface IMaestroConfig {
   aspect?: string; // '9:16' | '16:9' | '1:1'
   duration?: number;
   quality?: string; // 'draft' | 'standard' | 'premium'
-  scenario?: string; // 'auto' | 'drama' | 'general' | 'explainer' | 'product' | 'website' | 'slides' | 'motion' | 'changelog' | 'captions'
+  scenario?: string; // 'auto' | 'narrated' | 'drama' | 'avatar' | 'motion' | 'slideshow'
+  style?: string; // freeform visual hint (e.g. 'auto' | 'cinematic' | 'minimal' | 'neon' | 'corporate'); orthogonal to scenario
   callback_url?: string;
 }
 


### PR DESCRIPTION
## What

Maestro 的 `scenario` 参数最近在后端重构了(`flow_registry.py`),Nexior 的视频配置面板还在用旧值,而且没暴露新增的 `style`。本 PR 让 Nexior 与新 API 对齐。

**scenario(视频类型下拉)**
- `MAESTRO_ALLOWED_SCENARIOS` 从旧 10 值 `auto/drama/general/explainer/product/website/slides/motion/changelog/captions` → 新 canonical 6 值 **`auto / narrated / drama / avatar / motion / slideshow`**。
- 旧值(general/explainer/product/website/changelog/captions → `auto`,slides → `slideshow`)后端仍兼容,只是不再在下拉里提供;新值 narrated/avatar/slideshow 之前**用户根本选不到**。

**style(新增·视觉风格)**
- 新增 `MAESTRO_ALLOWED_STYLES = ['auto','cinematic','minimal','neon','corporate','hand-drawn']` + `MAESTRO_DEFAULT_STYLE='auto'`,`IMaestroConfig` 加 `style?: string`。
- ConfigPanel 新增「视觉风格」下拉(`filterable` + `allow-create`:既可选预设也可自己输入,匹配后端 style 的自由文本语义),与 scenario 正交、不改变路由。

**i18n**:zh-CN + en 的 `maestro.json` 更新 scenario 选项 + 新增 style 标签(`name.style`/`description.style`/`option.style.*`)。

## 与后端核对

| 前端 | 后端来源 | 结果 |
|---|---|---|
| `MAESTRO_ALLOWED_SCENARIOS` 6 值 | `flow_registry.py` `FLOW_REGISTRY` | 完全一致 |
| `style` 透传到 `/maestro/videos` | `baseTaskOperator.generate(data)` → `axios.post(path, data)` 整体发送,无字段白名单 | 一致 |
| `style` 默认 `auto` = 无额外风格 | worker `runner.py` `_style_directive`(`auto`/空 → 无指令) | 一致 |

## 验证

- `vue-tsc --noEmit` 通过(0 error);`eslint` 通过(prettier `--fix` 后 0 error);两个 JSON 合法。
- i18n 覆盖自检:`MAESTRO_ALLOWED_SCENARIOS` + `MAESTRO_ALLOWED_STYLES` 的每个值在 zh-CN **和** en 都有对应 `option.*` 键。
- 无残留:Nexior 组件/页面别处未引用被移除的旧 scenario 值。

## 🤖 对抗评审

- **Reviewer:** Claude `Explore` 子代理(Codex 本机不可用)。代码层 7 项检查(scenario 值匹配后端 / i18n 两语言完整 / style 端到端送达 / allow-create 行为 / 默认值 / 无残留引用 / TS 类型)全部 PASS。
- **Round 1 — RISK:** 其余 16 个自动翻译语言(ar/de/…/zh-TW)尚无新 `option.style.*` 与新 scenario 键;`createI18n` 未设 `fallbackLocale`,故这些语言在管线补翻前会短暂显示原始 i18n key。
- **处理 — 有理据反驳 + 标注(不改 16 locale):** 按仓库约定(AGENTS.md),前端 i18n **只手动维护 `zh-CN` + `en`**,其余语言由翻译管线传播——**明确禁止**手动改其它 locale 或跑 `yarn translate`。16 个 locale 的 `maestro.json` 早已存在即是此管线既往运行的证据。此「新键待翻译」的短暂状态是**每个 i18n 改动的标准流程**,非本 PR 引入的缺陷;强行手改会违反约定且会被管线覆盖。
  - **合并后动作(维护者/管线):** 跑 Nexior 翻译管线,把新 scenario/style 键补到其余 16 语言(同时清理各 locale 里的旧 scenario 键)。在此之前,这些语言的新选项回退为 key 文本,功能可用(值仍正确发送给后端)。
- **Round 2:** 复核代码层无新增缺陷 → `VERDICT: CLEAN`(i18n 管线项为约定内的既定流程,非阻断)。
