### PR TITLE
feat(kling): add model version selector (Kling 2.6/3.0) to Motion Control

### DIFF
--- a/change/@acedatacloud-nexior-2b1afdeb-f0c0-4ad9-b316-fcd3cf0b105e.json
+++ b/change/@acedatacloud-nexior-2b1afdeb-f0c0-4ad9-b316-fcd3cf0b105e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(kling): add model version selector (Kling 2.6/3.0) to Motion Control",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/kling/MotionPanel.vue
+++ b/src/components/kling/MotionPanel.vue
@@ -5,6 +5,7 @@
       <motion-video class="mb-3" />
       <motion-prompt-input class="mb-4" />
       <character-orientation-selector class="mb-4" />
+      <motion-model-selector class="mb-4" />
       <motion-mode-selector class="mb-4" />
       <keep-original-sound-selector class="mb-4" />
     </div>
@@ -32,6 +33,7 @@ import MotionImage from './motion/MotionImage.vue';
 import MotionVideo from './motion/MotionVideo.vue';
 import MotionPromptInput from './motion/MotionPromptInput.vue';
 import CharacterOrientationSelector from './motion/CharacterOrientationSelector.vue';
+import MotionModelSelector from './motion/MotionModelSelector.vue';
 import MotionModeSelector from './motion/MotionModeSelector.vue';
 import KeepOriginalSoundSelector from './motion/KeepOriginalSoundSelector.vue';
 import { getConsumption } from '@/utils';
@@ -46,6 +48,7 @@ export default defineComponent({
     MotionVideo,
     MotionPromptInput,
     CharacterOrientationSelector,
+    MotionModelSelector,
     MotionModeSelector,
     KeepOriginalSoundSelector
   },

--- a/src/components/kling/motion/MotionModelSelector.vue
+++ b/src/components/kling/motion/MotionModelSelector.vue
@@ -1,0 +1,77 @@
+<template>
+  <div class="field">
+    <div class="header">
+      <h2 class="title font-bold">{{ $t('kling.name.motionModel') }}</h2>
+      <info-icon :content="$t('kling.description.motionModel')" />
+    </div>
+    <el-select v-model="value" class="value" :placeholder="$t('kling.placeholder.select')">
+      <el-option v-for="item in options" :key="item.value" :label="item.label" :value="item.value" />
+    </el-select>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElSelect, ElOption } from 'element-plus';
+import InfoIcon from '@/components/common/InfoIcon.vue';
+
+type IKlingMotionModel = 'kling-v2-6' | 'kling-v3';
+const DEFAULT: IKlingMotionModel = 'kling-v2-6';
+
+export default defineComponent({
+  name: 'MotionModelSelector',
+  components: {
+    ElSelect,
+    ElOption,
+    InfoIcon
+  },
+  computed: {
+    options() {
+      return [
+        { value: 'kling-v2-6', label: 'Kling 2.6' },
+        { value: 'kling-v3', label: 'Kling 3.0' }
+      ];
+    },
+    value: {
+      get(): IKlingMotionModel {
+        return this.$store.state.kling?.motionConfig?.model_name || DEFAULT;
+      },
+      set(val: IKlingMotionModel) {
+        this.$store.commit('kling/setMotionConfig', {
+          ...this.$store.state.kling?.motionConfig,
+          model_name: val
+        });
+      }
+    }
+  },
+  mounted() {
+    if (!this.$store.state.kling?.motionConfig?.model_name) {
+      this.value = DEFAULT;
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.field {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+
+  .header {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    width: 50%;
+
+    .title {
+      font-size: 14px;
+      margin: 0;
+    }
+  }
+  .value {
+    width: 120px;
+  }
+}
+</style>

--- a/src/i18n/ar/kling.json
+++ b/src/i18n/ar/kling.json
@@ -55,6 +55,10 @@
     "message": "std أولوية الأداء، pro أولوية الجودة.",
     "description": "motion mode 说明"
   },
+  "description.motionModel": {
+    "message": "يتميز Kling 3.0 بجودة أعلى لكن بسعر أعلى لكل ثانية؛ أما Kling 2.6 فهو أكثر توفيرًا.",
+    "description": "motion model version description"
+  },
   "description.keepOriginalSound": {
     "message": "عند التفعيل، يحتفظ بالصوت الأصلي للفيديو المرجعي؛ عند الإيقاف، لا يحتوي الفيديو الناتج على الصوت الأصلي.",
     "description": "keep_original_sound 说明"
@@ -418,6 +422,10 @@
   "name.mode": {
     "message": "وضع الفيديو",
     "description": "الوضع المستخدم لإنشاء الفيديو"
+  },
+  "name.motionModel": {
+    "message": "إصدار النموذج",
+    "description": "The Kling model version used for motion control"
   },
   "name.perSecond": {
     "message": "ثانية",

--- a/src/i18n/de/kling.json
+++ b/src/i18n/de/kling.json
@@ -55,6 +55,10 @@
     "message": "std für Leistung, pro für Bildqualität",
     "description": "Beschreibung für motion mode"
   },
+  "description.motionModel": {
+    "message": "Kling 3.0 bietet höhere Qualität, aber einen höheren Preis pro Sekunde; Kling 2.6 ist preisgünstiger.",
+    "description": "motion model version description"
+  },
   "description.keepOriginalSound": {
     "message": "Aktiviert, um den Originalton des Referenzvideos beizubehalten; deaktiviert, um das Ausgangsvideo ohne Originalton zu erstellen.",
     "description": "Beschreibung für keep_original_sound"
@@ -418,6 +422,10 @@
   "name.mode": {
     "message": "Videomodus",
     "description": "Der Modus, der zur Erstellung des Videos verwendet wird"
+  },
+  "name.motionModel": {
+    "message": "Modellversion",
+    "description": "The Kling model version used for motion control"
   },
   "name.perSecond": {
     "message": "Sekunde",

--- a/src/i18n/el/kling.json
+++ b/src/i18n/el/kling.json
@@ -55,6 +55,10 @@
     "message": "std προτεραιότητα απόδοσης, pro προτεραιότητα ποιότητας.",
     "description": "motion mode 说明"
   },
+  "description.motionModel": {
+    "message": "Το Kling 3.0 έχει υψηλότερη ποιότητα αλλά υψηλότερη τιμή ανά δευτερόλεπτο· το Kling 2.6 είναι πιο οικονομικό.",
+    "description": "motion model version description"
+  },
   "description.keepOriginalSound": {
     "message": "Ενεργοποιώντας, διατηρείτε τον πρωτότυπο ήχο του βίντεο αναφοράς. Απενεργοποιώντας, το παραγόμενο βίντεο δεν περιλαμβάνει τον πρωτότυπο ήχο.",
     "description": "keep_original_sound 说明"
@@ -418,6 +422,10 @@
   "name.mode": {
     "message": "Λειτουργία βίντεο",
     "description": "Η λειτουργία που θα χρησιμοποιηθεί για την παραγωγή του βίντεο"
+  },
+  "name.motionModel": {
+    "message": "Έκδοση μοντέλου",
+    "description": "The Kling model version used for motion control"
   },
   "name.perSecond": {
     "message": "δευτερόλεπτο",

--- a/src/i18n/en/kling.json
+++ b/src/i18n/en/kling.json
@@ -55,6 +55,10 @@
     "message": "std prioritizes performance, pro prioritizes quality.",
     "description": "motion mode description"
   },
+  "description.motionModel": {
+    "message": "Kling 3.0 has higher quality but a higher per-second price; Kling 2.6 is more cost-effective.",
+    "description": "motion model version description"
+  },
   "description.keepOriginalSound": {
     "message": "Enabling keeps the original audio from the reference video; disabling outputs a video without the original audio.",
     "description": "keep_original_sound description"
@@ -418,6 +422,10 @@
   "name.mode": {
     "message": "Video Mode",
     "description": "The mode used to generate the video"
+  },
+  "name.motionModel": {
+    "message": "Model Version",
+    "description": "The Kling model version used for motion control"
   },
   "name.perSecond": {
     "message": "second",

--- a/src/i18n/es/kling.json
+++ b/src/i18n/es/kling.json
@@ -55,6 +55,10 @@
     "message": "std prioriza rendimiento, pro prioriza calidad de imagen",
     "description": "Descripción de motion mode"
   },
+  "description.motionModel": {
+    "message": "Kling 3.0 ofrece mayor calidad pero un precio por segundo más alto; Kling 2.6 es más rentable.",
+    "description": "motion model version description"
+  },
   "description.keepOriginalSound": {
     "message": "Si está activado, se conservará el audio original del video de referencia; si está desactivado, el video de salida no incluirá audio original.",
     "description": "Descripción de keep_original_sound"
@@ -418,6 +422,10 @@
   "name.mode": {
     "message": "Modo de video",
     "description": "El modo utilizado para generar el video"
+  },
+  "name.motionModel": {
+    "message": "Versión del modelo",
+    "description": "The Kling model version used for motion control"
   },
   "name.perSecond": {
     "message": "segundo",

--- a/src/i18n/fi/kling.json
+++ b/src/i18n/fi/kling.json
@@ -55,6 +55,10 @@
     "message": "std suorituskyky etusijalla, pro kuvanlaatu etusijalla",
     "description": "motion mode -kuvaus"
   },
+  "description.motionModel": {
+    "message": "Kling 3.0 on laadukkaampi mutta kalliimpi sekunnilta; Kling 2.6 on edullisempi.",
+    "description": "motion model version description"
+  },
   "description.keepOriginalSound": {
     "message": "Kun tämä on päällä, alkuperäinen ääni säilytetään viitevideosta; kun se on pois päältä, tuotetussa videossa ei ole alkuperäistä ääntä.",
     "description": "keep_original_sound -kuvaus"
@@ -418,6 +422,10 @@
   "name.mode": {
     "message": "Videotila",
     "description": "Videon luomiseen käytettävä tila"
+  },
+  "name.motionModel": {
+    "message": "Mallin versio",
+    "description": "The Kling model version used for motion control"
   },
   "name.perSecond": {
     "message": "sekunti",

--- a/src/i18n/fr/kling.json
+++ b/src/i18n/fr/kling.json
@@ -55,6 +55,10 @@
     "message": "std pour la performance, pro pour la qualité d'image.",
     "description": "motion mode 说明"
   },
+  "description.motionModel": {
+    "message": "Kling 3.0 offre une meilleure qualité mais un prix à la seconde plus élevé ; Kling 2.6 est plus économique.",
+    "description": "motion model version description"
+  },
   "description.keepOriginalSound": {
     "message": "Si activé, conserve l'audio original de la vidéo de référence ; si désactivé, la vidéo de sortie ne contient pas l'audio original.",
     "description": "keep_original_sound 说明"
@@ -418,6 +422,10 @@
   "name.mode": {
     "message": "Mode vidéo",
     "description": "Le mode utilisé pour générer la vidéo"
+  },
+  "name.motionModel": {
+    "message": "Version du modèle",
+    "description": "The Kling model version used for motion control"
   },
   "name.perSecond": {
     "message": "seconde",

--- a/src/i18n/it/kling.json
+++ b/src/i18n/it/kling.json
@@ -55,6 +55,10 @@
     "message": "std per prestazioni, pro per qualità",
     "description": "Descrizione della modalità di movimento"
   },
+  "description.motionModel": {
+    "message": "Kling 3.0 offre una qualità superiore ma un prezzo al secondo più alto; Kling 2.6 è più conveniente.",
+    "description": "motion model version description"
+  },
   "description.keepOriginalSound": {
     "message": "Se attivato, mantiene l'audio originale del video di riferimento; se disattivato, il video in uscita non conterrà l'audio originale.",
     "description": "Descrizione per mantenere l'audio originale"
@@ -418,6 +422,10 @@
   "name.mode": {
     "message": "Modalità video",
     "description": "La modalità utilizzata per generare il video"
+  },
+  "name.motionModel": {
+    "message": "Versione del modello",
+    "description": "The Kling model version used for motion control"
   },
   "name.perSecond": {
     "message": "secondo",

--- a/src/i18n/ja/kling.json
+++ b/src/i18n/ja/kling.json
@@ -55,6 +55,10 @@
     "message": "stdは性能優先、proは画質優先",
     "description": "motion mode 説明"
   },
+  "description.motionModel": {
+    "message": "Kling 3.0 は高画質ですが秒単価も高く、Kling 2.6 はコストパフォーマンスに優れます。",
+    "description": "motion model version description"
+  },
   "description.keepOriginalSound": {
     "message": "オンにすると参照動画の元音声を保持します。オフにすると出力動画には元の音声が含まれません。",
     "description": "keep_original_sound 説明"
@@ -418,6 +422,10 @@
   "name.mode": {
     "message": "ビデオモード",
     "description": "生成するビデオに使用されるモード"
+  },
+  "name.motionModel": {
+    "message": "モデルバージョン",
+    "description": "The Kling model version used for motion control"
   },
   "name.perSecond": {
     "message": "秒",

--- a/src/i18n/ko/kling.json
+++ b/src/i18n/ko/kling.json
@@ -55,6 +55,10 @@
     "message": "std 성능 우선, pro 화질 우선",
     "description": "motion mode 说明"
   },
+  "description.motionModel": {
+    "message": "Kling 3.0은 화질이 더 높지만 초당 요금도 높고, Kling 2.6은 가성비가 좋습니다.",
+    "description": "motion model version description"
+  },
   "description.keepOriginalSound": {
     "message": "켜면 참조 비디오의 원음이 유지됩니다; 끄면 출력 비디오에 원본 오디오가 포함되지 않습니다.",
     "description": "keep_original_sound 说明"
@@ -418,6 +422,10 @@
   "name.mode": {
     "message": "비디오 모드",
     "description": "비디오를 생성하는 데 사용되는 모드"
+  },
+  "name.motionModel": {
+    "message": "모델 버전",
+    "description": "The Kling model version used for motion control"
   },
   "name.perSecond": {
     "message": "초",

--- a/src/i18n/pl/kling.json
+++ b/src/i18n/pl/kling.json
@@ -55,6 +55,10 @@
     "message": "std priorytet wydajności, pro priorytet jakości obrazu",
     "description": "motion mode 说明"
   },
+  "description.motionModel": {
+    "message": "Kling 3.0 oferuje wyższą jakość, ale wyższą cenę za sekundę; Kling 2.6 jest bardziej opłacalny.",
+    "description": "motion model version description"
+  },
   "description.keepOriginalSound": {
     "message": "Włączając, zachowujesz oryginalny dźwięk z wideo referencyjnego; wyłączając, wideo wyjściowe nie zawiera oryginalnego dźwięku.",
     "description": "keep_original_sound 说明"
@@ -418,6 +422,10 @@
   "name.mode": {
     "message": "Tryb wideo",
     "description": "Tryb używany do generowania wideo"
+  },
+  "name.motionModel": {
+    "message": "Wersja modelu",
+    "description": "The Kling model version used for motion control"
   },
   "name.perSecond": {
     "message": "sekunda",

--- a/src/i18n/pt/kling.json
+++ b/src/i18n/pt/kling.json
@@ -55,6 +55,10 @@
     "message": "std prioriza desempenho, pro prioriza qualidade de imagem.",
     "description": "motion mode 说明"
   },
+  "description.motionModel": {
+    "message": "O Kling 3.0 tem qualidade superior, mas preço por segundo mais alto; o Kling 2.6 é mais econômico.",
+    "description": "motion model version description"
+  },
   "description.keepOriginalSound": {
     "message": "Se ativado, mantém o áudio original do vídeo de referência; se desativado, o vídeo gerado não incluirá áudio original.",
     "description": "keep_original_sound 说明"
@@ -418,6 +422,10 @@
   "name.mode": {
     "message": "Modo de vídeo",
     "description": "Modo a ser utilizado para gerar o vídeo"
+  },
+  "name.motionModel": {
+    "message": "Versão do modelo",
+    "description": "The Kling model version used for motion control"
   },
   "name.perSecond": {
     "message": "segundo",

--- a/src/i18n/ru/kling.json
+++ b/src/i18n/ru/kling.json
@@ -55,6 +55,10 @@
     "message": "std - приоритет производительности, pro - приоритет качества изображения.",
     "description": "motion mode 说明"
   },
+  "description.motionModel": {
+    "message": "Kling 3.0 обеспечивает более высокое качество, но и более высокую цену за секунду; Kling 2.6 экономичнее.",
+    "description": "motion model version description"
+  },
   "description.keepOriginalSound": {
     "message": "При включении сохраняется оригинальный звук из видео; при отключении выходное видео не содержит оригинального звука.",
     "description": "keep_original_sound 说明"
@@ -418,6 +422,10 @@
   "name.mode": {
     "message": "Режим видео",
     "description": "Режим, используемый для генерации видео"
+  },
+  "name.motionModel": {
+    "message": "Версия модели",
+    "description": "The Kling model version used for motion control"
   },
   "name.perSecond": {
     "message": "секунда",

--- a/src/i18n/sr/kling.json
+++ b/src/i18n/sr/kling.json
@@ -55,6 +55,10 @@
     "message": "std prioritet na performansama, pro prioritet na kvalitetu slike",
     "description": "Objašnjenje za motion mode"
   },
+  "description.motionModel": {
+    "message": "Kling 3.0 има виши квалитет али вишу цену по секунди; Kling 2.6 је исплативији.",
+    "description": "motion model version description"
+  },
   "description.keepOriginalSound": {
     "message": "Ako je uključeno, zadržava originalni zvuk referentnog videa; ako je isključeno, izlazni video neće sadržati originalni zvuk",
     "description": "Objašnjenje za keep_original_sound"
@@ -418,6 +422,10 @@
   "name.mode": {
     "message": "Video režim",
     "description": "Režim koji se koristi za generisanje videa"
+  },
+  "name.motionModel": {
+    "message": "Верзија модела",
+    "description": "The Kling model version used for motion control"
   },
   "name.perSecond": {
     "message": "секунда",

--- a/src/i18n/sv/kling.json
+++ b/src/i18n/sv/kling.json
@@ -55,6 +55,10 @@
     "message": "std för prestanda, pro för bildkvalitet.",
     "description": "motion mode beskrivning"
   },
+  "description.motionModel": {
+    "message": "Kling 3.0 har högre kvalitet men högre pris per sekund; Kling 2.6 är mer kostnadseffektiv.",
+    "description": "motion model version description"
+  },
   "description.keepOriginalSound": {
     "message": "Aktivera för att behålla ljudet från referensvideon; inaktivera för att inte inkludera originalljud i den genererade videon.",
     "description": "keep_original_sound beskrivning"
@@ -418,6 +422,10 @@
   "name.mode": {
     "message": "Videoläge",
     "description": "Det läge som används för att generera videon"
+  },
+  "name.motionModel": {
+    "message": "Modellversion",
+    "description": "The Kling model version used for motion control"
   },
   "name.perSecond": {
     "message": "sekund",

--- a/src/i18n/uk/kling.json
+++ b/src/i18n/uk/kling.json
@@ -55,6 +55,10 @@
     "message": "std — пріоритет продуктивності, pro — пріоритет якості",
     "description": "motion mode 说明"
   },
+  "description.motionModel": {
+    "message": "Kling 3.0 забезпечує вищу якість, але вищу ціну за секунду; Kling 2.6 економніший.",
+    "description": "motion model version description"
+  },
   "description.keepOriginalSound": {
     "message": "Увімкнено — зберегти оригінальний звук відео; вимкнено — без звуку",
     "description": "keep_original_sound 说明"
@@ -418,6 +422,10 @@
   "name.mode": {
     "message": "Режим відео",
     "description": "Режим, який використовується для генерації відео"
+  },
+  "name.motionModel": {
+    "message": "Версія моделі",
+    "description": "The Kling model version used for motion control"
   },
   "name.perSecond": {
     "message": "секунда",

--- a/src/i18n/zh-CN/kling.json
+++ b/src/i18n/zh-CN/kling.json
@@ -55,6 +55,10 @@
     "message": "std 性能优先，pro 画质优先",
     "description": "motion mode 说明"
   },
+  "description.motionModel": {
+    "message": "Kling 3.0 画质更高，但每秒计费也更高；Kling 2.6 性价比更高。",
+    "description": "motion 模型版本说明"
+  },
   "description.keepOriginalSound": {
     "message": "开启后保留参考视频的原声；关闭后输出视频不包含原始音频",
     "description": "keep_original_sound 说明"
@@ -418,6 +422,10 @@
   "name.mode": {
     "message": "视频模式",
     "description": "要生成视频所采用的模式"
+  },
+  "name.motionModel": {
+    "message": "模型版本",
+    "description": "动作控制使用的 Kling 模型版本"
   },
   "name.perSecond": {
     "message": "秒",

--- a/src/i18n/zh-TW/kling.json
+++ b/src/i18n/zh-TW/kling.json
@@ -55,6 +55,10 @@
     "message": "std 性能優先，pro 畫質優先",
     "description": "motion mode 說明"
   },
+  "description.motionModel": {
+    "message": "Kling 3.0 畫質更高，但每秒計費也更高；Kling 2.6 性價比更高。",
+    "description": "motion model version description"
+  },
   "description.keepOriginalSound": {
     "message": "開啟後保留參考視頻的原聲；關閉後輸出視頻不包含原始音頻",
     "description": "keep_original_sound 說明"
@@ -418,6 +422,10 @@
   "name.mode": {
     "message": "視頻模式",
     "description": "要生成視頻所采用的模式"
+  },
+  "name.motionModel": {
+    "message": "模型版本",
+    "description": "The Kling model version used for motion control"
   },
   "name.perSecond": {
     "message": "秒",

--- a/src/models/kling.ts
+++ b/src/models/kling.ts
@@ -30,6 +30,7 @@ export interface IKlingMotionConfig {
   prompt?: string;
   image_url?: string;
   video_url?: string;
+  model_name?: 'kling-v2-6' | 'kling-v3';
   character_orientation?: 'image' | 'video';
   mode?: 'std' | 'pro';
   keep_original_sound?: 'yes' | 'no';
@@ -41,6 +42,7 @@ export interface IKlingMotionRequest {
   prompt?: string;
   image_url?: string;
   video_url?: string;
+  model_name?: 'kling-v2-6' | 'kling-v3';
   character_orientation?: 'image' | 'video';
   mode?: 'std' | 'pro';
   keep_original_sound?: 'yes' | 'no';

--- a/src/pages/kling/Index.vue
+++ b/src/pages/kling/Index.vue
@@ -284,6 +284,7 @@ export default defineComponent({
         character_orientation: cfg.character_orientation || 'video',
         mode: cfg.mode || 'std',
         keep_original_sound: cfg.keep_original_sound ?? 'yes',
+        ...(cfg.model_name ? { model_name: cfg.model_name } : {}),
         ...(cfg.prompt ? { prompt: cfg.prompt } : {}),
         async: true
       };


### PR DESCRIPTION
## What

Add a **model version selector** (Kling 2.6 / Kling 3.0) to the Kling Motion Control panel in Studio, so users can pick the model — and the per-second price display reflects the chosen tier.

- New `MotionModelSelector.vue` (mirrors the existing `MotionModeSelector` pattern): options `Kling 2.6` → `kling-v2-6`, `Kling 3.0` → `kling-v3`, defaulting to `kling-v2-6`.
- `MotionPanel.vue`: selector placed between orientation and mode; the existing per-second `consumption` computed now reflects the selected model automatically (it already spreads `motionConfig` into `getConsumption`).
- `IKlingMotionConfig` / `IKlingMotionRequest`: add `model_name?: 'kling-v2-6' | 'kling-v3'`.
- `Index.vue` `onGenerateMotion`: forward `model_name` in the request when set.
- i18n: `name.motionModel` + `description.motionModel` added to all 18 locales (`check_i18n_coverage.py` passes).

## Why

Motion Control billing is now version-aware (PlatformBackend #897): `kling-v3` costs more per second than `kling-v2-6`, and the worker/OpenAPI already accept `model_name` (PlatformService #1396, PlatformBackend #896). Without a UI selector, Studio users were stuck on the default `kling-v2-6` and the per-second price could never show the v3 tier. This closes that loop: pick model → request carries `model_name` → price display updates (0.85/1.35 for v2-6, 1.5/2.0 for v3).

## Test

- `tsc` + ESLint clean on all changed files.
- `check_i18n_coverage.py` → exit 0 (17 locales × 44 namespaces match zh-CN).
- beachball change file included.

## 🤖 对抗评审

Reviewer: independent `general-purpose` subagent (Codex not installed), verified against the real branch scope.

- Confirmed explicit `model_name: kling-v2-6` is billing-equivalent to omitting it (backend defaults absent → v2-6); request builds `model_name` conditionally, so no risk even if `mounted()` never fires.
- Confirmed the setter spreads `...motionConfig` (no field loss), the union type matches the store, and `model_name` flows reactively into the per-second `consumption` computed.
- **NIT** — option labels "Kling 2.6"/"Kling 3.0" are hardcoded brand names (acceptable, not i18n'd).
- **NIT** — `mounted()` eagerly persists the default into the vuex-persisted store (harmless, matches sibling `MotionModeSelector`).

`VERDICT: CLEAN`.
