### PR TITLE
feat(white-label): 分销分享短链不再泄露 share.acedata.cloud（item 16）

### DIFF
--- a/change/@acedatacloud-nexior-white-label-share-link.json
+++ b/change/@acedatacloud-nexior-white-label-share-link.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(white-label): keep the neutral short-URL domain on white-label distribution links (no share.acedata.cloud rebrand)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/pages/distribution/Index.vue
+++ b/src/pages/distribution/Index.vue
@@ -200,7 +200,7 @@ import { userOperator } from '@/operators';
 import QrCode from 'vue-qrcode';
 import { ROUTE_DISTRIBUTION_HISTORY, ROUTE_DISTRIBUTION_INVITEES } from '@/router';
 import { IDistributionLevel, IDistributionStatus, IUser } from '@/models';
-import { getPriceString } from '@/utils';
+import { getPriceString, isOfficial } from '@/utils';
 
 interface IData {
   invitees: IUser[];
@@ -315,7 +315,12 @@ export default defineComponent({
       const link = `${origin}?inviter_id=${this.$store.getters.user.id}`;
       try {
         const url = (await shortUrlOperator.create(link))?.data?.data?.url;
-        this.distributionLink = (url || link).replace('surl.id', 'share.acedata.cloud');
+        const short = url || link;
+        // Only rebrand the shortener domain to our `share.acedata.cloud` on
+        // first-party sites. On a white-label site keep the neutral short URL
+        // the shortener returned (surl.id) so the shared link doesn't carry
+        // our brand. `link` (the long fallback) is already same-origin.
+        this.distributionLink = isOfficial() ? short.replace('surl.id', 'share.acedata.cloud') : short;
       } catch (error) {
         this.distributionLink = link;
       }


### PR DESCRIPTION
## 白标 · 分销分享短链域名（item 16）

分销分享链接**长链**本就从 `window.location.origin` 生成（白标站的链接已指向该站），但最后一步把短链域 `surl.id` **无条件**改写成 `share.acedata.cloud`——分享出去的短链仍带我们的品牌。

**改法**：把这步改写用 `isOfficial()` gate：
- 官方站 → 仍改写为 `share.acedata.cloud`（**行为不变**）。
- 白标站 → 保留中性短链域（`surl.id`），不带我们品牌。
- 目的地两者一致（都 302 到同一 origin），仅分享出去的字符串不同。

`src/pages/distribution/Index.vue` `onGenerateDistributionLink()`：`isOfficial() ? short.replace('surl.id','share.acedata.cloud') : short`。

### 验证
- eslint 干净；`get_errors` 无类型错误；改动仅 1 行逻辑 + import。

### 对抗评审（trivial）
一行 gate：官方站行为逐字节不变；白标站从泄露 `share.acedata.cloud` 改为中性 `surl.id`；`isOfficial()` 是纯 host 判断无 null 风险；shortener 失败时 catch 回落长链（同源，不变）。**VERDICT: CLEAN**。