### PR TITLE
feat(auth): embed web login iframe

### DIFF
--- a/change/@acedatacloud-nexior-3e626576-726d-4c77-901f-118f918d15f3.json
+++ b/change/@acedatacloud-nexior-3e626576-726d-4c77-901f-118f918d15f3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Use embedded AuthFrontend iframe for web login.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/AuthPanel.vue
+++ b/src/components/common/AuthPanel.vue
@@ -3,7 +3,7 @@
     <div v-if="useBrowser" class="auth-native__loading">
       <p>{{ $t('common.status.loading') }}</p>
     </div>
-    <iframe v-else class="auth-native__iframe" :src="iframeUrl" frameborder="0" />
+    <iframe v-else ref="iframe" class="auth-native__iframe" :src="iframeUrl" frameborder="0" />
   </div>
   <el-dialog
     v-else
@@ -14,7 +14,7 @@
     :close-on-press-escape="false"
     :close-on-click-modal="false"
   >
-    <iframe width="360" height="560" :src="iframeUrl" frameborder="0" />
+    <iframe ref="iframe" width="360" height="560" :src="iframeUrl" frameborder="0" />
   </el-dialog>
   <el-dialog v-model="showQR" width="400px" :show-close="true">
     <qr-code
@@ -76,16 +76,24 @@ export default defineComponent({
     nativeRedirect() {
       return isDesktop() ? 'acedata-desktop' : 'com.acedatacloud.nexior';
     },
+    authOrigin() {
+      return new URL(getBaseUrlAuth()).origin;
+    },
     iframeUrl() {
-      // Trailing slash matters: `/auth/login` 301s to a cleartext `http://`
-      // URL that iOS ATS blocks, leaving this iframe blank (white screen).
-      let url = `${getBaseUrlAuth()}/auth/login/?inviter_id=${this.inviterId}`;
+      const path = this.isInAppLogin ? '/auth/login/' : '/auth/embed-login/';
+      const url = new URL(path, getBaseUrlAuth());
+      if (this.inviterId) {
+        url.searchParams.set('inviter_id', this.inviterId);
+      }
       if (this.isInAppLogin) {
-        url += `&native_redirect=${this.nativeRedirect}`;
+        url.searchParams.set('native_redirect', this.nativeRedirect);
+      } else {
+        url.searchParams.set('embed_origin', window.location.origin);
+        url.searchParams.set('provider', 'email');
       }
       // Pass `site` so the embedded AuthFrontend login form renders the
       // calling subsite's white-label logo (no-op on the main official host).
-      return withCurrentSite(url);
+      return withCurrentSite(url.toString());
     },
     inviterId() {
       // if forceInviterId is set, then use forceInviterId
@@ -118,7 +126,8 @@ export default defineComponent({
     // When the user clicks Google/GitHub, the iframe (AuthFrontend) sends a
     // postMessage asking us to open the OAuth flow in the in-app browser.
     window.addEventListener('message', async (event: MessageEvent) => {
-      if (event.origin !== getBaseUrlAuth()) {
+      const iframe = this.$refs.iframe as HTMLIFrameElement | undefined;
+      if (event.origin !== this.authOrigin || event.source !== iframe?.contentWindow) {
         return;
       }
       console.debug('received from child page', event);

--- a/src/store/common/actions.ts
+++ b/src/store/common/actions.ts
@@ -12,7 +12,7 @@ import {
 } from '@/operators';
 import { IApplication, IApplicationScope, IApplicationType, ICredential, IToken, IUser, Status } from '@/models';
 import { getSiteOrigin } from '@/utils/site';
-import { getBaseUrlAuth, getBaseUrlHub, getInviterId, loginRedirect } from '@/utils';
+import { getBaseUrlAuth, getBaseUrlHub, getBaseUrlPlatform, getInviterId, loginRedirect } from '@/utils';
 import { isNative, isDesktop } from '@/utils/surface';
 
 export const resetAll = ({ commit }: ActionContext<IRootState, IRootState>) => {
@@ -218,6 +218,27 @@ export const createCredential = async ({ commit, state }: any): Promise<ICredent
   return credential;
 };
 
+const canUseEmbeddedLogin = async (state: IRootState): Promise<boolean> => {
+  const providers = state.site?.auth?.providers;
+  if (providers && providers.email?.enabled !== true && providers.phone?.enabled !== true) {
+    return false;
+  }
+  try {
+    const controller = new AbortController();
+    const timer = window.setTimeout(() => controller.abort(), 5000);
+    const url = `${getBaseUrlPlatform()}/api/v1/site-domains/frame-ancestors?${new URLSearchParams({
+      origin: window.location.origin
+    }).toString()}`;
+    const response = await fetch(url, { headers: { accept: 'application/json' }, signal: controller.signal });
+    window.clearTimeout(timer);
+    if (!response.ok) return false;
+    const data = await response.json();
+    return data?.allowed === true && data?.origin === window.location.origin;
+  } catch {
+    return false;
+  }
+};
+
 export const login = async ({ state, commit }: ActionContext<IRootState, IRootState>) => {
   const site = state?.site?.origin;
   if (isNative() || isDesktop()) {
@@ -229,15 +250,18 @@ export const login = async ({ state, commit }: ActionContext<IRootState, IRootSt
     });
     console.debug('login popup');
   } else {
+    if (!(await canUseEmbeddedLogin(state))) {
+      commit('setAuth', {
+        flow: 'redirect'
+      });
+      loginRedirect({ redirect: window.location.pathname + window.location.search, site });
+      return;
+    }
     commit('setAuth', {
-      flow: 'redirect'
+      flow: 'popup',
+      visible: true
     });
-    console.debug('login redirect');
-    // Preserve the original query string (e.g. ?inviter_id, ?utm_source) so
-    // it survives the auth round-trip and is still present when the user
-    // lands back on Nexior. inviter_id is also forwarded as a top-level
-    // query param by loginRedirect itself.
-    loginRedirect({ redirect: window.location.pathname + window.location.search, site });
+    console.debug('login embedded iframe', site);
   }
 };
 


### PR DESCRIPTION
## Summary
- Use the existing AuthPanel iframe flow for web login instead of leaving the white-label host.
- Load AuthFrontend `/auth/embed-login/` for web, while preserving the existing native/desktop `/auth/login/` flow.
- Strictly validate `postMessage` by auth origin and exact iframe window; preflight frame-ancestor policy and email/phone provider support before embedding.
- Add the required Beachball patch change file.

## Validation
- `npx vue-tsc -b`
- `npx beachball check --no-fetch`

## Rollout
- Depends on https://github.com/AceDataCloud/PlatformBackend/pull/922 and https://github.com/AceDataCloud/AuthFrontend/pull/191.
- If either dependency is not live yet, Nexior falls back to the old redirect login flow.

## 🤖 对抗评审 (reviewer: claude-subagent, 3 round(s))
- RISK: AuthFrontend deploy before PlatformBackend locks out embedded login → 已修 (policy preflight falls back to legacy redirect login).
- RISK: Embedded flow strands OAuth-only sites in an unusable email/phone-only login UI → 已修 (preflight requires email or phone enabled, otherwise fallback).
- RISK: Production policy allows localhost ancestors to receive silent SSO tokens → 已修 (backend policy rejects localhost/local HTTP by default).
- Final re-review: `VERDICT: CLEAN`.
