### PR TITLE
feat(chat): show scheduled task outcomes

### DIFF
--- a/change/@acedatacloud-nexior-2f1d9034-51fa-42d5-9f73-85f3019c8874.json
+++ b/change/@acedatacloud-nexior-2f1d9034-51fa-42d5-9f73-85f3019c8874.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Show verified scheduled-task outcomes, completion rules, and recovery actions.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/ScheduledOutcomeStatus.test.ts
+++ b/src/components/chat/ScheduledOutcomeStatus.test.ts
@@ -1,0 +1,22 @@
+// @vitest-environment jsdom
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import ScheduledOutcomeStatus from './ScheduledOutcomeStatus.vue';
+
+describe('ScheduledOutcomeStatus', () => {
+  it.each([
+    ['success', 'fa-solid fa-circle-check'],
+    ['failed', 'fa-solid fa-circle-exclamation'],
+    ['needs_user_input', 'fa-solid fa-triangle-exclamation'],
+    ['unknown', 'fa-solid fa-clock'],
+    ['unverified', 'fa-solid fa-circle-info'],
+    ['running', 'fa-solid fa-spinner']
+  ] as const)('renders a distinct icon for %s', (status, icon) => {
+    const wrapper = shallowMount(ScheduledOutcomeStatus, {
+      props: { status, reason: 'Reason from server' },
+      global: { mocks: { $t: (key: string) => key } }
+    });
+    expect(wrapper.findComponent({ name: 'FontAwesomeIcon' }).attributes('icon')).toBe(icon);
+    expect(wrapper.text()).toContain('Reason from server');
+  });
+});

--- a/src/components/chat/ScheduledOutcomeStatus.vue
+++ b/src/components/chat/ScheduledOutcomeStatus.vue
@@ -1,0 +1,115 @@
+<template>
+  <div class="scheduled-outcome" :class="[`status-${status}`, { compact }]" role="status">
+    <div class="outcome-heading">
+      <font-awesome-icon :icon="statusIcon" :spin="status === 'running'" class="outcome-icon" aria-hidden="true" />
+      <span class="outcome-label">{{ $t(`chat.scheduledTasks.run.${status}`) }}</span>
+    </div>
+    <div v-if="reason" class="outcome-reason">{{ reason }}</div>
+    <div v-if="$slots.default" class="outcome-actions"><slot /></div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, type PropType } from 'vue';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import type { ScheduledOutcomeStatus } from '@/operators/scheduledTasks';
+
+const STATUS_ICONS: Record<ScheduledOutcomeStatus, string> = {
+  queued: 'fa-solid fa-spinner',
+  running: 'fa-solid fa-spinner',
+  success: 'fa-solid fa-circle-check',
+  failed: 'fa-solid fa-circle-exclamation',
+  needs_user_input: 'fa-solid fa-triangle-exclamation',
+  unknown: 'fa-solid fa-clock',
+  unverified: 'fa-solid fa-circle-info'
+};
+
+export default defineComponent({
+  name: 'ScheduledOutcomeStatus',
+  components: { FontAwesomeIcon },
+  props: {
+    status: {
+      type: String as PropType<ScheduledOutcomeStatus>,
+      required: true
+    },
+    reason: {
+      type: String,
+      default: ''
+    },
+    compact: {
+      type: Boolean,
+      default: false
+    }
+  },
+  computed: {
+    statusIcon(): string {
+      return STATUS_ICONS[this.status];
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.scheduled-outcome {
+  --outcome-color: var(--el-text-color-secondary);
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 4px 10px;
+  min-width: 0;
+  color: var(--outcome-color);
+}
+.outcome-heading {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 650;
+  white-space: nowrap;
+}
+.outcome-icon {
+  width: 15px;
+  flex: none;
+}
+.outcome-reason {
+  min-width: 0;
+  color: var(--el-text-color-secondary);
+  line-height: 1.45;
+  word-break: break-word;
+}
+.outcome-actions {
+  grid-column: 2;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin-top: 4px;
+}
+.compact {
+  display: inline-flex;
+  gap: 7px;
+  max-width: 100%;
+  font-size: 12px;
+}
+.compact .outcome-reason {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.status-success {
+  --outcome-color: var(--el-color-success);
+}
+.status-failed {
+  --outcome-color: var(--el-color-danger);
+}
+.status-needs_user_input {
+  --outcome-color: var(--el-color-warning);
+}
+.status-unknown {
+  --outcome-color: var(--el-color-primary);
+}
+.status-unverified,
+.status-queued,
+.status-running {
+  --outcome-color: var(--el-text-color-secondary);
+}
+</style>

--- a/src/i18n/ar/chat.json
+++ b/src/i18n/ar/chat.json
@@ -1006,5 +1006,95 @@
   "artifacts.hiddenBadge": {
     "message": "Hidden",
     "description": "Badge shown on artifacts that are currently hidden"
+  },
+  "scheduledTasks.actionError": {
+    "message": "Action failed. Refresh and try again."
+  },
+  "scheduledTasks.confirmPublished": {
+    "message": "It was published"
+  },
+  "scheduledTasks.confirmPublishedPrompt": {
+    "message": "Paste the public article URL from the target platform."
+  },
+  "scheduledTasks.confirmNotPublished": {
+    "message": "It was not published"
+  },
+  "scheduledTasks.confirmNotPublishedPrompt": {
+    "message": "Confirm that no article was published. You can retry this run afterward."
+  },
+  "scheduledTasks.confirmSuccess": {
+    "message": "The run result has been updated."
+  },
+  "scheduledTasks.articleUrlInvalid": {
+    "message": "Enter a valid HTTPS article URL."
+  },
+  "scheduledTasks.openArticle": {
+    "message": "Open article"
+  },
+  "scheduledTasks.retry": {
+    "message": "Retry now"
+  },
+  "scheduledTasks.retrySuccess": {
+    "message": "Retry started."
+  },
+  "scheduledTasks.resume": {
+    "message": "Resume task"
+  },
+  "scheduledTasks.resumeSuccess": {
+    "message": "Task resumed from its next future schedule."
+  },
+  "scheduledTasks.run.unknown": {
+    "message": "Needs confirmation"
+  },
+  "scheduledTasks.run.unverified": {
+    "message": "Unverified"
+  },
+  "scheduledTasks.form.completionRule": {
+    "message": "Completion"
+  },
+  "scheduledTasks.form.completionRuleLoading": {
+    "message": "Determining the completion rule…"
+  },
+  "scheduledTasks.form.completionRuleAuto": {
+    "message": "Determined automatically"
+  },
+  "scheduledTasks.form.completionRuleUser": {
+    "message": "Corrected by you"
+  },
+  "scheduledTasks.form.completionRuleCorrect": {
+    "message": "Correct"
+  },
+  "scheduledTasks.form.completionRuleAutoOption": {
+    "message": "Automatic"
+  },
+  "scheduledTasks.form.completionRuleAnswer": {
+    "message": "Generate a complete final answer"
+  },
+  "scheduledTasks.form.completionRuleArticle": {
+    "message": "Publish an article"
+  },
+  "scheduledTasks.form.completionRuleArticleChannel": {
+    "message": "Publish an article to {channel} and obtain its public URL"
+  },
+  "scheduledTasks.form.completionRuleUnknown": {
+    "message": "Completion rule not confirmed"
+  },
+  "scheduledTasks.form.completionRuleUserReason": {
+    "message": "This rule will be used for future runs until you restore automatic detection."
+  },
+  "scheduledTasks.form.completionRulePrompt": {
+    "message": "Enter the task prompt to determine how completion should be verified."
+  },
+  "scheduledTasks.form.completionRuleInferenceError": {
+    "message": "Automatic detection is temporarily unavailable. Please choose a rule."
+  },
+  "scheduledTasks.form.completionRuleRequired": {
+    "message": "Confirm how this task should be considered complete."
+  },
+  "scheduledTasks.form.channelZhihu": {
+    "message": "Zhihu"
+  },
+  "scheduledTasks.form.channelCsdn": {
+    "message": "CSDN"
   }
 }

--- a/src/i18n/de/chat.json
+++ b/src/i18n/de/chat.json
@@ -1006,5 +1006,95 @@
   "artifacts.hiddenBadge": {
     "message": "Hidden",
     "description": "Badge shown on artifacts that are currently hidden"
+  },
+  "scheduledTasks.actionError": {
+    "message": "Action failed. Refresh and try again."
+  },
+  "scheduledTasks.confirmPublished": {
+    "message": "It was published"
+  },
+  "scheduledTasks.confirmPublishedPrompt": {
+    "message": "Paste the public article URL from the target platform."
+  },
+  "scheduledTasks.confirmNotPublished": {
+    "message": "It was not published"
+  },
+  "scheduledTasks.confirmNotPublishedPrompt": {
+    "message": "Confirm that no article was published. You can retry this run afterward."
+  },
+  "scheduledTasks.confirmSuccess": {
+    "message": "The run result has been updated."
+  },
+  "scheduledTasks.articleUrlInvalid": {
+    "message": "Enter a valid HTTPS article URL."
+  },
+  "scheduledTasks.openArticle": {
+    "message": "Open article"
+  },
+  "scheduledTasks.retry": {
+    "message": "Retry now"
+  },
+  "scheduledTasks.retrySuccess": {
+    "message": "Retry started."
+  },
+  "scheduledTasks.resume": {
+    "message": "Resume task"
+  },
+  "scheduledTasks.resumeSuccess": {
+    "message": "Task resumed from its next future schedule."
+  },
+  "scheduledTasks.run.unknown": {
+    "message": "Needs confirmation"
+  },
+  "scheduledTasks.run.unverified": {
+    "message": "Unverified"
+  },
+  "scheduledTasks.form.completionRule": {
+    "message": "Completion"
+  },
+  "scheduledTasks.form.completionRuleLoading": {
+    "message": "Determining the completion rule…"
+  },
+  "scheduledTasks.form.completionRuleAuto": {
+    "message": "Determined automatically"
+  },
+  "scheduledTasks.form.completionRuleUser": {
+    "message": "Corrected by you"
+  },
+  "scheduledTasks.form.completionRuleCorrect": {
+    "message": "Correct"
+  },
+  "scheduledTasks.form.completionRuleAutoOption": {
+    "message": "Automatic"
+  },
+  "scheduledTasks.form.completionRuleAnswer": {
+    "message": "Generate a complete final answer"
+  },
+  "scheduledTasks.form.completionRuleArticle": {
+    "message": "Publish an article"
+  },
+  "scheduledTasks.form.completionRuleArticleChannel": {
+    "message": "Publish an article to {channel} and obtain its public URL"
+  },
+  "scheduledTasks.form.completionRuleUnknown": {
+    "message": "Completion rule not confirmed"
+  },
+  "scheduledTasks.form.completionRuleUserReason": {
+    "message": "This rule will be used for future runs until you restore automatic detection."
+  },
+  "scheduledTasks.form.completionRulePrompt": {
+    "message": "Enter the task prompt to determine how completion should be verified."
+  },
+  "scheduledTasks.form.completionRuleInferenceError": {
+    "message": "Automatic detection is temporarily unavailable. Please choose a rule."
+  },
+  "scheduledTasks.form.completionRuleRequired": {
+    "message": "Confirm how this task should be considered complete."
+  },
+  "scheduledTasks.form.channelZhihu": {
+    "message": "Zhihu"
+  },
+  "scheduledTasks.form.channelCsdn": {
+    "message": "CSDN"
   }
 }

--- a/src/i18n/el/chat.json
+++ b/src/i18n/el/chat.json
@@ -1006,5 +1006,95 @@
   "artifacts.hiddenBadge": {
     "message": "Hidden",
     "description": "Badge shown on artifacts that are currently hidden"
+  },
+  "scheduledTasks.actionError": {
+    "message": "Action failed. Refresh and try again."
+  },
+  "scheduledTasks.confirmPublished": {
+    "message": "It was published"
+  },
+  "scheduledTasks.confirmPublishedPrompt": {
+    "message": "Paste the public article URL from the target platform."
+  },
+  "scheduledTasks.confirmNotPublished": {
+    "message": "It was not published"
+  },
+  "scheduledTasks.confirmNotPublishedPrompt": {
+    "message": "Confirm that no article was published. You can retry this run afterward."
+  },
+  "scheduledTasks.confirmSuccess": {
+    "message": "The run result has been updated."
+  },
+  "scheduledTasks.articleUrlInvalid": {
+    "message": "Enter a valid HTTPS article URL."
+  },
+  "scheduledTasks.openArticle": {
+    "message": "Open article"
+  },
+  "scheduledTasks.retry": {
+    "message": "Retry now"
+  },
+  "scheduledTasks.retrySuccess": {
+    "message": "Retry started."
+  },
+  "scheduledTasks.resume": {
+    "message": "Resume task"
+  },
+  "scheduledTasks.resumeSuccess": {
+    "message": "Task resumed from its next future schedule."
+  },
+  "scheduledTasks.run.unknown": {
+    "message": "Needs confirmation"
+  },
+  "scheduledTasks.run.unverified": {
+    "message": "Unverified"
+  },
+  "scheduledTasks.form.completionRule": {
+    "message": "Completion"
+  },
+  "scheduledTasks.form.completionRuleLoading": {
+    "message": "Determining the completion rule…"
+  },
+  "scheduledTasks.form.completionRuleAuto": {
+    "message": "Determined automatically"
+  },
+  "scheduledTasks.form.completionRuleUser": {
+    "message": "Corrected by you"
+  },
+  "scheduledTasks.form.completionRuleCorrect": {
+    "message": "Correct"
+  },
+  "scheduledTasks.form.completionRuleAutoOption": {
+    "message": "Automatic"
+  },
+  "scheduledTasks.form.completionRuleAnswer": {
+    "message": "Generate a complete final answer"
+  },
+  "scheduledTasks.form.completionRuleArticle": {
+    "message": "Publish an article"
+  },
+  "scheduledTasks.form.completionRuleArticleChannel": {
+    "message": "Publish an article to {channel} and obtain its public URL"
+  },
+  "scheduledTasks.form.completionRuleUnknown": {
+    "message": "Completion rule not confirmed"
+  },
+  "scheduledTasks.form.completionRuleUserReason": {
+    "message": "This rule will be used for future runs until you restore automatic detection."
+  },
+  "scheduledTasks.form.completionRulePrompt": {
+    "message": "Enter the task prompt to determine how completion should be verified."
+  },
+  "scheduledTasks.form.completionRuleInferenceError": {
+    "message": "Automatic detection is temporarily unavailable. Please choose a rule."
+  },
+  "scheduledTasks.form.completionRuleRequired": {
+    "message": "Confirm how this task should be considered complete."
+  },
+  "scheduledTasks.form.channelZhihu": {
+    "message": "Zhihu"
+  },
+  "scheduledTasks.form.channelCsdn": {
+    "message": "CSDN"
   }
 }

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -611,6 +611,42 @@
     "message": "Failed to trigger. Please try again later.",
     "description": "Manual trigger error"
   },
+  "scheduledTasks.actionError": {
+    "message": "Action failed. Refresh and try again."
+  },
+  "scheduledTasks.confirmPublished": {
+    "message": "It was published"
+  },
+  "scheduledTasks.confirmPublishedPrompt": {
+    "message": "Paste the public article URL from the target platform."
+  },
+  "scheduledTasks.confirmNotPublished": {
+    "message": "It was not published"
+  },
+  "scheduledTasks.confirmNotPublishedPrompt": {
+    "message": "Confirm that no article was published. You can retry this run afterward."
+  },
+  "scheduledTasks.confirmSuccess": {
+    "message": "The run result has been updated."
+  },
+  "scheduledTasks.articleUrlInvalid": {
+    "message": "Enter a valid HTTPS article URL."
+  },
+  "scheduledTasks.openArticle": {
+    "message": "Open article"
+  },
+  "scheduledTasks.retry": {
+    "message": "Retry now"
+  },
+  "scheduledTasks.retrySuccess": {
+    "message": "Retry started."
+  },
+  "scheduledTasks.resume": {
+    "message": "Resume task"
+  },
+  "scheduledTasks.resumeSuccess": {
+    "message": "Task resumed from its next future schedule."
+  },
   "scheduledTasks.viewResult": {
     "message": "View Result"
   },
@@ -642,13 +678,19 @@
     "message": "Running"
   },
   "scheduledTasks.run.success": {
-    "message": "Success"
+    "message": "Completed"
   },
   "scheduledTasks.run.failed": {
-    "message": "Failed"
+    "message": "Not completed"
   },
   "scheduledTasks.run.needs_user_input": {
     "message": "Needs action"
+  },
+  "scheduledTasks.run.unknown": {
+    "message": "Needs confirmation"
+  },
+  "scheduledTasks.run.unverified": {
+    "message": "Unverified"
   },
   "scheduledTasks.scheduleType.daily": {
     "message": "Daily"
@@ -783,6 +825,54 @@
   },
   "scheduledTasks.form.mcpServersHint": {
     "message": "Selected MCP servers may be loaded and used during scheduled background runs. Unselected MCP servers will not load in unattended mode."
+  },
+  "scheduledTasks.form.completionRule": {
+    "message": "Completion"
+  },
+  "scheduledTasks.form.completionRuleLoading": {
+    "message": "Determining the completion rule…"
+  },
+  "scheduledTasks.form.completionRuleAuto": {
+    "message": "Determined automatically"
+  },
+  "scheduledTasks.form.completionRuleUser": {
+    "message": "Corrected by you"
+  },
+  "scheduledTasks.form.completionRuleCorrect": {
+    "message": "Correct"
+  },
+  "scheduledTasks.form.completionRuleAutoOption": {
+    "message": "Automatic"
+  },
+  "scheduledTasks.form.completionRuleAnswer": {
+    "message": "Generate a complete final answer"
+  },
+  "scheduledTasks.form.completionRuleArticle": {
+    "message": "Publish an article"
+  },
+  "scheduledTasks.form.completionRuleArticleChannel": {
+    "message": "Publish an article to {channel} and obtain its public URL"
+  },
+  "scheduledTasks.form.completionRuleUnknown": {
+    "message": "Completion rule not confirmed"
+  },
+  "scheduledTasks.form.completionRuleUserReason": {
+    "message": "This rule will be used for future runs until you restore automatic detection."
+  },
+  "scheduledTasks.form.completionRulePrompt": {
+    "message": "Enter the task prompt to determine how completion should be verified."
+  },
+  "scheduledTasks.form.completionRuleInferenceError": {
+    "message": "Automatic detection is temporarily unavailable. Please choose a rule."
+  },
+  "scheduledTasks.form.completionRuleRequired": {
+    "message": "Confirm how this task should be considered complete."
+  },
+  "scheduledTasks.form.channelZhihu": {
+    "message": "Zhihu"
+  },
+  "scheduledTasks.form.channelCsdn": {
+    "message": "CSDN"
   },
   "scheduledTasks.form.maxTurns": {
     "message": "Max turns"

--- a/src/i18n/es/chat.json
+++ b/src/i18n/es/chat.json
@@ -1006,5 +1006,95 @@
   "artifacts.hiddenBadge": {
     "message": "Hidden",
     "description": "Badge shown on artifacts that are currently hidden"
+  },
+  "scheduledTasks.actionError": {
+    "message": "Action failed. Refresh and try again."
+  },
+  "scheduledTasks.confirmPublished": {
+    "message": "It was published"
+  },
+  "scheduledTasks.confirmPublishedPrompt": {
+    "message": "Paste the public article URL from the target platform."
+  },
+  "scheduledTasks.confirmNotPublished": {
+    "message": "It was not published"
+  },
+  "scheduledTasks.confirmNotPublishedPrompt": {
+    "message": "Confirm that no article was published. You can retry this run afterward."
+  },
+  "scheduledTasks.confirmSuccess": {
+    "message": "The run result has been updated."
+  },
+  "scheduledTasks.articleUrlInvalid": {
+    "message": "Enter a valid HTTPS article URL."
+  },
+  "scheduledTasks.openArticle": {
+    "message": "Open article"
+  },
+  "scheduledTasks.retry": {
+    "message": "Retry now"
+  },
+  "scheduledTasks.retrySuccess": {
+    "message": "Retry started."
+  },
+  "scheduledTasks.resume": {
+    "message": "Resume task"
+  },
+  "scheduledTasks.resumeSuccess": {
+    "message": "Task resumed from its next future schedule."
+  },
+  "scheduledTasks.run.unknown": {
+    "message": "Needs confirmation"
+  },
+  "scheduledTasks.run.unverified": {
+    "message": "Unverified"
+  },
+  "scheduledTasks.form.completionRule": {
+    "message": "Completion"
+  },
+  "scheduledTasks.form.completionRuleLoading": {
+    "message": "Determining the completion rule…"
+  },
+  "scheduledTasks.form.completionRuleAuto": {
+    "message": "Determined automatically"
+  },
+  "scheduledTasks.form.completionRuleUser": {
+    "message": "Corrected by you"
+  },
+  "scheduledTasks.form.completionRuleCorrect": {
+    "message": "Correct"
+  },
+  "scheduledTasks.form.completionRuleAutoOption": {
+    "message": "Automatic"
+  },
+  "scheduledTasks.form.completionRuleAnswer": {
+    "message": "Generate a complete final answer"
+  },
+  "scheduledTasks.form.completionRuleArticle": {
+    "message": "Publish an article"
+  },
+  "scheduledTasks.form.completionRuleArticleChannel": {
+    "message": "Publish an article to {channel} and obtain its public URL"
+  },
+  "scheduledTasks.form.completionRuleUnknown": {
+    "message": "Completion rule not confirmed"
+  },
+  "scheduledTasks.form.completionRuleUserReason": {
+    "message": "This rule will be used for future runs until you restore automatic detection."
+  },
+  "scheduledTasks.form.completionRulePrompt": {
+    "message": "Enter the task prompt to determine how completion should be verified."
+  },
+  "scheduledTasks.form.completionRuleInferenceError": {
+    "message": "Automatic detection is temporarily unavailable. Please choose a rule."
+  },
+  "scheduledTasks.form.completionRuleRequired": {
+    "message": "Confirm how this task should be considered complete."
+  },
+  "scheduledTasks.form.channelZhihu": {
+    "message": "Zhihu"
+  },
+  "scheduledTasks.form.channelCsdn": {
+    "message": "CSDN"
   }
 }

--- a/src/i18n/fi/chat.json
+++ b/src/i18n/fi/chat.json
@@ -1006,5 +1006,95 @@
   "artifacts.hiddenBadge": {
     "message": "Hidden",
     "description": "Badge shown on artifacts that are currently hidden"
+  },
+  "scheduledTasks.actionError": {
+    "message": "Action failed. Refresh and try again."
+  },
+  "scheduledTasks.confirmPublished": {
+    "message": "It was published"
+  },
+  "scheduledTasks.confirmPublishedPrompt": {
+    "message": "Paste the public article URL from the target platform."
+  },
+  "scheduledTasks.confirmNotPublished": {
+    "message": "It was not published"
+  },
+  "scheduledTasks.confirmNotPublishedPrompt": {
+    "message": "Confirm that no article was published. You can retry this run afterward."
+  },
+  "scheduledTasks.confirmSuccess": {
+    "message": "The run result has been updated."
+  },
+  "scheduledTasks.articleUrlInvalid": {
+    "message": "Enter a valid HTTPS article URL."
+  },
+  "scheduledTasks.openArticle": {
+    "message": "Open article"
+  },
+  "scheduledTasks.retry": {
+    "message": "Retry now"
+  },
+  "scheduledTasks.retrySuccess": {
+    "message": "Retry started."
+  },
+  "scheduledTasks.resume": {
+    "message": "Resume task"
+  },
+  "scheduledTasks.resumeSuccess": {
+    "message": "Task resumed from its next future schedule."
+  },
+  "scheduledTasks.run.unknown": {
+    "message": "Needs confirmation"
+  },
+  "scheduledTasks.run.unverified": {
+    "message": "Unverified"
+  },
+  "scheduledTasks.form.completionRule": {
+    "message": "Completion"
+  },
+  "scheduledTasks.form.completionRuleLoading": {
+    "message": "Determining the completion rule…"
+  },
+  "scheduledTasks.form.completionRuleAuto": {
+    "message": "Determined automatically"
+  },
+  "scheduledTasks.form.completionRuleUser": {
+    "message": "Corrected by you"
+  },
+  "scheduledTasks.form.completionRuleCorrect": {
+    "message": "Correct"
+  },
+  "scheduledTasks.form.completionRuleAutoOption": {
+    "message": "Automatic"
+  },
+  "scheduledTasks.form.completionRuleAnswer": {
+    "message": "Generate a complete final answer"
+  },
+  "scheduledTasks.form.completionRuleArticle": {
+    "message": "Publish an article"
+  },
+  "scheduledTasks.form.completionRuleArticleChannel": {
+    "message": "Publish an article to {channel} and obtain its public URL"
+  },
+  "scheduledTasks.form.completionRuleUnknown": {
+    "message": "Completion rule not confirmed"
+  },
+  "scheduledTasks.form.completionRuleUserReason": {
+    "message": "This rule will be used for future runs until you restore automatic detection."
+  },
+  "scheduledTasks.form.completionRulePrompt": {
+    "message": "Enter the task prompt to determine how completion should be verified."
+  },
+  "scheduledTasks.form.completionRuleInferenceError": {
+    "message": "Automatic detection is temporarily unavailable. Please choose a rule."
+  },
+  "scheduledTasks.form.completionRuleRequired": {
+    "message": "Confirm how this task should be considered complete."
+  },
+  "scheduledTasks.form.channelZhihu": {
+    "message": "Zhihu"
+  },
+  "scheduledTasks.form.channelCsdn": {
+    "message": "CSDN"
   }
 }

--- a/src/i18n/fr/chat.json
+++ b/src/i18n/fr/chat.json
@@ -1006,5 +1006,95 @@
   "artifacts.hiddenBadge": {
     "message": "Hidden",
     "description": "Badge shown on artifacts that are currently hidden"
+  },
+  "scheduledTasks.actionError": {
+    "message": "Action failed. Refresh and try again."
+  },
+  "scheduledTasks.confirmPublished": {
+    "message": "It was published"
+  },
+  "scheduledTasks.confirmPublishedPrompt": {
+    "message": "Paste the public article URL from the target platform."
+  },
+  "scheduledTasks.confirmNotPublished": {
+    "message": "It was not published"
+  },
+  "scheduledTasks.confirmNotPublishedPrompt": {
+    "message": "Confirm that no article was published. You can retry this run afterward."
+  },
+  "scheduledTasks.confirmSuccess": {
+    "message": "The run result has been updated."
+  },
+  "scheduledTasks.articleUrlInvalid": {
+    "message": "Enter a valid HTTPS article URL."
+  },
+  "scheduledTasks.openArticle": {
+    "message": "Open article"
+  },
+  "scheduledTasks.retry": {
+    "message": "Retry now"
+  },
+  "scheduledTasks.retrySuccess": {
+    "message": "Retry started."
+  },
+  "scheduledTasks.resume": {
+    "message": "Resume task"
+  },
+  "scheduledTasks.resumeSuccess": {
+    "message": "Task resumed from its next future schedule."
+  },
+  "scheduledTasks.run.unknown": {
+    "message": "Needs confirmation"
+  },
+  "scheduledTasks.run.unverified": {
+    "message": "Unverified"
+  },
+  "scheduledTasks.form.completionRule": {
+    "message": "Completion"
+  },
+  "scheduledTasks.form.completionRuleLoading": {
+    "message": "Determining the completion rule…"
+  },
+  "scheduledTasks.form.completionRuleAuto": {
+    "message": "Determined automatically"
+  },
+  "scheduledTasks.form.completionRuleUser": {
+    "message": "Corrected by you"
+  },
+  "scheduledTasks.form.completionRuleCorrect": {
+    "message": "Correct"
+  },
+  "scheduledTasks.form.completionRuleAutoOption": {
+    "message": "Automatic"
+  },
+  "scheduledTasks.form.completionRuleAnswer": {
+    "message": "Generate a complete final answer"
+  },
+  "scheduledTasks.form.completionRuleArticle": {
+    "message": "Publish an article"
+  },
+  "scheduledTasks.form.completionRuleArticleChannel": {
+    "message": "Publish an article to {channel} and obtain its public URL"
+  },
+  "scheduledTasks.form.completionRuleUnknown": {
+    "message": "Completion rule not confirmed"
+  },
+  "scheduledTasks.form.completionRuleUserReason": {
+    "message": "This rule will be used for future runs until you restore automatic detection."
+  },
+  "scheduledTasks.form.completionRulePrompt": {
+    "message": "Enter the task prompt to determine how completion should be verified."
+  },
+  "scheduledTasks.form.completionRuleInferenceError": {
+    "message": "Automatic detection is temporarily unavailable. Please choose a rule."
+  },
+  "scheduledTasks.form.completionRuleRequired": {
+    "message": "Confirm how this task should be considered complete."
+  },
+  "scheduledTasks.form.channelZhihu": {
+    "message": "Zhihu"
+  },
+  "scheduledTasks.form.channelCsdn": {
+    "message": "CSDN"
   }
 }

--- a/src/i18n/it/chat.json
+++ b/src/i18n/it/chat.json
@@ -1006,5 +1006,95 @@
   "artifacts.hiddenBadge": {
     "message": "Hidden",
     "description": "Badge shown on artifacts that are currently hidden"
+  },
+  "scheduledTasks.actionError": {
+    "message": "Action failed. Refresh and try again."
+  },
+  "scheduledTasks.confirmPublished": {
+    "message": "It was published"
+  },
+  "scheduledTasks.confirmPublishedPrompt": {
+    "message": "Paste the public article URL from the target platform."
+  },
+  "scheduledTasks.confirmNotPublished": {
+    "message": "It was not published"
+  },
+  "scheduledTasks.confirmNotPublishedPrompt": {
+    "message": "Confirm that no article was published. You can retry this run afterward."
+  },
+  "scheduledTasks.confirmSuccess": {
+    "message": "The run result has been updated."
+  },
+  "scheduledTasks.articleUrlInvalid": {
+    "message": "Enter a valid HTTPS article URL."
+  },
+  "scheduledTasks.openArticle": {
+    "message": "Open article"
+  },
+  "scheduledTasks.retry": {
+    "message": "Retry now"
+  },
+  "scheduledTasks.retrySuccess": {
+    "message": "Retry started."
+  },
+  "scheduledTasks.resume": {
+    "message": "Resume task"
+  },
+  "scheduledTasks.resumeSuccess": {
+    "message": "Task resumed from its next future schedule."
+  },
+  "scheduledTasks.run.unknown": {
+    "message": "Needs confirmation"
+  },
+  "scheduledTasks.run.unverified": {
+    "message": "Unverified"
+  },
+  "scheduledTasks.form.completionRule": {
+    "message": "Completion"
+  },
+  "scheduledTasks.form.completionRuleLoading": {
+    "message": "Determining the completion rule…"
+  },
+  "scheduledTasks.form.completionRuleAuto": {
+    "message": "Determined automatically"
+  },
+  "scheduledTasks.form.completionRuleUser": {
+    "message": "Corrected by you"
+  },
+  "scheduledTasks.form.completionRuleCorrect": {
+    "message": "Correct"
+  },
+  "scheduledTasks.form.completionRuleAutoOption": {
+    "message": "Automatic"
+  },
+  "scheduledTasks.form.completionRuleAnswer": {
+    "message": "Generate a complete final answer"
+  },
+  "scheduledTasks.form.completionRuleArticle": {
+    "message": "Publish an article"
+  },
+  "scheduledTasks.form.completionRuleArticleChannel": {
+    "message": "Publish an article to {channel} and obtain its public URL"
+  },
+  "scheduledTasks.form.completionRuleUnknown": {
+    "message": "Completion rule not confirmed"
+  },
+  "scheduledTasks.form.completionRuleUserReason": {
+    "message": "This rule will be used for future runs until you restore automatic detection."
+  },
+  "scheduledTasks.form.completionRulePrompt": {
+    "message": "Enter the task prompt to determine how completion should be verified."
+  },
+  "scheduledTasks.form.completionRuleInferenceError": {
+    "message": "Automatic detection is temporarily unavailable. Please choose a rule."
+  },
+  "scheduledTasks.form.completionRuleRequired": {
+    "message": "Confirm how this task should be considered complete."
+  },
+  "scheduledTasks.form.channelZhihu": {
+    "message": "Zhihu"
+  },
+  "scheduledTasks.form.channelCsdn": {
+    "message": "CSDN"
   }
 }

--- a/src/i18n/ja/chat.json
+++ b/src/i18n/ja/chat.json
@@ -1006,5 +1006,95 @@
   "artifacts.hiddenBadge": {
     "message": "Hidden",
     "description": "Badge shown on artifacts that are currently hidden"
+  },
+  "scheduledTasks.actionError": {
+    "message": "Action failed. Refresh and try again."
+  },
+  "scheduledTasks.confirmPublished": {
+    "message": "It was published"
+  },
+  "scheduledTasks.confirmPublishedPrompt": {
+    "message": "Paste the public article URL from the target platform."
+  },
+  "scheduledTasks.confirmNotPublished": {
+    "message": "It was not published"
+  },
+  "scheduledTasks.confirmNotPublishedPrompt": {
+    "message": "Confirm that no article was published. You can retry this run afterward."
+  },
+  "scheduledTasks.confirmSuccess": {
+    "message": "The run result has been updated."
+  },
+  "scheduledTasks.articleUrlInvalid": {
+    "message": "Enter a valid HTTPS article URL."
+  },
+  "scheduledTasks.openArticle": {
+    "message": "Open article"
+  },
+  "scheduledTasks.retry": {
+    "message": "Retry now"
+  },
+  "scheduledTasks.retrySuccess": {
+    "message": "Retry started."
+  },
+  "scheduledTasks.resume": {
+    "message": "Resume task"
+  },
+  "scheduledTasks.resumeSuccess": {
+    "message": "Task resumed from its next future schedule."
+  },
+  "scheduledTasks.run.unknown": {
+    "message": "Needs confirmation"
+  },
+  "scheduledTasks.run.unverified": {
+    "message": "Unverified"
+  },
+  "scheduledTasks.form.completionRule": {
+    "message": "Completion"
+  },
+  "scheduledTasks.form.completionRuleLoading": {
+    "message": "Determining the completion rule…"
+  },
+  "scheduledTasks.form.completionRuleAuto": {
+    "message": "Determined automatically"
+  },
+  "scheduledTasks.form.completionRuleUser": {
+    "message": "Corrected by you"
+  },
+  "scheduledTasks.form.completionRuleCorrect": {
+    "message": "Correct"
+  },
+  "scheduledTasks.form.completionRuleAutoOption": {
+    "message": "Automatic"
+  },
+  "scheduledTasks.form.completionRuleAnswer": {
+    "message": "Generate a complete final answer"
+  },
+  "scheduledTasks.form.completionRuleArticle": {
+    "message": "Publish an article"
+  },
+  "scheduledTasks.form.completionRuleArticleChannel": {
+    "message": "Publish an article to {channel} and obtain its public URL"
+  },
+  "scheduledTasks.form.completionRuleUnknown": {
+    "message": "Completion rule not confirmed"
+  },
+  "scheduledTasks.form.completionRuleUserReason": {
+    "message": "This rule will be used for future runs until you restore automatic detection."
+  },
+  "scheduledTasks.form.completionRulePrompt": {
+    "message": "Enter the task prompt to determine how completion should be verified."
+  },
+  "scheduledTasks.form.completionRuleInferenceError": {
+    "message": "Automatic detection is temporarily unavailable. Please choose a rule."
+  },
+  "scheduledTasks.form.completionRuleRequired": {
+    "message": "Confirm how this task should be considered complete."
+  },
+  "scheduledTasks.form.channelZhihu": {
+    "message": "Zhihu"
+  },
+  "scheduledTasks.form.channelCsdn": {
+    "message": "CSDN"
   }
 }

--- a/src/i18n/ko/chat.json
+++ b/src/i18n/ko/chat.json
@@ -1006,5 +1006,95 @@
   "artifacts.hiddenBadge": {
     "message": "Hidden",
     "description": "Badge shown on artifacts that are currently hidden"
+  },
+  "scheduledTasks.actionError": {
+    "message": "Action failed. Refresh and try again."
+  },
+  "scheduledTasks.confirmPublished": {
+    "message": "It was published"
+  },
+  "scheduledTasks.confirmPublishedPrompt": {
+    "message": "Paste the public article URL from the target platform."
+  },
+  "scheduledTasks.confirmNotPublished": {
+    "message": "It was not published"
+  },
+  "scheduledTasks.confirmNotPublishedPrompt": {
+    "message": "Confirm that no article was published. You can retry this run afterward."
+  },
+  "scheduledTasks.confirmSuccess": {
+    "message": "The run result has been updated."
+  },
+  "scheduledTasks.articleUrlInvalid": {
+    "message": "Enter a valid HTTPS article URL."
+  },
+  "scheduledTasks.openArticle": {
+    "message": "Open article"
+  },
+  "scheduledTasks.retry": {
+    "message": "Retry now"
+  },
+  "scheduledTasks.retrySuccess": {
+    "message": "Retry started."
+  },
+  "scheduledTasks.resume": {
+    "message": "Resume task"
+  },
+  "scheduledTasks.resumeSuccess": {
+    "message": "Task resumed from its next future schedule."
+  },
+  "scheduledTasks.run.unknown": {
+    "message": "Needs confirmation"
+  },
+  "scheduledTasks.run.unverified": {
+    "message": "Unverified"
+  },
+  "scheduledTasks.form.completionRule": {
+    "message": "Completion"
+  },
+  "scheduledTasks.form.completionRuleLoading": {
+    "message": "Determining the completion rule…"
+  },
+  "scheduledTasks.form.completionRuleAuto": {
+    "message": "Determined automatically"
+  },
+  "scheduledTasks.form.completionRuleUser": {
+    "message": "Corrected by you"
+  },
+  "scheduledTasks.form.completionRuleCorrect": {
+    "message": "Correct"
+  },
+  "scheduledTasks.form.completionRuleAutoOption": {
+    "message": "Automatic"
+  },
+  "scheduledTasks.form.completionRuleAnswer": {
+    "message": "Generate a complete final answer"
+  },
+  "scheduledTasks.form.completionRuleArticle": {
+    "message": "Publish an article"
+  },
+  "scheduledTasks.form.completionRuleArticleChannel": {
+    "message": "Publish an article to {channel} and obtain its public URL"
+  },
+  "scheduledTasks.form.completionRuleUnknown": {
+    "message": "Completion rule not confirmed"
+  },
+  "scheduledTasks.form.completionRuleUserReason": {
+    "message": "This rule will be used for future runs until you restore automatic detection."
+  },
+  "scheduledTasks.form.completionRulePrompt": {
+    "message": "Enter the task prompt to determine how completion should be verified."
+  },
+  "scheduledTasks.form.completionRuleInferenceError": {
+    "message": "Automatic detection is temporarily unavailable. Please choose a rule."
+  },
+  "scheduledTasks.form.completionRuleRequired": {
+    "message": "Confirm how this task should be considered complete."
+  },
+  "scheduledTasks.form.channelZhihu": {
+    "message": "Zhihu"
+  },
+  "scheduledTasks.form.channelCsdn": {
+    "message": "CSDN"
   }
 }

--- a/src/i18n/pl/chat.json
+++ b/src/i18n/pl/chat.json
@@ -1006,5 +1006,95 @@
   "artifacts.hiddenBadge": {
     "message": "Hidden",
     "description": "Badge shown on artifacts that are currently hidden"
+  },
+  "scheduledTasks.actionError": {
+    "message": "Action failed. Refresh and try again."
+  },
+  "scheduledTasks.confirmPublished": {
+    "message": "It was published"
+  },
+  "scheduledTasks.confirmPublishedPrompt": {
+    "message": "Paste the public article URL from the target platform."
+  },
+  "scheduledTasks.confirmNotPublished": {
+    "message": "It was not published"
+  },
+  "scheduledTasks.confirmNotPublishedPrompt": {
+    "message": "Confirm that no article was published. You can retry this run afterward."
+  },
+  "scheduledTasks.confirmSuccess": {
+    "message": "The run result has been updated."
+  },
+  "scheduledTasks.articleUrlInvalid": {
+    "message": "Enter a valid HTTPS article URL."
+  },
+  "scheduledTasks.openArticle": {
+    "message": "Open article"
+  },
+  "scheduledTasks.retry": {
+    "message": "Retry now"
+  },
+  "scheduledTasks.retrySuccess": {
+    "message": "Retry started."
+  },
+  "scheduledTasks.resume": {
+    "message": "Resume task"
+  },
+  "scheduledTasks.resumeSuccess": {
+    "message": "Task resumed from its next future schedule."
+  },
+  "scheduledTasks.run.unknown": {
+    "message": "Needs confirmation"
+  },
+  "scheduledTasks.run.unverified": {
+    "message": "Unverified"
+  },
+  "scheduledTasks.form.completionRule": {
+    "message": "Completion"
+  },
+  "scheduledTasks.form.completionRuleLoading": {
+    "message": "Determining the completion rule…"
+  },
+  "scheduledTasks.form.completionRuleAuto": {
+    "message": "Determined automatically"
+  },
+  "scheduledTasks.form.completionRuleUser": {
+    "message": "Corrected by you"
+  },
+  "scheduledTasks.form.completionRuleCorrect": {
+    "message": "Correct"
+  },
+  "scheduledTasks.form.completionRuleAutoOption": {
+    "message": "Automatic"
+  },
+  "scheduledTasks.form.completionRuleAnswer": {
+    "message": "Generate a complete final answer"
+  },
+  "scheduledTasks.form.completionRuleArticle": {
+    "message": "Publish an article"
+  },
+  "scheduledTasks.form.completionRuleArticleChannel": {
+    "message": "Publish an article to {channel} and obtain its public URL"
+  },
+  "scheduledTasks.form.completionRuleUnknown": {
+    "message": "Completion rule not confirmed"
+  },
+  "scheduledTasks.form.completionRuleUserReason": {
+    "message": "This rule will be used for future runs until you restore automatic detection."
+  },
+  "scheduledTasks.form.completionRulePrompt": {
+    "message": "Enter the task prompt to determine how completion should be verified."
+  },
+  "scheduledTasks.form.completionRuleInferenceError": {
+    "message": "Automatic detection is temporarily unavailable. Please choose a rule."
+  },
+  "scheduledTasks.form.completionRuleRequired": {
+    "message": "Confirm how this task should be considered complete."
+  },
+  "scheduledTasks.form.channelZhihu": {
+    "message": "Zhihu"
+  },
+  "scheduledTasks.form.channelCsdn": {
+    "message": "CSDN"
   }
 }

--- a/src/i18n/pt/chat.json
+++ b/src/i18n/pt/chat.json
@@ -1006,5 +1006,95 @@
   "artifacts.hiddenBadge": {
     "message": "Hidden",
     "description": "Badge shown on artifacts that are currently hidden"
+  },
+  "scheduledTasks.actionError": {
+    "message": "Action failed. Refresh and try again."
+  },
+  "scheduledTasks.confirmPublished": {
+    "message": "It was published"
+  },
+  "scheduledTasks.confirmPublishedPrompt": {
+    "message": "Paste the public article URL from the target platform."
+  },
+  "scheduledTasks.confirmNotPublished": {
+    "message": "It was not published"
+  },
+  "scheduledTasks.confirmNotPublishedPrompt": {
+    "message": "Confirm that no article was published. You can retry this run afterward."
+  },
+  "scheduledTasks.confirmSuccess": {
+    "message": "The run result has been updated."
+  },
+  "scheduledTasks.articleUrlInvalid": {
+    "message": "Enter a valid HTTPS article URL."
+  },
+  "scheduledTasks.openArticle": {
+    "message": "Open article"
+  },
+  "scheduledTasks.retry": {
+    "message": "Retry now"
+  },
+  "scheduledTasks.retrySuccess": {
+    "message": "Retry started."
+  },
+  "scheduledTasks.resume": {
+    "message": "Resume task"
+  },
+  "scheduledTasks.resumeSuccess": {
+    "message": "Task resumed from its next future schedule."
+  },
+  "scheduledTasks.run.unknown": {
+    "message": "Needs confirmation"
+  },
+  "scheduledTasks.run.unverified": {
+    "message": "Unverified"
+  },
+  "scheduledTasks.form.completionRule": {
+    "message": "Completion"
+  },
+  "scheduledTasks.form.completionRuleLoading": {
+    "message": "Determining the completion rule…"
+  },
+  "scheduledTasks.form.completionRuleAuto": {
+    "message": "Determined automatically"
+  },
+  "scheduledTasks.form.completionRuleUser": {
+    "message": "Corrected by you"
+  },
+  "scheduledTasks.form.completionRuleCorrect": {
+    "message": "Correct"
+  },
+  "scheduledTasks.form.completionRuleAutoOption": {
+    "message": "Automatic"
+  },
+  "scheduledTasks.form.completionRuleAnswer": {
+    "message": "Generate a complete final answer"
+  },
+  "scheduledTasks.form.completionRuleArticle": {
+    "message": "Publish an article"
+  },
+  "scheduledTasks.form.completionRuleArticleChannel": {
+    "message": "Publish an article to {channel} and obtain its public URL"
+  },
+  "scheduledTasks.form.completionRuleUnknown": {
+    "message": "Completion rule not confirmed"
+  },
+  "scheduledTasks.form.completionRuleUserReason": {
+    "message": "This rule will be used for future runs until you restore automatic detection."
+  },
+  "scheduledTasks.form.completionRulePrompt": {
+    "message": "Enter the task prompt to determine how completion should be verified."
+  },
+  "scheduledTasks.form.completionRuleInferenceError": {
+    "message": "Automatic detection is temporarily unavailable. Please choose a rule."
+  },
+  "scheduledTasks.form.completionRuleRequired": {
+    "message": "Confirm how this task should be considered complete."
+  },
+  "scheduledTasks.form.channelZhihu": {
+    "message": "Zhihu"
+  },
+  "scheduledTasks.form.channelCsdn": {
+    "message": "CSDN"
   }
 }

--- a/src/i18n/ru/chat.json
+++ b/src/i18n/ru/chat.json
@@ -1006,5 +1006,95 @@
   "artifacts.hiddenBadge": {
     "message": "Hidden",
     "description": "Badge shown on artifacts that are currently hidden"
+  },
+  "scheduledTasks.actionError": {
+    "message": "Action failed. Refresh and try again."
+  },
+  "scheduledTasks.confirmPublished": {
+    "message": "It was published"
+  },
+  "scheduledTasks.confirmPublishedPrompt": {
+    "message": "Paste the public article URL from the target platform."
+  },
+  "scheduledTasks.confirmNotPublished": {
+    "message": "It was not published"
+  },
+  "scheduledTasks.confirmNotPublishedPrompt": {
+    "message": "Confirm that no article was published. You can retry this run afterward."
+  },
+  "scheduledTasks.confirmSuccess": {
+    "message": "The run result has been updated."
+  },
+  "scheduledTasks.articleUrlInvalid": {
+    "message": "Enter a valid HTTPS article URL."
+  },
+  "scheduledTasks.openArticle": {
+    "message": "Open article"
+  },
+  "scheduledTasks.retry": {
+    "message": "Retry now"
+  },
+  "scheduledTasks.retrySuccess": {
+    "message": "Retry started."
+  },
+  "scheduledTasks.resume": {
+    "message": "Resume task"
+  },
+  "scheduledTasks.resumeSuccess": {
+    "message": "Task resumed from its next future schedule."
+  },
+  "scheduledTasks.run.unknown": {
+    "message": "Needs confirmation"
+  },
+  "scheduledTasks.run.unverified": {
+    "message": "Unverified"
+  },
+  "scheduledTasks.form.completionRule": {
+    "message": "Completion"
+  },
+  "scheduledTasks.form.completionRuleLoading": {
+    "message": "Determining the completion rule…"
+  },
+  "scheduledTasks.form.completionRuleAuto": {
+    "message": "Determined automatically"
+  },
+  "scheduledTasks.form.completionRuleUser": {
+    "message": "Corrected by you"
+  },
+  "scheduledTasks.form.completionRuleCorrect": {
+    "message": "Correct"
+  },
+  "scheduledTasks.form.completionRuleAutoOption": {
+    "message": "Automatic"
+  },
+  "scheduledTasks.form.completionRuleAnswer": {
+    "message": "Generate a complete final answer"
+  },
+  "scheduledTasks.form.completionRuleArticle": {
+    "message": "Publish an article"
+  },
+  "scheduledTasks.form.completionRuleArticleChannel": {
+    "message": "Publish an article to {channel} and obtain its public URL"
+  },
+  "scheduledTasks.form.completionRuleUnknown": {
+    "message": "Completion rule not confirmed"
+  },
+  "scheduledTasks.form.completionRuleUserReason": {
+    "message": "This rule will be used for future runs until you restore automatic detection."
+  },
+  "scheduledTasks.form.completionRulePrompt": {
+    "message": "Enter the task prompt to determine how completion should be verified."
+  },
+  "scheduledTasks.form.completionRuleInferenceError": {
+    "message": "Automatic detection is temporarily unavailable. Please choose a rule."
+  },
+  "scheduledTasks.form.completionRuleRequired": {
+    "message": "Confirm how this task should be considered complete."
+  },
+  "scheduledTasks.form.channelZhihu": {
+    "message": "Zhihu"
+  },
+  "scheduledTasks.form.channelCsdn": {
+    "message": "CSDN"
   }
 }

--- a/src/i18n/sr/chat.json
+++ b/src/i18n/sr/chat.json
@@ -1006,5 +1006,95 @@
   "artifacts.hiddenBadge": {
     "message": "Hidden",
     "description": "Badge shown on artifacts that are currently hidden"
+  },
+  "scheduledTasks.actionError": {
+    "message": "Action failed. Refresh and try again."
+  },
+  "scheduledTasks.confirmPublished": {
+    "message": "It was published"
+  },
+  "scheduledTasks.confirmPublishedPrompt": {
+    "message": "Paste the public article URL from the target platform."
+  },
+  "scheduledTasks.confirmNotPublished": {
+    "message": "It was not published"
+  },
+  "scheduledTasks.confirmNotPublishedPrompt": {
+    "message": "Confirm that no article was published. You can retry this run afterward."
+  },
+  "scheduledTasks.confirmSuccess": {
+    "message": "The run result has been updated."
+  },
+  "scheduledTasks.articleUrlInvalid": {
+    "message": "Enter a valid HTTPS article URL."
+  },
+  "scheduledTasks.openArticle": {
+    "message": "Open article"
+  },
+  "scheduledTasks.retry": {
+    "message": "Retry now"
+  },
+  "scheduledTasks.retrySuccess": {
+    "message": "Retry started."
+  },
+  "scheduledTasks.resume": {
+    "message": "Resume task"
+  },
+  "scheduledTasks.resumeSuccess": {
+    "message": "Task resumed from its next future schedule."
+  },
+  "scheduledTasks.run.unknown": {
+    "message": "Needs confirmation"
+  },
+  "scheduledTasks.run.unverified": {
+    "message": "Unverified"
+  },
+  "scheduledTasks.form.completionRule": {
+    "message": "Completion"
+  },
+  "scheduledTasks.form.completionRuleLoading": {
+    "message": "Determining the completion rule…"
+  },
+  "scheduledTasks.form.completionRuleAuto": {
+    "message": "Determined automatically"
+  },
+  "scheduledTasks.form.completionRuleUser": {
+    "message": "Corrected by you"
+  },
+  "scheduledTasks.form.completionRuleCorrect": {
+    "message": "Correct"
+  },
+  "scheduledTasks.form.completionRuleAutoOption": {
+    "message": "Automatic"
+  },
+  "scheduledTasks.form.completionRuleAnswer": {
+    "message": "Generate a complete final answer"
+  },
+  "scheduledTasks.form.completionRuleArticle": {
+    "message": "Publish an article"
+  },
+  "scheduledTasks.form.completionRuleArticleChannel": {
+    "message": "Publish an article to {channel} and obtain its public URL"
+  },
+  "scheduledTasks.form.completionRuleUnknown": {
+    "message": "Completion rule not confirmed"
+  },
+  "scheduledTasks.form.completionRuleUserReason": {
+    "message": "This rule will be used for future runs until you restore automatic detection."
+  },
+  "scheduledTasks.form.completionRulePrompt": {
+    "message": "Enter the task prompt to determine how completion should be verified."
+  },
+  "scheduledTasks.form.completionRuleInferenceError": {
+    "message": "Automatic detection is temporarily unavailable. Please choose a rule."
+  },
+  "scheduledTasks.form.completionRuleRequired": {
+    "message": "Confirm how this task should be considered complete."
+  },
+  "scheduledTasks.form.channelZhihu": {
+    "message": "Zhihu"
+  },
+  "scheduledTasks.form.channelCsdn": {
+    "message": "CSDN"
   }
 }

--- a/src/i18n/sv/chat.json
+++ b/src/i18n/sv/chat.json
@@ -1006,5 +1006,95 @@
   "artifacts.hiddenBadge": {
     "message": "Hidden",
     "description": "Badge shown on artifacts that are currently hidden"
+  },
+  "scheduledTasks.actionError": {
+    "message": "Action failed. Refresh and try again."
+  },
+  "scheduledTasks.confirmPublished": {
+    "message": "It was published"
+  },
+  "scheduledTasks.confirmPublishedPrompt": {
+    "message": "Paste the public article URL from the target platform."
+  },
+  "scheduledTasks.confirmNotPublished": {
+    "message": "It was not published"
+  },
+  "scheduledTasks.confirmNotPublishedPrompt": {
+    "message": "Confirm that no article was published. You can retry this run afterward."
+  },
+  "scheduledTasks.confirmSuccess": {
+    "message": "The run result has been updated."
+  },
+  "scheduledTasks.articleUrlInvalid": {
+    "message": "Enter a valid HTTPS article URL."
+  },
+  "scheduledTasks.openArticle": {
+    "message": "Open article"
+  },
+  "scheduledTasks.retry": {
+    "message": "Retry now"
+  },
+  "scheduledTasks.retrySuccess": {
+    "message": "Retry started."
+  },
+  "scheduledTasks.resume": {
+    "message": "Resume task"
+  },
+  "scheduledTasks.resumeSuccess": {
+    "message": "Task resumed from its next future schedule."
+  },
+  "scheduledTasks.run.unknown": {
+    "message": "Needs confirmation"
+  },
+  "scheduledTasks.run.unverified": {
+    "message": "Unverified"
+  },
+  "scheduledTasks.form.completionRule": {
+    "message": "Completion"
+  },
+  "scheduledTasks.form.completionRuleLoading": {
+    "message": "Determining the completion rule…"
+  },
+  "scheduledTasks.form.completionRuleAuto": {
+    "message": "Determined automatically"
+  },
+  "scheduledTasks.form.completionRuleUser": {
+    "message": "Corrected by you"
+  },
+  "scheduledTasks.form.completionRuleCorrect": {
+    "message": "Correct"
+  },
+  "scheduledTasks.form.completionRuleAutoOption": {
+    "message": "Automatic"
+  },
+  "scheduledTasks.form.completionRuleAnswer": {
+    "message": "Generate a complete final answer"
+  },
+  "scheduledTasks.form.completionRuleArticle": {
+    "message": "Publish an article"
+  },
+  "scheduledTasks.form.completionRuleArticleChannel": {
+    "message": "Publish an article to {channel} and obtain its public URL"
+  },
+  "scheduledTasks.form.completionRuleUnknown": {
+    "message": "Completion rule not confirmed"
+  },
+  "scheduledTasks.form.completionRuleUserReason": {
+    "message": "This rule will be used for future runs until you restore automatic detection."
+  },
+  "scheduledTasks.form.completionRulePrompt": {
+    "message": "Enter the task prompt to determine how completion should be verified."
+  },
+  "scheduledTasks.form.completionRuleInferenceError": {
+    "message": "Automatic detection is temporarily unavailable. Please choose a rule."
+  },
+  "scheduledTasks.form.completionRuleRequired": {
+    "message": "Confirm how this task should be considered complete."
+  },
+  "scheduledTasks.form.channelZhihu": {
+    "message": "Zhihu"
+  },
+  "scheduledTasks.form.channelCsdn": {
+    "message": "CSDN"
   }
 }

--- a/src/i18n/uk/chat.json
+++ b/src/i18n/uk/chat.json
@@ -1006,5 +1006,95 @@
   "artifacts.hiddenBadge": {
     "message": "Hidden",
     "description": "Badge shown on artifacts that are currently hidden"
+  },
+  "scheduledTasks.actionError": {
+    "message": "Action failed. Refresh and try again."
+  },
+  "scheduledTasks.confirmPublished": {
+    "message": "It was published"
+  },
+  "scheduledTasks.confirmPublishedPrompt": {
+    "message": "Paste the public article URL from the target platform."
+  },
+  "scheduledTasks.confirmNotPublished": {
+    "message": "It was not published"
+  },
+  "scheduledTasks.confirmNotPublishedPrompt": {
+    "message": "Confirm that no article was published. You can retry this run afterward."
+  },
+  "scheduledTasks.confirmSuccess": {
+    "message": "The run result has been updated."
+  },
+  "scheduledTasks.articleUrlInvalid": {
+    "message": "Enter a valid HTTPS article URL."
+  },
+  "scheduledTasks.openArticle": {
+    "message": "Open article"
+  },
+  "scheduledTasks.retry": {
+    "message": "Retry now"
+  },
+  "scheduledTasks.retrySuccess": {
+    "message": "Retry started."
+  },
+  "scheduledTasks.resume": {
+    "message": "Resume task"
+  },
+  "scheduledTasks.resumeSuccess": {
+    "message": "Task resumed from its next future schedule."
+  },
+  "scheduledTasks.run.unknown": {
+    "message": "Needs confirmation"
+  },
+  "scheduledTasks.run.unverified": {
+    "message": "Unverified"
+  },
+  "scheduledTasks.form.completionRule": {
+    "message": "Completion"
+  },
+  "scheduledTasks.form.completionRuleLoading": {
+    "message": "Determining the completion rule…"
+  },
+  "scheduledTasks.form.completionRuleAuto": {
+    "message": "Determined automatically"
+  },
+  "scheduledTasks.form.completionRuleUser": {
+    "message": "Corrected by you"
+  },
+  "scheduledTasks.form.completionRuleCorrect": {
+    "message": "Correct"
+  },
+  "scheduledTasks.form.completionRuleAutoOption": {
+    "message": "Automatic"
+  },
+  "scheduledTasks.form.completionRuleAnswer": {
+    "message": "Generate a complete final answer"
+  },
+  "scheduledTasks.form.completionRuleArticle": {
+    "message": "Publish an article"
+  },
+  "scheduledTasks.form.completionRuleArticleChannel": {
+    "message": "Publish an article to {channel} and obtain its public URL"
+  },
+  "scheduledTasks.form.completionRuleUnknown": {
+    "message": "Completion rule not confirmed"
+  },
+  "scheduledTasks.form.completionRuleUserReason": {
+    "message": "This rule will be used for future runs until you restore automatic detection."
+  },
+  "scheduledTasks.form.completionRulePrompt": {
+    "message": "Enter the task prompt to determine how completion should be verified."
+  },
+  "scheduledTasks.form.completionRuleInferenceError": {
+    "message": "Automatic detection is temporarily unavailable. Please choose a rule."
+  },
+  "scheduledTasks.form.completionRuleRequired": {
+    "message": "Confirm how this task should be considered complete."
+  },
+  "scheduledTasks.form.channelZhihu": {
+    "message": "Zhihu"
+  },
+  "scheduledTasks.form.channelCsdn": {
+    "message": "CSDN"
   }
 }

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -619,6 +619,42 @@
     "message": "触发失败，请稍后重试。",
     "description": "手动触发失败提示"
   },
+  "scheduledTasks.actionError": {
+    "message": "操作失败，请刷新后重试。"
+  },
+  "scheduledTasks.confirmPublished": {
+    "message": "已经发布"
+  },
+  "scheduledTasks.confirmPublishedPrompt": {
+    "message": "请粘贴目标平台上的公开文章链接。"
+  },
+  "scheduledTasks.confirmNotPublished": {
+    "message": "没有发布"
+  },
+  "scheduledTasks.confirmNotPublishedPrompt": {
+    "message": "确认目标平台没有发布文章。确认后可以立即重试本次任务。"
+  },
+  "scheduledTasks.confirmSuccess": {
+    "message": "运行结果已更新。"
+  },
+  "scheduledTasks.articleUrlInvalid": {
+    "message": "请输入有效的 HTTPS 文章链接。"
+  },
+  "scheduledTasks.openArticle": {
+    "message": "查看文章"
+  },
+  "scheduledTasks.retry": {
+    "message": "立即重试"
+  },
+  "scheduledTasks.retrySuccess": {
+    "message": "已开始重试。"
+  },
+  "scheduledTasks.resume": {
+    "message": "恢复任务"
+  },
+  "scheduledTasks.resumeSuccess": {
+    "message": "任务已恢复，将从下一个未来计划开始运行。"
+  },
   "scheduledTasks.viewResult": {
     "message": "查看结果",
     "description": "跳转到对话"
@@ -660,16 +696,24 @@
     "description": "运行中状态"
   },
   "scheduledTasks.run.success": {
-    "message": "成功",
+    "message": "已完成",
     "description": "成功状态"
   },
   "scheduledTasks.run.failed": {
-    "message": "失败",
+    "message": "未完成",
     "description": "失败状态"
   },
   "scheduledTasks.run.needs_user_input": {
     "message": "需要操作",
     "description": "需要用户操作状态"
+  },
+  "scheduledTasks.run.unknown": {
+    "message": "结果待确认",
+    "description": "发布请求可能已发出，需要用户确认"
+  },
+  "scheduledTasks.run.unverified": {
+    "message": "未验证",
+    "description": "运行时没有已确认的完成标准"
   },
   "scheduledTasks.scheduleType.daily": {
     "message": "每天",
@@ -826,6 +870,54 @@
   "scheduledTasks.form.mcpServersHint": {
     "message": "选中的 MCP Servers 可在定时任务后台加载并执行；未选中的 MCP Servers 不会在无人值守模式下加载。",
     "description": "授权 MCP server 说明"
+  },
+  "scheduledTasks.form.completionRule": {
+    "message": "完成标准"
+  },
+  "scheduledTasks.form.completionRuleLoading": {
+    "message": "正在自动判断完成标准…"
+  },
+  "scheduledTasks.form.completionRuleAuto": {
+    "message": "系统自动判断"
+  },
+  "scheduledTasks.form.completionRuleUser": {
+    "message": "你已更正"
+  },
+  "scheduledTasks.form.completionRuleCorrect": {
+    "message": "更正"
+  },
+  "scheduledTasks.form.completionRuleAutoOption": {
+    "message": "自动判断"
+  },
+  "scheduledTasks.form.completionRuleAnswer": {
+    "message": "生成完整的最终回答"
+  },
+  "scheduledTasks.form.completionRuleArticle": {
+    "message": "发布文章"
+  },
+  "scheduledTasks.form.completionRuleArticleChannel": {
+    "message": "发布一篇{channel}文章，并取得公开链接"
+  },
+  "scheduledTasks.form.completionRuleUnknown": {
+    "message": "完成标准未确认"
+  },
+  "scheduledTasks.form.completionRuleUserReason": {
+    "message": "后续运行会使用此标准，直到你恢复自动判断。"
+  },
+  "scheduledTasks.form.completionRulePrompt": {
+    "message": "输入任务要求后，系统会自动判断怎样才算完成。"
+  },
+  "scheduledTasks.form.completionRuleInferenceError": {
+    "message": "暂时无法自动判断，请手动选择完成标准。"
+  },
+  "scheduledTasks.form.completionRuleRequired": {
+    "message": "请确认这个任务怎样才算完成。"
+  },
+  "scheduledTasks.form.channelZhihu": {
+    "message": "知乎"
+  },
+  "scheduledTasks.form.channelCsdn": {
+    "message": "CSDN"
   },
   "scheduledTasks.form.maxTurns": {
     "message": "最大轮次",

--- a/src/i18n/zh-TW/chat.json
+++ b/src/i18n/zh-TW/chat.json
@@ -1006,5 +1006,95 @@
   "artifacts.hiddenBadge": {
     "message": "Hidden",
     "description": "Badge shown on artifacts that are currently hidden"
+  },
+  "scheduledTasks.actionError": {
+    "message": "Action failed. Refresh and try again."
+  },
+  "scheduledTasks.confirmPublished": {
+    "message": "It was published"
+  },
+  "scheduledTasks.confirmPublishedPrompt": {
+    "message": "Paste the public article URL from the target platform."
+  },
+  "scheduledTasks.confirmNotPublished": {
+    "message": "It was not published"
+  },
+  "scheduledTasks.confirmNotPublishedPrompt": {
+    "message": "Confirm that no article was published. You can retry this run afterward."
+  },
+  "scheduledTasks.confirmSuccess": {
+    "message": "The run result has been updated."
+  },
+  "scheduledTasks.articleUrlInvalid": {
+    "message": "Enter a valid HTTPS article URL."
+  },
+  "scheduledTasks.openArticle": {
+    "message": "Open article"
+  },
+  "scheduledTasks.retry": {
+    "message": "Retry now"
+  },
+  "scheduledTasks.retrySuccess": {
+    "message": "Retry started."
+  },
+  "scheduledTasks.resume": {
+    "message": "Resume task"
+  },
+  "scheduledTasks.resumeSuccess": {
+    "message": "Task resumed from its next future schedule."
+  },
+  "scheduledTasks.run.unknown": {
+    "message": "Needs confirmation"
+  },
+  "scheduledTasks.run.unverified": {
+    "message": "Unverified"
+  },
+  "scheduledTasks.form.completionRule": {
+    "message": "Completion"
+  },
+  "scheduledTasks.form.completionRuleLoading": {
+    "message": "Determining the completion rule…"
+  },
+  "scheduledTasks.form.completionRuleAuto": {
+    "message": "Determined automatically"
+  },
+  "scheduledTasks.form.completionRuleUser": {
+    "message": "Corrected by you"
+  },
+  "scheduledTasks.form.completionRuleCorrect": {
+    "message": "Correct"
+  },
+  "scheduledTasks.form.completionRuleAutoOption": {
+    "message": "Automatic"
+  },
+  "scheduledTasks.form.completionRuleAnswer": {
+    "message": "Generate a complete final answer"
+  },
+  "scheduledTasks.form.completionRuleArticle": {
+    "message": "Publish an article"
+  },
+  "scheduledTasks.form.completionRuleArticleChannel": {
+    "message": "Publish an article to {channel} and obtain its public URL"
+  },
+  "scheduledTasks.form.completionRuleUnknown": {
+    "message": "Completion rule not confirmed"
+  },
+  "scheduledTasks.form.completionRuleUserReason": {
+    "message": "This rule will be used for future runs until you restore automatic detection."
+  },
+  "scheduledTasks.form.completionRulePrompt": {
+    "message": "Enter the task prompt to determine how completion should be verified."
+  },
+  "scheduledTasks.form.completionRuleInferenceError": {
+    "message": "Automatic detection is temporarily unavailable. Please choose a rule."
+  },
+  "scheduledTasks.form.completionRuleRequired": {
+    "message": "Confirm how this task should be considered complete."
+  },
+  "scheduledTasks.form.channelZhihu": {
+    "message": "Zhihu"
+  },
+  "scheduledTasks.form.channelCsdn": {
+    "message": "CSDN"
   }
 }

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -284,6 +284,34 @@ export interface IChatConversation {
   share_id?: string;
   /** Unix seconds when the share snapshot was last (re)generated. */
   shared_at?: number;
+  metadata?: {
+    source?: string;
+    scheduled_task_id?: string;
+    run_id?: string;
+    terminal_reason?: string;
+    scheduled_outcome?: IChatScheduledOutcome;
+    [key: string]: unknown;
+  };
+}
+
+export type IChatScheduledOutcomeStatus =
+  | 'queued'
+  | 'running'
+  | 'success'
+  | 'failed'
+  | 'needs_user_input'
+  | 'unknown'
+  | 'unverified';
+
+export interface IChatScheduledOutcome {
+  status: IChatScheduledOutcomeStatus;
+  reason: string;
+  completion_type: 'answer' | 'article' | 'unknown';
+  artifact_ids: string[];
+  artifact_urls?: string[];
+  can_confirm?: boolean;
+  can_retry?: boolean;
+  can_resume?: boolean;
 }
 
 export interface IChatConversationOptions {

--- a/src/operators/scheduledTasks.test.ts
+++ b/src/operators/scheduledTasks.test.ts
@@ -1,0 +1,45 @@
+import axios from 'axios';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { scheduledTasksOperator } from './scheduledTasks';
+
+vi.mock('axios', () => ({
+  default: { post: vi.fn() }
+}));
+
+const post = vi.mocked(axios.post);
+
+describe('scheduledTasksOperator outcome actions', () => {
+  beforeEach(() => post.mockReset());
+
+  it('requests automatic completion-rule inference', async () => {
+    post.mockResolvedValue({ data: { completion_rule: { type: 'answer', source: 'auto', reason: 'summary' } } });
+    await expect(
+      scheduledTasksOperator.inferCompletionRule('token', {
+        name: 'Daily brief',
+        template: { model: 'gpt-5.5', question: 'Summarize today' }
+      })
+    ).resolves.toMatchObject({ type: 'answer' });
+    expect(post).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ action: 'infer_completion_rule', name: 'Daily brief' }),
+      expect.any(Object)
+    );
+  });
+
+  it('sends confirm, retry, and resume actions without deriving permissions locally', async () => {
+    post
+      .mockResolvedValueOnce({ data: { id: 'run-1', status: 'success' } })
+      .mockResolvedValueOnce({ data: { accepted: true, run_id: 'run-2' } })
+      .mockResolvedValueOnce({ data: { id: 'task-1', state: 'enabled' } });
+
+    await scheduledTasksOperator.confirmRun('token', 'run-1', 'published', 'https://zhuanlan.zhihu.com/p/1');
+    await scheduledTasksOperator.retryRun('token', 'run-1');
+    await scheduledTasksOperator.resumeTask('token', 'task-1');
+
+    expect(post.mock.calls.map(([, body]) => (body as { action: string }).action)).toEqual([
+      'confirm_run',
+      'retry_run',
+      'resume'
+    ]);
+  });
+});

--- a/src/operators/scheduledTasks.ts
+++ b/src/operators/scheduledTasks.ts
@@ -13,6 +13,28 @@ function headers(token: string) {
 
 const BASE = `${BASE_URL_API}/aichat2/scheduled-tasks`;
 
+export type ScheduledCompletionType = 'answer' | 'article' | 'unknown';
+export type ScheduledArticleChannel = 'zhihu' | 'csdn';
+export type ScheduledOutcomeStatus =
+  | 'queued'
+  | 'running'
+  | 'success'
+  | 'failed'
+  | 'needs_user_input'
+  | 'unknown'
+  | 'unverified';
+
+export interface IScheduledCompletionRule {
+  type: ScheduledCompletionType;
+  channel?: ScheduledArticleChannel;
+  source: 'auto' | 'user' | 'runtime';
+  reason: string;
+  confidence?: number;
+  classifier_version?: number;
+  classified_at?: number;
+  input_hash?: string;
+}
+
 export interface IScheduledTask {
   id: string;
   name: string;
@@ -27,6 +49,12 @@ export interface IScheduledTask {
     max_turns?: number;
   };
   unattended_policy?: IScheduledTaskUnattendedPolicy;
+  completion_rule?: IScheduledCompletionRule;
+  pause_reason?: 'needs_user_input' | 'unknown_result' | 'consecutive_failures';
+  last_outcome?: Exclude<ScheduledOutcomeStatus, 'queued' | 'running'>;
+  last_outcome_reason?: string;
+  consecutive_business_failures?: number;
+  can_resume?: boolean;
   run_count: number;
   last_output_snippet?: string;
   last_error?: string;
@@ -37,7 +65,19 @@ export interface IScheduledTask {
 export interface IScheduledRun {
   id: string;
   task_id: string;
-  status: 'queued' | 'running' | 'success' | 'failed' | 'needs_user_input';
+  status: ScheduledOutcomeStatus;
+  completion_rule?: IScheduledCompletionRule;
+  outcome_reason?: string;
+  artifact_ids?: string[];
+  artifact_urls?: string[];
+  confirmation?: {
+    result: 'published' | 'not_published';
+    url?: string;
+    confirmed_at: number;
+  };
+  retry_run_id?: string;
+  can_confirm?: boolean;
+  can_retry?: boolean;
   scheduled_at: number;
   llm_started_at?: number;
   llm_finished_at?: number;
@@ -105,12 +145,23 @@ export function extractSkillNotActive(error: unknown): IScheduledTaskCapabilityD
   return data.detail ?? { kind: 'skill', slug: '', reason: 'not_active' };
 }
 
+export function extractCompletionRuleRequired(error: unknown): IScheduledCompletionRule | null {
+  const data = (
+    error as {
+      response?: { data?: { error?: string; detail?: { completion_rule?: IScheduledCompletionRule } } };
+    }
+  )?.response?.data;
+  if (data?.error !== 'completion_rule_required') return null;
+  return data.detail?.completion_rule ?? null;
+}
+
 export type ScheduledTaskPayload = {
   name: string;
   description?: string;
   schedule: IScheduleSpec;
   template: IScheduledTask['template'];
   unattended_policy?: IScheduledTaskUnattendedPolicy;
+  completion_rule?: Pick<IScheduledCompletionRule, 'type' | 'channel'>;
 };
 
 class ScheduledTasksOperator {
@@ -158,6 +209,61 @@ class ScheduledTasksOperator {
   async listRuns(token: string, id: string): Promise<IScheduledRun[]> {
     const { data } = await axios.post(BASE, { action: 'retrieve_runs', id }, { headers: headers(token) });
     return data?.items ?? [];
+  }
+
+  async inferCompletionRule(
+    token: string,
+    payload: Pick<ScheduledTaskPayload, 'name' | 'template'>
+  ): Promise<IScheduledCompletionRule> {
+    const { data } = await axios.post(
+      BASE,
+      { action: 'infer_completion_rule', ...payload },
+      { headers: headers(token) }
+    );
+    return data.completion_rule;
+  }
+
+  async overrideCompletionRule(
+    token: string,
+    id: string,
+    type: Exclude<ScheduledCompletionType, 'unknown'>,
+    channel?: ScheduledArticleChannel
+  ): Promise<IScheduledTask> {
+    const { data } = await axios.post(
+      BASE,
+      { action: 'override_completion_rule', id, type, ...(channel ? { channel } : {}) },
+      { headers: headers(token) }
+    );
+    return data;
+  }
+
+  async useAutoCompletionRule(token: string, id: string): Promise<IScheduledTask> {
+    const { data } = await axios.post(BASE, { action: 'use_auto_completion_rule', id }, { headers: headers(token) });
+    return data;
+  }
+
+  async confirmRun(
+    token: string,
+    id: string,
+    result: 'published' | 'not_published',
+    url?: string
+  ): Promise<IScheduledRun> {
+    const { data } = await axios.post(
+      BASE,
+      { action: 'confirm_run', id, result, ...(url ? { url } : {}) },
+      { headers: headers(token) }
+    );
+    return data;
+  }
+
+  async retryRun(token: string, id: string): Promise<{ accepted: boolean; run_id: string }> {
+    const { data } = await axios.post(BASE, { action: 'retry_run', id }, { headers: headers(token) });
+    return data;
+  }
+
+  async resumeTask(token: string, id: string): Promise<IScheduledTask> {
+    const { data } = await axios.post(BASE, { action: 'resume', id }, { headers: headers(token) });
+    return data;
   }
 
   async listAuthorizableSkills(token: string): Promise<IAuthorizableSkill[]> {

--- a/src/pages/chat/Conversation.vue
+++ b/src/pages/chat/Conversation.vue
@@ -34,8 +34,68 @@
         :share-id="conversation?.share_id"
         @update:share-id="onShareIdUpdated"
       />
-      <div :class="{ dialogue: true, empty: messages.length === 0 }">
-        <div v-if="messages.length > 0" class="messages">
+      <div :class="{ dialogue: true, empty: messages.length === 0 && !scheduledOutcome }">
+        <div v-if="messages.length > 0 || scheduledOutcome" class="messages">
+          <div v-if="scheduledOutcome" class="scheduled-outcome-bar">
+            <scheduled-outcome-status :status="scheduledOutcome.status" :reason="scheduledOutcome.reason">
+              <el-button
+                v-for="url in scheduledOutcome.artifact_urls"
+                :key="url"
+                tag="a"
+                :href="url"
+                target="_blank"
+                rel="noopener noreferrer"
+                text
+                type="primary"
+                size="small"
+              >
+                <font-awesome-icon icon="fa-solid fa-up-right-from-square" />
+                {{ $t('chat.scheduledTasks.openArticle') }}
+              </el-button>
+              <el-button
+                v-if="scheduledOutcome.can_confirm"
+                text
+                type="success"
+                size="small"
+                :loading="scheduledOutcomeAction === 'confirm'"
+                @click="confirmScheduledPublished"
+              >
+                {{ $t('chat.scheduledTasks.confirmPublished') }}
+              </el-button>
+              <el-button
+                v-if="scheduledOutcome.can_confirm"
+                text
+                type="danger"
+                size="small"
+                :disabled="!!scheduledOutcomeAction"
+                @click="confirmScheduledNotPublished"
+              >
+                {{ $t('chat.scheduledTasks.confirmNotPublished') }}
+              </el-button>
+              <el-button
+                v-if="scheduledOutcome.can_retry"
+                text
+                type="primary"
+                size="small"
+                :loading="scheduledOutcomeAction === 'retry'"
+                @click="retryScheduledRun"
+              >
+                <font-awesome-icon v-if="scheduledOutcomeAction !== 'retry'" icon="fa-solid fa-rotate-right" />
+                {{ $t('chat.scheduledTasks.retry') }}
+              </el-button>
+              <el-button
+                v-if="scheduledOutcome.can_resume"
+                text
+                type="primary"
+                size="small"
+                :loading="scheduledOutcomeAction === 'resume'"
+                @click="resumeScheduledTask"
+              >
+                <font-awesome-icon v-if="scheduledOutcomeAction !== 'resume'" icon="fa-solid fa-play" />
+                {{ $t('chat.scheduledTasks.resume') }}
+              </el-button>
+            </scheduled-outcome-status>
+          </div>
           <message
             v-for="(message, messageIndex) in messages"
             :key="messageIndex"
@@ -80,6 +140,7 @@ import {
   IChatMessageState,
   IChatConversationResponse,
   IChatConversation,
+  IChatScheduledOutcome,
   IChatMessage,
   IChatReference,
   BaseError
@@ -89,6 +150,7 @@ import ModelSelector from '@/components/chat/ModelSelector.vue';
 import DesktopAgentManager from '@/components/chat/DesktopAgentManager.vue';
 import BYOKBadge from '@/components/chat/BYOKBadge.vue';
 import ShareConversationDialog from '@/components/chat/ShareConversationDialog.vue';
+import ScheduledOutcomeStatus from '@/components/chat/ScheduledOutcomeStatus.vue';
 import { ERROR_CODE_CANCELED, ERROR_CODE_NOT_APPLIED, ERROR_CODE_UNKNOWN } from '@/constants/errorCode';
 import { Status } from '@/models';
 import Disclaimer from '@/components/chat/Disclaimer.vue';
@@ -109,7 +171,8 @@ import {
 } from '@/components/chat/consentReturn';
 import { hasLoadedConversationMessages } from '@/components/chat/conversationRestore';
 import { chatOperator, agentOperator } from '@/operators';
-import { ElTooltip, ElButton } from 'element-plus';
+import { scheduledTasksOperator } from '@/operators/scheduledTasks';
+import { ElTooltip, ElButton, ElMessage, ElMessageBox } from 'element-plus';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 
 export interface IData {
@@ -160,6 +223,10 @@ export interface IData {
   // it to invalidate a run whose `localExec.invoke()` is still pending, so Stop
   // cancels the auto-resume even after the finalizer captured the pending tool.
   clientToolRunId: number;
+  scheduledOutcome: IChatScheduledOutcome | null;
+  scheduledTaskId: string | undefined;
+  scheduledRunId: string | undefined;
+  scheduledOutcomeAction: '' | 'confirm' | 'retry' | 'resume';
 }
 
 export default defineComponent({
@@ -172,6 +239,7 @@ export default defineComponent({
     DesktopAgentManager,
     'byok-badge': BYOKBadge,
     ShareConversationDialog,
+    ScheduledOutcomeStatus,
     Message,
     Layout,
     ElTooltip,
@@ -197,7 +265,11 @@ export default defineComponent({
       shareDialogVisible: false,
       skipNextRestoreId: undefined,
       messages: [],
-      pendingConsentReturn: null
+      pendingConsentReturn: null,
+      scheduledOutcome: null,
+      scheduledTaskId: undefined,
+      scheduledRunId: undefined,
+      scheduledOutcomeAction: ''
     };
   },
   computed: {
@@ -333,9 +405,112 @@ export default defineComponent({
       this.messages = [];
       this.question = '';
       this.references = [];
+      this.applyScheduledContext(undefined);
       // Drop any deferred desktop client tool from a prior turn so a new chat
       // never auto-runs a stale tool against the wrong conversation.
       this.pendingClientTools = [];
+    },
+    applyScheduledContext(conversation: IChatConversation | undefined) {
+      const metadata = conversation?.metadata;
+      if (metadata?.source !== 'scheduled_task' || !metadata.scheduled_outcome) {
+        this.scheduledOutcome = null;
+        this.scheduledTaskId = undefined;
+        this.scheduledRunId = undefined;
+        this.scheduledOutcomeAction = '';
+        return;
+      }
+      this.scheduledOutcome = metadata.scheduled_outcome;
+      this.scheduledTaskId = metadata.scheduled_task_id;
+      this.scheduledRunId = metadata.run_id;
+    },
+    async refreshScheduledOutcome() {
+      if (!this.conversationId) return;
+      const conversation = (await this.$store.dispatch('chat/getConversation', this.conversationId)) as
+        | IChatConversation
+        | undefined;
+      this.applyScheduledContext(conversation);
+    },
+    async confirmScheduledPublished() {
+      if (!this.credential?.token || !this.scheduledRunId || this.scheduledOutcomeAction) return;
+      let url = '';
+      try {
+        const result = await ElMessageBox.prompt(
+          this.$t('chat.scheduledTasks.confirmPublishedPrompt') as string,
+          this.$t('chat.scheduledTasks.confirmPublished') as string,
+          {
+            inputPlaceholder: 'https://',
+            inputPattern: /^https:\/\/.+/,
+            inputErrorMessage: this.$t('chat.scheduledTasks.articleUrlInvalid') as string,
+            confirmButtonText: this.$t('common.button.confirm') as string,
+            cancelButtonText: this.$t('common.button.cancel') as string
+          }
+        );
+        url = result.value.trim();
+      } catch {
+        return;
+      }
+      this.scheduledOutcomeAction = 'confirm';
+      try {
+        await scheduledTasksOperator.confirmRun(this.credential.token, this.scheduledRunId, 'published', url);
+        await this.refreshScheduledOutcome();
+        ElMessage.success(this.$t('chat.scheduledTasks.confirmSuccess') as string);
+      } catch {
+        ElMessage.error(this.$t('chat.scheduledTasks.actionError') as string);
+      } finally {
+        this.scheduledOutcomeAction = '';
+      }
+    },
+    async confirmScheduledNotPublished() {
+      if (!this.credential?.token || !this.scheduledRunId || this.scheduledOutcomeAction) return;
+      try {
+        await ElMessageBox.confirm(
+          this.$t('chat.scheduledTasks.confirmNotPublishedPrompt') as string,
+          this.$t('chat.scheduledTasks.confirmNotPublished') as string,
+          {
+            type: 'warning',
+            confirmButtonText: this.$t('common.button.confirm') as string,
+            cancelButtonText: this.$t('common.button.cancel') as string
+          }
+        );
+      } catch {
+        return;
+      }
+      this.scheduledOutcomeAction = 'confirm';
+      try {
+        await scheduledTasksOperator.confirmRun(this.credential.token, this.scheduledRunId, 'not_published');
+        await this.refreshScheduledOutcome();
+        ElMessage.success(this.$t('chat.scheduledTasks.confirmSuccess') as string);
+      } catch {
+        ElMessage.error(this.$t('chat.scheduledTasks.actionError') as string);
+      } finally {
+        this.scheduledOutcomeAction = '';
+      }
+    },
+    async retryScheduledRun() {
+      if (!this.credential?.token || !this.scheduledRunId || this.scheduledOutcomeAction) return;
+      this.scheduledOutcomeAction = 'retry';
+      try {
+        await scheduledTasksOperator.retryRun(this.credential.token, this.scheduledRunId);
+        await this.refreshScheduledOutcome();
+        ElMessage.success(this.$t('chat.scheduledTasks.retrySuccess') as string);
+      } catch {
+        ElMessage.error(this.$t('chat.scheduledTasks.actionError') as string);
+      } finally {
+        this.scheduledOutcomeAction = '';
+      }
+    },
+    async resumeScheduledTask() {
+      if (!this.credential?.token || !this.scheduledTaskId || this.scheduledOutcomeAction) return;
+      this.scheduledOutcomeAction = 'resume';
+      try {
+        await scheduledTasksOperator.resumeTask(this.credential.token, this.scheduledTaskId);
+        await this.refreshScheduledOutcome();
+        ElMessage.success(this.$t('chat.scheduledTasks.resumeSuccess') as string);
+      } catch {
+        ElMessage.error(this.$t('chat.scheduledTasks.actionError') as string);
+      } finally {
+        this.scheduledOutcomeAction = '';
+      }
     },
     onShareIdUpdated(shareId?: string) {
       // Keep the store conversation in sync so the dialog reopens with the
@@ -631,6 +806,7 @@ export default defineComponent({
       const targetModelGroup = CHAT_MODEL_GROUPS.find((g) => g.name === targetModel?.modelGroup);
       if (targetModelGroup) this.$store.dispatch('chat/setModelGroup', targetModelGroup);
       if (targetModel) this.$store.dispatch('chat/setModel', targetModel);
+      this.applyScheduledContext(conversation);
       this.messages = conversation?.messages || [];
       this.onScrollDown();
     },
@@ -1607,6 +1783,14 @@ export default defineComponent({
     .message {
       margin-bottom: 15px;
     }
+    .scheduled-outcome-bar {
+      margin: 0 0 18px;
+      padding: 12px 14px;
+      border-left: 3px solid var(--el-color-primary);
+      border-radius: 0 6px 6px 0;
+      background: var(--el-fill-color-extra-light);
+      font-size: 13px;
+    }
   }
   .starter {
     height: fit-content;
@@ -1639,6 +1823,10 @@ export default defineComponent({
   // Match the composer's mobile left control inset (.tools left:10px).
   .dialogue .composer-connectors {
     padding: 4px 10px;
+  }
+
+  .dialogue .messages .scheduled-outcome-bar {
+    padding: 11px 12px;
   }
 }
 </style>

--- a/src/pages/chat/ScheduledTasks.test.ts
+++ b/src/pages/chat/ScheduledTasks.test.ts
@@ -81,7 +81,11 @@ describe('chat/ScheduledTasks', () => {
       cronExpr: '0 9 * * *',
       authorizedSkills: [],
       authorizedMcpServers: [],
-      maxTurns: 50
+      maxTurns: 50,
+      completionMode: 'auto',
+      completionChannel: 'zhihu',
+      completionRule: null,
+      showCompletionChoices: false
     });
   });
 
@@ -111,5 +115,29 @@ describe('chat/ScheduledTasks', () => {
     expect(vm.editingTask).toMatchObject({ id: editedTask.id });
     expect(vm.form).toMatchObject({ name: 'Existing task' });
     expect(vm.showCreateDialog).toBe(true);
+  });
+
+  it('invalidates a pending inference before editing another task', async () => {
+    const wrapper = mountComponent();
+    const vm = wrapper.vm as unknown as {
+      openEdit: (task: IScheduledTask) => void;
+      completionInferenceRequest: number;
+      completionRuleLoading: boolean;
+      form: { completionRule: unknown };
+    };
+    await wrapper.setData({ completionInferenceRequest: 4, completionRuleLoading: true });
+
+    vm.openEdit({
+      ...editedTask,
+      completion_rule: {
+        type: 'answer',
+        source: 'auto',
+        reason: 'Existing task rule'
+      }
+    });
+
+    expect(vm.completionInferenceRequest).toBe(5);
+    expect(vm.completionRuleLoading).toBe(false);
+    expect(vm.form.completionRule).toMatchObject({ reason: 'Existing task rule' });
   });
 });

--- a/src/pages/chat/ScheduledTasks.vue
+++ b/src/pages/chat/ScheduledTasks.vue
@@ -21,10 +21,22 @@
               <div class="task-actions" @click.stop>
                 <el-switch
                   :model-value="task.state === 'enabled'"
+                  :disabled="task.state === 'error'"
                   @change="(v: string | number | boolean) => toggleState(task, v === true)"
                 />
+                <el-tooltip v-if="task.can_resume" :content="$t('chat.scheduledTasks.resume')" placement="top">
+                  <el-button text class="icon-action" :loading="resumingId === task.id" @click="resumeTask(task)">
+                    <font-awesome-icon v-if="resumingId !== task.id" icon="fa-solid fa-rotate-right" />
+                  </el-button>
+                </el-tooltip>
                 <el-tooltip :content="$t('chat.scheduledTasks.triggerNow')" placement="top">
-                  <el-button text class="icon-action" :loading="triggeringId === task.id" @click="triggerNow(task)">
+                  <el-button
+                    text
+                    class="icon-action"
+                    :disabled="task.last_outcome === 'unknown'"
+                    :loading="triggeringId === task.id"
+                    @click="triggerNow(task)"
+                  >
                     <font-awesome-icon v-if="triggeringId !== task.id" icon="fa-solid fa-play" />
                   </el-button>
                 </el-tooltip>
@@ -52,8 +64,19 @@
                 <font-awesome-icon icon="fa-solid fa-brain" class="meta-icon" />
                 {{ task.template.model }}
               </span>
+              <span class="meta-chip completion-chip">
+                <font-awesome-icon icon="fa-solid fa-circle-info" class="meta-icon" />
+                {{ completionRuleText(task.completion_rule) }}
+              </span>
             </div>
             <div class="task-prompt">{{ task.template.question }}</div>
+            <scheduled-outcome-status
+              v-if="taskOutcomeStatus(task)"
+              class="task-outcome"
+              :status="taskOutcomeStatus(task) || 'unverified'"
+              :reason="taskOutcomeReason(task)"
+              compact
+            />
             <div v-if="task.last_output_snippet" class="task-last-output">
               {{ task.last_output_snippet }}
             </div>
@@ -92,38 +115,95 @@
           <span>{{ $t('chat.scheduledTasks.runCount', { count: selectedTask.run_count }) }}</span>
         </div>
         <div class="run-context-prompt">{{ selectedTask.template.question }}</div>
+        <el-button
+          v-if="selectedTask.can_resume"
+          class="resume-task"
+          type="primary"
+          plain
+          size="small"
+          :loading="resumingId === selectedTask.id"
+          @click="resumeTask(selectedTask)"
+        >
+          <font-awesome-icon v-if="resumingId !== selectedTask.id" icon="fa-solid fa-rotate-right" />
+          {{ $t('chat.scheduledTasks.resume') }}
+        </el-button>
       </div>
       <el-skeleton v-if="runsLoading" :rows="3" animated />
       <el-empty v-else-if="!runs.length" :description="$t('chat.scheduledTasks.noRuns')" />
       <div v-else class="run-list">
-        <div
-          v-for="run in pagedRuns"
-          :key="run.id"
-          class="run-item"
-          :class="{ clickable: !!run.conversation_id }"
-          :tabindex="run.conversation_id ? 0 : -1"
-          :role="run.conversation_id ? 'button' : undefined"
-          @click="openRun(run)"
-          @keydown.enter="openRun(run)"
-          @keydown.space.prevent="openRun(run)"
-        >
+        <div v-for="run in pagedRuns" :key="run.id" class="run-item">
           <div class="run-body">
             <div class="run-line">
               <span class="run-title">{{ run.conversation_title || formatTime(run.scheduled_at) }}</span>
-              <el-tag size="small" :type="runTagType(run.status)" effect="dark" round class="run-tag">
-                {{ $t(`chat.scheduledTasks.run.${run.status}`) }}
-              </el-tag>
+              <scheduled-outcome-status :status="run.status" compact class="run-status" />
             </div>
             <div v-if="run.conversation_preview" class="run-preview">{{ run.conversation_preview }}</div>
+            <div v-if="run.outcome_reason" class="run-reason">{{ run.outcome_reason }}</div>
             <div class="run-sub">
               <span class="run-time">{{ formatTime(run.scheduled_at) }}</span>
               <span v-if="run.error_code || run.error_message" class="run-error" :title="runErrorText(run)">
                 {{ runErrorText(run) }}
               </span>
             </div>
+            <div
+              v-if="run.artifact_urls?.length || run.can_confirm || run.can_retry"
+              class="run-controls"
+              @click.stop
+              @keydown.stop
+            >
+              <el-button
+                v-for="url in run.artifact_urls"
+                :key="url"
+                tag="a"
+                :href="url"
+                target="_blank"
+                rel="noopener noreferrer"
+                text
+                type="primary"
+                size="small"
+              >
+                <font-awesome-icon icon="fa-solid fa-up-right-from-square" />
+                {{ $t('chat.scheduledTasks.openArticle') }}
+              </el-button>
+              <el-button
+                v-if="run.can_confirm"
+                text
+                type="success"
+                size="small"
+                :loading="runActionId === run.id"
+                @click="confirmPublished(run)"
+              >
+                {{ $t('chat.scheduledTasks.confirmPublished') }}
+              </el-button>
+              <el-button
+                v-if="run.can_confirm"
+                text
+                type="danger"
+                size="small"
+                :disabled="!!runActionId"
+                @click="confirmNotPublished(run)"
+              >
+                {{ $t('chat.scheduledTasks.confirmNotPublished') }}
+              </el-button>
+              <el-button
+                v-if="run.can_retry"
+                text
+                type="primary"
+                size="small"
+                :loading="runActionId === run.id"
+                @click="retryRun(run)"
+              >
+                <font-awesome-icon v-if="runActionId !== run.id" icon="fa-solid fa-rotate-right" />
+                {{ $t('chat.scheduledTasks.retry') }}
+              </el-button>
+            </div>
           </div>
           <div class="run-action">
-            <font-awesome-icon v-if="run.conversation_id" icon="fa-solid fa-chevron-right" class="run-arrow" />
+            <el-tooltip v-if="run.conversation_id" :content="$t('chat.scheduledTasks.viewResult')" placement="left">
+              <el-button text class="run-open" :aria-label="$t('chat.scheduledTasks.viewResult')" @click="openRun(run)">
+                <font-awesome-icon icon="fa-solid fa-chevron-right" class="run-arrow" />
+              </el-button>
+            </el-tooltip>
             <span v-else class="run-noconv">{{ $t('chat.scheduledTasks.noConversation') }}</span>
           </div>
         </div>
@@ -142,6 +222,7 @@
       :close-on-press-escape="!saving"
       :show-close="!saving"
       class="scheduled-task-dialog"
+      @closed="onTaskDialogClosed"
     >
       <el-form :model="form" label-width="92px">
         <el-form-item :label="$t('chat.scheduledTasks.form.name')">
@@ -270,6 +351,56 @@
           <div class="hint">{{ $t('chat.scheduledTasks.form.mcpServersHint') }}</div>
         </el-form-item>
 
+        <el-form-item :label="$t('chat.scheduledTasks.form.completionRule')">
+          <div class="completion-rule-box">
+            <div v-if="completionRuleLoading" class="completion-rule-loading">
+              <font-awesome-icon icon="fa-solid fa-spinner" spin />
+              {{ $t('chat.scheduledTasks.form.completionRuleLoading') }}
+            </div>
+            <template v-else>
+              <div class="completion-rule-heading">
+                <div>
+                  <div class="completion-rule-title">{{ formCompletionRuleText() }}</div>
+                  <div class="completion-rule-source">
+                    {{
+                      $t(
+                        form.completionMode === 'auto'
+                          ? 'chat.scheduledTasks.form.completionRuleAuto'
+                          : 'chat.scheduledTasks.form.completionRuleUser'
+                      )
+                    }}
+                  </div>
+                </div>
+                <el-button text type="primary" @click="form.showCompletionChoices = !form.showCompletionChoices">
+                  {{ $t('chat.scheduledTasks.form.completionRuleCorrect') }}
+                </el-button>
+              </div>
+              <div class="completion-rule-reason">{{ formCompletionRuleReason() }}</div>
+            </template>
+            <div v-if="form.showCompletionChoices || formCompletionNeedsChoice()" class="completion-rule-choices">
+              <el-radio-group v-model="form.completionMode" @change="onCompletionModeChange">
+                <el-radio-button value="auto">{{
+                  $t('chat.scheduledTasks.form.completionRuleAutoOption')
+                }}</el-radio-button>
+                <el-radio-button value="answer">{{
+                  $t('chat.scheduledTasks.form.completionRuleAnswer')
+                }}</el-radio-button>
+                <el-radio-button value="article">{{
+                  $t('chat.scheduledTasks.form.completionRuleArticle')
+                }}</el-radio-button>
+              </el-radio-group>
+              <el-select
+                v-if="form.completionMode === 'article'"
+                v-model="form.completionChannel"
+                class="channel-select"
+              >
+                <el-option :label="$t('chat.scheduledTasks.form.channelZhihu')" value="zhihu" />
+                <el-option :label="$t('chat.scheduledTasks.form.channelCsdn')" value="csdn" />
+              </el-select>
+            </div>
+          </div>
+        </el-form-item>
+
         <el-form-item :label="$t('chat.scheduledTasks.form.maxTurns')">
           <el-input-number v-model="form.maxTurns" :min="1" :max="50" :step="1" controls-position="right" />
           <div class="hint">{{ $t('chat.scheduledTasks.form.maxTurnsHint') }}</div>
@@ -278,7 +409,7 @@
 
       <template #footer>
         <el-button :disabled="saving" @click="closeTaskDialog">{{ $t('common.button.cancel') }}</el-button>
-        <el-button type="primary" :loading="saving" @click="saveTask">
+        <el-button type="primary" :loading="saving" :disabled="completionRuleLoading" @click="saveTask">
           {{ $t('common.button.confirm') }}
         </el-button>
       </template>
@@ -307,12 +438,14 @@ import {
   ElOptionGroup,
   ElRadioGroup,
   ElRadio,
+  ElRadioButton,
   ElTimePicker,
   ElInputNumber,
   ElMessage,
   ElMessageBox
 } from 'element-plus';
 import Pagination from '@/components/common/Pagination.vue';
+import ScheduledOutcomeStatus from '@/components/chat/ScheduledOutcomeStatus.vue';
 import {
   scheduledTasksOperator,
   IScheduledTask,
@@ -320,8 +453,12 @@ import {
   IScheduleSpec,
   IAuthorizableSkill,
   IAuthorizableMcpServer,
+  IScheduledCompletionRule,
+  ScheduledArticleChannel,
+  ScheduledOutcomeStatus as ScheduledOutcomeStatusValue,
   ScheduledTaskPayload,
   IScheduledTaskCapabilityDetail,
+  extractCompletionRuleRequired,
   extractSkillNotActive
 } from '@/operators/scheduledTasks';
 import { CHAT_MODEL_GROUPS, CHAT_MODEL_NAME_GPT_5_4_MINI } from '@/constants';
@@ -347,6 +484,10 @@ interface TaskForm {
   authorizedSkills: string[];
   authorizedMcpServers: string[];
   maxTurns: number;
+  completionMode: 'auto' | 'answer' | 'article';
+  completionChannel: ScheduledArticleChannel;
+  completionRule: IScheduledCompletionRule | null;
+  showCompletionChoices: boolean;
 }
 
 export default defineComponent({
@@ -370,9 +511,11 @@ export default defineComponent({
     ElOptionGroup,
     ElRadioGroup,
     ElRadio,
+    ElRadioButton,
     ElTimePicker,
     ElInputNumber,
-    Pagination
+    Pagination,
+    ScheduledOutcomeStatus
   },
   data() {
     return {
@@ -389,6 +532,11 @@ export default defineComponent({
       authorizableSkills: [] as IAuthorizableSkill[],
       authorizableMcpServers: [] as IAuthorizableMcpServer[],
       triggeringId: '' as string,
+      resumingId: '' as string,
+      runActionId: '' as string,
+      completionRuleLoading: false,
+      completionInferenceTimer: undefined as ReturnType<typeof setTimeout> | undefined,
+      completionInferenceRequest: 0,
       weekdays: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
       page: 1,
       pageSize: 6,
@@ -432,6 +580,23 @@ export default defineComponent({
   async mounted() {
     await this.loadTasks();
   },
+  beforeUnmount() {
+    if (this.completionInferenceTimer) clearTimeout(this.completionInferenceTimer);
+  },
+  watch: {
+    'form.name'() {
+      this.scheduleCompletionInference();
+    },
+    'form.question'() {
+      this.scheduleCompletionInference();
+    },
+    'form.authorizedSkills': {
+      deep: true,
+      handler() {
+        this.scheduleCompletionInference();
+      }
+    }
+  },
   methods: {
     emptyForm(): TaskForm {
       return {
@@ -447,13 +612,119 @@ export default defineComponent({
         cronExpr: '0 9 * * *',
         authorizedSkills: [],
         authorizedMcpServers: [],
-        maxTurns: DEFAULT_SCHEDULED_MAX_TURNS
+        maxTurns: DEFAULT_SCHEDULED_MAX_TURNS,
+        completionMode: 'auto',
+        completionChannel: 'zhihu',
+        completionRule: null,
+        showCompletionChoices: false
       };
     },
     // Fallback label when the user leaves the name field blank — derive from the prompt.
     deriveName(question: string): string {
       const firstLine = (question || '').trim().split('\n')[0].trim();
       return firstLine.length > 40 ? `${firstLine.slice(0, 40)}…` : firstLine || 'Scheduled Task';
+    },
+    completionRuleText(rule?: IScheduledCompletionRule): string {
+      if (rule?.type === 'answer') return this.$t('chat.scheduledTasks.form.completionRuleAnswer') as string;
+      if (rule?.type === 'article') {
+        const channel =
+          rule.channel === 'csdn'
+            ? this.$t('chat.scheduledTasks.form.channelCsdn')
+            : this.$t('chat.scheduledTasks.form.channelZhihu');
+        return this.$t('chat.scheduledTasks.form.completionRuleArticleChannel', { channel }) as string;
+      }
+      return this.$t('chat.scheduledTasks.form.completionRuleUnknown') as string;
+    },
+    formCompletionRuleText(): string {
+      if (this.form.completionMode === 'answer') {
+        return this.$t('chat.scheduledTasks.form.completionRuleAnswer') as string;
+      }
+      if (this.form.completionMode === 'article') {
+        return this.completionRuleText({
+          type: 'article',
+          channel: this.form.completionChannel,
+          source: 'user',
+          reason: ''
+        });
+      }
+      return this.completionRuleText(this.form.completionRule ?? undefined);
+    },
+    formCompletionRuleReason(): string {
+      if (this.form.completionMode !== 'auto') {
+        return this.$t('chat.scheduledTasks.form.completionRuleUserReason') as string;
+      }
+      return this.form.completionRule?.reason || (this.$t('chat.scheduledTasks.form.completionRulePrompt') as string);
+    },
+    formCompletionNeedsChoice(): boolean {
+      return this.form.completionMode === 'auto' && this.form.completionRule?.type === 'unknown';
+    },
+    onCompletionModeChange(value: string | number | boolean | undefined) {
+      if (value !== 'auto' && value !== 'answer' && value !== 'article') return;
+      this.form.completionMode = value;
+      if (value === 'auto') {
+        this.scheduleCompletionInference();
+      } else {
+        if (this.completionInferenceTimer) clearTimeout(this.completionInferenceTimer);
+        this.completionInferenceRequest += 1;
+        this.completionRuleLoading = false;
+      }
+    },
+    scheduleCompletionInference() {
+      if (!this.showCreateDialog || this.form.completionMode !== 'auto') return;
+      if (this.completionInferenceTimer) clearTimeout(this.completionInferenceTimer);
+      const question = this.form.question.trim();
+      if (!this.token || !question) {
+        this.completionInferenceRequest += 1;
+        this.completionRuleLoading = false;
+        this.form.completionRule = null;
+        return;
+      }
+      this.completionRuleLoading = true;
+      const requestId = ++this.completionInferenceRequest;
+      this.completionInferenceTimer = setTimeout(() => {
+        void this.inferCompletionRule(requestId);
+      }, 500);
+    },
+    async inferCompletionRule(requestId: number) {
+      try {
+        const rule = await scheduledTasksOperator.inferCompletionRule(this.token!, {
+          name: this.form.name.trim() || this.deriveName(this.form.question),
+          template: {
+            model: this.form.model,
+            question: this.form.question,
+            skills: [...this.form.authorizedSkills]
+          }
+        });
+        if (requestId !== this.completionInferenceRequest || this.form.completionMode !== 'auto') return;
+        this.form.completionRule = rule;
+        this.form.completionChannel = rule.channel ?? this.form.completionChannel;
+        this.form.showCompletionChoices = rule.type === 'unknown';
+      } catch {
+        if (requestId !== this.completionInferenceRequest || this.form.completionMode !== 'auto') return;
+        this.form.completionRule = {
+          type: 'unknown',
+          source: 'auto',
+          reason: this.$t('chat.scheduledTasks.form.completionRuleInferenceError') as string
+        };
+        this.form.showCompletionChoices = true;
+      } finally {
+        if (requestId === this.completionInferenceRequest) this.completionRuleLoading = false;
+      }
+    },
+    completionRulePayload(): ScheduledTaskPayload['completion_rule'] | undefined {
+      if (this.form.completionMode === 'answer') return { type: 'answer' };
+      if (this.form.completionMode === 'article') {
+        return { type: 'article', channel: this.form.completionChannel };
+      }
+      return undefined;
+    },
+    taskOutcomeStatus(task: IScheduledTask): ScheduledOutcomeStatusValue | undefined {
+      if (task.last_outcome) return task.last_outcome;
+      return task.completion_rule ? undefined : 'unverified';
+    },
+    taskOutcomeReason(task: IScheduledTask): string {
+      if (task.last_outcome_reason) return task.last_outcome_reason;
+      return task.completion_rule ? '' : (this.$t('chat.scheduledTasks.form.completionRuleUnknown') as string);
     },
     async loadTasks() {
       if (!this.token) return;
@@ -488,15 +759,29 @@ export default defineComponent({
     },
     openCreate() {
       if (this.saving) return;
+      if (this.completionInferenceTimer) clearTimeout(this.completionInferenceTimer);
+      this.completionInferenceRequest += 1;
+      this.completionRuleLoading = false;
       this.editingTask = null;
       this.form = this.emptyForm();
       this.showCreateDialog = true;
     },
     closeTaskDialog() {
       if (this.saving) return;
+      if (this.completionInferenceTimer) clearTimeout(this.completionInferenceTimer);
+      this.completionInferenceRequest += 1;
+      this.completionRuleLoading = false;
       this.showCreateDialog = false;
     },
+    onTaskDialogClosed() {
+      if (this.completionInferenceTimer) clearTimeout(this.completionInferenceTimer);
+      this.completionInferenceRequest += 1;
+      this.completionRuleLoading = false;
+    },
     openEdit(task: IScheduledTask) {
+      if (this.completionInferenceTimer) clearTimeout(this.completionInferenceTimer);
+      this.completionInferenceRequest += 1;
+      this.completionRuleLoading = false;
       this.editingTask = task;
       const s = task.schedule;
       let scheduleType: TaskForm['scheduleType'] = 'cron';
@@ -555,10 +840,18 @@ export default defineComponent({
           task.unattended_policy?.mode === 'allow_selected' || task.unattended_policy?.mode === 'allow_selected_skills'
             ? task.unattended_policy.allowed_mcp_servers || []
             : [],
-        maxTurns: task.template.max_turns ?? DEFAULT_SCHEDULED_MAX_TURNS
+        maxTurns: task.template.max_turns ?? DEFAULT_SCHEDULED_MAX_TURNS,
+        completionMode:
+          task.completion_rule?.source === 'user' && task.completion_rule.type !== 'unknown'
+            ? task.completion_rule.type
+            : 'auto',
+        completionChannel: task.completion_rule?.channel ?? 'zhihu',
+        completionRule: task.completion_rule ?? null,
+        showCompletionChoices: !task.completion_rule || task.completion_rule.type === 'unknown'
       };
       this.showCreateDialog = true;
       void this.loadAuthorizableSkills();
+      if (!task.completion_rule) this.scheduleCompletionInference();
     },
     buildSchedule(): IScheduleSpec {
       const { scheduleType, intervalValue, intervalUnit, hourlyMinute, dailyTime, weekday, cronExpr } = this.form;
@@ -585,6 +878,14 @@ export default defineComponent({
     async saveTask() {
       if (!this.form.question.trim()) {
         ElMessage.warning(this.$t('chat.scheduledTasks.form.required') as string);
+        return;
+      }
+      if (
+        this.form.completionMode === 'auto' &&
+        (!this.form.completionRule || this.form.completionRule.type === 'unknown')
+      ) {
+        this.form.showCompletionChoices = true;
+        ElMessage.warning(this.$t('chat.scheduledTasks.form.completionRuleRequired') as string);
         return;
       }
       if (this.form.authorizedSkills.length > 0 || this.form.authorizedMcpServers.length > 0) {
@@ -623,7 +924,8 @@ export default defineComponent({
                 allowed_skills: authorizedSkills,
                 allowed_mcp_servers: authorizedMcpServers
               }
-            : { mode: 'deny_all' as const, allowed_skills: [], allowed_mcp_servers: [] }
+            : { mode: 'deny_all' as const, allowed_skills: [], allowed_mcp_servers: [] },
+        ...(this.completionRulePayload() ? { completion_rule: this.completionRulePayload() } : {})
       };
       await this.submitTask(payload, false);
     },
@@ -632,10 +934,16 @@ export default defineComponent({
       // A pending "skill not bound" prompt to raise AFTER `saving` is reset,
       // so the confirm dialog is interactive rather than stuck behind a spinner.
       let notActive: IScheduledTaskCapabilityDetail | null = null;
+      let completionRuleRequired: IScheduledCompletionRule | null = null;
       try {
         if (this.editingTask) {
           const editId = this.editingTask.id;
-          const updated = await scheduledTasksOperator.updateTask(this.token!, editId, payload, force);
+          const restoreAutomatic =
+            this.form.completionMode === 'auto' && this.editingTask.completion_rule?.source === 'user';
+          let updated = await scheduledTasksOperator.updateTask(this.token!, editId, payload, force);
+          if (restoreAutomatic) {
+            updated = await scheduledTasksOperator.useAutoCompletionRule(this.token!, editId);
+          }
           // Patch the edited row in place — no full reload / skeleton flash.
           const idx = this.tasks.findIndex((t) => t.id === editId);
           if (idx !== -1) this.tasks[idx] = updated;
@@ -652,7 +960,14 @@ export default defineComponent({
       } catch (error) {
         // On an already-forced retry, don't loop on the same gate — surface it.
         notActive = force ? null : extractSkillNotActive(error);
-        if (!notActive) {
+        completionRuleRequired = extractCompletionRuleRequired(error);
+        if (completionRuleRequired) {
+          this.form.completionMode = 'auto';
+          this.form.completionRule = completionRuleRequired;
+          this.form.completionChannel = completionRuleRequired.channel ?? this.form.completionChannel;
+          this.form.showCompletionChoices = true;
+          ElMessage.warning(this.$t('chat.scheduledTasks.form.completionRuleRequired') as string);
+        } else if (!notActive) {
           ElMessage.error(this.$t('chat.scheduledTasks.loadError') as string);
         }
       } finally {
@@ -733,6 +1048,7 @@ export default defineComponent({
       }) as string;
     },
     async toggleState(task: IScheduledTask, enabled: boolean) {
+      if (task.state === 'error') return;
       const idx = this.tasks.findIndex((t) => t.id === task.id);
       const nextState = enabled ? 'enabled' : 'disabled';
       // Reflect the switch immediately and patch just this row in place — no
@@ -744,6 +1060,102 @@ export default defineComponent({
       } catch {
         if (idx !== -1) this.tasks[idx] = { ...task, state: task.state };
         ElMessage.error(this.$t('chat.scheduledTasks.loadError') as string);
+      }
+    },
+    async refreshOutcomeData(taskId: string) {
+      if (!this.token) return;
+      const [tasks, runs] = await Promise.all([
+        scheduledTasksOperator.listTasks(this.token),
+        scheduledTasksOperator.listRuns(this.token, taskId)
+      ]);
+      this.tasks = tasks;
+      this.runs = runs;
+      const selected = tasks.find((task) => task.id === taskId);
+      if (selected && this.selectedTask?.id === taskId) this.selectedTask = selected;
+    },
+    async confirmPublished(run: IScheduledRun) {
+      if (this.runActionId) return;
+      let url = '';
+      try {
+        const result = await ElMessageBox.prompt(
+          this.$t('chat.scheduledTasks.confirmPublishedPrompt') as string,
+          this.$t('chat.scheduledTasks.confirmPublished') as string,
+          {
+            inputPlaceholder: 'https://',
+            inputPattern: /^https:\/\/.+/,
+            inputErrorMessage: this.$t('chat.scheduledTasks.articleUrlInvalid') as string,
+            confirmButtonText: this.$t('common.button.confirm') as string,
+            cancelButtonText: this.$t('common.button.cancel') as string
+          }
+        );
+        url = result.value.trim();
+      } catch {
+        return;
+      }
+      this.runActionId = run.id;
+      try {
+        await scheduledTasksOperator.confirmRun(this.token!, run.id, 'published', url);
+        await this.refreshOutcomeData(run.task_id);
+        ElMessage.success(this.$t('chat.scheduledTasks.confirmSuccess') as string);
+      } catch {
+        ElMessage.error(this.$t('chat.scheduledTasks.actionError') as string);
+      } finally {
+        this.runActionId = '';
+      }
+    },
+    async confirmNotPublished(run: IScheduledRun) {
+      if (this.runActionId) return;
+      try {
+        await ElMessageBox.confirm(
+          this.$t('chat.scheduledTasks.confirmNotPublishedPrompt') as string,
+          this.$t('chat.scheduledTasks.confirmNotPublished') as string,
+          {
+            type: 'warning',
+            confirmButtonText: this.$t('common.button.confirm') as string,
+            cancelButtonText: this.$t('common.button.cancel') as string
+          }
+        );
+      } catch {
+        return;
+      }
+      this.runActionId = run.id;
+      try {
+        await scheduledTasksOperator.confirmRun(this.token!, run.id, 'not_published');
+        await this.refreshOutcomeData(run.task_id);
+        ElMessage.success(this.$t('chat.scheduledTasks.confirmSuccess') as string);
+      } catch {
+        ElMessage.error(this.$t('chat.scheduledTasks.actionError') as string);
+      } finally {
+        this.runActionId = '';
+      }
+    },
+    async retryRun(run: IScheduledRun) {
+      if (this.runActionId) return;
+      this.runActionId = run.id;
+      try {
+        await scheduledTasksOperator.retryRun(this.token!, run.id);
+        await this.refreshOutcomeData(run.task_id);
+        this.runPage = 1;
+        ElMessage.success(this.$t('chat.scheduledTasks.retrySuccess') as string);
+      } catch {
+        ElMessage.error(this.$t('chat.scheduledTasks.actionError') as string);
+      } finally {
+        this.runActionId = '';
+      }
+    },
+    async resumeTask(task: IScheduledTask) {
+      if (this.resumingId) return;
+      this.resumingId = task.id;
+      try {
+        const updated = await scheduledTasksOperator.resumeTask(this.token!, task.id);
+        const index = this.tasks.findIndex((item) => item.id === task.id);
+        if (index !== -1) this.tasks[index] = updated;
+        if (this.selectedTask?.id === task.id) this.selectedTask = updated;
+        ElMessage.success(this.$t('chat.scheduledTasks.resumeSuccess') as string);
+      } catch {
+        ElMessage.error(this.$t('chat.scheduledTasks.actionError') as string);
+      } finally {
+        this.resumingId = '';
       }
     },
     async triggerNow(task: IScheduledTask) {
@@ -925,6 +1337,9 @@ export default defineComponent({
   font-size: 11px;
   opacity: 0.85;
 }
+.completion-chip {
+  color: var(--el-text-color-regular);
+}
 .task-prompt {
   font-size: 13px;
   line-height: 1.55;
@@ -935,6 +1350,10 @@ export default defineComponent({
   line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
+}
+.task-outcome {
+  margin-top: 10px;
+  max-width: 100%;
 }
 .task-last-output {
   font-size: 12px;
@@ -1018,6 +1437,9 @@ export default defineComponent({
   max-height: 48px;
   overflow: hidden;
 }
+.resume-task {
+  margin-top: 12px;
+}
 .run-list {
   display: flex;
   flex-direction: column;
@@ -1034,15 +1456,6 @@ export default defineComponent({
   transition:
     background 0.16s,
     border-color 0.16s;
-}
-.run-item.clickable {
-  cursor: pointer;
-}
-.run-item.clickable:hover,
-.run-item.clickable:focus-visible {
-  background: var(--el-fill-color-lighter);
-  border-color: var(--el-border-color);
-  outline: none;
 }
 .run-body {
   flex: 1;
@@ -1066,8 +1479,9 @@ export default defineComponent({
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.run-tag {
+.run-status {
   flex-shrink: 0;
+  max-width: 48%;
 }
 .run-preview {
   font-size: 12px;
@@ -1076,6 +1490,12 @@ export default defineComponent({
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+.run-reason {
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--el-text-color-regular);
+  word-break: break-word;
 }
 .run-sub {
   display: flex;
@@ -1095,6 +1515,16 @@ export default defineComponent({
   overflow: hidden;
   text-overflow: ellipsis;
 }
+.run-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+  margin-left: -8px;
+}
+.run-controls :deep(.el-button + .el-button) {
+  margin-left: 0;
+}
 .run-action {
   display: flex;
   align-items: center;
@@ -1105,6 +1535,11 @@ export default defineComponent({
   color: var(--el-text-color-secondary);
   font-size: 12px;
   flex-shrink: 0;
+}
+.run-open {
+  width: 32px;
+  height: 32px;
+  padding: 0;
 }
 .run-noconv {
   font-size: 11px;
@@ -1158,6 +1593,74 @@ export default defineComponent({
   flex-shrink: 0;
   font-size: 11px;
   color: var(--el-text-color-secondary);
+}
+.completion-rule-box {
+  width: 100%;
+  min-width: 0;
+  padding: 12px;
+  border: 1px solid var(--app-border-subtle, var(--el-border-color-lighter));
+  border-radius: 8px;
+  background: var(--el-fill-color-extra-light);
+}
+.completion-rule-loading {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--el-text-color-secondary);
+}
+.completion-rule-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+.completion-rule-title {
+  font-size: 13px;
+  font-weight: 650;
+  line-height: 1.4;
+  color: var(--el-text-color-primary);
+}
+.completion-rule-source {
+  margin-top: 2px;
+  font-size: 11px;
+  color: var(--el-text-color-secondary);
+}
+.completion-rule-reason {
+  margin-top: 8px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--el-text-color-secondary);
+  word-break: break-word;
+}
+.completion-rule-choices {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--el-border-color-lighter);
+}
+.channel-select {
+  width: 132px;
+}
+@media (max-width: 640px) {
+  .task-top {
+    align-items: flex-start;
+  }
+  .task-actions {
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+  .run-line {
+    align-items: flex-start;
+  }
+  .run-status {
+    max-width: 56%;
+  }
+  .completion-rule-heading {
+    align-items: flex-start;
+  }
 }
 </style>
 


### PR DESCRIPTION
## Summary

- show the automatically inferred completion rule while creating or editing a scheduled task, with explicit correction and restore-auto controls
- separate scheduling state from the latest business outcome on task cards
- render completed, not completed, needs action, needs confirmation, unverified, queued, and running states with distinct Font Awesome icons and backend-provided reasons
- add article links plus confirm-published, confirm-not-published, retry, and resume controls gated by backend `can_*` fields
- show the authoritative scheduled outcome and the same recovery actions above scheduled conversation messages
- type the new task, run, and conversation contracts and cover all 17 locales

## Backend dependency

Depends on AceDataCloud/PlatformService#1444. Do not merge or release this PR before the backend contract is available. Both PRs are intentionally left open for review.

## Validation

- `npm run test:run`
- `npm run lint:check`
- `npx vue-tsc -b`
- `python3 scripts/check_i18n_coverage.py` (17 locales × 44 namespaces)
- `npm run build:web`
- `npx beachball check --branch origin/main`
- `git diff --check`
- focused post-rebase suite: 3 files / 11 tests
- desktop/mobile pixel and overflow checks at 1280px and 390px; all status reasons wrap without horizontal overflow

The production build only emitted existing Rolldown annotation/chunk warnings from third-party dependencies.

## 🤖 对抗评审 (reviewer: claude-subagent, 2 rounds)

- RISK: resume was advertised for expired one-time or scheduler-unlinked tasks → 已修（shared backend eligibility now checks scheduler linkage and future one-time execution）
- RISK: closing the dialog could allow stale inference to overwrite another task → 已修（invalidate timer/request generation on every close and before openEdit; regression test added）
- RISK: run action controls were nested inside a row with button semantics → 已修（conversation navigation is now a dedicated sibling button）
- Re-review: `VERDICT: CLEAN`
