### PR TITLE
fix(maestro): update bot logo asset

### DIFF
--- a/change/@acedatacloud-nexior-maestro-holo-logo.json
+++ b/change/@acedatacloud-nexior-maestro-holo-logo.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update the Maestro bot logo to the selected Holo Window CDN asset.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/constants/maestro.ts
+++ b/src/constants/maestro.ts
@@ -1,6 +1,6 @@
 export const MAESTRO_SERVICE_ID = '0d7031bf-610a-419e-a5a0-db8f240286d5';
 
-export const MAESTRO_LOGO = 'https://cdn.acedata.cloud/ee49012887.svg';
+export const MAESTRO_LOGO = 'https://cdn.acedata.cloud/df0e7b7eea.svg';
 
 export const MAESTRO_ACTION_GENERATE = 'generate';
 export const MAESTRO_ACTION_REMIX = 'remix';


### PR DESCRIPTION
## What

Update Nexior's Maestro bot logo constant to the selected Holo Window redesign:

- `MAESTRO_LOGO` -> `https://cdn.acedata.cloud/df0e7b7eea.svg`

This updates the Maestro chat/task avatar in Studio while the PlatformBackend companion PR updates the service/document logo and thumbnail metadata.

## Assets

- Logo: https://cdn.acedata.cloud/df0e7b7eea.svg
- Matching Platform thumbnail: https://cdn.acedata.cloud/2db2862e69.svg

## Validation

- `npx vue-tsc --noEmit`
- `npx beachball check --branch origin/main`
- CDN smoke check: logo URL returns `200 image/svg+xml`

## 🤖 对抗评审

VERDICT: CLEAN — Migration depends on the current `0207` head and rolls back to the prior `0205/0206` Maestro asset state. Covered surfaces match the request: Platform service `icon_url`, service `thumbnail`, root Maestro `Document.icon_url`, and Nexior `MAESTRO_LOGO`. SVG CDN usage is consistent for icons and should work for thumbnail consumers via normal image URL rendering; CDN/content-type and compile/type validations are sufficient for this small data/constant change.
