### PR TITLE
fix(setting): keep section notice text readable in dark mode

### DIFF
--- a/change/@acedatacloud-nexior-section-notice-dark-text.json
+++ b/change/@acedatacloud-nexior-section-notice-dark-text.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Keep setting section notice text readable in dark mode",
+  "packageName": "@acedatacloud/nexior",
+  "email": "dev@acedata.cloud",
+  "dependentChangeType": "patch"
+}

--- a/src/components/setting/SectionNotice.vue
+++ b/src/components/setting/SectionNotice.vue
@@ -58,7 +58,9 @@ export default defineComponent({
   border-radius: 8px;
   background: var(--el-color-info-light-9);
   border: 1px solid var(--el-color-info-light-7);
-  color: var(--el-text-color-regular);
+  // The tone backgrounds are always light-9 (light in every theme), so the text
+  // must stay dark or it turns invisible on the light banner in dark mode.
+  color: var(--el-color-info-dark-2);
 
   .icon {
     flex-shrink: 0;
@@ -69,11 +71,13 @@ export default defineComponent({
   .text {
     flex: 1;
     word-break: break-word;
+    color: inherit;
   }
 
   &.admin {
     background: var(--el-color-primary-light-9);
     border-color: var(--el-color-primary-light-7);
+    color: var(--el-color-primary-dark-2);
 
     .icon {
       color: var(--el-color-primary);
@@ -83,6 +87,7 @@ export default defineComponent({
   &.official {
     background: var(--el-color-success-light-9);
     border-color: var(--el-color-success-light-7);
+    color: var(--el-color-success-dark-2);
 
     .icon {
       color: var(--el-color-success);


### PR DESCRIPTION
## Problem
The admin-only notice banner in Settings (Site Settings, Auth, SEO, etc.) was nearly invisible in dark mode. The banner always uses a light `light-9` tone background, but its text color was `--el-text-color-regular`, which becomes light gray in dark mode — light text on a light banner.

## Fix
Give each tone (`info` / `admin` / `official`) an explicit dark text color (`--el-color-*-dark-2`) so it always contrasts against the light banner background regardless of theme.

## 🤖 对抗评审
Trivial CSS contrast fix (no logic change). VERDICT: CLEAN.