### PR TITLE
feat(maestro): sync style dropdown to backend style enum

### DIFF
--- a/change/@acedatacloud-nexior-7f3e9c21-4a5b-4c8d-9e10-2f6a8b1c3d4e.json
+++ b/change/@acedatacloud-nexior-7f3e9c21-4a5b-4c8d-9e10-2f6a8b1c3d4e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "sync maestro style dropdown to backend style enum (add glass/luxury/swiss/etc., drop stale minimal/corporate/hand-drawn)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/constants/maestro.ts
+++ b/src/constants/maestro.ts
@@ -28,8 +28,26 @@ export const MAESTRO_SCENARIO_THUMBNAILS: Record<string, string> = {
   motion: 'https://cdn.acedata.cloud/ab9dc386b6.png',
   captions: 'https://cdn.acedata.cloud/9a6d16d9f3.jpg'
 };
-// Visual style hint (freeform on the API; these are quick presets). Orthogonal to scenario routing.
-export const MAESTRO_ALLOWED_STYLES = ['auto', 'cinematic', 'minimal', 'neon', 'corporate', 'hand-drawn'];
+// Visual style presets — each maps to a real named capability on the backend (a visual-styles
+// identity, a palette, or a recipe like glass/retro). Freeform text still works. Orthogonal to scenario.
+export const MAESTRO_ALLOWED_STYLES = [
+  'auto',
+  'cinematic',
+  'glass',
+  'luxury',
+  'swiss',
+  'modern',
+  'editorial',
+  'warm',
+  'vibrant',
+  'neon',
+  'mono',
+  'pastel',
+  'bold',
+  'industrial',
+  'futuristic',
+  'retro'
+];
 
 // Accepted reference media for file_urls (images / video / audio).
 export const MAESTRO_FILE_ACCEPT = '.png,.jpg,.jpeg,.gif,.bmp,.webp,.mp4,.mov,.webm,.mp3,.wav,.m4a';

--- a/src/i18n/ar/maestro.json
+++ b/src/i18n/ar/maestro.json
@@ -235,21 +235,9 @@
     "message": "إحساس سينمائي",
     "description": "خيار أسلوب سينمائي"
   },
-  "option.style.minimal": {
-    "message": "بسيط جداً",
-    "description": "خيار أسلوب بسيط جداً"
-  },
   "option.style.neon": {
     "message": "نيون",
     "description": "خيار أسلوب نيون"
-  },
-  "option.style.corporate": {
-    "message": "أعمال",
-    "description": "خيار أسلوب أعمال"
-  },
-  "option.style.hand-drawn": {
-    "message": "مرسوم باليد",
-    "description": "خيار أسلوب مرسوم باليد"
   },
   "name.sourceType": {
     "message": "نوع المصدر",
@@ -338,5 +326,57 @@
   "option.scenario.captions": {
     "message": "إضافة ترجمات",
     "description": "Add-captions scenario option"
+  },
+  "option.style.glass": {
+    "message": "Frosted Glass",
+    "description": "Frosted glass style option"
+  },
+  "option.style.luxury": {
+    "message": "Luxury",
+    "description": "Luxury style option"
+  },
+  "option.style.swiss": {
+    "message": "Swiss Grid",
+    "description": "Swiss grid style option"
+  },
+  "option.style.modern": {
+    "message": "Modern",
+    "description": "Modern style option"
+  },
+  "option.style.editorial": {
+    "message": "Editorial",
+    "description": "Editorial style option"
+  },
+  "option.style.warm": {
+    "message": "Warm",
+    "description": "Warm style option"
+  },
+  "option.style.vibrant": {
+    "message": "Vibrant",
+    "description": "Vibrant style option"
+  },
+  "option.style.mono": {
+    "message": "Monochrome",
+    "description": "Monochrome style option"
+  },
+  "option.style.pastel": {
+    "message": "Pastel",
+    "description": "Pastel style option"
+  },
+  "option.style.bold": {
+    "message": "Bold Type",
+    "description": "Bold type style option"
+  },
+  "option.style.industrial": {
+    "message": "Industrial",
+    "description": "Industrial style option"
+  },
+  "option.style.futuristic": {
+    "message": "Futuristic",
+    "description": "Futuristic style option"
+  },
+  "option.style.retro": {
+    "message": "Retro Film",
+    "description": "Retro film style option"
   }
 }

--- a/src/i18n/de/maestro.json
+++ b/src/i18n/de/maestro.json
@@ -235,21 +235,9 @@
     "message": "Filmisch",
     "description": "Option für filmischen Stil"
   },
-  "option.style.minimal": {
-    "message": "Minimalistisch",
-    "description": "Option für minimalistischen Stil"
-  },
   "option.style.neon": {
     "message": "Neon",
     "description": "Option für Neon-Stil"
-  },
-  "option.style.corporate": {
-    "message": "Geschäftlich",
-    "description": "Option für geschäftlichen Stil"
-  },
-  "option.style.hand-drawn": {
-    "message": "Handgezeichnet",
-    "description": "Option für handgezeichneten Stil"
   },
   "name.sourceType": {
     "message": "Quelltyp",
@@ -338,5 +326,57 @@
   "option.scenario.captions": {
     "message": "Untertitel hinzufügen",
     "description": "Add-captions scenario option"
+  },
+  "option.style.glass": {
+    "message": "Frosted Glass",
+    "description": "Frosted glass style option"
+  },
+  "option.style.luxury": {
+    "message": "Luxury",
+    "description": "Luxury style option"
+  },
+  "option.style.swiss": {
+    "message": "Swiss Grid",
+    "description": "Swiss grid style option"
+  },
+  "option.style.modern": {
+    "message": "Modern",
+    "description": "Modern style option"
+  },
+  "option.style.editorial": {
+    "message": "Editorial",
+    "description": "Editorial style option"
+  },
+  "option.style.warm": {
+    "message": "Warm",
+    "description": "Warm style option"
+  },
+  "option.style.vibrant": {
+    "message": "Vibrant",
+    "description": "Vibrant style option"
+  },
+  "option.style.mono": {
+    "message": "Monochrome",
+    "description": "Monochrome style option"
+  },
+  "option.style.pastel": {
+    "message": "Pastel",
+    "description": "Pastel style option"
+  },
+  "option.style.bold": {
+    "message": "Bold Type",
+    "description": "Bold type style option"
+  },
+  "option.style.industrial": {
+    "message": "Industrial",
+    "description": "Industrial style option"
+  },
+  "option.style.futuristic": {
+    "message": "Futuristic",
+    "description": "Futuristic style option"
+  },
+  "option.style.retro": {
+    "message": "Retro Film",
+    "description": "Retro film style option"
   }
 }

--- a/src/i18n/el/maestro.json
+++ b/src/i18n/el/maestro.json
@@ -235,21 +235,9 @@
     "message": "Κινηματογραφικό",
     "description": "Επιλογή κινηματογραφικού στυλ"
   },
-  "option.style.minimal": {
-    "message": "Εξαιρετικά απλό",
-    "description": "Επιλογή ελάχιστου στυλ"
-  },
   "option.style.neon": {
     "message": "Νεον",
     "description": "Επιλογή στυλ νεον"
-  },
-  "option.style.corporate": {
-    "message": "Επιχειρηματικό",
-    "description": "Επιλογή επιχειρηματικού στυλ"
-  },
-  "option.style.hand-drawn": {
-    "message": "Χειροποίητο",
-    "description": "Επιλογή χειροποίητου στυλ"
   },
   "name.sourceType": {
     "message": "Τύπος πηγής",
@@ -338,5 +326,57 @@
   "option.scenario.captions": {
     "message": "Προσθήκη υπότιτλων",
     "description": "Add-captions scenario option"
+  },
+  "option.style.glass": {
+    "message": "Frosted Glass",
+    "description": "Frosted glass style option"
+  },
+  "option.style.luxury": {
+    "message": "Luxury",
+    "description": "Luxury style option"
+  },
+  "option.style.swiss": {
+    "message": "Swiss Grid",
+    "description": "Swiss grid style option"
+  },
+  "option.style.modern": {
+    "message": "Modern",
+    "description": "Modern style option"
+  },
+  "option.style.editorial": {
+    "message": "Editorial",
+    "description": "Editorial style option"
+  },
+  "option.style.warm": {
+    "message": "Warm",
+    "description": "Warm style option"
+  },
+  "option.style.vibrant": {
+    "message": "Vibrant",
+    "description": "Vibrant style option"
+  },
+  "option.style.mono": {
+    "message": "Monochrome",
+    "description": "Monochrome style option"
+  },
+  "option.style.pastel": {
+    "message": "Pastel",
+    "description": "Pastel style option"
+  },
+  "option.style.bold": {
+    "message": "Bold Type",
+    "description": "Bold type style option"
+  },
+  "option.style.industrial": {
+    "message": "Industrial",
+    "description": "Industrial style option"
+  },
+  "option.style.futuristic": {
+    "message": "Futuristic",
+    "description": "Futuristic style option"
+  },
+  "option.style.retro": {
+    "message": "Retro Film",
+    "description": "Retro film style option"
   }
 }

--- a/src/i18n/en/maestro.json
+++ b/src/i18n/en/maestro.json
@@ -235,20 +235,60 @@
     "message": "Cinematic",
     "description": "Cinematic style option"
   },
-  "option.style.minimal": {
-    "message": "Minimal",
-    "description": "Minimal style option"
+  "option.style.glass": {
+    "message": "Frosted Glass",
+    "description": "Frosted glass style option"
+  },
+  "option.style.luxury": {
+    "message": "Luxury",
+    "description": "Luxury style option"
+  },
+  "option.style.swiss": {
+    "message": "Swiss Grid",
+    "description": "Swiss grid style option"
+  },
+  "option.style.modern": {
+    "message": "Modern",
+    "description": "Modern style option"
+  },
+  "option.style.editorial": {
+    "message": "Editorial",
+    "description": "Editorial style option"
+  },
+  "option.style.warm": {
+    "message": "Warm",
+    "description": "Warm style option"
+  },
+  "option.style.vibrant": {
+    "message": "Vibrant",
+    "description": "Vibrant style option"
   },
   "option.style.neon": {
     "message": "Neon",
     "description": "Neon style option"
   },
-  "option.style.corporate": {
-    "message": "Corporate",
-    "description": "Corporate style option"
+  "option.style.mono": {
+    "message": "Monochrome",
+    "description": "Monochrome style option"
   },
-  "option.style.hand-drawn": {
-    "message": "Hand-drawn",
-    "description": "Hand-drawn style option"
+  "option.style.pastel": {
+    "message": "Pastel",
+    "description": "Pastel style option"
+  },
+  "option.style.bold": {
+    "message": "Bold Type",
+    "description": "Bold type style option"
+  },
+  "option.style.industrial": {
+    "message": "Industrial",
+    "description": "Industrial style option"
+  },
+  "option.style.futuristic": {
+    "message": "Futuristic",
+    "description": "Futuristic style option"
+  },
+  "option.style.retro": {
+    "message": "Retro Film",
+    "description": "Retro film style option"
   }
 }

--- a/src/i18n/es/maestro.json
+++ b/src/i18n/es/maestro.json
@@ -235,21 +235,9 @@
     "message": "Estilo cinematográfico",
     "description": "Opción de estilo cinematográfico"
   },
-  "option.style.minimal": {
-    "message": "Estilo minimalista",
-    "description": "Opción de estilo minimalista"
-  },
   "option.style.neon": {
     "message": "Estilo neón",
     "description": "Opción de estilo neón"
-  },
-  "option.style.corporate": {
-    "message": "Estilo corporativo",
-    "description": "Opción de estilo corporativo"
-  },
-  "option.style.hand-drawn": {
-    "message": "Dibujo a mano",
-    "description": "Opción de estilo dibujado a mano"
   },
   "name.sourceType": {
     "message": "Tipo de origen",
@@ -338,5 +326,57 @@
   "option.scenario.captions": {
     "message": "Añadir subtítulos",
     "description": "Add-captions scenario option"
+  },
+  "option.style.glass": {
+    "message": "Frosted Glass",
+    "description": "Frosted glass style option"
+  },
+  "option.style.luxury": {
+    "message": "Luxury",
+    "description": "Luxury style option"
+  },
+  "option.style.swiss": {
+    "message": "Swiss Grid",
+    "description": "Swiss grid style option"
+  },
+  "option.style.modern": {
+    "message": "Modern",
+    "description": "Modern style option"
+  },
+  "option.style.editorial": {
+    "message": "Editorial",
+    "description": "Editorial style option"
+  },
+  "option.style.warm": {
+    "message": "Warm",
+    "description": "Warm style option"
+  },
+  "option.style.vibrant": {
+    "message": "Vibrant",
+    "description": "Vibrant style option"
+  },
+  "option.style.mono": {
+    "message": "Monochrome",
+    "description": "Monochrome style option"
+  },
+  "option.style.pastel": {
+    "message": "Pastel",
+    "description": "Pastel style option"
+  },
+  "option.style.bold": {
+    "message": "Bold Type",
+    "description": "Bold type style option"
+  },
+  "option.style.industrial": {
+    "message": "Industrial",
+    "description": "Industrial style option"
+  },
+  "option.style.futuristic": {
+    "message": "Futuristic",
+    "description": "Futuristic style option"
+  },
+  "option.style.retro": {
+    "message": "Retro Film",
+    "description": "Retro film style option"
   }
 }

--- a/src/i18n/fi/maestro.json
+++ b/src/i18n/fi/maestro.json
@@ -235,21 +235,9 @@
     "message": "Elokuvamainen",
     "description": "Elokuvamainen tyylivaihtoehto"
   },
-  "option.style.minimal": {
-    "message": "Minimalistinen",
-    "description": "Minimalistinen tyylivaihtoehto"
-  },
   "option.style.neon": {
     "message": "Neon",
     "description": "Neon-tyylivaihtoehto"
-  },
-  "option.style.corporate": {
-    "message": "Liiketoiminta",
-    "description": "Liiketoimintatyylivaihtoehto"
-  },
-  "option.style.hand-drawn": {
-    "message": "Käsin piirretty",
-    "description": "Käsin piirretty tyylivaihtoehto"
   },
   "name.sourceType": {
     "message": "Lähteen tyyppi",
@@ -338,5 +326,57 @@
   "option.scenario.captions": {
     "message": "Lisää tekstitykset",
     "description": "Add-captions scenario option"
+  },
+  "option.style.glass": {
+    "message": "Frosted Glass",
+    "description": "Frosted glass style option"
+  },
+  "option.style.luxury": {
+    "message": "Luxury",
+    "description": "Luxury style option"
+  },
+  "option.style.swiss": {
+    "message": "Swiss Grid",
+    "description": "Swiss grid style option"
+  },
+  "option.style.modern": {
+    "message": "Modern",
+    "description": "Modern style option"
+  },
+  "option.style.editorial": {
+    "message": "Editorial",
+    "description": "Editorial style option"
+  },
+  "option.style.warm": {
+    "message": "Warm",
+    "description": "Warm style option"
+  },
+  "option.style.vibrant": {
+    "message": "Vibrant",
+    "description": "Vibrant style option"
+  },
+  "option.style.mono": {
+    "message": "Monochrome",
+    "description": "Monochrome style option"
+  },
+  "option.style.pastel": {
+    "message": "Pastel",
+    "description": "Pastel style option"
+  },
+  "option.style.bold": {
+    "message": "Bold Type",
+    "description": "Bold type style option"
+  },
+  "option.style.industrial": {
+    "message": "Industrial",
+    "description": "Industrial style option"
+  },
+  "option.style.futuristic": {
+    "message": "Futuristic",
+    "description": "Futuristic style option"
+  },
+  "option.style.retro": {
+    "message": "Retro Film",
+    "description": "Retro film style option"
   }
 }

--- a/src/i18n/fr/maestro.json
+++ b/src/i18n/fr/maestro.json
@@ -235,21 +235,9 @@
     "message": "Style cinématographique",
     "description": "Option de style cinématographique"
   },
-  "option.style.minimal": {
-    "message": "Style minimaliste",
-    "description": "Option de style minimal"
-  },
   "option.style.neon": {
     "message": "Style néon",
     "description": "Option de style néon"
-  },
-  "option.style.corporate": {
-    "message": "Style professionnel",
-    "description": "Option de style d'entreprise"
-  },
-  "option.style.hand-drawn": {
-    "message": "Dessin à la main",
-    "description": "Option de style dessin à la main"
   },
   "name.sourceType": {
     "message": "Type de source",
@@ -338,5 +326,57 @@
   "option.scenario.captions": {
     "message": "Ajouter des sous-titres",
     "description": "Add-captions scenario option"
+  },
+  "option.style.glass": {
+    "message": "Frosted Glass",
+    "description": "Frosted glass style option"
+  },
+  "option.style.luxury": {
+    "message": "Luxury",
+    "description": "Luxury style option"
+  },
+  "option.style.swiss": {
+    "message": "Swiss Grid",
+    "description": "Swiss grid style option"
+  },
+  "option.style.modern": {
+    "message": "Modern",
+    "description": "Modern style option"
+  },
+  "option.style.editorial": {
+    "message": "Editorial",
+    "description": "Editorial style option"
+  },
+  "option.style.warm": {
+    "message": "Warm",
+    "description": "Warm style option"
+  },
+  "option.style.vibrant": {
+    "message": "Vibrant",
+    "description": "Vibrant style option"
+  },
+  "option.style.mono": {
+    "message": "Monochrome",
+    "description": "Monochrome style option"
+  },
+  "option.style.pastel": {
+    "message": "Pastel",
+    "description": "Pastel style option"
+  },
+  "option.style.bold": {
+    "message": "Bold Type",
+    "description": "Bold type style option"
+  },
+  "option.style.industrial": {
+    "message": "Industrial",
+    "description": "Industrial style option"
+  },
+  "option.style.futuristic": {
+    "message": "Futuristic",
+    "description": "Futuristic style option"
+  },
+  "option.style.retro": {
+    "message": "Retro Film",
+    "description": "Retro film style option"
   }
 }

--- a/src/i18n/it/maestro.json
+++ b/src/i18n/it/maestro.json
@@ -235,21 +235,9 @@
     "message": "Stile cinematografico",
     "description": "Opzione stile cinematografico"
   },
-  "option.style.minimal": {
-    "message": "Stile minimalista",
-    "description": "Opzione stile minimalista"
-  },
   "option.style.neon": {
     "message": "Stile neon",
     "description": "Opzione stile neon"
-  },
-  "option.style.corporate": {
-    "message": "Stile aziendale",
-    "description": "Opzione stile aziendale"
-  },
-  "option.style.hand-drawn": {
-    "message": "Disegno a mano",
-    "description": "Opzione stile disegnato a mano"
   },
   "name.sourceType": {
     "message": "Tipo di sorgente",
@@ -338,5 +326,57 @@
   "option.scenario.captions": {
     "message": "Aggiungi sottotitoli",
     "description": "Add-captions scenario option"
+  },
+  "option.style.glass": {
+    "message": "Frosted Glass",
+    "description": "Frosted glass style option"
+  },
+  "option.style.luxury": {
+    "message": "Luxury",
+    "description": "Luxury style option"
+  },
+  "option.style.swiss": {
+    "message": "Swiss Grid",
+    "description": "Swiss grid style option"
+  },
+  "option.style.modern": {
+    "message": "Modern",
+    "description": "Modern style option"
+  },
+  "option.style.editorial": {
+    "message": "Editorial",
+    "description": "Editorial style option"
+  },
+  "option.style.warm": {
+    "message": "Warm",
+    "description": "Warm style option"
+  },
+  "option.style.vibrant": {
+    "message": "Vibrant",
+    "description": "Vibrant style option"
+  },
+  "option.style.mono": {
+    "message": "Monochrome",
+    "description": "Monochrome style option"
+  },
+  "option.style.pastel": {
+    "message": "Pastel",
+    "description": "Pastel style option"
+  },
+  "option.style.bold": {
+    "message": "Bold Type",
+    "description": "Bold type style option"
+  },
+  "option.style.industrial": {
+    "message": "Industrial",
+    "description": "Industrial style option"
+  },
+  "option.style.futuristic": {
+    "message": "Futuristic",
+    "description": "Futuristic style option"
+  },
+  "option.style.retro": {
+    "message": "Retro Film",
+    "description": "Retro film style option"
   }
 }

--- a/src/i18n/ja/maestro.json
+++ b/src/i18n/ja/maestro.json
@@ -235,21 +235,9 @@
     "message": "映画的",
     "description": "シネマティックスタイルオプション"
   },
-  "option.style.minimal": {
-    "message": "ミニマル",
-    "description": "ミニマルスタイルオプション"
-  },
   "option.style.neon": {
     "message": "ネオン",
     "description": "ネオンスタイルオプション"
-  },
-  "option.style.corporate": {
-    "message": "ビジネス",
-    "description": "コーポレートスタイルオプション"
-  },
-  "option.style.hand-drawn": {
-    "message": "手描き",
-    "description": "手描きスタイルオプション"
   },
   "name.sourceType": {
     "message": "ソースタイプ",
@@ -338,5 +326,57 @@
   "option.scenario.captions": {
     "message": "字幕を追加",
     "description": "Add-captions scenario option"
+  },
+  "option.style.glass": {
+    "message": "Frosted Glass",
+    "description": "Frosted glass style option"
+  },
+  "option.style.luxury": {
+    "message": "Luxury",
+    "description": "Luxury style option"
+  },
+  "option.style.swiss": {
+    "message": "Swiss Grid",
+    "description": "Swiss grid style option"
+  },
+  "option.style.modern": {
+    "message": "Modern",
+    "description": "Modern style option"
+  },
+  "option.style.editorial": {
+    "message": "Editorial",
+    "description": "Editorial style option"
+  },
+  "option.style.warm": {
+    "message": "Warm",
+    "description": "Warm style option"
+  },
+  "option.style.vibrant": {
+    "message": "Vibrant",
+    "description": "Vibrant style option"
+  },
+  "option.style.mono": {
+    "message": "Monochrome",
+    "description": "Monochrome style option"
+  },
+  "option.style.pastel": {
+    "message": "Pastel",
+    "description": "Pastel style option"
+  },
+  "option.style.bold": {
+    "message": "Bold Type",
+    "description": "Bold type style option"
+  },
+  "option.style.industrial": {
+    "message": "Industrial",
+    "description": "Industrial style option"
+  },
+  "option.style.futuristic": {
+    "message": "Futuristic",
+    "description": "Futuristic style option"
+  },
+  "option.style.retro": {
+    "message": "Retro Film",
+    "description": "Retro film style option"
   }
 }

--- a/src/i18n/ko/maestro.json
+++ b/src/i18n/ko/maestro.json
@@ -235,21 +235,9 @@
     "message": "영화 느낌",
     "description": "영화적 스타일 옵션"
   },
-  "option.style.minimal": {
-    "message": "미니멀",
-    "description": "미니멀 스타일 옵션"
-  },
   "option.style.neon": {
     "message": "네온",
     "description": "네온 스타일 옵션"
-  },
-  "option.style.corporate": {
-    "message": "비즈니스",
-    "description": "기업 스타일 옵션"
-  },
-  "option.style.hand-drawn": {
-    "message": "손으로 그린",
-    "description": "손그림 스타일 옵션"
   },
   "name.sourceType": {
     "message": "출처 유형",
@@ -338,5 +326,57 @@
   "option.scenario.captions": {
     "message": "자막 추가",
     "description": "Add-captions scenario option"
+  },
+  "option.style.glass": {
+    "message": "Frosted Glass",
+    "description": "Frosted glass style option"
+  },
+  "option.style.luxury": {
+    "message": "Luxury",
+    "description": "Luxury style option"
+  },
+  "option.style.swiss": {
+    "message": "Swiss Grid",
+    "description": "Swiss grid style option"
+  },
+  "option.style.modern": {
+    "message": "Modern",
+    "description": "Modern style option"
+  },
+  "option.style.editorial": {
+    "message": "Editorial",
+    "description": "Editorial style option"
+  },
+  "option.style.warm": {
+    "message": "Warm",
+    "description": "Warm style option"
+  },
+  "option.style.vibrant": {
+    "message": "Vibrant",
+    "description": "Vibrant style option"
+  },
+  "option.style.mono": {
+    "message": "Monochrome",
+    "description": "Monochrome style option"
+  },
+  "option.style.pastel": {
+    "message": "Pastel",
+    "description": "Pastel style option"
+  },
+  "option.style.bold": {
+    "message": "Bold Type",
+    "description": "Bold type style option"
+  },
+  "option.style.industrial": {
+    "message": "Industrial",
+    "description": "Industrial style option"
+  },
+  "option.style.futuristic": {
+    "message": "Futuristic",
+    "description": "Futuristic style option"
+  },
+  "option.style.retro": {
+    "message": "Retro Film",
+    "description": "Retro film style option"
   }
 }

--- a/src/i18n/pl/maestro.json
+++ b/src/i18n/pl/maestro.json
@@ -235,21 +235,9 @@
     "message": "Filmowy",
     "description": "Opcja stylu filmowego"
   },
-  "option.style.minimal": {
-    "message": "Minimalistyczny",
-    "description": "Opcja stylu minimalistycznego"
-  },
   "option.style.neon": {
     "message": "Neonowy",
     "description": "Opcja stylu neonowego"
-  },
-  "option.style.corporate": {
-    "message": "Biznesowy",
-    "description": "Opcja stylu korporacyjnego"
-  },
-  "option.style.hand-drawn": {
-    "message": "Ręcznie rysowany",
-    "description": "Opcja stylu ręcznie rysowanego"
   },
   "name.sourceType": {
     "message": "Typ źródła",
@@ -338,5 +326,57 @@
   "option.scenario.captions": {
     "message": "Dodaj napisy",
     "description": "Add-captions scenario option"
+  },
+  "option.style.glass": {
+    "message": "Frosted Glass",
+    "description": "Frosted glass style option"
+  },
+  "option.style.luxury": {
+    "message": "Luxury",
+    "description": "Luxury style option"
+  },
+  "option.style.swiss": {
+    "message": "Swiss Grid",
+    "description": "Swiss grid style option"
+  },
+  "option.style.modern": {
+    "message": "Modern",
+    "description": "Modern style option"
+  },
+  "option.style.editorial": {
+    "message": "Editorial",
+    "description": "Editorial style option"
+  },
+  "option.style.warm": {
+    "message": "Warm",
+    "description": "Warm style option"
+  },
+  "option.style.vibrant": {
+    "message": "Vibrant",
+    "description": "Vibrant style option"
+  },
+  "option.style.mono": {
+    "message": "Monochrome",
+    "description": "Monochrome style option"
+  },
+  "option.style.pastel": {
+    "message": "Pastel",
+    "description": "Pastel style option"
+  },
+  "option.style.bold": {
+    "message": "Bold Type",
+    "description": "Bold type style option"
+  },
+  "option.style.industrial": {
+    "message": "Industrial",
+    "description": "Industrial style option"
+  },
+  "option.style.futuristic": {
+    "message": "Futuristic",
+    "description": "Futuristic style option"
+  },
+  "option.style.retro": {
+    "message": "Retro Film",
+    "description": "Retro film style option"
   }
 }

--- a/src/i18n/pt/maestro.json
+++ b/src/i18n/pt/maestro.json
@@ -235,21 +235,9 @@
     "message": "Estilo cinematográfico",
     "description": "Opção de estilo cinematográfico"
   },
-  "option.style.minimal": {
-    "message": "Estilo minimalista",
-    "description": "Opção de estilo minimalista"
-  },
   "option.style.neon": {
     "message": "Estilo neon",
     "description": "Opção de estilo neon"
-  },
-  "option.style.corporate": {
-    "message": "Estilo corporativo",
-    "description": "Opção de estilo corporativo"
-  },
-  "option.style.hand-drawn": {
-    "message": "Estilo desenhado à mão",
-    "description": "Opção de estilo desenhado à mão"
   },
   "name.sourceType": {
     "message": "Tipo de origem",
@@ -338,5 +326,57 @@
   "option.scenario.captions": {
     "message": "Adicionar legendas",
     "description": "Add-captions scenario option"
+  },
+  "option.style.glass": {
+    "message": "Frosted Glass",
+    "description": "Frosted glass style option"
+  },
+  "option.style.luxury": {
+    "message": "Luxury",
+    "description": "Luxury style option"
+  },
+  "option.style.swiss": {
+    "message": "Swiss Grid",
+    "description": "Swiss grid style option"
+  },
+  "option.style.modern": {
+    "message": "Modern",
+    "description": "Modern style option"
+  },
+  "option.style.editorial": {
+    "message": "Editorial",
+    "description": "Editorial style option"
+  },
+  "option.style.warm": {
+    "message": "Warm",
+    "description": "Warm style option"
+  },
+  "option.style.vibrant": {
+    "message": "Vibrant",
+    "description": "Vibrant style option"
+  },
+  "option.style.mono": {
+    "message": "Monochrome",
+    "description": "Monochrome style option"
+  },
+  "option.style.pastel": {
+    "message": "Pastel",
+    "description": "Pastel style option"
+  },
+  "option.style.bold": {
+    "message": "Bold Type",
+    "description": "Bold type style option"
+  },
+  "option.style.industrial": {
+    "message": "Industrial",
+    "description": "Industrial style option"
+  },
+  "option.style.futuristic": {
+    "message": "Futuristic",
+    "description": "Futuristic style option"
+  },
+  "option.style.retro": {
+    "message": "Retro Film",
+    "description": "Retro film style option"
   }
 }

--- a/src/i18n/ru/maestro.json
+++ b/src/i18n/ru/maestro.json
@@ -235,21 +235,9 @@
     "message": "Кинематографический",
     "description": "Опция кинематографического стиля"
   },
-  "option.style.minimal": {
-    "message": "Минимализм",
-    "description": "Опция минималистского стиля"
-  },
   "option.style.neon": {
     "message": "Неон",
     "description": "Опция неонового стиля"
-  },
-  "option.style.corporate": {
-    "message": "Корпоративный",
-    "description": "Опция корпоративного стиля"
-  },
-  "option.style.hand-drawn": {
-    "message": "Ручная работа",
-    "description": "Опция стиля ручной работы"
   },
   "name.sourceType": {
     "message": "Тип источника",
@@ -338,5 +326,57 @@
   "option.scenario.captions": {
     "message": "Добавить субтитры",
     "description": "Add-captions scenario option"
+  },
+  "option.style.glass": {
+    "message": "Frosted Glass",
+    "description": "Frosted glass style option"
+  },
+  "option.style.luxury": {
+    "message": "Luxury",
+    "description": "Luxury style option"
+  },
+  "option.style.swiss": {
+    "message": "Swiss Grid",
+    "description": "Swiss grid style option"
+  },
+  "option.style.modern": {
+    "message": "Modern",
+    "description": "Modern style option"
+  },
+  "option.style.editorial": {
+    "message": "Editorial",
+    "description": "Editorial style option"
+  },
+  "option.style.warm": {
+    "message": "Warm",
+    "description": "Warm style option"
+  },
+  "option.style.vibrant": {
+    "message": "Vibrant",
+    "description": "Vibrant style option"
+  },
+  "option.style.mono": {
+    "message": "Monochrome",
+    "description": "Monochrome style option"
+  },
+  "option.style.pastel": {
+    "message": "Pastel",
+    "description": "Pastel style option"
+  },
+  "option.style.bold": {
+    "message": "Bold Type",
+    "description": "Bold type style option"
+  },
+  "option.style.industrial": {
+    "message": "Industrial",
+    "description": "Industrial style option"
+  },
+  "option.style.futuristic": {
+    "message": "Futuristic",
+    "description": "Futuristic style option"
+  },
+  "option.style.retro": {
+    "message": "Retro Film",
+    "description": "Retro film style option"
   }
 }

--- a/src/i18n/sr/maestro.json
+++ b/src/i18n/sr/maestro.json
@@ -235,21 +235,9 @@
     "message": "Кинематографски",
     "description": "Опција кинематографског стила"
   },
-  "option.style.minimal": {
-    "message": "Минималистички",
-    "description": "Опција минималистичког стила"
-  },
   "option.style.neon": {
     "message": "Неон",
     "description": "Опција неонског стила"
-  },
-  "option.style.corporate": {
-    "message": "Корпоративни",
-    "description": "Опција корпоративног стила"
-  },
-  "option.style.hand-drawn": {
-    "message": "Ручно цртано",
-    "description": "Опција ручно цртаног стила"
   },
   "name.sourceType": {
     "message": "Tip izvora",
@@ -338,5 +326,57 @@
   "option.scenario.captions": {
     "message": "Додај титлове",
     "description": "Add-captions scenario option"
+  },
+  "option.style.glass": {
+    "message": "Frosted Glass",
+    "description": "Frosted glass style option"
+  },
+  "option.style.luxury": {
+    "message": "Luxury",
+    "description": "Luxury style option"
+  },
+  "option.style.swiss": {
+    "message": "Swiss Grid",
+    "description": "Swiss grid style option"
+  },
+  "option.style.modern": {
+    "message": "Modern",
+    "description": "Modern style option"
+  },
+  "option.style.editorial": {
+    "message": "Editorial",
+    "description": "Editorial style option"
+  },
+  "option.style.warm": {
+    "message": "Warm",
+    "description": "Warm style option"
+  },
+  "option.style.vibrant": {
+    "message": "Vibrant",
+    "description": "Vibrant style option"
+  },
+  "option.style.mono": {
+    "message": "Monochrome",
+    "description": "Monochrome style option"
+  },
+  "option.style.pastel": {
+    "message": "Pastel",
+    "description": "Pastel style option"
+  },
+  "option.style.bold": {
+    "message": "Bold Type",
+    "description": "Bold type style option"
+  },
+  "option.style.industrial": {
+    "message": "Industrial",
+    "description": "Industrial style option"
+  },
+  "option.style.futuristic": {
+    "message": "Futuristic",
+    "description": "Futuristic style option"
+  },
+  "option.style.retro": {
+    "message": "Retro Film",
+    "description": "Retro film style option"
   }
 }

--- a/src/i18n/sv/maestro.json
+++ b/src/i18n/sv/maestro.json
@@ -235,21 +235,9 @@
     "message": "Filmisk känsla",
     "description": "Alternativ för filmisk stil"
   },
-  "option.style.minimal": {
-    "message": "Minimalistisk",
-    "description": "Alternativ för minimalistisk stil"
-  },
   "option.style.neon": {
     "message": "Neon",
     "description": "Alternativ för neonstil"
-  },
-  "option.style.corporate": {
-    "message": "Företagsstil",
-    "description": "Alternativ för företagsstil"
-  },
-  "option.style.hand-drawn": {
-    "message": "Handritad",
-    "description": "Alternativ för handritad stil"
   },
   "name.sourceType": {
     "message": "Källtyp",
@@ -338,5 +326,57 @@
   "option.scenario.captions": {
     "message": "Lägg till undertexter",
     "description": "Add-captions scenario option"
+  },
+  "option.style.glass": {
+    "message": "Frosted Glass",
+    "description": "Frosted glass style option"
+  },
+  "option.style.luxury": {
+    "message": "Luxury",
+    "description": "Luxury style option"
+  },
+  "option.style.swiss": {
+    "message": "Swiss Grid",
+    "description": "Swiss grid style option"
+  },
+  "option.style.modern": {
+    "message": "Modern",
+    "description": "Modern style option"
+  },
+  "option.style.editorial": {
+    "message": "Editorial",
+    "description": "Editorial style option"
+  },
+  "option.style.warm": {
+    "message": "Warm",
+    "description": "Warm style option"
+  },
+  "option.style.vibrant": {
+    "message": "Vibrant",
+    "description": "Vibrant style option"
+  },
+  "option.style.mono": {
+    "message": "Monochrome",
+    "description": "Monochrome style option"
+  },
+  "option.style.pastel": {
+    "message": "Pastel",
+    "description": "Pastel style option"
+  },
+  "option.style.bold": {
+    "message": "Bold Type",
+    "description": "Bold type style option"
+  },
+  "option.style.industrial": {
+    "message": "Industrial",
+    "description": "Industrial style option"
+  },
+  "option.style.futuristic": {
+    "message": "Futuristic",
+    "description": "Futuristic style option"
+  },
+  "option.style.retro": {
+    "message": "Retro Film",
+    "description": "Retro film style option"
   }
 }

--- a/src/i18n/uk/maestro.json
+++ b/src/i18n/uk/maestro.json
@@ -235,21 +235,9 @@
     "message": "Кінематографічний",
     "description": "Опція кінематографічного стилю"
   },
-  "option.style.minimal": {
-    "message": "Мінімалістичний",
-    "description": "Опція мінімалістичного стилю"
-  },
   "option.style.neon": {
     "message": "Неоновий",
     "description": "Опція неонового стилю"
-  },
-  "option.style.corporate": {
-    "message": "Корпоративний",
-    "description": "Опція корпоративного стилю"
-  },
-  "option.style.hand-drawn": {
-    "message": "Ручний малюнок",
-    "description": "Опція стилю ручного малюнка"
   },
   "name.sourceType": {
     "message": "Тип джерела",
@@ -338,5 +326,57 @@
   "option.scenario.captions": {
     "message": "Додати субтитри",
     "description": "Add-captions scenario option"
+  },
+  "option.style.glass": {
+    "message": "Frosted Glass",
+    "description": "Frosted glass style option"
+  },
+  "option.style.luxury": {
+    "message": "Luxury",
+    "description": "Luxury style option"
+  },
+  "option.style.swiss": {
+    "message": "Swiss Grid",
+    "description": "Swiss grid style option"
+  },
+  "option.style.modern": {
+    "message": "Modern",
+    "description": "Modern style option"
+  },
+  "option.style.editorial": {
+    "message": "Editorial",
+    "description": "Editorial style option"
+  },
+  "option.style.warm": {
+    "message": "Warm",
+    "description": "Warm style option"
+  },
+  "option.style.vibrant": {
+    "message": "Vibrant",
+    "description": "Vibrant style option"
+  },
+  "option.style.mono": {
+    "message": "Monochrome",
+    "description": "Monochrome style option"
+  },
+  "option.style.pastel": {
+    "message": "Pastel",
+    "description": "Pastel style option"
+  },
+  "option.style.bold": {
+    "message": "Bold Type",
+    "description": "Bold type style option"
+  },
+  "option.style.industrial": {
+    "message": "Industrial",
+    "description": "Industrial style option"
+  },
+  "option.style.futuristic": {
+    "message": "Futuristic",
+    "description": "Futuristic style option"
+  },
+  "option.style.retro": {
+    "message": "Retro Film",
+    "description": "Retro film style option"
   }
 }

--- a/src/i18n/zh-CN/maestro.json
+++ b/src/i18n/zh-CN/maestro.json
@@ -232,23 +232,63 @@
     "description": "Auto style option"
   },
   "option.style.cinematic": {
-    "message": "电影感",
+    "message": "电影感 · 暗黑质感",
     "description": "Cinematic style option"
   },
-  "option.style.minimal": {
-    "message": "极简",
-    "description": "Minimal style option"
+  "option.style.glass": {
+    "message": "毛玻璃 · 液态玻璃",
+    "description": "Frosted glass style option"
+  },
+  "option.style.luxury": {
+    "message": "奢华 · 留白",
+    "description": "Luxury style option"
+  },
+  "option.style.swiss": {
+    "message": "瑞士网格 · 精密",
+    "description": "Swiss grid style option"
+  },
+  "option.style.modern": {
+    "message": "简约现代 · SaaS",
+    "description": "Modern style option"
+  },
+  "option.style.editorial": {
+    "message": "杂志编辑",
+    "description": "Editorial style option"
+  },
+  "option.style.warm": {
+    "message": "温暖亲密",
+    "description": "Warm style option"
+  },
+  "option.style.vibrant": {
+    "message": "缤纷活力",
+    "description": "Vibrant style option"
   },
   "option.style.neon": {
-    "message": "霓虹",
+    "message": "霓虹电光",
     "description": "Neon style option"
   },
-  "option.style.corporate": {
-    "message": "商务",
-    "description": "Corporate style option"
+  "option.style.mono": {
+    "message": "极简黑白",
+    "description": "Monochrome style option"
   },
-  "option.style.hand-drawn": {
-    "message": "手绘",
-    "description": "Hand-drawn style option"
+  "option.style.pastel": {
+    "message": "柔粉彩",
+    "description": "Pastel style option"
+  },
+  "option.style.bold": {
+    "message": "巨型字 · 高能",
+    "description": "Bold type style option"
+  },
+  "option.style.industrial": {
+    "message": "工业故障",
+    "description": "Industrial style option"
+  },
+  "option.style.futuristic": {
+    "message": "未来科技",
+    "description": "Futuristic style option"
+  },
+  "option.style.retro": {
+    "message": "复古胶片",
+    "description": "Retro film style option"
   }
 }

--- a/src/i18n/zh-TW/maestro.json
+++ b/src/i18n/zh-TW/maestro.json
@@ -235,21 +235,9 @@
     "message": "電影感",
     "description": "電影風格選項"
   },
-  "option.style.minimal": {
-    "message": "極簡",
-    "description": "極簡風格選項"
-  },
   "option.style.neon": {
     "message": "霓虹",
     "description": "霓虹風格選項"
-  },
-  "option.style.corporate": {
-    "message": "商務",
-    "description": "商務風格選項"
-  },
-  "option.style.hand-drawn": {
-    "message": "手繪",
-    "description": "手繪風格選項"
   },
   "name.sourceType": {
     "message": "來源類型",
@@ -338,5 +326,57 @@
   "option.scenario.captions": {
     "message": "影片加字幕",
     "description": "Add-captions scenario option"
+  },
+  "option.style.glass": {
+    "message": "Frosted Glass",
+    "description": "Frosted glass style option"
+  },
+  "option.style.luxury": {
+    "message": "Luxury",
+    "description": "Luxury style option"
+  },
+  "option.style.swiss": {
+    "message": "Swiss Grid",
+    "description": "Swiss grid style option"
+  },
+  "option.style.modern": {
+    "message": "Modern",
+    "description": "Modern style option"
+  },
+  "option.style.editorial": {
+    "message": "Editorial",
+    "description": "Editorial style option"
+  },
+  "option.style.warm": {
+    "message": "Warm",
+    "description": "Warm style option"
+  },
+  "option.style.vibrant": {
+    "message": "Vibrant",
+    "description": "Vibrant style option"
+  },
+  "option.style.mono": {
+    "message": "Monochrome",
+    "description": "Monochrome style option"
+  },
+  "option.style.pastel": {
+    "message": "Pastel",
+    "description": "Pastel style option"
+  },
+  "option.style.bold": {
+    "message": "Bold Type",
+    "description": "Bold type style option"
+  },
+  "option.style.industrial": {
+    "message": "Industrial",
+    "description": "Industrial style option"
+  },
+  "option.style.futuristic": {
+    "message": "Futuristic",
+    "description": "Futuristic style option"
+  },
+  "option.style.retro": {
+    "message": "Retro Film",
+    "description": "Retro film style option"
   }
 }


### PR DESCRIPTION
## What

Sync Nexior's Maestro **style** dropdown to the new backend `style` enum shipped in [PlatformService#1391](https://github.com/AceDataCloud/PlatformService/pull/1391).

Before, the dropdown offered `auto / cinematic / minimal / neon / corporate / hand-drawn` — but `minimal`, `corporate`, and `hand-drawn` no longer map to any real backend capability (they'd silently fall back to a vague free-text hint). Now every option maps 1:1 to a real, renderable identity/palette/recipe the director deterministically adopts.

## Changes

- `src/constants/maestro.ts` — `MAESTRO_ALLOWED_STYLES` → the 16-value enum (`auto, cinematic, glass, luxury, swiss, modern, editorial, warm, vibrant, neon, mono, pastel, bold, industrial, futuristic, retro`).
- `src/i18n/zh-CN/maestro.json` + `src/i18n/en/maestro.json` — a label for every new value (the dropdown renders `maestro.option.style.<value>`). Only zh-CN + en are edited by hand, per repo convention.

Freeform text is still accepted by the API (the help text already says "pick a preset or type your own"), so nothing is lost.

## Verification

- Both i18n JSON files parse (`json.load`).
- `maestro.ts` type-checks clean.
- Every value in `MAESTRO_ALLOWED_STYLES` has a matching `option.style.*` label in **both** locales (no raw-key leaks in the dropdown).
- The 16 values exactly match the backend `STYLE_ENUM` (source of truth) and the OpenAPI enum.

## 🤖 对抗评审

Self-review (trivial config/i18n change): ✅ i18n keys ↔ dropdown values 1:1 in both locales · ✅ values match backend `STYLE_ENUM` and OpenAPI · ✅ JSON valid, TS clean · ✅ backward-compatible (free-text still allowed; default `auto` unchanged). **VERDICT: CLEAN.**
