### PR TITLE
Match purchase previews to effective markup

### DIFF
--- a/change/@acedatacloud-nexior-35e4d02a-e82c-4e15-8da4-bd02c8d2dea0.json
+++ b/change/@acedatacloud-nexior-35e4d02a-e82c-4e15-8da4-bd02c8d2dea0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Align purchase previews with effective site and service markup while failing closed when pricing is unavailable.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/models/application.ts
+++ b/src/models/application.ts
@@ -27,6 +27,9 @@ export interface IApplication {
   created_at?: string;
   updated_at?: string;
   expired_at?: string;
+  // Final request-site markup resolved by PlatformBackend using
+  // per-service override > site-wide default > 0.
+  effective_markup_ratio?: number;
   // Set by the backend (PR #540) when the current user is a grantee on this
   // application rather than its owner. Used to skip auto-createCredential and
   // to surface a "Shared" badge in the UI.

--- a/src/pages/console/application/Extra.vue
+++ b/src/pages/console/application/Extra.vue
@@ -12,6 +12,12 @@
             <el-row>
               <el-col :span="16" :offset="4">
                 <el-skeleton v-if="loading" />
+                <div v-else-if="loadFailed" class="text-center">
+                  <el-empty :description="$t('common.message.noData')" />
+                  <el-button type="primary" round @click="onFetchApplication">
+                    {{ $t('common.button.refresh') }}
+                  </el-button>
+                </div>
                 <el-empty v-else-if="!showPayment" :description="$t('common.message.noData')" />
                 <el-form v-else-if="application" label-width="100px">
                   <div v-if="!application?.service">
@@ -27,7 +33,7 @@
                     {{ $t('application.title.globalBuy') }}
                   </el-form-item>
                   <el-form-item :label="$t('application.field.package')" class="mb-0">
-                    <el-radio-group v-if="packages" v-model="form.packageId">
+                    <el-radio-group v-if="packages.length > 0" v-model="form.packageId">
                       <el-radio-button v-for="(pkg, pkgIndex) in packages" :key="pkgIndex" :label="pkg.id" class="mb-2">
                         <span v-show="pkgIndex !== 0" class="corner">
                           {{ getDiscount(pkg) }}
@@ -35,6 +41,7 @@
                         {{ pkg.amount }} {{ $t(`service.unit.${application?.service?.unit || 'credit'}s`) }}
                       </el-radio-button>
                     </el-radio-group>
+                    <el-empty v-else :description="$t('common.message.noData')" :image-size="48" />
                   </el-form-item>
                   <el-form-item
                     v-if="
@@ -45,24 +52,27 @@
                     <service-estimation v-if="application?.service" :service="application.service" :package="package" />
                   </el-form-item>
                   <el-form-item :label="$t('service.field.price')">
-                    <price :price="displayPackagePrice" />
-                    <span v-if="package" class="ml-2"
-                      >({{
-                        getPriceString({ value: displayUnitPrice }) +
-                        ' / ' +
-                        $t(`service.unit.${application?.service?.unit || 'credits'}`)
-                      }})
-                    </span>
+                    <template v-if="package && pricingAvailable">
+                      <price :price="displayPackagePrice" />
+                      <span v-if="package" class="ml-2"
+                        >({{
+                          getPriceString({ value: displayUnitPrice }) +
+                          ' / ' +
+                          $t(`service.unit.${application?.service?.unit || 'credits'}`)
+                        }})
+                      </span>
+                    </template>
+                    <span v-else class="text-[var(--el-text-color-secondary)]">{{ $t('common.message.noData') }}</span>
                   </el-form-item>
                   <el-divider border-style="dashed" />
                   <el-form-item :label="$t('application.field.shouldPayPrice')">
                     <span
-                      v-if="package"
+                      v-if="package && pricingAvailable"
                       :class="{ price: true, unfree: package?.price > 0, free: package?.price === 0 }"
                     >
                       {{ getPriceString({ value: displayPackagePrice }) }}
                     </span>
-                    <span v-else :class="{ price: true, free: true }"> $ 0 </span>
+                    <span v-else class="text-[var(--el-text-color-secondary)]">{{ $t('common.message.noData') }}</span>
                   </el-form-item>
                   <el-form-item>
                     <el-button
@@ -71,6 +81,7 @@
                       size="large"
                       class="btn-create"
                       :loading="creating"
+                      :disabled="!pricingAvailable || !package"
                       round
                       @click="onCreateOrder"
                     >
@@ -114,7 +125,7 @@ import {
 import { ROUTE_CONSOLE_APPLICATION_SUBSCRIBE, ROUTE_CONSOLE_ORDER_DETAIL } from '@/router';
 import Price from '@/components/common/Price.vue';
 import { applicationOperator, orderOperator } from '@/operators';
-import { getPriceString, applyMarkup, getSiteMarkupRatio } from '@/utils';
+import { getPriceString, applyMarkup, getApplicationMarkupRatio } from '@/utils';
 import { isIOS } from '@/utils';
 import { track } from '@/plugins/telemetry';
 import ServiceEstimation from '@/components/service/Estimation.vue';
@@ -122,6 +133,7 @@ import ServiceEstimation from '@/components/service/Estimation.vue';
 interface IData {
   application: IApplication | undefined;
   loading: boolean;
+  loadFailed: boolean;
   form: {
     amount: number | undefined;
     packageId: string | undefined;
@@ -153,6 +165,7 @@ export default defineComponent({
       lang: this.$i18n.locale,
       application: undefined,
       loading: false,
+      loadFailed: false,
       type: IPackageType.USAGE,
       form: {
         packageId: undefined,
@@ -203,17 +216,23 @@ export default defineComponent({
     site() {
       return this.$store.getters.site;
     },
-    markupRatio(): number {
-      return getSiteMarkupRatio(this.site);
+    markupRatio(): number | undefined {
+      return getApplicationMarkupRatio(this.application, this.site);
     },
-    // Displayed prices carry the site-wide markup so the sub-site figure equals
-    // what the gateway charges at order time; undefined until a package is
-    // selected (mirrors the original `package?.price` binding).
+    pricingAvailable(): boolean {
+      return this.markupRatio !== undefined;
+    },
+    // Backend-resolved markup keeps this preview aligned with order billing
+    // when a service overrides the site-wide default.
     displayPackagePrice(): number | undefined {
-      return this.package ? applyMarkup(this.package.price, this.markupRatio) : undefined;
+      return this.package && this.markupRatio !== undefined
+        ? applyMarkup(this.package.price, this.markupRatio)
+        : undefined;
     },
     displayUnitPrice(): number | undefined {
-      return this.package ? applyMarkup(this.package.price, this.markupRatio) / this.package.amount : undefined;
+      return this.package && this.markupRatio !== undefined
+        ? applyMarkup(this.package.price, this.markupRatio) / this.package.amount
+        : undefined;
     }
   },
   mounted() {
@@ -245,6 +264,7 @@ export default defineComponent({
     getPriceString,
     onFetchApplication() {
       this.loading = true;
+      this.loadFailed = false;
       applicationOperator
         .get(this.id)
         .then(({ data: data }: { data: IApplicationDetailResponse }) => {
@@ -255,6 +275,7 @@ export default defineComponent({
         })
         .catch(() => {
           this.loading = false;
+          this.loadFailed = true;
         });
     },
     onChangeType() {
@@ -264,7 +285,7 @@ export default defineComponent({
       });
     },
     onCreateOrder() {
-      if (!this.application?.id) {
+      if (!this.application?.id || !this.pricingAvailable || !this.package) {
         return;
       }
       this.creating = true;

--- a/src/pages/console/application/Subscribe.vue
+++ b/src/pages/console/application/Subscribe.vue
@@ -18,6 +18,12 @@
                   {{ $t('console.subscription.title') }}
                 </p>
                 <el-skeleton v-if="loading" />
+                <div v-else-if="loadFailed" class="text-center">
+                  <el-empty :description="$t('common.message.noData')" />
+                  <el-button type="primary" round @click="onInitialize">
+                    {{ $t('common.button.refresh') }}
+                  </el-button>
+                </div>
                 <el-row v-else :gutter="15" class="subscriptions">
                   <el-col
                     v-for="(item, index) in subscriptions"
@@ -27,15 +33,22 @@
                   >
                     <el-card
                       shadow="hover"
-                      :class="{ subscription: true, active: subscription?.name === item.name }"
-                      @click="subscription = item"
+                      :class="{
+                        subscription: true,
+                        active: subscription?.name === item.name,
+                        disabled: !item.available
+                      }"
+                      @click="item.available && (subscription = item)"
                     >
                       <h4 class="name">
                         {{ item.label }}
                         <el-tag v-if="item.tag" type="warning">{{ item.tag }}</el-tag>
                       </h4>
                       <h2 class="price">
-                        {{ getPriceString({ value: item.price }) }}
+                        <template v-if="item.price !== undefined">{{ getPriceString({ value: item.price }) }}</template>
+                        <span v-else class="text-[var(--el-text-color-secondary)]">{{
+                          $t('common.message.noData')
+                        }}</span>
                       </h2>
                       <p class="description">{{ item.description }}</p>
                       <div class="benefits">
@@ -50,6 +63,7 @@
                           v-if="showPayment"
                           class="btn btn-subscribe"
                           :type="subscription?.name === item?.name ? 'primary' : ''"
+                          :disabled="!item.available"
                           round
                           @click="onCreateOrder(item)"
                           >{{ $t('common.button.buy') }}</el-button
@@ -58,7 +72,7 @@
                     </el-card>
                   </el-col>
                 </el-row>
-                <div v-if="!loading && showPayment" class="extra">
+                <div v-if="!loading && !loadFailed && showPayment" class="extra">
                   <span>{{ $t('console.message.doNotWantSubscribe') }}</span>
                   <el-button type="primary" class="btn btn-extra" round size="small" @click="onBuyExtra">
                     {{ $t('console.message.buyExtra') }}
@@ -78,7 +92,7 @@ import { defineComponent } from 'vue';
 import { IService, IApplication, IApplicationType, IOrderDetailResponse, IPackageType, IPackage } from '@/models';
 import { ElRow, ElCol, ElCard, ElSkeleton, ElMessage, ElButton, ElTag, ElEmpty } from 'element-plus';
 import { applicationOperator, orderOperator, serviceOperator } from '@/operators';
-import { getPriceString, applyMarkup, getSiteMarkupRatio } from '@/utils';
+import { getPriceString, applyMarkup, getApplicationMarkupRatio } from '@/utils';
 import { isIOS } from '@/utils';
 import { track } from '@/plugins/telemetry';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
@@ -92,6 +106,7 @@ interface ISubscription {
   duration: number;
   benefits?: { enabled: boolean; content: string }[];
   description?: string;
+  available?: boolean;
 }
 
 interface IData {
@@ -100,6 +115,7 @@ interface IData {
   services: IService[];
   type: string;
   loading: boolean;
+  loadFailed: boolean;
   creating: boolean;
   subscription: ISubscription | undefined;
 }
@@ -124,6 +140,7 @@ export default defineComponent({
       type: IApplicationType.PERIOD,
       services: [],
       loading: false,
+      loadFailed: false,
       creating: false,
       subscription: undefined
     };
@@ -140,6 +157,12 @@ export default defineComponent({
     // displaying non-IAP paid content, not just the purchase action.
     showPayment(): boolean {
       return !isIOS();
+    },
+    effectiveMarkupRatio(): number | undefined {
+      return getApplicationMarkupRatio(this.application2, this.site);
+    },
+    pricingAvailable(): boolean {
+      return this.effectiveMarkupRatio !== undefined;
     },
     subscriptions(): ISubscription[] {
       const items: ISubscription[] = [
@@ -167,11 +190,10 @@ export default defineComponent({
         console.log('item', item);
         const pkgs = this.getPackages(item.duration);
         console.log('pkgs', pkgs);
-        if (pkgs) {
+        item.available = pkgs.length > 0 && this.effectiveMarkupRatio !== undefined;
+        if (item.available) {
           const subtotal = pkgs.reduce((acc, pkg) => acc + pkg.price, 0);
-          // Display the marked-up price so the sub-site card matches what the
-          // gateway charges at order time (backend re-applies the same markup).
-          item.price = applyMarkup(subtotal, getSiteMarkupRatio(this.site));
+          item.price = applyMarkup(subtotal, this.effectiveMarkupRatio!);
         }
         for (const pkg of pkgs) {
           if (!item.benefits) {
@@ -198,15 +220,24 @@ export default defineComponent({
     }
   },
   async mounted() {
-    this.loading = true;
-    await this.onFetchApplication();
-    // fetch the real period application
-    await this.onFetchApplication2();
-    await this.onCreateApplications();
-    this.loading = false;
-    this.subscription = this.subscriptions[2];
+    await this.onInitialize();
   },
   methods: {
+    async onInitialize() {
+      this.loading = true;
+      this.loadFailed = false;
+      try {
+        await this.onFetchApplication();
+        // Fetch or create the Period Application used by order creation.
+        await this.onFetchApplication2();
+        await this.onCreateApplications();
+        this.subscription = this.subscriptions.find((item) => item.available);
+      } catch {
+        this.loadFailed = true;
+      } finally {
+        this.loading = false;
+      }
+    },
     getPriceString,
     onBuyExtra() {
       this.$router.push({
@@ -280,6 +311,8 @@ export default defineComponent({
       console.debug('application2', this.application2);
     },
     onCreateOrder(subscription: ISubscription) {
+      const packages = this.getPackages(subscription.duration);
+      if (!this.pricingAvailable || !subscription.available || packages.length === 0) return;
       this.subscription = subscription;
       this.creating = true;
       if (!this.application2 || !this.application2.id) {
@@ -295,7 +328,7 @@ export default defineComponent({
       orderOperator
         .create({
           application_ids: [this.application2.id],
-          package_ids: this.getPackages(subscription.duration).map((p) => p.id),
+          package_ids: packages.map((p) => p.id),
           description: this.service?.title + ' - ' + subscription.label
         })
         .then(({ data: data }: { data: IOrderDetailResponse }) => {

--- a/src/pages/console/application/pricingContract.test.ts
+++ b/src/pages/console/application/pricingContract.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const readSibling = (name: string): string => readFileSync(fileURLToPath(new URL(name, import.meta.url)), 'utf8');
+
+describe('application purchase pricing contract', () => {
+  it.each(['Extra.vue', 'Subscribe.vue'])('%s uses the backend-resolved Application markup', (file) => {
+    const source = readSibling(file);
+    expect(source).toContain('getApplicationMarkupRatio');
+    expect(source).not.toContain('getSiteMarkupRatio(');
+  });
+
+  it('subscription preview uses the same Period Application as order creation', () => {
+    const source = readSibling('Subscribe.vue');
+    expect(source).toContain('getApplicationMarkupRatio(this.application2, this.site)');
+    expect(source).toContain('application_ids: [this.application2.id]');
+  });
+
+  it('usage checkout requires a selected compatible package', () => {
+    const source = readSibling('Extra.vue');
+    expect(source).toContain(':disabled="!pricingAvailable || !package"');
+    expect(source).toContain('!this.pricingAvailable || !this.package');
+  });
+
+  it('subscription checkout rejects unsupported durations', () => {
+    const source = readSibling('Subscribe.vue');
+    expect(source).toContain('packages.length === 0');
+    expect(source).toContain(':disabled="!item.available"');
+    expect(source).toContain('package_ids: packages.map((p) => p.id)');
+  });
+
+  it.each(['Extra.vue', 'Subscribe.vue'])('%s exposes a retryable load-failure state', (file) => {
+    const source = readSibling(file);
+    expect(source).toContain('v-else-if="loadFailed"');
+    expect(source).toContain("$t('common.button.refresh')");
+  });
+
+  it('subscription initialization always clears loading', () => {
+    const source = readSibling('Subscribe.vue');
+    expect(source).toContain('finally {');
+    expect(source).toContain('this.loading = false');
+  });
+});

--- a/src/utils/site.test.ts
+++ b/src/utils/site.test.ts
@@ -1,6 +1,13 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { getSiteOrigin, getSiteMarkupRatio, applyMarkup, isBrandingHidden, getBrandSupportUrl } from './site';
+import {
+  getSiteOrigin,
+  getSiteMarkupRatio,
+  getApplicationMarkupRatio,
+  applyMarkup,
+  isBrandingHidden,
+  getBrandSupportUrl
+} from './site';
 
 /**
  * getSiteOrigin must treat desktop (Electron, app://bundle authority "bundle")
@@ -52,6 +59,41 @@ describe('getSiteMarkupRatio', () => {
   it('ignores a non-"all" applies_to (only v1 "all" is honored)', () => {
     expect(getSiteMarkupRatio({ metadata: { pricing: { markup_ratio: 0.3, applies_to: 'foo' } } } as never)).toBe(0);
     expect(getSiteMarkupRatio({ metadata: { pricing: { markup_ratio: 0.3, applies_to: 'all' } } } as never)).toBe(0.3);
+  });
+});
+
+describe('getApplicationMarkupRatio', () => {
+  const site = { id: 'site-1', metadata: { pricing: { markup_ratio: 0.1 } } } as never;
+
+  it('prefers the backend-resolved service markup', () => {
+    expect(getApplicationMarkupRatio({ effective_markup_ratio: 0.3 }, site)).toBe(0.3);
+  });
+
+  it('preserves an explicit zero override', () => {
+    expect(getApplicationMarkupRatio({ effective_markup_ratio: 0 }, site)).toBe(0);
+  });
+
+  it('does not guess a service price when an older backend omits the field', () => {
+    expect(getApplicationMarkupRatio({ service_id: 'service-1' }, site)).toBeUndefined();
+    expect(getApplicationMarkupRatio({ service: { id: 'service-1' } } as never, site)).toBeUndefined();
+    expect(getApplicationMarkupRatio(undefined, site)).toBeUndefined();
+  });
+
+  it('safely falls back for global applications', () => {
+    expect(getApplicationMarkupRatio({}, site)).toBe(0.1);
+  });
+
+  it('does not quote a global price before Site bootstrap succeeds', () => {
+    expect(getApplicationMarkupRatio({}, {} as never)).toBeUndefined();
+    expect(getApplicationMarkupRatio({}, undefined)).toBeUndefined();
+  });
+
+  it('defensively clamps malformed backend values', () => {
+    expect(getApplicationMarkupRatio({ effective_markup_ratio: -1 }, site)).toBeUndefined();
+    expect(getApplicationMarkupRatio({ effective_markup_ratio: 9 }, site)).toBe(5);
+    expect(
+      getApplicationMarkupRatio({ service_id: 'service-1', effective_markup_ratio: Number.NaN }, site)
+    ).toBeUndefined();
   });
 });
 

--- a/src/utils/site.ts
+++ b/src/utils/site.ts
@@ -1,4 +1,4 @@
-import { ISite } from '@/models';
+import { IApplication, ISite } from '@/models';
 import { v4 as uuid } from 'uuid';
 import { BASE_HOST_HUB } from '@/constants/endpoint';
 import { isNative, isDesktop } from './surface';
@@ -104,6 +104,27 @@ export const getSiteMarkupRatio = (site?: ISite | null): number => {
   const raw = pricing.markup_ratio;
   if (typeof raw !== 'number' || !Number.isFinite(raw)) return 0;
   if (raw < MARKUP_RATIO_MIN) return 0;
+  if (raw > MARKUP_RATIO_MAX) return MARKUP_RATIO_MAX;
+  return raw;
+};
+
+/**
+ * Use the backend's order-consistent per-service markup when available.
+ * Individual-service applications fail closed when an older backend omits the
+ * field; only global applications fall back because their order pricing uses
+ * the site-wide default directly.
+ */
+export const getApplicationMarkupRatio = (
+  application?: IApplication | null,
+  site?: ISite | null
+): number | undefined => {
+  if (!application) return undefined;
+  const raw = application?.effective_markup_ratio;
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) {
+    const hasService = !!(application.service_id || application.service?.id);
+    return hasService || !site?.id ? undefined : getSiteMarkupRatio(site);
+  }
+  if (raw < MARKUP_RATIO_MIN) return undefined;
   if (raw > MARKUP_RATIO_MAX) return MARKUP_RATIO_MAX;
   return raw;
 };


### PR DESCRIPTION
## Depends on
- https://github.com/AceDataCloud/PlatformBackend/pull/958 must merge and deploy first; this PR fails closed for individual-service pricing until the backend field is available

## Summary
- consume backend-resolved `effective_markup_ratio` so usage and subscription previews match Order charging
- preserve explicit zero overrides and refuse to guess individual-service prices from old backend responses
- require loaded Site state before global fallback, and show retryable unavailable states on pricing 503s
- disable checkout when no compatible package/duration exists; subscription preview and order both use the Period Application

## Validation
- focused pricing and checkout tests: 27 passed
- touched-file ESLint
- `vue-tsc -b --force`
- `npm run build:web`
- i18n validation and Beachball check

## Adversarial review (claude-subagent, 3 rounds)
- RISK: old-backend fallback could underquote -> individual apps fail closed; only loaded-Site global apps fall back
- RISK: Subscribe used Usage Application while order used Period Application -> aligned both to `application2`
- RISK: missing packages could appear as free purchases -> unavailable cards/buttons plus method-level guards
- RISK: pricing 503 left permanent skeleton -> retryable load-failure state with `finally` cleanup
- RISK: unresolved Site produced zero global quote -> fallback requires `site.id`
- Final re-review: VERDICT CLEAN
