### PR TITLE
fix(payment): disable Stripe button and show temporary outage alert

### DIFF
--- a/change/@acedatacloud-nexior-disable-stripe-button.json
+++ b/change/@acedatacloud-nexior-disable-stripe-button.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Temporarily disable Stripe payment selection and show an outage notice.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/i18n/ar/order.json
+++ b/src/i18n/ar/order.json
@@ -99,6 +99,10 @@
     "message": "يرجى إكمال الدفع في الرابط الخارجي",
     "description": "رسالة للدفع عبر رابط خارجي."
   },
+  "message.stripeTemporarilyUnavailable": {
+    "message": "Our Stripe account is currently experiencing issues, so payments are temporarily unavailable. Please use another payment method for now.",
+    "description": "Notice shown below the payment method selector when Stripe payments are temporarily unavailable."
+  },
   "message.applePayProcessing": {
     "message": "جارٍ إتمام عملية الشراء عبر App Store…",
     "description": "Message while the Apple in-app purchase is processing."

--- a/src/i18n/de/order.json
+++ b/src/i18n/de/order.json
@@ -99,6 +99,10 @@
     "message": "Bitte schließen Sie die Zahlung über den externen Link ab.",
     "description": "Nachricht über die Zahlung über einen externen Link."
   },
+  "message.stripeTemporarilyUnavailable": {
+    "message": "Our Stripe account is currently experiencing issues, so payments are temporarily unavailable. Please use another payment method for now.",
+    "description": "Notice shown below the payment method selector when Stripe payments are temporarily unavailable."
+  },
   "message.applePayProcessing": {
     "message": "Kauf wird über den App Store abgeschlossen…",
     "description": "Message while the Apple in-app purchase is processing."

--- a/src/i18n/el/order.json
+++ b/src/i18n/el/order.json
@@ -99,6 +99,10 @@
     "message": "Παρακαλώ ολοκληρώστε την πληρωμή μέσω εξωτερικού συνδέσμου.",
     "description": "Μήνυμα για πληρωμή μέσω εξωτερικού συνδέσμου."
   },
+  "message.stripeTemporarilyUnavailable": {
+    "message": "Our Stripe account is currently experiencing issues, so payments are temporarily unavailable. Please use another payment method for now.",
+    "description": "Notice shown below the payment method selector when Stripe payments are temporarily unavailable."
+  },
   "message.applePayProcessing": {
     "message": "Ολοκλήρωση της αγοράς μέσω App Store…",
     "description": "Message while the Apple in-app purchase is processing."

--- a/src/i18n/en/order.json
+++ b/src/i18n/en/order.json
@@ -99,6 +99,10 @@
     "message": "Please complete the payment in the external link.",
     "description": "Message for external link payment."
   },
+  "message.stripeTemporarilyUnavailable": {
+    "message": "Our Stripe account is currently experiencing issues, so payments are temporarily unavailable. Please use another payment method for now.",
+    "description": "Notice shown below the payment method selector when Stripe payments are temporarily unavailable."
+  },
   "message.applePayProcessing": {
     "message": "Completing your purchase through the App Store…",
     "description": "Message while the Apple in-app purchase is processing."

--- a/src/i18n/es/order.json
+++ b/src/i18n/es/order.json
@@ -99,6 +99,10 @@
     "message": "Por favor, completa el pago en el enlace externo.",
     "description": "Mensaje para pagos a través de enlaces externos."
   },
+  "message.stripeTemporarilyUnavailable": {
+    "message": "Our Stripe account is currently experiencing issues, so payments are temporarily unavailable. Please use another payment method for now.",
+    "description": "Notice shown below the payment method selector when Stripe payments are temporarily unavailable."
+  },
   "message.applePayProcessing": {
     "message": "Completando tu compra a través de la App Store…",
     "description": "Message while the Apple in-app purchase is processing."

--- a/src/i18n/fi/order.json
+++ b/src/i18n/fi/order.json
@@ -99,6 +99,10 @@
     "message": "Suorita maksu ulkoisessa linkissä",
     "description": "Ulkoisen linkin maksamisen viesti."
   },
+  "message.stripeTemporarilyUnavailable": {
+    "message": "Our Stripe account is currently experiencing issues, so payments are temporarily unavailable. Please use another payment method for now.",
+    "description": "Notice shown below the payment method selector when Stripe payments are temporarily unavailable."
+  },
   "message.applePayProcessing": {
     "message": "Viimeistellään ostoa App Storessa…",
     "description": "Message while the Apple in-app purchase is processing."

--- a/src/i18n/fr/order.json
+++ b/src/i18n/fr/order.json
@@ -99,6 +99,10 @@
     "message": "Veuillez terminer le paiement via le lien externe",
     "description": "Message pour le paiement via un lien externe."
   },
+  "message.stripeTemporarilyUnavailable": {
+    "message": "Our Stripe account is currently experiencing issues, so payments are temporarily unavailable. Please use another payment method for now.",
+    "description": "Notice shown below the payment method selector when Stripe payments are temporarily unavailable."
+  },
   "message.applePayProcessing": {
     "message": "Finalisation de votre achat via l’App Store…",
     "description": "Message while the Apple in-app purchase is processing."

--- a/src/i18n/it/order.json
+++ b/src/i18n/it/order.json
@@ -99,6 +99,10 @@
     "message": "Completa il pagamento nel link esterno",
     "description": "Messaggio per pagamento tramite link esterno."
   },
+  "message.stripeTemporarilyUnavailable": {
+    "message": "Our Stripe account is currently experiencing issues, so payments are temporarily unavailable. Please use another payment method for now.",
+    "description": "Notice shown below the payment method selector when Stripe payments are temporarily unavailable."
+  },
   "message.applePayProcessing": {
     "message": "Completamento dell’acquisto tramite l’App Store…",
     "description": "Message while the Apple in-app purchase is processing."

--- a/src/i18n/ja/order.json
+++ b/src/i18n/ja/order.json
@@ -99,6 +99,10 @@
     "message": "外部リンクで支払いを完了してください。",
     "description": "外部リンクでの支払いに関するメッセージです。"
   },
+  "message.stripeTemporarilyUnavailable": {
+    "message": "Our Stripe account is currently experiencing issues, so payments are temporarily unavailable. Please use another payment method for now.",
+    "description": "Notice shown below the payment method selector when Stripe payments are temporarily unavailable."
+  },
   "message.applePayProcessing": {
     "message": "App Store で購入を完了しています…",
     "description": "Message while the Apple in-app purchase is processing."

--- a/src/i18n/ko/order.json
+++ b/src/i18n/ko/order.json
@@ -99,6 +99,10 @@
     "message": "외부 링크에서 결제를 완료하세요.",
     "description": "외부 링크 결제에 대한 메시지입니다."
   },
+  "message.stripeTemporarilyUnavailable": {
+    "message": "Our Stripe account is currently experiencing issues, so payments are temporarily unavailable. Please use another payment method for now.",
+    "description": "Notice shown below the payment method selector when Stripe payments are temporarily unavailable."
+  },
   "message.applePayProcessing": {
     "message": "App Store에서 결제를 완료하는 중…",
     "description": "Message while the Apple in-app purchase is processing."

--- a/src/i18n/pl/order.json
+++ b/src/i18n/pl/order.json
@@ -99,6 +99,10 @@
     "message": "Proszę zakończyć płatność w zewnętrznym linku",
     "description": "Wiadomość o płatności w zewnętrznym linku."
   },
+  "message.stripeTemporarilyUnavailable": {
+    "message": "Our Stripe account is currently experiencing issues, so payments are temporarily unavailable. Please use another payment method for now.",
+    "description": "Notice shown below the payment method selector when Stripe payments are temporarily unavailable."
+  },
   "message.applePayProcessing": {
     "message": "Finalizowanie zakupu przez App Store…",
     "description": "Message while the Apple in-app purchase is processing."

--- a/src/i18n/pt/order.json
+++ b/src/i18n/pt/order.json
@@ -99,6 +99,10 @@
     "message": "Conclua o pagamento no link externo.",
     "description": "Mensagem para pagamento via link externo."
   },
+  "message.stripeTemporarilyUnavailable": {
+    "message": "Our Stripe account is currently experiencing issues, so payments are temporarily unavailable. Please use another payment method for now.",
+    "description": "Notice shown below the payment method selector when Stripe payments are temporarily unavailable."
+  },
   "message.applePayProcessing": {
     "message": "A concluir a sua compra através da App Store…",
     "description": "Message while the Apple in-app purchase is processing."

--- a/src/i18n/ru/order.json
+++ b/src/i18n/ru/order.json
@@ -99,6 +99,10 @@
     "message": "Пожалуйста, завершите оплату по внешней ссылке",
     "description": "Сообщение о платеже по внешней ссылке."
   },
+  "message.stripeTemporarilyUnavailable": {
+    "message": "Our Stripe account is currently experiencing issues, so payments are temporarily unavailable. Please use another payment method for now.",
+    "description": "Notice shown below the payment method selector when Stripe payments are temporarily unavailable."
+  },
   "message.applePayProcessing": {
     "message": "Завершаем покупку через App Store…",
     "description": "Message while the Apple in-app purchase is processing."

--- a/src/i18n/sr/order.json
+++ b/src/i18n/sr/order.json
@@ -99,6 +99,10 @@
     "message": "Molimo završite plaćanje putem spoljnog linka",
     "description": "Poruka o plaćanju putem spoljnog linka."
   },
+  "message.stripeTemporarilyUnavailable": {
+    "message": "Our Stripe account is currently experiencing issues, so payments are temporarily unavailable. Please use another payment method for now.",
+    "description": "Notice shown below the payment method selector when Stripe payments are temporarily unavailable."
+  },
   "message.applePayProcessing": {
     "message": "Завршавање куповине преко App Store-а…",
     "description": "Message while the Apple in-app purchase is processing."

--- a/src/i18n/sv/order.json
+++ b/src/i18n/sv/order.json
@@ -99,6 +99,10 @@
     "message": "Vänligen slutför betalningen via den externa länken",
     "description": "Meddelande om betalning via extern länk."
   },
+  "message.stripeTemporarilyUnavailable": {
+    "message": "Our Stripe account is currently experiencing issues, so payments are temporarily unavailable. Please use another payment method for now.",
+    "description": "Notice shown below the payment method selector when Stripe payments are temporarily unavailable."
+  },
   "message.applePayProcessing": {
     "message": "Slutför ditt köp via App Store…",
     "description": "Message while the Apple in-app purchase is processing."

--- a/src/i18n/uk/order.json
+++ b/src/i18n/uk/order.json
@@ -99,6 +99,10 @@
     "message": "Будь ласка, завершіть оплату за зовнішнім посиланням",
     "description": "Повідомлення про оплату за зовнішнім посиланням."
   },
+  "message.stripeTemporarilyUnavailable": {
+    "message": "Our Stripe account is currently experiencing issues, so payments are temporarily unavailable. Please use another payment method for now.",
+    "description": "Notice shown below the payment method selector when Stripe payments are temporarily unavailable."
+  },
   "message.applePayProcessing": {
     "message": "Завершуємо покупку через App Store…",
     "description": "Message while the Apple in-app purchase is processing."

--- a/src/i18n/zh-CN/order.json
+++ b/src/i18n/zh-CN/order.json
@@ -99,6 +99,10 @@
     "message": "请在外部链接中完成支付",
     "description": "外部链接支付的消息。"
   },
+  "message.stripeTemporarilyUnavailable": {
+    "message": "我们的 Stripe 账户遇到一些问题，收款暂不可用，请临时改用其他方式付款。",
+    "description": "Notice shown below the payment method selector when Stripe payments are temporarily unavailable."
+  },
   "message.applePayProcessing": {
     "message": "正在通过 App Store 完成支付…",
     "description": "Apple 内购处理中的消息。"

--- a/src/i18n/zh-TW/order.json
+++ b/src/i18n/zh-TW/order.json
@@ -99,6 +99,10 @@
     "message": "請在外部鏈接中完成支付",
     "description": "外部鏈接支付的消息。"
   },
+  "message.stripeTemporarilyUnavailable": {
+    "message": "我們的 Stripe 帳戶遇到一些問題，收款暫不可用，請暫時改用其他方式付款。",
+    "description": "Notice shown below the payment method selector when Stripe payments are temporarily unavailable."
+  },
   "message.applePayProcessing": {
     "message": "正在透過 App Store 完成付款…",
     "description": "Message while the Apple in-app purchase is processing."

--- a/src/pages/console/order/Detail.vue
+++ b/src/pages/console/order/Detail.vue
@@ -123,7 +123,7 @@
                       alipay: true,
                       active: payWay === PayWay.AliPay
                     }"
-                    @click="payWay = PayWay.AliPay"
+                    @click="onSelectPayWay(PayWay.AliPay)"
                   >
                     <span class="payicon alipay"></span>
                     <span class="payname">{{ $t('order.title.aliPay') }}</span>
@@ -132,9 +132,10 @@
                     :class="{
                       payway: true,
                       stripe: true,
-                      active: payWay === PayWay.Stripe
+                      disabled: isStripeTemporarilyUnavailable,
+                      active: payWay === PayWay.Stripe && !isStripeTemporarilyUnavailable
                     }"
-                    @click="payWay = PayWay.Stripe"
+                    @click="onSelectPayWay(PayWay.Stripe)"
                   >
                     <span class="payicon stripe"></span>
                     <span class="payname">{{ $t('order.title.stripe') }}</span>
@@ -146,7 +147,7 @@
                       relative: true,
                       active: payWay === PayWay.X402
                     }"
-                    @click="payWay = PayWay.X402"
+                    @click="onSelectPayWay(PayWay.X402)"
                   >
                     <span class="payicon x402"></span>
                     <span class="payname">{{ $t('order.title.x402') }}</span>
@@ -167,12 +168,20 @@
                       paypal: true,
                       active: payWay === PayWay.PayPal
                     }"
-                    @click="payWay = PayWay.PayPal"
+                    @click="onSelectPayWay(PayWay.PayPal)"
                   >
                     <span class="payicon paypal"></span>
                     <span class="payname">{{ $t('order.title.paypal') }}</span>
                   </div>
                 </div>
+                <el-alert
+                  v-if="showStripeUnavailableAlert"
+                  class="stripe-unavailable-alert mb-4"
+                  :title="stripeUnavailableNotice"
+                  type="warning"
+                  show-icon
+                  :closable="false"
+                />
                 <div v-if="showPayment && !order?.pay_way">
                   <el-button :loading="prepaying" round type="primary" size="large" class="btn-pay" @click="onPay">{{
                     $t('common.button.pay')
@@ -325,6 +334,20 @@ export default defineComponent({
     },
     enablePaypal(): boolean {
       return !!this.config?.features?.ENABLE_PAYPAL;
+    },
+    isStripeTemporarilyUnavailable(): boolean {
+      return true;
+    },
+    stripeUnavailableNotice(): string {
+      return this.$t('order.message.stripeTemporarilyUnavailable').toString();
+    },
+    showStripeUnavailableAlert(): boolean {
+      return !!(
+        !this.isIos &&
+        this.order &&
+        this.order.state === OrderState.PENDING &&
+        ((!this.order.pay_way && (this.order.price || 0) > 0) || this.order.pay_way === PayWay.Stripe)
+      );
     },
     isIos(): boolean {
       return isIOS();
@@ -556,6 +579,12 @@ export default defineComponent({
   },
   methods: {
     getPriceString,
+    onSelectPayWay(nextPayWay: PayWay) {
+      if (this.isStripeTemporarilyUnavailable && nextPayWay === PayWay.Stripe) {
+        return;
+      }
+      this.payWay = nextPayWay;
+    },
     formatCredits(value: number): string {
       if (!Number.isFinite(value)) return '0';
       return Number.isInteger(value) ? String(value) : value.toFixed(2);
@@ -624,6 +653,12 @@ export default defineComponent({
         });
     },
     onRepay() {
+      if (
+        this.isStripeTemporarilyUnavailable &&
+        (this.payWay === PayWay.Stripe || this.order?.pay_way === PayWay.Stripe)
+      ) {
+        return;
+      }
       if (this.payWay === PayWay.X402) {
         this.x402Session = undefined;
       }
@@ -631,6 +666,12 @@ export default defineComponent({
       this.startOrderPolling();
     },
     onPay() {
+      if (
+        this.isStripeTemporarilyUnavailable &&
+        (this.payWay === PayWay.Stripe || this.order?.pay_way === PayWay.Stripe)
+      ) {
+        return;
+      }
       this.prepaying = true;
       // Apple IAP: no PSP session / pay_url. The ApplePay dialog drives the
       // StoreKit purchase and calls apple-verify; just open it and poll.
@@ -781,6 +822,12 @@ export default defineComponent({
         }
       }
     }
+    &.disabled {
+      cursor: not-allowed;
+      opacity: 0.45;
+      border-color: var(--el-border-color-light);
+      background: var(--el-fill-color-lighter);
+    }
   }
   .payname {
     display: inline-block;
@@ -827,6 +874,10 @@ export default defineComponent({
       background-size: contain;
     }
   }
+}
+
+.stripe-unavailable-alert {
+  max-width: 680px;
 }
 
 .btn-pay {

--- a/src/pages/order/Pay.vue
+++ b/src/pages/order/Pay.vue
@@ -68,26 +68,39 @@
                 <div v-if="!order.pay_way && order.price && order.price > 0" class="payways mb-6">
                   <div
                     :class="{ payway: true, wechatpay: true, active: payWay === PayWay.WechatPay }"
-                    @click="payWay = PayWay.WechatPay"
+                    @click="onSelectPayWay(PayWay.WechatPay)"
                   >
                     <span class="payicon wechatpay"></span>
                     <span class="payname">{{ $t('order.title.wechatPay') }}</span>
                   </div>
                   <div
                     :class="{ payway: true, alipay: true, active: payWay === PayWay.AliPay }"
-                    @click="payWay = PayWay.AliPay"
+                    @click="onSelectPayWay(PayWay.AliPay)"
                   >
                     <span class="payicon alipay"></span>
                     <span class="payname">{{ $t('order.title.aliPay') }}</span>
                   </div>
                   <div
-                    :class="{ payway: true, stripe: true, active: payWay === PayWay.Stripe }"
-                    @click="payWay = PayWay.Stripe"
+                    :class="{
+                      payway: true,
+                      stripe: true,
+                      disabled: isStripeTemporarilyUnavailable,
+                      active: payWay === PayWay.Stripe && !isStripeTemporarilyUnavailable
+                    }"
+                    @click="onSelectPayWay(PayWay.Stripe)"
                   >
                     <span class="payicon stripe"></span>
                     <span class="payname">{{ $t('order.title.stripe') }}</span>
                   </div>
                 </div>
+                <el-alert
+                  v-if="showStripeUnavailableAlert"
+                  class="stripe-unavailable-alert mb-4"
+                  :title="stripeUnavailableNotice"
+                  type="warning"
+                  show-icon
+                  :closable="false"
+                />
                 <div v-if="!order.pay_way">
                   <el-button :loading="prepaying" round type="primary" size="large" class="btn-pay" @click="onPay">
                     {{ $t('common.button.pay') }}
@@ -196,6 +209,20 @@ export default defineComponent({
     // App Store Review Guideline 3.1.1: no non-IAP payment UI on iOS.
     showPayment(): boolean {
       return !isIOS();
+    },
+    isStripeTemporarilyUnavailable(): boolean {
+      return true;
+    },
+    stripeUnavailableNotice(): string {
+      return this.$t('order.message.stripeTemporarilyUnavailable').toString();
+    },
+    showStripeUnavailableAlert(): boolean {
+      return !!(
+        this.showPayment &&
+        this.order &&
+        this.order.state === OrderState.PENDING &&
+        ((!this.order.pay_way && (this.order.price || 0) > 0) || this.order.pay_way === PayWay.Stripe)
+      );
     }
   },
   watch: {
@@ -215,6 +242,12 @@ export default defineComponent({
   },
   methods: {
     getPriceString,
+    onSelectPayWay(nextPayWay: PayWay) {
+      if (this.isStripeTemporarilyUnavailable && nextPayWay === PayWay.Stripe) {
+        return;
+      }
+      this.payWay = nextPayWay;
+    },
     payWayLabel(payWay: string): string {
       const map: Record<string, string> = {
         WechatPay: this.$t('order.title.wechatPay') as string,
@@ -273,10 +306,22 @@ export default defineComponent({
       }
     },
     onRepay() {
+      if (
+        this.isStripeTemporarilyUnavailable &&
+        (this.payWay === PayWay.Stripe || this.order?.pay_way === PayWay.Stripe)
+      ) {
+        return;
+      }
       this.paying = true;
     },
     onPay() {
       if (!this.id) return;
+      if (
+        this.isStripeTemporarilyUnavailable &&
+        (this.payWay === PayWay.Stripe || this.order?.pay_way === PayWay.Stripe)
+      ) {
+        return;
+      }
       this.prepaying = true;
       // AliPay's backend serves Page (PC) and Wap (mobile) URLs based on
       // the `surface` hint. WeChat Pay is pinned to Native QR on our
@@ -357,6 +402,12 @@ export default defineComponent({
         &.active {
           border: 2px solid var(--el-color-primary);
         }
+        &.disabled {
+          cursor: not-allowed;
+          opacity: 0.45;
+          border-color: var(--el-border-color-light);
+          background: var(--el-fill-color-lighter);
+        }
       }
       .payname {
         display: inline-block;
@@ -383,6 +434,9 @@ export default defineComponent({
           background-size: contain;
         }
       }
+    }
+    .stripe-unavailable-alert {
+      max-width: 680px;
     }
     .btn-pay,
     .btn-repay {


### PR DESCRIPTION
## What
Disable Stripe in order payment selectors and show a warning alert:

- Stripe option is visually disabled (grayed out) and not selectable.
- Added warning alert below payment methods:
  - zh: 我们的 Stripe 账户遇到一些问题，收款暂不可用，请临时改用其他方式付款。
  - en: Our Stripe account is currently experiencing issues, so payments are temporarily unavailable. Please use another payment method for now.
- Added defense-in-depth guards in both pages so `onPay` / `onRepay` return early when Stripe is selected or existing order pay way is Stripe.

Changed files:
- src/pages/console/order/Detail.vue
- src/pages/order/Pay.vue

## Why
Stripe is temporarily unavailable; prevent failed Stripe attempts and guide users to available methods.

## Notes
Frontend-only gating. Backend/API Stripe blocking should be handled operationally if hard shutdown is required.

## 🤖 对抗评审
Codex review: PASS for requested UI behavior (Stripe blocked + warning visible).