### PR TITLE
chore(maestro): remove estimate/start API layer (feature retired)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,5 @@ test-results
 
 launch.json
 temp
+
+.pr_body.md

--- a/src/models/maestro.ts
+++ b/src/models/maestro.ts
@@ -12,7 +12,6 @@ export interface IMaestroConfig {
   scenario?: string; // 'auto' | 'narrated' | 'drama' | 'avatar' | 'motion' | 'captions'
   style?: string; // freeform visual hint (e.g. 'auto' | 'cinematic' | 'minimal' | 'neon' | 'corporate'); orthogonal to scenario
   voice?: string; // narration timbre: 'auto' (director picks) | a preset key (constants) | a 32-hex Fish reference_id
-  startable?: boolean; // two-phase: estimate first, park, and only generate on Start
   callback_url?: string;
 }
 
@@ -39,47 +38,11 @@ export interface IMaestroProject {
   outputs?: string[];
 }
 
-// Bottom-up cost estimate (from POST /maestro/estimates). USD is at the volume credit rate;
-// `credits` is the rate-independent figure. `upper_bound` = the HIGH band (取上限).
-export interface IMaestroEstimatePrice {
-  low?: number;
-  expected?: number;
-  high?: number;
-  upper_bound?: number;
-  currency?: string;
-  credits?: { low?: number; expected?: number; high?: number };
-  credit_to_usd?: number;
-  basis?: string; // 'live' | 'partial'
-}
-
-export interface IMaestroEstimateLine {
-  item?: string;
-  kind?: string; // 'agent' | 'api'
-  unit_credits?: number;
-  count?: number;
-  credits?: number;
-  usd?: number;
-  live_price?: boolean;
-  turns?: number | null;
-}
-
-export interface IMaestroEstimate {
-  schema?: string;
-  currency?: string;
-  price?: IMaestroEstimatePrice;
-  breakdown?: IMaestroEstimateLine[];
-  flow?: string;
-  confidence?: string; // 'high' | 'medium' | 'low'
-  assumptions?: string[];
-  risks?: string[];
-}
-
 export interface IMaestroData {
   variants?: IMaestroVariant[];
   project?: IMaestroProject;
   progress?: IMaestroProgress[];
   stage?: string;
-  estimate?: IMaestroEstimate;
 }
 
 export interface IMaestroGenerateResponse {
@@ -100,9 +63,7 @@ export interface IMaestroAgentStats {
 
 export interface IMaestroTask {
   id: string;
-  status?: string; // ... | 'estimated' (parked, awaiting Start) | 'expired'
-  phase?: string; // 'estimate' | 'generate' (two-phase tasks)
-  startable?: boolean;
+  status?: string;
   created_at?: number;
   elapsed?: number;
   request?: IMaestroGenerateRequest;
@@ -111,12 +72,6 @@ export interface IMaestroTask {
 }
 
 export type IMaestroTaskResponse = IMaestroTask;
-
-export interface IMaestroEstimateResponse {
-  success: boolean;
-  estimate_id: string;
-  trace_id?: string;
-}
 
 export interface IMaestroTasksResponse {
   count: number;

--- a/src/operators/maestro.ts
+++ b/src/operators/maestro.ts
@@ -1,8 +1,4 @@
-import axios, { AxiosResponse } from 'axios';
-import { BASE_URL_API } from '@/constants';
 import {
-  IMaestroConfig,
-  IMaestroEstimateResponse,
   IMaestroGenerateRequest,
   IMaestroGenerateResponse,
   IMaestroTaskResponse,
@@ -19,43 +15,6 @@ class MaestroOperator extends BaseTaskOperator<
 > {
   constructor() {
     super({ tasksPath: '/maestro/tasks', generatePath: '/maestro/videos' });
-  }
-
-  /**
-   * Two-phase estimate: create a cost estimate that PARKS awaiting Start (startable=true).
-   * Free (never billed) and routed through /maestro/estimates so a low-balance user can still
-   * get a quote. Returns { estimate_id } — the task appears in the task list at status
-   * `estimated` with the cost, then `start()` launches the real generation.
-   */
-  async estimate(config: IMaestroConfig, options: { token: string }): Promise<AxiosResponse<IMaestroEstimateResponse>> {
-    return axios.post(
-      '/maestro/estimates',
-      { ...config, startable: true },
-      {
-        baseURL: BASE_URL_API,
-        headers: {
-          accept: 'application/json',
-          'content-type': 'application/json',
-          authorization: `Bearer ${options.token}`
-        }
-      }
-    );
-  }
-
-  /** Launch a parked `estimated` task's generation phase (the "Start" button). */
-  async start(id: string, options: { token: string }): Promise<AxiosResponse<IMaestroTaskResponse>> {
-    return axios.post(
-      this.tasksPath,
-      { action: 'start', id },
-      {
-        baseURL: BASE_URL_API,
-        headers: {
-          accept: 'application/json',
-          'content-type': 'application/json',
-          authorization: `Bearer ${options.token}`
-        }
-      }
-    );
   }
 }
 


### PR DESCRIPTION
## What

Removes the maestro cost-estimate / two-phase "Start" API layer from Nexior. The feature is being retired — Nexior already creates videos by posting straight to `/maestro/videos`; the estimate step is gone.

- `src/operators/maestro.ts` — drop the `estimate()` (POST `/maestro/estimates`) and `start()` (POST `/maestro/tasks {action:'start'}`) methods; the operator is back to just `{ tasksPath: '/maestro/tasks', generatePath: '/maestro/videos' }`. Removed the now-unused `axios` / `AxiosResponse` / `BASE_URL_API` / `IMaestroConfig` / `IMaestroEstimateResponse` imports.
- `src/models/maestro.ts` — drop `IMaestroEstimatePrice` / `IMaestroEstimateLine` / `IMaestroEstimate` / `IMaestroEstimateResponse`, and the `startable` / `phase` / `estimate` / `estimated`-status fields.

## Safety

The estimate layer had **no UI call sites** — grep across `src` finds no component invoking `maestroOperator.estimate()`/`start()` or reading `IMaestroEstimate*` / `task.phase` / `task.startable` (the only `this.phase` hit is an unrelated codingBridge typing animation). The models barrel is `export * from './maestro'`, so nothing else imports the removed symbols. Type-check is clean.

## Follow-ups (other repos)

- PlatformService#1412 — worker endpoint removed.
- PlatformGateway#186 — drop `/maestro/estimates` from the skip-auth whitelist.
- The `/maestro/estimates` Kong route + Api object (`2a5bb4f0…`) live in the production DB (not in any repo) — needs an admin/console removal.
