### PR TITLE
fix(chat): localize scheduled-run failure reason codes

### DIFF
--- a/change/@acedatacloud-nexior-54e0627c-d6ef-4ad9-8d95-bf4f4e90fb8b.json
+++ b/change/@acedatacloud-nexior-54e0627c-d6ef-4ad9-8d95-bf4f4e90fb8b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Localize scheduled-run failure reason codes",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/i18n/ar/chat.json
+++ b/src/i18n/ar/chat.json
@@ -648,6 +648,45 @@
   "scheduledTasks.run.failed": {
     "message": "Failed"
   },
+  "scheduledTasks.run.reason.max_turns": {
+    "message": "تم بلوغ حد الخطوات"
+  },
+  "scheduledTasks.run.reason.max_budget_usd": {
+    "message": "تم بلوغ حد الميزانية"
+  },
+  "scheduledTasks.run.reason.tool_call_loop": {
+    "message": "تم اكتشاف حلقة استدعاء الأدوات"
+  },
+  "scheduledTasks.run.reason.prompt_too_long": {
+    "message": "المطالبة طويلة جدًا"
+  },
+  "scheduledTasks.run.reason.aborted_streaming": {
+    "message": "تم الإيقاف"
+  },
+  "scheduledTasks.run.reason.aborted_tools": {
+    "message": "تم الإيقاف"
+  },
+  "scheduledTasks.run.reason.awaiting_user_input": {
+    "message": "في انتظار إدخالك"
+  },
+  "scheduledTasks.run.reason.error": {
+    "message": "خطأ"
+  },
+  "scheduledTasks.run.reason.unknown": {
+    "message": "خطأ غير معروف"
+  },
+  "scheduledTasks.run.reason.balance_insufficient": {
+    "message": "رصيد غير كافٍ"
+  },
+  "scheduledTasks.run.reason.unauthorized": {
+    "message": "غير مصرّح"
+  },
+  "scheduledTasks.run.reason.timeout": {
+    "message": "انتهت المهلة"
+  },
+  "scheduledTasks.run.reason.internal_error": {
+    "message": "خطأ داخلي"
+  },
   "scheduledTasks.run.needs_user_input": {
     "message": "Needs action"
   },

--- a/src/i18n/de/chat.json
+++ b/src/i18n/de/chat.json
@@ -648,6 +648,45 @@
   "scheduledTasks.run.failed": {
     "message": "Failed"
   },
+  "scheduledTasks.run.reason.max_turns": {
+    "message": "Schrittlimit erreicht"
+  },
+  "scheduledTasks.run.reason.max_budget_usd": {
+    "message": "Budgetlimit erreicht"
+  },
+  "scheduledTasks.run.reason.tool_call_loop": {
+    "message": "Tool-Aufruf-Schleife erkannt"
+  },
+  "scheduledTasks.run.reason.prompt_too_long": {
+    "message": "Prompt zu lang"
+  },
+  "scheduledTasks.run.reason.aborted_streaming": {
+    "message": "Unterbrochen"
+  },
+  "scheduledTasks.run.reason.aborted_tools": {
+    "message": "Unterbrochen"
+  },
+  "scheduledTasks.run.reason.awaiting_user_input": {
+    "message": "Warten auf Ihre Eingabe"
+  },
+  "scheduledTasks.run.reason.error": {
+    "message": "Fehler"
+  },
+  "scheduledTasks.run.reason.unknown": {
+    "message": "Unbekannter Fehler"
+  },
+  "scheduledTasks.run.reason.balance_insufficient": {
+    "message": "Unzureichendes Guthaben"
+  },
+  "scheduledTasks.run.reason.unauthorized": {
+    "message": "Nicht autorisiert"
+  },
+  "scheduledTasks.run.reason.timeout": {
+    "message": "Zeitüberschreitung"
+  },
+  "scheduledTasks.run.reason.internal_error": {
+    "message": "Interner Fehler"
+  },
   "scheduledTasks.run.needs_user_input": {
     "message": "Needs action"
   },

--- a/src/i18n/el/chat.json
+++ b/src/i18n/el/chat.json
@@ -648,6 +648,45 @@
   "scheduledTasks.run.failed": {
     "message": "Failed"
   },
+  "scheduledTasks.run.reason.max_turns": {
+    "message": "Επιτεύχθηκε το όριο βημάτων"
+  },
+  "scheduledTasks.run.reason.max_budget_usd": {
+    "message": "Επιτεύχθηκε το όριο προϋπολογισμού"
+  },
+  "scheduledTasks.run.reason.tool_call_loop": {
+    "message": "Εντοπίστηκε βρόχος κλήσεων εργαλείων"
+  },
+  "scheduledTasks.run.reason.prompt_too_long": {
+    "message": "Πολύ μεγάλο prompt"
+  },
+  "scheduledTasks.run.reason.aborted_streaming": {
+    "message": "Διακόπηκε"
+  },
+  "scheduledTasks.run.reason.aborted_tools": {
+    "message": "Διακόπηκε"
+  },
+  "scheduledTasks.run.reason.awaiting_user_input": {
+    "message": "Αναμονή για την εισαγωγή σας"
+  },
+  "scheduledTasks.run.reason.error": {
+    "message": "Σφάλμα"
+  },
+  "scheduledTasks.run.reason.unknown": {
+    "message": "Άγνωστο σφάλμα"
+  },
+  "scheduledTasks.run.reason.balance_insufficient": {
+    "message": "Ανεπαρκές υπόλοιπο"
+  },
+  "scheduledTasks.run.reason.unauthorized": {
+    "message": "Μη εξουσιοδοτημένο"
+  },
+  "scheduledTasks.run.reason.timeout": {
+    "message": "Λήξη χρόνου"
+  },
+  "scheduledTasks.run.reason.internal_error": {
+    "message": "Εσωτερικό σφάλμα"
+  },
   "scheduledTasks.run.needs_user_input": {
     "message": "Needs action"
   },

--- a/src/i18n/en/chat.json
+++ b/src/i18n/en/chat.json
@@ -647,6 +647,45 @@
   "scheduledTasks.run.failed": {
     "message": "Failed"
   },
+  "scheduledTasks.run.reason.max_turns": {
+    "message": "Reached step limit"
+  },
+  "scheduledTasks.run.reason.max_budget_usd": {
+    "message": "Reached budget limit"
+  },
+  "scheduledTasks.run.reason.tool_call_loop": {
+    "message": "Tool call loop detected"
+  },
+  "scheduledTasks.run.reason.prompt_too_long": {
+    "message": "Prompt too long"
+  },
+  "scheduledTasks.run.reason.aborted_streaming": {
+    "message": "Interrupted"
+  },
+  "scheduledTasks.run.reason.aborted_tools": {
+    "message": "Interrupted"
+  },
+  "scheduledTasks.run.reason.awaiting_user_input": {
+    "message": "Waiting for your input"
+  },
+  "scheduledTasks.run.reason.error": {
+    "message": "Error"
+  },
+  "scheduledTasks.run.reason.unknown": {
+    "message": "Unknown error"
+  },
+  "scheduledTasks.run.reason.balance_insufficient": {
+    "message": "Insufficient balance"
+  },
+  "scheduledTasks.run.reason.unauthorized": {
+    "message": "Unauthorized"
+  },
+  "scheduledTasks.run.reason.timeout": {
+    "message": "Timed out"
+  },
+  "scheduledTasks.run.reason.internal_error": {
+    "message": "Internal error"
+  },
   "scheduledTasks.run.needs_user_input": {
     "message": "Needs action"
   },

--- a/src/i18n/es/chat.json
+++ b/src/i18n/es/chat.json
@@ -648,6 +648,45 @@
   "scheduledTasks.run.failed": {
     "message": "Failed"
   },
+  "scheduledTasks.run.reason.max_turns": {
+    "message": "Límite de pasos alcanzado"
+  },
+  "scheduledTasks.run.reason.max_budget_usd": {
+    "message": "Límite de presupuesto alcanzado"
+  },
+  "scheduledTasks.run.reason.tool_call_loop": {
+    "message": "Bucle de llamadas a herramientas detectado"
+  },
+  "scheduledTasks.run.reason.prompt_too_long": {
+    "message": "Instrucción demasiado larga"
+  },
+  "scheduledTasks.run.reason.aborted_streaming": {
+    "message": "Interrumpido"
+  },
+  "scheduledTasks.run.reason.aborted_tools": {
+    "message": "Interrumpido"
+  },
+  "scheduledTasks.run.reason.awaiting_user_input": {
+    "message": "Esperando tu entrada"
+  },
+  "scheduledTasks.run.reason.error": {
+    "message": "Error"
+  },
+  "scheduledTasks.run.reason.unknown": {
+    "message": "Error desconocido"
+  },
+  "scheduledTasks.run.reason.balance_insufficient": {
+    "message": "Saldo insuficiente"
+  },
+  "scheduledTasks.run.reason.unauthorized": {
+    "message": "No autorizado"
+  },
+  "scheduledTasks.run.reason.timeout": {
+    "message": "Tiempo agotado"
+  },
+  "scheduledTasks.run.reason.internal_error": {
+    "message": "Error interno"
+  },
   "scheduledTasks.run.needs_user_input": {
     "message": "Needs action"
   },

--- a/src/i18n/fi/chat.json
+++ b/src/i18n/fi/chat.json
@@ -648,6 +648,45 @@
   "scheduledTasks.run.failed": {
     "message": "Failed"
   },
+  "scheduledTasks.run.reason.max_turns": {
+    "message": "Vaiheiden yläraja saavutettu"
+  },
+  "scheduledTasks.run.reason.max_budget_usd": {
+    "message": "Budjettiraja saavutettu"
+  },
+  "scheduledTasks.run.reason.tool_call_loop": {
+    "message": "Työkalukutsujen silmukka havaittu"
+  },
+  "scheduledTasks.run.reason.prompt_too_long": {
+    "message": "Kehote liian pitkä"
+  },
+  "scheduledTasks.run.reason.aborted_streaming": {
+    "message": "Keskeytetty"
+  },
+  "scheduledTasks.run.reason.aborted_tools": {
+    "message": "Keskeytetty"
+  },
+  "scheduledTasks.run.reason.awaiting_user_input": {
+    "message": "Odotetaan syötettäsi"
+  },
+  "scheduledTasks.run.reason.error": {
+    "message": "Virhe"
+  },
+  "scheduledTasks.run.reason.unknown": {
+    "message": "Tuntematon virhe"
+  },
+  "scheduledTasks.run.reason.balance_insufficient": {
+    "message": "Riittämätön saldo"
+  },
+  "scheduledTasks.run.reason.unauthorized": {
+    "message": "Ei valtuutettu"
+  },
+  "scheduledTasks.run.reason.timeout": {
+    "message": "Aikakatkaisu"
+  },
+  "scheduledTasks.run.reason.internal_error": {
+    "message": "Sisäinen virhe"
+  },
   "scheduledTasks.run.needs_user_input": {
     "message": "Needs action"
   },

--- a/src/i18n/fr/chat.json
+++ b/src/i18n/fr/chat.json
@@ -648,6 +648,45 @@
   "scheduledTasks.run.failed": {
     "message": "Failed"
   },
+  "scheduledTasks.run.reason.max_turns": {
+    "message": "Limite d'étapes atteinte"
+  },
+  "scheduledTasks.run.reason.max_budget_usd": {
+    "message": "Limite de budget atteinte"
+  },
+  "scheduledTasks.run.reason.tool_call_loop": {
+    "message": "Boucle d'appels d'outils détectée"
+  },
+  "scheduledTasks.run.reason.prompt_too_long": {
+    "message": "Invite trop longue"
+  },
+  "scheduledTasks.run.reason.aborted_streaming": {
+    "message": "Interrompu"
+  },
+  "scheduledTasks.run.reason.aborted_tools": {
+    "message": "Interrompu"
+  },
+  "scheduledTasks.run.reason.awaiting_user_input": {
+    "message": "En attente de votre saisie"
+  },
+  "scheduledTasks.run.reason.error": {
+    "message": "Erreur"
+  },
+  "scheduledTasks.run.reason.unknown": {
+    "message": "Erreur inconnue"
+  },
+  "scheduledTasks.run.reason.balance_insufficient": {
+    "message": "Solde insuffisant"
+  },
+  "scheduledTasks.run.reason.unauthorized": {
+    "message": "Non autorisé"
+  },
+  "scheduledTasks.run.reason.timeout": {
+    "message": "Délai dépassé"
+  },
+  "scheduledTasks.run.reason.internal_error": {
+    "message": "Erreur interne"
+  },
   "scheduledTasks.run.needs_user_input": {
     "message": "Needs action"
   },

--- a/src/i18n/it/chat.json
+++ b/src/i18n/it/chat.json
@@ -648,6 +648,45 @@
   "scheduledTasks.run.failed": {
     "message": "Failed"
   },
+  "scheduledTasks.run.reason.max_turns": {
+    "message": "Limite di passaggi raggiunto"
+  },
+  "scheduledTasks.run.reason.max_budget_usd": {
+    "message": "Limite di budget raggiunto"
+  },
+  "scheduledTasks.run.reason.tool_call_loop": {
+    "message": "Rilevato ciclo di chiamate agli strumenti"
+  },
+  "scheduledTasks.run.reason.prompt_too_long": {
+    "message": "Prompt troppo lungo"
+  },
+  "scheduledTasks.run.reason.aborted_streaming": {
+    "message": "Interrotto"
+  },
+  "scheduledTasks.run.reason.aborted_tools": {
+    "message": "Interrotto"
+  },
+  "scheduledTasks.run.reason.awaiting_user_input": {
+    "message": "In attesa del tuo input"
+  },
+  "scheduledTasks.run.reason.error": {
+    "message": "Errore"
+  },
+  "scheduledTasks.run.reason.unknown": {
+    "message": "Errore sconosciuto"
+  },
+  "scheduledTasks.run.reason.balance_insufficient": {
+    "message": "Saldo insufficiente"
+  },
+  "scheduledTasks.run.reason.unauthorized": {
+    "message": "Non autorizzato"
+  },
+  "scheduledTasks.run.reason.timeout": {
+    "message": "Timeout"
+  },
+  "scheduledTasks.run.reason.internal_error": {
+    "message": "Errore interno"
+  },
   "scheduledTasks.run.needs_user_input": {
     "message": "Needs action"
   },

--- a/src/i18n/ja/chat.json
+++ b/src/i18n/ja/chat.json
@@ -648,6 +648,45 @@
   "scheduledTasks.run.failed": {
     "message": "Failed"
   },
+  "scheduledTasks.run.reason.max_turns": {
+    "message": "ステップ上限に到達"
+  },
+  "scheduledTasks.run.reason.max_budget_usd": {
+    "message": "予算上限に到達"
+  },
+  "scheduledTasks.run.reason.tool_call_loop": {
+    "message": "ツール呼び出しループを検出"
+  },
+  "scheduledTasks.run.reason.prompt_too_long": {
+    "message": "プロンプトが長すぎます"
+  },
+  "scheduledTasks.run.reason.aborted_streaming": {
+    "message": "中断されました"
+  },
+  "scheduledTasks.run.reason.aborted_tools": {
+    "message": "中断されました"
+  },
+  "scheduledTasks.run.reason.awaiting_user_input": {
+    "message": "入力待ちです"
+  },
+  "scheduledTasks.run.reason.error": {
+    "message": "エラー"
+  },
+  "scheduledTasks.run.reason.unknown": {
+    "message": "不明なエラー"
+  },
+  "scheduledTasks.run.reason.balance_insufficient": {
+    "message": "残高不足"
+  },
+  "scheduledTasks.run.reason.unauthorized": {
+    "message": "認証エラー"
+  },
+  "scheduledTasks.run.reason.timeout": {
+    "message": "タイムアウト"
+  },
+  "scheduledTasks.run.reason.internal_error": {
+    "message": "内部エラー"
+  },
   "scheduledTasks.run.needs_user_input": {
     "message": "Needs action"
   },

--- a/src/i18n/ko/chat.json
+++ b/src/i18n/ko/chat.json
@@ -648,6 +648,45 @@
   "scheduledTasks.run.failed": {
     "message": "Failed"
   },
+  "scheduledTasks.run.reason.max_turns": {
+    "message": "단계 한도 도달"
+  },
+  "scheduledTasks.run.reason.max_budget_usd": {
+    "message": "예산 한도 도달"
+  },
+  "scheduledTasks.run.reason.tool_call_loop": {
+    "message": "도구 호출 루프 감지됨"
+  },
+  "scheduledTasks.run.reason.prompt_too_long": {
+    "message": "프롬프트가 너무 김"
+  },
+  "scheduledTasks.run.reason.aborted_streaming": {
+    "message": "중단됨"
+  },
+  "scheduledTasks.run.reason.aborted_tools": {
+    "message": "중단됨"
+  },
+  "scheduledTasks.run.reason.awaiting_user_input": {
+    "message": "입력 대기 중"
+  },
+  "scheduledTasks.run.reason.error": {
+    "message": "오류"
+  },
+  "scheduledTasks.run.reason.unknown": {
+    "message": "알 수 없는 오류"
+  },
+  "scheduledTasks.run.reason.balance_insufficient": {
+    "message": "잔액 부족"
+  },
+  "scheduledTasks.run.reason.unauthorized": {
+    "message": "권한 없음"
+  },
+  "scheduledTasks.run.reason.timeout": {
+    "message": "시간 초과"
+  },
+  "scheduledTasks.run.reason.internal_error": {
+    "message": "내부 오류"
+  },
   "scheduledTasks.run.needs_user_input": {
     "message": "Needs action"
   },

--- a/src/i18n/pl/chat.json
+++ b/src/i18n/pl/chat.json
@@ -648,6 +648,45 @@
   "scheduledTasks.run.failed": {
     "message": "Failed"
   },
+  "scheduledTasks.run.reason.max_turns": {
+    "message": "Osiągnięto limit kroków"
+  },
+  "scheduledTasks.run.reason.max_budget_usd": {
+    "message": "Osiągnięto limit budżetu"
+  },
+  "scheduledTasks.run.reason.tool_call_loop": {
+    "message": "Wykryto pętlę wywołań narzędzi"
+  },
+  "scheduledTasks.run.reason.prompt_too_long": {
+    "message": "Zbyt długi prompt"
+  },
+  "scheduledTasks.run.reason.aborted_streaming": {
+    "message": "Przerwano"
+  },
+  "scheduledTasks.run.reason.aborted_tools": {
+    "message": "Przerwano"
+  },
+  "scheduledTasks.run.reason.awaiting_user_input": {
+    "message": "Oczekiwanie na Twoje dane"
+  },
+  "scheduledTasks.run.reason.error": {
+    "message": "Błąd"
+  },
+  "scheduledTasks.run.reason.unknown": {
+    "message": "Nieznany błąd"
+  },
+  "scheduledTasks.run.reason.balance_insufficient": {
+    "message": "Niewystarczające środki"
+  },
+  "scheduledTasks.run.reason.unauthorized": {
+    "message": "Brak autoryzacji"
+  },
+  "scheduledTasks.run.reason.timeout": {
+    "message": "Przekroczono limit czasu"
+  },
+  "scheduledTasks.run.reason.internal_error": {
+    "message": "Błąd wewnętrzny"
+  },
   "scheduledTasks.run.needs_user_input": {
     "message": "Needs action"
   },

--- a/src/i18n/pt/chat.json
+++ b/src/i18n/pt/chat.json
@@ -648,6 +648,45 @@
   "scheduledTasks.run.failed": {
     "message": "Failed"
   },
+  "scheduledTasks.run.reason.max_turns": {
+    "message": "Limite de etapas atingido"
+  },
+  "scheduledTasks.run.reason.max_budget_usd": {
+    "message": "Limite de orçamento atingido"
+  },
+  "scheduledTasks.run.reason.tool_call_loop": {
+    "message": "Loop de chamadas de ferramenta detectado"
+  },
+  "scheduledTasks.run.reason.prompt_too_long": {
+    "message": "Prompt muito longo"
+  },
+  "scheduledTasks.run.reason.aborted_streaming": {
+    "message": "Interrompido"
+  },
+  "scheduledTasks.run.reason.aborted_tools": {
+    "message": "Interrompido"
+  },
+  "scheduledTasks.run.reason.awaiting_user_input": {
+    "message": "Aguardando sua entrada"
+  },
+  "scheduledTasks.run.reason.error": {
+    "message": "Erro"
+  },
+  "scheduledTasks.run.reason.unknown": {
+    "message": "Erro desconhecido"
+  },
+  "scheduledTasks.run.reason.balance_insufficient": {
+    "message": "Saldo insuficiente"
+  },
+  "scheduledTasks.run.reason.unauthorized": {
+    "message": "Não autorizado"
+  },
+  "scheduledTasks.run.reason.timeout": {
+    "message": "Tempo esgotado"
+  },
+  "scheduledTasks.run.reason.internal_error": {
+    "message": "Erro interno"
+  },
   "scheduledTasks.run.needs_user_input": {
     "message": "Needs action"
   },

--- a/src/i18n/ru/chat.json
+++ b/src/i18n/ru/chat.json
@@ -648,6 +648,45 @@
   "scheduledTasks.run.failed": {
     "message": "Failed"
   },
+  "scheduledTasks.run.reason.max_turns": {
+    "message": "Достигнут лимит шагов"
+  },
+  "scheduledTasks.run.reason.max_budget_usd": {
+    "message": "Достигнут лимит бюджета"
+  },
+  "scheduledTasks.run.reason.tool_call_loop": {
+    "message": "Обнаружен цикл вызовов инструментов"
+  },
+  "scheduledTasks.run.reason.prompt_too_long": {
+    "message": "Слишком длинный запрос"
+  },
+  "scheduledTasks.run.reason.aborted_streaming": {
+    "message": "Прервано"
+  },
+  "scheduledTasks.run.reason.aborted_tools": {
+    "message": "Прервано"
+  },
+  "scheduledTasks.run.reason.awaiting_user_input": {
+    "message": "Ожидание вашего ввода"
+  },
+  "scheduledTasks.run.reason.error": {
+    "message": "Ошибка"
+  },
+  "scheduledTasks.run.reason.unknown": {
+    "message": "Неизвестная ошибка"
+  },
+  "scheduledTasks.run.reason.balance_insufficient": {
+    "message": "Недостаточно средств"
+  },
+  "scheduledTasks.run.reason.unauthorized": {
+    "message": "Не авторизовано"
+  },
+  "scheduledTasks.run.reason.timeout": {
+    "message": "Время ожидания истекло"
+  },
+  "scheduledTasks.run.reason.internal_error": {
+    "message": "Внутренняя ошибка"
+  },
   "scheduledTasks.run.needs_user_input": {
     "message": "Needs action"
   },

--- a/src/i18n/sr/chat.json
+++ b/src/i18n/sr/chat.json
@@ -648,6 +648,45 @@
   "scheduledTasks.run.failed": {
     "message": "Failed"
   },
+  "scheduledTasks.run.reason.max_turns": {
+    "message": "Достигнут лимит корака"
+  },
+  "scheduledTasks.run.reason.max_budget_usd": {
+    "message": "Достигнут лимит буџета"
+  },
+  "scheduledTasks.run.reason.tool_call_loop": {
+    "message": "Откривена петља позива алата"
+  },
+  "scheduledTasks.run.reason.prompt_too_long": {
+    "message": "Упит је предугачак"
+  },
+  "scheduledTasks.run.reason.aborted_streaming": {
+    "message": "Прекинуто"
+  },
+  "scheduledTasks.run.reason.aborted_tools": {
+    "message": "Прекинуто"
+  },
+  "scheduledTasks.run.reason.awaiting_user_input": {
+    "message": "Чека се ваш унос"
+  },
+  "scheduledTasks.run.reason.error": {
+    "message": "Грешка"
+  },
+  "scheduledTasks.run.reason.unknown": {
+    "message": "Непозната грешка"
+  },
+  "scheduledTasks.run.reason.balance_insufficient": {
+    "message": "Недовољно средстава"
+  },
+  "scheduledTasks.run.reason.unauthorized": {
+    "message": "Неовлашћено"
+  },
+  "scheduledTasks.run.reason.timeout": {
+    "message": "Истекло време"
+  },
+  "scheduledTasks.run.reason.internal_error": {
+    "message": "Интерна грешка"
+  },
   "scheduledTasks.run.needs_user_input": {
     "message": "Needs action"
   },

--- a/src/i18n/sv/chat.json
+++ b/src/i18n/sv/chat.json
@@ -648,6 +648,45 @@
   "scheduledTasks.run.failed": {
     "message": "Failed"
   },
+  "scheduledTasks.run.reason.max_turns": {
+    "message": "Stegsgräns uppnådd"
+  },
+  "scheduledTasks.run.reason.max_budget_usd": {
+    "message": "Budgetgräns uppnådd"
+  },
+  "scheduledTasks.run.reason.tool_call_loop": {
+    "message": "Loop för verktygsanrop upptäckt"
+  },
+  "scheduledTasks.run.reason.prompt_too_long": {
+    "message": "Prompten är för lång"
+  },
+  "scheduledTasks.run.reason.aborted_streaming": {
+    "message": "Avbruten"
+  },
+  "scheduledTasks.run.reason.aborted_tools": {
+    "message": "Avbruten"
+  },
+  "scheduledTasks.run.reason.awaiting_user_input": {
+    "message": "Väntar på din inmatning"
+  },
+  "scheduledTasks.run.reason.error": {
+    "message": "Fel"
+  },
+  "scheduledTasks.run.reason.unknown": {
+    "message": "Okänt fel"
+  },
+  "scheduledTasks.run.reason.balance_insufficient": {
+    "message": "Otillräckligt saldo"
+  },
+  "scheduledTasks.run.reason.unauthorized": {
+    "message": "Obehörig"
+  },
+  "scheduledTasks.run.reason.timeout": {
+    "message": "Tidsgräns överskriden"
+  },
+  "scheduledTasks.run.reason.internal_error": {
+    "message": "Internt fel"
+  },
   "scheduledTasks.run.needs_user_input": {
     "message": "Needs action"
   },

--- a/src/i18n/uk/chat.json
+++ b/src/i18n/uk/chat.json
@@ -648,6 +648,45 @@
   "scheduledTasks.run.failed": {
     "message": "Failed"
   },
+  "scheduledTasks.run.reason.max_turns": {
+    "message": "Досягнуто ліміт кроків"
+  },
+  "scheduledTasks.run.reason.max_budget_usd": {
+    "message": "Досягнуто ліміт бюджету"
+  },
+  "scheduledTasks.run.reason.tool_call_loop": {
+    "message": "Виявлено цикл викликів інструментів"
+  },
+  "scheduledTasks.run.reason.prompt_too_long": {
+    "message": "Запит надто довгий"
+  },
+  "scheduledTasks.run.reason.aborted_streaming": {
+    "message": "Перервано"
+  },
+  "scheduledTasks.run.reason.aborted_tools": {
+    "message": "Перервано"
+  },
+  "scheduledTasks.run.reason.awaiting_user_input": {
+    "message": "Очікування вашого вводу"
+  },
+  "scheduledTasks.run.reason.error": {
+    "message": "Помилка"
+  },
+  "scheduledTasks.run.reason.unknown": {
+    "message": "Невідома помилка"
+  },
+  "scheduledTasks.run.reason.balance_insufficient": {
+    "message": "Недостатньо коштів"
+  },
+  "scheduledTasks.run.reason.unauthorized": {
+    "message": "Не авторизовано"
+  },
+  "scheduledTasks.run.reason.timeout": {
+    "message": "Час очікування вичерпано"
+  },
+  "scheduledTasks.run.reason.internal_error": {
+    "message": "Внутрішня помилка"
+  },
   "scheduledTasks.run.needs_user_input": {
     "message": "Needs action"
   },

--- a/src/i18n/zh-CN/chat.json
+++ b/src/i18n/zh-CN/chat.json
@@ -667,6 +667,58 @@
     "message": "失败",
     "description": "失败状态"
   },
+  "scheduledTasks.run.reason.max_turns": {
+    "message": "达到步数上限",
+    "description": "达到最大步数"
+  },
+  "scheduledTasks.run.reason.max_budget_usd": {
+    "message": "达到预算上限",
+    "description": "达到最大预算"
+  },
+  "scheduledTasks.run.reason.tool_call_loop": {
+    "message": "检测到工具调用循环",
+    "description": "工具调用陷入循环"
+  },
+  "scheduledTasks.run.reason.prompt_too_long": {
+    "message": "提示词过长",
+    "description": "提示词超出长度"
+  },
+  "scheduledTasks.run.reason.aborted_streaming": {
+    "message": "已中断",
+    "description": "流式响应被中断"
+  },
+  "scheduledTasks.run.reason.aborted_tools": {
+    "message": "已中断",
+    "description": "工具执行被中断"
+  },
+  "scheduledTasks.run.reason.awaiting_user_input": {
+    "message": "等待你的输入",
+    "description": "等待用户输入"
+  },
+  "scheduledTasks.run.reason.error": {
+    "message": "出错",
+    "description": "运行出错"
+  },
+  "scheduledTasks.run.reason.unknown": {
+    "message": "未知错误",
+    "description": "未知失败原因"
+  },
+  "scheduledTasks.run.reason.balance_insufficient": {
+    "message": "余额不足",
+    "description": "账户余额不足"
+  },
+  "scheduledTasks.run.reason.unauthorized": {
+    "message": "未授权",
+    "description": "凭证未授权"
+  },
+  "scheduledTasks.run.reason.timeout": {
+    "message": "超时",
+    "description": "请求超时"
+  },
+  "scheduledTasks.run.reason.internal_error": {
+    "message": "内部错误",
+    "description": "服务内部错误"
+  },
   "scheduledTasks.run.needs_user_input": {
     "message": "需要操作",
     "description": "需要用户操作状态"

--- a/src/i18n/zh-TW/chat.json
+++ b/src/i18n/zh-TW/chat.json
@@ -648,6 +648,45 @@
   "scheduledTasks.run.failed": {
     "message": "Failed"
   },
+  "scheduledTasks.run.reason.max_turns": {
+    "message": "達到步數上限"
+  },
+  "scheduledTasks.run.reason.max_budget_usd": {
+    "message": "達到預算上限"
+  },
+  "scheduledTasks.run.reason.tool_call_loop": {
+    "message": "偵測到工具呼叫迴圈"
+  },
+  "scheduledTasks.run.reason.prompt_too_long": {
+    "message": "提示詞過長"
+  },
+  "scheduledTasks.run.reason.aborted_streaming": {
+    "message": "已中斷"
+  },
+  "scheduledTasks.run.reason.aborted_tools": {
+    "message": "已中斷"
+  },
+  "scheduledTasks.run.reason.awaiting_user_input": {
+    "message": "等待你的輸入"
+  },
+  "scheduledTasks.run.reason.error": {
+    "message": "發生錯誤"
+  },
+  "scheduledTasks.run.reason.unknown": {
+    "message": "未知錯誤"
+  },
+  "scheduledTasks.run.reason.balance_insufficient": {
+    "message": "餘額不足"
+  },
+  "scheduledTasks.run.reason.unauthorized": {
+    "message": "未授權"
+  },
+  "scheduledTasks.run.reason.timeout": {
+    "message": "逾時"
+  },
+  "scheduledTasks.run.reason.internal_error": {
+    "message": "內部錯誤"
+  },
   "scheduledTasks.run.needs_user_input": {
     "message": "Needs action"
   },

--- a/src/pages/chat/ScheduledTasks.vue
+++ b/src/pages/chat/ScheduledTasks.vue
@@ -797,7 +797,11 @@ export default defineComponent({
       return status === 'success' ? 'success' : status === 'failed' ? 'danger' : 'warning';
     },
     runErrorText(run: IScheduledRun) {
-      return run.error_message || run.error_code?.replace(/_/g, ' ') || '';
+      if (run.error_message) return run.error_message;
+      const code = run.error_code;
+      if (!code) return '';
+      const key = `chat.scheduledTasks.run.reason.${code}`;
+      return (this as any).$te(key) ? (this.$t(key) as string) : code.replace(/_/g, ' ');
     },
     // Turn any backend schedule spec into a localized, human-readable phrase.
     humanizeSchedule(s: IScheduleSpec): string {


### PR DESCRIPTION
## Summary
The aichat2 backend records a scheduled task run's failure reason as a **machine `error_code`** string (`max_turns`, `max_budget_usd`, `tool_call_loop`, `prompt_too_long`, `aborted_streaming`, `aborted_tools`, `awaiting_user_input`, `error`, `unknown`, `balance_insufficient`, `unauthorized`, `timeout`, `internal_error`) — see PlatformService PR #1446. The frontend previously showed the raw code via `.replace(/_/g,' ')`, which was never localized.

This PR does the frontend half of the code+i18n pattern (backend stores machine codes, frontend localizes):

- Adds `chat.scheduledTasks.run.reason.<code>` labels (13 codes) to **all 18 locales** (`ar de el en es fi fr it ja ko pl pt ru sr sv uk zh-CN zh-TW`). zh-CN also carries a `description` to match neighbouring entries.
- Rewrites `runErrorText` in `src/pages/chat/ScheduledTasks.vue` to look up the localized label via `$te`/`$t`, keeping the underscore-replace fallback for any unmapped/future code and preserving the `error_message` → `error_code` priority.

No behavior change for the status tag (`runTagType` already maps `failed` → danger).

## Validation
- `python3 scripts/check_i18n_coverage.py` → exit 0 (17 target locales × 44 namespaces cover zh-CN)
- `vue-tsc -b`: only the 6 pre-existing `@acedatacloud/core/components` module-resolution errors that also appear on the unmodified baseline — **zero new type errors**
- `git diff --check` clean

## 🤖 对抗评审
Independent reviewer (subagent, read-only) verified:
- all 18 locale files valid JSON, exactly 13 non-empty `reason.*` messages each, no duplicate/extra keys, real translations (spot-checked `ar`, `zh-CN`, `en`)
- `$te`/`$t` legacy Options-API usage correct; no "`$te` true but `$t` empty" risk (all entries are flat leaf strings, proven by the already-working sibling `run.${status}` lookup)
- template `v-if="run.error_code || run.error_message"` guards the empty-string return
- unmapped/future codes fall back to underscore-replace (strict superset of prior logic)
- rendered as escaped text interpolation / `:title` attr — no `v-html`, no XSS
- `reason.awaiting_user_input` vs status `run.needs_user_input` are distinct namespaces, no collision

`VERDICT: CLEAN`