### PR TITLE
feat(scheduled): advanced schedule builder (every N min/h/day, hourly-at-minute)

### DIFF
--- a/change/@acedatacloud-nexior-19aa83bf-97e6-4878-8c8b-4843fbe70d49.json
+++ b/change/@acedatacloud-nexior-19aa83bf-97e6-4878-8c8b-4843fbe70d49.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Scheduled tasks: advanced schedule builder (every N min/h/day, hourly-at-minute) with live preview",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/i18n/ar/chat.json
+++ b/src/i18n/ar/chat.json
@@ -654,6 +654,74 @@
   "scheduledTasks.scheduleType.cron": {
     "message": "Cron expression"
   },
+  "scheduledTasks.scheduleType.interval": {
+    "message": "Every",
+    "description": "Run at a fixed interval"
+  },
+  "scheduledTasks.form.intervalUnit.minute": {
+    "message": "minutes",
+    "description": "Interval unit: minutes"
+  },
+  "scheduledTasks.form.intervalUnit.hour": {
+    "message": "hours",
+    "description": "Interval unit: hours"
+  },
+  "scheduledTasks.form.intervalUnit.day": {
+    "message": "days",
+    "description": "Interval unit: days"
+  },
+  "scheduledTasks.form.hourlyMinute": {
+    "message": "At minute",
+    "description": "Which minute of each hour to run"
+  },
+  "scheduledTasks.form.hourlyMinuteHint": {
+    "message": "Which minute of each hour to run (0–59)",
+    "description": "Hourly minute hint"
+  },
+  "scheduledTasks.form.intervalHint": {
+    "message": "Runs once every fixed interval after the previous run (minimum 1 minute)",
+    "description": "Interval hint"
+  },
+  "scheduledTasks.form.cronHint": {
+    "message": "Standard 5-field cron expression: minute hour day month weekday",
+    "description": "Cron hint"
+  },
+  "scheduledTasks.form.schedulePreview": {
+    "message": "Runs {text}",
+    "description": "Schedule preview"
+  },
+  "scheduledTasks.humanize.everyNMinutes": {
+    "message": "every {n} min",
+    "description": "Human-readable: every N minutes"
+  },
+  "scheduledTasks.humanize.everyNHours": {
+    "message": "every {n} h",
+    "description": "Human-readable: every N hours"
+  },
+  "scheduledTasks.humanize.everyNDays": {
+    "message": "every {n} d",
+    "description": "Human-readable: every N days"
+  },
+  "scheduledTasks.humanize.hourlyAtMinute": {
+    "message": "hourly at minute {n}",
+    "description": "Human-readable: hourly at minute N"
+  },
+  "scheduledTasks.humanize.dailyAt": {
+    "message": "daily at {time}",
+    "description": "Human-readable: daily at time"
+  },
+  "scheduledTasks.humanize.weeklyAt": {
+    "message": "{weekday} at {time}",
+    "description": "Human-readable: weekly at weekday/time"
+  },
+  "scheduledTasks.humanize.cronRaw": {
+    "message": "Cron: {cron}",
+    "description": "Human-readable: raw cron"
+  },
+  "scheduledTasks.humanize.once": {
+    "message": "once at {time}",
+    "description": "Human-readable: once"
+  },
   "scheduledTasks.form.name": {
     "message": "Task name"
   },

--- a/src/i18n/de/chat.json
+++ b/src/i18n/de/chat.json
@@ -654,6 +654,74 @@
   "scheduledTasks.scheduleType.cron": {
     "message": "Cron expression"
   },
+  "scheduledTasks.scheduleType.interval": {
+    "message": "Every",
+    "description": "Run at a fixed interval"
+  },
+  "scheduledTasks.form.intervalUnit.minute": {
+    "message": "minutes",
+    "description": "Interval unit: minutes"
+  },
+  "scheduledTasks.form.intervalUnit.hour": {
+    "message": "hours",
+    "description": "Interval unit: hours"
+  },
+  "scheduledTasks.form.intervalUnit.day": {
+    "message": "days",
+    "description": "Interval unit: days"
+  },
+  "scheduledTasks.form.hourlyMinute": {
+    "message": "At minute",
+    "description": "Which minute of each hour to run"
+  },
+  "scheduledTasks.form.hourlyMinuteHint": {
+    "message": "Which minute of each hour to run (0–59)",
+    "description": "Hourly minute hint"
+  },
+  "scheduledTasks.form.intervalHint": {
+    "message": "Runs once every fixed interval after the previous run (minimum 1 minute)",
+    "description": "Interval hint"
+  },
+  "scheduledTasks.form.cronHint": {
+    "message": "Standard 5-field cron expression: minute hour day month weekday",
+    "description": "Cron hint"
+  },
+  "scheduledTasks.form.schedulePreview": {
+    "message": "Runs {text}",
+    "description": "Schedule preview"
+  },
+  "scheduledTasks.humanize.everyNMinutes": {
+    "message": "every {n} min",
+    "description": "Human-readable: every N minutes"
+  },
+  "scheduledTasks.humanize.everyNHours": {
+    "message": "every {n} h",
+    "description": "Human-readable: every N hours"
+  },
+  "scheduledTasks.humanize.everyNDays": {
+    "message": "every {n} d",
+    "description": "Human-readable: every N days"
+  },
+  "scheduledTasks.humanize.hourlyAtMinute": {
+    "message": "hourly at minute {n}",
+    "description": "Human-readable: hourly at minute N"
+  },
+  "scheduledTasks.humanize.dailyAt": {
+    "message": "daily at {time}",
+    "description": "Human-readable: daily at time"
+  },
+  "scheduledTasks.humanize.weeklyAt": {
+    "message": "{weekday} at {time}",
+    "description": "Human-readable: weekly at weekday/time"
+  },
+  "scheduledTasks.humanize.cronRaw": {
+    "message": "Cron: {cron}",
+    "description": "Human-readable: raw cron"
+  },
+  "scheduledTasks.humanize.once": {
+    "message": "once at {time}",
+    "description": "Human-readable: once"
+  },
   "scheduledTasks.form.name": {
     "message": "Task name"
   },

--- a/src/i18n/el/chat.json
+++ b/src/i18n/el/chat.json
@@ -654,6 +654,74 @@
   "scheduledTasks.scheduleType.cron": {
     "message": "Cron expression"
   },
+  "scheduledTasks.scheduleType.interval": {
+    "message": "Every",
+    "description": "Run at a fixed interval"
+  },
+  "scheduledTasks.form.intervalUnit.minute": {
+    "message": "minutes",
+    "description": "Interval unit: minutes"
+  },
+  "scheduledTasks.form.intervalUnit.hour": {
+    "message": "hours",
+    "description": "Interval unit: hours"
+  },
+  "scheduledTasks.form.intervalUnit.day": {
+    "message": "days",
+    "description": "Interval unit: days"
+  },
+  "scheduledTasks.form.hourlyMinute": {
+    "message": "At minute",
+    "description": "Which minute of each hour to run"
+  },
+  "scheduledTasks.form.hourlyMinuteHint": {
+    "message": "Which minute of each hour to run (0–59)",
+    "description": "Hourly minute hint"
+  },
+  "scheduledTasks.form.intervalHint": {
+    "message": "Runs once every fixed interval after the previous run (minimum 1 minute)",
+    "description": "Interval hint"
+  },
+  "scheduledTasks.form.cronHint": {
+    "message": "Standard 5-field cron expression: minute hour day month weekday",
+    "description": "Cron hint"
+  },
+  "scheduledTasks.form.schedulePreview": {
+    "message": "Runs {text}",
+    "description": "Schedule preview"
+  },
+  "scheduledTasks.humanize.everyNMinutes": {
+    "message": "every {n} min",
+    "description": "Human-readable: every N minutes"
+  },
+  "scheduledTasks.humanize.everyNHours": {
+    "message": "every {n} h",
+    "description": "Human-readable: every N hours"
+  },
+  "scheduledTasks.humanize.everyNDays": {
+    "message": "every {n} d",
+    "description": "Human-readable: every N days"
+  },
+  "scheduledTasks.humanize.hourlyAtMinute": {
+    "message": "hourly at minute {n}",
+    "description": "Human-readable: hourly at minute N"
+  },
+  "scheduledTasks.humanize.dailyAt": {
+    "message": "daily at {time}",
+    "description": "Human-readable: daily at time"
+  },
+  "scheduledTasks.humanize.weeklyAt": {
+    "message": "{weekday} at {time}",
+    "description": "Human-readable: weekly at weekday/time"
+  },
+  "scheduledTasks.humanize.cronRaw": {
+    "message": "Cron: {cron}",
+    "description": "Human-readable: raw cron"
+  },
+  "scheduledTasks.humanize.once": {
+    "message": "once at {time}",
+    "description": "Human-readable: once"
+  },
   "scheduledTasks.form.name": {
     "message": "Task name"
   },

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -653,6 +653,74 @@
   "scheduledTasks.scheduleType.cron": {
     "message": "Cron expression"
   },
+  "scheduledTasks.scheduleType.interval": {
+    "message": "Every",
+    "description": "Run at a fixed interval"
+  },
+  "scheduledTasks.form.intervalUnit.minute": {
+    "message": "minutes",
+    "description": "Interval unit: minutes"
+  },
+  "scheduledTasks.form.intervalUnit.hour": {
+    "message": "hours",
+    "description": "Interval unit: hours"
+  },
+  "scheduledTasks.form.intervalUnit.day": {
+    "message": "days",
+    "description": "Interval unit: days"
+  },
+  "scheduledTasks.form.hourlyMinute": {
+    "message": "At minute",
+    "description": "Which minute of each hour to run"
+  },
+  "scheduledTasks.form.hourlyMinuteHint": {
+    "message": "Which minute of each hour to run (0–59)",
+    "description": "Hourly minute hint"
+  },
+  "scheduledTasks.form.intervalHint": {
+    "message": "Runs once every fixed interval after the previous run (minimum 1 minute)",
+    "description": "Interval hint"
+  },
+  "scheduledTasks.form.cronHint": {
+    "message": "Standard 5-field cron expression: minute hour day month weekday",
+    "description": "Cron hint"
+  },
+  "scheduledTasks.form.schedulePreview": {
+    "message": "Runs {text}",
+    "description": "Schedule preview"
+  },
+  "scheduledTasks.humanize.everyNMinutes": {
+    "message": "every {n} min",
+    "description": "Human-readable: every N minutes"
+  },
+  "scheduledTasks.humanize.everyNHours": {
+    "message": "every {n} h",
+    "description": "Human-readable: every N hours"
+  },
+  "scheduledTasks.humanize.everyNDays": {
+    "message": "every {n} d",
+    "description": "Human-readable: every N days"
+  },
+  "scheduledTasks.humanize.hourlyAtMinute": {
+    "message": "hourly at minute {n}",
+    "description": "Human-readable: hourly at minute N"
+  },
+  "scheduledTasks.humanize.dailyAt": {
+    "message": "daily at {time}",
+    "description": "Human-readable: daily at time"
+  },
+  "scheduledTasks.humanize.weeklyAt": {
+    "message": "{weekday} at {time}",
+    "description": "Human-readable: weekly at weekday/time"
+  },
+  "scheduledTasks.humanize.cronRaw": {
+    "message": "Cron: {cron}",
+    "description": "Human-readable: raw cron"
+  },
+  "scheduledTasks.humanize.once": {
+    "message": "once at {time}",
+    "description": "Human-readable: once"
+  },
   "scheduledTasks.form.name": {
     "message": "Task name"
   },

--- a/src/i18n/es/chat.json
+++ b/src/i18n/es/chat.json
@@ -654,6 +654,74 @@
   "scheduledTasks.scheduleType.cron": {
     "message": "Cron expression"
   },
+  "scheduledTasks.scheduleType.interval": {
+    "message": "Every",
+    "description": "Run at a fixed interval"
+  },
+  "scheduledTasks.form.intervalUnit.minute": {
+    "message": "minutes",
+    "description": "Interval unit: minutes"
+  },
+  "scheduledTasks.form.intervalUnit.hour": {
+    "message": "hours",
+    "description": "Interval unit: hours"
+  },
+  "scheduledTasks.form.intervalUnit.day": {
+    "message": "days",
+    "description": "Interval unit: days"
+  },
+  "scheduledTasks.form.hourlyMinute": {
+    "message": "At minute",
+    "description": "Which minute of each hour to run"
+  },
+  "scheduledTasks.form.hourlyMinuteHint": {
+    "message": "Which minute of each hour to run (0–59)",
+    "description": "Hourly minute hint"
+  },
+  "scheduledTasks.form.intervalHint": {
+    "message": "Runs once every fixed interval after the previous run (minimum 1 minute)",
+    "description": "Interval hint"
+  },
+  "scheduledTasks.form.cronHint": {
+    "message": "Standard 5-field cron expression: minute hour day month weekday",
+    "description": "Cron hint"
+  },
+  "scheduledTasks.form.schedulePreview": {
+    "message": "Runs {text}",
+    "description": "Schedule preview"
+  },
+  "scheduledTasks.humanize.everyNMinutes": {
+    "message": "every {n} min",
+    "description": "Human-readable: every N minutes"
+  },
+  "scheduledTasks.humanize.everyNHours": {
+    "message": "every {n} h",
+    "description": "Human-readable: every N hours"
+  },
+  "scheduledTasks.humanize.everyNDays": {
+    "message": "every {n} d",
+    "description": "Human-readable: every N days"
+  },
+  "scheduledTasks.humanize.hourlyAtMinute": {
+    "message": "hourly at minute {n}",
+    "description": "Human-readable: hourly at minute N"
+  },
+  "scheduledTasks.humanize.dailyAt": {
+    "message": "daily at {time}",
+    "description": "Human-readable: daily at time"
+  },
+  "scheduledTasks.humanize.weeklyAt": {
+    "message": "{weekday} at {time}",
+    "description": "Human-readable: weekly at weekday/time"
+  },
+  "scheduledTasks.humanize.cronRaw": {
+    "message": "Cron: {cron}",
+    "description": "Human-readable: raw cron"
+  },
+  "scheduledTasks.humanize.once": {
+    "message": "once at {time}",
+    "description": "Human-readable: once"
+  },
   "scheduledTasks.form.name": {
     "message": "Task name"
   },

--- a/src/i18n/fi/chat.json
+++ b/src/i18n/fi/chat.json
@@ -654,6 +654,74 @@
   "scheduledTasks.scheduleType.cron": {
     "message": "Cron expression"
   },
+  "scheduledTasks.scheduleType.interval": {
+    "message": "Every",
+    "description": "Run at a fixed interval"
+  },
+  "scheduledTasks.form.intervalUnit.minute": {
+    "message": "minutes",
+    "description": "Interval unit: minutes"
+  },
+  "scheduledTasks.form.intervalUnit.hour": {
+    "message": "hours",
+    "description": "Interval unit: hours"
+  },
+  "scheduledTasks.form.intervalUnit.day": {
+    "message": "days",
+    "description": "Interval unit: days"
+  },
+  "scheduledTasks.form.hourlyMinute": {
+    "message": "At minute",
+    "description": "Which minute of each hour to run"
+  },
+  "scheduledTasks.form.hourlyMinuteHint": {
+    "message": "Which minute of each hour to run (0–59)",
+    "description": "Hourly minute hint"
+  },
+  "scheduledTasks.form.intervalHint": {
+    "message": "Runs once every fixed interval after the previous run (minimum 1 minute)",
+    "description": "Interval hint"
+  },
+  "scheduledTasks.form.cronHint": {
+    "message": "Standard 5-field cron expression: minute hour day month weekday",
+    "description": "Cron hint"
+  },
+  "scheduledTasks.form.schedulePreview": {
+    "message": "Runs {text}",
+    "description": "Schedule preview"
+  },
+  "scheduledTasks.humanize.everyNMinutes": {
+    "message": "every {n} min",
+    "description": "Human-readable: every N minutes"
+  },
+  "scheduledTasks.humanize.everyNHours": {
+    "message": "every {n} h",
+    "description": "Human-readable: every N hours"
+  },
+  "scheduledTasks.humanize.everyNDays": {
+    "message": "every {n} d",
+    "description": "Human-readable: every N days"
+  },
+  "scheduledTasks.humanize.hourlyAtMinute": {
+    "message": "hourly at minute {n}",
+    "description": "Human-readable: hourly at minute N"
+  },
+  "scheduledTasks.humanize.dailyAt": {
+    "message": "daily at {time}",
+    "description": "Human-readable: daily at time"
+  },
+  "scheduledTasks.humanize.weeklyAt": {
+    "message": "{weekday} at {time}",
+    "description": "Human-readable: weekly at weekday/time"
+  },
+  "scheduledTasks.humanize.cronRaw": {
+    "message": "Cron: {cron}",
+    "description": "Human-readable: raw cron"
+  },
+  "scheduledTasks.humanize.once": {
+    "message": "once at {time}",
+    "description": "Human-readable: once"
+  },
   "scheduledTasks.form.name": {
     "message": "Task name"
   },

--- a/src/i18n/fr/chat.json
+++ b/src/i18n/fr/chat.json
@@ -654,6 +654,74 @@
   "scheduledTasks.scheduleType.cron": {
     "message": "Cron expression"
   },
+  "scheduledTasks.scheduleType.interval": {
+    "message": "Every",
+    "description": "Run at a fixed interval"
+  },
+  "scheduledTasks.form.intervalUnit.minute": {
+    "message": "minutes",
+    "description": "Interval unit: minutes"
+  },
+  "scheduledTasks.form.intervalUnit.hour": {
+    "message": "hours",
+    "description": "Interval unit: hours"
+  },
+  "scheduledTasks.form.intervalUnit.day": {
+    "message": "days",
+    "description": "Interval unit: days"
+  },
+  "scheduledTasks.form.hourlyMinute": {
+    "message": "At minute",
+    "description": "Which minute of each hour to run"
+  },
+  "scheduledTasks.form.hourlyMinuteHint": {
+    "message": "Which minute of each hour to run (0–59)",
+    "description": "Hourly minute hint"
+  },
+  "scheduledTasks.form.intervalHint": {
+    "message": "Runs once every fixed interval after the previous run (minimum 1 minute)",
+    "description": "Interval hint"
+  },
+  "scheduledTasks.form.cronHint": {
+    "message": "Standard 5-field cron expression: minute hour day month weekday",
+    "description": "Cron hint"
+  },
+  "scheduledTasks.form.schedulePreview": {
+    "message": "Runs {text}",
+    "description": "Schedule preview"
+  },
+  "scheduledTasks.humanize.everyNMinutes": {
+    "message": "every {n} min",
+    "description": "Human-readable: every N minutes"
+  },
+  "scheduledTasks.humanize.everyNHours": {
+    "message": "every {n} h",
+    "description": "Human-readable: every N hours"
+  },
+  "scheduledTasks.humanize.everyNDays": {
+    "message": "every {n} d",
+    "description": "Human-readable: every N days"
+  },
+  "scheduledTasks.humanize.hourlyAtMinute": {
+    "message": "hourly at minute {n}",
+    "description": "Human-readable: hourly at minute N"
+  },
+  "scheduledTasks.humanize.dailyAt": {
+    "message": "daily at {time}",
+    "description": "Human-readable: daily at time"
+  },
+  "scheduledTasks.humanize.weeklyAt": {
+    "message": "{weekday} at {time}",
+    "description": "Human-readable: weekly at weekday/time"
+  },
+  "scheduledTasks.humanize.cronRaw": {
+    "message": "Cron: {cron}",
+    "description": "Human-readable: raw cron"
+  },
+  "scheduledTasks.humanize.once": {
+    "message": "once at {time}",
+    "description": "Human-readable: once"
+  },
   "scheduledTasks.form.name": {
     "message": "Task name"
   },

--- a/src/i18n/it/chat.json
+++ b/src/i18n/it/chat.json
@@ -654,6 +654,74 @@
   "scheduledTasks.scheduleType.cron": {
     "message": "Cron expression"
   },
+  "scheduledTasks.scheduleType.interval": {
+    "message": "Every",
+    "description": "Run at a fixed interval"
+  },
+  "scheduledTasks.form.intervalUnit.minute": {
+    "message": "minutes",
+    "description": "Interval unit: minutes"
+  },
+  "scheduledTasks.form.intervalUnit.hour": {
+    "message": "hours",
+    "description": "Interval unit: hours"
+  },
+  "scheduledTasks.form.intervalUnit.day": {
+    "message": "days",
+    "description": "Interval unit: days"
+  },
+  "scheduledTasks.form.hourlyMinute": {
+    "message": "At minute",
+    "description": "Which minute of each hour to run"
+  },
+  "scheduledTasks.form.hourlyMinuteHint": {
+    "message": "Which minute of each hour to run (0–59)",
+    "description": "Hourly minute hint"
+  },
+  "scheduledTasks.form.intervalHint": {
+    "message": "Runs once every fixed interval after the previous run (minimum 1 minute)",
+    "description": "Interval hint"
+  },
+  "scheduledTasks.form.cronHint": {
+    "message": "Standard 5-field cron expression: minute hour day month weekday",
+    "description": "Cron hint"
+  },
+  "scheduledTasks.form.schedulePreview": {
+    "message": "Runs {text}",
+    "description": "Schedule preview"
+  },
+  "scheduledTasks.humanize.everyNMinutes": {
+    "message": "every {n} min",
+    "description": "Human-readable: every N minutes"
+  },
+  "scheduledTasks.humanize.everyNHours": {
+    "message": "every {n} h",
+    "description": "Human-readable: every N hours"
+  },
+  "scheduledTasks.humanize.everyNDays": {
+    "message": "every {n} d",
+    "description": "Human-readable: every N days"
+  },
+  "scheduledTasks.humanize.hourlyAtMinute": {
+    "message": "hourly at minute {n}",
+    "description": "Human-readable: hourly at minute N"
+  },
+  "scheduledTasks.humanize.dailyAt": {
+    "message": "daily at {time}",
+    "description": "Human-readable: daily at time"
+  },
+  "scheduledTasks.humanize.weeklyAt": {
+    "message": "{weekday} at {time}",
+    "description": "Human-readable: weekly at weekday/time"
+  },
+  "scheduledTasks.humanize.cronRaw": {
+    "message": "Cron: {cron}",
+    "description": "Human-readable: raw cron"
+  },
+  "scheduledTasks.humanize.once": {
+    "message": "once at {time}",
+    "description": "Human-readable: once"
+  },
   "scheduledTasks.form.name": {
     "message": "Task name"
   },

--- a/src/i18n/ja/chat.json
+++ b/src/i18n/ja/chat.json
@@ -654,6 +654,74 @@
   "scheduledTasks.scheduleType.cron": {
     "message": "Cron expression"
   },
+  "scheduledTasks.scheduleType.interval": {
+    "message": "Every",
+    "description": "Run at a fixed interval"
+  },
+  "scheduledTasks.form.intervalUnit.minute": {
+    "message": "minutes",
+    "description": "Interval unit: minutes"
+  },
+  "scheduledTasks.form.intervalUnit.hour": {
+    "message": "hours",
+    "description": "Interval unit: hours"
+  },
+  "scheduledTasks.form.intervalUnit.day": {
+    "message": "days",
+    "description": "Interval unit: days"
+  },
+  "scheduledTasks.form.hourlyMinute": {
+    "message": "At minute",
+    "description": "Which minute of each hour to run"
+  },
+  "scheduledTasks.form.hourlyMinuteHint": {
+    "message": "Which minute of each hour to run (0–59)",
+    "description": "Hourly minute hint"
+  },
+  "scheduledTasks.form.intervalHint": {
+    "message": "Runs once every fixed interval after the previous run (minimum 1 minute)",
+    "description": "Interval hint"
+  },
+  "scheduledTasks.form.cronHint": {
+    "message": "Standard 5-field cron expression: minute hour day month weekday",
+    "description": "Cron hint"
+  },
+  "scheduledTasks.form.schedulePreview": {
+    "message": "Runs {text}",
+    "description": "Schedule preview"
+  },
+  "scheduledTasks.humanize.everyNMinutes": {
+    "message": "every {n} min",
+    "description": "Human-readable: every N minutes"
+  },
+  "scheduledTasks.humanize.everyNHours": {
+    "message": "every {n} h",
+    "description": "Human-readable: every N hours"
+  },
+  "scheduledTasks.humanize.everyNDays": {
+    "message": "every {n} d",
+    "description": "Human-readable: every N days"
+  },
+  "scheduledTasks.humanize.hourlyAtMinute": {
+    "message": "hourly at minute {n}",
+    "description": "Human-readable: hourly at minute N"
+  },
+  "scheduledTasks.humanize.dailyAt": {
+    "message": "daily at {time}",
+    "description": "Human-readable: daily at time"
+  },
+  "scheduledTasks.humanize.weeklyAt": {
+    "message": "{weekday} at {time}",
+    "description": "Human-readable: weekly at weekday/time"
+  },
+  "scheduledTasks.humanize.cronRaw": {
+    "message": "Cron: {cron}",
+    "description": "Human-readable: raw cron"
+  },
+  "scheduledTasks.humanize.once": {
+    "message": "once at {time}",
+    "description": "Human-readable: once"
+  },
   "scheduledTasks.form.name": {
     "message": "Task name"
   },

--- a/src/i18n/ko/chat.json
+++ b/src/i18n/ko/chat.json
@@ -654,6 +654,74 @@
   "scheduledTasks.scheduleType.cron": {
     "message": "Cron expression"
   },
+  "scheduledTasks.scheduleType.interval": {
+    "message": "Every",
+    "description": "Run at a fixed interval"
+  },
+  "scheduledTasks.form.intervalUnit.minute": {
+    "message": "minutes",
+    "description": "Interval unit: minutes"
+  },
+  "scheduledTasks.form.intervalUnit.hour": {
+    "message": "hours",
+    "description": "Interval unit: hours"
+  },
+  "scheduledTasks.form.intervalUnit.day": {
+    "message": "days",
+    "description": "Interval unit: days"
+  },
+  "scheduledTasks.form.hourlyMinute": {
+    "message": "At minute",
+    "description": "Which minute of each hour to run"
+  },
+  "scheduledTasks.form.hourlyMinuteHint": {
+    "message": "Which minute of each hour to run (0–59)",
+    "description": "Hourly minute hint"
+  },
+  "scheduledTasks.form.intervalHint": {
+    "message": "Runs once every fixed interval after the previous run (minimum 1 minute)",
+    "description": "Interval hint"
+  },
+  "scheduledTasks.form.cronHint": {
+    "message": "Standard 5-field cron expression: minute hour day month weekday",
+    "description": "Cron hint"
+  },
+  "scheduledTasks.form.schedulePreview": {
+    "message": "Runs {text}",
+    "description": "Schedule preview"
+  },
+  "scheduledTasks.humanize.everyNMinutes": {
+    "message": "every {n} min",
+    "description": "Human-readable: every N minutes"
+  },
+  "scheduledTasks.humanize.everyNHours": {
+    "message": "every {n} h",
+    "description": "Human-readable: every N hours"
+  },
+  "scheduledTasks.humanize.everyNDays": {
+    "message": "every {n} d",
+    "description": "Human-readable: every N days"
+  },
+  "scheduledTasks.humanize.hourlyAtMinute": {
+    "message": "hourly at minute {n}",
+    "description": "Human-readable: hourly at minute N"
+  },
+  "scheduledTasks.humanize.dailyAt": {
+    "message": "daily at {time}",
+    "description": "Human-readable: daily at time"
+  },
+  "scheduledTasks.humanize.weeklyAt": {
+    "message": "{weekday} at {time}",
+    "description": "Human-readable: weekly at weekday/time"
+  },
+  "scheduledTasks.humanize.cronRaw": {
+    "message": "Cron: {cron}",
+    "description": "Human-readable: raw cron"
+  },
+  "scheduledTasks.humanize.once": {
+    "message": "once at {time}",
+    "description": "Human-readable: once"
+  },
   "scheduledTasks.form.name": {
     "message": "Task name"
   },

--- a/src/i18n/pl/chat.json
+++ b/src/i18n/pl/chat.json
@@ -654,6 +654,74 @@
   "scheduledTasks.scheduleType.cron": {
     "message": "Cron expression"
   },
+  "scheduledTasks.scheduleType.interval": {
+    "message": "Every",
+    "description": "Run at a fixed interval"
+  },
+  "scheduledTasks.form.intervalUnit.minute": {
+    "message": "minutes",
+    "description": "Interval unit: minutes"
+  },
+  "scheduledTasks.form.intervalUnit.hour": {
+    "message": "hours",
+    "description": "Interval unit: hours"
+  },
+  "scheduledTasks.form.intervalUnit.day": {
+    "message": "days",
+    "description": "Interval unit: days"
+  },
+  "scheduledTasks.form.hourlyMinute": {
+    "message": "At minute",
+    "description": "Which minute of each hour to run"
+  },
+  "scheduledTasks.form.hourlyMinuteHint": {
+    "message": "Which minute of each hour to run (0–59)",
+    "description": "Hourly minute hint"
+  },
+  "scheduledTasks.form.intervalHint": {
+    "message": "Runs once every fixed interval after the previous run (minimum 1 minute)",
+    "description": "Interval hint"
+  },
+  "scheduledTasks.form.cronHint": {
+    "message": "Standard 5-field cron expression: minute hour day month weekday",
+    "description": "Cron hint"
+  },
+  "scheduledTasks.form.schedulePreview": {
+    "message": "Runs {text}",
+    "description": "Schedule preview"
+  },
+  "scheduledTasks.humanize.everyNMinutes": {
+    "message": "every {n} min",
+    "description": "Human-readable: every N minutes"
+  },
+  "scheduledTasks.humanize.everyNHours": {
+    "message": "every {n} h",
+    "description": "Human-readable: every N hours"
+  },
+  "scheduledTasks.humanize.everyNDays": {
+    "message": "every {n} d",
+    "description": "Human-readable: every N days"
+  },
+  "scheduledTasks.humanize.hourlyAtMinute": {
+    "message": "hourly at minute {n}",
+    "description": "Human-readable: hourly at minute N"
+  },
+  "scheduledTasks.humanize.dailyAt": {
+    "message": "daily at {time}",
+    "description": "Human-readable: daily at time"
+  },
+  "scheduledTasks.humanize.weeklyAt": {
+    "message": "{weekday} at {time}",
+    "description": "Human-readable: weekly at weekday/time"
+  },
+  "scheduledTasks.humanize.cronRaw": {
+    "message": "Cron: {cron}",
+    "description": "Human-readable: raw cron"
+  },
+  "scheduledTasks.humanize.once": {
+    "message": "once at {time}",
+    "description": "Human-readable: once"
+  },
   "scheduledTasks.form.name": {
     "message": "Task name"
   },

--- a/src/i18n/pt/chat.json
+++ b/src/i18n/pt/chat.json
@@ -654,6 +654,74 @@
   "scheduledTasks.scheduleType.cron": {
     "message": "Cron expression"
   },
+  "scheduledTasks.scheduleType.interval": {
+    "message": "Every",
+    "description": "Run at a fixed interval"
+  },
+  "scheduledTasks.form.intervalUnit.minute": {
+    "message": "minutes",
+    "description": "Interval unit: minutes"
+  },
+  "scheduledTasks.form.intervalUnit.hour": {
+    "message": "hours",
+    "description": "Interval unit: hours"
+  },
+  "scheduledTasks.form.intervalUnit.day": {
+    "message": "days",
+    "description": "Interval unit: days"
+  },
+  "scheduledTasks.form.hourlyMinute": {
+    "message": "At minute",
+    "description": "Which minute of each hour to run"
+  },
+  "scheduledTasks.form.hourlyMinuteHint": {
+    "message": "Which minute of each hour to run (0–59)",
+    "description": "Hourly minute hint"
+  },
+  "scheduledTasks.form.intervalHint": {
+    "message": "Runs once every fixed interval after the previous run (minimum 1 minute)",
+    "description": "Interval hint"
+  },
+  "scheduledTasks.form.cronHint": {
+    "message": "Standard 5-field cron expression: minute hour day month weekday",
+    "description": "Cron hint"
+  },
+  "scheduledTasks.form.schedulePreview": {
+    "message": "Runs {text}",
+    "description": "Schedule preview"
+  },
+  "scheduledTasks.humanize.everyNMinutes": {
+    "message": "every {n} min",
+    "description": "Human-readable: every N minutes"
+  },
+  "scheduledTasks.humanize.everyNHours": {
+    "message": "every {n} h",
+    "description": "Human-readable: every N hours"
+  },
+  "scheduledTasks.humanize.everyNDays": {
+    "message": "every {n} d",
+    "description": "Human-readable: every N days"
+  },
+  "scheduledTasks.humanize.hourlyAtMinute": {
+    "message": "hourly at minute {n}",
+    "description": "Human-readable: hourly at minute N"
+  },
+  "scheduledTasks.humanize.dailyAt": {
+    "message": "daily at {time}",
+    "description": "Human-readable: daily at time"
+  },
+  "scheduledTasks.humanize.weeklyAt": {
+    "message": "{weekday} at {time}",
+    "description": "Human-readable: weekly at weekday/time"
+  },
+  "scheduledTasks.humanize.cronRaw": {
+    "message": "Cron: {cron}",
+    "description": "Human-readable: raw cron"
+  },
+  "scheduledTasks.humanize.once": {
+    "message": "once at {time}",
+    "description": "Human-readable: once"
+  },
   "scheduledTasks.form.name": {
     "message": "Task name"
   },

--- a/src/i18n/ru/chat.json
+++ b/src/i18n/ru/chat.json
@@ -654,6 +654,74 @@
   "scheduledTasks.scheduleType.cron": {
     "message": "Cron expression"
   },
+  "scheduledTasks.scheduleType.interval": {
+    "message": "Every",
+    "description": "Run at a fixed interval"
+  },
+  "scheduledTasks.form.intervalUnit.minute": {
+    "message": "minutes",
+    "description": "Interval unit: minutes"
+  },
+  "scheduledTasks.form.intervalUnit.hour": {
+    "message": "hours",
+    "description": "Interval unit: hours"
+  },
+  "scheduledTasks.form.intervalUnit.day": {
+    "message": "days",
+    "description": "Interval unit: days"
+  },
+  "scheduledTasks.form.hourlyMinute": {
+    "message": "At minute",
+    "description": "Which minute of each hour to run"
+  },
+  "scheduledTasks.form.hourlyMinuteHint": {
+    "message": "Which minute of each hour to run (0–59)",
+    "description": "Hourly minute hint"
+  },
+  "scheduledTasks.form.intervalHint": {
+    "message": "Runs once every fixed interval after the previous run (minimum 1 minute)",
+    "description": "Interval hint"
+  },
+  "scheduledTasks.form.cronHint": {
+    "message": "Standard 5-field cron expression: minute hour day month weekday",
+    "description": "Cron hint"
+  },
+  "scheduledTasks.form.schedulePreview": {
+    "message": "Runs {text}",
+    "description": "Schedule preview"
+  },
+  "scheduledTasks.humanize.everyNMinutes": {
+    "message": "every {n} min",
+    "description": "Human-readable: every N minutes"
+  },
+  "scheduledTasks.humanize.everyNHours": {
+    "message": "every {n} h",
+    "description": "Human-readable: every N hours"
+  },
+  "scheduledTasks.humanize.everyNDays": {
+    "message": "every {n} d",
+    "description": "Human-readable: every N days"
+  },
+  "scheduledTasks.humanize.hourlyAtMinute": {
+    "message": "hourly at minute {n}",
+    "description": "Human-readable: hourly at minute N"
+  },
+  "scheduledTasks.humanize.dailyAt": {
+    "message": "daily at {time}",
+    "description": "Human-readable: daily at time"
+  },
+  "scheduledTasks.humanize.weeklyAt": {
+    "message": "{weekday} at {time}",
+    "description": "Human-readable: weekly at weekday/time"
+  },
+  "scheduledTasks.humanize.cronRaw": {
+    "message": "Cron: {cron}",
+    "description": "Human-readable: raw cron"
+  },
+  "scheduledTasks.humanize.once": {
+    "message": "once at {time}",
+    "description": "Human-readable: once"
+  },
   "scheduledTasks.form.name": {
     "message": "Task name"
   },

--- a/src/i18n/sr/chat.json
+++ b/src/i18n/sr/chat.json
@@ -654,6 +654,74 @@
   "scheduledTasks.scheduleType.cron": {
     "message": "Cron expression"
   },
+  "scheduledTasks.scheduleType.interval": {
+    "message": "Every",
+    "description": "Run at a fixed interval"
+  },
+  "scheduledTasks.form.intervalUnit.minute": {
+    "message": "minutes",
+    "description": "Interval unit: minutes"
+  },
+  "scheduledTasks.form.intervalUnit.hour": {
+    "message": "hours",
+    "description": "Interval unit: hours"
+  },
+  "scheduledTasks.form.intervalUnit.day": {
+    "message": "days",
+    "description": "Interval unit: days"
+  },
+  "scheduledTasks.form.hourlyMinute": {
+    "message": "At minute",
+    "description": "Which minute of each hour to run"
+  },
+  "scheduledTasks.form.hourlyMinuteHint": {
+    "message": "Which minute of each hour to run (0–59)",
+    "description": "Hourly minute hint"
+  },
+  "scheduledTasks.form.intervalHint": {
+    "message": "Runs once every fixed interval after the previous run (minimum 1 minute)",
+    "description": "Interval hint"
+  },
+  "scheduledTasks.form.cronHint": {
+    "message": "Standard 5-field cron expression: minute hour day month weekday",
+    "description": "Cron hint"
+  },
+  "scheduledTasks.form.schedulePreview": {
+    "message": "Runs {text}",
+    "description": "Schedule preview"
+  },
+  "scheduledTasks.humanize.everyNMinutes": {
+    "message": "every {n} min",
+    "description": "Human-readable: every N minutes"
+  },
+  "scheduledTasks.humanize.everyNHours": {
+    "message": "every {n} h",
+    "description": "Human-readable: every N hours"
+  },
+  "scheduledTasks.humanize.everyNDays": {
+    "message": "every {n} d",
+    "description": "Human-readable: every N days"
+  },
+  "scheduledTasks.humanize.hourlyAtMinute": {
+    "message": "hourly at minute {n}",
+    "description": "Human-readable: hourly at minute N"
+  },
+  "scheduledTasks.humanize.dailyAt": {
+    "message": "daily at {time}",
+    "description": "Human-readable: daily at time"
+  },
+  "scheduledTasks.humanize.weeklyAt": {
+    "message": "{weekday} at {time}",
+    "description": "Human-readable: weekly at weekday/time"
+  },
+  "scheduledTasks.humanize.cronRaw": {
+    "message": "Cron: {cron}",
+    "description": "Human-readable: raw cron"
+  },
+  "scheduledTasks.humanize.once": {
+    "message": "once at {time}",
+    "description": "Human-readable: once"
+  },
   "scheduledTasks.form.name": {
     "message": "Task name"
   },

--- a/src/i18n/sv/chat.json
+++ b/src/i18n/sv/chat.json
@@ -654,6 +654,74 @@
   "scheduledTasks.scheduleType.cron": {
     "message": "Cron expression"
   },
+  "scheduledTasks.scheduleType.interval": {
+    "message": "Every",
+    "description": "Run at a fixed interval"
+  },
+  "scheduledTasks.form.intervalUnit.minute": {
+    "message": "minutes",
+    "description": "Interval unit: minutes"
+  },
+  "scheduledTasks.form.intervalUnit.hour": {
+    "message": "hours",
+    "description": "Interval unit: hours"
+  },
+  "scheduledTasks.form.intervalUnit.day": {
+    "message": "days",
+    "description": "Interval unit: days"
+  },
+  "scheduledTasks.form.hourlyMinute": {
+    "message": "At minute",
+    "description": "Which minute of each hour to run"
+  },
+  "scheduledTasks.form.hourlyMinuteHint": {
+    "message": "Which minute of each hour to run (0–59)",
+    "description": "Hourly minute hint"
+  },
+  "scheduledTasks.form.intervalHint": {
+    "message": "Runs once every fixed interval after the previous run (minimum 1 minute)",
+    "description": "Interval hint"
+  },
+  "scheduledTasks.form.cronHint": {
+    "message": "Standard 5-field cron expression: minute hour day month weekday",
+    "description": "Cron hint"
+  },
+  "scheduledTasks.form.schedulePreview": {
+    "message": "Runs {text}",
+    "description": "Schedule preview"
+  },
+  "scheduledTasks.humanize.everyNMinutes": {
+    "message": "every {n} min",
+    "description": "Human-readable: every N minutes"
+  },
+  "scheduledTasks.humanize.everyNHours": {
+    "message": "every {n} h",
+    "description": "Human-readable: every N hours"
+  },
+  "scheduledTasks.humanize.everyNDays": {
+    "message": "every {n} d",
+    "description": "Human-readable: every N days"
+  },
+  "scheduledTasks.humanize.hourlyAtMinute": {
+    "message": "hourly at minute {n}",
+    "description": "Human-readable: hourly at minute N"
+  },
+  "scheduledTasks.humanize.dailyAt": {
+    "message": "daily at {time}",
+    "description": "Human-readable: daily at time"
+  },
+  "scheduledTasks.humanize.weeklyAt": {
+    "message": "{weekday} at {time}",
+    "description": "Human-readable: weekly at weekday/time"
+  },
+  "scheduledTasks.humanize.cronRaw": {
+    "message": "Cron: {cron}",
+    "description": "Human-readable: raw cron"
+  },
+  "scheduledTasks.humanize.once": {
+    "message": "once at {time}",
+    "description": "Human-readable: once"
+  },
   "scheduledTasks.form.name": {
     "message": "Task name"
   },

--- a/src/i18n/uk/chat.json
+++ b/src/i18n/uk/chat.json
@@ -654,6 +654,74 @@
   "scheduledTasks.scheduleType.cron": {
     "message": "Cron expression"
   },
+  "scheduledTasks.scheduleType.interval": {
+    "message": "Every",
+    "description": "Run at a fixed interval"
+  },
+  "scheduledTasks.form.intervalUnit.minute": {
+    "message": "minutes",
+    "description": "Interval unit: minutes"
+  },
+  "scheduledTasks.form.intervalUnit.hour": {
+    "message": "hours",
+    "description": "Interval unit: hours"
+  },
+  "scheduledTasks.form.intervalUnit.day": {
+    "message": "days",
+    "description": "Interval unit: days"
+  },
+  "scheduledTasks.form.hourlyMinute": {
+    "message": "At minute",
+    "description": "Which minute of each hour to run"
+  },
+  "scheduledTasks.form.hourlyMinuteHint": {
+    "message": "Which minute of each hour to run (0–59)",
+    "description": "Hourly minute hint"
+  },
+  "scheduledTasks.form.intervalHint": {
+    "message": "Runs once every fixed interval after the previous run (minimum 1 minute)",
+    "description": "Interval hint"
+  },
+  "scheduledTasks.form.cronHint": {
+    "message": "Standard 5-field cron expression: minute hour day month weekday",
+    "description": "Cron hint"
+  },
+  "scheduledTasks.form.schedulePreview": {
+    "message": "Runs {text}",
+    "description": "Schedule preview"
+  },
+  "scheduledTasks.humanize.everyNMinutes": {
+    "message": "every {n} min",
+    "description": "Human-readable: every N minutes"
+  },
+  "scheduledTasks.humanize.everyNHours": {
+    "message": "every {n} h",
+    "description": "Human-readable: every N hours"
+  },
+  "scheduledTasks.humanize.everyNDays": {
+    "message": "every {n} d",
+    "description": "Human-readable: every N days"
+  },
+  "scheduledTasks.humanize.hourlyAtMinute": {
+    "message": "hourly at minute {n}",
+    "description": "Human-readable: hourly at minute N"
+  },
+  "scheduledTasks.humanize.dailyAt": {
+    "message": "daily at {time}",
+    "description": "Human-readable: daily at time"
+  },
+  "scheduledTasks.humanize.weeklyAt": {
+    "message": "{weekday} at {time}",
+    "description": "Human-readable: weekly at weekday/time"
+  },
+  "scheduledTasks.humanize.cronRaw": {
+    "message": "Cron: {cron}",
+    "description": "Human-readable: raw cron"
+  },
+  "scheduledTasks.humanize.once": {
+    "message": "once at {time}",
+    "description": "Human-readable: once"
+  },
   "scheduledTasks.form.name": {
     "message": "Task name"
   },

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -679,6 +679,74 @@
     "message": "Cron 表达式",
     "description": "自定义 cron"
   },
+  "scheduledTasks.scheduleType.interval": {
+    "message": "每隔",
+    "description": "每隔固定间隔执行"
+  },
+  "scheduledTasks.form.intervalUnit.minute": {
+    "message": "分钟",
+    "description": "间隔单位：分钟"
+  },
+  "scheduledTasks.form.intervalUnit.hour": {
+    "message": "小时",
+    "description": "间隔单位：小时"
+  },
+  "scheduledTasks.form.intervalUnit.day": {
+    "message": "天",
+    "description": "间隔单位：天"
+  },
+  "scheduledTasks.form.hourlyMinute": {
+    "message": "触发分钟",
+    "description": "每小时第几分钟触发"
+  },
+  "scheduledTasks.form.hourlyMinuteHint": {
+    "message": "每小时的第几分钟触发（0–59）",
+    "description": "每小时分钟说明"
+  },
+  "scheduledTasks.form.intervalHint": {
+    "message": "从上次运行起，每隔固定时间执行一次（最短 1 分钟）",
+    "description": "固定间隔说明"
+  },
+  "scheduledTasks.form.cronHint": {
+    "message": "标准 5 段 Cron 表达式：分 时 日 月 周",
+    "description": "Cron 说明"
+  },
+  "scheduledTasks.form.schedulePreview": {
+    "message": "执行频率：{text}",
+    "description": "频率预览"
+  },
+  "scheduledTasks.humanize.everyNMinutes": {
+    "message": "每 {n} 分钟",
+    "description": "人类可读：每 N 分钟"
+  },
+  "scheduledTasks.humanize.everyNHours": {
+    "message": "每 {n} 小时",
+    "description": "人类可读：每 N 小时"
+  },
+  "scheduledTasks.humanize.everyNDays": {
+    "message": "每 {n} 天",
+    "description": "人类可读：每 N 天"
+  },
+  "scheduledTasks.humanize.hourlyAtMinute": {
+    "message": "每小时第 {n} 分钟",
+    "description": "人类可读：每小时第 N 分钟"
+  },
+  "scheduledTasks.humanize.dailyAt": {
+    "message": "每天 {time}",
+    "description": "人类可读：每天某时刻"
+  },
+  "scheduledTasks.humanize.weeklyAt": {
+    "message": "每周 {weekday} {time}",
+    "description": "人类可读：每周某天某时刻"
+  },
+  "scheduledTasks.humanize.cronRaw": {
+    "message": "Cron：{cron}",
+    "description": "人类可读：原始 Cron"
+  },
+  "scheduledTasks.humanize.once": {
+    "message": "一次性 {time}",
+    "description": "人类可读：一次性"
+  },
   "scheduledTasks.form.name": {
     "message": "任务名称",
     "description": "名称字段"

--- a/src/i18n/zh-TW/chat.json
+++ b/src/i18n/zh-TW/chat.json
@@ -654,6 +654,74 @@
   "scheduledTasks.scheduleType.cron": {
     "message": "Cron expression"
   },
+  "scheduledTasks.scheduleType.interval": {
+    "message": "每隔",
+    "description": "每隔固定間隔執行"
+  },
+  "scheduledTasks.form.intervalUnit.minute": {
+    "message": "分鐘",
+    "description": "間隔單位：分鐘"
+  },
+  "scheduledTasks.form.intervalUnit.hour": {
+    "message": "小時",
+    "description": "間隔單位：小時"
+  },
+  "scheduledTasks.form.intervalUnit.day": {
+    "message": "天",
+    "description": "間隔單位：天"
+  },
+  "scheduledTasks.form.hourlyMinute": {
+    "message": "觸發分鐘",
+    "description": "每小時第幾分鐘觸發"
+  },
+  "scheduledTasks.form.hourlyMinuteHint": {
+    "message": "每小時的第幾分鐘觸發（0–59）",
+    "description": "每小時分鐘說明"
+  },
+  "scheduledTasks.form.intervalHint": {
+    "message": "從上次執行起，每隔固定時間執行一次（最短 1 分鐘）",
+    "description": "固定間隔說明"
+  },
+  "scheduledTasks.form.cronHint": {
+    "message": "標準 5 段 Cron 運算式：分 時 日 月 週",
+    "description": "Cron 說明"
+  },
+  "scheduledTasks.form.schedulePreview": {
+    "message": "執行頻率：{text}",
+    "description": "頻率預覽"
+  },
+  "scheduledTasks.humanize.everyNMinutes": {
+    "message": "每 {n} 分鐘",
+    "description": "人類可讀：每 N 分鐘"
+  },
+  "scheduledTasks.humanize.everyNHours": {
+    "message": "每 {n} 小時",
+    "description": "人類可讀：每 N 小時"
+  },
+  "scheduledTasks.humanize.everyNDays": {
+    "message": "每 {n} 天",
+    "description": "人類可讀：每 N 天"
+  },
+  "scheduledTasks.humanize.hourlyAtMinute": {
+    "message": "每小時第 {n} 分鐘",
+    "description": "人類可讀：每小時第 N 分鐘"
+  },
+  "scheduledTasks.humanize.dailyAt": {
+    "message": "每天 {time}",
+    "description": "人類可讀：每天某時刻"
+  },
+  "scheduledTasks.humanize.weeklyAt": {
+    "message": "每週 {weekday} {time}",
+    "description": "人類可讀：每週某天某時刻"
+  },
+  "scheduledTasks.humanize.cronRaw": {
+    "message": "Cron：{cron}",
+    "description": "人類可讀：原始 Cron"
+  },
+  "scheduledTasks.humanize.once": {
+    "message": "一次性 {time}",
+    "description": "人類可讀：一次性"
+  },
   "scheduledTasks.form.name": {
     "message": "Task name"
   },

--- a/src/pages/chat/ScheduledTasks.vue
+++ b/src/pages/chat/ScheduledTasks.vue
@@ -157,12 +157,37 @@
 
         <el-form-item :label="$t('chat.scheduledTasks.form.schedule')">
           <el-radio-group v-model="form.scheduleType">
-            <el-radio value="minutely">{{ $t('chat.scheduledTasks.scheduleType.minutely') }}</el-radio>
-            <el-radio value="daily">{{ $t('chat.scheduledTasks.scheduleType.daily') }}</el-radio>
+            <el-radio value="interval">{{ $t('chat.scheduledTasks.scheduleType.interval') }}</el-radio>
             <el-radio value="hourly">{{ $t('chat.scheduledTasks.scheduleType.hourly') }}</el-radio>
+            <el-radio value="daily">{{ $t('chat.scheduledTasks.scheduleType.daily') }}</el-radio>
             <el-radio value="weekly">{{ $t('chat.scheduledTasks.scheduleType.weekly') }}</el-radio>
             <el-radio value="cron">{{ $t('chat.scheduledTasks.scheduleType.cron') }}</el-radio>
           </el-radio-group>
+          <div v-if="schedulePreview" class="schedule-preview">
+            <font-awesome-icon icon="fa-solid fa-clock" class="preview-icon" />
+            {{ $t('chat.scheduledTasks.form.schedulePreview', { text: schedulePreview }) }}
+          </div>
+        </el-form-item>
+
+        <el-form-item v-if="form.scheduleType === 'interval'" :label="$t('chat.scheduledTasks.scheduleType.interval')">
+          <el-input-number
+            v-model="form.intervalValue"
+            :min="1"
+            :max="intervalMax"
+            :step="1"
+            controls-position="right"
+          />
+          <el-select v-model="form.intervalUnit" style="width: 110px; margin-left: 8px">
+            <el-option :label="$t('chat.scheduledTasks.form.intervalUnit.minute')" value="minute" />
+            <el-option :label="$t('chat.scheduledTasks.form.intervalUnit.hour')" value="hour" />
+            <el-option :label="$t('chat.scheduledTasks.form.intervalUnit.day')" value="day" />
+          </el-select>
+          <div class="hint">{{ $t('chat.scheduledTasks.form.intervalHint') }}</div>
+        </el-form-item>
+
+        <el-form-item v-if="form.scheduleType === 'hourly'" :label="$t('chat.scheduledTasks.form.hourlyMinute')">
+          <el-input-number v-model="form.hourlyMinute" :min="0" :max="59" :step="1" controls-position="right" />
+          <div class="hint">{{ $t('chat.scheduledTasks.form.hourlyMinuteHint') }}</div>
         </el-form-item>
 
         <el-form-item v-if="form.scheduleType === 'daily'" :label="$t('chat.scheduledTasks.form.time')">
@@ -179,6 +204,7 @@
 
         <el-form-item v-if="form.scheduleType === 'cron'" :label="$t('chat.scheduledTasks.form.cron')">
           <el-input v-model="form.cronExpr" placeholder="0 9 * * *" />
+          <div class="hint">{{ $t('chat.scheduledTasks.form.cronHint') }}</div>
         </el-form-item>
 
         <el-form-item :label="$t('chat.scheduledTasks.form.skills')">
@@ -299,7 +325,10 @@ interface TaskForm {
   name: string;
   question: string;
   model: string;
-  scheduleType: 'minutely' | 'daily' | 'hourly' | 'weekly' | 'cron';
+  scheduleType: 'interval' | 'hourly' | 'daily' | 'weekly' | 'cron';
+  intervalValue: number;
+  intervalUnit: 'minute' | 'hour' | 'day';
+  hourlyMinute: number;
   dailyTime: string;
   weekday: number;
   cronExpr: string;
@@ -372,6 +401,18 @@ export default defineComponent({
     pagedRuns(): IScheduledRun[] {
       const start = (this.runPage - 1) * this.runPageSize;
       return this.runs.slice(start, start + this.runPageSize);
+    },
+    // Sensible upper bound for the interval number input, per selected unit.
+    intervalMax(): number {
+      return this.form.intervalUnit === 'minute' ? 1440 : this.form.intervalUnit === 'hour' ? 720 : 365;
+    },
+    // Live human-readable summary of the schedule the form currently builds.
+    schedulePreview(): string {
+      try {
+        return this.humanizeSchedule(this.buildSchedule());
+      } catch {
+        return '';
+      }
     }
   },
   async mounted() {
@@ -384,6 +425,9 @@ export default defineComponent({
         question: '',
         model: CHAT_MODEL_NAME_GPT_5_4_MINI,
         scheduleType: 'daily',
+        intervalValue: 4,
+        intervalUnit: 'hour',
+        hourlyMinute: 0,
         dailyTime: '09:00',
         weekday: 1,
         cronExpr: '0 9 * * *',
@@ -432,33 +476,50 @@ export default defineComponent({
       this.editingTask = task;
       const s = task.schedule;
       let scheduleType: TaskForm['scheduleType'] = 'cron';
+      let intervalValue = 4;
+      let intervalUnit: TaskForm['intervalUnit'] = 'hour';
+      let hourlyMinute = 0;
       let dailyTime = '09:00';
       let cronExpr = '0 9 * * *';
       let weekday = 1;
       if (s.type === 'cron') {
         cronExpr = s.cron;
-        const parts = s.cron.split(' ');
-        if (parts.length === 5) {
-          const [min, hour, , , dow] = parts;
-          if (dow === '*' && !isNaN(Number(hour))) {
-            scheduleType = 'daily';
-            dailyTime = `${hour.padStart(2, '0')}:${min.padStart(2, '0')}`;
-          } else if (!isNaN(Number(dow))) {
-            scheduleType = 'weekly';
-            weekday = Number(dow);
-            dailyTime = `${hour.padStart(2, '0')}:${min.padStart(2, '0')}`;
-          }
+        const [min, hour, dom, mon, dow] = s.cron.split(/\s+/);
+        const isNum = (v: string) => /^\d+$/.test(v);
+        if (dom === '*' && mon === '*' && dow === '*' && hour === '*' && isNum(min)) {
+          // "M * * * *" → at minute M of every hour.
+          scheduleType = 'hourly';
+          hourlyMinute = Number(min);
+        } else if (dom === '*' && mon === '*' && dow === '*' && isNum(hour) && isNum(min)) {
+          scheduleType = 'daily';
+          dailyTime = `${hour.padStart(2, '0')}:${min.padStart(2, '0')}`;
+        } else if (dom === '*' && mon === '*' && isNum(dow) && isNum(hour) && isNum(min)) {
+          scheduleType = 'weekly';
+          weekday = Number(dow);
+          dailyTime = `${hour.padStart(2, '0')}:${min.padStart(2, '0')}`;
         }
       } else if (s.type === 'interval') {
-        if (s.interval_seconds === 60) scheduleType = 'minutely';
-        else if (s.interval_seconds === 3600) scheduleType = 'hourly';
-        else scheduleType = 'cron';
+        scheduleType = 'interval';
+        const sec = s.interval_seconds;
+        if (sec % 86400 === 0) {
+          intervalUnit = 'day';
+          intervalValue = sec / 86400;
+        } else if (sec % 3600 === 0) {
+          intervalUnit = 'hour';
+          intervalValue = sec / 3600;
+        } else {
+          intervalUnit = 'minute';
+          intervalValue = Math.max(1, Math.round(sec / 60));
+        }
       }
       this.form = {
         name: task.name,
         question: task.template.question,
         model: task.template.model,
         scheduleType,
+        intervalValue,
+        intervalUnit,
+        hourlyMinute,
         dailyTime,
         weekday,
         cronExpr,
@@ -476,12 +537,16 @@ export default defineComponent({
       void this.loadAuthorizableSkills();
     },
     buildSchedule(): IScheduleSpec {
-      const { scheduleType, dailyTime, weekday, cronExpr } = this.form;
-      if (scheduleType === 'minutely') {
-        return { type: 'interval', interval_seconds: 60, tz: USER_TZ };
+      const { scheduleType, intervalValue, intervalUnit, hourlyMinute, dailyTime, weekday, cronExpr } = this.form;
+      if (scheduleType === 'interval') {
+        const unitSeconds = intervalUnit === 'day' ? 86400 : intervalUnit === 'hour' ? 3600 : 60;
+        // Scheduler's finest cadence is 60s; guard against sub-minute intervals.
+        const seconds = Math.max(60, Math.round(intervalValue) * unitSeconds);
+        return { type: 'interval', interval_seconds: seconds, tz: USER_TZ };
       }
       if (scheduleType === 'hourly') {
-        return { type: 'interval', interval_seconds: 3600, tz: USER_TZ };
+        const m = Math.min(59, Math.max(0, Math.round(hourlyMinute)));
+        return { type: 'cron', cron: `${m} * * * *`, tz: USER_TZ };
       }
       if (scheduleType === 'daily') {
         const [h, m] = dailyTime.split(':');
@@ -692,10 +757,33 @@ export default defineComponent({
     runErrorText(run: IScheduledRun) {
       return run.error_message || run.error_code?.replace(/_/g, ' ') || '';
     },
+    // Turn any backend schedule spec into a localized, human-readable phrase.
+    humanizeSchedule(s: IScheduleSpec): string {
+      const t = (k: string, p?: Record<string, unknown>) =>
+        this.$t(`chat.scheduledTasks.humanize.${k}`, p ?? {}) as string;
+      if (s.type === 'interval') {
+        const sec = s.interval_seconds;
+        if (sec % 86400 === 0) return t('everyNDays', { n: sec / 86400 });
+        if (sec % 3600 === 0) return t('everyNHours', { n: sec / 3600 });
+        return t('everyNMinutes', { n: Math.round(sec / 60) });
+      }
+      if (s.type === 'cron') {
+        const [min, hour, dom, mon, dow] = s.cron.split(/\s+/);
+        const isNum = (v: string) => /^\d+$/.test(v);
+        if (dom === '*' && mon === '*' && dow === '*' && hour === '*' && isNum(min)) {
+          return t('hourlyAtMinute', { n: Number(min) });
+        }
+        const time = isNum(hour) && isNum(min) ? `${hour.padStart(2, '0')}:${min.padStart(2, '0')}` : '';
+        if (time && dom === '*' && mon === '*' && dow === '*') return t('dailyAt', { time });
+        if (time && dom === '*' && mon === '*' && isNum(dow)) {
+          return t('weeklyAt', { weekday: this.weekdays[Number(dow)] ?? dow, time });
+        }
+        return t('cronRaw', { cron: s.cron });
+      }
+      return t('once', { time: new Date(s.at * 1000).toLocaleString() });
+    },
     scheduleLabel(s: IScheduleSpec) {
-      if (s.type === 'interval') return `每 ${s.interval_seconds / 60} 分钟`;
-      if (s.type === 'cron') return `Cron: ${s.cron}`;
-      return `一次性: ${new Date(s.at * 1000).toLocaleString()}`;
+      return this.humanizeSchedule(s);
     },
     formatTime(ts: number) {
       return new Date(ts * 1000).toLocaleString();
@@ -993,6 +1081,20 @@ export default defineComponent({
   font-size: 11px;
   color: var(--el-text-color-secondary);
   margin-left: 8px;
+}
+.schedule-preview {
+  margin-top: 8px;
+  padding: 6px 12px;
+  border-radius: 8px;
+  background: var(--el-fill-color-light);
+  font-size: 12px;
+  color: var(--el-text-color-regular);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.preview-icon {
+  color: var(--el-color-primary);
 }
 .skill-option {
   display: flex;

--- a/src/pages/chat/ScheduledTasks.vue
+++ b/src/pages/chat/ScheduledTasks.vue
@@ -1075,7 +1075,11 @@ export default defineComponent({
 .hint {
   font-size: 11px;
   color: var(--el-text-color-secondary);
-  margin-top: 4px;
+  margin-top: 6px;
+  line-height: 1.5;
+  /* el-form-item content is flex-wrap; force the hint onto its own line
+     instead of cramming beside a narrow number input. */
+  flex-basis: 100%;
 }
 .jitter-hint {
   font-size: 11px;
@@ -1083,8 +1087,10 @@ export default defineComponent({
   margin-left: 8px;
 }
 .schedule-preview {
-  margin-top: 8px;
-  padding: 6px 12px;
+  flex-basis: 100%;
+  width: fit-content;
+  margin-top: 12px;
+  padding: 7px 12px;
   border-radius: 8px;
   background: var(--el-fill-color-light);
   font-size: 12px;


### PR DESCRIPTION
## What

定时任务(`studio.acedata.cloud/*/scheduled`)的"执行频率"从固定的 每分钟/每小时/每天/每周/Cron 升级为**更高级的自定义频率**,并加了**实时可读预览**。

新的频率模式:
- **每隔 N 分钟 / 小时 / 天**(interval builder):数字输入 + 单位下拉。覆盖"每 4 小时""每 90 分钟""每 3 天"等。
- **每小时第 M 分钟**(hourly-at-minute):0–59 分钟输入。覆盖"每小时的第 15 分钟"。
- 每天 / 每周 / Cron 保持不变。
- 表单底部新增 **执行频率预览**(`humanizeSchedule`),所见即所得。

## 背后如何映射(回答"是不是都映射成 cron")

不是全 cron。后端 `aichat2/scheduled-tasks` 本就支持**两种原语**,这次只是把它们完整暴露到 UI:

| UI 模式 | 发送给后端 |
|---|---|
| 每隔 N 分/时/天 | `{ type: 'interval', interval_seconds }`(任意秒,scheduler 无最小值守卫,实测最细 60s) |
| 每小时第 M 分钟 | `{ type: 'cron', cron: 'M * * * *' }` |
| 每天 | `{ type: 'cron', cron: 'M H * * *' }` |
| 每周 | `{ type: 'cron', cron: 'M H * * DOW' }` |
| Cron | 原始 cron |

原实现只硬编码了 interval 的 60s / 3600s 两个值,现在放开为任意 N × {60,3600,86400}。

## 往返正确性

`openEdit()` 的解析是 `buildSchedule()` 的严格逆:interval 秒数按 %86400 / %3600 反推天/时/分;cron 按 `dom/mon/dow` 通配符归类回 hourly / daily / weekly,非规整表达式(如 `*/15 * * * *`)安全落到"Cron 原始"模式。默认仍为 **每天 09:00**(保守,避免误配高频烧额度);interval 最短 1 分钟(`Math.max(60,…)` 守卫)。

## i18n

新增 17 个键到 **全部 18 个语言** 的 `chat.json`,`scripts/check_i18n_coverage.py` → OK(17 locale × 44 namespace all match zh-CN)。

## 验证
- `eslint src/pages/chat/ScheduledTasks.vue` → 干净(prettier --fix 后)
- `vue-tsc --noEmit` → 无相关类型错误
- beachball change file 已生成

## 🤖 对抗评审
Codex 用量到顶,改用 general-purpose 子代理逐模式核对 build⇄parse 往返、cron 归类边界(`*/15`、`1-5`、monthly `0 9 1 * *` 均正确落到 raw cron)、interval 单位反推(90min=5400s→minute/90 ✓)、i18n 键与占位符一致性、union 类型收窄。**VERDICT: CLEAN**。非阻塞观察:边界值重开后 label 归一(60min→"每 1 小时")、部分非中英 locale 的 humanize 值暂为英文(占位符完好,仅翻译质量)、遗留未引用的 `scheduleType.minutely` 死键(无害)。