### PR TITLE
feat: install GA4 gtag.js tracking tag (G-Y6N02K05B8)

### DIFF
--- a/change/@acedatacloud-nexior-ga4-gtag.json
+++ b/change/@acedatacloud-nexior-ga4-gtag.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add GA4 gtag.js (lazy, CN-safe) tracking tag",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/index.html
+++ b/index.html
@@ -3,6 +3,36 @@
   <head>
     <meta charset="UTF-8" />
     <!--
+      Google Analytics (GA4). The gtag stub + config are defined inline (cheap,
+      no network) so events queue immediately; the remote googletagmanager.com
+      library is loaded lazily after the page is idle. This way a blocked/slow
+      request (e.g. behind the GFW in CN) never blocks render or the load event
+      and never competes for the initial connection budget — it just fails
+      silently in the background.
+    -->
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag('js', new Date());
+      gtag('config', 'G-Y6N02K05B8');
+      (function () {
+        function loadGtag() {
+          var s = document.createElement('script');
+          s.async = true;
+          s.src = 'https://www.googletagmanager.com/gtag/js?id=G-Y6N02K05B8';
+          document.head.appendChild(s);
+        }
+        function schedule() {
+          if ('requestIdleCallback' in window) requestIdleCallback(loadGtag, { timeout: 3000 });
+          else setTimeout(loadGtag, 1200);
+        }
+        if (document.readyState === 'complete') schedule();
+        else window.addEventListener('load', schedule);
+      })();
+    </script>
+    <!--
       `viewport-fit=cover` is required so iOS Safari / Capacitor expose
       `env(safe-area-inset-*)` (notch + home indicator) — without it those
       env vars all resolve to 0px and our mobile layout draws under the


### PR DESCRIPTION
## 背景
为 Nexior（studio.acedata.cloud，同时打包成 iOS/Android）接入 Google Analytics 4（measurement ID `G-Y6N02K05B8`，与 platform / auth 同一 property）。

## 改动
在 `index.html` `<head>`（`<meta charset>` 之后）注入 GA4，采用**惰性加载**：`gtag` stub + `config` 内联定义（无网络，事件先入队），远程 `googletagmanager.com` 脚本在页面 `load` + idle 后再插入。中国网络下 googletagmanager 被拦截/拖慢时请求只在后台静默失败，**不阻塞渲染、不阻塞 load 事件、不抢占初始连接**。附带 beachball change file。

## 🤖 对抗评审
独立评审（subagent；codex token 失效）针对惰性加载逻辑：① `gtag(js/config)` 先入 `dataLayer`，gtag.js 载入后 drain 队列——GA4 标准模式，正确；② `<head>` 解析期 IIFE 同步执行，`readyState=loading` 走 `load` 监听、`complete` 直接调度、`interactive` 正确等待 `load`，无「永不触发」缺口；③ `schedule/loadGtag` 各只调用一次，无重复注入；④ 非严格模式、无未定义引用，不抛错；⑤ 老 Safari 无 `requestIdleCallback` 有 `setTimeout(1200)` 兜底；⑥ 延到 `load`+idle 会让秒退用户漏掉 `page_view`——既定、可接受的非阻塞取舍，非缺陷。VERDICT: CLEAN。