### PR TITLE
fix(maestro): show task trace id

### DIFF
--- a/change/@acedatacloud-nexior-2ac7991d-0f8f-4c39-87d4-0b90fd8c3263.json
+++ b/change/@acedatacloud-nexior-2ac7991d-0f8f-4c39-87d4-0b90fd8c3263.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Maestro: display task trace IDs from the task response top level",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/maestro/task/Preview.vue
+++ b/src/components/maestro/task/Preview.vue
@@ -52,10 +52,10 @@
             {{ $t('maestro.name.taskId') }}: {{ modelValue?.id }}
             <copy-to-clipboard :content="modelValue?.id!" />
           </p>
-          <p v-if="modelValue?.response?.trace_id" class="text-[var(--el-text-color-regular)] text-xs mb-0">
+          <p v-if="traceId" class="text-[var(--el-text-color-regular)] text-xs mb-0">
             <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />
-            {{ $t('maestro.name.traceId') }}: {{ modelValue?.response?.trace_id }}
-            <copy-to-clipboard :content="modelValue?.response?.trace_id" />
+            {{ $t('maestro.name.traceId') }}: {{ traceId }}
+            <copy-to-clipboard :content="traceId" />
           </p>
         </el-alert>
       </div>
@@ -107,10 +107,10 @@
             <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
             {{ $t('maestro.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
           </p>
-          <p v-if="modelValue?.response?.trace_id" class="text-[var(--el-text-color-regular)] text-xs mb-0">
+          <p v-if="traceId" class="text-[var(--el-text-color-regular)] text-xs mb-0">
             <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />
-            {{ $t('maestro.name.traceId') }}: {{ modelValue?.response?.trace_id }}
-            <copy-to-clipboard :content="modelValue?.response?.trace_id" />
+            {{ $t('maestro.name.traceId') }}: {{ traceId }}
+            <copy-to-clipboard :content="traceId" />
           </p>
         </el-alert>
       </div>
@@ -143,10 +143,10 @@
             <font-awesome-icon icon="fa-solid fa-clock" class="mr-1" />
             {{ $t('maestro.name.elapsed') }}: {{ modelValue?.elapsed?.toFixed(2) }}s
           </p>
-          <p v-if="modelValue?.response?.trace_id" class="text-[var(--el-text-color-regular)] text-xs mb-0">
+          <p v-if="traceId" class="text-[var(--el-text-color-regular)] text-xs mb-0">
             <font-awesome-icon icon="fa-solid fa-hashtag" class="mr-1" />
-            {{ $t('maestro.name.traceId') }}: {{ modelValue?.response?.trace_id }}
-            <copy-to-clipboard :content="modelValue?.response?.trace_id" />
+            {{ $t('maestro.name.traceId') }}: {{ traceId }}
+            <copy-to-clipboard :content="traceId" />
           </p>
         </el-alert>
       </div>
@@ -228,6 +228,9 @@ export default defineComponent({
     },
     isTerminal(): boolean {
       return TERMINAL.includes(this.modelValue?.status || '');
+    },
+    traceId(): string | undefined {
+      return this.modelValue?.trace_id || this.modelValue?.response?.trace_id;
     },
     progressPct(): number | undefined {
       const progress = this.modelValue?.response?.data?.progress;

--- a/src/models/maestro.ts
+++ b/src/models/maestro.ts
@@ -63,6 +63,7 @@ export interface IMaestroAgentStats {
 
 export interface IMaestroTask {
   id: string;
+  trace_id?: string;
   status?: string;
   created_at?: number;
   elapsed?: number;


### PR DESCRIPTION
## What

- Read Maestro task trace IDs from the top-level `trace_id` returned by `/maestro/tasks`.
- Keep fallback support for legacy `response.trace_id` payloads.
- Add the required beachball patch change file.

## Validation

- `npx vue-tsc --noEmit` — passed.
- `npx beachball check --branch origin/main` — blocked locally by GitHub HTTPS fetch failure (`SSL_ERROR_SYSCALL`); required change file is included and CI will rerun this in GitHub.

## 🤖 对抗评审 (reviewer: claude-subagent, 1 round)
- VERDICT: CLEAN
