### PR TITLE
fix(api-code): View docs opens the service documents landing page

### DIFF
--- a/change/@acedatacloud-nexior-79b1fe65-3511-46b5-83e3-14129f0e3bfc.json
+++ b/change/@acedatacloud-nexior-79b1fe65-3511-46b5-83e3-14129f0e3bfc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "View docs opens the service documents landing page",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/ApiCodeButton.vue
+++ b/src/components/common/ApiCodeButton.vue
@@ -64,14 +64,8 @@ const PATH_TO_STORE: Record<string, string> = {
 const PLATFORM_DOCS_BASE = 'https://platform.acedata.cloud/documents';
 
 // The "查看文档" deep-link points at each service's documents landing page,
-// whose alias equals the first path segment for almost every service
-// (e.g. /maestro/videos -> documents/maestro). Only the few services that
-// have no landing doc are overridden to their sole API doc alias.
-const DOC_ALIAS_OVERRIDES: Record<string, string> = {
-  qrart: 'qrart-generate',
-  headshots: 'headshots-generate',
-  pika: 'pika-videos'
-};
+// whose alias equals the first path segment (e.g. /maestro/videos ->
+// documents/maestro).
 
 export default defineComponent({
   name: 'ApiCodeButton',
@@ -144,8 +138,7 @@ export default defineComponent({
     docHref(): string {
       const seg = (this.path || '').split('/').filter(Boolean)[0] || '';
       if (!seg) return PLATFORM_DOCS_BASE;
-      const alias = DOC_ALIAS_OVERRIDES[seg] || seg;
-      return `${PLATFORM_DOCS_BASE}/${alias}`;
+      return `${PLATFORM_DOCS_BASE}/${seg}`;
     },
     resolvedTokenKey(): string {
       if (this.tokenKey) return this.tokenKey;

--- a/src/components/common/ApiCodeButton.vue
+++ b/src/components/common/ApiCodeButton.vue
@@ -63,29 +63,14 @@ const PATH_TO_STORE: Record<string, string> = {
 
 const PLATFORM_DOCS_BASE = 'https://platform.acedata.cloud/documents';
 
-// First path segment -> platform documentation alias for that service's
-// representative API. Powers the "查看文档" deep-link in the code dialog.
-const SERVICE_DOC_ALIAS: Record<string, string> = {
-  midjourney: 'midjourney-imagine',
-  luma: 'luma-videos',
-  sora: 'sora-videos',
-  veo: 'veo-videos',
-  kling: 'kling-videos',
-  hailuo: 'hailuo-videos-integration',
-  'nano-banana': 'nano-banana-images',
-  flux: 'flux-images',
+// The "查看文档" deep-link points at each service's documents landing page,
+// whose alias equals the first path segment for almost every service
+// (e.g. /maestro/videos -> documents/maestro). Only the few services that
+// have no landing doc are overridden to their sole API doc alias.
+const DOC_ALIAS_OVERRIDES: Record<string, string> = {
   qrart: 'qrart-generate',
   headshots: 'headshots-generate',
-  pika: 'pika-videos',
-  pixverse: 'pixverse',
-  seedance: 'seedance-videos',
-  seedream: 'seedream-images',
-  wan: 'wan-videos',
-  fish: 'fish-tts',
-  openai: 'openai-images-generations',
-  suno: 'suno-audios',
-  producer: 'producer-audios',
-  grok: 'grok-videos'
+  pika: 'pika-videos'
 };
 
 export default defineComponent({
@@ -158,8 +143,9 @@ export default defineComponent({
     },
     docHref(): string {
       const seg = (this.path || '').split('/').filter(Boolean)[0] || '';
-      const alias = SERVICE_DOC_ALIAS[seg];
-      return alias ? `${PLATFORM_DOCS_BASE}/${alias}` : PLATFORM_DOCS_BASE;
+      if (!seg) return PLATFORM_DOCS_BASE;
+      const alias = DOC_ALIAS_OVERRIDES[seg] || seg;
+      return `${PLATFORM_DOCS_BASE}/${alias}`;
     },
     resolvedTokenKey(): string {
       if (this.tokenKey) return this.tokenKey;


### PR DESCRIPTION
## What

In the studio 「API code for this request」 dialog, the **查看文档 / View docs** button was deep-linking to a *specific* API doc alias (e.g. `documents/maestro-videos-integration`), which didn't land on the expected place.

Now it uniformly opens each service's **documents landing page** — the same page as `documents/maestro` in the screenshot.

## How (generic, no per-service map)

`docHref` is derived purely from the **first path segment** of the API path:

- `/maestro/videos` → `documents/maestro`
- `/luma/videos` → `documents/luma`, `/suno/audios` → `documents/suno`, `/openai/images/...` → `documents/openai`, etc.

The old hand-maintained `SERVICE_DOC_ALIAS` map (segment → specific API doc) is gone, and there are **no override exceptions** — every service just uses `documents/<first-path-segment>`. Empty path → falls back to the `documents` root.

## Test

`eslint` ✅ · TS ✅ · beachball change file added.