### PR TITLE
feat(usage): show credential name for each usage record

### DIFF
--- a/change/@acedatacloud-nexior-e28127b5f603.json
+++ b/change/@acedatacloud-nexior-e28127b5f603.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "show credential name for each usage record",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/i18n/ar/usage.json
+++ b/src/i18n/ar/usage.json
@@ -19,6 +19,10 @@
     "message": "API",
     "description": "API المستدعاة، لا حاجة للترجمة"
   },
+  "field.credential": {
+    "message": "بيانات الاعتماد",
+    "description": "The API key (credential) that generated this usage record."
+  },
   "field.usedAmount": {
     "message": "الكمية المستخدمة",
     "description": "عدد الموارد المستخدمة."

--- a/src/i18n/de/usage.json
+++ b/src/i18n/de/usage.json
@@ -19,6 +19,10 @@
     "message": "API",
     "description": "Aufgerufene API, keine Übersetzung erforderlich."
   },
+  "field.credential": {
+    "message": "Zugangsdaten",
+    "description": "The API key (credential) that generated this usage record."
+  },
   "field.usedAmount": {
     "message": "Verwendete Menge",
     "description": "Menge der verwendeten Ressourcen."

--- a/src/i18n/el/usage.json
+++ b/src/i18n/el/usage.json
@@ -19,6 +19,10 @@
     "message": "API",
     "description": "Ο καλούμενος API, δεν χρειάζεται μετάφραση"
   },
+  "field.credential": {
+    "message": "Διαπιστευτήριο",
+    "description": "The API key (credential) that generated this usage record."
+  },
   "field.usedAmount": {
     "message": "Χρησιμοποιημένη ποσότητα",
     "description": "Η ποσότητα των πόρων που έχουν χρησιμοποιηθεί."

--- a/src/i18n/en/usage.json
+++ b/src/i18n/en/usage.json
@@ -19,6 +19,10 @@
     "message": "API",
     "description": "The called API, no translation needed."
   },
+  "field.credential": {
+    "message": "Credential ID",
+    "description": "The API key (credential) that generated this usage record."
+  },
   "field.usedAmount": {
     "message": "Used Amount",
     "description": "The amount of resources used."

--- a/src/i18n/es/usage.json
+++ b/src/i18n/es/usage.json
@@ -19,6 +19,10 @@
     "message": "API",
     "description": "API llamada, no necesita traducción."
   },
+  "field.credential": {
+    "message": "Credencial",
+    "description": "The API key (credential) that generated this usage record."
+  },
   "field.usedAmount": {
     "message": "Cantidad utilizada",
     "description": "Cantidad de recursos utilizados."

--- a/src/i18n/fi/usage.json
+++ b/src/i18n/fi/usage.json
@@ -19,6 +19,10 @@
     "message": "API",
     "description": "Käytetty API, ei tarvitse kääntää."
   },
+  "field.credential": {
+    "message": "Tunnistetieto",
+    "description": "The API key (credential) that generated this usage record."
+  },
   "field.usedAmount": {
     "message": "Käytetty määrä",
     "description": "Käytettyjen resurssien määrä."

--- a/src/i18n/fr/usage.json
+++ b/src/i18n/fr/usage.json
@@ -19,6 +19,10 @@
     "message": "API",
     "description": "API appelée, pas besoin de traduction"
   },
+  "field.credential": {
+    "message": "Identifiant",
+    "description": "The API key (credential) that generated this usage record."
+  },
   "field.usedAmount": {
     "message": "Quantité utilisée",
     "description": "Quantité de ressources utilisées."

--- a/src/i18n/it/usage.json
+++ b/src/i18n/it/usage.json
@@ -19,6 +19,10 @@
     "message": "API",
     "description": "API chiamata, non necessita di traduzione"
   },
+  "field.credential": {
+    "message": "Credenziale",
+    "description": "The API key (credential) that generated this usage record."
+  },
   "field.usedAmount": {
     "message": "Quantità utilizzata",
     "description": "Quantità di risorse utilizzate."

--- a/src/i18n/ja/usage.json
+++ b/src/i18n/ja/usage.json
@@ -19,6 +19,10 @@
     "message": "API",
     "description": "呼び出されたAPI、翻訳不要"
   },
+  "field.credential": {
+    "message": "認証情報",
+    "description": "The API key (credential) that generated this usage record."
+  },
   "field.usedAmount": {
     "message": "使用済み数量",
     "description": "使用されたリソースの数量。"

--- a/src/i18n/ko/usage.json
+++ b/src/i18n/ko/usage.json
@@ -19,6 +19,10 @@
     "message": "API",
     "description": "호출된 API, 번역할 필요 없음"
   },
+  "field.credential": {
+    "message": "자격 증명",
+    "description": "The API key (credential) that generated this usage record."
+  },
   "field.usedAmount": {
     "message": "사용된 수량",
     "description": "사용된 자원의 수량입니다."

--- a/src/i18n/pl/usage.json
+++ b/src/i18n/pl/usage.json
@@ -19,6 +19,10 @@
     "message": "API",
     "description": "Wywołane API, nie wymaga tłumaczenia."
   },
+  "field.credential": {
+    "message": "Poświadczenie",
+    "description": "The API key (credential) that generated this usage record."
+  },
   "field.usedAmount": {
     "message": "Zużyta ilość",
     "description": "Ilość zużytych zasobów."

--- a/src/i18n/pt/usage.json
+++ b/src/i18n/pt/usage.json
@@ -19,6 +19,10 @@
     "message": "API",
     "description": "API chamada, sem necessidade de tradução."
   },
+  "field.credential": {
+    "message": "Credencial",
+    "description": "The API key (credential) that generated this usage record."
+  },
   "field.usedAmount": {
     "message": "Quantidade utilizada",
     "description": "Quantidade de recursos utilizados."

--- a/src/i18n/ru/usage.json
+++ b/src/i18n/ru/usage.json
@@ -19,6 +19,10 @@
     "message": "API",
     "description": "Вызванный API, перевод не требуется"
   },
+  "field.credential": {
+    "message": "Учётные данные",
+    "description": "The API key (credential) that generated this usage record."
+  },
   "field.usedAmount": {
     "message": "Использованное количество",
     "description": "Количество использованных ресурсов."

--- a/src/i18n/sr/usage.json
+++ b/src/i18n/sr/usage.json
@@ -19,6 +19,10 @@
     "message": "API",
     "description": "Pozvani API, ne treba prevoditi"
   },
+  "field.credential": {
+    "message": "Креденцијал",
+    "description": "The API key (credential) that generated this usage record."
+  },
   "field.usedAmount": {
     "message": "Količina korišćena",
     "description": "Količina korišćenih resursa."

--- a/src/i18n/sv/usage.json
+++ b/src/i18n/sv/usage.json
@@ -19,6 +19,10 @@
     "message": "API",
     "description": "Det anropade API:et, ingen översättning behövs."
   },
+  "field.credential": {
+    "message": "Autentiseringsuppgift",
+    "description": "The API key (credential) that generated this usage record."
+  },
   "field.usedAmount": {
     "message": "Använd mängd",
     "description": "Mängden resurser som har använts."

--- a/src/i18n/uk/usage.json
+++ b/src/i18n/uk/usage.json
@@ -19,6 +19,10 @@
     "message": "API",
     "description": "Викликаний API, без перекладу"
   },
+  "field.credential": {
+    "message": "Облікові дані",
+    "description": "The API key (credential) that generated this usage record."
+  },
   "field.usedAmount": {
     "message": "Використана кількість",
     "description": "Кількість використаних ресурсів."

--- a/src/i18n/zh-CN/usage.json
+++ b/src/i18n/zh-CN/usage.json
@@ -19,6 +19,10 @@
     "message": "API",
     "description": "调用的API，无需翻译"
   },
+  "field.credential": {
+    "message": "凭证 ID",
+    "description": "生成该使用记录的 API 密钥（凭证）。"
+  },
   "field.usedAmount": {
     "message": "已使用数量",
     "description": "使用的资源数量。"

--- a/src/i18n/zh-TW/usage.json
+++ b/src/i18n/zh-TW/usage.json
@@ -19,6 +19,10 @@
     "message": "API",
     "description": "調用的API，無需翻譯"
   },
+  "field.credential": {
+    "message": "憑證",
+    "description": "生成该使用记录的 API 密钥（凭证）。"
+  },
   "field.usedAmount": {
     "message": "已使用數量",
     "description": "使用的資源數量。"

--- a/src/models/usage.ts
+++ b/src/models/usage.ts
@@ -1,8 +1,15 @@
 import { IService } from './service';
 
+export interface IUsageCredential {
+  id?: string;
+  name?: string;
+}
+
 export interface IApiUsage {
   id?: string;
   api_id?: string;
+  credential_id?: string;
+  credential?: IUsageCredential;
   status_code?: number;
   elapsed?: number;
   trace_id?: string;
@@ -25,6 +32,8 @@ export type IApiUsageDetailResponse = IApiUsage;
 export interface IProxyUsage {
   id?: string;
   proxy_id?: string;
+  credential_id?: string;
+  credential?: IUsageCredential;
   elapsed?: number;
   trace_id?: string;
   created_at?: string;

--- a/src/pages/console/usage/List.vue
+++ b/src/pages/console/usage/List.vue
@@ -302,6 +302,22 @@
                   </span>
                 </template>
               </el-table-column>
+              <el-table-column
+                prop="credential_id"
+                :label="$t('usage.field.credential')"
+                width="200px"
+                class-name="text-center"
+              >
+                <template #default="scope">
+                  <span class="key">{{ getCredentialLabel(scope.row) }}</span>
+                  <span v-if="scope.row.credential?.id || scope.row.credential_id" class="cursor-pointer">
+                    <copy-to-clipboard
+                      :content="scope.row.credential?.id || scope.row.credential_id"
+                      class="inline-block"
+                    />
+                  </span>
+                </template>
+              </el-table-column>
               <el-table-column :label="$t('usage.field.createdAt')" width="200px">
                 <template #default="scope">
                   <span class="created-at">{{ $dayjs.format(scope.row.created_at) }}</span>
@@ -358,6 +374,22 @@
                   <el-tag v-for="(name, key) in scope.row.metadata" :key="key" class="mb-2">
                     {{ key }}: {{ name }}
                   </el-tag>
+                </template>
+              </el-table-column>
+              <el-table-column
+                prop="credential_id"
+                :label="$t('usage.field.credential')"
+                width="200px"
+                class-name="text-center"
+              >
+                <template #default="scope">
+                  <span class="key">{{ getCredentialLabel(scope.row) }}</span>
+                  <span v-if="scope.row.credential?.id || scope.row.credential_id" class="cursor-pointer">
+                    <copy-to-clipboard
+                      :content="scope.row.credential?.id || scope.row.credential_id"
+                      class="inline-block"
+                    />
+                  </span>
                 </template>
               </el-table-column>
               <el-table-column :label="$t('usage.field.createdAt')" width="200px">
@@ -1014,6 +1046,12 @@ export default defineComponent({
         result[key] = value;
       }
       return result;
+    },
+    getCredentialLabel(usage: IApiUsage | IProxyUsage) {
+      const name = usage.credential?.name?.trim();
+      if (name) return name;
+      // Fall back to the full credential id (shown like the trace id column).
+      return usage.credential?.id || usage.credential_id || '-';
     },
     onShowDetail(row: IApiUsage) {
       this.detailRow = { ...row, metadata: undefined };


### PR DESCRIPTION
## What

Adds credential/token visibility to Nexior's usage list (studio.acedata.cloud) as a
dedicated **凭证 ID / Credential ID** column, placed as the **second-to-last column,
right before 使用时间 (created time)** — styled like the Trace ID column (value +
copy-to-clipboard). Shows the credential **name** when present, else the full id.
Applies to both API and Proxy tables. Nexior never had this before.

## Changes

- `src/models/usage.ts`: add `credential_id` + `credential` ({id,name}) to
  `IApiUsage` / `IProxyUsage`.
- `src/pages/console/usage/List.vue`: dedicated credential column before `createdAt`
  in both tables + `getCredentialLabel()` helper (name -> full id -> `-`).
- `src/i18n/*/usage.json`: new `field.credential` across all 18 locales; en/zh-CN =
  `Credential ID` / `凭证 ID` (coverage guard passes).
- `change/`: beachball change file.

Backend already returns `credential {id,name}` (PR #906); Nexior hits the same platform
usage API.

Companion PlatformFrontend PR: https://github.com/AceDataCloud/PlatformFrontend/pull/665

## 🤖 对抗评审

Reviewer: Codex (`codex exec --sandbox read-only`). Converged in 1 round; verified all 18
locales present, header en/zh-CN correctly = `Credential ID`/`凭证 ID`, no XSS, null handled.
