### PR TITLE
feat(maestro): regenerate Video Type thumbnails as a cohesive 3:4 portrait set

### DIFF
--- a/change/@acedatacloud-nexior-14827e00-cc30-42ba-ac25-1ae6f881fcaa.json
+++ b/change/@acedatacloud-nexior-14827e00-cc30-42ba-ac25-1ae6f881fcaa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Maestro: regenerate the Video Type thumbnails as a cohesive set of purpose-made 3:4 portrait images so each type reads at a glance",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/constants/maestro.ts
+++ b/src/constants/maestro.ts
@@ -20,14 +20,15 @@ export const MAESTRO_ALLOWED_QUALITIES = ['draft', 'standard', 'premium'];
 export const MAESTRO_ALLOWED_SCENARIOS = ['auto', 'narrated', 'drama', 'avatar', 'captions'];
 // `captions` post-processes an EXISTING talking-head video, so it requires an uploaded source clip.
 export const MAESTRO_UPLOAD_REQUIRED_SCENARIOS = ['captions'];
-// Preview thumbnail per scenario — real frames from generated videos (narrated/drama/avatar/captions);
-// auto stays as an illustration. Hosted on the CDN like MAESTRO_LOGO.
+// Preview thumbnail per scenario — a cohesive set of purpose-made 3:4 portrait
+// thumbnails (subject/head in the upper frame) so each Video Type reads at a
+// glance in the compact vertical cards. Hosted on the CDN like MAESTRO_LOGO.
 export const MAESTRO_SCENARIO_THUMBNAILS: Record<string, string> = {
-  auto: 'https://cdn.acedata.cloud/f61b85476e.png',
-  narrated: 'https://cdn.acedata.cloud/db6ef158be.jpg',
-  drama: 'https://cdn.acedata.cloud/af85b29164.jpg',
-  avatar: 'https://cdn.acedata.cloud/7ae3e94d5a.jpg',
-  captions: 'https://cdn.acedata.cloud/9a6d16d9f3.jpg'
+  auto: 'https://cdn.acedata.cloud/58bf7feea4.jpg',
+  narrated: 'https://cdn.acedata.cloud/fb12495d70.jpg',
+  drama: 'https://cdn.acedata.cloud/33b9189ad0.jpg',
+  avatar: 'https://cdn.acedata.cloud/540bda9cb6.jpg',
+  captions: 'https://cdn.acedata.cloud/e86fddfc71.jpg'
 };
 // Visual style presets — each maps to a real named capability on the backend (a visual-styles
 // identity, a palette, or a recipe like glass/retro). Freeform text still works. Orthogonal to scenario.


### PR DESCRIPTION
## What
Follow-up to #1222 (which made the Video Type cards compact vertical 3:4 rectangles). This regenerates the 5 scenario thumbnails as a **cohesive, purpose-made set** so each type reads at a glance.

- All 5 are freshly generated **3:4 portrait (1728×2304)** images with a consistent cinematic look and the subject/head in the **upper frame** — so they fill the vertical cards with zero cropping and no more cut-off heads.
- `auto` → magic-wand-conjures-video-panels concept · `narrated` → documentary b-roll · `drama` → cinematic close-up · `avatar` → news-anchor talking head · `captions` → presenter with a kinetic caption bar.
- Only `src/constants/maestro.ts` changes (the 5 `MAESTRO_SCENARIO_THUMBNAILS` URLs + comment). New images hosted on `cdn.acedata.cloud` like the rest.

## Verification
Rendered the real images in the actual 3-up card layout — every head is fully visible and each label matches its image at a glance.

## 🤖 对抗评审
Data-only change: swaps 5 CDN thumbnail URLs (verified live, correct 3:4 portrait dimensions) and updates a comment. No logic, layout, billing, or API surface touched. **VERDICT: CLEAN.**