### PR TITLE
feat(maestro): show input reference files in task history

### DIFF
--- a/change/@acedatacloud-nexior-eea36931-88d9-4c62-ac26-67afdefc4734.json
+++ b/change/@acedatacloud-nexior-eea36931-88d9-4c62-ac26-67afdefc4734.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Show input reference files (images/video/audio/documents) in the Maestro task history",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/maestro/task/Preview.vue
+++ b/src/components/maestro/task/Preview.vue
@@ -11,12 +11,26 @@
         </span>
       </div>
       <div class="info">
+        <div v-if="files.length" class="flex justify-start items-center gap-2 mt-2 w-full overflow-x-auto">
+          <template v-for="(file, idx) in files" :key="idx">
+            <image-preview v-if="file.kind === 'image'" :url="file.url" :name="file.name" :closable="false" />
+            <video-preview v-else-if="file.kind === 'video'" :url="file.url" :name="file.name" />
+            <audio-preview v-else-if="file.kind === 'audio'" :url="file.url" :name="file.name" />
+            <a
+              v-else
+              :href="file.url"
+              :title="file.name"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="shrink-0 no-underline"
+            >
+              <file-preview :name="file.name" :closable="false" />
+            </a>
+          </template>
+        </div>
         <p v-if="modelValue?.request?.prompt" class="prompt mt-2">
           {{ modelValue?.request?.prompt }}
           <span v-if="!isTerminal" class="progress-pct"> · {{ progressText }}</span>
-        </p>
-        <p v-if="fileCount" class="text-xs text-[var(--el-text-color-secondary)] mb-1">
-          <font-awesome-icon icon="fa-solid fa-paperclip" class="mr-1" />{{ fileCount }}
         </p>
       </div>
 
@@ -110,9 +124,21 @@ import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import VideoPlayer from '@/components/common/VideoPlayer.vue';
 import ApiCodeButton from '@/components/common/ApiCodeButton.vue';
+import ImagePreview from '@/components/common/ImagePreview.vue';
+import AudioPreview from '@/components/common/AudioPreview.vue';
+import VideoPreview from '@/components/common/VideoPreview.vue';
+import FilePreview from '@/components/common/FilePreview.vue';
+import { isImageUrl, isVideoUrl, isAudioUrl } from '@/utils/is';
 import ProgressSteps from './ProgressSteps.vue';
 
 const TERMINAL = ['succeeded', 'failed'];
+
+type MaestroFileKind = 'image' | 'video' | 'audio' | 'file';
+interface IMaestroInputFile {
+  url: string;
+  name: string;
+  kind: MaestroFileKind;
+}
 
 export default defineComponent({
   name: 'TaskPreview',
@@ -124,6 +150,10 @@ export default defineComponent({
     VideoPlayer,
     ElButton,
     ApiCodeButton,
+    ImagePreview,
+    AudioPreview,
+    VideoPreview,
+    FilePreview,
     ProgressSteps
   },
   props: {
@@ -141,8 +171,21 @@ export default defineComponent({
     variants(): IMaestroVariant[] {
       return this.modelValue?.response?.data?.variants || [];
     },
-    fileCount(): number {
-      return this.modelValue?.request?.file_urls?.length || 0;
+    files(): IMaestroInputFile[] {
+      const urls = this.modelValue?.request?.file_urls || [];
+      return urls
+        .filter((url): url is string => !!url)
+        .map((url) => {
+          const clean = url.split('?')[0].split('#')[0];
+          const kind: MaestroFileKind = isImageUrl(clean)
+            ? 'image'
+            : isVideoUrl(clean)
+              ? 'video'
+              : isAudioUrl(clean)
+                ? 'audio'
+                : 'file';
+          return { url, name: this.fileName(clean), kind };
+        });
     },
     isTerminal(): boolean {
       return TERMINAL.includes(this.modelValue?.status || '');
@@ -168,6 +211,14 @@ export default defineComponent({
     }
   },
   methods: {
+    fileName(url: string): string {
+      const base = url.substring(url.lastIndexOf('/') + 1);
+      try {
+        return decodeURIComponent(base) || url;
+      } catch {
+        return base || url;
+      }
+    },
     onDownload(event: MouseEvent, url: string) {
       event?.stopPropagation();
       window.open(url, '_blank');

--- a/src/utils/is.ts
+++ b/src/utils/is.ts
@@ -84,3 +84,23 @@ export function isImageUrl(url: string | undefined): boolean {
   }
   return /\.(jpg|jpeg|png|gif|bmp|webp|svg|tiff|ico|heic?)$/i.test(url.toLowerCase());
 }
+
+/**
+ * is video url
+ */
+export function isVideoUrl(url: string | undefined): boolean {
+  if (!url) {
+    return false;
+  }
+  return /\.(mp4|mov|webm|mkv|avi|m4v|flv)$/i.test(url.toLowerCase());
+}
+
+/**
+ * is audio url
+ */
+export function isAudioUrl(url: string | undefined): boolean {
+  if (!url) {
+    return false;
+  }
+  return /\.(mp3|wav|m4a|aac|ogg|flac|weba)$/i.test(url.toLowerCase());
+}


### PR DESCRIPTION
## What

Maestro video tasks accept reference uploads (images / video / audio), but the task history only showed a paperclip + a file **count**. This renders each input file as a rich thumbnail — exactly like the Seedance and NanoBanana task views already do for their reference inputs.

Mapping (by URL extension):

| Input | Component |
|---|---|
| image | `ImagePreview` |
| video | `VideoPreview` (click → player dialog) |
| audio | `AudioPreview` (click → play) |
| anything else / document | `FilePreview` in a `rel="noopener noreferrer"` anchor (click → open) |

The previews render in a single horizontally-scrolling row above the prompt, matching the reference pattern.

## Changes

- `src/components/maestro/task/Preview.vue` — replace the `fileCount` paperclip line with a `files` computed that maps `request.file_urls` → `{ url, name, kind }` and renders the matching preview component. Adds `fileName()` helper (basename from URL).
- `src/utils/is.ts` — add `isVideoUrl` / `isAudioUrl` next to the existing `isImageUrl` (used for classification).

## Verification

- `eslint` — clean (exit 0)
- `vue-tsc --noEmit` — clean (exit 0)
- Behavior matches `seedance/task/Preview.vue` and `nanobanana/task/Preview.vue` input rows.

## 🤖 对抗评审

Reviewer: Codex unavailable (401 unauth) → fell back to an independent read-only subagent. 2 rounds, converged.

**Round 1 — 3 RISKs, all fixed:**
1. `RISK: <file-preview @click> may not fire` — FilePreview declares only `emits:['remove']`, so `@click` relies on Vue attribute fallthrough (works, but implicit/fragile). **Fixed:** wrapped `FilePreview` in a native `<a :href target="_blank" rel="noopener noreferrer">` and deleted the `onOpenFile` method.
2. `RISK: flex-wrap + overflow-x-auto contradict` — reference rows use `overflow-x-auto` only. **Fixed:** dropped `flex-wrap` for a single scrolling row.
3. `RISK: window.open tabnabbing (no rel=noopener)` — **Fixed** for the new path by using the native anchor with `rel="noopener noreferrer"` (no `window.open`). Pre-existing `onDownload` left as-is (out of scope, matches codebase convention).

**Round 2 — `VERDICT: CLEAN`** (onOpenFile fully removed; anchor/`shrink-0`/`no-underline` valid; no color/underline leak into FilePreview text since it uses `--el-text-color-primary`; classification case-insensitive; imports/registration complete; no template errors).
