### PR TITLE
fix(maestro): loosen in-progress task card row spacing

### DIFF
--- a/change/@acedatacloud-nexior-maestro-card-spacing.json
+++ b/change/@acedatacloud-nexior-maestro-card-spacing.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Loosen row spacing on the in-progress Maestro task card so the request-params list is less cramped.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/maestro/task/Preview.vue
+++ b/src/components/maestro/task/Preview.vue
@@ -41,13 +41,13 @@
           <p
             v-for="(param, pIdx) in requestParams"
             :key="`param-${pIdx}`"
-            class="text-[var(--el-text-color-regular)] text-xs mb-1"
+            class="text-[var(--el-text-color-regular)] text-xs mb-2"
             :class="{ 'mt-3': pIdx === 0 }"
           >
             <font-awesome-icon :icon="param.icon" class="mr-1" />
             {{ param.label }}: {{ param.value }}
           </p>
-          <p class="text-[var(--el-text-color-regular)] text-xs mb-1 mt-3">
+          <p class="text-[var(--el-text-color-regular)] text-xs mb-2 mt-3">
             <font-awesome-icon icon="fa-solid fa-magic" class="mr-1" />
             {{ $t('maestro.name.taskId') }}: {{ modelValue?.id }}
             <copy-to-clipboard :content="modelValue?.id!" />


### PR DESCRIPTION
## What

The Maestro **in-progress** task card renders the request-params list
(Mode / Video Type / Visual Style / Quality / Aspect Ratio / Duration /
Languages) plus the Task ID directly under the step checklist. Those rows
used `mb-1` (4px), which read as cramped, while the **success** and
**failure** cards already use `mb-2` (8px) for the same list.

## Change

Bump the processing card's param rows and Task ID row from `mb-1` → `mb-2`
so all three card states share the same, less-cramped row spacing.
Pure CSS-class change, no logic.

## 🤖 对抗评审

Trivial CSS-only spacing change (two Tailwind `mb-1` → `mb-2` swaps),
no behavioral or logic impact. **VERDICT: CLEAN** — no RISK findings.