### PR TITLE
Improve Maestro language selection

### DIFF
--- a/change/@acedatacloud-nexior-maestro-language-picker.json
+++ b/change/@acedatacloud-nexior-maestro-language-picker.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Show localized Maestro language names and make the primary output language explicit",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/maestro/ConfigPanel.vue
+++ b/src/components/maestro/ConfigPanel.vue
@@ -35,15 +35,37 @@
           <h2 class="field-title font-bold">{{ $t('maestro.name.langs') }}</h2>
           <info-icon :content="$t('maestro.description.langs')" class="ml-1" />
         </div>
-        <el-select
-          v-model="langs"
-          multiple
-          collapse-tags
-          :placeholder="$t('maestro.placeholder.select')"
-          class="w-full"
-        >
-          <el-option v-for="l in MAESTRO_ALLOWED_LANGS" :key="l" :label="l" :value="l" />
-        </el-select>
+        <div class="language-picker">
+          <label class="language-role language-role--primary">
+            <span class="language-role-label">{{ $t('maestro.name.primaryLanguage') }}</span>
+            <el-select v-model="primaryLanguage" class="w-full">
+              <el-option
+                v-for="option in languageOptions"
+                :key="option.value"
+                :label="option.label"
+                :value="option.value"
+              />
+            </el-select>
+          </label>
+          <label class="language-role">
+            <span class="language-role-label">{{ $t('maestro.name.additionalLanguages') }}</span>
+            <el-select
+              v-model="additionalLanguages"
+              multiple
+              collapse-tags
+              collapse-tags-tooltip
+              :placeholder="$t('maestro.placeholder.additionalLanguages')"
+              class="w-full"
+            >
+              <el-option
+                v-for="option in additionalLanguageOptions"
+                :key="option.value"
+                :label="option.label"
+                :value="option.value"
+              />
+            </el-select>
+          </label>
+        </div>
       </div>
 
       <!-- Aspect ratio -->
@@ -223,7 +245,6 @@ import InfoIcon from '@/components/common/InfoIcon.vue';
 import PromptTextarea from '@/components/common/PromptTextarea.vue';
 import FileUrlsInput from './config/FileUrlsInput.vue';
 import {
-  MAESTRO_ALLOWED_LANGS,
   MAESTRO_ALLOWED_ASPECTS,
   MAESTRO_MIN_DURATION,
   MAESTRO_MAX_DURATION,
@@ -244,6 +265,13 @@ import {
 } from '@/constants';
 import { IMaestroConfig } from '@/models';
 import { isVideoUrl } from '@/utils/is';
+import {
+  getMaestroLanguageOptions,
+  normalizeMaestroLanguages,
+  setMaestroAdditionalLanguages,
+  setMaestroPrimaryLanguage,
+  type IMaestroLanguageOption
+} from '@/utils/maestroLanguages';
 
 // Preview rectangle dimensions (px) for each aspect-ratio chip.
 const RATIO_PREVIEW: Record<string, { width: number; height: number }> = {
@@ -269,7 +297,6 @@ export default defineComponent({
   emits: ['generate'],
   data() {
     return {
-      MAESTRO_ALLOWED_LANGS,
       MAESTRO_MIN_DURATION,
       MAESTRO_MAX_DURATION,
       MAESTRO_ALLOWED_QUALITIES,
@@ -321,11 +348,32 @@ export default defineComponent({
     },
     langs: {
       get(): string[] {
-        return this.config?.langs || [];
+        return normalizeMaestroLanguages(this.config?.langs);
       },
       set(val: string[]) {
-        // keep at least the primary language so billing/render always has one
-        this.update({ langs: val.length ? val : MAESTRO_DEFAULT_LANGS });
+        this.update({ langs: normalizeMaestroLanguages(val) });
+      }
+    },
+    languageOptions(): IMaestroLanguageOption[] {
+      return getMaestroLanguageOptions(this.$i18n.locale);
+    },
+    additionalLanguageOptions(): IMaestroLanguageOption[] {
+      return this.languageOptions.filter((option) => option.value !== this.primaryLanguage);
+    },
+    primaryLanguage: {
+      get(): string {
+        return this.langs[0] || MAESTRO_DEFAULT_LANGS[0];
+      },
+      set(val: string) {
+        this.update({ langs: setMaestroPrimaryLanguage(this.langs, val) });
+      }
+    },
+    additionalLanguages: {
+      get(): string[] {
+        return this.langs.slice(1);
+      },
+      set(val: string[]) {
+        this.update({ langs: setMaestroAdditionalLanguages(this.langs, val) });
       }
     },
     aspect: {
@@ -401,7 +449,7 @@ export default defineComponent({
   mounted() {
     this.update({
       action: this.config?.action ?? MAESTRO_DEFAULT_ACTION,
-      langs: this.config?.langs?.length ? this.config.langs : MAESTRO_DEFAULT_LANGS,
+      langs: normalizeMaestroLanguages(this.config?.langs),
       aspect: this.config?.aspect ?? MAESTRO_DEFAULT_ASPECT,
       duration: this.config?.duration ?? MAESTRO_DEFAULT_DURATION,
       quality: this.config?.quality ?? MAESTRO_DEFAULT_QUALITY,
@@ -517,6 +565,31 @@ export default defineComponent({
   margin-top: 16px;
   padding-top: 16px;
   border-top: 1px solid var(--el-border-color-lighter);
+}
+.language-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.language-role {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+.language-role-label {
+  color: var(--el-text-color-secondary);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.4;
+}
+.language-role--primary {
+  .language-role-label {
+    color: var(--el-color-primary);
+  }
+
+  :deep(.el-select__wrapper:not(.is-focused)) {
+    box-shadow: 0 0 0 1px var(--el-color-primary-light-5) inset;
+  }
 }
 .voice-row {
   display: flex;

--- a/src/i18n/ar/maestro.json
+++ b/src/i18n/ar/maestro.json
@@ -462,5 +462,17 @@
   "description.customize.manual": {
     "message": "اختر نوع الفيديو والأسلوب البصري ونغمة الصوت.",
     "description": "Customization enabled state"
+  },
+  "name.primaryLanguage": {
+    "message": "Primary language",
+    "description": "Primary output language field"
+  },
+  "name.additionalLanguages": {
+    "message": "Additional languages (optional)",
+    "description": "Additional output languages field"
+  },
+  "placeholder.additionalLanguages": {
+    "message": "Add output languages",
+    "description": "Additional languages placeholder"
   }
 }

--- a/src/i18n/de/maestro.json
+++ b/src/i18n/de/maestro.json
@@ -462,5 +462,17 @@
   "description.customize.manual": {
     "message": "Videotyp, visuellen Stil und Erzählstimme auswählen.",
     "description": "Customization enabled state"
+  },
+  "name.primaryLanguage": {
+    "message": "Primary language",
+    "description": "Primary output language field"
+  },
+  "name.additionalLanguages": {
+    "message": "Additional languages (optional)",
+    "description": "Additional output languages field"
+  },
+  "placeholder.additionalLanguages": {
+    "message": "Add output languages",
+    "description": "Additional languages placeholder"
   }
 }

--- a/src/i18n/el/maestro.json
+++ b/src/i18n/el/maestro.json
@@ -462,5 +462,17 @@
   "description.customize.manual": {
     "message": "Επιλέξτε τον τύπο βίντεο, το οπτικό στυλ και τον τόνο φωνής.",
     "description": "Customization enabled state"
+  },
+  "name.primaryLanguage": {
+    "message": "Primary language",
+    "description": "Primary output language field"
+  },
+  "name.additionalLanguages": {
+    "message": "Additional languages (optional)",
+    "description": "Additional output languages field"
+  },
+  "placeholder.additionalLanguages": {
+    "message": "Add output languages",
+    "description": "Additional languages placeholder"
   }
 }

--- a/src/i18n/en/maestro.json
+++ b/src/i18n/en/maestro.json
@@ -83,6 +83,14 @@
     "message": "Languages",
     "description": "Output languages field"
   },
+  "name.primaryLanguage": {
+    "message": "Primary language",
+    "description": "Primary output language field"
+  },
+  "name.additionalLanguages": {
+    "message": "Additional languages (optional)",
+    "description": "Additional output languages field"
+  },
   "name.aspect": {
     "message": "Aspect Ratio",
     "description": "Aspect ratio field"
@@ -118,6 +126,10 @@
   "placeholder.select": {
     "message": "Please select",
     "description": "Generic select placeholder"
+  },
+  "placeholder.additionalLanguages": {
+    "message": "Add output languages",
+    "description": "Additional languages placeholder"
   },
   "description.prompt": {
     "message": "Say what you want in plain language — Maestro plans the script, visuals, voiceover and edit.",

--- a/src/i18n/es/maestro.json
+++ b/src/i18n/es/maestro.json
@@ -462,5 +462,17 @@
   "description.customize.manual": {
     "message": "Elige el tipo de vídeo, el estilo visual y el tono de voz.",
     "description": "Customization enabled state"
+  },
+  "name.primaryLanguage": {
+    "message": "Primary language",
+    "description": "Primary output language field"
+  },
+  "name.additionalLanguages": {
+    "message": "Additional languages (optional)",
+    "description": "Additional output languages field"
+  },
+  "placeholder.additionalLanguages": {
+    "message": "Add output languages",
+    "description": "Additional languages placeholder"
   }
 }

--- a/src/i18n/fi/maestro.json
+++ b/src/i18n/fi/maestro.json
@@ -462,5 +462,17 @@
   "description.customize.manual": {
     "message": "Valitse videon tyyppi, visuaalinen tyyli ja ääninäytteen äänenväri.",
     "description": "Customization enabled state"
+  },
+  "name.primaryLanguage": {
+    "message": "Primary language",
+    "description": "Primary output language field"
+  },
+  "name.additionalLanguages": {
+    "message": "Additional languages (optional)",
+    "description": "Additional output languages field"
+  },
+  "placeholder.additionalLanguages": {
+    "message": "Add output languages",
+    "description": "Additional languages placeholder"
   }
 }

--- a/src/i18n/fr/maestro.json
+++ b/src/i18n/fr/maestro.json
@@ -462,5 +462,17 @@
   "description.customize.manual": {
     "message": "Choisissez le type de vidéo, le style visuel et le timbre de voix.",
     "description": "Customization enabled state"
+  },
+  "name.primaryLanguage": {
+    "message": "Primary language",
+    "description": "Primary output language field"
+  },
+  "name.additionalLanguages": {
+    "message": "Additional languages (optional)",
+    "description": "Additional output languages field"
+  },
+  "placeholder.additionalLanguages": {
+    "message": "Add output languages",
+    "description": "Additional languages placeholder"
   }
 }

--- a/src/i18n/it/maestro.json
+++ b/src/i18n/it/maestro.json
@@ -462,5 +462,17 @@
   "description.customize.manual": {
     "message": "Scegli il tipo di video, lo stile visivo e il timbro della voce.",
     "description": "Customization enabled state"
+  },
+  "name.primaryLanguage": {
+    "message": "Primary language",
+    "description": "Primary output language field"
+  },
+  "name.additionalLanguages": {
+    "message": "Additional languages (optional)",
+    "description": "Additional output languages field"
+  },
+  "placeholder.additionalLanguages": {
+    "message": "Add output languages",
+    "description": "Additional languages placeholder"
   }
 }

--- a/src/i18n/ja/maestro.json
+++ b/src/i18n/ja/maestro.json
@@ -462,5 +462,17 @@
   "description.customize.manual": {
     "message": "動画タイプ、ビジュアルスタイル、ナレーション音色を選択します。",
     "description": "Customization enabled state"
+  },
+  "name.primaryLanguage": {
+    "message": "Primary language",
+    "description": "Primary output language field"
+  },
+  "name.additionalLanguages": {
+    "message": "Additional languages (optional)",
+    "description": "Additional output languages field"
+  },
+  "placeholder.additionalLanguages": {
+    "message": "Add output languages",
+    "description": "Additional languages placeholder"
   }
 }

--- a/src/i18n/ko/maestro.json
+++ b/src/i18n/ko/maestro.json
@@ -462,5 +462,17 @@
   "description.customize.manual": {
     "message": "동영상 유형, 시각적 스타일, 내레이터 음색을 선택하세요.",
     "description": "Customization enabled state"
+  },
+  "name.primaryLanguage": {
+    "message": "Primary language",
+    "description": "Primary output language field"
+  },
+  "name.additionalLanguages": {
+    "message": "Additional languages (optional)",
+    "description": "Additional output languages field"
+  },
+  "placeholder.additionalLanguages": {
+    "message": "Add output languages",
+    "description": "Additional languages placeholder"
   }
 }

--- a/src/i18n/pl/maestro.json
+++ b/src/i18n/pl/maestro.json
@@ -462,5 +462,17 @@
   "description.customize.manual": {
     "message": "Wybierz typ wideo, styl wizualny i ton głosu.",
     "description": "Customization enabled state"
+  },
+  "name.primaryLanguage": {
+    "message": "Primary language",
+    "description": "Primary output language field"
+  },
+  "name.additionalLanguages": {
+    "message": "Additional languages (optional)",
+    "description": "Additional output languages field"
+  },
+  "placeholder.additionalLanguages": {
+    "message": "Add output languages",
+    "description": "Additional languages placeholder"
   }
 }

--- a/src/i18n/pt/maestro.json
+++ b/src/i18n/pt/maestro.json
@@ -462,5 +462,17 @@
   "description.customize.manual": {
     "message": "Escolha o tipo de vídeo, o estilo visual e o timbre da narração.",
     "description": "Customization enabled state"
+  },
+  "name.primaryLanguage": {
+    "message": "Primary language",
+    "description": "Primary output language field"
+  },
+  "name.additionalLanguages": {
+    "message": "Additional languages (optional)",
+    "description": "Additional output languages field"
+  },
+  "placeholder.additionalLanguages": {
+    "message": "Add output languages",
+    "description": "Additional languages placeholder"
   }
 }

--- a/src/i18n/ru/maestro.json
+++ b/src/i18n/ru/maestro.json
@@ -462,5 +462,17 @@
   "description.customize.manual": {
     "message": "Выберите тип видео, визуальный стиль и тембр голоса.",
     "description": "Customization enabled state"
+  },
+  "name.primaryLanguage": {
+    "message": "Primary language",
+    "description": "Primary output language field"
+  },
+  "name.additionalLanguages": {
+    "message": "Additional languages (optional)",
+    "description": "Additional output languages field"
+  },
+  "placeholder.additionalLanguages": {
+    "message": "Add output languages",
+    "description": "Additional languages placeholder"
   }
 }

--- a/src/i18n/sr/maestro.json
+++ b/src/i18n/sr/maestro.json
@@ -462,5 +462,17 @@
   "description.customize.manual": {
     "message": "Изаберите тип видеа, визуелни стил и тон гласа.",
     "description": "Customization enabled state"
+  },
+  "name.primaryLanguage": {
+    "message": "Primary language",
+    "description": "Primary output language field"
+  },
+  "name.additionalLanguages": {
+    "message": "Additional languages (optional)",
+    "description": "Additional output languages field"
+  },
+  "placeholder.additionalLanguages": {
+    "message": "Add output languages",
+    "description": "Additional languages placeholder"
   }
 }

--- a/src/i18n/sv/maestro.json
+++ b/src/i18n/sv/maestro.json
@@ -462,5 +462,17 @@
   "description.customize.manual": {
     "message": "Välj videotyp, visuell stil och berättarröst.",
     "description": "Customization enabled state"
+  },
+  "name.primaryLanguage": {
+    "message": "Primary language",
+    "description": "Primary output language field"
+  },
+  "name.additionalLanguages": {
+    "message": "Additional languages (optional)",
+    "description": "Additional output languages field"
+  },
+  "placeholder.additionalLanguages": {
+    "message": "Add output languages",
+    "description": "Additional languages placeholder"
   }
 }

--- a/src/i18n/uk/maestro.json
+++ b/src/i18n/uk/maestro.json
@@ -462,5 +462,17 @@
   "description.customize.manual": {
     "message": "Виберіть тип відео, візуальний стиль і тональність озвучення.",
     "description": "Customization enabled state"
+  },
+  "name.primaryLanguage": {
+    "message": "Primary language",
+    "description": "Primary output language field"
+  },
+  "name.additionalLanguages": {
+    "message": "Additional languages (optional)",
+    "description": "Additional output languages field"
+  },
+  "placeholder.additionalLanguages": {
+    "message": "Add output languages",
+    "description": "Additional languages placeholder"
   }
 }

--- a/src/i18n/zh-CN/maestro.json
+++ b/src/i18n/zh-CN/maestro.json
@@ -83,6 +83,14 @@
     "message": "语言",
     "description": "Output languages field"
   },
+  "name.primaryLanguage": {
+    "message": "主语言",
+    "description": "Primary output language field"
+  },
+  "name.additionalLanguages": {
+    "message": "其他语言（可选）",
+    "description": "Additional output languages field"
+  },
   "name.aspect": {
     "message": "画面比例",
     "description": "Aspect ratio field"
@@ -118,6 +126,10 @@
   "placeholder.select": {
     "message": "请选择",
     "description": "Generic select placeholder"
+  },
+  "placeholder.additionalLanguages": {
+    "message": "添加其他输出语言",
+    "description": "Additional languages placeholder"
   },
   "description.prompt": {
     "message": "用大白话说清楚你想要什么,脚本、画面、配音、剪辑都交给 Maestro。",

--- a/src/i18n/zh-TW/maestro.json
+++ b/src/i18n/zh-TW/maestro.json
@@ -462,5 +462,17 @@
   "description.customize.manual": {
     "message": "選擇影片類型、視覺風格與配音音色。",
     "description": "Customization enabled state"
+  },
+  "name.primaryLanguage": {
+    "message": "Primary language",
+    "description": "Primary output language field"
+  },
+  "name.additionalLanguages": {
+    "message": "Additional languages (optional)",
+    "description": "Additional output languages field"
+  },
+  "placeholder.additionalLanguages": {
+    "message": "Add output languages",
+    "description": "Additional languages placeholder"
   }
 }

--- a/src/store/maestro/mutations.test.ts
+++ b/src/store/maestro/mutations.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { setConfig } from './mutations';
+import initialState from './state';
+
+describe('Maestro config mutations', () => {
+  it('normalizes legacy languages written by remix', () => {
+    const state = initialState();
+
+    setConfig(state, {
+      action: 'remix',
+      ref_task_id: 'legacy-task',
+      langs: ['it', 'en', 'en']
+    });
+
+    expect(state.config).toMatchObject({
+      action: 'remix',
+      ref_task_id: 'legacy-task',
+      langs: ['en']
+    });
+  });
+});

--- a/src/store/maestro/mutations.ts
+++ b/src/store/maestro/mutations.ts
@@ -1,4 +1,5 @@
 import { IApplication, ICredential, IMaestroConfig, IMaestroTask, IService } from '@/models';
+import { normalizeMaestroLanguages } from '@/utils/maestroLanguages';
 import initialState from './state';
 import { IMaestroState } from './models';
 
@@ -23,7 +24,10 @@ export const setApplications = (state: IMaestroState, payload: IApplication[]): 
 };
 
 export const setConfig = (state: IMaestroState, payload: IMaestroConfig): void => {
-  state.config = payload;
+  state.config = {
+    ...payload,
+    langs: normalizeMaestroLanguages(payload.langs)
+  };
 };
 
 export const setTasksItems = (state: IMaestroState, payload: IMaestroTask[]): void => {

--- a/src/utils/maestroLanguages.test.ts
+++ b/src/utils/maestroLanguages.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getMaestroLanguageName,
+  getMaestroLanguageOptions,
+  normalizeMaestroLanguages,
+  setMaestroAdditionalLanguages,
+  setMaestroPrimaryLanguage
+} from './maestroLanguages';
+
+describe('Maestro language picker helpers', () => {
+  it('shows localized language names instead of API codes', () => {
+    expect(getMaestroLanguageName('zh-cn', 'zh-CN')).toBe('简体中文');
+    expect(getMaestroLanguageName('zh-cn', 'en')).toBe('Simplified Chinese');
+    expect(getMaestroLanguageOptions('zh-CN').map((option) => option.label)).toEqual([
+      '简体中文',
+      '英语',
+      '日语',
+      '韩语',
+      '西班牙语',
+      '法语',
+      '德语'
+    ]);
+  });
+
+  it('promotes a language to primary without dropping the previous primary', () => {
+    expect(setMaestroPrimaryLanguage(['zh-cn', 'en', 'ja'], 'en')).toEqual(['en', 'zh-cn', 'ja']);
+  });
+
+  it('normalizes empty, duplicate, and unsupported persisted languages', () => {
+    expect(normalizeMaestroLanguages()).toEqual(['zh-cn']);
+    expect(normalizeMaestroLanguages(['it', 'en', 'en', 'ja'])).toEqual(['en', 'ja']);
+  });
+
+  it('keeps the primary first and de-duplicates additional languages', () => {
+    expect(setMaestroAdditionalLanguages(['zh-cn', 'en'], ['ja', 'en', 'ja', 'zh-cn', 'it'])).toEqual([
+      'zh-cn',
+      'ja',
+      'en'
+    ]);
+  });
+});

--- a/src/utils/maestroLanguages.ts
+++ b/src/utils/maestroLanguages.ts
@@ -1,0 +1,57 @@
+import { MAESTRO_ALLOWED_LANGS, MAESTRO_DEFAULT_LANGS } from '@/constants/maestro';
+
+export interface IMaestroLanguageOption {
+  value: string;
+  label: string;
+}
+
+const DISPLAY_LANGUAGE_CODES: Record<string, string> = {
+  'zh-cn': 'zh-Hans'
+};
+
+const FALLBACK_LANGUAGE_NAMES: Record<string, string> = {
+  'zh-cn': '简体中文',
+  en: 'English',
+  ja: '日本語',
+  ko: '한국어',
+  es: 'Español',
+  fr: 'Français',
+  de: 'Deutsch'
+};
+
+const ALLOWED_LANGUAGES = new Set<string>(MAESTRO_ALLOWED_LANGS);
+
+export const getMaestroLanguageName = (language: string, locale: string): string => {
+  const displayCode = DISPLAY_LANGUAGE_CODES[language] || language;
+  try {
+    return (
+      new Intl.DisplayNames([locale], { type: 'language' }).of(displayCode) ||
+      FALLBACK_LANGUAGE_NAMES[language] ||
+      language
+    );
+  } catch {
+    return FALLBACK_LANGUAGE_NAMES[language] || language;
+  }
+};
+
+export const getMaestroLanguageOptions = (locale: string): IMaestroLanguageOption[] =>
+  MAESTRO_ALLOWED_LANGS.map((value) => ({
+    value,
+    label: getMaestroLanguageName(value, locale)
+  }));
+
+export const normalizeMaestroLanguages = (languages?: string[]): string[] => {
+  const normalized = Array.from(new Set((languages || []).filter((language) => ALLOWED_LANGUAGES.has(language))));
+  return normalized.length ? normalized : [...MAESTRO_DEFAULT_LANGS];
+};
+
+export const setMaestroPrimaryLanguage = (languages: string[], primaryLanguage: string): string[] => {
+  const normalized = normalizeMaestroLanguages(languages);
+  const nextPrimary = ALLOWED_LANGUAGES.has(primaryLanguage) ? primaryLanguage : normalized[0];
+  return [nextPrimary, ...normalized.filter((language) => language !== nextPrimary)];
+};
+
+export const setMaestroAdditionalLanguages = (languages: string[], additionalLanguages: string[]): string[] => {
+  const primaryLanguage = normalizeMaestroLanguages(languages)[0];
+  return normalizeMaestroLanguages([primaryLanguage, ...additionalLanguages]);
+};


### PR DESCRIPTION
## Summary
- replace raw language codes such as `zh-cn` with localized language names
- separate the required primary language from optional additional outputs
- preserve the ordered `langs` API contract and normalize legacy, duplicate, or unsupported values at the Vuex boundary
- add responsive styling, locale coverage, helper and mutation regression tests, and a Beachball patch record

## Validation
- `vitest run src/store/maestro/mutations.test.ts src/utils/maestroLanguages.test.ts` (5 passed)
- `eslint` on the changed Vue/TypeScript files
- `vue-tsc --noEmit`
- `npm run build:web`
- `python3 scripts/check_i18n_coverage.py`
- `npx beachball check`
- Playwright desktop and 390px mobile screenshots plus primary-language promotion interaction

## 🤖 对抗评审 (reviewer: claude-subagent, 3 rounds)
- RISK: helper/test files were initially outside the reviewed diff → 已修，全部纳入提交
- RISK: legacy duplicate or unsupported language arrays could survive interaction → 已修，新增统一过滤、去重与默认回退
- RISK: primary-language accent could obscure keyboard focus → 已修，idle 样式不再匹配 `.is-focused`
- RISK: Beachball change record missing → 已修，新增 patch change record并通过检查
- RISK: Remix could overwrite mounted normalization with raw legacy values → 已修，在 `maestro/setConfig` mutation 边界统一规范化，并新增回归测试
- Round 3: `VERDICT: CLEAN`
- Conflict-resolution re-review after rebasing onto latest main: `VERDICT: CLEAN`