### PR TITLE
feat(site services): favicon-only picker, fine-print markup help, localizable name/summary

### DIFF
--- a/change/@acedatacloud-nexior-service-override-l10n.json
+++ b/change/@acedatacloud-nexior-service-override-l10n.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Site service override: filter picker to non-private services with a favicon, fine-print markup helper, per-locale auto-translate toggles for display name/summary, fix sort-order tip spacing",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/setting/SiteServices.vue
+++ b/src/components/setting/SiteServices.vue
@@ -65,10 +65,11 @@
       v-model="dialogVisible"
       :title="editingRow ? $t('site.services.dialog.edit') : $t('site.services.dialog.create')"
       :width="mobile ? '94vw' : '520px'"
+      class="site-service-override-dialog"
       :close-on-click-modal="false"
       append-to-body
     >
-      <el-form :model="form" label-position="top" class="form" @submit.prevent>
+      <el-form :model="form" label-position="top" class="service-override-form" @submit.prevent>
         <el-form-item required>
           <template #label>
             <span class="field-head">
@@ -77,7 +78,14 @@
             </span>
           </template>
           <el-input v-if="editingRow" :model-value="catalogTitle(editingRow.service)" readonly />
-          <el-select v-else v-model="form.service" filterable :loading="catalogLoading" class="w-full">
+          <el-select
+            v-else
+            v-model="form.service"
+            filterable
+            :loading="catalogLoading"
+            popper-class="service-catalog-select-popper"
+            class="w-full"
+          >
             <el-option
               v-for="svc in catalogOptions"
               :key="svc.id"
@@ -85,12 +93,14 @@
               :value="svc.id"
               :disabled="isAlreadyOverridden(svc.id)"
             >
-              <img v-if="svc.icon_url" :src="svc.icon_url" class="option-favicon" alt="" />
-              <span class="option-title">{{ svc.title || svc.id }}</span>
-              <span v-if="svc.alias" class="option-alias">{{ svc.alias }}</span>
-              <el-tag v-if="isAlreadyOverridden(svc.id)" size="small" type="info" round>
-                {{ $t('site.services.message.alreadyOverridden') }}
-              </el-tag>
+              <span class="service-option">
+                <img v-if="svc.icon_url" :src="svc.icon_url" class="option-favicon" alt="" />
+                <span class="option-title">{{ svc.title || svc.id }}</span>
+                <span v-if="svc.alias" class="option-alias">{{ svc.alias }}</span>
+                <el-tag v-if="isAlreadyOverridden(svc.id)" size="small" type="info" round>
+                  {{ $t('site.services.message.alreadyOverridden') }}
+                </el-tag>
+              </span>
             </el-option>
           </el-select>
         </el-form-item>
@@ -669,66 +679,64 @@ export default defineComponent({
     color: var(--el-text-color-secondary);
     font-size: 12px;
   }
-  .form {
-    // The label now holds two lines (title + description), so let el-form-item's
-    // label box grow instead of clamping to its default single-line height.
-    :deep(.el-form-item__label) {
+}
+
+// The nested edit dialog is appended to body, so styles for its form must be
+// global rather than nested under `.site-services-settings`.
+:global(.site-service-override-dialog) {
+  .service-override-form {
+    .el-form-item__label {
       height: auto;
       line-height: 1.3;
       white-space: normal;
       margin-bottom: 4px;
     }
-    // Each field's label + a small gray description caption stacked beneath
-    // it, mirroring the Site settings rows.
     .field-head {
       display: block;
       line-height: 1.3;
-      .field-label {
-        font-weight: 500;
-        color: var(--el-text-color-primary);
-      }
-      .field-desc {
-        display: block;
-        margin-top: 2px;
-        font-size: 12px;
-        font-weight: 400;
-        line-height: 1.4;
-        white-space: normal;
-        color: var(--el-text-color-secondary);
-      }
+    }
+    .field-label {
+      display: block;
+      font-weight: 600;
+      color: var(--el-text-color-primary);
+    }
+    .field-desc {
+      display: block;
+      margin-top: 2px;
+      font-size: 12px;
+      font-weight: 400;
+      line-height: 1.4;
+      white-space: normal;
+      color: var(--el-text-color-secondary);
     }
     .markup-row {
       display: flex;
       align-items: center;
       gap: 10px;
-      .markup-input {
-        width: 150px;
-      }
-      .markup-percent {
-        font-variant-numeric: tabular-nums;
-        color: var(--el-color-primary);
-        font-weight: 600;
-      }
+    }
+    .markup-input {
+      width: 150px;
+    }
+    .markup-percent {
+      font-variant-numeric: tabular-nums;
+      color: var(--el-color-primary);
+      font-weight: 600;
     }
     .money-preview {
       display: flex;
       align-items: center;
       flex-wrap: wrap;
       gap: 8px;
-      margin-top: 4px;
-      .sample-input {
-        width: 120px;
-      }
-      .preview-result {
-        font-size: 12px;
-        color: var(--el-text-color-secondary);
-      }
+      margin-top: 6px;
     }
+    .sample-input {
+      width: 120px;
+    }
+    .preview-result,
     .field-tip {
       font-size: 12px;
       color: var(--el-text-color-secondary);
     }
-    // Auto-translate toggle rendered beneath the summary textarea.
     .auto-translate-inline {
       display: flex;
       align-items: center;
@@ -736,18 +744,41 @@ export default defineComponent({
       margin-top: 6px;
     }
   }
+}
+
+:global(.service-catalog-select-popper) {
+  .el-select-dropdown__item {
+    height: auto;
+    min-height: 34px;
+    line-height: 1.4;
+  }
+  .service-option {
+    display: flex;
+    align-items: center;
+    min-width: 0;
+    width: 100%;
+  }
   .option-favicon {
     width: 18px;
     height: 18px;
+    max-width: 18px;
+    max-height: 18px;
     border-radius: 4px;
     object-fit: contain;
-    vertical-align: middle;
+    flex-shrink: 0;
     margin-right: 6px;
+  }
+  .option-title {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
   .option-alias {
     margin-left: 8px;
     font-size: 12px;
     color: var(--el-text-color-secondary);
+    flex-shrink: 0;
   }
 }
 </style>

--- a/src/components/setting/SiteServices.vue
+++ b/src/components/setting/SiteServices.vue
@@ -17,8 +17,11 @@
         <el-table-column :label="$t('site.services.field.service')" min-width="200">
           <template #default="{ row }">
             <div class="service-cell">
-              <strong>{{ catalogTitle(row.service) }}</strong>
-              <div v-if="catalogAlias(row.service)" class="muted">{{ catalogAlias(row.service) }}</div>
+              <img v-if="catalogIcon(row.service)" :src="catalogIcon(row.service)" class="service-favicon" alt="" />
+              <div class="service-cell-text">
+                <strong>{{ catalogTitle(row.service) }}</strong>
+                <div v-if="catalogAlias(row.service)" class="muted">{{ catalogAlias(row.service) }}</div>
+              </div>
             </div>
           </template>
         </el-table-column>
@@ -83,6 +86,7 @@
               :value="svc.id"
               :disabled="isAlreadyOverridden(svc.id)"
             >
+              <img v-if="svc.icon_url" :src="svc.icon_url" class="option-favicon" alt="" />
               <span class="option-title">{{ svc.title || svc.id }}</span>
               <span v-if="svc.alias" class="option-alias">{{ svc.alias }}</span>
               <el-tag v-if="isAlreadyOverridden(svc.id)" size="small" type="info" round>
@@ -94,7 +98,7 @@
 
         <el-form-item :label="$t('site.services.field.visible')">
           <el-switch v-model="form.visible" />
-          <span class="field-tip">{{ $t('site.services.tip.visible') }}</span>
+          <span class="field-tip field-tip--inline">{{ $t('site.services.tip.visible') }}</span>
         </el-form-item>
 
         <el-form-item :label="$t('site.field.markupRatio')">
@@ -113,24 +117,26 @@
               {{ formatMarkup(form.markupRatio) }}
             </span>
           </div>
-          <span class="field-tip">{{ $t('site.services.tip.markup') }}</span>
-          <div class="money-preview">
-            <span class="field-tip">{{ $t('site.services.preview.sampleLabel') }}</span>
-            <el-input-number
-              v-model="sampleBase"
-              :min="0"
-              :step="1"
-              :precision="2"
-              size="small"
-              :controls-position="'right'"
-              class="sample-input"
-            />
-            <span class="preview-result">
-              {{ $t('site.message.markupExample', { from: previewFrom, to: previewTo }) }}
-            </span>
-            <span v-if="typeof form.markupRatio !== 'number'" class="field-tip">
-              {{ $t('site.services.preview.inherit', { percent: formatMarkup(siteDefaultRatio) }) }}
-            </span>
+          <div class="markup-help">
+            <p class="field-tip">{{ $t('site.services.tip.markup') }}</p>
+            <div class="money-preview">
+              <span class="field-tip">{{ $t('site.services.preview.sampleLabel') }}</span>
+              <el-input-number
+                v-model="sampleBase"
+                :min="0"
+                :step="1"
+                :precision="2"
+                size="small"
+                :controls-position="'right'"
+                class="sample-input"
+              />
+              <span class="preview-result">
+                {{ $t('site.message.markupExample', { from: previewFrom, to: previewTo }) }}
+              </span>
+              <span v-if="typeof form.markupRatio !== 'number'" class="field-tip">
+                {{ $t('site.services.preview.inherit', { percent: formatMarkup(siteDefaultRatio) }) }}
+              </span>
+            </div>
           </div>
         </el-form-item>
 
@@ -141,7 +147,19 @@
             maxlength="120"
             show-word-limit
             clearable
-          />
+          >
+            <template #suffix>
+              <auto-translate-toggle
+                model="site_service_override"
+                field="display_title"
+                :object-id="editingRow?.id"
+                :enabled="form.autoTranslatedFields.includes('display_title')"
+                :current-value="form.displayTitle"
+                @enabled-success="onDisplayTitleEnabled"
+                @disabled-success="onDisplayTitleDisabled"
+              />
+            </template>
+          </el-input>
         </el-form-item>
 
         <el-form-item :label="$t('site.services.field.displaySummary')">
@@ -152,6 +170,27 @@
             :placeholder="$t('site.services.placeholder.displaySummary')"
             clearable
           />
+          <!-- textarea has no #suffix slot; render the toggle inline beneath -->
+          <div class="auto-translate-inline">
+            <auto-translate-toggle
+              model="site_service_override"
+              field="display_summary"
+              :object-id="editingRow?.id"
+              :enabled="form.autoTranslatedFields.includes('display_summary')"
+              :current-value="form.displaySummary"
+              @enabled-success="onDisplaySummaryEnabled"
+              @disabled-success="onDisplaySummaryDisabled"
+            />
+            <span class="field-tip">
+              {{
+                editingRow
+                  ? form.autoTranslatedFields.includes('display_summary')
+                    ? $t('site.autoTranslate.tooltipOn')
+                    : $t('site.autoTranslate.tooltipOff')
+                  : $t('site.autoTranslate.tooltipDisabledNotSaved')
+              }}
+            </span>
+          </div>
         </el-form-item>
 
         <el-form-item :label="$t('site.services.field.sortOrder')">
@@ -163,7 +202,7 @@
             :precision="0"
             :controls-position="'right'"
           />
-          <span class="field-tip">{{ $t('site.services.tip.sortOrder') }}</span>
+          <span class="field-tip field-tip--inline">{{ $t('site.services.tip.sortOrder') }}</span>
         </el-form-item>
       </el-form>
       <template #footer>
@@ -207,6 +246,7 @@ import { Plus } from '@element-plus/icons-vue';
 import { serviceOperator, siteServiceOverrideOperator } from '@/operators';
 import type { IService, ISite, ISiteServiceOverride } from '@/models';
 import SectionNotice from '@/components/setting/SectionNotice.vue';
+import AutoTranslateToggle from '@/components/site/AutoTranslateToggle.vue';
 import { getPriceString, applyMarkup, getSiteMarkupRatio, MARKUP_RATIO_MAX } from '@/utils';
 
 // Pre-fetch the whole catalog once so each override row can show the
@@ -221,10 +261,21 @@ interface IForm {
   displayTitle: string;
   displaySummary: string;
   sortOrder: number;
+  // Server-derived: names of fields currently stored as ``$t(...)`` refs
+  // (auto-translated to 17 locales) rather than literal text.
+  autoTranslatedFields: string[];
 }
 
 function emptyForm(): IForm {
-  return { service: '', visible: true, markupRatio: undefined, displayTitle: '', displaySummary: '', sortOrder: 0 };
+  return {
+    service: '',
+    visible: true,
+    markupRatio: undefined,
+    displayTitle: '',
+    displaySummary: '',
+    sortOrder: 0,
+    autoTranslatedFields: []
+  };
 }
 
 /**
@@ -251,7 +302,8 @@ export default defineComponent({
     ElOption,
     ElSwitch,
     ElTag,
-    SectionNotice
+    SectionNotice,
+    AutoTranslateToggle
   },
   directives: {
     loading: vLoading
@@ -303,11 +355,15 @@ export default defineComponent({
       return typeof this.sampleBase === 'number' && this.sampleBase >= 0 ? this.sampleBase : 0;
     },
     catalogOptions(): IService[] {
-      return [...this.catalog].sort((a, b) => {
-        const at = (a.title || a.id || '').toLowerCase();
-        const bt = (b.title || b.id || '').toLowerCase();
-        return at < bt ? -1 : at > bt ? 1 : 0;
-      });
+      // Only offer services that are publicly listable (not catalog-private)
+      // and carry a favicon, so every homepage card renders with an icon.
+      return this.catalog
+        .filter((s) => s.private !== true && !!s.icon_url)
+        .sort((a, b) => {
+          const at = (a.title || a.id || '').toLowerCase();
+          const bt = (b.title || b.id || '').toLowerCase();
+          return at < bt ? -1 : at > bt ? 1 : 0;
+        });
     }
   },
   watch: {
@@ -348,6 +404,10 @@ export default defineComponent({
     catalogAlias(serviceId?: string): string | undefined {
       if (!serviceId) return undefined;
       return this.catalogMap[serviceId]?.alias;
+    },
+    catalogIcon(serviceId?: string): string | undefined {
+      if (!serviceId) return undefined;
+      return this.catalogMap[serviceId]?.icon_url || undefined;
     },
     optionLabel(svc: IService): string {
       // el-select filterable matches the label string, so concatenate
@@ -403,9 +463,60 @@ export default defineComponent({
         markupRatio: typeof row.markup_ratio === 'number' ? row.markup_ratio : undefined,
         displayTitle: row.display_title_source ?? row.display_title ?? '',
         displaySummary: row.display_summary_source ?? row.display_summary ?? '',
-        sortOrder: typeof row.sort_order === 'number' ? row.sort_order : 0
+        sortOrder: typeof row.sort_order === 'number' ? row.sort_order : 0,
+        autoTranslatedFields: [...(row.auto_translated_fields ?? [])]
       };
       this.dialogVisible = true;
+    },
+    async onDisplayTitleEnabled(payload: { source: string; fieldValue: string }): Promise<void> {
+      // Server now holds the literal in Translation; mirror its ``source`` so
+      // the next save round-trips the same zh-cn string, and keep ``editingRow``
+      // in sync so re-opening the dialog hydrates from post-toggle state.
+      this.form.displayTitle = payload.source;
+      this.form.autoTranslatedFields = [...new Set([...this.form.autoTranslatedFields, 'display_title'])].sort();
+      if (this.editingRow) {
+        this.editingRow.display_title = payload.fieldValue;
+        this.editingRow.display_title_source = payload.source;
+        this.editingRow.auto_translated_fields = [...this.form.autoTranslatedFields];
+      }
+      ElMessage.success(this.$t('site.services.message.saved'));
+      // Refetch so the table renders the locale-resolved title, not the $t(...) ref.
+      await this.onFetch();
+    },
+    async onDisplayTitleDisabled(payload: { fieldValue: string | null }): Promise<void> {
+      const value = payload.fieldValue ?? '';
+      this.form.displayTitle = value;
+      this.form.autoTranslatedFields = this.form.autoTranslatedFields.filter((f) => f !== 'display_title');
+      if (this.editingRow) {
+        this.editingRow.display_title = value || null;
+        this.editingRow.display_title_source = value || null;
+        this.editingRow.auto_translated_fields = [...this.form.autoTranslatedFields];
+      }
+      ElMessage.success(this.$t('site.services.message.saved'));
+      await this.onFetch();
+    },
+    async onDisplaySummaryEnabled(payload: { source: string; fieldValue: string }): Promise<void> {
+      this.form.displaySummary = payload.source;
+      this.form.autoTranslatedFields = [...new Set([...this.form.autoTranslatedFields, 'display_summary'])].sort();
+      if (this.editingRow) {
+        this.editingRow.display_summary = payload.fieldValue;
+        this.editingRow.display_summary_source = payload.source;
+        this.editingRow.auto_translated_fields = [...this.form.autoTranslatedFields];
+      }
+      ElMessage.success(this.$t('site.services.message.saved'));
+      await this.onFetch();
+    },
+    async onDisplaySummaryDisabled(payload: { fieldValue: string | null }): Promise<void> {
+      const value = payload.fieldValue ?? '';
+      this.form.displaySummary = value;
+      this.form.autoTranslatedFields = this.form.autoTranslatedFields.filter((f) => f !== 'display_summary');
+      if (this.editingRow) {
+        this.editingRow.display_summary = value || null;
+        this.editingRow.display_summary_source = value || null;
+        this.editingRow.auto_translated_fields = [...this.form.autoTranslatedFields];
+      }
+      ElMessage.success(this.$t('site.services.message.saved'));
+      await this.onFetch();
     },
     async onSubmit(): Promise<void> {
       if (this.editingRow) {
@@ -523,8 +634,20 @@ export default defineComponent({
     width: 100%;
     .service-cell {
       display: flex;
-      flex-direction: column;
-      gap: 2px;
+      align-items: center;
+      gap: 8px;
+      .service-favicon {
+        width: 22px;
+        height: 22px;
+        border-radius: 4px;
+        object-fit: contain;
+        flex-shrink: 0;
+      }
+      .service-cell-text {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+      }
     }
   }
   .muted {
@@ -550,20 +673,48 @@ export default defineComponent({
       align-items: center;
       flex-wrap: wrap;
       gap: 8px;
-      margin-top: 6px;
+      margin-top: 4px;
       .sample-input {
         width: 120px;
       }
       .preview-result {
-        font-size: 13px;
-        font-weight: 600;
-        color: var(--el-text-color-primary);
+        font-size: 12px;
+        color: var(--el-text-color-secondary);
+      }
+    }
+    // Markup helper reads as fine print stacked under the input, not as a
+    // sibling glued to its right.
+    .markup-help {
+      flex-basis: 100%;
+      margin-top: 6px;
+      .field-tip {
+        display: block;
       }
     }
     .field-tip {
       font-size: 12px;
       color: var(--el-text-color-secondary);
     }
+    // Tips that sit on the same row as an inline control (switch, sort input)
+    // need breathing room from it.
+    .field-tip--inline {
+      margin-left: 10px;
+    }
+    // Auto-translate toggle rendered beneath the summary textarea.
+    .auto-translate-inline {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      margin-top: 6px;
+    }
+  }
+  .option-favicon {
+    width: 18px;
+    height: 18px;
+    border-radius: 4px;
+    object-fit: contain;
+    vertical-align: middle;
+    margin-right: 6px;
   }
   .option-alias {
     margin-left: 8px;

--- a/src/components/setting/SiteServices.vue
+++ b/src/components/setting/SiteServices.vue
@@ -69,16 +69,15 @@
       append-to-body
     >
       <el-form :model="form" label-position="top" class="form" @submit.prevent>
-        <el-form-item :label="$t('site.services.field.service')" required>
+        <el-form-item required>
+          <template #label>
+            <span class="field-head">
+              <span class="field-label">{{ $t('site.services.field.service') }}</span>
+              <span class="field-desc">{{ $t('site.services.placeholder.service') }}</span>
+            </span>
+          </template>
           <el-input v-if="editingRow" :model-value="catalogTitle(editingRow.service)" readonly />
-          <el-select
-            v-else
-            v-model="form.service"
-            :placeholder="$t('site.services.placeholder.service')"
-            filterable
-            :loading="catalogLoading"
-            class="w-full"
-          >
+          <el-select v-else v-model="form.service" filterable :loading="catalogLoading" class="w-full">
             <el-option
               v-for="svc in catalogOptions"
               :key="svc.id"
@@ -96,12 +95,23 @@
           </el-select>
         </el-form-item>
 
-        <el-form-item :label="$t('site.services.field.visible')">
+        <el-form-item>
+          <template #label>
+            <span class="field-head">
+              <span class="field-label">{{ $t('site.services.field.visible') }}</span>
+              <span class="field-desc">{{ $t('site.services.tip.visible') }}</span>
+            </span>
+          </template>
           <el-switch v-model="form.visible" />
-          <span class="field-tip field-tip--inline">{{ $t('site.services.tip.visible') }}</span>
         </el-form-item>
 
-        <el-form-item :label="$t('site.field.markupRatio')">
+        <el-form-item>
+          <template #label>
+            <span class="field-head">
+              <span class="field-label">{{ $t('site.field.markupRatio') }}</span>
+              <span class="field-desc">{{ $t('site.services.tip.markup') }}</span>
+            </span>
+          </template>
           <div class="markup-row">
             <el-input-number
               v-model="form.markupRatio"
@@ -117,37 +127,34 @@
               {{ formatMarkup(form.markupRatio) }}
             </span>
           </div>
-          <div class="markup-help">
-            <p class="field-tip">{{ $t('site.services.tip.markup') }}</p>
-            <div class="money-preview">
-              <span class="field-tip">{{ $t('site.services.preview.sampleLabel') }}</span>
-              <el-input-number
-                v-model="sampleBase"
-                :min="0"
-                :step="1"
-                :precision="2"
-                size="small"
-                :controls-position="'right'"
-                class="sample-input"
-              />
-              <span class="preview-result">
-                {{ $t('site.message.markupExample', { from: previewFrom, to: previewTo }) }}
-              </span>
-              <span v-if="typeof form.markupRatio !== 'number'" class="field-tip">
-                {{ $t('site.services.preview.inherit', { percent: formatMarkup(siteDefaultRatio) }) }}
-              </span>
-            </div>
+          <div class="money-preview">
+            <span class="field-tip">{{ $t('site.services.preview.sampleLabel') }}</span>
+            <el-input-number
+              v-model="sampleBase"
+              :min="0"
+              :step="1"
+              :precision="2"
+              size="small"
+              :controls-position="'right'"
+              class="sample-input"
+            />
+            <span class="preview-result">
+              {{ $t('site.message.markupExample', { from: previewFrom, to: previewTo }) }}
+            </span>
+            <span v-if="typeof form.markupRatio !== 'number'" class="field-tip">
+              {{ $t('site.services.preview.inherit', { percent: formatMarkup(siteDefaultRatio) }) }}
+            </span>
           </div>
         </el-form-item>
 
-        <el-form-item :label="$t('site.services.field.displayTitle')">
-          <el-input
-            v-model="form.displayTitle"
-            :placeholder="$t('site.services.placeholder.displayTitle')"
-            maxlength="120"
-            show-word-limit
-            clearable
-          >
+        <el-form-item>
+          <template #label>
+            <span class="field-head">
+              <span class="field-label">{{ $t('site.services.field.displayTitle') }}</span>
+              <span class="field-desc">{{ $t('site.services.placeholder.displayTitle') }}</span>
+            </span>
+          </template>
+          <el-input v-model="form.displayTitle" maxlength="120" show-word-limit clearable>
             <template #suffix>
               <auto-translate-toggle
                 model="site_service_override"
@@ -162,14 +169,14 @@
           </el-input>
         </el-form-item>
 
-        <el-form-item :label="$t('site.services.field.displaySummary')">
-          <el-input
-            v-model="form.displaySummary"
-            type="textarea"
-            :rows="3"
-            :placeholder="$t('site.services.placeholder.displaySummary')"
-            clearable
-          />
+        <el-form-item>
+          <template #label>
+            <span class="field-head">
+              <span class="field-label">{{ $t('site.services.field.displaySummary') }}</span>
+              <span class="field-desc">{{ $t('site.services.placeholder.displaySummary') }}</span>
+            </span>
+          </template>
+          <el-input v-model="form.displaySummary" type="textarea" :rows="3" clearable />
           <!-- textarea has no #suffix slot; render the toggle inline beneath -->
           <div class="auto-translate-inline">
             <auto-translate-toggle
@@ -193,7 +200,13 @@
           </div>
         </el-form-item>
 
-        <el-form-item :label="$t('site.services.field.sortOrder')">
+        <el-form-item>
+          <template #label>
+            <span class="field-head">
+              <span class="field-label">{{ $t('site.services.field.sortOrder') }}</span>
+              <span class="field-desc">{{ $t('site.services.tip.sortOrder') }}</span>
+            </span>
+          </template>
           <el-input-number
             v-model="form.sortOrder"
             :min="-1000"
@@ -202,7 +215,6 @@
             :precision="0"
             :controls-position="'right'"
           />
-          <span class="field-tip field-tip--inline">{{ $t('site.services.tip.sortOrder') }}</span>
         </el-form-item>
       </el-form>
       <template #footer>
@@ -658,6 +670,33 @@ export default defineComponent({
     font-size: 12px;
   }
   .form {
+    // The label now holds two lines (title + description), so let el-form-item's
+    // label box grow instead of clamping to its default single-line height.
+    :deep(.el-form-item__label) {
+      height: auto;
+      line-height: 1.3;
+      white-space: normal;
+      margin-bottom: 4px;
+    }
+    // Each field's label + a small gray description caption stacked beneath
+    // it, mirroring the Site settings rows.
+    .field-head {
+      display: block;
+      line-height: 1.3;
+      .field-label {
+        font-weight: 500;
+        color: var(--el-text-color-primary);
+      }
+      .field-desc {
+        display: block;
+        margin-top: 2px;
+        font-size: 12px;
+        font-weight: 400;
+        line-height: 1.4;
+        white-space: normal;
+        color: var(--el-text-color-secondary);
+      }
+    }
     .markup-row {
       display: flex;
       align-items: center;
@@ -685,23 +724,9 @@ export default defineComponent({
         color: var(--el-text-color-secondary);
       }
     }
-    // Markup helper reads as fine print stacked under the input, not as a
-    // sibling glued to its right.
-    .markup-help {
-      flex-basis: 100%;
-      margin-top: 6px;
-      .field-tip {
-        display: block;
-      }
-    }
     .field-tip {
       font-size: 12px;
       color: var(--el-text-color-secondary);
-    }
-    // Tips that sit on the same row as an inline control (switch, sort input)
-    // need breathing room from it.
-    .field-tip--inline {
-      margin-left: 10px;
     }
     // Auto-translate toggle rendered beneath the summary textarea.
     .auto-translate-inline {

--- a/src/components/setting/SiteServices.vue
+++ b/src/components/setting/SiteServices.vue
@@ -70,13 +70,7 @@
       append-to-body
     >
       <el-form :model="form" label-position="top" class="service-override-form" @submit.prevent>
-        <el-form-item required>
-          <template #label>
-            <span class="field-head">
-              <span class="field-label">{{ $t('site.services.field.service') }}</span>
-              <span class="field-desc">{{ $t('site.services.placeholder.service') }}</span>
-            </span>
-          </template>
+        <el-form-item :label="$t('site.services.field.service')" required>
           <el-input v-if="editingRow" :model-value="catalogTitle(editingRow.service)" readonly />
           <el-select
             v-else
@@ -103,67 +97,33 @@
               </span>
             </el-option>
           </el-select>
+          <div class="field-desc">{{ $t('site.services.placeholder.service') }}</div>
         </el-form-item>
 
-        <el-form-item>
-          <template #label>
-            <span class="field-head">
-              <span class="field-label">{{ $t('site.services.field.visible') }}</span>
-              <span class="field-desc">{{ $t('site.services.tip.visible') }}</span>
-            </span>
-          </template>
+        <el-form-item :label="$t('site.services.field.visible')">
           <el-switch v-model="form.visible" />
+          <div class="field-desc">{{ $t('site.services.tip.visible') }}</div>
         </el-form-item>
 
-        <el-form-item>
-          <template #label>
-            <span class="field-head">
-              <span class="field-label">{{ $t('site.field.markupRatio') }}</span>
-              <span class="field-desc">{{ $t('site.services.tip.markup') }}</span>
-            </span>
-          </template>
+        <el-form-item :label="$t('site.field.markupRatio')">
           <div class="markup-row">
             <el-input-number
-              v-model="form.markupRatio"
+              v-model="markupPercent"
               :min="0"
-              :max="markupMax"
-              :step="0.05"
+              :max="markupPercentMax"
+              :step="1"
               :precision="2"
               :controls-position="'right'"
               :placeholder="$t('site.services.placeholder.markup')"
               class="markup-input"
             />
-            <span v-if="typeof form.markupRatio === 'number'" class="markup-percent">
-              {{ formatMarkup(form.markupRatio) }}
-            </span>
+            <span class="markup-percent">%</span>
           </div>
-          <div class="money-preview">
-            <span class="field-tip">{{ $t('site.services.preview.sampleLabel') }}</span>
-            <el-input-number
-              v-model="sampleBase"
-              :min="0"
-              :step="1"
-              :precision="2"
-              size="small"
-              :controls-position="'right'"
-              class="sample-input"
-            />
-            <span class="preview-result">
-              {{ $t('site.message.markupExample', { from: previewFrom, to: previewTo }) }}
-            </span>
-            <span v-if="typeof form.markupRatio !== 'number'" class="field-tip">
-              {{ $t('site.services.preview.inherit', { percent: formatMarkup(siteDefaultRatio) }) }}
-            </span>
-          </div>
+          <div class="field-desc">{{ $t('site.services.tip.markup') }}</div>
+          <div class="field-desc">{{ $t('site.message.markupExample') }}</div>
         </el-form-item>
 
-        <el-form-item>
-          <template #label>
-            <span class="field-head">
-              <span class="field-label">{{ $t('site.services.field.displayTitle') }}</span>
-              <span class="field-desc">{{ $t('site.services.placeholder.displayTitle') }}</span>
-            </span>
-          </template>
+        <el-form-item :label="$t('site.services.field.displayTitle')">
           <el-input v-model="form.displayTitle" maxlength="120" show-word-limit clearable>
             <template #suffix>
               <auto-translate-toggle
@@ -177,16 +137,12 @@
               />
             </template>
           </el-input>
+          <div class="field-desc">{{ $t('site.services.placeholder.displayTitle') }}</div>
         </el-form-item>
 
-        <el-form-item>
-          <template #label>
-            <span class="field-head">
-              <span class="field-label">{{ $t('site.services.field.displaySummary') }}</span>
-              <span class="field-desc">{{ $t('site.services.placeholder.displaySummary') }}</span>
-            </span>
-          </template>
+        <el-form-item :label="$t('site.services.field.displaySummary')">
           <el-input v-model="form.displaySummary" type="textarea" :rows="3" clearable />
+          <div class="field-desc">{{ $t('site.services.placeholder.displaySummary') }}</div>
           <!-- textarea has no #suffix slot; render the toggle inline beneath -->
           <div class="auto-translate-inline">
             <auto-translate-toggle
@@ -210,13 +166,7 @@
           </div>
         </el-form-item>
 
-        <el-form-item>
-          <template #label>
-            <span class="field-head">
-              <span class="field-label">{{ $t('site.services.field.sortOrder') }}</span>
-              <span class="field-desc">{{ $t('site.services.tip.sortOrder') }}</span>
-            </span>
-          </template>
+        <el-form-item :label="$t('site.services.field.sortOrder')">
           <el-input-number
             v-model="form.sortOrder"
             :min="-1000"
@@ -225,6 +175,7 @@
             :precision="0"
             :controls-position="'right'"
           />
+          <div class="field-desc">{{ $t('site.services.tip.sortOrder') }}</div>
         </el-form-item>
       </el-form>
       <template #footer>
@@ -269,13 +220,12 @@ import { serviceOperator, siteServiceOverrideOperator } from '@/operators';
 import type { IService, ISite, ISiteServiceOverride } from '@/models';
 import SectionNotice from '@/components/setting/SectionNotice.vue';
 import AutoTranslateToggle from '@/components/site/AutoTranslateToggle.vue';
-import { getPriceString, applyMarkup, getSiteMarkupRatio, MARKUP_RATIO_MAX } from '@/utils';
+import { getSiteMarkupRatio, MARKUP_RATIO_MAX } from '@/utils';
 
 // Pre-fetch the whole catalog once so each override row can show the
 // service title/alias without an N+1 per-row GET. If a tenant ever
 // exceeds this many services the picker should switch to remote search.
 const CATALOG_PAGE_LIMIT = 1000;
-
 interface IForm {
   service: string;
   visible: boolean;
@@ -343,7 +293,6 @@ export default defineComponent({
       dialogVisible: false,
       editingRow: null as ISiteServiceOverride | null,
       form: emptyForm(),
-      sampleBase: 10 as number,
       mobile: typeof window !== 'undefined' && window.innerWidth < 768
     };
   },
@@ -360,21 +309,20 @@ export default defineComponent({
     },
     // Never below the loaded value so el-input-number can't silently clamp a
     // pre-existing out-of-range override down on dialog open.
-    markupMax(): number {
+    markupPercentMax(): number {
       const cur = typeof this.form.markupRatio === 'number' ? this.form.markupRatio : 0;
-      return Math.max(MARKUP_RATIO_MAX, cur);
+      return Math.max(MARKUP_RATIO_MAX, cur) * 100;
+    },
+    markupPercent: {
+      get(): number | undefined {
+        return typeof this.form.markupRatio === 'number' ? Math.round(this.form.markupRatio * 10000) / 100 : undefined;
+      },
+      set(value: number | undefined) {
+        this.form.markupRatio = typeof value === 'number' ? value / 100 : undefined;
+      }
     },
     effectiveRatio(): number {
       return typeof this.form.markupRatio === 'number' ? this.form.markupRatio : this.siteDefaultRatio;
-    },
-    previewFrom(): string {
-      return getPriceString({ value: this.sampleBaseSafe });
-    },
-    previewTo(): string {
-      return getPriceString({ value: applyMarkup(this.sampleBaseSafe, this.effectiveRatio) });
-    },
-    sampleBaseSafe(): number {
-      return typeof this.sampleBase === 'number' && this.sampleBase >= 0 ? this.sampleBase : 0;
     },
     catalogOptions(): IService[] {
       // ``private`` is already excluded server-side (see onFetchCatalog); only
@@ -693,22 +641,14 @@ export default defineComponent({
   line-height: 1.3;
   white-space: normal;
   margin-bottom: 4px;
-}
-
-:global(.site-service-override-dialog .service-override-form .field-head) {
-  display: block;
-  line-height: 1.3;
-}
-
-:global(.site-service-override-dialog .service-override-form .field-label) {
-  display: block;
   font-weight: 600;
   color: var(--el-text-color-primary);
 }
 
 :global(.site-service-override-dialog .service-override-form .field-desc) {
   display: block;
-  margin-top: 2px;
+  width: 100%;
+  margin-top: 6px;
   font-size: 12px;
   font-weight: 400;
   line-height: 1.4;
@@ -723,7 +663,7 @@ export default defineComponent({
 }
 
 :global(.site-service-override-dialog .service-override-form .markup-input) {
-  width: 150px;
+  width: 180px;
 }
 
 :global(.site-service-override-dialog .service-override-form .markup-percent) {
@@ -732,19 +672,6 @@ export default defineComponent({
   font-weight: 600;
 }
 
-:global(.site-service-override-dialog .service-override-form .money-preview) {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 6px;
-}
-
-:global(.site-service-override-dialog .service-override-form .sample-input) {
-  width: 120px;
-}
-
-:global(.site-service-override-dialog .service-override-form .preview-result),
 :global(.site-service-override-dialog .service-override-form .field-tip) {
   font-size: 12px;
   color: var(--el-text-color-secondary);

--- a/src/components/setting/SiteServices.vue
+++ b/src/components/setting/SiteServices.vue
@@ -683,102 +683,115 @@ export default defineComponent({
 
 // The nested edit dialog is appended to body, so styles for its form must be
 // global rather than nested under `.site-services-settings`.
-:global(.site-service-override-dialog) {
-  .service-override-form {
-    .el-form-item__label {
-      height: auto;
-      line-height: 1.3;
-      white-space: normal;
-      margin-bottom: 4px;
-    }
-    .field-head {
-      display: block;
-      line-height: 1.3;
-    }
-    .field-label {
-      display: block;
-      font-weight: 600;
-      color: var(--el-text-color-primary);
-    }
-    .field-desc {
-      display: block;
-      margin-top: 2px;
-      font-size: 12px;
-      font-weight: 400;
-      line-height: 1.4;
-      white-space: normal;
-      color: var(--el-text-color-secondary);
-    }
-    .markup-row {
-      display: flex;
-      align-items: center;
-      gap: 10px;
-    }
-    .markup-input {
-      width: 150px;
-    }
-    .markup-percent {
-      font-variant-numeric: tabular-nums;
-      color: var(--el-color-primary);
-      font-weight: 600;
-    }
-    .money-preview {
-      display: flex;
-      align-items: center;
-      flex-wrap: wrap;
-      gap: 8px;
-      margin-top: 6px;
-    }
-    .sample-input {
-      width: 120px;
-    }
-    .preview-result,
-    .field-tip {
-      font-size: 12px;
-      color: var(--el-text-color-secondary);
-    }
-    .auto-translate-inline {
-      display: flex;
-      align-items: center;
-      gap: 6px;
-      margin-top: 6px;
-    }
-  }
+:global(.site-service-override-dialog.el-dialog),
+:global(.site-service-override-dialog .el-dialog) {
+  width: min(520px, calc(100vw - 32px)) !important;
 }
 
-:global(.service-catalog-select-popper) {
-  .el-select-dropdown__item {
-    height: auto;
-    min-height: 34px;
-    line-height: 1.4;
-  }
-  .service-option {
-    display: flex;
-    align-items: center;
-    min-width: 0;
-    width: 100%;
-  }
-  .option-favicon {
-    width: 18px;
-    height: 18px;
-    max-width: 18px;
-    max-height: 18px;
-    border-radius: 4px;
-    object-fit: contain;
-    flex-shrink: 0;
-    margin-right: 6px;
-  }
-  .option-title {
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-  .option-alias {
-    margin-left: 8px;
-    font-size: 12px;
-    color: var(--el-text-color-secondary);
-    flex-shrink: 0;
-  }
+:global(.site-service-override-dialog .service-override-form .el-form-item__label) {
+  height: auto;
+  line-height: 1.3;
+  white-space: normal;
+  margin-bottom: 4px;
+}
+
+:global(.site-service-override-dialog .service-override-form .field-head) {
+  display: block;
+  line-height: 1.3;
+}
+
+:global(.site-service-override-dialog .service-override-form .field-label) {
+  display: block;
+  font-weight: 600;
+  color: var(--el-text-color-primary);
+}
+
+:global(.site-service-override-dialog .service-override-form .field-desc) {
+  display: block;
+  margin-top: 2px;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 1.4;
+  white-space: normal;
+  color: var(--el-text-color-secondary);
+}
+
+:global(.site-service-override-dialog .service-override-form .markup-row) {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+:global(.site-service-override-dialog .service-override-form .markup-input) {
+  width: 150px;
+}
+
+:global(.site-service-override-dialog .service-override-form .markup-percent) {
+  font-variant-numeric: tabular-nums;
+  color: var(--el-color-primary);
+  font-weight: 600;
+}
+
+:global(.site-service-override-dialog .service-override-form .money-preview) {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 6px;
+}
+
+:global(.site-service-override-dialog .service-override-form .sample-input) {
+  width: 120px;
+}
+
+:global(.site-service-override-dialog .service-override-form .preview-result),
+:global(.site-service-override-dialog .service-override-form .field-tip) {
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+}
+
+:global(.site-service-override-dialog .service-override-form .auto-translate-inline) {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+:global(.service-catalog-select-popper .el-select-dropdown__item) {
+  height: auto;
+  min-height: 34px;
+  line-height: 1.4;
+}
+
+:global(.service-catalog-select-popper .service-option) {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  width: 100%;
+}
+
+:global(.service-catalog-select-popper .option-favicon) {
+  width: 18px;
+  height: 18px;
+  max-width: 18px;
+  max-height: 18px;
+  border-radius: 4px;
+  object-fit: contain;
+  flex-shrink: 0;
+  margin-right: 6px;
+}
+
+:global(.service-catalog-select-popper .option-title) {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+:global(.service-catalog-select-popper .option-alias) {
+  margin-left: 8px;
+  font-size: 12px;
+  color: var(--el-text-color-secondary);
+  flex-shrink: 0;
 }
 </style>

--- a/src/components/setting/SiteServices.vue
+++ b/src/components/setting/SiteServices.vue
@@ -355,10 +355,10 @@ export default defineComponent({
       return typeof this.sampleBase === 'number' && this.sampleBase >= 0 ? this.sampleBase : 0;
     },
     catalogOptions(): IService[] {
-      // Only offer services that are publicly listable (not catalog-private)
-      // and carry a favicon, so every homepage card renders with an icon.
+      // ``private`` is already excluded server-side (see onFetchCatalog); only
+      // the favicon requirement remains, so every homepage card has an icon.
       return this.catalog
-        .filter((s) => s.private !== true && !!s.icon_url)
+        .filter((s) => !!s.icon_url)
         .sort((a, b) => {
           const at = (a.title || a.id || '').toLowerCase();
           const bt = (b.title || b.id || '').toLowerCase();
@@ -441,7 +441,10 @@ export default defineComponent({
       if (this.catalog.length > 0) return;
       this.catalogLoading = true;
       try {
-        const { data } = await serviceOperator.getAll({ limit: CATALOG_PAGE_LIMIT });
+        // Filter out catalog-private services server-side (backend honours
+        // ``?private=false``) so we never ship internal services to the client.
+        // The favicon requirement has no server param, so it stays client-side.
+        const { data } = await serviceOperator.getAll({ limit: CATALOG_PAGE_LIMIT, private: false });
         this.catalog = data.items || [];
         this.catalogMap = Object.fromEntries(this.catalog.map((s) => [s.id as string, s]));
       } catch {

--- a/src/i18n/en/site.json
+++ b/src/i18n/en/site.json
@@ -48,8 +48,8 @@
     "description": "Help text for the markup ratio setting"
   },
   "message.markupExample": {
-    "message": "Example: official {from} → your price {to}",
-    "description": "Live example under the markup setting; {from} is the official price, {to} is the marked-up price"
+    "message": "For example, if the official price is $20 and you enter 10, your price is $22.",
+    "description": "Fixed example under the markup setting"
   },
   "field.distributionDefaultInviterId": {
     "message": "Default Inviter ID",
@@ -721,7 +721,7 @@
     "message": "Pick a service from the catalog"
   },
   "services.placeholder.markup": {
-    "message": "Leave blank to inherit the site default"
+    "message": "Blank inherits"
   },
   "services.placeholder.displayTitle": {
     "message": "Leave blank to use the catalog title"
@@ -733,7 +733,7 @@
     "message": "When off, the service is hidden on this site's homepage (users who already have it keep access)."
   },
   "services.tip.markup": {
-    "message": "0% = platform price; 0.5 = +50%; up to +500%. Leave blank to inherit the site default."
+    "message": "Enter a percentage markup: 10 means +10%, up to 500. Leave blank to inherit the site default."
   },
   "services.tip.sortOrder": {
     "message": "Lower numbers come first."

--- a/src/i18n/zh-CN/site.json
+++ b/src/i18n/zh-CN/site.json
@@ -48,8 +48,8 @@
     "description": "加价比例设置项的说明文字"
   },
   "message.markupExample": {
-    "message": "示例：官方价 {from} → 你的售价 {to}",
-    "description": "加价比例设置项下方的实时示例，{from} 是官方原价，{to} 是加价后的售价"
+    "message": "例如原价 ￥20，填写 10，则售价为 ￥22。",
+    "description": "加价比例设置项下方的固定示例"
   },
   "field.distributionDefaultInviterId": {
     "message": "默认邀请人 ID",
@@ -721,7 +721,7 @@
     "message": "从服务目录中选择一个服务"
   },
   "services.placeholder.markup": {
-    "message": "留空则继承本站默认加价"
+    "message": "留空则继承"
   },
   "services.placeholder.displayTitle": {
     "message": "留空则使用目录中的原名称"
@@ -733,7 +733,7 @@
     "message": "关闭后该服务在本站首页隐藏（已拥有的用户仍可访问）。"
   },
   "services.tip.markup": {
-    "message": "0% 按平台原价；0.5 即 +50%；上限 500%。留空则继承本站默认加价。"
+    "message": "填写百分制加价比例：10 表示加价 10%，上限 500；留空则继承本站默认加价。"
   },
   "services.tip.sortOrder": {
     "message": "数字越小越靠前。"

--- a/src/models/service.ts
+++ b/src/models/service.ts
@@ -39,6 +39,10 @@ export interface IService {
   tags?: string[];
   metadata?: any;
   thumbnail?: string;
+  // Square brand logo / favicon on cdn.acedata.cloud.
+  icon_url?: string;
+  // Catalog-private services are hidden from the public site picker.
+  private?: boolean;
   introduction?: string;
   proxies?: IProxy[];
   proxy_ids?: string[];


### PR DESCRIPTION
## What

Improvements to the 站长 **Services** settings tab (per-site service overrides) in the studio.

### 1. Service picker: only listable services with a favicon
The `Add service override` picker now lists only services where `private !== true` **and** `icon_url` (favicon) is set, so every homepage card renders with an icon and internal/private catalog services no longer leak into the picker. The favicon is shown next to each picker option and in the overrides table row.
> Note: the filter applies **only to the picker** — an existing override for a now-hidden service still renders in the table (its title/alias/icon resolve from the full catalog map).

### 2. Markup helper as fine print
The markup-ratio explanation (`0% = platform price; 0.5 = +50%; up to +500%…`), the sample base price and the `official $10.00 → your price …` example are restyled as small secondary text stacked **under** the input, instead of a bold sibling glued to its right.

### 3 + 4. Localizable Display name & Display summary
Both fields now carry the same **auto-translate toggle** used on the site's General settings and the developer portal (`AutoTranslateToggle`, `model=site_service_override`, fields `display_title` / `display_summary`). Turning it on stores the text as a `$t(key)` reference so the platform Translation cron fans it out to all 17 locales; off = literal storage. In **create** mode the toggle is disabled (no row id yet) with the standard "save first" tooltip — same UX as PlatformFrontend. After a successful toggle the table refetches so it shows the locale-resolved value, not a raw `$t(...)` ref.

### 5. Tip spacing
Added the missing left margin on the inline `Lower numbers come first.` (sort order) and `Visible` tips.

## Notes
- No backend change: the `site_service_override` translation capability already exists in PlatformBackend (`translation_capabilities.py`).
- No new i18n keys — reuses existing `site.autoTranslate.*` / `site.services.*` strings.
- `eslint` ✅ · `vue-tsc --noEmit` ✅ (no errors in changed files) · beachball change file added.

## 🤖 对抗评审
Independent read-only reviewer (general-purpose subagent) diffed against the PlatformFrontend reference implementation, models, translation types, live `services/` API and all 17 locales.
- Verified CLEAN: create-mode toggle is disabled and its handlers can't fire; `editingRow` mutations are reflected in the reactive rows; `catalogMap` built from the **unfiltered** catalog so hidden-service overrides still render; TS types for `IService.private?/icon_url?` and `IForm.autoTranslatedFields`; all i18n keys exist.
- **RISK (fixed):** after toggling, the table briefly showed a raw `$t(...)` ref until the next fetch → **addressed** by making the 4 handlers async and refetching.
- **RISK (intended):** the favicon filter makes ~5 public-but-iconless services unpickable — this is the explicit product requirement ("must have a favicon").
- **RISK (parity):** `el-input` `show-word-limit` + custom `#suffix` toggle can crowd the suffix — identical to the shipped PlatformFrontend implementation, verified acceptable at the 520px dialog width.
**VERDICT: CLEAN** (all substantive findings fixed or accepted).