### PR TITLE
Improve Maestro reference upload previews

### DIFF
--- a/change/@acedatacloud-nexior-14be765b-01b1-4143-883e-ae4b55409670.json
+++ b/change/@acedatacloud-nexior-14be765b-01b1-4143-883e-ae4b55409670.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Improve Maestro reference upload previews.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/maestro/config/FileUrlsInput.test.ts
+++ b/src/components/maestro/config/FileUrlsInput.test.ts
@@ -1,0 +1,186 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import type { UploadFile } from 'element-plus';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import FilePreview from '@/components/common/FilePreview.vue';
+import ImagePreview from '@/components/common/ImagePreview.vue';
+import FileUrlsInput from './FileUrlsInput.vue';
+
+const imageFile = {
+  name: 'storyboard.png',
+  uid: 1,
+  status: 'success',
+  percentage: 100,
+  url: 'https://cdn.example.com/storyboard.png',
+  response: { file_url: 'https://cdn.example.com/storyboard.png' }
+} as UploadFile;
+
+const audioFile = {
+  name: 'narration.mp3',
+  uid: 2,
+  status: 'success',
+  percentage: 100,
+  url: 'https://cdn.example.com/narration.mp3',
+  response: { file_url: 'https://cdn.example.com/narration.mp3' }
+} as UploadFile;
+
+const mountComponent = () => {
+  const commit = vi.fn();
+  const wrapper = shallowMount(FileUrlsInput, {
+    global: {
+      mocks: {
+        $t: (key: string) => key,
+        $store: {
+          state: {
+            token: { access: 'test-token' },
+            maestro: { config: { prompt: 'Create a launch video' } }
+          },
+          commit
+        }
+      }
+    }
+  });
+
+  return { wrapper, commit };
+};
+
+describe('maestro/config/FileUrlsInput', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uses the shared image and file previews for mixed uploads', async () => {
+    const { wrapper } = mountComponent();
+
+    await wrapper.setData({ fileList: [imageFile, audioFile] });
+
+    expect(wrapper.findAllComponents(ImagePreview)).toHaveLength(1);
+    expect(wrapper.findAllComponents(FilePreview)).toHaveLength(1);
+  });
+
+  it('removes a preview and syncs only completed file URLs to Maestro config', async () => {
+    const { wrapper, commit } = mountComponent();
+    await wrapper.setData({ fileList: [imageFile, audioFile] });
+
+    (wrapper.vm as unknown as { onRemovePreview: (index: number, file: UploadFile) => void }).onRemovePreview(
+      0,
+      imageFile
+    );
+
+    expect(commit).toHaveBeenCalledWith('maestro/setConfig', {
+      prompt: 'Create a launch video',
+      file_urls: ['https://cdn.example.com/narration.mp3']
+    });
+  });
+
+  it('aborts an in-progress upload before removing its preview', async () => {
+    const { wrapper } = mountComponent();
+    const abort = vi.fn();
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+    const uploadingFile = {
+      name: 'storyboard.png',
+      uid: 3,
+      status: 'uploading',
+      percentage: 50,
+      url: 'blob:storyboard'
+    } as UploadFile;
+    await wrapper.setData({ fileList: [uploadingFile] });
+    Object.assign(wrapper.vm.$refs.uploader as object, { abort });
+
+    (wrapper.vm as unknown as { onRemovePreview: (index: number, file: UploadFile) => void }).onRemovePreview(
+      0,
+      uploadingFile
+    );
+
+    expect(abort).toHaveBeenCalledWith(uploadingFile);
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:storyboard');
+    expect((wrapper.vm as unknown as { fileList: UploadFile[] }).fileList).toHaveLength(0);
+  });
+
+  it('releases a local image preview when an upload fails', async () => {
+    const { wrapper } = mountComponent();
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+    const failedFile = {
+      name: 'storyboard.png',
+      uid: 4,
+      status: 'fail',
+      percentage: 35,
+      url: 'blob:storyboard'
+    } as UploadFile;
+
+    (wrapper.vm as unknown as { onError: (error: Error, file: UploadFile) => void }).onError(
+      new Error('upload failed'),
+      failedFile
+    );
+
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:storyboard');
+  });
+
+  it('removes a broken preview when a successful response has no file URL', async () => {
+    const { wrapper, commit } = mountComponent();
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+    const malformedFile = {
+      name: 'storyboard.png',
+      uid: 5,
+      status: 'success',
+      percentage: 100,
+      url: 'blob:storyboard'
+    } as UploadFile;
+    await wrapper.setData({ fileList: [malformedFile] });
+
+    (wrapper.vm as unknown as { onSuccess: (response: unknown, file: UploadFile) => void }).onSuccess(
+      {},
+      malformedFile
+    );
+
+    expect((wrapper.vm as unknown as { fileList: UploadFile[] }).fileList).toHaveLength(0);
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:storyboard');
+    expect(commit).toHaveBeenLastCalledWith('maestro/setConfig', {
+      prompt: 'Create a launch video',
+      file_urls: []
+    });
+  });
+
+  it('replaces a local image preview once and does not recreate it after upload success', () => {
+    const { wrapper } = mountComponent();
+    const createObjectURL = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:storyboard');
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+    const file = {
+      name: 'storyboard.png',
+      uid: 6,
+      status: 'ready',
+      percentage: 0,
+      raw: new File(['image'], 'storyboard.png', { type: 'image/png' })
+    } as UploadFile;
+    const vm = wrapper.vm as unknown as {
+      onFileChange: (file: UploadFile) => void;
+      onSuccess: (response: unknown, file: UploadFile) => void;
+    };
+
+    vm.onFileChange(file);
+    file.status = 'success';
+    vm.onSuccess({ file_url: 'https://cdn.example.com/storyboard.png' }, file);
+    vm.onFileChange(file);
+
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:storyboard');
+    expect(file.url).toBe('https://cdn.example.com/storyboard.png');
+  });
+
+  it('releases local image previews when the component unmounts', async () => {
+    const { wrapper } = mountComponent();
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+    await wrapper.setData({
+      fileList: [
+        { name: 'one.png', uid: 7, url: 'blob:one', status: 'ready' },
+        { name: 'two.png', uid: 8, url: 'blob:two', status: 'uploading' }
+      ]
+    });
+
+    wrapper.unmount();
+
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:one');
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:two');
+  });
+});

--- a/src/components/maestro/config/FileUrlsInput.vue
+++ b/src/components/maestro/config/FileUrlsInput.vue
@@ -8,27 +8,49 @@
       class="w-full"
       :limit="MAESTRO_FILE_LIMIT"
       :multiple="true"
+      :show-file-list="false"
       :action="uploadUrl"
       :headers="headers"
       :on-exceed="onExceed"
       :on-error="onError"
-      :on-success="onChange"
-      :on-remove="onChange"
+      :on-change="onFileChange"
+      :on-success="onSuccess"
     >
-      <el-button size="small" round>
+      <el-button type="primary" size="small" round>
         <font-awesome-icon icon="fa-solid fa-paperclip" class="mr-1" />
         {{ $t('maestro.button.uploadFiles') }}
       </el-button>
     </el-upload>
+    <div v-if="fileList.length" class="mt-[10px] flex flex-wrap gap-[10px]">
+      <template v-for="(file, index) in fileList" :key="file.uid">
+        <image-preview
+          v-if="isImageFile(file)"
+          :url="getFileUrl(file)"
+          :name="file.name"
+          :percentage="file.percentage"
+          @remove="onRemovePreview(index, file)"
+        />
+        <file-preview
+          v-else
+          class="max-w-full"
+          :title="file.name"
+          :name="file.name"
+          :percentage="file.percentage"
+          @remove="onRemovePreview(index, file)"
+        />
+      </template>
+    </div>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ElButton, ElUpload, ElMessage, UploadFiles, UploadFile } from 'element-plus';
+import { ElButton, ElUpload, ElMessage, UploadFiles, UploadFile, UploadInstance } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { getBaseUrlPlatform } from '@/utils';
+import { getBaseUrlPlatform, isImageUrl } from '@/utils';
 import { MAESTRO_FILE_ACCEPT, MAESTRO_FILE_LIMIT } from '@/constants';
+import FilePreview from '@/components/common/FilePreview.vue';
+import ImagePreview from '@/components/common/ImagePreview.vue';
 
 interface IData {
   fileList: UploadFiles;
@@ -42,6 +64,8 @@ export default defineComponent({
   components: {
     ElUpload,
     ElButton,
+    FilePreview,
+    ImagePreview,
     FontAwesomeIcon
   },
   data(): IData {
@@ -59,15 +83,57 @@ export default defineComponent({
       };
     }
   },
+  beforeUnmount() {
+    this.fileList.forEach(this.revokeObjectUrl);
+  },
   methods: {
     onExceed() {
       ElMessage.warning(this.$t('maestro.message.uploadExceed'));
     },
-    onError() {
+    onError(_error: Error, file: UploadFile) {
+      this.revokeObjectUrl(file);
+      this.syncFileUrls();
       ElMessage.error(this.$t('maestro.message.uploadError'));
     },
-    onChange() {
-      // Only files that finished uploading have a response.file_url.
+    onFileChange(file: UploadFile) {
+      if (file.status === 'ready' && !file.url && file.raw && this.isImageFile(file)) {
+        file.url = URL.createObjectURL(file.raw);
+      }
+    },
+    onSuccess(response: any, file: UploadFile) {
+      this.revokeObjectUrl(file);
+      if (!response?.file_url) {
+        const index = this.fileList.indexOf(file);
+        if (index >= 0) {
+          this.fileList.splice(index, 1);
+        }
+        this.syncFileUrls();
+        ElMessage.error(this.$t('maestro.message.uploadError'));
+        return;
+      }
+      file.url = response.file_url;
+      file.response = response;
+      this.syncFileUrls();
+    },
+    onRemovePreview(index: number, file: UploadFile) {
+      const uploader = this.$refs.uploader as UploadInstance | undefined;
+      uploader?.abort?.(file);
+      this.revokeObjectUrl(file);
+      this.fileList.splice(index, 1);
+      this.syncFileUrls();
+    },
+    isImageFile(file: UploadFile): boolean {
+      return file.raw?.type.startsWith('image/') || isImageUrl(file.name);
+    },
+    getFileUrl(file: UploadFile): string {
+      return file.url || ((file.response as any)?.file_url as string | undefined) || '';
+    },
+    revokeObjectUrl(file: UploadFile) {
+      if (file.url?.startsWith('blob:')) {
+        URL.revokeObjectURL(file.url);
+      }
+    },
+    syncFileUrls() {
       const urls = this.fileList
         .map((file: UploadFile) => (file?.response as any)?.file_url)
         .filter((url: string | undefined): url is string => !!url);


### PR DESCRIPTION
## Summary
- replace Maestro's cramped default Element Plus file list with Nexior's shared image and file preview components
- show local image thumbnails, embedded upload progress, readable filenames, and consistent remove controls
- abort in-flight uploads on removal and clean local blob URLs across success, error, removal, and unmount paths
- keep attachment cards responsive in narrow configuration panels

## Validation
- `vitest run src/components/maestro/config/FileUrlsInput.test.ts` (7 tests)
- focused ESLint for the component and test
- `vue-tsc -b --force`
- browser harness with mixed image/audio/video files: no horizontal overflow at 400px or 280px panel widths; light and dark tokens verified

## Adversarial review (reviewer: claude-subagent, 3 rounds)
- RISK: removing a custom preview did not cancel its upload -> fixed with Element Plus `UploadInstance.abort(file)` before list removal
- RISK: local image blob URLs could leak or remain broken on error/success -> fixed cleanup on success, error, removal, and component unmount; malformed success responses are removed
- RISK: success callback could recreate a blob during the following `onChange` -> fixed with a `status === 'ready'` creation guard and covered by callback-order test
- RISK: failed file could remain after `onError` -> not adopted: Element Plus 2.10.4 `handleError` removes the file before invoking the page callback; the callback only releases the custom blob URL and syncs remaining successful URLs
- coverage findings -> addressed with seven lifecycle/rendering tests
