### PR TITLE
feat(maestro): narration voice selector + audio preview

### DIFF
--- a/change/@acedatacloud-nexior-7c1d9a02-maestro-voice.json
+++ b/change/@acedatacloud-nexior-7c1d9a02-maestro-voice.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(maestro): narration voice selector with inline audio preview (9 curated voices + auto)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/maestro/ConfigPanel.vue
+++ b/src/components/maestro/ConfigPanel.vue
@@ -150,6 +150,32 @@
           <el-option v-for="s in MAESTRO_ALLOWED_STYLES" :key="s" :label="$t(`maestro.option.style.${s}`)" :value="s" />
         </el-select>
       </div>
+
+      <!-- Voice (narration timbre) + preview -->
+      <div class="field-block mt-5">
+        <div class="field-head mb-2">
+          <h2 class="field-title font-bold">{{ $t('maestro.name.voice') }}</h2>
+          <info-icon :content="$t('maestro.description.voice')" class="ml-1" />
+        </div>
+        <div class="voice-row">
+          <el-select v-model="voice" class="voice-select" :placeholder="$t('maestro.placeholder.select')">
+            <el-option
+              v-for="v in MAESTRO_ALLOWED_VOICES"
+              :key="v.key"
+              :label="$t(`maestro.option.voice.${v.key}`)"
+              :value="v.key"
+            />
+          </el-select>
+          <el-button
+            class="voice-play"
+            :disabled="!currentSample"
+            :title="$t('maestro.button.preview')"
+            @click="onToggleSample"
+          >
+            <font-awesome-icon :icon="playing ? 'fa-solid fa-pause' : 'fa-solid fa-play'" />
+          </el-button>
+        </div>
+      </div>
     </div>
 
     <div class="flex flex-col items-center justify-center px-5 pb-5">
@@ -163,7 +189,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
+import { defineComponent, markRaw } from 'vue';
 import { ElButton, ElSelect, ElOption, ElInputNumber, ElAlert } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import Consumption from '../common/Consumption.vue';
@@ -186,7 +212,9 @@ import {
   MAESTRO_SCENARIO_THUMBNAILS,
   MAESTRO_DEFAULT_SCENARIO,
   MAESTRO_ALLOWED_STYLES,
-  MAESTRO_DEFAULT_STYLE
+  MAESTRO_DEFAULT_STYLE,
+  MAESTRO_ALLOWED_VOICES,
+  MAESTRO_DEFAULT_VOICE
 } from '@/constants';
 import { IMaestroConfig } from '@/models';
 
@@ -220,7 +248,10 @@ export default defineComponent({
       MAESTRO_ALLOWED_QUALITIES,
       MAESTRO_ALLOWED_SCENARIOS,
       MAESTRO_SCENARIO_THUMBNAILS,
-      MAESTRO_ALLOWED_STYLES
+      MAESTRO_ALLOWED_STYLES,
+      MAESTRO_ALLOWED_VOICES,
+      playing: false,
+      audioEl: null as HTMLAudioElement | null
     };
   },
   computed: {
@@ -308,6 +339,18 @@ export default defineComponent({
       set(val: string) {
         this.update({ style: val || MAESTRO_DEFAULT_STYLE });
       }
+    },
+    voice: {
+      get(): string {
+        return this.config?.voice || MAESTRO_DEFAULT_VOICE;
+      },
+      set(val: string) {
+        this.stopSample();
+        this.update({ voice: val || MAESTRO_DEFAULT_VOICE });
+      }
+    },
+    currentSample(): string | undefined {
+      return MAESTRO_ALLOWED_VOICES.find((v) => v.key === this.voice)?.sample;
     }
   },
   mounted() {
@@ -322,8 +365,16 @@ export default defineComponent({
         this.config?.scenario && MAESTRO_ALLOWED_SCENARIOS.includes(this.config.scenario)
           ? this.config.scenario
           : MAESTRO_DEFAULT_SCENARIO,
-      style: this.config?.style ?? MAESTRO_DEFAULT_STYLE
+      style: this.config?.style ?? MAESTRO_DEFAULT_STYLE,
+      // Drop a stale persisted voice not in the current catalog back to auto.
+      voice:
+        this.config?.voice && MAESTRO_ALLOWED_VOICES.some((v) => v.key === this.config!.voice)
+          ? this.config.voice
+          : MAESTRO_DEFAULT_VOICE
     });
+  },
+  beforeUnmount() {
+    this.stopSample();
   },
   methods: {
     update(patch: Partial<IMaestroConfig>) {
@@ -334,6 +385,38 @@ export default defineComponent({
     },
     onClearRemix() {
       this.update({ action: MAESTRO_DEFAULT_ACTION, ref_task_id: undefined });
+    },
+    onToggleSample() {
+      const src = this.currentSample;
+      if (!src) return;
+      if (!this.audioEl) {
+        this.audioEl = markRaw(new Audio());
+        this.audioEl.addEventListener('ended', () => {
+          this.playing = false;
+        });
+      }
+      if (this.playing) {
+        this.audioEl.pause();
+        this.playing = false;
+        return;
+      }
+      if (this.audioEl.src !== src) this.audioEl.src = src;
+      this.audioEl.currentTime = 0;
+      this.audioEl
+        .play()
+        .then(() => {
+          this.playing = true;
+        })
+        .catch(() => {
+          this.playing = false;
+        });
+    },
+    stopSample() {
+      if (this.audioEl) {
+        this.audioEl.pause();
+        this.audioEl.currentTime = 0;
+      }
+      this.playing = false;
     },
     onGenerate() {
       this.$emit('generate');
@@ -363,6 +446,18 @@ export default defineComponent({
 }
 .field-control {
   width: 168px;
+}
+.voice-row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+}
+.voice-select {
+  flex: 1;
+}
+.voice-play {
+  flex: 0 0 auto;
 }
 .ratio-items {
   display: flex;

--- a/src/constants/maestro.ts
+++ b/src/constants/maestro.ts
@@ -60,3 +60,25 @@ export const MAESTRO_DEFAULT_DURATION = 30;
 export const MAESTRO_DEFAULT_QUALITY = 'standard';
 export const MAESTRO_DEFAULT_SCENARIO = 'auto';
 export const MAESTRO_DEFAULT_STYLE = 'auto';
+
+// Curated narration voices → a Fish reference_id on the backend. Voice is a **timbre** and is
+// language-agnostic: the same voice speaks whatever language `langs` sets (verified live zh/en/ja),
+// so there is no per-voice language and the list is never filtered. `auto` = Maestro picks per tone.
+// `sample` is a short bilingual preview clip on the CDN (▶︎ 试听).
+export interface IMaestroVoiceOption {
+  key: string;
+  sample?: string;
+}
+export const MAESTRO_ALLOWED_VOICES: IMaestroVoiceOption[] = [
+  { key: 'auto' },
+  { key: 'warm-female', sample: 'https://cdn.acedata.cloud/7b7cec364c.mp3' },
+  { key: 'bright-female', sample: 'https://cdn.acedata.cloud/32ee903837.mp3' },
+  { key: 'anchor-female', sample: 'https://cdn.acedata.cloud/04374b7885.mp3' },
+  { key: 'clean-female', sample: 'https://cdn.acedata.cloud/cc0776b86f.mp3' },
+  { key: 'calm-male', sample: 'https://cdn.acedata.cloud/2ea4b5eb49.mp3' },
+  { key: 'deep-male', sample: 'https://cdn.acedata.cloud/7ba529ae25.mp3' },
+  { key: 'documentary-male', sample: 'https://cdn.acedata.cloud/5617e445dd.mp3' },
+  { key: 'energetic-male', sample: 'https://cdn.acedata.cloud/d516b56517.mp3' },
+  { key: 'storyteller-male', sample: 'https://cdn.acedata.cloud/9dfbd0ed00.mp3' }
+];
+export const MAESTRO_DEFAULT_VOICE = 'auto';

--- a/src/i18n/ar/maestro.json
+++ b/src/i18n/ar/maestro.json
@@ -215,9 +215,9 @@
     "message": "رسوم متحركة",
     "description": "Motion graphics scenario option"
   },
-  "option.scenario.slideshow": {
-    "message": "عرض شرائح",
-    "description": "خيار سيناريو عرض شرائح"
+  "option.scenario.captions": {
+    "message": "إضافة ترجمات",
+    "description": "Add-captions scenario option"
   },
   "name.style": {
     "message": "الأسلوب البصري",
@@ -235,9 +235,117 @@
     "message": "إحساس سينمائي",
     "description": "خيار أسلوب سينمائي"
   },
+  "option.style.glass": {
+    "message": "Frosted Glass",
+    "description": "Frosted glass style option"
+  },
+  "option.style.luxury": {
+    "message": "Luxury",
+    "description": "Luxury style option"
+  },
+  "option.style.swiss": {
+    "message": "Swiss Grid",
+    "description": "Swiss grid style option"
+  },
+  "option.style.modern": {
+    "message": "Modern",
+    "description": "Modern style option"
+  },
+  "option.style.editorial": {
+    "message": "Editorial",
+    "description": "Editorial style option"
+  },
+  "option.style.warm": {
+    "message": "Warm",
+    "description": "Warm style option"
+  },
+  "option.style.vibrant": {
+    "message": "Vibrant",
+    "description": "Vibrant style option"
+  },
   "option.style.neon": {
     "message": "نيون",
     "description": "خيار أسلوب نيون"
+  },
+  "option.style.mono": {
+    "message": "Monochrome",
+    "description": "Monochrome style option"
+  },
+  "option.style.pastel": {
+    "message": "Pastel",
+    "description": "Pastel style option"
+  },
+  "option.style.bold": {
+    "message": "Bold Type",
+    "description": "Bold type style option"
+  },
+  "option.style.industrial": {
+    "message": "Industrial",
+    "description": "Industrial style option"
+  },
+  "option.style.futuristic": {
+    "message": "Futuristic",
+    "description": "Futuristic style option"
+  },
+  "option.style.retro": {
+    "message": "Retro Film",
+    "description": "Retro film style option"
+  },
+  "name.voice": {
+    "message": "نغمة الصوت",
+    "description": "حقل نغمة الصوت"
+  },
+  "button.preview": {
+    "message": "معاينة",
+    "description": "زر معاينة الصوت / تشغيل العينة"
+  },
+  "description.voice": {
+    "message": "اختر نغمة الصوت للراوي. النغمة غير مرتبطة باللغة - ستستخدم نفس النغمة اللغة المختارة أعلاه للقراءة؛ اضغط على التشغيل للاستماع.",
+    "description": "مساعدة حقل الصوت"
+  },
+  "option.voice.auto": {
+    "message": "تلقائي · بواسطة Maestro",
+    "description": "خيار الصوت التلقائي"
+  },
+  "option.voice.warm-female": {
+    "message": "صوت أنثوي دافئ",
+    "description": "خيار الصوت الأنثوي الدافئ"
+  },
+  "option.voice.bright-female": {
+    "message": "صوت أنثوي مشرق",
+    "description": "خيار الصوت الأنثوي المشرق"
+  },
+  "option.voice.anchor-female": {
+    "message": "صوت المذيعة",
+    "description": "خيار صوت المذيعة"
+  },
+  "option.voice.clean-female": {
+    "message": "صوت أنثوي نقي",
+    "description": "خيار الصوت الأنثوي النقي"
+  },
+  "option.voice.calm-male": {
+    "message": "صوت ذكوري هادئ",
+    "description": "خيار الصوت الذكوري الهادئ"
+  },
+  "option.voice.deep-male": {
+    "message": "صوت ذكوري عميق",
+    "description": "خيار الصوت الذكوري العميق"
+  },
+  "option.voice.documentary-male": {
+    "message": "صوت ذكوري وثائقي",
+    "description": "خيار الصوت الذكوري الوثائقي"
+  },
+  "option.voice.energetic-male": {
+    "message": "صوت ذكوري نشيط",
+    "description": "خيار الصوت الذكوري النشيط"
+  },
+  "option.voice.storyteller-male": {
+    "message": "صوت ذكوري راوي",
+    "description": "خيار الصوت الذكوري الراوي"
+  },
+  "option.scenario.slideshow": {
+    "message": "عرض شرائح",
+    "description": "خيار سيناريو عرض شرائح"
   },
   "name.sourceType": {
     "message": "نوع المصدر",
@@ -322,61 +430,5 @@
   "option.scenario.changelog": {
     "message": "سجل التغييرات (PR)",
     "description": "Changelog scenario option"
-  },
-  "option.scenario.captions": {
-    "message": "إضافة ترجمات",
-    "description": "Add-captions scenario option"
-  },
-  "option.style.glass": {
-    "message": "Frosted Glass",
-    "description": "Frosted glass style option"
-  },
-  "option.style.luxury": {
-    "message": "Luxury",
-    "description": "Luxury style option"
-  },
-  "option.style.swiss": {
-    "message": "Swiss Grid",
-    "description": "Swiss grid style option"
-  },
-  "option.style.modern": {
-    "message": "Modern",
-    "description": "Modern style option"
-  },
-  "option.style.editorial": {
-    "message": "Editorial",
-    "description": "Editorial style option"
-  },
-  "option.style.warm": {
-    "message": "Warm",
-    "description": "Warm style option"
-  },
-  "option.style.vibrant": {
-    "message": "Vibrant",
-    "description": "Vibrant style option"
-  },
-  "option.style.mono": {
-    "message": "Monochrome",
-    "description": "Monochrome style option"
-  },
-  "option.style.pastel": {
-    "message": "Pastel",
-    "description": "Pastel style option"
-  },
-  "option.style.bold": {
-    "message": "Bold Type",
-    "description": "Bold type style option"
-  },
-  "option.style.industrial": {
-    "message": "Industrial",
-    "description": "Industrial style option"
-  },
-  "option.style.futuristic": {
-    "message": "Futuristic",
-    "description": "Futuristic style option"
-  },
-  "option.style.retro": {
-    "message": "Retro Film",
-    "description": "Retro film style option"
   }
 }

--- a/src/i18n/de/maestro.json
+++ b/src/i18n/de/maestro.json
@@ -215,9 +215,9 @@
     "message": "Motion Graphics",
     "description": "Motion graphics scenario option"
   },
-  "option.scenario.slideshow": {
-    "message": "Präsentationsdiashow",
-    "description": "Option für Diashow-Szenario"
+  "option.scenario.captions": {
+    "message": "Untertitel hinzufügen",
+    "description": "Add-captions scenario option"
   },
   "name.style": {
     "message": "Visueller Stil",
@@ -235,9 +235,117 @@
     "message": "Filmisch",
     "description": "Option für filmischen Stil"
   },
+  "option.style.glass": {
+    "message": "Frosted Glass",
+    "description": "Frosted glass style option"
+  },
+  "option.style.luxury": {
+    "message": "Luxury",
+    "description": "Luxury style option"
+  },
+  "option.style.swiss": {
+    "message": "Swiss Grid",
+    "description": "Swiss grid style option"
+  },
+  "option.style.modern": {
+    "message": "Modern",
+    "description": "Modern style option"
+  },
+  "option.style.editorial": {
+    "message": "Editorial",
+    "description": "Editorial style option"
+  },
+  "option.style.warm": {
+    "message": "Warm",
+    "description": "Warm style option"
+  },
+  "option.style.vibrant": {
+    "message": "Vibrant",
+    "description": "Vibrant style option"
+  },
   "option.style.neon": {
     "message": "Neon",
     "description": "Option für Neon-Stil"
+  },
+  "option.style.mono": {
+    "message": "Monochrome",
+    "description": "Monochrome style option"
+  },
+  "option.style.pastel": {
+    "message": "Pastel",
+    "description": "Pastel style option"
+  },
+  "option.style.bold": {
+    "message": "Bold Type",
+    "description": "Bold type style option"
+  },
+  "option.style.industrial": {
+    "message": "Industrial",
+    "description": "Industrial style option"
+  },
+  "option.style.futuristic": {
+    "message": "Futuristic",
+    "description": "Futuristic style option"
+  },
+  "option.style.retro": {
+    "message": "Retro Film",
+    "description": "Retro film style option"
+  },
+  "name.voice": {
+    "message": "Erzählstimme",
+    "description": "Feld für den Klang der Stimme"
+  },
+  "button.preview": {
+    "message": "Vorschau",
+    "description": "Button für Sprachvorschau / Abspielen einer Probe"
+  },
+  "description.voice": {
+    "message": "Wählen Sie den Klang der Erzählstimme. Der Klang ist unabhängig von der Sprache – derselbe Klang wird in der oben gewählten Sprache vorgelesen; klicken Sie auf Abspielen, um eine Vorschau zu hören.",
+    "description": "Hilfe für das Sprachfeld"
+  },
+  "option.voice.auto": {
+    "message": "Automatisch · Von Maestro zugeordnet",
+    "description": "Option für automatische Stimme"
+  },
+  "option.voice.warm-female": {
+    "message": "Warme Stimme (weiblich)",
+    "description": "Option für warme weibliche Stimme"
+  },
+  "option.voice.bright-female": {
+    "message": "Helle Stimme (weiblich)",
+    "description": "Option für helle weibliche Stimme"
+  },
+  "option.voice.anchor-female": {
+    "message": "Moderatorin",
+    "description": "Option für weibliche Moderatorenstimme"
+  },
+  "option.voice.clean-female": {
+    "message": "Klar Stimme (weiblich)",
+    "description": "Option für klare weibliche Stimme"
+  },
+  "option.voice.calm-male": {
+    "message": "Ruhige Stimme (männlich)",
+    "description": "Option für ruhige männliche Stimme"
+  },
+  "option.voice.deep-male": {
+    "message": "Tiefe Stimme (männlich)",
+    "description": "Option für tiefe männliche Stimme"
+  },
+  "option.voice.documentary-male": {
+    "message": "Dokumentationsstimme (männlich)",
+    "description": "Option für männliche Dokumentationsstimme"
+  },
+  "option.voice.energetic-male": {
+    "message": "Energiegeladene Stimme (männlich)",
+    "description": "Option für energiegeladene männliche Stimme"
+  },
+  "option.voice.storyteller-male": {
+    "message": "Erzählerstimme (männlich)",
+    "description": "Option für männliche Erzählerstimme"
+  },
+  "option.scenario.slideshow": {
+    "message": "Präsentationsdiashow",
+    "description": "Option für Diashow-Szenario"
   },
   "name.sourceType": {
     "message": "Quelltyp",
@@ -322,61 +430,5 @@
   "option.scenario.changelog": {
     "message": "Änderungsprotokoll (PR)",
     "description": "Changelog scenario option"
-  },
-  "option.scenario.captions": {
-    "message": "Untertitel hinzufügen",
-    "description": "Add-captions scenario option"
-  },
-  "option.style.glass": {
-    "message": "Frosted Glass",
-    "description": "Frosted glass style option"
-  },
-  "option.style.luxury": {
-    "message": "Luxury",
-    "description": "Luxury style option"
-  },
-  "option.style.swiss": {
-    "message": "Swiss Grid",
-    "description": "Swiss grid style option"
-  },
-  "option.style.modern": {
-    "message": "Modern",
-    "description": "Modern style option"
-  },
-  "option.style.editorial": {
-    "message": "Editorial",
-    "description": "Editorial style option"
-  },
-  "option.style.warm": {
-    "message": "Warm",
-    "description": "Warm style option"
-  },
-  "option.style.vibrant": {
-    "message": "Vibrant",
-    "description": "Vibrant style option"
-  },
-  "option.style.mono": {
-    "message": "Monochrome",
-    "description": "Monochrome style option"
-  },
-  "option.style.pastel": {
-    "message": "Pastel",
-    "description": "Pastel style option"
-  },
-  "option.style.bold": {
-    "message": "Bold Type",
-    "description": "Bold type style option"
-  },
-  "option.style.industrial": {
-    "message": "Industrial",
-    "description": "Industrial style option"
-  },
-  "option.style.futuristic": {
-    "message": "Futuristic",
-    "description": "Futuristic style option"
-  },
-  "option.style.retro": {
-    "message": "Retro Film",
-    "description": "Retro film style option"
   }
 }

--- a/src/i18n/el/maestro.json
+++ b/src/i18n/el/maestro.json
@@ -215,9 +215,9 @@
     "message": "Κινούμενα γραφικά",
     "description": "Motion graphics scenario option"
   },
-  "option.scenario.slideshow": {
-    "message": "Παρουσίαση διαφανειών",
-    "description": "Επιλογή σεναρίου παρουσίασης διαφανειών"
+  "option.scenario.captions": {
+    "message": "Προσθήκη υπότιτλων",
+    "description": "Add-captions scenario option"
   },
   "name.style": {
     "message": "Οπτικός στυλ",
@@ -235,9 +235,117 @@
     "message": "Κινηματογραφικό",
     "description": "Επιλογή κινηματογραφικού στυλ"
   },
+  "option.style.glass": {
+    "message": "Frosted Glass",
+    "description": "Frosted glass style option"
+  },
+  "option.style.luxury": {
+    "message": "Luxury",
+    "description": "Luxury style option"
+  },
+  "option.style.swiss": {
+    "message": "Swiss Grid",
+    "description": "Swiss grid style option"
+  },
+  "option.style.modern": {
+    "message": "Modern",
+    "description": "Modern style option"
+  },
+  "option.style.editorial": {
+    "message": "Editorial",
+    "description": "Editorial style option"
+  },
+  "option.style.warm": {
+    "message": "Warm",
+    "description": "Warm style option"
+  },
+  "option.style.vibrant": {
+    "message": "Vibrant",
+    "description": "Vibrant style option"
+  },
   "option.style.neon": {
     "message": "Νεον",
     "description": "Επιλογή στυλ νεον"
+  },
+  "option.style.mono": {
+    "message": "Monochrome",
+    "description": "Monochrome style option"
+  },
+  "option.style.pastel": {
+    "message": "Pastel",
+    "description": "Pastel style option"
+  },
+  "option.style.bold": {
+    "message": "Bold Type",
+    "description": "Bold type style option"
+  },
+  "option.style.industrial": {
+    "message": "Industrial",
+    "description": "Industrial style option"
+  },
+  "option.style.futuristic": {
+    "message": "Futuristic",
+    "description": "Futuristic style option"
+  },
+  "option.style.retro": {
+    "message": "Retro Film",
+    "description": "Retro film style option"
+  },
+  "name.voice": {
+    "message": "Τόνος φωνής",
+    "description": "Πεδίο τόνου φωνής"
+  },
+  "button.preview": {
+    "message": "Δείγμα",
+    "description": "Κουμπί προεπισκόπησης φωνής / αναπαραγωγής δείγματος"
+  },
+  "description.voice": {
+    "message": "Επιλέξτε τον τόνο της φωνής για την αφήγηση. Ο τόνος δεν σχετίζεται με τη γλώσσα - ο ίδιος τόνος θα διαβάσει στη γλώσσα που επιλέξατε παραπάνω. Πατήστε αναπαραγωγή για προεπισκόπηση.",
+    "description": "Βοήθεια πεδίου φωνής"
+  },
+  "option.voice.auto": {
+    "message": "Αυτόματα · Αντιστοίχιση από τον Maestro",
+    "description": "Αυτόματη επιλογή φωνής"
+  },
+  "option.voice.warm-female": {
+    "message": "Ζεστή γυναικεία φωνή",
+    "description": "Επιλογή ζεστής γυναικείας φωνής"
+  },
+  "option.voice.bright-female": {
+    "message": "Φωτεινή γυναικεία φωνή",
+    "description": "Επιλογή φωτεινής γυναικείας φωνής"
+  },
+  "option.voice.anchor-female": {
+    "message": "Γυναικεία φωνή παρουσιαστή",
+    "description": "Επιλογή γυναικείας φωνής παρουσιαστή"
+  },
+  "option.voice.clean-female": {
+    "message": "Καθαρή γυναικεία φωνή",
+    "description": "Επιλογή καθαρής γυναικείας φωνής"
+  },
+  "option.voice.calm-male": {
+    "message": "Ήρεμη ανδρική φωνή",
+    "description": "Επιλογή ήρεμης ανδρικής φωνής"
+  },
+  "option.voice.deep-male": {
+    "message": "Βαθιά ανδρική φωνή",
+    "description": "Επιλογή βαθιάς ανδρικής φωνής"
+  },
+  "option.voice.documentary-male": {
+    "message": "Αφήγηση ανδρικής φωνής",
+    "description": "Επιλογή ανδρικής φωνής για ντοκιμαντέρ"
+  },
+  "option.voice.energetic-male": {
+    "message": "Ενεργητική ανδρική φωνή",
+    "description": "Επιλογή ενεργητικής ανδρικής φωνής"
+  },
+  "option.voice.storyteller-male": {
+    "message": "Αφηγηματική ανδρική φωνή",
+    "description": "Επιλογή αφηγηματικής ανδρικής φωνής"
+  },
+  "option.scenario.slideshow": {
+    "message": "Παρουσίαση διαφανειών",
+    "description": "Επιλογή σεναρίου παρουσίασης διαφανειών"
   },
   "name.sourceType": {
     "message": "Τύπος πηγής",
@@ -322,61 +430,5 @@
   "option.scenario.changelog": {
     "message": "Αρχείο αλλαγών (PR)",
     "description": "Changelog scenario option"
-  },
-  "option.scenario.captions": {
-    "message": "Προσθήκη υπότιτλων",
-    "description": "Add-captions scenario option"
-  },
-  "option.style.glass": {
-    "message": "Frosted Glass",
-    "description": "Frosted glass style option"
-  },
-  "option.style.luxury": {
-    "message": "Luxury",
-    "description": "Luxury style option"
-  },
-  "option.style.swiss": {
-    "message": "Swiss Grid",
-    "description": "Swiss grid style option"
-  },
-  "option.style.modern": {
-    "message": "Modern",
-    "description": "Modern style option"
-  },
-  "option.style.editorial": {
-    "message": "Editorial",
-    "description": "Editorial style option"
-  },
-  "option.style.warm": {
-    "message": "Warm",
-    "description": "Warm style option"
-  },
-  "option.style.vibrant": {
-    "message": "Vibrant",
-    "description": "Vibrant style option"
-  },
-  "option.style.mono": {
-    "message": "Monochrome",
-    "description": "Monochrome style option"
-  },
-  "option.style.pastel": {
-    "message": "Pastel",
-    "description": "Pastel style option"
-  },
-  "option.style.bold": {
-    "message": "Bold Type",
-    "description": "Bold type style option"
-  },
-  "option.style.industrial": {
-    "message": "Industrial",
-    "description": "Industrial style option"
-  },
-  "option.style.futuristic": {
-    "message": "Futuristic",
-    "description": "Futuristic style option"
-  },
-  "option.style.retro": {
-    "message": "Retro Film",
-    "description": "Retro film style option"
   }
 }

--- a/src/i18n/en/maestro.json
+++ b/src/i18n/en/maestro.json
@@ -290,5 +290,57 @@
   "option.style.retro": {
     "message": "Retro Film",
     "description": "Retro film style option"
+  },
+  "name.voice": {
+    "message": "Voice Timbre",
+    "description": "Voice timbre field"
+  },
+  "button.preview": {
+    "message": "Preview",
+    "description": "Voice preview / play sample button"
+  },
+  "description.voice": {
+    "message": "Select the voice timbre for narration. The timbre is independent of the language — the same timbre will read in the language selected above; click play to preview.",
+    "description": "Voice field help"
+  },
+  "option.voice.auto": {
+    "message": "Auto · Matched by Maestro",
+    "description": "Auto voice option"
+  },
+  "option.voice.warm-female": {
+    "message": "Warm Female Voice",
+    "description": "warm female voice option"
+  },
+  "option.voice.bright-female": {
+    "message": "Bright Female Voice",
+    "description": "bright female voice option"
+  },
+  "option.voice.anchor-female": {
+    "message": "Anchor Female Voice",
+    "description": "anchor female voice option"
+  },
+  "option.voice.clean-female": {
+    "message": "Clear Female Voice",
+    "description": "clean female voice option"
+  },
+  "option.voice.calm-male": {
+    "message": "Calm Male Voice",
+    "description": "calm male voice option"
+  },
+  "option.voice.deep-male": {
+    "message": "Deep Male Voice",
+    "description": "deep male voice option"
+  },
+  "option.voice.documentary-male": {
+    "message": "Documentary Male Voice",
+    "description": "documentary male voice option"
+  },
+  "option.voice.energetic-male": {
+    "message": "Energetic Male Voice",
+    "description": "energetic male voice option"
+  },
+  "option.voice.storyteller-male": {
+    "message": "Storyteller Male Voice",
+    "description": "storyteller male voice option"
   }
 }

--- a/src/i18n/es/maestro.json
+++ b/src/i18n/es/maestro.json
@@ -215,9 +215,9 @@
     "message": "Gráficos animados",
     "description": "Motion graphics scenario option"
   },
-  "option.scenario.slideshow": {
-    "message": "Presentación de diapositivas",
-    "description": "Opción de escenario de presentación de diapositivas"
+  "option.scenario.captions": {
+    "message": "Añadir subtítulos",
+    "description": "Add-captions scenario option"
   },
   "name.style": {
     "message": "Estilo visual",
@@ -235,9 +235,117 @@
     "message": "Estilo cinematográfico",
     "description": "Opción de estilo cinematográfico"
   },
+  "option.style.glass": {
+    "message": "Frosted Glass",
+    "description": "Frosted glass style option"
+  },
+  "option.style.luxury": {
+    "message": "Luxury",
+    "description": "Luxury style option"
+  },
+  "option.style.swiss": {
+    "message": "Swiss Grid",
+    "description": "Swiss grid style option"
+  },
+  "option.style.modern": {
+    "message": "Modern",
+    "description": "Modern style option"
+  },
+  "option.style.editorial": {
+    "message": "Editorial",
+    "description": "Editorial style option"
+  },
+  "option.style.warm": {
+    "message": "Warm",
+    "description": "Warm style option"
+  },
+  "option.style.vibrant": {
+    "message": "Vibrant",
+    "description": "Vibrant style option"
+  },
   "option.style.neon": {
     "message": "Estilo neón",
     "description": "Opción de estilo neón"
+  },
+  "option.style.mono": {
+    "message": "Monochrome",
+    "description": "Monochrome style option"
+  },
+  "option.style.pastel": {
+    "message": "Pastel",
+    "description": "Pastel style option"
+  },
+  "option.style.bold": {
+    "message": "Bold Type",
+    "description": "Bold type style option"
+  },
+  "option.style.industrial": {
+    "message": "Industrial",
+    "description": "Industrial style option"
+  },
+  "option.style.futuristic": {
+    "message": "Futuristic",
+    "description": "Futuristic style option"
+  },
+  "option.style.retro": {
+    "message": "Retro Film",
+    "description": "Retro film style option"
+  },
+  "name.voice": {
+    "message": "Tono de voz",
+    "description": "Campo de tono de voz"
+  },
+  "button.preview": {
+    "message": "Vista previa",
+    "description": "Botón de vista previa de voz / reproducir muestra"
+  },
+  "description.voice": {
+    "message": "Selecciona el tono de la voz en off. El tono no está relacionado con el idioma: el mismo tono leerá en el idioma seleccionado arriba; haz clic en reproducir para escuchar una muestra.",
+    "description": "Ayuda del campo de voz"
+  },
+  "option.voice.auto": {
+    "message": "Automático · Coincide con Maestro",
+    "description": "Opción de voz automática"
+  },
+  "option.voice.warm-female": {
+    "message": "Voz femenina cálida",
+    "description": "Opción de voz femenina cálida"
+  },
+  "option.voice.bright-female": {
+    "message": "Voz femenina brillante",
+    "description": "Opción de voz femenina brillante"
+  },
+  "option.voice.anchor-female": {
+    "message": "Voz femenina de ancla",
+    "description": "Opción de voz femenina de ancla"
+  },
+  "option.voice.clean-female": {
+    "message": "Voz femenina clara",
+    "description": "Opción de voz femenina clara"
+  },
+  "option.voice.calm-male": {
+    "message": "Voz masculina tranquila",
+    "description": "Opción de voz masculina tranquila"
+  },
+  "option.voice.deep-male": {
+    "message": "Voz masculina profunda",
+    "description": "Opción de voz masculina profunda"
+  },
+  "option.voice.documentary-male": {
+    "message": "Voz masculina de documental",
+    "description": "Opción de voz masculina de documental"
+  },
+  "option.voice.energetic-male": {
+    "message": "Voz masculina enérgica",
+    "description": "Opción de voz masculina enérgica"
+  },
+  "option.voice.storyteller-male": {
+    "message": "Voz masculina narradora",
+    "description": "Opción de voz masculina narradora"
+  },
+  "option.scenario.slideshow": {
+    "message": "Presentación de diapositivas",
+    "description": "Opción de escenario de presentación de diapositivas"
   },
   "name.sourceType": {
     "message": "Tipo de origen",
@@ -322,61 +430,5 @@
   "option.scenario.changelog": {
     "message": "Registro de cambios (PR)",
     "description": "Changelog scenario option"
-  },
-  "option.scenario.captions": {
-    "message": "Añadir subtítulos",
-    "description": "Add-captions scenario option"
-  },
-  "option.style.glass": {
-    "message": "Frosted Glass",
-    "description": "Frosted glass style option"
-  },
-  "option.style.luxury": {
-    "message": "Luxury",
-    "description": "Luxury style option"
-  },
-  "option.style.swiss": {
-    "message": "Swiss Grid",
-    "description": "Swiss grid style option"
-  },
-  "option.style.modern": {
-    "message": "Modern",
-    "description": "Modern style option"
-  },
-  "option.style.editorial": {
-    "message": "Editorial",
-    "description": "Editorial style option"
-  },
-  "option.style.warm": {
-    "message": "Warm",
-    "description": "Warm style option"
-  },
-  "option.style.vibrant": {
-    "message": "Vibrant",
-    "description": "Vibrant style option"
-  },
-  "option.style.mono": {
-    "message": "Monochrome",
-    "description": "Monochrome style option"
-  },
-  "option.style.pastel": {
-    "message": "Pastel",
-    "description": "Pastel style option"
-  },
-  "option.style.bold": {
-    "message": "Bold Type",
-    "description": "Bold type style option"
-  },
-  "option.style.industrial": {
-    "message": "Industrial",
-    "description": "Industrial style option"
-  },
-  "option.style.futuristic": {
-    "message": "Futuristic",
-    "description": "Futuristic style option"
-  },
-  "option.style.retro": {
-    "message": "Retro Film",
-    "description": "Retro film style option"
   }
 }

--- a/src/i18n/fi/maestro.json
+++ b/src/i18n/fi/maestro.json
@@ -215,9 +215,9 @@
     "message": "Liikegrafiikka",
     "description": "Motion graphics scenario option"
   },
-  "option.scenario.slideshow": {
-    "message": "Esitysdia",
-    "description": "Diaesityksen skenaario vaihtoehto"
+  "option.scenario.captions": {
+    "message": "Lisää tekstitykset",
+    "description": "Add-captions scenario option"
   },
   "name.style": {
     "message": "Visuaalinen tyyli",
@@ -235,9 +235,117 @@
     "message": "Elokuvamainen",
     "description": "Elokuvamainen tyylivaihtoehto"
   },
+  "option.style.glass": {
+    "message": "Frosted Glass",
+    "description": "Frosted glass style option"
+  },
+  "option.style.luxury": {
+    "message": "Luxury",
+    "description": "Luxury style option"
+  },
+  "option.style.swiss": {
+    "message": "Swiss Grid",
+    "description": "Swiss grid style option"
+  },
+  "option.style.modern": {
+    "message": "Modern",
+    "description": "Modern style option"
+  },
+  "option.style.editorial": {
+    "message": "Editorial",
+    "description": "Editorial style option"
+  },
+  "option.style.warm": {
+    "message": "Warm",
+    "description": "Warm style option"
+  },
+  "option.style.vibrant": {
+    "message": "Vibrant",
+    "description": "Vibrant style option"
+  },
   "option.style.neon": {
     "message": "Neon",
     "description": "Neon-tyylivaihtoehto"
+  },
+  "option.style.mono": {
+    "message": "Monochrome",
+    "description": "Monochrome style option"
+  },
+  "option.style.pastel": {
+    "message": "Pastel",
+    "description": "Pastel style option"
+  },
+  "option.style.bold": {
+    "message": "Bold Type",
+    "description": "Bold type style option"
+  },
+  "option.style.industrial": {
+    "message": "Industrial",
+    "description": "Industrial style option"
+  },
+  "option.style.futuristic": {
+    "message": "Futuristic",
+    "description": "Futuristic style option"
+  },
+  "option.style.retro": {
+    "message": "Retro Film",
+    "description": "Retro film style option"
+  },
+  "name.voice": {
+    "message": "Ääninäytteen äänenväri",
+    "description": "Äänenväri-kenttä"
+  },
+  "button.preview": {
+    "message": "Esikatselu",
+    "description": "Ääninäytteen esikatselu / toisto -painike"
+  },
+  "description.voice": {
+    "message": "Valitse ääninäytteen äänenväri. Äänenväri ei riipu kielestä - sama äänenväri lukee valitun kielen mukaan; napsauta toistaaksesi.",
+    "description": "Voice field help"
+  },
+  "option.voice.auto": {
+    "message": "Automaattinen · Maestro valitsee",
+    "description": "Automaattinen äänenvalinta"
+  },
+  "option.voice.warm-female": {
+    "message": "Lämmin naisääni",
+    "description": "Lämmin naisääni -valinta"
+  },
+  "option.voice.bright-female": {
+    "message": "Kirkas naisääni",
+    "description": "Kirkas naisääni -valinta"
+  },
+  "option.voice.anchor-female": {
+    "message": "Naispuolinen juontaja",
+    "description": "Naispuolisen juontajan äänenvalinta"
+  },
+  "option.voice.clean-female": {
+    "message": "Puhtoinen naisääni",
+    "description": "Puhtoinen naisääni -valinta"
+  },
+  "option.voice.calm-male": {
+    "message": "Rauhallinen miesääni",
+    "description": "Rauhallinen miesääni -valinta"
+  },
+  "option.voice.deep-male": {
+    "message": "Syvä miesääni",
+    "description": "Syvä miesääni -valinta"
+  },
+  "option.voice.documentary-male": {
+    "message": "Dokumentaarinen miesääni",
+    "description": "Dokumentaarinen miesääni -valinta"
+  },
+  "option.voice.energetic-male": {
+    "message": "Energinen miesääni",
+    "description": "Energinen miesääni -valinta"
+  },
+  "option.voice.storyteller-male": {
+    "message": "Kertojamiesääni",
+    "description": "Kertojamiesääni -valinta"
+  },
+  "option.scenario.slideshow": {
+    "message": "Esitysdia",
+    "description": "Diaesityksen skenaario vaihtoehto"
   },
   "name.sourceType": {
     "message": "Lähteen tyyppi",
@@ -322,61 +430,5 @@
   "option.scenario.changelog": {
     "message": "Muutosloki (PR)",
     "description": "Changelog scenario option"
-  },
-  "option.scenario.captions": {
-    "message": "Lisää tekstitykset",
-    "description": "Add-captions scenario option"
-  },
-  "option.style.glass": {
-    "message": "Frosted Glass",
-    "description": "Frosted glass style option"
-  },
-  "option.style.luxury": {
-    "message": "Luxury",
-    "description": "Luxury style option"
-  },
-  "option.style.swiss": {
-    "message": "Swiss Grid",
-    "description": "Swiss grid style option"
-  },
-  "option.style.modern": {
-    "message": "Modern",
-    "description": "Modern style option"
-  },
-  "option.style.editorial": {
-    "message": "Editorial",
-    "description": "Editorial style option"
-  },
-  "option.style.warm": {
-    "message": "Warm",
-    "description": "Warm style option"
-  },
-  "option.style.vibrant": {
-    "message": "Vibrant",
-    "description": "Vibrant style option"
-  },
-  "option.style.mono": {
-    "message": "Monochrome",
-    "description": "Monochrome style option"
-  },
-  "option.style.pastel": {
-    "message": "Pastel",
-    "description": "Pastel style option"
-  },
-  "option.style.bold": {
-    "message": "Bold Type",
-    "description": "Bold type style option"
-  },
-  "option.style.industrial": {
-    "message": "Industrial",
-    "description": "Industrial style option"
-  },
-  "option.style.futuristic": {
-    "message": "Futuristic",
-    "description": "Futuristic style option"
-  },
-  "option.style.retro": {
-    "message": "Retro Film",
-    "description": "Retro film style option"
   }
 }

--- a/src/i18n/fr/maestro.json
+++ b/src/i18n/fr/maestro.json
@@ -215,9 +215,9 @@
     "message": "Motion design",
     "description": "Motion graphics scenario option"
   },
-  "option.scenario.slideshow": {
-    "message": "Diaporama",
-    "description": "Option de scénario diaporama"
+  "option.scenario.captions": {
+    "message": "Ajouter des sous-titres",
+    "description": "Add-captions scenario option"
   },
   "name.style": {
     "message": "Style visuel",
@@ -235,9 +235,117 @@
     "message": "Style cinématographique",
     "description": "Option de style cinématographique"
   },
+  "option.style.glass": {
+    "message": "Frosted Glass",
+    "description": "Frosted glass style option"
+  },
+  "option.style.luxury": {
+    "message": "Luxury",
+    "description": "Luxury style option"
+  },
+  "option.style.swiss": {
+    "message": "Swiss Grid",
+    "description": "Swiss grid style option"
+  },
+  "option.style.modern": {
+    "message": "Modern",
+    "description": "Modern style option"
+  },
+  "option.style.editorial": {
+    "message": "Editorial",
+    "description": "Editorial style option"
+  },
+  "option.style.warm": {
+    "message": "Warm",
+    "description": "Warm style option"
+  },
+  "option.style.vibrant": {
+    "message": "Vibrant",
+    "description": "Vibrant style option"
+  },
   "option.style.neon": {
     "message": "Style néon",
     "description": "Option de style néon"
+  },
+  "option.style.mono": {
+    "message": "Monochrome",
+    "description": "Monochrome style option"
+  },
+  "option.style.pastel": {
+    "message": "Pastel",
+    "description": "Pastel style option"
+  },
+  "option.style.bold": {
+    "message": "Bold Type",
+    "description": "Bold type style option"
+  },
+  "option.style.industrial": {
+    "message": "Industrial",
+    "description": "Industrial style option"
+  },
+  "option.style.futuristic": {
+    "message": "Futuristic",
+    "description": "Futuristic style option"
+  },
+  "option.style.retro": {
+    "message": "Retro Film",
+    "description": "Retro film style option"
+  },
+  "name.voice": {
+    "message": "Timbre de voix",
+    "description": "Champ de timbre de voix"
+  },
+  "button.preview": {
+    "message": "Aperçu",
+    "description": "Bouton d'aperçu de la voix / jouer un échantillon"
+  },
+  "description.voice": {
+    "message": "Choisissez le timbre de la voix pour la narration. Le timbre n'est pas lié à la langue — le même timbre lira dans la langue sélectionnée ci-dessus ; cliquez sur jouer pour écouter.",
+    "description": "Aide pour le champ de voix"
+  },
+  "option.voice.auto": {
+    "message": "Automatique · Correspondance par Maestro",
+    "description": "Option de voix automatique"
+  },
+  "option.voice.warm-female": {
+    "message": "Voix féminine chaleureuse",
+    "description": "Option de voix féminine chaleureuse"
+  },
+  "option.voice.bright-female": {
+    "message": "Voix féminine lumineuse",
+    "description": "Option de voix féminine lumineuse"
+  },
+  "option.voice.anchor-female": {
+    "message": "Voix féminine d'animatrice",
+    "description": "Option de voix féminine d'animatrice"
+  },
+  "option.voice.clean-female": {
+    "message": "Voix féminine claire",
+    "description": "Option de voix féminine claire"
+  },
+  "option.voice.calm-male": {
+    "message": "Voix masculine calme",
+    "description": "Option de voix masculine calme"
+  },
+  "option.voice.deep-male": {
+    "message": "Voix masculine profonde",
+    "description": "Option de voix masculine profonde"
+  },
+  "option.voice.documentary-male": {
+    "message": "Voix masculine de documentaire",
+    "description": "Option de voix masculine de documentaire"
+  },
+  "option.voice.energetic-male": {
+    "message": "Voix masculine énergique",
+    "description": "Option de voix masculine énergique"
+  },
+  "option.voice.storyteller-male": {
+    "message": "Voix masculine de narrateur",
+    "description": "Option de voix masculine de narrateur"
+  },
+  "option.scenario.slideshow": {
+    "message": "Diaporama",
+    "description": "Option de scénario diaporama"
   },
   "name.sourceType": {
     "message": "Type de source",
@@ -322,61 +430,5 @@
   "option.scenario.changelog": {
     "message": "Journal des modifs (PR)",
     "description": "Changelog scenario option"
-  },
-  "option.scenario.captions": {
-    "message": "Ajouter des sous-titres",
-    "description": "Add-captions scenario option"
-  },
-  "option.style.glass": {
-    "message": "Frosted Glass",
-    "description": "Frosted glass style option"
-  },
-  "option.style.luxury": {
-    "message": "Luxury",
-    "description": "Luxury style option"
-  },
-  "option.style.swiss": {
-    "message": "Swiss Grid",
-    "description": "Swiss grid style option"
-  },
-  "option.style.modern": {
-    "message": "Modern",
-    "description": "Modern style option"
-  },
-  "option.style.editorial": {
-    "message": "Editorial",
-    "description": "Editorial style option"
-  },
-  "option.style.warm": {
-    "message": "Warm",
-    "description": "Warm style option"
-  },
-  "option.style.vibrant": {
-    "message": "Vibrant",
-    "description": "Vibrant style option"
-  },
-  "option.style.mono": {
-    "message": "Monochrome",
-    "description": "Monochrome style option"
-  },
-  "option.style.pastel": {
-    "message": "Pastel",
-    "description": "Pastel style option"
-  },
-  "option.style.bold": {
-    "message": "Bold Type",
-    "description": "Bold type style option"
-  },
-  "option.style.industrial": {
-    "message": "Industrial",
-    "description": "Industrial style option"
-  },
-  "option.style.futuristic": {
-    "message": "Futuristic",
-    "description": "Futuristic style option"
-  },
-  "option.style.retro": {
-    "message": "Retro Film",
-    "description": "Retro film style option"
   }
 }

--- a/src/i18n/it/maestro.json
+++ b/src/i18n/it/maestro.json
@@ -215,9 +215,9 @@
     "message": "Grafica animata",
     "description": "Motion graphics scenario option"
   },
-  "option.scenario.slideshow": {
-    "message": "Presentazione",
-    "description": "Opzione scenario slideshow"
+  "option.scenario.captions": {
+    "message": "Aggiungi sottotitoli",
+    "description": "Add-captions scenario option"
   },
   "name.style": {
     "message": "Stile visivo",
@@ -235,9 +235,117 @@
     "message": "Stile cinematografico",
     "description": "Opzione stile cinematografico"
   },
+  "option.style.glass": {
+    "message": "Frosted Glass",
+    "description": "Frosted glass style option"
+  },
+  "option.style.luxury": {
+    "message": "Luxury",
+    "description": "Luxury style option"
+  },
+  "option.style.swiss": {
+    "message": "Swiss Grid",
+    "description": "Swiss grid style option"
+  },
+  "option.style.modern": {
+    "message": "Modern",
+    "description": "Modern style option"
+  },
+  "option.style.editorial": {
+    "message": "Editorial",
+    "description": "Editorial style option"
+  },
+  "option.style.warm": {
+    "message": "Warm",
+    "description": "Warm style option"
+  },
+  "option.style.vibrant": {
+    "message": "Vibrant",
+    "description": "Vibrant style option"
+  },
   "option.style.neon": {
     "message": "Stile neon",
     "description": "Opzione stile neon"
+  },
+  "option.style.mono": {
+    "message": "Monochrome",
+    "description": "Monochrome style option"
+  },
+  "option.style.pastel": {
+    "message": "Pastel",
+    "description": "Pastel style option"
+  },
+  "option.style.bold": {
+    "message": "Bold Type",
+    "description": "Bold type style option"
+  },
+  "option.style.industrial": {
+    "message": "Industrial",
+    "description": "Industrial style option"
+  },
+  "option.style.futuristic": {
+    "message": "Futuristic",
+    "description": "Futuristic style option"
+  },
+  "option.style.retro": {
+    "message": "Retro Film",
+    "description": "Retro film style option"
+  },
+  "name.voice": {
+    "message": "Timbro della voce",
+    "description": "Campo per il timbro della voce"
+  },
+  "button.preview": {
+    "message": "Anteprima",
+    "description": "Pulsante per la preview della voce / riproduzione del campione"
+  },
+  "description.voice": {
+    "message": "Seleziona il timbro della voce per la narrazione. Il timbro non è legato alla lingua: lo stesso timbro leggerà nella lingua selezionata sopra; fai clic su riproduci per ascoltare.",
+    "description": "Aiuto per il campo della voce"
+  },
+  "option.voice.auto": {
+    "message": "Automatico · Abbinato da Maestro",
+    "description": "Opzione di voce automatica"
+  },
+  "option.voice.warm-female": {
+    "message": "Voce femminile calda",
+    "description": "Opzione per voce femminile calda"
+  },
+  "option.voice.bright-female": {
+    "message": "Voce femminile brillante",
+    "description": "Opzione per voce femminile brillante"
+  },
+  "option.voice.anchor-female": {
+    "message": "Voce femminile dell'anchor",
+    "description": "Opzione per la voce femminile dell'anchor"
+  },
+  "option.voice.clean-female": {
+    "message": "Voce femminile chiara",
+    "description": "Opzione per voce femminile chiara"
+  },
+  "option.voice.calm-male": {
+    "message": "Voce maschile calma",
+    "description": "Opzione per voce maschile calma"
+  },
+  "option.voice.deep-male": {
+    "message": "Voce maschile profonda",
+    "description": "Opzione per voce maschile profonda"
+  },
+  "option.voice.documentary-male": {
+    "message": "Voce maschile da documentario",
+    "description": "Opzione per voce maschile da documentario"
+  },
+  "option.voice.energetic-male": {
+    "message": "Voce maschile energica",
+    "description": "Opzione per voce maschile energica"
+  },
+  "option.voice.storyteller-male": {
+    "message": "Voce maschile narratore",
+    "description": "Opzione per voce maschile narratore"
+  },
+  "option.scenario.slideshow": {
+    "message": "Presentazione",
+    "description": "Opzione scenario slideshow"
   },
   "name.sourceType": {
     "message": "Tipo di sorgente",
@@ -322,61 +430,5 @@
   "option.scenario.changelog": {
     "message": "Changelog (PR)",
     "description": "Changelog scenario option"
-  },
-  "option.scenario.captions": {
-    "message": "Aggiungi sottotitoli",
-    "description": "Add-captions scenario option"
-  },
-  "option.style.glass": {
-    "message": "Frosted Glass",
-    "description": "Frosted glass style option"
-  },
-  "option.style.luxury": {
-    "message": "Luxury",
-    "description": "Luxury style option"
-  },
-  "option.style.swiss": {
-    "message": "Swiss Grid",
-    "description": "Swiss grid style option"
-  },
-  "option.style.modern": {
-    "message": "Modern",
-    "description": "Modern style option"
-  },
-  "option.style.editorial": {
-    "message": "Editorial",
-    "description": "Editorial style option"
-  },
-  "option.style.warm": {
-    "message": "Warm",
-    "description": "Warm style option"
-  },
-  "option.style.vibrant": {
-    "message": "Vibrant",
-    "description": "Vibrant style option"
-  },
-  "option.style.mono": {
-    "message": "Monochrome",
-    "description": "Monochrome style option"
-  },
-  "option.style.pastel": {
-    "message": "Pastel",
-    "description": "Pastel style option"
-  },
-  "option.style.bold": {
-    "message": "Bold Type",
-    "description": "Bold type style option"
-  },
-  "option.style.industrial": {
-    "message": "Industrial",
-    "description": "Industrial style option"
-  },
-  "option.style.futuristic": {
-    "message": "Futuristic",
-    "description": "Futuristic style option"
-  },
-  "option.style.retro": {
-    "message": "Retro Film",
-    "description": "Retro film style option"
   }
 }

--- a/src/i18n/ja/maestro.json
+++ b/src/i18n/ja/maestro.json
@@ -215,9 +215,9 @@
     "message": "モーショングラフィックス",
     "description": "Motion graphics scenario option"
   },
-  "option.scenario.slideshow": {
-    "message": "スライドショー",
-    "description": "スライドショーシナリオオプション"
+  "option.scenario.captions": {
+    "message": "字幕を追加",
+    "description": "Add-captions scenario option"
   },
   "name.style": {
     "message": "ビジュアルスタイル",
@@ -235,9 +235,117 @@
     "message": "映画的",
     "description": "シネマティックスタイルオプション"
   },
+  "option.style.glass": {
+    "message": "Frosted Glass",
+    "description": "Frosted glass style option"
+  },
+  "option.style.luxury": {
+    "message": "Luxury",
+    "description": "Luxury style option"
+  },
+  "option.style.swiss": {
+    "message": "Swiss Grid",
+    "description": "Swiss grid style option"
+  },
+  "option.style.modern": {
+    "message": "Modern",
+    "description": "Modern style option"
+  },
+  "option.style.editorial": {
+    "message": "Editorial",
+    "description": "Editorial style option"
+  },
+  "option.style.warm": {
+    "message": "Warm",
+    "description": "Warm style option"
+  },
+  "option.style.vibrant": {
+    "message": "Vibrant",
+    "description": "Vibrant style option"
+  },
   "option.style.neon": {
     "message": "ネオン",
     "description": "ネオンスタイルオプション"
+  },
+  "option.style.mono": {
+    "message": "Monochrome",
+    "description": "Monochrome style option"
+  },
+  "option.style.pastel": {
+    "message": "Pastel",
+    "description": "Pastel style option"
+  },
+  "option.style.bold": {
+    "message": "Bold Type",
+    "description": "Bold type style option"
+  },
+  "option.style.industrial": {
+    "message": "Industrial",
+    "description": "Industrial style option"
+  },
+  "option.style.futuristic": {
+    "message": "Futuristic",
+    "description": "Futuristic style option"
+  },
+  "option.style.retro": {
+    "message": "Retro Film",
+    "description": "Retro film style option"
+  },
+  "name.voice": {
+    "message": "ナレーション音色",
+    "description": "音声音色フィールド"
+  },
+  "button.preview": {
+    "message": "試聴",
+    "description": "音声プレビュー / サンプル再生ボタン"
+  },
+  "description.voice": {
+    "message": "ナレーションの音色を選択します。音色は言語に依存せず、同じ音色が上部で選択した言語で読み上げられます。再生をクリックして試聴できます。",
+    "description": "音声フィールドのヘルプ"
+  },
+  "option.voice.auto": {
+    "message": "自動 · Maestro によるマッチ",
+    "description": "自動音声オプション"
+  },
+  "option.voice.warm-female": {
+    "message": "優しい女性の声",
+    "description": "優しい女性の音声オプション"
+  },
+  "option.voice.bright-female": {
+    "message": "明るい女性の声",
+    "description": "明るい女性の音声オプション"
+  },
+  "option.voice.anchor-female": {
+    "message": "女性アナウンサーの声",
+    "description": "女性アナウンサーの音声オプション"
+  },
+  "option.voice.clean-female": {
+    "message": "澄んだ女性の声",
+    "description": "澄んだ女性の音声オプション"
+  },
+  "option.voice.calm-male": {
+    "message": "落ち着いた男性の声",
+    "description": "落ち着いた男性の音声オプション"
+  },
+  "option.voice.deep-male": {
+    "message": "深い男性の声",
+    "description": "深い男性の音声オプション"
+  },
+  "option.voice.documentary-male": {
+    "message": "ドキュメンタリー男性の声",
+    "description": "ドキュメンタリー男性の音声オプション"
+  },
+  "option.voice.energetic-male": {
+    "message": "エネルギッシュな男性の声",
+    "description": "エネルギッシュな男性の音声オプション"
+  },
+  "option.voice.storyteller-male": {
+    "message": "語り手の男性の声",
+    "description": "語り手男性の音声オプション"
+  },
+  "option.scenario.slideshow": {
+    "message": "スライドショー",
+    "description": "スライドショーシナリオオプション"
   },
   "name.sourceType": {
     "message": "ソースタイプ",
@@ -322,61 +430,5 @@
   "option.scenario.changelog": {
     "message": "変更履歴 (PR)",
     "description": "Changelog scenario option"
-  },
-  "option.scenario.captions": {
-    "message": "字幕を追加",
-    "description": "Add-captions scenario option"
-  },
-  "option.style.glass": {
-    "message": "Frosted Glass",
-    "description": "Frosted glass style option"
-  },
-  "option.style.luxury": {
-    "message": "Luxury",
-    "description": "Luxury style option"
-  },
-  "option.style.swiss": {
-    "message": "Swiss Grid",
-    "description": "Swiss grid style option"
-  },
-  "option.style.modern": {
-    "message": "Modern",
-    "description": "Modern style option"
-  },
-  "option.style.editorial": {
-    "message": "Editorial",
-    "description": "Editorial style option"
-  },
-  "option.style.warm": {
-    "message": "Warm",
-    "description": "Warm style option"
-  },
-  "option.style.vibrant": {
-    "message": "Vibrant",
-    "description": "Vibrant style option"
-  },
-  "option.style.mono": {
-    "message": "Monochrome",
-    "description": "Monochrome style option"
-  },
-  "option.style.pastel": {
-    "message": "Pastel",
-    "description": "Pastel style option"
-  },
-  "option.style.bold": {
-    "message": "Bold Type",
-    "description": "Bold type style option"
-  },
-  "option.style.industrial": {
-    "message": "Industrial",
-    "description": "Industrial style option"
-  },
-  "option.style.futuristic": {
-    "message": "Futuristic",
-    "description": "Futuristic style option"
-  },
-  "option.style.retro": {
-    "message": "Retro Film",
-    "description": "Retro film style option"
   }
 }

--- a/src/i18n/ko/maestro.json
+++ b/src/i18n/ko/maestro.json
@@ -215,9 +215,9 @@
     "message": "모션 그래픽",
     "description": "Motion graphics scenario option"
   },
-  "option.scenario.slideshow": {
-    "message": "슬라이드 쇼",
-    "description": "슬라이드 쇼 시나리오 옵션"
+  "option.scenario.captions": {
+    "message": "자막 추가",
+    "description": "Add-captions scenario option"
   },
   "name.style": {
     "message": "시각적 스타일",
@@ -235,9 +235,117 @@
     "message": "영화 느낌",
     "description": "영화적 스타일 옵션"
   },
+  "option.style.glass": {
+    "message": "Frosted Glass",
+    "description": "Frosted glass style option"
+  },
+  "option.style.luxury": {
+    "message": "Luxury",
+    "description": "Luxury style option"
+  },
+  "option.style.swiss": {
+    "message": "Swiss Grid",
+    "description": "Swiss grid style option"
+  },
+  "option.style.modern": {
+    "message": "Modern",
+    "description": "Modern style option"
+  },
+  "option.style.editorial": {
+    "message": "Editorial",
+    "description": "Editorial style option"
+  },
+  "option.style.warm": {
+    "message": "Warm",
+    "description": "Warm style option"
+  },
+  "option.style.vibrant": {
+    "message": "Vibrant",
+    "description": "Vibrant style option"
+  },
   "option.style.neon": {
     "message": "네온",
     "description": "네온 스타일 옵션"
+  },
+  "option.style.mono": {
+    "message": "Monochrome",
+    "description": "Monochrome style option"
+  },
+  "option.style.pastel": {
+    "message": "Pastel",
+    "description": "Pastel style option"
+  },
+  "option.style.bold": {
+    "message": "Bold Type",
+    "description": "Bold type style option"
+  },
+  "option.style.industrial": {
+    "message": "Industrial",
+    "description": "Industrial style option"
+  },
+  "option.style.futuristic": {
+    "message": "Futuristic",
+    "description": "Futuristic style option"
+  },
+  "option.style.retro": {
+    "message": "Retro Film",
+    "description": "Retro film style option"
+  },
+  "name.voice": {
+    "message": "내레이터 음색",
+    "description": "음성 음색 필드"
+  },
+  "button.preview": {
+    "message": "미리보기",
+    "description": "음성 미리보기 / 샘플 재생 버튼"
+  },
+  "description.voice": {
+    "message": "내레이터 음색을 선택하세요. 음색은 언어와 무관합니다 — 동일한 음색이 위에서 선택한 언어로 읽어줍니다; 재생을 클릭하여 미리 들을 수 있습니다.",
+    "description": "음성 필드 도움말"
+  },
+  "option.voice.auto": {
+    "message": "자동 · Maestro가 매칭",
+    "description": "자동 음성 옵션"
+  },
+  "option.voice.warm-female": {
+    "message": "따뜻한 여자 음성",
+    "description": "따뜻한 여자 음성 옵션"
+  },
+  "option.voice.bright-female": {
+    "message": "밝은 여자 음성",
+    "description": "밝은 여자 음성 옵션"
+  },
+  "option.voice.anchor-female": {
+    "message": "여자 앵커 음성",
+    "description": "여자 앵커 음성 옵션"
+  },
+  "option.voice.clean-female": {
+    "message": "맑은 여자 음성",
+    "description": "맑은 여자 음성 옵션"
+  },
+  "option.voice.calm-male": {
+    "message": "차분한 남자 음성",
+    "description": "차분한 남자 음성 옵션"
+  },
+  "option.voice.deep-male": {
+    "message": "깊은 남자 음성",
+    "description": "깊은 남자 음성 옵션"
+  },
+  "option.voice.documentary-male": {
+    "message": "해설 남자 음성",
+    "description": "해설 남자 음성 옵션"
+  },
+  "option.voice.energetic-male": {
+    "message": "활기찬 남자 음성",
+    "description": "활기찬 남자 음성 옵션"
+  },
+  "option.voice.storyteller-male": {
+    "message": "서사 남자 음성",
+    "description": "서사 남자 음성 옵션"
+  },
+  "option.scenario.slideshow": {
+    "message": "슬라이드 쇼",
+    "description": "슬라이드 쇼 시나리오 옵션"
   },
   "name.sourceType": {
     "message": "출처 유형",
@@ -322,61 +430,5 @@
   "option.scenario.changelog": {
     "message": "변경 로그 (PR)",
     "description": "Changelog scenario option"
-  },
-  "option.scenario.captions": {
-    "message": "자막 추가",
-    "description": "Add-captions scenario option"
-  },
-  "option.style.glass": {
-    "message": "Frosted Glass",
-    "description": "Frosted glass style option"
-  },
-  "option.style.luxury": {
-    "message": "Luxury",
-    "description": "Luxury style option"
-  },
-  "option.style.swiss": {
-    "message": "Swiss Grid",
-    "description": "Swiss grid style option"
-  },
-  "option.style.modern": {
-    "message": "Modern",
-    "description": "Modern style option"
-  },
-  "option.style.editorial": {
-    "message": "Editorial",
-    "description": "Editorial style option"
-  },
-  "option.style.warm": {
-    "message": "Warm",
-    "description": "Warm style option"
-  },
-  "option.style.vibrant": {
-    "message": "Vibrant",
-    "description": "Vibrant style option"
-  },
-  "option.style.mono": {
-    "message": "Monochrome",
-    "description": "Monochrome style option"
-  },
-  "option.style.pastel": {
-    "message": "Pastel",
-    "description": "Pastel style option"
-  },
-  "option.style.bold": {
-    "message": "Bold Type",
-    "description": "Bold type style option"
-  },
-  "option.style.industrial": {
-    "message": "Industrial",
-    "description": "Industrial style option"
-  },
-  "option.style.futuristic": {
-    "message": "Futuristic",
-    "description": "Futuristic style option"
-  },
-  "option.style.retro": {
-    "message": "Retro Film",
-    "description": "Retro film style option"
   }
 }

--- a/src/i18n/pl/maestro.json
+++ b/src/i18n/pl/maestro.json
@@ -215,9 +215,9 @@
     "message": "Grafika ruchoma",
     "description": "Motion graphics scenario option"
   },
-  "option.scenario.slideshow": {
-    "message": "Pokaz slajdów",
-    "description": "Opcja scenariusza pokazu slajdów"
+  "option.scenario.captions": {
+    "message": "Dodaj napisy",
+    "description": "Add-captions scenario option"
   },
   "name.style": {
     "message": "Styl wizualny",
@@ -235,9 +235,117 @@
     "message": "Filmowy",
     "description": "Opcja stylu filmowego"
   },
+  "option.style.glass": {
+    "message": "Frosted Glass",
+    "description": "Frosted glass style option"
+  },
+  "option.style.luxury": {
+    "message": "Luxury",
+    "description": "Luxury style option"
+  },
+  "option.style.swiss": {
+    "message": "Swiss Grid",
+    "description": "Swiss grid style option"
+  },
+  "option.style.modern": {
+    "message": "Modern",
+    "description": "Modern style option"
+  },
+  "option.style.editorial": {
+    "message": "Editorial",
+    "description": "Editorial style option"
+  },
+  "option.style.warm": {
+    "message": "Warm",
+    "description": "Warm style option"
+  },
+  "option.style.vibrant": {
+    "message": "Vibrant",
+    "description": "Vibrant style option"
+  },
   "option.style.neon": {
     "message": "Neonowy",
     "description": "Opcja stylu neonowego"
+  },
+  "option.style.mono": {
+    "message": "Monochrome",
+    "description": "Monochrome style option"
+  },
+  "option.style.pastel": {
+    "message": "Pastel",
+    "description": "Pastel style option"
+  },
+  "option.style.bold": {
+    "message": "Bold Type",
+    "description": "Bold type style option"
+  },
+  "option.style.industrial": {
+    "message": "Industrial",
+    "description": "Industrial style option"
+  },
+  "option.style.futuristic": {
+    "message": "Futuristic",
+    "description": "Futuristic style option"
+  },
+  "option.style.retro": {
+    "message": "Retro Film",
+    "description": "Retro film style option"
+  },
+  "name.voice": {
+    "message": "Ton głosu",
+    "description": "Pole tonu głosu"
+  },
+  "button.preview": {
+    "message": "Podgląd",
+    "description": "Przycisk do podglądu głosu / odtwarzania próbki"
+  },
+  "description.voice": {
+    "message": "Wybierz ton głosu narratora. Ton nie jest związany z językiem — ten sam ton będzie czytany w języku wybranym powyżej; kliknij odtwarzanie, aby posłuchać.",
+    "description": "Pomoc dotycząca pola głosu"
+  },
+  "option.voice.auto": {
+    "message": "Automatycznie · dopasowane przez Maestro",
+    "description": "Opcja automatycznego głosu"
+  },
+  "option.voice.warm-female": {
+    "message": "Ciepły głos żeński",
+    "description": "Opcja ciepłego głosu żeńskiego"
+  },
+  "option.voice.bright-female": {
+    "message": "Jasny głos żeński",
+    "description": "Opcja jasnego głosu żeńskiego"
+  },
+  "option.voice.anchor-female": {
+    "message": "Głos żeński prowadzącego",
+    "description": "Opcja głosu żeńskiego prowadzącego"
+  },
+  "option.voice.clean-female": {
+    "message": "Czysty głos żeński",
+    "description": "Opcja czystego głosu żeńskiego"
+  },
+  "option.voice.calm-male": {
+    "message": "Spokojny głos męski",
+    "description": "Opcja spokojnego głosu męskiego"
+  },
+  "option.voice.deep-male": {
+    "message": "Głęboki głos męski",
+    "description": "Opcja głębokiego głosu męskiego"
+  },
+  "option.voice.documentary-male": {
+    "message": "Głos męski narratora",
+    "description": "Opcja głosu męskiego narratora"
+  },
+  "option.voice.energetic-male": {
+    "message": "Energetyczny głos męski",
+    "description": "Opcja energetycznego głosu męskiego"
+  },
+  "option.voice.storyteller-male": {
+    "message": "Głos męski narratora",
+    "description": "Opcja głosu męskiego narratora"
+  },
+  "option.scenario.slideshow": {
+    "message": "Pokaz slajdów",
+    "description": "Opcja scenariusza pokazu slajdów"
   },
   "name.sourceType": {
     "message": "Typ źródła",
@@ -322,61 +430,5 @@
   "option.scenario.changelog": {
     "message": "Lista zmian (PR)",
     "description": "Changelog scenario option"
-  },
-  "option.scenario.captions": {
-    "message": "Dodaj napisy",
-    "description": "Add-captions scenario option"
-  },
-  "option.style.glass": {
-    "message": "Frosted Glass",
-    "description": "Frosted glass style option"
-  },
-  "option.style.luxury": {
-    "message": "Luxury",
-    "description": "Luxury style option"
-  },
-  "option.style.swiss": {
-    "message": "Swiss Grid",
-    "description": "Swiss grid style option"
-  },
-  "option.style.modern": {
-    "message": "Modern",
-    "description": "Modern style option"
-  },
-  "option.style.editorial": {
-    "message": "Editorial",
-    "description": "Editorial style option"
-  },
-  "option.style.warm": {
-    "message": "Warm",
-    "description": "Warm style option"
-  },
-  "option.style.vibrant": {
-    "message": "Vibrant",
-    "description": "Vibrant style option"
-  },
-  "option.style.mono": {
-    "message": "Monochrome",
-    "description": "Monochrome style option"
-  },
-  "option.style.pastel": {
-    "message": "Pastel",
-    "description": "Pastel style option"
-  },
-  "option.style.bold": {
-    "message": "Bold Type",
-    "description": "Bold type style option"
-  },
-  "option.style.industrial": {
-    "message": "Industrial",
-    "description": "Industrial style option"
-  },
-  "option.style.futuristic": {
-    "message": "Futuristic",
-    "description": "Futuristic style option"
-  },
-  "option.style.retro": {
-    "message": "Retro Film",
-    "description": "Retro film style option"
   }
 }

--- a/src/i18n/pt/maestro.json
+++ b/src/i18n/pt/maestro.json
@@ -215,9 +215,9 @@
     "message": "Motion graphics",
     "description": "Motion graphics scenario option"
   },
-  "option.scenario.slideshow": {
-    "message": "Apresentação de slides",
-    "description": "Opção de cenário de apresentação de slides"
+  "option.scenario.captions": {
+    "message": "Adicionar legendas",
+    "description": "Add-captions scenario option"
   },
   "name.style": {
     "message": "Estilo visual",
@@ -235,9 +235,117 @@
     "message": "Estilo cinematográfico",
     "description": "Opção de estilo cinematográfico"
   },
+  "option.style.glass": {
+    "message": "Frosted Glass",
+    "description": "Frosted glass style option"
+  },
+  "option.style.luxury": {
+    "message": "Luxury",
+    "description": "Luxury style option"
+  },
+  "option.style.swiss": {
+    "message": "Swiss Grid",
+    "description": "Swiss grid style option"
+  },
+  "option.style.modern": {
+    "message": "Modern",
+    "description": "Modern style option"
+  },
+  "option.style.editorial": {
+    "message": "Editorial",
+    "description": "Editorial style option"
+  },
+  "option.style.warm": {
+    "message": "Warm",
+    "description": "Warm style option"
+  },
+  "option.style.vibrant": {
+    "message": "Vibrant",
+    "description": "Vibrant style option"
+  },
   "option.style.neon": {
     "message": "Estilo neon",
     "description": "Opção de estilo neon"
+  },
+  "option.style.mono": {
+    "message": "Monochrome",
+    "description": "Monochrome style option"
+  },
+  "option.style.pastel": {
+    "message": "Pastel",
+    "description": "Pastel style option"
+  },
+  "option.style.bold": {
+    "message": "Bold Type",
+    "description": "Bold type style option"
+  },
+  "option.style.industrial": {
+    "message": "Industrial",
+    "description": "Industrial style option"
+  },
+  "option.style.futuristic": {
+    "message": "Futuristic",
+    "description": "Futuristic style option"
+  },
+  "option.style.retro": {
+    "message": "Retro Film",
+    "description": "Retro film style option"
+  },
+  "name.voice": {
+    "message": "Timbre da narração",
+    "description": "Campo de timbre de voz"
+  },
+  "button.preview": {
+    "message": "Prévia",
+    "description": "Botão para prévia de voz / tocar amostra"
+  },
+  "description.voice": {
+    "message": "Escolha o timbre da narração. O timbre não está relacionado à língua — o mesmo timbre será lido na língua selecionada acima; clique em reproduzir para ouvir.",
+    "description": "Ajuda do campo de voz"
+  },
+  "option.voice.auto": {
+    "message": "Automático · Correspondido pelo Maestro",
+    "description": "Opção de voz automática"
+  },
+  "option.voice.warm-female": {
+    "message": "Voz feminina suave",
+    "description": "Opção de voz feminina suave"
+  },
+  "option.voice.bright-female": {
+    "message": "Voz feminina brilhante",
+    "description": "Opção de voz feminina brilhante"
+  },
+  "option.voice.anchor-female": {
+    "message": "Voz feminina de âncora",
+    "description": "Opção de voz feminina de âncora"
+  },
+  "option.voice.clean-female": {
+    "message": "Voz feminina clara",
+    "description": "Opção de voz feminina clara"
+  },
+  "option.voice.calm-male": {
+    "message": "Voz masculina calma",
+    "description": "Opção de voz masculina calma"
+  },
+  "option.voice.deep-male": {
+    "message": "Voz masculina profunda",
+    "description": "Opção de voz masculina profunda"
+  },
+  "option.voice.documentary-male": {
+    "message": "Voz masculina de documentário",
+    "description": "Opção de voz masculina de documentário"
+  },
+  "option.voice.energetic-male": {
+    "message": "Voz masculina enérgica",
+    "description": "Opção de voz masculina enérgica"
+  },
+  "option.voice.storyteller-male": {
+    "message": "Voz masculina narradora",
+    "description": "Opção de voz masculina narradora"
+  },
+  "option.scenario.slideshow": {
+    "message": "Apresentação de slides",
+    "description": "Opção de cenário de apresentação de slides"
   },
   "name.sourceType": {
     "message": "Tipo de origem",
@@ -322,61 +430,5 @@
   "option.scenario.changelog": {
     "message": "Registro de alterações (PR)",
     "description": "Changelog scenario option"
-  },
-  "option.scenario.captions": {
-    "message": "Adicionar legendas",
-    "description": "Add-captions scenario option"
-  },
-  "option.style.glass": {
-    "message": "Frosted Glass",
-    "description": "Frosted glass style option"
-  },
-  "option.style.luxury": {
-    "message": "Luxury",
-    "description": "Luxury style option"
-  },
-  "option.style.swiss": {
-    "message": "Swiss Grid",
-    "description": "Swiss grid style option"
-  },
-  "option.style.modern": {
-    "message": "Modern",
-    "description": "Modern style option"
-  },
-  "option.style.editorial": {
-    "message": "Editorial",
-    "description": "Editorial style option"
-  },
-  "option.style.warm": {
-    "message": "Warm",
-    "description": "Warm style option"
-  },
-  "option.style.vibrant": {
-    "message": "Vibrant",
-    "description": "Vibrant style option"
-  },
-  "option.style.mono": {
-    "message": "Monochrome",
-    "description": "Monochrome style option"
-  },
-  "option.style.pastel": {
-    "message": "Pastel",
-    "description": "Pastel style option"
-  },
-  "option.style.bold": {
-    "message": "Bold Type",
-    "description": "Bold type style option"
-  },
-  "option.style.industrial": {
-    "message": "Industrial",
-    "description": "Industrial style option"
-  },
-  "option.style.futuristic": {
-    "message": "Futuristic",
-    "description": "Futuristic style option"
-  },
-  "option.style.retro": {
-    "message": "Retro Film",
-    "description": "Retro film style option"
   }
 }

--- a/src/i18n/ru/maestro.json
+++ b/src/i18n/ru/maestro.json
@@ -215,9 +215,9 @@
     "message": "Моушн-графика",
     "description": "Motion graphics scenario option"
   },
-  "option.scenario.slideshow": {
-    "message": "Слайд-шоу",
-    "description": "Опция сценария слайд-шоу"
+  "option.scenario.captions": {
+    "message": "Добавить субтитры",
+    "description": "Add-captions scenario option"
   },
   "name.style": {
     "message": "Визуальный стиль",
@@ -235,9 +235,117 @@
     "message": "Кинематографический",
     "description": "Опция кинематографического стиля"
   },
+  "option.style.glass": {
+    "message": "Frosted Glass",
+    "description": "Frosted glass style option"
+  },
+  "option.style.luxury": {
+    "message": "Luxury",
+    "description": "Luxury style option"
+  },
+  "option.style.swiss": {
+    "message": "Swiss Grid",
+    "description": "Swiss grid style option"
+  },
+  "option.style.modern": {
+    "message": "Modern",
+    "description": "Modern style option"
+  },
+  "option.style.editorial": {
+    "message": "Editorial",
+    "description": "Editorial style option"
+  },
+  "option.style.warm": {
+    "message": "Warm",
+    "description": "Warm style option"
+  },
+  "option.style.vibrant": {
+    "message": "Vibrant",
+    "description": "Vibrant style option"
+  },
   "option.style.neon": {
     "message": "Неон",
     "description": "Опция неонового стиля"
+  },
+  "option.style.mono": {
+    "message": "Monochrome",
+    "description": "Monochrome style option"
+  },
+  "option.style.pastel": {
+    "message": "Pastel",
+    "description": "Pastel style option"
+  },
+  "option.style.bold": {
+    "message": "Bold Type",
+    "description": "Bold type style option"
+  },
+  "option.style.industrial": {
+    "message": "Industrial",
+    "description": "Industrial style option"
+  },
+  "option.style.futuristic": {
+    "message": "Futuristic",
+    "description": "Futuristic style option"
+  },
+  "option.style.retro": {
+    "message": "Retro Film",
+    "description": "Retro film style option"
+  },
+  "name.voice": {
+    "message": "Тембр голоса",
+    "description": "Поле для выбора тембра голоса"
+  },
+  "button.preview": {
+    "message": "Прослушать",
+    "description": "Кнопка предварительного прослушивания / воспроизведения образца"
+  },
+  "description.voice": {
+    "message": "Выберите тембр голоса для озвучивания. Тембр не зависит от языка — один и тот же тембр будет читать на языке, выбранном выше; нажмите воспроизвести, чтобы прослушать.",
+    "description": "Помощь по полю выбора голоса"
+  },
+  "option.voice.auto": {
+    "message": "Авто · Подбор от Maestro",
+    "description": "Опция автоматического голоса"
+  },
+  "option.voice.warm-female": {
+    "message": "Теплый женский голос",
+    "description": "Опция теплого женского голоса"
+  },
+  "option.voice.bright-female": {
+    "message": "Яркий женский голос",
+    "description": "Опция яркого женского голоса"
+  },
+  "option.voice.anchor-female": {
+    "message": "Женский голос ведущей",
+    "description": "Опция женского голоса ведущей"
+  },
+  "option.voice.clean-female": {
+    "message": "Чистый женский голос",
+    "description": "Опция чистого женского голоса"
+  },
+  "option.voice.calm-male": {
+    "message": "Спокойный мужской голос",
+    "description": "Опция спокойного мужского голоса"
+  },
+  "option.voice.deep-male": {
+    "message": "Глубокий мужской голос",
+    "description": "Опция глубокого мужского голоса"
+  },
+  "option.voice.documentary-male": {
+    "message": "Документальный мужской голос",
+    "description": "Опция документального мужского голоса"
+  },
+  "option.voice.energetic-male": {
+    "message": "Энергичный мужской голос",
+    "description": "Опция энергичного мужского голоса"
+  },
+  "option.voice.storyteller-male": {
+    "message": "Нарратор мужского голоса",
+    "description": "Опция мужского голоса рассказчика"
+  },
+  "option.scenario.slideshow": {
+    "message": "Слайд-шоу",
+    "description": "Опция сценария слайд-шоу"
   },
   "name.sourceType": {
     "message": "Тип источника",
@@ -322,61 +430,5 @@
   "option.scenario.changelog": {
     "message": "Список изменений (PR)",
     "description": "Changelog scenario option"
-  },
-  "option.scenario.captions": {
-    "message": "Добавить субтитры",
-    "description": "Add-captions scenario option"
-  },
-  "option.style.glass": {
-    "message": "Frosted Glass",
-    "description": "Frosted glass style option"
-  },
-  "option.style.luxury": {
-    "message": "Luxury",
-    "description": "Luxury style option"
-  },
-  "option.style.swiss": {
-    "message": "Swiss Grid",
-    "description": "Swiss grid style option"
-  },
-  "option.style.modern": {
-    "message": "Modern",
-    "description": "Modern style option"
-  },
-  "option.style.editorial": {
-    "message": "Editorial",
-    "description": "Editorial style option"
-  },
-  "option.style.warm": {
-    "message": "Warm",
-    "description": "Warm style option"
-  },
-  "option.style.vibrant": {
-    "message": "Vibrant",
-    "description": "Vibrant style option"
-  },
-  "option.style.mono": {
-    "message": "Monochrome",
-    "description": "Monochrome style option"
-  },
-  "option.style.pastel": {
-    "message": "Pastel",
-    "description": "Pastel style option"
-  },
-  "option.style.bold": {
-    "message": "Bold Type",
-    "description": "Bold type style option"
-  },
-  "option.style.industrial": {
-    "message": "Industrial",
-    "description": "Industrial style option"
-  },
-  "option.style.futuristic": {
-    "message": "Futuristic",
-    "description": "Futuristic style option"
-  },
-  "option.style.retro": {
-    "message": "Retro Film",
-    "description": "Retro film style option"
   }
 }

--- a/src/i18n/sr/maestro.json
+++ b/src/i18n/sr/maestro.json
@@ -215,9 +215,9 @@
     "message": "Покретна графика",
     "description": "Motion graphics scenario option"
   },
-  "option.scenario.slideshow": {
-    "message": "Презентација слајдова",
-    "description": "Опција за сценарио слајд шоу"
+  "option.scenario.captions": {
+    "message": "Додај титлове",
+    "description": "Add-captions scenario option"
   },
   "name.style": {
     "message": "Визуелни стил",
@@ -235,9 +235,117 @@
     "message": "Кинематографски",
     "description": "Опција кинематографског стила"
   },
+  "option.style.glass": {
+    "message": "Frosted Glass",
+    "description": "Frosted glass style option"
+  },
+  "option.style.luxury": {
+    "message": "Luxury",
+    "description": "Luxury style option"
+  },
+  "option.style.swiss": {
+    "message": "Swiss Grid",
+    "description": "Swiss grid style option"
+  },
+  "option.style.modern": {
+    "message": "Modern",
+    "description": "Modern style option"
+  },
+  "option.style.editorial": {
+    "message": "Editorial",
+    "description": "Editorial style option"
+  },
+  "option.style.warm": {
+    "message": "Warm",
+    "description": "Warm style option"
+  },
+  "option.style.vibrant": {
+    "message": "Vibrant",
+    "description": "Vibrant style option"
+  },
   "option.style.neon": {
     "message": "Неон",
     "description": "Опција неонског стила"
+  },
+  "option.style.mono": {
+    "message": "Monochrome",
+    "description": "Monochrome style option"
+  },
+  "option.style.pastel": {
+    "message": "Pastel",
+    "description": "Pastel style option"
+  },
+  "option.style.bold": {
+    "message": "Bold Type",
+    "description": "Bold type style option"
+  },
+  "option.style.industrial": {
+    "message": "Industrial",
+    "description": "Industrial style option"
+  },
+  "option.style.futuristic": {
+    "message": "Futuristic",
+    "description": "Futuristic style option"
+  },
+  "option.style.retro": {
+    "message": "Retro Film",
+    "description": "Retro film style option"
+  },
+  "name.voice": {
+    "message": "Тон гласа",
+    "description": "Поље за тон гласа"
+  },
+  "button.preview": {
+    "message": "Преглед",
+    "description": " dugme za pregled glasa / reprodukciju uzorka"
+  },
+  "description.voice": {
+    "message": "Изаберите тон гласа за нарацију. Тон није повезан са језиком — исти тон ће читати на језику изабраном горе; кликните на репродукцију за преглед.",
+    "description": "Помоћно поље за глас"
+  },
+  "option.voice.auto": {
+    "message": "Аутоматски · од Maestro",
+    "description": "опција аутоматског гласа"
+  },
+  "option.voice.warm-female": {
+    "message": "Топао женски глас",
+    "description": "опција топлог женског гласа"
+  },
+  "option.voice.bright-female": {
+    "message": "Светао женски глас",
+    "description": "опција светлог женског гласа"
+  },
+  "option.voice.anchor-female": {
+    "message": "Женски водитељ",
+    "description": "опција женског гласа водитеља"
+  },
+  "option.voice.clean-female": {
+    "message": "Чист женски глас",
+    "description": "опција чистог женског гласа"
+  },
+  "option.voice.calm-male": {
+    "message": "Смирен мушки глас",
+    "description": "опција смиреног мушког гласа"
+  },
+  "option.voice.deep-male": {
+    "message": "Дубок мушки глас",
+    "description": "опција дубоког мушког гласа"
+  },
+  "option.voice.documentary-male": {
+    "message": "Документарни мушки глас",
+    "description": "опција документарног мушког гласа"
+  },
+  "option.voice.energetic-male": {
+    "message": "Енергичан мушки глас",
+    "description": "опција енергичног мушког гласа"
+  },
+  "option.voice.storyteller-male": {
+    "message": "Приповедачки мушки глас",
+    "description": "опција приповедачког мушког гласа"
+  },
+  "option.scenario.slideshow": {
+    "message": "Презентација слајдова",
+    "description": "Опција за сценарио слајд шоу"
   },
   "name.sourceType": {
     "message": "Tip izvora",
@@ -322,61 +430,5 @@
   "option.scenario.changelog": {
     "message": "Списак измена (PR)",
     "description": "Changelog scenario option"
-  },
-  "option.scenario.captions": {
-    "message": "Додај титлове",
-    "description": "Add-captions scenario option"
-  },
-  "option.style.glass": {
-    "message": "Frosted Glass",
-    "description": "Frosted glass style option"
-  },
-  "option.style.luxury": {
-    "message": "Luxury",
-    "description": "Luxury style option"
-  },
-  "option.style.swiss": {
-    "message": "Swiss Grid",
-    "description": "Swiss grid style option"
-  },
-  "option.style.modern": {
-    "message": "Modern",
-    "description": "Modern style option"
-  },
-  "option.style.editorial": {
-    "message": "Editorial",
-    "description": "Editorial style option"
-  },
-  "option.style.warm": {
-    "message": "Warm",
-    "description": "Warm style option"
-  },
-  "option.style.vibrant": {
-    "message": "Vibrant",
-    "description": "Vibrant style option"
-  },
-  "option.style.mono": {
-    "message": "Monochrome",
-    "description": "Monochrome style option"
-  },
-  "option.style.pastel": {
-    "message": "Pastel",
-    "description": "Pastel style option"
-  },
-  "option.style.bold": {
-    "message": "Bold Type",
-    "description": "Bold type style option"
-  },
-  "option.style.industrial": {
-    "message": "Industrial",
-    "description": "Industrial style option"
-  },
-  "option.style.futuristic": {
-    "message": "Futuristic",
-    "description": "Futuristic style option"
-  },
-  "option.style.retro": {
-    "message": "Retro Film",
-    "description": "Retro film style option"
   }
 }

--- a/src/i18n/sv/maestro.json
+++ b/src/i18n/sv/maestro.json
@@ -215,9 +215,9 @@
     "message": "Rörlig grafik",
     "description": "Motion graphics scenario option"
   },
-  "option.scenario.slideshow": {
-    "message": "Bildspel",
-    "description": "Alternativ för bildspelscenario"
+  "option.scenario.captions": {
+    "message": "Lägg till undertexter",
+    "description": "Add-captions scenario option"
   },
   "name.style": {
     "message": "Visuell stil",
@@ -235,9 +235,117 @@
     "message": "Filmisk känsla",
     "description": "Alternativ för filmisk stil"
   },
+  "option.style.glass": {
+    "message": "Frosted Glass",
+    "description": "Frosted glass style option"
+  },
+  "option.style.luxury": {
+    "message": "Luxury",
+    "description": "Luxury style option"
+  },
+  "option.style.swiss": {
+    "message": "Swiss Grid",
+    "description": "Swiss grid style option"
+  },
+  "option.style.modern": {
+    "message": "Modern",
+    "description": "Modern style option"
+  },
+  "option.style.editorial": {
+    "message": "Editorial",
+    "description": "Editorial style option"
+  },
+  "option.style.warm": {
+    "message": "Warm",
+    "description": "Warm style option"
+  },
+  "option.style.vibrant": {
+    "message": "Vibrant",
+    "description": "Vibrant style option"
+  },
   "option.style.neon": {
     "message": "Neon",
     "description": "Alternativ för neonstil"
+  },
+  "option.style.mono": {
+    "message": "Monochrome",
+    "description": "Monochrome style option"
+  },
+  "option.style.pastel": {
+    "message": "Pastel",
+    "description": "Pastel style option"
+  },
+  "option.style.bold": {
+    "message": "Bold Type",
+    "description": "Bold type style option"
+  },
+  "option.style.industrial": {
+    "message": "Industrial",
+    "description": "Industrial style option"
+  },
+  "option.style.futuristic": {
+    "message": "Futuristic",
+    "description": "Futuristic style option"
+  },
+  "option.style.retro": {
+    "message": "Retro Film",
+    "description": "Retro film style option"
+  },
+  "name.voice": {
+    "message": "Berättarröst",
+    "description": "Fält för röstens tonläge"
+  },
+  "button.preview": {
+    "message": "Förhandsgranska",
+    "description": "Knapp för att förhandslyssna / spela upp exempel"
+  },
+  "description.voice": {
+    "message": "Välj röstens tonläge för berättarrösten. Tonläget är oberoende av språket — samma tonläge kommer att läsa upp på det språk som valts ovan; tryck på spela för att förhandslyssna.",
+    "description": "Hjälp för röstfält"
+  },
+  "option.voice.auto": {
+    "message": "Automatisk · Matchad av Maestro",
+    "description": "Alternativ för automatisk röst"
+  },
+  "option.voice.warm-female": {
+    "message": "Varm kvinnlig röst",
+    "description": "Alternativ för varm kvinnlig röst"
+  },
+  "option.voice.bright-female": {
+    "message": "Ljus kvinnlig röst",
+    "description": "Alternativ för ljus kvinnlig röst"
+  },
+  "option.voice.anchor-female": {
+    "message": "Programledarröst (kvinna)",
+    "description": "Alternativ för programledarröst (kvinna)"
+  },
+  "option.voice.clean-female": {
+    "message": "Klar kvinnlig röst",
+    "description": "Alternativ för klar kvinnlig röst"
+  },
+  "option.voice.calm-male": {
+    "message": "Lugn manlig röst",
+    "description": "Alternativ för lugn manlig röst"
+  },
+  "option.voice.deep-male": {
+    "message": "Djup manlig röst",
+    "description": "Alternativ för djup manlig röst"
+  },
+  "option.voice.documentary-male": {
+    "message": "Dokumentär manlig röst",
+    "description": "Alternativ för dokumentär manlig röst"
+  },
+  "option.voice.energetic-male": {
+    "message": "Energi manlig röst",
+    "description": "Alternativ för energisk manlig röst"
+  },
+  "option.voice.storyteller-male": {
+    "message": "Berättande manlig röst",
+    "description": "Alternativ för berättande manlig röst"
+  },
+  "option.scenario.slideshow": {
+    "message": "Bildspel",
+    "description": "Alternativ för bildspelscenario"
   },
   "name.sourceType": {
     "message": "Källtyp",
@@ -322,61 +430,5 @@
   "option.scenario.changelog": {
     "message": "Ändringslogg (PR)",
     "description": "Changelog scenario option"
-  },
-  "option.scenario.captions": {
-    "message": "Lägg till undertexter",
-    "description": "Add-captions scenario option"
-  },
-  "option.style.glass": {
-    "message": "Frosted Glass",
-    "description": "Frosted glass style option"
-  },
-  "option.style.luxury": {
-    "message": "Luxury",
-    "description": "Luxury style option"
-  },
-  "option.style.swiss": {
-    "message": "Swiss Grid",
-    "description": "Swiss grid style option"
-  },
-  "option.style.modern": {
-    "message": "Modern",
-    "description": "Modern style option"
-  },
-  "option.style.editorial": {
-    "message": "Editorial",
-    "description": "Editorial style option"
-  },
-  "option.style.warm": {
-    "message": "Warm",
-    "description": "Warm style option"
-  },
-  "option.style.vibrant": {
-    "message": "Vibrant",
-    "description": "Vibrant style option"
-  },
-  "option.style.mono": {
-    "message": "Monochrome",
-    "description": "Monochrome style option"
-  },
-  "option.style.pastel": {
-    "message": "Pastel",
-    "description": "Pastel style option"
-  },
-  "option.style.bold": {
-    "message": "Bold Type",
-    "description": "Bold type style option"
-  },
-  "option.style.industrial": {
-    "message": "Industrial",
-    "description": "Industrial style option"
-  },
-  "option.style.futuristic": {
-    "message": "Futuristic",
-    "description": "Futuristic style option"
-  },
-  "option.style.retro": {
-    "message": "Retro Film",
-    "description": "Retro film style option"
   }
 }

--- a/src/i18n/uk/maestro.json
+++ b/src/i18n/uk/maestro.json
@@ -215,9 +215,9 @@
     "message": "Моушн-графіка",
     "description": "Motion graphics scenario option"
   },
-  "option.scenario.slideshow": {
-    "message": "Слайд-шоу",
-    "description": "Опція сценарію слайд-шоу"
+  "option.scenario.captions": {
+    "message": "Додати субтитри",
+    "description": "Add-captions scenario option"
   },
   "name.style": {
     "message": "Візуальний стиль",
@@ -235,9 +235,117 @@
     "message": "Кінематографічний",
     "description": "Опція кінематографічного стилю"
   },
+  "option.style.glass": {
+    "message": "Frosted Glass",
+    "description": "Frosted glass style option"
+  },
+  "option.style.luxury": {
+    "message": "Luxury",
+    "description": "Luxury style option"
+  },
+  "option.style.swiss": {
+    "message": "Swiss Grid",
+    "description": "Swiss grid style option"
+  },
+  "option.style.modern": {
+    "message": "Modern",
+    "description": "Modern style option"
+  },
+  "option.style.editorial": {
+    "message": "Editorial",
+    "description": "Editorial style option"
+  },
+  "option.style.warm": {
+    "message": "Warm",
+    "description": "Warm style option"
+  },
+  "option.style.vibrant": {
+    "message": "Vibrant",
+    "description": "Vibrant style option"
+  },
   "option.style.neon": {
     "message": "Неоновий",
     "description": "Опція неонового стилю"
+  },
+  "option.style.mono": {
+    "message": "Monochrome",
+    "description": "Monochrome style option"
+  },
+  "option.style.pastel": {
+    "message": "Pastel",
+    "description": "Pastel style option"
+  },
+  "option.style.bold": {
+    "message": "Bold Type",
+    "description": "Bold type style option"
+  },
+  "option.style.industrial": {
+    "message": "Industrial",
+    "description": "Industrial style option"
+  },
+  "option.style.futuristic": {
+    "message": "Futuristic",
+    "description": "Futuristic style option"
+  },
+  "option.style.retro": {
+    "message": "Retro Film",
+    "description": "Retro film style option"
+  },
+  "name.voice": {
+    "message": "Тональність озвучення",
+    "description": "Поле для вибору тональності голосу"
+  },
+  "button.preview": {
+    "message": "Попередній перегляд",
+    "description": "Кнопка для попереднього прослуховування голосу / відтворення зразка"
+  },
+  "description.voice": {
+    "message": "Виберіть тональність озвучення. Тональність не залежить від мови — одна й та ж тональність буде читати мовою, вибраною вище; натисніть відтворення, щоб прослухати.",
+    "description": "Допомога для поля вибору голосу"
+  },
+  "option.voice.auto": {
+    "message": "Автоматично · Відповідає Maestro",
+    "description": "Автоматична опція голосу"
+  },
+  "option.voice.warm-female": {
+    "message": "Теплий жіночий голос",
+    "description": "Опція теплого жіночого голосу"
+  },
+  "option.voice.bright-female": {
+    "message": "Яскравий жіночий голос",
+    "description": "Опція яскравого жіночого голосу"
+  },
+  "option.voice.anchor-female": {
+    "message": "Жіночий ведучий",
+    "description": "Опція жіночого голосу ведучого"
+  },
+  "option.voice.clean-female": {
+    "message": "Чистий жіночий голос",
+    "description": "Опція чистого жіночого голосу"
+  },
+  "option.voice.calm-male": {
+    "message": "Спокійний чоловічий голос",
+    "description": "Опція спокійного чоловічого голосу"
+  },
+  "option.voice.deep-male": {
+    "message": "Глибокий чоловічий голос",
+    "description": "Опція глибокого чоловічого голосу"
+  },
+  "option.voice.documentary-male": {
+    "message": "Документальний чоловічий голос",
+    "description": "Опція документального чоловічого голосу"
+  },
+  "option.voice.energetic-male": {
+    "message": "Енергійний чоловічий голос",
+    "description": "Опція енергійного чоловічого голосу"
+  },
+  "option.voice.storyteller-male": {
+    "message": "Оповідач чоловічий голос",
+    "description": "Опція чоловічого голосу оповідача"
+  },
+  "option.scenario.slideshow": {
+    "message": "Слайд-шоу",
+    "description": "Опція сценарію слайд-шоу"
   },
   "name.sourceType": {
     "message": "Тип джерела",
@@ -322,61 +430,5 @@
   "option.scenario.changelog": {
     "message": "Журнал змін (PR)",
     "description": "Changelog scenario option"
-  },
-  "option.scenario.captions": {
-    "message": "Додати субтитри",
-    "description": "Add-captions scenario option"
-  },
-  "option.style.glass": {
-    "message": "Frosted Glass",
-    "description": "Frosted glass style option"
-  },
-  "option.style.luxury": {
-    "message": "Luxury",
-    "description": "Luxury style option"
-  },
-  "option.style.swiss": {
-    "message": "Swiss Grid",
-    "description": "Swiss grid style option"
-  },
-  "option.style.modern": {
-    "message": "Modern",
-    "description": "Modern style option"
-  },
-  "option.style.editorial": {
-    "message": "Editorial",
-    "description": "Editorial style option"
-  },
-  "option.style.warm": {
-    "message": "Warm",
-    "description": "Warm style option"
-  },
-  "option.style.vibrant": {
-    "message": "Vibrant",
-    "description": "Vibrant style option"
-  },
-  "option.style.mono": {
-    "message": "Monochrome",
-    "description": "Monochrome style option"
-  },
-  "option.style.pastel": {
-    "message": "Pastel",
-    "description": "Pastel style option"
-  },
-  "option.style.bold": {
-    "message": "Bold Type",
-    "description": "Bold type style option"
-  },
-  "option.style.industrial": {
-    "message": "Industrial",
-    "description": "Industrial style option"
-  },
-  "option.style.futuristic": {
-    "message": "Futuristic",
-    "description": "Futuristic style option"
-  },
-  "option.style.retro": {
-    "message": "Retro Film",
-    "description": "Retro film style option"
   }
 }

--- a/src/i18n/zh-CN/maestro.json
+++ b/src/i18n/zh-CN/maestro.json
@@ -290,5 +290,57 @@
   "option.style.retro": {
     "message": "复古胶片",
     "description": "Retro film style option"
+  },
+  "name.voice": {
+    "message": "配音音色",
+    "description": "Voice timbre field"
+  },
+  "button.preview": {
+    "message": "试听",
+    "description": "Voice preview / play sample button"
+  },
+  "description.voice": {
+    "message": "选择旁白配音的音色。音色与语言无关——同一音色会用上方选择的语言来朗读；点播放可试听。",
+    "description": "Voice field help"
+  },
+  "option.voice.auto": {
+    "message": "自动 · 由 Maestro 匹配",
+    "description": "Auto voice option"
+  },
+  "option.voice.warm-female": {
+    "message": "温柔女声",
+    "description": "warm female voice option"
+  },
+  "option.voice.bright-female": {
+    "message": "明亮女声",
+    "description": "bright female voice option"
+  },
+  "option.voice.anchor-female": {
+    "message": "主播女声",
+    "description": "anchor female voice option"
+  },
+  "option.voice.clean-female": {
+    "message": "清澈女声",
+    "description": "clean female voice option"
+  },
+  "option.voice.calm-male": {
+    "message": "沉稳男声",
+    "description": "calm male voice option"
+  },
+  "option.voice.deep-male": {
+    "message": "浑厚男声",
+    "description": "deep male voice option"
+  },
+  "option.voice.documentary-male": {
+    "message": "解说男声",
+    "description": "documentary male voice option"
+  },
+  "option.voice.energetic-male": {
+    "message": "活力男声",
+    "description": "energetic male voice option"
+  },
+  "option.voice.storyteller-male": {
+    "message": "叙事男声",
+    "description": "storyteller male voice option"
   }
 }

--- a/src/i18n/zh-TW/maestro.json
+++ b/src/i18n/zh-TW/maestro.json
@@ -215,9 +215,9 @@
     "message": "動態圖形",
     "description": "Motion graphics scenario option"
   },
-  "option.scenario.slideshow": {
-    "message": "演示幻燈",
-    "description": "幻燈片場景選項"
+  "option.scenario.captions": {
+    "message": "影片加字幕",
+    "description": "Add-captions scenario option"
   },
   "name.style": {
     "message": "視覺風格",
@@ -235,9 +235,117 @@
     "message": "電影感",
     "description": "電影風格選項"
   },
+  "option.style.glass": {
+    "message": "Frosted Glass",
+    "description": "Frosted glass style option"
+  },
+  "option.style.luxury": {
+    "message": "Luxury",
+    "description": "Luxury style option"
+  },
+  "option.style.swiss": {
+    "message": "Swiss Grid",
+    "description": "Swiss grid style option"
+  },
+  "option.style.modern": {
+    "message": "Modern",
+    "description": "Modern style option"
+  },
+  "option.style.editorial": {
+    "message": "Editorial",
+    "description": "Editorial style option"
+  },
+  "option.style.warm": {
+    "message": "Warm",
+    "description": "Warm style option"
+  },
+  "option.style.vibrant": {
+    "message": "Vibrant",
+    "description": "Vibrant style option"
+  },
   "option.style.neon": {
     "message": "霓虹",
     "description": "霓虹風格選項"
+  },
+  "option.style.mono": {
+    "message": "Monochrome",
+    "description": "Monochrome style option"
+  },
+  "option.style.pastel": {
+    "message": "Pastel",
+    "description": "Pastel style option"
+  },
+  "option.style.bold": {
+    "message": "Bold Type",
+    "description": "Bold type style option"
+  },
+  "option.style.industrial": {
+    "message": "Industrial",
+    "description": "Industrial style option"
+  },
+  "option.style.futuristic": {
+    "message": "Futuristic",
+    "description": "Futuristic style option"
+  },
+  "option.style.retro": {
+    "message": "Retro Film",
+    "description": "Retro film style option"
+  },
+  "name.voice": {
+    "message": "配音音色",
+    "description": "配音音色欄位"
+  },
+  "button.preview": {
+    "message": "试听",
+    "description": "語音預覽 / 播放範例按鈕"
+  },
+  "description.voice": {
+    "message": "選擇旁白配音的音色。音色與語言無關——同一音色會用上方選擇的語言來朗讀；點播放可试听。",
+    "description": "語音欄位幫助"
+  },
+  "option.voice.auto": {
+    "message": "自動 · 由 Maestro 匹配",
+    "description": "自動語音選項"
+  },
+  "option.voice.warm-female": {
+    "message": "溫柔女聲",
+    "description": "溫柔女聲選項"
+  },
+  "option.voice.bright-female": {
+    "message": "明亮女聲",
+    "description": "明亮女聲選項"
+  },
+  "option.voice.anchor-female": {
+    "message": "主播女聲",
+    "description": "主播女聲選項"
+  },
+  "option.voice.clean-female": {
+    "message": "清澈女聲",
+    "description": "清澈女聲選項"
+  },
+  "option.voice.calm-male": {
+    "message": "沉穩男聲",
+    "description": "沉穩男聲選項"
+  },
+  "option.voice.deep-male": {
+    "message": "浑厚男聲",
+    "description": "浑厚男聲選項"
+  },
+  "option.voice.documentary-male": {
+    "message": "解說男聲",
+    "description": "解說男聲選項"
+  },
+  "option.voice.energetic-male": {
+    "message": "活力男聲",
+    "description": "活力男聲選項"
+  },
+  "option.voice.storyteller-male": {
+    "message": "叙事男聲",
+    "description": "叙事男聲選項"
+  },
+  "option.scenario.slideshow": {
+    "message": "演示幻燈",
+    "description": "幻燈片場景選項"
   },
   "name.sourceType": {
     "message": "來源類型",
@@ -322,61 +430,5 @@
   "option.scenario.changelog": {
     "message": "更新日誌 (PR)",
     "description": "Changelog scenario option"
-  },
-  "option.scenario.captions": {
-    "message": "影片加字幕",
-    "description": "Add-captions scenario option"
-  },
-  "option.style.glass": {
-    "message": "Frosted Glass",
-    "description": "Frosted glass style option"
-  },
-  "option.style.luxury": {
-    "message": "Luxury",
-    "description": "Luxury style option"
-  },
-  "option.style.swiss": {
-    "message": "Swiss Grid",
-    "description": "Swiss grid style option"
-  },
-  "option.style.modern": {
-    "message": "Modern",
-    "description": "Modern style option"
-  },
-  "option.style.editorial": {
-    "message": "Editorial",
-    "description": "Editorial style option"
-  },
-  "option.style.warm": {
-    "message": "Warm",
-    "description": "Warm style option"
-  },
-  "option.style.vibrant": {
-    "message": "Vibrant",
-    "description": "Vibrant style option"
-  },
-  "option.style.mono": {
-    "message": "Monochrome",
-    "description": "Monochrome style option"
-  },
-  "option.style.pastel": {
-    "message": "Pastel",
-    "description": "Pastel style option"
-  },
-  "option.style.bold": {
-    "message": "Bold Type",
-    "description": "Bold type style option"
-  },
-  "option.style.industrial": {
-    "message": "Industrial",
-    "description": "Industrial style option"
-  },
-  "option.style.futuristic": {
-    "message": "Futuristic",
-    "description": "Futuristic style option"
-  },
-  "option.style.retro": {
-    "message": "Retro Film",
-    "description": "Retro film style option"
   }
 }

--- a/src/models/maestro.ts
+++ b/src/models/maestro.ts
@@ -11,6 +11,7 @@ export interface IMaestroConfig {
   quality?: string; // 'draft' | 'standard' | 'premium'
   scenario?: string; // 'auto' | 'narrated' | 'drama' | 'avatar' | 'motion' | 'captions'
   style?: string; // freeform visual hint (e.g. 'auto' | 'cinematic' | 'minimal' | 'neon' | 'corporate'); orthogonal to scenario
+  voice?: string; // narration timbre: 'auto' (director picks) | a preset key (constants) | a 32-hex Fish reference_id
   callback_url?: string;
 }
 


### PR DESCRIPTION
## What
Adds the **voice (narration timbre)** selector to the Maestro config panel — a dropdown of curated voices with an inline **▶︎ 试听 preview**. Pairs with PlatformService#1392 (service) and PlatformBackend#895 (OpenAPI). Default `auto` = unchanged.

## Changes
- **`constants/maestro.ts`** — `MAESTRO_ALLOWED_VOICES` (9 curated voices + `auto`), each with `langs` + a CDN `sample` preview clip; `MAESTRO_DEFAULT_VOICE`.
- **`models/maestro.ts`** — `IMaestroConfig.voice?`.
- **`components/maestro/ConfigPanel.vue`** — Voice field: `el-select` (filtered by the chosen output languages) + a play/pause button that previews the sample via a single reused `Audio` element (`markRaw`, stopped on change / unmount). Persisted-but-unknown voice falls back to `auto`.
- **i18n** — `name.voice` / `description.voice` / `button.preview` / `option.voice.*` added to the `zh-CN` base locale and propagated to all 17 other locales via `scripts/translate_i18n.py`.

## Preview samples
Each voice's `sample` is a short branded line ("欢迎使用 Ace Data Cloud …") generated once via Fish TTS and hosted on `cdn.acedata.cloud` — **stable, non-expiring** (Fish's own sample URLs are signed + expire in 1h, so they can't be used directly).

## Verification
- `vue-tsc -b` → exit 0 (typecheck clean).
- `eslint` on changed files → exit 0.
- Preview `Audio` reused + torn down on `beforeUnmount`; play button disabled for `auto` (no sample).

## Backward compatibility
Additive — omitting `voice` (or `auto`) yields identical behavior; no cost change.
