### PR TITLE
fix(auth): move iframe login into user menu

### DIFF
--- a/change/@acedatacloud-nexior-84f0b68b-6e92-458d-81f0-a2fa1f7526d8.json
+++ b/change/@acedatacloud-nexior-84f0b68b-6e92-458d-81f0-a2fa1f7526d8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Move iframe login entry into the bottom user menu.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/Navigator.vue
+++ b/src/components/common/Navigator.vue
@@ -55,17 +55,7 @@
       </div>
     </div>
     <div class="bottom">
-      <el-tooltip
-        v-if="!authenticated"
-        effect="dark"
-        :content="$t('common.button.login')"
-        :placement="direction === 'row' ? 'top' : 'right'"
-      >
-        <button class="login-button" type="button" :aria-label="$t('common.button.login').toString()" @click="onLogin">
-          <font-awesome-icon icon="fa-solid fa-user" />
-        </button>
-      </el-tooltip>
-      <user-center v-show="authenticated" />
+      <user-center />
     </div>
   </div>
 </template>
@@ -152,7 +142,6 @@ import Logo from './Logo.vue';
 import UserCenter from '@/components/user/Center.vue';
 import { isMacOS } from '@/utils/surface';
 import { desktopBridge } from '@/utils/desktop';
-import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 
 interface NavLink {
   route: { name: string };
@@ -170,8 +159,7 @@ export default defineComponent({
     ElPopover,
     Logo,
     ElTooltip,
-    UserCenter,
-    FontAwesomeIcon
+    UserCenter
   },
   props: {
     direction: {
@@ -523,9 +511,6 @@ export default defineComponent({
     onHome() {
       this.$router.push({ name: ROUTE_INDEX });
     },
-    onLogin() {
-      this.$store.dispatch('login', { redirect: this.$route.fullPath });
-    },
     onOverflowItemClick(link: { route: { name: string } }) {
       this.showOverflow = false;
       this.$router.push(link.route);
@@ -595,11 +580,6 @@ export default defineComponent({
       display: flex;
       flex: 1;
       justify-content: flex-end;
-    }
-
-    .login-button {
-      width: 36px;
-      height: 36px;
     }
   }
 
@@ -733,30 +713,6 @@ export default defineComponent({
       justify-content: flex-end;
       align-items: center;
       padding-bottom: 10px;
-    }
-  }
-
-  .login-button {
-    width: 38px;
-    height: 38px;
-    border: 0;
-    border-radius: 50%;
-    background: var(--el-color-primary);
-    color: #fff;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-    box-shadow: var(--app-shadow-xs);
-    transition:
-      transform 0.15s,
-      box-shadow 0.15s,
-      background-color 0.15s;
-
-    &:hover {
-      transform: translateY(-1px);
-      background: var(--el-color-primary-light-3);
-      box-shadow: var(--app-shadow-sm);
     }
   }
 }

--- a/src/components/user/Center.vue
+++ b/src/components/user/Center.vue
@@ -8,6 +8,10 @@
         </div>
         <el-divider v-if="user.email" class="mb-1 mt-1" />
         <el-dropdown-menu>
+          <el-dropdown-item v-if="!authenticated" class="py-2" @click="onLogin">
+            <font-awesome-icon icon="fa-solid fa-user" class="mr-2" />
+            {{ $t('common.button.login') }}
+          </el-dropdown-item>
           <el-dropdown-item v-if="!isNative" class="py-2" @click="onDownload">
             <font-awesome-icon icon="fa-solid fa-mobile-screen-button" class="mr-2" />
             {{ $t('common.nav.mobileApp') }}
@@ -29,7 +33,7 @@
             <font-awesome-icon icon="fa-solid fa-user-xmark" class="mr-2" />
             {{ $t('common.nav.deleteAccount') }}
           </el-dropdown-item>
-          <el-dropdown-item class="py-2" @click="onLogout">
+          <el-dropdown-item v-if="authenticated" class="py-2" @click="onLogout">
             <font-awesome-icon icon="fa-solid fa-arrow-right-from-bracket" class="mr-2" />
             {{ $t('common.nav.logOut') }}
           </el-dropdown-item>
@@ -76,6 +80,9 @@ export default defineComponent({
     user() {
       return this.$store.getters?.user;
     },
+    authenticated() {
+      return this.$store.getters?.authenticated;
+    },
     isNative() {
       return isNativeSurface();
     },
@@ -113,6 +120,9 @@ export default defineComponent({
     },
     async onLogout() {
       await this.$store.dispatch('logout');
+    },
+    onLogin() {
+      this.$store.dispatch('login', { redirect: this.$route.fullPath });
     },
     onDownload() {
       this.$router.push({ name: ROUTE_DOWNLOAD });


### PR DESCRIPTION
## Summary
- Remove the standalone unauthenticated bottom-left Login button from `Navigator`.
- Keep `UserCenter` mounted in the bottom nav and add Login as a guest-only menu item.
- Hide Logout for guests while preserving the existing menu entries and desktop settings event ownership.

## Validation
- `npx eslint src/components/common/Navigator.vue src/components/user/Center.vue`
- `npx vue-tsc -b`
- `npm run build`
- `git diff --check`
- `npx beachball check`
- Local smoke on `127.0.0.1:5192`: no standalone `.login-button`; bottom avatar menu contains Login; clicking Login opens the global auth iframe modal and stays in Nexior.

## 🤖 对抗评审
VERDICT: CLEAN — removes the separate Login button, moves Login into the existing user menu, keeps UserCenter mounted for desktop settings events, and reuses the same global iframe login action.