### PR TITLE
Fix Maestro remix reference previews

### DIFF
--- a/change/@acedatacloud-nexior-maestro-remix-reference.json
+++ b/change/@acedatacloud-nexior-maestro-remix-reference.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Show the referenced source video on Maestro remix results",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/maestro/task/Preview.test.ts
+++ b/src/components/maestro/task/Preview.test.ts
@@ -1,0 +1,202 @@
+// @vitest-environment jsdom
+import { flushPromises, shallowMount } from '@vue/test-utils';
+import { reactive } from 'vue';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ICredential, IMaestroTask } from '@/models';
+
+const maestroOperatorMock = vi.hoisted(() => ({
+  task: vi.fn()
+}));
+
+vi.mock('@/operators', () => ({
+  maestroOperator: maestroOperatorMock
+}));
+
+vi.mock('@/components/common/VideoPlayer.vue', () => ({
+  default: { name: 'VideoPlayer', template: '<div />' }
+}));
+
+import TaskPreview from './Preview.vue';
+import { clearMaestroReferenceTaskCache } from './referenceTask';
+
+const sourceTask: IMaestroTask = {
+  id: 'source-task',
+  status: 'succeeded',
+  response: {
+    success: true,
+    task_id: 'source-task',
+    data: {
+      variants: [{ lang: 'zh', output_url: 'https://cdn.example.com/source-video.mp4' }]
+    }
+  }
+};
+
+const remixTask: IMaestroTask = {
+  id: 'remix-task',
+  status: 'succeeded',
+  request: {
+    action: 'remix',
+    ref_task_id: sourceTask.id,
+    prompt: 'Make the background music quieter'
+  },
+  response: {
+    success: true,
+    task_id: 'remix-task',
+    data: { variants: [] }
+  }
+};
+
+const createMaestroState = (items: IMaestroTask[], credential?: ICredential) =>
+  reactive({
+    credential,
+    tasks: { items }
+  });
+
+const mountPreview = (
+  items: IMaestroTask[],
+  state = createMaestroState(items, { id: 'credential-1', token: 'test-token' }),
+  modelValue = remixTask
+) =>
+  shallowMount(TaskPreview, {
+    props: { modelValue },
+    global: {
+      mocks: {
+        $t: (key: string) => key,
+        $dayjs: { format: () => '' },
+        $store: {
+          state: {
+            maestro: state
+          }
+        }
+      }
+    }
+  });
+
+const expectReferenceBeforePrompt = (wrapper: ReturnType<typeof mountPreview>, selector = 'video-preview-stub') => {
+  const reference = wrapper.find(selector).element;
+  const prompt = wrapper.find('.prompt').element;
+  expect(reference.compareDocumentPosition(prompt) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+};
+
+describe('maestro/task/Preview', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+    clearMaestroReferenceTaskCache();
+  });
+
+  it('shows the referenced task output for a remix in the current history', () => {
+    const wrapper = mountPreview([sourceTask, remixTask]);
+
+    expect((wrapper.vm as unknown as { files: unknown[] }).files).toEqual([
+      {
+        url: 'https://cdn.example.com/source-video.mp4',
+        name: 'source-video.mp4',
+        kind: 'video'
+      }
+    ]);
+    expect(wrapper.findComponent({ name: 'VideoPreview' }).props('url')).toBe(
+      'https://cdn.example.com/source-video.mp4'
+    );
+    expectReferenceBeforePrompt(wrapper);
+    expect(maestroOperatorMock.task).not.toHaveBeenCalled();
+  });
+
+  it('loads the referenced task by id when it is outside the current history page', async () => {
+    maestroOperatorMock.task.mockResolvedValueOnce({ data: sourceTask });
+    const wrapper = mountPreview([remixTask]);
+
+    await flushPromises();
+
+    expect(maestroOperatorMock.task).toHaveBeenCalledWith(
+      sourceTask.id,
+      expect.objectContaining({ token: 'test-token' })
+    );
+    expect((wrapper.vm as unknown as { files: unknown[] }).files).toEqual([
+      {
+        url: 'https://cdn.example.com/source-video.mp4',
+        name: 'source-video.mp4',
+        kind: 'video'
+      }
+    ]);
+    expect(wrapper.findComponent({ name: 'VideoPreview' }).props('url')).toBe(
+      'https://cdn.example.com/source-video.mp4'
+    );
+    expectReferenceBeforePrompt(wrapper);
+  });
+
+  it('loads the reference when credentials arrive after the card mounts', async () => {
+    maestroOperatorMock.task.mockResolvedValueOnce({ data: sourceTask });
+    const state = createMaestroState([remixTask]);
+    const wrapper = mountPreview([remixTask], state);
+
+    await flushPromises();
+    expect(maestroOperatorMock.task).not.toHaveBeenCalled();
+
+    state.credential = { id: 'credential-1', token: 'late-token' };
+    await flushPromises();
+
+    expect(maestroOperatorMock.task).toHaveBeenCalledWith(
+      sourceTask.id,
+      expect.objectContaining({ token: 'late-token' })
+    );
+    expect(wrapper.findComponent({ name: 'VideoPreview' }).exists()).toBe(true);
+  });
+
+  it('ignores a stale response after the credential changes', async () => {
+    let resolveFirst: ((value: { data: IMaestroTask }) => void) | undefined;
+    maestroOperatorMock.task
+      .mockReturnValueOnce(new Promise((resolve) => (resolveFirst = resolve)))
+      .mockResolvedValueOnce({
+        data: {
+          ...sourceTask,
+          response: {
+            ...sourceTask.response!,
+            data: { variants: [{ output_url: 'https://cdn.example.com/new-credential.mp4' }] }
+          }
+        }
+      });
+    const state = createMaestroState([remixTask], { id: 'credential-1', token: 'old-token' });
+    const wrapper = mountPreview([remixTask], state);
+    await flushPromises();
+
+    state.credential = { id: 'credential-2', token: 'new-token' };
+    await flushPromises();
+    resolveFirst?.({ data: sourceTask });
+    await flushPromises();
+
+    expect(wrapper.findComponent({ name: 'VideoPreview' }).props('url')).toBe(
+      'https://cdn.example.com/new-credential.mp4'
+    );
+  });
+
+  it('surfaces exhausted retries and lets the user retry manually', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    maestroOperatorMock.task.mockRejectedValue(new Error('temporary outage'));
+    const mixedRemixTask: IMaestroTask = {
+      ...remixTask,
+      request: {
+        ...remixTask.request,
+        file_urls: ['https://cdn.example.com/uploaded-reference.jpg']
+      }
+    };
+    const state = createMaestroState([mixedRemixTask], { id: 'credential-1', token: 'test-token' });
+    const wrapper = mountPreview([mixedRemixTask], state, mixedRemixTask);
+
+    await vi.runAllTimersAsync();
+    await flushPromises();
+
+    expect(maestroOperatorMock.task).toHaveBeenCalledTimes(3);
+    expect(wrapper.findComponent({ name: 'ImagePreview' }).exists()).toBe(true);
+    expect(wrapper.find('.reference-load-failed').exists()).toBe(true);
+    expectReferenceBeforePrompt(wrapper, '.reference-load-failed');
+
+    maestroOperatorMock.task.mockReset().mockResolvedValueOnce({ data: sourceTask });
+    await wrapper.find('.reference-retry').trigger('click');
+    await flushPromises();
+
+    expect(wrapper.find('.reference-load-failed').exists()).toBe(false);
+    expect(wrapper.findComponent({ name: 'VideoPreview' }).exists()).toBe(true);
+  });
+});

--- a/src/components/maestro/task/Preview.vue
+++ b/src/components/maestro/task/Preview.vue
@@ -28,6 +28,24 @@
             </a>
           </template>
         </div>
+        <div
+          v-if="referenceLoadFailed && referenceTaskId && !referenceTask"
+          class="reference-load-failed flex items-center gap-1 mt-2 text-xs text-[var(--el-text-color-secondary)]"
+        >
+          <font-awesome-icon icon="fa-solid fa-circle-info" />
+          <span>{{ $t('maestro.name.files') }}: {{ $t('maestro.name.failure') }}</span>
+          <el-button
+            class="reference-retry"
+            size="small"
+            text
+            circle
+            :title="$t('codingBridge.session.retry')"
+            :aria-label="$t('codingBridge.session.retry')"
+            @click="retryReferenceTask"
+          >
+            <font-awesome-icon icon="fa-solid fa-rotate-right" />
+          </el-button>
+        </div>
         <p v-if="modelValue?.request?.prompt" class="prompt mt-2">
           {{ modelValue?.request?.prompt }}
           <span v-if="!isTerminal" class="progress-pct"> · {{ progressText }}</span>
@@ -168,9 +186,11 @@ import AudioPreview from '@/components/common/AudioPreview.vue';
 import VideoPreview from '@/components/common/VideoPreview.vue';
 import FilePreview from '@/components/common/FilePreview.vue';
 import { isImageUrl, isVideoUrl, isAudioUrl } from '@/utils/is';
+import { getMaestroReferenceTask } from './referenceTask';
 import ProgressSteps from './ProgressSteps.vue';
 
 const TERMINAL = ['succeeded', 'failed'];
+const REFERENCE_RETRY_DELAYS_MS = [1000, 3000];
 
 type MaestroFileKind = 'image' | 'video' | 'audio' | 'file';
 interface IMaestroInputFile {
@@ -203,7 +223,13 @@ export default defineComponent({
   },
   data() {
     return {
-      MAESTRO_LOGO
+      MAESTRO_LOGO,
+      fetchedReferenceTask: undefined as IMaestroTask | undefined,
+      fetchedReferenceKey: undefined as string | undefined,
+      referenceLoadAttempt: 0,
+      referenceLoadFailed: false,
+      referenceLoadTimer: undefined as number | undefined,
+      referenceLoadVersion: 0
     };
   },
   computed: {
@@ -211,8 +237,14 @@ export default defineComponent({
       return this.modelValue?.response?.data?.variants || [];
     },
     files(): IMaestroInputFile[] {
-      const urls = this.modelValue?.request?.file_urls || [];
-      return urls
+      const request = this.modelValue?.request;
+      const urls = [...(request?.file_urls || [])];
+      if (this.referenceTaskId) {
+        for (const variant of this.referenceTask?.response?.data?.variants || []) {
+          if (variant.output_url) urls.push(variant.output_url);
+        }
+      }
+      return [...new Set(urls)]
         .filter((url): url is string => !!url)
         .map((url) => {
           const clean = url.split('?')[0].split('#')[0];
@@ -225,6 +257,23 @@ export default defineComponent({
                 : 'file';
           return { url, name: this.fileName(clean), kind };
         });
+    },
+    referenceTaskId(): string | undefined {
+      const request = this.modelValue?.request;
+      return request?.action === MAESTRO_ACTION_REMIX ? request.ref_task_id : undefined;
+    },
+    referenceLoadKey(): string | undefined {
+      const credential = this.$store.state.maestro?.credential;
+      const token = credential?.token;
+      if (!this.referenceTaskId || !token) return undefined;
+      return JSON.stringify([this.referenceTaskId, credential?.id || credential?.user_id || token, token]);
+    },
+    referenceTask(): IMaestroTask | undefined {
+      if (!this.referenceTaskId) return undefined;
+      return (
+        this.$store.state.maestro?.tasks?.items?.find((task: IMaestroTask) => task.id === this.referenceTaskId) ||
+        (this.fetchedReferenceKey === this.referenceLoadKey ? this.fetchedReferenceTask : undefined)
+      );
     },
     isTerminal(): boolean {
       return TERMINAL.includes(this.modelValue?.status || '');
@@ -307,7 +356,60 @@ export default defineComponent({
       return out;
     }
   },
+  watch: {
+    referenceLoadKey: {
+      immediate: true,
+      handler(referenceLoadKey: string | undefined) {
+        this.resetReferenceLoad();
+        if (referenceLoadKey && !this.referenceTask) void this.loadReferenceTask(referenceLoadKey);
+      }
+    }
+  },
+  beforeUnmount() {
+    this.resetReferenceLoad();
+  },
   methods: {
+    resetReferenceLoad(): void {
+      if (this.referenceLoadTimer !== undefined) window.clearTimeout(this.referenceLoadTimer);
+      this.referenceLoadTimer = undefined;
+      this.referenceLoadVersion += 1;
+      this.referenceLoadAttempt = 0;
+      this.referenceLoadFailed = false;
+      this.fetchedReferenceTask = undefined;
+      this.fetchedReferenceKey = undefined;
+    },
+    async loadReferenceTask(referenceLoadKey: string): Promise<void> {
+      if (referenceLoadKey !== this.referenceLoadKey || this.referenceTask) return;
+      const credential = this.$store.state.maestro?.credential;
+      const token = credential?.token;
+      const taskId = this.referenceTaskId;
+      if (!taskId || !token) return;
+      const credentialKey = credential?.id || credential?.user_id || token;
+      const version = this.referenceLoadVersion;
+      this.referenceLoadAttempt += 1;
+      const task = await getMaestroReferenceTask(taskId, { token, credentialKey });
+      if (version !== this.referenceLoadVersion || referenceLoadKey !== this.referenceLoadKey) return;
+      if (task) {
+        this.fetchedReferenceTask = task;
+        this.fetchedReferenceKey = referenceLoadKey;
+        this.referenceLoadFailed = false;
+        return;
+      }
+      const retryDelay = REFERENCE_RETRY_DELAYS_MS[this.referenceLoadAttempt - 1];
+      if (retryDelay !== undefined) {
+        this.referenceLoadTimer = window.setTimeout(() => {
+          this.referenceLoadTimer = undefined;
+          void this.loadReferenceTask(referenceLoadKey);
+        }, retryDelay);
+      } else {
+        this.referenceLoadFailed = true;
+      }
+    },
+    retryReferenceTask(): void {
+      const referenceLoadKey = this.referenceLoadKey;
+      this.resetReferenceLoad();
+      if (referenceLoadKey) void this.loadReferenceTask(referenceLoadKey);
+    },
     optionLabel(prefix: string, value: string): string {
       const key = `${prefix}.${value}`;
       const label = this.$t(key) as string;

--- a/src/components/maestro/task/referenceTask.test.ts
+++ b/src/components/maestro/task/referenceTask.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IMaestroTask } from '@/models';
+
+const maestroOperatorMock = vi.hoisted(() => ({
+  task: vi.fn()
+}));
+
+vi.mock('@/operators', () => ({
+  maestroOperator: maestroOperatorMock
+}));
+
+import { clearMaestroReferenceTaskCache, getMaestroReferenceTask } from './referenceTask';
+
+const sourceTask: IMaestroTask = {
+  id: 'source-task',
+  status: 'succeeded',
+  response: { success: true, task_id: 'source-task', data: { variants: [] } }
+};
+const options = { token: 'test-token', credentialKey: 'credential-1' };
+
+describe('maestro reference task loader', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+    clearMaestroReferenceTaskCache();
+  });
+
+  it('deduplicates concurrent requests and caches the resolved task', async () => {
+    let resolveRequest: ((value: { data: IMaestroTask }) => void) | undefined;
+    maestroOperatorMock.task.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveRequest = resolve;
+      })
+    );
+
+    const first = getMaestroReferenceTask(sourceTask.id, options);
+    const second = getMaestroReferenceTask(sourceTask.id, options);
+    expect(maestroOperatorMock.task).toHaveBeenCalledTimes(1);
+    expect(maestroOperatorMock.task).toHaveBeenCalledWith(sourceTask.id, {
+      token: options.token,
+      signal: expect.any(AbortSignal)
+    });
+
+    resolveRequest?.({ data: sourceTask });
+    await expect(Promise.all([first, second])).resolves.toEqual([sourceTask, sourceTask]);
+    await expect(getMaestroReferenceTask(sourceTask.id, options)).resolves.toEqual(sourceTask);
+    expect(maestroOperatorMock.task).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not cache failures so a later caller can retry', async () => {
+    maestroOperatorMock.task.mockRejectedValueOnce(new Error('temporary')).mockResolvedValueOnce({ data: sourceTask });
+
+    await expect(getMaestroReferenceTask(sourceTask.id, options)).resolves.toBeUndefined();
+    await expect(getMaestroReferenceTask(sourceTask.id, options)).resolves.toEqual(sourceTask);
+    expect(maestroOperatorMock.task).toHaveBeenCalledTimes(2);
+  });
+
+  it('settles a stalled request and lets a later caller start a new one', async () => {
+    vi.useFakeTimers();
+    maestroOperatorMock.task.mockReturnValue(new Promise(() => undefined));
+
+    const first = getMaestroReferenceTask(sourceTask.id, options);
+    await vi.runAllTimersAsync();
+    await expect(first).resolves.toBeUndefined();
+
+    void getMaestroReferenceTask(sourceTask.id, options);
+    expect(maestroOperatorMock.task).toHaveBeenCalledTimes(2);
+  });
+
+  it('isolates cached tasks by credential', async () => {
+    maestroOperatorMock.task.mockResolvedValue({ data: sourceTask });
+
+    await getMaestroReferenceTask(sourceTask.id, options);
+    await getMaestroReferenceTask(sourceTask.id, { ...options, credentialKey: 'credential-2' });
+
+    expect(maestroOperatorMock.task).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/components/maestro/task/referenceTask.ts
+++ b/src/components/maestro/task/referenceTask.ts
@@ -1,0 +1,63 @@
+import type { IMaestroTask } from '@/models';
+import { maestroOperator } from '@/operators';
+
+const CACHE_LIMIT = 50;
+const REQUEST_TIMEOUT_MS = 10_000;
+const cache = new Map<string, IMaestroTask>();
+const inFlight = new Map<string, { controller: AbortController; promise: Promise<IMaestroTask | undefined> }>();
+
+const cacheTask = (key: string, task: IMaestroTask): void => {
+  cache.set(key, task);
+  if (cache.size > CACHE_LIMIT) {
+    const oldestKey = cache.keys().next().value;
+    if (oldestKey) cache.delete(oldestKey);
+  }
+};
+
+export async function getMaestroReferenceTask(
+  taskId: string,
+  options: { token: string; credentialKey: string }
+): Promise<IMaestroTask | undefined> {
+  const key = `${options.credentialKey}:${taskId}`;
+  const cached = cache.get(key);
+  if (cached) return cached;
+  const pending = inFlight.get(key);
+  if (pending) return pending.promise;
+
+  const controller = new AbortController();
+  let timeout: number | undefined;
+  const entry = {
+    controller,
+    promise: undefined as unknown as Promise<IMaestroTask | undefined>
+  };
+  const fetchTask = maestroOperator
+    .task(taskId, { token: options.token, signal: controller.signal })
+    .then(({ data }) => {
+      if (controller.signal.aborted) return undefined;
+      cacheTask(key, data);
+      return data;
+    })
+    .catch((error) => {
+      if (!controller.signal.aborted) console.warn('failed to load maestro remix reference task', taskId, error);
+      return undefined;
+    });
+  const timedOut = new Promise<undefined>((resolve) => {
+    timeout = window.setTimeout(() => {
+      controller.abort();
+      resolve(undefined);
+    }, REQUEST_TIMEOUT_MS);
+  });
+  entry.promise = Promise.race([fetchTask, timedOut]).finally(() => {
+    if (timeout !== undefined) window.clearTimeout(timeout);
+    if (inFlight.get(key) === entry) inFlight.delete(key);
+  });
+
+  inFlight.set(key, entry);
+  return entry.promise;
+}
+
+export function clearMaestroReferenceTaskCache(): void {
+  for (const request of inFlight.values()) request.controller.abort();
+  cache.clear();
+  inFlight.clear();
+}

--- a/src/operators/baseTaskOperator.ts
+++ b/src/operators/baseTaskOperator.ts
@@ -103,13 +103,14 @@ export class BaseTaskOperator<
     this.generatePath = paths.generatePath;
   }
 
-  async task(id: string, options: { token: string }): Promise<AxiosResponse<TTaskResponse>> {
+  async task(id: string, options: { token: string; signal?: AbortSignal }): Promise<AxiosResponse<TTaskResponse>> {
     return axios.post(
       this.tasksPath,
       { action: 'retrieve', id },
       {
         baseURL: BASE_URL_API,
-        headers: { ...TASK_HEADERS, authorization: `Bearer ${options.token}` }
+        headers: { ...TASK_HEADERS, authorization: `Bearer ${options.token}` },
+        signal: options.signal
       }
     );
   }


### PR DESCRIPTION
## Summary

- Show the referenced source video above the instruction on Maestro remix result cards.
- Resolve references from loaded history first, then use credential-scoped, deduplicated task retrieval for off-page sources.
- Add bounded retries, abortable request timeouts, stale-credential guards, and a visible manual retry state.

## Validation

- `vitest run src/components/maestro/task/Preview.test.ts src/components/maestro/task/referenceTask.test.ts` (9 tests)
- `eslint` on all changed TypeScript/Vue files
- `vue-tsc --noEmit -p tsconfig.app.json`
- `python3 scripts/check_i18n_coverage.py`
- `beachball check`
- `npm run build:web`
- Playwright desktop (1280x720) and mobile (390x844) visual checks: 50x50 reference preview above prompt, no horizontal overflow

## 🤖 对抗评审 (reviewer: claude-subagent, 3 rounds)

- RISK: transient lookup failures were permanent → 已修：3 轮有界后台重试，耗尽后显示手动重试。
- RISK: per-card lookup caused duplicate N+1 requests → 已修：credential + task ID 共享 resolved/in-flight cache。
- RISK: tests did not prove media appears before the prompt → 已修：DOM 顺序回归断言。
- RISK: branch lagged current main and could roll back merged work → 已修：rebase 到最新 `origin/main` / v3.324.14。
- RISK: credential arrival/change could skip loads or accept stale results → 已修：watch credential-aware key，版本守卫丢弃旧响应。
- RISK: retries could still end silently → 已修：失败状态可见且可手动恢复。
- RISK: uploaded `file_urls` hid the source-reference retry control → 已修：失败控件独立渲染，混合素材测试覆盖。
- RISK: stalled fetch could pin shared in-flight state forever → 已修：10 秒 `AbortController` + `Promise.race`，超时释放缓存并允许重试。
