### PR TITLE
fix(maestro): show full heads in Video Type cards (compact vertical thumbnails)

### DIFF
--- a/change/@acedatacloud-nexior-6c00e1a3-7d8a-4ecc-8913-28070a9e71c4.json
+++ b/change/@acedatacloud-nexior-6c00e1a3-7d8a-4ecc-8913-28070a9e71c4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Maestro: show full heads in Video Type cards with compact vertical (3:4) thumbnails instead of a 16:9 crop that hid faces",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/maestro/ConfigPanel.vue
+++ b/src/components/maestro/ConfigPanel.vue
@@ -530,13 +530,13 @@ export default defineComponent({
 }
 .scenario-cards {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 10px;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
 }
 .scenario-card {
   border: 1px solid var(--el-border-color);
   background-color: var(--el-fill-color-lighter);
-  border-radius: 10px;
+  border-radius: 8px;
   overflow: hidden;
   cursor: pointer;
   transition:
@@ -545,22 +545,26 @@ export default defineComponent({
 
   .scenario-thumb {
     width: 100%;
-    aspect-ratio: 16 / 9;
+    aspect-ratio: 3 / 4;
     background-color: var(--el-fill-color);
     overflow: hidden;
 
     img {
       width: 100%;
       height: 100%;
+      // Portrait crop anchored to the top so the subject's head is always
+      // visible (thumbnails are portrait photos; a centered 16:9 crop hid the face).
       object-fit: cover;
+      object-position: top center;
       display: block;
     }
   }
 
   .scenario-name {
-    font-size: 12px;
+    font-size: 11px;
+    line-height: 1.25;
     margin: 0;
-    padding: 6px 8px;
+    padding: 5px 4px;
     text-align: center;
     color: var(--el-text-color-primary);
   }


### PR DESCRIPTION
## Problem
On the Maestro config panel, the **Video Type** (scenario) cards cropped the thumbnails into a **16:9 landscape** box with `object-fit: cover`. The thumbnails are portrait photos (720×1280 / 1080×1920), so the landscape crop kept only the middle chest band and **cut the subjects' heads off** — the cards looked ugly and the content wasn't clear at a glance.

## Fix (CSS only — `ConfigPanel.vue`)
- Cards are now compact **vertical rectangles**: `3` per row (was 2), `3 / 4` portrait thumb (was `16 / 9`), smaller radius/gap/label.
- Crop is anchored to the top (`object-position: top center`) so the **head is always fully visible**, for both portrait talking-head photos and the landscape footage/illustration thumbnails.
- No image regeneration needed — the source photos already contain the heads; only the crop was hiding them.

## Before / After
Verified in a standalone render with the real CDN thumbnails: OLD 16:9 crop shows only necklines; NEW 3:4 top-anchored shows every face in full.

## 🤖 对抗评审
Trivial presentational CSS-only change (grid columns + aspect-ratio + object-position + label sizing), scoped to `.scenario-*` rules. Landscape thumbnails (narrated footage / auto illustration) were verified to remain centered and legible in the 3:4 box. No logic, data, billing, or API surface touched. **VERDICT: CLEAN.**