### PR TITLE
feat(settings): add send-message shortcut; remove source-code link

### DIFF
--- a/change/@acedatacloud-nexior-ca867df6-c3c5-441d-84fd-00fd62154ccc.json
+++ b/change/@acedatacloud-nexior-ca867df6-c3c5-441d-84fd-00fd62154ccc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat(settings): add send-message shortcut, remove source-code link",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/chat/Composer.vue
+++ b/src/components/chat/Composer.vue
@@ -46,7 +46,7 @@
       class="input"
       :placeholder="$t('chat.message.newMessagePlaceholder')"
       :style="{ height: inputHeight }"
-      @keydown.enter.exact="onEnterKey"
+      @keydown.enter="onEnterKey"
       @input="adjustTextareaHeight"
     ></textarea>
     <div class="tools">
@@ -148,6 +148,7 @@ import {
   uploadTrackerMixin,
   withCurrentUserIdAndSite
 } from '@/utils';
+import { getSendShortcut } from '@/utils/composer';
 import FilePreview from '@/components/common/FilePreview.vue';
 import ImagePreview from '@/components/common/ImagePreview.vue';
 import { ROUTE_CHATGPT_CALL } from '@/router/constants';
@@ -305,11 +306,24 @@ export default defineComponent({
       this.$emit('submit');
     },
     onEnterKey(e: KeyboardEvent) {
-      // Avoid submitting while an IME (e.g. Chinese/Japanese/Korean) is
-      // composing — pressing Enter to confirm the IME candidate must NOT
-      // send the message. `isComposing` is true during composition; some
-      // browsers also report keyCode 229 for the same state.
+      // Never send while an IME is composing (Enter confirms the candidate).
       if (e.isComposing || e.keyCode === 229) {
+        return;
+      }
+      // Shift+Enter always inserts a newline.
+      if (e.shiftKey) {
+        return;
+      }
+      const withMod = e.metaKey || e.ctrlKey;
+      const shouldSend =
+        getSendShortcut() === 'mod-enter'
+          ? // ⌘/Ctrl+Enter sends; plain or Alt+Enter inserts a newline.
+            withMod
+          : // Plain Enter sends; any modifier (⌘/Ctrl/Alt) inserts a newline,
+            // preserving the previous @keydown.enter.exact behaviour.
+            !withMod && !e.altKey;
+      if (!shouldSend) {
+        // Let the keystroke insert a newline instead of sending.
         return;
       }
       e.preventDefault();

--- a/src/components/setting/General.vue
+++ b/src/components/setting/General.vue
@@ -18,12 +18,10 @@
     </section>
     <section class="settings-item">
       <div class="settings-label">
-        <p class="settings-title">{{ $t('common.settings.github') }}</p>
+        <p class="settings-title">{{ $t('common.settings.sendShortcut') }}</p>
       </div>
       <div class="settings-content">
-        <a href="https://github.com/AceDataCloud/Nexior" target="_blank" rel="noopener noreferrer" class="github-link">
-          <font-awesome-icon :icon="faGithub" class="icon" />
-        </a>
+        <send-shortcut />
       </div>
     </section>
   </div>
@@ -31,40 +29,16 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { faGithub } from '@fortawesome/free-brands-svg-icons';
 import ThemeSwitcher from '@/components/user/Theme.vue';
 import LocaleSwitcher from '@/components/user/Locale.vue';
+import SendShortcut from '@/components/user/SendShortcut.vue';
 
 export default defineComponent({
   name: 'GeneralSettings',
   components: {
     ThemeSwitcher,
     LocaleSwitcher,
-    FontAwesomeIcon
-  },
-  data() {
-    return {
-      faGithub
-    };
+    SendShortcut
   }
 });
 </script>
-
-<style lang="scss" scoped>
-.github-link {
-  display: inline-flex;
-  align-items: center;
-  color: var(--el-text-color-regular);
-  text-decoration: none;
-  transition: color 0.3s;
-
-  .icon {
-    font-size: 18px;
-  }
-
-  &:hover {
-    color: var(--el-color-primary);
-  }
-}
-</style>

--- a/src/components/user/SendShortcut.vue
+++ b/src/components/user/SendShortcut.vue
@@ -1,0 +1,63 @@
+<template>
+  <el-dropdown trigger="click" @command="onSelect">
+    <span class="el-dropdown-link">
+      {{ currentLabel }}
+      <el-icon class="el-icon--right"><arrow-down /></el-icon>
+    </span>
+    <template #dropdown>
+      <el-dropdown-menu>
+        <el-dropdown-item command="enter">{{ $t('common.sendShortcut.enter') }}</el-dropdown-item>
+        <el-dropdown-item command="mod-enter">{{
+          $t('common.sendShortcut.modEnter', { key: modKey })
+        }}</el-dropdown-item>
+      </el-dropdown-menu>
+    </template>
+  </el-dropdown>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { ElDropdown, ElDropdownMenu, ElDropdownItem, ElIcon } from 'element-plus';
+import { getDomain } from '@/utils';
+import { getCookie, setCookie } from 'typescript-cookie';
+import { ArrowDown } from '@element-plus/icons-vue';
+
+export default defineComponent({
+  name: 'SendShortcutSelector',
+  components: {
+    ArrowDown,
+    ElDropdown,
+    ElDropdownMenu,
+    ElDropdownItem,
+    ElIcon
+  },
+  data() {
+    // Platform-specific modifier label; guarded for SSR where navigator is absent.
+    const isMac =
+      typeof navigator !== 'undefined' && /Mac|iPhone|iPad|iPod/.test(navigator.platform || navigator.userAgent);
+    return {
+      shortcut: 'enter' as 'enter' | 'mod-enter',
+      modKey: isMac ? '⌘' : 'Ctrl'
+    };
+  },
+  computed: {
+    currentLabel(): string {
+      return this.shortcut === 'mod-enter'
+        ? (this.$t('common.sendShortcut.modEnter', { key: this.modKey }) as string)
+        : (this.$t('common.sendShortcut.enter') as string);
+    }
+  },
+  mounted() {
+    this.shortcut = getCookie('SEND_SHORTCUT') === 'mod-enter' ? 'mod-enter' : 'enter';
+  },
+  methods: {
+    onSelect(command: 'enter' | 'mod-enter') {
+      this.shortcut = command;
+      setCookie('SEND_SHORTCUT', command, {
+        path: '/',
+        domain: getDomain()
+      });
+    }
+  }
+});
+</script>

--- a/src/i18n/ar/common.json
+++ b/src/i18n/ar/common.json
@@ -807,6 +807,18 @@
     "message": "السمة",
     "description": "عنوان قسم إعدادات السمة في صفحة الإعدادات"
   },
+  "settings.sendShortcut": {
+    "message": "إرسال الرسالة",
+    "description": "Title of the send-message shortcut row in General settings: choose Enter or modifier+Enter to send."
+  },
+  "sendShortcut.enter": {
+    "message": "الإرسال بمفتاح Enter",
+    "description": "Send-shortcut option: press Enter to send the message."
+  },
+  "sendShortcut.modEnter": {
+    "message": "الإرسال بـ {key} + Enter",
+    "description": "Send-shortcut option: press the platform modifier (⌘ or Ctrl) plus Enter to send. {key} is the modifier symbol."
+  },
   "settings.loginMode": {
     "message": "طريقة تسجيل الدخول",
     "description": "Login-mode row title in general settings"

--- a/src/i18n/de/common.json
+++ b/src/i18n/de/common.json
@@ -807,6 +807,18 @@
     "message": "Thema",
     "description": "Titel des Abschnitts für Themaeinstellungen auf der Einstellungsseite"
   },
+  "settings.sendShortcut": {
+    "message": "Nachricht senden",
+    "description": "Title of the send-message shortcut row in General settings: choose Enter or modifier+Enter to send."
+  },
+  "sendShortcut.enter": {
+    "message": "Mit Enter senden",
+    "description": "Send-shortcut option: press Enter to send the message."
+  },
+  "sendShortcut.modEnter": {
+    "message": "Mit {key} + Enter senden",
+    "description": "Send-shortcut option: press the platform modifier (⌘ or Ctrl) plus Enter to send. {key} is the modifier symbol."
+  },
   "settings.loginMode": {
     "message": "Anmeldemodus",
     "description": "Login-mode row title in general settings"

--- a/src/i18n/el/common.json
+++ b/src/i18n/el/common.json
@@ -807,6 +807,18 @@
     "message": "Θέμα",
     "description": "Επικεφαλίδα τμήματος ρυθμίσεων θέματος στη σελίδα ρυθμίσεων"
   },
+  "settings.sendShortcut": {
+    "message": "Αποστολή μηνύματος",
+    "description": "Title of the send-message shortcut row in General settings: choose Enter or modifier+Enter to send."
+  },
+  "sendShortcut.enter": {
+    "message": "Αποστολή με Enter",
+    "description": "Send-shortcut option: press Enter to send the message."
+  },
+  "sendShortcut.modEnter": {
+    "message": "Αποστολή με {key} + Enter",
+    "description": "Send-shortcut option: press the platform modifier (⌘ or Ctrl) plus Enter to send. {key} is the modifier symbol."
+  },
   "settings.loginMode": {
     "message": "Τρόπος σύνδεσης",
     "description": "Login-mode row title in general settings"

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -787,6 +787,18 @@
     "message": "Theme",
     "description": "Title for the theme settings section in the settings page"
   },
+  "settings.sendShortcut": {
+    "message": "Send message",
+    "description": "Title of the send-message shortcut row in General settings: choose Enter or modifier+Enter to send."
+  },
+  "sendShortcut.enter": {
+    "message": "Enter to send",
+    "description": "Send-shortcut option: press Enter to send the message."
+  },
+  "sendShortcut.modEnter": {
+    "message": "{key} + Enter to send",
+    "description": "Send-shortcut option: press the platform modifier (⌘ or Ctrl) plus Enter to send. {key} is the modifier symbol."
+  },
   "settings.loginMode": {
     "message": "Login Mode",
     "description": "Title for the login-mode row in the Auth settings tab: choose whether login uses an embedded popup (iframe) or a full-page redirect. Site-level, admin-only."

--- a/src/i18n/es/common.json
+++ b/src/i18n/es/common.json
@@ -807,6 +807,18 @@
     "message": "Tema",
     "description": "Título de la sección de configuración de tema en la página de configuración"
   },
+  "settings.sendShortcut": {
+    "message": "Enviar mensaje",
+    "description": "Title of the send-message shortcut row in General settings: choose Enter or modifier+Enter to send."
+  },
+  "sendShortcut.enter": {
+    "message": "Enviar con Enter",
+    "description": "Send-shortcut option: press Enter to send the message."
+  },
+  "sendShortcut.modEnter": {
+    "message": "Enviar con {key} + Enter",
+    "description": "Send-shortcut option: press the platform modifier (⌘ or Ctrl) plus Enter to send. {key} is the modifier symbol."
+  },
   "settings.loginMode": {
     "message": "Modo de inicio de sesión",
     "description": "Login-mode row title in general settings"

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -807,6 +807,18 @@
     "message": "Teema",
     "description": "Asetussivun teemavalintojen osan otsikko"
   },
+  "settings.sendShortcut": {
+    "message": "Lähetä viesti",
+    "description": "Title of the send-message shortcut row in General settings: choose Enter or modifier+Enter to send."
+  },
+  "sendShortcut.enter": {
+    "message": "Lähetä Enterillä",
+    "description": "Send-shortcut option: press Enter to send the message."
+  },
+  "sendShortcut.modEnter": {
+    "message": "Lähetä näppäimellä {key} + Enter",
+    "description": "Send-shortcut option: press the platform modifier (⌘ or Ctrl) plus Enter to send. {key} is the modifier symbol."
+  },
   "settings.loginMode": {
     "message": "Kirjautumistapa",
     "description": "Login-mode row title in general settings"

--- a/src/i18n/fr/common.json
+++ b/src/i18n/fr/common.json
@@ -807,6 +807,18 @@
     "message": "Thème",
     "description": "Titre de la section des paramètres de thème dans la page des paramètres"
   },
+  "settings.sendShortcut": {
+    "message": "Envoyer le message",
+    "description": "Title of the send-message shortcut row in General settings: choose Enter or modifier+Enter to send."
+  },
+  "sendShortcut.enter": {
+    "message": "Envoyer avec Entrée",
+    "description": "Send-shortcut option: press Enter to send the message."
+  },
+  "sendShortcut.modEnter": {
+    "message": "Envoyer avec {key} + Entrée",
+    "description": "Send-shortcut option: press the platform modifier (⌘ or Ctrl) plus Enter to send. {key} is the modifier symbol."
+  },
   "settings.loginMode": {
     "message": "Mode de connexion",
     "description": "Login-mode row title in general settings"

--- a/src/i18n/it/common.json
+++ b/src/i18n/it/common.json
@@ -807,6 +807,18 @@
     "message": "Tema",
     "description": "Titolo della sezione impostazioni tema nella pagina delle impostazioni"
   },
+  "settings.sendShortcut": {
+    "message": "Invia messaggio",
+    "description": "Title of the send-message shortcut row in General settings: choose Enter or modifier+Enter to send."
+  },
+  "sendShortcut.enter": {
+    "message": "Invia con Enter",
+    "description": "Send-shortcut option: press Enter to send the message."
+  },
+  "sendShortcut.modEnter": {
+    "message": "Invia con {key} + Enter",
+    "description": "Send-shortcut option: press the platform modifier (⌘ or Ctrl) plus Enter to send. {key} is the modifier symbol."
+  },
   "settings.loginMode": {
     "message": "Modalità di accesso",
     "description": "Login-mode row title in general settings"

--- a/src/i18n/ja/common.json
+++ b/src/i18n/ja/common.json
@@ -807,6 +807,18 @@
     "message": "テーマ",
     "description": "設定ページのテーマ設定部分のタイトル"
   },
+  "settings.sendShortcut": {
+    "message": "メッセージ送信",
+    "description": "Title of the send-message shortcut row in General settings: choose Enter or modifier+Enter to send."
+  },
+  "sendShortcut.enter": {
+    "message": "Enter で送信",
+    "description": "Send-shortcut option: press Enter to send the message."
+  },
+  "sendShortcut.modEnter": {
+    "message": "{key} + Enter で送信",
+    "description": "Send-shortcut option: press the platform modifier (⌘ or Ctrl) plus Enter to send. {key} is the modifier symbol."
+  },
   "settings.loginMode": {
     "message": "ログイン方式",
     "description": "Login-mode row title in general settings"

--- a/src/i18n/ko/common.json
+++ b/src/i18n/ko/common.json
@@ -807,6 +807,18 @@
     "message": "테마",
     "description": "설정 페이지의 테마 설정 부분 제목"
   },
+  "settings.sendShortcut": {
+    "message": "메시지 전송",
+    "description": "Title of the send-message shortcut row in General settings: choose Enter or modifier+Enter to send."
+  },
+  "sendShortcut.enter": {
+    "message": "Enter로 전송",
+    "description": "Send-shortcut option: press Enter to send the message."
+  },
+  "sendShortcut.modEnter": {
+    "message": "{key} + Enter로 전송",
+    "description": "Send-shortcut option: press the platform modifier (⌘ or Ctrl) plus Enter to send. {key} is the modifier symbol."
+  },
   "settings.loginMode": {
     "message": "로그인 방식",
     "description": "Login-mode row title in general settings"

--- a/src/i18n/pl/common.json
+++ b/src/i18n/pl/common.json
@@ -807,6 +807,18 @@
     "message": "Motyw",
     "description": "Tytuł sekcji ustawień motywu na stronie ustawień"
   },
+  "settings.sendShortcut": {
+    "message": "Wyślij wiadomość",
+    "description": "Title of the send-message shortcut row in General settings: choose Enter or modifier+Enter to send."
+  },
+  "sendShortcut.enter": {
+    "message": "Wyślij Enterem",
+    "description": "Send-shortcut option: press Enter to send the message."
+  },
+  "sendShortcut.modEnter": {
+    "message": "Wyślij {key} + Enter",
+    "description": "Send-shortcut option: press the platform modifier (⌘ or Ctrl) plus Enter to send. {key} is the modifier symbol."
+  },
   "settings.loginMode": {
     "message": "Tryb logowania",
     "description": "Login-mode row title in general settings"

--- a/src/i18n/pt/common.json
+++ b/src/i18n/pt/common.json
@@ -807,6 +807,18 @@
     "message": "Tema",
     "description": "Título da seção de configurações de tema na página de configurações"
   },
+  "settings.sendShortcut": {
+    "message": "Enviar mensagem",
+    "description": "Title of the send-message shortcut row in General settings: choose Enter or modifier+Enter to send."
+  },
+  "sendShortcut.enter": {
+    "message": "Enviar com Enter",
+    "description": "Send-shortcut option: press Enter to send the message."
+  },
+  "sendShortcut.modEnter": {
+    "message": "Enviar com {key} + Enter",
+    "description": "Send-shortcut option: press the platform modifier (⌘ or Ctrl) plus Enter to send. {key} is the modifier symbol."
+  },
   "settings.loginMode": {
     "message": "Modo de login",
     "description": "Login-mode row title in general settings"

--- a/src/i18n/ru/common.json
+++ b/src/i18n/ru/common.json
@@ -807,6 +807,18 @@
     "message": "Тема",
     "description": "Заголовок раздела настроек темы на странице настроек"
   },
+  "settings.sendShortcut": {
+    "message": "Отправка сообщения",
+    "description": "Title of the send-message shortcut row in General settings: choose Enter or modifier+Enter to send."
+  },
+  "sendShortcut.enter": {
+    "message": "Отправка по Enter",
+    "description": "Send-shortcut option: press Enter to send the message."
+  },
+  "sendShortcut.modEnter": {
+    "message": "Отправка по {key} + Enter",
+    "description": "Send-shortcut option: press the platform modifier (⌘ or Ctrl) plus Enter to send. {key} is the modifier symbol."
+  },
   "settings.loginMode": {
     "message": "Способ входа",
     "description": "Login-mode row title in general settings"

--- a/src/i18n/sr/common.json
+++ b/src/i18n/sr/common.json
@@ -807,6 +807,18 @@
     "message": "Tema",
     "description": "Naslov dela sa podešavanjima teme na stranici sa podešavanjima"
   },
+  "settings.sendShortcut": {
+    "message": "Слање поруке",
+    "description": "Title of the send-message shortcut row in General settings: choose Enter or modifier+Enter to send."
+  },
+  "sendShortcut.enter": {
+    "message": "Слање тастером Enter",
+    "description": "Send-shortcut option: press Enter to send the message."
+  },
+  "sendShortcut.modEnter": {
+    "message": "Слање помоћу {key} + Enter",
+    "description": "Send-shortcut option: press the platform modifier (⌘ or Ctrl) plus Enter to send. {key} is the modifier symbol."
+  },
   "settings.loginMode": {
     "message": "Начин пријаве",
     "description": "Login-mode row title in general settings"

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -807,6 +807,18 @@
     "message": "Tema",
     "description": "Rubrik för tema-inställningar på inställningssidan"
   },
+  "settings.sendShortcut": {
+    "message": "Skicka meddelande",
+    "description": "Title of the send-message shortcut row in General settings: choose Enter or modifier+Enter to send."
+  },
+  "sendShortcut.enter": {
+    "message": "Skicka med Enter",
+    "description": "Send-shortcut option: press Enter to send the message."
+  },
+  "sendShortcut.modEnter": {
+    "message": "Skicka med {key} + Enter",
+    "description": "Send-shortcut option: press the platform modifier (⌘ or Ctrl) plus Enter to send. {key} is the modifier symbol."
+  },
   "settings.loginMode": {
     "message": "Inloggningsläge",
     "description": "Login-mode row title in general settings"

--- a/src/i18n/uk/common.json
+++ b/src/i18n/uk/common.json
@@ -807,6 +807,18 @@
     "message": "Тема",
     "description": "Заголовок секції налаштувань теми на сторінці налаштувань"
   },
+  "settings.sendShortcut": {
+    "message": "Надсилання повідомлення",
+    "description": "Title of the send-message shortcut row in General settings: choose Enter or modifier+Enter to send."
+  },
+  "sendShortcut.enter": {
+    "message": "Надсилання за Enter",
+    "description": "Send-shortcut option: press Enter to send the message."
+  },
+  "sendShortcut.modEnter": {
+    "message": "Надсилання за {key} + Enter",
+    "description": "Send-shortcut option: press the platform modifier (⌘ or Ctrl) plus Enter to send. {key} is the modifier symbol."
+  },
   "settings.loginMode": {
     "message": "Спосіб входу",
     "description": "Login-mode row title in general settings"

--- a/src/i18n/zh-CN/common.json
+++ b/src/i18n/zh-CN/common.json
@@ -807,6 +807,18 @@
     "message": "主题",
     "description": "设置页面中的主题设置部分的标题"
   },
+  "settings.sendShortcut": {
+    "message": "发送消息快捷键",
+    "description": "设置页面中的发送消息快捷键行标题：选择按 Enter 发送还是按修饰键+Enter 发送"
+  },
+  "sendShortcut.enter": {
+    "message": "Enter 发送",
+    "description": "发送快捷键选项：按 Enter 键直接发送消息"
+  },
+  "sendShortcut.modEnter": {
+    "message": "{key} + Enter 发送",
+    "description": "发送快捷键选项：按修饰键（⌘ 或 Ctrl）加 Enter 发送消息，{key} 是平台修饰键符号"
+  },
   "settings.loginMode": {
     "message": "登录跳转方式",
     "description": "Auth 设置 tab 中的登录跳转方式行标题：选择登录时用弹窗嵌入（iframe）还是整页跳转。站点级配置，仅管理员可见"

--- a/src/i18n/zh-TW/common.json
+++ b/src/i18n/zh-TW/common.json
@@ -807,6 +807,18 @@
     "message": "主題",
     "description": "設置頁面中的主題設置部分的標題"
   },
+  "settings.sendShortcut": {
+    "message": "傳送訊息快捷鍵",
+    "description": "設定頁面中的傳送訊息快捷鍵列標題：選擇按 Enter 傳送還是按修飾鍵+Enter 傳送"
+  },
+  "sendShortcut.enter": {
+    "message": "Enter 傳送",
+    "description": "傳送快捷鍵選項：按 Enter 鍵直接傳送訊息"
+  },
+  "sendShortcut.modEnter": {
+    "message": "{key} + Enter 傳送",
+    "description": "傳送快捷鍵選項：按修飾鍵（⌘ 或 Ctrl）加 Enter 傳送訊息，{key} 是平台修飾鍵符號"
+  },
   "settings.loginMode": {
     "message": "登入方式",
     "description": "Login-mode row title in general settings"

--- a/src/utils/composer.ts
+++ b/src/utils/composer.ts
@@ -1,0 +1,8 @@
+import { getCookie } from 'typescript-cookie';
+
+export type SendShortcut = 'enter' | 'mod-enter';
+
+/** How pressing Enter behaves in the chat composer. Browser-local (cookie). */
+export function getSendShortcut(): SendShortcut {
+  return getCookie('SEND_SHORTCUT') === 'mod-enter' ? 'mod-enter' : 'enter';
+}


### PR DESCRIPTION
## Summary
- Remove the **源代码 / GitHub** row from 通用设置 (per request).
- Add a **发送消息快捷键** row: choose **Enter 发送** or **⌘/Ctrl + Enter 发送** (platform-aware label). Browser-local via the new `SEND_SHORTCUT` cookie.
- Chat composer honours the preference: Shift+Enter always newlines; in Enter mode any modifier (⌘/Ctrl/Alt) inserts a newline; IME composition still never sends.

## Files
- `src/components/user/SendShortcut.vue` — new dropdown selector (cookie-backed, ⌘ on mac / Ctrl elsewhere)
- `src/utils/composer.ts` — `getSendShortcut()` helper
- `src/components/chat/Composer.vue` — modifier-aware send logic
- `src/components/setting/General.vue` — swap source-code row → send-shortcut row
- `src/i18n/*/common.json` — 3 new keys across all 17 maintained locales

## Validation
- `vue-tsc -b --force` ✅  ·  `eslint` ✅

## 🤖 对抗评审
Reviewer: Codex (`codex exec --sandbox read-only`).
- **[RISK] Alt/Option+Enter would send in Enter mode** — removing `@keydown.enter.exact` let Alt+Enter reach the handler; the old `.exact` ignored any modifier. **Fixed**: Enter mode now sends only when no ⌘/Ctrl/**Alt** modifier is held.
- Re-review after fix: `vue-tsc -b` + eslint green; IME/Shift paths unchanged.
- **VERDICT: CLEAN** (1 risk raised, fixed)