### PR TITLE
fix(mobile-release): unblock Android prod promote + iOS review submit

### DIFF
--- a/.github/workflows/auto-production-mobile.yaml
+++ b/.github/workflows/auto-production-mobile.yaml
@@ -16,7 +16,8 @@ name: Auto Production Mobile (daily)
 # When the gate is clean it dispatches the proven build-ios.yaml /
 # build-android.yaml with production toggles ON:
 #     - iOS      -> TestFlight + auto-submit for App Store review
-#     - Android  -> upload straight to the Production track at 100% rollout
+#     - Android  -> beta upload (dedup-skipped if already there) then promote
+#                   the same versionCode from beta -> Production at the rollout
 #
 # Those build workflows ALSO run their own duplicate-version preflight, so even
 # if the gate is bypassed the same binary is never uploaded twice. The gate
@@ -321,24 +322,18 @@ jobs:
             ROLLOUT='1.0'
           fi
           printf '%s\n' "::notice::Android gate clean ($GATE_REASON) — releasing v$VERSION at rollout=$ROLLOUT."
-          # 100% → upload straight to the Production track (status=completed).
-          # Partial → upload to beta then promote to Production at the requested
-          # fraction; build-android only honors rollout_percent on the promote
-          # path, so a <1.0 fraction MUST go through beta+promote to be staged.
-          if [ "$ROLLOUT" = "1.0" ] || [ "$ROLLOUT" = "1" ]; then
-            gh workflow run build-android.yaml \
-              --ref "${{ github.ref_name }}" \
-              -f track=production \
-              -f promote_to_production=false \
-              -f force=false
-          else
-            gh workflow run build-android.yaml \
-              --ref "${{ github.ref_name }}" \
-              -f track=beta \
-              -f promote_to_production=true \
-              -f rollout_percent="$ROLLOUT" \
-              -f force=false
-          fi
+          # Always beta → promote (even at 100%): build-android's dedup preflight
+          # is track-agnostic, so a direct track=production dispatch skips the
+          # build (the test pipeline already put this versionCode on beta) and
+          # promote never runs → nothing reaches production. The promote job runs
+          # on a skipped build and pushes the existing beta bundle to production
+          # (rollout >= 1.0 commits it as a completed 100% release).
+          gh workflow run build-android.yaml \
+            --ref "${{ github.ref_name }}" \
+            -f track=beta \
+            -f promote_to_production=true \
+            -f rollout_percent="$ROLLOUT" \
+            -f force=false
 
   summary:
     name: Gate summary

--- a/.github/workflows/build-ios.yaml
+++ b/.github/workflows/build-ios.yaml
@@ -622,33 +622,76 @@ jobs:
               print(f'::warning::{msg}')
               sys.exit(0)
 
-          # 1) Look up existing iOS App Store versions matching our versionString.
-          # /v1/apps/{id}/appStoreVersions only allows sort on a small set
-          # (appStoreState, platform, versionString) — not createdDate — so we
-          # filter by versionString directly instead.
+          # 1) Find the single in-progress (editable) iOS App Store version.
+          # Apple allows only ONE editable version at a time, so we must NOT
+          # filter by versionString: a stale editable version left at an older
+          # number (e.g. a previous day's 3.301.2 stuck in PREPARE_FOR_SUBMISSION)
+          # would be missed, we'd try to create today's number, and Apple would
+          # 409 "You cannot create a new version of the App in the current state"
+          # — silently freezing every future submission. Instead we adopt the
+          # existing editable version and rename it to today's versionString.
           r = requests.get(
               f'https://api.appstoreconnect.apple.com/v1/apps/{app_id}/appStoreVersions',
-              params={'filter[platform]': 'IOS', 'filter[versionString]': version_name, 'limit': 50},
+              params={'filter[platform]': 'IOS', 'limit': 50},
               headers=H(), timeout=30,
           )
           if r.status_code != 200:
               die_soft(f'Failed to list App Store versions: {r.status_code} {r.text[:400]}')
           versions = r.json().get('data') or []
 
-          editable_states = {
+          # States we can safely adopt + edit (rename / re-attach a build).
+          adopt_states = {
               'PREPARE_FOR_SUBMISSION', 'DEVELOPER_REJECTED', 'METADATA_REJECTED',
-              'REJECTED', 'INVALID_BINARY', 'WAITING_FOR_REVIEW',
+              'REJECTED', 'INVALID_BINARY',
           }
-          version_id, version_state = None, None
-          for v in versions:
-              attrs = v['attributes']
-              if attrs.get('appStoreState') in editable_states:
-                  version_id = v['id']
-                  version_state = attrs.get('appStoreState')
-                  print(f'Reusing existing App Store version {version_id} (state={version_state}).')
-                  break
+          # States meaning a submission is already pending — must NOT be touched:
+          # renaming/re-attaching an in-review version is rejected by Apple and
+          # would disrupt the pending release. Bail (the gated cron already skips
+          # these; this also protects the ungated manual path).
+          inflight_states = {
+              'WAITING_FOR_REVIEW', 'IN_REVIEW', 'PENDING_DEVELOPER_RELEASE',
+              'PENDING_APPLE_RELEASE', 'PROCESSING_FOR_APP_STORE',
+          }
+          live_states = {
+              'READY_FOR_SALE', 'REPLACED_WITH_NEW_VERSION',
+              'DEVELOPER_REMOVED_FROM_SALE',
+          }
+          # Apple allows only ONE non-live (editable/in-flight) version. Collect
+          # them and pick deterministically (prefer PREPARE_FOR_SUBMISSION, then
+          # highest versionString) so multiple leftovers can't make us adopt the
+          # wrong one.
+          def vkey(vs):
+              try:
+                  return tuple(int(x) for x in (str(vs).split('.') + ['0', '0', '0'])[:3])
+              except Exception:
+                  return (0, 0, 0)
 
-          # 2) If no editable matching version exists, create one.
+          non_live = [v for v in versions
+                      if v['attributes'].get('appStoreState') not in live_states]
+          for v in non_live:
+              st = v['attributes'].get('appStoreState')
+              if st in inflight_states:
+                  die_soft(f"version {v['attributes'].get('versionString')} is {st} "
+                           f"(submission already pending) — not submitting a new build")
+
+          candidates = [v for v in non_live
+                        if v['attributes'].get('appStoreState') in adopt_states]
+          candidates.sort(
+              key=lambda v: (
+                  0 if v['attributes'].get('appStoreState') == 'PREPARE_FOR_SUBMISSION' else 1,
+                  tuple(-x for x in vkey(v['attributes'].get('versionString'))),
+              )
+          )
+          version_id, version_state, version_string = None, None, None
+          if candidates:
+              v = candidates[0]
+              version_id = v['id']
+              version_state = v['attributes'].get('appStoreState')
+              version_string = v['attributes'].get('versionString')
+              print(f'Reusing editable App Store version {version_id} '
+                    f'(v{version_string}, state={version_state}).')
+
+          # 2) No editable version yet → create one at today's versionString.
           if not version_id:
               create_payload = {
                   'data': {
@@ -669,7 +712,20 @@ jobs:
               version_id = c.json()['data']['id']
               print(f'::notice::Created App Store version {version_id} (v{version_name}).')
           else:
-              # Attach our build to the existing editable version.
+              # Adopt the existing editable version: bump its number to today's
+              # release if it lags, then attach our build.
+              if version_string != version_name:
+                  u = requests.patch(
+                      f'https://api.appstoreconnect.apple.com/v1/appStoreVersions/{version_id}',
+                      json={'data': {'type': 'appStoreVersions', 'id': version_id,
+                                     'attributes': {'versionString': version_name}}},
+                      headers=H(), timeout=30,
+                  )
+                  if u.status_code >= 400:
+                      die_soft(f'Failed to rename version {version_string}->{version_name}: '
+                               f'{u.status_code} {u.text[:400]}')
+                  print(f'::notice::Renamed App Store version {version_id} '
+                        f'{version_string} -> {version_name}.')
               a = requests.patch(
                   f'https://api.appstoreconnect.apple.com/v1/appStoreVersions/{version_id}/relationships/build',
                   json={'data': {'type': 'builds', 'id': build_id}},
@@ -746,5 +802,35 @@ jobs:
           )
           if fin.status_code >= 400:
               die_soft(f'Failed to submit for review: {fin.status_code} {fin.text[:400]}')
-          print(f'::notice::Submitted review {submission_id} for App Store review.')
+
+          # 6) Verify the submission actually left READY_FOR_REVIEW. The submit
+          # PATCH above (2xx) is the authority; this is a best-effort confirm.
+          # State transition is eventually consistent, so poll a few times and
+          # treat a transient/unknown read as neutral — only warn if it is still
+          # DEFINITIVELY READY_FOR_REVIEW (missing metadata/screenshots froze
+          # past releases silently).
+          submitted_states = {
+              'WAITING_FOR_REVIEW', 'IN_REVIEW', 'UNRESOLVED_ISSUES', 'COMPLETING',
+          }
+          final_state = None
+          for attempt in range(3):
+              chk = requests.get(
+                  f'https://api.appstoreconnect.apple.com/v1/reviewSubmissions/{submission_id}',
+                  headers=H(), timeout=30,
+              )
+              if chk.status_code == 200:
+                  final_state = (chk.json().get('data', {}).get('attributes', {}) or {}).get('state')
+                  if final_state in submitted_states:
+                      break
+              if attempt < 2:
+                  time.sleep(5)
+          if final_state == 'READY_FOR_REVIEW':
+              die_soft(f'Review submission {submission_id} did NOT enter review '
+                       f'(still READY_FOR_REVIEW) — likely missing metadata/screenshots; '
+                       f'needs manual fixup in App Store Connect.')
+          elif final_state in submitted_states:
+              print(f'::notice::Submitted review {submission_id} — state now {final_state}.')
+          else:
+              print(f'::notice::Submitted review {submission_id} '
+                    f'(post-submit state unconfirmed: {final_state}).')
           PY

--- a/change/@acedatacloud-nexior-fea2417c-afdf-4842-a0e4-4985a18b4984.json
+++ b/change/@acedatacloud-nexior-fea2417c-afdf-4842-a0e4-4985a18b4984.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(mobile-release): unblock Android prod promote (beta->production) + iOS review submit (adopt single editable version, self-heal, verify)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
## 问题：iOS 与 Android 两端商店的自动发布都被「已存在状态」卡死

每日 `Auto Production Mobile` 定时任务连续 8+ 天报「成功」，但两端商店的线上版本纹丝不动（Android production versionCode 冻结在 `58902`，iOS live 冻结在 `58600` / v3.286.0）。根因是**两个独立但同类**的缺陷：自动化处理不了商店里「同一制品/版本已存在」的状态，且失败被静默吞掉。

### Android — 本番 dispatch 被去重预检整体跳过

`auto-production-mobile.yaml` 的每日 job 以 `track=production` 直传方式 dispatch `build-android.yaml`。但：

1. 测试流水线（`auto-release-mobile.yaml`）在版本 bump 时**已经把这个 versionCode 传到 beta 轨道**。
2. `build-android.yaml` 的去重预检列出的是**所有轨道**已上传的 bundle/apk（不分轨道）→ 判定重复 → `should-build=false` → build job skipped。
3. 因为 dispatch 用的是 `track=production`，`promote` job 的条件 `track != 'production'` 也为假 → promote 也 skipped。
4. 结果：本番轨道永远收不到新 release。

**修复**：本番 dispatch 一律改成 `track=beta` + `promote_to_production=true`。`promote` job 本就设计成「build 被跳过也能跑」，于是它把已在 beta 的同一 bundle 提升 beta→production（rollout≥1.0 以 completed 100% 提交）。制品只上传一次，本番只走 promote —— 符合 "build once, promote many"。

### iOS — submit 步骤永远 409 且被静默吞掉

`build-ios.yaml` 的 submit 步骤 step 1 只按 `versionString == 今天的版本号` 过滤 appStoreVersions。但 App Store **只允许存在一个可编辑版本**。线上实测：一个旧号版本 `3.301.2` 卡在 `PREPARE_FOR_SUBMISSION`（还挂着一条 `submitted=None` 的 `READY_FOR_REVIEW` 提交），而过滤只找今天的 `3.319.0` → 找不到 → 走 create → Apple 返回 `409 "You cannot create a new version of the App in the current state"` → `die_soft` 吞掉 → 从未真正提审。

**修复**：
- 列出全部 iOS 版本（不再按 versionString 过滤），采用那个**唯一的可编辑版本**（与版本号无关），号落后就 PATCH 改成今天的号，再挂 build。
- 若唯一的非线上版本处于 `WAITING_FOR_REVIEW / IN_REVIEW / PENDING_* / PROCESSING` 等**在审状态**，则 bail（不 stack 新提交，也保护未受 gate 保护的手动路径）。
- 多个可编辑版本时**确定性选择**（优先 `PREPARE_FOR_SUBMISSION`，再取最高版本号）。
- 提交后**重试校验**提交状态，仅当确实仍停在 `READY_FOR_REVIEW` 才 loud 告警（元数据/截图缺失需人工），未知/瞬态则中性提示。

> ⚠️ **需一次性人工清理**：当前 App Store 里那个卡住的 `3.301.2`（PREPARE_FOR_SUBMISSION）+ 悬挂的 `READY_FOR_REVIEW` 提交。若下一次定时 run 的自动改名/提交仍被这个陈旧状态拒绝，请在 App Store Connect 手动删除该版本与提交，之后流水线即可自愈。

### 影响面 / 不改动

- 测试轨道（beta / TestFlight）路径不变。
- 手动 `release-mobile.yaml` 路径不变（iOS 侧新增的 in-flight bail 反而让手动路径更安全）。
- 未触碰版本号→versionCode 公式、签名、构建。

### 后续（本 PR 不含，刻意分阶段以降风险）

- **Phase 2 DRY**：把 Play API（SA-JWT→edit→bundles→track）三处复制抽成共享脚本；版本→versionCode 公式统一。
- **Phase 3**：`gh workflow run` fan-out 改成 reusable `workflow_call`，让真实 pass/fail 传播（本 bug 藏 8 天的根因：dispatch「成功」只代表发射成功）；合并三个 orchestrator。

## 🤖 对抗评审

评审器：codex 令牌过期 → 回退 Claude `general-purpose` 子代理。两轮收敛。

**Round 1（4 个 RISK，全部修复）**
- `RISK`：放宽过滤后可能采到 `WAITING_FOR_REVIEW`（在审）版本并改名/重挂 → 被 Apple 拒、静默冻结。**修**：`WAITING_FOR_REVIEW`+`IN_REVIEW`+`PENDING_*`+`PROCESSING` 归入 `inflight_states`，命中即 bail。
- `RISK`：多个可编辑版本时选择顺序不确定 → 可能采错。**修**：确定性排序（优先 `PREPARE_FOR_SUBMISSION`，再最高版本号）。
- `RISK`：改名 PATCH 在被锁版本上会失败 → 静默 no-op。**接受为 best-effort**：失败 die_soft 出告警供人工处理（PR 已标注一次性清理）。
- `RISK`：提交后立即读状态存在最终一致性 → 误报。**修**：3 次重试、仅确实 `READY_FOR_REVIEW` 才告警、未知态中性提示。

**Round 2 — VERDICT: CLEAN**（确认 4 条均已解决，无新缺陷；残余边角均降级为 die_soft 告警，优于原先静默冻结）。
