### PR TITLE
fix(seedance): expose official auto duration option

### DIFF
--- a/change/@acedatacloud-nexior-ceed5e70-3b53-4b5c-9d31-1ebf2cfe9481.json
+++ b/change/@acedatacloud-nexior-ceed5e70-3b53-4b5c-9d31-1ebf2cfe9481.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(seedance): expose official auto duration option",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/seedance/config/DurationSelector.vue
+++ b/src/components/seedance/config/DurationSelector.vue
@@ -34,6 +34,9 @@ export default defineComponent({
     },
     options(): { value: number; label: string }[] {
       const items: { value: number; label: string }[] = [];
+      if (this.capability.supportsAutoDuration) {
+        items.push({ value: -1, label: `${this.$t('seedance.placeholder.seed')} (-1)` });
+      }
       for (let s = this.capability.minDuration; s <= this.capability.maxDuration; s++) {
         items.push({ value: s, label: `${s}s` });
       }
@@ -66,7 +69,11 @@ export default defineComponent({
   methods: {
     clampValue() {
       const current = this.value;
-      if (current !== undefined && (current < this.capability.minDuration || current > this.capability.maxDuration)) {
+      if (
+        current !== undefined &&
+        !(current === -1 && this.capability.supportsAutoDuration) &&
+        (current < this.capability.minDuration || current > this.capability.maxDuration)
+      ) {
         this.value = SEEDANCE_DEFAULT_DURATION;
       }
     }

--- a/src/constants/seedance.ts
+++ b/src/constants/seedance.ts
@@ -70,6 +70,8 @@ export interface ISeedanceModelCapability {
   minDuration: number;
   /** Longest clip duration (seconds) the model accepts. */
   maxDuration: number;
+  /** Whether duration -1 (auto duration) is supported by this model. */
+  supportsAutoDuration: boolean;
   /** Accepts reference image(s) as subject input (Seedance 2.0 multimodal). */
   acceptsReferenceImage: boolean;
   /** Accepts a reference audio input (Seedance 2.0 multimodal talking-head). */
@@ -90,6 +92,7 @@ export const SEEDANCE_MODEL_CAPABILITIES: Record<string, ISeedanceModelCapabilit
     maxResolution: SEEDANCE_RESOLUTION_1080P,
     minDuration: 2,
     maxDuration: SEEDANCE_DEFAULT_MAX_DURATION,
+    supportsAutoDuration: false,
     acceptsReferenceImage: false,
     acceptsReferenceAudio: false,
     acceptsReferenceVideo: false
@@ -105,6 +108,7 @@ export const SEEDANCE_MODEL_CAPABILITIES: Record<string, ISeedanceModelCapabilit
     maxResolution: SEEDANCE_RESOLUTION_1080P,
     minDuration: 2,
     maxDuration: SEEDANCE_DEFAULT_MAX_DURATION,
+    supportsAutoDuration: false,
     acceptsReferenceImage: false,
     acceptsReferenceAudio: false,
     acceptsReferenceVideo: false
@@ -118,8 +122,9 @@ export const SEEDANCE_MODEL_CAPABILITIES: Record<string, ISeedanceModelCapabilit
     acceptsReturnLastFrame: true,
     defaultResolution: SEEDANCE_RESOLUTION_720P,
     maxResolution: SEEDANCE_RESOLUTION_1080P,
-    minDuration: 2,
+    minDuration: 4,
     maxDuration: SEEDANCE_DEFAULT_MAX_DURATION,
+    supportsAutoDuration: true,
     acceptsReferenceImage: false,
     acceptsReferenceAudio: false,
     acceptsReferenceVideo: false
@@ -135,6 +140,7 @@ export const SEEDANCE_MODEL_CAPABILITIES: Record<string, ISeedanceModelCapabilit
     maxResolution: SEEDANCE_RESOLUTION_4K,
     minDuration: 4,
     maxDuration: SEEDANCE_2_0_MAX_DURATION,
+    supportsAutoDuration: true,
     acceptsReferenceImage: true,
     acceptsReferenceAudio: true,
     acceptsReferenceVideo: true
@@ -150,6 +156,7 @@ export const SEEDANCE_MODEL_CAPABILITIES: Record<string, ISeedanceModelCapabilit
     maxResolution: SEEDANCE_RESOLUTION_720P,
     minDuration: 4,
     maxDuration: SEEDANCE_2_0_MAX_DURATION,
+    supportsAutoDuration: true,
     acceptsReferenceImage: true,
     acceptsReferenceAudio: true,
     acceptsReferenceVideo: true
@@ -165,6 +172,7 @@ export const SEEDANCE_MODEL_CAPABILITIES: Record<string, ISeedanceModelCapabilit
     maxResolution: SEEDANCE_RESOLUTION_720P,
     minDuration: 4,
     maxDuration: SEEDANCE_2_0_MAX_DURATION,
+    supportsAutoDuration: true,
     acceptsReferenceImage: true,
     acceptsReferenceAudio: true,
     acceptsReferenceVideo: true
@@ -180,6 +188,7 @@ export const SEEDANCE_MODEL_CAPABILITIES: Record<string, ISeedanceModelCapabilit
     maxResolution: SEEDANCE_RESOLUTION_720P,
     minDuration: 2,
     maxDuration: SEEDANCE_DEFAULT_MAX_DURATION,
+    supportsAutoDuration: false,
     acceptsReferenceImage: false,
     acceptsReferenceAudio: false,
     acceptsReferenceVideo: false
@@ -195,6 +204,7 @@ export const SEEDANCE_MODEL_CAPABILITIES: Record<string, ISeedanceModelCapabilit
     maxResolution: SEEDANCE_RESOLUTION_720P,
     minDuration: 2,
     maxDuration: SEEDANCE_DEFAULT_MAX_DURATION,
+    supportsAutoDuration: false,
     acceptsReferenceImage: false,
     acceptsReferenceAudio: false,
     acceptsReferenceVideo: false

--- a/src/i18n/en/seedance.json
+++ b/src/i18n/en/seedance.json
@@ -32,7 +32,7 @@
     "description": "Label for video duration selection"
   },
   "description.duration": {
-    "message": "Video duration (seconds), range 2-12 seconds.",
+    "message": "Video duration (seconds). Select -1 for Auto on supported models, or choose a concrete value.",
     "description": "Instructions for video duration"
   },
   "name.generateAudio": {

--- a/src/i18n/zh-CN/seedance.json
+++ b/src/i18n/zh-CN/seedance.json
@@ -32,7 +32,7 @@
     "description": "视频时长选择标签"
   },
   "description.duration": {
-    "message": "视频时长（秒），范围 2-12 秒。",
+    "message": "视频时长（秒）。支持的模型可选 -1 表示自动，或手动指定具体秒数。",
     "description": "视频时长说明"
   },
   "name.generateAudio": {


### PR DESCRIPTION
## Summary
- Add model capability metadata for official Seedance auto duration support.
- Show `Auto (-1)` only for Seedance 1.5 Pro and Seedance 2.0 models.
- Update Seedance 1.5 Pro duration range to `4-12` and keep 2.0 at `4-15`.
- Add required beachball patch change file.

## Validation
- `npx eslint src/constants/seedance.ts src/components/seedance/config/DurationSelector.vue` (using existing local node_modules symlink for worktree validation)
- Parsed modified `seedance.json` locale files
- VS Code diagnostics: no errors in touched files

## 🤖 对抗评审
- Reviewer checked model-specific `-1` gating, frames precedence impact, unrelated files, and docs consistency across the four paired PRs.
- Earlier findings were in backend/docs PRs; Nexior UI gating remained aligned.
- Final verdict: `VERDICT: CLEAN`.