### PR TITLE
fix(nanobanana): render result when image data exists, not just on success flag

### DIFF
--- a/change/@acedatacloud-nexior-3700179b-3b1f-4e15-9d84-57031e58fbcc.json
+++ b/change/@acedatacloud-nexior-3700179b-3b1f-4e15-9d84-57031e58fbcc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(nanobanana): render result whenever image data exists, not only when response.success===true, so a failover-dropped success flag no longer hides a valid image",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/nanobanana/task/Preview.vue
+++ b/src/components/nanobanana/task/Preview.vue
@@ -28,7 +28,7 @@
           <span v-if="!modelValue?.response"> - ({{ $t('nanobanana.status.pending') }}) </span>
         </p>
       </div>
-      <div v-if="modelValue?.response?.success === true" :class="{ content: true, failed: true }">
+      <div v-if="showResult" :class="{ content: true, failed: true }">
         <div class="flex justify-start items-center gap-4 w-full overflow-x-auto">
           <image-wrapper
             v-for="(image, imageIndex) in images"
@@ -138,7 +138,7 @@
           </p>
         </el-alert>
       </div>
-      <div v-else :class="{ content: true }">
+      <div v-else-if="modelValue?.response" :class="{ content: true }">
         <el-alert :closable="false" class="info">
           <template #template>
             <font-awesome-icon icon="fa-solid fa-exclamation-triangle" class="mr-1" />
@@ -217,6 +217,20 @@ export default defineComponent({
         });
       }
       return result;
+    },
+    // Show the result view when the task explicitly succeeded, OR when image
+    // data is present and it is not an explicit failure. A router failover write
+    // can drop the `success` flag while still storing a valid image, so keying
+    // render off the actual data (not only the boolean) stops a valid result
+    // from being hidden as a "failure". Explicit `success === false` always wins.
+    hasImages(): boolean {
+      return this.images.some((image) => !!image?.image_url);
+    },
+    showResult(): boolean {
+      const response = this.modelValue?.response;
+      if (!response) return false;
+      if (response.success === true) return true;
+      return this.hasImages && response.success !== false;
     }
   },
   methods: {


### PR DESCRIPTION
## 背景 / 现象

studio 里 nano-banana 生图任务出现「结果图先出现、过一会又消失（变回失败态）」。

排查任务 `bad8993c-1e1a-4b7d-8216-7ffb4eb6f88a`：图其实生成成功且仍存在（`response.data[0].image_url` 指向的图 HTTP 200、6.1MB 有效），但存储的任务 `response` 里缺了 `success` 字段（失败转移写入把它丢了，见配套 PlatformService PR #1386）。而 `Preview.vue` 只在 `response.success === true` 时渲染图，缺 flag 就把有效结果当「失败」展示；5s 轮询 merge 拿到该文档后图就「消失」。

## 改动

不再单纯依赖 `success` 布尔位，改为按「是否真的有图」渲染：

- 新增 `showResult`：`response.success === true` **或**（有 `image_url` 且不是显式失败）时显示结果视图。
- 显式失败（`success === false`）始终优先走失败分支，即使带 data。
- `success:true` 但空 data 仍显示成功态（不回归）。
- pending（无 `response`）不再误显示「失败」提示，只保留已有的「- (pending)」。

仅改 `src/components/nanobanana/task/Preview.vue`（模板分支 + 两个 computed）。eslint / vue-tsc 通过。

## 关联

- 根因修复（后端）：https://github.com/AceDataCloud/PlatformService/pull/1386 （router 在持久化终态时补齐缺失的 `success`）。本前端 PR 是纵深防御——即便某条链路再次丢 flag，只要有有效图就照常显示。

## 🤖 对抗评审

独立 reviewer（subagent）一轮，相关 RISK：

- **RISK3（已修）**：原始「hasImages 优先」会把「带 data 的失败」误显示为成功。→ 引入 `showResult`，显式 `success === false` 优先走失败分支。
- **RISK4（已修）**：原始改动使「`success:true` + 空 data」回归成失败态。→ `showResult` 对 `success === true` 直接返回 true，保留成功态。
- **RISK5（rebut）**：`retrieve_batch` 返回稳定终态文档，唯一「丢 data」路径正是后端写竞争（#1386 已修）；不加前端 sticky-merge 以免掩盖真实失败。
- 非风险：`image_url` 走 `:src` 属性绑定，无 XSS；`hasImages` 已过滤无 `image_url` 项。

VERDICT: CLEAN（收敛）。