### PR TITLE
feat(settings): per-service pricing/display overrides for site admins + editable markup previews

### DIFF
--- a/change/@acedatacloud-nexior-8e8e9e7f-3f80-41dd-8ab6-64de98241024.json
+++ b/change/@acedatacloud-nexior-8e8e9e7f-3f80-41dd-8ab6-64de98241024.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(settings): per-service pricing/display overrides tab for site admins + editable markup previews",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/setting/Site.vue
+++ b/src/components/setting/Site.vue
@@ -115,9 +115,21 @@
           <el-input-number :model-value="markupPercent" :min="0" :max="500" :step="5" @change="onSaveMarkup" />
           <span class="markup-suffix">%</span>
         </div>
-        <p class="markup-example">
-          {{ $t('site.message.markupExample', { from: markupExampleFrom, to: markupExampleTo }) }}
-        </p>
+        <div class="markup-example-row">
+          <span class="markup-sample-label">{{ $t('site.services.preview.sampleLabel') }}</span>
+          <el-input-number
+            v-model="sampleBase"
+            :min="0"
+            :step="1"
+            :precision="2"
+            size="small"
+            :controls-position="'right'"
+            class="markup-sample-input"
+          />
+          <span class="markup-example">
+            {{ $t('site.message.markupExample', { from: markupExampleFrom, to: markupExampleTo }) }}
+          </span>
+        </div>
       </div>
     </section>
 
@@ -188,7 +200,10 @@ export default defineComponent({
   },
   data() {
     return {
-      primaryColorPresets: PRIMARY_COLOR_PRESETS
+      primaryColorPresets: PRIMARY_COLOR_PRESETS,
+      // Editable base price for the live markup example (default 10) so the
+      // preview isn't a hard-coded number.
+      sampleBase: 10 as number
     };
   },
   computed: {
@@ -222,10 +237,13 @@ export default defineComponent({
       return Math.round(getSiteMarkupRatio(this.site) * 100);
     },
     markupExampleFrom(): string {
-      return getPriceString({ value: 10 });
+      return getPriceString({ value: this.sampleBaseSafe });
     },
     markupExampleTo(): string {
-      return getPriceString({ value: applyMarkup(10, this.markupPercent / 100) });
+      return getPriceString({ value: applyMarkup(this.sampleBaseSafe, this.markupPercent / 100) });
+    },
+    sampleBaseSafe(): number {
+      return typeof this.sampleBase === 'number' && this.sampleBase >= 0 ? this.sampleBase : 0;
     }
   },
   methods: {
@@ -323,6 +341,22 @@ export default defineComponent({
   margin: 0;
   font-size: 12px;
   color: var(--el-text-color-secondary);
+}
+
+.markup-example-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.markup-sample-label {
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+}
+
+.markup-sample-input {
+  width: 120px;
 }
 
 .favicon {

--- a/src/components/setting/SiteServices.vue
+++ b/src/components/setting/SiteServices.vue
@@ -1,0 +1,574 @@
+<template>
+  <div class="site-services-settings">
+    <section-notice tone="admin" :text="$t('common.settings.adminOnlyHint')" />
+    <div class="header">
+      <div>
+        <p class="settings-title">{{ $t('site.services.title') }}</p>
+        <p class="settings-tip">{{ $t('site.services.tip') }}</p>
+      </div>
+      <el-button type="primary" round :icon="Plus" :disabled="!site?.id" @click="onOpenCreate">
+        {{ $t('site.services.addButton') }}
+      </el-button>
+    </div>
+
+    <el-card v-loading="loading" shadow="never" class="list-card">
+      <el-empty v-if="!loading && rows.length === 0" :description="$t('site.services.empty')" :image-size="80" />
+      <el-table v-else :data="rows" stripe class="overrides-table">
+        <el-table-column :label="$t('site.services.field.service')" min-width="200">
+          <template #default="{ row }">
+            <div class="service-cell">
+              <strong>{{ catalogTitle(row.service) }}</strong>
+              <div v-if="catalogAlias(row.service)" class="muted">{{ catalogAlias(row.service) }}</div>
+            </div>
+          </template>
+        </el-table-column>
+        <el-table-column :label="$t('site.services.field.visible')" width="96" align="center">
+          <template #default="{ row }">
+            <el-tag :type="row.visible === false ? 'info' : 'success'" size="small" round effect="plain">
+              {{ row.visible === false ? $t('site.services.status.hidden') : $t('site.services.status.visible') }}
+            </el-tag>
+          </template>
+        </el-table-column>
+        <el-table-column :label="$t('site.field.markupRatio')" width="110" align="right">
+          <template #default="{ row }">
+            <span v-if="row.markup_ratio === null || row.markup_ratio === undefined" class="muted">{{
+              $t('site.services.status.inherit')
+            }}</span>
+            <span v-else>{{ formatMarkup(row.markup_ratio) }}</span>
+          </template>
+        </el-table-column>
+        <el-table-column :label="$t('site.services.field.displayTitle')" min-width="140">
+          <template #default="{ row }">
+            <span v-if="!row.display_title" class="muted">—</span>
+            <span v-else>{{ row.display_title }}</span>
+          </template>
+        </el-table-column>
+        <el-table-column :label="$t('site.services.field.sortOrder')" width="88" align="right">
+          <template #default="{ row }">{{ row.sort_order ?? 0 }}</template>
+        </el-table-column>
+        <el-table-column :label="$t('site.services.field.action')" width="150" align="right" fixed="right">
+          <template #default="{ row }">
+            <el-button size="small" round @click="onOpenEdit(row)">{{ $t('common.button.edit') }}</el-button>
+            <el-button size="small" round type="danger" plain :loading="deletingId === row.id" @click="onDelete(row)">
+              {{ $t('common.button.delete') }}
+            </el-button>
+          </template>
+        </el-table-column>
+      </el-table>
+    </el-card>
+
+    <!-- create / edit share one dialog: `editingRow` null = create -->
+    <el-dialog
+      v-model="dialogVisible"
+      :title="editingRow ? $t('site.services.dialog.edit') : $t('site.services.dialog.create')"
+      :width="mobile ? '94vw' : '520px'"
+      :close-on-click-modal="false"
+      append-to-body
+    >
+      <el-form :model="form" label-position="top" class="form" @submit.prevent>
+        <el-form-item :label="$t('site.services.field.service')" required>
+          <el-input v-if="editingRow" :model-value="catalogTitle(editingRow.service)" readonly />
+          <el-select
+            v-else
+            v-model="form.service"
+            :placeholder="$t('site.services.placeholder.service')"
+            filterable
+            :loading="catalogLoading"
+            class="w-full"
+          >
+            <el-option
+              v-for="svc in catalogOptions"
+              :key="svc.id"
+              :label="optionLabel(svc)"
+              :value="svc.id"
+              :disabled="isAlreadyOverridden(svc.id)"
+            >
+              <span class="option-title">{{ svc.title || svc.id }}</span>
+              <span v-if="svc.alias" class="option-alias">{{ svc.alias }}</span>
+              <el-tag v-if="isAlreadyOverridden(svc.id)" size="small" type="info" round>
+                {{ $t('site.services.message.alreadyOverridden') }}
+              </el-tag>
+            </el-option>
+          </el-select>
+        </el-form-item>
+
+        <el-form-item :label="$t('site.services.field.visible')">
+          <el-switch v-model="form.visible" />
+          <span class="field-tip">{{ $t('site.services.tip.visible') }}</span>
+        </el-form-item>
+
+        <el-form-item :label="$t('site.field.markupRatio')">
+          <div class="markup-row">
+            <el-input-number
+              v-model="form.markupRatio"
+              :min="0"
+              :max="markupMax"
+              :step="0.05"
+              :precision="2"
+              :controls-position="'right'"
+              :placeholder="$t('site.services.placeholder.markup')"
+              class="markup-input"
+            />
+            <span v-if="typeof form.markupRatio === 'number'" class="markup-percent">
+              {{ formatMarkup(form.markupRatio) }}
+            </span>
+          </div>
+          <span class="field-tip">{{ $t('site.services.tip.markup') }}</span>
+          <div class="money-preview">
+            <span class="field-tip">{{ $t('site.services.preview.sampleLabel') }}</span>
+            <el-input-number
+              v-model="sampleBase"
+              :min="0"
+              :step="1"
+              :precision="2"
+              size="small"
+              :controls-position="'right'"
+              class="sample-input"
+            />
+            <span class="preview-result">
+              {{ $t('site.message.markupExample', { from: previewFrom, to: previewTo }) }}
+            </span>
+            <span v-if="typeof form.markupRatio !== 'number'" class="field-tip">
+              {{ $t('site.services.preview.inherit', { percent: formatMarkup(siteDefaultRatio) }) }}
+            </span>
+          </div>
+        </el-form-item>
+
+        <el-form-item :label="$t('site.services.field.displayTitle')">
+          <el-input
+            v-model="form.displayTitle"
+            :placeholder="$t('site.services.placeholder.displayTitle')"
+            maxlength="120"
+            show-word-limit
+            clearable
+          />
+        </el-form-item>
+
+        <el-form-item :label="$t('site.services.field.displaySummary')">
+          <el-input
+            v-model="form.displaySummary"
+            type="textarea"
+            :rows="3"
+            :placeholder="$t('site.services.placeholder.displaySummary')"
+            clearable
+          />
+        </el-form-item>
+
+        <el-form-item :label="$t('site.services.field.sortOrder')">
+          <el-input-number
+            v-model="form.sortOrder"
+            :min="-1000"
+            :max="1000"
+            :step="1"
+            :precision="0"
+            :controls-position="'right'"
+          />
+          <span class="field-tip">{{ $t('site.services.tip.sortOrder') }}</span>
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button round @click="dialogVisible = false">{{ $t('common.button.cancel') }}</el-button>
+        <el-button
+          type="primary"
+          round
+          :loading="submitting"
+          :disabled="!editingRow && !form.service"
+          @click="onSubmit"
+        >
+          {{ editingRow ? $t('common.button.update') : $t('common.button.create') }}
+        </el-button>
+      </template>
+    </el-dialog>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, markRaw } from 'vue';
+import {
+  ElButton,
+  ElCard,
+  ElTable,
+  ElTableColumn,
+  ElEmpty,
+  ElDialog,
+  ElForm,
+  ElFormItem,
+  ElInput,
+  ElInputNumber,
+  ElSelect,
+  ElOption,
+  ElSwitch,
+  ElTag,
+  ElMessage,
+  ElMessageBox,
+  vLoading
+} from 'element-plus';
+import { Plus } from '@element-plus/icons-vue';
+import { serviceOperator, siteServiceOverrideOperator } from '@/operators';
+import type { IService, ISite, ISiteServiceOverride } from '@/models';
+import SectionNotice from '@/components/setting/SectionNotice.vue';
+import { getPriceString, applyMarkup, getSiteMarkupRatio, MARKUP_RATIO_MAX } from '@/utils';
+
+// Pre-fetch the whole catalog once so each override row can show the
+// service title/alias without an N+1 per-row GET. If a tenant ever
+// exceeds this many services the picker should switch to remote search.
+const CATALOG_PAGE_LIMIT = 1000;
+
+interface IForm {
+  service: string;
+  visible: boolean;
+  markupRatio: number | undefined;
+  displayTitle: string;
+  displaySummary: string;
+  sortOrder: number;
+}
+
+function emptyForm(): IForm {
+  return { service: '', visible: true, markupRatio: undefined, displayTitle: '', displaySummary: '', sortOrder: 0 };
+}
+
+/**
+ * Settings tab — per-service overrides for the current Site: hide a
+ * service, rename its homepage card, write a custom summary, reorder,
+ * or charge a per-service markup on top of (overriding) the site-wide
+ * default. Mirrors the developer-portal Services tab but scoped to the
+ * 站长 running their own white-label site. Admin+web gated by Setting.vue.
+ */
+export default defineComponent({
+  name: 'SiteServicesSetting',
+  components: {
+    ElButton,
+    ElCard,
+    ElTable,
+    ElTableColumn,
+    ElEmpty,
+    ElDialog,
+    ElForm,
+    ElFormItem,
+    ElInput,
+    ElInputNumber,
+    ElSelect,
+    ElOption,
+    ElSwitch,
+    ElTag,
+    SectionNotice
+  },
+  directives: {
+    loading: vLoading
+  },
+  data() {
+    return {
+      Plus: markRaw(Plus),
+      loading: false,
+      catalogLoading: false,
+      submitting: false,
+      deletingId: '' as string,
+      rows: [] as ISiteServiceOverride[],
+      catalog: [] as IService[],
+      catalogMap: {} as Record<string, IService>,
+      dialogVisible: false,
+      editingRow: null as ISiteServiceOverride | null,
+      form: emptyForm(),
+      sampleBase: 10 as number,
+      mobile: typeof window !== 'undefined' && window.innerWidth < 768
+    };
+  },
+  computed: {
+    site(): ISite {
+      return this.$store.getters.site || {};
+    },
+    siteId(): string | undefined {
+      return this.site?.id;
+    },
+    // Site-wide default a blank per-service markup inherits.
+    siteDefaultRatio(): number {
+      return getSiteMarkupRatio(this.site);
+    },
+    // Never below the loaded value so el-input-number can't silently clamp a
+    // pre-existing out-of-range override down on dialog open.
+    markupMax(): number {
+      const cur = typeof this.form.markupRatio === 'number' ? this.form.markupRatio : 0;
+      return Math.max(MARKUP_RATIO_MAX, cur);
+    },
+    effectiveRatio(): number {
+      return typeof this.form.markupRatio === 'number' ? this.form.markupRatio : this.siteDefaultRatio;
+    },
+    previewFrom(): string {
+      return getPriceString({ value: this.sampleBaseSafe });
+    },
+    previewTo(): string {
+      return getPriceString({ value: applyMarkup(this.sampleBaseSafe, this.effectiveRatio) });
+    },
+    sampleBaseSafe(): number {
+      return typeof this.sampleBase === 'number' && this.sampleBase >= 0 ? this.sampleBase : 0;
+    },
+    catalogOptions(): IService[] {
+      return [...this.catalog].sort((a, b) => {
+        const at = (a.title || a.id || '').toLowerCase();
+        const bt = (b.title || b.id || '').toLowerCase();
+        return at < bt ? -1 : at > bt ? 1 : 0;
+      });
+    }
+  },
+  watch: {
+    siteId: {
+      immediate: true,
+      handler(id: string | undefined) {
+        if (id) {
+          this.onFetch();
+          this.onFetchCatalog();
+        } else {
+          this.rows = [];
+        }
+      }
+    }
+  },
+  mounted() {
+    window.addEventListener('resize', this.onResize);
+  },
+  beforeUnmount() {
+    window.removeEventListener('resize', this.onResize);
+  },
+  methods: {
+    onResize() {
+      this.mobile = window.innerWidth < 768;
+    },
+    formatMarkup(ratio: number): string {
+      // 0 -> "+0%", 0.3 -> "+30%", 1.25 -> "+125%". One decimal max so
+      // binary-FP drift doesn't render as "+30.0000004%".
+      const pct = Math.round(ratio * 100 * 10) / 10;
+      const text = Number.isInteger(pct) ? pct.toFixed(0) : pct.toFixed(1);
+      return `+${text}%`;
+    },
+    catalogTitle(serviceId?: string): string {
+      if (!serviceId) return '—';
+      const svc = this.catalogMap[serviceId];
+      return svc?.title || svc?.alias || serviceId;
+    },
+    catalogAlias(serviceId?: string): string | undefined {
+      if (!serviceId) return undefined;
+      return this.catalogMap[serviceId]?.alias;
+    },
+    optionLabel(svc: IService): string {
+      // el-select filterable matches the label string, so concatenate
+      // title + alias + id to make all three searchable.
+      return [svc.title, svc.alias, svc.id].filter(Boolean).join(' ');
+    },
+    isAlreadyOverridden(serviceId?: string): boolean {
+      if (!serviceId) return false;
+      return this.rows.some((r) => r.service === serviceId && r.id !== this.editingRow?.id);
+    },
+    async onFetch(): Promise<void> {
+      if (!this.siteId) {
+        this.rows = [];
+        return;
+      }
+      this.loading = true;
+      try {
+        const { data } = await siteServiceOverrideOperator.getAll({
+          site: this.siteId,
+          limit: CATALOG_PAGE_LIMIT,
+          ordering: 'sort_order,created_at'
+        });
+        this.rows = data.items || [];
+      } catch {
+        ElMessage.error(this.$t('site.services.message.fetchFailed'));
+      } finally {
+        this.loading = false;
+      }
+    },
+    async onFetchCatalog(): Promise<void> {
+      if (this.catalog.length > 0) return;
+      this.catalogLoading = true;
+      try {
+        const { data } = await serviceOperator.getAll({ limit: CATALOG_PAGE_LIMIT });
+        this.catalog = data.items || [];
+        this.catalogMap = Object.fromEntries(this.catalog.map((s) => [s.id as string, s]));
+      } catch {
+        // Non-fatal: the table still renders with raw service ids.
+      } finally {
+        this.catalogLoading = false;
+      }
+    },
+    onOpenCreate(): void {
+      this.editingRow = null;
+      this.form = emptyForm();
+      this.dialogVisible = true;
+    },
+    onOpenEdit(row: ISiteServiceOverride): void {
+      this.editingRow = row;
+      this.form = {
+        service: row.service || '',
+        visible: row.visible !== false,
+        markupRatio: typeof row.markup_ratio === 'number' ? row.markup_ratio : undefined,
+        displayTitle: row.display_title_source ?? row.display_title ?? '',
+        displaySummary: row.display_summary_source ?? row.display_summary ?? '',
+        sortOrder: typeof row.sort_order === 'number' ? row.sort_order : 0
+      };
+      this.dialogVisible = true;
+    },
+    async onSubmit(): Promise<void> {
+      if (this.editingRow) {
+        await this.onUpdate();
+      } else {
+        await this.onCreate();
+      }
+    },
+    async onCreate(): Promise<void> {
+      if (!this.siteId || !this.form.service) {
+        ElMessage.error(this.$t('site.services.message.serviceRequired'));
+        return;
+      }
+      this.submitting = true;
+      try {
+        await siteServiceOverrideOperator.create({
+          site: this.siteId,
+          service: this.form.service,
+          visible: this.form.visible,
+          markup_ratio: typeof this.form.markupRatio === 'number' ? this.form.markupRatio : null,
+          display_title: this.form.displayTitle.trim() || null,
+          display_summary: this.form.displaySummary.trim() || null,
+          sort_order: typeof this.form.sortOrder === 'number' ? this.form.sortOrder : 0
+        });
+        ElMessage.success(this.$t('site.services.message.saved'));
+        this.dialogVisible = false;
+        await this.onFetch();
+      } catch (err) {
+        ElMessage.error(this.extractError(err) || this.$t('site.services.message.saveFailed'));
+      } finally {
+        this.submitting = false;
+      }
+    },
+    async onUpdate(): Promise<void> {
+      const row = this.editingRow;
+      if (!row?.id) return;
+      this.submitting = true;
+      try {
+        await siteServiceOverrideOperator.update(row.id, {
+          visible: this.form.visible,
+          markup_ratio: typeof this.form.markupRatio === 'number' ? this.form.markupRatio : null,
+          display_title: this.form.displayTitle.trim() || null,
+          display_summary: this.form.displaySummary.trim() || null,
+          sort_order: typeof this.form.sortOrder === 'number' ? this.form.sortOrder : 0
+        });
+        ElMessage.success(this.$t('site.services.message.saved'));
+        this.dialogVisible = false;
+        this.editingRow = null;
+        await this.onFetch();
+      } catch (err) {
+        ElMessage.error(this.extractError(err) || this.$t('site.services.message.saveFailed'));
+      } finally {
+        this.submitting = false;
+      }
+    },
+    async onDelete(row: ISiteServiceOverride): Promise<void> {
+      if (!row.id) return;
+      try {
+        await ElMessageBox.confirm(
+          this.$t('site.services.message.deleteConfirm', { name: this.catalogTitle(row.service) }),
+          this.$t('common.button.delete'),
+          {
+            type: 'warning',
+            confirmButtonText: this.$t('common.button.delete'),
+            cancelButtonText: this.$t('common.button.cancel'),
+            confirmButtonClass: 'el-button--danger'
+          }
+        );
+      } catch {
+        return; // cancelled
+      }
+      this.deletingId = row.id;
+      try {
+        await siteServiceOverrideOperator.delete(row.id);
+        ElMessage.success(this.$t('site.services.message.deleted'));
+        await this.onFetch();
+      } catch (err) {
+        ElMessage.error(this.extractError(err) || this.$t('site.services.message.deleteFailed'));
+      } finally {
+        this.deletingId = '';
+      }
+    },
+    extractError(err: unknown): string {
+      const detail = (err as { response?: { data?: Record<string, unknown> } })?.response?.data;
+      if (detail && typeof detail === 'object') {
+        return Object.values(detail).flat().filter(Boolean).join('; ');
+      }
+      return '';
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.site-services-settings {
+  .header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+    margin: 12px 0;
+  }
+  .settings-title {
+    font-weight: 600;
+  }
+  .settings-tip {
+    font-size: 12px;
+    color: var(--el-text-color-secondary);
+    margin-top: 2px;
+  }
+  .list-card {
+    border: 1px solid var(--el-border-color-lighter);
+  }
+  .overrides-table {
+    width: 100%;
+    .service-cell {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+  }
+  .muted {
+    color: var(--el-text-color-secondary);
+    font-size: 12px;
+  }
+  .form {
+    .markup-row {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      .markup-input {
+        width: 150px;
+      }
+      .markup-percent {
+        font-variant-numeric: tabular-nums;
+        color: var(--el-color-primary);
+        font-weight: 600;
+      }
+    }
+    .money-preview {
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 6px;
+      .sample-input {
+        width: 120px;
+      }
+      .preview-result {
+        font-size: 13px;
+        font-weight: 600;
+        color: var(--el-text-color-primary);
+      }
+    }
+    .field-tip {
+      font-size: 12px;
+      color: var(--el-text-color-secondary);
+    }
+  }
+  .option-alias {
+    margin-left: 8px;
+    font-size: 12px;
+    color: var(--el-text-color-secondary);
+  }
+}
+</style>

--- a/src/components/user/Setting.vue
+++ b/src/components/user/Setting.vue
@@ -44,6 +44,9 @@
         <div v-else-if="currentTab === SETTING_TAB_SITE && isSiteConfigVisible">
           <site-setting />
         </div>
+        <div v-else-if="currentTab === SETTING_TAB_SITE_SERVICES && isSiteConfigVisible">
+          <site-services-setting />
+        </div>
         <div v-else-if="currentTab === SETTING_TAB_SEO && isSiteConfigVisible">
           <seo-setting />
         </div>
@@ -85,6 +88,7 @@ import {
   faUserShield,
   faMagic,
   faMoneyBill,
+  faTags,
   faInfoCircle,
   faSitemap,
   faGlobe,
@@ -95,6 +99,7 @@ import GeneralSetting from '@/components/setting/General.vue';
 import ByokSetting from '@/components/setting/Byok.vue';
 import MemorySetting from '@/components/setting/Memory.vue';
 import SiteSetting from '@/components/setting/Site.vue';
+import SiteServicesSetting from '@/components/setting/SiteServices.vue';
 import SeoSetting from '@/components/setting/Seo.vue';
 import DistributionSetting from '@/components/setting/Distribution.vue';
 import FunctionSetting from '@/components/setting/Function.vue';
@@ -112,6 +117,7 @@ import {
   SETTING_TAB_GENERAL,
   SETTING_TAB_SEO,
   SETTING_TAB_SITE,
+  SETTING_TAB_SITE_SERVICES,
   SETTING_TAB_SUBSITES,
   SETTING_TAB_CUSTOM_DOMAIN,
   SETTING_TAB_LOCAL_TOOLS,
@@ -132,6 +138,7 @@ export default defineComponent({
     ByokSetting,
     MemorySetting,
     SiteSetting,
+    SiteServicesSetting,
     SeoSetting,
     DistributionSetting,
     FunctionSetting,
@@ -164,6 +171,7 @@ export default defineComponent({
       SETTING_TAB_API_KEY,
       SETTING_TAB_MEMORY,
       SETTING_TAB_SITE,
+      SETTING_TAB_SITE_SERVICES,
       SETTING_TAB_SEO,
       SETTING_TAB_DISTRIBUTION,
       SETTING_TAB_FUNCTION,
@@ -187,6 +195,15 @@ export default defineComponent({
           key: SETTING_TAB_SITE,
           label: this.$t('common.settings.site'),
           icon: faBell,
+          visible: this.isSiteConfigVisible
+        },
+        {
+          // Per-service overrides for THIS site: hide / rename / re-summarize /
+          // reorder a service, or set a per-service markup on top of the
+          // site-wide default. Admin + web gated like the other site config.
+          key: SETTING_TAB_SITE_SERVICES,
+          label: this.$t('common.settings.siteServices'),
+          icon: faTags,
           visible: this.isSiteConfigVisible
         },
         {

--- a/src/constants/setting.ts
+++ b/src/constants/setting.ts
@@ -9,6 +9,7 @@ export const SETTING_TAB_GENERAL = 'general';
 export const SETTING_TAB_API_KEY = 'apiKey';
 export const SETTING_TAB_MEMORY = 'memory';
 export const SETTING_TAB_SITE = 'site';
+export const SETTING_TAB_SITE_SERVICES = 'siteServices';
 export const SETTING_TAB_SEO = 'seo';
 export const SETTING_TAB_DISTRIBUTION = 'distribution';
 export const SETTING_TAB_FUNCTION = 'function';
@@ -23,6 +24,7 @@ export type SettingTabKey =
   | typeof SETTING_TAB_API_KEY
   | typeof SETTING_TAB_MEMORY
   | typeof SETTING_TAB_SITE
+  | typeof SETTING_TAB_SITE_SERVICES
   | typeof SETTING_TAB_SEO
   | typeof SETTING_TAB_DISTRIBUTION
   | typeof SETTING_TAB_FUNCTION

--- a/src/i18n/ar/common.json
+++ b/src/i18n/ar/common.json
@@ -1431,5 +1431,8 @@
   "settings.cuConsentDeny": {
     "message": "Deny",
     "description": "Deny button of the on-demand consent dialog."
+  },
+  "settings.siteServices": {
+    "message": "الخدمات"
   }
 }

--- a/src/i18n/ar/site.json
+++ b/src/i18n/ar/site.json
@@ -670,5 +670,101 @@
   "autoTranslate.error": {
     "message": "فشل تبديل الترجمة التلقائية، يُرجى المحاولة مرة أخرى",
     "description": "Fallback error toast when the enable/disable HTTP call fails with no detail"
+  },
+  "services.title": {
+    "message": "التسعير والعرض لكل خدمة"
+  },
+  "services.tip": {
+    "message": "إخفاء الخدمات الفردية أو إعادة تسميتها أو تسعيرها أو إعادة ترتيبها. الهامش الفارغ يرث الإعداد الافتراضي للموقع. حذف صف يعيد الخدمة إلى إعدادات الكتالوج."
+  },
+  "services.addButton": {
+    "message": "إضافة"
+  },
+  "services.empty": {
+    "message": "لا توجد تجاوزات — كل خدمة تستخدم إعداداتها الافتراضية."
+  },
+  "services.field.service": {
+    "message": "الخدمة"
+  },
+  "services.field.visible": {
+    "message": "مرئي"
+  },
+  "services.field.displayTitle": {
+    "message": "الاسم المعروض"
+  },
+  "services.field.displaySummary": {
+    "message": "الملخص المعروض"
+  },
+  "services.field.sortOrder": {
+    "message": "الترتيب"
+  },
+  "services.field.action": {
+    "message": "إجراءات"
+  },
+  "services.status.visible": {
+    "message": "معروض"
+  },
+  "services.status.hidden": {
+    "message": "مخفي"
+  },
+  "services.status.inherit": {
+    "message": "موروث"
+  },
+  "services.dialog.create": {
+    "message": "إضافة تجاوز للخدمة"
+  },
+  "services.dialog.edit": {
+    "message": "تعديل تجاوز الخدمة"
+  },
+  "services.placeholder.service": {
+    "message": "اختر خدمة من الكتالوج"
+  },
+  "services.placeholder.markup": {
+    "message": "اتركه فارغًا لوراثة إعداد الموقع الافتراضي"
+  },
+  "services.placeholder.displayTitle": {
+    "message": "اتركه فارغًا لاستخدام اسم الكتالوج"
+  },
+  "services.placeholder.displaySummary": {
+    "message": "اتركه فارغًا لاستخدام وصف الكتالوج"
+  },
+  "services.tip.visible": {
+    "message": "عند الإيقاف تُخفى الخدمة على الصفحة الرئيسية (يحتفظ من يملكها بالوصول)."
+  },
+  "services.tip.markup": {
+    "message": "0% سعر المنصة؛ 0.5 يعني +50%؛ حتى +500%. فارغ = افتراضي الموقع."
+  },
+  "services.tip.sortOrder": {
+    "message": "الأرقام الأصغر تظهر أولًا."
+  },
+  "services.preview.sampleLabel": {
+    "message": "سعر أساسي كمثال"
+  },
+  "services.preview.inherit": {
+    "message": "(يرث هامش الموقع الافتراضي {percent})"
+  },
+  "services.message.alreadyOverridden": {
+    "message": "مضاف بالفعل"
+  },
+  "services.message.serviceRequired": {
+    "message": "يرجى اختيار خدمة أولاً"
+  },
+  "services.message.saved": {
+    "message": "تم الحفظ"
+  },
+  "services.message.deleted": {
+    "message": "تم الحذف"
+  },
+  "services.message.deleteConfirm": {
+    "message": "حذف تجاوز «{name}»؟ ستعود الخدمة إلى إعدادات الكتالوج."
+  },
+  "services.message.saveFailed": {
+    "message": "فشل الحفظ، حاول مرة أخرى"
+  },
+  "services.message.deleteFailed": {
+    "message": "فشل الحذف، حاول مرة أخرى"
+  },
+  "services.message.fetchFailed": {
+    "message": "فشل تحميل تجاوزات الخدمة"
   }
 }

--- a/src/i18n/de/common.json
+++ b/src/i18n/de/common.json
@@ -1431,5 +1431,8 @@
   "settings.cuConsentDeny": {
     "message": "Deny",
     "description": "Deny button of the on-demand consent dialog."
+  },
+  "settings.siteServices": {
+    "message": "Dienste"
   }
 }

--- a/src/i18n/de/site.json
+++ b/src/i18n/de/site.json
@@ -670,5 +670,101 @@
   "autoTranslate.error": {
     "message": "Umschalten der automatischen Übersetzung fehlgeschlagen, bitte erneut versuchen",
     "description": "Fallback error toast when the enable/disable HTTP call fails with no detail"
+  },
+  "services.title": {
+    "message": "Preise & Anzeige je Dienst"
+  },
+  "services.tip": {
+    "message": "Einzelne Dienste ausblenden, umbenennen, bepreisen oder sortieren. Ein leerer Aufschlag erbt den Standard der Website. Das Löschen einer Zeile stellt die Katalog-Standards wieder her."
+  },
+  "services.addButton": {
+    "message": "Hinzufügen"
+  },
+  "services.empty": {
+    "message": "Noch keine Überschreibungen — jeder Dienst nutzt seine Standardwerte."
+  },
+  "services.field.service": {
+    "message": "Dienst"
+  },
+  "services.field.visible": {
+    "message": "Sichtbar"
+  },
+  "services.field.displayTitle": {
+    "message": "Anzeigename"
+  },
+  "services.field.displaySummary": {
+    "message": "Anzeige-Beschreibung"
+  },
+  "services.field.sortOrder": {
+    "message": "Sortierung"
+  },
+  "services.field.action": {
+    "message": "Aktionen"
+  },
+  "services.status.visible": {
+    "message": "Angezeigt"
+  },
+  "services.status.hidden": {
+    "message": "Ausgeblendet"
+  },
+  "services.status.inherit": {
+    "message": "Geerbt"
+  },
+  "services.dialog.create": {
+    "message": "Dienst-Überschreibung hinzufügen"
+  },
+  "services.dialog.edit": {
+    "message": "Dienst-Überschreibung bearbeiten"
+  },
+  "services.placeholder.service": {
+    "message": "Dienst aus dem Katalog wählen"
+  },
+  "services.placeholder.markup": {
+    "message": "Leer lassen, um den Website-Standard zu erben"
+  },
+  "services.placeholder.displayTitle": {
+    "message": "Leer lassen, um den Katalognamen zu verwenden"
+  },
+  "services.placeholder.displaySummary": {
+    "message": "Leer lassen, um die Katalogbeschreibung zu verwenden"
+  },
+  "services.tip.visible": {
+    "message": "Deaktiviert wird der Dienst auf der Startseite ausgeblendet (bestehende Nutzer behalten den Zugriff)."
+  },
+  "services.tip.markup": {
+    "message": "0 % = Plattformpreis; 0,5 = +50 %; max. +500 %. Leer = Website-Standard."
+  },
+  "services.tip.sortOrder": {
+    "message": "Kleinere Zahlen zuerst."
+  },
+  "services.preview.sampleLabel": {
+    "message": "Beispiel-Basispreis"
+  },
+  "services.preview.inherit": {
+    "message": "(erbt den Standardaufschlag der Website {percent})"
+  },
+  "services.message.alreadyOverridden": {
+    "message": "Bereits hinzugefügt"
+  },
+  "services.message.serviceRequired": {
+    "message": "Bitte zuerst einen Dienst wählen"
+  },
+  "services.message.saved": {
+    "message": "Gespeichert"
+  },
+  "services.message.deleted": {
+    "message": "Gelöscht"
+  },
+  "services.message.deleteConfirm": {
+    "message": "Überschreibung für „{name}“ löschen? Der Dienst kehrt zu den Katalog-Standards zurück."
+  },
+  "services.message.saveFailed": {
+    "message": "Speichern fehlgeschlagen, bitte erneut versuchen"
+  },
+  "services.message.deleteFailed": {
+    "message": "Löschen fehlgeschlagen, bitte erneut versuchen"
+  },
+  "services.message.fetchFailed": {
+    "message": "Dienst-Überschreibungen konnten nicht geladen werden"
   }
 }

--- a/src/i18n/el/common.json
+++ b/src/i18n/el/common.json
@@ -1431,5 +1431,8 @@
   "settings.cuConsentDeny": {
     "message": "Deny",
     "description": "Deny button of the on-demand consent dialog."
+  },
+  "settings.siteServices": {
+    "message": "Υπηρεσίες"
   }
 }

--- a/src/i18n/el/site.json
+++ b/src/i18n/el/site.json
@@ -670,5 +670,101 @@
   "autoTranslate.error": {
     "message": "Η εναλλαγή αυτόματης μετάφρασης απέτυχε, δοκιμάστε ξανά",
     "description": "Fallback error toast when the enable/disable HTTP call fails with no detail"
+  },
+  "services.title": {
+    "message": "Τιμολόγηση & εμφάνιση ανά υπηρεσία"
+  },
+  "services.tip": {
+    "message": "Απόκρυψη, μετονομασία, τιμολόγηση ή αναδιάταξη μεμονωμένων υπηρεσιών. Ένα κενό περιθώριο κληρονομεί την προεπιλογή του ιστότοπου. Η διαγραφή γραμμής επαναφέρει τις προεπιλογές."
+  },
+  "services.addButton": {
+    "message": "Προσθήκη"
+  },
+  "services.empty": {
+    "message": "Καμία παράκαμψη — κάθε υπηρεσία χρησιμοποιεί τις προεπιλογές της."
+  },
+  "services.field.service": {
+    "message": "Υπηρεσία"
+  },
+  "services.field.visible": {
+    "message": "Ορατό"
+  },
+  "services.field.displayTitle": {
+    "message": "Εμφανιζόμενο όνομα"
+  },
+  "services.field.displaySummary": {
+    "message": "Εμφανιζόμενη περίληψη"
+  },
+  "services.field.sortOrder": {
+    "message": "Σειρά"
+  },
+  "services.field.action": {
+    "message": "Ενέργειες"
+  },
+  "services.status.visible": {
+    "message": "Εμφανίζεται"
+  },
+  "services.status.hidden": {
+    "message": "Κρυφό"
+  },
+  "services.status.inherit": {
+    "message": "Κληρονομείται"
+  },
+  "services.dialog.create": {
+    "message": "Προσθήκη παράκαμψης υπηρεσίας"
+  },
+  "services.dialog.edit": {
+    "message": "Επεξεργασία παράκαμψης υπηρεσίας"
+  },
+  "services.placeholder.service": {
+    "message": "Επιλέξτε υπηρεσία από τον κατάλογο"
+  },
+  "services.placeholder.markup": {
+    "message": "Αφήστε το κενό για κληρονομιά της προεπιλογής"
+  },
+  "services.placeholder.displayTitle": {
+    "message": "Αφήστε κενό για χρήση του ονόματος καταλόγου"
+  },
+  "services.placeholder.displaySummary": {
+    "message": "Αφήστε κενό για χρήση της περιγραφής καταλόγου"
+  },
+  "services.tip.visible": {
+    "message": "Όταν είναι ανενεργό, η υπηρεσία κρύβεται στην αρχική (όσοι την έχουν διατηρούν πρόσβαση)."
+  },
+  "services.tip.markup": {
+    "message": "0% = τιμή πλατφόρμας· 0,5 = +50%· έως +500%. Κενό = προεπιλογή ιστότοπου."
+  },
+  "services.tip.sortOrder": {
+    "message": "Οι μικρότεροι αριθμοί προηγούνται."
+  },
+  "services.preview.sampleLabel": {
+    "message": "Δείγμα βασικής τιμής"
+  },
+  "services.preview.inherit": {
+    "message": "(κληρονομεί την προεπιλεγμένη προσαύξηση {percent})"
+  },
+  "services.message.alreadyOverridden": {
+    "message": "Έχει ήδη προστεθεί"
+  },
+  "services.message.serviceRequired": {
+    "message": "Επιλέξτε πρώτα μια υπηρεσία"
+  },
+  "services.message.saved": {
+    "message": "Αποθηκεύτηκε"
+  },
+  "services.message.deleted": {
+    "message": "Διαγράφηκε"
+  },
+  "services.message.deleteConfirm": {
+    "message": "Διαγραφή παράκαμψης για «{name}»; Η υπηρεσία επιστρέφει στις προεπιλογές."
+  },
+  "services.message.saveFailed": {
+    "message": "Αποτυχία αποθήκευσης, δοκιμάστε ξανά"
+  },
+  "services.message.deleteFailed": {
+    "message": "Αποτυχία διαγραφής, δοκιμάστε ξανά"
+  },
+  "services.message.fetchFailed": {
+    "message": "Αποτυχία φόρτωσης παρακάμψεων υπηρεσίας"
   }
 }

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -1431,5 +1431,9 @@
   "settings.cuConsentDeny": {
     "message": "Deny",
     "description": "Deny button of the on-demand consent dialog."
+  },
+  "settings.siteServices": {
+    "message": "Services",
+    "description": "Nav label for the per-service pricing & display settings Tab"
   }
 }

--- a/src/i18n/en/site.json
+++ b/src/i18n/en/site.json
@@ -670,5 +670,102 @@
   "autoTranslate.error": {
     "message": "Failed to toggle auto-translation, please retry",
     "description": "Fallback error toast when the enable/disable HTTP call fails with no detail"
+  },
+  "services.title": {
+    "message": "Per-service pricing & display"
+  },
+  "services.tip": {
+    "message": "Hide, rename, re-price or reorder individual services. A blank markup inherits the site-wide default. Deleting a row reverts the service to its catalog defaults."
+  },
+  "services.addButton": {
+    "message": "Add override"
+  },
+  "services.empty": {
+    "message": "No overrides yet — every service uses its catalog defaults."
+  },
+  "services.field.service": {
+    "message": "Service"
+  },
+  "services.field.visible": {
+    "message": "Visible"
+  },
+  "services.field.displayTitle": {
+    "message": "Display name"
+  },
+  "services.field.displaySummary": {
+    "message": "Display summary",
+    "description": "Per-service override: custom summary shown on this site's homepage card"
+  },
+  "services.field.sortOrder": {
+    "message": "Sort"
+  },
+  "services.field.action": {
+    "message": "Actions"
+  },
+  "services.status.visible": {
+    "message": "Shown"
+  },
+  "services.status.hidden": {
+    "message": "Hidden"
+  },
+  "services.status.inherit": {
+    "message": "Inherit"
+  },
+  "services.dialog.create": {
+    "message": "Add service override"
+  },
+  "services.dialog.edit": {
+    "message": "Edit service override"
+  },
+  "services.placeholder.service": {
+    "message": "Pick a service from the catalog"
+  },
+  "services.placeholder.markup": {
+    "message": "Leave blank to inherit the site default"
+  },
+  "services.placeholder.displayTitle": {
+    "message": "Leave blank to use the catalog title"
+  },
+  "services.placeholder.displaySummary": {
+    "message": "Leave blank to use the catalog description"
+  },
+  "services.tip.visible": {
+    "message": "When off, the service is hidden on this site's homepage (users who already have it keep access)."
+  },
+  "services.tip.markup": {
+    "message": "0% = platform price; 0.5 = +50%; up to +500%. Leave blank to inherit the site default."
+  },
+  "services.tip.sortOrder": {
+    "message": "Lower numbers come first."
+  },
+  "services.preview.sampleLabel": {
+    "message": "Sample base price"
+  },
+  "services.preview.inherit": {
+    "message": "(inheriting the site default markup {percent})"
+  },
+  "services.message.alreadyOverridden": {
+    "message": "Already added"
+  },
+  "services.message.serviceRequired": {
+    "message": "Please pick a service first"
+  },
+  "services.message.saved": {
+    "message": "Saved"
+  },
+  "services.message.deleted": {
+    "message": "Deleted"
+  },
+  "services.message.deleteConfirm": {
+    "message": "Delete the override for “{name}”? The service reverts to its catalog defaults."
+  },
+  "services.message.saveFailed": {
+    "message": "Save failed, please try again"
+  },
+  "services.message.deleteFailed": {
+    "message": "Delete failed, please try again"
+  },
+  "services.message.fetchFailed": {
+    "message": "Failed to load service overrides"
   }
 }

--- a/src/i18n/es/common.json
+++ b/src/i18n/es/common.json
@@ -1431,5 +1431,8 @@
   "settings.cuConsentDeny": {
     "message": "Deny",
     "description": "Deny button of the on-demand consent dialog."
+  },
+  "settings.siteServices": {
+    "message": "Servicios"
   }
 }

--- a/src/i18n/es/site.json
+++ b/src/i18n/es/site.json
@@ -670,5 +670,101 @@
   "autoTranslate.error": {
     "message": "Error al cambiar la traducción automática, inténtalo de nuevo",
     "description": "Fallback error toast when the enable/disable HTTP call fails with no detail"
+  },
+  "services.title": {
+    "message": "Precio y visualización por servicio"
+  },
+  "services.tip": {
+    "message": "Oculta, renombra, tarifica o reordena servicios concretos. Un recargo vacío hereda el valor por defecto del sitio. Eliminar una fila restablece los valores del catálogo."
+  },
+  "services.addButton": {
+    "message": "Añadir"
+  },
+  "services.empty": {
+    "message": "Sin anulaciones — cada servicio usa sus valores por defecto."
+  },
+  "services.field.service": {
+    "message": "Servicio"
+  },
+  "services.field.visible": {
+    "message": "Visible"
+  },
+  "services.field.displayTitle": {
+    "message": "Nombre visible"
+  },
+  "services.field.displaySummary": {
+    "message": "Resumen visible"
+  },
+  "services.field.sortOrder": {
+    "message": "Orden"
+  },
+  "services.field.action": {
+    "message": "Acciones"
+  },
+  "services.status.visible": {
+    "message": "Mostrado"
+  },
+  "services.status.hidden": {
+    "message": "Oculto"
+  },
+  "services.status.inherit": {
+    "message": "Heredado"
+  },
+  "services.dialog.create": {
+    "message": "Añadir anulación de servicio"
+  },
+  "services.dialog.edit": {
+    "message": "Editar anulación de servicio"
+  },
+  "services.placeholder.service": {
+    "message": "Elige un servicio del catálogo"
+  },
+  "services.placeholder.markup": {
+    "message": "Déjalo vacío para heredar el valor del sitio"
+  },
+  "services.placeholder.displayTitle": {
+    "message": "Déjalo vacío para usar el nombre del catálogo"
+  },
+  "services.placeholder.displaySummary": {
+    "message": "Déjalo vacío para usar la descripción del catálogo"
+  },
+  "services.tip.visible": {
+    "message": "Si se desactiva, el servicio se oculta en la portada del sitio (quien ya lo tiene mantiene el acceso)."
+  },
+  "services.tip.markup": {
+    "message": "0% = precio de plataforma; 0,5 = +50%; hasta +500%. Vacío = valor del sitio."
+  },
+  "services.tip.sortOrder": {
+    "message": "Los números más bajos van primero."
+  },
+  "services.preview.sampleLabel": {
+    "message": "Precio base de ejemplo"
+  },
+  "services.preview.inherit": {
+    "message": "(hereda el recargo por defecto del sitio {percent})"
+  },
+  "services.message.alreadyOverridden": {
+    "message": "Ya añadido"
+  },
+  "services.message.serviceRequired": {
+    "message": "Elige primero un servicio"
+  },
+  "services.message.saved": {
+    "message": "Guardado"
+  },
+  "services.message.deleted": {
+    "message": "Eliminado"
+  },
+  "services.message.deleteConfirm": {
+    "message": "¿Eliminar la anulación de «{name}»? El servicio vuelve a los valores del catálogo."
+  },
+  "services.message.saveFailed": {
+    "message": "Error al guardar, inténtalo de nuevo"
+  },
+  "services.message.deleteFailed": {
+    "message": "Error al eliminar, inténtalo de nuevo"
+  },
+  "services.message.fetchFailed": {
+    "message": "No se pudieron cargar las anulaciones de servicio"
   }
 }

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -1431,5 +1431,8 @@
   "settings.cuConsentDeny": {
     "message": "Deny",
     "description": "Deny button of the on-demand consent dialog."
+  },
+  "settings.siteServices": {
+    "message": "Palvelut"
   }
 }

--- a/src/i18n/fi/site.json
+++ b/src/i18n/fi/site.json
@@ -670,5 +670,101 @@
   "autoTranslate.error": {
     "message": "Automaattisen käännöksen vaihtaminen epäonnistui, yritä uudelleen",
     "description": "Fallback error toast when the enable/disable HTTP call fails with no detail"
+  },
+  "services.title": {
+    "message": "Palvelukohtainen hinnoittelu ja näyttö"
+  },
+  "services.tip": {
+    "message": "Piilota, nimeä uudelleen, hinnoittele tai järjestä yksittäisiä palveluja. Tyhjä lisä perii sivuston oletuksen. Rivin poisto palauttaa luettelon oletukset."
+  },
+  "services.addButton": {
+    "message": "Lisää"
+  },
+  "services.empty": {
+    "message": "Ei ohituksia — jokainen palvelu käyttää oletuksiaan."
+  },
+  "services.field.service": {
+    "message": "Palvelu"
+  },
+  "services.field.visible": {
+    "message": "Näkyvä"
+  },
+  "services.field.displayTitle": {
+    "message": "Näyttönimi"
+  },
+  "services.field.displaySummary": {
+    "message": "Näyttökuvaus"
+  },
+  "services.field.sortOrder": {
+    "message": "Järjestys"
+  },
+  "services.field.action": {
+    "message": "Toiminnot"
+  },
+  "services.status.visible": {
+    "message": "Näkyy"
+  },
+  "services.status.hidden": {
+    "message": "Piilotettu"
+  },
+  "services.status.inherit": {
+    "message": "Peritty"
+  },
+  "services.dialog.create": {
+    "message": "Lisää palvelun ohitus"
+  },
+  "services.dialog.edit": {
+    "message": "Muokkaa palvelun ohitusta"
+  },
+  "services.placeholder.service": {
+    "message": "Valitse palvelu luettelosta"
+  },
+  "services.placeholder.markup": {
+    "message": "Jätä tyhjäksi periäksesi sivuston oletuksen"
+  },
+  "services.placeholder.displayTitle": {
+    "message": "Jätä tyhjäksi käyttääksesi luettelon nimeä"
+  },
+  "services.placeholder.displaySummary": {
+    "message": "Jätä tyhjäksi käyttääksesi luettelon kuvausta"
+  },
+  "services.tip.visible": {
+    "message": "Pois päältä palvelu on piilotettu etusivulla (nykyiset käyttäjät säilyttävät pääsyn)."
+  },
+  "services.tip.markup": {
+    "message": "0 % = alustan hinta; 0,5 = +50 %; enintään +500 %. Tyhjä = sivuston oletus."
+  },
+  "services.tip.sortOrder": {
+    "message": "Pienemmät numerot ensin."
+  },
+  "services.preview.sampleLabel": {
+    "message": "Esimerkkihinta"
+  },
+  "services.preview.inherit": {
+    "message": "(perii sivuston oletuslisän {percent})"
+  },
+  "services.message.alreadyOverridden": {
+    "message": "Jo lisätty"
+  },
+  "services.message.serviceRequired": {
+    "message": "Valitse ensin palvelu"
+  },
+  "services.message.saved": {
+    "message": "Tallennettu"
+  },
+  "services.message.deleted": {
+    "message": "Poistettu"
+  },
+  "services.message.deleteConfirm": {
+    "message": "Poistetaanko kohteen ”{name}” ohitus? Palvelu palaa luettelon oletuksiin."
+  },
+  "services.message.saveFailed": {
+    "message": "Tallennus epäonnistui, yritä uudelleen"
+  },
+  "services.message.deleteFailed": {
+    "message": "Poisto epäonnistui, yritä uudelleen"
+  },
+  "services.message.fetchFailed": {
+    "message": "Palveluohitusten lataus epäonnistui"
   }
 }

--- a/src/i18n/fr/common.json
+++ b/src/i18n/fr/common.json
@@ -1431,5 +1431,8 @@
   "settings.cuConsentDeny": {
     "message": "Deny",
     "description": "Deny button of the on-demand consent dialog."
+  },
+  "settings.siteServices": {
+    "message": "Services"
   }
 }

--- a/src/i18n/fr/site.json
+++ b/src/i18n/fr/site.json
@@ -670,5 +670,101 @@
   "autoTranslate.error": {
     "message": "Échec du basculement de la traduction automatique, veuillez réessayer",
     "description": "Fallback error toast when the enable/disable HTTP call fails with no detail"
+  },
+  "services.title": {
+    "message": "Tarification et affichage par service"
+  },
+  "services.tip": {
+    "message": "Masquez, renommez, tarifez ou réordonnez chaque service. Une majoration vide hérite du défaut du site. Supprimer une ligne rétablit les valeurs par défaut du catalogue."
+  },
+  "services.addButton": {
+    "message": "Ajouter"
+  },
+  "services.empty": {
+    "message": "Aucune surcharge — chaque service utilise ses valeurs par défaut."
+  },
+  "services.field.service": {
+    "message": "Service"
+  },
+  "services.field.visible": {
+    "message": "Visible"
+  },
+  "services.field.displayTitle": {
+    "message": "Nom affiché"
+  },
+  "services.field.displaySummary": {
+    "message": "Résumé affiché"
+  },
+  "services.field.sortOrder": {
+    "message": "Ordre"
+  },
+  "services.field.action": {
+    "message": "Actions"
+  },
+  "services.status.visible": {
+    "message": "Affiché"
+  },
+  "services.status.hidden": {
+    "message": "Masqué"
+  },
+  "services.status.inherit": {
+    "message": "Hérité"
+  },
+  "services.dialog.create": {
+    "message": "Ajouter une surcharge de service"
+  },
+  "services.dialog.edit": {
+    "message": "Modifier la surcharge de service"
+  },
+  "services.placeholder.service": {
+    "message": "Choisir un service du catalogue"
+  },
+  "services.placeholder.markup": {
+    "message": "Laisser vide pour hériter du défaut du site"
+  },
+  "services.placeholder.displayTitle": {
+    "message": "Laisser vide pour utiliser le nom du catalogue"
+  },
+  "services.placeholder.displaySummary": {
+    "message": "Laisser vide pour utiliser la description du catalogue"
+  },
+  "services.tip.visible": {
+    "message": "Désactivé, le service est masqué sur l'accueil du site (les utilisateurs qui l'ont déjà gardent l'accès)."
+  },
+  "services.tip.markup": {
+    "message": "0 % = prix plateforme ; 0,5 = +50 % ; max +500 %. Vide = défaut du site."
+  },
+  "services.tip.sortOrder": {
+    "message": "Les plus petits nombres passent en premier."
+  },
+  "services.preview.sampleLabel": {
+    "message": "Prix de base d'exemple"
+  },
+  "services.preview.inherit": {
+    "message": "(hérite de la majoration par défaut du site {percent})"
+  },
+  "services.message.alreadyOverridden": {
+    "message": "Déjà ajouté"
+  },
+  "services.message.serviceRequired": {
+    "message": "Veuillez d'abord choisir un service"
+  },
+  "services.message.saved": {
+    "message": "Enregistré"
+  },
+  "services.message.deleted": {
+    "message": "Supprimé"
+  },
+  "services.message.deleteConfirm": {
+    "message": "Supprimer la surcharge de « {name} » ? Le service revient aux valeurs du catalogue."
+  },
+  "services.message.saveFailed": {
+    "message": "Échec de l'enregistrement, réessayez"
+  },
+  "services.message.deleteFailed": {
+    "message": "Échec de la suppression, réessayez"
+  },
+  "services.message.fetchFailed": {
+    "message": "Échec du chargement des surcharges de service"
   }
 }

--- a/src/i18n/it/common.json
+++ b/src/i18n/it/common.json
@@ -1431,5 +1431,8 @@
   "settings.cuConsentDeny": {
     "message": "Deny",
     "description": "Deny button of the on-demand consent dialog."
+  },
+  "settings.siteServices": {
+    "message": "Servizi"
   }
 }

--- a/src/i18n/it/site.json
+++ b/src/i18n/it/site.json
@@ -670,5 +670,101 @@
   "autoTranslate.error": {
     "message": "Impossibile cambiare la traduzione automatica, riprova",
     "description": "Fallback error toast when the enable/disable HTTP call fails with no detail"
+  },
+  "services.title": {
+    "message": "Prezzi e visualizzazione per servizio"
+  },
+  "services.tip": {
+    "message": "Nascondi, rinomina, prezza o riordina singoli servizi. Un ricarico vuoto eredita il valore predefinito del sito. Eliminare una riga ripristina i valori del catalogo."
+  },
+  "services.addButton": {
+    "message": "Aggiungi"
+  },
+  "services.empty": {
+    "message": "Nessuna sovrascrittura — ogni servizio usa i valori predefiniti."
+  },
+  "services.field.service": {
+    "message": "Servizio"
+  },
+  "services.field.visible": {
+    "message": "Visibile"
+  },
+  "services.field.displayTitle": {
+    "message": "Nome visualizzato"
+  },
+  "services.field.displaySummary": {
+    "message": "Riepilogo visualizzato"
+  },
+  "services.field.sortOrder": {
+    "message": "Ordine"
+  },
+  "services.field.action": {
+    "message": "Azioni"
+  },
+  "services.status.visible": {
+    "message": "Mostrato"
+  },
+  "services.status.hidden": {
+    "message": "Nascosto"
+  },
+  "services.status.inherit": {
+    "message": "Ereditato"
+  },
+  "services.dialog.create": {
+    "message": "Aggiungi sovrascrittura servizio"
+  },
+  "services.dialog.edit": {
+    "message": "Modifica sovrascrittura servizio"
+  },
+  "services.placeholder.service": {
+    "message": "Scegli un servizio dal catalogo"
+  },
+  "services.placeholder.markup": {
+    "message": "Lascia vuoto per ereditare il valore del sito"
+  },
+  "services.placeholder.displayTitle": {
+    "message": "Lascia vuoto per usare il nome del catalogo"
+  },
+  "services.placeholder.displaySummary": {
+    "message": "Lascia vuoto per usare la descrizione del catalogo"
+  },
+  "services.tip.visible": {
+    "message": "Se disattivato, il servizio è nascosto in home (chi lo possiede mantiene l'accesso)."
+  },
+  "services.tip.markup": {
+    "message": "0% = prezzo piattaforma; 0,5 = +50%; fino a +500%. Vuoto = valore del sito."
+  },
+  "services.tip.sortOrder": {
+    "message": "I numeri più bassi vengono prima."
+  },
+  "services.preview.sampleLabel": {
+    "message": "Prezzo base di esempio"
+  },
+  "services.preview.inherit": {
+    "message": "(eredita il ricarico predefinito del sito {percent})"
+  },
+  "services.message.alreadyOverridden": {
+    "message": "Già aggiunto"
+  },
+  "services.message.serviceRequired": {
+    "message": "Seleziona prima un servizio"
+  },
+  "services.message.saved": {
+    "message": "Salvato"
+  },
+  "services.message.deleted": {
+    "message": "Eliminato"
+  },
+  "services.message.deleteConfirm": {
+    "message": "Eliminare la sovrascrittura di «{name}»? Il servizio torna ai valori del catalogo."
+  },
+  "services.message.saveFailed": {
+    "message": "Salvataggio non riuscito, riprova"
+  },
+  "services.message.deleteFailed": {
+    "message": "Eliminazione non riuscita, riprova"
+  },
+  "services.message.fetchFailed": {
+    "message": "Impossibile caricare le sovrascritture dei servizi"
   }
 }

--- a/src/i18n/ja/common.json
+++ b/src/i18n/ja/common.json
@@ -1431,5 +1431,8 @@
   "settings.cuConsentDeny": {
     "message": "Deny",
     "description": "Deny button of the on-demand consent dialog."
+  },
+  "settings.siteServices": {
+    "message": "サービス"
   }
 }

--- a/src/i18n/ja/site.json
+++ b/src/i18n/ja/site.json
@@ -670,5 +670,101 @@
   "autoTranslate.error": {
     "message": "自動翻訳の切り替えに失敗しました。再試行してください",
     "description": "Fallback error toast when the enable/disable HTTP call fails with no detail"
+  },
+  "services.title": {
+    "message": "サービス別の価格と表示"
+  },
+  "services.tip": {
+    "message": "個々のサービスを非表示・改名・個別価格・並べ替えできます。加算を空にするとサイト既定を継承します。行を削除すると既定表示に戻ります。"
+  },
+  "services.addButton": {
+    "message": "上書きを追加"
+  },
+  "services.empty": {
+    "message": "上書きはまだありません。すべてのサービスは既定を使用します。"
+  },
+  "services.field.service": {
+    "message": "サービス"
+  },
+  "services.field.visible": {
+    "message": "表示"
+  },
+  "services.field.displayTitle": {
+    "message": "表示名"
+  },
+  "services.field.displaySummary": {
+    "message": "表示概要"
+  },
+  "services.field.sortOrder": {
+    "message": "並び順"
+  },
+  "services.field.action": {
+    "message": "操作"
+  },
+  "services.status.visible": {
+    "message": "表示"
+  },
+  "services.status.hidden": {
+    "message": "非表示"
+  },
+  "services.status.inherit": {
+    "message": "継承"
+  },
+  "services.dialog.create": {
+    "message": "サービス上書きを追加"
+  },
+  "services.dialog.edit": {
+    "message": "サービス上書きを編集"
+  },
+  "services.placeholder.service": {
+    "message": "カタログからサービスを選択"
+  },
+  "services.placeholder.markup": {
+    "message": "空にするとサイト既定を継承"
+  },
+  "services.placeholder.displayTitle": {
+    "message": "空にするとカタログ名を使用"
+  },
+  "services.placeholder.displaySummary": {
+    "message": "空にするとカタログの説明を使用"
+  },
+  "services.tip.visible": {
+    "message": "オフにするとこのサイトのトップで非表示になります（既に持つユーザーは引き続き利用可）。"
+  },
+  "services.tip.markup": {
+    "message": "0% は平台原価、0.5 は +50%、上限 500%。空にするとサイト既定を継承。"
+  },
+  "services.tip.sortOrder": {
+    "message": "数値が小さいほど先に表示。"
+  },
+  "services.preview.sampleLabel": {
+    "message": "サンプル原価"
+  },
+  "services.preview.inherit": {
+    "message": "（サイト既定の加算 {percent} を継承）"
+  },
+  "services.message.alreadyOverridden": {
+    "message": "追加済み"
+  },
+  "services.message.serviceRequired": {
+    "message": "先にサービスを選択してください"
+  },
+  "services.message.saved": {
+    "message": "保存しました"
+  },
+  "services.message.deleted": {
+    "message": "削除しました"
+  },
+  "services.message.deleteConfirm": {
+    "message": "「{name}」の上書きを削除しますか？既定の表示と価格に戻ります。"
+  },
+  "services.message.saveFailed": {
+    "message": "保存に失敗しました。後でもう一度お試しください"
+  },
+  "services.message.deleteFailed": {
+    "message": "削除に失敗しました。後でもう一度お試しください"
+  },
+  "services.message.fetchFailed": {
+    "message": "サービス上書きの読み込みに失敗しました"
   }
 }

--- a/src/i18n/ko/common.json
+++ b/src/i18n/ko/common.json
@@ -1431,5 +1431,8 @@
   "settings.cuConsentDeny": {
     "message": "Deny",
     "description": "Deny button of the on-demand consent dialog."
+  },
+  "settings.siteServices": {
+    "message": "서비스"
   }
 }

--- a/src/i18n/ko/site.json
+++ b/src/i18n/ko/site.json
@@ -670,5 +670,101 @@
   "autoTranslate.error": {
     "message": "자동 번역을 전환하지 못했습니다. 다시 시도해 주세요",
     "description": "Fallback error toast when the enable/disable HTTP call fails with no detail"
+  },
+  "services.title": {
+    "message": "서비스별 가격 및 표시"
+  },
+  "services.tip": {
+    "message": "개별 서비스를 숨기거나 이름 변경, 개별 가격, 정렬할 수 있습니다. 가산을 비우면 사이트 기본값을 상속합니다. 행을 삭제하면 기본 표시로 돌아갑니다."
+  },
+  "services.addButton": {
+    "message": "재정의 추가"
+  },
+  "services.empty": {
+    "message": "재정의가 없습니다. 모든 서비스가 기본값을 사용합니다."
+  },
+  "services.field.service": {
+    "message": "서비스"
+  },
+  "services.field.visible": {
+    "message": "표시"
+  },
+  "services.field.displayTitle": {
+    "message": "표시 이름"
+  },
+  "services.field.displaySummary": {
+    "message": "표시 요약"
+  },
+  "services.field.sortOrder": {
+    "message": "정렬"
+  },
+  "services.field.action": {
+    "message": "작업"
+  },
+  "services.status.visible": {
+    "message": "표시됨"
+  },
+  "services.status.hidden": {
+    "message": "숨김"
+  },
+  "services.status.inherit": {
+    "message": "상속"
+  },
+  "services.dialog.create": {
+    "message": "서비스 재정의 추가"
+  },
+  "services.dialog.edit": {
+    "message": "서비스 재정의 편집"
+  },
+  "services.placeholder.service": {
+    "message": "카탈로그에서 서비스 선택"
+  },
+  "services.placeholder.markup": {
+    "message": "비우면 사이트 기본값 상속"
+  },
+  "services.placeholder.displayTitle": {
+    "message": "비우면 카탈로그 이름 사용"
+  },
+  "services.placeholder.displaySummary": {
+    "message": "비우면 카탈로그 설명 사용"
+  },
+  "services.tip.visible": {
+    "message": "끄면 이 사이트 홈에서 숨겨집니다(이미 보유한 사용자는 계속 이용 가능)."
+  },
+  "services.tip.markup": {
+    "message": "0%는 플랫폼 원가, 0.5는 +50%, 최대 500%. 비우면 사이트 기본값 상속."
+  },
+  "services.tip.sortOrder": {
+    "message": "숫자가 작을수록 먼저 표시."
+  },
+  "services.preview.sampleLabel": {
+    "message": "예시 원가"
+  },
+  "services.preview.inherit": {
+    "message": "(사이트 기본 가산 {percent} 상속)"
+  },
+  "services.message.alreadyOverridden": {
+    "message": "이미 추가됨"
+  },
+  "services.message.serviceRequired": {
+    "message": "먼저 서비스를 선택하세요"
+  },
+  "services.message.saved": {
+    "message": "저장됨"
+  },
+  "services.message.deleted": {
+    "message": "삭제됨"
+  },
+  "services.message.deleteConfirm": {
+    "message": "'{name}' 재정의를 삭제할까요? 기본 표시와 가격으로 돌아갑니다."
+  },
+  "services.message.saveFailed": {
+    "message": "저장 실패, 나중에 다시 시도하세요"
+  },
+  "services.message.deleteFailed": {
+    "message": "삭제 실패, 나중에 다시 시도하세요"
+  },
+  "services.message.fetchFailed": {
+    "message": "서비스 재정의를 불러오지 못했습니다"
   }
 }

--- a/src/i18n/pl/common.json
+++ b/src/i18n/pl/common.json
@@ -1431,5 +1431,8 @@
   "settings.cuConsentDeny": {
     "message": "Deny",
     "description": "Deny button of the on-demand consent dialog."
+  },
+  "settings.siteServices": {
+    "message": "Usługi"
   }
 }

--- a/src/i18n/pl/site.json
+++ b/src/i18n/pl/site.json
@@ -670,5 +670,101 @@
   "autoTranslate.error": {
     "message": "Nie udało się przełączyć automatycznego tłumaczenia, spróbuj ponownie",
     "description": "Fallback error toast when the enable/disable HTTP call fails with no detail"
+  },
+  "services.title": {
+    "message": "Ceny i wyświetlanie dla usług"
+  },
+  "services.tip": {
+    "message": "Ukrywaj, zmieniaj nazwy, wyceniaj lub sortuj poszczególne usługi. Pusty narzut dziedziczy domyślną wartość witryny. Usunięcie wiersza przywraca domyślne wartości katalogu."
+  },
+  "services.addButton": {
+    "message": "Dodaj"
+  },
+  "services.empty": {
+    "message": "Brak nadpisań — każda usługa używa wartości domyślnych."
+  },
+  "services.field.service": {
+    "message": "Usługa"
+  },
+  "services.field.visible": {
+    "message": "Widoczny"
+  },
+  "services.field.displayTitle": {
+    "message": "Nazwa wyświetlana"
+  },
+  "services.field.displaySummary": {
+    "message": "Wyświetlany opis"
+  },
+  "services.field.sortOrder": {
+    "message": "Kolejność"
+  },
+  "services.field.action": {
+    "message": "Akcje"
+  },
+  "services.status.visible": {
+    "message": "Pokazany"
+  },
+  "services.status.hidden": {
+    "message": "Ukryty"
+  },
+  "services.status.inherit": {
+    "message": "Dziedziczone"
+  },
+  "services.dialog.create": {
+    "message": "Dodaj nadpisanie usługi"
+  },
+  "services.dialog.edit": {
+    "message": "Edytuj nadpisanie usługi"
+  },
+  "services.placeholder.service": {
+    "message": "Wybierz usługę z katalogu"
+  },
+  "services.placeholder.markup": {
+    "message": "Pozostaw puste, aby odziedziczyć domyślne"
+  },
+  "services.placeholder.displayTitle": {
+    "message": "Pozostaw puste, aby użyć nazwy z katalogu"
+  },
+  "services.placeholder.displaySummary": {
+    "message": "Pozostaw puste, aby użyć opisu z katalogu"
+  },
+  "services.tip.visible": {
+    "message": "Wyłączona usługa jest ukryta na stronie głównej (obecni użytkownicy zachowują dostęp)."
+  },
+  "services.tip.markup": {
+    "message": "0% = cena platformy; 0,5 = +50%; do +500%. Puste = domyślne witryny."
+  },
+  "services.tip.sortOrder": {
+    "message": "Mniejsze liczby są pierwsze."
+  },
+  "services.preview.sampleLabel": {
+    "message": "Przykładowa cena bazowa"
+  },
+  "services.preview.inherit": {
+    "message": "(dziedziczy domyślny narzut witryny {percent})"
+  },
+  "services.message.alreadyOverridden": {
+    "message": "Już dodano"
+  },
+  "services.message.serviceRequired": {
+    "message": "Najpierw wybierz usługę"
+  },
+  "services.message.saved": {
+    "message": "Zapisano"
+  },
+  "services.message.deleted": {
+    "message": "Usunięto"
+  },
+  "services.message.deleteConfirm": {
+    "message": "Usunąć nadpisanie dla „{name}”? Usługa wróci do wartości katalogu."
+  },
+  "services.message.saveFailed": {
+    "message": "Zapis nie powiódł się, spróbuj ponownie"
+  },
+  "services.message.deleteFailed": {
+    "message": "Usuwanie nie powiodło się, spróbuj ponownie"
+  },
+  "services.message.fetchFailed": {
+    "message": "Nie udało się wczytać nadpisań usług"
   }
 }

--- a/src/i18n/pt/common.json
+++ b/src/i18n/pt/common.json
@@ -1431,5 +1431,8 @@
   "settings.cuConsentDeny": {
     "message": "Deny",
     "description": "Deny button of the on-demand consent dialog."
+  },
+  "settings.siteServices": {
+    "message": "Serviços"
   }
 }

--- a/src/i18n/pt/site.json
+++ b/src/i18n/pt/site.json
@@ -670,5 +670,101 @@
   "autoTranslate.error": {
     "message": "Falha ao alternar a tradução automática, tente novamente",
     "description": "Fallback error toast when the enable/disable HTTP call fails with no detail"
+  },
+  "services.title": {
+    "message": "Preço e exibição por serviço"
+  },
+  "services.tip": {
+    "message": "Oculte, renomeie, precifique ou reordene serviços individuais. Um acréscimo vazio herda o padrão do site. Excluir uma linha restaura os padrões do catálogo."
+  },
+  "services.addButton": {
+    "message": "Adicionar"
+  },
+  "services.empty": {
+    "message": "Sem substituições — cada serviço usa seus padrões."
+  },
+  "services.field.service": {
+    "message": "Serviço"
+  },
+  "services.field.visible": {
+    "message": "Visível"
+  },
+  "services.field.displayTitle": {
+    "message": "Nome exibido"
+  },
+  "services.field.displaySummary": {
+    "message": "Resumo exibido"
+  },
+  "services.field.sortOrder": {
+    "message": "Ordem"
+  },
+  "services.field.action": {
+    "message": "Ações"
+  },
+  "services.status.visible": {
+    "message": "Exibido"
+  },
+  "services.status.hidden": {
+    "message": "Oculto"
+  },
+  "services.status.inherit": {
+    "message": "Herdado"
+  },
+  "services.dialog.create": {
+    "message": "Adicionar substituição de serviço"
+  },
+  "services.dialog.edit": {
+    "message": "Editar substituição de serviço"
+  },
+  "services.placeholder.service": {
+    "message": "Escolha um serviço do catálogo"
+  },
+  "services.placeholder.markup": {
+    "message": "Deixe vazio para herdar o padrão do site"
+  },
+  "services.placeholder.displayTitle": {
+    "message": "Deixe vazio para usar o nome do catálogo"
+  },
+  "services.placeholder.displaySummary": {
+    "message": "Deixe vazio para usar a descrição do catálogo"
+  },
+  "services.tip.visible": {
+    "message": "Desativado, o serviço fica oculto na página inicial (quem já tem mantém o acesso)."
+  },
+  "services.tip.markup": {
+    "message": "0% = preço da plataforma; 0,5 = +50%; até +500%. Vazio = padrão do site."
+  },
+  "services.tip.sortOrder": {
+    "message": "Números menores vêm primeiro."
+  },
+  "services.preview.sampleLabel": {
+    "message": "Preço base de exemplo"
+  },
+  "services.preview.inherit": {
+    "message": "(herda o acréscimo padrão do site {percent})"
+  },
+  "services.message.alreadyOverridden": {
+    "message": "Já adicionado"
+  },
+  "services.message.serviceRequired": {
+    "message": "Escolha um serviço primeiro"
+  },
+  "services.message.saved": {
+    "message": "Salvo"
+  },
+  "services.message.deleted": {
+    "message": "Excluído"
+  },
+  "services.message.deleteConfirm": {
+    "message": "Excluir a substituição de “{name}”? O serviço volta aos padrões do catálogo."
+  },
+  "services.message.saveFailed": {
+    "message": "Falha ao salvar, tente novamente"
+  },
+  "services.message.deleteFailed": {
+    "message": "Falha ao excluir, tente novamente"
+  },
+  "services.message.fetchFailed": {
+    "message": "Falha ao carregar as substituições de serviço"
   }
 }

--- a/src/i18n/ru/common.json
+++ b/src/i18n/ru/common.json
@@ -1431,5 +1431,8 @@
   "settings.cuConsentDeny": {
     "message": "Deny",
     "description": "Deny button of the on-demand consent dialog."
+  },
+  "settings.siteServices": {
+    "message": "Сервисы"
   }
 }

--- a/src/i18n/ru/site.json
+++ b/src/i18n/ru/site.json
@@ -670,5 +670,101 @@
   "autoTranslate.error": {
     "message": "Не удалось переключить автоперевод, попробуйте ещё раз",
     "description": "Fallback error toast when the enable/disable HTTP call fails with no detail"
+  },
+  "services.title": {
+    "message": "Цены и отображение по сервисам"
+  },
+  "services.tip": {
+    "message": "Скрывайте, переименовывайте, задавайте цену или порядок отдельных сервисов. Пустая наценка наследует значение сайта. Удаление строки возвращает сервис к значениям каталога."
+  },
+  "services.addButton": {
+    "message": "Добавить"
+  },
+  "services.empty": {
+    "message": "Переопределений нет — все сервисы используют значения по умолчанию."
+  },
+  "services.field.service": {
+    "message": "Сервис"
+  },
+  "services.field.visible": {
+    "message": "Видимость"
+  },
+  "services.field.displayTitle": {
+    "message": "Отображаемое имя"
+  },
+  "services.field.displaySummary": {
+    "message": "Отображаемое описание"
+  },
+  "services.field.sortOrder": {
+    "message": "Порядок"
+  },
+  "services.field.action": {
+    "message": "Действия"
+  },
+  "services.status.visible": {
+    "message": "Показан"
+  },
+  "services.status.hidden": {
+    "message": "Скрыт"
+  },
+  "services.status.inherit": {
+    "message": "Наследуется"
+  },
+  "services.dialog.create": {
+    "message": "Добавить переопределение сервиса"
+  },
+  "services.dialog.edit": {
+    "message": "Изменить переопределение сервиса"
+  },
+  "services.placeholder.service": {
+    "message": "Выберите сервис из каталога"
+  },
+  "services.placeholder.markup": {
+    "message": "Оставьте пустым, чтобы наследовать значение сайта"
+  },
+  "services.placeholder.displayTitle": {
+    "message": "Оставьте пустым, чтобы использовать имя из каталога"
+  },
+  "services.placeholder.displaySummary": {
+    "message": "Оставьте пустым, чтобы использовать описание из каталога"
+  },
+  "services.tip.visible": {
+    "message": "При выключении сервис скрыт на главной сайта (у кого он уже есть — доступ сохраняется)."
+  },
+  "services.tip.markup": {
+    "message": "0% — цена платформы; 0,5 — +50%; до +500%. Пусто — значение сайта."
+  },
+  "services.tip.sortOrder": {
+    "message": "Меньшие числа идут первыми."
+  },
+  "services.preview.sampleLabel": {
+    "message": "Пример базовой цены"
+  },
+  "services.preview.inherit": {
+    "message": "(наследует наценку сайта по умолчанию {percent})"
+  },
+  "services.message.alreadyOverridden": {
+    "message": "Уже добавлено"
+  },
+  "services.message.serviceRequired": {
+    "message": "Сначала выберите сервис"
+  },
+  "services.message.saved": {
+    "message": "Сохранено"
+  },
+  "services.message.deleted": {
+    "message": "Удалено"
+  },
+  "services.message.deleteConfirm": {
+    "message": "Удалить переопределение для «{name}»? Сервис вернётся к значениям каталога."
+  },
+  "services.message.saveFailed": {
+    "message": "Не удалось сохранить, повторите позже"
+  },
+  "services.message.deleteFailed": {
+    "message": "Не удалось удалить, повторите позже"
+  },
+  "services.message.fetchFailed": {
+    "message": "Не удалось загрузить переопределения сервисов"
   }
 }

--- a/src/i18n/sr/common.json
+++ b/src/i18n/sr/common.json
@@ -1431,5 +1431,8 @@
   "settings.cuConsentDeny": {
     "message": "Deny",
     "description": "Deny button of the on-demand consent dialog."
+  },
+  "settings.siteServices": {
+    "message": "Услуге"
   }
 }

--- a/src/i18n/sr/site.json
+++ b/src/i18n/sr/site.json
@@ -670,5 +670,101 @@
   "autoTranslate.error": {
     "message": "Промена аутоматског превода није успела, покушајте поново",
     "description": "Fallback error toast when the enable/disable HTTP call fails with no detail"
+  },
+  "services.title": {
+    "message": "Цене и приказ по услузи"
+  },
+  "services.tip": {
+    "message": "Сакријте, преименујте, одредите цену или преуредите поједине услуге. Празна маржа наслеђује подразумевану вредност сајта. Брисање реда враћа услугу на подразумеване вредности."
+  },
+  "services.addButton": {
+    "message": "Додај"
+  },
+  "services.empty": {
+    "message": "Нема измена — свака услуга користи подразумеване вредности."
+  },
+  "services.field.service": {
+    "message": "Услуга"
+  },
+  "services.field.visible": {
+    "message": "Видљиво"
+  },
+  "services.field.displayTitle": {
+    "message": "Приказано име"
+  },
+  "services.field.displaySummary": {
+    "message": "Приказани опис"
+  },
+  "services.field.sortOrder": {
+    "message": "Редослед"
+  },
+  "services.field.action": {
+    "message": "Радње"
+  },
+  "services.status.visible": {
+    "message": "Приказано"
+  },
+  "services.status.hidden": {
+    "message": "Сакривено"
+  },
+  "services.status.inherit": {
+    "message": "Наслеђено"
+  },
+  "services.dialog.create": {
+    "message": "Додај измену услуге"
+  },
+  "services.dialog.edit": {
+    "message": "Измени измену услуге"
+  },
+  "services.placeholder.service": {
+    "message": "Изаберите услугу из каталога"
+  },
+  "services.placeholder.markup": {
+    "message": "Оставите празно да наследите подразумевано"
+  },
+  "services.placeholder.displayTitle": {
+    "message": "Оставите празно за назив из каталога"
+  },
+  "services.placeholder.displaySummary": {
+    "message": "Оставите празно за опис из каталога"
+  },
+  "services.tip.visible": {
+    "message": "Када је искључено, услуга је сакривена на почетној (постојећи корисници задржавају приступ)."
+  },
+  "services.tip.markup": {
+    "message": "0% = цена платформе; 0,5 = +50%; до +500%. Празно = подразумевано сајта."
+  },
+  "services.tip.sortOrder": {
+    "message": "Мањи бројеви иду први."
+  },
+  "services.preview.sampleLabel": {
+    "message": "Пример основне цене"
+  },
+  "services.preview.inherit": {
+    "message": "(наслеђује подразумевану маржу сајта {percent})"
+  },
+  "services.message.alreadyOverridden": {
+    "message": "Већ додато"
+  },
+  "services.message.serviceRequired": {
+    "message": "Прво изаберите услугу"
+  },
+  "services.message.saved": {
+    "message": "Сачувано"
+  },
+  "services.message.deleted": {
+    "message": "Обрисано"
+  },
+  "services.message.deleteConfirm": {
+    "message": "Обрисати измену за „{name}”? Услуга се враћа на подразумеване вредности."
+  },
+  "services.message.saveFailed": {
+    "message": "Чување није успело, покушајте поново"
+  },
+  "services.message.deleteFailed": {
+    "message": "Брисање није успело, покушајте поново"
+  },
+  "services.message.fetchFailed": {
+    "message": "Учитавање измена услуга није успело"
   }
 }

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -1431,5 +1431,8 @@
   "settings.cuConsentDeny": {
     "message": "Deny",
     "description": "Deny button of the on-demand consent dialog."
+  },
+  "settings.siteServices": {
+    "message": "Tjänster"
   }
 }

--- a/src/i18n/sv/site.json
+++ b/src/i18n/sv/site.json
@@ -670,5 +670,101 @@
   "autoTranslate.error": {
     "message": "Det gick inte att växla automatisk översättning, försök igen",
     "description": "Fallback error toast when the enable/disable HTTP call fails with no detail"
+  },
+  "services.title": {
+    "message": "Pris och visning per tjänst"
+  },
+  "services.tip": {
+    "message": "Dölj, byt namn, prissätt eller sortera enskilda tjänster. Ett tomt påslag ärver webbplatsens standard. Att ta bort en rad återställer katalogens standard."
+  },
+  "services.addButton": {
+    "message": "Lägg till"
+  },
+  "services.empty": {
+    "message": "Inga åsidosättanden — varje tjänst använder sina standardvärden."
+  },
+  "services.field.service": {
+    "message": "Tjänst"
+  },
+  "services.field.visible": {
+    "message": "Synlig"
+  },
+  "services.field.displayTitle": {
+    "message": "Visningsnamn"
+  },
+  "services.field.displaySummary": {
+    "message": "Visningssammanfattning"
+  },
+  "services.field.sortOrder": {
+    "message": "Sortering"
+  },
+  "services.field.action": {
+    "message": "Åtgärder"
+  },
+  "services.status.visible": {
+    "message": "Visas"
+  },
+  "services.status.hidden": {
+    "message": "Dold"
+  },
+  "services.status.inherit": {
+    "message": "Ärvd"
+  },
+  "services.dialog.create": {
+    "message": "Lägg till tjänståsidosättning"
+  },
+  "services.dialog.edit": {
+    "message": "Redigera tjänståsidosättning"
+  },
+  "services.placeholder.service": {
+    "message": "Välj en tjänst från katalogen"
+  },
+  "services.placeholder.markup": {
+    "message": "Lämna tomt för att ärva webbplatsens standard"
+  },
+  "services.placeholder.displayTitle": {
+    "message": "Lämna tomt för att använda katalognamnet"
+  },
+  "services.placeholder.displaySummary": {
+    "message": "Lämna tomt för att använda katalogbeskrivningen"
+  },
+  "services.tip.visible": {
+    "message": "Avstängd döljs tjänsten på startsidan (befintliga användare behåller åtkomst)."
+  },
+  "services.tip.markup": {
+    "message": "0 % = plattformspris; 0,5 = +50 %; upp till +500 %. Tomt = webbplatsens standard."
+  },
+  "services.tip.sortOrder": {
+    "message": "Lägre nummer kommer först."
+  },
+  "services.preview.sampleLabel": {
+    "message": "Exempelpris"
+  },
+  "services.preview.inherit": {
+    "message": "(ärver webbplatsens standardpåslag {percent})"
+  },
+  "services.message.alreadyOverridden": {
+    "message": "Redan tillagd"
+  },
+  "services.message.serviceRequired": {
+    "message": "Välj en tjänst först"
+  },
+  "services.message.saved": {
+    "message": "Sparad"
+  },
+  "services.message.deleted": {
+    "message": "Borttagen"
+  },
+  "services.message.deleteConfirm": {
+    "message": "Ta bort åsidosättning för ”{name}”? Tjänsten återgår till katalogens standard."
+  },
+  "services.message.saveFailed": {
+    "message": "Sparandet misslyckades, försök igen"
+  },
+  "services.message.deleteFailed": {
+    "message": "Borttagningen misslyckades, försök igen"
+  },
+  "services.message.fetchFailed": {
+    "message": "Kunde inte läsa in tjänståsidosättningar"
   }
 }

--- a/src/i18n/uk/common.json
+++ b/src/i18n/uk/common.json
@@ -1431,5 +1431,8 @@
   "settings.cuConsentDeny": {
     "message": "Deny",
     "description": "Deny button of the on-demand consent dialog."
+  },
+  "settings.siteServices": {
+    "message": "Сервіси"
   }
 }

--- a/src/i18n/uk/site.json
+++ b/src/i18n/uk/site.json
@@ -670,5 +670,101 @@
   "autoTranslate.error": {
     "message": "Не вдалося перемкнути автопереклад, спробуйте знову",
     "description": "Fallback error toast when the enable/disable HTTP call fails with no detail"
+  },
+  "services.title": {
+    "message": "Ціни та відображення для сервісів"
+  },
+  "services.tip": {
+    "message": "Приховуйте, перейменовуйте, задавайте ціну чи порядок окремих сервісів. Порожня націнка успадковує типове значення сайту. Видалення рядка повертає типові значення каталогу."
+  },
+  "services.addButton": {
+    "message": "Додати"
+  },
+  "services.empty": {
+    "message": "Немає перевизначень — кожен сервіс використовує типові значення."
+  },
+  "services.field.service": {
+    "message": "Сервіс"
+  },
+  "services.field.visible": {
+    "message": "Видимий"
+  },
+  "services.field.displayTitle": {
+    "message": "Відображуване ім'я"
+  },
+  "services.field.displaySummary": {
+    "message": "Відображуваний опис"
+  },
+  "services.field.sortOrder": {
+    "message": "Порядок"
+  },
+  "services.field.action": {
+    "message": "Дії"
+  },
+  "services.status.visible": {
+    "message": "Показано"
+  },
+  "services.status.hidden": {
+    "message": "Приховано"
+  },
+  "services.status.inherit": {
+    "message": "Успадковано"
+  },
+  "services.dialog.create": {
+    "message": "Додати перевизначення сервісу"
+  },
+  "services.dialog.edit": {
+    "message": "Редагувати перевизначення сервісу"
+  },
+  "services.placeholder.service": {
+    "message": "Виберіть сервіс із каталогу"
+  },
+  "services.placeholder.markup": {
+    "message": "Залиште порожнім, щоб успадкувати типове"
+  },
+  "services.placeholder.displayTitle": {
+    "message": "Залиште порожнім, щоб використати назву з каталогу"
+  },
+  "services.placeholder.displaySummary": {
+    "message": "Залиште порожнім, щоб використати опис із каталогу"
+  },
+  "services.tip.visible": {
+    "message": "Вимкнено — сервіс прихований на головній (наявні користувачі зберігають доступ)."
+  },
+  "services.tip.markup": {
+    "message": "0% = ціна платформи; 0,5 = +50%; до +500%. Порожньо = типове сайту."
+  },
+  "services.tip.sortOrder": {
+    "message": "Менші числа йдуть першими."
+  },
+  "services.preview.sampleLabel": {
+    "message": "Приклад базової ціни"
+  },
+  "services.preview.inherit": {
+    "message": "(успадковує типову націнку сайту {percent})"
+  },
+  "services.message.alreadyOverridden": {
+    "message": "Уже додано"
+  },
+  "services.message.serviceRequired": {
+    "message": "Спершу виберіть сервіс"
+  },
+  "services.message.saved": {
+    "message": "Збережено"
+  },
+  "services.message.deleted": {
+    "message": "Видалено"
+  },
+  "services.message.deleteConfirm": {
+    "message": "Видалити перевизначення для «{name}»? Сервіс повернеться до значень каталогу."
+  },
+  "services.message.saveFailed": {
+    "message": "Не вдалося зберегти, повторіть пізніше"
+  },
+  "services.message.deleteFailed": {
+    "message": "Не вдалося видалити, повторіть пізніше"
+  },
+  "services.message.fetchFailed": {
+    "message": "Не вдалося завантажити перевизначення сервісів"
   }
 }

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -1431,5 +1431,9 @@
   "settings.cuConsentDeny": {
     "message": "拒绝",
     "description": "按需授权对话框的拒绝按钮。"
+  },
+  "settings.siteServices": {
+    "message": "服务定价",
+    "description": "用户设置弹窗中「服务定价与展示」Tab 的导航标签"
   }
 }

--- a/src/i18n/zh-CN/site.json
+++ b/src/i18n/zh-CN/site.json
@@ -670,5 +670,102 @@
   "autoTranslate.error": {
     "message": "切换自动翻译失败，请稍后重试",
     "description": "切换自动翻译接口返回错误时的兜底文案"
+  },
+  "services.title": {
+    "message": "服务定价与展示"
+  },
+  "services.tip": {
+    "message": "针对单个服务隐藏、改名、单独定价或排序。留空的加价将继承本站默认加价。删除某行后该服务恢复默认展示。"
+  },
+  "services.addButton": {
+    "message": "添加服务覆盖"
+  },
+  "services.empty": {
+    "message": "尚无服务覆盖，所有服务沿用目录默认展示与定价。"
+  },
+  "services.field.service": {
+    "message": "服务"
+  },
+  "services.field.visible": {
+    "message": "可见"
+  },
+  "services.field.displayTitle": {
+    "message": "展示名称"
+  },
+  "services.field.displaySummary": {
+    "message": "展示简介",
+    "description": "每服务覆盖项：自定义该服务在本站首页卡片上的简介"
+  },
+  "services.field.sortOrder": {
+    "message": "排序"
+  },
+  "services.field.action": {
+    "message": "操作"
+  },
+  "services.status.visible": {
+    "message": "显示"
+  },
+  "services.status.hidden": {
+    "message": "隐藏"
+  },
+  "services.status.inherit": {
+    "message": "继承"
+  },
+  "services.dialog.create": {
+    "message": "添加服务覆盖"
+  },
+  "services.dialog.edit": {
+    "message": "编辑服务覆盖"
+  },
+  "services.placeholder.service": {
+    "message": "从服务目录中选择一个服务"
+  },
+  "services.placeholder.markup": {
+    "message": "留空则继承本站默认加价"
+  },
+  "services.placeholder.displayTitle": {
+    "message": "留空则使用目录中的原名称"
+  },
+  "services.placeholder.displaySummary": {
+    "message": "留空则使用目录中的原描述"
+  },
+  "services.tip.visible": {
+    "message": "关闭后该服务在本站首页隐藏（已拥有的用户仍可访问）。"
+  },
+  "services.tip.markup": {
+    "message": "0% 按平台原价；0.5 即 +50%；上限 500%。留空则继承本站默认加价。"
+  },
+  "services.tip.sortOrder": {
+    "message": "数字越小越靠前。"
+  },
+  "services.preview.sampleLabel": {
+    "message": "示例原价"
+  },
+  "services.preview.inherit": {
+    "message": "（已继承本站默认加价 {percent}）"
+  },
+  "services.message.alreadyOverridden": {
+    "message": "已覆盖"
+  },
+  "services.message.serviceRequired": {
+    "message": "请先选择一个服务"
+  },
+  "services.message.saved": {
+    "message": "已保存"
+  },
+  "services.message.deleted": {
+    "message": "已删除"
+  },
+  "services.message.deleteConfirm": {
+    "message": "确定要删除「{name}」的覆盖配置吗？删除后该服务恢复默认展示与定价。"
+  },
+  "services.message.saveFailed": {
+    "message": "保存失败，请稍后重试"
+  },
+  "services.message.deleteFailed": {
+    "message": "删除失败，请稍后重试"
+  },
+  "services.message.fetchFailed": {
+    "message": "加载服务覆盖失败"
   }
 }

--- a/src/i18n/zh-TW/common.json
+++ b/src/i18n/zh-TW/common.json
@@ -1431,5 +1431,8 @@
   "settings.cuConsentDeny": {
     "message": "Deny",
     "description": "Deny button of the on-demand consent dialog."
+  },
+  "settings.siteServices": {
+    "message": "服務定價"
   }
 }

--- a/src/i18n/zh-TW/site.json
+++ b/src/i18n/zh-TW/site.json
@@ -670,5 +670,101 @@
   "autoTranslate.error": {
     "message": "切換自動翻譯失敗，請稍後重試",
     "description": "Fallback error toast when the enable/disable HTTP call fails with no detail"
+  },
+  "services.title": {
+    "message": "服務定價與展示"
+  },
+  "services.tip": {
+    "message": "針對單一服務隱藏、改名、單獨定價或排序。留空的加價將繼承本站預設加價。刪除某列後該服務恢復預設顯示。"
+  },
+  "services.addButton": {
+    "message": "新增服務覆蓋"
+  },
+  "services.empty": {
+    "message": "尚無服務覆蓋，所有服務沿用目錄預設展示與定價。"
+  },
+  "services.field.service": {
+    "message": "服務"
+  },
+  "services.field.visible": {
+    "message": "可見"
+  },
+  "services.field.displayTitle": {
+    "message": "顯示名稱"
+  },
+  "services.field.displaySummary": {
+    "message": "展示簡介"
+  },
+  "services.field.sortOrder": {
+    "message": "排序"
+  },
+  "services.field.action": {
+    "message": "操作"
+  },
+  "services.status.visible": {
+    "message": "顯示"
+  },
+  "services.status.hidden": {
+    "message": "隱藏"
+  },
+  "services.status.inherit": {
+    "message": "繼承"
+  },
+  "services.dialog.create": {
+    "message": "新增服務覆蓋"
+  },
+  "services.dialog.edit": {
+    "message": "編輯服務覆蓋"
+  },
+  "services.placeholder.service": {
+    "message": "從服務目錄中選擇一個服務"
+  },
+  "services.placeholder.markup": {
+    "message": "留空則繼承本站預設加價"
+  },
+  "services.placeholder.displayTitle": {
+    "message": "留空則使用目錄中的原名稱"
+  },
+  "services.placeholder.displaySummary": {
+    "message": "留空則使用目錄中的原描述"
+  },
+  "services.tip.visible": {
+    "message": "關閉後該服務在本站首頁隱藏（已擁有的使用者仍可存取）。"
+  },
+  "services.tip.markup": {
+    "message": "0% 按平台原價；0.5 即 +50%；上限 500%。留空則繼承本站預設加價。"
+  },
+  "services.tip.sortOrder": {
+    "message": "數字越小越靠前。"
+  },
+  "services.preview.sampleLabel": {
+    "message": "範例原價"
+  },
+  "services.preview.inherit": {
+    "message": "（已繼承本站預設加價 {percent}）"
+  },
+  "services.message.alreadyOverridden": {
+    "message": "已覆蓋"
+  },
+  "services.message.serviceRequired": {
+    "message": "請先選擇一個服務"
+  },
+  "services.message.saved": {
+    "message": "已儲存"
+  },
+  "services.message.deleted": {
+    "message": "已刪除"
+  },
+  "services.message.deleteConfirm": {
+    "message": "確定要刪除「{name}」的覆蓋設定嗎？刪除後該服務恢復預設展示與定價。"
+  },
+  "services.message.saveFailed": {
+    "message": "儲存失敗，請稍後重試"
+  },
+  "services.message.deleteFailed": {
+    "message": "刪除失敗，請稍後重試"
+  },
+  "services.message.fetchFailed": {
+    "message": "載入服務覆蓋失敗"
   }
 }

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -34,6 +34,7 @@ export * from './wan';
 export * from './webextrator';
 export * from './fish';
 export * from './site';
+export * from './siteServiceOverride';
 export * from './site_domain';
 export * from './exchange';
 export * from './error';

--- a/src/models/siteServiceOverride.ts
+++ b/src/models/siteServiceOverride.ts
@@ -1,0 +1,65 @@
+/**
+ * Per-site service presentation overrides — mirrors PlatformBackend's
+ * ``SiteServiceOverride`` row. A row exists when a site admin (站长) has
+ * chosen to deviate from the shared catalog Service's defaults for THIS
+ * site only: hide it, rename the homepage card, or charge a different
+ * per-service markup. Deleting the row reverts the site to the catalog
+ * Service defaults.
+ *
+ * Pairs are unique on ``(site, service)``. Field semantics are kept in
+ * sync with the backend serializer:
+ *
+ * - ``visible``       optional bool, default true.
+ * - ``markup_ratio``  optional float in [0, 5] (= +0..+500%). Null falls
+ *                     back to ``site.metadata.pricing.markup_ratio`` then 0.
+ * - ``display_title`` optional string, trimmed, max 120 chars. Empty/null
+ *                     = use catalog Service.title.
+ * - ``display_summary`` optional text. Empty/null = use catalog description.
+ * - ``sort_order``    integer, default 0. Lower comes first.
+ */
+export interface ISiteServiceOverride {
+  id?: string;
+  site?: string;
+  service?: string;
+  visible?: boolean;
+  markup_ratio?: number | null;
+  display_title?: string | null;
+  display_summary?: string | null;
+  // Read-only: raw zh-cn canonical text.
+  display_title_source?: string | null;
+  display_summary_source?: string | null;
+  auto_translated_fields?: string[];
+  sort_order?: number;
+  user_id?: string | null;
+  created_at?: string;
+  updated_at?: string;
+  tags?: string[] | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface ISiteServiceOverrideListResponse {
+  count: number;
+  items: ISiteServiceOverride[];
+}
+
+export type ISiteServiceOverrideDetailResponse = ISiteServiceOverride;
+
+export interface ISiteServiceOverrideCreateRequest {
+  site: string;
+  service: string;
+  visible?: boolean;
+  markup_ratio?: number | null;
+  display_title?: string | null;
+  display_summary?: string | null;
+  sort_order?: number;
+}
+
+// PATCH input. ``site`` / ``service`` are read-only on the backend, so
+// they're deliberately omitted here.
+export interface ISiteServiceOverrideUpdateRequest {
+  visible?: boolean;
+  markup_ratio?: number | null;
+  display_title?: string | null;
+  display_summary?: string | null;
+  sort_order?: number;
+}

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -24,6 +24,7 @@ export * from './flux';
 export * from './hailuo';
 export * from './headshots';
 export * from './site';
+export * from './siteServiceOverride';
 export * from './site_domain';
 export * from './translation';
 export * from './suno';

--- a/src/operators/siteServiceOverride.ts
+++ b/src/operators/siteServiceOverride.ts
@@ -1,0 +1,48 @@
+import { AxiosResponse } from 'axios';
+import { httpClient } from './common';
+import {
+  ISiteServiceOverrideCreateRequest,
+  ISiteServiceOverrideDetailResponse,
+  ISiteServiceOverrideListResponse,
+  ISiteServiceOverrideUpdateRequest
+} from '@/models';
+
+export interface ISiteServiceOverrideQuery {
+  site?: string;
+  service?: string;
+  visible?: boolean;
+  ordering?: string;
+  offset?: number;
+  limit?: number;
+}
+
+class SiteServiceOverrideOperator {
+  key = 'site-service-overrides';
+
+  async getAll(query?: ISiteServiceOverrideQuery): Promise<AxiosResponse<ISiteServiceOverrideListResponse>> {
+    return await httpClient.get(`/${this.key}/`, { params: query });
+  }
+
+  async get(id: string): Promise<AxiosResponse<ISiteServiceOverrideDetailResponse>> {
+    return await httpClient.get(`/${this.key}/${id}/`);
+  }
+
+  async create(data: ISiteServiceOverrideCreateRequest): Promise<AxiosResponse<ISiteServiceOverrideDetailResponse>> {
+    return await httpClient.post(`/${this.key}/`, data);
+  }
+
+  // PATCH (partial) so we only send the fields the dialog edited and never
+  // clobber server-managed columns (site / service / *_source).
+  async update(
+    id: string,
+    data: ISiteServiceOverrideUpdateRequest
+  ): Promise<AxiosResponse<ISiteServiceOverrideDetailResponse>> {
+    return await httpClient.patch(`/${this.key}/${id}/`, data);
+  }
+
+  async delete(id: string): Promise<AxiosResponse<void>> {
+    return await httpClient.delete(`/${this.key}/${id}/`);
+  }
+}
+
+export const siteServiceOverrideOperator = new SiteServiceOverrideOperator();


### PR DESCRIPTION
## What

Give white-label **site admins (站长)** a friendly, in-app way to configure **per-service** overrides — the capability that until now only existed in the developer portal (PlatformFrontend). Also makes the money previews interactive.

### New: "Services" settings tab (`SiteServices.vue`)
Admin + web gated (same `isSiteConfigVisible = isWebSurface && isSiteAdmin` as the Site/SEO/Distribution tabs; real boundary is backend `IsSiteAdmin` on `/site-service-overrides/`). Per service you can:
- **Hide / show** it on the site homepage.
- **Per-service markup** — an `el-input-number` (0–500%, unified cap) with a live `+N%` badge **and an editable money preview** (`Official $10 → your price $13`, base is editable). Blank = inherit the site-wide default (shown as `inherit`), and the preview says which default it's inheriting.
- **Rename** (display title) + **custom summary** + **sort order**.
- Service picker is a **filterable `el-select`** (searches title/alias/id) that disables already-overridden services.

### New operator + model
`operators/siteServiceOverride.ts` (+ `models/siteServiceOverride.ts`) — CRUD mirroring the backend, **PATCH** for update so we never clobber server-managed columns. Exported via the `@/models` / `@/operators` barrels.

### Editable site-wide preview (`Site.vue`)
The existing site-wide markup row's preview base was hard-coded `$10`; it's now an **editable sample price** so the 站长 can preview against a realistic amount.

### Unified cap
Per-service and site-wide inputs both cap at **+500%** (matches the companion backend PR AceDataCloud/PlatformBackend#946 which lowers the per-service backend cap 100→5) with a dynamic `:max = max(5, loaded)` guard so no pre-existing larger value is ever silently clamped.

### i18n
`common.settings.siteServices` + `site.services.*` added across **all 18 locales**; coverage guard passes (17 × 44).

## Test
- `npm run lint` ✅ · `vue-tsc -b` ✅ · `npm run test:run` ✅ (300 passed) · `check_i18n_coverage.py` ✅ · prettier ✅ · beachball change file added.

## 🤖 对抗评审

Independent read-only reviewer (subagent). Prioritized concerns (markup-0 semantics, SSG `window` safety, store getter) all came back **CLEAN**. One real finding fixed before this PR:

- **RISK 1 (fixed):** the Display-Summary form label referenced `site.services.field.displaySummary`, which I'd **never added** (missing in all 18 locales) — so it would render the raw key in every language, and the coverage guard couldn't catch it (absent from zh-CN too). Added the key to all 18 locales.
- **Polish (fixed):** `sort_order` now null-guarded (`el-input-number` can emit `null` on clear → backend 400); `onDelete` now surfaces `extractError(err)` like create/update.
- **Verified clean:** `markup_ratio: 0` (explicit "sell at platform price") is preserved end-to-end and never collapses to inherit; SSG-safe (`window` guarded, no fetch during prerender); `getters.site` == `state.site` (root module) so no empty-site mismatch; el-input-number clamp is display-only; catalog uses the public consumer `/services/` endpoint (no private leak); `isAlreadyOverridden` correct.