### PR TITLE
fix(scheduled): use --el-bg-color-page for the page background

### DIFF
--- a/change/@acedatacloud-nexior-scheduled-page-bg.json
+++ b/change/@acedatacloud-nexior-scheduled-page-bg.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Scheduled tasks: use --el-bg-color-page for the page background; keep default white cards",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/pages/chat/ScheduledTasks.vue
+++ b/src/pages/chat/ScheduledTasks.vue
@@ -796,7 +796,7 @@ export default defineComponent({
 .scheduled-tasks {
   height: 100%;
   overflow-y: auto;
-  background: var(--app-bg-section);
+  background: var(--el-bg-color-page);
 }
 .inner {
   max-width: 880px;
@@ -829,9 +829,6 @@ export default defineComponent({
 .task-card {
   border-radius: 16px;
   border: none;
-  // White cards on the grey page; keep el-card's own bg variable in sync.
-  --el-card-bg-color: var(--app-bg-surface);
-  background: var(--app-bg-surface, var(--el-bg-color-overlay));
   cursor: pointer;
   :deep(.el-card__body) {
     padding: 16px 18px;


### PR DESCRIPTION
## What

Follow-up to #1238 on the **Scheduled Tasks** page:

- `.scheduled-tasks` background now uses **`--el-bg-color-page`** (Element Plus page colour).
- `.task-card` drops the extra `--el-card-bg-color` / `background` overrides — cards keep el-card's **default white**.

Net result: white cards on the page-colour background. Border already removed, no hover movement.

## Scope

Single-file SCSS change in `src/pages/chat/ScheduledTasks.vue`.

## 🤖 对抗评审

Pure CSS token change, no behavior/logic change. **VERDICT: CLEAN**