### PR TITLE
feat(settings): add System theme option (follows OS)

### DIFF
--- a/change/@acedatacloud-nexior-40a36544-26cb-4377-9f8a-66bddbedf856.json
+++ b/change/@acedatacloud-nexior-40a36544-26cb-4377-9f8a-66bddbedf856.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(settings): add System theme option that follows the OS colour scheme",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/user/Theme.vue
+++ b/src/components/user/Theme.vue
@@ -8,6 +8,7 @@
       <el-dropdown-menu>
         <el-dropdown-item command="light">{{ $t('common.theme.light') }}</el-dropdown-item>
         <el-dropdown-item command="dark">{{ $t('common.theme.dark') }}</el-dropdown-item>
+        <el-dropdown-item command="system">{{ $t('common.theme.system') }}</el-dropdown-item>
       </el-dropdown-menu>
     </template>
   </el-dropdown>
@@ -17,7 +18,8 @@
 import { defineComponent } from 'vue';
 import { ElDropdown, ElDropdownMenu, ElDropdownItem, ElIcon } from 'element-plus';
 import { getDomain } from '@/utils';
-import { setCookie } from 'typescript-cookie';
+import { applyThemePreference } from '@/utils/theme';
+import { getCookie, setCookie } from 'typescript-cookie';
 import { ArrowDown } from '@element-plus/icons-vue';
 
 export default defineComponent({
@@ -31,25 +33,35 @@ export default defineComponent({
   },
   data() {
     return {
-      theme: 'light' as 'light' | 'dark'
+      theme: 'light' as 'light' | 'dark' | 'system'
     };
   },
   computed: {
     currentLabel(): string {
-      return this.theme === 'dark'
-        ? (this.$t('common.theme.dark') as string)
-        : (this.$t('common.theme.light') as string);
+      if (this.theme === 'dark') {
+        return this.$t('common.theme.dark') as string;
+      }
+      if (this.theme === 'system') {
+        return this.$t('common.theme.system') as string;
+      }
+      return this.$t('common.theme.light') as string;
     }
   },
   mounted() {
-    // Mirror the theme already applied at startup by `initializeTheme`
-    // (cookie-or-dark) via the live <html> class. Re-deriving from the
-    // cookie here used a different default ('light') and stricter parse,
-    // so a missing/non-canonical cookie flipped the theme on Settings open.
-    this.theme = document.documentElement.classList.contains('dark') ? 'dark' : 'light';
+    // Prefer an explicit stored preference ('dark' or 'system') so the System
+    // option round-trips; otherwise mirror the theme already applied at startup
+    // by `initializeTheme` via the live <html> class (avoids the old bug where a
+    // missing/non-canonical cookie flipped the theme on Settings open).
+    const pref = getCookie('THEME');
+    this.theme =
+      pref === 'dark' || pref === 'system'
+        ? pref
+        : document.documentElement.classList.contains('dark')
+          ? 'dark'
+          : 'light';
   },
   methods: {
-    onSelect(command: 'light' | 'dark') {
+    onSelect(command: 'light' | 'dark' | 'system') {
       this.theme = command;
       this.applyTheme();
     },
@@ -58,11 +70,7 @@ export default defineComponent({
         path: '/',
         domain: getDomain()
       });
-      if (this.theme === 'dark') {
-        document.documentElement.classList.add('dark');
-      } else {
-        document.documentElement.classList.remove('dark');
-      }
+      applyThemePreference(this.theme);
     }
   }
 });

--- a/src/utils/initializer.ts
+++ b/src/utils/initializer.ts
@@ -1,6 +1,6 @@
 import { getCookie, setCookie } from 'typescript-cookie';
 import favicon from '@/assets/images/favicon.ico';
-import { applyAccentColor, applyTheme } from './theme';
+import { applyAccentColor, applyThemePreference } from './theme';
 import store from '@/store';
 import { IToken } from '@/models';
 import { LOCALE_CURRENCY_MAPPING } from '@acedatacloud/core/constants';
@@ -195,7 +195,7 @@ export const initializeToken = async () => {
 export const initializeTheme = async () => {
   const theme = getCookie('THEME') || 'dark';
   console.debug('initialize theme', theme);
-  applyTheme(theme);
+  applyThemePreference(theme);
   const primaryColor = store.state.site?.theme?.primary_color;
   console.debug('initialize primary color', primaryColor || '(default)');
   applyAccentColor(primaryColor || null);

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -27,6 +27,39 @@ export function applyTheme(theme: string) {
   document.documentElement.style.colorScheme = theme === 'dark' ? 'dark' : 'light';
 }
 
+/** Resolve the OS colour-scheme preference. Falls back to 'light' when
+ *  matchMedia is unavailable (SSR / very old browsers). */
+export function resolveSystemTheme(): 'light' | 'dark' {
+  if (typeof window !== 'undefined' && window.matchMedia) {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+  return 'light';
+}
+
+let systemThemeMql: MediaQueryList | null = null;
+let systemThemeListener: ((e: MediaQueryListEvent) => void) | null = null;
+
+/** Apply a user THEME preference: 'light' | 'dark' | 'system'. For 'system'
+ *  it resolves against the OS now AND subscribes to live OS changes; any
+ *  previous system subscription is detached first so we never stack listeners. */
+export function applyThemePreference(pref: string): void {
+  if (systemThemeMql && systemThemeListener) {
+    systemThemeMql.removeEventListener('change', systemThemeListener);
+    systemThemeMql = null;
+    systemThemeListener = null;
+  }
+  if (pref === 'system') {
+    applyTheme(resolveSystemTheme());
+    if (typeof window !== 'undefined' && window.matchMedia) {
+      systemThemeMql = window.matchMedia('(prefers-color-scheme: dark)');
+      systemThemeListener = (e: MediaQueryListEvent) => applyTheme(e.matches ? 'dark' : 'light');
+      systemThemeMql.addEventListener('change', systemThemeListener);
+    }
+    return;
+  }
+  applyTheme(pref === 'dark' ? 'dark' : 'light');
+}
+
 /** Default brand colour (Ace Data Cloud teal). Kept in sync with
  *  `_element.scss` $colors.primary.base and `_common.scss` :root defaults. */
 export const DEFAULT_PRIMARY_COLOR = '#277186';


### PR DESCRIPTION
## Summary
- Add a third **System** choice to the theme switcher in 通用设置.
- When selected, resolves the OS preference via `matchMedia('(prefers-color-scheme: dark)')` and **subscribes to live OS changes**; any prior system subscription is detached first so listeners never stack.
- The preference round-trips through the existing `THEME` cookie and is re-applied at startup by `initializeTheme` via a shared `applyThemePreference` helper.
- Purely browser-local; no backend. Reuses the pre-existing `common.theme.system` i18n key (already present in all 18 locales).

## Files
- `src/utils/theme.ts` — new `resolveSystemTheme()` + `applyThemePreference()` (with matchMedia listener + cleanup)
- `src/components/user/Theme.vue` — System dropdown item, cookie round-trip
- `src/utils/initializer.ts` — startup applies preference (system-aware)

## Validation
- `vue-tsc -b --force` ✅  ·  `eslint` ✅

## 🤖 对抗评审
Reviewer: Codex (`codex exec --sandbox read-only`).
- Verified: matchMedia guarded for SSR; listener detached before re-subscribe (no stacking); `system` preference persists and re-applies on reload.
- `theme.system` i18n key confirmed present in all 18 locales — no coverage gap.
- **VERDICT: CLEAN**