### PR TITLE
Add default-off Maestro customization controls

### DIFF
--- a/change/@acedatacloud-nexior-maestro-customize-toggle.json
+++ b/change/@acedatacloud-nexior-maestro-customize-toggle.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Maestro: hide optional creative controls behind a default-off customization toggle",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/maestro/ConfigPanel.vue
+++ b/src/components/maestro/ConfigPanel.vue
@@ -105,83 +105,103 @@
         </el-select>
       </div>
 
-      <!-- Scenario (video type) -->
-      <div class="field-block mb-5">
-        <div class="field-head mb-2">
-          <h2 class="field-title font-bold">{{ $t('maestro.name.scenario') }}</h2>
-          <info-icon :content="$t('maestro.description.scenario')" class="ml-1" />
-        </div>
-        <div class="scenario-cards" role="radiogroup" :aria-label="$t('maestro.name.scenario')">
-          <div
-            v-for="s in MAESTRO_ALLOWED_SCENARIOS"
-            :key="s"
-            class="scenario-card"
-            :class="{ active: scenario === s }"
-            role="radio"
-            :aria-checked="scenario === s"
-            :aria-label="$t(`maestro.option.scenario.${s}`)"
-            tabindex="0"
-            @click="scenario = s"
-            @keydown.enter.prevent="scenario = s"
-            @keydown.space.prevent="scenario = s"
-          >
-            <div class="scenario-thumb">
-              <img :src="MAESTRO_SCENARIO_THUMBNAILS[s]" :alt="$t(`maestro.option.scenario.${s}`)" loading="lazy" />
-            </div>
-            <p class="scenario-name">{{ $t(`maestro.option.scenario.${s}`) }}</p>
+      <!-- Optional creative controls -->
+      <div class="customize-section">
+        <div class="customize-header">
+          <div class="customize-copy">
+            <h2 class="field-title font-bold">{{ $t('maestro.name.customize') }}</h2>
+            <p class="customize-description">
+              {{ $t(customize ? 'maestro.description.customize.manual' : 'maestro.description.customize.auto') }}
+            </p>
           </div>
+          <el-switch v-model="customize" :aria-label="$t('maestro.name.customize')" />
         </div>
-        <el-alert
-          v-if="needsVideoUpload"
-          :title="$t('maestro.message.captionsNeedVideo')"
-          type="warning"
-          :closable="false"
-          show-icon
-          class="mt-2"
-        />
-      </div>
 
-      <!-- Style (visual direction) -->
-      <div class="field-row">
-        <div class="field-head">
-          <h2 class="field-title font-bold">{{ $t('maestro.name.style') }}</h2>
-          <info-icon :content="$t('maestro.description.style')" class="ml-1" />
-        </div>
-        <el-select
-          v-model="style"
-          class="field-control"
-          filterable
-          allow-create
-          default-first-option
-          :placeholder="$t('maestro.placeholder.select')"
-        >
-          <el-option v-for="s in MAESTRO_ALLOWED_STYLES" :key="s" :label="$t(`maestro.option.style.${s}`)" :value="s" />
-        </el-select>
-      </div>
-
-      <!-- Voice (narration timbre) + preview -->
-      <div class="field-block mt-5">
-        <div class="field-head mb-2">
-          <h2 class="field-title font-bold">{{ $t('maestro.name.voice') }}</h2>
-          <info-icon :content="$t('maestro.description.voice')" class="ml-1" />
-        </div>
-        <div class="voice-row">
-          <el-select v-model="voice" class="voice-select" :placeholder="$t('maestro.placeholder.select')">
-            <el-option
-              v-for="v in MAESTRO_ALLOWED_VOICES"
-              :key="v.key"
-              :label="$t(`maestro.option.voice.${v.key}`)"
-              :value="v.key"
+        <div v-if="customize" class="customize-fields">
+          <!-- Scenario (video type) -->
+          <div class="field-block">
+            <div class="field-head mb-2">
+              <h2 class="field-title font-bold">{{ $t('maestro.name.scenario') }}</h2>
+              <info-icon :content="$t('maestro.description.scenario')" class="ml-1" />
+            </div>
+            <div class="scenario-cards" role="radiogroup" :aria-label="$t('maestro.name.scenario')">
+              <div
+                v-for="s in MAESTRO_ALLOWED_SCENARIOS"
+                :key="s"
+                class="scenario-card"
+                :class="{ active: scenario === s }"
+                role="radio"
+                :aria-checked="scenario === s"
+                :aria-label="$t(`maestro.option.scenario.${s}`)"
+                tabindex="0"
+                @click="scenario = s"
+                @keydown.enter.prevent="scenario = s"
+                @keydown.space.prevent="scenario = s"
+              >
+                <div class="scenario-thumb">
+                  <img :src="MAESTRO_SCENARIO_THUMBNAILS[s]" :alt="$t(`maestro.option.scenario.${s}`)" loading="lazy" />
+                </div>
+                <p class="scenario-name">{{ $t(`maestro.option.scenario.${s}`) }}</p>
+              </div>
+            </div>
+            <el-alert
+              v-if="needsVideoUpload"
+              :title="$t('maestro.message.captionsNeedVideo')"
+              type="warning"
+              :closable="false"
+              show-icon
+              class="mt-2"
             />
-          </el-select>
-          <el-button
-            class="voice-play"
-            :disabled="!currentSample"
-            :title="$t('maestro.button.preview')"
-            @click="onToggleSample"
-          >
-            <font-awesome-icon :icon="playing ? 'fa-solid fa-pause' : 'fa-solid fa-play'" />
-          </el-button>
+          </div>
+
+          <!-- Style (visual direction) -->
+          <div class="field-row mt-5">
+            <div class="field-head">
+              <h2 class="field-title font-bold">{{ $t('maestro.name.style') }}</h2>
+              <info-icon :content="$t('maestro.description.style')" class="ml-1" />
+            </div>
+            <el-select
+              v-model="style"
+              class="field-control"
+              filterable
+              allow-create
+              default-first-option
+              :placeholder="$t('maestro.placeholder.select')"
+            >
+              <el-option
+                v-for="s in MAESTRO_ALLOWED_STYLES"
+                :key="s"
+                :label="$t(`maestro.option.style.${s}`)"
+                :value="s"
+              />
+            </el-select>
+          </div>
+
+          <!-- Voice (narration timbre) + preview -->
+          <div class="field-block mt-5">
+            <div class="field-head mb-2">
+              <h2 class="field-title font-bold">{{ $t('maestro.name.voice') }}</h2>
+              <info-icon :content="$t('maestro.description.voice')" class="ml-1" />
+            </div>
+            <div class="voice-row">
+              <el-select v-model="voice" class="voice-select" :placeholder="$t('maestro.placeholder.select')">
+                <el-option
+                  v-for="v in MAESTRO_ALLOWED_VOICES"
+                  :key="v.key"
+                  :label="$t(`maestro.option.voice.${v.key}`)"
+                  :value="v.key"
+                />
+              </el-select>
+              <el-button
+                class="voice-play"
+                :disabled="!currentSample"
+                :title="$t('maestro.button.preview')"
+                @click="onToggleSample"
+              >
+                <font-awesome-icon :icon="playing ? 'fa-solid fa-pause' : 'fa-solid fa-play'" />
+              </el-button>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -197,7 +217,7 @@
 
 <script lang="ts">
 import { defineComponent, markRaw } from 'vue';
-import { ElButton, ElSelect, ElOption, ElInputNumber, ElAlert } from 'element-plus';
+import { ElButton, ElSelect, ElOption, ElInputNumber, ElAlert, ElSwitch } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import InfoIcon from '@/components/common/InfoIcon.vue';
 import PromptTextarea from '@/components/common/PromptTextarea.vue';
@@ -240,6 +260,7 @@ export default defineComponent({
     ElOption,
     ElInputNumber,
     ElAlert,
+    ElSwitch,
     InfoIcon,
     PromptTextarea,
     FileUrlsInput,
@@ -281,6 +302,7 @@ export default defineComponent({
       return this.config?.ref_task_id;
     },
     needsVideoUpload(): boolean {
+      if (!this.customize) return false;
       const scenario = this.config?.scenario;
       if (!scenario || !MAESTRO_UPLOAD_REQUIRED_SCENARIOS.includes(scenario)) return false;
       // captions post-processes a talking-head clip, so a video (not an image/audio) must be uploaded.
@@ -333,6 +355,15 @@ export default defineComponent({
         this.update({ quality: val });
       }
     },
+    customize: {
+      get(): boolean {
+        return this.config?.customization_enabled ?? false;
+      },
+      set(val: boolean) {
+        if (!val) this.stopSample();
+        this.update({ customization_enabled: val });
+      }
+    },
     scenario: {
       get(): string | undefined {
         return this.config?.scenario;
@@ -362,6 +393,11 @@ export default defineComponent({
       return MAESTRO_ALLOWED_VOICES.find((v) => v.key === this.voice)?.sample;
     }
   },
+  watch: {
+    customize(enabled: boolean) {
+      if (!enabled) this.stopSample();
+    }
+  },
   mounted() {
     this.update({
       action: this.config?.action ?? MAESTRO_DEFAULT_ACTION,
@@ -369,6 +405,7 @@ export default defineComponent({
       aspect: this.config?.aspect ?? MAESTRO_DEFAULT_ASPECT,
       duration: this.config?.duration ?? MAESTRO_DEFAULT_DURATION,
       quality: this.config?.quality ?? MAESTRO_DEFAULT_QUALITY,
+      customization_enabled: this.config?.customization_enabled ?? false,
       // Drop stale persisted scenarios (e.g. the removed `slideshow`) back to the default.
       scenario:
         this.config?.scenario && MAESTRO_ALLOWED_SCENARIOS.includes(this.config.scenario)
@@ -455,6 +492,31 @@ export default defineComponent({
 }
 .field-control {
   width: 168px;
+}
+.customize-section {
+  margin-top: 20px;
+  padding-top: 16px;
+  border-top: 1px solid var(--el-border-color-lighter);
+}
+.customize-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+.customize-copy {
+  min-width: 0;
+}
+.customize-description {
+  margin: 3px 0 0;
+  color: var(--el-text-color-secondary);
+  font-size: 12px;
+  line-height: 1.4;
+}
+.customize-fields {
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid var(--el-border-color-lighter);
 }
 .voice-row {
   display: flex;

--- a/src/i18n/ar/maestro.json
+++ b/src/i18n/ar/maestro.json
@@ -450,5 +450,17 @@
   "option.scenario.changelog": {
     "message": "سجل التغييرات (PR)",
     "description": "Changelog scenario option"
+  },
+  "name.customize": {
+    "message": "Customize",
+    "description": "Optional creative controls toggle"
+  },
+  "description.customize.auto": {
+    "message": "Auto · Maestro decides the video type, visual style, and voice.",
+    "description": "Customization disabled state"
+  },
+  "description.customize.manual": {
+    "message": "Choose the video type, visual style, and voice.",
+    "description": "Customization enabled state"
   }
 }

--- a/src/i18n/de/maestro.json
+++ b/src/i18n/de/maestro.json
@@ -450,5 +450,17 @@
   "option.scenario.changelog": {
     "message": "Änderungsprotokoll (PR)",
     "description": "Changelog scenario option"
+  },
+  "name.customize": {
+    "message": "Customize",
+    "description": "Optional creative controls toggle"
+  },
+  "description.customize.auto": {
+    "message": "Auto · Maestro decides the video type, visual style, and voice.",
+    "description": "Customization disabled state"
+  },
+  "description.customize.manual": {
+    "message": "Choose the video type, visual style, and voice.",
+    "description": "Customization enabled state"
   }
 }

--- a/src/i18n/el/maestro.json
+++ b/src/i18n/el/maestro.json
@@ -450,5 +450,17 @@
   "option.scenario.changelog": {
     "message": "Αρχείο αλλαγών (PR)",
     "description": "Changelog scenario option"
+  },
+  "name.customize": {
+    "message": "Customize",
+    "description": "Optional creative controls toggle"
+  },
+  "description.customize.auto": {
+    "message": "Auto · Maestro decides the video type, visual style, and voice.",
+    "description": "Customization disabled state"
+  },
+  "description.customize.manual": {
+    "message": "Choose the video type, visual style, and voice.",
+    "description": "Customization enabled state"
   }
 }

--- a/src/i18n/en/maestro.json
+++ b/src/i18n/en/maestro.json
@@ -207,6 +207,18 @@
     "message": "No videos yet — create your first one on the left.",
     "description": "No tasks"
   },
+  "name.customize": {
+    "message": "Customize",
+    "description": "Optional creative controls toggle"
+  },
+  "description.customize.auto": {
+    "message": "Auto · Maestro decides the video type, visual style, and voice.",
+    "description": "Customization disabled state"
+  },
+  "description.customize.manual": {
+    "message": "Choose the video type, visual style, and voice.",
+    "description": "Customization enabled state"
+  },
   "name.scenario": {
     "message": "Video Type",
     "description": "Video type field"

--- a/src/i18n/es/maestro.json
+++ b/src/i18n/es/maestro.json
@@ -450,5 +450,17 @@
   "option.scenario.changelog": {
     "message": "Registro de cambios (PR)",
     "description": "Changelog scenario option"
+  },
+  "name.customize": {
+    "message": "Customize",
+    "description": "Optional creative controls toggle"
+  },
+  "description.customize.auto": {
+    "message": "Auto · Maestro decides the video type, visual style, and voice.",
+    "description": "Customization disabled state"
+  },
+  "description.customize.manual": {
+    "message": "Choose the video type, visual style, and voice.",
+    "description": "Customization enabled state"
   }
 }

--- a/src/i18n/fi/maestro.json
+++ b/src/i18n/fi/maestro.json
@@ -450,5 +450,17 @@
   "option.scenario.changelog": {
     "message": "Muutosloki (PR)",
     "description": "Changelog scenario option"
+  },
+  "name.customize": {
+    "message": "Customize",
+    "description": "Optional creative controls toggle"
+  },
+  "description.customize.auto": {
+    "message": "Auto · Maestro decides the video type, visual style, and voice.",
+    "description": "Customization disabled state"
+  },
+  "description.customize.manual": {
+    "message": "Choose the video type, visual style, and voice.",
+    "description": "Customization enabled state"
   }
 }

--- a/src/i18n/fr/maestro.json
+++ b/src/i18n/fr/maestro.json
@@ -450,5 +450,17 @@
   "option.scenario.changelog": {
     "message": "Journal des modifs (PR)",
     "description": "Changelog scenario option"
+  },
+  "name.customize": {
+    "message": "Customize",
+    "description": "Optional creative controls toggle"
+  },
+  "description.customize.auto": {
+    "message": "Auto · Maestro decides the video type, visual style, and voice.",
+    "description": "Customization disabled state"
+  },
+  "description.customize.manual": {
+    "message": "Choose the video type, visual style, and voice.",
+    "description": "Customization enabled state"
   }
 }

--- a/src/i18n/it/maestro.json
+++ b/src/i18n/it/maestro.json
@@ -450,5 +450,17 @@
   "option.scenario.changelog": {
     "message": "Changelog (PR)",
     "description": "Changelog scenario option"
+  },
+  "name.customize": {
+    "message": "Customize",
+    "description": "Optional creative controls toggle"
+  },
+  "description.customize.auto": {
+    "message": "Auto · Maestro decides the video type, visual style, and voice.",
+    "description": "Customization disabled state"
+  },
+  "description.customize.manual": {
+    "message": "Choose the video type, visual style, and voice.",
+    "description": "Customization enabled state"
   }
 }

--- a/src/i18n/ja/maestro.json
+++ b/src/i18n/ja/maestro.json
@@ -450,5 +450,17 @@
   "option.scenario.changelog": {
     "message": "変更履歴 (PR)",
     "description": "Changelog scenario option"
+  },
+  "name.customize": {
+    "message": "Customize",
+    "description": "Optional creative controls toggle"
+  },
+  "description.customize.auto": {
+    "message": "Auto · Maestro decides the video type, visual style, and voice.",
+    "description": "Customization disabled state"
+  },
+  "description.customize.manual": {
+    "message": "Choose the video type, visual style, and voice.",
+    "description": "Customization enabled state"
   }
 }

--- a/src/i18n/ko/maestro.json
+++ b/src/i18n/ko/maestro.json
@@ -450,5 +450,17 @@
   "option.scenario.changelog": {
     "message": "변경 로그 (PR)",
     "description": "Changelog scenario option"
+  },
+  "name.customize": {
+    "message": "Customize",
+    "description": "Optional creative controls toggle"
+  },
+  "description.customize.auto": {
+    "message": "Auto · Maestro decides the video type, visual style, and voice.",
+    "description": "Customization disabled state"
+  },
+  "description.customize.manual": {
+    "message": "Choose the video type, visual style, and voice.",
+    "description": "Customization enabled state"
   }
 }

--- a/src/i18n/pl/maestro.json
+++ b/src/i18n/pl/maestro.json
@@ -450,5 +450,17 @@
   "option.scenario.changelog": {
     "message": "Lista zmian (PR)",
     "description": "Changelog scenario option"
+  },
+  "name.customize": {
+    "message": "Customize",
+    "description": "Optional creative controls toggle"
+  },
+  "description.customize.auto": {
+    "message": "Auto · Maestro decides the video type, visual style, and voice.",
+    "description": "Customization disabled state"
+  },
+  "description.customize.manual": {
+    "message": "Choose the video type, visual style, and voice.",
+    "description": "Customization enabled state"
   }
 }

--- a/src/i18n/pt/maestro.json
+++ b/src/i18n/pt/maestro.json
@@ -450,5 +450,17 @@
   "option.scenario.changelog": {
     "message": "Registro de alterações (PR)",
     "description": "Changelog scenario option"
+  },
+  "name.customize": {
+    "message": "Customize",
+    "description": "Optional creative controls toggle"
+  },
+  "description.customize.auto": {
+    "message": "Auto · Maestro decides the video type, visual style, and voice.",
+    "description": "Customization disabled state"
+  },
+  "description.customize.manual": {
+    "message": "Choose the video type, visual style, and voice.",
+    "description": "Customization enabled state"
   }
 }

--- a/src/i18n/ru/maestro.json
+++ b/src/i18n/ru/maestro.json
@@ -450,5 +450,17 @@
   "option.scenario.changelog": {
     "message": "Список изменений (PR)",
     "description": "Changelog scenario option"
+  },
+  "name.customize": {
+    "message": "Customize",
+    "description": "Optional creative controls toggle"
+  },
+  "description.customize.auto": {
+    "message": "Auto · Maestro decides the video type, visual style, and voice.",
+    "description": "Customization disabled state"
+  },
+  "description.customize.manual": {
+    "message": "Choose the video type, visual style, and voice.",
+    "description": "Customization enabled state"
   }
 }

--- a/src/i18n/sr/maestro.json
+++ b/src/i18n/sr/maestro.json
@@ -450,5 +450,17 @@
   "option.scenario.changelog": {
     "message": "Списак измена (PR)",
     "description": "Changelog scenario option"
+  },
+  "name.customize": {
+    "message": "Customize",
+    "description": "Optional creative controls toggle"
+  },
+  "description.customize.auto": {
+    "message": "Auto · Maestro decides the video type, visual style, and voice.",
+    "description": "Customization disabled state"
+  },
+  "description.customize.manual": {
+    "message": "Choose the video type, visual style, and voice.",
+    "description": "Customization enabled state"
   }
 }

--- a/src/i18n/sv/maestro.json
+++ b/src/i18n/sv/maestro.json
@@ -450,5 +450,17 @@
   "option.scenario.changelog": {
     "message": "Ändringslogg (PR)",
     "description": "Changelog scenario option"
+  },
+  "name.customize": {
+    "message": "Customize",
+    "description": "Optional creative controls toggle"
+  },
+  "description.customize.auto": {
+    "message": "Auto · Maestro decides the video type, visual style, and voice.",
+    "description": "Customization disabled state"
+  },
+  "description.customize.manual": {
+    "message": "Choose the video type, visual style, and voice.",
+    "description": "Customization enabled state"
   }
 }

--- a/src/i18n/uk/maestro.json
+++ b/src/i18n/uk/maestro.json
@@ -450,5 +450,17 @@
   "option.scenario.changelog": {
     "message": "Журнал змін (PR)",
     "description": "Changelog scenario option"
+  },
+  "name.customize": {
+    "message": "Customize",
+    "description": "Optional creative controls toggle"
+  },
+  "description.customize.auto": {
+    "message": "Auto · Maestro decides the video type, visual style, and voice.",
+    "description": "Customization disabled state"
+  },
+  "description.customize.manual": {
+    "message": "Choose the video type, visual style, and voice.",
+    "description": "Customization enabled state"
   }
 }

--- a/src/i18n/zh-CN/maestro.json
+++ b/src/i18n/zh-CN/maestro.json
@@ -207,6 +207,18 @@
     "message": "还没有视频 — 在左侧创建你的第一个吧。",
     "description": "No tasks"
   },
+  "name.customize": {
+    "message": "自定义",
+    "description": "Optional creative controls toggle"
+  },
+  "description.customize.auto": {
+    "message": "自动 · 由 Maestro 决定视频类型、视觉风格与配音音色。",
+    "description": "Customization disabled state"
+  },
+  "description.customize.manual": {
+    "message": "选择视频类型、视觉风格与配音音色。",
+    "description": "Customization enabled state"
+  },
   "name.scenario": {
     "message": "视频类型",
     "description": "Video type field"

--- a/src/i18n/zh-TW/maestro.json
+++ b/src/i18n/zh-TW/maestro.json
@@ -450,5 +450,17 @@
   "option.scenario.changelog": {
     "message": "更新日誌 (PR)",
     "description": "Changelog scenario option"
+  },
+  "name.customize": {
+    "message": "Customize",
+    "description": "Optional creative controls toggle"
+  },
+  "description.customize.auto": {
+    "message": "Auto · Maestro decides the video type, visual style, and voice.",
+    "description": "Customization disabled state"
+  },
+  "description.customize.manual": {
+    "message": "Choose the video type, visual style, and voice.",
+    "description": "Customization enabled state"
   }
 }

--- a/src/models/maestro.ts
+++ b/src/models/maestro.ts
@@ -1,6 +1,7 @@
 export type IMaestroAction = 'generate' | 'remix' | 'edit' | 'extend';
 
 export interface IMaestroConfig {
+  customization_enabled?: boolean;
   prompt?: string;
   action?: IMaestroAction;
   ref_task_id?: string;
@@ -15,7 +16,7 @@ export interface IMaestroConfig {
   callback_url?: string;
 }
 
-export type IMaestroGenerateRequest = IMaestroConfig;
+export type IMaestroGenerateRequest = Omit<IMaestroConfig, 'customization_enabled'>;
 
 export interface IMaestroVariant {
   lang?: string;

--- a/src/pages/maestro/Index.vue
+++ b/src/pages/maestro/Index.vue
@@ -21,6 +21,7 @@ import { IMaestroGenerateRequest, Status } from '@/models';
 import { ElMessage } from 'element-plus';
 import { ERROR_CODE_USED_UP } from '@/constants';
 import { loadPreviousPage } from '@/utils/pagination';
+import { buildMaestroGenerateRequest } from '@/utils/maestro';
 
 interface IData {
   job: number;
@@ -115,9 +116,7 @@ export default defineComponent({
       }
     },
     async onGenerate() {
-      const request = {
-        ...this.config
-      } as IMaestroGenerateRequest;
+      const request: IMaestroGenerateRequest = buildMaestroGenerateRequest(this.config);
       if (!ensureLoggedIn()) {
         return;
       }

--- a/src/utils/maestro.test.ts
+++ b/src/utils/maestro.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { buildMaestroGenerateRequest } from './maestro';
+
+describe('buildMaestroGenerateRequest', () => {
+  it('defaults to omitting customization fields when the toggle is unset', () => {
+    expect(
+      buildMaestroGenerateRequest({
+        prompt: 'Launch video',
+        scenario: 'avatar',
+        style: 'cinematic',
+        voice: 'warm-female'
+      })
+    ).toEqual({ prompt: 'Launch video' });
+  });
+
+  it('omits customization fields while customization is disabled', () => {
+    expect(
+      buildMaestroGenerateRequest({
+        customization_enabled: false,
+        prompt: 'Launch video',
+        scenario: 'avatar',
+        style: 'cinematic',
+        voice: 'warm-female'
+      })
+    ).toEqual({ prompt: 'Launch video' });
+  });
+
+  it('includes customization fields while customization is enabled', () => {
+    expect(
+      buildMaestroGenerateRequest({
+        customization_enabled: true,
+        prompt: 'Launch video',
+        scenario: 'avatar',
+        style: 'cinematic',
+        voice: 'warm-female'
+      })
+    ).toEqual({
+      prompt: 'Launch video',
+      scenario: 'avatar',
+      style: 'cinematic',
+      voice: 'warm-female'
+    });
+  });
+});

--- a/src/utils/maestro.ts
+++ b/src/utils/maestro.ts
@@ -1,0 +1,15 @@
+import { IMaestroConfig, IMaestroGenerateRequest } from '@/models';
+
+export function buildMaestroGenerateRequest(config?: IMaestroConfig): IMaestroGenerateRequest {
+  const source = config ?? {};
+  const { customization_enabled: customizationEnabled, scenario, style, voice, ...request } = source;
+
+  if (!customizationEnabled) return request;
+
+  return {
+    ...request,
+    ...(scenario !== undefined ? { scenario } : {}),
+    ...(style !== undefined ? { style } : {}),
+    ...(voice !== undefined ? { voice } : {})
+  };
+}


### PR DESCRIPTION
## Summary
- put Maestro's video type, visual style, and voice timbre behind a compact `Customize` toggle
- keep the toggle off by default and omit `scenario`, `style`, and `voice` from generation requests while it is off
- preserve selections locally so users can turn customization back on without re-entering them
- add localized toggle copy across all supported locales and a Beachball patch entry

## UX
- disabled: show one concise row explaining that Maestro chooses these creative settings automatically
- enabled: reveal the existing video type cards, visual style selector, and voice selector/preview
- verified at 390px mobile and 1440px desktop; the section has no horizontal overflow in either state

## Validation
- `npx vitest run src/utils/maestro.test.ts` (3 passed)
- `npx vue-tsc --noEmit`
- focused ESLint on changed Vue/TypeScript files
- `python3 scripts/check_i18n_coverage.py` (17 locales x 44 namespaces)
- `npm run build:web`
- `npx beachball check --branch origin/main`

## 🤖 对抗评审 (reviewer: claude-subagent, 2 rounds)
- RISK: disabling customization in one responsive panel could leave another panel's hidden voice preview playing → 已修: every mounted `ConfigPanel` now watches the shared toggle and stops its own audio when customization is disabled
- Round 2: `VERDICT: CLEAN` (one optional NIT suggested additional duplicate-panel audio regression coverage)

Codex was auto-detected first but its configured model required a newer CLI, so the protocol fell back to the independent subagent reviewer.