### PR TITLE
fix(application): show true final top-up price

### DIFF
--- a/change/@acedatacloud-nexior-a9d0075d-b770-4f83-a091-d3a2111eea4a.json
+++ b/change/@acedatacloud-nexior-a9d0075d-b770-4f83-a091-d3a2111eea4a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Show the applied VIP discount and true final price before creating a top-up order.",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/models/application.ts
+++ b/src/models/application.ts
@@ -30,6 +30,9 @@ export interface IApplication {
   // Final request-site markup resolved by PlatformBackend using
   // per-service override > site-wide default > 0.
   effective_markup_ratio?: number;
+  // Final order discount for the current user and this service. The backend
+  // applies this after site markup when creating an order.
+  effective_caller_order_discount_rate?: number;
   // Set by the backend (PR #540) when the current user is a grantee on this
   // application rather than its owner. Used to skip auto-createCredential and
   // to surface a "Shared" badge in the UI.

--- a/src/pages/console/application/Extra.vue
+++ b/src/pages/console/application/Extra.vue
@@ -10,7 +10,7 @@
         <el-col :span="24">
           <el-card shadow="hover" class="min-h-[500px]">
             <el-row>
-              <el-col :span="16" :offset="4">
+              <el-col :xs="{ span: 22, offset: 1 }" :sm="{ span: 20, offset: 2 }" :md="{ span: 16, offset: 4 }">
                 <el-skeleton v-if="loading" />
                 <div v-else-if="loadFailed" class="text-center">
                   <el-empty :description="$t('common.message.noData')" />
@@ -19,7 +19,7 @@
                   </el-button>
                 </div>
                 <el-empty v-else-if="!showPayment" :description="$t('common.message.noData')" />
-                <el-form v-else-if="application" label-width="100px">
+                <el-form v-else-if="application" class="purchase-form" label-width="100px">
                   <div v-if="!application?.service">
                     <p class="text-[var(--el-text-color-secondary)] text-[12px] mb-3">
                       {{ $t('application.message.globalBalanceBuyDescription') }}
@@ -33,7 +33,7 @@
                     {{ $t('application.title.globalBuy') }}
                   </el-form-item>
                   <el-form-item :label="$t('application.field.package')" class="mb-0">
-                    <el-radio-group v-if="packages.length > 0" v-model="form.packageId">
+                    <el-radio-group v-if="packages.length > 0" v-model="form.packageId" class="package-options">
                       <el-radio-button v-for="(pkg, pkgIndex) in packages" :key="pkgIndex" :label="pkg.id" class="mb-2">
                         <span v-show="pkgIndex !== 0" class="corner">
                           {{ getDiscount(pkg) }}
@@ -66,12 +66,19 @@
                   </el-form-item>
                   <el-divider border-style="dashed" />
                   <el-form-item :label="$t('application.field.shouldPayPrice')">
-                    <span
-                      v-if="package && pricingAvailable"
-                      :class="{ price: true, unfree: package?.price > 0, free: package?.price === 0 }"
-                    >
-                      {{ getPriceString({ value: displayPackagePrice }) }}
-                    </span>
+                    <div v-if="displayFinalPrice !== undefined" class="final-price-block">
+                      <div class="final-price-line">
+                        <span :class="{ price: true, unfree: displayFinalPrice > 0, free: displayFinalPrice === 0 }">
+                          {{ getPriceString({ value: displayFinalPrice }) }}
+                        </span>
+                        <el-tag v-if="hasOrderDiscount" class="discount-tag" effect="light" size="small" type="success">
+                          {{ $t('order.message.discountTag', { percent: discountPercent }) }}
+                        </el-tag>
+                      </div>
+                      <p v-if="hasOrderDiscount" class="discount-hint">
+                        {{ $t('order.message.discountHint', { percent: discountPercent }) }}
+                      </p>
+                    </div>
                     <span v-else class="text-[var(--el-text-color-secondary)]">{{ $t('common.message.noData') }}</span>
                   </el-form-item>
                   <el-form-item>
@@ -120,12 +127,13 @@ import {
   ElDivider,
   ElEmpty,
   ElRadioGroup,
-  ElRadioButton
+  ElRadioButton,
+  ElTag
 } from 'element-plus';
 import { ROUTE_CONSOLE_APPLICATION_SUBSCRIBE, ROUTE_CONSOLE_ORDER_DETAIL } from '@/router';
 import Price from '@/components/common/Price.vue';
 import { applicationOperator, orderOperator } from '@/operators';
-import { getPriceString, applyMarkup, getApplicationMarkupRatio } from '@/utils';
+import { getPriceString, applyMarkup, getApplicationMarkupRatio, getApplicationCallerOrderDiscountRate } from '@/utils';
 import { isIOS } from '@/utils';
 import { track } from '@/plugins/telemetry';
 import ServiceEstimation from '@/components/service/Estimation.vue';
@@ -157,6 +165,7 @@ export default defineComponent({
     ElEmpty,
     ElRadioGroup,
     ElRadioButton,
+    ElTag,
     Price,
     ServiceEstimation
   },
@@ -219,8 +228,12 @@ export default defineComponent({
     markupRatio(): number | undefined {
       return getApplicationMarkupRatio(this.application, this.site);
     },
+    orderDiscountRate(): number | undefined {
+      if (isIOS()) return 0;
+      return getApplicationCallerOrderDiscountRate(this.application);
+    },
     pricingAvailable(): boolean {
-      return this.markupRatio !== undefined;
+      return this.markupRatio !== undefined && this.orderDiscountRate !== undefined;
     },
     // Backend-resolved markup keeps this preview aligned with order billing
     // when a service overrides the site-wide default.
@@ -233,6 +246,19 @@ export default defineComponent({
       return this.package && this.markupRatio !== undefined
         ? applyMarkup(this.package.price, this.markupRatio) / this.package.amount
         : undefined;
+    },
+    displayFinalPrice(): number | undefined {
+      if (this.displayPackagePrice === undefined || this.orderDiscountRate === undefined) {
+        return undefined;
+      }
+      return this.displayPackagePrice * (1 - this.orderDiscountRate);
+    },
+    hasOrderDiscount(): boolean {
+      return (this.orderDiscountRate ?? 0) > 0;
+    },
+    discountPercent(): string {
+      const percent = (this.orderDiscountRate ?? 0) * 100;
+      return Number.isInteger(percent) ? percent.toFixed(0) : percent.toFixed(1);
     }
   },
   mounted() {
@@ -371,6 +397,87 @@ export default defineComponent({
         color: #29c287;
       }
     }
+    .final-price-block {
+      display: inline-flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+    .final-price-line {
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 12px;
+    }
+    .discount-tag {
+      border-radius: 999px;
+    }
+    .discount-hint {
+      margin: 0;
+      font-size: 13px;
+      color: var(--el-text-color-secondary);
+    }
+  }
+}
+
+@media only screen and (max-width: 767px) {
+  .panel {
+    .el-card {
+      padding: 16px 12px;
+    }
+  }
+
+  :deep(.purchase-form .el-form-item) {
+    display: block;
+    margin-bottom: 10px;
+  }
+
+  :deep(.purchase-form .el-form-item__label) {
+    width: auto !important;
+    height: auto;
+    margin-bottom: 8px;
+    line-height: 1.4;
+    text-align: left;
+  }
+
+  :deep(.purchase-form .el-form-item__content) {
+    margin-left: 0 !important;
+  }
+
+  .package-options {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px 8px;
+    width: 100%;
+    padding-top: 4px;
+  }
+
+  :deep(.package-options .el-radio-button) {
+    width: 100%;
+    margin-bottom: 0 !important;
+  }
+
+  :deep(.package-options .el-radio-button__inner) {
+    width: 100%;
+    padding: 8px 6px;
+    border: 1px solid var(--el-border-color);
+    border-radius: 4px;
+    box-shadow: none;
+  }
+
+  .final-price-block {
+    width: 100%;
+  }
+
+  .package-options .corner {
+    top: -8px;
+    right: 4px;
+    padding: 0 3px;
+    font-size: 10px;
+    line-height: 16px;
+  }
+
+  .btn-create {
+    width: 100%;
   }
 }
 </style>

--- a/src/pages/console/application/pricingContract.test.ts
+++ b/src/pages/console/application/pricingContract.test.ts
@@ -21,6 +21,16 @@ describe('application purchase pricing contract', () => {
     const source = readSibling('Extra.vue');
     expect(source).toContain(':disabled="!pricingAvailable || !package"');
     expect(source).toContain('!this.pricingAvailable || !this.package');
+    expect(source).toContain('this.markupRatio !== undefined && this.orderDiscountRate !== undefined');
+  });
+
+  it('usage preview applies the backend-resolved order discount after markup', () => {
+    const source = readSibling('Extra.vue');
+    expect(source).toContain('getApplicationCallerOrderDiscountRate');
+    expect(source).toContain('this.displayPackagePrice * (1 - this.orderDiscountRate)');
+    expect(source).toContain("$t('order.message.discountTag'");
+    expect(source).toContain("$t('order.message.discountHint'");
+    expect(source).toContain('if (isIOS()) return 0');
   });
 
   it('subscription checkout rejects unsupported durations', () => {

--- a/src/utils/site.test.ts
+++ b/src/utils/site.test.ts
@@ -4,6 +4,7 @@ import {
   getSiteOrigin,
   getSiteMarkupRatio,
   getApplicationMarkupRatio,
+  getApplicationCallerOrderDiscountRate,
   applyMarkup,
   isBrandingHidden,
   getBrandSupportUrl
@@ -94,6 +95,24 @@ describe('getApplicationMarkupRatio', () => {
     expect(
       getApplicationMarkupRatio({ service_id: 'service-1', effective_markup_ratio: Number.NaN }, site)
     ).toBeUndefined();
+  });
+});
+
+describe('getApplicationCallerOrderDiscountRate', () => {
+  it('returns the backend-resolved discount', () => {
+    expect(getApplicationCallerOrderDiscountRate({ effective_caller_order_discount_rate: 0.1 })).toBe(0.1);
+    expect(getApplicationCallerOrderDiscountRate({ effective_caller_order_discount_rate: 0 })).toBe(0);
+  });
+
+  it('falls back to zero only when a loaded application omits the legacy field', () => {
+    expect(getApplicationCallerOrderDiscountRate({})).toBe(0);
+    expect(getApplicationCallerOrderDiscountRate(undefined)).toBeUndefined();
+  });
+
+  it('fails closed when the backend returns a malformed discount', () => {
+    expect(getApplicationCallerOrderDiscountRate({ effective_caller_order_discount_rate: -1 })).toBeUndefined();
+    expect(getApplicationCallerOrderDiscountRate({ effective_caller_order_discount_rate: Number.NaN })).toBeUndefined();
+    expect(getApplicationCallerOrderDiscountRate({ effective_caller_order_discount_rate: 2 })).toBeUndefined();
   });
 });
 

--- a/src/utils/site.ts
+++ b/src/utils/site.ts
@@ -129,6 +129,14 @@ export const getApplicationMarkupRatio = (
   return raw;
 };
 
+export const getApplicationCallerOrderDiscountRate = (application?: IApplication | null): number | undefined => {
+  if (!application) return undefined;
+  const raw = application?.effective_caller_order_discount_rate;
+  if (raw === undefined || raw === null) return 0;
+  if (typeof raw !== 'number' || !Number.isFinite(raw) || raw < 0 || raw > 1) return undefined;
+  return raw;
+};
+
 /**
  * Apply a markup ratio to a price: `price * (1 + ratio)`. Mirrors the backend
  * `apply_markup` so the displayed price matches what the gateway charges at


### PR DESCRIPTION
## Summary
- show the marked-up package price and the caller-discounted final price before creating a top-up order
- render the VIP discount badge and explanation using the same backend-resolved rate used by order creation
- improve the mobile package grid and final-price layout so all tiers, discount details, and the action remain usable above the fixed navigation
- add a patch change file

## Context
The Suno package page showed $30 as “Final Price”, but creating the order applied the caller's 10% VIP rule and immediately changed it to $27. This PR consumes the authoritative quote added by https://github.com/AceDataCloud/PlatformBackend/pull/966 and makes the two screens agree.

## Pricing behavior
- web/desktop/Android: package markup first, then caller VIP discount
- iOS: keeps the StoreKit SKU price path and does not preview a server-side VIP discount
- legacy backend response with no discount field: falls back to 0% so checkout remains available
- explicit malformed discount outside `[0, 1]`: fails closed and disables pricing
- X402's optional 5% payment discount remains an order-page preview because the payment method is not selected here

## Validation
- focused Vitest: 31 passed
- focused ESLint: passed
- full `vue-tsc -b --force`: passed
- production build: passed
- Beachball check: passed
- desktop and 390px Playwright visual checks: $30 package price, $27 final price, 10% badge, no horizontal overflow; mobile package grid and action remain visible
- `git diff --check`: passed

## Rollout
1. Merge and deploy https://github.com/AceDataCloud/PlatformBackend/pull/966.
2. Wait for the PlatformBackend rollout to complete.
3. Merge/deploy this PR.

## 🤖 对抗评审 (reviewer: codex, 4 rounds)
- RISK: an omitted backend field could block checkout → fixed with a 0% compatibility fallback only for loaded legacy responses
- RISK: fixed-price iOS StoreKit purchases could promise a server-discounted amount → fixed by keeping iOS on the SKU price path
- RISK: a malformed rate above 100% was clamped into a free preview → fixed by rejecting all explicit rates outside `[0, 1]`
- RISK: compatibility must still show a price while checkout remains enabled → fixed by displaying the marked-up price at 0% only when the field is omitted; malformed explicit values remain blocked
- focused contract tests cover each resolution path after the final review fix