### PR TITLE
fix(maestro): enable Run again in the API code dialog

### DIFF
--- a/change/@acedatacloud-nexior-0b717707060c4a3caa71.json
+++ b/change/@acedatacloud-nexior-0b717707060c4a3caa71.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(maestro): enable Run again in the API code dialog (add maestro to PATH_TO_STORE so the dialog resolves the API token)",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/common/ApiCodeButton.vue
+++ b/src/components/common/ApiCodeButton.vue
@@ -54,6 +54,7 @@ const PATH_TO_STORE: Record<string, string> = {
   seedream: 'seedream',
   wan: 'wan',
   fish: 'fish',
+  maestro: 'maestro',
   // OpenAI image generation paths live under /openai/images/...
   openai: 'openaiimage',
   suno: 'suno',


### PR DESCRIPTION
## What

In Studio, the Maestro **API code for this request** dialog's **Run again** button was permanently unclickable, even for logged-in users who could start tasks normally.

## Root cause

`ApiCodeDialog` gates Run again on `canRun = !!token`. The token is resolved by `ApiCodeButton` via `PATH_TO_STORE` — it maps the first segment of the API path to the owning Vuex store and reads `state[key].credential.token`. **`maestro` was missing from `PATH_TO_STORE`**, so for `/maestro/videos` the lookup returned `''` → empty token → `canRun = false` → button `:disabled`.

Starting a task still worked because the generate flow reads the maestro store's credential **directly**, not through this map — which is why "I can start tasks but Run again is dead" was not a contradiction.

The disabled state is easy to miss: `.code-run` always keeps `background: var(--el-color-primary)` and only drops to `opacity: 0.4` + `cursor: not-allowed` when disabled, so it still looks like a blue, clickable button.

## Fix

One line: add `maestro: 'maestro'` to `PATH_TO_STORE`, so the dialog picks up the real maestro credential and Run again becomes clickable (with the existing billable-run confirmation).

## Scope note

Intentionally minimal — only the token map. The `SERVICE_DOC_ALIAS`/`docHref` (查看文档) logic for maestro is being handled in a separate in-flight branch (`fix/view-docs-service-landing`) and is left untouched here to avoid overlap.

## Test

- Verified against `origin/main`: `PATH_TO_STORE` had no `maestro` key.
- Change is a single entry appended to a `Record<string, string>` literal, matching the exact style of its siblings; no type or format impact. CI runs the real `build:strict` (vue-tsc + vite) + eslint.

## 🤖 对抗评审

One-line map addition, key type `string`, value is an existing store module (`maestro`, confirmed present: `store/maestro/mutations.ts` has `setCredential`, `store/maestro/persist.ts` persists `maestro.credential`). No new imports, no cycles, no behavior change for other services. **VERDICT: CLEAN**.