### PR TITLE
feat(nanobanana): add nano-banana-2-lite option

### DIFF
--- a/change/@acedatacloud-nexior-9e29e9d9-c864-40a5-abee-7b64599ad4aa.json
+++ b/change/@acedatacloud-nexior-9e29e9d9-c864-40a5-abee-7b64599ad4aa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add nano-banana-2-lite model option.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/nanobanana/config/ModelSelector.vue
+++ b/src/components/nanobanana/config/ModelSelector.vue
@@ -18,6 +18,7 @@ import { ElSelect, ElOption } from 'element-plus';
 import {
   NANOBANANA_DEFAULT_MODEL,
   NANOBANANA_MODEL_NANO_BANANA,
+  NANOBANANA_MODEL_NANO_BANANA_2_LITE,
   NANOBANANA_MODEL_NANO_BANANA_PRO,
   NANOBANANA_MODEL_NANO_BANANA_2
 } from '@/constants';
@@ -36,6 +37,10 @@ export default defineComponent({
         {
           value: NANOBANANA_MODEL_NANO_BANANA,
           label: this.$t('nanobanana.model.nanoBanana')
+        },
+        {
+          value: NANOBANANA_MODEL_NANO_BANANA_2_LITE,
+          label: NANOBANANA_MODEL_NANO_BANANA_2_LITE
         },
         {
           value: NANOBANANA_MODEL_NANO_BANANA_PRO,

--- a/src/components/nanobanana/config/ResolutionSelector.vue
+++ b/src/components/nanobanana/config/ResolutionSelector.vue
@@ -6,7 +6,12 @@
         <info-icon :content="$t('nanobanana.description.resolutionProOnly')" class="info" />
       </div>
     </div>
-    <el-select v-model="value" class="value" :placeholder="$t('nanobanana.placeholder.select')" :disabled="!isProModel">
+    <el-select
+      v-model="value"
+      class="value"
+      :placeholder="$t('nanobanana.placeholder.select')"
+      :disabled="!supportsResolution"
+    >
       <el-option v-for="item in options" :key="item.value" :label="item.label" :value="item.value" />
     </el-select>
   </div>
@@ -18,7 +23,8 @@ import { ElSelect, ElOption } from 'element-plus';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import {
   NANOBANANA_DEFAULT_RESOLUTION,
-  NANOBANANA_MODEL_NANO_BANANA,
+  NANOBANANA_MODEL_NANO_BANANA_2,
+  NANOBANANA_MODEL_NANO_BANANA_PRO,
   NANOBANANA_RESOLUTION_1K,
   NANOBANANA_RESOLUTION_2K,
   NANOBANANA_RESOLUTION_4K
@@ -62,17 +68,18 @@ export default defineComponent({
         });
       }
     },
-    isProModel(): boolean {
-      return this.$store.state.nanobanana?.config?.model !== NANOBANANA_MODEL_NANO_BANANA;
+    supportsResolution(): boolean {
+      const model = this.$store.state.nanobanana?.config?.model;
+      return model === NANOBANANA_MODEL_NANO_BANANA_2 || model === NANOBANANA_MODEL_NANO_BANANA_PRO;
     }
   },
   watch: {
     value(newVal: string) {
-      if (this.isProModel && newVal) {
+      if (this.supportsResolution && newVal) {
         this.cachedResolution = newVal;
       }
     },
-    isProModel(newVal: boolean) {
+    supportsResolution(newVal: boolean) {
       if (newVal) {
         if (!this.value) {
           this.value = this.cachedResolution || NANOBANANA_DEFAULT_RESOLUTION;
@@ -89,10 +96,10 @@ export default defineComponent({
     }
   },
   mounted() {
-    if (this.isProModel && !this.value) {
+    if (this.supportsResolution && !this.value) {
       this.value = NANOBANANA_DEFAULT_RESOLUTION;
     }
-    if (!this.isProModel && this.value) {
+    if (!this.supportsResolution && this.value) {
       this.cachedResolution = this.value;
       this.$store.commit('nanobanana/setConfig', {
         ...this.$store.state.nanobanana?.config,

--- a/src/constants/nanobanana.ts
+++ b/src/constants/nanobanana.ts
@@ -10,6 +10,7 @@ export const NANOBANANA_RESOLUTION_4K = '4K';
 export const NANOBANANA_DEFAULT_RESOLUTION = NANOBANANA_RESOLUTION_1K;
 
 export const NANOBANANA_MODEL_NANO_BANANA = 'nano-banana';
+export const NANOBANANA_MODEL_NANO_BANANA_2_LITE = 'nano-banana-2-lite';
 export const NANOBANANA_MODEL_NANO_BANANA_2 = 'nano-banana-2';
 export const NANOBANANA_MODEL_NANO_BANANA_PRO = 'nano-banana-pro';
 

--- a/src/i18n/en/nanobanana.json
+++ b/src/i18n/en/nanobanana.json
@@ -56,7 +56,7 @@
     "description": "Resolution of the generated image"
   },
   "description.resolutionProOnly": {
-    "message": "Resolution settings are supported by nano-banana-2 and nano-banana-pro.",
+    "message": "nano-banana-2 and nano-banana-pro support 1K/2K/4K; nano-banana and nano-banana-2-lite are 1K only.",
     "description": "Resolution options are effective only for nano-banana-2 and pro models"
   },
   "description.prompt": {
@@ -68,7 +68,7 @@
     "description": "Description of the action parameter"
   },
   "description.model": {
-    "message": "Model used for generating images. Default is nano-banana. nano-banana-pro is an alias for gemini-3-pro-image, nano-banana is an alias for gemini-2.5-flash-image.",
+    "message": "Model used for generating images. Default is nano-banana. nano-banana-2-lite is an alias for gemini-3.1-flash-lite-image and only supports 1K fast generation.",
     "description": "Description of the model parameter"
   },
   "description.imageUrls": {

--- a/src/i18n/zh-CN/nanobanana.json
+++ b/src/i18n/zh-CN/nanobanana.json
@@ -56,7 +56,7 @@
     "description": "生成图像的分辨率"
   },
   "description.resolutionProOnly": {
-    "message": "nano-banana-2 和 nano-banana-pro 支持分辨率设置。",
+    "message": "nano-banana-2 和 nano-banana-pro 支持 1K/2K/4K；nano-banana 与 nano-banana-2-lite 仅支持 1K。",
     "description": "分辨率选项仅对 nano-banana-2 和 pro 模型生效"
   },
   "description.prompt": {
@@ -68,7 +68,7 @@
     "description": "action 参数说明"
   },
   "description.model": {
-    "message": "用于生成图片的模型。默认是 nano-banana。nano-banana-pro 是 gemini-3-pro-image 的别名，nano-banana 是 gemini-2.5-flash-image 的别名。",
+    "message": "用于生成图片的模型。默认是 nano-banana。nano-banana-2-lite 是 gemini-3.1-flash-lite-image 的别名，仅支持 1K，生成速度快。",
     "description": "model 参数说明"
   },
   "description.imageUrls": {

--- a/src/pages/nanobanana/Index.vue
+++ b/src/pages/nanobanana/Index.vue
@@ -17,7 +17,12 @@ import { nanobananaOperator } from '@/operators';
 import { instrumentGeneration } from '@/plugins/telemetry';
 import { INanobananaGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
-import { ERROR_CODE_USED_UP, NANOBANANA_DEFAULT_RESOLUTION, NANOBANANA_MODEL_NANO_BANANA } from '@/constants';
+import {
+  ERROR_CODE_USED_UP,
+  NANOBANANA_DEFAULT_RESOLUTION,
+  NANOBANANA_MODEL_NANO_BANANA_2,
+  NANOBANANA_MODEL_NANO_BANANA_PRO
+} from '@/constants';
 import RecentPanel from '@/components/nanobanana/RecentPanel.vue';
 import { INanobananaTask } from '@/models';
 import { loadPreviousPage } from '@/utils/pagination';
@@ -158,11 +163,12 @@ export default defineComponent({
       if (!cfg?.aspect_ratio) {
         delete cfg.aspect_ratio;
       }
-      // Resolution (1K/2K/4K) is supported by nano-banana-2 and nano-banana-pro; base nano-banana is 1K only.
-      if (cfg?.model === NANOBANANA_MODEL_NANO_BANANA && 'resolution' in cfg) {
+      const supportsResolution =
+        cfg?.model === NANOBANANA_MODEL_NANO_BANANA_2 || cfg?.model === NANOBANANA_MODEL_NANO_BANANA_PRO;
+      if (!supportsResolution && 'resolution' in cfg) {
         delete cfg.resolution;
       }
-      if (cfg?.model !== NANOBANANA_MODEL_NANO_BANANA && !cfg?.resolution) {
+      if (supportsResolution && !cfg?.resolution) {
         cfg.resolution = NANOBANANA_DEFAULT_RESOLUTION;
       }
       const request = {


### PR DESCRIPTION
## Summary
- add `nano-banana-2-lite` to the Nano Banana model selector
- keep resolution controls enabled only for `nano-banana-2` and `nano-banana-pro`
- strip stale cached resolution from 1K-only model requests
- add Beachball change file

## Upstream Probe
- BananaRouter lists `gemini-3.1-flash-lite-image`, but current production credentials still get 404 on generation for that native model
- UI is ready for rollout once backend/service changes merge and the upstream token permission is granted

## Validation
- `npx eslint src/constants/nanobanana.ts src/components/nanobanana/config/ModelSelector.vue src/components/nanobanana/config/ResolutionSelector.vue src/pages/nanobanana/Index.vue`
- `python3 scripts/check_i18n_coverage.py`
- `npx vue-tsc -b`
- `npm run verify` generated a worktree-only Beachball `change/change` hook bug on push; a proper change file is committed and CI will re-run Beachball in a normal checkout

## 🤖 对抗评审
- Reviewer: default subagent, read-only diff review
- Verdict: `VERDICT: CLEAN`
