### PR TITLE
fix(maestro): even out task-card row spacing to match nano/kling convention

### DIFF
--- a/change/@acedatacloud-nexior-maestro-card-gap.json
+++ b/change/@acedatacloud-nexior-maestro-card-gap.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Even out Maestro task-card metadata row spacing to match the nanobanana/kling convention (uniform mb-2, last row mb-0).",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/maestro/task/Preview.vue
+++ b/src/components/maestro/task/Preview.vue
@@ -47,7 +47,7 @@
             <font-awesome-icon :icon="param.icon" class="mr-1" />
             {{ param.label }}: {{ param.value }}
           </p>
-          <p class="text-[var(--el-text-color-regular)] text-xs mb-2 mt-3">
+          <p class="text-[var(--el-text-color-regular)] text-xs mb-2">
             <font-awesome-icon icon="fa-solid fa-magic" class="mr-1" />
             {{ $t('maestro.name.taskId') }}: {{ modelValue?.id }}
             <copy-to-clipboard :content="modelValue?.id!" />
@@ -103,11 +103,11 @@
             {{ $t('maestro.name.taskId') }}: {{ modelValue?.id }}
             <copy-to-clipboard :content="modelValue?.id!" />
           </p>
-          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-0">
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-2">
             <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
             {{ $t('maestro.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
           </p>
-          <p v-if="modelValue?.response?.trace_id" class="text-[var(--el-text-color-regular)] text-xs mb-0 mt-1">
+          <p v-if="modelValue?.response?.trace_id" class="text-[var(--el-text-color-regular)] text-xs mb-0">
             <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />
             {{ $t('maestro.name.traceId') }}: {{ modelValue?.response?.trace_id }}
             <copy-to-clipboard :content="modelValue?.response?.trace_id" />
@@ -135,15 +135,15 @@
             {{ $t('maestro.name.taskId') }}: {{ modelValue?.id }}
             <copy-to-clipboard :content="modelValue?.id!" />
           </p>
-          <p v-if="failureReason" class="text-[var(--el-text-color-regular)] text-xs mb-0">
+          <p v-if="failureReason" class="text-[var(--el-text-color-regular)] text-xs mb-2">
             <font-awesome-icon icon="fa-solid fa-circle-info" class="mr-1" />
             {{ $t('maestro.name.failureReason') }}: {{ failureReason }}
           </p>
-          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-0 mt-1">
+          <p v-if="modelValue?.elapsed" class="text-[var(--el-text-color-regular)] text-xs mb-2">
             <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
             {{ $t('maestro.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
           </p>
-          <p v-if="modelValue?.response?.trace_id" class="text-[var(--el-text-color-regular)] text-xs mb-0 mt-1">
+          <p v-if="modelValue?.response?.trace_id" class="text-[var(--el-text-color-regular)] text-xs mb-0">
             <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />
             {{ $t('maestro.name.traceId') }}: {{ modelValue?.response?.trace_id }}
             <copy-to-clipboard :content="modelValue?.response?.trace_id" />


### PR DESCRIPTION
## Problem

Follow-up to #1219. The Maestro task-card metadata rows had inconsistent vertical gaps: most rows used `mb-2` (8px) but `elapsed` / `trace_id` / `failureReason` used `mb-0 mt-1` (4px), and the processing card's Task ID row carried a stray `mt-3`. Result: uneven spacing within a card, and the card didn't match the other scenario previews.

## Change

Align the rows to the **existing house convention** already used by the `nanobanana` and `kling` task previews — every metadata row is `text-xs mb-2`, the last row is `mb-0`, and the shared `:deep(p:last-child) { margin-bottom: 0 }` reset handles the real last row. No custom wrapper or bespoke CSS. Net diff is just dropping the stray `mt-1` / `mt-3` and normalizing `mb-0` -> `mb-2` on the middle rows, applied identically to processing / success / failure.

## 🤖 对抗评审

CSS-class-only change that makes Maestro match the established nanobanana/kling row-spacing pattern (uniform `mb-2`, last `mb-0`). No markup restructure, no logic, no billing/data impact. **VERDICT: CLEAN** — no RISK findings.