### PR TITLE
Fix New scheduled task form reset

### DIFF
--- a/change/@acedatacloud-nexior-scheduled-new-reset.json
+++ b/change/@acedatacloud-nexior-scheduled-new-reset.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Scheduled tasks: open New with a fresh form after editing an existing task",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/pages/chat/ScheduledTasks.test.ts
+++ b/src/pages/chat/ScheduledTasks.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+
+import { CHAT_MODEL_NAME_GPT_5_4_MINI } from '@/constants';
+import type { IScheduledTask } from '@/operators/scheduledTasks';
+import ScheduledTasks from './ScheduledTasks.vue';
+
+const editedTask: IScheduledTask = {
+  id: 'task-1',
+  name: 'Existing task',
+  state: 'enabled',
+  schedule: { type: 'interval', interval_seconds: 21600, tz: 'Asia/Shanghai' },
+  template: {
+    model: 'gpt-5.5',
+    question: 'Reuse the existing task prompt',
+    skills: ['hashnode'],
+    mcp_servers: ['publishing'],
+    max_turns: 12
+  },
+  unattended_policy: {
+    mode: 'allow_selected',
+    allowed_skills: ['hashnode'],
+    allowed_mcp_servers: ['publishing']
+  },
+  run_count: 1,
+  created_at: 1,
+  updated_at: 1
+};
+
+const mountComponent = () =>
+  shallowMount(ScheduledTasks, {
+    global: {
+      mocks: {
+        $t: (key: string) => key,
+        $store: {
+          state: {
+            chat: { credential: null },
+            site: { features: {} }
+          }
+        }
+      }
+    }
+  });
+
+describe('chat/ScheduledTasks', () => {
+  it('opens a fresh form when New is clicked after editing a task', async () => {
+    const wrapper = mountComponent();
+    const vm = wrapper.vm as unknown as {
+      openCreate: () => void;
+      closeTaskDialog: () => void;
+      openEdit: (task: IScheduledTask) => void;
+      editingTask: IScheduledTask | null;
+      form: Record<string, unknown>;
+      showCreateDialog: boolean;
+    };
+
+    vm.openEdit(editedTask);
+    expect(vm.form).toMatchObject({
+      name: 'Existing task',
+      question: 'Reuse the existing task prompt',
+      model: 'gpt-5.5',
+      authorizedSkills: ['hashnode'],
+      authorizedMcpServers: ['publishing']
+    });
+
+    await wrapper.find('.header el-button-stub').trigger('click');
+
+    expect(vm.editingTask).toBeNull();
+    expect(vm.showCreateDialog).toBe(true);
+    expect(vm.form).toEqual({
+      name: '',
+      question: '',
+      model: CHAT_MODEL_NAME_GPT_5_4_MINI,
+      scheduleType: 'daily',
+      intervalValue: 4,
+      intervalUnit: 'hour',
+      hourlyMinute: 0,
+      dailyTime: '09:00',
+      weekday: 1,
+      cronExpr: '0 9 * * *',
+      authorizedSkills: [],
+      authorizedMcpServers: [],
+      maxTurns: 50
+    });
+  });
+
+  it('prevents switching forms while a save is in progress', async () => {
+    const wrapper = mountComponent();
+    const vm = wrapper.vm as unknown as {
+      openCreate: () => void;
+      closeTaskDialog: () => void;
+      openEdit: (task: IScheduledTask) => void;
+      editingTask: IScheduledTask | null;
+      form: Record<string, unknown>;
+      showCreateDialog: boolean;
+    };
+    await wrapper.setData({ saving: true, showCreateDialog: true });
+
+    const newButton = wrapper.find('.header el-button-stub');
+    const dialog = wrapper.findComponent({ name: 'ElDialog' });
+
+    expect(newButton.attributes('disabled')).toBe('true');
+    expect(dialog.props('showClose')).toBe(false);
+    expect(dialog.props('closeOnPressEscape')).toBe(false);
+
+    vm.openEdit(editedTask);
+    vm.openCreate();
+    vm.closeTaskDialog();
+
+    expect(vm.editingTask).toMatchObject({ id: editedTask.id });
+    expect(vm.form).toMatchObject({ name: 'Existing task' });
+    expect(vm.showCreateDialog).toBe(true);
+  });
+});

--- a/src/pages/chat/ScheduledTasks.vue
+++ b/src/pages/chat/ScheduledTasks.vue
@@ -3,7 +3,7 @@
     <div class="inner">
       <div class="header">
         <h2 class="title">{{ $t('chat.scheduledTasks.title') }}</h2>
-        <el-button type="primary" round @click="showCreateDialog = true">
+        <el-button type="primary" round :disabled="saving" @click="openCreate">
           <font-awesome-icon icon="fa-solid fa-plus" class="icon" />
           {{ $t('chat.scheduledTasks.create') }}
         </el-button>
@@ -139,6 +139,8 @@
       :title="editingTask ? $t('chat.scheduledTasks.edit') : $t('chat.scheduledTasks.create')"
       width="540px"
       :close-on-click-modal="false"
+      :close-on-press-escape="!saving"
+      :show-close="!saving"
       class="scheduled-task-dialog"
     >
       <el-form :model="form" label-width="92px">
@@ -275,7 +277,7 @@
       </el-form>
 
       <template #footer>
-        <el-button @click="showCreateDialog = false">{{ $t('common.button.cancel') }}</el-button>
+        <el-button :disabled="saving" @click="closeTaskDialog">{{ $t('common.button.cancel') }}</el-button>
         <el-button type="primary" :loading="saving" @click="saveTask">
           {{ $t('common.button.confirm') }}
         </el-button>
@@ -483,6 +485,16 @@ export default defineComponent({
     },
     onRunPageChange(p: number) {
       this.runPage = p;
+    },
+    openCreate() {
+      if (this.saving) return;
+      this.editingTask = null;
+      this.form = this.emptyForm();
+      this.showCreateDialog = true;
+    },
+    closeTaskDialog() {
+      if (this.saving) return;
+      this.showCreateDialog = false;
     },
     openEdit(task: IScheduledTask) {
       this.editingTask = task;


### PR DESCRIPTION
## Summary
- Reset the scheduled-task form and edit state every time New is opened.
- Prevent dialog switching or closing while a save is in flight, so a stale edit completion cannot wipe a new draft.
- Add regression coverage for Edit → New reset behavior and save-in-progress guards.

## Validation
- `vitest run src/pages/chat/ScheduledTasks.test.ts`
- `eslint src/pages/chat/ScheduledTasks.vue src/pages/chat/ScheduledTasks.test.ts`
- `vue-tsc -b --force`
- `beachball check`
- `git diff --check`

## 🤖 对抗评审 (reviewer: claude-subagent, 2 rounds)
- RISK: A pending edit save can erase a newly opened form → 已修：保存期间禁用 New、Cancel、关闭按钮和 Esc，并在 New/Cancel 方法中增加同步守卫及回归测试。
- Round 2: `VERDICT: CLEAN`
