### PR TITLE
feat(scheduled): 定时任务卡片加「立即触发」按钮

### DIFF
--- a/change/@acedatacloud-nexior-ba930cfd-ae58-40e7-9d56-0b36319823b9.json
+++ b/change/@acedatacloud-nexior-ba930cfd-ae58-40e7-9d56-0b36319823b9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add a Run now button to scheduled tasks to trigger a run immediately",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/i18n/ar/chat.json
+++ b/src/i18n/ar/chat.json
@@ -599,6 +599,18 @@
   "scheduledTasks.deleteConfirm": {
     "message": "Delete \"{name}\"? The task will stop running."
   },
+  "scheduledTasks.triggerNow": {
+    "message": "Run now",
+    "description": "Trigger the task immediately, out of schedule"
+  },
+  "scheduledTasks.triggerSuccess": {
+    "message": "Triggered. The result will appear in run history shortly.",
+    "description": "Manual trigger success"
+  },
+  "scheduledTasks.triggerError": {
+    "message": "Failed to trigger. Please try again later.",
+    "description": "Manual trigger error"
+  },
   "scheduledTasks.viewResult": {
     "message": "View Result"
   },

--- a/src/i18n/de/chat.json
+++ b/src/i18n/de/chat.json
@@ -599,6 +599,18 @@
   "scheduledTasks.deleteConfirm": {
     "message": "Delete \"{name}\"? The task will stop running."
   },
+  "scheduledTasks.triggerNow": {
+    "message": "Run now",
+    "description": "Trigger the task immediately, out of schedule"
+  },
+  "scheduledTasks.triggerSuccess": {
+    "message": "Triggered. The result will appear in run history shortly.",
+    "description": "Manual trigger success"
+  },
+  "scheduledTasks.triggerError": {
+    "message": "Failed to trigger. Please try again later.",
+    "description": "Manual trigger error"
+  },
   "scheduledTasks.viewResult": {
     "message": "View Result"
   },

--- a/src/i18n/el/chat.json
+++ b/src/i18n/el/chat.json
@@ -599,6 +599,18 @@
   "scheduledTasks.deleteConfirm": {
     "message": "Delete \"{name}\"? The task will stop running."
   },
+  "scheduledTasks.triggerNow": {
+    "message": "Run now",
+    "description": "Trigger the task immediately, out of schedule"
+  },
+  "scheduledTasks.triggerSuccess": {
+    "message": "Triggered. The result will appear in run history shortly.",
+    "description": "Manual trigger success"
+  },
+  "scheduledTasks.triggerError": {
+    "message": "Failed to trigger. Please try again later.",
+    "description": "Manual trigger error"
+  },
   "scheduledTasks.viewResult": {
     "message": "View Result"
   },

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -599,6 +599,18 @@
   "scheduledTasks.deleteConfirm": {
     "message": "Delete \"{name}\"? The task will stop running."
   },
+  "scheduledTasks.triggerNow": {
+    "message": "Run now",
+    "description": "Trigger the task immediately, out of schedule"
+  },
+  "scheduledTasks.triggerSuccess": {
+    "message": "Triggered. The result will appear in run history shortly.",
+    "description": "Manual trigger success"
+  },
+  "scheduledTasks.triggerError": {
+    "message": "Failed to trigger. Please try again later.",
+    "description": "Manual trigger error"
+  },
   "scheduledTasks.viewResult": {
     "message": "View Result"
   },

--- a/src/i18n/es/chat.json
+++ b/src/i18n/es/chat.json
@@ -599,6 +599,18 @@
   "scheduledTasks.deleteConfirm": {
     "message": "Delete \"{name}\"? The task will stop running."
   },
+  "scheduledTasks.triggerNow": {
+    "message": "Run now",
+    "description": "Trigger the task immediately, out of schedule"
+  },
+  "scheduledTasks.triggerSuccess": {
+    "message": "Triggered. The result will appear in run history shortly.",
+    "description": "Manual trigger success"
+  },
+  "scheduledTasks.triggerError": {
+    "message": "Failed to trigger. Please try again later.",
+    "description": "Manual trigger error"
+  },
   "scheduledTasks.viewResult": {
     "message": "View Result"
   },

--- a/src/i18n/fi/chat.json
+++ b/src/i18n/fi/chat.json
@@ -599,6 +599,18 @@
   "scheduledTasks.deleteConfirm": {
     "message": "Delete \"{name}\"? The task will stop running."
   },
+  "scheduledTasks.triggerNow": {
+    "message": "Run now",
+    "description": "Trigger the task immediately, out of schedule"
+  },
+  "scheduledTasks.triggerSuccess": {
+    "message": "Triggered. The result will appear in run history shortly.",
+    "description": "Manual trigger success"
+  },
+  "scheduledTasks.triggerError": {
+    "message": "Failed to trigger. Please try again later.",
+    "description": "Manual trigger error"
+  },
   "scheduledTasks.viewResult": {
     "message": "View Result"
   },

--- a/src/i18n/fr/chat.json
+++ b/src/i18n/fr/chat.json
@@ -599,6 +599,18 @@
   "scheduledTasks.deleteConfirm": {
     "message": "Delete \"{name}\"? The task will stop running."
   },
+  "scheduledTasks.triggerNow": {
+    "message": "Run now",
+    "description": "Trigger the task immediately, out of schedule"
+  },
+  "scheduledTasks.triggerSuccess": {
+    "message": "Triggered. The result will appear in run history shortly.",
+    "description": "Manual trigger success"
+  },
+  "scheduledTasks.triggerError": {
+    "message": "Failed to trigger. Please try again later.",
+    "description": "Manual trigger error"
+  },
   "scheduledTasks.viewResult": {
     "message": "View Result"
   },

--- a/src/i18n/it/chat.json
+++ b/src/i18n/it/chat.json
@@ -599,6 +599,18 @@
   "scheduledTasks.deleteConfirm": {
     "message": "Delete \"{name}\"? The task will stop running."
   },
+  "scheduledTasks.triggerNow": {
+    "message": "Run now",
+    "description": "Trigger the task immediately, out of schedule"
+  },
+  "scheduledTasks.triggerSuccess": {
+    "message": "Triggered. The result will appear in run history shortly.",
+    "description": "Manual trigger success"
+  },
+  "scheduledTasks.triggerError": {
+    "message": "Failed to trigger. Please try again later.",
+    "description": "Manual trigger error"
+  },
   "scheduledTasks.viewResult": {
     "message": "View Result"
   },

--- a/src/i18n/ja/chat.json
+++ b/src/i18n/ja/chat.json
@@ -599,6 +599,18 @@
   "scheduledTasks.deleteConfirm": {
     "message": "Delete \"{name}\"? The task will stop running."
   },
+  "scheduledTasks.triggerNow": {
+    "message": "Run now",
+    "description": "Trigger the task immediately, out of schedule"
+  },
+  "scheduledTasks.triggerSuccess": {
+    "message": "Triggered. The result will appear in run history shortly.",
+    "description": "Manual trigger success"
+  },
+  "scheduledTasks.triggerError": {
+    "message": "Failed to trigger. Please try again later.",
+    "description": "Manual trigger error"
+  },
   "scheduledTasks.viewResult": {
     "message": "View Result"
   },

--- a/src/i18n/ko/chat.json
+++ b/src/i18n/ko/chat.json
@@ -599,6 +599,18 @@
   "scheduledTasks.deleteConfirm": {
     "message": "Delete \"{name}\"? The task will stop running."
   },
+  "scheduledTasks.triggerNow": {
+    "message": "Run now",
+    "description": "Trigger the task immediately, out of schedule"
+  },
+  "scheduledTasks.triggerSuccess": {
+    "message": "Triggered. The result will appear in run history shortly.",
+    "description": "Manual trigger success"
+  },
+  "scheduledTasks.triggerError": {
+    "message": "Failed to trigger. Please try again later.",
+    "description": "Manual trigger error"
+  },
   "scheduledTasks.viewResult": {
     "message": "View Result"
   },

--- a/src/i18n/pl/chat.json
+++ b/src/i18n/pl/chat.json
@@ -599,6 +599,18 @@
   "scheduledTasks.deleteConfirm": {
     "message": "Delete \"{name}\"? The task will stop running."
   },
+  "scheduledTasks.triggerNow": {
+    "message": "Run now",
+    "description": "Trigger the task immediately, out of schedule"
+  },
+  "scheduledTasks.triggerSuccess": {
+    "message": "Triggered. The result will appear in run history shortly.",
+    "description": "Manual trigger success"
+  },
+  "scheduledTasks.triggerError": {
+    "message": "Failed to trigger. Please try again later.",
+    "description": "Manual trigger error"
+  },
   "scheduledTasks.viewResult": {
     "message": "View Result"
   },

--- a/src/i18n/pt/chat.json
+++ b/src/i18n/pt/chat.json
@@ -599,6 +599,18 @@
   "scheduledTasks.deleteConfirm": {
     "message": "Delete \"{name}\"? The task will stop running."
   },
+  "scheduledTasks.triggerNow": {
+    "message": "Run now",
+    "description": "Trigger the task immediately, out of schedule"
+  },
+  "scheduledTasks.triggerSuccess": {
+    "message": "Triggered. The result will appear in run history shortly.",
+    "description": "Manual trigger success"
+  },
+  "scheduledTasks.triggerError": {
+    "message": "Failed to trigger. Please try again later.",
+    "description": "Manual trigger error"
+  },
   "scheduledTasks.viewResult": {
     "message": "View Result"
   },

--- a/src/i18n/ru/chat.json
+++ b/src/i18n/ru/chat.json
@@ -599,6 +599,18 @@
   "scheduledTasks.deleteConfirm": {
     "message": "Delete \"{name}\"? The task will stop running."
   },
+  "scheduledTasks.triggerNow": {
+    "message": "Run now",
+    "description": "Trigger the task immediately, out of schedule"
+  },
+  "scheduledTasks.triggerSuccess": {
+    "message": "Triggered. The result will appear in run history shortly.",
+    "description": "Manual trigger success"
+  },
+  "scheduledTasks.triggerError": {
+    "message": "Failed to trigger. Please try again later.",
+    "description": "Manual trigger error"
+  },
   "scheduledTasks.viewResult": {
     "message": "View Result"
   },

--- a/src/i18n/sr/chat.json
+++ b/src/i18n/sr/chat.json
@@ -599,6 +599,18 @@
   "scheduledTasks.deleteConfirm": {
     "message": "Delete \"{name}\"? The task will stop running."
   },
+  "scheduledTasks.triggerNow": {
+    "message": "Run now",
+    "description": "Trigger the task immediately, out of schedule"
+  },
+  "scheduledTasks.triggerSuccess": {
+    "message": "Triggered. The result will appear in run history shortly.",
+    "description": "Manual trigger success"
+  },
+  "scheduledTasks.triggerError": {
+    "message": "Failed to trigger. Please try again later.",
+    "description": "Manual trigger error"
+  },
   "scheduledTasks.viewResult": {
     "message": "View Result"
   },

--- a/src/i18n/sv/chat.json
+++ b/src/i18n/sv/chat.json
@@ -599,6 +599,18 @@
   "scheduledTasks.deleteConfirm": {
     "message": "Delete \"{name}\"? The task will stop running."
   },
+  "scheduledTasks.triggerNow": {
+    "message": "Run now",
+    "description": "Trigger the task immediately, out of schedule"
+  },
+  "scheduledTasks.triggerSuccess": {
+    "message": "Triggered. The result will appear in run history shortly.",
+    "description": "Manual trigger success"
+  },
+  "scheduledTasks.triggerError": {
+    "message": "Failed to trigger. Please try again later.",
+    "description": "Manual trigger error"
+  },
   "scheduledTasks.viewResult": {
     "message": "View Result"
   },

--- a/src/i18n/uk/chat.json
+++ b/src/i18n/uk/chat.json
@@ -599,6 +599,18 @@
   "scheduledTasks.deleteConfirm": {
     "message": "Delete \"{name}\"? The task will stop running."
   },
+  "scheduledTasks.triggerNow": {
+    "message": "Run now",
+    "description": "Trigger the task immediately, out of schedule"
+  },
+  "scheduledTasks.triggerSuccess": {
+    "message": "Triggered. The result will appear in run history shortly.",
+    "description": "Manual trigger success"
+  },
+  "scheduledTasks.triggerError": {
+    "message": "Failed to trigger. Please try again later.",
+    "description": "Manual trigger error"
+  },
   "scheduledTasks.viewResult": {
     "message": "View Result"
   },

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -607,6 +607,18 @@
     "message": "确认删除「{name}」？删除后任务将停止运行。",
     "description": "删除确认"
   },
+  "scheduledTasks.triggerNow": {
+    "message": "立即触发",
+    "description": "手动立刻运行一次任务"
+  },
+  "scheduledTasks.triggerSuccess": {
+    "message": "已触发，稍后可在运行记录中查看结果。",
+    "description": "手动触发成功提示"
+  },
+  "scheduledTasks.triggerError": {
+    "message": "触发失败，请稍后重试。",
+    "description": "手动触发失败提示"
+  },
   "scheduledTasks.viewResult": {
     "message": "查看结果",
     "description": "跳转到对话"

--- a/src/i18n/zh-TW/chat.json
+++ b/src/i18n/zh-TW/chat.json
@@ -599,6 +599,18 @@
   "scheduledTasks.deleteConfirm": {
     "message": "Delete \"{name}\"? The task will stop running."
   },
+  "scheduledTasks.triggerNow": {
+    "message": "立即觸發",
+    "description": "手動立刻執行一次任務"
+  },
+  "scheduledTasks.triggerSuccess": {
+    "message": "已觸發，稍後可在執行記錄中查看結果。",
+    "description": "手動觸發成功提示"
+  },
+  "scheduledTasks.triggerError": {
+    "message": "觸發失敗，請稍後重試。",
+    "description": "手動觸發失敗提示"
+  },
   "scheduledTasks.viewResult": {
     "message": "View Result"
   },

--- a/src/operators/scheduledTasks.ts
+++ b/src/operators/scheduledTasks.ts
@@ -148,6 +148,13 @@ class ScheduledTasksOperator {
     await axios.post(BASE, { action: 'delete', id }, { headers: headers(token) });
   }
 
+  // Fire a task immediately, out of band from its schedule. Returns the id of
+  // the freshly-spawned run so the caller can refresh the run history.
+  async triggerTask(token: string, id: string): Promise<{ run_id?: string }> {
+    const { data } = await axios.post(BASE, { action: 'trigger', id }, { headers: headers(token) });
+    return data ?? {};
+  }
+
   async listRuns(token: string, id: string): Promise<IScheduledRun[]> {
     const { data } = await axios.post(BASE, { action: 'retrieve_runs', id }, { headers: headers(token) });
     return data?.items ?? [];

--- a/src/pages/chat/ScheduledTasks.vue
+++ b/src/pages/chat/ScheduledTasks.vue
@@ -888,7 +888,7 @@ export default defineComponent({
 }
 .task-actions {
   display: flex;
-  gap: 4px;
+  gap: 0;
   align-items: center;
   flex-shrink: 0;
 }
@@ -898,7 +898,7 @@ export default defineComponent({
   margin-left: 0;
 }
 .icon-action {
-  padding: 6px 8px;
+  padding: 6px 5px;
 }
 .task-meta {
   display: flex;

--- a/src/pages/chat/ScheduledTasks.vue
+++ b/src/pages/chat/ScheduledTasks.vue
@@ -23,21 +23,21 @@
                   :model-value="task.state === 'enabled'"
                   @change="(v: string | number | boolean) => toggleState(task, v === true)"
                 />
-                <el-button
-                  text
-                  class="icon-action"
-                  :loading="triggeringId === task.id"
-                  :title="$t('chat.scheduledTasks.triggerNow')"
-                  @click="triggerNow(task)"
-                >
-                  <font-awesome-icon v-if="triggeringId !== task.id" icon="fa-solid fa-play" />
-                </el-button>
-                <el-button text class="icon-action" @click="openEdit(task)">
-                  <font-awesome-icon icon="fa-solid fa-pen" />
-                </el-button>
-                <el-button text type="danger" class="icon-action" @click="confirmDelete(task)">
-                  <font-awesome-icon icon="fa-solid fa-trash" />
-                </el-button>
+                <el-tooltip :content="$t('chat.scheduledTasks.triggerNow')" placement="top">
+                  <el-button text class="icon-action" :loading="triggeringId === task.id" @click="triggerNow(task)">
+                    <font-awesome-icon v-if="triggeringId !== task.id" icon="fa-solid fa-play" />
+                  </el-button>
+                </el-tooltip>
+                <el-tooltip :content="$t('common.button.edit')" placement="top">
+                  <el-button text class="icon-action" @click="openEdit(task)">
+                    <font-awesome-icon icon="fa-solid fa-pen" />
+                  </el-button>
+                </el-tooltip>
+                <el-tooltip :content="$t('common.button.delete')" placement="top">
+                  <el-button text type="danger" class="icon-action" @click="confirmDelete(task)">
+                    <font-awesome-icon icon="fa-solid fa-trash" />
+                  </el-button>
+                </el-tooltip>
               </div>
             </div>
             <div class="task-meta">
@@ -294,6 +294,7 @@ import {
   ElEmpty,
   ElSwitch,
   ElTag,
+  ElTooltip,
   ElDrawer,
   ElDialog,
   ElForm,
@@ -356,6 +357,7 @@ export default defineComponent({
     ElEmpty,
     ElSwitch,
     ElTag,
+    ElTooltip,
     ElDrawer,
     ElDialog,
     ElForm,
@@ -879,16 +881,21 @@ export default defineComponent({
 }
 .task-name {
   font-weight: 600;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 1.4;
   color: var(--el-text-color-primary);
   word-break: break-word;
 }
 .task-actions {
   display: flex;
-  gap: 2px;
+  gap: 4px;
   align-items: center;
   flex-shrink: 0;
+}
+/* Element Plus adds a 12px left margin between adjacent buttons; drop it so the
+   row is driven purely by the flex gap above. */
+.task-actions .el-button + .el-button {
+  margin-left: 0;
 }
 .icon-action {
   padding: 6px 8px;

--- a/src/pages/chat/ScheduledTasks.vue
+++ b/src/pages/chat/ScheduledTasks.vue
@@ -23,6 +23,15 @@
                   :model-value="task.state === 'enabled'"
                   @change="(v: string | number | boolean) => toggleState(task, v === true)"
                 />
+                <el-button
+                  text
+                  class="icon-action"
+                  :loading="triggeringId === task.id"
+                  :title="$t('chat.scheduledTasks.triggerNow')"
+                  @click="triggerNow(task)"
+                >
+                  <font-awesome-icon v-if="triggeringId !== task.id" icon="fa-solid fa-play" />
+                </el-button>
                 <el-button text class="icon-action" @click="openEdit(task)">
                   <font-awesome-icon icon="fa-solid fa-pen" />
                 </el-button>
@@ -375,6 +384,7 @@ export default defineComponent({
       editingTask: null as IScheduledTask | null,
       authorizableSkills: [] as IAuthorizableSkill[],
       authorizableMcpServers: [] as IAuthorizableMcpServer[],
+      triggeringId: '' as string,
       weekdays: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
       page: 1,
       pageSize: 6,
@@ -720,6 +730,24 @@ export default defineComponent({
       } catch {
         if (idx !== -1) this.tasks[idx] = { ...task, state: task.state };
         ElMessage.error(this.$t('chat.scheduledTasks.loadError') as string);
+      }
+    },
+    async triggerNow(task: IScheduledTask) {
+      if (this.triggeringId) return;
+      this.triggeringId = task.id;
+      try {
+        await scheduledTasksOperator.triggerTask(this.token!, task.id);
+        ElMessage.success(this.$t('chat.scheduledTasks.triggerSuccess') as string);
+        // If the run-history drawer is open on this task, refresh it so the
+        // freshly-queued run shows up right away.
+        if (this.showRunHistory && this.selectedTask?.id === task.id) {
+          this.runs = await scheduledTasksOperator.listRuns(this.token!, task.id);
+          this.runPage = 1;
+        }
+      } catch {
+        ElMessage.error(this.$t('chat.scheduledTasks.triggerError') as string);
+      } finally {
+        this.triggeringId = '';
       }
     },
     async confirmDelete(task: IScheduledTask) {


### PR DESCRIPTION
## What

`/chatgpt/scheduled`(以及其它模型分组的 `scheduled` 页)每个定时任务卡片上,新增一个 ▶️「立即触发 / Run now」按钮,让用户不必等排期就能手动跑一次。

- 按钮位于开关和编辑/删除之间,点击调用后端新增的 `trigger` action(`scheduledTasksOperator.triggerTask`)。
- `triggeringId` 做 loading + 防重复点击;成功/失败各弹一条 `ElMessage`。
- 若当前正打开该任务的「运行记录」抽屉,触发后自动刷新,让新排队的 run 立刻出现。
- 图标 `fa-solid fa-play`(已在 `plugins/font-awesome.ts` 注册)。

## i18n

新增 `scheduledTasks.triggerNow / triggerSuccess / triggerError` 三个键,覆盖全部 **17 个 locale**(zh-CN/zh-TW 中文,其余英文)。`scripts/check_i18n_coverage.py` → **OK, 17 locale × 44 namespace all match zh-CN**。

## Test

- `eslint src/pages/chat/ScheduledTasks.vue src/operators/scheduledTasks.ts` → 干净。
- `vue-tsc -b` → 无类型错误。
- `check_i18n_coverage.py` → 通过。
- beachball change 文件已生成。

后端配套 PR:https://github.com/AceDataCloud/PlatformService/pull/1431

## 🤖 对抗评审

Reviewer: general-purpose subagent(Codex 额度到顶)。RISK 全部落在后端(手动运行改写生命周期状态导致与 scheduler 失配),已在后端 PR 修复。前端侧核验:`triggeringId` 在 `data()` 中(响应式),`:loading` 防重点,i18n 键全 locale 齐备,`fa-play` 已注册。**VERDICT: CLEAN**。