### PR TITLE
feat(nexior): make task image thumbnails clickable to preview

### DIFF
--- a/change/@acedatacloud-nexior-1dd5614b-fccb-424f-8004-e7f5d348e13e.json
+++ b/change/@acedatacloud-nexior-1dd5614b-fccb-424f-8004-e7f5d348e13e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Make task image thumbnails clickable to open a full-screen preview lightbox",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/ImagePreview.vue
+++ b/src/components/common/ImagePreview.vue
@@ -2,7 +2,8 @@
   <div
     class="image w-[50px] h-[50px] relative rounded-[var(--el-border-radius-base)] overflow-hidden shadow-sm bg-[var(--el-fill-color-lighter)]"
   >
-    <img class="w-full h-full object-cover" :src="url" :alt="name" />
+    <img class="w-full h-full object-cover cursor-zoom-in" :src="url" :alt="name" @click.stop="onPreview" />
+    <el-image-viewer v-if="showViewer" :url-list="[url]" teleported hide-on-click-modal @close="showViewer = false" />
     <div v-show="isUploading" class="overlay absolute inset-0 bg-[var(--el-mask-color)] backdrop-blur-[1px]"></div>
     <el-progress
       v-show="isUploading"
@@ -24,13 +25,14 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { ElProgress } from 'element-plus';
+import { ElProgress, ElImageViewer } from 'element-plus';
 
 export default defineComponent({
   name: 'ImagePreview',
   components: {
     FontAwesomeIcon,
-    ElProgress
+    ElProgress,
+    ElImageViewer
   },
   props: {
     url: {
@@ -53,12 +55,25 @@ export default defineComponent({
     }
   },
   emits: ['remove'],
+  data() {
+    return {
+      showViewer: false
+    };
+  },
   computed: {
     isUploading(): boolean {
       return typeof this.percentage === 'number' && this.percentage < 100;
     },
     displayPercentage(): number {
       return typeof this.percentage === 'number' ? this.percentage : 0;
+    }
+  },
+  methods: {
+    onPreview(): void {
+      if (this.isUploading || !this.url) {
+        return;
+      }
+      this.showViewer = true;
     }
   }
 });

--- a/src/components/common/ImageWrapper.vue
+++ b/src/components/common/ImageWrapper.vue
@@ -1,20 +1,34 @@
 <template>
   <div class="image-wrapper">
-    <img v-if="src" :src="src" class="image" @error="onReload($event)" />
-    <el-button v-if="rawSrc" type="info" round class="btn-raw" @click="onOpenUrl(rawSrc)">
+    <img
+      v-if="displaySrc"
+      :src="displaySrc"
+      class="image cursor-zoom-in"
+      @error="onReload"
+      @click="showViewer = true"
+    />
+    <el-button v-if="rawSrc" type="info" round class="btn-raw" @click.stop="onOpenUrl(rawSrc)">
       {{ $t('common.button.seeRawImage') }}
     </el-button>
+    <el-image-viewer
+      v-if="showViewer"
+      :url-list="[rawSrc || displaySrc]"
+      teleported
+      hide-on-click-modal
+      @close="showViewer = false"
+    />
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElButton } from 'element-plus';
+import { ElButton, ElImageViewer } from 'element-plus';
 
 export default defineComponent({
   name: 'ImageWrapper',
   components: {
-    ElButton
+    ElButton,
+    ElImageViewer
   },
   props: {
     src: {
@@ -27,28 +41,35 @@ export default defineComponent({
       default: undefined
     }
   },
+  data() {
+    return {
+      showViewer: false,
+      // Displayed src is kept in sync with retries so the lightbox uses the URL that actually loaded.
+      displaySrc: this.src
+    };
+  },
+  watch: {
+    src(value: string) {
+      this.displaySrc = value;
+    }
+  },
   methods: {
     onOpenUrl(url: string) {
       window.open(url, '_blank');
     },
     onReload(event: Event) {
       const target = event.target as HTMLImageElement;
-      // append a random url query to existing url query, to force reload the image
-      // extract exiting url query
+      // append a retry query to force reload the image
       const url = new URL(target.src);
-      // extract `retry` query
       const retry = url.searchParams.get('retry');
       if (!retry) {
-        // if no retry query, set it as random string
         url.searchParams.set('retry', '1');
       } else if (parseInt(retry) < 2) {
-        // if retry < 3, increase it by 1
         url.searchParams.set('retry', (parseInt(retry) + 1).toString());
       } else {
         return;
       }
-      // set the new url
-      target.src = url.toString();
+      this.displaySrc = url.toString();
     }
   }
 });

--- a/src/components/headshots/ImageGallery.vue
+++ b/src/components/headshots/ImageGallery.vue
@@ -1,20 +1,32 @@
 <template>
   <div class="image-gallery">
     <div v-for="(image, index) in images" :key="index" class="image-container">
-      <img :src="image.image_url" alt="Image" />
-      <button v-if="image.image_url" class="view-button" @click="viewImage(image.image_url)">
+      <img :src="image.image_url" alt="Image" class="cursor-zoom-in" @click="onPreview(image.image_url)" />
+      <button v-if="image.image_url" class="view-button" @click.stop="viewImage(image.image_url)">
         {{ $t('headshots.button.viewImage') }}
       </button>
     </div>
+    <el-image-viewer
+      v-if="previewIndex !== null"
+      :url-list="previewList"
+      :initial-index="previewIndex"
+      teleported
+      hide-on-click-modal
+      @close="previewIndex = null"
+    />
   </div>
 </template>
 
 <script lang="ts">
-import { defineComponent, computed } from 'vue';
+import { defineComponent, computed, ref } from 'vue';
+import { ElImageViewer } from 'element-plus';
 import { IHeadshotsTask } from '@/models';
 
 export default defineComponent({
   name: 'ImageGallery',
+  components: {
+    ElImageViewer
+  },
   props: {
     modelValue: {
       type: Object as () => IHeadshotsTask | undefined,
@@ -27,6 +39,21 @@ export default defineComponent({
       return props.modelValue?.response?.data?.slice(0, 2) || [];
     });
 
+    const previewIndex = ref<number | null>(null);
+    const previewList = computed(() => images.value.map((image) => image.image_url).filter(Boolean) as string[]);
+
+    // Open the lightbox at the clicked image's position within the filtered list.
+    const onPreview = (url?: string) => {
+      if (!url) {
+        return;
+      }
+      const index = previewList.value.indexOf(url);
+      if (index === -1) {
+        return;
+      }
+      previewIndex.value = index;
+    };
+
     // Method to handle the "View Image" button click
     const viewImage = (url: string) => {
       window.open(url, '_blank');
@@ -34,6 +61,9 @@ export default defineComponent({
 
     return {
       images,
+      previewIndex,
+      previewList,
+      onPreview,
       viewImage
     };
   }
@@ -78,6 +108,8 @@ export default defineComponent({
     border-radius: 4px;
     cursor: pointer;
     opacity: 0;
+    /* Hidden by default so center clicks reach the image (open the lightbox); only clickable on hover. */
+    pointer-events: none;
     transition: opacity 0.3s ease;
 
     /* Optional: Add a slight delay for smoother appearance */
@@ -91,6 +123,7 @@ export default defineComponent({
   /* Show the button on hover */
   &:hover .view-button {
     opacity: 1;
+    pointer-events: auto;
   }
 }
 </style>


### PR DESCRIPTION
## What

All image thumbnails inside task history and result cards are now **clickable to open a full-screen preview lightbox** (`el-image-viewer`), across every image/video service — gpt-image (OpenAI), nano-banana, seedream, seedance, flux, kling, midjourney, maestro, qrart, headshots, etc.

## Why

Previously only some result images had a "see raw image" button (opened a new tab) and the small reference/input thumbnails had no preview at all. Users asked to be able to click any of these small preview images to enlarge them.

## Changes

- **`common/ImagePreview.vue`** (shared small reference/input thumbnails, used by ~all services incl. Maestro): image is now `cursor-zoom-in` and opens a teleported `el-image-viewer` on click. Guarded to skip while uploading. Close button + progress overlay unaffected (`@click.stop`).
- **`common/ImageWrapper.vue`** (shared result images: flux, nano, gpt-image, seedream, seedance, qrart, midjourney): click opens the lightbox. Kept the "see raw image" button (now `@click.stop`). Retry-on-error is tracked via a reactive `displaySrc` so a retried thumbnail stays consistent; the lightbox shows the full-resolution `rawSrc` when available.
- **`headshots/ImageGallery.vue`** (its own result renderer): click opens the lightbox at the correct index within the filtered list; the hover "view image" button no longer intercepts center clicks (`pointer-events` gated to hover).

## Notes

Because the two shared components back nearly every service, this one change lights up click-to-preview everywhere without touching each service's `task/Preview.vue`.

Reviewed adversarially; the reference/close/upload-progress/see-raw/retry behaviors are all preserved.