### PR TITLE
Add independent Maestro customization toggles

### DIFF
--- a/change/@acedatacloud-nexior-maestro-field-toggles.json
+++ b/change/@acedatacloud-nexior-maestro-field-toggles.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Maestro: control video type, visual style, and voice with independent toggles",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/scripts/check_i18n_coverage.py
+++ b/scripts/check_i18n_coverage.py
@@ -45,6 +45,9 @@ ENGLISH_LOCALE = "en"
 REQUIRE_LOCALIZED_MESSAGES = {
     "maestro.json": {
         "name.customize",
+        "name.customizeScenario",
+        "name.customizeStyle",
+        "name.customizeVoice",
         "description.customize.auto",
         "description.customize.manual",
     }

--- a/src/components/maestro/ConfigPanel.vue
+++ b/src/components/maestro/ConfigPanel.vue
@@ -127,103 +127,110 @@
         </el-select>
       </div>
 
-      <!-- Optional creative controls -->
-      <div class="customize-section">
-        <div class="customize-header">
-          <div class="customize-copy">
-            <h2 class="field-title font-bold">{{ $t('maestro.name.customize') }}</h2>
-            <p class="customize-description">
-              {{ $t(customize ? 'maestro.description.customize.manual' : 'maestro.description.customize.auto') }}
-            </p>
+      <!-- Scenario (video type) -->
+      <div class="custom-field">
+        <div class="custom-field-header mb-2">
+          <div class="field-head">
+            <h2 class="field-title font-bold">{{ $t('maestro.name.customizeScenario') }}</h2>
+            <info-icon :content="$t('maestro.description.scenario')" class="ml-1" />
           </div>
-          <el-switch v-model="customize" :aria-label="$t('maestro.name.customize')" />
+          <el-switch v-model="scenarioCustomizationEnabled" :aria-label="$t('maestro.name.customizeScenario')" />
         </div>
+        <div
+          class="scenario-cards"
+          :class="{ 'is-disabled': !scenarioCustomizationEnabled }"
+          role="radiogroup"
+          :aria-label="$t('maestro.name.scenario')"
+          :aria-disabled="!scenarioCustomizationEnabled"
+        >
+          <div
+            v-for="s in MAESTRO_ALLOWED_SCENARIOS"
+            :key="s"
+            class="scenario-card"
+            :class="{
+              active: scenarioCustomizationEnabled && scenario === s,
+              disabled: !scenarioCustomizationEnabled
+            }"
+            role="radio"
+            :aria-checked="scenarioCustomizationEnabled && scenario === s"
+            :aria-disabled="!scenarioCustomizationEnabled"
+            :aria-label="$t(`maestro.option.scenario.${s}`)"
+            :tabindex="scenarioCustomizationEnabled ? 0 : -1"
+            @click="scenarioCustomizationEnabled && (scenario = s)"
+            @keydown.enter.prevent="scenarioCustomizationEnabled && (scenario = s)"
+            @keydown.space.prevent="scenarioCustomizationEnabled && (scenario = s)"
+          >
+            <div class="scenario-thumb">
+              <img :src="MAESTRO_SCENARIO_THUMBNAILS[s]" :alt="$t(`maestro.option.scenario.${s}`)" loading="lazy" />
+            </div>
+            <p class="scenario-name">{{ $t(`maestro.option.scenario.${s}`) }}</p>
+          </div>
+        </div>
+        <el-alert
+          v-if="needsVideoUpload"
+          :title="$t('maestro.message.captionsNeedVideo')"
+          type="warning"
+          :closable="false"
+          show-icon
+          class="mt-2"
+        />
+      </div>
 
-        <div v-if="customize" class="customize-fields">
-          <!-- Scenario (video type) -->
-          <div class="field-block">
-            <div class="field-head mb-2">
-              <h2 class="field-title font-bold">{{ $t('maestro.name.scenario') }}</h2>
-              <info-icon :content="$t('maestro.description.scenario')" class="ml-1" />
-            </div>
-            <div class="scenario-cards" role="radiogroup" :aria-label="$t('maestro.name.scenario')">
-              <div
-                v-for="s in MAESTRO_ALLOWED_SCENARIOS"
-                :key="s"
-                class="scenario-card"
-                :class="{ active: scenario === s }"
-                role="radio"
-                :aria-checked="scenario === s"
-                :aria-label="$t(`maestro.option.scenario.${s}`)"
-                tabindex="0"
-                @click="scenario = s"
-                @keydown.enter.prevent="scenario = s"
-                @keydown.space.prevent="scenario = s"
-              >
-                <div class="scenario-thumb">
-                  <img :src="MAESTRO_SCENARIO_THUMBNAILS[s]" :alt="$t(`maestro.option.scenario.${s}`)" loading="lazy" />
-                </div>
-                <p class="scenario-name">{{ $t(`maestro.option.scenario.${s}`) }}</p>
-              </div>
-            </div>
-            <el-alert
-              v-if="needsVideoUpload"
-              :title="$t('maestro.message.captionsNeedVideo')"
-              type="warning"
-              :closable="false"
-              show-icon
-              class="mt-2"
+      <!-- Style (visual direction) -->
+      <div class="custom-field">
+        <div class="custom-field-header mb-2">
+          <div class="field-head">
+            <h2 class="field-title font-bold">{{ $t('maestro.name.customizeStyle') }}</h2>
+            <info-icon :content="$t('maestro.description.style')" class="ml-1" />
+          </div>
+          <el-switch v-model="styleCustomizationEnabled" :aria-label="$t('maestro.name.customizeStyle')" />
+        </div>
+        <el-select
+          v-model="style"
+          class="w-full"
+          filterable
+          allow-create
+          default-first-option
+          :disabled="!styleCustomizationEnabled"
+          :aria-label="$t('maestro.name.customizeStyle')"
+          :placeholder="$t('maestro.placeholder.select')"
+        >
+          <el-option v-for="s in MAESTRO_ALLOWED_STYLES" :key="s" :label="$t(`maestro.option.style.${s}`)" :value="s" />
+        </el-select>
+      </div>
+
+      <!-- Voice (narration timbre) + preview -->
+      <div class="custom-field">
+        <div class="custom-field-header mb-2">
+          <div class="field-head">
+            <h2 class="field-title font-bold">{{ $t('maestro.name.customizeVoice') }}</h2>
+            <info-icon :content="$t('maestro.description.voice')" class="ml-1" />
+          </div>
+          <el-switch v-model="voiceCustomizationEnabled" :aria-label="$t('maestro.name.customizeVoice')" />
+        </div>
+        <div class="voice-row">
+          <el-select
+            v-model="voice"
+            class="voice-select"
+            :disabled="!voiceCustomizationEnabled"
+            :aria-label="$t('maestro.name.customizeVoice')"
+            :placeholder="$t('maestro.placeholder.select')"
+          >
+            <el-option
+              v-for="v in MAESTRO_ALLOWED_VOICES"
+              :key="v.key"
+              :label="$t(`maestro.option.voice.${v.key}`)"
+              :value="v.key"
             />
-          </div>
-
-          <!-- Style (visual direction) -->
-          <div class="field-row mt-5">
-            <div class="field-head">
-              <h2 class="field-title font-bold">{{ $t('maestro.name.style') }}</h2>
-              <info-icon :content="$t('maestro.description.style')" class="ml-1" />
-            </div>
-            <el-select
-              v-model="style"
-              class="field-control"
-              filterable
-              allow-create
-              default-first-option
-              :placeholder="$t('maestro.placeholder.select')"
-            >
-              <el-option
-                v-for="s in MAESTRO_ALLOWED_STYLES"
-                :key="s"
-                :label="$t(`maestro.option.style.${s}`)"
-                :value="s"
-              />
-            </el-select>
-          </div>
-
-          <!-- Voice (narration timbre) + preview -->
-          <div class="field-block mt-5">
-            <div class="field-head mb-2">
-              <h2 class="field-title font-bold">{{ $t('maestro.name.voice') }}</h2>
-              <info-icon :content="$t('maestro.description.voice')" class="ml-1" />
-            </div>
-            <div class="voice-row">
-              <el-select v-model="voice" class="voice-select" :placeholder="$t('maestro.placeholder.select')">
-                <el-option
-                  v-for="v in MAESTRO_ALLOWED_VOICES"
-                  :key="v.key"
-                  :label="$t(`maestro.option.voice.${v.key}`)"
-                  :value="v.key"
-                />
-              </el-select>
-              <el-button
-                class="voice-play"
-                :disabled="!currentSample"
-                :title="$t('maestro.button.preview')"
-                @click="onToggleSample"
-              >
-                <font-awesome-icon :icon="playing ? 'fa-solid fa-pause' : 'fa-solid fa-play'" />
-              </el-button>
-            </div>
-          </div>
+          </el-select>
+          <el-button
+            class="voice-play"
+            :disabled="!voiceCustomizationEnabled || !currentSample"
+            :title="$t('maestro.button.preview')"
+            @click="onToggleSample"
+          >
+            <font-awesome-icon :icon="playing ? 'fa-solid fa-pause' : 'fa-solid fa-play'" />
+          </el-button>
         </div>
       </div>
     </div>
@@ -257,7 +264,6 @@ import {
   MAESTRO_ALLOWED_SCENARIOS,
   MAESTRO_SCENARIO_THUMBNAILS,
   MAESTRO_UPLOAD_REQUIRED_SCENARIOS,
-  MAESTRO_DEFAULT_SCENARIO,
   MAESTRO_ALLOWED_STYLES,
   MAESTRO_DEFAULT_STYLE,
   MAESTRO_ALLOWED_VOICES,
@@ -329,7 +335,7 @@ export default defineComponent({
       return this.config?.ref_task_id;
     },
     needsVideoUpload(): boolean {
-      if (!this.customize) return false;
+      if (!this.scenarioCustomizationEnabled) return false;
       const scenario = this.config?.scenario;
       if (!scenario || !MAESTRO_UPLOAD_REQUIRED_SCENARIOS.includes(scenario)) return false;
       // captions post-processes a talking-head clip, so a video (not an image/audio) must be uploaded.
@@ -403,13 +409,29 @@ export default defineComponent({
         this.update({ quality: val });
       }
     },
-    customize: {
+    scenarioCustomizationEnabled: {
       get(): boolean {
-        return this.config?.customization_enabled ?? false;
+        return this.config?.scenario_customization_enabled ?? false;
+      },
+      set(val: boolean) {
+        this.update({ scenario_customization_enabled: val });
+      }
+    },
+    styleCustomizationEnabled: {
+      get(): boolean {
+        return this.config?.style_customization_enabled ?? false;
+      },
+      set(val: boolean) {
+        this.update({ style_customization_enabled: val });
+      }
+    },
+    voiceCustomizationEnabled: {
+      get(): boolean {
+        return this.config?.voice_customization_enabled ?? false;
       },
       set(val: boolean) {
         if (!val) this.stopSample();
-        this.update({ customization_enabled: val });
+        this.update({ voice_customization_enabled: val });
       }
     },
     scenario: {
@@ -425,12 +447,13 @@ export default defineComponent({
         return this.config?.style;
       },
       set(val: string) {
-        this.update({ style: val || MAESTRO_DEFAULT_STYLE });
+        const normalized = val?.trim();
+        this.update({ style: !normalized || normalized.toLowerCase() === 'auto' ? MAESTRO_DEFAULT_STYLE : normalized });
       }
     },
     voice: {
-      get(): string {
-        return this.config?.voice || MAESTRO_DEFAULT_VOICE;
+      get(): string | undefined {
+        return this.config?.voice;
       },
       set(val: string) {
         this.stopSample();
@@ -442,8 +465,11 @@ export default defineComponent({
     }
   },
   watch: {
-    customize(enabled: boolean) {
+    voiceCustomizationEnabled(enabled: boolean) {
       if (!enabled) this.stopSample();
+    },
+    voice() {
+      this.stopSample();
     }
   },
   mounted() {
@@ -452,19 +478,7 @@ export default defineComponent({
       langs: normalizeMaestroLanguages(this.config?.langs),
       aspect: this.config?.aspect ?? MAESTRO_DEFAULT_ASPECT,
       duration: this.config?.duration ?? MAESTRO_DEFAULT_DURATION,
-      quality: this.config?.quality ?? MAESTRO_DEFAULT_QUALITY,
-      customization_enabled: this.config?.customization_enabled ?? false,
-      // Drop stale persisted scenarios (e.g. the removed `slideshow`) back to the default.
-      scenario:
-        this.config?.scenario && MAESTRO_ALLOWED_SCENARIOS.includes(this.config.scenario)
-          ? this.config.scenario
-          : MAESTRO_DEFAULT_SCENARIO,
-      style: this.config?.style ?? MAESTRO_DEFAULT_STYLE,
-      // Drop a stale persisted voice not in the current catalog back to auto.
-      voice:
-        this.config?.voice && MAESTRO_ALLOWED_VOICES.some((v) => v.key === this.config!.voice)
-          ? this.config.voice
-          : MAESTRO_DEFAULT_VOICE
+      quality: this.config?.quality ?? MAESTRO_DEFAULT_QUALITY
     });
   },
   beforeUnmount() {
@@ -541,30 +555,16 @@ export default defineComponent({
 .field-control {
   width: 168px;
 }
-.customize-section {
+.custom-field {
   margin-top: 20px;
   padding-top: 16px;
   border-top: 1px solid var(--el-border-color-lighter);
 }
-.customize-header {
+.custom-field-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-}
-.customize-copy {
-  min-width: 0;
-}
-.customize-description {
-  margin: 3px 0 0;
-  color: var(--el-text-color-secondary);
-  font-size: 12px;
-  line-height: 1.4;
-}
-.customize-fields {
-  margin-top: 16px;
-  padding-top: 16px;
-  border-top: 1px solid var(--el-border-color-lighter);
 }
 .language-picker {
   display: flex;
@@ -665,8 +665,12 @@ export default defineComponent({
 }
 .scenario-cards {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 8px;
+
+  &.is-disabled {
+    opacity: 0.55;
+  }
 }
 .scenario-card {
   border: 1px solid var(--el-border-color);
@@ -706,6 +710,10 @@ export default defineComponent({
 
   &:hover {
     border-color: var(--el-color-primary-light-5);
+  }
+
+  &.disabled {
+    cursor: not-allowed;
   }
 
   &:focus-visible {

--- a/src/components/maestro/config/FileUrlsInput.test.ts
+++ b/src/components/maestro/config/FileUrlsInput.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import { reactive } from 'vue';
+import { describe, expect, it } from 'vitest';
+import FileUrlsInput from './FileUrlsInput.vue';
+
+describe('Maestro FileUrlsInput', () => {
+  it('shows and preserves existing source URLs when another file is added', async () => {
+    const state = reactive({
+      token: { access: 'token' },
+      maestro: { config: { file_urls: ['https://example.com/source.mp4'] } }
+    });
+    const commits: unknown[] = [];
+    const wrapper = shallowMount(FileUrlsInput, {
+      global: {
+        mocks: {
+          $t: (key: string) => key,
+          $store: {
+            state,
+            commit: (_type: string, payload: unknown) => commits.push(payload)
+          }
+        }
+      }
+    });
+
+    const vm = wrapper.vm as unknown as {
+      fileList: Array<{ url?: string; response?: { file_url?: string } }>;
+      onChange: () => void;
+    };
+    expect(vm.fileList).toMatchObject([{ url: 'https://example.com/source.mp4', status: 'success' }]);
+
+    vm.fileList.push({ response: { file_url: 'https://example.com/new.png' } });
+    vm.onChange();
+
+    expect(commits.at(-1)).toMatchObject({
+      file_urls: ['https://example.com/source.mp4', 'https://example.com/new.png']
+    });
+  });
+});

--- a/src/components/maestro/config/FileUrlsInput.vue
+++ b/src/components/maestro/config/FileUrlsInput.vue
@@ -57,6 +57,32 @@ export default defineComponent({
       return {
         Authorization: `Bearer ${this.$store.state.token.access}`
       };
+    },
+    value(): string[] {
+      return this.$store.state.maestro?.config?.file_urls || [];
+    }
+  },
+  watch: {
+    value: {
+      immediate: true,
+      handler(urls: string[]) {
+        const existingByUrl = new Map(
+          this.fileList.map((file) => [((file?.response as any)?.file_url as string) || file.url, file])
+        );
+        const synced = urls.map(
+          (url) =>
+            existingByUrl.get(url) ||
+            ({
+              name: url.split('/').pop() || url,
+              url,
+              status: 'success',
+              percentage: 100,
+              response: { file_url: url }
+            } as UploadFile)
+        );
+        const uploading = this.fileList.filter((file) => !((file?.response as any)?.file_url || file.url));
+        this.fileList = [...synced, ...uploading];
+      }
     }
   },
   methods: {
@@ -69,7 +95,7 @@ export default defineComponent({
     onChange() {
       // Only files that finished uploading have a response.file_url.
       const urls = this.fileList
-        .map((file: UploadFile) => (file?.response as any)?.file_url)
+        .map((file: UploadFile) => ((file?.response as any)?.file_url as string | undefined) || file.url)
         .filter((url: string | undefined): url is string => !!url);
       this.$store.commit('maestro/setConfig', {
         ...this.$store.state.maestro?.config,

--- a/src/components/maestro/task/Preview.vue
+++ b/src/components/maestro/task/Preview.vue
@@ -175,8 +175,8 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import { ElImage, ElAlert, ElButton, ElMessage } from 'element-plus';
-import { IMaestroTask, IMaestroVariant, IMaestroConfig } from '@/models';
-import { MAESTRO_LOGO, MAESTRO_ACTION_REMIX } from '@/constants';
+import { IMaestroTask, IMaestroVariant } from '@/models';
+import { MAESTRO_ACTION_REMIX, MAESTRO_LOGO } from '@/constants';
 import CopyToClipboard from '@/components/common/CopyToClipboard.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import VideoPlayer from '@/components/common/VideoPlayer.vue';
@@ -186,6 +186,7 @@ import AudioPreview from '@/components/common/AudioPreview.vue';
 import VideoPreview from '@/components/common/VideoPreview.vue';
 import FilePreview from '@/components/common/FilePreview.vue';
 import { isImageUrl, isVideoUrl, isAudioUrl } from '@/utils/is';
+import { buildMaestroRemixConfig } from '@/utils/maestro';
 import { getMaestroReferenceTask } from './referenceTask';
 import ProgressSteps from './ProgressSteps.vue';
 
@@ -260,7 +261,7 @@ export default defineComponent({
     },
     referenceTaskId(): string | undefined {
       const request = this.modelValue?.request;
-      return request?.action === MAESTRO_ACTION_REMIX ? request.ref_task_id : undefined;
+      return request?.action === MAESTRO_ACTION_REMIX ? request?.ref_task_id : undefined;
     },
     referenceLoadKey(): string | undefined {
       const credential = this.$store.state.maestro?.credential;
@@ -428,17 +429,8 @@ export default defineComponent({
       window.open(url, '_blank');
     },
     onRemix() {
-      const req = this.modelValue?.request;
-      const patch: IMaestroConfig = {
-        ...(this.$store.state.maestro?.config || {}),
-        action: MAESTRO_ACTION_REMIX,
-        ref_task_id: this.modelValue?.id,
-        prompt: '',
-        langs: req?.langs?.length ? req.langs : this.$store.state.maestro?.config?.langs,
-        aspect: req?.aspect ?? this.$store.state.maestro?.config?.aspect,
-        duration: req?.duration ?? this.$store.state.maestro?.config?.duration,
-        file_urls: []
-      };
+      if (!this.modelValue) return;
+      const patch = buildMaestroRemixConfig(this.$store.state.maestro?.config, this.modelValue);
       this.$store.commit('maestro/setConfig', patch);
       ElMessage.info(this.$t('maestro.message.remixLoaded'));
     }

--- a/src/constants/maestro.ts
+++ b/src/constants/maestro.ts
@@ -14,17 +14,16 @@ export const MAESTRO_MIN_DURATION = 1;
 export const MAESTRO_MAX_DURATION = 600;
 // Production tier (effort/price): draft = fast preview, standard = balanced, premium = richer.
 export const MAESTRO_ALLOWED_QUALITIES = ['draft', 'standard', 'premium'];
-// Video type: a routing hint. `auto` lets the director pick; the rest bias the route.
+// Video type: an optional routing hint. Omitting the field lets the director pick.
 // Legacy values (general/explainer/product/website/changelog -> auto; slides/slideshow/motion -> auto)
 // are still accepted by the API but no longer offered here.
-export const MAESTRO_ALLOWED_SCENARIOS = ['auto', 'narrated', 'drama', 'avatar', 'captions'];
+export const MAESTRO_ALLOWED_SCENARIOS = ['narrated', 'drama', 'avatar', 'captions'];
 // `captions` post-processes an EXISTING talking-head video, so it requires an uploaded source clip.
 export const MAESTRO_UPLOAD_REQUIRED_SCENARIOS = ['captions'];
 // Preview thumbnail per scenario — a cohesive set of purpose-made 3:4 portrait
 // thumbnails (subject/head in the upper frame) so each Video Type reads at a
 // glance in the compact vertical cards. Hosted on the CDN like MAESTRO_LOGO.
 export const MAESTRO_SCENARIO_THUMBNAILS: Record<string, string> = {
-  auto: 'https://cdn.acedata.cloud/58bf7feea4.jpg',
   narrated: 'https://cdn.acedata.cloud/fb12495d70.jpg',
   drama: 'https://cdn.acedata.cloud/33b9189ad0.jpg',
   avatar: 'https://cdn.acedata.cloud/540bda9cb6.jpg',
@@ -33,7 +32,6 @@ export const MAESTRO_SCENARIO_THUMBNAILS: Record<string, string> = {
 // Visual style presets — each maps to a real named capability on the backend (a visual-styles
 // identity, a palette, or a recipe like glass/retro). Freeform text still works. Orthogonal to scenario.
 export const MAESTRO_ALLOWED_STYLES = [
-  'auto',
   'cinematic',
   'glass',
   'luxury',
@@ -60,19 +58,18 @@ export const MAESTRO_DEFAULT_LANGS = ['zh-cn'];
 export const MAESTRO_DEFAULT_ASPECT = '9:16';
 export const MAESTRO_DEFAULT_DURATION = 30;
 export const MAESTRO_DEFAULT_QUALITY = 'standard';
-export const MAESTRO_DEFAULT_SCENARIO = 'auto';
-export const MAESTRO_DEFAULT_STYLE = 'auto';
+export const MAESTRO_DEFAULT_SCENARIO = 'narrated';
+export const MAESTRO_DEFAULT_STYLE = 'cinematic';
 
 // Curated narration voices → a Fish reference_id on the backend. Voice is a **timbre** and is
 // language-agnostic: the same voice speaks whatever language `langs` sets (verified live zh/en/ja),
-// so there is no per-voice language and the list is never filtered. `auto` = Maestro picks per tone.
+// so there is no per-voice language and the list is never filtered. Omitting `voice` lets Maestro pick.
 // `sample` is a short bilingual preview clip on the CDN (▶︎ 试听).
 export interface IMaestroVoiceOption {
   key: string;
   sample?: string;
 }
 export const MAESTRO_ALLOWED_VOICES: IMaestroVoiceOption[] = [
-  { key: 'auto' },
   { key: 'warm-female', sample: 'https://cdn.acedata.cloud/7b7cec364c.mp3' },
   { key: 'bright-female', sample: 'https://cdn.acedata.cloud/32ee903837.mp3' },
   { key: 'anchor-female', sample: 'https://cdn.acedata.cloud/04374b7885.mp3' },
@@ -83,4 +80,4 @@ export const MAESTRO_ALLOWED_VOICES: IMaestroVoiceOption[] = [
   { key: 'energetic-male', sample: 'https://cdn.acedata.cloud/d516b56517.mp3' },
   { key: 'storyteller-male', sample: 'https://cdn.acedata.cloud/9dfbd0ed00.mp3' }
 ];
-export const MAESTRO_DEFAULT_VOICE = 'auto';
+export const MAESTRO_DEFAULT_VOICE = 'warm-female';

--- a/src/i18n/ar/maestro.json
+++ b/src/i18n/ar/maestro.json
@@ -212,7 +212,7 @@
     "description": "Video type field"
   },
   "description.scenario": {
-    "message": "اختر نوع الفيديو المراد إنشاؤه. «تلقائي» يترك القرار لـ Maestro؛ أو حدّد نمطًا مثل دراما قصيرة أو لقطات واقعية أو شرح أو ترويج منتج.",
+    "message": "فعّل التخصيص لاختيار نوع الفيديو؛ اتركه مغلقًا ليقرر Maestro تلقائيًا.",
     "description": "Scenario field help"
   },
   "option.scenario.auto": {
@@ -244,7 +244,7 @@
     "description": "حقل الأسلوب البصري"
   },
   "description.style": {
-    "message": "نصائح أسلوب بصري اختيارية (تؤثر على الطباعة، الألوان، الحركات، الإيقاع)، مستقلة عن نوع الفيديو. يمكن اختيار إعدادات مسبقة أو إدخالها يدويًا.",
+    "message": "فعّل التخصيص لاختيار الأسلوب البصري أو إدخاله؛ اتركه مغلقًا ليقرر Maestro تلقائيًا.",
     "description": "مساعدة حقل الأسلوب"
   },
   "option.style.auto": {
@@ -320,7 +320,7 @@
     "description": "زر معاينة الصوت / تشغيل العينة"
   },
   "description.voice": {
-    "message": "اختر نغمة الصوت للراوي. النغمة غير مرتبطة باللغة - ستستخدم نفس النغمة اللغة المختارة أعلاه للقراءة؛ اضغط على التشغيل للاستماع.",
+    "message": "فعّل التخصيص لاختيار نغمة الصوت؛ اتركه مغلقًا ليختار Maestro تلقائيًا. النغمة مستقلة عن اللغة، ويمكنك الضغط على التشغيل للاستماع.",
     "description": "مساعدة حقل الصوت"
   },
   "option.voice.auto": {
@@ -474,5 +474,17 @@
   "placeholder.additionalLanguages": {
     "message": "Add output languages",
     "description": "Additional languages placeholder"
+  },
+  "name.customizeScenario": {
+    "message": "تخصيص نوع الفيديو",
+    "description": "Video type customization toggle"
+  },
+  "name.customizeStyle": {
+    "message": "تخصيص الأسلوب البصري",
+    "description": "Visual style customization toggle"
+  },
+  "name.customizeVoice": {
+    "message": "تخصيص نغمة الصوت",
+    "description": "Voice timbre customization toggle"
   }
 }

--- a/src/i18n/de/maestro.json
+++ b/src/i18n/de/maestro.json
@@ -212,7 +212,7 @@
     "description": "Video type field"
   },
   "description.scenario": {
-    "message": "Wähle die Art des Videos. Auto lässt Maestro entscheiden; oder erzwinge einen Stil wie Kurzdrama, Realaufnahmen, Erklärvideo oder Produktwerbung.",
+    "message": "Aktiviere die Anpassung, um den Videotyp auszuwählen. Ist sie ausgeschaltet, entscheidet Maestro automatisch.",
     "description": "Scenario field help"
   },
   "option.scenario.auto": {
@@ -244,7 +244,7 @@
     "description": "Feld für visuellen Stil"
   },
   "description.style": {
-    "message": "Optionale visuelle Stilhinweise (wirken sich auf Typografie, Farbgebung, Animationen, Rhythmus aus), unabhängig vom Video-Typ. Wählen Sie eine vordefinierte Einstellung oder geben Sie Ihre eigene ein.",
+    "message": "Aktiviere die Anpassung, um einen visuellen Stil auszuwählen oder einzugeben. Ist sie ausgeschaltet, entscheidet Maestro automatisch.",
     "description": "Hilfe zum Stilfeld"
   },
   "option.style.auto": {
@@ -320,7 +320,7 @@
     "description": "Button für Sprachvorschau / Abspielen einer Probe"
   },
   "description.voice": {
-    "message": "Wählen Sie den Klang der Erzählstimme. Der Klang ist unabhängig von der Sprache – derselbe Klang wird in der oben gewählten Sprache vorgelesen; klicken Sie auf Abspielen, um eine Vorschau zu hören.",
+    "message": "Aktiviere die Anpassung, um die Erzählstimme auszuwählen. Ist sie ausgeschaltet, wählt Maestro automatisch. Die Stimme ist sprachunabhängig, und du kannst sie über die Wiedergabetaste vorhören.",
     "description": "Hilfe für das Sprachfeld"
   },
   "option.voice.auto": {
@@ -474,5 +474,17 @@
   "placeholder.additionalLanguages": {
     "message": "Add output languages",
     "description": "Additional languages placeholder"
+  },
+  "name.customizeScenario": {
+    "message": "Videotyp anpassen",
+    "description": "Video type customization toggle"
+  },
+  "name.customizeStyle": {
+    "message": "Visuellen Stil anpassen",
+    "description": "Visual style customization toggle"
+  },
+  "name.customizeVoice": {
+    "message": "Erzählstimme anpassen",
+    "description": "Voice timbre customization toggle"
   }
 }

--- a/src/i18n/el/maestro.json
+++ b/src/i18n/el/maestro.json
@@ -212,7 +212,7 @@
     "description": "Video type field"
   },
   "description.scenario": {
-    "message": "Επιλέξτε τον τύπο βίντεο. Το «Αυτόματο» αφήνει το Maestro να αποφασίσει· ή επιβάλετε στυλ όπως σύντομο δράμα, πραγματικά πλάνα, επεξήγηση ή προώθηση προϊόντος.",
+    "message": "Ενεργοποιήστε την προσαρμογή για να επιλέξετε τύπο βίντεο· αφήστε την απενεργοποιημένη για να αποφασίσει αυτόματα το Maestro.",
     "description": "Scenario field help"
   },
   "option.scenario.auto": {
@@ -244,7 +244,7 @@
     "description": "Πεδίο οπτικού στυλ"
   },
   "description.style": {
-    "message": "Επιλογές οπτικού στυλ (που επηρεάζουν την τυπογραφία, τα χρώματα, τις κινήσεις, τον ρυθμό), ανεξάρτητες από τον τύπο βίντεο. Επιλογές προεπιλογής ή εισαγωγή από τον χρήστη.",
+    "message": "Ενεργοποιήστε την προσαρμογή για να επιλέξετε ή να εισαγάγετε οπτικό στυλ· αφήστε την απενεργοποιημένη για να αποφασίσει αυτόματα το Maestro.",
     "description": "Βοήθεια πεδίου στυλ"
   },
   "option.style.auto": {
@@ -320,7 +320,7 @@
     "description": "Κουμπί προεπισκόπησης φωνής / αναπαραγωγής δείγματος"
   },
   "description.voice": {
-    "message": "Επιλέξτε τον τόνο της φωνής για την αφήγηση. Ο τόνος δεν σχετίζεται με τη γλώσσα - ο ίδιος τόνος θα διαβάσει στη γλώσσα που επιλέξατε παραπάνω. Πατήστε αναπαραγωγή για προεπισκόπηση.",
+    "message": "Ενεργοποιήστε την προσαρμογή για να επιλέξετε τόνο φωνής· διαφορετικά το Maestro επιλέγει αυτόματα. Ο τόνος είναι ανεξάρτητος από τη γλώσσα και μπορείτε να τον ακούσετε με την αναπαραγωγή.",
     "description": "Βοήθεια πεδίου φωνής"
   },
   "option.voice.auto": {
@@ -474,5 +474,17 @@
   "placeholder.additionalLanguages": {
     "message": "Add output languages",
     "description": "Additional languages placeholder"
+  },
+  "name.customizeScenario": {
+    "message": "Προσαρμογή τύπου βίντεο",
+    "description": "Video type customization toggle"
+  },
+  "name.customizeStyle": {
+    "message": "Προσαρμογή οπτικού στυλ",
+    "description": "Visual style customization toggle"
+  },
+  "name.customizeVoice": {
+    "message": "Προσαρμογή τόνου φωνής",
+    "description": "Voice timbre customization toggle"
   }
 }

--- a/src/i18n/en/maestro.json
+++ b/src/i18n/en/maestro.json
@@ -231,12 +231,24 @@
     "message": "Choose the video type, visual style, and voice.",
     "description": "Customization enabled state"
   },
+  "name.customizeScenario": {
+    "message": "Customize Video Type",
+    "description": "Video type customization toggle"
+  },
+  "name.customizeStyle": {
+    "message": "Customize Visual Style",
+    "description": "Visual style customization toggle"
+  },
+  "name.customizeVoice": {
+    "message": "Customize Voice Timbre",
+    "description": "Voice timbre customization toggle"
+  },
   "name.scenario": {
     "message": "Video Type",
     "description": "Video type field"
   },
   "description.scenario": {
-    "message": "Pick the kind of video to make. Auto lets Maestro decide; or force narrated footage, short drama, a talking-head avatar, or on-screen captions.",
+    "message": "Turn on customization to choose narrated footage, short drama, a talking-head avatar, or on-screen captions. Leave it off to let Maestro decide.",
     "description": "Scenario field help"
   },
   "option.scenario.auto": {
@@ -268,7 +280,7 @@
     "description": "Visual style field"
   },
   "description.style": {
-    "message": "Optional visual-style hint (typography, palette, motion, pacing), independent of the video type. Pick a preset or type your own.",
+    "message": "Turn on customization to choose a visual-style hint (typography, palette, motion, pacing). Leave it off to let Maestro decide.",
     "description": "Style field help"
   },
   "option.style.auto": {
@@ -344,7 +356,7 @@
     "description": "Voice preview / play sample button"
   },
   "description.voice": {
-    "message": "Select the voice timbre for narration. The timbre is independent of the language — the same timbre will read in the language selected above; click play to preview.",
+    "message": "Turn on customization to choose the narration timbre; leave it off to let Maestro match one. Timbre is independent of language, and you can click play to preview.",
     "description": "Voice field help"
   },
   "option.voice.auto": {

--- a/src/i18n/es/maestro.json
+++ b/src/i18n/es/maestro.json
@@ -212,7 +212,7 @@
     "description": "Video type field"
   },
   "description.scenario": {
-    "message": "Elige el tipo de vídeo a crear. Automático deja que Maestro decida; o fuerza un estilo como drama corto, secuencia real, explicativo o promoción de producto.",
+    "message": "Activa la personalización para elegir el tipo de vídeo; déjala desactivada para que Maestro decida automáticamente.",
     "description": "Scenario field help"
   },
   "option.scenario.auto": {
@@ -244,7 +244,7 @@
     "description": "Campo de estilo visual"
   },
   "description.style": {
-    "message": "Consejos de estilo visual opcionales (aplicables a tipografía, paleta de colores, efectos y ritmo), independientes del tipo de video. Preajustes opcionales o entrada manual.",
+    "message": "Activa la personalización para elegir o escribir el estilo visual; déjala desactivada para que Maestro decida automáticamente.",
     "description": "Ayuda para el campo de estilo"
   },
   "option.style.auto": {
@@ -320,7 +320,7 @@
     "description": "Botón de vista previa de voz / reproducir muestra"
   },
   "description.voice": {
-    "message": "Selecciona el tono de la voz en off. El tono no está relacionado con el idioma: el mismo tono leerá en el idioma seleccionado arriba; haz clic en reproducir para escuchar una muestra.",
+    "message": "Activa la personalización para elegir el tono de voz; déjala desactivada para que Maestro lo elija automáticamente. El tono es independiente del idioma y puedes pulsar el botón de reproducción para escucharlo.",
     "description": "Ayuda del campo de voz"
   },
   "option.voice.auto": {
@@ -474,5 +474,17 @@
   "placeholder.additionalLanguages": {
     "message": "Add output languages",
     "description": "Additional languages placeholder"
+  },
+  "name.customizeScenario": {
+    "message": "Personalizar tipo de vídeo",
+    "description": "Video type customization toggle"
+  },
+  "name.customizeStyle": {
+    "message": "Personalizar estilo visual",
+    "description": "Visual style customization toggle"
+  },
+  "name.customizeVoice": {
+    "message": "Personalizar tono de voz",
+    "description": "Voice timbre customization toggle"
   }
 }

--- a/src/i18n/fi/maestro.json
+++ b/src/i18n/fi/maestro.json
@@ -212,7 +212,7 @@
     "description": "Video type field"
   },
   "description.scenario": {
-    "message": "Valitse luotavan videon tyyppi. Automaattinen antaa Maestron päättää; tai pakota tyyli, kuten lyhytdraama, aito kuvamateriaali, selittävä tai tuote-esittely.",
+    "message": "Ota mukautus käyttöön valitaksesi videon tyypin. Kun se on pois käytöstä, Maestro päättää automaattisesti.",
     "description": "Scenario field help"
   },
   "option.scenario.auto": {
@@ -244,7 +244,7 @@
     "description": "Visuaalisen tyylin kenttä"
   },
   "description.style": {
-    "message": "Valinnainen visuaalinen tyyli (vaikuttaa typografiaan, väreihin, animaatioihin, rytmiin), riippumaton videotyypistä. Valinnaiset esiasetukset tai oma syöttö.",
+    "message": "Ota mukautus käyttöön valitaksesi tai kirjoittaaksesi visuaalisen tyylin. Kun se on pois käytöstä, Maestro päättää automaattisesti.",
     "description": "Tyylikentän ohje"
   },
   "option.style.auto": {
@@ -320,7 +320,7 @@
     "description": "Ääninäytteen esikatselu / toisto -painike"
   },
   "description.voice": {
-    "message": "Valitse ääninäytteen äänenväri. Äänenväri ei riipu kielestä - sama äänenväri lukee valitun kielen mukaan; napsauta toistaaksesi.",
+    "message": "Ota mukautus käyttöön valitaksesi äänenvärin. Kun se on pois käytöstä, Maestro valitsee automaattisesti. Äänenväri ei riipu kielestä, ja voit kuunnella esikatselun.",
     "description": "Voice field help"
   },
   "option.voice.auto": {
@@ -474,5 +474,17 @@
   "placeholder.additionalLanguages": {
     "message": "Add output languages",
     "description": "Additional languages placeholder"
+  },
+  "name.customizeScenario": {
+    "message": "Mukauta videon tyyppiä",
+    "description": "Video type customization toggle"
+  },
+  "name.customizeStyle": {
+    "message": "Mukauta visuaalista tyyliä",
+    "description": "Visual style customization toggle"
+  },
+  "name.customizeVoice": {
+    "message": "Mukauta ääninäytteen äänenväriä",
+    "description": "Voice timbre customization toggle"
   }
 }

--- a/src/i18n/fr/maestro.json
+++ b/src/i18n/fr/maestro.json
@@ -212,7 +212,7 @@
     "description": "Video type field"
   },
   "description.scenario": {
-    "message": "Choisissez le type de vidéo à créer. Auto laisse Maestro décider ; ou imposez un style comme drame court, séquence réelle, explicatif ou promo produit.",
+    "message": "Activez la personnalisation pour choisir le type de vidéo ; laissez-la désactivée pour que Maestro décide automatiquement.",
     "description": "Scenario field help"
   },
   "option.scenario.auto": {
@@ -244,7 +244,7 @@
     "description": "Champ de style visuel"
   },
   "description.style": {
-    "message": "Options de style visuel facultatives (affectant la typographie, les couleurs, les animations, le rythme), indépendantes du type de vidéo. Préréglages optionnels ou saisie manuelle.",
+    "message": "Activez la personnalisation pour choisir ou saisir le style visuel ; laissez-la désactivée pour que Maestro décide automatiquement.",
     "description": "Aide au champ de style"
   },
   "option.style.auto": {
@@ -320,7 +320,7 @@
     "description": "Bouton d'aperçu de la voix / jouer un échantillon"
   },
   "description.voice": {
-    "message": "Choisissez le timbre de la voix pour la narration. Le timbre n'est pas lié à la langue — le même timbre lira dans la langue sélectionnée ci-dessus ; cliquez sur jouer pour écouter.",
+    "message": "Activez la personnalisation pour choisir le timbre de voix ; laissez-la désactivée pour que Maestro le sélectionne automatiquement. Le timbre est indépendant de la langue et vous pouvez cliquer sur le bouton de lecture pour le préécouter.",
     "description": "Aide pour le champ de voix"
   },
   "option.voice.auto": {
@@ -474,5 +474,17 @@
   "placeholder.additionalLanguages": {
     "message": "Add output languages",
     "description": "Additional languages placeholder"
+  },
+  "name.customizeScenario": {
+    "message": "Personnaliser le type de vidéo",
+    "description": "Video type customization toggle"
+  },
+  "name.customizeStyle": {
+    "message": "Personnaliser le style visuel",
+    "description": "Visual style customization toggle"
+  },
+  "name.customizeVoice": {
+    "message": "Personnaliser le timbre de voix",
+    "description": "Voice timbre customization toggle"
   }
 }

--- a/src/i18n/it/maestro.json
+++ b/src/i18n/it/maestro.json
@@ -212,7 +212,7 @@
     "description": "Video type field"
   },
   "description.scenario": {
-    "message": "Scegli il tipo di video da creare. Auto lascia decidere a Maestro; oppure imponi uno stile come dramma breve, riprese reali, esplicativo o promo prodotto.",
+    "message": "Attiva la personalizzazione per scegliere il tipo di video; lasciala disattivata per far decidere automaticamente a Maestro.",
     "description": "Scenario field help"
   },
   "option.scenario.auto": {
@@ -244,7 +244,7 @@
     "description": "Campo per lo stile visivo"
   },
   "description.style": {
-    "message": "Suggerimenti di stile visivo opzionali (applicabili a tipografia, colori, animazioni, ritmo), indipendenti dal tipo di video. Preset opzionali o input manuale.",
+    "message": "Attiva la personalizzazione per scegliere o inserire lo stile visivo; lasciala disattivata per far decidere automaticamente a Maestro.",
     "description": "Aiuto per il campo stile"
   },
   "option.style.auto": {
@@ -320,7 +320,7 @@
     "description": "Pulsante per la preview della voce / riproduzione del campione"
   },
   "description.voice": {
-    "message": "Seleziona il timbro della voce per la narrazione. Il timbro non è legato alla lingua: lo stesso timbro leggerà nella lingua selezionata sopra; fai clic su riproduci per ascoltare.",
+    "message": "Attiva la personalizzazione per scegliere il timbro della voce; altrimenti Maestro lo seleziona automaticamente. Il timbro è indipendente dalla lingua e puoi ascoltarne l'anteprima.",
     "description": "Aiuto per il campo della voce"
   },
   "option.voice.auto": {
@@ -474,5 +474,17 @@
   "placeholder.additionalLanguages": {
     "message": "Add output languages",
     "description": "Additional languages placeholder"
+  },
+  "name.customizeScenario": {
+    "message": "Personalizza il tipo di video",
+    "description": "Video type customization toggle"
+  },
+  "name.customizeStyle": {
+    "message": "Personalizza lo stile visivo",
+    "description": "Visual style customization toggle"
+  },
+  "name.customizeVoice": {
+    "message": "Personalizza il timbro della voce",
+    "description": "Voice timbre customization toggle"
   }
 }

--- a/src/i18n/ja/maestro.json
+++ b/src/i18n/ja/maestro.json
@@ -212,7 +212,7 @@
     "description": "Video type field"
   },
   "description.scenario": {
-    "message": "作成する動画の種類を選びます。自動では Maestro が判断します。ショートドラマ・実写映像・解説・商品PRなどのスタイルを指定することもできます。",
+    "message": "カスタマイズをオンにすると動画タイプを選択できます。オフの場合は Maestro が自動で決定します。",
     "description": "Scenario field help"
   },
   "option.scenario.auto": {
@@ -244,7 +244,7 @@
     "description": "ビジュアルスタイルフィールド"
   },
   "description.style": {
-    "message": "選択可能なビジュアルスタイルのヒント（タイポグラフィ、カラースキーム、アニメーション、リズムに影響し、ビデオタイプとは独立しています）。プリセットを選択するか、自分で入力します。",
+    "message": "カスタマイズをオンにするとビジュアルスタイルを選択または入力できます。オフの場合は Maestro が自動で決定します。",
     "description": "スタイルフィールドのヘルプ"
   },
   "option.style.auto": {
@@ -320,7 +320,7 @@
     "description": "音声プレビュー / サンプル再生ボタン"
   },
   "description.voice": {
-    "message": "ナレーションの音色を選択します。音色は言語に依存せず、同じ音色が上部で選択した言語で読み上げられます。再生をクリックして試聴できます。",
+    "message": "カスタマイズをオンにするとナレーション音色を選択できます。オフの場合は Maestro が自動で選びます。音色は言語に依存せず、再生ボタンを押して試聴できます。",
     "description": "音声フィールドのヘルプ"
   },
   "option.voice.auto": {
@@ -474,5 +474,17 @@
   "placeholder.additionalLanguages": {
     "message": "Add output languages",
     "description": "Additional languages placeholder"
+  },
+  "name.customizeScenario": {
+    "message": "動画タイプをカスタマイズ",
+    "description": "Video type customization toggle"
+  },
+  "name.customizeStyle": {
+    "message": "ビジュアルスタイルをカスタマイズ",
+    "description": "Visual style customization toggle"
+  },
+  "name.customizeVoice": {
+    "message": "ナレーション音色をカスタマイズ",
+    "description": "Voice timbre customization toggle"
   }
 }

--- a/src/i18n/ko/maestro.json
+++ b/src/i18n/ko/maestro.json
@@ -212,7 +212,7 @@
     "description": "Video type field"
   },
   "description.scenario": {
-    "message": "제작할 동영상 종류를 선택하세요. 자동은 Maestro가 결정하며, 숏드라마·실사 영상·설명·제품 홍보 등 스타일을 지정할 수도 있습니다.",
+    "message": "맞춤 설정을 켜면 동영상 유형을 선택할 수 있습니다. 끄면 Maestro가 자동으로 결정합니다.",
     "description": "Scenario field help"
   },
   "option.scenario.auto": {
@@ -244,7 +244,7 @@
     "description": "시각적 스타일 필드"
   },
   "description.style": {
-    "message": "선택 가능한 시각적 스타일 힌트(타이포그래피, 색상, 애니메이션, 리듬에 적용되며 비디오 유형과 독립적입니다). 선택된 프리셋 또는 직접 입력 가능합니다.",
+    "message": "맞춤 설정을 켜면 시각적 스타일을 선택하거나 입력할 수 있습니다. 끄면 Maestro가 자동으로 결정합니다.",
     "description": "스타일 필드 도움말"
   },
   "option.style.auto": {
@@ -320,7 +320,7 @@
     "description": "음성 미리보기 / 샘플 재생 버튼"
   },
   "description.voice": {
-    "message": "내레이터 음색을 선택하세요. 음색은 언어와 무관합니다 — 동일한 음색이 위에서 선택한 언어로 읽어줍니다; 재생을 클릭하여 미리 들을 수 있습니다.",
+    "message": "맞춤 설정을 켜면 내레이터 음색을 선택할 수 있습니다. 끄면 Maestro가 자동으로 선택합니다. 음색은 언어와 무관하며 재생 버튼을 눌러 미리 들을 수 있습니다.",
     "description": "음성 필드 도움말"
   },
   "option.voice.auto": {
@@ -474,5 +474,17 @@
   "placeholder.additionalLanguages": {
     "message": "Add output languages",
     "description": "Additional languages placeholder"
+  },
+  "name.customizeScenario": {
+    "message": "동영상 유형 맞춤 설정",
+    "description": "Video type customization toggle"
+  },
+  "name.customizeStyle": {
+    "message": "시각적 스타일 맞춤 설정",
+    "description": "Visual style customization toggle"
+  },
+  "name.customizeVoice": {
+    "message": "내레이터 음색 맞춤 설정",
+    "description": "Voice timbre customization toggle"
   }
 }

--- a/src/i18n/pl/maestro.json
+++ b/src/i18n/pl/maestro.json
@@ -212,7 +212,7 @@
     "description": "Video type field"
   },
   "description.scenario": {
-    "message": "Wybierz rodzaj tworzonego wideo. Automatyczny pozwala Maestro zdecydować; albo wymuś styl, np. krótki dramat, ujęcia rzeczywiste, objaśnienie lub promocję produktu.",
+    "message": "Włącz dostosowanie, aby wybrać typ wideo. Po wyłączeniu Maestro zdecyduje automatycznie.",
     "description": "Scenario field help"
   },
   "option.scenario.auto": {
@@ -244,7 +244,7 @@
     "description": "Pole stylu wizualnego"
   },
   "description.style": {
-    "message": "Opcjonalne wskazówki dotyczące stylu wizualnego (dotyczące typografii, kolorystyki, animacji, rytmu), niezależne od typu wideo. Opcjonalne ustawienia wstępne lub własny wpis.",
+    "message": "Włącz dostosowanie, aby wybrać lub wpisać styl wizualny. Po wyłączeniu Maestro zdecyduje automatycznie.",
     "description": "Pomoc dotycząca pola stylu"
   },
   "option.style.auto": {
@@ -320,7 +320,7 @@
     "description": "Przycisk do podglądu głosu / odtwarzania próbki"
   },
   "description.voice": {
-    "message": "Wybierz ton głosu narratora. Ton nie jest związany z językiem — ten sam ton będzie czytany w języku wybranym powyżej; kliknij odtwarzanie, aby posłuchać.",
+    "message": "Włącz dostosowanie, aby wybrać ton głosu. Po wyłączeniu Maestro dobierze go automatycznie. Ton jest niezależny od języka i można go odsłuchać.",
     "description": "Pomoc dotycząca pola głosu"
   },
   "option.voice.auto": {
@@ -474,5 +474,17 @@
   "placeholder.additionalLanguages": {
     "message": "Add output languages",
     "description": "Additional languages placeholder"
+  },
+  "name.customizeScenario": {
+    "message": "Dostosuj typ wideo",
+    "description": "Video type customization toggle"
+  },
+  "name.customizeStyle": {
+    "message": "Dostosuj styl wizualny",
+    "description": "Visual style customization toggle"
+  },
+  "name.customizeVoice": {
+    "message": "Dostosuj ton głosu",
+    "description": "Voice timbre customization toggle"
   }
 }

--- a/src/i18n/pt/maestro.json
+++ b/src/i18n/pt/maestro.json
@@ -212,7 +212,7 @@
     "description": "Video type field"
   },
   "description.scenario": {
-    "message": "Escolha o tipo de vídeo a criar. Automático deixa o Maestro decidir; ou force um estilo como drama curto, sequência real, explicativo ou promoção de produto.",
+    "message": "Ative a personalização para escolher o tipo de vídeo; deixe-a desativada para o Maestro decidir automaticamente.",
     "description": "Scenario field help"
   },
   "option.scenario.auto": {
@@ -244,7 +244,7 @@
     "description": "Campo de estilo visual"
   },
   "description.style": {
-    "message": "Dicas de estilo visual opcionais (aplicáveis à tipografia, paleta de cores, animações, ritmo), independentes do tipo de vídeo. Presets opcionais ou entrada manual.",
+    "message": "Ative a personalização para escolher ou inserir o estilo visual; deixe-a desativada para o Maestro decidir automaticamente.",
     "description": "Ajuda para o campo de estilo"
   },
   "option.style.auto": {
@@ -320,7 +320,7 @@
     "description": "Botão para prévia de voz / tocar amostra"
   },
   "description.voice": {
-    "message": "Escolha o timbre da narração. O timbre não está relacionado à língua — o mesmo timbre será lido na língua selecionada acima; clique em reproduzir para ouvir.",
+    "message": "Ative a personalização para escolher o timbre da narração; desativada, o Maestro escolhe automaticamente. O timbre independe do idioma e pode ser ouvido na prévia.",
     "description": "Ajuda do campo de voz"
   },
   "option.voice.auto": {
@@ -474,5 +474,17 @@
   "placeholder.additionalLanguages": {
     "message": "Add output languages",
     "description": "Additional languages placeholder"
+  },
+  "name.customizeScenario": {
+    "message": "Personalizar tipo de vídeo",
+    "description": "Video type customization toggle"
+  },
+  "name.customizeStyle": {
+    "message": "Personalizar estilo visual",
+    "description": "Visual style customization toggle"
+  },
+  "name.customizeVoice": {
+    "message": "Personalizar timbre da narração",
+    "description": "Voice timbre customization toggle"
   }
 }

--- a/src/i18n/ru/maestro.json
+++ b/src/i18n/ru/maestro.json
@@ -212,7 +212,7 @@
     "description": "Video type field"
   },
   "description.scenario": {
-    "message": "Выберите тип создаваемого видео. «Авто» — Maestro решит сам; либо задайте стиль: короткая драма, реальные кадры, объяснение или промо продукта.",
+    "message": "Включите настройку, чтобы выбрать тип видео. Если она выключена, Maestro решит автоматически.",
     "description": "Scenario field help"
   },
   "option.scenario.auto": {
@@ -244,7 +244,7 @@
     "description": "Поле визуального стиля"
   },
   "description.style": {
-    "message": "Дополнительные визуальные стили (для типографики, цветовой схемы, анимации, ритма), независимые от типа видео. Можно выбрать предустановленный вариант или ввести свой.",
+    "message": "Включите настройку, чтобы выбрать или ввести визуальный стиль. Если она выключена, Maestro решит автоматически.",
     "description": "Помощь по полю стиля"
   },
   "option.style.auto": {
@@ -320,7 +320,7 @@
     "description": "Кнопка предварительного прослушивания / воспроизведения образца"
   },
   "description.voice": {
-    "message": "Выберите тембр голоса для озвучивания. Тембр не зависит от языка — один и тот же тембр будет читать на языке, выбранном выше; нажмите воспроизвести, чтобы прослушать.",
+    "message": "Включите настройку, чтобы выбрать тембр голоса. Если она выключена, Maestro подберёт его автоматически. Тембр не зависит от языка, его можно прослушать.",
     "description": "Помощь по полю выбора голоса"
   },
   "option.voice.auto": {
@@ -474,5 +474,17 @@
   "placeholder.additionalLanguages": {
     "message": "Add output languages",
     "description": "Additional languages placeholder"
+  },
+  "name.customizeScenario": {
+    "message": "Настроить тип видео",
+    "description": "Video type customization toggle"
+  },
+  "name.customizeStyle": {
+    "message": "Настроить визуальный стиль",
+    "description": "Visual style customization toggle"
+  },
+  "name.customizeVoice": {
+    "message": "Настроить тембр голоса",
+    "description": "Voice timbre customization toggle"
   }
 }

--- a/src/i18n/sr/maestro.json
+++ b/src/i18n/sr/maestro.json
@@ -212,7 +212,7 @@
     "description": "Video type field"
   },
   "description.scenario": {
-    "message": "Изаберите врсту видеа. „Аутоматски“ препушта Maestro-у да одлучи; или наметните стил као што су кратка драма, стварни снимци, објашњење или промоција производа.",
+    "message": "Укључите прилагођавање да бисте изабрали тип видеа. Када је искључено, Maestro одлучује аутоматски.",
     "description": "Scenario field help"
   },
   "option.scenario.auto": {
@@ -244,7 +244,7 @@
     "description": "Поље за визуелни стил"
   },
   "description.style": {
-    "message": "Опционални визуелни стилски савети (који се односе на типографију, боје, анимације, ритам), независно од типа видеа. Опционални предлози или ручно унети.",
+    "message": "Укључите прилагођавање да бисте изабрали или унели визуелни стил. Када је искључено, Maestro одлучује аутоматски.",
     "description": "Помоћно поље за стил"
   },
   "option.style.auto": {
@@ -320,7 +320,7 @@
     "description": " dugme za pregled glasa / reprodukciju uzorka"
   },
   "description.voice": {
-    "message": "Изаберите тон гласа за нарацију. Тон није повезан са језиком — исти тон ће читати на језику изабраном горе; кликните на репродукцију за преглед.",
+    "message": "Укључите прилагођавање да бисте изабрали тон гласа. Када је искључено, Maestro га бира аутоматски. Тон не зависи од језика и може се преслушати.",
     "description": "Помоћно поље за глас"
   },
   "option.voice.auto": {
@@ -474,5 +474,17 @@
   "placeholder.additionalLanguages": {
     "message": "Add output languages",
     "description": "Additional languages placeholder"
+  },
+  "name.customizeScenario": {
+    "message": "Прилагоди тип видеа",
+    "description": "Video type customization toggle"
+  },
+  "name.customizeStyle": {
+    "message": "Прилагоди визуелни стил",
+    "description": "Visual style customization toggle"
+  },
+  "name.customizeVoice": {
+    "message": "Прилагоди тон гласа",
+    "description": "Voice timbre customization toggle"
   }
 }

--- a/src/i18n/sv/maestro.json
+++ b/src/i18n/sv/maestro.json
@@ -212,7 +212,7 @@
     "description": "Video type field"
   },
   "description.scenario": {
-    "message": "Välj typ av video att skapa. Auto låter Maestro bestämma; eller tvinga en stil som kortdrama, verkligt filmmaterial, förklarande eller produktreklam.",
+    "message": "Aktivera anpassning för att välja videotyp. När den är avstängd bestämmer Maestro automatiskt.",
     "description": "Scenario field help"
   },
   "option.scenario.auto": {
@@ -244,7 +244,7 @@
     "description": "Fält för visuell stil"
   },
   "description.style": {
-    "message": "Valfri visuell stilindikation (påverkar typografi, färgsättning, animationer, rytm), oberoende av videotyp. Välj förinställning eller ange själv.",
+    "message": "Aktivera anpassning för att välja eller ange visuell stil. När den är avstängd bestämmer Maestro automatiskt.",
     "description": "Hjälp för stilfält"
   },
   "option.style.auto": {
@@ -320,7 +320,7 @@
     "description": "Knapp för att förhandslyssna / spela upp exempel"
   },
   "description.voice": {
-    "message": "Välj röstens tonläge för berättarrösten. Tonläget är oberoende av språket — samma tonläge kommer att läsa upp på det språk som valts ovan; tryck på spela för att förhandslyssna.",
+    "message": "Aktivera anpassning för att välja berättarröst. När den är avstängd väljer Maestro automatiskt. Rösten är språkoberoende och du kan trycka på uppspelningsknappen för att provlyssna.",
     "description": "Hjälp för röstfält"
   },
   "option.voice.auto": {
@@ -474,5 +474,17 @@
   "placeholder.additionalLanguages": {
     "message": "Add output languages",
     "description": "Additional languages placeholder"
+  },
+  "name.customizeScenario": {
+    "message": "Anpassa videotyp",
+    "description": "Video type customization toggle"
+  },
+  "name.customizeStyle": {
+    "message": "Anpassa visuell stil",
+    "description": "Visual style customization toggle"
+  },
+  "name.customizeVoice": {
+    "message": "Anpassa berättarröst",
+    "description": "Voice timbre customization toggle"
   }
 }

--- a/src/i18n/uk/maestro.json
+++ b/src/i18n/uk/maestro.json
@@ -212,7 +212,7 @@
     "description": "Video type field"
   },
   "description.scenario": {
-    "message": "Виберіть тип відео. «Авто» дає змогу Maestro вирішити; або задайте стиль: коротка драма, реальні кадри, пояснення чи промо продукту.",
+    "message": "Увімкніть налаштування, щоб вибрати тип відео. Якщо його вимкнено, Maestro вирішить автоматично.",
     "description": "Scenario field help"
   },
   "option.scenario.auto": {
@@ -244,7 +244,7 @@
     "description": "Поле візуального стилю"
   },
   "description.style": {
-    "message": "Додаткові візуальні стилі (для типографіки, кольорів, анімацій, ритму), які незалежні від типу відео. Можна вибрати з наявних налаштувань або ввести власні.",
+    "message": "Увімкніть налаштування, щоб вибрати або ввести візуальний стиль. Якщо його вимкнено, Maestro вирішить автоматично.",
     "description": "Допомога для поля стилю"
   },
   "option.style.auto": {
@@ -320,7 +320,7 @@
     "description": "Кнопка для попереднього прослуховування голосу / відтворення зразка"
   },
   "description.voice": {
-    "message": "Виберіть тональність озвучення. Тональність не залежить від мови — одна й та ж тональність буде читати мовою, вибраною вище; натисніть відтворення, щоб прослухати.",
+    "message": "Увімкніть налаштування, щоб вибрати тональність озвучення. Якщо його вимкнено, Maestro підбере її автоматично. Тональність не залежить від мови, її можна прослухати.",
     "description": "Допомога для поля вибору голосу"
   },
   "option.voice.auto": {
@@ -474,5 +474,17 @@
   "placeholder.additionalLanguages": {
     "message": "Add output languages",
     "description": "Additional languages placeholder"
+  },
+  "name.customizeScenario": {
+    "message": "Налаштувати тип відео",
+    "description": "Video type customization toggle"
+  },
+  "name.customizeStyle": {
+    "message": "Налаштувати візуальний стиль",
+    "description": "Visual style customization toggle"
+  },
+  "name.customizeVoice": {
+    "message": "Налаштувати тональність озвучення",
+    "description": "Voice timbre customization toggle"
   }
 }

--- a/src/i18n/zh-CN/maestro.json
+++ b/src/i18n/zh-CN/maestro.json
@@ -231,12 +231,24 @@
     "message": "选择视频类型、视觉风格与配音音色。",
     "description": "Customization enabled state"
   },
+  "name.customizeScenario": {
+    "message": "自定义视频类型",
+    "description": "Video type customization toggle"
+  },
+  "name.customizeStyle": {
+    "message": "自定义视觉风格",
+    "description": "Visual style customization toggle"
+  },
+  "name.customizeVoice": {
+    "message": "自定义配音音色",
+    "description": "Voice timbre customization toggle"
+  },
   "name.scenario": {
     "message": "视频类型",
     "description": "Video type field"
   },
   "description.scenario": {
-    "message": "选择要制作的视频类型。自动让 Maestro 决定；也可指定图文旁白、短剧、数字人口播、字幕花字。",
+    "message": "打开自定义后可选择图文旁白、短剧、数字人口播或字幕花字；关闭则由 Maestro 自动决定。",
     "description": "Scenario field help"
   },
   "option.scenario.auto": {
@@ -268,7 +280,7 @@
     "description": "Visual style field"
   },
   "description.style": {
-    "message": "可选的视觉风格提示（作用于排版、配色、动效、节奏），与视频类型相互独立。可选预设或自行输入。",
+    "message": "打开自定义后可选择或输入视觉风格（排版、配色、动效、节奏）；关闭则由 Maestro 自动决定。",
     "description": "Style field help"
   },
   "option.style.auto": {
@@ -344,7 +356,7 @@
     "description": "Voice preview / play sample button"
   },
   "description.voice": {
-    "message": "选择旁白配音的音色。音色与语言无关——同一音色会用上方选择的语言来朗读；点播放可试听。",
+    "message": "打开自定义后可选择旁白音色；关闭则由 Maestro 自动匹配。音色与语言无关，点击播放可试听。",
     "description": "Voice field help"
   },
   "option.voice.auto": {

--- a/src/i18n/zh-TW/maestro.json
+++ b/src/i18n/zh-TW/maestro.json
@@ -212,7 +212,7 @@
     "description": "Video type field"
   },
   "description.scenario": {
-    "message": "選擇要製作的影片類型。自動讓 Maestro 決定；也可指定短劇、圖文實拍、概念講解、產品推廣等風格。",
+    "message": "開啟自訂後可選擇影片類型；關閉則由 Maestro 自動決定。",
     "description": "Scenario field help"
   },
   "option.scenario.auto": {
@@ -244,7 +244,7 @@
     "description": "視覺風格欄位"
   },
   "description.style": {
-    "message": "可選的視覺風格提示（作用於排版、配色、動效、節奏），與視頻類型相互獨立。可選預設或自行輸入。",
+    "message": "開啟自訂後可選擇或輸入視覺風格；關閉則由 Maestro 自動決定。",
     "description": "樣式欄位幫助"
   },
   "option.style.auto": {
@@ -320,7 +320,7 @@
     "description": "語音預覽 / 播放範例按鈕"
   },
   "description.voice": {
-    "message": "選擇旁白配音的音色。音色與語言無關——同一音色會用上方選擇的語言來朗讀；點播放可试听。",
+    "message": "開啟自訂後可選擇配音音色；關閉則由 Maestro 自動配對。音色與語言無關，點擊播放即可試聽。",
     "description": "語音欄位幫助"
   },
   "option.voice.auto": {
@@ -474,5 +474,17 @@
   "placeholder.additionalLanguages": {
     "message": "Add output languages",
     "description": "Additional languages placeholder"
+  },
+  "name.customizeScenario": {
+    "message": "自訂影片類型",
+    "description": "Video type customization toggle"
+  },
+  "name.customizeStyle": {
+    "message": "自訂視覺風格",
+    "description": "Visual style customization toggle"
+  },
+  "name.customizeVoice": {
+    "message": "自訂配音音色",
+    "description": "Voice timbre customization toggle"
   }
 }

--- a/src/models/maestro.ts
+++ b/src/models/maestro.ts
@@ -1,7 +1,11 @@
 export type IMaestroAction = 'generate' | 'remix' | 'edit' | 'extend';
 
 export interface IMaestroConfig {
+  /** Legacy in-memory flag; normalized into the three field flags. */
   customization_enabled?: boolean;
+  scenario_customization_enabled?: boolean;
+  style_customization_enabled?: boolean;
+  voice_customization_enabled?: boolean;
   prompt?: string;
   action?: IMaestroAction;
   ref_task_id?: string;
@@ -16,7 +20,13 @@ export interface IMaestroConfig {
   callback_url?: string;
 }
 
-export type IMaestroGenerateRequest = Omit<IMaestroConfig, 'customization_enabled'>;
+export type IMaestroGenerateRequest = Omit<
+  IMaestroConfig,
+  | 'customization_enabled'
+  | 'scenario_customization_enabled'
+  | 'style_customization_enabled'
+  | 'voice_customization_enabled'
+>;
 
 export interface IMaestroVariant {
   lang?: string;

--- a/src/store/maestro/mutations.test.ts
+++ b/src/store/maestro/mutations.test.ts
@@ -19,4 +19,26 @@ describe('Maestro config mutations', () => {
       langs: ['en']
     });
   });
+
+  it('normalizes customization config at the Vuex boundary', () => {
+    const state = initialState();
+
+    setConfig(state, {
+      scenario_customization_enabled: false,
+      style_customization_enabled: true,
+      voice_customization_enabled: true,
+      scenario: 'avatar',
+      style: ' AUTO ',
+      voice: 'unknown-voice'
+    });
+
+    expect(state.config).toEqual({
+      scenario_customization_enabled: false,
+      style_customization_enabled: true,
+      voice_customization_enabled: true,
+      style: 'cinematic',
+      voice: 'warm-female',
+      langs: ['zh-cn']
+    });
+  });
 });

--- a/src/store/maestro/mutations.ts
+++ b/src/store/maestro/mutations.ts
@@ -2,6 +2,7 @@ import { IApplication, ICredential, IMaestroConfig, IMaestroTask, IService } fro
 import { normalizeMaestroLanguages } from '@/utils/maestroLanguages';
 import initialState from './state';
 import { IMaestroState } from './models';
+import { normalizeMaestroConfig } from '@/utils/maestro';
 
 export const resetAll = (state: IMaestroState): void => {
   Object.assign(state, initialState());
@@ -24,9 +25,10 @@ export const setApplications = (state: IMaestroState, payload: IApplication[]): 
 };
 
 export const setConfig = (state: IMaestroState, payload: IMaestroConfig): void => {
+  const normalized = normalizeMaestroConfig(payload);
   state.config = {
-    ...payload,
-    langs: normalizeMaestroLanguages(payload.langs)
+    ...normalized,
+    langs: normalizeMaestroLanguages(normalized.langs)
   };
 };
 

--- a/src/utils/maestro.test.ts
+++ b/src/utils/maestro.test.ts
@@ -1,44 +1,163 @@
 import { describe, expect, it } from 'vitest';
-import { buildMaestroGenerateRequest } from './maestro';
+import { MAESTRO_ALLOWED_SCENARIOS, MAESTRO_ALLOWED_STYLES, MAESTRO_ALLOWED_VOICES } from '@/constants';
+import { buildMaestroGenerateRequest, buildMaestroRemixConfig, normalizeMaestroConfig } from './maestro';
 
 describe('buildMaestroGenerateRequest', () => {
-  it('defaults to omitting customization fields when the toggle is unset', () => {
-    expect(
-      buildMaestroGenerateRequest({
-        prompt: 'Launch video',
-        scenario: 'avatar',
-        style: 'cinematic',
-        voice: 'warm-female'
-      })
-    ).toEqual({ prompt: 'Launch video' });
-  });
+  it.each([
+    [false, false, false, {}],
+    [true, false, false, { scenario: 'avatar' }],
+    [false, true, false, { style: 'cinematic' }],
+    [false, false, true, { voice: 'warm-female' }],
+    [true, true, false, { scenario: 'avatar', style: 'cinematic' }],
+    [true, false, true, { scenario: 'avatar', voice: 'warm-female' }],
+    [false, true, true, { style: 'cinematic', voice: 'warm-female' }],
+    [true, true, true, { scenario: 'avatar', style: 'cinematic', voice: 'warm-female' }]
+  ])(
+    'sends only independently enabled fields (%s, %s, %s)',
+    (scenarioEnabled, styleEnabled, voiceEnabled, expected) => {
+      expect(
+        buildMaestroGenerateRequest({
+          customization_enabled: true,
+          scenario_customization_enabled: scenarioEnabled,
+          style_customization_enabled: styleEnabled,
+          voice_customization_enabled: voiceEnabled,
+          prompt: 'Launch video',
+          scenario: 'avatar',
+          style: 'cinematic',
+          voice: 'warm-female'
+        })
+      ).toEqual({ prompt: 'Launch video', ...expected });
+    }
+  );
 
-  it('omits customization fields while customization is disabled', () => {
+  it('replaces legacy auto values with real options when field toggles are explicitly enabled', () => {
     expect(
       buildMaestroGenerateRequest({
-        customization_enabled: false,
-        prompt: 'Launch video',
-        scenario: 'avatar',
-        style: 'cinematic',
-        voice: 'warm-female'
-      })
-    ).toEqual({ prompt: 'Launch video' });
-  });
-
-  it('includes customization fields while customization is enabled', () => {
-    expect(
-      buildMaestroGenerateRequest({
-        customization_enabled: true,
-        prompt: 'Launch video',
-        scenario: 'avatar',
-        style: 'cinematic',
-        voice: 'warm-female'
+        scenario_customization_enabled: true,
+        style_customization_enabled: true,
+        voice_customization_enabled: true,
+        scenario: 'auto',
+        style: 'auto',
+        voice: 'auto'
       })
     ).toEqual({
-      prompt: 'Launch video',
-      scenario: 'avatar',
+      scenario: 'narrated',
       style: 'cinematic',
       voice: 'warm-female'
     });
+  });
+
+  it('migrates the legacy global flag without turning legacy auto values into selections', () => {
+    expect(
+      normalizeMaestroConfig({
+        customization_enabled: true,
+        scenario: ' AUTO ',
+        style: 'Auto',
+        voice: 'auto '
+      })
+    ).toEqual({
+      scenario_customization_enabled: false,
+      style_customization_enabled: false,
+      voice_customization_enabled: false
+    });
+  });
+
+  it('infers field toggles from an existing task request', () => {
+    expect(
+      normalizeMaestroConfig({
+        scenario: 'captions',
+        style: 'cinematic',
+        voice: 'warm-female',
+        file_urls: ['https://example.com/source.mp4']
+      })
+    ).toEqual({
+      scenario_customization_enabled: true,
+      style_customization_enabled: true,
+      voice_customization_enabled: true,
+      scenario: 'captions',
+      style: 'cinematic',
+      voice: 'warm-female',
+      file_urls: ['https://example.com/source.mp4']
+    });
+  });
+
+  it('normalizes preset casing and preserves a raw Fish reference id', () => {
+    expect(
+      normalizeMaestroConfig({
+        scenario: 'Avatar',
+        voice: 'ABCDEF0123456789ABCDEF0123456789'
+      })
+    ).toMatchObject({
+      scenario_customization_enabled: true,
+      voice_customization_enabled: true,
+      scenario: 'avatar',
+      voice: 'abcdef0123456789abcdef0123456789'
+    });
+  });
+
+  it('clears a field value when its independent toggle is disabled', () => {
+    expect(
+      normalizeMaestroConfig({
+        scenario_customization_enabled: false,
+        style_customization_enabled: true,
+        voice_customization_enabled: false,
+        scenario: 'avatar',
+        style: 'editorial',
+        voice: 'warm-female'
+      })
+    ).toEqual({
+      scenario_customization_enabled: false,
+      style_customization_enabled: true,
+      voice_customization_enabled: false,
+      style: 'editorial'
+    });
+  });
+
+  it('preserves the source video when remixing a captions task', () => {
+    expect(
+      buildMaestroRemixConfig(undefined, {
+        id: 'captions-task',
+        request: {
+          scenario: 'captions',
+          file_urls: ['https://example.com/source.mp4']
+        }
+      })
+    ).toMatchObject({
+      action: 'remix',
+      ref_task_id: 'captions-task',
+      scenario_customization_enabled: true,
+      scenario: 'captions',
+      file_urls: ['https://example.com/source.mp4']
+    });
+  });
+
+  it('drops stale auto and unknown values when remixing', () => {
+    const result = buildMaestroRemixConfig(undefined, {
+      id: 'legacy-task',
+      request: {
+        scenario: ' AUTO ',
+        style: 'Auto',
+        voice: 'unknown-voice'
+      }
+    });
+
+    expect(result).toEqual({
+      action: 'remix',
+      ref_task_id: 'legacy-task',
+      prompt: '',
+      langs: undefined,
+      aspect: undefined,
+      duration: undefined,
+      file_urls: [],
+      scenario_customization_enabled: false,
+      style_customization_enabled: false,
+      voice_customization_enabled: false
+    });
+  });
+
+  it('does not expose auto in any customization control', () => {
+    expect(MAESTRO_ALLOWED_SCENARIOS).not.toContain('auto');
+    expect(MAESTRO_ALLOWED_STYLES).not.toContain('auto');
+    expect(MAESTRO_ALLOWED_VOICES.map((voice) => voice.key)).not.toContain('auto');
   });
 });

--- a/src/utils/maestro.ts
+++ b/src/utils/maestro.ts
@@ -1,15 +1,94 @@
-import { IMaestroConfig, IMaestroGenerateRequest } from '@/models';
+import { IMaestroConfig, IMaestroGenerateRequest, IMaestroTask } from '@/models';
+import {
+  MAESTRO_ACTION_REMIX,
+  MAESTRO_ALLOWED_SCENARIOS,
+  MAESTRO_ALLOWED_VOICES,
+  MAESTRO_DEFAULT_SCENARIO,
+  MAESTRO_DEFAULT_STYLE,
+  MAESTRO_DEFAULT_VOICE
+} from '@/constants';
+
+const explicitValue = (value: string | undefined): string | undefined => {
+  const normalized = value?.trim();
+  return normalized && normalized.toLowerCase() !== 'auto' ? normalized : undefined;
+};
+
+const FISH_REFERENCE_ID = /^[0-9a-f]{32}$/;
+
+export function normalizeMaestroConfig(config?: IMaestroConfig): IMaestroConfig {
+  const source = config ?? {};
+  const {
+    customization_enabled: legacyCustomizationEnabled,
+    scenario_customization_enabled: scenarioFlag,
+    style_customization_enabled: styleFlag,
+    voice_customization_enabled: voiceFlag,
+    scenario: rawScenario,
+    style: rawStyle,
+    voice: rawVoice,
+    ...rest
+  } = source;
+  const scenario = explicitValue(rawScenario)?.toLowerCase();
+  const style = explicitValue(rawStyle);
+  const voice = explicitValue(rawVoice)?.toLowerCase();
+  const validScenario = scenario && MAESTRO_ALLOWED_SCENARIOS.includes(scenario) ? scenario : undefined;
+  const validStyle = style;
+  const validVoice =
+    voice && (MAESTRO_ALLOWED_VOICES.some((option) => option.key === voice) || FISH_REFERENCE_ID.test(voice))
+      ? voice
+      : undefined;
+  const hasLegacyFlag = typeof legacyCustomizationEnabled === 'boolean';
+  const legacyEnabled = legacyCustomizationEnabled === true;
+  const scenarioEnabled = scenarioFlag ?? (hasLegacyFlag ? legacyEnabled && !!validScenario : !!validScenario);
+  const styleEnabled = styleFlag ?? (hasLegacyFlag ? legacyEnabled && !!validStyle : !!validStyle);
+  const voiceEnabled = voiceFlag ?? (hasLegacyFlag ? legacyEnabled && !!validVoice : !!validVoice);
+
+  return {
+    ...rest,
+    scenario_customization_enabled: scenarioEnabled,
+    style_customization_enabled: styleEnabled,
+    voice_customization_enabled: voiceEnabled,
+    ...(scenarioEnabled ? { scenario: validScenario ?? MAESTRO_DEFAULT_SCENARIO } : {}),
+    ...(styleEnabled ? { style: validStyle ?? MAESTRO_DEFAULT_STYLE } : {}),
+    ...(voiceEnabled ? { voice: validVoice ?? MAESTRO_DEFAULT_VOICE } : {})
+  };
+}
+
+export function buildMaestroRemixConfig(config: IMaestroConfig | undefined, task: IMaestroTask): IMaestroConfig {
+  const request = task.request;
+  return normalizeMaestroConfig({
+    ...(config || {}),
+    action: MAESTRO_ACTION_REMIX,
+    ref_task_id: task.id,
+    prompt: '',
+    langs: request?.langs?.length ? request.langs : config?.langs,
+    aspect: request?.aspect ?? config?.aspect,
+    duration: request?.duration ?? config?.duration,
+    scenario_customization_enabled: undefined,
+    style_customization_enabled: undefined,
+    voice_customization_enabled: undefined,
+    scenario: request?.scenario,
+    style: request?.style,
+    voice: request?.voice,
+    file_urls: explicitValue(request?.scenario)?.toLowerCase() === 'captions' ? request?.file_urls || [] : []
+  });
+}
 
 export function buildMaestroGenerateRequest(config?: IMaestroConfig): IMaestroGenerateRequest {
-  const source = config ?? {};
-  const { customization_enabled: customizationEnabled, scenario, style, voice, ...request } = source;
-
-  if (!customizationEnabled) return request;
+  const source = normalizeMaestroConfig(config);
+  const {
+    scenario_customization_enabled: scenarioCustomizationEnabled,
+    style_customization_enabled: styleCustomizationEnabled,
+    voice_customization_enabled: voiceCustomizationEnabled,
+    scenario,
+    style,
+    voice,
+    ...request
+  } = source;
 
   return {
     ...request,
-    ...(scenario !== undefined ? { scenario } : {}),
-    ...(style !== undefined ? { style } : {}),
-    ...(voice !== undefined ? { voice } : {})
+    ...(scenarioCustomizationEnabled && scenario ? { scenario } : {}),
+    ...(styleCustomizationEnabled && style ? { style } : {}),
+    ...(voiceCustomizationEnabled && voice ? { voice } : {})
   };
 }


### PR DESCRIPTION
## Summary
- replace Maestro's single global customization switch with independent toggles for Video Type, Visual Style, and Voice Timbre
- keep each control visible but disabled until its own toggle is enabled; disabled fields are omitted independently from generation requests
- remove `auto` from all three selectors; enabling a field starts from a real option (`narrated`, `cinematic`, or `warm-female`)
- normalize legacy global-toggle and `auto` state at the Vuex/request boundary without forcing old users into explicit selections
- preserve and display source video URLs when remixing captions tasks

## UX
- each field is titled “Customize Video Type”, “Customize Visual Style”, or “Customize Voice Timbre”, with its toggle on the right
- four video types render as a 2×2 grid; style and voice selects remain disabled and unselected while their toggles are off
- verified with the real ConfigPanel at desktop and 390px mobile widths: toggles operate independently, no visible `Auto`, and no horizontal overflow
- all 18 locales include native field titles and updated help copy explaining that an off toggle lets Maestro decide

## Compatibility
- request serialization strips all UI-only flags and sends only independently enabled fields
- legacy `auto` values, casing, whitespace, unknown presets, freeform styles, and 32-hex Fish voice reference IDs are normalized defensively
- Remix infers toggles from actual task fields; captions Remix retains its source video
- desktop/mobile duplicate panels stop stale voice previews when shared voice state changes

## Validation
- focused Maestro tests: 4 files / 24 tests passed
- full Vitest suite: 31 files / 343 tests passed
- `npm run lint:check`
- `npx vue-tsc -b --force`
- `npm run build:web` (`built in 4.18s`)
- `python3 scripts/check_i18n_coverage.py` (17 locales × 44 namespaces)
- `npx beachball check --branch origin/main`

## 🤖 对抗评审 (reviewer: claude-subagent, 3 rounds)
- RISK: stale/legacy values and Remix could bypass independent toggle semantics → fixed by central normalization at the Vuex and request boundaries, with exact tests
- RISK: captions Remix could lose or hide its source video → fixed by retaining task URLs and syncing existing URLs into the upload list
- RISK: backend-compatible voice values and stale `auto` casing could be mishandled → fixed by normalized preset validation plus 32-hex Fish reference support
- RISK: duplicate responsive panels could keep stale audio and non-English help still referenced Auto → fixed shared-state audio cleanup and reviewed locale copy
- Final round: `VERDICT: CLEAN`
