### PR TITLE
fix(chat): stop the aichat send button greying out (txt-upload percentage bug + transient getApplications wipe)

### DIFF
--- a/change/@acedatacloud-nexior-7e347b2b-ca12-4125-9aec-5e14b8258183.json
+++ b/change/@acedatacloud-nexior-7e347b2b-ca12-4125-9aec-5e14b8258183.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(chat): don't wipe selected application on transient getApplications failure — fixes intermittently greyed-out send button",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/Composer.vue
+++ b/src/components/chat/Composer.vue
@@ -234,10 +234,12 @@ export default defineComponent({
       return out;
     },
     uploading() {
-      // if at least file is uploading, return true
-      return !!this.fileList.find(
-        (file) => file.percentage !== undefined && file.percentage >= 0 && file.percentage < 100
-      );
+      // Gate on the reliable `status` field, NOT `percentage`. A tiny file (e.g. a
+      // .txt) can finish so fast the browser fires no final progress event, so
+      // element-plus leaves `percentage` < 100 on a fully-uploaded file — which
+      // used to pin `uploading` true and grey the send button forever. Failed
+      // uploads are auto-removed by element-plus, so only in-flight files count.
+      return this.fileList.some((file) => file.status === 'ready' || file.status === 'uploading');
     },
     extensions() {
       if (this.isFileSupported === false && this.isImageSupported === true) {

--- a/src/store/chat/actions.ts
+++ b/src/store/chat/actions.ts
@@ -116,10 +116,12 @@ export const getApplications = async ({
     console.debug('set applications for chat', applications.items);
     return applications.items;
   } catch (error) {
+    // Keep the last-known application on a transient refresh failure — this runs
+    // on a balance timer / tab focus / after every turn, and wiping it flips the
+    // composer's `ready` to false, permanently greying the send button (Main.vue
+    // refreshBalances can't recover it) until a full remount.
     console.error('get applications failed for chat', error);
     state.status.getApplications = Status.Error;
-    commit('setApplications', undefined);
-    commit('setApplication', undefined);
   }
 };
 


### PR DESCRIPTION
## Symptom

Customers in Studio (studio.acedata.cloud) reported the **aichat send button frequently greys out / can't be clicked** — most reproducibly **right after uploading a `.txt` file** ("上传 txt 就出现，按钮灰了半小时"). This PR fixes **two independent root causes** that both disable the send button.

The send button is disabled by:
```ts
:disabled="answering || !questionValue || uploading || !ready"
```

---

## Fix 1 (primary — the txt-upload case): `uploading` keyed on `percentage` instead of `status`

`Composer.vue`'s `uploading` computed used to be:
```ts
uploading = fileList.find(f => f.percentage !== undefined && f.percentage >= 0 && f.percentage < 100)
```

In element-plus 2.10.4 (`use-handlers.mjs`):
- a file is added with `percentage: 0`,
- `handleProgress` only updates `percentage` when the browser fires upload-progress events,
- `handleSuccess` sets `status: 'success'` but **never sets `percentage` to 100**,
- `handleError` **removes** failed files from the list.

A **tiny file (e.g. a `.txt`)** uploads so fast the browser fires **no final progress event**, so `percentage` stays `0` on a fully-succeeded upload. The old computed then evaluates `0 < 100 → true` **forever**, pinning the send button greyed until the file is removed or the page is reloaded — exactly the reported "greyed for half an hour".

**Fix:** gate on the reliable `status` field instead:
```ts
uploading = fileList.some(f => f.status === 'ready' || f.status === 'uploading')
```
Successful uploads (`status: 'success'`) no longer block sending regardless of `percentage`; failed uploads are already auto-removed by element-plus, so only genuinely in-flight files count.

---

## Fix 2 (related hardening): `getApplications` wiping the selected application on transient failure

The composer's `ready` flag is `!initializing && !!credential?.token && !!application`. The chat store `getApplications` runs frequently in the background (balance-refresh timer, tab-focus, after every turn). Its `catch` used to wipe `application` → `undefined` on any transient error (network blip / 429 / 5xx / token race), flipping `ready` to `false` and greying the send button — and `Main.vue.refreshBalances()` early-returns when the current application is undefined, so it never recovers until a full remount.

**Fix:** the `catch` now only records `Status.Error` and preserves the last-known `application`/`credential`. The genuine "no application" case returns HTTP 200 with an empty list (`Status.Success`), not an exception, so it is unaffected; the guest path (handled before the `try`) still clears state.

---

## Validation
- `eslint --fix` clean, `vue-tsc --noEmit` clean.
- element-plus upload behavior confirmed against the installed `element-plus@2.10.4` source (`use-handlers.mjs`).
- Beachball change file included.
