### PR TITLE
feat(seedream): add Seedream 5.0 Pro model option

### DIFF
--- a/change/@acedatacloud-nexior-seedream-5-0-pro.json
+++ b/change/@acedatacloud-nexior-seedream-5-0-pro.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add Seedream 5.0 Pro (doubao-seedream-5-0-pro-260628) model option",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/seedream/config/ModelSelector.vue
+++ b/src/components/seedream/config/ModelSelector.vue
@@ -28,6 +28,7 @@ import {
   SEEDREAM_MODEL_4_0,
   SEEDREAM_MODEL_4_5,
   SEEDREAM_MODEL_5_0,
+  SEEDREAM_MODEL_5_0_PRO,
   SEEDREAM_MODEL_SEEDEDIT_3_0_I2I
 } from '@/constants';
 import { findSeedreamConflicts, clearSeedreamConflicts } from '@/utils/seedream/capabilities';
@@ -45,6 +46,7 @@ export default defineComponent({
       // when the user cancels a model switch.
       revertKey: 0,
       options: [
+        { value: SEEDREAM_MODEL_5_0_PRO, label: this.$t('seedream.model.seedream50pro') },
         { value: SEEDREAM_MODEL_5_0, label: this.$t('seedream.model.seedream50') },
         { value: SEEDREAM_MODEL_4_5, label: this.$t('seedream.model.seedream45') },
         { value: SEEDREAM_MODEL_4_0, label: this.$t('seedream.model.seedream40') },

--- a/src/constants/seedream.ts
+++ b/src/constants/seedream.ts
@@ -5,6 +5,7 @@ export const SEEDREAM_LOGO = 'https://cdn.acedata.cloud/9egrbn.png';
 export const SEEDREAM_MODEL_4_0 = 'doubao-seedream-4-0-250828';
 export const SEEDREAM_MODEL_4_5 = 'doubao-seedream-4-5-251128';
 export const SEEDREAM_MODEL_5_0 = 'doubao-seedream-5-0-260128';
+export const SEEDREAM_MODEL_5_0_PRO = 'doubao-seedream-5-0-pro-260628';
 export const SEEDREAM_MODEL_3_0_T2I = 'doubao-seedream-3-0-t2i-250415';
 export const SEEDREAM_MODEL_SEEDEDIT_3_0_I2I = 'doubao-seededit-3-0-i2i-250628';
 
@@ -57,6 +58,7 @@ export const SEEDREAM_MAX_IMAGES_LIMIT = 15;
 export const SEEDREAM_DEFAULT_MAX_IMAGES = 1;
 
 export const SEEDREAM_MODEL_FULL_TO_SHORT: Record<string, string> = {
+  [SEEDREAM_MODEL_5_0_PRO]: 'doubao-seedream-5.0-pro',
   [SEEDREAM_MODEL_5_0]: 'doubao-seedream-5.0',
   [SEEDREAM_MODEL_4_5]: 'doubao-seedream-4.5',
   [SEEDREAM_MODEL_4_0]: 'doubao-seedream-4.0',

--- a/src/i18n/ar/seedream.json
+++ b/src/i18n/ar/seedream.json
@@ -167,6 +167,10 @@
     "message": "doubao-seedream-5.0",
     "description": "خيار نموذج SeeDream 5.0 (يدعم توليد الصور المتسلسلة والإخراج المتدفق)"
   },
+  "model.seedream50pro": {
+    "message": "doubao-seedream-5.0-pro",
+    "description": "SeeDream 5.0 Pro model option (flagship single image; no image sets / streaming / web search)"
+  },
   "name.maxImages": {
     "message": "عدد الصور",
     "description": "عدد الصور التي يتم توليدها في مجموعة الصور (max_images)"

--- a/src/i18n/de/seedream.json
+++ b/src/i18n/de/seedream.json
@@ -167,6 +167,10 @@
     "message": "doubao-seedream-5.0",
     "description": "Option für das SeeDream 5.0 Modell (unterstützt Gruppenbilder und Streaming-Ausgabe)"
   },
+  "model.seedream50pro": {
+    "message": "doubao-seedream-5.0-pro",
+    "description": "SeeDream 5.0 Pro model option (flagship single image; no image sets / streaming / web search)"
+  },
   "name.maxImages": {
     "message": "Anzahl der Bilder",
     "description": "Anzahl der Bilder bei der Erstellung von Gruppenbildern (max_images)"

--- a/src/i18n/el/seedream.json
+++ b/src/i18n/el/seedream.json
@@ -167,6 +167,10 @@
     "message": "doubao-seedream-5.0",
     "description": "Επιλογή μοντέλου SeeDream 5.0 (υποστηρίζει ομαδική και ροή εξόδου)"
   },
+  "model.seedream50pro": {
+    "message": "doubao-seedream-5.0-pro",
+    "description": "SeeDream 5.0 Pro model option (flagship single image; no image sets / streaming / web search)"
+  },
   "name.maxImages": {
     "message": "Αριθμός εικόνων",
     "description": "Αριθμός εικόνων για ομαδική δημιουργία (max_images)"

--- a/src/i18n/en/seedream.json
+++ b/src/i18n/en/seedream.json
@@ -167,6 +167,10 @@
     "message": "doubao-seedream-5.0",
     "description": "SeeDream 5.0 model option (supports image sets and streaming output)"
   },
+  "model.seedream50pro": {
+    "message": "doubao-seedream-5.0-pro",
+    "description": "SeeDream 5.0 Pro model option (flagship single image; no image sets / streaming / web search)"
+  },
   "name.maxImages": {
     "message": "Number of Images",
     "description": "Number of images for generating image sets (max_images)"

--- a/src/i18n/es/seedream.json
+++ b/src/i18n/es/seedream.json
@@ -167,6 +167,10 @@
     "message": "doubao-seedream-5.0",
     "description": "Opción de modelo SeeDream 5.0 (soporta generación de imágenes en grupo y salida en flujo)"
   },
+  "model.seedream50pro": {
+    "message": "doubao-seedream-5.0-pro",
+    "description": "SeeDream 5.0 Pro model option (flagship single image; no image sets / streaming / web search)"
+  },
   "name.maxImages": {
     "message": "Número de imágenes",
     "description": "Número de imágenes generadas en grupo (max_images)"

--- a/src/i18n/fi/seedream.json
+++ b/src/i18n/fi/seedream.json
@@ -167,6 +167,10 @@
     "message": "doubao-seedream-5.0",
     "description": "SeeDream 5.0 mallivaihtoehto (tukee sarjakuvia ja jatkuvaa tuotantoa)"
   },
+  "model.seedream50pro": {
+    "message": "doubao-seedream-5.0-pro",
+    "description": "SeeDream 5.0 Pro model option (flagship single image; no image sets / streaming / web search)"
+  },
   "name.maxImages": {
     "message": "Kuvien määrä",
     "description": "Sarjakuvien luontiin käytettävien kuvien määrä (max_images)"

--- a/src/i18n/fr/seedream.json
+++ b/src/i18n/fr/seedream.json
@@ -167,6 +167,10 @@
     "message": "doubao-seedream-5.0",
     "description": "Option de modèle SeeDream 5.0 (prend en charge la génération d'images en série et la sortie en continu)"
   },
+  "model.seedream50pro": {
+    "message": "doubao-seedream-5.0-pro",
+    "description": "SeeDream 5.0 Pro model option (flagship single image; no image sets / streaming / web search)"
+  },
   "name.maxImages": {
     "message": "Nombre d'images",
     "description": "Nombre d'images générées pour la série d'images (max_images)"

--- a/src/i18n/it/seedream.json
+++ b/src/i18n/it/seedream.json
@@ -167,6 +167,10 @@
     "message": "doubao-seedream-5.0",
     "description": "Opzione modello SeeDream 5.0 (supporta output a gruppi e in streaming)"
   },
+  "model.seedream50pro": {
+    "message": "doubao-seedream-5.0-pro",
+    "description": "SeeDream 5.0 Pro model option (flagship single image; no image sets / streaming / web search)"
+  },
   "name.maxImages": {
     "message": "Numero di immagini",
     "description": "Numero di immagini generate in un gruppo (max_images)"

--- a/src/i18n/ja/seedream.json
+++ b/src/i18n/ja/seedream.json
@@ -167,6 +167,10 @@
     "message": "doubao-seedream-5.0",
     "description": "SeeDream 5.0 モデルオプション（グループ画像とストリーミング出力をサポート）"
   },
+  "model.seedream50pro": {
+    "message": "doubao-seedream-5.0-pro",
+    "description": "SeeDream 5.0 Pro model option (flagship single image; no image sets / streaming / web search)"
+  },
   "name.maxImages": {
     "message": "画像枚数",
     "description": "グループ画像生成の画像枚数（max_images）"

--- a/src/i18n/ko/seedream.json
+++ b/src/i18n/ko/seedream.json
@@ -167,6 +167,10 @@
     "message": "doubao-seedream-5.0",
     "description": "SeeDream 5.0 모델 옵션 (그룹 이미지 및 스트리밍 출력 지원)"
   },
+  "model.seedream50pro": {
+    "message": "doubao-seedream-5.0-pro",
+    "description": "SeeDream 5.0 Pro model option (flagship single image; no image sets / streaming / web search)"
+  },
   "name.maxImages": {
     "message": "이미지 수",
     "description": "그룹 이미지 생성의 이미지 수 (max_images)"

--- a/src/i18n/pl/seedream.json
+++ b/src/i18n/pl/seedream.json
@@ -167,6 +167,10 @@
     "message": "doubao-seedream-5.0",
     "description": "Opcja modelu SeeDream 5.0 (obsługuje generowanie serii i strumieniowe wyjście)"
   },
+  "model.seedream50pro": {
+    "message": "doubao-seedream-5.0-pro",
+    "description": "SeeDream 5.0 Pro model option (flagship single image; no image sets / streaming / web search)"
+  },
   "name.maxImages": {
     "message": "Liczba obrazów",
     "description": "Liczba obrazów generowanych w serii (max_images)"

--- a/src/i18n/pt/seedream.json
+++ b/src/i18n/pt/seedream.json
@@ -167,6 +167,10 @@
     "message": "doubao-seedream-5.0",
     "description": "Opção de modelo SeeDream 5.0 (suporta geração de imagens em grupo e saída contínua)"
   },
+  "model.seedream50pro": {
+    "message": "doubao-seedream-5.0-pro",
+    "description": "SeeDream 5.0 Pro model option (flagship single image; no image sets / streaming / web search)"
+  },
   "name.maxImages": {
     "message": "Número de Imagens",
     "description": "Número de imagens geradas em grupo (max_images)"

--- a/src/i18n/ru/seedream.json
+++ b/src/i18n/ru/seedream.json
@@ -167,6 +167,10 @@
     "message": "doubao-seedream-5.0",
     "description": "Опция модели SeeDream 5.0 (поддерживает групповые и потоковые выводы)"
   },
+  "model.seedream50pro": {
+    "message": "doubao-seedream-5.0-pro",
+    "description": "SeeDream 5.0 Pro model option (flagship single image; no image sets / streaming / web search)"
+  },
   "name.maxImages": {
     "message": "Количество изображений",
     "description": "Количество изображений для групповой генерации (max_images)"

--- a/src/i18n/sr/seedream.json
+++ b/src/i18n/sr/seedream.json
@@ -167,6 +167,10 @@
     "message": "doubao-seedream-5.0",
     "description": "Opcija modela SeeDream 5.0 (podržava grupne slike i kontinuirani izlaz)"
   },
+  "model.seedream50pro": {
+    "message": "doubao-seedream-5.0-pro",
+    "description": "SeeDream 5.0 Pro model option (flagship single image; no image sets / streaming / web search)"
+  },
   "name.maxImages": {
     "message": "Broj slika",
     "description": "Broj slika generisanih u grupi (max_images)"

--- a/src/i18n/sv/seedream.json
+++ b/src/i18n/sv/seedream.json
@@ -167,6 +167,10 @@
     "message": "doubao-seedream-5.0",
     "description": "Val av SeeDream 5.0-modell (stöder bildserie och strömmande utdata)"
   },
+  "model.seedream50pro": {
+    "message": "doubao-seedream-5.0-pro",
+    "description": "SeeDream 5.0 Pro model option (flagship single image; no image sets / streaming / web search)"
+  },
   "name.maxImages": {
     "message": "Antal bilder",
     "description": "Antal bilder som genereras i en bildserie (max_images)"

--- a/src/i18n/uk/seedream.json
+++ b/src/i18n/uk/seedream.json
@@ -167,6 +167,10 @@
     "message": "doubao-seedream-5.0",
     "description": "Опція моделі SeeDream 5.0 (підтримує групові зображення та потоковий вихід)"
   },
+  "model.seedream50pro": {
+    "message": "doubao-seedream-5.0-pro",
+    "description": "SeeDream 5.0 Pro model option (flagship single image; no image sets / streaming / web search)"
+  },
   "name.maxImages": {
     "message": "Кількість зображень",
     "description": "Кількість зображень для генерації групи (max_images)"

--- a/src/i18n/zh-CN/seedream.json
+++ b/src/i18n/zh-CN/seedream.json
@@ -167,6 +167,10 @@
     "message": "doubao-seedream-5.0",
     "description": "SeeDream 5.0 模型选项（支持组图与流式输出）"
   },
+  "model.seedream50pro": {
+    "message": "doubao-seedream-5.0-pro",
+    "description": "SeeDream 5.0 Pro 模型选项（旗舰单图，不支持组图/流式/联网）"
+  },
   "name.maxImages": {
     "message": "图片张数",
     "description": "组图生成的图片张数（max_images）"

--- a/src/i18n/zh-TW/seedream.json
+++ b/src/i18n/zh-TW/seedream.json
@@ -167,6 +167,10 @@
     "message": "doubao-seedream-5.0",
     "description": "SeeDream 5.0 模型選項（支持組圖與流式輸出）"
   },
+  "model.seedream50pro": {
+    "message": "doubao-seedream-5.0-pro",
+    "description": "SeeDream 5.0 Pro model option (flagship single image; no image sets / streaming / web search)"
+  },
   "name.maxImages": {
     "message": "圖片張數",
     "description": "組圖生成的圖片張數（max_images）"

--- a/src/utils/seedream/capabilities.ts
+++ b/src/utils/seedream/capabilities.ts
@@ -16,6 +16,7 @@ import {
   SEEDREAM_MODEL_4_0,
   SEEDREAM_MODEL_4_5,
   SEEDREAM_MODEL_5_0,
+  SEEDREAM_MODEL_5_0_PRO,
   SEEDREAM_MODEL_SEEDEDIT_3_0_I2I,
   SEEDREAM_SIZE_1K,
   SEEDREAM_SIZE_2K,
@@ -69,6 +70,21 @@ const FALLBACK: ISeedreamCapability = {
 /** Return the support matrix for a given model. */
 export function getSeedreamCapabilities(model?: string): ISeedreamCapability {
   switch (model) {
+    case SEEDREAM_MODEL_5_0_PRO:
+      // 5.0 Pro: flagship single-image. Size presets 1K/2K only. No group
+      // generation / stream / web_search tools. Supports output_format.
+      return {
+        image: true,
+        imageRequired: false,
+        sizeTiers: [SEEDREAM_SIZE_1K, SEEDREAM_SIZE_2K],
+        sizeAdaptive: true,
+        sizePixel: true,
+        groupGeneration: false,
+        seed: false,
+        guidanceScale: false,
+        outputFormat: true,
+        tools: false
+      };
     case SEEDREAM_MODEL_5_0:
       // 5.0-lite: tier presets 2K/3K/4K (no 1K — min ~3.7M pixels).
       return {


### PR DESCRIPTION
Add **Seedream 5.0 Pro** (`doubao-seedream-5-0-pro-260628`) to the Studio Seedream config.

## Changes
- `constants/seedream.ts`: `SEEDREAM_MODEL_5_0_PRO` + full→dot short map (`doubao-seedream-5.0-pro`) so the price panel resolves the display rule.
- `utils/seedream/capabilities.ts`: Pro capability matrix — image ✓, size tiers 1K/2K, output_format ✓; group/seed/guidance/tools ✗.
- `components/seedream/config/ModelSelector.vue`: add Pro option (top).
- i18n: `model.seedream50pro` in all 17 locales (coverage guard passes).

Pairs with PlatformBackend pricing + PlatformService worker PRs.

## 🤖 对抗评审
Feature is additive UI wiring around the existing Seedream config; the money path lives in PlatformBackend/PlatformService (reviewed there — VERDICT: CLEAN). i18n coverage guard run locally: `17 locale(s) × 44 namespace(s) all match zh-CN`. Type-check clean. **VERDICT: CLEAN.**