### PR TITLE
feat(maestro): scenario picker as preview-image cards instead of a dropdown

### DIFF
--- a/change/@acedatacloud-nexior-3f8c84c4-c7c6-40fc-a973-acb19fcdecae.json
+++ b/change/@acedatacloud-nexior-3f8c84c4-c7c6-40fc-a973-acb19fcdecae.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(maestro): scenario picker as preview-image cards instead of a dropdown",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/maestro/ConfigPanel.vue
+++ b/src/components/maestro/ConfigPanel.vue
@@ -106,19 +106,31 @@
       </div>
 
       <!-- Scenario (video type) -->
-      <div class="field-row">
-        <div class="field-head">
+      <div class="field-block mb-5">
+        <div class="field-head mb-2">
           <h2 class="field-title font-bold">{{ $t('maestro.name.scenario') }}</h2>
           <info-icon :content="$t('maestro.description.scenario')" class="ml-1" />
         </div>
-        <el-select v-model="scenario" class="field-control">
-          <el-option
+        <div class="scenario-cards" role="radiogroup" :aria-label="$t('maestro.name.scenario')">
+          <div
             v-for="s in MAESTRO_ALLOWED_SCENARIOS"
             :key="s"
-            :label="$t(`maestro.option.scenario.${s}`)"
-            :value="s"
-          />
-        </el-select>
+            class="scenario-card"
+            :class="{ active: scenario === s }"
+            role="radio"
+            :aria-checked="scenario === s"
+            :aria-label="$t(`maestro.option.scenario.${s}`)"
+            tabindex="0"
+            @click="scenario = s"
+            @keydown.enter.prevent="scenario = s"
+            @keydown.space.prevent="scenario = s"
+          >
+            <div class="scenario-thumb">
+              <img :src="MAESTRO_SCENARIO_THUMBNAILS[s]" :alt="$t(`maestro.option.scenario.${s}`)" loading="lazy" />
+            </div>
+            <p class="scenario-name">{{ $t(`maestro.option.scenario.${s}`) }}</p>
+          </div>
+        </div>
       </div>
 
       <!-- Style (visual direction) -->
@@ -171,6 +183,7 @@ import {
   MAESTRO_ALLOWED_QUALITIES,
   MAESTRO_DEFAULT_QUALITY,
   MAESTRO_ALLOWED_SCENARIOS,
+  MAESTRO_SCENARIO_THUMBNAILS,
   MAESTRO_DEFAULT_SCENARIO,
   MAESTRO_ALLOWED_STYLES,
   MAESTRO_DEFAULT_STYLE
@@ -206,6 +219,7 @@ export default defineComponent({
       MAESTRO_MAX_DURATION,
       MAESTRO_ALLOWED_QUALITIES,
       MAESTRO_ALLOWED_SCENARIOS,
+      MAESTRO_SCENARIO_THUMBNAILS,
       MAESTRO_ALLOWED_STYLES
     };
   },
@@ -403,6 +417,63 @@ export default defineComponent({
 
     .ratio-rect {
       border-color: var(--el-color-primary);
+    }
+  }
+}
+.scenario-cards {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 10px;
+}
+.scenario-card {
+  border: 1px solid var(--el-border-color);
+  background-color: var(--el-fill-color-lighter);
+  border-radius: 10px;
+  overflow: hidden;
+  cursor: pointer;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+
+  .scenario-thumb {
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    background-color: var(--el-fill-color);
+    overflow: hidden;
+
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    }
+  }
+
+  .scenario-name {
+    font-size: 12px;
+    margin: 0;
+    padding: 6px 8px;
+    text-align: center;
+    color: var(--el-text-color-primary);
+  }
+
+  &:hover {
+    border-color: var(--el-color-primary-light-5);
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: var(--el-color-primary);
+    box-shadow: 0 0 0 2px var(--el-color-primary-light-7);
+  }
+
+  &.active {
+    border-color: var(--el-color-primary);
+    box-shadow: 0 0 0 1px var(--el-color-primary);
+
+    .scenario-name {
+      color: var(--el-color-primary);
+      font-weight: 600;
     }
   }
 }

--- a/src/constants/maestro.ts
+++ b/src/constants/maestro.ts
@@ -18,6 +18,15 @@ export const MAESTRO_ALLOWED_QUALITIES = ['draft', 'standard', 'premium'];
 // Legacy values (general/explainer/product/website/changelog/captions -> auto, slides -> slideshow)
 // are still accepted by the API but no longer offered here.
 export const MAESTRO_ALLOWED_SCENARIOS = ['auto', 'narrated', 'drama', 'avatar', 'motion', 'slideshow'];
+// Preview thumbnail per scenario (cohesive illustrations hosted on the CDN, like MAESTRO_LOGO).
+export const MAESTRO_SCENARIO_THUMBNAILS: Record<string, string> = {
+  auto: 'https://cdn.acedata.cloud/f61b85476e.png',
+  narrated: 'https://cdn.acedata.cloud/2e94e507eb.png',
+  drama: 'https://cdn.acedata.cloud/279a8a0189.png',
+  avatar: 'https://cdn.acedata.cloud/c633f9e39c.png',
+  motion: 'https://cdn.acedata.cloud/ab9dc386b6.png',
+  slideshow: 'https://cdn.acedata.cloud/581b2148f5.png'
+};
 // Visual style hint (freeform on the API; these are quick presets). Orthogonal to scenario routing.
 export const MAESTRO_ALLOWED_STYLES = ['auto', 'cinematic', 'minimal', 'neon', 'corporate', 'hand-drawn'];
 


### PR DESCRIPTION
## What

把 maestro 视频配置面板里的 **scenario(视频类型)从下拉框换成可视化缩略图卡片**——每个类型配一张预览图,更直观地「选风格」。

- 为 6 个 scenario 各生成一张**风格统一**的预览缩略图(gpt-image-2,统一靛蓝/紫 + 青/珊瑚配色的扁平插画,无文字),上传到 `cdn.acedata.cloud`(永久,与现有 `MAESTRO_LOGO` 同源)。
- 新增常量 `MAESTRO_SCENARIO_THUMBNAILS`(scenario → CDN url)。
- `ConfigPanel.vue`:scenario 的 `<el-select>` → `.scenario-cards` 卡片网格(2 列,缩略图 16:9 + 类型名),沿用画面比例 `ratio-item` 的交互(点击/键盘选择、active/hover/focus 态、`role=radiogroup/radio` + `aria-checked` 无障碍)。
- `scenario` 双向绑定、默认值、计费预览均不变;`style` 保持下拉(自由文本)。

## 缩略图

| scenario | 预览 |
|---|---|
| auto | https://cdn.acedata.cloud/f61b85476e.png |
| narrated | https://cdn.acedata.cloud/2e94e507eb.png |
| drama | https://cdn.acedata.cloud/279a8a0189.png |
| avatar | https://cdn.acedata.cloud/c633f9e39c.png |
| motion | https://cdn.acedata.cloud/ab9dc386b6.png |
| slideshow | https://cdn.acedata.cloud/581b2148f5.png |

## 验证

- `eslint --fix` 通过(0 error);`vue-tsc --noEmit` 通过(0 error)。
- **无新增 i18n 键**(复用现有 `option.scenario.*` 标签)→ 不触发 16 语言翻译。
- `MAESTRO_SCENARIO_THUMBNAILS` 覆盖 `MAESTRO_ALLOWED_SCENARIOS` 全部 6 值,URL 互不相同。

## 🤖 对抗评审

- **Reviewer:** Claude `Explore` 子代理(Codex 本机不可用)。
- 8 项检查全过:6 缩略图键与 scenario 集一一对应、`MAESTRO_SCENARIO_THUMBNAILS` 经 `@/constants` barrel 导出且在 `data()` 可达、`scenario` computed 双向绑定保留、`ElSelect/ElOption` 仍被 langs/quality/style 用到无悬空导入、无障碍(radiogroup/radio + aria-checked + enter/space)完整、SCSS 无冲突、CDN URL 规范且 distinct、无新增 `$t` 键。
- **VERDICT: CLEAN**(一轮收敛,无 RISK)。
