### PR TITLE
feat(settings): configurable login mode (iframe popup vs redirect)

### DIFF
--- a/change/@acedatacloud-nexior-74617ec4-a09c-4bda-be73-add1fe78fa80.json
+++ b/change/@acedatacloud-nexior-74617ec4-a09c-4bda-be73-add1fe78fa80.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add configurable login mode (iframe popup vs redirect) in settings",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/setting/General.vue
+++ b/src/components/setting/General.vue
@@ -16,6 +16,14 @@
         <locale-switcher />
       </div>
     </section>
+    <section v-if="showLoginMode" class="settings-item">
+      <div class="settings-label">
+        <p class="settings-title">{{ $t('common.settings.loginMode') }}</p>
+      </div>
+      <div class="settings-content">
+        <login-mode-switcher />
+      </div>
+    </section>
     <section class="settings-item">
       <div class="settings-label">
         <p class="settings-title">{{ $t('common.settings.github') }}</p>
@@ -35,18 +43,28 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { faGithub } from '@fortawesome/free-brands-svg-icons';
 import ThemeSwitcher from '@/components/user/Theme.vue';
 import LocaleSwitcher from '@/components/user/Locale.vue';
+import LoginModeSwitcher from '@/components/user/LoginMode.vue';
+import { isNative, isDesktop } from '@/utils/surface';
 
 export default defineComponent({
   name: 'GeneralSettings',
   components: {
     ThemeSwitcher,
     LocaleSwitcher,
+    LoginModeSwitcher,
     FontAwesomeIcon
   },
   data() {
     return {
       faGithub
     };
+  },
+  computed: {
+    // Native / desktop always use the in-app iframe (a redirect can't return
+    // to an app://bundle window), so the choice only makes sense on web.
+    showLoginMode(): boolean {
+      return !isNative() && !isDesktop();
+    }
   }
 });
 </script>

--- a/src/components/user/LoginMode.vue
+++ b/src/components/user/LoginMode.vue
@@ -1,0 +1,54 @@
+<template>
+  <el-dropdown trigger="click" @command="onSelect">
+    <span class="el-dropdown-link">
+      {{ currentLabel }}
+      <el-icon class="el-icon--right"><arrow-down /></el-icon>
+    </span>
+    <template #dropdown>
+      <el-dropdown-menu>
+        <el-dropdown-item command="iframe">{{ $t('common.loginMode.iframe') }}</el-dropdown-item>
+        <el-dropdown-item command="redirect">{{ $t('common.loginMode.redirect') }}</el-dropdown-item>
+      </el-dropdown-menu>
+    </template>
+  </el-dropdown>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElDropdown, ElDropdownMenu, ElDropdownItem, ElIcon } from 'element-plus';
+import { ArrowDown } from '@element-plus/icons-vue';
+import { getLoginMethodPreference, setLoginMethodPreference, type LoginMethod } from '@/utils/loginMethod';
+import { isAuthIframeFeatureEnabled } from '@/utils/featureFlag';
+
+export default defineComponent({
+  name: 'LoginModeSelector',
+  components: {
+    ArrowDown,
+    ElDropdown,
+    ElDropdownMenu,
+    ElDropdownItem,
+    ElIcon
+  },
+  data() {
+    // Show the currently effective mode: an explicit choice if set, otherwise
+    // whatever the URL feature flag resolves to (redirect by default on web).
+    const initial: LoginMethod = getLoginMethodPreference() ?? (isAuthIframeFeatureEnabled() ? 'iframe' : 'redirect');
+    return {
+      method: initial
+    };
+  },
+  computed: {
+    currentLabel(): string {
+      return this.method === 'iframe'
+        ? (this.$t('common.loginMode.iframe') as string)
+        : (this.$t('common.loginMode.redirect') as string);
+    }
+  },
+  methods: {
+    onSelect(command: LoginMethod) {
+      this.method = command;
+      setLoginMethodPreference(command);
+    }
+  }
+});
+</script>

--- a/src/i18n/ar/common.json
+++ b/src/i18n/ar/common.json
@@ -807,6 +807,18 @@
     "message": "السمة",
     "description": "عنوان قسم إعدادات السمة في صفحة الإعدادات"
   },
+  "settings.loginMode": {
+    "message": "طريقة تسجيل الدخول",
+    "description": "Login-mode row title in general settings"
+  },
+  "loginMode.iframe": {
+    "message": "نافذة منبثقة مضمّنة",
+    "description": "Login mode option: embedded iframe popup"
+  },
+  "loginMode.redirect": {
+    "message": "إعادة توجيه لصفحة كاملة",
+    "description": "Login mode option: full-page redirect"
+  },
   "settings.seo": {
     "message": "إعدادات SEO",
     "description": "عنوان قسم إعدادات SEO في صفحة الإعدادات"

--- a/src/i18n/de/common.json
+++ b/src/i18n/de/common.json
@@ -807,6 +807,18 @@
     "message": "Thema",
     "description": "Titel des Abschnitts für Themaeinstellungen auf der Einstellungsseite"
   },
+  "settings.loginMode": {
+    "message": "Anmeldemodus",
+    "description": "Login-mode row title in general settings"
+  },
+  "loginMode.iframe": {
+    "message": "Eingebettetes Popup",
+    "description": "Login mode option: embedded iframe popup"
+  },
+  "loginMode.redirect": {
+    "message": "Ganzseitige Weiterleitung",
+    "description": "Login mode option: full-page redirect"
+  },
   "settings.seo": {
     "message": "SEO-Einstellungen",
     "description": "Titel des Abschnitts für SEO-Einstellungen auf der Einstellungsseite"

--- a/src/i18n/el/common.json
+++ b/src/i18n/el/common.json
@@ -807,6 +807,18 @@
     "message": "Θέμα",
     "description": "Επικεφαλίδα τμήματος ρυθμίσεων θέματος στη σελίδα ρυθμίσεων"
   },
+  "settings.loginMode": {
+    "message": "Τρόπος σύνδεσης",
+    "description": "Login-mode row title in general settings"
+  },
+  "loginMode.iframe": {
+    "message": "Ενσωματωμένο αναδυόμενο",
+    "description": "Login mode option: embedded iframe popup"
+  },
+  "loginMode.redirect": {
+    "message": "Ανακατεύθυνση πλήρους σελίδας",
+    "description": "Login mode option: full-page redirect"
+  },
   "settings.seo": {
     "message": "Ρυθμίσεις SEO",
     "description": "Επικεφαλίδα τμήματος ρυθμίσεων SEO στη σελίδα ρυθμίσεων"

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -787,6 +787,18 @@
     "message": "Theme",
     "description": "Title for the theme settings section in the settings page"
   },
+  "settings.loginMode": {
+    "message": "Login Mode",
+    "description": "Title for the login-mode row in general settings: choose whether login uses an embedded popup (iframe) or a full-page redirect"
+  },
+  "loginMode.iframe": {
+    "message": "Embedded popup",
+    "description": "Login mode option: complete login in an embedded iframe popup without leaving the current page"
+  },
+  "loginMode.redirect": {
+    "message": "Full-page redirect",
+    "description": "Login mode option: redirect to the login page and return after signing in"
+  },
   "settings.seo": {
     "message": "SEO Settings",
     "description": "Title for the SEO settings section in the settings page"

--- a/src/i18n/es/common.json
+++ b/src/i18n/es/common.json
@@ -807,6 +807,18 @@
     "message": "Tema",
     "description": "Título de la sección de configuración de tema en la página de configuración"
   },
+  "settings.loginMode": {
+    "message": "Modo de inicio de sesión",
+    "description": "Login-mode row title in general settings"
+  },
+  "loginMode.iframe": {
+    "message": "Ventana emergente integrada",
+    "description": "Login mode option: embedded iframe popup"
+  },
+  "loginMode.redirect": {
+    "message": "Redirección de página completa",
+    "description": "Login mode option: full-page redirect"
+  },
   "settings.seo": {
     "message": "Configuración SEO",
     "description": "Título de la sección de configuración SEO en la página de configuración"

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -807,6 +807,18 @@
     "message": "Teema",
     "description": "Asetussivun teemavalintojen osan otsikko"
   },
+  "settings.loginMode": {
+    "message": "Kirjautumistapa",
+    "description": "Login-mode row title in general settings"
+  },
+  "loginMode.iframe": {
+    "message": "Upotettu ponnahdusikkuna",
+    "description": "Login mode option: embedded iframe popup"
+  },
+  "loginMode.redirect": {
+    "message": "Koko sivun uudelleenohjaus",
+    "description": "Login mode option: full-page redirect"
+  },
   "settings.seo": {
     "message": "SEO-asetukset",
     "description": "Asetussivun SEO-asetusten osan otsikko"

--- a/src/i18n/fr/common.json
+++ b/src/i18n/fr/common.json
@@ -807,6 +807,18 @@
     "message": "Thème",
     "description": "Titre de la section des paramètres de thème dans la page des paramètres"
   },
+  "settings.loginMode": {
+    "message": "Mode de connexion",
+    "description": "Login-mode row title in general settings"
+  },
+  "loginMode.iframe": {
+    "message": "Fenêtre contextuelle intégrée",
+    "description": "Login mode option: embedded iframe popup"
+  },
+  "loginMode.redirect": {
+    "message": "Redirection pleine page",
+    "description": "Login mode option: full-page redirect"
+  },
   "settings.seo": {
     "message": "Paramètres SEO",
     "description": "Titre de la section des paramètres SEO dans la page des paramètres"

--- a/src/i18n/it/common.json
+++ b/src/i18n/it/common.json
@@ -807,6 +807,18 @@
     "message": "Tema",
     "description": "Titolo della sezione impostazioni tema nella pagina delle impostazioni"
   },
+  "settings.loginMode": {
+    "message": "Modalità di accesso",
+    "description": "Login-mode row title in general settings"
+  },
+  "loginMode.iframe": {
+    "message": "Popup incorporato",
+    "description": "Login mode option: embedded iframe popup"
+  },
+  "loginMode.redirect": {
+    "message": "Reindirizzamento a pagina intera",
+    "description": "Login mode option: full-page redirect"
+  },
   "settings.seo": {
     "message": "Impostazioni SEO",
     "description": "Titolo della sezione impostazioni SEO nella pagina delle impostazioni"

--- a/src/i18n/ja/common.json
+++ b/src/i18n/ja/common.json
@@ -807,6 +807,18 @@
     "message": "テーマ",
     "description": "設定ページのテーマ設定部分のタイトル"
   },
+  "settings.loginMode": {
+    "message": "ログイン方式",
+    "description": "Login-mode row title in general settings"
+  },
+  "loginMode.iframe": {
+    "message": "埋め込みポップアップ",
+    "description": "Login mode option: embedded iframe popup"
+  },
+  "loginMode.redirect": {
+    "message": "ページ全体のリダイレクト",
+    "description": "Login mode option: full-page redirect"
+  },
   "settings.seo": {
     "message": "SEO設定",
     "description": "設定ページのSEO設定部分のタイトル"

--- a/src/i18n/ko/common.json
+++ b/src/i18n/ko/common.json
@@ -807,6 +807,18 @@
     "message": "테마",
     "description": "설정 페이지의 테마 설정 부분 제목"
   },
+  "settings.loginMode": {
+    "message": "로그인 방식",
+    "description": "Login-mode row title in general settings"
+  },
+  "loginMode.iframe": {
+    "message": "임베디드 팝업",
+    "description": "Login mode option: embedded iframe popup"
+  },
+  "loginMode.redirect": {
+    "message": "전체 페이지 리디렉션",
+    "description": "Login mode option: full-page redirect"
+  },
   "settings.seo": {
     "message": "SEO 설정",
     "description": "설정 페이지의 SEO 설정 부분 제목"

--- a/src/i18n/pl/common.json
+++ b/src/i18n/pl/common.json
@@ -807,6 +807,18 @@
     "message": "Motyw",
     "description": "Tytuł sekcji ustawień motywu na stronie ustawień"
   },
+  "settings.loginMode": {
+    "message": "Tryb logowania",
+    "description": "Login-mode row title in general settings"
+  },
+  "loginMode.iframe": {
+    "message": "Osadzone wyskakujące okno",
+    "description": "Login mode option: embedded iframe popup"
+  },
+  "loginMode.redirect": {
+    "message": "Przekierowanie pełnostronicowe",
+    "description": "Login mode option: full-page redirect"
+  },
   "settings.seo": {
     "message": "Ustawienia SEO",
     "description": "Tytuł sekcji ustawień SEO na stronie ustawień"

--- a/src/i18n/pt/common.json
+++ b/src/i18n/pt/common.json
@@ -807,6 +807,18 @@
     "message": "Tema",
     "description": "Título da seção de configurações de tema na página de configurações"
   },
+  "settings.loginMode": {
+    "message": "Modo de login",
+    "description": "Login-mode row title in general settings"
+  },
+  "loginMode.iframe": {
+    "message": "Pop-up incorporado",
+    "description": "Login mode option: embedded iframe popup"
+  },
+  "loginMode.redirect": {
+    "message": "Redirecionamento de página inteira",
+    "description": "Login mode option: full-page redirect"
+  },
   "settings.seo": {
     "message": "Configurações de SEO",
     "description": "Título da seção de configurações de SEO na página de configurações"

--- a/src/i18n/ru/common.json
+++ b/src/i18n/ru/common.json
@@ -807,6 +807,18 @@
     "message": "Тема",
     "description": "Заголовок раздела настроек темы на странице настроек"
   },
+  "settings.loginMode": {
+    "message": "Способ входа",
+    "description": "Login-mode row title in general settings"
+  },
+  "loginMode.iframe": {
+    "message": "Встроенное всплывающее окно",
+    "description": "Login mode option: embedded iframe popup"
+  },
+  "loginMode.redirect": {
+    "message": "Переход на отдельную страницу",
+    "description": "Login mode option: full-page redirect"
+  },
   "settings.seo": {
     "message": "Настройки SEO",
     "description": "Заголовок раздела настроек SEO на странице настроек"

--- a/src/i18n/sr/common.json
+++ b/src/i18n/sr/common.json
@@ -807,6 +807,18 @@
     "message": "Tema",
     "description": "Naslov dela sa podešavanjima teme na stranici sa podešavanjima"
   },
+  "settings.loginMode": {
+    "message": "Начин пријаве",
+    "description": "Login-mode row title in general settings"
+  },
+  "loginMode.iframe": {
+    "message": "Уграђени искачући прозор",
+    "description": "Login mode option: embedded iframe popup"
+  },
+  "loginMode.redirect": {
+    "message": "Преусмеравање целе странице",
+    "description": "Login mode option: full-page redirect"
+  },
   "settings.seo": {
     "message": "SEO podešavanja",
     "description": "Naslov dela sa SEO podešavanjima na stranici sa podešavanjima"

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -807,6 +807,18 @@
     "message": "Tema",
     "description": "Rubrik för tema-inställningar på inställningssidan"
   },
+  "settings.loginMode": {
+    "message": "Inloggningsläge",
+    "description": "Login-mode row title in general settings"
+  },
+  "loginMode.iframe": {
+    "message": "Inbäddad popup",
+    "description": "Login mode option: embedded iframe popup"
+  },
+  "loginMode.redirect": {
+    "message": "Helsidesomdirigering",
+    "description": "Login mode option: full-page redirect"
+  },
   "settings.seo": {
     "message": "SEO-inställningar",
     "description": "Rubrik för SEO-inställningar på inställningssidan"

--- a/src/i18n/uk/common.json
+++ b/src/i18n/uk/common.json
@@ -807,6 +807,18 @@
     "message": "Тема",
     "description": "Заголовок секції налаштувань теми на сторінці налаштувань"
   },
+  "settings.loginMode": {
+    "message": "Спосіб входу",
+    "description": "Login-mode row title in general settings"
+  },
+  "loginMode.iframe": {
+    "message": "Вбудоване спливаюче вікно",
+    "description": "Login mode option: embedded iframe popup"
+  },
+  "loginMode.redirect": {
+    "message": "Перенаправлення на сторінку",
+    "description": "Login mode option: full-page redirect"
+  },
   "settings.seo": {
     "message": "Налаштування SEO",
     "description": "Заголовок секції налаштувань SEO на сторінці налаштувань"

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -807,6 +807,18 @@
     "message": "主题",
     "description": "设置页面中的主题设置部分的标题"
   },
+  "settings.loginMode": {
+    "message": "登录方式",
+    "description": "通用设置中的登录方式行标题：选择登录时用弹窗嵌入（iframe）还是整页跳转"
+  },
+  "loginMode.iframe": {
+    "message": "弹窗嵌入",
+    "description": "登录方式选项：在当前页面内以内嵌 iframe 弹窗完成登录，不跳走"
+  },
+  "loginMode.redirect": {
+    "message": "整页跳转",
+    "description": "登录方式选项：跳转到登录页面完成登录后再返回"
+  },
   "settings.seo": {
     "message": "SEO设置",
     "description": "设置页面中的SEO设置部分的标题"

--- a/src/i18n/zh-TW/common.json
+++ b/src/i18n/zh-TW/common.json
@@ -807,6 +807,18 @@
     "message": "主題",
     "description": "設置頁面中的主題設置部分的標題"
   },
+  "settings.loginMode": {
+    "message": "登入方式",
+    "description": "Login-mode row title in general settings"
+  },
+  "loginMode.iframe": {
+    "message": "彈窗嵌入",
+    "description": "Login mode option: embedded iframe popup"
+  },
+  "loginMode.redirect": {
+    "message": "整頁跳轉",
+    "description": "Login mode option: full-page redirect"
+  },
   "settings.seo": {
     "message": "SEO設置",
     "description": "設置頁面中的SEO設置部分的標題"

--- a/src/utils/featureFlag.ts
+++ b/src/utils/featureFlag.ts
@@ -33,6 +33,7 @@ import { getCookie, removeCookie, setCookie } from 'typescript-cookie';
 // cycle. It is safe ONLY because `store` is dereferenced lazily inside
 // `readServerFlag` at call time — never at module top level. Keep it that way.
 import store from '@/store';
+import { getLoginMethodPreference } from './loginMethod';
 
 const COOKIE_NAME = 'FEATURES';
 const ALL_TOKEN = '__all__';
@@ -138,6 +139,10 @@ export function isFeatureEnabled(name: string): boolean {
 }
 
 export function isAuthIframeFeatureEnabled(): boolean {
+  // An explicit user choice in Settings wins over the URL / server feature flag.
+  const preference = getLoginMethodPreference();
+  if (preference === 'iframe') return true;
+  if (preference === 'redirect') return false;
   // OR of two flags, and the server sends both — so to force it OFF you must
   // disable both tokens: `?features=-auth-iframe,-iframe`.
   return isFeatureEnabled('auth-iframe') || isFeatureEnabled('iframe');

--- a/src/utils/loginMethod.ts
+++ b/src/utils/loginMethod.ts
@@ -1,0 +1,26 @@
+// User-chosen login presentation on the **web** surface: the embedded
+// iframe popup vs. the full-page redirect to AuthFrontend. Persisted in a
+// host-only cookie (survives reloads, shared with the rest of the app's
+// cookie-based prefs) and read by `isAuthIframeFeatureEnabled`.
+//
+// Native / desktop always use the iframe regardless of this preference
+// (a redirect can't return to an app://bundle window) — the callers short
+// -circuit on `isNative() || isDesktop()` before consulting this value.
+
+import { getCookie, setCookie } from 'typescript-cookie';
+
+const COOKIE_NAME = 'LOGIN_METHOD';
+const EXPIRY_DAYS = 365;
+
+export type LoginMethod = 'iframe' | 'redirect';
+
+export function getLoginMethodPreference(): LoginMethod | undefined {
+  const value = getCookie(COOKIE_NAME);
+  return value === 'iframe' || value === 'redirect' ? value : undefined;
+}
+
+export function setLoginMethodPreference(method: LoginMethod): void {
+  // Host-only (no `domain=`) so it does not collide with sibling
+  // PlatformFrontend / AuthFrontend cookies of the same name.
+  setCookie(COOKIE_NAME, method, { path: '/', expires: EXPIRY_DAYS });
+}


### PR DESCRIPTION
## What

Adds a **登录方式 / Login Mode** row under **Settings → General** so web users can choose how login is presented:

- **弹窗嵌入 (iframe)** — the embedded AuthFrontend popup, no navigation away.
- **整页跳转 (redirect)** — full-page redirect to AuthFrontend, returns via `/auth/callback`.

The choice persists in a host-only `LOGIN_METHOD` cookie and takes effect immediately (re-read on every login, no reload).

## Why

The iframe-vs-redirect behavior was previously only reachable via the `?features=auth-iframe` URL flag — not discoverable and not sticky in a UI-friendly way. This surfaces it as a first-class, persisted user preference.

## How it wires in

One decision function drives every login entry point (`store/common/actions.ts` login/logout, the router guard, and `crossSiteUser.ts`), so only `isAuthIframeFeatureEnabled()` needed to change:

```ts
const preference = getLoginMethodPreference();
if (preference === 'iframe') return true;
if (preference === 'redirect') return false;
return isFeatureEnabled('auth-iframe') || isFeatureEnabled('iframe'); // unchanged fallback
```

- **Default unchanged**: no cookie + no flag → still redirect on web; `?features=auth-iframe` still works when the user hasn't chosen explicitly.
- **Native / desktop untouched**: those callsites are `isNative() || isDesktop() || isAuthIframeFeatureEnabled()`, so the app always uses the iframe (a redirect can't return to an `app://bundle` window). The settings row is hidden on native/desktop.

## Files

- `src/utils/loginMethod.ts` (new) — get/set the `LOGIN_METHOD` cookie.
- `src/utils/featureFlag.ts` — `isAuthIframeFeatureEnabled()` honors the preference first.
- `src/components/user/LoginMode.vue` (new) — dropdown switcher (mirrors `Theme.vue`).
- `src/components/setting/General.vue` — web-only row.
- `src/i18n/*/common.json` — `settings.loginMode` / `loginMode.iframe` / `loginMode.redirect` (zh-CN + en authored, 16 other locales backfilled).

## Test

- `npx eslint` on all touched files → clean.
- `npx vue-tsc --noEmit` → no errors.
- `python3 scripts/check_i18n_coverage.py` → 17 locales × 44 namespaces all match zh-CN.

## 🤖 对抗评审

Self-review (small UI feature; only auth-flow touchpoint is the single `isAuthIframeFeatureEnabled()` fallthrough):
1. **Default preservation** — unset preference falls through to the original flag logic; web default stays redirect. ✓
2. **Explicit redirect vs active flag** — an explicit `redirect` choice correctly overrides a lingering `?features=auth-iframe` cookie on web; native/desktop short-circuit before the preference so they're unaffected. ✓
3. **Immediacy** — cookie is read per call (not cached), so switching takes effect on the next login without reload. ✓
4. **Cookie hygiene** — host-only (no `domain=`) so it can't collide with sibling PlatformFrontend / AuthFrontend cookies. ✓
5. **i18n guard** — all 17 locales carry the 3 new keys; coverage script passes. ✓

**VERDICT: CLEAN.**