### PR TITLE
feat(white-label): 让站点可隐藏我们的品牌痕迹（View Code + About，items 10+14）

### DIFF
--- a/change/@acedatacloud-nexior-white-label-brand-hide.json
+++ b/change/@acedatacloud-nexior-white-label-brand-hide.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(white-label): let a site hide our brand traces (View Code + About) via Site.branding",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/ApiCodeButton.vue
+++ b/src/components/common/ApiCodeButton.vue
@@ -1,23 +1,25 @@
 <template>
-  <el-tooltip class="box-item" effect="dark" :content="$t('common.message.viewCodeHint')" placement="top-start">
-    <el-button
-      :type="buttonType"
-      :size="buttonSize"
-      :class="['btn-action', 'btn-api-code', buttonClass]"
-      @click.stop="onOpen"
-    >
-      <font-awesome-icon icon="fa-solid fa-code" class="mr-1" />
-      {{ $t('common.button.viewCode') }}
-    </el-button>
-  </el-tooltip>
-  <api-code-dialog
-    v-model:visible="dialogVisible"
-    method="POST"
-    :path="path"
-    :body="cleanedBody"
-    :token="resolvedToken"
-    :doc-href="docHref"
-  />
+  <template v-if="showViewCode">
+    <el-tooltip class="box-item" effect="dark" :content="$t('common.message.viewCodeHint')" placement="top-start">
+      <el-button
+        :type="buttonType"
+        :size="buttonSize"
+        :class="['btn-action', 'btn-api-code', buttonClass]"
+        @click.stop="onOpen"
+      >
+        <font-awesome-icon icon="fa-solid fa-code" class="mr-1" />
+        {{ $t('common.button.viewCode') }}
+      </el-button>
+    </el-tooltip>
+    <api-code-dialog
+      v-model:visible="dialogVisible"
+      method="POST"
+      :path="path"
+      :body="cleanedBody"
+      :token="resolvedToken"
+      :doc-href="docHref"
+    />
+  </template>
 </template>
 
 <script lang="ts">
@@ -25,6 +27,7 @@ import { defineComponent, type PropType } from 'vue';
 import { ElButton, ElTooltip } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import ApiCodeDialog from '@/components/common/ApiCodeDialog.vue';
+import { isBrandingHidden } from '@/utils';
 
 type ButtonType = '' | 'default' | 'text' | 'primary' | 'success' | 'warning' | 'info' | 'danger';
 type ButtonSize = '' | 'small' | 'default' | 'large';
@@ -129,6 +132,12 @@ export default defineComponent({
     };
   },
   computed: {
+    showViewCode(): boolean {
+      // Default: show (behavior unchanged). A reseller opts out per-site by
+      // setting Site.branding.hide_api_code === true (white-label item 14),
+      // so end users of a white-label site don't see our API host/code.
+      return !isBrandingHidden(this.$store?.state?.site, 'api_code');
+    },
     cleanedBody(): Record<string, unknown> {
       const src = (this.body || {}) as Record<string, unknown>;
       const out: Record<string, unknown> = {};

--- a/src/components/setting/About.vue
+++ b/src/components/setting/About.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="settings-list">
-    <section class="settings-item">
+    <section v-if="!brandingHidden" class="settings-item">
       <div class="settings-label">
         <p class="settings-title">{{ $t('common.settings.poweredBy') }}</p>
         <p class="settings-tip">{{ $t('common.settings.poweredByTip') }}</p>
@@ -12,7 +12,7 @@
         </a>
       </div>
     </section>
-    <section class="settings-item">
+    <section v-if="!brandingHidden" class="settings-item">
       <div class="settings-label">
         <p class="settings-title">{{ $t('common.settings.apiService') }}</p>
         <p class="settings-tip">{{ $t('common.settings.apiServiceTip') }}</p>
@@ -24,7 +24,7 @@
         </a>
       </div>
     </section>
-    <section class="settings-item">
+    <section v-if="showBuildSection" class="settings-item">
       <div class="settings-label">
         <p class="settings-title">{{ $t('common.settings.buildYourOwn') }}</p>
         <p class="settings-tip">{{ $t('common.settings.buildYourOwnTip') }}</p>
@@ -57,7 +57,8 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { faGithub } from '@fortawesome/free-brands-svg-icons';
 import { faCloud, faComments, faRocket } from '@fortawesome/free-solid-svg-icons';
 import { SETTING_TAB_SUBSITES } from '@/constants';
-import { isMainOfficial } from '@/utils';
+import { isMainOfficial, isBrandingHidden, getBrandSupportUrl } from '@/utils';
+import { ISite } from '@/models';
 
 export default defineComponent({
   name: 'AboutSetting',
@@ -75,11 +76,28 @@ export default defineComponent({
     };
   },
   computed: {
+    site(): ISite | undefined {
+      return this.$store?.state?.site;
+    },
+    brandingHidden(): boolean {
+      // White-label master switch (Site.branding.hide_powered_by). Hides the
+      // "Powered by" + "API Service" attribution. Default (unset) = show ours.
+      return isBrandingHidden(this.site, 'powered_by');
+    },
     supportUrl(): string {
-      return this.$store?.state?.site?.metadata?.support_url || 'https://platform.acedata.cloud';
+      // Reseller support link first (branding.links.support -> support_url).
+      // Only fall back to our platform when branding is NOT hidden, so a
+      // white-label site never leaks our domain.
+      return getBrandSupportUrl(this.site) || (this.brandingHidden ? '' : 'https://platform.acedata.cloud');
     },
     isMainOfficialHost(): boolean {
       return isMainOfficial();
+    },
+    showBuildSection(): boolean {
+      // Official main host shows one-click subsite build; other hosts show a
+      // "contact us" CTA. On a white-label site with no support URL there's
+      // nothing useful to show (and a "contact us" would leak us), so hide it.
+      return this.isMainOfficialHost || !this.brandingHidden || !!this.supportUrl;
     }
   },
   methods: {

--- a/src/models/site.ts
+++ b/src/models/site.ts
@@ -100,6 +100,27 @@ export interface ISiteMetadata {
   [key: string]: unknown;
 }
 
+// White-label brand chrome (PlatformBackend ``Site.branding`` column,
+// PR #919). All keys optional; an unset column means "use our default
+// brand" — default behavior is intentionally unchanged. Only an explicit
+// ``hide_* === true`` hides a surface. Backend validator lives in
+// ``app/utils/site_branding.py`` (rejects unknown keys). Consumed via
+// ``isBrandingHidden`` / ``getBrandSupportUrl`` in ``src/utils/site.ts``.
+export interface ISiteBrandingLinks {
+  support?: string;
+  docs?: string;
+  tos?: string;
+  privacy?: string;
+}
+
+export interface ISiteBranding {
+  company?: string;
+  copyright?: string;
+  hide_powered_by?: boolean;
+  hide_api_code?: boolean;
+  links?: ISiteBrandingLinks;
+}
+
 export interface ISite {
   id?: string;
   origin?: string;
@@ -116,6 +137,7 @@ export interface ISite {
   updated_at?: string;
   metadata?: ISiteMetadata;
   theme?: ISiteTheme | null;
+  branding?: ISiteBranding;
   tags?: string[];
   // Server-derived metadata for the per-field auto-translate toggle
   // (PlatformBackend PR #511/#513). When a field is in

--- a/src/utils/site.test.ts
+++ b/src/utils/site.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { getSiteOrigin, getSiteMarkupRatio, applyMarkup } from './site';
+import { getSiteOrigin, getSiteMarkupRatio, applyMarkup, isBrandingHidden, getBrandSupportUrl } from './site';
 
 /**
  * getSiteOrigin must treat desktop (Electron, app://bundle authority "bundle")
@@ -67,5 +67,41 @@ describe('applyMarkup', () => {
     expect(applyMarkup(10, -1)).toBe(10);
     expect(applyMarkup(undefined, 0.3)).toBe(0);
     expect(applyMarkup(NaN, 0.3)).toBe(0);
+  });
+});
+
+describe('isBrandingHidden', () => {
+  it('returns false when site / branding / flag is unset (default = show ours)', () => {
+    expect(isBrandingHidden(null, 'powered_by')).toBe(false);
+    expect(isBrandingHidden(undefined, 'api_code')).toBe(false);
+    expect(isBrandingHidden({} as never, 'powered_by')).toBe(false);
+    expect(isBrandingHidden({ branding: {} } as never, 'api_code')).toBe(false);
+  });
+
+  it('hides only on an explicit boolean true (not truthy coercions)', () => {
+    expect(isBrandingHidden({ branding: { hide_powered_by: true } } as never, 'powered_by')).toBe(true);
+    expect(isBrandingHidden({ branding: { hide_api_code: true } } as never, 'api_code')).toBe(true);
+    expect(isBrandingHidden({ branding: { hide_powered_by: false } } as never, 'powered_by')).toBe(false);
+    expect(isBrandingHidden({ branding: { hide_powered_by: 1 } } as never, 'powered_by')).toBe(false);
+  });
+
+  it('keys are independent', () => {
+    const site = { branding: { hide_api_code: true } } as never;
+    expect(isBrandingHidden(site, 'api_code')).toBe(true);
+    expect(isBrandingHidden(site, 'powered_by')).toBe(false);
+  });
+});
+
+describe('getBrandSupportUrl', () => {
+  it('prefers branding.links.support, then metadata.support_url, else empty', () => {
+    expect(
+      getBrandSupportUrl({
+        branding: { links: { support: 'https://a.com' } },
+        metadata: { support_url: 'https://b.com' }
+      } as never)
+    ).toBe('https://a.com');
+    expect(getBrandSupportUrl({ metadata: { support_url: 'https://b.com' } } as never)).toBe('https://b.com');
+    expect(getBrandSupportUrl({} as never)).toBe('');
+    expect(getBrandSupportUrl(null)).toBe('');
   });
 });

--- a/src/utils/site.ts
+++ b/src/utils/site.ts
@@ -61,6 +61,30 @@ export const getSiteOrigin = (site?: ISite) => {
   return host.split(':')[0];
 };
 
+/**
+ * White-label brand-hide switches. Reads `site.branding.hide_*`
+ * (PlatformBackend `Site.branding`, PR #919). Default — column unset or the
+ * flag not exactly `true` — is `false`, i.e. we keep showing our brand,
+ * matching the "unset = use our default" principle. Only an explicit `true`
+ * hides the surface.
+ */
+export const isBrandingHidden = (site: ISite | null | undefined, key: 'powered_by' | 'api_code'): boolean => {
+  const branding = site?.branding;
+  if (!branding) return false;
+  if (key === 'powered_by') return branding.hide_powered_by === true;
+  if (key === 'api_code') return branding.hide_api_code === true;
+  return false;
+};
+
+/**
+ * Resolve the reseller's support URL: `branding.links.support` first, then
+ * the legacy `metadata.support_url`. Returns '' when neither is set so
+ * callers can hide the entry instead of leaking our own domain.
+ */
+export const getBrandSupportUrl = (site?: ISite | null): string => {
+  return site?.branding?.links?.support || site?.metadata?.support_url || '';
+};
+
 // Site-wide markup ceiling, mirroring PlatformBackend
 // `app/utils/site_pricing.py` (MARKUP_RATIO_MIN/MAX). 0 = sell at platform
 // price; 5 = +500% (6x).


### PR DESCRIPTION
## 白标 · Nexior 隐藏我们的品牌痕迹（items 10 + 14）

让分销站长（站长）**能**把 Nexior 里显式点名 AceDataCloud 的地方隐藏掉——但**默认不变**：`Site.branding` 列不配置时，每个界面和今天**完全一样**（仍显示我们的品牌）。这遵循「不 override 默认仍是我们的，只提供隐藏能力」的原则。

### 改了什么

| 文件 | 作用 |
|---|---|
| `src/models/site.ts` | 新增 `ISiteBranding` / `ISiteBrandingLinks` 类型 + `ISite.branding?`（对齐 PlatformBackend `Site.branding` 列，PR #919） |
| `src/utils/site.ts` | `isBrandingHidden(site, 'powered_by'\|'api_code')` — 仅当 flag **恰为 boolean `true`** 才隐藏（`1`/truthy 不算）；`getBrandSupportUrl(site)` — `branding.links.support → metadata.support_url → ''`（末尾不回落我们的域名，白标站可隐藏而非泄露） |
| `src/components/common/ApiCodeButton.vue` | **item 14**：每次生成都出现、20+ 服务都挂的「View Code」按钮，由 `hide_api_code` 控制。**默认显示**（行为不变） |
| `src/components/setting/About.vue` | **item 10**：「Powered by（→ Nexior/GitHub）」+「API Service（→ Ace Data Cloud）」两块归 `hide_powered_by`；"Contact us" 走 `getBrandSupportUrl`，**仅未隐藏时**才回落 `platform.acedata.cloud`；白标站无 support URL 时整段「Build your own」隐藏（不留空壳、不泄露） |
| `src/utils/site.test.ts` | 6 个新 helper 单测 |

### 语义（关键）
- **默认 = 显示我们的**。只有站长显式设 `hide_* = true` 才隐藏。未配置站点零行为变化。
- **null-safe**：`branding` 字段来自尚未合并的后端 PR #919；`site`/`branding` 缺失时 helper 全部安全返回默认（不抛错）。

### 验证
- `npx vitest run src/utils/site.test.ts` → **13 passed**（含 6 新增）。
- eslint 干净；Vue LSP 无类型错误。

### 依赖
- 功能完整需后端 **PR #919**（`Site.branding` 列 + 校验器）合并；本 PR 在字段缺失时安全降级为「显示我们的」，故可独立评审/合并。

---

## 🤖 对抗评审

子代理 read-only 复审整个 diff（对照 worktree 实码 + barrel 导出 + i18n 文案 + 父组件用法 + 跑测试）。

**逐项核实为正确**：
1. **默认行为零回归** — `branding` 未配置时 `isBrandingHidden` 走 `if (!branding) return false` 短路，View Code 显示、About 两块显示、`supportUrl` 与旧表达式**逐字节相同**。
2. **null-safety** — 两个 helper 全用可选链，容忍 `null/undefined/{}/{branding:{}}`（有测试）。
3. **View Code gate** — 组件本就是 tooltip+dialog 多根 fragment，包进一个 `<template v-if>` 仍是合法 fragment；`dialogVisible` 是内部 data，无父组件 ref 依赖，隐藏按钮同时移除唯一 `onOpen` 触发，无孤儿 dialog。
4. **About 无死区/无泄露** — 追踪 `showBuildSection`/`v-else`：`supportUrl===''` 仅当 `hide_powered_by=true` 且无任何 support URL → 此时 `showBuildSection` 塌缩为 `isMainOfficialHost=false` → 整段隐藏；隐藏态下 `supportUrl` 只可能是站长/metadata 域，`platform.acedata.cloud` 回落被 `!brandingHidden` 挡住 → **无泄露**；`v-if/v-else` 保证有段必有一个按钮。
5. **hide 语义** — `=== true` 严格判等，`1`/truthy → false（有测试）。符合「默认显示，仅显式 true 隐藏」。
6. **i18n/a11y/响应式** — 唯一带品牌名的文案（`poweredByTip`/`apiServiceTip`）都在 `v-if="!brandingHidden"` 内；build 段文案品牌中性；computed 读响应式 Vuex `state.site`，站点异步加载后会重算。

**NIT（设计说明，非缺陷）**：白标站若设了 support URL，「Build your own → Contact Support」段仍会显示（`|| !!supportUrl`）——这是规格内的产品选择，文案品牌中性、按钮指向站长自己的 URL，非泄露。可与 PM 确认「Build your own」措辞是否希望出现在白标站，但无需改代码。

**VERDICT: CLEAN**（无 RISK）。
