### PR TITLE
fix(chat): show friendly upload size errors

### DIFF
--- a/change/@acedatacloud-nexior-aichat2-413-ui.json
+++ b/change/@acedatacloud-nexior-aichat2-413-ui.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Show a friendly message when AI chat uploads are too large.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -340,8 +340,8 @@
     "description": "Message on the webpage informing the user that the conversation does not exist or has expired, please start a new conversation"
   },
   "message.errorContentTooLarge": {
-    "message": "Question content is too long, please shorten it and try again",
-    "description": "Message on the webpage informing the user that the question content is too long, please shorten it and try again"
+    "message": "The uploaded images or conversation content are too large. Please compress images, reduce the number of images, or shorten the content and try again.",
+    "description": "Message informing the user that uploaded images or conversation content are too large and should be compressed or reduced before retrying"
   },
   "message.errorTooManyRequests": {
     "message": "Your requests are too frequent, please try again later",

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -340,8 +340,8 @@
     "description": "网页中的消息，告诉用户对话不存在或已过期，请开始新对话"
   },
   "message.errorContentTooLarge": {
-    "message": "问题内容过长，请缩短后重试",
-    "description": "网页中的消息，告诉用户问题内容过长，请缩短后重试"
+    "message": "上传的图片或对话内容过大，请压缩图片、减少图片数量或缩短内容后重试",
+    "description": "网页中的消息，告诉用户上传的图片或对话内容过大，需要压缩或减少内容后重试"
   },
   "message.errorTooManyRequests": {
     "message": "您的操作过于频繁，请稍后重试",

--- a/src/operators/chat.test.ts
+++ b/src/operators/chat.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { chatOperator } from './chat';
 import type { IChatConversationResponse } from '@/models';
+import { BaseError } from '@/models';
+import { ERROR_CODE_CONTENT_TOO_LARGE } from '@/constants';
 
 // currentSiteOrigin reads window/location; stub it so the operator can run
 // under the plain test environment without touching the DOM.
@@ -53,5 +55,26 @@ describe('chatOperator.chatConversation SSE forwarding', () => {
     expect(progressEvents.every((e) => e.tool_id === 'call_1')).toBe(true);
     const argText = progressEvents.map((e) => e.progress ?? '').join('');
     expect(argText).toBe('{"command":"echo hi"}');
+  });
+
+  it('normalizes streaming 413 request_entity_too_large errors for localized UI copy', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(
+          sseResponse([
+            'data: {"type":"error","status":413,"code":"request_entity_too_large","message":"Request payload is too large."}\n'
+          ])
+        )
+    );
+
+    await expect(
+      chatOperator.chatConversation({ model: 'gemini-3.1-pro', message: 'describe images' } as never, { token: 't' })
+    ).rejects.toMatchObject({
+      status: 413,
+      code: ERROR_CODE_CONTENT_TOO_LARGE,
+      detail: ''
+    } satisfies Partial<BaseError>);
   });
 });

--- a/src/operators/chat.ts
+++ b/src/operators/chat.ts
@@ -10,7 +10,7 @@ import {
   IChatConversationsResponse,
   IChatShareResponse
 } from '@/models';
-import { BASE_URL_API, ERROR_CODE_API_ERROR } from '@/constants';
+import { BASE_URL_API, ERROR_CODE_API_ERROR, ERROR_CODE_CONTENT_TOO_LARGE } from '@/constants';
 import { currentSiteOrigin } from '@/utils';
 
 /**
@@ -21,6 +21,13 @@ import { currentSiteOrigin } from '@/utils';
 function siteHeaders(): Record<string, string> {
   const origin = currentSiteOrigin();
   return origin ? { 'x-site-origin': origin } : {};
+}
+
+function normalizeChatError(status: number, code?: string, message?: string): BaseError {
+  if (status === 413 || code === 'request_entity_too_large') {
+    return new BaseError(status || 413, ERROR_CODE_CONTENT_TOO_LARGE, '');
+  }
+  return new BaseError(status || 500, code || ERROR_CODE_API_ERROR, message || 'An error occurred');
 }
 
 class ChatOperator {
@@ -50,7 +57,7 @@ class ChatOperator {
           const errorMessage = errorJson?.error?.message || 'An error occurred';
           const errorCode = errorJson?.error?.code || ERROR_CODE_API_ERROR;
           console.error('Error message:', errorMessage, 'Error code:', errorCode);
-          reject(new BaseError(status, errorCode, errorMessage));
+          reject(normalizeChatError(status, errorCode, errorMessage));
           return;
         }
 
@@ -91,8 +98,10 @@ class ChatOperator {
                 if (json.type === 'error') {
                   const errorMessage =
                     typeof json.message === 'string' && json.message.trim() ? json.message.trim() : 'An error occurred';
+                  const errorStatus = typeof json.status === 'number' ? json.status : 500;
+                  const errorCode = typeof json.code === 'string' ? json.code : ERROR_CODE_API_ERROR;
                   await reader.cancel().catch(() => undefined);
-                  reject(new BaseError(500, ERROR_CODE_API_ERROR, errorMessage));
+                  reject(normalizeChatError(errorStatus, errorCode, errorMessage));
                   return;
                 }
                 if (options?.stream) {


### PR DESCRIPTION
## Summary
- Normalize aichat2 `request_entity_too_large` / HTTP 413 SSE errors to the existing `content_too_large` UI error code.
- Update chat error copy so users see an actionable message about compressing images, reducing image count, or shortening content.
- Add a chat operator regression test for streaming 413 errors.

## Why
The backend now surfaces oversized aichat2 multimodal requests as structured 413 errors. Without this frontend mapping, the chat UI could still display raw backend text or a generic failure instead of a helpful instruction.

## Tests
- `npm run test:run -- src/operators/chat.test.ts`
- `npm run build:web`
- `npm run verify`

## 🤖 对抗评审
- Review verdict: `VERDICT: CLEAN`.
- Checked that the mapping applies to SSE and non-OK fetch paths, keeps existing tool-progress streaming intact, and intentionally leaves normalized 413 detail empty so `Message.vue` uses localized copy.
