### PR TITLE
feat(auth): gate web iframe login

### DIFF
--- a/change/@acedatacloud-nexior-0fec00bd-d08f-4d48-8961-2b2915fd3cbd.json
+++ b/change/@acedatacloud-nexior-0fec00bd-d08f-4d48-8961-2b2915fd3cbd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Gate web iframe login behind auth-iframe feature flag.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/AuthPanel.vue
+++ b/src/components/common/AuthPanel.vue
@@ -3,7 +3,7 @@
     <div v-if="useBrowser" class="auth-native__loading">
       <p>{{ $t('common.status.loading') }}</p>
     </div>
-    <iframe v-else class="auth-native__iframe" :src="iframeUrl" frameborder="0" />
+    <iframe v-else ref="iframe" class="auth-native__iframe" :src="iframeUrl" frameborder="0" referrerpolicy="origin" />
   </div>
   <el-dialog
     v-else
@@ -14,7 +14,7 @@
     :close-on-press-escape="false"
     :close-on-click-modal="false"
   >
-    <iframe width="360" height="560" :src="iframeUrl" frameborder="0" />
+    <iframe ref="iframe" width="360" height="560" :src="iframeUrl" frameborder="0" referrerpolicy="origin" />
   </el-dialog>
   <el-dialog v-model="showQR" width="400px" :show-close="true">
     <qr-code
@@ -34,7 +34,7 @@ import { defineComponent } from 'vue';
 import axios from 'axios';
 import { ElDialog } from 'element-plus';
 import { ElMessage } from 'element-plus';
-import { getBaseUrlAuth, withCurrentSite } from '@/utils';
+import { getBaseUrlAuth, getBaseUrlHub, withCurrentSite } from '@/utils';
 import { getCookie } from 'typescript-cookie';
 import QrCode from 'vue-qrcode';
 import { ROUTE_SETTINGS_INDEX } from '@/router';
@@ -76,16 +76,30 @@ export default defineComponent({
     nativeRedirect() {
       return isDesktop() ? 'acedata-desktop' : 'com.acedatacloud.nexior';
     },
+    authOrigin() {
+      return new URL(getBaseUrlAuth()).origin;
+    },
     iframeUrl() {
       // Trailing slash matters: `/auth/login` 301s to a cleartext `http://`
       // URL that iOS ATS blocks, leaving this iframe blank (white screen).
-      let url = `${getBaseUrlAuth()}/auth/login/?inviter_id=${this.inviterId}`;
+      const url = new URL('/auth/login/', getBaseUrlAuth());
+      if (this.inviterId) {
+        url.searchParams.set('inviter_id', this.inviterId);
+      }
       if (this.isInAppLogin) {
-        url += `&native_redirect=${this.nativeRedirect}`;
+        url.searchParams.set('native_redirect', this.nativeRedirect);
+      } else {
+        url.searchParams.set('embed_origin', window.location.origin);
+        url.searchParams.set(
+          'redirect',
+          `${getBaseUrlHub()}/auth/callback?${new URLSearchParams({
+            redirect: window.location.pathname + window.location.search
+          }).toString()}`
+        );
       }
       // Pass `site` so the embedded AuthFrontend login form renders the
       // calling subsite's white-label logo (no-op on the main official host).
-      return withCurrentSite(url);
+      return withCurrentSite(url.toString());
     },
     inviterId() {
       // if forceInviterId is set, then use forceInviterId
@@ -118,7 +132,8 @@ export default defineComponent({
     // When the user clicks Google/GitHub, the iframe (AuthFrontend) sends a
     // postMessage asking us to open the OAuth flow in the in-app browser.
     window.addEventListener('message', async (event: MessageEvent) => {
-      if (event.origin !== getBaseUrlAuth()) {
+      const iframe = this.$refs.iframe as HTMLIFrameElement | undefined;
+      if (event.origin !== this.authOrigin || event.source !== iframe?.contentWindow) {
         return;
       }
       console.debug('received from child page', event);

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -72,6 +72,7 @@ import {
 import { getCookie } from 'typescript-cookie';
 import { I18N_DEFAULT_LOCALE } from '@/constants/i18n';
 import { getLocale, setI18nLanguage } from '@/i18n';
+import { isFeatureEnabled } from '@/utils/featureFlag';
 import { updateSeo, setWebApplicationSchema, setOrganization, resetSeo } from '@/utils/seo';
 import { ensureStoreModule } from '@/store/lazy';
 import { evaluateUserIdGuard } from '@/utils/crossSiteUser';
@@ -437,7 +438,7 @@ export function setupRouterGuards(router: Router) {
     // page whose data calls 401 and spins forever. The login flow preserves the
     // intended destination so they return here after authenticating.
     if (!store.getters.authenticated && requiresLogin(to.path)) {
-      if (isNative() || isDesktop()) {
+      if (isNative() || isDesktop() || isFeatureEnabled('auth-iframe')) {
         store.dispatch('login');
       } else {
         loginRedirect({ redirect: to.fullPath });

--- a/src/store/common/actions.ts
+++ b/src/store/common/actions.ts
@@ -13,6 +13,7 @@ import {
 import { IApplication, IApplicationScope, IApplicationType, ICredential, IToken, IUser, Status } from '@/models';
 import { getSiteOrigin } from '@/utils/site';
 import { getBaseUrlAuth, getBaseUrlHub, getInviterId, loginRedirect } from '@/utils';
+import { isFeatureEnabled } from '@/utils/featureFlag';
 import { isNative, isDesktop } from '@/utils/surface';
 
 export const resetAll = ({ commit }: ActionContext<IRootState, IRootState>) => {
@@ -220,7 +221,7 @@ export const createCredential = async ({ commit, state }: any): Promise<ICredent
 
 export const login = async ({ state, commit }: ActionContext<IRootState, IRootState>) => {
   const site = state?.site?.origin;
-  if (isNative() || isDesktop()) {
+  if (isNative() || isDesktop() || isFeatureEnabled('auth-iframe')) {
     // In-app popup (iframe) login. NEVER window.location.href on desktop — an
     // app://bundle window navigated to the external auth host cannot return.
     commit('setAuth', {


### PR DESCRIPTION
## Summary
- Keep Nexior web login redirect behavior unchanged by default.
- When `?features=auth-iframe` is enabled, reuse the existing global AuthPanel iframe on web.
- Pass `embed_origin`, `site`, redirect callback, and `referrerpolicy=origin`; validate Auth origin and exact iframe source on messages.
- Make protected-route guard honor the same `auth-iframe` flag.

## Validation
- `npx eslint src/components/common/AuthPanel.vue src/store/common/actions.ts src/router/index.ts`
- `npx vue-tsc -b`
- `npx beachball check --no-fetch`
- Full `npm run lint:check` still fails on unrelated existing formatting in Navigator/TopHeader.

## Test Plan
- Default web login still redirects to Auth.
- With `?features=auth-iframe`, web login opens the existing AuthPanel modal in place.
- Native/desktop behavior remains unchanged.

## 🤖 对抗评审 (reviewer: claude-subagent, 2 round(s))
- RISK: protected routes bypassed `auth-iframe` flag → fixed in router guard.
- Final re-review: `VERDICT: CLEAN`.
