### PR TITLE
fix(auth): reload web after iframe login

### DIFF
--- a/change/@acedatacloud-nexior-6146341b-6f49-4984-9e3b-4be263ef2db3.json
+++ b/change/@acedatacloud-nexior-6146341b-6f49-4984-9e3b-4be263ef2db3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Reload after iframe login completes.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/AuthPanel.vue
+++ b/src/components/common/AuthPanel.vue
@@ -248,9 +248,6 @@ export default defineComponent({
           // white-label site owners, but skip on native/desktop where users
           // are always on the official site
           if (!isNativeSurface() && !isDesktop()) {
-            await this.$router.push({
-              name: ROUTE_SETTINGS_INDEX
-            });
             openedSettings = true;
           }
         }
@@ -263,8 +260,14 @@ export default defineComponent({
           await this.$router.push('/');
         } else {
           this.$store.commit('setAuth', { visible: false });
-          if (!openedSettings) {
-            await this.$router.push(this.redirect || '/');
+          const target = openedSettings
+            ? this.$router.resolve({ name: ROUTE_SETTINGS_INDEX }).href
+            : this.redirect || '/';
+          const targetUrl = new URL(this.resolveLocalRedirect(target), window.location.origin).toString();
+          if (targetUrl === window.location.href) {
+            window.location.reload();
+          } else {
+            window.location.href = targetUrl;
           }
         }
       }
@@ -281,6 +284,15 @@ export default defineComponent({
   methods: {
     closeWebLogin() {
       this.$store.commit('setAuth', { visible: false });
+    },
+    resolveLocalRedirect(target: string | undefined, fallback = '/') {
+      try {
+        const url = new URL(target || fallback, window.location.origin);
+        if (url.origin !== window.location.origin) return fallback;
+        return `${url.pathname}${url.search}${url.hash}`;
+      } catch {
+        return fallback;
+      }
     }
   }
 });


### PR DESCRIPTION
## Summary
- Reload or full-page navigate the web surface after iframe login succeeds, instead of using a pure Vue router push.
- Keep native/desktop login success on the existing router path to avoid reloading app shells.
- Constrain the stored redirect to same-origin paths before assigning `window.location.href`.

## Validation
- `npx eslint src/components/common/AuthPanel.vue`
- `npx vue-tsc -b`
- `npm run build`
- `git diff --check`
- `npx beachball check`

## 🤖 对抗评审
VERDICT: CLEAN — web iframe login now reloads to a normalized local target, native/desktop behavior is preserved, and redirect targets are same-origin-normalized.