### PR TITLE
fix(kling): show per-second price for Motion Control instead of a fixed estimate

### DIFF
--- a/change/@acedatacloud-nexior-bb4e2e91-250c-4353-a107-b6e5b16f79bf.json
+++ b/change/@acedatacloud-nexior-bb4e2e91-250c-4353-a107-b6e5b16f79bf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(kling): show per-second price for Motion Control instead of a fixed estimate",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/Consumption.vue
+++ b/src/components/common/Consumption.vue
@@ -3,8 +3,9 @@
     <font-awesome-icon icon="fa-solid fa-coins" class="text-xs mr-1 text-[var(--el-color-primary-light-3)]" />
     <span class="text-xs font-medium">
       {{ value.toFixed(2) }}
-      {{ $t(`service.unit.${service?.unit || 'credits'}`) }}
+      {{ $t(`service.unit.${service?.unit || 'credits'}`) }}<template v-if="rateUnit">/{{ rateUnit }}</template>
     </span>
+    <div v-if="note" class="text-[10px] leading-tight mt-0.5 opacity-80">{{ note }}</div>
   </div>
 </template>
 
@@ -27,6 +28,18 @@ export default defineComponent({
     service: {
       type: Object as () => IService | undefined,
       required: true
+    },
+    // When set, renders the price as a per-unit rate (e.g. "1.20 Credit/second").
+    rateUnit: {
+      type: String,
+      required: false,
+      default: ''
+    },
+    // Optional muted hint shown below the price (e.g. "billed by output length").
+    note: {
+      type: String,
+      required: false,
+      default: ''
     }
   }
 });

--- a/src/components/kling/MotionPanel.vue
+++ b/src/components/kling/MotionPanel.vue
@@ -9,7 +9,12 @@
       <keep-original-sound-selector class="mb-4" />
     </div>
     <div class="flex flex-col items-center justify-center px-5 pb-5">
-      <consumption :value="consumption" :service="service" />
+      <consumption
+        :value="consumption"
+        :service="service"
+        :rate-unit="$t('kling.name.perSecond')"
+        :note="$t('kling.message.motionPricingNote')"
+      />
       <el-button type="primary" class="btn w-full" round :disabled="!canGenerate" @click="onGenerate">
         <font-awesome-icon icon="fa-solid fa-magic" class="mr-2" />
         {{ $t('kling.button.generateMotion') }}
@@ -50,7 +55,11 @@ export default defineComponent({
       return this.$store.state.kling?.motionConfig;
     },
     consumption() {
-      return getConsumption(this.motionConfig, this.service?.cost);
+      // Motion Control is billed per second of the generated video, and the
+      // output length is not known before generation, so show the per-second
+      // rate (duration=1) instead of a fixed estimate that would understate the
+      // real charge.
+      return getConsumption({ ...this.motionConfig, duration: 1 }, this.service?.cost);
     },
     service() {
       return this.$store.state.kling?.service;

--- a/src/i18n/ar/kling.json
+++ b/src/i18n/ar/kling.json
@@ -71,6 +71,10 @@
     "message": "يرجى تحميل صورة الشخصية وفيديو الحركة معًا.",
     "description": "Motion Control 缺少输入时的提示"
   },
+  "message.motionPricingNote": {
+    "message": "يُحتسب السعر لكل ثانية من الفيديو الناتج؛ يتغيّر المبلغ النهائي حسب طول الفيديو المرجعي.",
+    "description": "Explains that Motion Control is billed per second"
+  },
   "inspiration.title": {
     "message": "إلهام وإعدادات مسبقة",
     "description": "Inspiration 抽屉的标题"
@@ -414,6 +418,10 @@
   "name.mode": {
     "message": "وضع الفيديو",
     "description": "الوضع المستخدم لإنشاء الفيديو"
+  },
+  "name.perSecond": {
+    "message": "ثانية",
+    "description": "Unit suffix for per-second pricing"
   },
   "name.effect": {
     "message": "تأثير الفيديو",

--- a/src/i18n/de/kling.json
+++ b/src/i18n/de/kling.json
@@ -71,6 +71,10 @@
     "message": "Bitte lade sowohl das Personenbild als auch das Referenzvideo hoch.",
     "description": "Hinweis bei fehlenden Eingaben in der Bewegungssteuerung"
   },
+  "message.motionPricingNote": {
+    "message": "Abrechnung pro Sekunde des generierten Videos; der Endbetrag richtet sich nach der Länge des Referenzvideos.",
+    "description": "Explains that Motion Control is billed per second"
+  },
   "inspiration.title": {
     "message": "Inspiration und Voreinstellungen",
     "description": "Titel des Inspiration-Dock"
@@ -414,6 +418,10 @@
   "name.mode": {
     "message": "Videomodus",
     "description": "Der Modus, der zur Erstellung des Videos verwendet wird"
+  },
+  "name.perSecond": {
+    "message": "Sekunde",
+    "description": "Unit suffix for per-second pricing"
   },
   "name.effect": {
     "message": "Videoeffekt",

--- a/src/i18n/el/kling.json
+++ b/src/i18n/el/kling.json
@@ -71,6 +71,10 @@
     "message": "Παρακαλώ ανεβάστε ταυτόχρονα την εικόνα προσώπου και το βίντεο αναφοράς κίνησης.",
     "description": "Motion Control 缺少输入时的提示"
   },
+  "message.motionPricingNote": {
+    "message": "Χρέωση ανά δευτερόλεπτο του παραγόμενου βίντεο· το τελικό ποσό εξαρτάται από τη διάρκεια του βίντεο αναφοράς.",
+    "description": "Explains that Motion Control is billed per second"
+  },
   "inspiration.title": {
     "message": "Έμπνευση και Προεπιλογές",
     "description": "Inspiration 抽屉的标题"
@@ -414,6 +418,10 @@
   "name.mode": {
     "message": "Λειτουργία βίντεο",
     "description": "Η λειτουργία που θα χρησιμοποιηθεί για την παραγωγή του βίντεο"
+  },
+  "name.perSecond": {
+    "message": "δευτερόλεπτο",
+    "description": "Unit suffix for per-second pricing"
   },
   "name.effect": {
     "message": "Εφέ βίντεο",

--- a/src/i18n/en/kling.json
+++ b/src/i18n/en/kling.json
@@ -71,6 +71,10 @@
     "message": "Please upload both the character image and motion reference video.",
     "description": "Prompt when inputs are missing in Motion Control"
   },
+  "message.motionPricingNote": {
+    "message": "Billed per second of the generated video; the final amount scales with the reference video length.",
+    "description": "Explains that Motion Control is billed per second"
+  },
   "inspiration.title": {
     "message": "Inspiration and Presets",
     "description": "Title of the Inspiration drawer"
@@ -414,6 +418,10 @@
   "name.mode": {
     "message": "Video Mode",
     "description": "The mode used to generate the video"
+  },
+  "name.perSecond": {
+    "message": "second",
+    "description": "Unit suffix for per-second pricing, e.g. \"1.20 Credit/second\""
   },
   "name.effect": {
     "message": "Video Effect",

--- a/src/i18n/es/kling.json
+++ b/src/i18n/es/kling.json
@@ -71,6 +71,10 @@
     "message": "Por favor, sube tanto la imagen del personaje como el video de referencia.",
     "description": "Mensaje cuando faltan entradas en Control de Movimiento"
   },
+  "message.motionPricingNote": {
+    "message": "Se cobra por segundo del vídeo generado; el importe final varía según la duración del vídeo de referencia.",
+    "description": "Explains that Motion Control is billed per second"
+  },
   "inspiration.title": {
     "message": "Inspiración y preajustes",
     "description": "Título del cajón de Inspiración"
@@ -414,6 +418,10 @@
   "name.mode": {
     "message": "Modo de video",
     "description": "El modo utilizado para generar el video"
+  },
+  "name.perSecond": {
+    "message": "segundo",
+    "description": "Unit suffix for per-second pricing"
   },
   "name.effect": {
     "message": "Efecto de video",

--- a/src/i18n/fi/kling.json
+++ b/src/i18n/fi/kling.json
@@ -71,6 +71,10 @@
     "message": "Lataa sekä henkilökuva että liikevideo",
     "description": "Liikeohjauksen puuttuvista syötteistä ilmoittava viesti"
   },
+  "message.motionPricingNote": {
+    "message": "Laskutetaan tuotetun videon sekunneilta; lopullinen summa riippuu viitevideon pituudesta.",
+    "description": "Explains that Motion Control is billed per second"
+  },
   "inspiration.title": {
     "message": "Inspiraatio ja esiasetukset",
     "description": "Inspiration-laatikon otsikko"
@@ -414,6 +418,10 @@
   "name.mode": {
     "message": "Videotila",
     "description": "Videon luomiseen käytettävä tila"
+  },
+  "name.perSecond": {
+    "message": "sekunti",
+    "description": "Unit suffix for per-second pricing"
   },
   "name.effect": {
     "message": "Videotehoste",

--- a/src/i18n/fr/kling.json
+++ b/src/i18n/fr/kling.json
@@ -71,6 +71,10 @@
     "message": "Veuillez télécharger à la fois l'image de référence et la vidéo de référence.",
     "description": "Motion Control 缺少输入时的提示"
   },
+  "message.motionPricingNote": {
+    "message": "Facturé à la seconde de la vidéo générée ; le montant final dépend de la durée de la vidéo de référence.",
+    "description": "Explains that Motion Control is billed per second"
+  },
   "inspiration.title": {
     "message": "Inspiration et préréglages",
     "description": "Inspiration 抽屉的标题"
@@ -414,6 +418,10 @@
   "name.mode": {
     "message": "Mode vidéo",
     "description": "Le mode utilisé pour générer la vidéo"
+  },
+  "name.perSecond": {
+    "message": "seconde",
+    "description": "Unit suffix for per-second pricing"
   },
   "name.effect": {
     "message": "Effet vidéo",

--- a/src/i18n/it/kling.json
+++ b/src/i18n/it/kling.json
@@ -71,6 +71,10 @@
     "message": "Carica sia l'immagine del personaggio che il video di riferimento.",
     "description": "Messaggio di avviso quando mancano input nel Controllo Movimento"
   },
+  "message.motionPricingNote": {
+    "message": "Addebito al secondo del video generato; l'importo finale varia in base alla durata del video di riferimento.",
+    "description": "Explains that Motion Control is billed per second"
+  },
   "inspiration.title": {
     "message": "Ispirazione e Preset",
     "description": "Titolo del cassetto Ispirazione"
@@ -414,6 +418,10 @@
   "name.mode": {
     "message": "Modalità video",
     "description": "La modalità utilizzata per generare il video"
+  },
+  "name.perSecond": {
+    "message": "secondo",
+    "description": "Unit suffix for per-second pricing"
   },
   "name.effect": {
     "message": "Effetto video",

--- a/src/i18n/ja/kling.json
+++ b/src/i18n/ja/kling.json
@@ -71,6 +71,10 @@
     "message": "人物画像と動作参照動画を同時にアップロードしてください。",
     "description": "Motion Control 入力が不足している時のメッセージ"
   },
+  "message.motionPricingNote": {
+    "message": "生成された動画の秒数で課金され、最終金額は参照動画の長さに応じて変動します。",
+    "description": "Explains that Motion Control is billed per second"
+  },
   "inspiration.title": {
     "message": "インスピレーションとプリセット",
     "description": "Inspiration ドロワーのタイトル"
@@ -414,6 +418,10 @@
   "name.mode": {
     "message": "ビデオモード",
     "description": "生成するビデオに使用されるモード"
+  },
+  "name.perSecond": {
+    "message": "秒",
+    "description": "Unit suffix for per-second pricing"
   },
   "name.effect": {
     "message": "ビデオ効果",

--- a/src/i18n/ko/kling.json
+++ b/src/i18n/ko/kling.json
@@ -71,6 +71,10 @@
     "message": "인물 이미지와 모션 참조 비디오를 모두 업로드해 주세요.",
     "description": "Motion Control 缺少输入时的提示"
   },
+  "message.motionPricingNote": {
+    "message": "생성된 영상의 초 단위로 청구되며, 최종 금액은 참조 영상 길이에 따라 달라집니다.",
+    "description": "Explains that Motion Control is billed per second"
+  },
   "inspiration.title": {
     "message": "영감 및 프리셋",
     "description": "Inspiration 抽屉的标题"
@@ -414,6 +418,10 @@
   "name.mode": {
     "message": "비디오 모드",
     "description": "비디오를 생성하는 데 사용되는 모드"
+  },
+  "name.perSecond": {
+    "message": "초",
+    "description": "Unit suffix for per-second pricing"
   },
   "name.effect": {
     "message": "비디오 효과",

--- a/src/i18n/pl/kling.json
+++ b/src/i18n/pl/kling.json
@@ -71,6 +71,10 @@
     "message": "Proszę przesłać zarówno obraz postaci, jak i wideo referencyjne ruchu.",
     "description": "Motion Control 缺少输入时的提示"
   },
+  "message.motionPricingNote": {
+    "message": "Rozliczenie za sekundę wygenerowanego wideo; ostateczna kwota zależy od długości wideo referencyjnego.",
+    "description": "Explains that Motion Control is billed per second"
+  },
   "inspiration.title": {
     "message": "Inspiracje i ustawienia",
     "description": "Inspiration 抽屉的标题"
@@ -414,6 +418,10 @@
   "name.mode": {
     "message": "Tryb wideo",
     "description": "Tryb używany do generowania wideo"
+  },
+  "name.perSecond": {
+    "message": "sekunda",
+    "description": "Unit suffix for per-second pricing"
   },
   "name.effect": {
     "message": "Efekt wideo",

--- a/src/i18n/pt/kling.json
+++ b/src/i18n/pt/kling.json
@@ -71,6 +71,10 @@
     "message": "Por favor, envie tanto a imagem do personagem quanto o vídeo de referência.",
     "description": "Motion Control 缺少输入时的提示"
   },
+  "message.motionPricingNote": {
+    "message": "Cobrado por segundo do vídeo gerado; o valor final varia conforme a duração do vídeo de referência.",
+    "description": "Explains that Motion Control is billed per second"
+  },
   "inspiration.title": {
     "message": "Inspiração e Predefinições",
     "description": "Inspiration 抽屉的标题"
@@ -414,6 +418,10 @@
   "name.mode": {
     "message": "Modo de vídeo",
     "description": "Modo a ser utilizado para gerar o vídeo"
+  },
+  "name.perSecond": {
+    "message": "segundo",
+    "description": "Unit suffix for per-second pricing"
   },
   "name.effect": {
     "message": "Efeito do vídeo",

--- a/src/i18n/ru/kling.json
+++ b/src/i18n/ru/kling.json
@@ -71,6 +71,10 @@
     "message": "Пожалуйста, загрузите изображение персонажа и видео с движением одновременно.",
     "description": "Motion Control 缺少输入时的提示"
   },
+  "message.motionPricingNote": {
+    "message": "Оплата за секунду сгенерированного видео; итоговая сумма зависит от длины исходного видео.",
+    "description": "Explains that Motion Control is billed per second"
+  },
   "inspiration.title": {
     "message": "Вдохновение и предустановки",
     "description": "Inspiration 抽屉的标题"
@@ -414,6 +418,10 @@
   "name.mode": {
     "message": "Режим видео",
     "description": "Режим, используемый для генерации видео"
+  },
+  "name.perSecond": {
+    "message": "секунда",
+    "description": "Unit suffix for per-second pricing"
   },
   "name.effect": {
     "message": "Эффект видео",

--- a/src/i18n/sr/kling.json
+++ b/src/i18n/sr/kling.json
@@ -71,6 +71,10 @@
     "message": "Molimo vas da otpremite i referentnu sliku i referentni video",
     "description": "Poruka kada nedostaju ulazi u Kontroli pokreta"
   },
+  "message.motionPricingNote": {
+    "message": "Наплаћује се по секунди генерисаног видеа; коначан износ зависи од дужине референтног видеа.",
+    "description": "Explains that Motion Control is billed per second"
+  },
   "inspiration.title": {
     "message": "Inspiracija i predlozi",
     "description": "Naslov u Inspiration fioci"
@@ -414,6 +418,10 @@
   "name.mode": {
     "message": "Video režim",
     "description": "Režim koji se koristi za generisanje videa"
+  },
+  "name.perSecond": {
+    "message": "секунда",
+    "description": "Unit suffix for per-second pricing"
   },
   "name.effect": {
     "message": "Video efekat",

--- a/src/i18n/sv/kling.json
+++ b/src/i18n/sv/kling.json
@@ -71,6 +71,10 @@
     "message": "Vänligen ladda upp både personbild och referensvideo.",
     "description": "Meddelande vid saknade indata i Rörelsekontroll"
   },
+  "message.motionPricingNote": {
+    "message": "Debiteras per sekund av den genererade videon; slutbeloppet beror på referensvideons längd.",
+    "description": "Explains that Motion Control is billed per second"
+  },
   "inspiration.title": {
     "message": "Inspiration och förinställningar",
     "description": "Titel för Inspiration-dragning"
@@ -414,6 +418,10 @@
   "name.mode": {
     "message": "Videoläge",
     "description": "Det läge som används för att generera videon"
+  },
+  "name.perSecond": {
+    "message": "sekund",
+    "description": "Unit suffix for per-second pricing"
   },
   "name.effect": {
     "message": "Videoeffekt",

--- a/src/i18n/uk/kling.json
+++ b/src/i18n/uk/kling.json
@@ -71,6 +71,10 @@
     "message": "Завантажте зображення персонажа та відео руху",
     "description": "Motion Control 缺少输入时的提示"
   },
+  "message.motionPricingNote": {
+    "message": "Оплата за секунду згенерованого відео; підсумкова сума залежить від довжини еталонного відео.",
+    "description": "Explains that Motion Control is billed per second"
+  },
   "inspiration.title": {
     "message": "Ідеї та шаблони",
     "description": "Inspiration 抽屉的标题"
@@ -414,6 +418,10 @@
   "name.mode": {
     "message": "Режим відео",
     "description": "Режим, який використовується для генерації відео"
+  },
+  "name.perSecond": {
+    "message": "секунда",
+    "description": "Unit suffix for per-second pricing"
   },
   "name.effect": {
     "message": "Ефект відео",

--- a/src/i18n/zh-CN/kling.json
+++ b/src/i18n/zh-CN/kling.json
@@ -71,6 +71,10 @@
     "message": "请同时上传人物图与动作参考视频",
     "description": "Motion Control 缺少输入时的提示"
   },
+  "message.motionPricingNote": {
+    "message": "按生成视频时长计费，最终金额随参考视频长度浮动",
+    "description": "Motion Control 按秒计费的说明"
+  },
   "inspiration.title": {
     "message": "灵感与预设",
     "description": "Inspiration 抽屉的标题"
@@ -414,6 +418,10 @@
   "name.mode": {
     "message": "视频模式",
     "description": "要生成视频所采用的模式"
+  },
+  "name.perSecond": {
+    "message": "秒",
+    "description": "按秒计费时的单位后缀，如“1.20 积分/秒”"
   },
   "name.effect": {
     "message": "视频效果",

--- a/src/i18n/zh-TW/kling.json
+++ b/src/i18n/zh-TW/kling.json
@@ -71,6 +71,10 @@
     "message": "請同時上傳人物圖與動作參考視頻",
     "description": "Motion Control 缺少輸入時的提示"
   },
+  "message.motionPricingNote": {
+    "message": "依生成影片時長計費，最終金額隨參考影片長度浮動。",
+    "description": "Explains that Motion Control is billed per second"
+  },
   "inspiration.title": {
     "message": "靈感與預設",
     "description": "Inspiration 抽屜的標題"
@@ -414,6 +418,10 @@
   "name.mode": {
     "message": "視頻模式",
     "description": "要生成視頻所采用的模式"
+  },
+  "name.perSecond": {
+    "message": "秒",
+    "description": "Unit suffix for per-second pricing"
   },
   "name.effect": {
     "message": "視頻效果",


### PR DESCRIPTION
## What

Fix the Kling Motion Control pricing shown in Studio so it reflects how the service is actually billed: **per second of the generated video**.

- `MotionPanel.vue`: `consumption` now evaluates the cost rule with `duration: 1`, i.e. the per-second rate (`1.2`/std, `1.6`/pro) instead of a 5-second estimate.
- `Consumption.vue` (shared): two **optional** props `rateUnit` and `note` (empty defaults → byte-identical rendering for all other call sites). Motion now renders `1.20 Credit/second` plus a muted note.
- i18n: `name.perSecond` + `message.motionPricingNote` added to all 18 locales; `check_i18n_coverage.py` passes.

## Why

The Motion Control panel had no duration selector yet displayed a fixed `6.00 Credit`. That number is the cost rule (`1.2 × duration`) evaluated with the rule's **default** `duration = 5`. But Motion Control output length ≈ the reference video length (up to 30 s), so real charges were 15–34 credits — 2.5–5.7× the displayed estimate. A customer budgeted against the `6.00` and was surprised by the actual deduction.

Since the true output duration is unknown before generation, the honest display is the **per-second rate** + a note that the final amount scales with the reference video length, rather than a fixed number that structurally understates the charge.

Actual billing is unchanged (it happens server-side, per second); this only corrects the pre-generation estimate shown to the user.

## Test

- `Consumption.vue` / `MotionPanel.vue` type-check clean; ESLint clean.
- All 18 i18n locale files parse; `check_i18n_coverage.py` → exit 0 (17 locales × 44 namespaces match zh-CN).
- beachball change file included.

## 🤖 对抗评审

Reviewer: independent `general-purpose` subagent (Codex not installed on this host). Verified against the live cost rules and the shared component's other ~15 call sites.

- Confirmed the motion cost rules are linear (`1.2×d` std, `1.6×d` pro, no fixed term), so `duration: 1` yields the exact per-second rate; rule 1 defaults `mode` to `std`.
- Confirmed the optional props keep all other `<consumption>` call sites byte-identical; `note` is text-interpolated (no `v-html`) → no XSS; inline `<template v-if>` in the `<span>` is valid.
- **NIT** — if `character_orientation` were unset no rule matches and the block would show a transient `0.00`; benign because `CharacterOrientationSelector` seeds `image` on mount before paint and `canGenerate` is false meanwhile, and real billing is server-side. Not gating.

`VERDICT: CLEAN`.
