### PR TITLE
fix(settings): make the Memory list readable with a card + dividers

### DIFF
--- a/change/@acedatacloud-nexior-bf004cfc-b298-486e-83d6-b6c5d0b25ff6.json
+++ b/change/@acedatacloud-nexior-bf004cfc-b298-486e-83d6-b6c5d0b25ff6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Restyle the Memory settings list with a bordered card and dividers for readability",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/setting/Memory.vue
+++ b/src/components/setting/Memory.vue
@@ -123,18 +123,71 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .memory-setting {
-  .memory-row {
+  .hint {
+    margin: 0;
+    font-size: 13px;
+    line-height: 1.6;
+  }
+
+  .muted {
+    color: var(--el-text-color-secondary, #909399);
+  }
+
+  .section-head {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    justify-content: space-between;
+    gap: 12px;
 
-    .memory-content {
-      flex: 1;
-      word-break: break-word;
+    h3 {
+      margin: 0;
+      font-size: 15px;
+      font-weight: 600;
+    }
+  }
+
+  // Bordered card so the list reads as one contained group instead of text
+  // running flush against the dialog; rows are separated by hairline dividers.
+  .rows {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    border: 1px solid var(--el-border-color-lighter, #ebeef5);
+    border-radius: 8px;
+    overflow: hidden;
+  }
+
+  .memory-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 12px 14px;
+    border-bottom: 1px solid var(--el-border-color-lighter, #ebeef5);
+    transition: background-color 0.15s ease;
+
+    &:last-child {
+      border-bottom: none;
+    }
+
+    &:hover {
+      background: var(--el-fill-color-light, #f5f7fa);
     }
 
     .row-icon {
-      opacity: 0.6;
+      flex-shrink: 0;
+      margin-top: 3px;
+      color: var(--el-text-color-secondary, #909399);
+    }
+
+    .memory-content {
+      flex: 1;
+      min-width: 0;
+      line-height: 1.6;
+      overflow-wrap: break-word;
+    }
+
+    :deep(.el-button) {
+      flex-shrink: 0;
     }
   }
 }


### PR DESCRIPTION
## What & why

The **Memory** settings tab looked cramped and ugly — entries stacked flush against
each other with no separation. Root cause: the template uses `.rows` / `.row`
classes, but the only styling for those lives in the **scoped** style block of the
sibling `LocalTools.vue`, so it never reached `Memory.vue`. On top of that,
`.section-head` and `.muted` weren't styled here either, so the "Saved memories"
heading + "Clear all" button weren't laid out and the intro text wasn't muted.

## Change (CSS-only, `Memory.vue` scoped styles)

- **Bordered rounded card** around the list (`.rows`) so it reads as one contained group.
- **Hairline dividers** between entries (`.memory-row` `border-bottom`, `:last-child` none) — the "加条线" the list was missing.
- **Roomier padding** (`12px 14px`) + `line-height: 1.6` so long memories breathe.
- Subtle **hover** highlight per row.
- Proper **flex `.section-head`** (heading left, "Clear all" pushed right).
- **Muted** intro paragraph.
- Icon top-aligned for multi-line entries; content uses `flex:1; min-width:0` to wrap.

All colors use **Element Plus CSS vars** (`--el-border-color-lighter`,
`--el-fill-color-light`, `--el-text-color-secondary`) so it stays correct in dark mode.
Mirrors the design vocabulary already used in `LocalTools.vue`.

No template / logic / i18n changes. ESLint + Prettier clean.

## 🤖 对抗评审

Reviewer: Codex unavailable on this host (`401 Unauthorized`) → fell back to a
read-only `general-purpose` subagent (per `.claude/commands/auto-review.md`).

- **RISK** — `.memory-content` used `word-break: break-word`, a non-standard/deprecated
  value (carried over from the original code). **Fixed** → switched to the standard
  `overflow-wrap: break-word`, which is the correct way to wrap long prose with the
  occasional long token/URL.
- Verified clean: every selector matches a real template element; theme-safe CSS vars
  with fallbacks; `:deep(.el-button)` correctly scoped under `.memory-row` (does not
  leak to the "Clear all" button); no scoped-style leakage; wrapping/alignment correct.

Re-review after the fix: `VERDICT: CLEAN`.
