### PR TITLE
feat(maestro): show live agent activity + render % as the progress detail

### DIFF
--- a/change/@acedatacloud-nexior-maestro-live-detail.json
+++ b/change/@acedatacloud-nexior-maestro-live-detail.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "maestro: show the agent's live activity line (and render %) as the progress detail",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/maestro/task/ProgressSteps.vue
+++ b/src/components/maestro/task/ProgressSteps.vue
@@ -63,9 +63,13 @@ export default defineComponent({
       return Math.max(max, 0);
     },
     // Latest progress message (may be from a previous step if the current step hasn't logged one
-    // yet) — shown as the live "currently doing" detail under the active step.
+    // yet) — shown as the live "currently doing" detail under the active step. Prefer the worker's
+    // live `activity` line (the director's own narration / "Rendering · 60% (1400/2388 frames)")
+    // over the sparse canned stage messages, so a long step exposes real, moving detail.
     detail(): string | undefined {
-      const events = this.modelValue?.response?.data?.progress || [];
+      const data = this.modelValue?.response?.data;
+      if (data?.activity) return data.activity;
+      const events = data?.progress || [];
       for (let i = events.length - 1; i >= 0; i--) {
         if (events[i]?.message) return events[i]?.message;
       }

--- a/src/models/maestro.ts
+++ b/src/models/maestro.ts
@@ -38,11 +38,24 @@ export interface IMaestroProject {
   outputs?: string[];
 }
 
+// Live per-frame render telemetry (worker parses it from the HyperFrames render output) so the
+// UI can move the bar and show "1194/2388 frames" during a long render instead of freezing.
+export interface IMaestroRender {
+  percent?: number;
+  frames_done?: number;
+  frames_total?: number;
+}
+
 export interface IMaestroData {
   variants?: IMaestroVariant[];
   project?: IMaestroProject;
   progress?: IMaestroProgress[];
   stage?: string;
+  percent?: number;
+  // Latest "what the agent is doing right now" one-liner (the director's own narration), shown as
+  // the live detail under the active step so a long stage exposes real, moving progress.
+  activity?: string;
+  render?: IMaestroRender;
 }
 
 export interface IMaestroGenerateResponse {


### PR DESCRIPTION
## What

Companion to **AceDataCloud/PlatformService#1430**. Maestro’s progress checklist showed a single sparse canned line per stage (e.g. a frozen “Uploading to CDN” at 93% during a long re-render). The worker now emits a live `response.data.activity` (the director’s own narration) and `response.data.render` telemetry, and moves the percent through the render band.

This makes the UI use it: `ProgressSteps.vue`’s `detail` line now **prefers `response.data.activity`** (falling back to the latest progress message), so the active step shows what the agent is actually doing right now — “背景音乐音量已从 0.28 降到 0.12，现在重新渲染视频”, “Rendering video · 60% (1400/2388 frames)”, “Interrupted — resuming in 35s” — instead of a static label.

Types: added `percent`, `activity`, and `render` (`IMaestroRender = {percent, frames_done, frames_total}`) to `IMaestroData`.

No behavior change beyond the detail source; the checklist stage logic and the header percent are untouched (the percent already reads `response.data.percent`, which the backend now advances during render).

## 🤖 对抗评审
UI-only: one computed reads a new optional field with a safe fallback; the interface additions are optional. Reviewer (Codex over limit → Claude subagent, read-only): the only borderline note was a brief stale “Rendering · N%” during the fast deliver window, which self-heals via the agent’s next narration and isn’t a reproducible defect; no type errors; `_public` actually delivers `response.data.activity`. **VERDICT: CLEAN.**
