### PR TITLE
feat(maestro): estimate/start API layer + remove old static cost display

### DIFF
--- a/change/acedatacloud-nexior-maestro-estimate-ux.json
+++ b/change/acedatacloud-nexior-maestro-estimate-ux.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(maestro): estimate/start API layer + remove old static cost display",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/maestro/ConfigPanel.vue
+++ b/src/components/maestro/ConfigPanel.vue
@@ -179,7 +179,6 @@
     </div>
 
     <div class="flex flex-col items-center justify-center px-5 pb-5">
-      <consumption :value="consumption" :service="service" />
       <el-button type="primary" class="btn w-full" round :disabled="!canGenerate" @click="onGenerate">
         <font-awesome-icon icon="fa-solid fa-magic" class="mr-2" />
         {{ $t('maestro.button.generate') }}
@@ -192,11 +191,9 @@
 import { defineComponent, markRaw } from 'vue';
 import { ElButton, ElSelect, ElOption, ElInputNumber, ElAlert } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import Consumption from '../common/Consumption.vue';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import PromptTextarea from '@/components/common/PromptTextarea.vue';
 import FileUrlsInput from './config/FileUrlsInput.vue';
-import { getConsumption } from '@/utils';
 import {
   MAESTRO_ALLOWED_LANGS,
   MAESTRO_ALLOWED_ASPECTS,
@@ -233,7 +230,6 @@ export default defineComponent({
     ElOption,
     ElInputNumber,
     ElAlert,
-    Consumption,
     InfoIcon,
     PromptTextarea,
     FileUrlsInput,
@@ -266,9 +262,6 @@ export default defineComponent({
         value,
         ...(RATIO_PREVIEW[value] ?? { width: 20, height: 20 })
       }));
-    },
-    consumption() {
-      return getConsumption(this.config, this.service?.cost);
     },
     isRemixing(): boolean {
       const action = this.config?.action;

--- a/src/models/maestro.ts
+++ b/src/models/maestro.ts
@@ -12,6 +12,7 @@ export interface IMaestroConfig {
   scenario?: string; // 'auto' | 'narrated' | 'drama' | 'avatar' | 'motion' | 'captions'
   style?: string; // freeform visual hint (e.g. 'auto' | 'cinematic' | 'minimal' | 'neon' | 'corporate'); orthogonal to scenario
   voice?: string; // narration timbre: 'auto' (director picks) | a preset key (constants) | a 32-hex Fish reference_id
+  startable?: boolean; // two-phase: estimate first, park, and only generate on Start
   callback_url?: string;
 }
 
@@ -38,11 +39,47 @@ export interface IMaestroProject {
   outputs?: string[];
 }
 
+// Bottom-up cost estimate (from POST /maestro/estimates). USD is at the volume credit rate;
+// `credits` is the rate-independent figure. `upper_bound` = the HIGH band (取上限).
+export interface IMaestroEstimatePrice {
+  low?: number;
+  expected?: number;
+  high?: number;
+  upper_bound?: number;
+  currency?: string;
+  credits?: { low?: number; expected?: number; high?: number };
+  credit_to_usd?: number;
+  basis?: string; // 'live' | 'partial'
+}
+
+export interface IMaestroEstimateLine {
+  item?: string;
+  kind?: string; // 'agent' | 'api'
+  unit_credits?: number;
+  count?: number;
+  credits?: number;
+  usd?: number;
+  live_price?: boolean;
+  turns?: number | null;
+}
+
+export interface IMaestroEstimate {
+  schema?: string;
+  currency?: string;
+  price?: IMaestroEstimatePrice;
+  breakdown?: IMaestroEstimateLine[];
+  flow?: string;
+  confidence?: string; // 'high' | 'medium' | 'low'
+  assumptions?: string[];
+  risks?: string[];
+}
+
 export interface IMaestroData {
   variants?: IMaestroVariant[];
   project?: IMaestroProject;
   progress?: IMaestroProgress[];
   stage?: string;
+  estimate?: IMaestroEstimate;
 }
 
 export interface IMaestroGenerateResponse {
@@ -63,7 +100,9 @@ export interface IMaestroAgentStats {
 
 export interface IMaestroTask {
   id: string;
-  status?: string;
+  status?: string; // ... | 'estimated' (parked, awaiting Start) | 'expired'
+  phase?: string; // 'estimate' | 'generate' (two-phase tasks)
+  startable?: boolean;
   created_at?: number;
   elapsed?: number;
   request?: IMaestroGenerateRequest;
@@ -72,6 +111,12 @@ export interface IMaestroTask {
 }
 
 export type IMaestroTaskResponse = IMaestroTask;
+
+export interface IMaestroEstimateResponse {
+  success: boolean;
+  estimate_id: string;
+  trace_id?: string;
+}
 
 export interface IMaestroTasksResponse {
   count: number;

--- a/src/operators/maestro.ts
+++ b/src/operators/maestro.ts
@@ -1,4 +1,8 @@
+import axios, { AxiosResponse } from 'axios';
+import { BASE_URL_API } from '@/constants';
 import {
+  IMaestroConfig,
+  IMaestroEstimateResponse,
   IMaestroGenerateRequest,
   IMaestroGenerateResponse,
   IMaestroTaskResponse,
@@ -15,6 +19,43 @@ class MaestroOperator extends BaseTaskOperator<
 > {
   constructor() {
     super({ tasksPath: '/maestro/tasks', generatePath: '/maestro/videos' });
+  }
+
+  /**
+   * Two-phase estimate: create a cost estimate that PARKS awaiting Start (startable=true).
+   * Free (never billed) and routed through /maestro/estimates so a low-balance user can still
+   * get a quote. Returns { estimate_id } — the task appears in the task list at status
+   * `estimated` with the cost, then `start()` launches the real generation.
+   */
+  async estimate(config: IMaestroConfig, options: { token: string }): Promise<AxiosResponse<IMaestroEstimateResponse>> {
+    return axios.post(
+      '/maestro/estimates',
+      { ...config, startable: true },
+      {
+        baseURL: BASE_URL_API,
+        headers: {
+          accept: 'application/json',
+          'content-type': 'application/json',
+          authorization: `Bearer ${options.token}`
+        }
+      }
+    );
+  }
+
+  /** Launch a parked `estimated` task's generation phase (the "Start" button). */
+  async start(id: string, options: { token: string }): Promise<AxiosResponse<IMaestroTaskResponse>> {
+    return axios.post(
+      this.tasksPath,
+      { action: 'start', id },
+      {
+        baseURL: BASE_URL_API,
+        headers: {
+          accept: 'application/json',
+          'content-type': 'application/json',
+          authorization: `Bearer ${options.token}`
+        }
+      }
+    );
   }
 }
 


### PR DESCRIPTION
M2（部分）of [Index #206](https://github.com/AceDataCloud/Index/pull/206).

## 改动
- 加 `maestroOperator.estimate()`（POST /maestro/estimates `startable:true`）+ `start()`（POST /maestro/tasks `action=start`）+ 两段式/预估类型（`phase` / `startable` / `response.data.estimate` 价格与 breakdown）。
- **删掉 ConfigPanel 旧的时长公式费用显示**（`getConsumption` + `<consumption>`）—— 成本改由预估流程给出（用户要求：老费用 rule 不要了）。

## 下一 slice（未含）
交互式"预估弹框 + 任务列表启动按钮"需先满足：
1. maestro 两段式 [#1398](https://github.com/AceDataCloud/PlatformService/pull/1398) 部署；
2. 网关计费封顶 F3/F4 落地（否则报价 $9.92 上限 vs 时长规则实扣 $10.6，会误导）。

所以本 PR 只落"API 层 + 删旧显示"，UI 弹框/启动按钮随 F4 一起上。
