### PR TITLE
fix(maestro): sync Nexior scenarios to backend taxonomy + real-frame previews

### DIFF
--- a/change/@acedatacloud-nexior-215fdb14-17ff-40ca-885d-2a04696c1db1.json
+++ b/change/@acedatacloud-nexior-215fdb14-17ff-40ca-885d-2a04696c1db1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "sync maestro scenarios to backend taxonomy (drop slideshow, add captions) + real-frame preview thumbnails",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/maestro/ConfigPanel.vue
+++ b/src/components/maestro/ConfigPanel.vue
@@ -317,7 +317,11 @@ export default defineComponent({
       aspect: this.config?.aspect ?? MAESTRO_DEFAULT_ASPECT,
       duration: this.config?.duration ?? MAESTRO_DEFAULT_DURATION,
       quality: this.config?.quality ?? MAESTRO_DEFAULT_QUALITY,
-      scenario: this.config?.scenario ?? MAESTRO_DEFAULT_SCENARIO,
+      // Drop stale persisted scenarios (e.g. the removed `slideshow`) back to the default.
+      scenario:
+        this.config?.scenario && MAESTRO_ALLOWED_SCENARIOS.includes(this.config.scenario)
+          ? this.config.scenario
+          : MAESTRO_DEFAULT_SCENARIO,
       style: this.config?.style ?? MAESTRO_DEFAULT_STYLE
     });
   },

--- a/src/constants/maestro.ts
+++ b/src/constants/maestro.ts
@@ -15,17 +15,18 @@ export const MAESTRO_MAX_DURATION = 600;
 // Production tier (effort/price): draft = fast preview, standard = balanced, premium = richer.
 export const MAESTRO_ALLOWED_QUALITIES = ['draft', 'standard', 'premium'];
 // Video type: a routing hint. `auto` lets the director pick; the rest bias the route.
-// Legacy values (general/explainer/product/website/changelog/captions -> auto, slides -> slideshow)
+// Legacy values (general/explainer/product/website/changelog -> auto; slides/slideshow -> auto)
 // are still accepted by the API but no longer offered here.
-export const MAESTRO_ALLOWED_SCENARIOS = ['auto', 'narrated', 'drama', 'avatar', 'motion', 'slideshow'];
-// Preview thumbnail per scenario (cohesive illustrations hosted on the CDN, like MAESTRO_LOGO).
+export const MAESTRO_ALLOWED_SCENARIOS = ['auto', 'narrated', 'drama', 'avatar', 'motion', 'captions'];
+// Preview thumbnail per scenario — real frames from generated videos (narrated/drama/avatar/captions);
+// auto/motion stay as illustrations. Hosted on the CDN like MAESTRO_LOGO.
 export const MAESTRO_SCENARIO_THUMBNAILS: Record<string, string> = {
   auto: 'https://cdn.acedata.cloud/f61b85476e.png',
-  narrated: 'https://cdn.acedata.cloud/2e94e507eb.png',
-  drama: 'https://cdn.acedata.cloud/279a8a0189.png',
-  avatar: 'https://cdn.acedata.cloud/c633f9e39c.png',
+  narrated: 'https://cdn.acedata.cloud/db6ef158be.jpg',
+  drama: 'https://cdn.acedata.cloud/af85b29164.jpg',
+  avatar: 'https://cdn.acedata.cloud/7ae3e94d5a.jpg',
   motion: 'https://cdn.acedata.cloud/ab9dc386b6.png',
-  slideshow: 'https://cdn.acedata.cloud/581b2148f5.png'
+  captions: 'https://cdn.acedata.cloud/9a6d16d9f3.jpg'
 };
 // Visual style hint (freeform on the API; these are quick presets). Orthogonal to scenario routing.
 export const MAESTRO_ALLOWED_STYLES = ['auto', 'cinematic', 'minimal', 'neon', 'corporate', 'hand-drawn'];

--- a/src/i18n/en/maestro.json
+++ b/src/i18n/en/maestro.json
@@ -192,7 +192,7 @@
     "description": "Video type field"
   },
   "description.scenario": {
-    "message": "Pick the kind of video to make. Auto lets Maestro decide; or force narrated footage, short drama, a talking-head avatar, motion graphics or a slideshow.",
+    "message": "Pick the kind of video to make. Auto lets Maestro decide; or force narrated footage, short drama, a talking-head avatar, motion graphics or on-screen captions.",
     "description": "Scenario field help"
   },
   "option.scenario.auto": {
@@ -215,9 +215,9 @@
     "message": "Motion Graphics",
     "description": "Motion graphics scenario option"
   },
-  "option.scenario.slideshow": {
-    "message": "Slideshow",
-    "description": "Slideshow scenario option"
+  "option.scenario.captions": {
+    "message": "Captions · Kinetic",
+    "description": "Captions scenario option (add captions/subtitles to an existing talking-head video)"
   },
   "name.style": {
     "message": "Visual Style",

--- a/src/i18n/zh-CN/maestro.json
+++ b/src/i18n/zh-CN/maestro.json
@@ -192,7 +192,7 @@
     "description": "Video type field"
   },
   "description.scenario": {
-    "message": "选择要制作的视频类型。自动让 Maestro 决定；也可指定图文旁白、短剧、数字人口播、动态图形、演示幻灯。",
+    "message": "选择要制作的视频类型。自动让 Maestro 决定；也可指定图文旁白、短剧、数字人口播、动态图形、字幕花字。",
     "description": "Scenario field help"
   },
   "option.scenario.auto": {
@@ -215,9 +215,9 @@
     "message": "动态图形",
     "description": "Motion graphics scenario option"
   },
-  "option.scenario.slideshow": {
-    "message": "演示幻灯",
-    "description": "Slideshow scenario option"
+  "option.scenario.captions": {
+    "message": "字幕 · 花字",
+    "description": "Captions scenario option (add captions/subtitles to an existing talking-head video)"
   },
   "name.style": {
     "message": "视觉风格",

--- a/src/models/maestro.ts
+++ b/src/models/maestro.ts
@@ -9,7 +9,7 @@ export interface IMaestroConfig {
   aspect?: string; // '9:16' | '16:9' | '1:1'
   duration?: number;
   quality?: string; // 'draft' | 'standard' | 'premium'
-  scenario?: string; // 'auto' | 'narrated' | 'drama' | 'avatar' | 'motion' | 'slideshow'
+  scenario?: string; // 'auto' | 'narrated' | 'drama' | 'avatar' | 'motion' | 'captions'
   style?: string; // freeform visual hint (e.g. 'auto' | 'cinematic' | 'minimal' | 'neon' | 'corporate'); orthogonal to scenario
   callback_url?: string;
 }


### PR DESCRIPTION
## What & why

Nexior's maestro (AI video) scenario picker had drifted from the backend taxonomy, and its preview thumbnails were generic illustrations that didn't reflect real output. This PR realigns both.

### Scenario taxonomy (adapts to the current API)
- **Drop `slideshow`** — the backend removed this workflow (PlatformService #1385).
- **Add `captions`** — now a first-class scenario (add on-screen captions / 花字 to a talking-head video).
- Persisted configs that still hold a stale scenario (e.g. `slideshow` in `localStorage`) are **normalized back to the default on mount**, so returning users don't land on an empty selection.
- Updated `en` + `zh-CN` scenario **labels** and **help text** (other locales are filled by the translate CronJob per project convention — not hand-translated).

### Real-frame preview thumbnails
Replaced the ugly illustration thumbnails with **actual frames extracted from generated maestro videos**, so each card shows what the scenario really produces:

| Scenario | Thumbnail | Source |
|---|---|---|
| `narrated` | https://cdn.acedata.cloud/db6ef158be.jpg | KD sports-highlight frame (16:9, data card) |
| `drama` | https://cdn.acedata.cloud/af85b29164.jpg | cinematic short-drama frame (9:16) |
| `avatar` | https://cdn.acedata.cloud/7ae3e94d5a.jpg | digital-human news anchor (9:16) |
| `captions` | https://cdn.acedata.cloud/9a6d16d9f3.jpg | anchor mid-talk with prominent subtitle (9:16) |

`auto` and `motion` keep their existing illustrations (no representative real video was generated for those).

## Files
- `src/constants/maestro.ts` — `MAESTRO_ALLOWED_SCENARIOS` + `MAESTRO_SCENARIO_THUMBNAILS`.
- `src/components/maestro/ConfigPanel.vue` — stale-scenario normalization in `mounted()`.
- `src/models/maestro.ts` — scenario comment.
- `src/i18n/{en,zh-CN}/maestro.json` — labels + help text.

## 🤖 对抗评审

Independent reviewer (Explore subagent; Codex unavailable this session). One round → converged.

- **RISK** — en help text still said "…or a slideshow." → **fixed** to "…or on-screen captions."
- **RISK** — zh-CN help text still said "…演示幻灯。" → **fixed** to "…字幕花字。"
- **RISK** — no fallback for a persisted `scenario: 'slideshow'`: the grid would render with no card selected (the existing `?? DEFAULT` only catches null/undefined, not a stale truthy value). → **fixed**: `mounted()` now drops any scenario not in `MAESTRO_ALLOWED_SCENARIOS` back to `MAESTRO_DEFAULT_SCENARIO`.
- **NOTE** — constants/thumbnails/i18n keys confirmed in sync (every allowed scenario has a thumbnail; no orphans).

Re-review after fixes: **VERDICT: CLEAN**.
