### PR TITLE
fix(aichat2): show client-tool screenshot live, not only after reload

### DIFF
--- a/change/@acedatacloud-nexior-aichat2-client-tool-screenshot-live.json
+++ b/change/@acedatacloud-nexior-aichat2-client-tool-screenshot-live.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(aichat2): render desktop client-tool screenshots live during streaming instead of only after a page reload",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -94,6 +94,10 @@ export interface IChatMessageContentItem {
   file_url?: { url: string } | string;
   name?: string;
   mimeType?: string;
+  // Alt text for an `image_url` block. The aichat2 worker sets this on a
+  // tool-result screenshot (`<tool_id> screenshot`); the frontend reuses it as
+  // a dedupe key when folding the same block locally on client-tool resume.
+  alt?: string;
   // Tool-calling fields (type='tool_use')
   tool_id?: string;
   tool_name?: string;

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -778,6 +778,13 @@ export default defineComponent({
       const lastAssistant = [...this.messages].reverse().find((m) => m.role === ROLE_ASSISTANT);
       if (lastAssistant && Array.isArray(lastAssistant.content)) {
         const content = lastAssistant.content as IChatMessageContentItem[];
+        // Collect tool-result screenshots here and append them AFTER folding
+        // every block, so they trail the tool_use blocks in the exact order
+        // the worker persists them (the worker buffers image blocks and pushes
+        // them once, post-loop — see conversations.ts). Interleaving per result
+        // would reorder images vs a reload when several parallel client tools
+        // return screenshots.
+        const imageBlocks: IChatMessageContentItem[] = [];
         for (const tr of toolResults) {
           const block = content.find((b) => b.type === 'tool_use' && b.tool_id === tr.tool_use_id);
           if (block) {
@@ -786,7 +793,26 @@ export default defineComponent({
             if (tr.is_error) block.is_error = true;
             delete block.pending_question;
           }
+          // Mirror the worker: a tool-result image (e.g. a computer.screenshot)
+          // is persisted as a trailing `image_url` block on the pause message,
+          // so a reload shows it. Buffer the same block locally so the live
+          // stream matches the reloaded view instead of only appearing after
+          // refresh. Idempotent by tool_use_id (a re-resume must not duplicate).
+          // Gate on the SAME validation the worker applies before persisting
+          // (`isValidResultImage`): if the worker would reject the value it
+          // won't persist it, so appending it locally would show live but
+          // vanish on reload — an inverse mismatch. Validating here keeps the
+          // two views identical and blocks any non-image URL from the <img>.
+          if (tr.image && this._isValidResultImage(tr.image)) {
+            const alt = `${tr.tool_use_id} screenshot`;
+            const already = content.some((b) => b.type === 'image_url' && b.alt === alt);
+            const buffered = imageBlocks.some((b) => b.alt === alt);
+            if (!already && !buffered) {
+              imageBlocks.push({ type: 'image_url', image_url: { url: tr.image }, alt });
+            }
+          }
         }
+        if (imageBlocks.length) content.push(...imageBlocks);
       }
       // Push fresh pending assistant message for the resumed turn.
       this.messages.push({
@@ -944,6 +970,21 @@ export default defineComponent({
       // Stop pressed while the last tool was running → don't resume the turn.
       if (runId !== undefined && runId !== this.clientToolRunId) return;
       this._resumeWithToolResults(results, conversationId);
+    },
+    /**
+     * Mirror of the aichat2 worker's `isValidResultImage` guard. The worker
+     * persists a tool-result screenshot as an `image_url` block ONLY when the
+     * value is a whitespace-free `https://` URL or a base64 raster
+     * `data:image/(png|jpeg|webp)` URI within the size cap; anything else it
+     * silently drops. The local fold gates on the same rule so the live view
+     * shows exactly what a reload would (no inverse mismatch) and no non-image
+     * URL ever reaches the `<img>` sink. Keep in sync with the worker.
+     */
+    _isValidResultImage(s: string): boolean {
+      const MAX_RESULT_IMAGE_CHARS = 6_000_000;
+      if (!s || s.length > MAX_RESULT_IMAGE_CHARS) return false;
+      if (s.startsWith('https://')) return !/\s/.test(s);
+      return /^data:image\/(png|jpe?g|webp);base64,[A-Za-z0-9+/]+={0,2}$/.test(s);
     },
     /**
      * Host a tool-result image (e.g. a computer.screenshot) on the platform


### PR DESCRIPTION
## 问题

aichat2 桌面端「computer use」客户端工具（如 `computer.screenshot`）返回的截图，在 **streaming 过程中不显示**，只有**刷新网页后**才出现。

## 根因

两条渲染路径不一致：

- **刷新后（服务端持久化的副本）**：worker 在客户端工具 resume 时，会把截图作为一个**尾随的 `image_url` 内容块**追加到暂停的 assistant 消息上并持久化（`PlatformService/aichat2/worker/src/handlers/conversations.ts` ~L435–444）。重新加载时，`Message.vue` 会把任意 `image_url` 项渲染成 `<img>` → 截图出现。
- **实时 streaming（本地折叠）**：`Conversation.vue` 的 `_resumeWithToolResults` 在本地折叠 `tool_use` 块时，只设置了 `output` / `is_error`，**从未把那个 `image_url` 块追加到本地消息**。于是直到刷新（重新拉取服务端副本）之前，实时视图里都是空的。

## 修复

在 `_resumeWithToolResults` 里，把带图的工具结果按 worker 完全相同的方式追加为本地 `image_url` 块，使实时视图与刷新后视图一致：

1. **门控校验**：新增 `_isValidResultImage`，逐字符镜像 worker 的 `isValidResultImage`（无空白的 `https://` 或 `data:image/(png|jpeg|webp);base64,…`，同样的 6MB 上限）。worker 会拒绝并**不持久化**不合法的值——本地也用同一规则门控，避免出现「实时显示但刷新消失」的反向不一致，同时确保没有非图片 URL 进入 `<img>` sink。
2. **顺序一致**：把图片块缓冲起来，在折叠完所有结果**之后**一次性追加（与 worker 的尾随顺序一致），这样多个并行客户端工具同时返回截图时，实时与刷新的顺序也不会错位。
3. **幂等**：以 `alt = '<tool_use_id> screenshot'` 为去重键（与 worker 的 alt 相同），re-resume 不会重复插入。
4. `IChatMessageContentItem` 增加可选 `alt?: string` 字段（worker 本就会设置该字段）。

纯前端改动，不涉及协议/后端。`vue-tsc --noEmit` 与 `eslint` 均通过。

## 🤖 对抗评审

Codex 本机未认证（401），按协议回退到独立 `general-purpose` 子代理评审，共 3 轮收敛。

**第 1 轮** — 2 处 `RISK`：

- **RISK（parity）**：本地追加未校验 `tr.image`，而 worker 用 `isValidResultImage` 校验并对不合法值**静默丢弃**；若 worker 拒绝该值，则「实时显示但刷新消失」——反向不一致。
  → **已修复**：新增 `_isValidResultImage`，镜像 worker 校验规则，作为本地追加的门控。
- **RISK（XSS）**：未校验的图片 URL 进入 `<img :src>`。
  → **部分反驳 + 已被门控覆盖**：`<img src>` 中的 `javascript:` 在现代浏览器不会执行，`data:text/html` 在 `img` 上不构成脚本上下文，Vue `:src` 绑定不是 HTML 注入 sink，故本身无实际 XSS；但新增的校验门控本就只放行图片 URL，该顾虑一并消除。

**第 2 轮** — 前两项确认关闭，新增 1 处 `RISK`：

- **RISK（ordering）**：worker 缓冲全部图片块、在折叠完所有结果后一次性追加（尾随）；而本地是在每个结果后就地插入（交错）。多个并行客户端工具同时返回截图时，实时与刷新的图片顺序会不同。
  → **已修复**：本地也改为缓冲、循环后一次性追加，与 worker 顺序一致。

**第 3 轮** — 全部 `RISK` 关闭，`_isValidResultImage` 与 worker 逐字符一致、`tr.tool_use_id == blk.tool_id`（parity 成立）、`_hostToolResultImage` 的两种返回（https / data:）均被放行（无误杀），`content.push` 对已有响应式数组足以触发 Options API 重渲染。**VERDICT: CLEAN**。
