### PR TITLE
fix(auth): honor server-side auth-iframe feature flag in Nexior

### DIFF
--- a/change/@acedatacloud-nexior-server-feature-flag.json
+++ b/change/@acedatacloud-nexior-server-feature-flag.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Honor the server-side auth-iframe feature flag from GET /config so in-app iframe login can be enabled for everyone.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -1,6 +1,10 @@
 export interface IConfigFeatures {
   DISCOUNT_FOR_X402?: number;
   ENABLE_PAYPAL?: boolean;
+  // Server-driven feature flags consumed via `isFeatureEnabled` (URL/cookie
+  // opt-in / opt-out still wins).
+  'auth-iframe'?: boolean;
+  iframe?: boolean;
 }
 
 export interface IConfigResponse {

--- a/src/utils/featureFlag.ts
+++ b/src/utils/featureFlag.ts
@@ -7,10 +7,11 @@
 //
 // Visit any page with `?features=foo` to enable a flag. Multiple flags can
 // be comma- or space-separated: `?features=foo,bar`. Prefix with `-` (or
-// `!`) to disable a single flag: `?features=-foo`. Use `?features=none`
-// (also `off`, `clear`) to drop the cookie entirely. `?features=all` (or
-// `*`) flips every flag the FE consults; combine with `-foo` to opt out
-// of a single one.
+// `!`) to disable a single flag: `?features=-foo` — this records an explicit
+// force-OFF that persists and wins over both `all` and the server value. Use
+// `?features=none` (also `off`, `clear`) to drop every override (falling back
+// to the server default). `?features=all` (or `*`) flips every flag the FE
+// consults; combine with `-foo` to opt out of a single one.
 //
 // Why a cookie:
 //
@@ -20,11 +21,25 @@
 //   a deploy.
 // - Host-only (no `domain=`) so the cookie does not collide with the
 //   sibling PlatformFrontend / AuthFrontend cookies of the same name.
+//
+// Server-driven flags: besides the URL/cookie opt-in (dev / beta-tester
+// escape hatch), a flag can also be turned on for everyone from the
+// backend via `GET /config`'s `features` bag. Resolution order: explicit
+// URL/cookie force-OFF (`-foo`) → `all`/opt-in → server value → off. The
+// force-OFF wins so a tester can still disable a broken server flag.
 
 import { getCookie, removeCookie, setCookie } from 'typescript-cookie';
+// NOTE: `@/store` imports this module (via common/actions.ts), so this is a
+// cycle. It is safe ONLY because `store` is dereferenced lazily inside
+// `readServerFlag` at call time — never at module top level. Keep it that way.
+import store from '@/store';
 
 const COOKIE_NAME = 'FEATURES';
 const ALL_TOKEN = '__all__';
+// A `!<flag>` token in the set is an explicit force-OFF that wins over both
+// the `all` token and the server-driven value (so `?features=-foo` can still
+// disable a flag the backend turned on for everyone).
+const OFF_PREFIX = '!';
 const EXPIRY_DAYS = 1;
 
 let cachedFeatures: Set<string> | null = null;
@@ -93,13 +108,38 @@ function parseTokens(raw: string): {
   return { clear, all, add, remove };
 }
 
+// Read the server-side value for `name` from the Vuex-stored `/config`
+// response (`state.config.features`). Returns `undefined` when the backend
+// hasn't shipped a value for this flag so the caller falls back to off.
+function readServerFlag(name: string): boolean | undefined {
+  let features: Record<string, unknown> | undefined;
+  try {
+    features = (store.getters.config as { features?: Record<string, unknown> } | undefined)?.features;
+  } catch {
+    return undefined;
+  }
+  if (!features) return undefined;
+  let v = features[name];
+  if (v === undefined) v = features[name.toLowerCase()];
+  if (v === undefined) return undefined;
+  if (typeof v === 'boolean') return v;
+  if (typeof v === 'number') return v !== 0;
+  if (typeof v === 'string') return v.length > 0;
+  return Boolean(v);
+}
+
 export function isFeatureEnabled(name: string): boolean {
   const set = cachedFeatures ?? readStoredFeatures();
+  const key = name.toLowerCase();
+  if (set.has(OFF_PREFIX + key)) return false;
   if (set.has(ALL_TOKEN)) return true;
-  return set.has(name.toLowerCase());
+  if (set.has(key)) return true;
+  return readServerFlag(name) === true;
 }
 
 export function isAuthIframeFeatureEnabled(): boolean {
+  // OR of two flags, and the server sends both — so to force it OFF you must
+  // disable both tokens: `?features=-auth-iframe,-iframe`.
   return isFeatureEnabled('auth-iframe') || isFeatureEnabled('iframe');
 }
 
@@ -121,9 +161,16 @@ export function syncFeaturesFromUrl(): Set<string> {
   const { clear, all, add, remove } = parseTokens(raw);
   if (clear) features.clear();
   if (all) features.add(ALL_TOKEN);
-  add.forEach((f) => features.add(f));
-  remove.forEach((f) => features.delete(f));
-  if (remove.size > 0) features.delete(ALL_TOKEN);
+  // Opt-in clears any prior force-OFF; opt-out records an explicit force-OFF
+  // (kept as `!flag`) so it overrides `all` and the server-driven value.
+  add.forEach((f) => {
+    features.delete(OFF_PREFIX + f);
+    features.add(f);
+  });
+  remove.forEach((f) => {
+    features.delete(f);
+    features.add(OFF_PREFIX + f);
+  });
 
   writeStoredFeatures(features);
   cachedFeatures = features;


### PR DESCRIPTION
## What

On **studio.acedata.cloud (Nexior)**, enabling the `auth-iframe` feature flag server-side (`GET /config` → `{"features":{"auth-iframe":true,"iframe":true,...}}`) had **no effect** — clicking login still full-page redirected to `auth.acedata.cloud` instead of opening the in-app iframe login.

### Root cause
Nexior's `isFeatureEnabled()` in `src/utils/featureFlag.ts` only read the URL/cookie `FEATURES` set and **never consulted the server `config.features`** — unlike the sibling PlatformFrontend, which has a `readServerFlag()` fallback. So the DB-backed flag was silently ignored; only `?features=auth-iframe`/`?features=iframe` (cookie) worked.

### Fix
- Add `readServerFlag(name)` that reads `store.getters.config?.features?.[name]` (lowercase fallback + boolean/number/string coercion, `try/catch` → off). `isFeatureEnabled` now falls back to it when the URL/cookie set doesn't decide.
- **Preserve the escape hatch:** URL/cookie opt-outs (`?features=-foo`) are now persisted as an explicit force-OFF (`!foo`) that wins over both `all` and the server value — so a broken server-on flag can still be disabled client-side. (`?features=none` clears overrides → server default.)
- Widen `IConfigFeatures` with the two known server flags (`'auth-iframe'`, `iframe`); kept strict (no index signature) so excess-property checks still catch typos.

### Precedence (resolution order)
`-foo` force-OFF  →  `all` / opt-in  →  server value  →  off.

## Validation
- `npx vue-tsc --noEmit` clean; `eslint` on both files clean.
- Traced boot order: `store` is imported before `syncFeaturesFromUrl` in `main.ts`; `store` is only dereferenced lazily inside `readServerFlag` at navigation time, after `initializeConfig` → `fetchConfig` populates `state.config`. Reproduced the original bug + verified the flag path live via Playwright on studio.acedata.cloud.

## Note for operators
`isAuthIframeFeatureEnabled()` is `auth-iframe || iframe` and the server sends **both**, so to force it OFF client-side you must pass **both** tokens: `?features=-auth-iframe,-iframe`.

## 🤖 对抗评审

Two rounds (read-only subagent).

- **Round 1 — RISK (medium):** with a server-on flag, the `?features=-foo`/`none` opt-out no longer worked → no client-side way to disable a broken iframe login. **Fixed** by persisting `!foo` force-OFF tokens that win over `all`/server. RISK (low): `[key:string]:unknown` weakened typing → **removed**, kept strict keys.
- **Round 2 — VERDICT: precedence logic correct, no functional/SSG/circular-import regression.** Remaining items are ergonomic footguns, addressed or rebutted:
  - Composite `auth-iframe||iframe` needs both `-tokens` to force off → **documented** (code comment + PR note).
  - store↔featureFlag import cycle is safe because access is lazy → **guard comment added** ("keep store access lazy").
  - String truthy-coercion / `-all` no longer exits all-mode / `!flag` cookie growth → **low, rebutted**: server contract is boolean-typed; `none` is the documented reset; growth bounded by the 24h sliding-cookie expiry and 4 KB limit.
