### PR TITLE
Fix Maestro customization translations

### DIFF
--- a/change/@acedatacloud-nexior-maestro-customize-translations.json
+++ b/change/@acedatacloud-nexior-maestro-customize-translations.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Maestro: localize customization controls across all supported languages",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/scripts/check_i18n_coverage.py
+++ b/scripts/check_i18n_coverage.py
@@ -21,13 +21,14 @@ Background:
 
     - every top-level zh-CN key exists in the target file
     - each target value is an object with a non-empty `message` string
+    - selected user-facing keys are not left as English placeholders
 
   `description` is treated as advisory — a missing description does NOT
   fail the check (it's a translator hint, not user-facing copy).
 
 Exit codes:
   0 — all locales fully cover zh-CN
-  1 — at least one locale is missing keys (`::error file=…::` lines emitted)
+    1 — at least one locale fails validation (`::error file=…::` lines emitted)
 """
 
 from __future__ import annotations
@@ -40,6 +41,14 @@ from typing import Any
 REPO_ROOT = Path(__file__).resolve().parent.parent
 I18N_ROOT = REPO_ROOT / "src" / "i18n"
 BASE_LOCALE = "zh-CN"
+ENGLISH_LOCALE = "en"
+REQUIRE_LOCALIZED_MESSAGES = {
+    "maestro.json": {
+        "name.customize",
+        "description.customize.auto",
+        "description.customize.manual",
+    }
+}
 
 
 def collect_keys(data: Any) -> set[str]:
@@ -48,9 +57,23 @@ def collect_keys(data: Any) -> set[str]:
         return set()
     keys: set[str] = set()
     for k, v in data.items():
-        if isinstance(v, dict) and isinstance(v.get("message"), str):
+        message = v.get("message") if isinstance(v, dict) else None
+        if isinstance(message, str) and message.strip():
             keys.add(k)
     return keys
+
+
+def get_message(data: Any, key: str) -> str | None:
+    """Return a non-empty message string from a locale entry."""
+    if not isinstance(data, dict):
+        return None
+    entry = data.get(key)
+    if not isinstance(entry, dict):
+        return None
+    message = entry.get("message")
+    if not isinstance(message, str) or not message.strip():
+        return None
+    return message.strip()
 
 
 def main() -> int:
@@ -70,6 +93,30 @@ def main() -> int:
 
     namespaces = sorted(p.name for p in base_dir.glob("*.json"))
     failures = 0
+    english_messages: dict[str, dict[str, str]] = {}
+
+    for namespace, localized_keys in REQUIRE_LOCALIZED_MESSAGES.items():
+        en_path = I18N_ROOT / ENGLISH_LOCALE / namespace
+        if not en_path.exists():
+            failures += 1
+            rel = en_path.relative_to(REPO_ROOT)
+            print(f"::error file={rel}::missing English source file")
+            continue
+
+        en_data = json.loads(en_path.read_text(encoding="utf-8"))
+        invalid = sorted(key for key in localized_keys if get_message(en_data, key) is None)
+        if invalid:
+            failures += 1
+            rel = en_path.relative_to(REPO_ROOT)
+            preview = ", ".join(invalid)
+            print(f"::error file={rel}::missing valid English message for: {preview}")
+            continue
+
+        english_messages[namespace] = {
+            key: message
+            for key in localized_keys
+            if (message := get_message(en_data, key)) is not None
+        }
 
     for locale in locales:
         for namespace in namespaces:
@@ -99,16 +146,33 @@ def main() -> int:
                     f"::error file={rel}::missing {len(missing)} key(s) vs zh-CN: {preview}"
                 )
 
+            localized_keys = REQUIRE_LOCALIZED_MESSAGES.get(namespace, set())
+            reference_messages = english_messages.get(namespace)
+            if locale != ENGLISH_LOCALE and localized_keys and reference_messages:
+                untranslated = sorted(
+                    key
+                    for key in localized_keys
+                    if get_message(target_data, key) == reference_messages[key]
+                )
+                if untranslated:
+                    failures += 1
+                    rel = target_path.relative_to(REPO_ROOT)
+                    preview = ", ".join(untranslated)
+                    print(
+                        f"::error file={rel}::English placeholder remains for: {preview}"
+                    )
+
     if failures:
         print(
-            f"\n::error::{failures} locale/namespace pair(s) are missing keys",
+            f"\n::error::{failures} locale/namespace pair(s) failed i18n validation",
             file=sys.stderr,
         )
         return 1
 
     print(
-        f"i18n key coverage OK: {len(locales)} locale(s) "
-        f"× {len(namespaces)} namespace(s) all match zh-CN."
+        f"i18n validation OK: {len(locales)} locale(s) "
+        f"× {len(namespaces)} namespace(s) cover zh-CN; "
+        "required localized messages contain no English placeholders."
     )
     return 0
 

--- a/src/i18n/ar/maestro.json
+++ b/src/i18n/ar/maestro.json
@@ -452,15 +452,15 @@
     "description": "Changelog scenario option"
   },
   "name.customize": {
-    "message": "Customize",
+    "message": "تخصيص",
     "description": "Optional creative controls toggle"
   },
   "description.customize.auto": {
-    "message": "Auto · Maestro decides the video type, visual style, and voice.",
+    "message": "تلقائي · يحدد Maestro نوع الفيديو والأسلوب البصري ونغمة الصوت.",
     "description": "Customization disabled state"
   },
   "description.customize.manual": {
-    "message": "Choose the video type, visual style, and voice.",
+    "message": "اختر نوع الفيديو والأسلوب البصري ونغمة الصوت.",
     "description": "Customization enabled state"
   }
 }

--- a/src/i18n/de/maestro.json
+++ b/src/i18n/de/maestro.json
@@ -452,15 +452,15 @@
     "description": "Changelog scenario option"
   },
   "name.customize": {
-    "message": "Customize",
+    "message": "Anpassen",
     "description": "Optional creative controls toggle"
   },
   "description.customize.auto": {
-    "message": "Auto · Maestro decides the video type, visual style, and voice.",
+    "message": "Auto · Maestro bestimmt Videotyp, visuellen Stil und Erzählstimme.",
     "description": "Customization disabled state"
   },
   "description.customize.manual": {
-    "message": "Choose the video type, visual style, and voice.",
+    "message": "Videotyp, visuellen Stil und Erzählstimme auswählen.",
     "description": "Customization enabled state"
   }
 }

--- a/src/i18n/el/maestro.json
+++ b/src/i18n/el/maestro.json
@@ -452,15 +452,15 @@
     "description": "Changelog scenario option"
   },
   "name.customize": {
-    "message": "Customize",
+    "message": "Προσαρμογή",
     "description": "Optional creative controls toggle"
   },
   "description.customize.auto": {
-    "message": "Auto · Maestro decides the video type, visual style, and voice.",
+    "message": "Αυτόματο · Το Maestro επιλέγει τον τύπο βίντεο, το οπτικό στυλ και τον τόνο φωνής.",
     "description": "Customization disabled state"
   },
   "description.customize.manual": {
-    "message": "Choose the video type, visual style, and voice.",
+    "message": "Επιλέξτε τον τύπο βίντεο, το οπτικό στυλ και τον τόνο φωνής.",
     "description": "Customization enabled state"
   }
 }

--- a/src/i18n/es/maestro.json
+++ b/src/i18n/es/maestro.json
@@ -452,15 +452,15 @@
     "description": "Changelog scenario option"
   },
   "name.customize": {
-    "message": "Customize",
+    "message": "Personalizar",
     "description": "Optional creative controls toggle"
   },
   "description.customize.auto": {
-    "message": "Auto · Maestro decides the video type, visual style, and voice.",
+    "message": "Automático · Maestro decide el tipo de vídeo, el estilo visual y el tono de voz.",
     "description": "Customization disabled state"
   },
   "description.customize.manual": {
-    "message": "Choose the video type, visual style, and voice.",
+    "message": "Elige el tipo de vídeo, el estilo visual y el tono de voz.",
     "description": "Customization enabled state"
   }
 }

--- a/src/i18n/fi/maestro.json
+++ b/src/i18n/fi/maestro.json
@@ -452,15 +452,15 @@
     "description": "Changelog scenario option"
   },
   "name.customize": {
-    "message": "Customize",
+    "message": "Mukauta",
     "description": "Optional creative controls toggle"
   },
   "description.customize.auto": {
-    "message": "Auto · Maestro decides the video type, visual style, and voice.",
+    "message": "Automaattinen · Maestro päättää videon tyypin, visuaalisen tyylin ja ääninäytteen äänenvärin.",
     "description": "Customization disabled state"
   },
   "description.customize.manual": {
-    "message": "Choose the video type, visual style, and voice.",
+    "message": "Valitse videon tyyppi, visuaalinen tyyli ja ääninäytteen äänenväri.",
     "description": "Customization enabled state"
   }
 }

--- a/src/i18n/fr/maestro.json
+++ b/src/i18n/fr/maestro.json
@@ -452,15 +452,15 @@
     "description": "Changelog scenario option"
   },
   "name.customize": {
-    "message": "Customize",
+    "message": "Personnaliser",
     "description": "Optional creative controls toggle"
   },
   "description.customize.auto": {
-    "message": "Auto · Maestro decides the video type, visual style, and voice.",
+    "message": "Auto · Maestro choisit le type de vidéo, le style visuel et le timbre de voix.",
     "description": "Customization disabled state"
   },
   "description.customize.manual": {
-    "message": "Choose the video type, visual style, and voice.",
+    "message": "Choisissez le type de vidéo, le style visuel et le timbre de voix.",
     "description": "Customization enabled state"
   }
 }

--- a/src/i18n/it/maestro.json
+++ b/src/i18n/it/maestro.json
@@ -452,15 +452,15 @@
     "description": "Changelog scenario option"
   },
   "name.customize": {
-    "message": "Customize",
+    "message": "Personalizza",
     "description": "Optional creative controls toggle"
   },
   "description.customize.auto": {
-    "message": "Auto · Maestro decides the video type, visual style, and voice.",
+    "message": "Auto · Maestro sceglie il tipo di video, lo stile visivo e il timbro della voce.",
     "description": "Customization disabled state"
   },
   "description.customize.manual": {
-    "message": "Choose the video type, visual style, and voice.",
+    "message": "Scegli il tipo di video, lo stile visivo e il timbro della voce.",
     "description": "Customization enabled state"
   }
 }

--- a/src/i18n/ja/maestro.json
+++ b/src/i18n/ja/maestro.json
@@ -452,15 +452,15 @@
     "description": "Changelog scenario option"
   },
   "name.customize": {
-    "message": "Customize",
+    "message": "カスタマイズ",
     "description": "Optional creative controls toggle"
   },
   "description.customize.auto": {
-    "message": "Auto · Maestro decides the video type, visual style, and voice.",
+    "message": "自動 · 動画タイプ、ビジュアルスタイル、ナレーション音色は Maestro が決定します。",
     "description": "Customization disabled state"
   },
   "description.customize.manual": {
-    "message": "Choose the video type, visual style, and voice.",
+    "message": "動画タイプ、ビジュアルスタイル、ナレーション音色を選択します。",
     "description": "Customization enabled state"
   }
 }

--- a/src/i18n/ko/maestro.json
+++ b/src/i18n/ko/maestro.json
@@ -452,15 +452,15 @@
     "description": "Changelog scenario option"
   },
   "name.customize": {
-    "message": "Customize",
+    "message": "맞춤 설정",
     "description": "Optional creative controls toggle"
   },
   "description.customize.auto": {
-    "message": "Auto · Maestro decides the video type, visual style, and voice.",
+    "message": "자동 · 동영상 유형, 시각적 스타일, 내레이터 음색은 Maestro가 결정합니다.",
     "description": "Customization disabled state"
   },
   "description.customize.manual": {
-    "message": "Choose the video type, visual style, and voice.",
+    "message": "동영상 유형, 시각적 스타일, 내레이터 음색을 선택하세요.",
     "description": "Customization enabled state"
   }
 }

--- a/src/i18n/pl/maestro.json
+++ b/src/i18n/pl/maestro.json
@@ -452,15 +452,15 @@
     "description": "Changelog scenario option"
   },
   "name.customize": {
-    "message": "Customize",
+    "message": "Dostosuj",
     "description": "Optional creative controls toggle"
   },
   "description.customize.auto": {
-    "message": "Auto · Maestro decides the video type, visual style, and voice.",
+    "message": "Automatycznie · Maestro wybiera typ wideo, styl wizualny i ton głosu.",
     "description": "Customization disabled state"
   },
   "description.customize.manual": {
-    "message": "Choose the video type, visual style, and voice.",
+    "message": "Wybierz typ wideo, styl wizualny i ton głosu.",
     "description": "Customization enabled state"
   }
 }

--- a/src/i18n/pt/maestro.json
+++ b/src/i18n/pt/maestro.json
@@ -452,15 +452,15 @@
     "description": "Changelog scenario option"
   },
   "name.customize": {
-    "message": "Customize",
+    "message": "Personalizar",
     "description": "Optional creative controls toggle"
   },
   "description.customize.auto": {
-    "message": "Auto · Maestro decides the video type, visual style, and voice.",
+    "message": "Automático · O Maestro define o tipo de vídeo, o estilo visual e o timbre da narração.",
     "description": "Customization disabled state"
   },
   "description.customize.manual": {
-    "message": "Choose the video type, visual style, and voice.",
+    "message": "Escolha o tipo de vídeo, o estilo visual e o timbre da narração.",
     "description": "Customization enabled state"
   }
 }

--- a/src/i18n/ru/maestro.json
+++ b/src/i18n/ru/maestro.json
@@ -452,15 +452,15 @@
     "description": "Changelog scenario option"
   },
   "name.customize": {
-    "message": "Customize",
+    "message": "Настроить",
     "description": "Optional creative controls toggle"
   },
   "description.customize.auto": {
-    "message": "Auto · Maestro decides the video type, visual style, and voice.",
+    "message": "Авто · Maestro выбирает тип видео, визуальный стиль и тембр голоса.",
     "description": "Customization disabled state"
   },
   "description.customize.manual": {
-    "message": "Choose the video type, visual style, and voice.",
+    "message": "Выберите тип видео, визуальный стиль и тембр голоса.",
     "description": "Customization enabled state"
   }
 }

--- a/src/i18n/sr/maestro.json
+++ b/src/i18n/sr/maestro.json
@@ -452,15 +452,15 @@
     "description": "Changelog scenario option"
   },
   "name.customize": {
-    "message": "Customize",
+    "message": "Прилагоди",
     "description": "Optional creative controls toggle"
   },
   "description.customize.auto": {
-    "message": "Auto · Maestro decides the video type, visual style, and voice.",
+    "message": "Аутоматски · Maestro бира тип видеа, визуелни стил и тон гласа.",
     "description": "Customization disabled state"
   },
   "description.customize.manual": {
-    "message": "Choose the video type, visual style, and voice.",
+    "message": "Изаберите тип видеа, визуелни стил и тон гласа.",
     "description": "Customization enabled state"
   }
 }

--- a/src/i18n/sv/maestro.json
+++ b/src/i18n/sv/maestro.json
@@ -452,15 +452,15 @@
     "description": "Changelog scenario option"
   },
   "name.customize": {
-    "message": "Customize",
+    "message": "Anpassa",
     "description": "Optional creative controls toggle"
   },
   "description.customize.auto": {
-    "message": "Auto · Maestro decides the video type, visual style, and voice.",
+    "message": "Auto · Maestro väljer videotyp, visuell stil och berättarröst.",
     "description": "Customization disabled state"
   },
   "description.customize.manual": {
-    "message": "Choose the video type, visual style, and voice.",
+    "message": "Välj videotyp, visuell stil och berättarröst.",
     "description": "Customization enabled state"
   }
 }

--- a/src/i18n/uk/maestro.json
+++ b/src/i18n/uk/maestro.json
@@ -452,15 +452,15 @@
     "description": "Changelog scenario option"
   },
   "name.customize": {
-    "message": "Customize",
+    "message": "Налаштувати",
     "description": "Optional creative controls toggle"
   },
   "description.customize.auto": {
-    "message": "Auto · Maestro decides the video type, visual style, and voice.",
+    "message": "Авто · Maestro обирає тип відео, візуальний стиль і тональність озвучення.",
     "description": "Customization disabled state"
   },
   "description.customize.manual": {
-    "message": "Choose the video type, visual style, and voice.",
+    "message": "Виберіть тип відео, візуальний стиль і тональність озвучення.",
     "description": "Customization enabled state"
   }
 }

--- a/src/i18n/zh-TW/maestro.json
+++ b/src/i18n/zh-TW/maestro.json
@@ -452,15 +452,15 @@
     "description": "Changelog scenario option"
   },
   "name.customize": {
-    "message": "Customize",
+    "message": "自訂",
     "description": "Optional creative controls toggle"
   },
   "description.customize.auto": {
-    "message": "Auto · Maestro decides the video type, visual style, and voice.",
+    "message": "自動 · 由 Maestro 決定影片類型、視覺風格與配音音色。",
     "description": "Customization disabled state"
   },
   "description.customize.manual": {
-    "message": "Choose the video type, visual style, and voice.",
+    "message": "選擇影片類型、視覺風格與配音音色。",
     "description": "Customization enabled state"
   }
 }


### PR DESCRIPTION
## Summary
- replace the English backfill placeholders for Maestro customization controls with reviewed translations in all 16 non-English locales
- reuse each locale’s existing Video Type, Visual Style, and Voice Timbre terminology
- extend the existing i18n CI guard so these user-facing keys cannot silently remain identical to English
- reject missing, malformed, blank, and whitespace-padded messages with actionable CI annotations

## Root cause
PR #1246 used the mechanical i18n backfill helper to satisfy key coverage, but the English placeholders were incorrectly treated as finished translations. The existing guard checked key presence only, so it did not catch the wrong-language UI.

## Validation
- multilingual review of ar/de/el/es/fi/fr/it/ja/ko/pl/pt/ru/sr/sv/uk/zh-TW against each locale’s existing Maestro terminology
- exact English-source search: the three English messages now appear only in en/maestro.json
- positive guard: 17 locales × 44 namespaces pass
- negative fixtures: copied English, whitespace-padded English, malformed English/target entries, missing English source, and blank messages are rejected
- full Vitest suite: 24 files / 305 tests passed
- npm run build:web
- npx beachball check --branch origin/main

## 🤖 对抗评审 (reviewer: claude-subagent, 3 rounds)
- RISK: malformed or missing English/target entries could crash the guard → fixed with safe message extraction and validated one-time English preload
- RISK: blank target messages could pass collect_keys → fixed by requiring non-empty, non-whitespace messages
- RISK: whitespace-padded English placeholders could evade exact comparison → fixed by normalized comparison; negative fixture passes
- Translation review: all 16 locales accepted after aligning Finnish and Japanese voice terminology