### PR TITLE
feat(maestro): drop Motion Graphics; require source video for Captions

### DIFF
--- a/change/@acedatacloud-nexior-1621809a-530c-440d-83b9-1eea15cc5fd0.json
+++ b/change/@acedatacloud-nexior-1621809a-530c-440d-83b9-1eea15cc5fd0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Maestro: remove the Motion Graphics video type and require a source video before generating Captions",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/maestro/ConfigPanel.vue
+++ b/src/components/maestro/ConfigPanel.vue
@@ -131,6 +131,14 @@
             <p class="scenario-name">{{ $t(`maestro.option.scenario.${s}`) }}</p>
           </div>
         </div>
+        <el-alert
+          v-if="needsVideoUpload"
+          :title="$t('maestro.message.captionsNeedVideo')"
+          type="warning"
+          :closable="false"
+          show-icon
+          class="mt-2"
+        />
       </div>
 
       <!-- Style (visual direction) -->
@@ -207,6 +215,7 @@ import {
   MAESTRO_DEFAULT_QUALITY,
   MAESTRO_ALLOWED_SCENARIOS,
   MAESTRO_SCENARIO_THUMBNAILS,
+  MAESTRO_UPLOAD_REQUIRED_SCENARIOS,
   MAESTRO_DEFAULT_SCENARIO,
   MAESTRO_ALLOWED_STYLES,
   MAESTRO_DEFAULT_STYLE,
@@ -214,6 +223,7 @@ import {
   MAESTRO_DEFAULT_VOICE
 } from '@/constants';
 import { IMaestroConfig } from '@/models';
+import { isVideoUrl } from '@/utils/is';
 
 // Preview rectangle dimensions (px) for each aspect-ratio chip.
 const RATIO_PREVIEW: Record<string, { width: number; height: number }> = {
@@ -270,8 +280,14 @@ export default defineComponent({
     refTaskId(): string | undefined {
       return this.config?.ref_task_id;
     },
+    needsVideoUpload(): boolean {
+      const scenario = this.config?.scenario;
+      if (!scenario || !MAESTRO_UPLOAD_REQUIRED_SCENARIOS.includes(scenario)) return false;
+      // captions post-processes a talking-head clip, so a video (not an image/audio) must be uploaded.
+      return !(this.config?.file_urls || []).some((u) => isVideoUrl(u));
+    },
     canGenerate(): boolean {
-      return !!this.prompt?.trim();
+      return !!this.prompt?.trim() && !this.needsVideoUpload;
     },
     prompt: {
       get(): string | undefined {

--- a/src/constants/maestro.ts
+++ b/src/constants/maestro.ts
@@ -15,17 +15,18 @@ export const MAESTRO_MAX_DURATION = 600;
 // Production tier (effort/price): draft = fast preview, standard = balanced, premium = richer.
 export const MAESTRO_ALLOWED_QUALITIES = ['draft', 'standard', 'premium'];
 // Video type: a routing hint. `auto` lets the director pick; the rest bias the route.
-// Legacy values (general/explainer/product/website/changelog -> auto; slides/slideshow -> auto)
+// Legacy values (general/explainer/product/website/changelog -> auto; slides/slideshow/motion -> auto)
 // are still accepted by the API but no longer offered here.
-export const MAESTRO_ALLOWED_SCENARIOS = ['auto', 'narrated', 'drama', 'avatar', 'motion', 'captions'];
+export const MAESTRO_ALLOWED_SCENARIOS = ['auto', 'narrated', 'drama', 'avatar', 'captions'];
+// `captions` post-processes an EXISTING talking-head video, so it requires an uploaded source clip.
+export const MAESTRO_UPLOAD_REQUIRED_SCENARIOS = ['captions'];
 // Preview thumbnail per scenario — real frames from generated videos (narrated/drama/avatar/captions);
-// auto/motion stay as illustrations. Hosted on the CDN like MAESTRO_LOGO.
+// auto stays as an illustration. Hosted on the CDN like MAESTRO_LOGO.
 export const MAESTRO_SCENARIO_THUMBNAILS: Record<string, string> = {
   auto: 'https://cdn.acedata.cloud/f61b85476e.png',
   narrated: 'https://cdn.acedata.cloud/db6ef158be.jpg',
   drama: 'https://cdn.acedata.cloud/af85b29164.jpg',
   avatar: 'https://cdn.acedata.cloud/7ae3e94d5a.jpg',
-  motion: 'https://cdn.acedata.cloud/ab9dc386b6.png',
   captions: 'https://cdn.acedata.cloud/9a6d16d9f3.jpg'
 };
 // Visual style presets — each maps to a real named capability on the backend (a visual-styles

--- a/src/i18n/ar/maestro.json
+++ b/src/i18n/ar/maestro.json
@@ -231,13 +231,13 @@
     "message": "شخصية رقمية · حديث مباشر",
     "description": "خيار سيناريو شخصية / حديث مباشر"
   },
-  "option.scenario.motion": {
-    "message": "رسوم متحركة",
-    "description": "Motion graphics scenario option"
-  },
   "option.scenario.captions": {
     "message": "إضافة ترجمات",
     "description": "Add-captions scenario option"
+  },
+  "message.captionsNeedVideo": {
+    "message": "تعمل التسميات الحركية على فيديو متحدث موجود — ارفع مقطعًا في الأعلى أولًا.",
+    "description": "Warning shown when captions video type is selected but no source video is uploaded"
   },
   "name.style": {
     "message": "الأسلوب البصري",

--- a/src/i18n/de/maestro.json
+++ b/src/i18n/de/maestro.json
@@ -231,13 +231,13 @@
     "message": "Digitale Person · Sprachübertragung",
     "description": "Avatar / Talking-Head-Szenario-Option"
   },
-  "option.scenario.motion": {
-    "message": "Motion Graphics",
-    "description": "Motion graphics scenario option"
-  },
   "option.scenario.captions": {
     "message": "Untertitel hinzufügen",
     "description": "Add-captions scenario option"
+  },
+  "message.captionsNeedVideo": {
+    "message": "Kinetische Untertitel arbeiten mit einem vorhandenen Talking-Head-Video – lade oben zuerst eines hoch.",
+    "description": "Warning shown when captions video type is selected but no source video is uploaded"
   },
   "name.style": {
     "message": "Visueller Stil",

--- a/src/i18n/el/maestro.json
+++ b/src/i18n/el/maestro.json
@@ -231,13 +231,13 @@
     "message": "Ψηφιακός άνθρωπος · Ομιλία",
     "description": "Επιλογή σεναρίου με avatar / ομιλητή"
   },
-  "option.scenario.motion": {
-    "message": "Κινούμενα γραφικά",
-    "description": "Motion graphics scenario option"
-  },
   "option.scenario.captions": {
     "message": "Προσθήκη υπότιτλων",
     "description": "Add-captions scenario option"
+  },
+  "message.captionsNeedVideo": {
+    "message": "Οι κινητικοί υπότιτλοι εφαρμόζονται σε υπάρχον βίντεο ομιλητή — ανεβάστε πρώτα ένα παραπάνω.",
+    "description": "Warning shown when captions video type is selected but no source video is uploaded"
   },
   "name.style": {
     "message": "Οπτικός στυλ",

--- a/src/i18n/en/maestro.json
+++ b/src/i18n/en/maestro.json
@@ -212,7 +212,7 @@
     "description": "Video type field"
   },
   "description.scenario": {
-    "message": "Pick the kind of video to make. Auto lets Maestro decide; or force narrated footage, short drama, a talking-head avatar, motion graphics or on-screen captions.",
+    "message": "Pick the kind of video to make. Auto lets Maestro decide; or force narrated footage, short drama, a talking-head avatar, or on-screen captions.",
     "description": "Scenario field help"
   },
   "option.scenario.auto": {
@@ -231,13 +231,13 @@
     "message": "Avatar · Talking Head",
     "description": "Avatar / talking-head scenario option"
   },
-  "option.scenario.motion": {
-    "message": "Motion Graphics",
-    "description": "Motion graphics scenario option"
-  },
   "option.scenario.captions": {
     "message": "Captions · Kinetic",
     "description": "Captions scenario option (add captions/subtitles to an existing talking-head video)"
+  },
+  "message.captionsNeedVideo": {
+    "message": "Kinetic captions runs on an existing talking-head video — upload one above first.",
+    "description": "Warning shown when captions video type is selected but no source video is uploaded"
   },
   "name.style": {
     "message": "Visual Style",

--- a/src/i18n/es/maestro.json
+++ b/src/i18n/es/maestro.json
@@ -231,13 +231,13 @@
     "message": "Avatar · Locución",
     "description": "Opción de escenario de avatar / cabeza hablante"
   },
-  "option.scenario.motion": {
-    "message": "Gráficos animados",
-    "description": "Motion graphics scenario option"
-  },
   "option.scenario.captions": {
     "message": "Añadir subtítulos",
     "description": "Add-captions scenario option"
+  },
+  "message.captionsNeedVideo": {
+    "message": "Los subtítulos cinéticos funcionan sobre un vídeo de locutor existente: sube uno arriba primero.",
+    "description": "Warning shown when captions video type is selected but no source video is uploaded"
   },
   "name.style": {
     "message": "Estilo visual",

--- a/src/i18n/fi/maestro.json
+++ b/src/i18n/fi/maestro.json
@@ -231,13 +231,13 @@
     "message": "Digitaalinen henkilö · Puhe",
     "description": "Avatar / puhuva pää -skenaario vaihtoehto"
   },
-  "option.scenario.motion": {
-    "message": "Liikegrafiikka",
-    "description": "Motion graphics scenario option"
-  },
   "option.scenario.captions": {
     "message": "Lisää tekstitykset",
     "description": "Add-captions scenario option"
+  },
+  "message.captionsNeedVideo": {
+    "message": "Kineettiset tekstitykset toimivat olemassa olevaan puhujavideoon — lataa ensin video yllä.",
+    "description": "Warning shown when captions video type is selected but no source video is uploaded"
   },
   "name.style": {
     "message": "Visuaalinen tyyli",

--- a/src/i18n/fr/maestro.json
+++ b/src/i18n/fr/maestro.json
@@ -231,13 +231,13 @@
     "message": "Avatar · Présentation orale",
     "description": "Option de scénario avatar / tête parlante"
   },
-  "option.scenario.motion": {
-    "message": "Motion design",
-    "description": "Motion graphics scenario option"
-  },
   "option.scenario.captions": {
     "message": "Ajouter des sous-titres",
     "description": "Add-captions scenario option"
+  },
+  "message.captionsNeedVideo": {
+    "message": "Les sous-titres cinétiques s'appliquent à une vidéo de présentateur existante — importez-en une ci-dessus d'abord.",
+    "description": "Warning shown when captions video type is selected but no source video is uploaded"
   },
   "name.style": {
     "message": "Style visuel",

--- a/src/i18n/it/maestro.json
+++ b/src/i18n/it/maestro.json
@@ -231,13 +231,13 @@
     "message": "Persona digitale · Voce narrante",
     "description": "Opzione scenario avatar / testa parlante"
   },
-  "option.scenario.motion": {
-    "message": "Grafica animata",
-    "description": "Motion graphics scenario option"
-  },
   "option.scenario.captions": {
     "message": "Aggiungi sottotitoli",
     "description": "Add-captions scenario option"
+  },
+  "message.captionsNeedVideo": {
+    "message": "I sottotitoli cinetici lavorano su un video con volto parlante esistente: caricane uno sopra prima.",
+    "description": "Warning shown when captions video type is selected but no source video is uploaded"
   },
   "name.style": {
     "message": "Stile visivo",

--- a/src/i18n/ja/maestro.json
+++ b/src/i18n/ja/maestro.json
@@ -231,13 +231,13 @@
     "message": "デジタル人 · ナレーション",
     "description": "アバター / トーキングヘッドシナリオオプション"
   },
-  "option.scenario.motion": {
-    "message": "モーショングラフィックス",
-    "description": "Motion graphics scenario option"
-  },
   "option.scenario.captions": {
     "message": "字幕を追加",
     "description": "Add-captions scenario option"
+  },
+  "message.captionsNeedVideo": {
+    "message": "キネティック字幕は既存のトーキングヘッド動画に適用します。まず上で動画をアップロードしてください。",
+    "description": "Warning shown when captions video type is selected but no source video is uploaded"
   },
   "name.style": {
     "message": "ビジュアルスタイル",

--- a/src/i18n/ko/maestro.json
+++ b/src/i18n/ko/maestro.json
@@ -231,13 +231,13 @@
     "message": "디지털 사람 · 구술",
     "description": "아바타 / 토킹 헤드 시나리오 옵션"
   },
-  "option.scenario.motion": {
-    "message": "모션 그래픽",
-    "description": "Motion graphics scenario option"
-  },
   "option.scenario.captions": {
     "message": "자막 추가",
     "description": "Add-captions scenario option"
+  },
+  "message.captionsNeedVideo": {
+    "message": "키네틱 자막은 기존 토킹헤드 영상에 적용됩니다. 먼저 위에서 영상을 업로드하세요.",
+    "description": "Warning shown when captions video type is selected but no source video is uploaded"
   },
   "name.style": {
     "message": "시각적 스타일",

--- a/src/i18n/pl/maestro.json
+++ b/src/i18n/pl/maestro.json
@@ -231,13 +231,13 @@
     "message": "Cyfrowa postać · Mówca",
     "description": "Opcja scenariusza z awatarem / mówiącą głową"
   },
-  "option.scenario.motion": {
-    "message": "Grafika ruchoma",
-    "description": "Motion graphics scenario option"
-  },
   "option.scenario.captions": {
     "message": "Dodaj napisy",
     "description": "Add-captions scenario option"
+  },
+  "message.captionsNeedVideo": {
+    "message": "Napisy kinetyczne działają na istniejącym filmie z mówiącą osobą — najpierw prześlij go powyżej.",
+    "description": "Warning shown when captions video type is selected but no source video is uploaded"
   },
   "name.style": {
     "message": "Styl wizualny",

--- a/src/i18n/pt/maestro.json
+++ b/src/i18n/pt/maestro.json
@@ -231,13 +231,13 @@
     "message": "Avatar · Apresentação",
     "description": "Opção de cenário de avatar / apresentador"
   },
-  "option.scenario.motion": {
-    "message": "Motion graphics",
-    "description": "Motion graphics scenario option"
-  },
   "option.scenario.captions": {
     "message": "Adicionar legendas",
     "description": "Add-captions scenario option"
+  },
+  "message.captionsNeedVideo": {
+    "message": "As legendas cinéticas funcionam sobre um vídeo de locutor existente — envie um acima primeiro.",
+    "description": "Warning shown when captions video type is selected but no source video is uploaded"
   },
   "name.style": {
     "message": "Estilo visual",

--- a/src/i18n/ru/maestro.json
+++ b/src/i18n/ru/maestro.json
@@ -231,13 +231,13 @@
     "message": "Цифровой человек · Озвучка",
     "description": "Опция сценария с аватаром / говорящей головой"
   },
-  "option.scenario.motion": {
-    "message": "Моушн-графика",
-    "description": "Motion graphics scenario option"
-  },
   "option.scenario.captions": {
     "message": "Добавить субтитры",
     "description": "Add-captions scenario option"
+  },
+  "message.captionsNeedVideo": {
+    "message": "Кинетические субтитры работают с уже существующим видео с говорящим — сначала загрузите его выше.",
+    "description": "Warning shown when captions video type is selected but no source video is uploaded"
   },
   "name.style": {
     "message": "Визуальный стиль",

--- a/src/i18n/sr/maestro.json
+++ b/src/i18n/sr/maestro.json
@@ -231,13 +231,13 @@
     "message": "Дигитална особа · Говорна глава",
     "description": "Опција за аватар / сценарио говорне главе"
   },
-  "option.scenario.motion": {
-    "message": "Покретна графика",
-    "description": "Motion graphics scenario option"
-  },
   "option.scenario.captions": {
     "message": "Додај титлове",
     "description": "Add-captions scenario option"
+  },
+  "message.captionsNeedVideo": {
+    "message": "Кинетички титлови раде на постојећем видеу говорника — прво отпремите један изнад.",
+    "description": "Warning shown when captions video type is selected but no source video is uploaded"
   },
   "name.style": {
     "message": "Визуелни стил",

--- a/src/i18n/sv/maestro.json
+++ b/src/i18n/sv/maestro.json
@@ -231,13 +231,13 @@
     "message": "Digital person · Talande huvud",
     "description": "Alternativ för avatar / talande huvudscenario"
   },
-  "option.scenario.motion": {
-    "message": "Rörlig grafik",
-    "description": "Motion graphics scenario option"
-  },
   "option.scenario.captions": {
     "message": "Lägg till undertexter",
     "description": "Add-captions scenario option"
+  },
+  "message.captionsNeedVideo": {
+    "message": "Kinetiska undertexter arbetar på en befintlig talande-huvud-video – ladda upp en ovan först.",
+    "description": "Warning shown when captions video type is selected but no source video is uploaded"
   },
   "name.style": {
     "message": "Visuell stil",

--- a/src/i18n/uk/maestro.json
+++ b/src/i18n/uk/maestro.json
@@ -231,13 +231,13 @@
     "message": "Цифрова людина · Виступ",
     "description": "Опція сценарію з аватаром / ведучим"
   },
-  "option.scenario.motion": {
-    "message": "Моушн-графіка",
-    "description": "Motion graphics scenario option"
-  },
   "option.scenario.captions": {
     "message": "Додати субтитри",
     "description": "Add-captions scenario option"
+  },
+  "message.captionsNeedVideo": {
+    "message": "Кінетичні субтитри працюють із наявним відео з мовцем — спершу завантажте його вище.",
+    "description": "Warning shown when captions video type is selected but no source video is uploaded"
   },
   "name.style": {
     "message": "Візуальний стиль",

--- a/src/i18n/zh-CN/maestro.json
+++ b/src/i18n/zh-CN/maestro.json
@@ -212,7 +212,7 @@
     "description": "Video type field"
   },
   "description.scenario": {
-    "message": "选择要制作的视频类型。自动让 Maestro 决定；也可指定图文旁白、短剧、数字人口播、动态图形、字幕花字。",
+    "message": "选择要制作的视频类型。自动让 Maestro 决定；也可指定图文旁白、短剧、数字人口播、字幕花字。",
     "description": "Scenario field help"
   },
   "option.scenario.auto": {
@@ -231,13 +231,13 @@
     "message": "数字人 · 口播",
     "description": "Avatar / talking-head scenario option"
   },
-  "option.scenario.motion": {
-    "message": "动态图形",
-    "description": "Motion graphics scenario option"
-  },
   "option.scenario.captions": {
     "message": "字幕 · 花字",
     "description": "Captions scenario option (add captions/subtitles to an existing talking-head video)"
+  },
+  "message.captionsNeedVideo": {
+    "message": "字幕花字需要基于已有的口播视频制作，请先在上方上传一段视频。",
+    "description": "Warning shown when captions video type is selected but no source video is uploaded"
   },
   "name.style": {
     "message": "视觉风格",

--- a/src/i18n/zh-TW/maestro.json
+++ b/src/i18n/zh-TW/maestro.json
@@ -231,13 +231,13 @@
     "message": "數字人 · 口播",
     "description": "數字人/口播場景選項"
   },
-  "option.scenario.motion": {
-    "message": "動態圖形",
-    "description": "Motion graphics scenario option"
-  },
   "option.scenario.captions": {
     "message": "影片加字幕",
     "description": "Add-captions scenario option"
+  },
+  "message.captionsNeedVideo": {
+    "message": "字幕花字需要以既有的口播影片製作，請先在上方上傳一段影片。",
+    "description": "Warning shown when captions video type is selected but no source video is uploaded"
   },
   "name.style": {
     "message": "視覺風格",

--- a/src/models/maestro.ts
+++ b/src/models/maestro.ts
@@ -9,7 +9,7 @@ export interface IMaestroConfig {
   aspect?: string; // '9:16' | '16:9' | '1:1'
   duration?: number;
   quality?: string; // 'draft' | 'standard' | 'premium'
-  scenario?: string; // 'auto' | 'narrated' | 'drama' | 'avatar' | 'motion' | 'captions'
+  scenario?: string; // 'auto' | 'narrated' | 'drama' | 'avatar' | 'captions'
   style?: string; // freeform visual hint (e.g. 'auto' | 'cinematic' | 'minimal' | 'neon' | 'corporate'); orthogonal to scenario
   voice?: string; // narration timbre: 'auto' (director picks) | a preset key (constants) | a 32-hex Fish reference_id
   callback_url?: string;


### PR DESCRIPTION
## Why

From product review of the Maestro video-type picker:

- **Motion Graphics** was a silent, unnarrated design-led type (kinetic type / logo sting / data-viz). As a top-level video type next to narrated/drama/avatar it under-delivered (no voice, more of an overlay/asset than a finished video), so it's being retired from the UI.
- **Captions · Kinetic** does *not* collide with the Avatar digital-human type — they're complementary (Avatar **generates** a talking head; Captions **post-processes an existing** talking-head clip with embedded/kinetic subtitles). The confusion came from the UI: Captions needs an **uploaded source video**, yet sat in the same "generate from text" selector with no gating, so a user could pick it and hit Generate with nothing to caption.

## What changed

- Remove `motion` from `MAESTRO_ALLOWED_SCENARIOS` + its thumbnail. It stays a valid **legacy API alias (→ auto)**; `ConfigPanel.mounted()` already resets any stale persisted `motion` selection to the default, so existing users are unaffected.
- Add `MAESTRO_UPLOAD_REQUIRED_SCENARIOS = ['captions']`. When Captions is selected, `Generate` is disabled and an inline warning is shown until the user uploads a **video** file (reuses the shared `isVideoUrl` helper — an image/audio upload does not satisfy the gate).
- i18n: drop `option.scenario.motion` and the motion mention in `description.scenario` (en/zh-CN); add `message.captionsNeedVideo` across **all 18 locales**. Coverage guard passes.

## Validation

- `scripts/check_i18n_coverage.py` → OK (17 locales × 44 namespaces match zh-CN)
- `eslint` + `vue-tsc --noEmit` → clean
- `beachball check` → OK (patch change file included)
- Adversarial review: 2 rounds → CLEAN (first round's upload-type gap fixed; the historical-scenario-label concern was a false positive — no component localizes past scenario values).