### PR TITLE
fix(scheduled): force page background-color with !important

### DIFF
--- a/change/@acedatacloud-nexior-scheduled-bg-important.json
+++ b/change/@acedatacloud-nexior-scheduled-bg-important.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Scheduled tasks: force page background with background-color !important",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/pages/chat/ScheduledTasks.vue
+++ b/src/pages/chat/ScheduledTasks.vue
@@ -826,7 +826,7 @@ export default defineComponent({
 .scheduled-tasks {
   height: 100%;
   overflow-y: auto;
-  background: var(--el-bg-color-page);
+  background-color: var(--el-bg-color-page) !important;
 }
 .inner {
   max-width: 880px;


### PR DESCRIPTION
## What

On the **Scheduled Tasks** page, change `.scheduled-tasks` to:

```scss
background-color: var(--el-bg-color-page) !important;
```

so the page-colour background reliably wins over any inherited/overlay background.

## Scope

Single-line SCSS change in `src/pages/chat/ScheduledTasks.vue`.

## 🤖 对抗评审

Pure CSS change. **VERDICT: CLEAN**