### PR TITLE
feat(usage): 全面对标 PlatformFrontend 使用分析（趋势/占比/明细三视图 + 自动刷新 + 流式导出）

### DIFF
--- a/change/@acedatacloud-nexior-30e1be00-93ff-48d4-97aa-de73bd980970.json
+++ b/change/@acedatacloud-nexior-30e1be00-93ff-48d4-97aa-de73bd980970.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "align Console usage analytics with PlatformFrontend: three-view card (trend bar / share doughnut / breakdown table) with dynamic Top-N, auto-refresh toggle, streamed CSV export, processing tag",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/i18n/ar/usage.json
+++ b/src/i18n/ar/usage.json
@@ -118,5 +118,45 @@
   "dialog.noData": {
     "message": "لا توجد بيانات",
     "description": "يظهر عند عدم وجود بيانات طلب أو استجابة."
+  },
+  "field.consumed": {
+    "message": "مستهلك",
+    "description": "Column header in the usage breakdown table for the total points a single API consumed within the selected time range."
+  },
+  "field.share": {
+    "message": "النسبة",
+    "description": "Column header in the usage breakdown table for a single API's percentage of the total consumption."
+  },
+  "field.autoRefresh": {
+    "message": "تحديث تلقائي",
+    "description": "Toggle label at the top-right of the usage table; when on, the latest records refresh automatically on an interval."
+  },
+  "value.processing": {
+    "message": "قيد المعالجة",
+    "description": "Placeholder shown in the status code column while an async task has not yet returned a final status code."
+  },
+  "value.others": {
+    "message": "أخرى",
+    "description": "Series name in the usage-trend chart that aggregates all APIs outside the top spenders."
+  },
+  "title.usageAnalytics": {
+    "message": "تحليلات الاستخدام",
+    "description": "Title of the usage analytics card, which contains trend, share, and breakdown view tabs."
+  },
+  "view.trend": {
+    "message": "الاتجاه",
+    "description": "View switch button in the usage analytics card: stacked bar chart of per-API consumption over time."
+  },
+  "view.distribution": {
+    "message": "النسبة",
+    "description": "View switch button in the usage analytics card: doughnut chart of each API's consumption share."
+  },
+  "view.breakdown": {
+    "message": "التفاصيل",
+    "description": "View switch button in the usage analytics card: a table listing every API's exact consumption and share."
+  },
+  "message.exportFailed": {
+    "message": "فشل التصدير. يرجى تضييق النطاق الزمني والمحاولة مرة أخرى.",
+    "description": "Error toast shown when the CSV export request fails (network or server error)."
   }
 }

--- a/src/i18n/de/usage.json
+++ b/src/i18n/de/usage.json
@@ -118,5 +118,45 @@
   "dialog.noData": {
     "message": "Keine Daten verfügbar",
     "description": "Wird angezeigt, wenn keine Anfrage- oder Antwortdaten vorhanden sind."
+  },
+  "field.consumed": {
+    "message": "Verbraucht",
+    "description": "Column header in the usage breakdown table for the total points a single API consumed within the selected time range."
+  },
+  "field.share": {
+    "message": "Anteil",
+    "description": "Column header in the usage breakdown table for a single API's percentage of the total consumption."
+  },
+  "field.autoRefresh": {
+    "message": "Automatische Aktualisierung",
+    "description": "Toggle label at the top-right of the usage table; when on, the latest records refresh automatically on an interval."
+  },
+  "value.processing": {
+    "message": "Wird verarbeitet",
+    "description": "Placeholder shown in the status code column while an async task has not yet returned a final status code."
+  },
+  "value.others": {
+    "message": "Sonstige",
+    "description": "Series name in the usage-trend chart that aggregates all APIs outside the top spenders."
+  },
+  "title.usageAnalytics": {
+    "message": "Nutzungsanalyse",
+    "description": "Title of the usage analytics card, which contains trend, share, and breakdown view tabs."
+  },
+  "view.trend": {
+    "message": "Trend",
+    "description": "View switch button in the usage analytics card: stacked bar chart of per-API consumption over time."
+  },
+  "view.distribution": {
+    "message": "Anteil",
+    "description": "View switch button in the usage analytics card: doughnut chart of each API's consumption share."
+  },
+  "view.breakdown": {
+    "message": "Aufschlüsselung",
+    "description": "View switch button in the usage analytics card: a table listing every API's exact consumption and share."
+  },
+  "message.exportFailed": {
+    "message": "Export fehlgeschlagen. Bitte grenzen Sie den Zeitraum ein und versuchen Sie es erneut.",
+    "description": "Error toast shown when the CSV export request fails (network or server error)."
   }
 }

--- a/src/i18n/el/usage.json
+++ b/src/i18n/el/usage.json
@@ -118,5 +118,45 @@
   "dialog.noData": {
     "message": "Δεν υπάρχουν διαθέσιμα δεδομένα",
     "description": "Εμφανίζεται όταν δεν υπάρχουν δεδομένα αιτήματος ή απόκρισης."
+  },
+  "field.consumed": {
+    "message": "Καταναλώθηκε",
+    "description": "Column header in the usage breakdown table for the total points a single API consumed within the selected time range."
+  },
+  "field.share": {
+    "message": "Ποσοστό",
+    "description": "Column header in the usage breakdown table for a single API's percentage of the total consumption."
+  },
+  "field.autoRefresh": {
+    "message": "Αυτόματη ανανέωση",
+    "description": "Toggle label at the top-right of the usage table; when on, the latest records refresh automatically on an interval."
+  },
+  "value.processing": {
+    "message": "Επεξεργασία",
+    "description": "Placeholder shown in the status code column while an async task has not yet returned a final status code."
+  },
+  "value.others": {
+    "message": "Άλλα",
+    "description": "Series name in the usage-trend chart that aggregates all APIs outside the top spenders."
+  },
+  "title.usageAnalytics": {
+    "message": "Αναλυτικά χρήσης",
+    "description": "Title of the usage analytics card, which contains trend, share, and breakdown view tabs."
+  },
+  "view.trend": {
+    "message": "Τάση",
+    "description": "View switch button in the usage analytics card: stacked bar chart of per-API consumption over time."
+  },
+  "view.distribution": {
+    "message": "Ποσοστό",
+    "description": "View switch button in the usage analytics card: doughnut chart of each API's consumption share."
+  },
+  "view.breakdown": {
+    "message": "Ανάλυση",
+    "description": "View switch button in the usage analytics card: a table listing every API's exact consumption and share."
+  },
+  "message.exportFailed": {
+    "message": "Η εξαγωγή απέτυχε. Περιορίστε το εύρος ημερομηνιών και δοκιμάστε ξανά.",
+    "description": "Error toast shown when the CSV export request fails (network or server error)."
   }
 }

--- a/src/i18n/en/usage.json
+++ b/src/i18n/en/usage.json
@@ -118,5 +118,45 @@
   "dialog.noData": {
     "message": "No Data Available",
     "description": "Shown when no request or response data is present."
+  },
+  "field.consumed": {
+    "message": "Consumed",
+    "description": "Column header in the usage breakdown table for the total points a single API consumed within the selected time range."
+  },
+  "field.share": {
+    "message": "Share",
+    "description": "Column header in the usage breakdown table for a single API's percentage of the total consumption."
+  },
+  "field.autoRefresh": {
+    "message": "Auto Refresh",
+    "description": "Toggle label at the top-right of the usage table; when on, the latest records refresh automatically on an interval."
+  },
+  "value.processing": {
+    "message": "Processing",
+    "description": "Placeholder shown in the status code column while an async task has not yet returned a final status code."
+  },
+  "value.others": {
+    "message": "Others",
+    "description": "Series name in the usage-trend chart that aggregates all APIs outside the top spenders."
+  },
+  "title.usageAnalytics": {
+    "message": "Usage Analytics",
+    "description": "Title of the usage analytics card, which contains trend, share, and breakdown view tabs."
+  },
+  "view.trend": {
+    "message": "Trend",
+    "description": "View switch button in the usage analytics card: stacked bar chart of per-API consumption over time."
+  },
+  "view.distribution": {
+    "message": "Share",
+    "description": "View switch button in the usage analytics card: doughnut chart of each API's consumption share."
+  },
+  "view.breakdown": {
+    "message": "Breakdown",
+    "description": "View switch button in the usage analytics card: a table listing every API's exact consumption and share."
+  },
+  "message.exportFailed": {
+    "message": "Export failed. Please narrow the date range and try again.",
+    "description": "Error toast shown when the CSV export request fails (network or server error)."
   }
 }

--- a/src/i18n/es/usage.json
+++ b/src/i18n/es/usage.json
@@ -118,5 +118,45 @@
   "dialog.noData": {
     "message": "Sin datos disponibles",
     "description": "Se muestra cuando no hay datos de solicitud o respuesta."
+  },
+  "field.consumed": {
+    "message": "Consumido",
+    "description": "Column header in the usage breakdown table for the total points a single API consumed within the selected time range."
+  },
+  "field.share": {
+    "message": "Proporción",
+    "description": "Column header in the usage breakdown table for a single API's percentage of the total consumption."
+  },
+  "field.autoRefresh": {
+    "message": "Actualización automática",
+    "description": "Toggle label at the top-right of the usage table; when on, the latest records refresh automatically on an interval."
+  },
+  "value.processing": {
+    "message": "Procesando",
+    "description": "Placeholder shown in the status code column while an async task has not yet returned a final status code."
+  },
+  "value.others": {
+    "message": "Otros",
+    "description": "Series name in the usage-trend chart that aggregates all APIs outside the top spenders."
+  },
+  "title.usageAnalytics": {
+    "message": "Análisis de uso",
+    "description": "Title of the usage analytics card, which contains trend, share, and breakdown view tabs."
+  },
+  "view.trend": {
+    "message": "Tendencia",
+    "description": "View switch button in the usage analytics card: stacked bar chart of per-API consumption over time."
+  },
+  "view.distribution": {
+    "message": "Proporción",
+    "description": "View switch button in the usage analytics card: doughnut chart of each API's consumption share."
+  },
+  "view.breakdown": {
+    "message": "Desglose",
+    "description": "View switch button in the usage analytics card: a table listing every API's exact consumption and share."
+  },
+  "message.exportFailed": {
+    "message": "Error al exportar. Reduzca el rango de fechas e inténtelo de nuevo.",
+    "description": "Error toast shown when the CSV export request fails (network or server error)."
   }
 }

--- a/src/i18n/fi/usage.json
+++ b/src/i18n/fi/usage.json
@@ -118,5 +118,45 @@
   "dialog.noData": {
     "message": "Ei tietoja saatavilla",
     "description": "Näytetään, kun pyyntö- tai vastaustietoja ei ole."
+  },
+  "field.consumed": {
+    "message": "Kulutettu",
+    "description": "Column header in the usage breakdown table for the total points a single API consumed within the selected time range."
+  },
+  "field.share": {
+    "message": "Osuus",
+    "description": "Column header in the usage breakdown table for a single API's percentage of the total consumption."
+  },
+  "field.autoRefresh": {
+    "message": "Automaattinen päivitys",
+    "description": "Toggle label at the top-right of the usage table; when on, the latest records refresh automatically on an interval."
+  },
+  "value.processing": {
+    "message": "Käsitellään",
+    "description": "Placeholder shown in the status code column while an async task has not yet returned a final status code."
+  },
+  "value.others": {
+    "message": "Muut",
+    "description": "Series name in the usage-trend chart that aggregates all APIs outside the top spenders."
+  },
+  "title.usageAnalytics": {
+    "message": "Käytön analytiikka",
+    "description": "Title of the usage analytics card, which contains trend, share, and breakdown view tabs."
+  },
+  "view.trend": {
+    "message": "Trendi",
+    "description": "View switch button in the usage analytics card: stacked bar chart of per-API consumption over time."
+  },
+  "view.distribution": {
+    "message": "Osuus",
+    "description": "View switch button in the usage analytics card: doughnut chart of each API's consumption share."
+  },
+  "view.breakdown": {
+    "message": "Erittely",
+    "description": "View switch button in the usage analytics card: a table listing every API's exact consumption and share."
+  },
+  "message.exportFailed": {
+    "message": "Vienti epäonnistui. Rajaa aikaväliä ja yritä uudelleen.",
+    "description": "Error toast shown when the CSV export request fails (network or server error)."
   }
 }

--- a/src/i18n/fr/usage.json
+++ b/src/i18n/fr/usage.json
@@ -118,5 +118,45 @@
   "dialog.noData": {
     "message": "Aucune donnée disponible",
     "description": "Affiché lorsqu'aucune donnée de requête ou réponse n'est présente."
+  },
+  "field.consumed": {
+    "message": "Consommé",
+    "description": "Column header in the usage breakdown table for the total points a single API consumed within the selected time range."
+  },
+  "field.share": {
+    "message": "Part",
+    "description": "Column header in the usage breakdown table for a single API's percentage of the total consumption."
+  },
+  "field.autoRefresh": {
+    "message": "Actualisation automatique",
+    "description": "Toggle label at the top-right of the usage table; when on, the latest records refresh automatically on an interval."
+  },
+  "value.processing": {
+    "message": "En cours",
+    "description": "Placeholder shown in the status code column while an async task has not yet returned a final status code."
+  },
+  "value.others": {
+    "message": "Autres",
+    "description": "Series name in the usage-trend chart that aggregates all APIs outside the top spenders."
+  },
+  "title.usageAnalytics": {
+    "message": "Analyse d'utilisation",
+    "description": "Title of the usage analytics card, which contains trend, share, and breakdown view tabs."
+  },
+  "view.trend": {
+    "message": "Tendance",
+    "description": "View switch button in the usage analytics card: stacked bar chart of per-API consumption over time."
+  },
+  "view.distribution": {
+    "message": "Répartition",
+    "description": "View switch button in the usage analytics card: doughnut chart of each API's consumption share."
+  },
+  "view.breakdown": {
+    "message": "Détail",
+    "description": "View switch button in the usage analytics card: a table listing every API's exact consumption and share."
+  },
+  "message.exportFailed": {
+    "message": "Échec de l'exportation. Veuillez réduire la plage de dates et réessayer.",
+    "description": "Error toast shown when the CSV export request fails (network or server error)."
   }
 }

--- a/src/i18n/it/usage.json
+++ b/src/i18n/it/usage.json
@@ -118,5 +118,45 @@
   "dialog.noData": {
     "message": "Nessun dato disponibile",
     "description": "Mostrato quando non sono presenti dati di richiesta o risposta."
+  },
+  "field.consumed": {
+    "message": "Consumato",
+    "description": "Column header in the usage breakdown table for the total points a single API consumed within the selected time range."
+  },
+  "field.share": {
+    "message": "Quota",
+    "description": "Column header in the usage breakdown table for a single API's percentage of the total consumption."
+  },
+  "field.autoRefresh": {
+    "message": "Aggiornamento automatico",
+    "description": "Toggle label at the top-right of the usage table; when on, the latest records refresh automatically on an interval."
+  },
+  "value.processing": {
+    "message": "In elaborazione",
+    "description": "Placeholder shown in the status code column while an async task has not yet returned a final status code."
+  },
+  "value.others": {
+    "message": "Altri",
+    "description": "Series name in the usage-trend chart that aggregates all APIs outside the top spenders."
+  },
+  "title.usageAnalytics": {
+    "message": "Analisi dell'utilizzo",
+    "description": "Title of the usage analytics card, which contains trend, share, and breakdown view tabs."
+  },
+  "view.trend": {
+    "message": "Tendenza",
+    "description": "View switch button in the usage analytics card: stacked bar chart of per-API consumption over time."
+  },
+  "view.distribution": {
+    "message": "Quota",
+    "description": "View switch button in the usage analytics card: doughnut chart of each API's consumption share."
+  },
+  "view.breakdown": {
+    "message": "Dettaglio",
+    "description": "View switch button in the usage analytics card: a table listing every API's exact consumption and share."
+  },
+  "message.exportFailed": {
+    "message": "Esportazione non riuscita. Riduci l'intervallo di date e riprova.",
+    "description": "Error toast shown when the CSV export request fails (network or server error)."
   }
 }

--- a/src/i18n/ja/usage.json
+++ b/src/i18n/ja/usage.json
@@ -118,5 +118,45 @@
   "dialog.noData": {
     "message": "データがありません",
     "description": "リクエストまたはレスポンスデータがない場合の表示"
+  },
+  "field.consumed": {
+    "message": "消費量",
+    "description": "Column header in the usage breakdown table for the total points a single API consumed within the selected time range."
+  },
+  "field.share": {
+    "message": "割合",
+    "description": "Column header in the usage breakdown table for a single API's percentage of the total consumption."
+  },
+  "field.autoRefresh": {
+    "message": "自動更新",
+    "description": "Toggle label at the top-right of the usage table; when on, the latest records refresh automatically on an interval."
+  },
+  "value.processing": {
+    "message": "処理中",
+    "description": "Placeholder shown in the status code column while an async task has not yet returned a final status code."
+  },
+  "value.others": {
+    "message": "その他",
+    "description": "Series name in the usage-trend chart that aggregates all APIs outside the top spenders."
+  },
+  "title.usageAnalytics": {
+    "message": "使用状況分析",
+    "description": "Title of the usage analytics card, which contains trend, share, and breakdown view tabs."
+  },
+  "view.trend": {
+    "message": "推移",
+    "description": "View switch button in the usage analytics card: stacked bar chart of per-API consumption over time."
+  },
+  "view.distribution": {
+    "message": "割合",
+    "description": "View switch button in the usage analytics card: doughnut chart of each API's consumption share."
+  },
+  "view.breakdown": {
+    "message": "明細",
+    "description": "View switch button in the usage analytics card: a table listing every API's exact consumption and share."
+  },
+  "message.exportFailed": {
+    "message": "エクスポートに失敗しました。期間を絞って再試行してください。",
+    "description": "Error toast shown when the CSV export request fails (network or server error)."
   }
 }

--- a/src/i18n/ko/usage.json
+++ b/src/i18n/ko/usage.json
@@ -118,5 +118,45 @@
   "dialog.noData": {
     "message": "데이터 없음",
     "description": "요청 또는 응답 데이터가 없을 때의 안내"
+  },
+  "field.consumed": {
+    "message": "소비량",
+    "description": "Column header in the usage breakdown table for the total points a single API consumed within the selected time range."
+  },
+  "field.share": {
+    "message": "비율",
+    "description": "Column header in the usage breakdown table for a single API's percentage of the total consumption."
+  },
+  "field.autoRefresh": {
+    "message": "자동 새로고침",
+    "description": "Toggle label at the top-right of the usage table; when on, the latest records refresh automatically on an interval."
+  },
+  "value.processing": {
+    "message": "처리 중",
+    "description": "Placeholder shown in the status code column while an async task has not yet returned a final status code."
+  },
+  "value.others": {
+    "message": "기타",
+    "description": "Series name in the usage-trend chart that aggregates all APIs outside the top spenders."
+  },
+  "title.usageAnalytics": {
+    "message": "사용량 분석",
+    "description": "Title of the usage analytics card, which contains trend, share, and breakdown view tabs."
+  },
+  "view.trend": {
+    "message": "추세",
+    "description": "View switch button in the usage analytics card: stacked bar chart of per-API consumption over time."
+  },
+  "view.distribution": {
+    "message": "비율",
+    "description": "View switch button in the usage analytics card: doughnut chart of each API's consumption share."
+  },
+  "view.breakdown": {
+    "message": "세부 내역",
+    "description": "View switch button in the usage analytics card: a table listing every API's exact consumption and share."
+  },
+  "message.exportFailed": {
+    "message": "내보내기에 실패했습니다. 기간을 좁혀 다시 시도하세요.",
+    "description": "Error toast shown when the CSV export request fails (network or server error)."
   }
 }

--- a/src/i18n/pl/usage.json
+++ b/src/i18n/pl/usage.json
@@ -118,5 +118,45 @@
   "dialog.noData": {
     "message": "Brak dostępnych danych",
     "description": "Wyświetlane, gdy brak danych żądania lub odpowiedzi."
+  },
+  "field.consumed": {
+    "message": "Zużyte",
+    "description": "Column header in the usage breakdown table for the total points a single API consumed within the selected time range."
+  },
+  "field.share": {
+    "message": "Udział",
+    "description": "Column header in the usage breakdown table for a single API's percentage of the total consumption."
+  },
+  "field.autoRefresh": {
+    "message": "Automatyczne odświeżanie",
+    "description": "Toggle label at the top-right of the usage table; when on, the latest records refresh automatically on an interval."
+  },
+  "value.processing": {
+    "message": "Przetwarzanie",
+    "description": "Placeholder shown in the status code column while an async task has not yet returned a final status code."
+  },
+  "value.others": {
+    "message": "Inne",
+    "description": "Series name in the usage-trend chart that aggregates all APIs outside the top spenders."
+  },
+  "title.usageAnalytics": {
+    "message": "Analityka użycia",
+    "description": "Title of the usage analytics card, which contains trend, share, and breakdown view tabs."
+  },
+  "view.trend": {
+    "message": "Trend",
+    "description": "View switch button in the usage analytics card: stacked bar chart of per-API consumption over time."
+  },
+  "view.distribution": {
+    "message": "Udział",
+    "description": "View switch button in the usage analytics card: doughnut chart of each API's consumption share."
+  },
+  "view.breakdown": {
+    "message": "Szczegóły",
+    "description": "View switch button in the usage analytics card: a table listing every API's exact consumption and share."
+  },
+  "message.exportFailed": {
+    "message": "Eksport nie powiódł się. Zawęź zakres dat i spróbuj ponownie.",
+    "description": "Error toast shown when the CSV export request fails (network or server error)."
   }
 }

--- a/src/i18n/pt/usage.json
+++ b/src/i18n/pt/usage.json
@@ -118,5 +118,45 @@
   "dialog.noData": {
     "message": "Sem dados disponíveis",
     "description": "Exibido quando não há dados de solicitação ou resposta."
+  },
+  "field.consumed": {
+    "message": "Consumido",
+    "description": "Column header in the usage breakdown table for the total points a single API consumed within the selected time range."
+  },
+  "field.share": {
+    "message": "Proporção",
+    "description": "Column header in the usage breakdown table for a single API's percentage of the total consumption."
+  },
+  "field.autoRefresh": {
+    "message": "Atualização automática",
+    "description": "Toggle label at the top-right of the usage table; when on, the latest records refresh automatically on an interval."
+  },
+  "value.processing": {
+    "message": "Processando",
+    "description": "Placeholder shown in the status code column while an async task has not yet returned a final status code."
+  },
+  "value.others": {
+    "message": "Outros",
+    "description": "Series name in the usage-trend chart that aggregates all APIs outside the top spenders."
+  },
+  "title.usageAnalytics": {
+    "message": "Análise de uso",
+    "description": "Title of the usage analytics card, which contains trend, share, and breakdown view tabs."
+  },
+  "view.trend": {
+    "message": "Tendência",
+    "description": "View switch button in the usage analytics card: stacked bar chart of per-API consumption over time."
+  },
+  "view.distribution": {
+    "message": "Proporção",
+    "description": "View switch button in the usage analytics card: doughnut chart of each API's consumption share."
+  },
+  "view.breakdown": {
+    "message": "Detalhamento",
+    "description": "View switch button in the usage analytics card: a table listing every API's exact consumption and share."
+  },
+  "message.exportFailed": {
+    "message": "Falha na exportação. Reduza o intervalo de datas e tente novamente.",
+    "description": "Error toast shown when the CSV export request fails (network or server error)."
   }
 }

--- a/src/i18n/ru/usage.json
+++ b/src/i18n/ru/usage.json
@@ -118,5 +118,45 @@
   "dialog.noData": {
     "message": "Нет данных",
     "description": "Отображается, когда нет данных запроса или ответа."
+  },
+  "field.consumed": {
+    "message": "Израсходовано",
+    "description": "Column header in the usage breakdown table for the total points a single API consumed within the selected time range."
+  },
+  "field.share": {
+    "message": "Доля",
+    "description": "Column header in the usage breakdown table for a single API's percentage of the total consumption."
+  },
+  "field.autoRefresh": {
+    "message": "Автообновление",
+    "description": "Toggle label at the top-right of the usage table; when on, the latest records refresh automatically on an interval."
+  },
+  "value.processing": {
+    "message": "Обработка",
+    "description": "Placeholder shown in the status code column while an async task has not yet returned a final status code."
+  },
+  "value.others": {
+    "message": "Прочее",
+    "description": "Series name in the usage-trend chart that aggregates all APIs outside the top spenders."
+  },
+  "title.usageAnalytics": {
+    "message": "Аналитика использования",
+    "description": "Title of the usage analytics card, which contains trend, share, and breakdown view tabs."
+  },
+  "view.trend": {
+    "message": "Тренд",
+    "description": "View switch button in the usage analytics card: stacked bar chart of per-API consumption over time."
+  },
+  "view.distribution": {
+    "message": "Доля",
+    "description": "View switch button in the usage analytics card: doughnut chart of each API's consumption share."
+  },
+  "view.breakdown": {
+    "message": "Детализация",
+    "description": "View switch button in the usage analytics card: a table listing every API's exact consumption and share."
+  },
+  "message.exportFailed": {
+    "message": "Не удалось экспортировать. Сузьте диапазон дат и повторите попытку.",
+    "description": "Error toast shown when the CSV export request fails (network or server error)."
   }
 }

--- a/src/i18n/sr/usage.json
+++ b/src/i18n/sr/usage.json
@@ -118,5 +118,45 @@
   "dialog.noData": {
     "message": "Нема доступних података",
     "description": "Приказује се када нема података захтева или одговора."
+  },
+  "field.consumed": {
+    "message": "Потрошено",
+    "description": "Column header in the usage breakdown table for the total points a single API consumed within the selected time range."
+  },
+  "field.share": {
+    "message": "Удео",
+    "description": "Column header in the usage breakdown table for a single API's percentage of the total consumption."
+  },
+  "field.autoRefresh": {
+    "message": "Аутоматско освежавање",
+    "description": "Toggle label at the top-right of the usage table; when on, the latest records refresh automatically on an interval."
+  },
+  "value.processing": {
+    "message": "Обрада",
+    "description": "Placeholder shown in the status code column while an async task has not yet returned a final status code."
+  },
+  "value.others": {
+    "message": "Остало",
+    "description": "Series name in the usage-trend chart that aggregates all APIs outside the top spenders."
+  },
+  "title.usageAnalytics": {
+    "message": "Аналитика коришћења",
+    "description": "Title of the usage analytics card, which contains trend, share, and breakdown view tabs."
+  },
+  "view.trend": {
+    "message": "Тренд",
+    "description": "View switch button in the usage analytics card: stacked bar chart of per-API consumption over time."
+  },
+  "view.distribution": {
+    "message": "Удео",
+    "description": "View switch button in the usage analytics card: doughnut chart of each API's consumption share."
+  },
+  "view.breakdown": {
+    "message": "Детаљно",
+    "description": "View switch button in the usage analytics card: a table listing every API's exact consumption and share."
+  },
+  "message.exportFailed": {
+    "message": "Извоз није успео. Сузите опсег датума и покушајте поново.",
+    "description": "Error toast shown when the CSV export request fails (network or server error)."
   }
 }

--- a/src/i18n/sv/usage.json
+++ b/src/i18n/sv/usage.json
@@ -118,5 +118,45 @@
   "dialog.noData": {
     "message": "Inga data tillgängliga",
     "description": "Visas när inga begäran- eller svarsdata finns."
+  },
+  "field.consumed": {
+    "message": "Förbrukat",
+    "description": "Column header in the usage breakdown table for the total points a single API consumed within the selected time range."
+  },
+  "field.share": {
+    "message": "Andel",
+    "description": "Column header in the usage breakdown table for a single API's percentage of the total consumption."
+  },
+  "field.autoRefresh": {
+    "message": "Automatisk uppdatering",
+    "description": "Toggle label at the top-right of the usage table; when on, the latest records refresh automatically on an interval."
+  },
+  "value.processing": {
+    "message": "Bearbetar",
+    "description": "Placeholder shown in the status code column while an async task has not yet returned a final status code."
+  },
+  "value.others": {
+    "message": "Övriga",
+    "description": "Series name in the usage-trend chart that aggregates all APIs outside the top spenders."
+  },
+  "title.usageAnalytics": {
+    "message": "Användningsanalys",
+    "description": "Title of the usage analytics card, which contains trend, share, and breakdown view tabs."
+  },
+  "view.trend": {
+    "message": "Trend",
+    "description": "View switch button in the usage analytics card: stacked bar chart of per-API consumption over time."
+  },
+  "view.distribution": {
+    "message": "Andel",
+    "description": "View switch button in the usage analytics card: doughnut chart of each API's consumption share."
+  },
+  "view.breakdown": {
+    "message": "Fördelning",
+    "description": "View switch button in the usage analytics card: a table listing every API's exact consumption and share."
+  },
+  "message.exportFailed": {
+    "message": "Exporten misslyckades. Begränsa datumintervallet och försök igen.",
+    "description": "Error toast shown when the CSV export request fails (network or server error)."
   }
 }

--- a/src/i18n/uk/usage.json
+++ b/src/i18n/uk/usage.json
@@ -118,5 +118,45 @@
   "dialog.noData": {
     "message": "Дані відсутні",
     "description": "Відображається, коли немає даних запиту або відповіді."
+  },
+  "field.consumed": {
+    "message": "Витрачено",
+    "description": "Column header in the usage breakdown table for the total points a single API consumed within the selected time range."
+  },
+  "field.share": {
+    "message": "Частка",
+    "description": "Column header in the usage breakdown table for a single API's percentage of the total consumption."
+  },
+  "field.autoRefresh": {
+    "message": "Автооновлення",
+    "description": "Toggle label at the top-right of the usage table; when on, the latest records refresh automatically on an interval."
+  },
+  "value.processing": {
+    "message": "Обробка",
+    "description": "Placeholder shown in the status code column while an async task has not yet returned a final status code."
+  },
+  "value.others": {
+    "message": "Інші",
+    "description": "Series name in the usage-trend chart that aggregates all APIs outside the top spenders."
+  },
+  "title.usageAnalytics": {
+    "message": "Аналітика використання",
+    "description": "Title of the usage analytics card, which contains trend, share, and breakdown view tabs."
+  },
+  "view.trend": {
+    "message": "Тренд",
+    "description": "View switch button in the usage analytics card: stacked bar chart of per-API consumption over time."
+  },
+  "view.distribution": {
+    "message": "Частка",
+    "description": "View switch button in the usage analytics card: doughnut chart of each API's consumption share."
+  },
+  "view.breakdown": {
+    "message": "Деталізація",
+    "description": "View switch button in the usage analytics card: a table listing every API's exact consumption and share."
+  },
+  "message.exportFailed": {
+    "message": "Не вдалося експортувати. Звузьте діапазон дат і повторіть спробу.",
+    "description": "Error toast shown when the CSV export request fails (network or server error)."
   }
 }

--- a/src/i18n/zh-CN/usage.json
+++ b/src/i18n/zh-CN/usage.json
@@ -118,5 +118,45 @@
   "dialog.noData": {
     "message": "暂无数据",
     "description": "没有请求或响应数据时的提示"
+  },
+  "field.consumed": {
+    "message": "消耗积分",
+    "description": "使用明细表格中，单个 API 在所选时间范围内消耗的积分总量列标题。"
+  },
+  "field.share": {
+    "message": "占比",
+    "description": "使用明细表格中，单个 API 消耗占总消耗百分比的列标题。"
+  },
+  "field.autoRefresh": {
+    "message": "自动刷新",
+    "description": "使用记录表格右上角的开关标签，开启后定时自动刷新最新记录。"
+  },
+  "value.processing": {
+    "message": "处理中",
+    "description": "异步任务尚未返回最终状态码时，状态码列显示的占位文案。"
+  },
+  "value.others": {
+    "message": "其他",
+    "description": "使用趋势图中，除消耗最高的若干 API 外，其余 API 合并显示的系列名称。"
+  },
+  "title.usageAnalytics": {
+    "message": "使用分析",
+    "description": "使用分析卡片的标题，卡片内含趋势、占比、明细三个视图切换。"
+  },
+  "view.trend": {
+    "message": "趋势",
+    "description": "使用分析卡片的视图切换按钮：按时间展示各 API 消耗的堆叠柱状图。"
+  },
+  "view.distribution": {
+    "message": "占比",
+    "description": "使用分析卡片的视图切换按钮：展示各 API 消耗占比的环形图。"
+  },
+  "view.breakdown": {
+    "message": "明细",
+    "description": "使用分析卡片的视图切换按钮：以表格列出全部 API 的精确消耗与占比。"
+  },
+  "message.exportFailed": {
+    "message": "导出失败，请缩小时间范围后重试。",
+    "description": "CSV 导出请求失败（网络或服务端错误）时的错误提示"
   }
 }

--- a/src/i18n/zh-TW/usage.json
+++ b/src/i18n/zh-TW/usage.json
@@ -118,5 +118,45 @@
   "dialog.noData": {
     "message": "暫無數據",
     "description": "沒有請求或回應資料時的提示"
+  },
+  "field.consumed": {
+    "message": "消耗積分",
+    "description": "Column header in the usage breakdown table for the total points a single API consumed within the selected time range."
+  },
+  "field.share": {
+    "message": "佔比",
+    "description": "Column header in the usage breakdown table for a single API's percentage of the total consumption."
+  },
+  "field.autoRefresh": {
+    "message": "自動重新整理",
+    "description": "Toggle label at the top-right of the usage table; when on, the latest records refresh automatically on an interval."
+  },
+  "value.processing": {
+    "message": "處理中",
+    "description": "Placeholder shown in the status code column while an async task has not yet returned a final status code."
+  },
+  "value.others": {
+    "message": "其他",
+    "description": "Series name in the usage-trend chart that aggregates all APIs outside the top spenders."
+  },
+  "title.usageAnalytics": {
+    "message": "使用分析",
+    "description": "Title of the usage analytics card, which contains trend, share, and breakdown view tabs."
+  },
+  "view.trend": {
+    "message": "趨勢",
+    "description": "View switch button in the usage analytics card: stacked bar chart of per-API consumption over time."
+  },
+  "view.distribution": {
+    "message": "佔比",
+    "description": "View switch button in the usage analytics card: doughnut chart of each API's consumption share."
+  },
+  "view.breakdown": {
+    "message": "明細",
+    "description": "View switch button in the usage analytics card: a table listing every API's exact consumption and share."
+  },
+  "message.exportFailed": {
+    "message": "匯出失敗，請縮小時間範圍後重試。",
+    "description": "Error toast shown when the CSV export request fails (network or server error)."
   }
 }

--- a/src/operators/usage.ts
+++ b/src/operators/usage.ts
@@ -12,6 +12,7 @@ export interface IApiUsageQuery {
   created_at_from?: string | Date;
   created_at_to?: string | Date;
   status_code?: number | string | (number | string)[];
+  trace_id?: string;
 }
 
 class ApiUsageOperator {
@@ -29,6 +30,7 @@ class ApiUsageOperator {
     api_id?: string | string[];
     created_at_from?: string | Date;
     created_at_to?: string | Date;
+    timezone?: string;
   }): Promise<
     AxiosResponse<{
       total: number;

--- a/src/pages/console/usage/List.vue
+++ b/src/pages/console/usage/List.vue
@@ -109,14 +109,76 @@
             </el-col>
             <el-col :md="18" :xs="24">
               <el-card shadow="hover" class="h-full">
+                <template #header>
+                  <div class="flex flex-wrap items-center justify-between gap-2">
+                    <span class="text-[15px] font-medium text-[var(--el-text-color-primary)]">
+                      {{ $t('usage.title.usageAnalytics') }}
+                    </span>
+                    <el-radio-group v-model="chartView" size="small">
+                      <el-radio-button value="trend" :label="$t('usage.view.trend')" />
+                      <el-radio-button value="distribution" :label="$t('usage.view.distribution')" />
+                      <el-radio-button value="breakdown" :label="$t('usage.view.breakdown')" />
+                    </el-radio-group>
+                  </div>
+                </template>
                 <div class="chart-wrapper">
                   <el-skeleton v-if="aggLoading" class="w-full" />
-                  <bar-chart v-else :data="barChartData" :options="barChartOptions" class="chart" />
+                  <template v-else-if="chartView === 'trend'">
+                    <bar-chart
+                      v-if="barChartSeries.length"
+                      :data="barChartData"
+                      :options="barChartOptions"
+                      class="chart"
+                    />
+                    <el-empty v-else :description="$t('common.message.noData')" :image-size="70" class="w-full" />
+                  </template>
+                  <template v-else-if="chartView === 'distribution'">
+                    <doughnut-chart
+                      v-if="pieData.length"
+                      :data="doughnutChartData"
+                      :options="doughnutChartOptions"
+                      class="chart"
+                    />
+                    <el-empty v-else :description="$t('common.message.noData')" :image-size="70" class="w-full" />
+                  </template>
+                  <template v-else>
+                    <el-table v-if="apiBreakdown.length" :data="apiBreakdown" size="small" height="300" class="w-full">
+                      <el-table-column :label="$t('usage.field.api')" min-width="160">
+                        <template #default="scope">
+                          <span class="color-dot" :style="{ backgroundColor: scope.row.color }" />
+                          <span>{{ scope.row.label }}</span>
+                        </template>
+                      </el-table-column>
+                      <el-table-column :label="$t('usage.field.consumed')" width="120" align="right">
+                        <template #default="scope">
+                          <span>{{ fmtAmount(scope.row.amount) }}</span>
+                        </template>
+                      </el-table-column>
+                      <el-table-column :label="$t('usage.field.share')" width="150">
+                        <template #default="scope">
+                          <div class="share-cell">
+                            <div class="share-bar">
+                              <div
+                                class="share-bar-fill"
+                                :style="{ width: scope.row.share * 100 + '%', backgroundColor: scope.row.color }"
+                              />
+                            </div>
+                            <span class="share-pct">{{ (scope.row.share * 100).toFixed(1) }}%</span>
+                          </div>
+                        </template>
+                      </el-table-column>
+                    </el-table>
+                    <el-empty v-else :description="$t('common.message.noData')" :image-size="70" class="w-full" />
+                  </template>
                 </div>
               </el-card>
             </el-col>
           </el-row>
           <el-card shadow="hover">
+            <div class="flex items-center justify-end gap-2 mb-4">
+              <span class="text-sm text-[var(--el-text-color-regular)]">{{ $t('usage.field.autoRefresh') }}</span>
+              <el-switch v-model="autoRefresh" />
+            </div>
             <el-table
               v-if="type === serviceType.API"
               v-loading="loading"
@@ -133,7 +195,8 @@
               </el-table-column>
               <el-table-column :label="$t('usage.field.statusCode')" width="120px">
                 <template #default="scope">
-                  <span>{{ scope.row.status_code }}</span>
+                  <span v-if="scope.row.status_code">{{ scope.row.status_code }}</span>
+                  <el-tag v-else type="warning" size="small">{{ $t('usage.value.processing') }}</el-tag>
                 </template>
               </el-table-column>
               <el-table-column :label="$t('usage.field.elapsed')" width="120px">
@@ -375,14 +438,62 @@ import {
   ElDialog,
   ElTabs,
   ElTabPane,
-  ElButton
+  ElButton,
+  ElEmpty,
+  ElSwitch,
+  ElMessage
 } from 'element-plus';
+import qs from 'qs';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
+import { getBaseUrlPlatform } from '@/utils';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { Bar as BarChart } from 'vue-chartjs';
-import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend } from 'chart.js';
+import { Bar as BarChart, Doughnut as DoughnutChart } from 'vue-chartjs';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  ArcElement,
+  DoughnutController,
+  Title,
+  Tooltip,
+  Legend
+} from 'chart.js';
 
-ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
+ChartJS.register(CategoryScale, LinearScale, BarElement, ArcElement, DoughnutController, Title, Tooltip, Legend);
+
+// Curated categorical palette — top spenders get distinct, readable hues
+// instead of the old hsl(idx*57) generator that collided past ~6 series.
+const CHART_PALETTE = [
+  '#5B8FF9',
+  '#5AD8A6',
+  '#5D7092',
+  '#F6BD16',
+  '#6F5EF9',
+  '#6DC8EC',
+  '#945FB9',
+  '#FF9845',
+  '#1E9493',
+  '#FF99C3'
+];
+const OTHERS_COLOR = '#C0C4CC';
+// "Others" must stay negligible: include as many top APIs (ranked by spend) as
+// needed so the folded tail is ≤ OTHERS_MAX_SHARE of the total — N is dynamic,
+// not a fixed Top-N. MAX_SERIES is only a sanity backstop for the pathological
+// "every API ~2%" case (the breakdown table still lists every API).
+const OTHERS_MAX_SHARE = 0.01;
+const MAX_SERIES = 20;
+
+// Distinct colors for the given series count: the curated palette for a handful
+// of series, else evenly-spaced hues (with alternating lightness) so adjacent
+// stacks/slices never collide.
+function seriesColors(n: number): string[] {
+  if (n <= CHART_PALETTE.length) return CHART_PALETTE.slice(0, n);
+  return Array.from({ length: n }, (_, i) => `hsl(${Math.round((i * 360) / n)}, 62%, ${i % 2 === 0 ? 55 : 45}%)`);
+}
+
+// Auto-refresh cadence for the usage table (ms).
+const AUTO_REFRESH_INTERVAL_MS = 15000;
 
 interface IData {
   apiUsages: IApiUsage[];
@@ -404,6 +515,11 @@ interface IData {
   totalUsed: number;
   barChartLabels: string[];
   barChartSeries: { key: string; label: string; data: number[]; color: string }[];
+  chartView: string;
+  apiBreakdown: { key: string; label: string; amount: number; color: string; share: number }[];
+  pieLabels: string[];
+  pieData: number[];
+  pieColors: string[];
   aggLoading: boolean;
   // detail dialog
   detailDialogVisible: boolean;
@@ -415,8 +531,12 @@ interface IData {
   // status-code filter (free-form string — user can pick from discovered
   // codes or type any number)
   statusCodeFilter: string;
+  traceId: string;
   statusCodeOptions: number[];
   statusCodeOptionsLoading: boolean;
+  autoRefresh: boolean;
+  autoRefreshTimer: number | null;
+  fetchSeq: number;
 }
 
 export default defineComponent({
@@ -441,8 +561,11 @@ export default defineComponent({
     ElTabs,
     ElTabPane,
     ElButton,
+    ElEmpty,
+    ElSwitch,
     FontAwesomeIcon,
-    BarChart
+    BarChart,
+    DoughnutChart
   },
   data(): IData {
     return {
@@ -534,6 +657,11 @@ export default defineComponent({
       totalUsed: 0,
       barChartLabels: [],
       barChartSeries: [],
+      chartView: 'trend',
+      apiBreakdown: [],
+      pieLabels: [],
+      pieData: [],
+      pieColors: [],
       aggLoading: false,
       // detail dialog
       detailDialogVisible: false,
@@ -544,8 +672,12 @@ export default defineComponent({
       exporting: false,
       // status-code filter — read from URL so back/forward + share work
       statusCodeFilter: this.$route.query.status_code?.toString() || '',
+      traceId: this.$route.query.trace_id?.toString() || '',
       statusCodeOptions: [],
-      statusCodeOptionsLoading: false
+      statusCodeOptionsLoading: false,
+      autoRefresh: true,
+      autoRefreshTimer: null,
+      fetchSeq: 0
     };
   },
   computed: {
@@ -561,36 +693,103 @@ export default defineComponent({
     barChartData() {
       return {
         labels: this.barChartLabels,
-        datasets: this.barChartSeries.map((s) => ({ label: s.label, data: s.data, backgroundColor: s.color }))
+        datasets: this.barChartSeries.map((s) => ({
+          label: s.label,
+          data: s.data,
+          backgroundColor: s.color,
+          maxBarThickness: 36,
+          borderRadius: 2,
+          borderSkipped: false
+        }))
       };
     },
     barChartOptions() {
+      const fmt = (v: number) => new Intl.NumberFormat().format(Math.round(((v || 0) + Number.EPSILON) * 100) / 100);
       return {
         responsive: true,
+        maintainAspectRatio: false,
+        interaction: { mode: 'index' as const, intersect: false },
         plugins: {
           legend: {
-            position: 'top' as const,
+            position: 'bottom' as const,
+            labels: { usePointStyle: true, pointStyle: 'circle', boxWidth: 8, boxHeight: 8, padding: 14 },
             // Clicking a legend item isolates that API; clicking again restores all
             onClick: (_event: unknown, legendItem: any, legend: any) => {
               const chart = legend?.chart;
               if (!chart || legendItem?.datasetIndex === undefined) return;
               const index: number = legendItem.datasetIndex;
               const datasets = chart.data?.datasets || [];
-              // Check if any other dataset is currently visible
               const othersVisible = datasets.some((_: any, i: number) => i !== index && chart.isDatasetVisible(i));
               if (othersVisible) {
-                // Show only the clicked dataset
                 datasets.forEach((_: any, i: number) => chart.setDatasetVisibility(i, i === index));
               } else {
-                // If only this dataset is visible, restore all
                 datasets.forEach((_: any, i: number) => chart.setDatasetVisibility(i, true));
               }
               chart.update();
             }
           },
-          title: { display: true, text: this.$t('usage.title.usageTrend') }
+          title: { display: false },
+          tooltip: {
+            itemSort: (a: any, b: any) => (b.parsed?.y || 0) - (a.parsed?.y || 0),
+            callbacks: {
+              label: (ctx: any) => ` ${ctx.dataset.label}: ${fmt(ctx.parsed.y)}`,
+              footer: (items: any[]) =>
+                `${this.$t('usage.title.totalUsed')}: ${fmt(items.reduce((s, it) => s + (it.parsed?.y || 0), 0))}`
+            }
+          }
         },
-        scales: { x: { stacked: true }, y: { stacked: true, beginAtZero: true } }
+        scales: {
+          x: {
+            stacked: true,
+            grid: { display: false },
+            ticks: { maxRotation: 0, autoSkip: true, autoSkipPadding: 16 }
+          },
+          y: {
+            stacked: true,
+            beginAtZero: true,
+            border: { display: false },
+            grid: { color: 'rgba(128, 128, 128, 0.15)' },
+            ticks: { callback: (v: string | number) => fmt(Number(v)) }
+          }
+        }
+      };
+    },
+    doughnutChartData() {
+      return {
+        labels: this.pieLabels,
+        datasets: [
+          {
+            data: this.pieData,
+            backgroundColor: this.pieColors,
+            borderWidth: 0,
+            hoverOffset: 6
+          }
+        ]
+      };
+    },
+    doughnutChartOptions() {
+      const fmt = (v: number) => this.fmtAmount(v);
+      const total = this.pieData.reduce((s, v) => s + (v || 0), 0);
+      return {
+        responsive: true,
+        maintainAspectRatio: false,
+        cutout: '58%',
+        plugins: {
+          legend: {
+            position: 'right' as const,
+            labels: { usePointStyle: true, pointStyle: 'circle', boxWidth: 8, boxHeight: 8, padding: 12 }
+          },
+          title: { display: false },
+          tooltip: {
+            callbacks: {
+              label: (ctx: any) => {
+                const v = ctx.parsed || 0;
+                const pct = total > 0 ? ((v / total) * 100).toFixed(1) : '0';
+                return ` ${ctx.label}: ${fmt(v)} (${pct}%)`;
+              }
+            }
+          }
+        }
       };
     }
   },
@@ -612,6 +811,15 @@ export default defineComponent({
         this.onFetchAggregate();
         this.onFetchStatusCodeOptions();
       }
+    },
+    autoRefresh: {
+      handler(enabled: boolean) {
+        if (enabled) {
+          this.startAutoRefresh();
+        } else {
+          this.stopAutoRefresh();
+        }
+      }
     }
   },
   mounted() {
@@ -620,13 +828,33 @@ export default defineComponent({
     this.onFetchUsages();
     this.onFetchAggregate();
     this.onFetchStatusCodeOptions();
+    if (this.autoRefresh) {
+      this.startAutoRefresh();
+    }
+  },
+  beforeUnmount() {
+    this.stopAutoRefresh();
   },
   methods: {
-    async onFetchUsages() {
+    async onFetchUsages(silent = false) {
       if (this.type === IServiceType.API) {
-        this.onFetchApiUsages();
+        this.onFetchApiUsages(silent);
       } else if (this.type === IServiceType.Proxy) {
-        this.onFetchProxyUsages();
+        this.onFetchProxyUsages(silent);
+      }
+    },
+    startAutoRefresh() {
+      this.stopAutoRefresh();
+      // Silent poll so filters/pagination stay put and the table doesn't flash.
+      this.autoRefreshTimer = window.setInterval(() => {
+        if (document.hidden) return;
+        this.onFetchUsages(true);
+      }, AUTO_REFRESH_INTERVAL_MS);
+    },
+    stopAutoRefresh() {
+      if (this.autoRefreshTimer !== null) {
+        clearInterval(this.autoRefreshTimer);
+        this.autoRefreshTimer = null;
       }
     },
     async onApiChange(apiId: string) {
@@ -652,7 +880,6 @@ export default defineComponent({
       this.onFetchAggregate();
     },
     async onTimeRangeChanged() {
-      console.log('onTimeRangeChanged', this.createdAtRange);
       await this.$router.push({
         name: this.$route.name?.toString(),
         query: {
@@ -831,7 +1058,7 @@ export default defineComponent({
       this.apisLoading = true;
       apiOperator
         .getAll({
-          limit: 100,
+          limit: 1000,
           offset: 0,
           ordering: '-created_at'
         })
@@ -843,9 +1070,9 @@ export default defineComponent({
           this.apisLoading = false;
         });
     },
-    onFetchApiUsages() {
-      console.log('onFetchApiUsages', this.createdAtRange);
-      this.loading = true;
+    onFetchApiUsages(silent = false) {
+      if (!silent) this.loading = true;
+      const seq = ++this.fetchSeq;
       apiUsageOperator
         .getAll({
           limit: this.limit,
@@ -856,19 +1083,22 @@ export default defineComponent({
           ...(this.createdAtRange?.[1] ? { created_at_to: this.createdAtRange[1] } : {}),
           ...(this.applicationIds && this.applicationIds.length ? { application_id: this.applicationIds } : {}),
           ...(this.apiIds && this.apiIds.length ? { api_id: this.apiIds } : {}),
-          ...(this.statusCodeFilter ? { status_code: this.statusCodeFilter } : {})
+          ...(this.statusCodeFilter ? { status_code: this.statusCodeFilter } : {}),
+          ...(this.traceId ? { trace_id: this.traceId } : {})
         })
         .then(({ data: data }: { data: IApiUsageListResponse }) => {
+          if (seq !== this.fetchSeq) return;
           this.apiUsages = data.items;
-          this.loading = false;
           this.total = data.count;
         })
-        .catch(() => {
-          this.loading = false;
+        .catch(() => {})
+        .finally(() => {
+          if (!silent) this.loading = false;
         });
     },
-    onFetchProxyUsages() {
-      this.loading = true;
+    onFetchProxyUsages(silent = false) {
+      if (!silent) this.loading = true;
+      const seq = ++this.fetchSeq;
       proxyUsageOperator
         .getAll({
           limit: this.limit,
@@ -878,65 +1108,176 @@ export default defineComponent({
           ...(this.applicationIds && this.applicationIds.length ? { application_id: this.applicationIds } : {})
         })
         .then(({ data: data }: { data: IProxyUsageListResponse }) => {
+          if (seq !== this.fetchSeq) return;
           this.proxyUsages = data.items;
-          this.loading = false;
           this.total = data.count;
-        })
-        .catch(() => {
-          this.loading = false;
-        });
-    },
-    onExport() {
-      this.exporting = true;
-      apiUsageOperator
-        .exportCsv({
-          user_id: this.$store.getters.user.id,
-          ...(this.createdAtRange?.[0] ? { created_at_from: this.createdAtRange[0] } : {}),
-          ...(this.createdAtRange?.[1] ? { created_at_to: this.createdAtRange[1] } : {}),
-          ...(this.applicationIds && this.applicationIds.length ? { application_id: this.applicationIds } : {}),
-          ...(this.apiIds && this.apiIds.length ? { api_id: this.apiIds } : {}),
-          ...(this.statusCodeFilter ? { status_code: this.statusCodeFilter } : {})
-        })
-        .then(({ data }: { data: Blob }) => {
-          const url = window.URL.createObjectURL(data);
-          const a = document.createElement('a');
-          a.href = url;
-          a.download = 'usages.csv';
-          a.click();
-          window.URL.revokeObjectURL(url);
         })
         .catch(() => {})
         .finally(() => {
-          this.exporting = false;
+          if (!silent) this.loading = false;
         });
     },
+    async onExport() {
+      const token = this.$store.state.token?.access;
+      if (!token) {
+        ElMessage.error(this.$t('usage.message.exportFailed') as string);
+        return;
+      }
+      const params: Record<string, unknown> = {
+        user_id: this.$store.getters.user.id,
+        ...(this.createdAtRange?.[0] ? { created_at_from: this.createdAtRange[0] } : {}),
+        ...(this.createdAtRange?.[1] ? { created_at_to: this.createdAtRange[1] } : {}),
+        ...(this.applicationIds && this.applicationIds.length ? { application_id: this.applicationIds } : {}),
+        ...(this.apiIds && this.apiIds.length ? { api_id: this.apiIds } : {}),
+        ...(this.statusCodeFilter ? { status_code: this.statusCodeFilter } : {})
+      };
+      // Absolute platform URL — raw fetch bypasses httpClient, and the relative
+      // `/api/v1` proxy only exists on the nginx web build (not Capacitor/Electron).
+      const url = `${getBaseUrlPlatform()}/api/v1/usage/apis/export/?${qs.stringify(params, { arrayFormat: 'repeat' })}`;
+
+      // Chromium: pick the save target up-front (needs the click's user
+      // activation), then stream the response body straight to disk so the
+      // browser writes each chunk as it arrives instead of buffering the whole
+      // (100 MB+) file in tab memory.
+      let fileHandle: { createWritable: () => Promise<WritableStream<Uint8Array>> } | null = null;
+      const picker = (window as unknown as { showSaveFilePicker?: (o: unknown) => Promise<typeof fileHandle> })
+        .showSaveFilePicker;
+      if (typeof picker === 'function') {
+        try {
+          fileHandle = await picker({
+            suggestedName: 'usages.csv',
+            types: [{ description: 'CSV', accept: { 'text/csv': ['.csv'] } }]
+          });
+        } catch (e) {
+          if ((e as DOMException)?.name === 'AbortError') return; // user cancelled the picker
+          fileHandle = null; // any other picker error -> fall back to blob
+        }
+      }
+
+      this.exporting = true;
+      try {
+        const response = await fetch(url, { headers: { authorization: `Bearer ${token}` } });
+        if (!response.ok || !response.body) {
+          throw new Error(`export failed: ${response.status}`);
+        }
+        if (fileHandle) {
+          // Stream chunk-by-chunk onto disk (constant memory); the file is
+          // committed when pipeTo() closes the writable, discarded on error.
+          await response.body.pipeTo(await fileHandle.createWritable());
+        } else {
+          // Fallback (Firefox/Safari or no picker): buffer then save.
+          const blob = await response.blob();
+          const objectUrl = window.URL.createObjectURL(blob);
+          const a = document.createElement('a');
+          a.href = objectUrl;
+          a.download = 'usages.csv';
+          a.click();
+          window.URL.revokeObjectURL(objectUrl);
+        }
+      } catch {
+        ElMessage.error(this.$t('usage.message.exportFailed') as string);
+      } finally {
+        this.exporting = false;
+      }
+    },
+    fmtAmount(v: number) {
+      return new Intl.NumberFormat().format(Math.round(((v || 0) + Number.EPSILON) * 100) / 100);
+    },
     async onFetchAggregate() {
-      this.aggLoading = true;
       if (this.type !== this.serviceType.API) return;
+      this.aggLoading = true;
       const params: any = {
         user_id: this.$store.getters.user.id,
         ...(this.applicationIds && this.applicationIds.length ? { application_id: this.applicationIds } : {}),
         ...(this.apiIds && this.apiIds.length ? { api_id: this.apiIds } : {}),
         ...(this.createdAtRange?.[0] ? { created_at_from: this.createdAtRange[0] } : {}),
-        ...(this.createdAtRange?.[1] ? { created_at_to: this.createdAtRange[1] } : {})
+        ...(this.createdAtRange?.[1] ? { created_at_to: this.createdAtRange[1] } : {}),
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone
       };
       try {
         const { data } = await apiUsageOperator.getAggregate(params);
         this.totalUsed = data.total || 0;
         const labels = Array.from(new Set((data.items || []).map((i: any) => i.date))).sort();
-        const apiIds = Array.from(new Set((data.items || []).map((i: any) => i.api_id)));
-        const color = (idx: number) => `hsl(${(idx * 57) % 360}, 70%, 60%)`;
-        const series = apiIds.map((id: string, idx: number) => {
-          const label = data.apis?.[id]?.title || id;
-          const map: Record<string, number> = {};
-          (data.items || [])
-            .filter((i: any) => i.api_id === id)
-            .forEach((i: any) => {
-              map[i.date] = i.amount || 0;
-            });
-          const arr = labels.map((d: string) => map[d] || 0);
-          return { key: id, label, data: arr, color: color(idx) };
+        // date -> api_id -> amount (single pass; also collapses any duplicates)
+        const grid: Record<string, Record<string, number>> = {};
+        const totals: Record<string, number> = {};
+        (data.items || []).forEach((i: any) => {
+          const amount = i.amount || 0;
+          (grid[i.date] || (grid[i.date] = {}))[i.api_id] = (grid[i.date]?.[i.api_id] || 0) + amount;
+          totals[i.api_id] = (totals[i.api_id] || 0) + amount;
         });
+        // Rank APIs by total spend (desc) and compute the grand total.
+        const rankedIds = Object.keys(totals).sort((a, b) => totals[b] - totals[a]);
+        const grand = rankedIds.reduce((s, id) => s + totals[id], 0);
+        // Dynamic Top-N: include as many top APIs as needed so the folded "Others"
+        // tail stays ≤ OTHERS_MAX_SHARE of the total (N is NOT fixed). Walk the
+        // cumulative share until the remainder is negligible; MAX_SERIES only guards
+        // the pathological "every API ~2%" case.
+        let topCount = rankedIds.length;
+        if (grand > 0) {
+          const limit = grand * (1 - OTHERS_MAX_SHARE);
+          let cum = 0;
+          for (let i = 0; i < rankedIds.length; i++) {
+            cum += totals[rankedIds[i]];
+            if (cum >= limit) {
+              topCount = i + 1;
+              break;
+            }
+          }
+          topCount = Math.min(topCount, MAX_SERIES);
+        }
+        // Folding a single leftover API into "Others" is pointless — just show it.
+        if (rankedIds.length - topCount === 1) topCount = rankedIds.length;
+        const topIds = rankedIds.slice(0, topCount);
+        const topSet = new Set(topIds);
+        const colors = seriesColors(topIds.length);
+        const tailIds = rankedIds.slice(topCount);
+        const othersLabel = `${this.$t('usage.value.others')} (${tailIds.length})`;
+
+        // Stacked-bar series (one per top API) + a folded "Others" series.
+        const series = topIds.map((id: string, idx: number) => ({
+          key: id,
+          label: data.apis?.[id]?.title || id,
+          data: labels.map((d: string) => grid[d]?.[id] || 0),
+          color: colors[idx]
+        }));
+        if (tailIds.length) {
+          const otherData = labels.map((d: string) =>
+            Object.entries(grid[d] || {}).reduce((sum, [id, amt]) => (topSet.has(id) ? sum : sum + amt), 0)
+          );
+          if (otherData.some((v) => v > 0)) {
+            series.push({ key: '__others__', label: othersLabel, data: otherData, color: OTHERS_COLOR });
+          }
+        }
+
+        // Breakdown table: ALL APIs, exact numbers + share (nothing hidden). Top rows
+        // get their chart color; the folded tail rows share the neutral "Others" grey.
+        this.apiBreakdown = rankedIds.map((id: string, idx: number) => ({
+          key: id,
+          label: data.apis?.[id]?.title || id,
+          amount: totals[id],
+          color: idx < topIds.length ? colors[idx] : OTHERS_COLOR,
+          share: grand > 0 ? totals[id] / grand : 0
+        }));
+
+        // Doughnut: one slice per top API + a single folded "Others" slice (≤ 1%).
+        const pieLabels: string[] = [];
+        const pieData: number[] = [];
+        const pieColors: string[] = [];
+        topIds.forEach((id: string, idx: number) => {
+          pieLabels.push(data.apis?.[id]?.title || id);
+          pieData.push(totals[id]);
+          pieColors.push(colors[idx]);
+        });
+        const othersTotal = tailIds.reduce((s, id) => s + totals[id], 0);
+        if (othersTotal > 0) {
+          pieLabels.push(othersLabel);
+          pieData.push(othersTotal);
+          pieColors.push(OTHERS_COLOR);
+        }
+        this.pieLabels = pieLabels;
+        this.pieData = pieData;
+        this.pieColors = pieColors;
         this.barChartLabels = labels;
         this.barChartSeries = series;
       } finally {
@@ -978,14 +1319,44 @@ export default defineComponent({
   font-size: 14px;
 }
 .chart-wrapper {
-  flex: 1;
-  min-height: 260px;
+  height: 300px;
   display: flex;
   align-items: center;
 }
 .chart {
   width: 100%;
-  max-height: 260px;
+  height: 100%;
+}
+.color-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-right: 8px;
+  vertical-align: middle;
+}
+.share-cell {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.share-bar {
+  flex: 1;
+  height: 6px;
+  border-radius: 3px;
+  background: var(--el-fill-color-light);
+  overflow: hidden;
+}
+.share-bar-fill {
+  height: 100%;
+  border-radius: 3px;
+}
+.share-pct {
+  min-width: 44px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  color: var(--el-text-color-regular);
+  font-size: 12px;
 }
 .detail-json {
   background: var(--el-bg-color-page);


### PR DESCRIPTION
## 背景
Nexior Console 的用量页面此前已通过 #837 与旧版 PlatformFrontend 对齐。但 PlatformFrontend 的 `main` 之后又合入了三个大改（#632/#633/#634），Nexior 落后了。本 PR 全面对标补齐。

## 改动
### 1. 使用分析三视图（#632）
把原来单一柱状图升级为「使用分析」卡片，右上角三视图切换：
- **趋势** — 各 API 消耗随时间的堆叠柱状图（点击图例可单独隔离某个 API）。
- **占比** — 各 API 消耗占比的环形图（饼图）。
- **明细** — 列出全部 API 的精确消耗与占比条形的表格。
- **动态 Top-N**：按消耗排序，自动把长尾折叠进「其他」（保证「其他」≤1%），明细表仍展示全部 API。

### 2. 自动刷新开关（#633）
表格右上角新增「自动刷新」开关（默认开），每 15s 静默轮询最新记录；页面隐藏时暂停；`fetchSeq` 防竞态；`beforeUnmount` 清理定时器。

### 3. 流式 CSV 导出（#634）
导出改用 `showSaveFilePicker` + `pipeTo` 直接落盘（Chromium），Firefox/Safari 回退到 blob 下载；用户取消 picker 不报错。
- **Nexior 专属修正**：导出 URL 改用 `getBaseUrlPlatform()`（绝对地址），使其在 Capacitor(iOS/Android) / Electron 桌面端也能工作，而非仅 nginx web 代理下可用。

### 4. 其他
- 状态码为空时显示「处理中」标签。
- 补 \`trace_id\` 过滤参数；API 筛选下拉框 \`limit\` 100→1000（#389）。
- usage operator 查询类型补 \`timezone\` / \`trace_id\`。
- 新增 10 个 i18n key，覆盖全部 18 个语种（en+zh-CN 手写，其余 16 语种本地化），过 i18n coverage guard。

## 验证
- \`vue-tsc --noEmit\`：0 error。
- \`eslint\`（List.vue + usage.ts）：0 error/warning。
- \`python3 scripts/check_i18n_coverage.py\`：\`17 locale(s) × 44 namespace(s) all match zh-CN\`。

## 🤖 对抗评审
独立评审（subagent）逐项核对导入、i18n 覆盖、动态 Top-N/Others 折叠、自动刷新生命周期与竞态守卫、导出 picker 流式+blob 回退+AbortError、operator 签名与图标/chart.js 注册。发现 1 个真实缺陷并已修复：
- **RISK（已修复）**：\`onExport\` 用相对 \`/api/v1/...\` fetch，只在 studio 的 nginx web 构建下经代理生效；Capacitor/Electron 无该代理，导出必然失败。改为 \`getBaseUrlPlatform()\` 绝对地址。
- 其余全部项通过。复评：修复后 VERDICT: CLEAN。